### PR TITLE
github-ci: provide commit id within manual trigger

### DIFF
--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   centos_7:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/centos_7_arm.yml
+++ b/.github/workflows/centos_7_arm.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   centos_7_arm:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   centos_8:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/centos_8_arm.yml
+++ b/.github/workflows/centos_8_arm.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   centos_8_arm:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   debian_10:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/debian_10_arm.yml
+++ b/.github/workflows/debian_10_arm.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   debian_10_arm:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   debian_11:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/debian_11_arm.yml
+++ b/.github/workflows/debian_11_arm.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   debian_11_arm:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   debian_9:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/fedora_30.yml
+++ b/.github/workflows/fedora_30.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   fedora_30:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/fedora_31.yml
+++ b/.github/workflows/fedora_31.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   fedora_31:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/fedora_32.yml
+++ b/.github/workflows/fedora_32.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   fedora_32:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/fedora_33.yml
+++ b/.github/workflows/fedora_33.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   fedora_33:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/fedora_33_arm.yml
+++ b/.github/workflows/fedora_33_arm.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   fedora_33_arm:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   fedora_34:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/fedora_34_arm.yml
+++ b/.github/workflows/fedora_34_arm.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   fedora_34_arm:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   opensuse_15_1:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   opensuse_15_2:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - name: packaging
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/ubuntu_14_04.yml
+++ b/.github/workflows/ubuntu_14_04.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   ubuntu_14_04:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   ubuntu_16_04:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   ubuntu_18_04:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   ubuntu_20_04:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/ubuntu_20_04_arm.yml
+++ b/.github/workflows/ubuntu_20_04_arm.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   ubuntu_20_04_arm:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/ubuntu_20_10.yml
+++ b/.github/workflows/ubuntu_20_10.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   ubuntu_20_10:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/ubuntu_20_10_arm.yml
+++ b/.github/workflows/ubuntu_20_10_arm.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   ubuntu_20_10_arm:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:

--- a/.github/workflows/ubuntu_21_04.yml
+++ b/.github/workflows/ubuntu_21_04.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit id"
+        required: false
 
 jobs:
   ubuntu_21_04:
@@ -31,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/environment
       - name: packaging
         env:


### PR DESCRIPTION
Git checkout was added to workflows where packaging is located
to check if workflow_dispatch is working correctly or not

There is three types of testing
  - Short commit hash
  - Long commit hash
  - Without hash