### PR TITLE
github-ci: add manual run ability to workflows

### DIFF
--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -1,6 +1,11 @@
 name: centos_7
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .gitlab.mk

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -1,6 +1,11 @@
 name: centos_8
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .gitlab.mk

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,6 +1,9 @@
 name: coverity
 
 on:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
   schedule:
     - cron:  '0 4 * * 6'
 

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -1,6 +1,11 @@
 name: debian_10
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .gitlab.mk

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -1,6 +1,11 @@
 name: debian_11
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .gitlab.mk

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -1,6 +1,11 @@
 name: debian_9
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .gitlab.mk

--- a/.github/workflows/debug_coverage.yml
+++ b/.github/workflows/debug_coverage.yml
@@ -1,6 +1,11 @@
 name: debug_coverage
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .travis.mk

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -1,6 +1,11 @@
 name: default_gcc_centos_7
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .travis.mk

--- a/.github/workflows/fedora_28.yml
+++ b/.github/workflows/fedora_28.yml
@@ -1,6 +1,11 @@
 name: fedora_28
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .gitlab.mk

--- a/.github/workflows/fedora_29.yml
+++ b/.github/workflows/fedora_29.yml
@@ -1,6 +1,11 @@
 name: fedora_29
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .gitlab.mk

--- a/.github/workflows/fedora_30.yml
+++ b/.github/workflows/fedora_30.yml
@@ -1,6 +1,11 @@
 name: fedora_30
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .gitlab.mk

--- a/.github/workflows/fedora_31.yml
+++ b/.github/workflows/fedora_31.yml
@@ -1,6 +1,11 @@
 name: fedora_31
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .gitlab.mk

--- a/.github/workflows/fedora_32.yml
+++ b/.github/workflows/fedora_32.yml
@@ -1,6 +1,11 @@
 name: fedora_32
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .gitlab.mk

--- a/.github/workflows/fedora_33.yml
+++ b/.github/workflows/fedora_33.yml
@@ -1,6 +1,11 @@
 name: fedora_33
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .gitlab.mk

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,6 +1,11 @@
 name: freebsd
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .gitlab.mk

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,6 +1,11 @@
 name: luacheck
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .travis.mk

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -1,6 +1,11 @@
 name: opensuse_15_1
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .gitlab.mk

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -1,6 +1,11 @@
 name: opensuse_15_2
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .gitlab.mk

--- a/.github/workflows/osx_10_15.yml
+++ b/.github/workflows/osx_10_15.yml
@@ -1,6 +1,11 @@
 name: osx_10_15
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .travis.mk

--- a/.github/workflows/osx_10_15_lto.yml
+++ b/.github/workflows/osx_10_15_lto.yml
@@ -1,6 +1,11 @@
 name: osx_10_15_lto
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .travis.mk

--- a/.github/workflows/osx_11_0.yml
+++ b/.github/workflows/osx_11_0.yml
@@ -1,6 +1,11 @@
 name: osx_11_0
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .travis.mk

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -1,6 +1,11 @@
 name: out_of_source
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .travis.mk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,11 @@
 name: release
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .travis.mk

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -1,6 +1,11 @@
 name: release_asan_clang11
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .travis.mk

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -1,6 +1,11 @@
 name: release_clang
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .travis.mk

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -1,6 +1,11 @@
 name: release_lto
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .travis.mk

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -1,6 +1,11 @@
 name: release_lto_clang11
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .travis.mk

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -1,6 +1,10 @@
 name: source
 
-on: [push]
+on:
+  push:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .gitlab.mk

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -1,6 +1,11 @@
 name: static_build
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .travis.mk

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -1,6 +1,11 @@
 name: static_build_cmake_linux
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .travis.mk

--- a/.github/workflows/static_build_cmake_osx_15.yml
+++ b/.github/workflows/static_build_cmake_osx_15.yml
@@ -1,6 +1,11 @@
 name: static_build_cmake_osx_15
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .travis.mk

--- a/.github/workflows/ubuntu_14_04.yml
+++ b/.github/workflows/ubuntu_14_04.yml
@@ -1,6 +1,11 @@
 name: ubuntu_14_04
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .gitlab.mk

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -1,6 +1,11 @@
 name: ubuntu_16_04
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .gitlab.mk

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -1,6 +1,11 @@
 name: ubuntu_18_04
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .gitlab.mk

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -1,6 +1,11 @@
 name: ubuntu_20_04
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
 
 env:
   CI_MAKE: make -f .gitlab.mk


### PR DESCRIPTION
Added manual and backend triggers to run test workflows. It will
give the ability to run missed/needed workflows in Github Actions
and to use standalone backend scripts to run test workflows.