### PR TITLE
test: fix bloom test build on MacOS

### DIFF
--- a/src/trivia/util.h
+++ b/src/trivia/util.h
@@ -233,6 +233,9 @@ strnindex(const char **haystack, const char *needle, uint32_t len, uint32_t hmax
  *
  * \example struct obuf { int a; int b; alignas(16) int c; };
  */
+#if defined(__cplusplus)
+#  include <stdalign.h>
+#endif
 #if !defined(alignas) && !defined(__alignas_is_defined)
 #  if __has_feature(c_alignas) || (defined(__GNUC__) && __GNUC__ >= 5)
 #    include <stdalign.h>


### PR DESCRIPTION
Before this patch test build failed with following error:
```
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/memory:2666:26: error: unexpected type name '_CompressedPair': expected expression
    struct _ALIGNAS_TYPE(_CompressedPair) _Storage {
```

This patch seems to be fix this issue.
The root of the problem is in "trivia/util.h" module. It defines
alignas macros: `#define alignas(_n)
__attribute__((aligned(_n)))`. And it seems causes some issues in
stdlib internals. To fix this issue let's unconditionally include
stdalign.h for C++. According [1] this header should internally
define __alignas_is_defined macro.

[1] https://en.cppreference.com/w/cpp/language/alignas

Part of #6576