### PR TITLE
txm: fix memtx_tx_tuple_clarify_slow call args

### DIFF
--- a/changelogs/unreleased/gh-6229-crash-in-snapshot-with-uncommitted-transaction.md
+++ b/changelogs/unreleased/gh-6229-crash-in-snapshot-with-uncommitted-transaction.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fix a crash if you call box.snapshot during an incomplete transaction (gh-6229)

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1973,8 +1973,8 @@ memtx_tx_snapshot_cleaner_create(struct memtx_tx_snapshot_cleaner *cleaner,
 	rlist_foreach_entry(story, &space->memtx_stories, in_space_stories) {
 		struct tuple *tuple = story->tuple;
 		struct tuple *clean =
-			memtx_tx_tuple_clarify_slow(NULL, space, tuple, 0, 0,
-						    true);
+			memtx_tx_tuple_clarify_slow(NULL, space, tuple,
+						    space->index[0], 0, true);
 		if (clean == tuple)
 			continue;
 

--- a/test/box/tx_man_recovery.result
+++ b/test/box/tx_man_recovery.result
@@ -1,0 +1,139 @@
+-- test-run result file version 2
+env = require('test_run')
+ | ---
+ | ...
+test_run = env.new()
+ | ---
+ | ...
+test_run:cmd("create server tx_man_recovery with script='box/tx_man.lua'")
+ | ---
+ | - true
+ | ...
+test_run:cmd("start server tx_man_recovery")
+ | ---
+ | - true
+ | ...
+test_run:cmd("switch tx_man_recovery")
+ | ---
+ | - true
+ | ...
+
+_ = box.schema.space.create('test', { engine = 'memtx' })
+ | ---
+ | ...
+_ = box.space.test:create_index('primary')
+ | ---
+ | ...
+
+tx = require('txn_proxy').new()
+ | ---
+ | ...
+tx:begin()
+ | ---
+ | - 
+ | ...
+tx('box.space.test:replace{1}')
+ | ---
+ | - - [1]
+ | ...
+box.snapshot()
+ | ---
+ | - ok
+ | ...
+test_run:cmd("restart server tx_man_recovery")
+ | 
+box.space.test:select{}
+ | ---
+ | - []
+ | ...
+
+box.space.test:replace{2, 1}
+ | ---
+ | - [2, 1]
+ | ...
+tx = require('txn_proxy').new()
+ | ---
+ | ...
+tx:begin()
+ | ---
+ | - 
+ | ...
+tx('box.space.test:replace{2, 2}')
+ | ---
+ | - - [2, 2]
+ | ...
+box.snapshot()
+ | ---
+ | - ok
+ | ...
+test_run:cmd("restart server tx_man_recovery")
+ | 
+box.space.test:select{}
+ | ---
+ | - - [2, 1]
+ | ...
+
+tx = require('txn_proxy').new()
+ | ---
+ | ...
+tx:begin()
+ | ---
+ | - 
+ | ...
+tx('box.space.test:replace{2, 3}')
+ | ---
+ | - - [2, 3]
+ | ...
+box.snapshot()
+ | ---
+ | - ok
+ | ...
+tx:commit()
+ | ---
+ | - 
+ | ...
+test_run:cmd("restart server tx_man_recovery")
+ | 
+box.space.test:select{}
+ | ---
+ | - - [2, 3]
+ | ...
+
+tx = require('txn_proxy').new()
+ | ---
+ | ...
+tx:begin()
+ | ---
+ | - 
+ | ...
+tx('box.space.test:replace{2, 4}')
+ | ---
+ | - - [2, 4]
+ | ...
+box.snapshot()
+ | ---
+ | - ok
+ | ...
+tx:rollback()
+ | ---
+ | - 
+ | ...
+test_run:cmd("restart server tx_man_recovery")
+ | 
+box.space.test:select{}
+ | ---
+ | - - [2, 3]
+ | ...
+
+test_run:cmd("switch default")
+ | ---
+ | - true
+ | ...
+test_run:cmd("stop server tx_man_recovery")
+ | ---
+ | - true
+ | ...
+test_run:cmd("cleanup server tx_man_recovery")
+ | ---
+ | - true
+ | ...

--- a/test/box/tx_man_recovery.test.lua
+++ b/test/box/tx_man_recovery.test.lua
@@ -1,0 +1,43 @@
+env = require('test_run')
+test_run = env.new()
+test_run:cmd("create server tx_man_recovery with script='box/tx_man.lua'")
+test_run:cmd("start server tx_man_recovery")
+test_run:cmd("switch tx_man_recovery")
+
+_ = box.schema.space.create('test', { engine = 'memtx' })
+_ = box.space.test:create_index('primary')
+
+tx = require('txn_proxy').new()
+tx:begin()
+tx('box.space.test:replace{1}')
+box.snapshot()
+test_run:cmd("restart server tx_man_recovery")
+box.space.test:select{}
+
+box.space.test:replace{2, 1}
+tx = require('txn_proxy').new()
+tx:begin()
+tx('box.space.test:replace{2, 2}')
+box.snapshot()
+test_run:cmd("restart server tx_man_recovery")
+box.space.test:select{}
+
+tx = require('txn_proxy').new()
+tx:begin()
+tx('box.space.test:replace{2, 3}')
+box.snapshot()
+tx:commit()
+test_run:cmd("restart server tx_man_recovery")
+box.space.test:select{}
+
+tx = require('txn_proxy').new()
+tx:begin()
+tx('box.space.test:replace{2, 4}')
+box.snapshot()
+tx:rollback()
+test_run:cmd("restart server tx_man_recovery")
+box.space.test:select{}
+
+test_run:cmd("switch default")
+test_run:cmd("stop server tx_man_recovery")
+test_run:cmd("cleanup server tx_man_recovery")


### PR DESCRIPTION
At some point memtx_tx_tuple_clarify_slow was changed in terms of
its signarure - index ID was replaced with pointer to index.
Unfortunately one of calls of this function was not fixed - zero
was passed as index ID which compiles successfully with the new
API.

This patch fixes that place as well and adds a bunch of tests.

Closes #6229