### PR TITLE
ci: add integration check for metrics module

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,3 +34,9 @@ jobs:
     uses: tarantool/smtp/.github/workflows/reusable_testing.yml@master
     with:
       artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+
+  metrics:
+    needs: tarantool
+    uses: tarantool/metrics/.github/workflows/reusable-test.yml@master
+    with:
+      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}


### PR DESCRIPTION
This patch extends the 'integration.yml' workflow and adds a new
workflow call for running tests to verify integration between tarantool
and the metrics module.

Part of tarantool/tarantool#5265
Part of tarantool/tarantool#6056
Closes tarantool/tarantool#6526