### PR TITLE
Alyapunov/gh 5385 tiny tuples v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ doc/*/Makefile
 extra/Makefile
 extra/*/Makefile
 extra/luarocks/hardcoded.lua
+perf/Makefile
 test/Makefile
 test/*/Makefile
 Doxyfile.API
@@ -89,6 +90,7 @@ src/box/lua/*.lua.c
 src/tarantool
 src/module.h
 tarantool-*.tar.gz
+perf/*.perftest
 test/lib/
 test/unit/*.test
 test/unit/fiob

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -595,6 +595,7 @@ include (cmake/rpm.cmake)
 add_subdirectory(src)
 add_subdirectory(extra)
 add_subdirectory(test)
+add_subdirectory(perf)
 add_subdirectory(doc)
 
 option(WITH_NOTIFY_SOCKET "Enable notifications on NOTIFY_SOCKET" ON)

--- a/changelogs/unreleased/gh-5385-tiny-tuples-v3.md
+++ b/changelogs/unreleased/gh-5385-tiny-tuples-v3.md
@@ -1,0 +1,3 @@
+## feature/core
+
+* Introduce compact tuples that allow to save 4 bytes per tuple in case of small userdata  (gh-5385)

--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(CMAKE_CXX_STANDARD 11)
+
+find_package(benchmark QUIET)
+if (NOT ${benchmark_FOUND})
+    message(AUTHOR_WARNING "Google Benchmark library was not found")
+    return()
+endif()
+
+include_directories(${MSGPUCK_INCLUDE_DIRS})
+include_directories(${PROJECT_SOURCE_DIR}/src/box)
+include_directories(${CMAKE_SOURCE_DIR}/third_party)
+
+add_executable(tuple.perftest tuple.cc)
+target_link_libraries(tuple.perftest core box tuple benchmark::benchmark)

--- a/perf/tuple.cc
+++ b/perf/tuple.cc
@@ -1,0 +1,450 @@
+#include "memory.h"
+#include "fiber.h"
+#include "tuple.h"
+#include "memtx_engine.h"
+
+#include <iostream>
+#include <benchmark/benchmark.h>
+
+const size_t NUM_TEST_TUPLES = 4096;
+const size_t MAX_TUPLE_DATA_SIZE = 512;
+
+// Class that creates and destroys tuple format for private memtx engine.
+class MemtxEngine {
+public:
+	static MemtxEngine &instance()
+	{
+		static MemtxEngine instance;
+		return instance;
+	}
+	struct tuple_format *format() { return fmt; }
+	struct key_def *key_def() { return kd; }
+private:
+	MemtxEngine()
+	{
+		memory_init();
+		fiber_init(fiber_c_invoke);
+		region_alloc(&fiber()->gc, 4);
+		tuple_init(NULL);
+
+		memset(&memtx, 0, sizeof(memtx));
+
+		quota_init(&memtx.quota, QUOTA_MAX);
+
+		int rc;
+		rc = slab_arena_create(&memtx.arena, &memtx.quota,
+				       16 * 1024 * 1024, 16 * 1024 * 1024,
+				       SLAB_ARENA_PRIVATE);
+		if (rc != 0)
+			abort();
+
+		slab_cache_create(&memtx.slab_cache, &memtx.arena);
+
+		float actual_alloc_factor;
+		small_alloc_create(&memtx.alloc, &memtx.slab_cache, 16, 8, 1.1,
+				   &actual_alloc_factor);
+
+		memtx.max_tuple_size = 1024 * 1024;
+
+		struct key_part_def kdp{0};
+		kdp.fieldno = 4;
+		kdp.type = FIELD_TYPE_UNSIGNED;
+		kd = key_def_new(&kdp, 1, false);
+		fmt = tuple_format_new(&memtx_tuple_format_vtab, &memtx, &kd, 1,
+					  NULL, 0, 0, NULL, false, false);
+		tuple_format_ref(fmt);
+	}
+	~MemtxEngine()
+	{
+		key_def_delete(kd);
+		tuple_format_unref(fmt);
+		small_alloc_destroy(&memtx.alloc);
+		slab_cache_destroy(&memtx.slab_cache);
+		tuple_arena_destroy(&memtx.arena);
+		tuple_free();
+		fiber_free();
+		memory_free();
+	}
+
+	struct memtx_engine memtx;
+	struct key_def *kd;
+	struct tuple_format *fmt;
+};
+
+// Generator of random msgpack array.
+class MpData {
+public:
+	const char *begin() const { return data; }
+	const char *end() const { return data_end; }
+	MpData()
+	{
+		uint64_t r1 = (uint64_t)rand() * 1024 + rand();
+		uint64_t r2 = (uint64_t)rand() * 1024 + rand();
+		uint64_t r3 = (uint64_t)rand() * 1024 + rand();
+		const size_t common_size = 12 + mp_sizeof_uint(r1) +
+			mp_sizeof_uint(r2) + mp_sizeof_uint(r3);
+		size_t add_bytes = rand() % (MAX_TUPLE_DATA_SIZE - common_size);
+		size_t add_nums = add_bytes / 5;
+
+		data_end = data;
+		data_end = mp_encode_array(data_end, 5 + add_nums);
+		data_end = mp_encode_uint(data_end, r1);
+		data_end = mp_encode_str(data_end, "hello", 5);
+		data_end = mp_encode_nil(data_end);
+		data_end = mp_encode_uint(data_end, r2);
+		data_end = mp_encode_uint(data_end, r3);
+		if (data_end - data > common_size)
+			abort();
+		for (size_t i = 0; i < add_nums; i++)
+			data_end = mp_encode_uint(data_end, 0xFFFFFF);
+		if (data_end - data > MAX_TUPLE_DATA_SIZE)
+			abort();
+	}
+private:
+	char data[MAX_TUPLE_DATA_SIZE];
+	char *data_end;
+};
+
+// Generator of set of random msgpack arrays.
+class MpDataSet {
+public:
+	static MpDataSet &instance()
+	{
+		static MpDataSet instance;
+		return instance;
+	}
+	const MpData &operator[](size_t i) const { return data[i]; }
+private:
+	MpData data[NUM_TEST_TUPLES];
+};
+
+// Generator of a set of random tuples.
+class TestTuples {
+public:
+	TestTuples()
+	{
+		format = MemtxEngine::instance().format();
+		tuple_format_ref(format);
+		MpDataSet &dataset = MpDataSet::instance();
+
+		for (size_t i = 0; i < NUM_TEST_TUPLES; i++) {
+			data[i] = memtx_tuple_new(format,
+						  dataset[i].begin(),
+						  dataset[i].end());
+			tuple_ref(data[i]);
+		}
+	}
+	~TestTuples()
+	{
+		for (size_t i = 0; i < NUM_TEST_TUPLES; i++)
+			tuple_unref(data[i]);
+
+		tuple_format_unref(format);
+	}
+	struct tuple *operator[](size_t i) { return data[i]; }
+
+private:
+	struct tuple_format *format;
+	struct tuple *data[NUM_TEST_TUPLES];
+};
+
+// memtx_tuple_new benchmark.
+static void
+bench_tuple_new(benchmark::State& state)
+{
+	size_t total_count = 0;
+
+	struct tuple_format *format = MemtxEngine::instance().format();
+	MpDataSet &dataset = MpDataSet::instance();
+	struct tuple *tuples[NUM_TEST_TUPLES];
+	size_t i = 0;
+
+	for (auto _ : state) {
+		if (i == NUM_TEST_TUPLES) {
+			total_count += i;
+			state.PauseTiming();
+			for (size_t k = 0; k < NUM_TEST_TUPLES; k++)
+				tuple_unref(tuples[k]);
+			i = 0;
+			state.ResumeTiming();
+		}
+		tuples[i] = memtx_tuple_new(format,
+					    dataset[i].begin(),
+					    dataset[i].end());
+		tuple_ref(tuples[i]);
+		++i;
+	}
+	total_count += i;
+	state.SetItemsProcessed(total_count);
+
+	for (size_t k = i; NUM_TEST_TUPLES < i; k++)
+		tuple_unref(tuples[k]);
+}
+
+BENCHMARK(bench_tuple_new);
+
+// memtx_tuple_delete benchmark.
+static void
+bench_tuple_delete(benchmark::State& state)
+{
+	size_t total_count = 0;
+
+	struct tuple_format *format = MemtxEngine::instance().format();
+	MpDataSet &dataset = MpDataSet::instance();
+	struct tuple *tuples[NUM_TEST_TUPLES];
+
+	size_t i = NUM_TEST_TUPLES;
+	for (auto _ : state) {
+		if (i == NUM_TEST_TUPLES) {
+			total_count += i;
+			state.PauseTiming();
+			for (size_t k = 0; k < NUM_TEST_TUPLES; k++) {
+				tuples[k] = memtx_tuple_new(format,
+							    dataset[k].begin(),
+							    dataset[k].end());
+				tuple_ref(tuples[k]);
+			}
+			i = 0;
+			state.ResumeTiming();
+		}
+		tuple_unref(tuples[i++]);
+	}
+	total_count += i;
+	state.SetItemsProcessed(total_count);
+
+	for (size_t k = i; k < NUM_TEST_TUPLES; k++)
+		tuple_unref(tuples[k]);
+}
+
+BENCHMARK(bench_tuple_delete);
+
+static void
+bench_tuple_ref_unref_low(benchmark::State& state)
+{
+	TestTuples tuples;
+	size_t total_count = 0;
+	const size_t NUM_REFS = 32;
+	for (auto _ : state) {
+		for (size_t k = 0; k < NUM_REFS; k++)
+			for (size_t i = 0; i < NUM_TEST_TUPLES; i++)
+				tuple_ref(tuples[i]);
+		for (size_t k = 0; k < NUM_REFS; k++)
+			for (size_t i = 0; i < NUM_TEST_TUPLES; i++)
+				tuple_unref(tuples[i]);
+		total_count += NUM_REFS * NUM_TEST_TUPLES;
+	}
+	state.SetItemsProcessed(total_count);
+}
+
+BENCHMARK(bench_tuple_ref_unref_low);
+
+static void
+bench_tuple_ref_unref_high(benchmark::State& state)
+{
+	TestTuples tuples;
+	size_t total_count = 0;
+	const size_t NUM_REFS = 1024;
+	for (auto _ : state) {
+		for (size_t k = 0; k < NUM_REFS; k++)
+			for (size_t i = 0; i < NUM_TEST_TUPLES; i++)
+				tuple_ref(tuples[i]);
+		for (size_t k = 0; k < NUM_REFS; k++)
+			for (size_t i = 0; i < NUM_TEST_TUPLES; i++)
+				tuple_unref(tuples[i]);
+		total_count += NUM_REFS * NUM_TEST_TUPLES;
+	}
+	state.SetItemsProcessed(total_count);
+}
+
+BENCHMARK(bench_tuple_ref_unref_high);
+
+// struct tuple member access benchmark.
+static void
+tuple_access_members(benchmark::State& state)
+{
+	TestTuples tuples;
+	size_t i = 0;
+	size_t total_count = 0;
+	for (auto _ : state) {
+		if (i == NUM_TEST_TUPLES) {
+			total_count += i;
+			i = 0;
+		}
+		struct tuple *t = tuples[i++];
+		benchmark::DoNotOptimize(bool(t->is_dirty));
+		benchmark::DoNotOptimize(uint16_t(t->format_id));
+	}
+	total_count += i;
+	state.SetItemsProcessed(total_count);
+}
+
+BENCHMARK(tuple_access_members);
+
+// tuple_data benchmark.
+static void
+tuple_access_data(benchmark::State& state)
+{
+	TestTuples tuples;
+	size_t i = 0;
+	size_t total_count = 0;
+	for (auto _ : state) {
+		if (i == NUM_TEST_TUPLES) {
+			total_count += i;
+			i = 0;
+		}
+		struct tuple *t = tuples[i++];
+		benchmark::DoNotOptimize(*tuple_data(t));
+	}
+	total_count += i;
+	state.SetItemsProcessed(total_count);
+}
+
+BENCHMARK(tuple_access_data);
+
+// tuple_data_range benchmark.
+static void
+tuple_access_data_range(benchmark::State& state)
+{
+	TestTuples tuples;
+	size_t i = 0;
+	size_t total_count = 0;
+	for (auto _ : state) {
+		if (i == NUM_TEST_TUPLES) {
+			total_count += i;
+			i = 0;
+		}
+		struct tuple *t = tuples[i++];
+		uint32_t size;
+		benchmark::DoNotOptimize(*tuple_data_range(t, &size));
+		benchmark::DoNotOptimize(size);
+	}
+	total_count += i;
+	state.SetItemsProcessed(total_count);
+}
+
+BENCHMARK(tuple_access_data_range);
+
+// benchmark of access of non-indexed field.
+static void
+tuple_access_unindexed_field(benchmark::State& state)
+{
+	TestTuples tuples;
+	size_t i = 0;
+	size_t total_count = 0;
+	for (auto _ : state) {
+		if (i == NUM_TEST_TUPLES) {
+			total_count += i;
+			i = 0;
+		}
+		struct tuple *t = tuples[i++];
+		benchmark::DoNotOptimize(*tuple_field(t, 3));
+	}
+	total_count += i;
+	state.SetItemsProcessed(total_count);
+}
+
+BENCHMARK(tuple_access_unindexed_field);
+
+// benchmark of access of indexed field.
+static void
+tuple_access_indexed_field(benchmark::State& state)
+{
+	TestTuples tuples;
+	size_t i = 0;
+	size_t total_count = 0;
+	for (auto _ : state) {
+		if (i == NUM_TEST_TUPLES) {
+			total_count += i;
+			i = 0;
+		}
+		struct tuple *t = tuples[i];
+		benchmark::DoNotOptimize(*tuple_field(t, 4));
+		++i;
+	}
+	total_count += i;
+	state.SetItemsProcessed(total_count);
+}
+
+BENCHMARK(tuple_access_indexed_field);
+
+// benchmark of tuple compare.
+static void
+tuple_tuple_compare(benchmark::State& state)
+{
+	TestTuples tuples;
+	size_t i = 0;
+	size_t j = 0;
+	struct key_def *kd = MemtxEngine::instance().key_def();
+	size_t total_count = 0;
+	for (auto _ : state) {
+		if (i == NUM_TEST_TUPLES) {
+			total_count += i;
+			i = 0;
+		}
+		if (j >= NUM_TEST_TUPLES)
+			j -= NUM_TEST_TUPLES;
+		struct tuple *t1 = tuples[i];
+		struct tuple *t2 = tuples[j];
+		benchmark::DoNotOptimize(tuple_compare(t1, 0, t2, 0, kd));
+		++i;
+		j += 3;
+	}
+	total_count += i;
+	state.SetItemsProcessed(total_count);
+}
+
+BENCHMARK(tuple_tuple_compare);
+
+// benchmark of tuple hints compare.
+static void
+tuple_tuple_compare_hint(benchmark::State& state)
+{
+	TestTuples tuples;
+	size_t i = 0;
+	size_t j = 0;
+	struct key_def *kd = MemtxEngine::instance().key_def();
+	size_t total_count = 0;
+	for (auto _ : state) {
+		if (i == NUM_TEST_TUPLES) {
+			total_count += i;
+			i = 0;
+		}
+		if (j >= NUM_TEST_TUPLES)
+			j -= NUM_TEST_TUPLES;
+		struct tuple *t1 = tuples[i];
+		struct tuple *t2 = tuples[j];
+		hint_t h1 = tuple_hint(t1, kd);
+		hint_t h2 = tuple_hint(t2, kd);
+		benchmark::DoNotOptimize(tuple_compare(t1, h1, t2, h2, kd));
+		++i;
+		j += 3;
+	}
+	total_count += i;
+	state.SetItemsProcessed(total_count);
+}
+
+BENCHMARK(tuple_tuple_compare_hint);
+
+BENCHMARK_MAIN();
+
+static void
+show_warning_if_debug()
+{
+#ifndef NDEBUG
+	std::cerr << "#######################################################\n"
+		  << "#######################################################\n"
+		  << "#######################################################\n"
+		  << "###                                                 ###\n"
+		  << "###                    WARNING!                     ###\n"
+		  << "###   The performance test is run in debug build!   ###\n"
+		  << "###   Test results are definitely inappropriate!    ###\n"
+		  << "###                                                 ###\n"
+		  << "#######################################################\n"
+		  << "#######################################################\n"
+		  << "#######################################################\n";
+#endif // #ifndef NDEBUG
+}
+
+struct DebugWarning {
+	DebugWarning() { show_warning_if_debug(); }
+} debug_warning;

--- a/src/box/lua/merger.c
+++ b/src/box/lua/merger.c
@@ -1115,7 +1115,7 @@ encode_result_buffer(struct lua_State *L, struct merge_source *source,
 	while (result_len < limit && (rc =
 	       merge_source_next(source, NULL, &tuple)) == 0 &&
 	       tuple != NULL) {
-		uint32_t bsize = tuple->bsize;
+		uint32_t bsize = tuple_bsize(tuple);
 		ibuf_reserve(output_buffer, bsize);
 		memcpy(output_buffer->wpos, tuple_data(tuple), bsize);
 		output_buffer->wpos += bsize;

--- a/src/box/memtx_engine.c
+++ b/src/box/memtx_engine.c
@@ -1300,7 +1300,7 @@ memtx_tuple_new(struct tuple_format *format, const char *data, const char *end)
 		goto end;
 	}
 	tuple = &memtx_tuple->base;
-	tuple->refs = 0;
+	tuple_ref_init(tuple, 0);
 	memtx_tuple->version = memtx->snapshot_version;
 	assert(tuple_len <= UINT32_MAX); /* bsize is UINT32_MAX */
 	tuple->bsize = tuple_len;
@@ -1322,7 +1322,7 @@ memtx_tuple_delete(struct tuple_format *format, struct tuple *tuple)
 {
 	struct memtx_engine *memtx = (struct memtx_engine *)format->engine;
 	say_debug("%s(%p)", __func__, tuple);
-	assert(tuple->refs == 0);
+	assert(tuple_is_unreferenced(tuple));
 	struct memtx_tuple *memtx_tuple =
 		container_of(tuple, struct memtx_tuple, base);
 	size_t total = tuple_size(tuple) + offsetof(struct memtx_tuple, base);

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1489,14 +1489,14 @@ memtx_tx_history_commit_stmt(struct txn_stmt *stmt)
 	size_t res = 0;
 	if (stmt->add_story != NULL) {
 		assert(stmt->add_story->add_stmt == stmt);
-		res += stmt->add_story->tuple->bsize;
+		res += tuple_bsize(stmt->add_story->tuple);
 		stmt->add_story->add_stmt = NULL;
 		stmt->add_story = NULL;
 	}
 	if (stmt->del_story != NULL) {
 		assert(stmt->del_story->del_stmt == stmt);
 		assert(stmt->next_in_del_list == NULL);
-		res -= stmt->del_story->tuple->bsize;
+		res -= tuple_bsize(stmt->del_story->tuple);
 		stmt->del_story->del_stmt = NULL;
 		stmt->del_story = NULL;
 	}

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -1248,7 +1248,7 @@ vdbe_field_ref_prepare_tuple(struct vdbe_field_ref *field_ref,
 			     struct tuple *tuple)
 {
 	vdbe_field_ref_create(field_ref, tuple, tuple_data(tuple),
-			      tuple->bsize);
+			      tuple_bsize(tuple));
 }
 
 ssize_t

--- a/src/box/tuple.c
+++ b/src/box/tuple.c
@@ -115,12 +115,8 @@ runtime_tuple_new(struct tuple_format *format, const char *data, const char *end
 		goto end;
 	uint32_t field_map_size = field_map_build_size(&builder);
 	uint32_t data_offset = sizeof(struct tuple) + field_map_size;
-	if (data_offset > INT16_MAX) {
-		/** tuple->data_offset is 15 bits */
-		diag_set(ClientError, ER_TUPLE_METADATA_IS_TOO_BIG,
-			 data_offset);
+	if (tuple_check_data_offset(data_offset) != 0)
 		goto end;
-	}
 
 	size_t data_len = end - data;
 	size_t total = sizeof(struct tuple) + field_map_size + data_len;
@@ -131,12 +127,9 @@ runtime_tuple_new(struct tuple_format *format, const char *data, const char *end
 		goto end;
 	}
 
-	tuple_ref_init(tuple, 0);
-	tuple->bsize = data_len;
-	tuple->format_id = tuple_format_id(format);
+	tuple_create(tuple, 0, tuple_format_id(format),
+		     data_offset, data_len);
 	tuple_format_ref(format);
-	tuple->data_offset = data_offset;
-	tuple->is_dirty = false;
 	char *raw = (char *) tuple + data_offset;
 	field_map_build(&builder, raw - field_map_size);
 	memcpy(raw, data, data_len);
@@ -609,7 +602,7 @@ size_t
 box_tuple_bsize(box_tuple_t *tuple)
 {
 	assert(tuple != NULL);
-	return tuple->bsize;
+	return tuple_bsize(tuple);
 }
 
 ssize_t

--- a/src/box/tuple.h
+++ b/src/box/tuple.h
@@ -325,6 +325,12 @@ struct PACKED tuple
 	 * For private use only.
 	 */
 	bool has_uploaded_refs : 1;
+	/**
+	 * The tuple (if it's found in index for example) could be invisible
+	 * for current transactions. The flag means that the tuple must
+	 * be clarified by transaction engine.
+	 */
+	bool is_dirty : 1;
 	/** Format identifier. */
 	uint16_t format_id;
 	/**
@@ -335,13 +341,7 @@ struct PACKED tuple
 	/**
 	 * Offset to the MessagePack from the begin of the tuple.
 	 */
-	uint16_t data_offset : 15;
-	/**
-	 * The tuple (if it's found in index for example) could be invisible
-	 * for current transactions. The flag means that the tuple must
-	 * be clarified by transaction engine.
-	 */
-	bool is_dirty : 1;
+	uint16_t data_offset;
 	/**
 	 * Engine specific fields and offsets array concatenated
 	 * with MessagePack fields array.

--- a/src/box/tuple_compare.cc
+++ b/src/box/tuple_compare.cc
@@ -874,7 +874,7 @@ tuple_compare_with_key_sequential(struct tuple *tuple, hint_t tuple_hint,
 		 * Key's and tuple's first field_count fields are
 		 * equal, and their bsize too.
 		 */
-		key += tuple->bsize - mp_sizeof_array(field_count);
+		key += tuple_bsize(tuple) - mp_sizeof_array(field_count);
 		for (uint32_t i = field_count; i < part_count;
 		     ++i, mp_next(&key)) {
 			if (mp_typeof(*key) != MP_NIL)

--- a/src/box/tuple_extract_key.cc
+++ b/src/box/tuple_extract_key.cc
@@ -95,7 +95,7 @@ tuple_extract_key_sequential(struct tuple *tuple, struct key_def *key_def,
 	assert(!has_optional_parts || key_def->is_nullable);
 	assert(has_optional_parts == key_def->has_optional_parts);
 	const char *data = tuple_data(tuple);
-	const char *data_end = data + tuple->bsize;
+	const char *data_end = data + tuple_bsize(tuple);
 	return tuple_extract_key_sequential_raw<has_optional_parts>(data,
 								    data_end,
 								    key_def,
@@ -127,7 +127,7 @@ tuple_extract_key_slowpath(struct tuple *tuple, struct key_def *key_def,
 	uint32_t bsize = mp_sizeof_array(part_count);
 	struct tuple_format *format = tuple_format(tuple);
 	const uint32_t *field_map = tuple_field_map(tuple);
-	const char *tuple_end = data + tuple->bsize;
+	const char *tuple_end = data + tuple_bsize(tuple);
 
 	/* Calculate the key size. */
 	for (uint32_t i = 0; i < part_count; ++i) {

--- a/src/box/vy_stmt.c
+++ b/src/box/vy_stmt.c
@@ -189,7 +189,7 @@ vy_stmt_alloc(struct tuple_format *format, uint32_t data_offset, uint32_t bsize)
 	say_debug("vy_stmt_alloc(format = %d data_offset = %u, bsize = %u) = %p",
 		  format->id, data_offset, bsize, tuple);
 	tuple_create(tuple, 1, tuple_format_id(format),
-		     data_offset, bsize);
+		     data_offset, bsize, false);
 	if (cord_is_main())
 		tuple_format_ref(format);
 	vy_stmt_set_lsn(tuple, 0);

--- a/src/box/vy_stmt.c
+++ b/src/box/vy_stmt.c
@@ -99,7 +99,7 @@ static void
 vy_tuple_delete(struct tuple_format *format, struct tuple *tuple)
 {
 	say_debug("%s(%p)", __func__, tuple);
-	assert(tuple->refs == 0);
+	assert(tuple_is_unreferenced(tuple));
 	/*
 	 * Turn off formats referencing in worker threads to avoid
 	 * multithread unsafe modifications of a reference
@@ -192,7 +192,7 @@ vy_stmt_alloc(struct tuple_format *format, uint32_t data_offset, uint32_t bsize)
 	}
 	say_debug("vy_stmt_alloc(format = %d data_offset = %u, bsize = %u) = %p",
 		  format->id, data_offset, bsize, tuple);
-	tuple->refs = 1;
+	tuple_ref_init(tuple, 1);
 	tuple->format_id = tuple_format_id(format);
 	if (cord_is_main())
 		tuple_format_ref(format);
@@ -221,7 +221,7 @@ vy_stmt_dup(struct tuple *stmt)
 	assert(tuple_size(res) == tuple_size(stmt));
 	assert(res->data_offset == stmt->data_offset);
 	memcpy(res, stmt, tuple_size(stmt));
-	res->refs = 1;
+	tuple_ref_init(res, 1);
 	return res;
 }
 
@@ -248,7 +248,7 @@ vy_stmt_dup_lsregion(struct tuple *stmt, struct lsregion *lsregion,
 	 * The reference count here is set to 0 for an assertion if somebody
 	 * will try to unreference this statement.
 	 */
-	mem_stmt->refs = 0;
+	tuple_ref_init(mem_stmt, 0);
 	return mem_stmt;
 
 	/*

--- a/src/box/vy_stmt.h
+++ b/src/box/vy_stmt.h
@@ -591,7 +591,7 @@ vy_stmt_upsert_ops(struct tuple *tuple, uint32_t *mp_size)
 	assert(vy_stmt_type(tuple) == IPROTO_UPSERT);
 	const char *mp = tuple_data(tuple);
 	mp_next(&mp);
-	*mp_size = tuple_data(tuple) + tuple->bsize - mp;
+	*mp_size = tuple_data(tuple) + tuple_bsize(tuple) - mp;
 	return mp;
 }
 

--- a/src/box/vy_stmt.h
+++ b/src/box/vy_stmt.h
@@ -238,7 +238,7 @@ vy_stmt_set_flags(struct tuple *stmt, uint8_t flags)
 static inline uint8_t
 vy_stmt_n_upserts(struct tuple *stmt)
 {
-	assert(stmt->refs == 0);
+	assert(tuple_is_unreferenced(stmt));
 	assert(vy_stmt_type(stmt) == IPROTO_UPSERT);
 	return ((struct vy_stmt *)stmt)->n_upserts;
 }
@@ -342,7 +342,7 @@ vy_stmt_dup_lsregion(struct tuple *stmt, struct lsregion *lsregion,
 static inline bool
 vy_stmt_is_refable(struct tuple *stmt)
 {
-	return stmt->refs > 0;
+	return !tuple_is_unreferenced(stmt);
 }
 
 /**

--- a/src/box/vy_stmt.h
+++ b/src/box/vy_stmt.h
@@ -171,15 +171,17 @@ enum {
  */
 struct vy_stmt {
 	struct tuple base;
-	int64_t lsn;
-	uint8_t  type; /* IPROTO_INSERT/REPLACE/UPSERT/DELETE */
+	uint8_t type; /* IPROTO_INSERT/REPLACE/UPSERT/DELETE */
 	uint8_t flags;
+	int64_t lsn;
 	/**
 	 * Offsets array concatenated with MessagePack fields
 	 * array.
 	 * char raw[0];
 	 */
 };
+
+static_assert(sizeof(struct vy_stmt) == 24, "Just to be sure");
 
 /** Get LSN of the vinyl statement. */
 static inline int64_t

--- a/test/box/errinj.result
+++ b/test/box/errinj.result
@@ -462,7 +462,7 @@ errinj.set("ERRINJ_TUPLE_ALLOC", true)
 ...
 s:auto_increment{}
 ---
-- error: Failed to allocate 16 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 12 bytes in slab allocator for memtx_tuple
 ...
 s:select{}
 ---
@@ -470,7 +470,7 @@ s:select{}
 ...
 s:auto_increment{}
 ---
-- error: Failed to allocate 16 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 12 bytes in slab allocator for memtx_tuple
 ...
 s:select{}
 ---
@@ -478,7 +478,7 @@ s:select{}
 ...
 s:auto_increment{}
 ---
-- error: Failed to allocate 16 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 12 bytes in slab allocator for memtx_tuple
 ...
 s:select{}
 ---
@@ -492,7 +492,7 @@ box.begin()
     s:insert{1}
 box.commit();
 ---
-- error: Failed to allocate 16 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 12 bytes in slab allocator for memtx_tuple
 ...
 box.rollback();
 ---
@@ -506,7 +506,7 @@ box.begin()
     s:insert{2}
 box.commit();
 ---
-- error: Failed to allocate 16 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 12 bytes in slab allocator for memtx_tuple
 ...
 s:select{};
 ---
@@ -520,7 +520,7 @@ box.begin()
     s:insert{2}
 box.commit();
 ---
-- error: Failed to allocate 16 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 12 bytes in slab allocator for memtx_tuple
 ...
 s:select{};
 ---
@@ -539,7 +539,7 @@ box.begin()
     s:insert{2}
 box.commit();
 ---
-- error: Failed to allocate 16 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 12 bytes in slab allocator for memtx_tuple
 ...
 errinj.set("ERRINJ_TUPLE_ALLOC", false);
 ---
@@ -801,7 +801,7 @@ errinj.set("ERRINJ_TUPLE_ALLOC", true)
 ...
 s:replace{1, "test"}
 ---
-- error: Failed to allocate 21 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 17 bytes in slab allocator for memtx_tuple
 ...
 s:bsize()
 ---
@@ -813,7 +813,7 @@ utils.space_bsize(s)
 ...
 s:update({1}, {{'=', 3, '!'}})
 ---
-- error: Failed to allocate 20 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 16 bytes in slab allocator for memtx_tuple
 ...
 s:bsize()
 ---

--- a/test/box/upsert_errinj.result
+++ b/test/box/upsert_errinj.result
@@ -19,7 +19,7 @@ errinj.set("ERRINJ_TUPLE_ALLOC", true)
 ...
 s:upsert({111, '111', 222, '222'}, {{'!', 5, '!'}})
 ---
-- error: Failed to allocate 26 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 22 bytes in slab allocator for memtx_tuple
 ...
 errinj.set("ERRINJ_TUPLE_ALLOC", false)
 ---

--- a/test/unit/tuple_bigref.result
+++ b/test/unit/tuple_bigref.result
@@ -1,17 +1,41 @@
 	*** main ***
-1..2
-	*** test_bigrefs_overall ***
-    1..3
-    ok 1 - All tuples have refs == 1.
-    ok 2 - All tuples have bigrefs.
-    ok 3 - All tuples were deleted.
-	*** test_bigrefs_overall: done ***
+1..3
+	*** test_one ***
+    1..12
+    ok 1 - allocated
+    ok 2 - no bigrefs
+    ok 3 - deallocated
+    ok 4 - no bigrefs
+    ok 5 - allocated
+    ok 6 - no bigrefs
+    ok 7 - deallocated
+    ok 8 - no bigrefs
+    ok 9 - allocated
+    ok 10 - bigrefs
+    ok 11 - all deallocated
+    ok 12 - no bigrefs
+	*** test_one: done ***
 ok 1 - subtests
-	*** test_bigrefs_non_consistent ***
-    1..3
-    ok 1 - All tuples have bigrefs.
-    ok 2 - 11 tuples don't have bigrefs and all other tuples have
-    ok 3 - All tuples have bigrefs and their indexes are in right order.
-	*** test_bigrefs_non_consistent: done ***
+	*** test_batch ***
+    1..12
+    ok 1 - all allocated
+    ok 2 - no bigrefs
+    ok 3 - all deallocated
+    ok 4 - no bigrefs
+    ok 5 - all allocated
+    ok 6 - no bigrefs
+    ok 7 - all deallocated
+    ok 8 - no bigrefs
+    ok 9 - all allocated
+    ok 10 - all bigrefs
+    ok 11 - all deallocated
+    ok 12 - no bigrefs
+	*** test_batch: done ***
 ok 2 - subtests
+	*** test_random ***
+    1..2
+    ok 1 - no errors
+    ok 2 - no bigrefs
+	*** test_random: done ***
+ok 3 - subtests
 	*** main: done ***

--- a/test/vinyl/cache.result
+++ b/test/vinyl/cache.result
@@ -1033,14 +1033,14 @@ for i = 1, 100 do s:get{i} end
 ...
 box.stat.vinyl().memory.tuple_cache
 ---
-- 108500
+- 107700
 ...
 box.cfg{vinyl_cache = 50 * 1000}
 ---
 ...
 box.stat.vinyl().memory.tuple_cache
 ---
-- 49910
+- 49542
 ...
 box.cfg{vinyl_cache = 0}
 ---
@@ -1116,7 +1116,7 @@ s.index.i2:count()
 ...
 box.stat.vinyl().memory.tuple_cache -- should be about 200 KB
 ---
-- 219200
+- 218400
 ...
 s:drop()
 ---

--- a/test/vinyl/quota.result
+++ b/test/vinyl/quota.result
@@ -36,7 +36,7 @@ space:insert({1, 1})
 ...
 box.stat.vinyl().memory.level0
 ---
-- 98344
+- 98336
 ...
 space:insert({1, 1})
 ---
@@ -45,7 +45,7 @@ space:insert({1, 1})
 ...
 box.stat.vinyl().memory.level0
 ---
-- 98344
+- 98336
 ...
 space:update({1}, {{'!', 1, 100}}) -- try to modify the primary key
 ---
@@ -53,7 +53,7 @@ space:update({1}, {{'!', 1, 100}}) -- try to modify the primary key
 ...
 box.stat.vinyl().memory.level0
 ---
-- 98344
+- 98336
 ...
 space:insert({2, 2})
 ---
@@ -69,7 +69,7 @@ space:insert({4, 4})
 ...
 box.stat.vinyl().memory.level0
 ---
-- 98463
+- 98431
 ...
 box.snapshot()
 ---
@@ -95,7 +95,7 @@ _ = space:replace{1, 1, string.rep('a', 1024 * 1024 * 5)}
 ...
 box.stat.vinyl().memory.level0
 ---
-- 5292080
+- 5292072
 ...
 space:drop()
 ---

--- a/test/vinyl/quota_timeout.result
+++ b/test/vinyl/quota_timeout.result
@@ -49,7 +49,7 @@ s:count()
 ...
 box.stat.vinyl().memory.level0
 ---
-- 748248
+- 748240
 ...
 -- Since the following operation requires more memory than configured
 -- and dump is disabled, it should fail with ER_VY_QUOTA_TIMEOUT.
@@ -63,7 +63,7 @@ s:count()
 ...
 box.stat.vinyl().memory.level0
 ---
-- 748248
+- 748240
 ...
 --
 -- Check that increasing box.cfg.vinyl_memory wakes up fibers
@@ -135,7 +135,7 @@ test_run:cmd("push filter '[0-9.]+ sec' to '<sec> sec'")
 ...
 test_run:grep_log('test', 'waited for .* quota for too long.*')
 ---
-- 'waited for 1048615 bytes of vinyl memory quota for too long: <sec> sec'
+- 'waited for 1048607 bytes of vinyl memory quota for too long: <sec> sec'
 ...
 test_run:cmd("clear filter")
 ---
@@ -167,7 +167,7 @@ pad = string.rep('x', box.cfg.vinyl_memory)
 ...
 _ = s:auto_increment{pad}
 ---
-- error: Failed to allocate 1572903 bytes in lsregion for vinyl transaction
+- error: Failed to allocate 1572895 bytes in lsregion for vinyl transaction
 ...
 s:drop()
 ---

--- a/test/vinyl/stat.result
+++ b/test/vinyl/stat.result
@@ -301,7 +301,7 @@ stat_diff(istat(), st)
 ---
 - put:
     rows: 25
-    bytes: 26525
+    bytes: 26325
   rows: 25
   run_avg: 1
   run_count: 1
@@ -318,7 +318,7 @@ stat_diff(istat(), st)
     dump:
       input:
         rows: 25
-        bytes: 26525
+        bytes: 26325
       count: 1
       output:
         bytes: 26049
@@ -350,7 +350,7 @@ stat_diff(istat(), st)
 ---
 - put:
     rows: 50
-    bytes: 53050
+    bytes: 52650
   bytes: 26042
   disk:
     last_level:
@@ -364,7 +364,7 @@ stat_diff(istat(), st)
     dump:
       input:
         rows: 50
-        bytes: 53050
+        bytes: 52650
       count: 1
       output:
         bytes: 52091
@@ -402,11 +402,11 @@ stat_diff(istat(), st)
 - cache:
     index_size: 49152
     rows: 1
-    bytes: 1061
+    bytes: 1053
     lookup: 1
     put:
       rows: 1
-      bytes: 1061
+      bytes: 1053
   lookup: 1
   disk:
     iterator:
@@ -418,13 +418,13 @@ stat_diff(istat(), st)
       lookup: 1
       get:
         rows: 1
-        bytes: 1061
+        bytes: 1053
   memory:
     iterator:
       lookup: 1
   get:
     rows: 1
-    bytes: 1061
+    bytes: 1053
 ...
 -- point lookup from cache
 st = istat()
@@ -440,14 +440,14 @@ stat_diff(istat(), st)
     lookup: 1
     put:
       rows: 1
-      bytes: 1061
+      bytes: 1053
     get:
       rows: 1
-      bytes: 1061
+      bytes: 1053
   lookup: 1
   get:
     rows: 1
-    bytes: 1061
+    bytes: 1053
 ...
 -- put in memory + cache invalidate
 st = istat()
@@ -461,18 +461,18 @@ stat_diff(istat(), st)
 - cache:
     invalidate:
       rows: 1
-      bytes: 1061
+      bytes: 1053
     rows: -1
-    bytes: -1061
+    bytes: -1053
   rows: 1
   memory:
     index_size: 49152
-    bytes: 1061
+    bytes: 1053
     rows: 1
   put:
     rows: 1
-    bytes: 1061
-  bytes: 1061
+    bytes: 1053
+  bytes: 1053
 ...
 -- point lookup from memory
 st = istat()
@@ -485,22 +485,22 @@ s:get(1) ~= nil
 stat_diff(istat(), st)
 ---
 - cache:
-    bytes: 1061
+    bytes: 1053
     lookup: 1
     rows: 1
     put:
       rows: 1
-      bytes: 1061
+      bytes: 1053
   memory:
     iterator:
       lookup: 1
       get:
         rows: 1
-        bytes: 1061
+        bytes: 1053
   lookup: 1
   get:
     rows: 1
-    bytes: 1061
+    bytes: 1053
 ...
 -- put in txw + point lookup from txw
 st = istat()
@@ -520,16 +520,16 @@ stat_diff(istat(), st)
 ---
 - txw:
     rows: 1
-    bytes: 1061
+    bytes: 1053
     iterator:
       lookup: 1
       get:
         rows: 1
-        bytes: 1061
+        bytes: 1053
   lookup: 1
   get:
     rows: 1
-    bytes: 1061
+    bytes: 1053
 ...
 box.rollback()
 ---
@@ -587,14 +587,14 @@ for i = 1, 100 do s:get(i) end
 stat_diff(istat(), st, 'cache')
 ---
 - rows: 14
-  bytes: 14854
+  bytes: 14742
   evict:
     rows: 86
-    bytes: 91246
+    bytes: 90558
   lookup: 100
   put:
     rows: 100
-    bytes: 106100
+    bytes: 105300
 ...
 -- range split
 for i = 1, 100 do put(i) end
@@ -650,14 +650,14 @@ stat_diff(istat(), st)
 ---
 - cache:
     rows: 13
-    bytes: 13793
+    bytes: 13689
     evict:
       rows: 37
-      bytes: 39257
+      bytes: 38961
     lookup: 1
     put:
       rows: 51
-      bytes: 54111
+      bytes: 53703
   disk:
     iterator:
       read:
@@ -668,23 +668,23 @@ stat_diff(istat(), st)
       lookup: 2
       get:
         rows: 100
-        bytes: 106100
+        bytes: 105300
   txw:
     iterator:
       lookup: 1
       get:
         rows: 50
-        bytes: 53050
+        bytes: 52650
   memory:
     iterator:
       lookup: 1
       get:
         rows: 100
-        bytes: 106100
+        bytes: 105300
   lookup: 1
   get:
     rows: 100
-    bytes: 106100
+    bytes: 105300
 ...
 box.rollback()
 ---
@@ -717,17 +717,17 @@ stat_diff(istat(), st)
     lookup: 1
     put:
       rows: 5
-      bytes: 5305
+      bytes: 5265
     get:
       rows: 5
-      bytes: 5305
+      bytes: 5265
   txw:
     iterator:
       lookup: 1
   lookup: 1
   get:
     rows: 5
-    bytes: 5305
+    bytes: 5265
 ...
 box.rollback()
 ---
@@ -761,7 +761,7 @@ put(1)
 ...
 stat_diff(gstat(), st, 'memory.level0')
 ---
-- 1064
+- 1056
 ...
 -- use cache
 st = gstat()
@@ -772,7 +772,7 @@ _ = s:get(1)
 ...
 stat_diff(gstat(), st, 'memory.tuple_cache')
 ---
-- 1109
+- 1101
 ...
 s:delete(1)
 ---
@@ -1019,7 +1019,7 @@ istat()
       rows: 0
       bytes: 0
     lookup: 0
-    bytes: 13793
+    bytes: 13689
     get:
       rows: 0
       bytes: 0
@@ -1088,7 +1088,7 @@ istat()
   upsert:
     squashed: 0
     applied: 0
-  bytes: 317731
+  bytes: 316083
   put:
     rows: 0
     bytes: 0
@@ -1105,7 +1105,7 @@ istat()
         rows: 0
         bytes: 0
   memory:
-    bytes: 213431
+    bytes: 211783
     index_size: 49152
     rows: 206
     iterator:
@@ -1128,9 +1128,9 @@ gstat()
     gap_locks: 0
     read_views: 0
   memory:
-    tuple_cache: 14417
+    tuple_cache: 14313
     tx: 0
-    level0: 263210
+    level0: 261562
     page_index: 1250
     bloom_filter: 140
   disk:
@@ -1173,7 +1173,7 @@ box.snapshot()
 ...
 stat_diff(gstat(), st, 'scheduler')
 ---
-- dump_input: 104200
+- dump_input: 103400
   dump_output: 103592
   tasks_completed: 2
   dump_count: 1
@@ -1190,7 +1190,7 @@ box.snapshot()
 ...
 stat_diff(gstat(), st, 'scheduler')
 ---
-- dump_input: 10420
+- dump_input: 10340
   dump_output: 10411
   tasks_completed: 2
   dump_count: 1
@@ -1272,7 +1272,7 @@ st2 = i2:stat()
 ...
 s:bsize()
 ---
-- 53300
+- 52900
 ...
 i1:len(), i2:len()
 ---
@@ -1397,7 +1397,7 @@ st2 = i2:stat()
 ...
 s:bsize()
 ---
-- 107199
+- 106399
 ...
 i1:len(), i2:len()
 ---


### PR DESCRIPTION
    Tuple are designed to store (almost) any sizes of msgpack data
    and rather big count of field offsets. That requires data_offsert
    and bsize members of tuples to be rather large - 16 and 32 bits.
    
    That is good, but the problem is that in cases when the majority
    of tuples are small that price is significant.
    
    This patch introduces compact tuples: if tuple data size and its
    offset table are small - both tuple_offset and bsize are stored in
    one 16 bit integer and that saves 4 bytes per tuple.
    
    Compact tuples are used for memtx and runtime tuples. They are not
    implemented for vinyl, because in contrast to memtx vinyl stores
    engine specific fields after struct tuple and thus requires
    different approach for compact tuple.
