### PR TITLE
sql: Make foreign key mismatch error more informative

### DIFF
--- a/src/box/sql/fkey.c
+++ b/src/box/sql/fkey.c
@@ -328,7 +328,9 @@ sqlite3FkLocateIndex(Parse * pParse,	/* Parse context to store any error in */
 	if (!pIdx) {
 		if (!pParse->disableTriggers) {
 			sqlite3ErrorMsg(pParse,
-					"foreign key mismatch - \"%w\" referencing \"%w\"",
+					"Foreign key mismatch - \"%w\" referencing \"%w\""
+					" Foreign keys can be created only on primary"
+					" key or unique indexes with the default collation sequence",
 					pFKey->pFrom->zName, pFKey->zTo);
 		}
 		sqlite3DbFree(pParse->db, aiCol);

--- a/test/sql-tap/fkey1.test.lua
+++ b/test/sql-tap/fkey1.test.lua
@@ -226,7 +226,9 @@ test:do_catchsql_test(
         INSERT INTO c1 VALUES(1);
     ]], {
         -- <fkey1-6.2>
-        1, "foreign key mismatch - \"C1\" referencing \"P1\""
+        1, "Foreign key mismatch - \"C1\" referencing \"P1\"" ..
+           " Foreign keys can be created only on primary key" ..
+           " or unique indexes with the default collation sequence"
         -- </fkey1-6.2>
     })
 

--- a/test/sql-tap/fkey2.test.lua
+++ b/test/sql-tap/fkey2.test.lua
@@ -314,7 +314,9 @@ test:do_catchsql_test(
         INSERT INTO t10 VALUES(1, 3);
     ]], {
         -- <fkey2-1.30>
-        1, "foreign key mismatch - \"T10\" referencing \"T9\""
+        1, "Foreign key mismatch - \"T10\" referencing \"T9\"" ..
+           " Foreign keys can be created only on primary key" ..
+           " or unique indexes with the default collation sequence"
         -- </fkey2-1.30>
     })
 
@@ -722,7 +724,9 @@ test:do_catchsql_test(
         INSERT INTO c DEFAULT VALUES;
     ]], {
         -- <fkey2-7.1>
-        1, "foreign key mismatch - \"C\" referencing \"P\""
+        1, "Foreign key mismatch - \"C\" referencing \"P\"" ..
+           " Foreign keys can be created only on primary key" ..
+           " or unique indexes with the default collation sequence"
         -- </fkey2-7.1>
     })
 
@@ -736,7 +740,9 @@ test:do_catchsql_test(
         INSERT INTO c DEFAULT VALUES;
     ]], {
         -- <fkey2-7.2>
-        1, "foreign key mismatch - \"C\" referencing \"V\""
+        1, "Foreign key mismatch - \"C\" referencing \"V\""..
+           " Foreign keys can be created only on primary key" ..
+           " or unique indexes with the default collation sequence"
         -- </fkey2-7.2>
     })
 
@@ -750,7 +756,9 @@ test:do_catchsql_test(
         INSERT INTO c DEFAULT VALUES;
     ]], {
         -- <fkey2-7.3>
-        1, "foreign key mismatch - \"C\" referencing \"P\""
+        1, "Foreign key mismatch - \"C\" referencing \"P\""..
+           " Foreign keys can be created only on primary key" ..
+           " or unique indexes with the default collation sequence"
         -- </fkey2-7.3>
     })
 
@@ -764,7 +772,9 @@ test:do_catchsql_test(
         INSERT INTO c DEFAULT VALUES;
     ]], {
         -- <fkey2-7.4>
-        1, "foreign key mismatch - \"C\" referencing \"P\""
+        1, "Foreign key mismatch - \"C\" referencing \"P\""..
+           " Foreign keys can be created only on primary key" ..
+           " or unique indexes with the default collation sequence"
         -- </fkey2-7.4>
     })
 
@@ -1153,7 +1163,9 @@ test:do_catchsql_test(
         INSERT INTO cc VALUES(1, 2);
     ]], {
         -- <fkey2-10.15>
-        1, "foreign key mismatch - \"CC\" referencing \"PP\""
+        1, "Foreign key mismatch - \"CC\" referencing \"PP\""..
+           " Foreign keys can be created only on primary key" ..
+           " or unique indexes with the default collation sequence"
         -- </fkey2-10.15>
     })
 


### PR DESCRIPTION
A foreign key constraint requires that the key columns in the parent
table are collectively subject to a unique or primary key constraint.
Otherwise, an error is raised.
Change error message from "foreign key mismatch - CHILD referencing PARENT"
to "Foreign key mismatch -  referencing PARENT Foreign keys can be
created only on primary key or unique indexes with the default collation sequence"

Closes: #3033