### PR TITLE
Exclude install targets of libyaml from CMake

### DIFF
--- a/cmake/BuildLibYAML.cmake
+++ b/cmake/BuildLibYAML.cmake
@@ -4,7 +4,7 @@ macro(libyaml_build)
     set(LIBYAML_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/third_party/libyaml/include)
     set(LIBYAML_LIBRARIES yaml)
 
-    add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/libyaml)
+    add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/libyaml EXCLUDE_FROM_ALL)
     # See comments in BuildLibEV.cmake
     set_target_properties(yaml PROPERTIES COMPILE_FLAGS "-w")
 


### PR DESCRIPTION
No more `include/yaml.h` and `lib/libyaml_static.a` installs.

closes gh-3547

Also need to be merged into 1.10/2.0(?)