### PR TITLE
netbox: add "path" to index schema

### DIFF
--- a/src/box/lua/net_box.lua
+++ b/src/box/lua/net_box.lua
@@ -1384,6 +1384,7 @@ function remote_methods:_install_schema(schema_version, spaces, indices,
                 local pknullable = index[PARTS][k].is_nullable or false
                 local pkexcludenull = index[PARTS][k].exclude_null or false
                 local pkcollationid = index[PARTS][k].collation
+                local pkpath = index[PARTS][k].path
                 local pktype = index[PARTS][k][2] or index[PARTS][k].type
                 local pkfield = index[PARTS][k][1] or index[PARTS][k].field
                 -- resolve a collation name if a peer has
@@ -1397,7 +1398,8 @@ function remote_methods:_install_schema(schema_version, spaces, indices,
                     type = pktype,
                     fieldno = pkfield + 1,
                     is_nullable = pknullable,
-                    exclude_null = pkexcludenull
+                    exclude_null = pkexcludenull,
+                    path = pkpath,
                 }
                 if collations == nil then
                     pk.collation_id = pkcollationid

--- a/test/box/gh-5451-netbox-path-index-schema.result
+++ b/test/box/gh-5451-netbox-path-index-schema.result
@@ -1,0 +1,60 @@
+netbox = require('net.box')
+---
+...
+--
+-- gh-5451: "path" is not installed to index schema.
+--
+box.schema.user.grant('guest','super')
+---
+...
+_ = box.schema.space.create('gh5451')
+---
+...
+_ = box.space.gh5451:create_index('primary',                    \
+    {parts = {{field = 1, type = 'unsigned', path = 'path1'}}})
+---
+...
+_ = box.space.gh5451:create_index('secondary',                  \
+    {parts = {{field = 2, type = 'unsigned', path = 'path2'}}})
+---
+...
+_ = box.space.gh5451:create_index('multikey',                   \
+    {parts = {{field = 3, type = 'unsigned', path = '[*]'}}})
+---
+...
+c = netbox.connect(box.cfg.listen)
+---
+...
+c.space.gh5451.index[0].parts
+---
+- - fieldno: 1
+    path: path1
+    type: unsigned
+    exclude_null: false
+    is_nullable: false
+...
+c.space.gh5451.index[1].parts
+---
+- - fieldno: 2
+    path: path2
+    type: unsigned
+    exclude_null: false
+    is_nullable: false
+...
+c.space.gh5451.index[2].parts
+---
+- - fieldno: 3
+    path: '[*]'
+    type: unsigned
+    exclude_null: false
+    is_nullable: false
+...
+c:close()
+---
+...
+box.space.gh5451:drop()
+---
+...
+box.schema.user.revoke('guest', 'super')
+---
+...

--- a/test/box/gh-5451-netbox-path-index-schema.test.lua
+++ b/test/box/gh-5451-netbox-path-index-schema.test.lua
@@ -1,0 +1,25 @@
+netbox = require('net.box')
+--
+-- gh-5451: "path" is not installed to index schema.
+--
+
+box.schema.user.grant('guest','super')
+
+_ = box.schema.space.create('gh5451')
+_ = box.space.gh5451:create_index('primary',                    \
+    {parts = {{field = 1, type = 'unsigned', path = 'path1'}}})
+_ = box.space.gh5451:create_index('secondary',                  \
+    {parts = {{field = 2, type = 'unsigned', path = 'path2'}}})
+_ = box.space.gh5451:create_index('multikey',                   \
+    {parts = {{field = 3, type = 'unsigned', path = '[*]'}}})
+
+c = netbox.connect(box.cfg.listen)
+
+c.space.gh5451.index[0].parts
+c.space.gh5451.index[1].parts
+c.space.gh5451.index[2].parts
+
+c:close()
+
+box.space.gh5451:drop()
+box.schema.user.revoke('guest', 'super')


### PR DESCRIPTION
Seems previously "path" wasn't installed to index schema. This
patch fixes it and introduces a test.

Closes #5451