### PR TITLE
test: mark #6198 test `long run`

### DIFF
--- a/test/box-tap/suite.ini
+++ b/test/box-tap/suite.ini
@@ -4,6 +4,7 @@ description = Database tests with #! using TAP
 is_parallel = True
 use_unix_sockets_iproto = True
 release_disabled = errinj_set_with_enviroment_vars.test.lua
+long_run = gh-6198-max-cnt-of-tuple-fields-insert-overflow-err-msg.test.lua
 config = suite.cfg
 fragile = {
     "retries": 10,


### PR DESCRIPTION
Test for #6198 handles an edge case (`box.schema.FIELD_MAX` tuple
field count), hence consuming a huge amount of memory (see #6684): mark
it as `long run`.

Closes #6684