### PR TITLE
test: need ASAN testing in commit process

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,6 +65,14 @@ release_lto_clang8:
   script:
     - ${GITLAB_MAKE} test_debian_no_deps
 
+release_asan_clang8:
+  image: ${IMAGE_TEST_LTO}
+  stage: test
+  tags:
+    - docker_test
+  script:
+    - ${GITLAB_MAKE} test_asan_debian_no_deps
+
 osx_13_release:
   only:
     refs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,17 +38,19 @@ jobs:
         os: osx
         osx_image: xcode9.4
         if: branch = "master"
-      # Special targets (only LTO for now).
+      # Special targets for LTO.
       - name: "LTO build + test (Linux, gcc)"
         env: >
-          TARGET=test
+          TARGET=lto
           CMAKE_EXTRA_PARAMS=-DENABLE_LTO=ON
           DOCKER_IMAGE=packpack/packpack:debian-buster
           APT_EXTRA_FLAGS="--allow-releaseinfo-change-version --allow-releaseinfo-change-suite"
         if: branch = "master"
-      - name: "LTO build + test (Linux, clang)"
+      - name: "LTO build + test (Linux, clang8)"
         env: >
-          TARGET=test
+          TARGET=lto_clang8
+          CC=clang-8
+          CXX=clang++-8
           CMAKE_EXTRA_PARAMS=-DENABLE_LTO=ON
           DOCKER_IMAGE=packpack/packpack:debian-buster
           APT_EXTRA_FLAGS="--allow-releaseinfo-change-version --allow-releaseinfo-change-suite"
@@ -58,6 +60,12 @@ jobs:
         os: osx
         env: TARGET=test CMAKE_EXTRA_PARAMS=-DENABLE_LTO=ON
         if: branch = "master"
+      # Special targets for ASAN.
+      - name: "ASAN build + test (Linux, clang8)"
+        env: >
+          TARGET=asan
+          DOCKER_IMAGE=packpack/packpack:debian-buster
+          APT_EXTRA_FLAGS="--allow-releaseinfo-change-version --allow-releaseinfo-change-suite"
       # Deploy targets (they also catch distro-specific problems).
       - name: "Create and deploy tarball"
         env: TARGET=source

--- a/test/app-tap/json.skipcond
+++ b/test/app-tap/json.skipcond
@@ -1,0 +1,7 @@
+import os
+
+# Disabled at ASAN build due to issue #4360.
+if os.getenv("ASAN") == 'ON':
+    self.skip = 1
+
+# vim: set ft=python:

--- a/test/unit/guard.skipcond
+++ b/test/unit/guard.skipcond
@@ -1,0 +1,7 @@
+import os
+
+# Disabled at ASAN build due to issue #4360.
+if os.getenv("ASAN") == 'ON':
+    self.skip = 1
+
+# vim: set ft=python:

--- a/test/unit/msgpack.skipcond
+++ b/test/unit/msgpack.skipcond
@@ -1,0 +1,7 @@
+import os
+
+# Disabled at ASAN build due to issue #4360.
+if os.getenv("ASAN") == 'ON':
+    self.skip = 1
+
+# vim: set ft=python:


### PR DESCRIPTION
Added ASAN tesing in commit process, used clang-8 for
ASAN build under debian-buster image. Added for testing
only the passing test suites, the rest of the tests
not used and will be enabled durring issue #4360. Also
fixed job for testing LTO with clang on debian-buster
in travis-ci, changed it to the same as in gitlab-ci,
changed default clang to clang-8.

Closes #4359