### PR TITLE
ci: reduce number of arm64 job runs

### DIFF
--- a/.github/workflows/centos_7_aarch64.yml
+++ b/.github/workflows/centos_7_aarch64.yml
@@ -2,20 +2,22 @@ name: centos_7_aarch64
 
 on:
   push:
-  pull_request:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
 
 jobs:
   centos_7_aarch64:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
+    # The job works on our own runners, forks do not have them.
+    #
     # FIXME: Testing and deploy for aarch64 is disabled temporarily.
-    if: (0 &&
-         (github.event_name == 'push' ||
-           github.event.pull_request.head.repo.full_name != github.repository ) &&
-           ! endsWith(github.ref, '-notest'))
+    if: 0 && github.repository == 'tarantool/tarantool'
 
     runs-on: graviton
 

--- a/.github/workflows/centos_8_aarch64.yml
+++ b/.github/workflows/centos_8_aarch64.yml
@@ -2,18 +2,20 @@ name: centos_8_aarch64
 
 on:
   push:
-  pull_request:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
 
 jobs:
   centos_8_aarch64:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # The job works on our own runners, forks do not have them.
+    if: github.repository == 'tarantool/tarantool'
 
     runs-on: graviton
 

--- a/.github/workflows/debian_10_aarch64.yml
+++ b/.github/workflows/debian_10_aarch64.yml
@@ -2,18 +2,20 @@ name: debian_10_aarch64
 
 on:
   push:
-  pull_request:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
 
 jobs:
   debian_10_aarch64:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # The job works on our own runners, forks do not have them.
+    if: github.repository == 'tarantool/tarantool'
 
     runs-on: graviton
 

--- a/.github/workflows/debian_11_aarch64.yml
+++ b/.github/workflows/debian_11_aarch64.yml
@@ -2,18 +2,20 @@ name: debian_11_aarch64
 
 on:
   push:
-  pull_request:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
 
 jobs:
   debian_11_aarch64:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # The job works on our own runners, forks do not have them.
+    if: github.repository == 'tarantool/tarantool'
 
     runs-on: graviton
 

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -2,7 +2,12 @@ name: debug_aarch64
 
 on:
   push:
-  pull_request:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -12,11 +17,8 @@ env:
 
 jobs:
   debug_aarch64:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # The job works on our own runners, forks do not have them.
+    if: github.repository == 'tarantool/tarantool'
 
     runs-on: graviton
 

--- a/.github/workflows/fedora_33_aarch64.yml
+++ b/.github/workflows/fedora_33_aarch64.yml
@@ -2,18 +2,20 @@ name: fedora_33_aarch64
 
 on:
   push:
-  pull_request:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
 
 jobs:
   fedora_33_aarch64:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # The job works on our own runners, forks do not have them.
+    if: github.repository == 'tarantool/tarantool'
 
     runs-on: graviton
 

--- a/.github/workflows/fedora_34_aarch64.yml
+++ b/.github/workflows/fedora_34_aarch64.yml
@@ -2,18 +2,20 @@ name: fedora_34_aarch64
 
 on:
   push:
-  pull_request:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
 
 jobs:
   fedora_34_aarch64:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # The job works on our own runners, forks do not have them.
+    if: github.repository == 'tarantool/tarantool'
 
     runs-on: graviton
 

--- a/.github/workflows/osx_arm64_11_2.yml
+++ b/.github/workflows/osx_arm64_11_2.yml
@@ -2,7 +2,12 @@ name: osx_arm64_11_2
 
 on:
   push:
-  pull_request:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -12,11 +17,8 @@ env:
 
 jobs:
   osx_arm64_11_2:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # The job works on our own runners, forks do not have them.
+    if: github.repository == 'tarantool/tarantool'
 
     runs-on: macos-m1-11.2
 

--- a/.github/workflows/osx_debug_arm64_11_2.yml
+++ b/.github/workflows/osx_debug_arm64_11_2.yml
@@ -2,7 +2,12 @@ name: osx_debug_arm64_11_2
 
 on:
   push:
-  pull_request:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -12,11 +17,8 @@ env:
 
 jobs:
   osx_debug_arm64_11_2:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # The job works on our own runners, forks do not have them.
+    if: github.repository == 'tarantool/tarantool'
 
     runs-on: macos-m1-11.2
 

--- a/.github/workflows/ubuntu_20_04_aarch64.yml
+++ b/.github/workflows/ubuntu_20_04_aarch64.yml
@@ -2,18 +2,20 @@ name: ubuntu_20_04_aarch64
 
 on:
   push:
-  pull_request:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
 
 jobs:
   ubuntu_20_04_aarch64:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # The job works on our own runners, forks do not have them.
+    if: github.repository == 'tarantool/tarantool'
 
     runs-on: graviton
 

--- a/.github/workflows/ubuntu_20_10_aarch64.yml
+++ b/.github/workflows/ubuntu_20_10_aarch64.yml
@@ -2,18 +2,20 @@ name: ubuntu_20_10_aarch64
 
 on:
   push:
-  pull_request:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
 
 jobs:
   ubuntu_20_10_aarch64:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # The job works on our own runners, forks do not have them.
+    if: github.repository == 'tarantool/tarantool'
 
     runs-on: graviton
 


### PR DESCRIPTION
We have limited amount of arm64 runners and arm64 jobs are often queued
for hours. So I disabled running of arm64 jobs on developer branches and
external PRs. Now we run them on master, release branches, tags and for
branches named as 'something-full-ci'.

While I'm here, disabled those jobs explicitly on forks: I guess
otherwise it'll be it a 'waiting a runner' state infinitely.