### PR TITLE
github-ci: check release branches statuses

### DIFF
--- a/.github/actions/send-telegram-status/README.md
+++ b/.github/actions/send-telegram-status/README.md
@@ -1,0 +1,21 @@
+# Send Telegram notifications with release branches statuses
+
+Action sends notifications to Telegram channel/bot. It checks for the issues the latest commits on release branches and sends the Telegram message with the list of non-success workflows. Action code is written in Python to be able to use ['composite'](https://docs.github.com/en/actions/creating-actions/creating-a-composite-run-steps-action) Github Action type, which can be used independently from different Github Actions workflows. Also use of Python gives the ability to run the Action on any OS with Python installed. Action uses ['MarkdownV2'](https://core.telegram.org/bots/api#markdownv2-style) style for sending messages.
+
+Action sends message to single common `TELEGRAM_TO` Telegram channel for release Tarantool branches:
+
+- 1.10
+- 2.\*
+- master
+
+## How to use Github Action from Github workflow
+
+Add the following code to the running steps:
+```
+  - name: call action to send Telegram message on failure
+    env:
+      TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+      TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+    uses: ./.github/actions/send-telegram-status
+    if: failure()
+```

--- a/.github/actions/send-telegram-status/action.yml
+++ b/.github/actions/send-telegram-status/action.yml
@@ -1,0 +1,65 @@
+name: 'Send Telegram message with Actions status'
+description: 'Send message to Telegram channel/bot with Actions status'
+
+runs:
+  using: "composite"
+  steps:
+    # install 'requests' Python module
+    - run: |
+        python -m pip install --upgrade pip ||:
+        pip install requests ||:
+      shell: bash
+    # logout github environment
+    - env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+      shell: bash
+    # extract branch latest tag
+    - run: |
+        branch_name=${{ github.ref }}
+        branch_name=${branch_name#refs/heads/}
+        echo 'BRANCH_TAG<<EOF' >> $GITHUB_ENV
+        git rev-parse $branch_name >>$GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+        echo REL_VER=${branch_name#origin/} | tee -a $GITHUB_ENV
+      shell: bash
+    - name: add GEM ENV
+      run: |
+        echo GEM_HOME=$HOME/.gem | tee -a $GITHUB_ENV
+        echo GEM_PATH=$HOME/.gem | tee -a $GITHUB_ENV
+      shell: bash
+    - name: get Actions status for current branch
+      run: |
+        mkdir -p $GEM_PATH
+        gem install octokit
+        gem install json
+        gem install optparse
+        gem install colorize
+        ruby .github/actions/send-telegram-status/check_status.rb -b $REL_VER -t $BRANCH_TAG -f issues.txt --no-color
+        issues=$(cat issues.txt)
+        echo ISSUES=${issues//$'\n'/'\n'} >>$GITHUB_ENV
+      shell: bash
+    - name: send Telegram message if it is not empty
+      env:
+        MSG: |
+          🔴 Workflow testing failed:
+          Release branch: [ `${{ env.REL_VER }}`](https://github.com/${{ github.repository }}/commits/${{ env.REL_VER }})
+          Latest commit: [ `#${{ env.BRANCH_TAG }}`](https://github.com/${{ github.repository }}/commit/${{ env.JOB_ID }})
+          ```
+          ---------------- Found issues -------------------
+          ${{ env.ISSUES }}
+          ```
+      run: |
+        if [ ! -s issues.txt ] ; then echo "No issues exists, exiting" ; exit 0 ; fi
+        # convert message from multi lines to single line and
+        # add backslashes to single quote marks in message
+        msg="${MSG//$'\n'/'\n'}"
+        msg="${msg//$'\''/\\\'}"
+        echo "Sending message: $msg"
+        # Use MarkdownV2 while Markdown is legacy
+        # https://core.telegram.org/bots/api#markdownv2-style
+        python -c "import urllib, requests ; \\
+          url = 'https://api.telegram.org/bot%s/sendMessage?chat_id=%s&text=%s&parse_mode=MarkdownV2&disable_web_page_preview=true' \\
+            % ('$TELEGRAM_TOKEN', '$TELEGRAM_TO', urllib.quote_plus('$msg')) ; \\
+          _ = requests.post(url, timeout=10)"
+      shell: bash

--- a/.github/actions/send-telegram-status/check_status.rb
+++ b/.github/actions/send-telegram-status/check_status.rb
@@ -1,0 +1,89 @@
+require 'octokit'
+require 'json'
+require 'optparse'
+require 'colorize'
+
+options = OpenStruct.new
+options.tnt_path = '.'
+options.branch = 'master'
+options.verbosity = 0
+options.com_tag = 0
+options.com_back = 0
+options.file_issues = "issues.txt"
+options.no_color = false
+
+OptionParser.new do |opt|
+  opt.on("-s", "--source <TARANTOOL SOURCE PATH, default '#{options.tnt_path}'>") { |s| options.tnt_path = s }
+  opt.on("-b", "--branch <BRANCH, ex. 1.10>") { |b| options.branch = b }
+  opt.on("-t", "--tag <COMMIT TAG long format> (disables --commits_back option)") { |t| options.com_tag = t }
+  opt.on("--commits_back <number of commits like for BRANCH~2, ex. 2>") { |c| options.com_back = c }
+  opt.on("-v", "--verbosity <NUMBER, [0-3]>") { |v| options.verbosity = v.to_i }
+  opt.on("-f", "--file_issues <FILE NAME, default '#{options.file_issues}'>") { |f| options.file_issues = f }
+  opt.on("--no-color>") { options.no_color = true }
+end.parse!
+
+if options.com_tag != 0
+  git_sha = options.com_tag
+else
+  # remove EOL by strip
+  git_sha = %x( cd #{options.tnt_path} && git rev-parse origin/#{options.branch}~#{options.com_back} ).strip
+end
+if options.verbosity > 0
+  puts "Options: #{options}"
+  puts "In branch #{options.branch} search for GIT SHA: #{git_sha}"
+end
+
+client = Octokit::Client.new :access_token => ENV['GITHUB_PATOKEN']
+
+# returns the same as client.last_response.data
+client.repository_workflow_runs('tarantool/tarantool', {event: 'push', branch: options.branch})
+
+# point and start work from the initial response
+last_response = client.last_response
+
+# print found results pages
+if options.verbosity > 1
+  number_of_pages = last_response.rels[:last].href.match(/page=(\d+).*$/)[1]
+  puts "There are #{last_response.data.total_count} results, on #{number_of_pages} pages!"
+end
+
+file = File.open(options.file_issues, 'w')
+
+# print in loop all paginated pages
+loop do
+  # for verbosity print all the current page data
+  if options.verbosity > 2
+    puts last_response.data.map(&:to_s).to_json
+  end
+
+  # print from workflow array needed item
+  workflow_array = last_response.data[:workflow_runs]
+  workflow_array.each do |item|
+    if item[:head_sha] == git_sha
+      if item[:conclusion] == 'success'
+        if options.no_color
+          puts "#{item[:conclusion]} #{item[:name]}"
+        else
+          puts "#{item[:conclusion].green} #{item[:name]}"
+        end
+      else
+        if options.no_color
+          issue = "#{item[:conclusion]} #{item[:name]}"
+        else
+          issue = "#{item[:conclusion].red} #{item[:name]}"
+        end
+        file.write("#{issue}\n")
+        puts issue
+      end
+    end
+  end
+
+  if last_response.rels[:next].nil?
+    break
+  end
+
+  # iterate and get next page data
+  last_response = last_response.rels[:next].get
+end
+
+file.close()

--- a/.github/workflows/actions_status.yml
+++ b/.github/workflows/actions_status.yml
@@ -1,0 +1,35 @@
+name: actions_status
+
+on:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 */1 * * *'
+
+jobs:
+  actions_status:
+    if: github.ref == 'refs/heads/master' ||
+        github.ref == 'refs/heads/1.10' ||
+        startsWith(github.ref, 'refs/heads/2.')
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: call action to send Telegram message with Actions status
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-status
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: actions_status
+          retention-days: 21
+          path: |
+            issues.txt


### PR DESCRIPTION
Added new workflow to be able to check latest commits on release
branches. It checks for the issues and sends the Telegram message
with the list of non-success workflows. This workflow runs by cron
either manually.