### PR TITLE
ci: verify changelog entries in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: luacheck
+name: lint
 
 on:
   push:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,3 +57,29 @@ jobs:
           TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
         uses: ./.github/actions/send-telegram-notify
         if: failure()
+
+  release-notes:
+    # Run on pull request only if the 'notest' label is unset and this is
+    # an external PR (internal PRs trigger a run on push).
+    if: github.event_name != 'pull_request' ||
+        ( ! contains(github.event.pull_request.labels.*.name, 'notest') &&
+          github.event.pull_request.head.repo.full_name != github.repository )
+
+    runs-on: ubuntu-20.04-self-hosted
+
+    steps:
+      # We don't need neither deep fetch, nor submodules here.
+      - uses: actions/checkout@v2.3.4
+      # Don't use actions/setup-python to don't bother with proper
+      # setup of our self-hosted machines, see [1].
+      #
+      # Any python version is okay for the script, even Python 2.
+      #
+      # [1]: https://github.com/actions/setup-python#using-setup-python-with-a-self-hosted-runner
+      - run: ./tools/gen-release-notes
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()

--- a/changelogs/unreleased/change-transaction-behaviour-after-rollback-on-yield.md
+++ b/changelogs/unreleased/change-transaction-behaviour-after-rollback-on-yield.md
@@ -1,4 +1,4 @@
-## core/feature
+## feature/core
 
 * Previously, if a yield occurs for a transaction that does not
   support it, we roll back all its statements, but still process

--- a/changelogs/unreleased/drop-net-box-console.md
+++ b/changelogs/unreleased/drop-net-box-console.md
@@ -3,5 +3,6 @@
 * **[Breaking change]** net.box console support, which was marked deprecated
   in 1.10, was dropped. Use `require('console').connect()` instead.
 
----
+----
+
 Breaking change: net.box console support was dropped.

--- a/changelogs/unreleased/gh-5814-memprof-group-allocation-on-traces.md
+++ b/changelogs/unreleased/gh-5814-memprof-group-allocation-on-traces.md
@@ -1,4 +1,4 @@
-##feature/luajit
+## feature/luajit
 
 * Now memory profiler records allocations from traces grouping them by the
   trace number (gh-5814). The memory profiler parser can display the new type

--- a/changelogs/unreleased/gh-6242-net-box-drop-conn-timeout.md
+++ b/changelogs/unreleased/gh-6242-net-box-drop-conn-timeout.md
@@ -5,5 +5,6 @@
   it negatively affected performance of hot net.box methods, like call() and
   select(), in case those are called without specifying a timeout (gh-6242).
 
----
+----
+
 Breaking change: timeout() method of net.box connection was dropped.


### PR DESCRIPTION
It should make development a bit more friendly: CI will assist with keeping release notes buildable.

The `gen-release-notes` script is written with care to error messages and if it raises an error it should be quite easy to find a cause and fix it. It does not check Markdown syntax and spelling, though: just ability to build the document from files.

The most often mistake is around section header format: `## feature/<...>` or `## bugfix/<...>`.

Just a reminder: if you want to see how your changelog entry will look in a future release notes, just run `./tools/gen-release-notes`. Don't hesitate to the changelog after a push to master: it is information for our users and there is nothing bad in making it better.