### PR TITLE
Fix #1882: Make error message ER_MORE_THAN_ONE_TUPLE more clear.

### DIFF
--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -93,7 +93,7 @@ struct errcode_record {
 	/* 38 */_(ER_EXACT_FIELD_COUNT,		"Tuple field count %u does not match space field count %u") \
 	/* 39 */_(ER_INDEX_FIELD_COUNT,		"Tuple field count %u is less than required by a defined index (expected %u)") \
 	/* 40 */_(ER_WAL_IO,			"Failed to write to disk") \
-	/* 41 */_(ER_MORE_THAN_ONE_TUPLE,	"More than one tuple found by get()") \
+	/* 41 */_(ER_MORE_THAN_ONE_TUPLE,	"Get() doesn't support partial keys and non-unique indexes") \
 	/* 42 */_(ER_ACCESS_DENIED,		"%s access on %s is denied for user '%s'") \
 	/* 43 */_(ER_CREATE_USER,		"Failed to create user '%s': %s") \
 	/* 44 */_(ER_DROP_USER,			"Failed to drop user or role '%s': %s") \

--- a/test/engine/update.result
+++ b/test/engine/update.result
@@ -581,11 +581,11 @@ index1:update({0, 'fwoen'}, {{'=', 3, 5}})
 ...
 index2:update({'fwoen'}, {'=', 3, 1000})
 ---
-- error: More than one tuple found by get()
+- error: Get() doesn't support partial keys and non-unique indexes
 ...
 index3:update({324, 'fwoen', 3}, {{'-', 3, 100}})
 ---
-- error: More than one tuple found by get()
+- error: Get() doesn't support partial keys and non-unique indexes
 ...
 space:drop()
 ---


### PR DESCRIPTION
Was:
More than one tuple found by get()

Now:
Get() doesn't support partial keys and non-unique indexes