### PR TITLE
lua: return back table.new() method

### DIFF
--- a/src/lua/table.lua
+++ b/src/lua/table.lua
@@ -87,9 +87,10 @@ end
 
 -- table library extension
 local table = require('table')
--- require modifies global "table" module and adds "clear" function to it.
--- Lua applications like Cartridge relies on it.
+-- require modifies global "table" module and adds functions "clear" and "new".
+-- Lua applications like Cartridge rely on it.
 require('table.clear')
+require('table.new')
 
 table.copy     = table_shallowcopy
 table.deepcopy = table_deepcopy

--- a/test/app-tap/gh-6330-table-new.test.lua
+++ b/test/app-tap/gh-6330-table-new.test.lua
@@ -1,0 +1,16 @@
+#!/usr/bin/env tarantool
+
+local tap = require('tap')
+local test = tap.test('gh-6330-table-new')
+
+test:plan(2)
+local t = table.new(16, 0)
+test:ok(t, 'table new')
+
+-- The following test relies on the internal table representaion and on
+-- the way LuaJIT calculates the table lenght. Without preallocation
+-- it would be #t == 0.
+t[16] = true
+test:is(#t, 16, 'preallocation works')
+
+os.exit(test:check() and 0 or 1)


### PR DESCRIPTION
Import of `table.new` module was removed as a part of net.box
refactoring in commit 954194a1ca5c2cd1826a8a689663c827313dbbef.
The `table.new` method became unavailable in Tarantool.

This commit returns it back and adds a corresponding regression test.

Closes #6330