### PR TITLE
Fix PyPI TLS connection failures in CI on OS X  …

### DIFF
--- a/.travis.mk
+++ b/.travis.mk
@@ -47,7 +47,6 @@ test_ubuntu: deps_ubuntu
 deps_osx:
 	brew update
 	brew install openssl readline curl icu4c --force
-	pip install -r test-run/requirements.txt --user
 
 test_osx: deps_osx
 	cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo
@@ -58,7 +57,13 @@ test_osx: deps_osx
 	ulimit -S -n 20480 || :
 	ulimit -n
 	make -j8
-	cd test && python test-run.py -j -1 unit/ app/ app-tap/ box/ box-tap/
+	virtualenv ./test-env && \
+	. ./test-env/bin/activate && \
+	curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python && \
+	pip --version && \
+	pip install -r test-run/requirements.txt && \
+	cd test && python test-run.py -j -1 unit/ app/ app-tap/ box/ box-tap/ && \
+	deactivate
 
 coverage_ubuntu: deps_ubuntu
 	cmake . -DCMAKE_BUILD_TYPE=Debug -DENABLE_GCOV=ON


### PR DESCRIPTION
The reason of the failures is TLSv1.0/TLSv1.1 brownout on the PyPI side,
see [1] for more information.

[1]: pypa/packaging-problems#130