### PR TITLE
fiber: keep reference to userdata if fiber created once

### DIFF
--- a/changelogs/unreleased/fiber-access-optimization.md
+++ b/changelogs/unreleased/fiber-access-optimization.md
@@ -1,0 +1,4 @@
+## feature/lua/fiber
+
+* Improved fiber fiber.self(), fiber.id() and fiber.find()
+  performance by 2-3 times.

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -895,6 +895,7 @@ fiber_recycle(struct fiber *fiber)
 	fiber->f = NULL;
 	fiber->wait_pad = NULL;
 	memset(&fiber->storage, 0, sizeof(fiber->storage));
+	fiber->storage.lua.storage_ref = FIBER_LUA_NOREF;
 	unregister_fid(fiber);
 	fiber->fid = 0;
 	region_free(&fiber->gc);
@@ -1236,6 +1237,7 @@ fiber_new_ex(const char *name, const struct fiber_attr *fiber_attr,
 			return NULL;
 		}
 		memset(fiber, 0, sizeof(struct fiber));
+		fiber->storage.lua.storage_ref = FIBER_LUA_NOREF;
 
 		if (fiber_stack_create(fiber, &cord()->slabc,
 				       fiber_attr->stack_size)) {

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -896,6 +896,7 @@ fiber_recycle(struct fiber *fiber)
 	fiber->wait_pad = NULL;
 	memset(&fiber->storage, 0, sizeof(fiber->storage));
 	fiber->storage.lua.storage_ref = FIBER_LUA_NOREF;
+	fiber->storage.lua.fid_ref = FIBER_LUA_NOREF;
 	unregister_fid(fiber);
 	fiber->fid = 0;
 	region_free(&fiber->gc);
@@ -1238,6 +1239,7 @@ fiber_new_ex(const char *name, const struct fiber_attr *fiber_attr,
 		}
 		memset(fiber, 0, sizeof(struct fiber));
 		fiber->storage.lua.storage_ref = FIBER_LUA_NOREF;
+		fiber->storage.lua.fid_ref = FIBER_LUA_NOREF;
 
 		if (fiber_stack_create(fiber, &cord()->slabc,
 				       fiber_attr->stack_size)) {

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -626,7 +626,7 @@ struct fiber {
 			/**
 			 * Optional fiber.storage Lua reference.
 			 */
-			int ref;
+			int storage_ref;
 		} lua;
 		/**
 		 * Iproto sync.

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -46,6 +46,16 @@
 #include <coro/coro.h>
 
 /*
+ * This constant is the same as LUA_NOREF. It should be used
+ * to initialize all Lua references in struct fiber.
+ * Since this module is independent on Lua the constant is
+ * defined directly. Value should be checked with
+ * static_assert in appropriate places to catch possible
+ * LUA_NOREF value changes in future.
+ */
+#define FIBER_LUA_NOREF (-2)
+
+/*
  * Fiber top doesn't work on ARM processors at the moment,
  * because we haven't chosen an alternative to rdtsc.
  */

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -634,6 +634,11 @@ struct fiber {
 			 */
 			struct lua_State *stack;
 			/**
+			 * Optional reference to userdata
+			 * representing current fiber id in Lua.
+			 */
+			int fid_ref;
+			/**
 			 * Optional fiber.storage Lua reference.
 			 */
 			int storage_ref;

--- a/src/lua/fiber.c
+++ b/src/lua/fiber.c
@@ -670,7 +670,7 @@ lbox_fiber_name(struct lua_State *L)
 
 /**
  * Trigger invoked when the fiber has stopped execution of its
- * current request. Only purpose - delete storage.lua.ref keeping
+ * current request. Only purpose - delete storage.lua.storage_ref keeping
  * a reference of Lua fiber.storage object. Unlike Lua stack,
  * Lua fiber storage may be created not only for fibers born from
  * Lua land. For example, an IProto request may execute a Lua
@@ -681,10 +681,10 @@ static int
 lbox_fiber_on_stop(struct trigger *trigger, void *event)
 {
 	struct fiber *f = (struct fiber *) event;
-	int storage_ref = f->storage.lua.ref;
+	int storage_ref = f->storage.lua.storage_ref;
 	assert(storage_ref > 0);
 	luaL_unref(tarantool_L, LUA_REGISTRYINDEX, storage_ref);
-	f->storage.lua.ref = LUA_NOREF;
+	f->storage.lua.storage_ref = LUA_NOREF;
 	trigger_clear(trigger);
 	free(trigger);
 	return 0;
@@ -694,7 +694,7 @@ static int
 lbox_fiber_storage(struct lua_State *L)
 {
 	struct fiber *f = lbox_checkfiber(L, 1);
-	int storage_ref = f->storage.lua.ref;
+	int storage_ref = f->storage.lua.storage_ref;
 	if (storage_ref <= 0) {
 		struct trigger *t = (struct trigger *)
 			malloc(sizeof(*t));
@@ -706,7 +706,7 @@ lbox_fiber_storage(struct lua_State *L)
 		trigger_add(&f->on_stop, t);
 		lua_newtable(L); /* create local storage on demand */
 		storage_ref = luaL_ref(L, LUA_REGISTRYINDEX);
-		f->storage.lua.ref = storage_ref;
+		f->storage.lua.storage_ref = storage_ref;
 	}
 	lua_rawgeti(L, LUA_REGISTRYINDEX, storage_ref);
 	return 1;

--- a/src/lua/fiber.c
+++ b/src/lua/fiber.c
@@ -38,7 +38,8 @@
 
 #include <lua.h>
 #include <lauxlib.h>
-#include <lualib.h>
+
+static_assert(FIBER_LUA_NOREF == LUA_NOREF, "FIBER_LUA_NOREF is ok");
 
 void
 luaL_testcancel(struct lua_State *L)
@@ -683,9 +684,8 @@ lbox_fiber_on_stop(struct trigger *trigger, void *event)
 {
 	struct fiber *f = (struct fiber *) event;
 	int storage_ref = f->storage.lua.storage_ref;
-	assert(storage_ref > 0);
 	luaL_unref(tarantool_L, LUA_REGISTRYINDEX, storage_ref);
-	f->storage.lua.storage_ref = LUA_NOREF;
+	f->storage.lua.storage_ref = FIBER_LUA_NOREF;
 	trigger_clear(trigger);
 	free(trigger);
 	return 0;
@@ -696,7 +696,7 @@ lbox_fiber_storage(struct lua_State *L)
 {
 	struct fiber *f = lbox_checkfiber(L, 1);
 	int storage_ref = f->storage.lua.storage_ref;
-	if (storage_ref <= 0) {
+	if (storage_ref == FIBER_LUA_NOREF) {
 		struct trigger *t = (struct trigger *)
 			malloc(sizeof(*t));
 		if (t == NULL) {

--- a/src/lua/fiber.c
+++ b/src/lua/fiber.c
@@ -88,27 +88,26 @@ luaL_testcancel(struct lua_State *L)
 static const char *fiberlib_name = "fiber";
 
 /**
- * @pre: stack top contains a table
- * @post: sets table field specified by name of the table on top
- * of the stack to a weak kv table and pops that weak table.
+ * Trigger invoked when the fiber has stopped execution of its
+ * current request. Only purpose - delete storage.lua.fid_ref and
+ * storage.lua.storage_ref keeping a reference of Lua
+ * fiber and fiber.storage objects. Unlike Lua stack,
+ * Lua fiber storage may be created not only for fibers born from
+ * Lua land. For example, an IProto request may execute a Lua
+ * function, which can create the storage. Trigger guarantees,
+ * that even for non-Lua fibers the Lua storage is destroyed.
  */
-static void
-lbox_create_weak_table(struct lua_State *L, const char *name)
+static int
+lbox_fiber_on_stop(struct trigger *trigger, void *event)
 {
-	lua_newtable(L);
-	/* and a metatable */
-	lua_newtable(L);
-	/* weak keys and values */
-	lua_pushstring(L, "kv");
-	/* pops 'kv' */
-	lua_setfield(L, -2, "__mode");
-	/* pops the metatable */
-	lua_setmetatable(L, -2);
-	/* assigns and pops table */
-	lua_setfield(L, -2, name);
-	/* gets memoize back. */
-	lua_getfield(L, -1, name);
-	assert(! lua_isnil(L, -1));
+	struct fiber *f = event;
+	luaL_unref(tarantool_L, LUA_REGISTRYINDEX, f->storage.lua.storage_ref);
+	f->storage.lua.storage_ref = FIBER_LUA_NOREF;
+	luaL_unref(tarantool_L, LUA_REGISTRYINDEX, f->storage.lua.fid_ref);
+	f->storage.lua.fid_ref = FIBER_LUA_NOREF;
+	trigger_clear(trigger);
+	free(trigger);
+	return 0;
 }
 
 /**
@@ -117,42 +116,26 @@ lbox_create_weak_table(struct lua_State *L, const char *name)
 static void
 lbox_pushfiber(struct lua_State *L, struct fiber *f)
 {
-	/*
-	 * Use 'memoize'  pattern and keep a single userdata for
-	 * the given fiber. This is important to not run __gc
-	 * twice for a copy of an attached fiber -- __gc should
-	 * not remove attached fiber's coro prematurely.
-	 */
-	luaL_getmetatable(L, fiberlib_name);
-	lua_getfield(L, -1, "memoize");
-	if (lua_isnil(L, -1)) {
-		/* first access - instantiate memoize */
-		/* pop the nil */
-		lua_pop(L, 1);
-		/* create memoize table */
-		lbox_create_weak_table(L, "memoize");
-	}
-	/* Find out whether the fiber is  already in the memoize table. */
-	uint64_t fid = f->fid;
-	luaL_pushuint64(L, fid);
-	lua_gettable(L, -2);
-	if (lua_isnil(L, -1)) {
-		/* no userdata for fiber created so far */
-		/* pop the nil */
-		lua_pop(L, 1);
-		/* push the key back */
-		luaL_pushuint64(L, fid);
+	int fid_ref = f->storage.lua.fid_ref;
+	if (fid_ref == FIBER_LUA_NOREF) {
+		struct trigger *t = malloc(sizeof(*t));
+		if (t == NULL) {
+			diag_set(OutOfMemory, sizeof(*t), "malloc", "t");
+			luaT_error(L);
+		}
+		trigger_create(t, lbox_fiber_on_stop, NULL, (trigger_f0)free);
+		trigger_add(&f->on_stop, t);
+
+		uint64_t fid = f->fid;
 		/* create a new userdata */
 		uint64_t *ptr = lua_newuserdata(L, sizeof(*ptr));
 		*ptr = fid;
 		luaL_getmetatable(L, fiberlib_name);
 		lua_setmetatable(L, -2);
-		/* memoize it */
-		lua_settable(L, -3);
-		luaL_pushuint64(L, fid);
-		/* get it back */
-		lua_gettable(L, -2);
+		fid_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+		f->storage.lua.fid_ref = fid_ref;
 	}
+	lua_rawgeti(L, LUA_REGISTRYINDEX, fid_ref);
 }
 
 static struct fiber *
@@ -670,41 +653,12 @@ lbox_fiber_name(struct lua_State *L)
 	}
 }
 
-/**
- * Trigger invoked when the fiber has stopped execution of its
- * current request. Only purpose - delete storage.lua.storage_ref keeping
- * a reference of Lua fiber.storage object. Unlike Lua stack,
- * Lua fiber storage may be created not only for fibers born from
- * Lua land. For example, an IProto request may execute a Lua
- * function, which can create the storage. Trigger guarantees,
- * that even for non-Lua fibers the Lua storage is destroyed.
- */
-static int
-lbox_fiber_on_stop(struct trigger *trigger, void *event)
-{
-	struct fiber *f = (struct fiber *) event;
-	int storage_ref = f->storage.lua.storage_ref;
-	luaL_unref(tarantool_L, LUA_REGISTRYINDEX, storage_ref);
-	f->storage.lua.storage_ref = FIBER_LUA_NOREF;
-	trigger_clear(trigger);
-	free(trigger);
-	return 0;
-}
-
 static int
 lbox_fiber_storage(struct lua_State *L)
 {
 	struct fiber *f = lbox_checkfiber(L, 1);
 	int storage_ref = f->storage.lua.storage_ref;
 	if (storage_ref == FIBER_LUA_NOREF) {
-		struct trigger *t = (struct trigger *)
-			malloc(sizeof(*t));
-		if (t == NULL) {
-			diag_set(OutOfMemory, sizeof(*t), "malloc", "t");
-			return luaT_error(L);
-		}
-		trigger_create(t, lbox_fiber_on_stop, NULL, (trigger_f0) free);
-		trigger_add(&f->on_stop, t);
 		lua_newtable(L); /* create local storage on demand */
 		storage_ref = luaL_ref(L, LUA_REGISTRYINDEX);
 		f->storage.lua.storage_ref = storage_ref;


### PR DESCRIPTION
This patch reworks approach to fiber management in Lua. Before
this patch each action that should return fiber led to new
userdata creation that was quite slow and made GC suffer. This
patch introduces new field in struct fiber to store a reference to
userdata that was created once for a fiber. It allows speedup
operations as fiber.self() and fiber.id().
Simple benchmark shows that access to fiber storage is faster in
two times, fiber.find() - 2-3 times and fiber.new/create functions
don't have any changes.

---
Benchmark:
```lua
local clock = require('clock')
local fiber = require('fiber')

local start = clock.time()
for _ = 1, 1e6 do
    fiber.self().storage['a'] = 'b'
end
print('fiber.self().storage', clock.time() - start)

collectgarbage()
collectgarbage()

local start = clock.time()
for _ = 1, 1e3 do
    fiber.new(function() end)
end
fiber.yield()
print('fiber.new()', clock.time() - start)

collectgarbage()
collectgarbage()

local id = fiber.id()
local start = clock.time()
for _ = 1, 1e5 do
    fiber.find(id)
end
print('fiber.find()', clock.time() - start)
```

Results:
```
Before patch (Darwin-x86_64-RelWithDebugInfo):
fiber.self().storage    0.27292203903198
fiber.new()	        0.013323068618774
fiber.find()	        0.01753306388855

After patch (Darwin-x86_64-RelWithDebugInfo):
fiber.self().storage    0.1610369682312
fiber.new()	        0.012982130050659
fiber.find()	        0.0054271221160889

Before patch (Linux-x86_64-RelWithDebInfo):
fiber.self().storage    0.38473320007324
fiber.new()	        0.016422748565674
fiber.find()	        0.028634548187256

After patch (Linux-x86_64-RelWithDebInfo):
fiber.self().storage    0.19618391990662
fiber.new()	        0.015584707260132
fiber.find()	        0.01058030128479
```