### PR TITLE
box: check for existence when resolving privileges

### DIFF
--- a/changelogs/unreleased/gh-6199-schema-priv-resolve-existence-check.md
+++ b/changelogs/unreleased/gh-6199-schema-priv-resolve-existence-check.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* We now check that all privileges passed to box.schema.grant are resolved 
+  (gh-6199).

--- a/test/box-luatest/gh_6199_schema_priv_resolve_existence_check_test.lua
+++ b/test/box-luatest/gh_6199_schema_priv_resolve_existence_check_test.lua
@@ -1,0 +1,49 @@
+local cluster = require('test.luatest_helpers.cluster')
+local t = require('luatest')
+
+local g = t.group('gh-6199-schema-priv-resolve-existence-check')
+
+g.before_all(function()
+    local helpers = require('test.luatest_helpers')
+
+    g.cluster = cluster:new({})
+
+    local default_box_cfg = {
+        listen = helpers.instance_uri('default'),
+    }
+    g.default = g.cluster:build_and_add_server({alias   = 'default',
+                                                box_cfg = default_box_cfg})
+    g.cluster:start()
+    g.default:exec(function()
+        box.session.su('admin')
+    end)
+end)
+
+g.after_all(function()
+    g.cluster:drop()
+end)
+
+g.test_priv_resolve_existence_check = function()
+    g.default:exec(function()
+        local t = require('luatest')
+
+        local msg = 'role cannot be granted together with a privilege'
+        t.assert_error(box.schema.user.grant, 'guest', 'read,replication',
+                       'universe', msg)
+
+        msg = 'when privileges are resolved, we check that all of them have' ..
+              'been resolved'
+        local privs = {'read', 'write', 'execute', 'session', 'usage', 'read',
+                       'create', 'drop', 'alter', 'reference', 'trigger',
+                       'update', 'delete'}
+        for _, priv in pairs(privs) do
+            local invalid_priv = ('%s, unknown,%s'):format(priv, priv)
+            t.assert_error(box.schema.user.grant, 'guest', invalid_priv,
+                           'universe', msg)
+        end
+        local invalid_all_privs = table.concat(privs, ',') .. ',unknown' ..
+                                  table.concat(privs, ',')
+        t.assert_error(box.schema.user.grant, 'guest', invalid_all_privs,
+                       'universe', msg)
+    end)
+end


### PR DESCRIPTION
When resolving privileges passed to box.schema.user.grant, we do not
check that all of them have been resolved: check that all privileges
have been resolved and throw an error otherwise.

Closes #6199