### PR TITLE
github-ci: kill hanged processes on self runners

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -11,6 +11,11 @@ runs:
         # Configure AWS Region to avoid of issue:
         #   https://github.com/tarantool/tarantool-qa/issues/111
         echo AWS_DEFAULT_REGION=MS | tee -a $GITHUB_ENV
+        # For self-hosted runners run w/o restart may need to kill
+        # hanged processes that could be leaved from the previous
+        # workflows runs.
+        ps aux | grep " tarantool " | awk '{system("kill -9 "$2)}' || true
+        ps aux | grep "test-run.py " | awk '{system("kill -9 "$2)}' || true
         # This switching off swap command will not work as github step
         # run from inside github 'container' tag. Also it will fail to
         # run from it. So running it only outside of docker container.


### PR DESCRIPTION
For self-hosted runners run w/o restart may need to kill hanged
processes that could be leaved from the previous workflows runs.
This patch implements in cleanup with kill for such processes in
'environment' actions which is called for all workflows and runs
before main steps. Cleanup searches for two names patterns of
running processes:

  - ' tarantool '
  - 'test-run.py '

Closes tarantool/tarantool-qa#114