### PR TITLE
test: fix flaky force_recovery test

### DIFF
--- a/src/box/memtx_engine.c
+++ b/src/box/memtx_engine.c
@@ -205,9 +205,9 @@ memtx_engine_recover_snapshot(struct memtx_engine *memtx,
 	 */
 	if (!xlog_cursor_is_eof(&cursor)) {
 		if (!memtx->force_recovery)
-			panic("snapshot `%s' has no EOF marker", filename);
+			panic("snapshot `%s' has no EOF marker", cursor.name);
 		else
-			say_error("snapshot `%s' has no EOF marker", filename);
+			say_error("snapshot `%s' has no EOF marker", cursor.name);
 	}
 
 	return 0;

--- a/test/box/gh-5422-broken_snapshot.result
+++ b/test/box/gh-5422-broken_snapshot.result
@@ -185,10 +185,6 @@ assert(valid_data_count_2 > 0)
 write_garbage_with_restore_or_save(snapshot, 5000, garbage_size, true)
 ---
 ...
-os.remove(string.format('%s.save', snapshot))
----
-- true
-...
 test_run:cmd("stop server test")
 ---
 - true
@@ -208,6 +204,31 @@ opts.filename = 'gh-5422-broken_snapshot.log'
 assert(test_run:grep_log("test", "ER_UNKNOWN_REPLICA", nil, opts) == nil)
 ---
 - true
+...
+-- Check that snapshot filename in log file is not corrupted
+os.execute(string.format('cp %s.save %s', snapshot, snapshot))
+---
+- 0
+...
+os.execute(string.format('dd if=%s.save of=%s bs=%d count=1', snapshot, snapshot, size - corruption_offset))
+---
+- 0
+...
+test_run:cmd("start server test")
+---
+- true
+...
+test_run:cmd("stop server test")
+---
+- true
+...
+os.remove(string.format('%s.save', snapshot))
+---
+- true
+...
+assert(test_run:grep_log("test", ".snap' has no EOF marker", nil, opts))
+---
+- .snap' has no EOF marker
 ...
 test_run:cmd("cleanup server test")
 ---

--- a/test/box/gh-5422-broken_snapshot.result
+++ b/test/box/gh-5422-broken_snapshot.result
@@ -12,18 +12,18 @@ test_run:cmd("setopt delimiter ';'")
 - true
 ...
 function get_snapshot_name ()
-    local shapshot = nil
+    local snapshot = nil
     local directory = fio.pathjoin(fio.cwd(), 'gh-5422-broken_snapshot')
     for files in io.popen(string.format("ls %s", directory)):lines() do
         local snapshots = string.find(files, "snap")
         if (snapshots ~= nil) then
-            shapshot = string.find(files, "%n")
-            if (shapshot ~= nil) then
-                shapshot = string.format("%s/%s", directory, files)
+            snapshot = string.find(files, "%n")
+            if (snapshot ~= nil) then
+                snapshot = string.format("%s/%s", directory, files)
             end
         end
     end
-    return shapshot
+    return snapshot
 end;
 ---
 ...
@@ -181,10 +181,6 @@ assert(valid_data_count_2 > 0)
 ---
 - true
 ...
-assert(valid_data_count_2 > valid_data_count_1)
----
-- true
-...
 -- Restore snapshot and write big garbage at the start of the file
 write_garbage_with_restore_or_save(snapshot, 5000, garbage_size, true)
 ---
@@ -202,11 +198,14 @@ test_run:cmd("start server test with crash_expected=True")
 ---
 - false
 ...
-log = string.format("%s/%s.%s", fio.cwd(), "gh-5422-broken_snapshot", "log")
+opts = {}
 ---
 ...
--- We must not find ER_UNKNOWN_REPLICA in log file, so grep return not 0
-assert(os.execute(string.format("cat %s | grep ER_UNKNOWN_REPLICA:", log)) ~= 0)
+opts.filename = 'gh-5422-broken_snapshot.log'
+---
+...
+-- We must not find ER_UNKNOWN_REPLICA in log file
+assert(test_run:grep_log("test", "ER_UNKNOWN_REPLICA", nil, opts) == nil)
 ---
 - true
 ...


### PR DESCRIPTION
In the test, there is a place, where it was checked that the amount
of valid data in snapshot in case when it was truncated is less than
in case we write garbage to it. Often it's really so, but depends on
the place of truncation/garbage location. Removed this check, because
on different systems, snapshot size is slightly different each time
you run test, so check will not pass every time.
Follow-up #5422