### PR TITLE
github-ci: decrease retention days for artifacts

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -40,5 +40,5 @@ jobs:
         if: failure()
         with:
           name: debug
-          retention-days: 1000000
+          retention-days: 21
           path: test/var/artifacts

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -54,5 +54,5 @@ jobs:
         if: failure()
         with:
           name: debian-bullseye
-          retention-days: 1000000
+          retention-days: 21
           path: test/var/artifacts

--- a/.github/workflows/debug_coverage.yml
+++ b/.github/workflows/debug_coverage.yml
@@ -36,5 +36,5 @@ jobs:
         if: failure()
         with:
           name: debug
-          retention-days: 1000000
+          retention-days: 21
           path: test/var/artifacts

--- a/.github/workflows/osx_10_15.yml
+++ b/.github/workflows/osx_10_15.yml
@@ -29,5 +29,5 @@ jobs:
         if: failure()
         with:
           name: osx_10_15
-          retention-days: 1000000
+          retention-days: 21
           path: test/var/artifacts

--- a/.github/workflows/osx_11_0.yml
+++ b/.github/workflows/osx_11_0.yml
@@ -29,5 +29,5 @@ jobs:
         if: failure()
         with:
           name: osx_11_0
-          retention-days: 1000000
+          retention-days: 21
           path: test/var/artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,5 +34,5 @@ jobs:
         if: failure()
         with:
           name: release
-          retention-days: 1000000
+          retention-days: 21
           path: test/var/artifacts

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -37,5 +37,5 @@ jobs:
         if: failure()
         with:
           name: release_asan_clang11
-          retention-days: 1000000
+          retention-days: 21
           path: test/var/artifacts

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -37,5 +37,5 @@ jobs:
         if: failure()
         with:
           name: release_clang
-          retention-days: 1000000
+          retention-days: 21
           path: test/var/artifacts

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -39,5 +39,5 @@ jobs:
         if: failure()
         with:
           name: release_lto
-          retention-days: 1000000
+          retention-days: 21
           path: test/var/artifacts

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -41,5 +41,5 @@ jobs:
         if: failure()
         with:
           name: release_lto_clang11
-          retention-days: 1000000
+          retention-days: 21
           path: test/var/artifacts


### PR DESCRIPTION
Found that artifacts uses storage space which is limited to 0,5 GiB.
To avoid of lack of the space there decided to decrease the retention
days option for artifacts from default 90 days to 21 days (3 weeks).