### PR TITLE
static build: export additional libraries

### DIFF
--- a/.travis.mk
+++ b/.travis.mk
@@ -61,7 +61,7 @@ deps_debian:
 	apt-get update ${APT_EXTRA_FLAGS} && apt-get install -y -f \
 		build-essential cmake coreutils sed \
 		libreadline-dev libncurses5-dev libyaml-dev libssl-dev \
-		libcurl4-openssl-dev libunwind-dev libicu-dev \
+		libcurl4-openssl-dev libunwind-dev libicu-dev liblz4-dev \
 		python python-pip python-setuptools python-dev \
 		python-msgpack python-yaml python-argparse python-six python-gevent \
 		lcov ruby clang llvm llvm-dev zlib1g-dev autoconf automake libtool
@@ -129,7 +129,7 @@ test_asan_debian: deps_debian deps_buster_clang_8 test_asan_debian_no_deps
 
 deps_osx:
 	brew update
-	brew install openssl readline curl icu4c libiconv zlib autoconf automake libtool --force
+	brew install openssl readline curl icu4c lz4 libiconv zlib autoconf automake libtool --force
 	python2 -V || brew install python2 --force
 	curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py >get-pip.py
 	python get-pip.py --user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,6 +312,13 @@ else()
 endif()
 
 #
+# LZ4
+#
+
+find_package(LZ4)
+set(LZ4_LIBRARIES ${LZ4_LIBRARY})
+
+#
 # OpenSSL
 #
 find_package(OpenSSL)

--- a/Dockerfile.staticbuild
+++ b/Dockerfile.staticbuild
@@ -8,8 +8,8 @@ RUN set -x \
         libstdc++ \
         libstdc++-static \
         readline \
-        openssl \
         lz4 \
+        lz4-static \
         binutils \
         ncurses \
         libgomp \
@@ -62,6 +62,12 @@ RUN set -x && \
     ./configure --enable-static --enable-shared && \
     make && make install
 
+RUN set -x && \
+    LD_LIBRARY_PATH=/usr/local/lib64 curl -O -L https://github.com/facebook/zstd/releases/download/v1.4.0/zstd-1.4.0.tar.gz && \
+    tar -xvf zstd-1.4.0.tar.gz && \
+    cd zstd-1.4.0 && \
+    make && make install
+
 COPY . /tarantool
 
 RUN set -x && \
@@ -82,6 +88,7 @@ RUN set -x \
        cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
              -DENABLE_DIST:BOOL=ON \
              -DBUILD_STATIC=ON \
+             -DENABLE_BUNDLED_ZSTD=OFF \
              -DOPENSSL_USE_STATIC_LIBS=ON \
              -DOPENSSL_ROOT_DIR=/usr/local \
              .) \

--- a/cmake/FindLZ4.cmake
+++ b/cmake/FindLZ4.cmake
@@ -1,0 +1,25 @@
+find_path(LZ4_INCLUDE_DIR NAMES lz4.h)
+
+if(BUILD_STATIC)
+	find_library(LZ4_STATIC NAMES ${CMAKE_STATIC_LIBRARY_PREFIX}lz4${CMAKE_STATIC_LIBRARY_SUFFIX})
+endif()
+find_library(LZ4_LIBRARY NAMES ${CMAKE_SHARED_LIBRARY_PREFIX}lz4${CMAKE_SHARED_LIBRARY_SUFFIX})
+
+if(BUILD_STATIC)
+    set(LZ4_FIND_REQUIRED ON)
+endif()
+
+if (LZ4_INCLUDE_DIR AND LZ4_LIBRARY)
+	if (NOT BUILD_STATIC OR (BUILD_STATIC AND LZ4_STATIC))
+		set(LZ4_FOUND ON)
+	endif()
+endif()
+
+if (LZ4_FOUND)
+	message(STATUS "Found lz4 includes: ${LZ4_INCLUDE_DIR}/lz4.h")
+	message(STATUS "Found lz4 library: ${LZ4_LIBRARY}")
+else()
+	if (LZ4_FIND_REQUIRED)
+		message(FATAL_ERROR "Could not find liblz4 development files")
+	endif()
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,8 @@ include_directories(${CURL_INCLUDE_DIRS})
 include_directories(${ICU_INCLUDE_DIRS})
 include_directories(${ICONV_INCLUDE_DIRS})
 include_directories(${DECNUMBER_INCLUDE_DIR})
+include_directories(${LZ4_INCLUDE_DIR})
+include_directories(${ZSTD_INCLUDE_DIRS})
 
 set(LIBUTIL_FREEBSD_SRC ${CMAKE_SOURCE_DIR}/third_party/libutil_freebsd)
 include_directories(${LIBUTIL_FREEBSD_SRC})
@@ -172,10 +174,24 @@ add_dependencies(server build_bundled_libs)
 target_link_libraries(server core coll http_parser bit uri uuid swim swim_udp
                       swim_ev crypto)
 
+if(BUILD_STATIC)
+    set(Z_STATIC libz.a)
+    set(ZZIP_STATIC libzzip.a)
+endif()
+
+find_library(Z_LIBRARY NAMES ${Z_STATIC} z)
+find_library(ZZIP_LIBRARY NAMES ${ZZIP_STATIC} zzip)
+
 # Rule of thumb: if exporting a symbol from a static library, list the
 # library here.
 set (reexport_libraries server core misc bitset csv swim swim_udp swim_ev
-     ${LUAJIT_LIBRARIES} ${MSGPUCK_LIBRARIES} ${ICU_LIBRARIES})
+     ${LUAJIT_LIBRARIES}
+     ${MSGPUCK_LIBRARIES}
+     ${ICU_LIBRARIES}
+     ${LZ4_STATIC}
+     ${Z_STATIC}
+     ${ZSTD_LIBRARIES}
+    )
 
 set (common_libraries
     ${reexport_libraries}
@@ -217,7 +233,12 @@ if(BUILD_STATIC)
             ${READLINE_LIBRARIES}
             ${CURL_LIBRARIES}
             ${OPENSSL_LIBRARIES}
-            ${ICU_LIBRARIES})
+            ${ICU_LIBRARIES}
+            ${Z_STATIC}
+            ${ZZIP_STATIC}
+            ${LZ4_STATIC}
+            ${ZSTD_LIBRARIES}
+        )
         if (${libstatic} MATCHES "lib[^/]+.a")
             string(REGEX MATCH "lib[^/]+.a" libname ${libstatic})
             string(REGEX REPLACE "\\.a$" "" libname ${libname})


### PR DESCRIPTION
This commit exports symbols from some libraries such as:

- zlib
- zzip
- lz4
- zstd

This is usefull for a static build so there is no need for all those
modules from tarantool ecosystem to each link these common libraries
inside itself.

To be able to export ZSTD symbols correctly, it is necessary to first
build zstd and then start cmake where "mkexports" machinery export all
static libs symbols.

Fixes #4225