### PR TITLE
net.box: fix IO error messages - alternative approach

### DIFF
--- a/src/lib/core/exception.h
+++ b/src/lib/core/exception.h
@@ -87,8 +87,6 @@ class SystemError: public Exception {
 public:
 	virtual void raise() { throw this; }
 
-	virtual void log() const;
-
 	SystemError(const char *file, unsigned line,
 		    const char *format, ...);
 

--- a/src/lib/core/say.c
+++ b/src/lib/core/say.c
@@ -483,7 +483,7 @@ syslog_connect_unix(const char *path)
 {
 	int fd = socket(PF_UNIX, SOCK_DGRAM, 0);
 	if (fd < 0) {
-		diag_set(SystemError, strerror(errno));
+		diag_set(SystemError, "socket");
 		return -1;
 	}
 	struct sockaddr_un un;
@@ -491,7 +491,7 @@ syslog_connect_unix(const char *path)
 	snprintf(un.sun_path, sizeof(un.sun_path), "%s", path);
 	un.sun_family = AF_UNIX;
 	if (connect(fd, (struct sockaddr *) &un, sizeof(un)) != 0) {
-		diag_set(SystemError, strerror(errno));
+		diag_set(SystemError, "connect");
 		close(fd);
 		return -1;
 	}
@@ -621,7 +621,7 @@ log_syslog_init(struct log *log, const char *init_str)
 	if (log->fd < 0) {
 		diag_log();
 		/* syslog indent is freed in atexit(). */
-		diag_set(SystemError, "syslog logger: %s", strerror(errno));
+		diag_set(SystemError, "syslog logger");
 		return -1;
 	}
 	return 0;

--- a/src/lua/fio.c
+++ b/src/lua/fio.c
@@ -48,7 +48,7 @@
 #include "coio_file.h"
 
 #define lbox_fio_pushsyserror(L) ({				\
-	diag_set(SystemError, "fio: %s", strerror(errno));	\
+	diag_set(SystemError, "fio");				\
 	luaT_push_nil_and_error(L);				\
 })
 
@@ -118,7 +118,7 @@ lbox_fio_pushbool(struct lua_State *L, bool res)
 {
 	lua_pushboolean(L, res);
 	if (!res) {
-		diag_set(SystemError, "fio: %s", strerror(errno));
+		diag_set(SystemError, "fio");
 		struct error *e = diag_last_error(diag_get());
 		assert(e != NULL);
 		luaT_pusherror(L, e);

--- a/test/app/on_shutdown.result
+++ b/test/app/on_shutdown.result
@@ -121,7 +121,7 @@ os.execute(string.format("grep -r \"join module fiber\" on_shutdown.log"))
  | ---
  | - 0
  | ...
-os.execute(string.format("grep -r \"SystemError timed out\" on_shutdown.log"))
+os.execute(string.format("grep -r \"TimedOut: timed out\" on_shutdown.log"))
  | ---
  | - 0
  | ...

--- a/test/app/on_shutdown.test.lua
+++ b/test/app/on_shutdown.test.lua
@@ -43,7 +43,7 @@ test_run:cmd('stop server test')
 os.execute(string.format("rm %s", on_shutdownlib))
 os.execute(string.format("grep -r \"stop module fiber\" on_shutdown.log"))
 os.execute(string.format("grep -r \"join module fiber\" on_shutdown.log"))
-os.execute(string.format("grep -r \"SystemError timed out\" on_shutdown.log"))
+os.execute(string.format("grep -r \"TimedOut: timed out\" on_shutdown.log"))
 
 test_run:cmd('cleanup server test')
 test_run:cmd('delete server test')

--- a/test/box/cfg.result
+++ b/test/box/cfg.result
@@ -574,7 +574,7 @@ _ = box.schema.space.create('test_vinyl', {engine = 'vinyl'})
  | ...
 _ = box.space.test_vinyl:create_index('pk') -- error
  | ---
- | - error: can not access vinyl data directory
+ | - error: 'can not access vinyl data directory: No such file or directory'
  | ...
 box.snapshot()
  | ---

--- a/test/box/func_reload.result
+++ b/test/box/func_reload.result
@@ -249,9 +249,9 @@ os.setenv("TMPDIR", "/dev/null")
 _, err = pcall(box.schema.func.reload, "reload")
 ---
 ...
-tostring(err):gsub(': [/%w]+$', '')
+tostring(err):gsub(': [/%w]+:', ':')
 ---
-- failed to create unique dir name
+- 'failed to create unique dir name: Not a directory'
 - 1
 ...
 os.setenv("TMPDIR", nil)

--- a/test/box/func_reload.test.lua
+++ b/test/box/func_reload.test.lua
@@ -86,7 +86,7 @@ box.schema.func.reload("non-existing")
 -- path for DSO copy
 os.setenv("TMPDIR", "/dev/null")
 _, err = pcall(box.schema.func.reload, "reload")
-tostring(err):gsub(': [/%w]+$', '')
+tostring(err):gsub(': [/%w]+:', ':')
 os.setenv("TMPDIR", nil)
 
 box.schema.func.drop("reload.test_reload")

--- a/test/box/gh-6092-invalid-listen-uri.result
+++ b/test/box/gh-6092-invalid-listen-uri.result
@@ -18,9 +18,16 @@ bad_uri = "baduribaduri:1"
 old_listen = box.cfg.listen
 ---
 ...
-box.cfg({ listen = bad_uri })
+success, err = pcall(box.cfg, {listen = bad_uri})
 ---
-- error: can't resolve uri for bind, called on fd -1
+...
+assert(not success)
+---
+- true
+...
+assert(err.message:match("can't resolve uri for bind") ~= nil)
+---
+- true
 ...
 conn = netbox.connect(old_listen)
 ---

--- a/test/box/gh-6092-invalid-listen-uri.test.lua
+++ b/test/box/gh-6092-invalid-listen-uri.test.lua
@@ -7,7 +7,9 @@ errinj = box.error.injection
 -- does not make tarantool blind.
 bad_uri = "baduribaduri:1"
 old_listen = box.cfg.listen
-box.cfg({ listen = bad_uri })
+success, err = pcall(box.cfg, {listen = bad_uri})
+assert(not success)
+assert(err.message:match("can't resolve uri for bind") ~= nil)
 conn = netbox.connect(old_listen)
 assert(conn:ping())
 assert(fio.path.exists(old_listen))

--- a/test/unit/fiber.result
+++ b/test/unit/fiber.result
@@ -1,5 +1,5 @@
 #gh-1238: log uncaught errors
-SystemError Failed to allocate 42 bytes in allocator for exception: Cannot allocate memory
+OutOfMemory: Failed to allocate 42 bytes in allocator for exception
 	*** fiber_name_test ***
 # name of a new fiber: main.
 

--- a/test/unit/fiber_stack.result
+++ b/test/unit/fiber_stack.result
@@ -1,4 +1,4 @@
-SystemError fiber mprotect failed: Cannot allocate memory
+SystemError: fiber mprotect failed: Cannot allocate memory
 	*** main_f ***
 1..6
 ok 1 - mprotect: failed to setup fiber guard page

--- a/test/vinyl/errinj.result
+++ b/test/vinyl/errinj.result
@@ -604,7 +604,7 @@ errinj.set("ERRINJ_VYRUN_DATA_READ", true)
 ...
 s:select()
 ---
-- error: failed to read from file
+- error: 'failed to read from file: Input/output error'
 ...
 errinj.set("ERRINJ_VYRUN_DATA_READ", false)
 ---


### PR DESCRIPTION
Commit c13b3a31a9b04d4e3fbf0be88f76285b2cc103a7 changed error messages reported by net.box on IO errors, which caused integration/cartridge test failure. The net.box state machine used to return `strerror(errno)`, e.g. something like `Connection refused`, while now it returns `error::errmsg`, which lacks `strerror(errno)`, e.g. `connect, called on fd 55, aka 127.0.0.1:34138`. The old error message is arguably more useful, because it explains *why* the failure happened, not *what* failed. In PR https://github.com/tarantool/tarantool/pull/6643 I tried to restore the original error messages. This would fix cartridge test, but the code looked confusing. In review of the aforementioned PR @Gerold103 suggested to append `strerror(errno)` to `error::errmsg` for `SystemError` and `SocketError`. This makes the error messages verbose hence useful - now they shows both *what* failed and *why*, e.g.:

```
connect, called on fd 55, aka 127.0.0.1:34138: Connection refused
```

This doesn't fix the integration/cartridge tests, which expect the error message string to be exactly `strerror(errno)`. but I think it's a good change. We can easily fix integration/cartridge tests by making them do pattern-matching instead of exact comparison. I'll file a ticket if this PR is accepted.