### PR TITLE
test: fix flaky test on temp space truncate

### DIFF
--- a/test/replication-luatest/gh_6123_truncate_temp_space_test.lua
+++ b/test/replication-luatest/gh_6123_truncate_temp_space_test.lua
@@ -57,6 +57,10 @@ g.test_truncate_is_local_transaction = function(cg)
 
     -- Checking that replica has received the last transaction,
     -- and that replication isn't broken.
+    local vclock = helpers:get_vclock(cg.master)
+    vclock[0] = nil
+    helpers:wait_vclock(cg.replica, vclock)
+
     t.assert_equals(cg.replica:eval("return box.space._schema:select{'smth'}"), {{'smth'}})
     t.assert_equals(cg.replica:eval("return box.info.replication[1].upstream.status"), 'follow')
 end


### PR DESCRIPTION
Replication of data in the test should happened before the data presence
test on the replica. Wait for lsn helper is used.

Closes #6663
