### PR TITLE
test: fix flaky net.box_tx_timeout.test

### DIFF
--- a/test/box/net.box_tx_timeout.result
+++ b/test/box/net.box_tx_timeout.result
@@ -38,6 +38,12 @@ box.cfg({ txn_timeout = txn_timeout })
 box.schema.user.grant("guest", "super")
 ---
 ...
+fiber = require('fiber')
+---
+...
+function sleep_with_timeout(timeout) fiber.sleep(timeout) end
+---
+...
 test_run:switch("default")
 ---
 - true
@@ -93,7 +99,7 @@ space:select({}) -- [1]
 ---
 - - [1]
 ...
-fiber.sleep(txn_timeout + 0.1)
+_ = test_run:eval("test", string.format("sleep_with_timeout(%f)", txn_timeout + 0.1))
 ---
 ...
 space:select({}) -- []
@@ -128,7 +134,7 @@ space:select({}) -- [1]
 ---
 - - [1]
 ...
-fiber.sleep(txn_timeout + 0.1)
+_= test_run:eval("test", string.format("sleep_with_timeout(%f)", txn_timeout + 0.1))
 ---
 ...
 space:select({}) -- []

--- a/test/box/net.box_tx_timeout.test.lua
+++ b/test/box/net.box_tx_timeout.test.lua
@@ -12,6 +12,8 @@ _ = s:create_index("pk")
 txn_timeout = 0.5
 box.cfg({ txn_timeout = txn_timeout })
 box.schema.user.grant("guest", "super")
+fiber = require('fiber')
+function sleep_with_timeout(timeout) fiber.sleep(timeout) end
 test_run:switch("default")
 
 -- Checks for remote transactions
@@ -35,7 +37,7 @@ stream:begin({timeout = "5"})
 stream:begin()
 space:replace({1})
 space:select({}) -- [1]
-fiber.sleep(txn_timeout + 0.1)
+_ = test_run:eval("test", string.format("sleep_with_timeout(%f)", txn_timeout + 0.1))
 space:select({}) -- []
 space:replace({2})
 fiber.yield()
@@ -47,7 +49,7 @@ stream:commit() -- transaction was aborted by timeout
 stream:begin({timeout = txn_timeout})
 space:replace({1})
 space:select({}) -- [1]
-fiber.sleep(txn_timeout + 0.1)
+_= test_run:eval("test", string.format("sleep_with_timeout(%f)", txn_timeout + 0.1))
 space:select({}) -- []
 space:replace({2})
 fiber.yield()


### PR DESCRIPTION
The problem was that when we wanted to check that
the transaction rolled back after the timeout, we
called `fiber.sleep` on the local instance, while
the timeout for transaction counted on the remote
instance. Fix the text, so now we call `fiber.sleep`
on remote server, ensuring that timeout for transaction
expires.

Closes #6586