### PR TITLE
Multilisten in opensource

### DIFF
--- a/changelogs/unreleased/gh-3554-several-listening-sockets.md
+++ b/changelogs/unreleased/gh-3554-several-listening-sockets.md
@@ -1,0 +1,6 @@
+## feature/core
+
+* Implemented ability to open several listening sockets.
+  In addition to ability to pass uri as a number or string, as
+  previously, ability to pass uri as a table of numbers or strings
+  has been added (gh-3554).

--- a/changelogs/unreleased/gh-6535-fix-error-in-listening-to-numerical-uri-after-listening-to-unix-socket.md
+++ b/changelogs/unreleased/gh-6535-fix-error-in-listening-to-numerical-uri-after-listening-to-unix-socket.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed error in listening when user pass uri in numerical form
+  after listening unix socket (gh-6535).

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -3085,7 +3085,7 @@ iproto_send_listen_msg(struct evio_service *binary)
 }
 
 int
-iproto_listen(const char *uri)
+iproto_listen(const char **uris, int size)
 {
 	iproto_send_stop_msg();
 	evio_service_stop(&tx_binary);
@@ -3096,8 +3096,7 @@ iproto_listen(const char *uri)
 	 * implementation, we rely on the Linux kernel to distribute
 	 * incoming connections across iproto threads.
 	 */
-	const char *uris[] = { uri };
-	if (evio_service_bind(&tx_binary, uris, (uri != NULL ? 1 : 0)) != 0)
+	if (evio_service_bind(&tx_binary, uris, size) != 0)
 		return -1;
 	if (iproto_send_listen_msg(&tx_binary) != 0)
 		return -1;

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -2571,7 +2571,7 @@ iproto_on_accept(struct evio_service *service, int fd,
 	struct iproto_msg *msg;
 
 	struct iproto_thread *iproto_thread =
-		(struct iproto_thread*)service->on_accept_param;
+		(struct iproto_thread *)service->on_accept_param;
 	struct iproto_connection *con =
 		iproto_connection_new(iproto_thread, fd);
 	if (con == NULL)
@@ -2886,14 +2886,8 @@ iproto_init(int threads_count)
 	 * we don't need any accept functions.
 	 */
 	evio_service_init(loop(), &tx_binary, "tx_binary", NULL, NULL);
-
 	iproto_threads = (struct iproto_thread *)
-		calloc(threads_count, sizeof(struct iproto_thread));
-	if (iproto_threads == NULL) {
-		tnt_raise(OutOfMemory, threads_count *
-			  sizeof(struct iproto_thread), "calloc",
-			  "struct iproto_thread");
-	}
+		xcalloc(threads_count, sizeof(struct iproto_thread));
 
 	for (int i = 0; i < threads_count; i++, iproto_threads_count++) {
 		struct iproto_thread *iproto_thread = &iproto_threads[i];
@@ -2962,7 +2956,6 @@ struct iproto_cfg_msg: public cbus_call_msg
 		struct iproto_stats *stats;
 		/** Pointer to evio_service, used for bind */
 		struct evio_service *binary;
-
 		/** New iproto max message count. */
 		int iproto_msg_max;
 	};

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -3102,6 +3102,7 @@ iproto_listen(const char *uri)
 {
 	iproto_send_stop_msg();
 	evio_service_stop(&tx_binary);
+	evio_service_init(loop(), &tx_binary, "tx_binary", NULL, NULL);
 	if (uri == NULL) {
 		tx_binary.addr_len = 0;
 		return 0;

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -2610,8 +2610,8 @@ net_cord_f(va_list  ap)
 	mempool_create(&iproto_thread->iproto_stream_pool, &cord()->slabc,
 		       sizeof(struct iproto_stream));
 
-	evio_service_init(loop(), &iproto_thread->binary, "binary",
-			  iproto_on_accept, iproto_thread);
+	evio_service_create(loop(), &iproto_thread->binary, "binary",
+			    iproto_on_accept, iproto_thread);
 
 	char endpoint_name[ENDPOINT_NAME_MAX];
 	snprintf(endpoint_name, ENDPOINT_NAME_MAX, "net%u",
@@ -2885,7 +2885,7 @@ iproto_init(int threads_count)
 	 * We use this tx_binary only for bind, not for listen, so
 	 * we don't need any accept functions.
 	 */
-	evio_service_init(loop(), &tx_binary, "tx_binary", NULL, NULL);
+	evio_service_create(loop(), &tx_binary, "tx_binary", NULL, NULL);
 	iproto_threads = (struct iproto_thread *)
 		xcalloc(threads_count, sizeof(struct iproto_thread));
 
@@ -3095,7 +3095,7 @@ iproto_listen(const char *uri)
 {
 	iproto_send_stop_msg();
 	evio_service_stop(&tx_binary);
-	evio_service_init(loop(), &tx_binary, "tx_binary", NULL, NULL);
+	evio_service_create(loop(), &tx_binary, "tx_binary", NULL, NULL);
 	if (uri == NULL) {
 		tx_binary.addr_len = 0;
 		return 0;

--- a/src/box/iproto.h
+++ b/src/box/iproto.h
@@ -94,11 +94,18 @@ void
 iproto_reset_stat(void);
 
 /**
- * String representation of the address served by
- * iproto. To be shown in box.info.
+ * Return count of the addresses currently served by iproto.
+ */
+int
+iproto_addr_count(void);
+
+/**
+ * Return representation of the address served by iproto by
+ * it's @a idx. @a buf should have at least SERVICE_NAME_MAXLEN
+ * size.
  */
 const char *
-iproto_bound_address(char *buf);
+iproto_addr_str(char *buf, int idx);
 
 int
 iproto_rmean_foreach(void *cb, void *cb_ctx);

--- a/src/box/iproto.h
+++ b/src/box/iproto.h
@@ -124,7 +124,7 @@ void
 iproto_init(int threads_count);
 
 int
-iproto_listen(const char *uri);
+iproto_listen(const char **uris, int size);
 
 void
 iproto_set_msg_max(int iproto_msg_max);

--- a/src/box/lua/info.c
+++ b/src/box/lua/info.c
@@ -592,9 +592,21 @@ lbox_info_sql(struct lua_State *L)
 static int
 lbox_info_listen(struct lua_State *L)
 {
-	/* NULL is ok, no need to check. */
+	int count = iproto_addr_count();
+	if (count == 0) {
+		lua_pushnil(L);
+		return 1;
+	}
 	char addrbuf[SERVICE_NAME_MAXLEN];
-	lua_pushstring(L, iproto_bound_address(addrbuf));
+	if (count == 1) {
+		lua_pushstring(L, iproto_addr_str(addrbuf, 0));
+		return 1;
+	}
+	lua_createtable(L, count, 0);
+	for (int i = 0; i < count; i++) {
+		lua_pushstring(L, iproto_addr_str(addrbuf, i));
+		lua_rawseti(L, -2, i + 1);
+	}
 	return 1;
 }
 

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -144,7 +144,7 @@ local module_cfg_type = {
 -- forget to update it when add a new type or a combination of
 -- types here.
 local template_cfg = {
-    listen              = 'string, number',
+    listen              = 'string, number, table',
     memtx_memory        = 'number',
     strip_core          = 'boolean',
     memtx_min_tuple_size  = 'number',
@@ -226,7 +226,7 @@ local function normalize_uri(port)
     return tostring(port);
 end
 
-local function normalize_uri_list(port_list)
+local function normalize_uri_list_for_replication(port_list)
     local result = {}
     if type(port_list) == 'table' then
         for _, port in ipairs(port_list) do
@@ -238,10 +238,22 @@ local function normalize_uri_list(port_list)
     return result
 end
 
+local function normalize_uri_list_for_listen(port_list)
+    local result = {}
+    if type(port_list) == 'table' then
+        for _, port in ipairs(port_list) do
+            table.insert(result, normalize_uri(port))
+        end
+    else
+        return normalize_uri(port_list)
+    end
+    return result
+end
+
 -- options that require special handling
 local modify_cfg = {
-    listen             = normalize_uri,
-    replication        = normalize_uri_list,
+    listen             = normalize_uri_list_for_listen,
+    replication        = normalize_uri_list_for_replication,
 }
 
 local function purge_password_from_uri(uri)

--- a/src/lib/core/coio.c
+++ b/src/lib/core/coio.c
@@ -498,8 +498,8 @@ void
 coio_service_init(struct coio_service *service, const char *name,
 		  fiber_func handler, void *handler_param)
 {
-	evio_service_init(loop(), &service->evio_service, name,
-			  coio_service_on_accept, service);
+	evio_service_create(loop(), &service->evio_service, name,
+			    coio_service_on_accept, service);
 	service->handler = handler;
 	service->handler_param = handler_param;
 }

--- a/src/lib/core/coio.c
+++ b/src/lib/core/coio.c
@@ -507,7 +507,8 @@ coio_service_init(struct coio_service *service, const char *name,
 int
 coio_service_start(struct evio_service *service, const char *uri)
 {
-	if (evio_service_bind(service, uri) != 0 ||
+	const char *uris[] = { uri };
+	if (evio_service_bind(service, uris, 1) != 0 ||
 	    evio_service_listen(service) != 0)
 		return -1;
 	return 0;

--- a/src/lib/core/evio.c
+++ b/src/lib/core/evio.c
@@ -274,18 +274,8 @@ evio_service_listen(struct evio_service *service)
 		  sio_strfaddr(&service->addr, service->addr_len));
 
 	int fd = service->ev.fd;
-	if (sio_listen(fd)) {
-		if (sio_wouldblock(errno)) {
-			/*
-			 * sio_listen() doesn't set the diag
-			 * for EINTR errors. Set the
-			 * diagnostics area, since the caller
-			 * doesn't handle EINTR in any special way.
-			 */
-			diag_set(SocketError, sio_socketname(fd), "listen");
-		}
+	if (sio_listen(fd))
 		return -1;
-	}
 	ev_io_start(service->loop, &service->ev);
 	return 0;
 }

--- a/src/lib/core/evio.c
+++ b/src/lib/core/evio.c
@@ -39,6 +39,30 @@
 #include <trivia/util.h>
 #include "exception.h"
 
+struct evio_service_entry {
+	/** Bind host:service, useful for logging */
+	char host[URI_MAXHOST];
+	char serv[URI_MAXSERVICE];
+
+	/** Interface/port to bind to */
+	union {
+		struct sockaddr addr;
+		struct sockaddr_storage addrstorage;
+	};
+	socklen_t addr_len;
+
+	/** libev io object for the acceptor socket. */
+	struct ev_io ev;
+	/** Pointer to the root evio_service, which contains this object */
+	struct evio_service *service;
+};
+
+static inline bool
+evio_service_entry_is_active(const struct evio_service_entry *entry)
+{
+	return entry->ev.fd >= 0;
+}
+
 static int
 evio_setsockopt_keepalive(int fd)
 {
@@ -140,11 +164,12 @@ evio_service_name(struct evio_service *service)
  * callback.
  */
 static void
-evio_service_accept_cb(ev_loop *loop, ev_io *watcher, int events)
+evio_service_entry_accept_cb(ev_loop *loop, ev_io *watcher, int events)
 {
 	(void) loop;
 	(void) events;
-	struct evio_service *service = (struct evio_service *) watcher->data;
+	struct evio_service_entry *entry =
+		(struct evio_service_entry *)watcher->data;
 	int fd;
 	while (1) {
 		/*
@@ -154,7 +179,7 @@ evio_service_accept_cb(ev_loop *loop, ev_io *watcher, int events)
 		 */
 		struct sockaddr_storage addr;
 		socklen_t addrlen = sizeof(addr);
-		fd = sio_accept(service->ev.fd, (struct sockaddr *)&addr,
+		fd = sio_accept(entry->ev.fd, (struct sockaddr *)&addr,
 				&addrlen);
 
 		if (fd < 0) {
@@ -162,11 +187,12 @@ evio_service_accept_cb(ev_loop *loop, ev_io *watcher, int events)
 				break;
 			return;
 		}
-		if (evio_setsockopt_client(fd, service->addr.sa_family,
+		if (evio_setsockopt_client(fd, entry->addr.sa_family,
 					   SOCK_STREAM) != 0)
 			break;
-		if (service->on_accept(service, fd, (struct sockaddr *)&addr,
-				       addrlen) != 0)
+		if (entry->service->on_accept(entry->service, fd,
+					      (struct sockaddr *)&addr,
+					      addrlen) != 0)
 			break;
 	}
 	if (fd >= 0)
@@ -179,7 +205,7 @@ evio_service_accept_cb(ev_loop *loop, ev_io *watcher, int events)
  * listening on it. Unlink the file if it's the case.
  */
 static int
-evio_service_reuse_addr(const char *uri)
+evio_service_entry_reuse_addr(const char *uri)
 {
 	struct uri u;
 	if (uri_parse(&u, uri) || u.service == NULL) {
@@ -219,35 +245,37 @@ err:
  * Throws an exception if error.
  */
 static int
-evio_service_bind_addr(struct evio_service *service)
+evio_service_entry_bind_addr(struct evio_service_entry *entry)
 {
-	say_debug("%s: binding to %s...", evio_service_name(service),
-		  sio_strfaddr(&service->addr, service->addr_len));
+	say_debug("%s: binding to %s...",
+		  evio_service_name(entry->service),
+		  sio_strfaddr(&entry->addr, entry->addr_len));
 	/* Create a socket. */
-	int fd = sio_socket(service->addr.sa_family,
+	int fd = sio_socket(entry->addr.sa_family,
 			    SOCK_STREAM, IPPROTO_TCP);
 	if (fd < 0)
 		return -1;
 
-	if (evio_setsockopt_server(fd, service->addr.sa_family,
+	if (evio_setsockopt_server(fd, entry->addr.sa_family,
 				   SOCK_STREAM) != 0)
 		goto error;
 
-	if (sio_bind(fd, &service->addr, service->addr_len) != 0)
+	if (sio_bind(fd, &entry->addr, entry->addr_len) != 0)
 		goto error;
 
 	/*
 	 * After binding a result address may be different. For
 	 * example, if a port was 0.
 	 */
-	if (sio_getsockname(fd, &service->addr, &service->addr_len) != 0)
+	if (sio_getsockname(fd, &entry->addr, &entry->addr_len) != 0)
 		goto error;
 
-	say_info("%s: bound to %s", evio_service_name(service),
-		 sio_strfaddr(&service->addr, service->addr_len));
+	say_info("%s: bound to %s",
+		 evio_service_name(entry->service),
+		 sio_strfaddr(&entry->addr, entry->addr_len));
 
 	/* Register the socket in the event loop. */
-	ev_io_set(&service->ev, fd, EV_READ);
+	ev_io_set(&entry->ev, fd, EV_READ);
 	return 0;
 error:
 	close(fd);
@@ -259,71 +287,64 @@ error:
  *
  * @retval 0 for success
  */
-int
-evio_service_listen(struct evio_service *service)
+static int
+evio_service_entry_listen(struct evio_service_entry *entry)
 {
-	say_debug("%s: listening on %s...", evio_service_name(service),
-		  sio_strfaddr(&service->addr, service->addr_len));
+	say_debug("%s: listening on %s...",
+		  evio_service_name(entry->service),
+		  sio_strfaddr(&entry->addr, entry->addr_len));
 
-	int fd = service->ev.fd;
+	int fd = entry->ev.fd;
 	if (sio_listen(fd))
 		return -1;
-	ev_io_start(service->loop, &service->ev);
+	ev_io_start(entry->service->loop, &entry->ev);
 	return 0;
 }
 
-void
-evio_service_create(ev_loop *loop, struct evio_service *service,
-		    const char *name, evio_accept_f on_accept,
-		    void *on_accept_param)
+static void
+evio_service_entry_create(struct evio_service_entry *entry,
+			  struct evio_service *service)
 {
-	memset(service, 0, sizeof(struct evio_service));
-	snprintf(service->name, sizeof(service->name), "%s", name);
-
-	service->loop = loop;
-
-	service->on_accept = on_accept;
-	service->on_accept_param = on_accept_param;
+	memset(entry, 0, sizeof(struct evio_service_entry));
 	/*
 	 * Initialize libev objects to be able to detect if they
-	 * are active or not in evio_service_stop().
+	 * are active or not in evio_service_entry_stop().
 	 */
-	ev_init(&service->ev, evio_service_accept_cb);
-	ev_io_set(&service->ev, -1, 0);
-	service->ev.data = service;
+	ev_init(&entry->ev, evio_service_entry_accept_cb);
+	ev_io_set(&entry->ev, -1, 0);
+	entry->ev.data = entry;
+	entry->service = service;
 }
 
 /**
  * Try to bind.
  */
-int
-evio_service_bind(struct evio_service *service, const char *uri)
+static int
+evio_service_entry_bind(struct evio_service_entry *entry, const char *uri)
 {
-	if (evio_service_reuse_addr(uri) != 0)
-		return -1;
 	struct uri u;
 	if (uri_parse(&u, uri) || u.service == NULL) {
 		diag_set(IllegalParams, "invalid uri for bind: %s", uri);
 		return -1;
 	}
 
-	snprintf(service->serv, sizeof(service->serv), "%.*s",
+	snprintf(entry->serv, sizeof(entry->serv), "%.*s",
 		 (int) u.service_len, u.service);
 	if (u.host != NULL && strncmp(u.host, "*", u.host_len) != 0) {
-		snprintf(service->host, sizeof(service->host), "%.*s",
-			(int) u.host_len, u.host);
-	} /* else { service->host[0] = '\0'; } */
+		snprintf(entry->host, sizeof(entry->host), "%.*s",
+			 (int) u.host_len, u.host);
+	} /* else { entry->host[0] = '\0'; } */
 
-	assert(! ev_is_active(&service->ev));
+	assert(! ev_is_active(&entry->ev));
 
-	if (strcmp(service->host, URI_HOST_UNIX) == 0) {
+	if (strcmp(entry->host, URI_HOST_UNIX) == 0) {
 		/* UNIX domain socket */
-		struct sockaddr_un *un = (struct sockaddr_un *) &service->addr;
-		service->addr_len = sizeof(*un);
+		struct sockaddr_un *un = (struct sockaddr_un *) &entry->addr;
+		entry->addr_len = sizeof(*un);
 		snprintf(un->sun_path, sizeof(un->sun_path), "%s",
-			 service->serv);
+			 entry->serv);
 		un->sun_family = AF_UNIX;
-		return evio_service_bind_addr(service);
+		return evio_service_entry_bind_addr(entry);
 	}
 
 	/* IP socket */
@@ -334,59 +355,179 @@ evio_service_bind(struct evio_service *service, const char *uri)
 	hints.ai_flags = AI_PASSIVE|AI_ADDRCONFIG;
 
 	/* make no difference between empty string and NULL for host */
-	if (getaddrinfo(*service->host ? service->host : NULL, service->serv,
+	if (getaddrinfo(*entry->host ? entry->host : NULL, entry->serv,
 			&hints, &res) != 0 || res == NULL) {
 		diag_set(SocketError, sio_socketname(-1),
 			 "can't resolve uri for bind");
 		return -1;
 	}
 	for (struct addrinfo *ai = res; ai != NULL; ai = ai->ai_next) {
-		memcpy(&service->addr, ai->ai_addr, ai->ai_addrlen);
-		service->addr_len = ai->ai_addrlen;
-		if (evio_service_bind_addr(service) == 0) {
+		memcpy(&entry->addr, ai->ai_addr, ai->ai_addrlen);
+		entry->addr_len = ai->ai_addrlen;
+		if (evio_service_entry_bind_addr(entry) == 0) {
 			freeaddrinfo(res);
 			return 0;
 		}
 		say_error("%s: failed to bind on %s: %s",
-			  evio_service_name(service),
+			  evio_service_name(entry->service),
 			  sio_strfaddr(ai->ai_addr, ai->ai_addrlen),
 			  diag_last_error(diag_get())->errmsg);
 	}
 	freeaddrinfo(res);
 	diag_set(SocketError, sio_socketname(-1), "%s: failed to bind",
-		 evio_service_name(service));
+		 evio_service_name(entry->service));
 	return -1;
 }
 
-/** It's safe to stop a service which is not started yet. */
-void
-evio_service_stop(struct evio_service *service)
+static void
+evio_service_entry_detach(struct evio_service_entry *entry)
 {
-	say_info("%s: stopped", evio_service_name(service));
+	if (ev_is_active(&entry->ev)) {
+		ev_io_stop(entry->service->loop, &entry->ev);
+		entry->addr_len = 0;
+	}
+	ev_io_set(&entry->ev, -1, 0);
+}
 
-	int service_fd = service->ev.fd;
-	evio_service_detach(service);
+/** It's safe to stop a service entry which is not started yet. */
+static void
+evio_service_entry_stop(struct evio_service_entry *entry)
+{
+	int service_fd = entry->ev.fd;
+	evio_service_entry_detach(entry);
 	if (service_fd < 0)
 		return;
 
 	if (close(service_fd) < 0)
 		say_error("Failed to close socket: %s", strerror(errno));
 
-	if (service->addr.sa_family != AF_UNIX)
+	if (entry->addr.sa_family != AF_UNIX)
 		return;
 
-	if (unlink(((struct sockaddr_un *)&service->addr)->sun_path) < 0) {
+	if (unlink(((struct sockaddr_un *)&entry->addr)->sun_path) < 0) {
 		say_error("Failed to unlink unix "
 			  "socket path: %s", strerror(errno));
 	}
 }
 
+static void
+evio_service_entry_attach(struct evio_service_entry *dst,
+			 const struct evio_service_entry *src)
+{
+	assert(!ev_is_active(&dst->ev));
+	strcpy(dst->host, src->host);
+	strcpy(dst->serv, src->serv);
+	dst->addrstorage = src->addrstorage;
+	dst->addr_len = src->addr_len;
+	ev_io_set(&dst->ev, src->ev.fd, EV_READ);
+}
+
+static inline int
+evio_service_reuse_addr(const char **uris, int size)
+{
+	for (int i = 0; i < size; i++) {
+		if (evio_service_entry_reuse_addr(uris[i]) != 0)
+			return -1;
+	}
+	return 0;
+}
+
+static void
+evio_service_create_entries(struct evio_service *service, int size)
+{
+	service->entry_count = size;
+	service->entries = (size != 0 ?
+		 xmalloc(size *sizeof(struct evio_service_entry)) : NULL);
+	for (int i = 0; i < service->entry_count; i++)
+		evio_service_entry_create(&service->entries[i], service);
+}
+
+int
+evio_service_count(const struct evio_service *service)
+{
+	return service->entry_count;
+}
+
+const struct sockaddr *
+evio_service_addr(const struct evio_service *service, int idx, socklen_t *size)
+{
+	assert(idx < service->entry_count);
+	const struct evio_service_entry *e = &service->entries[idx];
+	*size = e->addr_len;
+	return &e->addr;
+}
+
+void
+evio_service_create(struct ev_loop *loop, struct evio_service *service,
+		    const char *name, evio_accept_f on_accept,
+		    void *on_accept_param)
+{
+	memset(service, 0, sizeof(struct evio_service));
+	snprintf(service->name, sizeof(service->name), "%s", name);
+	service->loop = loop;
+	service->on_accept = on_accept;
+	service->on_accept_param = on_accept_param;
+}
+
+void
+evio_service_attach(struct evio_service *dst, const struct evio_service *src)
+{
+	assert(dst->entry_count == 0);
+	evio_service_create_entries(dst, src->entry_count);
+	for (int i = 0; i < src->entry_count; i++)
+		evio_service_entry_attach(&dst->entries[i], &src->entries[i]);
+}
+
 void
 evio_service_detach(struct evio_service *service)
 {
-	if (ev_is_active(&service->ev)) {
-		ev_io_stop(service->loop, &service->ev);
-		service->addr_len = 0;
+	for (int i = 0; i < service->entry_count; i++)
+		evio_service_entry_detach(&service->entries[i]);
+	free(service->entries);
+	service->entry_count = 0;
+	service->entries = NULL;
+}
+
+bool
+evio_service_is_active(const struct evio_service *service)
+{
+	for (int i = 0; i < service->entry_count; i++) {
+		if (evio_service_entry_is_active(&service->entries[i]))
+			return true;
 	}
-	ev_io_set(&service->ev, -1, 0);
+	return false;
+}
+
+int
+evio_service_listen(struct evio_service *service)
+{
+	for (int i = 0; i < service->entry_count; i++) {
+		if (evio_service_entry_listen(&service->entries[i]) != 0)
+			return -1;
+	}
+	return 0;
+}
+
+void
+evio_service_stop(struct evio_service *service)
+{
+	say_info("%s: stopped", evio_service_name(service));
+	for (int i = 0; i < service->entry_count; i++)
+		evio_service_entry_stop(&service->entries[i]);
+	free(service->entries);
+	service->entry_count = 0;
+	service->entries = NULL;
+}
+
+int
+evio_service_bind(struct evio_service *service, const char **uris, int size)
+{
+	if (evio_service_reuse_addr(uris, size) != 0)
+		return -1;
+	evio_service_create_entries(service, size);
+	for (int i = 0; i < size; i++) {
+		if (evio_service_entry_bind(&service->entries[i], uris[i]) != 0)
+			return -1;
+	}
+	return 0;
 }

--- a/src/lib/core/evio.c
+++ b/src/lib/core/evio.c
@@ -273,8 +273,9 @@ evio_service_listen(struct evio_service *service)
 }
 
 void
-evio_service_init(ev_loop *loop, struct evio_service *service, const char *name,
-		  evio_accept_f on_accept, void *on_accept_param)
+evio_service_create(ev_loop *loop, struct evio_service *service,
+		    const char *name, evio_accept_f on_accept,
+		    void *on_accept_param)
 {
 	memset(service, 0, sizeof(struct evio_service));
 	snprintf(service->name, sizeof(service->name), "%s", name);

--- a/src/lib/core/evio.c
+++ b/src/lib/core/evio.c
@@ -308,8 +308,7 @@ evio_service_bind(struct evio_service *service, const char *uri)
 {
 	struct uri u;
 	if (uri_parse(&u, uri) || u.service == NULL) {
-		diag_set(SocketError, sio_socketname(-1),
-			 "invalid uri for bind: %s", uri);
+		diag_set(IllegalParams, "invalid uri for bind: %s", uri);
 		return -1;
 	}
 

--- a/src/lib/core/evio.h
+++ b/src/lib/core/evio.h
@@ -57,7 +57,7 @@ extern "C" {
  * How to use a service:
  * struct evio_service *service;
  * service = malloc(sizeof(struct evio_service));
- * evio_service_init(service, ..., on_accept_cb, ...);
+ * evio_service_create(service, ..., on_accept_cb, ...);
  * evio_service_bind(service);
  * evio_service_listen(service);
  * ...
@@ -102,8 +102,9 @@ struct evio_service
 
 /** Initialize the service. Don't bind to the port yet. */
 void
-evio_service_init(ev_loop *loop, struct evio_service *service, const char *name,
-		  evio_accept_f on_accept, void *on_accept_param);
+evio_service_create(ev_loop *loop, struct evio_service *service,
+                    const char *name, evio_accept_f on_accept,
+                    void *on_accept_param);
 
 /** Bind service to specified uri */
 int

--- a/src/lib/core/sio.c
+++ b/src/lib/core/sio.c
@@ -224,7 +224,7 @@ int
 sio_listen(int fd)
 {
 	int rc = listen(fd, sio_listen_backlog());
-	if (rc < 0 && errno != EADDRINUSE)
+	if (rc < 0)
 		diag_set(SocketError, sio_socketname(fd), "listen");
 	return rc;
 }

--- a/src/lib/core/sio.c
+++ b/src/lib/core/sio.c
@@ -215,7 +215,7 @@ int
 sio_bind(int fd, const struct sockaddr *addr, socklen_t addrlen)
 {
 	int rc = bind(fd, addr, addrlen);
-	if (rc < 0 && errno != EADDRINUSE)
+	if (rc < 0)
 		diag_set(SocketError, sio_socketname(fd), "bind");
 	return rc;
 }

--- a/src/lib/core/sio.h
+++ b/src/lib/core/sio.h
@@ -181,8 +181,7 @@ sio_getsockopt(int fd, int level, int optname,
 int sio_connect(int fd, const struct sockaddr *addr, socklen_t addrlen);
 
 /**
- * Bind a socket to the given address. The diagnostics is not set
- * in case of EADDRINUSE.
+ * Bind a socket to the given address.
  */
 int sio_bind(int fd, const struct sockaddr *addr, socklen_t addrlen);
 

--- a/src/lib/core/sio.h
+++ b/src/lib/core/sio.h
@@ -187,8 +187,7 @@ int sio_connect(int fd, const struct sockaddr *addr, socklen_t addrlen);
 int sio_bind(int fd, const struct sockaddr *addr, socklen_t addrlen);
 
 /**
- * Mark a socket as accepting connections. The diagnostics is not
- * set in case of EADDRINUSE.
+ * Mark a socket as accepting connections.
  */
 int sio_listen(int fd);
 

--- a/src/lib/swim/swim_transport_udp.c
+++ b/src/lib/swim/swim_transport_udp.c
@@ -85,11 +85,9 @@ swim_transport_bind(struct swim_transport *transport,
 	int fd = sio_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
 	if (fd < 0)
 		return -1;
-	if (sio_bind(fd, addr, addr_len) != 0) {
-		if (errno == EADDRINUSE)
-			diag_set(SocketError, sio_socketname(fd), "bind");
+
+	if (sio_bind(fd, addr, addr_len) != 0)
 		goto end_error;
-	}
 	if (sio_setsockopt(fd, SOL_SOCKET, SO_BROADCAST, &is_on,
 			   sizeof(is_on)) != 0)
 		goto end_error;

--- a/test/box-tap/gh-6535-listen-update-numeric-uri.test.lua
+++ b/test/box-tap/gh-6535-listen-update-numeric-uri.test.lua
@@ -1,0 +1,17 @@
+#!/usr/bin/env tarantool
+
+local tap = require('tap')
+local net_box = require('net.box')
+local os = require('os')
+
+local test = tap.test('gh-6535-listen-update-numeric-uri')
+test:plan(2)
+box.cfg{listen = "unix/:./tarantoolA"}
+box.cfg{listen = 0}
+test:ok(not box.info.listen:match("unix"), "box.info.listen")
+local conn = net_box.connect(box.info.listen)
+test:ok(conn:ping(), "conn:ping")
+conn:close()
+box.cfg{listen = ""}
+
+os.exit(test:check() and 0 or 1)

--- a/test/box-tap/several-listening-sockets.test.lua
+++ b/test/box-tap/several-listening-sockets.test.lua
@@ -1,0 +1,94 @@
+#!/usr/bin/env tarantool
+local tap = require('tap')
+local net_box = require('net.box')
+local os = require('os')
+local fio = require('fio')
+
+-- Create table which contain several listening uri,
+-- according to template @a addr. It's simple adds
+-- capital letters in alphabetical order to the
+-- template.
+local function create_uri_table(addr, count)
+    local uris_table = {}
+    local path_table = {}
+    local ascii_A = string.byte('A')
+    for i = 1, count do
+        local ascii_code = ascii_A + i - 1
+        local letter = string.char(ascii_code)
+        path_table[i] = addr .. letter
+        uris_table[i] = "unix/:" .. addr .. letter
+    end
+    return uris_table, path_table
+end
+
+local function check_connection(port)
+    local conn = net_box.connect(port)
+    local rc = conn:ping()
+    conn:close()
+    return rc
+end
+
+local test = tap.test('gh-6535-listen-update-numeric-uri')
+test:plan(44)
+
+-- Check connection if listening uri passed as a single port number.
+local port_number = 0
+box.cfg{listen = port_number}
+test:ok(check_connection(box.info.listen), "URI as a single port number")
+
+-- Check connection if listening uri passed as a single string.
+local unix_socket_path = "unix/:./tarantoolA"
+box.cfg{listen = unix_socket_path}
+test:ok(check_connection(unix_socket_path), "URI as a single string")
+test:ok(box.cfg.listen == unix_socket_path, "box.cfg.listen")
+test:ok(box.info.listen:match("unix/:"), "box.info.listen")
+
+-- Check connection if listening uri passed as a table of port numbers.
+local port_numbers = {0, 0, 0, 0, 0}
+box.cfg{listen = port_numbers}
+for i, _ in ipairs(port_numbers) do
+    test:ok(check_connection(box.info.listen[i]), "URI as a table of numbers")
+end
+
+-- Check connection if listening uri passed as a table of strings.
+local uri_table, path_table = create_uri_table("./tarantool", 5)
+box.cfg{listen = uri_table}
+for i, uri in ipairs(uri_table) do
+    test:ok(check_connection(uri), "URI as a table of strings")
+    test:ok(box.cfg.listen[i] == uri, "box.cfg.listen")
+    test:ok(box.info.listen[i]:match("unix/:"), "box.info.listen")
+    test:ok(fio.path.exists(path_table[i]), "fio.path.exists")
+end
+
+box.cfg{listen = ""}
+for _, path in ipairs(path_table) do
+    test:ok(not fio.path.exists(path), "fio.path.exists")
+end
+
+-- Special test case to check that all unix socket paths deleted
+-- in case when `listen` fails because of invalid uri. Iproto performs
+-- `bind` and `listen` operations sequentially to all uris from the list,
+-- so we need to make sure that all resources for those uris for which
+-- everything has already completed will be successfully cleared in case
+-- of error for one of the next uri in list.
+local uri_table, path_table = create_uri_table("./tarantool", 5)
+table.insert(uri_table, "baduri:1")
+table.insert(uri_table, "unix/:./tarantoolX")
+
+-- can't resolve uri for bind
+local ok, err = pcall(box.cfg, {listen = uri_table})
+test:ok(not ok and err.message:match("can't resolve uri for bind"),
+        "err.message:match")
+for _, path in ipairs(path_table) do
+    test:ok(not fio.path.exists(path), "fio.path.exists")
+end
+test:ok(not box.cfg.listen, "box.cfg.listen")
+
+-- Special test case when we try to listen several identical URIs
+local uri = "unix/:./tarantool"
+local ok, err = pcall(box.cfg, {listen = {uri, uri, uri}})
+test:ok(not ok and err.message:match('bind'), "err.message:match")
+test:ok(not fio.path.exists(uri), "fio.path.exists")
+test:ok(not box.cfg.listen, "box.cfg.listen")
+
+os.exit(test:check() and 0 or 1)

--- a/test/box/cfg.result
+++ b/test/box/cfg.result
@@ -271,10 +271,6 @@ box.cfg{sherlock = 'holmes'}
  | ...
 
 -- check that cfg with unexpected type of parameter fails
-box.cfg{listen = {}}
- | ---
- | - error: 'Incorrect value for option ''listen'': should be one of types string, number'
- | ...
 box.cfg{wal_dir = 0}
  | ---
  | - error: 'Incorrect value for option ''wal_dir'': should be of type string'

--- a/test/box/cfg.test.lua
+++ b/test/box/cfg.test.lua
@@ -11,7 +11,6 @@ cfg_filter(box.cfg)
 box.cfg{sherlock = 'holmes'}
 
 -- check that cfg with unexpected type of parameter fails
-box.cfg{listen = {}}
 box.cfg{wal_dir = 0}
 box.cfg{coredump = 'true'}
 


### PR DESCRIPTION
iproto: implement ability to open several listening sockets
Previously, iproto could only open one socket for listening
only. This patch change this behaviour, now user can open
several listening sockets (up to 20). Also in addition to
ability to pass uri as a number or string, as  previously,
ability to pass uri as a table of numbers or strings has
been added.
```lua
box.cfg { listen = {3301, 3302, 3303} }
box.cfg { listen = {"127.0.0.1:3301", "127.0.0.1:3302"} }
```
