### PR TITLE
ssl_cert_paths_discover: delete unused headers

### DIFF
--- a/src/ssl_cert_paths_discover.c
+++ b/src/ssl_cert_paths_discover.c
@@ -35,7 +35,6 @@
 #include <sys/stat.h>
 #include <openssl/ssl.h>
 #include "ssl_cert_paths_discover.h"
-#include "tt_static.h"
 
 static int
 is_dir_empty(const char *dir_path)

--- a/test/app-tap/ssl-cert-paths-discover.test.lua
+++ b/test/app-tap/ssl-cert-paths-discover.test.lua
@@ -178,4 +178,4 @@ end)
 ----- Cleanup
 fio.rmtree(temp_dir)
 
-os:exit(test:check() and 0 or 1)
+os.exit(test:check() and 0 or 1)


### PR DESCRIPTION
* Remove unnecessary `#include "tt_static.h"` from
  src/ssl_cert_paths_discover.c
* Fix typo at test/app-tap/ssl-cert-paths-discover.test.lua
  call `os.exit` instead of `os:exit`

A follow up on #5615