### PR TITLE
github-ci: avoid of use container tags in actions

### DIFF
--- a/.github/workflows/debug_coverage.yml
+++ b/.github/workflows/debug_coverage.yml
@@ -18,26 +18,19 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
 
-    # image built by .gitlab.mk instructions and targets from .travis.mk
-    container:
-      image: docker.io/tarantool/testing:debian-stretch
-      # Our testing expects that the init process (PID 1) will
-      # reap orphan processes. At least the following test leans
-      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-      # Memory size hard coding will be removed within resolving issue
-      #   http://github.com/tarantool/tarantool-qa/issues/101
-      options: '--init --memory=7G --memory-swap=7G'
-
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
       - uses: ./.github/actions/environment
       - name: test
-        run: ${CI_MAKE} test_coverage_debian_no_deps
+        run: ${CI_MAKE} coverage_ubuntu_ghactions
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
       - name: call action to send Telegram message on failure

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -18,21 +18,16 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
 
-    # image built by .gitlab.mk instructions and targets from .travis.mk
-    container:
-      image: docker.io/tarantool/testing:debian-stretch
-      # Our testing expects that the init process (PID 1) will
-      # reap orphan processes. At least the following test leans
-      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-      options: '--init'
-
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
       - name: test
         run: ${CI_MAKE} test_debian_luacheck
       - name: call action to send Telegram message on failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,26 +18,19 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
 
-    # image built by .gitlab.mk instructions and targets from .travis.mk
-    container:
-      image: docker.io/tarantool/testing:debian-stretch
-      # Our testing expects that the init process (PID 1) will
-      # reap orphan processes. At least the following test leans
-      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-      # Memory size hard coding will be removed within resolving issue
-      #   http://github.com/tarantool/tarantool-qa/issues/101
-      options: '--init --memory=7G --memory-swap=7G'
-
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
       - uses: ./.github/actions/environment
       - name: test
-        run: ${CI_MAKE} test_debian_no_deps
+        run: ${CI_MAKE} test_ubuntu_ghactions
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -18,20 +18,10 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
-
-    # image built by .gitlab.mk instructions and targets from .travis.mk
-    container:
-      image: docker.io/tarantool/testing:debian-buster
-      # Our testing expects that the init process (PID 1) will
-      # reap orphan processes. At least the following test leans
-      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-      # Memory size hard coding will be removed within resolving issue
-      #   http://github.com/tarantool/tarantool-qa/issues/101
-      options: '--init --memory=7G --memory-swap=7G'
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -40,7 +30,7 @@ jobs:
           submodules: recursive
       - uses: ./.github/actions/environment
       - name: test
-        run: ${CI_MAKE} test_asan_debian_no_deps
+        run: ${CI_MAKE} test_asan_ubuntu_ghactions
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -18,29 +18,22 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
 
-    # image built by .gitlab.mk instructions and targets from .travis.mk
-    container:
-      image: docker.io/tarantool/testing:debian-stretch
-      # Our testing expects that the init process (PID 1) will
-      # reap orphan processes. At least the following test leans
-      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-      # Memory size hard coding will be removed within resolving issue
-      #   http://github.com/tarantool/tarantool-qa/issues/101
-      options: '--init --memory=7G --memory-swap=7G'
-
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
       - uses: ./.github/actions/environment
       - name: test
         env:
           CC: clang
           CXX: clang++
-        run: ${CI_MAKE} test_debian_no_deps
+        run: ${CI_MAKE} test_ubuntu_ghactions
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -18,20 +18,10 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
-
-    # image built by .gitlab.mk instructions and targets from .travis.mk
-    container:
-      image: docker.io/tarantool/testing:debian-buster
-      # Our testing expects that the init process (PID 1) will
-      # reap orphan processes. At least the following test leans
-      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-      # Memory size hard coding will be removed within resolving issue
-      #   http://github.com/tarantool/tarantool-qa/issues/101
-      options: '--init --memory=7G --memory-swap=7G'
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -42,7 +32,7 @@ jobs:
       - name: test
         env:
           CMAKE_EXTRA_PARAMS: -DENABLE_LTO=ON
-        run: ${CI_MAKE} test_debian_no_deps
+        run: ${CI_MAKE} test_ubuntu_ghactions
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -18,20 +18,10 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
-
-    # image built by .gitlab.mk instructions and targets from .travis.mk
-    container:
-      image: docker.io/tarantool/testing:debian-buster
-      # Our testing expects that the init process (PID 1) will
-      # reap orphan processes. At least the following test leans
-      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-      # Memory size hard coding will be removed within resolving issue
-      #   http://github.com/tarantool/tarantool-qa/issues/101
-      options: '--init --memory=7G --memory-swap=7G'
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -44,7 +34,7 @@ jobs:
           CC: clang-11
           CXX: clang++-11
           CMAKE_EXTRA_PARAMS: -DENABLE_LTO=ON
-        run: ${CI_MAKE} test_debian_no_deps
+        run: ${CI_MAKE} test_ubuntu_ghactions
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -18,23 +18,16 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
 
-    # image built by .gitlab.mk instructions and targets from .travis.mk
-    container:
-      image: docker.io/tarantool/testing:debian-stretch
-      # Our testing expects that the init process (PID 1) will
-      # reap orphan processes. At least the following test leans
-      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-      # Memory size hard coding will be removed within resolving issue
-      #   http://github.com/tarantool/tarantool-qa/issues/101
-      options: '--init --memory=7G --memory-swap=7G'
-
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
       - uses: ./.github/actions/environment
       - name: test
         run: ${CI_MAKE} test_static_build

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -18,23 +18,16 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
 
-    # image built by .gitlab.mk instructions and targets from .travis.mk
-    container:
-      image: docker.io/tarantool/testing:debian-stretch
-      # Our testing expects that the init process (PID 1) will
-      # reap orphan processes. At least the following test leans
-      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-      # Memory size hard coding will be removed within resolving issue
-      #   http://github.com/tarantool/tarantool-qa/issues/101
-      options: '--init --memory=7G --memory-swap=7G'
-
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
       - uses: ./.github/actions/environment
       - name: test
         run: ${CI_MAKE} test_static_build_cmake_linux

--- a/.travis.mk
+++ b/.travis.mk
@@ -82,7 +82,24 @@ docker_%:
 # commit, so the build requires old dependencies to be installed.
 # See ce623a23416eb192ce70116fd14992e84e7ccbbe ('Enable GitLab CI
 # testing') for more information.
-deps_debian:
+
+deps_tests:
+	pip install -r test-run/requirements.txt
+
+deps_ubuntu_ghactions: deps_tests
+	sudo apt-get update ${APT_EXTRA_FLAGS} && \
+		sudo apt-get install -y -f libreadline-dev libunwind-dev
+
+deps_coverage_ubuntu_ghactions: deps_ubuntu_ghactions
+	sudo apt-get install -y -f lcov
+	sudo gem install coveralls-lcov
+	# Link src/lib/uri/src to local src dircetory to avoid of issue:
+	# /var/lib/gems/2.7.0/gems/coveralls-lcov-1.7.0/lib/coveralls/lcov/converter.rb:64:in
+	#   `initialize': No such file or directory @ rb_sysopen -
+	#   /home/runner/work/tarantool/tarantool/src/lib/uri/src/lib/uri/uri.c (Errno::ENOENT)
+	ln -s ${PWD}/src src/lib/uri/src
+	
+deps_debian_packages:
 	apt-get update ${APT_EXTRA_FLAGS} && apt-get install -y -f \
 		build-essential cmake coreutils sed \
 		libreadline-dev libncurses5-dev libyaml-dev libssl-dev \
@@ -91,6 +108,8 @@ deps_debian:
 		python-msgpack python-yaml python-argparse python-six python-gevent \
 		python3 python3-gevent python3-six python3-yaml \
 		lcov ruby clang llvm llvm-dev zlib1g-dev autoconf automake libtool
+
+deps_debian: deps_debian_packages deps_tests
 
 deps_buster_clang_8: deps_debian
 	echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-8 main" > /etc/apt/sources.list.d/clang_8.list
@@ -139,6 +158,8 @@ test_debian_no_deps: build_debian
 
 test_debian: deps_debian test_debian_no_deps
 
+test_ubuntu_ghactions: deps_ubuntu_ghactions test_debian_no_deps
+
 test_debian_clang11: deps_debian deps_buster_clang_11 test_debian_no_deps
 
 # Debug with coverage
@@ -159,7 +180,6 @@ test_coverage_debian_no_deps: build_coverage_debian
 	# coveralls API: https://docs.coveralls.io/api-reference
 	@if [ -n "$(COVERALLS_TOKEN)" ]; then \
 		echo "Exporting code coverage information to coveralls.io"; \
-		gem install coveralls-lcov; \
 		echo coveralls-lcov --service-name github-ci --service-job-id $(GITHUB_RUN_ID) \
 			--repo-token [FILTERED] coverage.info; \
 		coveralls-lcov --service-name github-ci --service-job-id $(GITHUB_RUN_ID) \
@@ -167,6 +187,8 @@ test_coverage_debian_no_deps: build_coverage_debian
 	fi;
 
 coverage_debian: deps_debian test_coverage_debian_no_deps
+
+coverage_ubuntu_ghactions: deps_coverage_ubuntu_ghactions test_coverage_debian_no_deps
 
 # Coverity
 
@@ -223,15 +245,17 @@ test_asan_debian_no_deps: build_asan_debian
 
 test_asan_debian: deps_debian deps_buster_clang_11 test_asan_debian_no_deps
 
+test_asan_ubuntu_ghactions: deps_ubuntu_ghactions test_asan_debian_no_deps
+
 # Static build
 
-deps_debian_static:
+deps_debian_static: deps_tests
 	# Found that in Debian OS libunwind library built with dependencies to
 	# liblzma library, but there is no liblzma static library installed,
 	# while liblzma dynamic library exists. So the build dynamicaly has no
 	# issues, while static build fails. To fix it we need to install
 	# liblzma-dev package with static library only for static build.
-	apt-get install -y -f liblzma-dev
+	sudo apt-get install -y -f liblzma-dev
 
 test_static_build: deps_debian_static
 	CMAKE_EXTRA_PARAMS=-DBUILD_STATIC=ON make -f .travis.mk test_debian_no_deps
@@ -239,7 +263,7 @@ test_static_build: deps_debian_static
 # New static build
 # builddir used in this target - is a default build path from cmake
 # ExternalProject_Add()
-test_static_build_cmake_linux:
+test_static_build_cmake_linux: deps_tests
 	cd static-build && cmake -DCMAKE_TARANTOOL_ARGS="-DCMAKE_BUILD_TYPE=RelWithDebInfo;-DENABLE_WERROR=ON" . && \
 	make -j && ctest -V
 	make -C ${PWD}/static-build/tarantool-prefix/src/tarantool-build LuaJIT-test
@@ -262,9 +286,9 @@ test_debian_docker_luacheck:
 		make -f .travis.mk test_debian_luacheck
 
 test_debian_install_luacheck:
-	apt update -y
-	apt install -y lua5.1 luarocks
-	luarocks install luacheck
+	sudo apt update -y
+	sudo apt install -y lua5.1 luarocks
+	sudo luarocks install luacheck
 
 test_debian_luacheck: test_debian_install_luacheck configure_debian
 	make luacheck


### PR DESCRIPTION
Changed the following workflows:
```
  luacheck
  debug_coverage
  release*
  static_build
  static_build_cmake_linux
```
It was changed the OS in which the test run from debian to ubuntu.
Also changed the way how this OS was booted - before the change it
was booted as docker container using Github Actions tag from inside
the worklfows. And it caused all the workflow steps to be run inside
it. After the change no container run anymore on the running host.
Github Actions host uses for now with its native OS set in 'runs'
tag. It was decided to use the latest one OS `ubuntu-20.04` which is
already the default for 'ubuntu-latest' tag.

This change gave us the abilities to:
 - Remove extra container step in workflow.
 - Switch off swap using 'swapoff' command.
 - Use the same OS as Github Actions uses by default.
 - Setup our local hosts using Github Actions image snapshot.
 - Enable use of actions/checkout@v2.3.4 which is better than v1.
 - Light bootstrap of packages in local .*.mk makefile for:
     build: libreadline-dev libunwind-dev
     tests: pip install -r test-run/requirements.txt

Closes tarantool/tarantool-qa#101