### PR TITLE
build: fix include directories order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,6 +282,12 @@ include_directories(${PROJECT_SOURCE_DIR}/src/lib/small/third_party)
 include_directories(${PROJECT_SOURCE_DIR}/src/lib/core)
 include_directories(${PROJECT_SOURCE_DIR}/third_party)
 
+# gh-6683: libunwind include path should be after ${PROJECT_SOURCE_DIR}/src/lib
+if (UNWIND_INCLUDE_DIR)
+    include_directories(${UNWIND_INCLUDE_DIR})
+endif()
+
+
 #
 # Specify Tarantool modules prefixes
 #

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -120,10 +120,6 @@ message(STATUS "Looking for libunwind.h")
 find_path(UNWIND_INCLUDE_DIR libunwind.h)
 message(STATUS "Looking for libunwind.h - ${UNWIND_INCLUDE_DIR}")
 
-if (UNWIND_INCLUDE_DIR)
-    include_directories(${UNWIND_INCLUDE_DIR})
-endif()
-
 set(CMAKE_REQUIRED_INCLUDES ${UNWIND_INCLUDE_DIR})
 check_include_file(libunwind.h HAVE_LIBUNWIND_H)
 set(CMAKE_REQUIRED_INCLUDES "")


### PR DESCRIPTION
Build on FreeBSD fails with error:
In file included from /home/freebsd/tarantool/src/box/tuple.c:31:
In file included from /home/freebsd/tarantool/src/box/tuple.h:39:
In file included from /home/freebsd/tarantool/src/box/tuple_format.h:37:
In file included from /usr/local/include/json/json.h:8:
/usr/local/include/json/config.h:7:10: fatal error: 'cstddef' file not found

libunwind headers path is "/usr/local/include". We use json library from
"${PROJECT_SOURCE_DIR}/src/lib". Also devel/jsoncpp has headers in
"/usr/local/include". This ensures that a С++ library is included to the project.

We must change the order in which headers are included in order to use
correct headers.

Closes #6683