### PR TITLE
Add .editorconfig to properly detect indentation in editors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[CMakeLists.txt]
+indent_style = space
+indent_size = 4
+
+[*.cmake]
+indent_style = space
+indent_size = 4
+
+[*.lua]
+indent_style = space
+indent_size = 4
+
+[*.{h,c,cc}]
+indent_style = tab
+tab_width = 8


### PR DESCRIPTION
Editorconfig is a standard of defining indentation style and other
settings such as newline types for different file types in a project.

See https://editorconfig.org/

It is achieved by introducing a simple .editorconfig dotfile with
glob expressions and settings per fiile type. Editors then can read
this file and decide which indentation style they should use for a
given project file.

Fixes #3892 