### PR TITLE
iproto: add check for user input of the number of iproto threads

### DIFF
--- a/changelogs/unreleased/add-check-for-user-input-of-the-number-of-iproto-threads.md
+++ b/changelogs/unreleased/add-check-for-user-input-of-the-number-of-iproto-threads.md
@@ -1,0 +1,4 @@
+## core/bugfix
+
+ * Added check for user input of the number of iproto threads - value
+   must be > 0 and less then or equal to 1000 (gh-6005).

--- a/changelogs/unreleased/fix-undeleted-unix-socket-path-and-multiple-socket-closing.md
+++ b/changelogs/unreleased/fix-undeleted-unix-socket-path-and-multiple-socket-closing.md
@@ -1,0 +1,6 @@
+## core/bugfix
+
+ * Fixed error, related to the fact, that if user changed listen address,
+   all iproto threads closed same socket multiple times.
+   Fixed error, related to the fact, that tarantool not deleting the unix
+   socket path, when it's finishing work.

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -665,18 +665,20 @@ box_check_say(void)
 	}
 }
 
-static void
+static int
 box_check_uri(const char *source, const char *option_name)
 {
 	if (source == NULL)
-		return;
+		return 0;
 	struct uri uri;
 
 	/* URI format is [host:]service */
 	if (uri_parse(&uri, source) || !uri.service) {
-		tnt_raise(ClientError, ER_CFG, option_name,
-			  "expected host:service or /unix.socket");
+		diag_set(ClientError, ER_CFG, option_name,
+			 "expected host:service or /unix.socket");
+		return -1;
 	}
+	return 0;
 }
 
 static enum election_mode
@@ -720,7 +722,8 @@ box_check_replication(void)
 	int count = cfg_getarr_size("replication");
 	for (int i = 0; i < count; i++) {
 		const char *source = cfg_getarr_elem("replication", i);
-		box_check_uri(source, "replication");
+		if (box_check_uri(source, "replication") != 0)
+			diag_raise();
 	}
 }
 
@@ -1133,7 +1136,8 @@ box_check_config(void)
 {
 	struct tt_uuid uuid;
 	box_check_say();
-	box_check_uri(cfg_gets("listen"), "listen");
+	if (box_check_uri(cfg_gets("listen"), "listen") != 0)
+		diag_raise();
 	box_check_instance_uuid(&uuid);
 	box_check_replicaset_uuid(&uuid);
 	if (box_check_election_mode() == ELECTION_MODE_INVALID)
@@ -1686,7 +1690,8 @@ void
 box_listen(void)
 {
 	const char *uri = cfg_gets("listen");
-	box_check_uri(uri, "listen");
+	if (box_check_uri(uri, "listen") != 0)
+		diag_raise();
 	iproto_listen(uri);
 }
 

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -1686,13 +1686,13 @@ promote:
 	return rc;
 }
 
-void
+int
 box_listen(void)
 {
 	const char *uri = cfg_gets("listen");
-	if (box_check_uri(uri, "listen") != 0)
-		diag_raise();
-	iproto_listen(uri);
+	if (box_check_uri(uri, "listen") != 0 || iproto_listen(uri) != 0)
+		return -1;
+	return 0;
 }
 
 void
@@ -3093,7 +3093,8 @@ bootstrap(const struct tt_uuid *instance_uuid,
 	 * Begin listening on the socket to enable
 	 * master-master replication leader election.
 	 */
-	box_listen();
+	if (box_listen() != 0)
+		diag_raise();
 	/*
 	 * Wait for the cluster to start up.
 	 *
@@ -3180,7 +3181,8 @@ local_recovery(const struct tt_uuid *instance_uuid,
 	say_info("instance vclock %s", vclock_to_string(&replicaset.vclock));
 
 	if (wal_dir_lock >= 0) {
-		box_listen();
+		if (box_listen() != 0)
+			diag_raise();
 		box_sync_replication(false);
 
 		struct replica *master;
@@ -3258,7 +3260,8 @@ local_recovery(const struct tt_uuid *instance_uuid,
 		 * applied in hot standby mode.
 		 */
 		vclock_copy(&replicaset.vclock, &recovery->vclock);
-		box_listen();
+		if (box_listen() != 0)
+			diag_raise();
 		box_sync_replication(false);
 	}
 	stream_guard.is_active = false;

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -231,7 +231,7 @@ box_process_vote(struct ballot *ballot);
 void
 box_check_config(void);
 
-void box_listen(void);
+int box_listen(void);
 void box_set_replication(void);
 void box_set_log_level(void);
 void box_set_log_format(void);

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -138,7 +138,7 @@ struct iproto_thread {
 	/*
 	 * List of stopped connections
 	 */
-	RLIST_HEAD(stopped_connections);
+	struct rlist stopped_connections;
 	/*
 	 * Iproto thread stat
 	 */

--- a/src/box/iproto.h
+++ b/src/box/iproto.h
@@ -96,7 +96,7 @@ iproto_rmean_foreach(void *cb, void *cb_ctx);
 void
 iproto_init(int threads_count);
 
-void
+int
 iproto_listen(const char *uri);
 
 void

--- a/src/box/lua/cfg.cc
+++ b/src/box/lua/cfg.cc
@@ -68,11 +68,8 @@ lbox_cfg_load(struct lua_State *L)
 static int
 lbox_cfg_set_listen(struct lua_State *L)
 {
-	try {
-		box_listen();
-	} catch (Exception *) {
+	if (box_listen() != 0)
 		luaT_error(L);
-	}
 	return 0;
 }
 

--- a/src/lib/core/evio.h
+++ b/src/lib/core/evio.h
@@ -117,6 +117,10 @@ evio_service_bind(struct evio_service *service, const char *uri);
 int
 evio_service_listen(struct evio_service *service);
 
+/** If started, stop event flow, without closing the acceptor socket. */
+void
+evio_service_detach(struct evio_service *service);
+
 /** If started, stop event flow and close the acceptor socket. */
 void
 evio_service_stop(struct evio_service *service);

--- a/test/box/box-cfg-unix-socket-del.lua
+++ b/test/box/box-cfg-unix-socket-del.lua
@@ -1,0 +1,8 @@
+#!/usr/bin/env tarantool
+
+require('console').listen(os.getenv('ADMIN'))
+
+box.cfg({
+    listen = os.getenv('LISTEN'),
+    iproto_threads = tonumber(arg[1]),
+})

--- a/test/box/box-cfg-unix-socket-del.result
+++ b/test/box/box-cfg-unix-socket-del.result
@@ -1,0 +1,91 @@
+-- test-run result file version 2
+env = require('test_run')
+ | ---
+ | ...
+fio = require('fio')
+ | ---
+ | ...
+test_run = env.new()
+ | ---
+ | ...
+test_run:cmd("create server test with script='box/box-cfg-unix-socket-del.lua'")
+ | ---
+ | - true
+ | ...
+
+-- Check that unix socket path deleted after tarantool is finished
+test_run:cmd("setopt delimiter ';'")
+ | ---
+ | - true
+ | ...
+for i = 1, 2 do
+    local thread_count = i
+    test_run:cmd(string.format("start server test with args=\"%s\"", thread_count))
+    server_addr = test_run:eval('test', 'return box.cfg.listen')[1]
+    test_run:cmd("stop server test")
+    assert(fio.path.exists(server_addr) == false)
+end
+test_run:cmd("setopt delimiter ''");
+ | ---
+ | ...
+
+-- Check, that all sockets are closed correctly,
+-- when the listening address is changed.
+test_run:cmd("start server test with args=2")
+ | ---
+ | - true
+ | ...
+server_addr_before = test_run:eval('test', 'return box.cfg.listen')[1]
+ | ---
+ | ...
+test_run:eval('test', string.format("box.cfg{ listen = \'%s\' }", server_addr_before .. "X"))
+ | ---
+ | - []
+ | ...
+server_addr_after = test_run:eval('test', 'return box.cfg.listen')[1]
+ | ---
+ | ...
+assert(server_addr_after == server_addr_before .. "X")
+ | ---
+ | - true
+ | ...
+assert(test_run:grep_log("test", "Bad file descriptor") == nil)
+ | ---
+ | - true
+ | ...
+assert(test_run:grep_log("test", "No such file or directory") == nil)
+ | ---
+ | - true
+ | ...
+test_run:eval('test', string.format("box.cfg { listen = \'%s\' }", server_addr_before))
+ | ---
+ | - []
+ | ...
+server_addr_result = test_run:eval('test', 'return box.cfg.listen')[1]
+ | ---
+ | ...
+assert(server_addr_result == server_addr_before)
+ | ---
+ | - true
+ | ...
+test_run:cmd("stop server test")
+ | ---
+ | - true
+ | ...
+assert(not fio.path.exists(server_addr_before))
+ | ---
+ | - true
+ | ...
+assert(not fio.path.exists(server_addr_after))
+ | ---
+ | - true
+ | ...
+
+test_run:cmd("cleanup server test")
+ | ---
+ | - true
+ | ...
+test_run:cmd("delete server test")
+ | ---
+ | - true
+ | ...

--- a/test/box/box-cfg-unix-socket-del.test.lua
+++ b/test/box/box-cfg-unix-socket-del.test.lua
@@ -1,0 +1,34 @@
+env = require('test_run')
+fio = require('fio')
+test_run = env.new()
+test_run:cmd("create server test with script='box/box-cfg-unix-socket-del.lua'")
+
+-- Check that unix socket path deleted after tarantool is finished
+test_run:cmd("setopt delimiter ';'")
+for i = 1, 2 do
+    local thread_count = i
+    test_run:cmd(string.format("start server test with args=\"%s\"", thread_count))
+    server_addr = test_run:eval('test', 'return box.cfg.listen')[1]
+    test_run:cmd("stop server test")
+    assert(fio.path.exists(server_addr) == false)
+end
+test_run:cmd("setopt delimiter ''");
+
+-- Check, that all sockets are closed correctly,
+-- when the listening address is changed.
+test_run:cmd("start server test with args=2")
+server_addr_before = test_run:eval('test', 'return box.cfg.listen')[1]
+test_run:eval('test', string.format("box.cfg{ listen = \'%s\' }", server_addr_before .. "X"))
+server_addr_after = test_run:eval('test', 'return box.cfg.listen')[1]
+assert(server_addr_after == server_addr_before .. "X")
+assert(test_run:grep_log("test", "Bad file descriptor") == nil)
+assert(test_run:grep_log("test", "No such file or directory") == nil)
+test_run:eval('test', string.format("box.cfg { listen = \'%s\' }", server_addr_before))
+server_addr_result = test_run:eval('test', 'return box.cfg.listen')[1]
+assert(server_addr_result == server_addr_before)
+test_run:cmd("stop server test")
+assert(not fio.path.exists(server_addr_before))
+assert(not fio.path.exists(server_addr_after))
+
+test_run:cmd("cleanup server test")
+test_run:cmd("delete server test")

--- a/test/box/gh-5645-several-iproto-threads.lua
+++ b/test/box/gh-5645-several-iproto-threads.lua
@@ -13,7 +13,7 @@ box.cfg({
     wal_mode = 'none'
 })
 
-box.schema.user.grant('guest', 'read,write,execute,create,drop', 'universe')
+box.schema.user.grant('guest', 'read,write,execute,create,drop', 'universe', nil, {if_not_exists = true})
 function errinj_set(thread_id)
     if thread_id ~= nil then
         box.error.injection.set("ERRINJ_IPROTO_SINGLE_THREAD_STAT", thread_id)

--- a/test/box/gh-5645-several-iproto-threads.lua
+++ b/test/box/gh-5645-several-iproto-threads.lua
@@ -2,10 +2,15 @@
 
 require('console').listen(os.getenv('ADMIN'))
 
+local iproto_threads = arg[1]
+if iproto_threads == "negative" then
+	iproto_threads = -1
+end
+
 box.cfg({
     listen = os.getenv('LISTEN'),
-    iproto_threads = tonumber(arg[1]),
-    wal_mode='none'
+    iproto_threads = tonumber(iproto_threads),
+    wal_mode = 'none'
 })
 
 box.schema.user.grant('guest', 'read,write,execute,create,drop', 'universe')

--- a/test/box/gh-5645-several-iproto-threads.result
+++ b/test/box/gh-5645-several-iproto-threads.result
@@ -81,9 +81,41 @@ test_run:cmd("setopt delimiter ''");
  | ---
  | ...
 
+-- Check that we can't start server with iproto threads count <= 0 or > 1000
+-- We can't pass '-1' or another negative number as argument, so we pass string
+opts = {}
+ | ---
+ | ...
+opts.filename = 'gh-5645-several-iproto-threads.log'
+ | ---
+ | ...
+test_run:cmd("start server test with args='negative' with crash_expected=True")
+ | ---
+ | - false
+ | ...
+assert(test_run:grep_log("test", "Incorrect value for option 'iproto_threads'", nil, opts) ~= nil)
+ | ---
+ | - true
+ | ...
+test_run:cmd("start server test with args='0' with crash_expected=True")
+ | ---
+ | - false
+ | ...
+assert(test_run:grep_log("test", "Incorrect value for option 'iproto_threads'", nil, opts) ~= nil)
+ | ---
+ | - true
+ | ...
+test_run:cmd("start server test with args='1001' with crash_expected=True")
+ | ---
+ | - false
+ | ...
+assert(test_run:grep_log("test", "Incorrect value for option 'iproto_threads'", nil, opts) ~= nil)
+ | ---
+ | - true
+ | ...
+
 -- We check that statistics gathered per each thread in sum is equal to
 -- statistics gathered from all threads.
---
 thread_count = 2
  | ---
  | ...

--- a/test/box/gh-5645-several-iproto-threads.test.lua
+++ b/test/box/gh-5645-several-iproto-threads.test.lua
@@ -62,9 +62,19 @@ function get_network_stat()
 end
 test_run:cmd("setopt delimiter ''");
 
+-- Check that we can't start server with iproto threads count <= 0 or > 1000
+-- We can't pass '-1' or another negative number as argument, so we pass string
+opts = {}
+opts.filename = 'gh-5645-several-iproto-threads.log'
+test_run:cmd("start server test with args='negative' with crash_expected=True")
+assert(test_run:grep_log("test", "Incorrect value for option 'iproto_threads'", nil, opts) ~= nil)
+test_run:cmd("start server test with args='0' with crash_expected=True")
+assert(test_run:grep_log("test", "Incorrect value for option 'iproto_threads'", nil, opts) ~= nil)
+test_run:cmd("start server test with args='1001' with crash_expected=True")
+assert(test_run:grep_log("test", "Incorrect value for option 'iproto_threads'", nil, opts) ~= nil)
+
 -- We check that statistics gathered per each thread in sum is equal to
 -- statistics gathered from all threads.
---
 thread_count = 2
 fibers_count = 100
 test_run:cmd(string.format("start server test with args=\"%s\"", thread_count))

--- a/test/box/net.box_reconnect_after_gh-3164.result
+++ b/test/box/net.box_reconnect_after_gh-3164.result
@@ -70,9 +70,6 @@ test_run:cmd('cleanup server connecter')
 - true
 ...
 -- Check the connection tries to reconnect at least two times.
--- 'Cannot assign requested address' is the crutch for running the
--- tests in a docker. This error emits instead of
--- 'Connection refused' inside a docker.
 old_log_level = box.cfg.log_level
 ---
 ...
@@ -86,9 +83,8 @@ test_run:cmd("setopt delimiter ';'")
 ---
 - true
 ...
-while test_run:grep_log('default', 'Network is unreachable', 1000) == nil and
-      test_run:grep_log('default', 'Connection refused', 1000) == nil and
-      test_run:grep_log('default', 'Cannot assign requested address', 1000) == nil do
+while test_run:grep_log('default', 'unix/', 1000) == nil and
+      test_run:grep_log('default', 'No such file or directory', 1000) == nil do
        fiber.sleep(0.1)
 end;
 ---
@@ -96,9 +92,8 @@ end;
 log.info(string.rep('a', 1000));
 ---
 ...
-while test_run:grep_log('default', 'Network is unreachable', 1000) == nil and
-      test_run:grep_log('default', 'Connection refused', 1000) == nil and
-      test_run:grep_log('default', 'Cannot assign requested address', 1000) == nil do
+while test_run:grep_log('default', 'unix/', 1000) == nil and
+      test_run:grep_log('default', 'No such file or directory', 1000) == nil do
        fiber.sleep(0.1)
 end;
 ---

--- a/test/box/net.box_reconnect_after_gh-3164.test.lua
+++ b/test/box/net.box_reconnect_after_gh-3164.test.lua
@@ -26,22 +26,17 @@ weak.c:ping()
 test_run:cmd('stop server connecter')
 test_run:cmd('cleanup server connecter')
 -- Check the connection tries to reconnect at least two times.
--- 'Cannot assign requested address' is the crutch for running the
--- tests in a docker. This error emits instead of
--- 'Connection refused' inside a docker.
 old_log_level = box.cfg.log_level
 box.cfg{log_level = 6}
 log.info(string.rep('a', 1000))
 test_run:cmd("setopt delimiter ';'")
-while test_run:grep_log('default', 'Network is unreachable', 1000) == nil and
-      test_run:grep_log('default', 'Connection refused', 1000) == nil and
-      test_run:grep_log('default', 'Cannot assign requested address', 1000) == nil do
+while test_run:grep_log('default', 'unix/', 1000) == nil and
+      test_run:grep_log('default', 'No such file or directory', 1000) == nil do
        fiber.sleep(0.1)
 end;
 log.info(string.rep('a', 1000));
-while test_run:grep_log('default', 'Network is unreachable', 1000) == nil and
-      test_run:grep_log('default', 'Connection refused', 1000) == nil and
-      test_run:grep_log('default', 'Cannot assign requested address', 1000) == nil do
+while test_run:grep_log('default', 'unix/', 1000) == nil and
+      test_run:grep_log('default', 'No such file or directory', 1000) == nil do
        fiber.sleep(0.1)
 end;
 test_run:cmd("setopt delimiter ''");


### PR DESCRIPTION
At the moment, user can set any number of iproto threads, which leads
to incorrect behavior if the specified number of threads is less than
or equal to zero or too large. Add check for user input of the number
of iproto threads, value must be > 0 and less then or equal to 1000.

Follow-up #5645