### PR TITLE
github-ci: port from gitlab-ci FreeBSD 12 build

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,0 +1,46 @@
+name: freebsd
+
+on: [push, pull_request]
+
+env:
+  CI_MAKE: make -f .gitlab.mk
+
+jobs:
+  freebsd:
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository
+
+    runs-on: freebsd-sh
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: set PATH to GIT of the newer version 2.9.0
+        run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
+      - uses: actions/checkout@v1
+      - uses: ./.github/actions/environment
+      - name: test
+        env:
+          VMS_NAME: 'freebsd_12'
+          VMS_USER: 'vagrant'
+          VMS_PORT: '2232'
+          MAKE: 'gmake'
+        run: |
+          ${CI_MAKE} vms_start
+          ${CI_MAKE} vms_test_freebsd_no_deps
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: freebsd
+          retention-days: 21
+          path: test/var/artifacts

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -144,19 +144,6 @@ osx_14_release:
     - osx_14
   <<: *osx_definition
 
-freebsd_12_release:
-  <<: *vbox_definition
-  tags:
-    - vms_freebsd_12
-  variables:
-    VMS_NAME: 'freebsd_12'
-    VMS_USER: 'vagrant'
-    VMS_PORT: '2232'
-    MAKE: 'gmake'
-  script:
-    - ${GITLAB_MAKE} vms_start
-    - ${GITLAB_MAKE} vms_test_freebsd_no_deps
-
 jepsen-single-instance:
   <<: *jepsen_test_definition
   variables:


### PR DESCRIPTION
Ported from gitlab-ci FreeBSD 12 build as a standalone Github
Actions workflow. Used sh4/sh8 local hosts as self-runners with
label 'freebsd-sh'. These hosts based on CentOS 7 with FreeBSD
12.1 installed in VBox VM. It was tried to use runners from
Github Actions which based on OSX, but failed to build FreeBSD 12
there, created additional issue to investigate the issue [1].

Closes #5754

[1]: https://github.com/tarantool/tarantool-qa/issues/81