### PR TITLE
export iowait function from socket module

### DIFF
--- a/src/lua/socket.lua
+++ b/src/lua/socket.lua
@@ -1132,6 +1132,21 @@ local function tcp_server(host, port, opts, timeout)
     return nil
 end
 
+local function iowait(fd, events, timeout)
+    if type(events) == "string" then
+        -- events constants are taken from libev/ev.h
+        local ev = 0
+        if events:match"r" then
+            ev = ev + 1 -- EV_READ
+        end
+        if events:match"w" then
+            ev = ev + 2 -- EV_WRITE
+        end
+        events = ev
+    end
+    return internal.iowait(fd, events, timeout or TIMEOUT_INFINITY)
+end
+
 socket_mt   = {
     __index     = socket_methods,
     __tostring  = function(self)
@@ -1160,7 +1175,8 @@ socket_mt   = {
 return setmetatable({
     getaddrinfo = getaddrinfo,
     tcp_connect = tcp_connect,
-    tcp_server = tcp_server
+    tcp_server = tcp_server,
+    iowait = iowait
 }, {
     __call = function(self, ...) return create_socket(...) end;
 })

--- a/src/lua/socket.lua
+++ b/src/lua/socket.lua
@@ -1133,6 +1133,13 @@ local function tcp_server(host, port, opts, timeout)
 end
 
 local function iowait(fd, events, timeout)
+    if timeout == nil then
+        timeout = TIMEOUT_INFINITY
+    end
+    if fd == nil then
+        fiber.sleep(timeout)
+        return 0x00000100 -- EV_TIMER
+    end
     if type(events) == "string" then
         -- events constants are taken from libev/ev.h
         local ev = 0
@@ -1144,7 +1151,7 @@ local function iowait(fd, events, timeout)
         end
         events = ev
     end
-    return internal.iowait(fd, events, timeout or TIMEOUT_INFINITY)
+    return internal.iowait(fd, events, timeout)
 end
 
 socket_mt   = {


### PR DESCRIPTION
As discussed with @kostja at the lua workshop.

I made it so that the lua wrapper can take a string containing `"r"` and/or `"w"`, as the `EV_READ`/`EV_WRITE` constants shouldn't be forced upon user code.

The exposing of `iowait` opens up the possibility to use a wide range of libraries; not just lua libraries (e.g. cqueues, luv), but also C client libraries that expose an "async" interface that works with file descriptors (e.g. hiredis, libpq)

Example of what you can do once this is merged (using [cqueues](https://github.com/wahern/cqueues)):
```lua
local s = require "socket"

local cqueues = require "cqueues"
local cq = cqueues.new()
cq:wrap(function()
	for i=1, 100 do
		cqueues.sleep(1)
		print("SLEEP", i)
	end
end)
local cs = require "cqueues.socket"
local stdin = cs.fdopen(0)
cq:wrap(function()
	for line in stdin:lines() do
		print("LINE", line)
	end
end)
while not cq:empty() do
	s.iowait(cq:pollfd(), cq:events(), cq:timeout())
	assert(cq:step(0))
end
```