### PR TITLE
ci: add check for go-tarantool connector

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -121,3 +121,9 @@ jobs:
     uses: tarantool-php/queue/.github/workflows/reusable_qa.yml@master
     with:
       artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+
+  go-tarantool:
+    needs: tarantool
+    uses: tarantool/go-tarantool/.github/workflows/reusable_testing.yml@master
+    with:
+      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}


### PR DESCRIPTION
This patch extends the 'integration.yml' workflow and adds a new
workflow call for running tests to verify integration between tarantool
and go-tarantool connector.

Part of #5265
Part of #6056
Closes #6607

Depends on tarantool/go-tarantool#112
Manual [test run](https://github.com/tarantool/tarantool/actions/runs/1555764437)