### PR TITLE
datetime: parse date/time string - step.3

### DIFF
--- a/changelogs/unreleased/gh-5941-datetime-type-support.md
+++ b/changelogs/unreleased/gh-5941-datetime-type-support.md
@@ -2,3 +2,7 @@
 
  * Add a new builtin module `datetime.lua` which allows to operate
    timestamps and intervals values (gh-5941);
+ * Parse method to allow converting string literals in extended iso-8601
+   or rfc3339 formats (gh-6731);
+ * The range of supported years has been extended in all parsers to cover
+   fully -5879610-06-22..5879611-07-11 (gh-6731).

--- a/cmake/BuildCDT.cmake
+++ b/cmake/BuildCDT.cmake
@@ -5,6 +5,9 @@ macro(libccdt_build)
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/third_party/c-dt/build/)
     add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/c-dt
                      ${CMAKE_CURRENT_BINARY_DIR}/third_party/c-dt/build/)
-    set_target_properties(cdt PROPERTIES COMPILE_FLAGS "-DDT_NAMESPACE=tnt_")
+    set_target_properties(cdt
+        PROPERTIES COMPILE_FLAGS
+            "-DDT_NAMESPACE=tnt_ -DDT_PARSE_ISO_YEAR0 -DDT_PARSE_ISO_TNT"
+    )
     add_definitions("-DDT_NAMESPACE=tnt_")
 endmacro()

--- a/extra/exports
+++ b/extra/exports
@@ -418,6 +418,7 @@ title_update
 tnt_datetime_now
 tnt_datetime_parse_full
 tnt_datetime_strftime
+tnt_datetime_strptime
 tnt_datetime_to_string
 tnt_datetime_unpack
 tnt_default_cert_dir_paths

--- a/extra/exports
+++ b/extra/exports
@@ -416,6 +416,7 @@ title_set_script_name
 title_set_status
 title_update
 tnt_datetime_now
+tnt_datetime_parse_full
 tnt_datetime_strftime
 tnt_datetime_to_string
 tnt_datetime_unpack
@@ -429,6 +430,8 @@ tnt_dt_doy
 tnt_dt_from_rdn
 tnt_dt_from_ymd
 tnt_dt_month
+tnt_dt_parse_iso_date
+tnt_dt_parse_iso_time
 tnt_dt_parse_iso_zone_lenient
 tnt_dt_to_ymd
 tnt_dt_year

--- a/extra/exports
+++ b/extra/exports
@@ -430,6 +430,7 @@ tnt_dt_dow
 tnt_dt_doy
 tnt_dt_from_rdn
 tnt_dt_from_ymd
+tnt_dt_from_ymd_checked
 tnt_dt_month
 tnt_dt_parse_iso_date
 tnt_dt_parse_iso_time

--- a/src/lib/core/datetime.c
+++ b/src/lib/core/datetime.c
@@ -7,8 +7,10 @@
 #include <assert.h>
 #include <limits.h>
 #include <string.h>
+#include <stdbool.h>
 #include <time.h>
 
+#define DT_PARSE_ISO_TNT
 #include "c-dt/dt.h"
 #include "datetime.h"
 #include "trivia/util.h"
@@ -71,7 +73,7 @@ datetime_strftime(const struct datetime *date, char *buf, size_t len,
 /**
  * Create datetime structure using given tnt_tm fieldsю
  */
-static void
+static bool
 tm_to_datetime(struct tnt_tm *tm, struct datetime *date)
 {
 	assert(tm != NULL);
@@ -91,9 +93,12 @@ tm_to_datetime(struct tnt_tm *tm, struct datetime *date)
 			dt = ((wday - 4) % 7) + DT_EPOCH_1970_OFFSET;
 		}
 	} else {
-		assert(mday >= 0 && mday < 32);
+		if (mday == 0)
+			mday = 1;
+		assert(mday >= 1 && mday <= 31);
 		assert(mon >= 0 && mon <= 11);
-		dt = dt_from_ymd(year + 1900, mon + 1, mday);
+		if (dt_from_ymd_checked(year + 1900, mon + 1, mday, &dt) == false)
+			return false;
 	}
 	int64_t local_secs =
 		(int64_t)dt * SECS_PER_DAY - SECS_EPOCH_1970_OFFSET;
@@ -102,6 +107,7 @@ tm_to_datetime(struct tnt_tm *tm, struct datetime *date)
 	date->nsec = tm->tm_nsec;
 	date->tzindex = 0;
 	date->tzoffset = tm->tm_gmtoff / 60;
+	return true;
 }
 
 size_t
@@ -114,7 +120,8 @@ datetime_strptime(struct datetime *date, const char *buf, const char *fmt)
 	char *ret = tnt_strptime(buf, fmt, &t);
 	if (ret == NULL)
 		return 0;
-	tm_to_datetime(&t, date);
+	if (tm_to_datetime(&t, date) == false)
+		return 0;
 	return ret - buf;
 }
 
@@ -198,30 +205,37 @@ datetime_parse_full(struct datetime *date, const char *str, size_t len,
 	n = dt_parse_iso_date(str, len, &dt);
 	if (n == 0)
 		return 0;
-	if (n == len)
-		goto exit;
-
-	c = str[n++];
-	if (c != 'T' && c != 't' && c != ' ')
-		return 0;
 
 	str += n;
 	len -= n;
+	if (len <= 0)
+		goto exit;
+
+	c = *str++;
+	if (c != 'T' && c != 't' && c != ' ')
+		return 0;
+	len--;
+	if (len <= 0)
+		goto exit;
 
 	n = dt_parse_iso_time(str, len, &sec_of_day, &nanosecond);
 	if (n == 0)
 		return 0;
-	if (n == len)
-		goto exit;
-
-	if (str[n] == ' ')
-		n++;
 
 	str += n;
 	len -= n;
+	if (len <= 0)
+		goto exit;
+
+	if (*str == ' ') {
+		str++;
+		len--;
+	}
+	if (len <= 0)
+		goto exit;
 
 	n = dt_parse_iso_zone_lenient(str, len, &offset);
-	if (n == 0 || n != len)
+	if (n == 0)
 		return 0;
 	str += n;
 

--- a/src/lib/core/datetime.c
+++ b/src/lib/core/datetime.c
@@ -68,6 +68,56 @@ datetime_strftime(const struct datetime *date, char *buf, size_t len,
 	return tnt_strftime(buf, len, fmt, &tm);
 }
 
+/**
+ * Create datetime structure using given tnt_tm fieldsю
+ */
+static void
+tm_to_datetime(struct tnt_tm *tm, struct datetime *date)
+{
+	assert(tm != NULL);
+	assert(date != NULL);
+	int year = tm->tm_year;
+	int mon = tm->tm_mon;
+	int mday = tm->tm_mday;
+	int yday = tm->tm_yday;
+	int wday = tm->tm_wday;
+	dt_t dt = 0;
+
+	if ((year | mon | mday) == 0) {
+		if (yday != 0) {
+			dt = yday - 1 + DT_EPOCH_1970_OFFSET;
+		} else if (wday != 0) {
+			/* 1970-01-01 was Thursday */
+			dt = ((wday - 4) % 7) + DT_EPOCH_1970_OFFSET;
+		}
+	} else {
+		assert(mday >= 0 && mday < 32);
+		assert(mon >= 0 && mon <= 11);
+		dt = dt_from_ymd(year + 1900, mon + 1, mday);
+	}
+	int64_t local_secs =
+		(int64_t)dt * SECS_PER_DAY - SECS_EPOCH_1970_OFFSET;
+	local_secs += tm->tm_hour * 3600 + tm->tm_min * 60 + tm->tm_sec;
+	date->epoch = local_secs - tm->tm_gmtoff;
+	date->nsec = tm->tm_nsec;
+	date->tzindex = 0;
+	date->tzoffset = tm->tm_gmtoff / 60;
+}
+
+size_t
+datetime_strptime(struct datetime *date, const char *buf, const char *fmt)
+{
+	assert(date != NULL);
+	assert(fmt != NULL);
+	assert(buf != NULL);
+	struct tnt_tm t = { .tm_epoch = 0 };
+	char *ret = tnt_strptime(buf, fmt, &t);
+	if (ret == NULL)
+		return 0;
+	tm_to_datetime(&t, date);
+	return ret - buf;
+}
+
 void
 datetime_now(struct datetime *now)
 {

--- a/src/lib/core/datetime.h
+++ b/src/lib/core/datetime.h
@@ -130,6 +130,17 @@ datetime_to_tm(const struct datetime *date, struct tnt_tm *tm);
 size_t
 datetime_parse_full(struct datetime *date, const char *str, size_t len,
 		    int32_t offset);
+/**
+ * Parse buffer given format, and construct datetime value
+ * @param date output datetime value
+ * @param buf input text buffer (0-terminated)
+ * @param fmt format to use for parsing
+ * @retval Upon successful completion returns length of accepted
+ *         prefix substring, 0 otherwise.
+ * @sa strptime()
+ */
+size_t
+datetime_strptime(struct datetime *date, const char *buf, const char *fmt);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/lib/core/datetime.h
+++ b/src/lib/core/datetime.h
@@ -113,6 +113,24 @@ datetime_now(struct datetime *now);
 void
 datetime_to_tm(const struct datetime *date, struct tnt_tm *tm);
 
+/**
+ * Parse datetime text in ISO-8601 given format, and construct output
+ * datetime value
+ * @param date output datetime value
+ * @param str input text in relaxed ISO-8601 format (0-terminated)
+ * @param len length of str buffer
+ * @param offset timezone offset, if you need to interpret
+ *        date/time value as local. Pass 0 if you need to interpret it as UTC,
+ *        or apply offset from string.
+ * @retval Upon successful completion returns length of accepted
+ *         prefix substring. It's ok if there is some unaccepted trailer.
+ *         Returns 0 only if text is not recognizable as date/time string.
+ * @sa datetime_strptime()
+ */
+size_t
+datetime_parse_full(struct datetime *date, const char *str, size_t len,
+		    int32_t offset);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/lib/tzcode/CMakeLists.txt
+++ b/src/lib/tzcode/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_library(tzcode STATIC strftime.c)
+add_library(tzcode STATIC strftime.c strptime.c timelocal.c)
 target_link_libraries(tzcode)

--- a/src/lib/tzcode/strftime.c
+++ b/src/lib/tzcode/strftime.c
@@ -36,67 +36,12 @@
 #include "private.h"
 #include "trivia/util.h"
 #include "tzcode.h"
+#include "timelocal.h"
 
 #include <assert.h>
 #include <locale.h>
 #include <stdbool.h>
 #include <stdio.h>
-
-struct lc_time_T {
-	const char *mon[MONTHSPERYEAR];
-	const char *month[MONTHSPERYEAR];
-	const char *wday[DAYSPERWEEK];
-	const char *weekday[DAYSPERWEEK];
-	const char *X_fmt;
-	const char *x_fmt;
-	const char *c_fmt;
-	const char *am;
-	const char *pm;
-	const char *date_fmt;
-};
-
-#define Locale (&C_time_locale)
-
-static const struct lc_time_T C_time_locale = {
-	{"Jan", "Feb", "Mar", "Apr", "May", "Jun",
-	 "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"},
-	{"January", "February", "March", "April", "May", "June",
-	 "July", "August", "September", "October", "November", "December"},
-	{"Sun", "Mon", "Tue", "Wed",
-	 "Thu", "Fri", "Sat"},
-	{"Sunday", "Monday", "Tuesday", "Wednesday",
-	 "Thursday", "Friday", "Saturday"},
-
-	/* X_fmt */
-	"%H:%M:%S",
-
-	/*
-	 ** x_fmt
-	 ** C99 and later require this format.
-	 ** Using just numbers (as here) makes Quakers happier;
-	 ** it's also compatible with SVR4.
-	 */
-	"%m/%d/%y",
-
-	/*
-	 ** c_fmt
-	 ** C99 and later require this format.
-	 ** Previously this code used "%D %X", but we now conform to C99.
-	 ** Note that
-	 ** "%a %b %d %H:%M:%S %Y"
-	 ** is used by Solaris 2.3.
-	 */
-	"%a %b %e %T %Y",
-
-	/* am */
-	"AM",
-
-	/* pm */
-	"PM",
-
-	/* date_fmt */
-	"%a %b %e %H:%M:%S %Z %Y"
-};
 
 static int pow10[] = { 1,      10,	100,	  1000,	     10000,
 		       100000, 1000000, 10000000, 100000000, 1000000000 };

--- a/src/lib/tzcode/strptime.c
+++ b/src/lib/tzcode/strptime.c
@@ -1,0 +1,720 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * Copyright (c) 2014 Gary Mills
+ * Copyright 2011, Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 1994 Powerdog Industries.  All rights reserved.
+ *
+ * Copyright (c) 2011 The FreeBSD Foundation
+ * All rights reserved.
+ * Portions of this software were developed by David Chisnall
+ * under sponsorship from the FreeBSD Foundation.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer
+ *    in the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY POWERDOG INDUSTRIES ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE POWERDOG INDUSTRIES BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * official policies, either expressed or implied, of Powerdog Industries.
+ */
+
+#include <sys/cdefs.h>
+
+#ifndef lint
+#ifndef NOID
+static char copyright[] __attribute__((unused)) =
+"@(#) Copyright (c) 1994 Powerdog Industries.  All rights reserved.";
+static char sccsid[] __attribute__((unused)) =
+"@(#)strptime.c	0.1 (Powerdog) 94/03/27";
+#endif /* !defined NOID */
+#endif /* not lint */
+
+#include <assert.h>
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "private.h"
+#include "timelocal.h"
+#include "tzcode.h"
+
+enum flags {
+	FLAG_NONE = 1 << 0,
+	FLAG_YEAR = 1 << 1,
+	FLAG_MONTH = 1 << 2,
+	FLAG_YDAY = 1 << 3,
+	FLAG_MDAY = 1 << 4,
+	FLAG_WDAY = 1 << 5,
+	FLAG_EPOCH = 1 << 6,
+	FLAG_NSEC = 1 << 7,
+};
+
+/*
+ * Calculate the week day of the first day of a year. Valid for
+ * the Gregorian calendar, which began Sept 14, 1752 in the UK
+ * and its colonies. Ref:
+ * http://en.wikipedia.org/wiki/Determination_of_the_day_of_the_week
+ */
+
+static int
+first_wday_of(int year)
+{
+	return ((2 * (3 - (year / 100) % 4)) + (year % 100) +
+		((year % 100) / 4) + (isleap(year) ? 6 : 0) + 1) % 7;
+}
+
+char *
+tnt_strptime(const char *__restrict buf, const char *__restrict fmt,
+	     struct tnt_tm *__restrict tm)
+{
+	char c;
+	int day_offset = -1, wday_offset;
+	int week_offset;
+	int i, len;
+	int Ealternative, Oalternative;
+	enum flags flags = FLAG_NONE;
+	int century = -1;
+	int year = -1;
+	const char *ptr = fmt;
+
+	static int start_of_month[2][13] = {
+		{ 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365 },
+		{ 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366 }
+	};
+
+	while (*ptr != 0) {
+		c = *ptr++;
+
+		if (c != '%') {
+			if (isspace((u_char)c))
+				while (*buf != 0 && isspace((u_char)*buf))
+					buf++;
+			else if (c != *buf++)
+				return NULL;
+			continue;
+		}
+
+		Ealternative = 0;
+		Oalternative = 0;
+	label:
+		c = *ptr++;
+		switch (c) {
+		case '%':
+			if (*buf++ != '%')
+				return NULL;
+			break;
+
+		case '+':
+			buf = tnt_strptime(buf, Locale->date_fmt, tm);
+			if (buf == NULL)
+				return NULL;
+			flags |= FLAG_WDAY | FLAG_MONTH | FLAG_MDAY | FLAG_YEAR;
+			break;
+
+		case 'C':
+			if (!is_digit((u_char)*buf))
+				return NULL;
+
+			/* XXX This will break for 3-digit centuries. */
+			len = 2;
+			for (i = 0; len && *buf != 0 && is_digit((u_char)*buf);
+			     buf++) {
+				i *= 10;
+				i += *buf - '0';
+				len--;
+			}
+
+			century = i;
+			flags |= FLAG_YEAR;
+
+			break;
+
+		case 'c':
+			buf = tnt_strptime(buf, Locale->c_fmt, tm);
+			if (buf == NULL)
+				return NULL;
+			flags |= FLAG_WDAY | FLAG_MONTH | FLAG_MDAY | FLAG_YEAR;
+			break;
+
+		case 'D':
+			buf = tnt_strptime(buf, "%m/%d/%y", tm);
+			if (buf == NULL)
+				return NULL;
+			flags |= FLAG_MONTH | FLAG_MDAY | FLAG_YEAR;
+			break;
+
+		case 'E':
+			if (Ealternative || Oalternative)
+				break;
+			Ealternative++;
+			goto label;
+
+		case 'O':
+			if (Ealternative || Oalternative)
+				break;
+			Oalternative++;
+			goto label;
+
+		case 'v':
+			buf = tnt_strptime(buf, "%e-%b-%Y", tm);
+			if (buf == NULL)
+				return NULL;
+			flags |= FLAG_MONTH | FLAG_MDAY | FLAG_YEAR;
+			break;
+
+		case 'F':
+			buf = tnt_strptime(buf, "%Y-%m-%d", tm);
+			if (buf == NULL)
+				return NULL;
+			flags |= FLAG_MONTH | FLAG_MDAY | FLAG_YEAR;
+			break;
+
+		case 'R':
+			buf = tnt_strptime(buf, "%H:%M", tm);
+			if (buf == NULL)
+				return NULL;
+			break;
+
+		case 'r':
+			buf = tnt_strptime(buf, Locale->ampm_fmt, tm);
+			if (buf == NULL)
+				return NULL;
+			break;
+
+		case 'T':
+			buf = tnt_strptime(buf, "%H:%M:%S", tm);
+			if (buf == NULL)
+				return NULL;
+			break;
+
+		case 'X':
+			buf = tnt_strptime(buf, Locale->X_fmt, tm);
+			if (buf == NULL)
+				return NULL;
+			break;
+
+		case 'x':
+			buf = tnt_strptime(buf, Locale->x_fmt, tm);
+			if (buf == NULL)
+				return NULL;
+			flags |= FLAG_MONTH | FLAG_MDAY | FLAG_YEAR;
+			break;
+
+		case 'j':
+			if (!is_digit((u_char)*buf))
+				return NULL;
+
+			len = 3;
+			for (i = 0; len && *buf != 0 && is_digit((u_char)*buf);
+			     buf++) {
+				i *= 10;
+				i += *buf - '0';
+				len--;
+			}
+			if (i < 1 || i > 366)
+				return NULL;
+
+			tm->tm_yday = i - 1;
+			flags |= FLAG_YDAY;
+
+			break;
+
+		case '0':
+		case '1':
+		case '2':
+		case '3':
+		case '4':
+		case '5':
+		case '6':
+		case '7':
+		case '8':
+		case '9':
+			for (; *ptr != 0 && is_digit((u_char)*ptr); ptr++)
+				;
+
+			c = *ptr++;
+			assert(c == 'f');
+			/* fallthru */
+		case 'f':
+			if (!is_digit((u_char)*buf))
+				return NULL;
+
+			len = 9;
+			for (i = 0; len && *buf != 0 && is_digit((u_char)*buf);
+			     buf++) {
+				i *= 10;
+				i += *buf - '0';
+				len--;
+			}
+			while (len) {
+				i *= 10;
+				len--;
+			}
+			tm->tm_nsec = i;
+			flags |= FLAG_NSEC;
+
+			break;
+
+		case 'M':
+		case 'S':
+			if (*buf == 0 || isspace((u_char)*buf))
+				break;
+
+			if (!is_digit((u_char)*buf))
+				return NULL;
+
+			len = 2;
+			for (i = 0; len && *buf != 0 && is_digit((u_char)*buf);
+			     buf++) {
+				i *= 10;
+				i += *buf - '0';
+				len--;
+			}
+
+			if (c == 'M') {
+				if (i > 59)
+					return NULL;
+				tm->tm_min = i;
+			} else {
+				if (i > 60)
+					return NULL;
+				tm->tm_sec = i;
+			}
+
+			break;
+
+		case 'H':
+		case 'I':
+		case 'k':
+		case 'l':
+			/*
+			 * %k and %l specifiers are documented as being
+			 * blank-padded.  However, there is no harm in
+			 * allowing zero-padding.
+			 *
+			 * XXX %k and %l specifiers may gobble one too many
+			 * digits if used incorrectly.
+			 */
+
+			len = 2;
+			if ((c == 'k' || c == 'l') && isblank((u_char)*buf)) {
+				buf++;
+				len = 1;
+			}
+
+			if (!is_digit((u_char)*buf))
+				return NULL;
+
+			for (i = 0; len && *buf != 0 && is_digit((u_char)*buf);
+			     buf++) {
+				i *= 10;
+				i += *buf - '0';
+				len--;
+			}
+			if (c == 'H' || c == 'k') {
+				if (i > 23)
+					return NULL;
+			} else if (i == 0 || i > 12)
+				return NULL;
+
+			tm->tm_hour = i;
+
+			break;
+
+		case 'p':
+			/*
+			 * XXX This is bogus if parsed before hour-related
+			 * specifiers.
+			 */
+			if (tm->tm_hour > 12)
+				return NULL;
+
+			len = strlen(Locale->am);
+			if (strncasecmp(buf, Locale->am, len) == 0) {
+				if (tm->tm_hour == 12)
+					tm->tm_hour = 0;
+				buf += len;
+				break;
+			}
+
+			len = strlen(Locale->pm);
+			if (strncasecmp(buf, Locale->pm, len) == 0) {
+				if (tm->tm_hour != 12)
+					tm->tm_hour += 12;
+				buf += len;
+				break;
+			}
+
+			return NULL;
+
+		case 'A':
+		case 'a':
+			for (i = 0; i < DAYSPERWEEK; i++) {
+				len = strlen(Locale->weekday[i]);
+				if (strncasecmp(buf, Locale->weekday[i], len) ==
+				    0)
+					break;
+				len = strlen(Locale->wday[i]);
+				if (strncasecmp(buf, Locale->wday[i], len) == 0)
+					break;
+			}
+			if (i == DAYSPERWEEK)
+				return NULL;
+
+			buf += len;
+			tm->tm_wday = i;
+			flags |= FLAG_WDAY;
+			break;
+
+		case 'U':
+		case 'W':
+			/*
+			 * XXX This is bogus, as we can not assume any valid
+			 * information present in the tm structure at this
+			 * point to calculate a real value, so just check the
+			 * range for now.
+			 */
+			if (!is_digit((u_char)*buf))
+				return NULL;
+
+			len = 2;
+			for (i = 0; len && *buf != 0 && is_digit((u_char)*buf);
+			     buf++) {
+				i *= 10;
+				i += *buf - '0';
+				len--;
+			}
+			if (i > 53)
+				return NULL;
+
+			if (c == 'U')
+				day_offset = TM_SUNDAY;
+			else
+				day_offset = TM_MONDAY;
+
+			week_offset = i;
+
+			break;
+
+		case 'u':
+		case 'w':
+			if (!is_digit((u_char)*buf))
+				return NULL;
+
+			i = *buf++ - '0';
+			if (i < 0 || i > 7 || (c == 'u' && i < 1) ||
+			    (c == 'w' && i > 6))
+				return NULL;
+
+			tm->tm_wday = i % 7;
+			flags |= FLAG_WDAY;
+
+			break;
+
+		case 'e':
+			/*
+			 * With %e format, our strftime(3) adds a blank space
+			 * before single digits.
+			 */
+			if (*buf != 0 && isspace((u_char)*buf))
+				buf++;
+			/* FALLTHROUGH */
+		case 'd':
+			/*
+			 * The %e specifier was once explicitly documented as
+			 * not being zero-padded but was later changed to
+			 * equivalent to %d.  There is no harm in allowing
+			 * such padding.
+			 *
+			 * XXX The %e specifier may gobble one too many
+			 * digits if used incorrectly.
+			 */
+			if (!is_digit((u_char)*buf))
+				return NULL;
+
+			len = 2;
+			for (i = 0; len && *buf != 0 && is_digit((u_char)*buf);
+			     buf++) {
+				i *= 10;
+				i += *buf - '0';
+				len--;
+			}
+			if (i == 0 || i > 31)
+				return NULL;
+
+			tm->tm_mday = i;
+			flags |= FLAG_MDAY;
+
+			break;
+
+		case 'B':
+		case 'b':
+		case 'h':
+			for (i = 0; i < MONTHSPERYEAR; i++) {
+				if (Oalternative) {
+					if (c == 'B') {
+						len = strlen(
+							Locale->alt_month[i]);
+						if (strncasecmp(
+							    buf,
+							    Locale->alt_month
+								    [i],
+							    len) == 0)
+							break;
+					}
+				} else {
+					len = strlen(Locale->month[i]);
+					if (strncasecmp(buf, Locale->month[i],
+							len) == 0)
+						break;
+				}
+			}
+			/*
+			 * Try the abbreviated month name if the full name
+			 * wasn't found and Oalternative was not requested.
+			 */
+			if (i == MONTHSPERYEAR && !Oalternative) {
+				for (i = 0; i < MONTHSPERYEAR; i++) {
+					len = strlen(Locale->mon[i]);
+					if (strncasecmp(buf, Locale->mon[i],
+							len) == 0)
+						break;
+				}
+			}
+			if (i == MONTHSPERYEAR)
+				return NULL;
+
+			tm->tm_mon = i;
+			buf += len;
+			flags |= FLAG_MONTH;
+
+			break;
+
+		case 'm':
+			if (!is_digit((u_char)*buf))
+				return NULL;
+
+			len = 2;
+			for (i = 0; len && *buf != 0 && is_digit((u_char)*buf);
+			     buf++) {
+				i *= 10;
+				i += *buf - '0';
+				len--;
+			}
+			if (i < 1 || i > 12)
+				return NULL;
+
+			tm->tm_mon = i - 1;
+			flags |= FLAG_MONTH;
+
+			break;
+
+		case 's': {
+			char *cp;
+			long n;
+
+			n = strtol(buf, &cp, 10);
+			if (n == 0) {
+				return NULL;
+			}
+			buf = cp;
+			tm->tm_epoch = n;
+			flags |= FLAG_EPOCH;
+		} break;
+
+		case 'G': /* ISO 8601 year (four digits) */
+		case 'g': /* ISO 8601 year (two digits) */
+		case 'Y':
+		case 'y':
+			if (*buf == 0 || isspace((u_char)*buf))
+				break;
+
+			if (!is_digit((u_char)*buf))
+				return NULL;
+
+			len = (c == 'Y' || c == 'G') ? 4 : 2;
+			for (i = 0; len && *buf != 0 && is_digit((u_char)*buf);
+			     buf++) {
+				i *= 10;
+				i += *buf - '0';
+				len--;
+			}
+			if (c == 'Y' || c == 'G')
+				century = i / 100;
+			year = i % 100;
+
+			flags |= FLAG_YEAR;
+
+			break;
+
+		case 'Z': {
+			const char *cp;
+			char *zonestr;
+
+			for (cp = buf; *cp && isupper((u_char)*cp); ++cp)
+				/* empty */;
+			if (cp - buf) {
+				zonestr = alloca(cp - buf + 1);
+				strncpy(zonestr, buf, cp - buf);
+				zonestr[cp - buf] = '\0';
+				tzset();
+				if (0 == strcmp(zonestr, "GMT") ||
+				    0 == strcmp(zonestr, "UTC")) {
+					tm->tm_gmtoff = 0;
+				} else if (0 == strcmp(zonestr, tzname[0])) {
+					tm->tm_isdst = 0;
+				} else if (0 == strcmp(zonestr, tzname[1])) {
+					tm->tm_isdst = 1;
+				} else {
+					return NULL;
+				}
+				buf += cp - buf;
+			}
+		} break;
+
+		case 'z': {
+			int sign = 1;
+
+			if (*buf != '+') {
+				if (*buf == '-')
+					sign = -1;
+				else
+					return NULL;
+			}
+
+			buf++;
+			i = 0;
+			for (len = 4; len > 0; len--) {
+				if (is_digit((u_char)*buf)) {
+					i *= 10;
+					i += *buf - '0';
+					buf++;
+				} else if (len == 2) {
+					i *= 100;
+					break;
+				} else
+					return NULL;
+			}
+
+			if (i > 1400 || (sign == -1 && i > 1200) ||
+			    (i % 100) >= 60)
+				return NULL;
+			tm->tm_gmtoff =
+				sign * ((i / 100) * 3600 + i % 100 * 60);
+		} break;
+
+		case 'n':
+		case 't':
+			while (isspace((u_char)*buf))
+				buf++;
+			break;
+
+		default:
+			return NULL;
+		}
+	}
+
+	if (century != -1 || year != -1) {
+		if (year == -1)
+			year = 0;
+		if (century == -1) {
+			if (year < 69)
+				year += 100;
+		} else
+			year += century * 100 - TM_YEAR_BASE;
+		tm->tm_year = year;
+	}
+
+	if (!(flags & FLAG_YDAY) && (flags & FLAG_YEAR)) {
+		if ((flags & (FLAG_MONTH | FLAG_MDAY)) ==
+		    (FLAG_MONTH | FLAG_MDAY)) {
+			tm->tm_yday = start_of_month[isleap(tm->tm_year +
+							    TM_YEAR_BASE)]
+						    [tm->tm_mon] +
+				(tm->tm_mday - 1);
+			flags |= FLAG_YDAY;
+		} else if (day_offset != -1) {
+			int tmpwday, tmpyday, fwo;
+
+			fwo = first_wday_of(tm->tm_year + TM_YEAR_BASE);
+			/* No incomplete week (week 0). */
+			if (week_offset == 0 && fwo == day_offset)
+				return NULL;
+
+			/* Set the date to the first Sunday (or Monday)
+			 * of the specified week of the year.
+			 */
+			tmpwday =
+				(flags & FLAG_WDAY) ? tm->tm_wday : day_offset;
+			tmpyday = (7 - fwo + day_offset) % 7 +
+				(week_offset - 1) * 7 +
+				(tmpwday - day_offset + 7) % 7;
+			/* Impossible yday for incomplete week (week 0). */
+			if (tmpyday < 0) {
+				if (flags & FLAG_WDAY)
+					return NULL;
+				tmpyday = 0;
+			}
+			tm->tm_yday = tmpyday;
+			flags |= FLAG_YDAY;
+		}
+	}
+
+	if ((flags & (FLAG_YEAR | FLAG_YDAY)) == (FLAG_YEAR | FLAG_YDAY)) {
+		if (!(flags & FLAG_MONTH)) {
+			i = 0;
+			while (tm->tm_yday >=
+			       start_of_month[isleap(tm->tm_year +
+						     TM_YEAR_BASE)][i])
+				i++;
+			if (i > 12) {
+				i = 1;
+				tm->tm_yday -= start_of_month[isleap(
+					tm->tm_year + TM_YEAR_BASE)][12];
+				tm->tm_year++;
+			}
+			tm->tm_mon = i - 1;
+			flags |= FLAG_MONTH;
+		}
+		if (!(flags & FLAG_MDAY)) {
+			tm->tm_mday = tm->tm_yday -
+				start_of_month[isleap(tm->tm_year +
+						      TM_YEAR_BASE)]
+					      [tm->tm_mon] +
+				1;
+			flags |= FLAG_MDAY;
+		}
+		if (!(flags & FLAG_WDAY)) {
+			i = 0;
+			wday_offset = first_wday_of(tm->tm_year);
+			while (i++ <= tm->tm_yday) {
+				if (wday_offset++ >= 6)
+					wday_offset = 0;
+			}
+			tm->tm_wday = wday_offset;
+			flags |= FLAG_WDAY;
+		}
+	}
+
+	return (char *)buf;
+}

--- a/src/lib/tzcode/timelocal.c
+++ b/src/lib/tzcode/timelocal.c
@@ -1,0 +1,91 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * Copyright (c) 2001 Alexey Zelkin <phantom@FreeBSD.org>
+ * Copyright (c) 1997 FreeBSD Inc.
+ * All rights reserved.
+ *
+ * Copyright (c) 2011 The FreeBSD Foundation
+ * All rights reserved.
+ * Portions of this software were developed by David Chisnall
+ * under sponsorship from the FreeBSD Foundation.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <sys/cdefs.h>
+
+#include "timelocal.h"
+
+const struct lc_time_T C_time_locale = {
+	{ "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+	  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" },
+	{ "January", "February", "March", "April", "May", "June",
+	  "July", "August", "September", "October", "November", "December" },
+	{ "Sun", "Mon", "Tue", "Wed",
+	  "Thu", "Fri", "Sat" },
+	{ "Sunday", "Monday", "Tuesday", "Wednesday",
+	  "Thursday", "Friday", "Saturday" },
+
+	/* X_fmt */
+	"%H:%M:%S",
+
+	/*
+	 * x_fmt
+	 * Since the C language standard calls for
+	 * "date, using locale's date format," anything goes.
+	 * Using just numbers (as here) makes Quakers happier;
+	 * it's also compatible with SVR4.
+	 */
+	"%m/%d/%y",
+
+	/*
+	 * c_fmt
+	 */
+	"%a %b %e %H:%M:%S %Y",
+
+	/* am */
+	"AM",
+
+	/* pm */
+	"PM",
+
+	/* date_fmt */
+	"%a %b %e %H:%M:%S %Z %Y",
+
+	/* alt_month
+	 * Standalone months forms for %OB
+	 */
+	{ "January", "February", "March", "April", "May", "June", "July",
+	  "August", "September", "October", "November", "December" },
+
+	/* md_order
+	 * Month / day order in dates
+	 */
+	"md",
+
+	/* ampm_fmt
+	 * To determine 12-hour clock format time (empty, if N/A)
+	 */
+	"%I:%M:%S %p"
+};

--- a/src/lib/tzcode/timelocal.h
+++ b/src/lib/tzcode/timelocal.h
@@ -1,0 +1,65 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * Copyright (c) 1997-2002 FreeBSD Project.
+ * All rights reserved.
+ *
+ * Copyright (c) 2011 The FreeBSD Foundation
+ * All rights reserved.
+ * Portions of this software were developed by David Chisnall
+ * under sponsorship from the FreeBSD Foundation.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#ifndef _TIMELOCAL_H_
+#define _TIMELOCAL_H_
+#include "private.h"
+#include <locale.h>
+
+/**
+ * Private header file for the strftime and strptime localization
+ * stuff.
+ */
+struct lc_time_T {
+	const char *mon[MONTHSPERYEAR];
+	const char *month[MONTHSPERYEAR];
+	const char *wday[DAYSPERWEEK];
+	const char *weekday[DAYSPERWEEK];
+	const char *X_fmt;
+	const char *x_fmt;
+	const char *c_fmt;
+	const char *am;
+	const char *pm;
+	const char *date_fmt;
+	const char *alt_month[MONTHSPERYEAR];
+	const char *md_order;
+	const char *ampm_fmt;
+};
+
+#define Locale (&C_time_locale)
+
+extern const struct lc_time_T C_time_locale;
+
+#endif /* !_TIMELOCAL_H_ */

--- a/src/lib/tzcode/tzcode.h
+++ b/src/lib/tzcode/tzcode.h
@@ -56,6 +56,16 @@ size_t
 tnt_strftime(char *s, size_t maxsize, const char *format,
 	     const struct tnt_tm *tm);
 
+/**
+ * tnt_strptime is a Tarantool version of POSIX strptime()
+ * which has been extended with %f (fractions of second)
+ * flag support.
+ * @sa strptime()
+ */
+char *
+tnt_strptime(const char *__restrict buf, const char *__restrict fmt,
+	     struct tnt_tm *__restrict tm);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -76,6 +76,8 @@ size_t tnt_datetime_strftime(const struct datetime *date, char *buf,
                              uint32_t len, const char *fmt);
 size_t tnt_datetime_parse_full(struct datetime *date, const char *str,
                                size_t len, int32_t offset);
+size_t tnt_datetime_strptime(struct datetime *date, const char *buf,
+                             const char *fmt);
 void   tnt_datetime_now(struct datetime *now);
 
 ]]
@@ -923,6 +925,19 @@ local function datetime_parse_full(str, tzoffset)
     return date, len
 end
 
+--[[
+    Parse datetime string given `strptime` like format.
+    Returns constructed datetime object and length of accepted string.
+]]
+local function datetime_parse_format(str, fmt)
+    local date = ffi.new(datetime_t)
+    local len = builtin.tnt_datetime_strptime(date, str, fmt)
+    if len == 0 then
+        error(("could not parse '%s' using '%s' format"):format(str, fmt))
+    end
+    return date, len
+end
+
 local function datetime_parse_from(str, obj)
     check_str(str, 'datetime.parse()')
     local fmt = ''
@@ -946,7 +961,7 @@ local function datetime_parse_from(str, obj)
     if not fmt or fmt == '' or fmt == 'iso8601' or fmt == 'rfc3339' then
         return datetime_parse_full(str, offset or 0)
     else
-        error(("unknown format '%s'"):format(fmt), 2)
+        return datetime_parse_format(str, fmt)
     end
 end
 

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -922,7 +922,7 @@ local function datetime_parse_full(str, tzoffset)
     if len == 0 then
         error(("could not parse '%s'"):format(str))
     end
-    return date, len
+    return date, tonumber(len)
 end
 
 --[[
@@ -935,7 +935,7 @@ local function datetime_parse_format(str, fmt)
     if len == 0 then
         error(("could not parse '%s' using '%s' format"):format(str, fmt))
     end
-    return date, len
+    return date, tonumber(len)
 end
 
 local function datetime_parse_from(str, obj)

--- a/src/lua/tnt_datetime.c
+++ b/src/lua/tnt_datetime.c
@@ -26,6 +26,13 @@ tnt_datetime_to_string(const struct datetime *date, char *buf, ssize_t len)
 	return datetime_to_string(date, buf, len);
 }
 
+size_t
+tnt_datetime_parse_full(struct datetime *date, const char *str, size_t len,
+			int32_t offset)
+{
+	return datetime_parse_full(date, str, len, offset);
+}
+
 struct datetime *
 tnt_datetime_unpack(const char **data, uint32_t len, struct datetime *date)
 {

--- a/src/lua/tnt_datetime.c
+++ b/src/lua/tnt_datetime.c
@@ -14,6 +14,12 @@ tnt_datetime_strftime(const struct datetime *date, char *buf, size_t len,
 	return datetime_strftime(date, buf, len, fmt);
 }
 
+size_t
+tnt_datetime_strptime(struct datetime *date, const char *buf, const char *fmt)
+{
+	return datetime_strptime(date, buf, fmt);
+}
+
 void
 tnt_datetime_now(struct datetime *now)
 {

--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -11,7 +11,7 @@ local ffi = require('ffi')
 --]]
 if jit.arch == 'arm64' then jit.off() end
 
-test:plan(23)
+test:plan(29)
 
 -- minimum supported date - -5879610-06-22
 local MIN_DATE_YEAR = -5879610
@@ -90,6 +90,10 @@ end
 
 local function invalid_tz_fmt_error(val)
     return ('invalid time-zone format %s'):format(val)
+end
+
+local function invalid_date_fmt_error(str)
+    return ('invalid date format %s'):format(str)
 end
 
 -- utility functions to gracefully handle pcall errors
@@ -325,10 +329,10 @@ test:test("Simple date creation by attributes - check failed", function(test)
             {year = -16009610, month = 12, day = 31}},
         {range_check_error('year', 16009610, {MIN_DATE_YEAR, MAX_DATE_YEAR}),
             {year = 16009610, month = 1, day = 1}},
-        {greater_than_max(5879611, 9, 1),
-            {year = 5879611, month = 9, day = 1}},
-        {greater_than_max(5879611, 7, 12),
-            {year = 5879611, month = 7, day = 12}},
+        {greater_than_max(MAX_DATE_YEAR, 9, 1),
+            {year = MAX_DATE_YEAR, month = 9, day = 1}},
+        {greater_than_max(MAX_DATE_YEAR, 7, 12),
+            {year = MAX_DATE_YEAR, month = 7, day = 12}},
     }
     for _, row in pairs(specific_errors) do
         local err_msg, attribs = unpack(row)
@@ -372,6 +376,165 @@ test:test("Formatting limits", function(test)
         s = ts:format(bogus_fmt)
         test:is(len, #bogus_fmt, ('bogus format lengths check %d'):format(len))
         test:is(s, bogus_fmt, 'bogus format equality check')
+    end
+end)
+
+test:test("Simple tests for parser", function(test)
+    test:plan(12)
+    test:ok(date.parse("1970-01-01T01:00:00Z") ==
+            date.new{year=1970, mon=1, day=1, hour=1, min=0, sec=0})
+    test:ok(date.parse("1970-01-01T01:00:00Z", {format = 'iso8601'}) ==
+            date.new{year=1970, mon=1, day=1, hour=1, min=0, sec=0})
+    test:ok(date.parse("1970-01-01T01:00:00Z", {format = 'rfc3339'}) ==
+            date.new{year=1970, mon=1, day=1, hour=1, min=0, sec=0})
+    test:ok(date.parse("2020-01-01T01:00:00+00:00", {format = 'rfc3339'}) ==
+            date.parse("2020-01-01T01:00:00+00:00", {format = 'iso8601'}))
+    test:ok(date.parse("1970-01-01T02:00:00+02:00") ==
+            date.new{year=1970, mon=1, day=1, hour=2, min=0, sec=0, tzoffset=120})
+    test:ok(date.parse("1970-01-01T01:00:00", {tzoffset = 120}) ==
+            date.new{year=1970, mon=1, day=1, hour=1, min=0, sec=0, tzoffset=120})
+    test:ok(date.parse("1970-01-01T01:00:00", {tzoffset = '+0200'}) ==
+            date.new{year=1970, mon=1, day=1, hour=1, min=0, sec=0, tzoffset=120})
+    test:ok(date.parse("1970-01-01T01:00:00", {tzoffset = '+02:00'}) ==
+            date.new{year=1970, mon=1, day=1, hour=1, min=0, sec=0, tzoffset=120})
+    test:ok(date.parse("1970-01-01T01:00:00Z", {tzoffset = '+02:00'}) ==
+            date.new{year=1970, mon=1, day=1, hour=1, min=0, sec=0, tzoffset=0})
+    test:ok(date.parse("1970-01-01T01:00:00+01:00", {tzoffset = '+02:00'}) ==
+            date.new{year=1970, mon=1, day=1, hour=1, min=0, sec=0, tzoffset=60})
+
+    test:ok(date.parse("1970-01-01T02:00:00Z") <
+            date.new{year=1970, mon=1, day=1, hour=2, min=0, sec=1})
+    test:ok(date.parse("1970-01-01T02:00:00Z") <=
+            date.new{year=1970, mon=1, day=1, hour=2, min=0, sec=0})
+end)
+
+test:test("Multiple tests for parser (with nanoseconds)", function(test)
+    test:plan(211)
+    -- borrowed from
+    -- github.com/chansen/p5-time-moment/blob/master/t/180_from_string.t
+    local tests =
+    {
+        --{ iso-8601 string, epoch, nanoseconds, tz-offset, do reverse check?}
+        {'0001-01-01T00:00:00Z',    -62135596800,         0,    0, 0},
+        {'00010101T000000Z',        -62135596800,         0,    0, 0},
+        {'0001-W01-1T00:00:00Z',    -62135596800,         0,    0, 0},
+        {'0001W011T000000Z',        -62135596800,         0,    0, 0},
+        {'0001-001T00:00:00Z',      -62135596800,         0,    0, 0},
+        {'0001001T000000Z',         -62135596800,         0,    0, 0},
+        {'1970-01-01T00:00:00Z',               0,         0,    0, 1},
+        {'1970-01-01T02:00:00+0200',           0,         0,  120, 1},
+        {'1970-01-01T01:30:00+0130',           0,         0,   90, 1},
+        {'1970-01-01T01:00:00+0100',           0,         0,   60, 1},
+        {'1970-01-01T00:01:00+0001',           0,         0,    1, 1},
+        {'1970-01-01T00:00:00Z',               0,         0,    0, 1},
+        {'1969-12-31T23:59:00-0001',           0,         0,   -1, 1},
+        {'1969-12-31T23:00:00-0100',           0,         0,  -60, 1},
+        {'1969-12-31T22:30:00-0130',           0,         0,  -90, 1},
+        {'1969-12-31T22:00:00-0200',           0,         0, -120, 1},
+        {'1970-01-01T00:00:00.123456789Z',     0, 123456789,    0, 1},
+        {'1970-01-01T00:00:00.12345678Z',      0, 123456780,    0, 0},
+        {'1970-01-01T00:00:00.1234567Z',       0, 123456700,    0, 0},
+        {'1970-01-01T00:00:00.123456Z',        0, 123456000,    0, 1},
+        {'1970-01-01T00:00:00.12345Z',         0, 123450000,    0, 0},
+        {'1970-01-01T00:00:00.1234Z',          0, 123400000,    0, 0},
+        {'1970-01-01T00:00:00.123Z',           0, 123000000,    0, 1},
+        {'1970-01-01T00:00:00.12Z',            0, 120000000,    0, 0},
+        {'1970-01-01T00:00:00.1Z',             0, 100000000,    0, 0},
+        {'1970-01-01T00:00:00.01Z',            0,  10000000,    0, 0},
+        {'1970-01-01T00:00:00.001Z',           0,   1000000,    0, 1},
+        {'1970-01-01T00:00:00.0001Z',          0,    100000,    0, 0},
+        {'1970-01-01T00:00:00.00001Z',         0,     10000,    0, 0},
+        {'1970-01-01T00:00:00.000001Z',        0,      1000,    0, 1},
+        {'1970-01-01T00:00:00.0000001Z',       0,       100,    0, 0},
+        {'1970-01-01T00:00:00.00000001Z',      0,        10,    0, 0},
+        {'1970-01-01T00:00:00.000000001Z',     0,         1,    0, 1},
+        {'1970-01-01T00:00:00.000000009Z',     0,         9,    0, 1},
+        {'1970-01-01T00:00:00.00000009Z',      0,        90,    0, 0},
+        {'1970-01-01T00:00:00.0000009Z',       0,       900,    0, 0},
+        {'1970-01-01T00:00:00.000009Z',        0,      9000,    0, 1},
+        {'1970-01-01T00:00:00.00009Z',         0,     90000,    0, 0},
+        {'1970-01-01T00:00:00.0009Z',          0,    900000,    0, 0},
+        {'1970-01-01T00:00:00.009Z',           0,   9000000,    0, 1},
+        {'1970-01-01T00:00:00.09Z',            0,  90000000,    0, 0},
+        {'1970-01-01T00:00:00.9Z',             0, 900000000,    0, 0},
+        {'1970-01-01T00:00:00.99Z',            0, 990000000,    0, 0},
+        {'1970-01-01T00:00:00.999Z',           0, 999000000,    0, 1},
+        {'1970-01-01T00:00:00.9999Z',          0, 999900000,    0, 0},
+        {'1970-01-01T00:00:00.99999Z',         0, 999990000,    0, 0},
+        {'1970-01-01T00:00:00.999999Z',        0, 999999000,    0, 1},
+        {'1970-01-01T00:00:00.9999999Z',       0, 999999900,    0, 0},
+        {'1970-01-01T00:00:00.99999999Z',      0, 999999990,    0, 0},
+        {'1970-01-01T00:00:00.999999999Z',     0, 999999999,    0, 1},
+        {'1970-01-01T00:00:00.0Z',             0,         0,    0, 0},
+        {'1970-01-01T00:00:00.00Z',            0,         0,    0, 0},
+        {'1970-01-01T00:00:00.000Z',           0,         0,    0, 0},
+        {'1970-01-01T00:00:00.0000Z',          0,         0,    0, 0},
+        {'1970-01-01T00:00:00.00000Z',         0,         0,    0, 0},
+        {'1970-01-01T00:00:00.000000Z',        0,         0,    0, 0},
+        {'1970-01-01T00:00:00.0000000Z',       0,         0,    0, 0},
+        {'1970-01-01T00:00:00.00000000Z',      0,         0,    0, 0},
+        {'1970-01-01T00:00:00.000000000Z',     0,         0,    0, 0},
+        {'1973-11-29T21:33:09Z',       123456789,         0,    0, 1},
+        {'2013-10-28T17:51:56Z',      1382982716,         0,    0, 1},
+        {'9999-12-31T23:59:59Z',    253402300799,         0,    0, 1},
+    }
+    for _, value in ipairs(tests) do
+        local str, epoch, nsec, tzoffset, check
+        str, epoch, nsec, tzoffset, check = unpack(value)
+        local dt = date.parse(str)
+        test:is(dt.epoch, epoch, ('%s: dt.epoch == %d'):format(str, epoch))
+        test:is(dt.nsec, nsec, ('%s: dt.nsec == %d'):format(str, nsec))
+        test:is(dt.tzoffset, tzoffset, ('%s: dt.tzoffset == %d'):format(str, tzoffset))
+        if check > 0 then
+            test:is(str, tostring(dt), ('%s == tostring(%s)'):
+                    format(str, tostring(dt)))
+        end
+    end
+end)
+
+local function couldnt_parse(txt)
+    return ("could not parse '%s'"):format(txt)
+end
+
+local function create_date_string(date)
+    local year, month, day = date.year or 1970, date.month or 1, date.day or 1
+    local hour, min, sec = date.hour or 0, date.min or 0, date.sec or 0
+    return ('%04d-%02d-%02dT%02d:%02d:%02dZ'):format(year, month, day, hour, min, sec)
+end
+
+test:test("Check parsing of dates with invalid attributes", function(test)
+    test:plan(32)
+
+    local boundary_checks = {
+        {'month', {1, 12}},
+        {'day', {1, 31, -1}},
+        {'hour', {0, 23}},
+        {'min', {0, 59}},
+        {'sec', {0, 59}},
+    }
+    for _, row in pairs(boundary_checks) do
+        local attr_name, bounds = unpack(row)
+        local left, right = unpack(bounds)
+        local txt = create_date_string{[attr_name] = left}
+        local dt, len = date.parse(txt)
+        test:ok(dt ~= nil, dt)
+        test:ok(len == #txt, len)
+        local txt = create_date_string{[attr_name] = right}
+        dt, len = date.parse(txt)
+        test:ok(dt ~= nil, dt)
+        test:ok(len == #txt, len)
+        -- expected error
+        if left > 0 then
+            txt = create_date_string{[attr_name] = left - 1}
+            assert_raises(test, couldnt_parse(txt),
+                          function() dt, len = date.parse(txt) end)
+        end
+        txt = create_date_string{[attr_name] = right + 2}
+        assert_raises(test, couldnt_parse(txt),
+                      function() dt, len = date.parse(txt) end)
+        txt = create_date_string{[attr_name] = right + 50}
+        assert_raises(test, couldnt_parse(txt),
+                      function() dt, len = date.parse(txt) end)
     end
 end)
 
@@ -1127,6 +1290,90 @@ test:test("Matrix of allowed time and interval subtractions", function(test)
     test:is(catchsub_status(min_date, new_ival{week = 100}), false, "min - 100wk")
 end)
 
+test:test("Parse iso8601 date - valid strings", function(test)
+    test:plan(32)
+    local good = {
+        {2012, 12, 24, "20121224",                   8 },
+        {2012, 12, 24, "20121224  Foo bar",          8 },
+        {2012, 12, 24, "2012-12-24",                10 },
+        {2012, 12, 24, "2012-12-24 23:59:59",       10 },
+        {2012, 12, 24, "2012-12-24T00:00:00+00:00", 10 },
+        {2012, 12, 24, "2012359",                    7 },
+        {2012, 12, 24, "2012359T235959+0130",        7 },
+        {2012, 12, 24, "2012-359",                   8 },
+        {2012, 12, 24, "2012W521",                   8 },
+        {2012, 12, 24, "2012-W52-1",                10 },
+        {2012, 12, 24, "2012Q485",                   8 },
+        {2012, 12, 24, "2012-Q4-85",                10 },
+        {   1,  1,  1, "0001-Q1-01",                10 },
+        {   1,  1,  1, "0001-W01-1",                10 },
+        {   1,  1,  1, "0001-01-01",                10 },
+        {   1,  1,  1, "0001-001",                   8 },
+    }
+
+    for _, value in ipairs(good) do
+        local year, month, day, str, date_part_len
+        year, month, day, str, date_part_len = unpack(value)
+        local expected_date = date.new{year = year, month = month, day = day}
+        local date_part, len
+        date_part, len = date.parse_date(str)
+        test:is(len, date_part_len, ('%s: length check %d'):format(str, len))
+        test:is(expected_date, date_part, ('%s: expected date'):format(str))
+    end
+end)
+
+test:test("Parse iso8601 date - invalid strings", function(test)
+    test:plan(31)
+    local bad = {
+        "20121232"   , -- Invalid day of month
+        "2012-12-310", -- Invalid day of month
+        "2012-13-24" , -- Invalid month
+        "2012367"    , -- Invalid day of year
+        "2012-000"   , -- Invalid day of year
+        "2012W533"   , -- Invalid week of year
+        "2012-W52-8" , -- Invalid day of week
+        "2012Q495"   , -- Invalid day of quarter
+        "2012-Q5-85" , -- Invalid quarter
+        "20123670"   , -- Trailing digit
+        "201212320"  , -- Trailing digit
+        "2012-12"    , -- Reduced accuracy
+        "2012-Q4"    , -- Reduced accuracy
+        "2012-Q42"   , -- Invalid
+        "2012-Q1-1"  , -- Invalid day of quarter
+        "2012Q--420" , -- Invalid
+        "2012-Q-420" , -- Invalid
+        "2012Q11"    , -- Incomplete
+        "2012Q1234"  , -- Trailing digit
+        "2012W12"    , -- Incomplete
+        "2012W1234"  , -- Trailing digit
+        "2012W-123"  , -- Invalid
+        "2012-W12"   , -- Incomplete
+        "2012-W12-12", -- Trailing digit
+        "2012U1234"  , -- Invalid
+        "2012-1234"  , -- Invalid
+        "2012-X1234" , -- Invalid
+        "0000-Q1-01" , -- Year less than 0001
+        "0000-W01-1" , -- Year less than 0001
+        "0000-01-01" , -- Year less than 0001
+        "0000-001"   , -- Year less than 0001
+    }
+
+    for _, str in ipairs(bad) do
+        assert_raises(test, invalid_date_fmt_error(str),
+                      function() date.parse_date(str) end)
+    end
+end)
+
+test:test("Parse tiny date into seconds and other parts", function(test)
+    test:plan(4)
+    local str = '19700101 00:00:30.528'
+    local tiny = date.parse(str)
+    test:is(tiny.epoch, 30, ("epoch of '%s'"):format(str))
+    test:is(tiny.nsec, 528000000, ("nsec of '%s'"):format(str))
+    test:is(tiny.sec, 30, "sec")
+    test:is(tiny.timestamp, 30.528, "timestamp")
+end)
+
 test:test("totable{}", function(test)
     test:plan(78)
     local exp = {sec = 0, min = 0, wday = 5, day = 1,
@@ -1289,10 +1536,10 @@ test:test("Time invalid :set{} operations", function(test)
             {year = -16009610, month = 12, day = 31}},
         {range_check_error('year', 16009610, {MIN_DATE_YEAR, MAX_DATE_YEAR}),
             {year = 16009610, month = 1, day = 1}},
-        {greater_than_max(5879611, 9, 1),
-            {year = 5879611, month = 9, day = 1}},
-        {greater_than_max(5879611, 7, 12),
-            {year = 5879611, month = 7, day = 12}},
+        {greater_than_max(MAX_DATE_YEAR, 9, 1),
+            {year = MAX_DATE_YEAR, month = 9, day = 1}},
+        {greater_than_max(MAX_DATE_YEAR, 7, 12),
+            {year = MAX_DATE_YEAR, month = 7, day = 12}},
     }
     for _, row in pairs(specific_errors) do
         local err_msg, attribs = unpack(row)

--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -15,12 +15,8 @@ test:plan(32)
 
 -- minimum supported date - -5879610-06-22
 local MIN_DATE_YEAR = -5879610
-local MIN_DATE_MONTH = 6
-local MIN_DATE_DAY = 22
 -- maximum supported date - 5879611-07-11
 local MAX_DATE_YEAR = 5879611
-local MAX_DATE_MONTH = 7
-local MAX_DATE_DAY = 11
 
 local SECS_PER_DAY      = 86400
 local AVERAGE_DAYS_YEAR = 365.25
@@ -78,14 +74,8 @@ local function range_check_3_error(name, value, range)
             format(value, name, range[1], range[2], range[3])
 end
 
-local function less_than_min(y, M, d)
-    return ('date %d-%02d-%02d is less than minimum allowed %d-%02d-%02d'):
-            format(y, M, d, MIN_DATE_YEAR, MIN_DATE_MONTH, MIN_DATE_DAY)
-end
-
-local function greater_than_max(y, M, d)
-    return ('date %d-%02d-%02d is greater than maximum allowed %d-%02d-%02d'):
-            format(y, M, d, MAX_DATE_YEAR, MAX_DATE_MONTH, MAX_DATE_DAY)
+local function invalid_date(y, M, d)
+    return ('date %d-%02d-%02d is invalid'):format(y, M, d)
 end
 
 local function invalid_tz_fmt_error(val)
@@ -320,17 +310,17 @@ test:test("Simple date creation by attributes - check failed", function(test)
         {range_check_3_error('day', 32, {-1, 1, 31}),
             {year = 2021, month = 6, day = 32}},
         {invalid_days_in_mon(31, 6, 2021), { year = 2021, month = 6, day = 31}},
-        {less_than_min(-5879610, 6, 21),
+        {invalid_date(-5879610, 6, 21),
             {year = -5879610, month = 6, day = 21}},
-        {less_than_min(-5879610, 1, 1),
+        {invalid_date(-5879610, 1, 1),
             {year = -5879610, month = 1, day = 1}},
         {range_check_error('year', -16009610, {MIN_DATE_YEAR, MAX_DATE_YEAR}),
             {year = -16009610, month = 12, day = 31}},
         {range_check_error('year', 16009610, {MIN_DATE_YEAR, MAX_DATE_YEAR}),
             {year = 16009610, month = 1, day = 1}},
-        {greater_than_max(MAX_DATE_YEAR, 9, 1),
+        {invalid_date(MAX_DATE_YEAR, 9, 1),
             {year = MAX_DATE_YEAR, month = 9, day = 1}},
-        {greater_than_max(MAX_DATE_YEAR, 7, 12),
+        {invalid_date(MAX_DATE_YEAR, 7, 12),
             {year = MAX_DATE_YEAR, month = 7, day = 12}},
     }
     for _, row in pairs(specific_errors) do
@@ -1610,17 +1600,17 @@ test:test("Time invalid :set{} operations", function(test)
         {range_check_3_error('day', 32, {-1, 1, 31}),
             {year = 2021, month = 6, day = 32}},
         {invalid_days_in_mon(31, 6, 2021), { month = 6, day = 31}},
-        {less_than_min(-5879610, 6, 21),
+        {invalid_date(-5879610, 6, 21),
             {year = -5879610, month = 6, day = 21}},
-        {less_than_min(-5879610, 1, 1),
+        {invalid_date(-5879610, 1, 1),
             {year = -5879610, month = 1, day = 1}},
         {range_check_error('year', -16009610, {MIN_DATE_YEAR, MAX_DATE_YEAR}),
             {year = -16009610, month = 12, day = 31}},
         {range_check_error('year', 16009610, {MIN_DATE_YEAR, MAX_DATE_YEAR}),
             {year = 16009610, month = 1, day = 1}},
-        {greater_than_max(MAX_DATE_YEAR, 9, 1),
+        {invalid_date(MAX_DATE_YEAR, 9, 1),
             {year = MAX_DATE_YEAR, month = 9, day = 1}},
-        {greater_than_max(MAX_DATE_YEAR, 7, 12),
+        {invalid_date(MAX_DATE_YEAR, 7, 12),
             {year = MAX_DATE_YEAR, month = 7, day = 12}},
     }
     for _, row in pairs(specific_errors) do

--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -11,7 +11,7 @@ local ffi = require('ffi')
 --]]
 if jit.arch == 'arm64' then jit.off() end
 
-test:plan(29)
+test:plan(31)
 
 -- minimum supported date - -5879610-06-22
 local MIN_DATE_YEAR = -5879610
@@ -492,14 +492,14 @@ test:test("Multiple tests for parser (with nanoseconds)", function(test)
     end
 end)
 
-local function couldnt_parse(txt)
-    return ("could not parse '%s'"):format(txt)
-end
-
 local function create_date_string(date)
     local year, month, day = date.year or 1970, date.month or 1, date.day or 1
     local hour, min, sec = date.hour or 0, date.min or 0, date.sec or 0
     return ('%04d-%02d-%02dT%02d:%02d:%02dZ'):format(year, month, day, hour, min, sec)
+end
+
+local function couldnt_parse(txt)
+    return ("could not parse '%s'"):format(txt)
 end
 
 test:test("Check parsing of dates with invalid attributes", function(test)
@@ -590,94 +590,110 @@ test:test("Datetime formatting of huge dates", function(test)
     check_variant_formats(test, base, variants)
 end)
 
+local strftime_formats = {
+    { '%A',                      1, 'Thursday' },
+    { '%a',                      1, 'Thu' },
+    { '%B',                      1, 'January' },
+    { '%b',                      1, 'Jan' },
+    { '%h',                      1, 'Jan' },
+    { '%C',                      0, '19' },
+    { '%c',                      1, 'Thu Jan  1 03:00:00 1970' },
+    { '%D',                      1, '01/01/70' },
+    { '%m/%d/%y',                1, '01/01/70' },
+    { '%d',                      1, '01' },
+    { '%Ec',                     1, 'Thu Jan  1 03:00:00 1970' },
+    { '%EC',                     0, '19' },
+    { '%Ex',                     1, '01/01/70' },
+    { '%EX',                     1, '03:00:00' },
+    { '%Ey',                     1, '70' },
+    { '%EY',                     1, '1970' },
+    { '%Od',                     1, '01' },
+    { '%oe',                     0, 'oe' },
+    { '%OH',                     1, '03' },
+    { '%OI',                     1, '03' },
+    { '%Om',                     1, '01' },
+    { '%OM',                     1, '00' },
+    { '%OS',                     1, '00' },
+    { '%Ou',                     1, '4' },
+    { '%OU',                     1, '00' },
+    { '%OV',                     0, '01' },
+    { '%Ow',                     1, '4' },
+    { '%OW',                     1, '00' },
+    { '%Oy',                     1, '70' },
+    { '%e',                      1, ' 1' },
+    { '%F',                      1, '1970-01-01' },
+    { '%Y-%m-%d',                1, '1970-01-01' },
+    { '%H',                      1, '03' },
+    { '%I',                      1, '03' },
+    { '%j',                      1, '001' },
+    { '%k',                      1, ' 3' },
+    { '%l',                      1, ' 3' },
+    { '%M',                      1, '00' },
+    { '%m',                      1, '01' },
+    { '%n',                      1, '\n' },
+    { '%p',                      1, 'AM' },
+    { '%R',                      1, '03:00' },
+    { '%H:%M',                   1, '03:00' },
+    { '%r',                      1, '03:00:00 AM' },
+    { '%I:%M:%S %p',             1, '03:00:00 AM' },
+    { '%S',                      1, '00' },
+    { '%s',                      1, '10800' },
+    { '%f',                      1, '125' },
+    { '%3f',                     0, '125' },
+    { '%6f',                     0, '125000' },
+    { '%6d',                     0, '6d' },
+    { '%3D',                     0, '3D' },
+    { '%T',                      1, '03:00:00' },
+    { '%H:%M:%S',                1, '03:00:00' },
+    { '%t',                      1, '\t' },
+    { '%U',                      1, '00' },
+    { '%u',                      1, '4' },
+    { '%V',                      0, '01' },
+    { '%G',                      1, '1970' },
+    { '%g',                      1, '70' },
+    { '%v',                      1, ' 1-Jan-1970' },
+    { '%e-%b-%Y',                1, ' 1-Jan-1970' },
+    { '%W',                      1, '00' },
+    { '%w',                      1, '4' },
+    { '%X',                      1, '03:00:00' },
+    { '%x',                      1, '01/01/70' },
+    { '%y',                      1, '70' },
+    { '%Y',                      1, '1970' },
+    { '%z',                      1, '+0300' },
+    { '%%',                      1, '%' },
+    { '%Y-%m-%dT%H:%M:%S.%9f%z', 1, '1970-01-01T03:00:00.125000000+0300' },
+    { '%Y-%m-%dT%H:%M:%S.%f%z',  1, '1970-01-01T03:00:00.125+0300' },
+    { '%Y-%m-%dT%H:%M:%S.%f',    1, '1970-01-01T03:00:00.125' },
+    { '%FT%T.%f',                1, '1970-01-01T03:00:00.125' },
+    { '%FT%T.%f%z',              1, '1970-01-01T03:00:00.125+0300' },
+    { '%FT%T.%9f%z',             1, '1970-01-01T03:00:00.125000000+0300' },
+}
+
 test:test("Datetime string formatting detailed", function(test)
     test:plan(77)
     local T = date.new{ timestamp = 0.125 }
     T:set{ tzoffset = 180 }
     test:is(tostring(T), '1970-01-01T03:00:00.125+0300', 'tostring()')
 
-    local formats = {
-        { '%A',                         'Thursday' },
-        { '%a',                         'Thu' },
-        { '%B',                         'January' },
-        { '%b',                         'Jan' },
-        { '%h',                         'Jan' },
-        { '%C',                         '19' },
-        { '%c',                         'Thu Jan  1 03:00:00 1970' },
-        { '%D',                         '01/01/70' },
-        { '%m/%d/%y',                   '01/01/70' },
-        { '%d',                         '01' },
-        { '%Ec',                        'Thu Jan  1 03:00:00 1970' },
-        { '%EC',                        '19' },
-        { '%Ex',                        '01/01/70' },
-        { '%EX',                        '03:00:00' },
-        { '%Ey',                        '70' },
-        { '%EY',                        '1970' },
-        { '%Od',                        '01' },
-        { '%oe',                        'oe' },
-        { '%OH',                        '03' },
-        { '%OI',                        '03' },
-        { '%Om',                        '01' },
-        { '%OM',                        '00' },
-        { '%OS',                        '00' },
-        { '%Ou',                        '4' },
-        { '%OU',                        '00' },
-        { '%OV',                        '01' },
-        { '%Ow',                        '4' },
-        { '%OW',                        '00' },
-        { '%Oy',                        '70' },
-        { '%e',                         ' 1' },
-        { '%F',                         '1970-01-01' },
-        { '%Y-%m-%d',                   '1970-01-01' },
-        { '%H',                         '03' },
-        { '%I',                         '03' },
-        { '%j',                         '001' },
-        { '%k',                         ' 3' },
-        { '%l',                         ' 3' },
-        { '%M',                         '00' },
-        { '%m',                         '01' },
-        { '%n',                         '\n' },
-        { '%p',                         'AM' },
-        { '%R',                         '03:00' },
-        { '%H:%M',                      '03:00' },
-        { '%r',                         '03:00:00 AM' },
-        { '%I:%M:%S %p',                '03:00:00 AM' },
-        { '%S',                         '00' },
-        { '%s',                         '10800' },
-        { '%f',                         '125' },
-        { '%3f',                        '125' },
-        { '%6f',                        '125000' },
-        { '%6d',                        '6d' },
-        { '%3D',                        '3D' },
-        { '%T',                         '03:00:00' },
-        { '%H:%M:%S',                   '03:00:00' },
-        { '%t',                         '\t' },
-        { '%U',                         '00' },
-        { '%u',                         '4' },
-        { '%V',                         '01' },
-        { '%G',                         '1970' },
-        { '%g',                         '70' },
-        { '%v',                         ' 1-Jan-1970' },
-        { '%e-%b-%Y',                   ' 1-Jan-1970' },
-        { '%W',                         '00' },
-        { '%w',                         '4' },
-        { '%X',                         '03:00:00' },
-        { '%x',                         '01/01/70' },
-        { '%y',                         '70' },
-        { '%Y',                         '1970' },
-        { '%z',                         '+0300' },
-        { '%%',                         '%' },
-        { '%Y-%m-%dT%H:%M:%S.%9f%z',    '1970-01-01T03:00:00.125000000+0300' },
-        { '%Y-%m-%dT%H:%M:%S.%f%z',     '1970-01-01T03:00:00.125+0300' },
-        { '%Y-%m-%dT%H:%M:%S.%f',       '1970-01-01T03:00:00.125' },
-        { '%FT%T.%f',                   '1970-01-01T03:00:00.125' },
-        { '%FT%T.%f%z',                 '1970-01-01T03:00:00.125+0300' },
-        { '%FT%T.%9f%z',                '1970-01-01T03:00:00.125000000+0300' },
-    }
-    for _, row in pairs(formats) do
-        local fmt, value = unpack(row)
+    for _, row in pairs(strftime_formats) do
+        local fmt, _, value = unpack(row)
         test:is(T:format(fmt), value,
                 ('format %s, expected %s'):format(fmt, value))
+    end
+end)
+
+test:test("Datetime string parsing by format (detailed)", function(test)
+    test:plan(68)
+    local T = date.new{ timestamp = 0.125 }
+    T:set{ tzoffset = 180 }
+    test:is(tostring(T), '1970-01-01T03:00:00.125+0300', 'tostring()')
+
+    for _, row in pairs(strftime_formats) do
+        local fmt, check, value = unpack(row)
+        if check > 0 then
+            local res = date.parse(value, {format = fmt})
+            test:is(res ~= nil, true, ('parse of %s'):format(fmt))
+        end
     end
 end)
 
@@ -1372,6 +1388,42 @@ test:test("Parse tiny date into seconds and other parts", function(test)
     test:is(tiny.nsec, 528000000, ("nsec of '%s'"):format(str))
     test:is(tiny.sec, 30, "sec")
     test:is(tiny.timestamp, 30.528, "timestamp")
+end)
+
+test:test("Parse strptime format", function(test)
+    test:plan(17)
+    local formats = {
+        {'Thu Jan  1 03:00:00 1970',    '%c',       '1970-01-01T03:00:00Z'},
+        {'01/01/70',                    '%D',       '1970-01-01T00:00:00Z'},
+        {'01/01/70',                    '%m/%d/%y', '1970-01-01T00:00:00Z'},
+        {'Thu Jan  1 03:00:00 1970',    '%Ec',      '1970-01-01T03:00:00Z'},
+        {'1970-01-01',                  '%F',       '1970-01-01T00:00:00Z'},
+        {'1970-01-01',                  '%Y-%m-%d', '1970-01-01T00:00:00Z'},
+        {' 1-Jan-1970',                 '%v',       '1970-01-01T00:00:00Z'},
+        {' 1-Jan-1970',                 '%e-%b-%Y', '1970-01-01T00:00:00Z'},
+        {'01/01/70',                    '%x',       '1970-01-01T00:00:00Z'},
+        {'1970-01-01T0300+0300',        '%Y-%m-%dT%H%M%z',
+            '1970-01-01T03:00:00+0300'},
+        {'1970-01-01T03:00:00+0300',    '%Y-%m-%dT%H:%M:%S%z',
+            '1970-01-01T03:00:00+0300'},
+        {'1970-01-01T03:00:00.125000000+0300',  '%Y-%m-%dT%H:%M:%S.%f%z',
+            '1970-01-01T03:00:00.125+0300'},
+        {'1970-01-01T03:00:00.125+0300',        '%Y-%m-%dT%H:%M:%S.%f%z',
+            '1970-01-01T03:00:00.125+0300'},
+        {'1970-01-01T03:00:00.125',             '%Y-%m-%dT%H:%M:%S.%f',
+            '1970-01-01T03:00:00.125Z'},
+        {'1970-01-01T03:00:00.125',             '%FT%T.%f',
+            '1970-01-01T03:00:00.125Z'},
+        {'1970-01-01T03:00:00.125+0300',        '%FT%T.%f%z',
+            '1970-01-01T03:00:00.125+0300'},
+        {'1970-01-01T03:00:00.125000000+0300',  '%FT%T.%f%z',
+            '1970-01-01T03:00:00.125+0300'},
+    }
+    for _, row in pairs(formats) do
+        local str, fmt, exp = unpack(row)
+        local dt = date.parse(str, {format = fmt})
+        test:is(tostring(dt), exp, ('parse %s via %s'):format(str, fmt))
+    end
 end)
 
 test:test("totable{}", function(test)

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -44,7 +44,15 @@ target_link_libraries(swim_proto_member_fuzzer PUBLIC swim fuzzer_config)
 add_executable(swim_proto_meta_fuzzer swim_proto_meta_fuzzer.c)
 target_link_libraries(swim_proto_meta_fuzzer PUBLIC swim fuzzer_config)
 
+add_executable(datetime_parse_full_fuzzer datetime_parse_full_fuzzer.c)
+target_link_libraries(datetime_parse_full_fuzzer PUBLIC core fuzzer_config)
+
+add_executable(datetime_strptime_fuzzer datetime_strptime_fuzzer.c)
+target_link_libraries(datetime_strptime_fuzzer PUBLIC core fuzzer_config)
+
 set(fuzzing_binaries csv_fuzzer
+                     datetime_parse_full_fuzzer
+                     datetime_strptime_fuzzer
                      http_parser_fuzzer
                      swim_proto_member_fuzzer
                      swim_proto_meta_fuzzer

--- a/test/fuzz/datetime_parse_full_fuzzer.c
+++ b/test/fuzz/datetime_parse_full_fuzzer.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+#include <string.h>
+#include "datetime.h"
+#include "trivia/util.h"
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	char *buf = xcalloc(size + 1, sizeof(char));
+	if (buf == NULL)
+		return 0;
+	memcpy(buf, data, size);
+	buf[size] = '\0';
+	struct datetime date_expected;
+	datetime_parse_full(&date_expected, buf, size, 0);
+	free(buf);
+
+	return 0;
+}

--- a/test/fuzz/datetime_strptime_fuzzer.c
+++ b/test/fuzz/datetime_strptime_fuzzer.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+#include <string.h>
+#include "datetime.h"
+#include "trivia/util.h"
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	char *buf = xcalloc(size + 1, sizeof(char));
+	if (buf == NULL)
+		return 0;
+	memcpy(buf, data, size);
+	buf[size] = '\0';
+	struct datetime date_expected;
+	datetime_strptime(&date_expected, buf, "iso8601");
+	free(buf);
+
+	return 0;
+}

--- a/test/unit/datetime.c
+++ b/test/unit/datetime.c
@@ -102,7 +102,7 @@ datetime_test(void)
 	size_t index;
 	struct datetime date_expected;
 
-	plan(355);
+	plan(497);
 	datetime_parse_full(&date_expected, sample, sizeof(sample) - 1, 0);
 
 	for (index = 0; index < lengthof(tests); index++) {
@@ -121,15 +121,20 @@ datetime_test(void)
 		 * time fields
 		 */
 		static char buff[DT_TO_STRING_BUFSIZE];
-		struct tnt_tm tm = { .tm_sec = 0 };
 		len = datetime_strftime(&date, buff, sizeof(buff), "%F %T%z");
 		ok(len > 0, "strftime");
+		struct datetime date_strp;
+		len = datetime_strptime(&date_strp, buff, "%F %T%z");
+		is(len > 0, true, "correct parse_strptime return value "
+		   "for '%s'", buff);
+		is(date.epoch, date_strp.epoch,
+		   "reversible seconds via datetime_strptime for '%s'", buff);
 		struct datetime date_parsed;
 		len = datetime_parse_full(&date_parsed, buff, len, 0);
-		is(len > 0, true, "correct parse_datetime return value "
+		is(len > 0, true, "correct datetime_parse_full return value "
 		   "for '%s'", buff);
 		is(date.epoch, date_parsed.epoch,
-		   "reversible seconds via strftime for '%s'", buff);
+		   "reversible seconds via datetime_parse_full for '%s'", buff);
 	}
 	check_plan();
 }
@@ -158,10 +163,12 @@ tostring_datetime_test(void)
 		{"1973-11-29T21:33:09Z",    123456789,         0,    0},
 		{"2013-10-28T17:51:56Z",   1382982716,         0,    0},
 		{"9999-12-31T23:59:59Z", 253402300799,         0,    0},
+		{"10000-01-01T00:00:00Z", 253402300800,        0,    0},
+		{"5879611-07-11T00:00:00Z", 185480451417600,   0,    0},
 	};
 	size_t index;
 
-	plan(15);
+	plan(17);
 	for (index = 0; index < lengthof(tests); index++) {
 		struct datetime date = {
 			tests[index].secs,
@@ -187,7 +194,7 @@ _dt_to_epoch(dt_t dt)
 static void
 parse_date_test(void)
 {
-	plan(59);
+	plan(154);
 
 	static struct {
 		int64_t epoch;
@@ -210,6 +217,19 @@ parse_date_test(void)
 		{ -62135596800, "0001-W01-1", 10 },
 		{ -62135596800, "0001-01-01", 10 },
 		{ -62135596800, "0001-001", 8 },
+
+		/* Tarantool extra ranges */
+		{ -62167219200, "0000-01-01", 10 },
+		{ -62167046400, "0000-W01-1", 10 },
+		{ -62167219200, "0000-Q1-01", 10 },
+		{ -68447116800, "-200-12-31", 10 },
+		{ -377705203200, "-10000-12-31", 12 },
+		{ -185604722870400, "-5879610-06-22", 14 },
+		{ -185604706627200, "-5879610W521", 12 },
+		{ 253402214400, "9999-12-31", 10 },
+		{ 253402300800, "10000-01-01", 11 },
+		{ 185480451417600, "5879611-07-11", 13 },
+		{ 185480434915200, "5879611Q101", 11 },
 	};
 	size_t index;
 
@@ -220,10 +240,10 @@ parse_date_test(void)
 		int64_t expected_epoch = valid_tests[index].epoch;
 		size_t len = tnt_dt_parse_iso_date(str, expected_len, &dt);
 		int64_t epoch = _dt_to_epoch(dt);
-		is(len, expected_len, "string '%s' parse failed, len %lu", str,
+		is(len, expected_len, "string '%s' parse, len %lu", str,
 		   len);
-		is(epoch, expected_epoch,
-		   "string '%s' parse failed, epoch %" PRId64, str, epoch);
+		is(epoch, expected_epoch, "string '%s' parse, epoch %" PRId64,
+		   str, epoch);
 	}
 
 	static const char *const invalid_tests[] = {
@@ -262,6 +282,98 @@ parse_date_test(void)
 		is(len, 0, "expected failure of string '%s' parse, len %lu",
 		   str, len);
 	}
+
+	/* check strptime formats */
+	const struct {
+		const char *fmt;
+		const char *text;
+	} format_tests[] = {
+		{ "%A",                      "Thursday" },
+		{ "%a",                      "Thu" },
+		{ "%B",                      "January" },
+		{ "%b",                      "Jan" },
+		{ "%h",                      "Jan" },
+		{ "%c",                      "Thu Jan  1 03:00:00 1970" },
+		{ "%D",                      "01/01/70" },
+		{ "%m/%d/%y",                "01/01/70" },
+		{ "%d",                      "01" },
+		{ "%Ec",                     "Thu Jan  1 03:00:00 1970" },
+		{ "%Ex",                     "01/01/70" },
+		{ "%EX",                     "03:00:00" },
+		{ "%Ey",                     "70" },
+		{ "%EY",                     "1970" },
+		{ "%Od",                     "01" },
+		{ "%OH",                     "03" },
+		{ "%OI",                     "03" },
+		{ "%Om",                     "01" },
+		{ "%OM",                     "00" },
+		{ "%OS",                     "00" },
+		{ "%Ou",                     "4" },
+		{ "%OU",                     "00" },
+		{ "%Ow",                     "4" },
+		{ "%OW",                     "00" },
+		{ "%Oy",                     "70" },
+		{ "%e",                      " 1" },
+		{ "%F",                      "1970-01-01" },
+		{ "%Y-%m-%d",                "1970-01-01" },
+		{ "%H",                      "03" },
+		{ "%I",                      "03" },
+		{ "%j",                      "001" },
+		{ "%k",                      " 3" },
+		{ "%l",                      " 3" },
+		{ "%M",                      "00" },
+		{ "%m",                      "01" },
+		{ "%n",                      "\n" },
+		{ "%p",                      "AM" },
+		{ "%R",                      "03:00" },
+		{ "%H:%M",                   "03:00" },
+		{ "%r",                      "03:00:00 AM" },
+		{ "%I:%M:%S %p",             "03:00:00 AM" },
+		{ "%S",                      "00" },
+		{ "%s",                      "10800" },
+		{ "%f",                      "125" },
+		{ "%T",                      "03:00:00" },
+		{ "%H:%M:%S",                "03:00:00" },
+		{ "%t",                      "\t" },
+		{ "%U",                      "00" },
+		{ "%u",                      "4" },
+		{ "%G",                      "1970" },
+		{ "%g",                      "70" },
+		{ "%v",                      " 1-Jan-1970" },
+		{ "%e-%b-%Y",                " 1-Jan-1970" },
+		{ "%W",                      "00" },
+		{ "%w",                      "4" },
+		{ "%X",                      "03:00:00" },
+		{ "%x",                      "01/01/70" },
+		{ "%y",                      "70" },
+		{ "%Y",                      "1970" },
+		{ "%z",                      "+0300" },
+		{ "%%",                      "%" },
+		{ "%Y-%m-%dT%H:%M:%S.%9f%z", "1970-01-01T03:00:00.125000000+0300" },
+		{ "%Y-%m-%dT%H:%M:%S.%f%z",  "1970-01-01T03:00:00.125+0300" },
+		{ "%Y-%m-%dT%H:%M:%S.%f",    "1970-01-01T03:00:00.125" },
+		{ "%FT%T.%f",                "1970-01-01T03:00:00.125" },
+		{ "%FT%T.%f%z",              "1970-01-01T03:00:00.125+0300" },
+		{ "%FT%T.%9f%z",             "1970-01-01T03:00:00.125000000+0300" },
+		{ "%Y-%m-%d",                "0000-01-01" },
+		{ "%Y-%m-%d",                "0001-01-01" },
+		{ "%Y-%m-%d",                "9999-01-01" },
+		{ "%Y-%m-%d",                "10000-01-01" },
+		{ "%Y-%m-%d",                "10000-01-01" },
+		{ "%Y-%m-%d",                "5879611-07-11" },
+	};
+
+	for (index = 0; index < lengthof(format_tests); index++) {
+		const char *fmt = format_tests[index].fmt;
+		const char *text = format_tests[index].text;
+		struct tnt_tm date = { .tm_epoch = 0};
+		char *ptr = tnt_strptime(text, fmt, &date);
+		static char buff[DT_TO_STRING_BUFSIZE];
+		tnt_strftime(buff, sizeof(buff), "%FT%T%z", &date);
+		isnt(ptr, NULL, "parse string '%s' using '%s' (result '%s')",
+		     text, fmt, buff);
+	}
+
 	check_plan();
 }
 

--- a/test/unit/datetime.c
+++ b/test/unit/datetime.c
@@ -1,5 +1,6 @@
 #include "dt.h"
 #include <assert.h>
+#include <inttypes.h>
 #include <stdint.h>
 #include <string.h>
 #include <time.h>
@@ -95,72 +96,22 @@ struct {
 };
 #undef S
 
-static int
-parse_datetime(const char *str, size_t len, int64_t *secs_p,
-	       int32_t *nanosecs_p, int32_t *offset_p)
-{
-	size_t n;
-	dt_t dt;
-	char c;
-	int sec_of_day = 0, nanosecond = 0, offset = 0;
-
-	n = dt_parse_iso_date(str, len, &dt);
-	if (!n)
-		return 1;
-	if (n == len)
-		goto exit;
-
-	c = str[n++];
-	if (!(c == 'T' || c == 't' || c == ' '))
-		return 1;
-
-	str += n;
-	len -= n;
-
-	n = dt_parse_iso_time(str, len, &sec_of_day, &nanosecond);
-	if (!n)
-		return 1;
-	if (n == len)
-		goto exit;
-
-	if (str[n] == ' ')
-		n++;
-
-	str += n;
-	len -= n;
-
-	n = dt_parse_iso_zone_lenient(str, len, &offset);
-	if (!n || n != len)
-		return 1;
-
-exit:
-	*secs_p = ((int64_t)dt_rdn(dt) - DT_EPOCH_1970_OFFSET) * SECS_PER_DAY +
-		  sec_of_day - offset * 60;
-	*nanosecs_p = nanosecond;
-	*offset_p = offset;
-
-	return 0;
-}
-
 static void
 datetime_test(void)
 {
 	size_t index;
-	int64_t secs_expected;
-	int32_t nanosecs;
-	int32_t offset;
+	struct datetime date_expected;
 
 	plan(355);
-	parse_datetime(sample, sizeof(sample) - 1, &secs_expected, &nanosecs,
-		       &offset);
+	datetime_parse_full(&date_expected, sample, sizeof(sample) - 1, 0);
 
 	for (index = 0; index < lengthof(tests); index++) {
-		int64_t secs;
-		int rc = parse_datetime(tests[index].str, tests[index].len,
-					&secs, &nanosecs, &offset);
-		is(rc, 0, "correct parse_datetime return value for '%s'",
-		   tests[index].str);
-		is(secs, secs_expected,
+		struct datetime date;
+		size_t len = datetime_parse_full(&date, tests[index].str,
+						 tests[index].len, 0);
+		is(len > 0, true, "correct parse_datetime return value "
+		   "for '%s'", tests[index].str);
+		is(date.epoch, date_expected.epoch,
 		   "correct parse_datetime output "
 		   "seconds for '%s",
 		   tests[index].str);
@@ -169,18 +120,15 @@ datetime_test(void)
 		 * check that stringized literal produces the same date
 		 * time fields
 		 */
-		static char buff[40];
-		struct datetime dt = { secs, nanosecs, offset, 0 };
+		static char buff[DT_TO_STRING_BUFSIZE];
 		struct tnt_tm tm = { .tm_sec = 0 };
-		datetime_to_tm(&dt, &tm);
-		size_t len = tnt_strftime(buff, sizeof(buff), "%F %T%z", &tm);
+		len = datetime_strftime(&date, buff, sizeof(buff), "%F %T%z");
 		ok(len > 0, "strftime");
-		int64_t parsed_secs;
-		int32_t parsed_nsecs, parsed_ofs;
-		rc = parse_datetime(buff, len, &parsed_secs, &parsed_nsecs,
-				    &parsed_ofs);
-		is(rc, 0, "correct parse_datetime return value for '%s'", buff);
-		is(secs, parsed_secs,
+		struct datetime date_parsed;
+		len = datetime_parse_full(&date_parsed, buff, len, 0);
+		is(len > 0, true, "correct parse_datetime return value "
+		   "for '%s'", buff);
+		is(date.epoch, date_parsed.epoch,
 		   "reversible seconds via strftime for '%s'", buff);
 	}
 	check_plan();
@@ -226,6 +174,93 @@ tostring_datetime_test(void)
 		is(strcmp(buf, tests[index].string), 0,
 		   "string '%s' expected, received '%s'",
 		   tests[index].string, buf);
+	}
+	check_plan();
+}
+
+static int64_t
+_dt_to_epoch(dt_t dt)
+{
+	return ((int64_t)dt_rdn(dt) - DT_EPOCH_1970_OFFSET) * SECS_PER_DAY;
+}
+
+static void
+parse_date_test(void)
+{
+	plan(59);
+
+	static struct {
+		int64_t epoch;
+		const char *string;
+		size_t len; /* expected parsed length, may be not full */
+	} const valid_tests[] = {
+		{ 1356307200, "20121224", 8 },
+		{ 1356307200, "20121224  Foo bar", 8 },
+		{ 1356307200, "2012-12-24", 10 },
+		{ 1356307200, "2012-12-24 23:59:59", 10 },
+		{ 1356307200, "2012-12-24T00:00:00+00:00", 10 },
+		{ 1356307200, "2012359", 7 },
+		{ 1356307200, "2012359T235959+0130", 7 },
+		{ 1356307200, "2012-359", 8 },
+		{ 1356307200, "2012W521", 8 },
+		{ 1356307200, "2012-W52-1", 10 },
+		{ 1356307200, "2012Q485", 8 },
+		{ 1356307200, "2012-Q4-85", 10 },
+		{ -62135596800, "0001-Q1-01", 10 },
+		{ -62135596800, "0001-W01-1", 10 },
+		{ -62135596800, "0001-01-01", 10 },
+		{ -62135596800, "0001-001", 8 },
+	};
+	size_t index;
+
+	for (index = 0; index < lengthof(valid_tests); index++) {
+		dt_t dt = 0;
+		const char *str = valid_tests[index].string;
+		size_t expected_len = valid_tests[index].len;
+		int64_t expected_epoch = valid_tests[index].epoch;
+		size_t len = tnt_dt_parse_iso_date(str, expected_len, &dt);
+		int64_t epoch = _dt_to_epoch(dt);
+		is(len, expected_len, "string '%s' parse failed, len %lu", str,
+		   len);
+		is(epoch, expected_epoch,
+		   "string '%s' parse failed, epoch %" PRId64, str, epoch);
+	}
+
+	static const char *const invalid_tests[] = {
+		"20121232",    /* Invalid day of month */
+		"2012-12-310", /* Invalid day of month */
+		"2012-13-24",  /* Invalid month */
+		"2012367",     /* Invalid day of year */
+		"2012-000",    /* Invalid day of year */
+		"2012W533",    /* Invalid week of year */
+		"2012-W52-8",  /* Invalid day of week */
+		"2012Q495",    /* Invalid day of quarter */
+		"2012-Q5-85",  /* Invalid quarter */
+		"20123670",    /* Trailing digit */
+		"201212320",   /* Trailing digit */
+		"2012-12",     /* Reduced accuracy */
+		"2012-Q4",     /* Reduced accuracy */
+		"2012-Q42",    /* Invalid */
+		"2012-Q1-1",   /* Invalid day of quarter */
+		"2012Q/* 420", /* Invalid */
+		"2012-Q-420",  /* Invalid */
+		"2012Q11",     /* Incomplete */
+		"2012Q1234",   /* Trailing digit */
+		"2012W12",     /* Incomplete */
+		"2012W1234",   /* Trailing digit */
+		"2012W-123",   /* Invalid */
+		"2012-W12",    /* Incomplete */
+		"2012-W12-12", /* Trailing digit */
+		"2012U1234",   /* Invalid */
+		"2012-1234",   /* Invalid */
+		"2012-X1234",  /* Invalid */
+	};
+	for (index = 0; index < lengthof(invalid_tests); index++) {
+		dt_t dt = 0;
+		const char *str = invalid_tests[index];
+		size_t len = tnt_dt_parse_iso_date(str, strlen(str), &dt);
+		is(len, 0, "expected failure of string '%s' parse, len %lu",
+		   str, len);
 	}
 	check_plan();
 }
@@ -354,9 +389,10 @@ mp_print_test(void)
 int
 main(void)
 {
-	plan(4);
+	plan(5);
 	datetime_test();
 	tostring_datetime_test();
+	parse_date_test();
 	mp_datetime_test();
 	mp_print_test();
 


### PR DESCRIPTION
> _Work in progress - extensive testing to be added!_

`datetime` method to parse date/time iso-8601 (and their extensions) strings. 

`datetime.parse` function expect 1 required argument - which is
input string, and set of optional parameters passed as table
in 2nd argument.

Allowed attributes in this optional table are:
* `format` - should be either 'iso8601', 'rfc3339' or `strptime()`
  format string. [strptime format will be added as part of next
  commit];
* `tzoffset` - to redefine offset of input string value, if there
  is no timezone provided.
* `tz` - human-readable, Olson database, timezone identifier, e.g.
  'Europe/Moscow'. Not yet implemented in this commit.

```


tarantool> T = date.parse('1970-01-01T00:00:00Z')

tarantool> T
- 1970-01-01T00:00:00Z

tarantool> T = date.parse('1970-01-01T00:00:00', {format = 'iso8601', tzoffset = 180})

tarantool> T
- 1970-01-01T00:00:00+0300

tarantool> T = date.parse('2017-12-27T18:45:32.999999-05:00', {format = 'rfc3339'})

tarantool> T
- 2017-12-27T18:45:32.999999-0500
```

To parse date/time strings using format string we use
`strptime()` implementation from FreeBSD, which is
modified to use our `struct datetime` data structure.

List of supported format has been extended to include
`%f` which is flag used whenever you need to process
nanoseconds part of datetime value.

```
tarantool> T = date.parse('Thu Jan  1 03:00:00 1970', {format = '%c'})

tarantool> T
- 1970-01-01T03:00:00Z

tarantool> T = date.parse('12/31/2020', {format = '%m/%d/%y'})

tarantool> T
- 2020-12-31T00:00:00Z

tarantool> T = date.parse('1970-01-01T03:00:00.125000000+0300', {format = '%FT%T.%f%z'})

tarantool> T
- 1970-01-01T03:00:00.125+0300
```

Follow-up to #5941
