### PR TITLE
Add new metrics to `box.stat.net`

### DIFF
--- a/changelogs/unreleased/gh-6293-implement-detailed-iproto-requests-stats.md
+++ b/changelogs/unreleased/gh-6293-implement-detailed-iproto-requests-stats.md
@@ -1,0 +1,6 @@
+## feature/core
+
+ * Add new  metrics `REQUESTS_IN_PROGRESS` and `REQUESTS_IN_STREAM_QUEUE`
+   to `box.stat.net`, which contain detailed statistics for iproto requests.
+   These metrics contains same counters as other metrics in `box.stat.net`:
+   current, rps and total (gh-6293).

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -2719,10 +2719,10 @@ iproto_thread_init(struct iproto_thread *iproto_thread)
 	if (iproto_thread->rmean == NULL) {
 		slab_cache_destroy(&iproto_thread->net_slabc);
 		diag_set(OutOfMemory, sizeof(struct rmean),
-			  "rmean_new", "struct rmean");
+			 "rmean_new", "struct rmean");
 		return -1;
 	}
-
+	rlist_create(&iproto_thread->stopped_connections);
 	return 0;
 }
 
@@ -2763,9 +2763,6 @@ iproto_init(int threads_count)
 			goto fail;
 		}
 		/* Create a pipe to "net" thread. */
-		iproto_thread->stopped_connections =
-			RLIST_HEAD_INITIALIZER(iproto_thread->
-					       stopped_connections);
 		char endpoint_name[ENDPOINT_NAME_MAX];
 		snprintf(endpoint_name, ENDPOINT_NAME_MAX, "net%u",
 			 iproto_thread->id);

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -371,10 +371,10 @@ enum rmean_net_name {
 	IPROTO_CONNECTIONS,
 	IPROTO_REQUESTS,
 	IPROTO_STREAMS,
-	IPROTO_LAST,
+	RMEAN_NET_LAST,
 };
 
-const char *rmean_net_strings[IPROTO_LAST] = {
+const char *rmean_net_strings[RMEAN_NET_LAST] = {
 	"SENT",
 	"RECEIVED",
 	"CONNECTIONS",
@@ -2715,7 +2715,7 @@ iproto_thread_init(struct iproto_thread *iproto_thread)
 	iproto_thread_init_routes(iproto_thread);
 	slab_cache_create(&iproto_thread->net_slabc, &runtime);
 	/* Init statistics counter */
-	iproto_thread->rmean = rmean_new(rmean_net_strings, IPROTO_LAST);
+	iproto_thread->rmean = rmean_new(rmean_net_strings, RMEAN_NET_LAST);
 	if (iproto_thread->rmean == NULL) {
 		slab_cache_destroy(&iproto_thread->net_slabc);
 		diag_set(OutOfMemory, sizeof(struct rmean),
@@ -3041,7 +3041,7 @@ iproto_free(void)
 int
 iproto_rmean_foreach(void *cb, void *cb_ctx)
 {
-	for (size_t i = 0; i < IPROTO_LAST; i++) {
+	for (size_t i = 0; i < RMEAN_NET_LAST; i++) {
 		int64_t mean = 0;
 		int64_t total = 0;
 		for (int j = 0; j < iproto_threads_count; j++)  {
@@ -3062,7 +3062,7 @@ iproto_thread_rmean_foreach(int thread_id, void *cb, void *cb_ctx)
 	assert(thread_id >= 0 && thread_id < iproto_threads_count);
 
 	int rc = 0;
-	for (size_t i = 0; i < IPROTO_LAST; i++) {
+	for (size_t i = 0; i < RMEAN_NET_LAST; i++) {
 		int64_t mean = rmean_mean(iproto_threads[thread_id].rmean, i);
 		int64_t total = rmean_total(iproto_threads[thread_id].rmean, i);
 		if (((rmean_cb)cb)(rmean_net_strings[i], mean,

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -2815,13 +2815,8 @@ struct iproto_cfg_msg: public cbus_call_msg
 	/** Operation to execute in iproto thread. */
 	enum iproto_cfg_op op;
 	union {
-		/** statistic stucture */
-		struct {
-			size_t mem_used;
-			size_t connections;
-			size_t requests;
-			size_t streams;
-		};
+		/** Pointer to the statistic stucture. */
+		struct iproto_stats *stats;
 		/** Pointer to evio_service, used for bind */
 		struct evio_service *binary;
 
@@ -2853,15 +2848,16 @@ static void
 iproto_fill_stat(struct iproto_thread *iproto_thread,
 		 struct iproto_cfg_msg *cfg_msg)
 {
-	cfg_msg->mem_used =
+	assert(cfg_msg->stats != NULL);
+	cfg_msg->stats->mem_used =
 		slab_cache_used(&iproto_thread->net_cord.slabc) +
 		slab_cache_used(&iproto_thread->net_slabc);
-	cfg_msg->connections =
+	cfg_msg->stats->connections =
 		mempool_count(&iproto_thread->iproto_connection_pool);
-	cfg_msg->requests =
-		mempool_count(&iproto_thread->iproto_msg_pool);
-	cfg_msg->streams =
+	cfg_msg->stats->streams =
 		mempool_count(&iproto_thread->iproto_stream_pool);
+	cfg_msg->stats->requests =
+		mempool_count(&iproto_thread->iproto_msg_pool);
 }
 
 static int
@@ -2963,86 +2959,36 @@ iproto_listen(const char *uri)
 	return 0;
 }
 
-size_t
-iproto_mem_used(void)
+static void
+iproto_stats_add(struct iproto_stats *total_stats,
+		 struct iproto_stats *thread_stats)
 {
-	struct iproto_cfg_msg cfg_msg;
-	size_t mem = 0;
-	iproto_cfg_msg_create(&cfg_msg, IPROTO_CFG_STAT);
-	for (int i = 0; i < iproto_threads_count; i++) {
-		iproto_do_cfg(&iproto_threads[i], &cfg_msg);
-		mem += cfg_msg.mem_used;
-	}
-	return mem;
+	total_stats->mem_used += thread_stats->mem_used;
+	total_stats->connections += thread_stats->connections;
+	total_stats->streams += thread_stats->streams;
+	total_stats->requests += thread_stats->requests;
 }
 
-size_t
-iproto_connection_count(void)
+void
+iproto_stats_get(struct iproto_stats *stats)
 {
-	struct iproto_cfg_msg cfg_msg;
-	size_t count = 0;
-	iproto_cfg_msg_create(&cfg_msg, IPROTO_CFG_STAT);
+	struct iproto_stats thread_stats;
+	memset(stats, 0, sizeof(iproto_stats));
 	for (int i = 0; i < iproto_threads_count; i++) {
-		iproto_do_cfg(&iproto_threads[i], &cfg_msg);
-		count += cfg_msg.connections;
+		iproto_thread_stats_get(&thread_stats, i);
+		iproto_stats_add(stats, &thread_stats);
 	}
-	return count;
 }
 
-size_t
-iproto_thread_connection_count(int thread_id)
+void
+iproto_thread_stats_get(struct iproto_stats *stats, int thread_id)
 {
+	memset(stats, 0, sizeof(iproto_stats));
 	struct iproto_cfg_msg cfg_msg;
 	iproto_cfg_msg_create(&cfg_msg, IPROTO_CFG_STAT);
 	assert(thread_id >= 0 && thread_id < iproto_threads_count);
+	cfg_msg.stats = stats;
 	iproto_do_cfg(&iproto_threads[thread_id], &cfg_msg);
-	return cfg_msg.connections;
-}
-
-size_t
-iproto_stream_count(void)
-{
-	struct iproto_cfg_msg cfg_msg;
-	size_t count = 0;
-	iproto_cfg_msg_create(&cfg_msg, IPROTO_CFG_STAT);
-	for (int i = 0; i < iproto_threads_count; i++) {
-		iproto_do_cfg(&iproto_threads[i], &cfg_msg);
-		count += cfg_msg.streams;
-	}
-	return count;
-}
-
-size_t
-iproto_thread_stream_count(int thread_id)
-{
-	struct iproto_cfg_msg cfg_msg;
-	iproto_cfg_msg_create(&cfg_msg, IPROTO_CFG_STAT);
-	assert(thread_id >= 0 && thread_id < iproto_threads_count);
-	iproto_do_cfg(&iproto_threads[thread_id], &cfg_msg);
-	return cfg_msg.streams;
-}
-
-size_t
-iproto_request_count(void)
-{
-	struct iproto_cfg_msg cfg_msg;
-	size_t count = 0;
-	iproto_cfg_msg_create(&cfg_msg, IPROTO_CFG_STAT);
-	for (int i = 0; i < iproto_threads_count; i++) {
-		iproto_do_cfg(&iproto_threads[i], &cfg_msg);
-		count += cfg_msg.requests;
-	}
-	return count;
-}
-
-size_t
-iproto_thread_request_count(int thread_id)
-{
-	struct iproto_cfg_msg cfg_msg;
-	iproto_cfg_msg_create(&cfg_msg, IPROTO_CFG_STAT);
-	assert(thread_id >= 0 && thread_id < iproto_threads_count);
-	iproto_do_cfg(&iproto_threads[thread_id], &cfg_msg);
-	return cfg_msg.requests;
 }
 
 void

--- a/src/box/iproto.h
+++ b/src/box/iproto.h
@@ -56,53 +56,32 @@ enum {
 	IPROTO_THREADS_MAX = 1000,
 };
 
+struct iproto_stats {
+	/** Size of memory used for storing network buffers. */
+	size_t mem_used;
+	/** Number of active iproto connections. */
+	size_t connections;
+	/** Number of active iproto streams. */
+	size_t streams;
+	/** Number of iproto requests in flight. */
+	size_t requests;
+};
+
 extern unsigned iproto_readahead;
 extern int iproto_threads_count;
 
 /**
- * Return size of memory used for storing network buffers.
+ * Return total iproto statistic.
  */
-size_t
-iproto_mem_used(void);
+void
+iproto_stats_get(struct iproto_stats *stats);
 
 /**
- * Return the number of active iproto connections.
+ * Return total iproto statistic for
+ * the thread with the given id.
  */
-size_t
-iproto_connection_count(void);
-
-/**
- * Return the number of active iproto connections
- * for the thread with the given id.
- */
-size_t
-iproto_thread_connection_count(int thread_id);
-
-/**
- * Return the number of active iproto streams.
- */
-size_t
-iproto_stream_count(void);
-
-/**
- * Return the number of active iproto streams
- * for the thread with the given id.
- */
-size_t
-iproto_thread_stream_count(int thread_id);
-
-/**
- * Return the number of iproto requests in flight.
- */
-size_t
-iproto_request_count(void);
-
-/**
- * Return the number of iproto requests in flight
- * for the thread with the given id.
- */
-size_t
-iproto_thread_request_count(int thread_id);
+void
+iproto_thread_stats_get(struct iproto_stats *stats, int thread_id);
 
 /**
  * Reset network statistics.

--- a/src/box/iproto.h
+++ b/src/box/iproto.h
@@ -65,6 +65,10 @@ struct iproto_stats {
 	size_t streams;
 	/** Number of iproto requests in flight. */
 	size_t requests;
+	/** Count of requests currently processing in tx thread. */
+	size_t requests_in_progress;
+	/** Count of requests currently pending in stream queue. */
+	size_t requests_in_stream_queue;
 };
 
 extern unsigned iproto_readahead;

--- a/src/box/iproto.h
+++ b/src/box/iproto.h
@@ -52,7 +52,7 @@ enum {
 	 * processing stops until some new fibers are freed up.
 	 */
 	IPROTO_FIBER_POOL_SIZE_FACTOR = 5,
-	/** Maximum count of iproto threads */
+	/** Maximum count of iproto threads. */
 	IPROTO_THREADS_MAX = 1000,
 };
 

--- a/src/box/lua/info.c
+++ b/src/box/lua/info.c
@@ -405,8 +405,10 @@ lbox_info_memory_call(struct lua_State *L)
 	luaL_pushuint64(L, stat.tx);
 	lua_settable(L, -3);
 
+	struct iproto_stats stats;
+	iproto_stats_get(&stats);
 	lua_pushstring(L, "net");
-	luaL_pushuint64(L, iproto_mem_used());
+	luaL_pushuint64(L, stats.mem_used);
 	lua_settable(L, -3);
 
 	lua_pushstring(L, "lua");

--- a/src/box/lua/stat.c
+++ b/src/box/lua/stat.c
@@ -73,6 +73,10 @@ inject_iproto_stats(struct lua_State *L, struct iproto_stats *stats)
 	inject_current_stat(L, "CONNECTIONS", stats->connections);
 	inject_current_stat(L, "STREAMS", stats->streams);
 	inject_current_stat(L, "REQUESTS", stats->requests);
+	inject_current_stat(L, "REQUESTS_IN_PROGRESS",
+			    stats->requests_in_progress);
+	inject_current_stat(L, "REQUESTS_IN_STREAM_QUEUE",
+			    stats->requests_in_stream_queue);
 }
 
 static void
@@ -187,6 +191,14 @@ lbox_stat_net_index(struct lua_State *L)
 		lua_pushstring(L, "current");
 		lua_pushnumber(L, stats.requests);
 		lua_rawset(L, -3);
+	} else if (strcmp(key, "REQUESTS_IN_PROGRESS") == 0) {
+		lua_pushstring(L, "current");
+		lua_pushnumber(L, stats.requests_in_progress);
+		lua_rawset(L, -3);
+	} else if (strcmp(key, "REQUESTS_IN_STREAM_QUEUE") == 0) {
+		lua_pushstring(L, "current");
+		lua_pushnumber(L, stats.requests_in_stream_queue);
+		lua_rawset(L, -3);
 	}
 	return 1;
 }
@@ -200,7 +212,9 @@ lbox_stat_net_index(struct lua_State *L)
  * - RECEIVED (packets): total, rps;
  * - CONNECTIONS: total, rps, current;
  * - STREAMS: total, rps, current;
- * - REQUESTS: total, rps, current.
+ * - REQUESTS: total, rps, current;
+ * - REQUESTS_IN_PROGRESS: total, rps, current;
+ * - REQUESTS_IN_STREAM_QUEUE: total, rps, current.
  *
  * These fields have the following meaning:
  *

--- a/src/box/lua/stat.c
+++ b/src/box/lua/stat.c
@@ -71,8 +71,8 @@ static void
 inject_iproto_stats(struct lua_State *L, struct iproto_stats *stats)
 {
 	inject_current_stat(L, "CONNECTIONS", stats->connections);
-	inject_current_stat(L, "REQUESTS", stats->requests);
 	inject_current_stat(L, "STREAMS", stats->streams);
+	inject_current_stat(L, "REQUESTS", stats->requests);
 }
 
 static void
@@ -179,13 +179,13 @@ lbox_stat_net_index(struct lua_State *L)
 		lua_pushstring(L, "current");
 		lua_pushnumber(L, stats.connections);
 		lua_rawset(L, -3);
-	} else if (strcmp(key, "REQUESTS") == 0) {
-		lua_pushstring(L, "current");
-		lua_pushnumber(L, stats.requests);
-		lua_rawset(L, -3);
 	} else if (strcmp(key, "STREAMS") == 0) {
 		lua_pushstring(L, "current");
 		lua_pushnumber(L, stats.streams);
+		lua_rawset(L, -3);
+	} else if (strcmp(key, "REQUESTS") == 0) {
+		lua_pushstring(L, "current");
+		lua_pushnumber(L, stats.requests);
 		lua_rawset(L, -3);
 	}
 	return 1;
@@ -198,7 +198,9 @@ lbox_stat_net_index(struct lua_State *L)
  *
  * - SENT (packets): total, rps;
  * - RECEIVED (packets): total, rps;
- * - CONNECTIONS: current.
+ * - CONNECTIONS: total, rps, current;
+ * - STREAMS: total, rps, current;
+ * - REQUESTS: total, rps, current.
  *
  * These fields have the following meaning:
  *
@@ -218,6 +220,9 @@ lbox_stat_net_call(struct lua_State *L)
 	return 1;
 }
 
+/**
+ * Same as `lbox_stat_net_index` but for thread with given id.
+ */
 static int
 lbox_stat_net_thread_index(struct lua_State *L)
 {
@@ -233,6 +238,9 @@ lbox_stat_net_thread_index(struct lua_State *L)
 	return 1;
 }
 
+/**
+ * Same as `lbox_stat_net_call` but for thread with given id.
+ */
 static int
 lbox_stat_net_thread_call(struct lua_State *L)
 {

--- a/src/box/lua/stat.c
+++ b/src/box/lua/stat.c
@@ -68,6 +68,14 @@ inject_current_stat(struct lua_State *L, const char *name, size_t val)
 }
 
 static void
+inject_iproto_stats(struct lua_State *L, struct iproto_stats *stats)
+{
+	inject_current_stat(L, "CONNECTIONS", stats->connections);
+	inject_current_stat(L, "REQUESTS", stats->requests);
+	inject_current_stat(L, "STREAMS", stats->streams);
+}
+
+static void
 fill_stat_item(struct lua_State *L, int rps, int64_t total)
 {
 	lua_pushstring(L, "rps");
@@ -165,17 +173,19 @@ lbox_stat_net_index(struct lua_State *L)
 	if (iproto_rmean_foreach(seek_stat_item, L) == 0)
 		return 0;
 
+	struct iproto_stats stats;
+	iproto_stats_get(&stats);
 	if (strcmp(key, "CONNECTIONS") == 0) {
 		lua_pushstring(L, "current");
-		lua_pushnumber(L, iproto_connection_count());
+		lua_pushnumber(L, stats.connections);
 		lua_rawset(L, -3);
 	} else if (strcmp(key, "REQUESTS") == 0) {
 		lua_pushstring(L, "current");
-		lua_pushnumber(L, iproto_request_count());
+		lua_pushnumber(L, stats.requests);
 		lua_rawset(L, -3);
 	} else if (strcmp(key, "STREAMS") == 0) {
 		lua_pushstring(L, "current");
-		lua_pushnumber(L, iproto_stream_count());
+		lua_pushnumber(L, stats.streams);
 		lua_rawset(L, -3);
 	}
 	return 1;
@@ -202,45 +212,37 @@ lbox_stat_net_call(struct lua_State *L)
 {
 	lua_newtable(L);
 	iproto_rmean_foreach(set_stat_item, L);
-	inject_current_stat(L, "CONNECTIONS", iproto_connection_count());
-	inject_current_stat(L, "REQUESTS", iproto_request_count());
-	inject_current_stat(L, "STREAMS", iproto_stream_count());
+	struct iproto_stats stats;
+	iproto_stats_get(&stats);
+	inject_iproto_stats(L, &stats);
 	return 1;
 }
 
 static int
 lbox_stat_net_thread_index(struct lua_State *L)
 {
-	size_t value;
 	const int thread_id = luaL_checkinteger(L, -1) - 1;
 	if (thread_id < 0 || thread_id > iproto_threads_count)
 		return 0;
 
 	lua_newtable(L);
 	iproto_thread_rmean_foreach(thread_id, set_stat_item, L);
-	value = iproto_thread_connection_count(thread_id);
-	inject_current_stat(L, "CONNECTIONS", value);
-	value = iproto_thread_request_count(thread_id);
-	inject_current_stat(L, "REQUESTS", value);
-	value = iproto_thread_stream_count(thread_id);
-	inject_current_stat(L, "STREAMS", value);
+	struct iproto_stats stats;
+	iproto_thread_stats_get(&stats, thread_id);
+	inject_iproto_stats(L, &stats);
 	return 1;
 }
 
 static int
 lbox_stat_net_thread_call(struct lua_State *L)
 {
-	size_t value;
+	struct iproto_stats stats;
 	lua_newtable(L);
 	for (int thread_id = 0; thread_id < iproto_threads_count; thread_id++) {
 		lua_newtable(L);
 		iproto_thread_rmean_foreach(thread_id, set_stat_item, L);
-		value = iproto_thread_connection_count(thread_id);
-		inject_current_stat(L, "CONNECTIONS", value);
-		value = iproto_thread_request_count(thread_id);
-		inject_current_stat(L, "REQUESTS", value);
-		value = iproto_thread_stream_count(thread_id);
-		inject_current_stat(L, "STREAMS", value);
+		iproto_thread_stats_get(&stats, thread_id);
+		inject_iproto_stats(L, &stats);
 		lua_rawseti(L, -2, thread_id + 1);
 	}
 	return 1;

--- a/test/box-tap/feedback_daemon.test.lua
+++ b/test/box-tap/feedback_daemon.test.lua
@@ -251,7 +251,7 @@ box.space.features_sync:drop()
 
 local function check_stats(stat)
     local sub = test:test('feedback operation stats')
-    sub:plan(23)
+    sub:plan(27)
     local box_stat = box.stat()
     local net_stat = box.stat.net()
     for op, val in pairs(box_stat) do

--- a/test/box/gh-6293-implement-new-net-stat.lua
+++ b/test/box/gh-6293-implement-new-net-stat.lua
@@ -1,0 +1,11 @@
+#!/usr/bin/env tarantool
+
+require('console').listen(os.getenv('ADMIN'))
+
+box.cfg({
+    listen = os.getenv('LISTEN'),
+    iproto_threads = tonumber(arg[1]),
+    wal_mode = 'none'
+})
+
+box.schema.user.grant('guest', 'read,write,execute,create,drop', 'universe', nil, {if_not_exists = true})

--- a/test/box/gh-6293-implement-new-net-stat.result
+++ b/test/box/gh-6293-implement-new-net-stat.result
@@ -1,0 +1,287 @@
+env = require('test_run')
+---
+...
+net_box = require('net.box')
+---
+...
+test_run = env.new()
+---
+...
+test_run:cmd("create server test with script=\
+              'box/gh-6293-implement-new-net-stat.lua'")
+---
+- true
+...
+test_run:cmd("setopt delimiter ';'")
+---
+- true
+...
+function get_network_requests_stats_using_call(rtype)
+    local box_stat_net = test_run:cmd(string.format(
+        "eval test 'return box.stat.net()'"
+    ))[1]
+    local total = box_stat_net.REQUESTS[rtype]
+    local in_progress = box_stat_net.REQUESTS_IN_PROGRESS[rtype]
+    local in_stream_queue = box_stat_net.REQUESTS_IN_STREAM_QUEUE[rtype]
+    return total, in_progress, in_stream_queue
+end;
+---
+...
+function get_network_requests_stats_for_thread_using_call(thread_id, rtype)
+    local box_stat_net = test_run:cmd(string.format(
+        "eval test 'return box.stat.net.thread()'"
+    ))[1][thread_id]
+    local total = box_stat_net.REQUESTS[rtype]
+    local in_progress = box_stat_net.REQUESTS_IN_PROGRESS[rtype]
+    local in_stream_queue = box_stat_net.REQUESTS_IN_STREAM_QUEUE[rtype]
+    return total, in_progress, in_stream_queue
+end;
+---
+...
+function get_network_requests_stats_using_index(rtype)
+    local total = test_run:cmd(string.format(
+        "eval test 'return box.stat.net.%s.%s'",
+        "REQUESTS", rtype
+    ))[1]
+    local in_progress = test_run:cmd(string.format(
+        "eval test 'return box.stat.net.%s.%s'",
+        "REQUESTS_IN_PROGRESS", rtype
+    ))[1]
+    local in_stream_queue = test_run:cmd(string.format(
+        "eval test 'return box.stat.net.%s.%s'",
+        "REQUESTS_IN_STREAM_QUEUE", rtype
+    ))[1]
+    return total, in_progress, in_stream_queue
+end;
+---
+...
+function get_network_requests_stats_for_thread_using_index(thread_id, rtype)
+    local total = test_run:cmd(string.format(
+        "eval test 'return box.stat.net.thread[%d].%s.%s'",
+        thread_id, "REQUESTS", rtype
+    ))[1]
+    local in_progress = test_run:cmd(string.format(
+        "eval test 'return box.stat.net.thread[%d].%s.%s'",
+        thread_id, "REQUESTS_IN_PROGRESS", rtype
+    ))[1]
+    local in_stream_queue = test_run:cmd(string.format(
+        "eval test 'return box.stat.net.thread[%d].%s.%s'",
+        thread_id, "REQUESTS_IN_STREAM_QUEUE", rtype
+    ))[1]
+    return total, in_progress, in_stream_queue
+end;
+---
+...
+function check_requests_stats_per_thread_using_call(thread_count)
+    local total, in_progress, in_stream_queue = 0, 0, 0
+    for thread_id = 1, thread_count do
+        local total_c, in_progress_c, in_stream_queue_c =
+        get_network_requests_stats_for_thread_using_call(
+            thread_id, "current"
+        )
+        assert(total_c == in_progress_c + in_stream_queue_c)
+        total = total + total_c
+        in_progress = in_progress + in_progress_c
+        in_stream_queue = in_stream_queue + in_stream_queue_c
+    end
+    assert(total == in_progress + in_stream_queue)
+    return total, in_progress, in_stream_queue
+end;
+---
+...
+function check_requests_stats_per_thread_using_index(thread_count)
+    local total, in_progress, in_stream_queue = 0, 0, 0
+    for thread_id = 1, thread_count do
+        local total_c, in_progress_c, in_stream_queue_c =
+        get_network_requests_stats_for_thread_using_index(
+            thread_id, "current"
+        )
+        assert(total_c == in_progress_c + in_stream_queue_c)
+        total = total + total_c
+        in_progress = in_progress + in_progress_c
+        in_stream_queue = in_stream_queue + in_stream_queue_c
+    end
+    assert(total == in_progress + in_stream_queue)
+    return total, in_progress, in_stream_queue
+end;
+---
+...
+test_run:cmd("setopt delimiter ''");
+---
+- true
+...
+-- We check that statistics gathered per each thread in sum is equal to
+-- statistics gathered from all threads.
+thread_count = 5
+---
+...
+test_run:cmd(string.format("start server test with args=\"%s\"", thread_count))
+---
+- true
+...
+test_run:switch("test")
+---
+- true
+...
+fiber = require('fiber')
+---
+...
+cond = fiber.cond()
+---
+...
+function wait() cond:wait() end
+---
+...
+function wakeup() cond:signal() end
+---
+...
+test_run:switch("default")
+---
+- true
+...
+server_addr = test_run:cmd("eval test 'return box.cfg.listen'")[1]
+---
+...
+conn = net_box.new(server_addr)
+---
+...
+stream = conn:new_stream()
+---
+...
+request_count = 10
+---
+...
+service_total_msg_count, service_in_progress_msg_count, \
+service_stream_msg_count = \
+    get_network_requests_stats_using_call("total");
+---
+...
+test_run:cmd("setopt delimiter ';'")
+---
+- true
+...
+for i = 1, request_count do
+    stream:call("wait", {}, {is_async = true})
+end;
+---
+...
+conn:close();
+---
+...
+-- Here we check a few things for 'current' request statistics:
+-- - statistics getting by call same as getting by index
+-- - total statistics is equal to the sum of statistics per threads
+-- - total request count is equal to the sum of in progress request_count
+--   count + in stream queue request count (we can ignore the number of
+--   requests in the cbus queue, it is always 0, since there are only one
+--   request in progress and it do not have time to get stuck.
+for i = 1, request_count do
+    local total_c_call, in_progress_c_call, in_stream_queue_c_call =
+          get_network_requests_stats_using_call("current")
+    local total_c_index, in_progress_c_index, in_stream_queue_c_index =
+          get_network_requests_stats_using_index("current")
+    assert(
+        total_c_call == total_c_index and
+        in_progress_c_call == in_progress_c_index and
+        in_stream_queue_c_call == in_stream_queue_c_index
+    )
+    assert(total_c_call == request_count - (i - 1))
+    assert(in_progress_c_call == 1)
+    assert(in_stream_queue_c_call == request_count - i)
+    assert(
+        total_c_call ==
+        in_progress_c_call + in_stream_queue_c_call
+    )
+    local total_thd_c_call, in_progress_thd_c_call,
+          in_stream_queue_thd_c_call =
+          check_requests_stats_per_thread_using_call(thread_count)
+    local total_thd_c_index, in_progress_thd_c_index,
+          in_stream_queue_thd_c_index =
+          check_requests_stats_per_thread_using_index(thread_count)
+    assert(
+        total_thd_c_call == total_thd_c_index and
+        in_progress_thd_c_call == in_progress_thd_c_index and
+        in_stream_queue_thd_c_call == in_stream_queue_thd_c_index
+    )
+    assert(
+        total_thd_c_call == total_c_call and
+        in_progress_thd_c_call == in_progress_c_call and
+        in_stream_queue_thd_c_call == in_stream_queue_c_call
+    )
+    test_run:cmd("eval test 'wakeup()'")
+end;
+---
+...
+total, in_progress, in_stream_queue = 0, 0, 0;
+---
+...
+-- Here we check a few things for 'total' request statistics:
+-- - statistics getting by call same as getting by index
+-- - total statistics is equal to the sum of statistics per threads
+for thread_id = 1, thread_count do
+    local total_thd_t_call, in_progress_thd_t_call,
+          in_stream_queue_thd_t_call =
+          get_network_requests_stats_for_thread_using_call(thread_id, "total")
+    local total_thd_t_index, in_progress_thd_t_index,
+          in_stream_queue_thd_t_index =
+          get_network_requests_stats_for_thread_using_index(thread_id, "total")
+    assert(
+        total_thd_t_call == total_thd_t_index and
+        in_progress_thd_t_call == in_progress_thd_t_index and
+        in_stream_queue_thd_t_call == in_stream_queue_thd_t_index
+    )
+    total = total + total_thd_t_call
+    in_progress = in_progress + in_progress_thd_t_call
+    in_stream_queue = in_stream_queue + in_stream_queue_thd_t_call
+end;
+---
+...
+total_t_call, in_progress_t_call, in_stream_queue_t_call =
+    get_network_requests_stats_using_call("total");
+---
+...
+total_t_index, in_progress_t_index, in_stream_queue_t_index =
+    get_network_requests_stats_using_index("total");
+---
+...
+assert(
+    total_t_call == total_t_index and
+    in_progress_t_call == in_progress_t_index and
+    in_stream_queue_t_call == in_stream_queue_t_index
+);
+---
+- true
+...
+assert(
+    total == total_t_call and
+    in_progress == in_progress_t_call and
+    in_stream_queue == in_stream_queue_t_call
+);
+---
+- true
+...
+-- We do not take into account service messages which was sent
+-- when establishing a connection
+assert(
+    total_t_call == request_count + service_total_msg_count and
+    in_progress_t_call  == request_count + service_in_progress_msg_count
+);
+---
+- true
+...
+test_run:cmd("setopt delimiter ''");
+---
+- true
+...
+test_run:cmd("stop server test")
+---
+- true
+...
+test_run:cmd("cleanup server test")
+---
+- true
+...
+test_run:cmd("delete server test")
+---
+- true
+...

--- a/test/box/gh-6293-implement-new-net-stat.test.lua
+++ b/test/box/gh-6293-implement-new-net-stat.test.lua
@@ -1,0 +1,199 @@
+env = require('test_run')
+net_box = require('net.box')
+test_run = env.new()
+
+test_run:cmd("create server test with script=\
+              'box/gh-6293-implement-new-net-stat.lua'")
+
+test_run:cmd("setopt delimiter ';'")
+function get_network_requests_stats_using_call(rtype)
+    local box_stat_net = test_run:cmd(string.format(
+        "eval test 'return box.stat.net()'"
+    ))[1]
+    local total = box_stat_net.REQUESTS[rtype]
+    local in_progress = box_stat_net.REQUESTS_IN_PROGRESS[rtype]
+    local in_stream_queue = box_stat_net.REQUESTS_IN_STREAM_QUEUE[rtype]
+    return total, in_progress, in_stream_queue
+end;
+function get_network_requests_stats_for_thread_using_call(thread_id, rtype)
+    local box_stat_net = test_run:cmd(string.format(
+        "eval test 'return box.stat.net.thread()'"
+    ))[1][thread_id]
+    local total = box_stat_net.REQUESTS[rtype]
+    local in_progress = box_stat_net.REQUESTS_IN_PROGRESS[rtype]
+    local in_stream_queue = box_stat_net.REQUESTS_IN_STREAM_QUEUE[rtype]
+    return total, in_progress, in_stream_queue
+end;
+function get_network_requests_stats_using_index(rtype)
+    local total = test_run:cmd(string.format(
+        "eval test 'return box.stat.net.%s.%s'",
+        "REQUESTS", rtype
+    ))[1]
+    local in_progress = test_run:cmd(string.format(
+        "eval test 'return box.stat.net.%s.%s'",
+        "REQUESTS_IN_PROGRESS", rtype
+    ))[1]
+    local in_stream_queue = test_run:cmd(string.format(
+        "eval test 'return box.stat.net.%s.%s'",
+        "REQUESTS_IN_STREAM_QUEUE", rtype
+    ))[1]
+    return total, in_progress, in_stream_queue
+end;
+function get_network_requests_stats_for_thread_using_index(thread_id, rtype)
+    local total = test_run:cmd(string.format(
+        "eval test 'return box.stat.net.thread[%d].%s.%s'",
+        thread_id, "REQUESTS", rtype
+    ))[1]
+    local in_progress = test_run:cmd(string.format(
+        "eval test 'return box.stat.net.thread[%d].%s.%s'",
+        thread_id, "REQUESTS_IN_PROGRESS", rtype
+    ))[1]
+    local in_stream_queue = test_run:cmd(string.format(
+        "eval test 'return box.stat.net.thread[%d].%s.%s'",
+        thread_id, "REQUESTS_IN_STREAM_QUEUE", rtype
+    ))[1]
+    return total, in_progress, in_stream_queue
+end;
+function check_requests_stats_per_thread_using_call(thread_count)
+    local total, in_progress, in_stream_queue = 0, 0, 0
+    for thread_id = 1, thread_count do
+        local total_c, in_progress_c, in_stream_queue_c =
+        get_network_requests_stats_for_thread_using_call(
+            thread_id, "current"
+        )
+        assert(total_c == in_progress_c + in_stream_queue_c)
+        total = total + total_c
+        in_progress = in_progress + in_progress_c
+        in_stream_queue = in_stream_queue + in_stream_queue_c
+    end
+    assert(total == in_progress + in_stream_queue)
+    return total, in_progress, in_stream_queue
+end;
+function check_requests_stats_per_thread_using_index(thread_count)
+    local total, in_progress, in_stream_queue = 0, 0, 0
+    for thread_id = 1, thread_count do
+        local total_c, in_progress_c, in_stream_queue_c =
+        get_network_requests_stats_for_thread_using_index(
+            thread_id, "current"
+        )
+        assert(total_c == in_progress_c + in_stream_queue_c)
+        total = total + total_c
+        in_progress = in_progress + in_progress_c
+        in_stream_queue = in_stream_queue + in_stream_queue_c
+    end
+    assert(total == in_progress + in_stream_queue)
+    return total, in_progress, in_stream_queue
+end;
+test_run:cmd("setopt delimiter ''");
+
+-- We check that statistics gathered per each thread in sum is equal to
+-- statistics gathered from all threads.
+thread_count = 5
+test_run:cmd(string.format("start server test with args=\"%s\"", thread_count))
+test_run:switch("test")
+fiber = require('fiber')
+cond = fiber.cond()
+function wait() cond:wait() end
+function wakeup() cond:signal() end
+test_run:switch("default")
+
+server_addr = test_run:cmd("eval test 'return box.cfg.listen'")[1]
+conn = net_box.new(server_addr)
+stream = conn:new_stream()
+request_count = 10
+service_total_msg_count, service_in_progress_msg_count, \
+service_stream_msg_count = \
+    get_network_requests_stats_using_call("total");
+
+test_run:cmd("setopt delimiter ';'")
+for i = 1, request_count do
+    stream:call("wait", {}, {is_async = true})
+end;
+conn:close();
+-- Here we check a few things for 'current' request statistics:
+-- - statistics getting by call same as getting by index
+-- - total statistics is equal to the sum of statistics per threads
+-- - total request count is equal to the sum of in progress request_count
+--   count + in stream queue request count (we can ignore the number of
+--   requests in the cbus queue, it is always 0, since there are only one
+--   request in progress and it do not have time to get stuck.
+for i = 1, request_count do
+    local total_c_call, in_progress_c_call, in_stream_queue_c_call =
+          get_network_requests_stats_using_call("current")
+    local total_c_index, in_progress_c_index, in_stream_queue_c_index =
+          get_network_requests_stats_using_index("current")
+    assert(
+        total_c_call == total_c_index and
+        in_progress_c_call == in_progress_c_index and
+        in_stream_queue_c_call == in_stream_queue_c_index
+    )
+    assert(total_c_call == request_count - (i - 1))
+    assert(in_progress_c_call == 1)
+    assert(in_stream_queue_c_call == request_count - i)
+    assert(
+        total_c_call ==
+        in_progress_c_call + in_stream_queue_c_call
+    )
+    local total_thd_c_call, in_progress_thd_c_call,
+          in_stream_queue_thd_c_call =
+          check_requests_stats_per_thread_using_call(thread_count)
+    local total_thd_c_index, in_progress_thd_c_index,
+          in_stream_queue_thd_c_index =
+          check_requests_stats_per_thread_using_index(thread_count)
+    assert(
+        total_thd_c_call == total_thd_c_index and
+        in_progress_thd_c_call == in_progress_thd_c_index and
+        in_stream_queue_thd_c_call == in_stream_queue_thd_c_index
+    )
+    assert(
+        total_thd_c_call == total_c_call and
+        in_progress_thd_c_call == in_progress_c_call and
+        in_stream_queue_thd_c_call == in_stream_queue_c_call
+    )
+    test_run:cmd("eval test 'wakeup()'")
+end;
+total, in_progress, in_stream_queue = 0, 0, 0;
+-- Here we check a few things for 'total' request statistics:
+-- - statistics getting by call same as getting by index
+-- - total statistics is equal to the sum of statistics per threads
+for thread_id = 1, thread_count do
+    local total_thd_t_call, in_progress_thd_t_call,
+          in_stream_queue_thd_t_call =
+          get_network_requests_stats_for_thread_using_call(thread_id, "total")
+    local total_thd_t_index, in_progress_thd_t_index,
+          in_stream_queue_thd_t_index =
+          get_network_requests_stats_for_thread_using_index(thread_id, "total")
+    assert(
+        total_thd_t_call == total_thd_t_index and
+        in_progress_thd_t_call == in_progress_thd_t_index and
+        in_stream_queue_thd_t_call == in_stream_queue_thd_t_index
+    )
+    total = total + total_thd_t_call
+    in_progress = in_progress + in_progress_thd_t_call
+    in_stream_queue = in_stream_queue + in_stream_queue_thd_t_call
+end;
+total_t_call, in_progress_t_call, in_stream_queue_t_call =
+    get_network_requests_stats_using_call("total");
+total_t_index, in_progress_t_index, in_stream_queue_t_index =
+    get_network_requests_stats_using_index("total");
+assert(
+    total_t_call == total_t_index and
+    in_progress_t_call == in_progress_t_index and
+    in_stream_queue_t_call == in_stream_queue_t_index
+);
+assert(
+    total == total_t_call and
+    in_progress == in_progress_t_call and
+    in_stream_queue == in_stream_queue_t_call
+);
+-- We do not take into account service messages which was sent
+-- when establishing a connection
+assert(
+    total_t_call == request_count + service_total_msg_count and
+    in_progress_t_call  == request_count + service_in_progress_msg_count
+);
+test_run:cmd("setopt delimiter ''");
+
+test_run:cmd("stop server test")
+test_run:cmd("cleanup server test")
+test_run:cmd("delete server test")


### PR DESCRIPTION
Add new  metrics `REQUESTS_IN_PROGRESS`, `REQUESTS_IN_STREAM_QUEUE`
and `REQUESTS_IN_CBUS_QUEUE` to `box.stat.net`, which contain detail statistics for iproto requests. These metrics contains same counters as other metrics in `box.stat.net`: current, rps and total.

Add new  metric `STREAM_QUEUE_MAX` to `box.stat.net`. This metric contain two counters `current` (displays the current length of the longest stream queue) and `total` (displays the maximal length of the stream queue for all time).


