### PR TITLE
infra: initial Github Actions support

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,49 @@
+name: CMake
+
+on: [push]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: RelWithDebInfo
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#configuring-a-build-matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Install Mac prerequisites
+      if: runner.os == 'macOS'
+      run: |
+        brew install readline icu4c openssl
+        brew install autoconf automake libtool
+
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      # Note the current convention is to use the -S and -B options here to specify source 
+      # and build directories, but this is only available with CMake 3.13 and higher.  
+      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute the build.  You can specify a specific target with "--target <NAME>"
+      run: cmake --build . --config $BUILD_TYPE
+  


### PR DESCRIPTION
* Created cmake.yml for checkout, cmake configure, and build
* Change git `fetch-depth:` to 0
   Increase git fetch-depth for the actions/checkout@v2
   to make sure we are retrieving fuller history, including tags.
   Using `fetch-depth: 0` now to retrieve all tags

* Do not fail fast for concurrent jobs
   By default Github Actions uses strategy.fail-fast = true,
   which cancels all running jobs, if any of them failed.
   At the moment we had missing Mac dependencies problems,
   but still preferred to see Linux job completed fully, thus disable
   `fail-fast` mode.

* Install all Mac OSX prerequisites
   Introduced Mac OSX specific build step which is installing necessary
   Mac `homebrew` prerequisites (i.e. `readline`, `icu4c`, `openssl`,
   `autoconf`, `automake`, `libtool`)

Part of #5258

_NB!_

_This is triggered per commit - let me know if we wan to run it per pull-request instead!_