### PR TITLE
update: don't allow to autofill with nulls not root array

### DIFF
--- a/src/box/xrow_update_array.c
+++ b/src/box/xrow_update_array.c
@@ -322,6 +322,13 @@ xrow_update_array_append_nils(struct xrow_update_field *field,
 	uint32_t size = xrow_update_rope_size(rope);
 	if (op->field_no < 0 || (uint32_t)op->field_no <= size)
 		return 0;
+	/*
+	 * Do not allow autofill of nested arrays with nulls. It is not
+	 * supported only because there is no an easy way how to apply that to
+	 * bar updates which can also affect arrays.
+	 */
+	if (!op->is_for_root)
+		return 0;
 	uint32_t nil_count = op->field_no - size;
 	struct xrow_update_array_item *item =
 		(struct xrow_update_array_item *)

--- a/src/box/xrow_update_field.c
+++ b/src/box/xrow_update_field.c
@@ -727,6 +727,7 @@ xrow_update_op_decode(struct xrow_update_op *op, int op_num, int index_base,
 	switch(mp_typeof(**expr)) {
 	case MP_INT:
 	case MP_UINT: {
+		op->is_for_root = true;
 		json_lexer_create(&op->lexer, NULL, 0, 0);
 		if (xrow_update_mp_read_int32(op, expr, &field_no) != 0)
 			return -1;
@@ -748,6 +749,7 @@ xrow_update_op_decode(struct xrow_update_op *op, int op_num, int index_base,
 					  &field_no) == 0) {
 			op->field_no = (int32_t) field_no;
 			op->lexer.offset = len;
+			op->is_for_root = true;
 			break;
 		}
 		struct json_token token;
@@ -771,6 +773,7 @@ xrow_update_op_decode(struct xrow_update_op *op, int op_num, int index_base,
 				 tt_cstr(path, len));
 			return -1;
 		}
+		op->is_for_root = json_lexer_is_eof(&op->lexer);
 		break;
 	}
 	default:

--- a/src/box/xrow_update_field.h
+++ b/src/box/xrow_update_field.h
@@ -210,6 +210,13 @@ struct xrow_update_op {
 	 * update tree.
 	 */
 	struct json_lexer lexer;
+	/**
+	 * Flag, indicates that this operation is applied to the root, which
+	 * happens to be only an array so far. Can't use the lexer emptiness
+	 * because even in case of a single token it is not NULL and us used for
+	 * error reporting.
+	 */
+	bool is_for_root;
 };
 
 /**

--- a/test/engine/update.result
+++ b/test/engine/update.result
@@ -1135,3 +1135,78 @@ s:update({1}, {{'!', 'field4.key1', 0}})
 ---
 - error: Field 'field4.key1' was not found in the tuple
 ...
+s:drop()
+---
+...
+--
+-- Autofill of nils is baned for nested arrays.
+--
+s = box.schema.create_space('test', {engine = engine})
+---
+...
+pk = s:create_index('pk')
+---
+...
+s:insert({1, 2, {11, 22}})
+---
+- [1, 2, [11, 22]]
+...
+-- When two operations are used for one array, internally it looks very similar
+-- to how the root array is represented. Still the ban should work.
+op1 = {'=', '[3][1]', 11}
+---
+...
+op2 = {'=', '[3][4]', 44}
+---
+...
+s:update({1}, {op1, op2})
+---
+- error: Field ''[3][4]'' was not found in the tuple
+...
+s:update({1}, {op1})
+---
+- [1, 2, [11, 22]]
+...
+s:update({1}, {op2})
+---
+- error: Field ''[3][4]'' was not found in the tuple
+...
+s:drop()
+---
+...
+format = {}
+---
+...
+format[1] = {name = 'field1', type = 'unsigned'}
+---
+...
+format[2] = {name = 'field2', type = 'unsigned', is_nullable = true}
+---
+...
+format[3] = {name = 'field3', type = 'unsigned', is_nullable = true}
+---
+...
+s = box.schema.create_space('test', {format = format})
+---
+...
+_ = s:create_index('pk')
+---
+...
+t = s:replace({1})
+---
+...
+t:update({{'=', 3, 3}})
+---
+- [1, null, 3]
+...
+t:update({{'=', '[3]', 3}})
+---
+- [1, null, 3]
+...
+t:update({{'=', 'field3', 3}})
+---
+- [1, null, 3]
+...
+s:drop()
+---
+...


### PR DESCRIPTION
tuple: do not allow autofill of nested arrays with nulls

In previous version there was inconsistent/ behaviour for update
operations to nested arrays. When user try to update non existent
field of nested array along with previous update existent field,
it's works, otherwise no. For example we create tuple and two
update operations:
`t = box.tuple.new({1, 2, {11, 22}})`
`op1 = {'=', '[3][1]', 11}`
`op2 = {'=', '[3][4]', 44}`
Then in case we apply operations separately `t:update({op1})` and
then `t:update({op2})`, second operation fails but is case we apply
them together t:update({op1, op2}) they both complete successfully.

Follow up #3378
 