### PR TITLE
Explicitly include <ctype.h> in src/lua/init.c

### DIFF
--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -55,6 +55,7 @@
 #include "lua/fio.h"
 #include <small/ibuf.h>
 
+#include <ctype.h>
 #include <readline/readline.h>
 #include <readline/history.h>
 


### PR DESCRIPTION
	* src/lua/init.c: Explicitly include <ctype.h>.
	`isspace` is used in source. Normally <ctype.h> is included
	through <readline/readline.h>, nut native `Readline` on OSX doesn't
	include <ctype.h>.