### PR TITLE
iproto: implement ability to pass several uries in different ways

### DIFF
--- a/changelogs/unreleased/gh-5928-ability-to-pass-several-uris-with-properties-in-different-ways.md
+++ b/changelogs/unreleased/gh-5928-ability-to-pass-several-uris-with-properties-in-different-ways.md
@@ -1,0 +1,4 @@
+## feature/core
+* Implemented ability to pass several listening uries in different ways
+  with different properties. Uries can be passed either as a string or
+  as a table, or as a combination of these options.

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -118,6 +118,7 @@ add_library(box STATIC
     memtx_allocator.cc
     msgpack.c
     iproto.cc
+    cfg_uri.c
     xrow_io.cc
     tuple_convert.c
     identifier.c

--- a/src/box/cfg_uri.c
+++ b/src/box/cfg_uri.c
@@ -1,0 +1,434 @@
+/*
+ * Copyright 2010-2021, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#include "cfg_uri.h"
+#include "lua/utils.h"
+#include "tt_static.h"
+#include "say.h"
+#include "diag.h"
+#include "error.h"
+#include "trivia/util.h"
+
+static const char *valid_options[CFG_URI_OPTION_MAX] = {
+	/* CFG_URI_OPTION_BACKLOG */   "backlog",
+	/* CFG_URI_OPTION_READAHEAD */ "readahead",
+	/* CFG_URI_OPTION_TRANSPORT */ "transport",
+};
+
+/**
+ * Returns URI option index by @a option_name. If the option name
+ * is not in the registry, returns 'CFG_URI_OPTION_MAX'.
+ */
+static enum cfg_uri_options
+cfg_uri_option_idx_from_name(const char *option_name)
+{
+	for (enum cfg_uri_options i = 0; i < CFG_URI_OPTION_MAX; i++)
+		if (strcmp(option_name, valid_options[i]) == 0)
+			return i;
+	return CFG_URI_OPTION_MAX;
+}
+
+/**
+ * Splits @a source string by ';' and adds new option values to
+ * array in @option structure. Expected input:
+ * "val1;val2;val3" -- string separated by ';'.
+ */
+static int
+cfg_uri_option_values_from_string(struct cfg_uri_option *option,
+				  const char *source, const char *cfg_option)
+{
+	unsigned int size = (option->values_copy_size + 1) * sizeof(char *);
+	option->values_copy = xrealloc(option->values_copy, size);
+	option->values_copy[option->values_copy_size++] = xstrdup(source);
+	char *source_copy = option->values_copy[option->values_copy_size - 1];
+	char *delim = strchr(source_copy, ';');
+	bool found_next;
+	do {
+		char *value = source_copy;
+		if (delim != NULL) {
+			source_copy = delim + 1;
+			*delim = '\0';
+			delim = strchr(source_copy, ';');
+			found_next = true;
+		} else {
+			found_next = false;
+		}
+		if (strlen(source_copy) == 0 || strlen(value) == 0) {
+			diag_set(ClientError, ER_CFG, cfg_option,
+				 "not found option value for URI");
+			return -1;
+		}
+		size = (option->size + 1) * sizeof(char *);
+		option->values = xrealloc(option->values, size);
+		option->values[option->size++] = value;
+	} while (found_next);
+	return 0;
+}
+
+/**
+ * Adds new option values to array in @option structure. Expected
+ * table with option values at the top of lua stack. Each item in
+ * this table should be a string which contains option value or
+ * several option values separated by ";". For example:
+ * {"10", 10;20;30", "40;50;60"}
+ */
+static int
+cfg_uri_option_values_from_table(struct cfg_uri_option *option,
+				 lua_State *L, const char *cfg_option)
+{
+	int size = lua_objlen(L, -1);
+	for (int i = 0; i < size; i++) {
+		lua_rawgeti(L, -1, i + 1);
+		if (!lua_isstring(L, -1)) {
+			diag_set(ClientError, ER_CFG, cfg_option,
+				 "URI option value"
+				 "should be one of types string, numer");
+			lua_pop(L, 1);
+			return -1;
+		}
+		const char *source = lua_tostring(L, -1);
+		if (cfg_uri_option_values_from_string(option, source,
+						      cfg_option) != 0) {
+			lua_pop(L, 1);
+			return -1;
+		}
+		lua_pop(L, 1);
+	}
+	return 0;
+}
+
+/**
+ * Destroys option and all associated resources.
+ */
+static void
+cfg_uri_option_destroy(struct cfg_uri_option *option)
+{
+	for (int i = 0; i < option->values_copy_size; i++)
+		free(option->values_copy[i]);
+	free(option->values);
+	free(option->copy);
+	memset(option, 0, sizeof(struct cfg_uri_option));
+}
+
+/**
+ * Creates URI option at appropriate position in @a options array
+ * from @source string. Expected @a source format is a string which
+ * contains option name and option values separated by '=':
+ * "backlog="10;20;30"
+ */
+static int
+cfg_uri_option_create_from_string(struct cfg_uri_option *options,
+				  const char *source,
+				  const char *cfg_option)
+{
+	char *copy = xstrdup(source);
+	char *delim = strchr(copy, '=');
+	if (delim == NULL) {
+		diag_set(ClientError, ER_CFG, cfg_option,
+			 "not found option value for URI");
+		free(copy);
+		return -1;
+	}
+	char *values = delim + 1;
+	*delim = '\0';
+	enum cfg_uri_options opt_idx =
+		cfg_uri_option_idx_from_name(copy);
+	if (opt_idx == CFG_URI_OPTION_MAX) {
+		diag_set(ClientError, ER_CFG, cfg_option,
+			 "invalid option name for URI");
+		free(copy);
+		return -1;
+	}
+	struct cfg_uri_option *option = &options[opt_idx];
+	option->copy = copy;
+	option->name = option->copy;
+	if (strlen(values) == 0) {
+		diag_set(ClientError, ER_CFG, cfg_option,
+			 "not found option value for URI after '='");
+		goto fail;
+	}
+	if (cfg_uri_option_values_from_string(option, values,
+					      cfg_option) != 0)
+		goto fail;
+	return 0;
+fail:
+	cfg_uri_option_destroy(option);
+	return -1;
+}
+
+/**
+ * Destroys all URI options in @a cfg_uri.
+ */
+static void
+cfg_uri_options_destroy(struct cfg_uri *cfg_uri)
+{
+	for (int i = 0; i < CFG_URI_OPTION_MAX; i++)
+		cfg_uri_option_destroy(&cfg_uri->options[i]);
+}
+
+/**
+ * Creates URI options from @a source string. Expected @a source format
+ * is a string which contains options separated by '&'. For example:
+ * "backlog=10;20;30&transport=tls;plain".
+ * User can several values for one option separated by '&'. For this
+ * case he should use same syntax:
+ * "backlog=10;20&backlog=30;40"
+ */
+static int
+cfg_uri_options_create_from_string(struct cfg_uri *cfg_uri, const char *source,
+				   const char *cfg_option)
+{
+	cfg_uri->options_copy = xstrdup(source);
+	char *options_copy = cfg_uri->options_copy;
+	char *delim = strchr(options_copy, '&');
+	bool found_next;
+	do {
+		char *option = options_copy;
+		if (delim != NULL) {
+			options_copy = delim + 1;
+			*delim = '\0';
+			delim = strchr(options_copy, '&');
+			found_next = true;
+		} else {
+			found_next = false;
+		}
+		if (strlen(options_copy) == 0 || strlen(option) == 0) {
+			diag_set(ClientError, ER_CFG, cfg_option,
+				 "not found option for URI after '&'");
+			goto fail;
+		}
+		if (cfg_uri_option_create_from_string(cfg_uri->options,
+						      option, cfg_option) != 0)
+			goto fail;
+	} while (found_next);
+	return 0;
+fail:
+	cfg_uri_options_destroy(cfg_uri);
+	return -1;
+}
+
+/**
+ * Creates URI options from the table which located at the top position of
+ * lua stack. Ignores options with names out of option registry. For example:
+ * { backlog="10;20;30", transport="tls;plain", unexpected = "unexpected" }.
+ * In this case only backlog and transport options will be processed.
+ */
+static int
+cfg_uri_options_create_from_table(struct cfg_uri *cfg_uri, lua_State *L,
+				  const char *cfg_option)
+{
+	for (enum cfg_uri_options i = 0; i < lengthof(valid_options); i++) {
+		lua_pushstring(L, valid_options[i]);
+		lua_gettable(L, -2);
+		if (lua_isstring(L, -1)) {
+			const char *source = lua_tostring(L, -1);
+			char *copy = xstrdup(source);
+			struct cfg_uri_option *option =
+				&cfg_uri->options[i];
+			option->copy = copy;
+			if (cfg_uri_option_values_from_string(option,
+							      option->copy,
+							      cfg_option) != 0)
+				goto fail;
+		} else if (lua_istable(L, -1)) {
+			struct cfg_uri_option *option =
+				&cfg_uri->options[i];
+			if (cfg_uri_option_values_from_table(option, L,
+							     cfg_option) != 0)
+				goto fail;
+		} else if (!lua_isnil(L ,-1)) {
+			diag_set(ClientError, ER_CFG, cfg_option, "common URI option"
+				 "should be one of types string, table");
+			lua_pop(L, 1);
+			goto fail;
+		}
+		lua_pop(L, 1);
+	}
+	return 0;
+fail:
+	lua_pop(L, 1);
+	cfg_uri_options_destroy(cfg_uri);
+	return -1;
+}
+
+/**
+ * Destroys @a cfg_uri and all associated resources.
+ */
+static void
+cfg_uri_destroy(struct cfg_uri *cfg_uri)
+{
+	cfg_uri_options_destroy(cfg_uri);
+	free(cfg_uri->options_copy);
+	memset(cfg_uri, 0, sizeof(struct cfg_uri));
+}
+
+/**
+ * Creates @a cfg_uri from string @a source. Expected format of
+ * @a source string: "uri?query", where query contains options
+ * separated by '&'. See 'cfg_uri_options_create_from_string'
+ * for details.
+ */
+static int
+cfg_uri_create_from_string(struct cfg_uri *cfg_uri, char *source,
+			   const char *cfg_option)
+{
+	cfg_uri->uri = source;
+	char *delim = strchr(source, '?');
+	if (delim == NULL)
+		return 0;
+	char *query = delim + 1;
+	if (strlen(query) == 0) {
+		diag_set(ClientError, ER_CFG, cfg_option,
+			 "not found query for URI after '?'");
+		return -1;
+	}
+	*delim = '\0';
+	if (cfg_uri_options_create_from_string(cfg_uri, query, cfg_option) != 0)
+		goto fail;
+	return 0;
+fail:
+	cfg_uri_destroy(cfg_uri);
+	return -1;
+}
+
+/**
+ * Creates 'cfg_uri_array' struct @a array from string, which located at the top
+ * of lua stack. String should contains one URI or several URIs, separated by commas.
+ * URIs format should be appropriate for 'cfg_uri_create_from_string' function.
+ */
+static int
+cfg_uri_array_create_from_string(struct cfg_uri_array *array,
+				 struct lua_State *L, const char *cfg_option)
+{
+	const char *source = lua_tostring(L, -1);
+	unsigned int size = (++array->copies_size) * sizeof(char *);
+	int pos = array->copies_size - 1;
+	array->copies = (char **)xrealloc(array->copies, size);
+	array->copies[pos] = xstrdup(source);
+	char *saveptr, *token, *uri;
+	for (uri = array->copies[pos]; ; array->size++, uri = NULL) {
+		token = strtok_r(uri, ", ", &saveptr);
+		if (token == NULL)
+			break;
+		size = (array->size + 1) * sizeof(struct cfg_uri);
+		array->uris = xrealloc(array->uris, size);
+		memset(&(array->uris[array->size]), 0, sizeof(struct cfg_uri));
+		if (cfg_uri_create_from_string(&array->uris[array->size],
+					       token, cfg_option) != 0)
+			goto fail;
+	}
+	return 0;
+fail:
+	cfg_uri_array_destroy(array);
+	return -1;
+}
+
+/**
+ * Creates 'cfg_uri_array' struct @a array from table, which located at the top
+ * of lua stack. Table can contains URIs in string or table format and options
+ * which are common to all URIs in this table.
+ */
+static int
+cfg_uri_array_create_from_table(struct cfg_uri_array *array,
+				struct lua_State *L, const char *cfg_option)
+{
+	lua_pushstring(L, "options");
+	lua_gettable(L, -2);
+	if (lua_isstring(L, -1)) {
+		const char *source = lua_tostring(L, -1);
+		struct cfg_uri *opt_storage = &array->common_options_storage;
+		if (cfg_uri_options_create_from_string(opt_storage, source,
+						       cfg_option) != 0)
+			goto fail;
+	} else if (lua_istable(L, -1)) {
+		struct cfg_uri *opt_storage = &array->common_options_storage;
+		if (cfg_uri_options_create_from_table(opt_storage, L,
+						      cfg_option) != 0)
+			goto fail;
+	} else if (!lua_isnil(L ,-1)) {
+		diag_set(ClientError, ER_CFG, cfg_option, "common URI options"
+			 "should be one of types string, table");
+		goto fail;
+	}
+	lua_pop(L, 1);
+	int size = lua_objlen(L, -1);
+	for (int i = 0; i < size; i++) {
+		lua_rawgeti(L, -1, i + 1);
+		if (lua_isstring(L, -1)) {
+			if (cfg_uri_array_create_from_string(array, L,
+							     cfg_option) != 0)
+				goto fail;
+		} else if (lua_istable(L, -1)) {
+			/** TODO */
+		} else {
+			diag_set(ClientError, ER_CFG, cfg_option,
+				 "URI should be one of types string, table");
+			goto fail;
+		}
+		lua_pop(L, 1);
+	}
+	return 0;
+fail:
+	lua_pop(L, 1);
+	cfg_uri_array_destroy(array);
+	return -1;
+}
+
+int
+cfg_uri_array_create(struct cfg_uri_array *array, struct lua_State *L,
+		     const char *cfg_option)
+{
+	memset(array, 0, sizeof(struct cfg_uri_array));
+	int rc = 0;
+	if (lua_isnil(L, -1)) {
+		array->size = 0;
+	} else if (lua_isstring(L, -1)) {
+		rc = cfg_uri_array_create_from_string(array, L, cfg_option);
+	} else if (lua_istable(L, -1)) {
+		rc = cfg_uri_array_create_from_table(array, L, cfg_option);
+	} else {
+		diag_set(ClientError, ER_CFG, cfg_option,
+			 "should be one of types string, number, table");
+		rc = -1;
+	}
+	return rc;
+}
+
+void
+cfg_uri_array_destroy(struct cfg_uri_array *array)
+{
+	cfg_uri_destroy(&array->common_options_storage);
+	for (int i = 0; i < array->size; i++)
+		cfg_uri_destroy(&array->uris[i]);
+	free(array->uris);
+	for (int i = 0; i < array->copies_size; i++)
+		free(array->copies[i]);
+	memset(array, 0, sizeof(struct cfg_uri_array));
+}

--- a/src/box/cfg_uri.h
+++ b/src/box/cfg_uri.h
@@ -1,0 +1,122 @@
+#pragma once
+/*
+ * Copyright 2010-2021, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+struct lua_State;
+
+enum cfg_uri_options {
+	CFG_URI_OPTION_BACKLOG = 0,
+	CFG_URI_OPTION_READAHEAD,
+        CFG_URI_OPTION_TRANSPORT,
+	CFG_URI_OPTION_MAX,
+};
+
+struct cfg_uri_option {
+        /**
+         * Copy of URI option. We should work with copy of
+         * appropriate string, because lua strings are constants.
+         */
+	char *copy;
+        /**
+         * Copy of URI option values strings.  We should work with
+         * copy of appropriate string, because lua strings are constants.
+         */
+        char **values_copy;
+        /** Size of 'values_copy' array */
+        int values_copy_size;
+        /** Name of URI option. */
+	const char *name;
+        /** Array of URI option values. */
+	const char **values;
+        /** Size of 'values' array. */
+	int size;
+};
+
+struct cfg_uri {
+        /** Pointer to a URI without options */
+	const char *uri;
+        /**
+         * Copy of URI options. We should work with copy of
+         * appropriate string, because lua strings are constants.
+         */
+	char *options_copy;
+        /** Array of URI options */
+	struct cfg_uri_option options[CFG_URI_OPTION_MAX];
+};
+
+/**
+ * Array of structures, each of which contains URI and its options.
+ * Also contains common URIs options, which related to all URIs.
+ */
+struct cfg_uri_array {
+	/**
+         * An array of strings that contains copies of all URI strings.
+         * These strings can contain several different URIs along with
+         * their options separated by commas. Since lua strings are
+         * constants, we should make copies of them before splitting them
+         * into parts.
+         */
+        char **copies;
+        /** Size of 'copies' array. */
+        int copies_size;
+        /** Array of resulting URIs. */
+	struct cfg_uri *uris;
+        /** Size of 'uris' array */
+	int size;
+        /**
+         * Storage of common URIs options, which related to all URIs.
+         * This options are contained in the URI structure so that
+         * the same functions can be used to get common options and
+         * options specific to a particular URI.
+         */
+	struct cfg_uri common_options_storage;
+};
+
+/**
+ * Creates @a array of structures, each of which contains URI and its options.
+ * Expects that caller puts on the top of Lua stack a string or a table which
+ * contains URI in a specific format.
+ */
+int
+cfg_uri_array_create(struct cfg_uri_array *array, struct lua_State *L,
+		     const char *cfg_option);
+
+/** Destroys @a array and frees all associated resources. */
+void
+cfg_uri_array_destroy(struct cfg_uri_array *array);
+
+#if defined(__cplusplus)
+} /* extern "C" { */
+#endif

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -35,7 +35,7 @@
 
 enum { MAX_OPT_NAME_LEN = 256, MAX_OPT_VAL_LEN = 256 };
 
-static void
+void
 cfg_get(const char *param)
 {
 	const char *buf =

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -37,6 +37,9 @@
 extern "C" {
 #endif /* defined(__cplusplus) */
 
+void
+cfg_get(const char *param);
+
 int
 cfg_geti(const char *param);
 

--- a/test/box/several-uris-with-properties.result
+++ b/test/box/several-uris-with-properties.result
@@ -1,0 +1,47 @@
+test_run = require('test_run').new()
+---
+...
+net_box = require('net.box')
+---
+...
+fio = require('fio')
+---
+...
+default_listen_addr = box.cfg.listen
+---
+...
+unix_socket_path = "unix/:" .. "./tarantool"
+---
+...
+-- Check ability to pass several listening uris in one string
+-- with different properties
+test_run:cmd("setopt delimiter ';'")
+---
+- true
+...
+valid_listen_uris = {
+    unix_socket_path .. "A" .. "," .. unix_socket_path .. "B",
+    unix_socket_path .. "A" .. "?backlog=10;20",
+    unix_socket_path .. "A" .. "?backlog=10&backlog=20",
+    unix_socket_path .. "A" .. "?backlog=10;20&backlog=30;40",
+    unix_socket_path .. "A" .. "?backlog=10&readahead=2048",
+    unix_socket_path .. "A" .. "?backlog=10;20&readahead=2048;4096",
+    unix_socket_path .. "A" .. "?backlog=10&backlog=20" .. "&" ..
+                               "readahead=2048&readahead=4096",
+    unix_socket_path .. "A" .. "?backlog=10;20&backlog=30;40" .. "&" ..
+                               "readahead=2048;4096&readahead=8192;16384",
+    unix_socket_path .. "A" .. "?backlog=10;20&backlog=30;40" .. "&" ..
+                               "readahead=2048;4096&readahead=8192;16384" ..
+                               ", " ..
+    unix_socket_path .. "B" .. "?backlog=10;20&backlog=30;40" .. "&" ..
+                               "readahead=2048;4096&readahead=8192;16384" ..
+                               ", " ..
+    unix_socket_path .. "C" .. "?backlog=10;20&backlog=30;40" .. "&" ..
+                               "readahead=2048;4096&readahead=8192;16384"
+};
+---
+...
+test_run:cmd("setopt delimiter ''");
+---
+- true
+...

--- a/test/box/several-uris-with-properties.test.lua
+++ b/test/box/several-uris-with-properties.test.lua
@@ -1,0 +1,30 @@
+test_run = require('test_run').new()
+net_box = require('net.box')
+fio = require('fio')
+
+default_listen_addr = box.cfg.listen
+unix_socket_path = "unix/:" .. "./tarantool"
+-- Check ability to pass several listening uris in one string
+-- with different properties
+test_run:cmd("setopt delimiter ';'")
+valid_listen_uris = {
+    unix_socket_path .. "A" .. "," .. unix_socket_path .. "B",
+    unix_socket_path .. "A" .. "?backlog=10;20",
+    unix_socket_path .. "A" .. "?backlog=10&backlog=20",
+    unix_socket_path .. "A" .. "?backlog=10;20&backlog=30;40",
+    unix_socket_path .. "A" .. "?backlog=10&readahead=2048",
+    unix_socket_path .. "A" .. "?backlog=10;20&readahead=2048;4096",
+    unix_socket_path .. "A" .. "?backlog=10&backlog=20" .. "&" ..
+                               "readahead=2048&readahead=4096",
+    unix_socket_path .. "A" .. "?backlog=10;20&backlog=30;40" .. "&" ..
+                               "readahead=2048;4096&readahead=8192;16384",
+    unix_socket_path .. "A" .. "?backlog=10;20&backlog=30;40" .. "&" ..
+                               "readahead=2048;4096&readahead=8192;16384" ..
+                               ", " ..
+    unix_socket_path .. "B" .. "?backlog=10;20&backlog=30;40" .. "&" ..
+                               "readahead=2048;4096&readahead=8192;16384" ..
+                               ", " ..
+    unix_socket_path .. "C" .. "?backlog=10;20&backlog=30;40" .. "&" ..
+                               "readahead=2048;4096&readahead=8192;16384"
+};
+test_run:cmd("setopt delimiter ''");

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -189,6 +189,13 @@ set(ITERATOR_TEST_LIBS core tuple xrow unit)
 add_executable(vy_mem.test vy_mem.c ${ITERATOR_TEST_SOURCES} core_test_utils.c)
 target_link_libraries(vy_mem.test ${ITERATOR_TEST_LIBS} ${LIB_DL})
 
+add_executable(cfg_uri.test
+    cfg_uri.c
+    unit.c
+    ${PROJECT_SOURCE_DIR}/src/box/cfg_uri.c
+)
+target_link_libraries(cfg_uri.test box core unit)
+
 add_executable(vy_point_lookup.test
     vy_point_lookup.c
     vy_iterators_helper.c

--- a/test/unit/cfg_uri.c
+++ b/test/unit/cfg_uri.c
@@ -1,0 +1,553 @@
+#include "unit.h"
+#include "cfg_uri.h"
+#include "lua/utils.h"
+#include "trivia/util.h"
+#include "diag.h"
+#include "memory.h"
+#include "fiber.h"
+#include "tt_static.h"
+
+#include <stdio.h>
+
+#define BASE_URI_NAME "/path_to_unix_socket"
+#define BASE_URI_NAME_LEN sizeof(BASE_URI_NAME) - 1
+
+struct cfg_uri_validator {
+	/**
+	 * Expected count of options for URI at the top of the
+	 * lua stack. Should be same for all URIs.
+	 */
+	int opt_cnt;
+	/**
+	 * First option value, should be same for all URIs.
+	 * Each next value should be twice as large as the
+	 * previous one.
+	 */
+	int first_optval;
+	/**
+	 * Count of option values. Should be same for all
+	 * options of all URIs.
+	 */
+	int optval_cnt;
+};
+
+/**
+ * A structure that contains the information expected
+ * after URI parsing
+ */
+struct cfg_uri_array_validator {
+	/**
+	 * Some meta information used for in the validation
+	 * function (may be URI, some URI options or just
+	 * log message).
+	 */
+	const char *meta;
+	/** Expected count of URI at the top of the lua stack. */
+	int uri_cnt;
+	/** Expected settings for all URIs. */
+	struct cfg_uri_validator uris_validator;
+	/** Expected settings for common URIs options */
+	struct cfg_uri_validator common_options_validator;
+};
+
+/**
+ * Check count of values of the URI @a option. Each @a option
+ * value should be a string, which contain number. Each next
+ * option value should be twice as large as the previous one.
+ */
+static int
+cfg_uri_option_validate(const struct cfg_uri_option *option,
+			const struct cfg_uri_validator *validator)
+{
+	plan(1 + option->size);
+	is(option->size, validator->optval_cnt,
+	   tt_sprintf("'%s' count of values of the URI option is valid",
+		      option->name));
+	int optval  = validator->first_optval;
+	for (int i = 0; i < option->size; i++, optval *= 2) {
+		char string_optval[13];
+		snprintf(string_optval, sizeof(string_optval), "%d", optval);
+		is(strcmp(option->values[i], string_optval),
+		   0, "value of URI option is valid")
+	}
+	return check_plan();
+}
+
+/**
+ * Check single URI structure. All options which
+ * are missing should be zeroed.
+ */
+static int
+cfg_uri_validate(const struct cfg_uri *uri,
+		 const struct cfg_uri_validator *validator)
+{
+	plan(CFG_URI_OPTION_MAX);
+	for (int i = validator->opt_cnt; i < CFG_URI_OPTION_MAX; i++) {
+		struct cfg_uri_option opt = {0};
+		int rc = memcmp(&uri->options[i], &opt,
+				sizeof(struct cfg_uri_option));
+		is(rc, 0, "missing URI options are zeroed")
+	}
+	for (int i = 0; i < validator->opt_cnt; i++)
+		cfg_uri_option_validate(&uri->options[i], validator);
+	return check_plan();
+}
+
+/**
+ * Check @a array, structure according to expected @a validator.
+ */
+static int
+cfg_uri_array_validate(const struct cfg_uri_array *array,
+		       const struct cfg_uri_array_validator *validator)
+{
+	plan(1 + 2 * validator->uri_cnt + 1);
+	is (array->size, validator->uri_cnt, "count of URIs is valid");
+	for (int i = 0; i < array->size; i++) {
+		char uri[BASE_URI_NAME_LEN + 3];
+		strcpy(uri, BASE_URI_NAME);
+		strcat(uri, tt_sprintf("_%d", i + 1));
+		is(strcmp(array->uris[i].uri, uri), 0, "URI is valid");
+		cfg_uri_validate(&array->uris[i], &validator->uris_validator);
+	}
+	cfg_uri_validate(&array->common_options_storage,
+			 &validator->common_options_validator);
+	return check_plan();
+}
+
+/**
+ * Check that URI located at the top position of the lua stack
+ * parsed successfully and meets expectations. Pay attention,
+ * this function relies on the several facts:
+ * - first URI has a name `/path_to_unix_socket_1` and for each
+ *   subsequent URI, the digit at the end of the name increases
+ *   by 1.
+ * - URI options are passed in order based on `cfg_uri_options`
+ *   enuum. It means that if opt_cnt == 2, we pass `backlog` and
+ *   `readahead` options.
+ * - We check only such options that have the `int` type. Option
+ *   values count is same for all passsed options. Each subsequent
+ *   option value is twice as large as the previous one.
+ */
+static void
+check_valid_parse(const struct cfg_uri_array_validator *validator,
+		  struct lua_State *L)
+{
+	struct cfg_uri_array array;
+	int rc = cfg_uri_array_create(&array, L, "listen");
+	const char *errmsg = (rc != 0 ?
+		diag_last_error(diag_get())->errmsg :
+		tt_sprintf("%s: parsed successfully", validator->meta));
+	is(rc, 0, "%s", errmsg);
+	if (rc == 0) {
+		cfg_uri_array_validate(&array, validator);
+		cfg_uri_array_destroy(&array);
+	}
+}
+
+/**
+ * Check that URI located at the top of the stack is invalid.
+ */
+static void
+check_invalid_parse(const char *listen, struct lua_State *L)
+{
+	struct cfg_uri_array array;
+	int rc = cfg_uri_array_create(&array, L, "listen");
+	const char *errmsg = (rc != 0 ?
+		diag_last_error(diag_get())->errmsg :
+		tt_sprintf("%s: is invalid", listen));
+	isnt(rc, 0, "%s", errmsg);
+	if (rc == 0)
+		cfg_uri_array_destroy(&array);
+}
+
+
+static void
+prepare_string_uri_array(const char **string_uri, unsigned size,
+			 struct lua_State *L)
+{
+	lua_newtable(L);
+	for (unsigned int i = 0; i < size; i++) {
+		lua_pushstring(L, string_uri[i]);
+		lua_rawseti(L, -2, i + 1);
+	}
+}
+
+static int
+test_valid_string_uri(struct lua_State *L)
+{
+	const struct cfg_uri_array_validator validator_array[] = {
+		/* One string URI without options. */
+		{
+			/* meta = */ BASE_URI_NAME "_1",
+			/* uri_count = */ 1,
+			/* uris_validator = */ {
+				/* opt_cnt = */ 0,
+				/* first_optval = */ 0,
+				/* optval_cnt = */ 0,
+			},
+			/* common_options_validator = */ { 0 },
+		},
+		/* One string URI with one option and one option value. */
+		{
+			/* meta = */ BASE_URI_NAME "_1"
+				     "?" "backlog=10",
+			/* uri_count = */ 1,
+			/* uris_validator = */ {
+				/* opt_cnt = */ 1,
+				/* first_optval = */ 10,
+				/* optval_cnt = */ 1,
+			},
+			/* common_options_validator = */ { 0 },
+		},
+		/*
+		 * One string URI with one option and two option values,
+		 * separated by ";".
+		 */
+		{
+			/* meta = */ BASE_URI_NAME "_1"
+				     "?" "backlog=10;20",
+			/* uri_count = */ 1,
+			/* uris_validator = */ {
+				/* opt_cnt = */ 1,
+				/* first_optval = */ 10,
+				/* optval_cnt = */ 2,
+			},
+			/* common_options_validator = */ { 0 },
+		},
+		/*
+		 * One string URI with one option and two option values,
+		 * separated by "&".
+		 */
+		{
+			/* meta = */ BASE_URI_NAME "_1"
+				     "?" "backlog=10&backlog=20",
+			/* uri_count = */ 1,
+			/* uris_validator = */ {
+				/* opt_cnt = */ 1,
+				/* first_optval = */ 10,
+				/* optval_cnt = */ 2,
+			},
+			/* common_options_validator = */ { 0 },
+		},
+		/*
+		 * One string URI with one option and several option values,
+		 * passed in different ways.
+		 */
+		{
+			/* meta = */ BASE_URI_NAME "_1"
+				     "?" "backlog=10;20&backlog=40;80",
+			/* uri_count = */ 1,
+			/* uris_validator = */ {
+				/* opt_cnt = */ 1,
+				/* first_optval = */ 10,
+				/* optval_cnt = */ 4,
+			},
+			/* common_options_validator = */ { 0 },
+		},
+		/*
+		 * One string URI with several options and several option
+		 * values, passed in different ways.
+		 */
+		{
+			/* meta = */ BASE_URI_NAME "_1"
+				     "?" "backlog=2048;4096&backlog=8192;16384"
+				     "&" "readahead=2048;4096"
+				     "&" "readahead=8192;16384",
+			/* uri_count = */ 1,
+			/* uris_validator = */ {
+				/* opt_cnt = */ 2,
+				/* first_optval = */ 2048,
+				/* optval_cnt = */ 4,
+			},
+			/* common_options_validator = */ { 0 },
+		},
+		/*
+		 * Two string URIs separated by commas, with several options
+		 * and several option values, passed in different ways.
+		 */
+		{
+			/* meta = */ BASE_URI_NAME "_1"
+				     "?" "backlog=2048;4096&backlog=8192;16384"
+				     "&" "readahead=2048;4096"
+				     "&" "readahead=8192;16384"
+				     ", "
+				     BASE_URI_NAME "_2"
+				     "?" "backlog=2048;4096&backlog=8192;16384"
+				     "&" "readahead=2048;4096"
+				     "&" "readahead=8192;16384",
+			/* uri_count = */ 2,
+			/* uris_validator = */ {
+				/* opt_cnt = */ 2,
+				/* first_optval = */ 2048,
+				/* optval_cnt = */ 4,
+			},
+			/* common_options_validator = */ { 0 },
+		},
+	};
+	plan(2 * lengthof(validator_array));
+	for (unsigned i = 0; i < lengthof(validator_array); i++) {
+		lua_pushstring(L, validator_array[i].meta);
+		check_valid_parse(&validator_array[i], L);
+		lua_pop(L, 1);
+	}
+	return check_plan();
+}
+
+static int
+test_invalid_string_uri(struct lua_State *L)
+{
+	const char *string_uri[] = {
+		/** not found query for URI after '?' */
+		"/path_to_unix_socket?",
+		/** not found option value for URI */
+		"/path_to_unix_socket??",
+		/** not found option for URI after '&' */
+		"/path_to_unix_socket?backlog=10&",
+		/** Same as previous, but for URI with several options. */
+		"/path_to_unix_socket?backlog=10&backlog=20&",
+		/** not found option for URI after '&' */
+		"/path_to_unix_socket?backlog=10&&backlog=20",
+		/** not found option value for URI */
+		"/path_to_unix_socket?backlog",
+		/** Same as previous, but for URI with several options. */
+		"/path_to_unix_socket?backlog=10&backlog",
+		/** not found option value for URI after '=' */
+		"/path_to_unix_socket?backlog=",
+		/** Same as previous, but for URI with several options. */
+		"/path_to_unix_socket?backlog=10&backlog=",
+		/** invalid option name for URI */
+		"/path_to_unix_socket?unexpected_option=10",
+		/** not found option value for URI */
+		"/path_to_unix_socket?backlog=10;",
+		/** Same as previous, but for URI with several option values. */
+		"/path_to_unix_socket?backlog=10;20;",
+		/** not found option value for URI */
+		"/path_to_unix_socket?backlog=10;;20",
+	};
+	plan(lengthof(string_uri));
+	for (unsigned i = 0; i < lengthof(string_uri); i++) {
+		lua_pushstring(L, string_uri[i]);
+		check_invalid_parse(string_uri[i], L);
+		lua_pop(L, 1);
+	}
+	return check_plan();
+}
+
+static int
+test_common_options_string(struct lua_State *L)
+{
+	/*
+	 * Common options passed in the string are passed
+	 * as if they were part of a URI.
+	 */
+	const struct cfg_uri_array_validator validator_array[] = {
+		{
+			/* meta = */ "backlog=10",
+			/* uri_count = */ 0,
+			/* uris_validator = */ { 0 },
+			/* common_options_validator = */ {
+				/* opt_cnt = */ 1,
+				/* first_optval = */ 10,
+				/* optval_cnt = */ 1,
+			},
+		},
+		{
+			/* meta = */ "backlog=10;20",
+			/* uri_count = */ 0,
+			/* uris_validator = */ { 0 },
+			/* common_options_validator = */ {
+				/* opt_cnt = */ 1,
+				/* first_optval = */ 10,
+				/* optval_cnt = */ 2,
+			},
+		},
+		{
+			/* meta = */ "backlog=10&backlog=20",
+			/* uri_count = */ 0,
+			/* uris_validator = */ { 0 },
+			/* common_options_validator = */ {
+				/* opt_cnt = */ 1,
+				/* first_optval = */ 10,
+				/* optval_cnt = */ 2,
+			},
+		},
+		{
+			/* meta = */ "backlog=10;20&backlog=40;80",
+			/* uri_count = */ 0,
+			/* uris_validator = */ { 0 },
+			/* common_options_validator = */ {
+				/* opt_cnt = */ 1,
+				/* first_optval = */ 10,
+				/* optval_cnt = */ 4,
+			},
+		},
+		{
+			/* meta = */ "backlog=2048;4096&backlog=8192;16384"
+				     "&" "readahead=2048;4096"
+				     "&" "readahead=8192;16384",
+			/* uri_count = */ 0,
+			/* uris_validator = */ { 0 },
+			/* common_options_validator = */ {
+				/* opt_cnt = */ 2,
+				/* first_optval = */ 2048,
+				/* optval_cnt = */ 4,
+			},
+		},
+	};
+	const char *invalid_common_options[] = {
+		"backlog=10&",
+		"backlog=10&backlog=20&",
+		"backlog=10&&backlog=20",
+		"backlog",
+		"backlog=10&backlog",
+		"backlog=",
+		"backlog=10&backlog=",
+		"unexpected_option=10",
+		"backlog=10;",
+		"backlog=10;20;",
+		"backlog=10;;20",
+	};
+	plan(2 * lengthof(validator_array) + lengthof(invalid_common_options));
+	for (unsigned i = 0; i < lengthof(validator_array); i++) {
+		lua_newtable(L);
+		lua_pushstring(L, "options");
+		lua_pushstring(L, validator_array[i].meta);
+		lua_settable(L, -3);
+		check_valid_parse(&validator_array[i], L);
+		lua_pop(L, 1);
+	}
+	for (unsigned i = 0; i < lengthof(invalid_common_options); i++) {
+		lua_newtable(L);
+		lua_pushstring(L, "options");
+		lua_pushstring(L, invalid_common_options[i]);
+		lua_settable(L, -3);
+		check_invalid_parse(invalid_common_options[i], L);
+		lua_pop(L, 1);
+	}
+	return check_plan();
+}
+
+static int
+test_common_options_table(struct lua_State *L)
+{
+	/*
+	 * Common options passed in the string are passed
+	 * as if they were part of a URI.
+	 */
+	const struct cfg_uri_array_validator validator_array[] = {
+		{
+			/* meta = */ "10",
+			/* uri_count = */ 0,
+			/* uris_validator = */ { 0 },
+			/* common_options_validator = */ {
+				/* opt_cnt = */ 1,
+				/* first_optval = */ 10,
+				/* optval_cnt = */ 1,
+			},
+		},
+		{
+			/* meta = */ "10;20;40;80",
+			/* uri_count = */ 0,
+			/* uris_validator = */ { 0 },
+			/* common_options_validator = */ {
+				/* opt_cnt = */ 1,
+				/* first_optval = */ 10,
+				/* optval_cnt = */ 4,
+			},
+		},
+	};
+	const char *invalid_common_options_values[] = {
+		"10;",
+		"10;;20",
+	};
+	plan(2 * lengthof(validator_array) +
+	     lengthof(invalid_common_options_values));
+	lua_newtable(L);
+	lua_pushstring(L, "options");
+	lua_newtable(L);
+	lua_settable(L, -3);
+	for (unsigned i = 0; i < lengthof(validator_array); i++) {
+		lua_pushstring(L, "options");
+		lua_gettable(L, -2);
+		lua_pushstring(L, "backlog");
+		lua_pushstring(L, validator_array[i].meta);
+		lua_settable(L, -3);
+		lua_pop(L, 1);
+		check_valid_parse(&validator_array[i], L);
+	}
+	for (unsigned i = 0; i < lengthof(invalid_common_options_values); i++) {
+		lua_pushstring(L, "options");
+		lua_gettable(L, -2);
+		lua_pushstring(L, "backlog");
+		lua_pushstring(L, invalid_common_options_values[i]);
+		lua_settable(L, -3);
+		lua_pop(L, 1);
+		check_invalid_parse(invalid_common_options_values[i], L);
+	}
+	lua_pop(L, 1);
+	return check_plan();
+}
+
+static int
+test_string_uri_array(struct lua_State *L)
+{
+	/**
+	 * URI array with same options, but passed in different ways
+	 */
+	const char *string_uri[] = {
+		BASE_URI_NAME "_1" "?" "backlog=2048&backlog=4096"
+				   "&" "backlog=8192&backlog=16384"
+				   "&" "readahead=2048&readahead=4096"
+				   "&" "readahead=8192&readahead=16384",
+		BASE_URI_NAME "_2" "?" "backlog=2048;4096&backlog=8192;16384"
+				   "&" "readahead=2048;4096"
+				   "&" "readahead=8192;16384",
+		BASE_URI_NAME "_3" "?" "backlog=2048;4096;8192;16384"
+				   "&" "readahead=2048;4096"
+				   "&" "readahead=8192;16384"
+				   ", "
+		BASE_URI_NAME "_4" "?" "backlog=2048;4096;8192;16384"
+				   "&" "readahead=2048;4096;8192;16384",
+		/**
+		 * Invalid URI: not found query for URI after '?'.
+		 * Used to check graceful resource release in case when
+		 * we try to parse invalid URI array.
+		 */
+		BASE_URI_NAME "?",
+	};
+	const struct cfg_uri_array_validator validator_array = {
+			/* meta = */ "string URI array",
+			/* uri_count = */ 4,
+			/* uris_validator = */ {
+				/* opt_cnt = */ 2,
+				/* first_optval = */ 2048,
+				/* optval_cnt = */ 4,
+			},
+			/* common_options_validator = */ { 0 },
+	};
+	plan(2 + 1);
+	prepare_string_uri_array(string_uri, lengthof(string_uri) - 1, L);
+	check_valid_parse(&validator_array, L);
+	lua_pop(L, 1);
+	prepare_string_uri_array(string_uri, lengthof(string_uri), L);
+	check_invalid_parse("string URI array", L);
+	lua_pop(L, 1);
+	return check_plan();
+}
+
+int
+main(void)
+{
+	memory_init();
+	fiber_init(fiber_c_invoke);
+	lua_State* L = lua_open();
+	plan(5);
+	test_valid_string_uri(L);
+	test_invalid_string_uri(L);
+	test_common_options_string(L);
+	test_common_options_table(L);
+	test_string_uri_array(L);
+	fiber_free();
+	memory_free();
+	return check_plan();
+}

--- a/test/unit/cfg_uri.result
+++ b/test/unit/cfg_uri.result
@@ -1,0 +1,384 @@
+1..5
+    1..14
+    ok 1 - /path_to_unix_socket_1: parsed successfully
+        1..4
+        ok 1 - count of URIs is valid
+        ok 2 - URI is valid
+            1..3
+            ok 1 - missing URI options are zeroed
+            ok 2 - missing URI options are zeroed
+            ok 3 - missing URI options are zeroed
+        ok 3 - subtests
+            1..3
+            ok 1 - missing URI options are zeroed
+            ok 2 - missing URI options are zeroed
+            ok 3 - missing URI options are zeroed
+        ok 4 - subtests
+    ok 2 - subtests
+    ok 3 - /path_to_unix_socket_1?backlog=10: parsed successfully
+        1..4
+        ok 1 - count of URIs is valid
+        ok 2 - URI is valid
+            1..3
+            ok 1 - missing URI options are zeroed
+            ok 2 - missing URI options are zeroed
+                1..2
+                ok 1 - 'backlog' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+            ok 3 - subtests
+        ok 3 - subtests
+            1..3
+            ok 1 - missing URI options are zeroed
+            ok 2 - missing URI options are zeroed
+            ok 3 - missing URI options are zeroed
+        ok 4 - subtests
+    ok 4 - subtests
+    ok 5 - /path_to_unix_socket_1?backlog=10;20: parsed successfully
+        1..4
+        ok 1 - count of URIs is valid
+        ok 2 - URI is valid
+            1..3
+            ok 1 - missing URI options are zeroed
+            ok 2 - missing URI options are zeroed
+                1..3
+                ok 1 - 'backlog' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+            ok 3 - subtests
+        ok 3 - subtests
+            1..3
+            ok 1 - missing URI options are zeroed
+            ok 2 - missing URI options are zeroed
+            ok 3 - missing URI options are zeroed
+        ok 4 - subtests
+    ok 6 - subtests
+    ok 7 - /path_to_unix_socket_1?backlog=10&backlog=20: parsed successfully
+        1..4
+        ok 1 - count of URIs is valid
+        ok 2 - URI is valid
+            1..3
+            ok 1 - missing URI options are zeroed
+            ok 2 - missing URI options are zeroed
+                1..3
+                ok 1 - 'backlog' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+            ok 3 - subtests
+        ok 3 - subtests
+            1..3
+            ok 1 - missing URI options are zeroed
+            ok 2 - missing URI options are zeroed
+            ok 3 - missing URI options are zeroed
+        ok 4 - subtests
+    ok 8 - subtests
+    ok 9 - /path_to_unix_socket_1?backlog=10;20&backlog=40;80: parsed successfully
+        1..4
+        ok 1 - count of URIs is valid
+        ok 2 - URI is valid
+            1..3
+            ok 1 - missing URI options are zeroed
+            ok 2 - missing URI options are zeroed
+                1..5
+                ok 1 - 'backlog' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+                ok 4 - value of URI option is valid
+                ok 5 - value of URI option is valid
+            ok 3 - subtests
+        ok 3 - subtests
+            1..3
+            ok 1 - missing URI options are zeroed
+            ok 2 - missing URI options are zeroed
+            ok 3 - missing URI options are zeroed
+        ok 4 - subtests
+    ok 10 - subtests
+    ok 11 - /path_to_unix_socket_1?backlog=2048;4096&backlog=8192;16384&readahead=2048;4096&readahead=8192;16384: parsed successfully
+        1..4
+        ok 1 - count of URIs is valid
+        ok 2 - URI is valid
+            1..3
+            ok 1 - missing URI options are zeroed
+                1..5
+                ok 1 - 'backlog' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+                ok 4 - value of URI option is valid
+                ok 5 - value of URI option is valid
+            ok 2 - subtests
+                1..5
+                ok 1 - 'readahead' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+                ok 4 - value of URI option is valid
+                ok 5 - value of URI option is valid
+            ok 3 - subtests
+        ok 3 - subtests
+            1..3
+            ok 1 - missing URI options are zeroed
+            ok 2 - missing URI options are zeroed
+            ok 3 - missing URI options are zeroed
+        ok 4 - subtests
+    ok 12 - subtests
+    ok 13 - /path_to_unix_socket_1?backlog=2048;4096&backlog=8192;16384&readahead=2048;4096&readahead=8192;16384, /path_to_unix_socket_2?backlog=2048;4096&backlog=8192;16384&readahead=2048;4096&readahead=8192;16384: parsed successfully
+        1..6
+        ok 1 - count of URIs is valid
+        ok 2 - URI is valid
+            1..3
+            ok 1 - missing URI options are zeroed
+                1..5
+                ok 1 - 'backlog' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+                ok 4 - value of URI option is valid
+                ok 5 - value of URI option is valid
+            ok 2 - subtests
+                1..5
+                ok 1 - 'readahead' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+                ok 4 - value of URI option is valid
+                ok 5 - value of URI option is valid
+            ok 3 - subtests
+        ok 3 - subtests
+        ok 4 - URI is valid
+            1..3
+            ok 1 - missing URI options are zeroed
+                1..5
+                ok 1 - 'backlog' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+                ok 4 - value of URI option is valid
+                ok 5 - value of URI option is valid
+            ok 2 - subtests
+                1..5
+                ok 1 - 'readahead' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+                ok 4 - value of URI option is valid
+                ok 5 - value of URI option is valid
+            ok 3 - subtests
+        ok 5 - subtests
+            1..3
+            ok 1 - missing URI options are zeroed
+            ok 2 - missing URI options are zeroed
+            ok 3 - missing URI options are zeroed
+        ok 6 - subtests
+    ok 14 - subtests
+ok 1 - subtests
+    1..13
+    ok 1 - Incorrect value for option 'listen': not found query for URI after '?'
+    ok 2 - Incorrect value for option 'listen': not found option value for URI
+    ok 3 - Incorrect value for option 'listen': not found option for URI after '&'
+    ok 4 - Incorrect value for option 'listen': not found option for URI after '&'
+    ok 5 - Incorrect value for option 'listen': not found option for URI after '&'
+    ok 6 - Incorrect value for option 'listen': not found option value for URI
+    ok 7 - Incorrect value for option 'listen': not found option value for URI
+    ok 8 - Incorrect value for option 'listen': not found option value for URI after '='
+    ok 9 - Incorrect value for option 'listen': not found option value for URI after '='
+    ok 10 - Incorrect value for option 'listen': invalid option name for URI
+    ok 11 - Incorrect value for option 'listen': not found option value for URI
+    ok 12 - Incorrect value for option 'listen': not found option value for URI
+    ok 13 - Incorrect value for option 'listen': not found option value for URI
+ok 2 - subtests
+    1..21
+    ok 1 - backlog=10: parsed successfully
+        1..2
+        ok 1 - count of URIs is valid
+            1..3
+            ok 1 - missing URI options are zeroed
+            ok 2 - missing URI options are zeroed
+                1..2
+                ok 1 - 'backlog' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+            ok 3 - subtests
+        ok 2 - subtests
+    ok 2 - subtests
+    ok 3 - backlog=10;20: parsed successfully
+        1..2
+        ok 1 - count of URIs is valid
+            1..3
+            ok 1 - missing URI options are zeroed
+            ok 2 - missing URI options are zeroed
+                1..3
+                ok 1 - 'backlog' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+            ok 3 - subtests
+        ok 2 - subtests
+    ok 4 - subtests
+    ok 5 - backlog=10&backlog=20: parsed successfully
+        1..2
+        ok 1 - count of URIs is valid
+            1..3
+            ok 1 - missing URI options are zeroed
+            ok 2 - missing URI options are zeroed
+                1..3
+                ok 1 - 'backlog' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+            ok 3 - subtests
+        ok 2 - subtests
+    ok 6 - subtests
+    ok 7 - backlog=10;20&backlog=40;80: parsed successfully
+        1..2
+        ok 1 - count of URIs is valid
+            1..3
+            ok 1 - missing URI options are zeroed
+            ok 2 - missing URI options are zeroed
+                1..5
+                ok 1 - 'backlog' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+                ok 4 - value of URI option is valid
+                ok 5 - value of URI option is valid
+            ok 3 - subtests
+        ok 2 - subtests
+    ok 8 - subtests
+    ok 9 - backlog=2048;4096&backlog=8192;16384&readahead=2048;4096&readahead=8192;16384: parsed successfully
+        1..2
+        ok 1 - count of URIs is valid
+            1..3
+            ok 1 - missing URI options are zeroed
+                1..5
+                ok 1 - 'backlog' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+                ok 4 - value of URI option is valid
+                ok 5 - value of URI option is valid
+            ok 2 - subtests
+                1..5
+                ok 1 - 'readahead' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+                ok 4 - value of URI option is valid
+                ok 5 - value of URI option is valid
+            ok 3 - subtests
+        ok 2 - subtests
+    ok 10 - subtests
+    ok 11 - Incorrect value for option 'listen': not found option for URI after '&'
+    ok 12 - Incorrect value for option 'listen': not found option for URI after '&'
+    ok 13 - Incorrect value for option 'listen': not found option for URI after '&'
+    ok 14 - Incorrect value for option 'listen': not found option value for URI
+    ok 15 - Incorrect value for option 'listen': not found option value for URI
+    ok 16 - Incorrect value for option 'listen': not found option value for URI after '='
+    ok 17 - Incorrect value for option 'listen': not found option value for URI after '='
+    ok 18 - Incorrect value for option 'listen': invalid option name for URI
+    ok 19 - Incorrect value for option 'listen': not found option value for URI
+    ok 20 - Incorrect value for option 'listen': not found option value for URI
+    ok 21 - Incorrect value for option 'listen': not found option value for URI
+ok 3 - subtests
+    1..6
+    ok 1 - 10: parsed successfully
+        1..2
+        ok 1 - count of URIs is valid
+            1..3
+            ok 1 - missing URI options are zeroed
+            ok 2 - missing URI options are zeroed
+                1..2
+                ok 1 - '(null)' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+            ok 3 - subtests
+        ok 2 - subtests
+    ok 2 - subtests
+    ok 3 - 10;20;40;80: parsed successfully
+        1..2
+        ok 1 - count of URIs is valid
+            1..3
+            ok 1 - missing URI options are zeroed
+            ok 2 - missing URI options are zeroed
+                1..5
+                ok 1 - '(null)' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+                ok 4 - value of URI option is valid
+                ok 5 - value of URI option is valid
+            ok 3 - subtests
+        ok 2 - subtests
+    ok 4 - subtests
+    ok 5 - Incorrect value for option 'listen': not found option value for URI
+    ok 6 - Incorrect value for option 'listen': not found option value for URI
+ok 4 - subtests
+    1..3
+    ok 1 - string URI array: parsed successfully
+        1..10
+        ok 1 - count of URIs is valid
+        ok 2 - URI is valid
+            1..3
+            ok 1 - missing URI options are zeroed
+                1..5
+                ok 1 - 'backlog' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+                ok 4 - value of URI option is valid
+                ok 5 - value of URI option is valid
+            ok 2 - subtests
+                1..5
+                ok 1 - 'readahead' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+                ok 4 - value of URI option is valid
+                ok 5 - value of URI option is valid
+            ok 3 - subtests
+        ok 3 - subtests
+        ok 4 - URI is valid
+            1..3
+            ok 1 - missing URI options are zeroed
+                1..5
+                ok 1 - 'backlog' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+                ok 4 - value of URI option is valid
+                ok 5 - value of URI option is valid
+            ok 2 - subtests
+                1..5
+                ok 1 - 'readahead' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+                ok 4 - value of URI option is valid
+                ok 5 - value of URI option is valid
+            ok 3 - subtests
+        ok 5 - subtests
+        ok 6 - URI is valid
+            1..3
+            ok 1 - missing URI options are zeroed
+                1..5
+                ok 1 - 'backlog' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+                ok 4 - value of URI option is valid
+                ok 5 - value of URI option is valid
+            ok 2 - subtests
+                1..5
+                ok 1 - 'readahead' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+                ok 4 - value of URI option is valid
+                ok 5 - value of URI option is valid
+            ok 3 - subtests
+        ok 7 - subtests
+        ok 8 - URI is valid
+            1..3
+            ok 1 - missing URI options are zeroed
+                1..5
+                ok 1 - 'backlog' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+                ok 4 - value of URI option is valid
+                ok 5 - value of URI option is valid
+            ok 2 - subtests
+                1..5
+                ok 1 - 'readahead' count of values of the URI option is valid
+                ok 2 - value of URI option is valid
+                ok 3 - value of URI option is valid
+                ok 4 - value of URI option is valid
+                ok 5 - value of URI option is valid
+            ok 3 - subtests
+        ok 9 - subtests
+            1..3
+            ok 1 - missing URI options are zeroed
+            ok 2 - missing URI options are zeroed
+            ok 3 - missing URI options are zeroed
+        ok 10 - subtests
+    ok 2 - subtests
+    ok 3 - Incorrect value for option 'listen': not found query for URI after '?'
+ok 5 - subtests

--- a/test/unit/suite.ini
+++ b/test/unit/suite.ini
@@ -2,5 +2,5 @@
 core = unittest
 description = unit tests
 disabled = snap_quorum_delay.test
-release_disabled = fiber_stack.test swim_errinj.test
+release_disabled = fiber_stack.test swim_errinj.test cfg_uri.test
 is_parallel = True


### PR DESCRIPTION
Previously, uri can be passed as a number, as a string value or as
a table, which contains numbers and strings, no special properties
for uris was available. Now user can pass uris in different ways:
as before, as strings which contains several uris, separated by
commas, as a table which contains uri and it's properties, as a
table which contains different combinations of previously described
methods. Also there are different ways to specify properties for uri:
in a string which contains uri, after '?' delimiter, in a table which
contains uri, in a table, which contains several uris in a field with
name "options" (this options will be common for all uris in this table).

Closes #5928

@TarantoolBot document
Title: ability to pass uris in different ways with properties
Implement ability to pass several listening uries in different ways
with different properties: as strings which contains several uris,
separated by commas, as a table which contains uri and it's properties,
as a table which contains different combinations of previously described
methods. Also there are different ways to specify properties for uri:
in a string which contains uri, after '?' delimiter, in a table which
contains uri, in a table, which contains several uris in a field with
name "options" (this options will be common for all uris in this table)
For example:
``` lua
-- one string address
box.cfg { listen = '10.10.0.1:3301' }
-- array with one string address
box.cfg { listen = {'10.10.0.1:3301'} }
-- array with two string addresses
box.cfg { listen = {'10.10.0.1:3301', '10.10.0.2:3302'} }
-- array with one object, which contain adress and option
box.cfg { listen = {{uri='10.10.0.1:3301', transport='plain'}} }
-- one string address and array with one object, which contain
-- adress and option
box.cfg { listen = {
              '10.10.0.1:3301',
              {uri='10.10.0.2:3302', transport='plain'}
          }
        }
-- array with 2 objects
box.cfg { listen = {
              {uri='10.10.0.1:3301', transport='plain'},
              {uri='10.10.0.2:3313', transport='plain'}
          }
        }
-- one object with array in option
box.cfg { listen = {uri='10.10.0.1:3301', transport={'plain', 'tls'}} }
-- one object with option values separated by ';'
box.cfg { listen = {uri='10.10.0.1:3301', transport='plain; tls'} }
-- comma delimits addresses if they passed on one string
box.cfg { listen = '10.10.0.1:3301, 10.10.0.1:3313' }
-- same as previous but with option values
box.cfg { listen = '10.10.0.1:3301?transport=plain,
                    10.10.0.1:3313?transport=plain' }
-- common way to pass multiple values for one key
box.cfg { listen = '10.10.0.1:3301?transport=plain&transport=plain' }
-- Semicolon also delimit as comma
box.cfg { listen = {'10.10.0.1:3301?transport=plain;tls'} }
box.cfg { listen = {
            '10.10.0.1:3301',
            '10.10.0.1:3313',
            options = { transport = 'plain; tls' }
          }
        }
```