### PR TITLE
security: update libcurl from 7.71.1 to 7.76.0

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Build-Depends: cdbs (>= 0.4.100), debhelper (>= 9), dpkg-dev (>= 1.16.1~),
 # make package manager seek for cmake3 package at first and use it
 # if found or fallback to cmake package (that provides CMake 3+
 # for modern distributions) otherwise.
- cmake3 (>= 3.1) | cmake (>= 3.1),
+ cmake3 (>= 3.2) | cmake (>= 3.2),
  libreadline-dev,
  libncurses5-dev,
  libssl-dev,

--- a/rpm/tarantool.spec
+++ b/rpm/tarantool.spec
@@ -18,9 +18,9 @@
 # otherwise this dependency is left unmet. If there are any issues
 # with building an RPM package on RHEL/CentOS 7 read the docs:
 # https://www.tarantool.io/en/doc/latest/dev_guide/building_from_source/
-BuildRequires: cmake3 >= 3.1
+BuildRequires: cmake3 >= 3.2
 %else
-BuildRequires: cmake >= 3.1
+BuildRequires: cmake >= 3.2
 %endif
 
 BuildRequires: make
@@ -124,7 +124,7 @@ Requires: openssl
 # RHEL <= 7 doesn't support Recommends:
 Recommends: tarantool-devel
 Recommends: git-core
-Recommends: cmake >= 3.1
+Recommends: cmake >= 3.2
 Recommends: make
 Recommends: gcc >= 4.5
 Recommends: gcc-c++ >= 4.5


### PR DESCRIPTION
The reason of the update is to protect us against possible MITM attack
from a malicious HTTPS proxy server with trusted certificate when TLS
1.3 is used ([CVE-2021-22890][1]). libcurl versions prior to 7.76.0 can
skip a TLS handshake with a target host in this circumstances.

Other vulnerabilities fixed in the (7.71.1; 7.76.0] version range do not
look relevant to our built-in http client. See [here][2] for the full list.

The CMake version requirement is updated from 3.1 to 3.2, because curl's
CMakeLists.txt has the following clause at beginning:

```cmake
cmake_minimum_required(VERSION 3.2...3.16 FATAL_ERROR)
```

(It was there in vanilla curl 7.71.1 too and we had to remove it in
order to support CMake 2. Now we don't support CMake 2, so it is good
time to get rid of the extra patch upward vanilla curl repository.)

According to the CMake versions table in 8a7702b ('github-ci: purge Debian
Jessie from CI'), CMake 3.2+ is available on all supported OSes.

[1]: https://curl.se/docs/CVE-2021-22890.html
[2]: https://curl.se/docs/vulnerabilities.html

@TarantoolBot document
Title: Now we require CMake 3.2 to build tarantool

In https://github.com/tarantool/doc/issues/1780 we requested
to update the CMake minimum version to 3.1. Now it is time for 3.2. See details in
the linked commit.

Please, update the 'Building from source' manual.