### PR TITLE
Change 'force_recovery' option behavior and makes tarantool to ignore some errors during snapshot recovery just like during xlog recovery

### DIFF
--- a/src/box/memtx_engine.c
+++ b/src/box/memtx_engine.c
@@ -159,8 +159,16 @@ memtx_engine_recover_snapshot(struct memtx_engine *memtx,
 	/* Process existing snapshot */
 	say_info("recovery start");
 	int64_t signature = vclock_sum(vclock);
-	const char *filename = xdir_format_filename(&memtx->snap_dir,
-						    signature, NONE);
+	const char *name = xdir_format_filename(&memtx->snap_dir,
+						signature, NONE);
+	/*
+	 * We need to save name in local variable because
+	 * xdir_format_filename() allocates memory in static buffer
+	 * which will be overwritten later.
+	 */
+	char filename[PATH_MAX];
+	strncpy(filename, name, PATH_MAX - 1);
+	filename[PATH_MAX - 1] = '\0';
 
 	say_info("recovering from `%s'", filename);
 	struct xlog_cursor cursor;

--- a/src/box/xlog.c
+++ b/src/box/xlog.c
@@ -1964,6 +1964,12 @@ xlog_cursor_openfd(struct xlog_cursor *i, int fd, const char *name)
 
 	ssize_t rc;
 	/*
+	 * xlog_cursor_ensure() in case of fail may use cursor's name
+	 * to print fine diagnostic message. So set the name of cursor
+	 * before calling it.
+	 */
+	snprintf(i->name, sizeof(i->name), "%s", name);
+	/*
 	 * we can have eof here, but this is no error,
 	 * because we don't know exact meta size
 	 */
@@ -1979,7 +1985,6 @@ xlog_cursor_openfd(struct xlog_cursor *i, int fd, const char *name)
 		diag_set(XlogError, "Unexpected end of file, run with 'force_recovery = true'");
 		goto error;
 	}
-	snprintf(i->name, sizeof(i->name), "%s", name);
 	i->zdctx = ZSTD_createDStream();
 	if (i->zdctx == NULL) {
 		diag_set(ClientError, ER_DECOMPRESSION,

--- a/test/box/gh-5422-broken_snapshot.lua
+++ b/test/box/gh-5422-broken_snapshot.lua
@@ -1,0 +1,9 @@
+#!/usr/bin/env tarantool
+
+require('console').listen(os.getenv('ADMIN'))
+
+box.cfg({
+    listen = os.getenv("LISTEN"),
+    force_recovery = true,
+    read_only = false,
+})

--- a/test/box/gh-5422-broken_snapshot.result
+++ b/test/box/gh-5422-broken_snapshot.result
@@ -1,0 +1,299 @@
+-- write data recover from latest snapshot
+env = require('test_run')
+---
+...
+test_run = env.new()
+---
+...
+test_run:cmd("restart server default")
+fio = require 'fio'
+---
+...
+test_run:cmd("setopt delimiter ';'")
+---
+- true
+...
+function get_snap_file ()
+    local snapfile = nil
+    local directory = fio.pathjoin(fio.cwd(), 'gh-5422-broken_snapshot')
+    for files in io.popen(string.format("ls %s", directory)):lines() do
+        local snaps = string.find(files, "snap")
+        if (snaps ~= nil) then
+            local snap = string.find(files, "%n")
+	    if (snap ~= nil) then
+                snapfile = string.format("%s/%s", directory, files)
+            end
+        end
+    end
+    return snapfile
+end;
+---
+...
+test_run:cmd("setopt delimiter ''");
+---
+- true
+...
+test_run:cmd("create server test with script='box/gh-5422-broken_snapshot.lua'")
+---
+- true
+...
+test_run:cmd("start server test")
+---
+- true
+...
+test_run:cmd("switch test")
+---
+- true
+...
+space = box.schema.space.create('test', { engine = "memtx" })
+---
+...
+space:format({ {name = 'id', type = 'unsigned'}, {name = 'year', type = 'unsigned'} })
+---
+...
+index = space:create_index('primary', { parts = {'id'} })
+---
+...
+for key = 1, 10000 do space:insert({key, key + 1000}) end
+---
+...
+box.snapshot()
+---
+- ok
+...
+test_run:cmd("switch default")
+---
+- true
+...
+snapfile = get_snap_file()
+---
+...
+file = io.open(snapfile, "r")
+---
+...
+size = file:seek("end")
+---
+...
+if size > 30000 then size = 30000 end
+---
+...
+io.close(file)
+---
+- true
+...
+-- save last snapshot
+os.execute(string.format('cp %s %s.save', snapfile, snapfile))
+---
+- 0
+...
+-- write garbage at the end of file
+file = io.open(snapfile, "ab")
+---
+...
+for i = 1, 1000, 1 do file:write(math.random(1,254)) end
+---
+...
+io.close(file)
+---
+- true
+...
+test_run:cmd("switch test")
+---
+- true
+...
+test_run:cmd("restart server test with script='box/gh-5422-broken_snapshot.lua'")
+test_run:cmd("setopt delimiter ';'")
+---
+- true
+...
+-- check that all data valid
+val = box.space.test:select()
+for i = 1, 10000, 1 do
+    assert(val[i] ~= nil)
+end;
+---
+...
+test_run:cmd("setopt delimiter ''");
+---
+- true
+...
+test_run:cmd("switch default")
+---
+- true
+...
+-- restore snapshot
+os.execute(string.format('cp %s.save %s', snapfile, snapfile))
+---
+- 0
+...
+-- truncate
+os.execute(string.format('dd if=%s.save of=%s bs=%d count=1', snapfile, snapfile, size))
+---
+- 0
+...
+test_run:cmd("switch test")
+---
+- true
+...
+test_run:cmd("restart server test with script='box/gh-5422-broken_snapshot.lua'")
+-- check than some data valid
+test_run:cmd("setopt delimiter ';'")
+---
+- true
+...
+val = box.space.test:select();
+---
+...
+for i = 1, 1000, 1 do
+    assert(val[i] ~= nil)
+end;
+---
+...
+test_run:cmd("setopt delimiter ''");
+---
+- true
+...
+test_run:cmd("switch default")
+---
+- true
+...
+-- restore snapshot
+os.execute(string.format('cp %s.save %s', snapfile, snapfile))
+---
+- 0
+...
+-- write garbage at the middle of file
+file = io.open(snapfile, "r+b")
+---
+...
+file:seek("set", size)
+---
+- 30000
+...
+for i = 1, 100, 1 do file:write(math.random(1,254)) end
+---
+...
+io.close(file)
+---
+- true
+...
+test_run:cmd("switch test")
+---
+- true
+...
+test_run:cmd("restart server test with script='box/gh-5422-broken_snapshot.lua'")
+test_run:cmd("setopt delimiter ';'")
+---
+- true
+...
+-- check that some data valid
+val = box.space.test:select();
+---
+...
+for i = 1, 1000, 1 do
+    assert(val[i] ~= nil)
+end;
+---
+...
+test_run:cmd("setopt delimiter ''");
+---
+- true
+...
+test_run:cmd("switch default")
+---
+- true
+...
+-- restore snapshot
+os.execute(string.format('cp %s.save %s', snapfile, snapfile))
+---
+- 0
+...
+-- write big garbage at the middle of file, check that start data valid
+file = io.open(snapfile, "r+b")
+---
+...
+file:seek("set", size / 2 + 8000)
+---
+- 23000
+...
+for i = 1, 10000, 1 do file:write(math.random(1,254)) end
+---
+...
+io.close(file)
+---
+- true
+...
+test_run:cmd("switch test")
+---
+- true
+...
+test_run:cmd("restart server test with script='box/gh-5422-broken_snapshot.lua'")
+test_run:cmd("setopt delimiter ';'")
+---
+- true
+...
+-- check that some data valid
+val = box.space.test:select();
+---
+...
+for i = 1, 1000, 1 do
+    assert(val[i] ~= nil)
+end;
+---
+...
+test_run:cmd("setopt delimiter ''");
+---
+- true
+...
+test_run:cmd("switch default")
+---
+- true
+...
+test_run:cmd('stop server test')
+---
+- true
+...
+-- restore snapshot
+os.execute(string.format('cp %s.save %s', snapfile, snapfile))
+---
+- 0
+...
+os.execute(string.format('rm %s.save', snapfile))
+---
+- 0
+...
+-- write big garbage at the start of file
+file = io.open(snapfile, "r+b")
+---
+...
+file:seek("set", size / 2)
+---
+- 15000
+...
+for i = 1, 1000, 1 do file:write(math.random(1,254)) end
+---
+...
+io.close(file)
+---
+- true
+...
+test_run:cmd("start server test with crash_expected=True")
+---
+- false
+...
+log = string.format("%s/%s.%s", fio.cwd(), "gh-5422-broken_snapshot", "log")
+---
+...
+-- We must not find ER_UNKNOWN_REPLICA in log file, so grep return not 0
+assert(os.execute(string.format("cat %s | grep ER_UNKNOWN_REPLICA:", log)) ~= 0)
+---
+- true
+...
+test_run:cmd("cleanup server test")
+---
+- true
+...
+test_run:cmd("delete server test")
+---
+- true
+...

--- a/test/box/gh-5422-broken_snapshot.test.lua
+++ b/test/box/gh-5422-broken_snapshot.test.lua
@@ -1,0 +1,124 @@
+
+-- write data recover from latest snapshot
+env = require('test_run')
+test_run = env.new()
+
+test_run:cmd("restart server default")
+fio = require 'fio'
+test_run:cmd("setopt delimiter ';'")
+function get_snap_file ()
+    local snapfile = nil
+    local directory = fio.pathjoin(fio.cwd(), 'gh-5422-broken_snapshot')
+    for files in io.popen(string.format("ls %s", directory)):lines() do
+        local snaps = string.find(files, "snap")
+        if (snaps ~= nil) then
+            local snap = string.find(files, "%n")
+	    if (snap ~= nil) then
+                snapfile = string.format("%s/%s", directory, files)
+            end
+        end
+    end
+    return snapfile
+end;
+test_run:cmd("setopt delimiter ''");
+
+
+test_run:cmd("create server test with script='box/gh-5422-broken_snapshot.lua'")
+test_run:cmd("start server test")
+test_run:cmd("switch test")
+space = box.schema.space.create('test', { engine = "memtx" })
+space:format({ {name = 'id', type = 'unsigned'}, {name = 'year', type = 'unsigned'} })
+index = space:create_index('primary', { parts = {'id'} })
+
+for key = 1, 10000 do space:insert({key, key + 1000}) end
+box.snapshot()
+
+test_run:cmd("switch default")
+snapfile = get_snap_file()
+file = io.open(snapfile, "r")
+size = file:seek("end")
+if size > 30000 then size = 30000 end
+io.close(file)
+
+-- save last snapshot
+os.execute(string.format('cp %s %s.save', snapfile, snapfile))
+-- write garbage at the end of file
+file = io.open(snapfile, "ab")
+for i = 1, 1000, 1 do file:write(math.random(1,254)) end
+io.close(file)
+test_run:cmd("switch test")
+test_run:cmd("restart server test with script='box/gh-5422-broken_snapshot.lua'")
+test_run:cmd("setopt delimiter ';'")
+-- check that all data valid
+val = box.space.test:select()
+for i = 1, 10000, 1 do
+    assert(val[i] ~= nil)
+end;
+test_run:cmd("setopt delimiter ''");
+test_run:cmd("switch default")
+-- restore snapshot
+os.execute(string.format('cp %s.save %s', snapfile, snapfile))
+-- truncate
+os.execute(string.format('dd if=%s.save of=%s bs=%d count=1', snapfile, snapfile, size))
+
+test_run:cmd("switch test")
+test_run:cmd("restart server test with script='box/gh-5422-broken_snapshot.lua'")
+-- check than some data valid
+test_run:cmd("setopt delimiter ';'")
+val = box.space.test:select();
+for i = 1, 1000, 1 do
+    assert(val[i] ~= nil)
+end;
+test_run:cmd("setopt delimiter ''");
+
+test_run:cmd("switch default")
+-- restore snapshot
+os.execute(string.format('cp %s.save %s', snapfile, snapfile))
+-- write garbage at the middle of file
+file = io.open(snapfile, "r+b")
+file:seek("set", size)
+for i = 1, 100, 1 do file:write(math.random(1,254)) end
+io.close(file)
+test_run:cmd("switch test")
+test_run:cmd("restart server test with script='box/gh-5422-broken_snapshot.lua'")
+test_run:cmd("setopt delimiter ';'")
+-- check that some data valid
+val = box.space.test:select();
+for i = 1, 1000, 1 do
+    assert(val[i] ~= nil)
+end;
+test_run:cmd("setopt delimiter ''");
+test_run:cmd("switch default")
+-- restore snapshot
+os.execute(string.format('cp %s.save %s', snapfile, snapfile))
+-- write big garbage at the middle of file, check that start data valid
+file = io.open(snapfile, "r+b")
+file:seek("set", size / 2 + 8000)
+for i = 1, 10000, 1 do file:write(math.random(1,254)) end
+io.close(file)
+test_run:cmd("switch test")
+test_run:cmd("restart server test with script='box/gh-5422-broken_snapshot.lua'")
+test_run:cmd("setopt delimiter ';'")
+-- check that some data valid
+val = box.space.test:select();
+for i = 1, 1000, 1 do
+    assert(val[i] ~= nil)
+end;
+test_run:cmd("setopt delimiter ''");
+test_run:cmd("switch default")
+test_run:cmd('stop server test')
+
+-- restore snapshot
+os.execute(string.format('cp %s.save %s', snapfile, snapfile))
+os.execute(string.format('rm %s.save', snapfile))
+-- write big garbage at the start of file
+file = io.open(snapfile, "r+b")
+file:seek("set", size / 2)
+for i = 1, 1000, 1 do file:write(math.random(1,254)) end
+io.close(file)
+test_run:cmd("start server test with crash_expected=True")
+log = string.format("%s/%s.%s", fio.cwd(), "gh-5422-broken_snapshot", "log")
+-- We must not find ER_UNKNOWN_REPLICA in log file, so grep return not 0
+assert(os.execute(string.format("cat %s | grep ER_UNKNOWN_REPLICA:", log)) ~= 0)
+test_run:cmd("cleanup server test")
+test_run:cmd("delete server test")


### PR DESCRIPTION
Change 'force_recovery' option behavior and makes tarantool to ignore
some errors during snapshot recovery just like during xlog recovery.