### PR TITLE
Trigger build of docker image every package build

### DIFF
--- a/.travis.mk
+++ b/.travis.mk
@@ -84,3 +84,13 @@ source_deploy:
 	aws --endpoint-url "${AWS_S3_ENDPOINT_URL}" s3 \
 		cp build/*.tar.gz "s3://tarantool-${TRAVIS_BRANCH}-src/" \
 		--acl public-read
+
+TARANTOOL_VERSION:=$(shell git describe)
+trigger_progaudi_docker_build:
+	curl -s -X POST \
+		-H "Content-Type: application/json" \
+		-H "Accept: application/json" \
+		-H "Travis-API-Version: 3" \
+		-H "Authorization: token ${PROGAUDI_ACCESS_TOKEN}" \
+		-d '{"request": {"branch":"develop","config": {"env": {"TARANTOOL_VERSION": "${TARANTOOL_VERSION}"}}}}' \
+		https://api.travis-ci.org/repo/progaudi%2Ftarantool-docker/requests

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,13 @@ deploy:
     on:
       branch: "1.7"
       condition: "x${TARGET} = xsource"
+  # Trigger build of proguadi/tarantool docker image
+  - provider: script
+    script: make -f .travis.mk trigger_progaudi_docker_build
+    skip_cleanup: true
+    on:
+      branch: "1.7"
+      condition: "x${TARGET} = xsource"
 
 notifications:
   email:


### PR DESCRIPTION
I set up fork of and travis build. To trigger build with right version we need to pass version in format of `git describe`.

Contact me on telegram or by mail for value of PROGAUDI_ACCESS_TOKEN, if you're going to accept this PR.

Results: https://hub.docker.com/r/progaudi/tarantool/tags/