### PR TITLE
github-ci: ubuntu-20.04 misses createrepo package

### DIFF
--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/debug_coverage.yml
+++ b/.github/workflows/debug_coverage.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_28.yml
+++ b/.github/workflows/fedora_28.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_29.yml
+++ b/.github/workflows/fedora_29.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_30.yml
+++ b/.github/workflows/fedora_30.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_31.yml
+++ b/.github/workflows/fedora_31.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_32.yml
+++ b/.github/workflows/fedora_32.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_33.yml
+++ b/.github/workflows/fedora_33.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -14,7 +14,7 @@ jobs:
   fuzzing:
     if: (github.repository == 'tarantool/tarantool')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/jepsen-cluster-txm.yml
+++ b/.github/workflows/jepsen-cluster-txm.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event_name == 'repository_dispatch' ||
         github.event_name == 'workflow_dispatch'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/jepsen-cluster.yml
+++ b/.github/workflows/jepsen-cluster.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event_name == 'repository_dispatch' ||
         github.event_name == 'workflow_dispatch'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/jepsen-single-instance-txm.yml
+++ b/.github/workflows/jepsen-single-instance-txm.yml
@@ -20,7 +20,7 @@ jobs:
         github.event_name == 'workflow_dispatch' ||
         github.event_name == 'schedule'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/jepsen-single-instance.yml
+++ b/.github/workflows/jepsen-single-instance.yml
@@ -20,7 +20,7 @@ jobs:
         github.event_name == 'workflow_dispatch' ||
         github.event_name == 'schedule'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -14,7 +14,7 @@ jobs:
         startsWith(github.ref, 'refs/tags') ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ubuntu_14_04.yml
+++ b/.github/workflows/ubuntu_14_04.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -13,7 +13,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Found that ubuntu-latest that switched in Github Actions from
ubuntu-18.04 to ubuntu-20.04, doesn't have createrepo package
available in Ubuntu repositories to be installed. It happened
because createrepo written on python2, which is not supported
by ubuntu-20.04. Anyway createrepo tool was rewritten on C to
make it available for the later distributions, its new naming
is createrepo_c. It is already avaliable in Ubuntu 21.04, but
still not backported to 20.04 version. So we need to wait its
avalaibility in Ubuntu 22.04 either its backported version in
20.04 [1]. As for now we need to use ubuntu-18.04 in Actions.

[1]: https://answers.launchpad.net/createrepo/+question/690448