### PR TITLE
coio: handle spurious wakeup correctly

### DIFF
--- a/src/lib/core/coio.c
+++ b/src/lib/core/coio.c
@@ -238,17 +238,17 @@ coio_accept(int sfd, struct sockaddr *addr, socklen_t addrlen,
 		}
 		if (!sio_wouldblock(errno))
 			return -1;
+		if (delay <= 0) {
+			diag_set(TimedOut);
+			return -1;
+		}
 		/*
 		 * Yield control to other fibers until the
 		 * timeout is reached.
 		 */
-		int revents = coio_wait(sfd, EV_READ, delay);
+		coio_wait(sfd, EV_READ, delay);
 		if (fiber_is_cancelled()) {
 			diag_set(FiberIsCancelled);
-			return -1;
-		}
-		if (revents == 0) {
-			diag_set(TimedOut);
 			return -1;
 		}
 		coio_timeout_update(&start, &delay);
@@ -291,18 +291,17 @@ coio_read_ahead_timeout(struct iostream *io, void *buf, size_t sz,
 		} else if (nrd == IOSTREAM_ERROR) {
 			return -1;
 		}
+		if (delay <= 0) {
+			diag_set(TimedOut);
+			return -1;
+		}
 		/*
 		 * Yield control to other fibers until the
 		 * timeout is being reached.
 		 */
-		int revents = coio_wait(io->fd, iostream_status_to_events(nrd),
-					delay);
+		coio_wait(io->fd, iostream_status_to_events(nrd), delay);
 		if (fiber_is_cancelled()) {
 			diag_set(FiberIsCancelled);
-			return -1;
-		}
-		if (revents == 0) {
-			diag_set(TimedOut);
 			return -1;
 		}
 		coio_timeout_update(&start, &delay);
@@ -387,19 +386,18 @@ coio_write_timeout(struct iostream *io, const void *buf, size_t sz,
 		} else if (nwr == IOSTREAM_ERROR) {
 			return -1;
 		}
+		if (delay <= 0) {
+			diag_set(TimedOut);
+			return -1;
+		}
 		/*
 		 * Yield control to other fibers until the
 		 * timeout is reached or the socket is
 		 * ready.
 		 */
-		int revents = coio_wait(io->fd, iostream_status_to_events(nwr),
-					delay);
+		coio_wait(io->fd, iostream_status_to_events(nwr), delay);
 		if (fiber_is_cancelled()) {
 			diag_set(FiberIsCancelled);
-			return -1;
-		}
-		if (revents == 0) {
-			diag_set(TimedOut);
 			return -1;
 		}
 		coio_timeout_update(&start, &delay);
@@ -451,19 +449,18 @@ coio_writev_timeout(struct iostream *io, struct iovec *iov, int iovcnt,
 		} else if (nwr == IOSTREAM_ERROR) {
 			return -1;
 		}
+		if (delay <= 0) {
+			diag_set(TimedOut);
+			return -1;
+		}
 		/*
 		 * Yield control to other fibers until the
 		 * timeout is reached or the socket is
 		 * ready.
 		 */
-		int revents = coio_wait(io->fd, iostream_status_to_events(nwr),
-					delay);
+		coio_wait(io->fd, iostream_status_to_events(nwr), delay);
 		if (fiber_is_cancelled()) {
 			diag_set(FiberIsCancelled);
-			return -1;
-		}
-		if (revents == 0) {
-			diag_set(TimedOut);
 			return -1;
 		}
 		coio_timeout_update(&start, &delay);

--- a/test/unit/coio.result
+++ b/test/unit/coio.result
@@ -19,3 +19,12 @@ ok 2 - bad ipv4 host name - error message
 ok 3 - bad ipv6 host name - error
 ok 4 - bad ipv6 host name - error message
 	*** test_connect: done ***
+	*** read_write_test ***
+1..6
+ok 1 - coio_read handle spurious wakeup
+ok 2 - coio_read success after a spurious wakeup
+ok 3 - coio_write handle spurious wakeup
+ok 4 - coio_write success after a spurious wakeup
+ok 5 - coio_writev handle spurious wakeup
+ok 6 - coio_writev success after a spurious wakeup
+	*** read_write_test: done ***


### PR DESCRIPTION
coio_accept, coio_read, coio_write, coio_writev used to handle spurious
wakeups correctly: if the timeout hasn't passed yet, they would simply
retry reading (or writing) and fall asleep once again if no data is
ready.

This behaviour changed in the following patches:
577a640a7fdec986d19101ed04d2afa80e951c78 ("coio: pass fd to
coio_accept") and 4f84859dcdd6126b0bdcda810b7f5f58386bdac6 ("Introduce
iostream wrapper for socket I/O").

Now the functions timeout on the very first spurious wakeup.

Fix this, add the appropriate unit tests and a test_iostream
implementation for the ease of testing.