### PR TITLE
feedback: Extend features report

### DIFF
--- a/test/box-tap/feedback_daemon.test.lua
+++ b/test/box-tap/feedback_daemon.test.lua
@@ -67,7 +67,7 @@ if not ok then
     os.exit(0)
 end
 
-test:plan(11)
+test:plan(14)
 
 local function check(message)
     while feedback_count < 1 do
@@ -130,6 +130,15 @@ local daemon = box.internal.feedback_daemon
 daemon.start()
 daemon.send_test()
 daemon.stop()
+
+--
+-- gh-3608: OS version and containerization detection in feedback daemon
+--
+
+local actual = daemon.generate_feedback()
+test:is(type(actual.os), 'string', 'feedback contains "os" key')
+test:is(type(actual.arch), 'string', 'feedback contains "arch" key')
+test:is(type(actual.cgroup), 'string', 'feedback contains "cgroup" key')
 
 test:check()
 os.exit(0)


### PR DESCRIPTION
This patchset adds more information about running
tarantool instance. Firstly, it collects **platform information**
such as os, arch and cgroup environment. Secondly, it looks
through box user spaces and collects info about **db engines and
indices**.

Example of full feedback report:

```json
{
  "arch": "x64",
  "features": {
    "schema": {
      "local_spaces": 0,
      "functional_indices": 0,
      "hash_indices": 0,
      "rtree_indices": 0,
      "temporary_spaces": 0,
      "tree_indices": 0,
      "jsonpath_indices": 0,
      "vinyl_spaces": 0,
      "bitset_indices": 0,
      "memtx_spaces": 0
    }
  },
  "server_id": "79047619-2c60-4195-af4f-23dee72285e6",
  "cgroup": "",
  "os": "OSX",
  "cluster_id": "57da2972-c33f-4b68-8e98-12cffb2fe16f",
  "tarantool_version": "2.5.0-147-g4a80bc779",
  "feedback_version": 2
}
```

Closes #3608
Part of #4943