### PR TITLE
xlog: reduce snapshot verbosity

### DIFF
--- a/changelogs/unreleased/gh-6220-reduce-snapshot-verbosity.md
+++ b/changelogs/unreleased/gh-6220-reduce-snapshot-verbosity.md
@@ -1,0 +1,3 @@
+## feature/xlog
+
+* Reduce snapshot verbosity (gh-6620).

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -481,8 +481,10 @@ applier_wait_snapshot(struct applier *applier)
 		if (iproto_type_is_dml(row.type)) {
 			if (apply_snapshot_row(&row) != 0)
 				diag_raise();
-			if (++row_count % ROWS_PER_LOG == 0)
-				say_info("%.1fM rows received", row_count / 1e6);
+			if (++row_count % ROWS_PER_LOG == 0) {
+				say_info_ratelimited("%.1fM rows received",
+						     row_count / 1e6);
+			}
 		} else if (row.type == IPROTO_OK) {
 			if (applier->version_id < version_id(1, 7, 0)) {
 				/*
@@ -560,7 +562,8 @@ applier_wait_register(struct applier *applier, uint64_t row_count)
 		struct stailq rows;
 		row_count += applier_read_tx(applier, &rows, TIMEOUT_INFINITY);
 		while (row_count >= next_log_cnt) {
-			say_info("%.1fM rows received", next_log_cnt / 1e6);
+			say_info_ratelimited("%.1fM rows received",
+					     next_log_cnt / 1e6);
 			next_log_cnt += ROWS_PER_LOG;
 		}
 		struct xrow_header *first_row =

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -190,8 +190,8 @@ memtx_engine_recover_snapshot(struct memtx_engine *memtx,
 		}
 		++row_count;
 		if (row_count % 100000 == 0) {
-			say_info("%.1fM rows processed",
-				 row_count / 1000000.);
+			say_info_ratelimited("%.1fM rows processed",
+					     row_count / 1e6);
 			fiber_yield_timeout(0);
 		}
 	}
@@ -522,8 +522,10 @@ checkpoint_write_row(struct xlog *l, struct xrow_header *row)
 	if (written < 0)
 		return -1;
 
-	if ((l->rows + l->tx_rows) % 100000 == 0)
-		say_crit("%.1fM rows written", (l->rows + l->tx_rows) / 1000000.0);
+	if ((l->rows + l->tx_rows) % 100000 == 0) {
+		say_crit_ratelimited("%.1fM rows written",
+				     (l->rows + l->tx_rows) / 1e6);
+	}
 	return 0;
 
 }

--- a/src/box/recovery.cc
+++ b/src/box/recovery.cc
@@ -252,9 +252,10 @@ recover_xlog(struct recovery *r, struct xstream *stream,
 		if (++stream->row_count % WAL_ROWS_PER_YIELD == 0) {
 			xstream_yield(stream);
 		}
-		if (stream->row_count % 100000 == 0)
-			say_info("%.1fM rows processed",
-				 stream->row_count / 1000000.);
+		if (stream->row_count % 100000 == 0) {
+			say_info_ratelimited("%.1fM rows processed",
+					     stream->row_count / 1e6);
+		}
 		/*
 		 * Read the next row from xlog file.
 		 *

--- a/src/lib/core/say.h
+++ b/src/lib/core/say.h
@@ -361,11 +361,11 @@ enum {
  * messages are suppressed. It uses ev_monotonic_now() as a time
  * source.
  */
-#define say_ratelimit_check(rl) ({					\
+#define say_ratelimit_check(rl, level) ({				\
 	int suppressed = 0;						\
 	bool ret = ratelimit_check((rl), ev_monotonic_now(loop()),	\
 				   &suppressed);			\
-	if (suppressed > 0)						\
+	if ((level) >= S_WARN && suppressed > 0)			\
 		say_warn("%d messages suppressed", suppressed);		\
 	ret;								\
 })
@@ -380,12 +380,18 @@ enum {
 	static struct ratelimit rl =					\
 		RATELIMIT_INITIALIZER(SAY_RATELIMIT_INTERVAL,		\
 				      SAY_RATELIMIT_BURST);		\
-	if (say_ratelimit_check(&rl))					\
+	if (say_ratelimit_check(&rl, level))				\
 		say(level, error, format, ##__VA_ARGS__);		\
 })
 
+#define say_crit_ratelimited(format, ...) \
+        say_ratelimited(S_CRIT, NULL, format, ##__VA_ARGS__)
+
 #define say_warn_ratelimited(format, ...) \
 	say_ratelimited(S_WARN, NULL, format, ##__VA_ARGS__)
+
+#define say_info_ratelimited(format, ...) \
+        say_ratelimited(S_INFO, NULL, format, ##__VA_ARGS__)
 
 /**
  * Format and print a message to Tarantool log file.


### PR DESCRIPTION
On big instances core produces too much logs related to shapshotting,
which feels redudant: reduce snapshot verbosity.

Closes #6220