### PR TITLE
test: fix flaky tests for -e and iteractive mode

### DIFF
--- a/test/app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua
+++ b/test/app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua
@@ -13,7 +13,7 @@ local ffi = require('ffi')
 --
 
 local TARANTOOL_PATH = arg[-1]
-local output_file = fio.abspath('out.txt')
+local output_file = fio.abspath('gh-4983_out.txt')
 local line = ('%s -e "assert(false)" > %s 2>&1 & echo $!'):
         format(TARANTOOL_PATH, output_file)
 
@@ -45,6 +45,7 @@ local res = tap.test('gh-4983-tnt-e-assert-false-hangs', function(test)
     test:like(data, 'assertion failed', 'assertion failure is displayed')
 
     fh:close()
+    os.remove(output_file)
 end)
 
 os.exit(res and 0 or 1)

--- a/test/app-tap/gh-5040-inter-mode-isatty-via-errinj.test.lua
+++ b/test/app-tap/gh-5040-inter-mode-isatty-via-errinj.test.lua
@@ -12,7 +12,7 @@ local fio = require('fio')
 --
 
 local TARANTOOL_PATH = arg[-1]
-local output_file = fio.abspath('out.txt')
+local output_file = fio.abspath('gh-5040_out.txt')
 local cmd_end = (' >%s & echo $!'):format(output_file)
 
 -- Like a default timeout for `cond_wait` in test-run


### PR DESCRIPTION
Occasionally, test/app-tap/gh-5040-inter-mode-isatty-via-errinj.test.lua
failed because it used output file with the same name as
test/app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua and the last one
didn't remove file after usage.

Added removal of output file to test for 4983 and also changed file names
to distinguish outputs of these tests better in case of failure.

Fixes tarantool/tarantool-qa#122