### PR TITLE
Pass uri to net.box and iproto

### DIFF
--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -2565,11 +2565,12 @@ net_send_greeting(struct cmsg *m)
  * Create a connection and start input.
  */
 static int
-iproto_on_accept(struct evio_service *service, int fd,
+iproto_on_accept(struct evio_service *service, const struct uri *uri, int fd,
 		 struct sockaddr *addr, socklen_t addrlen)
 {
-	(void) addr;
-	(void) addrlen;
+	(void)uri;
+	(void)addr;
+	(void)addrlen;
 	struct iproto_msg *msg;
 
 	struct iproto_thread *iproto_thread =

--- a/src/lib/core/coio.c
+++ b/src/lib/core/coio.c
@@ -40,6 +40,7 @@
 #include "iostream.h"
 #include "sio.h"
 #include "coio_task.h" /* coio_resolve() */
+#include "uri/uri.h"
 
 typedef void (*ev_stat_cb)(ev_loop *, ev_stat *, int);
 
@@ -469,9 +470,10 @@ coio_writev_timeout(struct iostream *io, struct iovec *iov, int iovcnt,
 }
 
 static int
-coio_service_on_accept(struct evio_service *evio_service,
+coio_service_on_accept(struct evio_service *evio_service, const struct uri *uri,
 		       int fd, struct sockaddr *addr, socklen_t addrlen)
 {
+	(void)uri;
 	struct coio_service *service = (struct coio_service *)
 			evio_service->on_accept_param;
 

--- a/src/lib/core/coio.h
+++ b/src/lib/core/coio.h
@@ -41,6 +41,7 @@ extern "C" {
 
 struct iostream;
 struct sockaddr;
+struct uri_set;
 
 /**
  * Co-operative I/O

--- a/src/lib/core/evio.h
+++ b/src/lib/core/evio.h
@@ -37,7 +37,6 @@
 #include <stdbool.h>
 #include "tarantool_ev.h"
 #include "sio.h"
-#include "uri/uri.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -64,9 +63,12 @@ extern "C" {
  */
 struct evio_service_entry;
 struct evio_service;
+struct uri;
+struct uri_set;
 
-typedef int (*evio_accept_f)(struct evio_service *, int, struct sockaddr *,
-			     socklen_t);
+typedef int (*evio_accept_f)(struct evio_service *service,
+			     const struct uri *uri, int fd,
+			     struct sockaddr *addr, socklen_t addrlen);
 
 struct evio_service {
         /** Total count of services */

--- a/src/lib/uri/uri.c
+++ b/src/lib/uri/uri.c
@@ -7,6 +7,7 @@
 #include "uri_parser.h"
 #include "trivia/util.h"
 
+#define XSTRDUP(s)      (s != NULL ? xstrdup(s) : NULL)
 #define XSTRNDUP(s, n)  (s != NULL ? xstrndup(s, n) : NULL)
 
 struct uri_param {
@@ -64,6 +65,20 @@ uri_param_create(struct uri_param *param, const char *name)
 	param->name = xstrdup(name);
 	param->values = NULL;
 	param->value_count = 0;
+}
+
+/**
+ * Copy URI parameter @a src to @a dst.
+ */
+static void
+uri_param_copy(struct uri_param *dst, const struct uri_param *src)
+{
+	dst->name = xstrdup(src->name);
+	dst->value_count = src->value_count;
+	dst->values = (src->value_count == 0 ? NULL :
+		       xmalloc(src->value_count * sizeof(*dst->values)));
+	for (int i = 0; i < src->value_count; i++)
+		dst->values[i] = xstrdup(src->values[i]);
 }
 
 void
@@ -132,6 +147,25 @@ uri_create_params(struct uri *uri, const char *query)
 		uri_add_param(uri, name, value);
 	}
 	free(copy);
+}
+
+void
+uri_copy(struct uri *dst, const struct uri *src)
+{
+	dst->scheme = XSTRDUP(src->scheme);
+	dst->login = XSTRDUP(src->login);
+	dst->password = XSTRDUP(src->password);
+	dst->host = XSTRDUP(src->host);
+	dst->service = XSTRDUP(src->service);
+	dst->path = XSTRDUP(src->path);
+	dst->query = XSTRDUP(src->query);
+	dst->fragment = XSTRDUP(src->fragment);
+	dst->host_hint = src->host_hint;
+	dst->param_count = src->param_count;
+	dst->params = (src->param_count == 0 ? NULL :
+		       xmalloc(src->param_count * sizeof(*dst->params)));
+	for (int i = 0; i < src->param_count; i++)
+		uri_param_copy(&dst->params[i], &src->params[i]);
 }
 
 void

--- a/src/lib/uri/uri.h
+++ b/src/lib/uri/uri.h
@@ -56,6 +56,13 @@ void
 uri_remove_param(struct uri *uri, const char *name);
 
 /**
+ * Copy constructor for @a dst URI. Copies all fiels from
+ * @a src URI to @dst URI.
+ */
+void
+uri_copy(struct uri *dst, const struct uri *src);
+
+/**
  * Move constructor for @a dst URI. Move all fields from
  * @a src URI to @a dst and clear @a src URI.
  */

--- a/src/lua/uri.c
+++ b/src/lua/uri.c
@@ -171,10 +171,7 @@ uri_create_from_lua_table(struct lua_State *L, int idx, struct uri *uri)
 
 }
 
-/**
- * Create @a uri from the value at the given valid @a idx.
- */
-static int
+int
 luaT_uri_create(struct lua_State *L, int idx, struct uri *uri)
 {
 	int rc = 0;

--- a/src/lua/uri.h
+++ b/src/lua/uri.h
@@ -10,7 +10,14 @@ extern "C" {
 #endif /* defined(__cplusplus) */
 
 struct lua_State;
+struct uri;
 struct uri_set;
+
+/**
+ * Create @a uri from the value at the given valid @a idx.
+ */
+int
+luaT_uri_create(struct lua_State *L, int idx, struct uri *uri);
 
 /**
  * Create @a uri_set from the value at the given valid @a idx.

--- a/test/unit/uri.result
+++ b/test/unit/uri.result
@@ -1,4 +1,144 @@
-1..3
+1..7
+	*** test_copy_sample ***
+    1..3
+    ok 1 - sample uri create
+        1..16
+        ok 1 - src scheme
+        ok 2 - src login
+        ok 3 - src password
+        ok 4 - src host
+        ok 5 - src service
+        ok 6 - src path
+        ok 7 - src query
+        ok 8 - src fragment
+        ok 9 - src hint
+        ok 10 - src param count
+        ok 11 - src param 1 value count
+        ok 12 - src param 1 value 1
+        ok 13 - src param 1 value 2
+        ok 14 - src param 2 value count
+        ok 15 - src param 2 value
+        ok 16 - src param 3 value count
+    ok 2 - subtests
+        1..16
+        ok 1 - dst scheme
+        ok 2 - dst login
+        ok 3 - dst password
+        ok 4 - dst host
+        ok 5 - dst service
+        ok 6 - dst path
+        ok 7 - dst query
+        ok 8 - dst fragment
+        ok 9 - dst hint
+        ok 10 - dst param count
+        ok 11 - dst param 1 value count
+        ok 12 - dst param 1 value 1
+        ok 13 - dst param 1 value 2
+        ok 14 - dst param 2 value count
+        ok 15 - dst param 2 value
+        ok 16 - dst param 3 value count
+    ok 3 - subtests
+ok 1 - subtests
+	*** test_copy_sample: done ***
+	*** test_copy_empty ***
+    1..3
+    ok 1 - empty uri create
+        1..11
+        ok 1 - src scheme
+        ok 2 - src login
+        ok 3 - src password
+        ok 4 - src host
+        ok 5 - src service
+        ok 6 - src path
+        ok 7 - src query
+        ok 8 - src fragment
+        ok 9 - src hint
+        ok 10 - src param count
+        ok 11 - src params
+    ok 2 - subtests
+        1..11
+        ok 1 - dst scheme
+        ok 2 - dst login
+        ok 3 - dst password
+        ok 4 - dst host
+        ok 5 - dst service
+        ok 6 - dst path
+        ok 7 - dst query
+        ok 8 - dst fragment
+        ok 9 - dst hint
+        ok 10 - dst param count
+        ok 11 - dst params
+    ok 3 - subtests
+ok 2 - subtests
+	*** test_copy_empty: done ***
+	*** test_move_sample ***
+    1..3
+    ok 1 - sample uri create
+        1..11
+        ok 1 - src scheme
+        ok 2 - src login
+        ok 3 - src password
+        ok 4 - src host
+        ok 5 - src service
+        ok 6 - src path
+        ok 7 - src query
+        ok 8 - src fragment
+        ok 9 - src hint
+        ok 10 - src param count
+        ok 11 - src params
+    ok 2 - subtests
+        1..16
+        ok 1 - dst scheme
+        ok 2 - dst login
+        ok 3 - dst password
+        ok 4 - dst host
+        ok 5 - dst service
+        ok 6 - dst path
+        ok 7 - dst query
+        ok 8 - dst fragment
+        ok 9 - dst hint
+        ok 10 - dst param count
+        ok 11 - dst param 1 value count
+        ok 12 - dst param 1 value 1
+        ok 13 - dst param 1 value 2
+        ok 14 - dst param 2 value count
+        ok 15 - dst param 2 value
+        ok 16 - dst param 3 value count
+    ok 3 - subtests
+ok 3 - subtests
+	*** test_move_sample: done ***
+	*** test_move_empty ***
+    1..3
+    ok 1 - empty uri create
+        1..11
+        ok 1 - src scheme
+        ok 2 - src login
+        ok 3 - src password
+        ok 4 - src host
+        ok 5 - src service
+        ok 6 - src path
+        ok 7 - src query
+        ok 8 - src fragment
+        ok 9 - src hint
+        ok 10 - src param count
+        ok 11 - src params
+    ok 2 - subtests
+        1..11
+        ok 1 - dst scheme
+        ok 2 - dst login
+        ok 3 - dst password
+        ok 4 - dst host
+        ok 5 - dst service
+        ok 6 - dst path
+        ok 7 - dst query
+        ok 8 - dst fragment
+        ok 9 - dst hint
+        ok 10 - dst param count
+        ok 11 - dst params
+    ok 3 - subtests
+ok 4 - subtests
+	*** test_move_empty: done ***
+	*** test_string_uri_with_query_params_parse ***
     1..26
     ok 1 - /unix.sock: parse
         1..1
@@ -110,7 +250,9 @@
         1..1
         ok 1 - param count
     ok 26 - subtests
-ok 1 - subtests
+ok 5 - subtests
+	*** test_string_uri_with_query_params_parse: done ***
+	*** test_string_uri_set_with_query_params_parse ***
     1..4
         1..2
         ok 1 - /unix.sock?q1=v1&q1=&q2&q3=: parse successful
@@ -183,7 +325,9 @@ ok 1 - subtests
         1..1
         ok 1 - : parse successful
     ok 4 - subtests
-ok 2 - subtests
+ok 6 - subtests
+	*** test_string_uri_set_with_query_params_parse: done ***
+	*** test_invalid_string_uri_set ***
     1..5
         1..1
         ok 1 - /unix.sock, ://: parse unsuccessful
@@ -200,4 +344,5 @@ ok 2 - subtests
         1..1
         ok 1 - /unix.sock?q1=v1 ,,/unix.sock?q2=v2: parse unsuccessful
     ok 5 - subtests
-ok 3 - subtests
+ok 7 - subtests
+	*** test_invalid_string_uri_set: done ***


### PR DESCRIPTION
Currently, iproto and net.box don't know the full uri used to listen/connect, only host and port. This PR replaces host/port with a full uri. We will use it later to pass connection options in uri parameters (e.g. to setup encryption). No user-visible changes are expected.