### PR TITLE
iproto: fix kharon use after free

### DIFF
--- a/changelogs/unreleased/gh-6520-fix-box-session-push-crash.md
+++ b/changelogs/unreleased/gh-6520-fix-box-session-push-crash.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a crash caused by a race between box.session.push() and closing
+  connection (gh-6520).

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -1652,6 +1652,13 @@ tx_process_disconnect(struct cmsg *m)
 		container_of(m, struct iproto_connection, disconnect_msg);
 	if (con->session != NULL) {
 		session_close(con->session);
+		/*
+		 * When kharon returns, it should not go back - the socket is
+		 * already dead anyway, and soon the connection itself will be
+		 * deleted. More pushes can't come, because after the session is
+		 * closed, its push() method is replaced with a stub.
+		 */
+		con->tx.is_push_pending = false;
 		if (! rlist_empty(&session_on_disconnect)) {
 			tx_fiber_init(con->session, 0);
 			session_run_on_disconnect_triggers(con->session);

--- a/test/box/gh-6520-race-between-push-and-close.result
+++ b/test/box/gh-6520-race-between-push-and-close.result
@@ -1,0 +1,39 @@
+-- test-run result file version 2
+test_run = require('test_run').new()
+ | ---
+ | ...
+net = require('net.box')
+ | ---
+ | ...
+--
+-- gh-6520: race between box.session.push and closing connection
+-- leads to a crash.
+--
+box.schema.user.grant('guest', 'super')
+ | ---
+ | ...
+test_run:cmd("setopt delimiter ';'")
+ | ---
+ | - true
+ | ...
+function test()
+    for i = 1, 10 do
+        box.session.push(i)
+    end
+end;
+ | ---
+ | ...
+for i = 1, 100 do
+    local c = net.connect(box.cfg.listen)
+    c:call('test', {}, {is_async = true})
+    c:close()
+end;
+ | ---
+ | ...
+test_run:cmd("setopt delimiter ''");
+ | ---
+ | - true
+ | ...
+box.schema.user.revoke('guest', 'super')
+ | ---
+ | ...

--- a/test/box/gh-6520-race-between-push-and-close.test.lua
+++ b/test/box/gh-6520-race-between-push-and-close.test.lua
@@ -1,0 +1,20 @@
+test_run = require('test_run').new()
+net = require('net.box')
+--
+-- gh-6520: race between box.session.push and closing connection
+-- leads to a crash.
+--
+box.schema.user.grant('guest', 'super')
+test_run:cmd("setopt delimiter ';'")
+function test()
+    for i = 1, 10 do
+        box.session.push(i)
+    end
+end;
+for i = 1, 100 do
+    local c = net.connect(box.cfg.listen)
+    c:call('test', {}, {is_async = true})
+    c:close()
+end;
+test_run:cmd("setopt delimiter ''");
+box.schema.user.revoke('guest', 'super')


### PR DESCRIPTION
The session can be closed while kharon is travelling between tx and
iproto. If this happens, kharon shouldn't go back to iproto when it
returns to tx, even if there are pending pushes, because the connection
is going to be freed soon.

Thanks to @Gerold103 for the simple fix.

Closes tarantool#6520