### PR TITLE
Add package.setpath() to set load paths in app entry point

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,6 +48,8 @@ lua_source(lua_sources lua/table.lua)
 lua_source(lua_sources ../third_party/luafun/fun.lua)
 lua_source(lua_sources lua/httpc.lua)
 lua_source(lua_sources lua/iconv.lua)
+lua_source(lua_sources lua/packagepath.lua)
+
 # LuaJIT jit.* library
 lua_source(lua_sources "${CMAKE_BINARY_DIR}/third_party/luajit/src/jit/bc.lua")
 lua_source(lua_sources "${CMAKE_BINARY_DIR}/third_party/luajit/src/jit/bcsave.lua")

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -116,7 +116,8 @@ extern char strict_lua[],
 	trigger_lua[],
 	string_lua[],
 	p_lua[], /* LuaJIT 2.1 profiler */
-	zone_lua[] /* LuaJIT 2.1 profiler */;
+	zone_lua[], /* LuaJIT 2.1 profiler */
+	packagepath_lua[];
 
 static const char *lua_modules[] = {
 	/* Make it first to affect load of all other modules */
@@ -160,6 +161,7 @@ static const char *lua_modules[] = {
 	/* Profiler */
 	"jit.p", p_lua,
 	"jit.zone", zone_lua,
+	"packagepath", packagepath_lua,
 	NULL
 };
 

--- a/src/lua/packagepath.lua
+++ b/src/lua/packagepath.lua
@@ -1,0 +1,50 @@
+-- packagepath.lua
+--
+-- The purpose of package.setpath() is to be called from the
+-- application entry point script to make relative imports and imports
+-- from .rocks subdirectory possible. package.setpath() is recommended
+-- to be called from entrypoint before any require() calls.
+--
+-- Without this if the app is started while current working directory
+-- is not application root, relative require() and attempts to
+-- require() lua packages installed to .rocks will fail, because all
+-- require() calls will load modules relatively to current working
+-- directory.
+
+local fio = require('fio')
+
+local function extend_path(path)
+    package.path = package.path .. ';' .. path
+end
+
+local function extend_cpath(path)
+    package.cpath = package.cpath .. ';' .. path
+end
+
+local function set_script_path()
+    local script_filename = debug.getinfo(2, "S").source:sub(2)
+
+    -- Absolute paths are required because the user can change working
+    -- directory at runtime, for example when calling
+    -- box.cfg{work_dir=...}  Without absolute base dir, the added
+    -- load paths will become invalid.
+    local script_dir = fio.abspath(script_filename:match("(.*/)") or './')
+
+    extend_path(fio.pathjoin(script_dir, '/?.lua'))
+    extend_path(fio.pathjoin(script_dir, '/?/init.lua'))
+    extend_cpath(fio.pathjoin(script_dir, '/?.so'))
+
+    extend_path(fio.pathjoin(script_dir, '/.rocks/share/tarantool/?.lua'))
+    extend_path(fio.pathjoin(script_dir, '/.rocks/share/tarantool/?/init.lua'))
+    extend_cpath(fio.pathjoin(script_dir, '/.rocks/lib/tarantool/?.so'))
+
+    -- On OS X some rocks and apps ship shared libraries as .dylib,
+    -- and others as .so. So we can't exclude .so by default, and just
+    -- add .dylib to the list of options.
+    if jit.os == "OSX" then
+        extend_cpath(fio.pathjoin(script_dir, '/?.dylib'))
+        extend_cpath(fio.pathjoin(script_dir, '/.rocks/lib/tarantool/?.dylib'))
+    end
+end
+
+package.setpath = set_script_path


### PR DESCRIPTION
This patch solves a pressing problem that we have to include a
complicated and non-obvious prologue to many enterprise (and
non-enterprise) apps.

With this patch, users may call package.setpath() in their entry point
script, and the containing directory of that script will be added to
lua load paths, as well as the .rocks subdir.

Without this patch, each app has to handle it on its own.

Supersedes #3777 