### PR TITLE
c-api: add log_error

### DIFF
--- a/extra/exports
+++ b/extra/exports
@@ -83,6 +83,7 @@ tnt_HMAC_CTX_free
 # Module API
 
 _say
+log_error
 fiber_attr_new
 fiber_attr_delete
 fiber_attr_setstacksize

--- a/src/say.c
+++ b/src/say.c
@@ -157,6 +157,22 @@ say_format_by_name(const char *format)
 	return STR2ENUM(say_format, format);
 }
 
+void
+log_error(int level, const char *filename, int line, int format, const char *error)
+{
+	if (say_log_level_is_enabled(level)) {
+		const char* syserror = NULL;
+		if (level == S_SYSERROR) {
+			syserror = strerror(errno);
+		}
+		const char* fmt = "%s";
+		if (log_format == SF_JSON && format == SF_JSON) {
+			fmt = "json";
+		}
+		_say(level, filename, line, syserror, fmt, error);
+	}
+}
+
 /**
  * Initialize the logger pipe: a standalone
  * process which is fed all log messages.

--- a/src/say.h
+++ b/src/say.h
@@ -120,6 +120,19 @@ typedef void (*sayfunc_t)(int, const char *, int, const char *,
 CFORMAT(printf, 5, 0) extern sayfunc_t _say;
 
 /**
+ * Print a message to Tarantool log file.
+ *
+ * \param level (int) - log level (see enum \link say_level \endlink)
+ * \param filename (const char * ) - error source file name
+ * \param line (int) - error source file line number
+ * \param format (int) - error string format (see enum \link say_format \endlink)
+ * \param error (const char * ) - formatted error string
+ * \sa enum say_level
+ * \sa enum say_format
+ */
+void log_error(int level, const char *filename, int line, int format, const char *error);
+
+/**
  * Format and print a message to Tarantool log file.
  *
  * \param level (int) - log level (see enum \link say_level \endlink)

--- a/test/app-tap/module_api.c
+++ b/test/app-tap/module_api.c
@@ -43,6 +43,17 @@ test_say(lua_State *L)
 	return 1;
 }
 
+static int
+test_log_error(lua_State *L)
+{
+	log_error(S_INFO, __FILE__, __LINE__, SF_PLAIN, "test plain");
+	log_error(S_INFO, __FILE__, __LINE__, SF_JSON, "{\"message\": \"test json\"}");
+	errno = 0;
+	log_error(S_SYSERROR, __FILE__, __LINE__, SF_PLAIN, "test syserror");
+	lua_pushboolean(L, 1);
+	return 1;
+}
+
 static ssize_t
 coio_call_func(va_list ap)
 {
@@ -408,6 +419,7 @@ luaopen_module_api(lua_State *L)
 	(void) consts;
 	static const struct luaL_Reg lib[] = {
 		{"test_say", test_say },
+		{"test_log_error", test_log_error },
 		{"test_coio_call", test_coio_call },
 		{"test_coio_getaddrinfo", test_coio_getaddrinfo },
 		{"test_pushcheck_cdata", test_pushcheck_cdata },


### PR DESCRIPTION
Related issues: https://github.com/tarantool/tarantool/issues/2795

Motivation:
1. embrace #2795, abstract "json" and "%s" format values.
2. we can't use _say function (it's a different story)

the logic is based on https://github.com/tarantool/tarantool/blob/29248ab440919b7c62a6e7997a41a7fba5a3b37a/src/lua/log.lua#L75