### PR TITLE
MsgPack object

### DIFF
--- a/changelogs/unreleased/func-multikey-opt-without-sub-table.md
+++ b/changelogs/unreleased/func-multikey-opt-without-sub-table.md
@@ -1,0 +1,4 @@
+## feature/lua/schema
+
+* `is_multikey` option may now be passed to `box.schema.func.create` directly,
+  without `opts` sub-table.

--- a/changelogs/unreleased/gh-3349-func-takes-raw-args.md
+++ b/changelogs/unreleased/gh-3349-func-takes-raw-args.md
@@ -1,0 +1,4 @@
+## feature/core
+
+* Added `takes_raw_args` Lua function option for wrapping arguments in
+  `msgpack.object` to skip decoding (gh-3349).

--- a/changelogs/unreleased/gh-4861-net-box-return-raw.md
+++ b/changelogs/unreleased/gh-4861-net-box-return-raw.md
@@ -1,0 +1,4 @@
+## feature/lua/netbox
+
+* Added `return_raw` net.box option for returning `msgpack.object` instead of
+  decoding the response (gh-4861).

--- a/changelogs/unreleased/gh-5316-msgpack-object.md
+++ b/changelogs/unreleased/gh-5316-msgpack-object.md
@@ -1,0 +1,4 @@
+## feature/lua/msgpack
+
+* Added `msgpack.object` container for marshalling arbitrary MsgPack data
+  (gh-1629, gh-3349, gh-3909, gh-4861, gh-5316).

--- a/src/box/func_def.c
+++ b/src/box/func_def.c
@@ -40,10 +40,12 @@ const char *func_aggregate_strs[] = {"none", "group"};
 
 const struct func_opts func_opts_default = {
 	/* .is_multikey = */ false,
+	/* .takes_raw_args = */ false,
 };
 
 const struct opt_def func_opts_reg[] = {
 	OPT_DEF("is_multikey", OPT_BOOL, struct func_opts, is_multikey),
+	OPT_DEF("takes_raw_args", OPT_BOOL, struct func_opts, takes_raw_args),
 };
 
 int
@@ -51,6 +53,8 @@ func_opts_cmp(struct func_opts *o1, struct func_opts *o2)
 {
 	if (o1->is_multikey != o2->is_multikey)
 		return o1->is_multikey - o2->is_multikey;
+	if (o1->takes_raw_args != o2->takes_raw_args)
+		return o1->takes_raw_args - o2->takes_raw_args;
 	return 0;
 }
 

--- a/src/box/func_def.h
+++ b/src/box/func_def.h
@@ -68,6 +68,10 @@ struct func_opts {
 	 * packed in array.
 	 */
 	bool is_multikey;
+	/**
+	 * True if the function expects a msgpack object for args.
+	 */
+	bool takes_raw_args;
 };
 
 extern const struct func_opts func_opts_default;

--- a/src/box/lua/net_box.lua
+++ b/src/box/lua/net_box.lua
@@ -638,20 +638,21 @@ end
 
 function remote_methods:_request(method, opts, format, stream_id, ...)
     local transport = self._transport
-    local on_push, on_push_ctx, buffer, skip_header, deadline
+    local on_push, on_push_ctx, buffer, skip_header, return_raw, deadline
     -- Extract options, set defaults, check if the request is
     -- async.
     if opts then
         buffer = opts.buffer
         skip_header = opts.skip_header
+        return_raw = opts.return_raw
         if opts.is_async then
             if opts.on_push or opts.on_push_ctx then
                 error('To handle pushes in an async request use future:pairs()')
             end
             local res, err =
-                transport:perform_async_request(buffer, skip_header, method,
+                transport:perform_async_request(buffer, skip_header, return_raw,
                                                 table.insert, {}, format,
-                                                stream_id, ...)
+                                                stream_id, method, ...)
             if err then
                 box.error(err)
             end
@@ -672,8 +673,8 @@ function remote_methods:_request(method, opts, format, stream_id, ...)
         timeout = deadline and max(0, deadline - fiber_clock())
     end
     local res, err = transport:perform_request(timeout, buffer, skip_header,
-                                               method, on_push, on_push_ctx,
-                                               format, stream_id, ...)
+                                               return_raw, on_push, on_push_ctx,
+                                               format, stream_id, method, ...)
     if err then
         box.error(err)
     end

--- a/src/box/lua/net_box.lua
+++ b/src/box/lua/net_box.lua
@@ -387,14 +387,16 @@ local function check_remote_arg(remote, method)
 end
 
 local function check_call_args(args)
-    if args ~= nil and type(args) ~= 'table' then
+    if args ~= nil and type(args) ~= 'table' and
+       not msgpack.is_object(args) then
         error("Use remote:call(func_name, {arg1, arg2, ...}, opts) "..
               "instead of remote:call(func_name, arg1, arg2, ...)")
     end
 end
 
 local function check_eval_args(args)
-    if args ~= nil and type(args) ~= 'table' then
+    if args ~= nil and type(args) ~= 'table' and
+       not msgpack.is_object(args) then
         error("Use remote:eval(expression, {arg1, arg2, ...}, opts) "..
               "instead of remote:eval(expression, arg1, arg2, ...)")
     end

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -2599,7 +2599,9 @@ box.schema.func.create = function(name, opts)
                               if_not_exists = 'boolean',
                               language = 'string', body = 'string',
                               is_deterministic = 'boolean',
-                              is_sandboxed = 'boolean', comment = 'string',
+                              is_sandboxed = 'boolean',
+                              is_multikey = 'boolean',
+                              comment = 'string',
                               param_list = 'table', returns = 'string',
                               exports = 'table', opts = 'table' })
     local _func = box.space[box.schema.FUNC_ID]
@@ -2620,6 +2622,9 @@ box.schema.func.create = function(name, opts)
                     comment = '', created = datetime, last_altered = datetime})
     opts.language = string.upper(opts.language)
     opts.setuid = opts.setuid and 1 or 0
+    if opts.is_multikey then
+        opts.opts.is_multikey = opts.is_multikey
+    end
     _func:auto_increment{session.euid(), name, opts.setuid, opts.language,
                          opts.body, opts.routine_type, opts.param_list,
                          opts.returns, opts.aggregate, opts.sql_data_access,

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -2601,6 +2601,7 @@ box.schema.func.create = function(name, opts)
                               is_deterministic = 'boolean',
                               is_sandboxed = 'boolean',
                               is_multikey = 'boolean',
+                              takes_raw_args = 'boolean',
                               comment = 'string',
                               param_list = 'table', returns = 'string',
                               exports = 'table', opts = 'table' })
@@ -2624,6 +2625,9 @@ box.schema.func.create = function(name, opts)
     opts.setuid = opts.setuid and 1 or 0
     if opts.is_multikey then
         opts.opts.is_multikey = opts.is_multikey
+    end
+    if opts.takes_raw_args then
+        opts.opts.takes_raw_args = opts.takes_raw_args
     end
     _func:auto_increment{session.euid(), name, opts.setuid, opts.language,
                          opts.body, opts.routine_type, opts.param_list,

--- a/src/box/lua/tuple.c
+++ b/src/box/lua/tuple.c
@@ -427,6 +427,11 @@ luamp_convert_key(struct lua_State *L, struct luaL_serializer *cfg,
 	if (tuple != NULL)
 		return tuple_to_mpstream(tuple, stream);
 
+	size_t data_len;
+	const char *data = luamp_get(L, index, &data_len);
+	if (data != NULL)
+		return mpstream_memcpy(stream, data, data_len);
+
 	struct luaL_field field;
 	if (luaL_tofield(L, cfg, index, &field) < 0)
 		luaT_error(L);

--- a/src/lua/msgpack.c
+++ b/src/lua/msgpack.c
@@ -50,6 +50,44 @@
 #include "cord_buf.h"
 #include <fiber.h>
 
+/**
+ * Lua object that stores raw msgpack data and implements methods for decoding
+ * it in Lua. Allocated as Lua userdata.
+ */
+struct luamp_object {
+	/** Pointer to the serializer used for decoding data. */
+	struct luaL_serializer *cfg;
+	/** Reference to the serializer. */
+	int cfg_ref;
+	/**
+	 * If this object doesn't own data, but instead points to data of
+	 * another object (i.e. it was created by an iterator), then this
+	 * member stores a Lua reference to the original object. Otherwise,
+	 * it's set to LUA_NOREF.
+	 */
+	int data_ref;
+	/** Pointer to msgpack data. */
+	const char *data;
+	/** Pointer to the end of msgpack data. */
+	const char *data_end;
+};
+
+static const char luamp_object_typename[] = "msgpack.object";
+
+/**
+ * Iterator over a msgpack object. Allocated as Lua userdata.
+ */
+struct luamp_iterator {
+	/** Pointer to the source object. */
+	struct luamp_object *source;
+	/** Lua reference to the source object. */
+	int source_ref;
+	/** Current iterator position in the source object data. */
+	const char *pos;
+};
+
+static const char luamp_iterator_typename[] = "msgpack.iterator";
+
 void
 luamp_error(void *error_ctx)
 {
@@ -116,6 +154,7 @@ luamp_encode_r(struct lua_State *L, struct luaL_serializer *cfg,
 {
 	int top = lua_gettop(L);
 	enum mp_type type;
+	struct luamp_object *obj;
 
 restart: /* used by MP_EXT of unidentified subtype */
 	switch (field->type) {
@@ -204,10 +243,18 @@ restart: /* used by MP_EXT of unidentified subtype */
 			}
 			return luamp_encode_extension(L, top, stream);
 		default:
+			obj = luaL_testudata(L, top, luamp_object_typename);
+			if (obj != NULL) {
+				mpstream_memcpy(stream, obj->data,
+						obj->data_end - obj->data);
+				return mp_typeof(*obj->data);
+			}
 			/* Run trigger if type can't be encoded */
 			type = luamp_encode_extension(L, top, stream);
-			if (type != MP_EXT)
-				return type; /* Value has been packed by the trigger */
+			if (type != MP_EXT) {
+				/* Value has been packed by the trigger */
+				return type;
+			}
 convert:
 			/* Try to convert value to serializable type */
 			luaL_convertfield(L, cfg, top, field);
@@ -569,8 +616,285 @@ lua_decode_map_header(lua_State *L)
 	return 2;
 }
 
+/**
+ * Allocates a new msgpack object capable of storing msgpack data of the given
+ * size and pushes it to Lua stack. Returns a pointer to the object.
+ */
+static struct luamp_object *
+luamp_new_object(struct lua_State *L, size_t data_len)
+{
+	struct luamp_object *obj = lua_newuserdata(L, sizeof(*obj) + data_len);
+	obj->cfg = luaL_msgpack_default;
+	obj->cfg_ref = LUA_NOREF;
+	obj->data_ref = LUA_NOREF;
+	obj->data = (char *)obj + sizeof(*obj);
+	obj->data_end = obj->data + data_len;
+	luaL_getmetatable(L, luamp_object_typename);
+	lua_setmetatable(L, -2);
+	return obj;
+}
+
+/**
+ * Creates a new msgpack object and pushes it to Lua stack.
+ * Takes a Lua object as the only argument.
+ */
 static int
-lua_msgpack_new(lua_State *L);
+lua_msgpack_object(struct lua_State *L)
+{
+	if (lua_gettop(L) != 1)
+		luaL_error(L, "msgpack.object: a Lua object expected");
+	struct luaL_serializer *cfg = luaL_checkserializer(L);
+	struct ibuf *buf = cord_ibuf_take();
+	struct mpstream stream;
+	mpstream_init(&stream, buf, ibuf_reserve_cb, ibuf_alloc_cb,
+		      luamp_error, L);
+	luamp_encode(L, cfg, &stream, 1);
+	mpstream_flush(&stream);
+	struct luamp_object *obj = luamp_new_object(L, ibuf_used(buf));
+	memcpy((char *)obj->data, buf->buf, obj->data_end - obj->data);
+	cord_ibuf_put(buf);
+	obj->cfg = cfg;
+	luaL_pushserializer(L);
+	obj->cfg_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+	return 1;
+}
+
+/**
+ * Creates a new msgpack object from raw data and pushes it to Lua stack.
+ * The data is given either by a Lua string or by a char ptr and size.
+ */
+static int
+lua_msgpack_object_from_raw(struct lua_State *L)
+{
+	const char *data;
+	size_t data_len;
+	uint32_t cdata_type;
+	switch (lua_type(L, 1)) {
+	case LUA_TCDATA:
+		if (luaL_checkconstchar(L, 1, &data, &cdata_type) != 0)
+			goto error;
+		data_len = luaL_checkinteger(L, 2);
+		break;
+	case LUA_TSTRING:
+		data = lua_tolstring(L, 1, &data_len);
+		break;
+	default:
+		goto error;
+	}
+	const char *p = data;
+	const char *data_end = data + data_len;
+	if (mp_check(&p, data_end) != 0 || p != data_end) {
+		return luaL_error(L, "msgpack.object_from_raw: "
+				  "invalid MsgPack");
+	}
+	struct luamp_object *obj = luamp_new_object(L, data_len);
+	memcpy((char *)obj->data, data, data_len);
+	obj->cfg = luaL_checkserializer(L);
+	luaL_pushserializer(L);
+	obj->cfg_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+	return 1;
+error:
+	return luaL_error(L, "msgpack.object_from_raw: "
+			  "a Lua string or 'char *' expected");
+}
+
+/**
+ * Takes a Lua value. Returns true if it's a msgpack object, false otherwise.
+ */
+static int
+lua_msgpack_is_object(struct lua_State *L)
+{
+	void *obj = luaL_testudata(L, 1, luamp_object_typename);
+	lua_pushboolean(L, obj != NULL);
+	return 1;
+}
+
+static inline struct luamp_object *
+luamp_check_object(struct lua_State *L, int idx)
+{
+	return luaL_checkudata(L, idx, luamp_object_typename);
+}
+
+static int
+luamp_object_gc(struct lua_State *L)
+{
+	struct luamp_object *obj = luamp_check_object(L, 1);
+	luaL_unref(L, LUA_REGISTRYINDEX, obj->cfg_ref);
+	luaL_unref(L, LUA_REGISTRYINDEX, obj->data_ref);
+	return 0;
+}
+
+static int
+luamp_object_tostring(struct lua_State *L)
+{
+	lua_pushstring(L, luamp_object_typename);
+	return 1;
+}
+
+/**
+ * Decodes the data stored in a msgpack object and pushes it to Lua stack.
+ * Takes a msgpack object as the only argument.
+ */
+static int
+luamp_object_decode(struct lua_State *L)
+{
+	struct luamp_object *obj = luamp_check_object(L, 1);
+	const char *data = obj->data;
+	luamp_decode(L, obj->cfg, &data);
+	assert(data == obj->data_end);
+	return 1;
+}
+
+/**
+ * Creates an iterator over a msgpack object and pushes it to Lua stack.
+ * Takes a msgpack object as the only argument.
+ */
+static int
+luamp_object_iterator(struct lua_State *L)
+{
+	struct luamp_object *obj = luamp_check_object(L, 1);
+	struct luamp_iterator *it = lua_newuserdata(L, sizeof(*it));
+	it->source = obj;
+	it->source_ref = LUA_NOREF;
+	it->pos = obj->data;
+	luaL_getmetatable(L, luamp_iterator_typename);
+	lua_setmetatable(L, -2);
+	lua_insert(L, 1);
+	it->source_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+	return 1;
+}
+
+static inline struct luamp_iterator *
+luamp_check_iterator(struct lua_State *L, int idx)
+{
+	return luaL_checkudata(L, idx, luamp_iterator_typename);
+}
+
+static int
+luamp_iterator_gc(struct lua_State *L)
+{
+	struct luamp_iterator *it = luamp_check_iterator(L, 1);
+	luaL_unref(L, LUA_REGISTRYINDEX, it->source_ref);
+	return 0;
+}
+
+static int
+luamp_iterator_tostring(struct lua_State *L)
+{
+	lua_pushstring(L, luamp_iterator_typename);
+	return 1;
+}
+
+/**
+ * Raises a Lua error if there's no data to decode.
+ */
+static inline void
+luamp_iterator_check_data_end(struct lua_State *L, struct luamp_iterator *it)
+{
+	assert(it->pos >= it->source->data);
+	assert(it->pos <= it->source->data_end);
+	if (it->pos == it->source->data_end)
+		luaL_error(L, "iteration ended");
+}
+
+/**
+ * Raises a Lua error if the type of the msgpack value under the iterator
+ * cursor doesn't match the expected type.
+ */
+static inline void
+luamp_iterator_check_data_type(struct lua_State *L, struct luamp_iterator *it,
+			       enum mp_type type)
+{
+	luamp_iterator_check_data_end(L, it);
+	if (mp_typeof(*it->pos) != type)
+		luaL_error(L, "unexpected msgpack type");
+}
+
+/**
+ * Decodes a msgpack array header and returns the number of elements in the
+ * array. After calling this function the iterator points to the first element
+ * of the array or to the value following the array if the array is empty.
+ * Raises a Lua error if the type of the value under the iterator cursor is not
+ * MP_ARRAY.
+ */
+static int
+luamp_iterator_decode_array_header(struct lua_State *L)
+{
+	struct luamp_iterator *it = luamp_check_iterator(L, 1);
+	luamp_iterator_check_data_type(L, it, MP_ARRAY);
+	uint32_t len = mp_decode_array(&it->pos);
+	lua_pushinteger(L, len);
+	return 1;
+}
+
+/**
+ * Decodes a msgpack map header and returns the number of key value paris in
+ * the map. After calling this function the iterator points to the first
+ * key stored in the map or to the value following the map if the map is empty.
+ * Raises a Lua error if the type of the value under the iterator cursor is not
+ * MP_MAP.
+ */
+static int
+luamp_iterator_decode_map_header(struct lua_State *L)
+{
+	struct luamp_iterator *it = luamp_check_iterator(L, 1);
+	luamp_iterator_check_data_type(L, it, MP_MAP);
+	uint32_t len = mp_decode_map(&it->pos);
+	lua_pushinteger(L, len);
+	return 1;
+}
+
+/**
+ * Decodes a msgpack value under the iterator cursor and advances the cursor.
+ * Returns a Lua object corresponding to the msgpack value. Raises a Lua error
+ * if there's no data to decode.
+ */
+static int
+luamp_iterator_decode(struct lua_State *L)
+{
+	struct luamp_iterator *it = luamp_check_iterator(L, 1);
+	luamp_iterator_check_data_end(L, it);
+	luamp_decode(L, it->source->cfg, &it->pos);
+	return 1;
+}
+
+/**
+ * Returns a msgpack value under the iterator cursor as a msgpack object,
+ * (without decoding) and advances the cursor. The new msgpack object
+ * points to the data of the source object (references it). Raises a Lua error
+ * if there's no data to decode.
+ */
+static int
+luamp_iterator_take(struct lua_State *L)
+{
+	struct luamp_iterator *it = luamp_check_iterator(L, 1);
+	luamp_iterator_check_data_end(L, it);
+	struct luamp_object *obj = luamp_new_object(L, 0);
+	obj->data = it->pos;
+	mp_next(&it->pos);
+	obj->data_end = it->pos;
+	lua_rawgeti(L, LUA_REGISTRYINDEX, it->source_ref);
+	obj->data_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+	/* No need to take ref to cfg, because it's pinned via data_ref. */
+	obj->cfg = it->source->cfg;
+	return 1;
+}
+
+/**
+ * Advances the iterator cursor by skipping one msgpack value under the cursor.
+ * Raises a Lua error if there's no data to skip.
+ */
+static int
+luamp_iterator_skip(struct lua_State *L)
+{
+	struct luamp_iterator *it = luamp_check_iterator(L, 1);
+	luamp_iterator_check_data_end(L, it);
+	mp_next(&it->pos);
+	return 0;
+}
+
+static int
+lua_msgpack_new(struct lua_State *L);
 
 static const luaL_Reg msgpacklib[] = {
 	{ "encode", lua_msgpack_encode },
@@ -579,6 +903,9 @@ static const luaL_Reg msgpacklib[] = {
 	{ "ibuf_decode", lua_ibuf_msgpack_decode },
 	{ "decode_array_header", lua_decode_array_header },
 	{ "decode_map_header", lua_decode_map_header },
+	{ "object", lua_msgpack_object },
+	{ "object_from_raw", lua_msgpack_object_from_raw },
+	{ "is_object", lua_msgpack_is_object },
 	{ "new", lua_msgpack_new },
 	{ NULL, NULL }
 };
@@ -593,6 +920,27 @@ lua_msgpack_new(lua_State *L)
 LUALIB_API int
 luaopen_msgpack(lua_State *L)
 {
+	static const struct luaL_Reg luamp_object_meta[] = {
+		{ "__gc", luamp_object_gc },
+		{ "__tostring", luamp_object_tostring },
+		{ "decode", luamp_object_decode },
+		{ "iterator", luamp_object_iterator },
+		{ NULL, NULL }
+	};
+	luaL_register_type(L, luamp_object_typename, luamp_object_meta);
+
+	static const struct luaL_Reg luamp_iterator_meta[] = {
+		{ "__gc", luamp_iterator_gc },
+		{ "__tostring", luamp_iterator_tostring },
+		{ "decode_array_header", luamp_iterator_decode_array_header },
+		{ "decode_map_header", luamp_iterator_decode_map_header },
+		{ "decode", luamp_iterator_decode },
+		{ "take", luamp_iterator_take },
+		{ "skip", luamp_iterator_skip },
+		{ NULL, NULL }
+	};
+	luaL_register_type(L, luamp_iterator_typename, luamp_iterator_meta);
+
 	luaL_msgpack_default = luaL_newserializer(L, "msgpack", msgpacklib);
 	return 1;
 }

--- a/src/lua/msgpack.c
+++ b/src/lua/msgpack.c
@@ -646,6 +646,15 @@ luamp_new_object(struct lua_State *L, size_t data_len)
 	return obj;
 }
 
+void
+luamp_push(struct lua_State *L, const char *data, const char *data_end)
+{
+	size_t data_len = data_end - data;
+	struct luamp_object *obj = luamp_new_object(L, data_len);
+	memcpy((char *)obj->data, data, data_len);
+	assert(mp_check(&data, data_end) == 0 && data == data_end);
+}
+
 /**
  * Creates a new msgpack object and pushes it to Lua stack.
  * Takes a Lua object as the only argument.

--- a/src/lua/msgpack.h
+++ b/src/lua/msgpack.h
@@ -61,6 +61,14 @@ luamp_error(void *);
 
 enum { LUAMP_ALLOC_FACTOR = 256 };
 
+/**
+ * Returns a pointer to the msgpack data and writes the length of the data to
+ * data_len if the object at the given index is a msgpack object. Otherwise
+ * returns NULL.
+ */
+const char *
+luamp_get(struct lua_State *L, int idx, size_t *data_len);
+
 /* low-level function needed for execute_lua_call() */
 enum mp_type
 luamp_encode_r(struct lua_State *L, struct luaL_serializer *cfg,

--- a/src/lua/msgpack.h
+++ b/src/lua/msgpack.h
@@ -62,6 +62,13 @@ luamp_error(void *);
 enum { LUAMP_ALLOC_FACTOR = 256 };
 
 /**
+ * Pushes to the Lua stack a new msgpack object and stores the given msgpack
+ * data in it. The new object uses the default serializer for decoding.
+ */
+void
+luamp_push(struct lua_State *L, const char *data, const char *data_end);
+
+/**
  * Returns a pointer to the msgpack data and writes the length of the data to
  * data_len if the object at the given index is a msgpack object. Otherwise
  * returns NULL.

--- a/src/lua/serializer.h
+++ b/src/lua/serializer.h
@@ -189,6 +189,12 @@ luaL_checkserializer(struct lua_State *L)
 		luaL_checkudata(L, lua_upvalueindex(1), LUAL_SERIALIZER);
 }
 
+static inline void
+luaL_pushserializer(struct lua_State *L)
+{
+	lua_pushvalue(L, lua_upvalueindex(1));
+}
+
 /**
  * Initialize serializer with default parameters.
  * @param cfg Serializer to inherit configuration.

--- a/test/app-luatest/msgpack_test.lua
+++ b/test/app-luatest/msgpack_test.lua
@@ -58,6 +58,16 @@ g.test_errors = function()
     t.assert_error_msg_content_equals(
         "bad argument #2 to 'decode_unchecked' (number expected, got string)",
         function() msgpack.decode_unchecked('test', 'offset') end)
+
+    t.assert_error_msg_content_equals(
+        "msgpack.object: a Lua object expected",
+        function() msgpack.object() end)
+    t.assert_error_msg_content_equals(
+        "msgpack.object_from_raw: a Lua string or 'char *' expected",
+        function() msgpack.object_from_raw() end)
+    t.assert_error_msg_content_equals(
+        "bad argument #2 to 'object_from_raw' (number expected, got string)",
+        function() msgpack.object_from_raw(buf.buf, 'test') end)
 end
 
 g.test_encode_decode_strings = function()
@@ -180,4 +190,231 @@ g.test_encode_decode_uuid = function()
         local res = msgpack.decode(msgpack.encode(src))
         t.assert_equals(src, res)
     end
+end
+
+g.test_object_encode_decode = function()
+    local o = nil
+    t.assert_equals(msgpack.object(o):decode(), o)
+    o = box.NULL
+    t.assert_equals(msgpack.object(o):decode(), o)
+    o = 123
+    t.assert_equals(msgpack.object(o):decode(), o)
+    o = 'foobar'
+    t.assert_equals(msgpack.object(o):decode(), o)
+    o = {foo = 123, bar = 456}
+    t.assert_equals(msgpack.object(o):decode(), o)
+    o = {foo = {1, 2, 3}, bar = {'a', 'b', 'c'}}
+    t.assert_equals(msgpack.object(o):decode(), o)
+    local mp = msgpack.object({bar = 123})
+    t.assert_equals(
+        msgpack.object({mp, {foo = mp}}):decode(),
+        {mp:decode(), {foo = mp:decode()}})
+    t.assert_equals(
+        msgpack.decode(msgpack.encode({mp, {foo = mp}})),
+        {mp:decode(), {foo = mp:decode()}})
+    t.assert_equals(msgpack.object(box.tuple.new(1, 2, 3)):decode(), {1, 2, 3})
+    t.assert_equals(
+        msgpack.object({
+            foo = box.tuple.new(123),
+            bar = box.tuple.new(456),
+        }):decode(), {foo = {123}, bar = {456}})
+end
+
+g.test_object_from_raw = function()
+    local o = {foo = 'bar'}
+    local mp
+
+    -- from string
+    mp = msgpack.object_from_raw(msgpack.encode(o))
+    t.assert_equals(mp:decode(), o)
+
+    -- from buffer
+    local buf = buffer.ibuf()
+    msgpack.encode(o, buf)
+    mp = msgpack.object_from_raw(buf.buf, buf:size())
+    t.assert_equals(mp:decode(), o)
+    buf:recycle()
+
+    -- invalid msgpack
+    local s = msgpack.encode(o)
+    t.assert_error_msg_content_equals(
+        "msgpack.object_from_raw: invalid MsgPack",
+        msgpack.object_from_raw, s:sub(1, -2))
+    t.assert_error_msg_content_equals(
+        "msgpack.object_from_raw: invalid MsgPack",
+        msgpack.object_from_raw, s .. s)
+end
+
+g.test_object_iterator = function()
+    local o = {foo = {1, 2, 3}, bar = {'a', 'b', 'c'}}
+    local it
+
+    -- iterator.decode
+    it = msgpack.object(o):iterator()
+    t.assert_equals(it:decode(), o)
+    t.assert_error_msg_content_equals(
+        "iteration ended", function() it:decode() end)
+
+    -- iterator.decode for msgpack.object_from_raw
+    it = msgpack.object_from_raw(msgpack.encode(o)):iterator()
+    t.assert_equals(it:decode(), o)
+    t.assert_error_msg_content_equals(
+        "iteration ended", function() it:decode() end)
+
+    -- iterator.take
+    it = msgpack.object(o):iterator()
+    t.assert_equals(it:take():decode(), o)
+    t.assert_error_msg_content_equals(
+        "iteration ended", function() it:take() end)
+
+    -- iterator.decode_array_header
+    it = msgpack.object({{}}):iterator()
+    t.assert_error_msg_content_equals(
+        "unexpected msgpack type", function() it:decode_map_header() end)
+    t.assert_equals(it:decode_array_header(), 1)
+    t.assert_error_msg_content_equals(
+        "unexpected msgpack type", function() it:decode_map_header() end)
+    t.assert_equals(it:decode_array_header(), 0)
+    t.assert_error_msg_content_equals(
+        "iteration ended", function() it:decode_map_header() end)
+
+    -- iterator.decode_map_header
+    it = msgpack.object(
+        {key = setmetatable({}, {__serialize = 'map'})}):iterator()
+    t.assert_error_msg_content_equals(
+        "unexpected msgpack type", function() it:decode_array_header() end)
+    t.assert_equals(it:decode_map_header(), 1)
+    t.assert_equals(it:decode(), 'key')
+    t.assert_error_msg_content_equals(
+        "unexpected msgpack type", function() it:decode_array_header() end)
+    t.assert_equals(it:decode_map_header(), 0)
+    t.assert_error_msg_content_equals(
+        "iteration ended", function() it:decode_map_header() end)
+
+    -- iterator.skip
+    it = msgpack.object(
+        {'foo', {'bar'}, {foo = 'bar'}, 'fuzz', 'buzz'}):iterator()
+    t.assert_equals(it:decode_array_header(), 5)
+    it:skip()
+    it:skip()
+    it:skip()
+    t.assert_equals(it:decode(), 'fuzz')
+    it:skip()
+    t.assert_error_msg_content_equals(
+        "iteration ended", function() it:skip() end)
+
+    -- iterator.take.iterator
+    it = msgpack.object({{foo = 123}, {bar = 456}}):iterator()
+    t.assert_equals(it:decode_array_header(), 2)
+    local it2 = it:take():iterator()
+    t.assert_equals(it:decode_map_header(), 1)
+    t.assert_equals(it:decode(), 'bar')
+    t.assert_equals(it:decode(), 456)
+    t.assert_error_msg_content_equals(
+        "iteration ended", function() it:decode() end)
+    t.assert_equals(it2:decode_map_header(), 1)
+    t.assert_equals(it2:decode(), 'foo')
+    t.assert_equals(it2:decode(), 123)
+    t.assert_error_msg_content_equals(
+        "iteration ended", function() it2:decode() end)
+end
+
+g.test_object_cfg = function()
+    local inf = 1 / 0
+    local serializer = msgpack.new()
+    serializer.cfg({
+        encode_invalid_numbers = true,
+        decode_invalid_numbers = true,
+    })
+    local mp = serializer.object(inf)
+    t.assert_equals(mp:decode(), inf)
+    local mp_from_raw = serializer.object_from_raw(msgpack.encode(inf))
+    t.assert_equals(mp_from_raw:decode(), inf)
+    serializer.cfg({
+        encode_invalid_numbers = false,
+        decode_invalid_numbers = false,
+    })
+    t.assert_error_msg_content_equals(
+        "number must not be NaN or Inf",
+        function() serializer.object(inf) end)
+    t.assert_error_msg_content_equals(
+        "number must not be NaN or Inf",
+        function() mp:decode() end)
+    t.assert_error_msg_content_equals(
+        "number must not be NaN or Inf",
+        function() mp_from_raw:decode() end)
+    t.assert_error_msg_content_equals(
+        "number must not be NaN or Inf",
+        function() mp:iterator():decode() end)
+    t.assert_error_msg_content_equals(
+        "number must not be NaN or Inf",
+        function() mp:iterator():take():decode() end)
+end
+
+g.test_object_gc = function()
+    local function gc()
+        for _ = 1, 5 do
+            collectgarbage('collect')
+        end
+    end
+    local weak = setmetatable({}, {__mode = 'v'})
+    local o = {{foo = 1}, {bar = 2}}
+    local mp, mp_from_raw, mp_from_it, it
+
+    -- iterator pins object
+    mp = msgpack.new().object(o)
+    it = mp:iterator()
+    weak.mp = mp
+    mp = nil -- luacheck: no unused
+    gc()
+    t.assert_not_equals(weak.mp, nil)
+    t.assert_equals(it:decode(), o)
+    it = nil -- luacheck: no unused
+    gc()
+    t.assert_equals(weak.mp, nil)
+
+    -- iterator pins object created from raw msgpack
+    mp_from_raw = msgpack.new().object_from_raw(msgpack.encode(o))
+    it = mp_from_raw:iterator()
+    weak.mp_from_raw = mp_from_raw
+    mp_from_raw = nil -- luacheck: no unused
+    gc()
+    t.assert_not_equals(weak.mp_from_raw, nil)
+    t.assert_equals(it:decode(), o)
+    it = nil -- luacheck: no unused
+    gc()
+    t.assert_equals(weak.mp_from_raw, nil)
+
+    -- object created by iterator pins original object, but not iterator
+    mp = msgpack.new().object(o)
+    it = mp:iterator()
+    mp_from_it = it:take()
+    weak.mp = mp
+    weak.it = it
+    mp = nil -- luacheck: no unused
+    it = nil -- luacheck: no unused
+    gc()
+    t.assert_not_equals(weak.mp, nil)
+    t.assert_equals(weak.it, nil)
+    t.assert_equals(mp_from_it:decode(), o)
+    mp_from_it = nil -- luacheck: no unused
+    gc()
+    t.assert_equals(weak.mp, nil)
+end
+
+g.test_object_misc = function()
+    -- tostring
+    local mp = msgpack.object(nil)
+    t.assert_equals(tostring(mp), "msgpack.object")
+    local mp_from_raw = msgpack.object_from_raw(msgpack.encode(nil))
+    t.assert_equals(tostring(mp), "msgpack.object")
+    local it = mp:iterator()
+    t.assert_equals(tostring(it), "msgpack.iterator")
+
+    -- msgpack.is_object
+    t.assert(msgpack.is_object(mp))
+    t.assert(msgpack.is_object(mp_from_raw))
+    t.assert_not(msgpack.is_object())
+    t.assert_not(msgpack.is_object(it))
+    t.assert_not(msgpack.is_object({mp}))
 end

--- a/test/box-luatest/func_test.lua
+++ b/test/box-luatest/func_test.lua
@@ -1,0 +1,44 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all = function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end
+
+g.after_all = function()
+    g.server:stop()
+end
+
+g.after_test('test_legacy_opts', function()
+    g.server:exec(function()
+        box.schema.func.drop('test', {if_exists = true})
+    end)
+end)
+
+g.test_legacy_opts = function()
+    -- New way: no opts sub-table.
+    t.assert(g.server:exec(function()
+        box.schema.func.create('test', {is_multikey = true})
+        local ret = box.func.test.is_multikey
+        box.schema.func.drop('test')
+        return ret
+    end))
+    -- Value type is checked.
+    t.assert_error_msg_equals(
+        "Illegal parameters, options parameter 'is_multikey' should be of " ..
+        "type boolean",
+        function()
+            g.server:exec(function()
+                box.schema.func.create('test', {is_multikey = 'test'})
+            end)
+        end)
+    -- Legacy way: with opts sub-table.
+    t.assert(g.server:exec(function()
+        box.schema.func.create('test', {opts = {is_multikey = true}})
+        local ret = box.func.test.is_multikey
+        box.schema.func.drop('test')
+        return ret
+    end))
+end

--- a/test/box-luatest/func_test.lua
+++ b/test/box-luatest/func_test.lua
@@ -1,3 +1,4 @@
+local net = require('net.box')
 local server = require('test.luatest_helpers.server')
 local t = require('luatest')
 local g = t.group()
@@ -41,4 +42,74 @@ g.test_legacy_opts = function()
         box.schema.func.drop('test')
         return ret
     end))
+end
+
+g.before_test('test_msgpack_object_args', function()
+    local echo_code = "function(...) return ... end"
+    local check_code = "function(o) return require('msgpack').is_object(o) end"
+    local decode_code = "function(o) return o:decode() end"
+    g.server:eval("echo = " .. echo_code)
+    g.server:eval("echo_mp = " .. echo_code)
+    g.server:eval("check = " .. check_code)
+    g.server:eval("decode = " .. decode_code)
+    g.server:exec(function(check_code, decode_code)
+        box.schema.func.create('echo')
+        box.schema.func.create('echo_mp', {takes_raw_args = true})
+        box.schema.func.create('check', {takes_raw_args = true})
+        box.schema.func.create('decode', {takes_raw_args = true})
+        box.schema.func.create(
+            'check_persistent', {body = check_code, takes_raw_args = true})
+        box.schema.func.create(
+            'decode_persistent', {body = decode_code, takes_raw_args = true})
+    end, {check_code, decode_code})
+end)
+
+g.after_test('test_msgpack_object_args', function()
+    g.server:exec(function()
+        box.schema.func.drop('echo')
+        box.schema.func.drop('echo_mp')
+        box.schema.func.drop('check')
+        box.schema.func.drop('decode')
+        box.schema.func.drop('check_persistent')
+        box.schema.func.drop('decode_persistent')
+    end)
+    g.server:eval("echo = nil")
+    g.server:eval("echo_mp = nil")
+    g.server:eval("check = nil")
+    g.server:eval("decode = nil")
+end)
+
+g.test_msgpack_object_args = function()
+    local args = {'foo', 'bar', {foo = 'bar'}}
+
+    -- remote call
+    local c = net:connect(g.server.net_box_uri)
+    t.assert_equals({c:call('echo', args)}, args)
+    t.assert_equals(c:call('echo_mp', args), args)
+    t.assert(c:call('check', args))
+    t.assert_equals(c:call('decode', args), args)
+    t.assert(c:call('check_persistent', args))
+    t.assert_equals(c:call('decode_persistent', args), args)
+    c:close()
+
+    -- local call
+    local call = function(name, args)
+        return g.server:exec(function(name, args)
+            return box.func[name]:call(args)
+        end, {name, args})
+    end
+    t.assert_equals({call('echo', args)}, args)
+    t.assert_equals(call('echo_mp', args), args)
+    t.assert(call('check', args))
+    t.assert_equals(call('decode', args), args)
+    t.assert(call('check_persistent', args))
+    t.assert_equals(call('decode_persistent', args), args)
+
+    -- info
+    t.assert_not(g.server:eval('return box.func.echo.takes_raw_args'))
+    t.assert(g.server:eval('return box.func.echo_mp.takes_raw_args'))
+    t.assert(g.server:eval('return box.func.check.takes_raw_args'))
+    t.assert(g.server:eval('return box.func.decode.takes_raw_args'))
+    t.assert(g.server:eval('return box.func.check_persistent.takes_raw_args'))
+    t.assert(g.server:eval('return box.func.decode_persistent.takes_raw_args'))
 end

--- a/test/box-luatest/net_box_test.lua
+++ b/test/box-luatest/net_box_test.lua
@@ -74,3 +74,125 @@ g.test_msgpack_object_args = function()
 
     c:close()
 end
+
+g.before_test('test_msgpack_object_return', function()
+    g.server:eval('function echo(...) return ... end')
+    g.server:eval([[function echo_mp(...)
+        return require('msgpack').object({...})
+    end]])
+    g.server:exec(function()
+        box.schema.space.create(
+            'T', {format = {{'F1', 'unsigned'}, {'F2', 'string'}}})
+        box.space.T:create_index('PK')
+    end)
+end)
+
+g.after_test('test_msgpack_object_return', function()
+    g.server:eval('echo = nil')
+    g.server:eval('echo_mp = nil')
+    g.server:exec(function()
+        box.space.T:drop()
+    end)
+end)
+
+g.test_msgpack_object_return = function()
+    local c = net.connect(g.server.net_box_uri)
+    local opts = {return_raw = true}
+    local ret
+
+    -- eval
+    ret = c:eval('return ...', {}, opts)
+    t.assert(msgpack.is_object(ret))
+    t.assert_equals(ret:decode(), {})
+    ret = c:eval('return ...', {1, 2, 3}, opts)
+    t.assert(msgpack.is_object(ret))
+    t.assert_equals(ret:decode(), {1, 2, 3})
+    ret = c:eval("return require('msgpack').object({1, 2, 3})", {}, opts)
+    t.assert(msgpack.is_object(ret))
+    t.assert_equals(ret:decode(), {{1, 2, 3}})
+    -- sic: no return_raw
+    ret = c:eval("return require('msgpack').object({1, 2, 3})")
+    t.assert_not(msgpack.is_object(ret))
+    t.assert_equals(ret, {1, 2, 3})
+
+    -- call
+    ret = c:call('echo', {}, opts)
+    t.assert(msgpack.is_object(ret))
+    t.assert_equals(ret:decode(), {})
+    ret = c:call('echo', {1, 2, 3}, opts)
+    t.assert(msgpack.is_object(ret))
+    t.assert_equals(ret:decode(), {1, 2, 3})
+    ret = c:call('echo_mp', {1, 2, 3}, opts)
+    t.assert(msgpack.is_object(ret))
+    t.assert_equals(ret:decode(), {{1, 2, 3}})
+    -- sic: no return_raw
+    ret = c:call('echo_mp', {1, 2, 3})
+    t.assert_not(msgpack.is_object(ret))
+    t.assert_equals(ret, {1, 2, 3})
+
+    -- dml
+    ret = c.space.T:insert({1, 'foo'}, opts)
+    t.assert(msgpack.is_object(ret))
+    t.assert_equals(ret:decode(), {1, 'foo'})
+    ret = c.space.T:replace({1, 'bar'}, opts)
+    t.assert(msgpack.is_object(ret))
+    t.assert_equals(ret:decode(), {1, 'bar'})
+    ret = c.space.T:update({1}, {{'=', 2, 'baz'}}, opts)
+    t.assert(msgpack.is_object(ret))
+    t.assert_equals(ret:decode(), {1, 'baz'})
+    ret = c.space.T:select({1}, opts)
+    t.assert(msgpack.is_object(ret))
+    t.assert_equals(ret:decode(), {{1, 'baz'}})
+    ret = c.space.T:delete({1}, opts)
+    t.assert(msgpack.is_object(ret))
+    t.assert_equals(ret:decode(), {1, 'baz'})
+
+    -- min/max/get
+    c.space.T:insert({1, 'a'})
+    c.space.T:insert({2, 'b'})
+    ret = c.space.T.index.PK:min({}, opts)
+    t.assert(msgpack.is_object(ret))
+    t.assert_equals(ret:decode(), {1, 'a'})
+    ret = c.space.T.index.PK:max({}, opts)
+    t.assert(msgpack.is_object(ret))
+    t.assert_equals(ret:decode(), {2, 'b'})
+    ret = c.space.T.index.PK:get({2}, opts)
+    t.assert(msgpack.is_object(ret))
+    t.assert_equals(ret:decode(), {2, 'b'})
+
+    -- count (ignores return_raw)
+    ret = c.space.T.index.PK:count({}, opts)
+    t.assert_equals(ret, 2)
+
+    -- upsert (returns nil)
+    ret = c.space.T:upsert({1, 'a'}, {{'=', 2, 'a'}}, opts)
+    t.assert_equals(ret, nil)
+
+    -- begin/commit/rollback (returns nil)
+    local s = c:new_stream()
+    ret = s:begin(nil, opts)
+    t.assert_equals(ret, nil)
+    ret = s:commit(nil, opts)
+    t.assert_equals(ret, nil)
+    ret = s:rollback(nil, opts)
+    t.assert_equals(ret, nil)
+
+    -- sql (ignores return_raw except for rows)
+    local metadata = {
+        {name = 'F1', type = 'unsigned'},
+        {name = 'F2', type = 'string'},
+    }
+    ret = c:execute('SELECT * FROM T WHERE F1 < ?;', {2}, nil, opts)
+    t.assert(msgpack.is_object(ret.rows))
+    ret.rows = ret.rows:decode()
+    t.assert_equals(ret, {rows = {{1, 'a'}}, metadata = metadata})
+    ret = c:prepare('SELECT * FROM T WHERE F1 < ?;', nil, nil, opts)
+    local stmt_id = ret.stmt_id
+    ret.stmt_id = nil
+    t.assert_equals(ret, {metadata = metadata, param_count = 1,
+                          params = {{name = "?", type = "ANY"}}})
+    ret = c:unprepare(stmt_id, nil, nil, opts)
+    t.assert_equals(ret, nil)
+
+    c:close()
+end

--- a/test/box-luatest/net_box_test.lua
+++ b/test/box-luatest/net_box_test.lua
@@ -15,10 +15,18 @@ end
 
 g.before_test('test_msgpack_object_args', function()
     g.server:eval('function echo(...) return ... end')
+    g.server:exec(function()
+        box.schema.space.create(
+            'T', {format = {{'F1', 'unsigned'}, {'F2', 'string'}}})
+        box.space.T:create_index('PK')
+    end)
 end)
 
 g.after_test('test_msgpack_object_args', function()
     g.server:eval('echo = nil')
+    g.server:exec(function()
+        box.space.T:drop()
+    end)
 end)
 
 g.test_msgpack_object_args = function()
@@ -46,6 +54,23 @@ g.test_msgpack_object_args = function()
     t.assert_equals(ret, {})
     ret = {c:call('echo', msgpack.object({1, 2, 3}))}
     t.assert_equals(ret, {1, 2, 3})
+
+    -- dml
+    ret = c.space.T:insert(msgpack.object({1, 'foo'}))
+    t.assert_equals(ret, {1, 'foo'})
+    ret = c.space.T:replace({1, 'bar'})
+    t.assert_equals(ret, {1, 'bar'})
+    ret = c.space.T:update(
+        msgpack.object({1}), msgpack.object({{'=', 2, 'baz'}}))
+    t.assert_equals(ret, {1, 'baz'})
+    ret = c.space.T:select(msgpack.object({1}))
+    t.assert_equals(ret, {{1, 'baz'}})
+    ret = c.space.T:delete(msgpack.object({1}))
+    t.assert_equals(ret, {1, 'baz'})
+
+    -- sql
+    c:execute('INSERT INTO T VALUES(?, ?);', msgpack.object({1, 'a'}))
+    t.assert_equals(c.space.T:get(1), {1, 'a'})
 
     c:close()
 end

--- a/test/box-luatest/net_box_test.lua
+++ b/test/box-luatest/net_box_test.lua
@@ -1,0 +1,51 @@
+local msgpack = require('msgpack')
+local net = require('net.box')
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all = function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end
+
+g.after_all = function()
+    g.server:stop()
+end
+
+g.before_test('test_msgpack_object_args', function()
+    g.server:eval('function echo(...) return ... end')
+end)
+
+g.after_test('test_msgpack_object_args', function()
+    g.server:eval('echo = nil')
+end)
+
+g.test_msgpack_object_args = function()
+    local c = net.connect(g.server.net_box_uri)
+    local ret
+
+    -- eval
+    t.assert_error_msg_content_equals(
+        "Tuple/Key must be MsgPack array",
+        function() c:eval('return ...', msgpack.object(123)) end)
+    ret = {c:eval('return ...', {msgpack.object(123)})}
+    t.assert_equals(ret, {123})
+    ret = {c:eval('return ...', msgpack.object({}))}
+    t.assert_equals(ret, {})
+    ret = {c:eval('return ...', msgpack.object({1, 2, 3}))}
+    t.assert_equals(ret, {1, 2, 3})
+
+    -- call
+    t.assert_error_msg_content_equals(
+        "Tuple/Key must be MsgPack array",
+        function() c:call('echo', msgpack.object(123)) end)
+    ret = {c:call('echo', {msgpack.object(123)})}
+    t.assert_equals(ret, {123})
+    ret = {c:call('echo', msgpack.object({}))}
+    t.assert_equals(ret, {})
+    ret = {c:call('echo', msgpack.object({1, 2, 3}))}
+    t.assert_equals(ret, {1, 2, 3})
+
+    c:close()
+end

--- a/test/box-luatest/suite.ini
+++ b/test/box-luatest/suite.ini
@@ -1,0 +1,4 @@
+[default]
+core = luatest
+description = Database tests
+is_parallel = True

--- a/test/box/function1.result
+++ b/test/box/function1.result
@@ -98,6 +98,7 @@ box.func["function1.args"]
     lua: true
     sql: false
   id: 66
+  takes_raw_args: false
   setuid: false
   is_multikey: false
   is_deterministic: false
@@ -589,6 +590,7 @@ func
     lua: true
     sql: false
   id: 66
+  takes_raw_args: false
   setuid: false
   is_multikey: false
   is_deterministic: false
@@ -661,6 +663,7 @@ func
     lua: true
     sql: false
   id: 66
+  takes_raw_args: false
   setuid: false
   is_multikey: false
   is_deterministic: false


### PR DESCRIPTION
This pull request introduces a new userdata Lua object `msgpack.object` that stores arbitrary msgpack data. A msgpack object can be created from any Lua object, including another msgpack object. A msgpack object can be passed to net.box or inserted into a database space. It's possible to configure net.box to return a msgpack object from call/eval and other methods (`return_raw` option). It's also possible to configure a function to take a msgpack object (`takes_raw_args` option).

For more details, see the commits comments and the [design document](https://docs.google.com/document/d/11mbV5fRlcrmTz_tE1tanCwaXjFmHM7mcUfaUzkhcG8w).

Closes #1629
Closes #3349
Closes #3909
Closes #4861
Closes #5316