### PR TITLE
github-ci: port send-telegram-notify to python3

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -21,8 +21,7 @@ runs:
         # run from it. So running it only outside of docker container.
         # Also on local hosts, like that we use for 'freebsd' workflow
         # testing, 'sudo' not acceptable outside of 'freebsd' virtual
-        # machine and to avoid of hangs let's check sudo run ability
-        # with command like 'timeout 2 sudo ls /sbin/swapoff'.
+        # machine and to avoid of hangs let's run it with '-n' flag.
         # NOTE: To switch off swap from inside github 'container' tag
         # additional memory flags should be added to its 'options' tag:
         #   options: '--memory=<some value, like 7G> --memory-swap=<the same value as for memory option>'
@@ -30,7 +29,7 @@ runs:
             echo "Check initial swap memory values:"
             free
         fi
-        if timeout 2 sudo ls /sbin/swapoff ; then
+        if sudo -n ls /sbin/swapoff ; then
             echo "Verified that 'sudo' enabled, switching off swap ..."
             sudo /sbin/swapoff -a || echo "'swapoff' command failed, but failure is acceptable from inside the container"
             if [ -e /proc/meminfo ] ; then

--- a/.github/actions/send-telegram-notify/action.yml
+++ b/.github/actions/send-telegram-notify/action.yml
@@ -28,6 +28,12 @@ runs:
         uname -s | tee -a $GITHUB_ENV
         echo 'EOF' >> $GITHUB_ENV
       shell: bash
+    # check if host OS is rhel or fedora
+    - run: |
+        echo 'OS_IS_FEDORA_OR_RHEL<<EOF' >> $GITHUB_ENV
+        grep "^ID=" /etc/os-release | grep -e 'centos' -e 'fedora' && echo true | tee -a $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+      shell: bash
     # get job id number
     - run: |
         sudo -n apt update -y ||:
@@ -53,7 +59,7 @@ runs:
       run: |
         # convert message from multi lines to single line and
         # add backslashes to single quote marks in message
-        if ${{ env.KERNEL_NAME == 'Darwin' }} ; then
+        if ${{ env.OS_IS_FEDORA_OR_RHEL == 'true' }} || ${{ env.KERNEL_NAME == 'Darwin' }} ; then
           msg="${MSG//$'\n'/\n}"
           msg="${msg//$'\\\''/\'}"
         else

--- a/.github/actions/send-telegram-notify/action.yml
+++ b/.github/actions/send-telegram-notify/action.yml
@@ -30,8 +30,8 @@ runs:
       shell: bash
     # get job id number
     - run: |
-        apt update ||:
-        apt install -y jq ||:
+        sudo -n apt update -y ||:
+        sudo -n apt install -y jq ||:
         echo 'JOB_ID<<EOF' >> $GITHUB_ENV
         curl -s https://api.github.com/repos/tarantool/tarantool/actions/runs/${{ github.run_id }}/jobs | jq -r '.jobs[0].id' | tee -a $GITHUB_ENV
         echo 'EOF' >> $GITHUB_ENV

--- a/.github/actions/send-telegram-notify/action.yml
+++ b/.github/actions/send-telegram-notify/action.yml
@@ -5,8 +5,8 @@ runs:
   steps:
     # install 'requests' Python module
     - run: |
-        python -m pip install --upgrade pip ||:
-        pip install requests ||:
+        python3 -m pip install --upgrade pip ||:
+        pip3 install requests ||:
       shell: bash
     # logout github environment
     - env:
@@ -72,8 +72,9 @@ runs:
         fi
         # Use MarkdownV2 while Markdown is legacy
         # https://core.telegram.org/bots/api#markdownv2-style
-        python -c "import urllib, requests ; \\
-          url = 'https://api.telegram.org/bot%s/sendMessage?chat_id=%s&text=%s&parse_mode=MarkdownV2&disable_web_page_preview=true' \\
-            % ('$TELEGRAM_TOKEN', '$send_to', urllib.quote_plus('$msg')) ; \\
-          _ = requests.post(url, timeout=10)"
+        python3 -c "from urllib import request, parse ; \\
+          url = 'https://api.telegram.org/bot%s/sendMessage' % ('$TELEGRAM_TOKEN') ; \\
+          data = parse.urlencode({'chat_id' : '$send_to', 'parse_mode' : 'MarkdownV2', 'disable_web_page_preview' : 'true', 'text' : '$msg'}).encode('ascii') ; \\
+          response = request.urlopen(url=url, data=data, timeout=10) ; \\
+          print(response.read())"
       shell: bash

--- a/.github/actions/send-telegram-notify/action.yml
+++ b/.github/actions/send-telegram-notify/action.yml
@@ -42,6 +42,49 @@ runs:
         curl -s https://api.github.com/repos/tarantool/tarantool/actions/runs/${{ github.run_id }}/jobs | jq -r '.jobs[0].id' | tee -a $GITHUB_ENV
         echo 'EOF' >> $GITHUB_ENV
       shell: bash
+    # convert commit message to single line with marked new lines as 'TELEGRAMNEWLINE'
+    - env:
+        COMMIT_MSG: |
+          ${{ github.event.head_commit.message }}
+      run: |
+        # Make changes in the commit message to avoid of its fail on Markdown:
+        # 1. Convert message from multi lines to single line.
+        # 2. Add backslashes to single quote marks in message.
+        # 3. Add backslashes to '`' in message.
+        if ${{ env.OS_IS_FEDORA_OR_RHEL == 'true' }} || ${{ env.KERNEL_NAME == 'Darwin' }} ; then
+          msg="${COMMIT_MSG//$'\n'/TELEGRAMNEWLINE}"
+          msg="${msg//$'\\\\'/BACKSLASH}"
+          msg="${msg//$'\\\''/\'}"
+          msg="${msg//$'\`'/BACKTICK}"
+        else
+          msg="${COMMIT_MSG//$'\n'/TELEGRAMNEWLINE}"
+          msg="${msg//$'\\'/BACKSLASH}"
+          msg="${msg//$'\''/\\\'}"
+          msg="${msg//$'`'/BACKTICK}"
+        fi
+        echo 'COMMIT_MSG_LINE<<EOF' >> $GITHUB_ENV
+        echo "$msg" | tee -a $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+      shell: bash
+    # strip Markdown from commit message
+    - run: |
+        pip3 install setuptools
+        pip3 install markdown bs4
+        echo "Sending commit message part as a single line: ${{ env.COMMIT_MSG_LINE }}"
+        msg=`python3 -c "import markdown ; \\
+          from bs4 import BeautifulSoup ; \\
+          md = markdown.markdown(\"${{ env.COMMIT_MSG_LINE }}\") ; \\
+          soup = BeautifulSoup(md, features='html.parser') ; \\
+          print(soup.get_text())"`
+        echo "Sending commit message part as a single line: $msg"
+        echo 'COMMIT_MSG<<EOF' >> $GITHUB_ENV
+          if ${{ env.OS_IS_FEDORA_OR_RHEL == 'true' }} || ${{ env.KERNEL_NAME == 'Darwin' }} ; then
+            echo $msg | sed "s#TELEGRAMNEWLINE#\\\n#g" | tee -a $GITHUB_ENV
+          else
+            echo $msg | sed "s#TELEGRAMNEWLINE#\n#g" | tee -a $GITHUB_ENV
+          fi
+        echo 'EOF' >> $GITHUB_ENV
+      shell: bash
     - env:
         MSG: |
           🔴 Workflow testing failed:
@@ -54,7 +97,7 @@ runs:
           Committer: `${{ github.actor }}`
           ```
           ---------------- Commit message -------------------
-          ${{ github.event.head_commit.message }}
+          ${{ env.COMMIT_MSG }}
           ```
       run: |
         # convert message from multi lines to single line and


### PR DESCRIPTION
Patch set consists of 4 commits:

1. github-ci: port send-telegram-notify to python3

    For now python3 is used as the default python on all OS and it is
    needed to enable it in send-telegram-notify action.

    Found issue:
    ```
      Traceback (most recent call last):
        File "<string>", line 3, in <module>
      AttributeError: module 'urllib' has no attribute 'quote_plus'
    ```

    In Python 3 quote_plus included into urllib.parse.

    Check documentaion [1]:
    ```
      Note The urllib module has been split into parts and renamed in Python 3 to urllib.request, urllib.parse, and urllib.error.
    ```
    Check the same issue [2].

    This patch changes use of all needed routines just from 'urllib'.

    Closes tarantool/tarantool-qa#112

    [1]: https://docs.python.org/2/library/urllib.html
    [2]: https://github.com/web2py/web2py/issues/1822

2. github-ci: set sudo for apt commands

    After commit:
    
      58fe0fcb17f77e3bc111c9ae25a3c1e01a0b1c41 ('github-ci: avoid of use container tags in actions')
    
    We began to use not the docker containers, but native github hosts.
    To avoid of permissions fails on native github actions runners apt
    command must run using sudo. Added flag '-n|--non-interactive' to
    sudo command to avoid prompting the user for input of any kind which
    could hang it. Added '-y' flag to apt update command to accept changes.

3. github-ci: fix message send on rhel/fedora hosts
    
    Found that on self-hosted runners where CentOS 7 is the base OS,
    'send-telegram-notify' action creates message with syntax error:
    ```
      --------------'\n't'\n'```'\n'')) ; \
      ^
      SyntaxError: unexpected character after line continuation character
    ```
    It happened because of extra quotes at '\n' while it had to be \n.
    To avoid of it the same message changes must be done as for OSX
    hosts are doing. These changes should be done when self-hosted
    runners uses RHEL or Fedora as base OS.

4. github-ci: fix commit message for markdown
    
    Found that commit message may consists of special characters which can
    be used be Markdown as commands, like '`' or '```'. To avoid of it these
    characters must be changed to some predefined names like for:
    ```
    '\' - BACKSLASH
    '`' - BACKTICK
    ```
    Also added filter block to avoid of other not known symbols which we
    could miss. This block converts commit message to HTML and then takes
    only text from it.
