### PR TITLE
Relay: send heartbeats while scanning a WAL

### DIFF
--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -136,11 +136,6 @@ struct relay {
 	 */
 	uint32_t id_filter;
 	/**
-	 * How many rows has this relay sent to the replica. Used to yield once
-	 * in a while when reading a WAL to unblock the event loop.
-	 */
-	int64_t row_count;
-	/**
 	 * Local vclock at the moment of subscribe, used to check
 	 * dataset on the other side and send missing data rows if any.
 	 */
@@ -304,7 +299,6 @@ relay_start(struct relay *relay, struct iostream *io, uint64_t sync,
 	relay->io = io;
 	relay->sync = sync;
 	relay->state = RELAY_FOLLOW;
-	relay->row_count = 0;
 	relay->last_row_time = ev_monotonic_now(loop());
 }
 


### PR DESCRIPTION
As soon as replica subscribes, relay starts scanning the first requested
WAL file to find the position from which to start replication. While the
scan is in progress, relay never sends heartbeats to the replica, so a
really long scan can make the replica timeout before relay finally finds
the point to replicate from.

Two similar problems were already addressed in
30ad4a5 ("relay: yield explicitly every
N sent rows") and 1728944 ("recovery: make it
yield when positioning in a WAL")

These patches do not fix the issue completely for relay: even though now
it yields while scanning a WAL, it doesn't send heartbeats anyway.

Fix the issue by not only yielding, but sending heartbeats as well while
WAL scan is in progress.

Follow-up #5979
Closes #6706