### PR TITLE
lib: use memcpy for unaligned load/store

### DIFF
--- a/src/lib/bit/bit.h
+++ b/src/lib/bit/bit.h
@@ -40,8 +40,8 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
-#if defined(HAVE_FFSL) || defined(HAVE_FFSLL)
 #include <string.h>
+#if defined(HAVE_FFSL) || defined(HAVE_FFSLL)
 #include <strings.h>
 #endif /* defined(HAVE_FFSL) || defined(HAVE_FFSLL) */
 #include <limits.h>
@@ -53,20 +53,6 @@ extern "C" {
 /** @cond false **/
 #define bit_likely(x)    __builtin_expect((x),1)
 #define bit_unlikely(x)  __builtin_expect((x),0)
-
-struct PACKED unaligned_mem
-{
-	union
-	{
-		uint8_t  u8;
-		uint16_t u16;
-		uint32_t u32;
-		uint64_t u64;
-		float	 f;
-		double	 lf;
-		bool     b;
-	};
-};
 /** @endcond **/
 
 /**
@@ -77,49 +63,63 @@ struct PACKED unaligned_mem
 inline uint8_t
 load_u8(const void *p)
 {
-	return ((const struct unaligned_mem *)p)->u8;
+	uint8_t res;
+	memcpy(&res, p, sizeof(res));
+	return res;
 }
 
 /** @copydoc load_u8 */
 inline uint16_t
 load_u16(const void *p)
 {
-	return ((const struct unaligned_mem *)p)->u16;
+	uint16_t res;
+	memcpy(&res, p, sizeof(res));
+	return res;
 }
 
 /** @copydoc load_u8 */
 inline uint32_t
 load_u32(const void *p)
 {
-	return ((const struct unaligned_mem *)p)->u32;
+	uint32_t res;
+	memcpy(&res, p, sizeof(res));
+	return res;
 }
 
 /** @copydoc load_u8 */
 inline uint64_t
 load_u64(const void *p)
 {
-	return ((const struct unaligned_mem *)p)->u64;
+	uint64_t res;
+	memcpy(&res, p, sizeof(res));
+	return res;
 }
 
 /** @copydoc load_u8 */
 inline float
 load_float(const void *p)
 {
-	return ((const struct unaligned_mem *)p)->f;
+	float res;
+	memcpy(&res, p, sizeof(res));
+	return res;
 }
 
 /** @copydoc load_u8 */
 inline double
 load_double(const void *p)
 {
-	return ((const struct unaligned_mem *)p)->lf;
+	double res;
+	memcpy(&res, p, sizeof(res));
+	return res;
 }
 
 /** @copydoc load_u8 */
 inline bool
 load_bool(const void *p)
 {
-	return ((const struct unaligned_mem *)p)->b;
+	bool res;
+	memcpy(&res, p, sizeof(res));
+	return res;
 }
 
 /**
@@ -130,49 +130,49 @@ load_bool(const void *p)
 inline void
 store_u8(void *p, uint8_t v)
 {
-	((struct unaligned_mem *)p)->u8 = v;
+	memcpy(p, &v, sizeof(v));
 }
 
 /** @copydoc store_u8 */
 inline void
 store_u16(void *p, uint16_t v)
 {
-	((struct unaligned_mem *)p)->u16 = v;
+	memcpy(p, &v, sizeof(v));
 }
 
 /** @copydoc store_u8 */
 inline void
 store_u32(void *p, uint32_t v)
 {
-	((struct unaligned_mem *)p)->u32 = v;
+	memcpy(p, &v, sizeof(v));
 }
 
 /** @copydoc store_u8 */
 inline void
 store_u64(void *p, uint64_t v)
 {
-	((struct unaligned_mem *)p)->u64 = v;
+	memcpy(p, &v, sizeof(v));
 }
 
 /** @copydoc store_u8 */
 inline void
 store_float(void *p, float v)
 {
-	((struct unaligned_mem *)p)->f = v;
+	memcpy(p, &v, sizeof(v));
 }
 
 /** @copydoc store_u8 */
 inline void
 store_double(void *p, double v)
 {
-	((struct unaligned_mem *)p)->lf = v;
+	memcpy(p, &v, sizeof(v));
 }
 
 /** @copydoc store_bool */
 inline void
-store_bool(void *p, bool b)
+store_bool(void *p, bool v)
 {
-	((struct unaligned_mem *)p)->b = b;
+	memcpy(p, &v, sizeof(v));
 }
 
 /**

--- a/src/pickle.h
+++ b/src/pickle.h
@@ -32,6 +32,7 @@
  */
 #include <stdbool.h>
 #include <stdint.h>
+#include "bit/bit.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -44,19 +45,11 @@ extern "C" {
  * load_* - no boundary checking
  */
 
-static inline uint32_t
-load_u32(const char **data)
-{
-	const uint32_t *b = (const uint32_t *) *data;
-	*data += sizeof(uint32_t);
-	return *b;
-}
-
 #define pack_u(bits)						\
 static inline char *						\
 pack_u##bits(char *buf, uint##bits##_t val)			\
 {								\
-	*(uint##bits##_t *) buf = val;				\
+	memcpy(buf, &val, sizeof(val));				\
 	return buf + sizeof(uint##bits##_t);			\
 }
 


### PR DESCRIPTION
Now there's a lot of load_*/store_* functions that are designed
for unaligned access to variables in data stream. Unfortunately
they are written in a way that makes new compilers to warn about
outside bounds.

Rewrite it in the most safe, cross-platform and efficient way -
using memcpy. Note that memcpy with compile-time-defined size is
recognized by the magority of compilers and they make the most
efficient operation.

Closes #6703