### PR TITLE
test: flaky replication/long_row_timeout.test.lua

### DIFF
--- a/test/replication/long_row_timeout.result
+++ b/test/replication/long_row_timeout.result
@@ -21,9 +21,9 @@ test_run:cmd('start server replica')
 ---
 - true
 ...
-box.info.replication[2].downstream.status
+test_run:wait_downstream(2, {status = 'follow'})
 ---
-- follow
+- true
 ...
 -- make applier incapable of reading rows in one go, so that it
 -- yields a couple of times.
@@ -54,15 +54,16 @@ test_run:cmd('setopt delimiter ";"')
 ---
 - true
 ...
-ok = true;
+status = nil;
 ---
 ...
 start = fiber.time();
 ---
 ...
 while fiber.time() - start < 3 * box.cfg.replication_timeout do
-    if box.info.replication[2].downstream.status ~= 'follow' then
-        ok = false
+    status = box.info.replication[2].downstream.status
+    if status ~= 'follow' then
+        status = box.info.replication
         break
     end
     fiber.sleep(0.001)
@@ -73,9 +74,9 @@ test_run:cmd('setopt delimiter ""');
 ---
 - true
 ...
-ok
+status
 ---
-- true
+- follow
 ...
 s:drop()
 ---

--- a/test/replication/suite.ini
+++ b/test/replication/suite.ini
@@ -17,10 +17,6 @@ fragile = {
             "issues": [ "gh-3870" ],
             "checksums": [ "5d3f58323aafc1a11d9b9264258f7acf", "919921e13968b108d342555746ba55c9" ]
         },
-        "long_row_timeout.test.lua": {
-            "issues": [ "gh-4351" ],
-            "checksums": [ "acd88b48b0046ec52346274eeeef0b25", "a645ff7616b5caf0fcd2099022b776bf", "eb3e92564ba71e7b7c458050223f4d57" ]
-        },
         "skip_conflict_row.test.lua": {
             "issues": [ "gh-4958" ],
             "checksums": [ "a21f07339237cd9d0b8c74e144284449", "0359b0b1cc80052faf96972959513694", "ef104dfd04afa7c75087de13246e3eb0" ]


### PR DESCRIPTION
On heavy loaded hosts either slow machines like VMware found the
following issues:
```
  [010] --- replication/long_row_timeout.result   Fri May  8 08:56:08 2020
  [010] +++ var/rejects/replication/long_row_timeout.reject       Mon Jun 21 04:39:08 2021
  [010] @@ -23,7 +23,7 @@
  [010]  ...
  [010]  box.info.replication[2].downstream.status
  [010]  ---
  [010] -- follow
  [010] +- stopped
  [010]  ...
  [010]  -- make applier incapable of reading rows in one go, so that it
  [010]  -- yields a couple of times.
  [010]

  [026] --- replication/long_row_timeout.result Fri Sep 25 19:08:46 2020
  [026] +++ replication/long_row_timeout.reject Fri May  8 08:23:39 2020
  [026] @@ -80,7 +80,7 @@
  [026]  ...
  [026]  ok
  [026]  ---
  [026] -- true
  [026] +- false
  [026]  ...
  [026]  s:drop()
  [026]  ---
  [026]
```
It happened because replication downstream status check occurred too
early, when it was only in 'stopped' state. This situation happens
when replica done its initial join, but not reached subscription yet.
To give the replication status check routine ability to reach the
needed 'follow' state, it need for it using test_run:wait_downstream()
routine.

The second issue happened on testing timeout calculations on applier.
To avoid of it were found 2 ways to fix it:
  - Increase ERRINJ_SIO_READ_MAX from 1 to 10:
      showed better test influence on success results.
  - Increase REPLICATION_TIMOEOUT for replicas in 5 times:
      showed low test influence on success results.

Decided to use variant with SIO_READ_MAX=10, without the timeout
increase. Otherwise we would lower the test's precision.

The test was about wrong timeout calculations on applier. Here's what
happened. Applier reads the incoming rows via coio, and yields as soon
as there's no more data available. After each yield the elapsed time is
updated to raise an error as soon as the timeout passes.
    
This timeout was calculated inaccurately, instead of doing something like:
```
  time_elapsed = 0
  do
      start = time()
      n += read()
      fiber.yield()
      time_elapsed += time() - start
  while n < to_read
```
It did:
```
  time_elapsed = 0
  start = time()
  do
      ...
      time_elapsed += time() - start
  while n < to_read
```
This lead to a situation that applier timed out much faster than it should
(0.4 seconds when timeout is ~15 seconds) when there were lots of yields.

So in order for the test to remain correct, we need to make applier yield
a lot of times while reading the rows.

If we set SIO_READ_MAX to 10 AND increase the timeout at the same time,
the test might become irrelevant. Because there will be only 100 yields
per row and the timeout will be 5 times higher, meaning even if the applier
behavior is broken again we might miss it.
    
Also changed return value from 'ok' to downstream status to be sure in its
values.

Removed test from fragile list.

Closes #4351

Co-developed-by: Serge Petrenko <sergepetrenko@tarantool.org>