### PR TITLE
mvcc: dirty fix for handling outdated delete statements

### DIFF
--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1446,14 +1446,12 @@ memtx_tx_history_prepare_stmt(struct txn_stmt *stmt)
 		while (dels != NULL) {
 			struct txn_stmt *next = dels->next_in_del_list;
 			if (dels != stmt) {
-				dels->del_story = NULL;
 				dels->next_in_del_list = NULL;
 			}
 			dels = next;
 		}
 		// Set the only deleting statement for that story.
 		stmt->del_story->del_stmt = stmt;
-		stmt->next_in_del_list = NULL;
 	}
 }
 
@@ -1471,7 +1469,6 @@ memtx_tx_history_commit_stmt(struct txn_stmt *stmt)
 		assert(stmt->del_story->del_stmt == stmt);
 		assert(stmt->next_in_del_list == NULL);
 		res -= stmt->del_story->tuple->bsize;
-		stmt->del_story->del_stmt = NULL;
 		stmt->del_story = NULL;
 	}
 	return res;


### PR DESCRIPTION
It's my weekend's try to localize the problem with outdated delete statements. 

The idea is simple: during rollback, the statement `s:delete(1)` doesn't have `del_stmt` because it was cleared by tx_2. We should leave the pointer to `del_stmt` for the usual rollback.

During my research, some things I don't understand. 
For example, why the `s:replace({1,1})` statement ocuppied memtx_story of `s:delete(1)`?

That and some other nuances aren't allowed me to write a more useful patch in a limited time.

Partly fix https://github.com/tarantool/tarantool/issues/6021.
