### PR TITLE
coio refactoring

### DIFF
--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -350,7 +350,8 @@ applier_connect(struct applier *applier)
 	if (fd < 0)
 		diag_raise();
 	iostream_create(io, fd);
-	coio_readn(io, greetingbuf, IPROTO_GREETING_SIZE);
+	if (coio_readn(io, greetingbuf, IPROTO_GREETING_SIZE) < 0)
+		diag_raise();
 	applier->last_row_time = ev_monotonic_now(loop());
 
 	/* Decode instance version and name from greeting */

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -337,7 +337,16 @@ applier_connect(struct applier *applier)
 	 */
 	applier->addr_len = sizeof(applier->addrstorage);
 	applier_set_state(applier, APPLIER_CONNECT);
-	int fd = coio_connect(uri, &applier->addr, &applier->addr_len);
+	char host[URI_MAXHOST] = { '\0' };
+	if (uri->host != NULL) {
+		snprintf(host, sizeof(host), "%.*s",
+			 (int)uri->host_len, uri->host);
+	}
+	char service[URI_MAXSERVICE];
+	snprintf(service, sizeof(service), "%.*s",
+		 (int)uri->service_len, uri->service);
+	int fd = coio_connect(host, service, uri->host_hint,
+			      &applier->addr, &applier->addr_len);
 	iostream_create(io, fd);
 	coio_readn(io, greetingbuf, IPROTO_GREETING_SIZE);
 	applier->last_row_time = ev_monotonic_now(loop());

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -347,6 +347,8 @@ applier_connect(struct applier *applier)
 		 (int)uri->service_len, uri->service);
 	int fd = coio_connect(host, service, uri->host_hint,
 			      &applier->addr, &applier->addr_len);
+	if (fd < 0)
+		diag_raise();
 	iostream_create(io, fd);
 	coio_readn(io, greetingbuf, IPROTO_GREETING_SIZE);
 	applier->last_row_time = ev_monotonic_now(loop());

--- a/src/box/lua/console.c
+++ b/src/box/lua/console.c
@@ -576,8 +576,7 @@ console_session_push(struct session *session, struct port *port)
 		return -1;
 	struct iostream io;
 	iostream_create(&io, session_fd(session));
-	int ret = coio_write_timeout_noxc(&io, text, text_len,
-					  TIMEOUT_INFINITY);
+	int ret = coio_write_timeout(&io, text, text_len, TIMEOUT_INFINITY);
 	iostream_destroy(&io);
 	return ret >= 0 ? 0 : -1;
 }

--- a/src/box/xrow_io.cc
+++ b/src/box/xrow_io.cc
@@ -100,6 +100,7 @@ coio_write_xrow(struct iostream *io, const struct xrow_header *row)
 {
 	struct iovec iov[XROW_IOVMAX];
 	int iovcnt = xrow_to_iovec_xc(row, iov);
-	coio_writev(io, iov, iovcnt, 0);
+	if (coio_writev(io, iov, iovcnt, 0) < 0)
+		diag_raise();
 }
 

--- a/src/lib/core/CMakeLists.txt
+++ b/src/lib/core/CMakeLists.txt
@@ -13,7 +13,7 @@ set(core_sources
     latch.c
     sio.c
     evio.c
-    coio.cc
+    coio.c
     coio_task.c
     coio_file.c
     popen.c

--- a/src/lib/core/coio.h
+++ b/src/lib/core/coio.h
@@ -190,27 +190,31 @@ void
 coio_service_init(struct coio_service *service, const char *name,
 		  fiber_func handler, void *handler_param);
 
-/** Wait until the service binds to the port. */
-void
+/**
+ * Wait until the service binds to the port.
+ * Returns 0 on success, -1 on error.
+ */
+int
 coio_service_start(struct evio_service *service, const char *uri);
 
 void
 coio_stat_init(ev_stat *stat, const char *path);
 
-void
+/**
+ * Wait for the stat data changes.
+ * Returns 0 on event or timeout, -1 if the fiber was cancelled.
+ */
+int
 coio_stat_stat_timeout(ev_stat *stat, ev_tstamp delay);
 
 /**
  * Wait for a child to end.
- * @note this is a cancellation point (can throw
- * FiberIsCancelled).
- *
- * @retval exit status of the child.
- *
+ * The exit status is written to @a status.
+ * Returns 0 on success, -1 if the fiber was cancelled.
  * This call only works in the main thread.
  */
 int
-coio_waitpid(pid_t pid);
+coio_waitpid(pid_t pid, int *status);
 
 /** \cond public */
 

--- a/src/lib/core/coio.h
+++ b/src/lib/core/coio.h
@@ -41,7 +41,6 @@ extern "C" {
 
 struct iostream;
 struct sockaddr;
-struct uri;
 
 /**
  * Co-operative I/O
@@ -57,13 +56,16 @@ struct coio_service
 };
 
 int
-coio_connect_timeout(struct uri *uri, struct sockaddr *addr,
-		     socklen_t *addr_len, ev_tstamp timeout);
+coio_connect_timeout(const char *host, const char *service, int host_hint,
+		     struct sockaddr *addr, socklen_t *addr_len,
+		     ev_tstamp timeout);
 
 static inline int
-coio_connect(struct uri *uri, struct sockaddr *addr, socklen_t *addr_len)
+coio_connect(const char *host, const char *service, int host_hint,
+	     struct sockaddr *addr, socklen_t *addr_len)
 {
-	return coio_connect_timeout(uri, addr, addr_len, TIMEOUT_INFINITY);
+	return coio_connect_timeout(host, service, host_hint, addr, addr_len,
+				    TIMEOUT_INFINITY);
 }
 
 int

--- a/src/lib/core/coio.h
+++ b/src/lib/core/coio.h
@@ -92,7 +92,7 @@ coio_timeout_update(ev_tstamp *start, ev_tstamp *delay)
 /**
  * Reat at least sz bytes, with readahead.
  *
- * Returns 0 in case of EOF.
+ * Returns 0 in case of EOF, -1 in case of error.
  */
 static inline ssize_t
 coio_read_ahead(struct iostream *io, void *buf, size_t sz, size_t bufsiz)
@@ -115,29 +115,6 @@ coio_read_timeout(struct iostream *io, void *buf, size_t sz, ev_tstamp timeout)
 	return coio_read_ahead_timeout(io, buf, sz, sz, timeout);
 }
 
-/**
- * Read data with timeout.
- *
- * Yield until some data will be available for read.
- *
- * Returns amount of read bytes at success, otherwise returns -1
- * and set a diag.
- *
- * Zero return value means EOF.
- *
- * Note: Less then @a count bytes may be available for read at a
- * moment, so a return value less then @a count does not mean EOF.
- *
- * Possible errors:
- *
- * - SocketError: an IO error occurs at read().
- * - TimedOut: @a timeout quota is exceeded.
- * - FiberIsCancelled: cancelled by an outside code.
- */
-ssize_t
-coio_read_ahead_timeout_noxc(struct iostream *io, void *buf, size_t sz,
-			     size_t bufsiz, ev_tstamp timeout);
-
 static inline ssize_t
 coio_readn(struct iostream *io, void *buf, size_t sz)
 {
@@ -151,24 +128,6 @@ coio_readn_ahead_timeout(struct iostream *io, void *buf, size_t sz,
 ssize_t
 coio_write_timeout(struct iostream *io, const void *buf, size_t sz,
 		   ev_tstamp timeout);
-
-/**
- * Write @a count bytes with timeout.
- *
- * Yield until all @a count bytes will be written.
- *
- * Returns @a count at success, otherwise returns -1 and set a
- * diag.
- *
- * Possible errors:
- *
- * - SocketError: an IO error occurs at write().
- * - TimedOut: @a timeout quota is exceeded.
- * - FiberIsCancelled: cancelled by an outside code.
- */
-ssize_t
-coio_write_timeout_noxc(struct iostream *io, const void *buf, size_t sz,
-			ev_tstamp timeout);
 
 static inline void
 coio_write(struct iostream *io, const void *buf, size_t sz)

--- a/src/lib/core/coio_buf.h
+++ b/src/lib/core/coio_buf.h
@@ -31,6 +31,7 @@
  * SUCH DAMAGE.
  */
 #include "coio.h"
+#include "diag.h"
 #include <small/ibuf.h>
 
 struct iostream;
@@ -47,6 +48,8 @@ coio_bread(struct iostream *io, struct ibuf *buf, size_t sz)
 {
 	ibuf_reserve_xc(buf, sz);
 	ssize_t n = coio_read_ahead(io, buf->wpos, sz, ibuf_unused(buf));
+	if (n < 0)
+		diag_raise();
 	buf->wpos += n;
 	return n;
 }
@@ -63,6 +66,8 @@ coio_bread_timeout(struct iostream *io, struct ibuf *buf, size_t sz,
 	ibuf_reserve_xc(buf, sz);
 	ssize_t n = coio_read_ahead_timeout(io, buf->wpos, sz, ibuf_unused(buf),
 			                    timeout);
+	if (n < 0)
+		diag_raise();
 	buf->wpos += n;
 	return n;
 }
@@ -73,6 +78,8 @@ coio_breadn(struct iostream *io, struct ibuf *buf, size_t sz)
 {
 	ibuf_reserve_xc(buf, sz);
 	ssize_t n = coio_readn_ahead(io, buf->wpos, sz, ibuf_unused(buf));
+	if (n < 0)
+		diag_raise();
 	buf->wpos += n;
 	return n;
 }
@@ -90,6 +97,8 @@ coio_breadn_timeout(struct iostream *io, struct ibuf *buf, size_t sz,
 	ibuf_reserve_xc(buf, sz);
 	ssize_t n = coio_readn_ahead_timeout(io, buf->wpos, sz, ibuf_unused(buf),
 			                     timeout);
+	if (n < 0)
+		diag_raise();
 	buf->wpos += n;
 	return n;
 }

--- a/src/lib/core/popen.c
+++ b/src/lib/core/popen.c
@@ -395,8 +395,7 @@ popen_write_timeout(struct popen_handle *handle, const void *buf,
 		  handle->pid, stdX_str(idx), idx, buf, count,
 		  handle->ios[idx].fd, timeout);
 
-	ssize_t rc = coio_write_timeout_noxc(&handle->ios[idx], buf,
-					     count, timeout);
+	ssize_t rc = coio_write_timeout(&handle->ios[idx], buf, count, timeout);
 	assert(rc < 0 || rc == (ssize_t)count);
 	return rc;
 }
@@ -460,8 +459,8 @@ popen_read_timeout(struct popen_handle *handle, void *buf,
 		  handle->pid, stdX_str(idx), idx, buf, count,
 		  handle->ios[idx].fd, timeout);
 
-	return coio_read_ahead_timeout_noxc(&handle->ios[idx], buf, 1, count,
-					    timeout);
+	return coio_read_ahead_timeout(&handle->ios[idx], buf, 1, count,
+				       timeout);
 }
 
 /**

--- a/test/unit/coio.cc
+++ b/test/unit/coio.cc
@@ -32,7 +32,8 @@ stat_notify_test(FILE *f, const char *filename)
 	ev_stat stat;
 	note("filename: %s", filename);
 	coio_stat_init(&stat, filename);
-	coio_stat_stat_timeout(&stat, TIMEOUT_INFINITY);
+	int rc = coio_stat_stat_timeout(&stat, TIMEOUT_INFINITY);
+	fail_unless(rc == 0);
 	fail_unless(stat.prev.st_size < stat.attr.st_size);
 	fiber_cancel(touch);
 
@@ -46,7 +47,8 @@ stat_timeout_test(const char *filename)
 
 	ev_stat stat;
 	coio_stat_init(&stat, filename);
-	coio_stat_stat_timeout(&stat, 0.01);
+	int rc = coio_stat_stat_timeout(&stat, 0.01);
+	fail_unless(rc == 0);
 
 	footer();
 }


### PR DESCRIPTION
To convert the net.box state machine to C, I need `coio_connect` to take host and service as strings (not as URI) and be exception-free. While we are at it, let's also convert `coio.cc` to C.

Closes #4881