### PR TITLE
memtx: fix MVCC breaking TREE index iterators

### DIFF
--- a/changelogs/unreleased/gh_6344_mvcc_txm_story_gc_breaks_memtx_tree_iter.md
+++ b/changelogs/unreleased/gh_6344_mvcc_txm_story_gc_breaks_memtx_tree_iter.md
@@ -1,0 +1,4 @@
+## bugfix/memtx
+
+* Fixed MVCC transaction manager story garbage collection breaking memtx TREE 
+  index iterator (gh-6344).

--- a/test/box-luatest/gh_6344_mvcc_txm_story_gc_breaks_memtx_tree_iter_test.lua
+++ b/test/box-luatest/gh_6344_mvcc_txm_story_gc_breaks_memtx_tree_iter_test.lua
@@ -1,0 +1,49 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all = function()
+    g.server = server:new{
+        alias   = 'default',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    g.server:start()
+end
+
+g.after_all = function()
+    g.server:drop()
+end
+
+g.test_mvcc_txm_story_gc_does_not_break_memtx_tree_iter = function()
+    g.server:exec(function()
+        local t = require('luatest')
+
+        local s = box.schema.space.create('test')
+        local idx_parts = {
+            {field = 1, type = 'unsigned'},
+            {field = 2, type = 'unsigned'}
+        }
+        local idx = s:create_index('primary', {parts = idx_parts})
+
+        local space_sz = 16
+        for i = 1, space_sz do
+            s:insert({i, i})
+        end
+
+        local offs = 2
+        local err_msg = 'MVCC transaction manager story garbage collection ' ..
+                        'breaks memtx TREE index iterator'
+        for i = 1, space_sz - offs do
+            box.begin()
+            s:delete{i, i}
+            for _, tuple in idx:pairs{i + offs} do
+                if i + offs ~= tuple[1] then
+                    box.rollback()
+                    t.assert_equals(i + offs, tuple[1], err_msg)
+                end
+            end
+            box.commit()
+        end
+    end)
+end


### PR DESCRIPTION
The MVCC transaction manager story garbage collection introduced a
subtle code dependency: TREE index iterators can get broken (see
definition of “broken” at struct bps_tree_iterator), because the
elements they are referencing can change during story garbage
collection.

We coined the notion “MVCC TRANSACTION MANAGER STORY GARBAGE
COLLECTION BOUND” to refer to this issue explicitly: iterators must not
be used after this point in code.

Closes #6344