### PR TITLE
fiber: hide backtraces of idle fibers from fiber.info

### DIFF
--- a/changelogs/unreleased/gh-4235-dont-show-idle-in-fiber-info.md
+++ b/changelogs/unreleased/gh-4235-dont-show-idle-in-fiber-info.md
@@ -1,0 +1,3 @@
+## feature/lua/fiber
+
+ * Changed `fiber.info()` to hide backtraces of idle fibers (gh-4235).

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -166,6 +166,11 @@ enum {
 	 * The flag is set for the fiber currently being executed by the cord.
 	 */
 	FIBER_IS_RUNNING	= 1 << 6,
+	/**
+	 * This flag is set when fiber is in the idle list
+	 * of fiber_pool.
+	 */
+	FIBER_IS_IDLE		= 1 << 7,
 	FIBER_DEFAULT_FLAGS = FIBER_IS_CANCELLABLE
 };
 

--- a/src/lib/core/fiber_pool.c
+++ b/src/lib/core/fiber_pool.c
@@ -82,8 +82,11 @@ restart:
 		 * Add the fiber to the front of the list, so that
 		 * it is most likely to get scheduled again.
 		 */
+		f->flags |= FIBER_IS_IDLE;
 		rlist_add_entry(&pool->idle, fiber(), state);
 		fiber_yield();
+		f->flags &= ~FIBER_IS_IDLE;
+
 		goto restart;
 	}
 	pool->size--;

--- a/src/lua/fiber.c
+++ b/src/lua/fiber.c
@@ -319,7 +319,8 @@ lbox_fiber_statof(struct fiber *f, void *cb_ctx, bool backtrace)
 	struct lua_State *L = cb_ctx;
 	luaL_pushuint64(L, f->fid);
 	lua_newtable(L);
-	lbox_fiber_statof_map(f, cb_ctx, backtrace);
+	lbox_fiber_statof_map(f, cb_ctx,
+			      backtrace && (f->flags & FIBER_IS_IDLE) == 0);
 	lua_settable(L, -3);
 	return 0;
 }

--- a/test/app/gh-4235-dont-show-idle-in-fiber-info.result
+++ b/test/app/gh-4235-dont-show-idle-in-fiber-info.result
@@ -1,0 +1,92 @@
+-- test-run result file version 2
+test_run = require('test_run').new()
+ | ---
+ | ...
+netbox = require('net.box')
+ | ---
+ | ...
+fiber = require('fiber')
+ | ---
+ | ...
+
+test_run:cmd('setopt delimiter ";"')
+ | ---
+ | - true
+ | ...
+function count_idle()
+    local idle = 0
+    for fid, info in pairs(fiber.info()) do
+        if info.backtrace == nil then
+            idle = idle + 1
+        end
+    end
+    return idle
+end;
+ | ---
+ | ...
+
+cnt = 0;
+ | ---
+ | ...
+idle = 0;
+ | ---
+ | ...
+done = false;
+ | ---
+ | ...
+function yielder()
+    cnt = cnt + 1
+    while not done do
+        fiber.yield()
+    end
+    cnt = cnt - 1
+end;
+ | ---
+ | ...
+test_run:cmd('setopt delimiter ""');
+ | ---
+ | - true
+ | ...
+
+box.schema.user.grant('guest', 'execute', 'universe')
+ | ---
+ | ...
+conn = netbox.connect(box.cfg.listen)
+ | ---
+ | ...
+
+prev_idle = count_idle()
+ | ---
+ | ...
+
+n = 100
+ | ---
+ | ...
+-- We need to fill cbus with multiple requests to make
+-- fiber pool in TX thread expand to at least `n` fibers.
+for i = 1, n do conn:call('yielder', nil, {is_async = true}) end
+ | ---
+ | ...
+
+while cnt < n do fiber.yield() end
+ | ---
+ | ...
+done = true
+ | ---
+ | ...
+while cnt > 0 do fiber.yield() end
+ | ---
+ | ...
+
+-- Most of the fibers created by `conn:call` must be in the IDLE state
+assert(count_idle() + prev_idle >= n)
+ | ---
+ | - true
+ | ...
+
+conn:close()
+ | ---
+ | ...
+box.schema.user.revoke('guest', 'execute', 'universe')
+ | ---
+ | ...

--- a/test/app/gh-4235-dont-show-idle-in-fiber-info.test.lua
+++ b/test/app/gh-4235-dont-show-idle-in-fiber-info.test.lua
@@ -1,0 +1,46 @@
+test_run = require('test_run').new()
+netbox = require('net.box')
+fiber = require('fiber')
+
+test_run:cmd('setopt delimiter ";"')
+function count_idle()
+    local idle = 0
+    for fid, info in pairs(fiber.info()) do
+        if info.backtrace == nil then
+            idle = idle + 1
+        end
+    end
+    return idle
+end;
+
+cnt = 0;
+idle = 0;
+done = false;
+function yielder()
+    cnt = cnt + 1
+    while not done do
+        fiber.yield()
+    end
+    cnt = cnt - 1
+end;
+test_run:cmd('setopt delimiter ""');
+
+box.schema.user.grant('guest', 'execute', 'universe')
+conn = netbox.connect(box.cfg.listen)
+
+prev_idle = count_idle()
+
+n = 100
+-- We need to fill cbus with multiple requests to make
+-- fiber pool in TX thread expand to at least `n` fibers.
+for i = 1, n do conn:call('yielder', nil, {is_async = true}) end
+
+while cnt < n do fiber.yield() end
+done = true
+while cnt > 0 do fiber.yield() end
+
+-- Most of the fibers created by `conn:call` must be in the IDLE state
+assert(count_idle() + prev_idle >= n)
+
+conn:close()
+box.schema.user.revoke('guest', 'execute', 'universe')


### PR DESCRIPTION
`FIBER_IS_IDLE` flag is added to track fibers from fiber pool.
These fibers are still present in the `fiber.info` but without their stacks. 

Closes #4235 