### PR TITLE
vinyl: fix adding the same tx twice to the list of writers

### DIFF
--- a/src/box/vy_tx.c
+++ b/src/box/vy_tx.c
@@ -893,6 +893,12 @@ vy_tx_begin_statement(struct vy_tx *tx, struct space *space, void **savepoint)
 	 * When want to add to the writer list, can't rely on the log emptiness.
 	 * During recovery it is empty always for the data stored both in runs
 	 * and xlogs. Must check the list member explicitly.
+	 *
+	 * Apart from that, we may add to writers statement which in fact
+	 * don't get into tx log. Imagine first-in-tx update by non-existent
+	 * key: tx will get into xm->writers, but won't to tx log. The next
+	 * operation will lead to adding the same entry of tx to xm->writers,
+	 * which in turn will break rlist.
 	 */
 	if (rlist_empty(&tx->in_writers)) {
 		assert(stailq_empty(&tx->log));

--- a/src/box/vy_tx.c
+++ b/src/box/vy_tx.c
@@ -889,8 +889,15 @@ vy_tx_begin_statement(struct vy_tx *tx, struct space *space, void **savepoint)
 	}
 	assert(tx->state == VINYL_TX_READY);
 	tx->last_stmt_space = space;
-	if (stailq_empty(&tx->log))
+	/*
+	 * When want to add to the writer list, can't rely on the log emptiness.
+	 * During recovery it is empty always for the data stored both in runs
+	 * and xlogs. Must check the list member explicitly.
+	 */
+	if (rlist_empty(&tx->in_writers)) {
+		assert(stailq_empty(&tx->log));
 		rlist_add_entry(&tx->xm->writers, tx, in_writers);
+	}
 	*savepoint = stailq_last(&tx->log);
 	return 0;
 }

--- a/test/vinyl/gh-5934-dupicate-tx-writers.result
+++ b/test/vinyl/gh-5934-dupicate-tx-writers.result
@@ -1,0 +1,47 @@
+-- test-run result file version 2
+-- In this test we are attempting at simulating following scenario:
+-- inside transaction execute such first operation which won't get into
+-- tx log, but will get into tx writers list. Verify that the next operation
+-- in the same transaction won't be added to tx writers list again (otherwise
+-- it will break writers list itself since it doesn't tolerate adding the
+-- same entry twice). As verification of writers list integrity we switch
+-- read_only mode which assumes iteration over mentioned list.
+--
+format = {{name = "k", type = "unsigned"}, {name = "v", type = "unsigned"}}
+ | ---
+ | ...
+space = box.schema.space.create("t", {engine="vinyl", format=format})
+ | ---
+ | ...
+
+_ = space:create_index('k', { parts = { 'k' }, unique = true })
+ | ---
+ | ...
+-- Execute update operation by non-exitent key as first statement in tx.
+--
+box.begin()
+ | ---
+ | ...
+space:update(1, { { '+', 2, 1 } })
+ | ---
+ | ...
+space:insert{1, 1 }
+ | ---
+ | - [1, 1]
+ | ...
+box.commit()
+ | ---
+ | ...
+box.cfg({read_only=true})
+ | ---
+ | ...
+box.cfg({read_only=false})
+ | ---
+ | ...
+assert(box.cfg.read_only == false)
+ | ---
+ | - true
+ | ...
+space:drop()
+ | ---
+ | ...

--- a/test/vinyl/gh-5934-dupicate-tx-writers.test.lua
+++ b/test/vinyl/gh-5934-dupicate-tx-writers.test.lua
@@ -1,0 +1,22 @@
+-- In this test we are attempting at simulating following scenario:
+-- inside transaction execute such first operation which won't get into
+-- tx log, but will get into tx writers list. Verify that the next operation
+-- in the same transaction won't be added to tx writers list again (otherwise
+-- it will break writers list itself since it doesn't tolerate adding the
+-- same entry twice). As verification of writers list integrity we switch
+-- read_only mode which assumes iteration over mentioned list.
+--
+format = {{name = "k", type = "unsigned"}, {name = "v", type = "unsigned"}}
+space = box.schema.space.create("t", {engine="vinyl", format=format})
+
+_ = space:create_index('k', { parts = { 'k' }, unique = true })
+-- Execute update operation by non-exitent key as first statement in tx.
+--
+box.begin()
+space:update(1, { { '+', 2, 1 } })
+space:insert{1, 1 }
+box.commit()
+box.cfg({read_only=true})
+box.cfg({read_only=false})
+assert(box.cfg.read_only == false)
+space:drop()


### PR DESCRIPTION
Subj. Turns out that commit (59fed2d1d567c5d49d09d006777261ede34f8e6c) in master already fixes this problem. So let's simply cherry-pick it and add corresponding test.

Test case can be also cherry-picked to master branch.

Closes #5934