### PR TITLE
ci: add integration check for 'checks' module

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -52,3 +52,9 @@ jobs:
     uses: tarantool/queue/.github/workflows/reusable_testing.yml@master
     with:
       artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+
+  checks:
+    needs: tarantool
+    uses: tarantool/checks/.github/workflows/reusable_testing.yml@master
+    with:
+      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}


### PR DESCRIPTION
This patch extends the 'integration.yml' workflow and adds a new
workflow call for running tests to verify integration between tarantool
and the 'checks' module.

Part of #5265
Part of #6056
Closes #6562

Depends on tarantool/checks#27
Manual [test run](https://github.com/tarantool/tarantool/actions/runs/1399155369)