### PR TITLE
Expose log.init function from log module

### DIFF
--- a/extra/exports
+++ b/extra/exports
@@ -52,6 +52,7 @@ tt_uuid_is_equal
 tt_uuid_is_nil
 tt_uuid_bswap
 tt_uuid_from_string
+log_initialized
 log_level
 log_format
 uri_parse
@@ -73,6 +74,7 @@ log_type
 say_set_log_level
 say_logrotate
 say_set_log_format
+say_logger_init
 tarantool_uptime
 tarantool_exit
 log_pid

--- a/src/lib/core/say.c
+++ b/src/lib/core/say.c
@@ -50,6 +50,8 @@
 
 pid_t log_pid = 0;
 int log_level = S_INFO;
+bool log_initialized = false;
+
 enum say_format log_format = SF_PLAIN;
 enum { SAY_SYSLOG_DEFAULT_PORT = 512 };
 
@@ -701,6 +703,7 @@ say_logger_init(const char *init_str, int level, int nonblock,
 			dup2(log_default->fd, STDOUT_FILENO);
 		}
 	}
+	log_initialized = true;
 	return;
 fail:
 	diag_log();

--- a/src/lib/core/say.h
+++ b/src/lib/core/say.h
@@ -69,6 +69,7 @@ enum say_format {
 };
 
 extern int log_level;
+extern bool log_initialized;
 
 static inline bool
 say_log_level_is_enabled(int level)

--- a/test/app-tap/logger_init.test.lua
+++ b/test/app-tap/logger_init.test.lua
@@ -1,0 +1,42 @@
+#!/usr/bin/env tarantool
+
+local test = require('tap').test('log')
+test:plan(4)
+
+local filename = "1.log"
+local message = "Hello, World!"
+
+local log = require('log')
+log.init({init_str = filename})
+
+local file = io.open(filename)
+
+while file:read() do
+end
+
+log.info(message)
+test:is(file:read():match('I>%s+(.*)'), message, 'logging works without box.cfg{}')
+
+log.verbose(message)
+test:isnil(file:read(), 'Default log level is 5 (INFO)')
+
+log.level(6)
+
+message = 'updates log level works'
+log.verbose(message)
+test:is(file:read():match('V>%s+(.*)'), message, 'verbose logging')
+
+box.cfg{
+	memtx_memory=107374182
+}
+
+while file:read() do
+end
+
+message = 'calling box.cfg does not reset logging level'
+log.verbose(message)
+test:is(file:read():match('V>%s+(.*)'), message, 'verbose logging after box.cfg')
+
+file:close()
+test:check()
+os.exit()


### PR DESCRIPTION
This now allows to initialize logging subsystem without calling box.cfg.
This is helpful when you want to do something before database
initialization (i.e. setup cluster connections)

Closes #689 