### PR TITLE
iproto: fix dropping messages when connection is closed with SHUT_RDWR.

### DIFF
--- a/changelogs/unreleased/gh-6292-fix-dropping-messages-in-case-when-connection-closing.md
+++ b/changelogs/unreleased/gh-6292-fix-dropping-messages-in-case-when-connection-closing.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed dropping incoming messages when connection is closed or SHUT_RDWR
+  received and net_msg_max or readahead limit is reached (gh-6292).

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -546,6 +546,12 @@ struct iproto_connection
 	enum iproto_connection_state state;
 	struct rlist in_stop_list;
 	/**
+	 * Flag indicates, that client sent SHUT_RDWR or connection
+	 * is closed from client side. When it is set to false, we
+	 * should not write to the socket.
+	 */
+	bool can_write;
+	/**
 	 * Hash table that holds all streams for this connection.
 	 * This field is accesable only from iproto thread.
 	 */
@@ -1284,6 +1290,11 @@ iproto_flush(struct iproto_connection *con)
 		/* Nothing to do. */
 		return 1;
 	}
+	if (!con->can_write) {
+		/* Receiving end was closed. Discard the output. */
+		*begin = *end;
+		return 0;
+	}
 	assert(begin->used < end->used);
 	struct iovec iov[SMALL_OBUF_IOV_MAX+1];
 	struct iovec *src = obuf->iov;
@@ -1313,8 +1324,18 @@ iproto_flush(struct iproto_connection *con)
 		begin->iov_len = advance == 0 ? begin->iov_len + offset: offset;
 		begin->pos += advance;
 		assert(begin->pos <= end->pos);
+		return -1;
 	} else if (nwr < 0 && ! sio_wouldblock(errno)) {
-		diag_raise();
+		/*
+		 * Don't close the connection on write error. Log the error and
+		 * don't write to the socket anymore. Continue processing
+		 * requests as usual, because the client might have closed the
+		 * socket, but still expect pending requests to complete.
+		 */
+		diag_log();
+		con->can_write = false;
+		*begin = *end;
+		return 0;
 	}
 	return -1;
 }
@@ -1325,24 +1346,19 @@ iproto_connection_on_output(ev_loop *loop, struct ev_io *watcher,
 {
 	struct iproto_connection *con = (struct iproto_connection *) watcher->data;
 
-	try {
-		int rc;
-		while ((rc = iproto_flush(con)) <= 0) {
-			if (rc != 0) {
-				ev_io_start(loop, &con->output);
-				return;
-			}
-			if (! ev_is_active(&con->input) &&
-			    rlist_empty(&con->in_stop_list)) {
-				ev_feed_event(loop, &con->input, EV_READ);
-			}
+	int rc;
+	while ((rc = iproto_flush(con)) <= 0) {
+		if (rc != 0) {
+			ev_io_start(loop, &con->output);
+			return;
 		}
-		if (ev_is_active(&con->output))
-			ev_io_stop(con->loop, &con->output);
-	} catch (Exception *e) {
-		e->log();
-		iproto_connection_close(con);
+		if (!ev_is_active(&con->input) &&
+		    rlist_empty(&con->in_stop_list)) {
+			ev_feed_event(loop, &con->input, EV_READ);
+		}
 	}
+	if (ev_is_active(&con->output))
+		ev_io_stop(con->loop, &con->output);
 }
 
 static struct iproto_connection *
@@ -1377,6 +1393,7 @@ iproto_connection_new(struct iproto_thread *iproto_thread, int fd)
 	iproto_wpos_create(&con->wpos, con->tx.p_obuf);
 	iproto_wpos_create(&con->wend, con->tx.p_obuf);
 	con->parse_size = 0;
+	con->can_write = true;
 	con->long_poll_count = 0;
 	con->session = NULL;
 	rlist_create(&con->in_stop_list);

--- a/test/box/gh-6292-fix-dropping-msg-when-connection-closing.result
+++ b/test/box/gh-6292-fix-dropping-msg-when-connection-closing.result
@@ -1,0 +1,80 @@
+net = require('net.box')
+---
+...
+fiber = require('fiber')
+---
+...
+test_run = require('test_run').new()
+---
+...
+box.schema.user.grant('guest', 'execute', 'universe')
+---
+...
+old_readahead = box.cfg.readahead
+---
+...
+old_net_msg_max = box.cfg.net_msg_max
+---
+...
+--
+-- Check that tarantool process all requests when connection is closing,
+-- net_msg_max limit is reached and readahead limit is not reached:
+--
+box.cfg ({ net_msg_max = 2, readahead = 100 * 1024 * 1024 })
+---
+...
+counter = 0
+---
+...
+expected_counter = 1024
+---
+...
+conn = net.connect(box.cfg.listen)
+---
+...
+for i = 1, expected_counter do \
+    conn:eval('counter = counter + 1', {}, {is_async = true}) \
+end
+---
+...
+conn:close()
+---
+...
+test_run:wait_cond(function() return counter == expected_counter end)
+---
+- true
+...
+--
+-- Check that tarantool process all requests when connection is closing
+-- readahead limit is reached and net_msg_max limit is not reached:
+--
+box.cfg ({ net_msg_max = 16 * 1024, readahead = 128 })
+---
+...
+counter = 0
+---
+...
+expected_counter = 1024
+---
+...
+conn = net.connect(box.cfg.listen)
+---
+...
+for i = 1, expected_counter do \
+    conn:eval('counter = counter + 1', {}, {is_async = true}) \
+end
+---
+...
+conn:close()
+---
+...
+test_run:wait_cond(function() return counter == expected_counter end)
+---
+- true
+...
+box.cfg ({ net_msg_max = old_net_msg_max, readahead = old_readahead })
+---
+...
+box.schema.user.revoke('guest', 'execute', 'universe')
+---
+...

--- a/test/box/gh-6292-fix-dropping-msg-when-connection-closing.test.lua
+++ b/test/box/gh-6292-fix-dropping-msg-when-connection-closing.test.lua
@@ -1,0 +1,38 @@
+net = require('net.box')
+fiber = require('fiber')
+test_run = require('test_run').new()
+
+box.schema.user.grant('guest', 'execute', 'universe')
+old_readahead = box.cfg.readahead
+old_net_msg_max = box.cfg.net_msg_max
+
+--
+-- Check that tarantool process all requests when connection is closing,
+-- net_msg_max limit is reached and readahead limit is not reached:
+--
+box.cfg ({ net_msg_max = 2, readahead = 100 * 1024 * 1024 })
+counter = 0
+expected_counter = 1024
+conn = net.connect(box.cfg.listen)
+for i = 1, expected_counter do \
+    conn:eval('counter = counter + 1', {}, {is_async = true}) \
+end
+conn:close()
+test_run:wait_cond(function() return counter == expected_counter end)
+
+--
+-- Check that tarantool process all requests when connection is closing
+-- readahead limit is reached and net_msg_max limit is not reached:
+--
+box.cfg ({ net_msg_max = 16 * 1024, readahead = 128 })
+counter = 0
+expected_counter = 1024
+conn = net.connect(box.cfg.listen)
+for i = 1, expected_counter do \
+    conn:eval('counter = counter + 1', {}, {is_async = true}) \
+end
+conn:close()
+test_run:wait_cond(function() return counter == expected_counter end)
+
+box.cfg ({ net_msg_max = old_net_msg_max, readahead = old_readahead })
+box.schema.user.revoke('guest', 'execute', 'universe')


### PR DESCRIPTION
Fixed dropping incoming messages when connection is closed or SHUT_RDWR
received and net_msg_max or readahead limit is reached. Now we don't close
connection if an error occurred while writing response, but only set a
special flag to stop further writing. Connection will be closed when we
read 0 from socket and process all requests. 
Closes #6292