### PR TITLE
Export luaT_call, luaT_cpcall, luaT_state

### DIFF
--- a/extra/exports
+++ b/extra/exports
@@ -114,7 +114,7 @@ luaT_istuple
 luaT_error
 luaT_call
 luaT_cpcall
-tarantool_L
+luaT_state
 box_txn
 box_txn_begin
 box_txn_commit

--- a/extra/exports
+++ b/extra/exports
@@ -112,6 +112,9 @@ luaL_toint64
 luaT_pushtuple
 luaT_istuple
 luaT_error
+luaT_call
+luaT_cpcall
+tarantool_L
 box_txn
 box_txn_begin
 box_txn_commit

--- a/src/lua/utils.c
+++ b/src/lua/utils.c
@@ -964,6 +964,12 @@ luaT_cpcall(lua_State *L, lua_CFunction func, void *ud)
 	return 0;
 }
 
+lua_State *
+luaT_state(void)
+{
+  return tarantool_L;
+}
+
 int
 tarantool_lua_utils_init(struct lua_State *L)
 {

--- a/src/lua/utils.h
+++ b/src/lua/utils.h
@@ -451,6 +451,12 @@ luaT_call(lua_State *L, int nargs, int nreturns);
 LUA_API int
 luaT_cpcall(lua_State *L, lua_CFunction func, void *ud);
 
+/*
+ * Get lua global state (tarantool_L)
+ */
+LUA_API lua_State *
+luaT_state(void);
+
 /** \endcond public */
 
 void

--- a/test/app-tap/module_api.c
+++ b/test/app-tap/module_api.c
@@ -417,6 +417,15 @@ test_cpcall(lua_State *L)
   return 1;
 }
 
+static int
+test_state(lua_State *L)
+{
+  lua_State *tarantool_L = luaT_state();
+  assert(lua_newthread(tarantool_L) != 0);
+  lua_pushboolean(L, true);
+  return 1;
+}
+
 LUA_API int
 luaopen_module_api(lua_State *L)
 {
@@ -443,6 +452,7 @@ luaopen_module_api(lua_State *L)
 		{"check_error", check_error},
 		{"test_call", test_call},
 		{"test_cpcall", test_cpcall},
+		{"test_state", test_state},
 		{NULL, NULL}
 	};
 	luaL_register(L, "module_api", lib);

--- a/test/app-tap/module_api.c
+++ b/test/app-tap/module_api.c
@@ -394,6 +394,29 @@ check_error(lua_State *L)
 	return 1;
 }
 
+static int
+test_call(lua_State *L)
+{
+  assert(luaL_loadbuffer(L, "", 0, "=eval") == 0);
+  assert(luaT_call(L, 0, LUA_MULTRET) == 0);
+  lua_pushboolean(L, true);
+  return 1;
+}
+
+static int
+cpcall_handler(lua_State *L)
+{
+  return 0;
+}
+
+static int
+test_cpcall(lua_State *L)
+{
+  assert(luaT_cpcall(L, cpcall_handler, 0) == 0);
+  lua_pushboolean(L, true);
+  return 1;
+}
+
 LUA_API int
 luaopen_module_api(lua_State *L)
 {
@@ -418,6 +441,8 @@ luaopen_module_api(lua_State *L)
 		{"test_key_def_api", test_key_def_api},
 		{"test_key_def_api2", test_key_def_api2},
 		{"check_error", check_error},
+		{"test_call", test_call},
+		{"test_cpcall", test_cpcall},
 		{NULL, NULL}
 	};
 	luaL_register(L, "module_api", lib);

--- a/test/app-tap/module_api.result
+++ b/test/app-tap/module_api.result
@@ -1,6 +1,6 @@
 TAP version 13
 # module_api
-1..21
+1..22
 ok - module is loaded
 ok - test_touint64 is ok
 ok - test_checkint64 is ok
@@ -9,6 +9,7 @@ ok - test_pushuint64 is ok
 ok - test_fiber is ok
 ok - test_cord is ok
 ok - test_key_def_api2 is ok
+ok - test_state is ok
 ok - test_coio_getaddrinfo is ok
 ok - test_pushint64 is ok
 ok - test_cpcall is ok

--- a/test/app-tap/module_api.result
+++ b/test/app-tap/module_api.result
@@ -1,6 +1,6 @@
 TAP version 13
 # module_api
-1..19
+1..21
 ok - module is loaded
 ok - test_touint64 is ok
 ok - test_checkint64 is ok
@@ -11,7 +11,9 @@ ok - test_cord is ok
 ok - test_key_def_api2 is ok
 ok - test_coio_getaddrinfo is ok
 ok - test_pushint64 is ok
+ok - test_cpcall is ok
 ok - test_coio_call is ok
+ok - test_call is ok
 ok - test_checkuint64 is ok
 ok - test_key_def_api is ok
 ok - test_clock is ok

--- a/test/app-tap/module_api.test.lua
+++ b/test/app-tap/module_api.test.lua
@@ -33,7 +33,7 @@ local function test_pushcdata(test, module)
 end
 
 local test = require('tap').test("module_api", function(test)
-    test:plan(21)
+    test:plan(22)
     local status, module = pcall(require, 'module_api')
     test:ok(status, "module is loaded")
     if not status then

--- a/test/app-tap/module_api.test.lua
+++ b/test/app-tap/module_api.test.lua
@@ -33,7 +33,7 @@ local function test_pushcdata(test, module)
 end
 
 local test = require('tap').test("module_api", function(test)
-    test:plan(19)
+    test:plan(21)
     local status, module = pcall(require, 'module_api')
     test:ok(status, "module is loaded")
     if not status then


### PR DESCRIPTION
Required to implement eval in [TarantoolModule/Lua.swift](https://github.com/tris-foundation/tarantool/blob/0757f094f7ebdc8ab356e2fcd87164072d709612/Sources/TarantoolModule/Lua.swift#L52)