### PR TITLE
sql: added a comment to disable OoB checking in Rule_sort function

### DIFF
--- a/extra/lemon.c
+++ b/extra/lemon.c
@@ -1555,6 +1555,7 @@ static struct rule *Rule_sort(struct rule *rp){
       rp = Rule_merge(x[i], rp);
       x[i] = 0;
     }
+    /* coverity[overrun-local] */
     x[i] = rp;
     rp = pNext;
   }


### PR DESCRIPTION
The static analyzer found a potential OoB problem in the lemon.c file.
This situation occurs when you go beyond the boundaries of the
array x in the Rule_sort() function.

It is impossible to go beyond the boundary of the array x, since the number of
cells used in the algorithm of this array logorithmically depends on the
size of the input list. In order to use the 32 index, the list size must be 2^33.
Such a list can only be created if the input file is invalid. The parse() function
has a limit on the input file of 1000000 bytes. Therefore, a file of this size
cannot contain such a number of rules, and a list of rules of size 2^33 cannot be created.

Since such a situation is not possible, a comment was added above the line where OoB could
potentially occur, disabling this check in coverity.