### PR TITLE
box/lua: new way to define index parts

### DIFF
--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -704,7 +704,11 @@ local function update_index_parts(format, parts)
         "options.parts must have at least one part")
     end
     if type(parts[1]) == 'number' and type(parts[2]) == 'string' then
-        return update_index_parts_1_6_0(parts), true
+        if parts[3] == nil then
+            parts = {parts} -- one part only
+        else
+            return update_index_parts_1_6_0(parts), true
+        end
     end
 
     local parts_can_be_simplified = true

--- a/test/box/misc.result
+++ b/test/box/misc.result
@@ -1024,3 +1024,53 @@ test_run:grep_log('default', 'test log')
 ---
 - test log
 ...
+--
+-- gh-2866: one more way to declare index parts
+--
+s = box.schema.space.create('test')
+---
+...
+i = s:create_index('test1', {parts = {{1, 'unsigned'}}})
+---
+...
+i = s:create_index('test2', {parts = {{2, 'string', is_nullable = true, collation = 'unicode'}}})
+---
+...
+i.parts
+---
+- - type: string
+    is_nullable: true
+    collation: unicode
+    fieldno: 2
+...
+i = s:create_index('test4', {parts = {3, 'string', is_nullable = true}})
+---
+...
+i.parts
+---
+- - type: string
+    is_nullable: true
+    fieldno: 3
+...
+i = s:create_index('test5', {parts = {3, 'string', collation = 'unicode'}})
+---
+...
+i.parts
+---
+- - type: string
+    is_nullable: false
+    collation: unicode
+    fieldno: 3
+...
+i = s:create_index('test6', {parts = {4, 'string'}})
+---
+...
+i.parts
+---
+- - type: string
+    is_nullable: false
+    fieldno: 4
+...
+s:drop()
+---
+...

--- a/test/box/misc.test.lua
+++ b/test/box/misc.test.lua
@@ -348,3 +348,18 @@ tuple_format = box.internal.new_tuple_format(format)
 box.cfg{}
 local ffi = require'ffi' ffi.C._say(ffi.C.S_WARN, nil, 0, nil, "%s", "test log")
 test_run:grep_log('default', 'test log')
+
+--
+-- gh-2866: one more way to declare index parts
+--
+s = box.schema.space.create('test')
+i = s:create_index('test1', {parts = {{1, 'unsigned'}}})
+i = s:create_index('test2', {parts = {{2, 'string', is_nullable = true, collation = 'unicode'}}})
+i.parts
+i = s:create_index('test4', {parts = {3, 'string', is_nullable = true}})
+i.parts
+i = s:create_index('test5', {parts = {3, 'string', collation = 'unicode'}})
+i.parts
+i = s:create_index('test6', {parts = {4, 'string'}})
+i.parts
+s:drop()


### PR DESCRIPTION
Previously accepted formats of index parts:
parts = {field1, type1, field2, type2}, or
parts = {{field1, type1, ...}, {field2, type2, ...}}

Now it is allowed to write without extra brace if there is one part only:
parts = {field1, type1, ...}

Closes #2866