### PR TITLE
NOT TO MERGE ! JUST CHECK THE PR

### DIFF
--- a/.github/workflows/debug_coverage.yml
+++ b/.github/workflows/debug_coverage.yml
@@ -15,7 +15,7 @@ jobs:
     # We want to run on external PRs, but not on our own internal PRs
     # as they'll be run by the push to the branch.
     if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        github.event_name == 'pull_request') &&
         ! endsWith(github.ref, '-notest')
 
     runs-on: ubuntu-20.04
@@ -30,25 +30,61 @@ jobs:
         shell: bash
         run: |
           sudo chown -R $(id -u):$(id -g) .
-      - uses: actions/checkout@v2.3.4
+      # Finds an associated PR (PR can be detected only on push and never on pull_request).
+      # WARNING !!! use in these ways only:
+      #   on push: steps.findPr.outputs.pr
+      #   on pull_request: github.event.pull_request.number
+      - name: Find the PR associated with this push on push trigger, if there is one.
+        uses: jwalton/gh-find-current-pr@v1
+        id: findPr
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      # Run always but once - w/o PR on push otherwise on pull_request.
+      # To avoid of issue https://github.com/coverallsapp/github-action/issues/55
+      # sources checkout should be based on 2nd action version and later.
+      - name: Sources checkout
+        if: ( steps.findPr.outputs.pr == false && github.event_name == 'push' ) ||
+            github.event_name == 'pull_request'
+        uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0
           submodules: recursive
-      - uses: ./.github/actions/environment
+      # Run always but once - w/o PR on push otherwise on pull_request.
+      - name: Set environment
+        if: ( steps.findPr.outputs.pr == false && github.event_name == 'push' ) ||
+            github.event_name == 'pull_request'
+        uses: ./.github/actions/environment
+      # Run always but once - w/o PR on push otherwise on pull_request.
       - name: test
+        if: ( steps.findPr.outputs.pr == false && github.event_name == 'push' ) ||
+            github.event_name == 'pull_request'
         run: ${CI_MAKE} coverage_ubuntu_ghactions
-        env:
-          COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+      # Run always but once - w/o PR on push otherwise on pull_request.
+      - name: Upload coverage.info results to coveralls.io
+        if: success() &&
+            ( ( steps.findPr.outputs.pr == false && github.event_name == 'push' ) ||
+            github.event_name == 'pull_request' )
+        uses: coverallsapp/github-action@v1.1.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./coverage.info
+      # Run on failure only.
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
           TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
         uses: ./.github/actions/send-telegram-notify
         if: failure()
+      # Run always but once - w/o PR on push otherwise on pull_request
+      # for failed tests either Coveralls results.
       - name: artifacts
         uses: actions/upload-artifact@v2
-        if: failure()
+        if: always() &&
+            ( ( steps.findPr.outputs.pr == false && github.event_name == 'push' ) ||
+            github.event_name == 'pull_request' )
         with:
           name: debug
           retention-days: 21
-          path: test/var/artifacts
+          path: |
+            test/var/artifacts
+            *.info

--- a/.travis.mk
+++ b/.travis.mk
@@ -54,7 +54,6 @@ docker_%:
 		--workdir /tarantool \
 		-e XDG_CACHE_HOME=/cache \
 		-e CCACHE_DIR=/cache/ccache \
-		-e COVERALLS_TOKEN=${COVERALLS_TOKEN} \
 		-e TRAVIS_JOB_ID=${TRAVIS_JOB_ID} \
 		-e CMAKE_EXTRA_PARAMS=${CMAKE_EXTRA_PARAMS} \
 		-e APT_EXTRA_FLAGS="${APT_EXTRA_FLAGS}" \
@@ -177,14 +176,6 @@ test_coverage_debian_no_deps: build_coverage_debian
 	lcov --compat-libtool --remove coverage.info.tmp 'tests/*' 'third_party/*' '/usr/*' \
 		--rc lcov_branch_coverage=1 --rc lcov_function_coverage=1 --output-file coverage.info
 	lcov --list coverage.info
-	# coveralls API: https://docs.coveralls.io/api-reference
-	@if [ -n "$(COVERALLS_TOKEN)" ]; then \
-		echo "Exporting code coverage information to coveralls.io"; \
-		echo coveralls-lcov --service-name github-ci --service-job-id $(GITHUB_RUN_ID) \
-			--repo-token [FILTERED] coverage.info; \
-		coveralls-lcov --service-name github-ci --service-job-id $(GITHUB_RUN_ID) \
-			--repo-token $(COVERALLS_TOKEN) coverage.info; \
-	fi;
 
 coverage_debian: deps_debian test_coverage_debian_no_deps
 


### PR DESCRIPTION
Workflow 'debug_coverage' produces and uploads results to 'coveralls.io'
web site. Message about it can be shown in PR within each run was done.
This patch adds the ability to send message in available PR otherwise it
is skipped. Also added 'coverage.info' file to artifacts list.

Found that used 'coverallsapp/github-action' action checks if the
trigger was 'pull_request' used to run the workflow [1]. And only in
this way it writes results message to PR. Previously 'pull_request'
trigger was blocked to avoid duplication with 'push' trigger. To make
able to run workflow by any single trigger and to send message to PR
if it exits, it was implemented the following logic:

  - run workflows on both triggers 'push' and 'pull_request';
  - for workflow with 'push' trigger check if PR exists then skip all
    jobs otherwise continue running;
  - for workflow with 'pull_request' trigger continue running;

To avoid of issue coverallsapp/github-action#55 [2], sources checkout
should be based on 2nd version and later.

Closes #5644

[1]: https://github.com/coverallsapp/github-action/blob/master/src/run.ts#L38
[2]: https://github.com/coverallsapp/github-action/issues/55#issuecomment-644927165