### PR TITLE
staticbuild: fix RUN_TESTS condition

### DIFF
--- a/Dockerfile.staticbuild
+++ b/Dockerfile.staticbuild
@@ -90,9 +90,10 @@ RUN set -x \
 RUN cd /tarantool && make install
 
 ARG RUN_TESTS
-RUN [ -n ${RUN_TESTS} ] && \
-    set -x && \
-    cd test && \
-    /usr/bin/python test-run.py --force
+RUN if [ -n "${RUN_TESTS}" ]; then \
+        set -x && \
+        cd test && \
+        /usr/bin/python test-run.py --force; \
+    fi
 
 ENTRYPOINT /bin/bash


### PR DESCRIPTION
Before this patch RUN_TESTS condition in Dockerfile.staticbuild
was ignored and always was true.

This patch fixes it and allows build tarantool statically
without running tests

Example:

Part 1:
```bash
# case 1
➜   export TEST
➜   [ -n ${TEST} ] && echo "success" # returns success
success
➜   [ -n "${TEST}" ] && echo "success" # no output, '-n' checked that string is really empty
# case 2
➜   export TEST=ON
➜   [ -n ${TEST} ] && echo "success" # ok
success
➜   [ -n "${TEST}" ] && echo "success" # ok
success
```

Part 2
```bash
➜   export TEST=''
➜   [ -n "${TEST}" ] && echo "success"
➜   echo $?
1 # build failed

➜   [ -n "${TEST}" ] && echo "success" || true
➜   echo $?
0 # continue build image if variable is not specified
```
