### PR TITLE
Display tarantool distribution in box.info.version

### DIFF
--- a/src/box/lua/info.c
+++ b/src/box/lua/info.c
@@ -610,7 +610,7 @@ lbox_info_init_static_values(struct lua_State *L)
 {
 	/* tarantool version */
 	lua_pushstring(L, "version");
-	lua_pushstring(L, tarantool_version());
+	lua_pushfstring(L, "%s %s", tarantool_package(), tarantool_version());
 	lua_settable(L, -3);
 }
 

--- a/test/box/info.result
+++ b/test/box/info.result
@@ -15,7 +15,7 @@ box.info['unknown_variable']
 ---
 - null
 ...
-string.match(box.info.version, '^[1-9]') ~= nil
+string.match(box.info.version, '^[%a%s]*[1-9]') ~= nil
 ---
 - true
 ...

--- a/test/box/info.test.lua
+++ b/test/box/info.test.lua
@@ -5,7 +5,7 @@ fiber = require('fiber')
 box.info.unknown_variable
 box.info[23]
 box.info['unknown_variable']
-string.match(box.info.version, '^[1-9]') ~= nil
+string.match(box.info.version, '^[%a%s]*[1-9]') ~= nil
 string.match(box.info.pid, '^[1-9][0-9]*$') ~= nil
 box.info.id > 0
 box.info.uuid == box.space._cluster:get(box.info.id)[2]


### PR DESCRIPTION
Allows runtime code to detect current distribution in
box.info.version.
Before: 2.2.0-300-g7f9f420e5
After: Tarantool Enterprise 2.2.0-300-g7f9f420e5

Make it consistent with cmd tarantool --version