### PR TITLE
test: ASAN leak on feedback demon call using cURL

### DIFF
--- a/asan/lsan.supp
+++ b/asan/lsan.supp
@@ -8,6 +8,13 @@
 # source: /usr/lib/x86_64-linux-gnu/libcrypto.so
 leak:CRYPTO_zalloc
 
+# test: all (feedback demon fails using cURL)
+# https://github.com/tarantool/tarantool-qa/issues/116
+# source: /lib/x86_64-linux-gnu/libcrypto.so
+leak:libcrypto.so*
+# source: /lib/x86_64-linux-gnu/libssl.so
+leak:libssl.so*
+
 # test: app-tap/http_client.test.lua
 # source: src/tarantool
 leak:Curl_setstropt


### PR DESCRIPTION
Found that after patch set of 5 commits:

  aa97a18575a5fba29550e131c4764b81841612b9 ("feedback_daemon: count and report some events")
  e9c9832a0f3635fa0179a2cc1bfd334dea8cdc64 ("feedback_daemon: generate report right before sending")
  bc15e0f070c89e00cd76b0432d906697aae25202 ("feedback_daemon: send feedback on server start")
  670acf0d163436a6853dc54d521ff7f037acba8d ("feedback_daemon: rename `send_test` to `send`")
  c5d595bcae1a539604895b186cdda86a212909e8 ("feedback_daemon: include server uptime in the report")

began to leak feedback demon on using cURL. To avoid of it decided to
add LSAN suppresions:

  1. for /lib/x86_64-linux-gnu/libcrypto.so
     leak:libcrypto.so*
  2. for /lib/x86_64-linux-gnu/libssl.so
     leak:libssl.so*

Needed for tarantool/tarantool-qa#116