### PR TITLE
build: fix build with glibc-2.34

### DIFF
--- a/changelogs/unreleased/gh-6686-build-with-glibc-2-34.md
+++ b/changelogs/unreleased/gh-6686-build-with-glibc-2-34.md
@@ -1,0 +1,4 @@
+## bugfix/build
+
+* Fix build errors with glibc-2.34 (gh-6686).
+* Change size of alt. signal stack for ASAN needs.

--- a/test/unit/guard.cc
+++ b/test/unit/guard.cc
@@ -28,16 +28,24 @@ stack_break_f(char *ptr)
 	return sum;
 }
 
-static char stack_buf[SIGSTKSZ];
-
 static int
 main_f(va_list ap)
 {
 	stack_t stack;
-	stack.ss_sp = stack_buf;
-	stack.ss_size = SIGSTKSZ;
 	stack.ss_flags = 0;
-	sigaltstack(&stack, NULL);
+	/*
+	 * It is said that SIGSTKSZ is not enough for one of llvm sanitizers
+	 * (probably asan, because this test fails with segmentation fault if
+	 * we use SIGSTKSZ as alternative signal stack size when we use it).
+	 * https://github.com/llvm/llvm-project/blame/699231ab3c7dd8f028d868b103481fa901f3c721/compiler-rt/lib/sanitizer_common/sanitizer_posix_libcdep.cpp#L169
+	 */
+	stack.ss_size = 4 * SIGSTKSZ;
+	stack.ss_sp = xmalloc(stack.ss_size);
+	if (sigaltstack(&stack, NULL) < 0) {
+		free(stack.ss_sp);
+		perror("sigaltstack");
+		exit(EXIT_FAILURE);
+	}
 	struct sigaction sa;
 	sa.sa_handler = sigsegf_handler;
 	sigemptyset(&sa.sa_mask);
@@ -48,6 +56,7 @@ main_f(va_list ap)
 	int res = stack_break_f((char *)&stack);
 
 	ev_break(loop(), EVBREAK_ALL);
+	free(stack.ss_sp);
 	return res;
 }
 


### PR DESCRIPTION
Macros SIGSTKSZ used to be an integral constant but
in glibc-2.34 it turned into a runtime function so it
cannot be used as constant known size for arrays anymore.

Beyond this, SIGSTKSZ is not enough for alt. signal stack size
when you use ASAN, so the size was increased.

Closes #6686