### PR TITLE
txm: fix a crash in rollback when the space was deleted

### DIFF
--- a/src/box/memtx_engine.c
+++ b/src/box/memtx_engine.c
@@ -409,6 +409,10 @@ memtx_engine_rollback_statement(struct engine *engine, struct txn *txn,
 	if (stmt->old_tuple == NULL && stmt->new_tuple == NULL)
 		return;
 	struct space *space = stmt->space;
+	if (space == NULL) {
+		/* The space was deleted. Nothing to rollback. */
+		return;
+	}
 	struct memtx_space *memtx_space = (struct memtx_space *)space;
 	uint32_t index_count;
 

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -62,6 +62,7 @@ enum { MEMTX_DDL_YIELD_LOOPS = 10 };
 static void
 memtx_space_destroy(struct space *space)
 {
+	TRASH(space);
 	free(space);
 }
 

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1594,6 +1594,7 @@ memtx_tx_on_space_delete(struct space *space)
 		memtx_tx_story_full_unlink(story);
 		if (story->add_stmt != NULL) {
 			story->add_stmt->add_story = NULL;
+			story->add_stmt->space = NULL;
 			story->add_stmt = NULL;
 		}
 		while (story->del_stmt != NULL) {
@@ -1601,6 +1602,7 @@ memtx_tx_on_space_delete(struct space *space)
 			stmt->del_story = NULL;
 			story->del_stmt = stmt->next_in_del_list;
 			stmt->next_in_del_list = NULL;
+			stmt->space = NULL;
 		}
 		memtx_tx_story_delete(story);
 	}

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -640,6 +640,7 @@ vinyl_engine_create_space(struct engine *engine, struct space_def *def,
 static void
 vinyl_space_destroy(struct space *space)
 {
+	TRASH(space);
 	free(space);
 }
 

--- a/test/box/tx_man.result
+++ b/test/box/tx_man.result
@@ -2033,6 +2033,33 @@ s:drop()
  | ---
  | ...
 
+-- https://github.com/tarantool/tarantool/issues/6140
+s3 = box.schema.space.create('test3')
+ | ---
+ | ...
+i31 = s3:create_index('pk', {parts={{1, 'uint'}}})
+ | ---
+ | ...
+tx1:begin()
+ | ---
+ | - 
+ | ...
+tx1('s3:replace{2}')
+ | ---
+ | - - [2]
+ | ...
+tx1('s3:select{}')
+ | ---
+ | - - [[2]]
+ | ...
+s3:drop()
+ | ---
+ | ...
+tx1:rollback()
+ | ---
+ | - 
+ | ...
+
 -- gh-6095: SQL query may crash in MVCC mode if it involves ephemeral spaces.
 --
 box.execute([[ CREATE TABLE test (id INT NOT NULL PRIMARY KEY, count INT NOT NULL)]])

--- a/test/box/tx_man.test.lua
+++ b/test/box/tx_man.test.lua
@@ -626,6 +626,15 @@ tx1:commit()
 
 s:drop()
 
+-- https://github.com/tarantool/tarantool/issues/6140
+s3 = box.schema.space.create('test3')
+i31 = s3:create_index('pk', {parts={{1, 'uint'}}})
+tx1:begin()
+tx1('s3:replace{2}')
+tx1('s3:select{}')
+s3:drop()
+tx1:rollback()
+
 -- gh-6095: SQL query may crash in MVCC mode if it involves ephemeral spaces.
 --
 box.execute([[ CREATE TABLE test (id INT NOT NULL PRIMARY KEY, count INT NOT NULL)]])


### PR DESCRIPTION
With MVCC a case may happen:
TX1 does something with some space and yields.
TX2 deletes the space and commits.
TX1 rolls back.

The problem was that TX1 does something with already deleted space.
This commit fixes that.

Part of #6140

After merge the issue must remain open