### PR TITLE
github-ci: correct artifacts paths

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -4,6 +4,7 @@ runs:
   using: "composite"
   steps:
     - run: |
+        echo VARDIR=/tmp/tnt | tee -a $GITHUB_ENV
         echo REPLICATION_SYNC_TIMEOUT=300 | tee -a $GITHUB_ENV
         echo TEST_TIMEOUT=310 | tee -a $GITHUB_ENV
         echo NO_OUTPUT_TIMEOUT=320 | tee -a $GITHUB_ENV

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           name: debug
           retention-days: 21
-          path: test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts
       # Find the PR associated with this push, if there is one.
       - uses: jwalton/gh-find-current-pr@v1
         if: success()

--- a/.github/workflows/debug_coverage.yml
+++ b/.github/workflows/debug_coverage.yml
@@ -86,5 +86,5 @@ jobs:
           name: debug
           retention-days: 21
           path: |
-            test/var/artifacts
+            ${{ env.VARDIR }}/artifacts
             *.info

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -48,4 +48,4 @@ jobs:
         with:
           name: freebsd
           retention-days: 21
-          path: test/var/artifacts
+          path: ./artifacts

--- a/.github/workflows/osx_10_15.yml
+++ b/.github/workflows/osx_10_15.yml
@@ -43,4 +43,4 @@ jobs:
         with:
           name: osx_10_15
           retention-days: 21
-          path: /tmp/tnt/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/osx_10_15_lto.yml
+++ b/.github/workflows/osx_10_15_lto.yml
@@ -45,4 +45,4 @@ jobs:
         with:
           name: osx_10_15_lto
           retention-days: 21
-          path: /tmp/tnt/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/osx_11_0.yml
+++ b/.github/workflows/osx_11_0.yml
@@ -43,4 +43,4 @@ jobs:
         with:
           name: osx_11_0
           retention-days: 21
-          path: /tmp/tnt/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,4 +49,4 @@ jobs:
         with:
           name: release
           retention-days: 21
-          path: test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -49,4 +49,4 @@ jobs:
         with:
           name: release_asan_clang11
           retention-days: 21
-          path: test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -52,4 +52,4 @@ jobs:
         with:
           name: release_clang
           retention-days: 21
-          path: test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -51,4 +51,4 @@ jobs:
         with:
           name: release_lto
           retention-days: 21
-          path: test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -53,4 +53,4 @@ jobs:
         with:
           name: release_lto_clang11
           retention-days: 21
-          path: test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -49,4 +49,4 @@ jobs:
         with:
           name: static_build
           retention-days: 21
-          path: test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -49,4 +49,4 @@ jobs:
         with:
           name: static_build_cmake_linux
           retention-days: 21
-          path: test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/static_build_cmake_osx_15.yml
+++ b/.github/workflows/static_build_cmake_osx_15.yml
@@ -43,4 +43,4 @@ jobs:
         with:
           name: static_build_cmake_osx_15
           retention-days: 21
-          path: /tmp/tnt/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.gitlab.mk
+++ b/.gitlab.mk
@@ -103,7 +103,9 @@ vms_start:
 vms_test_%:
 	tar czf - ../tarantool | ssh ${VMS_USER}@127.0.0.1 -p ${VMS_PORT} tar xzf -
 	ssh ${VMS_USER}@127.0.0.1 -p ${VMS_PORT} "/bin/bash -c \
-		'cd tarantool && ${PRESERVE_ENV} ${TRAVIS_MAKE} $(subst vms_,,$@)'"
+		'cd tarantool && ${PRESERVE_ENV} ${TRAVIS_MAKE} $(subst vms_,,$@)'" || \
+		( scp -r -P ${VMS_PORT} ${VMS_USER}@127.0.0.1:tarantool/test/var/artifacts . \
+		; exit 1 )
 
 vms_shutdown:
 	VBoxManage controlvm ${VMS_NAME} poweroff


### PR DESCRIPTION
Found that after change:

  474eda49b90176406eac6684c8b502e05e49af04 ('github-ci: use vardir option in tests runs')

where 'vardir' was changed. It was forgot to update the Github Actions
workflows with the same change to be able to collect artifacts. This
patch fixes it.

Closes tarantool/tarantool-qa#125