### PR TITLE
Add tarantoolctl rocks pack/unpack subcommands

### DIFF
--- a/extra/dist/tarantoolctl.in
+++ b/extra/dist/tarantoolctl.in
@@ -910,6 +910,8 @@ local function rocks()
        remove = "luarocks.remove",
        show = "luarocks.show",
        make = "luarocks.make",
+       pack = "luarocks.pack",
+       unpack = "luarocks.unpack",
     }
     rawset(_G, 'commands', commands)
 


### PR DESCRIPTION
The subcommands are used to create binary rock distributions.
In context of #3525