### PR TITLE
tpch: use normal perf image instead of patched one

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -328,7 +328,7 @@ perf_tpch:
   <<: *perf_docker_test_definition
   tags:
     - docker_sh2_perf
-  image: ${IMAGE_PERF_BUILT}_tpch
+  image: ${IMAGE_PERF_BUILT}
   variables:
     <<: *perf_vars_definition
     BENCH: 'tpch'


### PR DESCRIPTION
TPCH benchmark used to be launched with numerous patches applied
to tarantool's source code. Not only it does not bench actual
tarantool, it also adds extra complications in benchmarking process.
Recently we got pipeline failed only because of tpch benchmark as it
would fail to launch because it failed to apply all of the needed
patches. Instead of fixing the patches we'd better get rid of that
patching in the first place.

Fixes the [issue](https://github.com/tarantool/bench-run/issues/15)