### PR TITLE
Export tarantool_package symbol

### DIFF
--- a/extra/exports
+++ b/extra/exports
@@ -69,6 +69,7 @@ log_type
 say_set_log_level
 say_logrotate
 say_set_log_format
+tarantool_package
 tarantool_uptime
 tarantool_exit
 log_pid


### PR DESCRIPTION
There is compile time option PACKAGE in cmake to define
current build distribution info. For community edition
is it "Tarantool" by default and "Tarantool Enterprise" for the
enterprise version.

It's displayed in console greeting and in `box.info().package`,
but, unfortunately, it can't be accessed before `box.cfg` neither
from Lua API, neither with FFI.

This patch exports `tarantool_package` symbol making it accessible with
FFI.