### PR TITLE
vinyl: optimize deletion of compacted run files

### DIFF
--- a/changelogs/unreleased/gh-6568-replica-initial-join-removal-of-compacted-run-files.md
+++ b/changelogs/unreleased/gh-6568-replica-initial-join-removal-of-compacted-run-files.md
@@ -1,0 +1,4 @@
+## bugfix/vinyl
+
+* Immediate removal of compacted run files created after the last checkpoint
+  optimization now works for replica's initial JOIN stage (gh-6568). 

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -2858,6 +2858,7 @@ vinyl_engine_begin_initial_recovery(struct engine *engine,
 			return -1;
 		vy_env_complete_recovery(e);
 		e->status = VINYL_INITIAL_RECOVERY_REMOTE;
+		e->run_env.initial_join = true;
 	}
 	return 0;
 }
@@ -2872,6 +2873,7 @@ vinyl_engine_begin_final_recovery(struct engine *engine)
 		break;
 	case VINYL_INITIAL_RECOVERY_REMOTE:
 		e->status = VINYL_FINAL_RECOVERY_REMOTE;
+		e->run_env.initial_join = false;
 		break;
 	default:
 		unreachable();

--- a/src/box/vy_run.c
+++ b/src/box/vy_run.c
@@ -183,6 +183,7 @@ vy_run_env_create(struct vy_run_env *env, int read_threads)
 	tt_pthread_key_create(&env->zdctx_key, vy_free_zdctx);
 	mempool_create(&env->read_task_pool, cord_slab_cache(),
 		       sizeof(struct vy_page_read_task));
+	env->initial_join = false;
 }
 
 /**

--- a/src/box/vy_run.h
+++ b/src/box/vy_run.h
@@ -69,6 +69,11 @@ struct vy_run_env {
 	 * processing the next read request.
 	 */
 	int next_reader;
+	/**
+	 * We need this flag during compaction in order to determine we can
+	 * unconditionally remove unused runs' files in-place.
+	 */
+	bool initial_join;
 };
 
 /**

--- a/src/box/vy_scheduler.c
+++ b/src/box/vy_scheduler.c
@@ -1541,7 +1541,8 @@ vy_task_compaction_complete(struct vy_task *task)
 	 * next checkpoint.
 	 */
 	rlist_foreach_entry(run, &unused_runs, in_unused) {
-		if (run->dump_lsn > vy_log_signature())
+		if (run->dump_lsn > vy_log_signature() ||
+		    scheduler->run_env->initial_join)
 			vy_run_remove_files(lsm->env->path, lsm->space_id,
 					    lsm->index_id, run->id);
 	}

--- a/test/vinyl-luatest/gh_6568_replica_initial_join_removal_of_compacted_run_files_test.lua
+++ b/test/vinyl-luatest/gh_6568_replica_initial_join_removal_of_compacted_run_files_test.lua
@@ -1,0 +1,73 @@
+local cluster = require('test.luatest_helpers.cluster')
+local fio = require('fio')
+local t = require('luatest')
+
+local g = t.group('gh-6568-replica-initial-join-removal-of-compacted-run-files')
+
+local s_id = 0
+g.before_all(function()
+    local helpers = require('test.luatest_helpers')
+
+    g.cluster = cluster:new({})
+
+    local master_uri = helpers.instance_uri('master')
+    local master_box_cfg = {
+        listen           = master_uri,
+    }
+    g.master = g.cluster:build_and_add_server({alias   = 'master',
+                                               box_cfg = master_box_cfg})
+
+    local replica_box_cfg = {
+        listen       = helpers.instance_uri('replica'),
+        vinyl_memory = 128,
+        replication  = {
+            master_uri,
+        },
+        read_only    = true,
+    }
+    g.replica = g.cluster:build_and_add_server({alias   = 'replica',
+                                                box_cfg = replica_box_cfg})
+
+    g.master:start()
+    s_id = g.master:exec(function()
+        local s = box.schema.space.create('test', {engine = 'vinyl'})
+        s:create_index('primary')
+
+        for i = 1, 64 do s:insert{i, ('x'):rep(63)} end
+
+        return s.id
+    end)
+
+    g.replica:start()
+end)
+
+g.after_all(function()
+    g.cluster:drop()
+end)
+
+g.test_replication_compaction_cleanup = function()
+    local replica_vinyl_dir = g.replica:exec(function()
+        local fio = require('fio')
+
+        return fio.cwd()
+    end)
+    local replica_index_dir = fio.pathjoin(replica_vinyl_dir,
+                                           ('%d/0/'):format(s_id))
+    local observed_sz = 0
+    for _, file_name in pairs(fio.listdir(replica_index_dir)) do
+        if file_name:find('.run$') then
+            local file_path = fio.pathjoin(replica_index_dir, file_name)
+            observed_sz = observed_sz + fio.stat(file_path).size
+        end
+    end
+    local expected_sz = g.replica:exec(function()
+        return box.stat.vinyl().disk.data
+    end)
+    local sz_diff = observed_sz - expected_sz
+    local msg = 'the total actual size of run files directories of replica ' ..
+                'must not differ from box.stat.vinyl().disk.data by more ' ..
+                'than %.1f%%'
+    local perm_rel_sz_diff = 1
+    msg = msg:format(perm_rel_sz_diff * 100)
+    t.assert_le(sz_diff / expected_sz, perm_rel_sz_diff, msg)
+end

--- a/test/vinyl-luatest/suite.ini
+++ b/test/vinyl-luatest/suite.ini
@@ -1,0 +1,4 @@
+[default]
+core = luatest
+description = vinyl space engine luatests
+is_parallel = True


### PR DESCRIPTION
On completion of compaction tasks we remove compacted run files created
after the last checkpoint immediately to save disk space. In order to perform this
optimization we compare the unused runs' dump LSN with the last
checkpoint's one.

But during replica's initial JOIN stage we set the LSN of all rows
received from remote master to 0 (see
box/box.cc/boostrap_journal_write). Considering that the LSN of an
initial checkpoint is also 0, our optimization stops working, and we
receive a huge disk space usage spike (as the unused run files will
only get removed when garbage collection occurs).

We should check the vinyl space engine's status and perform
our optimization unconditionally if we are in replica's initial JOIN
stage.

Closes #6568