### PR TITLE
Mechanik20051988/gh 5385 tiny tuples with perf test v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ doc/*/Makefile
 extra/Makefile
 extra/*/Makefile
 extra/luarocks/hardcoded.lua
+perf/Makefile
 test/Makefile
 test/*/Makefile
 Doxyfile.API
@@ -88,6 +89,7 @@ src/box/lua/*.lua.c
 src/tarantool
 src/module.h
 tarantool-*.tar.gz
+perf/*.perftest
 test/lib/
 test/unit/*.test
 test/unit/fiob

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -581,6 +581,7 @@ include (cmake/rpm.cmake)
 add_subdirectory(src)
 add_subdirectory(extra)
 add_subdirectory(test)
+add_subdirectory(perf)
 add_subdirectory(doc)
 
 option(WITH_NOTIFY_SOCKET "Enable notifications on NOTIFY_SOCKET" ON)

--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -1,0 +1,25 @@
+set(CMAKE_CXX_STANDARD 11)
+
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(AUTHOR_WARNING "Benchmark available only in release build")
+    return()
+endif()
+
+find_package(benchmark QUIET)
+if (NOT ${benchmark_FOUND})
+    message(AUTHOR_WARNING "Google Benchmark submodule not found")
+    return()
+endif()
+
+file(GLOB all_sources *.c *.cc)
+
+if(NOT TARGET_OS_OPENBSD)
+    set(LIB_DL "dl")
+endif()
+
+include_directories(${MSGPUCK_INCLUDE_DIRS})
+include_directories(${PROJECT_SOURCE_DIR}/src/box)
+include_directories(${CMAKE_SOURCE_DIR}/third_party)
+
+add_executable(tuple.perftest tuple.cc)
+target_link_libraries(tuple.perftest core box tuple benchmark::benchmark)

--- a/perf/tuple.cc
+++ b/perf/tuple.cc
@@ -1,0 +1,244 @@
+#include "memory.h"
+#include "fiber.h"
+#include "tuple.h"
+
+#include <benchmark/benchmark.h>
+
+#include <cstdlib>
+#include <vector>
+#include <iostream>
+
+enum {
+	FIELD_COUNT_MAX = 1000,
+	TUPLE_COUNT_MAX = 16384,
+	TUPLE_MAX = 1048575,
+};
+
+static void
+print_description_header(void)
+{
+	std::cout << std::endl << std::endl;
+	std::cout << "******************************************************"
+		"********************************" << std::endl;
+	std::cout << "This benchmark consists of two parts: the first one "
+		<< "checks the performance of access *" << std::endl
+		<< "to indexed tuple fields, the second one checks "
+		<< " the performance of memory allocation *" << std::endl
+		<< "and deallocation operations for tuples for typical "
+		<< "workload.                         *" << std::endl;
+	std::cout << "To check access performance, test allocates 16384 objects "
+		<< "with size near 255 (tiny   *" << std::endl << "tuples) or "
+		<< "5000 (big tuples) bytes and push it in the vector. Then, in "
+		<< "a loop, test  *" << std::endl << "checks the preformnance of "
+		<< "access to indexed fields in random tuple.                 *"
+		<< std::endl;
+	std::cout << "To check allocation and deallocation performance, test "
+		<< " allocates 1048575 objects    *" << std::endl << "with size "
+		<< "near 255 (tiny tuples) or 5000 (big tuples) bytes and push "
+		<< "it in the       *" << std::endl << "vector. Then in a loop "
+		<< "test checks performance of one pair of memory allocation "
+		<< "and  *" << std::endl << "deallocation operations.        "
+		<< "                                                     *"
+		<< std::endl;
+	std::cout << "******************************************************"
+		"********************************" << std::endl;
+	std::cout << std::endl << std::endl;
+}
+
+static void
+free_random_tuple(std::vector<struct tuple*>& v)
+{
+	unsigned i = rand() & (v.size() - 1);
+	tuple_unref(v[i]);
+	v[i] = v.back();
+	v.pop_back();
+
+}
+
+static bool
+tuple_alloc_default(std::vector<struct tuple*>& v, box_tuple_format_t *format,
+		    char *tuple_buf, char *tuple_buf_end)
+{
+	struct tuple *tuple = tuple_new(format, tuple_buf, tuple_buf_end);
+	if (tuple == NULL)
+		return false;
+	tuple_ref(tuple);
+	try {
+		v.push_back(tuple);
+	} catch(std::bad_alloc& e) {
+		tuple_unref(tuple);
+		return false;
+	}
+	return true;
+}
+
+static bool
+tuple_alloc(std::vector<struct tuple*>& v, box_tuple_format_t *format,
+	    char *tuple_buf, unsigned tuple_buf_size, bool is_tiny)
+{
+	char *tuple_buf_end = tuple_buf;
+	unsigned max_tuple_size = 0;
+	unsigned field_size_max = mp_sizeof_uint(RAND_MAX);
+	unsigned count = 0;
+
+	if (is_tiny)
+		max_tuple_size = UINT8_MAX;
+	else
+		max_tuple_size = tuple_buf_size;
+
+	/*
+	 * We don't know how many random items will fit in tuple with
+	 * fixed size. That's why first we encode items, and then calculate
+	 * array size for this items count. Then we move array items from the
+	 * beginning of the buffer by the size of the array header.
+	 */
+	while (tuple_buf_end - tuple_buf <
+	       max_tuple_size - field_size_max - mp_sizeof_array(count + 1)) {
+		tuple_buf_end = mp_encode_uint(tuple_buf_end, rand());
+		count++;
+	}
+
+	memmove(tuple_buf + mp_sizeof_array(count), tuple_buf, tuple_buf_end - tuple_buf);
+	mp_encode_array(tuple_buf, count);
+
+	return tuple_alloc_default(v, format, tuple_buf, tuple_buf_end + mp_sizeof_array(count));
+}
+
+static void
+free_tuples(std::vector<struct tuple *> v)
+{
+	for (unsigned i = 0; i < v.size(); i++)
+		tuple_unref(v[i]);
+	v.clear();
+}
+
+static void
+access_index_field(std::vector<struct tuple *> &v, unsigned field)
+{
+	uint32_t out;
+	unsigned i = rand() & (v.size() - 1);
+	::benchmark::DoNotOptimize(tuple_field_u32(v[i], field, &out));
+}
+
+static void
+access_tuple_fields(benchmark::State& state)
+{
+	static const unsigned tuple_buf_size = 5 /*array header */ +
+		FIELD_COUNT_MAX * mp_sizeof_uint(RAND_MAX);
+	char tuple_buf[tuple_buf_size];
+	std::vector<struct tuple *>tuples;
+	unsigned count = state.range(0);
+	bool is_tiny = state.range(1);
+	unsigned field = state.range(2);
+	uint32_t fieldno1[] = {1}, fieldno2[] = {field};
+	uint32_t type1[] = {FIELD_TYPE_UNSIGNED};
+	uint32_t type2[] = {FIELD_TYPE_UNSIGNED};
+	box_key_def_t *key_defs[] = {
+		box_key_def_new(fieldno1, type1, 1),
+		box_key_def_new(fieldno2, type2, 1)
+	};
+	box_tuple_format_t *format = NULL;
+
+	if (key_defs[0] == NULL || key_defs[1] == NULL) {
+		state.SkipWithError("Failed to create key_defs");
+		goto finish;
+	}
+
+	format = box_tuple_format_new(key_defs, 2);
+	if (format == NULL) {
+		state.SkipWithError("Failed to create tuple format");
+		goto finish;
+	}
+
+	for (unsigned i = 0; i < count; i++) {
+		if (!tuple_alloc(tuples, format, tuple_buf,
+				 tuple_buf_size, is_tiny)) {
+			state.SkipWithError("Failed to allocate tuple");
+			goto finish;
+		}
+	}
+
+	for (auto _ : state)
+		access_index_field(tuples, field);
+
+finish:
+	free_tuples(tuples);
+	if (format != NULL)
+		tuple_format_unref(format);
+	if (key_defs[0] != NULL)
+		box_key_def_delete(key_defs[0]);
+	if (key_defs[1] != NULL)
+		box_key_def_delete(key_defs[1]);
+}
+
+static void
+alloc_free_tuple(benchmark::State& state)
+{
+	static const unsigned tuple_buf_size = 5 /*array header */ +
+		FIELD_COUNT_MAX * mp_sizeof_uint(RAND_MAX);
+	char tuple_buf[tuple_buf_size];
+	std::vector<struct tuple *>tuples;
+	unsigned count = state.range(0);
+	bool is_tiny = state.range(1);
+	unsigned mask = (is_tiny ? 0x7f : 0xfff);
+	unsigned size_min = (is_tiny ? 5 : UINT8_MAX + 1);
+	unsigned size_max = (is_tiny ? UINT8_MAX : tuple_buf_size);
+
+	/*
+	 * Usually we need to create valid msgpuck array for tuple
+	 * body, but here we check only allocation/deallocation
+	 * preformance, so we don't need it.
+	 */
+	memset(tuple_buf, 0, sizeof(tuple_buf));
+	for (unsigned i = 0; i < count; i++) {
+		unsigned size = size_min + rand() & mask;
+		if (size > size_max) {
+			state.SkipWithError("Bad tuple size");
+			goto finish;
+		}
+		if (! tuple_alloc_default(tuples, box_tuple_format_default(),
+					  tuple_buf, tuple_buf + size)) {
+			state.SkipWithError("Failed to allocate tuple");
+			goto finish;
+		}
+	}
+
+	for (auto _ : state) {
+		unsigned size = size_min + rand() & mask;
+		if (! tuple_alloc_default(tuples, box_tuple_format_default(),
+					  tuple_buf, tuple_buf + size)) {
+			state.SkipWithError("Failed to allocate tuple");
+			goto finish;
+		}
+		free_random_tuple(tuples);
+	}
+
+finish:
+	free_tuples(tuples);
+}
+
+BENCHMARK(access_tuple_fields)
+	->ArgsProduct({{TUPLE_COUNT_MAX}, {0, 1}, {1, 2, 8, 32}})
+	->ArgNames({"tuples count", "is_tiny", "access field"});
+
+BENCHMARK(alloc_free_tuple)
+	->ArgsProduct({{TUPLE_MAX}, {0, 1}})
+	->ArgNames({"tuples count", "is_tiny"});
+
+int main(int argc, char** argv)
+{
+	::benchmark::Initialize(&argc, argv);
+	if (::benchmark::ReportUnrecognizedArguments(argc, argv))
+		return 1;
+
+	print_description_header();
+	memory_init();
+	fiber_init(fiber_c_invoke);
+	tuple_init(NULL);
+
+	::benchmark::RunSpecifiedBenchmarks();
+
+	tuple_free();
+	fiber_free();
+	memory_free();
+}

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -4538,7 +4538,7 @@ on_drop_sequence_data_rollback(struct trigger *trigger, void * /* event */)
 	uint32_t id;
 	if (tuple_field_u32(tuple, BOX_SEQUENCE_DATA_FIELD_ID, &id) != 0)
 		return -1;
-	int64_t val;
+	int64_t val = 0;
 	if (tuple_field_i64(tuple, BOX_SEQUENCE_DATA_FIELD_VALUE, &val) != 0)
 		return -1;
 	struct sequence *seq = sequence_by_id(id);

--- a/src/box/lua/merger.c
+++ b/src/box/lua/merger.c
@@ -1115,7 +1115,7 @@ encode_result_buffer(struct lua_State *L, struct merge_source *source,
 	while (result_len < limit && (rc =
 	       merge_source_next(source, NULL, &tuple)) == 0 &&
 	       tuple != NULL) {
-		uint32_t bsize = tuple->bsize;
+		uint32_t bsize = tuple_bsize(tuple);
 		ibuf_reserve(output_buffer, bsize);
 		memcpy(output_buffer->wpos, tuple_data(tuple), bsize);
 		output_buffer->wpos += bsize;

--- a/src/box/lua/tuple.c
+++ b/src/box/lua/tuple.c
@@ -655,7 +655,8 @@ lbox_tuple_field_by_path(struct lua_State *L)
 					     tuple_data(tuple),
 					     tuple_field_map(tuple),
 					     path, (uint32_t)len,
-					     lua_hashstring(L, 2));
+					     lua_hashstring(L, 2),
+					     tuple_is_tiny(tuple));
 	if (field == NULL)
 		return 0;
 	luamp_decode(L, luaL_msgpack_default, &field);

--- a/src/box/memtx_engine.c
+++ b/src/box/memtx_engine.c
@@ -1224,9 +1224,9 @@ memtx_tuple_new(struct tuple_format *format, const char *data, const char *end)
 	size_t tuple_len = end - data;
 	bool is_tiny = (tuple_len <= UINT8_MAX);
 	struct field_map_builder builder;
-	if (tuple_field_map_create(format, data, true, &builder) != 0)
+	if (tuple_field_map_create(format, data, true, &builder, &is_tiny) != 0)
 		goto end;
-	uint32_t field_map_size = field_map_build_size(&builder);
+	uint32_t field_map_size = field_map_build_size(&builder, is_tiny);
 	/*
 	 * Data offset is calculated from the begin of the struct
 	 * tuple base, not from memtx_tuple, because the struct
@@ -1234,6 +1234,7 @@ memtx_tuple_new(struct tuple_format *format, const char *data, const char *end)
 	 */
 	is_tiny = (is_tiny && (sizeof(struct tuple) +
 			       field_map_size <= MAX_TINY_DATA_OFFSET));
+	field_map_size = field_map_build_size(&builder, is_tiny);
 	uint32_t extra_size = field_map_size +
 			      !is_tiny * sizeof(struct tuple_extra);
 	uint32_t data_offset = sizeof(struct tuple) + extra_size;
@@ -1278,7 +1279,7 @@ memtx_tuple_new(struct tuple_format *format, const char *data, const char *end)
 	tuple_set_data_offset(tuple, data_offset);
 	tuple_set_dirty_bit(tuple, false);
 	char *raw = (char *) tuple + data_offset;
-	field_map_build(&builder, raw - field_map_size);
+	field_map_build(&builder, raw - field_map_size, is_tiny);
 	memcpy(raw, data, tuple_len);
 	say_debug("%s(%zu) = %p", __func__, tuple_len, memtx_tuple);
 end:

--- a/src/box/memtx_engine.c
+++ b/src/box/memtx_engine.c
@@ -1221,6 +1221,8 @@ memtx_tuple_new(struct tuple_format *format, const char *data, const char *end)
 	struct tuple *tuple = NULL;
 	struct region *region = &fiber()->gc;
 	size_t region_svp = region_used(region);
+	size_t tuple_len = end - data;
+	bool is_tiny = (tuple_len <= UINT8_MAX);
 	struct field_map_builder builder;
 	if (tuple_field_map_create(format, data, true, &builder) != 0)
 		goto end;
@@ -1230,7 +1232,12 @@ memtx_tuple_new(struct tuple_format *format, const char *data, const char *end)
 	 * tuple base, not from memtx_tuple, because the struct
 	 * tuple is not the first field of the memtx_tuple.
 	 */
-	uint32_t data_offset = sizeof(struct tuple) + field_map_size;
+	is_tiny = (is_tiny && (sizeof(struct tuple) +
+			       field_map_size <= MAX_TINY_DATA_OFFSET));
+	uint32_t extra_size = field_map_size +
+			      !is_tiny * sizeof(struct tuple_extra);
+	uint32_t data_offset = sizeof(struct tuple) + extra_size;
+	assert(!is_tiny || data_offset <= MAX_TINY_DATA_OFFSET);
 	if (data_offset > INT16_MAX) {
 		/** tuple data_offset can't be more than 15 bits */
 		diag_set(ClientError, ER_TUPLE_METADATA_IS_TOO_BIG,
@@ -1238,8 +1245,7 @@ memtx_tuple_new(struct tuple_format *format, const char *data, const char *end)
 		goto end;
 	}
 
-	size_t tuple_len = end - data;
-	size_t total = sizeof(struct memtx_tuple) + field_map_size + tuple_len;
+	size_t total = sizeof(struct memtx_tuple) + tuple_len + extra_size;
 
 	ERROR_INJECT(ERRINJ_TUPLE_ALLOC, {
 		diag_set(OutOfMemory, total, "slab allocator", "memtx_tuple");
@@ -1265,6 +1271,7 @@ memtx_tuple_new(struct tuple_format *format, const char *data, const char *end)
 	tuple = &memtx_tuple->base;
 	tuple->refs = 0;
 	memtx_tuple->version = memtx->snapshot_version;
+	tuple_set_tiny_bit(tuple, is_tiny);
 	tuple_set_bsize(tuple, tuple_len);
 	tuple->format_id = tuple_format_id(format);
 	tuple_format_ref(format);

--- a/src/box/memtx_engine.c
+++ b/src/box/memtx_engine.c
@@ -1232,7 +1232,7 @@ memtx_tuple_new(struct tuple_format *format, const char *data, const char *end)
 	 */
 	uint32_t data_offset = sizeof(struct tuple) + field_map_size;
 	if (data_offset > INT16_MAX) {
-		/** tuple->data_offset is 15 bits */
+		/** tuple data_offset can't be more than 15 bits */
 		diag_set(ClientError, ER_TUPLE_METADATA_IS_TOO_BIG,
 			 data_offset);
 		goto end;
@@ -1265,13 +1265,12 @@ memtx_tuple_new(struct tuple_format *format, const char *data, const char *end)
 	tuple = &memtx_tuple->base;
 	tuple->refs = 0;
 	memtx_tuple->version = memtx->snapshot_version;
-	assert(tuple_len <= UINT32_MAX); /* bsize is UINT32_MAX */
-	tuple->bsize = tuple_len;
+	tuple_set_bsize(tuple, tuple_len);
 	tuple->format_id = tuple_format_id(format);
 	tuple_format_ref(format);
-	tuple->data_offset = data_offset;
-	tuple->is_dirty = false;
-	char *raw = (char *) tuple + tuple->data_offset;
+	tuple_set_data_offset(tuple, data_offset);
+	tuple_set_dirty_bit(tuple, false);
+	char *raw = (char *) tuple + data_offset;
 	field_map_build(&builder, raw - field_map_size);
 	memcpy(raw, data, tuple_len);
 	say_debug("%s(%zu) = %p", __func__, tuple_len, memtx_tuple);

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -194,7 +194,7 @@ memtx_tx_story_new(struct space *space, struct tuple *tuple)
 	/* Free some memory. */
 	for (size_t i = 0; i < TX_MANAGER_GC_STEPS_SIZE; i++)
 		memtx_tx_story_gc_step();
-	assert(!tuple->is_dirty);
+	assert(!tuple_is_dirty(tuple));
 	uint32_t index_count = space->index_count;
 	assert(index_count < BOX_INDEX_MAX);
 	struct mempool *pool = &txm.memtx_tx_story_pool[index_count];
@@ -218,7 +218,7 @@ memtx_tx_story_new(struct space *space, struct tuple *tuple)
 			 "mh_history_node");
 		return NULL;
 	}
-	tuple->is_dirty = true;
+	tuple_set_dirty_bit(tuple, true);
 	tuple_ref(tuple);
 
 	story->space = space;
@@ -298,7 +298,7 @@ memtx_tx_story_delete_del_stmt(struct memtx_story *story)
 static struct memtx_story *
 memtx_tx_story_get(struct tuple *tuple)
 {
-	assert(tuple->is_dirty);
+	assert(tuple_is_dirty(tuple));
 
 	mh_int_t pos = mh_history_find(txm.history, tuple, 0);
 	assert(pos != mh_end(txm.history));
@@ -348,7 +348,7 @@ memtx_tx_story_link_tuple(struct memtx_story *story,
 	assert(link->older.tuple == NULL);
 	if (older_tuple == NULL)
 		return;
-	if (older_tuple->is_dirty) {
+	if (tuple_is_dirty(older_tuple)) {
 		memtx_tx_story_link_story(story,
 					  memtx_tx_story_get(older_tuple),
 					  index);
@@ -586,7 +586,7 @@ memtx_tx_story_find_visible_tuple(struct memtx_story *story,
 			/* The tuple is so old that we don't know its story. */
 			*visible_replaced = story->link[index].older.tuple;
 			assert(*visible_replaced == NULL ||
-			       !(*visible_replaced)->is_dirty);
+			       !tuple_is_dirty(*visible_replaced));
 			break;
 		}
 		story = story->link[index].older.story;
@@ -704,7 +704,7 @@ memtx_tx_history_add_stmt(struct txn_stmt *stmt, struct tuple *old_tuple,
 		del_tuple = old_tuple;
 	}
 	if (del_tuple != NULL && del_story == NULL) {
-		if (del_tuple->is_dirty) {
+		if (tuple_is_dirty(del_tuple)) {
 			del_story = memtx_tx_story_get(del_tuple);
 		} else {
 			del_story = memtx_tx_story_new_del_stmt(del_tuple,
@@ -1030,14 +1030,14 @@ memtx_tx_history_commit_stmt(struct txn_stmt *stmt)
 	size_t res = 0;
 	if (stmt->add_story != NULL) {
 		assert(stmt->add_story->add_stmt == stmt);
-		res += stmt->add_story->tuple->bsize;
+		res += tuple_bsize(stmt->add_story->tuple);
 		stmt->add_story->add_stmt = NULL;
 		stmt->add_story = NULL;
 	}
 	if (stmt->del_story != NULL) {
 		assert(stmt->del_story->del_stmt == stmt);
 		assert(stmt->next_in_del_list == NULL);
-		res -= stmt->del_story->tuple->bsize;
+		res -= tuple_bsize(stmt->del_story->tuple);
 		stmt->del_story->del_stmt = NULL;
 		stmt->del_story = NULL;
 	}
@@ -1049,7 +1049,7 @@ memtx_tx_tuple_clarify_slow(struct txn *txn, struct space *space,
 			    struct tuple *tuple, uint32_t index,
 			    uint32_t mk_index, bool is_prepared_ok)
 {
-	assert(tuple->is_dirty);
+	assert(tuple_is_dirty(tuple));
 	struct memtx_story *story = memtx_tx_story_get(tuple);
 	bool own_change = false;
 	struct tuple *result = NULL;
@@ -1104,7 +1104,7 @@ memtx_tx_story_delete(struct memtx_story *story)
 	assert(pos != mh_end(txm.history));
 	mh_history_del(txm.history, pos, 0);
 
-	story->tuple->is_dirty = false;
+	tuple_set_dirty_bit(story->tuple, false);
 	tuple_unref(story->tuple);
 
 #ifndef NDEBUG
@@ -1133,7 +1133,7 @@ memtx_tx_track_read(struct txn *txn, struct space *space, struct tuple *tuple)
 	struct memtx_story *story;
 	struct tx_read_tracker *tracker = NULL;
 
-	if (!tuple->is_dirty) {
+	if (!tuple_is_dirty(tuple)) {
 		story = memtx_tx_story_new(space, tuple);
 		if (story == NULL)
 			return -1;

--- a/src/box/memtx_tx.h
+++ b/src/box/memtx_tx.h
@@ -302,7 +302,7 @@ memtx_tx_tuple_clarify(struct txn *txn, struct space *space,
 {
 	if (!memtx_tx_manager_use_mvcc_engine)
 		return tuple;
-	if (!tuple->is_dirty) {
+	if (!tuple_is_dirty(tuple)) {
 		memtx_tx_track_read(txn, space, tuple);
 		return tuple;
 	}

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -1315,5 +1315,5 @@ vdbe_field_ref_prepare_tuple(struct vdbe_field_ref *field_ref,
 			     struct tuple *tuple)
 {
 	vdbe_field_ref_create(field_ref, tuple, tuple_data(tuple),
-			      tuple->bsize);
+			      tuple_bsize(tuple));
 }

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -728,7 +728,7 @@ tarantoolsqlIdxKeyCompare(struct BtCursor *cursor,
 	struct tuple *tuple;
 	const char *base;
 	struct tuple_format *format;
-	const uint32_t *field_map;
+	const uint8_t *field_map;
 	uint32_t field_count, next_fieldno = 0;
 	const char *p, *field0;
 	u32 i, n;
@@ -777,7 +777,8 @@ tarantoolsqlIdxKeyCompare(struct BtCursor *cursor,
 				uint32_t field_offset =
 					field_map_get_offset(field_map,
 							     field->offset_slot,
-							     MULTIKEY_NONE);
+							     MULTIKEY_NONE,
+							     tuple_is_tiny(tuple));
 				p = base + field_offset;
 			}
 		}

--- a/src/box/tuple.c
+++ b/src/box/tuple.c
@@ -82,11 +82,12 @@ runtime_tuple_new(struct tuple_format *format, const char *data, const char *end
 	size_t data_len = end - data;
 	bool is_tiny = (data_len <= UINT8_MAX);
 	struct field_map_builder builder;
-	if (tuple_field_map_create(format, data, true, &builder) != 0)
+	if (tuple_field_map_create(format, data, true, &builder, &is_tiny) != 0)
 		goto end;
-	uint32_t field_map_size = field_map_build_size(&builder);
+	uint32_t field_map_size = field_map_build_size(&builder, is_tiny);
 	is_tiny = (is_tiny && (sizeof(struct tuple) +
 			       field_map_size <= MAX_TINY_DATA_OFFSET));
+	field_map_size = field_map_build_size(&builder, is_tiny);
 	uint32_t data_offset = sizeof(struct tuple) + field_map_size +
 			       !is_tiny * sizeof(uint32_t);
 	assert(!is_tiny || data_offset <= MAX_TINY_DATA_OFFSET);
@@ -113,7 +114,7 @@ runtime_tuple_new(struct tuple_format *format, const char *data, const char *end
 	tuple_set_data_offset(tuple, data_offset);
 	tuple_set_dirty_bit(tuple, false);
 	char *raw = (char *) tuple + data_offset;
-	field_map_build(&builder, raw - field_map_size);
+	field_map_build(&builder, raw - field_map_size, is_tiny);
 	memcpy(raw, data, data_len);
 	say_debug("%s(%zu) = %p", __func__, data_len, tuple);
 end:
@@ -141,7 +142,9 @@ tuple_validate_raw(struct tuple_format *format, const char *tuple)
 	struct region *region = &fiber()->gc;
 	size_t region_svp = region_used(region);
 	struct field_map_builder builder;
-	int rc = tuple_field_map_create(format, tuple, true, &builder);
+	bool is_tiny = false;
+	int rc = tuple_field_map_create(format, tuple, true, &builder,
+					&is_tiny);
 	region_truncate(region, region_svp);
 	return rc;
 }
@@ -495,8 +498,9 @@ tuple_go_to_path(const char **data, const char *path, uint32_t path_len,
 
 const char *
 tuple_field_raw_by_full_path(struct tuple_format *format, const char *tuple,
-			     const uint32_t *field_map, const char *path,
-			     uint32_t path_len, uint32_t path_hash)
+			     const uint8_t *field_map, const char *path,
+			     uint32_t path_len, uint32_t path_hash,
+			     bool is_tiny)
 {
 	assert(path_len > 0);
 	uint32_t fieldno;
@@ -508,7 +512,8 @@ tuple_field_raw_by_full_path(struct tuple_format *format, const char *tuple,
 	 */
 	if (tuple_fieldno_by_name(format->dict, path, path_len, path_hash,
 				  &fieldno) == 0)
-		return tuple_field_raw(format, tuple, field_map, fieldno);
+		return tuple_field_raw(format, tuple, field_map, fieldno,
+				       is_tiny);
 	struct json_lexer lexer;
 	struct json_token token;
 	json_lexer_create(&lexer, path, path_len, TUPLE_INDEX_BASE);
@@ -546,13 +551,13 @@ tuple_field_raw_by_full_path(struct tuple_format *format, const char *tuple,
 	return tuple_field_raw_by_path(format, tuple, field_map, fieldno,
 				       path + lexer.offset,
 				       path_len - lexer.offset,
-				       NULL, MULTIKEY_NONE);
+				       NULL, MULTIKEY_NONE, is_tiny);
 }
 
 uint32_t
 tuple_raw_multikey_count(struct tuple_format *format, const char *data,
-			       const uint32_t *field_map,
-			       struct key_def *key_def)
+			 const uint8_t *field_map,
+			 struct key_def *key_def, bool is_tiny)
 {
 	assert(key_def->is_multikey);
 	const char *array_raw =
@@ -560,7 +565,7 @@ tuple_raw_multikey_count(struct tuple_format *format, const char *data,
 					key_def->multikey_fieldno,
 					key_def->multikey_path,
 					key_def->multikey_path_len,
-					NULL, MULTIKEY_NONE);
+					NULL, MULTIKEY_NONE, is_tiny);
 	if (array_raw == NULL)
 		return 0;
 	enum mp_type type = mp_typeof(*array_raw);

--- a/src/box/tuple.c
+++ b/src/box/tuple.c
@@ -85,7 +85,7 @@ runtime_tuple_new(struct tuple_format *format, const char *data, const char *end
 	uint32_t field_map_size = field_map_build_size(&builder);
 	uint32_t data_offset = sizeof(struct tuple) + field_map_size;
 	if (data_offset > INT16_MAX) {
-		/** tuple->data_offset is 15 bits */
+		/** tuple data_offset can't be more than 15 bits */
 		diag_set(ClientError, ER_TUPLE_METADATA_IS_TOO_BIG,
 			 data_offset);
 		goto end;
@@ -101,11 +101,11 @@ runtime_tuple_new(struct tuple_format *format, const char *data, const char *end
 	}
 
 	tuple->refs = 0;
-	tuple->bsize = data_len;
+	tuple_set_bsize(tuple, data_len);
 	tuple->format_id = tuple_format_id(format);
 	tuple_format_ref(format);
-	tuple->data_offset = data_offset;
-	tuple->is_dirty = false;
+	tuple_set_data_offset(tuple, data_offset);
+	tuple_set_dirty_bit(tuple, false);
 	char *raw = (char *) tuple + data_offset;
 	field_map_build(&builder, raw - field_map_size);
 	memcpy(raw, data, data_len);
@@ -612,7 +612,7 @@ size_t
 box_tuple_bsize(box_tuple_t *tuple)
 {
 	assert(tuple != NULL);
-	return tuple->bsize;
+	return tuple_bsize(tuple);
 }
 
 ssize_t

--- a/src/box/tuple.h
+++ b/src/box/tuple.h
@@ -296,6 +296,64 @@ box_tuple_validate(box_tuple_t *tuple, box_tuple_format_t *format);
 
 /** \endcond public */
 
+#define MAX_TINY_DATA_OFFSET 63
+
+/** Part of struct tuple. */
+struct tiny_tuple_props {
+	/**
+	 * Tuple is tiny in case it's bsize fits in 1 byte,
+	 * it's data_offset fits in 6 bits and field map
+	 * offsets fit into 1 byte each.
+	 */
+	bool is_tiny : 1;
+	/**
+	 * The tuple (if it's found in index for example) could be invisible
+	 * for current transactions. The flag means that the tuple must
+	 * be clarified by the transaction engine.
+	 */
+	bool is_dirty : 1;
+	/**
+	 * Offset to the MessagePack from the beginning of the
+	 * tuple. 6 bits in case tuple is tiny.
+	 */
+	uint8_t data_offset : 6;
+	/**
+	 * Length of the MessagePack data in raw part of the
+	 * tuple. 8 bits in case tuple is tiny.
+	 */
+	uint8_t bsize;
+};
+
+/** Part of struct tuple. */
+struct tuple_props {
+	/**
+	 * Tuple is tiny in case it's bsize fits in 1 byte,
+	 * it's data_offset fits in 6 bits and field map
+	 * offsets fit into 1 byte each.
+	 */
+	bool is_tiny : 1;
+	/**
+	 * Offset to the MessagePack from the beginning of the
+	 * tuple. 15 bits in case tuple is not tiny.
+	 */
+	uint16_t data_offset: 15;
+};
+
+/** Part of struct tuple. */
+struct PACKED tuple_extra {
+	/**
+	 * The tuple (if it's found in index for example) could be invisible
+	 * for current transactions. The flag means that the tuple must
+	 * be clarified by the transaction engine.
+	 */
+	bool is_dirty : 1;
+	/**
+	 * Length of the MessagePack data in raw part of the
+	 * tuple. 31 bits in case tuple is not tiny.
+	 */
+	uint32_t bsize : 31;
+};
+
 /**
  * An atom of Tarantool storage. Represents MsgPack Array.
  * Tuple has the following structure:
@@ -323,20 +381,40 @@ struct PACKED tuple
 	/** Format identifier. */
 	uint16_t format_id;
 	/**
-	 * Length of the MessagePack data in raw part of the
-	 * tuple.
+	 * Both structs in the following union contain is_tiny bit
+	 * as the first field. It is guaranteed it will be the same
+	 * for both of them in any case. Tuple is tiny in case it's
+	 * bsize fits in 1 byte, it's data_offset fits in 6 bits and
+	 * field map offsets fit into 1 byte each. In case it is tiny
+	 * we will obtain data_offset, bsize and is_dirty flag from the
+	 * struct tiny_tuple_props. Otherwise we will obtain data_offset
+	 * from struct tuple_props, while bsize and is_dirty flag will be
+	 * stored in struct tuple_extra (4 bytes at the end of the tuple).
 	 */
-	uint32_t bsize;
+	union {
+		/**
+		 * In case the tuple is tiny this struct is used to obtain
+		 * data_offset (offset to the MessagePack from the beginning
+		 * of the tuple), bsize (the length of the MessagePack data
+		 * in the raw part of the tuple) and is_dirty flag (true if
+		 * the tuple must be clarified by transaction engine).
+		 */
+		struct tiny_tuple_props tiny_props;
+		/**
+		 * In case the tuple is not tiny this struct is used to obtain
+		 * data_offset (offset to the MessagePack from the beginning of
+		 * the tuple).
+		 */
+		struct tuple_props props;
+	};
 	/**
-	 * Offset to the MessagePack from the begin of the tuple.
+	 * In case the tuple is not tiny this struct contains is_dirty
+	 * flag (true if the tuple must be clarified by transaction
+	 * engine) and bsize (the length of the MessagePack data
+	 * in the raw part of the tuple).
+	 * If the tuple is tiny, this fields is 0 bytes.
 	 */
-	uint16_t data_offset : 15;
-	/**
-	 * The tuple (if it's found in index for example) could be invisible
-	 * for current transactions. The flag means that the tuple must
-	 * be clarified by transaction engine.
-	 */
-	bool is_dirty : 1;
+	struct tuple_extra extra[];
 	/**
 	 * Engine specific fields and offsets array concatenated
 	 * with MessagePack fields array.
@@ -344,47 +422,117 @@ struct PACKED tuple
 	 */
 };
 
+/**
+ * According to C standard sections 6.5.2.3-5 it is guaranteed
+ * if a union contains several structures that share a common
+ * initial sequence of members (bool is_tiny in this case), it is
+ * permitted to inspect the common initial part of any of them
+ * anywhere that a declaration of the complete type of the union
+ * is visible. Two structures share a common initial sequence if
+ * corresponding members have compatible types (and, for
+ * bit-fields, the same widths) for a sequence of one or more
+ * initial members. Thus we are guaranteed that is_tiny bit is
+ * same for both struct tiny_tuple_props and struct tuple_props
+ * and we can simply read or write any of them.
+ */
+static inline void
+tuple_set_tiny_bit(struct tuple *tuple, bool is_tiny)
+{
+	assert(tuple != NULL);
+	tuple->props.is_tiny = is_tiny;
+}
+
+static inline bool
+tuple_is_tiny(struct tuple *tuple)
+{
+	assert(tuple != NULL);
+	return tuple->props.is_tiny;
+}
+
+static inline void
+tiny_tuple_set_dirty_bit(struct tuple *tuple, bool is_dirty)
+{
+	tuple->tiny_props.is_dirty = is_dirty;
+}
+
+static inline void
+basic_tuple_set_dirty_bit(struct tuple *tuple, bool is_dirty)
+{
+	tuple->extra->is_dirty = is_dirty;
+}
+
 static inline void
 tuple_set_dirty_bit(struct tuple *tuple, bool is_dirty)
 {
 	assert(tuple != NULL);
-	tuple->is_dirty = is_dirty;
+	tuple->props.is_tiny ? tiny_tuple_set_dirty_bit(tuple, is_dirty) :
+			       basic_tuple_set_dirty_bit(tuple, is_dirty);
 }
 
 static inline bool
 tuple_is_dirty(struct tuple *tuple)
 {
 	assert(tuple != NULL);
-	return tuple->is_dirty;
+	return tuple->props.is_tiny ? tuple->tiny_props.is_dirty :
+				      tuple->extra->is_dirty;
+}
+
+static inline void
+tiny_tuple_set_bsize(struct tuple *tuple, uint32_t bsize)
+{
+	assert(bsize <= UINT8_MAX); /* bsize has to fit in UINT8_MAX */
+	tuple->tiny_props.bsize = bsize;
+}
+
+static inline void
+basic_tuple_set_bsize(struct tuple *tuple, uint32_t bsize)
+{
+	assert(bsize <= INT32_MAX); /* bsize has to fit in INT32_MAX */
+	tuple->extra->bsize = bsize;
 }
 
 static inline void
 tuple_set_bsize(struct tuple *tuple, uint32_t bsize)
 {
 	assert(tuple != NULL);
-	assert(bsize <= UINT32_MAX); /* bsize is UINT32_MAX */
-	tuple->bsize = bsize;
+	tuple->props.is_tiny ? tiny_tuple_set_bsize(tuple, bsize) :
+			       basic_tuple_set_bsize(tuple, bsize);
 }
 
 static inline uint32_t
 tuple_bsize(struct tuple *tuple)
 {
 	assert(tuple != NULL);
-	return tuple->bsize;
+	return tuple->props.is_tiny ? tuple->tiny_props.bsize :
+				      tuple->extra->bsize;
+}
+
+static inline void
+tiny_tuple_set_data_offset(struct tuple *tuple, uint8_t data_offset)
+{
+	tuple->tiny_props.data_offset = data_offset;
+}
+
+static inline void
+basic_tuple_set_data_offset(struct tuple *tuple, uint16_t data_offset)
+{
+	tuple->props.data_offset = data_offset;
 }
 
 static inline void
 tuple_set_data_offset(struct tuple *tuple, uint16_t data_offset)
 {
 	assert(tuple != NULL);
-	tuple->data_offset = data_offset;
+	tuple->props.is_tiny ? tiny_tuple_set_data_offset(tuple, data_offset) :
+			       basic_tuple_set_data_offset(tuple, data_offset);
 }
 
 static inline uint16_t
 tuple_data_offset(struct tuple *tuple)
 {
 	assert(tuple != NULL);
-	return tuple->data_offset;
+	return tuple->props.is_tiny ? tuple->tiny_props.data_offset :
+				      tuple->props.data_offset;
 }
 
 /** Size of the tuple including size of struct tuple. */

--- a/src/box/tuple_compare.cc
+++ b/src/box/tuple_compare.cc
@@ -874,7 +874,7 @@ tuple_compare_with_key_sequential(struct tuple *tuple, hint_t tuple_hint,
 		 * Key's and tuple's first field_count fields are
 		 * equal, and their bsize too.
 		 */
-		key += tuple->bsize - mp_sizeof_array(field_count);
+		key += tuple_bsize(tuple) - mp_sizeof_array(field_count);
 		for (uint32_t i = field_count; i < part_count;
 		     ++i, mp_next(&key)) {
 			if (mp_typeof(*key) != MP_NIL)

--- a/src/box/tuple_extract_key.cc
+++ b/src/box/tuple_extract_key.cc
@@ -95,7 +95,7 @@ tuple_extract_key_sequential(struct tuple *tuple, struct key_def *key_def,
 	assert(!has_optional_parts || key_def->is_nullable);
 	assert(has_optional_parts == key_def->has_optional_parts);
 	const char *data = tuple_data(tuple);
-	const char *data_end = data + tuple->bsize;
+	const char *data_end = data + tuple_bsize(tuple);
 	return tuple_extract_key_sequential_raw<has_optional_parts>(data,
 								    data_end,
 								    key_def,
@@ -127,7 +127,7 @@ tuple_extract_key_slowpath(struct tuple *tuple, struct key_def *key_def,
 	uint32_t bsize = mp_sizeof_array(part_count);
 	struct tuple_format *format = tuple_format(tuple);
 	const uint32_t *field_map = tuple_field_map(tuple);
-	const char *tuple_end = data + tuple->bsize;
+	const char *tuple_end = data + tuple_bsize(tuple);
 
 	/* Calculate the key size. */
 	for (uint32_t i = 0; i < part_count; ++i) {

--- a/src/box/tuple_format.c
+++ b/src/box/tuple_format.c
@@ -482,7 +482,7 @@ tuple_format_create(struct tuple_format *format, struct key_def * const *keys,
 	       || json_token_is_multikey(&tuple_format_field(format, 0)->token));
 	size_t field_map_size = -current_slot * sizeof(uint32_t);
 	if (field_map_size > INT16_MAX) {
-		/** tuple->data_offset is 15 bits */
+		/** tuple data_offset can't be more than 15 bits */
 		diag_set(ClientError, ER_INDEX_FIELD_COUNT_LIMIT,
 			 -current_slot);
 		return -1;

--- a/src/box/tuple_format.c
+++ b/src/box/tuple_format.c
@@ -859,7 +859,8 @@ tuple_format_required_fields_validate(struct tuple_format *format,
 
 static int
 tuple_field_map_create_plain(struct tuple_format *format, const char *tuple,
-			     bool validate, struct field_map_builder *builder)
+			     bool validate, struct field_map_builder *builder,
+			     bool *is_tiny)
 {
 	struct region *region = &fiber()->gc;
 	const char *pos = tuple;
@@ -906,7 +907,7 @@ tuple_field_map_create_plain(struct tuple_format *format, const char *tuple,
 		if (field->offset_slot != TUPLE_OFFSET_SLOT_NIL &&
 		    field_map_builder_set_slot(builder, field->offset_slot,
 					       pos - tuple, MULTIKEY_NONE,
-					       0, NULL) != 0) {
+					       0, NULL, is_tiny) != 0) {
 			return -1;
 		}
 	}
@@ -922,7 +923,8 @@ end:
 /** @sa declaration for details. */
 int
 tuple_field_map_create(struct tuple_format *format, const char *tuple,
-		       bool validate, struct field_map_builder *builder)
+		       bool validate, struct field_map_builder *builder,
+		       bool *is_tiny)
 {
 	struct region *region = &fiber()->gc;
 	if (field_map_builder_create(builder, format->field_map_size,
@@ -937,7 +939,7 @@ tuple_field_map_create(struct tuple_format *format, const char *tuple,
 	 */
 	if (format->fields_depth == 1) {
 		return tuple_field_map_create_plain(format, tuple, validate,
-						    builder);
+						    builder, is_tiny);
 	}
 
 	uint32_t field_count;
@@ -954,7 +956,8 @@ tuple_field_map_create(struct tuple_format *format, const char *tuple,
 		if (entry.field->offset_slot != TUPLE_OFFSET_SLOT_NIL &&
 		    field_map_builder_set_slot(builder, entry.field->offset_slot,
 					entry.data - tuple, entry.multikey_idx,
-					entry.multikey_count, region) != 0)
+					entry.multikey_count, region,
+					is_tiny) != 0)
 			return -1;
 	}
 	return entry.data == NULL ? 0 : -1;

--- a/src/box/tuple_format.h
+++ b/src/box/tuple_format.h
@@ -427,7 +427,8 @@ box_tuple_format_unref(box_tuple_format_t *format);
  */
 int
 tuple_field_map_create(struct tuple_format *format, const char *tuple,
-		       bool validate, struct field_map_builder *builder);
+		       bool validate, struct field_map_builder *builder,
+		       bool *is_tiny);
 
 /**
  * Initialize tuple format subsystem.

--- a/src/box/tuple_hash.cc
+++ b/src/box/tuple_hash.cc
@@ -372,14 +372,15 @@ tuple_hash_slowpath(struct tuple *tuple, struct key_def *key_def)
 	uint32_t prev_fieldno = key_def->parts[0].fieldno;
 	struct tuple_format *format = tuple_format(tuple);
 	const char *tuple_raw = tuple_data(tuple);
-	const uint32_t *field_map = tuple_field_map(tuple);
+	const uint8_t *field_map = tuple_field_map(tuple);
 	const char *field;
 	if (has_json_paths) {
 		field = tuple_field_raw_by_part(format, tuple_raw, field_map,
-						key_def->parts, MULTIKEY_NONE);
+						key_def->parts, MULTIKEY_NONE,
+						tuple_is_tiny(tuple));
 	} else {
 		field = tuple_field_raw(format, tuple_raw, field_map,
-					prev_fieldno);
+					prev_fieldno, tuple_is_tiny(tuple));
 	}
 	const char *end = (char *)tuple + tuple_size(tuple);
 	if (has_optional_parts && field == NULL) {
@@ -398,10 +399,12 @@ tuple_hash_slowpath(struct tuple *tuple, struct key_def *key_def)
 			if (has_json_paths) {
 				field = tuple_field_raw_by_part(format, tuple_raw,
 								field_map, part,
-								MULTIKEY_NONE);
+								MULTIKEY_NONE,
+								tuple_is_tiny(tuple));
 			} else {
-				field = tuple_field_raw(format, tuple_raw, field_map,
-						    part->fieldno);
+				field = tuple_field_raw(format, tuple_raw,
+							field_map, part->fieldno,
+							tuple_is_tiny(tuple));
 			}
 		}
 		if (has_optional_parts && (field == NULL || field >= end)) {

--- a/src/box/vy_stmt.h
+++ b/src/box/vy_stmt.h
@@ -583,7 +583,7 @@ vy_stmt_upsert_ops(struct tuple *tuple, uint32_t *mp_size)
 	assert(vy_stmt_type(tuple) == IPROTO_UPSERT);
 	const char *mp = tuple_data(tuple);
 	mp_next(&mp);
-	*mp_size = tuple_data(tuple) + tuple->bsize - mp;
+	*mp_size = tuple_data(tuple) + tuple_bsize(tuple) - mp;
 	return mp;
 }
 

--- a/test/box/errinj.result
+++ b/test/box/errinj.result
@@ -457,7 +457,7 @@ errinj.set("ERRINJ_TUPLE_ALLOC", true)
 ...
 s:auto_increment{}
 ---
-- error: Failed to allocate 16 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 12 bytes in slab allocator for memtx_tuple
 ...
 s:select{}
 ---
@@ -465,7 +465,7 @@ s:select{}
 ...
 s:auto_increment{}
 ---
-- error: Failed to allocate 16 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 12 bytes in slab allocator for memtx_tuple
 ...
 s:select{}
 ---
@@ -473,7 +473,7 @@ s:select{}
 ...
 s:auto_increment{}
 ---
-- error: Failed to allocate 16 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 12 bytes in slab allocator for memtx_tuple
 ...
 s:select{}
 ---
@@ -487,7 +487,7 @@ box.begin()
     s:insert{1}
 box.commit();
 ---
-- error: Failed to allocate 16 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 12 bytes in slab allocator for memtx_tuple
 ...
 box.rollback();
 ---
@@ -501,7 +501,7 @@ box.begin()
     s:insert{2}
 box.commit();
 ---
-- error: Failed to allocate 16 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 12 bytes in slab allocator for memtx_tuple
 ...
 s:select{};
 ---
@@ -515,7 +515,7 @@ box.begin()
     s:insert{2}
 box.commit();
 ---
-- error: Failed to allocate 16 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 12 bytes in slab allocator for memtx_tuple
 ...
 s:select{};
 ---
@@ -534,7 +534,7 @@ box.begin()
     s:insert{2}
 box.commit();
 ---
-- error: Failed to allocate 16 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 12 bytes in slab allocator for memtx_tuple
 ...
 errinj.set("ERRINJ_TUPLE_ALLOC", false);
 ---
@@ -796,7 +796,7 @@ errinj.set("ERRINJ_TUPLE_ALLOC", true)
 ...
 s:replace{1, "test"}
 ---
-- error: Failed to allocate 21 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 17 bytes in slab allocator for memtx_tuple
 ...
 s:bsize()
 ---
@@ -808,7 +808,7 @@ utils.space_bsize(s)
 ...
 s:update({1}, {{'=', 3, '!'}})
 ---
-- error: Failed to allocate 20 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 16 bytes in slab allocator for memtx_tuple
 ...
 s:bsize()
 ---

--- a/test/box/upsert_errinj.result
+++ b/test/box/upsert_errinj.result
@@ -19,7 +19,7 @@ errinj.set("ERRINJ_TUPLE_ALLOC", true)
 ...
 s:upsert({111, '111', 222, '222'}, {{'!', 5, '!'}})
 ---
-- error: Failed to allocate 26 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 22 bytes in slab allocator for memtx_tuple
 ...
 errinj.set("ERRINJ_TUPLE_ALLOC", false)
 ---

--- a/test/vinyl/cache.result
+++ b/test/vinyl/cache.result
@@ -1033,14 +1033,14 @@ for i = 1, 100 do s:get{i} end
 ...
 box.stat.vinyl().memory.tuple_cache
 ---
-- 108500
+- 107300
 ...
 box.cfg{vinyl_cache = 50 * 1000}
 ---
 ...
 box.stat.vinyl().memory.tuple_cache
 ---
-- 49910
+- 49358
 ...
 box.cfg{vinyl_cache = 0}
 ---
@@ -1116,7 +1116,7 @@ s.index.i2:count()
 ...
 box.stat.vinyl().memory.tuple_cache -- should be about 200 KB
 ---
-- 219200
+- 218000
 ...
 s:drop()
 ---

--- a/test/vinyl/quota.result
+++ b/test/vinyl/quota.result
@@ -36,7 +36,7 @@ space:insert({1, 1})
 ...
 box.stat.vinyl().memory.level0
 ---
-- 98344
+- 98336
 ...
 space:insert({1, 1})
 ---
@@ -44,7 +44,7 @@ space:insert({1, 1})
 ...
 box.stat.vinyl().memory.level0
 ---
-- 98344
+- 98336
 ...
 space:update({1}, {{'!', 1, 100}}) -- try to modify the primary key
 ---
@@ -52,7 +52,7 @@ space:update({1}, {{'!', 1, 100}}) -- try to modify the primary key
 ...
 box.stat.vinyl().memory.level0
 ---
-- 98344
+- 98336
 ...
 space:insert({2, 2})
 ---
@@ -68,7 +68,7 @@ space:insert({4, 4})
 ...
 box.stat.vinyl().memory.level0
 ---
-- 98463
+- 98417
 ...
 box.snapshot()
 ---
@@ -94,7 +94,7 @@ _ = space:replace{1, 1, string.rep('a', 1024 * 1024 * 5)}
 ...
 box.stat.vinyl().memory.level0
 ---
-- 5292080
+- 5292064
 ...
 space:drop()
 ---

--- a/test/vinyl/quota_timeout.result
+++ b/test/vinyl/quota_timeout.result
@@ -49,7 +49,7 @@ s:count()
 ...
 box.stat.vinyl().memory.level0
 ---
-- 748248
+- 748232
 ...
 -- Since the following operation requires more memory than configured
 -- and dump is disabled, it should fail with ER_VY_QUOTA_TIMEOUT.
@@ -63,7 +63,7 @@ s:count()
 ...
 box.stat.vinyl().memory.level0
 ---
-- 748248
+- 748232
 ...
 --
 -- Check that increasing box.cfg.vinyl_memory wakes up fibers
@@ -135,7 +135,7 @@ test_run:cmd("push filter '[0-9.]+ sec' to '<sec> sec'")
 ...
 test_run:grep_log('test', 'waited for .* quota for too long.*')
 ---
-- 'waited for 1048615 bytes of vinyl memory quota for too long: <sec> sec'
+- 'waited for 1048603 bytes of vinyl memory quota for too long: <sec> sec'
 ...
 test_run:cmd("clear filter")
 ---
@@ -167,7 +167,7 @@ pad = string.rep('x', box.cfg.vinyl_memory)
 ...
 _ = s:auto_increment{pad}
 ---
-- error: Failed to allocate 1572903 bytes in lsregion for vinyl transaction
+- error: Failed to allocate 1572891 bytes in lsregion for vinyl transaction
 ...
 s:drop()
 ---

--- a/test/vinyl/stat.result
+++ b/test/vinyl/stat.result
@@ -301,7 +301,7 @@ stat_diff(istat(), st)
 ---
 - put:
     rows: 25
-    bytes: 26525
+    bytes: 26225
   rows: 25
   run_avg: 1
   run_count: 1
@@ -318,7 +318,7 @@ stat_diff(istat(), st)
     dump:
       input:
         rows: 25
-        bytes: 26525
+        bytes: 26225
       count: 1
       output:
         bytes: 26049
@@ -350,7 +350,7 @@ stat_diff(istat(), st)
 ---
 - put:
     rows: 50
-    bytes: 53050
+    bytes: 52450
   bytes: 26042
   disk:
     last_level:
@@ -364,7 +364,7 @@ stat_diff(istat(), st)
     dump:
       input:
         rows: 50
-        bytes: 53050
+        bytes: 52450
       count: 1
       output:
         bytes: 52091
@@ -402,11 +402,11 @@ stat_diff(istat(), st)
 - cache:
     index_size: 49152
     rows: 1
-    bytes: 1061
+    bytes: 1049
     lookup: 1
     put:
       rows: 1
-      bytes: 1061
+      bytes: 1049
   lookup: 1
   disk:
     iterator:
@@ -418,13 +418,13 @@ stat_diff(istat(), st)
       lookup: 1
       get:
         rows: 1
-        bytes: 1061
+        bytes: 1049
   memory:
     iterator:
       lookup: 1
   get:
     rows: 1
-    bytes: 1061
+    bytes: 1049
 ...
 -- point lookup from cache
 st = istat()
@@ -440,14 +440,14 @@ stat_diff(istat(), st)
     lookup: 1
     put:
       rows: 1
-      bytes: 1061
+      bytes: 1049
     get:
       rows: 1
-      bytes: 1061
+      bytes: 1049
   lookup: 1
   get:
     rows: 1
-    bytes: 1061
+    bytes: 1049
 ...
 -- put in memory + cache invalidate
 st = istat()
@@ -461,18 +461,18 @@ stat_diff(istat(), st)
 - cache:
     invalidate:
       rows: 1
-      bytes: 1061
+      bytes: 1049
     rows: -1
-    bytes: -1061
+    bytes: -1049
   rows: 1
   memory:
     index_size: 49152
-    bytes: 1061
+    bytes: 1049
     rows: 1
   put:
     rows: 1
-    bytes: 1061
-  bytes: 1061
+    bytes: 1049
+  bytes: 1049
 ...
 -- point lookup from memory
 st = istat()
@@ -485,22 +485,22 @@ s:get(1) ~= nil
 stat_diff(istat(), st)
 ---
 - cache:
-    bytes: 1061
+    bytes: 1049
     lookup: 1
     rows: 1
     put:
       rows: 1
-      bytes: 1061
+      bytes: 1049
   memory:
     iterator:
       lookup: 1
       get:
         rows: 1
-        bytes: 1061
+        bytes: 1049
   lookup: 1
   get:
     rows: 1
-    bytes: 1061
+    bytes: 1049
 ...
 -- put in txw + point lookup from txw
 st = istat()
@@ -520,16 +520,16 @@ stat_diff(istat(), st)
 ---
 - txw:
     rows: 1
-    bytes: 1061
+    bytes: 1049
     iterator:
       lookup: 1
       get:
         rows: 1
-        bytes: 1061
+        bytes: 1049
   lookup: 1
   get:
     rows: 1
-    bytes: 1061
+    bytes: 1049
 ...
 box.rollback()
 ---
@@ -586,15 +586,15 @@ for i = 1, 100 do s:get(i) end
 ...
 stat_diff(istat(), st, 'cache')
 ---
-- rows: 14
-  bytes: 14854
+- rows: 15
+  bytes: 15735
   evict:
-    rows: 86
-    bytes: 91246
+    rows: 85
+    bytes: 89165
   lookup: 100
   put:
     rows: 100
-    bytes: 106100
+    bytes: 104900
 ...
 -- range split
 for i = 1, 100 do put(i) end
@@ -649,15 +649,15 @@ st = istat()
 stat_diff(istat(), st)
 ---
 - cache:
-    rows: 13
-    bytes: 13793
+    rows: 14
+    bytes: 14686
     evict:
-      rows: 37
-      bytes: 39257
+      rows: 36
+      bytes: 37764
     lookup: 1
     put:
       rows: 51
-      bytes: 54111
+      bytes: 53499
   disk:
     iterator:
       read:
@@ -668,23 +668,23 @@ stat_diff(istat(), st)
       lookup: 2
       get:
         rows: 100
-        bytes: 106100
+        bytes: 104900
   txw:
     iterator:
       lookup: 1
       get:
         rows: 50
-        bytes: 53050
+        bytes: 52450
   memory:
     iterator:
       lookup: 1
       get:
         rows: 100
-        bytes: 106100
+        bytes: 104900
   lookup: 1
   get:
     rows: 100
-    bytes: 106100
+    bytes: 104900
 ...
 box.rollback()
 ---
@@ -717,17 +717,17 @@ stat_diff(istat(), st)
     lookup: 1
     put:
       rows: 5
-      bytes: 5305
+      bytes: 5245
     get:
       rows: 5
-      bytes: 5305
+      bytes: 5245
   txw:
     iterator:
       lookup: 1
   lookup: 1
   get:
     rows: 5
-    bytes: 5305
+    bytes: 5245
 ...
 box.rollback()
 ---
@@ -761,7 +761,7 @@ put(1)
 ...
 stat_diff(gstat(), st, 'memory.level0')
 ---
-- 1064
+- 1049
 ...
 -- use cache
 st = gstat()
@@ -772,7 +772,7 @@ _ = s:get(1)
 ...
 stat_diff(gstat(), st, 'memory.tuple_cache')
 ---
-- 1109
+- 1097
 ...
 s:delete(1)
 ---
@@ -1011,7 +1011,7 @@ istat()
       rows: 0
       bytes: 0
     index_size: 49152
-    rows: 13
+    rows: 14
     evict:
       rows: 0
       bytes: 0
@@ -1019,7 +1019,7 @@ istat()
       rows: 0
       bytes: 0
     lookup: 0
-    bytes: 13793
+    bytes: 14686
     get:
       rows: 0
       bytes: 0
@@ -1088,7 +1088,7 @@ istat()
   upsert:
     squashed: 0
     applied: 0
-  bytes: 317731
+  bytes: 315259
   put:
     rows: 0
     bytes: 0
@@ -1105,7 +1105,7 @@ istat()
         rows: 0
         bytes: 0
   memory:
-    bytes: 213431
+    bytes: 210959
     index_size: 49152
     rows: 206
     iterator:
@@ -1128,9 +1128,9 @@ gstat()
     gap_locks: 0
     read_views: 0
   memory:
-    tuple_cache: 14417
+    tuple_cache: 15358
     tx: 0
-    level0: 263210
+    level0: 260118
     page_index: 1250
     bloom_filter: 140
   disk:
@@ -1173,7 +1173,7 @@ box.snapshot()
 ...
 stat_diff(gstat(), st, 'scheduler')
 ---
-- dump_input: 104200
+- dump_input: 103000
   dump_output: 103592
   tasks_completed: 2
   dump_count: 1
@@ -1190,7 +1190,7 @@ box.snapshot()
 ...
 stat_diff(gstat(), st, 'scheduler')
 ---
-- dump_input: 10420
+- dump_input: 10300
   dump_output: 10411
   tasks_completed: 2
   dump_count: 1
@@ -1272,7 +1272,7 @@ st2 = i2:stat()
 ...
 s:bsize()
 ---
-- 53300
+- 52700
 ...
 i1:len(), i2:len()
 ---
@@ -1397,7 +1397,7 @@ st2 = i2:stat()
 ...
 s:bsize()
 ---
-- 107199
+- 105999
 ...
 i1:len(), i2:len()
 ---


### PR DESCRIPTION
Tuple bsize was stored in 4 byte uint32_t field. Tuple data_offset was
stored in 2 byte uint16_t field. Now the tuple contains flexible byte
array at the end, allowing to put it in the same way. On the other hand,
if it is possible, bsize and data_offset use 1 byte each. Such tuples
are called tiny tuples. They only require 6 bytes instead of 10. Also
tiny tuples use 1 byte offsets insead of 4 byte offsets. This allows
to save lots of memory for small enough tuples.