### PR TITLE
ci: pass SHA to reusable_build.yml instead of ref

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ jobs:
   tarantool:
     uses: tarantool/tarantool/.github/workflows/reusable_build.yml@master
     with:
-      ref: ${{ github.ref }}
+      ref: ${{ github.sha }}
       os: ubuntu
       dist: focal
 


### PR DESCRIPTION
Imagine the following situation. One pushed a commit to the master
branch, the 'integration.yml' workflow is triggered and starts to work.
The first step of this workflow is to build tarantool from the pushed
commit. Sometimes we have to wait for a free runner for some period of
time because our resources are limited. One pushed a commit to the
master branch one more time, but tarantool build for the previous
commit hasn't started yet. When tarantool build from the previous
commit starts, actually tarantool will be built from the last commit
because ${{ github.ref }} is passed to the 'reusable_build.yml'
workflow as an input parameter. So we need to pass ${{ github.sha }}.