### PR TITLE
Enable support for NOTIFY_SOCKET on macOS

### DIFF
--- a/src/trivia/config.h.cmake
+++ b/src/trivia/config.h.cmake
@@ -201,11 +201,6 @@
  */
 #cmakedefine HAVE_ICU_STRCOLLUTF8 1
 
-/*
-* Defined if systemd is enabled
- */
-#cmakedefine WITH_SYSTEMD 1
-
 /** \cond public */
 
 /** System configuration dir (e.g /etc) */


### PR DESCRIPTION
Please see results in https://github.com/tarantool/tarantool/search?q=-DWITH_SYSTEMD&unscoped_q=-DWITH_SYSTEMD . Should this flags be removed?

UPD. NOTIFY_SOCKET is used in #4381. This PR make is required to make updated tarantoolctl work on macOS.