### PR TITLE
Enable LTO on 1.10 and disable 'lto-type-mismatch' warning on linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,9 @@ include(cmake/pod2man.cmake)
 include(cmake/arch.cmake)
 include(cmake/os.cmake)
 include(cmake/compiler.cmake)
+# NO_POLICY_SCOPE is to suppress CMP0069 warnings on the unset
+# policy.
+include(cmake/lto.cmake NO_POLICY_SCOPE)
 include(cmake/simd.cmake)
 include(cmake/atomic.cmake)
 include(cmake/profile.cmake)

--- a/cmake/lto.cmake
+++ b/cmake/lto.cmake
@@ -1,0 +1,97 @@
+#
+# Manage LTO (Link-Time-Optimization) and IPO
+# (Inter-Procedural-Optimization)
+#
+
+# Tarantool uses both dynamic-list and lto link options, which
+# works only since binutils:
+#
+# - 2.30 for linking with ld.gold (gold version is 1.15);
+# - last 2.30 or 2.31 in case of ld.bfd.
+
+# This cmake module exports CMP0069 policy and should be included
+# with NO_POLICY_SCOPE option.
+
+# The file gives an error if LTO is requested, but cannot be
+# enabled for some reason.
+
+if (NOT DEFINED ENABLE_LTO)
+    set(ENABLE_LTO OFF)
+endif()
+
+# Disable LTO if not requested.
+if (NOT ENABLE_LTO)
+    message(STATUS "Enabling LTO: FALSE")
+    return()
+endif()
+
+if(CMAKE_VERSION VERSION_LESS 3.9)
+    message(FATAL_ERROR "cmake >= 3.9 is needed to enable LTO")
+endif()
+
+# 'CMP0069 NEW' behaviour enables LTO for compilers other then
+# Intel Compiler when CMAKE_INTERPROCEDURAL_OPTIMIZATION is
+# enabled and provides CheckIPOSupported module. We set the policy
+# to support LTO with GCC / Clang and to suppress cmake warnings
+# on the unset policy.
+cmake_policy(SET CMP0069 NEW)
+
+# Retain 'CMP0069 NEW' behaviour after
+# 'cmake_minimum_required(VERSION ...) in subprojects to
+# avoid cmake warnings on the unset policy.
+set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
+
+# Check whether LTO is supported by the compiler / toolchain and
+# give an error otherwise.
+include(CheckIPOSupported)
+check_ipo_supported(RESULT CMAKE_IPO_AVAILABLE)
+if (NOT CMAKE_IPO_AVAILABLE)
+    message(FATAL_ERROR "LTO is not supported by the compiler / toolchain")
+endif()
+
+# Extra checks on Linux whether all needed LTO features are
+# supported. Mac OS seems to work correctly with xcode >= 8.
+if (NOT TARGET_OS_DARWIN)
+    execute_process(
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        COMMAND ld -v OUTPUT_VARIABLE linker_version_str)
+    message(STATUS "ld version string: ${linker_version_str}")
+
+    # GNU ld (Gentoo 2.31.1 p3) 2.31.1
+    # GNU ld (GNU Binutils for Ubuntu) 2.30
+    # GNU ld version 2.27-10.el7
+    string(REGEX MATCH "^GNU ld.* (2\\.[0-9]+)[^ ]*$" matched_bfd
+        ${linker_version_str})
+
+    # GNU gold (Gentoo 2.31.1 p3 2.31.1) 1.16
+    # GNU gold (GNU Binutils for Ubuntu 2.30) 1.15
+    # GNU gold (version 2.27-10.el7) 1.12
+    if (NOT matched_bfd)
+        string(REGEX MATCH "^GNU gold.* (1\\.[0-9]+)[^ ]*$" matched_gold
+            ${linker_version_str})
+    endif()
+
+    if(matched_bfd)
+        set(linker_version ${CMAKE_MATCH_1})
+        message(STATUS "Found ld.bfd version: ${linker_version}")
+
+        if (linker_version VERSION_LESS "2.31")
+            message(FATAL_ERROR "ld.bfd >= 2.31 is needed for LTO")
+        endif()
+    elseif(matched_gold)
+        set(linker_version ${CMAKE_MATCH_1})
+        message(STATUS "Found ld.gold version: ${linker_version}")
+
+        if (linker_version VERSION_LESS "1.15")
+            message(FATAL_ERROR "ld.gold >= 1.15 is needed for LTO")
+        endif()
+    else()
+        message(FATAL_ERROR "Unsupported ld version format")
+    endif()
+endif()
+
+# gh-3742: investigate LTO warnings.
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wno-lto-type-mismatch")
+
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+message(STATUS "Enabling LTO: TRUE")

--- a/cmake/lto.cmake
+++ b/cmake/lto.cmake
@@ -90,8 +90,39 @@ if (NOT TARGET_OS_DARWIN)
     endif()
 endif()
 
-# gh-3742: investigate LTO warnings.
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wno-lto-type-mismatch")
+# {{{ Expose build tools and flags
+#
+# It is convenient for building non-cmake targets with the same
+# flags as we use for sources under CMake control.
+#
+# It leans on uncodumented variables that are set in the following
+# CMake modules: Compiler/GNU.cmake and Compiler/Clang.cmake.
 
+# CFLAGS_LTO (list)
+set(CFLAGS_LTO ${CMAKE_C_COMPILE_OPTIONS_IPO})
+message(STATUS "CFLAGS_LTO: ${CFLAGS_LTO}")
+
+# LDFLAGS_LTO (list)
+set(LDFLAGS_LTO ${CMAKE_C_LINK_OPTIONS_IPO})
+# FIXME: gh-3742: investigate LTO warnings.
+list(APPEND LDFLAGS_LTO -Wno-lto-type-mismatch)
+message(STATUS "LDFLAGS_LTO: ${LDFLAGS_LTO}")
+
+# AR_LTO (string)
+#
+# Note: Platform/Linux-Intel.cmake and Platform/Windows-MSVC.cmake
+# set CMAKE_C_CREATE_STATIC_LIBRARY_IPO, but not
+# CMAKE_C_ARCHIVE_CREATE_IPO. So this snippet is only for GCC and
+# clang.
+set(_ar_command ${CMAKE_C_ARCHIVE_CREATE_IPO})
+separate_arguments(_ar_command)
+list(GET _ar_command 0 AR_LTO)
+unset(_ar_command)
+message(STATUS "AR_LTO: ${AR_LTO}")
+
+# }}}
+
+# Set build tools and flags for files that are built using CMake.
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wno-lto-type-mismatch")
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
 message(STATUS "Enabling LTO: TRUE")

--- a/cmake/luajit.cmake
+++ b/cmake/luajit.cmake
@@ -230,6 +230,16 @@ macro(luajit_build)
     # above.
     set (luajit_ld ${CMAKE_LINKER})
     set (luajit_ar ${CMAKE_AR} rcus)
+    # Enablibg LTO for luajit if DENABLE_LTO set.
+    if (ENABLE_LTO)
+        message(STATUS "Enable LTO for luajit")
+        set (luajit_ldflags ${luajit_ldflags} ${LDFLAGS_LTO})
+        message(STATUS "ld: " ${luajit_ldflags})
+        set (luajit_cflags ${luajit_cflags} ${CFLAGS_LTO})
+        message(STATUS "cflags: " ${luajit_cflags})
+        set (luajit_ar  ${AR_LTO} rcus)
+        message(STATUS "ar: " ${luajit_ar})
+    endif()
     set (luajit_strip ${CMAKE_STRIP})
 
     set (luajit_buildoptions


### PR DESCRIPTION
LTO wasn't enabled on Tarantool 1.10. Also was added packages build for Fedora 33 in:

[github-ci: add Fedora 33 to packaging](https://github.com/tarantool/tarantool/commit/44fcf3fef8e0ef38e74cc6907e85bdf88ac605f9)

which uses by default LTO in build. It broke the testing:

https://github.com/tarantool/tarantool/runs/1776978079#step:3:4134

with error:
```
/build/usr/src/debug/tarantool-1.10.9.16/src/reflection.h:124:33: error: type of ‘METHODS_SENTINEL’ does not match original declaration [-Werror=lto-type-mismatch]
  124 | extern const struct method_info METHODS_SENTINEL;
      |                                 ^
/build/usr/src/debug/tarantool-1.10.9.16/src/reflection.c:35:26: note: ‘METHODS_SENTINEL’ was previously declared here
   35 | const struct method_info METHODS_SENTINEL = {
      |                          ^
```

this warning '-Werror=lto-type-mismatch' was disabled in commit [cmake: add LTO support for building luajit](https://github.com/tarantool/tarantool/pull/5760/commits/97a5b72509c624a5b6a8eaf77a49c5b0c9fddf71#diff-d7a0570335bb0db6590464ab72c417f4d5c2cbf0f2c941f302dc78a21299b81cR107), but to use it commit [Add LTO support]( https://github.com/tarantool/tarantool/pull/5760/commits/b459b75c1b630dc2cdfe92548360e2712301b6a5) must be also used to LTO enable.