### PR TITLE
travis-ci: apt-get fails to update the APT repos

### DIFF
--- a/.travis.mk
+++ b/.travis.mk
@@ -29,6 +29,7 @@ docker_%:
 		-e COVERALLS_TOKEN=${COVERALLS_TOKEN} \
 		-e TRAVIS_JOB_ID=${TRAVIS_JOB_ID} \
 		-e CMAKE_EXTRA_PARAMS=${CMAKE_EXTRA_PARAMS} \
+		-e APT_EXTRA_FLAGS="${APT_EXTRA_FLAGS}" \
 		-e CC=${CC} \
 		-e CXX=${CXX} \
 		${DOCKER_IMAGE} \
@@ -39,7 +40,7 @@ docker_%:
 #########
 
 deps_debian:
-	apt-get update && apt-get install -y -f \
+	apt-get update ${APT_EXTRA_FLAGS} && apt-get install -y -f \
 		build-essential cmake coreutils sed \
 		libreadline-dev libncurses5-dev libyaml-dev libssl-dev \
 		libcurl4-openssl-dev libunwind-dev libicu-dev \

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,14 @@ jobs:
           TARGET=test
           CMAKE_EXTRA_PARAMS=-DENABLE_LTO=ON
           DOCKER_IMAGE=packpack/packpack:debian-buster
+          APT_EXTRA_FLAGS="--allow-releaseinfo-change-version --allow-releaseinfo-change-suite"
         if: branch = "master"
       - name: "LTO build + test (Linux, clang)"
         env: >
           TARGET=test
           CMAKE_EXTRA_PARAMS=-DENABLE_LTO=ON
           DOCKER_IMAGE=packpack/packpack:debian-buster
+          APT_EXTRA_FLAGS="--allow-releaseinfo-change-version --allow-releaseinfo-change-suite"
         if: branch = "master"
         compiler: clang
       - name: "LTO build + test (OS X Mojave 10.14)"


### PR DESCRIPTION
travis-ci APT repository update failed on Debian 10 (Buster)
with command 'apt-get update', like:

Get:1 http://deb.debian.org/debian buster InRelease [118 kB]
Get:2 http://security.debian.org/debian-security buster/updates InRelease [39.1 kB]
Get:3 http://deb.debian.org/debian buster-updates InRelease [46.8 kB]
Reading package lists... Done
N: Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Version' value from '' to '10'
E: Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'testing' to 'stable'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
N: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Version' value from '' to '10.0'
E: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'testing' to 'stable'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
E: Repository 'http://deb.debian.org/debian buster-updates InRelease' changed its 'Suite' value from 'testing-updates' to 'stable-updates'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.

The cause of the issue was:

According to Debian Project News published 1st of July, Debian 10 "Buster"
was scheduled to transition from testing to stable on 2019-07-06.
It looks like the transition was in fact performed as scheduled, and so the
testing distribution should now be catching up witn unstable, to eventually
become Debian 11 "Bullseye". You might be experiencing some temporary side
effects because of this transition of the Debian mirrors.
If you want to stay with Debian 10 "Buster", now would be a good time to switch
your /etc/apt/sources.list to use the release name buster instead of testing.
Otherwise, you'll soon be getting the raw bleeding-edge stuff from unstable,
and you might accidentally get a partial upgrade to proto-"Bullseye".
Also, this is a reminder for anyone using the word stable in their
/etc/apt/sources.list to consider whether to change it to stretch and stay with
the old version, or read the Release Notes and perform the recommended upgrade
steps.

To fix the issue it had to accept interactively the changes in the repositories
NOTE: apt instead of apt-get can accept the changes interactively

apt update -y

either accept only the needed changes for 'version' and 'suite'

apt-get update --allow-releaseinfo-change-version --allow-releaseinfo-change-suite

Seems that the only 'version' and 'suite' accept is better than blind
accept of the all changes.

Closes #4331