### PR TITLE
github-ci: add test-run timeouts to actions

### DIFF
--- a/.github/actions/environment/README.md
+++ b/.github/actions/environment/README.md
@@ -1,0 +1,11 @@
+# Setup environment
+
+Action setup environment to $GITHUB_ENV as suggested in [Github Action documentation](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable). It can be used for common environment setup for different testing workflows.
+
+## How to use Github Action from Github workflow
+
+Add the following code to the running steps after checkout done:
+```
+  - uses: ./.github/actions/environment
+```
+

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -1,0 +1,11 @@
+name: 'Set environment'
+description: 'Top level to set environment'
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        echo REPLICATION_SYNC_TIMEOUT=300 | tee -a $GITHUB_ENV
+        echo TEST_TIMEOUT=310 | tee -a $GITHUB_ENV
+        echo NO_OUTPUT_TIMEOUT=320 | tee -a $GITHUB_ENV
+        echo PRESERVE_ENVVARS=REPLICATION_SYNC_TIMEOUT,TEST_TIMEOUT,NO_OUTPUT_TIMEOUT | tee -a $GITHUB_ENV
+      shell: bash

--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: packaging
         env:
           # Our testing expects that the init process (PID 1) will

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: packaging
         env:
           # Our testing expects that the init process (PID 1) will

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -31,6 +31,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+      - uses: ./.github/actions/environment
       - name: test
         run: ${CI_MAKE} test_coverity_debian_no_deps
         env:

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: packaging
         env:
           # Our testing expects that the init process (PID 1) will

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: packaging
         env:
           # Our testing expects that the init process (PID 1) will

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: packaging
         env:
           # Our testing expects that the init process (PID 1) will

--- a/.github/workflows/debug_coverage.yml
+++ b/.github/workflows/debug_coverage.yml
@@ -27,6 +27,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+      - uses: ./.github/actions/environment
       - name: test
         run: ${CI_MAKE} test_coverage_debian_no_deps
         env:

--- a/.github/workflows/fedora_28.yml
+++ b/.github/workflows/fedora_28.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: packaging
         env:
           # Our testing expects that the init process (PID 1) will

--- a/.github/workflows/fedora_29.yml
+++ b/.github/workflows/fedora_29.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: packaging
         env:
           # Our testing expects that the init process (PID 1) will

--- a/.github/workflows/fedora_30.yml
+++ b/.github/workflows/fedora_30.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: packaging
         env:
           # Our testing expects that the init process (PID 1) will

--- a/.github/workflows/fedora_31.yml
+++ b/.github/workflows/fedora_31.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: packaging
         env:
           # Our testing expects that the init process (PID 1) will

--- a/.github/workflows/fedora_32.yml
+++ b/.github/workflows/fedora_32.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: packaging
         env:
           # Our testing expects that the init process (PID 1) will

--- a/.github/workflows/fedora_33.yml
+++ b/.github/workflows/fedora_33.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: packaging
         env:
           # Our testing expects that the init process (PID 1) will

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: packaging
         env:
           # Our testing expects that the init process (PID 1) will

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: packaging
         env:
           # Our testing expects that the init process (PID 1) will

--- a/.github/workflows/osx_10_15.yml
+++ b/.github/workflows/osx_10_15.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: test
         run: ${CI_MAKE} test_osx_github_actions
       - name: artifacts

--- a/.github/workflows/osx_11_0.yml
+++ b/.github/workflows/osx_11_0.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: test
         run: ${CI_MAKE} test_osx_github_actions
       - name: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+      - uses: ./.github/actions/environment
       - name: test
         run: ${CI_MAKE} test_debian_no_deps
       - name: artifacts

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: test
         run: ${CI_MAKE} test_asan_debian_no_deps
       - name: artifacts

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -27,6 +27,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+      - uses: ./.github/actions/environment
       - name: test
         env:
           CC: clang

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: test
         env:
           CMAKE_EXTRA_PARAMS: -DENABLE_LTO=ON

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: test
         env:
           CC: clang-11

--- a/.github/workflows/ubuntu_14_04.yml
+++ b/.github/workflows/ubuntu_14_04.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: packaging
         env:
           # Our testing expects that the init process (PID 1) will

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: packaging
         env:
           # Our testing expects that the init process (PID 1) will

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: packaging
         env:
           # Our testing expects that the init process (PID 1) will

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: packaging
         env:
           # Our testing expects that the init process (PID 1) will


### PR DESCRIPTION
After commit ['test: update test-run (pass timeouts via env)'](https://github.com/tarantool/tarantool/commit/a598f3f5f73133d56b9e1782cda4a9051bf60af2)
The following variables added to github actions with testing:
```
  REPLICATION_SYNC_TIMEOUT
  TEST_TIMEOUT
  NO_OUTPUT_TIMEOUT
```
and cumulative variable to pass environment to pack/deploy jobs:
```
  PRESERVE_ENVVARS=REPLICATION_SYNC_TIMEOUT,TEST_TIMEOUT,NO_OUTPUT_TIMEOUT
```
These variables added within newly added local action:
```
  .github/actions/environment
```
Patch really works - it can be seen that [environment variables were successfully set](https://github.com/tarantool/tarantool/pull/5785/checks?check_run_id=1828857435#step:5:3685)