### PR TITLE
github-ci: add link to log in Telegram message

### DIFF
--- a/.github/actions/send-telegram-notify/action.yml
+++ b/.github/actions/send-telegram-notify/action.yml
@@ -22,10 +22,18 @@ runs:
         fi
         echo BRANCH_NAME=$branch_name | tee -a $GITHUB_ENV
       shell: bash
+    # get job id number
+    - run: |
+        apt update && apt install -y jq
+        echo 'JOB_ID<<EOF' >> $GITHUB_ENV
+        curl -s https://api.github.com/repos/tarantool/tarantool/actions/runs/${{ github.run_id }}/jobs | jq -r '.jobs[0].id' | tee -a $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+      shell: bash
     - env:
         MSG: |
           🔴 Workflow testing failed:
           Job: [ `${{ github.job }}`](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          Log: [ `#${{ env.JOB_ID }}`](https://github.com/${{ github.repository }}/runs/${{ env.JOB_ID }})
           Commit: [ `${{ github.sha }}`](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
           Branch: [ `${{ env.BRANCH_NAME }}`](https://github.com/${{ github.repository }}/tree/${{ env.BRANCH_NAME }})
           History: [commits](https://github.com/${{ github.repository }}/commits/${{ github.sha }})

--- a/.github/actions/send-telegram-notify/action.yml
+++ b/.github/actions/send-telegram-notify/action.yml
@@ -22,6 +22,12 @@ runs:
         fi
         echo BRANCH_NAME=$branch_name | tee -a $GITHUB_ENV
       shell: bash
+    # get host kernel name
+    - run: |
+        echo 'KERNEL_NAME<<EOF' >> $GITHUB_ENV
+        uname -s | tee -a $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+      shell: bash
     # get job id number
     - run: |
         apt update && apt install -y jq
@@ -40,14 +46,19 @@ runs:
           Triggered on: `${{ github.event_name }}`
           Committer: `${{ github.actor }}`
           ```
-          -------------------- Commit message --------------------------
+          ---------------- Commit message -------------------
           ${{ github.event.head_commit.message }}
           ```
       run: |
-        # convert message from multi lines to single line
-        msg="${MSG//$'\n'/'\n'}"
+        # convert message from multi lines to single line and
         # add backslashes to single quote marks in message
-        msg="${msg//$'\''/\\\'}"
+        if ${{ env.KERNEL_NAME == 'Darwin' }} ; then
+          msg="${MSG//$'\n'/\n}"
+          msg="${msg//$'\\\''/\'}"
+        else
+          msg="${MSG//$'\n'/'\n'}"
+          msg="${msg//$'\''/\\\'}"
+        fi
         echo "Sending message: $msg"
         # select target channel
         send_to=$TELEGRAM_TO


### PR DESCRIPTION
1. github-ci: correct Telegram message for OSX
  The processing of the message to be sent via Telegram is separated for
  OSX and other platforms for two reasons:
   * there is no need to wrap newline symbol with a single quote marks
   * backslashes used in the message haven't to be escaped

2. github-ci: add link to log in Telegram message
  The link to the failed job log is not saved in other GitHub Actions
  links. At the same time this link can be obtained via the following
  command using GitHub API:
      
    $ curl -s https://api.github.com/repos/tarantool/tarantool/actions/runs/${{  github.run_id }}/jobs | jq -r '.jobs[0].html_url'

    The obtained link for the particular run has the following format:
    https://github.com/tarantool/tarantool/runs/<id\>, where 'id' is the
    number of the job.
  
    This link is added to the Telegram message for the failed job which ID
    is set as suggested in GitHub [docs](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#example-6).