### PR TITLE
swim: fix debug assertion abort in proto decode

### DIFF
--- a/src/lib/swim/swim_proto.c
+++ b/src/lib/swim/swim_proto.c
@@ -125,7 +125,7 @@ static inline int
 swim_decode_bin(const char **bin, uint32_t *size, const char **pos,
 		const char *end, const char *prefix, const char *param_name)
 {
-	if (*pos == end || mp_typeof(**pos) != MP_BIN ||
+	if (*pos + 1 >= end || mp_typeof(**pos) != MP_BIN ||
 	    mp_check_binl(*pos, end) > 0) {
 		diag_set(SwimError, "%s %s should be bin", prefix,
 			 param_name);

--- a/test/unit/swim_proto.c
+++ b/test/unit/swim_proto.c
@@ -45,7 +45,7 @@ static void
 swim_test_member_def(void)
 {
 	header();
-	plan(12);
+	plan(13);
 
 	struct swim_member_def mdef;
 	const char *pos = buffer;
@@ -128,6 +128,12 @@ swim_test_member_def(void)
 	end = mp_encode_uint(end, 0);
 	is(swim_member_def_decode(&mdef, &pos, end, "test"), 0,
 	   "normal member def");
+
+	pos = buffer;
+	end = mp_encode_bin(buffer, (const char *) &uuid, sizeof(uuid));
+	end = buffer + 1;
+	is(swim_decode_uuid(&uuid, &pos, end, "test", "test"), -1,
+	   "zero length bin");
 
 	check_plan();
 	footer();

--- a/test/unit/swim_proto.result
+++ b/test/unit/swim_proto.result
@@ -1,7 +1,7 @@
 	*** main ***
 1..3
 	*** swim_test_member_def ***
-    1..12
+    1..13
     ok 1 - not map header
     ok 2 - not uint member key
     ok 3 - too big member key
@@ -14,6 +14,7 @@
     ok 10 - uuid is nil/undefined
     ok 11 - port is 0/undefined
     ok 12 - normal member def
+    ok 13 - zero length bin
 ok 1 - subtests
 	*** swim_test_member_def: done ***
 	*** swim_test_meta ***


### PR DESCRIPTION
assert(cur < end) after mp_load_u8 in mp_check_binl was failing

This PR fixes abort found with libFuzzer target in #6627