### PR TITLE
github-ci: static_docker_build fails on build icu

### DIFF
--- a/Dockerfile.staticbuild
+++ b/Dockerfile.staticbuild
@@ -52,7 +52,7 @@ RUN set -x && \
     tar -xvf icu4c-62_1-src.tgz && \
     cd icu/source && \
     ./configure --with-data-packaging=static --enable-static --enable-shared && \
-    make -j && make install
+    make -j $(nproc) && make install
 
 RUN set -x && \
     cd / && \


### PR DESCRIPTION
Issue initially happened after commit:
  6d220fede1a50dc7d3cbef1b9b810896e4026065 ('github-ci: switch off swap use')

Issue happened on docker build command:
  https://github.com/tarantool/tarantool/runs/2255728324#step:4:14232

  `Step 8/18 : RUN set -x && ... make -j && make install`

Failed like:
  https://github.com/tarantool/tarantool/runs/2255728324#step:4:18129
```
  make: *** [test_static_docker_build] Killed
  .travis.mk:204: recipe for target 'test_static_docker_build' failed
```
Seems that w/o swap available happened OOM on ICU build. To avoid of
such situation better to limit the build with less parallel make.

Closes tarantool/tarantool-qa#109