### PR TITLE
memtx: fix a bug with insertion to space during recovery

### DIFF
--- a/src/box/lua/ctl.c
+++ b/src/box/lua/ctl.c
@@ -41,6 +41,8 @@
 
 #include "box/box.h"
 #include "box/schema.h"
+#include "box/engine.h"
+#include "box/memtx_engine.h"
 
 static int
 lbox_ctl_wait_ro(struct lua_State *L)
@@ -86,12 +88,23 @@ lbox_ctl_clear_synchro_queue(struct lua_State *L)
 	return 0;
 }
 
+static int
+lbox_ctl_is_recovery_finished(struct lua_State *L)
+{
+	struct memtx_engine *memtx;
+	memtx = (struct memtx_engine *)engine_by_name("memtx");
+	lua_pushboolean(L, (memtx ?
+		(memtx->state < MEMTX_FINAL_RECOVERY ? 0 : 1) : 0));
+	return 1;
+}
+
 static const struct luaL_Reg lbox_ctl_lib[] = {
 	{"wait_ro", lbox_ctl_wait_ro},
 	{"wait_rw", lbox_ctl_wait_rw},
 	{"on_shutdown", lbox_ctl_on_shutdown},
 	{"on_schema_init", lbox_ctl_on_schema_init},
 	{"clear_synchro_queue", lbox_ctl_clear_synchro_queue},
+	{"is_recovery_finished", lbox_ctl_is_recovery_finished},
 	{NULL, NULL}
 };
 

--- a/src/box/memtx_space.h
+++ b/src/box/memtx_space.h
@@ -31,6 +31,7 @@
  * SUCH DAMAGE.
  */
 #include "space.h"
+#include "memtx_engine.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -86,6 +87,14 @@ memtx_space_replace_all_keys(struct space *, struct tuple *, struct tuple *,
 struct space *
 memtx_space_new(struct memtx_engine *memtx,
 		struct space_def *def, struct rlist *key_list);
+
+static inline bool
+memtx_space_is_recovering(struct space *space)
+{
+	assert(space_is_memtx(space));
+	struct memtx_engine *memtx = (struct memtx_engine *)space->engine;
+	return memtx->state < MEMTX_FINAL_RECOVERY;
+}
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/test/box/gh-5304-insert_during_recovery.lua
+++ b/test/box/gh-5304-insert_during_recovery.lua
@@ -1,0 +1,49 @@
+#!/usr/bin/env tarantool
+
+function none(old_space, new_space)
+end
+
+function trigger_replace(old_space, new_space)
+    box.space.temp:replace({1})
+    box.space.loc:replace({1})
+end
+
+function trigger_insert(old_space, new_space)
+    box.space.temp:insert({1})
+    box.space.loc:insert({1})
+end
+
+function trigger_upsert(old_space, new_space)
+    box.space.temp:upsert({1}, {{'=', 1, 4}})
+    box.space.loc:upsert({1}, {{'=', 1, 4}})
+end
+
+trigger = nil
+
+if arg[1] == 'none' then
+    trigger = none
+elseif arg[1] == 'replace' then
+    trigger = trigger_replace
+elseif arg[1] == 'insert' then
+    trigger = trigger_insert
+elseif arg[1] == 'upsert' then
+    trigger = trigger_upsert
+end
+
+if arg[2] == 'is_recovery_finished' then
+    box.ctl.on_schema_init(function()
+        if box.ctl.is_recovery_finished() then
+            box.space._user:on_replace(trigger)
+        end
+    end)
+else
+    box.ctl.on_schema_init(function()
+        box.space._user:on_replace(trigger)
+    end)
+end
+
+require('console').listen(os.getenv('ADMIN'))
+
+box.cfg({
+    listen = os.getenv("LISTEN"),
+})

--- a/test/box/gh-5304-insert_during_recovery.result
+++ b/test/box/gh-5304-insert_during_recovery.result
@@ -1,0 +1,91 @@
+-- test-run result file version 2
+
+-- write data recover from latest snapshot
+env = require('test_run')
+ | ---
+ | ...
+test_run = env.new()
+ | ---
+ | ...
+
+test_run:cmd('create server test with script="box/gh-5304-insert_during_recovery.lua"')
+ | ---
+ | - true
+ | ...
+test_run:cmd('start server test with args="none"')
+ | ---
+ | - true
+ | ...
+test_run:cmd('switch test')
+ | ---
+ | - true
+ | ...
+s1 = box.schema.space.create('temp', {temporary=true})
+ | ---
+ | ...
+i1 = s1:create_index('test')
+ | ---
+ | ...
+s2 = box.schema.space.create('loc', {is_local=true})
+ | ---
+ | ...
+i2 = s2:create_index('test')
+ | ---
+ | ...
+box.snapshot()
+ | ---
+ | - ok
+ | ...
+
+test_run:cmd('switch default')
+ | ---
+ | - true
+ | ...
+test_run:cmd('stop server test')
+ | ---
+ | - true
+ | ...
+test_run:cmd('start server test with args="replace" with crash_expected=True')
+ | ---
+ | - false
+ | ...
+test_run:cmd('start server test with args="insert" with crash_expected=True')
+ | ---
+ | - false
+ | ...
+test_run:cmd('start server test with args="upsert" with crash_expected=True')
+ | ---
+ | - false
+ | ...
+test_run:cmd('start server test with args="replace is_recovery_finished"')
+ | ---
+ | - true
+ | ...
+test_run:cmd('stop server test')
+ | ---
+ | - true
+ | ...
+test_run:cmd('start server test with args="insert is_recovery_finished"')
+ | ---
+ | - true
+ | ...
+test_run:cmd('stop server test')
+ | ---
+ | - true
+ | ...
+test_run:cmd('start server test with args="upsert is_recovery_finished"')
+ | ---
+ | - true
+ | ...
+test_run:cmd('stop server test')
+ | ---
+ | - true
+ | ...
+test_run:cmd('cleanup server test')
+ | ---
+ | - true
+ | ...
+test_run:cmd('delete server test')
+ | ---
+ | - true
+ | ...

--- a/test/box/gh-5304-insert_during_recovery.test.lua
+++ b/test/box/gh-5304-insert_during_recovery.test.lua
@@ -1,0 +1,27 @@
+
+-- write data recover from latest snapshot
+env = require('test_run')
+test_run = env.new()
+
+test_run:cmd('create server test with script="box/gh-5304-insert_during_recovery.lua"')
+test_run:cmd('start server test with args="none"')
+test_run:cmd('switch test')
+s1 = box.schema.space.create('temp', {temporary=true})
+i1 = s1:create_index('test')
+s2 = box.schema.space.create('loc', {is_local=true})
+i2 = s2:create_index('test')
+box.snapshot()
+
+test_run:cmd('switch default')
+test_run:cmd('stop server test')
+test_run:cmd('start server test with args="replace" with crash_expected=True')
+test_run:cmd('start server test with args="insert" with crash_expected=True')
+test_run:cmd('start server test with args="upsert" with crash_expected=True')
+test_run:cmd('start server test with args="replace is_recovery_finished"')
+test_run:cmd('stop server test')
+test_run:cmd('start server test with args="insert is_recovery_finished"')
+test_run:cmd('stop server test')
+test_run:cmd('start server test with args="upsert is_recovery_finished"')
+test_run:cmd('stop server test')
+test_run:cmd('cleanup server test')
+test_run:cmd('delete server test')

--- a/test/box/gh-5304-replace_during_recovery.lua
+++ b/test/box/gh-5304-replace_during_recovery.lua
@@ -1,0 +1,22 @@
+#!/usr/bin/env tarantool
+
+if arg[1] == 'replace' then
+    box.ctl.on_schema_init(function()
+        box.space._index:on_replace(function(old_space, new_space)
+            if new_space[1] == 512 then
+                box.space.test:on_replace(function(old_tup, new_tup)
+                    box.space.temp:replace({1})
+                    box.space.temp:replace({1})
+                    box.space.loc:replace({1})
+                    box.space.loc:replace({1})
+                end)
+            end
+        end)
+    end)
+end
+
+require('console').listen(os.getenv('ADMIN'))
+
+box.cfg({
+    listen = os.getenv("LISTEN"),
+})

--- a/test/box/gh-5304-replace_during_recovery.result
+++ b/test/box/gh-5304-replace_during_recovery.result
@@ -1,0 +1,69 @@
+-- test-run result file version 2
+
+-- write data recover from latest snapshot
+env = require('test_run')
+ | ---
+ | ...
+test_run = env.new()
+ | ---
+ | ...
+
+test_run:cmd('create server test with script="box/gh-5304-replace_during_recovery.lua"')
+ | ---
+ | - true
+ | ...
+test_run:cmd('start server test')
+ | ---
+ | - true
+ | ...
+test_run:cmd('switch test')
+ | ---
+ | - true
+ | ...
+s0 = box.schema.space.create('test')
+ | ---
+ | ...
+i0 = s0:create_index('test')
+ | ---
+ | ...
+s1 = box.schema.space.create('temp', {temporary=true})
+ | ---
+ | ...
+i1 = s1:create_index('test')
+ | ---
+ | ...
+s2 = box.schema.space.create('loc', {is_local=true})
+ | ---
+ | ...
+i2 = s2:create_index('test')
+ | ---
+ | ...
+s0:replace{1}
+ | ---
+ | - [1]
+ | ...
+box.snapshot()
+ | ---
+ | - ok
+ | ...
+
+test_run:cmd('switch default')
+ | ---
+ | - true
+ | ...
+test_run:cmd('stop server test')
+ | ---
+ | - true
+ | ...
+test_run:cmd('start server test with args="replace" with crash_expected=True')
+ | ---
+ | - false
+ | ...
+test_run:cmd('cleanup server test')
+ | ---
+ | - true
+ | ...
+test_run:cmd('delete server test')
+ | ---
+ | - true
+ | ...

--- a/test/box/gh-5304-replace_during_recovery.test.lua
+++ b/test/box/gh-5304-replace_during_recovery.test.lua
@@ -1,0 +1,22 @@
+
+-- write data recover from latest snapshot
+env = require('test_run')
+test_run = env.new()
+
+test_run:cmd('create server test with script="box/gh-5304-replace_during_recovery.lua"')
+test_run:cmd('start server test')
+test_run:cmd('switch test')
+s0 = box.schema.space.create('test')
+i0 = s0:create_index('test')
+s1 = box.schema.space.create('temp', {temporary=true})
+i1 = s1:create_index('test')
+s2 = box.schema.space.create('loc', {is_local=true})
+i2 = s2:create_index('test')
+s0:replace{1}
+box.snapshot()
+
+test_run:cmd('switch default')
+test_run:cmd('stop server test')
+test_run:cmd('start server test with args="replace" with crash_expected=True')
+test_run:cmd('cleanup server test')
+test_run:cmd('delete server test')


### PR DESCRIPTION
memtx: fix a bug with insertion to space during recovery
    
There was a problem whith on_schema_init trigger.
This trigger gives a way to create on_replace trigger
that will modify temporary or is_local spaces during recovery
from snapshot, but on that stage of recovery process
all space indexes are in special build mode when no check
for uniqueness are made. I added a new function
'is_recovery_finished' in box.ctl, which gives
user ability to check that we are in snapshot recovery stage
and can't insert/replace/update/upsert something. Also i added a
check for corresponding operations, now they are failed
if user tries to do them during snapshot recovery.
    
@TarantoolBot document
Title: Add 'is_recovery_finished' function
Add 'is_recovery_finished' function in box.ctl
to add user ability to check that we are
in snapshot recovery stage and can't
insert/replace/update/upsert something
    
Closes #5304
