### PR TITLE
index: add option "exclude_null" to index part definition

### DIFF
--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -554,6 +554,23 @@ index_build(struct index *index, struct index *pk)
 	return 0;
 }
 
+struct tuple *
+index_filter_tuple_slow(struct index *index, struct tuple *tuple)
+{
+	if (tuple == NULL)
+		return tuple;
+	struct key_def* key_def = index->def->key_def;
+	struct key_part* parts = key_def->parts;
+	for (uint32_t i = 0; i < key_def->part_count; ++i) {
+		if (!parts[i].exclude_null)
+			continue;
+		const char* field = tuple_field(tuple, parts[i].fieldno);
+		if (field != NULL && mp_typeof(*field) == MP_NIL)
+			return NULL;
+	}
+	return tuple;
+}
+
 /* }}} */
 
 /* {{{ Virtual method stubs */

--- a/src/box/key_def.h
+++ b/src/box/key_def.h
@@ -71,6 +71,8 @@ struct key_part_def {
 	 * This sting is 0-terminated.
 	 */
 	const char *path;
+	/** True if nulls are ignored by index. */
+	bool exclude_null;
 };
 
 extern const struct key_part_def key_part_def_default;
@@ -87,6 +89,8 @@ struct key_part {
 	struct coll *coll;
 	/** Action to perform if NULL constraint failed. */
 	enum on_conflict_action nullable_action;
+	/** True if nulls are ignored by index. */
+	bool exclude_null;
 	/** Part sort order. */
 	enum sort_order sort_order;
 	/**
@@ -194,6 +198,8 @@ struct key_def {
 	uint32_t unique_part_count;
 	/** True, if at least one part can store NULL. */
 	bool is_nullable;
+	/** True if some key part has exclude_null option */
+	bool has_exclude_null;
 	/** True if some key part has JSON path. */
 	bool has_json_paths;
 	/** True if it is a multikey index definition.
@@ -298,6 +304,7 @@ typedef struct key_def box_key_def_t;
 /** Key part definition flags. */
 enum {
 	BOX_KEY_PART_DEF_IS_NULLABLE = 1 << 0,
+	BOX_KEY_PART_DEF_EXCLUDE_NULL = 1 << 1,
 };
 
 /**
@@ -418,9 +425,10 @@ box_key_def_new(uint32_t *fields, uint32_t *types, uint32_t part_count);
  *
  * Default flag values are the following:
  *
- *  | Flag                         | Default value |
- *  | ---------------------------- | ------------- |
- *  | BOX_KEY_PART_DEF_IS_NULLABLE | 0 (unset)     |
+ *  | Flag                          | Default value |
+ *  | ----------------------------- | ------------- |
+ *  | BOX_KEY_PART_DEF_IS_NULLABLE  | 0 (unset)     |
+ *  | BOX_KEY_PART_DEF_EXCLUDE_NULL | 0 (unset)     |
  *
  * Default values of fields and flags are permitted to be changed
  * in future tarantool versions. However we should be VERY

--- a/src/box/lua/key_def.c
+++ b/src/box/lua/key_def.c
@@ -62,6 +62,11 @@ luaT_push_key_def(struct lua_State *L, const struct key_def *key_def)
 		lua_pushboolean(L, key_part_is_nullable(part));
 		lua_setfield(L, -2, "is_nullable");
 
+		if (part->exclude_null) {
+			lua_pushboolean(L, true);
+			lua_setfield(L, -2, "exclude_null");
+		}
+
 		if (part->coll_id != COLL_NONE) {
 			struct coll_id *coll_id = coll_by_id(part->coll_id);
 			assert(coll_id != NULL);
@@ -138,6 +143,13 @@ luaT_key_def_set_part(struct lua_State *L, struct key_part_def *part,
 	if (!lua_isnil(L, -1) && lua_toboolean(L, -1) != 0) {
 		part->is_nullable = true;
 		part->nullable_action = ON_CONFLICT_ACTION_NONE;
+	}
+	lua_pop(L, 1);
+
+	lua_pushstring(L, "exclude_null");
+	lua_gettable(L, -2);
+	if (!lua_isnil(L, -1) && lua_toboolean(L, -1) != 0) {
+		part->exclude_null = true;
 	}
 	lua_pop(L, 1);
 
@@ -434,6 +446,7 @@ lbox_key_def_new(struct lua_State *L)
 		return luaL_error(L, "Bad params, use: key_def.new({"
 				  "{fieldno = fieldno, type = type"
 				  "[, is_nullable = <boolean>]"
+				  "[, exclude_null = <boolean>]"
 				  "[, path = <string>]"
 				  "[, collation_id = <number>]"
 				  "[, collation = <string>]}, ...}");

--- a/src/box/lua/net_box.lua
+++ b/src/box/lua/net_box.lua
@@ -1382,6 +1382,7 @@ function remote_methods:_install_schema(schema_version, spaces, indices,
         else
             for k = 1, #index[PARTS] do
                 local pknullable = index[PARTS][k].is_nullable or false
+                local pkexcludenull = index[PARTS][k].exclude_null or false
                 local pkcollationid = index[PARTS][k].collation
                 local pktype = index[PARTS][k][2] or index[PARTS][k].type
                 local pkfield = index[PARTS][k][1] or index[PARTS][k].field
@@ -1395,7 +1396,8 @@ function remote_methods:_install_schema(schema_version, spaces, indices,
                 local pk = {
                     type = pktype,
                     fieldno = pkfield + 1,
-                    is_nullable = pknullable
+                    is_nullable = pknullable,
+                    exclude_null = pkexcludenull
                 }
                 if collations == nil then
                     pk.collation_id = pkcollationid

--- a/src/box/memtx_engine.c
+++ b/src/box/memtx_engine.c
@@ -1454,6 +1454,8 @@ memtx_index_def_change_requires_rebuild(struct index *index,
 				  new_part->path, new_part->path_len,
 				  TUPLE_INDEX_BASE) != 0)
 			return true;
+		if (old_part->exclude_null != new_part->exclude_null)
+			return true;
 	}
 	assert(old_cmp_def->is_multikey == new_cmp_def->is_multikey);
 	return false;

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -1297,6 +1297,8 @@ template <bool USE_HINT>
 static int
 memtx_tree_index_build_next(struct index *base, struct tuple *tuple)
 {
+	if (index_filter_tuple(base, tuple) == NULL)
+		return 0;
 	struct memtx_tree_index<USE_HINT> *index =
 		(struct memtx_tree_index<USE_HINT> *)base;
 	struct key_def *cmp_def = memtx_tree_cmp_def(&index->tree);

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -387,6 +387,7 @@ sql_ephemeral_space_create(uint32_t field_count, struct sql_key_info *key_info)
 		part->fieldno = j;
 		part->nullable_action = ON_CONFLICT_ACTION_NONE;
 		part->is_nullable = true;
+		part->exclude_null = false;
 		part->sort_order = SORT_ORDER_ASC;
 		part->path = NULL;
 		part->type = fields[j].type;
@@ -1096,7 +1097,7 @@ sql_encode_index_parts(struct region *region, const struct field_def *fields,
 		       action_is_nullable(fields[col].nullable_action));
 		/* Do not decode default collation. */
 		uint32_t cid = part->coll_id;
-		mpstream_encode_map(&stream, 5 + (cid != COLL_NONE));
+		mpstream_encode_map(&stream, 6 + (cid != COLL_NONE));
 		mpstream_encode_str(&stream, "type");
 		mpstream_encode_str(&stream, field_type_strs[fields[col].type]);
 		mpstream_encode_str(&stream, "field");
@@ -1118,6 +1119,8 @@ sql_encode_index_parts(struct region *region, const struct field_def *fields,
 		assert(sort_order < sort_order_MAX);
 		const char *sort_order_str = sort_order_strs[sort_order];
 		mpstream_encode_str(&stream, sort_order_str);
+		mpstream_encode_str(&stream, "exclude_null");
+		mpstream_encode_bool(&stream, false);
 	}
 	mpstream_flush(&stream);
 	if (is_error) {

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -2576,6 +2576,7 @@ index_fill_def(struct Parse *parse, struct index *index,
 		part->type = space_def->fields[fieldno].type;
 		part->nullable_action = space_def->fields[fieldno].nullable_action;
 		part->is_nullable = part->nullable_action == ON_CONFLICT_ACTION_NONE;
+		part->exclude_null = false;
 		part->sort_order = SORT_ORDER_ASC;
 		part->coll_id = coll_id;
 		part->path = NULL;

--- a/src/box/sql/where.c
+++ b/src/box/sql/where.c
@@ -853,6 +853,7 @@ constructAutomaticIndex(Parse * pParse,			/* The parsing context */
 				part->sort_order = SORT_ORDER_ASC;
 				part->coll_id = field->coll_id;
 				part->path = NULL;
+				part->exclude_null = false;
 				n++;
 			}
 		}
@@ -873,6 +874,7 @@ constructAutomaticIndex(Parse * pParse,			/* The parsing context */
 			part->sort_order = SORT_ORDER_ASC;
 			part->coll_id = field->coll_id;
 			part->path = NULL;
+			part->exclude_null = false;
 			n++;
 		}
 	}
@@ -887,6 +889,7 @@ constructAutomaticIndex(Parse * pParse,			/* The parsing context */
 			part->sort_order = SORT_ORDER_ASC;
 			part->coll_id = field->coll_id;
 			part->path = NULL;
+			part->exclude_null = false;
 			n++;
 		}
 	}
@@ -2831,6 +2834,7 @@ whereLoopAddBtree(WhereLoopBuilder * pBuilder,	/* WHERE clause information */
 		part.sort_order = SORT_ORDER_ASC;
 		part.coll_id = COLL_NONE;
 		part.path = NULL;
+		part.exclude_null = false;
 
 		struct key_def *key_def = key_def_new(&part, 1, false);
 		if (key_def == NULL) {
@@ -2926,6 +2930,9 @@ tnt_error:
 	for (uint32_t i = 0; i < idx_count; iSortIdx++, i++) {
 		if (i > 0)
 			probe = space->index[i]->def;
+		/* Such index may possibly contain not all tuples, so skip it */
+		if (pSrc->pIBIndex == NULL && probe->key_def->has_exclude_null)
+			continue;
 		rSize = index_field_tuple_est(probe, 0);
 		pNew->nEq = 0;
 		pNew->nBtm = 0;

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -964,6 +964,8 @@ vinyl_index_def_change_requires_rebuild(struct index *index,
 				  new_part->path, new_part->path_len,
 				  TUPLE_INDEX_BASE) != 0)
 			return true;
+		if (old_part->exclude_null != new_part->exclude_null)
+			return true;
 	}
 	assert(old_cmp_def->is_multikey == new_cmp_def->is_multikey);
 	return false;
@@ -1838,12 +1840,14 @@ vy_perform_update(struct vy_env *env, struct vy_tx *tx, struct txn_stmt *stmt,
 		return -1;
 
 	for (uint32_t i = 1; i < space->index_count; ++i) {
+		struct tuple *new_tuple = index_filter_tuple(space->index[i],
+							     stmt->new_tuple);
 		struct vy_lsm *lsm = vy_lsm(space->index[i]);
 		if (vy_is_committed(env, lsm))
 			continue;
 		if (vy_tx_set(tx, lsm, delete) != 0)
 			goto error;
-		if (vy_tx_set(tx, lsm, stmt->new_tuple) != 0)
+		if (new_tuple != NULL && vy_tx_set(tx, lsm, new_tuple) != 0)
 			goto error;
 	}
 	tuple_unref(delete);
@@ -1946,6 +1950,8 @@ vy_insert_first_upsert(struct vy_env *env, struct vy_tx *tx,
 	if (vy_tx_set(tx, pk, stmt) != 0)
 		return -1;
 	for (uint32_t i = 1; i < space->index_count; ++i) {
+		if (index_filter_tuple(space->index[i], stmt) == NULL)
+			continue;
 		struct vy_lsm *lsm = vy_lsm(space->index[i]);
 		if (vy_tx_set(tx, lsm, stmt) != 0)
 			return -1;
@@ -2217,10 +2223,12 @@ vy_insert(struct vy_env *env, struct vy_tx *tx, struct txn_stmt *stmt,
 		return -1;
 
 	for (uint32_t iid = 1; iid < space->index_count; ++iid) {
+		struct tuple *new_tuple = index_filter_tuple(space->index[iid],
+							     stmt->new_tuple);
 		struct vy_lsm *lsm = vy_lsm(space->index[iid]);
 		if (vy_is_committed(env, lsm))
 			continue;
-		if (vy_tx_set(tx, lsm, stmt->new_tuple) != 0)
+		if (new_tuple != NULL && vy_tx_set(tx, lsm, new_tuple) != 0)
 			return -1;
 	}
 	return 0;
@@ -2301,6 +2309,8 @@ vy_replace(struct vy_env *env, struct vy_tx *tx, struct txn_stmt *stmt,
 			return -1;
 	}
 	for (uint32_t i = 1; i < space->index_count; i++) {
+		struct tuple *new_tuple = index_filter_tuple(space->index[i],
+							     stmt->new_tuple);
 		struct vy_lsm *lsm = vy_lsm(space->index[i]);
 		if (vy_is_committed(env, lsm))
 			continue;
@@ -2309,9 +2319,11 @@ vy_replace(struct vy_env *env, struct vy_tx *tx, struct txn_stmt *stmt,
 			if (rc != 0)
 				break;
 		}
-		rc = vy_tx_set(tx, lsm, stmt->new_tuple);
-		if (rc != 0)
-			break;
+		if (new_tuple != NULL) {
+			rc = vy_tx_set(tx, lsm, new_tuple);
+			if (rc != 0)
+				break;
+		}
 	}
 	if (delete != NULL)
 		tuple_unref(delete);
@@ -3825,6 +3837,9 @@ vy_build_on_replace(struct trigger *trigger, void *event)
 	struct tuple_format *format = ctx->format;
 	struct vy_lsm *lsm = ctx->lsm;
 
+	stmt->old_tuple = index_filter_tuple(&lsm->base, stmt->old_tuple);
+	stmt->new_tuple = index_filter_tuple(&lsm->base, stmt->new_tuple);
+
 	if (ctx->is_failed)
 		return 0; /* already failed, nothing to do */
 
@@ -4000,6 +4015,8 @@ vy_build_recover_stmt(struct vy_lsm *lsm, struct vy_lsm *pk,
 		      struct vy_entry mem_entry)
 {
 	struct tuple *mem_stmt = mem_entry.stmt;
+	if (index_filter_tuple(&lsm->base, mem_stmt) == NULL)
+		return 0;
 	int64_t lsn = vy_stmt_lsn(mem_stmt);
 	if (lsn <= lsm->dump_lsn)
 		return 0; /* statement was dumped, nothing to do */
@@ -4233,6 +4250,9 @@ vinyl_space_build_index(struct space *src_space, struct index *new_index,
 		struct tuple *tuple = entry.stmt;
 		if (tuple == NULL)
 			break;
+		struct tuple* new_tuple = index_filter_tuple(new_index, tuple);
+		if (new_tuple == NULL)
+			continue;
 		/*
 		 * Insert the tuple into the new index unless it
 		 * was inserted into the space after we started
@@ -4246,13 +4266,13 @@ vinyl_space_build_index(struct space *src_space, struct index *new_index,
 		 * could be overwritten by a concurrent transaction,
 		 * in which case we would insert an outdated tuple.
 		 */
-		if (vy_stmt_lsn(tuple) <= build_lsn) {
+		if (vy_stmt_lsn(new_tuple) <= build_lsn) {
 			rc = vy_build_insert_tuple(env, new_lsm,
 						   space_name(src_space),
 						   new_index->def->name,
 						   new_format,
 						   check_unique_constraint,
-						   tuple);
+						   new_tuple);
 			if (rc != 0)
 				break;
 		}

--- a/test/box-tap/key_def.test.lua
+++ b/test/box-tap/key_def.test.lua
@@ -17,6 +17,7 @@ local key_def_lib = require('key_def')
 local usage_error = 'Bad params, use: key_def.new({' ..
                     '{fieldno = fieldno, type = type' ..
                     '[, is_nullable = <boolean>]' ..
+                    '[, exclude_null = <boolean>]' ..
                     '[, path = <string>]' ..
                     '[, collation_id = <number>]' ..
                     '[, collation = <string>]}, ...}'

--- a/test/box/net.box_incompatible_index-gh-1729.result
+++ b/test/box/net.box_incompatible_index-gh-1729.result
@@ -29,21 +29,25 @@ c = net:connect(box.cfg.listen)
 -- gh-1729 net.box index metadata incompatible with local metadata
 c.space.test.index.primary.parts
 ---
-- - type: unsigned
+- - fieldno: 1
+    type: unsigned
+    exclude_null: false
     is_nullable: false
-    fieldno: 1
 ...
 c.space.test.index.covering.parts
 ---
-- - type: unsigned
+- - fieldno: 1
+    type: unsigned
+    exclude_null: false
     is_nullable: false
-    fieldno: 1
-  - type: string
+  - fieldno: 3
+    type: string
+    exclude_null: false
     is_nullable: false
-    fieldno: 3
-  - type: unsigned
+  - fieldno: 2
+    type: unsigned
+    exclude_null: false
     is_nullable: false
-    fieldno: 2
 ...
 box.space.test:drop()
 ---

--- a/test/box/net.box_is_nullable_gh-3256.result
+++ b/test/box/net.box_is_nullable_gh-3256.result
@@ -21,9 +21,10 @@ c = net:connect(box.cfg.listen)
 ...
 c.space.test.index.sk.parts
 ---
-- - type: unsigned
+- - fieldno: 2
+    type: unsigned
+    exclude_null: false
     is_nullable: true
-    fieldno: 2
 ...
 space:drop()
 ---

--- a/test/engine/null.result
+++ b/test/engine/null.result
@@ -1927,3 +1927,510 @@ s:insert{2, nil, 2} --error
 s:drop()
 ---
 ...
+--
+-- gh-4480: Introduce exclude_null option
+--
+-- Basic functionality
+s = box.schema.space.create('test', {engine=engine})
+---
+...
+pk = s:create_index('primary', {parts={1, 'number'}})
+---
+...
+sk1 = s:create_index('sk1', {parts={{2, 'number', is_nullable=true, exclude_null=true}}})
+---
+...
+sk1.parts
+---
+- - type: number
+    exclude_null: true
+    is_nullable: true
+    fieldno: 2
+...
+sk2 = s:create_index('sk2', {parts={{2, 'number', is_nullable=true, exclude_null=false}}})
+---
+...
+sk2.parts
+---
+- - type: number
+    is_nullable: true
+    fieldno: 2
+...
+s:insert{1, 1}
+---
+- [1, 1]
+...
+s:insert{2, box.NULL}
+---
+- [2, null]
+...
+pk:select{}
+---
+- - [1, 1]
+  - [2, null]
+...
+sk1:select{} -- [1, 1] only
+---
+- - [1, 1]
+...
+sk2:select{}
+---
+- - [2, null]
+  - [1, 1]
+...
+-- Error
+sk3 = s:create_index('sk3', {parts={{2, 'number', is_nullable=false}}})
+---
+- error: 'Tuple field 2 type does not match one required by operation: expected number'
+...
+s:truncate()
+---
+...
+-- Ok
+sk3 = s:create_index('sk3', {parts={{2, 'number', is_nullable=false}}})
+---
+...
+s:insert{1, 1}
+---
+- [1, 1]
+...
+s:insert{2, box.NULL} -- error
+---
+- error: 'Tuple field 2 type does not match one required by operation: expected number'
+...
+s:drop()
+---
+...
+-- if exclude_null=true, then is_nullable=true (explicitly or implicitly)
+s = box.schema.space.create('test', {engine=engine})
+---
+...
+pk = s:create_index('primary', {parts={1, 'number'}})
+---
+...
+sk1 = s:create_index('sk1', {parts={{2, 'number', is_nullable=false, exclude_null=true}}})
+---
+- error: 'Illegal parameters, options.parts[1]: exclude_null=true and is_nullable=false
+    are incompatible'
+...
+sk1 = s:create_index('sk1', {parts={{2, 'number', exclude_null=true}}})
+---
+...
+s:drop()
+---
+...
+-- Multipart
+s = box.schema.space.create('test', {engine=engine})
+---
+...
+pk = s:create_index('primary', {parts={1, 'number'}})
+---
+...
+parts = {}
+---
+...
+parts[1] = {2, 'number', exclude_null=true}
+---
+...
+parts[2] = {3, 'number', is_nullable=true}
+---
+...
+sk1 = s:create_index('sk1', {parts=parts})
+---
+...
+s:insert{1, 1, 1}
+---
+- [1, 1, 1]
+...
+s:insert{2, box.NULL, 2}
+---
+- [2, null, 2]
+...
+s:insert{3, 3, box.NULL}
+---
+- [3, 3, null]
+...
+s:select{}
+---
+- - [1, 1, 1]
+  - [2, null, 2]
+  - [3, 3, null]
+...
+sk1:select{}
+---
+- - [1, 1, 1]
+  - [3, 3, null]
+...
+s:drop()
+---
+...
+-- Insert, then create index
+s = box.schema.space.create('test', {engine=engine})
+---
+...
+pk = s:create_index('primary', {parts={1, 'number'}})
+---
+...
+s:insert{1, 11}
+---
+- [1, 11]
+...
+s:insert{2, 22}
+---
+- [2, 22]
+...
+s:insert{3, box.NULL}
+---
+- [3, null]
+...
+s:insert{4, box.NULL}
+---
+- [4, null]
+...
+sk1 = s:create_index('sk1', {parts={{2, 'number', exclude_null=true}}})
+---
+...
+sk1.parts
+---
+- - type: number
+    exclude_null: true
+    is_nullable: true
+    fieldno: 2
+...
+s:select{}
+---
+- - [1, 11]
+  - [2, 22]
+  - [3, null]
+  - [4, null]
+...
+sk1:select{}
+---
+- - [1, 11]
+  - [2, 22]
+...
+-- Alter to exclude_null=false
+sk1:alter({parts={{2, 'number', is_nullable=true, exclude_null=false}}})
+---
+...
+sk1.parts
+---
+- - type: number
+    is_nullable: true
+    fieldno: 2
+...
+sk1:select{}
+---
+- - [3, null]
+  - [4, null]
+  - [1, 11]
+  - [2, 22]
+...
+-- Alter back to exclude_null=true
+sk1:alter({parts={{2, 'number', exclude_null=true}}})
+---
+...
+sk1.parts
+---
+- - type: number
+    exclude_null: true
+    is_nullable: true
+    fieldno: 2
+...
+sk1:select{}
+---
+- - [1, 11]
+  - [2, 22]
+...
+-- Alter to the wrong format
+sk1:alter({parts={{2, 'number', is_nullable=false, exclude_null=true}}})
+---
+- error: 'Illegal parameters, options.parts[1]: exclude_null=true and is_nullable=false
+    are incompatible'
+...
+sk1.parts
+---
+- - type: number
+    exclude_null: true
+    is_nullable: true
+    fieldno: 2
+...
+-- Check that delete doesn't crash on sk1
+s:insert{5, box.NULL}
+---
+- [5, null]
+...
+sk1:select{}
+---
+- - [1, 11]
+  - [2, 22]
+...
+_ = s:delete{5}
+---
+...
+sk1:select{}
+---
+- - [1, 11]
+  - [2, 22]
+...
+s:select{}
+---
+- - [1, 11]
+  - [2, 22]
+  - [3, null]
+  - [4, null]
+...
+-- Update and upsert correctness
+_ = s:update(1, {{'=', 2, box.NULL}})
+---
+...
+_ = s:update(3, {{'=', 2, 33}})
+---
+...
+s:upsert({2, 22}, {{'=', 2, box.NULL}})
+---
+...
+s:upsert({5, 55}, {{'=', 2, box.NULL}})
+---
+...
+sk1:select{}
+---
+- - [3, 33]
+  - [5, 55]
+...
+s:select{}
+---
+- - [1, null]
+  - [2, null]
+  - [3, 33]
+  - [4, null]
+  - [5, 55]
+...
+-- Replace correctness
+_ = s:replace({1, 11})
+---
+...
+_ = s:replace({3, box.NULL})
+---
+...
+sk1:select{}
+---
+- - [1, 11]
+  - [5, 55]
+...
+s:select{}
+---
+- - [1, 11]
+  - [2, null]
+  - [3, null]
+  - [4, null]
+  - [5, 55]
+...
+s:drop()
+---
+...
+-- Tuple without the field
+s = box.schema.space.create('test')
+---
+...
+pk = s:create_index('pk', {type='tree', parts={{1, 'uint'}}})
+---
+...
+sk = s:create_index('sk', {type='tree', parts={{2, 'uint', exclude_null=true}}})
+---
+...
+s:replace{1}
+---
+- [1]
+...
+sk:select{}
+---
+- - [1]
+...
+s:select{}
+---
+- - [1]
+...
+s:drop()
+---
+...
+-- Forbid creating primary key with exclude_null option
+s = box.schema.space.create('test', {engine=engine})
+---
+...
+pk = s:create_index('primary', {parts={1, 'number', exclude_null=true}})
+---
+- error: Primary index of space 'test' can not contain nullable parts
+...
+s:drop()
+---
+...
+-- Restore from snapshot
+s = box.schema.space.create('test', {engine=engine})
+---
+...
+pk = s:create_index('primary', {parts={1, 'number'}})
+---
+...
+sk = s:create_index('sk', {parts={{2, 'number', exclude_null=true}}})
+---
+...
+s:replace{1, box.NULL}
+---
+- [1, null]
+...
+s:replace{2, 2}
+---
+- [2, 2]
+...
+s:select{}
+---
+- - [1, null]
+  - [2, 2]
+...
+sk:select{}
+---
+- - [2, 2]
+...
+box.snapshot()
+---
+- ok
+...
+test_run:cmd("restart server default")
+s = box.space.test
+---
+...
+sk = s.index.sk
+---
+...
+s:select{}
+---
+- - [1, null]
+  - [2, 2]
+...
+sk:select{}
+---
+- - [2, 2]
+...
+s:drop()
+---
+...
+-- First upsert
+engine = test_run:get_cfg('engine')
+---
+...
+s = box.schema.space.create('test', {engine=engine})
+---
+...
+pk = s:create_index('pk')
+---
+...
+sk = s:create_index('sk', {parts={{2, 'number', exclude_null=true}}})
+---
+...
+s:replace{1, 1}
+---
+- [1, 1]
+...
+box.snapshot()
+---
+- ok
+...
+s:upsert({2, box.NULL}, {{'=', 2, box.NULL}})
+---
+...
+s:select{}
+---
+- - [1, 1]
+  - [2, null]
+...
+sk:select{}
+---
+- - [1, 1]
+...
+s:drop()
+---
+...
+-- Both old and new tuple are null when creating index
+s = box.schema.space.create('test', {engine=engine})
+---
+...
+pk = s:create_index('pk')
+---
+...
+fiber = require('fiber')
+---
+...
+s:replace{1, box.NULL}
+---
+- [1, null]
+...
+sk = s:create_index('sk', {parts={{2, 'number', exclude_null=true}}})
+---
+...
+s:select{}
+---
+- - [1, null]
+...
+sk:select{}
+---
+- []
+...
+s:drop()
+---
+...
+-- Check that vy_build_on_replace works as expected
+errinj = box.error.injection
+---
+...
+s = box.schema.space.create('test', {engine=engine})
+---
+...
+pk = s:create_index('primary', {parts={1, 'number'}})
+---
+...
+s:replace{42, 42}
+---
+- [42, 42]
+...
+errinj.set('ERRINJ_BUILD_INDEX_DELAY', true)
+---
+- ok
+...
+ch = fiber.channel(1)
+---
+...
+test_run:cmd("setopt delimiter ';'")
+---
+- true
+...
+function txn_fun()
+    box.begin()
+    s:replace{1, box.NULL}
+    errinj.set('ERRINJ_BUILD_INDEX_DELAY', false)
+    box.commit()
+    ch:put(true)
+end;
+---
+...
+test_run:cmd("setopt delimiter ''");
+---
+- true
+...
+_ = fiber.new(txn_fun)
+---
+...
+sk = s:create_index('sk', {parts={{2, 'number', exclude_null=true}}})
+---
+...
+ch:get()
+---
+- true
+...
+sk:select{}
+---
+- - [42, 42]
+...
+s:drop()
+---
+...

--- a/test/sql/misc.result
+++ b/test/sql/misc.result
@@ -255,3 +255,107 @@ diag == box.error.last()
 ---
 - true
 ...
+-- exclude_null + SQL correctness
+box.execute([[CREATE TABLE j (s1 INT PRIMARY KEY, s2 STRING, s3 VARBINARY)]])
+---
+- row_count: 1
+...
+s = box.space.J
+---
+...
+i = box.space.J:create_index('I3',{parts={2,'string', exclude_null=true}})
+---
+...
+box.execute([[INSERT INTO j VALUES (1,NULL,NULL), (2,'',X'00');]])
+---
+- row_count: 2
+...
+box.execute([[SELECT * FROM j;]])
+---
+- metadata:
+  - name: S1
+    type: integer
+  - name: S2
+    type: string
+  - name: S3
+    type: varbinary
+  rows:
+  - [1, null, null]
+  - [2, '', "\0"]
+...
+box.execute([[SELECT * FROM j INDEXED BY I3;]])
+---
+- metadata:
+  - name: S1
+    type: integer
+  - name: S2
+    type: string
+  - name: S3
+    type: varbinary
+  rows:
+  - [2, '', "\0"]
+...
+box.execute([[SELECT COUNT(*) FROM j GROUP BY s2;]])
+---
+- metadata:
+  - name: COLUMN_1
+    type: integer
+  rows:
+  - [1]
+  - [1]
+...
+box.execute([[SELECT COUNT(*) FROM j INDEXED BY I3;]])
+---
+- metadata:
+  - name: COLUMN_1
+    type: integer
+  rows:
+  - [1]
+...
+box.execute([[UPDATE j INDEXED BY i3 SET s2 = NULL;]])
+---
+- row_count: 1
+...
+box.execute([[INSERT INTO j VALUES (3, 'a', X'33');]])
+---
+- row_count: 1
+...
+box.execute([[SELECT * FROM j;]])
+---
+- metadata:
+  - name: S1
+    type: integer
+  - name: S2
+    type: string
+  - name: S3
+    type: varbinary
+  rows:
+  - [1, null, null]
+  - [2, null, "\0"]
+  - [3, 'a', '3']
+...
+box.execute([[SELECT * FROM j INDEXED BY I3;]])
+---
+- metadata:
+  - name: S1
+    type: integer
+  - name: S2
+    type: string
+  - name: S3
+    type: varbinary
+  rows:
+  - [3, 'a', '3']
+...
+box.execute([[UPDATE j INDEXED BY i3 SET s3 = NULL;]])
+---
+- row_count: 1
+...
+s:select{}
+---
+- - [1, null, null]
+  - [2, null, "\0"]
+  - [3, 'a', null]
+...
+s:drop()
+---
+...

--- a/test/sql/misc.test.lua
+++ b/test/sql/misc.test.lua
@@ -79,3 +79,26 @@ box.execute('SELECT a;')
 diag = box.error.last()
 box.execute('SELECT * FROM (VALUES(true));')
 diag == box.error.last()
+
+-- exclude_null + SQL correctness
+box.execute([[CREATE TABLE j (s1 INT PRIMARY KEY, s2 STRING, s3 VARBINARY)]])
+s = box.space.J
+i = box.space.J:create_index('I3',{parts={2,'string', exclude_null=true}})
+box.execute([[INSERT INTO j VALUES (1,NULL,NULL), (2,'',X'00');]])
+
+box.execute([[SELECT * FROM j;]])
+box.execute([[SELECT * FROM j INDEXED BY I3;]])
+
+box.execute([[SELECT COUNT(*) FROM j GROUP BY s2;]])
+box.execute([[SELECT COUNT(*) FROM j INDEXED BY I3;]])
+
+box.execute([[UPDATE j INDEXED BY i3 SET s2 = NULL;]])
+box.execute([[INSERT INTO j VALUES (3, 'a', X'33');]])
+
+box.execute([[SELECT * FROM j;]])
+box.execute([[SELECT * FROM j INDEXED BY I3;]])
+
+box.execute([[UPDATE j INDEXED BY i3 SET s3 = NULL;]])
+s:select{}
+
+s:drop()

--- a/test/vinyl/errinj_ddl.result
+++ b/test/vinyl/errinj_ddl.result
@@ -143,6 +143,68 @@ s.index.sk:stat().memory.rows
 s:drop()
 ---
 ...
+-- exclude_null: correct recovering tuples from memory (vy_build_recover_stmt)
+s = box.schema.space.create('test', {engine='vinyl'})
+---
+...
+_ = s:create_index('pk')
+---
+...
+s:replace{1, 1}
+---
+- [1, 1]
+...
+s:replace{2, 2}
+---
+- [2, 2]
+...
+errinj.set("ERRINJ_VY_RUN_WRITE_DELAY", true)
+---
+- ok
+...
+ch = fiber.channel(1)
+---
+...
+_ = fiber.create(function() s:create_index('sk', {parts = {2, 'integer', exclude_null=true}}) ch:put(true) end)
+---
+...
+test_run:wait_cond(function() return box.stat.vinyl().scheduler.tasks_inprogress > 0 end)
+---
+- true
+...
+_ = s:replace{2, box.NULL}
+---
+...
+errinj.set("ERRINJ_VY_RUN_WRITE_DELAY", false)
+---
+- ok
+...
+ch:get()
+---
+- true
+...
+test_run:cmd('restart server default')
+s = box.space.test
+---
+...
+s:select{}
+---
+- - [1, 1]
+  - [2, null]
+...
+s.index.sk:select{}
+---
+- - [1, 1]
+...
+s:drop()
+---
+...
+fiber = require('fiber')
+---
+...
+errinj = box.error.injection
+---
+...
 --
 -- gh-3458: check that rw transactions that started before DDL are
 -- aborted.


### PR DESCRIPTION
New option "exclude_null=true/false" was introduced.
"is_nullable=true" option will be set automatically.
When it is on, index skips tuples with "null" value of this part.
E.g. index `s:create_index('sk', {parts={{2, 'number', exclude_null=true}}})`
will ignore `{1, null}, {2, null}`, but will not ignore `{null, 1}, {1, 1}`.

Closes #4480

@TarantoolBot document
Title: new option "exclude_null=true/false"
Added new option for index part definition,
that allows index to skip tuples with null at this part.