### PR TITLE
Simplify memory size options

### DIFF
--- a/test/box/cfg.result
+++ b/test/box/cfg.result
@@ -278,7 +278,8 @@ box.cfg{replication = {}}
 
 box.cfg{memtx_memory = "100500"}
  | ---
- | - error: 'Incorrect value for option ''memtx_memory'': should be of type number'
+ | - error: 'Incorrect value for option ''memtx_memory'': cannot decrease memory size
+ |     at runtime'
  | ...
 box.cfg{memtx_memory = -1}
  | ---
@@ -310,6 +311,25 @@ box.cfg{vinyl_memory = 5000000000000}
  | ---
  | - error: 'Incorrect value for option ''vinyl_memory'': must be >= 0 and <= 4398046510080,
  |     but it is 5000000000000'
+ | ...
+
+--------------------------------------------------------------------------------
+-- Test of literals in memory options
+--------------------------------------------------------------------------------
+
+box.cfg{memtx_memory = "1GB", vinyl_memory = " 2 GB "}
+ | ---
+ | ...
+box.cfg{memtx_memory = "1025 MB", vinyl_memory = "  3  00  0000 KB   "}
+ | ---
+ | - error: 'Incorrect value for option ''vinyl_memory'': non integer memory amount'
+ | ...
+box.cfg{memtx_memory = "   1025   MB   "}
+ | ---
+ | ...
+box.cfg{memtx_memory = "MB"}
+ | ---
+ | - error: 'Incorrect value for option ''memtx_memory'': non integer memory amount'
  | ...
 
 --------------------------------------------------------------------------------

--- a/test/box/cfg.test.lua
+++ b/test/box/cfg.test.lua
@@ -35,6 +35,15 @@ box.cfg{memtx_memory = 5000000000000}
 box.cfg{vinyl_memory = 5000000000000}
 
 --------------------------------------------------------------------------------
+-- Test of literals in memory options
+--------------------------------------------------------------------------------
+
+box.cfg{memtx_memory = "1GB", vinyl_memory = " 2 GB "}
+box.cfg{memtx_memory = "1025 MB", vinyl_memory = "  3  00  0000 KB   "}
+box.cfg{memtx_memory = "   1025   MB   "}
+box.cfg{memtx_memory = "MB"}
+
+--------------------------------------------------------------------------------
 -- Dynamic configuration check
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Currently, you can specify the amount of memory for the configuration
only in bytes. It would also be convenient to be able to specify the
amount of memory in KB, MB or GB.

Add option to specify amount of memory as a string and a parser for this
string.

String must contain number of memory amount, suffix(KB, MB, or GB) and
any number of spaces at the begining, at the ending of the string or
between memory amount and suffix.