### PR TITLE
Lookup openssl config at tarantool startup

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,6 +107,7 @@ set (server_sources
      title.c
      proc_title.c
      path_lock.c
+     ssl_cert_paths_discover.c
      systemd.c
      version.c
      lua/digest.c

--- a/src/main.cc
+++ b/src/main.cc
@@ -80,6 +80,7 @@
 #include "crypto/crypto.h"
 #include "core/popen.h"
 #include "core/crash.h"
+#include "ssl_cert_paths_discover.h"
 
 static pid_t master_pid = getpid();
 static struct pidfh *pid_file_handle;
@@ -710,6 +711,7 @@ main(int argc, char **argv)
 	memtx_tx_manager_init();
 	crypto_init();
 	systemd_init();
+	ssl_cert_paths_discover(0); // don't overwrite user defined env vars
 	tarantool_lua_init(tarantool_bin, main_argc, main_argv);
 
 	start_time = ev_monotonic_time();

--- a/src/ssl_cert_paths_discover.c
+++ b/src/ssl_cert_paths_discover.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2010-2020, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <openssl/ssl.h>
+#include "ssl_cert_paths_discover.h"
+#include "tt_static.h"
+
+static int is_dir_empty(const char *dir_path) {
+	DIR *dir = opendir(dir_path);
+	if (!dir)
+		return 1;
+
+	struct dirent *d_ent;
+	int is_empty = 1;
+	while ((d_ent = readdir(dir))) {
+		if (strcmp(d_ent->d_name, ".") && strcmp(d_ent->d_name, "..")) {
+			if (d_ent->d_type == DT_REG ||
+				d_ent->d_type == DT_LNK ||
+				d_ent->d_type == DT_DIR) {
+				is_empty = 0;
+				break;
+			}
+		}
+	}
+
+	closedir(dir);
+	return is_empty;
+}
+
+const char **get_default_cert_dir_paths() {
+	static const char *default_cert_dir_paths[] = {
+		// Fedora/RHEL/Centos
+		"/etc/pki/tls/certs",
+		// Debian/Ubuntu/Gentoo etc. (OpenSuse)
+		"/etc/ssl/certs",
+		// FreeBSD
+		"/usr/local/share/certs",
+		// NetBSD
+		"/etc/openssl/certs",
+		// macOS
+		"/private/etc/ssl/certs",
+		"/usr/local/etc/openssl@1.1/certs",
+		"/usr/local/etc/openssl@1.0/certs",
+		"/usr/local/etc/openssl/certs",
+		NULL
+	};
+	return default_cert_dir_paths;
+}
+
+const char **get_default_cert_file_paths() {
+	static const char *default_cert_file_paths[] = {
+		// Fedora/RHEL 6
+		"/etc/pki/tls/certs/ca-bundle.crt",
+		// CentOS/RHEL 7
+		"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+		// Debian/Ubuntu/Gentoo etc.
+		"/etc/ssl/certs/ca-certificates.crt",
+		// OpenSUSE
+		"/etc/ssl/ca-bundle.pem",
+		// FreeBSD
+		"/usr/local/share/certs/ca-root-nss.crt",
+		// macOS
+		"/private/etc/ssl/cert.pem",
+		"/usr/local/etc/openssl@1.1/cert.pem",
+		"/usr/local/etc/openssl@1.0/cert.pem",
+		NULL
+	};
+	return default_cert_file_paths;
+}
+
+void ssl_cert_paths_discover(int overwrite) {
+	char *cert_dirs = tt_static_buf();
+	char *cert_dirs_end = cert_dirs;
+
+	const char *path_iter = NULL;
+	const char **default_dir_paths = get_default_cert_dir_paths();
+	for (int i = 0; (path_iter = default_dir_paths[i]); i++) {
+		struct stat sb;
+		if (stat(path_iter, &sb) != 0 || !S_ISDIR(sb.st_mode))
+			continue;
+
+		if (!is_dir_empty(path_iter))
+			cert_dirs_end += sprintf(cert_dirs_end, "%s:", path_iter);
+	}
+
+	path_iter = NULL;
+	const char *cert_file = NULL;
+	const char **default_file_paths = get_default_cert_file_paths();
+	for (int i = 0; (path_iter = default_file_paths[i]); i++) {
+		struct stat sb;
+		if (stat(path_iter, &sb) == 0) {
+			cert_file = path_iter;
+			break;
+		}
+	}
+
+	if (cert_dirs_end > cert_dirs) {
+		*(cert_dirs_end -1) = '\0';
+		setenv(X509_get_default_cert_dir_env(), cert_dirs, overwrite);
+	}
+
+	if (cert_file)
+		setenv(X509_get_default_cert_file_env(), cert_file, overwrite);
+}

--- a/src/ssl_cert_paths_discover.c
+++ b/src/ssl_cert_paths_discover.c
@@ -37,18 +37,20 @@
 #include "ssl_cert_paths_discover.h"
 #include "tt_static.h"
 
-static int is_dir_empty(const char *dir_path) {
+static int
+is_dir_empty(const char *dir_path)
+{
 	DIR *dir = opendir(dir_path);
 	if (!dir)
 		return 1;
 
-	struct dirent *d_ent;
+	struct dirent *ent;
 	int is_empty = 1;
-	while ((d_ent = readdir(dir))) {
-		if (strcmp(d_ent->d_name, ".") && strcmp(d_ent->d_name, "..")) {
-			if (d_ent->d_type == DT_REG ||
-				d_ent->d_type == DT_LNK ||
-				d_ent->d_type == DT_DIR) {
+	while ((ent = readdir(dir))) {
+		if (strcmp(ent->d_name, ".") && strcmp(ent->d_name, "..")) {
+			if (ent->d_type == DT_REG ||
+			    ent->d_type == DT_LNK ||
+			    ent->d_type == DT_DIR) {
 				is_empty = 0;
 				break;
 			}
@@ -59,17 +61,19 @@ static int is_dir_empty(const char *dir_path) {
 	return is_empty;
 }
 
-const char **get_default_cert_dir_paths() {
+const char **
+get_default_cert_dir_paths()
+{
 	static const char *default_cert_dir_paths[] = {
-		// Fedora/RHEL/Centos
+		/* Fedora/RHEL/Centos */
 		"/etc/pki/tls/certs",
-		// Debian/Ubuntu/Gentoo etc. (OpenSuse)
+		/* Debian/Ubuntu/Gentoo etc. (OpenSuse) */
 		"/etc/ssl/certs",
-		// FreeBSD
+		/* FreeBSD */
 		"/usr/local/share/certs",
-		// NetBSD
+		/* NetBSD */
 		"/etc/openssl/certs",
-		// macOS
+		/* macOS */
 		"/private/etc/ssl/certs",
 		"/usr/local/etc/openssl@1.1/certs",
 		"/usr/local/etc/openssl@1.0/certs",
@@ -79,19 +83,21 @@ const char **get_default_cert_dir_paths() {
 	return default_cert_dir_paths;
 }
 
-const char **get_default_cert_file_paths() {
+const char **
+get_default_cert_file_paths()
+{
 	static const char *default_cert_file_paths[] = {
-		// Fedora/RHEL 6
+		/* Fedora/RHEL 6 */
 		"/etc/pki/tls/certs/ca-bundle.crt",
-		// CentOS/RHEL 7
+		/* CentOS/RHEL 7 */
 		"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
-		// Debian/Ubuntu/Gentoo etc.
+		/* Debian/Ubuntu/Gentoo etc. */
 		"/etc/ssl/certs/ca-certificates.crt",
-		// OpenSUSE
+		/* OpenSUSE */
 		"/etc/ssl/ca-bundle.pem",
-		// FreeBSD
+		/* FreeBSD */
 		"/usr/local/share/certs/ca-root-nss.crt",
-		// macOS
+		/* macOS */
 		"/private/etc/ssl/cert.pem",
 		"/usr/local/etc/openssl@1.1/cert.pem",
 		"/usr/local/etc/openssl@1.0/cert.pem",
@@ -100,28 +106,30 @@ const char **get_default_cert_file_paths() {
 	return default_cert_file_paths;
 }
 
-void ssl_cert_paths_discover(int overwrite) {
+void
+ssl_cert_paths_discover(int overwrite)
+{
 	char *cert_dirs = tt_static_buf();
 	char *cert_dirs_end = cert_dirs;
 
-	const char *path_iter = NULL;
+	const char *path = NULL;
 	const char **default_dir_paths = get_default_cert_dir_paths();
-	for (int i = 0; (path_iter = default_dir_paths[i]); i++) {
+	for (int i = 0; (path = default_dir_paths[i]); i++) {
 		struct stat sb;
-		if (stat(path_iter, &sb) != 0 || !S_ISDIR(sb.st_mode))
+		if (stat(path, &sb) != 0 || !S_ISDIR(sb.st_mode))
 			continue;
 
-		if (!is_dir_empty(path_iter))
-			cert_dirs_end += sprintf(cert_dirs_end, "%s:", path_iter);
+		if (!is_dir_empty(path))
+			cert_dirs_end += sprintf(cert_dirs_end, "%s:", path);
 	}
 
-	path_iter = NULL;
+	path = NULL;
 	const char *cert_file = NULL;
 	const char **default_file_paths = get_default_cert_file_paths();
-	for (int i = 0; (path_iter = default_file_paths[i]); i++) {
+	for (int i = 0; (path = default_file_paths[i]); i++) {
 		struct stat sb;
-		if (stat(path_iter, &sb) == 0) {
-			cert_file = path_iter;
+		if (stat(path, &sb) == 0) {
+			cert_file = path;
 			break;
 		}
 	}

--- a/src/ssl_cert_paths_discover.h
+++ b/src/ssl_cert_paths_discover.h
@@ -1,0 +1,69 @@
+#ifndef TARANTOOL_SSL_CERT_PATH_DISCOVER_H_INCLUDED
+#define TARANTOOL_SSL_CERT_PATH_DISCOVER_H_INCLUDED
+/*
+ * Copyright 2010-2020, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+/**
+ * Get default paths of directory where stores OpenSSL certificates
+ * for different systems
+ */
+const char** get_default_cert_dir_paths();
+
+/**
+ * Get default paths of OpenSSL certificates file for different systems
+ */
+const char** get_default_cert_file_paths();
+
+/**
+ * Set SSL certificates paths (from system default paths) through
+ * OpenSSL env variables if these variables are not set:
+ *   - SSL_CERT_DIR - it's a colon-separated list of directories
+ *     (like the Unix PATH variable) where stores certiifcates.
+ *   - SSL_CERT_FILE - it's a path to certificate file
+ * @param overwrite - flag for setenv if overwrite is zero, then the
+ * value of name (variable) not changed (from man setenv)
+ * @see https://serverfault.com/a/722646
+ * @see https://golang.org/src/crypto/x509/root_unix.go
+ * @see https://golang.org/src/crypto/x509/root_linux.go
+ * @see https://github.com/edenhill/librdkafka/blob/cb69d2a8486344252e0fcaa1f959c4ab2d8afff3/src/rdkafka_ssl.c#L845
+ * @see https://www.happyassassin.net/posts/2015/01/12/a-note-about-ssltls-trusted-certificate-stores-and-platforms/
+ */
+void ssl_cert_paths_discover(int overwrite);
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */
+
+#endif /* TARANTOOL_SSL_CERT_PATH_DISCOVER_H_INCLUDED */

--- a/static-build/CMakeLists.txt
+++ b/static-build/CMakeLists.txt
@@ -309,3 +309,9 @@ add_test(
     COMMAND ${TARANTOOL_BINARY_DIR}/src/tarantool
             ${CMAKE_CURRENT_SOURCE_DIR}/test/static-build/traceback.test.lua
 )
+
+add_test(
+    NAME check-ssl-certificates
+    COMMAND ${TARANTOOL_BINARY_DIR}/src/tarantool
+            ${CMAKE_CURRENT_SOURCE_DIR}/test/static-build/ssl-cert-paths-discover.test.lua
+)

--- a/static-build/test/static-build/ssl-cert-paths-discover.test.lua
+++ b/static-build/test/static-build/ssl-cert-paths-discover.test.lua
@@ -1,0 +1,150 @@
+local tap = require("tap")
+local ffi = require("ffi")
+local fio = require("fio")
+
+local test = tap.test("ssl_cert_paths_discover")
+test:plan(6)
+
+
+----- Init test env
+
+ffi.cdef([[
+    const char* X509_get_default_cert_dir_env();
+    const char* X509_get_default_cert_file_env();
+    void ssl_cert_paths_discover(int overwrite);
+    const char **get_default_cert_dir_paths();
+    const char **get_default_cert_file_paths();
+]])
+
+local CERT_DIR_ENV = ffi.string(ffi.C.X509_get_default_cert_dir_env())
+local CERT_FILE_ENV = ffi.string(ffi.C.X509_get_default_cert_file_env())
+
+local temp_dir = fio.tempdir()
+local cert_file1 = fio.pathjoin(temp_dir, "cert1.pem")
+local cert_file2 = fio.pathjoin(temp_dir, "cert2.pem")
+
+local handle = fio.open(cert_file1, {"O_RDWR", "O_CREAT"}, tonumber("755", 8))
+handle:close()
+fio.copyfile(cert_file1, cert_file2)
+
+
+----- Helpers
+
+local function mock_cert_paths_by_addr(addr, paths)
+    -- insert NULL to the end of array as flag of end
+    local paths = table.copy(paths)
+    table.insert(paths, box.NULL)
+
+    local mock_paths = ffi.new(("const char*[%s]"):format(#paths), paths)
+    ffi.copy(addr, mock_paths, ffi.sizeof(mock_paths))
+    ffi.C.ssl_cert_paths_discover(1)
+end
+
+local function mock_cert_dir_paths(t, dir_paths)
+    local dir_paths_addr = ffi.C.get_default_cert_dir_paths()
+    t:diag("Mock cert dir paths: %s", table.concat(dir_paths, ";"))
+    mock_cert_paths_by_addr(dir_paths_addr, dir_paths)
+end
+
+local function mock_cert_file_paths(t, file_paths)
+    local file_paths_addr = ffi.C.get_default_cert_file_paths()
+    t:diag("Mock cert file paths: %s", table.concat(file_paths, ";"))
+    mock_cert_paths_by_addr(file_paths_addr, file_paths)
+end
+
+local function run_user_defined_env(t, var_name, var_val)
+    local binary_dir = arg[-1]
+    local log_file = fio.pathjoin(temp_dir, "out.log")
+    local cmd = string.format(
+        [[%s=%s %s -e 'print(os.getenv(%q)) os.exit(0)' 1>%s 2>&1]],
+        var_name, var_val, binary_dir, var_name, log_file
+    )
+
+    t:diag("Run cmd: %s", cmd)
+
+    local status = os.execute(cmd)
+    local output = io.open(log_file, "r"):read("*a"):strip()
+
+    t:is(status, 0, "exit status 0")
+    return output and output:strip()
+end
+
+
+----- Tests
+
+test:test("Default cert dir paths would set", function(t)
+    t:plan(2)
+
+    mock_cert_dir_paths(t, {temp_dir})
+    t:is(
+        os.getenv(CERT_DIR_ENV), temp_dir, "One cert dir path was set"
+    )
+
+    local dir_paths = {temp_dir, temp_dir}
+    mock_cert_dir_paths(t, dir_paths)
+    t:is(
+        os.getenv(CERT_DIR_ENV),
+        table.concat(dir_paths, ":"),
+        "Multiple cert dir paths (like unix $PATH) was set"
+    )
+end)
+
+
+test:test("Invalid dir paths won't set", function(t)
+    t:plan(2)
+
+    -- Cleanup env
+    os.setenv(CERT_DIR_ENV, nil)
+
+    mock_cert_dir_paths(t, {"/not/existing_dir"})
+    t:is(os.getenv(CERT_DIR_ENV), nil, "Not existing cert dir wasn't set")
+
+    local empty_dir_name = fio.pathjoin(temp_dir, "empty")
+    fio.mkdir(empty_dir_name)
+
+    mock_cert_dir_paths(t, {empty_dir_name})
+    t:is(os.getenv(CERT_DIR_ENV), nil, "Empty cert dir wasn't set")
+end)
+
+
+test:test("Default cert file path would set", function(t)
+    t:plan(2)
+
+    mock_cert_file_paths(t, {cert_file1})
+    t:is(os.getenv(CERT_FILE_ENV), cert_file1, "Cert file was set")
+
+    mock_cert_file_paths(t, {cert_file2, cert_file1})
+    t:is(os.getenv(CERT_FILE_ENV), cert_file2, "Only one (first) existing default cert file was set")
+end)
+
+
+test:test("Invalid cert file won't set", function(t)
+    t:plan(1)
+
+    -- Cleanup
+    os.setenv(CERT_FILE_ENV, nil)
+
+    mock_cert_file_paths(t, {"/not/existing_dir/cert1"})
+    t:is(os.getenv(CERT_FILE_ENV), nil, "Not existing cert file wasn't set")
+end)
+
+
+test:test("User defined cert dir won't be overridden", function(t)
+    t:plan(2)
+
+    local res = run_user_defined_env(t, CERT_DIR_ENV, "/dev/null")
+    t:is(res, "/dev/null", "User defined wasn't overridden")
+end)
+
+
+test:test("User defined cert file won't be overridden", function(t)
+    t:plan(2)
+
+    local res = run_user_defined_env(t, CERT_FILE_ENV, "/dev/null/cert.pem")
+    t:is(res, "/dev/null/cert.pem", "User defined wasn't overridden")
+end)
+
+----- Cleanup
+fio.rmtree(temp_dir)
+
+os:exit(test:check() and 0 or 1)


### PR DESCRIPTION
The static build isn't as portable as it should be. In fact, the OPENSSLDIR is configured at build time, but in runtime, it may (and do) differ:

```console
$ strace tarantool -e 'require("http.client").get("https://...")'
...
openat(AT_FDCWD, "/__w/sdk/sdk/build/tarantool/static-build/"
                 "openssl-prefix/ssl/openssl.cnf", O_RDONLY) =
                 -1 ENOENT (No such file or directory)
```

As a result, statically build tarantool can't open some https links with an error:

```console
tarantool> http_client = require('http.client').new({max_connections = 5})
tarantool> http_client:get('https://..../', {verbose = true})
*   Trying X.Y.Z.W:443...
* TCP_NODELAY set
* Connected to .... (X.Y.Z.W) port 443 (#0)
* ALPN, offering http/1.1
* SSL certificate problem: self signed certificate in certificate chain
* Closing connection 0
---
- status: 495
  reason: SSL peer certificate or SSH remote key was not OK
...
```

In this patch, we adopt the approach from the golang ecosystem [1-3]. At startup, tarantool scans several popular locations and uses it for `SSL_CERT_DIR` and/or `SSL_SERT_FILE` setting. See also [4,5] - it's fun.

[1] https://serverfault.com/a/722646
[2] https://golang.org/src/crypto/x509/root_unix.go
[3] https://golang.org/src/crypto/x509/root_linux.go
[4] https://github.com/edenhill/librdkafka/blob/cb69d2a8486344252e0fcaa1f959c4ab2d8afff3/src/rdkafka_ssl.c#L845
[5] https://www.happyassassin.net/posts/2015/01/12/a-note-about-ssltls-trusted-certificate-stores-and-platforms/

Close #5615

The patch is originally developed by @HustonMmmavr 