### PR TITLE
Increase maximum replicas count in cluster to 64.

### DIFF
--- a/src/box/vclock.h
+++ b/src/box/vclock.h
@@ -50,7 +50,7 @@ enum {
 	/**
 	 * The maximum number of components in vclock
 	 */
-	VCLOCK_MAX = 99,
+	VCLOCK_MAX = 64,
 
 	/**
 	 * The maximum length of string representation of vclock.
@@ -69,7 +69,7 @@ enum {
 /** Cluster vector clock */
 struct vclock {
 	/** Map of used components in lsn array */
-	unsigned int map;
+	uint64_t map;
 	/** Sum of all components of vclock. */
 	int64_t signature;
 	int64_t lsn[VCLOCK_MAX];
@@ -144,7 +144,7 @@ vclock_copy(struct vclock *dst, const struct vclock *src)
 static inline uint32_t
 vclock_size(const struct vclock *vclock)
 {
-	return __builtin_popcount(vclock->map);
+	return __builtin_popcountl(vclock->map);
 }
 
 static inline int64_t
@@ -203,7 +203,7 @@ static inline int
 vclock_compare(const struct vclock *a, const struct vclock *b)
 {
 	bool le = true, ge = true;
-	unsigned int map = a->map | b->map;
+	uint64_t map = a->map | b->map;
 	struct bit_iterator it;
 	bit_iterator_init(&it, &map, sizeof(map), true);
 

--- a/src/box/vclock.h
+++ b/src/box/vclock.h
@@ -50,7 +50,7 @@ enum {
 	/**
 	 * The maximum number of components in vclock
 	 */
-	VCLOCK_MAX = 32,
+	VCLOCK_MAX = 99,
 
 	/**
 	 * The maximum length of string representation of vclock.

--- a/test/replication/prune.result
+++ b/test/replication/prune.result
@@ -56,7 +56,7 @@ uuid = require('uuid')
 ...
 box.space._cluster:insert{box.schema.REPLICA_MAX, uuid.str()}
 ---
-- error: 'Replica count limit reached: 99'
+- error: 'Replica count limit reached: 64'
 ...
 -- Delete all replication nodes
 replica_set.drop_all(test_run)

--- a/test/replication/prune.result
+++ b/test/replication/prune.result
@@ -56,7 +56,7 @@ uuid = require('uuid')
 ...
 box.space._cluster:insert{box.schema.REPLICA_MAX, uuid.str()}
 ---
-- error: 'Replica count limit reached: 32'
+- error: 'Replica count limit reached: 99'
 ...
 -- Delete all replication nodes
 replica_set.drop_all(test_run)


### PR DESCRIPTION
Current limitation of 32 replicas in cluster is too low.
This patch increases it to 99.
Why not more? Due to comment in

./src/box/vclock.h:60:   *    <server_id> is 0..VCLOCK_MAX (2 chars),

So there is only 2 chars reserved for server ID.

Testing done:

    mkdir ~/tarantool/bin
    ln /usr/bin/python ~/tarantool/bin/python
    cd ~/tarantool/test
    PATH=~/tarantool/bin:$PATH ./test-run.py

All tests passed.
Plus custom tests ensuring that master-master replication with 99 replication_source really works.
(requires a lot of memory)