### PR TITLE
net.box: remove varargs from call() and eval()

### DIFF
--- a/test/box/access_bin.result
+++ b/test/box/access_bin.result
@@ -20,10 +20,10 @@ remote = require('net.box')
 c = remote.connect(box.cfg.listen)
 ---
 ...
-c:call("dostring", "session.su('admin')")
+c:eval("session.su('admin')")
 ---
 ...
-c:call("dostring", "return session.user()")
+c:eval("return session.user()")
 ---
 - admin
 ...
@@ -201,7 +201,7 @@ box.schema.user.passwd('Gx5!')
 c = require('net.box').new('admin:Gx5!@'..box.cfg.listen)
 ---
 ...
-c:call('dostring', 'return 2 + 2')
+c:call('dostring', { 'return 2 + 2' })
 ---
 - 4
 ...

--- a/test/box/access_bin.test.lua
+++ b/test/box/access_bin.test.lua
@@ -8,8 +8,8 @@ box.schema.user.grant('guest','read,write,execute','universe')
 session = box.session
 remote = require('net.box')
 c = remote.connect(box.cfg.listen)
-c:call("dostring", "session.su('admin')")
-c:call("dostring", "return session.user()")
+c:eval("session.su('admin')")
+c:eval("return session.user()")
 c:close()
 box.schema.user.revoke('guest', 'read,write,execute', 'universe')
 
@@ -77,7 +77,7 @@ u = box.space._user:get{1}
 box.session.su('admin')
 box.schema.user.passwd('Gx5!')
 c = require('net.box').new('admin:Gx5!@'..box.cfg.listen)
-c:call('dostring', 'return 2 + 2')
+c:call('dostring', { 'return 2 + 2' })
 c:close()
 box.space._user:replace(u)
 --

--- a/test/box/function1.result
+++ b/test/box/function1.result
@@ -45,11 +45,11 @@ c:call('function1.args')
 ---
 - error: invalid argument count
 ...
-c:call('function1.args', "xx")
+c:call('function1.args', { "xx" })
 ---
 - error: first tuple field must be uint
 ...
-c:call('function1.args', 15)
+c:call('function1.args', { 15 })
 ---
 - [[15, 'hello']]
 ...
@@ -70,7 +70,7 @@ box.space.test:select{}
 ---
 - []
 ...
-c:call('function1.multi_inc', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+c:call('function1.multi_inc', { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
 ---
 - []
 ...
@@ -87,7 +87,7 @@ box.space.test:select{}
   - [9, 0]
   - [10, 0]
 ...
-c:call('function1.multi_inc', 2, 4, 6, 8, 10)
+c:call('function1.multi_inc', { 2, 4, 6, 8, 10 })
 ---
 - []
 ...
@@ -104,7 +104,7 @@ box.space.test:select{}
   - [9, 0]
   - [10, 1]
 ...
-c:call('function1.multi_inc', 0, 2, 4)
+c:call('function1.multi_inc', { 0, 2, 4 })
 ---
 - []
 ...

--- a/test/box/function1.test.lua
+++ b/test/box/function1.test.lua
@@ -18,8 +18,8 @@ box.schema.func.drop("function1")
 box.schema.func.create('function1.args', {language = "C"})
 box.schema.user.grant('guest', 'execute', 'function', 'function1.args')
 c:call('function1.args')
-c:call('function1.args', "xx")
-c:call('function1.args', 15)
+c:call('function1.args', { "xx" })
+c:call('function1.args', { 15 })
 box.schema.func.drop("function1.args")
 
 box.schema.func.create('function1.multi_inc', {language = "C"})
@@ -27,11 +27,11 @@ box.schema.user.grant('guest', 'execute', 'function', 'function1.multi_inc')
 
 c:call('function1.multi_inc')
 box.space.test:select{}
-c:call('function1.multi_inc', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+c:call('function1.multi_inc', { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
 box.space.test:select{}
-c:call('function1.multi_inc', 2, 4, 6, 8, 10)
+c:call('function1.multi_inc', { 2, 4, 6, 8, 10 })
 box.space.test:select{}
-c:call('function1.multi_inc', 0, 2, 4)
+c:call('function1.multi_inc', { 0, 2, 4 })
 box.space.test:select{}
 
 box.schema.func.drop("function1.multi_inc")

--- a/test/box/net.box.result
+++ b/test/box/net.box.result
@@ -77,7 +77,7 @@ cn:call('unexists_procedure')
 function test_foo(a,b,c) return { {{ [a] = 1 }}, {{ [b] = 2 }}, c } end
 ---
 ...
-cn:call('test_foo', 'a', 'b', 'c')
+cn:call('test_foo', {'a', 'b', 'c'})
 ---
 - error: Execute access is denied for user 'guest' to function 'test_foo'
 ...
@@ -98,11 +98,11 @@ cn:call('unexists_procedure')
 ---
 - error: Execute access is denied for user 'guest' to function 'unexists_procedure'
 ...
-cn:call('test_foo', 'a', 'b', 'c')
+cn:call('test_foo', {'a', 'b', 'c'})
 ---
 - error: Execute access is denied for user 'guest' to function 'test_foo'
 ...
-cn:call(nil, 'a', 'b', 'c')
+cn:call(nil, {'a', 'b', 'c'})
 ---
 - error: Execute access is denied for user 'guest' to function 'nil'
 ...
@@ -116,7 +116,7 @@ cn:eval('return 1, 2, 3')
 - 2
 - 3
 ...
-cn:eval('return ...', 1, 2, 3)
+cn:eval('return ...', {1, 2, 3})
 ---
 - 1
 - 2
@@ -562,18 +562,18 @@ cn:call('pause')
 ---
 - error: Peer closed
 ...
-cn:call('test_foo', 'a', 'b', 'c')
+cn:call('test_foo', {'a', 'b', 'c'})
 ---
 - [[{'a': 1}], [{'b': 2}], 'c']
 ...
 -- call
-remote.self:call('test_foo', 'a', 'b', 'c')
+remote.self:call('test_foo', {'a', 'b', 'c'})
 ---
 - - - a: 1
   - - b: 2
   - c
 ...
-cn:call('test_foo', 'a', 'b', 'c')
+cn:call('test_foo', {'a', 'b', 'c'})
 ---
 - [[{'a': 1}], [{'b': 2}], 'c']
 ...
@@ -619,15 +619,15 @@ X.X = X
 function X.fn(x,y) return y or x end
 ---
 ...
-cn:call('X.fn', u)
+cn:call('X.fn', {u})
 ---
 - 84F7BCFA-079C-46CC-98B4-F0C821BE833E
 ...
-cn:call('X.X.X.X.X.X.X.fn', u)
+cn:call('X.X.X.X.X.X.X.fn', {u})
 ---
 - 84F7BCFA-079C-46CC-98B4-F0C821BE833E
 ...
-cn:call('X.X.X.X:fn', u)
+cn:call('X.X.X.X:fn', {u})
 ---
 - 84F7BCFA-079C-46CC-98B4-F0C821BE833E
 ...
@@ -956,19 +956,39 @@ remote_space:get(2)
 remote_space = nil
 ---
 ...
+cn:call('ret_after', {0.01}, { timeout = 1.00 })
+---
+- [[0.01]]
+...
+cn:call('ret_after', {1.00}, { timeout = 1e-9 })
+---
+- error: Timeout exceeded
+...
+cn:eval('return ret_after(...)', {0.01}, { timeout = 1.00 })
+---
+- [[0.01]]
+...
+cn:eval('return ret_after(...)', {1.00}, { timeout = 1e-9 })
+---
+- error: Timeout exceeded
+...
+--
+-- :timeout()
+-- @deprecated since 1.7.4
+--
 cn:timeout(1).space.net_box_test_space.index.primary:select{234}
 ---
 - - [234, 1, 2, 3]
 ...
-cn:call('ret_after', .01)
+cn:call('ret_after', {.01})
 ---
 - [[0.01]]
 ...
-cn:timeout(1):call('ret_after', .01)
+cn:timeout(1):call('ret_after', {.01})
 ---
 - [[0.01]]
 ...
-cn:timeout(.01):call('ret_after', 1)
+cn:timeout(.01):call('ret_after', {1})
 ---
 - error: Timeout exceeded
 ...
@@ -1055,7 +1075,7 @@ remote.self:eval('return true')
 ...
 remote.self.eval('return true')
 ---
-- error: 'usage: remote:eval(expr, ...)'
+- error: 'Use remote:eval(...) instead of remote.eval(...):'
 ...
 -- uri as the first argument
 uri = string.format('%s:%s@%s:%s', 'netbox', 'test', LISTEN.host, LISTEN.service)
@@ -1115,7 +1135,7 @@ test_run:cmd("setopt delimiter ';'")
 function gh594()
     local cn = remote.connect(box.cfg.listen)
     local ping = fiber.create(function() cn:ping() end)
-    cn:call('dostring', 'return 2 + 2')
+    cn:call('dostring', {'return 2 + 2'})
     cn:close()
 end;
 ---
@@ -1303,15 +1323,30 @@ box.space.test:drop()
 ---
 ...
 -- CALL vs CALL_16 in connect options
-function scalar42() return 42 end
+function echo(...) return ... end
 ---
 ...
 c = net.connect(box.cfg.listen)
 ---
 ...
-c:call('scalar42')
+c:call('echo', {42})
 ---
 - 42
+...
+c:eval('return echo(...)', {42})
+---
+- 42
+...
+-- invalid arguments
+c:call('echo', 42)
+---
+- error: 'builtin/box/net_box.lua..."]:<line>: Use remote:call(func_name, {arg1, arg2, ...},
+    opts) instead of remote:call(func_name, arg1, arg2, ...)'
+...
+c:eval('return echo(...)', 42)
+---
+- error: 'builtin/box/net_box.lua..."]:<line>: Use remote:eval(expression, {arg1, arg2, ...},
+    opts) instead of remote:eval(expression, arg1, arg2, ...)'
 ...
 c:close()
 ---
@@ -1319,9 +1354,13 @@ c:close()
 c = net.connect(box.cfg.listen, {call_16 = true})
 ---
 ...
-c:call('scalar42')
+c:call('echo', 42)
 ---
 - - [42]
+...
+c:eval('return echo(...)', 42)
+---
+- 42
 ...
 c:close()
 ---
@@ -1456,6 +1495,74 @@ len
 result
 ---
 - {48: [[1, 'hello'], [2], [3], [4]]}
+...
+-- call
+c:call("echo", {1, 2, 3}, {buffer = ibuf})
+---
+- 10
+...
+ibuf.rpos, result = msgpack.ibuf_decode(ibuf.rpos)
+---
+...
+result
+---
+- {48: [1, 2, 3]}
+...
+c:call("echo", {}, {buffer = ibuf})
+---
+- 7
+...
+ibuf.rpos, result = msgpack.ibuf_decode(ibuf.rpos)
+---
+...
+result
+---
+- {48: []}
+...
+c:call("echo", nil, {buffer = ibuf})
+---
+- 7
+...
+ibuf.rpos, result = msgpack.ibuf_decode(ibuf.rpos)
+---
+...
+result
+---
+- {48: []}
+...
+-- eval
+c:eval("echo(...)", {1, 2, 3}, {buffer = ibuf})
+---
+- 7
+...
+ibuf.rpos, result = msgpack.ibuf_decode(ibuf.rpos)
+---
+...
+result
+---
+- {48: []}
+...
+c:eval("echo(...)", {}, {buffer = ibuf})
+---
+- 7
+...
+ibuf.rpos, result = msgpack.ibuf_decode(ibuf.rpos)
+---
+...
+result
+---
+- {48: []}
+...
+c:eval("echo(...)", nil, {buffer = ibuf})
+---
+- 7
+...
+ibuf.rpos, result = msgpack.ibuf_decode(ibuf.rpos)
+---
+...
+result
+---
+- {48: []}
 ...
 -- unsupported methods
 c.space.test:get({1}, { buffer = ibuf})

--- a/test/replication/hot_standby.result
+++ b/test/replication/hot_standby.result
@@ -145,7 +145,7 @@ REPLICA ~= nil
 a = (require 'net.box').connect(REPLICA.host, REPLICA.service)
 ---
 ...
-a:call('_set_pri_lsn', box.info.id, box.info.lsn)
+a:call('_set_pri_lsn', {box.info.id, box.info.lsn})
 ---
 ...
 a:close()
@@ -228,7 +228,7 @@ HOT_STANDBY ~= nil
 a = (require 'net.box').connect(HOT_STANDBY.host, HOT_STANDBY.service)
 ---
 ...
-a:call('_set_pri_lsn', box.info.id, box.info.lsn)
+a:call('_set_pri_lsn', {box.info.id, box.info.lsn})
 ---
 ...
 a:close()

--- a/test/replication/hot_standby.test.lua
+++ b/test/replication/hot_standby.test.lua
@@ -77,7 +77,7 @@ test_run:cmd("set variable replica_port to 'replica.listen'")
 REPLICA = require('uri').parse(tostring(replica_port))
 REPLICA ~= nil
 a = (require 'net.box').connect(REPLICA.host, REPLICA.service)
-a:call('_set_pri_lsn', box.info.id, box.info.lsn)
+a:call('_set_pri_lsn', {box.info.id, box.info.lsn})
 a:close()
 
 _insert(1, 10)
@@ -98,7 +98,7 @@ test_run:cmd("set variable hot_standby_port to 'hot_standby.master'")
 HOT_STANDBY = require('uri').parse(tostring(hot_standby_port))
 HOT_STANDBY ~= nil
 a = (require 'net.box').connect(HOT_STANDBY.host, HOT_STANDBY.service)
-a:call('_set_pri_lsn', box.info.id, box.info.lsn)
+a:call('_set_pri_lsn', {box.info.id, box.info.lsn})
 a:close()
 
 test_run:cmd("switch hot_standby")


### PR DESCRIPTION
Change conn:call() and conn:eval() API to accept Lua table instead of
varargs for function/expression arguments:

    conn:call(func_name, arg1, arg2, ...)
      =>
    conn:call(func_name, {arg1, arg2, ...}, opts)

    conn:eval(expr, arg1, arg2, ...)
      =>
    conn:eval(expr, {arg1, arg2, ...}, opts)

This breaking change is needed to extend call() and eval() API with
per-requests options, like `timeout` and `buffer` (see #2195):

    c:call("echo", {1, 2, 3}, {timeout = 0.2})

    c:call("echo", {1, 2, 3}, {buffer = ibuf})
    ibuf.rpos, result = msgpack.ibuf_decode(ibuf.rpos)
    result

Tarantool 1.6.x behaviour can be turned on by `call_16` per-connection option:

    c = net.connect(box.cfg.listen, {call_16 = true})
    c:call('echo', 1, 2, 3)

This is a breaking change for 1.7.x.

Needed for #2285
Closes #2195