### PR TITLE
vinyl: add test that creates a run with several tuples for one key.

### DIFF
--- a/test/vinyl/iterator.result
+++ b/test/vinyl/iterator.result
@@ -1905,3 +1905,64 @@ box.commit()
 space:drop()
 ---
 ...
+--make runs with more than one record with every key
+s = box.schema.space.create('test', { engine = 'vinyl' })
+---
+...
+pk = s:create_index('primary', { parts = { 1, 'uint' } })
+---
+...
+for i=1,10 do s:upsert({i, 1}, {{'+', 2, 1}}) end
+---
+...
+itr = create_iterator(s, {}, {})
+---
+...
+iterator_next(itr)
+---
+- [1, 1]
+...
+for i=1,10 do s:upsert({i, 1}, {{'+', 2, 1}}) end
+---
+...
+iterator_next(itr)
+---
+- [2, 1]
+...
+box.snapshot() -- create last-level run
+---
+- ok
+...
+iterator_next(itr)
+---
+- [3, 1]
+...
+for i=1,10 do s:upsert({i, 1}, {{'+', 2, 1}}) end
+---
+...
+iterator_next(itr)
+---
+- [4, 1]
+...
+box.snapshot() -- create not-last-level run
+---
+- ok
+...
+iterator_next(itr)
+---
+- [5, 1]
+...
+for i=1,10 do s:upsert({i, 1}, {{'+', 2, 1}}) end
+---
+...
+iterator_next(itr)
+---
+- [6, 1]
+...
+s:select{1}
+---
+- - [1, 4]
+...
+s:drop()
+---
+...

--- a/test/vinyl/iterator.test.lua
+++ b/test/vinyl/iterator.test.lua
@@ -659,3 +659,24 @@ space:select({2}, {iterator = 'LE'})
 box.commit()
 
 space:drop()
+
+--make runs with more than one record with every key
+s = box.schema.space.create('test', { engine = 'vinyl' })
+pk = s:create_index('primary', { parts = { 1, 'uint' } })
+
+for i=1,10 do s:upsert({i, 1}, {{'+', 2, 1}}) end
+itr = create_iterator(s, {}, {})
+iterator_next(itr)
+for i=1,10 do s:upsert({i, 1}, {{'+', 2, 1}}) end
+iterator_next(itr)
+box.snapshot() -- create last-level run
+iterator_next(itr)
+for i=1,10 do s:upsert({i, 1}, {{'+', 2, 1}}) end
+iterator_next(itr)
+box.snapshot() -- create not-last-level run
+iterator_next(itr)
+for i=1,10 do s:upsert({i, 1}, {{'+', 2, 1}}) end
+iterator_next(itr)
+s:select{1}
+
+s:drop()


### PR DESCRIPTION
The test creates long-live read view and creates a pair of snapshots.
The test ensures that runs has unquashed (uncompacted) data that is
needed for an old transaction.