### PR TITLE
update_repo: fix remove functionality for fedora

### DIFF
--- a/tools/update_repo.sh
+++ b/tools/update_repo.sh
@@ -895,6 +895,8 @@ function remove_rpm {
             # '1' is $(RELEASE) RPM spec directive value and the second
             # '1' is the number of rebuilds.
             os_dist="lp$(echo $option_dist | sed 's#\.##g').1.1"
+        elif [ "$os" == "fedora" ]; then
+            os_dist="1.fc${option_dist}"
         else
             os_dist="1.${os}${option_dist}"
         fi


### PR DESCRIPTION
Found that running package removement command from S3:

`  ./tools/update_repo.sh -o=fedora -d=30 -b=s3://tarantool_repo/live/1.10 -r=tarantool-1.10.9.108`

it searched to remove:

`  Searching to remove: s3://tarantool_repo/live/1.10/fedora/30/SRPMS/Packages/tarantool-1.10.9.108-1.fedora30.src.rpm`

while it had to be:

`  Searching to remove: s3://tarantool_repo/live/1.10/fedora/30/SRPMS/Packages/tarantool-1.10.9.108-1.fc30.src.rpm`

where 'fc30' had to be instead of 'fedora30'. This patch fixes it.