### PR TITLE
github-ci: move more jobs from gitlab-ci 1.10

### DIFF
--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: centos-7
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: centos-8
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: debian-buster
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: debian-bullseye
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: debian-stretch
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -1,0 +1,46 @@
+name: default_gcc_centos_7
+
+on: [push, pull_request]
+
+env:
+  CI_MAKE: make -f .travis.mk
+
+jobs:
+  default_gcc_centos_7:
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: test
+        env:
+          # Our testing expects that the init process (PID 1) will
+          # reap orphan processes. At least the following test leans
+          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
+          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '--init -e CC=/usr/bin/gcc -e CXX=/usr/bin/g++'
+        run: OS=el DIST=7 ${CI_MAKE} package
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: default_gcc_centos_7
+          retention-days: 21
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/fedora_28.yml
+++ b/.github/workflows/fedora_28.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: fedora-28
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/fedora_29.yml
+++ b/.github/workflows/fedora_29.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: fedora-29
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/fedora_30.yml
+++ b/.github/workflows/fedora_30.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: fedora-30
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/fedora_31.yml
+++ b/.github/workflows/fedora_31.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: fedora-31
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/fedora_32.yml
+++ b/.github/workflows/fedora_32.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: fedora-32
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/fedora_33.yml
+++ b/.github/workflows/fedora_33.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: fedora-33
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: opensuse-leap-15.1
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: opensuse-leap-15.2
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/osx_10_15.yml
+++ b/.github/workflows/osx_10_15.yml
@@ -38,4 +38,4 @@ jobs:
         with:
           name: osx_10_15
           retention-days: 21
-          path: test/var/artifacts
+          path: /tmp/tnt/artifacts

--- a/.github/workflows/osx_10_15_lto.yml
+++ b/.github/workflows/osx_10_15_lto.yml
@@ -1,0 +1,43 @@
+name: osx_10_15_lto
+
+on: [push, pull_request]
+
+env:
+  CI_MAKE: make -f .travis.mk
+
+jobs:
+  osx_10_15_lto:
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
+
+    runs-on: macos-10.15
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: test
+        env:
+          CMAKE_EXTRA_PARAMS: -DENABLE_LTO=ON
+        run: ${CI_MAKE} test_osx_github_actions
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: osx_10_15_lto
+          retention-days: 21
+          path: /tmp/tnt/artifacts

--- a/.github/workflows/osx_11_0.yml
+++ b/.github/workflows/osx_11_0.yml
@@ -38,4 +38,4 @@ jobs:
         with:
           name: osx_11_0
           retention-days: 21
-          path: test/var/artifacts
+          path: /tmp/tnt/artifacts

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -1,0 +1,46 @@
+name: static_build
+
+on: [push, pull_request]
+
+env:
+  CI_MAKE: make -f .travis.mk
+
+jobs:
+  static_build:
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    # image built by .gitlab.mk instructions and targets from .travis.mk
+    container:
+      image: docker.io/tarantool/testing:debian-stretch
+      # Our testing expects that the init process (PID 1) will
+      # reap orphan processes. At least the following test leans
+      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
+      options: '--init'
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: ./.github/actions/environment
+      - name: test
+        run: ${CI_MAKE} test_static_build
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: static_build
+          retention-days: 21
+          path: test/var/artifacts

--- a/.github/workflows/static_docker_build.yml
+++ b/.github/workflows/static_docker_build.yml
@@ -1,0 +1,41 @@
+name: static_docker_build
+
+on: [push, pull_request]
+
+env:
+  CI_MAKE: make -f .travis.mk
+
+jobs:
+  static_docker_build:
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: test
+        run: ${CI_MAKE} test_static_docker_build
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: static_docker_build
+          retention-days: 21
+          path: artifacts

--- a/.github/workflows/ubuntu_14_04.yml
+++ b/.github/workflows/ubuntu_14_04.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: ubuntu-trusty
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: ubuntu-xenial
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: ubuntu-bionic
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           name: ubuntu-focal
           retention-days: 21
-          path: test/var/artifacts
+          path: build/usr/src/*/tarantool-*/test/var/artifacts

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,13 +121,6 @@ osx_14_release:
     - osx_14
   <<: *osx_definition
 
-osx_15_release_lto:
-  tags:
-    - osx_15
-  variables:
-    CMAKE_EXTRA_PARAMS: -DENABLE_LTO=ON
-  <<: *osx_definition
-
 freebsd_12_release:
   <<: *vbox_definition
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,12 +51,6 @@ before_script:
   after_script:
     - cp -r test/var/artifacts .
 
-.pack_only_template: &pack_only_definition
-  except:
-    - "1.10"
-    - tags
-    - /^.*-notest$/
-
 .perf_only_template: &perf_only_definition
   only:
     - "1.10"
@@ -76,28 +70,6 @@ before_script:
   stage: test
   tags:
     - docker_test
-
-.pack_artifacts_files_template: &pack_artifacts_files_definition
-  <<: *artifacts_files_definition
-  after_script:
-    - cp -r build/usr/src/*/tarantool-*/test/var/artifacts .
-
-.pack_template: &pack_definition
-  <<: *pack_only_definition
-  stage: test
-  tags:
-    - deploy
-  script:
-    - ${GITLAB_MAKE} package
-
-.pack_test_template: &pack_test_definition
-  <<: *pack_only_definition
-  <<: *pack_artifacts_files_definition
-  stage: test
-  tags:
-    - deploy_test
-  script:
-    - ${GITLAB_MAKE} package
 
 .osx_template: &osx_definition
   <<: *artifacts_files_definition
@@ -168,13 +140,6 @@ freebsd_12_release:
   script:
     - ${GITLAB_MAKE} vms_start
     - ${GITLAB_MAKE} vms_test_freebsd_no_deps
-
-default_gcc_centos_7:
-  <<: *pack_test_definition
-  variables:
-    PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '-e CC=/usr/bin/gcc -e CXX=/usr/bin/g++'
-    OS: 'el'
-    DIST: '7'
 
 # ####
 # Perf

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -225,12 +225,3 @@ remove_images_sh9:
   <<: *perf_cleanup_definition
   tags:
     - sh9_shell
-
-# Static builds
-
-static_docker_build:
-  <<: *osx_definition
-  tags:
-    - deploy_test
-  script:
-    - ${GITLAB_MAKE} test_static_docker_build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -228,11 +228,6 @@ remove_images_sh9:
 
 # Static builds
 
-static_build:
-  <<: *docker_test_definition
-  script:
-    - ${GITLAB_MAKE} test_static_build
-
 static_docker_build:
   <<: *osx_definition
   tags:

--- a/.travis.mk
+++ b/.travis.mk
@@ -194,7 +194,11 @@ test_static_build: deps_debian_static
 	CMAKE_EXTRA_PARAMS=-DBUILD_STATIC=ON make -f .travis.mk test_debian_no_deps
 
 test_static_docker_build:
-	docker build --no-cache --network=host --build-arg RUN_TESTS=ON -f Dockerfile.staticbuild .
+	docker build --no-cache --network=host -f Dockerfile.staticbuild -t static_build:tmp .
+	docker run --rm -v ${PWD}/artifacts:/tarantool/test/var/artifacts static_build:tmp \
+		-c "set -x && cd /tarantool/test && \
+		        /usr/bin/python test-run.py --force box/admin || \
+		        ( chmod -R a+rwx var/artifacts ; exit 1 )"
 
 #######
 # OSX #


### PR DESCRIPTION
1. Artifacts paths for pack/deploy/osx based jobs corrected.

2. Moved from gitlab-ci to github-ci 'default_gcc_centos_7' job for
building/testing Tarantool on default GCC installed in CentOS 7.
Removed not used after movement templates from gitlab-ci config.

3. Moved from gitlab-ci to github-ci 'osx_10_15_lto' job for
building/testing Tarantool on OSX with LTO.

4. Moved from gitlab-ci to github-ci 'static_build' job for
building/testing Tarantool using build flag 'BUILD_STATIC=ON'.

5. Moved from gitlab-ci to github-ci 'static_docker_build' job for
building/testing Tarantool based on local 'Dockerfile.staticbuild'
docker build file. Set testing in make file instead of use from
docker file due to not possible to pass artifacts from it, check [1].
    
[1] - https://stackoverflow.com/questions/57339971/docker-copy-file-out-of-container-while-building-it