### PR TITLE
lenkis/gh 3362 update tutorial

### DIFF
--- a/src/lua/help.lua
+++ b/src/lua/help.lua
@@ -1,5 +1,12 @@
 local doc = require('help.en_US')
 
+-- The built-in tutorial contains links to the online
+-- documentation with a <version> placeholder like
+-- https://tarantool.io/en/doc/<version>/<...>. We should replace
+-- the placeholders with a version of a documentation page that
+-- corresponds to a tarantool version a user runs.
+local DOCUMENTATION_VERSION = '2.1'
+
 help = { doc.help }
 tutorial = {}
 tutorial[1] = help[1]
@@ -33,7 +40,10 @@ local function tutorial_call(table, action)
     elseif screen_id > #doc.tutorial then
         screen_id = #doc.tutorial
     end
-    return doc.tutorial[screen_id]
+    local res = doc.tutorial[screen_id]
+    -- The parentheses are to discard return values except first
+    -- one.
+    return (res:gsub('<version>', DOCUMENTATION_VERSION))
 end
 
 setmetatable(tutorial, { __call = tutorial_call })

--- a/src/lua/help_en_US.lua
+++ b/src/lua/help_en_US.lua
@@ -1,4 +1,4 @@
---- help (en_US)
+--- help (en_US) 2.x
 
 return {
     help = [[

--- a/src/lua/help_en_US.lua
+++ b/src/lua/help_en_US.lua
@@ -7,10 +7,10 @@ To start the interactive Tarantool tutorial, type 'tutorial()'
 
 Available backslash commands:
 
-  \set language <language> for setting language
-  \set delimiter <delimiter> for setting delimiter
-  \help show this screen
-  \quit quit interactive console
+  \set language <language>   -- set language (lua or sql)
+  \set delimiter <delimiter> -- set expression delimiter
+  \help                      -- show this screen
+  \quit                      -- quit interactive console
 ]];
     tutorial = {
     [[

--- a/src/lua/help_en_US.lua
+++ b/src/lua/help_en_US.lua
@@ -2,7 +2,7 @@
 
 return {
     help = [[
-To get help, see the Tarantool manual at https://tarantool.org/doc/
+To get help, see the Tarantool manual at https://tarantool.io/en/doc/
 To start the interactive Tarantool tutorial, type 'tutorial()'
 
 Available backslash commands:
@@ -168,7 +168,7 @@ Tarantool instruction that means <don’t execute
 every time I type Enter; wait until I type a
 special string called the "delimiter".>
 More in the Tarantool manual:
-http://tarantool.org/doc/book/administration.html#requests
+https://tarantool.io/en/doc/<version>/reference/reference_lua/console/#console-delimiter
 
 Request #6 is:
 
@@ -181,7 +181,8 @@ console.delimiter("")!
 but you’ll see "!" in following exercises.
 
 You'll need a custom delimiter only in the trial console at
-http://try.tarantool.org. Tarantool console in production is smarter.
+https://tarantool.io/en/try-dev/.
+Tarantool console in production is smarter.
 It can tell when a multi-line request has not ended (for example,
 if it sees that a function declaration does not have an end keyword,
 as we'll be writing on the next screen).
@@ -309,7 +310,7 @@ tasks each get a slice, but they have to yield
 occasionally so that other tasks get a chance.
 That’s what a properly designed fiber will do.
 More in the Tarantool manual:
-http://tarantool.org/doc/reference/reference_lua/fiber.html
+https://tarantool.io/en/doc/<version>/reference/reference_lua/fiber/
 
 Request #11 is:
 
@@ -345,8 +346,8 @@ Request #12 is:
 function socket_get ()
 local socket, sock, result
 socket = require("socket")
-sock = socket.tcp_connect("tarantool.org", 80)
-sock:send("GET / HTTP/1.0\r\nHost: tarantool.org\r\n\r\n")
+sock = socket.tcp_connect("tarantool.io", 80)
+sock:send("GET / HTTP/1.0\r\nHost: tarantool.io\r\n\r\n")
 result = sock:read(17)
 sock:close()
 return result
@@ -355,12 +356,12 @@ socket_get()!
 --------------------------------
 
 Briefly these requests are opening a socket
-and sending a "GET" request to tarantool.org’s server.
+and sending a "GET" request to tarantool.io’s server.
 The response will be short, for example
 "- "HTTP/1.1 302 OK\r\n""
 but it shows you’ve gotten in touch with a distant server.
 More in the Tarantool manual:
-http://tarantool.org/doc/reference/reference_lua/socket.html
+https://tarantool.io/en/doc/<version>/reference/reference_lua/socket/
 ]];
 
 [[
@@ -378,7 +379,7 @@ and grant read/write access to you, but here
 you’re the "admin" user -- you have administrative
 powers -- so you can start manipulating data immediately.
 More in the Tarantool manual:
-http://tarantool.org/doc/book/box/index.html
+https://tarantool.io/en/doc/<version>/book/box/box_space/#box-space-replace
 
 Request #13 is:
 
@@ -454,7 +455,7 @@ That’s all you need to replace the rest of the fields with
 new values. The syntax of box.replace(), pared down, is:
 box.space.tutor:replace{primary-key-field, other-fields}
 More in the Tarantool manual:
-http://tarantool.org/doc/book/box/box_space.html#lua-function.space_object.replace
+https://tarantool.io/en/doc/<version>/book/box/box_space/#box-space-replace
 Tarantool by default keeps database changes in memory,
 but box.replace() will cause a write to a log, and log
 information can later be consolidated with another box
@@ -483,7 +484,7 @@ But you’ve been confined to a space and an index
 that Tarantool started with.
 Suppose that you want to create your own.
 More in the Tarantool manual:
-http://tarantool.org/doc/getting_started.html#starting-tarantool-and-making-your-first-database
+https://tarantool.io/en/doc/<version>/book/getting_started/using_docker/#creating-a-database
 
 Request #16 is:
 
@@ -507,7 +508,7 @@ Indexes can be declared to be "unique", which
 is important because some combination of the
 fields must be unique, for identification purposes.
 More in the Tarantool manual:
-https://tarantool.org/doc/book/box/data_model.html#index
+https://tarantool.io/en/doc/<version>/book/box/data_model/#index
 
 Request #17 is:
 
@@ -583,7 +584,7 @@ Insert one million tuples with a Lua stored procedure,
 Sum a JSON field for all tuples, and
 Indexed pattern search.
 
-See http://tarantool.org/en/doc/tutorials/lua_tutorials.html
+See https://tarantool.io/en/doc/<version>/tutorials/lua_tutorials/
 
 Request #20 is:
 

--- a/src/lua/help_en_US.lua
+++ b/src/lua/help_en_US.lua
@@ -3,7 +3,7 @@
 return {
     help = [[
 To get help, see the Tarantool manual at https://tarantool.io/en/doc/
-To start the interactive Tarantool tutorial, type 'tutorial()'
+To start the interactive Tarantool tutorial, type 'tutorial()' here.
 
 Available backslash commands:
 
@@ -265,24 +265,24 @@ Obviously it will work, so just type <tutorial("next")!> now.
 ]];
 
 [[
-Tutorial -- Screen #10 -- Packages
-==================================
+Tutorial -- Screen #10 -- Modules
+=================================
 
-Many developers have gone to the trouble of making
-packages of functions (sometimes called "modules")
-that have a general utility.
+Many developers have gone to the trouble of making modules,
+i.e. distributable packages of functions that have a general
+utility. In the Lua world, modules are called "rocks".
 More in the Luarocks list: http://luarocks.org/
 
-Most packages have to be "required", with the syntax
-variable_name = require("package-name")
+Most modules have to be "required", with the syntax
+variable_name = require("module-name")
 which should look familiar because earlier you said
 console = require("console")
 
 At this point, if you just say the variable_name,
-you’ll see a list of the package’s members and
+you’ll see a list of the module’s members and
 functions. If then you use a "." operator as in
-package-variable-name.function_name()
-you’ll invoke a package’s function.
+variable_name.function_name()
+you’ll invoke a module’s function.
 (At a different level you’ll have to use a ":"
 operator, as you’ll see in later examples.)
 
@@ -299,8 +299,8 @@ More on fibers on the next screen, so type <tutorial("next")!> now.
 ]];
 
 [[
-Tutorial -- Screen #11 -- The fiber package
-===========================================
+Tutorial -- Screen #11 -- The fiber module
+==========================================
 
 Make a function that will run like a daemon in the
 background until you cancel it. For this you need
@@ -336,8 +336,8 @@ times and notice how the value mysteriously increases.
 ]];
 
 [[
-Tutorial -- Screen #12 -- The socket package
-============================================
+Tutorial -- Screen #12 -- The socket module
+===========================================
 
 Connect to the Internet and send a message to Tarantool's web-site.
 
@@ -365,8 +365,8 @@ https://tarantool.io/en/doc/<version>/reference/reference_lua/socket/
 ]];
 
 [[
-Tutorial -- Screen #13 -- The box package
-=========================================
+Tutorial -- Screen #13 -- The box module
+========================================
 
 So far you’ve seen Tarantool in action as a
 Lua application server. Henceforth you’ll see
@@ -401,11 +401,11 @@ To understand the description, you just have to know that:
 ** tuples are collections of fields, as are Lua tables
 (vaguely like rows in an SQL DBMS)
 ** spaces are where Tarantool stores sets of tuples
-(vaguely like databases in an SQL DBMS)
+(vaguely like tables in an SQL DBMS)
 ** indexes are objects that make lookups of tuples faster
 (vaguely like indexes in an SQL DBMS)
 Much of the description doesn’t matter right now; it’s
-enough if you see that package box gets a space which is
+enough if you see that module box gets a space which is
 named tutor, and it has one index on the first field.
 ]];
 
@@ -574,11 +574,11 @@ Tutorial -- Screen #20 -- The bigger Tutorials
 ==============================================
 
 You can continue to type in whatever Lua instructions,
-package requires, and database-manipulations you want,
+module requires, and database-manipulations you want,
 here on this screen. But to really get into Tarantool,
 you should download it so that you can be your own
 administrator and create your own permanent databases. The
-Tarantool manual has three significant tutorials:
+Tarantool manual has three significant Lua tutorials:
 
 Insert one million tuples with a Lua stored procedure,
 Sum a JSON field for all tuples, and

--- a/test/box/admin.result
+++ b/test/box/admin.result
@@ -19,10 +19,10 @@ help()
 
     Available backslash commands:
 
-      \set language <language> for setting language
-      \set delimiter <delimiter> for setting delimiter
-      \help show this screen
-      \quit quit interactive console
+      \set language <language>   -- set language (lua or sql)
+      \set delimiter <delimiter> -- set expression delimiter
+      \help                      -- show this screen
+      \quit                      -- quit interactive console
 ...
 cfg_filter(box.cfg)
 ---

--- a/test/box/admin.result
+++ b/test/box/admin.result
@@ -15,7 +15,7 @@ help()
 ---
 - - |
     To get help, see the Tarantool manual at https://tarantool.io/en/doc/
-    To start the interactive Tarantool tutorial, type 'tutorial()'
+    To start the interactive Tarantool tutorial, type 'tutorial()' here.
 
     Available backslash commands:
 

--- a/test/box/admin.result
+++ b/test/box/admin.result
@@ -14,7 +14,7 @@ index = space:create_index('primary')
 help()
 ---
 - - |
-    To get help, see the Tarantool manual at https://tarantool.org/doc/
+    To get help, see the Tarantool manual at https://tarantool.io/en/doc/
     To start the interactive Tarantool tutorial, type 'tutorial()'
 
     Available backslash commands:


### PR DESCRIPTION
When merging to 1.10, please cherry-pick keeping this in mind:

1.
```
  commit 6e7056a7c3a7c881b20437f1a28cc049c07f91e2
  Update help output in test results
```
Amend the help output to match the changes done in these commits:

* 410308b3114a3973c5072599b27c7ae5391f75ed Fix text in built-in tutorial
* c6c44a108a903713da23acb9a2bf92ac257a94e5 Update list of backslash commands in built-in tutorial

2.
```
commit 410308b3114a3973c5072599b27c7ae5391f75ed
Fix text in built-in tutorial
```
Applicable "as is" for both 2.x and 1.10, no amendments required.

3.
```
commit c6c44a108a903713da23acb9a2bf92ac257a94e5
Update list of backslash commands in built-in tutorial
```
Applies only to 2.x, because backslash commands do not work in 1.10.

4.
```
commit 6d181beeeb103f0323badc5434c3b41f5a00e448
Update URLs to online documentation in built-in tutorial
```
Applicable "as is" for both 2.x and 1.10, no amendments required.

5.
```
commit bf8ba1a77e8076e330fe13da7a6f1cb7a6fb8305
Indicate Tarantool version in built-in tutorial
```
Please replace 2.x with 1.10 to avoid confusion for editors.
