### PR TITLE
ci: add check for tarantool-python connector

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -70,3 +70,9 @@ jobs:
     uses: tarantool/tarantool-c/.github/workflows/reusable_testing.yml@master
     with:
       artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+
+  tarantool-python:
+    needs: tarantool
+    uses: tarantool/tarantool-python/.github/workflows/reusable_testing.yml@master
+    with:
+      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}


### PR DESCRIPTION
This patch extends the 'integration.yml' workflow and adds a new
workflow call for running tests to verify integration between tarantool
and tarantool-python connector.

Part of #5265
Part of #6056
Closes #6584 

Depends on tarantool/tarantool-python#192
Manual [test run](https://github.com/tarantool/tarantool/actions/runs/1446356476)