### PR TITLE
ci: run full ci only on PRs with 'full-ci' label

### DIFF
--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -2,7 +2,14 @@ name: centos_7
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -29,11 +36,9 @@ concurrency:
 
 jobs:
   centos_7:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/centos_7_aarch64.yml
+++ b/.github/workflows/centos_7_aarch64.yml
@@ -8,6 +8,8 @@ on:
       - '**-full-ci'
     tags:
       - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -34,10 +36,10 @@ concurrency:
 
 jobs:
   centos_7_aarch64:
-    # The job works on our own runners, forks do not have them.
-    #
+    # Run on pull request only if the 'full-ci' label is set.
     # FIXME: Testing and deploy for aarch64 is disabled temporarily.
-    if: 0 && github.repository == 'tarantool/tarantool'
+    if: 0 && ( github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: graviton
 

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -2,7 +2,14 @@ name: centos_8
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -29,11 +36,9 @@ concurrency:
 
 jobs:
   centos_8:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/centos_8_aarch64.yml
+++ b/.github/workflows/centos_8_aarch64.yml
@@ -8,6 +8,8 @@ on:
       - '**-full-ci'
     tags:
       - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -34,8 +36,9 @@ concurrency:
 
 jobs:
   centos_8_aarch64:
-    # The job works on our own runners, forks do not have them.
-    if: github.repository == 'tarantool/tarantool'
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: graviton
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -12,12 +12,6 @@ env:
 
 jobs:
   coverity:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
-
     runs-on: ubuntu-18.04
 
     strategy:

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -2,7 +2,14 @@ name: debian_10
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -29,11 +36,9 @@ concurrency:
 
 jobs:
   debian_10:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/debian_10_aarch64.yml
+++ b/.github/workflows/debian_10_aarch64.yml
@@ -8,6 +8,8 @@ on:
       - '**-full-ci'
     tags:
       - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -34,8 +36,9 @@ concurrency:
 
 jobs:
   debian_10_aarch64:
-    # The job works on our own runners, forks do not have them.
-    if: github.repository == 'tarantool/tarantool'
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: graviton
 

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -2,7 +2,14 @@ name: debian_11
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -29,11 +36,9 @@ concurrency:
 
 jobs:
   debian_11:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/debian_11_aarch64.yml
+++ b/.github/workflows/debian_11_aarch64.yml
@@ -8,6 +8,8 @@ on:
       - '**-full-ci'
     tags:
       - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -34,8 +36,9 @@ concurrency:
 
 jobs:
   debian_11_aarch64:
-    # The job works on our own runners, forks do not have them.
-    if: github.repository == 'tarantool/tarantool'
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: graviton
 

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -2,7 +2,14 @@ name: debian_9
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -29,11 +36,9 @@ concurrency:
 
 jobs:
   debian_9:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -8,6 +8,8 @@ on:
       - '**-full-ci'
     tags:
       - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -37,8 +39,9 @@ env:
 
 jobs:
   debug_aarch64:
-    # The job works on our own runners, forks do not have them.
-    if: github.repository == 'tarantool/tarantool'
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: graviton
 

--- a/.github/workflows/debug_coverage.yml
+++ b/.github/workflows/debug_coverage.yml
@@ -2,6 +2,10 @@ name: debug_coverage
 
 on:
   push:
+    branches-ignore:
+      - '**-notest'
+    tags:
+      - '**'
   pull_request:
   repository_dispatch:
     types: [backend_automation]
@@ -32,11 +36,11 @@ env:
 
 jobs:
   debug_coverage:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event_name == 'pull_request') &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'notest' label is unset and this is
+    # an external PR (internal PRs trigger a run on push).
+    if: github.event_name != 'pull_request' ||
+        ( ! contains(github.event.pull_request.labels.*.name, 'notest') &&
+          github.event.pull_request.head.repo.full_name != github.repository )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -2,7 +2,14 @@ name: default_gcc_centos_7
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -32,11 +39,9 @@ env:
 
 jobs:
   default_gcc_centos_7:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/fedora_30.yml
+++ b/.github/workflows/fedora_30.yml
@@ -2,7 +2,14 @@ name: fedora_30
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -29,11 +36,9 @@ concurrency:
 
 jobs:
   fedora_30:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/fedora_31.yml
+++ b/.github/workflows/fedora_31.yml
@@ -2,7 +2,14 @@ name: fedora_31
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -29,11 +36,9 @@ concurrency:
 
 jobs:
   fedora_31:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/fedora_32.yml
+++ b/.github/workflows/fedora_32.yml
@@ -2,7 +2,14 @@ name: fedora_32
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -29,11 +36,9 @@ concurrency:
 
 jobs:
   fedora_32:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/fedora_33.yml
+++ b/.github/workflows/fedora_33.yml
@@ -2,7 +2,14 @@ name: fedora_33
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -29,11 +36,9 @@ concurrency:
 
 jobs:
   fedora_33:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/fedora_33_aarch64.yml
+++ b/.github/workflows/fedora_33_aarch64.yml
@@ -8,6 +8,8 @@ on:
       - '**-full-ci'
     tags:
       - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -34,8 +36,9 @@ concurrency:
 
 jobs:
   fedora_33_aarch64:
-    # The job works on our own runners, forks do not have them.
-    if: github.repository == 'tarantool/tarantool'
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: graviton
 

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -2,7 +2,14 @@ name: fedora_34
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -29,11 +36,9 @@ concurrency:
 
 jobs:
   fedora_34:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/fedora_34_aarch64.yml
+++ b/.github/workflows/fedora_34_aarch64.yml
@@ -8,6 +8,8 @@ on:
       - '**-full-ci'
     tags:
       - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -34,8 +36,9 @@ concurrency:
 
 jobs:
   fedora_34_aarch64:
-    # The job works on our own runners, forks do not have them.
-    if: github.repository == 'tarantool/tarantool'
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: graviton
 

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -2,7 +2,14 @@ name: freebsd
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -32,11 +39,9 @@ env:
 
 jobs:
   freebsd:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: freebsd-sh
 

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -12,8 +12,6 @@ on:
 
 jobs:
   fuzzing:
-    if: (github.repository == 'tarantool/tarantool')
-
     runs-on: ubuntu-18.04
 
     strategy:

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -2,6 +2,10 @@ name: luacheck
 
 on:
   push:
+    branches-ignore:
+      - '**-notest'
+    tags:
+      - '**'
   pull_request:
   repository_dispatch:
     types: [backend_automation]
@@ -32,11 +36,11 @@ env:
 
 jobs:
   luacheck:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'notest' label is unset and this is
+    # an external PR (internal PRs trigger a run on push).
+    if: github.event_name != 'pull_request' ||
+        ( ! contains(github.event.pull_request.labels.*.name, 'notest') &&
+          github.event.pull_request.head.repo.full_name != github.repository )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -2,7 +2,14 @@ name: memtx_allocator_based_on_malloc
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -33,11 +40,9 @@ env:
 
 jobs:
   memtx_allocator_based_on_malloc:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -2,7 +2,14 @@ name: opensuse_15_1
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -29,11 +36,9 @@ concurrency:
 
 jobs:
   opensuse_15_1:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -2,7 +2,14 @@ name: opensuse_15_2
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -29,11 +36,9 @@ concurrency:
 
 jobs:
   opensuse_15_2:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/osx_10_15.yml
+++ b/.github/workflows/osx_10_15.yml
@@ -2,7 +2,14 @@ name: osx_10_15
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -32,11 +39,9 @@ env:
 
 jobs:
   osx_10_15:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: macos-10.15
 

--- a/.github/workflows/osx_10_15_lto.yml
+++ b/.github/workflows/osx_10_15_lto.yml
@@ -2,7 +2,14 @@ name: osx_10_15_lto
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -32,11 +39,9 @@ env:
 
 jobs:
   osx_10_15_lto:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: macos-10.15
 

--- a/.github/workflows/osx_11_0.yml
+++ b/.github/workflows/osx_11_0.yml
@@ -2,7 +2,14 @@ name: osx_11_0
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -32,11 +39,9 @@ env:
 
 jobs:
   osx_11_0:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: macos-11.0
 

--- a/.github/workflows/osx_arm64_11_2.yml
+++ b/.github/workflows/osx_arm64_11_2.yml
@@ -8,6 +8,8 @@ on:
       - '**-full-ci'
     tags:
       - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -37,8 +39,9 @@ env:
 
 jobs:
   osx_arm64_11_2:
-    # The job works on our own runners, forks do not have them.
-    if: github.repository == 'tarantool/tarantool'
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: macos-m1-11.2
 

--- a/.github/workflows/osx_debug_arm64_11_2.yml
+++ b/.github/workflows/osx_debug_arm64_11_2.yml
@@ -8,6 +8,8 @@ on:
       - '**-full-ci'
     tags:
       - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -37,8 +39,9 @@ env:
 
 jobs:
   osx_debug_arm64_11_2:
-    # The job works on our own runners, forks do not have them.
-    if: github.repository == 'tarantool/tarantool'
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: macos-m1-11.2
 

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -2,7 +2,14 @@ name: out_of_source
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -32,11 +39,9 @@ env:
 
 jobs:
   out_of_source:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,10 @@ name: release
 
 on:
   push:
+    branches-ignore:
+      - '**-notest'
+    tags:
+      - '**'
   pull_request:
   repository_dispatch:
     types: [backend_automation]
@@ -32,11 +36,11 @@ env:
 
 jobs:
   release:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'notest' label is unset and this is
+    # an external PR (internal PRs trigger a run on push).
+    if: github.event_name != 'pull_request' ||
+        ( ! contains(github.event.pull_request.labels.*.name, 'notest') &&
+          github.event.pull_request.head.repo.full_name != github.repository )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -2,7 +2,14 @@ name: release_asan_clang11
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -32,11 +39,9 @@ env:
 
 jobs:
   release_asan_clang11:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -2,7 +2,14 @@ name: release_clang
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -32,11 +39,9 @@ env:
 
 jobs:
   release_clang:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -2,7 +2,14 @@ name: release_lto
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -32,11 +39,9 @@ env:
 
 jobs:
   release_lto:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -2,7 +2,14 @@ name: release_lto_clang11
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -32,11 +39,9 @@ env:
 
 jobs:
   release_lto_clang11:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -2,6 +2,8 @@ name: source
 
 on:
   push:
+    tags:
+      - '**'
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -11,9 +13,6 @@ env:
 
 jobs:
   source:
-    # We want to run only on tags.
-    if: startsWith(github.ref, 'refs/tags/')
-
     runs-on: ubuntu-20.04-self-hosted
 
     strategy:

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -2,7 +2,14 @@ name: static_build
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -32,11 +39,9 @@ env:
 
 jobs:
   static_build:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -2,7 +2,14 @@ name: static_build_cmake_linux
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -32,11 +39,9 @@ env:
 
 jobs:
   static_build_cmake_linux:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/static_build_cmake_osx_15.yml
+++ b/.github/workflows/static_build_cmake_osx_15.yml
@@ -2,7 +2,14 @@ name: static_build_cmake_osx_15
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -32,11 +39,9 @@ env:
 
 jobs:
   static_build_cmake_osx_15:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: macos-10.15
 

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -2,7 +2,14 @@ name: ubuntu_16_04
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -29,11 +36,9 @@ concurrency:
 
 jobs:
   ubuntu_16_04:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -2,7 +2,14 @@ name: ubuntu_18_04
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -29,11 +36,9 @@ concurrency:
 
 jobs:
   ubuntu_18_04:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -2,7 +2,14 @@ name: ubuntu_20_04
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -29,11 +36,9 @@ concurrency:
 
 jobs:
   ubuntu_20_04:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/ubuntu_20_04_aarch64.yml
+++ b/.github/workflows/ubuntu_20_04_aarch64.yml
@@ -8,6 +8,8 @@ on:
       - '**-full-ci'
     tags:
       - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -34,8 +36,9 @@ concurrency:
 
 jobs:
   ubuntu_20_04_aarch64:
-    # The job works on our own runners, forks do not have them.
-    if: github.repository == 'tarantool/tarantool'
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: graviton
 

--- a/.github/workflows/ubuntu_20_10.yml
+++ b/.github/workflows/ubuntu_20_10.yml
@@ -2,7 +2,14 @@ name: ubuntu_20_10
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -29,11 +36,9 @@ concurrency:
 
 jobs:
   ubuntu_20_10:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/ubuntu_20_10_aarch64.yml
+++ b/.github/workflows/ubuntu_20_10_aarch64.yml
@@ -8,6 +8,8 @@ on:
       - '**-full-ci'
     tags:
       - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -34,8 +36,9 @@ concurrency:
 
 jobs:
   ubuntu_20_10_aarch64:
-    # The job works on our own runners, forks do not have them.
-    if: github.repository == 'tarantool/tarantool'
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: graviton
 

--- a/.github/workflows/ubuntu_21_04.yml
+++ b/.github/workflows/ubuntu_21_04.yml
@@ -2,7 +2,14 @@ name: ubuntu_21_04
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -29,11 +36,9 @@ concurrency:
 
 jobs:
   ubuntu_21_04:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: ubuntu-20.04-self-hosted
 


### PR DESCRIPTION
After this commit only three workflow are run on pull request or push to
a developer branch:
 - luacheck
 - release
 - debug_coverage

To run all other tests, one should either name the branch `*-full-ci`
and push it to the main repository or set the 'full-ci' label on the
pull request.

It is also possible to disable all tests on push by naming branch as
`*-notest' or setting the 'notest' label on the pull request.

**Caveats**:
 - Unfortunately, currently it doesn't seem to be possible to run
   workflows automatically when a particular label is set - the best we
   can do is run workflows when *any* label is set. So labeling a PR
   that has the 'full-ci' label set will trigger all workflows!
 - For the same reason, removing the 'notest' label doesn't trigger ci.
   One has to synchronize the PR afterwards. We could trigger ci on the
   'unlabel' event, but this would trigger tests when any label is
   removed, not necessarily 'notest'. Since 'notest' is supposed to be
   used only by developers, who can sync the branch, this should be
   acceptable.

While we are at it:
 - Remove the check disabling certain workflow runs on forks - it's
   pointless, because forks don't have ci. Anyway, we don't bother
   disabling most of our workflows on forks, even those that we run on
   self-hosted machines, so that would only be consistent.
 - Remove the condition from the coverity workflow - coverity doesn't
   run on push or PR so it doesn't make any sense.
 - Remove the condition from the 'source' workflow. Instead trigger it
   only when a tag is pushed. This is needed to avoid showing it as a
   skipped workflow in PRs and commits.

Closes #6605