### PR TITLE
decimal: fix index comparison with Inf, NaN

### DIFF
--- a/changelogs/unreleased/gh-6377-decimal-index-comparison.md
+++ b/changelogs/unreleased/gh-6377-decimal-index-comparison.md
@@ -1,0 +1,8 @@
+## bugfix/core
+
+* Fixed a crash / undefined behaviour when using `scalar` and `number` indexes
+  over fields containing both decimals and double `Inf` or `NaN`.
+
+  Note, for vinyl spaces the above conditions could lead to wrong ordering of
+  indexed values. In order to fix the issue, please recreate the indexes on such
+  spaces following this [guide](https://github.com/tarantool/tarantool/wiki/Fix-wrong-order-of-decimals-and-doubles-in-indices) (gh-6377).

--- a/test/engine-luatest/gh_6377_decimal_compare_inf_crash_test.lua
+++ b/test/engine-luatest/gh_6377_decimal_compare_inf_crash_test.lua
@@ -1,0 +1,56 @@
+local t = require('luatest')
+local cluster = require('test.luatest_helpers.cluster')
+
+local decimal = require('decimal')
+
+local g = t.group('gh-6377-decimal-compare-inf-crash',
+                  {{engine = 'memtx'}, {engine = 'vinyl'}})
+
+g.before_all(function(cg)
+    cg.cluster = cluster:new({})
+    cg.master = cg.cluster:build_and_add_server({alias = 'master'})
+    cg.master:start()
+end)
+
+g.after_all(function(cg)
+    cg.cluster:stop()
+end)
+
+g.before_each(function(cg)
+    local engine = cg.params.engine
+    cg.master:exec(function(engine)
+        box.schema.space.create('test', {engine = engine})
+        box.space.test:create_index('pk', {parts = {{1, 'number'}}})
+        box.space.test:insert{1.8e308}
+        box.space.test:insert{-1.8e308}
+        box.space.test:insert{0/0}
+    end, {engine})
+end)
+
+g.after_each(function(cg)
+    cg.master:exec(function()
+        box.space.test:drop()
+    end)
+end)
+
+g.test_decimal_compare_inf_crash = function(cg)
+    local minf = -1 / 0
+    local inf = 1 / 0
+    local nan = 0 / 0
+    local val = decimal.new(1)
+    local ordered_ret = {
+        tostring(nan),
+        tostring(minf),
+        tostring(val),
+        tostring(inf),
+    }
+    local ret = cg.master:exec(function(val)
+        box.space.test:insert{val}
+        local tab = box.space.test:select{}
+        for k, v in pairs(tab) do
+            tab[k] = tostring(v[1])
+        end
+        return tab
+    end, {val})
+    t.assert_equals(ret, ordered_ret, "Error in decimal comarison with Inf/NaN")
+end


### PR DESCRIPTION
There was an assertion failure when inserting  a decimal into an index
which contained double Inf or NaN.

The reason for that was never checking decimal_from_*() return values,
and decimal_from_double() not being able to handle NaN or Inf, because
these values are not representable in decimal numbers.

Start handling decimal_from_<type> return values and fix decimal
comparison with Inf, NaN.

Closes #6377
