### PR TITLE
Add cli option to setup app's dir as require root

### DIFF
--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -611,10 +611,6 @@ run_script_f(va_list ap)
 			lua_pushstring(L, appdir_realpath);
 			lua_call(L, 1, 0);
 
-			lua_getfield(L, -1, "add_modules_loadpaths");
-			lua_pushstring(L, appdir_realpath);
-			lua_call(L, 1, 0);
-
 			lua_pop(L, 1);
 			break;
 		case 'l':

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -608,31 +608,12 @@ run_script_f(va_list ap)
 			lua_getfield(L, -1, "set_appdir");
 			if (lua_isfunction(L, -1) == 0)
 				panic("No package.set_appdir specified");
-			lua_pushstring(L, optv[i + 1]);
+			lua_pushstring(L, appdir_realpath);
 			lua_call(L, 1, 0);
 
-			lua_getfield(L, -1, "path");
-			const char *package_path = lua_tostring(L, -1);
-			lua_pop(L, 1);
-
-			lua_getfield(L, -1, "cpath");
-			const char *package_cpath = lua_tostring(L, -1);
-			lua_pop(L, 1);
-
-			int top = lua_gettop(L);
+			lua_getfield(L, -1, "add_modules_loadpaths");
 			lua_pushstring(L, appdir_realpath);
-			lua_pushliteral(L, "/?.lua;");
-			lua_pushstring(L, appdir_realpath);
-			lua_pushliteral(L, "/?/init.lua;");
-			lua_pushstring(L, package_path);
-			lua_concat(L, lua_gettop(L) - top);
-			lua_setfield(L, top, "path");
-
-			lua_pushstring(L, appdir_realpath);
-			lua_pushliteral(L, "/?.so");
-			lua_pushstring(L, package_cpath);
-			lua_concat(L, lua_gettop(L) - top);
-			lua_setfield(L, top, "cpath");
+			lua_call(L, 1, 0);
 
 			lua_pop(L, 1);
 			break;

--- a/src/lua/init.lua
+++ b/src/lua/init.lua
@@ -56,6 +56,20 @@ local function get_appdir()
     return package_appdir or fio.cwd()
 end
 
+local function extend_path(path)
+    package.path = path .. ';' .. package.path
+end
+
+local function extend_cpath(path)
+    package.cpath = path .. ';' .. package.cpath
+end
+
+local function add_modules_loadpaths(path)
+    extend_path(path .. '/?/init.lua')
+    extend_path(path .. '/?.lua')
+    extend_cpath(path .. '/?.so')
+end
+
 dostring = function(s, ...)
     local chunk, message = loadstring(s)
     if chunk == nil then
@@ -217,6 +231,8 @@ table.insert(package.loaders, 5, rocks_loader_func(true))
 package.search = search
 package.set_appdir = set_appdir
 package.get_appdir = get_appdir
+package.set_rocks_loadpaths = set_appdir
+package.add_modules_loadpaths = add_modules_loadpaths
 
 return {
     uptime = uptime;


### PR DESCRIPTION
Currently, `require` loads rocks and modules relatively to CWD. It is
often usefull to keep all dependencies close to start script.

But if someone tries to start a script from a directory different than
CWD, i.e.:

```
$ tarantool myapp/init.lua
```
It won't look into dependencies installed under `myapp` directory.

This patch adds a new option `--appdir/-a` to the tarantool cli. It also
adds new helpers `package.set_appdir` and `package.get_appdir` which is
accessible within lua. `package.script_dir` field is set to an absolute path
where init script is located. If no script was specified, it sets
script_dir to CWD.

This lets user to customize the behaviour how dependencies are
loaded. If appdir is specified, than require will look for all dependencies
relatively to it.

```
$ tarantool --appdir=myapp myapp/init.lua
```

If not, user may also set appdir from within lua using
`package.set_appdir('myapp')`. But this will only affect how rocks
dependencies are loaded. If local modules and libs are needed to be
loaded, user may use `package.script_dir` to manually extend
`package.path` and `package.cpath`