### PR TITLE
Input history improvements.

### DIFF
--- a/src/box/lua/console.c
+++ b/src/box/lua/console.c
@@ -320,8 +320,7 @@ lbox_console_add_history(struct lua_State *L)
 		luaL_error(L, "add_history(string)");
 
 	const char *s = lua_tostring(L, 1);
-	if (*s)
-	{
+	if (*s) {
 		HIST_ENTRY *hist_ent = history_get(history_length - 1 + history_base);
 		const char *prev_s = hist_ent ? hist_ent->line : "";
 		if (strcmp(prev_s, s) != 0)

--- a/src/box/lua/console.c
+++ b/src/box/lua/console.c
@@ -319,7 +319,14 @@ lbox_console_add_history(struct lua_State *L)
 	if (lua_gettop(L) < 1 || !lua_isstring(L, 1))
 		luaL_error(L, "add_history(string)");
 
-	add_history(lua_tostring(L, 1));
+	const char *s = lua_tostring(L, 1);
+	if (*s)
+	{
+		HIST_ENTRY *hist_ent = history_get(history_length - 1 + history_base);
+		const char *prev_s = hist_ent ? hist_ent->line : "";
+		if (strcmp(prev_s, s) != 0)
+			add_history(s);
+	}
 	return 0;
 }
 


### PR DESCRIPTION
Don't add to input history empty lines and two same lines together (to achieve behavior as in bash, python, etc.)