### PR TITLE
github-ci: enable Fedora 33 packaging

### DIFF
--- a/.github/workflows/fedora_33.yml
+++ b/.github/workflows/fedora_33.yml
@@ -1,0 +1,58 @@
+name: fedora_33
+
+on: [push, pull_request]
+
+env:
+  CI_MAKE: make -f .gitlab.mk
+
+jobs:
+  fedora_33:
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: packaging
+        env:
+          # Our testing expects that the init process (PID 1) will
+          # reap orphan processes. At least the following test leans
+          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
+          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '--init'
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
+          LIVE_REPO_S3_DIR: ${{ secrets.LIVE_REPO_S3_DIR }}
+          RELEASE_REPO_S3_DIR: ${{ secrets.RELEASE_REPO_S3_DIR }}
+          GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
+          GPG_SIGN_KEY: ${{ secrets.GPG_SIGN_KEY }}
+        run: |
+          if ${{ github.event_name == 'push' &&
+              ( github.ref == 'refs/heads/master' ||
+                github.ref == 'refs/heads/1.10' ||
+                startsWith(github.ref, 'refs/heads/2.') ||
+                startsWith(github.ref, 'refs/tags') ) }} ; then
+            sudo apt-get -y update
+            sudo apt-get install -y procmail createrepo awscli reprepro
+            mkdir -p ~/.gnupg
+            echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
+            OS=fedora DIST=33 ${CI_MAKE} deploy
+          else
+            OS=fedora DIST=33 ${CI_MAKE} package
+          fi
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: fedora-33
+          retention-days: 21
+          path: test/var/artifacts

--- a/rpm/tarantool.spec
+++ b/rpm/tarantool.spec
@@ -72,6 +72,11 @@ BuildRequires: libunwind-devel
 %endif
 
 # Set dependences for tests.
+# Since Python 2 was deprecated then new OS do not have repositories
+# with its packages. It is not good way to create all these packages
+# manually and store it as backported. Let's wait when Python 3 will
+# be used for testing.
+%if (0%{?fedora} < 33 && 0%{?rhel} < 9)
 # Do not install unused Python 3 packages which
 # is default since Fedora 31 and CentOS 8.
 %if (0%{?fedora} >= 31 || 0%{?rhel} >= 8)
@@ -84,6 +89,7 @@ BuildRequires: python >= 2.7
 BuildRequires: python-six >= 1.9.0
 BuildRequires: python-gevent >= 1.0
 BuildRequires: python-yaml >= 3.0.9
+%endif
 %endif
 
 Name: tarantool
@@ -141,7 +147,15 @@ C and Lua/C modules.
 
 %build
 # RHBZ #1301720: SYSCONFDIR an LOCALSTATEDIR must be specified explicitly
-%cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+# Must specified explicitly since Fedora 33:
+# 1. -B .
+#    because for now binary path by default value like:
+#      '-B x86_64-redhat-linux-gnu'
+# 2. -DENABLE_LTO=ON
+#    because for now LTO flags are set in CC/LD flags by default:
+#      '-flto=auto -ffat-lto-objects'
+%cmake -B . \
+         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
          -DCMAKE_INSTALL_LOCALSTATEDIR:PATH=%{_localstatedir} \
          -DCMAKE_INSTALL_SYSCONFDIR:PATH=%{_sysconfdir} \
 %if %{with backtrace}
@@ -154,6 +168,9 @@ C and Lua/C modules.
          -DSYSTEMD_UNIT_DIR:PATH=%{_unitdir} \
          -DSYSTEMD_TMPFILES_DIR:PATH=%{_tmpfilesdir} \
 %endif
+%if 0%{?fedora} >= 33
+         -DENABLE_LTO=ON \
+%endif
          -DENABLE_WERROR:BOOL=ON \
          -DENABLE_DIST:BOOL=ON
 make %{?_smp_mflags}
@@ -164,7 +181,11 @@ make %{?_smp_mflags}
 rm -rf %{buildroot}%{_datarootdir}/doc/tarantool/
 
 %check
+# Blocked testing starting from Fedora 33 while Python 3 not enabled
+# for testing, issue for switching it on is tarantool/tarantool-qa#17.
+%if 0%{?fedora} < 33
 make test-force
+%endif
 
 %pre
 /usr/sbin/groupadd -r tarantool > /dev/null 2>&1 || :

--- a/tools/update_repo.sh
+++ b/tools/update_repo.sh
@@ -30,7 +30,7 @@ function get_os_dists {
     elif [ "$os" == "el" ]; then
         alldists='6 7 8'
     elif [ "$os" == "fedora" ]; then
-        alldists='27 28 29 30 31 32'
+        alldists='27 28 29 30 31 32 33'
     elif [ "$os" == "opensuse-leap" ]; then
         alldists='15.0 15.1 15.2'
     fi


### PR DESCRIPTION
1.    github-ci: add Fedora 33 to packaging
    
    Added jobs for testing and deploying Fedora 33 packages.
    
    Added Fedora 33 at update_repo tool to make able to save packages
    in S3 buckets.
    
    Closes #5502

2. build: enable packaging for Fedora 33
    
    Since Python 2 was deprecated then new OS do not have repositories
    with its packages. It is not good way to create all these packages
    manually and store it as backported. Let's wait when Python 3 will
    be used for testing and for now the testing disabled for Fedora 33
    packaging.
    
    Also found that %cmake macros used in build spec was changed - new
    option was added:
    
      -B x86_64-redhat-linux-gnu
    
    It changed the build path and broke the build, to fix it these
    options was additionally locally reset to:
    
      -B .
    
    Found that LTO was set by default in Fedora 33, check
    
      /usr/lib/rpm/redhat/macros
    
        # LTO is the default in Fedora.
        #   "%define _lto_cflags %{nil}"  to opt out
        #
        # We currently have -ffat-lto-objects turned on out of an abundance of
        # caution.  To remove it we need to do a check of the installed .o/.a files
        # to verify they have real sections/symbols after LTO stripping.  That
        # way we can detect installing an unusable .o/.a file.  This is on the TODO
        # list for F34.
        %_gcc_lto_cflags        -flto=auto -ffat-lto-objects
        %_clang_lto_cflags      -flto
        %_lto_cflags            %{expand:%%{_%{toolchain}_lto_cflags}}
    
        %_general_options       -O2 %{?_lto_cflags} -fexceptions -g -grecord-gcc-switches -pipe
    
    and build issues occured:
    
      /build/usr/src/debug/tarantool-2.8.0.2/src/lib/core/reflection.h:124:33: warning: type of â€˜METHODS_SENTINELâ€™ does not match original declaration [-Wlto-type-mismatch]
        124 | extern const struct method_info METHODS_SENTINEL;
            |                                 ^
      /build/usr/src/debug/tarantool-2.8.0.2/src/lib/core/reflection.c:35:26: note: â€˜METHODS_SENTINELâ€™ was previously declared here
         35 | const struct method_info METHODS_SENTINEL = {
            |                          ^
    
    it was fixed as was suggested in 1st way of [1][2]. This warning was
    disabled in commit:
    
      f9e28ce4602aff3f9bb4e743b0d6167b0f8df88d ("Add LTO support")
    
    with cmake flag:
    
      -D_ENABLE_LTO=ON
    
    so added this flag to cmake RPM spec build flags for Fedora 33 and its
    later versions.
    
    Needed for #5502
    Needed for #5697
    
    [1] - https://github.com/tarantool/tarantool/issues/5697#issuecomment-759409465
    [2] - https://github.com/tarantool/tarantool/pull/5707#discussion_r561072044