### PR TITLE
tools: fix script to run jepsen tests

### DIFF
--- a/tools/run-jepsen-tests.sh
+++ b/tools/run-jepsen-tests.sh
@@ -71,6 +71,7 @@ BUILD_DIR="$PROJECT_SOURCE_DIR/build"
 TESTS_DIR="$PROJECT_BINARY_DIR/jepsen-tests-prefix/src/jepsen-tests/"
 TERRAFORM_CONFIG="$PROJECT_SOURCE_DIR/extra/tf"
 TERRAFORM_STATE="$PROJECT_BINARY_DIR/terraform.tfstate"
+CUR_DIR=$(pwd)
 SSH_KEY_FILENAME="$HOME/.ssh/id_rsa"
 NODES_FILENAME="$BUILD_DIR/nodes"
 
@@ -83,6 +84,7 @@ CI_COMMIT_SHA=$(git rev-parse HEAD)
 # setup cleanup routine, which removes testing nodes by Terraform
 function cleanup {
     echo "Cleanup running ..."
+    cd $CUR_DIR
     rm -f $NODES_FILENAME $SSH_KEY_FILENAME
     [[ -e $TERRAFORM_STATE ]] && \
 	terraform destroy -state=$TERRAFORM_STATE -auto-approve $TERRAFORM_CONFIG


### PR DESCRIPTION
Script used to run Jepsen tests uses Terraform to prepare test environment.
When I made this script I had a wrong assumption about working directory
used by Terraform. Due to this sometimes job with Jepsen tests
failed on cleanup with message:

```
Error: Could not load plugin

Plugin reinitialization required. Please run "terraform init".

Plugins are external binaries that Terraform uses to access and manipulate
resources. The configuration provided requires plugins which can't be located,
don't satisfy the version constraints, or are otherwise incompatible.

Terraform automatically discovers provider requirements from your
configuration, including providers used in child modules. To see the
requirements and constraints, run "terraform providers".

Failed to instantiate provider
"registry.terraform.io/terraform-providers/openstack" to obtain schema:
unknown provider "registry.terraform.io/terraform-providers/openstack"
```

Terraform documentation describes how Terraform uses working directories [1]
and there are at least to ways to resolve an issue. First one is using always
one directory before running terraform subcommands. Second one is using option
`-chdir` in all terraform commands [2].

1. https://www.terraform.io/docs/cli/init/index.html
2. https://www.terraform.io/docs/cli/commands/index.html#switching-working-directory-with-chdir

Closes #6089