### PR TITLE
sql: fixed potential OoB issue in lemon.c file

### DIFF
--- a/extra/lemon.c
+++ b/extra/lemon.c
@@ -1555,6 +1555,10 @@ static struct rule *Rule_sort(struct rule *rp){
       rp = Rule_merge(x[i], rp);
       x[i] = 0;
     }
+    if ( i==32 ){
+      rp->next = pNext;
+      return 0;
+    }
     x[i] = rp;
     rp = pNext;
   }
@@ -1673,6 +1677,10 @@ int main(int argc, char **argv)
   }
   lem.startRule = lem.rule;
   lem.rule = Rule_sort(lem.rule);
+  if ( lem.rule==0 ){
+    fprintf(stderr,"Invalid file containing rules, too many rules.\n");
+    exit(1);
+  }
 
   /* Generate a reprint of the grammar, if requested on the command line */
   if( rpflag ){


### PR DESCRIPTION
The static analyzer found a potential OoB problem in the lemon.c file.
This situation occurs when you go beyond the boundaries of the
array x in the Rule_sort() function. The number of elements
of the array x used for sorting has a logarithmic dependence on
the size of the input list. Thus, to go beyond the bounds of the array x
and refer to index 32, the size of the input list must be 2^33.

This patch adds an array index check to the Rule_sort () function.
If the 32-item limit is exceeded, the function aborts and
returns NULL instead of the sorted list. The function interrupts its
execution and does not complete the sorting, because the number
of elements in the list exceeding INT32_MAX violates the logic of the program.

It is technically impossible to reproduce this problem in a test, since, firstly,
such a test will require memory allocation for 2^33 elements of the rule structure,
and secondly, it will take too much time to process such a test.

Fixes #5789