### PR TITLE
github-ci: set same workflow name as job

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,4 +1,4 @@
-name: CI
+name: coverity
 
 on:
   schedule:

--- a/.github/workflows/debug_coverage.yml
+++ b/.github/workflows/debug_coverage.yml
@@ -1,4 +1,4 @@
-name: CI
+name: debug_coverage
 
 on: [push, pull_request]
 

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,4 +1,4 @@
-name: CI
+name: luacheck
 
 on: [push, pull_request]
 

--- a/.github/workflows/osx_10_15.yml
+++ b/.github/workflows/osx_10_15.yml
@@ -1,4 +1,4 @@
-name: CI
+name: osx_10_15
 
 on: [push, pull_request]
 

--- a/.github/workflows/osx_11_0.yml
+++ b/.github/workflows/osx_11_0.yml
@@ -1,4 +1,4 @@
-name: CI
+name: osx_11_0
 
 on: [push, pull_request]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: CI
+name: release
 
 on: [push, pull_request]
 

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -1,4 +1,4 @@
-name: CI
+name: release_asan_clang11
 
 on: [push, pull_request]
 

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -1,4 +1,4 @@
-name: CI
+name: release_clang
 
 on: [push, pull_request]
 

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -1,4 +1,4 @@
-name: CI
+name: release_lto
 
 on: [push, pull_request]
 

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -1,4 +1,4 @@
-name: CI
+name: release_lto_clang11
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Due to current testing schema uses separate pipelines per each testing
job then workflow names should be the same as jobs to make it more
visible on github actions results page [1].

[1] - https://github.com/tarantool/tarantool/actions