### PR TITLE
Abort snapshot if wal in rollback state

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -1742,7 +1742,10 @@ box_snapshot()
 		goto end;
 
 	struct vclock vclock;
-	wal_checkpoint(&vclock, true);
+	if ((rc = wal_checkpoint(&vclock, true))) {
+		tnt_error(ClientError, ER_SNAPSHOT_ROLLBACK);
+		goto end;
+	}
 	rc = engine_commit_checkpoint(&vclock);
 end:
 	if (rc)

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -183,6 +183,7 @@ struct errcode_record {
 	/*128 */_(ER_LOCAL_INSTANCE_ID_IS_READ_ONLY, "The local instance id %u is read-only") \
 	/*129 */_(ER_BACKUP_IN_PROGRESS,	"Backup is already in progress") \
 	/*130 */_(ER_READ_VIEW_ABORTED,         "The read view is aborted") \
+	/*131 */_(ER_SNAPSHOT_ROLLBACK,		"Can't start snapshot while rollback")
 
 /*
  * !IMPORTANT! Please follow instructions at start of the file

--- a/src/box/wal.h
+++ b/src/box/wal.h
@@ -93,7 +93,7 @@ extern "C" {
  * @param[out] vclock WAL vclock
  *
  */
-void
+int
 wal_checkpoint(struct vclock *vclock, bool rotate);
 
 /**

--- a/test/engine/snapshot.result
+++ b/test/engine/snapshot.result
@@ -238,3 +238,58 @@ box.space.test.index.secondary:select{}
 box.space.test:drop()
 ---
 ...
+engine = test_run:get_cfg('engine')
+---
+...
+space = box.schema.space.create('test', { engine = engine })
+---
+...
+index1 = space:create_index('primary', { parts = {1, 'unsigned'} } )
+---
+...
+fiber = require'fiber'
+---
+...
+errinj = box.error.injection
+---
+...
+ch = fiber.channel(1)
+---
+...
+test_run:cmd('setopt delimiter ";"')
+---
+- true
+...
+function test()
+  errinj.set('ERRINJ_WAL_WRITE_DISK', true)
+  pcall(box.space.test.replace, box.space.test, {1, 1})
+  errinj.set('ERRINJ_WAL_WRITE_DISK', false)
+  ch:put(true)
+end ;
+---
+...
+test_run:cmd('setopt delimiter ""');
+---
+- true
+...
+-- should be on one line
+f = fiber.create(test) box.snapshot()
+---
+- error: Can't start snapshot while rollback
+...
+ch:get()
+---
+- true
+...
+box.space.test:select()
+---
+- []
+...
+test_run:cmd('restart server default')
+box.space.test:select()
+---
+- []
+...
+box.space.test:drop()
+---
+...


### PR DESCRIPTION
If wal is in rollback state snapshot should be aborted. In other case
snapshot will write dirty datas.