### PR TITLE
ci: add integration check for smtp module

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,3 +28,9 @@ jobs:
     uses: tarantool/cartridge/.github/workflows/reusable-backend-test.yml@master
     with:
       artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+
+  smtp:
+    needs: tarantool
+    uses: tarantool/smtp/.github/workflows/reusable_testing.yml@master
+    with:
+      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}


### PR DESCRIPTION
This patch extends the 'integration.yml' workflow and adds a new
workflow call for running tests to verify integration between tarantool
and the smtp module.

Part of #5265
Part of #6056
Closes #6523