### PR TITLE
build: fix coro build for Apple ARM M1

### DIFF
--- a/third_party/coro/coro.c
+++ b/third_party/coro/coro.c
@@ -297,9 +297,14 @@ trampoline (int sig)
 
 #if CORO_STARTUP
   asm (
+# ifndef __APPLE__
          "\t.globl coro_startup\n"
          "\t.type coro_startup, %function\n"
          "coro_startup:\n"
+# else
+         "\t.globl _coro_startup\n"
+         "_coro_startup:\n"
+# endif
 
        #if __ARM_ARCH==7
 	 ".syntax unified\n"
@@ -324,7 +329,11 @@ trampoline (int sig)
          ".cfi_offset 30, -16\n"
          "\tmov x0, x20\n"
          "\tblr x19\n"
+# ifdef __APPLE__
+         "\tb _abort\n"
+# else
          "\tb abort\n"
+# endif
          ".cfi_endproc\n"
 
        #else


### PR DESCRIPTION
There are a few issues concerning build of coro on Mac M1.

Firstly, Mach-O assembler does not support .type directive. So let's put
it under ifndef __APPLE__ preprocessing guard.

Secondly, for some reason linker fails to resolve unmangled symbols
referenced in inlined assembly:
Undefined symbols for architecture arm64:
  "_coro_startup", referenced from:
      _coro_create in libcoro.a(coro.c.o)

The same concerns "abort" function call. I suspect that clang by default
mangle each function's name with "_" (in GCC this option can be turned
on/off by -f[no]leading-underscore). So to call function from assembly
inline we have to specify exact name (i.e. mangled). However, in case of
user-defined function, we can force function name placing asm() after
its declaration. Still have to patch abort name.

Part of #5983