### PR TITLE
actualize debian and rpm changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,698 @@
+tarantool (2.8.2.0.gfc96d10f5-1) unstable; urgency=medium
+
+  * Introduced support for LJ_DUALNUM mode in luajit-gdb.py.
+  * The new method table.equals compares two tables by value with respect
+    to the __eq metamethod.
+  * The log module now supports symbolic representation of log levels.
+  * Descriptions of type mismatch error and inconsistent type error
+    have become more informative.
+  * Removed explicit cast from BOOLEAN to numeric types and vice versa.
+  * Removed explicit cast from VARBINARY to numeric types and vice versa.
+  * Fixed a bug due to which a string that is not NULL terminated
+    could not be cast to BOOLEAN, even if the conversion should
+    be successful according to the rules.
+  * fiber.wakeup() in Lua and fiber_wakeup() in C became NOP on
+    the currently running fiber.
+  * Various bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.8.2
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Thu, 19 Aug 2021 18:00:00 +0300
+
+tarantool (2.7.3.0.gdddf926c3-1) unstable; urgency=medium
+
+  * Provide information about state of synchronous replication via
+    box.info.synchro interface.
+  * Introduced support for LJ_DUALNUM mode in luajit-gdb.py.
+  * The new method table.equals compares two tables by value with respect
+    to the __eq metamethod.
+  * Descriptions of type mismatch error and inconsistent type error
+    have become more informative.
+  * Removed explicit cast from BOOLEAN to numeric types and vice versa.
+  * Removed explicit cast from VARBINARY to numeric types and vice versa.
+  * Fixed a bug due to which a string that is not NULL terminated
+    could not be cast to BOOLEAN, even if the conversion should
+    be successful according to the rules.
+  * fiber.wakeup() in Lua and fiber_wakeup() in C became NOP on
+    the currently running fiber.
+  * Various bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.7.3
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Thu, 19 Aug 2021 14:00:00 +0300
+
+tarantool (1.10.11.0.gf0b0e7ecf-1) stable; urgency=medium
+
+  * Introduced support for LJ_DUALNUM mode in luajit-gdb.py.
+  * fiber.wakeup() in Lua and fiber_wakeup() in C became
+  * NOP on the currently running fiber.
+  * Fixed memory leak on each box.on_commit() and box.on_rollback().
+  * Fixed invalid results produced by json module's encode function when it
+    was used from the Lua garbage collector.
+  * Fixed a bug when iterators became invalid after schema change.
+  * Fixed crash in case of reloading a compiled module when the
+    new module lacks some of functions which were present in the
+    former code.
+  * Fixed console client connection breakage if request times out.
+  * Added missing broadcast to net.box.future:discard() so that now
+    fibers waiting for a request result are woken up when the request
+    is discarded.
+  * Fix possible keys divergence during secondary index build which might
+    lead to missing tuples in it.
+  * Fix crash which may occur while switching read_only mode due to
+    duplicating transaction in tx writer list.
+  * Fixed a race between Vinyl garbage collection and compaction
+    resulting in broken vylog and recovery.
+  * Fix replication stopping occasionally with ER_INVALID_MSGPACK when
+    replica is under high load.
+  * Fixed optimization for single-char strings in IR_BUFPUT
+    assembly routine.
+  * Fixed slots alignment in lj-stack command output when
+    LJ_GC64 is enabled.
+  * Fixed dummy frame unwinding in lj-stack command.
+  * Fixed detection of inconsistent renames even in the presence
+    of sunk values.
+  * Fixed the order VM registers are allocated by LuaJIT frontend
+    in case of BC_ISGE and BC_ISGT.
+  * When error is raised during encoding call results,
+    auxiliary lightuserdata value is not removed from the main
+    Lua coroutine stack.
+  * Fixed Lua C API misuse, when the error is raised during call results
+    encoding on unprotected coroutine and expected to be catched
+    on the different one, that is protected.
+  * Fixed possibility crash in case when trigger removes itself.
+  * Fixed possibility crash in case when someone destroy trigger,
+    when it's yield.
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Thu, 19 Aug 2021 10:00:00 +0300
+
+tarantool (2.8.1.0.ge2a1ec0c2-1) unstable; urgency=medium
+
+  * Implement ability to run multiple iproto threads.
+  * Set box.cfg options with environment variables.
+  * Introduce box.ctl.promote() and the concept of manual elections.
+  * Lua memory profiler enhancements.
+  * Many other features and bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.8.1
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Wed, 21 Apr 2021 18:00:00 +0300
+
+tarantool (2.7.2.0.g4d8c06890-1) unstable; urgency=medium
+
+  * Introduce the concept of WAL queue and a new configuration option:
+    wal_queue_max_size.
+  * Introduce box.ctl.promote() and the concept of manual elections.
+  * Updated CMake minimum required version to 3.1.
+  * Drop autotools dependencies.
+  * Stop publishing new binary packages for Debian Jessie.
+  * Bump built-in zstd version from v1.3.3 to v1.4.8.
+  * Enable smtp and smtps protocols in bundled libcurl.
+  * Ship libcurl headers to system path "${PREFIX}/include/tarantool"
+    in the case of libcurl included as bundled library or static build.
+  * Various bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.7.2
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Wed, 21 Apr 2021 14:00:00 +0300
+
+tarantool (2.6.3.0.gcd487a2c5-1) unstable; urgency=medium
+
+  * Introduce the concept of WAL queue and a new configuration option:
+    wal_queue_max_size.
+  * Introduce box.ctl.promote() and the concept of manual elections.
+  * Updated CMake minimum required version to 3.1.
+  * Drop autotools dependencies.
+  * Stop publishing new binary packages for Debian Jessie.
+  * Bump built-in zstd version from v1.3.3 to v1.4.8.
+  * Enable smtp and smtps protocols in bundled libcurl.
+  * Ship libcurl headers to system path "${PREFIX}/include/tarantool"
+    in the case of libcurl included as bundled library or static build.
+  * Various bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.6.3
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Wed, 21 Apr 2021 12:00:00 +0300
+
+tarantool (1.10.10.0.gaea7ae77a-1) stable; urgency=medium
+
+  * Updated CMake minimum required version in Tarantool
+    build infrastructure to 3.1.
+  * Stop publishing new binary packages for Debian Jessie.
+  * Backported -DENABLE_LTO=ON/OFF cmake option.
+  * Bump built-in zstd version from v1.3.3 to v1.4.8.
+  * libcurl symbols in the case of bundled libcurl are now exported.
+  * Enable smtp and smtps protocols in bundled libcurl.
+  * Ship libcurl headers to system path "${PREFIX}/include/tarantool"
+    in the case of libcurl included as bundled library or static build.
+  * Extensive usage of uri and uuid modules with debug log level could lead to
+    a crash or corrupted result of the functions from these modules.
+    The same could happen with some functions from the modules fio,
+    box.tuple, iconv.
+  * Fixed -e option, when tarantool always entered interactive mode
+    when stdin is a tty.
+  * Make recovering with force_recovery option delete newer than
+    snapshot vylog files.
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Wed, 21 Apr 2021 10:00:00 +0300
+
+tarantool (2.7.1.0.g3ac498c9f-1) unstable; urgency=medium
+
+  * LuaJIT memory profiler.
+  * Expression evaluation for replication_synchro_quorum.
+  * The ALTER TABLE ADD COLUMN statement.
+  * Many other features and bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.7.1
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Wed, 30 Dec 2020 14:00:00 +0300
+
+tarantool (2.6.2.0.g34d504d7d-1) unstable; urgency=medium
+
+  * The new box.ctl.is_recovery_finished() function allows user
+    to determine whether memtx recovery is finished.
+  * It is now possible to specify synchro quorum as a function of
+    a number N of registered replicas.
+  * Show JSON tokens themselves instead of token names T_*
+    in the JSON decoder error messages.
+  * Show a decoding context in the JSON decoder error messages.
+  * Deploy packages for Debian Bullseye.
+  * Various bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.6.2
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Wed, 30 Dec 2020 14:00:00 +0300
+
+tarantool (2.5.3.0.gf93e48013-1) unstable; urgency=medium
+
+  * The new box.ctl.is_recovery_finished() function allows user
+    to determine whether memtx recovery is finished.
+  * A lot of bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.5.3
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Wed, 30 Dec 2020 12:00:00 +0300
+
+tarantool (1.10.9.0.g720ffdd23-1) stable; urgency=medium
+
+  * Deploy packages for Debian Bullseye.
+  * Don't start an 'example' instance after installing tarantool.
+  * fiber.cond:wait() now correctly throws an error when
+    a fiber is cancelled.
+  * Fixed a memory corruption issue.
+  * A dynamic module now gets correctly unloaded from memory in case
+    of an attempt to load a non-existing function from it.
+  * The fiber region (the box region) won't be invalidated on
+    a read-only transaction.
+  * Dispatching __call metamethod no longer causes address clashing.
+  * Fixed a false positive panic when yielding in debug hook.
+  * An attempt to use a net.box connection which is not established yet
+    now results in a correctly reported error.
+  * Fixed a hang which occured when tarantool ran a user script with
+    the -e option and this script exited with an error.
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Wed, 30 Dec 2020 10:00:00 +0300
+
+tarantool (2.6.1.0.gcfe0d1a55-1) unstable; urgency=medium
+
+  * Transactional manager for the memtx engine that allows yielding
+    in transactions.
+  * Raft-based automated failover mechanism for a single-leader replica set.
+  * Many other features and bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.6.1
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Thu, 22 Oct 2020 18:00:00 +0300
+
+tarantool (2.5.2.0.g05730d326-1) unstable; urgency=medium
+
+  * New function space:alter(options).
+  * Exposed the box region, key_def and several other functions.
+  * A lot of bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.5.2
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Thu, 22 Oct 2020 14:00:00 +0300
+
+tarantool (2.4.3.0.g5180d98f1-1) unstable; urgency=medium
+
+  * Exposed the box region, key_def and several other functions
+    in order to implement external tuple.keydef and tuple.merger
+    modules on top of them.
+  * Various improvements and bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.4.3
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Thu, 22 Oct 2020 12:00:00 +0300
+
+tarantool (1.10.8.0.g2f18757b7-1) stable; urgency=medium
+
+  * Exposed the box region, key_def and several other functions in order
+    to implement external tuple.keydef and tuple.merger modules
+    on top of them.
+  * Fixed fibers switch-over to prevent JIT machinery misbehavior.
+  * Fixed fibers switch-over to prevent implicit GC disabling.
+  * Fixed unhandled Lua error that might lead to memory leaks and
+    inconsistencies in <space_object>:frommap(), <key_def_object>:compare(),
+    <merge_source>:select().
+  * Fixed the error occurring on loading luajit-gdb.py with Python2.
+  * Fixed potential lag on boot up procedure when system's password
+    database is slow in access.
+  * Get rid of typedef redefinitions for compatibility with C99.
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Thu, 22 Oct 2020 10:00:00 +0300
+
+tarantool (2.5.1.0.gc2d8c03ee-1) unstable; urgency=medium
+
+  * Synchronous replication (beta).
+  * Allow an anonymous replica follow another anonymous replica.
+  * Fixed numerous crashes in Vinyl.
+  * Make implicit cast rules for assignment operation more strict in SQL.
+  * Updated curl version to 7.71.
+  * Don't start 'example' instance after installing tarantool.
+  * Many other features and bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.5.1
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Fri, 17 Jul 2020 18:00:00 +0300
+
+tarantool (2.4.2.0.gcccd89701-1) unstable; urgency=medium
+
+  * box.session.push() parameter sync is deprecated.
+  * Don't start 'example' instance after installing tarantool.
+  * Various bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.4.2
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Fri, 17 Jul 2020 14:00:00 +0300
+
+tarantool (2.3.3.0.g5be85a37f-1) unstable; urgency=medium
+
+  * Various improvements and bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.3.3
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Fri, 17 Jul 2020 12:00:00 +0300
+
+ tarantool (1.10.7.0.g554d439a5-1) stable; urgency=medium
+
+  * Fixed a bug in C module reloading.
+  * Fixed races and corner cases in box (re)configuration.
+  * Fixed check of index field map size which led to crash.
+  * Fixed wrong mpsgpack extension type in an error message at decoding.
+  * Fixed error while closing socket.tcp_server socket.
+  * Don't ruin rock name when freshly installing *.all.rock
+  * with dependencies.
+  * Fixed crash during compaction due to tuples with size exceeding
+    vinyl_max_tuple_size setting.
+  * Fixed crash during recovery of vinyl index due to the lack of file
+    descriptor.
+  * Fixed crash during executing upsert changing primary key
+    in debug mode.
+  * Fixed crash due to triggered dump process during secondary index
+    creation.
+  * Fixed crash/deadlock (depending on build type) during dump process
+    scheduling and concurrent DDL operation.
+  * Fixed crash during read of prepared but still not yet
+    not committed statement.
+  * Fixed squashing set and arithmetic upsert operations.
+  * Create missing folders for vinyl spaces and indexes if needed
+    to avoid confusing fails of tarantool started from backup.
+  * Fixed crash during squash of many (more than 4000) upserts modifying
+    the same key.
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Fri, 17 Jul 2020 10:00:00 +0300
+
+tarantool (2.4.1.0.g91d323782-1) unstable; urgency=medium
+
+  * UUID type was introduced.
+  * It is now possible to report stack of errors.
+  * Added popen built-in module.
+  * Create errors of custom type and transparent marshaling over net.box.
+  * Many other features and bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.4.1
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Mon, 20 Apr 2020 18:00:00 +0300
+
+tarantool (2.3.2.0.gcb25c5473-1) unstable; urgency=medium
+
+  * fiber.storage is cleaned between requests.
+  * tuple/space/index:update()/upsert() were fixed not to turn
+    a value into an infinity when a float value was added to or
+    subtracted from a float column and exceeded the float value range
+  * Fix potential execution abort when operating the system runs
+    under heavy memory load.
+  * Make RTREE indexes handle the out of memory error.
+  * Fix the error message returned on using an already dropped sequence.
+  * Add cancellation guard to avoid WAL thread stuck.
+  * Fix execution abort when memtx_memory and vinyl_memory are set
+    to more than 4398046510080 bytes.
+  * Fix rebootstrap procedure not working in case replica itself is
+    listed in box.cfg.replication.
+  * Fix possible user password leaking via replication logs.
+  * Refactor vclock map to be exactly 4 bytes in size.
+  * Fix crash when the replication applier rollbacks a transaction.
+  * Local space operations are now counted in 0th vclock component.
+  * Gc consumers are now ordered by their vclocks and not by vclock
+    signatures.
+  * json:decode() doesn't spoil instance's options with per-call ones.
+  * Handle empty input for uri.format() properly.
+  * os.environ() is now changed when os.setenv() is called.
+  * netbox.self:call/eval() now returns the same types as
+    netbox_connection:call/eval.
+  * box.tuple.* namespace is cleaned up from private functions.
+  * tarantoolctl rocks search: fix the --all flag.
+  * tarantoolctl rocks remove: fix the --force flag.
+  * Fix box.stat() behavior: now it collects statistics on the
+    PREPARE and EXECUTE methods as expected.
+  * The inserted values are inserted in the order in which they are given
+    in case of SQL INSERT into space with autoincrement.
+  * When building Tarantool with bundled libcurl, link it with the c-ares
+    library by default.
+  * __pairs/__ipairs metamethods handling is removed.
+  * Introduce luajit-gdb.py extension with commands for inspecting
+    LuaJIT internals.
+  * Fix string to number conversion.
+  * "FFI sandwich"(*) detection is introduced.
+  * luaJIT_setmode call is prohibited while mcode execution.
+  * Fix assertion fault due to triggered dump process during
+    secondary index build.
+  * Fix crashes at attempts to use -e and -l command line options
+    concatenated with their values.
+  * Fix inability to upgrade from 2.1 if there was an automatically
+    generated sequence.
+  * Update libopenssl version to 1.1.1f since the previous one was EOLed.
+  * Fix static build (-DBUILD_STATIC=ON) when libunwind depends on liblzma.
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Mon, 20 Apr 2020 14:00:00 +0300
+
+tarantool (2.2.3.0.gb9c4c7c04-1) unstable; urgency=medium
+
+  * Various improvements and bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.2.3
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Mon, 20 Apr 2020 12:00:00 +0300
+
+tarantool (1.10.6.0.g5372cd2fa-1) stable; urgency=medium
+
+  * fiber.storage is cleaned between requests.
+  * tuple/space/index:update()/upsert() were fixed not to turn a value
+    into an infinity when a float value was added to or subtracted from
+    a float column and exceeded the float value range.
+  * Make RTREE indexes handle the out of memory error.
+  * Add cancellation guard to avoid WAL thread stuck.
+  * Fix the rebootstrap procedure not working if the replica itself
+    is listed in box.cfg.replication.
+  * Fix possible user password leaking via replication logs.
+  * Local space operations are now counted in 0th vclock component.
+  * Gc consumers are now ordered by their vclocks and not by vclock
+    signatures.
+  * json: :decode() doesn't spoil instance's options with per-call ones.
+  * os.environ() is now changed when os.setenv() is called.
+  * netbox.self:call/eval() now returns the same types as
+    netbox_connection:call/eval.
+  * __pairs/__ipairs metamethods handling is removed.
+  * Introduce luajit-gdb.py extension with commands for inspecting
+    LuaJIT internals.
+  * Fix string to number conversion.
+  * "FFI sandwich" detection is introduced.
+  * luaJIT_setmode call is prohibited while mcode execution and leads
+    to the platform panic.
+  * Fix assertion fault due to triggered dump process during secondary
+    index build.
+  * Fix crashes at attempts to use -e and -l command line options
+    concatenated with their values.
+  * Update libopenssl version to 1.1.1f.
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Mon, 20 Apr 2020 10:00:00 +0300
+
+tarantool (1.10.5.0.g83a2ae919-1) stable; urgency=medium
+
+  * Exit gracefully when a main script throws an error.
+  * Enable __pairs and __ipairs metamethods from Lua 5.2.
+  * A lof of bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/1.10.5
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Tue, 14 Jan 2020 10:00:00 +0300
+
+tarantool (2.3.1.0.g5a1a220ee-1) unstable; urgency=medium
+
+  * Field name and JSON path updates.
+  * Anonymous replica.
+  * New DOUBLE SQL type (and new 'double' box field type).
+  * Stored and indexed decimals (and new 'decimal' field type).
+  * fiber.top()
+  * Feed data from a memory during replica initial join.
+  * SQL prepared statements.
+  * Sessions settings service space.
+  * Many other features and bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.3.1
+
+ -- Alexander Turenko <alexander.turenko@tarantool.org>  Tue, 31 Dec 2019 14:00:00 +0300
+
+tarantool (2.2.2.0.g0a577ff30-1) unstable; urgency=medium
+
+  * Drop rows_per_wal box.cfg() option in favor of wal_max_size.
+  * json and msgpack serializers now raise an error when a depth of
+    data nesting exceeds encode_max_depth option value.
+  * Show line and column in json.decode() errors.
+  * Exit gracefully when a main script throws an error.
+  * key_def: accept both field and fieldno in key_def.new(<...>).
+  * Enable __pairs and __ipairs metamethods from Lua 5.2.
+  * tarantoolctl: allow to start instances with delayed box.cfg{}.
+  * Dozens of bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.2.2
+
+ -- Alexander Turenko <alexander.turenko@tarantool.org>  Tue, 31 Dec 2019 10:00:00 +0300
+
+tarantool (2.1.3.0.g38d7d6c5d-1) unstable; urgency=medium
+
+  * Various improvements and bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.1.3
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Wed, 06 Nov 2019 10:00:00 +0300
+
+tarantool (1.10.4.0.g9dbcdba14-1) stable; urgency=medium
+
+  * Improve dump start/stop logging.
+  * Look up key in reader thread.
+  * Improve box.stat.net.
+  * Add idle to downstream status in box.info.
+  * Deprecate rows_per_wal in favor of wal_max_size.
+  * Print corrupted rows on decoding error.
+  * Add type of operation to space trigger parameters.
+  * Add debug.sourcefile() and debug.sourcedir() helpers to determine
+    the location of a current Lua source file.
+  * Add max_total_connections option in addition to total_connection
+    to allow more fine-grained tuning of libcurl connection cache.
+  * A lof of bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/1.10.4
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Thu, 26 Sep 2019 10:00:00 +0300
+
+tarantool (2.2.1.0.g4138645e0-1) unstable; urgency=medium
+
+  * New fixed point type (DECIMAL) was introduced to Tarantool.
+  * Multikey index support.
+  * Now it is possible to make functions persistent.
+  * Functional indexes implemented.
+  * Partial core dumps, which are now on by default.
+  * Data definition statements, which do not yield, can now be used
+    in a transaction.
+  * It is now possible to set a sequence not only for the first part
+    of the index.
+  * Allow to call box.session.exists() and box.session.fd() without
+    any arguments.
+  * New function introduced to get index key from tuple.
+  * New protocol called SWIM implemented to keep a table
+    of cluster members.
+  * Provide type of operation inside before_replace() trigger.
+  * Remove yields from Vinyl DDL on commit triggers.
+  * Improved performance of SELECT-s on memtx spaces.
+  * Indexes of memtx spaces are now built in background fibers.
+  * Hand over key lookup in a page to vinyl reader thread.
+  * Replication applier now can apply transactions which were
+    concurrent on the master concurrently on replica.
+  * Transaction boundaries introduced to replication protocol.
+  * Tuple access by field name for net.box.
+  * It is now possible to set the output format to Lua instead of YAML
+    in the interactive console.
+  * Multiple new collations added.
+  * New function touch introduced to fio module.
+  * Merger for tuples streams added.
+  * Default collation strength is explicit tertiary now.
+  * Improve box.stat.net.
+  * Tarantool now uses luarocks 3.
+  * New module key_def introduced to Lua.
+  * SQL ALTER now allows to add a constraint.
+  * SQL CHECK constraints are also validated during DML operations
+    performed from Lua land.
+  * New SQL types VARBINARY, UNSIGNED and BOOLEAN.
+  * CREATE TABLE SQL statement (and all other data definition statements)
+    are now truly transactional.
+  * SQL now uses Tarantool diagnostics API to set errors.
+  * Multiple improvements to SQL type system to make it more consistent.
+  * Added aliases for LENGTH() from ANSI SQL.
+  * It is possible to use HAVING without GROUP BY in SQL.
+  * A lot of bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.2.1
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Fri, 02 Aug 2019 10:00:00 +0300
+
+tarantool (2.1.2.0.g5e6821cbd-1) unstable; urgency=medium
+
+  * Index based on JSON path.
+  * In case of ENOSPC delete WALs not needed for recovery
+    from the last checkpoint.
+  * Add support for "tarantoolctl rocks pack" subcommand.
+  * string.rstrip and string.lstrip should accept symbols to strip.
+  * on shutdown trigger added.
+  * on_schema_init trigger added.
+  * snapshot daemon: limit the maximum disk size of maintained WALs.
+  * Permissions to create, alter and drop space.
+  * Replace box.sql.execute() with box.execute().
+  * SQL Type system was significantly refactored.
+  * Do not use SQL delete+insert for updates.
+  * Improve value comparison of different SQL types.
+  * Allow constraints to appear along with column definitions in SQL.
+  * Improve pragma index_info syntax.
+  * Dozens of bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.1.2
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Fri, 05 Apr 2019 10:00:00 +0300
+
+tarantool (1.10.3.0.g0b7078a93-1) stable; urgency=medium
+
+  * Randomize vinyl index compaction.
+  * Throttle tx thread if compaction doesn't keep up with dumps.
+  * Do not apply run_count_per_level to the last level.
+  * Report the number of active iproto connections.
+  * Never keep a dead replica around if running out of disk space.
+  * Report join progress to the replica log.
+  * Expose snapshot status in box.info.gc().
+  * Show names of Lua functions in backtraces in fiber.info().
+  * Check if transaction opened.
+  * A lof of bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/1.10.3
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Mon, 1 Apr 2019 10:00:00 +0300
+
+tarantool (2.1.1.0.g8a09adb46-1) unstable; urgency=medium
+
+  * Add function box.sql.execute() to query Tarantool database
+    using SQL statements.
+  * Added support for SQL collations by incorporating libICU
+    character set and collation library.
+  * IPROTO interface was extended to support SQL queries.
+  * net.box subsystem was extended to support SQL queries.
+  * Enabled ANALYZE statement to produce correct results,
+    necessary for efficient query plans.
+  * Enabled savepoints functionality. SAVEPOINT statement works w/o issues.
+  * Enabled ALTER TABLE … RENAME statement.
+  * Improved rules for identifier names: now fully consistent
+    with Lua frontend.
+  * Enabled support for triggers; trigger bodies now persist in Tarantool
+    snapshots and survive server restart.
+  * Significant performance improvements.
+  * Functions in SQL.
+  * Introduce new SQL wire protocol.
+  * Is nullable type attribute wanted by API in IPROTO.
+  * Add collation field to tuple format.
+  * Add string.fromhex() method.
+  * Select input language in tarantoolctl.
+  * Use Tarantool's structs for metadata during query compilation.
+  * Resolve names for VIEW right after its creation.
+  * Various SQL features and bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/2.1.1
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Thu, 15 Nov 2018 10:00:00 +0300
+
+tarantool (1.10.2.0.gc0d8063b6-1) stable; urgency=medium
+
+  * Configurable syslog destination.
+  * Allow different nullability in indexes and format.
+  * Allow to back up any checkpoint.
+  * A way to detect that a Tarantool process was started or
+    restarted by tarantoolctl.
+  * `TARANTOOLCTL` and `TARANTOOL_RESTARTED` env vars.
+  * New configuration parameter net_msg_max to restrict
+    the number of allocated fibers;
+  * Automatic replication rebootstrap.
+  * Replica-local space.
+  * Display the connection status if the downstream gets
+    disconnected from the upstream.
+  * New option replication_skip_conflict.
+  * Remove old snapshots which are not needed by replicas.
+  * New function fiber.join().
+  * New option `names_only` in tuple:tomap().
+  * Support custom rock servers in tarantoolctl. 
+  * Expose on_commit/on_rollback triggers to Lua.
+  * New function box.is_in_txn() to check if a transaction is open.
+  * Tuple field access via a json path.
+  * New function space:frommap() to convert a map to a tuple instance
+    or to a table.
+  * New module utf8 that implements libicu's bindings for use in Lua.
+  * Support ALTER for non-empty vinyl spaces.
+  * Tuples stored in the vinyl cache are not shared among the indexes
+    of the same space.
+  * Keep a stack of UPSERTS in `vy_read_iterator`.
+  * New function `box.ctl.reset_stat()` to reset vinyl statistics.
+  * A lof of bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/1.10.2
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Sat, 13 Oct 2018 10:00:00 +0300
+
+tarantool (1.9.2.0.g113ade24e-1) unstable; urgency=medium
+  * Dozens of bugfixes, see GitHub release notes:
+    https://github.com/tarantool/tarantool/releases/tag/1.9.1
+    https://github.com/tarantool/tarantool/releases/tag/1.9.2
+
+ -- Kirill Yukhin <kyukhin@tarantool.org>  Wed, 05 Sep 2018 10:00:00 +0300
+
+tarantool (1.9.0.4.g195d4462d-1) unstable; urgency=medium
+
+  * It is now possible to block/unblock users.
+  * New function `box.session.euid()` to return effective user.
+  * New 'super' role, with superuser access.
+  * `on_auth` trigger is now fired in case of both successful and
+    failed authentication.
+  * New replication configuration algorithm.
+  * After replication connect at startup, the server
+    does not start processing write requests before syncing up
+    with all connected peers.
+  * It is now possible to explicitly set instance and replica set
+    uuid via database configuration.
+  * `box.once()` no longer fails on a read-only replica but waits.
+  * `force_recovery` can now skip a corrupted xlog file.
+  * Improved replication monitoring.
+  * New 'BEFORE' triggers which can be used for conflict resolution
+    in master-master replication.
+  * http client now correctly parses cookies and supports
+    http+unix:// paths.
+  * `fio` rock now supports `file_exists()`, `rename()` works across
+    filesystems, and `read()` without arguments reads the whole file.
+  * `fio` rock errors now follow Tarantool function call conventions
+    and always return an error message in addition to the error flag.
+  * `digest` rock now supports pbkdf2 password hashing algorithm,
+    useful in PCI/DSS compliant applications.
+  * `box.info.memory()` provides a high-level overview of
+    server memory usage, including networking, Lua, transaction
+    and index memory.
+  * It is now possible to add missing tuple fields to an index.
+  * Lots of improvements in field type support when creating or
+    altering spaces and indexes.
+  * It is now possible to turn on `is_nullable` property on a field
+    even if the space is not empty.
+  * Several logging improvements. 
+  * It is now possible to make a unique vinyl index non-unique
+    without index rebuild.
+  * Improved vynil UPDATE, REPLACE and recovery performance in presence of
+    secondary keys.
+  * `space:len()` and `space:bsize()` now work for vinyl.
+  * Vinyl recovery speed has improved in presence of secondary keys.
+
+ -- Konstantin Osipov <kostja@tarantool.org>  Mon, 26 Feb 2018 10:00:00 +0300
+
+tarantool (1.7.6.0.g7b2945d6c-1) unstable; urgency=medium
+
+  * Hybrid schema-less + schema-full data model.
+  * Collation and Unicode Support.
+  * NULL values in unique and non-unique indexes.
+  * Sequences and a new implementation of auto_increment().
+  * Add gap locks in Vinyl transaction manager.
+  * on_connect/on_disconnect triggers for net.box.
+  * Structured logging in JSON format.
+  * Several Lua features and various bugfixes, see GitHub release notes
+    for details: https://github.com/tarantool/tarantool/releases/tag/1.7.6
+
+ -- Roman Tsisyk <roman@tarantool.org>  Tue, 07 Nov 2017 10:00:00 +0300
+
 tarantool (1.7.5.46.gd98815384-1) unstable; urgency=medium
 
   * Stabilization of Vinyl storage engine.

--- a/rpm/tarantool.spec
+++ b/rpm/tarantool.spec
@@ -275,6 +275,592 @@ fi
 %{_includedir}/tarantool/curl
 
 %changelog
+* Thu Aug 19 2021 Kirill Yukhin <kyukhin@tarantool.org> 2.8.2.0-1
+- Introduced support for LJ_DUALNUM mode in luajit-gdb.py.
+- The new method table.equals compares two tables by value with respect
+  to the __eq metamethod.
+- The log module now supports symbolic representation of log levels.
+- Descriptions of type mismatch error and inconsistent type error
+  have become more informative.
+- Removed explicit cast from BOOLEAN to numeric types and vice versa.
+- Removed explicit cast from VARBINARY to numeric types and vice versa.
+- Fixed a bug due to which a string that is not NULL terminated
+  could not be cast to BOOLEAN, even if the conversion should
+  be successful according to the rules.
+- fiber.wakeup() in Lua and fiber_wakeup() in C became NOP on
+  the currently running fiber.
+- Various bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.8.2
+
+* Thu Aug 19 2021 Kirill Yukhin <kyukhin@tarantool.org> 2.7.3.0-1
+- Provide information about state of synchronous replication via
+  box.info.synchro interface.
+- Introduced support for LJ_DUALNUM mode in luajit-gdb.py.
+- The new method table.equals compares two tables by value with respect
+  to the __eq metamethod.
+- Descriptions of type mismatch error and inconsistent type error
+  have become more informative.
+- Removed explicit cast from BOOLEAN to numeric types and vice versa.
+- Removed explicit cast from VARBINARY to numeric types and vice versa.
+- Fixed a bug due to which a string that is not NULL terminated
+  could not be cast to BOOLEAN, even if the conversion should
+  be successful according to the rules.
+- fiber.wakeup() in Lua and fiber_wakeup() in C became NOP on
+  the currently running fiber.
+- Various bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.7.3
+
+* Thu Aug 19 2021 Kirill Yukhin <kyukhin@tarantool.org> 1.10.11.0-1
+- Introduced support for LJ_DUALNUM mode in luajit-gdb.py.
+- fiber.wakeup() in Lua and fiber_wakeup() in C became
+- NOP on the currently running fiber.
+- Fixed memory leak on each box.on_commit() and box.on_rollback().
+- Fixed invalid results produced by json module's encode function when it
+  was used from the Lua garbage collector.
+- Fixed a bug when iterators became invalid after schema change.
+- Fixed crash in case of reloading a compiled module when the
+  new module lacks some of functions which were present in the
+  former code.
+- Fixed console client connection breakage if request times out.
+- Added missing broadcast to net.box.future:discard() so that now
+  fibers waiting for a request result are woken up when the request
+  is discarded.
+- Fix possible keys divergence during secondary index build which might
+  lead to missing tuples in it.
+- Fix crash which may occur while switching read_only mode due to
+  duplicating transaction in tx writer list.
+- Fixed a race between Vinyl garbage collection and compaction
+  resulting in broken vylog and recovery.
+- Fix replication stopping occasionally with ER_INVALID_MSGPACK when
+  replica is under high load.
+- Fixed optimization for single-char strings in IR_BUFPUT
+  assembly routine.
+- Fixed slots alignment in lj-stack command output when
+  LJ_GC64 is enabled.
+- Fixed dummy frame unwinding in lj-stack command.
+- Fixed detection of inconsistent renames even in the presence
+  of sunk values.
+- Fixed the order VM registers are allocated by LuaJIT frontend
+  in case of BC_ISGE and BC_ISGT.
+- When error is raised during encoding call results,
+  auxiliary lightuserdata value is not removed from the main
+  Lua coroutine stack.
+- Fixed Lua C API misuse, when the error is raised during call results
+  encoding on unprotected coroutine and expected to be catched
+  on the different one, that is protected.
+- Fixed possibility crash in case when trigger removes itself.
+- Fixed possibility crash in case when someone destroy trigger,
+  when it's yield.
+
+* Wed Apr 21 2021 Kirill Yukhin <kyukhin@tarantool.org> 2.8.1.0-1
+- Implement ability to run multiple iproto threads.
+- Set box.cfg options with environment variables.
+- Introduce box.ctl.promote() and the concept of manual elections.
+- Lua memory profiler enhancements.
+- Many other features and bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.8.1
+
+* Wed Apr 21 2021 Kirill Yukhin <kyukhin@tarantool.org> 2.7.2.0-1
+- Introduce the concept of WAL queue and a new configuration option:
+  wal_queue_max_size.
+- Introduce box.ctl.promote() and the concept of manual elections.
+- Updated CMake minimum required version to 3.1.
+- Drop autotools dependencies.
+- Bump built-in zstd version from v1.3.3 to v1.4.8.
+- Enable smtp and smtps protocols in bundled libcurl.
+- Ship libcurl headers to system path "${PREFIX}/include/tarantool"
+  in the case of libcurl included as bundled library or static build.
+- Various bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.7.2
+
+* Wed Apr 21 2021 Kirill Yukhin <kyukhin@tarantool.org> 2.6.3.0-1
+- Introduce the concept of WAL queue and a new configuration option:
+  wal_queue_max_size.
+- Introduce box.ctl.promote() and the concept of manual elections.
+- Updated CMake minimum required version to 3.1.
+- Drop autotools dependencies.
+- Stop publishing new binary packages for Debian Jessie.
+- Bump built-in zstd version from v1.3.3 to v1.4.8.
+- Enable smtp and smtps protocols in bundled libcurl.
+- Ship libcurl headers to system path "${PREFIX}/include/tarantool"
+  in the case of libcurl included as bundled library or static build.
+- Various bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.6.3
+
+* Wed Apr 21 2021 Kirill Yukhin <kyukhin@tarantool.org> 1.10.10.0-1
+- Updated CMake minimum required version in Tarantool
+  build infrastructure to 3.1.
+- Stop publishing new binary packages for Debian Jessie.
+- Backported -DENABLE_LTO=ON/OFF cmake option.
+- Bump built-in zstd version from v1.3.3 to v1.4.8.
+- libcurl symbols in the case of bundled libcurl are now exported.
+- Enable smtp and smtps protocols in bundled libcurl.
+- Ship libcurl headers to system path "${PREFIX}/include/tarantool"
+  in the case of libcurl included as bundled library or static build.
+- Extensive usage of uri and uuid modules with debug log level could lead to
+  a crash or corrupted result of the functions from these modules.
+  The same could happen with some functions from the modules fio,
+  box.tuple, iconv.
+- Fixed -e option, when tarantool always entered interactive mode
+  when stdin is a tty.
+- Make recovering with force_recovery option delete newer than
+  snapshot vylog files.
+
+* Wed Dec 30 2020 Kirill Yukhin <kyukhin@tarantool.org> 2.7.1.0-1
+- LuaJIT memory profiler.
+- Expression evaluation for replication_synchro_quorum.
+- The ALTER TABLE ADD COLUMN statement.
+- Many other features and bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.7.1
+
+* Wed Dec 30 2020 Kirill Yukhin <kyukhin@tarantool.org> 2.6.2.0-1
+- The new box.ctl.is_recovery_finished() function allows user
+  to determine whether memtx recovery is finished.
+- It is now possible to specify synchro quorum as a function of
+  a number N of registered replicas.
+- Show JSON tokens themselves instead of token names T_*
+  in the JSON decoder error messages.
+- Show a decoding context in the JSON decoder error messages.
+- Various bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.6.2
+
+* Wed Dec 30 2020 Kirill Yukhin <kyukhin@tarantool.org> 2.5.3.0-1
+- The new box.ctl.is_recovery_finished() function allows user
+  to determine whether memtx recovery is finished.
+- A lot of bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.5.3
+
+* Wed Dec 30 2020 Kirill Yukhin <kyukhin@tarantool.org> 1.10.9.0-1
+- Deploy packages for Debian Bullseye.
+- Don't start an 'example' instance after installing tarantool.
+- fiber.cond:wait() now correctly throws an error when
+  a fiber is cancelled.
+- Fixed a memory corruption issue.
+- A dynamic module now gets correctly unloaded from memory in case
+  of an attempt to load a non-existing function from it.
+- The fiber region (the box region) won't be invalidated on
+  a read-only transaction.
+- Dispatching __call metamethod no longer causes address clashing.
+- Fixed a false positive panic when yielding in debug hook.
+- An attempt to use a net.box connection which is not established yet
+  now results in a correctly reported error.
+- Fixed a hang which occured when tarantool ran a user script with
+  the -e option and this script exited with an error.
+
+* Thu Oct 22 2020 Kirill Yukhin <kyukhin@tarantool.org> 2.6.1.0-1
+- Transactional manager for the memtx engine that allows yielding
+  in transactions.
+- Raft-based automated failover mechanism for a single-leader replica set.
+- Many other features and bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.6.1
+
+* Thu Oct 22 2020 Kirill Yukhin <kyukhin@tarantool.org> 2.5.2.0-1
+- New function space:alter(options).
+- Exposed the box region, key_def and several other functions.
+- A lot of bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.5.2
+
+* Thu Oct 22 2020 Kirill Yukhin <kyukhin@tarantool.org> 2.4.3.0-1
+- Exposed the box region, key_def and several other functions
+  in order to implement external tuple.keydef and tuple.merger
+  modules on top of them.
+- Various improvements and bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.4.3
+
+* Thu Oct 22 2020 Kirill Yukhin <kyukhin@tarantool.org> 1.10.8.0-1
+- Exposed the box region, key_def and several other functions in order
+  to implement external tuple.keydef and tuple.merger modules
+  on top of them.
+- Fixed fibers switch-over to prevent JIT machinery misbehavior.
+- Fixed fibers switch-over to prevent implicit GC disabling.
+- Fixed unhandled Lua error that might lead to memory leaks and
+  inconsistencies in <space_object>:frommap(), <key_def_object>:compare(),
+  <merge_source>:select().
+- Fixed the error occurring on loading luajit-gdb.py with Python2.
+- Fixed potential lag on boot up procedure when system's password
+  database is slow in access.
+- Get rid of typedef redefinitions for compatibility with C99.
+
+* Fri Jul 17 2020 Kirill Yukhin <kyukhin@tarantool.org> 2.5.1.0-1
+- Synchronous replication (beta).
+- Allow an anonymous replica follow another anonymous replica.
+- Fixed numerous crashes in Vinyl.
+- Make implicit cast rules for assignment operation more strict in SQL.
+- Updated curl version to 7.71.
+- Don't start 'example' instance after installing tarantool.
+- Many other features and bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.5.1
+
+* Fri Jul 17 2020 Kirill Yukhin <kyukhin@tarantool.org> 2.4.2.0-1
+- box.session.push() parameter sync is deprecated.
+- Don't start 'example' instance after installing tarantool.
+- Various bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.4.2
+
+* Fri Jul 17 2020 Kirill Yukhin <kyukhin@tarantool.org> 2.3.3.0-1
+- Various improvements and bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.3.3
+
+* Fri Jul 17 2020 Kirill Yukhin <kyukhin@tarantool.org> 1.10.7.0-1
+- Fixed a bug in C module reloading.
+- Fixed races and corner cases in box (re)configuration.
+- Fixed check of index field map size which led to crash.
+- Fixed wrong mpsgpack extension type in an error message at decoding.
+- Fixed error while closing socket.tcp_server socket.
+- Don't ruin rock name when freshly installing *.all.rock
+- with dependencies.
+- Fixed crash during compaction due to tuples with size exceeding
+  vinyl_max_tuple_size setting.
+- Fixed crash during recovery of vinyl index due to the lack of file
+  descriptor.
+- Fixed crash during executing upsert changing primary key
+  in debug mode.
+- Fixed crash due to triggered dump process during secondary index
+  creation.
+- Fixed crash/deadlock (depending on build type) during dump process
+  scheduling and concurrent DDL operation.
+- Fixed crash during read of prepared but still not yet
+  not committed statement.
+- Fixed squashing set and arithmetic upsert operations.
+- Create missing folders for vinyl spaces and indexes if needed
+  to avoid confusing fails of tarantool started from backup.
+- Fixed crash during squash of many (more than 4000) upserts modifying
+  the same key.
+
+* Mon Apr 20 2020 Kirill Yukhin <kyukhin@tarantool.org> 2.4.1.0-1
+- UUID type was introduced.
+- It is now possible to report stack of errors.
+- Added popen built-in module.
+- Create errors of custom type and transparent marshaling over net.box.
+- Many other features and bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.4.1
+
+* Mon Apr 20 2020 Kirill Yukhin <kyukhin@tarantool.org> 2.3.2.0-1
+- fiber.storage is cleaned between requests.
+- tuple/space/index:update()/upsert() were fixed not to turn
+  a value into an infinity when a float value was added to or
+  subtracted from a float column and exceeded the float value range
+- Fix potential execution abort when operating the system runs
+  under heavy memory load.
+- Make RTREE indexes handle the out of memory error.
+- Fix the error message returned on using an already dropped sequence.
+- Add cancellation guard to avoid WAL thread stuck.
+- Fix execution abort when memtx_memory and vinyl_memory are set
+  to more than 4398046510080 bytes.
+- Fix rebootstrap procedure not working in case replica itself is
+  listed in box.cfg.replication.
+- Fix possible user password leaking via replication logs.
+- Refactor vclock map to be exactly 4 bytes in size.
+- Fix crash when the replication applier rollbacks a transaction.
+- Local space operations are now counted in 0th vclock component.
+- Gc consumers are now ordered by their vclocks and not by vclock
+  signatures.
+- json:decode() doesn't spoil instance's options with per-call ones.
+- Handle empty input for uri.format() properly.
+- os.environ() is now changed when os.setenv() is called.
+- netbox.self:call/eval() now returns the same types as
+  netbox_connection:call/eval.
+- box.tuple.* namespace is cleaned up from private functions.
+- tarantoolctl rocks search: fix the --all flag.
+- tarantoolctl rocks remove: fix the --force flag.
+- Fix box.stat() behavior: now it collects statistics on the
+  PREPARE and EXECUTE methods as expected.
+- The inserted values are inserted in the order in which they are given
+  in case of SQL INSERT into space with autoincrement.
+- When building Tarantool with bundled libcurl, link it with the c-ares
+  library by default.
+- __pairs/__ipairs metamethods handling is removed.
+- Introduce luajit-gdb.py extension with commands for inspecting
+  LuaJIT internals.
+- Fix string to number conversion.
+- "FFI sandwich"(*) detection is introduced.
+- luaJIT_setmode call is prohibited while mcode execution.
+- Fix assertion fault due to triggered dump process during
+  secondary index build.
+- Fix crashes at attempts to use -e and -l command line options
+  concatenated with their values.
+- Fix inability to upgrade from 2.1 if there was an automatically
+  generated sequence.
+- Update libopenssl version to 1.1.1f since the previous one was EOLed.
+- Fix static build (-DBUILD_STATIC=ON) when libunwind depends on liblzma.
+
+* Mon Apr 20 2020 Kirill Yukhin <kyukhin@tarantool.org> 2.2.3.0-1
+- Various improvements and bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.2.3
+
+* Mon Apr 20 2020 Kirill Yukhin <kyukhin@tarantool.org> 1.10.6.0-1
+- fiber.storage is cleaned between requests.
+- tuple/space/index:update()/upsert() were fixed not to turn a value
+  into an infinity when a float value was added to or subtracted from
+  a float column and exceeded the float value range.
+- Make RTREE indexes handle the out of memory error.
+- Add cancellation guard to avoid WAL thread stuck.
+- Fix the rebootstrap procedure not working if the replica itself
+  is listed in box.cfg.replication.
+- Fix possible user password leaking via replication logs.
+- Local space operations are now counted in 0th vclock component.
+- Gc consumers are now ordered by their vclocks and not by vclock
+  signatures.
+- json: :decode() doesn't spoil instance's options with per-call ones.
+- os.environ() is now changed when os.setenv() is called.
+- netbox.self:call/eval() now returns the same types as
+  netbox_connection:call/eval.
+- __pairs/__ipairs metamethods handling is removed.
+- Introduce luajit-gdb.py extension with commands for inspecting
+  LuaJIT internals.
+- Fix string to number conversion.
+- "FFI sandwich" detection is introduced.
+- luaJIT_setmode call is prohibited while mcode execution and leads
+  to the platform panic.
+- Fix assertion fault due to triggered dump process during secondary
+  index build.
+- Fix crashes at attempts to use -e and -l command line options
+  concatenated with their values.
+- Update libopenssl version to 1.1.1f.
+
+* Tue Jan 14 2020 Kirill Yukhin <kyukhin@tarantool.org> 1.10.5.0-1
+- Exit gracefully when a main script throws an error.
+- Enable __pairs and __ipairs metamethods from Lua 5.2.
+- A lof of bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/1.10.5
+
+* Tue Dec 31 2019 Alexander Turenko <alexander.turenko@tarantool.org> 2.3.1.0-1
+- Field name and JSON path updates.
+- Anonymous replica.
+- New DOUBLE SQL type (and new 'double' box field type).
+- Stored and indexed decimals (and new 'decimal' field type).
+- fiber.top()
+- Feed data from a memory during replica initial join.
+- SQL prepared statements.
+- Sessions settings service space.
+- Many other features and bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.3.1
+
+* Tue Dec 31 2019 Alexander Turenko <alexander.turenko@tarantool.org> 2.2.2.0-1
+- Drop rows_per_wal box.cfg() option in favor of wal_max_size.
+- json and msgpack serializers now raise an error when a depth of
+  data nesting exceeds encode_max_depth option value.
+- Show line and column in json.decode() errors.
+- Exit gracefully when a main script throws an error.
+- key_def: accept both field and fieldno in key_def.new(<...>).
+- Enable __pairs and __ipairs metamethods from Lua 5.2.
+- tarantoolctl: allow to start instances with delayed box.cfg{}.
+- Dozens of bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.2.2
+
+* Wed Nov 06 2019 Kirill Yukhin <kyukhin@tarantool.org> 2.1.3.0-1
+- Various improvements and bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.1.3
+
+* Thu Sep 26 2019 Kirill Yukhin <kyukhin@tarantool.org> 1.10.4.0-1
+- Improve dump start/stop logging.
+- Look up key in reader thread.
+- Improve box.stat.net.
+- Add idle to downstream status in box.info.
+- Deprecate rows_per_wal in favor of wal_max_size.
+- Print corrupted rows on decoding error.
+- Add type of operation to space trigger parameters.
+- Add debug.sourcefile() and debug.sourcedir() helpers to determine
+  the location of a current Lua source file.
+- Add max_total_connections option in addition to total_connection
+  to allow more fine-grained tuning of libcurl connection cache.
+- A lof of bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/1.10.4
+
+* Fri Aug 02 2019 Kirill Yukhin <kyukhin@tarantool.org> 2.2.1.0-1
+- New fixed point type (DECIMAL) was introduced to Tarantool.
+- Multikey index support.
+- Now it is possible to make functions persistent.
+- Functional indexes implemented.
+- Partial core dumps, which are now on by default.
+- Data definition statements, which do not yield, can now be used
+  in a transaction.
+- It is now possible to set a sequence not only for the first part
+  of the index.
+- Allow to call box.session.exists() and box.session.fd() without
+  any arguments.
+- New function introduced to get index key from tuple.
+- New protocol called SWIM implemented to keep a table
+  of cluster members.
+- Provide type of operation inside before_replace() trigger.
+- Remove yields from Vinyl DDL on commit triggers.
+- Improved performance of SELECT-s on memtx spaces.
+- Indexes of memtx spaces are now built in background fibers.
+- Hand over key lookup in a page to vinyl reader thread.
+- Replication applier now can apply transactions which were
+  concurrent on the master concurrently on replica.
+- Transaction boundaries introduced to replication protocol.
+- Tuple access by field name for net.box.
+- It is now possible to set the output format to Lua instead of YAML
+  in the interactive console.
+- Multiple new collations added.
+- New function touch introduced to fio module.
+- Merger for tuples streams added.
+- Default collation strength is explicit tertiary now.
+- Improve box.stat.net.
+- Tarantool now uses luarocks 3.
+- New module key_def introduced to Lua.
+- SQL ALTER now allows to add a constraint.
+- SQL CHECK constraints are also validated during DML operations
+  performed from Lua land.
+- New SQL types VARBINARY, UNSIGNED and BOOLEAN.
+- CREATE TABLE SQL statement (and all other data definition statements)
+  are now truly transactional.
+- SQL now uses Tarantool diagnostics API to set errors.
+- Multiple improvements to SQL type system to make it more consistent.
+- Added aliases for LENGTH() from ANSI SQL.
+- It is possible to use HAVING without GROUP BY in SQL.
+- A lot of bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.2.1
+
+* Fri Apr 05 2019 Kirill Yukhin <kyukhin@tarantool.org> 2.1.2.0-1
+- Index based on JSON path.
+- In case of ENOSPC delete WALs not needed for recovery
+  from the last checkpoint.
+- Add support for "tarantoolctl rocks pack" subcommand.
+- string.rstrip and string.lstrip should accept symbols to strip.
+- on shutdown trigger added.
+- on_schema_init trigger added.
+- snapshot daemon: limit the maximum disk size of maintained WALs.
+- Permissions to create, alter and drop space.
+- Replace box.sql.execute() with box.execute().
+- SQL Type system was significantly refactored.
+- Do not use SQL delete+insert for updates.
+- Improve value comparison of different SQL types.
+- Allow constraints to appear along with column definitions in SQL.
+- Improve pragma index_info syntax.
+- Dozens of bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.1.2
+
+* Mon Apr 1 2019 Kirill Yukhin <kyukhin@tarantool.org> 1.10.3.0-1
+- Randomize vinyl index compaction.
+- Throttle tx thread if compaction doesn't keep up with dumps.
+- Do not apply run_count_per_level to the last level.
+- Report the number of active iproto connections.
+- Never keep a dead replica around if running out of disk space.
+- Report join progress to the replica log.
+- Expose snapshot status in box.info.gc().
+- Show names of Lua functions in backtraces in fiber.info().
+- Check if transaction opened.
+- A lof of bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/1.10.3
+
+* Thu Nov 15 2018 Kirill Yukhin <kyukhin@tarantool.org> 2.1.1.0-1
+- Add function box.sql.execute() to query Tarantool database
+  using SQL statements.
+- Added support for SQL collations by incorporating libICU
+  character set and collation library.
+- IPROTO interface was extended to support SQL queries.
+- net.box subsystem was extended to support SQL queries.
+- Enabled ANALYZE statement to produce correct results,
+  necessary for efficient query plans.
+- Enabled savepoints functionality. SAVEPOINT statement works w/o issues.
+- Enabled ALTER TABLE … RENAME statement.
+- Improved rules for identifier names: now fully consistent
+  with Lua frontend.
+- Enabled support for triggers; trigger bodies now persist in Tarantool
+  snapshots and survive server restart.
+- Significant performance improvements.
+- Functions in SQL.
+- Introduce new SQL wire protocol.
+- Is nullable type attribute wanted by API in IPROTO.
+- Add collation field to tuple format.
+- Add string.fromhex() method.
+- Select input language in tarantoolctl.
+- Use Tarantool's structs for metadata during query compilation.
+- Resolve names for VIEW right after its creation.
+- Various SQL features and bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/2.1.1
+
+* Sat Oct 13 2018 Kirill Yukhin <kyukhin@tarantool.org> 1.10.2.0-1
+- Configurable syslog destination.
+- Allow different nullability in indexes and format.
+- Allow to back up any checkpoint.
+- A way to detect that a Tarantool process was started or
+  restarted by tarantoolctl.
+- `TARANTOOLCTL` and `TARANTOOL_RESTARTED` env vars.
+- New configuration parameter net_msg_max to restrict
+  the number of allocated fibers;
+- Automatic replication rebootstrap.
+- Replica-local space.
+- Display the connection status if the downstream gets
+  disconnected from the upstream.
+- New option replication_skip_conflict.
+- Remove old snapshots which are not needed by replicas.
+- New function fiber.join().
+- New option `names_only` in tuple:tomap().
+- Support custom rock servers in tarantoolctl. 
+- Expose on_commit/on_rollback triggers to Lua.
+- New function box.is_in_txn() to check if a transaction is open.
+- Tuple field access via a json path.
+- New function space:frommap() to convert a map to a tuple instance
+  or to a table.
+- New module utf8 that implements libicu's bindings for use in Lua.
+- Support ALTER for non-empty vinyl spaces.
+- Tuples stored in the vinyl cache are not shared among the indexes
+  of the same space.
+- Keep a stack of UPSERTS in `vy_read_iterator`.
+- New function `box.ctl.reset_stat()` to reset vinyl statistics.
+- A lof of bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/1.10.2
+
+* Wed Sep 05 2018 Kirill Yukhin <kyukhin@tarantool.org> 1.9.2.0-1
+- Dozens of bugfixes, see GitHub release notes:
+  https://github.com/tarantool/tarantool/releases/tag/1.9.1
+  https://github.com/tarantool/tarantool/releases/tag/1.9.2
+
+* Mon Feb 26 2018 Konstantin Osipov <kostja@tarantool.org> 1.9.0.4-1
+- It is now possible to block/unblock users.
+- New function `box.session.euid()` to return effective user.
+- New 'super' role, with superuser access.
+- `on_auth` trigger is now fired in case of both successful and
+  failed authentication.
+- New replication configuration algorithm.
+- After replication connect at startup, the server
+  does not start processing write requests before syncing up
+  with all connected peers.
+- It is now possible to explicitly set instance and replica set
+  uuid via database configuration.
+- `box.once()` no longer fails on a read-only replica but waits.
+- `force_recovery` can now skip a corrupted xlog file.
+- Improved replication monitoring.
+- New 'BEFORE' triggers which can be used for conflict resolution
+  in master-master replication.
+- http client now correctly parses cookies and supports
+  http+unix:// paths.
+- `fio` rock now supports `file_exists()`, `rename()` works across
+  filesystems, and `read()` without arguments reads the whole file.
+- `fio` rock errors now follow Tarantool function call conventions
+  and always return an error message in addition to the error flag.
+- `digest` rock now supports pbkdf2 password hashing algorithm,
+  useful in PCI/DSS compliant applications.
+- `box.info.memory()` provides a high-level overview of
+  server memory usage, including networking, Lua, transaction
+  and index memory.
+- It is now possible to add missing tuple fields to an index.
+- Lots of improvements in field type support when creating or
+  altering spaces and indexes.
+- It is now possible to turn on `is_nullable` property on a field
+  even if the space is not empty.
+- Several logging improvements. 
+- It is now possible to make a unique vinyl index non-unique
+  without index rebuild.
+- Improved vynil UPDATE, REPLACE and recovery performance in presence of
+  secondary keys.
+- `space:len()` and `space:bsize()` now work for vinyl.
+- Vinyl recovery speed has improved in presence of secondary keys.
+
+* Tue Nov 07 2017 Roman Tsisyk <roman@tarantool.org> 1.7.6.0-1
+- Hybrid schema-less + schema-full data model.
+- Collation and Unicode Support.
+- NULL values in unique and non-unique indexes.
+- Sequences and a new implementation of auto_increment().
+- Add gap locks in Vinyl transaction manager.
+- on_connect/on_disconnect triggers for net.box.
+- Structured logging in JSON format.
+- Several Lua features and various bugfixes, see GitHub release notes
+  for details: https://github.com/tarantool/tarantool/releases/tag/1.7.6
+
 * Tue Sep 12 2017 Roman Tsisyk <roman@tarantool.org> 1.7.5.46-1
 - Stabilization of Vinyl storage engine.
 - Improved MemTX TREE iterators.


### PR DESCRIPTION
Actualize changelog based on GitHub release pages changelogs. Some entries were skipped since they are not relevant to modern packages. Versions 1.8.1 and 2.0.4 changelogs were merged to 2.1.1 changelog.

Closes #6397