### PR TITLE
Allow packpack's build for Debian 11 (bullseye)

### DIFF
--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -1,0 +1,54 @@
+name: debian_11
+
+on: [push, pull_request]
+
+env:
+  CI_MAKE: make -f .gitlab.mk
+
+jobs:
+  debian_11:
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: packaging
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
+          LIVE_REPO_S3_DIR: ${{ secrets.LIVE_REPO_S3_DIR }}
+          RELEASE_REPO_S3_DIR: ${{ secrets.RELEASE_REPO_S3_DIR }}
+          GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
+          GPG_SIGN_KEY: ${{ secrets.GPG_SIGN_KEY }}
+        run: |
+          if ${{ github.event_name == 'push' &&
+              ( github.ref == 'ref/head/master' ||
+                github.ref == 'ref/head/1.10' ||
+                startsWith(github.ref, 'refs/head/2.') ||
+                startsWith(github.ref, 'refs/tags') ) }} ; then
+            sudo apt-get -y update
+            sudo apt-get install -y procmail createrepo awscli reprepro
+            mkdir -p ~/.gnupg
+            echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
+            OS=debian DIST=bullseye ${CI_MAKE} deploy
+          else
+            OS=debian DIST=bullseye ${CI_MAKE} package
+          fi
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: debian-bullseye
+          retention-days: 1000000
+          path: test/var/artifacts

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Maintainer: Roman Tsisyk <roman@tarantool.org>
 Uploaders: Dmitry E. Oboukhov <unera@debian.org>
 Build-Depends: cdbs (>= 0.4.100), debhelper (>= 9), dpkg-dev (>= 1.16.1~),
 # Enable systemd for Debian Jessie+ and Ubuntu Wily+
- dh-systemd (>= 1.22) | sysvinit (<< 2.88dsf-59) | upstart (<< 1.13),
+ debhelper (>= 9.20160709) | dh-systemd (>= 1.22) | sysvinit (<< 2.88dsf-59) | upstart (<< 1.13),
  cmake,
  libreadline-dev,
  libncurses5-dev,

--- a/tools/update_repo.sh
+++ b/tools/update_repo.sh
@@ -26,7 +26,7 @@ function get_os_dists {
     if [ "$os" == "ubuntu" ]; then
         alldists='trusty xenial bionic disco eoan focal'
     elif [ "$os" == "debian" ]; then
-        alldists='jessie stretch buster'
+        alldists='jessie stretch buster bullseye'
     elif [ "$os" == "el" ]; then
         alldists='6 7 8'
     elif [ "$os" == "fedora" ]; then


### PR DESCRIPTION
Allow packpack's build for Debian 11 (bullseye).

Make build dependency on dh-systemd optional, as this package is deprecated
and removed from Debian 11. It part of debhelper (>= 9.20160709) now.
No new dependencies, as tarantool already depends on debhelper (>= 9).