### PR TITLE
box: fix tuple field count overflow handling

### DIFF
--- a/changelogs/unreleased/gh-6198-max-cnt-of-tuple-fields-insert-overflow-error-msg.md
+++ b/changelogs/unreleased/gh-6198-max-cnt-of-tuple-fields-insert-overflow-error-msg.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fix error message on attempt to insert into a tuple which size equals to 
+  box.schema.FIELD_MAX (gh-6198).

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -285,6 +285,7 @@ struct errcode_record {
 	/*227 */_(ER_UNABLE_TO_PROCESS_OUT_OF_STREAM, "Unable to process %s request out of stream") \
 	/*228 */_(ER_TRANSACTION_TIMEOUT,       "Transaction has been aborted by timeout") \
 	/*229 */_(ER_ACTIVE_TIMER,              "Operation is not permitted if timer is already running") \
+	/*230 */_(ER_TUPLE_FIELD_COUNT_LIMIT,	"Tuple field count limit reached: see box.schema.FIELD_MAX") \
 
 /*
  * !IMPORTANT! Please follow instructions at start of the file

--- a/src/box/xrow_update_array.c
+++ b/src/box/xrow_update_array.c
@@ -31,6 +31,7 @@
 #include "xrow_update_field.h"
 #include "msgpuck.h"
 #include "fiber.h"
+#include "schema_def.h"
 #include "tuple_format.h"
 
 /**
@@ -369,6 +370,11 @@ xrow_update_op_do_array_insert(struct xrow_update_op *op,
 
 	struct xrow_update_rope *rope = field->array.rope;
 	uint32_t size = xrow_update_rope_size(rope);
+	assert(size <= BOX_FIELD_MAX);
+	if (size == BOX_FIELD_MAX) {
+		diag_set(ClientError, ER_TUPLE_FIELD_COUNT_LIMIT);
+		return -1;
+	}
 	if (xrow_update_op_adjust_field_no(op, size + 1) != 0)
 		return -1;
 

--- a/test/box-tap/gh-6198-max-cnt-of-tuple-fields-insert-overflow-err-msg.test.lua
+++ b/test/box-tap/gh-6198-max-cnt-of-tuple-fields-insert-overflow-err-msg.test.lua
@@ -1,0 +1,18 @@
+#!/usr/bin/env tarantool
+
+local tap = require('tap')
+local test = tap.test('gh-6198-max-cnt-of-tuple-fields-insert-overflow-err-msg')
+
+test:plan(1)
+
+box.cfg{}
+
+local t = box.tuple.new({1}):update({{'=', box.schema.FIELD_MAX, 1}})
+local expected_err_msg = 'Tuple field count limit reached: see ' ..
+                         'box.schema.FIELD_MAX'
+local ok, observed_err_msg = pcall(t.update, t, {{'!', #t, 1}})
+test:is_deeply({ok, tostring(observed_err_msg)}, {false, expected_err_msg},
+               'unable to insert into a tuple which size equals to ' ..
+               'box.schema.FIELD_MAX')
+
+os.exit(test:check() and 0 or 1)

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -451,6 +451,7 @@ t;
  |   230: box.error.UNABLE_TO_PROCESS_OUT_OF_STREAM
  |   231: box.error.TRANSACTION_TIMEOUT
  |   232: box.error.ACTIVE_TIMER
+ |   233: box.error.TUPLE_FIELD_COUNT_LIMIT
  | ...
 
 test_run:cmd("setopt delimiter ''");


### PR DESCRIPTION
Tuple field count overflow is not handled: before inserting, explicitly
compare the current tuple size to box.schema.FIELD_MAX and set a newly
introduced diagnostic message if overflow occurs.

Closes #6198