### PR TITLE
sql: fix quote() function

### DIFF
--- a/changelogs/unreleased/gh-6239-fix-double-for-quote.md
+++ b/changelogs/unreleased/gh-6239-fix-double-for-quote.md
@@ -1,0 +1,6 @@
+## bugfix/sql
+
+* Now function quote() will return the argument in case the argument is DOUBLE.
+  The same for all other numeric types. For types other than numeric, STRING
+  will be returned (gh-6239).
+

--- a/src/box/sql/func.c
+++ b/src/box/sql/func.c
@@ -1094,26 +1094,13 @@ quoteFunc(sql_context * context, int argc, sql_value ** argv)
 	assert(argc == 1);
 	UNUSED_PARAMETER(argc);
 	switch (argv[0]->type) {
-	case MEM_TYPE_DOUBLE:{
-			double r1, r2;
-			char zBuf[50];
-			r1 = mem_get_double_unsafe(argv[0]);
-			sql_snprintf(sizeof(zBuf), zBuf, "%!.15g", r1);
-			sqlAtoF(zBuf, &r2, 20);
-			if (r1 != r2) {
-				sql_snprintf(sizeof(zBuf), zBuf, "%!.20e",
-						 r1);
-			}
-			sql_result_text(context, zBuf, -1,
-					    SQL_TRANSIENT);
-			break;
-		}
 	case MEM_TYPE_UUID: {
 		char buf[UUID_STR_LEN + 1];
 		tt_uuid_to_string(&argv[0]->u.uuid, &buf[0]);
 		sql_result_text(context, buf, UUID_STR_LEN, SQL_TRANSIENT);
 		break;
 	}
+	case MEM_TYPE_DOUBLE:
 	case MEM_TYPE_DEC:
 	case MEM_TYPE_UINT:
 	case MEM_TYPE_INT: {

--- a/test/sql-tap/engine.cfg
+++ b/test/sql-tap/engine.cfg
@@ -29,6 +29,9 @@
     "decimal.test.lua": {
         "memtx": {"engine": "memtx"}
     },
+    "gh-6239-quote-with-double-arg.test.lua": {
+        "memtx": {"engine": "memtx"}
+    },
     "gh-4077-iproto-execute-no-bind.test.lua": {},
     "*": {
         "memtx": {"engine": "memtx"},

--- a/test/sql-tap/gh-6239-quote-with-double-arg.test.lua
+++ b/test/sql-tap/gh-6239-quote-with-double-arg.test.lua
@@ -1,0 +1,14 @@
+#!/usr/bin/env tarantool
+local test = require("sqltester")
+test:plan(1)
+
+-- Make sure that QUOTE() returns DOUBLE in cast it receives DOUBLE.
+test:do_execsql_test(
+    "gh-6239",
+    [[
+        SELECT QUOTE(1.5), TYPEOF(QUOTE(1.5));
+    ]], {
+        1.5, "double"
+    })
+
+test:finish_test()

--- a/test/sql-tap/trigger5.test.lua
+++ b/test/sql-tap/trigger5.test.lua
@@ -31,7 +31,8 @@ test:do_execsql_test(
           INSERT INTO Undo VALUES
              ((SELECT coalesce(max(id),0) + 1 FROM Undo),
               (SELECT 'INSERT INTO Item (a,b,c) VALUES (' || CAST(coalesce(old.a,'NULL') AS TEXT)
-                  || ',' || quote(old.b) || ',' || CAST(old.c AS TEXT) || ');'));
+                  || ',' || CAST(quote(old.b) AS STRING) || ',' ||
+                  CAST(old.c AS TEXT) || ');'));
         END;
         DELETE FROM Item WHERE a = 1;
         SELECT * FROM Undo;

--- a/test/sql/types.result
+++ b/test/sql/types.result
@@ -1909,10 +1909,10 @@ box.execute("SELECT quote(d) FROM t;")
   - name: COLUMN_1
     type: string
   rows:
-  - ['10.0']
-  - ['-2.0']
-  - ['3.3']
-  - ['1.8e+19']
+  - [10]
+  - [-2]
+  - [3.3]
+  - [18000000000000000000]
 ...
 box.execute("SELECT LEAST(d, 0) FROM t;")
 ---


### PR DESCRIPTION
After this patch SQL built-in function QUOTE() will return the argument
in case DOUBLE value is given. If the argument is not number, string
representation of the argument will be returned.

Closes #6239

@TarantoolBot document
Title: QUOTE() and DOUBLE argument

After this patch function QUOTE() will return argument in case it
receives DOUBLE value as an argument. The same for all other numeric
types. In case it was given value of non-numeric type, it will return
string representation of the argument.