### PR TITLE
Move FreeBSD CI to MCS

### DIFF
--- a/.github/workflows/freebsd-12.yml
+++ b/.github/workflows/freebsd-12.yml
@@ -1,4 +1,4 @@
-name: freebsd
+name: freebsd-12
 
 on:
   push:
@@ -34,44 +34,22 @@ concurrency:
     format('{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: true
 
-env:
-  CI_MAKE: make -f .gitlab.mk
-
 jobs:
-  freebsd:
+  freebsd-12:
     # Run on pull request only if the 'full-ci' label is set.
     if: github.event_name != 'pull_request' ||
         contains(github.event.pull_request.labels.*.name, 'full-ci')
 
-    runs-on: freebsd-sh
+    runs-on: freebsd-12-mcs
 
     strategy:
       fail-fast: false
 
     steps:
-      - name: set PATH to GIT of the newer version 2.9.0
-        run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: recursive
       - uses: ./.github/actions/environment
       - name: test
-        env:
-          VMS_NAME: 'freebsd_12'
-          VMS_USER: 'vagrant'
-          VMS_PORT: '2232'
-          MAKE: 'gmake'
-        run: |
-          ${CI_MAKE} vms_start
-          ${CI_MAKE} vms_test_freebsd_no_deps
-      - name: call action to send Telegram message on failure
-        env:
-          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
-          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
-        uses: ./.github/actions/send-telegram-notify
-        if: failure()
-      - name: artifacts
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: freebsd
-          retention-days: 21
-          path: ./artifacts
+        run: make -f .travis.mk test_freebsd

--- a/.github/workflows/freebsd-13.yml
+++ b/.github/workflows/freebsd-13.yml
@@ -1,0 +1,55 @@
+name: freebsd-13
+
+on:
+  push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
+
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch (1.10,
+  # 2.8, etc.), and tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    github.ref == 'refs/heads/1.10' ||
+    startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+jobs:
+  freebsd-13:
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
+
+    runs-on: freebsd-13-mcs
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: test
+        run: make -f .travis.mk test_freebsd

--- a/.travis.mk
+++ b/.travis.mk
@@ -445,6 +445,7 @@ test_static_build_cmake_osx_github_actions: base_deps_osx_github_actions test_st
 deps_freebsd:
 	sudo pkg install -y git cmake gmake icu libiconv \
 		python38 py38-yaml py38-six py38-gevent
+	which python3 || sudo ln -s /usr/local/bin/python3.8 /usr/local/bin/python3
 
 build_freebsd:
 	if [ "$$(swapctl -l | wc -l)" != "1" ]; then sudo swapoff -a ; fi ; swapctl -l
@@ -453,7 +454,7 @@ build_freebsd:
 
 test_freebsd_no_deps: build_freebsd
 	make LuaJIT-test
-	cd test && python3.8 test-run.py --vardir ${VARDIR} --force $(TEST_RUN_EXTRA_PARAMS)
+	cd test && ./test-run.py --vardir ${VARDIR} --force $(TEST_RUN_EXTRA_PARAMS)
 
 test_freebsd: deps_freebsd test_freebsd_no_deps
 

--- a/.travis.mk
+++ b/.travis.mk
@@ -444,7 +444,7 @@ test_static_build_cmake_osx_github_actions: base_deps_osx_github_actions test_st
 
 deps_freebsd:
 	sudo pkg install -y git cmake gmake icu libiconv \
-		python27 py27-yaml py27-six py27-gevent
+		python38 py38-yaml py38-six py38-gevent
 
 build_freebsd:
 	if [ "$$(swapctl -l | wc -l)" != "1" ]; then sudo swapoff -a ; fi ; swapctl -l
@@ -453,7 +453,7 @@ build_freebsd:
 
 test_freebsd_no_deps: build_freebsd
 	make LuaJIT-test
-	cd test && python2.7 test-run.py --force $(TEST_RUN_EXTRA_PARAMS)
+	cd test && python3.8 test-run.py --force $(TEST_RUN_EXTRA_PARAMS)
 
 test_freebsd: deps_freebsd test_freebsd_no_deps
 

--- a/.travis.mk
+++ b/.travis.mk
@@ -453,7 +453,7 @@ build_freebsd:
 
 test_freebsd_no_deps: build_freebsd
 	make LuaJIT-test
-	cd test && python3.8 test-run.py --force $(TEST_RUN_EXTRA_PARAMS)
+	cd test && python3.8 test-run.py --vardir ${VARDIR} --force $(TEST_RUN_EXTRA_PARAMS)
 
 test_freebsd: deps_freebsd test_freebsd_no_deps
 

--- a/README.FreeBSD
+++ b/README.FreeBSD
@@ -1,8 +1,8 @@
-Target OS: FreeBSD 10.4 (RELEASE) and FreeBSD 11.2 (RELEASE)
+Target OS: FreeBSD 12.2 (RELEASE) and FreeBSD 13.0 (RELEASE)
 
 1. Install necessary packages:
 -------------
-pkg install git cmake gmake readline icu
+pkg install git cmake gmake readline icu libiconv
 
 
 2. Download & build tarantool source code:
@@ -16,21 +16,25 @@ git submodule update --init --recursive
 cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo
 gmake
 
-3. Set up python 2.7
+3. Set up python 3.8
 -------------
 
 Install testing dependences either from packages or from pip.
 
 3.1. From packages:
 -------------
-pkg install python27 py27-yaml py27-daemon py27-msgpack
+pkg install python38 py38-yaml py38-six py38-gevent
 
 3.2. From pip:
 -------------
-pkg install py27-virtualenv
+pkg install py38-virtualenv py38-pip
 virtualenv .venv
 source .venv/bin/activate
 pip install -r ../test-run/requirements.txt
+
+3.3. Fix python path if necessary
+-------------
+which python3 || ln -s /usr/local/bin/python3.8 /usr/local/bin/python3
 
 4. Run tarantool test suite
 -------------

--- a/extra/mkexports
+++ b/extra/mkexports
@@ -23,5 +23,5 @@ else
         # or follow patch from shared object script
         nm -D `cat $so | grep GROUP | awk '{print $3}'` ;
       } | awk '{print $3}' ; done ;
-    } | sed '/^\s*$/d;s/$/;/;' && echo "};" ) > $2
+    } | sed '/^[[:space:]]*$/d;s/$/;/;' && echo "};" ) > $2
 fi


### PR DESCRIPTION
FreeBSD images for MCS was created. Now we can run tests directly from
MCS instances.
    
There are no official github runner for FreeBSD, but we can use
unofficial runner that supports FreeBSD:
https://github.com/ChristopherHX/github-act-runner.
    
It has limitation:
You won't be able to run steps after a failure without using continue-on-error: true
So steps: artifacts and Telegram message on failure was removed.