### PR TITLE
github-ci: add jepsen* test jobs

### DIFF
--- a/.github/workflows/jepsen-cluster-txm.yml
+++ b/.github/workflows/jepsen-cluster-txm.yml
@@ -1,0 +1,53 @@
+name: jepsen-cluster-txm
+
+on:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
+
+env:
+  CI_MAKE: make -f .travis.mk
+
+jobs:
+  jepsen-cluster-txm:
+    if: github.event_name == 'repository_dispatch' ||
+        github.event_name == 'workflow_dispatch'
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    # image built by .gitlab.mk instructions and targets from .travis.mk
+    container:
+      image: docker.io/tarantool/testing:debian-stretch
+      ports:
+        # Opens tcp port 2222 on the host for internal SSH port
+        - 2222:22
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: long_test
+        env:
+          TF_VAR_keypair_name: ${{ secrets.TF_VAR_keypair_name }}
+          TF_VAR_password: ${{ secrets.TF_VAR_password }}
+          TF_VAR_tenant_id: ${{ secrets.TF_VAR_tenant_id }}
+          TF_VAR_user_domain_id: ${{ secrets.TF_VAR_user_domain_id }}
+          TF_VAR_user_name: ${{ secrets.TF_VAR_user_name }}
+          TF_VAR_ssh_key: ${{ secrets.TF_VAR_ssh_key }}
+          LEIN_OPT: '--nemesis standard --mvcc'
+          INSTANCE_COUNT: '5'
+        run: ${CI_MAKE} test_jepsen
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: jepsen-cluster-txm
+          retention-days: 21
+          path: jepsen-tests-prefix/src/jepsen-tests/store

--- a/.github/workflows/jepsen-cluster.yml
+++ b/.github/workflows/jepsen-cluster.yml
@@ -1,0 +1,53 @@
+name: jepsen-cluster
+
+on:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
+
+env:
+  CI_MAKE: make -f .travis.mk
+
+jobs:
+  jepsen-cluster:
+    if: github.event_name == 'repository_dispatch' ||
+        github.event_name == 'workflow_dispatch'
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    # image built by .gitlab.mk instructions and targets from .travis.mk
+    container:
+      image: docker.io/tarantool/testing:debian-stretch
+      ports:
+        # Opens tcp port 2222 on the host for internal SSH port
+        - 2222:22
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: long_test
+        env:
+          TF_VAR_keypair_name: ${{ secrets.TF_VAR_keypair_name }}
+          TF_VAR_password: ${{ secrets.TF_VAR_password }}
+          TF_VAR_tenant_id: ${{ secrets.TF_VAR_tenant_id }}
+          TF_VAR_user_domain_id: ${{ secrets.TF_VAR_user_domain_id }}
+          TF_VAR_user_name: ${{ secrets.TF_VAR_user_name }}
+          TF_VAR_ssh_key: ${{ secrets.TF_VAR_ssh_key }}
+          LEIN_OPT: '--nemesis standard'
+          INSTANCE_COUNT: '5'
+        run: ${CI_MAKE} test_jepsen
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: jepsen-cluster
+          retention-days: 21
+          path: jepsen-tests-prefix/src/jepsen-tests/store

--- a/.github/workflows/jepsen-single-instance-txm.yml
+++ b/.github/workflows/jepsen-single-instance-txm.yml
@@ -1,0 +1,59 @@
+name: jepsen-single-instance-txm
+
+on:
+  push:
+    tags:
+      - '*'
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 */3 * * *'
+
+env:
+  CI_MAKE: make -f .travis.mk
+
+jobs:
+  jepsen-single-instance-txm:
+    if: github.event_name == 'push'
+        github.event_name == 'repository_dispatch' ||
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'schedule'
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    # image built by .gitlab.mk instructions and targets from .travis.mk
+    container:
+      image: docker.io/tarantool/testing:debian-stretch
+      ports:
+        # Opens tcp port 2222 on the host for internal SSH port
+        - 2222:22
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: long_test
+        env:
+          TF_VAR_keypair_name: ${{ secrets.TF_VAR_keypair_name }}
+          TF_VAR_password: ${{ secrets.TF_VAR_password }}
+          TF_VAR_tenant_id: ${{ secrets.TF_VAR_tenant_id }}
+          TF_VAR_user_domain_id: ${{ secrets.TF_VAR_user_domain_id }}
+          TF_VAR_user_name: ${{ secrets.TF_VAR_user_name }}
+          TF_VAR_ssh_key: ${{ secrets.TF_VAR_ssh_key }}
+          LEIN_OPT: '--nemesis standard --mvcc'
+        run: ${CI_MAKE} test_jepsen
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: jepsen-single-instance-txm
+          retention-days: 21
+          path: jepsen-tests-prefix/src/jepsen-tests/store

--- a/.github/workflows/jepsen-single-instance.yml
+++ b/.github/workflows/jepsen-single-instance.yml
@@ -1,0 +1,59 @@
+name: jepsen-single-instance
+
+on:
+  push:
+    tags:
+      - '*'
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 */3 * * *'
+
+env:
+  CI_MAKE: make -f .travis.mk
+
+jobs:
+  jepsen-single-instance:
+    if: github.event_name == 'push'
+        github.event_name == 'repository_dispatch' ||
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'schedule'
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    # image built by .gitlab.mk instructions and targets from .travis.mk
+    container:
+      image: docker.io/tarantool/testing:debian-stretch
+      ports:
+        # Opens tcp port 2222 on the host for internal SSH port
+        - 2222:22
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: long_test
+        env:
+          TF_VAR_keypair_name: ${{ secrets.TF_VAR_keypair_name }}
+          TF_VAR_password: ${{ secrets.TF_VAR_password }}
+          TF_VAR_tenant_id: ${{ secrets.TF_VAR_tenant_id }}
+          TF_VAR_user_domain_id: ${{ secrets.TF_VAR_user_domain_id }}
+          TF_VAR_user_name: ${{ secrets.TF_VAR_user_name }}
+          TF_VAR_ssh_key: ${{ secrets.TF_VAR_ssh_key }}
+          LEIN_OPT: '--nemesis standard'
+        run: ${CI_MAKE} test_jepsen
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: jepsen-single-instance
+          retention-days: 21
+          path: jepsen-tests-prefix/src/jepsen-tests/store

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,5 @@
 stages:
-  - static_analysis
   - test
-  - long_tests
   - perf
   - cleanup
 
@@ -115,58 +113,12 @@ before_script:
   script:
     - ${GITLAB_MAKE} perf_cleanup
 
-.jepsen_test_definition: &jepsen_test_definition
-  <<: *docker_test_definition
-  script:
-    - ${GITLAB_MAKE} test_jepsen
-  stage: long_tests
-  tags:
-    - mcs_jepsen_docker
-  artifacts:
-    paths:
-      - jepsen-tests-prefix/src/jepsen-tests/store
-    expire_in: 6 month
-
-# Static Analysis
-
-luacheck:
-  <<: *docker_test_definition
-  stage: static_analysis
-  tags:
-    - deploy_test
-  script:
-    - ${GITLAB_MAKE} test_debian_docker_luacheck
-
 # Tests
 
 osx_14_release:
   tags:
     - osx_14
   <<: *osx_definition
-
-jepsen-single-instance:
-  <<: *jepsen_test_definition
-  variables:
-    LEIN_OPT: '--nemesis standard'
-
-jepsen-single-instance-txm:
-  <<: *jepsen_test_definition
-  variables:
-    LEIN_OPT: '--nemesis standard --mvcc'
-
-jepsen-cluster:
-  <<: *jepsen_test_definition
-  when: manual
-  variables:
-    LEIN_OPT: '--nemesis standard'
-    INSTANCE_COUNT: '5'
-
-jepsen-cluster-txm:
-  <<: *jepsen_test_definition
-  when: manual
-  variables:
-    LEIN_OPT: '--nemesis standard --mvcc'
-    INSTANCE_COUNT: '5'
 
 # ####
 # Perf

--- a/.travis.mk
+++ b/.travis.mk
@@ -402,5 +402,9 @@ test_freebsd: deps_freebsd test_freebsd_no_deps
 # ###################
 
 test_jepsen: deps_debian_jepsen
+	# Jepsen build uses git commands internally, like command
+	# 'git stash --all' which fails w/o git configuration setup
+	git config --get user.name || git config --global user.name "Nodody User"
+	git config --get user.email || git config --global user.email "nobody@nowhere.com"
 	cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_WERROR=ON -DWITH_JEPSEN=ON
 	make run-jepsen

--- a/tools/run-jepsen-tests.sh
+++ b/tools/run-jepsen-tests.sh
@@ -15,24 +15,45 @@
 
 set -Eeo pipefail
 
+function usage {
+    echo "Usage: $0 <PROJECT_SOURCE_DIR> <PROJECT_BINARY_DIR>"
+    echo "Options:"
+    echo "  PROJECT_SOURCE_DIR - path with project sources"
+    echo "  PROJECT_BINARY_DIR - path to build the project"
+    echo "Mandatory environment:"
+    echo "  TF_VAR_ssh_key - SSH private key to reach the testing nodes"
+    echo "  TF_VAR_keypair_name - key pair name used by Terraform"
+    echo "  TF_VAR_user_name - user name used by Terraform to reach the testing nodes"
+    echo "  TF_VAR_password - password used by Terraform"
+    echo "  TF_VAR_tenant_id - tenant ID used by Terraform"
+    echo "  TF_VAR_user_domain_id - users domain ID used by Terraform"
+    echo "Optional environment:"
+    echo "  LEIN_OPT - Jepsen tests additional options, ex. '--nemesis standard', default is empty"
+    echo "  INSTANCE_COUNT - number of nodes to be tested, default is '1'"
+    exit 1
+}
+
+################################################
+# check script startup environment and options #
+################################################
+
+# get mandatory options from script run command
 PROJECT_SOURCE_DIR=$1
 PROJECT_BINARY_DIR=$2
+[[ -z ${PROJECT_SOURCE_DIR} ]] && (echo "Please specify path to a project source directory"; usage)
+[[ -z ${PROJECT_BINARY_DIR} ]] && (echo "Please specify path to a project binary directory"; usage)
 
-TESTS_DIR="$PROJECT_BINARY_DIR/jepsen-tests-prefix/src/jepsen-tests/"
-TERRAFORM_CONFIG="$PROJECT_SOURCE_DIR/extra/tf"
-TERRAFORM_STATE="$PROJECT_BINARY_DIR/terraform.tfstate"
-SSH_KEY_FILENAME="$PROJECT_SOURCE_DIR/build/tf-cloud-init"
-NODES_FILENAME="$PROJECT_SOURCE_DIR/build/nodes"
+# check if mandatory variables were set in environment
+[[ -z ${TF_VAR_ssh_key} ]] && (echo "Please specify TF_VAR_ssh_key env var"; usage)
+[[ -z ${TF_VAR_keypair_name} ]] && (echo "Please specify TF_VAR_keypair_name env var"; usage)
 
-CI_COMMIT_SHA=$(git rev-parse HEAD)
+# check if mandatory variables were provided even by CI
+[[ -z ${TF_VAR_user_name} ]] && (echo "Please specify TF_VAR_user_name env var"; usage)
+[[ -z ${TF_VAR_password} ]] && (echo "Please specify TF_VAR_password env var"; usage)
+[[ -z ${TF_VAR_tenant_id} ]] && (echo "Please specify TF_VAR_tenant_id env var"; usage)
+[[ -z ${TF_VAR_user_domain_id} ]] && (echo "Please specify TF_VAR_user_domain_id env var"; usage)
 
-LEIN_OPTIONS="test-all --nodes-file $NODES_FILENAME --username ubuntu $LEIN_OPT --version $CI_COMMIT_SHA"
-
-[[ -z ${PROJECT_SOURCE_DIR} ]] && (echo "Please specify path to a project source directory"; exit 1)
-[[ -z ${PROJECT_BINARY_DIR} ]] && (echo "Please specify path to a project binary directory"; exit 1)
-[[ -z ${TF_VAR_ssh_key} ]] && (echo "Please specify TF_VAR_ssh_key env var"; exit 1)
-[[ -z ${TF_VAR_keypair_name} ]] && (echo "Please specify TF_VAR_keypair_name env var"; exit 1)
-
+# check existance of tools and setup its paths
 TERRAFORM_BIN=$(which terraform)
 LEIN_BIN=$(which lein)
 CLOJURE_BIN=$(which clojure)
@@ -41,39 +62,93 @@ CLOJURE_BIN=$(which clojure)
 [[ -z ${LEIN_BIN} ]] && (echo "lein is not installed"; exit 1)
 [[ -z ${CLOJURE_BIN} ]] && (echo "clojure is not installed"; exit 1)
 
+################################
+# make script run preparations #
+################################
+
+# setup files paths
+BUILD_DIR="$PROJECT_SOURCE_DIR/build"
+TESTS_DIR="$PROJECT_BINARY_DIR/jepsen-tests-prefix/src/jepsen-tests/"
+TERRAFORM_CONFIG="$PROJECT_SOURCE_DIR/extra/tf"
+TERRAFORM_STATE="$PROJECT_BINARY_DIR/terraform.tfstate"
+SSH_KEY_FILENAME="$HOME/.ssh/id_rsa"
+NODES_FILENAME="$BUILD_DIR/nodes"
+
+# build directory should be prepared before use
+[[ -d $BUILD_DIR ]] || mkdir -p $BUILD_DIR
+
+# git must initialized before use even to any unknown user
+CI_COMMIT_SHA=$(git rev-parse HEAD)
+
+# setup cleanup routine, which removes testing nodes by Terraform
 function cleanup {
-    echo "cleanup"
+    echo "Cleanup running ..."
     rm -f $NODES_FILENAME $SSH_KEY_FILENAME
     [[ -e $TERRAFORM_STATE ]] && \
 	terraform destroy -state=$TERRAFORM_STATE -auto-approve $TERRAFORM_CONFIG
 }
 
+# set signal handler on script interrupts
 trap "{ cleanup; exit 255; }" SIGINT SIGTERM ERR
 
-echo -e "${TF_VAR_ssh_key//_/\\n}" > $SSH_KEY_FILENAME
-chmod 400 $SSH_KEY_FILENAME
-$(pgrep ssh-agent 2>&1 > /dev/null) || eval "$(ssh-agent)"
-ssh-add $SSH_KEY_FILENAME
+# setup SSH home path with needed files
+[[ -d $HOME/.ssh ]] || mkdir -p $HOME/.ssh
+chmod 700 $HOME/.ssh
 
-if [[ -z ${CI_JOB_ID} ]]; then
+# remove extra spaces from TF_VAR_ssh_key key at the end of lines
+SSH_KEY=$(echo -e "$TF_VAR_ssh_key" | sed 's# *$##g')
+
+# Create file with SSH private key, add it to SSH agent and
+# setup Terraform mandatory TF_VAR_ssh_key_path with its name.
+echo -e "${SSH_KEY//_/\\n}" >$SSH_KEY_FILENAME
+chmod 600 $SSH_KEY_FILENAME
+# reinitialize SSH agent
+eval "$(ssh-agent -s)"
+ssh-add $SSH_KEY_FILENAME
+# check that SSH key added
+ssh-add -l
+export TF_VAR_ssh_key_path=$SSH_KEY_FILENAME
+export TF_VAR_ssh_key=$(cat $SSH_KEY_FILENAME)
+
+# setup Terraform mandatory TF_VAR_id variable to run the nodes
+if [[ -n ${CI_JOB_ID} ]]; then
     TF_VAR_id=$CI_JOB_ID
 else
     RANDOM_ID=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13; echo '')
     TF_VAR_id=TF-$RANDOM_ID
 fi
-
 export TF_VAR_id
-export TF_VAR_ssh_key_path=$SSH_KEY_FILENAME
+
+# setup Terraform mandatory TF_VAR_instance_count with nodes number
 [[ -z ${INSTANCE_COUNT} ]] && TF_VAR_instance_count=1 || TF_VAR_instance_count=$INSTANCE_COUNT
 export TF_VAR_instance_count
 
-[[ -e $HOME/.ssh ]] || (mkdir $HOME/.ssh && touch $HOME/.ssh/known_hosts)
+###########################
+# main part of the script #
+###########################
 
+# 1. initiate Terraform configuration for node setup
 terraform init $TERRAFORM_CONFIG
+
+# 2. setup node and create its configuration in $TERRAFORM_STATE file
 terraform apply -state=$TERRAFORM_STATE -auto-approve $TERRAFORM_CONFIG
+
+# 3. print the schemas of the providers used in the configuration
 terraform providers $TERRAFORM_CONFIG
+
+# 4. read an output variable from a Terraform state file and print the value
 terraform output -state=$TERRAFORM_STATE instance_names
+
+# 5. get IP of the node from Terraform state file
 terraform output -state=$TERRAFORM_STATE -json instance_ips | jq --raw-output '.[]' > $NODES_FILENAME
-pushd $TESTS_DIR && lein run $LEIN_OPTIONS
-popd
+
+# 6. add nodes to SSH known hosts and check that they are reachable by SSH
+for node in $(cat $NODES_FILENAME) ; do
+    ssh -vvv -o "StrictHostKeyChecking=no" -o "BatchMode=yes" -i $SSH_KEY_FILENAME ubuntu@$node hostname
+done
+
+# 7. run Jepsen tests
+( cd $TESTS_DIR && lein run test-all --nodes-file $NODES_FILENAME --username ubuntu $LEIN_OPT --version $CI_COMMIT_SHA )
+
+# post script cleanup
 cleanup


### PR DESCRIPTION
Moved from gitlab-ci to github-ci 'jepsen*' jobs for
testing Tarantool with long Jepsen tests.
    
Closes tarantool/tarantool-qa#79

Found issues and resolved:
    
- Added '$PROJECT_BINARY_DIR/build/' path creation before use.
    
- Set always ssh-agent restart before add new SSH key, because
  found that in some situations it may fail to add w/o it.
    
- Found mistake in TF_VAR_id variable setup, inverted ${CI_JOB_ID}
  variable check for it.
    
Also made improvements in script:
    
- Added all needed checks for all externally set mandatory variables.
    
- Added usage message with the list of mandatory and optional variables.
    
- Added comments to all script steps.
    
- Added step with checking nodes that they are reachable by SSH.

Found issue:
```
      root@hpalx:/source# make run-jepsen
      [  0%] Performing update step for 'jepsen-tests'
    
      *** Please tell me who you are.
    
      Run
    
        git config --global user.email "you@example.com"
        git config --global user.name "Your Name"
    
      to set your account's default identity.
      Omit --global to set the identity only in this repository.
    
      fatal: unable to auto-detect email address (got 'root@hpalx.(none)')
      Cannot save the current index state
      CMake Error at /source/jepsen-tests-prefix/tmp/jepsen-tests-gitupdate.cmake:83 (message):
        Failed to stash changes
    
      CMakeFiles/jepsen-tests.dir/build.make:95: recipe for target 'jepsen-tests-prefix/src/jepsen-tests-stamp/jepsen-tests-update' failed
```    
added 'Nobody' User setup to git configuration if needed.
