### PR TITLE
ci: add check for tarantool-c connector

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -64,3 +64,9 @@ jobs:
     uses: tarantool/mysql/.github/workflows/reusable_testing.yml@master
     with:
       artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+
+  tarantool-c:
+    needs: tarantool
+    uses: tarantool/tarantool-c/.github/workflows/reusable_testing.yml@master
+    with:
+      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}


### PR DESCRIPTION
This patch extends the 'integration.yml' workflow and adds a new
workflow call for running tests to verify integration between tarantool
and tarantool-c connector.

Part of #5265
Part of #6056
Closes #6582

Depends on tarantool/tarantool-c#153
Manual [test run](https://github.com/tarantool/tarantool/actions/runs/1443997343) 