### PR TITLE
uri: don't create params table in parse if there's no params

### DIFF
--- a/src/lua/uri.lua
+++ b/src/lua/uri.lua
@@ -66,14 +66,16 @@ local function parse_uribuf(uribuf)
             result[k] = ffi.string(uribuf[k])
         end
     end
-    result.params = {}
-    for param_idx = 0, uribuf.param_count - 1 do
-        local param = uribuf.params[param_idx]
-        local name = ffi.string(param.name)
-        result.params[name] = {}
-        for val_idx = 0, param.value_count - 1 do
-            result.params[name][val_idx + 1] =
-                ffi.string(param.values[val_idx])
+    if uribuf.param_count > 0 then
+        result.params = {}
+        for param_idx = 0, uribuf.param_count - 1 do
+            local param = uribuf.params[param_idx]
+            local name = ffi.string(param.name)
+            result.params[name] = {}
+            for val_idx = 0, param.value_count - 1 do
+                result.params[name][val_idx + 1] =
+                    ffi.string(param.values[val_idx])
+            end
         end
     end
     if uribuf.host_hint == 1 then

--- a/test/app-tap/uri.test.lua
+++ b/test/app-tap/uri.test.lua
@@ -332,7 +332,7 @@ end
 local function test_parse_uri_set_from_lua_table(test)
     -- Tests for uri.parse_many() Lua bindings.
     -- (Several URIs with parameters, passed in different ways).
-    test:plan(134)
+    test:plan(132)
 
     local uri_set
 
@@ -525,13 +525,11 @@ local function test_parse_uri_set_from_lua_table(test)
     test:is(uri_set[1].host, 'unix/', 'host')
     test:is(uri_set[1].service, '/tmp/unix.sock', 'service')
     test:is(uri_set[1].unix, '/tmp/unix.sock', 'unix')
-    test:is(type(uri_set[1].params["q1"]), "nil", "name")
-    test:is(type(uri_set[1].params["q2"]), "nil", "name")
+    test:is(type(uri_set[1].params), "nil", "params")
     test:is(uri_set[2].host, 'unix/', 'host')
     test:is(uri_set[2].service, '/tmp/unix.sock', 'service')
     test:is(uri_set[2].unix, '/tmp/unix.sock', 'unix')
-    test:is(type(uri_set[2].params["q1"]), "nil", "name")
-    test:is(type(uri_set[2].params["q2"]), "nil", "name")
+    test:is(type(uri_set[1].params), "nil", "params")
 
     -- URI table without URI
     uri_set = uri.parse_many({


### PR DESCRIPTION
`uri.parse` always creates params table even if there's no query parameters in the given uri:

```
tarantool> require('uri').parse('localhost:3301')
---
- host: localhost
  service: '3301'
  params: []
...
```

This is confusing and inconsistent with other uri properties, which are created only if they actually exist. Let's create the params table only if the given uri actually has any params.