### PR TITLE
uri: fix break of backward compatibility

### DIFF
--- a/src/lua/uri.lua
+++ b/src/lua/uri.lua
@@ -123,8 +123,15 @@ end
 
 local function fill_uribuf_params(uribuf, uri)
     uribuf.param_count = 0
+    uribuf.params = nil
+    if not uri.params then
+        return
+    end
     for _, _ in pairs(uri.params) do
         uribuf.param_count = uribuf.param_count + 1
+    end
+    if uribuf.param_count == 0 then
+        return
     end
     uribuf.params = ffi.new("struct uri_param[?]", uribuf.param_count)
     local i = 0

--- a/test/app-tap/uri.test.lua
+++ b/test/app-tap/uri.test.lua
@@ -97,7 +97,7 @@ local function test_parse(test)
 end
 
 local function test_format(test)
-    test:plan(12)
+    test:plan(13)
     local u = uri.parse("user:password@localhost")
     test:is(uri.format(u), "user@localhost", "password removed")
     test:is(uri.format(u, false), "user@localhost", "password removed")
@@ -150,6 +150,9 @@ local function test_format(test)
         params = {q1 = {"v13", "v14"}, q2 = "v2"}
     })
     test:is(uri.format(u), "unix/:/tmp/unix.sock?q1=v13&q1=v14&q2=v2", "URI format")
+
+    test:is(uri.format{host = "unix/", service = "/tmp/unix.sock"},
+            "unix/:/tmp/unix.sock", "URI format")
 end
 
 local function test_parse_uri_query_params(test)


### PR DESCRIPTION
After updating the uri library, the "params" table was added
to the URI structure. It breaks backward compatibility in
case when URI passed to "uri.format" function in old way,
without params table.