### PR TITLE
net.box: add __serialize and __tostring methods for future objects

### DIFF
--- a/src/box/lua/net_box.c
+++ b/src/box/lua/net_box.c
@@ -1433,6 +1433,25 @@ luaT_netbox_request_gc(struct lua_State *L)
 }
 
 static int
+luaT_netbox_request_tostring(struct lua_State *L)
+{
+	lua_pushstring(L, netbox_request_typename);
+	return 1;
+}
+
+static int
+luaT_netbox_request_serialize(struct lua_State *L)
+{
+	struct netbox_request *request = luaT_check_netbox_request(L, 1);
+	if (request->index_ref != LUA_NOREF) {
+		lua_rawgeti(L, LUA_REGISTRYINDEX, request->index_ref);
+	} else {
+		lua_newtable(L);
+	}
+	return 1;
+}
+
+static int
 luaT_netbox_request_index(struct lua_State *L)
 {
 	struct netbox_request *request = luaT_check_netbox_request(L, 1);
@@ -2107,6 +2126,8 @@ luaopen_net_box(struct lua_State *L)
 
 	static const struct luaL_Reg netbox_request_meta[] = {
 		{ "__gc",           luaT_netbox_request_gc },
+		{ "__tostring",     luaT_netbox_request_tostring },
+		{ "__serialize",    luaT_netbox_request_serialize },
 		{ "__index",        luaT_netbox_request_index },
 		{ "__newindex",     luaT_netbox_request_newindex },
 		{ "is_ready",       luaT_netbox_request_is_ready },

--- a/test/box/net.box_fiber-async_gh-3107.result
+++ b/test/box/net.box_fiber-async_gh-3107.result
@@ -251,6 +251,39 @@ gc.data3 == nil
 ---
 - true
 ...
+--
+-- __tostring and __serialize future methods
+--
+future = c:eval('return 123', {}, {is_async = true})
+---
+...
+tostring(future)
+---
+- net.box.request
+...
+future
+---
+- []
+...
+future.abc = 123
+---
+...
+future.xyz = 'abc'
+---
+...
+tostring(future)
+---
+- net.box.request
+...
+future
+---
+- xyz: abc
+  abc: 123
+...
+future:wait_result()
+---
+- [123]
+...
 box.schema.user.revoke('guest', 'execute', 'universe')
 ---
 ...

--- a/test/box/net.box_fiber-async_gh-3107.test.lua
+++ b/test/box/net.box_fiber-async_gh-3107.test.lua
@@ -89,6 +89,18 @@ _ = collectgarbage('collect')
 _ = collectgarbage('collect')
 gc.data3 == nil
 
+--
+-- __tostring and __serialize future methods
+--
+future = c:eval('return 123', {}, {is_async = true})
+tostring(future)
+future
+future.abc = 123
+future.xyz = 'abc'
+tostring(future)
+future
+future:wait_result()
+
 box.schema.user.revoke('guest', 'execute', 'universe')
 
 c:close()


### PR DESCRIPTION
__tostring always returns the type name, which is 'net.box.request'.

__serialize returns user-defined fields attached to the future or an
empty table if there's none.

Closes #6314