### PR TITLE
net.box: doing some renames and moving send/recv buffers to C

### DIFF
--- a/src/box/lua/net_box.lua
+++ b/src/box/lua/net_box.lua
@@ -322,11 +322,8 @@ local function create_transport(host, port, user, password, callback,
             local msg = string.format("Connection is closing")
             return box.error.new({code = code, reason = msg})
         end
-        -- alert worker to notify it of the queued outgoing data;
-        -- if the buffer wasn't empty, assume the worker was already alerted
-        if send_buf:size() == 0 then
-            worker_fiber:wakeup()
-        end
+        -- Alert worker to notify it of the queued outgoing data.
+        worker_fiber:wakeup()
     end
 
     --


### PR DESCRIPTION
We will need to store net.box watchers (see #6257) in a C struct. We already have a C struct per net.box connection, but it has an unfortunate name - netbox_registry - because initially it was introduced to only store the requests hash table. This patch renames it to netbox_transport. While we are at it, let's also move the send/recv buffers to this struct (which is now aptly named), because they fit well in there (this would be a part of #6291).