### PR TITLE
box: 'box.cfg' error behaviour

### DIFF
--- a/changelogs/unreleased/gh-6086-log-cfg-must-not-be-updated-on-box-cfg-error.md
+++ b/changelogs/unreleased/gh-6086-log-cfg-must-not-be-updated-on-box-cfg-error.md
@@ -1,0 +1,3 @@
+## bugfix/box
+
+* Fix 'log.cfg' getting updated on 'box.cfg' error (gh-6086).

--- a/src/lua/log.lua
+++ b/src/lua/log.lua
@@ -427,7 +427,7 @@ local function box_api_cfg_set_log_level()
 
     local ok, msg = verify_option(log_key, v)
     if not ok then
-        return false, msg
+        box.error(box.error.CFG, 'log_level', msg)
     end
 
     if type(v) == 'string' then
@@ -435,7 +435,6 @@ local function box_api_cfg_set_log_level()
     end
 
     set_log_level(v, false)
-    return true
 end
 
 -- Set logging format from reloading box.cfg{}
@@ -445,11 +444,10 @@ local function box_api_set_log_format()
 
     local ok, msg = verify_option(log_key, v)
     if not ok then
-        return false, msg
+        box.error(box.error.CFG, 'log_format', msg)
     end
 
     set_log_format(v, false)
-    return true
 end
 
 -- Reload dynamic options.

--- a/test/app-tap/logger.test.lua
+++ b/test/app-tap/logger.test.lua
@@ -107,7 +107,8 @@ box.cfg{
 
 -- Now try to change a static field.
 _, err = pcall(box.cfg, {log_level = 5, log = "2.txt"})
-test:ok(tostring(err):find("can\'t be set dynamically") ~= nil)
+test:ok(tostring(err):find("Can't set option 'log' dynamically") ~= nil,
+        "box.cfg.log cannot be set dynamically")
 test:ok(box.cfg.log == filename, "filename match")
 test:ok(box.cfg.log_level == 6, "loglevel match")
 verify_keys("box.cfg static error")

--- a/test/box-tap/gh-6086-log-cfg-must-not-be-updated-on-box-cfg-error.test.lua
+++ b/test/box-tap/gh-6086-log-cfg-must-not-be-updated-on-box-cfg-error.test.lua
@@ -1,0 +1,15 @@
+#!/usr/bin/env tarantool
+
+local tap = require('tap')
+local test = tap.test('gh-6086-log-cfg-must-not-be-updated-on-box-cfg-error')
+
+test:plan(1)
+
+local log = require('log')
+local log_cfg_copy = {}
+for k, v in pairs(log.cfg) do log_cfg_copy[k] = v end
+pcall(box.cfg, {log_nonblock = true})
+test:is_deeply(log.cfg, log_cfg_copy, '\'log.cfg did not get updated on ' ..
+               '\'box.cfg\' error')
+
+os.exit(test:check() and 0 or 1)

--- a/test/box/reconfigure.result
+++ b/test/box/reconfigure.result
@@ -93,7 +93,7 @@ box.cfg{memtx_dir="dynamic"}
 ...
 box.cfg{log="new logger"}
 ---
-- error: 'Incorrect value for option ''log'': can''t be set dynamically'
+- error: Can't set option 'log' dynamically
 ...
 -- bad1
 box.cfg{memtx_memory=53687091}


### PR DESCRIPTION
If 'box.cfg' fails with error, 'log.cfg' still gets updated: instead,
update 'log.cfg' after verifying 'box.cfg', and rollback if update of
'log.cfg' fails.

Closes #6086
