### PR TITLE
gitlab-ci: add OSX 11.0 to testing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -264,6 +264,11 @@ osx_15_release_lto:
     CMAKE_EXTRA_PARAMS: -DENABLE_LTO=ON
   <<: *osx_definition
 
+osx_110_release:
+  tags:
+    - osx_110
+  <<: *osx_definition
+
 freebsd_12_release:
   <<: *vbox_definition
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -135,7 +135,7 @@ before_script:
   <<: *artifacts_files_definition
   stage: test
   script:
-    - ${GITLAB_MAKE} test_osx
+    - ${GITLAB_MAKE} test_osx_no_deps
   after_script:
     # Artifacts can't be used from outside the project directory, check:
     #   https://docs.gitlab.com/ee/ci/yaml/README.html#artifactspaths


### PR DESCRIPTION
Added OSX 11.0 testing job to commit criteria.    
Changed OSX build target from 'test_osx' to 'test_osx_no_deps' to
avoid of depends installation to save test time.
