### PR TITLE
Remove "error_unpack_unsafe" from "exports"

### DIFF
--- a/extra/exports
+++ b/extra/exports
@@ -152,7 +152,6 @@ decimal_from_string
 decimal_unpack
 error_ref
 error_set_prev
-error_unpack_unsafe
 error_unref
 exception_get_int
 exception_get_string


### PR DESCRIPTION
"error_unpack_unsafe" was removed from export in commit [1] and accidentally reanimated during rebase [2].
Let's remove "error_unpack_unsafe" from "exports".

1. https://github.com/tarantool/tarantool/commit/6aafa697e1ec8166df721573195711cea5ec3135
2. https://github.com/tarantool/tarantool/commit/5ceabb378d0169dc776449e45577515114e39f12

Follow-up #5932