### PR TITLE
test: fix watcher unit test duplicate symbol

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -283,5 +283,5 @@ target_link_libraries(popen.test misc unit core)
 add_executable(serializer.test serializer.c)
 target_link_libraries(serializer.test unit box ${LUAJIT_LIBRARIES})
 
-add_executable(watcher.test watcher.c core_test_utils.c)
-target_link_libraries(watcher.test unit core box)
+add_executable(watcher.test watcher.c)
+target_link_libraries(watcher.test unit box)

--- a/test/unit/watcher.c
+++ b/test/unit/watcher.c
@@ -4,6 +4,8 @@
 
 #include "box/watcher.h"
 #include "fiber.h"
+#include "lua/utils.h"
+#include "lualib.h"
 #include "memory.h"
 #include "tarantool_ev.h"
 #include "trivia/util.h"
@@ -519,6 +521,10 @@ main_f(va_list ap)
 int
 main()
 {
+	struct lua_State *L = luaL_newstate();
+	luaL_openlibs(L);
+	tarantool_L = L;
+
 	memory_init();
 	fiber_init(fiber_c_invoke);
 	struct fiber *f = fiber_new("main", main_f);
@@ -526,5 +532,8 @@ main()
 	ev_run(loop(), 0);
 	fiber_free();
 	memory_free();
+
+	lua_close(L);
+	tarantool_L = NULL;
 	return test_result;
 }


### PR DESCRIPTION
Watcher unit test linked with libbox and included
core_test_utils.c. Both contain cord_on_yield() symbol.

It is defined as a stub in core_test_utils and checks being inside
of GC in libbox.

Somehow it managed to link all this time just fine. And moreover
the linker selected the correct symbol - the one from
core_test_utils.

But while making another patch (not submitted yet), some other
unit test was changed a bit and the watcher unit test link stage
started failing with 'cord_on_yield()' duplicate symbol.

The patch drops core_test_utils from the test and makes it work
with libbox correctly. To support that the test now needs to
initialize the global Lua state.