### PR TITLE
Reuse tuple formats in Lua

### DIFF
--- a/changelogs/unreleased/gh-6217-fix-net-box-connect-error.md
+++ b/changelogs/unreleased/gh-6217-fix-net-box-connect-error.md
@@ -1,0 +1,4 @@
+## bugfix/lua
+
+* Fixed net.box error in case connections are frequently opened and closed
+  (gh-6217).

--- a/src/box/lua/misc.cc
+++ b/src/box/lua/misc.cc
@@ -233,7 +233,7 @@ lbox_tuple_format_new(struct lua_State *L)
 		return luaT_error(L);
 	struct tuple_format *format =
 		tuple_format_new(&tuple_format_runtime->vtab, NULL, NULL, 0,
-				 NULL, 0, 0, dict, false, false);
+				 NULL, 0, 0, dict, false, true);
 	/*
 	 * Since dictionary reference counter is 1 from the
 	 * beginning and after creation of the tuple_format

--- a/src/box/tuple_dictionary.c
+++ b/src/box/tuple_dictionary.c
@@ -32,6 +32,8 @@
 #include "error.h"
 #include "diag.h"
 
+#include "PMurHash.h"
+
 field_name_hash_f field_name_hash;
 
 #define mh_name _strnu32
@@ -173,6 +175,33 @@ err_hash:
 err_memory:
 	free(dict);
 	return NULL;
+}
+
+uint32_t
+tuple_dictionary_hash_process(const struct tuple_dictionary *dict,
+			      uint32_t *ph, uint32_t *pcarry)
+{
+	uint32_t size = 0;
+	for (uint32_t i = 0; i < dict->name_count; ++i) {
+		uint32_t name_len = strlen(dict->names[i]);
+		PMurHash32_Process(ph, pcarry, dict->names[i], name_len);
+		size += name_len;
+	}
+	return size;
+}
+
+int
+tuple_dictionary_cmp(const struct tuple_dictionary *a,
+		     const struct tuple_dictionary *b)
+{
+	if (a->name_count != b->name_count)
+		return a->name_count > b->name_count ? 1 : -1;
+	for (uint32_t i = 0; i < a->name_count; ++i) {
+		int ret = strcmp(a->names[i], b->names[i]);
+		if (ret != 0)
+			return ret;
+	}
+	return 0;
 }
 
 void

--- a/src/box/tuple_dictionary.h
+++ b/src/box/tuple_dictionary.h
@@ -71,6 +71,19 @@ struct tuple_dictionary *
 tuple_dictionary_new(const struct field_def *fields, uint32_t field_count);
 
 /**
+ * Compute a tuple dictionary hash with PMurHash32_Process and return
+ * the size of data processed.
+ */
+uint32_t
+tuple_dictionary_hash_process(const struct tuple_dictionary *dict,
+			      uint32_t *ph, uint32_t *pcarry);
+
+/** Compare two tuple dictionaries. */
+int
+tuple_dictionary_cmp(const struct tuple_dictionary *a,
+		     const struct tuple_dictionary *b);
+
+/**
  * Swap content of two dictionaries. Reference counters are not
  * swaped.
  */

--- a/src/box/tuple_format.c
+++ b/src/box/tuple_format.c
@@ -99,7 +99,7 @@ tuple_format_cmp(const struct tuple_format *format1,
 				(int)field_b->is_key_part;
 	}
 
-	return 0;
+	return tuple_dictionary_cmp(format1->dict, format2->dict);
 }
 
 static uint32_t
@@ -122,6 +122,7 @@ tuple_format_hash(struct tuple_format *format)
 		TUPLE_FIELD_MEMBER_HASH(f, is_key_part, h, carry, size)
 	}
 #undef TUPLE_FIELD_MEMBER_HASH
+	size += tuple_dictionary_hash_process(format->dict, &h, &carry);
 	return PMurHash32_Result(h, carry, size);
 }
 
@@ -441,7 +442,7 @@ tuple_format_create(struct tuple_format *format, struct key_def * const *keys,
 					     field_count);
 	if (tuple_format_field_count(format) == 0) {
 		format->field_map_size = 0;
-		return 0;
+		goto out;
 	}
 	/* Initialize defined fields */
 	for (uint32_t i = 0; i < field_count; ++i) {
@@ -547,6 +548,7 @@ tuple_format_create(struct tuple_format *format, struct key_def * const *keys,
 		    !tuple_field_is_nullable(field))
 			bit_set(required_fields, field->id);
 	}
+out:
 	format->hash = tuple_format_hash(format);
 	return 0;
 }

--- a/src/box/tuple_format.h
+++ b/src/box/tuple_format.h
@@ -189,10 +189,13 @@ struct tuple_format {
 	 */
 	bool is_temporary;
 	/**
-	 * This format belongs to ephemeral space and thus might
-	 * be shared with other ephemeral spaces.
+	 * True if this format may be reused instead of creating a new format.
+	 * Not all formats are reusable: a typical space format is mutable,
+	 * because its dictionary may be updated by space alter, and therefore
+	 * can't be reused. We can reuse formats of ephemeral spaces, because
+	 * those are never altered. We can also reuse formats exported to Lua.
 	 */
-	bool is_ephemeral;
+	bool is_reusable;
 	/**
 	 * Size of minimal field map of tuple where each indexed
 	 * field has own offset slot (in bytes). The real tuple
@@ -331,7 +334,7 @@ tuple_format_unref(struct tuple_format *format)
  * @param space_field_count Length of @a space_fields.
  * @param exact_field_count Exact field count for format.
  * @param is_temporary Set if format belongs to temporary space.
- * @param is_ephemeral Set if format belongs to ephemeral space.
+ * @param is_reusable Set if format may be reused.
  *
  * @retval not NULL Tuple format.
  * @retval     NULL Memory error.
@@ -342,7 +345,7 @@ tuple_format_new(struct tuple_format_vtab *vtab, void *engine,
 		 const struct field_def *space_fields,
 		 uint32_t space_field_count, uint32_t exact_field_count,
 		 struct tuple_dictionary *dict, bool is_temporary,
-		 bool is_ephemeral);
+		 bool is_reusable);
 
 /**
  * Check, if @a format1 can store any tuples of @a format2. For

--- a/test/box/net.box_reuse_tuple_formats_gh-6217.result
+++ b/test/box/net.box_reuse_tuple_formats_gh-6217.result
@@ -1,0 +1,46 @@
+-- test-run result file version 2
+net = require('net.box')
+ | ---
+ | ...
+errinj = box.error.injection
+ | ---
+ | ...
+
+box.schema.user.grant('guest', 'execute', 'universe')
+ | ---
+ | ...
+
+-- Check that formats created by net.box for schema are reused (gh-6217).
+COUNT = 100
+ | ---
+ | ...
+errinj.set('ERRINJ_TUPLE_FORMAT_COUNT', COUNT)
+ | ---
+ | - ok
+ | ...
+connections = {}
+ | ---
+ | ...
+for i = 1, COUNT do                                                         \
+    local c = net.connect(box.cfg.listen)                                   \
+    c:eval('return')                                                        \
+    table.insert(connections, c)                                            \
+end
+ | ---
+ | ...
+errinj.set('ERRINJ_TUPLE_FORMAT_COUNT', -1)
+ | ---
+ | - ok
+ | ...
+
+#connections == COUNT
+ | ---
+ | - true
+ | ...
+for _, c in pairs(connections) do c:close() end
+ | ---
+ | ...
+
+box.schema.user.revoke('guest', 'execute', 'universe')
+ | ---
+ | ...

--- a/test/box/net.box_reuse_tuple_formats_gh-6217.test.lua
+++ b/test/box/net.box_reuse_tuple_formats_gh-6217.test.lua
@@ -1,0 +1,20 @@
+net = require('net.box')
+errinj = box.error.injection
+
+box.schema.user.grant('guest', 'execute', 'universe')
+
+-- Check that formats created by net.box for schema are reused (gh-6217).
+COUNT = 100
+errinj.set('ERRINJ_TUPLE_FORMAT_COUNT', COUNT)
+connections = {}
+for i = 1, COUNT do                                                         \
+    local c = net.connect(box.cfg.listen)                                   \
+    c:eval('return')                                                        \
+    table.insert(connections, c)                                            \
+end
+errinj.set('ERRINJ_TUPLE_FORMAT_COUNT', -1)
+
+#connections == COUNT
+for _, c in pairs(connections) do c:close() end
+
+box.schema.user.revoke('guest', 'execute', 'universe')


### PR DESCRIPTION
The number of tuple formats is limited by 65K. Each net.box connection creates a few formats for schema. So if one opens/closes connections in a loop, they will soon run out of formats unless they manually invoke the garbage collector. Let's reuse formats exported to Lua to avoid that. All the infrastructure is already there - it was introduced for ephemeral spaces. We just need to extend it a little bit.

Closes #6217