### PR TITLE
swim: fix out of bounds access in proto decode

### DIFF
--- a/src/lib/swim/swim_proto.c
+++ b/src/lib/swim/swim_proto.c
@@ -51,7 +51,7 @@ int
 swim_decode_map(const char **pos, const char *end, uint32_t *size,
 		const char *prefix, const char *param_name)
 {
-	if (mp_typeof(**pos) != MP_MAP || *pos == end ||
+	if (*pos == end || mp_typeof(**pos) != MP_MAP ||
 	    mp_check_map(*pos, end) > 0) {
 		diag_set(SwimError, "%s %s should be a map", prefix,
 			 param_name);
@@ -65,7 +65,7 @@ int
 swim_decode_array(const char **pos, const char *end, uint32_t *size,
 		  const char *prefix, const char *param_name)
 {
-	if (mp_typeof(**pos) != MP_ARRAY || *pos == end ||
+	if (*pos == end || mp_typeof(**pos) != MP_ARRAY ||
 	    mp_check_array(*pos, end) > 0) {
 		diag_set(SwimError, "%s %s should be an array", prefix,
 			 param_name);
@@ -79,7 +79,7 @@ int
 swim_decode_uint(const char **pos, const char *end, uint64_t *value,
 		 const char *prefix, const char *param_name)
 {
-	if (mp_typeof(**pos) != MP_UINT || *pos == end ||
+	if (*pos == end || mp_typeof(**pos) != MP_UINT ||
 	    mp_check_uint(*pos, end) > 0) {
 		diag_set(SwimError, "%s %s should be a uint", prefix,
 			 param_name);
@@ -125,7 +125,7 @@ static inline int
 swim_decode_bin(const char **bin, uint32_t *size, const char **pos,
 		const char *end, const char *prefix, const char *param_name)
 {
-	if (mp_typeof(**pos) != MP_BIN || *pos == end ||
+	if (*pos == end || mp_typeof(**pos) != MP_BIN ||
 	    mp_check_binl(*pos, end) > 0) {
 		diag_set(SwimError, "%s %s should be bin", prefix,
 			 param_name);


### PR DESCRIPTION
I was playing with libFuzzer and found heap-buffer-overflow.

`**pos` is dereferenced before it is checked via `*pos == end`. This leads
to out of bounds access when `*pos == end`.

You can build Docker from [oss-sydr-fuzz](https://github.com/ispras/oss-sydr-fuzz/tree/master/projects/tarantool) to reproduce the crash. Copy
[crash-090cbc46c3a13cd05fceb2fe55cccaab870d6795.txt](https://github.com/tarantool/tarantool/files/7546134/crash-090cbc46c3a13cd05fceb2fe55cccaab870d6795.txt)
to current directory before docker build. Then run inside docker:

```
/swim_proto_member_fuzzer /fuzz/crash-090cbc46c3a13cd05fceb2fe55cccaab870d6795.txt
```

Result:

```
=================================================================
==15==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x602000000051 at pc 0x000000519017 bp 0x7fffb2ea2010 sp 0x7fffb2ea2008
READ of size 1 at 0x602000000051 thread T0
    #0 0x519016 in swim_decode_uint /tarantool/src/lib/swim/swim_proto.c:82:16
    #1 0x519fc5 in swim_member_def_decode /tarantool/src/lib/swim/swim_proto.c:313:7
    #2 0x517efc in LLVMFuzzerTestOneInput /tarantool/test/fuzz/swim_proto_member_fuzzer.c:37:5
    #3 0x444e31 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:611:15
    #4 0x42f44c in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:324:6
    #5 0x4351bb in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:860:9
    #6 0x45df02 in main /llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #7 0x7fc1f027b0b2 in __libc_start_main /build/glibc-eX1tMB/glibc-2.31/csu/../csu/libc-start.c:308:16
    #8 0x429d6d in _start (/swim_proto_member_fuzzer+0x429d6d)

0x602000000051 is located 0 bytes to the right of 1-byte region [0x602000000050,0x602000000051)
allocated by thread T0 here:
    #0 0x4ded0d in malloc /llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:129:3
    #1 0x517e2d in LLVMFuzzerTestOneInput /tarantool/test/fuzz/swim_proto_member_fuzzer.c:34:17
    #2 0x444e31 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:611:15
    #3 0x42f44c in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:324:6
    #4 0x4351bb in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:860:9
    #5 0x45df02 in main /llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #6 0x7fc1f027b0b2 in __libc_start_main /build/glibc-eX1tMB/glibc-2.31/csu/../csu/libc-start.c:308:16

SUMMARY: AddressSanitizer: heap-buffer-overflow /tarantool/src/lib/swim/swim_proto.c:82:16 in swim_decode_uint
Shadow bytes around the buggy address:
  0x0c047fff7fb0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c047fff7fc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c047fff7fd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c047fff7fe0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c047fff7ff0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0c047fff8000: fa fa 01 fa fa fa 01 fa fa fa[01]fa fa fa fa fa
  0x0c047fff8010: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff8020: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff8030: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff8040: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff8050: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==15==ABORTING
```

