### PR TITLE
Add several functions from `box.session` to module API

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -166,6 +166,7 @@ set(api_headers
     ${CMAKE_SOURCE_DIR}/src/box/index.h
     ${CMAKE_SOURCE_DIR}/src/box/iterator_type.h
     ${CMAKE_SOURCE_DIR}/src/box/error.h
+    ${CMAKE_SOURCE_DIR}/src/box/session.h
     ${CMAKE_SOURCE_DIR}/src/box/lua/call.h
     ${CMAKE_SOURCE_DIR}/src/box/lua/tuple.h
     ${CMAKE_SOURCE_DIR}/src/lib/core/latch.h

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -277,6 +277,7 @@ struct errcode_record {
 	/*222 */_(ER_QUORUM_WAIT,		"Couldn't wait for quorum %d: %s") \
 	/*223 */_(ER_INTERFERING_PROMOTE,	"Instance with replica id %u was promoted first") \
 	/*224 */_(ER_RAFT_DISABLED,		"Elections were turned off while running box.ctl.promote()")\
+	/*225 */_(ER_NO_SUCH_SESSION,		"Session does not exist") \
 
 /*
  * !IMPORTANT! Please follow instructions at start of the file

--- a/src/box/session.h
+++ b/src/box/session.h
@@ -375,6 +375,78 @@ generic_session_fd(struct session *session);
 int64_t
 generic_session_sync(struct session *session);
 
+/** \cond public */
+
+/**
+ * Get the unique identifier (ID) for the current session.
+ *
+ * @retval session ID
+ */
+API_EXPORT uint64_t
+box_session_id(void);
+
+/**
+ * Check if session exists.
+ *
+ * @param sid session ID
+ * @retval true if sessions exists, false otherwise
+ */
+API_EXPORT bool
+box_session_exists(uint64_t sid);
+
+struct sockaddr;
+
+/**
+ * Get the address of session peer (if it exists).
+ *
+ * @param sid session ID.
+ * @param addr address of the peer.
+ * @param addrlen amount of space, pointed to by addr.
+ *
+ * @retval  0 Success.
+ * @retval -1 Error.
+ */
+API_EXPORT int
+box_session_peer(uint64_t sid, struct sockaddr *addr, uint32_t *addrlen);
+
+/**
+ * Get user's name for current session.
+ *
+ * @retval session user on success, emtpy string on error.
+ */
+API_EXPORT const char *
+box_session_user(void);
+
+/**
+ * Get the type of connection or cause of action. Can be
+ * "binary", "console", "repl", "applier" or "background".
+ * This list is subject to change. More session type can
+ * be added in future, while some of existing type can be
+ * deleted or removed.
+ *
+ * @retval session type or cause of action
+ */
+API_EXPORT const char *
+box_session_type(void);
+
+/**
+ * Get the user ID of the current user.
+ *
+ * @retval user ID
+ */
+API_EXPORT uint32_t
+box_session_uid(void);
+
+/**
+ * Get the effective user ID of the current user.
+ *
+ * @retval effective user ID
+ */
+API_EXPORT uint32_t
+box_session_euid(void);
+
+/** \endcond public */
+
 #if defined(__cplusplus)
 } /* extern "C" */
 

--- a/test/app-tap/module_api.c
+++ b/test/app-tap/module_api.c
@@ -2380,11 +2380,14 @@ test_tuple_validate_formatted(lua_State *L)
 }
 
 static int
-session_check_admin(lua_State *L)
+session_check_default(lua_State *L)
 {
 	int sess_id = box_session_id();
 	bool sess_exist = box_session_exists(sess_id);
 	assert(sess_exist);
+
+	bool sess_not_exist = !box_session_exists(1234567890);
+	assert(sess_not_exist);
 
 	struct sockaddr addr;
 	uint32_t addrlen = sizeof(addr);
@@ -2392,10 +2395,18 @@ session_check_admin(lua_State *L)
 	bool status_is_not_ok = (status == -1);
 	assert(status_is_not_ok);
 
-	bool sess_not_exist = !box_session_exists(1234567890);
-	assert(sess_not_exist);
-
 	lua_pushboolean(L, 1);
+
+	return 1;
+}
+
+static int
+session_check_peer_exists(lua_State *L)
+{
+	assert(lua_gettop(L) == 1);
+
+	uint32_t ctypeid = lua_tointeger(L, 1);
+	assert(ctypeid > 0);
 
 	return 1;
 }
@@ -2496,7 +2507,8 @@ luaopen_module_api(lua_State *L)
 		{"tuple_validate_def", test_tuple_validate_default},
 		{"tuple_validate_fmt", test_tuple_validate_formatted},
 		{"test_key_def_dup", test_key_def_dup},
-		{"session_check_admin", session_check_admin},
+		{"session_check_default", session_check_default},
+		{"session_check_peer_exists", session_check_peer_exists},
 		{"session_check_fiber", session_check_fiber},
 		{"session_check_after_cleanup", session_check_after_cleanup},
 		{NULL, NULL}

--- a/test/app-tap/module_api.test.lua
+++ b/test/app-tap/module_api.test.lua
@@ -252,13 +252,6 @@ require('tap').test("module_api", function(test)
     test:test("iscdata", test_iscdata, module)
     test:test("buffers", test_buffers, module)
     test:test("tuple_validate", test_tuple_validate, module)
-
-    test:ok(module.session_check_admin(), "session_check_admin is ok")
-    test:ok(module.session_check_fiber(), "session_check_fiber is ok")
-
-    space:drop()
-
-    test:ok(module.session_check_after_cleanup(), "session_check_after_cleanup is ok")
 end)
 
 os.exit(0)

--- a/test/app-tap/module_api.test.lua
+++ b/test/app-tap/module_api.test.lua
@@ -223,7 +223,7 @@ local function test_iscdata(test, module)
 end
 
 require('tap').test("module_api", function(test)
-    test:plan(38)
+    test:plan(41)
     local status, module = pcall(require, 'module_api')
     test:is(status, true, "module")
     test:ok(status, "module is loaded")
@@ -253,7 +253,12 @@ require('tap').test("module_api", function(test)
     test:test("buffers", test_buffers, module)
     test:test("tuple_validate", test_tuple_validate, module)
 
+    test:ok(module.session_check_admin(), "session_check_admin is ok")
+    test:ok(module.session_check_fiber(), "session_check_fiber is ok")
+
     space:drop()
+
+    test:ok(module.session_check_after_cleanup(), "session_check_after_cleanup is ok")
 end)
 
 os.exit(0)

--- a/test/app-tap/session_module_api.test.lua
+++ b/test/app-tap/session_module_api.test.lua
@@ -1,0 +1,52 @@
+#!/usr/bin/env tarantool
+
+local ffi = require('ffi')
+local fio = require('fio')
+local net = { box = require('net.box') }
+
+--box.cfg{log = "tarantool.log"}
+-- Use BUILDDIR passed from test-run or cwd when run w/o
+-- test-run to find test/app-tap/session_module_api.{so,dylib}.
+local build_path = os.getenv("BUILDDIR") or '.'
+package.cpath = fio.pathjoin(build_path, 'test/app-tap/?.so'   ) .. ';' ..
+                fio.pathjoin(build_path, 'test/app-tap/?.dylib') .. ';' ..
+                package.cpath
+
+box.cfg{
+    listen = os.getenv('LISTEN');
+    log="tarantool.log";
+}
+
+local uri = require('uri').parse(box.cfg.listen)
+local HOST, PORT = uri.host or 'localhost', uri.service
+session = box.session
+space = box.schema.space.create('tweedledum')
+space:create_index('primary', { type = 'hash' })
+
+require('tap').test("session_module_api", function(test)
+    test:plan(4)
+    local status, module = pcall(require, 'module_api')
+    test:is(status, true, "module")
+    test:ok(status, "module is loaded")
+    if not status then
+        test:diag("Failed to load library:")
+        for _, line in ipairs(module:split("\n")) do
+            test:diag("%s", line)
+        end
+        return
+    end
+
+    local space  = box.schema.space.create("test")
+    space:create_index('primary')
+
+    local session_id = 1
+    local function get_session_id() session_id = box.session.id() end
+    session.on_connect(get_session_id)
+
+    test:ok(module.session_check_default(), "session_check_default is ok")
+
+    local c = net.box.connect(HOST, PORT)
+    test:ok(module.session_check_peer_exists(session_id), "session_check_peer_exists is ok")
+end)
+
+os.exit(0)


### PR DESCRIPTION
The following functions from `box.session` are added to module API:
- `box_session_id`
- `box_session_exists`
- `box_session_peer`
- `box_session_user`
- `box_session_type`
- `box_session_uid`
- `box_session_euid`

Only trivial functions were added. We have to put some thought into implementations of `box.session.su()`,  `box.session.on_connect()`,  `box.session.on_disconnect()` `box.session.on_auth()` and can add them via future pull requests.