### PR TITLE
github-ci: add more cleanup for running WS

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -52,4 +52,7 @@ runs:
         if ${{ ! startsWith(github.ref, 'refs/tags/') }}; then
             git tag -d "$(git tag --points-at HEAD)" 2>/dev/null || true
         fi
+        # Found that actions/checkout does not remove all temporary
+        # files from previous runs, to avoid of it need to run:
+        git submodule foreach --recursive 'git clean -xffd'
       shell: bash


### PR DESCRIPTION
gitub-ci: add more cleanup for running WS

Found that 'actions/checkout' does not remove all temporary files from
previous runs in submodules [1], it runs only 'git clean -xffd' [2]:
```
  libgcov profiling error:/home/ubuntu/actions-runner/_work/tarantool/tarantool/src/lib/small/CMakeFiles/small.dir/small/small_class.c.gcda:overwriting an existing profile data with a different timestamp
```
To avoid of it added:
```
  git submodules foreach --recursive 'git clean -xffd'
```
to 'actions/environment' which is run after each 'actions/checkout'.

Part of #5986

[1]: https://github.com/tarantool/tarantool/runs/2318244478?check_suite_focus=true#step:5:4012
[2]: https://github.com/actions/checkout/issues/358
