### PR TITLE
github-ci: skip testing on -notest branches

### DIFF
--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -9,8 +9,9 @@ jobs:
   centos_7:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -9,8 +9,9 @@ jobs:
   centos_8:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -11,8 +11,9 @@ jobs:
   coverity:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -9,8 +9,9 @@ jobs:
   debian_10:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -9,8 +9,9 @@ jobs:
   debian_11:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -9,8 +9,9 @@ jobs:
   debian_9:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/debug_coverage.yml
+++ b/.github/workflows/debug_coverage.yml
@@ -9,8 +9,9 @@ jobs:
   debug_coverage:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/fedora_28.yml
+++ b/.github/workflows/fedora_28.yml
@@ -9,8 +9,9 @@ jobs:
   fedora_28:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/fedora_29.yml
+++ b/.github/workflows/fedora_29.yml
@@ -9,8 +9,9 @@ jobs:
   fedora_29:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/fedora_30.yml
+++ b/.github/workflows/fedora_30.yml
@@ -9,8 +9,9 @@ jobs:
   fedora_30:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/fedora_31.yml
+++ b/.github/workflows/fedora_31.yml
@@ -9,8 +9,9 @@ jobs:
   fedora_31:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/fedora_32.yml
+++ b/.github/workflows/fedora_32.yml
@@ -9,8 +9,9 @@ jobs:
   fedora_32:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/fedora_33.yml
+++ b/.github/workflows/fedora_33.yml
@@ -9,8 +9,9 @@ jobs:
   fedora_33:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -9,8 +9,9 @@ jobs:
   luacheck:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -9,8 +9,9 @@ jobs:
   opensuse_15_1:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -9,8 +9,9 @@ jobs:
   opensuse_15_2:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/osx_10_15.yml
+++ b/.github/workflows/osx_10_15.yml
@@ -9,8 +9,9 @@ jobs:
   osx_10_15:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: macos-10.15
 

--- a/.github/workflows/osx_11_0.yml
+++ b/.github/workflows/osx_11_0.yml
@@ -9,8 +9,9 @@ jobs:
   osx_11_0:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: macos-11.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,9 @@ jobs:
   release:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -9,8 +9,9 @@ jobs:
   release_asan_clang11:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -9,8 +9,9 @@ jobs:
   release_clang:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -9,8 +9,9 @@ jobs:
   release_lto:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -9,8 +9,9 @@ jobs:
   release_lto_clang11:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -8,10 +8,11 @@ env:
 jobs:
   source:
     # We want to run only on release branches and tags.
-    if: github.ref == 'refs/heads/master' ||
+    if: ( github.ref == 'refs/heads/master' ||
         github.ref == 'refs/heads/1.10' ||
         startsWith(github.ref, 'refs/heads/2.') ||
-        startsWith(github.ref, 'refs/tags')
+        startsWith(github.ref, 'refs/tags') ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ubuntu_14_04.yml
+++ b/.github/workflows/ubuntu_14_04.yml
@@ -9,8 +9,9 @@ jobs:
   ubuntu_14_04:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -9,8 +9,9 @@ jobs:
   ubuntu_16_04:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -9,8 +9,9 @@ jobs:
   ubuntu_18_04:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -9,8 +9,9 @@ jobs:
   ubuntu_20_04:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
-    if: github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-latest
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,15 +53,6 @@ before_script:
   after_script:
     - cp -r test/var/artifacts .
 
-.deploy_only_template: &deploy_only_definition
-  only:
-    - master
-    - tags
-  except:
-    - schedules
-    - external_pull_requests
-    - merge_requests
-
 .pack_only_template: &pack_only_definition
   except:
     - master
@@ -81,13 +72,6 @@ before_script:
 .docker_test_template: &docker_test_definition
   <<: *artifacts_files_definition
   image: "${CI_REGISTRY}/${CI_PROJECT_PATH}/testing/debian-stretch:latest"
-  stage: test
-  tags:
-    - docker_test
-
-.docker_test_clang11_template: &docker_test_clang8_definition
-  <<: *artifacts_files_definition
-  image: "${CI_REGISTRY}/${CI_PROJECT_PATH}/testing/debian-buster:latest"
   stage: test
   tags:
     - docker_test
@@ -113,23 +97,6 @@ before_script:
     - deploy_test
   script:
     - ${GITLAB_MAKE} package
-
-.deploy_template: &deploy_definition
-  <<: *deploy_only_definition
-  stage: test
-  tags:
-    - deploy
-  script:
-    - ${GITLAB_MAKE} deploy
-
-.deploy_test_template: &deploy_test_definition
-  <<: *deploy_only_definition
-  <<: *pack_artifacts_files_definition
-  stage: test
-  tags:
-    - deploy_test
-  script:
-    - ${GITLAB_MAKE} deploy
 
 .osx_template: &osx_definition
   <<: *artifacts_files_definition
@@ -200,53 +167,9 @@ out_of_source:
   script:
     - ${GITLAB_MAKE} test_oos_build
 
-release:
-  <<: *docker_test_definition
-  script:
-    - ${GITLAB_MAKE} test_debian_no_deps
-
-debug:
-  <<: *docker_test_definition
-  script:
-    - ${GITLAB_MAKE} test_coverage_debian_no_deps
-
-release_clang:
-  <<: *docker_test_definition
-  variables:
-    CC: clang
-    CXX: clang++
-  script:
-    - ${GITLAB_MAKE} test_debian_no_deps
-
-release_lto:
-  <<: *docker_test_clang8_definition
-  variables:
-    CMAKE_EXTRA_PARAMS: -DENABLE_LTO=ON
-  script:
-    - ${GITLAB_MAKE} test_debian_no_deps
-
-release_lto_clang11:
-  <<: *docker_test_clang8_definition
-  variables:
-    CC: clang-11
-    CXX: clang++-11
-    CMAKE_EXTRA_PARAMS: -DENABLE_LTO=ON
-  script:
-    - ${GITLAB_MAKE} test_debian_no_deps
-
-release_asan_clang11:
-  <<: *docker_test_clang8_definition
-  script:
-    - ${GITLAB_MAKE} test_asan_debian_no_deps
-
 osx_14_release:
   tags:
     - osx_14
-  <<: *osx_definition
-
-osx_15_release:
-  tags:
-    - osx_15
   <<: *osx_definition
 
 osx_15_release_lto:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,6 +57,7 @@ before_script:
   except:
     - master
     - tags
+    - /^.*-notest$/
 
 .perf_only_template: &perf_only_definition
   only:
@@ -71,6 +72,8 @@ before_script:
 
 .docker_test_template: &docker_test_definition
   <<: *artifacts_files_definition
+  except:
+    - /^.*-notest$/
   image: "${CI_REGISTRY}/${CI_PROJECT_PATH}/testing/debian-stretch:latest"
   stage: test
   tags:
@@ -100,6 +103,8 @@ before_script:
 
 .osx_template: &osx_definition
   <<: *artifacts_files_definition
+  except:
+    - /^.*-notest$/
   stage: test
   script:
     - ${GITLAB_MAKE} test_osx
@@ -112,6 +117,8 @@ before_script:
 
 .vbox_template: &vbox_definition
   <<: *artifacts_files_definition
+  except:
+    - /^.*-notest$/
   stage: test
   after_script:
     - >
@@ -162,6 +169,8 @@ luacheck:
 
 out_of_source:
   stage: test
+  except:
+    - /^.*-notest$/
   tags:
     - deploy_test
   script:


### PR DESCRIPTION
Added condition in gitlab-ci and github actions to skip testings
when branch names ends with '-notest'.

Removed jobs that already testing in Github Actions:

debug
release
release_clang
release_lto
release_lto_clang11
release_asan_clang11
osx_15_release
and templates:

deploy_*