### PR TITLE
ci: reduce amount of boilerplate code in workflows

### DIFF
--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/centos_7_aarch64.yml
+++ b/.github/workflows/centos_7_aarch64.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: graviton
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/centos_7_aarch64.yml
+++ b/.github/workflows/centos_7_aarch64.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: graviton
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/centos_8_aarch64.yml
+++ b/.github/workflows/centos_8_aarch64.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: graviton
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/centos_8_aarch64.yml
+++ b/.github/workflows/centos_8_aarch64.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: graviton
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -25,12 +25,6 @@ jobs:
       options: '--init'
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v1
       - uses: ./.github/actions/environment
       - name: test

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -14,9 +14,6 @@ jobs:
   coverity:
     runs-on: ubuntu-18.04
 
-    strategy:
-      fail-fast: false
-
     # Image built by .gitlab.mk instructions and targets from .travis.mk.
     # Also additional installation of coverity tool installation check
     # exists in target deps_coverity_debian at .travis.mk file.

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/debian_10_aarch64.yml
+++ b/.github/workflows/debian_10_aarch64.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: graviton
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/debian_10_aarch64.yml
+++ b/.github/workflows/debian_10_aarch64.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: graviton
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/debian_11_aarch64.yml
+++ b/.github/workflows/debian_11_aarch64.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: graviton
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/debian_11_aarch64.yml
+++ b/.github/workflows/debian_11_aarch64.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: graviton
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -45,9 +45,6 @@ jobs:
 
     runs-on: graviton
 
-    strategy:
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v1
       - uses: ./.github/actions/environment

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -46,7 +46,10 @@ jobs:
     runs-on: graviton
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
       - uses: ./.github/actions/environment
       - name: test
         env:

--- a/.github/workflows/debug_coverage.yml
+++ b/.github/workflows/debug_coverage.yml
@@ -44,9 +44,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/debug_coverage.yml
+++ b/.github/workflows/debug_coverage.yml
@@ -45,12 +45,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       # Finds an associated PR (PR can be detected only on push and never on pull_request).
       # WARNING !!! use in these ways only:
       #   on push: steps.findPr.outputs.pr

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -46,12 +46,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -45,9 +45,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/fedora_30.yml
+++ b/.github/workflows/fedora_30.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/fedora_30.yml
+++ b/.github/workflows/fedora_30.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_31.yml
+++ b/.github/workflows/fedora_31.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/fedora_31.yml
+++ b/.github/workflows/fedora_31.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_32.yml
+++ b/.github/workflows/fedora_32.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/fedora_32.yml
+++ b/.github/workflows/fedora_32.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_33.yml
+++ b/.github/workflows/fedora_33.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/fedora_33.yml
+++ b/.github/workflows/fedora_33.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_33_aarch64.yml
+++ b/.github/workflows/fedora_33_aarch64.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: graviton
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/fedora_33_aarch64.yml
+++ b/.github/workflows/fedora_33_aarch64.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: graviton
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_34_aarch64.yml
+++ b/.github/workflows/fedora_34_aarch64.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: graviton
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/fedora_34_aarch64.yml
+++ b/.github/workflows/fedora_34_aarch64.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: graviton
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/freebsd-12.yml
+++ b/.github/workflows/freebsd-12.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: freebsd-12-mcs
 
-    strategy:
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/freebsd-13.yml
+++ b/.github/workflows/freebsd-13.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: freebsd-13-mcs
 
-    strategy:
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/jepsen-cluster-txm.yml
+++ b/.github/workflows/jepsen-cluster-txm.yml
@@ -15,9 +15,6 @@ jobs:
 
     runs-on: ubuntu-18.04
 
-    strategy:
-      fail-fast: false
-
     # image built by .gitlab.mk instructions and targets from .travis.mk
     container:
       image: docker.io/tarantool/testing:debian-stretch

--- a/.github/workflows/jepsen-cluster.yml
+++ b/.github/workflows/jepsen-cluster.yml
@@ -15,9 +15,6 @@ jobs:
 
     runs-on: ubuntu-18.04
 
-    strategy:
-      fail-fast: false
-
     # image built by .gitlab.mk instructions and targets from .travis.mk
     container:
       image: docker.io/tarantool/testing:debian-stretch

--- a/.github/workflows/jepsen-single-instance-txm.yml
+++ b/.github/workflows/jepsen-single-instance-txm.yml
@@ -22,9 +22,6 @@ jobs:
 
     runs-on: ubuntu-18.04
 
-    strategy:
-      fail-fast: false
-
     # image built by .gitlab.mk instructions and targets from .travis.mk
     container:
       image: docker.io/tarantool/testing:debian-stretch

--- a/.github/workflows/jepsen-single-instance.yml
+++ b/.github/workflows/jepsen-single-instance.yml
@@ -22,9 +22,6 @@ jobs:
 
     runs-on: ubuntu-18.04
 
-    strategy:
-      fail-fast: false
-
     # image built by .gitlab.mk instructions and targets from .travis.mk
     container:
       image: docker.io/tarantool/testing:debian-stretch

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -44,9 +44,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -45,12 +45,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -46,9 +46,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     # image built by .gitlab.mk instructions and targets from .travis.mk
     container:
       image: docker.io/tarantool/testing:debian-stretch

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -46,19 +46,14 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    # image built by .gitlab.mk instructions and targets from .travis.mk
-    container:
-      image: docker.io/tarantool/testing:debian-stretch
-      # Our testing expects that the init process (PID 1) will
-      # reap orphan processes. At least the following test leans
-      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-      options: '--init'
-
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
       - uses: ./.github/actions/environment
       - name: test
-        run: ${CI_MAKE} test_debian_no_deps
+        run: ${CI_MAKE} test_ubuntu_ghactions
       - name: call action to send Telegram message on failure
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/osx_10_15.yml
+++ b/.github/workflows/osx_10_15.yml
@@ -45,9 +45,6 @@ jobs:
 
     runs-on: macos-10.15
 
-    strategy:
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v2.3.4
         with:

--- a/.github/workflows/osx_10_15_lto.yml
+++ b/.github/workflows/osx_10_15_lto.yml
@@ -45,9 +45,6 @@ jobs:
 
     runs-on: macos-10.15
 
-    strategy:
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v2.3.4
         with:

--- a/.github/workflows/osx_11_0.yml
+++ b/.github/workflows/osx_11_0.yml
@@ -45,9 +45,6 @@ jobs:
 
     runs-on: macos-11.0
 
-    strategy:
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v2.3.4
         with:

--- a/.github/workflows/osx_arm64_11_2.yml
+++ b/.github/workflows/osx_arm64_11_2.yml
@@ -45,9 +45,6 @@ jobs:
 
     runs-on: macos-m1-11.2
 
-    strategy:
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v2.3.4
         with:

--- a/.github/workflows/osx_debug_arm64_11_2.yml
+++ b/.github/workflows/osx_debug_arm64_11_2.yml
@@ -45,9 +45,6 @@ jobs:
 
     runs-on: macos-m1-11.2
 
-    strategy:
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v2.3.4
         with:

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -46,12 +46,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -45,9 +45,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/perf_cbench.yml
+++ b/.github/workflows/perf_cbench.yml
@@ -19,9 +19,6 @@ jobs:
 
     runs-on: perf-sh2
 
-    strategy:
-      fail-fast: false
-
     steps:
       - name: set PATH to GIT of the newer version 2.9.0
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH

--- a/.github/workflows/perf_linkbench_ssd.yml
+++ b/.github/workflows/perf_linkbench_ssd.yml
@@ -19,9 +19,6 @@ jobs:
 
     runs-on: perf-sh9
 
-    strategy:
-      fail-fast: false
-
     steps:
       - name: set PATH to GIT of the newer version 2.9.0
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH

--- a/.github/workflows/perf_nosqlbench_hash.yml
+++ b/.github/workflows/perf_nosqlbench_hash.yml
@@ -19,9 +19,6 @@ jobs:
 
     runs-on: perf-sh1
 
-    strategy:
-      fail-fast: false
-
     steps:
       - name: set PATH to GIT of the newer version 2.9.0
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH

--- a/.github/workflows/perf_nosqlbench_tree.yml
+++ b/.github/workflows/perf_nosqlbench_tree.yml
@@ -19,9 +19,6 @@ jobs:
 
     runs-on: perf-sh1
 
-    strategy:
-      fail-fast: false
-
     steps:
       - name: set PATH to GIT of the newer version 2.9.0
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH

--- a/.github/workflows/perf_sysbench.yml
+++ b/.github/workflows/perf_sysbench.yml
@@ -19,9 +19,6 @@ jobs:
 
     runs-on: perf-sh3
 
-    strategy:
-      fail-fast: false
-
     steps:
       - name: set PATH to GIT of the newer version 2.9.0
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH

--- a/.github/workflows/perf_tpcc.yml
+++ b/.github/workflows/perf_tpcc.yml
@@ -19,9 +19,6 @@ jobs:
 
     runs-on: perf-sh3
 
-    strategy:
-      fail-fast: false
-
     steps:
       - name: set PATH to GIT of the newer version 2.9.0
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH

--- a/.github/workflows/perf_tpch.yml
+++ b/.github/workflows/perf_tpch.yml
@@ -19,9 +19,6 @@ jobs:
 
     runs-on: perf-sh2
 
-    strategy:
-      fail-fast: false
-
     steps:
       - name: set PATH to GIT of the newer version 2.9.0
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH

--- a/.github/workflows/perf_ycsb_hash.yml
+++ b/.github/workflows/perf_ycsb_hash.yml
@@ -19,9 +19,6 @@ jobs:
 
     runs-on: perf-sh2
 
-    strategy:
-      fail-fast: false
-
     steps:
       - name: set PATH to GIT of the newer version 2.9.0
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH

--- a/.github/workflows/perf_ycsb_tree.yml
+++ b/.github/workflows/perf_ycsb_tree.yml
@@ -19,9 +19,6 @@ jobs:
 
     runs-on: perf-sh2
 
-    strategy:
-      fail-fast: false
-
     steps:
       - name: set PATH to GIT of the newer version 2.9.0
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,9 +44,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,12 +45,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -46,12 +46,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -45,9 +45,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -46,12 +46,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -45,9 +45,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -46,12 +46,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -45,9 +45,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -46,12 +46,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -45,9 +45,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -27,10 +27,6 @@ jobs:
       OS: ${{ inputs.os }}
       DIST: ${{ inputs.dist }}
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: 'Correct file permissions in the workspace'
-        run: sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2
         with:
           ref: ${{ inputs.ref }}

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -15,9 +15,6 @@ jobs:
   source:
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -16,12 +16,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -46,12 +46,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -45,9 +45,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -46,12 +46,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -45,9 +45,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/static_build_cmake_osx_15.yml
+++ b/.github/workflows/static_build_cmake_osx_15.yml
@@ -45,9 +45,6 @@ jobs:
 
     runs-on: macos-10.15
 
-    strategy:
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v2.3.4
         with:

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_20_04_aarch64.yml
+++ b/.github/workflows/ubuntu_20_04_aarch64.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: graviton
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/ubuntu_20_04_aarch64.yml
+++ b/.github/workflows/ubuntu_20_04_aarch64.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: graviton
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_20_10.yml
+++ b/.github/workflows/ubuntu_20_10.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/ubuntu_20_10.yml
+++ b/.github/workflows/ubuntu_20_10.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_20_10_aarch64.yml
+++ b/.github/workflows/ubuntu_20_10_aarch64.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: graviton
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/ubuntu_20_10_aarch64.yml
+++ b/.github/workflows/ubuntu_20_10_aarch64.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: graviton
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_21_04.yml
+++ b/.github/workflows/ubuntu_21_04.yml
@@ -42,9 +42,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    strategy:
-      fail-fast: false
-
     steps:
       # Permissions correction is needed for self-host runners,
       # where work path is saved between different workflows runs.

--- a/.github/workflows/ubuntu_21_04.yml
+++ b/.github/workflows/ubuntu_21_04.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      # Permissions correction is needed for self-host runners,
-      # where work path is saved between different workflows runs.
-      - name: correct permissions in working directory
-        shell: bash
-        run: |
-          sudo chown -R $(id -u):$(id -g) .
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.travis.mk
+++ b/.travis.mk
@@ -329,7 +329,7 @@ build_odroid_arm64:
 	make -j
 
 test_odroid_arm64_no_deps: build_odroid_arm64
-	make LuaJIT-test
+	make test
 
 test_odroid_arm64: deps_odroid_arm64 test_odroid_arm64_no_deps
 


### PR DESCRIPTION
There are snippets that are copied across many workflow files, but look redundant: the fail-fast strategy and the hack with file permissions. I dropped them.

While I'm here, bumped actions/checkout from v1 to v2.3.4 in a couple of workflows and enabled all tests in aarch64 workflow.

See all details in the commit messages.

----

There are still rooms for improvements: one is about the [Telegram notifier](https://github.com/tarantool/tarantool/pull/6427#issuecomment-991838261). @locker also has thoughts about reducing amount of repeating code, see #6604.