### PR TITLE
Add Tarantool version to XLOG header

### DIFF
--- a/src/box/xlog.cc
+++ b/src/box/xlog.cc
@@ -132,6 +132,7 @@ enum {
 #define INSTANCE_UUID_KEY "Instance"
 #define INSTANCE_UUID_KEY_V12 "Server"
 #define VCLOCK_KEY "VClock"
+#define VERSION_KEY "Version"
 
 static const char v13[] = "0.13";
 static const char v12[] = "0.12";
@@ -155,9 +156,13 @@ xlog_meta_format(const struct xlog_meta *meta, char *buf, int size)
 	if (vstr == NULL)
 		return -1;
 	char *instance_uuid = tt_uuid_str(&meta->instance_uuid);
-	int total = snprintf(buf, size, "%s\n%s\n" INSTANCE_UUID_KEY ": "
-		"%s\n" VCLOCK_KEY ": %s\n\n",
-		 meta->filetype, v13, instance_uuid, vstr);
+	int total = snprintf(buf, size,
+		"%s\n"
+		"%s\n"
+		VERSION_KEY ": %s\n"
+		INSTANCE_UUID_KEY ": %s\n"
+		VCLOCK_KEY ": %s\n\n",
+		meta->filetype, v13, PACKAGE_VERSION, instance_uuid, vstr);
 	assert(total > 0);
 	free(vstr);
 	return total;

--- a/test/xlog/header.result
+++ b/test/xlog/header.result
@@ -1,0 +1,114 @@
+test_run = require('test_run').new()
+---
+...
+test_run:cmd('restart server default with cleanup=1')
+fio = require('fio')
+---
+...
+test_run:cmd("setopt delimiter ';'")
+---
+- true
+...
+function dump_header(path)
+    local f = io.open(path)
+    local header = {}
+    while true do
+        local line = f:read()
+        if line == "" then break end
+        table.insert(header, line)
+    end
+    f:close()
+    return header
+end;
+---
+...
+test_run:cmd("setopt delimiter ''");
+---
+- true
+...
+test_run:cmd("push filter '"..box.info.server.uuid.."' to '<instance_uuid>'")
+---
+- true
+...
+test_run:cmd("push filter '".._TARANTOOL.."' to '<version>'")
+---
+- true
+...
+checkpoint_lsn = box.info.server.lsn
+---
+...
+-- SNAP files
+snap_name = string.format("%020d.snap", checkpoint_lsn)
+---
+...
+dump_header(fio.pathjoin(box.cfg.memtx_dir, snap_name))
+---
+- - SNAP
+  - '0.13'
+  - 'Version: <version>'
+  - 'Instance: <instance_uuid>'
+  - 'VClock: {}'
+...
+-- XLOG files
+box.space._schema:insert({"layout_test"})
+---
+- ['layout_test']
+...
+xlog_name = string.format("%020d.xlog", checkpoint_lsn)
+---
+...
+dump_header(fio.pathjoin(box.cfg.wal_dir, xlog_name))
+---
+- - XLOG
+  - '0.13'
+  - 'Version: <version>'
+  - 'Instance: <instance_uuid>'
+  - 'VClock: {}'
+...
+box.space._schema:delete({"layout_test"})
+---
+- ['layout_test']
+...
+box.snapshot()
+---
+- ok
+...
+checkpoint_lsn = box.info.server.lsn
+---
+...
+-- SNAP files
+snap_name = string.format("%020d.snap", checkpoint_lsn)
+---
+...
+dump_header(fio.pathjoin(box.cfg.memtx_dir, snap_name))
+---
+- - SNAP
+  - '0.13'
+  - 'Version: <version>'
+  - 'Instance: <instance_uuid>'
+  - 'VClock: {1: 2}'
+...
+-- XLOG files
+box.space._schema:insert({"layout_test"})
+---
+- ['layout_test']
+...
+xlog_name = string.format("%020d.xlog", checkpoint_lsn)
+---
+...
+dump_header(fio.pathjoin(box.cfg.wal_dir, xlog_name))
+---
+- - XLOG
+  - '0.13'
+  - 'Version: <version>'
+  - 'Instance: <instance_uuid>'
+  - 'VClock: {1: 2}'
+...
+box.space._schema:delete({"layout_test"})
+---
+- ['layout_test']
+...
+test_run:cmd("clear filter")
+---
+- true
+...

--- a/test/xlog/header.test.lua
+++ b/test/xlog/header.test.lua
@@ -1,0 +1,47 @@
+test_run = require('test_run').new()
+test_run:cmd('restart server default with cleanup=1')
+
+fio = require('fio')
+
+test_run:cmd("setopt delimiter ';'")
+function dump_header(path)
+    local f = io.open(path)
+    local header = {}
+    while true do
+        local line = f:read()
+        if line == "" then break end
+        table.insert(header, line)
+    end
+    f:close()
+    return header
+end;
+test_run:cmd("setopt delimiter ''");
+test_run:cmd("push filter '"..box.info.server.uuid.."' to '<instance_uuid>'")
+test_run:cmd("push filter '".._TARANTOOL.."' to '<version>'")
+
+checkpoint_lsn = box.info.server.lsn
+
+-- SNAP files
+snap_name = string.format("%020d.snap", checkpoint_lsn)
+dump_header(fio.pathjoin(box.cfg.memtx_dir, snap_name))
+
+-- XLOG files
+box.space._schema:insert({"layout_test"})
+xlog_name = string.format("%020d.xlog", checkpoint_lsn)
+dump_header(fio.pathjoin(box.cfg.wal_dir, xlog_name))
+box.space._schema:delete({"layout_test"})
+
+box.snapshot()
+checkpoint_lsn = box.info.server.lsn
+
+-- SNAP files
+snap_name = string.format("%020d.snap", checkpoint_lsn)
+dump_header(fio.pathjoin(box.cfg.memtx_dir, snap_name))
+
+-- XLOG files
+box.space._schema:insert({"layout_test"})
+xlog_name = string.format("%020d.xlog", checkpoint_lsn)
+dump_header(fio.pathjoin(box.cfg.wal_dir, xlog_name))
+box.space._schema:delete({"layout_test"})
+
+test_run:cmd("clear filter")


### PR DESCRIPTION
* Add `Version: 1.7.x` to XLOG header to use in the future versions.
* Add the test cases for XLOG header.

See #2100 and #2297