### PR TITLE
perf: take off sysbench from docker

### DIFF
--- a/.github/workflows/perf_sysbench.yml
+++ b/.github/workflows/perf_sysbench.yml
@@ -8,7 +8,7 @@ on:
     types: [backend_automation]
   workflow_dispatch:
   schedule:
-    - cron:  '0 */3 * * *'
+    - cron:  '0 1 * * *'
 
 jobs:
   perf_sysbench:
@@ -23,15 +23,28 @@ jobs:
       fail-fast: false
 
     steps:
-      - name: set PATH to GIT of the newer version 2.9.0
-        run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
-      - name: cleanup workspace
-        run: docker run -w /source -v ${PWD}:/source -i centos:8 /bin/bash -c "chown -R $(id -u):$(id -g) * .[^.]*"
-      - uses: actions/checkout@v1
-      - name: test
-        env:
-          BENCH: 'sysbench'
-        uses: ./.github/actions/perf
+#      TODO: migrate to v2 when Git 2.18 or higher would be available
+      - name: checkout tarantool
+        uses: actions/checkout@v1
+        with:
+          submodules: true
+      - name: checkout sysbench
+        uses: actions/checkout@v2.3.4
+        with:
+          path: sysbench
+          repository: tarantool/sysbench
+      - name: tarantool build
+        run: |
+          cmake . -DENABLE_DIST=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo && make -j 4
+      - name: configure benchmark
+        run: |
+          ./autogen.sh
+          ./configure --with-tarantool --without-mysql
+          make -j 4
+        working-directory: ./sysbench
+      - name: run benchmark
+        run: ./run.sh
+        working-directory: ./bench-run/benchs/sysbench
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
@@ -45,5 +58,39 @@ jobs:
           name: perf_sysbench
           retention-days: 21
           path: |
-            *_result.txt
-            *_t_version.txt
+            ./bench-run/benchs/sysbench/*_result.txt
+            ./bench-run/benchs/sysbench/*_t_version.txt
+
+# TODO: set up publishing in same job
+  publish:
+    needs: perf_sysbench
+    # TODO: either fix post request availability from perf machines or
+    # decide which boxes could be used
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout tarantool
+        uses: actions/checkout@v2.3.4
+      - name: download all workflow run artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: perf_sysbench
+          path: ./bench-run/publish/perf_sysbench
+      - name: set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: install requirements
+        run: python3 -m pip install -r ./bench-run/publish/requirements.txt
+      - name: publish
+        env:
+          INFLUXDB_BUCKET_URL: ${{ secrets.INFLUXDB_BUCKET_URL }}
+          INFLUXDB_TOKEN: ${{ secrets.INFLUXDB_TOKEN }}
+        run: ./publish.py -f ./perf_sysbench
+        working-directory: ./bench-run/publish
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()

--- a/bench-run/benchs/cbench/run.sh
+++ b/bench-run/benchs/cbench/run.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+TAR_VER=$(tarantool -v | grep -e "Tarantool" |  grep -oP '\s\K\S*')
+numaopts="numactl --membind=1 --cpunodebind=1 --physcpubind=11"
+cbench_opts=500
+
+killall tarantool 2>/dev/null || true
+rm -rf 5* 0*
+sync && echo "sync passed" || echo "sync failed with error" $?
+echo 3 > /proc/sys/vm/drop_caches
+$numaopts tarantool /opt/cbench/cbench_runner.lua memtx 2>&1 | tee cbench_output_memtx.txt
+
+killall tarantool 2>/dev/null || true
+rm -rf 5* 0*
+sync && echo "sync passed" || echo "sync failed with error" $?
+echo 3 > /proc/sys/vm/drop_caches
+$numaopts tarantool /opt/cbench/cbench_runner.lua vinyl fsync $cbench_opts 2>&1 | tee cbench_output_vinyl_fsync.txt
+
+killall tarantool 2>/dev/null || true
+rm -rf 5* 0*
+sync && echo "sync passed" || echo "sync failed with error" $?
+echo 3 > /proc/sys/vm/drop_caches
+$numaopts tarantool /opt/cbench/cbench_runner.lua vinyl write $cbench_opts 2>&1 | tee cbench_output_vinyl_write.txt
+
+grep "^?tab=cbench.tree" cbench_output_memtx.txt | \
+  sed "s/.*name=//"| sed "s/&param=/:/"| sed "s/cb\./cb\.memtx\./"| \
+  tee -a cbench-memtx-tree_result.txt
+grep "^?tab=cbench.hash" cbench_output_memtx.txt | \
+  sed "s/.*name=//"| sed "s/&param=/:/"| sed "s/cb\./cb\.memtx\./"| \
+  tee -a cbench-memtx-hash_result.txt
+grep "^?tab" cbench_output_vinyl_fsync.txt | \
+  sed "s/.*name=//"| sed "s/&param=/:/"| sed "s/cb\./cb\.vinyl\.fsync\./"| \
+  tee -a cbench-vinyl-fsync_result.txt
+grep "^?tab" cbench_output_vinyl_write.txt | \
+  sed "s/.*name=//"| sed "s/&param=/:/"| sed "s/cb\./cb\.vinyl\.write\./"| \
+  tee -a cbench-vinyl-write_result.txt
+
+echo ${TAR_VER} | tee cbench-memtx-tree_t_version.txt
+echo ${TAR_VER} | tee cbench-memtx-hash_t_version.txt
+echo ${TAR_VER} | tee cbench-vinyl-fsync_t_version.txt
+echo ${TAR_VER} | tee cbench-vinyl-write_t_version.txt
+echo ${TAR_VER} | tee cbench_t_version.txt
+
+echo "Tarantool TAG:"
+cat cbench_t_version.txt
+echo "Overall results:"
+echo "================"
+echo "RESULTS (cbench-memtx-tree_result.txt):"
+cat cbench-memtx-tree_result.txt
+echo " "
+echo "RESULTS (cbench-memtx-hash_result.txt):"
+cat cbench-memtx-hash_result.txt
+echo " "
+echo "RESULTS (cbench-vinyl-fsync_result.txt):"
+cat cbench-vinyl-fsync_result.txt
+echo " "
+echo "RESULTS (cbench-vinyl-write_result.txt):"
+cat cbench-vinyl-write_result.txt

--- a/bench-run/benchs/linkbench/app.lua
+++ b/bench-run/benchs/linkbench/app.lua
@@ -1,0 +1,17 @@
+#!/usr/bin/env tarantool
+
+local path = require('fio').dirname(arg[0])
+package.path = path.."/?.lua;"..package.path
+package.cpath = path.."/?.so;"..package.cpath
+
+require('console').listen('unix/:./tarantool.sock')
+require('gperftools').cpu.start('tarantool.prof')
+
+box.cfg{
+    listen = 3301;
+    vinyl_memory = 256 * 1024 * 1024;
+    vinyl_cache =  256 * 1024 * 1024;
+    vinyl_read_threads = 1;
+}
+
+require('app_internal')

--- a/bench-run/benchs/linkbench/run.sh
+++ b/bench-run/benchs/linkbench/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+TAR_VER=$(tarantool -v | grep -e "Tarantool" |  grep -oP '\s\K\S*')
+numaopts="numactl --membind=1 --cpunodebind=1 --physcpubind=6,7,8,9,10,11"
+base_dir=$(pwd)
+
+cd /opt/linkbench && mvn clean package -Dmaven.test.skip=true
+cd src/tarantool && make
+cd -
+
+# use always newly created path specialy mounted if needed
+wpath=/builds/ws
+rm -rf $wpath
+mkdir -p $wpath
+cd $wpath
+tfile=/opt/linkbench/src/tarantool/app.lua
+# rewrite the lua script at the needed location
+# to be able to use its add additional files
+cp -f `dirname $0`/app.lua $tfile
+$numaopts tarantool $tfile &
+
+cfgfile=/opt/linkbench/config/LinkConfigTarantool.properties
+sed "s/^maxid1 = .*/maxid1 = 5000000/g" -i /opt/linkbench/config/FBWorkload.properties
+sed "s/^requesters = .*/requesters = 1/g" -i $cfgfile
+sed "s/^requests = .*/requests = 2000000/g" -i $cfgfile
+$numaopts /opt/linkbench/bin/linkbench -c $cfgfile -l 2>&1 | tee loading.res.txt
+
+sync && echo "sync passed" || echo "sync failed with error" $?
+echo 3 > /proc/sys/vm/drop_caches
+$numaopts /opt/linkbench/bin/linkbench -c $cfgfile -r 2>&1 | tee linkbench_output.txt
+
+grep "REQUEST PHASE COMPLETED" linkbench_output.txt | sed "s/.*second = /linkbench:/" | tee -a linkbench.ssd_result.txt
+echo ${TAR_VER} | tee linkbench.ssd_t_version.txt
+cp -f linkbench.ssd_t_version.txt $base_dir
+cp -f linkbench.ssd_result.txt $base_dir
+
+echo "Tarantool TAG:"
+cat linkbench.ssd_t_version.txt
+echo "Overall results:"
+echo "================"
+cat linkbench.ssd_result.txt

--- a/bench-run/benchs/nosqlbench/run.sh
+++ b/bench-run/benchs/nosqlbench/run.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+type=$1
+if [ "$type" == "" ]; then
+    type=hash
+fi
+
+TAR_VER=$(tarantool -v | grep -e "Tarantool" |  grep -oP '\s\K\S*')
+numaopts="numactl --membind=1 --cpunodebind=1 --physcpubind=6,7,8,9,10,11"
+
+killall tarantool 2>/dev/null || true
+sync && echo "sync passed" || echo "sync failed with error" $?
+echo 3 > /proc/sys/vm/drop_caches
+
+$numaopts tarantool `dirname $0`/tnt_${type}.lua 2>&1 &
+sed  "s/port 3303/port 3301/" /opt/nosqlbench/src/nosqlbench.conf -i
+sed  "s/benchmark 'no_limit'/benchmark 'time_limit'/" /opt/nosqlbench/src/nosqlbench.conf -i
+sed  "s/time_limit 10/time_limit 2000/" /opt/nosqlbench/src/nosqlbench.conf -i
+sed  "s/request_batch_count 1/request_batch_count 10/" /opt/nosqlbench/src/nosqlbench.conf -i
+sed  "s/rps 12000/rps 20000/" /opt/nosqlbench/src/nosqlbench.conf -i
+sleep 5
+echo "Run NB"
+# WARNING: don't try to save output from stderr - file will use the whole disk space !
+$numaopts  /opt/nosqlbench/src/nb /opt/nosqlbench/src/nosqlbench.conf | \
+    grep -v "Warmup" | grep -v "Failed to allocate" >nosqlbench_output.txt || cat nosqlbench_output.txt
+
+grep "TOTAL RPS STATISTICS:" nosqlbench_output.txt -A6 | \
+  awk -F "|" 'NR > 4 {print $2,":", $4}' > noSQLbench.${type}_result.txt
+echo ${TAR_VER} | tee noSQLbench.${type}_t_version.txt
+
+echo "Tarantool TAG:"
+cat noSQLbench.${type}_t_version.txt
+echo "Overall results:"
+echo "================"
+cat noSQLbench.${type}_result.txt

--- a/bench-run/benchs/nosqlbench/tnt_hash.lua
+++ b/bench-run/benchs/nosqlbench/tnt_hash.lua
@@ -1,0 +1,28 @@
+local console = require('console')
+console.listen("/tmp/tarantool-server.sock")
+
+box.cfg {
+    pid_file   = "./tarantool-server.pid",
+    log        = "./tarantool-server.log",
+    listen = 3301,
+    memtx_memory = 2000000000,
+    background = true,
+    checkpoint_interval = 0,
+    wal_mode = 'none',
+}
+
+s = box.schema.space.create('tester_nosqlbench')
+s:create_index('primary', {type = 'hash', parts = {1, 'unsigned'}})
+
+function try(f, catch_f)
+    local status, exception = pcall(f)
+    if not status then
+        catch_f(exception)
+    end
+end
+
+try(function()
+    box.schema.user.grant('guest', 'create,read,write,execute', 'universe')
+end, function(e)
+    print(e)
+end)

--- a/bench-run/benchs/nosqlbench/tnt_tree.lua
+++ b/bench-run/benchs/nosqlbench/tnt_tree.lua
@@ -1,0 +1,29 @@
+local console = require('console')
+console.listen("/tmp/tarantool-server.sock")
+
+--memtx_memory = 2000000000,
+box.cfg {
+    pid_file   = "./tarantool-server.pid",
+    log        = "./tarantool-server.log",
+    listen = 3301,
+    vinyl_memory = 107374182,
+    background = true,
+    checkpoint_interval = 0,
+    wal_mode = 'none',
+}
+
+s = box.schema.space.create('tester_nosqlbench')
+s:create_index('primary', {type = 'tree', parts = {1, 'unsigned'}})
+
+function try(f, catch_f)
+    local status, exception = pcall(f)
+    if not status then
+        catch_f(exception)
+    end
+end
+
+try(function()
+    box.schema.user.grant('guest', 'create,read,write,execute', 'universe')
+end, function(e)
+    print(e)
+end)

--- a/bench-run/benchs/sysbench/run.sh
+++ b/bench-run/benchs/sysbench/run.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+runs=1
+
+TAR_VER=$(tarantool -v | grep -e "Tarantool" |  grep -oP '\s\K\S*')
+numaconf="numactl --membind=1 --cpunodebind=1 --physcpubind=6,7,8,9,10,11"
+
+ARRAY_TESTS=(
+    "oltp_read_only"
+#    "oltp_write_only"
+#    "oltp_read_write"
+#    "oltp_update_index"
+#    "oltp_update_non_index"
+#    "oltp_insert"
+#    "oltp_delete"
+#    "oltp_point_select"
+#    "select_random_points"
+#    "select_random_ranges"
+#    "bulk_insert"
+)
+
+WARMUP_TIME=5
+TIME=20
+DBMS="tarantool"
+THREADS=200
+opts="--db-driver=${DBMS} --threads=${THREADS}"
+
+export LD_LIBRARY_PATH=/usr/local/lib
+
+for test in "${ARRAY_TESTS[@]}"; do
+    res=0
+    tlog=sysbench_${test}_results.txt
+    rm -f $tlog
+    maxres=0
+    for run in `eval echo {1..$runs}` ; do
+        echo "------------ $test ------------ rerun: # $run ------------"
+        "$PWD"/run_tnt.sh >tnt_server.txt 2>&1 || ( cat tnt_server.txt ; exit 1 )
+
+        sysbench $test $opts cleanup >sysbench_output.txt
+        sysbench $test $opts prepare >>sysbench_output.txt
+ 
+        $numaconf sysbench $test $opts \
+            --time=${TIME} --warmup-time=${WARMUP_TIME} run >>sysbench_output.txt
+
+        $numaconf sysbench $test $opts cleanup >>sysbench_output.txt
+
+        cat sysbench_output.txt | grep -e 'transactions:' | grep -oP '\(\K\S*' | tee $tlog
+        tres=`cat $tlog | sed 's#^.*:##g' | sed 's#\..*$##g'`
+        res=$(($res+$tres))
+        if [[ $tres -gt $maxres ]]; then maxres=$tres ; fi
+    done
+    res=$(($res/$runs))
+    echo "${test}: $res" >>Sysbench_result.txt
+
+    echo "Subtest '$test' results:"
+    echo "==============================="
+    echo "Average result: $res"
+    echo "Maximum result: $maxres"
+    printf "Deviations (AVG -> MAX): %.2f" `bc <<< "scale = 4; (1 - $res / $maxres) * 100"` ; echo %
+done
+
+echo ${TAR_VER} | tee Sysbench_t_version.txt
+
+echo "Tarantool TAG:"
+cat Sysbench_t_version.txt
+echo "Overall results:"
+echo "================"
+cat Sysbench_result.txt

--- a/bench-run/benchs/sysbench/run_tnt.sh
+++ b/bench-run/benchs/sysbench/run_tnt.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# use always newly created path specialy mounted if needed
+wpath=/builds/ws
+rm -rf $wpath
+mkdir -p $wpath
+cd $wpath
+
+numactl --show
+numactl --hardware
+killall tarantool 2>/dev/null || true
+rm -rf 0*.xlog 0*.snap /tmp/tarantool-server.sock
+while netstat -tulnp | grep 3301 ; do
+    echo "Waiting the port 3301 release..."
+    sleep 4
+done
+while ! numactl --membind=1 --cpunodebind=1 --physcpubind=6,7,8,9,10,11 \
+	tarantool `dirname $0`/tnt_srv.lua 2>&1 ; do
+    echo "Waiting for Tarantool trying to start..."
+    sleep 5
+done
+sync
+echo 3 > /proc/sys/vm/drop_caches
+
+STATUS=
+while [ ${#STATUS} -eq "0" ]; do
+    STATUS="$(echo box.info.status | tarantoolctl connect /tmp/tarantool-server.sock | grep -e "- running")"
+    echo "waiting load snapshot to tarantool..."
+    sleep 6
+done

--- a/bench-run/benchs/sysbench/tnt_srv.lua
+++ b/bench-run/benchs/sysbench/tnt_srv.lua
@@ -1,0 +1,25 @@
+local console = require('console')
+console.listen("/tmp/tarantool-server.sock")
+
+box.cfg {
+    pid_file   = "./tarantool-server.pid",
+    log        = "./tarantool-server.log",
+    listen = 3301,
+    memtx_memory = 2000000000,
+    background = true,
+    checkpoint_interval = 0,
+}
+
+
+function try(f, catch_f)
+    local status, exception = pcall(f)
+    if not status then
+        catch_f(exception)
+    end
+end
+
+try(function()
+    box.schema.user.grant('guest', 'create,read,write,execute', 'universe')
+end, function(e)
+    print(e)
+end)

--- a/bench-run/benchs/tpcc/run.sh
+++ b/bench-run/benchs/tpcc/run.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -eu
+set -o pipefail
+
+TAR_VER=$(tarantool -v | grep -e "Tarantool" |  grep -oP '\s\K\S*')
+numaopts="numactl --membind=1 --cpunodebind=1 --physcpubind=6,7,8,9,10,11"
+base_dir=$(pwd)
+
+TIME=1200
+WARMUP_TIME=10
+
+killall tarantool tpcc_load 2>/dev/null || true
+sync && echo "sync passed" || echo "sync failed with error" $?
+echo 3 > /proc/sys/vm/drop_caches
+
+sed 's#box.sql#box#g' -i /opt/tpcc/create_table.lua
+$numaopts tarantool /opt/tpcc/create_table.lua &
+sleep 5
+
+# Usage: tpcc_load -h server_host -P port -d database_name -u mysql_user 
+#            -p mysql_password -w warehouses -l part -m min_wh -n max_wh
+#        * [part]: 1=ITEMS 2=WAREHOUSE 3=CUSTOMER 4=ORDERS
+tpcc_opts="-h localhost -P 3301 -d tarantool -u root -p '' -w 15"
+
+cd /opt/tpcc
+. /opt/tpcc/load.sh tarantool 15
+
+$numaopts /opt/tpcc/tpcc_start $tpcc_opts -r10 -l${TIME} -i${TIME} >tpcc_output.txt 2>/dev/null
+
+echo -n "tpcc:" | tee tpc.c_result.txt
+cat tpcc_output.txt | grep -e '<TpmC>' | grep -oP '\K[0-9.]*' | tee -a tpc.c_result.txt
+cat tpcc_output.txt
+
+echo ${TAR_VER} | tee tpc.c_t_version.txt
+cp -f tpc.c_t_version.txt $base_dir
+cp -f tpc.c_result.txt $base_dir
+
+echo "Tarantool TAG:"
+cat tpc.c_t_version.txt
+echo "Overall result:"
+echo "==============="
+cat tpc.c_result.txt

--- a/bench-run/benchs/tpch/run.sh
+++ b/bench-run/benchs/tpch/run.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -eu
+set -o pipefail
+
+TAR_VER=$(tarantool -v | grep -e "Tarantool" |  grep -oP '\s\K\S*')
+numaopts="numactl --membind=1 --cpunodebind=1 --physcpubind=6,7,8,9,10,11"
+base_dir=$(pwd)
+
+cd /opt/tpch
+make create_SQL_db
+
+killall tarantool 2>/dev/null || true
+sync && echo "sync passed" || echo "sync failed with error" $?
+echo 3 > /proc/sys/vm/drop_caches
+
+make bench-sqlite NUMAOPTS="$numaopts"
+make create_TNT_db
+
+killall tarantool 2>/dev/null || true
+sync && echo "sync passed" || echo "sync failed with error" $?
+echo 3 > /proc/sys/vm/drop_caches
+
+make bench-tnt NUMAOPTS="$numaopts"
+make report
+sed "/-2/d" bench-tnt.csv | sed "s/;/:/" | sed "s/-1/0/" | tee tpc.h_result.txt
+
+echo ${TAR_VER} | tee tpc.h_t_version.txt
+cp -f tpc.h_t_version.txt $base_dir
+cp -f tpc.h_result.txt $base_dir
+cp -f bench-sqlite.csv $base_dir
+cp -f bench-tnt.csv $base_dir
+
+echo "Tarantool TAG:"
+cat tpc.h_t_version.txt
+echo "Overall result SQL:"
+echo "==================="
+cat bench-sqlite.csv
+echo " "
+echo "Overall result TNT:"
+echo "==================="
+cat tpc.h_result.txt

--- a/bench-run/benchs/ycsb/run.sh
+++ b/bench-run/benchs/ycsb/run.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+mode=$1
+runs=1
+
+if [ "$mode" == "" ]; then
+    mode=hash
+fi
+
+TAR_VER=$(tarantool -v | grep -e "Tarantool" |  grep -oP '\s\K\S*')
+numaopts="numactl --membind=1 --cpunodebind=1 --physcpubind=6,7,8,9,10,11"
+base_dir=$(pwd)
+
+ws=/opt/ycsb
+cd $ws
+
+for f in workloads/workload[a-f] ; do
+    sed 's#recordcount=.*#recordcount=1000000#g' -i $f
+    sed 's#operationcount=.*#operationcount=1000000#g' -i $f
+done
+
+srvlua=$ws/tarantool/src/main/conf/tarantool-${mode}.lua
+cd $ws
+sed 's/listen=.*/listen=3301,\n   memtx_memory = 2000000000,/' -i $srvlua
+sed 's/logger_nonblock.*//' -i $srvlua
+sed 's/logger/log/' -i $srvlua
+sed 's/read,write,execute/create,read,write,execute/' -i $srvlua
+$numaopts tarantool $srvlua 2>&1 &
+sleep 5
+
+plogs=$ws/results
+rm -rf $ws/0* $plogs
+mkdir $plogs
+for l in a b c d e f ; do
+    echo =============== $l
+    for r in `eval echo {1..$runs}` ; do
+        res=$plogs/run${l}_${r}
+        echo ---------------- ${l}: $r
+        echo "tarantool.port=3301" >> $ws/workloads/workload${l}
+        $numaopts bin/ycsb load tarantool -s -P workloads/workload${l} >${res}.load 2>&1 || cat ${res}.load
+	sync && echo "sync passed" || echo "sync failed with error" $?
+	echo 3 > /proc/sys/vm/drop_caches
+        $numaopts bin/ycsb run tarantool -s -P workloads/workload${l} >${res}.log 2>&1 || cat ${res}.log
+        grep Thro ${res}.log | awk '{ print "Overall result: "$3 }' | tee ${res}.txt
+        sed "s#Overall result#$l $r#g" ${res}.txt >>${plogs}/ycsb.${mode}_result.txt
+    done
+done
+
+echo ${TAR_VER} | tee ycsb.${mode}_t_version.txt
+cp -f ${plogs}/ycsb.${mode}_result.txt .
+cp -f ycsb.${mode}_t_version.txt $base_dir
+cp -f ycsb.${mode}_result.txt $base_dir
+
+echo "Tarantool TAG:"
+cat ycsb.${mode}_t_version.txt
+echo "Overall results:"
+echo "================"
+cat ycsb.${mode}_result.txt

--- a/bench-run/publish/metrics.py
+++ b/bench-run/publish/metrics.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+import os
+from typing import Dict
+
+import git
+
+
+class Metric:
+
+    def __init__(self, benchmark: str, values: Dict) -> None:
+        """Provide basic tags for describing metric.
+
+        Mostly common tags are benchmark name, commit, branch, timestamp.
+        """
+        self.path_to_repo = os.getenv("GITHUB_WORKSPACE")
+        self.repo = git.Repo(self.path_to_repo)
+        self.benchmark = benchmark
+        self.branch = self.repo.active_branch
+        self.commit = self.repo.head.commit
+        self.values = ",".join(
+            [f"{label}={value}" for label, value in values.items()])
+
+        # use commit timestamp as a basic time value. default value
+        # is provided by database as a time when value is posted.
+        # It is important for retrospective.
+        self.timestamp = os.getenv("COMMIT_TIMESTAMP", '')
+
+    def __str__(self) -> str:
+        """Represent metric in prometheus format to make POST request."""
+        return f"perf,benchmark={self.benchmark},branch={self.branch}" \
+               f" {self.values} {self.timestamp}"

--- a/bench-run/publish/publish.py
+++ b/bench-run/publish/publish.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+import argparse
+import fnmatch
+import logging
+import os
+from typing import AnyStr
+from typing import List
+
+import requests
+
+from metrics import Metric
+
+URL = os.getenv("INFLUXDB_BUCKET_URL")
+
+
+def parse_bench(filename: str) -> List[AnyStr]:
+    with open(filename) as raw_data:
+        return raw_data.readlines()
+
+
+def get_version(filename: str) -> str:
+    """Get tarantool version from the file
+
+    Version is provided by benchmarks in a file <Benchmark>_t_version.txt.
+    Example: Sysbench_t_version.txt includes '2.10.0-beta1-113-g16f7bf1'.
+    """
+    with open(filename) as raw_data:
+        version = raw_data.readlines()[-1]
+    version = version.split()[0]
+    if not version:
+        raise Exception("There was no version in a version file.")
+    return version
+
+
+def post_to_database(metric: Metric) -> None:
+    """Post request to the database."""
+    response = requests.post(
+        URL, data=str(metric),
+        headers={'Authorization': f'Token {os.environ["INFLUXDB_TOKEN"]}'}
+    )
+
+    logging.info(f"Sent metric: {metric} to the database. "
+                 f"Response is {response.status_code}")
+
+    if response.status_code >= 400:
+        raise Exception(f"Bad response: {response.status_code}")
+
+
+def main(directory: str):
+    logging.info(f"Files will be published from {directory}")
+    for file in os.listdir(directory):
+        if fnmatch.fnmatch(file, '*_result.txt'):
+            logging.info(f"{file} was matched as file with results")
+            values = parse_bench(os.path.join(directory, file))
+            benchmark = file.split('_')[0]
+            version = get_version(
+                os.path.join(directory, '{}_t_version.txt'.format(benchmark)))
+            logging.info(f"VERSION - {version}")
+            for value in values:
+                test_name = value.split(':')[0]
+                test_res = float(value.split(':')[1])
+                metric = Metric(benchmark=benchmark,
+                                values={test_name: test_res})
+                post_to_database(metric)
+
+    return 0
+
+
+if __name__ == '__main__':
+    ap = argparse.ArgumentParser()
+    ap.add_argument("-f", "--from-directory", required=True,
+                    help="directory with files to publish")
+    args = ap.parse_args()
+
+    logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
+
+    main(directory=args.from_directory)

--- a/bench-run/publish/requirements.txt
+++ b/bench-run/publish/requirements.txt
@@ -1,0 +1,2 @@
+GitPython>=3.1
+requests>=2.26

--- a/bench-run/targets.mk
+++ b/bench-run/targets.mk
@@ -1,0 +1,53 @@
+# Use host network at dockerfiles builds
+DOCKERFILE_BUILD=docker build --network=host
+
+# #########################################################
+# Prepare 2 major images for performance testing:
+#
+# - perf/ubuntu-bionic:perf_master
+#   image with only built benchmarks w/o Tarantool sources,
+#   image rare changed, for its fast rebuild better to save
+#   it on performance build hosts
+#
+# - perf_tmp/ubuntu-bionic:perf_<commit_SHA>
+#   images with always changed Tarantool sources and its
+#   depends benchmarks like 'cbench', image need to be
+#   removed after each testing to save the disk space
+#
+# And temporary image for TPC-H, while it uses Tarantool
+# sources patching: 
+#
+# - perf_tmp/ubuntu-bionic:perf_<commit_SHA>_tpch
+#   image with patched Tarantool sources for TPC-H bench.
+# #########################################################
+
+IMAGE_PERF_TPCH_BUILT=${IMAGE_PERF_BUILT}_tpch
+
+prepare:
+	docker login -u ${CI_REGISTRY_USER} -p ${CI_REGISTRY_PASSWORD} \
+		${CI_REGISTRY}
+	# build all benchmarks w/o depends on Tarantool sources
+	${DOCKERFILE_BUILD} --add-host $(shell hostname):127.0.0.1 \
+		-t ${IMAGE_PERF} -f bench-run/dockerfiles/ubuntu_benchs .
+	docker push ${IMAGE_PERF}
+	# build Tarantool and benchmarks with depends on Tarantool sources
+	${DOCKERFILE_BUILD} --build-arg image_from=${IMAGE_PERF} \
+		-t ${IMAGE_PERF_BUILT} --no-cache \
+		-f bench-run/dockerfiles/ubuntu_tnt .
+	docker push ${IMAGE_PERF_BUILT}
+	# Build image with patched Tarantool for TPC-H bench.
+	# The image uses Tarantool sources patching and should be
+	# updated each time sources changed and patching fails, so
+	# to avoid of fails of the images preparation process this
+	# build should be blocked from failing.
+	( ${DOCKERFILE_BUILD} --build-arg image_from=${IMAGE_PERF} \
+			-t ${IMAGE_PERF_TPCH_BUILT} --no-cache \
+			-f bench-run/dockerfiles/ubuntu_tnt_tpch . && \
+		docker push ${IMAGE_PERF_TPCH_BUILT} ) || :
+
+# #####################################################
+# Remove temporary performance image from the test host
+# #####################################################
+cleanup:
+	docker rmi --force ${IMAGE_PERF_BUILT}
+	docker rmi --force ${IMAGE_PERF_TPCH_BUILT} || :


### PR DESCRIPTION
Previously, sysbench benchmark is running inside the container.
According to perf testing it was a non-prod state.

Also, was added publishing job to the database connected with grafana.

Closed: tarantool/bench-run#21


run: https://github.com/tarantool/tarantool/actions/runs/1548742429
run1: https://github.com/tarantool/tarantool/runs/4455629863?check_suite_focus=true