### PR TITLE
Memtx MVCC memory monitoring

### DIFF
--- a/extra/exports
+++ b/extra/exports
@@ -361,6 +361,7 @@ lua_upvalueid
 lua_upvaluejoin
 lua_xmove
 lua_yield
+memtx_tx_story_gc_step
 password_prepare
 PMurHash32
 PMurHash32_Process

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -180,6 +180,7 @@ set(box_sources
     port.c
     txn.c
     tx_memory.c
+    memtx_tx_memory.c
     txn_limbo.c
     raft.c
     box.cc

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -179,6 +179,7 @@ set(box_sources
     session.cc
     port.c
     txn.c
+    tx_memory.c
     txn_limbo.c
     raft.c
     box.cc

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -73,6 +73,8 @@ ffi.cdef[[
     box_txn_begin();
     int
     box_txn_set_timeout(double timeout);
+    void
+    memtx_tx_story_gc_step();
     /** \endcond public */
     /** \cond public */
     int
@@ -349,6 +351,12 @@ box.begin = function(options)
 end
 
 box.is_in_txn = builtin.box_txn
+
+box.internal.memtx_tx_gc = function(step_num)
+    for _ = 1, step_num do
+        builtin.memtx_tx_story_gc_step()
+    end
+end
 
 box.txn_id = function()
     local id = builtin.box_txn_id()

--- a/src/box/lua/stat.c
+++ b/src/box/lua/stat.c
@@ -43,6 +43,8 @@
 #include "box/engine.h"
 #include "box/vinyl.h"
 #include "box/sql.h"
+#include "box/memtx_tx_memory.h"
+#include "box/memtx_tx.h"
 #include "info/info.h"
 #include "lua/info.h"
 #include "lua/utils.h"
@@ -279,6 +281,159 @@ lbox_stat_sql(struct lua_State *L)
 	return 1;
 }
 
+static void
+fill_memtx_mvcc_alloc_stat_item(struct lua_State *L, uint64_t total, uint64_t max,
+		  uint64_t avg)
+{
+	lua_pushstring(L, "total");
+	lua_pushnumber(L, total);
+	lua_settable(L, -3);
+
+	lua_pushstring(L, "max");
+	lua_pushnumber(L, max);
+	lua_settable(L, -3);
+
+	lua_pushstring(L, "avg");
+	lua_pushnumber(L, avg);
+	lua_settable(L, -3);
+}
+
+static void
+set_memtx_mvcc_alloc_stat_item(struct lua_State *L, const char *name, uint64_t total,
+		 uint64_t max, uint64_t avg)
+{
+
+	lua_pushstring(L, name);
+	lua_newtable(L);
+
+	fill_memtx_mvcc_alloc_stat_item(L, total, max, avg);
+
+	lua_settable(L, -3);
+}
+
+static int
+lbox_stat_memtx_mvcc_call(struct lua_State *L)
+{
+	struct memtx_tx_memory_stats stats;
+	memtx_tx_memory_get_stats(memtx_tx_memory_get(), &stats);
+	for (size_t i = 0; i < TXN_ALLOC_MAX; ++i) {
+		set_memtx_mvcc_alloc_stat_item(L, TXN_ALLOC_TYPE_STRS[i],
+					       stats.total[i], stats.max[i],
+					       stats.avg[i]);
+	}
+	for (size_t i = MEMTX_TX_ALLOC_MIN + 1; i < MEMTX_TX_ALLOC_MAX; ++i) {
+		set_memtx_mvcc_alloc_stat_item(L, MEMTX_TX_ALLOC_TYPE_STRS[i],
+					       stats.total[i], stats.max[i],
+					       stats.avg[i]);
+	}
+
+	lua_pushstring(L, "TUPLE PINNED");
+	lua_newtable(L);
+	for (size_t i = 0; i < MEMTX_TX_PIN_MAX; ++i) {
+		lua_pushstring(L, MEMTX_TX_PIN_TYPE_STRS[i]);
+		lua_newtable(L);
+
+		lua_pushstring(L, "total");
+		lua_pushnumber(L, stats.pinned_tuples_total[i]);
+		lua_settable(L, -3);
+
+		lua_pushstring(L, "count");
+		lua_pushnumber(L, stats.pinned_tuples_count[i]);
+		lua_settable(L, -3);
+
+		lua_settable(L, -3);
+	}
+	lua_settable(L, -3);
+
+	lua_pushstring(L, "STORIES");
+	lua_newtable(L);
+	for (size_t i = 0; i < MEMTX_TX_PIN_MAX; ++i) {
+		lua_pushstring(L, MEMTX_TX_PIN_TYPE_STRS[i]);
+		lua_newtable(L);
+
+		lua_pushstring(L, "total");
+		lua_pushnumber(L, stats.stories_total[i]);
+		lua_settable(L, -3);
+
+		lua_settable(L, -3);
+	}
+	lua_settable(L, -3);
+
+	return 1;
+}
+
+static int
+lbox_stat_memtx_mvcc_index(struct lua_State *L) {
+	const char *key = luaL_checkstring(L, -1);
+	struct memtx_tx_memory_stats stats;
+	memtx_tx_memory_get_stats(memtx_tx_memory_get(), &stats);
+	lua_newtable(L);
+	for (size_t i = 0; i < TXN_ALLOC_MAX; ++i) {
+		if (strcmp(TXN_ALLOC_TYPE_STRS[i], key) == 0) {
+			set_memtx_mvcc_alloc_stat_item(L, key, stats.total[i],
+						       stats.max[i],
+						       stats.avg[i]);
+			return 1;
+		}
+	}
+	for (size_t i = MEMTX_TX_ALLOC_MIN + 1; i < MEMTX_TX_ALLOC_MAX; ++i) {
+		if (strcmp(MEMTX_TX_ALLOC_TYPE_STRS[i], key) == 0) {
+			set_memtx_mvcc_alloc_stat_item(L, key, stats.total[i],
+						       stats.max[i],
+						       stats.avg[i]);
+			return 1;
+		}
+	}
+	for (size_t i = MEMTX_TX_ALLOC_MIN + 1; i < MEMTX_TX_ALLOC_MAX; ++i) {
+		if (strcmp(MEMTX_TX_ALLOC_TYPE_STRS[i], key) == 0) {
+			set_memtx_mvcc_alloc_stat_item(L, key, stats.total[i],
+						       stats.max[i],
+						       stats.avg[i]);
+			return 1;
+		}
+	}
+
+	if (strcmp(key, "TUPLE PINNED") == 0) {
+		lua_pushstring(L, key);
+		lua_newtable(L);
+		for (size_t i = 0; i < MEMTX_TX_PIN_MAX; ++i) {
+			lua_pushstring(L, MEMTX_TX_PIN_TYPE_STRS[i]);
+			lua_newtable(L);
+
+			lua_pushstring(L, "total");
+			lua_pushnumber(L, stats.pinned_tuples_total[i]);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "count");
+			lua_pushnumber(L, stats.pinned_tuples_count[i]);
+			lua_settable(L, -3);
+
+			lua_settable(L, -3);
+		}
+		lua_settable(L, -3);
+		return 1;
+	}
+
+	if (strcmp(key, "STORIES") == 0) {
+		lua_pushstring(L, key);
+		lua_newtable(L);
+		for (size_t i = 0; i < MEMTX_TX_PIN_MAX; ++i) {
+			lua_pushstring(L, MEMTX_TX_PIN_TYPE_STRS[i]);
+			lua_newtable(L);
+
+			lua_pushstring(L, "total");
+			lua_pushnumber(L, stats.stories_total[i]);
+			lua_settable(L, -3);
+
+			lua_settable(L, -3);
+		}
+		lua_settable(L, -3);
+		return 1;
+	}
+	lua_pop(L, -1);
+	return 0;
+}
+
 static const struct luaL_Reg lbox_stat_meta [] = {
 	{"__index", lbox_stat_index},
 	{"__call",  lbox_stat_call},
@@ -294,6 +449,12 @@ static const struct luaL_Reg lbox_stat_net_meta [] = {
 static const struct luaL_Reg lbox_stat_net_thread_meta [] = {
 	{"__index", lbox_stat_net_thread_index},
 	{"__call",  lbox_stat_net_thread_call},
+	{NULL, NULL}
+};
+
+static const struct luaL_Reg lbox_stat_memtx_mvcc_meta[] = {
+	{"__index", lbox_stat_memtx_mvcc_index },
+	{"__call", lbox_stat_memtx_mvcc_call },
 	{NULL, NULL}
 };
 
@@ -332,5 +493,17 @@ box_lua_stat_init(struct lua_State *L)
 	luaL_register(L, NULL, lbox_stat_net_thread_meta);
 	lua_setmetatable(L, -2);
 	lua_pop(L, 1); /* stat net module */
+
+	static const struct luaL_Reg memtx_mvcc_statlib[] = {
+		{NULL, NULL}
+	};
+
+	luaL_register_module(L, "box.stat.memtx.mvcc", memtx_mvcc_statlib);
+
+	lua_newtable(L);
+	luaL_register(L, NULL, lbox_stat_memtx_mvcc_meta);
+	lua_setmetatable(L, -2);
+	lua_pop(L, 1); /* stat tx module */
+
 }
 

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -873,8 +873,13 @@ memtx_tx_story_gc_step()
 		return;
 	}
 
-	/* Lowest read view PSN */
-	int64_t lowest_rv_psm = txn_last_psn;
+	/*
+	 * Lowest read view PSN.
+	 * Default value is more than txn_last_psn because if it is not so
+	 * some stories (stories produced by last txn at least) will be marked as
+	 * potentially in read view even though there are no txns in read view.
+	 */
+	int64_t lowest_rv_psm = txn_last_psn + 1;
 	if (!rlist_empty(&txm.read_view_txs)) {
 		struct txn *txn =
 			rlist_first_entry(&txm.read_view_txs, struct txn,

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -864,7 +864,7 @@ memtx_tx_story_full_unlink(struct memtx_story *story)
  * Run one step of a crawler that traverses all stories and removes no more
  * used stories.
  */
-static void
+void
 memtx_tx_story_gc_step()
 {
 	if (txm.traverse_all_stories == &txm.all_stories) {

--- a/src/box/memtx_tx.h
+++ b/src/box/memtx_tx.h
@@ -485,6 +485,12 @@ memtx_tx_snapshot_clarify(struct memtx_tx_snapshot_cleaner *cleaner,
 void
 memtx_tx_snapshot_cleaner_destroy(struct memtx_tx_snapshot_cleaner *cleaner);
 
+/**
+ * Export step of garbage collector to builtin module
+ */
+API_EXPORT void
+memtx_tx_story_gc_step();
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/memtx_tx.h
+++ b/src/box/memtx_tx.h
@@ -151,6 +151,13 @@ struct memtx_story {
 	 * Number of indexes in this space - and the count of link[].
 	 */
 	uint32_t index_count;
+	/** Status of story for memory manager. */
+	int pin_status;
+	/**
+	 * Flag is set when @a tuple is not placed in primary key and
+	 * the story is the only reason why @a tuple cannot be deleted.
+	 */
+	bool is_pinned;
 	/**
 	 * Link with older and newer stories (and just tuples) for each
 	 * index respectively.
@@ -181,6 +188,14 @@ memtx_tx_manager_init();
  */
 void
 memtx_tx_manager_free();
+
+
+struct memtx_tx_memory_manager;
+/**
+ * Get memory manager of memtx transaction manager.
+ */
+struct memtx_tx_memory_manager *
+memtx_tx_memory_get();
 
 /**
  * Transaction providing DDL changes is disallowed to yield after

--- a/src/box/memtx_tx_memory.c
+++ b/src/box/memtx_tx_memory.c
@@ -1,0 +1,95 @@
+#include "memtx_tx_memory.h"
+
+const char *MEMTX_TX_ALLOC_TYPE_STRS[] = {
+	"",
+	"",
+	"",
+	"",
+	"",
+	"",
+	"",
+	"TRACKERS"
+};
+
+static_assert(lengthof(MEMTX_TX_ALLOC_TYPE_STRS) == MEMTX_TX_ALLOC_MAX,
+	      "MEMTX_TX_ALLOC_TYPE_STRS does not match MEMTX_TX_ALLOC_TYPE");
+
+const char *MEMTX_TX_PIN_TYPE_STRS[] = {
+	"USED BY ACTIVE TXNS",
+	"POTENTIALLY IN READ VIEW",
+	"USED TO TRACK GAP"
+};
+
+struct memtx_story *
+memtx_tx_memory_story_alloc(struct memtx_tx_memory_manager *stat, struct mempool *pool)
+{
+	assert(pool != NULL);
+
+	struct mempool_stats pool_stats;
+	mempool_stats(pool, &pool_stats);
+	struct memtx_story *new_story = mempool_alloc(pool);
+	if (new_story != NULL) {
+		stat->stories_total[MEMTX_TX_PIN_USED] += pool_stats.objsize;
+	}
+	return new_story;
+}
+
+void
+memtx_tx_memory_story_free(struct memtx_tx_memory_manager *stat,
+			 struct mempool *pool, struct memtx_story *story,
+			 enum MEMTX_TX_PIN_TYPE story_status)
+{
+	assert(pool != NULL);
+	assert(story != NULL);
+	assert(story_status < MEMTX_TX_PIN_MAX);
+
+	struct mempool_stats pool_stats;
+	mempool_stats(pool, &pool_stats);
+	assert(stat->stories_total[story_status] >= pool_stats.objsize);
+	stat->stories_total[story_status] -= pool_stats.objsize;
+	mempool_free(pool, story);
+}
+
+void
+memtx_tx_memory_get_stats(struct memtx_tx_memory_manager *stat_manager,
+			struct memtx_tx_memory_stats *stats_out)
+{
+	assert(stat_manager != NULL);
+	assert(stats_out != NULL);
+
+	for (size_t i = 0; i < MEMTX_TX_ALLOC_MAX; ++i) {
+		stats_out->total[i] = stat_manager->stats_storage[i].total;
+		if (stat_manager->txn_stats.txn_num > 0) {
+			stats_out->avg[i] = stat_manager->stats_storage[i].total /
+					    stat_manager->txn_stats.txn_num;
+		} else {
+			stats_out->avg[i] = 0;
+		}
+		stats_out->max[i] = histogram_max(
+			stat_manager->stats_storage[i].hist);
+	}
+	for (size_t i = 0; i < MEMTX_TX_PIN_MAX; ++i) {
+		stats_out->pinned_tuples_total[i] =
+			stat_manager->pinned_tuples_total[i];
+		stats_out->pinned_tuples_count[i] =
+			stat_manager->pinned_tuples_count[i];
+		stats_out->stories_total[i] = stat_manager->stories_total[i];
+	}
+}
+
+void
+memtx_tx_memory_init(struct memtx_tx_memory_manager *stat)
+{
+	memset(&stat->stats_storage, 0, sizeof(uint64_t) * MEMTX_TX_PIN_MAX);
+	memset(&stat->pinned_tuples_total, 0, sizeof(uint64_t) * MEMTX_TX_PIN_MAX);
+	memset(&stat->pinned_tuples_count, 0, sizeof(uint64_t) * MEMTX_TX_PIN_MAX);
+	memset(&stat->stories_total, 0, sizeof(uint64_t) * MEMTX_TX_PIN_MAX);
+	tx_memory_init(&stat->txn_stats, MEMTX_TX_ALLOC_MAX,
+		       stat->stats_storage);
+}
+
+void
+memtx_tx_memory_free(struct memtx_tx_memory_manager *stat)
+{
+	tx_memory_free(&stat->txn_stats);
+}

--- a/src/box/memtx_tx_memory.h
+++ b/src/box/memtx_tx_memory.h
@@ -1,0 +1,199 @@
+#pragma once
+
+#include <assert.h>
+#include <trivia/util.h>
+#include "tx_memory.h"
+struct memtx_story;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Allocations types for txns used only by memtx tx manager.
+ */
+enum MEMTX_TX_ALLOC_TYPE {
+	MEMTX_TX_ALLOC_MIN = 6,
+	MEMTX_TX_ALLOC_TRACKER = 7,
+	MEMTX_TX_ALLOC_MAX = 8
+};
+
+static_assert(MEMTX_TX_ALLOC_MIN == TXN_ALLOC_MAX - 1,
+	      "enum MEMTX_TX_ALLOC_TYPE is not consistent with TXN_ALLOC_TYPE");
+
+/**
+ * String appearance of enum MEMTX_TX_ALLOC_TYPE
+ */
+extern const char *MEMTX_TX_ALLOC_TYPE_STRS[];
+
+/**
+ * @brief Status of memtx_story and a tuple it references to.
+ */
+enum MEMTX_TX_PIN_TYPE {
+	MEMTX_TX_PIN_USED = 0,
+	MEMTX_TX_PIN_RV = 1,
+	MEMTX_TX_PIN_TRACK_GAP = 2,
+	MEMTX_TX_PIN_MAX = 3
+};
+
+/**
+ * String appearance of enum MEMTX_TX_PIN_TYPE
+ */
+extern const char *MEMTX_TX_PIN_TYPE_STRS[];
+
+/**
+ * @brief Stats that contains all the statistics collected by memory manager.
+ * Made for statistics getter.
+ */
+struct memtx_tx_memory_stats {
+	uint64_t total[MEMTX_TX_ALLOC_MAX];
+	uint64_t avg[MEMTX_TX_ALLOC_MAX];
+	uint64_t max[MEMTX_TX_ALLOC_MAX];
+	uint64_t min[MEMTX_TX_ALLOC_MAX];
+
+	uint64_t stories_total[MEMTX_TX_PIN_MAX];
+	uint64_t pinned_tuples_total[MEMTX_TX_PIN_MAX];
+	uint64_t pinned_tuples_count[MEMTX_TX_PIN_MAX];
+};
+
+/**
+ * @brief Memory manager of memtx tx manager.
+ */
+struct memtx_tx_memory_manager {
+	/** Base class of memory manager, */
+	struct tx_memory_manager txn_stats;
+	/** Statistics of memtx_stories and tuple they references to. */
+	uint64_t stories_total[MEMTX_TX_PIN_MAX];
+	uint64_t pinned_tuples_total[MEMTX_TX_PIN_MAX];
+	uint64_t pinned_tuples_count[MEMTX_TX_PIN_MAX];
+	/** Statistics storage. Passed to base class. */
+	struct txn_stat_storage stats_storage[MEMTX_TX_ALLOC_MAX];
+};
+
+/**
+ * @brief Allocate @a memtx_story object.
+ * @param stat Memtx memory manager.
+ * @param pool Mempool where story will be allocated.
+ * @return Pointer to allocated story.
+ * @note Allocate memtx_story only with this method to help memory manager
+ * track this allocation.
+ */
+struct memtx_story *
+memtx_tx_memory_story_alloc(struct memtx_tx_memory_manager *stat, struct mempool *pool);
+
+
+/**
+ * @brief Free @a memtx_story object.
+ * @param stat Memtx memory manager.
+ * @param pool Mempool where story will be deallocated.
+ * @param story Story to deallocate.
+ * @param story_status Status of story to track memory usage.
+ */
+void
+memtx_tx_memory_story_free(struct memtx_tx_memory_manager *stat,
+			 struct mempool *pool, struct memtx_story *story,
+			 enum MEMTX_TX_PIN_TYPE story_status);
+
+/**
+ * @brief Pin tuple (it means that tuple is not placed in any space but
+ * cannot be deleted because a story holds a reference).
+ * @param stat Memtx memory manager.
+ * @param status Status of story which pinned the tuple.
+ * @param tuple_size Size of tuple.
+ */
+static inline void
+memtx_tx_memory_tuple_pin(struct memtx_tx_memory_manager *stat,
+			enum MEMTX_TX_PIN_TYPE status, size_t tuple_size)
+{
+	assert(status >= 0 && status < MEMTX_TX_PIN_MAX);
+
+	stat->pinned_tuples_total[status] += tuple_size;
+	stat->pinned_tuples_count[status]++;
+}
+
+/**
+ * @brief Unpin tuple (it means that tuple is being placed in space).
+ * @param stat Memtx memory manager.
+ * @param status Status of story which pinned the tuple.
+ * @param tuple_size Size of tuple.
+ */
+static inline void
+memtx_tx_memory_tuple_unpin(struct memtx_tx_memory_manager *stat,
+			    enum MEMTX_TX_PIN_TYPE status, size_t tuple_size)
+{
+	assert(status >= 0 && status < MEMTX_TX_PIN_MAX);
+	assert(stat->pinned_tuples_count[status] > 0);
+
+	stat->pinned_tuples_total[status] -= tuple_size;
+	stat->pinned_tuples_count[status]--;
+}
+
+/**
+ * @brief Change status of story (helps to detect garbage stories).
+ * @param stat Memtx memory manager.
+ * @param old_status Old status of story.
+ * @param new_status New status of story.
+ * @param size Size of story.
+ */
+static inline void
+memtx_tx_memory_story_refresh_status(struct memtx_tx_memory_manager *stat,
+				   enum MEMTX_TX_PIN_TYPE old_status,
+				   enum MEMTX_TX_PIN_TYPE new_status,
+				   size_t size)
+{
+	assert(old_status >= 0 && old_status < MEMTX_TX_PIN_MAX);
+	assert(new_status >= 0 && new_status < MEMTX_TX_PIN_MAX);
+
+	stat->stories_total[old_status] -= size;
+	stat->stories_total[new_status] += size;
+}
+
+/**
+ * @brief Change status of tuple which is referenced by story that changed its status.
+ * @param stat Memtx memory manager.
+ * @param old_status Old status of story.
+ * @param new_status New status of story.
+ * @param size Size of tuple.
+ * @note Use this function only with pinned tuples!
+ */
+static inline void
+memtx_tx_memory_tuple_refresh_pin_status(struct memtx_tx_memory_manager *stat,
+					  enum MEMTX_TX_PIN_TYPE old_status,
+					  enum MEMTX_TX_PIN_TYPE new_status,
+					  size_t size)
+{
+	assert(old_status >= 0 && old_status < MEMTX_TX_PIN_MAX);
+	assert(new_status >= 0 && new_status < MEMTX_TX_PIN_MAX);
+
+	stat->pinned_tuples_total[old_status] -= size;
+	stat->pinned_tuples_count[old_status]--;
+	stat->pinned_tuples_total[new_status] += size;
+	stat->pinned_tuples_count[new_status]++;
+}
+
+/**
+ * @brief Get statistics collected by memory manager.
+ * @param stat_manager Memtx memory manager.
+ * @param out stats_out
+ */
+void
+memtx_tx_memory_get_stats(struct memtx_tx_memory_manager *stat_manager,
+			struct memtx_tx_memory_stats *stats_out);
+
+/**
+ * @brief Constructor of memtx memory manager.
+ * @param stat Memtx memory manager.
+ */
+void
+memtx_tx_memory_init(struct memtx_tx_memory_manager *stat);
+
+/**
+ * @brief Destructor of memtx memory manager.
+ * @param stat Memtx memory manager.
+ */
+void
+memtx_tx_memory_free(struct memtx_tx_memory_manager *stat);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/box/tx_memory.c
+++ b/src/box/tx_memory.c
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2010-2022, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <assert.h>
+#include <lib/core/say.h>
+#include "tx_memory.h"
+#include "small/mempool.h"
+#include "small/region.h"
+#include "histogram.h"
+#include "txn.h"
+
+const char *TXN_ALLOC_TYPE_STRS[] = {
+	"STATEMENTS",
+	"SAVEPOINTS",
+	"USER DATA",
+	"REDO LOGS",
+	"TRIGGERS",
+	"TIMERS",
+	"JOURNAL ENTRIES"
+};
+
+static_assert(lengthof(TXN_ALLOC_TYPE_STRS) == TXN_ALLOC_MAX,
+	      "TXN_ALLOC_TYPE_STRS does not match TXN_ALLOC_TYPE");
+
+/**
+ * @brief Add info about allocation to @a stat.
+ * @param stat Memory manager.
+ * @param txn Txn that requires an allocation.
+ * @param alloc_size Size of allocation.
+ * @param alloc_type Type of allocation.
+ * @param deallocate False on allocation, True on deallocation.
+ */
+static void
+tx_track_allocation(struct tx_memory_manager *stat, struct txn *txn,
+		    uint64_t alloc_size, size_t alloc_type, bool deallocate)
+{
+	assert(alloc_type < stat->alloc_max);
+	assert(txn != NULL);
+
+	histogram_discard(stat->stats_storage[alloc_type].hist,
+			  txn->mem_used->total[alloc_type]);
+	if (!deallocate) {
+		txn->mem_used->total[alloc_type] += alloc_size;
+		stat->stats_storage[alloc_type].total += alloc_size;
+	} else {
+		assert(txn->mem_used->total[alloc_type] >= alloc_size);
+		assert(stat->stats_storage[alloc_type].total >= alloc_size);
+		txn->mem_used->total[alloc_type] -= alloc_size;
+		stat->stats_storage[alloc_type].total -= alloc_size;
+	}
+	histogram_collect(stat->stats_storage[alloc_type].hist,
+			  txn->mem_used->total[alloc_type]);
+}
+
+int
+tx_memory_register_txn(struct tx_memory_manager *stat, struct txn *txn)
+{
+	assert(txn != NULL);
+	assert(txn->mem_used == NULL);
+	assert(txn->given_region_used == 0);
+
+	const size_t metadata_size = sizeof(struct txn_mem_used) +
+				     sizeof(uint64_t) * stat->alloc_max;
+	struct txn_mem_used *mem_used =
+		region_aligned_alloc(&txn->region, metadata_size,
+				     alignof(*(txn->mem_used)));
+	// TODO: errinj
+	if (mem_used == NULL) {
+		diag_set(OutOfMemory, metadata_size, "tx region",
+			 "tx memory metadata");
+		return -1;
+	}
+	memset(mem_used, 0, metadata_size);
+	txn->mem_used = mem_used;
+	/* Collect zero memory consumption initially. */
+	for (size_t i = 0; i < stat->alloc_max; ++i) {
+		assert(mem_used->total[i] == 0);
+		histogram_collect(stat->stats_storage[i].hist,0);
+	}
+	stat->txn_num++;
+	return 0;
+}
+
+void
+tx_memory_clear_txn(struct tx_memory_manager *stat, struct txn *txn)
+{
+	assert(txn != NULL);
+	assert(txn->mem_used != NULL);
+	assert(txn->given_region_used == 0);
+
+	/*
+	 * Check if txn does not owe any mempool allocation.
+	 * In this case all the tracked allocation are from region
+	 * and we will delete them via region_truncate.
+	 */
+	assert(txn->mem_used->mempool_total == 0);
+	for (size_t i = 0; i < stat->alloc_max; ++i) {
+		tx_track_allocation(stat, txn, txn->mem_used->total[i], i, true);
+	}
+	txn->mem_used = NULL;
+	region_truncate(&txn->region, sizeof(struct txn));
+	assert(stat->txn_num > 0);
+	stat->txn_num--;
+}
+
+void *
+tx_memory_mempool_alloc(struct tx_memory_manager *stat, struct txn *txn,
+			struct mempool* pool, size_t alloc_type)
+{
+	assert(pool != NULL);
+	assert(txn != NULL);
+	assert(alloc_type < stat->alloc_max);
+
+	void *allocation = mempool_alloc(pool);
+	if (allocation == NULL)
+		return NULL;
+	/* Track an allocation only if it succeeded. */
+	struct mempool_stats pool_stats;
+	mempool_stats(pool, &pool_stats);
+	tx_track_allocation(stat, txn, pool_stats.objsize, alloc_type, false);
+#ifndef NDEBUG
+	txn->mem_used->mempool_total += pool_stats.objsize;
+#endif
+	return allocation;
+}
+
+void
+tx_memory_mempool_free(struct tx_memory_manager *stat, struct txn *txn,
+		       struct mempool *pool, void *ptr, size_t alloc_type)
+{
+	assert(pool != NULL);
+	assert(txn != NULL);
+	assert(alloc_type < stat->alloc_max);
+
+	struct mempool_stats pool_stats;
+	mempool_stats(pool, &pool_stats);
+	tx_track_allocation(stat, txn, pool_stats.objsize,
+			    alloc_type, true);
+#ifndef NDEBUG
+	assert(txn->mem_used->mempool_total >= pool_stats.objsize);
+	txn->mem_used->mempool_total -= pool_stats.objsize;
+#endif
+	mempool_free(pool, ptr);
+}
+
+void *
+tx_memory_region_alloc(struct tx_memory_manager *stat, struct txn *txn,
+		       size_t size, size_t alloc_type)
+{
+	assert(txn != NULL);
+	assert(alloc_type < stat->alloc_max);
+	void *allocation = region_alloc(&txn->region, size);
+	if (allocation == NULL)
+		return NULL;
+	/* Track an allocation only if it succeeded. */
+	tx_track_allocation(stat, txn, size, alloc_type, false);
+	return allocation;
+}
+
+void *
+tx_memory_region_aligned_alloc(struct tx_memory_manager *stat, struct txn *txn,
+			size_t size, size_t alignment, size_t alloc_type)
+{
+	assert(txn != NULL);
+	assert(alloc_type < stat->alloc_max);
+	void *allocation = region_aligned_alloc(&txn->region, size, alignment);
+	if (allocation == NULL)
+		return NULL;
+	/* Track an allocation only if it succeeded. */
+	tx_track_allocation(stat, txn, size, alloc_type, false);
+	return allocation;
+}
+
+struct region *
+tx_memory_txn_region_give(struct txn *txn)
+{
+	assert(txn != NULL);
+	assert(txn->given_region_used == 0);
+
+	struct region *txn_region = &txn->region;
+	txn->given_region_used = region_used(txn_region);
+	return txn_region;
+}
+
+void
+tx_memory_txn_region_take(struct tx_memory_manager *stat, struct txn *txn,
+			  size_t alloc_type)
+{
+	assert(txn != NULL);
+	assert(txn->given_region_used != 0);
+
+	uint64_t new_alloc_size = region_used(&txn->region) - txn->given_region_used;
+	txn->given_region_used = 0;
+	if (new_alloc_size > 0) {
+		tx_track_allocation(stat, txn, new_alloc_size, alloc_type,
+				    false);
+	}
+}
+
+void
+tx_memory_init(struct tx_memory_manager *stat, size_t alloc_max,
+	     struct txn_stat_storage *stat_storage)
+{
+	assert(stat_storage != NULL);
+	assert(alloc_max >= TXN_ALLOC_MAX);
+
+	const int64_t KB = 1024;
+	const int64_t MB = 1024 * KB;
+	const int64_t GB = 1024 * MB;
+	int64_t buckets[] = {0, 128, 512, KB, 8 * KB, 32 * KB, 128 * KB, 512 * KB,
+			     MB, 8 * MB, 32 * MB, 128 * MB, 512 * MB, GB};
+	for (size_t i = 0; i < alloc_max; ++i) {
+		stat_storage[i].hist =
+			histogram_new(buckets, lengthof(buckets));
+		histogram_collect(stat_storage[i].hist, 0);
+	}
+	stat->alloc_max = alloc_max;
+	stat->stats_storage = stat_storage;
+	stat->txn_num = 0;
+}
+
+void
+tx_memory_free(struct tx_memory_manager *stat)
+{
+	for (size_t i = 0; i < stat->alloc_max; ++i) {
+		histogram_delete(stat->stats_storage[i].hist);
+	}
+}

--- a/src/box/tx_memory.h
+++ b/src/box/tx_memory.h
@@ -1,0 +1,211 @@
+#pragma once
+/*
+ * Copyright 2010-2022, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * This file contains declaration class @a tx_memory_manager that is common
+ * memory manager for every transaction manager and txns themselves.
+ * Txns and transaction managers must allocate memory using methods @a tx_stat
+ * only because it make possible to monitor memory usage,
+ * and that is why every transaction manager must have its own memory manager
+ * derived from this one.
+ * It is also important to say that one should not create an instance of
+ * @a tx_stat, create instance of derivated memory manager instead.
+ */
+
+#include <trivia/util.h>
+#include "small/mempool.h"
+#include "histogram.h"
+struct txn;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Allocations types for txns.
+ */
+enum TXN_ALLOC_TYPE {
+	TXN_ALLOC_STMT = 0,
+	TXN_ALLOC_SVP = 1,
+	TXN_ALLOC_USER_DATA = 2,
+	TXN_ALLOC_REDO_LOG = 3,
+	TXN_ALLOC_TRIGGER = 4,
+	TXN_ALLOC_TIMER = 5,
+	TXN_ALLOC_JOURNAL_ENTRY = 6,
+	TXN_ALLOC_MAX = 7
+};
+
+/**
+ * String appearance of enum TXN_ALLOC_TYPE
+ */
+extern const char *TXN_ALLOC_TYPE_STRS[];
+
+/**
+ * Storage for statistics of one allocation type for txn.
+ */
+struct txn_stat_storage {
+	struct histogram *hist;
+	uint64_t total;
+};
+
+/**
+ * Memory manager itself.
+ */
+struct tx_memory_manager {
+	/** Number of allocation types. */
+	uint32_t alloc_max;
+	/** Number of registered txn. */
+	uint64_t txn_num;
+	/**
+	 * Pointer to array of @txn_stat_storage objects.
+	 * It is better to allocate it as a field of derived memory manager.
+	 */
+	struct txn_stat_storage *stats_storage;
+};
+
+/**
+ * Memory usage of one txn. Allocated on its region.
+ */
+struct txn_mem_used {
+	/**
+	 * This field is used only in debug mode to make sure that txn has
+	 * deallocated all the mempool allocations before it was deleted.
+	 */
+	uint64_t mempool_total;
+	/** Total memory used for every type of allocations. */
+	uint64_t total[];
+};
+
+/**
+ * @brief A wrapper over region_alloc.
+ * @param txn Owner of a region.
+ * @param size Bytes to allocate.
+ * @param alloc_type See TXN_ALLOC_TYPE.
+ * @note The only way to truncate a region of @a txn is to clear @a txn.
+ */
+void *
+tx_memory_region_alloc(struct tx_memory_manager *stat, struct txn *txn,
+		       size_t size, size_t alloc_type);
+
+/**
+ * @brief Register @a txn in @a tx_stat. It is very important
+ * to register txn before using allocators from @a tx_stat.
+ */
+int
+tx_memory_register_txn(struct tx_memory_manager *stat, struct txn *txn);
+
+/**
+ * @brief Unregister @a txn and truncate its region up to sizeof(txn).
+ */
+void
+tx_memory_clear_txn(struct tx_memory_manager *stat, struct txn *txn);
+
+/**
+ * @brief A wrapper over region_aligned_alloc.
+ * @param txn Owner of a region.
+ * @param size Bytes to allocate.
+ * @param alignment Alignment of allocation.
+ * @param alloc_type Type of allocation.
+ */
+void *
+tx_memory_region_aligned_alloc(struct tx_memory_manager *stat, struct txn *txn,
+			size_t size, size_t alignment, size_t alloc_type);
+
+#define tx_memory_region_alloc_object(stat, txn, T, size, alloc_type) ({  \
+	*(size) = sizeof(T);                                              \
+	(T *)tx_memory_region_aligned_alloc((stat), (txn), sizeof(T),     \
+	                                    alignof(T), (alloc_type));    \
+})
+
+/**
+ * @brief Getter for txn's region. Use only if region was not given before.
+ * @param txn Owner of region.
+ * @return Pointer to region of txn.
+ * @note Do not use txn's region directly, use this method instead.
+ */
+struct region *
+tx_memory_txn_region_give(struct txn *txn);
+
+/**
+ * @brief Notify @a stat that you finished using given @a txn to allow it
+ * collect allocations statistics.
+ * @param stat Memory manager.
+ * @param txn Owner of region.
+ * @param alloc_type Type of all the allocations via given region.
+ */
+void
+tx_memory_txn_region_take(struct tx_memory_manager *stat, struct txn *txn,
+			  size_t alloc_type);
+
+/**
+ * @brief A wrapper over mempool_alloc.
+ * @param txn Txn that requires an allocation.
+ * @param pool Mempool to allocate from.
+ * @param alloc_type Type of allocation.
+ */
+void *
+tx_memory_mempool_alloc(struct tx_memory_manager *stat, struct txn *txn,
+		 struct mempool *pool, size_t alloc_type);
+
+/**
+ * @brief A wrapper over mempool_free.
+ * @param txn Txn that requires a deallocation.
+ * @param pool Mempool to deallocate from.
+ * @param ptr Pointer to free.
+ * @param alloc_type Type of allocation.
+ */
+void
+tx_memory_mempool_free(struct tx_memory_manager *stat, struct txn *txn,
+		struct mempool *pool, void *ptr, size_t alloc_type);
+
+/**
+ * @brief Constructor of @a tx_stat.
+ * @param stat Pointer to an instance of @a tx_stat.
+ * @param alloc_max Number of allocation types.
+ * @param stat_storage Externally allocated storage of statistics.
+ * @note Should be called only from constructor of derived memory manager.
+ */
+void
+tx_memory_init(struct tx_memory_manager *stat, size_t alloc_max,
+	     struct txn_stat_storage *stat_storage);
+
+/**
+ * @brief Destructor of @a tx_stat.
+ * @param stat Pointer to an instance of @a tx_stat.
+ * @note Should be called only from destructor of derived memory manager.
+ */
+void
+tx_memory_free(struct tx_memory_manager *stat);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -126,11 +126,11 @@ txn_add_redo(struct txn *txn, struct txn_stmt *stmt, struct request *request)
 
 /** Initialize a new stmt object within txn. */
 static struct txn_stmt *
-txn_stmt_new(struct region *region)
+txn_stmt_new(struct txn *txn)
 {
 	int size;
 	struct txn_stmt *stmt;
-	stmt = region_alloc_object(region, struct txn_stmt, &size);
+	stmt = region_alloc_object(&txn->region, struct txn_stmt, &size);
 	if (stmt == NULL) {
 		diag_set(OutOfMemory, size, "region_alloc_object", "stmt");
 		return NULL;
@@ -407,7 +407,7 @@ txn_begin_stmt(struct txn *txn, struct space *space, uint16_t type)
 	if (txn_check_can_continue(txn) != 0)
 		return -1;
 
-	struct txn_stmt *stmt = txn_stmt_new(&txn->region);
+	struct txn_stmt *stmt = txn_stmt_new(txn);
 	if (stmt == NULL)
 		return -1;
 

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -39,6 +39,7 @@
 #include "errinj.h"
 #include "iproto_constants.h"
 #include "box.h"
+#include "tx_memory.h"
 
 double too_long_threshold;
 
@@ -258,6 +259,8 @@ txn_new(void)
 	rlist_create(&txn->conflicted_by_list);
 	rlist_create(&txn->in_read_view_txs);
 	rlist_create(&txn->in_all_txs);
+	txn->mem_used = NULL;
+	txn->given_region_used = 0;
 	return txn;
 }
 

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -345,6 +345,10 @@ struct txn {
 	 */
 	struct region region;
 	/**
+	 * Used memory of region before it was given, 0 if was not.
+	 */
+	uint64_t given_region_used;
+	/**
 	 * A sequentially growing transaction id, assigned when
 	 * a transaction is initiated. Used to identify
 	 * a transaction after it has possibly been destroyed.
@@ -393,6 +397,11 @@ struct txn {
 	struct engine *engine;
 	/** Engine-specific transaction data */
 	void *engine_tx;
+	/**
+	 * Information about txn's allocations for memory manager.
+	 * Allocated on region of txn.
+	 */
+	struct txn_mem_used *mem_used;
 	/* A fiber to wake up when transaction is finished. */
 	struct fiber *fiber;
 	/** Timestampt of entry write start. */

--- a/src/histogram.c
+++ b/src/histogram.c
@@ -158,6 +158,18 @@ histogram_percentile_lower(struct histogram *hist, int pct)
 	return hist->max;
 }
 
+int64_t
+histogram_max(struct histogram *hist)
+{
+	for (int64_t i = hist->n_buckets - 1; i >= 0; i--) {
+		struct histogram_bucket *bucket = &hist->buckets[i];
+		if (bucket->count > 0)
+			return bucket->max;
+	}
+	struct histogram_bucket *first_bucket = hist->buckets;
+	return first_bucket->max;
+}
+
 int
 histogram_snprint(char *buf, int size, struct histogram *hist)
 {

--- a/src/histogram.h
+++ b/src/histogram.h
@@ -97,6 +97,12 @@ int64_t
 histogram_percentile_lower(struct histogram *hist, int pct);
 
 /**
+ * Return upper bound of bucket containing maximal observed value.
+ */
+int64_t
+histogram_max(struct histogram *hist);
+
+/**
  * Print string representation of a histogram.
  */
 int

--- a/test/box-luatest/lua/txn_proxy.lua
+++ b/test/box-luatest/lua/txn_proxy.lua
@@ -1,0 +1,54 @@
+-- A fiber can't use multiple transactions simultaneously;
+-- i.e. [fiber] --? [transaction] in UML parlor.
+--
+-- This module provides a simple transaction proxy facility
+-- to control multiple transactions at once. A proxy executes
+-- statements in a worker fiber in order to overcome
+-- "one transaction per fiber" limitation.
+--
+-- Ex:
+-- proxy = require('txn_proxy').new()
+-- proxy:begin()
+-- proxy('box.space.test:replace{1, 42}')
+-- proxy:commit() -- or proxy:rollback()
+
+local ffi = require('ffi')
+local yaml = require('yaml')
+local fiber = require('fiber')
+local console = require('console')
+
+local array_mt = { __serialize = 'array' }
+
+local mt = {
+    __call = function(self, code_str)
+        self.c1:put(code_str)
+        local res = yaml.decode(self.c2:get())
+        return type(res) == 'table' and setmetatable(res, array_mt) or res
+    end,
+    __index = {
+        begin    = function(self) return self('box.begin()') end,
+        commit   = function(self) return self('box.commit()') end,
+        rollback = function(self) return self('box.rollback()') end,
+        close    = function(self) self.c1:close(); self.c2:close() end
+    }
+}
+
+local function fiber_main(c1, c2)
+    local code_str = c1:get()
+    if code_str then
+        c2:put(console.eval(code_str))
+        return fiber_main(c1, c2) -- tail call
+    end
+end
+
+local function new_txn_proxy()
+    local c1, c2 = fiber.channel(), fiber.channel()
+    local function on_gc() c1:close(); c2:close() end
+    fiber.create(fiber_main, c1, c2)
+    return setmetatable({
+        c1 = c1, c2 = c2,
+        __gc = ffi.gc(ffi.new('char[1]'), on_gc)
+    }, mt)
+end
+
+return { new = new_txn_proxy }

--- a/test/box-luatest/memtx_tx_memory_monitoring_test.lua
+++ b/test/box-luatest/memtx_tx_memory_monitoring_test.lua
@@ -1,0 +1,183 @@
+local t = require('luatest')
+local Cluster =  require('test.luatest_helpers.cluster')
+
+local pg = t.group('txm')
+
+local current_stat = {}
+
+local function table_apply_change(table, related_changes)
+    for k, v in pairs(related_changes) do
+        if type(v) ~= 'table' then
+            table[k] = table[k] + v
+        else
+            table_apply_change(table[k], v)
+        end
+    end
+end
+
+local function table_values_are_zeros(table)
+    for _, v in pairs(table) do
+        if type(v) ~= 'table' then
+            if v ~= 0 then
+                return false
+            end
+        else
+            if table_values_are_zeros(v) == false then
+                return false
+            end
+        end
+    end
+    return true
+end
+
+local function tx_gc(server, steps, related_changes)
+    server:eval('box.internal.memtx_tx_gc(' .. steps .. ')')
+    if related_changes then
+        table_apply_change(current_stat, related_changes)
+    end
+    assert(table.equals(current_stat, server:eval('return box.stat.memtx.mvcc()')))
+end
+
+local function tx_step(server, txn_name, op, related_changes)
+    server:eval(txn_name ..  '("' .. op .. '")')
+    if related_changes then
+        table_apply_change(current_stat, related_changes)
+    end
+    assert(table.equals(current_stat, server:eval('return box.stat.memtx.mvcc()')))
+end
+
+pg.before_each(function(cg)
+    cg.cluster = Cluster:new({})
+    local box_cfg = {
+        memtx_use_mvcc_engine = true
+    }
+    cg.txm_server = cg.cluster:build_server({alias = 'txm_server', box_cfg = box_cfg})
+    cg.cluster:add_server(cg.txm_server)
+    cg.cluster:start()
+
+    cg.txm_server:eval('txn_proxy = require("test.box-luatest.lua.txn_proxy")')
+    cg.txm_server:eval('s = box.schema.space.create("test")')
+    cg.txm_server:eval('s:create_index("pk")')
+    cg.txm_server:eval('box.internal.memtx_tx_gc(100)')
+    -- CREATING CURRENT STAT
+    current_stat = cg.txm_server:eval('return box.stat.memtx.mvcc()')
+    -- Check if txm use no memory
+    assert(table_values_are_zeros(current_stat))
+end)
+
+pg.after_each(function(cg)
+    -- Check if there is no memory occupied by txm
+    assert(table_values_are_zeros(current_stat))
+    cg.cluster.servers = nil
+    cg.cluster:drop()
+end)
+
+pg.test_txm_mem = function(cg)
+    cg.txm_server:eval('tx1 = txn_proxy.new()')
+    cg.txm_server:eval('tx2 = txn_proxy.new()')
+    cg.txm_server:eval('tx1:begin()')
+    cg.txm_server:eval('tx2:begin()')
+    local diff = {
+        ["STATEMENTS"] = {
+            ["avg"] = 60,
+            ["total"] = 120,
+            ["max"] = 128
+        },
+        ["STORIES"] = {
+            ["USED BY ACTIVE TXNS"] = {
+                ["total"] = 152
+            }
+        },
+        ["REDO LOGS"] = {
+            ["total"] = 147,
+            ["max"] = 512,
+            ["avg"] = 73
+        }
+    }
+    tx_step(cg.txm_server, 'tx1', "s:replace{1, 1}", diff)
+    diff = {
+        ["STATEMENTS"] = {
+            ["total"] = 120,
+            ["avg"] = 60
+        },
+        ["STORIES"] = {
+            ["USED BY ACTIVE TXNS"] = {
+                ["total"] = 152
+            }
+        },
+        ["TUPLE PINNED"] = {
+            ["USED BY ACTIVE TXNS"] = {
+                ["total"] = 9,
+                ["count"] = 1
+            }
+        },
+        ["REDO LOGS"] = {
+            ["total"] = 147,
+            ["avg"] = 74
+        }
+    }
+    tx_step(cg.txm_server, 'tx2', "s:replace{1, 2}", diff)
+    diff = {
+        ["STATEMENTS"] = {
+            ["total"] = 120,
+            ["avg"] = 60,
+            ["max"] = 512 - 128
+        },
+        ["STORIES"] = {
+            ["USED BY ACTIVE TXNS"] = {
+                ["total"] = 152
+            }
+        },
+        ["REDO LOGS"] = {
+            ["total"] = 147,
+            ["avg"] = 73
+        }
+    }
+    tx_step(cg.txm_server, 'tx2', "s:replace{2, 2}", diff)
+    tx_gc(cg.txm_server, 100, nil)
+    local err = cg.txm_server:eval('return tx2:commit()')
+    assert(not err[1])
+    diff = {
+        ["STATEMENTS"] = {
+            ["total"] = -120 * 2,
+            ["avg"] = -60,
+            ["max"] = 128 - 512
+        },
+        ["STORIES"] = {
+            ["USED BY ACTIVE TXNS"] = {
+                ["total"] = -152
+            }
+        },
+        ["REDO LOGS"] = {
+            ["total"] = -147 * 2,
+            ["avg"] = -73
+        }
+    }
+    tx_gc(cg.txm_server, 10, diff)
+    err = cg.txm_server:eval('return tx1:commit()')
+    assert(not err[1])
+    diff = {
+        ["STATEMENTS"] = {
+            ["total"] = -120,
+            ["avg"] = -120,
+            ["max"] = -128
+        },
+        ["STORIES"] = {
+            ["USED BY ACTIVE TXNS"] = {
+                ["total"] = -152 * 2
+            }
+        },
+        ["REDO LOGS"] = {
+            ["total"] = -147,
+            ["avg"] = -147,
+            ["max"] = -512
+        },
+        ["TUPLE PINNED"] = {
+            ["USED BY ACTIVE TXNS"] = {
+                ["total"] = -9,
+                ["count"] = -1
+            }
+        }
+    }
+    tx_gc(cg.txm_server, 100, diff)
+end

--- a/test/box/tx_man.result
+++ b/test/box/tx_man.result
@@ -3819,6 +3819,147 @@ tx1:commit()
  | - 
  | ...
 
+-- https://github.com/tarantool/tarantool/issues/6635
+
+s = box.schema.create_space('test')
+ | ---
+ | ...
+_ = s:create_index('pk')
+ | ---
+ | ...
+
+-- Collect garbage before replacing tuples
+box.internal.memtx_tx_gc(100)
+ | ---
+ | ...
+collectgarbage('collect')
+ | ---
+ | - 0
+ | ...
+
+default_log_lvl = box.cfg.log_level
+ | ---
+ | ...
+box.cfg{log_level = 7}
+ | ---
+ | ...
+_ = s:replace{0, 0, 0, 0, 0, 0, 0}
+ | ---
+ | ...
+box.cfg{log_level = default_log_lvl}
+ | ---
+ | ...
+
+-- Remember address of inserted tuple to check if it will be deleted.
+str = test_run:grep_log('tx_man', 'tuple_new%(%d+%) = 0x%x+$')
+ | ---
+ | ...
+new_tuple_address = string.match(str, '0x%x+$')
+ | ---
+ | ...
+new_tuple_address = string.sub(new_tuple_address, 3)
+ | ---
+ | ...
+
+_ = s:replace{0, 1}
+ | ---
+ | ...
+
+box.cfg{log_level = 7}
+ | ---
+ | ...
+box.internal.memtx_tx_gc(10)
+ | ---
+ | ...
+collectgarbage('collect')
+ | ---
+ | - 0
+ | ...
+box.cfg{log_level = default_log_lvl}
+ | ---
+ | ...
+
+-- Check if last deleted tuple is the tuple which was inserted above.
+str = test_run:grep_log('tx_man', 'tuple_delete%(0x%x+%)')
+ | ---
+ | ...
+deleted_tuple_address = string.match(str, '0x%x+%)')
+ | ---
+ | ...
+deleted_tuple_address = string.sub(deleted_tuple_address, 3, -2)
+ | ---
+ | ...
+assert(new_tuple_address == deleted_tuple_address)
+ | ---
+ | - true
+ | ...
+
+s:drop()
+ | ---
+ | ...
+
+-- Better test coverage for garbage collector of memtx mvcc engine.
+
+s = box.schema.space.create('test')
+ | ---
+ | ...
+_ = s:create_index('pk')
+ | ---
+ | ...
+
+for i = 1, 100 do   \
+    s:replace{i, 0} \
+end
+ | ---
+ | ...
+
+tx1:begin()
+ | ---
+ | - 
+ | ...
+tx1('s:select{1}[1]')
+ | ---
+ | - - [1, 0]
+ | ...
+tx2:begin()
+ | ---
+ | - 
+ | ...
+tx2('s:replace{1, 1}')
+ | ---
+ | - - [1, 1]
+ | ...
+for i = 2, 100 do                \
+    tx2('s:delete(' .. i .. ')') \
+end
+ | ---
+ | ...
+tx2:commit()
+ | ---
+ | - 
+ | ...
+box.internal.memtx_tx_gc(1000)
+ | ---
+ | ...
+collectgarbage('collect')
+ | ---
+ | - 0
+ | ...
+
+-- tx1 has read tuple {1, 0}, and then tx2 replaced it
+-- so tx1 must fall into read-view and all {i, 0} tuples
+-- must not be deleted.
+for i = 2, 100 do                               \
+    local res = tx1('s:get{' .. i .. '}')       \
+    assert(res[1] ~= nil)                       \
+end
+ | ---
+ | ...
+tx1:commit()
+ | ---
+ | - 
+ | ...
+
 test_run:cmd("switch default")
  | ---
  | - true

--- a/test/unit/histogram.c
+++ b/test/unit/histogram.c
@@ -168,6 +168,43 @@ test_percentile(void)
 	footer();
 }
 
+static void
+test_max(void)
+{
+	header();
+
+	size_t n_buckets;
+	int64_t *buckets = gen_buckets(&n_buckets);
+
+	size_t data_len;
+	int64_t *data = gen_rand_data(&data_len);
+
+	struct histogram *hist = histogram_new(buckets, n_buckets);
+
+	int64_t max = buckets[0];
+	int64_t max_bucket = buckets[n_buckets - 1];
+	for (size_t i = 0; i < data_len; i++) {
+		int64_t val = data[i];
+		histogram_collect(hist, val);
+		if (max < val && val <= max_bucket) {
+			for (size_t b = 0; b < n_buckets; b++) {
+				if (buckets[b] >= val) {
+					max = buckets[b];
+					break;
+				}
+			}
+		}
+		int64_t hist_max = histogram_max(hist);
+		fail_if(hist_max != max);
+	}
+
+	histogram_delete(hist);
+	free(data);
+	free(buckets);
+
+	footer();
+}
+
 int
 main()
 {
@@ -175,4 +212,5 @@ main()
 	test_counts();
 	test_discard();
 	test_percentile();
+	test_max();
 }

--- a/test/unit/histogram.result
+++ b/test/unit/histogram.result
@@ -4,3 +4,5 @@
 	*** test_discard: done ***
 	*** test_percentile ***
 	*** test_percentile: done ***
+	*** test_max ***
+	*** test_max: done ***


### PR DESCRIPTION
Memtx MVCC engine uses additional memory so many opened transactions can be bring tarantool to OOM. 
That is why we need opportunity to monitor memory consumption of memtx MVCC.
This patchset add this opportunity and fix bugs that were on way to this feature.

Statistics of memtx MVCC memory consumption is placed at `box.stat.memtx.mvcc()`.
Statistics has total/max/avg metrics for allocations assigned to a particular transaction ,
total metric for other types of allocations and total/count metrics for tuples in read-view.

Closes #6150
Closes #6635