### PR TITLE
build: update cmake for zstd submodule build

### DIFF
--- a/cmake/BuildZSTD.cmake
+++ b/cmake/BuildZSTD.cmake
@@ -6,8 +6,11 @@ macro(zstd_build)
         third_party/zstd/lib/common/pool.c
         third_party/zstd/lib/common/xxhash.c
         third_party/zstd/lib/common/fse_decompress.c
+        third_party/zstd/lib/common/debug.c
         third_party/zstd/lib/decompress/zstd_decompress.c
         third_party/zstd/lib/decompress/huf_decompress.c
+        third_party/zstd/lib/decompress/zstd_ddict.c
+        third_party/zstd/lib/decompress/zstd_decompress_block.c
         third_party/zstd/lib/compress/zstd_double_fast.c
         third_party/zstd/lib/compress/zstd_fast.c
         third_party/zstd/lib/compress/zstd_lazy.c
@@ -17,6 +20,10 @@ macro(zstd_build)
         third_party/zstd/lib/compress/zstdmt_compress.c
         third_party/zstd/lib/compress/huf_compress.c
         third_party/zstd/lib/compress/fse_compress.c
+        third_party/zstd/lib/compress/hist.c
+        third_party/zstd/lib/compress/zstd_compress_superblock.c
+        third_party/zstd/lib/compress/zstd_compress_sequences.c
+        third_party/zstd/lib/compress/zstd_compress_literals.c
     )
 
     if (CC_HAS_WNO_IMPLICIT_FALLTHROUGH)

--- a/static-build/test/static-build/exports.test.lua
+++ b/static-build/test/static-build/exports.test.lua
@@ -129,8 +129,6 @@ local check_symbols = {
 
     'ZSTD_compress',
     'ZSTD_decompress',
-    'ZSTD_free',
-    'ZSTD_malloc',
     'ZSTD_versionString',
 }
 


### PR DESCRIPTION
**Use for master, 2.7, 2.6 release, branch:   avtikhon/gh-5502-fedora-33-zstd
use for 1.10 release, branch:                        avtikhon/gh-5502-fedora-33-zstd_1.10**

Found issue building on Fedora 33:
```
  third_party/zstd/lib/decompress/zstd_decompress.c: In function ‘ZSTD_findFrameCompressedSize’:
  third_party/zstd/lib/decompress/zstd_decompress.c:1502:18: error: ‘zfh.headerSize’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   1502 |         ip += zfh.headerSize;
        |                  ^
```
Also found that later releases of third_party/zstd submodule already
fixed it. Decided to bump third_party/zstd submodule from v1.3.3 to
v1.4.8. Added to zstd cmake build rules new files appeared on bumping.

**For master, 2.7, 2.6:**
Found that some checking in static-build test exporting symbols like:
```
      ZSTD_free
      ZSTD_malloc
```
never were public symbols and should not be tested for presence in the
Tarantool executable, but also these symbols currently outdated and
broke the testing. To avoid of it these symbols removed from test.

Needed for #5502
Closes #5697
