### PR TITLE
test: flaky election_basic.test.lua test

### DIFF
--- a/test/replication/election_basic.result
+++ b/test/replication/election_basic.result
@@ -127,20 +127,29 @@ test_run:create_cluster(SERVERS, "replication")
 test_run:wait_fullmesh(SERVERS)
  | ---
  | ...
+is_r1_leader = nil
+ | ---
+ | ...
+is_r2_leader = nil
+ | ---
+ | ...
+is_r3_leader = nil
+ | ---
+ | ...
 is_leader_cmd = 'return box.info.election.state == \'leader\''
  | ---
  | ...
 leader_id_cmd = 'return box.info.election.leader'
  | ---
  | ...
-is_r1_leader = test_run:eval('election_replica1', is_leader_cmd)[1]
+test_run:wait_cond(function()                                                   \
+    is_r1_leader = test_run:eval('election_replica1', is_leader_cmd)[1]         \
+    is_r2_leader = test_run:eval('election_replica2', is_leader_cmd)[1]         \
+    is_r3_leader = test_run:eval('election_replica3', is_leader_cmd)[1]         \
+    return is_r1_leader or is_r2_leader or is_r3_leader                         \
+end)
  | ---
- | ...
-is_r2_leader = test_run:eval('election_replica2', is_leader_cmd)[1]
- | ---
- | ...
-is_r3_leader = test_run:eval('election_replica3', is_leader_cmd)[1]
- | ---
+ | - true
  | ...
 leader_count = is_r1_leader and 1 or 0
  | ---
@@ -198,7 +207,7 @@ elseif is_r2_leader then                                                        
     leader_name = 'election_replica2'                                           \
     nonleader1_name = 'election_replica1'                                       \
     nonleader2_name = 'election_replica3'                                       \
-else                                                                            \
+elseif is_r3_leader then                                                        \
     leader_name = 'election_replica3'                                           \
     nonleader1_name = 'election_replica1'                                       \
     nonleader2_name = 'election_replica2'                                       \

--- a/test/replication/election_basic.test.lua
+++ b/test/replication/election_basic.test.lua
@@ -50,11 +50,17 @@ box.cfg{                                                                        
 SERVERS = {'election_replica1', 'election_replica2', 'election_replica3'}
 test_run:create_cluster(SERVERS, "replication")
 test_run:wait_fullmesh(SERVERS)
+is_r1_leader = nil
+is_r2_leader = nil
+is_r3_leader = nil
 is_leader_cmd = 'return box.info.election.state == \'leader\''
 leader_id_cmd = 'return box.info.election.leader'
-is_r1_leader = test_run:eval('election_replica1', is_leader_cmd)[1]
-is_r2_leader = test_run:eval('election_replica2', is_leader_cmd)[1]
-is_r3_leader = test_run:eval('election_replica3', is_leader_cmd)[1]
+test_run:wait_cond(function()                                                   \
+    is_r1_leader = test_run:eval('election_replica1', is_leader_cmd)[1]         \
+    is_r2_leader = test_run:eval('election_replica2', is_leader_cmd)[1]         \
+    is_r3_leader = test_run:eval('election_replica3', is_leader_cmd)[1]         \
+    return is_r1_leader or is_r2_leader or is_r3_leader                         \
+end)
 leader_count = is_r1_leader and 1 or 0
 leader_count = leader_count + (is_r2_leader and 1 or 0)
 leader_count = leader_count + (is_r3_leader and 1 or 0)
@@ -81,7 +87,7 @@ elseif is_r2_leader then                                                        
     leader_name = 'election_replica2'                                           \
     nonleader1_name = 'election_replica1'                                       \
     nonleader2_name = 'election_replica3'                                       \
-else                                                                            \
+elseif is_r3_leader then                                                        \
     leader_name = 'election_replica3'                                           \
     nonleader1_name = 'election_replica1'                                       \
     nonleader2_name = 'election_replica2'                                       \

--- a/test/replication/suite.ini
+++ b/test/replication/suite.ini
@@ -106,10 +106,6 @@ fragile = {
             "issues": [ "gh-5366" ],
             "checksums": [ "4a7286b7141c6a15556990ead3bf26b0" ]
         },
-        "election_basic.test.lua": {
-            "issues": [ "gh-5368" ],
-            "checksums": [ "9c27e4fbc1acfb49f3bd1ab05423bf72", "69d75832017bb140887fd9c7b1d43cf1", "42ff9f71a7ad2de4b379ec61707b0761", "2870483307db27542796a3b2cf76a9f1", "b47d6b13798ba8357f67785c51e190ba", "25ff2ebf99ea05aa4373a251d295234a", "db9218e6901ad1c3f8ed57304885ba56", "85bb11402cb3e6df2d24900307fe5cb8", "18af1ce1a70e295d717294b876a0773c", "081266c856ca3770e6a2ae24f00c6081", "227dd89bb54fa0727d3c2feda21f7e10", "aefacc78b73aeb6f008e084cdcd78172", "f063fc4906707858c7af406365353363" ]
-        },
         "show_error_on_disconnect.test.lua": {
             "issues": [ "gh-5371" ],
             "checksums": [ "304214225ce2a0238cc583059733f73a", "7bb4a0f8d3f82fa998462ea8120983fb", "67ca0a848e3e0f3c213e9c9e74514dc1", "7bb4a0f8d3f82fa998462ea8120983fb" ]


### PR DESCRIPTION
Found that on slow test hosts like FreeBSD VMware test flaky failed, like:

  [001] @@ -153,7 +153,7 @@
  [001]   | ...
  [001]  assert(leader_count == 1)
  [001]   | ---
  [001] - | - true
  [001] + | - error: assertion failed!
  [001]   | ...
  [001]  -- All nodes have the same leader.
  [001]  r1_leader = test_run:eval('election_replica1', leader_id_cmd)[1]

It happened because there was not enough time right after wait_fullmesh()
call and before check of the current leader to make any of the replicas
leader. Later in the code was not correct logic when checked who is the
leader and choosed 'election_replica3' if not the others, it caused the
later fails in the test. Decided to wait after wait_fullmesh() when any
of the replicas became leader using test_cond() routine.

Closes #5368