### PR TITLE
fix(fio): empty path part in pathjoin

### DIFF
--- a/src/lua/fio.lua
+++ b/src/lua/fio.lua
@@ -243,9 +243,10 @@ fio.pathjoin = function(...)
 
         i = i + 1
     end
-    path = string.gsub(path, "/+",'/')
-    if string.match(path, '/$') ~= nil and #path > 1 then
-        path = string.gsub(path, '/$', '')
+
+    path = path:gsub('/+', '/')
+    if path ~= '/' then
+        path = path:gsub('/$', '')
     end
 
     return path

--- a/src/lua/fio.lua
+++ b/src/lua/fio.lua
@@ -225,8 +225,16 @@ fio.pathjoin = function(...)
         end
     end
 
+    if path == nil then
+        return '.'
+    end
+
     i = i + 1
     while i <= len do
+        if string.match(path, '/$') ~= nil then
+            path = string.gsub(path, '/$', '')
+        end
+
         local sp = select(i, ...)
         if sp == nil then
             error("Undefined path part")

--- a/src/lua/fio.lua
+++ b/src/lua/fio.lua
@@ -220,9 +220,6 @@ fio.pathjoin = function(path, ...)
         if sp == nil then
             error("Undefined path part")
         end
-        if sp == '' then
-            error("Empty path part")
-        end
 
         if sp ~= '' then
             path = path .. '/' .. sp

--- a/src/lua/fio.lua
+++ b/src/lua/fio.lua
@@ -206,16 +206,27 @@ fio.open = function(path, flags, mode)
     return fh
 end
 
-fio.pathjoin = function(path, ...)
-    path = tostring(path)
-    if path == nil or path == '' then
-        error("Empty path part")
-    end
-    for i = 1, select('#', ...) do
-        if string.match(path, '/$') ~= nil then
-            path = string.gsub(path, '/$', '')
+fio.pathjoin = function(...)
+    local i, path = 1, nil
+
+    local len = select('#', ...)
+    while i <= len do
+        local sp = select(i, ...)
+        if sp == nil then
+            error("Undefined path part")
         end
 
+        sp = tostring(sp)
+        if sp ~= '' then
+            path = sp
+            break
+        else
+            i = i + 1
+        end
+    end
+
+    i = i + 1
+    while i <= len do
         local sp = select(i, ...)
         if sp == nil then
             error("Undefined path part")
@@ -224,6 +235,8 @@ fio.pathjoin = function(path, ...)
         if sp ~= '' then
             path = path .. '/' .. sp
         end
+
+        i = i + 1
     end
     path = string.gsub(path, "/+",'/')
     if string.match(path, '/$') ~= nil and #path > 1 then

--- a/src/lua/fio.lua
+++ b/src/lua/fio.lua
@@ -231,10 +231,6 @@ fio.pathjoin = function(...)
 
     i = i + 1
     while i <= len do
-        if string.match(path, '/$') ~= nil then
-            path = string.gsub(path, '/$', '')
-        end
-
         local sp = select(i, ...)
         if sp == nil then
             error("Undefined path part")

--- a/src/lua/fio.lua
+++ b/src/lua/fio.lua
@@ -240,6 +240,7 @@ fio.pathjoin = function(...)
             error("Undefined path part")
         end
 
+        sp = tostring(sp)
         if sp ~= '' then
             path = path .. '/' .. sp
         end


### PR DESCRIPTION
Empty strings should be ignored, rather than throw an error.

```lua
fio.pathjoin('foo', '', 'bar') -- "foo/bar"
```

**Note:** I have more changes coming. Please wait on merging this.