### PR TITLE
coverity: add errinj macroses to fix dead code

### DIFF
--- a/src/lib/core/errinj.h
+++ b/src/lib/core/errinj.h
@@ -178,6 +178,7 @@ void errinj_set_with_environment_vars(void);
 
 #ifdef NDEBUG
 #  define ERROR_INJECT(ID, CODE)
+#  define ERROR_INJECT_COND(ID, TYPE, COND, CODE)
 #  define ERROR_INJECT_WHILE(ID, CODE)
 #  define errinj(ID, TYPE) ((struct errinj *) NULL)
 #  define ERROR_INJECT_COUNTDOWN(ID, CODE)
@@ -193,6 +194,13 @@ void errinj_set_with_environment_vars(void);
 	do { \
 		if (errinj(ID, ERRINJ_BOOL)->bparam) \
 			CODE; \
+	} while (0)
+#  define ERROR_INJECT_COND(ID, TYPE, COND, CODE) \
+	do { \
+		struct errinj *inj = errinj(ID, TYPE); \
+		if (COND) { \
+			CODE; \
+		} \
 	} while (0)
 #  define ERROR_INJECT_WHILE(ID, CODE) \
 	do { \
@@ -211,6 +219,8 @@ void errinj_set_with_environment_vars(void);
 #define ERROR_INJECT_SLEEP(ID) ERROR_INJECT_WHILE(ID, usleep(1000))
 #define ERROR_INJECT_YIELD(ID) ERROR_INJECT_WHILE(ID, fiber_sleep(0.001))
 #define ERROR_INJECT_TERMINATE(ID) ERROR_INJECT(ID, assert(0))
+#define ERROR_INJECT_INT(ID, COND, CODE) ERROR_INJECT_COND(ID, ERRINJ_INT, COND, CODE)
+#define ERROR_INJECT_DOUBLE(ID, COND, CODE) ERROR_INJECT_COND(ID, ERRINJ_DOUBLE, COND, CODE)
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -629,6 +629,7 @@ run_script_f(va_list ap)
 	fiber_sleep(0.0);
 	aux_loop_is_run = true;
 
+	int is_a_tty = isatty(STDIN_FILENO);
 	/*
 	 * Override return value of isatty(STDIN_FILENO) if
 	 * ERRINJ_STDIN_ISATTY enabled (iparam not set to default).
@@ -636,13 +637,9 @@ run_script_f(va_list ap)
 	 * Integer param of errinj is used in order to set different
 	 * return values.
 	*/
-	int is_a_tty;
-	struct errinj *inj = errinj(ERRINJ_STDIN_ISATTY, ERRINJ_INT);
-	if (inj != NULL && inj->iparam >= 0) {
+	ERROR_INJECT_INT(ERRINJ_STDIN_ISATTY, inj->iparam >= 0, {
 		is_a_tty = inj->iparam;
-	} else {
-		is_a_tty = isatty(STDIN_FILENO);
-	}
+	});
 
 	if (path && strcmp(path, "-") != 0 && access(path, F_OK) == 0) {
 		/* Execute script. */


### PR DESCRIPTION
Our coverity (scan.coverity.com) reports about dead code (CWE-561)
in cases where variable of type `struct errinj *` is compared with
NULL at if condition. Dead code appears due to function-like macro
`errinj()` always returns NULL at non-debug version, so execution
never goes into if block.

Added macroses ERROR_INJECT_INT and ERROR_INJECT_DOUBLE which solves
this problem like it does ERROR_INJECT macro with boolean errinj type.

Usage you can see on example of ERRINJ_STDIN_ISATTY fix in this commit.

Follows up #5040