### PR TITLE
Add tarantoolctl rocks doc subcommand

### DIFF
--- a/extra/dist/tarantoolctl.in
+++ b/extra/dist/tarantoolctl.in
@@ -929,6 +929,7 @@ local function rocks()
        make = "luarocks.make",
        pack = "luarocks.pack",
        unpack = "luarocks.unpack",
+       doc = "luarocks.doc",
     }
     rawset(_G, 'commands', commands)
 


### PR DESCRIPTION
Allow exploring rocks documentation locally with
`tarantoolctl rocks doc ...`

In context of #3753