### PR TITLE
What happens after connection close with request with unread tail

### DIFF
--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -695,6 +695,11 @@ iproto_connection_close(struct iproto_connection *con)
 		ev_io_stop(con->loop, &con->input);
 		ev_io_stop(con->loop, &con->output);
 
+		if (con->parse_size > 0)
+			say_warn("closing connection %s and discarding %zu "
+				 "unread bytes", sio_socketname(con->input.fd),
+				 con->parse_size);
+
 		int fd = con->input.fd;
 		/* Make evio_has_fd() happy */
 		con->input.fd = con->output.fd = -1;


### PR DESCRIPTION
1. If server started to read data from connection socket and connection suddenly closed, then before the patch server silently discarded read data. Lets log, that server did it.
2. If net_box client  started to read data from connection socket and socket suddenly closed, then before the patch everything works good - request to the server gets error. Don't change anything.