### PR TITLE
Fix argument getpeername

### DIFF
--- a/src/replication.m
+++ b/src/replication.m
@@ -595,7 +595,7 @@ replication_relay_loop(int client_sock)
 	 */
 	struct sockaddr_in peer;
 	socklen_t addrlen = sizeof(peer);
-	getpeername(client_sock, &peer, &addrlen);
+	getpeername(client_sock, ((struct sockaddr*)&peer), &addrlen);
 	snprintf(name, sizeof(name), "relay/%s", sio_strfaddr(&peer));
 	fiber_set_name(fiber, name);
 	set_proc_title("%s%s", name, custom_proc_title);


### PR DESCRIPTION
[ 65%] Building CXX object src/box/CMakeFiles/ltbox.dir/**/assoc.m.o
[ 67%] Building CXX object src/box/CMakeFiles/ltbox.dir/**/replication.m.o
/usr/home/zloidemon/Repos/zloidemon/databases/tarantool/work/tarantool-1.4.7-328-g1af7b0b-src/src/replication.m: In function 'replication_relay_loop':
/usr/home/zloidemon/Repos/zloidemon/databases/tarantool/work/tarantool-1.4.7-328-g1af7b0b-src/src/replication.m:598:2: error: passing argument 2 of 'getpeername' from incompatible pointer type [-Werror]
/usr/include/sys/socket.h:630:5: note: expected 'struct sockaddr \* restrict' but argument is of type 'struct sockaddr_in _'
cc1obj: all warnings being treated as errors
gmake[2]: *_\* [src/box/CMakeFiles/ltbox.dir/__/replication.m.o] Ошибка 1
gmake[1]: **\* [src/box/CMakeFiles/ltbox.dir/all] Ошибка 2
gmake: **\* [all] Ошибка 2
**\* Error code 1

Stop in /usr/home/zloidemon/Repos/zloidemon/databases/tarantool.
**\* Error code 1

Stop in /usr/home/zloidemon/Repos/zloidemon/databases/tarantool.
