### PR TITLE
txm: add a test that makes tons of concurrent replaces

### DIFF
--- a/changelogs/unreleased/gh-6193-assertion-with-mass-replace.md
+++ b/changelogs/unreleased/gh-6193-assertion-with-mass-replace.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fixed a bug with failed assertion after stress update of the same key. (gh-6193)

--- a/test/box/tx_man.result
+++ b/test/box/tx_man.result
@@ -2386,6 +2386,49 @@ box.execute([[DROP TABLE u ;]])
  | - row_count: 1
  | ...
 
+--https://github.com/tarantool/tarantool/issues/6193
+s = box.schema.create_space('test')
+ | ---
+ | ...
+_ = s:create_index('pk')
+ | ---
+ | ...
+fiber = require('fiber')
+ | ---
+ | ...
+_ = fiber.create(function() box.space.test:replace({1, 2, 3}) end)
+ | ---
+ | ...
+box.space.test:delete({1})
+ | ---
+ | - [1, 2, 3]
+ | ...
+box.space.test:delete({1})
+ | ---
+ | ...
+N = 1e4
+ | ---
+ | ...
+fibers = {}
+ | ---
+ | ...
+for i = 1, N do                            \
+    local fib = fiber.new(function()       \
+        box.begin()                        \
+        box.space.test:replace({1, 2, 3})  \
+    end)                                   \
+    fib:set_joinable(true)                 \
+    table.insert(fibers, fib)              \
+end
+ | ---
+ | ...
+for _,fib in pairs(fibers) do fib:join() end
+ | ---
+ | ...
+s:drop()
+ | ---
+ | ...
+
 test_run:cmd("switch default")
  | ---
  | - true

--- a/test/box/tx_man.test.lua
+++ b/test/box/tx_man.test.lua
@@ -752,6 +752,26 @@ box.execute([[SELECT * FROM u;]])
 
 box.execute([[DROP TABLE u ;]])
 
+--https://github.com/tarantool/tarantool/issues/6193
+s = box.schema.create_space('test')
+_ = s:create_index('pk')
+fiber = require('fiber')
+_ = fiber.create(function() box.space.test:replace({1, 2, 3}) end)
+box.space.test:delete({1})
+box.space.test:delete({1})
+N = 1e4
+fibers = {}
+for i = 1, N do                            \
+    local fib = fiber.new(function()       \
+        box.begin()                        \
+        box.space.test:replace({1, 2, 3})  \
+    end)                                   \
+    fib:set_joinable(true)                 \
+    table.insert(fibers, fib)              \
+end
+for _,fib in pairs(fibers) do fib:join() end
+s:drop()
+
 test_run:cmd("switch default")
 test_run:cmd("stop server tx_man")
 test_run:cmd("cleanup server tx_man")


### PR DESCRIPTION
The problem was fixed in #5515, this commit just verifies that the
test case works fine.

Closes #6193