### PR TITLE
debian: eliminate dependency from binutils package

### DIFF
--- a/changelogs/unreleased/debian-remove-binutils-dependency.md
+++ b/changelogs/unreleased/debian-remove-binutils-dependency.md
@@ -1,0 +1,3 @@
+## bugfix/build
+
+* The Debian package does not depend on binutils anymore (gh-6699).

--- a/debian/control
+++ b/debian/control
@@ -66,7 +66,7 @@ Description: Tarantool in-memory database - common files
 Package: tarantool
 Architecture: i386 amd64 armhf arm64
 Priority: optional
-Depends: ${shlibs:Depends}, ${misc:Depends}, netbase, binutils, libgomp1,
+Depends: ${shlibs:Depends}, ${misc:Depends}, netbase, libgomp1,
   openssl, tarantool-common (>= 2.2.1),
 # libcurl dependencies (except ones we have already)
  zlib1g


### PR DESCRIPTION
tarantool debian package MUST NOT depends on binutils package.
This is due to the fact that binutils include linker and assembler,
what in most cases forbidden on production servers.

Fixes #6699