### PR TITLE
test: fix status check in replication/transaction

### DIFF
--- a/test/replication/suite.ini
+++ b/test/replication/suite.ini
@@ -35,7 +35,7 @@ fragile = {
             "checksums": [ "1bf966198e1521a8a230d9f53e244056", "251df1dfcab4a19508cbe4c3333c9bc6", "2fedbbfc8267f2aa1321683a23534bbb", "0b509192767a75639582e68efa9c4ac4", "4a0fff059cbb7ea097e0ee920c266950", "f1a824f43436d1c0117577ba2932a970", "29a67ed6320e1d7887198ea8b7f47817", "aa7e32bcf0b4ffaffab9c87b7507b544", "ff211f29d3153ebdca518545e992b635", "f6b4e9b5c4c4f4d59ddea45a9c4ae76e", "1a5a388f933995a664c670c259e40fa8" ]
         },
         "transaction.test.lua": {
-            "issues": [ "gh-4312", "gh-5331", "gh-5563" ],
+            "issues": [ "gh-4312", "gh-5331" ],
             "checksums": [ "302cbcfde971bc8cb65b059165509d20", "a488d1f66d4d0325c28746db77cf5e17", "7072465a0fc9453a128eb343f91b0688", "b5461bb005c14823fbb80e75977bdc67", "7ca7041a32330f3a6152b3eb4049cd9c", "962c3e79f44fd28f3b59c0846b298789", "73f992a886de2f4bef751bd6bfef1b56", "15aa1572d24151434b3a1bfcf5549b72", "727a033eb0b837a2e89e4d43f83ac5c3", "a68cbc7ea7e8414d140dae4390d90e11" ]
         },
         "autobootstrap.test.lua": {

--- a/test/replication/transaction.result
+++ b/test/replication/transaction.result
@@ -234,9 +234,9 @@ box.space.test:select()
   - [8, 'r']
   - [9, 'r']
 ...
-box.info.replication[1].upstream.status
+test_run:wait_upstream(1, {status = 'follow'})
 ---
-- follow
+- true
 ...
 test_run:cmd("switch default")
 ---

--- a/test/replication/transaction.test.lua
+++ b/test/replication/transaction.test.lua
@@ -81,7 +81,7 @@ test_run:cmd("restart server replica")
 test_run:cmd("switch replica")
 
 box.space.test:select()
-box.info.replication[1].upstream.status
+test_run:wait_upstream(1, {status = 'follow'})
 
 test_run:cmd("switch default")
 test_run:cmd("stop server replica")


### PR DESCRIPTION
On heavy loaded hosts found the following issue:

  [046] --- replication/transaction.result	Wed Sep 30 17:19:32 2020
  [046] +++ /tmp/tnt/rejects/replication/transaction.reject	Tue Nov 24 04:39:29 2020
  [046] @@ -234,7 +234,7 @@
  [046]  ...
  [046]  box.info.replication[1].upstream.status
  [046]  ---
  [046] -- follow
  [046] +- disconnected
  [046]  ...
  [046]  test_run:cmd("switch default")
  [046]  ---
  [046]

It happened because box.cfg was not ready to provide information. In
real there is no need to use local check for replication information
parts availablity, due to wait_upstream() function used below, do it
itself.

Closes #5563