### PR TITLE
Implement index:info() introspection

### DIFF
--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -37,6 +37,7 @@
 #include "iproto_constants.h"
 #include "txn.h"
 #include "rmean.h"
+#include "info.h"
 
 const char *iterator_type_strs[] = {
 	/* [ITER_EQ]  = */ "EQ",
@@ -532,6 +533,31 @@ box_iterator_free(box_iterator_t *it)
 {
 	if (it->free)
 		it->free(it);
+}
+
+/* }}} */
+
+/* {{{ Introspection */
+
+void
+Index::info(struct info_handler *info) const
+{
+	info_begin(info);
+	info_end(info);
+}
+
+int
+box_index_info(uint32_t space_id, uint32_t index_id,
+	       struct info_handler *info)
+{
+	try {
+		struct space *space;
+		Index *index = check_index(space_id, index_id, &space);
+		index->info(info);
+		return 0;
+	}  catch (Exception *) {
+		return -1;
+	}
 }
 
 /* }}} */

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -243,6 +243,21 @@ box_index_count(uint32_t space_id, uint32_t index_id, int type,
 
 /** \endcond public */
 
+struct info_handler;
+
+/**
+ * Index introspection (index:info())
+ *
+ * \param space_id space identifier
+ * \param index_id index identifier
+ * \param info info handler
+ * \retval -1 on error (check box_error_last())
+ * \retval >=0 on success
+ */
+int
+box_index_info(uint32_t space_id, uint32_t index_id,
+	       struct info_handler *info);
+
 extern const char *iterator_type_strs[];
 
 #if defined(__cplusplus)
@@ -367,6 +382,9 @@ public:
 	 * for which createReadViewForIterator() was called.
 	 */
 	virtual void destroyReadViewForIterator(struct iterator *iterator);
+
+	/** Introspection (index:info()) */
+	virtual void info(struct info_handler *handler) const;
 };
 
 /*

--- a/src/box/info.h
+++ b/src/box/info.h
@@ -1,0 +1,254 @@
+#ifndef INCLUDES_TARANTOOL_BOX_INFO_H
+#define INCLUDES_TARANTOOL_BOX_INFO_H
+/*
+ * Copyright 2010-2017, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+
+/**
+ * @file
+ * This module provides an adapter for Lua/C API to generate box.info()
+ * and index:info() introspection trees. The primary purpose of this
+ * adapter is to eliminate Engine <-> Lua interdependency.
+ *
+ * TREE STRUCTURE
+ *
+ * { -- INFO_BEGIN
+ *    section = { -- INFO_TABLE_BEGIN
+ *        key1 = u32; -- INFO_U32
+ *        key2 = u64; -- INFO_U64
+ *        key3 = str;  -- INFO_STRING;
+ *    };          -- INFO_TABLE_END
+ *
+ *    section2 = {
+ *        ...
+ *    };
+ *    ...
+ * } -- INFO_END
+ *
+ *
+ * IMPLEMENTATION DETAILS
+ *
+ * Current implementation calls Lua/C API under the hood without any
+ * pcall() wrapping. As you may now, idiosyncratic Lua/C API unwinds
+ * C stacks on errors in a way you can't handle in C. Please ensure that
+ * all blocks of code which call info_append_XXX() functions are
+ * exception/longjmp safe.
+ */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+/**
+ * Tree element type
+ */
+enum info_type {
+	/** The begin of document. */
+	INFO_BEGIN,
+	/** The end of document. */
+	INFO_END,
+	/* The begin of associative array (a map). */
+	INFO_TABLE_BEGIN,
+	/* The end of associative array (a map). */
+	INFO_TABLE_END,
+	/* Null-terminated string value. */
+	INFO_STRING,
+	/* uint32_t value. */
+	INFO_U32,
+	/* uint64_t value. */
+	INFO_U64,
+};
+
+/**
+ * Represents an element in box.info() tree.
+ */
+struct info_node {
+	/** Element type. */
+	enum info_type type;
+	/** Key in associative array. */
+	const char *key;
+	union {
+		/** Value of INFO_STRING type. */
+		const char *str;
+		/** Value of INFO_U32 type. */
+		uint32_t u32;
+		/** Value of INFO_U64 type. */
+		uint64_t u64;
+	} value;
+};
+
+/**
+ * Adapter for Lua/C API to generate box.info() sections from engines.
+ */
+struct info_handler {
+	/** A callback called by info_XXX() methods. */
+	void (*fn)(struct info_node *node, void *ctx);
+	/** Context for this callback. */
+	void *ctx;
+};
+
+/**
+ * Starts a new document and creates root-level associative array.
+ * @param info box.info() adapter.
+ * @throws C++ exception on OOM, see info.h comments.
+ * @pre must be called once before any other functions.
+ */
+static inline void
+info_begin(struct info_handler *info)
+{
+	struct info_node node = {
+		.type = INFO_BEGIN,
+		.key = NULL,
+		.value = {}
+	};
+	info->fn(&node, info->ctx);
+}
+
+/**
+ * Finishes the document and closes root-level associative array.
+ * @param info box.info() adapter.
+ * @throws C++ exception on OOM, see info.h comments.
+ * @pre must be called at the end.
+ */
+static inline void
+info_end(struct info_handler *info)
+{
+	struct info_node node = {
+		.type = INFO_END,
+		.key = NULL,
+		.value = {}
+	};
+	info->fn(&node, info->ctx);
+}
+
+/**
+ * Associates uint32_t value with @a key in the current associative array.
+ * @param info box.info() adapter.
+ * @param key key.
+ * @param value value.
+ * @throws C++ exception on OOM, see info.h comments.
+ * @pre associative array is started.
+ */
+static inline void
+info_append_u32(struct info_handler *info, const char *key, uint32_t value)
+{
+	struct info_node node = {
+		.type = INFO_U32,
+		.key = key,
+		.value = {
+			.u32 = value,
+		}
+	};
+	info->fn(&node, info->ctx);
+}
+
+/**
+ * Associates uint64_t value with @a key in the current associative array.
+ * @param info box.info() adapter.
+ * @param key key.
+ * @param value value.
+ * @throws C++ exception on OOM, see info.h comments.
+ * @pre associative array is started.
+ */
+static inline void
+info_append_u64(struct info_handler *info, const char *key, uint64_t value)
+{
+	struct info_node node = {
+		.type = INFO_U64,
+		.key = key,
+		.value = {
+			 .u64 = value,
+		},
+	};
+	info->fn(&node, info->ctx);
+}
+
+/**
+ * Associates zero-terminated string with @a key in the current associative
+ * array.
+ * @param info box.info() adapter.
+ * @param key key.
+ * @param value value.
+ * @throws C++ exception on OOM, see info.h comments.
+ */
+static inline void
+info_append_str(struct info_handler *info, const char *key,
+		   const char *value)
+{
+	struct info_node node = {
+		.type = INFO_STRING,
+		.key = key,
+		.value = {
+			 .str = value,
+		},
+	};
+	info->fn(&node, info->ctx);
+}
+
+/*
+ * Associates a new associative array with @a key.
+ * @param info box.info() adapter.
+ * @param key key.
+ * @throws C++ exception on OOM, see info.h comments.
+ */
+static inline void
+info_table_begin(struct info_handler *info, const char *key)
+{
+	struct info_node node = {
+		.type = INFO_TABLE_BEGIN,
+		.key = key,
+		.value = {}
+	};
+	info->fn(&node, info->ctx);
+}
+
+/*
+ * Finishes the current active associative array.
+ * @param info box.info() adapter
+ * @throws C++ exception on OOM, see info.h comments.
+ */
+static inline void
+info_table_end(struct info_handler *info)
+{
+	struct info_node node = {
+		.type = INFO_TABLE_END,
+		.key = NULL,
+		.value = {}
+	};
+	info->fn(&node, info->ctx);
+}
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */
+
+#endif /* INCLUDES_TARANTOOL_BOX_INFO_H */

--- a/src/box/lua/index.c
+++ b/src/box/lua/index.c
@@ -32,6 +32,8 @@
 #include "lua/utils.h"
 #include "box/box.h"
 #include "box/index.h"
+#include "box/info.h"
+#include "box/lua/info.h"
 #include "box/lua/tuple.h"
 #include "box/lua/misc.h" /* lbox_encode_tuple_on_gc() */
 
@@ -294,6 +296,26 @@ lbox_truncate(struct lua_State *L)
 
 /* }}} */
 
+/* {{{ Introspection */
+
+static int
+lbox_index_info(lua_State *L)
+{
+	if (lua_gettop(L) != 2 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2))
+		return luaL_error(L, "usage index.info(space_id, index_id)");
+
+	uint32_t space_id = lua_tointeger(L, 1);
+	uint32_t index_id = lua_tointeger(L, 2);
+
+	struct info_handler info;
+	luaT_info_handler_create(&info, L);
+	if (box_index_info(space_id, index_id, &info) != 0)
+		return luaT_error(L);
+	return 1;
+}
+
+/* }}} */
+
 void
 box_lua_index_init(struct lua_State *L)
 {
@@ -327,6 +349,7 @@ box_lua_index_init(struct lua_State *L)
 		{"iterator", lbox_index_iterator},
 		{"iterator_next", lbox_iterator_next},
 		{"truncate", lbox_truncate},
+		{"info", lbox_index_info},
 		{NULL, NULL}
 	};
 

--- a/src/box/lua/info.h
+++ b/src/box/lua/info.h
@@ -37,8 +37,13 @@ extern "C" {
 #endif /* defined(__cplusplus) */
 
 struct lua_State;
+struct info_handler;
+
 void
 box_lua_info_init(struct lua_State *L);
+
+void
+luaT_info_handler_create(struct info_handler *h, struct lua_State *L);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -924,6 +924,11 @@ function box.schema.space.bless(space)
         check_index_arg(index, 'delete')
         return internal.delete(index.space_id, index.id, keify(key));
     end
+
+    index_mt.info = function(index)
+        return internal.info(index.space_id, index.id);
+    end
+
     index_mt.drop = function(index)
         check_index_arg(index, 'drop')
         return box.schema.index.drop(index.space_id, index.id)

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -5314,39 +5314,36 @@ vy_info_append_metric(struct vy_env *env, struct info_handler *h)
 	info_table_end(h);
 }
 
-static void
-vy_info_append_indices(struct vy_env *env, struct info_handler *h)
+int
+vy_info(struct vy_env *env, struct info_handler *h)
 {
-	struct vy_index *i;
-	char buf[1024];
-
-	info_table_begin(h, "db");
-	rlist_foreach_entry(i, &env->indexes, link) {
-		info_table_begin(h, i->name);
-		info_append_u64(h, "range_size", i->index_def->opts.range_size);
-		info_append_u64(h, "page_size", i->index_def->opts.page_size);
-		info_append_u64(h, "memory_used", i->used);
-		info_append_u64(h, "size", i->size);
-		info_append_u64(h, "count", i->stmt_count);
-		info_append_u32(h, "page_count", i->page_count);
-		info_append_u32(h, "range_count", i->range_count);
-		info_append_u32(h, "run_count", i->run_count);
-		info_append_u32(h, "run_avg", i->run_count / i->range_count);
-		histogram_snprint(buf, sizeof(buf), i->run_hist);
-		info_append_str(h, "run_histogram", buf);
-		info_table_end(h);
-	}
-	info_table_end(h);
-}
-
-void
-vy_info_gather(struct vy_env *env, struct info_handler *h)
-{
-	vy_info_append_indices(env, h);
+	info_begin(h);
 	vy_info_append_global(env, h);
 	vy_info_append_memory(env, h);
 	vy_info_append_metric(env, h);
 	vy_info_append_performance(env, h);
+	info_end(h);
+	return 0;
+}
+
+int
+vy_index_info(struct vy_index *index, struct info_handler *h)
+{
+	char buf[1024];
+	info_begin(h);
+	info_append_u64(h, "range_size", index->index_def->opts.range_size);
+	info_append_u64(h, "page_size", index->index_def->opts.page_size);
+	info_append_u64(h, "memory_used", index->used);
+	info_append_u64(h, "size", index->size);
+	info_append_u64(h, "count", index->stmt_count);
+	info_append_u32(h, "page_count", index->page_count);
+	info_append_u32(h, "range_count", index->range_count);
+	info_append_u32(h, "run_count", index->run_count);
+	info_append_u32(h, "run_avg", index->run_count / index->range_count);
+	histogram_snprint(buf, sizeof(buf), index->run_hist);
+	info_append_str(h, "run_histogram", buf);
+	info_end(h);
+	return 0;
 }
 
 /** }}} Introspection */

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -5314,7 +5314,7 @@ vy_info_append_metric(struct vy_env *env, struct info_handler *h)
 	info_table_end(h);
 }
 
-int
+void
 vy_info(struct vy_env *env, struct info_handler *h)
 {
 	info_begin(h);
@@ -5323,10 +5323,9 @@ vy_info(struct vy_env *env, struct info_handler *h)
 	vy_info_append_metric(env, h);
 	vy_info_append_performance(env, h);
 	info_end(h);
-	return 0;
 }
 
-int
+void
 vy_index_info(struct vy_index *index, struct info_handler *h)
 {
 	char buf[1024];
@@ -5343,7 +5342,6 @@ vy_index_info(struct vy_index *index, struct info_handler *h)
 	histogram_snprint(buf, sizeof(buf), index->run_hist);
 	info_append_str(h, "run_histogram", buf);
 	info_end(h);
-	return 0;
 }
 
 /** }}} Introspection */

--- a/src/box/vinyl.h
+++ b/src/box/vinyl.h
@@ -93,31 +93,10 @@ vy_end_checkpoint(struct vy_env *env);
  * Introspection
  */
 
-enum vy_info_type {
-	VY_INFO_TABLE_BEGIN,
-	VY_INFO_TABLE_END,
-	VY_INFO_STRING,
-	VY_INFO_U32,
-	VY_INFO_U64,
-};
-
-struct vy_info_node {
-	enum vy_info_type type;
-	const char *key;
-	union {
-		const char *str;
-		uint32_t u32;
-		uint64_t u64;
-	} value;
-};
-
-struct vy_info_handler {
-	void (*fn)(struct vy_info_node *node, void *ctx);
-	void *ctx;
-};
+struct info_handler;
 
 void
-vy_info_gather(struct vy_env *env, struct vy_info_handler *h);
+vy_info_gather(struct vy_env *env, struct info_handler *h);
 
 /*
  * Transaction

--- a/src/box/vinyl.h
+++ b/src/box/vinyl.h
@@ -95,8 +95,23 @@ vy_end_checkpoint(struct vy_env *env);
 
 struct info_handler;
 
-void
-vy_info_gather(struct vy_env *env, struct info_handler *h);
+/*
+ * Engine introspection (box.info.vinyl())
+ *
+ * @param env environment
+ * @param handler info handler
+ */
+int
+vy_info(struct vy_env *env, struct info_handler *handler);
+
+/**
+ * Index introspection (index:info())
+ *
+ * @param index index
+ * @param handler info handler
+ */
+int
+vy_index_info(struct vy_index *index, struct info_handler *handler);
 
 /*
  * Transaction

--- a/src/box/vinyl.h
+++ b/src/box/vinyl.h
@@ -101,7 +101,7 @@ struct info_handler;
  * @param env environment
  * @param handler info handler
  */
-int
+void
 vy_info(struct vy_env *env, struct info_handler *handler);
 
 /**
@@ -110,7 +110,7 @@ vy_info(struct vy_env *env, struct info_handler *handler);
  * @param index index
  * @param handler info handler
  */
-int
+void
 vy_index_info(struct vy_index *index, struct info_handler *handler);
 
 /*

--- a/src/box/vinyl_index.cc
+++ b/src/box/vinyl_index.cc
@@ -208,6 +208,5 @@ VinylIndex::initIterator(struct iterator *ptr,
 void
 VinylIndex::info(struct info_handler *handler) const
 {
-	if (vy_index_info(db, handler) != 0)
-		diag_raise();
+	vy_index_info(db, handler);
 }

--- a/src/box/vinyl_index.cc
+++ b/src/box/vinyl_index.cc
@@ -204,3 +204,10 @@ VinylIndex::initIterator(struct iterator *ptr,
 	if (it->cursor == NULL)
 		diag_raise();
 }
+
+void
+VinylIndex::info(struct info_handler *handler) const
+{
+	if (vy_index_info(db, handler) != 0)
+		diag_raise();
+}

--- a/src/box/vinyl_index.h
+++ b/src/box/vinyl_index.h
@@ -67,6 +67,9 @@ public:
 	count(enum iterator_type type, const char *key, uint32_t part_count)
 		const override;
 
+	virtual void
+	info(struct info_handler *handler) const override;
+
 public:
 	struct vy_env *env;
 	struct vy_index *db;

--- a/test/vinyl/coalesce.result
+++ b/test/vinyl/coalesce.result
@@ -10,7 +10,7 @@ s = box.schema.space.create('test', {engine='vinyl'})
 _ = s:create_index('primary', {unique=true, parts={1, 'unsigned'}, page_size=256, range_size=2048, run_count_per_level=1, run_size_ratio=1000})
 ---
 ...
-function vyinfo() return box.info.vinyl().db[box.space.test.id..'/0'] end
+function vyinfo() return box.space.test.index.primary:info() end
 ---
 ...
 range_count = 4

--- a/test/vinyl/coalesce.test.lua
+++ b/test/vinyl/coalesce.test.lua
@@ -5,7 +5,7 @@ fiber = require('fiber')
 s = box.schema.space.create('test', {engine='vinyl'})
 _ = s:create_index('primary', {unique=true, parts={1, 'unsigned'}, page_size=256, range_size=2048, run_count_per_level=1, run_size_ratio=1000})
 
-function vyinfo() return box.info.vinyl().db[box.space.test.id..'/0'] end
+function vyinfo() return box.space.test.index.primary:info() end
 
 range_count = 4
 tuple_size = math.ceil(vyinfo().page_size / 4)

--- a/test/vinyl/compact.result
+++ b/test/vinyl/compact.result
@@ -10,7 +10,7 @@ space = box.schema.space.create("vinyl", { engine = 'vinyl' })
 _= space:create_index('primary', { parts = { 1, 'unsigned' }, run_count_per_level = 2 })
 ---
 ...
-function vyinfo() return box.info.vinyl().db[box.space.vinyl.id..'/0'] end
+function vyinfo() return box.space.vinyl.index.primary:info() end
 ---
 ...
 vyinfo().run_count == 0

--- a/test/vinyl/compact.test.lua
+++ b/test/vinyl/compact.test.lua
@@ -4,7 +4,7 @@ fiber = require('fiber')
 space = box.schema.space.create("vinyl", { engine = 'vinyl' })
 _= space:create_index('primary', { parts = { 1, 'unsigned' }, run_count_per_level = 2 })
 
-function vyinfo() return box.info.vinyl().db[box.space.vinyl.id..'/0'] end
+function vyinfo() return box.space.vinyl.index.primary:info() end
 
 vyinfo().run_count == 0
 

--- a/test/vinyl/ddl.result
+++ b/test/vinyl/ddl.result
@@ -113,7 +113,7 @@ box.snapshot()
 ---
 - ok
 ...
-while box.info.vinyl().db[space.id..'/0'].count ~= 0 do fiber.sleep(0.01) end
+while space.index.primary:info().count ~= 0 do fiber.sleep(0.01) end
 ---
 ...
 -- after a dump REPLACE + DELETE = nothing, so the space is empty now and
@@ -161,7 +161,7 @@ box.snapshot()
 ---
 - ok
 ...
-while box.info.vinyl().db[space.id..'/0'].run_count ~= 2 do fiber.sleep(0.01) end
+while space.index.primary:info().run_count ~= 2 do fiber.sleep(0.01) end
 ---
 ...
 -- must fail because vy_runs have data
@@ -179,7 +179,7 @@ box.snapshot()
 - ok
 ...
 -- Wait until the dump is finished.
-while box.info.vinyl().db[space.id..'/0'].count ~= 0 do fiber.sleep(0.01) end
+while space.index.primary:info().count ~= 0 do fiber.sleep(0.01) end
 ---
 ...
 index2 = space:create_index('secondary', { parts = {2, 'unsigned'} })
@@ -208,7 +208,7 @@ box.snapshot()
 ---
 - ok
 ...
-while box.info.vinyl().db[space.id..'/0'].run_count ~= 1 do fiber.sleep(0.01) end
+while space.index.primary:info().run_count ~= 1 do fiber.sleep(0.01) end
 ---
 ...
 box.space.test.index.primary:bsize() == 0

--- a/test/vinyl/ddl.test.lua
+++ b/test/vinyl/ddl.test.lua
@@ -43,7 +43,7 @@ space:delete({1})
 -- must fail because vy_mems have data
 index2 = space:create_index('secondary', { parts = {2, 'unsigned'} })
 box.snapshot()
-while box.info.vinyl().db[space.id..'/0'].count ~= 0 do fiber.sleep(0.01) end
+while space.index.primary:info().count ~= 0 do fiber.sleep(0.01) end
 
 -- after a dump REPLACE + DELETE = nothing, so the space is empty now and
 -- can be altered.
@@ -60,7 +60,7 @@ space:insert({1, 2})
 box.snapshot()
 space:delete({1})
 box.snapshot()
-while box.info.vinyl().db[space.id..'/0'].run_count ~= 2 do fiber.sleep(0.01) end
+while space.index.primary:info().run_count ~= 2 do fiber.sleep(0.01) end
 -- must fail because vy_runs have data
 index2 = space:create_index('secondary', { parts = {2, 'unsigned'} })
 
@@ -69,7 +69,7 @@ index2 = space:create_index('secondary', { parts = {2, 'unsigned'} })
 space:delete({1})
 box.snapshot()
 -- Wait until the dump is finished.
-while box.info.vinyl().db[space.id..'/0'].count ~= 0 do fiber.sleep(0.01) end
+while space.index.primary:info().count ~= 0 do fiber.sleep(0.01) end
 index2 = space:create_index('secondary', { parts = {2, 'unsigned'} })
 
 space:drop()
@@ -83,7 +83,7 @@ for i=1,10 do box.space.test:replace({i}) end
 box.space.test.index.primary:bsize() > 0
 
 box.snapshot()
-while box.info.vinyl().db[space.id..'/0'].run_count ~= 1 do fiber.sleep(0.01) end
+while space.index.primary:info().run_count ~= 1 do fiber.sleep(0.01) end
 
 box.space.test.index.primary:bsize() == 0
 

--- a/test/vinyl/errinj_gc.result
+++ b/test/vinyl/errinj_gc.result
@@ -26,7 +26,7 @@ _ = s:create_index('pk', {run_count_per_level=1})
 path = fio.pathjoin(box.cfg.vinyl_dir, tostring(s.id), tostring(s.index.pk.id))
 ---
 ...
-function run_count() return box.info.vinyl().db[s.id..'/'..s.index.pk.id].run_count end
+function run_count() return s.index.pk:info().run_count end
 ---
 ...
 function file_count() return #fio.glob(fio.pathjoin(path, '*')) end

--- a/test/vinyl/errinj_gc.test.lua
+++ b/test/vinyl/errinj_gc.test.lua
@@ -12,7 +12,7 @@ s = box.schema.space.create('test', {engine='vinyl'})
 _ = s:create_index('pk', {run_count_per_level=1})
 path = fio.pathjoin(box.cfg.vinyl_dir, tostring(s.id), tostring(s.index.pk.id))
 
-function run_count() return box.info.vinyl().db[s.id..'/'..s.index.pk.id].run_count end
+function run_count() return s.index.pk:info().run_count end
 function file_count() return #fio.glob(fio.pathjoin(path, '*')) end
 function snapshot() box.snapshot() box.internal.gc.run(box.info.cluster.signature) end
 

--- a/test/vinyl/gc.result
+++ b/test/vinyl/gc.result
@@ -13,7 +13,7 @@ _ = s:create_index('pk', {run_count_per_level=1})
 path = fio.pathjoin(box.cfg.vinyl_dir, tostring(s.id), tostring(s.index.pk.id))
 ---
 ...
-function run_count() return box.info.vinyl().db[s.id..'/'..s.index.pk.id].run_count end
+function run_count() return s.index.pk:info().run_count end
 ---
 ...
 function file_count() return #fio.glob(fio.pathjoin(path, '*')) end

--- a/test/vinyl/gc.test.lua
+++ b/test/vinyl/gc.test.lua
@@ -6,7 +6,7 @@ _ = s:create_index('pk', {run_count_per_level=1})
 
 path = fio.pathjoin(box.cfg.vinyl_dir, tostring(s.id), tostring(s.index.pk.id))
 
-function run_count() return box.info.vinyl().db[s.id..'/'..s.index.pk.id].run_count end
+function run_count() return s.index.pk:info().run_count end
 function file_count() return #fio.glob(fio.pathjoin(path, '*')) end
 function snapshot() box.snapshot() box.internal.gc.run(box.info.cluster.signature) end
 

--- a/test/vinyl/info.result
+++ b/test/vinyl/info.result
@@ -61,19 +61,7 @@ box.snapshot()
 ...
 box_info_sort(box.info.vinyl())
 ---
-- - db:
-    - 512/0:
-      - count: <count>
-      - memory_used: <used>
-      - page_count: <count>
-      - page_size: <size>
-      - range_count: <count>
-      - range_size: <size>
-      - run_avg: <avg>
-      - run_count: <count>
-      - run_histogram: <run_histogram>
-      - size: <size>
-  - memory:
+- - memory:
     - limit: 536870912
     - min_lsn: 9223372036854775807
     - ratio: 0%
@@ -153,20 +141,23 @@ test_run:cmd("clear filter")
 space:drop()
 ---
 ...
+info = {}
+---
+...
 test_run:cmd("setopt delimiter ';'")
 ---
 - true
 ...
 for i = 1, 16 do
-	c = box.schema.space.create('i'..i, { engine='vinyl' })
-	c:create_index('pk')
+    local space = box.schema.space.create('i'..i, { engine='vinyl' })
+    local pk = space:create_index('pk')
+    info[i] = box_info_sort(pk:info())
 end;
 ---
 ...
-box_info_sort(box.info.vinyl().db);
+info;
 ---
-- - 513/0:
-    - count: 0
+- - - count: 0
     - memory_used: 0
     - page_count: 0
     - page_size: 1024
@@ -176,8 +167,7 @@ box_info_sort(box.info.vinyl().db);
     - run_count: 0
     - run_histogram: '[0]:1'
     - size: 0
-  - 514/0:
-    - count: 0
+  - - count: 0
     - memory_used: 0
     - page_count: 0
     - page_size: 1024
@@ -187,8 +177,7 @@ box_info_sort(box.info.vinyl().db);
     - run_count: 0
     - run_histogram: '[0]:1'
     - size: 0
-  - 515/0:
-    - count: 0
+  - - count: 0
     - memory_used: 0
     - page_count: 0
     - page_size: 1024
@@ -198,8 +187,7 @@ box_info_sort(box.info.vinyl().db);
     - run_count: 0
     - run_histogram: '[0]:1'
     - size: 0
-  - 516/0:
-    - count: 0
+  - - count: 0
     - memory_used: 0
     - page_count: 0
     - page_size: 1024
@@ -209,8 +197,7 @@ box_info_sort(box.info.vinyl().db);
     - run_count: 0
     - run_histogram: '[0]:1'
     - size: 0
-  - 517/0:
-    - count: 0
+  - - count: 0
     - memory_used: 0
     - page_count: 0
     - page_size: 1024
@@ -220,8 +207,7 @@ box_info_sort(box.info.vinyl().db);
     - run_count: 0
     - run_histogram: '[0]:1'
     - size: 0
-  - 518/0:
-    - count: 0
+  - - count: 0
     - memory_used: 0
     - page_count: 0
     - page_size: 1024
@@ -231,8 +217,7 @@ box_info_sort(box.info.vinyl().db);
     - run_count: 0
     - run_histogram: '[0]:1'
     - size: 0
-  - 519/0:
-    - count: 0
+  - - count: 0
     - memory_used: 0
     - page_count: 0
     - page_size: 1024
@@ -242,8 +227,7 @@ box_info_sort(box.info.vinyl().db);
     - run_count: 0
     - run_histogram: '[0]:1'
     - size: 0
-  - 520/0:
-    - count: 0
+  - - count: 0
     - memory_used: 0
     - page_count: 0
     - page_size: 1024
@@ -253,8 +237,7 @@ box_info_sort(box.info.vinyl().db);
     - run_count: 0
     - run_histogram: '[0]:1'
     - size: 0
-  - 521/0:
-    - count: 0
+  - - count: 0
     - memory_used: 0
     - page_count: 0
     - page_size: 1024
@@ -264,8 +247,7 @@ box_info_sort(box.info.vinyl().db);
     - run_count: 0
     - run_histogram: '[0]:1'
     - size: 0
-  - 522/0:
-    - count: 0
+  - - count: 0
     - memory_used: 0
     - page_count: 0
     - page_size: 1024
@@ -275,8 +257,7 @@ box_info_sort(box.info.vinyl().db);
     - run_count: 0
     - run_histogram: '[0]:1'
     - size: 0
-  - 523/0:
-    - count: 0
+  - - count: 0
     - memory_used: 0
     - page_count: 0
     - page_size: 1024
@@ -286,8 +267,7 @@ box_info_sort(box.info.vinyl().db);
     - run_count: 0
     - run_histogram: '[0]:1'
     - size: 0
-  - 524/0:
-    - count: 0
+  - - count: 0
     - memory_used: 0
     - page_count: 0
     - page_size: 1024
@@ -297,8 +277,7 @@ box_info_sort(box.info.vinyl().db);
     - run_count: 0
     - run_histogram: '[0]:1'
     - size: 0
-  - 525/0:
-    - count: 0
+  - - count: 0
     - memory_used: 0
     - page_count: 0
     - page_size: 1024
@@ -308,8 +287,7 @@ box_info_sort(box.info.vinyl().db);
     - run_count: 0
     - run_histogram: '[0]:1'
     - size: 0
-  - 526/0:
-    - count: 0
+  - - count: 0
     - memory_used: 0
     - page_count: 0
     - page_size: 1024
@@ -319,8 +297,7 @@ box_info_sort(box.info.vinyl().db);
     - run_count: 0
     - run_histogram: '[0]:1'
     - size: 0
-  - 527/0:
-    - count: 0
+  - - count: 0
     - memory_used: 0
     - page_count: 0
     - page_size: 1024
@@ -330,8 +307,7 @@ box_info_sort(box.info.vinyl().db);
     - run_count: 0
     - run_histogram: '[0]:1'
     - size: 0
-  - 528/0:
-    - count: 0
+  - - count: 0
     - memory_used: 0
     - page_count: 0
     - page_size: 1024
@@ -350,6 +326,9 @@ end;
 test_run:cmd("setopt delimiter ''");
 ---
 - true
+...
+info = nil;
+---
 ...
 space = box.schema.space.create('test', { engine = 'vinyl' })
 ---

--- a/test/vinyl/info.test.lua
+++ b/test/vinyl/info.test.lua
@@ -28,16 +28,19 @@ test_run:cmd("clear filter")
 
 space:drop()
 
+info = {}
 test_run:cmd("setopt delimiter ';'")
 for i = 1, 16 do
-	c = box.schema.space.create('i'..i, { engine='vinyl' })
-	c:create_index('pk')
+    local space = box.schema.space.create('i'..i, { engine='vinyl' })
+    local pk = space:create_index('pk')
+    info[i] = box_info_sort(pk:info())
 end;
-box_info_sort(box.info.vinyl().db);
+info;
 for i = 1, 16 do
 	box.space['i'..i]:drop()
 end;
 test_run:cmd("setopt delimiter ''");
+info = nil;
 
 space = box.schema.space.create('test', { engine = 'vinyl' })
 index = space:create_index('primary')

--- a/test/vinyl/recover.result
+++ b/test/vinyl/recover.result
@@ -82,7 +82,7 @@ tmp = box.schema.space.create('tmp')
 _ = tmp:create_index('primary')
 ---
 ...
-_ = tmp:insert{0, box.info.vinyl().db[s.id .. '/0']}
+_ = tmp:insert{0, s.index.primary:info()}
 ---
 ...
 test_run:cmd('restart server default')
@@ -95,7 +95,7 @@ tmp = box.space.tmp
 vyinfo1 = tmp:select(0)[1][2]
 ---
 ...
-vyinfo2 = box.info.vinyl().db[s.id .. '/0']
+vyinfo2 = s.index.primary:info()
 ---
 ...
 vyinfo1.size == vyinfo2.size or {vyinfo1.size, vyinfo2.size}

--- a/test/vinyl/recover.test.lua
+++ b/test/vinyl/recover.test.lua
@@ -56,7 +56,7 @@ for i=5,6 do gen(i) end
 -- and the number of runs are the same before and after recovery.
 tmp = box.schema.space.create('tmp')
 _ = tmp:create_index('primary')
-_ = tmp:insert{0, box.info.vinyl().db[s.id .. '/0']}
+_ = tmp:insert{0, s.index.primary:info()}
 
 test_run:cmd('restart server default')
 
@@ -64,7 +64,7 @@ s = box.space.test
 tmp = box.space.tmp
 
 vyinfo1 = tmp:select(0)[1][2]
-vyinfo2 = box.info.vinyl().db[s.id .. '/0']
+vyinfo2 = s.index.primary:info()
 vyinfo1.size == vyinfo2.size or {vyinfo1.size, vyinfo2.size}
 vyinfo1.page_count == vyinfo2.page_count or {vyinfo1.page_count, vyinfo2.page_count}
 vyinfo1.run_count == vyinfo2.run_count or {vyinfo1.run_count, vyinfo2.run_count}

--- a/test/vinyl/split.result
+++ b/test/vinyl/split.result
@@ -10,7 +10,7 @@ space = box.schema.space.create("vinyl", { engine = 'vinyl' })
 _= space:create_index('primary', { parts = { 1, 'unsigned' }, run_count_per_level = 1 })
 ---
 ...
-function vyinfo() return box.info.vinyl().db[box.space.vinyl.id..'/0'] end
+function vyinfo() return space.index.primary:info() end
 ---
 ...
 range_size = vyinfo().range_size

--- a/test/vinyl/split.test.lua
+++ b/test/vinyl/split.test.lua
@@ -4,7 +4,7 @@ fiber = require('fiber')
 space = box.schema.space.create("vinyl", { engine = 'vinyl' })
 _= space:create_index('primary', { parts = { 1, 'unsigned' }, run_count_per_level = 1 })
 
-function vyinfo() return box.info.vinyl().db[box.space.vinyl.id..'/0'] end
+function vyinfo() return space.index.primary:info() end
 
 range_size = vyinfo().range_size
 tuple_size = vyinfo().page_size / 2

--- a/test/vinyl/update_optimize.result
+++ b/test/vinyl/update_optimize.result
@@ -24,11 +24,11 @@ test_run:cmd("setopt delimiter ';'")
 ---
 - true
 ...
-function wait_for_dump(index_id, old_count)
-	while box.info.vinyl().db[space.id..'/'..index_id].run_count == old_count do
+function wait_for_dump(index, old_count)
+	while index:info().run_count == old_count do
 		fiber.sleep(0)
 	end
-	return box.info.vinyl().db[space.id..'/'..index_id].run_count
+	return index:info().run_count
 end;
 ---
 ...
@@ -36,10 +36,10 @@ test_run:cmd("setopt delimiter ''");
 ---
 - true
 ...
-index_run_count = box.info.vinyl().db[space.id..'/0'].run_count
+index_run_count = index:info().run_count
 ---
 ...
-index2_run_count = box.info.vinyl().db[space.id..'/1'].run_count
+index2_run_count = index2:info().run_count
 ---
 ...
 old_stmt_count = box.info.vinyl().performance.dumped_statements
@@ -66,10 +66,10 @@ box.snapshot()
 - ok
 ...
 -- Wait for dump both indexes.
-index_run_count = wait_for_dump(0, index_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
 ---
 ...
-index2_run_count = wait_for_dump(1, index2_run_count)
+index2_run_count = wait_for_dump(index2, index2_run_count)
 ---
 ...
 new_stmt_count = box.info.vinyl().performance.dumped_statements
@@ -93,10 +93,10 @@ box.snapshot()
 ---
 - ok
 ...
-index_run_count = wait_for_dump(0, index_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
 ---
 ...
-index2_run_count = wait_for_dump(1, index2_run_count)
+index2_run_count = wait_for_dump(index2, index2_run_count)
 ---
 ...
 space:update({1}, {{'!', 4, 20}}) -- move range containing index field
@@ -107,10 +107,10 @@ box.snapshot()
 ---
 - ok
 ...
-index_run_count = wait_for_dump(0, index_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
 ---
 ...
-index2_run_count = wait_for_dump(1, index2_run_count)
+index2_run_count = wait_for_dump(index2, index2_run_count)
 ---
 ...
 space:update({1}, {{'#', 3, 1}}) -- same
@@ -121,10 +121,10 @@ box.snapshot()
 ---
 - ok
 ...
-index_run_count = wait_for_dump(0, index_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
 ---
 ...
-index2_run_count = wait_for_dump(1, index2_run_count)
+index2_run_count = wait_for_dump(index2, index2_run_count)
 ---
 ...
 new_stmt_count = box.info.vinyl().performance.dumped_statements
@@ -160,7 +160,7 @@ box.snapshot()
 ---
 - ok
 ...
-index_run_count = wait_for_dump(0, index_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
 ---
 ...
 -- Move range that doesn't contain indexed fields.
@@ -172,7 +172,7 @@ box.snapshot()
 ---
 - ok
 ...
-index_run_count = wait_for_dump(0, index_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
 ---
 ...
 space:update({2}, {{'#', 6, 1}}) -- same
@@ -183,7 +183,7 @@ box.snapshot()
 ---
 - ok
 ...
-index_run_count = wait_for_dump(0, index_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
 ---
 ...
 new_stmt_count = box.info.vinyl().performance.dumped_statements
@@ -230,13 +230,13 @@ box.snapshot()
 ---
 - ok
 ...
-index_run_count = box.info.vinyl().db[space.id..'/0'].run_count
+index_run_count = index:info().run_count
 ---
 ...
-index2_run_count = box.info.vinyl().db[space.id..'/1'].run_count
+index2_run_count = index2:info().run_count
 ---
 ...
-index3_run_count = box.info.vinyl().db[space.id..'/2'].run_count
+index3_run_count = index3:info().run_count
 ---
 ...
 old_stmt_count = box.info.vinyl().performance.dumped_statements
@@ -262,13 +262,13 @@ box.snapshot()
 ---
 - ok
 ...
-index_run_count = wait_for_dump(0, index_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
 ---
 ...
-index2_run_count = wait_for_dump(1, index2_run_count)
+index2_run_count = wait_for_dump(index2, index2_run_count)
 ---
 ...
-index3_run_count = wait_for_dump(2, index3_run_count)
+index3_run_count = wait_for_dump(index3, index3_run_count)
 ---
 ...
 new_stmt_count = box.info.vinyl().performance.dumped_statements
@@ -290,13 +290,13 @@ box.snapshot()
 ---
 - ok
 ...
-index_run_count = wait_for_dump(0, index_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
 ---
 ...
-index2_run_count = wait_for_dump(1, index2_run_count)
+index2_run_count = wait_for_dump(index2, index2_run_count)
 ---
 ...
-index3_run_count = wait_for_dump(2, index3_run_count)
+index3_run_count = wait_for_dump(index3, index3_run_count)
 ---
 ...
 index:update({2}, {{'!', 3, 20}}) -- move range containing all indexes
@@ -307,13 +307,13 @@ box.snapshot()
 ---
 - ok
 ...
-index_run_count = wait_for_dump(0, index_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
 ---
 ...
-index2_run_count = wait_for_dump(1, index2_run_count)
+index2_run_count = wait_for_dump(index2, index2_run_count)
 ---
 ...
-index3_run_count = wait_for_dump(2, index3_run_count)
+index3_run_count = wait_for_dump(index3, index3_run_count)
 ---
 ...
 index:update({2}, {{'=', 7, 100}, {'+', 5, 10}, {'#', 3, 1}}) -- change two cols but then move range with all indexed fields
@@ -324,13 +324,13 @@ box.snapshot()
 ---
 - ok
 ...
-index_run_count = wait_for_dump(0, index_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
 ---
 ...
-index2_run_count = wait_for_dump(1, index2_run_count)
+index2_run_count = wait_for_dump(index2, index2_run_count)
 ---
 ...
-index3_run_count = wait_for_dump(2, index3_run_count)
+index3_run_count = wait_for_dump(index3, index3_run_count)
 ---
 ...
 new_stmt_count = box.info.vinyl().performance.dumped_statements
@@ -373,10 +373,10 @@ box.snapshot()
 ---
 - ok
 ...
-index_run_count = wait_for_dump(0, index_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
 ---
 ...
-index3_run_count = wait_for_dump(2, index3_run_count)
+index3_run_count = wait_for_dump(index3, index3_run_count)
 ---
 ...
 new_stmt_count = box.info.vinyl().performance.dumped_statements
@@ -398,10 +398,10 @@ box.snapshot()
 ---
 - ok
 ...
-index_run_count = wait_for_dump(0, index_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
 ---
 ...
-index2_run_count = wait_for_dump(1, index2_run_count)
+index2_run_count = wait_for_dump(index3, index2_run_count)
 ---
 ...
 new_stmt_count = box.info.vinyl().performance.dumped_statements
@@ -423,7 +423,7 @@ box.snapshot()
 ---
 - ok
 ...
-index_run_count = wait_for_dump(0, index_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
 ---
 ...
 new_stmt_count = box.info.vinyl().performance.dumped_statements

--- a/test/vinyl/update_optimize.test.lua
+++ b/test/vinyl/update_optimize.test.lua
@@ -10,16 +10,16 @@ index = space:create_index('primary', { run_count_per_level = 20 })
 index2 = space:create_index('secondary', { parts = {5, 'unsigned'}, run_count_per_level = 20 })
 box.snapshot()
 test_run:cmd("setopt delimiter ';'")
-function wait_for_dump(index_id, old_count)
-	while box.info.vinyl().db[space.id..'/'..index_id].run_count == old_count do
+function wait_for_dump(index, old_count)
+	while index:info().run_count == old_count do
 		fiber.sleep(0)
 	end
-	return box.info.vinyl().db[space.id..'/'..index_id].run_count
+	return index:info().run_count
 end;
 test_run:cmd("setopt delimiter ''");
 
-index_run_count = box.info.vinyl().db[space.id..'/0'].run_count
-index2_run_count = box.info.vinyl().db[space.id..'/1'].run_count
+index_run_count = index:info().run_count
+index2_run_count = index2:info().run_count
 old_stmt_count = box.info.vinyl().performance.dumped_statements
 space:insert({1, 2, 3, 4, 5})
 space:insert({2, 3, 4, 5, 6})
@@ -27,8 +27,8 @@ space:insert({3, 4, 5, 6, 7})
 space:insert({4, 5, 6, 7, 8})
 box.snapshot()
 -- Wait for dump both indexes.
-index_run_count = wait_for_dump(0, index_run_count)
-index2_run_count = wait_for_dump(1, index2_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
+index2_run_count = wait_for_dump(index2, index2_run_count)
 new_stmt_count = box.info.vinyl().performance.dumped_statements
 new_stmt_count - old_stmt_count == 8
 old_stmt_count = new_stmt_count
@@ -39,16 +39,16 @@ space:update({1}, {{'=', 5, 10}}) -- change secondary index field
 -- statements in vy_write_iterator during dump.
 
 box.snapshot()
-index_run_count = wait_for_dump(0, index_run_count)
-index2_run_count = wait_for_dump(1, index2_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
+index2_run_count = wait_for_dump(index2, index2_run_count)
 space:update({1}, {{'!', 4, 20}}) -- move range containing index field
 box.snapshot()
-index_run_count = wait_for_dump(0, index_run_count)
-index2_run_count = wait_for_dump(1, index2_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
+index2_run_count = wait_for_dump(index2, index2_run_count)
 space:update({1}, {{'#', 3, 1}}) -- same
 box.snapshot()
-index_run_count = wait_for_dump(0, index_run_count)
-index2_run_count = wait_for_dump(1, index2_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
+index2_run_count = wait_for_dump(index2, index2_run_count)
 new_stmt_count = box.info.vinyl().performance.dumped_statements
 new_stmt_count - old_stmt_count == 9
 old_stmt_count = new_stmt_count
@@ -58,14 +58,14 @@ index2:select{}
 -- optimized updates
 space:update({2}, {{'=', 6, 10}}) -- change not indexed field
 box.snapshot()
-index_run_count = wait_for_dump(0, index_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
 -- Move range that doesn't contain indexed fields.
 space:update({2}, {{'!', 7, 20}})
 box.snapshot()
-index_run_count = wait_for_dump(0, index_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
 space:update({2}, {{'#', 6, 1}}) -- same
 box.snapshot()
-index_run_count = wait_for_dump(0, index_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
 new_stmt_count = box.info.vinyl().performance.dumped_statements
 new_stmt_count - old_stmt_count == 3
 old_stmt_count = new_stmt_count
@@ -80,18 +80,18 @@ index = space:create_index('primary', { parts = {2, 'unsigned'}, run_count_per_l
 index2 = space:create_index('secondary', { parts = {4, 'unsigned', 3, 'unsigned'}, run_count_per_level = 20 })
 index3 = space:create_index('third', { parts = {5, 'unsigned'}, run_count_per_level = 20 })
 box.snapshot()
-index_run_count = box.info.vinyl().db[space.id..'/0'].run_count
-index2_run_count = box.info.vinyl().db[space.id..'/1'].run_count
-index3_run_count = box.info.vinyl().db[space.id..'/2'].run_count
+index_run_count = index:info().run_count
+index2_run_count = index2:info().run_count
+index3_run_count = index3:info().run_count
 old_stmt_count = box.info.vinyl().performance.dumped_statements
 space:insert({1, 2, 3, 4, 5})
 space:insert({2, 3, 4, 5, 6})
 space:insert({3, 4, 5, 6, 7})
 space:insert({4, 5, 6, 7, 8})
 box.snapshot()
-index_run_count = wait_for_dump(0, index_run_count)
-index2_run_count = wait_for_dump(1, index2_run_count)
-index3_run_count = wait_for_dump(2, index3_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
+index2_run_count = wait_for_dump(index2, index2_run_count)
+index3_run_count = wait_for_dump(index3, index3_run_count)
 new_stmt_count = box.info.vinyl().performance.dumped_statements
 new_stmt_count - old_stmt_count == 12
 old_stmt_count = new_stmt_count
@@ -99,19 +99,19 @@ old_stmt_count = new_stmt_count
 -- not optimizes updates
 index:update({2}, {{'+', 1, 10}, {'+', 3, 10}, {'+', 4, 10}, {'+', 5, 10}}) -- change all fields
 box.snapshot()
-index_run_count = wait_for_dump(0, index_run_count)
-index2_run_count = wait_for_dump(1, index2_run_count)
-index3_run_count = wait_for_dump(2, index3_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
+index2_run_count = wait_for_dump(index2, index2_run_count)
+index3_run_count = wait_for_dump(index3, index3_run_count)
 index:update({2}, {{'!', 3, 20}}) -- move range containing all indexes
 box.snapshot()
-index_run_count = wait_for_dump(0, index_run_count)
-index2_run_count = wait_for_dump(1, index2_run_count)
-index3_run_count = wait_for_dump(2, index3_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
+index2_run_count = wait_for_dump(index2, index2_run_count)
+index3_run_count = wait_for_dump(index3, index3_run_count)
 index:update({2}, {{'=', 7, 100}, {'+', 5, 10}, {'#', 3, 1}}) -- change two cols but then move range with all indexed fields
 box.snapshot()
-index_run_count = wait_for_dump(0, index_run_count)
-index2_run_count = wait_for_dump(1, index2_run_count)
-index3_run_count = wait_for_dump(2, index3_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
+index2_run_count = wait_for_dump(index2, index2_run_count)
+index3_run_count = wait_for_dump(index3, index3_run_count)
 new_stmt_count = box.info.vinyl().performance.dumped_statements
 new_stmt_count - old_stmt_count == 15
 old_stmt_count = new_stmt_count
@@ -122,23 +122,23 @@ index3:select{}
 -- optimize one 'secondary' index update
 index:update({3}, {{'+', 1, 10}, {'-', 5, 2}, {'!', 6, 100}}) -- change only index 'third'
 box.snapshot()
-index_run_count = wait_for_dump(0, index_run_count)
-index3_run_count = wait_for_dump(2, index3_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
+index3_run_count = wait_for_dump(index3, index3_run_count)
 new_stmt_count = box.info.vinyl().performance.dumped_statements
 new_stmt_count - old_stmt_count == 3
 old_stmt_count = new_stmt_count
 -- optimize one 'third' index update
 index:update({3}, {{'=', 1, 20}, {'+', 3, 5}, {'=', 4, 30}, {'!', 6, 110}}) -- change only index 'secondary'
 box.snapshot()
-index_run_count = wait_for_dump(0, index_run_count)
-index2_run_count = wait_for_dump(1, index2_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
+index2_run_count = wait_for_dump(index3, index2_run_count)
 new_stmt_count = box.info.vinyl().performance.dumped_statements
 new_stmt_count - old_stmt_count == 3
 old_stmt_count = new_stmt_count
 -- optimize both indexes
 index:update({3}, {{'+', 1, 10}, {'#', 6, 1}}) -- don't change any indexed fields
 box.snapshot()
-index_run_count = wait_for_dump(0, index_run_count)
+index_run_count = wait_for_dump(index, index_run_count)
 new_stmt_count = box.info.vinyl().performance.dumped_statements
 new_stmt_count - old_stmt_count == 1
 old_stmt_count = new_stmt_count
@@ -147,4 +147,3 @@ index2:select{}
 index3:select{}
 
 space:drop()
-


### PR DESCRIPTION
Extract and refactor vy_info implementation from Vinyl in order to implement index:info() introspection.

```
tarantool> box.space.vinyl.index.primary:info()
---
- page_size: 8192
  size: 0
  run_avg: 0
  range_count: 1
  run_histogram: '[0]:1'
  page_count: 0
  run_count: 0
  memory_used: 3400
  count: 100
  range_size: 1073741824
...
```

Short history of previous reviews:

- [x] Comments to info.h headers by @kostja 
- [x] Replace `struct info_node` with virtual methods by @alyapunov 

See #1662