### PR TITLE
os.getenv('HOME') returns NIL

### DIFF
--- a/extra/dist/tarantoolctl
+++ b/extra/dist/tarantoolctl
@@ -106,10 +106,12 @@ local fiber = require 'fiber'
 
 ffi.cdef[[ int kill(int pid, int sig); ]]
 
-local config_file = os.getenv('HOME') .. '/.config/tarantool/tarantool'
+if( os.getenv('HOME') ) then
+    local config_file = os.getenv('HOME') .. '/.config/tarantool/tarantool'
+end
 local usermode = true
 
-if not fio.stat(config_file) then
+if not config_file and not fio.stat(config_file) then
     usermode = false
     local config_list = {
         '/etc/sysconfig/tarantool',


### PR DESCRIPTION
Иногда os.getenv('HOME') может возвращать NIL.
Если это происходит tarantoolctl падает с ошибкой:
`/usr/bin/tarantoolctl:109: attempt to concatenate a nil value`
В частности я обнаружил такое поведение на ubuntu 14.04.
Эта небольшая правка решает эту проблему.