### PR TITLE
github-ci: delete option in odroid debug workflow

### DIFF
--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -31,8 +31,6 @@ jobs:
       - name: test
         env:
           CMAKE_BUILD_TYPE: Debug
-          # FIXME: disabled '-Wtype-limits' flag till #6143 is fixed.
-          CMAKE_EXTRA_PARAMS: '-DCMAKE_C_FLAGS="-Wno-type-limits "'
         run: ${CI_MAKE} test_odroid_arm64
       - name: call action to send Telegram message on failure
         env:


### PR DESCRIPTION
There was a build problem with CMAKE_BUILD_TYPE=Debug build on ARM64. It
 was fixed in 224cb68c4ddca83f0e95daa4e97a393b3a89c471 (build: fix
 build on Linux ARM64 with CMAKE_BUILD_TYPE=Debug), before this fix
 '-DCMAKE_C_FLAGS="-Wno-type-limits "' was used to avoid the issue,
 implemented by 72c77166344e0a42293aaaed7d838dff000de746 (github-ci:
 add GitHub Actions workflow for Odroid).

Follow-up #6143