### PR TITLE
Fix crash in functional index iterator

### DIFF
--- a/changelogs/unreleased/gh-6786-func-index-iterator-stable.md
+++ b/changelogs/unreleased/gh-6786-func-index-iterator-stable.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a crash that could happen in case a tuple is deleted from a functional
+  index while there is an iterator pointing to it (gh-6786).

--- a/src/box/key_list.c
+++ b/src/box/key_list.c
@@ -131,7 +131,7 @@ key_list_iterator_next(struct key_list_iterator *it, const char **value)
 		 */
 		mp_next(&it->data);
 		assert(it->data <= it->data_end);
-		*value = it->key_allocator(it->tuple, key, it->data - key);
+		*value = it->key_allocator(key, it->data - key);
 		return *value != NULL ? 0 : -1;
 	}
 
@@ -177,6 +177,6 @@ key_list_iterator_next(struct key_list_iterator *it, const char **value)
 	}
 
 	it->data = key_end;
-	*value = it->key_allocator(it->tuple, key, key_end - key);
+	*value = it->key_allocator(key, key_end - key);
 	return *value != NULL ? 0 : -1;
 }

--- a/src/box/key_list.h
+++ b/src/box/key_list.h
@@ -49,8 +49,7 @@ struct tuple;
  * key, since the key is only used to lookup the old tuple in the
  * b+* tree, so we pass in a dummy allocator.
  */
-typedef const char *(*key_list_allocator_t)(struct tuple *tuple, const char *key,
-					    uint32_t key_sz);
+typedef const char *(*key_list_allocator_t)(const char *key, uint32_t key_sz);
 
 /**
  * An iterator over key_data returned by a stored function function.

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -269,6 +269,19 @@ enum {
 };
 
 /**
+ * Allocates size bytes using the memtx allocator (MemtxAllocator::alloc).
+ * On error returns NULL. Does not set diag.
+ */
+extern void *
+(*memtx_alloc)(uint32_t size);
+
+/**
+ * Frees memory allocated with memtx_alloc.
+ */
+extern void
+(*memtx_free)(void *ptr);
+
+/**
  * Allocate a block of size MEMTX_EXTENT_SIZE for memtx index
  * @ctx must point to memtx engine
  */

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -118,7 +118,7 @@ enum memtx_reserve_extents_num {
  * allocated for each iterator (except rtree index iterator that
  * is significantly bigger so has own pool).
  */
-#define MEMTX_ITERATOR_SIZE (152)
+#define MEMTX_ITERATOR_SIZE (176)
 
 struct memtx_engine {
 	struct engine base;
@@ -280,6 +280,16 @@ extern void *
  */
 extern void
 (*memtx_free)(void *ptr);
+
+/**
+ * Returns the size of an allocation done with memtx_alloc.
+ * (The size is stored before the data.)
+ */
+static inline uint32_t
+memtx_alloc_size(void *ptr)
+{
+	return *((uint32_t *)ptr - 1);
+}
 
 /**
  * Allocate a block of size MEMTX_EXTENT_SIZE for memtx index

--- a/src/box/tuple.c
+++ b/src/box/tuple.c
@@ -97,8 +97,6 @@ runtime_tuple_new(struct tuple_format *format, const char *data, const char *end
 static struct tuple_format_vtab tuple_format_runtime_vtab = {
 	runtime_tuple_delete,
 	runtime_tuple_new,
-	NULL,
-	NULL,
 };
 
 static struct tuple *

--- a/src/box/tuple.h
+++ b/src/box/tuple.h
@@ -644,40 +644,6 @@ tuple_delete(struct tuple *tuple)
 	format->vtab.tuple_delete(format, tuple);
 }
 
-/** Tuple chunk memory object. */
-struct tuple_chunk {
-	/** The payload size. Needed to perform memory release.*/
-	uint32_t data_sz;
-	/** Metadata object payload. */
-	char data[0];
-};
-
-/** Calculate the size of tuple_chunk object by given data_sz. */
-static inline uint32_t
-tuple_chunk_sz(uint32_t data_sz)
-{
-	return sizeof(struct tuple_chunk) + data_sz;
-}
-
-/**
- * Allocate a new tuple_chunk for given tuple and data and
- * return a pointer to it's payload section.
- */
-static inline const char *
-tuple_chunk_new(struct tuple *tuple, const char *data, uint32_t data_sz)
-{
-	struct tuple_format *format = tuple_format(tuple);
-	return format->vtab.tuple_chunk_new(format, tuple, data, data_sz);
-}
-
-/** Free a tuple_chunk allocated for given tuple and data. */
-static inline void
-tuple_chunk_delete(struct tuple *tuple, const char *data)
-{
-	struct tuple_format *format = tuple_format(tuple);
-	format->vtab.tuple_chunk_delete(format, data);
-}
-
 /**
  * Check tuple data correspondence to space format.
  * Actually, checks everything that is checked by

--- a/src/box/tuple_format.h
+++ b/src/box/tuple_format.h
@@ -83,20 +83,6 @@ struct tuple_format_vtab {
 	struct tuple*
 	(*tuple_new)(struct tuple_format *format, const char *data,
 	             const char *end);
-	/**
-	 * Free a tuple_chunk allocated for given tuple and
-	 * data.
-	 */
-	void
-	(*tuple_chunk_delete)(struct tuple_format *format,
-			      const char *data);
-	/**
-	 * Allocate a new tuple_chunk for given tuple and data and
-	 * return a pointer to it's data section.
-	 */
-	const char *
-	(*tuple_chunk_new)(struct tuple_format *format, struct tuple *tuple,
-			   const char *data, uint32_t data_sz);
 };
 
 /** Tuple field meta information for tuple_format. */

--- a/src/box/vy_stmt.c
+++ b/src/box/vy_stmt.c
@@ -118,8 +118,6 @@ vy_stmt_env_create(struct vy_stmt_env *env)
 {
 	env->tuple_format_vtab.tuple_new = vy_tuple_new;
 	env->tuple_format_vtab.tuple_delete = vy_tuple_delete;
-	env->tuple_format_vtab.tuple_chunk_new = NULL;
-	env->tuple_format_vtab.tuple_chunk_delete = NULL;
 	env->max_tuple_size = 1024 * 1024;
 	env->key_format = vy_stmt_format_new(env, NULL, 0, NULL, 0, 0, NULL);
 	if (env->key_format == NULL)

--- a/test/box-luatest/gh-6786_func_index_iterator_stable_test.lua
+++ b/test/box-luatest/gh-6786_func_index_iterator_stable_test.lua
@@ -1,0 +1,59 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all = function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end
+
+g.after_all = function()
+    g.server:stop()
+end
+
+g.before_test('test_func_index_iterator_stable', function()
+    g.server:exec(function()
+        box.schema.func.create('test', {
+            body = [[function(t)
+                local ret = {}
+                for _, v in ipairs(string.split(t[2])) do
+                    table.insert(ret, {v})
+                end
+                return ret
+            end]],
+            is_deterministic = true,
+            is_sandboxed = true,
+            is_multikey = true,
+        })
+        local s = box.schema.create_space('test')
+        s:create_index('pk')
+        s:create_index('f', {
+            func = 'test',
+            parts = {{1, 'string'}},
+        })
+    end)
+end)
+
+g.after_test('test_func_index_iterator_stable', function()
+    g.server:exec(function()
+        box.space.test:drop()
+        box.schema.func.drop('test')
+    end)
+end)
+
+g.test_func_index_iterator_stable = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.test
+        s:insert{1, 'abc'}
+        s:insert{2, 'foo bar'}
+        s:insert{3, string.format('%s %s %s',
+                                  string.rep('x', 1000),
+                                  string.rep('y', 3000),
+                                  string.rep('z', 5000))}
+        for _, t in s.index.f:pairs() do
+            s:delete({t[1]})
+        end
+        t.assert_equals(s.index.f:select(), {})
+    end)
+end


### PR DESCRIPTION
A memtx tree iterator remembers the last tuple returned to the user and its hint so that it can restore iteration if the index is changed. To prevent the tuple from being freed, it references it. The problem is it's not enough for a functional index, because the latter allocates key parts separately from tuples (it stores pointers to them in memtx tree hints). As a result, if a tuple is deleted from the tree, its key parts will be immediately freed, even if the tuple itself is referenced. Since key parts are necessary to restore an iterator, this results in a use after free bug.

To fix the issue, let's store a copy of the current tuple key part in the iterator along with the tuple. If a key part is small, the copy is stored in a preallocated fixed-size buffer, otherwise it's allocated with malloc.

Closes #6786