### PR TITLE
build: Fix build with backtraces enabled on arm64 (aarch64)

### DIFF
--- a/src/lib/core/backtrace.cc
+++ b/src/lib/core/backtrace.cc
@@ -358,7 +358,7 @@ __asm__ volatile(
 	"\tldp d14, d15, [x0, #16 * 9]\n"
 	"\tadd sp, x0, #8 * 20\n"
 	:
-	: "r" (unw_context), "r" (coro_ctx), "i" (unw_getcontext_f)
+	: "r" (unw_context), "r" (coro_ctx), "S" (unw_getcontext_f)
 	: /*"lr", "r0", "r1", "ip" */
 	 "x0", "x1", "x2", "x30"
 	);
@@ -376,22 +376,22 @@ void
 backtrace_foreach(backtrace_cb cb, coro_context *coro_ctx, void *cb_ctx)
 {
 	unw_cursor_t unw_cur;
-	unw_context_t unw_ctx;
+	unw_context_t unw_ctx_bt;
 	if (coro_ctx == NULL) {
 		/*
 		 * Current executing coroutine and simple unw_getcontext
 		 * should function.
 		 */
-		unw_getcontext(&unw_ctx);
+		unw_getcontext(&unw_ctx_bt);
 	} else {
 		/*
 		 * Execution context is stored in the coro_ctx
 		 * so use special context-switching handler to
 		 * capture an unwind context.
 		 */
-		coro_unwcontext(&unw_ctx, coro_ctx);
+		coro_unwcontext(&unw_ctx_bt, coro_ctx);
 	}
-	unw_init_local(&unw_cur, &unw_ctx);
+	unw_init_local(&unw_cur, &unw_ctx_bt);
 	int frame_no = 0;
 	unw_word_t sp = 0, old_sp = 0, ip, offset;
 	int unw_status, demangle_status;


### PR DESCRIPTION
Fix build errors on arm64 when backtraces being enabled.

**Q:** Will it always work?
**A:** No, most probably it'll crash somewhere inside libunwind. This is due to the bug in libunwind, fixed not so long ago in https://github.com/libunwind/libunwind/pull/221 and not yet even released, not to mention availability in various distributives.

But with current libunwind master it gives nice and shiny backtrace:

Code:
```
local fiber = require ('fiber')
local log = require('log')

log.error(fiber.info())
```

Result:
```
{
   "102":{
      "csw":0,
      "backtrace":[
         
      ],
      "fid":102,
      "memory":{
         "total":516448,
         "used":0
      },
      "name":"on_shutdown"
   },
   "101":{
      "csw":1,
      "backtrace":[
         {
            "C":"#0  0x7d9d1c29548 in +116"
         }
      ],
      "fid":101,
      "memory":{
         "total":516448,
         "used":0
      },
      "name":"lua"
   },
   "103":{
      "csw":1,
      "backtrace":[
         {
            "C":"#0  0xaaaab41e2904 in fiber_stat+92"
         },
         {
            "C":"#1  0xaaaab41bf318 in lbox_fiber_info+64"
         },
         {
            "L":"info in =[C] at line -1"
         },
         {
            "L":"(unnamed) in @..\/little.lua at line 4"
         },
         {
            "C":"#2  0xaaaab4236274 in lj_BC_FUNCC+44"
         },
         {
            "C":"#3  0xaaaab421744c in lua_pcall+196"
         },
         {
            "C":"#4  0xaaaab41c54c8 in luaT_call+24"
         },
         {
            "C":"#5  0xaaaab41be1ac in lua_main+108"
         },
         {
            "C":"#6  0xaaaab41be5f8 in run_script_f+1064"
         },
         {
            "C":"#7  0xaaaab40602fc in fiber_cxx_invoke(int (*)(std::__va_list), std::__va_list)+36"
         },
         {
            "C":"#8  0xaaaab41e00f0 in fiber_loop+88"
         },
         {
            "C":"#9  0xaaaab43594a8 in coro_startup+20"
         }
      ],
      "fid":103,
      "memory":{
         "total":516448,
         "used":0
      },
      "name":"little.lua"
   }
}
```

Checked with Ubuntu Focal (20.04) on RaspberryPi3 (arm64)
```
# uname -a
Linux 5.4.0-1025-raspi #28-Ubuntu SMP PREEMPT Wed Dec 9 17:10:53 UTC 2020 aarch64 aarch64 aarch64 GNU/Linux
```
libc 2.31
gcc 9.3.0

Also checked that it works well with 1.10 branch.

See also:
 - #5471 