### PR TITLE
Add IPROTO SSL encryption stub

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -77,6 +77,7 @@ set_property(DIRECTORY PROPERTY ADDITIONAL_MAKE_CLEAN_FILES ${lua_sources})
 include_directories(${ZSTD_INCLUDE_DIRS})
 include_directories(${PROJECT_BINARY_DIR}/src/box/sql)
 include_directories(${PROJECT_BINARY_DIR}/src/box)
+include_directories(${EXTRA_CORE_INCLUDE_DIRS})
 include_directories(${EXTRA_BOX_INCLUDE_DIRS})
 
 add_library(box_error STATIC error.cc errcode.c mp_error.cc)

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -344,7 +344,7 @@ applier_connect(struct applier *applier)
 			      &applier->addr_len);
 	if (fd < 0)
 		diag_raise();
-	iostream_create(io, fd);
+	plain_iostream_create(io, fd);
 	if (coio_readn(io, greetingbuf, IPROTO_GREETING_SIZE) < 0)
 		diag_raise();
 	applier->last_row_time = ev_monotonic_now(loop());

--- a/src/box/applier.h
+++ b/src/box/applier.h
@@ -117,6 +117,8 @@ struct applier {
 	};
 	/** Length of addr */
 	socklen_t addr_len;
+	/** I/O stream context */
+	struct iostream_ctx io_ctx;
 	/** I/O stream */
 	struct iostream io;
 	/** Input buffer */
@@ -163,6 +165,7 @@ applier_stop(struct applier *applier);
  * remote uri (copied to struct applier).
  *
  * @pre     the uri is a valid and checked one
+ * @error   throws exception
  */
 struct applier *
 applier_new(struct uri *uri);

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -1409,7 +1409,7 @@ iproto_connection_new(struct iproto_thread *iproto_thread, int fd)
 	con->iproto_thread = iproto_thread;
 	con->input.data = con->output.data = con;
 	con->loop = loop();
-	iostream_create(&con->io, fd);
+	plain_iostream_create(&con->io, fd);
 	ev_io_init(&con->input, iproto_connection_on_input, fd, EV_READ);
 	ev_io_init(&con->output, iproto_connection_on_output, fd, EV_WRITE);
 	ibuf_create(&con->ibuf[0], cord_slab_cache(), iproto_readahead);

--- a/src/box/lua/console.c
+++ b/src/box/lua/console.c
@@ -575,7 +575,7 @@ console_session_push(struct session *session, struct port *port)
 	if (text == NULL)
 		return -1;
 	struct iostream io;
-	iostream_create(&io, session_fd(session));
+	plain_iostream_create(&io, session_fd(session));
 	int ret = coio_write_timeout(&io, text, text_len, TIMEOUT_INFINITY);
 	iostream_destroy(&io);
 	return ret >= 0 ? 0 : -1;

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -602,15 +602,7 @@ local function compare_cfg(cfg1, cfg2)
     if type(cfg1) ~= 'table' then
         return cfg1 == cfg2
     end
-    if #cfg1 ~= #cfg2 then
-        return false
-    end
-    for k, v in ipairs(cfg1) do
-        if v ~= cfg2[k] then
-            return false
-        end
-    end
-    return true
+    return table.equals(cfg1, cfg2)
 end
 
 local function reload_cfg(oldcfg, cfg)

--- a/src/box/lua/net_box.c
+++ b/src/box/lua/net_box.c
@@ -937,7 +937,7 @@ netbox_transport_connect(struct netbox_transport *transport)
 	coio_timeout_update(&start, &delay);
 	if (fd < 0)
 		goto io_error;
-	iostream_create(io, fd);
+	plain_iostream_create(io, fd);
 	char greetingbuf[IPROTO_GREETING_SIZE];
 	if (coio_readn_timeout(io, greetingbuf, IPROTO_GREETING_SIZE,
 			       delay) < 0)

--- a/src/box/lua/net_box.lua
+++ b/src/box/lua/net_box.lua
@@ -7,6 +7,8 @@ local urilib   = require('uri')
 local internal = require('net.box.lib')
 local trigger  = require('internal.trigger')
 
+local this_module
+
 local max               = math.max
 local fiber_clock       = fiber.clock
 
@@ -89,7 +91,7 @@ local function on_push_sync_default() end
 
 local function parse_connect_params(host_or_uri, ...) -- self? host_or_uri port? opts?
     local port, opts = ...
-    if type(host_or_uri) == 'table' then host_or_uri, port, opts = ... end
+    if host_or_uri == this_module then host_or_uri, port, opts = ... end
     if type(port) == 'table' then opts = port; port = nil end
     if opts == nil then opts = {} else
         local copy = {}
@@ -1036,7 +1038,7 @@ index_metatable = function(remote)
     return { __index = methods, __metatable = false }
 end
 
-local this_module = {
+this_module = {
     connect = connect,
     new = connect, -- Tarantool < 1.7.1 compatibility,
     _method = { -- for tests

--- a/src/box/mp_error.cc
+++ b/src/box/mp_error.cc
@@ -41,6 +41,7 @@
 #include "msgpuck.h"
 #include "mp_extension_types.h"
 #include "fiber.h"
+#include "ssl_error.h"
 
 /**
  * MP_ERROR format:
@@ -257,6 +258,8 @@ error_build_xc(struct mp_error *mp_error)
 		err = new SwimError();
 	} else if (strcmp(mp_error->type, "CryptoError") == 0) {
 		err = new CryptoError();
+	} else if (strcmp(mp_error->type, "SSLError") == 0) {
+		err = new SSLError();
 	} else {
 		err = new ClientError();
 	}

--- a/src/lib/core/CMakeLists.txt
+++ b/src/lib/core/CMakeLists.txt
@@ -37,6 +37,18 @@ set(core_sources
     mp_datetime.c
 )
 
+if(ENABLE_SSL)
+    list(APPEND core_sources ${SSL_SOURCES})
+else()
+    list(APPEND core_sources ssl.c ssl_error.cc)
+endif()
+
+include_directories(${EXTRA_CORE_INCLUDE_DIRS})
+
+if(ENABLE_SSL)
+    include_directories(${OPENSSL_INCLUDE_DIR})
+endif()
+
 if (TARGET_OS_NETBSD)
     # A workaround for "undefined reference to `__gcc_personality_v0'"
     # on x86_64-rumprun-netbsd-gcc
@@ -62,4 +74,8 @@ endif()
 # HAVE_CLOCK_GETTIME_WITHOUT_RT in ${REPO}/CMakeLists.txt.
 if ("${HAVE_CLOCK_GETTIME}" AND NOT "${HAVE_CLOCK_GETTIME_WITHOUT_RT}")
     target_link_libraries(core rt)
+endif()
+
+if(ENABLE_SSL)
+    target_link_libraries(core ${OPENSSL_LIBRARIES})
 endif()

--- a/src/lib/core/coio.h
+++ b/src/lib/core/coio.h
@@ -41,20 +41,6 @@ extern "C" {
 
 struct iostream;
 struct sockaddr;
-struct uri_set;
-
-/**
- * Co-operative I/O
- * Yield the current fiber until IO is ready.
- */
-struct coio_service
-{
-	struct evio_service evio_service;
-	/* Fiber function. */
-	fiber_func handler;
-	/** Passed to the created fiber. */
-	void *handler_param;
-};
 
 int
 coio_connect_timeout(const char *host, const char *service, int host_hint,
@@ -151,17 +137,6 @@ coio_writev(struct iostream *io, struct iovec *iov, int iovcnt, size_t size)
 {
 	return coio_writev_timeout(io, iov, iovcnt, size, TIMEOUT_INFINITY);
 }
-
-void
-coio_service_init(struct coio_service *service, const char *name,
-		  fiber_func handler, void *handler_param);
-
-/**
- * Wait until the service binds to the port.
- * Returns 0 on success, -1 on error.
- */
-int
-coio_service_start(struct evio_service *service, const struct uri_set *uri_set);
 
 void
 coio_stat_init(ev_stat *stat, const char *path);

--- a/src/lib/core/evio.h
+++ b/src/lib/core/evio.h
@@ -63,12 +63,12 @@ extern "C" {
  */
 struct evio_service_entry;
 struct evio_service;
-struct uri;
+struct iostream;
 struct uri_set;
 
-typedef int (*evio_accept_f)(struct evio_service *service,
-			     const struct uri *uri, int fd,
-			     struct sockaddr *addr, socklen_t addrlen);
+typedef int
+(*evio_accept_f)(struct evio_service *service, struct iostream *io,
+		 struct sockaddr *addr, socklen_t addrlen);
 
 struct evio_service {
         /** Total count of services */
@@ -81,6 +81,9 @@ struct evio_service {
          * A callback invoked on every accepted client socket.
          * If a callback returned != 0, the accepted socket is
          * closed and the error is logged.
+         *
+         * On success the callback must move the IO stream object
+         * it was passed.
          */
         evio_accept_f on_accept;
         void *on_accept_param;

--- a/src/lib/core/iostream.c
+++ b/src/lib/core/iostream.c
@@ -8,6 +8,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <stddef.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -80,3 +81,28 @@ static const struct iostream_vtab plain_iostream_vtab = {
 	/* .write = */ plain_iostream_write,
 	/* .writev = */ plain_iostream_writev,
 };
+
+int
+iostream_ctx_create(struct iostream_ctx *ctx, enum iostream_mode mode,
+		    const struct uri *uri)
+{
+	(void)uri;
+	assert(mode == IOSTREAM_SERVER || mode == IOSTREAM_CLIENT);
+	ctx->mode = mode;
+	return 0;
+}
+
+void
+iostream_ctx_destroy(struct iostream_ctx *ctx)
+{
+	iostream_ctx_clear(ctx);
+}
+
+int
+iostream_create(struct iostream *io, int fd, struct iostream_ctx *ctx)
+{
+	assert(ctx->mode == IOSTREAM_SERVER || ctx->mode == IOSTREAM_CLIENT);
+	(void)ctx;
+	plain_iostream_create(io, fd);
+	return 0;
+}

--- a/src/lib/core/iostream.c
+++ b/src/lib/core/iostream.c
@@ -20,7 +20,7 @@ plain_iostream_create(struct iostream *io, int fd)
 {
 	assert(fd >= 0);
 	io->vtab = &plain_iostream_vtab;
-	io->ctx = NULL;
+	io->data = NULL;
 	io->fd = fd;
 }
 
@@ -33,9 +33,9 @@ iostream_close(struct iostream *io)
 }
 
 static void
-plain_iostream_delete_ctx(void *ctx)
+plain_iostream_destroy(struct iostream *io)
 {
-	(void)ctx;
+	(void)io;
 }
 
 static ssize_t
@@ -75,7 +75,7 @@ plain_iostream_writev(struct iostream *io, const struct iovec *iov, int iovcnt)
 }
 
 static const struct iostream_vtab plain_iostream_vtab = {
-	/* .delete_ctx = */ plain_iostream_delete_ctx,
+	/* .destroy = */ plain_iostream_destroy,
 	/* .read = */ plain_iostream_read,
 	/* .write = */ plain_iostream_write,
 	/* .writev = */ plain_iostream_writev,

--- a/src/lib/core/iostream.c
+++ b/src/lib/core/iostream.c
@@ -16,7 +16,7 @@
 static const struct iostream_vtab plain_iostream_vtab;
 
 void
-iostream_create(struct iostream *io, int fd)
+plain_iostream_create(struct iostream *io, int fd)
 {
 	assert(fd >= 0);
 	io->vtab = &plain_iostream_vtab;

--- a/src/lib/core/iostream.h
+++ b/src/lib/core/iostream.h
@@ -62,9 +62,9 @@ iostream_status_to_events(ssize_t status)
 }
 
 struct iostream_vtab {
-	/** Frees implementation-specific context. */
+	/** Destroys implementation-specific data. */
 	void
-	(*delete_ctx)(void *ctx);
+	(*destroy)(struct iostream *io);
 	/** See iostream_read. */
 	ssize_t
 	(*read)(struct iostream *io, void *buf, size_t count);
@@ -82,8 +82,8 @@ struct iostream_vtab {
  */
 struct iostream {
 	const struct iostream_vtab *vtab;
-	/** Implementation specific context. */
-	void *ctx;
+	/** Implementation specific data. */
+	void *data;
 	/** File descriptor used for IO. Set to -1 on destruction. */
 	int fd;
 };
@@ -95,7 +95,7 @@ static inline void
 iostream_clear(struct iostream *io)
 {
 	io->vtab = NULL;
-	io->ctx = NULL;
+	io->data = NULL;
 	io->fd = -1;
 }
 
@@ -142,7 +142,7 @@ static inline void
 iostream_destroy(struct iostream *io)
 {
 	assert(io->fd >= 0);
-	io->vtab->delete_ctx(io->ctx);
+	io->vtab->destroy(io);
 	iostream_clear(io);
 }
 

--- a/src/lib/core/iostream.h
+++ b/src/lib/core/iostream.h
@@ -112,6 +112,17 @@ iostream_is_initialized(struct iostream *io)
 }
 
 /**
+ * Move constructor: copies src to dst and clears src.
+ */
+static inline void
+iostream_move(struct iostream *dst, struct iostream *src)
+{
+	assert(iostream_is_initialized(src));
+	*dst = *src;
+	iostream_clear(src);
+}
+
+/**
  * Creates a plain stream (reads/writes fd without any processing)
  * for the given file descriptor.
  */

--- a/src/lib/core/iostream.h
+++ b/src/lib/core/iostream.h
@@ -191,12 +191,19 @@ enum iostream_mode {
 	IOSTREAM_CLIENT,
 };
 
+struct ssl_iostream_ctx;
+
 /**
  * Context used for creating IO stream objects of a particular type.
  */
 struct iostream_ctx {
 	/** IO stream mode: server or client. */
 	enum iostream_mode mode;
+	/**
+	 * Context used for creating encrypted streams. If it's NULL, then
+	 * streams created with this context will be unencrypted.
+	 */
+	struct ssl_iostream_ctx *ssl;
 };
 
 /**
@@ -208,6 +215,7 @@ static inline void
 iostream_ctx_clear(struct iostream_ctx *ctx)
 {
 	ctx->mode = IOSTREAM_MODE_UNINITIALIZED;
+	ctx->ssl = NULL;
 }
 
 /**
@@ -232,7 +240,7 @@ iostream_ctx_destroy(struct iostream_ctx *ctx);
  * and clears the iostream struct (see iostream_clear).
  */
 int
-iostream_create(struct iostream *io, int fd, struct iostream_ctx *ctx);
+iostream_create(struct iostream *io, int fd, const struct iostream_ctx *ctx);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/lib/core/iostream.h
+++ b/src/lib/core/iostream.h
@@ -102,7 +102,7 @@ iostream_clear(struct iostream *io)
 /**
  * Returns:
  *  - false after iostream_clear
- *  - true  after iostream_create
+ *  - true  after construction
  *  - false after iostream_destroy and iostream_close
  */
 static inline bool
@@ -116,7 +116,7 @@ iostream_is_initialized(struct iostream *io)
  * for the given file descriptor.
  */
 void
-iostream_create(struct iostream *io, int fd);
+plain_iostream_create(struct iostream *io, int fd);
 
 /**
  * Destroys a stream and closes its fd. The stream fd is set to -1.

--- a/src/lib/core/popen.c
+++ b/src/lib/core/popen.c
@@ -1347,7 +1347,7 @@ exit_child:
 			int parent_fd = pfd[i][parent_idx];
 
 			assert(!iostream_is_initialized(&handle->ios[i]));
-			iostream_create(&handle->ios[i], parent_fd);
+			plain_iostream_create(&handle->ios[i], parent_fd);
 			if (fcntl(parent_fd, F_SETFL, O_NONBLOCK)) {
 				diag_set(SystemError, "Can't set O_NONBLOCK [%s:%d]",
 					 stdX_str(i), parent_fd);

--- a/src/lib/core/ssl.c
+++ b/src/lib/core/ssl.c
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2021, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include "ssl.h"
+
+#include <stddef.h>
+
+#include "diag.h"
+#include "iostream.h"
+#include "trivia/config.h"
+
+#if defined(ENABLE_SSL)
+# error unimplemented
+#endif
+
+struct ssl_iostream_ctx *
+ssl_iostream_ctx_new(enum iostream_mode mode, const struct uri *uri)
+{
+	(void)mode;
+	(void)uri;
+	diag_set(IllegalParams, "SSL is not available in this build");
+	return NULL;
+}

--- a/src/lib/core/ssl.h
+++ b/src/lib/core/ssl.h
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2021, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include "trivia/config.h"
+
+#if defined(ENABLE_SSL)
+# include "ssl_impl.h"
+#else /* !defined(ENABLE_SSL) */
+
+#include "iostream.h"
+#include "trivia/util.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+struct uri;
+struct ssl_iostream_ctx;
+
+struct ssl_iostream_ctx *
+ssl_iostream_ctx_new(enum iostream_mode mode, const struct uri *uri);
+
+static inline void
+ssl_iostream_ctx_delete(struct ssl_iostream_ctx *ctx)
+{
+	(void)ctx;
+	unreachable();
+}
+
+static inline int
+ssl_iostream_create(struct iostream *io, int fd, enum iostream_mode mode,
+		    const struct ssl_iostream_ctx *ctx)
+{
+	(void)io;
+	(void)fd;
+	(void)mode;
+	(void)ctx;
+	unreachable();
+	return 0;
+}
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */
+
+#endif /* !defined(ENABLE_SSL) */

--- a/src/lib/core/ssl_error.cc
+++ b/src/lib/core/ssl_error.cc
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2021, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include "ssl_error.h"
+
+#include <stddef.h>
+
+#include "reflection.h"
+#include "trivia/config.h"
+
+#if defined(ENABLE_SSL)
+# error unimplemented
+#endif
+
+const struct type_info type_SSLError = make_type("SSLError", NULL);

--- a/src/lib/core/ssl_error.h
+++ b/src/lib/core/ssl_error.h
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2021, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include "trivia/config.h"
+
+#if defined(ENABLE_SSL)
+# include "ssl_error_impl.h"
+#else /* !defined(ENABLE_SSL) */
+
+#include <stddef.h>
+
+#include "exception.h"
+#include "reflection.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+extern const struct type_info type_SSLError;
+
+#if defined(__cplusplus)
+} /* extern "C" */
+
+class SSLError: public Exception {
+public:
+	SSLError(): Exception(&type_SSLError, NULL, 0) {}
+	virtual void raise() { throw this; }
+};
+
+#endif /* defined(__cplusplus) */
+
+#endif /* !defined(ENABLE_SSL) */

--- a/src/trivia/config.h.cmake
+++ b/src/trivia/config.h.cmake
@@ -256,6 +256,7 @@
 /* Cacheline size to calculate alignments */
 #define CACHELINE_SIZE 64
 
+#cmakedefine ENABLE_SSL 1
 #cmakedefine ENABLE_AUDIT_LOG 1
 #cmakedefine ENABLE_FEEDBACK_DAEMON 1
 

--- a/test/box-luatest/transport_test.lua
+++ b/test/box-luatest/transport_test.lua
@@ -1,0 +1,77 @@
+local net = require('net.box')
+local server = require('test.luatest_helpers.server')
+local tarantool = require('tarantool')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all = function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end
+
+g.after_all = function()
+    g.server:stop()
+end
+
+g.test_listen = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local listen = box.cfg.listen
+        box.cfg({listen = {listen, params = {transport = 'plain'}}})
+        t.assert_error_msg_equals(
+            'Invalid transport: foo',
+            box.cfg, {listen = {listen, params = {transport = 'foo'}}})
+        box.cfg({listen = listen})
+    end)
+end
+
+g.test_replication = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local listen = box.cfg.listen
+        box.cfg({replication = {listen, params = {transport = 'plain'}}})
+        t.assert_error_msg_equals(
+            'Invalid transport: foo',
+            box.cfg, {replication = {listen, params = {transport = 'foo'}}})
+        box.cfg({replication = {}})
+    end)
+end
+
+g.test_net_box = function()
+    local c = net.connect({g.server.net_box_uri,
+                           params = {transport = 'plain'}})
+    t.assert_equals(c.state, 'active')
+    c:close()
+    t.assert_error_msg_equals(
+        'Invalid transport: foo',
+        net.connect, {g.server.net_box_uri, params = {transport = 'foo'}})
+end
+
+-- Check that SSL isn't available in open-source builds.
+if tarantool.package ~= 'Tarantool Enterprise' then
+
+g.test_listen_ssl = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        t.assert_error_msg_equals(
+            'SSL is not available in this build',
+            box.cfg, {listen = 'localhost:0?transport=ssl'})
+    end)
+end
+
+g.test_replication_ssl = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        t.assert_error_msg_equals(
+            'SSL is not available in this build',
+            box.cfg, {replication = 'localhost:0?transport=ssl'})
+    end)
+end
+
+g.test_net_box_ssl = function()
+    t.assert_error_msg_equals(
+        'SSL is not available in this build',
+        net.connect, {g.server.net_box_uri, params = {transport = 'ssl'}})
+end
+
+end -- tarantool.package ~= 'Tarantool Enterprise'

--- a/test/unit/coio.cc
+++ b/test/unit/coio.cc
@@ -227,9 +227,9 @@ read_write_test(void)
 		struct iostream io;
 		if (i == 0) {
 			/* A non-readable fd, since the pipe is empty. */
-			iostream_create(&io, fds[0]);
+			plain_iostream_create(&io, fds[0]);
 		} else {
-			iostream_create(&io, fds[1]);
+			plain_iostream_create(&io, fds[1]);
 			/* Make the fd non-writable. */
 			fill_pipe(fds[1]);
 		}

--- a/test/unit/mp_error.cc
+++ b/test/unit/mp_error.cc
@@ -86,6 +86,7 @@ const char *standard_errors[] = {
 	"CollationError",
 	"SwimError",
 	"CryptoError",
+	"SSLError",
 };
 
 enum {

--- a/test/unit/mp_error.result
+++ b/test/unit/mp_error.result
@@ -1,7 +1,7 @@
 	*** main ***
 1..7
 	*** test_stack_error_decode ***
-    1..17
+    1..18
     ok 1 - check CustomError
     ok 2 - check AccessDeniedError
     ok 3 - check ClientError
@@ -18,7 +18,8 @@
     ok 14 - check CollationError
     ok 15 - check SwimError
     ok 16 - check CryptoError
-    ok 17 - stack size
+    ok 17 - check SSLError
+    ok 18 - stack size
 ok 1 - subtests
 	*** test_stack_error_decode: done ***
 	*** test_decode_unknown_type ***


### PR DESCRIPTION
This PR adds a new URI parameter: `transport`. In open-source builds, the parameter is useless - it can only be set to `'plain'`, otherwise an error will be raised. In EE builds, it can, however, it can also be set to `'ssl'`, in which case the connection will be encrypted. The parameter is used by `box.cfg.listen`, `box.cfg.replication`, and `net.box`.

EE part: https://github.com/tarantool/tarantool-ee/pull/4