### PR TITLE
github-ci: add build check on M1 with ARM64

### DIFF
--- a/.github/workflows/osx_10_15.yml
+++ b/.github/workflows/osx_10_15.yml
@@ -30,6 +30,9 @@ jobs:
           submodules: recursive
       - uses: ./.github/actions/environment
       - name: test
+        env:
+          CMAKE_BUILD_TYPE: RelWithDebInfo
+          CMAKE_EXTRA_PARAMS: -DENABLE_WERROR=ON
         run: ${CI_MAKE} test_osx_github_actions
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/osx_10_15_lto.yml
+++ b/.github/workflows/osx_10_15_lto.yml
@@ -31,7 +31,8 @@ jobs:
       - uses: ./.github/actions/environment
       - name: test
         env:
-          CMAKE_EXTRA_PARAMS: -DENABLE_LTO=ON
+          CMAKE_BUILD_TYPE: RelWithDebInfo
+          CMAKE_EXTRA_PARAMS: -DENABLE_WERROR=ON -DENABLE_LTO=ON
         run: ${CI_MAKE} test_osx_github_actions
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/osx_11_0.yml
+++ b/.github/workflows/osx_11_0.yml
@@ -30,6 +30,9 @@ jobs:
           submodules: recursive
       - uses: ./.github/actions/environment
       - name: test
+        env:
+          CMAKE_BUILD_TYPE: RelWithDebInfo
+          CMAKE_EXTRA_PARAMS: -DENABLE_WERROR=ON
         run: ${CI_MAKE} test_osx_github_actions
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/osx_arm64_11_2.yml
+++ b/.github/workflows/osx_arm64_11_2.yml
@@ -1,0 +1,49 @@
+name: osx_arm64_11_2
+
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
+
+env:
+  CI_MAKE: arch -arm64 make -f .travis.mk
+
+jobs:
+  osx_arm64_11_2:
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
+
+    runs-on: macos-m1-11.2
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: test
+        env:
+          CMAKE_BUILD_TYPE: RelWithDebInfo
+          CMAKE_EXTRA_PARAMS: -DENABLE_WERROR=ON
+        run: ${CI_MAKE} test_osx_arm64_github_actions
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: osx_arm64_11_2
+          retention-days: 21
+          path: /tmp/tnt/artifacts

--- a/.github/workflows/osx_debug_arm64_11_2.yml
+++ b/.github/workflows/osx_debug_arm64_11_2.yml
@@ -1,0 +1,48 @@
+name: osx_debug_arm64_11_2
+
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
+
+env:
+  CI_MAKE: arch -arm64 make -f .travis.mk
+
+jobs:
+  osx_debug_arm64_11_2:
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
+
+    runs-on: macos-m1-11.2
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: test
+        env:
+          CMAKE_BUILD_TYPE: Debug
+        run: ${CI_MAKE} test_osx_arm64_github_actions
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: osx_debug_arm64_11_2
+          retention-days: 21
+          path: /tmp/tnt/artifacts

--- a/.travis.mk
+++ b/.travis.mk
@@ -346,7 +346,7 @@ build_osx:
 	# due swap disabling should be manualy configured need to
 	# control it's status
 	sysctl vm.swapusage
-	cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_WERROR=ON ${CMAKE_EXTRA_PARAMS}
+	cmake . -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} ${CMAKE_EXTRA_PARAMS}
 	make -j
 
 

--- a/.travis.mk
+++ b/.travis.mk
@@ -321,7 +321,10 @@ test_oos_build:
 # OSX #
 #######
 
-OSX_PKGS=openssl readline curl icu4c libiconv zlib cmake python3
+# FIXME: Temporary pinned python3 to specific version (i.e. python@3.8) to
+# avoid gevent package installation failure described in gevent/gevent#1721.
+# Revert this back when the issue is resolved.
+OSX_PKGS=openssl readline curl icu4c libiconv zlib cmake python@3.8
 
 deps_osx:
 	# install brew using command from Homebrew repository instructions:
@@ -374,9 +377,16 @@ test_osx_no_deps: build_osx
 	${INIT_TEST_ENV_OSX}; \
 	cd test && ./test-run.py --vardir ${VARDIR} --force $(TEST_RUN_EXTRA_PARAMS)
 
+# FIXME: Temporary target with reduced number of tests.
+# Use test_osx_no_deps target, when all M1 issues are resolved.
+test_osx_arm64_no_deps: build_osx
+	make PUC-Rio-Lua-5.1-tests lua-Harness-tests tarantool-tests
+
 test_osx: deps_osx test_osx_no_deps
 
 test_osx_github_actions: deps_osx_github_actions test_osx_no_deps
+
+test_osx_arm64_github_actions: deps_osx_github_actions test_osx_arm64_no_deps
 
 # Static macOS build
 


### PR DESCRIPTION
Added new Github Action workflow to check the M1 with Tarantool builds:
```
  Release: .github/workflows/osx_arm64_11_2.yml
  Debug: .github/workflows/osx_debug_arm64_11_2.yml
```
Added in Github Action workflow prefix to run all commands from
makefile 'arch -arm64', otherwise found that Github Action uses
'arch -x86_64' prefix by default.

In .travis.mk makefile created new targets to test Tarantool
on M1:
```
  Release: test_osx_arm64_github_actions
  Debug: test_osx_debug_arm64_github_actions
```
Also added test target 'test_osx_arm64_only' with LuaJIT test target:
```
  PUC-Rio-Lua-5.1-tests
```
Found that on M1 hosts running python3 installation python3.9 is
installing by default. But we need to install gevent as test
required package, which fails to be installed with python3.9.5
and successfully installs with python3.8.2 (python@3.8):
```
  Using cached gevent-21.1.2.tar.gz (5.9 MB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... error
    ERROR: Command errored out with exit status 1:
     command: /opt/homebrew/opt/python@3.9/bin/python3.9 /opt/homebrew/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py prepare_metadata_for_build_wheel /var/folders/b0/1vlv5rvn77x2rn6zbl2p4tqr0000gp/T/tmpyy59ae2p
         cwd: /private/var/folders/b0/1vlv5rvn77x2rn6zbl2p4tqr0000gp/T/pip-install-msbf7_vz/gevent_c2956687bb0d4de9bfb5f0660da759ee
    Complete output (42 lines):
      ...
      File "/private/var/folders/b0/1vlv5rvn77x2rn6zbl2p4tqr0000gp/T/pip-build-env-1lesbbxi/overlay/lib/python3.9/site-packages/cffi/api.py", line 48, in __init__
        import _cffi_backend as backend
    ImportError: dlopen(/private/var/folders/b0/1vlv5rvn77x2rn6zbl2p4tqr0000gp/T/pip-build-env-1lesbbxi/overlay/lib/python3.9/site-packages/_cffi_backend.cpython-39-darwin.so, 2): no suitable image found.  Did find:
    	/private/var/folders/b0/1vlv5rvn77x2rn6zbl2p4tqr0000gp/T/pip-build-env-1lesbbxi/overlay/lib/python3.9/site-packages/_cffi_backend.cpython-39-darwin.so: mach-o, but wrong architecture
    	/private/var/folders/b0/1vlv5rvn77x2rn6zbl2p4tqr0000gp/T/pip-build-env-1lesbbxi/overlay/lib/python3.9/site-packages/_cffi_backend.cpython-39-darwin.so: mach-o, but wrong architecture
```
To avoid of it changed python3 to python@3.8 in brew installation.

Closes tarantool/tarantool-qa#120