### PR TITLE
ci: make osx workflow names consistent

### DIFF
--- a/.github/workflows/osx_11_aarch64.yml
+++ b/.github/workflows/osx_11_aarch64.yml
@@ -1,4 +1,4 @@
-name: osx_debug_arm64_11_2
+name: osx_11_aarch64
 
 on:
   push:
@@ -38,12 +38,12 @@ env:
   CI_MAKE: arch -arm64 make -f .travis.mk
 
 jobs:
-  osx_debug_arm64_11_2:
+  osx_11_aarch64:
     # Run on pull request only if the 'full-ci' label is set.
     if: github.event_name != 'pull_request' ||
         contains(github.event.pull_request.labels.*.name, 'full-ci')
 
-    runs-on: macos-m1-11.2
+    runs-on: macos-11-m1
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -53,7 +53,8 @@ jobs:
       - uses: ./.github/actions/environment
       - name: test
         env:
-          CMAKE_BUILD_TYPE: Debug
+          CMAKE_BUILD_TYPE: RelWithDebInfo
+          CMAKE_EXTRA_PARAMS: -DENABLE_WERROR=ON
         run: ${CI_MAKE} test_osx_arm64_github_actions
       - name: call action to send Telegram message on failure
         env:
@@ -65,6 +66,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: osx_debug_arm64_11_2
+          name: osx_11_aarch64
           retention-days: 21
           path: /tmp/tnt/artifacts

--- a/.github/workflows/osx_11_aarch64_debug.yml
+++ b/.github/workflows/osx_11_aarch64_debug.yml
@@ -1,4 +1,4 @@
-name: osx_arm64_11_2
+name: osx_11_aarch64_debug
 
 on:
   push:
@@ -38,12 +38,12 @@ env:
   CI_MAKE: arch -arm64 make -f .travis.mk
 
 jobs:
-  osx_arm64_11_2:
+  osx_11_aarch64_debug:
     # Run on pull request only if the 'full-ci' label is set.
     if: github.event_name != 'pull_request' ||
         contains(github.event.pull_request.labels.*.name, 'full-ci')
 
-    runs-on: macos-m1-11.2
+    runs-on: macos-11-m1
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -53,8 +53,7 @@ jobs:
       - uses: ./.github/actions/environment
       - name: test
         env:
-          CMAKE_BUILD_TYPE: RelWithDebInfo
-          CMAKE_EXTRA_PARAMS: -DENABLE_WERROR=ON
+          CMAKE_BUILD_TYPE: Debug
         run: ${CI_MAKE} test_osx_arm64_github_actions
       - name: call action to send Telegram message on failure
         env:
@@ -66,6 +65,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: osx_arm64_11_2
+          name: osx_11_aarch64_debug
           retention-days: 21
           path: /tmp/tnt/artifacts


### PR DESCRIPTION
This patch brings consistency to OSX workflow names with other workflow 
names.

The following changes were made:

  * Arch suffix changed (arm64 -> aarch64)
  * Minor OS version removed (11_2 -> 11)
  * Specific options moved to the end of the workflow name
    (osx_debug_xyz.yml -> osx_xyz_debug.yml)

Closes tarantool/tarantool-qa#149