### PR TITLE
txm: fix iterators for hash index

### DIFF
--- a/changelogs/unreleased/gh-6040-hash-select-not-tracked-by-mvcc.md
+++ b/changelogs/unreleased/gh-6040-hash-select-not-tracked-by-mvcc.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fix a bug when hash select{} was not tracked by mvcc engine (gh-6040)
+

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -501,6 +501,7 @@ index_create(struct index *index, struct engine *engine,
 	/* Unusable until set to proper value during space creation. */
 	index->dense_id = UINT32_MAX;
 	rlist_create(&index->nearby_gaps);
+	rlist_create(&index->full_scans);
 	return 0;
 }
 

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -475,11 +475,14 @@ struct index {
 	/** Compact ID - index in space->index array. */
 	uint32_t dense_id;
 	/**
-	 * List of gap read in the index with NULL successor. Those gap
-	 * reads happen when reading from empty index, or when reading
-	 * from rightmost part of ordered index (TREE).
+	 * List of gap_item's describing gap reads in the index with NULL
+	 * successor. Those gap reads happen when reading from empty index,
+	 * or when reading from rightmost part of ordered index (TREE).
+	 * @sa struct gap_item.
 	 */
 	struct rlist nearby_gaps;
+	/** List of full scans of the index. @sa struct full_scan_item. */
+	struct rlist full_scans;
 };
 
 /**

--- a/src/box/memtx_hash.c
+++ b/src/box/memtx_hash.c
@@ -433,10 +433,17 @@ memtx_hash_index_create_iterator(struct index *base, enum iterator_type type,
 			light_index_iterator_begin(&index->hash_table, &it->iterator);
 			it->base.next = hash_iterator_ge;
 		}
+		/* This iterator needs to be supported as a legacy. */
+		memtx_tx_track_full_scan(in_txn(),
+					 space_by_id(it->base.space_id),
+					 &index->base);
 		break;
 	case ITER_ALL:
 		light_index_iterator_begin(&index->hash_table, &it->iterator);
 		it->base.next = hash_iterator_ge;
+		memtx_tx_track_full_scan(in_txn(),
+					 space_by_id(it->base.space_id),
+					 &index->base);
 		break;
 	case ITER_EQ:
 		assert(part_count > 0);

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -106,6 +106,19 @@ struct gap_item {
 };
 
 /**
+ * An element that stores the fact that some transaction have read
+ * a full index.
+ */
+struct full_scan_item {
+	/** A link in index::full_scans. */
+	struct rlist in_full_scans;
+	/** Link in txn->full_scan_list. */
+	struct rlist in_full_scan_list;
+	/** The transaction that read it. */
+	struct txn *txn;
+};
+
+/**
  * Helper structure for searching for point_hole_item in the hash table,
  * @sa point_hole_item_pool.
  */
@@ -189,6 +202,8 @@ struct tx_manager
 	size_t point_holes_size;
 	/** Mempool for gap_item objects. */
 	struct mempool gap_item_mempoool;
+	/** Mempool for full_scan_item objects. */
+	struct mempool full_scan_item_mempool;
 	/** List of all memtx_story objects. */
 	struct rlist all_stories;
 	/** Iterator that sequentially traverses all memtx_story objects. */
@@ -232,6 +247,8 @@ memtx_tx_manager_init()
 		panic("mh_history_new()");
 	mempool_create(&txm.gap_item_mempoool,
 		       cord_slab_cache(), sizeof(struct gap_item));
+	mempool_create(&txm.full_scan_item_mempool,
+		       cord_slab_cache(), sizeof(struct full_scan_item));
 	txm.point_holes_size = 0;
 	rlist_create(&txm.all_stories);
 	txm.traverse_all_stories = &txm.all_stories;
@@ -247,6 +264,7 @@ memtx_tx_manager_free()
 	mempool_destroy(&txm.point_hole_item_pool);
 	mh_point_holes_delete(txm.point_holes);
 	mempool_destroy(&txm.gap_item_mempoool);
+	mempool_destroy(&txm.full_scan_item_mempool);
 }
 
 int
@@ -1039,9 +1057,16 @@ memtx_tx_handle_gap_write(struct txn *txn, struct space *space,
 			  struct memtx_story *story, struct tuple *tuple,
 			  struct tuple *successor, uint32_t ind)
 {
+	struct index *index = space->index[ind];
+	struct full_scan_item *fsc_item, *fsc_tmp;
+	struct rlist *fsc_list = &index->full_scans;
+	rlist_foreach_entry_safe(fsc_item, fsc_list, in_full_scans, fsc_tmp) {
+		if (memtx_tx_cause_conflict(txn, fsc_item->txn) != 0)
+			return -1;
+	}
 	if (successor != NULL && !successor->is_dirty)
 		return 0; /* no gap records */
-	struct index *index = space->index[ind];
+
 	struct rlist *list = &index->nearby_gaps;
 	if (successor != NULL) {
 		assert(successor->is_dirty);
@@ -1580,6 +1605,14 @@ memtx_tx_delete_gap(struct gap_item *item)
 	mempool_free(&txm.gap_item_mempoool, item);
 }
 
+static void
+memtx_tx_full_scan_item_delete(struct full_scan_item *item)
+{
+	rlist_del(&item->in_full_scan_list);
+	rlist_del(&item->in_full_scans);
+	mempool_free(&txm.full_scan_item_mempool, item);
+}
+
 void
 memtx_tx_on_index_delete(struct index *index)
 {
@@ -1589,6 +1622,13 @@ memtx_tx_on_index_delete(struct index *index)
 					  struct gap_item,
 					  in_nearby_gaps);
 		memtx_tx_delete_gap(item);
+	}
+	while (!rlist_empty(&index->full_scans)) {
+		struct full_scan_item *item =
+			rlist_first_entry(&index->full_scans,
+					  struct full_scan_item,
+					  in_full_scans);
+		memtx_tx_full_scan_item_delete(item);
 	}
 }
 
@@ -1906,6 +1946,43 @@ memtx_tx_track_gap_slow(struct txn *txn, struct space *space, struct index *inde
 	return 0;
 }
 
+static struct full_scan_item *
+memtx_tx_full_scan_item_new(struct txn *txn)
+{
+	struct full_scan_item *item = (struct full_scan_item *)
+		mempool_alloc(&txm.full_scan_item_mempool);
+	if (item == NULL) {
+		diag_set(OutOfMemory, sizeof(*item), "mempool_alloc",
+			 "full_scan_item");
+		return NULL;
+	}
+
+	item->txn = txn;
+	rlist_add(&txn->full_scan_list, &item->in_full_scan_list);
+	return item;
+}
+
+/**
+ * Record in TX manager that a transaction @a txn have read full @ a index.
+ * This function must be used for unordered indexes, such as HASH, for queries
+ * when interation type is ALL.
+ * @return 0 on success, -1 on memory error.
+ */
+int
+memtx_tx_track_full_scan_slow(struct txn *txn, struct index *index)
+{
+	if (txn->status != TXN_INPROGRESS)
+		return 0;
+
+	struct full_scan_item *item = memtx_tx_full_scan_item_new(txn);
+	if (item == NULL)
+		return -1;
+
+	rlist_add(&index->full_scans, &item->in_full_scans);
+	memtx_tx_story_gc();
+	return 0;
+}
+
 /**
  * Clean memtx_tx part of @a txm.
  */
@@ -1925,6 +2002,13 @@ memtx_tx_clean_txn(struct txn *txn)
 					  struct gap_item,
 					  in_gap_list);
 		memtx_tx_delete_gap(item);
+	}
+	while (!rlist_empty(&txn->full_scan_list)) {
+		struct full_scan_item *item =
+			rlist_first_entry(&txn->full_scan_list,
+					  struct full_scan_item,
+					  in_full_scan_list);
+		memtx_tx_full_scan_item_delete(item);
 	}
 }
 

--- a/src/box/memtx_tx.h
+++ b/src/box/memtx_tx.h
@@ -332,6 +332,33 @@ memtx_tx_track_gap(struct txn *txn, struct space *space, struct index *index,
 }
 
 /**
+ * Helper of memtx_tx_track_full_scan.
+ */
+int
+memtx_tx_track_full_scan_slow(struct txn *txn, struct index *index);
+
+/**
+ * Record in TX manager that a transaction @a txn have read full @ a index
+ * from @a space.
+ * This function must be used for unordered indexes, such as HASH, for queries
+ * when interation type is ALL.
+ * @return 0 on success, -1 on memory error.
+ */
+static inline int
+memtx_tx_track_full_scan(struct txn *txn, struct space *space,
+			 struct index *index)
+{
+	if (!memtx_tx_manager_use_mvcc_engine)
+		return 0;
+	if (txn == NULL)
+		return 0;
+	/* Skip ephemeral spaces. */
+	if (space == NULL || space->def->id == 0)
+		return 0;
+	return memtx_tx_track_full_scan_slow(txn, index);
+}
+
+/**
  * Clean a tuple if it's dirty - finds a visible tuple in history.
  * @param txn - current transactions.
  * @param space - space in which the tuple was found.

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -202,6 +202,7 @@ txn_new(void)
 	rlist_create(&txn->read_set);
 	rlist_create(&txn->point_holes_list);
 	rlist_create(&txn->gap_list);
+	rlist_create(&txn->full_scan_list);
 	rlist_create(&txn->conflict_list);
 	rlist_create(&txn->conflicted_by_list);
 	rlist_create(&txn->in_read_view_txs);

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -422,6 +422,8 @@ struct txn {
 	struct rlist point_holes_list;
 	/** List of gap reads. @sa struct gap_item. */
 	struct rlist gap_list;
+	/** List of full scans. @sa struct full_scan_item. */
+	struct rlist full_scan_list;
 };
 
 static inline bool

--- a/test/box/tx_man.result
+++ b/test/box/tx_man.result
@@ -1291,6 +1291,44 @@ s:drop()
  | ---
  | ...
 
+-- Repeatable read for hash index (issue gh-6040)
+s = box.schema.space.create('test')
+ | ---
+ | ...
+i1 = s:create_index('pk', {type='hash'})
+ | ---
+ | ...
+i2 = s:create_index('sk', {type='hash'})
+ | ---
+ | ...
+tx1:begin()
+ | ---
+ | - 
+ | ...
+tx1('s:select{}')
+ | ---
+ | - - []
+ | ...
+s:replace{1, 1}
+ | ---
+ | - [1, 1]
+ | ...
+tx1('s:select{}')
+ | ---
+ | - - []
+ | ...
+tx1:commit()
+ | ---
+ | - 
+ | ...
+s:select{}
+ | ---
+ | - - [1, 1]
+ | ...
+s:drop()
+ | ---
+ | ...
+
 --TREE
 -- One select
 s = box.schema.space.create('test')

--- a/test/box/tx_man.test.lua
+++ b/test/box/tx_man.test.lua
@@ -381,6 +381,18 @@ tx3:commit()
 s:select{}
 s:drop()
 
+-- Repeatable read for hash index (issue gh-6040)
+s = box.schema.space.create('test')
+i1 = s:create_index('pk', {type='hash'})
+i2 = s:create_index('sk', {type='hash'})
+tx1:begin()
+tx1('s:select{}')
+s:replace{1, 1}
+tx1('s:select{}')
+tx1:commit()
+s:select{}
+s:drop()
+
 --TREE
 -- One select
 s = box.schema.space.create('test')


### PR DESCRIPTION
MVCC operates with 2 types of objects storing information about visible tuples in index order:
 - holes indicating an absence of tuple for some particular key
and
 - gaps indicating continuous absent ranges before some key

However, only ordered indices may manage nontrivial gaps.
But, in fact, the hash index must also signal about sequential scan of all the keys occurred so that thansaction
manager could transfer corresponding transaction to read view after any subsequent external change.

To provide this functionality hash index iterators of type ITER_ALL mark all the keys set as a gap with end at positive infinity right after the start of iteration.

Closes #6040