### PR TITLE
tarantoolctl: always initialize notify_socket

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -555,7 +555,6 @@ load_cfg()
 			cfg_getb("log_nonblock"),
 			log_format,
 			background);
-	systemd_init();
 
 	if (background)
 		daemonize();
@@ -795,6 +794,7 @@ main(int argc, char **argv)
 	cbus_init();
 	coll_init();
 	crypto_init();
+	systemd_init();
 	tarantool_lua_init(tarantool_bin, main_argc, main_argv);
 
 	start_time = ev_monotonic_time();


### PR DESCRIPTION
Notify socket used to be initialized during `box.cfg()`.
There is no apparent reason for that, because we can write tarantool
apps that don't use box api at all, but still leverage the event loop
and async operations.

This patch makes initialization of notify socket independent.
Instance can notify entering event loop even if box.cfg wasn't called.

Closes #4305