### PR TITLE
build: cleanup BuildZSTD.cmake

### DIFF
--- a/cmake/BuildZSTD.cmake
+++ b/cmake/BuildZSTD.cmake
@@ -41,5 +41,4 @@ macro(zstd_build)
     include_directories(${ZSTD_INCLUDE_DIRS})
     find_package_message(ZSTD "Using bundled ZSTD"
         "${ZSTD_LIBRARIES}:${ZSTD_INCLUDE_DIRS}")
-    add_dependencies(build_bundled_libs zstd)
 endmacro(zstd_build)


### PR DESCRIPTION
Seems CMakeLists.txt contains the same line as inside
BuildZSTD.cmake. Seems we don't need to duplicate this logic
twice let's remove it.