### PR TITLE
cmake: allow to add extra export symbols

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -215,7 +215,8 @@ endif()
 # library here.
 set (reexport_libraries server core misc bitset csv swim swim_udp swim_ev
      shutdown tzcode ${LUAJIT_LIBRARIES} ${MSGPUCK_LIBRARIES} ${ICU_LIBRARIES}
-     ${CURL_LIBRARIES} ${XXHASH_LIBRARIES} ${LIBCDT_LIBRARIES})
+     ${CURL_LIBRARIES} ${XXHASH_LIBRARIES} ${LIBCDT_LIBRARIES}
+     ${EXTRA_REEXPORT_LIBRARIES})
 
 set (common_libraries
     ${reexport_libraries}
@@ -282,7 +283,9 @@ if(BUILD_STATIC)
     endif()
 endif()
 
-set(exports_file_sources ${PROJECT_SOURCE_DIR}/extra/exports)
+set(exports_file_sources
+    ${PROJECT_SOURCE_DIR}/extra/exports
+    ${EXTRA_EXPORTS_FILE_SOURCES})
 if (EXPORT_LIBCURL_SYMBOLS)
     set(exports_file_sources ${exports_file_sources}
         ${PROJECT_SOURCE_DIR}/extra/exports_libcurl)


### PR DESCRIPTION
This commit defines two cmake variables:

 - EXTRA_REEXPORT_LIBRARIES: list of libraries appended to reexport_libraries.
 - EXTRA_EXPORTS_FILE_SOURCES: list of exports file sources appended to export_file_sources.

Needed to export extra symbols in [Tarantool EE](https://github.com/tarantool/tarantool-ee) build.