### PR TITLE
box/lua: forbid specifying index options in key parts

### DIFF
--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -605,7 +605,16 @@ local function update_index_parts_1_6_0(parts)
         box.error(box.error.ILLEGAL_PARAMS,
                   "options.parts: expected field_no (number), type (string) pairs")
     end
-    for i=1,#parts,2 do
+    local i = 0
+    for _ in pairs(parts) do
+        i = i + 1
+        if parts[i] == nil then
+            box.error(box.error.ILLEGAL_PARAMS,
+                      "options.parts: expected field_no (number), type (string) pairs")
+        end
+        if i % 2 == 0 then
+            goto continue
+        end
         if type(parts[i]) ~= "number" then
             box.error(box.error.ILLEGAL_PARAMS,
                       "options.parts: expected field_no (number), type (string) pairs")
@@ -619,6 +628,7 @@ local function update_index_parts_1_6_0(parts)
                       "options.parts: expected field_no (number), type (string) pairs")
         end
         table.insert(result, {field = parts[i] - 1, type = parts[i + 1]})
+        ::continue::
     end
     return result
 end
@@ -779,6 +789,19 @@ local function update_index_parts(format, parts)
             if fmt and fmt.action ~= nil then
                 part.action = fmt.action
                 parts_can_be_simplified = false
+            end
+        end
+        if type(parts[i]) == "table" then
+            local first_illegal_index = 3
+            if parts[i].field ~= nil then
+                first_illegal_index = first_illegal_index - 1
+            end
+            if parts[i].type ~= nil then
+                first_illegal_index = first_illegal_index - 1
+            end
+            if parts[i][first_illegal_index] ~= nil then
+                box.error(box.error.ILLEGAL_PARAMS,
+                        "options.parts[" .. i .. "]: unexpected option " .. parts[i][first_illegal_index])
             end
         end
         table.insert(result, part)

--- a/test/box/misc.result
+++ b/test/box/misc.result
@@ -1074,3 +1074,74 @@ i.parts
 s:drop()
 ---
 ...
+--
+-- gh-5473: forbid specifying index options in key parts
+--
+--
+s = box.schema.space.create('test')
+---
+...
+i = s:create_index('test1', {parts = {1, 'unsigned', unique=false}})
+---
+- error: 'Wrong index options (field 1): unexpected option ''unique'''
+...
+i = s:create_index('test1', {parts = {1, 'unsigned', distance=3}})
+---
+- error: 'Wrong index options (field 1): unexpected option ''distance'''
+...
+i = s:create_index('test1', {parts = {2, 'string', 3, 'string', unique=false}})
+---
+- error: 'Illegal parameters, options.parts: expected field_no (number), type (string)
+    pairs'
+...
+i = s:create_index('test1', {parts = {2, 'string', 3, 'string', distance=3}})
+---
+- error: 'Illegal parameters, options.parts: expected field_no (number), type (string)
+    pairs'
+...
+i = s:create_index('test1', {parts = {{1,'int', distance=3}, {field=2, type='int'}}})
+---
+- error: 'Wrong index options (field 1): unexpected option ''distance'''
+...
+i = s:create_index('test1', {parts = {{1,'int'}, {field=2, type='int', type='hash'}}})
+---
+- error: 'Wrong index parts: unknown field type; expected field1 id (number), field1
+    type (string), ...'
+...
+i = s:create_index('test1', {parts = {{1,'int'}, {2, field=2, type='int'}}})
+---
+- error: 'Illegal parameters, options.parts[2]: unexpected option 2'
+...
+i = s:create_index('test1', {parts = {{1,'int'}, {field=2, type='int', 'asd'}}})
+---
+- error: 'Illegal parameters, options.parts[2]: unexpected option asd'
+...
+i = s:create_index('test1', {parts = {1,'int', 'asd'}})
+---
+- error: 'Illegal parameters, options.parts: expected field_no (number), type (string)
+    pairs'
+...
+i = s:create_index('test1', {parts = {{1, 'int'}, {2, 'int', 'asd'}}})
+---
+- error: 'Illegal parameters, options.parts[2]: unexpected option asd'
+...
+i = s:create_index('test1', {parts = {{2, type='unsigned', 'asd'}, {1, 'int'}}})
+---
+- error: 'Illegal parameters, options.parts[1]: unexpected option asd'
+...
+i = s:create_index('test1', {parts = {{1, 'int'}, {2, 'asd', type='unsigned'}}})
+---
+- error: 'Illegal parameters, options.parts[2]: unexpected option asd'
+...
+i = s:create_index('test1', {parts = {{'asd', 2, type='unsigned'}}})
+---
+- error: 'Illegal parameters, options.parts[1]: field was not found by name ''asd'''
+...
+i = s:create_index('test1', {parts = {{1, 'int'}, {2, type='asd'}}})
+---
+- error: 'Wrong index parts: unknown field type; expected field1 id (number), field1
+    type (string), ...'
+...
+s:drop()
+---
+...

--- a/test/box/misc.test.lua
+++ b/test/box/misc.test.lua
@@ -363,3 +363,24 @@ i.parts
 i = s:create_index('test6', {parts = {4, 'string'}})
 i.parts
 s:drop()
+
+--
+-- gh-5473: forbid specifying index options in key parts
+--
+--
+s = box.schema.space.create('test')
+i = s:create_index('test1', {parts = {1, 'unsigned', unique=false}})
+i = s:create_index('test1', {parts = {1, 'unsigned', distance=3}})
+i = s:create_index('test1', {parts = {2, 'string', 3, 'string', unique=false}})
+i = s:create_index('test1', {parts = {2, 'string', 3, 'string', distance=3}})
+i = s:create_index('test1', {parts = {{1,'int', distance=3}, {field=2, type='int'}}})
+i = s:create_index('test1', {parts = {{1,'int'}, {field=2, type='int', type='hash'}}})
+i = s:create_index('test1', {parts = {{1,'int'}, {2, field=2, type='int'}}})
+i = s:create_index('test1', {parts = {{1,'int'}, {field=2, type='int', 'asd'}}})
+i = s:create_index('test1', {parts = {1,'int', 'asd'}})
+i = s:create_index('test1', {parts = {{1, 'int'}, {2, 'int', 'asd'}}})
+i = s:create_index('test1', {parts = {{2, type='unsigned', 'asd'}, {1, 'int'}}})
+i = s:create_index('test1', {parts = {{1, 'int'}, {2, 'asd', type='unsigned'}}})
+i = s:create_index('test1', {parts = {{'asd', 2, type='unsigned'}}})
+i = s:create_index('test1', {parts = {{1, 'int'}, {2, type='asd'}}})
+s:drop()

--- a/test/engine/errinj_ddl.result
+++ b/test/engine/errinj_ddl.result
@@ -100,7 +100,7 @@ errinj.set('ERRINJ_BUILD_INDEX_DELAY', true);
 - ok
 ...
 fiber.new(function() t:replace{1, 2} errinj.set('ERRINJ_BUILD_INDEX_DELAY',false) end)
-t:create_index('sk', {parts = {2, 'unsigned', unique=true}});
+t:create_index('sk', {parts = {2, 'unsigned'}, unique=true});
 ---
 - error: Duplicate key exists in unique index 'sk' in space 'space'
 ...
@@ -121,7 +121,7 @@ errinj.set('ERRINJ_BUILD_INDEX_DELAY', true);
 - ok
 ...
 fiber.new(function() t:replace{2, 3} errinj.set('ERRINJ_BUILD_INDEX_DELAY', false) end)
-t:create_index('sk', {parts = {2, 'unsigned', unique=true}});
+t:create_index('sk', {parts = {2, 'unsigned'}, unique=true});
 ---
 - error: Duplicate key exists in unique index 'sk' in space 'space'
 ...

--- a/test/engine/errinj_ddl.test.lua
+++ b/test/engine/errinj_ddl.test.lua
@@ -49,7 +49,7 @@ test_run:cmd("setopt delimiter ';'")
 
 errinj.set('ERRINJ_BUILD_INDEX_DELAY', true);
 fiber.new(function() t:replace{1, 2} errinj.set('ERRINJ_BUILD_INDEX_DELAY',false) end)
-t:create_index('sk', {parts = {2, 'unsigned', unique=true}});
+t:create_index('sk', {parts = {2, 'unsigned'}, unique=true});
 
 t:get{1};
 t.index.sk;
@@ -58,7 +58,7 @@ t:replace{1, 1};
 
 errinj.set('ERRINJ_BUILD_INDEX_DELAY', true);
 fiber.new(function() t:replace{2, 3} errinj.set('ERRINJ_BUILD_INDEX_DELAY', false) end)
-t:create_index('sk', {parts = {2, 'unsigned', unique=true}});
+t:create_index('sk', {parts = {2, 'unsigned'}, unique=true});
 
 t:get{2};
 t.index.sk == nil;


### PR DESCRIPTION
Degradation caused by #2866 forbade specifying index optios in key parts, which is actually right. Tests were fixed and the behaviour was extended to the other way of specifying index parts.

Closes #5473