### PR TITLE
box/lua: allow to pass multiple keys to box.broadcast

### DIFF
--- a/test/app/watcher.result
+++ b/test/app/watcher.result
@@ -28,15 +28,27 @@ box.watch('foo', {})
  | ...
 box.broadcast()
  | ---
- | - error: 'Usage: box.broadcast(key[, value])'
+ | - error: 'Usage: box.broadcast(key[, value]) or box.broadcast{key[ = value], ...}'
  | ...
 box.broadcast(1, 2, 3)
  | ---
- | - error: 'Usage: box.broadcast(key[, value])'
+ | - error: 'Usage: box.broadcast(key[, value]) or box.broadcast{key[ = value], ...}'
  | ...
-box.broadcast({})
+box.broadcast(123)
  | ---
- | - error: 'bad argument #1 to ''?'' (string expected, got table)'
+ | - error: 'box.broadcast: key must be a string'
+ | ...
+box.broadcast({}, 123)
+ | ---
+ | - error: 'box.broadcast: key must be a string'
+ | ...
+box.broadcast({123})
+ | ---
+ | - error: 'box.broadcast: key must be a string'
+ | ...
+box.broadcast({[123] = 456})
+ | ---
+ | - error: 'box.broadcast: key must be a string'
  | ...
 
 -- Callback is invoked after registration.
@@ -544,4 +556,113 @@ test_run:wait_cond(function() return count == 1 end)
 assert(count == 1)
  | ---
  | - true
+ | ...
+
+-- Broadcasting multiple keys.
+count = 0
+ | ---
+ | ...
+value = {}
+ | ---
+ | ...
+cb = function(k, v) value[k] = v count = count + 1 end
+ | ---
+ | ...
+w1 = box.watch('k1', cb)
+ | ---
+ | ...
+w2 = box.watch('k2', cb)
+ | ---
+ | ...
+box.broadcast{}
+ | ---
+ | ...
+fiber.sleep(0.01)
+ | ---
+ | ...
+assert(value.k1 == nil)
+ | ---
+ | - true
+ | ...
+assert(value.k2 == nil)
+ | ---
+ | - true
+ | ...
+count = 0
+ | ---
+ | ...
+box.broadcast{k1 = 'v1', k2 = 'v2'}
+ | ---
+ | ...
+test_run:wait_cond(function() return count == 2 end)
+ | ---
+ | - true
+ | ...
+assert(value.k1 == 'v1')
+ | ---
+ | - true
+ | ...
+assert(value.k2 == 'v2')
+ | ---
+ | - true
+ | ...
+count = 0
+ | ---
+ | ...
+box.broadcast{'k1', 'k2'}
+ | ---
+ | ...
+test_run:wait_cond(function() return count == 2 end)
+ | ---
+ | - true
+ | ...
+assert(value.k1 == nil)
+ | ---
+ | - true
+ | ...
+assert(value.k2 == nil)
+ | ---
+ | - true
+ | ...
+count = 0
+ | ---
+ | ...
+box.broadcast{k1 = 'v1', 'k2'}
+ | ---
+ | ...
+test_run:wait_cond(function() return count == 2 end)
+ | ---
+ | - true
+ | ...
+assert(value.k1 == 'v1')
+ | ---
+ | - true
+ | ...
+assert(value.k2 == nil)
+ | ---
+ | - true
+ | ...
+count = 0
+ | ---
+ | ...
+box.broadcast{'k1', k2 = 'v2'}
+ | ---
+ | ...
+test_run:wait_cond(function() return count == 2 end)
+ | ---
+ | - true
+ | ...
+assert(value.k1 == nil)
+ | ---
+ | - true
+ | ...
+assert(value.k2 == 'v2')
+ | ---
+ | - true
+ | ...
+w1:unregister()
+ | ---
+ | ...
+w2:unregister()
+ | ---
  | ...


### PR DESCRIPTION
Requested by @unera.

Follow-up #6257

@TarantoolBot document
Title: Document that box.broadcast can take multiple keys

```lua
box.broadcast{key1, key2, key3 = value3, key4 = value4}
```

is a shortcut for

```lua
box.broadcast(key1)
box.broadcast(key2)
box.broadcast(key3, value3)
box.broadcast(key4, value4)
```