### PR TITLE
expose space_mt and index_mt on `box` table

### DIFF
--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -1089,7 +1089,7 @@ internal.check_iterator_type = check_iterator_type -- export for net.box
 
 local space_mt = {}
 space_mt.__index = space_mt
-box.space_mt = space_mt
+box.schema.space_mt = space_mt
 
 space_mt.len = function(space)
     check_space_arg(space, 'len')
@@ -1210,7 +1210,7 @@ end
 
 local index_mt = {}
 index_mt.__index = index_mt
-box.index_mt = index_mt
+box.schema.index_mt = index_mt
 
 -- __len and __index
 index_mt.len = function(index)
@@ -1428,7 +1428,7 @@ index_mt.__ipairs = index_mt.pairs -- Lua 5.2 compatibility
 function box.schema.space.bless(space)
     local index_mt = {}
     index_mt.__index = function(index, key)
-      return index_mt[key] or box.index_mt[key]
+      return index_mt[key] or box.schema.index_mt[key]
     end
 
     -- true if reading operations may yield
@@ -1437,15 +1437,15 @@ function box.schema.space.bless(space)
     for _, op in ipairs(read_ops) do
         if read_yields then
             -- use Lua/C implmenetation
-            index_mt[op] = box.index_mt[op .. "_luac"]
+            index_mt[op] = box.schema.index_mt[op .. "_luac"]
         else
             -- use FFI implementation
-            index_mt[op] = box.index_mt[op .. "_ffi"]
+            index_mt[op] = box.schema.index_mt[op .. "_ffi"]
         end
     end
     --
 
-    setmetatable(space, box.space_mt)
+    setmetatable(space, box.schema.space_mt)
     if type(space.index) == 'table' and space.enabled then
         for j, index in pairs(space.index) do
             if type(j) == 'number' then

--- a/test/box-tap/schema_mt.test.lua
+++ b/test/box-tap/schema_mt.test.lua
@@ -1,0 +1,74 @@
+#!/usr/bin/env tarantool
+--
+-- pr-3204: expose space_mt, index_mt into box.schema.
+--
+
+local tap = require('tap')
+local test = tap.test('schema_mt')
+
+test:plan(7)
+
+box.cfg{
+  log="tarantool.log",
+}
+
+local sp1 = box.schema.space.create('test')
+local sp2 = box.schema.space.create('test2')
+
+test:is(
+  getmetatable(sp1),
+  getmetatable(sp2),
+  'all spaces use the same metatable'
+)
+
+local idx1 = sp1:create_index('primary')
+local idx2 = sp2:create_index('primary')
+
+test:isnt(
+  getmetatable(idx1),
+  getmetatable(idx2),
+  'all indexes have their own metatable'
+)
+
+test:is(
+  idx1.get,
+  idx2.get,
+  'memtx indexes share read methods'
+)
+
+local sp3 = box.schema.space.create('test3', {engine='vinyl'})
+local sp4 = box.schema.space.create('test4', {engine='vinyl'})
+
+local idx3 = sp3:create_index('primary')
+local idx4 = sp4:create_index('primary')
+
+test:is(
+  idx3.get,
+  idx4.get,
+  'vinyl indexes share read methods'
+)
+
+test:isnt(
+  idx1.get,
+  idx3.get,
+  'memtx and vinyl indexes have separate read methods'
+)
+
+function box.schema.space_mt.foo() end
+
+test:is(
+  sp1.foo,
+  box.schema.space_mt.foo,
+  'box.schema.space_mt is mutable'
+)
+
+function box.schema.index_mt.foo() end
+
+test:is(
+  idx1.foo,
+  box.schema.index_mt.foo,
+  'box.schema.index_mt is mutable'
+)
+
+test:check()
+os.exit(0)


### PR DESCRIPTION
This commit allows userland to extend the space and index metatables
with their own functions or even metamethods. Reducing barriers for
this kind of experimentation is vital for user contribution toward
the improvement of Tarantool's API.

Also, this commit reuses functions between all spaces/indexes.

The metatables are exposed on `box` to make them simple to discover.
The suggested alternatives were `box.internal` and `box.schema`.

In a future commit, we should look into "freezing" the built-in
methods so the user cannot accidentally override them. This is
especially important when updating Tarantool.