### PR TITLE
ci: add integration check for mysql module

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -58,3 +58,9 @@ jobs:
     uses: tarantool/checks/.github/workflows/reusable_testing.yml@master
     with:
       artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+
+  mysql:
+    needs: tarantool
+    uses: tarantool/mysql/.github/workflows/reusable_testing.yml@master
+    with:
+      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}


### PR DESCRIPTION
This patch extends the 'integration.yml' workflow and adds a new
workflow call for running tests to verify integration between tarantool
and the mysql module.

Part of #5265
Part of #6056
Closes #6577

Depends on tarantool/mysql#61
Manual [test run](https://github.com/tarantool/tarantool/actions/runs/1409106252)