### PR TITLE
txm: switch to normal mode earlier durion recovery with MVCC

### DIFF
--- a/src/box/memtx_engine.c
+++ b/src/box/memtx_engine.c
@@ -315,7 +315,7 @@ memtx_engine_begin_final_recovery(struct engine *engine)
 	/* End of the fast path: loaded the primary key. */
 	space_foreach(memtx_end_build_primary_key, memtx);
 
-	if (!memtx->force_recovery) {
+	if (!memtx->force_recovery && !memtx_tx_manager_use_mvcc_engine) {
 		/*
 		 * Fast start path: "play out" WAL
 		 * records using the primary key only,

--- a/test/box/gh-5610-dirty-restart.lua
+++ b/test/box/gh-5610-dirty-restart.lua
@@ -1,0 +1,10 @@
+#!/usr/bin/env tarantool
+
+box.cfg{
+    listen = os.getenv("LISTEN"),
+    replication_synchro_quorum = 2,
+    replication_synchro_timeout = 100,
+    memtx_use_mvcc_engine = true,
+}
+
+require('console').listen(os.getenv('ADMIN'))

--- a/test/box/gh-5610-dirty-restart.result
+++ b/test/box/gh-5610-dirty-restart.result
@@ -1,0 +1,63 @@
+-- test-run result file version 2
+env = require('test_run')
+ | ---
+ | ...
+test_run = env.new()
+ | ---
+ | ...
+test_run:cmd("create server gh_5610_dirty_restart with script='box/gh-5610-dirty-restart.lua'")
+ | ---
+ | - true
+ | ...
+test_run:cmd("start server gh_5610_dirty_restart")
+ | ---
+ | - true
+ | ...
+test_run:cmd("switch gh_5610_dirty_restart")
+ | ---
+ | - true
+ | ...
+
+fiber = require('fiber')
+ | ---
+ | ...
+s = box.schema.space.create('test', {is_sync = true})
+ | ---
+ | ...
+i = s:create_index('pk')
+ | ---
+ | ...
+_ = fiber.new(function() box.space.test:insert{1} end)
+ | ---
+ | ...
+s:select{}
+ | ---
+ | - []
+ | ...
+fiber.sleep(0) -- to be sure
+ | ---
+ | ...
+s:select{}
+ | ---
+ | - []
+ | ...
+
+test_run:cmd("restart server gh_5610_dirty_restart")
+ | 
+box.space.test:select{}
+ | ---
+ | - []
+ | ...
+
+test_run:cmd("switch default")
+ | ---
+ | - true
+ | ...
+test_run:cmd("stop server gh_5610_dirty_restart")
+ | ---
+ | - true
+ | ...
+test_run:cmd("cleanup server gh_5610_dirty_restart")
+ | ---
+ | - true
+ | ...

--- a/test/box/gh-5610-dirty-restart.test.lua
+++ b/test/box/gh-5610-dirty-restart.test.lua
@@ -1,0 +1,20 @@
+env = require('test_run')
+test_run = env.new()
+test_run:cmd("create server gh_5610_dirty_restart with script='box/gh-5610-dirty-restart.lua'")
+test_run:cmd("start server gh_5610_dirty_restart")
+test_run:cmd("switch gh_5610_dirty_restart")
+
+fiber = require('fiber')
+s = box.schema.space.create('test', {is_sync = true})
+i = s:create_index('pk')
+_ = fiber.new(function() box.space.test:insert{1} end)
+s:select{}
+fiber.sleep(0) -- to be sure
+s:select{}
+
+test_run:cmd("restart server gh_5610_dirty_restart")
+box.space.test:select{}
+
+test_run:cmd("switch default")
+test_run:cmd("stop server gh_5610_dirty_restart")
+test_run:cmd("cleanup server gh_5610_dirty_restart")


### PR DESCRIPTION
Usually during final recovery, when .xlog files are loaded and
applied, a special memtx_space_replace_primary_key function is
used for faster recovery. The function only updates primary key
while all other indexes are scheduled to build at the end of
recovery.

This approach doesn't work with MVCC engine and synchro spaces:
When transactions appear in xlog and they may or may not be
committed, we should process the in normal mode throught all
indexes in order to leave transaction history in each index.

Fixes #5610 #5973