### PR TITLE
test: fix flaky read_only_reason test

### DIFF
--- a/test/replication-luatest/gh_5568_read_only_reason_test.lua
+++ b/test/replication-luatest/gh_5568_read_only_reason_test.lua
@@ -261,7 +261,7 @@ g.test_read_only_reason_election_has_leader_no_uuid = function(g)
 
     t.helpers.retrying({}, function()
         assert(g.replica:exec(function(leader_id)
-            return box.space._cluster:get{leader_id} == nil
+            return box.info.replication[leader_id] == nil
         end, {leader_id}))
     end)
 
@@ -301,7 +301,7 @@ g.test_read_only_reason_synchro_no_uuid = function(g)
     t.helpers.retrying({}, function()
         assert(g.replica:exec(function(leader_id)
             return box.info.synchro.queue.owner ~= 0 and
-                   box.space._cluster:get{leader_id} == nil
+                   box.info.replication[leader_id] == nil
         end, {leader_id}))
     end)
 


### PR DESCRIPTION
The test sometimes failed the test cases
test_read_only_reason_synchro_no_uuid and
test_read_only_reason_election_has_leader_no_uuid.

Both relied on an instance being gone from 'replicaset' global
internal object in C once it is gone from _cluster. But it wasn't
true.

If an instance is not visible in _cluster, it could still be not
deleted from 'replicaset' because it is done only on WAL write
end. So this was a dirty read - the check about an id absent in
_cluster.

The more reliable way is to check that the replica is gone from
box.info.replication - it is built from this 'replicaset' object.

Closes #6621