### PR TITLE
net.box: fix IO error messages

### DIFF
--- a/src/box/lua/net_box.c
+++ b/src/box/lua/net_box.c
@@ -919,6 +919,7 @@ netbox_encode_upsert(lua_State *L, int idx, struct mpstream *stream,
 static int
 netbox_transport_connect(struct netbox_transport *transport)
 {
+	struct error *e;
 	struct iostream *io = &transport->io;
 	assert(!iostream_is_initialized(io));
 	ev_tstamp start, delay;
@@ -928,12 +929,12 @@ netbox_transport_connect(struct netbox_transport *transport)
 				      /*addr=*/NULL, /*addr_len=*/NULL, delay);
 	coio_timeout_update(&start, &delay);
 	if (fd < 0)
-		return -1;
+		goto io_error;
 	iostream_create(io, fd);
 	char greetingbuf[IPROTO_GREETING_SIZE];
 	if (coio_readn_timeout(io, greetingbuf, IPROTO_GREETING_SIZE,
 			       delay) < 0)
-		goto error;
+		goto io_error;
 	if (greeting_decode(greetingbuf, &transport->greeting) != 0) {
 		box_error_raise(ER_NO_CONNECTION, "Invalid greeting");
 		goto error;
@@ -944,8 +945,14 @@ netbox_transport_connect(struct netbox_transport *transport)
 		goto error;
 	}
 	return 0;
+io_error:
+	assert(!diag_is_empty(diag_get()));
+	e = diag_last_error(diag_get());
+	box_error_raise(ER_NO_CONNECTION, "%s", e->saved_errno != 0 ?
+			strerror(e->saved_errno) : e->errmsg);
 error:
-	iostream_close(io);
+	if (iostream_is_initialized(io))
+		iostream_close(io);
 	return -1;
 }
 
@@ -970,6 +977,7 @@ error:
 static int
 netbox_transport_communicate(struct netbox_transport *transport, size_t limit)
 {
+	struct error *e;
 	struct iostream *io = &transport->io;
 	assert(iostream_is_initialized(io));
 	struct ibuf *send_buf = &transport->send_buf;
@@ -994,7 +1002,7 @@ netbox_transport_communicate(struct netbox_transport *transport, size_t limit)
 			} if (rc > 0) {
 				recv_buf->wpos += rc;
 			} else if (rc == IOSTREAM_ERROR) {
-				goto handle_error;
+				goto io_error;
 			} else {
 				events |= iostream_status_to_events(rc);
 				break;
@@ -1010,7 +1018,7 @@ netbox_transport_communicate(struct netbox_transport *transport, size_t limit)
 				if (ibuf_used(send_buf) == 0)
 					fiber_cond_broadcast(on_send_buf_empty);
 			} else if (rc == IOSTREAM_ERROR) {
-				goto handle_error;
+				goto io_error;
 			} else {
 				events |= iostream_status_to_events(rc);
 				break;
@@ -1027,8 +1035,11 @@ netbox_transport_communicate(struct netbox_transport *transport, size_t limit)
 			return -1;
 		}
 	}
-handle_error:
-	box_error_raise(ER_NO_CONNECTION, "%s", strerror(errno));
+io_error:
+	assert(!diag_is_empty(diag_get()));
+	e = diag_last_error(diag_get());
+	box_error_raise(ER_NO_CONNECTION, "%s", e->saved_errno != 0 ?
+			strerror(e->saved_errno) : e->errmsg);
 	return -1;
 }
 

--- a/src/box/mp_error.cc
+++ b/src/box/mp_error.cc
@@ -257,6 +257,8 @@ error_build_xc(struct mp_error *mp_error)
 		err = new SwimError();
 	} else if (strcmp(mp_error->type, "CryptoError") == 0) {
 		err = new CryptoError();
+	} else if (strcmp(mp_error->type, "GaiError") == 0) {
+		err = new GaiError();
 	} else {
 		err = new ClientError();
 	}

--- a/src/lib/core/coio_task.c
+++ b/src/lib/core/coio_task.c
@@ -416,9 +416,7 @@ coio_getaddrinfo(const char *host, const char *port,
 	/* Task finished */
 	if (task->rc != 0) {
 		/* getaddrinfo() failed */
-		errno = EIO;
-		diag_set(SystemError, "getaddrinfo: %s",
-			 gai_strerror(task->rc));
+		diag_set(GaiError, task->rc);
 		getaddrinfo_free_cb(&task->base);
 		return -1;
 	}

--- a/src/lib/core/diag.h
+++ b/src/lib/core/diag.h
@@ -445,6 +445,8 @@ BuildUnsupportedIndexFeature(const char *file, unsigned line,
 struct error *
 BuildSocketError(const char *file, unsigned line, const char *socketname,
 		 const char *format, ...);
+struct error *
+BuildGaiError(const char *file, unsigned line, int errcode);
 
 #define diag_set_detailed(file, line, class, ...) ({			\
 	/* Preserve the original errno. */                              \

--- a/src/lib/core/exception.h
+++ b/src/lib/core/exception.h
@@ -49,6 +49,8 @@ extern const struct type_info type_ChannelIsClosed;
 extern const struct type_info type_LuajitError;
 extern const struct type_info type_IllegalParams;
 extern const struct type_info type_SystemError;
+extern const struct type_info type_SocketError;
+extern const struct type_info type_GaiError;
 extern const struct type_info type_CollationError;
 extern const struct type_info type_SwimError;
 extern const struct type_info type_CryptoError;
@@ -101,7 +103,6 @@ protected:
 	SystemError(const struct type_info *type, const char *file, unsigned line);
 };
 
-extern const struct type_info type_SocketError;
 class SocketError: public SystemError {
 public:
 	SocketError(const char *file, unsigned line, const char *socketname,
@@ -116,6 +117,18 @@ public:
 	{
 		throw this;
 	}
+};
+
+class GaiError: public SystemError {
+public:
+	GaiError(const char *file, unsigned line, int errcode);
+
+	GaiError()
+		:SystemError(&type_GaiError, NULL, 0)
+	{
+	}
+
+	virtual void raise() { throw this; }
 };
 
 class OutOfMemory: public SystemError {

--- a/src/lib/core/say.c
+++ b/src/lib/core/say.c
@@ -533,9 +533,7 @@ syslog_connect_remote(const char *server_address)
 
 	ret = getaddrinfo(remote, portnum, &hints, &inf);
 	if (ret != 0) {
-		errno = EIO;
-		diag_set(SystemError, "getaddrinfo: %s",
-			 gai_strerror(ret));
+		diag_set(GaiError, ret);
 		goto out;
 	}
 	for (ptr = inf; ptr; ptr = ptr->ai_next) {

--- a/src/lua/socket.lua
+++ b/src/lua/socket.lua
@@ -1000,7 +1000,12 @@ local function getaddrinfo(host, port, timeout, opts)
         end
 
     end
-    return internal.getaddrinfo(host, port, timeout, ga_opts)
+    local dns, err = internal.getaddrinfo(host, port, timeout, ga_opts)
+    if not dns then
+        boxerrno(boxerrno.EIO)
+        return nil, err
+    end
+    return dns
 end
 
 -- tcp connector

--- a/test/unit/mp_error.cc
+++ b/test/unit/mp_error.cc
@@ -86,6 +86,7 @@ const char *standard_errors[] = {
 	"CollationError",
 	"SwimError",
 	"CryptoError",
+	"GaiError",
 };
 
 enum {

--- a/test/unit/mp_error.result
+++ b/test/unit/mp_error.result
@@ -1,7 +1,7 @@
 	*** main ***
 1..7
 	*** test_stack_error_decode ***
-    1..17
+    1..18
     ok 1 - check CustomError
     ok 2 - check AccessDeniedError
     ok 3 - check ClientError
@@ -18,7 +18,8 @@
     ok 14 - check CollationError
     ok 15 - check SwimError
     ok 16 - check CryptoError
-    ok 17 - stack size
+    ok 17 - check GaiError
+    ok 18 - stack size
 ok 1 - subtests
 	*** test_stack_error_decode: done ***
 	*** test_decode_unknown_type ***


### PR DESCRIPTION
Commit c13b3a31a9b04d4e3fbf0be88f76285b2cc103a7 changed error messages reported by net.box on IO errors, which caused integration/cartridge test failure. This PR restores the old error messages: `strerror(error->saved_errno)` if `saved_errno` is set, `error->errmsg` otherwise.