### PR TITLE
test: disable Lua JIT for net.box_reconnect_after_gh-3164

### DIFF
--- a/test/box/net.box_reconnect_after_gh-3164.result
+++ b/test/box/net.box_reconnect_after_gh-3164.result
@@ -10,6 +10,13 @@ test_run = require('test_run').new()
 net = require('net.box')
 ---
 ...
+-- TODO(gh-5081): Remove this once the bug is fixed.
+jit_enabled = jit.status()
+---
+...
+if jit_enabled then jit.off() end
+---
+...
 test_run:cmd("push filter 'peer_uuid: .*' to 'peer_uuid: <UUID>'")
 ---
 - true
@@ -131,4 +138,7 @@ collectgarbage('collect')
 weak.c
 ---
 - null
+...
+if jit_enabled then jit.on() end
+---
 ...

--- a/test/box/net.box_reconnect_after_gh-3164.test.lua
+++ b/test/box/net.box_reconnect_after_gh-3164.test.lua
@@ -3,6 +3,10 @@ log = require 'log'
 test_run = require('test_run').new()
 net = require('net.box')
 
+-- TODO(gh-5081): Remove this once the bug is fixed.
+jit_enabled = jit.status()
+if jit_enabled then jit.off() end
+
 test_run:cmd("push filter 'peer_uuid: .*' to 'peer_uuid: <UUID>'")
 test_run:cmd("push filter 'reconnect_after: .*' to 'reconnect_after: <NUM>'")
 test_run:cmd("push filter 'schema_version: .*' to 'schema_version: <NUM>'")
@@ -51,3 +55,5 @@ collectgarbage('collect')
 -- Now weak.c is null, because it was weak reference, and the
 -- connection is deleted by 'collect'.
 weak.c
+
+if jit_enabled then jit.on() end


### PR DESCRIPTION
The test is flaky, supposedly because of a bug in Lua JIT.
Disabling Lua JIT makes the test pass.

Workaround for #5081