### PR TITLE
The condition is redundant

### DIFF
--- a/src/lib/salad/rope.c
+++ b/src/lib/salad/rope.c
@@ -646,7 +646,7 @@ rope_node_print(struct rope_node *node,
 		print(node->data, node->leaf_size);
 		printf("'}\n");
 
-		if (node && (node->link[0] || node->link[1]))
+		if (node->link[0] || node->link[1])
 			rope_node_print(node->link[1], print, child_prefix, 1);
 	}
 


### PR DESCRIPTION
You alredy checked if node is not NULL at string 640 in "if else" condition https://github.com/tarantool/tarantool/blob/1.7/src/lib/salad/rope.c#L640 so you don't really need to check it again