### PR TITLE
ci: switch to 'ubuntu-20.04-self-hosted' run label

### DIFF
--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/debug_coverage.yml
+++ b/.github/workflows/debug_coverage.yml
@@ -18,7 +18,7 @@ jobs:
         github.event_name == 'pull_request') &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -18,7 +18,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_30.yml
+++ b/.github/workflows/fedora_30.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_31.yml
+++ b/.github/workflows/fedora_31.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_32.yml
+++ b/.github/workflows/fedora_32.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_33.yml
+++ b/.github/workflows/fedora_33.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -18,7 +18,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -19,7 +19,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -18,7 +18,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -18,7 +18,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -18,7 +18,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -18,7 +18,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -18,7 +18,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -14,7 +14,7 @@ jobs:
     # We want to run only on tags.
     if: startsWith(github.ref, 'refs/tags/')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -18,7 +18,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -18,7 +18,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ubuntu_20_10.yml
+++ b/.github/workflows/ubuntu_20_10.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ubuntu_21_04.yml
+++ b/.github/workflows/ubuntu_21_04.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ! endsWith(github.ref, '-notest')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-self-hosted
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
The idea of these changes is to run testing workflows on self-hosted
ubuntu-20.04 machines instead of GitHub ubuntu-20.04 runners. It is
planned to use GitHub ubuntu-20.04 runners only for integration testing
of tarantool with a module/connector where ephemeral environments will
allow us to avoid various cleanup pains on self-hosted runners like

    - if: always()
      run: sudo apt-get -y purge 'tarantool*'

or

    - if: always()
      run: rm -rf .rocks

or

    - if: always()
      run: rm -rf pytest-venv

Also, switch workflows running on GitHub ubuntu-18.04 runners to
self-hosted ubuntu-20.04 machines.