### PR TITLE
extendable authentication via on_auth trigger

### DIFF
--- a/src/box/authentication.cc
+++ b/src/box/authentication.cc
@@ -111,6 +111,7 @@ authenticate(const char *user_name, uint32_t len, const char *salt,
 			struct user *user = user_by_id(uid);
 			if (user != NULL) {
 				credentials_reset(&session->credentials, user);
+				session->credentials.universal_access |= PRIV_U;
 				return;
 			}
 		}

--- a/src/box/authentication.h
+++ b/src/box/authentication.h
@@ -41,6 +41,10 @@ struct on_auth_trigger_ctx {
 	const char *username;
 	/* true if authentication was successful */
 	bool is_authenticated;
+
+	/* customized authentication artifacts */
+	const char *salt;
+	const char *scramble;
 };
 
 

--- a/src/box/session.cc
+++ b/src/box/session.cc
@@ -248,7 +248,7 @@ session_run_on_connect_triggers(struct session *session)
 }
 
 int
-session_run_on_auth_triggers(const struct on_auth_trigger_ctx *result)
+session_run_on_auth_triggers(struct on_auth_trigger_ctx *result)
 {
 	return trigger_run(&session_on_auth, (void *)result);
 }

--- a/src/box/session.h
+++ b/src/box/session.h
@@ -317,7 +317,7 @@ session_run_on_disconnect_triggers(struct session *session);
 
 /** Run auth triggers */
 int
-session_run_on_auth_triggers(const struct on_auth_trigger_ctx *result);
+session_run_on_auth_triggers(struct on_auth_trigger_ctx *result);
 
 /**
  * Check whether or not the current user is authorized to connect


### PR DESCRIPTION
```lua
box.session.on_auth(function(uname, is_ok, salt, scramble)
   if uname == 'test' then
      return 'super'
   end
end, box.session.on_auth()[1])
```
```bash
$ tarantoolctl connect bad_test:test@127.0.0.1:3301
User 'bad_test' is not found
$ tarantoolctl connect test:test@127.0.0.1:3301
connected to 127.0.0.1:3301
127.0.0.1:3301> box.session.user()
---
- super
...
```