### PR TITLE
datetime: intervals implementation - step.2

### DIFF
--- a/extra/exports
+++ b/extra/exports
@@ -420,6 +420,7 @@ tnt_datetime_strftime
 tnt_datetime_to_string
 tnt_default_cert_dir_paths
 tnt_default_cert_file_paths
+tnt_dt_add_months
 tnt_dt_days_in_month
 tnt_dt_dom
 tnt_dt_dow

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -56,6 +56,15 @@ int     tnt_dt_month        (dt_t dt);
 int     tnt_dt_doy          (dt_t dt);
 int     tnt_dt_dom          (dt_t dt);
 
+/* dt_arithmetic.h definitions */
+typedef enum {
+    DT_EXCESS,
+    DT_LIMIT,
+    DT_SNAP
+} dt_adjust_t;
+
+dt_t   tnt_dt_add_months   (dt_t dt, int delta, dt_adjust_t adjust);
+
 /* dt_parse_iso.h definitions */
 size_t tnt_dt_parse_iso_zone_lenient(const char *str, size_t len, int *offset);
 
@@ -71,11 +80,14 @@ void   tnt_datetime_now(struct datetime *now);
 local builtin = ffi.C
 local math_modf = math.modf
 local math_floor = math.floor
+local math_fmod = math.fmod
+local math_abs = math.abs
 
 -- Unix, January 1, 1970, Thursday
 local DAYS_EPOCH_OFFSET = 719163
 local SECS_PER_DAY      = 86400
 local SECS_EPOCH_OFFSET = DAYS_EPOCH_OFFSET * SECS_PER_DAY
+local NANOS_PER_SEC     = 1e9
 local TOSTRING_BUFSIZE  = 48
 local STRFTIME_BUFSIZE  = 128
 
@@ -87,6 +99,31 @@ local MIN_DATE_DAY = 22
 local MAX_DATE_YEAR = 5879611
 local MAX_DATE_MONTH = 7
 local MAX_DATE_DAY = 11
+-- In the Julian calendar, the average year length is
+-- 365 1/4 days = 365.25 days. This gives an error of
+-- about 1 day in 128 years.
+local AVERAGE_DAYS_YEAR = 365.25
+local AVERAGE_DAYS_MONTH = AVERAGE_DAYS_YEAR / 12
+local AVERAGE_WEEK_YEAR = AVERAGE_DAYS_YEAR / 7
+local INT_MAX = 2147483647
+local INT_MIN = -2147483648
+-- -5879610-06-22
+local MIN_DATE_TEXT = ('%d-%02d-%02d'):format(MIN_DATE_YEAR, MIN_DATE_MONTH,
+                                              MIN_DATE_DAY)
+-- 5879611-07-11
+local MAX_DATE_TEXT = ('%d-%02d-%02d'):format(MAX_DATE_YEAR, MAX_DATE_MONTH,
+                                              MAX_DATE_DAY)
+local MAX_YEAR_RANGE = MAX_DATE_YEAR - MIN_DATE_YEAR
+local MAX_MONTH_RANGE = MAX_YEAR_RANGE * 12
+local MAX_WEEK_RANGE = MAX_YEAR_RANGE * AVERAGE_WEEK_YEAR
+local MAX_DAY_RANGE = MAX_YEAR_RANGE * AVERAGE_DAYS_YEAR
+local MAX_HOUR_RANGE = MAX_DAY_RANGE * 24
+local MAX_MIN_RANGE = MAX_HOUR_RANGE * 60
+local MAX_SEC_RANGE = MAX_DAY_RANGE * SECS_PER_DAY
+local MAX_NSEC_RANGE = INT_MAX
+local MAX_USEC_RANGE = math_floor(MAX_NSEC_RANGE / 1e3)
+local MAX_MSEC_RANGE = math_floor(MAX_NSEC_RANGE / 1e6)
+local DEF_DT_ADJUST = builtin.DT_LIMIT
 
 local date_tostr_stash =
     buffer.ffi_stash_new(string.format('char[%s]', TOSTRING_BUFSIZE))
@@ -100,8 +137,41 @@ local date_strf_stash_put = date_strf_stash.put
 
 local datetime_t = ffi.typeof('struct datetime')
 
+--[[
+    To be able to perform arithmetics on time intervals and receive
+    deterministic results, we have to keep months and years separately
+    from seconds.
+    Weeks, days, hours and minutes, all could be _precisely_ converted
+    to seconds, but it's not the case for months (which might be 28, 29,
+    30, or 31 days long), or years (which could be leap year or not).
+    Approach used here - to add/subtract months or years intervals only
+    at the moment when we have particular date we operate on.
+    Determinism of results is achieved due to the order we apply
+    operations (from larger to smaller quantities):
+    - years, then months, then weeks, days, hours, minutes,
+      seconds, and nanoseconds.
+]]
+ffi.cdef [[
+    struct datetime_interval {
+        double sec;
+        int nsec;
+        int month;
+        int year;
+        dt_adjust_t adjust;
+    };
+]]
+local interval_t = ffi.typeof('struct datetime_interval')
+
+local function is_interval(o)
+    return ffi.istype(interval_t, o)
+end
+
 local function is_datetime(o)
     return ffi.istype(datetime_t, o)
+end
+
+local function is_table(o)
+    return type(o) == 'table'
 end
 
 local function check_date(o, message)
@@ -111,8 +181,36 @@ local function check_date(o, message)
     end
 end
 
+local function check_date_interval(o, message)
+    if not is_datetime(o) and not is_interval(o) then
+        return error(("%s: expected datetime or interval, but received %s"):
+                     format(message, type(o)), 2)
+    end
+end
+
+local function check_interval(o, message)
+    if not is_interval(o) then
+        return error(("%s: expected interval, but received %s"):
+                     format(message, type(o)), 2)
+    end
+end
+
+local function check_interval_table(o, message)
+    if not is_table(o) and not is_interval(o) then
+        return error(("%s: expected interval or table, but received %s"):
+                     format(message, type(o)), 2)
+    end
+end
+
+local function check_date_interval_table(o, message)
+    if not is_table(o) and not is_datetime(o) and not is_interval(o) then
+        return error(("%s: expected datetime, interval or table, but received %s"):
+                     format(message, type(o)), 2)
+    end
+end
+
 local function check_table(o, message)
-    if type(o) ~= 'table' then
+    if not is_table(o) then
         return error(("%s: expected table, but received %s"):
                      format(message, type(o)), 2)
     end
@@ -122,6 +220,16 @@ local function check_str(s, message)
     if type(s) ~= 'string' then
         return error(("%s: expected string, but received %s"):
                      format(message, type(s)), 2)
+    end
+end
+
+local function check_integer(v, message)
+    if v == nil then
+        return
+    end
+    if type(v) ~= 'number' or v % 1 ~= 0 then
+        error(('%s: integer value expected, but received %s'):
+              format(message, type(v)), 4)
     end
 end
 
@@ -142,6 +250,24 @@ local function check_range(v, from, to, txt, extra)
     else
         error(('value %d of %s is out of allowed range [%d, %d..%d]'):
               format(v, txt, extra, from, to), 3)
+    end
+end
+
+local function check_dt(dt_v, direction, v, unit)
+    if dt_v >= INT_MIN and dt_v <= INT_MAX then
+        return
+    end
+    local operation = direction >= 0 and 'addition' or 'subtraction'
+    local title = unit ~= nil and ('%s of %d %s'):format(operation, v, unit) or
+                                  operation
+    if dt_v < INT_MIN then
+        error(('%s makes date less than minimum allowed %s'):
+                format(title, MIN_DATE_TEXT), 3)
+    elseif dt_v > INT_MAX then
+        error(('%s makes date greater than maximum allowed %s'):
+                format(title, MAX_DATE_TEXT), 3)
+    else
+        assert(false)
     end
 end
 
@@ -172,11 +298,95 @@ local function check_ymd_range(y, M, d)
         return
     end
 ::min_err::
-    error(('date %d-%02d-%02d is less than minimum allowed %d-%02d-%02d'):
-        format(y, M, d, MIN_DATE_YEAR, MIN_DATE_MONTH, MIN_DATE_DAY))
+    error(('date %d-%02d-%02d is less than minimum allowed %s'):
+        format(y, M, d, MIN_DATE_TEXT))
 ::max_err::
-    error(('date %d-%02d-%02d is greater than maximum allowed %d-%02d-%02d'):
-        format(y, M, d, MAX_DATE_YEAR, MAX_DATE_MONTH, MAX_DATE_DAY))
+    error(('date %d-%02d-%02d is greater than maximum allowed %s'):
+        format(y, M, d, MAX_DATE_TEXT))
+end
+
+-- check v value against maximum/minimum possible values
+-- if there is nil then simply return default 0
+local function checked_max_value(v, max, txt, def)
+    if v == nil then
+        return def
+    end
+    if type(v) ~= 'number' then
+        error(('numeric value expected, but received %s'):
+              format(type(v)), 2)
+    end
+    if v > -max and v < max then
+        return v
+    end
+    error(('value %s of %s is out of allowed range [%s, %s]'):
+            format(v, txt, -max, max), 4)
+end
+
+local function bool2int(b)
+    return b and 1 or 0
+end
+
+local function normalize_nsec(secs, nsec)
+    if nsec < 0 or nsec >= NANOS_PER_SEC then
+        secs = secs + math_floor(nsec / NANOS_PER_SEC)
+        nsec = nsec % NANOS_PER_SEC
+    end
+    return secs, nsec
+end
+
+local adjust_xlat = {
+    none = builtin.DT_LIMIT,
+    last = builtin.DT_SNAP,
+    excess = builtin.DT_EXCESS,
+}
+
+local function interval_decouple_args(obj)
+    if is_interval(obj) then
+        return obj.year, obj.month, obj.sec, obj.nsec, obj.adjust
+    end
+    local year = checked_max_value(obj.year, MAX_YEAR_RANGE, 'year', 0)
+    local month = checked_max_value(obj.month, MAX_MONTH_RANGE, 'month', 0)
+    local adjust = adjust_xlat[obj.adjust] or DEF_DT_ADJUST
+
+    local secs = 0
+    secs = secs + (7 * SECS_PER_DAY) *
+                  checked_max_value(obj.week, MAX_WEEK_RANGE, 'week', 0)
+    secs = secs + SECS_PER_DAY *
+                  checked_max_value(obj.day, MAX_DAY_RANGE, 'day', 0)
+    secs = secs + (60 * 60) *
+                  checked_max_value(obj.hour, MAX_HOUR_RANGE, 'hour', 0)
+    secs = secs + 60 * checked_max_value(obj.min, MAX_MIN_RANGE, 'min', 0)
+    local sec = checked_max_value(obj.sec, MAX_SEC_RANGE, 'sec', 0)
+    check_integer(sec, 'sec')
+
+    local nsec = checked_max_value(obj.nsec, MAX_NSEC_RANGE, 'nsec')
+    local usec = checked_max_value(obj.usec, MAX_USEC_RANGE, 'usec')
+    local msec = checked_max_value(obj.msec, MAX_MSEC_RANGE, 'msec')
+    local count_usec = bool2int(nsec ~= nil) + bool2int(usec ~= nil) +
+                       bool2int(msec ~= nil)
+    if count_usec > 1 then
+        error('only one of nsec, usec or msecs may be defined '..
+                'simultaneously', 3)
+    end
+    secs = secs + sec
+    nsec = (msec or 0) * 1e6 + (usec or 0) * 1e3 + (nsec or 0)
+
+    return year, month, secs, nsec, adjust
+end
+
+local function interval_new(obj)
+    local ival = ffi.new(interval_t, 0, 0, 0, 0, DEF_DT_ADJUST)
+    if obj == nil then
+        return ival
+    end
+    check_table(obj, 'interval.new()')
+    ival.year, ival.month, ival.sec, ival.nsec, ival.adjust =
+        interval_decouple_args(obj)
+    return ival
+end
+
+local function interval_init(year, month, sec, nsec, adjust)
+    return ffi.new(interval_t, sec, nsec, month, year, adjust)
 end
 
 local function nyi(msg)
@@ -205,29 +415,28 @@ local function local_dt(obj)
     return builtin.tnt_dt_from_rdn(local_rd(local_secs(obj)))
 end
 
-local function datetime_cmp(lhs, rhs)
+local function datetime_cmp(lhs, rhs, is_raising)
     if not is_datetime(lhs) or not is_datetime(rhs) then
-        return nil
+        if is_raising then
+            error('incompatible types for datetime comparison', 3)
+        else
+            return nil
+        end
     end
     local sdiff = lhs.epoch - rhs.epoch
     return sdiff ~= 0 and sdiff or (lhs.nsec - rhs.nsec)
 end
 
 local function datetime_eq(lhs, rhs)
-    local rc = datetime_cmp(lhs, rhs)
-    return rc == 0
+    return datetime_cmp(lhs, rhs, false) == 0
 end
 
 local function datetime_lt(lhs, rhs)
-    local rc = datetime_cmp(lhs, rhs)
-    return rc == nil and error('incompatible types for comparison', 2) or
-           rc < 0
+    return datetime_cmp(lhs, rhs, true) < 0
 end
 
 local function datetime_le(lhs, rhs)
-    local rc = datetime_cmp(lhs, rhs)
-    return rc == nil and error('incompatible types for comparison', 2) or
-           rc <= 0
+    return datetime_cmp(lhs, rhs, true) <= 0
 end
 
 --[[
@@ -262,6 +471,10 @@ local function datetime_new_raw(epoch, nsec, tzoffset)
     return dt_obj
 end
 
+local function datetime_new_copy(obj)
+    return datetime_new_raw(obj.epoch, obj.nsec, obj.tzoffset)
+end
+
 local function datetime_new_dt(dt, secs, nanosecs, offset)
     local epoch = (dt - DAYS_EPOCH_OFFSET) * SECS_PER_DAY
     return datetime_new_raw(epoch + secs - offset * 60, nanosecs, offset)
@@ -276,10 +489,6 @@ local function get_timezone(offset, msg)
         error(('%s: string or number expected, but received %s'):
               format(msg, offset), 3)
     end
-end
-
-local function bool2int(b)
-    return b and 1 or 0
 end
 
 -- create datetime given attribute values from obj
@@ -420,6 +629,241 @@ local function datetime_tostring(self)
     return s
 end
 
+local function qtail(s)
+    return #s ~= 0 and (s .. ', ') or s
+end
+
+-- if |nsec| is larger than allowed range 1e9 then modify passed
+-- sec accordingly
+local function denormalize_interval_nsec(sec, nsec)
+    if nsec == 0 then
+        return sec, nsec
+    end
+    -- nothing to change:
+    -- - if there is small nsec with 0 in sec
+    -- - or if both sec and nsec have the same sign, and nsec is
+    --   small enough
+    local same_sign = (sec < 0) == (nsec < 0)
+    if (sec == 0 or same_sign) and math_abs(nsec) < 1e9 then
+        return sec, nsec
+    end
+
+    sec = sec + math_modf(nsec / NANOS_PER_SEC)
+    if sec >= 0 then
+        nsec = nsec % NANOS_PER_SEC
+    else
+        nsec = NANOS_PER_SEC - nsec % NANOS_PER_SEC
+    end
+    return sec, nsec
+end
+
+-- signed or unsigned textual representation of sec and nsec
+local function seconds_str(need_sign, sec, nsec)
+    sec = math_fmod(sec, 60)
+    sec, nsec = denormalize_interval_nsec(sec, nsec)
+    local is_negative = sec < 0 or (sec == 0 and nsec < 0)
+    local str = is_negative and '-' or (need_sign and '+' or '')
+    sec = math_abs(sec)
+    if nsec ~= 0 then
+        str = str .. ('%d.%09d seconds'):format(sec, math_abs(nsec))
+    else
+        str = str .. ('%d seconds'):format(sec)
+    end
+    return str
+end
+
+
+local signed_fmt = {
+    [false] = '%d',
+    [true]  = '%+d',
+}
+
+--[[
+    Convert to text interval values of different types
+
+    - depending on a values stored there generic interval
+      values may display in following format:
+        +12 secs
+        -23 minutes, 0 seconds
+        +12 hours, 23 minutes, 1 seconds
+        -7 days, -23 hours, -23 minutes, -1 seconds
+    - years will be displayed as
+        +10 years
+    - months will be displayed as:
+         +2 months
+]]
+local function interval_tostring(o)
+    check_interval(o, 'datetime.interval.tostring')
+    local s = ''
+    local need_sign = true
+    if o.year ~= 0 then
+        s = qtail(s) .. ('%+d years'):format(o.year)
+        need_sign = false
+    end
+    if o.month ~= 0 then
+        s = qtail(s) .. (signed_fmt[need_sign] .. ' months'):format(o.month)
+        need_sign = false
+    end
+    local sec, nsec = o.sec, o.nsec
+    if sec == 0 and nsec == 0 then
+        return #s > 0 and s or '0 seconds'
+    end
+    local abs_s = math_abs(sec)
+    if abs_s < 60 then
+        s = qtail(s) .. seconds_str(need_sign, sec, nsec)
+    elseif abs_s < (60 * 60) then
+        s = qtail(s) .. (signed_fmt[need_sign] .. ' minutes, %s'):
+                        format(o.min, seconds_str(false, sec, nsec))
+    elseif abs_s < SECS_PER_DAY then
+        s = qtail(s) .. (signed_fmt[need_sign] .. ' hours, %d minutes, %s'):
+                        format(o.hour, math_fmod(o.min, 60),
+                               seconds_str(false, sec, nsec))
+    else
+        s = qtail(s) .. (signed_fmt[need_sign] .. ' days, %d hours, %d minutes, %s'):
+                        format(o.day, math_fmod(o.hour, 24),
+                               math_fmod(o.min, 60),
+                               seconds_str(false, sec, nsec))
+    end
+    return s
+end
+
+local function datetime_increment_by(self, direction, years, months,
+                                     seconds, nanoseconds, adjust)
+    -- operations with intervals should be done using local human dates
+    -- not UTC dates, thus normalize to local timezone before operations.
+    local dt = local_dt(self)
+    local secs, nsec = local_secs(self), self.nsec
+    local offset = self.tzoffset
+
+    local is_ym_updated = false
+    adjust = adjust or DEF_DT_ADJUST
+
+    if years ~= 0 then
+        check_range(years, MIN_DATE_YEAR, MAX_DATE_YEAR, 'years')
+        local approx_dt = dt + direction * years * AVERAGE_DAYS_YEAR
+        check_dt(approx_dt, direction, years, 'years')
+        -- tnt_dt_add_years() not handle properly DT_SNAP or DT_LIMIT mode
+        -- so use tnt_dt_add_months() as a work-around
+        dt = builtin.tnt_dt_add_months(dt, direction * years * 12, adjust)
+        is_ym_updated = true
+    end
+    if months ~= 0 then
+        local new_dt = dt + direction * months * AVERAGE_DAYS_MONTH
+        check_dt(new_dt, direction, months, 'months')
+        dt = builtin.tnt_dt_add_months(dt, direction * months, adjust)
+        is_ym_updated = true
+    end
+    if is_ym_updated then
+        secs = (dt - DAYS_EPOCH_OFFSET) * SECS_PER_DAY + secs % SECS_PER_DAY
+    end
+
+    if seconds ~= 0 then
+        secs = secs + direction * seconds
+    end
+
+    if nanoseconds ~= 0 then
+        nsec = nsec + direction * nanoseconds
+    end
+
+    secs, self.nsec = normalize_nsec(secs, nsec)
+    check_dt((secs + SECS_EPOCH_OFFSET) / SECS_PER_DAY, direction)
+    self.epoch = utc_secs(secs, offset)
+    return self
+end
+
+local function date_first(lhs, rhs)
+    if is_datetime(rhs) then
+        return rhs, lhs
+    else
+        return lhs, rhs
+    end
+end
+
+local function error_incompatible(name)
+    error(("datetime:%s() - incompatible type of arguments"):
+          format(name), 3)
+end
+
+--[[
+Matrix of subtraction operands eligibility and their result type
+
+|                 | datetime | interval | table    |
++-----------------+----------+----------+----------+
+| datetime        | interval | datetime | datetime |
+| interval        |          | interval | interval |
+| table           |          |          |          |
+]]
+local function datetime_interval_sub(lhs, rhs)
+    check_date_interval(lhs, "operator -")
+    check_date_interval_table(rhs, "operator -")
+    local left_is_interval = is_table(lhs) or is_interval(lhs)
+    local right_is_interval = is_table(rhs) or is_interval(rhs)
+    local year, month, secs, nsec, adjust
+
+    -- left is date, right is interval
+    if not left_is_interval and right_is_interval then
+        year, month, secs, nsec, adjust = interval_decouple_args(rhs)
+        return datetime_increment_by(datetime_new_copy(lhs), -1, year, month,
+                                     secs, nsec, adjust)
+    -- left is date, right is date
+    elseif not left_is_interval and not right_is_interval then
+        local obj = interval_new()
+        obj.sec, obj.nsec = normalize_nsec(lhs.epoch - rhs.epoch,
+                                           lhs.nsec - rhs.nsec)
+        return obj
+    -- both left and right are intervals
+    elseif left_is_interval and right_is_interval then
+        year, month, secs, nsec, adjust = interval_decouple_args(lhs)
+        local obj = interval_init(year, month, secs, nsec, adjust)
+        year, month, secs, nsec = interval_decouple_args(rhs)
+        obj.year = obj.year - year
+        obj.month = obj.month - month
+        -- do not normalize nsec yet - leave till the operation with date
+        obj.sec, obj.nsec = obj.sec - secs, obj.nsec - nsec
+        return obj
+    else
+        error_incompatible("operator -")
+    end
+end
+
+--[[
+Matrix of addition operands eligibility and their result type
+
+|                 | datetime | interval | table    |
++-----------------+----------+----------+----------+
+| datetime        |          | datetime | datetime |
+| interval        | datetime | interval | interval |
+| table           |          |          |          |
+]]
+local function datetime_interval_add(lhs, rhs)
+    lhs, rhs = date_first(lhs, rhs)
+
+    check_date_interval(lhs, "operator +")
+    check_interval_table(rhs, "operator +")
+    local left_is_interval = is_table(lhs) or is_interval(lhs)
+    local right_is_interval = is_table(rhs) or is_interval(rhs)
+    local year, month, secs, nsec, adjust
+
+    -- left is date, right is interval
+    if not left_is_interval and right_is_interval then
+        local obj = datetime_new_copy(lhs)
+        year, month, secs, nsec, adjust = interval_decouple_args(rhs)
+        return datetime_increment_by(obj, 1, year, month, secs, nsec, adjust)
+    -- both left and right are intervals
+    elseif left_is_interval and right_is_interval then
+        year, month, secs, nsec, adjust = interval_decouple_args(lhs)
+        local obj = interval_init(year, month, secs, nsec, adjust)
+        year, month, secs, nsec = interval_decouple_args(rhs)
+        obj.year = obj.year + year
+        obj.month = obj.month + month
+        -- do not normalize nsec yet - leave till the operation with date
+        obj.sec, obj.nsec = obj.sec + secs, obj.nsec + nsec
+        return obj
+    else
+        error_incompatible("operator +")
+    end
+end
+
 --[[
     Create datetime object representing current time using microseconds
     platform timer and local timezone information.
@@ -428,6 +872,18 @@ local function datetime_now()
     local d = datetime_new_raw(0, 0, 0)
     builtin.tnt_datetime_now(d)
     return d
+end
+
+-- addition or subtraction from date/time of a given interval
+-- described via table direction should be +1 or -1
+local function datetime_shift(self, o, direction)
+    assert(direction == -1 or direction == 1)
+    local title = direction > 0 and "datetime.add" or "datetime.sub"
+    check_interval_table(o, title)
+
+    local year, month, secs, nsec, adjust = interval_decouple_args(o)
+    return datetime_increment_by(self, direction, year, month, secs, nsec,
+                                 adjust)
 end
 
 --[[
@@ -665,6 +1121,8 @@ local datetime_index_functions = {
     format = datetime_format,
     totable = datetime_totable,
     set = datetime_set,
+    add = function(self, obj) return datetime_shift(self, obj, 1) end,
+    sub = function(self, obj) return datetime_shift(self, obj, -1) end,
 }
 
 local function datetime_index(self, key)
@@ -680,11 +1138,59 @@ ffi.metatype(datetime_t, {
     __eq = datetime_eq,
     __lt = datetime_lt,
     __le = datetime_le,
+    __sub = datetime_interval_sub,
+    __add = datetime_interval_add,
     __index = datetime_index,
 })
 
-return setmetatable({
-    new         = datetime_new,
-    now         = datetime_now,
-    is_datetime = is_datetime,
-}, {})
+local function total_secs(self)
+    return self.sec + self.nsec / 1e9
+end
+
+local interval_index_fields = {
+    usec = function(self) return math_floor(self.nsec / 1e3) end,
+    msec = function(self) return math_floor(self.nsec / 1e6) end,
+
+    week = function(self)
+        return math_modf(total_secs(self) / (7 * SECS_PER_DAY))
+    end,
+    day = function(self)
+        return math_modf(total_secs(self) / SECS_PER_DAY)
+    end,
+    hour = function(self)
+        return math_modf(total_secs(self) / (60 * 60))
+    end,
+    min =  function(self)
+        return math_modf(total_secs(self) / 60)
+    end,
+}
+
+local interval_index_functions = {
+    __serialize = interval_tostring,
+}
+
+local function interval_index(self, key)
+    local handler_field = interval_index_fields[key]
+    return handler_field ~= nil and handler_field(self) or
+           interval_index_functions[key]
+end
+
+ffi.metatype(interval_t, {
+    __tostring = interval_tostring,
+    __sub = datetime_interval_sub,
+    __add = datetime_interval_add,
+    __index = interval_index,
+})
+
+local interval_mt = {
+    new     = interval_new,
+}
+
+return setmetatable(
+    {
+        new         = datetime_new,
+        interval    = setmetatable(interval_mt, interval_mt),
+        now         = datetime_now,
+        is_datetime = is_datetime,
+    }, {}
+)

--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -11,7 +11,7 @@ local ffi = require('ffi')
 --]]
 if jit.arch == 'arm64' then jit.off() end
 
-test:plan(14)
+test:plan(22)
 
 -- minimum supported date - -5879610-06-22
 local MIN_DATE_YEAR = -5879610
@@ -22,15 +22,29 @@ local MAX_DATE_YEAR = 5879611
 local MAX_DATE_MONTH = 7
 local MAX_DATE_DAY = 11
 
-local incompat_types = 'incompatible types for comparison'
+local SECS_PER_DAY      = 86400
+local AVERAGE_DAYS_YEAR = 365.25
+local AVERAGE_WEEK_YEAR = AVERAGE_DAYS_YEAR / 7
+local MAX_YEAR_RANGE = MAX_DATE_YEAR - MIN_DATE_YEAR
+local MAX_MONTH_RANGE = MAX_YEAR_RANGE * 12
+local MAX_WEEK_RANGE = MAX_YEAR_RANGE * AVERAGE_WEEK_YEAR
+local MAX_DAY_RANGE = MAX_YEAR_RANGE * AVERAGE_DAYS_YEAR
+local MAX_HOUR_RANGE = MAX_DAY_RANGE * 24
+local MAX_MIN_RANGE = MAX_HOUR_RANGE * 60
+local MAX_SEC_RANGE = MAX_DAY_RANGE * SECS_PER_DAY
+
+local incompat_types = 'incompatible types for datetime comparison'
 local only_integer_ts = 'only integer values allowed in timestamp'..
                         ' if nsec, usec, or msecs provided'
 local only_one_of = 'only one of nsec, usec or msecs may be defined'..
                     ' simultaneously'
+local int_ival_exp = 'sec: integer value expected, but received number'
 local timestamp_and_ymd = 'timestamp is not allowed if year/month/day provided'
 local timestamp_and_hms = 'timestamp is not allowed if hour/min/sec provided'
 local str_or_num_exp = 'tzoffset: string or number expected, but received'
 local numeric_exp = 'numeric value expected, but received '
+local expected_interval_but = 'expected interval or table, but received'
+local expected_datetime_but = 'expected datetime, interval or table, but received'
 
 -- various error message generators
 local function exp_datetime(name, value)
@@ -55,7 +69,7 @@ local function invalid_days_in_mon(d, M, y)
 end
 
 local function range_check_error(name, value, range)
-    return ('value %s of %s is out of allowed range [%d, %d]'):
+    return ('value %s of %s is out of allowed range [%s, %s]'):
               format(value, name, range[1], range[2])
 end
 
@@ -318,7 +332,6 @@ test:test("Simple date creation by attributes - check failed", function(test)
     }
     for _, row in pairs(specific_errors) do
         local err_msg, attribs = unpack(row)
-        print(require'json'.encode(attribs))
         assert_raises(test, err_msg, function() date.new(attribs) end)
     end
 end)
@@ -528,6 +541,571 @@ test:test("__index functions()", function(test)
     test:is(ts.nsec, 123000000, 'ts.nsec')
     test:is(ts.usec, 123000, 'ts.usec')
     test:is(ts.msec, 123, 'ts.msec')
+end)
+
+test:test("Time interval tostring()", function(test)
+    test:plan(19)
+    local ivals = {
+        {{sec = 1}, '+1 seconds'},
+        {{sec = 49}, '+49 seconds'},
+        {{min = 10, sec = 30}, '+10 minutes, 30 seconds'},
+        {{hour = 1, min = 59, sec = 10}, '+1 hours, 59 minutes, 10 seconds'},
+        {{hour = 12, min = 10, sec = 30}, '+12 hours, 10 minutes, 30 seconds'},
+        {{day = 2, hour = 8, min = 10, sec = 30},
+         '+2 days, 8 hours, 10 minutes, 30 seconds'},
+        {{week = 10, hour = 8, min = 10, sec = 30},
+         '+70 days, 8 hours, 10 minutes, 30 seconds'},
+        {{month = 20, week = 10, hour = 8, min = 10, sec = 30},
+         '+20 months, 70 days, 8 hours, 10 minutes, 30 seconds'},
+        {{year = 10, month = 20, week = 10, hour = 8, min = 10, sec = 30},
+         '+10 years, 20 months, 70 days, 8 hours, 10 minutes, 30 seconds'},
+        {{year = 1e4, month = 20, week = 10, hour = 8, min = 10, sec = 30},
+         '+10000 years, 20 months, 70 days, 8 hours, 10 minutes, 30 seconds'},
+        {{year = 5e6, month = 20, week = 10, hour = 8, min = 10, sec = 30},
+         '+5000000 years, 20 months, 70 days, 8 hours, 10 minutes, 30 seconds'},
+        {{year = -5e6, month = -20, week = -10, hour = -8, min = -10, sec = -30},
+         '-5000000 years, -20 months, -70 days, -8 hours, -10 minutes, -30 seconds'},
+        {{month = -20, week = -10, hour = -8, min = -10, sec = -30},
+         '-20 months, -70 days, -8 hours, -10 minutes, -30 seconds'},
+        {{week = -10, hour = -8, min = -10, sec = -30},
+         '-70 days, -8 hours, -10 minutes, -30 seconds'},
+        {{hour = -12, min = -10, sec = -30}, '-12 hours, -10 minutes, -30 seconds'},
+        {{hour = -1, min = -59, sec = -10}, '-1 hours, -59 minutes, -10 seconds'},
+        {{min = -10, sec = -30}, '-10 minutes, -30 seconds'},
+        {{sec = -49}, '-49 seconds'},
+        {{sec = -1}, '-1 seconds'},
+    }
+    for _, row in pairs(ivals) do
+        local ival_init, str = unpack(row)
+        local ival = date.interval.new(ival_init)
+        test:is(tostring(ival), str, str)
+    end
+end)
+
+test:test("Time interval __index fields", function(test)
+    test:plan(11)
+
+    local ival = date.interval.new{year = 12345, month = 123, week = 100,
+                                   day = 45, hour = 48, min = 3, sec = 1,
+                                   nsec = 12345678}
+    test:is(tostring(ival), '+12345 years, 123 months, 747 days, 0 hours,'..
+            ' 3 minutes, 1.012345678 seconds', '__tostring')
+
+    test:is(ival.nsec, 12345678, 'nsec')
+    test:is(ival.usec, 12345, 'usec')
+    test:is(ival.msec, 12, 'msec')
+
+    test:is(ival.year, 12345, 'interval.year')
+    test:is(ival.month, 123, 'interval.month')
+    test:is(ival.week, 106, 'interval.week')
+    test:is(ival.day, 747, 'interval.day')
+    test:is(ival.hour, 17928, 'interval.hour')
+    test:is(ival.min, 1075683, 'interval.min')
+    test:is(ival.sec, 64540981, 'interval.sec')
+end)
+
+test:test("Time interval operations", function(test)
+    test:plan(164)
+
+    local ival_new = date.interval.new
+
+    -- check arithmetic with leap dates
+    local base_leap_date = { year = 1972, month = 2, day = 29}
+
+    local leap_ivals_check = {
+        {{month = 1}, '1972-03-29T00:00:00Z', '1972-01-29T00:00:00Z'},
+        {{month = 1}, '1972-04-29T00:00:00Z', '1971-12-29T00:00:00Z'},
+        {{month = 5}, '1972-09-29T00:00:00Z', '1971-07-29T00:00:00Z'},
+        {{year = 1, month = 2}, '1973-11-29T00:00:00Z', '1970-05-29T00:00:00Z'},
+        {{year = 2, month = 3}, '1976-02-29T00:00:00Z', '1968-02-29T00:00:00Z'},
+        {{month = 1}, '1976-03-29T00:00:00Z', '1968-01-29T00:00:00Z'},
+        {{month = 1}, '1976-04-29T00:00:00Z', '1967-12-29T00:00:00Z'},
+        {{month = 5}, '1976-09-29T00:00:00Z', '1967-07-29T00:00:00Z'},
+        {{year = -1}, '1975-09-29T00:00:00Z', '1968-07-29T00:00:00Z'},
+        {{year = -1}, '1974-09-29T00:00:00Z', '1969-07-29T00:00:00Z'},
+    }
+
+    local tadd_t = date.new(base_leap_date) -- :add{table}
+    local tadd_i = date.new(base_leap_date) -- :add{interval}
+    local tplus_i = date.new(base_leap_date) -- t + interval
+    local tplus_t = date.new(base_leap_date) -- t + {table}
+
+    -- check additions
+    for _, row in pairs(leap_ivals_check) do
+        local delta, sadd, _ = unpack(row)
+        -- t:add{table}
+        test:is(tostring(tadd_t:add(delta)), sadd,
+                ('add delta to %s'):format(sadd))
+        -- t:add(interval)
+        test:is(tostring(tadd_i:add(ival_new(delta))), sadd,
+                ('add ival delta to %s'):format(sadd))
+        -- t + interval
+        tplus_i = tplus_i + ival_new(delta)
+        test:is(tostring(tplus_i), sadd, ('%s: t + ival delta'):format(sadd))
+        -- t - interval
+        tplus_t = tplus_t + delta
+        test:is(tostring(tplus_t), sadd, ('%s: t + table delta'):format(sadd))
+    end
+
+    local tsub_t = date.new(base_leap_date) -- :sub{table}
+    local tsub_i = date.new(base_leap_date) -- :sub{interval}
+    local tminus_i = date.new(base_leap_date) -- t - interval
+    local tminus_t = date.new(base_leap_date) -- t - {table}
+
+    -- check subtractions
+    for _, row in pairs(leap_ivals_check) do
+        local delta, _, ssub = unpack(row)
+        -- t:add{table}
+        test:is(tostring(tsub_t:sub(delta)), ssub,
+                ('sub delta to %s'):format(ssub))
+        -- t:add(interval)
+        test:is(tostring(tsub_i:sub(ival_new(delta))), ssub,
+                ('sub ival delta to %s'):format(ssub))
+        -- t + interval
+        tminus_i = tminus_i - ival_new(delta)
+        test:is(tostring(tminus_i), ssub, ('%s: t - ival delta'):format(ssub))
+        -- t - interval
+        tminus_t = tminus_t - delta
+        test:is(tostring(tminus_t), ssub, ('%s: t - table delta'):format(ssub))
+    end
+
+    -- check average, not leap dates
+    local base_non_leap_date = {year = 1970, month = 1, day = 8}
+    local non_leap_ivals_check = {
+        {{year = 1, month = 2}, '1971-03-08T00:00:00Z', '1968-11-08T00:00:00Z'},
+        {{week = 10}, '1971-05-17T00:00:00Z', '1968-08-30T00:00:00Z'},
+        {{day = 15}, '1971-06-01T00:00:00Z', '1968-08-15T00:00:00Z'},
+        {{hour = 2}, '1971-06-01T02:00:00Z', '1968-08-14T22:00:00Z'},
+        {{min = 15}, '1971-06-01T02:15:00Z', '1968-08-14T21:45:00Z'},
+        {{sec = 48}, '1971-06-01T02:15:48Z', '1968-08-14T21:44:12Z'},
+        {{nsec = 2e9}, '1971-06-01T02:15:50Z', '1968-08-14T21:44:10Z'},
+        {{hour = 12, min = 600, sec = 1024}, '1971-06-02T00:32:54Z',
+         '1968-08-13T23:27:06Z'},
+    }
+
+    tadd_t = date.new(base_non_leap_date) -- :add{table}
+    tadd_i = date.new(base_non_leap_date) -- :add{interval}
+    tplus_i = date.new(base_non_leap_date) -- t + interval
+    tplus_t = date.new(base_non_leap_date) -- t + {table}
+
+    -- check additions
+    for _, row in pairs(non_leap_ivals_check) do
+        local delta, sadd, _ = unpack(row)
+        -- t:add{table}
+        test:is(tostring(tadd_t:add(delta)), sadd,
+                ('add delta to %s'):format(sadd))
+        -- t:add(interval)
+        test:is(tostring(tadd_i:add(ival_new(delta))), sadd,
+                ('add ival delta to %s'):format(sadd))
+        -- t + interval
+        tplus_i = tplus_i + ival_new(delta)
+        test:is(tostring(tplus_i), sadd, ('%s: t + ival delta'):format(sadd))
+        -- t - interval
+        tplus_t = tplus_t + delta
+        test:is(tostring(tplus_t), sadd, ('%s: t + table delta'):format(sadd))
+    end
+
+    tsub_t = date.new(base_non_leap_date) -- :sub{table}
+    tsub_i = date.new(base_non_leap_date) -- :sub{interval}
+    tminus_i = date.new(base_non_leap_date) -- t - interval
+    tminus_t = date.new(base_non_leap_date) -- t - {table}
+
+    -- check subtractions
+    for _, row in pairs(non_leap_ivals_check) do
+        local delta, _, ssub = unpack(row)
+        -- t:add{table}
+        test:is(tostring(tsub_t:sub(delta)), ssub,
+                ('sub delta to %s'):format(ssub))
+        -- t:add(interval)
+        test:is(tostring(tsub_i:sub(ival_new(delta))), ssub,
+                ('sub ival delta to %s'):format(ssub))
+        -- t + interval
+        tminus_i = tminus_i - ival_new(delta)
+        test:is(tostring(tminus_i), ssub, ('%s: t - ival delta'):format(ssub))
+        -- t - interval
+        tminus_t = tminus_t - delta
+        test:is(tostring(tminus_t), ssub, ('%s: t - table delta'):format(ssub))
+    end
+
+    -- check nsec boundary overflow
+    local i1, i2
+    i1 = ival_new{nsec = 1e9 - 1}
+    i2 = ival_new{nsec = 2}
+    test:is(tostring(i1 + i2), '+1.000000001 seconds', 'nsec: 999999999 + 2')
+    i1 = ival_new{nsec = -1e9 + 1}
+    i2 = ival_new{nsec = -2}
+    test:is(tostring(i1 + i2), '-1.000000001 seconds', 'nsec: -999999999 - 2')
+
+    local specific_errors = {
+        {only_one_of, { nsec = 123456, usec = 123}},
+        {only_one_of, { nsec = 123456, msec = 123}},
+        {only_one_of, { usec = 123, msec = 123}},
+        {only_one_of, { nsec = 123456, usec = 123, msec = 123}},
+        {int_ival_exp, { sec = 12345.125, usec = 123}},
+        {int_ival_exp, { sec = 12345.125, msec = 123}},
+        {int_ival_exp, { sec = 12345.125, nsec = 123}},
+    }
+    for _, row in pairs(specific_errors) do
+        local err_msg, obj = unpack(row)
+        assert_raises(test, err_msg, function() return tadd_t:add(obj) end)
+        assert_raises(test, err_msg, function() return tsub_t:sub(obj) end)
+    end
+    assert_raises_like(test, expected_interval_but, function() tadd_t:add('bogus') end)
+    assert_raises_like(test, expected_interval_but, function() tadd_t:add(123) end)
+    assert_raises_like(test, expected_interval_but, function() tsub_t:sub('bogus') end)
+    assert_raises_like(test, expected_interval_but, function() tsub_t:sub(123) end)
+end)
+
+test:test("Time interval operations - different adjustments", function(test)
+    test:plan(60)
+
+    -- check arithmetic with leap dates
+    local base_leap_date = { year = 1972, month = 2, day = 29}
+    local adj_modes = {
+        [1] = "last", -- default if omitted
+        [2] = "none",
+        [3] = "excess",
+    }
+
+    local leap_ivals_check_add = {
+        {{month = 1}, {'1972-03-31T00:00:00Z', '1972-03-29T00:00:00Z',
+                       '1972-03-29T00:00:00Z'}},
+        {{month = 1}, {'1972-04-30T00:00:00Z', '1972-04-29T00:00:00Z',
+                       '1972-04-29T00:00:00Z'}},
+        {{month = 5}, {'1972-09-30T00:00:00Z', '1972-09-29T00:00:00Z',
+                       '1972-09-29T00:00:00Z'}},
+        {{year = 1, month = 2}, {'1973-11-30T00:00:00Z', '1973-11-29T00:00:00Z',
+                                 '1973-11-29T00:00:00Z'}},
+        {{year = 2, month = 3}, {'1976-02-29T00:00:00Z', '1976-02-29T00:00:00Z',
+                                 '1976-02-29T00:00:00Z'}},
+        {{month = 1}, {'1976-03-31T00:00:00Z', '1976-03-29T00:00:00Z',
+                       '1976-03-29T00:00:00Z'}},
+        {{month = 1}, {'1976-04-30T00:00:00Z', '1976-04-29T00:00:00Z',
+                       '1976-04-29T00:00:00Z'}},
+        {{month = 5}, {'1976-09-30T00:00:00Z', '1976-09-29T00:00:00Z',
+                       '1976-09-29T00:00:00Z'}},
+        {{year = -1}, {'1975-09-30T00:00:00Z', '1975-09-29T00:00:00Z',
+                       '1975-09-29T00:00:00Z'}},
+        {{year = -1}, {'1974-09-30T00:00:00Z', '1974-09-29T00:00:00Z',
+                       '1974-09-29T00:00:00Z'}},
+    }
+
+    local tadd = {}
+    for i=1,3 do
+        tadd[i] = date.new(base_leap_date)
+    end
+
+    -- check additions with adjustments
+    for _, row in pairs(leap_ivals_check_add) do
+        local delta, sadds = unpack(row)
+        for i=1,3 do
+            local tsbefore = tostring(tadd[i])
+            local adjust = adj_modes[i]
+            local sadd = sadds[i]
+            delta.adjust = adjust
+            test:is(tostring(tadd[i]:add(delta)), sadd,
+                    ('add delta to %s with adjust %s'):format(tsbefore, adjust))
+
+        end
+    end
+
+    local leap_ivals_check_sub = {
+        {{month = 1}, {'1972-01-31T00:00:00Z', '1972-01-29T00:00:00Z',
+                       '1972-01-29T00:00:00Z'}},
+        {{month = 1}, {'1971-12-31T00:00:00Z', '1971-12-29T00:00:00Z',
+                       '1971-12-29T00:00:00Z'}},
+        {{month = 5}, {'1971-07-31T00:00:00Z', '1971-07-29T00:00:00Z',
+                       '1971-07-29T00:00:00Z'}},
+        {{year = 1, month = 2}, {'1970-05-31T00:00:00Z', '1970-05-29T00:00:00Z',
+                       '1970-05-29T00:00:00Z'}},
+        {{year = 2, month = 3}, {'1968-02-29T00:00:00Z', '1968-02-29T00:00:00Z',
+                       '1968-02-29T00:00:00Z'}},
+        {{month = 1}, {'1968-01-31T00:00:00Z', '1968-01-29T00:00:00Z',
+                       '1968-01-29T00:00:00Z'}},
+        {{month = 1}, {'1967-12-31T00:00:00Z', '1967-12-29T00:00:00Z',
+                       '1967-12-29T00:00:00Z'}},
+        {{month = 5}, {'1967-07-31T00:00:00Z', '1967-07-29T00:00:00Z',
+                       '1967-07-29T00:00:00Z'}},
+        {{year = -1}, {'1968-07-31T00:00:00Z', '1968-07-29T00:00:00Z',
+                       '1968-07-29T00:00:00Z'}},
+        {{year = -1}, {'1969-07-31T00:00:00Z', '1969-07-29T00:00:00Z',
+                       '1969-07-29T00:00:00Z'}},
+    }
+
+    local tsub = {}
+    for i=1,3 do
+        tsub[i] = date.new(base_leap_date)
+    end
+
+    -- check subtractions with adjustments
+    for _, row in pairs(leap_ivals_check_sub) do
+        local delta, ssubs = unpack(row)
+        for i=1,3 do
+            local tsbefore = tostring(tsub[i])
+            local adjust = adj_modes[i]
+            local ssub = ssubs[i]
+            delta.adjust = adjust
+            test:is(tostring(tsub[i]:sub(delta)), ssub,
+                    ('sub delta to %s with adjust %s'):format(tsbefore, adjust))
+        end
+    end
+end)
+
+test:test("Time intervals creation - range checks", function(test)
+    test:plan(23)
+
+    local inew = date.interval.new
+
+    local specific_errors = {
+        {only_one_of, { nsec = 123456, usec = 123}},
+        {only_one_of, { nsec = 123456, msec = 123}},
+        {only_one_of, { usec = 123, msec = 123}},
+        {only_one_of, { nsec = 123456, usec = 123, msec = 123}},
+        {int_ival_exp, { sec = 12345.125, usec = 123}},
+        {int_ival_exp, { sec = 12345.125, msec = 123}},
+        {int_ival_exp, { sec = 12345.125, nsec = 123}},
+        {table_expected('interval.new()', '2001-01-01'), '2001-01-01'},
+        {table_expected('interval.new()', 20010101), 20010101},
+        {range_check_error('year', 1e21, {-MAX_YEAR_RANGE, MAX_YEAR_RANGE}),
+            {year = 1e21}},
+        {range_check_error('year', -1e21, {-MAX_YEAR_RANGE, MAX_YEAR_RANGE}),
+            {year = -1e21}},
+        {range_check_error('month', 1e21, {-MAX_MONTH_RANGE, MAX_MONTH_RANGE}),
+            {month = 1e21}},
+        {range_check_error('month', -1e21, {-MAX_MONTH_RANGE, MAX_MONTH_RANGE}),
+            {month = -1e21}},
+        {range_check_error('week', 1e21, {-MAX_WEEK_RANGE, MAX_WEEK_RANGE}),
+            {week = 1e21}},
+        {range_check_error('week', -1e21, {-MAX_WEEK_RANGE, MAX_WEEK_RANGE}),
+            {week = -1e21}},
+        {range_check_error('day', 1e21, {-MAX_DAY_RANGE, MAX_DAY_RANGE}),
+            {day = 1e21}},
+        {range_check_error('day', -1e21, {-MAX_DAY_RANGE, MAX_DAY_RANGE}),
+            {day = -1e21}},
+        {range_check_error('hour', 1e21, {-MAX_HOUR_RANGE, MAX_HOUR_RANGE}),
+            {hour = 1e21}},
+        {range_check_error('hour', -1e21, {-MAX_HOUR_RANGE, MAX_HOUR_RANGE}),
+            {hour = -1e21}},
+        {range_check_error('min', 1e21, {-MAX_MIN_RANGE, MAX_MIN_RANGE}),
+            {min = 1e21}},
+        {range_check_error('min', -1e21, {-MAX_MIN_RANGE, MAX_MIN_RANGE}),
+            {min = -1e21}},
+        {range_check_error('sec', 1e21, {-MAX_SEC_RANGE, MAX_SEC_RANGE}),
+            {sec = 1e21}},
+        {range_check_error('sec', -1e21, {-MAX_SEC_RANGE, MAX_SEC_RANGE}),
+            {sec = -1e21}},
+    }
+    for _, row in pairs(specific_errors) do
+        local err_msg, attribs = unpack(row)
+        assert_raises(test, err_msg, function() return inew(attribs) end)
+    end
+
+end)
+
+test:test("Months intervals with last days", function(test)
+    test:plan(122)
+    local month1 = date.interval.new{month = 1, adjust = 'last'}
+    local base_day = date.new{year = 1998, month = 12, day = 31}
+    local current = base_day
+    test:is(current, date.new{year = 1998, month = 12, day = -1}, "day = -1")
+
+    -- check the fact that last day of month will snap
+    -- forward moves by 1 month
+    for year=1999,2003 do
+        for month=1,12 do
+            local month_last_day = date.new{year = year, month = month, day = -1}
+            current = current + month1
+            test:is(month_last_day, current, ('%s: last day of %d/%d'):
+                    format(current, year, month))
+        end
+    end
+
+    -- backward moves by 1 month
+    current = date.new{year = 2004, month = 1, day = 31}
+    test:is(current, date.new{year = 2004, month = 1, day = -1}, "day #2 = -1")
+
+    for year=2003,1999,-1 do
+        for month=12,1,-1 do
+            local month_last_day = date.new{year = year, month = month, day = -1}
+            current = current - month1
+            test:is(month_last_day, current, ('%s: last day of %d/%d'):
+                    format(current, year, month))
+        end
+    end
+end)
+
+local function catchadd(A, B)
+    return pcall(function() return A + B end)
+end
+
+--[[
+Matrix of addition operands eligibility and their result type
+
+|                 | datetime | interval | table    |
++-----------------+----------+----------+----------+
+| datetime        |          | datetime | datetime |
+| interval        | datetime | interval | interval |
+| table           |          |          |          |
+]]
+test:test("Matrix of allowed time and interval additions", function(test)
+    test:plan(67)
+
+    -- check arithmetic with leap dates
+    local T1970 = date.new{year = 1970, month = 1, day = 1}
+    local T2000 = date.new{year = 2000, month = 1, day = 1}
+
+    local I1 = date.interval.new{day = 1}
+    local M2 = date.interval.new{month = 2}
+    local M10 = date.interval.new{month = 10}
+    local Y1 = date.interval.new{year = 1}
+    local Y5 = date.interval.new{year = 5}
+
+    local i1 = {day = 1}
+    local m2 = {month = 2}
+    local m10 = {month = 10}
+    local y1 = {year = 1}
+    local y5 = {year = 5}
+
+    test:is(catchadd(T1970, I1), true, "status: T + I")
+    test:is(catchadd(T1970, i1), true, "status: T + i")
+    test:is(catchadd(T1970, M2), true, "status: T + M")
+    test:is(catchadd(T1970, m2), true, "status: T + m")
+    test:is(catchadd(T1970, Y1), true, "status: T + Y")
+    test:is(catchadd(T1970, y1), true, "status: T + y")
+    test:is(catchadd(T1970, T2000), false, "status: T + T")
+    test:is(catchadd(I1, T1970), true, "status: I + T")
+    test:is(catchadd(i1, T1970), true, "status: i + T")
+    test:is(catchadd(M2, T1970), true, "status: M + T")
+    test:is(catchadd(m2, T1970), true, "status: m + T")
+    test:is(catchadd(Y1, T1970), true, "status: Y + T")
+    test:is(catchadd(y1, T1970), true, "status: y + T")
+    test:is(catchadd(I1, Y1), true, "status: I + Y")
+    test:is(catchadd(I1, y1), true, "status: I + y")
+    test:is(catchadd(i1, y1), false, "status: i + y")
+    test:is(catchadd(i1, Y1), false, "status: i + Y")
+    test:is(catchadd(M2, Y1), true, "status: M + Y")
+    test:is(catchadd(M2, y1), true, "status: M + y")
+    test:is(catchadd(m2, y1), false, "status: m + y")
+    test:is(catchadd(m2, Y1), false, "status: m + Y")
+    test:is(catchadd(I1, Y1), true, "status: I + Y")
+    test:is(catchadd(I1, y1), true, "status: I + y")
+    test:is(catchadd(i1, y1), false, "status: i + y")
+    test:is(catchadd(i1, Y1), false, "status: i + Y")
+    test:is(catchadd(Y5, M10), true, "status: Y + M")
+    test:is(catchadd(Y5, m10), true, "status: Y + m")
+    test:is(catchadd(y5, m10), false, "status: y + m")
+    test:is(catchadd(y5, M10), false, "status: y + M")
+    test:is(catchadd(Y5, I1), true, "status: Y + I")
+    test:is(catchadd(Y5, i1), true, "status: Y + i")
+    test:is(catchadd(y5, i1), false, "status: y + i")
+    test:is(catchadd(y5, I1), false, "status: y + I")
+    test:is(catchadd(Y5, Y1), true, "status: Y + Y")
+    test:is(catchadd(Y5, y1), true, "status: Y + y")
+    test:is(catchadd(y5, y1), false, "status: y + y")
+    test:is(catchadd(y5, Y1), false, "status: y + Y")
+
+    test:is(tostring(T1970 + I1), "1970-01-02T00:00:00Z", "value: T + I")
+    test:is(tostring(T1970 + i1), "1970-01-02T00:00:00Z", "value: T + i")
+    test:is(tostring(T1970 + M2), "1970-03-01T00:00:00Z", "value: T + M")
+    test:is(tostring(T1970 + m2), "1970-03-01T00:00:00Z", "value: T + m")
+    test:is(tostring(T1970 + Y1), "1971-01-01T00:00:00Z", "value: T + Y")
+    test:is(tostring(T1970 + y1), "1971-01-01T00:00:00Z", "value: T + y")
+    test:is(tostring(I1 + T1970), "1970-01-02T00:00:00Z", "value: I + T")
+    test:is(tostring(M2 + T1970), "1970-03-01T00:00:00Z", "value: M + T")
+    test:is(tostring(Y1 + T1970), "1971-01-01T00:00:00Z", "value: Y + T")
+    test:is(tostring(Y5 + Y1), "+6 years", "Y + Y")
+
+    assert_raises_like(test, expected_interval_but,
+                       function() return T1970 + 123 end)
+    assert_raises_like(test, expected_interval_but,
+                       function() return T1970 + "0" end)
+
+    local max_date = date.new{year = MAX_DATE_YEAR - 1}
+    local new_ival = date.interval.new
+    test:is(catchadd(max_date, new_ival{year = 1}), true, "max + 1y")
+    test:is(catchadd(max_date, new_ival{year = 2}), false, "max + 2y")
+    test:is(catchadd(max_date, new_ival{year = 10}), false, "max + 10y")
+    test:is(catchadd(max_date, new_ival{month = 1}), true, "max + 1m")
+    test:is(catchadd(max_date, new_ival{month = 6}), true, "max + 6m")
+    test:is(catchadd(max_date, new_ival{month = 12}), true, "max + 12m")
+    test:is(catchadd(max_date, new_ival{month = 24}), false, "max + 24m")
+    test:is(catchadd(max_date, new_ival{week = 10}), true, "max + 10wk")
+    test:is(catchadd(max_date, new_ival{week = 100}), false, "max + 100wk")
+
+    test:is(catchadd(max_date, {year = 1}), true, "max + 1y")
+    test:is(catchadd(max_date, {year = 2}), false, "max + 2y")
+    test:is(catchadd(max_date, {year = 10}), false, "max + 10y")
+    test:is(catchadd(max_date, {month = 1}), true, "max + 1m")
+    test:is(catchadd(max_date, {month = 6}), true, "max + 6m")
+    test:is(catchadd(max_date, {month = 12}), true, "max + 12m")
+    test:is(catchadd(max_date, {month = 24}), false, "max + 24m")
+    test:is(catchadd(max_date, {week = 10}), true, "max + 10wk")
+    test:is(catchadd(max_date, {week = 100}), false, "max + 100wk")
+
+end)
+
+local function catchsub_status(A, B)
+    return pcall(function() return A - B end)
+end
+
+--[[
+Matrix of subtraction operands eligibility and their result type
+
+|                 | datetime | interval | table    |
++-----------------+----------+----------+----------+
+| datetime        | interval | datetime | datetime |
+| interval        |          | interval | interval |
+| table           |          |          |          |
+]]
+test:test("Matrix of allowed time and interval subtractions", function(test)
+    test:plan(29)
+
+    -- check arithmetic with leap dates
+    local T1970 = date.new{year = 1970, month = 1, day = 1}
+    local T2000 = date.new{year = 2000, month = 1, day = 1}
+    local I1 = date.interval.new{day = 1}
+    local M2 = date.interval.new{month = 2}
+    local M10 = date.interval.new{month = 10}
+    local Y1 = date.interval.new{year = 1}
+    local Y5 = date.interval.new{year = 5}
+
+    test:is(catchsub_status(T1970, I1), true, "status: T - I")
+    test:is(catchsub_status(T1970, M2), true, "status: T - M")
+    test:is(catchsub_status(T1970, Y1), true, "status: T - Y")
+    test:is(catchsub_status(T1970, T2000), true, "status: T - T")
+    test:is(catchsub_status(I1, T1970), false, "status: I - T")
+    test:is(catchsub_status(M2, T1970), false, "status: M - T")
+    test:is(catchsub_status(Y1, T1970), false, "status: Y - T")
+    test:is(catchsub_status(I1, Y1), true, "status: I - Y")
+    test:is(catchsub_status(M2, Y1), true, "status: M - Y")
+    test:is(catchsub_status(I1, Y1), true, "status: I - Y")
+    test:is(catchsub_status(Y5, M10), true, "status: Y - M")
+    test:is(catchsub_status(Y5, I1), true, "status: Y - I")
+    test:is(catchsub_status(Y5, Y1), true, "status: Y - Y")
+
+    test:is(tostring(T1970 - I1), "1969-12-31T00:00:00Z", "value: T - I")
+    test:is(tostring(T1970 - M2), "1969-11-01T00:00:00Z", "value: T - M")
+    test:is(tostring(T1970 - Y1), "1969-01-01T00:00:00Z", "value: T - Y")
+    test:is(tostring(T1970 - T2000), "-10957 days, 0 hours, 0 minutes, 0 seconds",
+            "value: T - T")
+    test:is(tostring(Y5 - Y1), "+4 years", "value: Y - Y")
+
+    assert_raises_like(test, expected_datetime_but,
+                       function() return T1970 - 123 end)
+    assert_raises_like(test, expected_datetime_but,
+                       function() return T1970 - "0" end)
+
+    local min_date = date.new{year = MIN_DATE_YEAR + 1}
+    local new_ival = date.interval.new
+    test:is(catchsub_status(min_date, new_ival{year = 1}), false, "min - 1y")
+    test:is(catchsub_status(min_date, new_ival{year = 2}), false, "min - 2y")
+    test:is(catchsub_status(min_date, new_ival{year = 10}), false, "min - 10y")
+    test:is(catchsub_status(min_date, new_ival{month = 1}), true, "min - 1m")
+    test:is(catchsub_status(min_date, new_ival{month = 6}), true, "min - 6m")
+    test:is(catchsub_status(min_date, new_ival{month = 12}), false, "min - 12m")
+    test:is(catchsub_status(min_date, new_ival{month = 24}), false, "min - 24m")
+    test:is(catchsub_status(min_date, new_ival{week = 10}), true, "min - 10wk")
+    test:is(catchsub_status(min_date, new_ival{week = 100}), false, "min - 100wk")
 end)
 
 test:test("totable{}", function(test)


### PR DESCRIPTION
> #6453 has created `datetime` module. Here we add intervals support, but not yet with daylight saving time information, 
> or transitions thru human-readable time-zones, which will be added in a future as a separate step.

## Interval arithmetics

This pull-request is following this RFC https://hackmd.io/hJU7rbnGQv6CSJCJl7KUiA?view#%D0%AD%D1%82%D0%B0%D0%BF-2-%D0%98%D0%BD%D1%82%D0%B5%D1%80%D0%B2%D0%B0%D0%BB%D1%8C%D0%BD%D0%BE%D0%B5-%D0%B2%D1%8B%D1%87%D0%B8%D1%81%D0%BB%D0%B5%D0%BD%D0%B8%D0%B5-%D0%B4%D0%B0%D1%82%D1%8B

* One could create interval object via
```lua
local ival = datetime.interval{ year=123, hour=565 }
```
where `year` and `hour` are of a list of allowed attributes, similar to date constructor.

* interval arithmetics is accessible either via `:add{}`/':sub{}` methods without interval object:
```lua
date:add{
	year  = 9000, month = 82, week  = 5, day   = 201,
	sec   = 191, min   = 292, hour  = 183,
	nsec  = 1239234,
}
datet:sub{
	year  = 9000, month = 82, week  = 5, day   = 201,
	sec   = 191, min   = 292, hour  = 183,
	nsec  = 1239234,
}
```
* or using overloaded `__add`/`__sub` operators for date or interval objects:
```lua
local t1970 = datetime.new{year = 1970, month = 1, day = 1}
local i1 = datetime.interval.new{year = 10, month = 10, week = 3}
return t1970 - i1
```

## Correct formats for pre-Rata Die days

As we discovered lately, we used to print incorrectly "negative" (pre 0001-01-01) dates, if there were any portion with non-zero hour/minutes/seconds.

```
tarantool> T = date.new{year = -1, mon = 6, day = 10, hour = 12, min = 10, sec = 10}

tarantool> T
- -001-01-11T-11:-49:-50Z
```

This problem has been fixed.