### PR TITLE
gitlab-ci: remove OSX 13 from testing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -240,13 +240,6 @@ release_asan_clang11:
   script:
     - ${GITLAB_MAKE} test_asan_debian_no_deps
 
-osx_13_release:
-  tags:
-    - osx_13
-  variables:
-    MACOSX_DEPLOYMENT_TARGET: '10.13'
-  <<: *osx_definition
-
 osx_14_release:
   tags:
     - osx_14


### PR DESCRIPTION
OSX 13 was tested for homebrew commit criteria. But a month ago
criteria list changed and OSX 13 was removed [1]. So we don't
need it any more in our commit criteria - removing.

[1] - https://github.com/Homebrew/homebrew-core/actions/runs/465259174