### PR TITLE
txm: fix a crash in conflict collection

### DIFF
--- a/changelogs/unreleased/gh-6131-fix-crash-update-conflict.md
+++ b/changelogs/unreleased/gh-6131-fix-crash-update-conflict.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fixed a crash in MVCC during simultaneous update of a key in different transactions (gh-6131)

--- a/test/box/tx_man.result
+++ b/test/box/tx_man.result
@@ -1992,6 +1992,43 @@ tx1:commit()
  | - - {'error': 'Transaction has been aborted by conflict'}
  | ...
 
+-- https://github.com/tarantool/tarantool/issues/6131
+s:truncate()
+ | ---
+ | ...
+s:replace{1, 1}
+ | ---
+ | - [1, 1]
+ | ...
+tx1:begin()
+ | ---
+ | - 
+ | ...
+tx2:begin()
+ | ---
+ | - 
+ | ...
+tx1('s:select{1}')
+ | ---
+ | - - [[1, 1]]
+ | ...
+tx2("s:update({1}, {{'=', 2, 2}})")
+ | ---
+ | - - [1, 2]
+ | ...
+tx2:commit()
+ | ---
+ | - 
+ | ...
+tx1("s:update({1}, {{'=', 2, 3}})")
+ | ---
+ | - - [1, 3]
+ | ...
+tx1:commit()
+ | ---
+ | - - {'error': 'Transaction has been aborted by conflict'}
+ | ...
+
 s:drop()
  | ---
  | ...

--- a/test/box/tx_man.test.lua
+++ b/test/box/tx_man.test.lua
@@ -613,6 +613,17 @@ tx2('s:replace{1, 2}')
 tx2:commit()
 tx1:commit()
 
+-- https://github.com/tarantool/tarantool/issues/6131
+s:truncate()
+s:replace{1, 1}
+tx1:begin()
+tx2:begin()
+tx1('s:select{1}')
+tx2("s:update({1}, {{'=', 2, 2}})")
+tx2:commit()
+tx1("s:update({1}, {{'=', 2, 3}})")
+tx1:commit()
+
 s:drop()
 
 -- gh-6095: SQL query may crash in MVCC mode if it involves ephemeral spaces.


### PR DESCRIPTION
The problem was in case when mvcc engine was enabled and a transaction
that was sent to read view due to conflict was trying to read a key that
was the cause of the conflict.

Closes #6131