### PR TITLE
github-ci: add workflow to run fuzzing testing

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,0 +1,45 @@
+name: fuzzing
+
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - '.github/workflows/**'
+      - 'src/**'
+      - 'test/fuzz/**'
+      - 'test/static/corpus/**'
+
+jobs:
+  fuzzing:
+    if: (github.repository == 'tarantool/tarantool')
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address, undefined]
+
+    steps:
+      - name: build fuzzers (${{ matrix.sanitizer }})
+        id: build
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+        with:
+          oss-fuzz-project-name: 'tarantool'
+          dry-run: false
+          sanitizer: ${{ matrix.sanitizer }}
+      - name: run fuzzers (${{ matrix.sanitizer }})
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+        with:
+          oss-fuzz-project-name: 'tarantool'
+          fuzz-seconds: 600
+          dry-run: false
+          sanitizer: ${{ matrix.sanitizer }}
+      - name: upload crash
+        uses: actions/upload-artifact@v1
+        if: failure() && steps.build.outcome == 'success'
+        with:
+          name: ${{ matrix.sanitizer }}-artifacts
+          retention-days: 21
+          path: ./out/artifacts

--- a/changelogs/unreleased/oss-fuzz-in-ci.md
+++ b/changelogs/unreleased/oss-fuzz-in-ci.md
@@ -1,0 +1,3 @@
+## feature/testing
+
+* Run fuzzing testing continuously on per-push basis (gh-1809).


### PR DESCRIPTION
Tarantool has been integrated to OSS-Fuzz infrastructure [1], and
implemented fuzzers are passed now [1]. Patch adds a new workflow that
will execute fuzzers on each push to a master branch using OSS-Fuzz
infrastructure [2]. To reduce a load on testing machines job triggers on
changes in directory with Tarantool's source code, fuzzers source code,
corpus files and GH Actions workflow file for fuzzing.

OSS-Fuzz provides web interface with fuzzing
statistics, found errors and other useful information. Access to OSS-Fuzz
UI is available for persons whose email addresses specified in
project.yml, committed to oss-fuzz repository [4]. Bugs found in OSS-Fuzz
reported to bugtracker [5].

Using fuzzing testing documented in Tarantool's wiki [6].

1. https://github.com/google/oss-fuzz/pull/4723
2. https://google.github.io/oss-fuzz/getting-started/continuous-integration/
3. https://google.github.io/oss-fuzz/further-reading/clusterfuzz/
4. https://github.com/google/oss-fuzz
5. https://bugs.chromium.org/p/oss-fuzz/issues/list
6. https://github.com/tarantool/tarantool/wiki/Fuzzing

Follows up #1809