### PR TITLE
log: per-module-logging. The name of the module is in the logs.

### DIFF
--- a/extra/exports
+++ b/extra/exports
@@ -385,6 +385,7 @@ say_logrotate
 say_parse_logger_type
 say_set_log_format
 say_set_log_level
+say_with_module
 SHA1internal
 space_bsize
 space_by_id

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -134,10 +134,11 @@ local default_cfg = {
 -- cfg variables which are covered by modules
 local module_cfg = {
     -- logging
-    log                 = log.box_api,
-    log_nonblock        = log.box_api,
-    log_level           = log.box_api,
-    log_format          = log.box_api,
+    log                   = log.box_api,
+    log_nonblock          = log.box_api,
+    log_print_module_name = log.box_api,
+    log_level             = log.box_api,
+    log_format            = log.box_api,
 }
 
 -- cfg types for modules, probably better to
@@ -150,10 +151,11 @@ local module_cfg = {
 -- type or a combination of types here.
 local module_cfg_type = {
     -- logging
-    log                 = 'string',
-    log_nonblock        = 'boolean',
-    log_level           = 'number, string',
-    log_format          = 'string',
+    log                   = 'string',
+    log_nonblock          = 'boolean',
+    log_print_module_name = 'boolean',
+    log_level             = 'number, string',
+    log_format            = 'string',
 }
 
 -- types of available options
@@ -189,10 +191,11 @@ local template_cfg = {
     vinyl_page_size           = 'number',
     vinyl_bloom_fpr           = 'number',
 
-    log                 = 'module',
-    log_nonblock        = 'module',
-    log_level           = 'module',
-    log_format          = 'module',
+    log                   = 'module',
+    log_nonblock          = 'module',
+    log_print_module_name = 'module',
+    log_level             = 'module',
+    log_format            = 'module',
 
     audit_log           = 'string',
     audit_nonblock      = 'boolean',

--- a/src/lib/core/say.c
+++ b/src/lib/core/say.c
@@ -1286,7 +1286,7 @@ log_vsay(struct log *log, int level, const char* module_name, const char *filena
 		log->on_log(level, filename, line, error, format, ap_copy);
 		va_end(ap_copy);
 	}
-	if (level > log->level) {
+	if (module_name == NULL && level > log->level) {
 		return 0;
 	}
 	int total = log->format_func(log, buf, sizeof(buf), level, module_name,

--- a/src/lua/init.lua
+++ b/src/lua/init.lua
@@ -122,7 +122,6 @@ require = function(modname)
     return old_require(modname)
 end
 
-
 local package_searchroot
 
 local function searchroot()

--- a/src/lua/log.lua
+++ b/src/lua/log.lua
@@ -144,17 +144,19 @@ local log_cfg = {
 -- back. Make sure all required fields
 -- are covered!
 local log2box_keys = {
-    ['log']             = 'log',
-    ['nonblock']        = 'log_nonblock',
-    ['level']           = 'log_level',
-    ['format']          = 'log_format',
+    ['log']                 = 'log',
+    ['nonblock']            = 'log_nonblock',
+    ['print_module_name']   = 'log_print_module_name',
+    ['format']              = 'log_format',
+    ['level']               = 'log_level',
 }
 
 local box2log_keys = {
-    ['log']             = 'log',
-    ['log_nonblock']    = 'nonblock',
-    ['log_level']       = 'level',
-    ['log_format']      = 'format',
+    ['log']                      = 'log',
+    ['log_nonblock']             = 'nonblock',
+    ['log_print_module_name']    = 'print_module_name',
+    ['log_level']                = 'level',
+    ['log_format']               = 'format',
 }
 
 -- Update cfg value(s) in box.cfg instance conditionally
@@ -186,8 +188,9 @@ end
 
 -- Log options which can be set ony once.
 local cfg_static_keys = {
-    log         = true,
-    nonblock    = true,
+    log               = true,
+    nonblock          = true,
+    print_module_name = true,
 }
 
 -- Test if static key is not changed.
@@ -592,6 +595,12 @@ local function load_cfg(self, cfg)
         end
     end
 
+    if cfg.print_module_name ~= nil then
+        if type(cfg.print_module_name) ~= 'boolean' then
+            error("log.cfg: 'print_module_name' option must be 'true' or 'false'")
+        end
+    end
+
     if ffi.C.say_logger_initialized() == true then
         return reload_cfg(cfg)
     end
@@ -599,6 +608,7 @@ local function load_cfg(self, cfg)
     cfg.level = cfg.level or log_cfg.level
     cfg.format = cfg.format or log_cfg.format
     cfg.nonblock = cfg.nonblock or log_cfg.nonblock
+    cfg.print_module_name = cfg.print_module_name or log_cfg.print_module_name
 
     -- nonblock is special: it has to become integer
     -- for ffi call but in config we have to save
@@ -633,6 +643,7 @@ local function load_cfg(self, cfg)
     rawset(log_cfg, 'log', cfg.log)
     rawset(log_cfg, 'level', cfg.level)
     rawset(log_cfg, 'nonblock', nonblock)
+    rawset(log_cfg, 'print_module_name', cfg.print_module_name)
     rawset(log_cfg, 'format', cfg.format)
 
     -- and box.cfg output as well.

--- a/src/lua/log.lua
+++ b/src/lua/log.lua
@@ -1,8 +1,9 @@
 -- log.lua
 --
+local debug = require('debug')
 local ffi = require('ffi')
 ffi.cdef[[
-    typedef void (*sayfunc_t)(int level, const char *filename, int line,
+    typedef void (*sayfunc_t)(int level, const char *module_name, const char *filename, int line,
                const char *error, const char *format, ...);
 
     enum say_logger_type {
@@ -28,6 +29,10 @@ ffi.cdef[[
 
     extern bool
     say_logger_initialized(void);
+
+    extern void
+    say_with_module(int level, const char *module_name, const char *filename, int line,
+                    const char *error, const char *format, ...);
 
     extern sayfunc_t _say;
     extern struct ev_loop;
@@ -128,10 +133,11 @@ end
 -- Default options. The keys are part of
 -- user API , so change with caution.
 local log_cfg = {
-    log             = nil,
-    nonblock        = nil,
-    level           = S_INFO,
-    format          = fmt_num2str[ffi.C.SF_PLAIN],
+    log               = nil,
+    nonblock          = nil,
+    print_module_name = false,
+    level             = S_INFO,
+    format            = fmt_num2str[ffi.C.SF_PLAIN],
 }
 
 -- Name mapping from box to log module and
@@ -261,11 +267,21 @@ local function verify_level(key, level)
     return true
 end
 
+-- Test if module_name is a valid string.
+local function verify_module_name(module_name)
+    if type(module_name) ~= 'string' then
+        return false, "must be a string"
+    end
+
+    return true
+end
+
 local verify_ops = {
-    ['log']         = verify_static,
-    ['nonblock']    = verify_static,
-    ['format']      = verify_format,
-    ['level']       = verify_level,
+    ['log']                 = verify_static,
+    ['nonblock']            = verify_static,
+    ['print_module_name']   = verify_static,
+    ['format']              = verify_format,
+    ['level']               = verify_level,
 }
 
 -- Verify a value for the particular key.
@@ -280,7 +296,7 @@ local function verify_option(k, v, ...)
 end
 
 -- Main routine which pass data to C logging code.
-local function say(level, fmt, ...)
+local function say(self, level, fmt, ...)
     if ffi.C.log_level < level then
         -- don't waste cycles on debug.getinfo()
         return
@@ -307,7 +323,6 @@ local function say(level, fmt, ...)
         fmt = tostring(fmt)
     end
 
-    local debug = require('debug')
     local frame = debug.getinfo(3, "Sl")
     local line, file = 0, 'eval'
     if type(frame) == 'table' then
@@ -315,13 +330,21 @@ local function say(level, fmt, ...)
         file = frame.short_src or frame.src or 'eval'
     end
 
-    ffi.C._say(level, file, line, nil, format, fmt)
+    local module_name = box.NULL
+    if (log_cfg.print_module_name) then
+        if (self ~= nil) then
+            module_name = self.module_name
+        else
+            module_name = "log"
+        end
+    end
+    ffi.C.say_with_module(level, module_name, file, line, nil, format, fmt)
 end
 
 -- Just a syntactic sugar over say routine.
-local function say_closure(lvl)
+local function say_closure(lvl, self)
     return function (fmt, ...)
-        say(lvl, fmt, ...)
+        say(self, lvl, fmt, ...)
     end
 end
 
@@ -344,7 +367,7 @@ local function set_log_level(level, update_box_cfg)
     end
 
     local m = "log: level set to %s"
-    say(S_DEBUG, m:format(level))
+    say_closure(S_DEBUG, nil)(m:format(level))
 end
 
 -- Tries to set a new level, or print an error.
@@ -378,7 +401,7 @@ local function set_log_format(name, update_box_cfg)
     end
 
     local m = "log: format set to '%s'"
-    say(S_DEBUG, m:format(name))
+    say_closure(S_DEBUG, nil)(m:format(name))
 end
 
 -- Tries to set a new format, or print an error.
@@ -434,14 +457,14 @@ end
 function Ratelimit:log_check(lvl)
     local suppressed, ok = self:check()
     if lvl >= S_WARN and suppressed > 0 then
-        say(S_WARN, '%d messages suppressed due to rate limiting', suppressed)
+        say_closure(S_WARN, nil)('%d messages suppressed due to rate limiting', suppressed)
     end
     return ok
 end
 
 function Ratelimit:log(lvl, fmt, ...)
     if self:log_check(lvl) then
-        say(lvl, fmt, ...)
+        say_closure(lvl, nil)(fmt, ...)
     end
 end
 
@@ -615,8 +638,8 @@ local function load_cfg(self, cfg)
     -- and box.cfg output as well.
     box_cfg_update()
 
-    local m = "log.cfg({log=%s,level=%s,nonblock=%s,format=\'%s\'})"
-    say(S_DEBUG, m:format(cfg.log, cfg.level, cfg.nonblock, cfg.format))
+    local m = "log.cfg({log=%s,level=%s,nonblock=%s,print_module_name=%s,format=\'%s\'})"
+    say_closure(S_DEBUG, nil)(m:format(cfg.log, cfg.level, cfg.nonblock, cfg.print_module_name, cfg.format))
 end
 
 local compat_warning_said = false
@@ -624,21 +647,17 @@ local compat_v16 = {
     logger_pid = function()
         if not compat_warning_said then
             compat_warning_said = true
-            say(S_WARN, 'logger_pid() is deprecated, please use pid() instead')
+            say_closure(S_WARN, nil)('logger_pid() is deprecated, please use pid() instead')
         end
         return log_pid()
     end;
 }
 
 local log = {
-    warn = say_closure(S_WARN),
-    info = say_closure(S_INFO),
-    verbose = say_closure(S_VERBOSE),
-    debug = say_closure(S_DEBUG),
-    error = say_closure(S_ERROR),
     rotate = log_rotate,
     pid = log_pid,
     level = log_level,
+    module_name = "tarantool",
     log_format = log_format,
     cfg = setmetatable(log_cfg, {
         __call = load_cfg,
@@ -654,13 +673,47 @@ local log = {
     }
 }
 
+-- Set new logging module name, the module name must be valid!
+local function set_module_name(self, module_name)
+    self.module_name = module_name
+end
+
+-- Tries to set a new module name, or print an error.
+local function log_module_name(self, module_name)
+    local ok, msg = verify_module_name(module_name)
+    if not ok then
+        error(msg)
+    end
+
+    set_module_name(self, module_name)
+end
+
+
+function log:new(module_name)
+    log_module_name(self, module_name)
+end
+
 setmetatable(log, {
     __serialize = function(self)
         local res = table.copy(self)
         res.box_api = nil
         return setmetatable(res, {})
     end,
-    __index = compat_v16;
+    __index = function(self, key)
+        if key == 'info' then
+            return say_closure(S_INFO, self)
+        elseif key == 'warn' then
+            return say_closure(S_WARN, self)
+        elseif key == 'verbose' then
+            return say_closure(S_VERBOSE, self)
+        elseif key == 'debug' then
+            return say_closure(S_DEBUG, self)
+        elseif key == 'error' then
+            return say_closure(S_ERROR, self)
+        elseif key == 'logger_pid' then
+            return compat_v16.logger_pid
+        end
+    end
 })
 
 return log

--- a/test/app-tap/init_script.result
+++ b/test/app-tap/init_script.result
@@ -33,7 +33,6 @@ iproto_threads:1
 listen:port
 log:tarantool.log
 log_format:plain
-log_level:5
 log_print_module_name:false
 memtx_allocator:small
 memtx_dir:.

--- a/test/app-tap/init_script.result
+++ b/test/app-tap/init_script.result
@@ -34,6 +34,7 @@ listen:port
 log:tarantool.log
 log_format:plain
 log_level:5
+log_print_module_name:false
 memtx_allocator:small
 memtx_dir:.
 memtx_max_tuple_size:1048576

--- a/test/app-tap/logmod.test.lua
+++ b/test/app-tap/logmod.test.lua
@@ -9,28 +9,28 @@ log.log_format('plain')
 
 -- Test symbolic names for loglevels
 local _, err = pcall(log.cfg, {level='fatal'})
-test:ok(err == nil and log.cfg.level == 0, 'both got fatal')
+test:ok(err == nil and log.cfg.level.default == 0, 'both got fatal')
 
 _, err = pcall(log.cfg, {level='syserror'})
-test:ok(err == nil and log.cfg.level == 1, 'got syserror')
+test:ok(err == nil and log.cfg.level.default == 1, 'got syserror')
 
 _, err = pcall(log.cfg, {level='error'})
-test:ok(err == nil and log.cfg.level == 2, 'got error')
+test:ok(err == nil and log.cfg.level.default == 2, 'got error')
 
 _, err = pcall(log.cfg, {level='crit'})
-test:ok(err == nil and log.cfg.level == 3, 'got crit')
+test:ok(err == nil and log.cfg.level.default == 3, 'got crit')
 
 _, err = pcall(log.cfg, {level='warn'})
-test:ok(err == nil and log.cfg.level == 4, 'got warn')
+test:ok(err == nil and log.cfg.level.default == 4, 'got warn')
 
 _, err = pcall(log.cfg, {level='info'})
-test:ok(err == nil and log.cfg.level == 5, 'got info')
+test:ok(err == nil and log.cfg.level.default == 5, 'got info')
 
 _, err = pcall(log.cfg, {level='verbose'})
-test:ok(err == nil and log.cfg.level == 6, 'got verbose')
+test:ok(err == nil and log.cfg.level.default == 6, 'got verbose')
 
 _, err = pcall(log.cfg, {level='debug'})
-test:ok(err == nil and log.cfg.level == 7, 'got debug')
+test:ok(err == nil and log.cfg.level.default == 7, 'got debug')
 
 test:check()
 os.exit()

--- a/test/box-luatest/gh_3211_modules/testmod.lua
+++ b/test/box-luatest/gh_3211_modules/testmod.lua
@@ -1,0 +1,41 @@
+-- luacheck: globals old_require_testmod_1
+old_require_testmod_1 = require
+
+require = function(modname)
+    print('modname require 2 = ', modname)
+    local module = old_require_testmod_1(modname)
+    return module
+end
+
+-- luacheck: globals old_require_testmod_2
+old_require_testmod_2 = require
+
+require = function(modname)
+    print('modname require 3 = ', modname)
+    local module = old_require_testmod_2(modname)
+    return module
+end
+
+-- luacheck: globals old_require_testmod_3
+old_require_testmod_3 = require
+
+require = function(modname)
+    print('modname require 4 = ', modname)
+    local module = old_require_testmod_3(modname)
+    return module
+end
+
+local log = require("log")
+
+local function make_logs()
+    log.info("info message from testmod")
+    log.error("error message from testmod")
+    log.debug("debug message from testmod")
+end
+
+
+local testmod = {
+    make_logs       = make_logs,
+}
+
+return testmod

--- a/test/box-luatest/gh_3211_modules/testmod2.lua
+++ b/test/box-luatest/gh_3211_modules/testmod2.lua
@@ -1,0 +1,25 @@
+old_require_testmod2 = require
+
+require = function(modname)
+    print('modname require 5 = ', modname)
+    local module = old_require_testmod2(modname)
+    return module
+end
+
+local testmod = require("test.box-luatest.gh_3211_modules.testmod")
+local log = require("log")
+
+
+local function make_logs()
+    log.info("info message from testmod2")
+    log.error("error message from testmod2")
+
+    testmod.make_logs()
+end
+
+
+local testmod2 = {
+    make_logs       = make_logs,
+}
+
+return testmod2

--- a/test/box-luatest/gh_3211_modules/testmod3.lua
+++ b/test/box-luatest/gh_3211_modules/testmod3.lua
@@ -1,0 +1,21 @@
+old_require_testmod3 = require
+require = function(modname)
+    print('modname require testmod3 = ', modname)
+    local module = old_require_testmod3(modname)
+    return module
+end
+
+local log = require("log")
+
+local function make_logs()
+    log.info("info message from testmod3")
+    log.error("error message from testmod3")
+    log.debug("debug message from testmod3")
+end
+
+
+local testmod3 = {
+    make_logs       = make_logs,
+}
+
+return testmod3

--- a/test/box-luatest/gh_3211_per_module_logging_test.lua
+++ b/test/box-luatest/gh_3211_per_module_logging_test.lua
@@ -1,0 +1,113 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+local function module_name_is_in_logs(logs_module_name, level)
+    t.helpers.retrying({timeout = 0.3, delay = 0.1}, function()
+        local msg = logs_module_name .. " " .. level .. ">"
+        t.assert(g.server:grep_log(msg))
+    end)
+end
+
+local function configure_server_with_printing_module()
+    g.server = server:new({alias = 'with_option',
+                           box_cfg = {log_print_module_name=true}})
+    g.server:start()
+end
+
+g.before_test("test_with_option", configure_server_with_printing_module)
+g.after_test("test_with_option", function() g.server:drop() end)
+
+g.test_with_option = function()
+    g.server:exec(function()
+        testmod = require('test.box-luatest.gh_3211_modules.testmod')
+        testmod.make_logs()
+    end)
+    module_name_is_in_logs('testmod', "I")
+end
+
+g.before_test("test_without_option", function()
+    g.server = server:new({alias = 'without_option'})
+    g.server:start()
+end)
+g.after_test("test_without_option", function() g.server:drop() end)
+
+g.test_without_option = function()
+    t.xfail('Must fail because log_print_module_name=false by default')
+    g.test_with_option()
+end
+
+g.before_test("test_is_local_for_each_module", configure_server_with_printing_module)
+g.after_test("test_is_local_for_each_module", function() g.server:drop() end)
+
+g.test_is_local_for_each_module = function()
+    g.server:exec(function()
+        testmod = require('test.box-luatest.gh_3211_modules.testmod')
+        testmod3 = require('test.box-luatest.gh_3211_modules.testmod3')
+        testmod3.make_logs()
+        testmod.make_logs()
+    end)
+    module_name_is_in_logs('testmod', "I")
+end
+
+g.before_test("test_module_with_other_modules", configure_server_with_printing_module)
+g.after_test("test_module_with_other_modules", function() g.server:drop() end)
+
+g.test_module_with_other_modules = function()
+    g.server:exec(function()
+        testmod2 = require('test.box-luatest.gh_3211_modules.testmod2')
+        testmod2.make_logs()
+    end)
+    module_name_is_in_logs('testmod2', "I")
+    module_name_is_in_logs('testmod', "I")
+end
+
+g.before_test("test_expirationd", function()
+    configure_server_with_printing_module()
+    g.server:exec(function()
+        local s = box.schema.space.create('test')
+        s:format({
+            {name = 'id',   type = 'unsigned'},
+            {name = 'data', type = 'string'},
+        })
+        s:create_index('primary', {parts = {'id'}})
+        box.schema.user.grant('guest', 'read,write', 'space', 'test')
+        box.space.test:insert({1, "some data"})
+    end)
+end)
+g.after_test("test_expirationd", function()
+    g.server:exec(function()
+        local s = box.space.test
+        if s then
+            s:drop()
+        end
+    end)
+    g.server:drop()
+end)
+
+g.test_expirationd = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local space = box.space.test
+        local job_name = "clean_all"
+        local status, expirationd = pcall(require,"expirationd")
+
+        t.skip_if(not status, expirationd)
+
+        local function is_expired(args, tuple)
+            return true
+        end
+
+        local function delete_tuple(space_id, args, tuple)
+            box.space[space_id]:delete{tuple[1]}
+        end
+
+        expirationd.start(job_name, space.id, is_expired, {
+            process_expired_tuple = delete_tuple,
+            args = nil,
+            tuples_per_iteration = 50,
+            full_scan_time = 3600
+        })
+    end)
+    module_name_is_in_logs('expirationd', "I")
+end

--- a/test/box/admin.result
+++ b/test/box/admin.result
@@ -88,7 +88,8 @@ cfg_filter(box.cfg)
   - - log_format
     - plain
   - - log_level
-    - 5
+    - - - default
+        - 5
   - - log_print_module_name
     - false
   - - memtx_allocator

--- a/test/box/admin.result
+++ b/test/box/admin.result
@@ -89,6 +89,8 @@ cfg_filter(box.cfg)
     - plain
   - - log_level
     - 5
+  - - log_print_module_name
+    - false
   - - memtx_allocator
     - <hidden>
   - - memtx_dir

--- a/test/box/cfg.result
+++ b/test/box/cfg.result
@@ -77,6 +77,8 @@ cfg_filter(box.cfg)
  |     - plain
  |   - - log_level
  |     - 5
+ |   - - log_print_module_name
+ |     - false
  |   - - memtx_allocator
  |     - <hidden>
  |   - - memtx_dir
@@ -236,6 +238,8 @@ cfg_filter(box.cfg)
  |     - plain
  |   - - log_level
  |     - 5
+ |   - - log_print_module_name
+ |     - false
  |   - - memtx_allocator
  |     - <hidden>
  |   - - memtx_dir

--- a/test/box/cfg.result
+++ b/test/box/cfg.result
@@ -76,7 +76,8 @@ cfg_filter(box.cfg)
  |   - - log_format
  |     - plain
  |   - - log_level
- |     - 5
+ |     - - - default
+ |         - 5
  |   - - log_print_module_name
  |     - false
  |   - - memtx_allocator
@@ -237,7 +238,8 @@ cfg_filter(box.cfg)
  |   - - log_format
  |     - plain
  |   - - log_level
- |     - 5
+ |     - - - default
+ |         - 5
  |   - - log_print_module_name
  |     - false
  |   - - memtx_allocator

--- a/test/box/misc.result
+++ b/test/box/misc.result
@@ -1022,7 +1022,7 @@ tuple_format = box.internal.new_tuple_format(format)
 box.cfg{}
 ---
 ...
-local ffi = require'ffi' ffi.C._say(ffi.C.S_WARN, nil, 0, nil, "%s", "test log")
+local ffi = require'ffi' ffi.C._say(ffi.C.S_WARN, nil, nil, 0, nil, "%s", "test log")
 ---
 ...
 test_run:grep_log('default', 'test log')

--- a/test/box/misc.test.lua
+++ b/test/box/misc.test.lua
@@ -346,7 +346,7 @@ tuple_format = box.internal.new_tuple_format(format)
 -- segfault
 --
 box.cfg{}
-local ffi = require'ffi' ffi.C._say(ffi.C.S_WARN, nil, 0, nil, "%s", "test log")
+local ffi = require'ffi' ffi.C._say(ffi.C.S_WARN, nil, nil, 0, nil, "%s", "test log")
 test_run:grep_log('default', 'test log')
 
 --

--- a/test/unit/say.c
+++ b/test/unit/say.c
@@ -52,13 +52,14 @@ parse_syslog_opts(const char *input)
 
 static int
 format_func_custom(struct log *log, char *buf, int len, int level,
-		   const char *filename, int line, const char *error,
-		   const char *format, va_list ap)
+           const char* module_name, const char *filename, int line,
+           const char *error, const char *format, va_list ap)
 {
 	int total = 0;
 	(void) log;
 	(void) level;
 	(void) filename;
+	(void) module_name;
 	(void) line;
 	(void) error;
 	SNPRINT(total, snprintf, buf, len, "\"msg\" = \"");
@@ -211,11 +212,11 @@ int main()
 	struct log test_log;
 	log_create(&test_log, tmp_filename, false);
 	log_set_format(&test_log, say_format_plain);
-	log_say(&test_log, 0, NULL, 0, NULL, "hello %s\n", "user");
+	log_say(&test_log, 0, NULL, NULL, 0, NULL, "hello %s\n", "user");
 	log_set_format(&test_log, say_format_json);
-	log_say(&test_log, 0, NULL, 0, NULL, "hello %s", "user");
+	log_say(&test_log, 0, NULL, NULL, 0, NULL, "hello %s", "user");
 	log_set_format(&test_log, format_func_custom);
-	log_say(&test_log, 0, NULL, 0, NULL, "hello %s", "user");
+	log_say(&test_log, 0, NULL, NULL, 0, NULL, "hello %s", "user");
 
 	FILE* fd = fopen(tmp_filename, "r+");
 	const size_t len = 4096;
@@ -262,7 +263,7 @@ int main()
 	ok(test_log.syslog_facility == SYSLOG_LOCAL0, "parsed facility");
 	long before = ftell(fd);
 	ok(before >= 0, "ftell");
-	ok(log_say(&test_log, 0, NULL, 0, NULL, "hello %s", "user") > 0, "log_say");
+	ok(log_say(&test_log, 0, NULL, NULL, 0, NULL, "hello %s", "user") > 0, "log_say");
 	ok(fseek(fd, before, SEEK_SET) >= 0, "fseek");
 
 	if (fgets(line, len, fd) != NULL) {


### PR DESCRIPTION
## Abstract
Now you can see in the logs the name of the module from which the logging
function was called. The name of the module is determined automatically
during the execution of `require('log')` in the module source code. You can
also set the module name yourself using the function `log:new('module_name')`.

To enable the output of the module name in the logs, you must enable the `log_print_module_name` option:
```lua
box.cfg{log_print_module_name=true}
```

## Determining the module name from the file name
To define a module, we process the name of the file from which `require('log')` was made (the file in which our module is defined) with the following algorithm:
* We remove the path prefixes contained in `package.path`, `package.cpath`, all subpaths to the current directory, `ROCKS_LIB_PATH`, `ROCKS_LUA_PATH`.
* Remove suffixes `/init.lua`, `.lua`, `.so`, `.dylib`.
* Replace all `/` with `.`.

This is done by the function `module_name_form_filename(src_name)`

## Dealing with the call stack
The function `module_name_by_func` takes as input the function level in the call stack and returns the name of the module in which the function is defined. With this function, the name of the module is defined. (It is called at runtime `require('log')` and converts the name of the file in which this line was written into the module name). 
```lua
local function module_name_by_func(func_level)
    local src_name = debug.getinfo(func_level + 1).source
    return module_name_form_filename(src_name)
end
```
### Behaviour in normal case
Normally, the level we pass is a constant value of 2, because we just want to convert the name of the file in which `require('log')` was called into the module name.
The call stack will now be:
`module_name_by_func <-require(our)<-require('log') in file`
----------^--------------2-----------------^------
```lua
old_require = require
require = function(modname)
     if modname == 'log' then
         local log = old_require(modname)
         local src_modname = module_name_by_func(2)
         log:new(src_modname)
     ...
     return old_require(modname)
end
```
### Multiple require override problem
Someone may want to override the standard `require` function in their module as follows:
```lua
external.lua

old_require_ext = require
require = function(modname)
    ...
    return old_require_ext(modname)
end
```
After requiring this module, the require function will be overrided twice. Because of this, when `require('log')` is called, the call stack will now be:
`module_name_by_func <-require(our)<-require(from external module)<-require('log') in file`
--------------^-----------------------------3-------------------------------^---------

Now if we still pass 2 to the function `module_name_by_func` we will convert the name of the file where the override is defined (external.lua) into the module name instead of the desired file. In general there can be more than one override. 

To fix the problem, we need to pass 2 instead of 2 to the function `module_name_by_func` 2 + the number of overloads. The algorithm above gets the number of overrides of the `require` function.

### Algorithm for solving multiple require override problem

There is an algorithm for solving the multiple `require` override problem:

#### Idea
The idea is to compare the two call stacks inside our `require` overload to find out the number of overloads. The first call stack is the call sequence that brought us to our overload. We get the second call stack by calling `require('log.internal')` inside our overload (this call will return us the call stack instead of the module). Knowing the number of overloads, we can calculate the level in the call stack where the information to produce the module name is located.

#### Implementation
```lua
local function wrapper_e6c2bafc7d0611ec8008db177bebd1df()
     return require('log.internal')
end

old_require = require
require = function(modname)
     if modname == 'log' then
         local log = old_require(modname)
         local stack_int = wrapper_e6c2bafc7d0611ec8008db177bebd1df()
         local overload_num = get_require_overload_num(stack_int)  -- looking for wrapper_e6c2bafc7d0611ec8008db177bebd1df
         log:new(module_name_by_func(2 + overload_num))
         return table.deepcopy(log)
     end
     if modname == 'log.internal' then
         return get_stack()
     end
     return old_require(modname)
 end
```

The  function `get_stack` returns a table with information about each stack frame.

For easier and more accurate implementation, the `require('log.internal')` call is wrapped in a function with a unique name (`wrapper_e6c2bafc7d0611ec8008db177bebd1df`). Then the `stack_int` will look like this: 
`require_our<-req_ovrl1<-req_ovrl2<-wrapper_e6c2b...<-require_our<-...`
---^-------------override number----------^---


We don't compare stacks, we just look for `wrapper_e6c2bafc7d0611ec8008db177bebd1df` in the stack obtained with `require('log.internal')` in order to count the number of overrides.


In the area of #3211