### PR TITLE
jepsen: fix race condition with apt's sources.list

### DIFF
--- a/extra/tf/main.tf
+++ b/extra/tf/main.tf
@@ -28,6 +28,7 @@ resource "openstack_compute_instance_v2" "instance" {
   provisioner "remote-exec" {
     inline = [
       "set -o errexit",
+      "sudo cloud-init status --wait",
       "sudo hostnamectl set-hostname n${count.index + 1}",
       "sudo apt-get -o Debug::Acquire::http=true -o Debug::pkgAcquire::Worker=1 update"
     ]


### PR DESCRIPTION
Jepsen testing starts one or several virtual machines and runs tarantool
instances on them. The first (first important for us here) command on
the virtual machine is `apt-get <...> update`: we should download
packages list to allow Jepsen to install necessary dependencies.

However we can access the virtual machine (using ssh) before it is fully
initialized by the cloud-init script. In particular, the cloud-init
script replaces apt's mirror list file (`/etc/apt/sources.list`).

Normally we should call `apt-get <...> update` after the package list
update, but here cloud-init races with the update command.

In the bad case the commands are executed in the opposite order:

* Terraform calls `apt-get <...> update`.
* cloud-init replaces `/etc/apt/sources.list`.

Now an attempt to install a package using apt-get will give the 'unable
to locate package' error, because we have no packages list for the 'new'
mirrors.

The problem is nicely described in [1]. See also the linked issue for
details.

[1]: https://github.com/hashicorp/packer/issues/41#issuecomment-21288589

Fixes https://github.com/tarantool/jepsen.tarantool/issues/87