### PR TITLE
build: FreeBSD no definition of 'struct sockaddr'

### DIFF
--- a/test/unit/swim_test_transport.c
+++ b/test/unit/swim_test_transport.c
@@ -30,6 +30,8 @@
  */
 #include <assert.h>
 #include <string.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
 #include "fakesys/fakenet.h"
 #include "swim/swim_transport.h"
 


### PR DESCRIPTION
Building on FreeBSD 12 using VM VBox with commands:
```
  cmake . && gmake -j
```
got issue in test build:
```
  [ 72%] Building C object test/unit/CMakeFiles/swim_proto.test.dir/swim_test_transport.c.o
  /home/vagrant/tnt/test/unit/swim_test_transport.c:55:13: error: incomplete definition of type 'struct sockaddr'
          assert(addr->sa_family == AF_INET);
                 ~~~~^
  /usr/include/assert.h:56:21: note: expanded from macro 'assert'
  #define assert(e)       ((e) ? (void)0 : __assert(__func__, __FILE__, \
                            ^
  /usr/include/netinet/in.h:586:8: note: forward declaration of 'struct sockaddr'
  struct sockaddr;
         ^
  /home/vagrant/tnt/test/unit/swim_test_transport.c:55:28: error: use of undeclared identifier 'AF_INET'
          assert(addr->sa_family == AF_INET);
                                    ^
  2 errors generated.
  gmake[2]: *** [test/unit/CMakeFiles/swim_proto.test.dir/build.make:76: test/unit/CMakeFiles/swim_proto.test.dir/swim_test_transport.c.o] Error 1
  gmake[1]: *** [CMakeFiles/Makefile2:5404: test/unit/CMakeFiles/swim_proto.test.dir/all] Error 2
  gmake: *** [Makefile:152: all] Error 2
```
To fix the test added headers in it:
```
  #include <netinet/in.h>
  #include <sys/socket.h>
```
Closes #5748