### PR TITLE
github-ci: check the other way of duplication jobs

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -8,29 +8,11 @@ env:
   CI_MAKE: make -f .travis.mk
 
 jobs:
-  # By default jobs on push and pull_request filters run duplicating each other.
-  # To avoid of it used additional external module 'skip-duplicate-actions'.
-  # Used option 'concurrent_skipping' to skip duplicating jobs. Check info:
-  # https://github.com/marketplace/actions/skip-duplicate-actions#concurrent_skipping
-  pre_job:
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          # avoid of duplicating runs on "push & pull_request"
-          # avoid of running previous of the updated jobs
-          concurrent_skipping: 'same_content'
-
   coverity:
-    needs: pre_job
-    if: |
-      needs.pre_job.outputs.should_skip != 'true' ||
-      github.event_name == 'push'
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/debug_coverage.yml
+++ b/.github/workflows/debug_coverage.yml
@@ -6,29 +6,11 @@ env:
   CI_MAKE: make -f .travis.mk
 
 jobs:
-  # By default jobs on push and pull_request filters run duplicating each other.
-  # To avoid of it used additional external module 'skip-duplicate-actions'.
-  # Used option 'concurrent_skipping' to skip duplicating jobs. Check info:
-  # https://github.com/marketplace/actions/skip-duplicate-actions#concurrent_skipping
-  pre_job:
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          # avoid of duplicating runs on "push & pull_request"
-          # avoid of running previous of the updated jobs
-          concurrent_skipping: 'same_content'
-
   debug_coverage:
-    needs: pre_job
-    if: |
-      needs.pre_job.outputs.should_skip != 'true' ||
-      github.event_name == 'push'
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -6,29 +6,11 @@ env:
   CI_MAKE: make -f .travis.mk
 
 jobs:
-  # By default jobs on push and pull_request filters run duplicating each other.
-  # To avoid of it used additional external module 'skip-duplicate-actions'.
-  # Used option 'concurrent_skipping' to skip duplicating jobs. Check info:
-  # https://github.com/marketplace/actions/skip-duplicate-actions#concurrent_skipping
-  pre_job:
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          # avoid of duplicating runs on "push & pull_request"
-          # avoid of running previous of the updated jobs
-          concurrent_skipping: 'same_content'
-
   luacheck:
-    needs: pre_job
-    if: |
-      needs.pre_job.outputs.should_skip != 'true' ||
-      github.event_name == 'push'
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/osx_10_15.yml
+++ b/.github/workflows/osx_10_15.yml
@@ -6,29 +6,11 @@ env:
   CI_MAKE: make -f .travis.mk
 
 jobs:
-  # By default jobs on push and pull_request filters run duplicating each other.
-  # To avoid of it used additional external module 'skip-duplicate-actions'.
-  # Used option 'concurrent_skipping' to skip duplicating jobs. Check info:
-  # https://github.com/marketplace/actions/skip-duplicate-actions#concurrent_skipping
-  pre_job:
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          # avoid of duplicating runs on "push & pull_request"
-          # avoid of running previous of the updated jobs
-          concurrent_skipping: 'same_content'
-
   osx_10_15:
-    needs: pre_job
-    if: |
-      needs.pre_job.outputs.should_skip != 'true' ||
-      github.event_name == 'push'
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: macos-10.15
 

--- a/.github/workflows/osx_11_0.yml
+++ b/.github/workflows/osx_11_0.yml
@@ -6,29 +6,11 @@ env:
   CI_MAKE: make -f .travis.mk
 
 jobs:
-  # By default jobs on push and pull_request filters run duplicating each other.
-  # To avoid of it used additional external module 'skip-duplicate-actions'.
-  # Used option 'concurrent_skipping' to skip duplicating jobs. Check info:
-  # https://github.com/marketplace/actions/skip-duplicate-actions#concurrent_skipping
-  pre_job:
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          # avoid of duplicating runs on "push & pull_request"
-          # avoid of running previous of the updated jobs
-          concurrent_skipping: 'same_content'
-
   osx_11_0:
-    needs: pre_job
-    if: |
-      needs.pre_job.outputs.should_skip != 'true' ||
-      github.event_name == 'push'
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: macos-11.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,29 +6,11 @@ env:
   CI_MAKE: make -f .travis.mk
 
 jobs:
-  # By default jobs on push and pull_request filters run duplicating each other.
-  # To avoid of it used additional external module 'skip-duplicate-actions'.
-  # Used option 'concurrent_skipping' to skip duplicating jobs. Check info:
-  # https://github.com/marketplace/actions/skip-duplicate-actions#concurrent_skipping
-  pre_job:
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          # avoid of duplicating runs on "push & pull_request"
-          # avoid of running previous of the updated jobs
-          concurrent_skipping: 'same_content'
-
   release:
-    needs: pre_job
-    if: |
-      needs.pre_job.outputs.should_skip != 'true' ||
-      github.event_name == 'push'
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -6,29 +6,11 @@ env:
   CI_MAKE: make -f .travis.mk
 
 jobs:
-  # By default jobs on push and pull_request filters run duplicating each other.
-  # To avoid of it used additional external module 'skip-duplicate-actions'.
-  # Used option 'concurrent_skipping' to skip duplicating jobs. Check info:
-  # https://github.com/marketplace/actions/skip-duplicate-actions#concurrent_skipping
-  pre_job:
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          # avoid of duplicating runs on "push & pull_request"
-          # avoid of running previous of the updated jobs
-          concurrent_skipping: 'same_content'
-
   release_asan_clang11:
-    needs: pre_job
-    if: |
-      needs.pre_job.outputs.should_skip != 'true' ||
-      github.event_name == 'push'
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -6,29 +6,11 @@ env:
   CI_MAKE: make -f .travis.mk
 
 jobs:
-  # By default jobs on push and pull_request filters run duplicating each other.
-  # To avoid of it used additional external module 'skip-duplicate-actions'.
-  # Used option 'concurrent_skipping' to skip duplicating jobs. Check info:
-  # https://github.com/marketplace/actions/skip-duplicate-actions#concurrent_skipping
-  pre_job:
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          # avoid of duplicating runs on "push & pull_request"
-          # avoid of running previous of the updated jobs
-          concurrent_skipping: 'same_content'
-
   release_clang:
-    needs: pre_job
-    if: |
-      needs.pre_job.outputs.should_skip != 'true' ||
-      github.event_name == 'push'
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -6,29 +6,11 @@ env:
   CI_MAKE: make -f .travis.mk
 
 jobs:
-  # By default jobs on push and pull_request filters run duplicating each other.
-  # To avoid of it used additional external module 'skip-duplicate-actions'.
-  # Used option 'concurrent_skipping' to skip duplicating jobs. Check info:
-  # https://github.com/marketplace/actions/skip-duplicate-actions#concurrent_skipping
-  pre_job:
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          # avoid of duplicating runs on "push & pull_request"
-          # avoid of running previous of the updated jobs
-          concurrent_skipping: 'same_content'
-
   release_lto:
-    needs: pre_job
-    if: |
-      needs.pre_job.outputs.should_skip != 'true' ||
-      github.event_name == 'push'
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -6,29 +6,11 @@ env:
   CI_MAKE: make -f .travis.mk
 
 jobs:
-  # By default jobs on push and pull_request filters run duplicating each other.
-  # To avoid of it used additional external module 'skip-duplicate-actions'.
-  # Used option 'concurrent_skipping' to skip duplicating jobs. Check info:
-  # https://github.com/marketplace/actions/skip-duplicate-actions#concurrent_skipping
-  pre_job:
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          # avoid of duplicating runs on "push & pull_request"
-          # avoid of running previous of the updated jobs
-          concurrent_skipping: 'same_content'
-
   release_lto_clang11:
-    needs: pre_job
-    if: |
-      needs.pre_job.outputs.should_skip != 'true' ||
-      github.event_name == 'push'
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Initially decided to use external module:
```
  fkirc/skip-duplicate-actions
```
but after some additional investigation [1], decided to use simple check
```
  github.event.pull_request.head.repo.full_name != github.repository
```
instead of this module. This solution was found in github.com/h2o/h2o
repository [2].
    
Co-authored-by: Alexander Turenko <alexander.turenko@tarantool.org>
    
[1] - https://github.com/tarantool/tarantool/pull/5638#discussion_r549248841
[2] - https://github.com/h2o/h2o/commit/1c79d79e8b7686145975bc1cb04201e78b875924
