### PR TITLE
ci: enable fuzzing for *-full-ci branches

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - '**-full-ci'
     paths:
       - '.github/workflows/**'
       - 'src/**'


### PR DESCRIPTION
Now it is not possible to run fuzzing on CI without merge to master
branch. Last time we missed [1] a broken compilation on merging new
fuzzers to master [2]. This patch enables fuzzing for branches with
postfix 'full-ci'.

1. https://github.com/tarantool/tarantool/pull/6757
2. https://github.com/tarantool/tarantool/pull/6627