### PR TITLE
Fix some minor memory leaks

### DIFF
--- a/test/unit/bps_tree.cc
+++ b/test/unit/bps_tree.cc
@@ -789,6 +789,8 @@ insert_get_iterator()
 	for (i = -9999; i < 10000; i += 2)
 		bps_insert_and_check(test, &tree, i, NULL)
 
+	test_destroy(&tree);
+
 	footer();
 }
 

--- a/test/unit/heap.c
+++ b/test/unit/heap.c
@@ -475,6 +475,7 @@ test_random_delete_workload()
 		}
 		else {
 			test_heap_delete(&heap, &(nodes[nodes_it]->node));
+			free(nodes[nodes_it]);
 			current_size--;
 			nodes_it++;
 		}
@@ -511,9 +512,11 @@ test_delete_last_node()
 	}
 
 	test_heap_delete(&heap, &value->node);
+	free(value);
 	if (test_heap_check(&heap)) {
 		fail("check heap invariants failed", "test_heap_check(&heap)");
 	}
+	free_all_nodes(&heap);
 	test_heap_destroy(&heap);
 	footer();
 }

--- a/test/unit/heap_iterator.c
+++ b/test/unit/heap_iterator.c
@@ -63,7 +63,7 @@ test_iterator_create()
 		fail("incorrect position after create", "it.curr_pos != 0");
 
 	free_all_nodes(&heap);
-
+	test_heap_destroy(&heap);
 	footer();
 }
 
@@ -84,7 +84,7 @@ test_iterator_empty()
 		fail("incorrect node", "nd != NULL");
 
 	free_all_nodes(&heap);
-
+	test_heap_destroy(&heap);
 	footer();
 }
 
@@ -141,6 +141,7 @@ test_iterator_small()
 		     "test_node != NULL");
 
 	free_all_nodes(&heap);
+	test_heap_destroy(&heap);
 	footer();
 }
 
@@ -198,6 +199,7 @@ test_iterator_large()
 		     "test_node != NULL");
 
 	free_all_nodes(&heap);
+	test_heap_destroy(&heap);
 	footer();
 }
 


### PR DESCRIPTION
I've fixed the following memory leaks found by `asan`:
```sh
    Direct leak of 2048 byte(s) in 1 object(s) allocated from:
        #0 0x4dafb8 in __interceptor_malloc (.tarantool/test/unit/bps_tree.test+0x4dafb8)
        #1 0x51db83 in extent_alloc(void*) .tarantool/test/unit/bps_tree.cc:110:9
        #2 0x569c65 in matras_alloc_extent .tarantool/src/lib/small/small/matras.c:91:14
        #3 0x56981c in matras_alloc .tarantool/src/lib/small/small/matras.c:181:22
        #4 0x52471f in bps_tree_test_create_leaf(test*, unsigned int*) .tarantool/src/lib/salad/bps_tree.h:2142:28
        #5 0x51f9cf in bps_tree_test_insert_first_elem(test*, long) .tarantool/src/lib/salad/bps_tree.h:2213:26
        #6 0x567373 in test_insert_get_iterator(test*, long, long*, test_iterator*) .tarantool/src/lib/salad/bps_tree.h:4461:12
        #7 0x51cd50 in insert_get_iterator() .tarantool/test/unit/bps_tree.cc:783:2
        #8 0x5159c5 in main .tarantool/test/unit/bps_tree.cc:808:2
        #9 0x7f663082e82f in __libc_start_main /build/glibc-Cl5G7W/glibc-2.23/csu/../csu/libc-start.c:291
```

```sh
    Direct leak of 8192 byte(s) in 1 object(s) allocated from:
        #0 0x4bb057 in realloc .final/llvm.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:98:3
        #1 0x4e6309 in test_heap_reserve .tarantool/src/lib/salad/heap.h:341:15
        #2 0x4e5ff0 in test_heap_insert .tarantool/src/lib/salad/heap.h:359:7
        #3 0x4e7647 in test_iterator_large .tarantool/test/unit/heap_iterator.c:160:3
        #4 0x4e5ace in main .tarantool/test/unit/heap_iterator.c:212:2
        #5 0x7fc527ba482f in __libc_start_main /build/glibc-Cl5G7W/glibc-2.23/csu/../csu/libc-start.c:291

    Direct leak of 64 byte(s) in 1 object(s) allocated from:
        #0 0x4bb057 in realloc .final/llvm.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:98:3
        #1 0x4e6309 in test_heap_reserve .tarantool/src/lib/salad/heap.h:341:15
        #2 0x4e5ff0 in test_heap_insert .tarantool/src/lib/salad/heap.h:359:7
        #3 0x4e6dfb in test_iterator_small .tarantool/test/unit/heap_iterator.c:104:3
        #4 0x4e5ac9 in main .tarantool/test/unit/heap_iterator.c:211:2
        #5 0x7fc527ba482f in __libc_start_main /build/glibc-Cl5G7W/glibc-2.23/csu/../csu/libc-start.c:291

    Direct leak of 64 byte(s) in 1 object(s) allocated from:
        #0 0x4bb057 in realloc .final/llvm.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:98:3
        #1 0x4e6309 in test_heap_reserve .tarantool/src/lib/salad/heap.h:341:15
        #2 0x4e5ff0 in test_heap_insert .tarantool/src/lib/salad/heap.h:359:7
        #3 0x4e5c69 in test_iterator_create .tarantool/test/unit/heap_iterator.c:57:2
        #4 0x4e5abf in main .tarantool/test/unit/heap_iterator.c:209:2
        #5 0x7fc527ba482f in __libc_start_main /build/glibc-Cl5G7W/glibc-2.23/csu/../csu/libc-start.c:291
```

```

    Direct leak of 3136 byte(s) in 196 object(s) allocated from:
        #0 0x4bad33 in __interceptor_malloc .final/llvm.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:67:3
        #1 0x4eaca6 in test_random_delete_workload .tarantool/test/unit/heap.c:470:5
        #2 0x4e5e5c in main .tarantool/test/unit/heap.c:561:2
        #3 0x7f3dc406082f in __libc_start_main /build/glibc-Cl5G7W/glibc-2.23/csu/../csu/libc-start.c:291

    Direct leak of 64 byte(s) in 4 object(s) allocated from:
        #0 0x4bad33 in __interceptor_malloc .final/llvm.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:67:3
        #1 0x4eb149 in test_delete_last_node .tarantool/test/unit/heap.c:508:4
        #2 0x4e5e61 in main .tarantool/test/unit/heap.c:562:2
        #3 0x7f3dc406082f in __libc_start_main /build/glibc-Cl5G7W/glibc-2.23/csu/../csu/libc-start.c:291
```