### PR TITLE
github-ci: port perf jobs from gitlab-ci

### DIFF
--- a/.github/actions/perf/README.md
+++ b/.github/actions/perf/README.md
@@ -1,0 +1,20 @@
+# Prepare docker image with benchmarks and run testings using it
+
+Action prepares 2 images:
+
+- perf_master - image with benchmarks installed, changing very rare
+- perf_'<commit_sha>' - image with Tanatool installed and benchmarks built with Tarantool headers
+
+## How to use Github Action from Github workflow
+
+Add the following code to the running steps after checkout done:
+```
+  - name test
+    env:
+      BENCH: '<sysbench;tpcc;nosqlbench;ycsb>' # anyone benchmark from the list
+      ARGS: '<tree;hash>' # anyone argument for the benchmark
+      DOCKER_RUN_ARGS: '--memory=3g' # any docker options to run docker on testing
+      IMAGE_SUFFIX: '_tpch' # any suffix like is used for TPC-H testing
+    uses: ./.github/actions/perf
+```
+

--- a/.github/actions/perf/action.yml
+++ b/.github/actions/perf/action.yml
@@ -1,0 +1,40 @@
+name: 'Prepare docker image with benchmarks and run testing in it'
+description: 'Prepare docker image with benchmarks and run testing in it'
+
+runs:
+  using: "composite"
+  steps:
+    # get host name
+    - run: |
+        echo 'HOSTNAME<<EOF' >> $GITHUB_ENV
+        hostname | tee -a $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+      shell: bash
+    - name: test
+      env:
+        CI_MAKE: make -f .gitlab.mk
+        IMAGE_PERF: registry.gitlab.com/tarantool/tarantool/perf/ubuntu-bionic:perf_master
+        IMAGE_PERF_BUILT: ubuntu-bionic:perf_${{ github.sha }}
+        DOCKER_NETWORK_ARG: --network=host
+        DOCKER_RUN_ARGS: ${DOCKER_NETWORK_ARG} ${{ env.DOCKER_RUN_ARGS }}
+      run: |
+          set -x
+          ${CI_MAKE} perf_clone_benchs_repo
+          docker build ${DOCKER_NETWORK_ARG} \
+            --add-host ${{ env.HOSTNAME }}:127.0.0.1 \
+            -t ${IMAGE_PERF} \
+            -f bench-run/dockerfiles/ubuntu_benchs .
+          docker build ${DOCKER_NETWORK_ARG} \
+            --build-arg image_from=${IMAGE_PERF} \
+            --no-cache \
+            -t ${IMAGE_PERF_BUILT}${{ env.IMAGE_SUFFIX }} \
+            -f bench-run/dockerfiles/ubuntu_tnt${{ env.IMAGE_SUFFIX }} .
+          docker run ${{ env.DOCKER_RUN_ARGS }} \
+            --privileged \
+            --cpuset-cpus='6-11' \
+            -v ${PWD}:/source \
+            -w /source \
+            -i ${IMAGE_PERF_BUILT}${{ env.IMAGE_SUFFIX }} \
+            /opt/bench-run/benchs/${BENCH}/run.sh ${ARG}
+          ${CI_MAKE} perf_cleanup_image
+      shell: bash

--- a/.github/actions/send-telegram-notify/action.yml
+++ b/.github/actions/send-telegram-notify/action.yml
@@ -5,8 +5,8 @@ runs:
   steps:
     # install 'requests' Python module
     - run: |
-        python -m pip install --upgrade pip
-        pip install requests
+        python -m pip install --upgrade pip ||:
+        pip install requests ||:
       shell: bash
     # logout github environment
     - env:
@@ -30,7 +30,8 @@ runs:
       shell: bash
     # get job id number
     - run: |
-        apt update && apt install -y jq
+        apt update ||:
+        apt install -y jq ||:
         echo 'JOB_ID<<EOF' >> $GITHUB_ENV
         curl -s https://api.github.com/repos/tarantool/tarantool/actions/runs/${{ github.run_id }}/jobs | jq -r '.jobs[0].id' | tee -a $GITHUB_ENV
         echo 'EOF' >> $GITHUB_ENV

--- a/.github/workflows/perf_cbench.yml
+++ b/.github/workflows/perf_cbench.yml
@@ -1,0 +1,47 @@
+name: perf_cbench
+
+on:
+  push:
+    tags:
+      - '*'
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 */3 * * *'
+
+jobs:
+  perf_cbench:
+    if: github.event_name == 'push'
+        github.event_name == 'repository_dispatch' ||
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'schedule'
+
+    runs-on: perf-sh2
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: set PATH to GIT of the newer version 2.9.0
+        run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
+      - uses: actions/checkout@v1
+      - name: test
+        env:
+          BENCH: 'cbench'
+        uses: ./.github/actions/perf
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: perf_cbench
+          retention-days: 21
+          path: |
+            *_result.txt
+            *_t_version.txt

--- a/.github/workflows/perf_linkbench_ssd.yml
+++ b/.github/workflows/perf_linkbench_ssd.yml
@@ -1,0 +1,48 @@
+name: perf_linkbench_ssd
+
+on:
+  push:
+    tags:
+      - '*'
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 */3 * * *'
+
+jobs:
+  perf_linkbench_ssd:
+    if: github.event_name == 'push'
+        github.event_name == 'repository_dispatch' ||
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'schedule'
+
+    runs-on: perf-sh9
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: set PATH to GIT of the newer version 2.9.0
+        run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
+      - uses: actions/checkout@v1
+      - name: test
+        env:
+          BENCH: 'linkbench'
+          DOCKER_RUN_ARGS: '-v /test_ssd/gitlab:/builds --memory=3g --memory-swap=3g'
+        uses: ./.github/actions/perf
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: perf_linkbench_ssd
+          retention-days: 21
+          path: |
+            *_result.txt
+            *_t_version.txt

--- a/.github/workflows/perf_nosqlbench_hash.yml
+++ b/.github/workflows/perf_nosqlbench_hash.yml
@@ -1,0 +1,48 @@
+name: perf_nosqlbench_hash
+
+on:
+  push:
+    tags:
+      - '*'
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 */3 * * *'
+
+jobs:
+  perf_nosqlbench_hash:
+    if: github.event_name == 'push'
+        github.event_name == 'repository_dispatch' ||
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'schedule'
+
+    runs-on: perf-sh1
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: set PATH to GIT of the newer version 2.9.0
+        run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
+      - uses: actions/checkout@v1
+      - name: test
+        env:
+          BENCH: 'nosqlbench'
+          ARG: 'hash'
+        uses: ./.github/actions/perf
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: perf_nosqlbench_hash
+          retention-days: 21
+          path: |
+            *_result.txt
+            *_t_version.txt

--- a/.github/workflows/perf_nosqlbench_tree.yml
+++ b/.github/workflows/perf_nosqlbench_tree.yml
@@ -1,0 +1,48 @@
+name: perf_nosqlbench_tree
+
+on:
+  push:
+    tags:
+      - '*'
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 */3 * * *'
+
+jobs:
+  perf_nosqlbench_tree:
+    if: github.event_name == 'push'
+        github.event_name == 'repository_dispatch' ||
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'schedule'
+
+    runs-on: perf-sh1
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: set PATH to GIT of the newer version 2.9.0
+        run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
+      - uses: actions/checkout@v1
+      - name: test
+        env:
+          BENCH: 'nosqlbench'
+          ARG: 'tree'
+        uses: ./.github/actions/perf
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: perf_nosqlbench_tree
+          retention-days: 21
+          path: |
+            *_result.txt
+            *_t_version.txt

--- a/.github/workflows/perf_sysbench.yml
+++ b/.github/workflows/perf_sysbench.yml
@@ -1,0 +1,47 @@
+name: perf_sysbench
+
+on:
+  push:
+    tags:
+      - '*'
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 */3 * * *'
+
+jobs:
+  perf_sysbench:
+    if: github.event_name == 'push'
+        github.event_name == 'repository_dispatch' ||
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'schedule'
+
+    runs-on: perf-sh3
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: set PATH to GIT of the newer version 2.9.0
+        run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
+      - uses: actions/checkout@v1
+      - name: test
+        env:
+          BENCH: 'sysbench'
+        uses: ./.github/actions/perf
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: perf_sysbench
+          retention-days: 21
+          path: |
+            *_result.txt
+            *_t_version.txt

--- a/.github/workflows/perf_tpcc.yml
+++ b/.github/workflows/perf_tpcc.yml
@@ -1,0 +1,47 @@
+name: perf_tpcc
+
+on:
+  push:
+    tags:
+      - '*'
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 */3 * * *'
+
+jobs:
+  perf_tpcc:
+    if: github.event_name == 'push'
+        github.event_name == 'repository_dispatch' ||
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'schedule'
+
+    runs-on: perf-sh3
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: set PATH to GIT of the newer version 2.9.0
+        run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
+      - uses: actions/checkout@v1
+      - name: test
+        env:
+          BENCH: 'tpcc'
+        uses: ./.github/actions/perf
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: perf_tpcc
+          retention-days: 21
+          path: |
+            *_result.txt
+            *_t_version.txt

--- a/.github/workflows/perf_tpch.yml
+++ b/.github/workflows/perf_tpch.yml
@@ -1,0 +1,49 @@
+name: perf_tpch
+
+on:
+  push:
+    tags:
+      - '*'
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 */3 * * *'
+
+jobs:
+  perf_tpch:
+    if: github.event_name == 'push'
+        github.event_name == 'repository_dispatch' ||
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'schedule'
+
+    runs-on: perf-sh2
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: set PATH to GIT of the newer version 2.9.0
+        run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
+      - uses: actions/checkout@v1
+      - name: test
+        env:
+          BENCH: 'tpch'
+          IMAGE_SUFFIX: '_tpch'
+        uses: ./.github/actions/perf
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: perf_tpch
+          retention-days: 21
+          path: |
+            *_result.txt
+            *_t_version.txt
+            bench-*.csv

--- a/.github/workflows/perf_ycsb_hash.yml
+++ b/.github/workflows/perf_ycsb_hash.yml
@@ -1,0 +1,48 @@
+name: perf_ycsb_hash
+
+on:
+  push:
+    tags:
+      - '*'
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 */3 * * *'
+
+jobs:
+  perf_ycsb_hash:
+    if: github.event_name == 'push'
+        github.event_name == 'repository_dispatch' ||
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'schedule'
+
+    runs-on: perf-sh2
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: set PATH to GIT of the newer version 2.9.0
+        run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
+      - uses: actions/checkout@v1
+      - name: test
+        env:
+          BENCH: 'ycsb'
+          ARG: 'hash'
+        uses: ./.github/actions/perf
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: perf_ycsb_hash
+          retention-days: 21
+          path: |
+            *_result.txt
+            *_t_version.txt

--- a/.github/workflows/perf_ycsb_tree.yml
+++ b/.github/workflows/perf_ycsb_tree.yml
@@ -1,0 +1,48 @@
+name: perf_ycsb_tree
+
+on:
+  push:
+    tags:
+      - '*'
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 */3 * * *'
+
+jobs:
+  perf_ycsb_tree:
+    if: github.event_name == 'push'
+        github.event_name == 'repository_dispatch' ||
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'schedule'
+
+    runs-on: perf-sh2
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: set PATH to GIT of the newer version 2.9.0
+        run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
+      - uses: actions/checkout@v1
+      - name: test
+        env:
+          BENCH: 'ycsb'
+          ARG: 'tree'
+        uses: ./.github/actions/perf
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: perf_ycsb_tree
+          retention-days: 21
+          path: |
+            *_result.txt
+            *_t_version.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,5 @@
 stages:
   - test
-  - perf
-  - cleanup
 
 # 1. Git strategy disabled as shown at:
 #    https://docs.gitlab.com/ee/ci/yaml/README.html#git-strategy
@@ -51,17 +49,6 @@ before_script:
   after_script:
     - cp -r test/var/artifacts .
 
-.perf_only_template: &perf_only_definition
-  only:
-    - master
-    - tags
-    - /^.*-perf$/
-  except:
-    - schedules
-  variables: &perf_vars_definition
-    IMAGE_PERF: "${CI_REGISTRY}/${CI_PROJECT_PATH}/perf/ubuntu-bionic:perf_master"
-    IMAGE_PERF_BUILT: "${CI_REGISTRY}/${CI_PROJECT_PATH}/perf_tmp/ubuntu-bionic:perf_${CI_COMMIT_SHORT_SHA}"
-
 .docker_test_template: &docker_test_definition
   <<: *artifacts_files_definition
   except:
@@ -85,160 +72,9 @@ before_script:
     # "and can’t directly link outside it."
     - cp -rf ${OSX_VARDIR}/artifacts .
 
-.vbox_template: &vbox_definition
-  <<: *artifacts_files_definition
-  except:
-    - /^.*-notest$/
-  stage: test
-  after_script:
-    - >
-      scp -r -P ${VMS_PORT} ${VMS_USER}@127.0.0.1:tarantool/test/var/artifacts . ;
-      ${GITLAB_MAKE} vms_shutdown
-
-.perf_docker_test_template: &perf_docker_test_definition
-  <<: *perf_only_definition
-  image: ${IMAGE_PERF_BUILT}
-  stage: perf
-  artifacts:
-    when: always
-    paths:
-      - "*_result.txt"
-      - "*_t_version.txt"
-  script:
-    - ${GITLAB_MAKE} perf_run
-
-.perf_cleanup_definition: &perf_cleanup_definition
-  <<: *perf_only_definition
-  stage: cleanup
-  script:
-    - ${GITLAB_MAKE} perf_cleanup
-
 # Tests
 
 osx_14_release:
   tags:
     - osx_14
   <<: *osx_definition
-
-# ####
-# Perf
-# ####
-
-# Pre-testing part
-
-perf_bootstrap:
-  <<: *perf_only_definition
-  stage: test
-  tags:
-    - deploy
-  script:
-    - ${GITLAB_MAKE} perf_prepare
-  after_script:
-    - ${GITLAB_MAKE} perf_cleanup_image
-
-# Testing part
-
-perf_tpch:
-  <<: *perf_docker_test_definition
-  tags:
-    - docker_sh2_perf
-  image: ${IMAGE_PERF_BUILT}_tpch
-  variables:
-    <<: *perf_vars_definition
-    BENCH: 'tpch'
-  artifacts:
-    when: always
-    paths:
-      - "bench-*.csv"
-      - "*_t_version.txt"
-      - "*_result.txt"
-
-perf_sysbench:
-  <<: *perf_docker_test_definition
-  tags:
-    - docker_sh3_perf
-  variables:
-    <<: *perf_vars_definition
-    BENCH: 'sysbench'
-
-perf_tpcc:
-  <<: *perf_docker_test_definition
-  tags:
-    - docker_sh3_perf
-  variables:
-    <<: *perf_vars_definition
-    BENCH: 'tpcc'
-
-perf_ycsb_hash:
-  <<: *perf_docker_test_definition
-  tags:
-    - docker_sh2_perf
-  variables:
-    <<: *perf_vars_definition
-    BENCH: 'ycsb'
-    ARG: 'hash'
-
-perf_ycsb_tree:
-  <<: *perf_docker_test_definition
-  tags:
-    - docker_sh2_perf
-  variables:
-    <<: *perf_vars_definition
-    BENCH: 'ycsb'
-    ARG: 'tree'
-
-perf_nosqlbench_hash:
-  <<: *perf_docker_test_definition
-  tags:
-    - docker_sh1_perf
-  variables:
-    <<: *perf_vars_definition
-    BENCH: 'nosqlbench'
-    ARG: 'hash'
-
-perf_nosqlbench_tree:
-  <<: *perf_docker_test_definition
-  tags:
-    - docker_sh1_perf
-  variables:
-    <<: *perf_vars_definition
-    BENCH: 'nosqlbench'
-    ARG: 'tree'
-
-perf_cbench:
-  <<: *perf_docker_test_definition
-  tags:
-    - docker_sh2_perf
-  variables:
-    <<: *perf_vars_definition
-    BENCH: 'cbench'
-
-perf_linkbench_ssd:
-  <<: *perf_docker_test_definition
-  tags:
-    - docker_perf_ssd
-  variables:
-    <<: *perf_vars_definition
-    BENCH: 'linkbench'
-
-# Post-testing part
-
-remove_images_sh1:
-  <<: *perf_cleanup_definition
-  tags:
-    - sh1_shell
-
-remove_images_sh2:
-  <<: *perf_cleanup_definition
-  tags:
-    - sh2_shell
-
-remove_images_sh3:
-  <<: *perf_cleanup_definition
-  tags:
-    - sh3_shell
-
-remove_images_sh9:
-  <<: *perf_cleanup_definition
-  tags:
-    - sh9_shell


### PR DESCRIPTION
Perf jobs checked at
https://github.com/tarantool/tarantool/runs/1913758190

Added Github local Action 'perf' to be used for perf docker images
preparations and benchmarks runs. Ported jobs from gitlab-ci:

- perf_cbench
- perf_linkbench_ssd
- perf_nosqlbench_hash
- perf_nosqlbench_tree
- perf_sysbench
- perf_tpcc
- perf_tpch
- perf_ycsb_hash
- perf_ycsb_tree
    
Closes #5663

Also made fix in Telegram action to avoid failure on packages installations.
Pip and jq installations may fail if the host is real, in this way it should be
manually pre-installed.
