### PR TITLE
txm: fix ER_TUPLE_FOUND error message in MVCC

### DIFF
--- a/changelogs/unreleased/gh-6247-broken-error-message.md
+++ b/changelogs/unreleased/gh-6247-broken-error-message.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fix an error message that happened in very specific case
+  during mvcc operation (gh-6247)

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -997,7 +997,9 @@ check_dup_dirty(struct txn_stmt *stmt, struct tuple *new_tuple,
 			 */
 			diag_set(ClientError, ER_TUPLE_FOUND,
 				 space->index[i]->def->name,
-				 space_name(space));
+				 space_name(space),
+				 tuple_str(replaced[i]),
+				 tuple_str(new_tuple));
 			return -1;
 		}
 

--- a/test/box/tx_man.result
+++ b/test/box/tx_man.result
@@ -2479,6 +2479,48 @@ s:drop()
  | ---
  | ...
 
+--https://github.com/tarantool/tarantool/issues/6247
+s = box.schema.create_space('test')
+ | ---
+ | ...
+pk = s:create_index('pk', {parts={1, 'uint'}})
+ | ---
+ | ...
+sk = s:create_index('sk', {parts={2, 'uint'}})
+ | ---
+ | ...
+
+-- Make lots of changes to ensure that GC make the first tuple {1, 1,1} clean.
+collectgarbage('collect')
+ | ---
+ | - 0
+ | ...
+for i = 1,10 do s:replace{i, i, i} end
+ | ---
+ | ...
+collectgarbage('collect')
+ | ---
+ | - 0
+ | ...
+for i = 11,100 do s:replace{i, i, i} end
+ | ---
+ | ...
+-- Make a new tuple that is definitely dirty now.
+s:replace{0, 0, 0}
+ | ---
+ | - [0, 0, 0]
+ | ...
+-- Hit dirty {0, 0, 0} in pk and conflict clean {1, 1, 1}.
+s:replace{0, 1, 0}
+ | ---
+ | - error: Duplicate key exists in unique index "sk" in space "test" with old tuple
+ |     - [1, 1, 1] and new tuple - [0, 1, 0]
+ | ...
+
+s:drop()
+ | ---
+ | ...
+
 test_run:cmd("switch default")
  | ---
  | - true


### PR DESCRIPTION
At some point ER_TUPLE_FOUND error message was extended to contain
old tuple and new tuple. It seems that after rebase this change
was ignored in MVCC code that used prevous format. This patch
fixes that.

Closes #6247