### PR TITLE
build: fix flaky issue with FreeBSD repos updates

### DIFF
--- a/.travis.mk
+++ b/.travis.mk
@@ -369,6 +369,7 @@ test_static_build_cmake_osx: base_deps_osx
 ###########
 
 deps_freebsd:
+	echo y | sudo pkg update -f
 	sudo pkg install -y git cmake gmake icu libiconv \
 		python27 py27-yaml py27-six py27-gevent
 


### PR DESCRIPTION
Found that repositories on FreeBSD saved old registries for available
packages. Trying to install any new packages failed on it. Found that
the issue is well known [1]:
```
  sudo pkg fetch py37-yaml
  Updating FreeBSD repository catalogue...
  FreeBSD repository is up to date.
  All repositories are up to date.
  The following packages will be fetched:

  New packages to be FETCHED:
          py37-yaml-5.2 (81 KiB: 100.00% of the 81 KiB to download)

  Number of packages to be fetched: 1

  81 KiB to be downloaded.

  Proceed with fetching packages? [y/N]: y
  pkg: http://pkg.FreeBSD.org/FreeBSD:12:amd64/quarterly/All/py37-yaml-5.2.txz: Not Found
```
and fix solution is to force it's update with:
```
  sudo pkg update -f
```
[1] - https://stackoverflow.com/questions/29770779/freebsd-pkg-repository-not-updating-and-thinks-it-is-up-to-date