### PR TITLE
ci: add integration check for avro-schema module

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,3 +40,9 @@ jobs:
     uses: tarantool/metrics/.github/workflows/reusable-test.yml@master
     with:
       artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+
+  avro-schema:
+    needs: tarantool
+    uses: tarantool/avro-schema/.github/workflows/reusable_testing.yml@master
+    with:
+      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}


### PR DESCRIPTION
This patch extends the 'integration.yml' workflow and adds a new
workflow call for running tests to verify integration between tarantool
and the avro-schema module.

Part of #5265
Part of #6056
Closes #6558

Depends on  tarantool/avro-schema#142
Manual [test run](https://github.com/tarantool/tarantool/actions/runs/1391171700)