### PR TITLE
cd: deploy source packages with the right version

### DIFF
--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - uses: ./.github/actions/environment
       - name: packaging
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
For now, source packages are deployed to our repositories with the wrong
version. It is due to the actions/checkout bug with not preserving tag
annotations [1].

This issue was fixed from our side by adding a workaround [2] to the
.github/actions/environment action. But for some reason, invocation of
this action was not added to the 'source.yml' workflow. This patch fixes
that.

[1] https://github.com/actions/checkout/issues/290
[2] https://github.com/tarantool/tarantool/pull/6197

Closes tarantool/tarantool-qa#146