### PR TITLE
datetime: disable datetime.test.lua on Graviton

### DIFF
--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -5,6 +5,12 @@ local test = tap.test('errno')
 local date = require('datetime')
 local ffi = require('ffi')
 
+--[[
+    Workaround for #6599 where we may randomly fail on AWS Graviton machines,
+    while it's working properly when jit disabled.
+--]]
+if jit.arch == 'arm64' then jit.off() end
+
 test:plan(13)
 
 -- minimum supported date - -5879610-06-22


### PR DESCRIPTION
`test/app-tap/datetime.test` is flaky on Graviton runners
(Linux/Ubuntu/aarch64) so we disable this test for a while.

Part of #6599
Follow-up to #5941