### PR TITLE
build: fix build on Linux ARM64 with CMAKE_BUILD_TYPE=Debug

### DIFF
--- a/changelogs/unreleased/gh-6143-arm64-debug-build
+++ b/changelogs/unreleased/gh-6143-arm64-debug-build
@@ -1,0 +1,3 @@
+## bugfix/build
+
+ * Fix build errors on arm64 with `CMAKE_BUILD_TYPE=Debug`.

--- a/src/lib/http_parser/http_parser.c
+++ b/src/lib/http_parser/http_parser.c
@@ -221,7 +221,8 @@ int
 http_parse_header_line(struct http_parser *prsr, char **bufp,
 		       const char *end_buf, int max_hname_len)
 {
-	char c, ch;
+	char c;
+	unsigned char ch;
 	char *p = *bufp;
 	char *header_name_start = p;
 	prsr->hdr_name_idx = 0;
@@ -268,10 +269,6 @@ http_parse_header_line(struct http_parser *prsr, char **bufp,
 				goto header_done;
 			default:
 				state = sw_name;
-
-				if (ch < 0) {
-					return HTTP_PARSE_INVALID;
-				}
 				c = lowcase[ch];
 				if (c != 0) {
 					prsr->hdr_name[0] = c;
@@ -306,9 +303,6 @@ http_parse_header_line(struct http_parser *prsr, char **bufp,
 			break;
 		/* http_header name */
 		case sw_name:
-			if (ch < 0) {
-				return HTTP_PARSE_INVALID;
-			}
 			c = lowcase[ch];
 			if (c != 0) {
 				if (prsr->hdr_name_idx < max_hname_len) {


### PR DESCRIPTION
Fix build errors on arm64 with CMAKE_BUILD_TYPE=Debug.

Despite doubts about the correctness of http parser, keep the principle of its work and unify behavior whether plain char is signed or unsigned.

Closes #6143