### PR TITLE
Expose tarantool_package value to lua api

### DIFF
--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -390,6 +390,10 @@ luaopen_tarantool(lua_State *L)
 	};
 	luaL_register_module(L, "tarantool", initlib);
 
+	/* package */
+	lua_pushstring(L, tarantool_package());
+	lua_setfield(L, -2, "package");
+
 	/* version */
 	lua_pushstring(L, tarantool_version());
 	lua_setfield(L, -2, "version");

--- a/test/app-tap/info.test.lua
+++ b/test/app-tap/info.test.lua
@@ -3,8 +3,9 @@
 local tarantool = require('tarantool')
 
 require('tap').test("info", function(test)
-    test:plan(8)
+    test:plan(9)
     test:like(tarantool.version, '^[1-9]', "version")
+    test:isstring(tarantool.package, "package")
     test:ok(_TARANTOOL == tarantool.version, "version")
     test:isstring(tarantool.build.target, "build.target")
     test:isstring(tarantool.build.compiler, "build.compiler")


### PR DESCRIPTION
There is compile time option PACKAGE in cmake to define
current build distribution info. By default it's
"Tarantool" for the community version and "Tarantool Enterprise"
for the enterprise version.

It's displayed in console greeting and in `box.info().package`,
but, unfortunately, it can't be accessed from Lua before `box.cfg`.

This patch exposes `require('tarantool').package`.

Close #4408