### PR TITLE
mvcc engine: intervals for memtx txm

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -122,6 +122,7 @@ add_library(box STATIC
     index_def.c
     iterator_type.c
     memtx_hash.c
+    memtx_read_set.c
     memtx_tree.cc
     memtx_rtree.c
     memtx_bitset.c

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -34,6 +34,7 @@
 #include "trivia/util.h"
 #include "iterator_type.h"
 #include "index_def.h"
+#include "memtx_read_set.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -460,6 +461,8 @@ struct index {
 	int refs;
 	/* Space cache version at the time of construction. */
 	uint32_t space_cache_version;
+	/** Tree of intervals read from this index. */
+    	memtx_index_read_set_t memtx_read_set;
 };
 
 /**

--- a/src/box/key_def.h
+++ b/src/box/key_def.h
@@ -943,6 +943,25 @@ key_compare(const char *key_a, hint_t key_a_hint,
 	    const char *key_b, hint_t key_b_hint,
 	    struct key_def *key_def);
 
+/** Dummy keys representing -inf and +inf accordingly. */
+extern const char min_key;
+extern const char max_key;
+
+static inline bool
+is_inf(const char *key)
+{
+	return key == &min_key || key == &max_key;
+}
+
+/**
+ * Compare keys that can be +- inf.
+ * @sa key_compare()
+ */
+int
+key_compare_ext(const char *key_a, hint_t key_a_hint,
+		const char *key_b, hint_t key_b_hint,
+		struct key_def *key_def);
+
 /**
  * Compare tuples using the key definition and comparison hints.
  * @param tuple_a first tuple

--- a/src/box/memtx_read_set.c
+++ b/src/box/memtx_read_set.c
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2010-2020, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY AUTHORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * AUTHORS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "memtx_read_set.h"
+#include "index.h"
+#include "key_def.h"
+
+int
+memtx_read_interval_cmpl(const struct memtx_read_interval *a,
+		      const struct memtx_read_interval *b)
+{
+	assert(a->index == b->index);
+	assert(a->left.key != NULL);
+	assert(a->right.key != NULL);
+	assert(b->left.key != NULL);
+	assert(b->right.key != NULL);
+
+	struct key_def *cmp_def = a->index->def->cmp_def;
+	int cmp = key_compare_ext(a->left.key, a->left.hint,
+				  b->left.key, b->left.hint, cmp_def);
+	if (cmp != 0)
+		return cmp;
+	if (a->left_belongs && !b->left_belongs)
+		return -1;
+	if (!a->left_belongs && b->left_belongs)
+		return 1;
+	if (is_inf(a->left.key) || is_inf(b->left.key))
+		return 0;
+
+	const char* a_key = a->left.key;
+	uint32_t a_parts = mp_decode_array(&a_key);
+	const char* b_key = b->left.key;
+	uint32_t b_parts = mp_decode_array(&b_key);
+	if (a->left_belongs)
+		return a_parts < b_parts ? -1 : a_parts > b_parts;
+	else
+		return a_parts > b_parts ? -1 : a_parts < b_parts;
+}
+
+int
+memtx_read_interval_cmpr(const struct memtx_read_interval *a,
+		      const struct memtx_read_interval *b)
+{
+	assert(a->index == b->index);
+	assert(a->left.key != NULL);
+	assert(a->right.key != NULL);
+	assert(b->left.key != NULL);
+	assert(b->right.key != NULL);
+
+	struct key_def *cmp_def = a->index->def->cmp_def;
+	int cmp = key_compare_ext(a->right.key, a->right.hint,
+				  b->right.key, b->right.hint, cmp_def);
+	if (cmp != 0)
+		return cmp;
+	if (a->right_belongs && !b->right_belongs)
+		return 1;
+	if (!a->right_belongs && b->right_belongs)
+		return -1;
+	if (is_inf(a->right.key) || is_inf(b->right.key))
+		return 0;
+
+	const char* a_key = a->right.key;
+	uint32_t a_parts = mp_decode_array(&a_key);
+	const char* b_key = b->right.key;
+	uint32_t b_parts = mp_decode_array(&b_key);
+	if (a->right_belongs)
+		return a_parts > b_parts ? -1 : a_parts < b_parts;
+	else
+		return a_parts < b_parts ? -1 : a_parts > b_parts;
+}
+
+bool
+memtx_read_interval_should_merge(const struct memtx_read_interval *l,
+			      const struct memtx_read_interval *r)
+{
+	assert(l->index == r->index);
+	assert(l->left.key != NULL);
+	assert(l->right.key != NULL);
+	assert(r->left.key != NULL);
+	assert(r->right.key != NULL);
+	assert(memtx_read_interval_cmpl(l, r) <= 0);
+
+	struct key_def *cmp_def = l->index->def->cmp_def;
+	int cmp = key_compare_ext(l->right.key, l->right.hint,
+				  r->left.key, r->left.hint, cmp_def);
+	if (cmp > 0)
+		return true;
+	if (cmp < 0)
+		return false;
+	if (l->right_belongs && r->left_belongs)
+		return true;
+	if (!l->right_belongs && !r->left_belongs)
+		return false;
+	if (is_inf(l->right.key) || is_inf(r->left.key))
+		return true;
+
+	const char* left_key = l->right.key;
+	uint32_t l_parts = mp_decode_array(&left_key);
+	const char* right_key = r->left.key;
+	uint32_t r_parts = mp_decode_array(&right_key);
+	if (l->right_belongs)
+		return l_parts <= r_parts;
+	else
+		return l_parts >= r_parts;
+}
+
+int
+memtx_entry_compare(struct memtx_entry left, struct memtx_entry right,
+	struct key_def *key_def)
+{
+	return key_compare_ext(left.key, left.hint, right.key, right.hint,
+			       key_def);
+}
+
+static inline bool
+memtx_entry_is_equal(struct memtx_entry a, struct memtx_entry b)
+{
+	return a.key == b.key && a.hint == b.hint;
+}
+
+struct txn *
+memtx_tx_conflict_iterator_next(struct memtx_tx_conflict_iterator *it)
+{
+	struct memtx_read_interval *curr, *left, *right;
+	while ((curr = memtx_index_read_set_walk_next(&it->tree_walk, it->tree_dir,
+						 &left, &right)) != NULL) {
+		struct key_def *cmp_def = curr->index->def->cmp_def;
+		const struct memtx_read_interval *last = curr->subtree_last;
+
+		assert(left == NULL || left->index == curr->index);
+		assert(right == NULL || right->index == curr->index);
+
+		int cmp_right = memtx_entry_compare(it->key, last->right,
+						 cmp_def);
+		if (cmp_right == 0 && !last->right_belongs)
+			cmp_right = 1;
+
+		if (cmp_right > 0) {
+			/*
+			 * The point is to the right of the rightmost
+			 * interval in the subtree so there cannot be
+			 * any conflicts in this subtree.
+			 */
+			it->tree_dir = 0;
+			continue;
+		}
+
+		int cmp_left;
+		if (memtx_entry_is_equal(curr->left, last->right)) {
+			/* Optimize comparison out. */
+			cmp_left = cmp_right;
+		} else {
+			cmp_left = memtx_entry_compare(it->key, curr->left,
+						    cmp_def);
+			if (cmp_left == 0 && !curr->left_belongs)
+				cmp_left = -1;
+		}
+
+		if (cmp_left < 0) {
+			/*
+			 * The point is to the left of the current interval
+			 * so an intersection can only be found in the left
+			 * subtree.
+			 */
+			it->tree_dir = RB_WALK_LEFT;
+		} else {
+			/*
+			 * Both subtrees can have intervals that contain the
+			 * given point.
+			 */
+			it->tree_dir = RB_WALK_LEFT | RB_WALK_RIGHT;
+		}
+
+		/*
+		 * Check if the point is within the current interval.
+		 */
+		if (memtx_entry_is_equal(curr->left, curr->right)) {
+			/* Optimize comparison out. */
+			cmp_right = cmp_left;
+		} else if (curr != last) {
+			cmp_right = memtx_entry_compare(it->key, curr->right,
+						     cmp_def);
+			if (cmp_right == 0 && !curr->right_belongs)
+				cmp_right = 1;
+		}
+
+		if (cmp_left >= 0 && cmp_right <= 0) {
+			/*
+			 * The point is within the current interval.
+			 * Return the conflicting transaction before
+			 * continuing tree traversal.
+			 */
+			break;
+		}
+	}
+	return curr != NULL ? curr->tx : NULL;
+}

--- a/src/box/memtx_read_set.h
+++ b/src/box/memtx_read_set.h
@@ -1,0 +1,248 @@
+#ifndef INCLUDES_TARANTOOL_BOX_MEMTX_READ_SET_H
+#define INCLUDES_TARANTOOL_BOX_MEMTX_READ_SET_H
+/*
+ * Copyright 2010-2020, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY AUTHORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * AUTHORS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define RB_COMPACT 1
+#include <small/rb.h>
+
+#include "salad/stailq.h"
+#include "trivia/util.h"
+#include "tuple_compare.h"
+#include "tuple.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+struct memtx_entry {
+    const char *key;
+    hint_t hint;
+};
+
+static inline struct memtx_entry
+memtx_entry_empty()
+{
+	struct memtx_entry e = {NULL, HINT_NONE};
+	return e;
+}
+
+static inline struct memtx_entry
+memtx_entry_from_tuple(struct tuple *tuple)
+{
+	struct memtx_entry e = {tuple_data(tuple), HINT_NONE};
+	return e;
+}
+
+/**
+ * A tuple interval read by a transaction.
+ */
+struct memtx_read_interval {
+    /** Transaction. */
+    struct txn *tx;
+    /** index tree that the transaction read from. */
+    struct index *index;
+    /** Left boundary of the interval. */
+    struct memtx_entry left;
+    /** Right boundary of the interval. */
+    struct memtx_entry right;
+    /** Set if the left boundary belongs to the interval. */
+    bool left_belongs;
+    /** Set if the right boundary belongs to the interval. */
+    bool right_belongs;
+    /**
+     * The interval with the max right boundary over
+     * all nodes in the subtree rooted at this node.
+     */
+    const struct memtx_read_interval *subtree_last;
+    /** Link in memtx_tx->read_set. */
+    rb_node(struct memtx_read_interval) in_tx;
+    /** Link in memtx_index->read_set. */
+    rb_node(struct memtx_read_interval) in_index;
+    /**
+     * Auxiliary list node. Used by memtx_tx_track() to
+     * link intervals to be merged.
+     */
+    struct stailq_entry in_merge;
+};
+
+struct memtx_read_interval *
+memtx_read_interval_new(struct txn *tx, struct index *index,
+			struct memtx_entry left, bool left_belongs,
+			struct memtx_entry right, bool right_belongs);
+
+void
+memtx_read_interval_delete(struct memtx_read_interval *interval);
+
+/**
+ * Compare left boundaries of two intervals.
+ *
+ * Let 'A' and 'B' be the intervals of keys from the left boundary
+ * of 'a' and 'b' to plus infinity, respectively. Assume that
+ *
+ * - a > b iff A is spanned by B
+ * - a = b iff A equals B
+ * - a < b iff A spans B
+ */
+int
+memtx_read_interval_cmpl(const struct memtx_read_interval *a,
+		      const struct memtx_read_interval *b);
+
+/**
+ * Compare right boundaries of two intervals.
+ *
+ * Let 'A' and 'B' be the intervals of keys from minus infinity to
+ * the right boundary of 'a' and 'b', respectively. Assume that
+ *
+ * - a > b iff A spans B
+ * - a = b iff A equals B
+ * - a < b iff A is spanned by B
+ */
+int
+memtx_read_interval_cmpr(const struct memtx_read_interval *a,
+		      const struct memtx_read_interval *b);
+
+/**
+ * Return true if two intervals should be merged.
+ * Interval 'l' must start before interval 'r'.
+ * Note, if this function returns true, it does not
+ * necessarily mean that the intervals intersect -
+ * they might complement each other, e.g.
+ *
+ *   (10, 12] and (12, 20]
+ */
+bool
+memtx_read_interval_should_merge(const struct memtx_read_interval *l,
+			      const struct memtx_read_interval *r);
+
+/**
+ * Tree that contains tuple intervals read by a transactions.
+ * Linked by memtx_read_interval->in_tx. Sorted by memtx_index, then
+ * by memtx_read_interval->left. Intervals stored in this tree
+ * must not intersect.
+ */
+typedef rb_tree(struct memtx_read_interval) memtx_tx_read_set_t;
+
+static inline int
+memtx_tx_read_set_cmp(const struct memtx_read_interval *a,
+		   const struct memtx_read_interval *b)
+{
+	assert(a->tx == b->tx);
+	int rc = a->index < b->index ? -1 : a->index > b->index;
+	if (rc == 0)
+		rc = memtx_read_interval_cmpl(a, b);
+	return rc;
+}
+
+rb_gen(MAYBE_UNUSED static inline, memtx_tx_read_set_, memtx_tx_read_set_t,
+       struct memtx_read_interval, in_tx, memtx_tx_read_set_cmp);
+
+/**
+ * Interval tree used for tracking reads done from an index tree by
+ * all active transactions. Linked by memtx_read_interval->in_index.
+ * Sorted by memtx_read_interval->left, then by tx. Intervals that
+ * belong to different transactions may intersect.
+ */
+typedef rb_tree(struct memtx_read_interval) memtx_index_read_set_t;
+
+static inline int
+memtx_index_read_set_cmp(const struct memtx_read_interval *a,
+		    const struct memtx_read_interval *b)
+{
+	assert(a->index == b->index);
+	int rc = memtx_read_interval_cmpl(a, b);
+	if (rc == 0)
+		rc = a->tx < b->tx ? -1 : a->tx > b->tx;
+	return rc;
+}
+
+static inline void
+memtx_index_read_set_aug(struct memtx_read_interval *node,
+		    const struct memtx_read_interval *left,
+		    const struct memtx_read_interval *right)
+{
+	node->subtree_last = node;
+	if (left != NULL &&
+	    memtx_read_interval_cmpr(left->subtree_last, node->subtree_last) > 0)
+		node->subtree_last = left->subtree_last;
+	if (right != NULL &&
+	    memtx_read_interval_cmpr(right->subtree_last, node->subtree_last) > 0)
+		node->subtree_last = right->subtree_last;
+}
+
+rb_gen_aug(MAYBE_UNUSED static inline, memtx_index_read_set_, memtx_index_read_set_t,
+	   struct memtx_read_interval, in_index, memtx_index_read_set_cmp,
+	   memtx_index_read_set_aug);
+
+/**
+ * Iterator over transactions that conflict with a statement.
+ */
+struct memtx_tx_conflict_iterator {
+    /** The statement. */
+    struct memtx_entry key;
+    /**
+     * Iterator over the interval tree checked
+     * for intersections with the statement.
+     */
+    struct memtx_index_read_set_walk tree_walk;
+    /**
+     * Direction of tree traversal to be used on the
+     * next iteration.
+     */
+    int tree_dir;
+};
+
+static inline void
+memtx_tx_conflict_iterator_init(struct memtx_tx_conflict_iterator *it,
+			     memtx_index_read_set_t *read_set, struct memtx_entry key)
+{
+	memtx_index_read_set_walk_init(&it->tree_walk, read_set);
+	it->tree_dir = 0;
+	it->key = key;
+}
+
+/**
+ * Return the next conflicting transaction or NULL.
+ * Note, the same transaction may be returned more than once.
+ */
+struct txn *
+memtx_tx_conflict_iterator_next(struct memtx_tx_conflict_iterator *it);
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */
+
+#endif /* INCLUDES_TARANTOOL_BOX_MEMTX_READ_SET_H */

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -794,19 +794,30 @@ memtx_space_create_index(struct space *space, struct index_def *index_def)
 		return sequence_data_index_new(memtx, index_def);
 	}
 
+	struct index *index = NULL;
+
 	switch (index_def->type) {
 	case HASH:
-		return memtx_hash_index_new(memtx, index_def);
+		index = memtx_hash_index_new(memtx, index_def);
+		break;
 	case TREE:
-		return memtx_tree_index_new(memtx, index_def);
+		index = memtx_tree_index_new(memtx, index_def);
+		break;
 	case RTREE:
-		return memtx_rtree_index_new(memtx, index_def);
+		index = memtx_rtree_index_new(memtx, index_def);
+		break;
 	case BITSET:
-		return memtx_bitset_index_new(memtx, index_def);
+		index = memtx_bitset_index_new(memtx, index_def);
+		break;
 	default:
 		unreachable();
 		return NULL;
 	}
+
+	if (index != NULL)
+		memtx_index_read_set_new(&index->memtx_read_set);
+
+	return index;
 }
 
 /**

--- a/src/box/memtx_tx.h
+++ b/src/box/memtx_tx.h
@@ -310,6 +310,12 @@ memtx_tx_tuple_clarify(struct txn *txn, struct space *space,
 					   is_prepared_ok);
 }
 
+int
+memtx_tx_track(struct txn *txn, struct index *index,
+	    struct memtx_entry left, bool left_belongs,
+	    struct memtx_entry right, bool right_belongs);
+
+
 /**
  * Notify manager the a space is deleted.
  * It's necessary because there is a chance that garbage collector hasn't

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -36,6 +36,7 @@
 #include "trigger.h"
 #include "fiber.h"
 #include "space.h"
+#include "memtx_read_set.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -391,6 +392,7 @@ struct txn {
 	struct rlist in_read_view_txs;
 	/** List of tx_read_trackers with stories that the TX have read. */
 	struct rlist read_set;
+	memtx_tx_read_set_t memtx_read_set;
 };
 
 static inline bool

--- a/test/box/tx_man.result
+++ b/test/box/tx_man.result
@@ -540,7 +540,7 @@ tx1:commit()
  | ...
 tx2:commit()
  | ---
- | - 
+ | - - {'error': 'Transaction has been aborted by conflict'}
  | ...
 s:select{}
  | ---
@@ -552,7 +552,6 @@ s2:select{}
  | ---
  | - - [1, 2]
  |   - [2, 1]
- |   - [4, 4]
  | ...
 s:truncate()
  | ---
@@ -811,19 +810,19 @@ s:select{}
  | ...
 tx2:commit()
  | ---
- | - 
+ | - - {'error': 'Transaction has been aborted by conflict'}
  | ...
 s:select{}
  | ---
- | - - [1, 2]
+ | - - [1, 1]
  | ...
 tx3:commit()
  | ---
- | - 
+ | - - {'error': 'Transaction has been aborted by conflict'}
  | ...
 s:select{}
  | ---
- | - - [1, 3]
+ | - - [1, 1]
  | ...
 
 s:drop()

--- a/test/box/tx_man_intervals.result
+++ b/test/box/tx_man_intervals.result
@@ -1,0 +1,419 @@
+env = require('test_run')
+---
+...
+test_run = env.new()
+---
+...
+test_run:cmd("create server tx_man with script='box/tx_man.lua'")
+---
+- true
+...
+test_run:cmd("start server tx_man")
+---
+- true
+...
+test_run:cmd("switch tx_man")
+---
+- true
+...
+txn_proxy = require('txn_proxy')
+---
+...
+tx1 = txn_proxy.new()
+---
+...
+tx2 = txn_proxy.new()
+---
+...
+tx3 = txn_proxy.new()
+---
+...
+s = box.schema.space.create('test')
+---
+...
+i = s:create_index('pk', {parts={{1, 'uint'}}})
+---
+...
+-- Completely empty selects
+tx1:begin()
+---
+- 
+...
+tx2:begin()
+---
+- 
+...
+tx1('s:select{}')
+---
+- - []
+...
+tx2('s:select{}')
+---
+- - []
+...
+tx1('s:replace{1, 1}')
+---
+- - [1, 1]
+...
+tx2('s:replace{2, 2}')
+---
+- - [2, 2]
+...
+tx1:commit()
+---
+- 
+...
+tx2:commit()
+---
+- - {'error': 'Transaction has been aborted by conflict'}
+...
+s:truncate()
+---
+...
+-- Non-empty selects
+s:replace{3, 3}
+---
+- [3, 3]
+...
+tx1:begin()
+---
+- 
+...
+tx2:begin()
+---
+- 
+...
+tx1('s:select{}')
+---
+- - [[3, 3]]
+...
+tx2('s:select{}')
+---
+- - [[3, 3]]
+...
+tx1('s:replace{1, 1}')
+---
+- - [1, 1]
+...
+tx2('s:replace{2, 2}')
+---
+- - [2, 2]
+...
+tx1:commit()
+---
+- 
+...
+tx2:commit()
+---
+- - {'error': 'Transaction has been aborted by conflict'}
+...
+s:truncate()
+---
+...
+-- Insert then delete
+s:replace{3, 3}
+---
+- [3, 3]
+...
+s:delete{3}
+---
+- [3, 3]
+...
+tx1:begin()
+---
+- 
+...
+tx2:begin()
+---
+- 
+...
+tx1('s:select{}')
+---
+- - []
+...
+tx2('s:select{}')
+---
+- - []
+...
+tx1('s:replace{1, 1}')
+---
+- - [1, 1]
+...
+tx2('s:replace{2, 2}')
+---
+- - [2, 2]
+...
+tx1:commit()
+---
+- 
+...
+tx2:commit()
+---
+- - {'error': 'Transaction has been aborted by conflict'}
+...
+s:truncate()
+---
+...
+-- GT: non-intersect
+tx1:begin()
+---
+- 
+...
+tx2:begin()
+---
+- 
+...
+tx1('s:select({5}, {iterator=\'GT\'})')
+---
+- - []
+...
+tx2('s:select({5}, {iterator=\'GT\'})')
+---
+- - []
+...
+tx1('s:replace{1, 1}')
+---
+- - [1, 1]
+...
+tx2('s:replace{2, 2}')
+---
+- - [2, 2]
+...
+tx1:commit()
+---
+- 
+...
+tx2:commit()
+---
+- 
+...
+s:select{}
+---
+- - [1, 1]
+  - [2, 2]
+...
+s:truncate()
+---
+...
+-- GT: non-intersect, borders (1)
+tx1:begin()
+---
+- 
+...
+tx2:begin()
+---
+- 
+...
+tx1('s:select({5}, {iterator=\'GT\'})')
+---
+- - []
+...
+tx2('s:replace{5, 1}')
+---
+- - [5, 1]
+...
+tx1:commit()
+---
+- 
+...
+tx2:commit()
+---
+- 
+...
+s:select{}
+---
+- - [5, 1]
+...
+s:truncate()
+---
+...
+-- GT: non-intersect, borders (2)
+tx1:begin()
+---
+- 
+...
+tx2:begin()
+---
+- 
+...
+tx1('s:select({5}, {iterator=\'GT\'})')
+---
+- - []
+...
+tx2('s:select({6}, {iterator=\'GT\'})')
+---
+- - []
+...
+tx2('s:replace{5, 1}')
+---
+- - [5, 1]
+...
+tx1('s:replace{6, 2}')
+---
+- - [6, 2]
+...
+tx1:commit()
+---
+- 
+...
+tx2:commit()
+---
+- 
+...
+s:truncate()
+---
+...
+-- GE: sending to read-view
+tx1:begin()
+---
+- 
+...
+tx2:begin()
+---
+- 
+...
+tx1('s:select({5}, {iterator=\'GE\'})')
+---
+- - []
+...
+tx2('s:replace{5, 2}')
+---
+- - [5, 2]
+...
+tx2:commit()
+---
+- 
+...
+tx1('s:select({5}, {iterator=\'GE\'})')
+---
+- - []
+...
+tx1:commit()
+---
+- 
+...
+s:truncate()
+---
+...
+--s:replace{5, 0}
+-- GE: sending to read-view, different order
+tx1:begin()
+---
+- 
+...
+tx2:begin()
+---
+- 
+...
+tx1('s:replace{5, 1}')
+---
+- - [5, 1]
+...
+--tx2('s:select({5}, {iterator=\'GE\'})')
+tx2('s:select{5}')
+---
+- - []
+...
+tx1:commit()
+---
+- 
+...
+--tx2('s:select({5}, {iterator=\'GE\'})')
+tx2('s:select{5}')
+---
+- - []
+...
+tx2:commit()
+---
+- 
+...
+s:truncate()
+---
+...
+-- Empty point-like select
+tx1:begin()
+---
+- 
+...
+tx2:begin()
+---
+- 
+...
+tx1('s:select{1}')
+---
+- - []
+...
+tx2('s:select{1}')
+---
+- - []
+...
+tx1('s:replace{1, 1}')
+---
+- - [1, 1]
+...
+tx2('s:replace{1, 2}')
+---
+- - [1, 2]
+...
+tx1:commit()
+---
+- 
+...
+tx2:commit()
+---
+- - {'error': 'Transaction has been aborted by conflict'}
+...
+s:truncate()
+---
+...
+-- Empty point-like select: no intersection
+tx1:begin()
+---
+- 
+...
+tx2:begin()
+---
+- 
+...
+tx1('s:select{1}')
+---
+- - []
+...
+tx2('s:select{2}')
+---
+- - []
+...
+tx1('s:replace{1, 1}')
+---
+- - [1, 1]
+...
+tx2('s:replace{2, 2}')
+---
+- - [2, 2]
+...
+tx1:commit()
+---
+- 
+...
+tx2:commit()
+---
+- 
+...
+s:truncate()
+---
+...
+s:drop()
+---
+...
+test_run:cmd("switch default")
+---
+- true
+...
+test_run:cmd("stop server tx_man")
+---
+- true
+...
+test_run:cmd("cleanup server tx_man")
+---
+- true
+...

--- a/test/box/tx_man_intervals.test.lua
+++ b/test/box/tx_man_intervals.test.lua
@@ -1,0 +1,150 @@
+env = require('test_run')
+test_run = env.new()
+test_run:cmd("create server tx_man with script='box/tx_man.lua'")
+test_run:cmd("start server tx_man")
+test_run:cmd("switch tx_man")
+
+txn_proxy = require('txn_proxy')
+
+tx1 = txn_proxy.new()
+tx2 = txn_proxy.new()
+tx3 = txn_proxy.new()
+
+s = box.schema.space.create('test')
+
+i = s:create_index('pk', {parts={{1, 'uint'}}})
+
+-- Completely empty selects
+tx1:begin()
+tx2:begin()
+tx1('s:select{}')
+tx2('s:select{}')
+tx1('s:replace{1, 1}')
+tx2('s:replace{2, 2}')
+tx1:commit()
+tx2:commit()
+
+s:truncate()
+
+-- Non-empty selects
+s:replace{3, 3}
+
+tx1:begin()
+tx2:begin()
+tx1('s:select{}')
+tx2('s:select{}')
+tx1('s:replace{1, 1}')
+tx2('s:replace{2, 2}')
+tx1:commit()
+tx2:commit()
+
+s:truncate()
+
+-- Insert then delete
+s:replace{3, 3}
+s:delete{3}
+
+tx1:begin()
+tx2:begin()
+tx1('s:select{}')
+tx2('s:select{}')
+tx1('s:replace{1, 1}')
+tx2('s:replace{2, 2}')
+tx1:commit()
+tx2:commit()
+
+s:truncate()
+
+-- GT: non-intersect
+tx1:begin()
+tx2:begin()
+tx1('s:select({5}, {iterator=\'GT\'})')
+tx2('s:select({5}, {iterator=\'GT\'})')
+tx1('s:replace{1, 1}')
+tx2('s:replace{2, 2}')
+tx1:commit()
+tx2:commit()
+
+s:select{}
+
+s:truncate()
+
+-- GT: non-intersect, borders (1)
+tx1:begin()
+tx2:begin()
+tx1('s:select({5}, {iterator=\'GT\'})')
+tx2('s:replace{5, 1}')
+tx1:commit()
+tx2:commit()
+
+s:select{}
+
+s:truncate()
+
+-- GT: non-intersect, borders (2)
+tx1:begin()
+tx2:begin()
+tx1('s:select({5}, {iterator=\'GT\'})')
+tx2('s:select({6}, {iterator=\'GT\'})')
+tx2('s:replace{5, 1}')
+tx1('s:replace{6, 2}')
+tx1:commit()
+tx2:commit()
+
+s:truncate()
+
+-- GE: sending to read-view
+tx1:begin()
+tx2:begin()
+tx1('s:select({5}, {iterator=\'GE\'})')
+tx2('s:replace{5, 2}')
+tx2:commit()
+tx1('s:select({5}, {iterator=\'GE\'})')
+tx1:commit()
+
+s:truncate()
+
+--s:replace{5, 0}
+
+-- GE: sending to read-view, different order
+tx1:begin()
+tx2:begin()
+tx1('s:replace{5, 1}')
+--tx2('s:select({5}, {iterator=\'GE\'})')
+tx2('s:select{5}')
+tx1:commit()
+--tx2('s:select({5}, {iterator=\'GE\'})')
+tx2('s:select{5}')
+tx2:commit()
+
+s:truncate()
+
+-- Empty point-like select
+tx1:begin()
+tx2:begin()
+tx1('s:select{1}')
+tx2('s:select{1}')
+tx1('s:replace{1, 1}')
+tx2('s:replace{1, 2}')
+tx1:commit()
+tx2:commit()
+
+s:truncate()
+
+-- Empty point-like select: no intersection
+tx1:begin()
+tx2:begin()
+tx1('s:select{1}')
+tx2('s:select{2}')
+tx1('s:replace{1, 1}')
+tx2('s:replace{2, 2}')
+tx1:commit()
+tx2:commit()
+
+s:truncate()
+
+s:drop()
+
+test_run:cmd("switch default")
+test_run:cmd("stop server tx_man")
+test_run:cmd("cleanup server tx_man")


### PR DESCRIPTION
Previously mvcc txm didn't take into account
that transactions can:
a) read not just one tuple, but interval
b) read tuple and get null
In both cases it is not sufficient to track tuple histories.
Instead, txm can store those reads in interval tree and then
search in such a tree for conflicts.
Approach is taken from vinyl txm.