### PR TITLE
build: coverage needs workaround with link

### DIFF
--- a/.travis.mk
+++ b/.travis.mk
@@ -83,8 +83,8 @@ deps_coverage_ubuntu_ghactions: deps_ubuntu_ghactions
 	# Link src/lib/uri/src to local src dircetory to avoid of issue:
 	# /var/lib/gems/2.7.0/gems/coveralls-lcov-1.7.0/lib/coveralls/lcov/converter.rb:64:in
 	#   `initialize': No such file or directory @ rb_sysopen -
-	#   /home/runner/work/tarantool/tarantool/src/lib/uri/src/lib/uri/uri.c (Errno::ENOENT)
-	ln -s ${PWD}/src src/lib/uri/src
+	#   /home/runner/work/tarantool/tarantool/src/src/uri.c (Errno::ENOENT)
+	ln -s ${PWD}/src src/src
 
 deps_debian_packages:
 	apt-get update ${APT_EXTRA_FLAGS} && apt-get install -y -f \


### PR DESCRIPTION
Changing the way of running debug build with coverage collecting at
tarantool/tarantool#5949 was found that for paths based on src/ root
directory make routine automatically adds additional src/ directory
prefix in the meta data path at creating .gcda files for src/ paths.

Issue was found running 'lcov' tool command which collects results
from "*.gcda" files:
```
  Processing lib/uri/CMakeFiles/uri.dir/uri.c.gcda
  Cannot open source file src/lib/uri/uri.rl
  Cannot open source file src/lib/uri/uri.c
```
To fix it was added workaround - created link to the needed path before
'lcov' call for master and 2.x:

`  ln -s ${PWD}/src src/lib/uri/src`

but on Tarantool 1.10 it should be:

`  ln -s ${PWD}/src src/src`

This patch fixes it for Tarantool 1.10 branch.

Follows up tarantool/tarantool-qa#101