### PR TITLE
Make fiber death errors more clear

### DIFF
--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -925,8 +925,11 @@ fiber_loop(MAYBE_UNUSED void *data)
 			 * of the caller to deal with the error.
 			 */
 			if (!(fiber->flags & FIBER_IS_JOINABLE)) {
-				if (!(fiber->flags & FIBER_IS_CANCELLED))
-					error_log(e);
+				if (!(fiber->flags & FIBER_IS_CANCELLED)) {
+					struct error *e2 = BuildLuajitError(__FILE__, __LINE__, "");
+					error_format_msg(e2, "Fiber is dying: %s", e->errmsg);
+					error_log(e2);
+				}
 				diag_clear(&fiber()->diag);
 			}
 		} else {


### PR DESCRIPTION
One couldn't understand from logs that fiber has died. Especially tricky it was in the case of OOM errors in (supposedly) immortal fibers.

This patch makes such errors more verbose.

Log diff after the patch:

```diff
$ tarantool -l log -l fiber -e "log.cfg() fiber.new(function() fiber.name('xyz') error('oops', 0) end)"
- 2021-09-15 00:00:00.000 [1111] main/104/xyz utils.c:449 E> LuajitError: oops
+ 2021-09-15 00:00:00.000 [1111] main/104/xyz fiber.c:929 E> LuajitError: Fiber is dying: oops
```

Close #6439 