### PR TITLE
build: Fix static build based on Dockerfile

### DIFF
--- a/Dockerfile.staticbuild
+++ b/Dockerfile.staticbuild
@@ -40,9 +40,9 @@ RUN yum -y install python-devel python-pip
 
 RUN set -x && \
     cd / && \
-    curl -O -L https://www.openssl.org/source/openssl-1.1.0h.tar.gz && \
-    tar -xvf openssl-1.1.0h.tar.gz && \
-    cd openssl-1.1.0h && \
+    curl -O -L https://www.openssl.org/source/openssl-1.1.1f.tar.gz && \
+    tar -xvf openssl-1.1.1f.tar.gz && \
+    cd openssl-1.1.1f && \
     ./config --libdir=lib && \
     make && make install
 


### PR DESCRIPTION
Found that 'openssl-1.1.0h' is EOL and its external link was removed.
Fixed static build based on Dockerfile with the new link to the external
openssl version 'openssl-1.1.1f'.

Close #4830