### PR TITLE
ci: enable CentOS 7 on aarch64

### DIFF
--- a/.github/workflows/centos_7_aarch64.yml
+++ b/.github/workflows/centos_7_aarch64.yml
@@ -37,9 +37,8 @@ concurrency:
 jobs:
   centos_7_aarch64:
     # Run on pull request only if the 'full-ci' label is set.
-    # FIXME: Testing and deploy for aarch64 is disabled temporarily.
-    if: 0 && ( github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    if: github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: graviton
 


### PR DESCRIPTION
This commit actually reverts 2.10.0-beta1-136-gaa2a6bc83 ('ci:
temporarily disable deploy for CentOS 7 for aarch64').

I built packages necessary for testing for CentOS 7 on aarch64 and
placed them into packpack backports [1].

The source packages are from CentOS 8 [2] and are the following:

* Cython-0.29.14-4.module_el8.3.0+441+3b561464.src.rpm
* python-gevent-1.2.2-4.el8.src.rpm
* PyYAML-5.3.1-1.module_el8.3.0+441+3b561464.src.rpm
* python-six-1.12.0-9.module_el8.3.0+441+3b561464.src.rpm

[1]: https://packagecloud.io/packpack/backports
[2]: https://vault.centos.org/8.3.2011/AppStream/Source/SPackages/

If you're curious about steps to re-build the packages for CentOS 7,
read below.

----

Build steps are the following:

```sh
$ ssh <aarch64 machine>
$ docker run -it -v <...>:/src -v <...>:/res centos:7
```

Install tools:

```sh
$ yum install yum-utils rpm-build
```

(Here I also installed epel-release, but I doubt that it is necessary.)

Build and install Cython:

```sh
$ rpmbuild --rebuild /src/Cpython*.src.rpm
$ vim /root/rpmbuild/SPECS/Cython.spec
<..fix changelog dates..>
$ rpmbuild -bb /root/rpmbuild/SPECS/Cython.spec
<...>
error: Failed build dependencies:
  gcc is needed by Cython-0.29.14-4.el7.aarch64
  python3-devel is needed by Cython-0.29.14-4.el7.aarch64
  python3-setuptools is needed by Cython-0.29.14-4.el7.aarch64
  python3-rpm-macros is needed by Cython-0.29.14-4.el7.aarch64
$ yum install gcc python3-devel python3-rpm-macros python3-setuptools
$ rpmbuild -bb /root/rpmbuild/SPECS/Cython.spec # repeat, yep
$ ls -1 /root/rpmbuild/RPMS/aarch64/
Cython-debuginfo-0.29.14-4.el7.aarch64.rpm
python3-Cython-0.29.14-4.el7.aarch64.rpm
$ cp /root/rpmbuild/RPMS/aarch64/* /res/
$ rpm -i /root/rpmbuild/RPMS/aarch64/*
```

Build python-gevent:

```sh
$ rpmbuild --rebuild /src/python-gevent*.src.rpm
<...>
error: Failed build dependencies:
  c-ares-devel is needed by python-gevent-1.2.2-4.el7.aarch64
  libev-devel is needed by python-gevent-1.2.2-4.el7.aarch64
  python2-devel is needed by python-gevent-1.2.2-4.el7.aarch64
$ yum install c-ares-devel libev-devel # but not python2-devel
$ vim /root/rpmbuild/SPECS/python-gevent.spec
<..leave '%bcond_with python2'..>
$ rpmbuild -bb /root/rpmbuild/SPECS/python-gevent.spec
$ ls -1 /root/rpmbuild/RPMS/aarch64/*gevent*
/root/rpmbuild/RPMS/aarch64/python-gevent-debuginfo-1.2.2-4.el7.aarch64.rpm
/root/rpmbuild/RPMS/aarch64/python3-gevent-1.2.2-4.el7.aarch64.rpm
$ cp /root/rpmbuild/RPMS/aarch64/*gevent* /res/
```

Build PyYAML:

```sh
$ rpmbuild --rebuild /src/PyYAML*.src.rpm
<...>
error: Failed build dependencies:
    libyaml-devel is needed by PyYAML-5.3.1-1.el7.aarch64
$ yum install libyaml-devel
$ rpmbuild --rebuild /src/PyYAML*.src.rpm # again, yep
$ ls -1 /root/rpmbuild/RPMS/aarch64/*{pyyaml,PyYAML}*
/root/rpmbuild/RPMS/aarch64/PyYAML-debuginfo-5.3.1-1.el7.aarch64.rpm
/root/rpmbuild/RPMS/aarch64/python3-pyyaml-5.3.1-1.el7.aarch64.rpm
$ cp /root/rpmbuild/RPMS/aarch64/*{pyyaml,PyYAML}* /res/
```

Build python-six:

```sh
$ rpmbuild --rebuild /src/python-six*.src.rpm
error: Failed build dependencies:
    python3-wheel is needed by python-six-1.12.0-9.el7.noarch
    python3-pytest is needed by python-six-1.12.0-9.el7.noarch
    python3-tkinter is needed by python-six-1.12.0-9.el7.noarch
$ yum install python3-wheel python3-pytest python3-tkinter
$ rpmbuild --rebuild /src/python-six*.src.rpm # again, yep
error: Failed build dependencies:
    python3-pytest is needed by python-six-1.12.0-9.el7.noarch
$ vim /root/rpmbuild/SPECS/python-six.spec
<..change '%bcond_without tests' to '%bcond_with tests'..>
$ rpmbuild -bb /root/rpmbuild/SPECS/python-six.spec
$ ls -1 /root/rpmbuild/RPMS/noarch/
python3-six-1.12.0-9.el7.noarch.rpm
$ cp /root/rpmbuild/RPMS/noarch/* /res/
```