### PR TITLE
sql: handle properly empty literals passed to C functions

### DIFF
--- a/src/box/sql/malloc.c
+++ b/src/box/sql/malloc.c
@@ -35,6 +35,8 @@
  */
 #include "sqlInt.h"
 #include <stdarg.h>
+#include <valgrind/valgrind.h>
+#include <valgrind/memcheck.h>
 
 /*
  * Like malloc(), but remember the size of the allocation
@@ -57,7 +59,9 @@ sql_sized_malloc(int nByte)
 		return NULL;
 	}
 	p[0] = nByte;
+	VALGRIND_MAKE_MEM_DEFINED(p, sizeof(p[0]));
 	p++;
+	VALGRIND_MAKE_MEM_UNDEFINED(p, nByte);
 	return (void *)p;
 }
 
@@ -92,6 +96,7 @@ sql_sized_realloc(void *pPrior, int nByte)
 	assert(pPrior != 0 && nByte > 0);
 	assert(nByte == ROUND8(nByte));	/* EV: R-46199-30249 */
 	p--;
+	VALGRIND_MAKE_MEM_NOACCESS(p, nByte + sizeof(p[0]));
 	p = realloc(p, nByte + 8);
 	if (p == NULL) {
 		sql_get()->mallocFailed = 1;
@@ -99,7 +104,9 @@ sql_sized_realloc(void *pPrior, int nByte)
 		return NULL;
 	}
 	p[0] = nByte;
+	VALGRIND_MAKE_MEM_DEFINED(p, sizeof(p[0]));
 	p++;
+	VALGRIND_MAKE_MEM_UNDEFINED(p, nByte);
 	return (void *)p;
 }
 
@@ -182,6 +189,7 @@ sql_free(void *p)
 		return;
 	sql_int64 *raw_p = (sql_int64 *) p;
 	raw_p--;
+	VALGRIND_MAKE_MEM_NOACCESS(raw_p, raw_p[0] + 8);
 	free(raw_p);
 }
 
@@ -196,6 +204,7 @@ sqlDbFree(sql * db, void *p)
 		if (isLookaside(db, p)) {
 			LookasideSlot *pBuf = (LookasideSlot *) p;
 			pBuf->pNext = db->lookaside.pFree;
+			VALGRIND_MAKE_MEM_UNDEFINED(p, db->lookaside.sz);
 			db->lookaside.pFree = pBuf;
 			db->lookaside.nOut--;
 			return;
@@ -248,6 +257,7 @@ sqlMallocZero(u64 n)
 	void *p = sqlMalloc(n);
 	if (p) {
 		memset(p, 0, (size_t) n);
+		VALGRIND_MAKE_MEM_DEFINED(p, n);
 	}
 	return p;
 }
@@ -262,8 +272,10 @@ sqlDbMallocZero(sql * db, u64 n)
 	void *p;
 	testcase(db == 0);
 	p = sqlDbMallocRaw(db, n);
-	if (p)
+	if (p) {
 		memset(p, 0, (size_t) n);
+		VALGRIND_MAKE_MEM_DEFINED(p, n);
+	}
 	return p;
 }
 
@@ -368,6 +380,7 @@ dbReallocFinish(sql * db, void *p, u64 n)
 			pNew = sqlDbMallocRawNN(db, n);
 			if (pNew) {
 				memcpy(pNew, p, db->lookaside.sz);
+				VALGRIND_MAKE_MEM_DEFINED(pNew, db->lookaside.sz);
 				sqlDbFree(db, p);
 			}
 		} else {

--- a/src/box/sql/malloc.c
+++ b/src/box/sql/malloc.c
@@ -98,7 +98,7 @@ sql_sized_realloc(void *pPrior, int nByte)
 	p--;
 	VALGRIND_MAKE_MEM_NOACCESS(p, nByte + sizeof(p[0]));
 	p = realloc(p, nByte + 8);
-	if (p == NULL) {
+	if (p == NULL && nByte != 0) {
 		sql_get()->mallocFailed = 1;
 		diag_set(OutOfMemory, nByte, "realloc", "p");
 		return NULL;
@@ -288,7 +288,7 @@ dbMallocRawFinish(sql * db, u64 n)
 	void *p;
 	assert(db != 0);
 	p = sqlMalloc(n);
-	if (!p)
+	if (p == NULL && n != 0)
 		sqlOomFault(db);
 	return p;
 }
@@ -385,7 +385,7 @@ dbReallocFinish(sql * db, void *p, u64 n)
 			}
 		} else {
 			pNew = sql_realloc64(p, n);
-			if (!pNew)
+			if (pNew == NULL && n != 0)
 				sqlOomFault(db);
 		}
 	}
@@ -401,7 +401,7 @@ sqlDbReallocOrFree(sql * db, void *p, u64 n)
 {
 	void *pNew;
 	pNew = sqlDbRealloc(db, p, n);
-	if (!pNew) {
+	if (pNew == NULL && n != 0) {
 		sqlDbFree(db, p);
 	}
 	return pNew;

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -1366,8 +1366,10 @@ mem_copy(struct Mem *to, const struct Mem *from)
 	if ((to->flags & MEM_Zero) != 0)
 		return sqlVdbeMemExpandBlob(to);
 	to->zMalloc = sqlDbReallocOrFree(to->db, to->zMalloc, to->n);
-	if (to->zMalloc == NULL)
+	if (to->zMalloc == NULL) {
+		to->szMalloc = 0;
 		return -1;
+	}
 	to->szMalloc = sqlDbMallocSize(to->db, to->zMalloc);
 	memcpy(to->zMalloc, to->z, to->n);
 	to->z = to->zMalloc;


### PR DESCRIPTION
* As a helper for future investigations we have Instrumented sql `malloc.c` functions with calls 
  to various `VALGRIND_MAKE_MEM_*` macros. This aids in `valgrind` `memcheck` mode.

* Mike Siomkin has found bug with double-free of memory pointer iff we use _empty_ literal
 which is passed to C function from SQL. The problem that `realloc()` should return NULL if 
 requested to trim memory to 0 bytes.

Relates to #6157