### PR TITLE
Lookup openssl certs at tarantool startup

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,6 +107,7 @@ set (server_sources
      title.c
      proc_title.c
      path_lock.c
+     ssl_cert_paths_discover.c
      systemd.c
      version.c
      lua/digest.c

--- a/src/main.cc
+++ b/src/main.cc
@@ -80,6 +80,7 @@
 #include "crypto/crypto.h"
 #include "core/popen.h"
 #include "core/crash.h"
+#include "ssl_cert_paths_discover.h"
 
 static pid_t master_pid = getpid();
 static struct pidfh *pid_file_handle;
@@ -710,6 +711,12 @@ main(int argc, char **argv)
 	memtx_tx_manager_init();
 	crypto_init();
 	systemd_init();
+
+	const int override_cert_paths_env_vars = 0;
+	int res = ssl_cert_paths_discover(override_cert_paths_env_vars);
+	if (res != 0)
+		say_warn("No enough memory for setup ssl certificates paths");
+
 	tarantool_lua_init(tarantool_bin, main_argc, main_argv);
 
 	start_time = ev_monotonic_time();

--- a/src/ssl_cert_paths_discover.c
+++ b/src/ssl_cert_paths_discover.c
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2010-2021, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <openssl/ssl.h>
+#include "ssl_cert_paths_discover.h"
+#include "tt_static.h"
+
+static int
+is_dir_empty(const char *dir_path)
+{
+	DIR *dir = opendir(dir_path);
+	if (!dir)
+		return 1;
+
+	struct dirent *ent;
+	int is_empty = 1;
+	while ((ent = readdir(dir))) {
+		if (strcmp(ent->d_name, ".") && strcmp(ent->d_name, "..")) {
+			is_empty = 0;
+			break;
+		}
+	}
+
+	closedir(dir);
+	return is_empty;
+}
+
+/**
+ * Default paths of directory where stores OpenSSL certificates
+ * for different systems
+ */
+const char *default_cert_dir_paths[] = {
+	/* Fedora/RHEL/Centos */
+	"/etc/pki/tls/certs",
+	/* Debian/Ubuntu/Gentoo etc. (OpenSuse) */
+	"/etc/ssl/certs",
+	/* FreeBSD */
+	"/usr/local/share/certs",
+	/* NetBSD */
+	"/etc/openssl/certs",
+	/* macOS */
+	"/private/etc/ssl/certs",
+	"/usr/local/etc/openssl@1.1/certs",
+	"/usr/local/etc/openssl@1.0/certs",
+	"/usr/local/etc/openssl/certs",
+	NULL
+};
+
+/**
+ * Default paths of OpenSSL certificates file for different systems
+ */
+const char *default_cert_file_paths[] = {
+	/* Fedora/RHEL 6 */
+	"/etc/pki/tls/certs/ca-bundle.crt",
+	/* CentOS/RHEL 7/8 */
+	"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+	/* Debian/Ubuntu/Gentoo etc. */
+	"/etc/ssl/certs/ca-certificates.crt",
+	/* OpenSUSE */
+	"/etc/ssl/ca-bundle.pem",
+	/* FreeBSD */
+	"/usr/local/share/certs/ca-root-nss.crt",
+	/* macOS */
+	"/private/etc/ssl/cert.pem",
+	"/usr/local/etc/openssl@1.1/cert.pem",
+	"/usr/local/etc/openssl@1.0/cert.pem",
+	NULL
+};
+
+int
+ssl_cert_paths_discover(int overwrite)
+{
+	int rc = -1;
+	struct stat sb;
+	size_t dir_buf_end = 0;
+	size_t initial_size = 32;
+	size_t buf_size = initial_size;
+	char *dir_buf = (char *) malloc(buf_size);
+
+	if (dir_buf == NULL)
+		goto fail;
+
+	for (const char **path = default_cert_dir_paths; *path != NULL; path++) {
+		if ((stat(*path, &sb) != 0) ||
+		    (!S_ISDIR(sb.st_mode)) ||
+		    (is_dir_empty(*path) != 0))
+			continue;
+
+		size_t path_len = strlen(*path);
+		size_t needed = dir_buf_end + path_len + 1;
+		if (needed > buf_size) {
+			if (buf_size * 2 >= needed)
+				buf_size *= 2;
+			else
+				buf_size = needed * 2;
+			char *new_buf = (char *) realloc(dir_buf, buf_size);
+			if (new_buf == NULL)
+				goto fail;
+			dir_buf = new_buf;
+		}
+		memcpy(dir_buf + dir_buf_end, *path, path_len);
+		dir_buf_end += path_len;
+		dir_buf[dir_buf_end++] = ':';
+	}
+
+	const char *cert_file = NULL;
+	for (const char **path = default_cert_file_paths; *path != NULL; path++) {
+		if (stat(*path, &sb) == 0) {
+			cert_file = *path;
+			break;
+		}
+	}
+
+	if (dir_buf_end > 0) {
+		dir_buf[dir_buf_end - 1] = '\0';
+		setenv(X509_get_default_cert_dir_env(), dir_buf, overwrite);
+	}
+
+	if (cert_file)
+		setenv(X509_get_default_cert_file_env(), cert_file, overwrite);
+
+	rc = 0;
+
+fail:
+	free(dir_buf);
+	return rc;
+}

--- a/src/ssl_cert_paths_discover.h
+++ b/src/ssl_cert_paths_discover.h
@@ -1,0 +1,54 @@
+#ifndef TARANTOOL_SSL_CERT_PATH_DISCOVER_H_INCLUDED
+#define TARANTOOL_SSL_CERT_PATH_DISCOVER_H_INCLUDED
+/*
+ * Copyright 2010-2021, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+/**
+ * Set SSL certificates paths (from system default paths) through
+ * OpenSSL env variables:
+ *   - SSL_CERT_DIR - it's a colon-separated list of directories
+ *     (like the Unix PATH variable) where stores certificates.
+ *   - SSL_CERT_FILE - it's a path to certificate file
+ * @param overwrite - flag for setenv. If this param is zero, then user
+ * defined OpenSSL env variables won't be overwritten.
+ * @return 0 on success
+ */
+int ssl_cert_paths_discover(int overwrite);
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */
+
+#endif /* TARANTOOL_SSL_CERT_PATH_DISCOVER_H_INCLUDED */

--- a/test/app-tap/ssl-cert-paths-discover.test.lua
+++ b/test/app-tap/ssl-cert-paths-discover.test.lua
@@ -1,0 +1,181 @@
+#!/usr/bin/env tarantool
+
+local tap = require("tap")
+local ffi = require("ffi")
+local fio = require("fio")
+
+--
+-- gh-5615: Static build: Bundled curl in Tarantool http client does
+-- not accept a valid SSL certificate
+--
+local test = tap.test("ssl_cert_paths_discover")
+test:plan(6)
+
+
+----- Init test env
+
+ffi.cdef([[
+    const char* X509_get_default_cert_dir_env();
+    const char* X509_get_default_cert_file_env();
+    void ssl_cert_paths_discover(int overwrite);
+    const char *default_cert_dir_paths[];
+    const char *default_cert_file_paths[];
+]])
+
+local CERT_DIR_ENV = ffi.string(ffi.C.X509_get_default_cert_dir_env())
+local CERT_FILE_ENV = ffi.string(ffi.C.X509_get_default_cert_file_env())
+
+local temp_dir = fio.tempdir()
+local cert_file1 = fio.pathjoin(temp_dir, "cert1.pem")
+local cert_file2 = fio.pathjoin(temp_dir, "cert2.pem")
+
+local handle = fio.open(cert_file1, {"O_RDWR", "O_CREAT"}, tonumber("755", 8))
+handle:close()
+fio.copyfile(cert_file1, cert_file2)
+
+
+----- Helpers
+
+local function cert_dir_paths_mockable()
+    return pcall(function()
+        return ffi.C.default_cert_dir_paths
+    end)
+end
+
+local function cert_file_paths_mockable()
+    return pcall(function()
+        return ffi.C.default_cert_file_paths
+    end)
+end
+
+local function mock_cert_paths_by_addr(addr, paths)
+    -- insert NULL to the end of array as flag of end
+    local paths = table.copy(paths)
+    table.insert(paths, box.NULL)
+
+    local mock_paths = ffi.new(("const char*[%s]"):format(#paths), paths)
+    ffi.copy(addr, mock_paths, ffi.sizeof(mock_paths))
+    ffi.C.ssl_cert_paths_discover(1)
+end
+
+local function mock_cert_dir_paths(t, dir_paths)
+    local dir_paths_addr = ffi.C.default_cert_dir_paths;
+    t:diag("Mock cert dir paths: %s", table.concat(dir_paths, ";"))
+    mock_cert_paths_by_addr(dir_paths_addr, dir_paths)
+end
+
+local function mock_cert_file_paths(t, file_paths)
+    local file_paths_addr = ffi.C.default_cert_file_paths
+    t:diag("Mock cert file paths: %s", table.concat(file_paths, ";"))
+    mock_cert_paths_by_addr(file_paths_addr, file_paths)
+end
+
+local function run_user_defined_env(t, var_name, var_val)
+    local binary_dir = arg[-1]
+    local log_file = fio.pathjoin(temp_dir, "out.log")
+    local cmd = string.format(
+        [[%s=%s %s -e 'print(os.getenv(%q)) os.exit(0)' 1>%s 2>&1]],
+        var_name, var_val, binary_dir, var_name, log_file
+    )
+
+    t:diag("Run cmd: %s", cmd)
+
+    local status = os.execute(cmd)
+    local output = io.open(log_file, "r"):read("*a"):strip()
+
+    t:is(status, 0, "exit status 0")
+    return output and output:strip()
+end
+
+
+----- Tests
+
+if not cert_dir_paths_mockable() then
+    -- Because of LTO (especially on macOS) symbol default_cert_dir_paths
+    -- may become local and unavailable through ffi, so there is no
+    -- chance to mock tests
+    test:skip("Default cert dir paths would set")
+    test:skip("Invalid dir paths won't set")
+else
+    test:test("Default cert dir paths would set", function(t)
+        t:plan(2)
+
+        mock_cert_dir_paths(t, {temp_dir})
+        t:is(
+            os.getenv(CERT_DIR_ENV), temp_dir, "One cert dir path was set"
+        )
+
+        local dir_paths = {temp_dir, temp_dir}
+        mock_cert_dir_paths(t, dir_paths)
+        t:is(
+            os.getenv(CERT_DIR_ENV),
+            table.concat(dir_paths, ":"),
+            "Multiple cert dir paths (like unix $PATH) was set"
+        )
+    end)
+
+    test:test("Invalid dir paths won't set", function(t)
+        t:plan(2)
+
+        -- Cleanup env
+        os.setenv(CERT_DIR_ENV, nil)
+
+        mock_cert_dir_paths(t, {"/not/existing_dir"})
+        t:is(os.getenv(CERT_DIR_ENV), nil, "Not existing cert dir wasn't set")
+
+        local empty_dir_name = fio.pathjoin(temp_dir, "empty")
+        fio.mkdir(empty_dir_name)
+
+        mock_cert_dir_paths(t, {empty_dir_name})
+        t:is(os.getenv(CERT_DIR_ENV), nil, "Empty cert dir wasn't set")
+    end)
+end
+
+
+if not cert_file_paths_mockable() then
+    -- Because of LTO (especially on macOS) symbol default_cert_file_paths
+    -- may become local and unavailable through ffi, so there is no
+    -- chance to mock tests
+    test:skip("Default cert file path would set")
+    test:skip("Invalid cert file won't set")
+else
+    test:test("Default cert file path would set", function(t)
+        t:plan(2)
+
+        mock_cert_file_paths(t, {cert_file1})
+        t:is(os.getenv(CERT_FILE_ENV), cert_file1, "Cert file was set")
+
+        mock_cert_file_paths(t, {cert_file2, cert_file1})
+        t:is(os.getenv(CERT_FILE_ENV), cert_file2, "Only one (first) existing default cert file was set")
+    end)
+
+    test:test("Invalid cert file won't set", function(t)
+        t:plan(1)
+
+        -- Cleanup
+        os.setenv(CERT_FILE_ENV, nil)
+
+        mock_cert_file_paths(t, {"/not/existing_dir/cert1"})
+        t:is(os.getenv(CERT_FILE_ENV), nil, "Not existing cert file wasn't set")
+    end)
+end
+
+test:test("User defined cert dir won't be overridden", function(t)
+    t:plan(2)
+
+    local res = run_user_defined_env(t, CERT_DIR_ENV, "/dev/null")
+    t:is(res, "/dev/null", "User defined wasn't overridden")
+end)
+
+
+test:test("User defined cert file won't be overridden", function(t)
+    t:plan(2)
+
+    local res = run_user_defined_env(t, CERT_FILE_ENV, "/dev/null/cert.pem")
+    t:is(res, "/dev/null/cert.pem", "User defined wasn't overridden")
+end)
+
+----- Cleanup
+fio.rmtree(temp_dir)
+
+os:exit(test:check() and 0 or 1)


### PR DESCRIPTION
The static build isn't as portable as it should be. In fact, the OPENSSLDIR is configured at build time, but in runtime, it may (and do) differ:

```
$ strace tarantool -e 'require("http.client").get("https://...")'
...
openat(AT_FDCWD, "/__w/sdk/sdk/build/tarantool/static-build/"
                 "openssl-prefix/ssl/cert.pem", O_RDONLY) =
                 -1 ENOENT (No such file or directory)
...
stat("/__w/sdk/sdk/build/tarantool/static-build/"
     "openssl-prefix/ssl/certs/...", ...) =
     -1 ENOENT (No such file or directory)
...
```

As a result, statically build tarantool can't open some https links with an error:

```
tarantool> http_client = require('http.client').new({max_connections = 5})
tarantool> http_client:get('https://..../', {verbose = true})
*   Trying X.Y.Z.W:443...
* TCP_NODELAY set
* Connected to .... (X.Y.Z.W) port 443 (#0)
* ALPN, offering http/1.1
* SSL certificate problem: self signed certificate in certificate chain
* Closing connection 0
---
- status: 495
  reason: SSL peer certificate or SSH remote key was not OK
...
```

Also this error may occur at dynamically build tarantool in case of linkage tarantool binary with incorrectly configured openssl.

In this patch, we adopt the approach from the golang ecosystem [1-3]. At startup, tarantool scans several popular locations and uses it for `SSL_CERT_DIR` and/or `SSL_CERT_FILE` setting. See also [4,5] - it's fun.

[1] https://serverfault.com/a/722646
[2] https://golang.org/src/crypto/x509/root_unix.go
[3] https://golang.org/src/crypto/x509/root_linux.go
[4] https://github.com/edenhill/librdkafka/blob/cb69d2a8486344252e0fcaa1f959c4ab2d8afff3/src/rdkafka_ssl.c#L845
[5] https://www.happyassassin.net/posts/2015/01/12/a-note-about-ssltls-trusted-certificate-stores-and-platforms/

Close #5615

Co-authored-by: Yaroslav Dynnikov <yaroslav.dynnikov@gmail.com>

@Changelog

Misc: Lookup openssl certs at tarantool startup and set them if there is no user defined certs (gh-5615)
