### PR TITLE
gen-release-notes: relax validation rules

### DIFF
--- a/tools/gen-release-notes
+++ b/tools/gen-release-notes
@@ -208,9 +208,8 @@ def changelog_entries():
     # Add the rest in the alphabetical order.
     entries_glob = os.path.join(entries_dir, '*.md')
     entries = sorted(glob.glob(entries_glob))
-    if not entries:
-        raise RuntimeError('Not found any *.md file in the changelog entries '
-                           'directory {}'.format(entries_dir))
+    # NB: It is perfectly okay to have no entries at all: say, we
+    # just start to work on a future release.
     for entry in entries:
         if entry not in entries_known:
             res.append(entry)

--- a/tools/gen-release-notes
+++ b/tools/gen-release-notes
@@ -349,15 +349,20 @@ def parse_changelog_entries(changelog_entries):
 
         # Nested slash delimited subcategories.
         for section_header in parser.header.split('/'):
-            if section_header not in section['subsections']:
-                section['subsections'][section_header] = {
+            # Group entries by a section header (case
+            # insensitively). Save first header variant as is (not
+            # lowercased) into the 'header' field to prettify in
+            # ``print_section()`` later.
+            section_key = section_header.lower()
+            if section_key not in section['subsections']:
+                section['subsections'][section_key] = {
                     'header': section_header,
                     'level': section['level'] + 1,
                     'entries': [],
                     'subsections': dict(),
                     'nested_entry_count': 0,
                 }
-            section = section['subsections'][section_header]
+            section = section['subsections'][section_key]
             section['nested_entry_count'] += 1
 
         section['entries'].append(parser.content)

--- a/tools/gen-release-notes
+++ b/tools/gen-release-notes
@@ -411,10 +411,11 @@ def print_section(section, redefinitions):
     level = section['level']
     header = section['header']
 
+    # Prettify the header if it is in the lower case.
     redefinition = redefinitions.get((level, header))
     if redefinition:
         section.update(redefinition)
-    else:
+    elif header.islower():
         section['header'] = header.capitalize()
 
     level = section['level']

--- a/tools/gen-release-notes
+++ b/tools/gen-release-notes
@@ -312,11 +312,27 @@ class Parser:
 def parse_changelog_entries(changelog_entries):
     """ Parse and structurize changelog entries content.
     """
+    # 'feature' and 'bugfix' sections are always present.
     entry_section = {
         'header': 'main',
         'level': 1,
         'entries': [],
-        'subsections': dict(),
+        'subsections': {
+            'feature': {
+                'header': 'feature',
+                'level': 2,
+                'entries': [],
+                'subsections': dict(),
+                'nested_entry_count': 0,
+            },
+            'bugfix': {
+                'header': 'bugfix',
+                'level': 2,
+                'entries': [],
+                'subsections': dict(),
+                'nested_entry_count': 0,
+            },
+        },
         'nested_entry_count': 0,
     }
     comments = []
@@ -421,6 +437,9 @@ def print_section(section, redefinitions):
     for subheader in it:
         if subheader in subsections:
             print_section(subsections[subheader], redefinitions)
+
+    if not section['entries'] and not section['subsections']:
+        print_block('*No changes.*')
 
 
 def print_templates(feature_count, bugfix_count):


### PR DESCRIPTION
Several changes are there:

* Always keep the `changelogs/unreleased` directory.
* Gracefully handle situations, when there is no changelog entries or when only bugfixes (or only features) are present.
* Properly handle title/mixed case in headers: group sections case insensitively and prettify only lowercased headers.

First two bullets resolve problems in CI, when the script is used as linter (see PR #6701). It is a bit more general alternative for PR #6755.

The third bullet allows to write `## feature/SQL` instead of `## feature/sql` in a changelog entry. The restriction was artificial and hard to remember, so it worth to relax it to easy developer's life.