### PR TITLE
lua: fix several possibility crashes in lua triggers implementation.

### DIFF
--- a/changelogs/unreleased/gh-6266-fix-crash-in-lua-triggers.md
+++ b/changelogs/unreleased/gh-6266-fix-crash-in-lua-triggers.md
@@ -1,0 +1,5 @@
+## bugfix/lua/triggers
+
+* Fixed possibility crash in case when trigger removes itself.
+  Fixed possibility crash in case when someone destroy trigger,
+  when it's yield (gh-6266).

--- a/src/lua/trigger.c
+++ b/src/lua/trigger.c
@@ -58,7 +58,9 @@ lbox_trigger_destroy(struct trigger *ptr)
 	if (tarantool_L) {
 		struct lbox_trigger *trigger = (struct lbox_trigger *) ptr;
 		luaL_unref(tarantool_L, LUA_REGISTRYINDEX, trigger->ref);
+		TRASH(trigger);
 	}
+	TRASH(ptr);
 	free(ptr);
 }
 
@@ -91,13 +93,25 @@ lbox_trigger_run(struct trigger *ptr, void *event)
 	if (trigger->push_event != NULL) {
 		nargs = trigger->push_event(L, event);
 	}
+	/*
+	 * There are two cases why we can't access `trigger` after
+	 * calling it's function:
+	 * - trigger can be unregistered and destroyed
+	 *   directly in its function.
+	 * - trigger function may yield and someone destroy trigger
+	 *   at this moment.
+	 * So we keep 'trigger->pop_event' in local variable for
+	 * further use.
+	 */
+	lbox_pop_event_f pop_event = trigger->pop_event;
+	trigger = NULL;
 	if (luaT_call(L, nargs, LUA_MULTRET)) {
 		luaL_unref(tarantool_L, LUA_REGISTRYINDEX, coro_ref);
 		return -1;
 	}
 	int nret = lua_gettop(L) - top;
-	if (trigger->pop_event != NULL &&
-	    trigger->pop_event(L, nret, event) != 0) {
+	if (pop_event != NULL &&
+	    pop_event(L, nret, event) != 0) {
 		lua_settop(L, top);
 		luaL_unref(tarantool_L, LUA_REGISTRYINDEX, coro_ref);
 		return -1;
@@ -217,6 +231,7 @@ lbox_trigger_reset(struct lua_State *L, int top, struct rlist *list,
 
 	} else if (trg) {
 		trigger_clear(&trg->base);
+		TRASH(trg);
 		free(trg);
 	}
 	return 0;

--- a/test/box/gh-6266-crash-in-lua-triggers.result
+++ b/test/box/gh-6266-crash-in-lua-triggers.result
@@ -1,0 +1,42 @@
+-- test-run result file version 2
+env = require('test_run')
+ | ---
+ | ...
+test_run = env.new()
+ | ---
+ | ...
+
+trg = nil;
+ | ---
+ | ...
+trg = box.ctl.on_shutdown(function() trg = box.ctl.on_shutdown(nil, trg) end)
+ | ---
+ | ...
+test_run:cmd("restart server default")
+ | 
+
+fiber = require('fiber')
+ | ---
+ | ...
+channel = fiber.channel(1)
+ | ---
+ | ...
+s = box.schema.space.create('test')
+ | ---
+ | ...
+_ = s:create_index('primary')
+ | ---
+ | ...
+_ = s:on_replace(function() fiber.sleep(1) channel:put(true) end)
+ | ---
+ | ...
+_ = fiber.create(function() s:replace({7}) end)
+ | ---
+ | ...
+-- destroy on_replace triggers
+s:drop()
+ | ---
+ | ...
+_ = channel:get()
+ | ---
+ | ...

--- a/test/box/gh-6266-crash-in-lua-triggers.test.lua
+++ b/test/box/gh-6266-crash-in-lua-triggers.test.lua
@@ -1,0 +1,16 @@
+env = require('test_run')
+test_run = env.new()
+
+trg = nil;
+trg = box.ctl.on_shutdown(function() trg = box.ctl.on_shutdown(nil, trg) end)
+test_run:cmd("restart server default")
+
+fiber = require('fiber')
+channel = fiber.channel(1)
+s = box.schema.space.create('test')
+_ = s:create_index('primary')
+_ = s:on_replace(function() fiber.sleep(1) channel:put(true) end)
+_ = fiber.create(function() s:replace({7}) end)
+-- destroy on_replace triggers
+s:drop()
+_ = channel:get()


### PR DESCRIPTION
There are two cases in lua trigger implementation, which leads
to access to freed memory: if trigger removes itself and if
trigger yields and someone destroy it. These problems was fixed
by remembering the necessary fields from the trigger structure
in local variables before calling trigger function.

Closes #6266