### PR TITLE
Don't wrap box_return_tuple result into array

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -941,35 +941,15 @@ func_call(struct func *func, struct request *request, struct obuf *out)
 	if (iproto_prepare_select(out, &svp) != 0)
 		goto error;
 
-	if (request->type == IPROTO_CALL_16) {
-		/* Tarantool < 1.7.1 compatibility */
-		for (struct port_entry *entry = port.first;
-		     entry != NULL; entry = entry->next) {
-			if (tuple_to_obuf(entry->tuple, out) != 0) {
-				obuf_rollback_to_svp(out, &svp);
-				goto error;
-			}
-		}
-		iproto_reply_select(out, &svp, request->header->sync, port.size);
-	} else {
-		assert(request->type == IPROTO_CALL);
-		char *size_buf = (char *)
-			obuf_alloc(out, mp_sizeof_array(port.size));
-		if (size_buf == NULL)
+	for (struct port_entry *entry = port.first;
+			entry != NULL; entry = entry->next) {
+		if (tuple_to_obuf(entry->tuple, out) != 0) {
+			obuf_rollback_to_svp(out, &svp);
 			goto error;
-		mp_encode_array(size_buf, port.size);
-		for (struct port_entry *entry = port.first;
-		     entry != NULL; entry = entry->next) {
-			if (tuple_to_obuf(entry->tuple, out) != 0) {
-				obuf_rollback_to_svp(out, &svp);
-				goto error;
-			}
 		}
-		iproto_reply_select(out, &svp, request->header->sync, 1);
 	}
-
+	iproto_reply_select(out, &svp, request->header->sync, port.size);
 	port_destroy(&port);
-
 	return 0;
 
 error:

--- a/test/box/function1.result
+++ b/test/box/function1.result
@@ -27,9 +27,8 @@ box.schema.user.grant('guest', 'read,write', 'space', 'test')
 ...
 c:call('function1')
 ---
-- []
 ...
-box.schema.func.drop("function1")
+box.schema.func.drop('function1')
 ---
 ...
 box.schema.func.create('function1.args', {language = "C"})
@@ -42,15 +41,15 @@ c:call('function1.args')
 ---
 - error: invalid argument count
 ...
-c:call('function1.args', "xx")
+c:call('function1.args', 'xx')
 ---
 - error: first tuple field must be uint
 ...
 c:call('function1.args', 15)
 ---
-- [[15, 'hello']]
+- [15, 'hello']
 ...
-box.schema.func.drop("function1.args")
+box.schema.func.drop('function1.args')
 ---
 ...
 box.schema.func.create('function1.multi_inc', {language = "C"})
@@ -61,7 +60,6 @@ box.schema.user.grant('guest', 'execute', 'function', 'function1.multi_inc')
 ...
 c:call('function1.multi_inc')
 ---
-- []
 ...
 box.space.test:select{}
 ---
@@ -69,7 +67,6 @@ box.space.test:select{}
 ...
 c:call('function1.multi_inc', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 ---
-- []
 ...
 box.space.test:select{}
 ---
@@ -86,7 +83,6 @@ box.space.test:select{}
 ...
 c:call('function1.multi_inc', 2, 4, 6, 8, 10)
 ---
-- []
 ...
 box.space.test:select{}
 ---
@@ -103,7 +99,6 @@ box.space.test:select{}
 ...
 c:call('function1.multi_inc', 0, 2, 4)
 ---
-- []
 ...
 box.space.test:select{}
 ---
@@ -119,7 +114,7 @@ box.space.test:select{}
   - [9, 0]
   - [10, 1]
 ...
-box.schema.func.drop("function1.multi_inc")
+box.schema.func.drop('function1.multi_inc')
 ---
 ...
 box.schema.func.create('function1.errors', {language = "C"})
@@ -132,7 +127,7 @@ c:call('function1.errors')
 ---
 - error: unknown error
 ...
-box.schema.func.drop("function1.errors")
+box.schema.func.drop('function1.errors')
 ---
 ...
 box.schema.func.create('xxx', {language = 'invalid'})

--- a/test/box/function1.test.lua
+++ b/test/box/function1.test.lua
@@ -12,14 +12,14 @@ _ = box.space.test:create_index('primary')
 box.schema.user.grant('guest', 'read,write', 'space', 'test')
 
 c:call('function1')
-box.schema.func.drop("function1")
+box.schema.func.drop('function1')
 
 box.schema.func.create('function1.args', {language = "C"})
 box.schema.user.grant('guest', 'execute', 'function', 'function1.args')
 c:call('function1.args')
-c:call('function1.args', "xx")
+c:call('function1.args', 'xx')
 c:call('function1.args', 15)
-box.schema.func.drop("function1.args")
+box.schema.func.drop('function1.args')
 
 box.schema.func.create('function1.multi_inc', {language = "C"})
 box.schema.user.grant('guest', 'execute', 'function', 'function1.multi_inc')
@@ -33,12 +33,12 @@ box.space.test:select{}
 c:call('function1.multi_inc', 0, 2, 4)
 box.space.test:select{}
 
-box.schema.func.drop("function1.multi_inc")
+box.schema.func.drop('function1.multi_inc')
 
 box.schema.func.create('function1.errors', {language = "C"})
 box.schema.user.grant('guest', 'execute', 'function', 'function1.errors')
 c:call('function1.errors')
-box.schema.func.drop("function1.errors")
+box.schema.func.drop('function1.errors')
 
 box.schema.func.create('xxx', {language = 'invalid'})
 


### PR DESCRIPTION
We have inconsistent behavior between Lua and C functions (aka stored procedures)
because iproto call (1.7) wraps the result to another array.
So even `select` operation would result in: `[[[tuple1], [tuple2]]]`
Solution: call 1.6 -> 1.7 change shouldn't affect C API, it already works as expected.