### PR TITLE
lib: insignificant change to calm down coverity checker

### DIFF
--- a/src/lib/bit/bit.h
+++ b/src/lib/bit/bit.h
@@ -590,11 +590,11 @@ bit_iterator_init(struct bit_iterator *it, const void *data, size_t size,
 	it->word_base = 0;
 
 	/* Check if size is a multiple of sizeof(ITER_UINT) */
-	const char *e = it->next + size % sizeof(ITER_UINT);
-	if (bit_likely(it->next == e)) {
+	if (bit_likely(size % sizeof(ITER_UINT) == 0)) {
 		it->word = ITER_LOAD(it->next);
 		it->next += sizeof(ITER_UINT);
 	} else {
+		const char *e = it->next + size % sizeof(ITER_UINT);
 		it->word = it->word_xor;
 		char *w = (char *) &it->word;
 		while (it->next < e)

--- a/test/unit/bit.c
+++ b/test/unit/bit.c
@@ -159,7 +159,6 @@ test_index(void)
 	footer();
 }
 
-
 static void
 test_bit_iter(void)
 {
@@ -206,6 +205,38 @@ test_bit_iter_empty(void)
 	footer();
 }
 
+/**
+ * Check that bit iterator works correctly with bit sequences of size that are
+ * not multiple of uint64_t.
+ */
+static void
+test_bit_iter_fractional(void)
+{
+	header();
+
+	struct bit_iterator it;
+	uint64_t data[2] = {UINT64_MAX, UINT64_MAX};
+
+	for (size_t size = 1; size <= 16; size++) {
+		bit_iterator_init(&it, &data, size, true);
+
+		size_t expect_count = size * CHAR_BIT;
+		size_t expect_pos = 0;
+		size_t pos;
+
+		while ( (pos = bit_iterator_next(&it)) != SIZE_MAX) {
+			fail_unless(expect_count > 0);
+			fail_unless(pos == expect_pos);
+			expect_count--;
+			expect_pos++;
+		}
+
+		fail_unless(expect_count == 0);
+	}
+
+	footer();
+}
+
 static void
 test_bitmap_size(void)
 {
@@ -230,5 +261,6 @@ main(void)
 	test_index();
 	test_bit_iter();
 	test_bit_iter_empty();
+	test_bit_iter_fractional();
 	test_bitmap_size();
 }

--- a/test/unit/bit.result
+++ b/test/unit/bit.result
@@ -711,5 +711,7 @@ Clear: 0, 1, 2, 4, 5, 6, 7, 8, 10, 12, 13, 14, 15, 19, 20, 21, 23, 26, 28, 30, 3
 	*** test_bit_iter: done ***
 	*** test_bit_iter_empty ***
 	*** test_bit_iter_empty: done ***
+	*** test_bit_iter_fractional ***
+	*** test_bit_iter_fractional: done ***
 	*** test_bitmap_size ***
 	*** test_bitmap_size: done ***


### PR DESCRIPTION
Now scan.coverity.com reports "Overrunning buffer pointed to by
&map of 4 bytes by passing it to a function which accesses it at
byte offset 7" in bit_iterator_init call.

Add an unit test that verifies that bit iterator works correctly
with small size bitmaps (like uint32_t).

Change condition a bit hoping that it will calm down the checker.

No functional changes.