### PR TITLE
tap: add ':isfunction()' test function

### DIFF
--- a/src/lua/tap.lua
+++ b/src/lua/tap.lua
@@ -182,6 +182,10 @@ local function isboolean(test, v, message, extra)
     return is(test, type(v), 'boolean', message, extra)
 end
 
+local function isfunction(test, v, message, extra)
+    return is(test, type(v), 'function', message, extra)
+end
+
 local function isudata(test, v, utype, message, extra)
     extra = extra or {}
     extra.expected = 'userdata<'..utype..'>'
@@ -279,6 +283,7 @@ test_mt = {
         isstring  = isstring;
         istable   = istable;
         isboolean = isboolean;
+        isfunction = isfunction;
         isudata   = isudata;
         iscdata   = iscdata;
         is_deeply = is_deeply;


### PR DESCRIPTION
Implement ':isfunction()' test function  in Tap testing framework
that checks whether type of an argument is 'function'.

Closes #1859