### PR TITLE
ci: add integration check for queue module

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,3 +46,9 @@ jobs:
     uses: tarantool/avro-schema/.github/workflows/reusable_testing.yml@master
     with:
       artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+
+  queue:
+    needs: tarantool
+    uses: tarantool/queue/.github/workflows/reusable_testing.yml@master
+    with:
+      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}


### PR DESCRIPTION
This patch extends the 'integration.yml' workflow and adds a new
workflow call for running tests to verify integration between tarantool
and the queue module.

Part of #5265
Part of #6056
Closes #6559

Depends on tarantool/queue#153
Manual [test run](https://github.com/tarantool/tarantool/actions/runs/1395340473)
