### PR TITLE
Minor fixes

### DIFF
--- a/doc/sphinx/book/user_guide_getting_started.rst
+++ b/doc/sphinx/book/user_guide_getting_started.rst
@@ -171,7 +171,7 @@ In the previous section the first request was with :code:`box.cfg{listen = 3301}
 The :code:`listen` value can be any form of URI (uniform resource identifier);
 in this case it's just a local port: port 3301.
 It's possible to send requests to the listen URI via (a) telnet,
-(b) a connector (which will be the subject of Chapter 8),
+(b) a connector (which will be the subject of the :ref:`box-connectors` chapter),
 or (c) another instance of Tarantool. Let's try (c).
 
 Switch to another terminal.

--- a/doc/sphinx/dev_guide/building_documentation.rst
+++ b/doc/sphinx/dev_guide/building_documentation.rst
@@ -7,16 +7,15 @@ Building documentation
 After building and testing your local instance of Tarantool, you can build a
 local version of this documentation and contribute to it.
 
-Documentation is based on the python-based Sphinx generator. So, make sure to
-install all python modules indicated in the BUILDING FROM SOURCE
-(http://tarantool.org/doc/dev_guide/building_from_source.html) section of this
-documentation. The procedure below implies that you already took those steps and
-successfully tested your instance of Tarantool.
+Documentation is based on the Python-based Sphinx generator. So, make sure to
+install all Python modules indicated in the :ref:`building-from-source` section
+of this documentation. The procedure below implies that you already took those
+steps and successfully tested your instance of Tarantool.
 
 1. Build a local version of the existing documentation package.
 
 Run the following set of commands (the example below is based on Ubuntu OS, but
-the precedure is similar for other supported OS's):
+the procedure is similar for other supported platforms):
 
    .. code-block:: bash
 
@@ -46,7 +45,7 @@ guidelines below:
 
 If all the prerequisites are met, run the following command to set up a
 web-server (the example below is based on Ubuntu, but the procedure is similar
-for other supported OS's). Make sure to run it from the documentation output
+for other supported platforms). Make sure to run it from the documentation output
 folder, as specified below:
 
    .. code-block:: bash


### PR DESCRIPTION
 - Added reference links
 - Made Python title-case
 - Fixed typo (`precedure` -> `procedure`)
 - Replaced "OS's" with "platforms". 

The last one is disputable, since "OS's" isn't "Operating Systems" in plural, it is "Operating System's" which is wrong in this case. There are several choices like "OSs", "OSes", "platforms" and whatever else, but I have found several usages of "platforms" in the documentation already, so I decided to choose it.