### PR TITLE
sql: remove OP_Realify

### DIFF
--- a/changelogs/unreleased/gh-5335-remove-wrong-double-to-int-cast.md
+++ b/changelogs/unreleased/gh-5335-remove-wrong-double-to-int-cast.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Removed spontaneous conversion from INTEGER to DOUBLE in a field of type
+  NUMBER (gh-5335).

--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -3700,11 +3700,6 @@ sqlExprCodeTarget(Parse * pParse, Expr * pExpr, int target)
 				sqlVdbeAddOp3(v, OP_Column,
 						  pAggInfo->sortingIdxPTab,
 						  pCol->iSorterColumn, target);
-				if (pCol->space_def->fields[pExpr->iAgg].type ==
-				    FIELD_TYPE_NUMBER) {
-					sqlVdbeAddOp1(v, OP_Realify,
-							  target);
-				}
 				return target;
 			}
 			/*
@@ -4260,14 +4255,6 @@ sqlExprCodeTarget(Parse * pParse, Expr * pExpr, int target)
 				    (pExpr->iTable ? "new" : "old"),
 				    pExpr->space_def->fields[
 					pExpr->iColumn].name, target));
-
-			/* If the column has type NUMBER, it may currently be stored as an
-			 * integer. Use OP_Realify to make sure it is really real.
-			 */
-			if (pExpr->iColumn >= 0 && def->fields[
-				pExpr->iColumn].type == FIELD_TYPE_NUMBER) {
-				sqlVdbeAddOp1(v, OP_Realify, target);
-			}
 			break;
 		}
 

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -1445,23 +1445,6 @@ case OP_MustBeInt: {            /* jump, in1 */
 	break;
 }
 
-/* Opcode: Realify P1 * * * *
- *
- * If register P1 holds an integer convert it to a real value.
- *
- * This opcode is used when extracting information from a column that
- * has float type.  Such column values may still be stored as
- * integers, for space efficiency, but after extraction we want them
- * to have only a real value.
- */
-case OP_Realify: {                  /* in1 */
-	pIn1 = &aMem[pOp->p1];
-	if (mem_is_int(pIn1)) {
-		mem_to_double(pIn1);
-	}
-	break;
-}
-
 /* Opcode: Cast P1 P2 * * *
  * Synopsis: type(r[P1])
  *

--- a/test/sql-tap/gh-5335-wrong-int-to-double-cast.test.lua
+++ b/test/sql-tap/gh-5335-wrong-int-to-double-cast.test.lua
@@ -1,0 +1,40 @@
+#!/usr/bin/env tarantool
+local test = require("sqltester")
+test:plan(2)
+
+test:execsql([[
+    CREATE TABLE t1 (i NUMBER PRIMARY KEY, n NUMBER);
+    CREATE TABLE t2 (i NUMBER PRIMARY KEY, n NUMBER);
+    -- This trigger is only needed to reproduce the error.
+    CREATE TRIGGER r AFTER INSERT ON t1 FOR EACH ROW BEGIN UPDATE t1 SET n = new.n; END;
+    INSERT INTO t1 VALUES (1, 1);
+    INSERT INTO t2 VALUES (1, 1);
+]])
+
+--
+-- Make sure that there are no unnecesary INTEGER to DOUBLE implicit cast in
+-- field of type NUMBER.
+--
+test:do_execsql_test(
+    "gh-5335-1",
+    [[
+        SELECT i / 2, n / 2 FROM t1;
+    ]], {
+        0, 0
+    })
+
+test:do_execsql_test(
+    "gh-5335-2",
+    [[
+        SELECT i / 2, n / 2 FROM t2 GROUP BY n;
+    ]], {
+        0, 0
+    })
+
+test:execsql([[
+    DROP TRIGGER r;
+    DROP TABLE t1;
+    DROP TABLE t2;
+]])
+
+test:finish_test()


### PR DESCRIPTION
This opcode was used to convert INTEGER values to REAL. It is not
necessary in Tarantool and causes errors.

Due to OP_Realify two type of errors appeared:
1) In some cases in trigger INTEGER may be converted to DOUBLE.
For example:
box.execute("CREATE TABLE t (i NUMBER PRIMARY KEY, n NUMBER);")
box.execute("CREATE TRIGGER t AFTER INSERT ON t FOR EACH ROW BEGIN UPDATE t SET n = new.n; END;")
box.execute("INSERT INTO t VALUES (1, 1);")
box.execute("SELECT i / 2, n / 2 FROM t;")

Result:
tarantool> box.execute("SELECT i / 2, n / 2 FROM t;")
---
- metadata:
  - name: COLUMN_1
    type: number
  - name: COLUMN_2
    type: number
  rows:
  - [0, 0.5]
...

2) If SELECT uses GROUP BY then it may return DOUBLE instead of INTEGER.
For example:
box.execute("CREATE TABLE t (i NUMBER PRIMARY KEY, n NUMBER);")
box.execute("INSERT INTO t VALUES (1,1);")
box.execute("SELECT i / 2, n / 2 FROM t GROUP BY n;")

Result:
tarantool> box.execute("SELECT i / 2, n / 2 FROM t GROUP BY n;")
---
- metadata:
  - name: COLUMN_1
    type: number
  - name: COLUMN_2
    type: number
  rows:
  - [0.5, 0.5]
...

This patch removes OP_Realify, after which these errors disappear.

Closes #5335