### PR TITLE
Add field name and actual type to field type mismatch errors

### DIFF
--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -3367,10 +3367,11 @@ func_def_new_from_tuple(struct tuple *tuple)
 			return NULL;
 		uint32_t cnt = mp_decode_array(&exports);
 		for (uint32_t i = 0; i < cnt; i++) {
-			if (mp_typeof(*exports) != MP_STR) {
+			enum mp_type actual_type = mp_typeof(*exports);
+			if (actual_type != MP_STR) {
 				diag_set(ClientError, ER_FIELD_TYPE,
 					  int2str(BOX_FUNC_FIELD_EXPORTS + 1),
-					 mp_type_strs[MP_STR]);
+					 mp_type_strs[MP_STR], mp_type_strs[actual_type]);
 				return NULL;
 			}
 			uint32_t len;
@@ -3404,10 +3405,11 @@ func_def_new_from_tuple(struct tuple *tuple)
 			return NULL;
 		uint32_t argc = mp_decode_array(&param_list);
 		for (uint32_t i = 0; i < argc; i++) {
-			 if (mp_typeof(*param_list) != MP_STR) {
+			enum mp_type actual_type = mp_typeof(*param_list);
+			 if (actual_type != MP_STR) {
 				diag_set(ClientError, ER_FIELD_TYPE,
-					  int2str(BOX_FUNC_FIELD_PARAM_LIST + 1),
-					 mp_type_strs[MP_STR]);
+					 int2str(BOX_FUNC_FIELD_PARAM_LIST + 1),
+					 mp_type_strs[MP_STR], mp_type_strs[actual_type]);
 				return NULL;
 			}
 			uint32_t len;

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -75,7 +75,7 @@ struct errcode_record {
 	/* 20 */_(ER_INVALID_MSGPACK,		"Invalid MsgPack - %s") \
 	/* 21 */_(ER_PROC_RET,			"msgpack.encode: can not encode Lua type '%s'") \
 	/* 22 */_(ER_TUPLE_NOT_ARRAY,		"Tuple/Key must be MsgPack array") \
-	/* 23 */_(ER_FIELD_TYPE,		"Tuple field %s type does not match one required by operation: expected %s") \
+	/* 23 */_(ER_FIELD_TYPE,		"Tuple field %s type does not match one required by operation: expected %s, got %s") \
 	/* 24 */_(ER_INDEX_PART_TYPE_MISMATCH,	"Field %s has type '%s' in one index, but type '%s' in another") \
 	/* 25 */_(ER_UPDATE_SPLICE,		"SPLICE error on field %s: %s") \
 	/* 26 */_(ER_UPDATE_ARG_TYPE,		"Argument type in operation '%c' on field %s does not match field type: expected %s") \

--- a/src/box/memtx_rtree.c
+++ b/src/box/memtx_rtree.c
@@ -58,9 +58,11 @@ static inline int
 mp_decode_num(const char **data, uint32_t fieldno, double *ret)
 {
 	if (mp_read_double(data, ret) != 0) {
+		enum mp_type actual_type = mp_typeof(**data);
 		diag_set(ClientError, ER_FIELD_TYPE,
 			 int2str(fieldno + TUPLE_INDEX_BASE),
-			 field_type_strs[FIELD_TYPE_NUMBER]);
+			 field_type_strs[FIELD_TYPE_NUMBER],
+			 mp_type_strs[actual_type]);
 		return -1;
 	}
 	return 0;

--- a/src/box/tuple.h
+++ b/src/box/tuple.h
@@ -869,10 +869,11 @@ tuple_next_with_type(struct tuple_iterator *it, enum mp_type type)
 		diag_set(ClientError, ER_NO_SUCH_FIELD_NO, it->fieldno);
 		return NULL;
 	}
-	if (mp_typeof(*field) != type) {
+	enum mp_type actual_type = mp_typeof(*field);
+	if (actual_type != type) {
 		diag_set(ClientError, ER_FIELD_TYPE,
 			 int2str(fieldno + TUPLE_INDEX_BASE),
-			 mp_type_strs[type]);
+			 mp_type_strs[type], mp_type_strs[actual_type]);
 		return NULL;
 	}
 	return field;
@@ -882,17 +883,10 @@ tuple_next_with_type(struct tuple_iterator *it, enum mp_type type)
 static inline int
 tuple_next_u32(struct tuple_iterator *it, uint32_t *out)
 {
-	uint32_t fieldno = it->fieldno;
 	const char *field = tuple_next_with_type(it, MP_UINT);
 	if (field == NULL)
 		return -1;
 	uint32_t val = mp_decode_uint(&field);
-	if (val > UINT32_MAX) {
-		diag_set(ClientError, ER_FIELD_TYPE,
-			 int2str(fieldno + TUPLE_INDEX_BASE),
-			 field_type_strs[FIELD_TYPE_UNSIGNED]);
-		return -1;
-	}
 	*out = val;
 	return 0;
 }
@@ -934,10 +928,11 @@ tuple_field_with_type(struct tuple *tuple, uint32_t fieldno, enum mp_type type)
 			 fieldno + TUPLE_INDEX_BASE);
 		return NULL;
 	}
-	if (mp_typeof(*field) != type) {
+	enum mp_type actual_type = mp_typeof(*field);
+	if (actual_type != type) {
 		diag_set(ClientError, ER_FIELD_TYPE,
 			 int2str(fieldno + TUPLE_INDEX_BASE),
-			 mp_type_strs[type]);
+			 mp_type_strs[type], mp_type_strs[actual_type]);
 		return NULL;
 	}
 	return field;
@@ -970,7 +965,8 @@ tuple_field_i64(struct tuple *tuple, uint32_t fieldno, int64_t *out)
 		return -1;
 	}
 	uint64_t val;
-	switch (mp_typeof(*field)) {
+	enum mp_type actual_type = mp_typeof(*field);
+	switch (actual_type) {
 	case MP_INT:
 		*out = mp_decode_int(&field);
 		break;
@@ -984,7 +980,7 @@ tuple_field_i64(struct tuple *tuple, uint32_t fieldno, int64_t *out)
 	default:
 		diag_set(ClientError, ER_FIELD_TYPE,
 			 int2str(fieldno + TUPLE_INDEX_BASE),
-			 field_type_strs[FIELD_TYPE_INTEGER]);
+			 field_type_strs[FIELD_TYPE_INTEGER],mp_type_strs[actual_type]);
 		return -1;
 	}
 	return 0;
@@ -1015,12 +1011,6 @@ tuple_field_u32(struct tuple *tuple, uint32_t fieldno, uint32_t *out)
 	if (field == NULL)
 		return -1;
 	*out = mp_decode_uint(&field);
-	if (*out > UINT32_MAX) {
-		diag_set(ClientError, ER_FIELD_TYPE,
-			 int2str(fieldno + TUPLE_INDEX_BASE),
-			 field_type_strs[FIELD_TYPE_UNSIGNED]);
-		return -1;
-	}
 	return 0;
 }
 

--- a/src/box/tuple_format.c
+++ b/src/box/tuple_format.c
@@ -1170,9 +1170,12 @@ tuple_format_iterator_next(struct tuple_format_iterator *it,
 	 */
 	bool is_nullable = tuple_field_is_nullable(field);
 	if (!field_mp_type_is_compatible(field->type, entry->data, is_nullable) != 0) {
+		enum mp_type actual_type = mp_typeof(*entry->data);
+
 		diag_set(ClientError, ER_FIELD_TYPE,
 			 tuple_field_path(field),
-			 field_type_strs[field->type]);
+			 field_type_strs[field->type],
+			 mp_type_strs[actual_type]);
 		return -1;
 	}
 	bit_clear(it->multikey_frame != NULL ?

--- a/src/box/tuple_format.c
+++ b/src/box/tuple_format.c
@@ -166,12 +166,25 @@ tuple_field_delete(struct tuple_field *field)
 
 /** Return path to a tuple field. Used for error reporting. */
 static const char *
-tuple_field_path(const struct tuple_field *field)
+tuple_field_path(const struct tuple_field *field, const struct tuple_format *format)
 {
 	assert(field->token.parent != NULL);
 	if (field->token.parent->parent == NULL) {
-		/* Top-level field, no need to format the path. */
-		return int2str(field->token.num + TUPLE_INDEX_BASE);
+		int n_named = format->dict->name_count;
+
+
+		if (field->token.num < n_named) {
+			char *path = tt_static_buf();
+
+			snprintf(path, TT_STATIC_BUF_LEN, "%d (%s)",
+				 field->token.num + TUPLE_INDEX_BASE,
+				 format->dict->names[field->token.num]);
+
+			return path;
+		}
+
+		else
+			return int2str(field->token.num + TUPLE_INDEX_BASE);
 	}
 	char *path = tt_static_buf();
 	json_tree_snprint_path(path, TT_STATIC_BUF_LEN, &field->token,
@@ -203,7 +216,8 @@ tuple_format_field_by_id(struct tuple_format *format, uint32_t id)
  */
 static int
 tuple_field_ensure_child_compatibility(struct tuple_field *parent,
-				       struct tuple_field *child)
+				       struct tuple_field *child,
+				       struct tuple_format* format)
 {
 	enum field_type expected_type =
 		child->token.type == JSON_TOKEN_STR ?
@@ -212,7 +226,7 @@ tuple_field_ensure_child_compatibility(struct tuple_field *parent,
 		parent->type = expected_type;
 	} else {
 		diag_set(ClientError, ER_INDEX_PART_TYPE_MISMATCH,
-			 tuple_field_path(parent),
+			 tuple_field_path(parent, format),
 			 field_type_strs[parent->type],
 			 field_type_strs[expected_type]);
 		return -1;
@@ -226,7 +240,7 @@ tuple_field_ensure_child_compatibility(struct tuple_field *parent,
 	    !json_token_is_multikey(&parent->token) &&
 	    !json_token_is_leaf(&parent->token)) {
 		diag_set(ClientError, ER_MULTIKEY_INDEX_MISMATCH,
-			 tuple_field_path(parent));
+			 tuple_field_path(parent, format));
 		return -1;
 	}
 	/*
@@ -236,7 +250,7 @@ tuple_field_ensure_child_compatibility(struct tuple_field *parent,
 	if (json_token_is_multikey(&parent->token) &&
 	    child->token.type != JSON_TOKEN_ANY) {
 		diag_set(ClientError, ER_MULTIKEY_INDEX_MISMATCH,
-			 tuple_field_path(parent));
+			 tuple_field_path(parent, format));
 		return -1;
 	}
 	return 0;
@@ -283,7 +297,7 @@ tuple_format_add_field(struct tuple_format *format, uint32_t fieldno,
 	json_lexer_create(&lexer, path, path_len, TUPLE_INDEX_BASE);
 	while ((rc = json_lexer_next_token(&lexer, &field->token)) == 0 &&
 	       field->token.type != JSON_TOKEN_END) {
-		if (tuple_field_ensure_child_compatibility(parent, field) != 0)
+		if (tuple_field_ensure_child_compatibility(parent, field, format) != 0)
 			goto fail;
 		struct tuple_field *next =
 			json_tree_lookup_entry(tree, &parent->token,
@@ -386,7 +400,7 @@ tuple_format_use_key_part(struct tuple_format *format, uint32_t field_count,
 			field->nullable_action = part->nullable_action;
 	} else if (field->nullable_action != part->nullable_action) {
 		diag_set(ClientError, ER_ACTION_MISMATCH,
-			 tuple_field_path(field),
+			 tuple_field_path(field, format),
 			 on_conflict_action_strs[field->nullable_action],
 			 on_conflict_action_strs[part->nullable_action]);
 		return -1;
@@ -408,7 +422,7 @@ tuple_format_use_key_part(struct tuple_format *format, uint32_t field_count,
 			errcode = ER_FORMAT_MISMATCH_INDEX_PART;
 		else
 			errcode = ER_INDEX_PART_TYPE_MISMATCH;
-		diag_set(ClientError, errcode, tuple_field_path(field),
+		diag_set(ClientError, errcode, tuple_field_path(field, format),
 			 field_type_strs[field->type],
 			 field_type_strs[part->type]);
 		return -1;
@@ -1026,7 +1040,7 @@ tuple_format_required_fields_validate(struct tuple_format *format,
 			tuple_format_field_by_id(format, id);
 		assert(field != NULL);
 		diag_set(ClientError, ER_FIELD_MISSING,
-			 tuple_field_path(field));
+			 tuple_field_path(field, format));
 		return -1;
 	}
 	return 0;
@@ -1173,7 +1187,7 @@ tuple_format_iterator_next(struct tuple_format_iterator *it,
 		enum mp_type actual_type = mp_typeof(*entry->data);
 
 		diag_set(ClientError, ER_FIELD_TYPE,
-			 tuple_field_path(field),
+			 tuple_field_path(field, it->format),
 			 field_type_strs[field->type],
 			 mp_type_strs[actual_type]);
 		return -1;

--- a/test/box/access_sysview.result
+++ b/test/box/access_sysview.result
@@ -713,7 +713,8 @@ box.internal.collation.drop('guest0')
 --
 box.space._vspace.index[1]:alter({parts = { 2, 'string' }})
 ---
-- error: Field 2 has type 'unsigned' in space format, but type 'string' in index definition
+- error: Field 2 (owner) has type 'unsigned' in space format, but type 'string' in
+    index definition
 ...
 box.space._vspace.index[1]:select('xxx')
 ---

--- a/test/box/alter.result
+++ b/test/box/alter.result
@@ -36,7 +36,8 @@ _space:insert{_space.id, ADMIN, 'test', 'memtx', 0, EMPTY_MAP, {}}
 --
 _space:insert{'hello', 'world', 'test', 'memtx', 0, EMPTY_MAP, {}}
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 1 (id) type does not match one required by operation: expected
+    unsigned, got string'
 ...
 --
 -- Can't create a space which has wrong field count - field_count must be NUM
@@ -1013,7 +1014,8 @@ s:replace{1}
 ...
 pk:alter{parts = {{1, 'string'}}} -- Must fail.
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected string'
+- error: 'Tuple field 1 type does not match one required by operation: expected string,
+    got unsigned'
 ...
 s:drop()
 ---

--- a/test/box/alter_limits.result
+++ b/test/box/alter_limits.result
@@ -854,7 +854,8 @@ s:insert{'Der Baader Meinhof Komplex', '2009 '}
 -- create an index on a field with a wrong type
 index = s:create_index('year', { type = 'tree', unique = false, parts = { 2, 'unsigned'}})
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 type does not match one required by operation: expected unsigned,
+    got string'
 ...
 -- a field is missing
 s:replace{'Der Baader Meinhof Komplex'}

--- a/test/box/blackhole.result
+++ b/test/box/blackhole.result
@@ -28,11 +28,13 @@ t, t.key, t.value
 ...
 s:insert{1, 2, 3} -- error
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected string'
+- error: 'Tuple field 2 (value) type does not match one required by operation: expected
+    string, got unsigned'
 ...
 s:replace{'a', 'b', 'c'} -- error
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 1 (key) type does not match one required by operation: expected
+    unsigned, got string'
 ...
 s:format{}
 ---

--- a/test/box/ddl_collation.result
+++ b/test/box/ddl_collation.result
@@ -132,27 +132,31 @@ box.internal.collation.drop('test')
 
 box.space._collation:auto_increment{'test'}
  | ---
- | - error: Tuple field 3 required by space format is missing
+ | - error: Tuple field 3 (owner) required by space format is missing
  | ...
 box.space._collation:auto_increment{'test', 0, 'ICU'}
  | ---
- | - error: Tuple field 5 required by space format is missing
+ | - error: Tuple field 5 (locale) required by space format is missing
  | ...
 box.space._collation:auto_increment{'test', 'ADMIN', 'ICU', 'ru_RU'}
  | ---
- | - error: 'Tuple field 3 type does not match one required by operation: expected unsigned'
+ | - error: 'Tuple field 3 (owner) type does not match one required by operation: expected
+ |     unsigned, got string'
  | ...
 box.space._collation:auto_increment{42, 0, 'ICU', 'ru_RU'}
  | ---
- | - error: 'Tuple field 2 type does not match one required by operation: expected string'
+ | - error: 'Tuple field 2 (name) type does not match one required by operation: expected
+ |     string, got unsigned'
  | ...
 box.space._collation:auto_increment{'test', 0, 42, 'ru_RU'}
  | ---
- | - error: 'Tuple field 4 type does not match one required by operation: expected string'
+ | - error: 'Tuple field 4 (type) type does not match one required by operation: expected
+ |     string, got unsigned'
  | ...
 box.space._collation:auto_increment{'test', 0, 'ICU', 42}
  | ---
- | - error: 'Tuple field 5 type does not match one required by operation: expected string'
+ | - error: 'Tuple field 5 (locale) type does not match one required by operation: expected
+ |     string, got unsigned'
  | ...
 box.space._collation:auto_increment{'test', 0, 'ICU', 'ru_RU', setmap{}} --ok
  | ---
@@ -171,11 +175,13 @@ box.space._collation.index.name:delete{'nothing'} -- allowed
  | ...
 box.space._collation:auto_increment{'test', 0, 'ICU', 'ru_RU', 42}
  | ---
- | - error: 'Tuple field 6 type does not match one required by operation: expected map'
+ | - error: 'Tuple field 6 (opts) type does not match one required by operation: expected
+ |     map, got unsigned'
  | ...
 box.space._collation:auto_increment{'test', 0, 'ICU', 'ru_RU', 'options'}
  | ---
- | - error: 'Tuple field 6 type does not match one required by operation: expected map'
+ | - error: 'Tuple field 6 (opts) type does not match one required by operation: expected
+ |     map, got string'
  | ...
 box.space._collation:auto_increment{'test', 0, 'ICU', 'ru_RU', {ping='pong'}}
  | ---

--- a/test/box/ddl_tuple.result
+++ b/test/box/ddl_tuple.result
@@ -44,7 +44,8 @@ _ = {fiber.create(insert_tuple, {1, 2, 'a'}), fiber.create(add_index), fiber.cre
 {ch:get(), ch:get(), ch:get()}
  | ---
  | - - - false
- |     - 'Tuple field 2 type does not match one required by operation: expected unsigned'
+ |     - 'Tuple field 2 type does not match one required by operation: expected unsigned,
+ |       got string'
  |   - - true
  |     - [1, 2, 'a']
  |   - true

--- a/test/box/hash_32bit_insert.result
+++ b/test/box/hash_32bit_insert.result
@@ -30,7 +30,8 @@ hash:insert{3, 'value1 v1.0', 'value2 v1.0'}
 -- Insert invalid fields
 hash:insert{'invalid key', 'value1 v1.0', 'value2 v1.0'}
  | ---
- | - error: 'Tuple field 1 type does not match one required by operation: expected unsigned'
+ | - error: 'Tuple field 1 type does not match one required by operation: expected unsigned,
+ |     got string'
  | ...
 
 hash:drop()

--- a/test/box/hash_32bit_replace.result
+++ b/test/box/hash_32bit_replace.result
@@ -48,7 +48,8 @@ hash:replace{2, 'value1 v1.43', 'value2 1.92'}
 -- Replace invalid fields
 hash:replace{'invalid key', 'value1 v1.0', 'value2 v1.0'}
  | ---
- | - error: 'Tuple field 1 type does not match one required by operation: expected unsigned'
+ | - error: 'Tuple field 1 type does not match one required by operation: expected unsigned,
+ |     got string'
  | ...
 
 hash:drop()

--- a/test/box/hash_64bit_insert.result
+++ b/test/box/hash_64bit_insert.result
@@ -46,7 +46,8 @@ hash:insert{103, 'value1 v1.0', 'value2 v1.0'}
  | ...
 hash:insert{'invalid key', 'value1 v1.0', 'value2 v1.0'}
  | ---
- | - error: 'Tuple field 1 type does not match one required by operation: expected unsigned'
+ | - error: 'Tuple field 1 type does not match one required by operation: expected unsigned,
+ |     got string'
  | ...
 
 hash:drop()

--- a/test/box/hash_64bit_replace.result
+++ b/test/box/hash_64bit_replace.result
@@ -60,7 +60,8 @@ hash:replace{2, 'value1 v1.43', 'value2 1.92'}
  | ...
 hash:replace{'invalid key', 'value1 v1.0', 'value2 v1.0'}
  | ---
- | - error: 'Tuple field 1 type does not match one required by operation: expected unsigned'
+ | - error: 'Tuple field 1 type does not match one required by operation: expected unsigned,
+ |     got string'
  | ...
 
 hash:drop()

--- a/test/box/hash_gh-616.result
+++ b/test/box/hash_gh-616.result
@@ -10,7 +10,8 @@ _ = box.space.test:create_index('i',{parts={1,'string'}})
  | ...
 box.space.test:insert{1}
  | ---
- | - error: 'Tuple field 1 type does not match one required by operation: expected string'
+ | - error: 'Tuple field 1 type does not match one required by operation: expected string,
+ |     got unsigned'
  | ...
 box.space.test:drop()
  | ---

--- a/test/box/rtree_misc.result
+++ b/test/box/rtree_misc.result
@@ -50,11 +50,13 @@ i = s:create_index('secondary', { type = 'hash', parts = {2, 'unsigned'}})
 -- adding a tuple with array instead of num will fail
 i = s:insert{{1, 2, 3}, 4}
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 1 type does not match one required by operation: expected unsigned,
+    got array'
 ...
 i = s:insert{1, {2, 3, 4}}
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 type does not match one required by operation: expected unsigned,
+    got array'
 ...
 -- rtree index must be one-part
 i = s:create_index('spatial', { type = 'rtree', unique = false, parts = {1, 'array', 2, 'array'}})
@@ -87,15 +89,18 @@ i = s:create_index('spatial', { type = 'rtree', unique = false, parts = {3, 'arr
 -- inserting wrong values (should fail)
 s:insert{1, 2, 3}
 ---
-- error: 'Tuple field 3 type does not match one required by operation: expected array'
+- error: 'Tuple field 3 type does not match one required by operation: expected array,
+    got unsigned'
 ...
 s:insert{1, 2, "3"}
 ---
-- error: 'Tuple field 3 type does not match one required by operation: expected array'
+- error: 'Tuple field 3 type does not match one required by operation: expected array,
+    got string'
 ...
 s:insert{1, 2, nil, 3}
 ---
-- error: 'Tuple field 3 type does not match one required by operation: expected array'
+- error: 'Tuple field 3 type does not match one required by operation: expected array,
+    got nil'
 ...
 s:insert{1, 2, {}}
 ---
@@ -104,23 +109,28 @@ s:insert{1, 2, {}}
 ...
 s:insert{1, 2, {"3", "4", "5", "6"}}
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected number'
+- error: 'Tuple field 1 type does not match one required by operation: expected number,
+    got string'
 ...
 s:insert{1, 2, {nil, 4, 5, 6}}
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected number'
+- error: 'Tuple field 1 type does not match one required by operation: expected number,
+    got nil'
 ...
 s:insert{1, 2, {3, {4}, 5, 6}}
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected number'
+- error: 'Tuple field 2 type does not match one required by operation: expected number,
+    got array'
 ...
 s:insert{1, 2, {3, 4, {}, 6}}
 ---
-- error: 'Tuple field 3 type does not match one required by operation: expected number'
+- error: 'Tuple field 3 type does not match one required by operation: expected number,
+    got array'
 ...
 s:insert{1, 2, {3, 4, 5, "6"}}
 ---
-- error: 'Tuple field 4 type does not match one required by operation: expected number'
+- error: 'Tuple field 4 type does not match one required by operation: expected number,
+    got string'
 ...
 s:insert{1, 2, {3}}
 ---
@@ -554,7 +564,8 @@ s.index.s:drop()
 -- with wrong args
 box.space._index:insert{s.id, 2, 's', 'rtree', nil, {{2, 'array'}}}
 ---
-- error: 'Tuple field 5 type does not match one required by operation: expected map'
+- error: 'Tuple field 5 (opts) type does not match one required by operation: expected
+    map, got nil'
 ...
 box.space._index:insert{s.id, 2, 's', 'rtree', utils.setmap({}), {{2, 'array'}}}
 ---

--- a/test/box/sequence.result
+++ b/test/box/sequence.result
@@ -1115,7 +1115,8 @@ s.index.pk.sequence_id == nil
 ...
 s:insert{nil, 'x'} -- error
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 1 type does not match one required by operation: expected unsigned,
+    got nil'
 ...
 box.sequence.test_seq == nil
 ---
@@ -2269,7 +2270,8 @@ s.index.pk.sequence_id == nil
 ...
 s:insert{box.NULL} -- error
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 1 type does not match one required by operation: expected unsigned,
+    got nil'
 ...
 s.index.pk:alter{sequence = sq}
 ---

--- a/test/box/tree_pk.result
+++ b/test/box/tree_pk.result
@@ -64,15 +64,18 @@ s0:delete{3}
 -- https://bugs.launchpad.net/tarantool/+bug/1072624
 s0:insert{'xxxxxxx'}
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 1 type does not match one required by operation: expected unsigned,
+    got string'
 ...
 s0:insert{''}
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 1 type does not match one required by operation: expected unsigned,
+    got string'
 ...
 s0:insert{'12'}
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 1 type does not match one required by operation: expected unsigned,
+    got string'
 ...
 s1 = box.schema.space.create('tweedledee')
 ---

--- a/test/box/tuple.result
+++ b/test/box/tuple.result
@@ -1122,12 +1122,13 @@ s:frommap()
 s:frommap({})
 ---
 - null
-- Tuple field 1 required by space format is missing
+- Tuple field 1 (aaa) required by space format is missing
 ...
 s:frommap({ddd = 'fail', aaa = 2, ccc = 3, bbb = 4}, {table=true})
 ---
 - null
-- 'Tuple field 4 type does not match one required by operation: expected unsigned'
+- 'Tuple field 4 (ddd) type does not match one required by operation: expected unsigned,
+  got string'
 ...
 s:frommap({ddd = 1, aaa = 2, ccc = 3, bbb = 4}, {table = true})
 ---

--- a/test/box/varbinary_type.result
+++ b/test/box/varbinary_type.result
@@ -15,7 +15,7 @@ s:format({{"b", "integer"}})
 ...
 _ = s:create_index('pk', {parts = {1, "varbinary"}})
 ---
-- error: Field 1 has type 'integer' in space format, but type 'varbinary' in index
+- error: Field 1 (b) has type 'integer' in space format, but type 'varbinary' in index
     definition
 ...
 s:format({{"b", "varbinary"}})
@@ -23,7 +23,7 @@ s:format({{"b", "varbinary"}})
 ...
 _ = s:create_index('pk', {parts = {1, "integer"}})
 ---
-- error: Field 1 has type 'varbinary' in space format, but type 'integer' in index
+- error: Field 1 (b) has type 'varbinary' in space format, but type 'integer' in index
     definition
 ...
 pk = s:create_index('pk', {parts = {1, "varbinary"}})
@@ -117,7 +117,8 @@ box.execute("SELECT * FROM \"withdata\" WHERE \"b\" <= x'DEADBEAF';")
 ...
 pk:alter({parts = {1, "varbinary"}})
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected varbinary'
+- error: 'Tuple field 1 (b) type does not match one required by operation: expected
+    varbinary, got unsigned'
 ...
 s:delete({11})
 ---

--- a/test/engine/ddl.result
+++ b/test/engine/ddl.result
@@ -682,7 +682,8 @@ sk = s:create_index('sk', { parts = { 2, 'string' } })
 ...
 s:replace{1, 1}
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected string'
+- error: 'Tuple field 2 type does not match one required by operation: expected string,
+    got unsigned'
 ...
 sk:drop()
 ---
@@ -706,7 +707,8 @@ pk = s:create_index('pk')
 ...
 sk1 = s:create_index('sk1', { parts = { 2, 'unsigned' } })
 ---
-- error: Field 2 has type 'string' in space format, but type 'unsigned' in index definition
+- error: Field 2 (field2) has type 'string' in space format, but type 'unsigned' in
+    index definition
 ...
 -- Check space format conflicting with index parts.
 sk3 = s:create_index('sk3', { parts = { 2, 'string' } })
@@ -717,7 +719,8 @@ format[2].type = 'unsigned'
 ...
 s:format(format)
 ---
-- error: Field 2 has type 'unsigned' in space format, but type 'string' in index definition
+- error: Field 2 (field2) has type 'unsigned' in space format, but type 'string' in
+    index definition
 ...
 s:format()
 ---
@@ -819,35 +822,41 @@ s:replace{1, '2', {3, 3}, 4.4, -5, true, {value=7}, 8, 9}
 ...
 s:replace{1, 2, {3, 3}, 4.4, -5, true, {value=7}, 8, 9}
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected string'
+- error: 'Tuple field 2 (field2) type does not match one required by operation: expected
+    string, got unsigned'
 ...
 s:replace{1, '2', 3, 4.4, -5, true, {value=7}, 8, 9}
 ---
-- error: 'Tuple field 3 type does not match one required by operation: expected array'
+- error: 'Tuple field 3 (field3) type does not match one required by operation: expected
+    array, got unsigned'
 ...
 s:replace{1, '2', {3, 3}, '4', -5, true, {value=7}, 8, 9}
 ---
-- error: 'Tuple field 4 type does not match one required by operation: expected number'
+- error: 'Tuple field 4 (field4) type does not match one required by operation: expected
+    number, got string'
 ...
 s:replace{1, '2', {3, 3}, 4.4, -5.5, true, {value=7}, 8, 9}
 ---
-- error: 'Tuple field 5 type does not match one required by operation: expected integer'
+- error: 'Tuple field 5 (field5) type does not match one required by operation: expected
+    integer, got double'
 ...
 s:replace{1, '2', {3, 3}, 4.4, -5, {6, 6}, {value=7}, 8, 9}
 ---
-- error: 'Tuple field 6 type does not match one required by operation: expected scalar'
+- error: 'Tuple field 6 (field6) type does not match one required by operation: expected
+    scalar, got array'
 ...
 s:replace{1, '2', {3, 3}, 4.4, -5, true, {7}, 8, 9}
 ---
-- error: 'Tuple field 7 type does not match one required by operation: expected map'
+- error: 'Tuple field 7 (field7) type does not match one required by operation: expected
+    map, got array'
 ...
 s:replace{1, '2', {3, 3}, 4.4, -5, true, {value=7}}
 ---
-- error: Tuple field 8 required by space format is missing
+- error: Tuple field 8 (field8) required by space format is missing
 ...
 s:replace{1, '2', {3, 3}, 4.4, -5, true, {value=7}, 8}
 ---
-- error: Tuple field 9 required by space format is missing
+- error: Tuple field 9 (err) required by space format is missing
 ...
 s:truncate()
 ---
@@ -1144,7 +1153,8 @@ inspector:cmd("setopt delimiter ''");
 -- any --X--> unsigned
 fail_format_change(2, 'unsigned')
 ---
-- 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- 'Tuple field 2 (field2) type does not match one required by operation: expected
+  unsigned, got array'
 ...
 -- unsigned -----> any
 ok_format_change(3, 'any')
@@ -1153,7 +1163,8 @@ ok_format_change(3, 'any')
 -- unsigned --X--> string
 fail_format_change(3, 'string')
 ---
-- 'Tuple field 3 type does not match one required by operation: expected string'
+- 'Tuple field 3 (field3) type does not match one required by operation: expected
+  string, got unsigned'
 ...
 -- unsigned -----> number
 ok_format_change(3, 'number')
@@ -1170,17 +1181,20 @@ ok_format_change(3, 'scalar')
 -- unsigned --X--> map
 fail_format_change(3, 'map')
 ---
-- 'Tuple field 3 type does not match one required by operation: expected map'
+- 'Tuple field 3 (field3) type does not match one required by operation: expected
+  map, got unsigned'
 ...
 -- unsigned --X--> decimal
 fail_format_change(3, 'decimal')
 ---
-- 'Tuple field 3 type does not match one required by operation: expected decimal'
+- 'Tuple field 3 (field3) type does not match one required by operation: expected
+  decimal, got unsigned'
 ...
 -- unsigned --X--> uuid
 fail_format_change(3, 'uuid')
 ---
-- 'Tuple field 3 type does not match one required by operation: expected uuid'
+- 'Tuple field 3 (field3) type does not match one required by operation: expected
+  uuid, got unsigned'
 ...
 -- string -----> any
 ok_format_change(4, 'any')
@@ -1193,17 +1207,20 @@ ok_format_change(4, 'scalar')
 -- string --X--> boolean
 fail_format_change(4, 'boolean')
 ---
-- 'Tuple field 4 type does not match one required by operation: expected boolean'
+- 'Tuple field 4 (field4) type does not match one required by operation: expected
+  boolean, got string'
 ...
 -- string --X--> decimal
 fail_format_change(4, 'decimal')
 ---
-- 'Tuple field 4 type does not match one required by operation: expected decimal'
+- 'Tuple field 4 (field4) type does not match one required by operation: expected
+  decimal, got string'
 ...
 -- string --X--> uuid
 fail_format_change(4, 'uuid')
 ---
-- 'Tuple field 4 type does not match one required by operation: expected uuid'
+- 'Tuple field 4 (field4) type does not match one required by operation: expected
+  uuid, got string'
 ...
 -- number -----> any
 ok_format_change(5, 'any')
@@ -1216,17 +1233,20 @@ ok_format_change(5, 'scalar')
 -- number --X--> integer
 fail_format_change(5, 'integer')
 ---
-- 'Tuple field 5 type does not match one required by operation: expected integer'
+- 'Tuple field 5 (field5) type does not match one required by operation: expected
+  integer, got double'
 ...
 -- number --X--> decimal
 fail_format_change(5, 'decimal')
 ---
-- 'Tuple field 5 type does not match one required by operation: expected decimal'
+- 'Tuple field 5 (field5) type does not match one required by operation: expected
+  decimal, got double'
 ...
 -- number --X--> uuid
 fail_format_change(5, 'uuid')
 ---
-- 'Tuple field 5 type does not match one required by operation: expected uuid'
+- 'Tuple field 5 (field5) type does not match one required by operation: expected
+  uuid, got double'
 ...
 -- integer -----> any
 ok_format_change(6, 'any')
@@ -1243,17 +1263,20 @@ ok_format_change(6, 'scalar')
 -- integer --X--> unsigned
 fail_format_change(6, 'unsigned')
 ---
-- 'Tuple field 6 type does not match one required by operation: expected unsigned'
+- 'Tuple field 6 (field6) type does not match one required by operation: expected
+  unsigned, got integer'
 ...
 -- integer --X--> decimal
 fail_format_change(6, 'decimal')
 ---
-- 'Tuple field 6 type does not match one required by operation: expected decimal'
+- 'Tuple field 6 (field6) type does not match one required by operation: expected
+  decimal, got integer'
 ...
 -- integer --X--> uuid
 fail_format_change(6, 'uuid')
 ---
-- 'Tuple field 6 type does not match one required by operation: expected uuid'
+- 'Tuple field 6 (field6) type does not match one required by operation: expected
+  uuid, got integer'
 ...
 -- boolean -----> any
 ok_format_change(7, 'any')
@@ -1266,17 +1289,20 @@ ok_format_change(7, 'scalar')
 -- boolean --X--> string
 fail_format_change(7, 'string')
 ---
-- 'Tuple field 7 type does not match one required by operation: expected string'
+- 'Tuple field 7 (field7) type does not match one required by operation: expected
+  string, got boolean'
 ...
 -- boolead --X--> decimal
 fail_format_change(7, 'decimal')
 ---
-- 'Tuple field 7 type does not match one required by operation: expected decimal'
+- 'Tuple field 7 (field7) type does not match one required by operation: expected
+  decimal, got boolean'
 ...
 -- boolean --X--> uuid
 fail_format_change(7, 'uuid')
 ---
-- 'Tuple field 7 type does not match one required by operation: expected uuid'
+- 'Tuple field 7 (field7) type does not match one required by operation: expected
+  uuid, got boolean'
 ...
 -- scalar -----> any
 ok_format_change(8, 'any')
@@ -1285,17 +1311,20 @@ ok_format_change(8, 'any')
 -- scalar --X--> unsigned
 fail_format_change(8, 'unsigned')
 ---
-- 'Tuple field 8 type does not match one required by operation: expected unsigned'
+- 'Tuple field 8 (field8) type does not match one required by operation: expected
+  unsigned, got integer'
 ...
 -- scalar --X--> decimal
 fail_format_change(8, 'decimal')
 ---
-- 'Tuple field 8 type does not match one required by operation: expected decimal'
+- 'Tuple field 8 (field8) type does not match one required by operation: expected
+  decimal, got integer'
 ...
 -- scalar --X--> uuid
 fail_format_change(8, 'uuid')
 ---
-- 'Tuple field 8 type does not match one required by operation: expected uuid'
+- 'Tuple field 8 (field8) type does not match one required by operation: expected
+  uuid, got integer'
 ...
 -- array -----> any
 ok_format_change(9, 'any')
@@ -1304,17 +1333,20 @@ ok_format_change(9, 'any')
 -- array --X--> scalar
 fail_format_change(9, 'scalar')
 ---
-- 'Tuple field 9 type does not match one required by operation: expected scalar'
+- 'Tuple field 9 (field9) type does not match one required by operation: expected
+  scalar, got array'
 ...
 -- arary --X--> decimal
 fail_format_change(9, 'decimal')
 ---
-- 'Tuple field 9 type does not match one required by operation: expected decimal'
+- 'Tuple field 9 (field9) type does not match one required by operation: expected
+  decimal, got array'
 ...
 -- array --X--> uuid
 fail_format_change(9, 'uuid')
 ---
-- 'Tuple field 9 type does not match one required by operation: expected uuid'
+- 'Tuple field 9 (field9) type does not match one required by operation: expected
+  uuid, got array'
 ...
 -- map -----> any
 ok_format_change(10, 'any')
@@ -1323,17 +1355,20 @@ ok_format_change(10, 'any')
 -- map --X--> scalar
 fail_format_change(10, 'scalar')
 ---
-- 'Tuple field 10 type does not match one required by operation: expected scalar'
+- 'Tuple field 10 (field10) type does not match one required by operation: expected
+  scalar, got map'
 ...
 -- map --X--> decimal
 fail_format_change(10, 'decimal')
 ---
-- 'Tuple field 10 type does not match one required by operation: expected decimal'
+- 'Tuple field 10 (field10) type does not match one required by operation: expected
+  decimal, got map'
 ...
 -- map --X--> uuid
 fail_format_change(10, 'uuid')
 ---
-- 'Tuple field 10 type does not match one required by operation: expected uuid'
+- 'Tuple field 10 (field10) type does not match one required by operation: expected
+  uuid, got map'
 ...
 -- decimal ----> any
 ok_format_change(11, 'any')
@@ -1350,32 +1385,38 @@ ok_format_change(11, 'scalar')
 -- decimal --X--> string
 fail_format_change(11, 'string')
 ---
-- 'Tuple field 11 type does not match one required by operation: expected string'
+- 'Tuple field 11 (field11) type does not match one required by operation: expected
+  string, got extension'
 ...
 -- decimal --X--> integer
 fail_format_change(11, 'integer')
 ---
-- 'Tuple field 11 type does not match one required by operation: expected integer'
+- 'Tuple field 11 (field11) type does not match one required by operation: expected
+  integer, got extension'
 ...
 -- decimal --X--> unsigned
 fail_format_change(11, 'unsigned')
 ---
-- 'Tuple field 11 type does not match one required by operation: expected unsigned'
+- 'Tuple field 11 (field11) type does not match one required by operation: expected
+  unsigned, got extension'
 ...
 -- decimal --X--> map
 fail_format_change(11, 'map')
 ---
-- 'Tuple field 11 type does not match one required by operation: expected map'
+- 'Tuple field 11 (field11) type does not match one required by operation: expected
+  map, got extension'
 ...
 -- decimal --X--> array
 fail_format_change(11, 'array')
 ---
-- 'Tuple field 11 type does not match one required by operation: expected array'
+- 'Tuple field 11 (field11) type does not match one required by operation: expected
+  array, got extension'
 ...
 -- decimal --X--> uuid
 fail_format_change(11, 'uuid')
 ---
-- 'Tuple field 11 type does not match one required by operation: expected uuid'
+- 'Tuple field 11 (field11) type does not match one required by operation: expected
+  uuid, got extension'
 ...
 -- uuid ----> any
 ok_format_change(12, 'any')
@@ -1384,42 +1425,50 @@ ok_format_change(12, 'any')
 -- uuid --X--> number
 fail_format_change(12, 'number')
 ---
-- 'Tuple field 12 type does not match one required by operation: expected number'
+- 'Tuple field 12 (field12) type does not match one required by operation: expected
+  number, got extension'
 ...
 -- uuid --X--> scalar
 fail_format_change(12, 'scalar')
 ---
-- 'Tuple field 12 type does not match one required by operation: expected scalar'
+- 'Tuple field 12 (field12) type does not match one required by operation: expected
+  scalar, got extension'
 ...
 -- uuid --X--> string
 fail_format_change(12, 'string')
 ---
-- 'Tuple field 12 type does not match one required by operation: expected string'
+- 'Tuple field 12 (field12) type does not match one required by operation: expected
+  string, got extension'
 ...
 -- uuid --X--> integer
 fail_format_change(12, 'integer')
 ---
-- 'Tuple field 12 type does not match one required by operation: expected integer'
+- 'Tuple field 12 (field12) type does not match one required by operation: expected
+  integer, got extension'
 ...
 -- uuid --X--> unsigned
 fail_format_change(12, 'unsigned')
 ---
-- 'Tuple field 12 type does not match one required by operation: expected unsigned'
+- 'Tuple field 12 (field12) type does not match one required by operation: expected
+  unsigned, got extension'
 ...
 -- uuid --X--> map
 fail_format_change(12, 'map')
 ---
-- 'Tuple field 12 type does not match one required by operation: expected map'
+- 'Tuple field 12 (field12) type does not match one required by operation: expected
+  map, got extension'
 ...
 -- uuid --X--> array
 fail_format_change(12, 'array')
 ---
-- 'Tuple field 12 type does not match one required by operation: expected array'
+- 'Tuple field 12 (field12) type does not match one required by operation: expected
+  array, got extension'
 ...
 -- uuid --X--> decimal
 fail_format_change(12, 'decimal')
 ---
-- 'Tuple field 12 type does not match one required by operation: expected decimal'
+- 'Tuple field 12 (field12) type does not match one required by operation: expected
+  decimal, got extension'
 ...
 s:drop()
 ---
@@ -1509,7 +1558,7 @@ s:format(format)
 -- Fail, not enough fields.
 s:replace{2, 2, 2, 2, 2}
 ---
-- error: Tuple field 6 required by space format is missing
+- error: Tuple field 6 (field6) required by space format is missing
 ...
 s:replace{2, 2, 2, 2, 2, 2, 2}
 ---
@@ -1649,7 +1698,8 @@ format[2].is_nullable = false
 ...
 s:format(format)
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 (field2) type does not match one required by operation: expected
+    unsigned, got nil'
 ...
 _ = s:delete(1)
 ---
@@ -1707,7 +1757,8 @@ s:insert({1, NULL})
 ...
 s.index.secondary:alter({ parts = {{2, 'string', is_nullable = false} }})
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected string'
+- error: 'Tuple field 2 type does not match one required by operation: expected string,
+    got nil'
 ...
 _ = s:delete({1})
 ---
@@ -1717,7 +1768,8 @@ s.index.secondary:alter({ parts = {{2, 'string', is_nullable = false} }})
 ...
 s:insert({1, NULL})
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected string'
+- error: 'Tuple field 2 type does not match one required by operation: expected string,
+    got nil'
 ...
 s:insert({2, 'xxx'})
 ---
@@ -1837,7 +1889,8 @@ s:replace{1, box.NULL, 1}
 ...
 sk1:alter({parts = {{2, 'unsigned', is_nullable = false}}})
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 type does not match one required by operation: expected unsigned,
+    got nil'
 ...
 s:replace{1, 1, 1}
 ---
@@ -1848,7 +1901,8 @@ sk1:alter({parts = {{2, 'unsigned', is_nullable = false}}})
 ...
 s:replace{1, 1, box.NULL}
 ---
-- error: 'Tuple field 3 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 3 type does not match one required by operation: expected unsigned,
+    got nil'
 ...
 sk2:alter({parts = {{3, 'unsigned', is_nullable = true}}})
 ---
@@ -1932,11 +1986,13 @@ s:format()
 ...
 s:replace{1, '100', -20.2}
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 (field2) type does not match one required by operation: expected
+    unsigned, got string'
 ...
 s:replace{1, 100, -20.2}
 ---
-- error: 'Tuple field 3 type does not match one required by operation: expected integer'
+- error: 'Tuple field 3 (field3) type does not match one required by operation: expected
+    integer, got double'
 ...
 s:replace{1, 100, -20}
 ---
@@ -2000,11 +2056,13 @@ sk4:alter{parts = {{3, 'integer'}}}
 ...
 s:replace{1, 50.5, 1.5}
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 (field2) type does not match one required by operation: expected
+    unsigned, got double'
 ...
 s:replace{1, 50, 1.5}
 ---
-- error: 'Tuple field 3 type does not match one required by operation: expected integer'
+- error: 'Tuple field 3 (field3) type does not match one required by operation: expected
+    integer, got double'
 ...
 s:replace{5, 5, 5}
 ---
@@ -2177,11 +2235,13 @@ s:create_index('sk', {parts = {2, 'string'}}) -- error: unique constraint
 ...
 s:create_index('sk', {parts = {3, 'string'}}) -- error: nullability constraint
 ---
-- error: 'Tuple field 3 type does not match one required by operation: expected string'
+- error: 'Tuple field 3 type does not match one required by operation: expected string,
+    got nil'
 ...
 s:create_index('sk', {parts = {4, 'unsigned'}}) -- error: field type
 ---
-- error: 'Tuple field 4 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 4 type does not match one required by operation: expected unsigned,
+    got integer'
 ...
 s:create_index('sk', {parts = {4, 'integer', 5, 'string'}}) -- error: field missing
 ---
@@ -2229,11 +2289,13 @@ i1:alter{unique = true} -- error: unique contraint
 ...
 i2:alter{parts = {3, 'string'}} -- error: nullability contraint
 ---
-- error: 'Tuple field 3 type does not match one required by operation: expected string'
+- error: 'Tuple field 3 type does not match one required by operation: expected string,
+    got nil'
 ...
 i3:alter{parts = {4, 'unsigned'}} -- error: field type
 ---
-- error: 'Tuple field 4 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 4 type does not match one required by operation: expected unsigned,
+    got integer'
 ...
 i3:alter{parts = {4, 'integer', 5, 'string'}} -- error: field missing
 ---

--- a/test/engine/decimal.result
+++ b/test/engine/decimal.result
@@ -130,15 +130,18 @@ box.space.test:select{}
 -- check invalid values
 box.space.test:insert{1.23}
  | ---
- | - error: 'Tuple field 1 type does not match one required by operation: expected decimal'
+ | - error: 'Tuple field 1 type does not match one required by operation: expected decimal,
+ |     got double'
  | ...
 box.space.test:insert{'str'}
  | ---
- | - error: 'Tuple field 1 type does not match one required by operation: expected decimal'
+ | - error: 'Tuple field 1 type does not match one required by operation: expected decimal,
+ |     got string'
  | ...
 box.space.test:insert{ffi.new('uint64_t', 0)}
  | ---
- | - error: 'Tuple field 1 type does not match one required by operation: expected decimal'
+ | - error: 'Tuple field 1 type does not match one required by operation: expected decimal,
+ |     got unsigned'
  | ...
 -- check duplicates
 box.space.test:insert{decimal.new(0)}
@@ -315,7 +318,8 @@ box.space.test:insert{2, -5}
 -- failure
 box.space.test.index.sk:alter{parts={2, 'decimal'}}
  | ---
- | - error: 'Tuple field 2 type does not match one required by operation: expected decimal'
+ | - error: 'Tuple field 2 type does not match one required by operation: expected decimal,
+ |     got integer'
  | ...
 _ = box.space.test:delete{2}
  | ---
@@ -330,12 +334,14 @@ box.space.test:insert{3, decimal.new(3)}
 --failure
 box.space.test:insert{4, 'string'}
  | ---
- | - error: 'Tuple field 2 type does not match one required by operation: expected decimal'
+ | - error: 'Tuple field 2 type does not match one required by operation: expected decimal,
+ |     got string'
  | ...
 -- failure
 box.space.test:insert{2, -5}
  | ---
- | - error: 'Tuple field 2 type does not match one required by operation: expected decimal'
+ | - error: 'Tuple field 2 type does not match one required by operation: expected decimal,
+ |     got integer'
  | ...
 box.space.test.index.sk:alter{parts={2, 'number'}}
  | ---

--- a/test/engine/errinj_ddl.result
+++ b/test/engine/errinj_ddl.result
@@ -65,7 +65,8 @@ errinj.set("ERRINJ_CHECK_FORMAT_DELAY", true)
 ...
 s:format(format) -- must fail
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected string'
+- error: 'Tuple field 2 (field2) type does not match one required by operation: expected
+    string, got nil'
 ...
 ch:get()
 ---
@@ -144,7 +145,8 @@ errinj.set('ERRINJ_BUILD_INDEX_DELAY', true);
 fiber.new(function() t:replace{1, 'asdf'} errinj.set('ERRINJ_BUILD_INDEX_DELAY', false) end)
 t:create_index('sk', {parts = {2, 'unsigned'}});
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 type does not match one required by operation: expected unsigned,
+    got string'
 ...
 t:get{1};
 ---
@@ -165,7 +167,8 @@ errinj.set('ERRINJ_BUILD_INDEX_DELAY', true);
 fiber.new(function() t:replace{2, 'asdf'} errinj.set('ERRINJ_BUILD_INDEX_DELAY', false) end)
 t:create_index('sk', {parts = {2, 'unsigned'}});
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 type does not match one required by operation: expected unsigned,
+    got string'
 ...
 t:get{2};
 ---

--- a/test/engine/gh-5192-multikey-root-nullability.result
+++ b/test/engine/gh-5192-multikey-root-nullability.result
@@ -41,14 +41,16 @@ _ = s:create_index('i1', {parts={{1, 'unsigned'}}})
  | ...
 s:replace{1, box.NULL} -- error
  | ---
- | - error: 'Tuple field 2 type does not match one required by operation: expected array'
+ | - error: 'Tuple field 2 (data) type does not match one required by operation: expected
+ |     array, got nil'
  | ...
 _ = s:create_index('i2', {parts={{field=2, path='[*].key', type='string'}}})
  | ---
  | ...
 s:replace{2, box.NULL} -- error
  | ---
- | - error: 'Tuple field 2 type does not match one required by operation: expected array'
+ | - error: 'Tuple field 2 (data) type does not match one required by operation: expected
+ |     array, got nil'
  | ...
 s:replace{3, {}} -- ok
  | ---

--- a/test/engine/indices_any_type.result
+++ b/test/engine/indices_any_type.result
@@ -698,15 +698,18 @@ i4_1 = s4:create_index('my_space5_idx1', {type='TREE', parts={1, 'scalar', 2, 'i
 ...
 s4:insert({mp.NULL, 1, 1, 1})
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected scalar'
+- error: 'Tuple field 1 type does not match one required by operation: expected scalar,
+    got nil'
 ...
 s4:insert({2, mp.NULL, 2, 2}) -- all nulls must fail
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected integer'
+- error: 'Tuple field 2 type does not match one required by operation: expected integer,
+    got nil'
 ...
 s4:insert({3, 3, mp.NULL, 3})
 ---
-- error: 'Tuple field 3 type does not match one required by operation: expected number'
+- error: 'Tuple field 3 type does not match one required by operation: expected number,
+    got nil'
 ...
 s4:insert({4, 4, 4, mp.NULL})
 ---
@@ -782,7 +785,8 @@ s5:insert({7, true})
 ...
 s5:insert({8, mp.NULL}) -- must fail
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected scalar'
+- error: 'Tuple field 2 type does not match one required by operation: expected scalar,
+    got nil'
 ...
 s5:insert({9, -40.5})
 ---

--- a/test/engine/insert.result
+++ b/test/engine/insert.result
@@ -762,15 +762,18 @@ s:insert({3, -3.0009})
 --
 s:insert({4, 1})
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected double'
+- error: 'Tuple field 2 (d) type does not match one required by operation: expected
+    double, got unsigned'
 ...
 s:insert({5, -9223372036854775800ULL})
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected double'
+- error: 'Tuple field 2 (d) type does not match one required by operation: expected
+    double, got unsigned'
 ...
 s:insert({6, 18000000000000000000ULL})
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected double'
+- error: 'Tuple field 2 (d) type does not match one required by operation: expected
+    double, got unsigned'
 ...
 --
 -- To insert an integer, we must cast it to a CDATA of type DOUBLE
@@ -892,19 +895,23 @@ ddd = s:create_index('ddd', {parts = {{2, 'double'}}})
 ...
 s:update(1, {{'=', 2, 2}})
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected double'
+- error: 'Tuple field 2 (d) type does not match one required by operation: expected
+    double, got unsigned'
 ...
 s:insert({22, 22})
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected double'
+- error: 'Tuple field 2 (d) type does not match one required by operation: expected
+    double, got unsigned'
 ...
 s:upsert({10, 100}, {{'=', 2, 2}})
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected double'
+- error: 'Tuple field 2 (d) type does not match one required by operation: expected
+    double, got unsigned'
 ...
 s:upsert({100, 100}, {{'=', 2, 2}})
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected double'
+- error: 'Tuple field 2 (d) type does not match one required by operation: expected
+    double, got unsigned'
 ...
 ddd:update(1, {{'=', 1, 70}})
 ---

--- a/test/engine/json.result
+++ b/test/engine/json.result
@@ -76,12 +76,12 @@ s:create_index('test2', {parts = {{2, 'number'}, {3, 'number', path = 'FIO.fname
 s:insert{7, 7, {town = 'London', FIO = 666}, 4, 5}
 ---
 - error: 'Tuple field [3]["FIO"] type does not match one required by operation: expected
-    map'
+    map, got unsigned'
 ...
 s:insert{7, 7, {town = 'London', FIO = {fname = 666, sname = 'Bond'}}, 4, 5}
 ---
 - error: 'Tuple field [3]["FIO"]["fname"] type does not match one required by operation:
-    expected string'
+    expected string, got unsigned'
 ...
 s:insert{7, 7, {town = 'London', FIO = {fname = "James"}}, 4, 5}
 ---
@@ -269,7 +269,7 @@ s:insert{4, 4, 7, {town = 'London', FIO = {1,2,3}}, 4, 5}
 s:create_index('test1', {parts = {{3, 'number'}, {4, 'str', path = '["FIO"]["fname"]'}, {4, 'str', path = '["FIO"]["sname"]'}}})
 ---
 - error: 'Tuple field [4]["FIO"] type does not match one required by operation: expected
-    map'
+    map, got unsigned'
 ...
 _ = s:delete(1)
 ---
@@ -284,7 +284,7 @@ _ = s:delete(2)
 s:create_index('test1', {parts = {{3, 'number'}, {4, 'str', path = '["FIO"]["fname"]'}, {4, 'str', path = '["FIO"]["sname"]'}}})
 ---
 - error: 'Tuple field [4]["FIO"] type does not match one required by operation: expected
-    map'
+    map, got array'
 ...
 _ = s:delete(4)
 ---
@@ -509,12 +509,12 @@ s:insert{{-1}}
 i:alter{parts = {{1, 'string', path = '[1]'}}}
 ---
 - error: 'Tuple field [1][1] type does not match one required by operation: expected
-    string'
+    string, got integer'
 ...
 s:insert{{'a'}}
 ---
 - error: 'Tuple field [1][1] type does not match one required by operation: expected
-    integer'
+    integer, got string'
 ...
 i:drop()
 ---
@@ -529,12 +529,12 @@ s:insert{{{FIO=-1}}}
 i:alter{parts = {{1, 'integer', path = '[1][1]'}}}
 ---
 - error: 'Tuple field [1][1] type does not match one required by operation: expected
-    array'
+    array, got map'
 ...
 i:alter{parts = {{1, 'integer', path = '[1].FIO[1]'}}}
 ---
 - error: 'Tuple field [1][1]["FIO"] type does not match one required by operation:
-    expected array'
+    expected array, got integer'
 ...
 s:drop()
 ---

--- a/test/engine/multikey.result
+++ b/test/engine/multikey.result
@@ -801,7 +801,7 @@ s:insert{1, box.NULL} -- ok
 s:insert{2, {box.NULL}} -- error
 ---
 - error: 'Tuple field [2][*] type does not match one required by operation: expected
-    unsigned'
+    unsigned, got nil'
 ...
 s:insert{3, {}} -- ok
 ---
@@ -854,7 +854,8 @@ _ = s:create_index('sk', {parts = {{'[2][*]', 'unsigned'}}})
 ...
 s:insert{1, {a = 1}} -- error
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected array'
+- error: 'Tuple field 2 type does not match one required by operation: expected array,
+    got map'
 ...
 s:insert{2, {1}} -- ok
 ---

--- a/test/engine/null.result
+++ b/test/engine/null.result
@@ -458,7 +458,7 @@ sk = s:create_index('sk', {parts = {2, 'unsigned'}})
 ...
 s:replace{1, 2} -- error
 ---
-- error: Tuple field 3 required by space format is missing
+- error: Tuple field 3 (field3) required by space format is missing
 ...
 t1 = s:replace{2, 3, 4}
 ---
@@ -529,15 +529,15 @@ sk = s:create_index('sk', {parts = {2, 'unsigned'}})
 ...
 s:replace{1, 2} -- error
 ---
-- error: Tuple field 3 required by space format is missing
+- error: Tuple field 3 (field3) required by space format is missing
 ...
 s:replace{2, 3, 4} -- error
 ---
-- error: Tuple field 5 required by space format is missing
+- error: Tuple field 5 (field5) required by space format is missing
 ...
 s:replace{3, 4, 5, 6} -- error
 ---
-- error: Tuple field 5 required by space format is missing
+- error: Tuple field 5 (field5) required by space format is missing
 ...
 t1 = s:replace{4, 5, 6, 7, 8}
 ---
@@ -966,7 +966,8 @@ s:replace{50, 50}
 ...
 s:replace{25, box.NULL}
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 (field2) type does not match one required by operation: expected
+    unsigned, got nil'
 ...
 format[2].is_nullable = true
 ---
@@ -1021,7 +1022,8 @@ s:replace{50, 50}
 ...
 s:replace{25, box.NULL}
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 type does not match one required by operation: expected unsigned,
+    got nil'
 ...
 sk:alter({parts = {{2, 'unsigned', is_nullable = true}}})
 ---
@@ -1612,7 +1614,8 @@ s:replace{1, 1}
 ...
 s:replace{2, box.NULL}
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 type does not match one required by operation: expected unsigned,
+    got nil'
 ...
 s:select{}
 ---
@@ -1764,11 +1767,12 @@ s:format(format)
 -- Field 2 is not nullable.
 s:insert{5}
 ---
-- error: Tuple field 2 required by space format is missing
+- error: Tuple field 2 (second) required by space format is missing
 ...
 s:insert{5, box.NULL}
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 (second) type does not match one required by operation: expected
+    unsigned, got nil'
 ...
 s.index.secondary:alter{parts={{2, 'unsigned', is_nullable=true}}} -- This is allowed.
 ---
@@ -1776,11 +1780,12 @@ s.index.secondary:alter{parts={{2, 'unsigned', is_nullable=true}}} -- This is al
 -- Without space format setting this fails.
 s:insert{5, box.NULL}
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 (second) type does not match one required by operation: expected
+    unsigned, got nil'
 ...
 s:insert{5}
 ---
-- error: Tuple field 2 required by space format is missing
+- error: Tuple field 2 (second) required by space format is missing
 ...
 s.index.secondary:alter{parts={{2, 'unsigned', is_nullable=false}}}
 ---
@@ -1794,11 +1799,12 @@ s:format(format) -- This is also allowed.
 -- inserts still fail due to not nullable index parts.
 s:insert{5, box.NULL}
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 (second) type does not match one required by operation: expected
+    unsigned, got nil'
 ...
 s:insert{5}
 ---
-- error: Tuple field 2 required by space format is missing
+- error: Tuple field 2 (second) required by space format is missing
 ...
 s.index.secondary:alter{parts={{2, 'unsigned', is_nullable=true}}}
 ---
@@ -1830,22 +1836,24 @@ format[2].is_nullable = false
 ...
 s:format(format) -- Fail.
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 (second) type does not match one required by operation: expected
+    unsigned, got nil'
 ...
 s.index.secondary:alter{parts={{2, 'unsigned', is_nullable=false}}} -- Fail.
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 (second) type does not match one required by operation: expected
+    unsigned, got nil'
 ...
 _ = s:delete{5}
 ---
 ...
 s:format(format) -- Still fail.
 ---
-- error: Tuple field 2 required by space format is missing
+- error: Tuple field 2 (second) required by space format is missing
 ...
 s.index.secondary:alter{parts={{2, 'unsigned', is_nullable=false}}} -- Still fail.
 ---
-- error: Tuple field 2 required by space format is missing
+- error: Tuple field 2 (second) required by space format is missing
 ...
 -- Now check we can set nullability to false step by step.
 _ = s:delete{6}
@@ -1859,11 +1867,12 @@ s:format(format)
 ...
 s:insert{5, box.NULL} -- Fail.
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 (second) type does not match one required by operation: expected
+    unsigned, got nil'
 ...
 s:insert{5} -- Fail.
 ---
-- error: Tuple field 2 required by space format is missing
+- error: Tuple field 2 (second) required by space format is missing
 ...
 format[2].is_nullable = true
 ---
@@ -1876,11 +1885,12 @@ s.index.secondary:alter{parts={{2, 'unsigned', is_nullable=false}}}
 ...
 s:insert{5, box.NULL} -- Fail.
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 (second) type does not match one required by operation: expected
+    unsigned, got nil'
 ...
 s:insert{5} -- Fail.
 ---
-- error: Tuple field 2 required by space format is missing
+- error: Tuple field 2 (second) required by space format is missing
 ...
 format[2].is_nullable = false
 ---
@@ -1894,7 +1904,7 @@ s:select{}
 ...
 s:insert{5} -- Fail.
 ---
-- error: Tuple field 2 required by space format is missing
+- error: Tuple field 2 (second) required by space format is missing
 ...
 s:insert{9, 10} -- Success.
 ---
@@ -1922,7 +1932,8 @@ sk2 = s:create_index('sk2', {parts={{2, 'number', is_nullable=true}}})
 ...
 s:insert{2, nil, 2} --error
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected number'
+- error: 'Tuple field 2 type does not match one required by operation: expected number,
+    got nil'
 ...
 s:drop()
 ---

--- a/test/engine/tree.result
+++ b/test/engine/tree.result
@@ -2877,19 +2877,23 @@ sort(space:select{})
 -- https://bugs.launchpad.net/tarantool/+bug/1072624
 space:insert{'', 1, 2, '', '', '', '', '', 0}
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 1 type does not match one required by operation: expected unsigned,
+    got string'
 ...
 space:insert{'xxxxxxxx', 1, 2, '', '', '', '', '', 0}
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 1 type does not match one required by operation: expected unsigned,
+    got string'
 ...
 space:insert{1, '', 2, '', '', '', '', '', 0}
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 type does not match one required by operation: expected unsigned,
+    got string'
 ...
 space:insert{1, 'xxxxxxxxxxx', 2, '', '', '', '', '', 0}
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 type does not match one required by operation: expected unsigned,
+    got string'
 ...
 space:drop()
 ---

--- a/test/engine/tree_variants.result
+++ b/test/engine/tree_variants.result
@@ -184,19 +184,23 @@ sort(space:select{})
 -- https://bugs.launchpad.net/tarantool/+bug/1072624
 space:insert{'', 1, 2, '', '', '', '', '', 0}
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 1 type does not match one required by operation: expected unsigned,
+    got string'
 ...
 space:insert{'xxxxxxxx', 1, 2, '', '', '', '', '', 0}
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 1 type does not match one required by operation: expected unsigned,
+    got string'
 ...
 space:insert{1, '', 2, '', '', '', '', '', 0}
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 type does not match one required by operation: expected unsigned,
+    got string'
 ...
 space:insert{1, 'xxxxxxxxxxx', 2, '', '', '', '', '', 0}
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 type does not match one required by operation: expected unsigned,
+    got string'
 ...
 space:drop()
 ---

--- a/test/engine/update.result
+++ b/test/engine/update.result
@@ -722,7 +722,8 @@ aa.VAL
 -- invalid update
 aa:update({{'=',2, 666}})
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected string'
+- error: 'Tuple field 2 (VAL) type does not match one required by operation: expected
+    string, got unsigned'
 ...
 -- test transform integrity
 aa:transform(-1, 1)
@@ -753,7 +754,8 @@ box.space.tst_sample:get(2).VAL
 -- invalid upsert
 s:upsert({2, 666}, {{'=', 2, 666}})
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected string'
+- error: 'Tuple field 2 (VAL) type does not match one required by operation: expected
+    string, got unsigned'
 ...
 s:drop()
 ---

--- a/test/engine/upsert.result
+++ b/test/engine/upsert.result
@@ -1085,7 +1085,8 @@ index = space:create_index('primary', { type = 'tree', parts = {1, 'unsigned', 2
 ...
 space:upsert({0, 'key', 0}, {{'+', 3, 1}})
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 type does not match one required by operation: expected unsigned,
+    got string'
 ...
 space:drop()
 ---
@@ -1805,7 +1806,8 @@ index1 = space:create_index('primary', { parts = {1, 'string'} })
 ...
 space:upsert({1}, {{'!', 2, 100}}) -- must fail on checking tuple
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected string'
+- error: 'Tuple field 1 type does not match one required by operation: expected string,
+    got unsigned'
 ...
 space:upsert({'a'}, {{'a', 2, 100}}) -- must fail on checking ops
 ---
@@ -1859,7 +1861,8 @@ index2:select{}
 -- test upsert that executes as update
 space:upsert({'a', 100, 100}, {{'=', 3, -200}}) -- must fail on cheking new tuple in secondary index
 ---
-- error: 'Tuple field 3 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 3 type does not match one required by operation: expected unsigned,
+    got integer'
 ...
 space:upsert({'b', 100, 200}, {{'=', 1, 'd'}}) -- must fail with attempt to modify primary index
 ---

--- a/test/replication/gh-3247-misc-iproto-sequence-value-not-replicated.result
+++ b/test/replication/gh-3247-misc-iproto-sequence-value-not-replicated.result
@@ -41,7 +41,8 @@ c = net_box.connect(box.cfg.listen)
 ...
 c.space.space1:insert{box.NULL, "data"} -- fails, but bumps sequence value
 ---
-- error: 'Tuple field 2 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 2 type does not match one required by operation: expected unsigned,
+    got string'
 ...
 c.space.space1:insert{box.NULL, 1, "data"}
 ---

--- a/test/sql/checks.result
+++ b/test/sql/checks.result
@@ -49,7 +49,8 @@ box.space._ck_constraint:insert({550, 'CK_CONSTRAINT_01', false, 'SQL', 'X<5', t
 -- Pass integer instead of expression.
 box.space._ck_constraint:insert({513, 'CK_CONSTRAINT_01', false, 'SQL', 666, true})
 ---
-- error: 'Tuple field 5 type does not match one required by operation: expected string'
+- error: 'Tuple field 5 (code) type does not match one required by operation: expected
+    string, got unsigned'
 ...
 -- Deferred CK constraints are not supported.
 box.space._ck_constraint:insert({513, 'CK_CONSTRAINT_01', true, 'SQL', 'X<5', true})
@@ -392,11 +393,12 @@ _ = box.space._ck_constraint:insert({s.id, 'XlessY', false, 'SQL', 'X < Y and Y 
 ...
 s:insert({'1', 2})
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 1 (X) type does not match one required by operation: expected
+    unsigned, got string'
 ...
 s:insert({})
 ---
-- error: Tuple field 1 required by space format is missing
+- error: Tuple field 1 (X) required by space format is missing
 ...
 s:insert({2, 1})
 ---

--- a/test/vinyl/constraint.result
+++ b/test/vinyl/constraint.result
@@ -7,11 +7,13 @@ index = space:create_index('primary', { type = 'tree', parts = {1, 'string'} })
 ...
 space:insert{1}
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected string'
+- error: 'Tuple field 1 type does not match one required by operation: expected string,
+    got unsigned'
 ...
 space:replace{1}
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected string'
+- error: 'Tuple field 1 type does not match one required by operation: expected string,
+    got unsigned'
 ...
 space:delete{1}
 ---
@@ -23,7 +25,8 @@ space:update({1}, {{'=', 1, 101}})
 ...
 space:upsert({1}, {{'+', 1, 10}})
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected string'
+- error: 'Tuple field 1 type does not match one required by operation: expected string,
+    got unsigned'
 ...
 space:get{1}
 ---
@@ -45,11 +48,13 @@ index = space:create_index('primary', { type = 'tree', parts = {1, 'unsigned'} }
 ...
 space:insert{'A'}
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 1 type does not match one required by operation: expected unsigned,
+    got string'
 ...
 space:replace{'A'}
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 1 type does not match one required by operation: expected unsigned,
+    got string'
 ...
 space:delete{'A'}
 ---
@@ -61,7 +66,8 @@ space:update({'A'}, {{'=', 1, 101}})
 ...
 space:upsert({'A'}, {{'+', 1, 10}})
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 1 type does not match one required by operation: expected unsigned,
+    got string'
 ...
 space:get{'A'}
 ---

--- a/test/vinyl/gh.result
+++ b/test/vinyl/gh.result
@@ -158,7 +158,8 @@ i = s:create_index('primary',{parts={1, 'string'}})
 ...
 box.space.t:insert{1,'A'}
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected string'
+- error: 'Tuple field 1 type does not match one required by operation: expected string,
+    got unsigned'
 ...
 s:drop()
 ---

--- a/test/vinyl/savepoint.result
+++ b/test/vinyl/savepoint.result
@@ -423,7 +423,8 @@ space:upsert({12}, {})
 ...
 space:insert({'abc'})
 ---
-- error: 'Tuple field 1 type does not match one required by operation: expected unsigned'
+- error: 'Tuple field 1 type does not match one required by operation: expected unsigned,
+    got string'
 ...
 space:update({1}, {{'#', 2, 1}})
 ---


### PR DESCRIPTION
An example is worth a thousand words, so:

```lua
box.cfg{}

box.schema.space.create('account', {if_not_exists=true})
box.space.account:format({ {name='id',type='unsigned'},
      {name='first_name',type='string'},
      {name='last_name',type='string'},
})

box.space.account:put({2, "John", 3})
```

This will lead to:

```
ER_FIELD_TYPE: Tuple field 3 (last_name) type does not match one required by operation: expected string, got unsigned
```

As opposed to:

```
ER_FIELD_TYPE: Tuple field 3 type does not match one required by operation: expected string
```

Which is way easier to debug, when you meet this in production.

Related to #4707 