### PR TITLE
github-ci: add GitHub Actions workflow for Odroid

### DIFF
--- a/.github/workflows/odroid_arm64.yml
+++ b/.github/workflows/odroid_arm64.yml
@@ -1,0 +1,47 @@
+name: odroid_arm64
+
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
+
+env:
+  CI_MAKE: make -f .travis.mk
+
+jobs:
+  odroid_arm64:
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
+
+    runs-on: odroid-arm64
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: ./.github/actions/environment
+      - name: test
+        env:
+          CMAKE_BUILD_TYPE: RelWithDebInfo
+          # FIXME: switched off backtraces support till #6142 is fixed.
+          CMAKE_EXTRA_PARAMS: '-DENABLE_BACKTRACE=OFF'
+        run: ${CI_MAKE} test_odroid_arm64
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: odroid_arm64
+          retention-days: 21
+          path: /tmp/tnt/artifacts

--- a/.github/workflows/odroid_debug_arm64.yml
+++ b/.github/workflows/odroid_debug_arm64.yml
@@ -1,0 +1,48 @@
+name: odroid_debug_arm64
+
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
+
+env:
+  CI_MAKE: make -f .travis.mk
+
+jobs:
+  odroid_debug_arm64:
+    # We want to run on external PRs, but not on our own internal PRs
+    # as they'll be run by the push to the branch.
+    if: ( github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ) &&
+        ! endsWith(github.ref, '-notest')
+
+    runs-on: odroid-arm64
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: ./.github/actions/environment
+      - name: test
+        env:
+          CMAKE_BUILD_TYPE: Debug
+          # FIXME: switched off backtraces support till #6142 is fixed,
+          #        disabled '-Wtype-limits' flag till #6143 is fixed.
+          CMAKE_EXTRA_PARAMS: '-DENABLE_BACKTRACE=OFF -DCMAKE_C_FLAGS="-Wno-type-limits "'
+        run: ${CI_MAKE} test_odroid_arm64
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: odroid_debug_arm64
+          retention-days: 21
+          path: /tmp/tnt/artifacts

--- a/.travis.mk
+++ b/.travis.mk
@@ -317,6 +317,22 @@ test_oos_build:
 		-i ${DOCKER_IMAGE_TARANTOOL} \
 		make -f .travis.mk ${OOS_BUILD_RULE}
 
+# Odroid arm64
+
+deps_odroid_arm64:
+	sudo apt update -y && sudo apt -y install git build-essential cmake make zlib1g-dev \
+		libreadline-dev libncurses5-dev libssl-dev libunwind-dev libicu-dev python3 \
+		python3-six python3-gevent python3-pip
+
+build_odroid_arm64:
+	cmake . -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} ${CMAKE_EXTRA_PARAMS}
+	make -j
+
+test_odroid_arm64_no_deps: build_odroid_arm64
+	make LuaJIT-test
+
+test_odroid_arm64: deps_odroid_arm64 test_odroid_arm64_no_deps
+
 #######
 # OSX #
 #######


### PR DESCRIPTION
Odroid is GNU/Linux ARM64 platform. In scope of this commit new GitHub
Actions workflows for testing Tarantool on Odroid hosts are added:
```
  Release: .github/workflows/odroid_arm64.yml
  Debug: .github/workflows/odroid_debug_arm64.yml
```
Introduced new targets in .travis.mk Makefile:
```
  deps_odroid: Installs needed dependencies.

  build_odroid: Builds Tarantool with the following flags set
    in env of .github/workflows/odroid_debug_arm64.yml file:
      1. to avoid of issue #6142:
         -DENABLE_BACKTRACE=OFF
      2. to avoid of issue #6143:
         -DCMAKE_C_FLAGS="-Wno-type-limits "
         -DCMAKE_BUILD_TYPE=Debug

  test_odroid: Builds and tests on Odroid `LuaJIT-test` suite.
```
Also v1 version of GitHub checkout action is used, because action
version v2 was introduced in git version 2.18.0 [1]. The latest
available version on Odroid is the following:
```    
  git is already the newest version (1:2.17.1-1ubuntu0.8).
```
Closes tarantool/tarantool-qa#121

[1]: https://github.com/actions/checkout#readme
