### PR TITLE
man: update outdated copyright year in manual page

### DIFF
--- a/doc/man/tarantool.pod
+++ b/doc/man/tarantool.pod
@@ -91,6 +91,6 @@ tarantoolctl(1), Tarantool documentation at http://tarantool.org
 
 =head1 COPYRIGHT
 
-Copyright (C) 2010-2017 Tarantool AUTHORS: please see AUTHORS file.
+Copyright (C) 2010-2021 Tarantool AUTHORS: please see AUTHORS file.
 
 =cut


### PR DESCRIPTION
Copyright year in manual page is outdated: update copyright year to
2021.

Closes #5309