### PR TITLE
tools: do not raise on empty unreleased/ directory

### DIFF
--- a/tools/gen-release-notes
+++ b/tools/gen-release-notes
@@ -185,9 +185,16 @@ def changelog_entries():
 
     entries_dir_relative = os.path.join('changelogs', 'unreleased')
     entries_dir = os.path.join(source_dir, entries_dir_relative)
+
+    res = []
+
     if not os.path.exists(entries_dir):
-        raise RuntimeError('The changelog entries directory {} does not '
-                           'exist'.format(entries_dir))
+        # Since git does not store directories, empty unreleased/
+        # directory won't exist on a fresh tree, which just have been
+        # released. So, do not raise here, just warn.
+        print('The changelog entries directory {} does not '
+              'exist (or was empty originally)'.format(entries_dir))
+        return res
     if not os.path.isdir(entries_dir):
         raise RuntimeError('The path {} that is expected to be the changelog '
                            'entries directory is not a directory'.format(
@@ -197,8 +204,6 @@ def changelog_entries():
     # are present.
     entries_sorted = changelog_entries_sorted(source_dir, entries_dir_relative)
     entries_known = set(entries_sorted)
-
-    res = []
 
     # Add entries according to 'git log' order first.
     for entry in entries_sorted:
@@ -465,8 +470,9 @@ def print_release_notes(entry_section, comments, redefinitions):
 if __name__ == '__main__':
     try:
         entries = changelog_entries()
-        entry_section, comments = parse_changelog_entries(entries)
-        print_release_notes(entry_section, comments, REDEFINITIONS)
+        if entries:
+            entry_section, comments = parse_changelog_entries(entries)
+            print_release_notes(entry_section, comments, REDEFINITIONS)
     except RuntimeError as e:
         print(str(e))
         exit(1)


### PR DESCRIPTION
Since git does not store directories, empty unreleased/
directory won't exist on a fresh tree, which just have been
released. So, do not raise here, just warn.