### PR TITLE
Details on SIGSEGV added

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -146,7 +146,7 @@ signal_cb(ev_loop *loop, struct ev_signal *w, int revents)
  * quietly _exit() when called for a second time.
  */
 static void
-sig_fatal_cb(int signo, siginfo_t *siginfo, void *)
+sig_fatal_cb(int signo, siginfo_t *siginfo, void *context)
 {
 	static volatile sig_atomic_t in_cb = 0;
 	int fd = STDERR_FILENO;
@@ -178,6 +178,8 @@ sig_fatal_cb(int signo, siginfo_t *siginfo, void *)
 		fprintf(stderr, "  addr: %p\n", siginfo->si_addr); 
 	} else
 		fdprintf(fd, "Got a fatal signal %d\n", signo);
+	fprintf(stderr, "  context: %p\n", context); 
+	fprintf(stderr, "  siginfo: %p\n", siginfo); 
 
 	fdprintf(fd, "Current time: %u\n", (unsigned) time(0));
 	fdprintf(fd,

--- a/src/main.cc
+++ b/src/main.cc
@@ -130,7 +130,7 @@ signal_cb(ev_loop *loop, struct ev_signal *w, int revents)
 	ev_break(loop, EVBREAK_ALL);
 }
 
-#ifdef __amd64
+#if defined(__linux__) && defined(__amd64)
 
 inline void dump_x86_64_register(const char *reg_name, unsigned long long val)
 {
@@ -139,36 +139,34 @@ inline void dump_x86_64_register(const char *reg_name, unsigned long long val)
 
 void dump_x86_64_registers(ucontext_t *uc)
 {
-  dump_x86_64_register("rax", uc->uc_mcontext.gregs[REG_RAX]);
-  dump_x86_64_register("rbx", uc->uc_mcontext.gregs[REG_RBX]);
-  dump_x86_64_register("rcx", uc->uc_mcontext.gregs[REG_RCX]);
-  dump_x86_64_register("rdx", uc->uc_mcontext.gregs[REG_RDX]);
-  dump_x86_64_register("rsi", uc->uc_mcontext.gregs[REG_RSI]);
-  dump_x86_64_register("rdi", uc->uc_mcontext.gregs[REG_RDI]);
-  dump_x86_64_register("rsp", uc->uc_mcontext.gregs[REG_RSP]);
-  dump_x86_64_register("rbp", uc->uc_mcontext.gregs[REG_RBP]);
-  dump_x86_64_register("r8", uc->uc_mcontext.gregs[REG_R8]);
-  dump_x86_64_register("r9", uc->uc_mcontext.gregs[REG_R9]);
-  dump_x86_64_register("r10", uc->uc_mcontext.gregs[REG_R10]);
-  dump_x86_64_register("r11", uc->uc_mcontext.gregs[REG_R11]);
-  dump_x86_64_register("r12", uc->uc_mcontext.gregs[REG_R12]);
-  dump_x86_64_register("r13", uc->uc_mcontext.gregs[REG_R13]);
-  dump_x86_64_register("r14", uc->uc_mcontext.gregs[REG_R14]);
-  dump_x86_64_register("r15", uc->uc_mcontext.gregs[REG_R15]);
-  dump_x86_64_register("rip", uc->uc_mcontext.gregs[REG_RIP]);
-  dump_x86_64_register("eflags", uc->uc_mcontext.gregs[REG_EFL]);
-
-  dump_x86_64_register("cs", (uc->uc_mcontext.gregs[REG_CSGSFS] >> 0) & 0xffff);
-  dump_x86_64_register("gs", (uc->uc_mcontext.gregs[REG_CSGSFS] >> 16) & 0xffff);
-  dump_x86_64_register("fs", (uc->uc_mcontext.gregs[REG_CSGSFS] >> 32) & 0xffff);
-
-  dump_x86_64_register("cr2", uc->uc_mcontext.gregs[REG_CR2]);
-  dump_x86_64_register("err", uc->uc_mcontext.gregs[REG_ERR]);
-  dump_x86_64_register("oldmask", uc->uc_mcontext.gregs[REG_OLDMASK]);
-  dump_x86_64_register("trapno", uc->uc_mcontext.gregs[REG_TRAPNO]);
+	dump_x86_64_register("rax", uc->uc_mcontext.gregs[REG_RAX]);
+	dump_x86_64_register("rbx", uc->uc_mcontext.gregs[REG_RBX]);
+	dump_x86_64_register("rcx", uc->uc_mcontext.gregs[REG_RCX]);
+	dump_x86_64_register("rdx", uc->uc_mcontext.gregs[REG_RDX]);
+	dump_x86_64_register("rsi", uc->uc_mcontext.gregs[REG_RSI]);
+	dump_x86_64_register("rdi", uc->uc_mcontext.gregs[REG_RDI]);
+	dump_x86_64_register("rsp", uc->uc_mcontext.gregs[REG_RSP]);
+	dump_x86_64_register("rbp", uc->uc_mcontext.gregs[REG_RBP]);
+	dump_x86_64_register("r8", uc->uc_mcontext.gregs[REG_R8]);
+	dump_x86_64_register("r9", uc->uc_mcontext.gregs[REG_R9]);
+	dump_x86_64_register("r10", uc->uc_mcontext.gregs[REG_R10]);
+	dump_x86_64_register("r11", uc->uc_mcontext.gregs[REG_R11]);
+	dump_x86_64_register("r12", uc->uc_mcontext.gregs[REG_R12]);
+	dump_x86_64_register("r13", uc->uc_mcontext.gregs[REG_R13]);
+	dump_x86_64_register("r14", uc->uc_mcontext.gregs[REG_R14]);
+	dump_x86_64_register("r15", uc->uc_mcontext.gregs[REG_R15]);
+	dump_x86_64_register("rip", uc->uc_mcontext.gregs[REG_RIP]);
+	dump_x86_64_register("eflags", uc->uc_mcontext.gregs[REG_EFL]);
+	dump_x86_64_register("cs", (uc->uc_mcontext.gregs[REG_CSGSFS] >> 0) & 0xffff);
+	dump_x86_64_register("gs", (uc->uc_mcontext.gregs[REG_CSGSFS] >> 16) & 0xffff);
+	dump_x86_64_register("fs", (uc->uc_mcontext.gregs[REG_CSGSFS] >> 32) & 0xffff);
+	dump_x86_64_register("cr2", uc->uc_mcontext.gregs[REG_CR2]);
+	dump_x86_64_register("err", uc->uc_mcontext.gregs[REG_ERR]);
+	dump_x86_64_register("oldmask", uc->uc_mcontext.gregs[REG_OLDMASK]);
+	dump_x86_64_register("trapno", uc->uc_mcontext.gregs[REG_TRAPNO]);
 }
 
-#endif //__amd64
+#endif //#if defined(__linux__) && defined(__amd64)
 
 /** Try to log as much as possible before dumping a core.
  *
@@ -221,7 +219,7 @@ sig_fatal_cb(int signo, siginfo_t *siginfo, void *context)
 	fprintf(stderr, "  context: %p\n", context); 
 	fprintf(stderr, "  siginfo: %p\n", siginfo); 
 
-#ifdef __amd64
+#if defined(__linux__) && defined(__amd64)
 	dump_x86_64_registers((ucontext_t *)context);
 #endif
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -130,6 +130,46 @@ signal_cb(ev_loop *loop, struct ev_signal *w, int revents)
 	ev_break(loop, EVBREAK_ALL);
 }
 
+#ifdef __amd64
+
+inline void dump_x86_64_register(const char *reg_name, unsigned long long val)
+{
+	fprintf(stderr, "  %-9s0x%-17llx%lld\n", reg_name, val, val);
+}
+
+void dump_x86_64_registers(ucontext_t *uc)
+{
+  dump_x86_64_register("rax", uc->uc_mcontext.gregs[REG_RAX]);
+  dump_x86_64_register("rbx", uc->uc_mcontext.gregs[REG_RBX]);
+  dump_x86_64_register("rcx", uc->uc_mcontext.gregs[REG_RCX]);
+  dump_x86_64_register("rdx", uc->uc_mcontext.gregs[REG_RDX]);
+  dump_x86_64_register("rsi", uc->uc_mcontext.gregs[REG_RSI]);
+  dump_x86_64_register("rdi", uc->uc_mcontext.gregs[REG_RDI]);
+  dump_x86_64_register("rsp", uc->uc_mcontext.gregs[REG_RSP]);
+  dump_x86_64_register("rbp", uc->uc_mcontext.gregs[REG_RBP]);
+  dump_x86_64_register("r8", uc->uc_mcontext.gregs[REG_R8]);
+  dump_x86_64_register("r9", uc->uc_mcontext.gregs[REG_R9]);
+  dump_x86_64_register("r10", uc->uc_mcontext.gregs[REG_R10]);
+  dump_x86_64_register("r11", uc->uc_mcontext.gregs[REG_R11]);
+  dump_x86_64_register("r12", uc->uc_mcontext.gregs[REG_R12]);
+  dump_x86_64_register("r13", uc->uc_mcontext.gregs[REG_R13]);
+  dump_x86_64_register("r14", uc->uc_mcontext.gregs[REG_R14]);
+  dump_x86_64_register("r15", uc->uc_mcontext.gregs[REG_R15]);
+  dump_x86_64_register("rip", uc->uc_mcontext.gregs[REG_RIP]);
+  dump_x86_64_register("eflags", uc->uc_mcontext.gregs[REG_EFL]);
+
+  dump_x86_64_register("cs", (uc->uc_mcontext.gregs[REG_CSGSFS] >> 0) & 0xffff);
+  dump_x86_64_register("gs", (uc->uc_mcontext.gregs[REG_CSGSFS] >> 16) & 0xffff);
+  dump_x86_64_register("fs", (uc->uc_mcontext.gregs[REG_CSGSFS] >> 32) & 0xffff);
+
+  dump_x86_64_register("cr2", uc->uc_mcontext.gregs[REG_CR2]);
+  dump_x86_64_register("err", uc->uc_mcontext.gregs[REG_ERR]);
+  dump_x86_64_register("oldmask", uc->uc_mcontext.gregs[REG_OLDMASK]);
+  dump_x86_64_register("trapno", uc->uc_mcontext.gregs[REG_TRAPNO]);
+}
+
+#endif //__amd64
+
 /** Try to log as much as possible before dumping a core.
  *
  * Core files are not aways allowed and it takes an effort to
@@ -180,6 +220,10 @@ sig_fatal_cb(int signo, siginfo_t *siginfo, void *context)
 		fdprintf(fd, "Got a fatal signal %d\n", signo);
 	fprintf(stderr, "  context: %p\n", context); 
 	fprintf(stderr, "  siginfo: %p\n", siginfo); 
+
+#ifdef __amd64
+	dump_x86_64_registers((ucontext_t *)context);
+#endif
 
 	fdprintf(fd, "Current time: %u\n", (unsigned) time(0));
 	fdprintf(fd,


### PR DESCRIPTION
With this changes stderr output may look like:
 ```
Segmentation fault
  code: SEGV_MAPERR
  addr: 0x14049f048
  context: 0x7f2bcd01f840
  siginfo: 0x7f2bcd01f970
  rax      0xa                10
  rbx      0x409e7960         1084127584
  rcx      0xffffffb0         4294967216
  rdx      0x4049f098         1078587544
  rsi      0x0                0
  rdi      0x7f2bcd01f870     139826099779696
  rsp      0x7f2bcd01fdd0     139826099781072
  rbp      0x4067c378         1080542072
  r8       0x0                0
  r9       0xa                10
  r10      0x0                0
  r11      0x246              582
  r12      0x0                0
  r13      0x0                0
  r14      0x4067d000         1080545280
  r15      0x4049f098         1078587544
  rip      0x519b7d           5348221
  eflags   0x10206            66054
  cs       0x33               51
  gs       0x0                0
  fs       0x0                0
  cr2      0x14049f048        5373554760
  err      0x4                4
  oldmask  0x0                0
  trapno   0xe                14
```