### PR TITLE
tuple: fix crash in reversed nullable json update

### DIFF
--- a/changelogs/unreleased/gh-6069-json-update-crash.md
+++ b/changelogs/unreleased/gh-6069-json-update-crash.md
@@ -1,0 +1,6 @@
+## bugfix/core
+
+* Fixed a crash in JSON update on tuple/space when it had more than one
+  operation, they accessed fields in reversed order, and these fields didn't
+  exist. Example: `box.tuple.new({1}):update({{'=', 4, 4}, {'=', 3, 3}})`
+  (gh-6069).

--- a/src/box/xrow_update_array.c
+++ b/src/box/xrow_update_array.c
@@ -342,8 +342,8 @@ xrow_update_array_append_nils(struct xrow_update_field *field,
 		return -1;
 	}
 	memset(item_data, 0xc0, nil_count);
-	xrow_update_array_item_create(item, XUPDATE_NOP, item_data,
-				      nil_count, 0);
+	xrow_update_array_item_create(item, XUPDATE_NOP, item_data, 1,
+				      nil_count - 1);
 	return xrow_update_rope_insert(rope, op->field_no, item, nil_count);
 }
 

--- a/test/box/update.result
+++ b/test/box/update.result
@@ -2128,3 +2128,11 @@ s:update({1}, {{'+', 'field3[1].key1.key2[2]', dbl1}})
 s:drop()
 ---
 ...
+--
+-- gh-6069: update of an absent field could crash when had 2 operations in
+-- reversed order both on not specified fields.
+--
+box.tuple.new({1}):update({{'=', 4, 4}, {'=', 3, 3}})
+---
+- [1, null, 3, 4]
+...

--- a/test/box/update.test.lua
+++ b/test/box/update.test.lua
@@ -777,3 +777,9 @@ _ = s:replace{1, dbl1, {{key1 = {key2 = {1, dbl1}}}}}
 s:update({1}, {{'+', 'field3[1].key1.key2[2]', dbl1}})
 
 s:drop()
+
+--
+-- gh-6069: update of an absent field could crash when had 2 operations in
+-- reversed order both on not specified fields.
+--
+box.tuple.new({1}):update({{'=', 4, 4}, {'=', 3, 3}})


### PR DESCRIPTION
Update of an absent field could crash when had 2 operations in
reversed order both on not specified fields.

The problem was that the rope item was created incorrectly.

Rope item is a range of array fields and consists of 2 parts:
xrow_update_field and a tail. The xrow field should describe
exactly one array field (first in the given range) and its update
operation. When no operation, it is NOP.

The tail includes the rest of the array fields not affected by
any operations yet.

But in the code it was so the rope item was created with its xrow
field covering multiple array fields, and with zero tail. As a
result, split of that item didn't work because it can't split an
xrow field.

The bug was in the nil-autofill for absent array fields. The patch
fixes it so the newly created item with nils has its xrow field
containing one nil, and the other nils in the tail. This allows to
split the item correctly if necessary.

Closes #6069