### PR TITLE
gitlab-ci: FreeBSD 12 lack of python 2 packages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -275,7 +275,7 @@ freebsd_12_release:
     MAKE: 'gmake'
   script:
     - ${GITLAB_MAKE} vms_start
-    - ${GITLAB_MAKE} vms_test_freebsd
+    - ${GITLAB_MAKE} vms_test_freebsd_no_deps
 
 jepsen-single-instance:
   <<: *jepsen_test_definition


### PR DESCRIPTION
Found issue:
```
  pkg: No packages available to install matching 'py27-yaml' have been found in the repositories
  pkg: No packages available to install matching 'py27-gevent' have been found in the repositories
```
Happened at .travis.mk file target:
```
  deps_freebsd:
          sudo pkg install -y git cmake gmake icu libiconv \
                  python27 py27-yaml py27-six py27-gevent \
                  autoconf automake libtool
```
It happened because Python 2 is end of life and all OS distributions
changed to use Python 3. Also all repositories removed its copies of
the Python 2 packages.

Due to FreeBSD 12 is testing using VBox VM image which already has
all the needed Python 2 packages, the current fix is to change the
gitlab-ci job to use instead of 'test_freebsd' target, which calls
'deps_freebsd' target with calls to install Python 2 packages, use
'test_freebsd_no_deps' target without it. We really won't need these
packages feather due to next update of these gitlab-ci jobs will be
change of make targets to use Python 3 packages instead of Python 2.

Closes tarantool/tarantool-qa#4