### PR TITLE
fiber: introduce a method to get storage of current fiber

### DIFF
--- a/src/lua/fiber.c
+++ b/src/lua/fiber.c
@@ -693,7 +693,9 @@ lbox_fiber_on_stop(struct trigger *trigger, void *event)
 static int
 lbox_fiber_storage(struct lua_State *L)
 {
-	struct fiber *f = lbox_checkfiber(L, 1);
+	struct fiber *f = lbox_get_fiber(L);
+	if (f == NULL)
+		luaL_error(L, "the fiber is dead");
 	int storage_ref = f->storage.lua.ref;
 	if (storage_ref <= 0) {
 		struct trigger *t = (struct trigger *)
@@ -948,6 +950,7 @@ static const struct luaL_Reg fiberlib[] = {
 	{"new", lbox_fiber_new},
 	{"status", lbox_fiber_status},
 	{"name", lbox_fiber_name},
+	{"storage", lbox_fiber_storage},
 	/* Internal functions, to hide in fiber.lua. */
 	{"stall", lbox_fiber_stall},
 	{NULL, NULL}

--- a/test/app/fiber.result
+++ b/test/app/fiber.result
@@ -681,6 +681,31 @@ pcall(function(f) return f.storage end, f)
 - '[string "return pcall(function(f) return f.storage end..."]:1: the fiber is dead'
 ...
 --
+-- gh-6210: Access to fiber storage of current fiber via fiber.storage()
+--
+fiber.self().storage == fiber.storage()
+---
+- true
+...
+fiber.storage()['key'] = 'value'
+---
+...
+fiber.storage()['key']
+---
+- value
+...
+fiber.self().storage['key']
+---
+- value
+...
+fiber.self().storage['key'] = 'value2'
+---
+...
+fiber.storage()['key']
+---
+- value2
+...
+--
 -- Test that local storage is garbage collected when fiber is died
 --
 ffi = require('ffi')

--- a/test/app/fiber.test.lua
+++ b/test/app/fiber.test.lua
@@ -256,6 +256,17 @@ fiber.self().storage.key -- our local storage is not affected by f
 pcall(function(f) return f.storage end, f)
 
 --
+-- gh-6210: Access to fiber storage of current fiber via fiber.storage()
+--
+
+fiber.self().storage == fiber.storage()
+fiber.storage()['key'] = 'value'
+fiber.storage()['key']
+fiber.self().storage['key']
+fiber.self().storage['key'] = 'value2'
+fiber.storage()['key']
+
+--
 -- Test that local storage is garbage collected when fiber is died
 --
 ffi = require('ffi')


### PR DESCRIPTION
This patch introduces new method to simplify access to fiber
storage. Before this patch single way to do it was
`fiber.self().storage`. In fact `fiber.self()` call is too
expensive because returns complex table with excess fields.

Customers use fiber storage to save some session/request context.
And in case if such information is used in different places of
application quite intensive it's reasonable to eliminate redundant
tables creation and simplify access to fiber storage.

Closes #6210

@TarantoolBot document
Title: introduce fiber.storage() function

This function returns fiber storage of current fiber. Before a
single way to do it was `fiber.self().storage` that is quite
expensive in case if user needs only storage.