### PR TITLE
tools: add deploy via sftp for rpm and deb packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,6 @@ jobs:
       - name: "Debug build + test + coverage (Linux, gcc)"
         env: TARGET=coverage
       # Deploy targets (they also catch distro-specific problems).
-      - name: "Create and deploy tarball"
-        env: TARGET=source
-        if: branch = "1.10"
       - name: "CentOS 6 build + deploy RPM"
         env: OS=el DIST=6
         if: branch = "1.10"
@@ -70,9 +67,6 @@ jobs:
       - name: "Ubuntu Disco (19.04) build + deploy DEB"
         env: OS=ubuntu DIST=disco
         if: branch = "1.10"
-      - name: "Ubuntu Eoan (19.10) build + deploy DEB"
-        env: OS=ubuntu DIST=eoan
-        if: branch = "1.10"
       - name: "Debian Jessie (8) build + deploy DEB"
         env: OS=debian DIST=jessie
         if: branch = "1.10"
@@ -89,53 +83,6 @@ script:
 before_deploy:
   - ls -l build/
 
-deploy:
-  # Deploy packages to PackageCloud from master branch (w/o tagged revisions)
-  - provider: packagecloud
-    username: "tarantool"
-    repository: "1_10"
-    token: "${PACKAGECLOUD_TOKEN}"
-    dist: "${OS}/${DIST}"
-    package_glob: build/*.{rpm,deb,dsc}
-    skip_cleanup: true
-    on:
-      repo: tarantool/tarantool
-      branch: "1.10" # releases
-      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
-  # Deploy source tarballs to S3 from master branch (w/o tagged revisions)
-  - provider: script
-    script: make -f .travis.mk source_deploy
-    skip_cleanup: true
-    on:
-      repo: tarantool/tarantool
-      branch: "1.10" # releases
-      condition: "x${TARGET} = xsource"
-  # Deploy packages to PackageCloud from tagged revisions
-  # https://github.com/travis-ci/travis-ci/issues/7780#issuecomment-302389370
-  - provider: packagecloud
-    username: "tarantool"
-    repository: "1_10"
-    token: "${PACKAGECLOUD_TOKEN}"
-    dist: "${OS}/${DIST}"
-    package_glob: build/*.{rpm,deb,dsc}
-    skip_cleanup: true
-    on:
-      repo: tarantool/tarantool
-      tags: true
-      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
-  # Deploy source tarballs to S3 from tagged revisions
-  # https://github.com/travis-ci/travis-ci/issues/7780#issuecomment-302389370
-  - provider: script
-    script: make -f .travis.mk source_deploy
-    skip_cleanup: true
-    on:
-      repo: tarantool/tarantool
-      tags: true
-      condition: "x${TARGET} = xsource"
-
-notifications:
-  email:
-    recipients:
-      - build@tarantool.org
-    on_success: change
-    on_failure: always
+after_success:
+  - pip install --user paramiko
+  - python tools/upload_packages.py

--- a/tools/upload_packages.py
+++ b/tools/upload_packages.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+# This script uploads to remote server packages,
+# created by packpack  and stored in "/build".
+# directory, to remote server. It uses paramiko
+# library to establish client sftp connection.
+# It is aware of stucture of package repository,
+# located at https://download.picodata.io. It is
+# actually part of internal package distribution
+# system, and has nothing to do with Tarantool.
+# However, it is kept here for ease of operations.
+
+import os
+import subprocess
+import requests
+
+import paramiko
+
+# Executes shell command and returns its output.
+def exec_capture_stdout(cmd):
+    proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+    (stdout, stderr) = proc.communicate()
+    return stdout.strip().decode('utf-8')
+
+
+git_version_cmd = 'git describe --long --always'
+
+# Returns major version like 1.10, 2.2, 3.5, etc.
+def get_version():
+    version = exec_capture_stdout(git_version_cmd)
+    version_array = version.split('-')
+    version_1 = version_array[0]
+    version_array_1 = version_1.split('.')
+    version_2 = '.'.join([version_array_1[0], version_array_1[1]])
+    return version_2
+
+
+def is_deb(os):
+    return (os == 'debian' or os == 'ubuntu')
+
+
+def is_rpm(os):
+    return (os == 'el' or os == 'fedora')
+
+# Uploads all files from local directory to specified
+# remote directory via SFTP.
+def upload_deb(sftp, src_dir, dst_dir):
+    for f in os.listdir(src_dir):
+        src_file = os.path.join(src_dir, f)
+        dst_file = os.path.join(dst_dir, f)
+        print('uploading %s to %s' % (src_file, dst_file))
+        sftp.put(src_file, dst_file)
+
+    update_tarantool_repo(dst_dir)
+
+# Uploads .rpm and .src.rpm files from local directory
+# to specified remote directory via SFTP.
+def upload_rpm(sftp, src_dir, dst_dir):
+    dist_dir_x86_64 = '/'.join([dst_dir, 'x86_64'])
+    dist_dir_sprms = '/'.join([dst_dir, 'SRPMS'])
+
+    for f in os.listdir(src_dir):
+        src_file = os.path.join(src_dir, f)
+        dst_file = ''
+
+        if f.endswith('.src.rpm'):
+            dst_file = os.path.join(dist_dir_sprms, f)
+        elif f.endswith('.rpm'):
+            dst_file = os.path.join(dist_dir_x86_64, f)
+
+        if dst_file != '':
+            print('uploading %s to %s' % (src_file, dst_file))
+            sftp.put(src_file, dst_file)
+
+    update_tarantool_repo(dist_dir_x86_64)
+    update_tarantool_repo(dist_dir_sprms)
+
+# Notifies repository manager (internal system) to update
+# index metadata and signature of repository at sepcifed
+def update_tarantool_repo(repo_path):
+    env_repo_manager_host = os.environ.get("REPO_MANAGER_HOST")
+    env_repo_manager_port = int(os.environ.get("REPO_MANAGER_PORT"))
+
+    addr = 'http://%s:%s/updateRepo' % (env_repo_manager_host,
+                                        env_repo_manager_port)
+    repo_path = '/'.join(['tarantool', repo_path])
+
+    print("updating index and signature of %s" % (repo_path))
+
+    requests.post(addr, json={"path": repo_path})
+
+    return
+
+
+def main():
+    # Get configuration from Travis variables.
+    env_sftp_host = os.environ.get('SFTP_HOST')
+    env_sftp_port = int(os.environ.get('SFTP_PORT'))
+
+    env_sftp_user = os.environ.get('SFTP_USER')
+    env_sftp_pass = os.environ.get('SFTP_PASSWORD')
+
+    env_os = os.environ.get('OS')
+    env_dist = os.environ.get('DIST')
+    version = get_version()
+
+    # Establish SFTP connection.
+    t = paramiko.Transport((env_sftp_host, env_sftp_port))
+    t.connect(None, env_sftp_user, env_sftp_pass)
+    sftp = paramiko.SFTPClient.from_transport(t)
+
+    # Determine directory of package repository and its type.
+    src_dir = 'build/'
+    dst_dir = '/'.join([version, env_os, env_dist])
+
+    if is_deb(env_os):
+        upload_deb(sftp, src_dir, dst_dir)
+    elif is_rpm(env_os):
+        upload_rpm(sftp, src_dir, dst_dir)
+    else:
+        print("unknown package type")
+        return
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
1. python script tools/deploy_packages.py has been added.
It usesparamiko to upload packages, created with packpack
to remote server (where package repositories are hosted)

2. travis.yml has been updated to call upload_packages.py