### PR TITLE
csv: treat box.NULL as empty field

### DIFF
--- a/src/lua/csv.lua
+++ b/src/lua/csv.lua
@@ -192,7 +192,10 @@ module.dump = function(t, opts, writable)
         local first = true
         local output_tuple = {}
         for k2, field in pairs(line) do
-            local strf = tostring(field)
+            local strf = ''
+            if field ~= nil then
+                strf = tostring(field)
+            end
             local buf_new_size = (strf:len() + 1) * 2
             if buf_new_size > bufsz then
                 bufsz = buf_new_size

--- a/test/app-tap/csv.test.lua
+++ b/test/app-tap/csv.test.lua
@@ -36,7 +36,7 @@ local test6_ans = "|23|\t|456|\t|abcac|\t|'multiword field 4'|\t\n|none|" ..
                   "lag[ flag ])|\t\n||\t||\t||\t\n"
 
 test = tap.test("csv")
-test:plan(12)
+test:plan(13)
 
 readable = {}
 readable.read = myread
@@ -134,3 +134,6 @@ local exp = {{'929', 'N1XDN', '', 'Enfield, CT', ''}}
 test:is_deeply(res, exp, 'gh-3489')
 
 test:check()
+
+-- gh-5026: treat `box.NULL` in csv.dump as an empty field
+test:is(csv.dump({{1, box.NULL, 2}, {box.NULL}}), '1,,2\n\n', "gh-5026")


### PR DESCRIPTION
There is a problem when one tries to dump tuple with NULL field to csv
file. box.NULL is dumped as: `cdata<void *>: NULL`.

This patch takes special attention to NULL value and print it as empty
field.

 How it works now:
```
tarantool> require('csv').dump({1,box.NULL,2})
---
- '1,,2

  '
...
```

Unfortunately I don't know a way how to make csv to treat lua's `nil` as empty field. For now the behaviour is:

```
tarantool> require('csv').dump({1,nil,2})
---
- '1,2

  '
...
```
Closes #5026 (partially)