### PR TITLE
github-ci: missed or symbol in if check (1.10)

### DIFF
--- a/.github/workflows/perf_cbench.yml
+++ b/.github/workflows/perf_cbench.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   perf_cbench:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' ||
         github.event_name == 'repository_dispatch' ||
         github.event_name == 'workflow_dispatch' ||
         github.event_name == 'schedule'

--- a/.github/workflows/perf_linkbench_ssd.yml
+++ b/.github/workflows/perf_linkbench_ssd.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   perf_linkbench_ssd:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' ||
         github.event_name == 'repository_dispatch' ||
         github.event_name == 'workflow_dispatch' ||
         github.event_name == 'schedule'

--- a/.github/workflows/perf_nosqlbench_hash.yml
+++ b/.github/workflows/perf_nosqlbench_hash.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   perf_nosqlbench_hash:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' ||
         github.event_name == 'repository_dispatch' ||
         github.event_name == 'workflow_dispatch' ||
         github.event_name == 'schedule'

--- a/.github/workflows/perf_nosqlbench_tree.yml
+++ b/.github/workflows/perf_nosqlbench_tree.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   perf_nosqlbench_tree:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' ||
         github.event_name == 'repository_dispatch' ||
         github.event_name == 'workflow_dispatch' ||
         github.event_name == 'schedule'

--- a/.github/workflows/perf_ycsb_hash.yml
+++ b/.github/workflows/perf_ycsb_hash.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   perf_ycsb_hash:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' ||
         github.event_name == 'repository_dispatch' ||
         github.event_name == 'workflow_dispatch' ||
         github.event_name == 'schedule'

--- a/.github/workflows/perf_ycsb_tree.yml
+++ b/.github/workflows/perf_ycsb_tree.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   perf_ycsb_tree:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' ||
         github.event_name == 'repository_dispatch' ||
         github.event_name == 'workflow_dispatch' ||
         github.event_name == 'schedule'


### PR DESCRIPTION
Found that in commits:

  c53c650e4c0b9c122e86767e45d073eb88b344bd ("github-ci: port perf jobs from gitlab-ci")
  5c68884a6ea2d8807ffed0845e94fa64744c1d29 ("github-ci: add jepsen* test jobs")

was mistakenly missed "or" check "if:" condition, fixed.

Follows up #5663
Follows up tarantool/tarantool-qa#79