### PR TITLE
github-ci: move more jobs from gitlab-ci 2.x

### DIFF
--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: centos-7
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: centos-8
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: debian-buster
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: debian-bullseye
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: debian-stretch
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -1,0 +1,46 @@
+name: default_gcc_centos_7
+
+on: [push, pull_request]
+
+env:
+  CI_MAKE: make -f .travis.mk
+
+jobs:
+  default_gcc_centos_7:
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: test
+        env:
+          # Our testing expects that the init process (PID 1) will
+          # reap orphan processes. At least the following test leans
+          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
+          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '--init -e CC=/usr/bin/gcc -e CXX=/usr/bin/g++'
+        run: OS=el DIST=7 ${CI_MAKE} package
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: default_gcc_centos_7
+          retention-days: 21
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/fedora_28.yml
+++ b/.github/workflows/fedora_28.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: fedora-28
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/fedora_29.yml
+++ b/.github/workflows/fedora_29.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: fedora-29
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/fedora_30.yml
+++ b/.github/workflows/fedora_30.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: fedora-30
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/fedora_31.yml
+++ b/.github/workflows/fedora_31.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: fedora-31
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/fedora_32.yml
+++ b/.github/workflows/fedora_32.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: fedora-32
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/fedora_33.yml
+++ b/.github/workflows/fedora_33.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: fedora-33
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: opensuse-leap-15.1
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: opensuse-leap-15.2
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/osx_10_15.yml
+++ b/.github/workflows/osx_10_15.yml
@@ -38,4 +38,4 @@ jobs:
         with:
           name: osx_10_15
           retention-days: 21
-          path: test/var/artifacts
+          path: /tmp/tnt/artifacts

--- a/.github/workflows/osx_10_15_lto.yml
+++ b/.github/workflows/osx_10_15_lto.yml
@@ -1,4 +1,4 @@
-name: static_build_cmake_osx_15
+name: osx_10_15_lto
 
 on: [push, pull_request]
 
@@ -6,7 +6,7 @@ env:
   CI_MAKE: make -f .travis.mk
 
 jobs:
-  static_build_cmake_osx_15:
+  osx_10_15_lto:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
     if: ( github.event_name == 'push' ||
@@ -25,7 +25,9 @@ jobs:
           submodules: recursive
       - uses: ./.github/actions/environment
       - name: test
-        run: ${CI_MAKE} test_static_build_cmake_osx_github_actions
+        env:
+          CMAKE_EXTRA_PARAMS: -DENABLE_LTO=ON
+        run: ${CI_MAKE} test_osx_github_actions
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
@@ -36,6 +38,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: static_build_cmake_osx_15
+          name: osx_10_15_lto
           retention-days: 21
           path: /tmp/tnt/artifacts

--- a/.github/workflows/osx_11_0.yml
+++ b/.github/workflows/osx_11_0.yml
@@ -38,4 +38,4 @@ jobs:
         with:
           name: osx_11_0
           retention-days: 21
-          path: test/var/artifacts
+          path: /tmp/tnt/artifacts

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -1,0 +1,41 @@
+name: out_of_source
+
+on: [push, pull_request]
+
+env:
+  CI_MAKE: make -f .travis.mk
+
+jobs:
+  out_of_source:
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: test
+        run: ${CI_MAKE} test_oos_build
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: out_of_source
+          retention-days: 21
+          path: artifacts

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -1,0 +1,46 @@
+name: static_build
+
+on: [push, pull_request]
+
+env:
+  CI_MAKE: make -f .travis.mk
+
+jobs:
+  static_build:
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    # image built by .gitlab.mk instructions and targets from .travis.mk
+    container:
+      image: docker.io/tarantool/testing:debian-stretch
+      # Our testing expects that the init process (PID 1) will
+      # reap orphan processes. At least the following test leans
+      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
+      options: '--init'
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: ./.github/actions/environment
+      - name: test
+        run: ${CI_MAKE} test_static_build
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: static_build
+          retention-days: 21
+          path: test/var/artifacts

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -1,0 +1,46 @@
+name: static_build_cmake_linux
+
+on: [push, pull_request]
+
+env:
+  CI_MAKE: make -f .travis.mk
+
+jobs:
+  static_build_cmake_linux:
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    # image built by .gitlab.mk instructions and targets from .travis.mk
+    container:
+      image: docker.io/tarantool/testing:debian-stretch
+      # Our testing expects that the init process (PID 1) will
+      # reap orphan processes. At least the following test leans
+      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
+      options: '--init'
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: ./.github/actions/environment
+      - name: test
+        run: ${CI_MAKE} test_static_build_cmake_linux
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: static_build_cmake_linux
+          retention-days: 21
+          path: test/var/artifacts

--- a/.github/workflows/static_build_cmake_osx_15.yml
+++ b/.github/workflows/static_build_cmake_osx_15.yml
@@ -1,0 +1,41 @@
+name: static_build_cmake_osx_15
+
+on: [push, pull_request]
+
+env:
+  CI_MAKE: make -f .travis.mk
+
+jobs:
+  static_build_cmake_osx_15:
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
+
+    runs-on: macos-10.15
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: test
+        run: ${CI_MAKE} test_static_build_cmake_osx
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: static_build_cmake_osx_15
+          retention-days: 21
+          path: /tmp/tnt/artifacts

--- a/.github/workflows/ubuntu_14_04.yml
+++ b/.github/workflows/ubuntu_14_04.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: ubuntu-trusty
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: ubuntu-xenial
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: ubuntu-bionic
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: ubuntu-focal
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -144,13 +144,6 @@ osx_14_release:
     - osx_14
   <<: *osx_definition
 
-osx_15_release_lto:
-  tags:
-    - osx_15
-  variables:
-    CMAKE_EXTRA_PARAMS: -DENABLE_LTO=ON
-  <<: *osx_definition
-
 freebsd_12_release:
   <<: *vbox_definition
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,12 +53,6 @@ before_script:
   after_script:
     - cp -r test/var/artifacts .
 
-.pack_only_template: &pack_only_definition
-  except:
-    - master
-    - tags
-    - /^.*-notest$/
-
 .perf_only_template: &perf_only_definition
   only:
     - master
@@ -78,28 +72,6 @@ before_script:
   stage: test
   tags:
     - docker_test
-
-.pack_artifacts_files_template: &pack_artifacts_files_definition
-  <<: *artifacts_files_definition
-  after_script:
-    - cp -r build/usr/src/*/tarantool-*/test/var/artifacts .
-
-.pack_template: &pack_definition
-  <<: *pack_only_definition
-  stage: test
-  tags:
-    - deploy
-  script:
-    - ${GITLAB_MAKE} package
-
-.pack_test_template: &pack_test_definition
-  <<: *pack_only_definition
-  <<: *pack_artifacts_files_definition
-  stage: test
-  tags:
-    - deploy_test
-  script:
-    - ${GITLAB_MAKE} package
 
 .osx_template: &osx_definition
   <<: *artifacts_files_definition
@@ -224,13 +196,6 @@ jepsen-cluster-txm:
   variables:
     LEIN_OPT: '--nemesis standard --mvcc'
     INSTANCE_COUNT: '5'
-
-default_gcc_centos_7:
-  <<: *pack_test_definition
-  variables:
-    PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '-e CC=/usr/bin/gcc -e CXX=/usr/bin/g++'
-    OS: 'el'
-    DIST: '7'
 
 # ####
 # Perf

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -139,15 +139,6 @@ luacheck:
 
 # Tests
 
-out_of_source:
-  stage: test
-  except:
-    - /^.*-notest$/
-  tags:
-    - deploy_test
-  script:
-    - ${GITLAB_MAKE} test_oos_build
-
 osx_14_release:
   tags:
     - osx_14

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -310,22 +310,3 @@ remove_images_sh9:
   <<: *perf_cleanup_definition
   tags:
     - sh9_shell
-
-# Static builds
-
-static_build:
-  <<: *docker_test_definition
-  script:
-    - ${GITLAB_MAKE} test_static_build
-
-static_build_cmake_linux:
-  <<: *docker_test_definition
-  script:
-    - ${GITLAB_MAKE} test_static_build_cmake_linux
-
-static_build_cmake_osx_15:
-  <<: *osx_definition
-  tags:
-    - osx_15
-  script:
-    - ${GITLAB_MAKE} test_static_build_cmake_osx

--- a/.travis.mk
+++ b/.travis.mk
@@ -351,8 +351,8 @@ test_osx_github_actions: deps_osx_github_actions test_osx_no_deps
 
 # Static macOS build
 
-STATIC_OSX_MIN=cmake
-STATIC_OSX_PKGS=${STATIC_OSX_MIN} file://$${PWD}/tools/brew_taps/tntpython2.rb
+STATIC_OSX_PKGS_MIN=cmake
+STATIC_OSX_PKGS=${STATIC_OSX_PKGS_MIN} file://$${PWD}/tools/brew_taps/tntpython2.rb
 base_deps_osx:
 	brew update || echo | /usr/bin/ruby -e \
 		"$$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
@@ -367,7 +367,7 @@ base_deps_osx_github_actions:
 
 # builddir used in this target - is a default build path from cmake
 # ExternalProject_Add()
-test_static_build_cmake_osx_no_deps: base_deps_osx
+test_static_build_cmake_osx_no_deps:
 	cd static-build && cmake -DCMAKE_TARANTOOL_ARGS="-DCMAKE_BUILD_TYPE=RelWithDebInfo;-DENABLE_WERROR=ON" . && \
 	make -j && ctest -V
 	${INIT_TEST_ENV_OSX}; \


### PR DESCRIPTION
1. Artifacts paths for pack/deploy/osx based jobs corrected.

2. Moved from gitlab-ci to github-ci 'default_gcc_centos_7' job for
building/testing Tarantool on default GCC installed in CentOS 7.
Removed not used after movement templates from gitlab-ci config.

3. Moved from gitlab-ci to github-ci 'out-of-source' job for
building/testing Tarantool in standalone build path while
source path is not writable.

4. Moved from gitlab-ci to github-ci 'static_build*' jobs for
building/testing Tarantool on Linux and OSX. Added targets
in .travis.mk file for static build on OSX on Github hosts.
    
5. Moved from gitlab-ci to github-ci 'osx_10_15_lto' job for
    building/testing Tarantool on OSX with LTO.