### PR TITLE
txm: fix a dangerous misprint in gap handling

### DIFF
--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1055,7 +1055,6 @@ memtx_tx_handle_gap_write(struct txn *txn, struct space *space,
 			if (memtx_tx_cause_conflict(txn, item->txn) != 0)
 				return -1;
 			is_split = true;
-			continue;
 		} else {
 			struct key_def *def = index->def->key_def;
 			hint_t oh = def->key_hint(item->key, item->part_count, def);

--- a/test/box/tx_man.result
+++ b/test/box/tx_man.result
@@ -2429,6 +2429,56 @@ s:drop()
  | ---
  | ...
 
+s = box.schema.create_space('test')
+ | ---
+ | ...
+_ = s:create_index('pk')
+ | ---
+ | ...
+tx1:begin()
+ | ---
+ | - 
+ | ...
+tx1('s:select{}')
+ | ---
+ | - - []
+ | ...
+tx2:begin()
+ | ---
+ | - 
+ | ...
+tx2('s:replace{2, 2, 2}')
+ | ---
+ | - - [2, 2, 2]
+ | ...
+tx3:begin()
+ | ---
+ | - 
+ | ...
+tx3('s:replace{1, 1, 1}')
+ | ---
+ | - - [1, 1, 1]
+ | ...
+tx3:commit()
+ | ---
+ | - 
+ | ...
+tx1('s:select{}')
+ | ---
+ | - - []
+ | ...
+tx1:commit();
+ | ---
+ | - 
+ | ...
+tx2:rollback()
+ | ---
+ | - 
+ | ...
+s:drop()
+ | ---
+ | ...
+
 test_run:cmd("switch default")
  | ---
  | - true

--- a/test/box/tx_man.test.lua
+++ b/test/box/tx_man.test.lua
@@ -772,6 +772,20 @@ end
 for _,fib in pairs(fibers) do fib:join() end
 s:drop()
 
+s = box.schema.create_space('test')
+_ = s:create_index('pk')
+tx1:begin()
+tx1('s:select{}')
+tx2:begin()
+tx2('s:replace{2, 2, 2}')
+tx3:begin()
+tx3('s:replace{1, 1, 1}')
+tx3:commit()
+tx1('s:select{}')
+tx1:commit();
+tx2:rollback()
+s:drop()
+
 test_run:cmd("switch default")
 test_run:cmd("stop server tx_man")
 test_run:cmd("cleanup server tx_man")


### PR DESCRIPTION
Read gap is a fact that a search by key in index found nothing.
In order to remember that fact a record is stored in the nearest
(to the right) tuple in that index; in case of no such tuple -
in special place in struct index.
In other words a gap record means that its transaction can be
vulnerable to inserts into that place in index. If something is
inserted into that gap - its transaction must fall into read view
or be aborted.

Further, if a tuple is inserted into that place of index, we have
to decide to which interval (or to both) that gap belongs. If its
owner transaction is vulnerable to both subintervals - the gap
record is splitted into two parts.

There's a special case when the search key is NULL, that stands
for index:select{} call (with empty table as an argument).
Obviously such a read is vulnerable to writes to any part of that
index, that means that such a gap record must always be splitted.

This patch remove an obvious misprint and makes gap to be splitted
in this case.

Part of #6206