### PR TITLE
Update external links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Gitter][gitter-badge]][gitter-url]
 [![Google Groups][groups-badge]][groups-url]
 
-https://tarantool.io/
+https://tarantool.io/en/
 
 Tarantool is an in-memory database and application server.
 
@@ -39,7 +39,7 @@ scalable Web architecture: queue servers, caches,
 stateful Web applications.
 
 To download and install Tarantool as a binary package for your OS, please visit
-https://tarantool.io/download/download.html.
+https://tarantool.io/en/download/.
 
 To build Tarantool from source, see detailed instructions in the Tarantool
 documentation at https://tarantool.io/en/doc/2.1/dev_guide/building_from_source/.

--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@
 [![Gitter][gitter-badge]][gitter-url]
 [![Google Groups][groups-badge]][groups-url]
 
-http://tarantool.org
+https://tarantool.io/
 
 Tarantool is an in-memory database and application server.
 
 Key features of the application server:
  * 100% compatible drop-in replacement for Lua 5.1,
    based on LuaJIT 2.1.
-   Simply use #!/usr/bin/tarantool instead of
-   #!/usr/bin/lua in your script.
+   Simply use `#!/usr/bin/tarantool` instead of
+   `#!/usr/bin/lua` in your script.
  * full support for Lua modules and a rich set of
    own modules, including cooperative multitasking,
    non-blocking I/O, access to external databases, etc
@@ -30,7 +30,7 @@ Key features of the database:
  * asynchronous master-master replication
  * authentication and access control
  * the database is just a C extension to the
-   app server and can be turned off
+   application server and can be turned off
 
 Supported platforms are Linux/x86 and FreeBSD/x86, Mac OS X.
 
@@ -39,12 +39,12 @@ scalable Web architecture: queue servers, caches,
 stateful Web applications.
 
 To download and install Tarantool as a binary package for your OS, please visit
-https://tarantool.org/en/download/download.html.
+https://tarantool.io/download/download.html.
 
 To build Tarantool from source, see detailed instructions in the Tarantool
-documentation at https://tarantool.org/en/doc/dev_guide/building_from_source.html.
+documentation at https://tarantool.io/en/doc/2.1/dev_guide/building_from_source/.
 
-Please report bugs at http://github.com/tarantool/tarantool/issues
+Please report bugs at https://github.com/tarantool/tarantool/issues
 We also warmly welcome your feedback in the discussion mailing
 list, tarantool@googlegroups.com.
 


### PR DESCRIPTION
The tarantool.org domain now redirects to tarantool.io, so I think the readme file should link to the new domain. Additionally, some of the older links were broken, leading to 404 pages - that should be fixed now.