### PR TITLE
Rename global `fiber` into `fiber_ptr`

### DIFF
--- a/include/fiber.h
+++ b/include/fiber.h
@@ -111,12 +111,12 @@ struct fiber {
 	uint64_t cookie;
 };
 
-extern __thread struct fiber *fiber;
+extern __thread struct fiber *fiber_ptr;
 
 void fiber_init(void);
 void fiber_free(void);
 typedef void(*fiber_func)(va_list);
-struct fiber *fiber_new(const char *name, fiber_func f);
+struct fiber *fiber_new(const char *name, fiber_func func);
 void fiber_set_name(struct fiber *fiber, const char *name);
 int wait_for_child(pid_t pid);
 

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -76,18 +76,18 @@ mutex_destroy(struct mutex *m)
 static inline bool
 mutex_lock_timeout(struct mutex *m, ev_tstamp timeout)
 {
-	rlist_add_tail_entry(&m->queue, fiber, state);
+	rlist_add_tail_entry(&m->queue, fiber_ptr, state);
 	ev_tstamp start = timeout;
 	while (timeout > 0) {
 		struct fiber *f = rlist_first_entry(&m->queue,
 						    struct fiber, state);
-		if (f == fiber)
+		if (f == fiber_ptr)
 			break;
 
 		fiber_yield_timeout(timeout);
 		timeout -= ev_now() - start;
 		if (timeout <= 0) {
-			rlist_del_entry(fiber, state);
+			rlist_del_entry(fiber_ptr, state);
 			errno = ETIMEDOUT;
 			return true;
 		}
@@ -129,7 +129,7 @@ mutex_unlock(struct mutex *m)
 {
 	struct fiber *f;
 	f = rlist_first_entry(&m->queue, struct fiber, state);
-	assert(f == fiber);
+	assert(f == fiber_ptr);
 	rlist_del_entry(f, state);
 	if (!rlist_empty(&m->queue)) {
 		f = rlist_first_entry(&m->queue, struct fiber, state);

--- a/src/admin.cc
+++ b/src/admin.cc
@@ -247,8 +247,8 @@ static int
 admin_dispatch(struct ev_io *coio, struct iobuf *iobuf, lua_State *L)
 {
 	struct ibuf *in = &iobuf->in;
-	struct tbuf *out = tbuf_new(fiber->gc_pool);
-	struct tbuf *err = tbuf_new(fiber->gc_pool);
+	struct tbuf *out = tbuf_new(fiber_ptr->gc_pool);
+	struct tbuf *err = tbuf_new(fiber_ptr->gc_pool);
 	int cs;
 	char *p, *pe;
 	char *strstart, *strend;
@@ -1994,7 +1994,7 @@ admin_handler(va_list ap)
 		luaL_unref(tarantool_L, LUA_REGISTRYINDEX, coro_ref);
 		evio_close(&coio);
 		iobuf_delete(iobuf);
-		session_destroy(fiber->sid);
+		session_destroy(fiber_ptr->sid);
 	});
 
 	/*

--- a/src/admin.rl
+++ b/src/admin.rl
@@ -238,8 +238,8 @@ static int
 admin_dispatch(struct ev_io *coio, struct iobuf *iobuf, lua_State *L)
 {
 	struct ibuf *in = &iobuf->in;
-	struct tbuf *out = tbuf_new(fiber->gc_pool);
-	struct tbuf *err = tbuf_new(fiber->gc_pool);
+	struct tbuf *out = tbuf_new(fiber_ptr->gc_pool);
+	struct tbuf *err = tbuf_new(fiber_ptr->gc_pool);
 	int cs;
 	char *p, *pe;
 	char *strstart, *strend;
@@ -387,7 +387,7 @@ admin_handler(va_list ap)
 		luaL_unref(tarantool_L, LUA_REGISTRYINDEX, coro_ref);
 		evio_close(&coio);
 		iobuf_delete(iobuf);
-		session_destroy(fiber->sid);
+		session_destroy(fiber_ptr->sid);
 	});
 
 	/*

--- a/src/box/request.cc
+++ b/src/box/request.cc
@@ -116,7 +116,7 @@ execute_update(struct request *request, struct txn *txn)
 	/* Update the tuple. */
 	struct tuple *new_tuple = tuple_update(space->format,
 					       palloc_region_alloc,
-					       fiber->gc_pool,
+					       fiber_ptr->gc_pool,
 					       old_tuple, *reqpos, reqend);
 	try {
 		space_validate_tuple(space, new_tuple);
@@ -234,7 +234,7 @@ request_create(uint32_t type, const char *data, uint32_t len)
 	}
 	request_check_type(type);
 	struct request *request = (struct request *)
-			palloc(fiber->gc_pool, sizeof(struct request));
+			palloc(fiber_ptr->gc_pool, sizeof(struct request));
 	request->type = type;
 	request->data = data;
 	request->len = len;

--- a/src/box/txn.cc
+++ b/src/box/txn.cc
@@ -67,7 +67,7 @@ txn_replace(struct txn *txn, struct space *space,
 struct txn *
 txn_begin()
 {
-	struct txn *txn = (struct txn *) p0alloc(fiber->gc_pool, sizeof(*txn));
+	struct txn *txn = (struct txn *) p0alloc(fiber_ptr->gc_pool, sizeof(*txn));
 	return txn;
 }
 
@@ -78,7 +78,7 @@ txn_commit(struct txn *txn)
 		int64_t lsn = next_lsn(recovery_state);
 
 		ev_tstamp start = ev_now(), stop;
-		int res = wal_write(recovery_state, lsn, fiber->cookie,
+		int res = wal_write(recovery_state, lsn, fiber_ptr->cookie,
 				    txn->op, txn->data, txn->len);
 		stop = ev_now();
 

--- a/src/coeio.cc
+++ b/src/coeio.cc
@@ -187,7 +187,7 @@ ssize_t
 coeio_custom(ssize_t (*func)(va_list ap), ev_tstamp timeout, ...)
 {
 	struct coeio_task task;
-	task.fiber = fiber;
+	task.fiber = fiber_ptr;
 	task.func = func;
 	task.result = -1;
 	task.complete = 0;

--- a/src/coio.cc
+++ b/src/coio.cc
@@ -53,7 +53,7 @@ void
 coio_init(struct ev_io *coio)
 {
 	/* Prepare for ev events. */
-	coio->data = fiber;
+	coio->data = fiber_ptr;
 	ev_init(coio, fiber_schedule_coio);
 	coio->fd = -1;
 }
@@ -61,7 +61,7 @@ coio_init(struct ev_io *coio)
 static inline void
 coio_fiber_yield(struct ev_io *coio)
 {
-	coio->data = fiber;
+	coio->data = fiber_ptr;
 	fiber_yield();
 #ifdef DEBUG
 	coio->data = NULL;
@@ -71,7 +71,7 @@ coio_fiber_yield(struct ev_io *coio)
 static inline bool
 coio_fiber_yield_timeout(struct ev_io *coio, ev_tstamp delay)
 {
-	coio->data = fiber;
+	coio->data = fiber_ptr;
 	bool is_timedout = fiber_yield_timeout(delay);
 #ifdef DEBUG
 	coio->data = NULL;

--- a/src/iproto.cc
+++ b/src/iproto.cc
@@ -175,7 +175,7 @@ static inline void
 iproto_cache_fiber(struct iproto_queue *i_queue)
 {
 	fiber_gc();
-	rlist_add_entry(&i_queue->fiber_cache, fiber, state);
+	rlist_add_entry(&i_queue->fiber_cache, fiber_ptr, state);
 	fiber_yield();
 }
 
@@ -230,7 +230,7 @@ iproto_queue_handler(va_list ap)
 restart:
 	while (iproto_dequeue_request(i_queue, &request)) {
 
-		fiber_set_sid(fiber, iproto_session_id(request.session), iproto_session_cookie(request.session));
+		fiber_set_sid(fiber_ptr, iproto_session_id(request.session), iproto_session_cookie(request.session));
 		request.process(&request);
 	}
 	iproto_cache_fiber(&request_queue);
@@ -734,7 +734,7 @@ iproto_process_connect(struct iproto_request *request)
 static void
 iproto_process_disconnect(struct iproto_request *request)
 {
-	fiber_set_sid(fiber, request->session->sid, request->session->cookie);
+	fiber_set_sid(fiber_ptr, request->session->sid, request->session->cookie);
 	/* Runs the trigger, which may yield. */
 	iproto_session_destroy(request->session);
 }

--- a/src/log_io.cc
+++ b/src/log_io.cc
@@ -100,7 +100,7 @@ scan_dir(struct log_dir *dir, int64_t **ret_lsn)
 	ssize_t result = -1;
 	size_t i = 0, size = 1024;
 	ssize_t ext_len = strlen(dir->filename_ext);
-	int64_t *lsn = (int64_t *) palloc(fiber->gc_pool, sizeof(int64_t) * size);
+	int64_t *lsn = (int64_t *) palloc(fiber_ptr->gc_pool, sizeof(int64_t) * size);
 	DIR *dh = opendir(dir->dirname);
 
 	if (lsn == NULL || dh == NULL)
@@ -144,7 +144,7 @@ scan_dir(struct log_dir *dir, int64_t **ret_lsn)
 
 		i++;
 		if (i == size) {
-			int64_t *n = (int64_t *) palloc(fiber->gc_pool, sizeof(int64_t) * size * 2);
+			int64_t *n = (int64_t *) palloc(fiber_ptr->gc_pool, sizeof(int64_t) * size * 2);
 			if (n == NULL)
 				goto out;
 			memcpy(n, lsn, sizeof(int64_t) * size);
@@ -240,7 +240,7 @@ row_reader_v11(FILE *f, uint32_t *rowlen)
 		say_error("header crc32c mismatch");
 		return NULL;
 	}
-	char *row = (char *) palloc(fiber->gc_pool, sizeof(m) + m.len);
+	char *row = (char *) palloc(fiber_ptr->gc_pool, sizeof(m) + m.len);
 	memcpy(row, &m, sizeof(m));
 
 	if (fread(row + sizeof(m), m.len, 1, f) != 1)
@@ -278,7 +278,7 @@ log_io_cursor_close(struct log_io_cursor *i)
 	 * Seek back to last known good offset.
 	 */
 	fseeko(l->f, i->good_offset, SEEK_SET);
-	prelease(fiber->gc_pool);
+	prelease(fiber_ptr->gc_pool);
 }
 
 /**
@@ -306,7 +306,7 @@ log_io_cursor_next(struct log_io_cursor *i, uint32_t *rowlen)
 	 * it before reading the next row, to make
 	 * sure it's not freed along here.
 	 */
-	prelease_after(fiber->gc_pool, 128 * 1024);
+	prelease_after(fiber_ptr->gc_pool, 128 * 1024);
 
 restart:
 	if (marker_offset > 0)

--- a/src/lua/bsdsocket.cc
+++ b/src/lua/bsdsocket.cc
@@ -422,7 +422,7 @@ lbox_bsdsocket_iowait(struct lua_State *L)
 
 	struct ev_io io;
 	ev_io_init(&io, bsdsocket_io, fh, events);
-	struct bsdsocket_io_wdata wdata = { fiber, 0 };
+	struct bsdsocket_io_wdata wdata = { fiber_ptr, 0 };
 	io.data = &wdata;
 	ev_set_priority(&io, EV_MAXPRI);
 	ev_io_start(&io);

--- a/src/lua/session.cc
+++ b/src/lua/session.cc
@@ -53,7 +53,7 @@ extern lua_State *root_L;
 static int
 lbox_session_id(struct lua_State *L)
 {
-	lua_pushnumber(L, fiber->sid);
+	lua_pushnumber(L, fiber_ptr->sid);
 	return 1;
 }
 
@@ -81,7 +81,7 @@ lbox_session_peer(struct lua_State *L)
 		luaL_error(L, "session.peer(sid): bad arguments");
 
 	uint32_t sid = lua_gettop(L) == 1 ?
-		luaL_checkint(L, -1) : fiber->sid;
+		luaL_checkint(L, -1) : fiber_ptr->sid;
 
 	int fd = session_fd(sid);
 	struct sockaddr_in addr;

--- a/src/memcached-grammar.cc
+++ b/src/memcached-grammar.cc
@@ -47,7 +47,7 @@ memcached_dispatch(struct ev_io *coio, struct iobuf *iobuf)
 	int cs;
 	char *p, *pe;
 	char *fstart;
-	struct tbuf *keys = tbuf_new(fiber->gc_pool);
+	struct tbuf *keys = tbuf_new(fiber_ptr->gc_pool);
 	const char *key;
 	bool append, show_cas;
 	int incr_sign;
@@ -428,7 +428,7 @@ tr58:
 				obuf_dup(out, "NOT_STORED\r\n", 12);
 			} else {
 				field = tuple_field(tuple, 3, &field_len);
-				b = tbuf_new(fiber->gc_pool);
+				b = tbuf_new(fiber_ptr->gc_pool);
 				if (append) {
 					tbuf_append(b, field, field_len);
 					tbuf_append(b, data, bytes);
@@ -487,7 +487,7 @@ tr62:
 				obuf_dup(out, "NOT_STORED\r\n", 12);
 			} else {
 				field = tuple_field(tuple, 3, &field_len);
-				b = tbuf_new(fiber->gc_pool);
+				b = tbuf_new(fiber_ptr->gc_pool);
 				if (append) {
 					tbuf_append(b, field, field_len);
 					tbuf_append(b, data, bytes);
@@ -548,7 +548,7 @@ tr71:
 				obuf_dup(out, "NOT_STORED\r\n", 12);
 			} else {
 				field = tuple_field(tuple, 3, &field_len);
-				b = tbuf_new(fiber->gc_pool);
+				b = tbuf_new(fiber_ptr->gc_pool);
 				if (append) {
 					tbuf_append(b, field, field_len);
 					tbuf_append(b, data, bytes);
@@ -742,7 +742,7 @@ tr118:
 					exptime = m->exptime;
 					flags = m->flags;
 
-					b = tbuf_new(fiber->gc_pool);
+					b = tbuf_new(fiber_ptr->gc_pool);
 					tbuf_printf(b, "%" PRIu64, value);
 					data = b->data;
 					bytes = b->size;
@@ -806,7 +806,7 @@ tr122:
 					exptime = m->exptime;
 					flags = m->flags;
 
-					b = tbuf_new(fiber->gc_pool);
+					b = tbuf_new(fiber_ptr->gc_pool);
 					tbuf_printf(b, "%" PRIu64, value);
 					data = b->data;
 					bytes = b->size;
@@ -872,7 +872,7 @@ tr132:
 					exptime = m->exptime;
 					flags = m->flags;
 
-					b = tbuf_new(fiber->gc_pool);
+					b = tbuf_new(fiber_ptr->gc_pool);
 					tbuf_printf(b, "%" PRIu64, value);
 					data = b->data;
 					bytes = b->size;

--- a/src/memcached-grammar.rl
+++ b/src/memcached-grammar.rl
@@ -38,7 +38,7 @@ memcached_dispatch(struct ev_io *coio, struct iobuf *iobuf)
 	int cs;
 	char *p, *pe;
 	char *fstart;
-	struct tbuf *keys = tbuf_new(fiber->gc_pool);
+	struct tbuf *keys = tbuf_new(fiber_ptr->gc_pool);
 	const char *key;
 	bool append, show_cas;
 	int incr_sign;
@@ -105,7 +105,7 @@ memcached_dispatch(struct ev_io *coio, struct iobuf *iobuf)
 				obuf_dup(out, "NOT_STORED\r\n", 12);
 			} else {
 				field = tuple_field(tuple, 3, &field_len);
-				b = tbuf_new(fiber->gc_pool);
+				b = tbuf_new(fiber_ptr->gc_pool);
 				if (append) {
 					tbuf_append(b, field, field_len);
 					tbuf_append(b, data, bytes);
@@ -151,7 +151,7 @@ memcached_dispatch(struct ev_io *coio, struct iobuf *iobuf)
 					exptime = m->exptime;
 					flags = m->flags;
 
-					b = tbuf_new(fiber->gc_pool);
+					b = tbuf_new(fiber_ptr->gc_pool);
 					tbuf_printf(b, "%" PRIu64, value);
 					data = b->data;
 					bytes = b->size;

--- a/src/memcached.cc
+++ b/src/memcached.cc
@@ -127,7 +127,7 @@ memcached_store(const char *key, uint32_t exptime, uint32_t flags, uint32_t byte
 	static uint64_t cas = 42;
 	struct meta m;
 
-	struct tbuf *req = tbuf_new(fiber->gc_pool);
+	struct tbuf *req = tbuf_new(fiber_ptr->gc_pool);
 
 	tbuf_append(req, &cfg.memcached_space, sizeof(uint32_t));
 	tbuf_append(req, &box_flags, sizeof(box_flags));
@@ -161,7 +161,7 @@ memcached_delete(const char *key)
 {
 	uint32_t key_len = 1;
 	uint32_t box_flags = 0;
-	struct tbuf *req = tbuf_new(fiber->gc_pool);
+	struct tbuf *req = tbuf_new(fiber_ptr->gc_pool);
 
 	tbuf_append(req, &cfg.memcached_space, sizeof(uint32_t));
 	tbuf_append(req, &box_flags, sizeof(box_flags));
@@ -233,7 +233,7 @@ salloc_stat_memcached_cb(const struct slab_cache_stats *cstat, void *cb_ctx)
 static void
 memcached_print_stats(struct obuf *out)
 {
-	struct tbuf *buf = tbuf_new(fiber->gc_pool);
+	struct tbuf *buf = tbuf_new(fiber_ptr->gc_pool);
 
 	struct salloc_stat_memcached_cb_ctx memstats;
 	memstats.bytes_used = memstats.items = 0;
@@ -315,7 +315,7 @@ void memcached_get(struct obuf *out, size_t keys_count, struct tbuf *keys,
 		stat_collect(stat_base, MEMC_GET_HIT, 1);
 
 		if (show_cas) {
-			struct tbuf *b = tbuf_new(fiber->gc_pool);
+			struct tbuf *b = tbuf_new(fiber_ptr->gc_pool);
 			tbuf_printf(b, "VALUE %.*s %" PRIu32 " %" PRIu32 " %" PRIu64 "\r\n", key_len, (char*) key, m->flags, value_len, m->cas);
 			obuf_dup(out, b->data, b->size);
 			stats.bytes_written += b->size;
@@ -562,7 +562,7 @@ restart:
 		if (tuple == NULL)
 			memcached_index->initIterator(memcached_it, ITER_ALL, NULL, 0);
 
-		struct tbuf *keys_to_delete = tbuf_new(fiber->gc_pool);
+		struct tbuf *keys_to_delete = tbuf_new(fiber_ptr->gc_pool);
 
 		for (int j = 0; j < cfg.memcached_expire_per_loop; j++) {
 

--- a/src/replica.cc
+++ b/src/replica.cc
@@ -107,7 +107,7 @@ pull_from_remote(va_list ap)
 				title("replica", "%s/%s", r->remote->source,
 				      "connecting");
 				if (iobuf == NULL)
-					iobuf = iobuf_new(fiber_name(fiber));
+					iobuf = iobuf_new(fiber_name(fiber_ptr));
 				remote_connect(&coio, &r->remote->addr,
 					       r->confirmed_lsn + 1, &err);
 				warning_said = false;

--- a/src/replication.cc
+++ b/src/replication.cc
@@ -302,7 +302,7 @@ spawner_init(int sock)
 	struct sigaction sa;
 
 	title("spawner", NULL);
-	fiber_set_name(fiber, status);
+	fiber_set_name(fiber_ptr, status);
 
 	/* init replicator process context */
 	spawner.sock = sock;
@@ -619,7 +619,7 @@ replication_relay_loop(int client_sock)
 	socklen_t addrlen = sizeof(peer);
 	getpeername(client_sock, ((struct sockaddr*)&peer), &addrlen);
 	title("relay", "%s", sio_strfaddr(&peer));
-	fiber_set_name(fiber, status);
+	fiber_set_name(fiber_ptr, status);
 
 	/* init signals */
 	memset(&sa, 0, sizeof(sa));

--- a/src/say.cc
+++ b/src/say.cc
@@ -192,7 +192,7 @@ vsay(int level, const char *filename, int line, const char *error, const char *f
 		      ev_now() - now + tm.tm_sec);
 
 	p += snprintf(buf + p, len - p, " [%i] %i/%s", getpid(),
-		      fiber->fid, fiber_name(fiber));
+		      fiber_ptr->fid, fiber_name(fiber_ptr));
 
 	if (level == S_WARN || level == S_ERROR)
 		p += snprintf(buf + p, len - p, " %s:%i", filename, line);

--- a/src/session.cc
+++ b/src/session.cc
@@ -62,13 +62,13 @@ session_create(int fd, uint64_t cookie)
 	 * Run the trigger *after* setting the current
 	 * fiber sid.
 	 */
-	fiber_set_sid(fiber, sid, cookie);
+	fiber_set_sid(fiber_ptr, sid, cookie);
 	if (session_on_connect.trigger) {
 		void *param = session_on_connect.param;
 		try {
 			session_on_connect.trigger(param);
 		} catch (const Exception& e) {
-			fiber_set_sid(fiber, 0, 0);
+			fiber_set_sid(fiber_ptr, 0, 0);
 			mh_i32ptr_remove(session_registry, &node, NULL);
 			throw;
 		}

--- a/src/tarantool.cc
+++ b/src/tarantool.cc
@@ -366,7 +366,7 @@ snapshot(void)
 	salloc_protect();
 
 	title("dumper", "%" PRIu32, getppid());
-	fiber_set_name(fiber, status);
+	fiber_set_name(fiber_ptr, status);
 
 	/*
 	 * Safety: make sure we don't double-write
@@ -933,7 +933,7 @@ main(int argc, char **argv)
 		 * initialized.
 		 */
 		tarantool_lua_load_init_script(tarantool_L);
-		prelease(fiber->gc_pool);
+		prelease(fiber_ptr->gc_pool);
 		say_crit("log level %i", cfg.log_level);
 		say_crit("entering event loop");
 		if (cfg.io_collect_interval > 0)

--- a/src/util.cc
+++ b/src/util.cc
@@ -271,13 +271,13 @@ print_backtrace()
 	void *stack_top;
 	size_t stack_size;
 
-	if (fiber == NULL || fiber_name(fiber) == NULL ||
-	    strcmp(fiber_name(fiber), "sched") == 0) {
+	if (fiber_ptr == NULL || fiber_name(fiber_ptr) == NULL ||
+	    strcmp(fiber_name(fiber_ptr), "sched") == 0) {
 		stack_top = frame; /* we don't know where the system stack top is */
 		stack_size = (const char *) __libc_stack_end - (const char *) frame;
 	} else {
-		stack_top = fiber->coro.stack;
-		stack_size = fiber->coro.stack_size;
+		stack_top = fiber_ptr->coro.stack;
+		stack_size = fiber_ptr->coro.stack_size;
 	}
 
 	fdprintf(STDERR_FILENO, "%s", backtrace(frame, stack_top, stack_size));


### PR DESCRIPTION
For use with gdb and avoidance of ambiguity with `struct fiber`