### PR TITLE
make iproto answer to be 3 part even for ping

### DIFF
--- a/src/box/iproto_port.cc
+++ b/src/box/iproto_port.cc
@@ -72,9 +72,11 @@ void
 iproto_reply_ping(struct obuf *out, uint64_t sync)
 {
 	struct iproto_header_bin reply = iproto_header_bin;
-	reply.v_len = mp_bswap_u32(sizeof(iproto_header_bin) - 5);
+	reply.v_len = mp_bswap_u32(sizeof(iproto_header_bin) - 5 + 1);
 	reply.v_sync = mp_bswap_u64(sync);
+	uint8_t empty_map[1] = { 0x80 };
 	obuf_dup(out, &reply, sizeof(reply));
+	obuf_dup(out, &empty_map, sizeof(empty_map));
 }
 
 static inline uint32_t


### PR DESCRIPTION
This will simplify client library construction cause it will allow to use
streaming MsgPack decoding.
If reply has variable part count, then request decoder which uses streaming
decoder, need to wait next part to analize: is it belongs to this reply
(body map) or start of next reply (ie length integer)? So that, if request
(ping) were single request, request decoder will stuck.
Even in case of non-streaming decoder, tarantool-python, for example, pays a price
of throwing and catching exception for ping request.