### PR TITLE
Tweak extra/dist/example.lua

### DIFF
--- a/extra/dist/example.lua
+++ b/extra/dist/example.lua
@@ -184,7 +184,6 @@ box.once('example-1.0', bootstrap)
 -- Docs: https://github.com/tarantool/queue/blob/master/README.md
 -- Example:
 --  local queue = require('queue')
---  queue.start()
 --  queue.create_tube(tube_name, 'fifottl')
 
 -------------------


### PR DESCRIPTION
According to @bigbes  `queue.start()` is not needed anymore.