### PR TITLE
http-client: fix setting response headers

### DIFF
--- a/src/httpc.c
+++ b/src/httpc.c
@@ -75,6 +75,27 @@ curl_easy_header_cb(char *buffer, size_t size, size_t nitems, void *ctx)
 {
 	struct httpc_request *req = (struct httpc_request *) ctx;
 	const size_t bytes = size * nitems;
+
+	/**
+	 * Skip saving response headers if redirect will be performed
+	 * (to get headers of the final response).
+	 *
+	 * From CURLOPT_HEADERFUNCTION man:
+	 * It's important to note that the callback will be invoked for the
+	 * headers of all responses received after initiating a request and
+	 * not just the final response. This includes all responses which
+	 * occur during authentication negotiation. If you need to operate
+	 * on only the headers from the final response, you will need to
+	 * collect headers in the callback yourself and use HTTP status
+	 * lines, for example, to delimit response boundaries.
+	 */
+	long response_code = 0;
+	curl_easy_getinfo(req->curl_request.easy, CURLINFO_RESPONSE_CODE, &response_code);
+	int is_redirected = (response_code / 100) == 3;
+	if (req->follow_location && is_redirected) {
+		return bytes;
+	}
+
 	char *p = region_alloc(&req->resp_headers, bytes);
 	if (p == NULL) {
 		diag_set(OutOfMemory, bytes, "ibuf", "httpc header");
@@ -149,6 +170,7 @@ httpc_request_new(struct httpc_env *env, const char *method,
 	curl_easy_setopt(req->curl_request.easy, CURLOPT_URL, url);
 
 	curl_easy_setopt(req->curl_request.easy, CURLOPT_FOLLOWLOCATION, 1);
+	req->follow_location = true;
 	curl_easy_setopt(req->curl_request.easy, CURLOPT_SSL_VERIFYPEER, 1);
 	curl_easy_setopt(req->curl_request.easy, CURLOPT_WRITEFUNCTION,
 			 curl_easy_write_cb);
@@ -357,6 +379,7 @@ httpc_set_interface(struct httpc_request *req, const char *interface)
 void
 httpc_set_follow_location(struct httpc_request *req, long follow)
 {
+	req->follow_location = (bool)follow;
 	curl_easy_setopt(req->curl_request.easy, CURLOPT_FOLLOWLOCATION,
 			 follow);
 }

--- a/src/httpc.h
+++ b/src/httpc.h
@@ -130,6 +130,14 @@ struct httpc_request {
 	 * execution automatically.
 	 */
 	bool set_keep_alive_header;
+	/**
+	 * True by default. Used to skip saving response headers
+	 * at resp_headers from not the final responses in case of
+	 * curl internal redirections (status code=3xx
+	 * CURLOPT_FOLLOWLOCATION is set), to get headers from the
+	 * final response.
+	 */
+	bool follow_location;
 };
 
 /**

--- a/test/app-tap/http_client.test.lua
+++ b/test/app-tap/http_client.test.lua
@@ -90,26 +90,47 @@ local function test_http_client(test, url, opts)
 
     -- gh-4119: specify whether to follow 'Location' header
     test:test('gh-4119: follow location', function(test)
-        test:plan(7)
+        test:plan(10)
         local endpoint = 'redirect'
 
         -- Verify that the default behaviour is to follow location.
         local r = client.request('GET', url .. endpoint, nil, opts)
+        local body_len_str = tostring((r.body and #r.body) or 0)
         test:is(r.status, 200, 'default: status')
         test:is(r.body, 'hello world', 'default: body')
+        -- gh-6101: verify headers after redirect is correct (from the final response)
+        test:is_deeply(
+            {r.headers['content-type'], r.headers['content-length']},
+            {'application/json', body_len_str},
+            'got headers from the final response (redirection)'
+        )
 
         -- Verify {follow_location = true} behaviour.
         local r = client.request('GET', url .. endpoint, nil, merge(opts, {
                                  follow_location = true}))
+        local body_len_str = tostring((r.body and #r.body) or 0)
         test:is(r.status, 200, 'follow location: status')
         test:is(r.body, 'hello world', 'follow location: body')
+        -- gh-6101: verify headers after redirecrt is correct (from the final response)
+        test:is_deeply(
+            {r.headers['content-type'], r.headers['content-length']},
+            {'application/json', body_len_str},
+            'got headers from the final response (redirection)'
+        )
 
         -- Verify {follow_location = false} behaviour.
         local r = client.request('GET', url .. endpoint, nil, merge(opts, {
                                  follow_location = false}))
+        local body_len_str = tostring((r.body and #r.body) or 0)
         test:is(r.status, 302, 'do not follow location: status')
         test:is(r.body, 'redirecting', 'do not follow location: body')
         test:is(r.headers['location'], '/', 'do not follow location: header')
+        -- gh-6101: verify headers after redirecrt is correct (from the final response)
+        test:is_deeply(
+            {r.headers['content-type'], r.headers['content-length']},
+            {nil, body_len_str},
+            'got headers from the final response (no redirection)'
+        )
     end)
 end
 


### PR DESCRIPTION
* Fix behaviour of `curl_easy_header_cb` (from src/httpc.c).
  By default CURLOPT_HEADERFUNCTION collects headers of all
  responses received after initiating a request and not just
  the final response. But in case of redirection, only headers
  from the final response is needed.

Close #6101