### PR TITLE
ci: add integration check for tarantool-php/client

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -76,3 +76,9 @@ jobs:
     uses: tarantool/tarantool-python/.github/workflows/reusable_testing.yml@master
     with:
       artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+
+  php-client:
+    needs: tarantool
+    uses: tarantool-php/client/.github/workflows/reusable_qa.yml@master
+    with:
+      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}


### PR DESCRIPTION
This patch extends the 'integration.yml' workflow and adds a new
workflow call for running tests to verify integration between tarantool
and the tarantool-php/client connector.

Part of tarantool/tarantool#5265
Part of tarantool/tarantool#6056
Closes tarantool/tarantool#6594

Depends on tarantool-php/client#74
Manual [test run](https://github.com/tarantool/tarantool/actions/runs/1446280386)