### PR TITLE
lua: implement timeout for 'fiber:join'

### DIFF
--- a/changelogs/unreleased/gh-6203-implement-fiber-join-with-timeout.md
+++ b/changelogs/unreleased/gh-6203-implement-fiber-join-with-timeout.md
@@ -1,0 +1,3 @@
+## feature/core
+
+* Implement timeout for 'fiber:join' in lua (gh-6203).

--- a/test/app/gh-6203-fiber-join-with-timeout.result
+++ b/test/app/gh-6203-fiber-join-with-timeout.result
@@ -1,0 +1,51 @@
+fiber = require('fiber')
+---
+...
+timeout = 10
+---
+...
+function sleep(timeout) \
+    channel:get() \
+    fiber.sleep(timeout) \
+end
+---
+...
+channel = fiber.channel()
+---
+...
+f = fiber.create(sleep, timeout)
+---
+...
+f:set_joinable(true)
+---
+...
+channel:put(true)
+---
+- true
+...
+f:join(0.1) -- Join failed because of timeout
+---
+- false
+- timed out
+...
+timeout = 0.2
+---
+...
+f = fiber.create(sleep, timeout)
+---
+...
+f:set_joinable(true)
+---
+...
+channel:put(true)
+---
+- true
+...
+f:join("xxx") --error: 'fiber:join(timeout): bad arguments'
+---
+- error: 'fiber:join(timeout): bad arguments'
+...
+f:join(-1) --error: 'fiber:join(timeout): bad arguments'
+---
+- error: 'fiber:join(timeout): bad arguments'
+...

--- a/test/app/gh-6203-fiber-join-with-timeout.test.lua
+++ b/test/app/gh-6203-fiber-join-with-timeout.test.lua
@@ -1,0 +1,21 @@
+fiber = require('fiber')
+
+timeout = 10
+function sleep(timeout) \
+    channel:get() \
+    fiber.sleep(timeout) \
+end
+
+channel = fiber.channel()
+f = fiber.create(sleep, timeout)
+f:set_joinable(true)
+channel:put(true)
+f:join(0.1) -- Join failed because of timeout
+
+timeout = 0.2
+f = fiber.create(sleep, timeout)
+f:set_joinable(true)
+channel:put(true)
+f:join("xxx") --error: 'fiber:join(timeout): bad arguments'
+f:join(-1) --error: 'fiber:join(timeout): bad arguments'
+


### PR DESCRIPTION
Implement ability to pass timeout to 'fiber:join' function.
If timeout expired, join fails with 'timed out' error.

Closes #6203

@TarantoolBot document
Title: ability to set timeout for 'fiber:join' function was implemented
Implement ability to pass timeout to 'fiber:join' function.
If timeout expired, join fails with 'timed out' error.