### PR TITLE
github-ci: Move LTO testing on macOS to version 11

### DIFF
--- a/.github/workflows/osx_11_lto.yml
+++ b/.github/workflows/osx_11_lto.yml
@@ -1,4 +1,4 @@
-name: osx_10_15_lto
+name: osx_11_lto
 
 on:
   push:
@@ -38,12 +38,12 @@ env:
   CI_MAKE: make -f .travis.mk
 
 jobs:
-  osx_10_15_lto:
+  osx_11_lto:
     # Run on pull request only if the 'full-ci' label is set.
     if: github.event_name != 'pull_request' ||
         contains(github.event.pull_request.labels.*.name, 'full-ci')
 
-    runs-on: macos-10.15
+    runs-on: macos-11
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -66,6 +66,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: osx_10_15_lto
+          name: osx_11_lto
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts


### PR DESCRIPTION
We're about to stop CI for macOS version 10.15. But
seems (for now) we still interested in LTO on mscOS.
So, move LTO testing to macOS version 11.

Part of #6739