### PR TITLE
Fix out of source modules update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,8 @@ if (EXISTS "${CMAKE_SOURCE_DIR}/.git" AND GIT)
         file(WRITE ${VERSION_FILE} "${TARANTOOL_VERSION}\n")
 
         message(STATUS "Updating submodules")
-        execute_process(COMMAND ${GIT} submodule update --init --recursive)
+        execute_process(COMMAND ${GIT} submodule update --init --recursive
+                        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
     endif()
 endif()
 


### PR DESCRIPTION
Set working directory to root of source tree while doing
`git modules update`.