### PR TITLE
build: fix linking of debug curl library

### DIFF
--- a/cmake/BuildLibCURL.cmake
+++ b/cmake/BuildLibCURL.cmake
@@ -149,6 +149,10 @@ macro(curl_build)
     # link hardening fails.
     list(APPEND LIBCURL_CMAKE_FLAGS "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
 
+    # For debug builds: name the library as libcurl.a, not
+    # libcurl-d.a. We use this name below.
+    list(APPEND LIBCURL_CMAKE_FLAGS "-DCMAKE_DEBUG_POSTFIX=")
+
     include(ExternalProject)
     ExternalProject_Add(
         bundled-libcurl-project


### PR DESCRIPTION
```
[100%] Linking C static library libcurl-d.a
<...>
make[3]: *** No rule to make target `build/curl/dest/lib/libcurl.a',
    needed by `test/unit/luaL_iterator.test'. Stop.
```

The problem appears on Mac OS. It is a bit strange that we don't see it
on Linux. However I didn't dig into this, just fixed the observed
problem.

Related: https://github.com/curl/curl/issues/2121

Fixes #6656