### PR TITLE
Add proxy server options for curl

### DIFF
--- a/src/httpc.c
+++ b/src/httpc.c
@@ -321,6 +321,24 @@ httpc_set_ssl_cert(struct httpc_request *req, const char *ssl_cert)
 }
 
 void
+httpc_set_proxy(struct httpc_request *req, const char *proxy)
+{
+	curl_easy_setopt(req->curl_request.easy, CURLOPT_PROXY, proxy);
+}
+
+void
+httpc_set_proxy_port(struct httpc_request *req, long port)
+{
+	curl_easy_setopt(req->curl_request.easy, CURLOPT_PROXYPORT, port);
+}
+
+void
+httpc_set_proxy_userpwd(struct httpc_request *req, const char *userpwd)
+{
+	curl_easy_setopt(req->curl_request.easy, CURLOPT_PROXYUSERPWD, userpwd);
+}
+
+void
 httpc_set_interface(struct httpc_request *req, const char *interface)
 {
 	curl_easy_setopt(req->curl_request.easy, CURLOPT_INTERFACE, interface);

--- a/src/httpc.h
+++ b/src/httpc.h
@@ -292,6 +292,36 @@ void
 httpc_set_ssl_cert(struct httpc_request *req, const char *ssl_cert);
 
 /**
+ * Specify a proxy to use
+ * @param req request
+ * @param proxy - a host name or an IP address. The application does not
+ * have to keep the string around after setting this option.
+ * @see https://curl.haxx.se/libcurl/c/CURLOPT_PROXY.html
+ */
+void
+httpc_set_proxy(struct httpc_request *req, const char *proxy);
+
+/**
+ * Specify a port number the proxy listens on
+ * @param req request
+ * @param port - a port number the proxy listens on
+ * @see https://curl.haxx.se/libcurl/c/CURLOPT_PROXYPORT.html
+ */
+void
+httpc_set_proxy_port(struct httpc_request *req, long port);
+
+/**
+ * Specify a user name and a password to use in authentication
+ * @param req request
+ * @param userpwd - a login details string for the connection.
+ * The format is: [user name]:[password]. The application does not
+ * have to keep the string around after setting this option.
+ * @see https://curl.haxx.se/libcurl/c/CURLOPT_USERPWD.html
+ */
+void
+httpc_set_proxy_userpwd(struct httpc_request *req, const char *userpwd);
+
+/**
  * Specify source interface for outgoing traffic
  * @param req request
  * @param interface - interface name to use as outgoing network interface.

--- a/src/lua/httpc.c
+++ b/src/lua/httpc.c
@@ -240,6 +240,21 @@ luaT_httpc_request(lua_State *L)
 		httpc_set_ssl_cert(req, lua_tostring(L, -1));
 	lua_pop(L, 1);
 
+	lua_getfield(L, 5, "proxy");
+	if (!lua_isnil(L, -1))
+		httpc_set_proxy(req, lua_tostring(L, -1));
+	lua_pop(L, 1);
+
+	lua_getfield(L, 5, "proxy_port");
+	if (!lua_isnil(L, -1))
+		httpc_set_proxy_port(req, (long) lua_tonumber(L, -1));
+	lua_pop(L, 1);
+
+	lua_getfield(L, 5, "proxy_userpwd");
+	if (!lua_isnil(L, -1))
+		httpc_set_proxy_userpwd(req, lua_tostring(L, -1));
+	lua_pop(L, 1);
+
 	long keepalive_idle = 0;
 	long keepalive_interval = 0;
 

--- a/src/lua/httpc.lua
+++ b/src/lua/httpc.lua
@@ -254,6 +254,12 @@ end
 --
 --      ssl_cert - set path to the file with SSL client certificate;
 --
+--      proxy - set a proxy to use
+--
+--      proxy_port - set a port number the proxy listens on
+--
+--      proxy_userpwd - set a user name and a password to use in authentication
+--
 --      headers - a table of HTTP headers;
 --
 --      keepalive_idle & keepalive_interval -


### PR DESCRIPTION
Added support for the following curl options:
* CURLOPT_PROXY
* CURLOPT_PROXYPORT
* CURLOPT_PROXYUSERPWD

@TarantoolBot document
Title: httpc: proxy server options

Use httpc_set_proxy to specify the proxy server host or IP-address
(optionally may be prefexed with a scheme - e.g. http:// or https://).
httpc_set_proxy_port and httpc_set_proxy_userpwd may be used to
specify the proxy port (443 for https proxy and 1080 for others by
default) and user credentials (format: [user name]:[password])
respectively.

See:
https://curl.haxx.se/libcurl/c/CURLOPT_PROXY.html
https://curl.haxx.se/libcurl/c/CURLOPT_PROXYPORT.html
https://curl.haxx.se/libcurl/c/CURLOPT_USERPWD.html