### PR TITLE
Add option for disable follow location behavior

### DIFF
--- a/src/httpc.c
+++ b/src/httpc.c
@@ -326,6 +326,13 @@ httpc_set_interface(struct httpc_request *req, const char *interface)
 	curl_easy_setopt(req->curl_request.easy, CURLOPT_INTERFACE, interface);
 }
 
+void
+httpc_set_follow_location(struct httpc_request *req, long follow)
+{
+	curl_easy_setopt(req->curl_request.easy, CURLOPT_FOLLOWLOCATION,
+			 follow);
+}
+
 int
 httpc_execute(struct httpc_request *req, double timeout)
 {

--- a/src/httpc.h
+++ b/src/httpc.h
@@ -303,6 +303,16 @@ void
 httpc_set_interface(struct httpc_request *req, const char *interface);
 
 /**
+ * Specify whether the client will follow 'Location' header that
+ * a server sends as part of an 3xx response.
+ * @param req request
+ * @param follow flag
+ * @see https://curl.haxx.se/libcurl/c/CURLOPT_FOLLOWLOCATION.html
+ */
+void
+httpc_set_follow_location(struct httpc_request *req, long follow);
+
+/**
  * This function does async HTTP request
  * @param request - reference to request object with filled fields
  * @param timeout - timeout of waiting for libcurl api

--- a/src/lua/httpc.c
+++ b/src/lua/httpc.c
@@ -287,6 +287,11 @@ luaT_httpc_request(lua_State *L)
 		httpc_set_interface(req, lua_tostring(L, -1));
 	lua_pop(L, 1);
 
+	lua_getfield(L, 5, "follow_location");
+	if (!lua_isnil(L, -1) && lua_isboolean(L, -1))
+		httpc_set_follow_location(req, lua_toboolean(L, -1));
+	lua_pop(L, 1);
+
 	if (httpc_execute(req, timeout) != 0) {
 		httpc_request_delete(req);
 		return luaT_error(L);

--- a/src/lua/httpc.lua
+++ b/src/lua/httpc.lua
@@ -237,12 +237,14 @@ end
 --  method  - HTTP method, like GET, POST, PUT and so on
 --  url     - HTTP url, like https://tarantool.org/doc
 --  body    - this parameter is optional, you may use it for passing
+--            data to a server. Like 'My text string!'
 --  options - this is a table of options.
---       data to a server. Like 'My text string!'
 --
 --      ca_path - a path to ssl certificate dir;
 --
 --      ca_file - a path to ssl certificate file;
+--
+--      unix_socket - a path to Unix domain socket;
 --
 --      verify_host - set on/off verification of the certificate's name (CN)
 --          against host;
@@ -269,11 +271,19 @@ end
 --          it is less than 2000 bytes/sec
 --          during 20 seconds;
 --
---      timeout - Time-out the read operation and
+--      timeout - time-out the read operation and
 --          waiting for the curl api request
 --          after this amount of seconds;
 --
---      verbose - set on/off verbose mode
+--      max_header_name_length - maximum length of a response header;
+--
+--      verbose - set on/off verbose mode;
+--
+--      interface - source interface for outgoing traffic;
+--
+--      follow_location - whether the client will follow
+--          'Location' header that a server sends as part of an
+--          3xx response;
 --
 --  Returns:
 --      {

--- a/test/app-tap/httpd.py
+++ b/test/app-tap/httpd.py
@@ -15,6 +15,7 @@ def hello():
     body = ["hello world"]
     headers = [('Content-Type', 'application/json')]
     return code, body, headers
+
 def hello1():
     code = "200 OK"
     body = [b"abc"]
@@ -44,12 +45,19 @@ def long_query():
     headers = [('Content-Type', 'application/json')]
     return code, body, headers
 
+def redirect():
+    code = "302 Found"
+    body = "redirecting"
+    headers = [('Location', '/')]
+    return code, body, headers
+
 paths = {
         "/": hello,
         "/abc": hello1,
         "/absent": absent,
         "/headers": headers,
         "/long_query": long_query,
+        "/redirect": redirect,
         }
 
 def read_handle(env, response):


### PR DESCRIPTION
@TarantoolBot document
Title: 'follow_location' http.client option
It allows disable follow location behavior used by default by set 0
For additional info see https://curl.haxx.se/libcurl/c/CURLOPT_FOLLOWLOCATION.html