### PR TITLE
test: box/net.box test flaky fails on grep_log

### DIFF
--- a/test/box/net.box.result
+++ b/test/box/net.box.result
@@ -1374,7 +1374,7 @@ test_run:cmd("setopt delimiter ''");
 ---
 - true
 ...
-test_run:grep_log("default", "ER_NO_SUCH_PROC")
+test_run:wait_log('default', 'ER_NO_SUCH_PROC', nil, 10)
 ---
 - ER_NO_SUCH_PROC
 ...

--- a/test/box/net.box.test.lua
+++ b/test/box/net.box.test.lua
@@ -537,7 +537,7 @@ _ = fiber.create(
    end
 );
 test_run:cmd("setopt delimiter ''");
-test_run:grep_log("default", "ER_NO_SUCH_PROC")
+test_run:wait_log('default', 'ER_NO_SUCH_PROC', nil, 10)
 box.schema.user.revoke('guest', 'execute', 'universe')
 
 --


### PR DESCRIPTION
box/net.box test flaky failed on grepping the log file
for 'ER_NO_SUCH_PROC' pattern on high load running hosts,
found that the issue can be resolved by updating the
grep_log to wait_log function to make able to wait the
needed message for some time.

[008] Test failed! Result content mismatch:
[008] --- box/net.box.result	Tue Jul  9 17:00:24 2019
[008] +++ box/net.box.reject	Tue Jul  9 17:03:34 2019
[008] @@ -1376,7 +1376,7 @@
[008]  ...
[008]  test_run:grep_log("default", "ER_NO_SUCH_PROC")
[008]  ---
[008] -- ER_NO_SUCH_PROC
[008] +- null
[008]  ...
[008]  box.schema.user.revoke('guest', 'execute', 'universe')
[008]  ---

Closes #4329