### PR TITLE
index: fix omitting index part options when type is missing

### DIFF
--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -713,7 +713,8 @@ local function update_index_parts(format, parts)
         box.error(box.error.ILLEGAL_PARAMS,
         "options.parts must have at least one part")
     end
-    if type(parts[1]) == 'number' and type(parts[2]) == 'string' then
+    if type(parts[1]) == 'number' and
+            (parts[2] == nil or type(parts[2]) == 'string') then
         if parts[3] == nil then
             parts = {parts} -- one part only
         else
@@ -723,7 +724,13 @@ local function update_index_parts(format, parts)
 
     local parts_can_be_simplified = true
     local result = {}
-    for i=1,#parts do
+    local i = 0
+    for _ in pairs(parts) do
+        i = i + 1
+        if parts[i] == nil then
+            box.error(box.error.ILLEGAL_PARAMS,
+                    "options.parts: unexpected option(s)")
+        end
         local part = {}
         if type(parts[i]) ~= "table" then
             part.field = parts[i]

--- a/test/engine/null.result
+++ b/test/engine/null.result
@@ -2434,3 +2434,129 @@ sk:select{}
 s:drop()
 ---
 ...
+-- gh-5674: ignoring index part options when type is omitted
+s = box.schema.space.create('test', {engine=engine})
+---
+...
+_ = s:create_index('pk', {parts = {1, 'int'}})
+---
+...
+sk = s:create_index('sk', {parts = {2, is_nullable=true}})
+---
+...
+sk.parts
+---
+- - type: scalar
+    is_nullable: true
+    fieldno: 2
+...
+sk:drop()
+---
+...
+sk = s:create_index('sk', {parts = {2, is_nullable=true, collation='unicode'}})
+---
+...
+sk.parts
+---
+- - type: scalar
+    is_nullable: true
+    collation: unicode
+    fieldno: 2
+...
+sk:drop()
+---
+...
+sk = s:create_index('sk', {parts = {2, type='string', is_nullable=true, collation='unicode'}})
+---
+...
+sk.parts
+---
+- - type: string
+    is_nullable: true
+    collation: unicode
+    fieldno: 2
+...
+sk:drop()
+---
+...
+sk = s:create_index('sk', {parts = {2, is_nullable=true, 3}})
+---
+- error: 'Illegal parameters, options.parts: unexpected option(s)'
+...
+sk.parts
+---
+- - type: string
+    is_nullable: true
+    collation: unicode
+    fieldno: 2
+...
+sk:drop()
+---
+...
+sk = s:create_index('sk', {parts = {2, 3}})
+---
+...
+sk.parts
+---
+- - type: scalar
+    is_nullable: false
+    fieldno: 2
+  - type: scalar
+    is_nullable: false
+    fieldno: 3
+...
+sk:drop()
+---
+...
+sk = s:create_index('sk', {parts = {2, 3, 4}})
+---
+...
+sk.parts
+---
+- - type: scalar
+    is_nullable: false
+    fieldno: 2
+  - type: scalar
+    is_nullable: false
+    fieldno: 3
+  - type: scalar
+    is_nullable: false
+    fieldno: 4
+...
+sk:drop()
+---
+...
+sk = s:create_index('sk', {parts = {{2, 'int'}, {3, 'string'}}})
+---
+...
+sk.parts
+---
+- - type: integer
+    is_nullable: false
+    fieldno: 2
+  - type: string
+    is_nullable: false
+    fieldno: 3
+...
+sk:drop()
+---
+...
+sk = s:create_index('sk', {parts = {{2, is_nullable=true}, {3, collation='unicode'}}})
+---
+...
+sk.parts
+---
+- - type: scalar
+    is_nullable: true
+    fieldno: 2
+  - type: scalar
+    is_nullable: false
+    collation: unicode
+    fieldno: 3
+...
+sk:drop()
+---
+...
+s:drop()
+---
+...

--- a/test/engine/null.test.lua
+++ b/test/engine/null.test.lua
@@ -791,5 +791,33 @@ _ = fiber.new(txn_fun)
 sk = s:create_index('sk', {parts={{2, 'number', exclude_null=true}}})
 ch:get()
 sk:select{}
+s:drop()
 
+-- gh-5674: ignoring index part options when type is omitted
+s = box.schema.space.create('test', {engine=engine})
+_ = s:create_index('pk', {parts = {1, 'int'}})
+sk = s:create_index('sk', {parts = {2, is_nullable=true}})
+sk.parts
+sk:drop()
+sk = s:create_index('sk', {parts = {2, is_nullable=true, collation='unicode'}})
+sk.parts
+sk:drop()
+sk = s:create_index('sk', {parts = {2, type='string', is_nullable=true, collation='unicode'}})
+sk.parts
+sk:drop()
+sk = s:create_index('sk', {parts = {2, is_nullable=true, 3}})
+sk.parts
+sk:drop()
+sk = s:create_index('sk', {parts = {2, 3}})
+sk.parts
+sk:drop()
+sk = s:create_index('sk', {parts = {2, 3, 4}})
+sk.parts
+sk:drop()
+sk = s:create_index('sk', {parts = {{2, 'int'}, {3, 'string'}}})
+sk.parts
+sk:drop()
+sk = s:create_index('sk', {parts = {{2, is_nullable=true}, {3, collation='unicode'}}})
+sk.parts
+sk:drop()
 s:drop()


### PR DESCRIPTION
previously such code:
s = box.schema.space.create('test')
s:create_index('pk', {parts = {1, 'int'}})
s:create_index('sk', {parts = {2, is_nullable=true}})

was resulting in is_nullable=false, which is wrong

Closes #5674