### PR TITLE
readme: actualize without much changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,88 @@
 # Tarantool
 
-[![Build Status][travis-badge]][travis-url]
-[![Build Status][gitlab-ci-badge]][gitlab-ci-url]
+[![Actions Status][actions-badge]][actions-url]
 [![Code Coverage][coverage-badge]][coverage-url]
 [![Telegram][telegram-badge]][telegram-url]
-[![Slack][slack-badge]][slack-url]
-[![Gitter][gitter-badge]][gitter-url]
-[![Google Groups][groups-badge]][groups-url]
+[![GitHub Discussions][discussions-badge]][discussions-url]
+[![Stack Overflow][stackoverflow-badge]][stackoverflow-url]
 
-https://tarantool.io/en/
+[Tarantool][tarantool-url] is an in-memory computing platform consisting of a
+database and an application server.
 
-Patch submissions and discussion of particular patches https://lists.tarantool.org/mailman/listinfo/tarantool-patches/
-
-General development discussions https://lists.tarantool.org/mailman/listinfo/tarantool-discussions/
-
-Tarantool is an in-memory database and application server.
+It is distributed under [BSD 2-Clause][license] terms.
 
 Key features of the application server:
- * 100% compatible drop-in replacement for Lua 5.1,
-   based on LuaJIT 2.1.
-   Simply use `#!/usr/bin/tarantool` instead of
-   `#!/usr/bin/lua` in your script.
- * full support for Lua modules and a rich set of
-   own modules, including cooperative multitasking,
-   non-blocking I/O, access to external databases, etc
+
+* Heavily optimized Lua interpreter with incredibly fast tracing JIT compiler,
+  based on LuaJIT 2.1.
+* Cooperative multitasking, non-blocking IO.
+* [Persistent queues][queue].
+* [Sharding][vshard].
+* [Cluster and application management framework][cartridge].
+* Access to external databases such as [MySQL][mysql] and [PostgreSQL][pg].
+* A rich set of built-in and standalone [modules][modules].
 
 Key features of the database:
- * ANSI SQL, including views, joins, referential
-   and check constraints
- * MsgPack data format and MsgPack based
-   client-server protocol
- * two data engines: 100% in-memory with
-   optional persistence and an own implementation of LSM-tree, 
-   to use with large data sets
- * multiple index types: HASH, TREE, RTREE, BITSET
- * asynchronous master-master replication
- * authentication and access control
- * the database is just a C extension to the
-   application server and can be turned off
 
-Supported platforms are Linux/x86, FreeBSD/x86 and OpenBSD/x86, Mac OS X.
+* MessagePack data format and MessagePack based client-server protocol.
+* Two data engines: 100% in-memory with complete WAL-based persistence and an
+  own implementation of LSM-tree, to use with large data sets.
+* Multiple index types: HASH, TREE, RTREE, BITSET.
+* Document oriented JSON path indexes.
+* Asynchronous master-master replication.
+* Synchronous quorum-based replication.
+* RAFT-based automatic leader election for the single-leader configuration.
+* Authentication and access control.
+* ANSI SQL, including views, joins, referential and check constraints.
+* [Connectors][connectors] for many programming languages.
+* The database is a C extension of the application server and can be turned
+  off.
 
-Tarantool is ideal for data-enriched components of
-scalable Web architecture: queue servers, caches,
-stateful Web applications.
+Supported platforms are Linux (x86_64, aarch64), Mac OS X (x86_64, M1), FreeBSD
+(x86_64).
 
-To download and install Tarantool as a binary package for your OS, please visit
-https://tarantool.io/en/download/.
+Tarantool is ideal for data-enriched components of scalable Web architecture:
+queue servers, caches, stateful Web applications.
 
-To build Tarantool from source, see detailed instructions in the Tarantool
-documentation at https://tarantool.io/en/doc/2.1/dev_guide/building_from_source/.
+To download and install Tarantool as a binary package for your OS or using
+Docker, please see the [download instructions][download].
 
-Please report bugs at https://github.com/tarantool/tarantool/issues
-We also warmly welcome your feedback in the discussion mailing
-list, tarantool@googlegroups.com.
+To build Tarantool from source, see detailed [instructions][building] in the
+Tarantool documentation.
+
+To find modules, connectors and tools for Tarantool, check out our [Awesome
+Tarantool][awesome-list] list.
+
+Please report bugs to our [issue tracker][issue-tracker]. We also warmly
+welcome your feedback on the [discussions][discussions-url] page and questions
+on [Stack Overflow][stackoverflow-url].
+
+We accept contributions via pull requests. Check out our [How to get
+involved][get-involved] guide.
 
 Thank you for your interest in Tarantool!
 
-[travis-badge]: https://api.travis-ci.org/tarantool/tarantool.svg?branch=master
-[travis-url]: https://travis-ci.org/tarantool/tarantool
-[gitlab-ci-badge]: https://gitlab.com/tarantool/tarantool/badges/master/pipeline.svg
-[gitlab-ci-url]: https://gitlab.com/tarantool/tarantool/commits/master
+[actions-badge]: https://github.com/tarantool/tarantool/workflows/release/badge.svg
+[actions-url]: https://github.com/tarantool/tarantool/actions
 [coverage-badge]: https://coveralls.io/repos/github/tarantool/tarantool/badge.svg?branch=master
 [coverage-url]: https://coveralls.io/github/tarantool/tarantool?branch=master
-[groups-badge]: https://img.shields.io/badge/Google-Groups-orange.svg
-[groups-url]: https://groups.google.com/forum/#!forum/tarantool
 [telegram-badge]: https://img.shields.io/badge/Telegram-join%20chat-blue.svg
 [telegram-url]: http://telegram.me/tarantool
-[slack-badge]: https://img.shields.io/badge/Slack-join%20chat-lightgrey.svg
-[slack-url]: http://slack.tarantool.org/
-[gitter-badge]: https://badges.gitter.im/Join%20Chat.svg
-[gitter-url]: https://gitter.im/tarantool/tarantool
+[discussions-badge]: https://img.shields.io/github/discussions/tarantool/tarantool
+[discussions-url]: https://github.com/tarantool/tarantool/discussions
+[stackoverflow-badge]: https://img.shields.io/badge/stackoverflow-tarantool-orange.svg
+[stackoverflow-url]: https://stackoverflow.com/questions/tagged/tarantool
+[tarantool-url]: https://www.tarantool.io/en/
+[license]: LICENSE
+[modules]: https://www.tarantool.io/en/download/rocks
+[queue]: https://github.com/tarantool/queue
+[vshard]: https://github.com/tarantool/vshard
+[cartridge]: https://github.com/tarantool/cartridge
+[mysql]: https://github.com/tarantool/mysql
+[pg]: https://github.com/tarantool/pg
+[connectors]: https://www.tarantool.io/en/download/connectors
+[download]: https://www.tarantool.io/en/download/
+[building]: https://www.tarantool.io/en/doc/latest/dev_guide/building_from_source/
+[issue-tracker]: https://github.com/tarantool/tarantool/issues
+[get-involved]: https://www.tarantool.io/en/doc/latest/contributing/contributing/
+[awesome-list]: https://github.com/tarantool/awesome-tarantool/


### PR DESCRIPTION
readme: actualize without much changes

Well, the diff is not nice, so I'll summarize the changes for humans.

General changes:

* Moved patch submission and so on to the end of the document.
* Reformatted to usual 80 columns, inlined and actualized links.
* Reformatted lists: start from a capital letter, end with a period.
* Minor wording tweaks to make it sound better.

Badges:

* Travis CI and GitLab CI -> GitHub Actions.
* Removed Slack and Gitter.
* Google Groups -> GitHub Discussions.
* Added Stack Overflow.

Define Tarantool as in-memory computing platform as on the website.

Added license information.

Appserver:

* Rewrote the sentence regarding compatibility with Lua 5.1 and
  highlighted key LuaJIT features instead. There are doubts within the
  team about declaring 100% compatibility with Lua 5.1, let's go to the
  safe ground so.
* Splitted the list in a more granular way.
* Added links to mysql and pg connectors.
* Added queue, vshard, cartridge with links.
* Added a link to the modules page.

Database:

* Replaced MsgPack with MessagePack. It is called so on the official
  website.
* Replaced 'optional persistence' with 'complete WAL-based persistence'
  in the memtx description to make it less confusing. There are users,
  which believe that memtx does not offer persistency.
* Moved SQL down.
* Added JSON path indexes.
* Added synchronous quorum-based replication.
* Added RAFT-based automatic leader election.
* Added a link to the connectors list.

Platforms:

* Dropped OpenBSD from the list. It is not verified in CI, so I feel it
  like 'we have no commitments here'.
* Replaced x86 with more explicit x86_64.
* Moved Mac OS before FreeBSD (we have more users here).
* Added aarch64/M1.

Tarantool is ideal for...

* Kept intact, just reformatted to 80 columns.

Download:

* Added 'or using Docker' in addition to 'as a binary package to your
  OS'.

Added a link to the 'Awesome Tarantool' list.

Report bugs / send feedback or patch:

* Replaced Google Groups with GitHub Discussions.
* Added Stack Overflow.
* Highlighted that we accept pull requests and linked 'How to get
  involved' guide.

Fixes #6579