### PR TITLE
Introduce interactive transactions

### DIFF
--- a/src/box/iproto_constants.c
+++ b/src/box/iproto_constants.c
@@ -108,6 +108,9 @@ const char *iproto_type_strs[] =
 	"EXECUTE",
 	NULL, /* NOP */
 	"PREPARE",
+	"BEGIN",
+	"COMMIT",
+	"ROLLBACK",
 };
 
 #define bit(c) (1ULL<<IPROTO_##c)
@@ -126,6 +129,9 @@ const uint64_t iproto_body_key_map[IPROTO_TYPE_STAT_MAX] = {
 	0,                                                     /* EXECUTE */
 	0,                                                     /* NOP */
 	0,                                                     /* PREPARE */
+	0,                                                     /* BEGIN */
+	0,                                                     /* COMMIT */
+	0,                                                     /* ROLLBACK */
 };
 #undef bit
 

--- a/src/box/iproto_constants.h
+++ b/src/box/iproto_constants.h
@@ -217,6 +217,9 @@ enum iproto_type {
 	IPROTO_NOP = 12,
 	/** Prepare SQL statement. */
 	IPROTO_PREPARE = 13,
+	IPROTO_BEGIN = 14,
+	IPROTO_COMMIT = 15,
+	IPROTO_NET_ROLLBACK = 16,
 	/** The maximum typecode used for box.stat() */
 	IPROTO_TYPE_STAT_MAX,
 
@@ -319,7 +322,7 @@ static inline bool
 iproto_type_is_dml(uint32_t type)
 {
 	return (type >= IPROTO_SELECT && type <= IPROTO_DELETE) ||
-		type == IPROTO_UPSERT || type == IPROTO_NOP;
+		type == IPROTO_UPSERT || type == IPROTO_NOP || (type >= IPROTO_BEGIN && type <= IPROTO_NET_ROLLBACK);
 }
 
 /**

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -968,6 +968,7 @@ txn_rollback_stmt(struct txn *txn)
 void
 txn_rollback(struct txn *txn)
 {
+	assert(txn);
 	assert(txn == in_txn());
 	txn->status = TXN_ABORTED;
 	trigger_clear(&txn->fiber_on_stop);

--- a/test/box/engine.cfg
+++ b/test/box/engine.cfg
@@ -2,5 +2,9 @@
     "gh-4513-netbox-self-and-connect-interchangeable.test.lua": {
         "remote": {"remote": "true"},
         "local": {"remote": "false"}
+    },
+    "remote_transactions.test.lua": {
+        "vinyl": {"engine": "vinyl"},
+        "memtx": {"engine": "memtx"}
     }
 }

--- a/test/box/misc.result
+++ b/test/box/misc.result
@@ -135,11 +135,14 @@ end;
 t;
 ---
 - - DELETE
+  - COMMIT
   - SELECT
+  - ROLLBACK
   - INSERT
   - EVAL
-  - CALL
   - ERROR
+  - CALL
+  - BEGIN
   - PREPARE
   - REPLACE
   - UPSERT

--- a/test/box/net.box_permissions.result
+++ b/test/box/net.box_permissions.result
@@ -147,16 +147,15 @@ cn:eval('!invalid expression')
 - error: 'eval:1: unexpected symbol near ''!'''
 ...
 -- box.commit() missing at return of CALL/EVAL
+-- see gh-2016 - now the behaviour is to silently rollback tx
 function no_commit() box.begin() fiber.sleep(0.001) end
 ---
 ...
 cn:call('no_commit')
 ---
-- error: Transaction is active at return from function
 ...
 cn:eval('no_commit()')
 ---
-- error: Transaction is active at return from function
 ...
 remote.self:eval('return 1+1, 2+2')
 ---

--- a/test/box/net.box_permissions.test.lua
+++ b/test/box/net.box_permissions.test.lua
@@ -51,6 +51,7 @@ cn:eval('box.error(0)')
 cn:eval('!invalid expression')
 
 -- box.commit() missing at return of CALL/EVAL
+-- see gh-2016 - now the behaviour is to silently rollback tx
 function no_commit() box.begin() fiber.sleep(0.001) end
 cn:call('no_commit')
 cn:eval('no_commit()')

--- a/test/box/remote_transactions.result
+++ b/test/box/remote_transactions.result
@@ -1,0 +1,355 @@
+env = require('test_run')
+---
+...
+test_run = env.new()
+---
+...
+test_run:cmd("create server tx_man with script='box/tx_man.lua'")
+---
+- true
+...
+test_run:cmd("start server tx_man")
+---
+- true
+...
+test_run:cmd("switch tx_man")
+---
+- true
+...
+engine = test_run:get_cfg('engine')
+---
+...
+LISTEN = require('uri').parse(box.cfg.listen)
+---
+...
+remote = require('net.box')
+---
+...
+fiber = require('fiber')
+---
+...
+log = require('log')
+---
+...
+local_space = box.schema.space.create('test', { engine = engine })
+---
+...
+pk = local_space:create_index('primary')
+---
+...
+box.schema.user.grant('guest', 'read,write,execute', 'universe')
+---
+...
+function local_replace(tuple) return local_space:replace(tuple) end
+---
+...
+log.info("create connection")
+---
+...
+conn = remote.connect(LISTEN.host, LISTEN.service)
+---
+...
+log.info("state is %s", conn.state)
+---
+...
+conn:ping()
+---
+- true
+...
+log.info("ping is done")
+---
+...
+remote_space = conn.space.test
+---
+...
+-- Check that a transaction isn't stored in the connection, if
+-- explicit conn:begin() wasn't called.
+conn:eval('return 2 + 2')
+---
+- 4
+...
+remote_space:replace({1})
+---
+- [1]
+...
+remote_space:select{}
+---
+- - [1]
+...
+-- Nothing to rollback, so the next select returns the same
+-- result.
+conn:rollback()
+---
+- true
+...
+remote_space:select{}
+---
+- - [1]
+...
+_ = remote_space:delete({1})
+---
+...
+remote_space:select{}
+---
+- []
+...
+--
+-- Test BEGIN of the new remote transaction.
+--
+conn:begin()
+---
+- true
+...
+-- No error: the remote transaction is stored in the connection
+-- object, so we can create also localhost transactions.
+box.begin()
+---
+...
+-- Error - this connection in this fiber already has the opened
+-- transaction.
+conn:begin()
+---
+- error: 'Operation is not permitted when there is an active transaction '
+...
+-- Commit the local transaction, but the remote is still alive, so
+-- conn:begin() returns error again.
+box.commit()
+---
+...
+conn:begin()
+---
+- error: 'Operation is not permitted when there is an active transaction '
+...
+conn:commit()
+---
+- true
+...
+--
+-- Test attaching remote requests to the connection transaction.
+--
+-- Attach space:method()
+conn:begin()
+---
+- true
+...
+remote_space:replace({1})
+---
+- [1]
+...
+remote_space:replace({2})
+---
+- [2]
+...
+remote_space:select{} -- check result of the remote select
+---
+- - [1]
+  - [2]
+...
+local_space:select{} -- result of the local select
+---
+- []
+...
+conn:commit()
+---
+- true
+...
+remote_space:select{}
+---
+- - [1]
+  - [2]
+...
+local_space:select{}
+---
+- - [1]
+  - [2]
+...
+-- Attach call/eval
+conn:begin()
+---
+- true
+...
+conn:eval('local_space:replace({1, 1})')
+---
+...
+conn:call('local_replace', {{2, 2}})
+---
+- [2, 2]
+...
+remote_space:select{}
+---
+- - [1, 1]
+  - [2, 2]
+...
+local_space:select{}
+---
+- - [1]
+  - [2]
+...
+conn:commit()
+---
+- true
+...
+remote_space:select{}
+---
+- - [1, 1]
+  - [2, 2]
+...
+local_space:select{}
+---
+- - [1, 1]
+  - [2, 2]
+...
+-- Check errors in call/eval. Error in call/eval must not rollback
+-- the entire transaction.
+conn:begin()
+---
+- true
+...
+remote_space:replace({1})
+---
+- [1]
+...
+conn:eval('box.box.box(123(456))')
+---
+- error: 'eval:1: '')'' expected near ''('''
+...
+remote_space:select{}
+---
+- - [1]
+  - [2, 2]
+...
+conn:call('error', {'1', '2', '3'})
+---
+- error: '1'
+...
+remote_space:select{}
+---
+- - [1]
+  - [2, 2]
+...
+conn:commit()
+---
+- true
+...
+remote_space:select{}
+---
+- - [1]
+  - [2, 2]
+...
+local_space:select{}
+---
+- - [1]
+  - [2, 2]
+...
+-- Check BEGIN via iproto and COMMIT via eval or call.
+conn:begin()
+---
+- true
+...
+_ = remote_space:delete({2})
+---
+...
+conn:eval('box.commit()')
+---
+...
+remote_space:select{}
+---
+- - [1]
+...
+-- We can start the new transaction, because the eval commited the
+-- previous one.
+conn:begin()
+---
+- true
+...
+remote_space:replace({2})
+---
+- [2]
+...
+conn:call('box.commit')
+---
+...
+remote_space:select{}
+---
+- - [1]
+  - [2]
+...
+-- We can start the new transaction, because the call commited the
+-- previous one.
+conn:begin()
+---
+- true
+...
+conn:commit()
+---
+- true
+...
+remote_space:select{}
+---
+- - [1]
+  - [2]
+...
+local_space:select{}
+---
+- - [1]
+  - [2]
+...
+function create_and_leave_opened() box.begin() local_space:replace({10}) end
+---
+...
+-- Check rollback of the transaction, created in eval or call.
+conn:eval('create_and_leave_opened()')
+---
+...
+remote_space:select{}
+---
+- - [1]
+  - [2]
+...
+local_space:select{}
+---
+- - [1]
+  - [2]
+...
+conn:call('create_and_leave_opened')
+---
+...
+remote_space:select{}
+---
+- - [1]
+  - [2]
+...
+local_space:select{}
+---
+- - [1]
+  - [2]
+...
+-- Check rollback on disconnect.
+conn:begin()
+---
+- true
+...
+remote_space:replace({10})
+---
+- [10]
+...
+-- All transactions are aborted after the connection closed.
+conn:close()
+---
+...
+-- Close begins in net thread, so we wait until close is finished.
+test_run:wait_cond(function() return not conn:is_connected() end, 1000)
+---
+- true
+...
+local_space:select{}
+---
+- - [1]
+  - [2]
+...
+local_space:drop()
+---
+...
+box.schema.user.revoke('guest', 'read,write,execute', 'universe')
+---
+...

--- a/test/box/remote_transactions.test.lua
+++ b/test/box/remote_transactions.test.lua
@@ -1,0 +1,138 @@
+env = require('test_run')
+test_run = env.new()
+
+test_run:cmd("create server tx_man with script='box/tx_man.lua'")
+test_run:cmd("start server tx_man")
+test_run:cmd("switch tx_man")
+
+engine = test_run:get_cfg('engine')
+
+LISTEN = require('uri').parse(box.cfg.listen)
+
+remote = require('net.box')
+fiber = require('fiber')
+log = require('log')
+
+local_space = box.schema.space.create('test', { engine = engine })
+pk = local_space:create_index('primary')
+box.schema.user.grant('guest', 'read,write,execute', 'universe')
+
+function local_replace(tuple) return local_space:replace(tuple) end
+
+log.info("create connection")
+conn = remote.connect(LISTEN.host, LISTEN.service)
+log.info("state is %s", conn.state)
+conn:ping()
+log.info("ping is done")
+remote_space = conn.space.test
+
+-- Check that a transaction isn't stored in the connection, if
+-- explicit conn:begin() wasn't called.
+conn:eval('return 2 + 2')
+remote_space:replace({1})
+remote_space:select{}
+-- Nothing to rollback, so the next select returns the same
+-- result.
+conn:rollback()
+remote_space:select{}
+_ = remote_space:delete({1})
+remote_space:select{}
+
+--
+-- Test BEGIN of the new remote transaction.
+--
+conn:begin()
+-- No error: the remote transaction is stored in the connection
+-- object, so we can create also localhost transactions.
+box.begin()
+-- Error - this connection in this fiber already has the opened
+-- transaction.
+conn:begin()
+-- Commit the local transaction, but the remote is still alive, so
+-- conn:begin() returns error again.
+box.commit()
+conn:begin()
+conn:commit()
+
+--
+-- Test attaching remote requests to the connection transaction.
+--
+
+-- Attach space:method()
+conn:begin()
+remote_space:replace({1})
+remote_space:replace({2})
+remote_space:select{} -- check result of the remote select
+local_space:select{} -- result of the local select
+conn:commit()
+
+remote_space:select{}
+local_space:select{}
+
+-- Attach call/eval
+conn:begin()
+conn:eval('local_space:replace({1, 1})')
+conn:call('local_replace', {{2, 2}})
+remote_space:select{}
+local_space:select{}
+conn:commit()
+
+remote_space:select{}
+local_space:select{}
+
+-- Check errors in call/eval. Error in call/eval must not rollback
+-- the entire transaction.
+conn:begin()
+remote_space:replace({1})
+conn:eval('box.box.box(123(456))')
+remote_space:select{}
+conn:call('error', {'1', '2', '3'})
+remote_space:select{}
+conn:commit()
+
+remote_space:select{}
+local_space:select{}
+
+-- Check BEGIN via iproto and COMMIT via eval or call.
+conn:begin()
+_ = remote_space:delete({2})
+conn:eval('box.commit()')
+remote_space:select{}
+-- We can start the new transaction, because the eval commited the
+-- previous one.
+conn:begin()
+remote_space:replace({2})
+conn:call('box.commit')
+remote_space:select{}
+-- We can start the new transaction, because the call commited the
+-- previous one.
+conn:begin()
+conn:commit()
+
+remote_space:select{}
+local_space:select{}
+
+function create_and_leave_opened() box.begin() local_space:replace({10}) end
+
+-- Check rollback of the transaction, created in eval or call.
+conn:eval('create_and_leave_opened()')
+remote_space:select{}
+local_space:select{}
+
+conn:call('create_and_leave_opened')
+remote_space:select{}
+local_space:select{}
+
+-- Check rollback on disconnect.
+conn:begin()
+remote_space:replace({10})
+
+-- All transactions are aborted after the connection closed.
+conn:close()
+-- Close begins in net thread, so we wait until close is finished.
+test_run:wait_cond(function() return not conn:is_connected() end, 1000)
+
+local_space:select{}
+
+local_space:drop()
+box.schema.user.revoke('guest', 'read,write,execute', 'universe')


### PR DESCRIPTION
(based on [2pc](https://github.com/tarantool/tarantool/tree/2pc) branch)

With introduction of mvcc, both memtx and vinyl engines are
allowed to yield during a transaction. This makes possible to
implement interactive transactions: when txn statements don't
have to be sent at once.

Current implementation allows to have one transaction per connection.
More flexible approach is to multiplex transactions in one connection
using e.g. idea of streams. This is going to be implemented later.

Closes #2016