### PR TITLE
github-ci: add result message from coverity in PR

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -53,3 +53,17 @@ jobs:
           name: debug
           retention-days: 21
           path: test/var/artifacts
+      # Find the PR associated with this push, if there is one.
+      - uses: jwalton/gh-find-current-pr@v1
+        if: success()
+        id: findPr
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create comment in PR if it exists
+        if: success() && steps.findPr.outputs.number != false
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ steps.findPr.outputs.pr }}
+          body: |
+            Check coverity results on coverity.com site
+            [![Coverity Status](https://scan.coverity.com/projects/11609/badge.svg?flat=1)](https://scan.coverity.com/projects/tarantool-tarantool)


### PR DESCRIPTION
Workflow 'coverity' produces and uploads results to 'coverity.com' web
site. Message about it can be shown in PR within each run was done.
This patch adds the ability to send message in available PR otherwise
it is skipped.

Part of #5644