### PR TITLE
APKBUILD spec for tarantool 1.7.6

### DIFF
--- a/apkbuild/APKBUILD
+++ b/apkbuild/APKBUILD
@@ -12,7 +12,6 @@ depends="libstdc++ readline libressl yaml lz4 binutils ncurses libgomp lua curl 
 makedepends="perl gcc cmake readline-dev libressl-dev yaml-dev lz4-dev binutils-dev ncurses-dev lua-dev musl-dev make git libunwind-dev autoconf automake libtool linux-headers go curl-dev icu-dev"
 subpackages=""
 
-# builddir="$startdir"/..
 builddir="$srcdir"/"$pkgname-$pkgver"
 
 prepare() {

--- a/apkbuild/APKBUILD
+++ b/apkbuild/APKBUILD
@@ -1,0 +1,70 @@
+pkgname="tarantool"
+pkgver="1.7.6"
+pkgrel="0"
+pkgdesc="Tarantool is an in-memory database and application server"
+maintainer="Ilya Konyukhov <i.konyukhov@tarantool.org>"
+license="BSD-2-Clause"
+arch="all"
+source=""
+giturl="https://github.com/tarantool/tarantool.git"
+url="https://github.com/tarantool/tarantool"
+depends="libstdc++ readline libressl yaml lz4 binutils ncurses libgomp lua curl tar zip libunwind libcurl icu"
+makedepends="perl gcc cmake readline-dev libressl-dev yaml-dev lz4-dev binutils-dev ncurses-dev lua-dev musl-dev make git libunwind-dev autoconf automake libtool linux-headers go curl-dev icu-dev"
+subpackages=""
+
+# builddir="$startdir"/..
+builddir="$srcdir"/"$pkgname-$pkgver"
+
+prepare() {
+    default_prepare
+
+    git clone "$giturl" "$builddir"
+    # git -C "$builddir" checkout "$pkgver"
+    git -C "$builddir" submodule update --init --recursive
+}
+
+build() {
+    cd "$builddir"
+
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DENABLE_BUNDLED_LIBYAML:BOOL=OFF \
+          -DENABLE_BACKTRACE:BOOL=ON \
+          -DENABLE_DIST:BOOL=ON \
+          .
+    make -C "$builddir" -j || return 1
+
+    # "---------- small ----------"
+    cmake -DCMAKE_INSTALL_PREFIX=/usr \
+          -DCMAKE_INSTALL_LIBDIR=lib \
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          . || return 1
+    make -C "$builddir"/src/lib/small || return 1
+
+    # "---------- msgpuck ----------"
+    cmake -DCMAKE_INSTALL_PREFIX=/usr \
+          -DCMAKE_INSTALL_LIBDIR=lib \
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          . || return 1
+    make -C "$builddir"/src/lib/msgpuck || return 1
+
+    return 0
+}
+
+package() {
+    mkdir -p "$pkgdir"
+
+    make -C "$builddir" DESTDIR="$pkgdir" install
+    make -C "$builddir"/src/lib/small DESTDIR="$pkgdir" install
+    make -C "$builddir"/src/lib/msgpuck DESTDIR="$pkgdir" install
+
+    make -C /usr/src/tarantool/src/lib/msgpuck clean
+    make -C /usr/src/tarantool/src/lib/small clean
+    make -C /usr/src/tarantool clean
+
+    return 0
+}
+
+# Even if subpackages var is explicitly set to "", this function failed while trying to setup default subpackages
+prepare_subpackages() {
+    return 0
+}

--- a/apkbuild/APKBUILD
+++ b/apkbuild/APKBUILD
@@ -19,7 +19,7 @@ prepare() {
     default_prepare
 
     git clone "$giturl" "$builddir"
-    # git -C "$builddir" checkout "$pkgver"
+    git -C "$builddir" checkout "$pkgver"
     git -C "$builddir" submodule update --init --recursive
 }
 

--- a/apkbuild/Dockerfile
+++ b/apkbuild/Dockerfile
@@ -13,12 +13,6 @@ RUN sudo mkdir -p /var/cache/distfiles \
 	&& sudo chmod g+w /var/cache/distfiles \
 	&& abuild-keygen -a -i
 
-# WORKDIR /home/builder/tarantool/
-
-# COPY --chown=builder:abuild apkbuild/APKBUILD /home/builder/tarantool/apkbuild/APKBUILD
-# COPY --chown=builder:abuild apkbuild/tarantool.pre-install /home/builder/tarantool/apkbuild/tarantool.pre-install
-# COPY --chown=builder:abuild apkbuild/tarantool.post-install /home/builder/tarantool/apkbuild/tarantool.post-install
-
 COPY --chown=builder:abuild . /home/builder/tarantool/
 
 WORKDIR /home/builder/tarantool/apkbuild

--- a/apkbuild/Dockerfile
+++ b/apkbuild/Dockerfile
@@ -1,0 +1,28 @@
+FROM alpine:3.5
+
+RUN apk update \
+	&& apk add alpine-sdk \
+	&& adduser -G abuild -g "Alpine Package Builder" -s /bin/sh -D builder \
+	&& echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+USER builder
+
+RUN sudo mkdir -p /var/cache/distfiles \
+	&& sudo chmod a+w /var/cache/distfiles \
+	&& sudo chgrp abuild /var/cache/distfiles \
+	&& sudo chmod g+w /var/cache/distfiles \
+	&& abuild-keygen -a -i
+
+# WORKDIR /home/builder/tarantool/
+
+# COPY --chown=builder:abuild apkbuild/APKBUILD /home/builder/tarantool/apkbuild/APKBUILD
+# COPY --chown=builder:abuild apkbuild/tarantool.pre-install /home/builder/tarantool/apkbuild/tarantool.pre-install
+# COPY --chown=builder:abuild apkbuild/tarantool.post-install /home/builder/tarantool/apkbuild/tarantool.post-install
+
+COPY --chown=builder:abuild . /home/builder/tarantool/
+
+WORKDIR /home/builder/tarantool/apkbuild
+
+VOLUME ["/target"]
+
+CMD ["abuild", "-r", "-P", "/target"]

--- a/apkbuild/README.md
+++ b/apkbuild/README.md
@@ -1,0 +1,8 @@
+Building apk package
+---
+
+```
+git clone https://github.com/tarantool/tarantool.git
+docker build -t apkbuild -f apkbuild/Dockerfile .
+docker run --rm -it -v $(pwd)/target:/target apkbuild:latest
+```

--- a/apkbuild/README.md
+++ b/apkbuild/README.md
@@ -6,3 +6,5 @@ git clone https://github.com/tarantool/tarantool.git
 docker build -t apkbuild -f apkbuild/Dockerfile .
 docker run --rm -it -v $(pwd)/target:/target apkbuild:latest
 ```
+
+Then you will find newly created package under `./target/tarantool/<arch>` dir

--- a/apkbuild/tarantool.post-install
+++ b/apkbuild/tarantool.post-install
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+mkdir -p /var/lib/tarantool
+chown tarantool:tarantool /var/lib/tarantool
+
+mkdir -p /opt/tarantool
+chown tarantool:tarantool /opt/tarantool
+
+mkdir -p /var/run/tarantool
+chown tarantool:tarantool /var/run/tarantool
+
+mkdir /etc/tarantool
+chown tarantool:tarantool /etc/tarantool

--- a/apkbuild/tarantool.pre-install
+++ b/apkbuild/tarantool.pre-install
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+addgroup -S tarantool
+adduser -S -G tarantool tarantool
+
+apk add --no-cache 'su-exec>=0.2'


### PR DESCRIPTION
Setup basic APKBUILD configuration to be able more easily distribute tarantool on alpine systems.

This spec was setup against 1.7.6 version.
It only builds tarantool + tarantool/small + tarantool/msgpuck.

Closes #3067 