### PR TITLE
Remove redundant coio_init call

### DIFF
--- a/src/coio.cc
+++ b/src/coio.cc
@@ -730,7 +730,6 @@ coio_wait(int fd, int events, double timeout)
 	if (fiber_is_cancelled())
 		return 0;
 	struct ev_io io;
-	coio_init(&io, fd);
 	ev_io_init(&io, coio_wait_cb, fd, events);
 	struct coio_wdata wdata = {
 		/* .fiber =   */ fiber(),


### PR DESCRIPTION
ev_io data get overwritten on the next line by ev_io_init