### PR TITLE
memtx: disable building index in background if primary index is hash

### DIFF
--- a/changelogs/unreleased/gh-5977-build-index-in-background-with-hash-primary.md
+++ b/changelogs/unreleased/gh-5977-build-index-in-background-with-hash-primary.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fix a bug when index was inconsistent after background build in case when the primary index is hash (gh-5977)

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -1165,21 +1165,36 @@ memtx_space_build_index(struct space *src_space, struct index *new_index,
 	struct iterator *it = index_create_iterator(pk, ITER_ALL, NULL, 0);
 	if (it == NULL)
 		return -1;
+	/*
+	 * If we insert a tuple during index being built, new tuple will or
+	 * will not be inserted in index depending on result of lexicographical
+	 * comparison with tuple which was inserted into new index last.
+	 * The problem is HASH index is unordered, so background
+	 * build will not work properly if primary key is HASH index.
+	 */
+	bool can_yield = pk->def->type != HASH;
 
 	if (txn_check_singlestatement(txn, "index build") != 0)
 		return -1;
 
 	struct memtx_engine *memtx = (struct memtx_engine *)src_space->engine;
 	struct memtx_ddl_state state;
-	state.index = new_index;
-	state.format = new_format;
-	state.cmp_def = pk->def->key_def;
-	state.rc = 0;
-	diag_create(&state.diag);
-
 	struct trigger on_replace;
-	trigger_create(&on_replace, memtx_build_on_replace, &state, NULL);
-	trigger_add(&src_space->on_replace, &on_replace);
+	/*
+	 * Create trigger and initialize ddl state
+	 * if build in background is enabled.
+	 */
+	if (can_yield) {
+		state.index = new_index;
+		state.format = new_format;
+		state.cmp_def = pk->def->key_def;
+		state.rc = 0;
+		diag_create(&state.diag);
+
+		trigger_create(&on_replace, memtx_build_on_replace, &state,
+			       NULL);
+		trigger_add(&src_space->on_replace, &on_replace);
+	}
 
 	/*
 	 * The index has to be built tuple by tuple, since
@@ -1218,6 +1233,12 @@ memtx_space_build_index(struct space *src_space, struct index *new_index,
 		if (new_index->def->iid == 0)
 			tuple_ref(tuple);
 		/*
+		 * Do not build index in background
+		 * if the feature is disabled.
+		 */
+		if (!can_yield)
+			continue;
+		/*
 		 * Remember the latest inserted tuple to
 		 * avoid processing yet to be added tuples
 		 * in on_replace triggers.
@@ -1244,8 +1265,10 @@ memtx_space_build_index(struct space *src_space, struct index *new_index,
 		}
 	}
 	iterator_delete(it);
-	diag_destroy(&state.diag);
-	trigger_clear(&on_replace);
+	if (can_yield) {
+		diag_destroy(&state.diag);
+		trigger_clear(&on_replace);
+	}
 	return rc;
 }
 

--- a/test/box/gh-5977-inconsistency-on-shadow-build-with-hash-pk.result
+++ b/test/box/gh-5977-inconsistency-on-shadow-build-with-hash-pk.result
@@ -1,0 +1,183 @@
+-- test-run result file version 2
+env = require('test_run')
+ | ---
+ | ...
+test_run = env.new()
+ | ---
+ | ...
+fiber = require('fiber')
+ | ---
+ | ...
+
+-- Test consists of two reproducers from a corresponding issue.
+
+s = box.schema.space.create('test', {engine = 'memtx'})
+ | ---
+ | ...
+i = s:create_index('pk',  {type='hash', parts={{1, 'uint'}}})
+ | ---
+ | ...
+
+known = {}
+ | ---
+ | ...
+
+-- Get seed randomly and remember it to reproduce easily.
+math.randomseed(os.time())
+ | ---
+ | ...
+seed = math.random(10000)
+ | ---
+ | ...
+math.randomseed(seed)
+ | ---
+ | ...
+
+test_run:cmd("setopt delimiter ';'");
+ | ---
+ | - true
+ | ...
+
+function replace()
+    local r = 42
+    while known[r] do r = math.random(1000000) end
+    known[r] = true
+    s:replace{r, r}
+end;
+ | ---
+ | ...
+
+-- Insert enough tuples to enable build in background.
+for i = 0, 6000 do replace() end;
+ | ---
+ | ...
+
+function joinable(fib)
+    fib:set_joinable(true)
+    return fib
+end;
+ | ---
+ | ...
+
+-- Make some replaces.
+function disturb()
+    for j = 1,10 do
+        box.begin()
+        for i = 1,10 do
+            replace()
+        end
+        box.commit()
+    end
+end;
+ | ---
+ | ...
+
+-- Create secondary index
+function create(index_type)
+    s:create_index('sk', {type=index_type, parts={{2, 'uint'}}})
+end;
+ | ---
+ | ...
+
+-- Call create() and disturb() concurrently and then
+-- check consistency of secondary index.
+-- Print random seed on fail.
+function process_test(index_type)
+    local disturber = joinable(fiber.new(disturb))
+    local creator = joinable(fiber.new(create, index_type))
+    disturber:join()
+    creator:join()
+    assert(s.index.pk:count() == s.index.sk:count(), 'Test failed with seed = ' .. seed)
+end;
+ | ---
+ | ...
+
+test_run:cmd("setopt delimiter ''");
+ | ---
+ | - true
+ | ...
+
+process_test('hash')
+ | ---
+ | ...
+s.index.sk:drop()
+ | ---
+ | ...
+
+process_test('tree')
+ | ---
+ | ...
+s:drop()
+ | ---
+ | ...
+known = nil
+ | ---
+ | ...
+
+s = box.schema.space.create('test', {engine = 'memtx'})
+ | ---
+ | ...
+i = s:create_index('pk',  {type='hash', parts={{1, 'uint'}}})
+ | ---
+ | ...
+
+space_size = 6000
+ | ---
+ | ...
+
+test_run:cmd("setopt delimiter ';'");
+ | ---
+ | - true
+ | ...
+
+for i = 0, space_size do
+    s:replace{i, i}
+end;
+ | ---
+ | ...
+
+for i = 0, 9 do
+    s:delete{i}
+end;
+ | ---
+ | ...
+
+function disturb()
+    fiber.sleep(0)
+    for i = 1, 10 do
+        s:replace{space_size + i, space_size + i}
+    end
+end;
+ | ---
+ | ...
+
+function create(index_type)
+    s:create_index('sk', {type=index_type, parts={{2, 'uint'}}})
+end;
+ | ---
+ | ...
+
+test_run:cmd("setopt delimiter ''");
+ | ---
+ | - true
+ | ...
+
+process_test('hash')
+ | ---
+ | ...
+s.index.sk:drop()
+ | ---
+ | ...
+
+process_test('tree')
+ | ---
+ | ...
+s:drop()
+ | ---
+ | ...
+seed = nil
+ | ---
+ | ...
+space_size = nil
+ | ---
+ | ...

--- a/test/box/gh-5977-inconsistency-on-shadow-build-with-hash-pk.test.lua
+++ b/test/box/gh-5977-inconsistency-on-shadow-build-with-hash-pk.test.lua
@@ -1,0 +1,104 @@
+env = require('test_run')
+test_run = env.new()
+fiber = require('fiber')
+
+-- Test consists of two reproducers from a corresponding issue.
+
+s = box.schema.space.create('test', {engine = 'memtx'})
+i = s:create_index('pk',  {type='hash', parts={{1, 'uint'}}})
+
+known = {}
+
+-- Get seed randomly and remember it to reproduce easily.
+math.randomseed(os.time())
+seed = math.random(10000)
+math.randomseed(seed)
+
+test_run:cmd("setopt delimiter ';'");
+
+function replace()
+    local r = 42
+    while known[r] do r = math.random(1000000) end
+    known[r] = true
+    s:replace{r, r}
+end;
+
+-- Insert enough tuples to enable build in background.
+for i = 0, 6000 do replace() end;
+
+function joinable(fib)
+    fib:set_joinable(true)
+    return fib
+end;
+
+-- Make some replaces.
+function disturb()
+    for j = 1,10 do
+        box.begin()
+        for i = 1,10 do
+            replace()
+        end
+        box.commit()
+    end
+end;
+
+-- Create secondary index
+function create(index_type)
+    s:create_index('sk', {type=index_type, parts={{2, 'uint'}}})
+end;
+
+-- Call create() and disturb() concurrently and then
+-- check consistency of secondary index.
+-- Print random seed on fail.
+function process_test(index_type)
+    local disturber = joinable(fiber.new(disturb))
+    local creator = joinable(fiber.new(create, index_type))
+    disturber:join()
+    creator:join()
+    assert(s.index.pk:count() == s.index.sk:count(), 'Test failed with seed = ' .. seed)
+end;
+
+test_run:cmd("setopt delimiter ''");
+
+process_test('hash')
+s.index.sk:drop()
+
+process_test('tree')
+s:drop()
+known = nil
+
+s = box.schema.space.create('test', {engine = 'memtx'})
+i = s:create_index('pk',  {type='hash', parts={{1, 'uint'}}})
+
+space_size = 6000
+
+test_run:cmd("setopt delimiter ';'");
+
+for i = 0, space_size do
+    s:replace{i, i}
+end;
+
+for i = 0, 9 do
+    s:delete{i}
+end;
+
+function disturb()
+    fiber.sleep(0)
+    for i = 1, 10 do
+        s:replace{space_size + i, space_size + i}
+    end
+end;
+
+function create(index_type)
+    s:create_index('sk', {type=index_type, parts={{2, 'uint'}}})
+end;
+
+test_run:cmd("setopt delimiter ''");
+
+process_test('hash')
+s.index.sk:drop()
+
+process_test('tree')
+s:drop()
+seed = nil
+space_size = nil


### PR DESCRIPTION
If we insert a tuple in space with an index that is being built in background,
new tuple will or will not be inserted into new index depending on the result of
lexicographical comparison with tuple which was inserted into new index last.
The problem is hash index is unordered, so background build will not work properly
if primary key is HASH index.

To avoid this, disable building index in background if primary index is hash.

Closes #5977