### PR TITLE
vfork on macOS

### DIFF
--- a/src/lib/core/crash.c
+++ b/src/lib/core/crash.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <limits.h>
 #include <time.h>
+#include <spawn.h>
 #include <sys/types.h>
 #include <sys/utsname.h>
 
@@ -392,29 +393,13 @@ crash_report_feedback_daemon(struct crash_info *cinfo)
 		[6] = NULL,
 	};
 
-	/*
-	 * Can't use fork here because libev has own
-	 * at_fork helpers with mutex where we might
-	 * stuck (see popen code).
-	 */
-	pid_t pid = vfork();
-	if (pid == 0) {
-		extern char **environ;
-		/*
-		 * The script must exit at the end but there
-		 * is no simple way to make sure from inside
-		 * of a signal crash handler. So just hope it
-		 * is running fine.
-		 */
-		execve(exec_argv[0], exec_argv, environ);
-		pr_crit("exec(%s,[%s,%s,%s,%s,%s,%s,%s]) failed",
-			exec_argv[0], exec_argv[0],
-			exec_argv[1], exec_argv[2],
-			exec_argv[3], exec_argv[4],
-			exec_argv[5], exec_argv[6]);
-		_exit(1);
-	} else if (pid < 0) {
-		pr_crit("unable to vfork (errno %d)", errno);
+	extern char **environ;
+	int rc = posix_spawn(NULL, exec_argv[0], NULL, NULL, exec_argv, environ);
+	if (rc != 0) {
+		pr_crit("posix_spawn with "
+			"exec(%s,[%s,%s,%s,%s,%s,%s,%s]) failed: %s", exec_argv[0],
+			exec_argv[0], exec_argv[1], exec_argv[2], exec_argv[3],
+			exec_argv[4], exec_argv[5], exec_argv[6], strerror(rc));
 		return -1;
 	}
 

--- a/src/lib/core/popen.c
+++ b/src/lib/core/popen.c
@@ -1178,7 +1178,15 @@ popen_new(struct popen_opts *opts)
 	 * vfork to complete. Also we try to do as minimum
 	 * operations before the exec() as possible.
 	 */
+#pragma GCC diagnostic push
+	/*
+	 * TODO(gh-6674): we need to review popen's design and refactor this
+	 * part, completely getting rid of vfork, or change vfork to
+	 * posix_spawn here, but only on macOS.
+	 */
+#pragma GCC diagnostic warning "-Wdeprecated-declarations"
 	handle->pid = vfork();
+#pragma GCC diagnostic pop
 	if (handle->pid < 0) {
 		diag_set(SystemError, "vfork() fails");
 		goto out_err;


### PR DESCRIPTION
`vfork` got deprecated on macOS:

* refactor crash signal hander: change `vfork` to more portable `posix_spawn`.
* `popen`: for now, change `vfork` deprecation error to a warning until we find a suitable solution. We plan to review
`popen`'s design and get rid of `vfork` completely, or change `vfork` to `posix_spawn` only on macOS (#6674).

Closes #6576