### PR TITLE
github-ci: add work path permissions correction

### DIFF
--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -34,6 +34,12 @@ jobs:
       options: '--init'
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v1
       - uses: ./.github/actions/environment
       - name: test

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/debug_coverage.yml
+++ b/.github/workflows/debug_coverage.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_28.yml
+++ b/.github/workflows/fedora_28.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_29.yml
+++ b/.github/workflows/fedora_29.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_30.yml
+++ b/.github/workflows/fedora_30.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_31.yml
+++ b/.github/workflows/fedora_31.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_32.yml
+++ b/.github/workflows/fedora_32.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_33.yml
+++ b/.github/workflows/fedora_33.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_14_04.yml
+++ b/.github/workflows/ubuntu_14_04.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # Permissions correction is needed for self-host runners,
+      # where work path is saved between different workflows runs.
+      - name: correct permissions in working directory
+        shell: bash
+        run: |
+          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0


### PR DESCRIPTION
For self-host runners, where work path with sources is saving between
different workflows runs, it is needed to be sure that all permissions
correct for running user to be sure that later call to sources checkout
by 'actions/checkout' action run by the same user won't fail on sources
cleanup.

Closes tarantool/tarantool-qa#102