### PR TITLE
Static build: Export symbols from common libraries for tarantool binary

### DIFF
--- a/.travis.mk
+++ b/.travis.mk
@@ -49,7 +49,7 @@ test_ubuntu: deps_ubuntu
 
 deps_osx:
 	brew update
-	brew install openssl readline curl icu4c --force
+	brew install openssl readline curl icu4c lz4 --force
 	python2 -V || brew install python2 --force
 	curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python
 	pip install -r test-run/requirements.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,6 +312,13 @@ else()
 endif()
 
 #
+# LZ4
+#
+
+find_package(LZ4)
+set(LZ4_LIBRARIES ${LZ4_LIBRARY})
+
+#
 # OpenSSL
 #
 find_package(OpenSSL)
@@ -356,6 +363,15 @@ find_package(ICONV)
 
 set(ICU_FIND_REQUIRED ON)
 find_package(ICU)
+
+#
+# Sasl
+#
+
+if(ENABLE_SASL)
+    set(Sasl_FIND_REQUIRED ON)
+    find_package(Sasl)
+endif()
 
 #
 # LuaJIT

--- a/Dockerfile.staticbuild
+++ b/Dockerfile.staticbuild
@@ -8,8 +8,8 @@ RUN set -x \
         libstdc++ \
         libstdc++-static \
         readline \
-        openssl \
         lz4 \
+        lz4-static \
         binutils \
         ncurses \
         libgomp \
@@ -69,6 +69,19 @@ RUN set -x && \
     ./configure --enable-static --enable-shared && \
     make && make install
 
+RUN set -x && \
+    LD_LIBRARY_PATH=/usr/local/lib64 curl -O -L https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-2.1.27/cyrus-sasl-2.1.27.tar.gz && \
+    tar -xvf cyrus-sasl-2.1.27.tar.gz && \
+    cd cyrus-sasl-2.1.27 && \
+    LD_LIBRARY_PATH=/usr/local/lib64 LIBS=" -lssl -lcrypto -ldl" ./configure --enable-static --enable-shared  --enable-krb4 --prefix /usr && \
+    make && make install
+
+RUN set -x && \
+    LD_LIBRARY_PATH=/usr/local/lib64 curl -O -L https://github.com/facebook/zstd/releases/download/v1.4.0/zstd-1.4.0.tar.gz && \
+    tar -xvf zstd-1.4.0.tar.gz && \
+    cd zstd-1.4.0 && \
+    make && make install
+
 COPY . /tarantool
 
 RUN set -x && \
@@ -81,6 +94,8 @@ RUN set -x \
        cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
              -DENABLE_DIST:BOOL=ON \
              -DBUILD_STATIC=ON \
+             -DENABLE_SASL=ON \
+             -DENABLE_BUNDLED_ZSTD=OFF \
              -DOPENSSL_USE_STATIC_LIBS=ON \
              .) \
     && make -C /tarantool -j

--- a/cmake/FindLz4.cmake
+++ b/cmake/FindLz4.cmake
@@ -1,0 +1,25 @@
+find_path(LZ4_INCLUDE_DIR NAMES lz4.h)
+
+if(BUILD_STATIC)
+	find_library(LZ4_STATIC NAMES ${CMAKE_STATIC_LIBRARY_PREFIX}lz4${CMAKE_STATIC_LIBRARY_SUFFIX})
+endif()
+find_library(LZ4_LIBRARY NAMES ${CMAKE_SHARED_LIBRARY_PREFIX}lz4${CMAKE_SHARED_LIBRARY_SUFFIX})
+
+if(BUILD_STATIC)
+    set(LZ4_FIND_REQUIRED ON)
+endif()
+
+if (LZ4_INCLUDE_DIR AND LZ4_LIBRARY)
+	if (NOT BUILD_STATIC OR (BUILD_STATIC AND LZ4_STATIC))
+		set(LZ4_FOUND ON)
+	endif()
+endif()
+
+if (LZ4_FOUND)
+	message(STATUS "Found lz4 includes: ${LZ4_INCLUDE_DIR}/lz4.h")
+	message(STATUS "Found lz4 library: ${LZ4_LIBRARY}")
+else()
+	if (LZ4_FIND_REQUIRED)
+		message(FATAL_ERROR "Could not find liblz4 development files")
+	endif()
+endif()

--- a/cmake/FindSasl.cmake
+++ b/cmake/FindSasl.cmake
@@ -1,0 +1,38 @@
+# Support preference of static libs by adjusting CMAKE_FIND_LIBRARY_SUFFIXES
+if(BUILD_STATIC)
+    set(_sasl_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a )
+
+    find_library(SASL_LIB NAMES sasl2)
+    file(GLOB_RECURSE SASL_PLUGIN_LIBRARIES "/usr/lib/sasl2/*.a" "/usr/local/lib/sasl2/*.a")
+else()
+    find_library(SASL_LIB NAMES sasl2)
+endif()
+
+
+find_path(SASL_INCLUDE_DIRS sasl/sasl.h)
+
+
+if(SASL_INCLUDE_DIRS AND SASL_LIB)
+  set(SASL_FOUND TRUE)
+  set(SASL_LIBRARIES ${SASL_LIB} ${SASL_PLUGIN_LIBRARIES})
+endif(SASL_INCLUDE_DIRS AND SASL_LIB)
+
+
+if(SASL_FOUND)
+  if(NOT Sasl_FIND_QUIETLY)
+    message(STATUS "SASL include dir: ${SASL_INCLUDE_DIRS}")
+    message(STATUS "SASL libraries: ${SASL_LIBRARIES}")
+  endif(NOT Sasl_FIND_QUIETLY)
+else(SASL_FOUND)
+  if (Sasl_FIND_REQUIRED)
+    message(FATAL_ERROR "Could NOT find sasl")
+  endif (Sasl_FIND_REQUIRED)
+endif(SASL_FOUND)
+
+MARK_AS_ADVANCED(SASL_INCLUDE_DIRS SASL_LIBRARIES)
+
+# Restore the original find library ordering
+if(BUILD_STATIC)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ${_sasl_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,9 @@ include_directories(${MSGPUCK_INCLUDE_DIRS})
 include_directories(${CURL_INCLUDE_DIRS})
 include_directories(${ICU_INCLUDE_DIRS})
 include_directories(${ICONV_INCLUDE_DIRS})
+include_directories(${SASL_INCLUDE_DIRS})
+include_directories(${LZ4_INCLUDE_DIR})
+include_directories(${ZSTD_INCLUDE_DIRS})
 
 set(LIBUTIL_FREEBSD_SRC ${CMAKE_SOURCE_DIR}/third_party/libutil_freebsd)
 include_directories(${LIBUTIL_FREEBSD_SRC})
@@ -169,10 +172,25 @@ add_library(server STATIC ${server_sources})
 target_link_libraries(server core coll http_parser bit uri uuid swim swim_udp
                       swim_ev crypto)
 
+if(BUILD_STATIC)
+    set(Z_STATIC libz.a)
+    set(ZZIP_STATIC libzzip.a)
+endif()
+
+find_library(Z_LIBRARY NAMES ${Z_STATIC} z)
+find_library(ZZIP_LIBRARY NAMES ${ZZIP_STATIC} zzip)
+
 # Rule of thumb: if exporting a symbol from a static library, list the
 # library here.
 set (reexport_libraries server core misc bitset csv swim swim_udp swim_ev
-     ${LUAJIT_LIBRARIES} ${MSGPUCK_LIBRARIES} ${ICU_LIBRARIES})
+     ${LUAJIT_LIBRARIES}
+     ${MSGPUCK_LIBRARIES}
+     ${ICU_LIBRARIES}
+     ${LZ4_STATIC}
+     ${Z_STATIC}
+     ${SASL_LIB}
+     ${ZSTD_LIBRARIES}
+    )
 
 set (common_libraries
     ${reexport_libraries}
@@ -181,6 +199,7 @@ set (common_libraries
     ${CURL_LIBRARIES}
     ${ICONV_LIBRARIES}
     ${OPENSSL_LIBRARIES}
+    ${SASL_LIBRARIES}
 )
 
 if (TARGET_OS_LINUX OR TARGET_OS_DEBIAN_FREEBSD)
@@ -214,7 +233,13 @@ if(BUILD_STATIC)
             ${READLINE_LIBRARIES}
             ${CURL_LIBRARIES}
             ${OPENSSL_LIBRARIES}
-            ${ICU_LIBRARIES})
+            ${ICU_LIBRARIES}
+            ${SASL_LIBRARIES}
+            ${Z_STATIC}
+            ${ZZIP_STATIC}
+            ${LZ4_STATIC}
+            ${ZSTD_LIBRARIES}
+        )
         if (${libstatic} MATCHES "lib[^/]+.a")
             string(REGEX MATCH "lib[^/]+.a" libname ${libstatic})
             string(REGEX REPLACE "\\.a$" "" libname ${libname})


### PR DESCRIPTION
This commit exports symbols from some libraries such as:

- cyrus sasl
- zlib
- zzip
- lz4
- zstd

This is usefull for a static build so there is no need for all those
modules from tarantool ecosystem which would build statically
to link these dependencies inside itself.

To be able to export ZSTD symbols correctly, it is necessary to first
    build zstd and then start cmake where "mkexports" machinery export all
    static libs symbols.

Fixes #4225