### PR TITLE
test: fix static build exports test

### DIFF
--- a/static-build/test/static-build/exports.test.lua
+++ b/static-build/test/static-build/exports.test.lua
@@ -53,8 +53,6 @@ local check_symbols = {
     'tnt_mp_sizeof_error',
     'tnt_mp_sizeof_decimal',
     'tnt_mp_sizeof_uuid',
-    'exception_get_int',
-    'exception_get_string',
 
     'uuid_nil',
     'tt_uuid_create',


### PR DESCRIPTION
It got broken in 54be00b6aa0f4320e3dbdfa0b539c5e73cd0143f
("error: use error_payload in Lua"). 2 symbols were dropped from
the exports but not from this test.

Follow-up #5568