### PR TITLE
github-ci: enable ubuntu-20.04 hosts for packaging

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -8,6 +8,9 @@ runs:
         echo TEST_TIMEOUT=310 | tee -a $GITHUB_ENV
         echo NO_OUTPUT_TIMEOUT=320 | tee -a $GITHUB_ENV
         echo PRESERVE_ENVVARS=REPLICATION_SYNC_TIMEOUT,TEST_TIMEOUT,NO_OUTPUT_TIMEOUT | tee -a $GITHUB_ENV
+        # Configure AWS Region to avoid of issue:
+        #   https://github.com/tarantool/tarantool-qa/issues/111
+        echo AWS_DEFAULT_REGION=MS | tee -a $GITHUB_ENV
         # This switching off swap command will not work as github step
         # run from inside github 'container' tag. Also it will fail to
         # run from it. So running it only outside of docker container.

--- a/.github/actions/pack_and_deploy/README.md
+++ b/.github/actions/pack_and_deploy/README.md
@@ -1,0 +1,11 @@
+# Pack and Deploy Tarantool packages
+
+Action packs and deploys Tarantool packages.
+
+## How to use Github Action from Github workflow
+
+Add the following code to the running steps after checkout done:
+```
+  - uses: ./.github/actions/pack_and_deploy
+```
+

--- a/.github/actions/pack_and_deploy/action.yml
+++ b/.github/actions/pack_and_deploy/action.yml
@@ -17,7 +17,26 @@ runs:
             startsWith(github.ref, 'refs/heads/2.') ||
             startsWith(github.ref, 'refs/tags') ) }} ; then
           sudo apt-get -y update
-          sudo apt-get install -y procmail createrepo awscli reprepro
+          sudo apt-get install -y procmail awscli reprepro
+          # For RPM packages need to build 'createrepo_c' tool from
+          # sources till Github Actions will use ubuntu-21.04 where
+          # it be avaliable as DEB package for installation.
+          if [ ${OS} == 'el' -o ${OS} == 'fedora' -o ${OS} == 'opensuse-leap' ] ; then
+            git clone https://github.com/rpm-software-management/createrepo_c.git
+            cd createrepo_c/
+            # let's use the latest checked version
+            git checkout 0.17.1
+            mkdir build
+            cd build
+            sudo apt install -y libbz2-dev cmake libmagic-dev \
+              libglib2.0-dev libcurl4-openssl-dev libxml2-dev \
+              libpython3-dev librpm-dev libssl-dev libsqlite3-dev \
+              liblzma-dev zlib1g-dev libzstd-dev doxygen
+            cmake .. -DWITH_ZCHUNK=OFF -DWITH_LIBMODULEMD=OFF
+            make -j $(nproc)
+            sudo make install
+            cd ../..
+          fi
           mkdir -p ~/.gnupg
           echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
           make -f .gitlab.mk deploy

--- a/.github/actions/pack_and_deploy/action.yml
+++ b/.github/actions/pack_and_deploy/action.yml
@@ -1,0 +1,25 @@
+name: 'Pack and Deploy'
+description: 'Pack and deploy the package'
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        # Our testing expects that the init process (PID 1) will
+        # reap orphan processes. At least the following test leans
+        # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
+        echo PACKPACK_EXTRA_DOCKER_RUN_PARAMS='--init' | tee -a $GITHUB_ENV
+        # create packages
+        make -f .gitlab.mk package
+        # deploy packages
+        if ${{ github.event_name == 'push' &&
+          ( github.ref == 'refs/heads/master' ||
+            github.ref == 'refs/heads/1.10' ||
+            startsWith(github.ref, 'refs/heads/2.') ||
+            startsWith(github.ref, 'refs/tags') ) }} ; then
+          sudo apt-get -y update
+          sudo apt-get install -y procmail createrepo awscli reprepro
+          mkdir -p ~/.gnupg
+          echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
+          make -f .gitlab.mk deploy
+        fi
+      shell: bash

--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -7,9 +7,6 @@ on:
     types: [backend_automation]
   workflow_dispatch:
 
-env:
-  CI_MAKE: make -f .gitlab.mk
-
 jobs:
   centos_7:
     # We want to run on external PRs, but not on our own internal PRs
@@ -31,10 +28,6 @@ jobs:
       - uses: ./.github/actions/environment
       - name: packaging
         env:
-          # Our testing expects that the init process (PID 1) will
-          # reap orphan processes. At least the following test leans
-          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '--init'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
@@ -42,20 +35,9 @@ jobs:
           RELEASE_REPO_S3_DIR: ${{ secrets.RELEASE_REPO_S3_DIR }}
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGN_KEY: ${{ secrets.GPG_SIGN_KEY }}
-        run: |
-          if ${{ github.event_name == 'push' &&
-              ( github.ref == 'refs/heads/master' ||
-                github.ref == 'refs/heads/1.10' ||
-                startsWith(github.ref, 'refs/heads/2.') ||
-                startsWith(github.ref, 'refs/tags') ) }} ; then
-            sudo apt-get -y update
-            sudo apt-get install -y procmail createrepo awscli reprepro
-            mkdir -p ~/.gnupg
-            echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
-            OS=el DIST=7 ${CI_MAKE} deploy
-          else
-            OS=el DIST=7 ${CI_MAKE} package
-          fi
+          OS: 'el'
+          DIST: '7'
+        uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -7,9 +7,6 @@ on:
     types: [backend_automation]
   workflow_dispatch:
 
-env:
-  CI_MAKE: make -f .gitlab.mk
-
 jobs:
   centos_8:
     # We want to run on external PRs, but not on our own internal PRs
@@ -31,10 +28,6 @@ jobs:
       - uses: ./.github/actions/environment
       - name: packaging
         env:
-          # Our testing expects that the init process (PID 1) will
-          # reap orphan processes. At least the following test leans
-          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '--init'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
@@ -42,20 +35,9 @@ jobs:
           RELEASE_REPO_S3_DIR: ${{ secrets.RELEASE_REPO_S3_DIR }}
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGN_KEY: ${{ secrets.GPG_SIGN_KEY }}
-        run: |
-          if ${{ github.event_name == 'push' &&
-              ( github.ref == 'refs/heads/master' ||
-                github.ref == 'refs/heads/1.10' ||
-                startsWith(github.ref, 'refs/heads/2.') ||
-                startsWith(github.ref, 'refs/tags') ) }} ; then
-            sudo apt-get -y update
-            sudo apt-get install -y procmail createrepo awscli reprepro
-            mkdir -p ~/.gnupg
-            echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
-            OS=el DIST=8 ${CI_MAKE} deploy
-          else
-            OS=el DIST=8 ${CI_MAKE} package
-          fi
+          OS: 'el'
+          DIST: '8'
+        uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -7,9 +7,6 @@ on:
     types: [backend_automation]
   workflow_dispatch:
 
-env:
-  CI_MAKE: make -f .gitlab.mk
-
 jobs:
   debian_10:
     # We want to run on external PRs, but not on our own internal PRs
@@ -31,10 +28,6 @@ jobs:
       - uses: ./.github/actions/environment
       - name: packaging
         env:
-          # Our testing expects that the init process (PID 1) will
-          # reap orphan processes. At least the following test leans
-          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '--init'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
@@ -42,20 +35,9 @@ jobs:
           RELEASE_REPO_S3_DIR: ${{ secrets.RELEASE_REPO_S3_DIR }}
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGN_KEY: ${{ secrets.GPG_SIGN_KEY }}
-        run: |
-          if ${{ github.event_name == 'push' &&
-              ( github.ref == 'refs/heads/master' ||
-                github.ref == 'refs/heads/1.10' ||
-                startsWith(github.ref, 'refs/heads/2.') ||
-                startsWith(github.ref, 'refs/tags') ) }} ; then
-            sudo apt-get -y update
-            sudo apt-get install -y procmail createrepo awscli reprepro
-            mkdir -p ~/.gnupg
-            echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
-            OS=debian DIST=buster ${CI_MAKE} deploy
-          else
-            OS=debian DIST=buster ${CI_MAKE} package
-          fi
+          OS: 'debian'
+          DIST: 'buster'
+        uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -7,9 +7,6 @@ on:
     types: [backend_automation]
   workflow_dispatch:
 
-env:
-  CI_MAKE: make -f .gitlab.mk
-
 jobs:
   debian_11:
     # We want to run on external PRs, but not on our own internal PRs
@@ -31,10 +28,6 @@ jobs:
       - uses: ./.github/actions/environment
       - name: packaging
         env:
-          # Our testing expects that the init process (PID 1) will
-          # reap orphan processes. At least the following test leans
-          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '--init'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
@@ -42,20 +35,9 @@ jobs:
           RELEASE_REPO_S3_DIR: ${{ secrets.RELEASE_REPO_S3_DIR }}
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGN_KEY: ${{ secrets.GPG_SIGN_KEY }}
-        run: |
-          if ${{ github.event_name == 'push' &&
-              ( github.ref == 'refs/heads/master' ||
-                github.ref == 'refs/heads/1.10' ||
-                startsWith(github.ref, 'refs/heads/2.') ||
-                startsWith(github.ref, 'refs/tags') ) }} ; then
-            sudo apt-get -y update
-            sudo apt-get install -y procmail createrepo awscli reprepro
-            mkdir -p ~/.gnupg
-            echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
-            OS=debian DIST=bullseye ${CI_MAKE} deploy
-          else
-            OS=debian DIST=bullseye ${CI_MAKE} package
-          fi
+          OS: 'debian'
+          DIST: 'bullseye'
+        uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -7,9 +7,6 @@ on:
     types: [backend_automation]
   workflow_dispatch:
 
-env:
-  CI_MAKE: make -f .gitlab.mk
-
 jobs:
   debian_9:
     # We want to run on external PRs, but not on our own internal PRs
@@ -31,10 +28,6 @@ jobs:
       - uses: ./.github/actions/environment
       - name: packaging
         env:
-          # Our testing expects that the init process (PID 1) will
-          # reap orphan processes. At least the following test leans
-          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '--init'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
@@ -42,20 +35,9 @@ jobs:
           RELEASE_REPO_S3_DIR: ${{ secrets.RELEASE_REPO_S3_DIR }}
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGN_KEY: ${{ secrets.GPG_SIGN_KEY }}
-        run: |
-          if ${{ github.event_name == 'push' &&
-              ( github.ref == 'refs/heads/master' ||
-                github.ref == 'refs/heads/1.10' ||
-                startsWith(github.ref, 'refs/heads/2.') ||
-                startsWith(github.ref, 'refs/tags') ) }} ; then
-            sudo apt-get -y update
-            sudo apt-get install -y procmail createrepo awscli reprepro
-            mkdir -p ~/.gnupg
-            echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
-            OS=debian DIST=stretch ${CI_MAKE} deploy
-          else
-            OS=debian DIST=stretch ${CI_MAKE} package
-          fi
+          OS: 'debian'
+          DIST: 'stretch'
+        uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_28.yml
+++ b/.github/workflows/fedora_28.yml
@@ -7,9 +7,6 @@ on:
     types: [backend_automation]
   workflow_dispatch:
 
-env:
-  CI_MAKE: make -f .gitlab.mk
-
 jobs:
   fedora_28:
     # We want to run on external PRs, but not on our own internal PRs
@@ -31,10 +28,6 @@ jobs:
       - uses: ./.github/actions/environment
       - name: packaging
         env:
-          # Our testing expects that the init process (PID 1) will
-          # reap orphan processes. At least the following test leans
-          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '--init'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
@@ -42,20 +35,9 @@ jobs:
           RELEASE_REPO_S3_DIR: ${{ secrets.RELEASE_REPO_S3_DIR }}
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGN_KEY: ${{ secrets.GPG_SIGN_KEY }}
-        run: |
-          if ${{ github.event_name == 'push' &&
-              ( github.ref == 'refs/heads/master' ||
-                github.ref == 'refs/heads/1.10' ||
-                startsWith(github.ref, 'refs/heads/2.') ||
-                startsWith(github.ref, 'refs/tags') ) }} ; then
-            sudo apt-get -y update
-            sudo apt-get install -y procmail createrepo awscli reprepro
-            mkdir -p ~/.gnupg
-            echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
-            OS=fedora DIST=28 ${CI_MAKE} deploy
-          else
-            OS=fedora DIST=28 ${CI_MAKE} package
-          fi
+          OS: 'fedora'
+          DIST: '28'
+        uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/fedora_28.yml
+++ b/.github/workflows/fedora_28.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_29.yml
+++ b/.github/workflows/fedora_29.yml
@@ -7,9 +7,6 @@ on:
     types: [backend_automation]
   workflow_dispatch:
 
-env:
-  CI_MAKE: make -f .gitlab.mk
-
 jobs:
   fedora_29:
     # We want to run on external PRs, but not on our own internal PRs
@@ -31,10 +28,6 @@ jobs:
       - uses: ./.github/actions/environment
       - name: packaging
         env:
-          # Our testing expects that the init process (PID 1) will
-          # reap orphan processes. At least the following test leans
-          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '--init'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
@@ -42,20 +35,9 @@ jobs:
           RELEASE_REPO_S3_DIR: ${{ secrets.RELEASE_REPO_S3_DIR }}
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGN_KEY: ${{ secrets.GPG_SIGN_KEY }}
-        run: |
-          if ${{ github.event_name == 'push' &&
-              ( github.ref == 'refs/heads/master' ||
-                github.ref == 'refs/heads/1.10' ||
-                startsWith(github.ref, 'refs/heads/2.') ||
-                startsWith(github.ref, 'refs/tags') ) }} ; then
-            sudo apt-get -y update
-            sudo apt-get install -y procmail createrepo awscli reprepro
-            mkdir -p ~/.gnupg
-            echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
-            OS=fedora DIST=29 ${CI_MAKE} deploy
-          else
-            OS=fedora DIST=29 ${CI_MAKE} package
-          fi
+          OS: 'fedora'
+          DIST: '29'
+        uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/fedora_29.yml
+++ b/.github/workflows/fedora_29.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_30.yml
+++ b/.github/workflows/fedora_30.yml
@@ -7,9 +7,6 @@ on:
     types: [backend_automation]
   workflow_dispatch:
 
-env:
-  CI_MAKE: make -f .gitlab.mk
-
 jobs:
   fedora_30:
     # We want to run on external PRs, but not on our own internal PRs
@@ -31,10 +28,6 @@ jobs:
       - uses: ./.github/actions/environment
       - name: packaging
         env:
-          # Our testing expects that the init process (PID 1) will
-          # reap orphan processes. At least the following test leans
-          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '--init'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
@@ -42,20 +35,9 @@ jobs:
           RELEASE_REPO_S3_DIR: ${{ secrets.RELEASE_REPO_S3_DIR }}
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGN_KEY: ${{ secrets.GPG_SIGN_KEY }}
-        run: |
-          if ${{ github.event_name == 'push' &&
-              ( github.ref == 'refs/heads/master' ||
-                github.ref == 'refs/heads/1.10' ||
-                startsWith(github.ref, 'refs/heads/2.') ||
-                startsWith(github.ref, 'refs/tags') ) }} ; then
-            sudo apt-get -y update
-            sudo apt-get install -y procmail createrepo awscli reprepro
-            mkdir -p ~/.gnupg
-            echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
-            OS=fedora DIST=30 ${CI_MAKE} deploy
-          else
-            OS=fedora DIST=30 ${CI_MAKE} package
-          fi
+          OS: 'fedora'
+          DIST: '30'
+        uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/fedora_30.yml
+++ b/.github/workflows/fedora_30.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_31.yml
+++ b/.github/workflows/fedora_31.yml
@@ -7,9 +7,6 @@ on:
     types: [backend_automation]
   workflow_dispatch:
 
-env:
-  CI_MAKE: make -f .gitlab.mk
-
 jobs:
   fedora_31:
     # We want to run on external PRs, but not on our own internal PRs
@@ -31,10 +28,6 @@ jobs:
       - uses: ./.github/actions/environment
       - name: packaging
         env:
-          # Our testing expects that the init process (PID 1) will
-          # reap orphan processes. At least the following test leans
-          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '--init'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
@@ -42,20 +35,9 @@ jobs:
           RELEASE_REPO_S3_DIR: ${{ secrets.RELEASE_REPO_S3_DIR }}
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGN_KEY: ${{ secrets.GPG_SIGN_KEY }}
-        run: |
-          if ${{ github.event_name == 'push' &&
-              ( github.ref == 'refs/heads/master' ||
-                github.ref == 'refs/heads/1.10' ||
-                startsWith(github.ref, 'refs/heads/2.') ||
-                startsWith(github.ref, 'refs/tags') ) }} ; then
-            sudo apt-get -y update
-            sudo apt-get install -y procmail createrepo awscli reprepro
-            mkdir -p ~/.gnupg
-            echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
-            OS=fedora DIST=31 ${CI_MAKE} deploy
-          else
-            OS=fedora DIST=31 ${CI_MAKE} package
-          fi
+          OS: 'fedora'
+          DIST: '31'
+        uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/fedora_31.yml
+++ b/.github/workflows/fedora_31.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_32.yml
+++ b/.github/workflows/fedora_32.yml
@@ -7,9 +7,6 @@ on:
     types: [backend_automation]
   workflow_dispatch:
 
-env:
-  CI_MAKE: make -f .gitlab.mk
-
 jobs:
   fedora_32:
     # We want to run on external PRs, but not on our own internal PRs
@@ -31,10 +28,6 @@ jobs:
       - uses: ./.github/actions/environment
       - name: packaging
         env:
-          # Our testing expects that the init process (PID 1) will
-          # reap orphan processes. At least the following test leans
-          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '--init'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
@@ -42,20 +35,9 @@ jobs:
           RELEASE_REPO_S3_DIR: ${{ secrets.RELEASE_REPO_S3_DIR }}
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGN_KEY: ${{ secrets.GPG_SIGN_KEY }}
-        run: |
-          if ${{ github.event_name == 'push' &&
-              ( github.ref == 'refs/heads/master' ||
-                github.ref == 'refs/heads/1.10' ||
-                startsWith(github.ref, 'refs/heads/2.') ||
-                startsWith(github.ref, 'refs/tags') ) }} ; then
-            sudo apt-get -y update
-            sudo apt-get install -y procmail createrepo awscli reprepro
-            mkdir -p ~/.gnupg
-            echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
-            OS=fedora DIST=32 ${CI_MAKE} deploy
-          else
-            OS=fedora DIST=32 ${CI_MAKE} package
-          fi
+          OS: 'fedora'
+          DIST: '32'
+        uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/fedora_32.yml
+++ b/.github/workflows/fedora_32.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_33.yml
+++ b/.github/workflows/fedora_33.yml
@@ -7,9 +7,6 @@ on:
     types: [backend_automation]
   workflow_dispatch:
 
-env:
-  CI_MAKE: make -f .gitlab.mk
-
 jobs:
   fedora_33:
     # We want to run on external PRs, but not on our own internal PRs
@@ -31,10 +28,6 @@ jobs:
       - uses: ./.github/actions/environment
       - name: packaging
         env:
-          # Our testing expects that the init process (PID 1) will
-          # reap orphan processes. At least the following test leans
-          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '--init'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
@@ -42,20 +35,9 @@ jobs:
           RELEASE_REPO_S3_DIR: ${{ secrets.RELEASE_REPO_S3_DIR }}
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGN_KEY: ${{ secrets.GPG_SIGN_KEY }}
-        run: |
-          if ${{ github.event_name == 'push' &&
-              ( github.ref == 'refs/heads/master' ||
-                github.ref == 'refs/heads/1.10' ||
-                startsWith(github.ref, 'refs/heads/2.') ||
-                startsWith(github.ref, 'refs/tags') ) }} ; then
-            sudo apt-get -y update
-            sudo apt-get install -y procmail createrepo awscli reprepro
-            mkdir -p ~/.gnupg
-            echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
-            OS=fedora DIST=33 ${CI_MAKE} deploy
-          else
-            OS=fedora DIST=33 ${CI_MAKE} package
-          fi
+          OS: 'fedora'
+          DIST: '33'
+        uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/fedora_33.yml
+++ b/.github/workflows/fedora_33.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -7,9 +7,6 @@ on:
     types: [backend_automation]
   workflow_dispatch:
 
-env:
-  CI_MAKE: make -f .gitlab.mk
-
 jobs:
   opensuse_15_1:
     # We want to run on external PRs, but not on our own internal PRs
@@ -31,10 +28,6 @@ jobs:
       - uses: ./.github/actions/environment
       - name: packaging
         env:
-          # Our testing expects that the init process (PID 1) will
-          # reap orphan processes. At least the following test leans
-          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '--init'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
@@ -42,20 +35,9 @@ jobs:
           RELEASE_REPO_S3_DIR: ${{ secrets.RELEASE_REPO_S3_DIR }}
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGN_KEY: ${{ secrets.GPG_SIGN_KEY }}
-        run: |
-          if ${{ github.event_name == 'push' &&
-              ( github.ref == 'refs/heads/master' ||
-                github.ref == 'refs/heads/1.10' ||
-                startsWith(github.ref, 'refs/heads/2.') ||
-                startsWith(github.ref, 'refs/tags') ) }} ; then
-            sudo apt-get -y update
-            sudo apt-get install -y procmail createrepo awscli reprepro
-            mkdir -p ~/.gnupg
-            echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
-            OS=opensuse-leap DIST=15.1 ${CI_MAKE} deploy
-          else
-            OS=opensuse-leap DIST=15.1 ${CI_MAKE} package
-          fi
+          OS: 'opensuse-leap'
+          DIST: '15.1'
+        uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -7,9 +7,6 @@ on:
     types: [backend_automation]
   workflow_dispatch:
 
-env:
-  CI_MAKE: make -f .gitlab.mk
-
 jobs:
   opensuse_15_2:
     # We want to run on external PRs, but not on our own internal PRs
@@ -31,10 +28,6 @@ jobs:
       - uses: ./.github/actions/environment
       - name: packaging
         env:
-          # Our testing expects that the init process (PID 1) will
-          # reap orphan processes. At least the following test leans
-          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '--init'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
@@ -42,20 +35,9 @@ jobs:
           RELEASE_REPO_S3_DIR: ${{ secrets.RELEASE_REPO_S3_DIR }}
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGN_KEY: ${{ secrets.GPG_SIGN_KEY }}
-        run: |
-          if ${{ github.event_name == 'push' &&
-              ( github.ref == 'refs/heads/master' ||
-                github.ref == 'refs/heads/1.10' ||
-                startsWith(github.ref, 'refs/heads/2.') ||
-                startsWith(github.ref, 'refs/tags') ) }} ; then
-            sudo apt-get -y update
-            sudo apt-get install -y procmail createrepo awscli reprepro
-            mkdir -p ~/.gnupg
-            echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
-            OS=opensuse-leap DIST=15.2 ${CI_MAKE} deploy
-          else
-            OS=opensuse-leap DIST=15.2 ${CI_MAKE} package
-          fi
+          OS: 'opensuse-leap'
+          DIST: '15.2'
+        uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ubuntu_14_04.yml
+++ b/.github/workflows/ubuntu_14_04.yml
@@ -7,9 +7,6 @@ on:
     types: [backend_automation]
   workflow_dispatch:
 
-env:
-  CI_MAKE: make -f .gitlab.mk
-
 jobs:
   ubuntu_14_04:
     # We want to run on external PRs, but not on our own internal PRs
@@ -31,10 +28,6 @@ jobs:
       - uses: ./.github/actions/environment
       - name: packaging
         env:
-          # Our testing expects that the init process (PID 1) will
-          # reap orphan processes. At least the following test leans
-          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '--init'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
@@ -42,20 +35,9 @@ jobs:
           RELEASE_REPO_S3_DIR: ${{ secrets.RELEASE_REPO_S3_DIR }}
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGN_KEY: ${{ secrets.GPG_SIGN_KEY }}
-        run: |
-          if ${{ github.event_name == 'push' &&
-              ( github.ref == 'refs/heads/master' ||
-                github.ref == 'refs/heads/1.10' ||
-                startsWith(github.ref, 'refs/heads/2.') ||
-                startsWith(github.ref, 'refs/tags') ) }} ; then
-            sudo apt-get -y update
-            sudo apt-get install -y procmail createrepo awscli reprepro
-            mkdir -p ~/.gnupg
-            echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
-            OS=ubuntu DIST=trusty ${CI_MAKE} deploy
-          else
-            OS=ubuntu DIST=trusty ${CI_MAKE} package
-          fi
+          OS: 'ubuntu'
+          DIST: 'trusty'
+        uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/ubuntu_14_04.yml
+++ b/.github/workflows/ubuntu_14_04.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -7,9 +7,6 @@ on:
     types: [backend_automation]
   workflow_dispatch:
 
-env:
-  CI_MAKE: make -f .gitlab.mk
-
 jobs:
   ubuntu_16_04:
     # We want to run on external PRs, but not on our own internal PRs
@@ -31,10 +28,6 @@ jobs:
       - uses: ./.github/actions/environment
       - name: packaging
         env:
-          # Our testing expects that the init process (PID 1) will
-          # reap orphan processes. At least the following test leans
-          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '--init'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
@@ -42,20 +35,9 @@ jobs:
           RELEASE_REPO_S3_DIR: ${{ secrets.RELEASE_REPO_S3_DIR }}
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGN_KEY: ${{ secrets.GPG_SIGN_KEY }}
-        run: |
-          if ${{ github.event_name == 'push' &&
-              ( github.ref == 'refs/heads/master' ||
-                github.ref == 'refs/heads/1.10' ||
-                startsWith(github.ref, 'refs/heads/2.') ||
-                startsWith(github.ref, 'refs/tags') ) }} ; then
-            sudo apt-get -y update
-            sudo apt-get install -y procmail createrepo awscli reprepro
-            mkdir -p ~/.gnupg
-            echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
-            OS=ubuntu DIST=xenial ${CI_MAKE} deploy
-          else
-            OS=ubuntu DIST=xenial ${CI_MAKE} package
-          fi
+          OS: 'ubuntu'
+          DIST: 'xenial'
+        uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -7,9 +7,6 @@ on:
     types: [backend_automation]
   workflow_dispatch:
 
-env:
-  CI_MAKE: make -f .gitlab.mk
-
 jobs:
   ubuntu_18_04:
     # We want to run on external PRs, but not on our own internal PRs
@@ -31,10 +28,6 @@ jobs:
       - uses: ./.github/actions/environment
       - name: packaging
         env:
-          # Our testing expects that the init process (PID 1) will
-          # reap orphan processes. At least the following test leans
-          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '--init'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
@@ -42,20 +35,9 @@ jobs:
           RELEASE_REPO_S3_DIR: ${{ secrets.RELEASE_REPO_S3_DIR }}
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGN_KEY: ${{ secrets.GPG_SIGN_KEY }}
-        run: |
-          if ${{ github.event_name == 'push' &&
-              ( github.ref == 'refs/heads/master' ||
-                github.ref == 'refs/heads/1.10' ||
-                startsWith(github.ref, 'refs/heads/2.') ||
-                startsWith(github.ref, 'refs/tags') ) }} ; then
-            sudo apt-get -y update
-            sudo apt-get install -y procmail createrepo awscli reprepro
-            mkdir -p ~/.gnupg
-            echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
-            OS=ubuntu DIST=bionic ${CI_MAKE} deploy
-          else
-            OS=ubuntu DIST=bionic ${CI_MAKE} package
-          fi
+          OS: 'ubuntu'
+          DIST: 'bionic'
+        uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -7,9 +7,6 @@ on:
     types: [backend_automation]
   workflow_dispatch:
 
-env:
-  CI_MAKE: make -f .gitlab.mk
-
 jobs:
   ubuntu_20_04:
     # We want to run on external PRs, but not on our own internal PRs
@@ -31,10 +28,6 @@ jobs:
       - uses: ./.github/actions/environment
       - name: packaging
         env:
-          # Our testing expects that the init process (PID 1) will
-          # reap orphan processes. At least the following test leans
-          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: '--init'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
@@ -42,20 +35,9 @@ jobs:
           RELEASE_REPO_S3_DIR: ${{ secrets.RELEASE_REPO_S3_DIR }}
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGN_KEY: ${{ secrets.GPG_SIGN_KEY }}
-        run: |
-          if ${{ github.event_name == 'push' &&
-              ( github.ref == 'refs/heads/master' ||
-                github.ref == 'refs/heads/1.10' ||
-                startsWith(github.ref, 'refs/heads/2.') ||
-                startsWith(github.ref, 'refs/tags') ) }} ; then
-            sudo apt-get -y update
-            sudo apt-get install -y procmail createrepo awscli reprepro
-            mkdir -p ~/.gnupg
-            echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
-            OS=ubuntu DIST=focal ${CI_MAKE} deploy
-          else
-            OS=ubuntu DIST=focal ${CI_MAKE} package
-          fi
+          OS: 'ubuntu'
+          DIST: 'focal'
+        uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.gitlab.mk
+++ b/.gitlab.mk
@@ -126,7 +126,7 @@ deploy_prepare:
 package: deploy_prepare
 	PACKPACK_EXTRA_DOCKER_RUN_PARAMS="--network=host ${PACKPACK_EXTRA_DOCKER_RUN_PARAMS}" ./packpack/packpack
 
-deploy: package
+deploy:
 	echo ${GPG_SECRET_KEY} | base64 -d | gpg --batch --import || true
 	./tools/update_repo.sh -o=${OS} -d=${DIST} \
 		-b="${LIVE_REPO_S3_DIR}/${BUCKET}" build

--- a/.gitlab.mk
+++ b/.gitlab.mk
@@ -126,6 +126,9 @@ deploy_prepare:
 package: deploy_prepare
 	PACKPACK_EXTRA_DOCKER_RUN_PARAMS="--network=host ${PACKPACK_EXTRA_DOCKER_RUN_PARAMS}" ./packpack/packpack
 
+# found that libcreaterepo_c.so installed in local lib path
+deploy: export LD_LIBRARY_PATH=/usr/local/lib
+
 deploy:
 	echo ${GPG_SECRET_KEY} | base64 -d | gpg --batch --import || true
 	./tools/update_repo.sh -o=${OS} -d=${DIST} \

--- a/tools/update_repo.sh
+++ b/tools/update_repo.sh
@@ -618,7 +618,7 @@ EOF
 # The 'pack_rpm' function especialy created for RPM packages. It works
 # with RPM packing OS like CentOS, Fedora. It is based on globally known
 # tool 'createrepo' from:
-#   https://linux.die.net/man/8/createrepo
+#   https://github.com/rpm-software-management/createrepo_c.git
 # This tool works with single distribution of the given OS.
 #
 # The RPM packages structure must pass the documented instructions at
@@ -657,7 +657,7 @@ function pack_rpm {
     done
 
     # create the new repository metadata files
-    createrepo --no-database --update --workers=2 \
+    createrepo_c --no-database --update --workers=2 \
         --compress-type=gz --simple-md-filenames .
 
     updated_rpms=0


### PR DESCRIPTION
Patch set consists of 2 commits:

1. Created local composite action 'pack_and_deploy' for Tarantool packages
    creation and deployment. It was created using local scripts in packages
    workflows. It let to change common parts of packages creations and
    deployment in each packaging workflow to call for this action. It helped
    to consolidate all the instructions on packages creation and deployment
    in a single place.

2. Enabling ubuntu-20.04 hosts for packaging workflows found that DEB
    package Github Actions workflows do not need to install createrepo
    tool. Also found that createrepo is not ready for ubuntu-20.04 as
    described in (till ubuntu-21.04 where it is available as the new
    version of this tool named as 'createrepo_c' as DEB package):

  3a7c21023367424baa9bf2d4d823102cb2b3c751 ('github-ci: ubuntu-20.04 misses createrepo package')

To fix it added 'createrepo_c' build and installation from sources
and changed in update_repo tool 'createrepo' tool to 'createrepo_c'.
This patch is needed to use these workflows on self-hosted runners
which run under ubuntu-20.04 by default for now.

Also checking the patch on ubuntu-20.04 hosts got the following issue:
```
  Regenerated DEB file: pool/xenial/main/t/tarantool/tarantool-common_2.8.0.185.g4c3e0eb-1_all.deb

  <botocore.awsrequest.AWSRequest object at 0x7f7998a4ca90>

  <botocore.awsrequest.AWSRequest object at 0x7f627d965070>
  make: *** [.gitlab.mk:131: deploy] Error 255
  Error: Process completed with exit code 2.
```
Found that there is already issue exists in Github Actions on it [1].
Provided solution to setup AWS region in environment helped to workaround the issue [2].

Closes tarantool/tarantool-qa#110
Closes tarantool/tarantool-qa#111

[1]: https://github.com/aws/aws-cli/issues/5234
[2]: https://github.com/aws/aws-cli/issues/5234#issuecomment-635459464