### PR TITLE
travis-ci: set jobs not to stop on failed tests

### DIFF
--- a/.travis.mk
+++ b/.travis.mk
@@ -42,7 +42,7 @@ deps_ubuntu:
 test_ubuntu: deps_ubuntu
 	cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfoWError ${CMAKE_EXTRA_PARAMS}
 	make -j8
-	cd test && /usr/bin/python test-run.py -j 1
+	cd test && /usr/bin/python test-run.py --force -j 1
 
 deps_osx:
 	brew update
@@ -59,13 +59,13 @@ test_osx: deps_osx
 	ulimit -S -n 20480 || :
 	ulimit -n
 	make -j8
-	cd test && python test-run.py -j 1 unit/ app/ app-tap/ box/ box-tap/
+	cd test && python test-run.py --force -j 1 unit/ app/ app-tap/ box/ box-tap/
 
 coverage_ubuntu: deps_ubuntu
 	cmake . -DCMAKE_BUILD_TYPE=Debug -DENABLE_GCOV=ON
 	make -j8
 	# Enable --long tests for coverage
-	cd test && /usr/bin/python test-run.py -j 1 --long
+	cd test && /usr/bin/python test-run.py --force -j 1 --long
 	lcov --compat-libtool --directory src/ --capture --output-file coverage.info.tmp
 	lcov --compat-libtool --remove coverage.info.tmp 'tests/*' 'third_party/*' '/usr/*' \
 		--output-file coverage.info


### PR DESCRIPTION
Added --force flag to travis-ci jobs not to stop on failed tests.
Due to any found failed test breaks the testing it masks the other
fails and in the following ways it's not good:
- flaky test masks real problem
- release testing needs overall result to fix it fast
- parallel testing may produce flaky test

Close: #4131