### PR TITLE
there are no --append parameter in OSX tee cmd, only -a

### DIFF
--- a/doc/user/configuration-reference.xml
+++ b/doc/user/configuration-reference.xml
@@ -732,7 +732,7 @@ tarantool_box: primary@sessions pri: 33013 sec: 33014 adm: 33015</programlisting
           is given a value, Tarantool creates a child process,
           executes the command indicated by the value, and pipes its standard
           output to the standard input of the created process.
-          Example setting: <command>tee --append
+          Example setting: <command>tee -a
           tarantool.log</command> (this will duplicate log output
           to <filename>stdout</filename> and a log file).
           </entry>

--- a/doc/user/tutorial.xml
+++ b/doc/user/tutorial.xml
@@ -432,7 +432,7 @@ which make a minimal configuration file that will be suitable for day one.
 <command>echo</command> "space[0].index[0].unique = 1" | <command>tee</command> <option>-a</option> tarantool.cfg
 <command>echo</command> "space[0].index[0].key_field[0].fieldno = 0" | <command>tee</command> <option>-a</option> tarantool.cfg
 <command>echo</command> "space[0].index[0].key_field[0].type = \"NUM\"" | <command>tee</command> <option>-a</option> tarantool.cfg
-<command>echo</command> "logger = \"tee --append tarantool.log\"" | <command>tee</command> <option>-a</option> tarantool.cfg
+<command>echo</command> "logger = \"tee -a tarantool.log\"" | <command>tee</command> <option>-a</option> tarantool.cfg
 <command>echo</command> "work_dir = \"work_dir\"" | <command>tee</command> <option>-a</option> tarantool.cfg
 (With some downloads a tarantool.cfg file like this is already available in a test subdirectory.)
 </programlisting>


### PR DESCRIPTION
OSX tee command don't have --apend parameter, only -a. This change will make documentation more portable.
