### PR TITLE
Add distribution info to box.info

### DIFF
--- a/src/box/lua/info.c
+++ b/src/box/lua/info.c
@@ -534,6 +534,9 @@ lbox_info_init_static_values(struct lua_State *L)
 	lua_pushstring(L, "version");
 	lua_pushstring(L, tarantool_version());
 	lua_settable(L, -3);
+	lua_pushstring(L, "package");
+	lua_pushstring(L, tarantool_package());
+	lua_settable(L, -3);
 }
 
 /**

--- a/test/box/info.result
+++ b/test/box/info.result
@@ -79,6 +79,7 @@ t
   - id
   - lsn
   - memory
+  - package
   - pid
   - replication
   - ro


### PR DESCRIPTION
There is compile time option PACKAGE in cmake to define
current build distribution info. For community edition
is it Tarantool by default. For entreprise it is
Tarantool Entreprise.

There were no option to check distribution name in runtime.
This change adds box.info.package output for CE and TE.

CE box.info.package -> Tarantool
TE box.info.package -> Tarantool Entreprise