### PR TITLE
Make fibers joinable by default

### DIFF
--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -326,9 +326,6 @@ fiber_attr_getstacksize(struct fiber_attr *fiber_attr)
 }
 
 static void
-fiber_recycle(struct fiber *fiber);
-
-static void
 fiber_stack_recycle(struct fiber *fiber);
 
 static void
@@ -795,7 +792,7 @@ fiber_reset(struct fiber *fiber)
 }
 
 /** Destroy an active fiber and prepare it for reuse. */
-static void
+void
 fiber_recycle(struct fiber *fiber)
 {
 	/* no exceptions are leaking */

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -295,6 +295,9 @@ fiber_wakeup(struct fiber *f);
 API_EXPORT void
 fiber_cancel(struct fiber *f);
 
+API_EXPORT void
+fiber_recycle(struct fiber *fiber);
+
 /**
  * Make it possible or not possible to wakeup the current
  * fiber immediately when it's cancelled.


### PR DESCRIPTION
"Joinable" flag at fiber is an implementation details
and should not bother end users.

This patch makes every new fiber joinable and registers
GC callback for it. GC'ed fiber can be either dead or
alive. As there is no more ref to the fiber from lua
it means that dead one can be recycled and alive one
can be marked as not joinable so it can be fully recycled
automatically later.

This makes set_joinable obsolete, however the patch
is completely backward-compatible.

@TarantoolBot document
Title: Remove set_joinable from docs or mark it obsolete
As of all fibers are joinable by default
set_joinable got useless.