### PR TITLE
fiber: introduce creation backtrace

### DIFF
--- a/changelogs/unreleased/gh-4002-fiber-creation-backtrace.md
+++ b/changelogs/unreleased/gh-4002-fiber-creation-backtrace.md
@@ -1,0 +1,7 @@
+## feature/core
+
+ * Added new entries into subtable `backtrace` to the `fiber.info()`
+   corresponding to the C and Lua backtraces of fiber creation and
+   `fiber.parent_bt_enable()`/`fiber.parent_bt_disable()` options in order to
+   switch on/off the ability to collect parent backtraces for newly created
+   fibers and to show/hide those entries in the `fiber.info()`.

--- a/src/lib/core/backtrace.cc
+++ b/src/lib/core/backtrace.cc
@@ -46,6 +46,10 @@
 #ifdef ENABLE_BACKTRACE
 #include <libunwind.h>
 
+#ifdef TARGET_OS_DARWIN
+#include <dlfcn.h>
+#endif
+
 #include "small/region.h"
 #include "small/static.h"
 /*
@@ -58,6 +62,18 @@
 
 static __thread struct region cache_region;
 static __thread struct mh_i64ptr_t *proc_cache = NULL;
+
+static void *backtrace_lua_entry_start_rip = NULL;
+static void *backtrace_lua_entry_end_rip = NULL;
+static backtrace_collect_lua_cb backtrace_collect_lua
+	= backtrace_collect_lua_default;
+
+#ifndef NDEBUG
+#ifndef TARGET_OS_DARWIN
+static void *backtrace_collect_start_rip = NULL;
+static void *backtrace_collect_end_rip = NULL;
+#endif // TARGET_OS_DARWIN
+#endif // NDEBUG
 
 struct proc_cache_entry {
 	char name[BACKTRACE_NAME_MAX];
@@ -196,25 +212,210 @@ out:
 	return start;
 }
 
-/*
- * Libunwind unw_getcontext wrapper.
- * unw_getcontext can be a macros on some platform and can not be called
- * directly from asm code. Stack variable pass through the wrapper to
- * preserve a old stack pointer during the wrapper call.
- *
- * @param unw_context unwind context to store execution state
- * @param stack pointer to preserve.
- * @retval preserved stack pointer.
- */
-static void *
-unw_getcontext_f(unw_context_t *unw_context, void *stack)
+void NOINLINE
+backtrace_foreach_current(backtrace_cxx_cb cxx_cb, backtrace_lua_cb lua_cb,
+			  struct fiber *fiber, void *cb_ctx)
 {
-	unw_getcontext(unw_context);
+	struct backtrace bt;
+	backtrace_collect(&bt, fiber);
+	memmove(&bt.frames, &bt.frames[1],
+		sizeof(bt.frames[0]) * (BACKTRACE_MAX_FRAMES - 1));
+	--bt.frames_count;
+	backtrace_foreach(&bt, cxx_cb, lua_cb, cb_ctx);
+}
+
+/**
+ * Resolve frame procedure and offest based on `ip`.
+ *
+ * The implementation uses poorly documented `get_proc_name' callback
+ * from the `unw_accessors_t' to get procedure names via `ip_buf' values.
+ * Although `get_proc_name' is present on most architectures, it's an optional
+ * field, so procedure name is allowed to be absent (NULL) in `cb' call.
+ */
+int
+backtrace_resolve_from_ip(unw_word_t ip, const char **proc, unw_word_t *offset)
+{
+	if (backtrace_proc_cache_find(ip, proc, offset) == 0)
+		return 0;
+
+#ifndef TARGET_OS_DARWIN
+	static __thread char proc_name[BACKTRACE_NAME_MAX];
+
+	int ret = 0;
+	unw_proc_info_t pi;
+	unw_accessors_t *acc = unw_get_accessors(unw_local_addr_space);
+	if (acc->get_proc_name == NULL) {
+		ret = unw_get_proc_info_by_ip(unw_local_addr_space, ip, &pi,
+					      NULL);
+		if (ret != 0) {
+			say_debug("unwinding error: %s", unw_strerror(ret));
+			return -1;
+		}
+
+		*offset = ip - (unw_word_t)pi.start_ip;
+		*proc = NULL;
+	} else {
+		ret = acc->get_proc_name(unw_local_addr_space, ip, proc_name,
+					 sizeof(proc_name), offset, NULL);
+		if (ret != 0) {
+			say_debug("unwinding error: %s", unw_strerror(ret));
+			return -1;
+		}
+
+		*proc = proc_name;
+	}
+#else
+	Dl_info dli;
+	if (dladdr((void *)ip, &dli) == 0) {
+		say_debug("unwinding error: dladdr()");
+		return -1;
+	}
+
+	*offset = ip - (unw_word_t)dli.dli_saddr;
+	*proc = dli.dli_sname;
+#endif /* TARGET_OS_DARWIN */
+
+	backtrace_proc_cache_put(ip, *proc, *offset);
+	return 0;
+}
+
+int
+backtrace_collect_lua_default(struct backtrace *bt, struct fiber *fiber) {
+	(void) fiber;
+	backtrace_append_lua(bt, "<lua stack>", "<lua stack>", -1);
+
+	return 0;
+}
+
+int
+backtrace_init(void *lua_stack_entry_point,
+	       backtrace_collect_lua_cb collect_lua_cb) {
+	if (collect_lua_cb != NULL)
+		backtrace_collect_lua = collect_lua_cb;
+#ifndef TARGET_OS_DARWIN
+	unw_proc_info_t pi;
+	if (lua_stack_entry_point != NULL) {
+		if (unw_get_proc_info_by_ip(unw_local_addr_space,
+					    (unw_word_t) lua_stack_entry_point,
+					    &pi, NULL) != 0)
+			return -1;
+
+		backtrace_lua_entry_start_rip = (void *)pi.start_ip;
+		backtrace_lua_entry_end_rip = (void *)pi.end_ip;
+	}
+
+#ifndef NDEBUG
+	if (unw_get_proc_info_by_ip(unw_local_addr_space,
+				    (unw_word_t) backtrace_collect,
+				    &pi, NULL) != 0)
+		return -1;
+
+	backtrace_collect_start_rip = (void *)pi.start_ip;;
+	backtrace_collect_end_rip = (void *)pi.end_ip;
+#endif // NDEBUG
+#else // TARGET_OS_DARWIN
+	backtrace_lua_entry_start_rip = lua_stack_entry_point;
+	backtrace_lua_entry_end_rip = NULL;
+#endif // TARGET_OS_DARWIN
+	return 0;
+}
+
+/**
+ * Add rip of a C/C++ frame and its corresponding Lua frames (if any) to @a bt.
+ */
+#ifndef TARGET_OS_DARWIN
+static int
+backtrace_add_rip(struct backtrace *bt, struct fiber *fiber, void *rip) {
+	int prev_frames_count = bt->frames_count;
+	if (rip > backtrace_lua_entry_start_rip &&
+	    rip < backtrace_lua_entry_end_rip) {
+		backtrace_collect_lua(bt, fiber);
+	}
+	backtrace_append_cxx(bt, rip);
+
+	return bt->frames_count - prev_frames_count;
+}
+#else // TARGET_OS_DARWIN
+static int
+backtrace_add_rip(struct backtrace *bt, struct fiber *fiber,
+		  unw_cursor_t *unw_cur) {
+	int prev_frames_count = bt->frames_count;
+	unw_word_t rip_word;
+	unw_get_reg(unw_cur, UNW_REG_IP, &rip_word);
+	void *rip = (void *)rip_word;
+
+	/* Try to obtain a `backtrace_lua_entry_end_rip` value. */
+	if (backtrace_lua_entry_start_rip != NULL &&
+	    backtrace_lua_entry_end_rip == NULL) {
+		unw_proc_info_t pi;
+		unw_get_proc_info(unw_cur, &pi);
+		if ((void *)pi.start_ip <= backtrace_lua_entry_start_rip &&
+		    backtrace_lua_entry_start_rip <= (void *)pi.end_ip) {
+			backtrace_lua_entry_start_rip = (void *)pi.start_ip;
+			backtrace_lua_entry_end_rip = (void *)pi.end_ip;
+		}
+	}
+	if (rip > backtrace_lua_entry_start_rip &&
+	    rip < backtrace_lua_entry_end_rip) {
+		backtrace_collect_lua(bt, fiber);
+	}
+	backtrace_append_cxx(bt, rip);
+
+	return bt->frames_count - prev_frames_count;
+}
+#endif // TARGET_OS_DARWIN
+
+/**
+ * Helper for @a backtrace_collect.
+ * Must be called only by backtrace_collect function.
+ * Returns its second parameter to simplify its call on foreign stack.
+ * @returns @a stack
+ * @sa backtrace_collect
+ */
+static void * NOINLINE
+backtrace_collect_local(struct backtrace *bt, struct fiber *fiber,
+			void *stack) {
+	bt->frames_count = 0;
+#ifndef TARGET_OS_DARWIN
+	void *rips[BACKTRACE_MAX_FRAMES + 2];
+	int frames_count = unw_backtrace(rips, BACKTRACE_MAX_FRAMES + 2);
+	assert(rips[1] > backtrace_collect_start_rip &&
+	       rips[1] < backtrace_collect_end_rip);
+	for (int frame_no = 2; frame_no < frames_count; ++frame_no) {
+		if (backtrace_add_rip(bt, fiber, rips[frame_no]) == 0)
+			break;
+	}
+#else
+	/*
+	 * This dumb implementation was chosen because the DARWIN
+	 * lacks unw_backtrace() routine from libunwind and
+	 * usual backtrace() from <execinfo.h> has less capabilities
+	 * than the libunwind version which uses DWARF.
+	 */
+	unw_cursor_t unw_cur;
+	unw_context_t unw_ctx;
+
+	unw_getcontext(&unw_ctx);
+	unw_init_local(&unw_cur, &unw_ctx);
+
+	for (int frame_no = 0; frame_no < BACKTRACE_MAX_FRAMES + 2;
+	     ++frame_no) {
+		if (frame_no >= 2) {
+			if (backtrace_add_rip(bt, fiber, &unw_cur) == 0)
+				break;
+		}
+		if (unw_step(&unw_cur) <= 0) {
+			++frame_no;
+			break;
+		}
+	}
+#endif /* TARGET_OS_DARWIN */
+
 	return stack;
 }
 
 /*
- * Restore target coro context and call unw_getcontext over it.
+ * Restore target coro context and call backtrace_collect_local over it.
  * Work is done in four parts:
  * 1. Save current fiber context to a stack and save a stack pointer
  * 2. Restore target fiber context, stack pointer is not incremented because
@@ -226,15 +427,27 @@ unw_getcontext_f(unw_context_t *unw_context, void *stack)
  * 4. Restore old stack pointer from wrapper return and restore old fiber
  *    contex.
  *
- * @param @unw_context unwind context to store execution state.
- * @param @coro_ctx fiber context to unwind.
+ * @param @bt backtrace
+ * @param @fiber fiber to unwind its context.
  *
  * Note, this function needs a separate stack frame and therefore
  * MUST NOT be inlined.
  */
-static void NOINLINE
-coro_unwcontext(unw_context_t *unw_context, struct coro_context *coro_ctx)
-{
+int NOINLINE
+backtrace_collect(struct backtrace *bt, struct fiber *fiber) {
+	if (fiber == fiber()) {
+		backtrace_collect_local(bt, fiber(), NULL);
+		return bt->frames_count;
+	} else if ((fiber->flags & FIBER_IS_CANCELLABLE) == 0) {
+		/*
+		* Fiber stacks can't be traced for non-cancellable fibers
+		* due to the limited capabilities of libcoro in CORO_ASM mode.
+		*/
+		bt->frames_count = 0;
+		return 0;
+	}
+
+	volatile coro_context *coro_ctx = &fiber->ctx;
 #if __amd64
 __asm__ volatile(
 	/* Preserve current context */
@@ -244,22 +457,22 @@ __asm__ volatile(
 	"\tpushq %%r13\n"
 	"\tpushq %%r14\n"
 	"\tpushq %%r15\n"
-	/* Setup second arg as old sp */
-	"\tmovq %%rsp, %%rsi\n"
+	/* Set first arg */
+	"\tmovq %1, %%rdi\n"
+	/* Set second arg */
+	"\tmovq %2, %%rsi\n"
+	/* Setup third arg as old sp */
+	"\tmovq %%rsp, %%rdx\n"
 	/* Restore target context, but not increment sp to preserve it */
-	"\tmovq 0(%1), %%rsp\n"
+	"\tmovq 0(%3), %%rsp\n"
 	"\tmovq 0(%%rsp), %%r15\n"
 	"\tmovq 8(%%rsp), %%r14\n"
 	"\tmovq 16(%%rsp), %%r13\n"
 	"\tmovq 24(%%rsp), %%r12\n"
 	"\tmovq 32(%%rsp), %%rbx\n"
 	"\tmovq 40(%%rsp), %%rbp\n"
-	/* Set first arg and call */
-	"\tmovq %0, %%rdi\n"
-#ifdef TARGET_OS_DARWIN
 	"\tandq $0xfffffffffffffff0, %%rsp\n"
-#endif
-	"\tleaq %P2(%%rip), %%rax\n"
+	"\tleaq %P4(%%rip), %%rax\n"
 	"\tcall *%%rax\n"
 	/* Restore old sp and context */
 	"\tmov %%rax, %%rsp\n"
@@ -269,9 +482,9 @@ __asm__ volatile(
 	"\tpopq %%r12\n"
 	"\tpopq %%rbx\n"
 	"\tpopq %%rbp\n"
-	:
-	: "r" (unw_context), "r" (coro_ctx), "i" (unw_getcontext_f)
-	: "rdi", "rsi", "rax"//, "r8"//"rsp", "r11", "r10", "r9", "r8"
+	: "=m" (*bt)
+	: "r" (bt), "r" (fiber), "r" (coro_ctx), "i" (backtrace_collect_local)
+	: "rdi", "rsi", "rdx", "rax", "memory"
 	);
 
 #elif __i386
@@ -281,18 +494,24 @@ __asm__ volatile(
 	"\tpushl %%ebx\n"
 	"\tpushl %%esi\n"
 	"\tpushl %%edi\n"
-	/* Setup second arg as old sp */
+	/* Setup third arg as old sp */
 	"\tmovl %%esp, %%ecx\n"
+	/* Setup second arg */
+	"\tmovl %2, %%edx\n"
 	/* Restore target context ,but not increment sp to preserve it */
-	"\tmovl (%1), %%esp\n"
+	"\tmovl (%3), %%esp\n"
 	"\tmovl 0(%%esp), %%edi\n"
 	"\tmovl 4(%%esp), %%esi\n"
 	"\tmovl 8(%%esp), %%ebx\n"
 	"\tmovl 12(%%esp), %%ebp\n"
+	/* Align stack by 16 according to the i386 ABI v1.1 */
+	"\tandl $0xfffffff0, %%rsp\n"
+	"\tsubl $4, %%esp\n"
 	/* Setup first arg and call */
 	"\tpushl %%ecx\n"
-	"\tpushl %0\n"
-	"\tmovl %2, %%ecx\n"
+	"\tpushl %%edx\n"
+	"\tpushl %1\n"
+	"\tmovl %4, %%ecx\n"
 	"\tcall *%%ecx\n"
 	/* Restore old sp and context */
 	"\tmovl %%eax, %%esp\n"
@@ -300,9 +519,9 @@ __asm__ volatile(
 	"\tpopl %%esi\n"
 	"\tpopl %%ebx\n"
 	"\tpopl %%ebp\n"
-	:
-	: "r" (unw_context), "r" (coro_ctx), "i" (unw_getcontext_f)
-	: "ecx", "eax"
+	: "=m" (*bt)
+	: "r" (bt), "r" (fiber), "r" (coro_ctx), "i" (backtrace_collect_local)
+	: "ecx", "edx", "eax", "memory"
 	);
 
 #elif __ARM_ARCH==7
@@ -311,60 +530,66 @@ __asm__ volatile(
 	".syntax unified\n"
 	"\tvpush {d8-d15}\n"
 	"\tpush {r4-r11,lr}\n"
+	/* Setup first arg */
+	"\tmov r0, %1\n"
+	/* Setup second arg */
+	"\tmov r1, %2\n"
 	/* Save sp */
-	"\tmov r1, sp\n"
+	"\tmov r2, sp\n"
 	/* Restore target context, but not increment sp to preserve it */
-	"\tldr sp, [%1]\n"
+	"\tldr sp, [%3]\n"
 	"\tldmia sp, {r4-r11,lr}\n"
 	"\tvldmia sp, {d8-d15}\n"
-	/* Setup first arg */
-	"\tmov r0, %0\n"
 	/* Setup stack frame */
 	"\tpush {r7, lr}\n"
-	"\tsub sp, #8\n"
-	"\tstr r0, [sp, #4]\n"
-	"\tstr r1, [sp, #0]\n"
+	/* Align sp as on some ARMv7 archs it has to be multiple of 8 */
+	"\tsub sp, #16\n"
+	"\tstr r0, [sp, #8]\n"
+	"\tstr r1, [sp, #4]\n"
+	"\tstr r2, [sp, #0]\n"
 	"\tmov r7, sp\n"
-	"\tbl %2\n"
+	"\tbl %4\n"
 	/* Old sp is returned via r0 */
 	"\tmov sp, r0\n"
 	"\tpop {r4-r11,lr}\n"
 	"\tvpop {d8-d15}\n"
-	:
-	: "r" (unw_context), "r" (coro_ctx), "i" (unw_getcontext_f)
-	: "lr", "r0", "r1", "ip"
+	: "=m" (*bt)
+	: "r" (bt), "r" (fiber), "r" (coro_ctx), "i" (backtrace_collect_local)
+	: "lr", "r0", "r1", "r2", "ip", "memory"
 	);
 
 #elif __aarch64__
 __asm__ volatile(
+	/* Setup first arg */
+	"\tmov x0, %1\n"
+	/* Setup second arg */
+	"\tmov x1, %2\n"
 	/* Save current context */
-	"\tsub x1, sp, #8 * 20\n"
-	"\tstp x19, x20, [x1, #16 * 0]\n"
-	"\tstp x21, x22, [x1, #16 * 1]\n"
-	"\tstp x23, x24, [x1, #16 * 2]\n"
-	"\tstp x25, x26, [x1, #16 * 3]\n"
-	"\tstp x27, x28, [x1, #16 * 4]\n"
-	"\tstp x29, x30, [x1, #16 * 5]\n"
-	"\tstp d8,  d9,  [x1, #16 * 6]\n"
-	"\tstp d10, d11, [x1, #16 * 7]\n"
-	"\tstp d12, d13, [x1, #16 * 8]\n"
-	"\tstp d14, d15, [x1, #16 * 9]\n"
+	"\tsub x2, sp, #8 * 20\n"
+	"\tstp x19, x20, [x2, #16 * 0]\n"
+	"\tstp x21, x22, [x2, #16 * 1]\n"
+	"\tstp x23, x24, [x2, #16 * 2]\n"
+	"\tstp x25, x26, [x2, #16 * 3]\n"
+	"\tstp x27, x28, [x2, #16 * 4]\n"
+	"\tstp x29, x30, [x2, #16 * 5]\n"
+	"\tstp d8,  d9,  [x2, #16 * 6]\n"
+	"\tstp d10, d11, [x2, #16 * 7]\n"
+	"\tstp d12, d13, [x2, #16 * 8]\n"
+	"\tstp d14, d15, [x2, #16 * 9]\n"
 	/* Restore target context */
-	"\tldr x2, [%1]\n"
-	"\tldp x19, x20, [x2, #16 * 0]\n"
-	"\tldp x21, x22, [x2, #16 * 1]\n"
-	"\tldp x23, x24, [x2, #16 * 2]\n"
-	"\tldp x25, x26, [x2, #16 * 3]\n"
-	"\tldp x27, x28, [x2, #16 * 4]\n"
-	"\tldp x29, x30, [x2, #16 * 5]\n"
-	"\tldp d8,  d9,  [x2, #16 * 6]\n"
-	"\tldp d10, d11, [x2, #16 * 7]\n"
-	"\tldp d12, d13, [x2, #16 * 8]\n"
-	"\tldp d14, d15, [x2, #16 * 9]\n"
-	"\tmov sp, x2\n"
-	/* Setup fisrst arg */
-	"\tmov x0, %0\n"
-	"\tbl %2\n"
+	"\tldr x3, [%3]\n"
+	"\tldp x19, x20, [x3, #16 * 0]\n"
+	"\tldp x21, x22, [x3, #16 * 1]\n"
+	"\tldp x23, x24, [x3, #16 * 2]\n"
+	"\tldp x25, x26, [x3, #16 * 3]\n"
+	"\tldp x27, x28, [x3, #16 * 4]\n"
+	"\tldp x29, x30, [x3, #16 * 5]\n"
+	"\tldp d8,  d9,  [x3, #16 * 6]\n"
+	"\tldp d10, d11, [x3, #16 * 7]\n"
+	"\tldp d12, d13, [x3, #16 * 8]\n"
+	"\tldp d14, d15, [x3, #16 * 9]\n"
+	"\tmov sp, x3\n"
+	"\tbl %4\n"
 	/* Restore context (old sp in x0) */
 	"\tldp x19, x20, [x0, #16 * 0]\n"
 	"\tldp x21, x22, [x0, #16 * 1]\n"
@@ -377,79 +602,100 @@ __asm__ volatile(
 	"\tldp d12, d13, [x0, #16 * 8]\n"
 	"\tldp d14, d15, [x0, #16 * 9]\n"
 	"\tadd sp, x0, #8 * 20\n"
-	:
-	: "r" (unw_context), "r" (coro_ctx), "S" (unw_getcontext_f)
-	: /*"lr", "r0", "r1", "ip" */
-	 "x0", "x1", "x2", "x30"
+	: "=m" (*bt)
+	: "r" (bt), "r" (fiber), "r" (coro_ctx), "S" (backtrace_collect_local)
+	: /*"lr", "r0", "r1", "r2", "ip" */
+	 "x0", "x1", "x2", "x3", "x30", "memory"
 	);
 #endif
+
+	return bt->frames_count;
 }
 
-/**
- * Call `cb' callback for each `coro_ctx' contained frame or the current
- * executed coroutine if `coro_ctx' is NULL. A coro_context is a structure
- * created on each coroutine yield to store execution context so for an
- * on-CPU coroutine there is no valid coro_context could be defined and
- * NULL is passed.
- */
-void
-backtrace_foreach(backtrace_cb cb, coro_context *coro_ctx, void *cb_ctx)
-{
-	unw_cursor_t unw_cur;
-	unw_context_t unw_ctx_bt;
-	if (coro_ctx == NULL) {
-		/*
-		 * Current executing coroutine and simple unw_getcontext
-		 * should function.
-		 */
-		unw_getcontext(&unw_ctx_bt);
-	} else {
-		/*
-		 * Execution context is stored in the coro_ctx
-		 * so use special context-switching handler to
-		 * capture an unwind context.
-		 */
-		coro_unwcontext(&unw_ctx_bt, coro_ctx);
-	}
-	unw_init_local(&unw_cur, &unw_ctx_bt);
-	int frame_no = 0;
-	unw_word_t sp = 0, old_sp = 0, ip, offset;
-	int unw_status, demangle_status;
+int
+backtrace_foreach(const struct backtrace *bt, backtrace_cxx_cb cxx_cb,
+		  backtrace_lua_cb lua_cb, void *cb_ctx) {
+	int demangle_status;
 	char *demangle_buf = NULL;
 	size_t demangle_buf_len = 0;
 
-	while ((unw_status = unw_step(&unw_cur)) > 0) {
-		const char *proc;
-		old_sp = sp;
-		unw_get_reg(&unw_cur, UNW_REG_IP, &ip);
-		unw_get_reg(&unw_cur, UNW_REG_SP, &sp);
-		if (sp == old_sp) {
-			say_debug("unwinding error: previous frame "
-				  "identical to this frame (corrupt stack?)");
-			goto out;
-		}
-		proc = get_proc_name(&unw_cur, &offset, false);
+	int frame_no = 0;
+	const struct backtrace_frame *frame = bt->frames;
+	const struct backtrace_frame *end_frame = bt->frames + bt->frames_count;
+	for (; frame != end_frame; ++frame) {
+		if (frame->is_lua) {
+			if (lua_cb != NULL &&
+			    lua_cb(frame_no++, frame->name, frame->source,
+				   frame->line, cb_ctx) != 0)
+				break;
+		} else {
+			unw_word_t offset = 0;
+			const char *proc = NULL;
+			if (backtrace_resolve_from_ip((unw_word_t)frame->rip,
+						      &proc, &offset) != 0)
+				break;
 
-		char *cxxname = abi::__cxa_demangle(proc, demangle_buf,
-						    &demangle_buf_len,
-						    &demangle_status);
-		if (cxxname != NULL)
-			demangle_buf = cxxname;
-		if (frame_no > 0 &&
-		    (cb(frame_no - 1, (void *)ip, cxxname != NULL ? cxxname : proc,
-			offset, cb_ctx) != 0))
-			goto out;
-		++frame_no;
+			if (proc != NULL) {
+				char *cxxname
+					= abi::__cxa_demangle(proc,
+							      demangle_buf,
+							      &demangle_buf_len,
+							      &demangle_status);
+				if (cxxname != NULL) {
+					demangle_buf = cxxname;
+					proc = cxxname;
+				}
+			}
+
+			if (cxx_cb(frame_no++, frame->rip, proc, offset,
+				   cb_ctx) != 0)
+				break;
+		}
 	}
-#ifndef TARGET_OS_DARWIN
-	if (unw_status != 0)
-		say_debug("unwinding error: %s", unw_strerror(unw_status));
-#else
-	if (unw_status != 0)
-		say_debug("unwinding error: %i", unw_status);
-#endif
-out:
+
 	free(demangle_buf);
+
+	return frame_no;
+}
+
+int
+backtrace_concat(struct backtrace *to, const struct backtrace *add) {
+	int add_frames = MIN(BACKTRACE_MAX_FRAMES - to->frames_count,
+			     add->frames_count);
+	memcpy(to->frames + to->frames_count, add->frames,
+	       sizeof(to->frames[0]) * add_frames);
+	to->frames_count += add_frames;
+
+	return add_frames;
+}
+
+int
+backtrace_append_cxx(struct backtrace *bt, void *rip) {
+	if (bt->frames_count < BACKTRACE_MAX_FRAMES) {
+		struct backtrace_frame *frame = bt->frames + bt->frames_count;
+		frame->is_lua = false;
+		frame->rip = rip;
+		++bt->frames_count;
+	}
+
+	return bt->frames_count;
+}
+
+int
+backtrace_append_lua(struct backtrace *bt, const char *name, const char *source,
+		     int line) {
+	if (bt->frames_count < BACKTRACE_MAX_FRAMES) {
+		struct backtrace_frame *frame = bt->frames + bt->frames_count;
+		frame->is_lua = true;
+		frame->line = line;
+		strncpy(frame->name, name, BACKTRACE_LUA_MAX_NAME - 1);
+		strncpy(frame->source, source, BACKTRACE_LUA_MAX_NAME - 1);
+		frame->name[BACKTRACE_LUA_MAX_NAME - 1] = '\0';
+		frame->source[BACKTRACE_LUA_MAX_NAME - 1] = '\0';
+		++bt->frames_count;
+	}
+
+	return bt->frames_count;
 }
 
 void

--- a/src/lib/core/backtrace.h
+++ b/src/lib/core/backtrace.h
@@ -31,6 +31,7 @@
  * SUCH DAMAGE.
  */
 #include "trivia/config.h"
+#include "trivia/util.h"
 #include <stddef.h>
 
 #if defined(__cplusplus)
@@ -40,20 +41,144 @@ extern "C" {
 #ifdef ENABLE_BACKTRACE
 #include <coro.h>
 
+enum {
+	/** Maximal size of  of Lua frame's name and source name. */
+	BACKTRACE_LUA_MAX_NAME = 64,
+	/** Maximal number of frames in @a backtrace structure. */
+	BACKTRACE_MAX_FRAMES = 32,
+};
+
+/**
+ * Frame information common for C and Lua
+ * sufficient for further resolving of names and offsets.
+ */
+struct backtrace_frame {
+	/** True iff frame is for lua code. */
+	bool is_lua;
+	union {
+		/** C frame RIP register value */
+		void *rip;
+		/** Lua frame */
+		struct {
+			/** Current line inside lua function */
+			int line;
+			/** Lua function name */
+			char name[BACKTRACE_LUA_MAX_NAME];
+			/** Lua frame source */
+			char source[BACKTRACE_LUA_MAX_NAME];
+		};
+	};
+};
+
+/**
+ * Backtrace context storing a 'snapshot' of a
+ * fixed number of last stack frames.
+ */
+struct backtrace {
+    /** Number of frames. */
+    int frames_count;
+    /** Buffer of Lua frame data. */
+    struct backtrace_frame frames[BACKTRACE_MAX_FRAMES];
+};
+
+/**
+ * Forward declaration only to use pointer to fiber.
+ */
+struct fiber;
+
 char *
 backtrace(char *start, size_t size);
 
 void print_backtrace(void);
 
-typedef int (backtrace_cb)(int frameno, void *frameret,
-                           const char *func, size_t offset, void *cb_ctx);
+/**
+ * Callback to be called on each C/C++ frame of the backtrace.
+ * Note that @a frameno counter in @a backtrace_foreach and
+ * @a backtrace_foreach_current is common for both C/C++ and Lua callbacks
+ * @sa backtrace_foreach_current
+ * @sa backtrace_foreach
+ */
+typedef int (backtrace_cxx_cb)(int frameno, void *frameret, const char *func,
+			       size_t offset, void *cb_ctx);
 
+/**
+ * Callback to be called on each Lua frame of the backtrace.
+ * Note that @a frameno counter in @a backtrace_foreach and
+ * @a backtrace_foreach_current is common for both C/C++ and Lua callbacks
+ * @sa backtrace_foreach_current
+ * @sa backtrace_foreach
+ */
+typedef int (backtrace_lua_cb)(int frameno, const char *func,
+			       const char *source, int line, void *cb_ctx);
 
-void
-backtrace_foreach(backtrace_cb cb, coro_context *coro_ctx, void *cb_ctx);
+/**
+ * Run @a cxx_cb and @a lua_cb on each C/C++ and Lua frame of a current
+ * context of @a fiber correspondingly.
+ * @a lua_cb may be NULL when tracing only C frames.
+ * @returns number of frames traversed
+ */
+void NOINLINE
+backtrace_foreach_current(backtrace_cxx_cb cxx_cb, backtrace_lua_cb lua_cb,
+			  struct fiber *fiber, void *cb_ctx);
 
 void
 backtrace_proc_cache_clear(void);
+
+/**
+ * Callback used to collect lua frames.
+ */
+typedef int (*backtrace_collect_lua_cb)(struct backtrace *, struct fiber *);
+
+/**
+ * Default callback to collect lua frames in backtrace.
+ */
+int
+backtrace_collect_lua_default(struct backtrace *bt, struct fiber *fiber);
+
+/**
+ * Initialize helpers to track Lua stack starting
+ * from @a lua_stack_entry_point procedure's frame.
+ * Do not track lua stack if @a lua_stack_entry_point is NULL.
+ */
+int
+backtrace_init(void *lua_stack_entry_point,
+	       backtrace_collect_lua_cb collect_lua_cb);
+
+/**
+ * Collect current stack snapshot of a current context of @a fiber to @a bt.
+ * Do not collect its own (backtrace_collect()'s) frame.
+ * @returns number of frames collected
+ */
+int NOINLINE
+backtrace_collect(struct backtrace *bt, struct fiber *fiber);
+
+/**
+ * Run @a cxx_cb and @a lua_cb on each C/C++ and Lua frame of @a bt
+ * correspondingly.
+ * @returns number of frames traversed
+ */
+int
+backtrace_foreach(const struct backtrace *bt, backtrace_cxx_cb cxx_cb,
+		  backtrace_lua_cb lua_cb, void *cb_ctx);
+
+/**
+ * Append frames from @a add to the bottom of @a to.
+ */
+int
+backtrace_concat(struct backtrace *to, const struct backtrace *add);
+
+/**
+ * Append C/C++ frame bt the botbtm of @a bt.
+ */
+int
+backtrace_append_cxx(struct backtrace *bt, void *rip);
+
+/**
+ * Append Lua frame to the bottom of @a bt.
+ */
+int
+backtrace_append_lua(struct backtrace *bt, const char *name, const char *source,
+		     int line);
 
 #endif /* ENABLE_BACKTRACE */
 

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -531,6 +531,8 @@ struct txn;
 struct credentials;
 struct lua_State;
 struct ipc_wait_pad;
+struct parent_bt_lua;
+struct backtrace;
 
 struct fiber {
 	coro_context ctx;
@@ -660,6 +662,13 @@ struct fiber {
 	 */
 	char *name;
 	char inline_name[FIBER_NAME_INLINE];
+#if ENABLE_BACKTRACE
+	/**
+	 * Pointer to the fiber creation backtrace data
+	 * allocated on the fiber region.
+	 */
+	struct backtrace *parent_bt;
+#endif /* ENABLE_BACKTRACE */
 };
 
 /** Invoke on_stop triggers and delete them. */
@@ -874,6 +883,17 @@ fiber_top_enable(void);
 void
 fiber_top_disable(void);
 #endif /* ENABLE_FIBER_TOP */
+
+#if ENABLE_BACKTRACE
+bool
+fiber_parent_bt_is_enabled(void);
+
+void
+fiber_parent_bt_enable(void);
+
+void
+fiber_parent_bt_disable(void);
+#endif /* ENABLE_BACKTRACE */
 
 /** Useful for C unit tests */
 static inline int

--- a/test/app/gh-4002-fiber-creation-backtrace.result
+++ b/test/app/gh-4002-fiber-creation-backtrace.result
@@ -1,0 +1,113 @@
+-- test-run result file version 2
+yaml = require('yaml')
+ | ---
+ | ...
+fiber = require('fiber')
+ | ---
+ | ...
+test_run = require('test_run').new()
+ | ---
+ | ...
+
+stack_len = 0
+ | ---
+ | ...
+stack_str = ""
+ | ---
+ | ...
+
+test_run:cmd('setopt delimiter ";"')
+ | ---
+ | - true
+ | ...
+foo1 = function() foo2() end;
+ | ---
+ | ...
+foo2 = function() foo3() end;
+ | ---
+ | ...
+
+foo3 = function()
+    local id = fiber.self():id()
+    local info = fiber.info()[id]
+    local stack = info.backtrace
+    stack_len = stack and #stack or -1
+    stack_str = yaml.encode(stack)
+end;
+ | ---
+ | ...
+
+test_run:cmd('setopt delimiter ""');
+ | ---
+ | - true
+ | ...
+
+local bar,baz
+ | ---
+ | ...
+
+bar = function(n) if n ~= 0 then baz(n - 1) else fiber.create(foo1) end end
+ | ---
+ | ...
+baz = function(n) fiber.create(bar, n) end
+ | ---
+ | ...
+
+baz(5)
+ | ---
+ | ...
+init_stack_len = stack_len
+ | ---
+ | ...
+
+if stack_len ~= -1 then fiber:parent_bt_enable() end
+ | ---
+ | ...
+baz(5)
+ | ---
+ | ...
+with_parent_stack_len = stack_len
+ | ---
+ | ...
+assert(with_parent_stack_len > 0 or init_stack_len == -1)
+ | ---
+ | - true
+ | ...
+assert(stack_str:find("foo2") ~= nil or init_stack_len == -1)
+ | ---
+ | - true
+ | ...
+assert(stack_str:find("baz") ~= nil or init_stack_len == -1)
+ | ---
+ | - true
+ | ...
+
+if stack_len ~= -1 then fiber:parent_bt_disable() end
+ | ---
+ | ...
+baz(5)
+ | ---
+ | ...
+without_parent_stack_len = stack_len
+ | ---
+ | ...
+assert(without_parent_stack_len > 0 or init_stack_len == -1)
+ | ---
+ | - true
+ | ...
+assert(without_parent_stack_len == init_stack_len)
+ | ---
+ | - true
+ | ...
+assert(without_parent_stack_len < with_parent_stack_len or init_stack_len == -1)
+ | ---
+ | - true
+ | ...
+assert(stack_str:find("foo2") ~= nil or init_stack_len == -1)
+ | ---
+ | - true
+ | ...
+assert(stack_str:find("baz") == nil)
+ | ---
+ | - true
+ | ...

--- a/test/app/gh-4002-fiber-creation-backtrace.test.lua
+++ b/test/app/gh-4002-fiber-creation-backtrace.test.lua
@@ -1,0 +1,44 @@
+yaml = require('yaml')
+fiber = require('fiber')
+test_run = require('test_run').new()
+
+stack_len = 0
+stack_str = ""
+
+test_run:cmd('setopt delimiter ";"')
+foo1 = function() foo2() end;
+foo2 = function() foo3() end;
+
+foo3 = function()
+    local id = fiber.self():id()
+    local info = fiber.info()[id]
+    local stack = info.backtrace
+    stack_len = stack and #stack or -1
+    stack_str = yaml.encode(stack)
+end;
+
+test_run:cmd('setopt delimiter ""');
+
+local bar,baz
+
+bar = function(n) if n ~= 0 then baz(n - 1) else fiber.create(foo1) end end
+baz = function(n) fiber.create(bar, n) end
+
+baz(5)
+init_stack_len = stack_len
+
+if stack_len ~= -1 then fiber:parent_bt_enable() end
+baz(5)
+with_parent_stack_len = stack_len
+assert(with_parent_stack_len > 0 or init_stack_len == -1)
+assert(stack_str:find("foo2") ~= nil or init_stack_len == -1)
+assert(stack_str:find("baz") ~= nil or init_stack_len == -1)
+
+if stack_len ~= -1 then fiber:parent_bt_disable() end
+baz(5)
+without_parent_stack_len = stack_len
+assert(without_parent_stack_len > 0 or init_stack_len == -1)
+assert(without_parent_stack_len == init_stack_len)
+assert(without_parent_stack_len < with_parent_stack_len or init_stack_len == -1)
+assert(stack_str:find("foo2") ~= nil or init_stack_len == -1)
+assert(stack_str:find("baz") == nil)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -282,3 +282,27 @@ target_link_libraries(popen.test misc unit core)
 
 add_executable(serializer.test serializer.c)
 target_link_libraries(serializer.test unit box ${LUAJIT_LIBRARIES})
+
+if (UNWIND_LIBRARY AND HAVE_LIBUNWIND_H AND
+    NOT CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm*" AND
+    NOT CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "aarch*")
+    add_executable(backtrace_unw_coro.test
+                   backtrace_unw_coro.c
+                   core_test_utils.c)
+    target_link_libraries(backtrace_unw_coro.test core unit)
+
+    add_executable(backtrace_rip_coro.test
+                   backtrace_rip_coro.c
+                   core_test_utils.c)
+    target_link_libraries(backtrace_rip_coro.test core unit)
+
+    add_executable(backtrace_indirect.test
+                   backtrace_indirect.c
+                   core_test_utils.c)
+    target_link_libraries(backtrace_indirect.test core unit)
+
+    if (CMAKE_BUILD_TYPE MATCHES Debug)
+        add_executable(backtrace.test backtrace.c core_test_utils.c)
+        target_link_libraries(backtrace.test core unit)
+    endif ()
+endif()

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -13,6 +13,7 @@ include_directories(${PROJECT_SOURCE_DIR}/src)
 include_directories(${PROJECT_BINARY_DIR}/src)
 include_directories(${PROJECT_SOURCE_DIR}/src/box)
 include_directories(${CMAKE_SOURCE_DIR}/third_party)
+include_directories(${CMAKE_SOURCE_DIR}/third_party/coro)
 include_directories(${ICU_INCLUDE_DIRS})
 include_directories(${CURL_INCLUDE_DIRS})
 

--- a/test/unit/backtrace.c
+++ b/test/unit/backtrace.c
@@ -1,0 +1,146 @@
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#include "backtrace.h"
+#include "memory.h"
+#include "fiber.h"
+#include "unit.h"
+#include "trivia/util.h"
+
+enum {
+	BT_NAME_MAX = 64,
+	BT_ENTRIES_MAX = 32,
+	BT_RECURSE_CNT = 10,
+};
+
+struct bt_entry {
+	char name[BT_NAME_MAX];
+	void *addr;
+	size_t offset;
+};
+
+static int
+save_entry_cb(int idx, void *addr, const char *name, size_t offset,
+	      void *cb_arg)
+{
+	if (idx >= BT_ENTRIES_MAX)
+		return 1;
+
+	struct bt_entry *entry_buf = (struct bt_entry *)cb_arg;
+	entry_buf[idx].name[BT_NAME_MAX - 1] = '\0';
+	strncpy(entry_buf[idx].name, name, BT_NAME_MAX - 1);
+	entry_buf[idx].addr = addr;
+	entry_buf[idx].offset = offset;
+
+	return 0;
+}
+
+static int
+compare_entries(const struct bt_entry *lhs, const struct bt_entry *rhs)
+{
+	if (strncmp(lhs->name, rhs->name, BT_NAME_MAX) != 0)
+		return 1;
+	if (lhs->addr != NULL && rhs->addr != NULL && lhs->addr != rhs->addr)
+		return 1;
+	if (lhs->offset != 0 && rhs->offset != 0 && lhs->offset != rhs->offset)
+		return 1;
+
+	return 0;
+}
+
+static int NOINLINE
+foo(struct backtrace *bt, struct bt_entry entry_buf[])
+{
+	note("Collecting backtrace...");
+#ifdef ENABLE_BACKTRACE
+	backtrace_collect(bt, fiber());
+	backtrace_foreach_current(save_entry_cb, NULL, fiber(), entry_buf);
+#endif
+	note("ok");
+
+	return 0;
+}
+
+static int NOINLINE
+bar(struct backtrace *bt, struct bt_entry entry_buf[])
+{
+	note("Calling foo()");
+	int depth = foo(bt, entry_buf);
+
+	return 1 + depth;
+}
+
+static int NOINLINE
+baz(int n, struct backtrace *bt, struct bt_entry entry_buf[])
+{
+	int depth = 0;
+	if (n <= 0) {
+		note("Calling bar()");
+		depth = bar(bt, entry_buf);
+	} else {
+		note("Calling baz()");
+		depth = baz(n - 1, bt, entry_buf);
+	}
+
+	return 1 + depth;
+}
+
+static void
+test_equal()
+{
+	header();
+
+	struct backtrace bt;
+	struct bt_entry entry_buf_local[BT_ENTRIES_MAX];
+	struct bt_entry entry_buf_new[BT_ENTRIES_MAX];
+
+	note("Calling baz()");
+	int call_cnt = baz(BT_RECURSE_CNT, &bt, entry_buf_local);
+
+	note("Resolving entries...");
+#ifdef ENABLE_BACKTRACE
+	int entries_cnt = backtrace_foreach(&bt, save_entry_cb, NULL,
+					    entry_buf_new);
+#endif
+	note("ok");
+
+	note("Comparing entries...");
+#ifdef ENABLE_BACKTRACE
+	int frame_max = MIN(call_cnt, entries_cnt);
+	int frame_no = 0;
+	for (; frame_no + 1 < frame_max; ++frame_no) {
+		note("#%d %.*s", frame_no, BT_NAME_MAX,
+		     entry_buf_new[frame_no].name);
+		if (frame_no == 0) {
+			fail_unless(strncmp(entry_buf_new[frame_no].name, "foo",
+					    BT_NAME_MAX) == 0);
+		} else if (frame_no == 1) {
+			fail_unless(strncmp(entry_buf_new[frame_no].name, "bar",
+					    BT_NAME_MAX) == 0);
+		} else if (frame_no <= 2 + BT_RECURSE_CNT) {
+			fail_unless(strncmp(entry_buf_new[frame_no].name, "baz",
+					    BT_NAME_MAX) == 0);
+		}
+		fail_unless(compare_entries(&entry_buf_local[frame_no + 1],
+					    &entry_buf_new[frame_no + 1]) == 0);
+	}
+#endif
+	note("ok");
+
+	footer();
+}
+
+int
+main(int argc, char *argv[])
+{
+	setbuf(stdout, NULL);
+	memory_init();
+	fiber_init(fiber_c_invoke);
+	backtrace_init(NULL, NULL);
+	test_equal();
+	fiber_free();
+	memory_free();
+
+	return 0;
+}

--- a/test/unit/backtrace.result
+++ b/test/unit/backtrace.result
@@ -1,0 +1,32 @@
+	*** test_equal ***
+# Calling baz()
+# Calling baz()
+# Calling baz()
+# Calling baz()
+# Calling baz()
+# Calling baz()
+# Calling baz()
+# Calling baz()
+# Calling baz()
+# Calling baz()
+# Calling baz()
+# Calling bar()
+# Calling foo()
+# Collecting backtrace...
+# ok
+# Resolving entries...
+# ok
+# Comparing entries...
+# #0 foo
+# #1 bar
+# #2 baz
+# #3 baz
+# #4 baz
+# #5 baz
+# #6 baz
+# #7 baz
+# #8 baz
+# #9 baz
+# #10 baz
+# ok
+	*** test_equal: done ***

--- a/test/unit/backtrace_indirect.c
+++ b/test/unit/backtrace_indirect.c
@@ -1,0 +1,161 @@
+#include <libunwind.h>
+
+#include "trivia/util.h"
+#include "coro/coro.h"
+#include "unit.h"
+
+enum {
+	BACKTRACE_RIP_LIMIT = 8
+};
+
+struct data {
+	struct coro_context parent_ctx;
+	struct coro_context child_ctx;
+	int csw;
+};
+
+static void * NOINLINE
+rip_getcontext(void **rip_buf, int *rip_cnt, void *stack)
+{
+#ifndef TARGET_OS_DARWIN
+	int frame_cnt = unw_backtrace(rip_buf, BACKTRACE_RIP_LIMIT);
+	if (frame_cnt < BACKTRACE_RIP_LIMIT)
+		rip_buf[frame_cnt] = NULL;
+
+	if (rip_cnt != NULL)
+		*rip_cnt = frame_cnt;
+#else
+	unw_cursor_t unw_cur;
+	unw_context_t unw_ctx;
+	int frame_no = 0;
+	unw_word_t rip = 0;
+
+	unw_getcontext(&unw_ctx);
+	unw_init_local(&unw_cur, &unw_ctx);
+
+	rip_buf[0] = (void *)rip_getcontext;
+	for (frame_no = 1;
+	     frame_no < BACKTRACE_RIP_LIMIT && unw_step(&unw_cur) > 0;
+	     ++frame_no) {
+		unw_get_reg(&unw_cur, UNW_REG_IP, &rip);
+		rip_buf[frame_no] = (void *)rip;
+	}
+
+	if (rip_cnt != NULL)
+		*rip_cnt = frame_no;
+#endif /* TARGET_OS_DARWIN */
+
+	return stack;
+}
+
+static void NOINLINE
+foo(struct data *data)
+{
+	++data->csw;
+	coro_transfer(&data->child_ctx, &data->parent_ctx);
+	++data->csw;
+	coro_transfer(&data->child_ctx, &data->parent_ctx);
+}
+
+static void NOINLINE
+bar(struct data *data)
+{
+	foo(data);
+}
+
+static void NOINLINE
+baz(struct data *data)
+{
+	bar(data);
+}
+
+static void
+co_fnc(void *arg)
+{
+	struct data *data = arg;
+	baz(data);
+}
+
+static void
+co_backtrace(void *rip_buf[], int *rip_cnt, struct coro_context *coro_ctx)
+{
+	__asm__ volatile(
+	/* Preserve current context */
+	"\tpushq %%rbp\n"
+	"\tpushq %%rbx\n"
+	"\tpushq %%r12\n"
+	"\tpushq %%r13\n"
+	"\tpushq %%r14\n"
+	"\tpushq %%r15\n"
+	/* Set first arg */
+	"\tmovq %1, %%rdi\n"
+	/* Set second arg */
+	"\tmovq %2, %%rsi\n"
+	/* Setup third arg as old sp */
+	"\tmovq %%rsp, %%rdx\n"
+	/* Restore target context, but not increment sp to preserve it */
+	"\tmovq 0(%3), %%rsp\n"
+	"\tmovq 0(%%rsp), %%r15\n"
+	"\tmovq 8(%%rsp), %%r14\n"
+	"\tmovq 16(%%rsp), %%r13\n"
+	"\tmovq 24(%%rsp), %%r12\n"
+	"\tmovq 32(%%rsp), %%rbx\n"
+	"\tmovq 40(%%rsp), %%rbp\n"
+	"\tandq $0xfffffffffffffff0, %%rsp\n"
+	"\tleaq %P4(%%rip), %%rax\n"
+	"\tcall *%%rax\n"
+	/* Restore old sp and context */
+	"\tmov %%rax, %%rsp\n"
+	"\tpopq %%r15\n"
+	"\tpopq %%r14\n"
+	"\tpopq %%r13\n"
+	"\tpopq %%r12\n"
+	"\tpopq %%rbx\n"
+	"\tpopq %%rbp\n"
+	: "=m" (*rip_buf)
+	: "r" (rip_buf), "r" (rip_cnt), "r" (coro_ctx), "i" (rip_getcontext)
+	: "rdi", "rsi", "rdx", "rax", "memory"
+	);
+}
+
+static void
+test_unw()
+{
+	header();
+
+	const unsigned int ssze = 1 << 16;
+	struct coro_stack co_stk;
+
+	int rip_cnt = 0;
+	void *rip_buf[BACKTRACE_RIP_LIMIT];
+	struct data data;
+
+	fail_if(coro_stack_alloc(&co_stk, ssze) == 0);
+	// Empty context, used for initial coro_transfer
+	coro_create(&data.parent_ctx, NULL, NULL, NULL, 0);
+	coro_create(&data.child_ctx, co_fnc, &data, co_stk.sptr, co_stk.ssze);
+	data.csw = 0;
+
+	coro_transfer(&data.parent_ctx, &data.child_ctx);
+	fail_unless(data.csw == 1);
+
+	co_backtrace(rip_buf, &rip_cnt, &data.child_ctx);
+
+	coro_transfer(&data.parent_ctx, &data.child_ctx);
+	fail_unless(data.csw == 2);
+
+	coro_destroy(&data.parent_ctx);
+	coro_destroy(&data.child_ctx);
+	coro_stack_free(&co_stk);
+
+	footer();
+}
+
+int
+main(int argc, char* argv[])
+{
+	setbuf(stdout, NULL);
+	test_unw();
+
+	return 0;
+}

--- a/test/unit/backtrace_indirect.result
+++ b/test/unit/backtrace_indirect.result
@@ -1,0 +1,2 @@
+	*** test_unw ***
+	*** test_unw: done ***

--- a/test/unit/backtrace_rip_coro.c
+++ b/test/unit/backtrace_rip_coro.c
@@ -1,0 +1,161 @@
+#include "trivia/util.h"
+#include "coro/coro.h"
+#include "unit.h"
+
+#include <libunwind.h>
+
+#ifdef TARGET_OS_DARWIN
+#include <dlfcn.h>
+#endif
+
+enum {
+	BACKTRACE_RIP_LIMIT = 8
+};
+
+struct co_data {
+	struct coro_context *parent_ctx;
+	struct coro_context *child_ctx;
+	int rip_cnt;
+	void *rip_buf[BACKTRACE_RIP_LIMIT];
+};
+
+static int NOINLINE
+rip_getcontext(void **rip_buf, int limit)
+{
+#ifndef TARGET_OS_DARWIN
+	int frame_cnt = unw_backtrace(rip_buf, limit);
+	if (frame_cnt < limit)
+		rip_buf[frame_cnt] = NULL;
+
+	return frame_cnt;
+#else
+	unw_cursor_t unw_cur;
+	unw_context_t unw_ctx;
+	int frame_no = 0;
+	unw_word_t rip = 0;
+
+	unw_getcontext(&unw_ctx);
+	unw_init_local(&unw_cur, &unw_ctx);
+
+	if (limit > 0)
+		rip_buf[0] = (void *)rip_getcontext;
+
+	for (frame_no = 1; frame_no < limit && unw_step(&unw_cur) > 0;
+	     ++frame_no) {
+		unw_get_reg(&unw_cur, UNW_REG_IP, &rip);
+		rip_buf[frame_no] = (void *)rip;
+	}
+
+	return frame_no;
+#endif /* TARGET_OS_DARWIN */
+}
+
+static int NOINLINE
+rip_get_proc_name(void *rip, char bufp[], size_t buf_size)
+{
+#ifndef TARGET_OS_DARWIN
+	unw_accessors_t *acc = unw_get_accessors(unw_local_addr_space);
+	if (acc->get_proc_name != NULL) {
+		unw_word_t offset = 0;
+		if (acc->get_proc_name(unw_local_addr_space, (unw_word_t)rip,
+				       bufp, buf_size, &offset, NULL) != 0) {
+			diag("ERROR: get_proc_name() != 0");
+			return -1;
+		}
+	} else {
+		diag("ERROR: get_proc_name == NULL");
+		return -1;
+	}
+#else
+	Dl_info dli;
+	if (dladdr(rip, &dli) == 0) {
+		diag("ERROR: dladdr() == 0");
+		return -1;
+	}
+
+	strncpy(bufp, dli.dli_sname, buf_size);
+	bufp[buf_size - 1] = '\0';
+#endif /* TARGET_OS_DARWIN */
+
+	return 0;
+}
+
+static void NOINLINE
+foo(struct co_data *data)
+{
+	data->rip_cnt = rip_getcontext(data->rip_buf, BACKTRACE_RIP_LIMIT);
+	coro_transfer(data->child_ctx, data->parent_ctx);
+}
+
+static void NOINLINE
+bar(struct co_data *data)
+{
+	foo(data);
+}
+
+static void NOINLINE
+baz(struct co_data *data)
+{
+	bar(data);
+}
+
+static void
+co_fnc(void *arg)
+{
+	struct co_data *data = arg;
+	baz(data);
+}
+
+static void
+test_unw()
+{
+	header();
+
+	const unsigned int ssze = 1 << 16;
+	struct coro_stack co_stk;
+	struct coro_context parent_ctx;
+	struct coro_context child_ctx;
+
+	unw_context_t unw_ctx;
+	unw_cursor_t unw_cur;
+	struct co_data data = {
+		.parent_ctx = &parent_ctx,
+		.child_ctx = &child_ctx,
+		.rip_cnt = 0,
+		.rip_buf = {},
+	};
+
+	char proc_name[256];
+	unw_word_t offset = 0;
+
+	fail_if(coro_stack_alloc(&co_stk, ssze) == 0);
+	// Empty context, used for initial coro_transfer
+	coro_create(&parent_ctx, NULL, NULL, NULL, 0);
+	coro_create(&child_ctx, co_fnc, &data, co_stk.sptr, co_stk.ssze);
+	coro_transfer(&parent_ctx, &child_ctx);
+
+	// Skip the first frame corresponding to the collecting function itself
+	fail_unless(data.rip_cnt > 2);
+	fail_if(rip_get_proc_name(data.rip_buf[1], proc_name,
+				  sizeof(proc_name)) != 0);
+	note("TOP %s", proc_name);
+	fail_if(rip_get_proc_name(data.rip_buf[data.rip_cnt - 1], proc_name,
+				  sizeof(proc_name)) != 0);
+	note("BOTTOM %s", proc_name);
+
+	coro_transfer(&parent_ctx, &child_ctx);
+	coro_destroy(&parent_ctx);
+	coro_destroy(&child_ctx);
+	coro_stack_free(&co_stk);
+
+	footer();
+}
+
+int
+main(int argc, char* argv[])
+{
+	setbuf(stdout, NULL);
+	test_unw();
+
+	return 0;
+}

--- a/test/unit/backtrace_rip_coro.result
+++ b/test/unit/backtrace_rip_coro.result
@@ -1,0 +1,3 @@
+	*** test_unw ***
+# TOP foo
+# BOTTOM coro_init

--- a/test/unit/backtrace_unw_coro.c
+++ b/test/unit/backtrace_unw_coro.c
@@ -1,0 +1,92 @@
+#include <libunwind.h>
+
+#include "coro/coro.h"
+#include "unit.h"
+#include "trivia/util.h"
+
+struct co_data {
+	struct coro_context *parent_ctx;
+	struct coro_context *child_ctx;
+	unw_context_t *unw_ctx;
+};
+
+static void NOINLINE
+foo(struct co_data *data)
+{
+	unw_getcontext(data->unw_ctx);
+	coro_transfer(data->child_ctx, data->parent_ctx);
+}
+
+static void NOINLINE
+bar(struct co_data *data)
+{
+	foo(data);
+}
+
+static void NOINLINE
+baz(struct co_data *data)
+{
+	bar(data);
+}
+
+static void
+co_fnc(void *arg)
+{
+	struct co_data *data = arg;
+	baz(data);
+}
+
+static void
+test_unw()
+{
+	header();
+
+	const unsigned int ssze = 1 << 16;
+	struct coro_stack co_stk;
+	struct coro_context parent_ctx;
+	struct coro_context child_ctx;
+
+	unw_context_t unw_ctx;
+	unw_cursor_t unw_cur;
+	struct co_data data = {
+		.parent_ctx = &parent_ctx,
+		.child_ctx = &child_ctx,
+		.unw_ctx = &unw_ctx,
+	};
+
+	char proc_name[256];
+	unw_word_t offset = 0;
+
+	fail_if(coro_stack_alloc(&co_stk, ssze) == 0);
+	// Empty context, used for initial coro_transfer
+	coro_create(&parent_ctx, NULL, NULL, NULL, 0);
+	coro_create(&child_ctx, co_fnc, &data, co_stk.sptr, co_stk.ssze);
+	coro_transfer(&parent_ctx, &child_ctx);
+
+	unw_init_local(&unw_cur, &unw_ctx);
+	fail_if(unw_get_proc_name(&unw_cur, proc_name,
+				  sizeof(proc_name), &offset) != 0);
+	note("TOP %s", proc_name);
+	while (unw_step(&unw_cur) > 0) {
+		// `proc_name` and `offset` may differ under different systems.
+		fail_if(unw_get_proc_name(&unw_cur, proc_name,
+					  sizeof(proc_name), &offset) != 0);
+	}
+	note("BOTTOM %s", proc_name);
+
+	coro_transfer(&parent_ctx, &child_ctx);
+	coro_destroy(&parent_ctx);
+	coro_destroy(&child_ctx);
+	coro_stack_free(&co_stk);
+
+	footer();
+}
+
+int
+main(int argc, char* argv[])
+{
+	setbuf(stdout, NULL);
+	test_unw();
+
+	return 0;
+}

--- a/test/unit/backtrace_unw_coro.result
+++ b/test/unit/backtrace_unw_coro.result
@@ -1,0 +1,3 @@
+	*** test_unw ***
+# TOP foo
+# BOTTOM coro_init


### PR DESCRIPTION
This patch introduces the backtrace of fiber creation stored in `backtrace_parent` subtable in `fiber.info()`.

Lua stack chunks are collected after each fiber creation, C stack chunks are collected at the time of fiber creation and resolved on demand.
`fiber.parent_bt_enable()` and `fiber.parent_bt_disable()` functions turn on and off the ability to collect fiber creation backtraces.
When enabled this feature results in approximately 1.4 times increase in fiber creation time.
Creation backtraces of fibers created while the feature flag was off can never be obtained.

Closes #4002