### PR TITLE
debian: resolve lintian warnings

### DIFF
--- a/.gitlab.mk
+++ b/.gitlab.mk
@@ -133,7 +133,9 @@ package: deploy_prepare
 		export VERSION="$$(echo $(GIT_DESCRIBE) | sed 's/-\([0-9]\+\)-g[0-9a-f]\+$$/.\1/' | sed 's/-/~/').dev"; \
 	fi;                                                                                                             \
 	echo VERSION=$$VERSION;                                                                                         \
-	PACKPACK_EXTRA_DOCKER_RUN_PARAMS="--network=host ${PACKPACK_EXTRA_DOCKER_RUN_PARAMS}" ./packpack/packpack
+	PACKPACK_EXTRA_DOCKER_RUN_PARAMS="--network=host ${PACKPACK_EXTRA_DOCKER_RUN_PARAMS}"                           \
+	TARBALL_EXTRA_ARGS="--exclude=*.exe --exclude=*.dll"                                                            \
+	PRESERVE_ENVVARS="TARBALL_EXTRA_ARGS,${PRESERVE_ENVVARS}" ./packpack/packpack
 
 # found that libcreaterepo_c.so installed in local lib path
 deploy: export LD_LIBRARY_PATH=/usr/local/lib

--- a/changelogs/unreleased/gh-6390-resolve-lintian-warnings.md
+++ b/changelogs/unreleased/gh-6390-resolve-lintian-warnings.md
@@ -1,0 +1,3 @@
+## feature/build
+
+* Remove Windows binaries from debian source packages (gh-6390).

--- a/changelogs/unreleased/gh-6390-resolve-lintian-warnings.md
+++ b/changelogs/unreleased/gh-6390-resolve-lintian-warnings.md
@@ -1,3 +1,5 @@
 ## feature/build
 
 * Remove Windows binaries from debian source packages (gh-6390).
+
+* Bump debian control Standards-Version to 4.5.1 (gh-6390).

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,9 @@
 Source: tarantool
 Priority: optional
 Maintainer: Alexander Turenko <alexander.turenko@tarantool.org>
-Uploaders: Dmitry E. Oboukhov <unera@debian.org>
+Uploaders:
+ Dmitry E. Oboukhov <unera@debian.org>,
+ PackPack <build@tarantool.org>
 Build-Depends: cdbs (>= 0.4.100), debhelper (>= 9), dpkg-dev (>= 1.16.1~),
 # It is recommended to use debhelper version equal to or greater than
 # compatibility level. This is a workaround for Ubuntu Xenial repos

--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,7 @@ Build-Depends: cdbs (>= 0.4.100), debhelper (>= 9), dpkg-dev (>= 1.16.1~),
 # Install prove to run LuaJIT tests.
  libtest-harness-perl,
 Section: database
-Standards-Version: 3.9.8
+Standards-Version: 4.5.1
 Homepage: http://tarantool.org/
 VCS-Browser: https://github.com/tarantool/tarantool
 VCS-Git: git://github.com/tarantool/tarantool.git

--- a/debian/copyright
+++ b/debian/copyright
@@ -226,10 +226,6 @@ Files: third_party/proctitle.c
 Copyright: 2000-2010 PostgreSQL Global Development Group
 License: BSD-2-Clause
 
-Files: third_party/lua-cjson/*
-Copyright: 2010-2012 Mark Pulford <mark@kyne.com.au>
-License: Expat
-
 Files: src/lib/salad/rope.*
 Copyright: 1993-1994 by Xerox Corporation.
 License: BSD-2-Clause

--- a/debian/rules
+++ b/debian/rules
@@ -54,6 +54,8 @@ tarball: clean
 		--exclude=test-run/lib/tarantool-python/debian \
 		--exclude=third_party/luafun/debian \
 		--exclude=FreeBSD \
+		--exclude="*.exe" \
+		--exclude="*.dll" \
 		--transform='s,^\.,tarantool_$(UVERSION),S' \
 		-czf ../tarantool_$(UVERSION).orig.tar.gz .
 

--- a/debian/rules
+++ b/debian/rules
@@ -28,7 +28,7 @@ DEB_DH_SYSTEMD_START_ARGS_tarantool-common  := --no-restart-on-upgrade tarantool
 
 # Needed for proper backtraces in fiber.info()
 DEB_DH_STRIP_ARGS	        := -X/usr/bin/tarantool
-export DEB_BUILD_MAINT_OPTIONS = hardening=-stackprotector,-pie
+export DEB_BUILD_MAINT_OPTIONS = hardening=-stackprotector
 DPKG_EXPORT_BUILDFLAGS = 1
 
 include /usr/share/dpkg/buildflags.mk

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,4 +1,0 @@
-tarantool source: outdated-autotools-helper-file third_party/libeio/config.guess 2012-02-10
-tarantool source: outdated-autotools-helper-file third_party/libeio/config.sub 2012-02-10
-tarantool source: outdated-autotools-helper-file third_party/libev/config.guess 2008-01-23
-tarantool source: outdated-autotools-helper-file third_party/libev/config.sub 2008-01-16

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,0 +1,5 @@
+# This override can be removed after Ubuntu Xenial support is dropped
+# and debian/control Build-Depends Ubuntu Xenial workaround 
+# 'base-files (<< 9.9) | debhelper (>= 10)' is replaced with strict
+# 'debhelper (>= 10)' condition.
+tarantool source: package-needs-versioned-debhelper-build-depends 10

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -3,3 +3,4 @@
 # 'base-files (<< 9.9) | debhelper (>= 10)' is replaced with strict
 # 'debhelper (>= 10)' condition.
 tarantool source: package-needs-versioned-debhelper-build-depends 10
+tarantool source: newer-standards-version *

--- a/debian/tarantool.lintian-overrides
+++ b/debian/tarantool.lintian-overrides
@@ -1,1 +1,3 @@
 tarantool: unstripped-binary-or-object usr/bin/tarantool
+tarantool: embedded-library usr/bin/tarantool: curl
+tarantool: embedded-library usr/bin/tarantool: libyaml


### PR DESCRIPTION
Closes #6390 

### duplicate-globbing-patterns
Remove duplicate pattern from copyright.

### malformed-override
Remove outdated tags override.

### embedded-library
Ignore embedded library lintian errors for curl and libyaml.

### package-needs-versioned-debhelper-build-depends
Ignore lintian warning. This warning triggers when debhelper minimal required version is less than compat level. Ubuntu Xenial repos do not contain debhelper 10. This warning also triggers on Ubuntu Bionic and Debian Stretch and Buster despite using debhelper 10 or newer, which highly likely is a lintian bug. Debian Bullseye and Ubuntu newer that Bionic
pipelines do not yield this warning.

### no-nmu-in-changelog
Add PackPack to uploaders. Before this patch all PackPack-builded packages was treated as non-maintainer updates.

### source-nmu-has-incorrect-version-number
Add PackPack to uploaders. Before this patch all PackPack-builded packages was treated as non-maintainer updates.

### source-contains-prebuilt-windows-binary
Remove Windows binaries from source tars.

### ancient-standards-version
Standards-Version is 4.5.1 recommended for Debian Bullseye, Ubuntu Groovy and Hirsute. Older versions do not support 4.5.1 and thus yield newer-standards-version warning. This patch overrides it.

Most notable changes:

- Packages must not call /etc/init.d scripts directly even as a fallback, and instead must always use invoke-rc.d (which is essential and shouldn’t require any conditional).

- Packages may not install files in both /path and /usr/path, and must manage any backward-compatibility symlinks so that they don’t break if /path and /usr/path are the same directory.

- Packages are recommended to build reproducibly even when build paths and most environment variables are allowed to vary.

- Clarify that programs may invoke either /usr/bin/editor and  /usr/bin/pager directly, or use editor and pager and rely on PATH.

- If /etc/staff-group-for-usr-local does not exist, /usr/local and all subdirectories created by packages should have permissions 0755 and be owned by root:root. If the file exists, the old permissions of 2775 and ownership of root:staff should remain.

- Packages should not contain a non-default series file. That is, dpkg’s vendor-specific patch series feature should not be used for packages in the Debian archive.

- Binaries should be stripped using strip --strip-unneeded --remove-section=.comment --remove-section=.note (as dh_strip already does).

- Packages that include system services should include systemd service units to start or stop those services.

- Use of update-rc.d is required if the package includes an init script (previously, Policy said in one place that it was required, and in another said that it was recommended).

- Shared libraries must now invoke ldconfig by means of triggers, instead of maintscripts.

- Required targets must not write outside of the unpacked source package tree, except for TMPDIR, /tmp and /var/tmp.

You can read full changelog here: https://www.debian.org/doc/debian-policy/upgrading-checklist.html

No changes was introduced in package building pipeline after upgrade since there aren't any affecting behavior changes.

### hardening-no-pie
Remove `-pie` flag. In Debian, since version 6.2.0-7 of the gcc-6 package GCC will compile ELF binaries with PIE by default. Ubuntu Xenial uses older versions of gcc which not build ELF binaries with PIE by default, but since Xenial builds did not trigger this warning, we do not change the behavior with additional flags. Part of #5372