### PR TITLE
net.box: check arguments presence in ping

### DIFF
--- a/src/box/lua/net_box.lua
+++ b/src/box/lua/net_box.lua
@@ -1149,6 +1149,13 @@ end
 
 function remote_methods:ping(opts)
     check_remote_arg(self, 'ping')
+
+    if opts ~= nil and type(opts) ~= 'table' then
+        box.error(
+            box.error.UNSUPPORTED, "ping",
+            string.format("options of type %s", type(opts)))
+    end
+
     return (pcall(self._request, self, M_PING, opts, nil, self._stream_id))
 end
 


### PR DESCRIPTION
Check that no arguments are provided in ping() call or the provided argument is of type 'table', otherwise throw box.error.UNSUPPORTED. This behavior is similar to several other methods like execute, prepare, unprepare.

 Closes #6063