### PR TITLE
lua: fix several possibility crashes in lua triggers implementation.

### DIFF
--- a/changelogs/unreleased/gh-6266-fix-crash-in-lua-triggers.md
+++ b/changelogs/unreleased/gh-6266-fix-crash-in-lua-triggers.md
@@ -1,0 +1,5 @@
+## bugfix/lua/triggers
+
+* Fixed possibility crash in case when trigger removes itself.
+  Fixed possibility crash in case when someone destroy trigger,
+  when it's yield (gh-6266).

--- a/test/box/gh-6266-crash-in-lua-triggers.result
+++ b/test/box/gh-6266-crash-in-lua-triggers.result
@@ -1,0 +1,33 @@
+-- test-run result file version 2
+env = require('test_run')
+ | ---
+ | ...
+test_run = env.new()
+ | ---
+ | ...
+
+fiber = require('fiber')
+ | ---
+ | ...
+channel = fiber.channel(1)
+ | ---
+ | ...
+s = box.schema.space.create('test')
+ | ---
+ | ...
+_ = s:create_index('primary')
+ | ---
+ | ...
+_ = s:on_replace(function() fiber.sleep(1) channel:put(true) end)
+ | ---
+ | ...
+_ = fiber.create(function() s:replace({7}) end)
+ | ---
+ | ...
+-- destroy on_replace triggers
+s:drop()
+ | ---
+ | ...
+_ = channel:get()
+ | ---
+ | ...

--- a/test/box/gh-6266-crash-in-lua-triggers.test.lua
+++ b/test/box/gh-6266-crash-in-lua-triggers.test.lua
@@ -1,0 +1,12 @@
+env = require('test_run')
+test_run = env.new()
+
+fiber = require('fiber')
+channel = fiber.channel(1)
+s = box.schema.space.create('test')
+_ = s:create_index('primary')
+_ = s:on_replace(function() fiber.sleep(1) channel:put(true) end)
+_ = fiber.create(function() s:replace({7}) end)
+-- destroy on_replace triggers
+s:drop()
+_ = channel:get()


### PR DESCRIPTION
There are two cases in lua trigger implementation, which leads
to access to freed memory: if trigger removes itself and if
trigger yields and someone destroy it. These problems was fixed
by remembering the necessary fields from the trigger structure
in local variables before calling trigger function.

Closes #6266