### PR TITLE
Properly check for non-x86 architectures

### DIFF
--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -49,7 +49,7 @@
  * Fiber top doesn't work on ARM processors at the moment,
  * because we haven't chosen an alternative to rdtsc.
  */
-#ifdef __CC_ARM
+#if !defined(__amd64__) && !defined(__i386__) && !defined(__x86_64__)
 #define ENABLE_FIBER_TOP 0
 #else
 #define ENABLE_FIBER_TOP 1


### PR DESCRIPTION
On my ARM system __CC_ARM is not defined. Checking whether we don't run on non-x86 may also make supporting other architectures (like POWER or RISC-V) easier.