### PR TITLE
ci: add integration check for tarantool-php/queue

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -82,3 +82,9 @@ jobs:
     uses: tarantool-php/client/.github/workflows/reusable_qa.yml@master
     with:
       artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+
+  php-queue:
+    needs: tarantool
+    uses: tarantool-php/queue/.github/workflows/reusable_qa.yml@master
+    with:
+      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}


### PR DESCRIPTION
This patch extends the 'integration.yml' workflow and adds a new
workflow call for running tests to verify integration between tarantool
and the tarantool-php/queue connector.

Part of tarantool/tarantool#5265
Part of tarantool/tarantool#6056
Closes tarantool/tarantool#6595

Depends on https://github.com/tarantool-php/queue/pull/18
Manual [test run](https://github.com/tarantool/tarantool/actions/runs/1446230838)