### PR TITLE
github-ci: send Telegram notifications on failures

### DIFF
--- a/.github/actions/send-telegram-notify/README.md
+++ b/.github/actions/send-telegram-notify/README.md
@@ -1,0 +1,24 @@
+# Send Telegram notifications on failures
+
+Action sends notifications to Telegram channel/bot. Action code is written in Python to be able to use ['composite'](https://docs.github.com/en/actions/creating-actions/creating-a-composite-run-steps-action) Github Action type, which can be used independently from different Github Actions workflows. Also use of Python gives the ability to run the Action on any OS with Python installed. Action uses ['MarkdownV2'](https://core.telegram.org/bots/api#markdownv2-style) style for sending messages. Action has comment in Telegram message that it runs for failed jobs. Github environment variables printing also added to get more information from results log.
+
+Action sends message to single common `TELEGRAM_TO` Telegram channel for release Tarantool branches and tagged commits:
+
+- 1.10
+- 2.\*
+- master
+- 'tagged versions'
+
+And sends all the others to `<TELEGRAM_TO>_<USER>`.
+
+## How to use Github Action from Github workflow
+
+Add the following code to the running steps:
+```
+  - name: call action to send Telegram message on failure
+    env:
+      TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+      TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+    uses: ./.github/actions/send-telegram-notify
+    if: failure()
+```

--- a/.github/actions/send-telegram-notify/action.yml
+++ b/.github/actions/send-telegram-notify/action.yml
@@ -1,0 +1,59 @@
+name: 'Send Telegram message on failure'
+description: 'Send message to Telegram channel/bot on failure'
+runs:
+  using: "composite"
+  steps:
+    # install 'requests' Python module
+    - run: |
+        python -m pip install --upgrade pip
+        pip install requests
+      shell: bash
+    # logout github environment
+    - env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+      shell: bash
+    # extract branch name
+    - run: |
+        branch_name=${{ github.head_ref }}
+        if ${{ github.event_name != 'pull_request' }} ; then
+          branch_name=${{ github.ref }}
+          branch_name=${branch_name#refs/heads/}
+        fi
+        echo BRANCH_NAME=$branch_name | tee -a $GITHUB_ENV
+      shell: bash
+    - env:
+        MSG: |
+          🔴 Workflow testing failed:
+          Job: [ `${{ github.job }}`](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          Commit: [ `${{ github.sha }}`](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
+          Branch: [ `${{ env.BRANCH_NAME }}`](https://github.com/${{ github.repository }}/tree/${{ env.BRANCH_NAME }})
+          History: [commits](https://github.com/${{ github.repository }}/commits/${{ github.sha }})
+          Triggered on: `${{ github.event_name }}`
+          Committer: `${{ github.actor }}`
+          ```
+          -------------------- Commit message --------------------------
+          ${{ github.event.head_commit.message }}
+          ```
+      run: |
+        # convert message from multi lines to single line
+        msg="${MSG//$'\n'/'\n'}"
+        # add backslashes to single quote marks in message
+        msg="${msg//$'\''/\\\'}"
+        echo "Sending message: $msg"
+        # select target channel
+        send_to=$TELEGRAM_TO
+        if ${{ github.ref != 'refs/heads/master' &&
+            github.ref != 'refs/heads/1.10' &&
+            ! startsWith(github.ref, 'refs/heads/2.') &&
+            ! startsWith(github.ref, 'refs/tags') }} ; then
+          send_to=${send_to}_${{ github.actor }}
+          echo "Sending message to '$send_to' developer's chat"
+        fi
+        # Use MarkdownV2 while Markdown is legacy
+        # https://core.telegram.org/bots/api#markdownv2-style
+        python -c "import urllib, requests ; \\
+          url = 'https://api.telegram.org/bot%s/sendMessage?chat_id=%s&text=%s&parse_mode=MarkdownV2&disable_web_page_preview=true' \\
+            % ('$TELEGRAM_TOKEN', '$send_to', urllib.quote_plus('$msg')) ; \\
+          _ = requests.post(url, timeout=10)"
+      shell: bash

--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -49,6 +49,12 @@ jobs:
           else
             OS=el DIST=7 ${CI_MAKE} package
           fi
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -49,6 +49,12 @@ jobs:
           else
             OS=el DIST=8 ${CI_MAKE} package
           fi
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -35,6 +35,12 @@ jobs:
         run: ${CI_MAKE} test_coverity_debian_no_deps
         env:
           COVERITY_TOKEN: ${{ secrets.COVERITY_TOKEN }}
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -49,6 +49,12 @@ jobs:
           else
             OS=debian DIST=buster ${CI_MAKE} package
           fi
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -49,6 +49,12 @@ jobs:
           else
             OS=debian DIST=bullseye ${CI_MAKE} package
           fi
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -49,6 +49,12 @@ jobs:
           else
             OS=debian DIST=stretch ${CI_MAKE} package
           fi
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/debug_coverage.yml
+++ b/.github/workflows/debug_coverage.yml
@@ -31,6 +31,12 @@ jobs:
         run: ${CI_MAKE} test_coverage_debian_no_deps
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/fedora_28.yml
+++ b/.github/workflows/fedora_28.yml
@@ -49,6 +49,12 @@ jobs:
           else
             OS=fedora DIST=28 ${CI_MAKE} package
           fi
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/fedora_29.yml
+++ b/.github/workflows/fedora_29.yml
@@ -49,6 +49,12 @@ jobs:
           else
             OS=fedora DIST=29 ${CI_MAKE} package
           fi
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/fedora_30.yml
+++ b/.github/workflows/fedora_30.yml
@@ -49,6 +49,12 @@ jobs:
           else
             OS=fedora DIST=30 ${CI_MAKE} package
           fi
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/fedora_31.yml
+++ b/.github/workflows/fedora_31.yml
@@ -49,6 +49,12 @@ jobs:
           else
             OS=fedora DIST=31 ${CI_MAKE} package
           fi
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/fedora_32.yml
+++ b/.github/workflows/fedora_32.yml
@@ -49,6 +49,12 @@ jobs:
           else
             OS=fedora DIST=32 ${CI_MAKE} package
           fi
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/fedora_33.yml
+++ b/.github/workflows/fedora_33.yml
@@ -49,6 +49,12 @@ jobs:
           else
             OS=fedora DIST=33 ${CI_MAKE} package
           fi
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -29,3 +29,9 @@ jobs:
       - uses: actions/checkout@v1
       - name: test
         run: ${CI_MAKE} test_debian_luacheck
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -49,6 +49,12 @@ jobs:
           else
             OS=opensuse-leap DIST=15.1 ${CI_MAKE} package
           fi
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -49,6 +49,12 @@ jobs:
           else
             OS=opensuse-leap DIST=15.2 ${CI_MAKE} package
           fi
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/osx_10_15.yml
+++ b/.github/workflows/osx_10_15.yml
@@ -24,6 +24,12 @@ jobs:
           submodules: recursive
       - name: test
         run: ${CI_MAKE} test_osx_github_actions
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/osx_11_0.yml
+++ b/.github/workflows/osx_11_0.yml
@@ -24,6 +24,12 @@ jobs:
           submodules: recursive
       - name: test
         run: ${CI_MAKE} test_osx_github_actions
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,12 @@ jobs:
       - uses: actions/checkout@v1
       - name: test
         run: ${CI_MAKE} test_debian_no_deps
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -32,6 +32,12 @@ jobs:
           submodules: recursive
       - name: test
         run: ${CI_MAKE} test_asan_debian_no_deps
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -32,6 +32,12 @@ jobs:
           CC: clang
           CXX: clang++
         run: ${CI_MAKE} test_debian_no_deps
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -34,6 +34,12 @@ jobs:
         env:
           CMAKE_EXTRA_PARAMS: -DENABLE_LTO=ON
         run: ${CI_MAKE} test_debian_no_deps
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -36,6 +36,12 @@ jobs:
           CXX: clang++-11
           CMAKE_EXTRA_PARAMS: -DENABLE_LTO=ON
         run: ${CI_MAKE} test_debian_no_deps
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -32,3 +32,9 @@ jobs:
           sudo apt-get -y update
           sudo apt-get install -y awscli
           ${CI_MAKE} source_deploy
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()

--- a/.github/workflows/ubuntu_14_04.yml
+++ b/.github/workflows/ubuntu_14_04.yml
@@ -49,6 +49,12 @@ jobs:
           else
             OS=ubuntu DIST=trusty ${CI_MAKE} package
           fi
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -49,6 +49,12 @@ jobs:
           else
             OS=ubuntu DIST=xenial ${CI_MAKE} package
           fi
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -49,6 +49,12 @@ jobs:
           else
             OS=ubuntu DIST=bionic ${CI_MAKE} package
           fi
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -49,6 +49,12 @@ jobs:
           else
             OS=ubuntu DIST=focal ${CI_MAKE} package
           fi
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()


### PR DESCRIPTION
Used Telegram public channel to send notifications for failed Github
Actions workflows. Created new Github Action based on Python:
    
    .github/actions/send-telegram-notify/action.yml
    
with the ability to send messages in MarkdownV2 format [1]. To make
able to run standalone Github Action used its 'composite' type [2].
Also added ability to logout Github environment variables in this
action.
    
[1] - https://core.telegram.org/bots/api#markdownv2-style
[2] - https://docs.github.com/en/actions/creating-actions/creating-a-composite-run-steps-action

Result looks like the following markdown format message in Telegram:
----------------------------------------------------------------------

🔴 Workflow testing failed:
Job:  [release](https://github.com/tarantool/tarantool/actions/runs/533640919)
Commit:  [f9a93818f17b9eef3e91398befc9bc078157be93](https://github.com/tarantool/tarantool/commit/f9a93818f17b9eef3e91398befc9bc078157be93)
Branch:  [avtikhon/github-common](https://github.com/tarantool/tarantool/tree/refs/heads/avtikhon/github-common)
History: [commits](https://github.com/tarantool/tarantool/commits/f9a93818f17b9eef3e91398befc9bc078157be93)
Triggered on: `push`
Committer: `avtikhon`
-------------------- Commit message --------------------------
github-ci: send Telegram notifications on failures

Used Telegram public channel to send notifications for failed Github
Actions workflows. Created new Github Action based on Python:

  .github/actions/send-telegram-notify/action.yml

with the ability to send messages in MarkdownV2 format [1]. To make
able to run standalone Github Action used its 'composite' type [2].
Also added ability to logout Github environment variables in this
action.

[1] - https://core.telegram.org/bots/api#markdownv2-style
[2] - https://docs.github.com/en/actions/creating-actions/creating-a-composite-run-steps-action
