### PR TITLE
test: unblock tests from fragile list after fix with Tarantool server restart

### DIFF
--- a/test/box/suite.ini
+++ b/test/box/suite.ini
@@ -29,9 +29,6 @@ fragile = {
         "tree_pk.test.lua": {
             "issues": [ "gh-4882" ]
         },
-        "alter_limits.test.lua": {
-            "issues": [ "gh-4926" ]
-        },
         "misc.test.lua": {
             "issues": [ "gh-4982" ],
             "checksums": [ "851dcc5dfd0cc77456ce1d9e6ec7d38f" ]
@@ -161,10 +158,6 @@ fragile = {
             "issues": [ "gh-5546" ],
             "checksums": [ "6379f11bde87b463059911b670a29906" ]
         },
-        "net.box_schema_change_gh-2666.test.lua": {
-            "issues": [ "gh-5547" ],
-            "checksums": [ "193c3e139deb808a93f8f62a7ce96d28" ]
-        },
         "net.box_iproto_hangs_gh-3464.test.lua": {
             "issues": [ "gh-5548" ],
             "checksums": [ "78e53d88a92708766af55557fc5889b2" ]
@@ -268,10 +261,6 @@ fragile = {
         "tx_man.test.lua": {
             "issues": [ "gh-5579" ],
             "checksums": [ "72a91771dd0a3e4a1a4052f61e4b72e9" ]
-        },
-        "net.box_methods_gh-3107.test.lua": {
-            "issues": [ "gh-5583" ],
-            "checksums": [ "9e5c778bd463ac88d2d51e428c9de427" ]
         }
     }
   }

--- a/test/engine/suite.ini
+++ b/test/engine/suite.ini
@@ -12,10 +12,6 @@ is_parallel = True
 fragile = {
     "retries": 10,
     "tests": {
-        "ddl.test.lua": {
-            "issues": [ "gh-4353" ],
-            "checksums": [ "c04fa9a0fae1bb63a86a5304f7679245", "f2e895cb6be3cd2d1c059b9c4b35e256", "0498012b878a6c638687a0b5de6e2090", "fc6d3bcd8d2d745d9dd34245b18186f1", "d54ee830446114bbe9d8fec8ac68be90" ]
-        },
         "gh-4973-concurrent-alter-fails.test.lua": {
             "issues": [ "gh-5157" ],
             "checksums": [ "4e797e63335cebe24dab15eae4aa8044" ]

--- a/test/vinyl/suite.ini
+++ b/test/vinyl/suite.ini
@@ -18,10 +18,6 @@ fragile = {
             "issues": [ "gh-4309" ],
             "checksums": [ "99dbd33845b40f5399a657fe40abe826", "3d2799ef503feb6f6f636b93187d4dee", "d41d8cd98f00b204e9800998ecf8427e", "0fd6dc0786e45067fae536db3520bbd6", "fa6c5df32c6cf6a355f654950a0cbe0d" ]
         },
-        "errinj.test.lua": {
-            "issues": [ "gh-4346" ],
-            "checksums": [ "51f3c3d4342faf442c6016cfad336a28", "9cd059c3ef67a1b0dd708b5fdfa9e90d", "f0be3af36d88891db5cdc3870e4a3599", "3bed1492ffbbd9e6629c9a1c224741e6", "0b82bad84abf90de22271e5f15563e73", "ddf44f2fac43b20102b32ce91dc204d5" ]
-        },
         "select_consistency.test.lua": {
             "issues": [ "gh-4385" ],
             "checksums": [ "ea50883a8a5372d492644efa917650b7" ]
@@ -33,18 +29,6 @@ fragile = {
             "issues": [ "gh-4951" ],
             "checksums": [ "5db4cf9154310dc41303ff68fb413252", "15315a27520db81ce03b396025f21f7a", "cbb6a968f77083a691bd454db2f93871", "9db031967cbed3af665cb5f077d03b66", "0a9f809784f64bb638b3a047237777a1", "0c8c1c8fe2210cef9e2a1292314eeab2" ]
         },
-        "misc.test.lua": {
-            "issues": [ "gh-4979" ],
-            "checksums": [ "213ca1e79ef1ddedb9a6e9fe12db4cae", "4add3fda05ca6fcc488de40de4671cc0", "ef25d25dd71a518ea2fe1b0bfefd1d6a" ]
-        },
-        "snapshot.test.lua": {
-            "issues": [ "gh-4984" ],
-            "checksums": [ "a221e2583ccef2ec884b945bbbba106e", "2caa0a1c7f07b57a1ad784688b8dff40", "ee936b3dc787e39de15ad33e00b77051", "1774c0acc1f7f3705c2a40ca84816b9c", "b67f70ec51647b7c22c61ff97483316e", "d5885e4b35e9ca16187d7ffed109c061", "f3feb722cafea4054e7df3572ad94494", "f1d554ab5380696cd4e0d417cf4968f9", "5456244e7fe6bea4d0531266bc025026", "45108d1764f134d078a918572490b06b", "e6d7cb322c304e4522eb70619ba017e0", "56d409a1bbf5b5b612fb34742fd4eecc", "67ca0a848e3e0f3c213e9c9e74514dc1", "6ed4404b0b827a62443bfdf08fc4d9b9", "78f613d5ee8bd9774db6e1068f113afd", "af2a26ac92c3577a3d510b10ad8a3abf" ]
-        },
-        "write_iterator.test.lua": {
-            "issues": [ "gh-4572" ],
-            "checksums": [ "c46465b7d20debacfac904862a34fe35", "d981c4409ac22109befbabc477e9e0bc", "997e17a9abf36da668446f4742717e8c", "e7fddd3adc8f3b43b55764369602da9d", "552c5b4286fde5e8ce45cf0e8ff203e2", "f670fea9df4babf7999a8e855da75d86", "d5c9d872b9fed01f913d57b00d12dba6", "a2e54008ded9cbb965b16152b0ab8eb3", "7480103359e0d0498cc3bf0884c7e161", "d939da813a74fe8a2639430b71571a52", "99f7c868558158de5dcca1fbd13f3176", "92e0bd7e89ca3a24b0cd53c619aae5b0", "4d8f449dd4a12428bd20a7ca1c1a92bf", "00d1c8d10e9355c2d58669386ba1496a", "c9e66ada1a93b4483fe87bbfed72bc8f", "b104f84ed046e1922679fd9b31a26202", "7d97b83d0c0f354200582b97b852aa70", "17e45b88af7c3a9f07b4dd6a83f22503", "5df1b6597f42a044d68fa98e81ad5f53", "c11c1aabc3473caeecacc3c7201cb13a", "53a0c664bdd6eb122b0d254e380b6d36", "56744b51bd17c8e8faf4578e96d41bff", "f98e6affd5b4da90f04b053cdf1471b8", "a501f0c454e6140237e02a890351bf53", "040b9cba816bcdc00b77dcb2f2b79899", "a42053977e2ce96fd7a1d650e7a6a4ec", "cec850d66c24803524d3c1b49d8c3cd9", "5195a1cffa0083e8fcfccc957512605e", "39af136bb3d1c23aa1b3eb00590012cb", "4682cb046c39df3bd907601fc327ba89", "809496572b88b03258b0a91c922221ab", "337dfdc9251a5f0e46f90a06560cb9b1", "6f62b12a79eb99159107518b542d826a", "f4834d8eb9c300136a74f7a8bf43b4a0", "43ab12974e3d5e6b8b488ed488dc7a39", "1309f9ffc3f381d413a9baab0d873f12" ]
-        },
         "errinj_ddl.test.lua": {
             "issues": [ "gh-4993" ],
             "checksums": [ "64cc53b41f5a6ee281bce71212741277", "3254a8d1a983fa7c0f166692e078a7cb", "f0c445d28517206a3af2b69ca94e8d25" ]
@@ -55,15 +39,11 @@ fragile = {
         },
         "deferred_delete.test.lua": {
             "issues": [ "gh-5089" ],
-            "checksums": [ "f6d6c5aed699b65c9e9eb1ad068578d2", "dbd3d6e852b2db785b3222c30e1f6f9c", "f56467141ef34c20c16ef86ca4124c47", "a64091902c05801d2a380729520c4c64" ]
+            "checksums": [ "f56467141ef34c20c16ef86ca4124c47" ]
         },
         "gh-5141-invalid-vylog-file.test.lua": {
-            "issues": [ "gh-5141" ],
-            "checksums": [ "1f4d4261fc63291c4020372986c62e2e", "7e103822262602a7fba4f8f3f6ffb6b7", "09279dacc8c3f96d86de37481774f5f6" ]
-        },
-        "iterator.test.lua": {
-            "issues": [ "gh-5336" ],
-            "checksums": [ "f56d6d279692e46d84a06f470af0090d", "a8a2824fb09380330a70a589d4fc545e", "e03548bcb918e824c349dc4c52ae3715", "adbd4ad9878302d570e40aef9a6b92cc", "39ee43ee7b2004166ca54402dfe02238", "098b00f3162651cfb5e6286bdfcae534" , "a932fc47ba696a3ba822066a8c955c59", "244613bd18d5a44bfe73c20f431145d3", "30475ade20385ec1b1cbbc4fb434a4cc" ]
+            "issues": [ "gh-5436" ],
+            "checksums": [ "1f4d4261fc63291c4020372986c62e2e", "7e103822262602a7fba4f8f3f6ffb6b7", "09279dacc8c3f96d86de37481774f5f6", "fe3f1d93e9e67478cfa3a9c0ce4504f1" ]
         },
         "ddl.test.lua": {
             "issues": [ "gh-5338" ],
@@ -73,29 +53,9 @@ fragile = {
             "issues": [ "gh-5197" ],
             "checksums": [ "82156b1f64522ca82685c56e4803a3f7", "6ab639ce38b94231c6f0be9a8380d2ff", "af815eb253434134bfc96ded9b501e78", "36dfb19d83fd9c9926294edc4c37a702", "a43c82084a09f98b80ffa6181996705d", "58f9724327a3c990f8caabb835ed6466", "f1f110ce67a7bdc3a42bf7223f067d7b", "49c8a8de85ad4086a5837904ba910df4", "026c7664d0022e3d0f92d918e422ee44", "c2ffda73f76b16d97985dd0edeabaeed", "a83d8875c40c56b263dd6aef3e0f0c9d" ]
         },
-        "write_iterator_rand.test.lua": {
-            "issues": [ "gh-5356" ],
-            "checksums": [ "2dd52fed642b0132ccef3853ad96a807", "f670fea9df4babf7999a8e855da75d86", "f3b6fb7bd4c3b907efd1bdc023c0dd76", "0a2809f2e6646228c183c014467a7907", "bcc1a3902c0acf429cf4cd772e824126" ]
-        },
-        "quota.test.lua": {
-            "issues": [ "gh-5377" ],
-            "checksums": [ "6b023a67afd5e3df09a684eaac91dcaa" ]
-        },
-        "gh-4957-too-many-upserts.test.lua": {
-            "issues": [ "gh-5378" ],
-            "checksums": [ "56826ed479bf2ce7613fc56533c93c9a", "b6621dc64afd1f71f66d7c2b22f4e320", "97312b89bc0097eb3b9a203df71e8358", "fe3f1d93e9e67478cfa3a9c0ce4504f1", "1cf21302db0e462f42fea19cbcfb3d6a", "fb4fa06c3239eabf8321946ff0a107d7", "5930e07d39e76cedb70e558089c90e8a", "57f9fea345b44933e4e155020e25e0a1", "9f78ce781453864fbb6283ca4859aec6" ]
-        },
-        "gc.test.lua": {
-            "issues": [ "gh-5383" ],
-            "checksums": [ "9dd6709144f9de95427619537659f41a", "c767230073d3ae93105ff2d502646165", "d93e0d2ddedb497f4f4bf09e2dc35a82", "bcd4d4008241c7cb059f70f493a72522", "44ae1834d1b1f009fa267eb65ecb1140", "adb9957967535296500080e364ebb4ec", "a4a91afc827fad96aead8e4dbdfc2087" ]
-        },
         "upsert.test.lua": {
             "issues": [ "gh-5398" ],
-            "checksums": [ "753255681b39a0f31e4ab4af0d694ec3", "17c147f920425be52060791da1aaff5c", "3c6aeec7448c6bbedd66e9d7dd8cb7b9", "a4145512c15a33b78d2c11b8bf719b33" ]
-        },
-        "gh-4864-stmt-alloc-fail-compact.test.lua": {
-            "issues": [ "gh-5408" ],
-            "checksums": [ "8394c05bb5aaa8a542237c44f19b04d4", "2f836e3bfeaab82657acab0d3ab62c39", "358e1757855343112a93d545f1b2b7ff" ]
+            "checksums": [ "753255681b39a0f31e4ab4af0d694ec3", "17c147f920425be52060791da1aaff5c", "3c6aeec7448c6bbedd66e9d7dd8cb7b9", "a4145512c15a33b78d2c11b8bf719b33", "5d3dc7d85f9d0d9ccbc1eed5f9f525ae" ]
         },
         "replica_rejoin.test.lua": {
             "issues": [ "gh-4985" ],
@@ -104,13 +64,6 @@ fragile = {
         "errinj_tx.test.lua": {
             "issues": [ "gh-5539" ],
             "checksums": [ "0f9de3eaa09260df452704d431a174b9" ]
-        },
-        "update_optimize.test.lua": {
-            "issues": [ "gh-5586" ]
-        },
-        "replica_quota.test.lua": {
-            "issues": [ "gh-5584" ],
-            "checksums": [ "558d38d56f0b9ed2bb6fa815a6930a95", "ea868a70342c648a0085c5412c60cac1" ]
         }
     }
   }


### PR DESCRIPTION
1.     test: remove fixed tests from fragile lists
    
    Checked and found that:
    
      #4353 -> tarantool/tarantool-qa#13:
        engine/ddl.test.lua fixed in #6102.
      #4926, tarantool/tarantool#115:
        box/alter_limits.test.lua fixed in
        tarantool/tarantool-qa#126.
      #5547 -> tarantool/tarantool-qa#50:
        box/net.box_schema_change_gh-2666.test.lua fixed in
        tarantool/tarantool-qa#126.
      #5583 -> tarantool/tarantool-qa#22:
        box/net.box_methods_gh-3107.test.lua fixed in
        tarantool/tarantool-qa#126.
    
    Closes tarantool/tarantool-qa#13
    Closes tarantool/tarantool-qa#115
    Closes #4926
    Closes tarantool/tarantool-qa#50
    Closes tarantool/tarantool-qa#22

2. test: unblock vinyl tests from fragile list
    
    Found that the root cause of the issues happened with vinyl tests were
    backside effects of the not correct test 'vinyl/gh.test.lua' which
    leaved Tarantool worker process in inconsistent state. After it any
    other next test on the same Tarantool worker process could fail on
    running testings with snapshots calls, like tarantool/tarantool-qa#126:
    ```
      error: Snapshot is already in progress
    ```
    Either restarting Tarantool worker process could fail on stopping it,
    like tarantool/test-run#261 and #5141:
    ```
      E> failed to process vylog record: delete_slice{slice_id=115, }
      E> ER_INVALID_VYLOG_FILE: Invalid VYLOG file: Slice 115 deleted but not registered
    ```
    Decided to remove all vinyl tests from 'fragile' list except test
    'gh.test.lua', which should be improved before, to be able to run it
    with the other tests. And 'gh-5141-invalid-vylog-file.test.lua' test
    which checks this issue and can be removed after the fix will be done.
    
    The following issues were moved to tarantool/tarantool-qa repository:
      #4346 -> tarantool/tarantool-qa#11
      #5408 -> tarantool/tarantool-qa#73
      #5584 -> tarantool/tarantool-qa#21
      #5586 -> tarantool/tarantool-qa#19
    
    Part of tarantool/tarantool-qa#97
    Closes tarantool/tarantool-qa#11
    Closes #4572
    Closes #4979
    Closes #4984
    Closes #5336
    Closes #5356
    Closes #5377
    Closes #5378
    Closes #5383
    Closes tarantool/tarantool-qa#73
    Closes tarantool/tarantool-qa#21
    Closes tarantool/tarantool-qa#19
