### PR TITLE
github-ci: use openssl@1.1

### DIFF
--- a/.travis.mk
+++ b/.travis.mk
@@ -321,7 +321,7 @@ test_oos_build:
 # OSX #
 #######
 
-OSX_PKGS=openssl readline curl icu4c libiconv zlib cmake python3
+OSX_PKGS=openssl@1.1 readline curl icu4c libiconv zlib cmake python3
 
 deps_osx:
 	# install brew using command from Homebrew repository instructions:

--- a/cmake/os.cmake
+++ b/cmake/os.cmake
@@ -132,7 +132,7 @@ elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
         endif()
 
         # Detecting OpenSSL
-        execute_process(COMMAND ${HOMEBREW_EXECUTABLE} --prefix openssl
+        execute_process(COMMAND ${HOMEBREW_EXECUTABLE} --prefix openssl@1.1
                         OUTPUT_VARIABLE HOMEBREW_OPENSSL
                         OUTPUT_STRIP_TRAILING_WHITESPACE)
         if (DEFINED HOMEBREW_OPENSSL)


### PR DESCRIPTION
OSX workflows use brew for install openssl.
There was a new release of openssl@3.0 and
homebrew updated the openssl formula.

Close #6468

(cherry picked from commit 59c794c3cf765f74225391a49369b0f7c3deac32)