### PR TITLE
github-ci: drop not needed tag on branches commits

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -39,4 +39,9 @@ runs:
                 free
             fi
         fi
+        # Drop a tag that points to a current commit (if any)
+        # on a job triggered by pushing to a branch.
+        if ${{ ! startsWith(github.ref, 'refs/tags/') }}; then
+            git tag -d "$(git tag --points-at HEAD)" 2>/dev/null || true
+        fi
       shell: bash


### PR DESCRIPTION
We should remove a tag after fetching of a remote repository.
Ported the following commits:

  0f575e01a20a2da76d73e72e77f6ebd0080ef1b1 ('gitlab-ci: fix tag removal for a branch push job')
  0f564f3497e6a8afd42da2175104118ba5213593 ('gitlab-ci: remove tag from pushed branch commit')

Drop a tag that points to a current commit (if any) on a job triggered
by pushing to a branch (as against of pushing a tag). Otherwise we may
get two jobs for the same x.y.z-0-gxxxxxxxxx build: one is run by
pushing a branch and another by pushing a tag. The idea is to hide the
new tag from the branch job as if a tag would be pushed strictly after
all branch jobs for the same commit.

Closes tarantool/tarantool-qa#103