### PR TITLE
github-ci: pull all available tags

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -47,8 +47,35 @@ runs:
                 free
             fi
         fi
-        # Drop a tag that points to a current commit (if any)
-        # on a job triggered by pushing to a branch.
+        # Found that Github checkout Actions pulls all the tags, but
+        # right it deannotates the testing tag, check:
+        #   https://github.com/actions/checkout/issues/290
+        # But we use 'git describe ..' calls w/o '--tags' flag and it
+        # prevents us from getting the needed tag for packages version
+        # setup. To avoid of it, let's fetch it manually, to be sure
+        # that all tags will exists always.
+        # To check it, were used commands to create dump commit and tag
+        # the new version. Also made twice push with extra flag for
+        # tags:
+        #
+        #   git commit -m"Dump commit" --allow-empty
+        #   git tag -a 2.4.8 -m ''
+        #   git push && git push --tags
+        #
+        # In this way would be run 2 jobs for each package:
+        #
+        # 1. Build package on testing branch. It will produce package
+        #    with name 2.4.7.x (because of the exception mentioned
+        #    below).
+        # 2. Build package on tag 2.4.8. It will produce package with
+        #    name 2.4.8.x.
+        git fetch --tags -f
+        # Github Actions may runs twice the same job on branch push and
+        # on new tag if it was created on this push. To avoid of fails
+        # on saving the commonly named packages, lets drop a tag that
+        # points to a current commit (if any) on a job triggered by
+        # pushing to a branch (it will produce the package based on
+        # previous tag) and leave the new tag in job triggered by tag.
         if ${{ ! startsWith(github.ref, 'refs/tags/') }}; then
             git tag -d "$(git tag --points-at HEAD)" 2>/dev/null || true
         fi


### PR DESCRIPTION
Found that Github actions/checkout@v2, when Github Actions triggers
a job upon the tag push, it makes the following calls [1]:
```
  git fetch origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
  git fetch origin +$HASH:refs/tags/$TAG
```
While the first call is fine, the second one spoils the tag and makes
it non-annotated.
    
Later, Tarantool calls git describe without --tags flag, and the
spoiled tag is ignored. This patch handles it by fetching all the
tags once again explicitly.
    
Also explained the next step, where we remove the tag. The Github
Actions may runs twice the same job on branch push and on new tag
if it was created on this push. To avoid of fails on saving the
commonly named packages, we drop a tag that points to a current
commit (if any) on a job triggered by pushing to a branch (it will
produce the package based on previous tag) and leave the new tag
in job triggered by tag.
    
To check this change was used commands to create dump commit and tag
the new version. Also made twice push with extra flag for tags:
```    
      git commit -m"Dump commit" --allow-empty
      git tag -a 2.4.8 -m ''
      git push && git push --tags
```
In this way would be run 2 jobs for each package:
    
      1. Build package on testing branch. It will produce package with
         name 2.4.7.x (because of the exception mentioned above).
      2. Build package on tag 2.4.8. It will produce package with name
         2.4.8.x.
    
Closes tarantool/tarantool-qa#119

[1]: https://github.com/actions/checkout/issues/290