### PR TITLE
build: fix uninitialized ptr before use

### DIFF
--- a/test/unit/fiber_channel.cc
+++ b/test/unit/fiber_channel.cc
@@ -34,7 +34,7 @@ fiber_channel_basic()
 
 	ok(fiber_channel_is_empty(channel) == false, "fiber_channel_is_empty(1)");
 
-	void *ptr;
+	void *ptr = NULL;
 
 	fiber_channel_get(channel, &ptr);
 	ok(ptr == &dummy, "fiber_channel_get()");
@@ -58,7 +58,7 @@ fiber_channel_get()
 	   "fiber_channel_put(0)");
 	ok(fiber_channel_put_timeout(channel, &dummy, 0) == -1,
 	   "fiber_channel_put_timeout(0)");
-	void *ptr;
+	void *ptr = NULL;
 	fiber_channel_get(channel, &ptr);
 	ok(ptr == &dummy, "fiber_channel_get(0)");
 	ok(fiber_channel_put_timeout(channel, &dummy, 0.01) == 0,


### PR DESCRIPTION
Found issues building on Fedora 33:
```
  test/unit/fiber_channel.cc: In function ‘fiber_channel_basic’:
  test/unit/fiber_channel.cc:40:2: error: ‘ptr’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     40 |  ok(ptr == &dummy, "fiber_channel_get()");
        |  ^
  test/unit/fiber_channel.cc:37:8: note: ‘ptr’ was declared here
     37 |  void *ptr;
        |        ^

  test/unit/fiber_channel.cc: In function ‘fiber_channel_get’:
  test/unit/fiber_channel.cc:63:2: error: ‘ptr’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     63 |  ok(ptr == &dummy, "fiber_channel_get(0)");
        |  ^
  test/unit/fiber_channel.cc:61:8: note: ‘ptr’ was declared here
     61 |  void *ptr;
        |        ^
```
To fix the issue set ptr to NULL during initialization.

Needed for #5502
Part of #5697