### PR TITLE
ci: add integration check for memcached module

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -68,6 +68,12 @@ jobs:
     with:
       artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
 
+  memcached:
+    needs: tarantool
+    uses: tarantool/memcached/.github/workflows/reusable_testing.yml@master
+    with:
+      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+
   metrics:
     needs: tarantool
     uses: tarantool/metrics/.github/workflows/reusable-test.yml@master


### PR DESCRIPTION
This patch extends the 'integration.yml' workflow and adds a new
workflow call for running tests to verify integration between tarantool
and the memcached module.

Part of #5265
Part of #6056
Closes #6563

Depends on tarantool/memcached#74
Manual [test run](https://github.com/tarantool/tarantool/runs/4650789830?check_suite_focus=true)