### PR TITLE
build: fix configuring using cmake3 command

### DIFF
--- a/changelogs/unreleased/fix-cmake3-build.md
+++ b/changelogs/unreleased/fix-cmake3-build.md
@@ -1,0 +1,7 @@
+## bugfix/build
+
+* Fixed libcurl configuring, when tarantool itself is configured with `cmake3`
+  command and there is no `cmake` command in PATH (gh-5955).
+
+  This affects building tarantool from sources with bundled libcurl (it is the
+  default mode).

--- a/cmake/BuildLibCURL.cmake
+++ b/cmake/BuildLibCURL.cmake
@@ -154,7 +154,7 @@ macro(curl_build)
         STAMP_DIR ${LIBCURL_BINARY_DIR}/stamp
         BINARY_DIR ${LIBCURL_BINARY_DIR}/curl
         CONFIGURE_COMMAND
-            cd <BINARY_DIR> && cmake <SOURCE_DIR>
+            cd <BINARY_DIR> && ${CMAKE_COMMAND} <SOURCE_DIR>
                 ${LIBCURL_CMAKE_FLAGS}
         BUILD_COMMAND cd <BINARY_DIR> && $(MAKE)
         INSTALL_COMMAND cd <BINARY_DIR> && $(MAKE) install)


### PR DESCRIPTION
`cmake` command was hardcoded for configuring libcurl, however only
`cmake3` may be installed in a system. Now we use the same cmake command
for configuring libcurl as one that is used for configuring tarantool
itself.

The problem exists since 2.6.0-196-g2b0760192 ('build: enable cmake in
curl build').

Fixes #5955