### PR TITLE
box/lua: log dangerous :select and :pairs calls

### DIFF
--- a/changelogs/unreleased/gh-6539-log-space-select-pairs-args-nil.md
+++ b/changelogs/unreleased/gh-6539-log-space-select-pairs-args-nil.md
@@ -1,0 +1,8 @@
+## feature/box/lua
+
+* Critical log entry, containing the current stack traceback, upon empty or nil 
+  :select and :pairs calls on user spaces (gh-6539).
+
+## feature/box/lua/log
+* log.crit() writes a user-generated message to the corresponding log
+  file with CRITICAL log level.

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -1677,7 +1677,7 @@ base_index_mt.fselect = function(index, key, opts, fselect_opts)
     local json = require('json')
     for _,t in index:pairs(key, opts) do
         local row = { }
-        for _,f in t:pairs() do
+        for _,f in t:pairs{} do
             table.insert(row, json.encode(f))
         end
         table.insert(tab, row)

--- a/src/box/lua/upgrade.lua
+++ b/src/box/lua/upgrade.lua
@@ -54,7 +54,7 @@ end
 local function truncate(space)
     local pk = space.index[0]
     while pk:len() > 0 do
-        for _, t in pk:pairs() do
+        for _, t in pk:pairs{} do
             local key = {}
             for _, parts in ipairs(pk.parts) do
                 table.insert(key, t[parts.fieldno])
@@ -608,7 +608,7 @@ local function upgrade_to_1_7_7()
     --
     -- grant 'session' and 'usage' to all existing users
     --
-    for _, v in _user:pairs() do
+    for _, v in _user:pairs{} do
         if v[4] ~= "role" then
             _priv:upsert({ADMIN, v[1], "universe", 0, box.priv.S + box.priv.U},
                                                 {{"|", 5, box.priv.S + box.priv.U}})
@@ -711,7 +711,7 @@ local function upgrade_priv_to_2_1_0()
     -- objects, since it has no effect. We also skip grants for
     -- sequences since they were added after the new privileges
     -- and compatibility mode was always off for them.
-    for _, user in _user:pairs() do
+    for _, user in _user:pairs{} do
         if user[0] ~= ADMIN and user[0] ~= SUPER then
             for _, priv in _priv:pairs(user[0]) do
                 if priv[3] ~= 'sequence' and
@@ -790,7 +790,7 @@ end
 
 local function upgrade_to_2_1_1()
     local _index = box.space[box.schema.INDEX_ID]
-    for _, index in _index:pairs() do
+    for _, index in _index:pairs{} do
         local opts = index.opts
         if opts['sql'] ~= nil then
             opts['sql'] = nil
@@ -806,7 +806,7 @@ end
 
 local function update_collation_strength_field()
     local _collation = box.space[box.schema.COLLATION_ID]
-    for _, collation in _collation:pairs() do
+    for _, collation in _collation:pairs{} do
         if collation.type == 'ICU' and collation.opts.strength == nil then
             local new_collation = collation:totable()
             new_collation[6].strength = 'tertiary'
@@ -949,7 +949,7 @@ local function upgrade_sequence_to_2_2_1()
     log.info("add sequence field to space _space_sequence")
     local _index = box.space[box.schema.INDEX_ID]
     local _space_sequence = box.space[box.schema.SPACE_SEQUENCE_ID]
-    for _, v in _space_sequence:pairs() do
+    for _, v in _space_sequence:pairs{} do
         if #v > 3 then
             -- Must be a sequence created after upgrade.
             -- It doesn't need to get updated.
@@ -994,7 +994,7 @@ local function upgrade_ck_constraint_to_2_2_1()
     _index:insert{_ck_constraint.id, 0, 'primary', 'tree',
                   {unique = true}, {{0, 'unsigned'}, {1, 'string'}}}
 
-    for _, space in _space:pairs() do
+    for _, space in _space:pairs{} do
         local flags = space.flags
         if flags.checks then
             for i, check in pairs(flags.checks) do
@@ -1125,7 +1125,7 @@ local function upgrade_to_2_3_0()
 
     log.info("Extend _ck_constraint space format with is_enabled field")
     local _ck_constraint = box.space._ck_constraint
-    for _, tuple in _ck_constraint:pairs() do
+    for _, tuple in _ck_constraint:pairs{} do
         _ck_constraint:update({tuple[1], tuple[2]}, {{'=', 6, true}})
     end
     local format = {{name='space_id', type='unsigned'},
@@ -1200,7 +1200,7 @@ end
 local function remove_sql_builtin_functions_from_func()
     local _func = box.space._func
     local _priv = box.space._priv
-    for _, v in _func:pairs() do
+    for _, v in _func:pairs{} do
         if v.language == "SQL_BUILTIN" then
             _priv:delete({2, 'function', v.id})
             _func:delete({v.id})

--- a/src/lua/log.lua
+++ b/src/lua/log.lua
@@ -59,6 +59,7 @@ ffi.cdef[[
     say_parse_logger_type(const char **str, enum say_logger_type *type);
 ]]
 
+local S_CRIT = ffi.C.S_CRIT
 local S_WARN = ffi.C.S_WARN
 local S_INFO = ffi.C.S_INFO
 local S_VERBOSE = ffi.C.S_VERBOSE
@@ -575,6 +576,7 @@ local compat_v16 = {
 }
 
 local log = {
+    crit = say_closure(S_CRIT),
     warn = say_closure(S_WARN),
     info = say_closure(S_INFO),
     verbose = say_closure(S_VERBOSE),

--- a/test/app/luafun.test.lua
+++ b/test/app/luafun.test.lua
@@ -29,12 +29,12 @@ fun.iter(box.tuple.new({1, 2, 3}):pairs()):totable()
 function pred(t) return t[1] % 2 == 0 end
 fun.iter(space):totable()
 fun.iter(space:pairs()):totable()
-space:pairs():filter(pred):drop(2):take(3):totable()
+space:pairs{}:filter(pred):drop(2):take(3):totable()
 
 -- iter on index (using __ipairs)
 fun.iter(space.index[0]):totable()
 fun.iter(space.index[0]:pairs()):totable()
-space.index[0]:pairs():drop(2):take(3):totable()
+space.index[0]:pairs{}:drop(2):take(3):totable()
 
 -- test global functions
 test_run:cmd("setopt delimiter ';'")

--- a/test/app/uuid.test.lua
+++ b/test/app/uuid.test.lua
@@ -180,7 +180,7 @@ box.execute([[INSERT INTO "s" VALUES (x'303030')]])
 -- Make sure that comparison is right. Comparison in SCALAR field:
 -- bool < number < string < varbinary < uuid.
 --
-s:select()
+s:select{}
 s:select({}, {iterator='LE'})
 s:drop()
 

--- a/test/box-tap/gh-4954-merger-via-net-box.test.lua
+++ b/test/box-tap/gh-4954-merger-via-net-box.test.lua
@@ -32,7 +32,7 @@ end
 
 local function use_table_source(tuples)
     local source = merger_lib.new_source_fromtable(tuples)
-    return source:select()
+    return source:select{}
 end
 _G.use_table_source = use_table_source
 
@@ -40,13 +40,13 @@ local function use_buffer_source(tuples)
     local buf = buffer.ibuf()
     msgpack.encode(tuples, buf)
     local source = merger_lib.new_source_frombuffer(buf)
-    return source:select()
+    return source:select{}
 end
 _G.use_buffer_source = use_buffer_source
 
 local function use_tuple_source(tuples)
     local source = merger_lib.new_tuple_source(array_next, tuples)
-    return source:select()
+    return source:select{}
 end
 _G.use_tuple_source = use_tuple_source
 
@@ -56,7 +56,7 @@ local function use_table_source_yield(tuples)
         chunks[i] = {t}
     end
     local source = merger_lib.new_table_source(array_yield_next, chunks)
-    return source:select()
+    return source:select{}
 end
 _G.use_table_source_yield = use_table_source_yield
 
@@ -67,13 +67,13 @@ local function use_buffer_source_yield(tuples)
         msgpack.encode({t}, buffers[i])
     end
     local source = merger_lib.new_buffer_source(array_yield_next, buffers)
-    return source:select()
+    return source:select{}
 end
 _G.use_buffer_source_yield = use_buffer_source_yield
 
 local function use_tuple_source_yield(tuples)
     local source = merger_lib.new_tuple_source(array_yield_next, tuples)
-    return source:select()
+    return source:select{}
 end
 _G.use_tuple_source_yield = use_tuple_source_yield
 

--- a/test/box-tap/gh-6539-log-space-select-pairs-args-nil.test.lua
+++ b/test/box-tap/gh-6539-log-space-select-pairs-args-nil.test.lua
@@ -1,0 +1,66 @@
+#!/usr/bin/env tarantool
+
+local tap = require('tap')
+local test = tap.test('gh-6539-log-space-select-pairs-args-nil')
+test:plan(7)
+local inspector = require('test_run').new()
+local fio = require('fio')
+
+local expected_log_entry = 'C> empty or nil :%a+ call on user space with id=%d+:'
+local log_file_name = 'test.log'
+local grep_log_args = {nil, expected_log_entry, 512, {filename = log_file_name}}
+
+box.cfg{log = log_file_name}
+
+box.space._space:select()
+box.space._space:pairs()
+test:ok(inspector:grep_log(unpack(grep_log_args)) == nil,
+        'check that log does not contain a critical entry about empty ' ..
+        ':select and :pairs on a system space')
+
+local s = box.schema.space.create('test_vinyl', {engine='vinyl'})
+s:create_index('primary')
+
+s:select{}
+s:pairs{}
+s:select(nil, {})
+s:pairs(nil, {})
+test:ok(inspector:grep_log(unpack(grep_log_args)) == nil,
+        'check that log does not contain a critical entry about non-empty ' ..
+        ':select and :pairs call on a vinyl user space')
+
+s:select()
+test:ok(inspector:grep_log(unpack(grep_log_args)) ~= nil,
+        'check that log contains a critical entry about an empty ' ..
+        ':select call on a vinyl user space')
+fio.truncate(log_file_name)
+
+s:pairs()
+test:ok(inspector:grep_log(unpack(grep_log_args)) ~= nil,
+        'check that log contains a critical entry about an empty ' ..
+        ':pairs call on a vinyl user space')
+fio.truncate(log_file_name)
+
+s = box.schema.space.create('test_memtx')
+s:create_index('primary')
+
+s:select{}
+s:pairs{}
+s:select(nil, {})
+s:pairs(nil, {})
+test:ok(inspector:grep_log(unpack(grep_log_args)) == nil,
+        'check that log does not contain a critical entry about non-empty ' ..
+        ':select and :pairs call on a memtx user space')
+
+s:select()
+test:ok(inspector:grep_log(unpack(grep_log_args)) ~= nil,
+        'check that log contains a critical entry about an empty ' ..
+        ':select call on a memtx user space')
+fio.truncate(log_file_name)
+
+s:pairs()
+test:ok(inspector:grep_log(unpack(grep_log_args)) ~= nil,
+        'check that log contains a critical entry about an empty ' ..
+        ':pairs call on a memtx user space')
+
+os.exit(test:check() and 0 or 1)

--- a/test/box-tap/merger.test.lua
+++ b/test/box-tap/merger.test.lua
@@ -486,7 +486,7 @@ local function run_merger(test, schema, tuple_count, source_count, opts)
     -- Run merger and prepare output for compare.
     if opts.output_type == 'table' then
         -- Table output.
-        res = merger_inst:select()
+        res = merger_inst:select{}
     elseif opts.output_type == 'buffer' then
         -- Buffer output.
         local output_buffer = buffer.ibuf()
@@ -495,7 +495,7 @@ local function run_merger(test, schema, tuple_count, source_count, opts)
     else
         -- Tuple output.
         assert(opts.output_type == 'tuple')
-        res = merger_inst:pairs():totable()
+        res = merger_inst:pairs{}:totable()
     end
 
     -- A bit more postprocessing to compare.
@@ -571,7 +571,7 @@ for _, case in ipairs(bad_chunks) do
         return state, case.chunk
     end, {}, {})
     local ok, err = pcall(function()
-        return source:pairs():take(1):totable()
+        return source:pairs{}:take(1):totable()
     end)
     test:ok(ok == false and err:match(case.exp_err), case[1])
 end
@@ -607,8 +607,8 @@ test:test('use a source in two mergers', function(test)
 
     local data = {{'a'}, {'b'}, {'c'}}
     local source = merger.new_source_fromtable(data)
-    local i1 = merger.new(key_def, {source}):pairs()
-    local i2 = merger.new(key_def, {source}):pairs()
+    local i1 = merger.new(key_def, {source}):pairs{}
+    local i2 = merger.new(key_def, {source}):pairs{}
 
     local t1 = i1:head():totable()
     test:is_deeply(t1, data[1], 'tuple 1 from merger 1')
@@ -644,15 +644,15 @@ local function verify_reusable_source(test, source)
     test:plan(3)
 
     local exp = {{1}, {2}}
-    local res = source:pairs():map(box.tuple.totable):totable()
+    local res = source:pairs{}:map(box.tuple.totable):totable()
     test:is_deeply(res, exp, '1st use')
 
     local exp = {{3}, {4}, {5}}
-    local res = source:pairs():map(box.tuple.totable):totable()
+    local res = source:pairs{}:map(box.tuple.totable):totable()
     test:is_deeply(res, exp, '2nd use')
 
     local exp = {}
-    local res = source:pairs():map(box.tuple.totable):totable()
+    local res = source:pairs{}:map(box.tuple.totable):totable()
     test:is_deeply(res, exp, 'end')
 end
 
@@ -727,7 +727,7 @@ test:test('cascade mergers', function(test)
     local m1 = merger.new(key_def, {source})
     local m2 = merger.new(key_def, {m1})
 
-    local res = m2:pairs():map(box.tuple.totable):totable()
+    local res = m2:pairs{}:map(box.tuple.totable):totable()
     test:is_deeply(res, data, 'same key_def')
 
     local key_def_unicode = key_def_lib.new({{
@@ -740,7 +740,7 @@ test:test('cascade mergers', function(test)
     local m1 = merger.new(key_def, {source})
     local m2 = merger.new(key_def_unicode, {m1})
 
-    local res = m2:pairs():map(box.tuple.totable):totable()
+    local res = m2:pairs{}:map(box.tuple.totable):totable()
     test:is_deeply(res, data, 'different key_defs')
 end)
 

--- a/test/box/access_misc.test.lua
+++ b/test/box/access_misc.test.lua
@@ -80,7 +80,7 @@ box.schema.func.create('guest_func')
 session.su('admin')
 box.schema.user.revoke("guest", "read", "universe")
 
-s:select()
+s:select{}
 --
 -- Create user with universe read&write grants
 -- and create this user session
@@ -114,7 +114,7 @@ box.schema.user.drop('uniuser_testus')
 --
 -- Check access system and any spaces
 --
-box.space.admin_space:select()
+box.space.admin_space:select{}
 box.space._user:select(1)
 box.space._space:select(280)
 
@@ -200,7 +200,7 @@ for key, v in s.index.primary:pairs(3, {iterator = 'GE'}) do table.insert (t, v)
 t
 t = {}
 session.su('testuser')
-s:select()
+s:select{}
 for key, v in s.index.primary:pairs(3, {iterator = 'GE'}) do table.insert (t, v) end
 t
 t = {}
@@ -208,26 +208,26 @@ session.su('admin')
 box.schema.user.revoke('testuser', 'read', 'space', 'glade')
 box.schema.user.grant('testuser', 'write', 'space', 'glade')
 session.su('testuser')
-s:select()
+s:select{}
 for key, v in s.index.primary:pairs(1, {iterator = 'GE'}) do table.insert (t, v) end
 t
 t = {}
 session.su('admin')
 box.schema.user.grant('testuser', 'read, write, execute', 'space', 'glade')
 session.su('testuser')
-s:select()
+s:select{}
 for key, v in s.index.primary:pairs(3, {iterator = 'GE'}) do table.insert (t, v) end
 t
 t = {}
 
 session.su('guest')
-s:select()
+s:select{}
 for key, v in s.index.primary:pairs(3, {iterator = 'GE'}) do table.insert (t, v) end
 t
 t = {}
 
 session.su('guest')
-s:select()
+s:select{}
 for key, v in s.index.primary:pairs(3, {iterator = 'GE'}) do table.insert (t, v) end
 t
 
@@ -238,14 +238,14 @@ session.su('admin')
 _ = s:create_index('secondary', {unique = false, parts = {2, 'string'}})
 
 session.su('testuser')
-s:select()
+s:select{}
 
 session.su('admin')
 s:truncate()
 s:insert({1234, 'ABCD'})
 
 session.su('testuser')
-s:select()
+s:select{}
 
 session.su('admin')
 box.schema.user.drop('testuser')

--- a/test/box/access_sysview.test.lua
+++ b/test/box/access_sysview.test.lua
@@ -4,11 +4,11 @@ session = box.session
 -- Basic tests
 --
 
-#box.space._vspace:select{} == #box.space._space:select{}
-#box.space._vindex:select{} == #box.space._index:select{}
-#box.space._vuser:select{} == #box.space._user:select{}
-#box.space._vpriv:select{} == #box.space._priv:select{}
-#box.space._vfunc:select{} == #box.space._func:select{}
+#box.space._vspace:select() == #box.space._space:select()
+#box.space._vindex:select() == #box.space._index:select()
+#box.space._vuser:select() == #box.space._user:select()
+#box.space._vpriv:select() == #box.space._priv:select()
+#box.space._vfunc:select() == #box.space._func:select()
 
 -- gh-1042: bad error message for _vspace, _vuser, _vindex, etc.
 -- Space '_vspace' (sysview) does not support replace
@@ -44,21 +44,21 @@ box.session.su('admin')
 box.schema.user.revoke('guest', 'public')
 box.session.su('guest')
 
-#box.space._vspace:select{}
-#box.space._vindex:select{}
-#box.space._vuser:select{}
-#box.space._vpriv:select{}
-#box.space._vfunc:select{}
-#box.space._vsequence:select{}
-#box.space._vcollation:select{}
+#box.space._vspace:select()
+#box.space._vindex:select()
+#box.space._vuser:select()
+#box.space._vpriv:select()
+#box.space._vfunc:select()
+#box.space._vsequence:select()
+#box.space._vcollation:select()
 
 box.session.su('admin')
 box.schema.user.grant('guest', 'public')
 box.session.su('guest')
 
-#box.space._vspace:select{}
-#box.space._vindex:select{}
-#box.space._vcollation:select{}
+#box.space._vspace:select()
+#box.space._vindex:select()
+#box.space._vcollation:select()
 
 box.session.su('admin')
 s = box.schema.space.create('test')
@@ -95,24 +95,24 @@ box.session.su('admin')
 box.schema.user.grant('guest', 'read', 'universe')
 box.session.su('guest')
 
-#box.space._vspace:select{}
-#box.space._vindex:select{}
-#box.space._vuser:select{}
-#box.space._vpriv:select{}
-#box.space._vfunc:select{}
-#box.space._vcollation:select{}
+#box.space._vspace:select()
+#box.space._vindex:select()
+#box.space._vuser:select()
+#box.space._vpriv:select()
+#box.space._vfunc:select()
+#box.space._vcollation:select()
 
 box.session.su('admin')
 box.schema.user.revoke('guest', 'read', 'universe')
 box.schema.user.grant('guest', 'write', 'universe')
 box.session.su('guest')
 
-#box.space._vindex:select{}
-#box.space._vuser:select{}
-#box.space._vpriv:select{}
-#box.space._vfunc:select{}
-#box.space._vsequence:select{}
-#box.space._vcollation:select{}
+#box.space._vindex:select()
+#box.space._vuser:select()
+#box.space._vpriv:select()
+#box.space._vfunc:select()
+#box.space._vsequence:select()
+#box.space._vcollation:select()
 
 box.session.su('admin')
 box.schema.user.revoke('guest', 'write', 'universe')
@@ -121,19 +121,19 @@ box.session.su('guest')
 
 -- read access to original space also allow to read a view
 box.session.su('admin')
-space_cnt = #box.space._space:select{}
-index_cnt = #box.space._index:select{}
+space_cnt = #box.space._space:select()
+index_cnt = #box.space._index:select()
 box.schema.user.grant('guest', 'read', 'space', '_space')
 box.schema.user.grant('guest', 'read', 'space', '_index')
 box.session.su('guest')
-#box.space._vspace:select{} == space_cnt
-#box.space._vindex:select{} == index_cnt
+#box.space._vspace:select() == space_cnt
+#box.space._vindex:select() == index_cnt
 box.session.su('admin')
 box.schema.user.revoke('guest', 'read', 'space', '_space')
 box.schema.user.revoke('guest', 'read', 'space', '_index')
 box.session.su('guest')
-#box.space._vspace:select{} < space_cnt
-#box.space._vindex:select{} < index_cnt
+#box.space._vspace:select() < space_cnt
+#box.space._vindex:select() < index_cnt
 
 --
 -- _vuser
@@ -144,14 +144,14 @@ t = box.space._vuser:select(); for i = 1, #t do if t[i][3] == 'guest' then retur
 
 -- read access to original space also allow to read a view
 box.session.su('admin')
-user_cnt = #box.space._user:select{}
+user_cnt = #box.space._user:select()
 box.schema.user.grant('guest', 'read', 'space', '_user')
 box.session.su('guest')
-#box.space._vuser:select{} == user_cnt
+#box.space._vuser:select() == user_cnt
 box.session.su('admin')
 box.schema.user.revoke('guest', 'read', 'space', '_user')
 box.session.su('guest')
-#box.space._vuser:select{} < user_cnt
+#box.space._vuser:select() < user_cnt
 
 box.session.su('admin')
 box.schema.user.grant('guest', 'read,write,create', 'universe')
@@ -179,13 +179,13 @@ box.space._vpriv.index[2]:select('role')[1][2] == session.uid()
 -- read access to original space also allow to read a view
 box.session.su('admin')
 box.schema.user.grant('guest', 'read', 'space', '_priv')
-priv_cnt = #box.space._priv:select{}
+priv_cnt = #box.space._priv:select()
 box.session.su('guest')
-#box.space._vpriv:select{} == priv_cnt
+#box.space._vpriv:select() == priv_cnt
 box.session.su('admin')
 box.schema.user.revoke('guest', 'read', 'space', '_priv')
 box.session.su('guest')
-cnt = #box.space._vpriv:select{}
+cnt = #box.space._vpriv:select()
 
 cnt < priv_cnt
 
@@ -193,13 +193,13 @@ box.session.su('admin')
 box.schema.user.grant('guest', 'read,write', 'space', '_schema')
 box.session.su('guest')
 
-#box.space._vpriv:select{} == cnt + 1
+#box.space._vpriv:select() == cnt + 1
 
 box.session.su('admin')
 box.schema.user.revoke('guest', 'read,write', 'space', '_schema')
 box.session.su('guest')
 
-#box.space._vpriv:select{} == cnt
+#box.space._vpriv:select() == cnt
 
 --
 -- _vfunc
@@ -209,14 +209,14 @@ box.session.su('admin')
 box.schema.func.create('test')
 
 -- read access to original space also allow to read a view
-func_cnt = #box.space._func:select{}
+func_cnt = #box.space._func:select()
 box.schema.user.grant('guest', 'read', 'space', '_func')
 box.session.su('guest')
-#box.space._vfunc:select{} == func_cnt
+#box.space._vfunc:select() == func_cnt
 box.session.su('admin')
 box.schema.user.revoke('guest', 'read', 'space', '_func')
 box.session.su('guest')
-cnt = #box.space._vfunc:select{}
+cnt = #box.space._vfunc:select()
 
 cnt < func_cnt
 
@@ -224,26 +224,26 @@ box.session.su('admin')
 box.schema.user.grant('guest', 'execute', 'function', 'test')
 box.session.su('guest')
 
-#box.space._vfunc:select{} == func_cnt
+#box.space._vfunc:select() == func_cnt
 
 box.session.su('admin')
 box.schema.user.revoke('guest', 'execute', 'function', 'test')
 box.session.su('guest')
 
-#box.space._vfunc:select{} == cnt
+#box.space._vfunc:select() == cnt
 
 box.session.su('admin')
 box.schema.user.grant('guest', 'execute', 'universe')
 box.session.su('guest')
 
-#box.space._vfunc:select{} == func_cnt
+#box.space._vfunc:select() == func_cnt
 
 box.session.su('admin')
 box.schema.user.revoke('guest', 'execute', 'universe')
 box.schema.func.drop('test')
 box.session.su('guest')
 
-#box.space._vfunc:select{} == cnt
+#box.space._vfunc:select() == cnt
 
 --
 -- _vsequence
@@ -253,20 +253,20 @@ box.session.su('admin')
 seq = box.schema.sequence.create('test')
 
 -- read access to original sequence also allow to read a view
-seq_cnt = #box.space._sequence:select{}
+seq_cnt = #box.space._sequence:select()
 box.schema.user.grant("guest", "read", "sequence", "test")
 box.session.su("guest")
-#box.space._vsequence:select{} == seq_cnt
+#box.space._vsequence:select() == seq_cnt
 box.session.su('admin')
 
 box.schema.user.revoke("guest", "read", "sequence", "test")
 box.session.su("guest")
-cnt = #box.space._vsequence:select{}
+cnt = #box.space._vsequence:select()
 cnt < seq_cnt
 session.su('admin')
 box.schema.user.grant("guest", "write", "sequence", "test")
 box.session.su("guest")
-#box.space._vsequence:select{} == cnt + 1
+#box.space._vsequence:select() == cnt + 1
 session.su('admin')
 seq:drop()
 
@@ -278,18 +278,18 @@ box.session.su('admin')
 box.internal.collation.create('test', 'ICU', 'ru-RU')
 
 -- Only admin can create collation.
-coll_cnt = #box.space._collation:select{}
+coll_cnt = #box.space._collation:select()
 box.schema.user.grant("guest", "read, write, alter, execute", "space", "_collation")
 box.session.su("guest")
 box.internal.collation.create('guest0', 'ICU', 'ru-RU')
 box.space._vcollation:select{0}
-#box.space._vcollation:select{} == coll_cnt
+#box.space._vcollation:select() == coll_cnt
 box.session.su('admin')
 
 -- _vcollation is readable anyway.
 box.schema.user.revoke("guest", "read, write, alter, execute", "space", "_collation")
 box.session.su("guest")
-#box.space._vcollation:select{}
+#box.space._vcollation:select()
 session.su('admin')
 box.internal.collation.drop('test')
 box.internal.collation.drop('guest0')

--- a/test/box/alter.test.lua
+++ b/test/box/alter.test.lua
@@ -99,7 +99,7 @@ box.space[1000]
 space = box.schema.space.create('gh197')
 space:len()
 space:truncate()
-space:pairs():totable()
+space:pairs{}:totable()
 space:drop()
 
 --------------------------------------------------------------------------------

--- a/test/box/backup.test.lua
+++ b/test/box/backup.test.lua
@@ -78,8 +78,8 @@ files = box.backup.start(1) -- error: checkpoint not found
 _ = test_run:cmd(string.format("create server copy1 with script='box/backup_test.lua', workdir='%s'", BACKUP_DIR))
 _ = test_run:cmd("start server copy1")
 _ = test_run:cmd('switch copy1')
-box.space.memtx:select()
-box.space.vinyl:select()
+box.space.memtx:select{}
+box.space.vinyl:select{}
 _ = test_run:cmd('switch default')
 _ = test_run:cmd("stop server copy1")
 _ = test_run:cmd("cleanup server copy1")
@@ -97,8 +97,8 @@ box.backup.stop()
 _ = test_run:cmd(string.format("create server copy2 with script='box/backup_test.lua', workdir='%s'", BACKUP_DIR))
 _ = test_run:cmd("start server copy2")
 _ = test_run:cmd('switch copy2')
-box.space.memtx:select()
-box.space.vinyl:select()
+box.space.memtx:select{}
+box.space.vinyl:select{}
 _ = test_run:cmd('switch default')
 _ = test_run:cmd("stop server copy2")
 _ = test_run:cmd("cleanup server copy2")
@@ -111,8 +111,8 @@ box.backup.stop()
 _ = test_run:cmd(string.format("create server copy3 with script='box/backup_test.lua', workdir='%s'", BACKUP_DIR))
 _ = test_run:cmd("start server copy3")
 _ = test_run:cmd('switch copy3')
-box.space.memtx:select()
-box.space.vinyl:select()
+box.space.memtx:select{}
+box.space.vinyl:select{}
 _ = test_run:cmd('switch default')
 _ = test_run:cmd("stop server copy3")
 _ = test_run:cmd("cleanup server copy3")

--- a/test/box/before_replace.test.lua
+++ b/test/box/before_replace.test.lua
@@ -18,7 +18,7 @@ function ret_update_pk(old, new) return box.tuple.update(new, {{'+', 1, 1}}) end
 -- Exception in trigger.
 s:before_replace(fail) == fail
 s:insert{1, 1}
-s:select()
+s:select{}
 s:before_replace(nil, fail)
 
 -- Check 'old' and 'new' trigger arguments.
@@ -35,21 +35,21 @@ s:upsert({1, 1}, {{'=', 2, 1}})
 old_tuple, new_tuple
 s:upsert({2, 2}, {{'=', 2, 2}})
 old_tuple, new_tuple
-s:select()
+s:select{}
 s:delete(1)
 old_tuple, new_tuple
 s:delete(2)
 old_tuple, new_tuple
-s:select()
+s:select{}
 s:before_replace(nil, save)
 
 -- Returning 'new' from trigger doesn't affect statement.
 s:before_replace(ret_new) == ret_new
 s:insert{1, 1}
 s:update(1, {{'+', 2, 1}})
-s:select()
+s:select{}
 s:delete(1)
-s:select()
+s:select{}
 s:before_replace(nil, ret_new)
 
 -- Returning 'old' from trigger skips statement.
@@ -58,7 +58,7 @@ s:before_replace(ret_old) == ret_old
 s:insert{2, 2}
 s:update(1, {{'+', 2, 1}})
 s:delete(1)
-s:select()
+s:select{}
 s:before_replace(nil, ret_old)
 s:delete(1)
 
@@ -66,14 +66,14 @@ s:delete(1)
 s:insert{1, 1}
 s:before_replace(ret_nil) == ret_nil
 s:replace{1, 2}
-s:select()
+s:select{}
 s:before_replace(nil, ret_nil)
 
 -- Returning box.NULL from trigger turns statement into DELETE.
 s:insert{1, 1}
 s:before_replace(ret_null) == ret_null
 s:replace{1, 2}
-s:select()
+s:select{}
 s:before_replace(nil, ret_null)
 
 -- Returning nothing doesn't affect the operation.
@@ -83,7 +83,7 @@ s:before_replace(ret_none) == ret_none
 s:replace{1, 2}
 s:update(1, {{'+', 2, 1}})
 s:delete(2)
-s:select()
+s:select{}
 s:before_replace(nil, ret_none)
 s:delete(1)
 
@@ -91,14 +91,14 @@ s:delete(1)
 s:before_replace(ret_update) == ret_update
 s:insert{1, 1, 1}
 s:update(1, {{'+', 2, 1}})
-s:select()
+s:select{}
 s:before_replace(nil, ret_update)
 s:delete(1)
 
 -- Invalid return value.
 s:before_replace(ret_invalid) == ret_invalid
 s:insert{1, 1}
-s:select()
+s:select{}
 s:before_replace(nil, ret_invalid)
 
 -- Update of the primary key from trigger is forbidden.
@@ -115,7 +115,7 @@ _ = s2:create_index('sk', {unique = true, parts = {2, 'unsigned'}})
 s2:insert{1, 1, 1, 1}
 s2:before_replace(ret_update) == ret_update
 s2.index.sk:update(1, {{'+', 4, 1}})
-s2:select()
+s2:select{}
 s2:drop()
 
 -- Stacking triggers.
@@ -139,8 +139,8 @@ s:insert{1, 1}
 i = 2
 s:replace{1, 2}
 s:replace{1, 3} -- error: conflict in s2
-s:select()
-s2:select()
+s:select{}
+s2:select{}
 
 -- DML done from space:before_replace is undone
 -- if space:on_replace fails.
@@ -148,8 +148,8 @@ s:truncate()
 s2:truncate()
 s:on_replace(fail) == fail
 s:replace{1, 3}
-s:select()
-s2:select()
+s:select{}
+s2:select{}
 s:on_replace(nil, fail)
 s:before_replace(nil, cb)
 s2:drop()
@@ -167,7 +167,7 @@ s:delete(1)
 old_tuple, new_tuple
 s:insert{2, 2}
 old_tuple, new_tuple
-s:select()
+s:select{}
 s:before_replace(nil, ret_old)
 s:on_replace(nil, save)
 s:delete(1)
@@ -182,7 +182,7 @@ s:insert{1, 1, 1}
 old_tuple, new_tuple
 s:replace{1, 2, 2}
 old_tuple, new_tuple
-s:select()
+s:select{}
 s:before_replace(nil, ret_update)
 s:on_replace(nil, save)
 s:delete(1)
@@ -191,7 +191,7 @@ s:delete(1)
 cb = function(old, new) s:insert{1, 1} end
 s:before_replace(cb) == cb
 s:insert{1, 1} -- error
-s:select()
+s:select{}
 s:before_replace(nil, cb)
 
 -- Nesting limit: space.before_replace + space.on_replace
@@ -199,7 +199,7 @@ cb = function(old, new) s:delete(1) end
 s:before_replace(cb) == cb
 s:on_replace(cb) == cb
 s:insert{1, 1} -- error
-s:select()
+s:select{}
 s:before_replace(nil, cb)
 s:on_replace(nil, cb)
 
@@ -212,7 +212,7 @@ box.begin() s:replace{10, 10} s:before_replace(nil, f) s:replace{10, 100} box.co
 test_run:cmd('restart server default')
 
 s = box.space.test
-s:select() -- [10, 100]
+s:select{} -- [10, 100]
 
 -- Check that IPROTO_NOP is actually written to xlog.
 fio = require('fio')

--- a/test/box/blackhole.test.lua
+++ b/test/box/blackhole.test.lua
@@ -44,11 +44,11 @@ s:replace{2}
 memtx:replace{2}
 box.commit();
 test_run:cmd("setopt delimiter ''");
-memtx:select()
+memtx:select{}
 f = s:on_replace(function(old, new) memtx:replace(new) end)
 s:replace{3}
 s:replace{4}
-memtx:select()
+memtx:select{}
 s:on_replace(nil, f)
 memtx:drop()
 

--- a/test/box/ddl_alter.test.lua
+++ b/test/box/ddl_alter.test.lua
@@ -5,5 +5,5 @@ space:replace({1, 2, 3})
 index:rename('primary')
 index2 = space:create_index('sec')
 space:replace({2, 3, 1})
-space:select()
+space:select{}
 space:drop()

--- a/test/box/ddl_tuple.test.lua
+++ b/test/box/ddl_tuple.test.lua
@@ -20,9 +20,9 @@ test_run:cmd("setopt delimiter ''");
 _ = {fiber.create(insert_tuple, {1, 2, 'a'}), fiber.create(add_index), fiber.create(insert_tuple, {2, '3', 'b'})}
 {ch:get(), ch:get(), ch:get()}
 
-box.space.test:select()
+box.space.test:select{}
 
 test_run:cmd('restart server default')
 
-box.space.test:select()
+box.space.test:select{}
 box.space.test:drop()

--- a/test/box/errinj.test.lua
+++ b/test/box/errinj.test.lua
@@ -296,9 +296,9 @@ box.schema.user.revoke('guest', 'read', 'space', '_space')
 run()
 ch:get()
 
-box.space.test:select()
+box.space.test:select{}
 test_run:cmd('restart server default')
-box.space.test:select()
+box.space.test:select{}
 box.space.test:drop()
 
 errinj = box.error.injection
@@ -394,7 +394,7 @@ c = net_box.connect(box.cfg.listen)
 ch = fiber.channel(200)
 errinj.set("ERRINJ_IPROTO_TX_DELAY", true)
 for i = 1, 100 do fiber.create(function() for j = 1, 10 do c.space.test:replace{1} end ch:put(true) end) end
-for i = 1, 100 do fiber.create(function() for j = 1, 10 do c.space.test:select() end ch:put(true) end) end
+for i = 1, 100 do fiber.create(function() for j = 1, 10 do c.space.test:select{} end ch:put(true) end) end
 for i = 1, 200 do ch:get() end
 errinj.set("ERRINJ_IPROTO_TX_DELAY", false)
 
@@ -492,7 +492,7 @@ s:drop()
 s:truncate()
 errinj.set('ERRINJ_WAL_IO', false)
 for i = 1, 10 do s:replace{i + 10} end
-s:select()
+s:select{}
 s:drop()
 
 --
@@ -609,7 +609,7 @@ box.error.injection.set('ERRINJ_WAL_IO', true)
 box.schema.user.grant('testg', 'read,write', 'space', 'testg')
 -- switch user and check they couldn't select
 box.session.su('testg')
-box.space.testg:select()
+box.space.testg:select{}
 box.session.su('admin')
 box.error.injection.set('ERRINJ_WAL_IO', false)
 box.schema.user.drop('testg')

--- a/test/box/errinj_index.test.lua
+++ b/test/box/errinj_index.test.lua
@@ -10,7 +10,7 @@ res = {}
 for i = 1,10 do table.insert(res, s:get{i}) end
 res
 res = {}
-for _, t in s.index[0]:pairs() do table.insert(res, t) end
+for _, t in s.index[0]:pairs{} do table.insert(res, t) end
 res
 
 errinj.set("ERRINJ_INDEX_ALLOC", true)
@@ -19,7 +19,7 @@ res = {}
 for i = 1,10 do table.insert(res, s:get{i}) end
 res
 res = {}
-for _, t in s.index[0]:pairs() do table.insert(res, t) end
+for _, t in s.index[0]:pairs{} do table.insert(res, t) end
 res
 
 for i = 501,2500 do s:insert{i, i} end
@@ -33,7 +33,7 @@ for i = 501,510 do table.insert(res, (s:get{i})) end
 res
 
 --count must be exactly 10
-function check_iter_and_size() local count = 0 for _, t in s.index[0]:pairs() do count = count + 1 end return count == 10 and "ok" or "fail" end
+function check_iter_and_size() local count = 0 for _, t in s.index[0]:pairs{} do count = count + 1 end return count == 10 and "ok" or "fail" end
 check_iter_and_size()
 
 for i = 2501,3500 do s:insert{i, i} end
@@ -70,7 +70,7 @@ res = {}
 for i = 1,10 do table.insert(res, s:get{i}) end
 res
 res = {}
-for _, t in s.index[0]:pairs() do table.insert(res, t) end
+for _, t in s.index[0]:pairs{} do table.insert(res, t) end
 res
 
 errinj.set("ERRINJ_INDEX_ALLOC", true)
@@ -79,7 +79,7 @@ res = {}
 for i = 1,10 do table.insert(res, s:get{i}) end
 res
 res = {}
-for _, t in s.index[0]:pairs() do table.insert(res, t) end
+for _, t in s.index[0]:pairs{} do table.insert(res, t) end
 res
 
 for i = 501,2500 do s:insert{i, i} end

--- a/test/box/gh-5304-insert_during_recovery.test.lua
+++ b/test/box/gh-5304-insert_during_recovery.test.lua
@@ -19,41 +19,41 @@ test_run:cmd('start server test with args="insert" with crash_expected=True')
 test_run:cmd('start server test with args="upsert" with crash_expected=True')
 test_run:cmd('start server test with args="replace is_recovery_finished"')
 test_run:cmd('switch test')
-box.space.temp:select()
-box.space.loc:select()
+box.space.temp:select{}
+box.space.loc:select{}
 -- Creating a new space and index invokes on_replace trigger in _index space,
 -- which inserts tuples in temp and loc spaces (see gh-5304-insert_during_recovery.lua)!
 s0 = box.schema.space.create('test')
 i0 = s0:create_index('test')
-box.space.temp:select()
-box.space.loc:select()
+box.space.temp:select{}
+box.space.loc:select{}
 s0:drop()
 
 test_run:cmd('switch default')
 test_run:cmd('stop server test')
 test_run:cmd('start server test with args="insert is_recovery_finished"')
 test_run:cmd('switch test')
-box.space.temp:select()
-box.space.loc:select()
+box.space.temp:select{}
+box.space.loc:select{}
 -- Creating a new space and index invoke on_replace trigger in _index space.
 -- Here we get error during insert tuple in loc space, because the tuple
 -- with the same primary key is already in the loc space
 s0 = box.schema.space.create('test')
 i0 = s0:create_index('test')
-box.space.temp:select()
-box.space.loc:select()
+box.space.temp:select{}
+box.space.loc:select{}
 s0:drop()
 
 test_run:cmd('switch default')
 test_run:cmd('stop server test')
 test_run:cmd('start server test with args="upsert is_recovery_finished"')
 test_run:cmd('switch test')
-box.space.temp:select()
-box.space.loc:select()
+box.space.temp:select{}
+box.space.loc:select{}
 s0 = box.schema.space.create('test')
 i0 = s0:create_index('test')
-box.space.temp:select()
-box.space.loc:select()
+box.space.temp:select{}
+box.space.loc:select{}
 s0:drop()
 
 test_run:cmd('switch default')

--- a/test/box/gh-5422-broken_snapshot.test.lua
+++ b/test/box/gh-5422-broken_snapshot.test.lua
@@ -38,7 +38,7 @@ function write_garbage_with_restore_or_save(filename, offset, count, restore)
 end;
 function check_count_valid_snapshot_data(count)
     local cnt = 0
-    local val = test_run:eval('test', "box.space.test:select()")[1]
+    local val = test_run:eval('test', "box.space.test:select{}")[1]
     for i = 1, count do
         if val[i] ~= nil then
             cnt = cnt + 1

--- a/test/box/hash_multipart.test.lua
+++ b/test/box/hash_multipart.test.lua
@@ -24,7 +24,7 @@ test_run:cmd("setopt delimiter ';'")
 function select_all()
     local result = {}
     local tuple, v
-    for tuple, v in hash:pairs() do
+    for tuple, v in hash:pairs{} do
         table.insert(result, v)
     end
     return result

--- a/test/box/indices_any_type.test.lua
+++ b/test/box/indices_any_type.test.lua
@@ -30,72 +30,72 @@ _ = s5:create_index('primary', {parts={1, 'scalar'}})
 -- small range 1
 s5:insert({5})
 s5:insert({5.1})
-s5:select()
+s5:select{}
 s5:truncate()
 -- small range 2
 s5:insert({5.1})
 s5:insert({5})
-s5:select()
+s5:select{}
 s5:truncate()
 -- small range 3
 s5:insert({-5})
 s5:insert({-5.1})
-s5:select()
+s5:select{}
 s5:truncate()
 -- small range 4
 s5:insert({-5.1})
 s5:insert({-5})
-s5:select()
+s5:select{}
 s5:truncate()
 -- conversion to another type is lossy for both values
 s5:insert({18446744073709551615ULL})
 s5:insert({3.6893488147419103e+19})
-s5:select()
+s5:select{}
 s5:truncate()
 -- insert in a different order to excersise another codepath
 s5:insert({3.6893488147419103e+19})
 s5:insert({18446744073709551615ULL})
-s5:select()
+s5:select{}
 s5:truncate()
 -- MP_INT vs MP_UINT
 s5:insert({-9223372036854775808LL})
 s5:insert({-3.6893488147419103e+19})
-s5:select()
+s5:select{}
 s5:truncate()
 -- insert in a different order to excersise another codepath
 s5:insert({-3.6893488147419103e+19})
 s5:insert({-9223372036854775808LL})
-s5:select()
+s5:select{}
 s5:truncate()
 -- different signs 1
 s5:insert({9223372036854775807LL})
 s5:insert({-3.6893488147419103e+19})
-s5:select()
+s5:select{}
 s5:truncate()
 -- different signs 2
 s5:insert({-3.6893488147419103e+19})
 s5:insert({9223372036854775807LL})
-s5:select()
+s5:select{}
 s5:truncate()
 -- different signs 3
 s5:insert({-9223372036854775808LL})
 s5:insert({3.6893488147419103e+19})
-s5:select()
+s5:select{}
 s5:truncate()
 -- different signs 4
 s5:insert({3.6893488147419103e+19})
 s5:insert({-9223372036854775808LL})
-s5:select()
+s5:select{}
 s5:truncate()
 -- different magnitude 1
 s5:insert({1.1})
 s5:insert({18446744073709551615ULL})
-s5:select()
+s5:select{}
 s5:truncate()
 -- different magnitude 2
 s5:insert({18446744073709551615ULL})
 s5:insert({1.1})
-s5:select()
+s5:select{}
 s5:truncate()
 -- Close values
 ffi = require('ffi')
@@ -104,38 +104,38 @@ ffi.new('double', 1152921504606846977) == 1152921504606846976ULL
 -- Close values 1
 s5:insert({1152921504606846976ULL})
 s5:insert({ffi.new('double', 1152921504606846976ULL)}) -- fail
-s5:select()
+s5:select{}
 s5:truncate()
 -- Close values 2
 s5:insert({1152921504606846977ULL})
 s5:insert({ffi.new('double', 1152921504606846976ULL)}) -- success
-s5:select()
+s5:select{}
 s5:truncate()
 -- Close values 3
 s5:insert({-1152921504606846976LL})
 s5:insert({ffi.new('double', -1152921504606846976LL)}) -- fail
-s5:select()
+s5:select{}
 s5:truncate()
 -- Close values 4
 s5:insert({-1152921504606846977LL})
 s5:insert({ffi.new('double', -1152921504606846976LL)}) -- success
-s5:select()
+s5:select{}
 s5:truncate()
 -- Close values 5
 ffi.cdef "double exp2(double);"
 s5:insert({0xFFFFFFFFFFFFFFFFULL})
 s5:insert({ffi.new('double', ffi.C.exp2(64))}) -- success
-s5:select()
+s5:select{}
 s5:truncate()
 -- Close values 6
 s5:insert({0x8000000000000000LL})
 s5:insert({ffi.new('double', -ffi.C.exp2(63))}) -- duplicate
-s5:select()
+s5:select{}
 s5:truncate()
 -- Close values 7
 s5:insert({0x7FFFFFFFFFFFFFFFLL})
 s5:insert({ffi.new('double', ffi.C.exp2(63))}) -- ok
-s5:select()
+s5:select{}
 s5:truncate()
 
 s5:drop()

--- a/test/box/lua.test.lua
+++ b/test/box/lua.test.lua
@@ -108,14 +108,14 @@ space:auto_increment{'c'}
 space.index.primary:drop()
 space:auto_increment{'a'}
 space:get({1})
-space:select()
+space:select{}
 space:update({1}, {})
 space:upsert({1}, {})
 space:delete({1})
 space:bsize()
 space:count()
 space:len()
-space:pairs():totable()
+space:pairs{}:totable()
 space:drop()
 
 --

--- a/test/box/lua/utils.lua
+++ b/test/box/lua/utils.lua
@@ -163,7 +163,7 @@ local function check_space(space, N)
         end
     end
 
-    local count = #space:select()
+    local count = #space:select{}
     -- :len() doesn't work on vinyl
     if count ~= 0 then
         table.insert(errors, {'invalid count after delete', count})
@@ -174,7 +174,7 @@ end
 
 local function space_bsize(s)
     local bsize = 0
-    for _, t in s:pairs() do
+    for _, t in s:pairs{} do
         bsize = bsize + t:bsize()
     end
 

--- a/test/box/net.box_count_inconsistent_gh-3262.test.lua
+++ b/test/box/net.box_count_inconsistent_gh-3262.test.lua
@@ -122,7 +122,7 @@ function do_count_test(min, it)
     return r1 == r2 and r2 == r3
 end;
 
-data = remote_pk:select();
+data = remote_pk:select{};
 
 for _, v in pairs(data) do
     local itrs = {'GE', 'GT', 'LE', 'LT' }

--- a/test/box/net.box_field_names_gh-2978.test.lua
+++ b/test/box/net.box_field_names_gh-2978.test.lua
@@ -15,14 +15,14 @@ s:get{1}:tomap()
 s:insert{2,3}:tomap()
 s:replace{2,14}:tomap()
 s:update(1, {{'+', 2, 10}}):tomap()
-s:select()[1]:tomap()
+s:select{}[1]:tomap()
 s:delete({2}):tomap()
 
 -- Check that formats changes after reload.
 box.space.named:format({{name = "id2"}, {name="abc2"}})
-s:select()[1]:tomap()
+s:select{}[1]:tomap()
 cn:reload_schema()
-s:select()[1]:tomap()
+s:select{}[1]:tomap()
 
 cn:close()
 box.space.named:drop()

--- a/test/box/net.box_incorrect_iterator_gh-841.test.lua
+++ b/test/box/net.box_incorrect_iterator_gh-841.test.lua
@@ -84,7 +84,7 @@ cn.space.net_box_test_space:delete{10}
 
 cn.space.net_box_test_space:select({}, { iterator = 'ALL' })
 -- gh-841: net.box uses incorrect iterator type for select with no arguments
-cn.space.net_box_test_space:select()
+cn.space.net_box_test_space:select{}
 
 cn.space.net_box_test_space.index.primary:min()
 cn.space.net_box_test_space.index.primary:min(354)

--- a/test/box/net.box_iproto_streams.test.lua
+++ b/test/box/net.box_iproto_streams.test.lua
@@ -161,7 +161,7 @@ test_run:wait_cond(function () return get_current_stream_count() == 0 end)
 test_run:wait_cond(function () return get_current_msg_count() == 0 end)
 test_run:switch("test")
 -- [1] [2] [3] [4] [5]
-s:select()
+s:select{}
 test_run:switch('default')
 conn:close()
 test_run:wait_cond(function () return get_current_connection_count() == 0 end)

--- a/test/box/net.box_iproto_transactions_over_streams.test.lua
+++ b/test/box/net.box_iproto_transactions_over_streams.test.lua
@@ -154,7 +154,7 @@ space:select{}
 space:select({})
 test_run:switch("test")
 -- Select is empty, transaction was not commited
-s:select()
+s:select{}
 test_run:switch('default')
 -- Commit fails, transaction yeild with memtx_use_mvcc_engine = false
 stream:commit()
@@ -174,7 +174,7 @@ space:select({})
 stream:call('s:select', {})
 test_run:switch("test")
 -- Select is empty, transaction was not commited
-s:select()
+s:select{}
 test_run:switch('default')
 -- Commit fails, transaction yeild with memtx_use_mvcc_engine = false
 stream:eval('box.commit()')
@@ -190,7 +190,7 @@ space:select({})
 stream:call('s:select', {})
 test_run:switch("test")
 -- Select is empty, transaction was not commited
-s:select()
+s:select{}
 test_run:switch('default')
 -- Commit fails, transaction yeild with memtx_use_mvcc_engine = false
 stream:execute('COMMIT')
@@ -227,7 +227,7 @@ space_no_stream:select{}
 space:select({})
 test_run:switch("test")
 -- Select is empty, transaction was not commited
-s:select()
+s:select{}
 test_run:switch('default')
 -- Commit was successful, transaction can yeild with
 -- memtx_use_mvcc_engine = true.
@@ -241,7 +241,7 @@ space:select{}
 test_run:switch("test")
 -- Select return tuple, which was previously inserted,
 -- because transaction was successful
-s:select()
+s:select{}
 test_run:switch('default')
 cleanup_and_stop_server(conn)
 
@@ -269,7 +269,7 @@ space_1_2:select({})
 
 test_run:switch('test')
 -- Both select return tuple [1, 1], transaction commited
-s:select()
+s:select{}
 test_run:switch('default')
 cleanup_and_stop_server(conn)
 
@@ -297,7 +297,7 @@ conn:close()
 
 test_run:switch('test')
 -- Both select are empty, because transaction rollback
-s:select()
+s:select{}
 test_run:switch('default')
 cleanup_and_stop_server(conn)
 
@@ -319,7 +319,7 @@ test_run:wait_cond(function () return get_current_connection_count() == 0 end)
 
 test_run:switch("test")
 -- Empty select, transaction was rollback
-s:select()
+s:select{}
 test_run:switch("default")
 cleanup_and_stop_server(conn)
 
@@ -352,7 +352,7 @@ test_run:wait_cond(function () return get_current_connection_count() == 0 end)
 
 test_run:switch("test")
 -- Select was empty, transaction rollbacked
-s:select()
+s:select{}
 test_run:switch("default")
 
 -- Same test, but now we check that if `commit` was received
@@ -381,7 +381,7 @@ test_run:wait_cond(function () return get_current_connection_count() == 0 end)
 test_run:switch("test")
 -- Select return tuples from [1] to [100],
 -- transaction was commit
-rc = s:select()
+rc = s:select{}
 assert(#rc)
 test_run:switch("default")
 cleanup_and_stop_server(conn)
@@ -432,7 +432,7 @@ futures["select"] = space:select({}, {is_async = true})
 
 test_run:switch("test")
 -- Select is empty, transaction was not commited
-s:select()
+s:select{}
 test_run:switch('default')
 futures["commit"] = stream:commit({is_async = true})
 
@@ -454,7 +454,7 @@ test_run:wait_cond(function() return get_current_msg_count() == 0 end)
 test_run:switch("test")
 -- Select return tuples, which was previously inserted,
 -- because transaction was successful
-s:select()
+s:select{}
 test_run:switch('default')
 cleanup_and_stop_server(conn)
 
@@ -503,7 +503,7 @@ test_run:wait_cond(function() return get_current_msg_count() == 0 end)
 
 test_run:switch('test')
 -- Select return tuple [1, 1], transaction commited
-s:select()
+s:select{}
 test_run:switch('default')
 cleanup_and_stop_server(conn)
 
@@ -543,7 +543,7 @@ space_no_stream:select{}
 space:select({})
 test_run:switch("test")
 -- Select is empty, transaction was not commited
-s:select()
+s:select{}
 test_run:switch('default')
 --Successful commit using stream:execute
 stream:execute('COMMIT')
@@ -552,7 +552,7 @@ stream:execute('COMMIT')
 space_no_stream:select{}
 test_run:switch("test")
 -- Select return tuple, because transaction was successful
-s:select()
+s:select{}
 s:delete{1}
 test_run:switch('default')
 -- Check rollback using stream:call
@@ -567,7 +567,7 @@ space_no_stream:select{}
 space:select({})
 test_run:switch("test")
 -- Select is empty, transaction was not commited
-s:select()
+s:select{}
 test_run:switch('default')
 --Successful rollback using stream:call
 stream:call('box.rollback')
@@ -580,7 +580,7 @@ test_run:wait_cond(function() return get_current_msg_count() == 0 end)
 
 test_run:switch("test")
 -- Empty select transaction rollbacked
-s:select()
+s:select{}
 test_run:switch('default')
 cleanup_and_stop_server(conn)
 
@@ -815,9 +815,9 @@ space = stream.space.TEST
 assert(space ~= nil)
 stream:execute('START TRANSACTION')
 space:replace{1, 2, '3'}
-space:select()
+space:select{}
 -- select is empty, because transaction was not commited
-conn.space.TEST:select()
+conn.space.TEST:select{}
 stream_pr = stream:prepare("SELECT * FROM test WHERE id = ? AND a = ?;")
 conn_pr = conn:prepare("SELECT * FROM test WHERE id = ? AND a = ?;")
 assert(stream_pr.stmt_id == conn_pr.stmt_id)
@@ -834,7 +834,7 @@ stream:unprepare(stream_pr.stmt_id)
 conn:close()
 test_run:switch('test')
 -- [ 1, 2, '3' ]
-box.space.TEST:select()
+box.space.TEST:select{}
 box.space.TEST:drop()
 test_run:switch('default')
 test_run:cmd("stop server test")

--- a/test/box/on_replace.test.lua
+++ b/test/box/on_replace.test.lua
@@ -71,8 +71,8 @@ trigger_id = first:on_replace(function()
 end);
 test_run:cmd("setopt delimiter ''");
 first:replace({1, "hello"})
-first:select()
-second:select()
+first:select{}
+second:select{}
 first:on_replace(nil, trigger_id)
 first:delete(1)
 second:delete(1)
@@ -86,8 +86,8 @@ trigger_id = first:on_replace(function()
 end);
 test_run:cmd("setopt delimiter ''");
 first:replace({1, "multistatement tx"})
-first:select()
-second:select()
+first:select{}
+second:select{}
 first:on_replace(nil, trigger_id)
 first:delete(1)
 second:delete(1)
@@ -102,8 +102,8 @@ trigger_id = first:on_replace(function()
 end);
 test_run:cmd("setopt delimiter ''");
 first:replace({1, "rollback"})
-first:select()
-second:select()
+first:select{}
+second:select{}
 first:on_replace(nil, trigger_id)
 
 -- max recursion depth
@@ -115,8 +115,8 @@ trigger_id = first:on_replace(function()
 end);
 test_run:cmd("setopt delimiter ''");
 first:replace({1, "recursive"})
-first:select()
-second:select()
+first:select{}
+second:select{}
 RECURSION_LIMIT
 first:on_replace(nil, trigger_id)
 
@@ -132,8 +132,8 @@ trigger_id = first:on_replace(function()
 end);
 test_run:cmd("setopt delimiter ''");
 first:replace({0, "initial"})
-first:select()
-second:select()
+first:select{}
+second:select{}
 RECURSION_LIMIT
 first:on_replace(nil, trigger_id)
 first:truncate()
@@ -148,8 +148,8 @@ trigger_id = first:on_replace(function()
 end);
 test_run:cmd("setopt delimiter ''");
 first:replace({0, "initial"})
-first:select()
-second:select()
+first:select{}
+second:select{}
 first:on_replace(nil, trigger_id)
 
 test_run:cmd("setopt delimiter ';'");
@@ -159,8 +159,8 @@ trigger_id = first:on_replace(function()
 end);
 test_run:cmd("setopt delimiter ''");
 first:replace({0, "initial"})
-first:select()
-second:select()
+first:select{}
+second:select{}
 first:on_replace(nil, trigger_id)
 
 test_run:cmd("setopt delimiter ';'");
@@ -172,8 +172,8 @@ end);
 
 test_run:cmd("setopt delimiter ''");
 first:replace({0, "initial"})
-first:select()
-second:select()
+first:select{}
+second:select{}
 first:on_replace(nil, trigger_id)
 
 first:drop()
@@ -200,7 +200,7 @@ t = s:on_replace(function () s:rename('newname') end, t)
 s:replace({8, 9})
 t = s:on_replace(function () s.index.pk:rename('newname') end, t)
 s:replace({9, 10})
-s:select()
+s:select{}
 s:drop() -- test_on_repl_ddl
 
 --
@@ -246,9 +246,9 @@ box.commit();
 
 test_run:cmd("setopt delimiter ''");
 
-s1:select()
-s2:select()
-s3:select()
+s1:select{}
+s2:select{}
+s3:select{}
 
 s1:drop()
 s2:drop()
@@ -271,9 +271,9 @@ _ = s1:on_replace(function(old, new) s3:insert(new:update{{'!', 2, x}}) x = x + 
 
 box.begin() s1:insert{1} s1:insert{2} s1:insert{3} box.commit()
 
-s1:select()
-s2:select()
-s3:select()
+s1:select{}
+s2:select{}
+s3:select{}
 
 s1:drop()
 s2:drop()

--- a/test/box/push.test.lua
+++ b/test/box/push.test.lua
@@ -210,7 +210,7 @@ future:result()
 -- Even if pushes are ignored, they still are available via pairs.
 messages = {}
 keys = {}
-for i, message in future:pairs() do table.insert(messages, message) table.insert(keys, i) end
+for i, message in future:pairs{} do table.insert(messages, message) table.insert(keys, i) end
 messages
 keys
 
@@ -228,7 +228,7 @@ future = c:call('do_push_and_duplicate', {}, {is_async = true})
 future:wait_result(1000)
 messages = {}
 keys = {}
-for i, message in future:pairs() do table.insert(messages, message) table.insert(keys, i) end
+for i, message in future:pairs{} do table.insert(messages, message) table.insert(keys, i) end
 messages
 keys
 

--- a/test/box/sequence.test.lua
+++ b/test/box/sequence.test.lua
@@ -186,7 +186,7 @@ s:insert{sq1:next(), sq2:next()}
 box.commit();
 test_run:cmd("setopt delimiter ''");
 
-s:select() -- [4, -4], [5, -5], [6, -6]
+s:select{} -- [4, -4], [5, -5], [6, -6]
 
 sq1:drop()
 sq2:drop()
@@ -409,7 +409,7 @@ s:insert{nil, 'e'} -- 103
 s:insert{nil, 'f'} -- 104
 box.commit()
 
-s:select() -- {1, 'a'}, {100, 'b'}, {103, 'e'}, {104, 'f'}
+s:select{} -- {1, 'a'}, {100, 'b'}, {103, 'e'}, {104, 'f'}
 s:drop()
 
 --

--- a/test/box/session_settings.test.lua
+++ b/test/box/session_settings.test.lua
@@ -24,11 +24,11 @@ s:replace({'sql_defer_foreign_keys', true})
 -- the same way as an ordinary space with an index of the type
 -- "TREE".
 --
-s:select()
+s:select{}
 
 t = box.schema.space.create('settings', {format = s:format()})
 _ = t:create_index('primary')
-for _,value in s:pairs() do t:insert(value) end
+for _,value in s:pairs{} do t:insert(value) end
 
 test_run:cmd('setopt delimiter ";"')
 function check_sorting(ss, ts, key)
@@ -65,7 +65,7 @@ s:get({'abcd'})
 
 -- Check pairs() method of session_settings space.
 t = {}
-for key, value in s:pairs() do table.insert(t, {key, value}) end
+for key, value in s:pairs{} do table.insert(t, {key, value}) end
 #t == s:count()
 
 -- Check update() method of session_settings space.

--- a/test/box/sql.test.lua
+++ b/test/box/sql.test.lua
@@ -179,7 +179,7 @@ space:insert{31234567, 'part1_a', 'part2'}
 space:insert{41234567, 'part1_a', 'part2_a'}
 
 l = {}
-for state, v in s:pairs() do table.insert(l, v) end
+for state, v in s:pairs{} do table.insert(l, v) end
 l
 
 space:select{1234567}

--- a/test/box/stat.test.lua
+++ b/test/box/stat.test.lua
@@ -35,7 +35,7 @@ space:select(5)
 box.stat.SELECT.total
 space:select(15)
 box.stat.SELECT.total
-for _ in space:pairs() do end
+for _ in space:pairs{} do end
 box.stat.SELECT.total
 
 -- reset

--- a/test/box/stat_net.test.lua
+++ b/test/box/stat_net.test.lua
@@ -24,7 +24,7 @@ cn1 = remote.connect(LISTEN.host, LISTEN.service)
 cn2 = remote.connect(LISTEN.host, LISTEN.service)
 cn3 = remote.connect(LISTEN.host, LISTEN.service)
 
-cn.space.tweedledum:select() --small request
+cn.space.tweedledum:select{} --small request
 
 box.stat.net.SENT.total > 0
 box.stat.net.RECEIVED.total > 0

--- a/test/box/transaction.test.lua
+++ b/test/box/transaction.test.lua
@@ -250,7 +250,7 @@ space:auto_increment{box.space._vindex:get{space.id, index.id}}
 box.commit();
 test_run:cmd("setopt delimiter ''");
 
-space:select()
+space:select{}
 space:drop()
 
 -- In order to implement a transactional applier, we  lifted a

--- a/test/box/tree_pk.test.lua
+++ b/test/box/tree_pk.test.lua
@@ -58,13 +58,13 @@ test_run = env.new()
 test_run:cmd("setopt delimiter ';'")
 function crossjoin(space0, space1, limit)
     local result = {}
-    for state, v0 in space0:pairs() do
-        for state, v1 in space1:pairs() do
+    for state, v0 in space0:pairs{} do
+        for state, v1 in space1:pairs{} do
             if limit <= 0 then
                 return result
             end
             local newtuple = v0:totable()
-            for _, v in v1:pairs() do
+            for _, v in v1:pairs{} do
                 table.insert(newtuple, v)
             end
             table.insert(result, box.tuple.new(newtuple))

--- a/test/box/tree_pk_multipart.test.lua
+++ b/test/box/tree_pk_multipart.test.lua
@@ -182,7 +182,7 @@ end;
 local pk = space.index[0]
 while pk:len() > 0 do
     local state, t
-    for state, t in pk:pairs() do
+    for state, t in pk:pairs{} do
         local key = {}
         for _k2, parts in ipairs(pk.parts) do
             table.insert(key, t[parts.fieldno])

--- a/test/box/tuple.test.lua
+++ b/test/box/tuple.test.lua
@@ -147,20 +147,20 @@ t:next(t:next())
 -- test tuple:pairs
 --------------------------------------------------------------------------------
 
-ta = {} for k, v in t:pairs() do table.insert(ta, v) end
+ta = {} for k, v in t:pairs{} do table.insert(ta, v) end
 ta
 t=space:replace{1953719668, 'another field'}
-ta = {} for k, v in t:pairs() do table.insert(ta, v) end
+ta = {} for k, v in t:pairs{} do table.insert(ta, v) end
 ta
 t=space:replace{1953719668, 'another field', 'one more'}
-ta = {} for k, v in t:pairs() do table.insert(ta, v) end
+ta = {} for k, v in t:pairs{} do table.insert(ta, v) end
 ta
 t=box.tuple.new({'a', 'b', 'c', 'd'})
-ta = {} for it,field in t:pairs() do table.insert(ta, field); end
+ta = {} for it,field in t:pairs{} do table.insert(ta, field); end
 ta
 
 t = box.tuple.new({'a', 'b', 'c'})
-gen, init, state = t:pairs()
+gen, init, state = t:pairs{}
 gen, init, state
 state, val = gen(init, state)
 state, val
@@ -172,11 +172,11 @@ state, val = gen(init, state)
 state, val
 
 r = {}
-for _state, val in t:pairs() do table.insert(r, val) end
+for _state, val in t:pairs{} do table.insert(r, val) end
 r
 
 r = {}
-for _state, val in t:pairs() do table.insert(r, val) end
+for _state, val in t:pairs{} do table.insert(r, val) end
 r
 
 r = {}
@@ -192,10 +192,10 @@ for _state, val in t:pairs(10) do table.insert(r, val) end
 r
 
 r = {}
-for _state, val in t:pairs(nil) do table.insert(r, val) end
+for _state, val in t:pairs{} do table.insert(r, val) end
 r
 
-t:pairs(nil)
+t:pairs{}
 t:pairs("fdsaf")
 
 --------------------------------------------------------------------------------

--- a/test/box/tx_man.test.lua
+++ b/test/box/tx_man.test.lua
@@ -1190,13 +1190,13 @@ _ = s3:create_index('primary')
 format = {{name = 'field1', type = 'unsigned'}}
 tx1:begin()
 tx1('s3:replace{2}')
-s3:select()
+s3:select{}
 s3:alter({format = format})
 s3:select{}
 -- Alter operation aborts transaction, so results of tx1 should be rolled back.
 --
 tx1:commit()
-s3:select()
+s3:select{}
 s3:drop()
 
 --gh-6263: basically the same as previous version but involves index creation.
@@ -1222,8 +1222,8 @@ s:create_index('sk', {parts = {{2, 'unsigned'}}})
 ch1:put(true)
 ch2:get()
 
-s.index.pk:select()
-s.index.sk:select()
+s.index.pk:select{}
+s.index.sk:select{}
 
 s:drop()
 
@@ -1241,4 +1241,3 @@ tx1:commit()
 test_run:cmd("switch default")
 test_run:cmd("stop server tx_man")
 test_run:cmd("cleanup server tx_man")
-

--- a/test/box/update.test.lua
+++ b/test/box/update.test.lua
@@ -495,7 +495,7 @@ vy_s:upsert({1, 1}, {{'+', 'field2.c.f[1]', 1}})
 vy_s:upsert({1, 1}, {{'+', '[3][3][1][1]', 1}})
 box.commit()
 
-vy_s:select()
+vy_s:select{}
 vy_s:drop()
 
 --

--- a/test/box/varbinary_type.test.lua
+++ b/test/box/varbinary_type.test.lua
@@ -38,7 +38,7 @@ test_run:cmd("setopt delimiter ''");
 
 bintuple_insert(s, {0xDE, 0xAD, 0xBE, 0xAF})
 bintuple_insert(s, {0xFE, 0xED, 0xFA, 0xCE})
-s:select()
+s:select{}
 box.execute("SELECT * FROM \"withdata\" WHERE \"b\" < x'FEEDFACE';")
 pk:alter({parts = {1, "scalar"}})
 s:format({{"b", "scalar"}})
@@ -46,7 +46,7 @@ s:insert({11})
 s:insert({22})
 s:insert({"11"})
 s:insert({"22"})
-s:select()
+s:select{}
 box.execute("SELECT * FROM \"withdata\" WHERE \"b\" <= x'DEADBEAF';")
 pk:alter({parts = {1, "varbinary"}})
 s:delete({11})
@@ -55,7 +55,7 @@ s:delete({"11"})
 s:delete({"22"})
 bintuple_insert(s, {0xFA, 0xDE, 0xDE, 0xAD})
 pk:alter({parts = {1, "varbinary"}})
-s:select()
+s:select{}
 
 --
 -- gh-5071: bitset index for binary fields

--- a/test/engine/crossjoin.test.lua
+++ b/test/engine/crossjoin.test.lua
@@ -8,13 +8,13 @@ index = space:create_index('primary', { type = 'tree' })
 test_run:cmd("setopt delimiter ';'")
 function crossjoin(space0, space1, limit)
   local result = {}
-  for _,v0 in space0:pairs() do
-    for _,v1 in space1:pairs() do
+  for _,v0 in space0:pairs{} do
+    for _,v1 in space1:pairs{} do
       if limit <= 0 then
         return result
       end
       local newtuple = v0:totable()
-      for _, v in v1:pairs() do table.insert(newtuple, v) end
+      for _, v in v1:pairs{} do table.insert(newtuple, v) end
       table.insert(result, newtuple)
       limit = limit - 1
     end

--- a/test/engine/ddl.test.lua
+++ b/test/engine/ddl.test.lua
@@ -200,23 +200,23 @@ _ = s:insert{3, 2, 1}
 
 i1:alter{parts = {1, 'integer'}}
 _ = s:insert{-1, 2, 2}
-i1:select()
-i2:select()
-i3:select()
+i1:select{}
+i2:select{}
+i3:select{}
 
 i2:alter{parts = {2, 'integer'}}
 i3:alter{parts = {3, 'integer'}}
 _ = s:replace{-1, -1, -1}
-i1:select()
-i2:select()
-i3:select()
+i1:select{}
+i2:select{}
+i3:select{}
 
 box.snapshot()
 _ = s:replace{-1, -2, -3}
 _ = s:replace{-3, -2, -1}
-i1:select()
-i2:select()
-i3:select()
+i1:select{}
+i2:select{}
+i3:select{}
 
 s:drop()
 
@@ -596,7 +596,7 @@ s:format()
 format[1].type = 'unsigned'
 s:format(format)
 s:format()
-s:select()
+s:select{}
 s:drop()
 
 --
@@ -810,7 +810,7 @@ _ = s:upsert({3, '3', '3', -3}, {{'=', 5, 'ggg'}})
 _ = s:insert{5, 'xxx', 'eee', 555, 'hhh'}
 _ = s:replace{6, 'yyy', box.NULL, -444}
 
-s:select()
+s:select{}
 
 s:create_index('sk', {parts = {2, 'string'}}) -- error: unique constraint
 s:create_index('sk', {parts = {3, 'string'}}) -- error: nullability constraint
@@ -821,9 +821,9 @@ i1 = s:create_index('i1', {parts = {2, 'string'}, unique = false})
 i2 = s:create_index('i2', {parts = {{3, 'string', is_nullable = true}}})
 i3 = s:create_index('i3', {parts = {4, 'integer'}})
 
-i1:select()
-i2:select()
-i3:select()
+i1:select{}
+i2:select{}
+i3:select{}
 
 i1:alter{unique = true} -- error: unique contraint
 i2:alter{parts = {3, 'string'}} -- error: nullability contraint
@@ -831,7 +831,7 @@ i3:alter{parts = {4, 'unsigned'}} -- error: field type
 i3:alter{parts = {4, 'integer', 5, 'string'}} -- error: field missing
 
 i3:alter{parts = {2, 'string', 4, 'integer'}} -- ok
-i3:select()
+i3:select{}
 
 --
 -- gh-4350: crash while trying to drop a multi-index space created
@@ -852,9 +852,9 @@ inspector = test_run.new()
 engine = inspector:get_cfg('engine')
 
 s = box.space.test
-s.index.i1:select()
-s.index.i2:select()
-s.index.i3:select()
+s.index.i1:select{}
+s.index.i2:select{}
+s.index.i3:select{}
 
 -- gh-4350: see above.
 box.space.test_crash:drop()
@@ -864,7 +864,7 @@ box.space.test_crash:drop()
 --
 s.index.i1:drop()
 _ = s:create_index('i1', {parts = {2, 'string'}, unique = false})
-s.index.i1:select()
+s.index.i1:select{}
 
 box.snapshot()
 
@@ -900,7 +900,7 @@ s:replace({3});
 box.begin()
 s:truncate()
 box.commit();
-s:select();
+s:select{};
 
 box.begin()
 box.schema.user.grant('guest', 'write', 'space', 'ddl_test')

--- a/test/engine/errinj.test.lua
+++ b/test/engine/errinj.test.lua
@@ -11,5 +11,5 @@ for i = 1, 10 do s:replace({i, i}) end
 errinj.set('ERRINJ_WAL_IO', true)
 s:truncate()
 errinj.set('ERRINJ_WAL_IO', false)
-s:select()
+s:select{}
 s:drop()

--- a/test/engine/errinj_ddl.test.lua
+++ b/test/engine/errinj_ddl.test.lua
@@ -186,7 +186,7 @@ for i = 1, 5 do s:insert{i, i * 10} end
 errinj.set("ERRINJ_SNAP_WRITE_DELAY", false)
 ch:get()
 
-s:select()
+s:select{}
 s:drop()
 
 --
@@ -223,7 +223,7 @@ s2:drop()
 errinj.set("ERRINJ_BUILD_INDEX_DELAY", false)
 ch:get()
 
-s1.index.pk:select()
+s1.index.pk:select{}
 -- gh-5998: first DDL operation to be committed wins and aborts all other
 -- transactions. So index creation should fail.
 --

--- a/test/engine/func_index.test.lua
+++ b/test/engine/func_index.test.lua
@@ -123,7 +123,7 @@ idx = s:create_index('idx', {unique = true, func = 'extr', parts = {{1, 'integer
 s:insert({2, 1})
 idx:get(3)
 idx:delete(3)
-s:select()
+s:select{}
 s:insert({2, 1})
 idx:get(3)
 s:drop()
@@ -138,7 +138,7 @@ idx = s:create_index('idx', {unique = true, func = box.func.extr.id, parts = {{1
 s:insert({1, 2})
 s:insert({3, 5})
 s:insert({5, 3})
-idx:select()
+idx:select{}
 idx:get(8)
 idx:get(3)
 idx:get(1)
@@ -222,7 +222,7 @@ s:insert({1})
 s:insert({2})
 s:insert({3})
 s:insert({4})
-idx:select()
+idx:select{}
 s:drop()
 box.schema.func.drop('extr')
 

--- a/test/engine/hints.test.lua
+++ b/test/engine/hints.test.lua
@@ -25,13 +25,13 @@ inspector:cmd("setopt delimiter ''");
 s = box.schema.space.create('test', {engine = engine})
 i1 = s:create_index('i1', {parts = {1, 'unsigned'}})
 insert_values('uint64_t')
-s:select()
+s:select{}
 i1:alter{parts = {1, 'integer'}}
 insert_values('int64_t')
-s:select()
+s:select{}
 i1:alter{parts = {1, 'number'}}
 insert_values('double')
-s:select()
+s:select{}
 s:drop()
 
 -- Test that the use of hint(s) does not violate alter between
@@ -43,7 +43,7 @@ s:insert({"ccc"})
 i1:alter{parts = {1, 'scalar'}}
 s:insert({"aaa"})
 s:insert({"ddd"})
-s:select()
+s:select{}
 s:drop()
 
 -- Test that hints does not violate the correct order of
@@ -58,5 +58,5 @@ s:insert({-33.33})
 i1:alter{parts = {1, 'scalar'}}
 s:insert({44.44})
 s:insert({"Hello world"})
-s:select()
+s:select{}
 s:drop()

--- a/test/engine/insert.test.lua
+++ b/test/engine/insert.test.lua
@@ -156,7 +156,7 @@ s:insert({10, ffi.cast('double', tonumber64('18000000000000000000'))})
 s:insert({11, ffi.cast('double', 1.1)})
 s:insert({12, ffi.cast('double', -3.0009)})
 
-s:select()
+s:select{}
 
 -- The same rules apply to the key of this field:
 dd = s:create_index('dd', {unique = false, parts = {{2, 'double'}}})
@@ -207,6 +207,6 @@ s:get(200)
 ddd:update(ffi.cast('double', 1), {{'=', 3, 7}})
 ddd:delete(ffi.cast('double', 123))
 
-s:select()
+s:select{}
 
 s:drop()

--- a/test/engine/json.test.lua
+++ b/test/engine/json.test.lua
@@ -29,7 +29,7 @@ s:insert{7, 7, {town = 'London', FIO = {fname = 'James', sname = 'Bond'}}, 4, 5}
 s:insert{7, 7, {town = 'London', FIO = {fname = 'James', sname = 'Bond'}}, 4, 5}
 s:insert{7, 7, {town = 'London', FIO = {fname = 'James', sname = 'Bond', data = "extra"}}, 4, 5}
 s:insert{7, 7, {town = 'Moscow', FIO = {fname = 'Max', sname = 'Isaev', data = "extra"}}, 4, 5}
-idx:select()
+idx:select{}
 idx:min()
 idx:max()
 s:drop()
@@ -90,7 +90,7 @@ s:create_index('test2', {parts = {{3, 'number'}, {4, 'number', path = '["FIO"]["
 idx2 = s:create_index('test2', {parts = {{3, 'number'}, {4, 'str', path = '["FIO"]["fname"]'}}})
 idx2 ~= nil
 t = s:insert{5, 5, 7, {town = 'Matrix', FIO = {fname = 'Agent', sname = 'Smith'}}, 4, 5}
-idx:select()
+idx:select{}
 idx:min()
 idx:max()
 idx:drop()
@@ -121,7 +121,7 @@ parts[1] = {1, 'unsigned', path='[3][2].b'}
 num_idx = s:create_index('numeric', {parts =  parts})
 s:insert{{1, 2, {3, {a = 'str3', b = 9}}}, {'c', {d = {'e', 'f'}, e = 'g'}}, 6, {0}}
 num_idx:get(2)
-num_idx:select()
+num_idx:select{}
 num_idx:max()
 num_idx:min()
 crosspart_idx:max() == num_idx:max()
@@ -138,9 +138,9 @@ idx = s:create_index('idx', {parts = {{2, 'integer', path = 'a'}}})
 s:insert{31, {a = 1, aa = -1}}
 s:insert{22, {a = 2, aa = -2}}
 s:insert{13, {a = 3, aa = -3}}
-idx:select()
+idx:select{}
 idx:alter({parts = {{2, 'integer', path = 'aa'}}})
-idx:select()
+idx:select{}
 s:drop()
 
 -- Incompatible format change.
@@ -189,9 +189,9 @@ town:select({'Berlin'})
 s:update({1, 'Berlin'}, {{"+", 2, 45}})
 box.snapshot()
 s:upsert({1, 90, {town = 'Berlin', FIO = {fname = 'X', sname = 'Y'}}}, {{'+', 2, 1}})
-town:select()
+town:select{}
 name:drop()
-town:select()
+town:select{}
 s:drop()
 
 -- Check replace with tuple with map having numeric keys that
@@ -227,7 +227,7 @@ s:insert{9} -- ok
 s:insert{10, {}} -- ok
 s:insert{11, {{b = 1}}} -- ok
 s:insert{12, {{a = box.NULL}}} -- ok
-s.index.sk:select()
+s.index.sk:select{}
 s:drop()
 
 --

--- a/test/engine/multikey.test.lua
+++ b/test/engine/multikey.test.lua
@@ -23,14 +23,14 @@ s:insert({2, {3, 4, 5}, {{fname='Ivan', sname='Ivanych'}}})
 _ = s:create_index('arr_idx', {unique = true, parts = {{2, 'unsigned', path = '[*]'}}})
 -- Non-unique multikey index; two multikey indexes per space.
 arr_idx = s:create_index('arr_idx', {unique = false, parts = {{2, 'unsigned', path = '[*]'}}})
-arr_idx:select()
+arr_idx:select{}
 idx:get({'James', 'Bond'})
 idx:get({'Ivan', 'Ivanych'})
 idx:get({'Vasya', 'Pupkin'})
-idx:select()
+idx:select{}
 s:insert({3, {1, 2}, {{fname='Vasya', sname='Pupkin'}}})
 s:insert({4, {1}, {{fname='James', sname='Bond'}}})
-idx:select()
+idx:select{}
 -- Duplicates in multikey parts.
 s:insert({5, {1, 1, 1}, {{fname='A', sname='B'}, {fname='C', sname='D'}, {fname='A', sname='B'}}})
 arr_idx:select({1})
@@ -43,16 +43,16 @@ _ = idx:delete({'Vasya', 'Pupkin'})
 s:insert({6, {1, 2}, {{fname='Vasya', sname='Pupkin'}}})
 s:insert({7, {1}, {{fname='James', sname='Bond'}}})
 arr_idx:select({1})
-idx:select()
+idx:select{}
 -- Snapshot & recovery.
 box.snapshot()
 test_run:cmd("restart server default")
 s = box.space["withdata"]
 idx = s.index["idx"]
 arr_idx = s.index["arr_idx"]
-s:select()
-idx:select()
-arr_idx:select()
+s:select{}
+idx:select{}
+arr_idx:select{}
 s:drop()
 
 -- Assymetric multikey index paths.
@@ -74,10 +74,10 @@ s:insert({3, {3, 3, 2, 2, 1, 1}})
 idx0:get(2)
 idx0:get(1)
 idx0:get(3)
-idx0:select()
+idx0:select{}
 _ = idx0:delete(2)
 idx0:get(2)
-idx0:select()
+idx0:select{}
 s:drop()
 
 -- Test user JSON endpoint doesn't fail in case of multikey index.
@@ -91,21 +91,21 @@ s = box.schema.space.create('withdata', {engine = engine})
 pk = s:create_index('pk')
 idx0 = s:create_index('idx0', {parts = {{2, 'int', path = '[*]', is_nullable = true}}})
 s:insert({1, {1, 1, 3, 1}})
-idx0:select()
+idx0:select{}
 s:replace({1, {5, 5, 5, 1, 3, 3}})
-idx0:select()
+idx0:select{}
 -- Test update.
 s:update(1, {{'=', 2, {20, 10, 30, 30}}})
-idx0:select()
+idx0:select{}
 box.snapshot()
 test_run:cmd("restart server default")
 s = box.space.withdata
-s:select()
+s:select{}
 idx0 = s.index.idx0
-idx0:select()
+idx0:select{}
 s:insert({2, {2, 4, 2}})
-s:select()
-idx0:select()
+s:select{}
+idx0:select{}
 s:drop()
 
 -- Test upsert & reverse iterators.
@@ -119,9 +119,9 @@ s:insert({2, {3, 3, 4, 4, 4}})
 s:insert({3, {5, 5, 5, 5, 6, 6, 6, 6}})
 idx0:select(5, {iterator = box.index.LT})
 idx0:select(5, {iterator = box.index.GE})
-idx0:select()
+idx0:select{}
 s:upsert({3, {5, 5, 5, 5, 6, 6, 6, 6}}, {{'=', 2, {1, 1, 2, 2, 3, 3, 4, 4}}})
-idx0:select()
+idx0:select{}
 s:drop()
 
 -- Test multikey index with epsent data (1 part, is_nullable = false).
@@ -144,13 +144,13 @@ s:insert({2, {{fname='A2_1'}, {fname='B2_1', name='ZB2_1'}, {fname='C2_1'}, {nam
 s:replace({2, {{fname='A2_2'}, {fname='B2_2', name='ZB2_2'}, {fname='C2_2'}, {name="DUP"}, {name="DUP"}}})
 s:replace({2, {{fname='A2_3'}, {fname='B2_3', name='ZB2_3'}, {fname='C2_3'}, {name="DUP"}, {name='CONFLICT1'}, {name='CONFLICT2'}, {name="DUP"}}})
 s:replace({2, {{fname='A2_4'}, {fname='B2_4', name='ZB2_4'}, {fname='C2_4'}, {name="DUP"}, {name='CONFLICT2'}, {name='CONFLICT1'}, {name="DUP"}}})
-idx0:select()
+idx0:select{}
 box.snapshot()
 test_run:cmd("restart server default")
 s = box.space.withdata
 idx0 = s.index.idx0
-s:select()
-idx0:select()
+s:select{}
+idx0:select{}
 s:drop()
 
 -- Test multikey index with epsent data (2 parts, is_nullable = true).
@@ -161,27 +161,27 @@ pk = s:create_index('pk')
 idx0 = s:create_index('idx0', {unique=false, parts = {{2, 'str', path = '[*].name', is_nullable=true}}})
 -- No idx0 index data at all.
 s:insert({0, {{fname='A0'}, {fname='B0'}, {fname='C0'}}})
-idx0:select()
+idx0:select{}
 -- Only one field corresponds idx0.
 s:insert({1, {{fname='A1'}, {fname='B1', name='ZB1'}, {fname='C1'}}})
 s:insert({2, {{fname='A2'}, {fname='B2', name='ZB2'}, {fname='C2'}, {name="DUP"}, {name="DUP"}}})
-idx0:select()
+idx0:select{}
 s:replace({1, {{fname='A3'}, {fname='B3', name='ZB3'}, {fname='C3'}}})
-idx0:select()
+idx0:select{}
 s:replace({1, {{fname='A4', name='ZA4'}, {fname='B4', name='ZB4'}, {fname='C4', name='ZC4'}, {name="DUP"}, {name="DUP"}, {name="DUP"}}})
-idx0:select()
+idx0:select{}
 s:replace({1, {{fname='A5', name='ZA5'}, {fname='B5'}, {fname='C5'}, {name="DUP"}, {name="DUP"}, {name="DUP"}}})
-idx0:select()
-s:select()
+idx0:select{}
+s:select{}
 box.snapshot()
 test_run:cmd("restart server default")
 s = box.space.withdata
 idx0 = s.index.idx0
-s:select()
-idx0:select()
+s:select{}
+idx0:select{}
 -- Test multikey index alter.
 idx0:alter({parts = {{2, 'str', path = '[*].fname', is_nullable=true}}})
-idx0:select()
+idx0:select{}
 s:drop()
 
 -- Create unique multikey index on space with tuple which
@@ -193,7 +193,7 @@ i = s:create_index('pk')
 s:replace{1, {{1, 1}}}
 s:replace{2, {{2, 3}}}
 i2 = s:create_index('sk', {parts = {{2, 'unsigned', path = '[1][*]'}}})
-i2:select()
+i2:select{}
 s:drop()
 
 --
@@ -223,7 +223,7 @@ s:insert{5, box.NULL} -- ok
 s:insert{6, {box.NULL}} -- ok
 s:insert{7, {}} -- ok
 s:insert{8, {2}} -- ok
-s.index.sk:select()
+s.index.sk:select{}
 s:drop()
 
 --
@@ -235,5 +235,5 @@ _ = s:create_index('pk')
 _ = s:create_index('sk', {parts = {{'[2][*]', 'unsigned'}}})
 s:insert{1, {a = 1}} -- error
 s:insert{2, {1}} -- ok
-s.index.sk:select()
+s.index.sk:select{}
 s:drop()

--- a/test/engine/null.test.lua
+++ b/test/engine/null.test.lua
@@ -218,11 +218,11 @@ _ = s:auto_increment{'888', 8.88, box.NULL, true, 8.88}
 _ = s:auto_increment{'999', 9.99, -999, box.NULL, false}
 _ = s:auto_increment{'000', 0.00, -000, true, box.NULL}
 
-s.index.i1:select()
-s.index.i2:select()
-s.index.i3:select()
-s.index.i4:select()
-s.index.i5:select()
+s.index.i1:select{}
+s.index.i2:select{}
+s.index.i3:select{}
+s.index.i4:select{}
+s.index.i5:select{}
 
 s:drop()
 

--- a/test/engine/recover_snapshot_wal.test.lua
+++ b/test/engine/recover_snapshot_wal.test.lua
@@ -39,7 +39,7 @@ space = box.space['test']
 index = space.index['primary']
 i = 0
 err = nil
-for _, t in space:pairs() do                                    \
+for _, t in space:pairs{} do                                    \
     if t[1] ~= i then                                           \
         err = {i, t}                                            \
         break                                                   \

--- a/test/engine/replica_join.test.lua
+++ b/test/engine/replica_join.test.lua
@@ -17,10 +17,10 @@ test_run:cmd("create server replica with rpl_master=default, script='replication
 test_run:cmd("start server replica")
 test_run:wait_lsn('replica', 'default')
 test_run:cmd('switch replica')
-box.space.test:select()
-box.space.test.index.secondary:select()
-box.space.test2:select()
-box.space.test3:select()
+box.space.test:select{}
+box.space.test.index.secondary:select{}
+box.space.test2:select{}
+box.space.test3:select{}
 test_run:cmd('switch default')
 test_run:cmd("stop server replica")
 _ = test_run:cmd("cleanup server replica")
@@ -44,10 +44,10 @@ test_run:cmd("deploy server replica")
 test_run:cmd("start server replica")
 test_run:wait_lsn('replica', 'default')
 test_run:cmd('switch replica')
-box.space.test:select()
-box.space.test.index.secondary:select()
-box.space.test2:select()
-box.space.test3:select()
+box.space.test:select{}
+box.space.test.index.secondary:select{}
+box.space.test2:select{}
+box.space.test3:select{}
 test_run:cmd('switch default')
 test_run:cmd("stop server replica")
 _ = test_run:cmd("cleanup server replica")
@@ -60,10 +60,10 @@ test_run:cmd("deploy server replica")
 test_run:cmd("start server replica")
 test_run:wait_lsn('replica', 'default')
 test_run:cmd('switch replica')
-box.space.test:select()
-box.space.test.index.secondary:select()
-box.space.test2:select()
-box.space.test3:select()
+box.space.test:select{}
+box.space.test.index.secondary:select{}
+box.space.test2:select{}
+box.space.test3:select{}
 test_run:cmd('switch default')
 test_run:cmd("stop server replica")
 _ = test_run:cmd("cleanup server replica")
@@ -86,10 +86,10 @@ test_run:cmd("deploy server replica")
 test_run:cmd("start server replica")
 test_run:wait_lsn('replica', 'default')
 test_run:cmd('switch replica')
-box.space.test:select()
-box.space.test.index.secondary:select()
-box.space.test2:select()
-box.space.test3:select()
+box.space.test:select{}
+box.space.test.index.secondary:select{}
+box.space.test2:select{}
+box.space.test3:select{}
 test_run:cmd('switch default')
 test_run:cmd("stop server replica")
 _ = test_run:cmd("cleanup server replica")
@@ -108,9 +108,9 @@ test_run:cmd("start server replica")
 test_run:wait_lsn('replica', 'default')
 test_run:cmd('switch replica')
 box.space.test.id
-box.space.test:select()
-box.space.test2:select()
-box.space.test3:select()
+box.space.test:select{}
+box.space.test2:select{}
+box.space.test3:select{}
 test_run:cmd('switch default')
 test_run:cmd("stop server replica")
 _ = test_run:cmd("cleanup server replica")
@@ -128,7 +128,7 @@ test_run:cmd("start server replica")
 test_run:wait_lsn('replica', 'default')
 test_run:cmd('restart server replica')
 test_run:cmd('switch replica')
-box.space.test:select()
+box.space.test:select{}
 test_run:cmd('switch default')
 test_run:cmd("stop server replica")
 _ = test_run:cmd("cleanup server replica")

--- a/test/engine/tree_min_max_count.test.lua
+++ b/test/engine/tree_min_max_count.test.lua
@@ -13,7 +13,7 @@ space0:insert({2, "AAAA"})
 space0:insert({3, "AAAA"})
 space0:insert({4, "AAAA"})
 
-index0:select()
+index0:select{}
 index0:max(2)
 index0:min(2)
 index0:count(2)
@@ -25,7 +25,7 @@ space0:insert({20, "AAAA"})
 space0:insert({30, "AAAA"})
 space0:insert({40, "AAAA"})
 
-index0:select()
+index0:select{}
 index0:max(15)
 index0:min(15)
 index0:count(15)
@@ -37,7 +37,7 @@ space0:insert({-2, "AAAA"})
 space0:insert({-3, "AAAA"})
 space0:insert({-4, "AAAA"})
 
-index0:select()
+index0:select{}
 index0:max(0)
 index0:min(0)
 index0:count(0)
@@ -57,7 +57,7 @@ space1:insert({2, "AAAA"})
 space1:insert({3, "AAAA"})
 space1:insert({4, "AAAA"})
 
-index1:select()
+index1:select{}
 index1:max(2)
 index1:min(2)
 index1:count(2)
@@ -69,7 +69,7 @@ space1:insert({20, "AAAA"})
 space1:insert({30, "AAAA"})
 space1:insert({40, "AAAA"})
 
-index1:select()
+index1:select{}
 index1:max(15)
 index1:min(15)
 index1:count(15)
@@ -81,7 +81,7 @@ space1:insert({-2, "AAAA"})
 space1:insert({-3, "AAAA"})
 space1:insert({-4, "AAAA"})
 
-index1:select()
+index1:select{}
 index1:max(0)
 index1:min(0)
 index1:count(0)
@@ -94,7 +94,7 @@ space1:insert({2.5, "AAAA"})
 space1:insert({3.5, "AAAA"})
 space1:insert({4.5, "AAAA"})
 
-index1:select()
+index1:select{}
 index1:max(1)
 index1:min(1)
 index1:count(1)
@@ -113,7 +113,7 @@ space2:insert({'2', "AAAA"})
 space2:insert({'3', "AAAA"})
 space2:insert({'4', "AAAA"})
 
-index2:select()
+index2:select{}
 index2:max('2')
 index2:min('2')
 index2:count('2')
@@ -125,7 +125,7 @@ space2:insert({'20', "AAAA"})
 space2:insert({'30', "AAAA"})
 space2:insert({'40', "AAAA"})
 
-index2:select()
+index2:select{}
 index2:max('15')
 index2:min('15')
 index2:count('15')
@@ -137,7 +137,7 @@ space2:insert({'-2', "AAAA"})
 space2:insert({'-3', "AAAA"})
 space2:insert({'-4', "AAAA"})
 
-index2:select()
+index2:select{}
 index2:max('0')
 index2:min('0')
 index2:count('0')
@@ -156,7 +156,7 @@ space3:insert({2, "AAAA"})
 space3:insert({3, "AAAA"})
 space3:insert({4, "AAAA"})
 
-index3:select()
+index3:select{}
 index3:max(2)
 index3:min(2)
 index3:count(2)
@@ -168,7 +168,7 @@ space3:insert({20, "AAAA"})
 space3:insert({30, "AAAA"})
 space3:insert({40, "AAAA"})
 
-index3:select()
+index3:select{}
 index3:max(15)
 index3:min(15)
 index3:count(15)
@@ -187,7 +187,7 @@ space4:insert({2, "AAAA"})
 space4:insert({3, "AAAA"})
 space4:insert({4, "AAAA"})
 
-index4:select()
+index4:select{}
 index4:max(2)
 index4:min(2)
 index4:count(2)
@@ -199,7 +199,7 @@ space4:insert({20, "AAAA"})
 space4:insert({30, "AAAA"})
 space4:insert({40, "AAAA"})
 
-index4:select()
+index4:select{}
 index4:max(15)
 index4:min(15)
 index4:count(15)
@@ -211,7 +211,7 @@ space4:insert({'2', "AAAA"})
 space4:insert({'3', "AAAA"})
 space4:insert({'4', "AAAA"})
 
-index4:select()
+index4:select{}
 index4:max('2')
 index4:min('2')
 index4:count('2')
@@ -223,7 +223,7 @@ space4:insert({'20', "AAAA"})
 space4:insert({'30', "AAAA"})
 space4:insert({'40', "AAAA"})
 
-index4:select()
+index4:select{}
 index4:max('15')
 index4:min('15')
 index4:count('15')
@@ -235,7 +235,7 @@ space4:insert({'-2', "AAAA"})
 space4:insert({'-3', "AAAA"})
 space4:insert({'-4', "AAAA"})
 
-index4:select()
+index4:select{}
 index4:max('0')
 index4:min('0')
 index4:count('0')
@@ -247,7 +247,7 @@ space4:insert({-2, "AAAA"})
 space4:insert({-3, "AAAA"})
 space4:insert({-4, "AAAA"})
 
-index4:select()
+index4:select{}
 index4:max(0)
 index4:min(0)
 index4:count(0)
@@ -268,7 +268,7 @@ space5:insert({1, 2})
 space5:insert({1, 3})
 space5:insert({1, -4})
 
-index5:select()
+index5:select{}
 index5:max({1})
 index5:min({1})
 index5:count({1})
@@ -284,7 +284,7 @@ space5:insert({2, 2})
 space5:insert({2, 3})
 space5:insert({2, -4})
 
-index5:select()
+index5:select{}
 index5:max({2})
 index5:min({2})
 index5:count({2})
@@ -306,7 +306,7 @@ space6:insert({1, '2'})
 space6:insert({1, '3'})
 space6:insert({1, '-4'})
 
-index6:select()
+index6:select{}
 index6:max({1})
 index6:min({1})
 index6:count({1})
@@ -322,7 +322,7 @@ space6:insert({2, '2'})
 space6:insert({2, '3'})
 space6:insert({2, '-4'})
 
-index6:select()
+index6:select{}
 index6:max({2})
 index6:min({2})
 index6:count({2})

--- a/test/engine/truncate.test.lua
+++ b/test/engine/truncate.test.lua
@@ -10,7 +10,7 @@ s = box.schema.create_space('test', {engine = engine})
 _ = s:create_index('pk')
 _ = s:insert{123}
 box.begin() s:truncate() box.commit()
-s:select()
+s:select{}
 s:drop()
 
 --
@@ -20,9 +20,9 @@ s:drop()
 _ = box.space._space:insert{512, 1, 'test', engine, 0, {temporary = false}, {}}
 _ = box.space._index:insert{512, 0, 'pk', 'tree', {unique = true}, {{0, 'unsigned'}}}
 _ = box.space.test:insert{123}
-box.space.test:select()
+box.space.test:select{}
 box.space.test:truncate()
-box.space.test:select()
+box.space.test:select{}
 box.space.test:drop()
 
 --
@@ -54,7 +54,7 @@ s:drop()
 s = box.schema.create_space('test', {engine = engine})
 _ = s:create_index('pk')
 s:truncate()
-s:select()
+s:select{}
 s:drop()
 
 --
@@ -68,15 +68,15 @@ _ = s:insert{1, 3, 'a'}
 _ = s:insert{2, 2, 'b'}
 _ = s:insert{3, 1, 'c'}
 s:truncate()
-s.index.i1:select()
-s.index.i2:select()
-s.index.i3:select()
+s.index.i1:select{}
+s.index.i2:select{}
+s.index.i3:select{}
 _ = s:insert{10, 30, 'x'}
 _ = s:insert{20, 20, 'y'}
 _ = s:insert{30, 10, 'z'}
-s.index.i1:select()
-s.index.i2:select()
-s.index.i3:select()
+s.index.i1:select{}
+s.index.i2:select{}
+s.index.i3:select{}
 s:drop()
 
 --
@@ -139,14 +139,14 @@ s1 = box.space.test1
 s2 = box.space.test2
 s3 = box.space.test3
 s4 = box.space.test4
-s1.index.i1:select()
-s1.index.i2:select()
-s2.index.i1:select()
-s2.index.i2:select()
-s3.index.i1:select()
-s3.index.i2:select()
-s4.index.i1:select()
-s4.index.i2:select()
+s1.index.i1:select{}
+s1.index.i2:select{}
+s2.index.i1:select{}
+s2.index.i2:select{}
+s3.index.i1:select{}
+s3.index.i2:select{}
+s4.index.i1:select{}
+s4.index.i2:select{}
 s1:drop()
 s2:drop()
 s3:drop()
@@ -162,10 +162,10 @@ box.schema.user.grant('guest', 'execute', 'universe')
 box.schema.user.grant('guest', 'read', 'space', 'access_truncate')
 con = require('net.box').connect(box.cfg.listen)
 con:eval([[box.space.access_truncate:truncate()]])
-con.space.access_truncate:select()
+con.space.access_truncate:select{}
 box.schema.user.grant('guest', 'write', 'space', 'access_truncate')
 con:eval([[box.space.access_truncate:truncate()]])
-con.space.access_truncate:select()
+con.space.access_truncate:select{}
 con:close()
 box.schema.user.revoke('guest', 'execute', 'universe')
 box.schema.user.revoke('guest', 'read,write', 'space', 'access_truncate')

--- a/test/engine/update.test.lua
+++ b/test/engine/update.test.lua
@@ -131,8 +131,8 @@ pk = s:create_index('pk')
 sk = s:create_index('sk', {parts = {2, 'unsigned'}})
 s:insert{1, 1, 1}
 box.begin() s:update(1, {{'=', 2, 2}}) s:update(1, {{'=', 3, 2}}) box.commit()
-pk:select()
-sk:select()
+pk:select{}
+sk:select{}
 s:drop()
 
 --

--- a/test/engine/upsert.test.lua
+++ b/test/engine/upsert.test.lua
@@ -431,7 +431,7 @@ s:replace({1, 1, 1})
 box.snapshot()
 s:upsert({1, 1}, {{'+', 2, 2}})
 s:upsert({1, 1}, {{'+', 3, 4}})
-s:select()
+s:select{}
 
 s:drop()
 

--- a/test/replication/autobootstrap.test.lua
+++ b/test/replication/autobootstrap.test.lua
@@ -45,11 +45,11 @@ vclock_diff(vclock1, vclock2)
 -- Check result
 --
 _ = test_run:cmd("switch autobootstrap1")
-box.space.test:select()
+box.space.test:select{}
 _ = test_run:cmd("switch autobootstrap2")
-box.space.test:select()
+box.space.test:select{}
 _ = test_run:cmd("switch autobootstrap3")
-box.space.test:select()
+box.space.test:select{}
 _ = test_run:cmd("switch default")
 
 
@@ -64,7 +64,7 @@ box.session.su('test_u')
 _ = box.schema.space.create('test_u'):create_index('pk')
 box.session.su('admin')
 _ = box.space.test_u:replace({1, 2, 3, 4})
-box.space.test_u:select()
+box.space.test_u:select{}
 
 box.schema.user.revoke('test_u', 'read', 'space', '_space_sequence')
 box.schema.user.revoke('test_u', 'write', 'space', '_index')
@@ -79,9 +79,9 @@ _ = test_run:wait_vclock("autobootstrap2", vclock)
 _ = test_run:wait_vclock("autobootstrap3", vclock)
 
 _ = test_run:cmd("switch autobootstrap2")
-box.space.test_u:select()
+box.space.test_u:select{}
 _ = test_run:cmd("switch autobootstrap3")
-box.space.test_u:select()
+box.space.test_u:select{}
 
 --
 -- Rebootstrap one node and check that others follow.
@@ -90,7 +90,7 @@ _ = test_run:cmd("switch autobootstrap1")
 _ = test_run:cmd("restart server autobootstrap1 with cleanup=1, args ='0.1'")
 
 _ = box.space.test_u:replace({5, 6, 7, 8})
-box.space.test_u:select()
+box.space.test_u:select{}
 
 _ = test_run:cmd("switch default")
 test_run:wait_fullmesh(SERVERS)
@@ -101,9 +101,9 @@ _ = test_run:wait_vclock("autobootstrap2", vclock)
 _ = test_run:wait_vclock("autobootstrap3", vclock)
 
 _ = test_run:cmd("switch autobootstrap2")
-box.space.test_u:select()
+box.space.test_u:select{}
 _ = test_run:cmd("switch autobootstrap3")
-box.space.test_u:select()
+box.space.test_u:select{}
 
 _ = test_run:cmd("switch default")
 

--- a/test/replication/autobootstrap_guest.test.lua
+++ b/test/replication/autobootstrap_guest.test.lua
@@ -44,11 +44,11 @@ vclock_diff(vclock1, vclock2)
 -- Check result
 --
 _ = test_run:cmd("switch autobootstrap_guest1")
-box.space.test:select()
+box.space.test:select{}
 _ = test_run:cmd("switch autobootstrap_guest2")
-box.space.test:select()
+box.space.test:select{}
 _ = test_run:cmd("switch autobootstrap_guest3")
-box.space.test:select()
+box.space.test:select{}
 _ = test_run:cmd("switch default")
 
 --

--- a/test/replication/before_replace.test.lua
+++ b/test/replication/before_replace.test.lua
@@ -64,18 +64,18 @@ vclock2 = test_run:wait_cluster_vclock(SERVERS, vclock)
 -- Check that all replicas converged to the same data
 -- and the state persists after restart.
 test_run:cmd("switch autobootstrap1")
-box.space.test:select()
+box.space.test:select{}
 test_run:cmd('restart server autobootstrap1 with args="0.1"')
-box.space.test:select()
+box.space.test:select{}
 test_run:cmd("switch autobootstrap2")
-box.space.test:select()
+box.space.test:select{}
 test_run:cmd('restart server autobootstrap2 with args="0.1"')
-box.space.test:select()
+box.space.test:select{}
 test_run:cmd("switch autobootstrap3")
-box.space.test:select()
+box.space.test:select{}
 push_err
 test_run:cmd('restart server autobootstrap3 with args="0.1"')
-box.space.test:select()
+box.space.test:select{}
 
 -- Cleanup.
 test_run:cmd("switch default")
@@ -108,13 +108,13 @@ _ = test_run:wait_vclock('replica', vclock)
 -- Check that replace{1, 2} coming from the master was suppressed
 -- by the before_replace trigger on the replica.
 test_run:cmd("switch replica")
-box.space.test:select() -- [1, 2]
+box.space.test:select{} -- [1, 2]
 
 -- Check that master's component of replica's vclock was bumped
 -- so that the replica doesn't apply replace{1, 2} after restart
 -- while syncing with the master.
 test_run:cmd("restart server replica")
-box.space.test:select() -- [1, 2]
+box.space.test:select{} -- [1, 2]
 
 test_run:cmd("switch default")
 test_run:cmd("stop server replica")

--- a/test/replication/force_recovery.test.lua
+++ b/test/replication/force_recovery.test.lua
@@ -30,7 +30,7 @@ box.cfg{force_recovery = true}
 test_run:cmd("start server test with wait=False")
 test_run:cmd("switch test")
 test_run:wait_upstream(1, {message_re = 'Missing %.xlog file', status = 'loading'})
-box.space.test:select()
+box.space.test:select{}
 test_run:cmd("switch default")
 box.cfg{force_recovery = false}
 

--- a/test/replication/gh-5874-qsync-txn-recovery.test.lua
+++ b/test/replication/gh-5874-qsync-txn-recovery.test.lua
@@ -77,9 +77,9 @@ test_run:cmd('restart server default')
 async = box.space.async
 sync = box.space.sync
 loc = box.space.loc
-async:select()
-sync:select()
-loc:select()
+async:select{}
+sync:select{}
+loc:select{}
 async:drop()
 sync:drop()
 loc:drop()

--- a/test/replication/hot_standby.test.lua
+++ b/test/replication/hot_standby.test.lua
@@ -93,7 +93,7 @@ _select(1, 10)
 -- Check box.info.vclock is updated during hot standby.
 test_run:cmd("switch hot_standby")
 _wait_lsn(10)
-box.space.tweedledum.index[1]:select()
+box.space.tweedledum.index[1]:select{}
 
 test_run:cmd("switch replica")
 _wait_lsn(10)

--- a/test/replication/join_without_snap.test.lua
+++ b/test/replication/join_without_snap.test.lua
@@ -19,7 +19,7 @@ test_run:cmd('create server replica with rpl_master=default, script="replication
 test_run:cmd('start server replica')
 test_run:cmd('switch replica')
 
-box.space.test:select()
+box.space.test:select{}
 
 test_run:cmd('switch default')
 test_run:cmd('stop server replica')

--- a/test/replication/local_spaces.test.lua
+++ b/test/replication/local_spaces.test.lua
@@ -71,19 +71,19 @@ box.space.test4.is_local
 box.space.test4.temporary
 box.space.test5.is_local
 box.space.test5.temporary
-box.space.test1:select()
-box.space.test2:select()
-box.space.test3:select()
-box.space.test4:select()
-box.space.test5:select()
+box.space.test1:select{}
+box.space.test2:select{}
+box.space.test3:select{}
+box.space.test4:select{}
+box.space.test5:select{}
 
 -- To check truncation fill replica's copy with 2 entries
 _=box.space.test4:insert{4}
 _=box.space.test4:insert{5}
 _=box.space.test5:insert{4}
 _=box.space.test5:insert{5}
-box.space.test4:select()
-box.space.test5:select()
+box.space.test4:select{}
+box.space.test5:select{}
 
 -- truncate temp & local space on master
 test_run:cmd("switch default")
@@ -99,8 +99,8 @@ test_run:cmd("switch replica")
 box.space._truncate:count()
 
 -- the affected space must be unchanged
-box.space.test4:select()
-box.space.test5:select()
+box.space.test4:select{}
+box.space.test5:select{}
 
 
 box.cfg{read_only = true} -- local spaces ignore read_only
@@ -118,13 +118,13 @@ vclock[0] = nil
 _ = test_run:wait_vclock('replica', vclock)
 
 test_run:cmd("switch replica")
-box.space.test1:select()
-box.space.test2:select()
-box.space.test3:select()
+box.space.test1:select{}
+box.space.test2:select{}
+box.space.test3:select{}
 test_run:cmd("restart server replica")
-box.space.test1:select()
-box.space.test2:select()
-box.space.test3:select()
+box.space.test1:select{}
+box.space.test2:select{}
+box.space.test3:select{}
 
 test_run:cmd("switch default")
 test_run:cmd("stop server replica")
@@ -133,9 +133,9 @@ test_run:cmd("delete server replica")
 test_run:cleanup_cluster()
 box.schema.user.revoke('guest', 'replication')
 
-s1:select()
-s2:select()
-s3:select()
+s1:select{}
+s2:select{}
+s3:select{}
 
 s1:drop()
 s2:drop()

--- a/test/replication/on_replace.test.lua
+++ b/test/replication/on_replace.test.lua
@@ -69,12 +69,12 @@ while (box.info.replication[3 - box.info.id].downstream.status ~= 'stopped') do 
 test_run:cmd('switch on_replace2')
 while (box.info.replication[3 - box.info.id].upstream.status ~= 'stopped') do fiber.sleep(0.00001) end
 box.info.replication[3 - box.info.id].upstream.message
-box.space.s1:select()
-box.space.s2:select()
+box.space.s1:select{}
+box.space.s2:select{}
 
 test_run:cmd('switch on_replace1')
-box.space.s1:select()
-box.space.s2:select()
+box.space.s1:select{}
+box.space.s2:select{}
 
 -- gh-2798 on_replace on slave server with local data change is allowed
 test_run:cmd('switch on_replace2')
@@ -86,7 +86,7 @@ replication = box.cfg.replication
 box.cfg{replication = {}}
 box.cfg{replication = replication}
 
-s3:select()
+s3:select{}
 
 _ = test_run:cmd('switch default')
 test_run:drop_cluster(SERVERS)

--- a/test/replication/quorum.test.lua
+++ b/test/replication/quorum.test.lua
@@ -112,7 +112,7 @@ test_run:cmd("create server replica with rpl_master=default, script='replication
 test_run:cmd("start server replica")
 test_run:cmd("switch replica")
 box.info.status -- running
-box.space.test:select()
+box.space.test:select{}
 test_run:cmd("switch default")
 test_run:cmd("stop server replica")
 listen = box.cfg.listen
@@ -129,7 +129,7 @@ vclock[0] = nil
 _ = test_run:wait_vclock("replica", vclock)
 test_run:cmd("switch replica")
 box.info.status -- running
-box.space.test:select()
+box.space.test:select{}
 test_run:cmd("switch default")
 test_run:cmd("stop server replica")
 test_run:cmd("cleanup server replica")
@@ -149,7 +149,7 @@ vclock = test_run:get_vclock("master_quorum1")
 vclock[0] = nil
 _ = test_run:wait_vclock("master_quorum2", vclock)
 test_run:cmd("switch master_quorum2")
-box.space.test:select()
+box.space.test:select{}
 test_run:cmd("switch default")
 -- Cleanup.
 test_run:drop_cluster(SERVERS)

--- a/test/replication/recover_missing_xlog.test.lua
+++ b/test/replication/recover_missing_xlog.test.lua
@@ -34,7 +34,7 @@ test_run:cmd('start server autobootstrap1 with args="0.1"')
 test_run:cmd("switch autobootstrap1")
 for i = 10, 19 do box.space.test:insert{i, 'test' .. i} end
 fiber = require('fiber')
-box.space.test:select()
+box.space.test:select{}
 
 -- Cleanup.
 test_run:cmd('switch default')

--- a/test/replication/replica_rejoin.test.lua
+++ b/test/replication/replica_rejoin.test.lua
@@ -29,7 +29,7 @@ test_run:cmd("create server replica with rpl_master=master, script='replication/
 test_run:cmd("start server replica")
 test_run:cmd("switch replica")
 box.info.replication[1].upstream.status == 'follow' or log.error(box.info)
-box.space.test:select()
+box.space.test:select{}
 test_run:cmd("switch master")
 test_run:cmd("stop server replica")
 
@@ -59,7 +59,7 @@ test_run:cmd("start server replica")
 box.info.replication[2].downstream.vclock ~= nil or log.error(box.info)
 test_run:cmd("switch replica")
 box.info.replication[1].upstream.status == 'follow' or log.error(box.info)
-box.space.test:select()
+box.space.test:select{}
 test_run:cmd("switch master")
 
 -- Make sure the replica follows new changes.
@@ -68,12 +68,12 @@ vclock = test_run:get_vclock('master')
 vclock[0] = nil
 _ = test_run:wait_vclock('replica', vclock)
 test_run:cmd("switch replica")
-box.space.test:select()
+box.space.test:select{}
 
 -- Check that restart works as usual.
 test_run:cmd("restart server replica with args='true'")
 box.info.replication[1].upstream.status == 'follow' or log.error(box.info)
-box.space.test:select()
+box.space.test:select{}
 
 -- Check that rebootstrap is NOT initiated unless the replica
 -- is strictly behind the master.
@@ -93,7 +93,7 @@ box.cfg{checkpoint_count = checkpoint_count}
 test_run:cmd("start server replica with wait=False")
 test_run:cmd("switch replica")
 test_run:wait_upstream(1, {message_re = 'Missing %.xlog file', status = 'loading'})
-box.space.test:select()
+box.space.test:select{}
 
 --
 -- gh-3740: rebootstrap crashes if the master has rows originating
@@ -144,7 +144,7 @@ vclock[0] = nil
 _ = test_run:wait_vclock('master', vclock)
 -- Restart the replica. It should successfully rebootstrap.
 test_run:cmd("restart server replica with args='true'")
-box.space.test:select()
+box.space.test:select{}
 box.snapshot()
 box.space.test:replace{2}
 

--- a/test/replication/show_error_on_disconnect.test.lua
+++ b/test/replication/show_error_on_disconnect.test.lua
@@ -27,11 +27,11 @@ box.space.test:insert{3}
 -- Check error reporting.
 test_run:cmd("switch master_quorum1")
 box.cfg{replication = repl}
-box.space.test:select()
+box.space.test:select{}
 other_id = box.info.id % 2 + 1
 test_run:wait_upstream(other_id, {status = 'loading', message_re = 'Missing'})
 test_run:cmd("switch master_quorum2")
-box.space.test:select()
+box.space.test:select{}
 other_id = box.info.id % 2 + 1
 test_run:wait_upstream(other_id, {status = 'follow', message_re = box.NULL})
 test_run:wait_downstream(other_id, {status = 'stopped', message_re = 'Missing'})

--- a/test/replication/skip_conflict_row.test.lua
+++ b/test/replication/skip_conflict_row.test.lua
@@ -23,7 +23,7 @@ vclock[0] = nil
 _ = test_run:wait_vclock("replica", vclock)
 test_run:cmd("switch replica")
 test_run:wait_upstream(1, {status = 'follow', message_re = box.NULL})
-box.space.test:select()
+box.space.test:select{}
 
 test_run:cmd("switch default")
 box.info.status

--- a/test/replication/transaction.test.lua
+++ b/test/replication/transaction.test.lua
@@ -28,7 +28,7 @@ box.begin() s:insert({5, 'm'}) s:insert({6, 'm'}) s:insert({7, 'm'}) box.commit(
 test_run:cmd("switch replica")
 -- nothing was applied
 v1[1] == box.info.vclock[1]
-box.space.test:select()
+box.space.test:select{}
 -- check replication status
 box.info.replication[1].upstream.status
 box.info.replication[1].upstream.message
@@ -43,7 +43,7 @@ box.cfg{replication = replication}
 -- flush wal
 box.space.l_space:replace({1})
 v1[1] + 2 == box.info.vclock[1]
-box.space.test:select()
+box.space.test:select{}
 -- check replication status
 box.info.replication[1].upstream.status
 box.info.replication[1].upstream.message
@@ -53,14 +53,14 @@ test_run:cmd("switch default")
 test_run:cmd("restart server replica")
 test_run:cmd("switch replica")
 
-box.space.test:select()
+box.space.test:select{}
 -- set skip conflict rows and check that non-conflicting were applied
 replication = box.cfg.replication
 box.cfg{replication = {}, replication_skip_conflict = true}
 box.cfg{replication = replication}
 
 -- check last transaction applied without conflicting row
-box.space.test:select()
+box.space.test:select{}
 box.info.replication[1].upstream.status
 
 -- make some new conflicting rows with skip-conflicts
@@ -73,14 +73,14 @@ box.begin() s:insert({8, 'm'}) s:insert({9, 'm'}) box.commit()
 
 test_run:cmd("switch replica")
 -- vclock should be increased but rows skipped
-box.space.test:select()
+box.space.test:select{}
 
 -- check restart does not change something
 test_run:cmd("switch default")
 test_run:cmd("restart server replica")
 test_run:cmd("switch replica")
 
-box.space.test:select()
+box.space.test:select{}
 test_run:wait_upstream(1, {status = 'follow'})
 
 test_run:cmd("switch default")

--- a/test/sql-tap/analyze9.test.lua
+++ b/test/sql-tap/analyze9.test.lua
@@ -1079,7 +1079,7 @@ test:do_execsql_test(
 
 local inject_stat_error_func = function (space_name)
     local space = box.space[space_name]
-    local stats = space:select()
+    local stats = space:select{}
     for _, stat in pairs(stats) do
         space:delete(get_pk(space, stat))
         local new_tuple = {"no such tbl"}

--- a/test/sql-tap/gh-4077-iproto-execute-no-bind.test.lua
+++ b/test/sql-tap/gh-4077-iproto-execute-no-bind.test.lua
@@ -63,7 +63,7 @@ test:is_deeply(exp_body, body, 'verify response body')
 
 -- Verify space data.
 local exp_res = {{1}}
-local res = box.space.T:pairs():map(box.tuple.totable):totable()
+local res = box.space.T:pairs{}:map(box.tuple.totable):totable()
 test:is_deeply(res, exp_res, 'verify inserted data')
 
 box.execute('drop table T')

--- a/test/sql/bind.test.lua
+++ b/test/sql/bind.test.lua
@@ -108,7 +108,7 @@ test_run:cmd("setopt delimiter ';'")
 if remote then
 	execute("CREATE TABLE t(a VARBINARY PRIMARY KEY);")
 	execute("INSERT INTO t VALUES (X'00');")
-	res = execute("SELECT typeof(?);", box.space.T:select()[1])
+	res = execute("SELECT typeof(?);", box.space.T:select{}[1])
 	assert(res['rows'][1][1] == "varbinary")
 	execute("DROP TABLE t;")
 end;

--- a/test/sql/foreign-keys.test.lua
+++ b/test/sql/foreign-keys.test.lua
@@ -159,7 +159,7 @@ box.execute('ALTER TABLE tc ADD CONSTRAINT fk1 FOREIGN KEY (id) REFERENCES tp(id
 -- Test that ADD/DROP CONSTRAINT return correct row_count value.
 --
 box.execute('SELECT row_count();')
-box.space._fk_constraint:select{}
+box.space._fk_constraint:select()
 box.execute('ALTER TABLE tc DROP CONSTRAINT fk1;')
 box.execute('SELECT row_count();')
 box.execute('DROP TABLE tc')
@@ -204,7 +204,7 @@ box.space.T:insert({'abc', 1})
 box.space.S:insert({'abc', 1})
 box.execute("CREATE INDEX i ON s (t_id);")
 box.execute("DELETE FROM t WHERE id = 'abc';")
-box.space.T:select()
+box.space.T:select{}
 
 box.space.S:drop()
 box.space.T:drop()

--- a/test/sql/gh-5427-lua-func-changes-result.test.lua
+++ b/test/sql/gh-5427-lua-func-changes-result.test.lua
@@ -9,7 +9,7 @@ box.schema.func.create('CORRUPT_SELECT', {
     returns = 'integer',
     body = [[
         function()
-            box.space.T:select()
+            box.space.T:select{}
             return 1
         end]],
     exports = {'LUA', 'SQL'},

--- a/test/sql/transitive-transactions.test.lua
+++ b/test/sql/transitive-transactions.test.lua
@@ -25,7 +25,7 @@ fk_violation_1 = function()
     end
 end;
 fk_violation_1();
-box.space.CHILD:select();
+box.space.CHILD:select{};
 
 fk_violation_2 = function()
     box.execute('START TRANSACTION;')
@@ -33,7 +33,7 @@ fk_violation_2 = function()
     box.commit()
 end;
 fk_violation_2();
-box.space.CHILD:select();
+box.space.CHILD:select{};
 
 fk_violation_3 = function()
     box.begin()
@@ -42,8 +42,8 @@ fk_violation_3 = function()
     box.commit()
 end;
 fk_violation_3();
-box.space.CHILD:select();
-box.space.PARENT:select();
+box.space.CHILD:select{};
+box.space.PARENT:select{};
 
 -- Make sure that setting 'defer_foreign_keys' works.
 --
@@ -60,13 +60,13 @@ fk_defer = function()
     box.commit()
 end;
 fk_defer();
-box.space.CHILD:select();
-box.space.PARENT:select();
+box.space.CHILD:select{};
+box.space.PARENT:select{};
 box.space._session_settings:update('sql_defer_foreign_keys', {{'=', 2, true}})
 box.rollback()
 fk_defer();
-box.space.CHILD:select();
-box.space.PARENT:select();
+box.space.CHILD:select{};
+box.space.PARENT:select{};
 box.space._session_settings:update('sql_defer_foreign_keys', {{'=', 2, false}})
 
 -- Cleanup
@@ -85,5 +85,5 @@ box.execute('INSERT INTO t VALUES (null);')
 box.execute('ROLLBACK TO sp;')
 box.execute('INSERT INTO t VALUES (null);')
 box.commit();
-box.space.T:select();
+box.space.T:select{};
 box.space.T:drop();

--- a/test/sql/types.test.lua
+++ b/test/sql/types.test.lua
@@ -221,7 +221,7 @@ box.space.T1:drop()
 
 box.execute("CREATE TABLE t1 (id INT PRIMARY KEY, a INT DEFAULT 18446744073709551615);")
 box.execute("INSERT INTO t1 (id) VALUES (1);")
-box.space.T1:select()
+box.space.T1:select{}
 box.space.T1:drop()
 
 -- Test that autoincrement accepts only max 2^63 - 1 .
@@ -326,7 +326,7 @@ box.space.T1:drop()
 
 box.execute("CREATE TABLE t1 (id INT PRIMARY KEY, a VARBINARY DEFAULT x'616263');")
 box.execute("INSERT INTO t1 (id) VALUES (1);")
-box.space.T1:select()
+box.space.T1:select{}
 box.space.T1:drop()
 
 box.execute("SELECT CAST(1 AS VARBINARY);")
@@ -366,7 +366,7 @@ s = box.schema.space.create('T', {format = format})
 ii = s:create_index('ii')
 s:insert({1, true, {1, 2}, {a = 3}, 'asd'})
 box.execute('UPDATE t SET b = false WHERE i = 1;')
-s:select()
+s:select{}
 s:drop()
 
 --

--- a/test/sql/upgrade.test.lua
+++ b/test/sql/upgrade.test.lua
@@ -36,8 +36,8 @@ assert(t1t.space_id == t2t.space_id)
 assert(t1t.space_id == box.space.T.id)
 
 box.execute("INSERT INTO T VALUES(1);")
-box.space.T:select()
-box.space.T_OUT:select()
+box.space.T:select{}
+box.space.T_OUT:select{}
 box.execute("SELECT * FROM T")
 box.execute("SELECT * FROM T")
 

--- a/test/swim/swim.test.lua
+++ b/test/swim/swim.test.lua
@@ -260,11 +260,11 @@ s2:delete()
 --
 -- Iterators.
 --
-function iterate() local t = {} for k, v in s:pairs() do table.insert(t, {k, v}) end return t end
+function iterate() local t = {} for k, v in s:pairs{} do table.insert(t, {k, v}) end return t end
 s = swim.new({generation = 0})
 iterate()
 s:cfg({uuid = uuid(1), uri = uri(), gc_mode = 'off'})
-s.pairs()
+s.pairs{}
 iterate()
 s:add_member({uuid = uuid(2), uri = uri()})
 iterate()

--- a/test/vinyl/cache.test.lua
+++ b/test/vinyl/cache.test.lua
@@ -373,7 +373,7 @@ box.cfg{vinyl_cache = 0}
 box.stat.vinyl().memory.tuple_cache
 -- Make sure cache is not populated if box.cfg.vinyl_cache is set to 0
 st1 = s.index.pk:stat().cache
-#s:select()
+#s:select{}
 for i = 1, 100 do s:get{i} end
 st2 = s.index.pk:stat().cache
 st2.put.rows - st1.put.rows

--- a/test/vinyl/compact.test.lua
+++ b/test/vinyl/compact.test.lua
@@ -14,8 +14,8 @@ space:insert({1})
 space:replace({1, 2})
 space:upsert({1},{{'+', 4, 5}}) -- bad upsert
 require('log').info(string.rep(" ", 1024))
-space:select()
-space:select()
+space:select{}
+space:select{}
 -- gh-1571: bad upsert should not log on reads
 test_run:grep_log('default', 'UPSERT operation failed', 400) == nil
 

--- a/test/vinyl/ddl.test.lua
+++ b/test/vinyl/ddl.test.lua
@@ -43,7 +43,7 @@ pk:alter{parts = {2, 'unsigned'}} -- success: space is empty now
 space:replace{1, 2}
 -- gh-3508 - Altering primary index of a vinyl space doesn't work as expected
 space:replace{2, 2}
-space:select()
+space:select{}
 space:drop()
 
 --
@@ -241,7 +241,7 @@ box.snapshot()
 s:replace{1, 1}
 s:delete{2}
 _ = s:create_index('secondary', {parts = {2, 'unsigned'}})
-s:select()
+s:select{}
 s:drop()
 
 --

--- a/test/vinyl/deferred_delete.test.lua
+++ b/test/vinyl/deferred_delete.test.lua
@@ -35,13 +35,13 @@ i2:stat().rows -- ditto
 -- Although there are only 5 tuples in the space, we have to look up
 -- overwritten tuples in the primary index hence 15 lookups per SELECT
 -- in a secondary index.
-i1:select()
+i1:select{}
 i1:stat().get.rows -- 5
 i1:stat().skip.rows -- 10
 pk:stat().lookup -- 15
 pk:stat().get.rows -- 5
 pk:stat().skip.rows -- 5
-i2:select()
+i2:select{}
 i2:stat().get.rows -- 5
 i2:stat().skip.rows -- 10
 pk:stat().lookup -- 30
@@ -51,13 +51,13 @@ pk:stat().skip.rows -- 10
 -- Overwritten/deleted tuples are not stored in the cache so calling
 -- SELECT for a second time does only 5 lookups.
 box.stat.reset()
-i1:select()
+i1:select{}
 i1:stat().get.rows -- 5
 i1:stat().skip.rows -- 0
 pk:stat().lookup -- 5
 pk:stat().get.rows -- 5
 pk:stat().skip.rows -- 0
-i2:select()
+i2:select{}
 i2:stat().get.rows -- 5
 i2:stat().skip.rows -- 0
 pk:stat().lookup -- 10
@@ -81,13 +81,13 @@ i2:stat().rows -- ditto
 -- they may break the read iterator invariant, so they don't reduce
 -- the number of lookups.
 box.stat.reset()
-i1:select()
+i1:select{}
 i1:stat().get.rows -- 5
 i1:stat().skip.rows -- 10
 pk:stat().lookup -- 15
 pk:stat().get.rows -- 5
 pk:stat().skip.rows -- 5
-i2:select()
+i2:select{}
 i2:stat().get.rows -- 5
 i2:stat().skip.rows -- 10
 pk:stat().lookup -- 30
@@ -114,10 +114,10 @@ while i2:stat().disk.compaction.count == 0 do fiber.sleep(0.001) end
 i1:stat().rows -- 5 new REPLACEs
 i2:stat().rows -- ditto
 box.stat.reset()
-i1:select()
+i1:select{}
 i1:stat().get.rows -- 5
 pk:stat().lookup -- 5
-i2:select()
+i2:select{}
 i2:stat().get.rows -- 5
 pk:stat().lookup -- 10
 
@@ -163,7 +163,7 @@ pk:stat().memory.iterator.lookup -- 10
 pk:stat().memory.iterator.get.rows -- 10
 sk:stat().rows -- 25 old REPLACEs + 25 DELETEs
 
-sk:select()
+sk:select{}
 pk:stat().lookup -- 0
 
 -- Check that the global tx memory counter doesn't underflow when
@@ -263,9 +263,9 @@ box.snapshot()
 pk:compact()
 while pk:stat().disk.compaction.count == 0 do fiber.sleep(0.001) end
 
-sk:select() -- [1, 10, 'c']
+sk:select{} -- [1, 10, 'c']
 box.snapshot()
-sk:select() -- ditto
+sk:select{} -- ditto
 s:drop()
 
 --
@@ -290,8 +290,8 @@ sk:stat().rows -- 3: INSERT{1,1} + INSERT{2,2} + DELETE{1,1}
 box.snapshot()
 pk:stat().rows -- 1: INSERT{2,2,3}
 sk:stat().rows -- 1: INSERT{2,2}
-pk:select()
-sk:select()
+pk:select{}
+sk:select{}
 s:drop()
 
 --
@@ -311,8 +311,8 @@ box.commit()
 box.snapshot()
 pk:stat().rows -- 2: REPLACE{1, 12} + REPLACE{2, 22}
 sk:stat().rows -- ditto
-pk:select()
-sk:select()
+pk:select{}
+sk:select{}
 s:drop()
 
 box.cfg{vinyl_cache = vinyl_cache}

--- a/test/vinyl/errinj.test.lua
+++ b/test/vinyl/errinj.test.lua
@@ -65,20 +65,20 @@ s = box.schema.space.create('test', {engine='vinyl'})
 _ = s:create_index('pk')
 for i = 1, 10 do s:insert({i, 'test str' .. tostring(i)}) end
 box.snapshot()
-s:select()
+s:select{}
 errinj.set("ERRINJ_VY_READ_PAGE", true)
-s:select()
+s:select{}
 errinj.set("ERRINJ_VY_READ_PAGE", false)
-s:select()
+s:select{}
 
 errinj.set("ERRINJ_VY_READ_PAGE_TIMEOUT", 0.05)
-function test_cancel_read () k = s:select() return #k end
+function test_cancel_read () k = s:select{} return #k end
 f1 = fiber.create(test_cancel_read)
 fiber.cancel(f1)
 -- task should be done
 fiber.sleep(0.1)
 errinj.set("ERRINJ_VY_READ_PAGE_TIMEOUT", 0);
-s:select()
+s:select{}
 
 -- error after timeout for canceled fiber
 errinj.set("ERRINJ_VY_READ_PAGE", true)
@@ -88,7 +88,7 @@ fiber.cancel(f1)
 fiber.sleep(0.1)
 errinj.set("ERRINJ_VY_READ_PAGE_TIMEOUT", 0);
 errinj.set("ERRINJ_VY_READ_PAGE", false);
-s:select()
+s:select{}
 
 -- index is dropped while a read task is in progress
 errinj.set("ERRINJ_VY_READ_PAGE_TIMEOUT", 0.05)
@@ -141,7 +141,7 @@ box.snapshot()
 for i=1,256 do s:upsert({0, 0}, {{'+', 2, 1}}) end
 box.snapshot() -- in-memory tree is gone
 fiber.sleep(0.05)
-s:select()
+s:select{}
 s:replace{0, 0}
 box.snapshot()
 for i=1,256 do s:upsert({0, 0}, {{'+', 2, 1}}) end
@@ -215,12 +215,12 @@ _ = s:create_index('i1', {parts = {1, 'unsigned'}})
 for i = 0, 9 do s:replace({i, i + 1}) end
 box.snapshot()
 errinj.set("ERRINJ_XLOG_GARBAGE", true)
-s:select()
+s:select{}
 errinj.set("ERRINJ_XLOG_GARBAGE", false)
 errinj.set("ERRINJ_VYRUN_DATA_READ", true)
-s:select()
+s:select{}
 errinj.set("ERRINJ_VYRUN_DATA_READ", false)
-s:select()
+s:select{}
 s:drop()
 
 s = box.schema.space.create('test', {engine = 'vinyl'})
@@ -231,7 +231,7 @@ box.snapshot()
 for i = 10, 19 do s:replace({i, i + 1}) end
 errinj.set("ERRINJ_XLOG_GARBAGE", false)
 box.snapshot()
-s:select()
+s:select{}
 
 s:drop()
 

--- a/test/vinyl/errinj_ddl.test.lua
+++ b/test/vinyl/errinj_ddl.test.lua
@@ -37,7 +37,7 @@ _ = s:upsert({7, -7}, {{'=', 2, -7}})
 errinj.set("ERRINJ_VY_RUN_WRITE_DELAY", false)
 ch:get()
 
-s.index.sk:select()
+s.index.sk:select{}
 s.index.sk:stat().memory.rows
 
 test_run:cmd('restart server default')
@@ -47,12 +47,12 @@ errinj = box.error.injection
 
 s = box.space.test
 
-s.index.sk:select()
+s.index.sk:select{}
 s.index.sk:stat().memory.rows
 
 box.snapshot()
 
-s.index.sk:select()
+s.index.sk:select{}
 s.index.sk:stat().memory.rows
 
 s:drop()
@@ -163,7 +163,7 @@ _ = fiber.create(function() fiber.sleep(0.01) errinj.set('ERRINJ_WAL_DELAY', fal
 
 fiber.sleep(0)
 s:format{{'key', 'unsigned'}, {'value', 'unsigned'}} -- must fail
-s:select()
+s:select{}
 s:truncate()
 
 errinj.set('ERRINJ_WAL_DELAY', true)
@@ -172,7 +172,7 @@ _ = fiber.create(function() fiber.sleep(0.01) errinj.set('ERRINJ_WAL_DELAY', fal
 
 fiber.sleep(0)
 s:create_index('sk', {parts = {2, 'unsigned'}})
-s:select()
+s:select{}
 s:drop()
 
 --
@@ -261,7 +261,7 @@ ch1:get()
 ch2:get()
 ch3:get()
 ch4:get()
-s:select()
+s:select{}
 s:drop()
 
 --
@@ -302,8 +302,8 @@ box.error.injection.set('ERRINJ_VY_READ_PAGE_DELAY', false);
 ch:get();
 test_run:cmd("setopt delimiter ''");
 
-s.index.primary:select()
-s.index.secondary:select()
+s.index.primary:select{}
+s.index.secondary:select{}
 s:drop()
 
 --

--- a/test/vinyl/errinj_gc.test.lua
+++ b/test/vinyl/errinj_gc.test.lua
@@ -83,7 +83,7 @@ function gc() temp:auto_increment{} box.snapshot() end
 
 file_count()
 
-s:select()
+s:select{}
 
 s:drop()
 gc()

--- a/test/vinyl/errinj_tx.test.lua
+++ b/test/vinyl/errinj_tx.test.lua
@@ -224,7 +224,7 @@ errinj.set('ERRINJ_WAL_WRITE', false)
 -- Must fail.
 itr.next()
 c('s:get(1)')
-c('s:select()')
+c('s:select{}')
 c('s:replace{1}')
 c:commit()
 

--- a/test/vinyl/errinj_vylog.test.lua
+++ b/test/vinyl/errinj_vylog.test.lua
@@ -42,7 +42,7 @@ _ = s:insert{3, 'z'}
 test_run:cmd('restart server default')
 
 s = box.space.test
-s:select()
+s:select{}
 s:drop()
 
 --
@@ -87,8 +87,8 @@ test_run:cmd('restart server default')
 
 s1 = box.space.test1
 s2 = box.space.test2
-s1:select()
-s2:select()
+s1:select{}
+s2:select{}
 s1:drop()
 s2:drop()
 
@@ -133,8 +133,8 @@ s2 = box.space.test2
 _ = s1:insert{444, 'ddd'}
 _ = s2:insert{555, 'eee'}
 
-s1:select()
-s2:select()
+s1:select{}
+s2:select{}
 
 box.snapshot()
 
@@ -142,8 +142,8 @@ test_run:cmd('restart server default')
 
 s1 = box.space.test1
 s2 = box.space.test2
-s1:select()
-s2:select()
+s1:select{}
+s2:select{}
 s1:drop()
 s2:drop()
 
@@ -171,8 +171,8 @@ ch:get()
 test_run:cmd('restart server default')
 
 s = box.space.test
-s.index.pk:select()
-s.index.sk:select()
+s.index.pk:select{}
+s.index.sk:select{}
 
 s:drop()
 

--- a/test/vinyl/gh-4957-too-many-upserts.test.lua
+++ b/test/vinyl/gh-4957-too-many-upserts.test.lua
@@ -20,7 +20,7 @@ box.commit()
 -- second test.
 --
 box.snapshot()
-s:select()
+s:select{}
 
 s:drop()
 
@@ -36,7 +36,7 @@ box.begin()
 for k = 2, ups_cnt do s:upsert({1}, {{'+', k, 1}}) end
 box.commit()
 box.snapshot()
-s:select()[1][ups_cnt]
+s:select{}[1][ups_cnt]
 
 s:drop()
 
@@ -49,12 +49,10 @@ pk = s:create_index('pk')
 ups_ops = {}
 for k = 2, ups_cnt do ups_ops[k] = {'+', k, 1} end
 s:upsert({1}, ups_ops)
-s:select()
+s:select{}
 s:drop()
 
 -- restart the current server to resolve the issue #5141
 -- which reproduced in test:
 --   vinyl/gh-5141-invalid-vylog-file.test.lua
 test_run:cmd("restart server default with cleanup=True")
-
-

--- a/test/vinyl/gh-5005-upsert-affecting-pk.test.lua
+++ b/test/vinyl/gh-5005-upsert-affecting-pk.test.lua
@@ -5,8 +5,8 @@
 s = box.schema.create_space('test', {engine = 'vinyl'})
 pk = s:create_index('pk')
 s:insert{1, 1}
-s:select()
+s:select{}
 s:upsert({1}, {{'+', 1, 1}})
-s:select()
+s:select{}
 
 s:drop()

--- a/test/vinyl/gh-5107-upsert-upgrade.test.lua
+++ b/test/vinyl/gh-5107-upsert-upgrade.test.lua
@@ -16,7 +16,7 @@ test_run:switch('upgrade')
 -- place, only internal format of :upserts have been changed.
 -- box.schema.upgrade()
 
-box.space.test:select()
+box.space.test:select{}
 
 test_run:switch('default')
 test_run:cmd('stop server upgrade')

--- a/test/vinyl/gh.test.lua
+++ b/test/vinyl/gh.test.lua
@@ -150,9 +150,9 @@ s2:drop()
 s = box.schema.create_space('test', {engine = 'vinyl'})
 _ = s:create_index('test', {type = 'tree', parts = {1, 'unsigned', 2, 'string'}})
 s:put({1, 'test', 3, 4})
-s:select()
+s:select{}
 s:upsert({1, 'test', 'failed'}, {{'=', 3, 33}, {'=', 4, nil}})
-s:select()
+s:select{}
 s:drop()
 
 --
@@ -325,5 +325,5 @@ box.begin()
 s:update(1, {{'+', 3, 1}})
 s:delete(1)
 box.commit()
-s:select()
+s:select{}
 s:drop()

--- a/test/vinyl/hermitage.test.lua
+++ b/test/vinyl/hermitage.test.lua
@@ -157,10 +157,10 @@ t:replace{2, 20}
 
 c1:begin()
 c2:begin()
-c1("t:select()") -- {1, 10}, {2, 20}
+c1("t:select{}") -- {1, 10}, {2, 20}
 c2("t:replace{3, 30}")
 c2:commit() -- ok
-c1("t:select()") -- still {1, 10}, {2, 20}
+c1("t:select{}") -- still {1, 10}, {2, 20}
 c1:commit() -- ok
 
 -- teardown
@@ -283,8 +283,8 @@ t:replace{2, 20}
 c1:begin()
 c2:begin()
 -- select * from test where value % 3 = 0
-c1("t:select()") -- {1, 10}, {2, 20}
-c2("t:select()") -- {1, 10}, {2, 20}
+c1("t:select{}") -- {1, 10}, {2, 20}
+c2("t:select{}") -- {1, 10}, {2, 20}
 c1("t:replace{3, 30}")
 c2("t:replace{4, 42}")
 c1:commit() -- ok

--- a/test/vinyl/json.test.lua
+++ b/test/vinyl/json.test.lua
@@ -8,7 +8,7 @@ s = box.schema.space.create('test', {engine = 'vinyl'})
 pk = s:create_index('pk', {parts = { {'[1].a', 'unsigned'}, {'[1].b', 'unsigned'}, {'[1].c', 'unsigned'} }})
 sk = s:create_index('sk', {unique = false, parts = {2, 'unsigned'}})
 s:replace{{a = 1, b = 2, c = 3}, 10}
-sk:select()
+sk:select{}
 s:drop()
 
 --

--- a/test/vinyl/large.lua
+++ b/test/vinyl/large.lua
@@ -28,7 +28,7 @@ end
 
 local function check_test()
     local i = 0
-    for _, tuple in box.space.large_s1:pairs() do
+    for _, tuple in box.space.large_s1:pairs{} do
         if TUPLE_SIZE ~= tuple[2]:len() then
             error('Large tuple has incorect length')
         end

--- a/test/vinyl/misc.test.lua
+++ b/test/vinyl/misc.test.lua
@@ -35,7 +35,7 @@ s:insert{1, 1, 1}
 box.snapshot()
 s:delete(1)
 box.snapshot()
-s:select()
+s:select{}
 s:drop()
 
 --
@@ -145,7 +145,7 @@ end);
 ch2 = fiber.channel(1);
 _ = fiber.create(function()
     box.begin()
-    s:select()
+    s:select{}
     ch2:get()
     local status, err = pcall(s.select, s)
     ch2:put(status or err)
@@ -165,7 +165,7 @@ ch2:get()
 ch2:get()
 -- Cleanup.
 box.cfg{read_only = false}
-s:select()
+s:select{}
 s:drop()
 
 --

--- a/test/vinyl/mvcc.test.lua
+++ b/test/vinyl/mvcc.test.lua
@@ -1491,11 +1491,11 @@ c1("t:select{}")
 --
 c1:begin()
 c1("t:select{1}")
-c1("for k, v in box.space.test:pairs() do box.commit() end")
+c1("for k, v in box.space.test:pairs{} do box.commit() end")
 c1:rollback()
 c1:begin()
 c1("t:select{1}")
-c1("for k, v in box.space.test:pairs() do box.rollback() end")
+c1("for k, v in box.space.test:pairs{} do box.rollback() end")
 c1:rollback()
 t:truncate()
 
@@ -1548,7 +1548,7 @@ c1("t:select({}, {limit = 1})") -- {1, 'new'}
 c2:begin()
 c2("t:replace{2, 'new'}")
 c2:commit()
-c1("t:select()") -- {1, 'new'}, {2, 'new'}
+c1("t:select{}") -- {1, 'new'}, {2, 'new'}
 c1:commit()
 t:truncate()
 
@@ -1562,7 +1562,7 @@ c1("t:insert{1, 2}")
 c2("t:insert{2, 2}")
 c1:commit()
 c2:commit() -- rollback
-t:select() -- {1, 2}
+t:select{} -- {1, 2}
 t:truncate()
 t.index.sk:drop()
 

--- a/test/vinyl/partial_dump.test.lua
+++ b/test/vinyl/partial_dump.test.lua
@@ -41,7 +41,7 @@ INDEX_COUNT = box.cfg.vinyl_write_threads * 3
 assert(INDEX_COUNT < 100)
 
 s = box.space.test
-s:select()
+s:select{}
 
 bad_index = -1
 test_run:cmd("setopt delimiter ';'")
@@ -49,13 +49,13 @@ for i = 1, INDEX_COUNT - 1 do
     if s:count() ~= s.index[i]:count() then
         bad_index = i
     end
-    for _, v in s.index[i]:pairs() do
+    for _, v in s.index[i]:pairs{} do
         if v ~= s:get(v[1]) then
             bad_index = i
         end
     end
 end
 test_run:cmd("setopt delimiter ''");
-bad_index < 0 or {bad_index, s.index[bad_index]:select()}
+bad_index < 0 or {bad_index, s.index[bad_index]:select{}}
 
 s:drop()

--- a/test/vinyl/recover.test.lua
+++ b/test/vinyl/recover.test.lua
@@ -52,14 +52,14 @@ s5 = box.space.test5
 var = box.space.var
 
 -- Check space contents.
-s1:select()
-s2:select()
-s3.index.primary:select()
-s3.index.secondary:select()
-s4.index.i1:select()
-s4.index.i2:select()
-s5.index.i1:select()
-s5.index.i2:select()
+s1:select{}
+s2:select{}
+s3.index.primary:select{}
+s3.index.secondary:select{}
+s4.index.i1:select{}
+s4.index.i2:select{}
+s5.index.i1:select{}
+s5.index.i2:select{}
 
 -- Check that stats didn't change after recovery.
 vyinfo1 = var:get('vyinfo')[2]
@@ -134,8 +134,8 @@ new_info.disk.pages == old_info.disk.pages
 new_info.run_count == old_info.run_count
 new_info.range_count == old_info.range_count
 
-box.space.test2:select()
-box.space.test2.index.sec:select()
+box.space.test2:select{}
+box.space.test2.index.sec:select{}
 test_run:cmd('switch default')
 test_run:cmd('stop server force_recovery')
 test_run:cmd('delete server force_recovery')

--- a/test/vinyl/stat.test.lua
+++ b/test/vinyl/stat.test.lua
@@ -196,7 +196,7 @@ for i = 1, 100 do put(i) end
 box.begin()
 for i = 1, 100, 2 do put(i) end
 st = istat()
-#s:select()
+#s:select{}
 stat_diff(istat(), st)
 box.rollback()
 
@@ -298,7 +298,7 @@ ch2 = fiber.channel(1)
 test_run:cmd("setopt delimiter ';'")
 _ = fiber.create(function()
     box.begin()
-    s:select()
+    s:select{}
     ch1:put(true)
     ch2:get()
     pcall(box.commit)

--- a/test/vinyl/tx_gap_lock.test.lua
+++ b/test/vinyl/tx_gap_lock.test.lua
@@ -19,9 +19,9 @@ _ = s:insert{1}
 _ = s:insert{3}
 
 c:begin()
-c("s:select()") -- {1}, {3}
+c("s:select{}") -- {1}, {3}
 _ = s:insert{2} -- send c to read view
-c("s:select()") -- {1}, {3}
+c("s:select{}") -- {1}, {3}
 c:commit()
 
 s:truncate()
@@ -30,9 +30,9 @@ _ = s:insert{1}
 _ = s:insert{2}
 
 c:begin()
-c("s:select()") -- {1}, {2}
+c("s:select{}") -- {1}, {2}
 _ = s:insert{3} -- send c to read view
-c("s:select()") -- {1}, {2}
+c("s:select{}") -- {1}, {2}
 c:commit()
 
 s:truncate()
@@ -41,9 +41,9 @@ _ = s:insert{2}
 _ = s:insert{3}
 
 c:begin()
-c("s:select()") -- {2}, {3}
+c("s:select{}") -- {2}, {3}
 _ = s:insert{1} -- send c to read view
-c("s:select()") -- {2}, {3}
+c("s:select{}") -- {2}, {3}
 c:commit()
 
 s:truncate()
@@ -393,7 +393,7 @@ _ = s.index.sk:select({}, {limit = 50})
 gap_lock_count() -- 51
 for i = 1, 100 do s.index.sk:get(i) end
 gap_lock_count() -- 151
-_ = s.index.sk:select()
+_ = s.index.sk:select{}
 gap_lock_count() -- 101
 box.commit()
 gap_lock_count() -- 0

--- a/test/vinyl/update_optimize.test.lua
+++ b/test/vinyl/update_optimize.test.lua
@@ -257,6 +257,6 @@ box.snapshot()
 s.index.sk:stat().rows
 
 s:insert{1, 20}
-s.index.sk:select()
+s.index.sk:select{}
 
 s:drop()

--- a/test/vinyl/upsert.test.lua
+++ b/test/vinyl/upsert.test.lua
@@ -358,11 +358,11 @@ box.snapshot()
 s:upsert({1, 0}, {{'=', 2, 2}})
 s:upsert({1, 0}, {{'-', 2, 1}})
 box.snapshot()
-s:select()
+s:select{}
 
 for i = 0, 11 do if i%2 == 0 then s:upsert({1, 0}, {{'=', 2, i}}) else s:upsert({1, 0}, {{'+', 2, i}}) end end
 box.snapshot()
-s:select()
+s:select{}
 
 -- Operations won't squash (owing to incompatible types), so
 -- during applying resulting upsert on the top of replace
@@ -372,7 +372,7 @@ s:select()
 s:upsert({1, 0}, {{'=', 2, 'abc'}})
 s:upsert({1, 0}, {{'-', 2, 1}})
 box.snapshot()
-s:select()
+s:select{}
 
 s:drop()
 
@@ -389,7 +389,7 @@ box.snapshot()
 s:upsert({1}, {{'=', 3, 100}})
 s:upsert({1}, {{'=', -1, 200}})
 box.snapshot()
-s:select() -- {1, 1, 200}
+s:select{} -- {1, 1, 200}
 
 s:delete({1})
 s:insert({1, 1, 1})
@@ -401,7 +401,7 @@ box.snapshot()
 -- gh-5105: Two upserts are NOT squashed into one, so only one (first one)
 -- is skipped, meanwhile second one is applied.
 --
-s:select() -- {1, 1, 1}
+s:select{} -- {1, 1, 1}
 
 s:delete({1})
 box.snapshot()
@@ -412,7 +412,7 @@ s:upsert({1}, {{'-', 2, 100}}) -- {1, 1}
 s:upsert({1}, {{'+', -1, 200}}) -- {1, 201}
 s:upsert({1}, {{'-', 2, 200}}) -- {1, 1}
 box.snapshot()
-s:select() -- {1, 1}
+s:select{} -- {1, 1}
 
 s:delete({1})
 box.snapshot()
@@ -423,7 +423,7 @@ s:upsert({1}, {{'=', -1, 100}}) -- {1, 101, 100}
 s:upsert({1}, {{'+', -1, 200}}) -- {1, 101, 300}
 s:upsert({1}, {{'-', -2, 100}}) -- {1, 1, 300}
 box.snapshot()
-s:select()
+s:select{}
 
 s:drop()
 
@@ -502,7 +502,7 @@ s:upsert({1, 1, 1, 2.5, decimal.new(1.1)}, {{'=', 4, 4}})
 s:upsert({2, 1, 1, 2.5, decimal.new(1.1)}, {{'+', 2, 5}})
 s:upsert({2, 1, 1, 2.5, decimal.new(1.1)}, {{'+', 2, 5.5}})
 box.snapshot()
-s:select()
+s:select{}
 -- Integer overflow check.
 --
 s:upsert({1, 1, 1, 2.5, decimal.new(1.1)}, {{'+', 3, 9223372036854775808}})
@@ -512,7 +512,7 @@ s:upsert({1, 1, 1, 2.5, decimal.new(1.1)}, {{'+', 3, 9223372036854775808}})
 s:upsert({2, 1, 1, 2.5, decimal.new(1.1)}, {{'+', 2, 2}})
 s:upsert({2, 1, 1, 2.5, decimal.new(1.1)}, {{'-', 2, 10}})
 box.snapshot()
-s:select()
+s:select{}
 -- Decimals do not fit into numerics and vice versa.
 --
 s:upsert({1, 1, 1, 2.5, decimal.new(1.1)}, {{'+', 5, 2}})
@@ -520,7 +520,7 @@ s:upsert({1, 1, 1, 2.5, decimal.new(1.1)}, {{'-', 5, 1}})
 s:upsert({2, 1, 1, 2.5, decimal.new(1.1)}, {{'+', 2, decimal.new(2.1)}})
 s:upsert({2, 1, 1, 2.5, decimal.new(1.1)}, {{'-', 2, decimal.new(1.2)}})
 box.snapshot()
-s:select()
+s:select{}
 
 s:drop()
 
@@ -539,7 +539,7 @@ s:upsert({1, 0}, {{'+', 2, 1}})
 s:upsert({1, 0}, {{'+', 2, 1}})
 s:upsert({1, 0}, {{'+', 2, 1}})
 box.snapshot()
-s:select()
+s:select{}
 
 s:delete{1}
 s:replace{1, uint_max - 2, 0}
@@ -550,7 +550,7 @@ s:upsert({1, 0, 0}, {{'+', 2, 1}})
 s:upsert({1, 0, 0}, {{'+', 2, 0.5}})
 s:upsert({1, 0, 0}, {{'+', 2, 1}})
 box.snapshot()
-s:select()
+s:select{}
 s:drop()
 
 -- Make sure upserts satisfy associativity rule.
@@ -584,7 +584,7 @@ box.snapshot()
 s:upsert({1, 1}, {{'=', 2, 2}})
 s:upsert({1, 1}, {{'=', 1, 0}})
 box.snapshot()
-s:select()
+s:select{}
 
 s:drop()
 
@@ -596,6 +596,6 @@ box.snapshot()
 s:upsert({1, 1}, {{'=', 2, 2}})
 s:upsert({1, 1}, {{'=', 1, 0}})
 box.snapshot()
-s:select()
+s:select{}
 
 s:drop()

--- a/test/wal_off/lua.test.lua
+++ b/test/wal_off/lua.test.lua
@@ -14,7 +14,7 @@ for i = 1, 1000 do
         space:insert{tostring(j), os.time(), 1}
     end
     count = 0
-    for state, v in space.index[1]:pairs() do
+    for state, v in space.index[1]:pairs{} do
         count = count + 1
     end
     if count ~= 30 then
@@ -29,7 +29,7 @@ space:truncate()
 -- 5.4
 --
 for i = 1, 100000, 1 do space:insert{tostring(i), i} end
-local t1 = space.index['secondary']:select()
+local t1 = space.index['secondary']:select{}
 space:drop()
 
 --

--- a/test/wal_off/oom.test.lua
+++ b/test/wal_off/oom.test.lua
@@ -34,7 +34,7 @@ space.index['primary']:get{15}
 i = 0
 t = {}
 test_run:cmd("setopt delimiter ';'")
-for state, v in space:pairs() do
+for state, v in space:pairs{} do
     table.insert(t, v)
     i = i + 1
     if i == 50 then
@@ -104,4 +104,3 @@ index:count()
 
 space:drop()
 str = nil
-

--- a/test/wal_off/snapshot_stress.test.lua
+++ b/test/wal_off/snapshot_stress.test.lua
@@ -210,12 +210,12 @@ s2 = box.space.operations
 
 total_sum = 0
 t1 = {}
-for k,v in s1:pairs() do t1[ v[1] ] = v[2] total_sum = total_sum + v[2] end
+for k,v in s1:pairs{} do t1[ v[1] ] = v[2] total_sum = total_sum + v[2] end
 if total_sum ~= 0 then log.info('error: total sum mismatch') os.execute("rm -r " .. new_snap_dir) os.exit(-1) end
 
 t2 = {}
 function acc_inc(n1, v) t2[n1] = (t2[n1] and t2[n1] or 0) + v end
-for k,v in s2:pairs() do acc_inc(v[2], v[4]) acc_inc(v[3], -v[4]) end
+for k,v in s2:pairs{} do acc_inc(v[2], v[4]) acc_inc(v[3], -v[4]) end
 
 bad = false
 for k,v in pairs(t1) do if (t2[k] and t2[k] or 0) ~= v then bad = true end end
@@ -261,5 +261,3 @@ snapshot_check_failed;
 log.info('Part II: checking snapshot done');
 
 test_run:cmd("setopt delimiter ''");
-
-

--- a/test/xlog/big_tx.test.lua
+++ b/test/xlog/big_tx.test.lua
@@ -5,7 +5,6 @@ _ = box.schema.space.create('big_tx'):create_index('pk')
 t = box.space.big_tx:insert({1, digest.urandom(512 * 1024)})
 env:cmd('restart server default')
 
-#box.space.big_tx:select()
+#box.space.big_tx:select{}
 
 box.space.big_tx:drop()
-


### PR DESCRIPTION
box/lua: log dangerous :select and :pairs calls

Empty or nil :select and :pairs calls on user spaces tend to be
dangerous: we see Tarantool crashing with OOM, or Tarantool becoming
slow and its transaction thread utilizing 100% CPU usage. Also,
debugging of such killer-requests is often too painful and exhausting.

Proposed solution: upon such a call, create a critical log entry,
containing the current stack traceback.

Closes #6539