### PR TITLE
ci: add integration check for expirationd module

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,6 +29,12 @@ jobs:
     with:
       artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
 
+  expirationd:
+    needs: tarantool
+    uses: tarantool/expirationd/.github/workflows/reusable_testing.yml@master
+    with:
+      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+
   smtp:
     needs: tarantool
     uses: tarantool/smtp/.github/workflows/reusable_testing.yml@master


### PR DESCRIPTION
This patch extends the 'integration.yml' workflow and adds a new
workflow call for running tests to verify integration between tarantool
and the expiration module.

Part of #5265
Part of #6056
Closes #6528

Depends on tarantool/expirationd#88
Manual [test run](https://github.com/tarantool/tarantool/actions/runs/1452521713)