### PR TITLE
sql: VARBINARY result for user-defined C functions

### DIFF
--- a/changelogs/unreleased/fix-error-on-return-bin-from-funcs.md
+++ b/changelogs/unreleased/fix-error-on-return-bin-from-funcs.md
@@ -1,0 +1,3 @@
+## bugfix/sql
+
+* User-defined functions can now return VARBINARY to SQL as result (gh-6024).

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -3047,6 +3047,17 @@ port_c_get_vdbemem(struct port *base, uint32_t *size)
 			if (mem_copy_str(&val[i], str, len) != 0)
 				goto error;
 			break;
+		case MP_BIN:
+			str = mp_decode_bin(&data, &len);
+			if (mem_copy_bin(&val[i], str, len) != 0)
+				goto error;
+			break;
+		case MP_EXT:
+			str = data;
+			mp_next(&data);
+			if (mem_copy_bin(&val[i], str, data - str) != 0)
+				goto error;
+			break;
 		case MP_NIL:
 			break;
 		default:

--- a/test/sql-tap/CMakeLists.txt
+++ b/test/sql-tap/CMakeLists.txt
@@ -1,2 +1,3 @@
 include_directories(${MSGPUCK_INCLUDE_DIRS})
 build_module(gh-5938-wrong-string-length gh-5938-wrong-string-length.c)
+build_module(gh-6024-funcs-return-bin gh-6024-funcs-return-bin.c)

--- a/test/sql-tap/gh-6024-funcs-return-bin.c
+++ b/test/sql-tap/gh-6024-funcs-return-bin.c
@@ -1,0 +1,46 @@
+#include "msgpuck.h"
+#include "module.h"
+#include "uuid/mp_uuid.h"
+#include "mp_decimal.h"
+
+enum {
+	BUF_SIZE = 512,
+};
+
+int
+ret_bin(box_function_ctx_t *ctx, const char *args, const char *args_end)
+{
+	(void)args;
+	(void)args_end;
+	const char bin[] = "some varbinary string";
+	char res[BUF_SIZE];
+	char *end = mp_encode_bin(res, bin, sizeof(bin));
+	box_return_mp(ctx, res, end);
+	return 0;
+}
+
+int
+ret_uuid(box_function_ctx_t *ctx, const char *args, const char *args_end)
+{
+	(void)args;
+	(void)args_end;
+	struct tt_uuid uuid;
+	memset(&uuid, 0x11, sizeof(uuid));
+	char res[BUF_SIZE];
+	char *end = mp_encode_uuid(res, &uuid);
+	box_return_mp(ctx, res, end);
+	return 0;
+}
+
+int
+ret_decimal(box_function_ctx_t *ctx, const char *args, const char *args_end)
+{
+	(void)args;
+	(void)args_end;
+	decimal_t dec;
+	decimal_from_string(&dec, "9999999999999999999.9999999999999999999");
+	char res[BUF_SIZE];
+	char *end = mp_encode_decimal(res, &dec);
+	box_return_mp(ctx, res, end);
+	return 0;
+}

--- a/test/sql-tap/gh-6024-funcs-return-bin.test.lua
+++ b/test/sql-tap/gh-6024-funcs-return-bin.test.lua
@@ -1,0 +1,57 @@
+#!/usr/bin/env tarantool
+local build_path = os.getenv("BUILDDIR")
+package.cpath = build_path..'/test/sql-tap/?.so;'..build_path..'/test/sql-tap/?.dylib;'..package.cpath
+
+local test = require("sqltester")
+test:plan(3)
+
+box.schema.func.create("gh-6024-funcs-return-bin.ret_bin", {
+    language = "C",
+    param_list = {},
+    returns = "varbinary",
+    exports = {"SQL"},
+})
+
+test:do_execsql_test(
+    "gh-6024-1",
+    [[
+        SELECT typeof("gh-6024-funcs-return-bin.ret_bin"());
+    ]], {
+        "varbinary"
+    })
+
+box.schema.func.create("gh-6024-funcs-return-bin.ret_uuid", {
+    language = "C",
+    param_list = {},
+    returns = "varbinary",
+    exports = {"SQL"},
+})
+
+test:do_execsql_test(
+    "gh-6024-2",
+    [[
+        SELECT typeof("gh-6024-funcs-return-bin.ret_uuid"());
+    ]], {
+        "varbinary"
+    })
+
+box.schema.func.create("gh-6024-funcs-return-bin.ret_decimal", {
+    language = "C",
+    param_list = {},
+    returns = "varbinary",
+    exports = {"SQL"},
+})
+
+test:do_execsql_test(
+    "gh-6024-3",
+    [[
+        SELECT typeof("gh-6024-funcs-return-bin.ret_decimal"());
+    ]], {
+        "varbinary"
+    })
+
+box.schema.func.drop("gh-6024-funcs-return-bin.ret_bin")
+box.schema.func.drop("gh-6024-funcs-return-bin.ret_uuid")
+box.schema.func.drop("gh-6024-funcs-return-bin.ret_decimal")
+
+test:finish_test()

--- a/test/sql-tap/gh-6024-funcs-return-bin.test.lua
+++ b/test/sql-tap/gh-6024-funcs-return-bin.test.lua
@@ -3,7 +3,7 @@ local build_path = os.getenv("BUILDDIR")
 package.cpath = build_path..'/test/sql-tap/?.so;'..build_path..'/test/sql-tap/?.dylib;'..package.cpath
 
 local test = require("sqltester")
-test:plan(3)
+test:plan(5)
 
 box.schema.func.create("gh-6024-funcs-return-bin.ret_bin", {
     language = "C",
@@ -50,8 +50,42 @@ test:do_execsql_test(
         "varbinary"
     })
 
+box.schema.func.create("get_uuid", {
+    language = "LUA",
+    param_list = {},
+    returns = "varbinary",
+    body = "function(x) return require('uuid').fromstr('11111111-1111-1111-1111-111111111111') end",
+    exports = {"SQL"},
+})
+
+test:do_execsql_test(
+    "gh-6024-4",
+    [[
+        SELECT typeof("get_uuid"()), "get_uuid"() == "gh-6024-funcs-return-bin.ret_uuid"();
+    ]], {
+        "varbinary", true
+    })
+
+box.schema.func.create("get_decimal", {
+    language = "LUA",
+    param_list = {},
+    returns = "varbinary",
+    body = "function(x) return require('decimal').new('9999999999999999999.9999999999999999999') end",
+    exports = {"SQL"},
+})
+
+test:do_execsql_test(
+    "gh-6024-5",
+    [[
+        SELECT typeof("get_decimal"()), "get_decimal"() == "gh-6024-funcs-return-bin.ret_decimal"();
+    ]], {
+        "varbinary", true
+    })
+
 box.schema.func.drop("gh-6024-funcs-return-bin.ret_bin")
 box.schema.func.drop("gh-6024-funcs-return-bin.ret_uuid")
 box.schema.func.drop("gh-6024-funcs-return-bin.ret_decimal")
+box.schema.func.drop("get_uuid")
+box.schema.func.drop("get_decimal")
 
 test:finish_test()


### PR DESCRIPTION
This patch-set allows VARBINARY to be returned for user-defined functions. For user-defined LUA functions there is no values that can be interpreted as VARBINARY by serializer, so the only way to return VARBINARY is to return a DECIMAL or UUID, since both types are not supported by SQL and treated as VARBINARY.

Closes #6024