### PR TITLE
fiber: add fiber_object:csw() and fiber_object:info() functions

### DIFF
--- a/changelogs/unreleased/gh-5799-add-info-to-fiber-object.md
+++ b/changelogs/unreleased/gh-5799-add-info-to-fiber-object.md
@@ -1,0 +1,4 @@
+## feature/lua/fiber
+
+* Introduce `fiber_object:info()` to get `info` from fiber. Works as `require(fiber).info()` but only for one fiber.
+* Introduce `fiber_object:csw()` to get `csw` from fiber (gh-5799).

--- a/changelogs/unreleased/gh-5799-set-csw-is-0-for-new-fibers.md
+++ b/changelogs/unreleased/gh-5799-set-csw-is-0-for-new-fibers.md
@@ -1,0 +1,3 @@
+## feature/fiber
+
+* Previously csw (Context SWitch) of new fiber can be more than 0, now it is always 0 (gh-5799).

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -1260,6 +1260,7 @@ fiber_new_ex(const char *name, const struct fiber_attr *fiber_attr,
 	fiber->fid = cord->next_fid;
 	fiber_set_name(fiber, name);
 	register_fid(fiber);
+	fiber->csw = 0;
 
 	cord->next_fid++;
 	assert(cord->next_fid > FIBER_ID_MAX_RESERVED);

--- a/test/app/gh-5799-fiber-info.result
+++ b/test/app/gh-5799-fiber-info.result
@@ -26,11 +26,9 @@ test_run:cmd('setopt delimiter ";"')
  | ...
 for i=1,100 do
     fibers[i] = fiber.new(function()
-        local start_csw = fiber.info()[fiber.self():id()].csw
         for j=1,10 do
             fiber.yield()
-            if j + start_csw == fiber.self():csw() and
-               j + start_csw == fiber.self():info().csw then
+            if j == fiber.self():csw() and j == fiber.self():info().csw then
                 csw_check_counter = csw_check_counter + 1
             end
         end

--- a/test/app/gh-5799-fiber-info.result
+++ b/test/app/gh-5799-fiber-info.result
@@ -1,0 +1,80 @@
+-- test-run result file version 2
+test_run = require('test_run').new()
+ | ---
+ | ...
+fiber = require('fiber')
+ | ---
+ | ...
+json = require('json')
+ | ---
+ | ...
+
+function yielder(n) for i=1, n do fiber.yield() end end
+ | ---
+ | ...
+
+csw_check_counter = 0
+ | ---
+ | ...
+fibers = {}
+ | ---
+ | ...
+
+test_run:cmd('setopt delimiter ";"')
+ | ---
+ | - true
+ | ...
+for i=1,100 do
+    fibers[i] = fiber.new(function()
+        local start_csw = fiber.info()[fiber.self():id()].csw
+        for j=1,10 do
+            fiber.yield()
+            if j + start_csw == fiber.self():csw() and
+               j + start_csw == fiber.self():info().csw then
+                csw_check_counter = csw_check_counter + 1
+            end
+        end
+    end)
+    fibers[i]:set_joinable(true)
+end;
+ | ---
+ | ...
+for i=1,100 do
+    fibers[i]:join()
+end;
+ | ---
+ | ...
+test_run:cmd('setopt delimiter ""');
+ | ---
+ | - true
+ | ...
+csw_check_counter
+ | ---
+ | - 1000
+ | ...
+
+cond = fiber.cond()
+ | ---
+ | ...
+running = fiber.create(function() cond:wait() end)
+ | ---
+ | ...
+json.encode(running:info()) == json.encode(fiber.info()[running:id()])
+ | ---
+ | - true
+ | ...
+cond:signal()
+ | ---
+ | ...
+dead = fiber.create(function() end)
+ | ---
+ | ...
+
+dead:csw()
+ | ---
+ | - error: the fiber is dead
+ | ...
+dead:info()
+ | ---
+ | - error: the fiber is dead
+ | ...

--- a/test/app/gh-5799-fiber-info.test.lua
+++ b/test/app/gh-5799-fiber-info.test.lua
@@ -1,0 +1,37 @@
+test_run = require('test_run').new()
+fiber = require('fiber')
+json = require('json')
+
+function yielder(n) for i=1, n do fiber.yield() end end
+
+csw_check_counter = 0
+fibers = {}
+
+test_run:cmd('setopt delimiter ";"')
+for i=1,100 do
+    fibers[i] = fiber.new(function()
+        local start_csw = fiber.info()[fiber.self():id()].csw
+        for j=1,10 do
+            fiber.yield()
+            if j + start_csw == fiber.self():csw() and
+               j + start_csw == fiber.self():info().csw then
+                csw_check_counter = csw_check_counter + 1
+            end
+        end
+    end)
+    fibers[i]:set_joinable(true)
+end;
+for i=1,100 do
+    fibers[i]:join()
+end;
+test_run:cmd('setopt delimiter ""');
+csw_check_counter
+
+cond = fiber.cond()
+running = fiber.create(function() cond:wait() end)
+json.encode(running:info()) == json.encode(fiber.info()[running:id()])
+cond:signal()
+dead = fiber.create(function() end)
+
+dead:csw()
+dead:info()

--- a/test/app/gh-5799-fiber-info.test.lua
+++ b/test/app/gh-5799-fiber-info.test.lua
@@ -10,11 +10,9 @@ fibers = {}
 test_run:cmd('setopt delimiter ";"')
 for i=1,100 do
     fibers[i] = fiber.new(function()
-        local start_csw = fiber.info()[fiber.self():id()].csw
         for j=1,10 do
             fiber.yield()
-            if j + start_csw == fiber.self():csw() and
-               j + start_csw == fiber.self():info().csw then
+            if j == fiber.self():csw() and j == fiber.self():info().csw then
                 csw_check_counter = csw_check_counter + 1
             end
         end


### PR DESCRIPTION
Add `fiber_object:csw()` function to get `csw` from both alive or dead fiber.
Add `fiber_object:info()` function to get `info` from alive fiber.