### PR TITLE
test: vinyl/gh.test.lua fix mistake

### DIFF
--- a/test/vinyl/gh.result
+++ b/test/vinyl/gh.result
@@ -714,7 +714,7 @@ test_run:cmd("setopt delimiter ''");
 cont = false
 ---
 ...
-test_run:wait_cond(function() return finished ~= 2 end)
+test_run:wait_cond(function() return finished == 2 end)
 ---
 - true
 ...

--- a/test/vinyl/gh.test.lua
+++ b/test/vinyl/gh.test.lua
@@ -309,7 +309,7 @@ end;
 test_run:cmd("setopt delimiter ''");
 
 cont = false
-test_run:wait_cond(function() return finished ~= 2 end)
+test_run:wait_cond(function() return finished == 2 end)
 
 s:drop()
 

--- a/test/vinyl/suite.ini
+++ b/test/vinyl/suite.ini
@@ -58,10 +58,6 @@ fragile = {
             "issues": [ "gh-5089" ],
             "checksums": [ "f6d6c5aed699b65c9e9eb1ad068578d2", "dbd3d6e852b2db785b3222c30e1f6f9c", "f56467141ef34c20c16ef86ca4124c47", "a64091902c05801d2a380729520c4c64" ]
         },
-        "gh.test.lua": {
-            "issues": [ "gh-5141" ],
-            "checksums": [ "f1286e9e4710062ddfbffb61b2fe2743", "96b22440ab8a881d6b8d14c5ee1672fb", "fc77a97c3c891c57d4717087f7a65bd0", "83efab113cd395b943a2d89c5e63328e", "aa0858238bbf7ee8f1ab77a3ae75f06b", "f6d23254a69a08f2a7773f2ca6c13066", "071ef0486622540e665009047b6eea19" ]
-        },
         "gh-5141-invalid-vylog-file.test.lua": {
             "issues": [ "gh-5141" ],
             "checksums": [ "1f4d4261fc63291c4020372986c62e2e", "7e103822262602a7fba4f8f3f6ffb6b7", "09279dacc8c3f96d86de37481774f5f6" ]


### PR DESCRIPTION
Found that in one previous commit
```
  42c64d06d5d1a3ec937b3c596af083a672a68ad8 ('test: fix hanging of vinyl/gh.test.lua')
```
Was mistakenly made such change:
```
  -while finished ~= 2 do fiber.sleep(0.01) end
  +test_run:wait_cond(function() return finished ~= 2 end)
```
And the logic of the check was broken. This patch fixes it.
    
Part of #5141
Fixes tarantool/test-run#261
Part of tarantool/tarantool-qa#106