### PR TITLE
Fix nondeterminism of ER_TUPLE_FOUND error

### DIFF
--- a/test/box/alter.result
+++ b/test/box/alter.result
@@ -27,14 +27,12 @@ EMPTY_MAP = utils.setmap({})
 -- Test insertion into a system space - verify that
 -- mandatory fields are required.
 --
-_space:insert{_space.id, ADMIN, 'test', 'memtx', 0, EMPTY_MAP, {}}
+err, res = pcall(function() return _space:insert{_space.id, ADMIN, 'test', 'memtx', 0, EMPTY_MAP, {}} end)
 ---
-- error: 'Duplicate key exists in unique index "primary" in space "_space" with old
-    tuple - [280, 1, "_space", "memtx", 0, {}, [{"name": "id", "type": "unsigned"},
-    {"name": "owner", "type": "unsigned"}, {"name": "name", "type": "string"}, {"name":
-    "engine", "type": "string"}, {"name": "field_count", "type": "unsigned"}, {"name":
-    "flags", "type": "map"}, {"name": "format", "type": "array"}]] and new tuple -
-    [280, 1, "test", "memtx", 0, {}, []]'
+...
+assert(res.code == box.error.TUPLE_FOUND)
+---
+- true
 ...
 --
 -- Bad space id
@@ -47,26 +45,22 @@ _space:insert{'hello', 'world', 'test', 'memtx', 0, EMPTY_MAP, {}}
 --
 -- Can't create a space which has wrong field count - field_count must be NUM
 --
-_space:insert{_space.id, ADMIN, 'test', 'world', 0, EMPTY_MAP, {}}
+err, res = pcall(function() return _space:insert{_space.id, ADMIN, 'test', 'world', 0, EMPTY_MAP, {}} end)
 ---
-- error: 'Duplicate key exists in unique index "primary" in space "_space" with old
-    tuple - [280, 1, "_space", "memtx", 0, {}, [{"name": "id", "type": "unsigned"},
-    {"name": "owner", "type": "unsigned"}, {"name": "name", "type": "string"}, {"name":
-    "engine", "type": "string"}, {"name": "field_count", "type": "unsigned"}, {"name":
-    "flags", "type": "map"}, {"name": "format", "type": "array"}]] and new tuple -
-    [280, 1, "test", "world", 0, {}, []]'
+...
+assert(res.code == box.error.TUPLE_FOUND)
+---
+- true
 ...
 --
 -- There is already a tuple for the system space
 --
-_space:insert{_space.id, ADMIN, '_space', 'memtx', 0, EMPTY_MAP, {}}
+err, res = pcall(function() return _space:insert{_space.id, ADMIN, '_space', 'memtx', 0, EMPTY_MAP, {}} end)
 ---
-- error: 'Duplicate key exists in unique index "primary" in space "_space" with old
-    tuple - [280, 1, "_space", "memtx", 0, {}, [{"name": "id", "type": "unsigned"},
-    {"name": "owner", "type": "unsigned"}, {"name": "name", "type": "string"}, {"name":
-    "engine", "type": "string"}, {"name": "field_count", "type": "unsigned"}, {"name":
-    "flags", "type": "map"}, {"name": "format", "type": "array"}]] and new tuple -
-    [280, 1, "_space", "memtx", 0, {}, []]'
+...
+assert(res.code == box.error.TUPLE_FOUND)
+---
+- true
 ...
 _space:insert{_index.id, ADMIN, '_index', 'memtx', 0, EMPTY_MAP, {}}
 ---
@@ -159,22 +153,23 @@ space:replace{0}
 ---
 - error: Space '381' does not exist
 ...
-_index:insert{_space.id, 0, 'primary', 'tree', {unique=true}, {{0, 'unsigned'}}}
+err, res = pcall(function() return _index:insert{_space.id, 0, 'primary', 'tree', {unique=true}, {{0, 'unsigned'}}} end)
 ---
-- error: 'Duplicate key exists in unique index "primary" in space "_index" with old
-    tuple - [280, 0, "primary", "tree", {"unique": true}, [[0, "unsigned"]]] and new
-    tuple - [280, 0, "primary", "tree", {"unique": true}, [[0, "unsigned"]]]'
+...
+assert(res.code == box.error.TUPLE_FOUND)
+---
+- true
 ...
 _index:replace{_space.id, 0, 'primary', 'tree', {unique=true}, {{0, 'unsigned'}}}
 ---
 - [280, 0, 'primary', 'tree', {'unique': true}, [[0, 'unsigned']]]
 ...
-_index:insert{_index.id, 0, 'primary', 'tree', {unique=true}, {{0, 'unsigned'}, {1, 'unsigned'}}}
+err, res = pcall(function() return _index:insert{_index.id, 0, 'primary', 'tree', {unique=true}, {{0, 'unsigned'}, {1, 'unsigned'}}} end)
 ---
-- error: 'Duplicate key exists in unique index "primary" in space "_index" with old
-    tuple - [288, 0, "primary", "tree", {"unique": true}, [[0, "unsigned"], [1, "unsigned"]]]
-    and new tuple - [288, 0, "primary", "tree", {"unique": true}, [[0, "unsigned"],
-    [1, "unsigned"]]]'
+...
+assert(res.code == box.error.TUPLE_FOUND)
+---
+- true
 ...
 _index:replace{_index.id, 0, 'primary', 'tree', {unique=true}, {{0, 'unsigned'}, {1, 'unsigned'}}}
 ---
@@ -461,11 +456,12 @@ space:drop()
 auto = box.schema.space.create('auto_original')
 ---
 ...
-box.schema.space.create('auto', {id = auto.id})
+err, res = pcall(function() return box.schema.space.create('auto', {id = auto.id}) end)
 ---
-- error: Duplicate key exists in unique index "primary" in space "_space" with old
-    tuple - [524, 1, "auto_original", "memtx", 0, {}, []] and new tuple - [524, 1,
-    "auto", "memtx", 0, {}, []]
+...
+assert(res.code == box.error.TUPLE_FOUND)
+---
+- true
 ...
 box.schema.space.drop('auto')
 ---
@@ -1548,14 +1544,12 @@ assert(s.name == 'test2')
 ---
 - true
 ...
-s:alter({name = '_space'})
+err, res = pcall(function() return s:alter({name = '_space'}) end)
 ---
-- error: 'Duplicate key exists in unique index "name" in space "_space" with old tuple
-    - [280, 1, "_space", "memtx", 0, {}, [{"name": "id", "type": "unsigned"}, {"name":
-    "owner", "type": "unsigned"}, {"name": "name", "type": "string"}, {"name": "engine",
-    "type": "string"}, {"name": "field_count", "type": "unsigned"}, {"name": "flags",
-    "type": "map"}, {"name": "format", "type": "array"}]] and new tuple - [799, 1,
-    "_space", "memtx", 0, {"temporary": false, "is_sync": false}, []]'
+...
+assert(res.code == box.error.TUPLE_FOUND)
+---
+- true
 ...
 s:alter({name = 'test'})
 ---

--- a/test/box/alter.test.lua
+++ b/test/box/alter.test.lua
@@ -11,7 +11,8 @@ EMPTY_MAP = utils.setmap({})
 -- Test insertion into a system space - verify that
 -- mandatory fields are required.
 --
-_space:insert{_space.id, ADMIN, 'test', 'memtx', 0, EMPTY_MAP, {}}
+err, res = pcall(function() return _space:insert{_space.id, ADMIN, 'test', 'memtx', 0, EMPTY_MAP, {}} end)
+assert(res.code == box.error.TUPLE_FOUND)
 --
 -- Bad space id
 --
@@ -19,11 +20,13 @@ _space:insert{'hello', 'world', 'test', 'memtx', 0, EMPTY_MAP, {}}
 --
 -- Can't create a space which has wrong field count - field_count must be NUM
 --
-_space:insert{_space.id, ADMIN, 'test', 'world', 0, EMPTY_MAP, {}}
+err, res = pcall(function() return _space:insert{_space.id, ADMIN, 'test', 'world', 0, EMPTY_MAP, {}} end)
+assert(res.code == box.error.TUPLE_FOUND)
 --
 -- There is already a tuple for the system space
 --
-_space:insert{_space.id, ADMIN, '_space', 'memtx', 0, EMPTY_MAP, {}}
+err, res = pcall(function() return _space:insert{_space.id, ADMIN, '_space', 'memtx', 0, EMPTY_MAP, {}} end)
+assert(res.code == box.error.TUPLE_FOUND)
 _space:insert{_index.id, ADMIN, '_index', 'memtx', 0, EMPTY_MAP, {}}
 --
 -- Can't drop a system space
@@ -56,9 +59,11 @@ t = _space:delete{space.id}
 space_deleted = box.space[t[1]]
 space_deleted
 space:replace{0}
-_index:insert{_space.id, 0, 'primary', 'tree', {unique=true}, {{0, 'unsigned'}}}
+err, res = pcall(function() return _index:insert{_space.id, 0, 'primary', 'tree', {unique=true}, {{0, 'unsigned'}}} end)
+assert(res.code == box.error.TUPLE_FOUND)
 _index:replace{_space.id, 0, 'primary', 'tree', {unique=true}, {{0, 'unsigned'}}}
-_index:insert{_index.id, 0, 'primary', 'tree', {unique=true}, {{0, 'unsigned'}, {1, 'unsigned'}}}
+err, res = pcall(function() return _index:insert{_index.id, 0, 'primary', 'tree', {unique=true}, {{0, 'unsigned'}, {1, 'unsigned'}}} end)
+assert(res.code == box.error.TUPLE_FOUND)
 _index:replace{_index.id, 0, 'primary', 'tree', {unique=true}, {{0, 'unsigned'}, {1, 'unsigned'}}}
 -- access_sysview.test changes output of _index:select{}.
 -- let's change _index space in such a way that it will be
@@ -154,7 +159,8 @@ space:drop()
 -- gh-57 Confusing error message when trying to create space with a
 -- duplicate id
 auto = box.schema.space.create('auto_original')
-box.schema.space.create('auto', {id = auto.id})
+err, res = pcall(function() return box.schema.space.create('auto', {id = auto.id}) end)
+assert(res.code == box.error.TUPLE_FOUND)
 box.schema.space.drop('auto')
 box.schema.space.create('auto_original', {id = auto.id})
 auto:drop()
@@ -606,7 +612,8 @@ s:alter({name = nil})
 assert(box.space.test2 ~= nil)
 assert(box.space.test == nil)
 assert(s.name == 'test2')
-s:alter({name = '_space'})
+err, res = pcall(function() return s:alter({name = '_space'}) end)
+assert(res.code == box.error.TUPLE_FOUND)
 s:alter({name = 'test'})
 assert(box.space.test ~= nil)
 assert(box.space.test2 == nil)

--- a/test/box/alter_limits.result
+++ b/test/box/alter_limits.result
@@ -92,11 +92,12 @@ s.id
 - 3000
 ...
 -- duplicate id
-box.schema.space.create('tweedledee', { id = 3000 })
+err, res = pcall(function() return box.schema.space.create('tweedledee', { id = 3000 }) end)
 ---
-- error: Duplicate key exists in unique index "primary" in space "_space" with old
-    tuple - [3000, 1, "tweedledum", "memtx", 0, {}, []] and new tuple - [3000, 1,
-    "tweedledee", "memtx", 0, {}, []]
+...
+assert(res.code == box.error.TUPLE_FOUND)
+---
+- true
 ...
 -- stupid space id
 box.schema.space.create('tweedledee', { id = 'tweedledee' })
@@ -736,11 +737,12 @@ s.index.second.id
 index = s:create_index('third', { type = 'hash', parts = {  3, 'unsigned' } })
 ---
 ...
-s.index.third:rename('second')
+err, res = pcall(function() return s.index.third:rename('second') end)
 ---
-- error: 'Duplicate key exists in unique index "name" in space "_index" with old tuple
-    - [814, 1, "second", "tree", {"unique": true}, [[1, "string"]]] and new tuple
-    - [814, 2, "second", "hash", {"unique": true}, [[2, "unsigned"]]]'
+...
+assert(res.code == box.error.TUPLE_FOUND)
+---
+- true
 ...
 s.index.third.id
 ---

--- a/test/box/alter_limits.test.lua
+++ b/test/box/alter_limits.test.lua
@@ -35,7 +35,8 @@ box.schema.space.create('tweedleedee', { engine = 'unknown' })
 s = box.schema.space.create('tweedledum', { id = 3000 })
 s.id
 -- duplicate id
-box.schema.space.create('tweedledee', { id = 3000 })
+err, res = pcall(function() return box.schema.space.create('tweedledee', { id = 3000 }) end)
+assert(res.code == box.error.TUPLE_FOUND)
 -- stupid space id
 box.schema.space.create('tweedledee', { id = 'tweedledee' })
 s:drop()
@@ -255,7 +256,8 @@ s.index.pk:rename('primary')
 index = s:create_index('second', { type = 'tree', parts = {  2, 'string' } })
 s.index.second.id
 index = s:create_index('third', { type = 'hash', parts = {  3, 'unsigned' } })
-s.index.third:rename('second')
+err, res = pcall(function() return s.index.third:rename('second') end)
+assert(res.code == box.error.TUPLE_FOUND)
 s.index.third.id
 s.index.second:drop()
 s.index.third:alter({name = 'second'})

--- a/test/box/ddl_collation.result
+++ b/test/box/ddl_collation.result
@@ -38,11 +38,12 @@ box.internal.collation.create('test', 'nothing', 'ru_RU')
 box.internal.collation.create('test', 'ICU', 'ru_RU', setmap{}) --ok
  | ---
  | ...
-box.internal.collation.create('test', 'ICU', 'ru_RU')
+err, res = pcall(function() return box.internal.collation.create('test', 'ICU', 'ru_RU') end)
  | ---
- | - error: 'Duplicate key exists in unique index "name" in space "_collation" with old
- |     tuple - [277, "test", 1, "ICU", "ru_RU", {"strength": "tertiary"}] and new tuple
- |     - [278, "test", 1, "ICU", "ru_RU", {"strength": "tertiary"}]'
+ | ...
+assert(res.code == box.error.TUPLE_FOUND)
+ | ---
+ | - true
  | ...
 box.internal.collation.drop('test')
  | ---
@@ -164,11 +165,12 @@ box.space._collation:auto_increment{'test', 0, 'ICU', 'ru_RU', setmap{}} --ok
  | ---
  | - [277, 'test', 0, 'ICU', 'ru_RU', {}]
  | ...
-box.space._collation:auto_increment{'test', 0, 'ICU', 'ru_RU', setmap{}}
+err, res = pcall(function() return box.space._collation:auto_increment{'test', 0, 'ICU', 'ru_RU', setmap{}} end)
  | ---
- | - error: Duplicate key exists in unique index "name" in space "_collation" with old
- |     tuple - [277, "test", 0, "ICU", "ru_RU", {}] and new tuple - [278, "test", 0,
- |     "ICU", "ru_RU", {}]
+ | ...
+assert(res.code == box.error.TUPLE_FOUND)
+ | ---
+ | - true
  | ...
 box.space._collation.index.name:delete{'test'} -- ok
  | ---

--- a/test/box/ddl_collation.test.lua
+++ b/test/box/ddl_collation.test.lua
@@ -11,7 +11,8 @@ box.internal.collation.create('test', 42, 'ru_RU')
 box.internal.collation.create('test', 'ICU', 42)
 box.internal.collation.create('test', 'nothing', 'ru_RU')
 box.internal.collation.create('test', 'ICU', 'ru_RU', setmap{}) --ok
-box.internal.collation.create('test', 'ICU', 'ru_RU')
+err, res = pcall(function() return box.internal.collation.create('test', 'ICU', 'ru_RU') end)
+assert(res.code == box.error.TUPLE_FOUND)
 box.internal.collation.drop('test')
 box.internal.collation.drop('nothing') -- allowed
 box.internal.collation.create('test', 'ICU', 'ru_RU', 42)
@@ -48,7 +49,8 @@ box.space._collation:auto_increment{42, 0, 'ICU', 'ru_RU'}
 box.space._collation:auto_increment{'test', 0, 42, 'ru_RU'}
 box.space._collation:auto_increment{'test', 0, 'ICU', 42}
 box.space._collation:auto_increment{'test', 0, 'ICU', 'ru_RU', setmap{}} --ok
-box.space._collation:auto_increment{'test', 0, 'ICU', 'ru_RU', setmap{}}
+err, res = pcall(function() return box.space._collation:auto_increment{'test', 0, 'ICU', 'ru_RU', setmap{}} end)
+assert(res.code == box.error.TUPLE_FOUND)
 box.space._collation.index.name:delete{'test'} -- ok
 box.space._collation.index.name:delete{'nothing'} -- allowed
 box.space._collation:auto_increment{'test', 0, 'ICU', 'ru_RU', 42}

--- a/test/box/sequence.result
+++ b/test/box/sequence.result
@@ -112,11 +112,12 @@ sq1 == sq2, msg
 _ = box.schema.sequence.create('test2')
 ---
 ...
-box.schema.sequence.alter('test2', {name = 'test'})
+err, res = pcall(function() return box.schema.sequence.alter('test2', {name = 'test'}) end)
 ---
-- error: Duplicate key exists in unique index "name" in space "_sequence" with old
-    tuple - [1, 1, "test", 1, 1, 9223372036854775807, 1, 0, false] and new tuple -
-    [2, 1, "test", 1, 1, 9223372036854775807, 1, 0, false]
+...
+assert(res.code == box.error.TUPLE_FOUND)
+---
+- true
 ...
 box.schema.sequence.drop('test2')
 ---

--- a/test/box/sequence.test.lua
+++ b/test/box/sequence.test.lua
@@ -33,7 +33,8 @@ box.schema.sequence.create('test')
 sq2, msg = box.schema.sequence.create('test', {if_not_exists = true})
 sq1 == sq2, msg
 _ = box.schema.sequence.create('test2')
-box.schema.sequence.alter('test2', {name = 'test'})
+err, res = pcall(function() return box.schema.sequence.alter('test2', {name = 'test'}) end)
+assert(res.code == box.error.TUPLE_FOUND)
 box.schema.sequence.drop('test2')
 box.schema.sequence.drop('test')
 


### PR DESCRIPTION
ER_TUPLE_FOUND error message depends on the previous tests, so we can
just check error code in these tests to avoid it.