### PR TITLE
txm: rebind read trackers of rollbacked txns (2.7)

### DIFF
--- a/changelogs/unreleased/gh-6325-not-serializable-read-before-rollback.md
+++ b/changelogs/unreleased/gh-6325-not-serializable-read-before-rollback.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fix a bug when rollback resulted in unserializable behaviour (gh-6325)

--- a/test/box/tx_man.result
+++ b/test/box/tx_man.result
@@ -3510,6 +3510,64 @@ s:drop()
  | ---
  | ...
 
+-- Found by https://github.com/tarantool/tarantool/issues/5999
+-- https://github.com/tarantool/tarantool/issues/6325
+s=box.schema.space.create("s", {engine="memtx"})
+ | ---
+ | ...
+ti=s:create_index("ti", {type="tree"})
+ | ---
+ | ...
+hi=s:create_index("hi", {type="hash"})
+ | ---
+ | ...
+
+tx1:begin()
+ | ---
+ | - 
+ | ...
+tx2:begin()
+ | ---
+ | - 
+ | ...
+tx3:begin()
+ | ---
+ | - 
+ | ...
+
+tx1("s:insert{1,'A'}")
+ | ---
+ | - - [1, 'A']
+ | ...
+tx2("s:insert{1,'B'}")
+ | ---
+ | - - [1, 'B']
+ | ...
+tx3("s:select{1}")
+ | ---
+ | - - []
+ | ...
+tx3("s:insert{2,'C'}")
+ | ---
+ | - - [2, 'C']
+ | ...
+
+tx1:rollback()
+ | ---
+ | - 
+ | ...
+tx2:commit()
+ | ---
+ | - 
+ | ...
+tx3:commit() -- Must fail as a RW reader of the rollbacked tx1
+ | ---
+ | - - {'error': 'Transaction has been aborted by conflict'}
+ | ...
+s:drop()
+ | ---
+ | ...
+
 -- https://github.com/tarantool/tarantool/issues/5801
 -- flaw #1
 box.execute([[CREATE TABLE k1 (s1 INT PRIMARY KEY);]])

--- a/test/box/tx_man.test.lua
+++ b/test/box/tx_man.test.lua
@@ -1129,6 +1129,26 @@ tx2('s:replace{11, 11}') -- make an op to become RW
 tx2:commit() -- must fail since it actually saw {1, 1, "original"}
 s:drop()
 
+-- Found by https://github.com/tarantool/tarantool/issues/5999
+-- https://github.com/tarantool/tarantool/issues/6325
+s=box.schema.space.create("s", {engine="memtx"})
+ti=s:create_index("ti", {type="tree"})
+hi=s:create_index("hi", {type="hash"})
+
+tx1:begin()
+tx2:begin()
+tx3:begin()
+
+tx1("s:insert{1,'A'}")
+tx2("s:insert{1,'B'}")
+tx3("s:select{1}")
+tx3("s:insert{2,'C'}")
+
+tx1:rollback()
+tx2:commit()
+tx3:commit() -- Must fail as a RW reader of the rollbacked tx1
+s:drop()
+
 -- https://github.com/tarantool/tarantool/issues/5801
 -- flaw #1
 box.execute([[CREATE TABLE k1 (s1 INT PRIMARY KEY);]])


### PR DESCRIPTION
RW transactions used to commit without problems after rollback
of transactions holding stories responsible to track their reads.
That behaviour led to unserializable results.
This patch fixes this problem.

Closes #6325

(cherry picked from commit f77d2869db559d59c68e97f7e490a85600fcac9d)