### PR TITLE
Add workflow to check commits

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -83,3 +83,25 @@ jobs:
           TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
         uses: ./.github/actions/send-telegram-notify
         if: failure()
+
+  commits:
+    # Run only if the workflow was triggered by a pull request that doesn't
+    # have the 'notest' label.
+    if: github.event_name == 'pull_request' &&
+        ! contains(github.event.pull_request.labels.*.name, 'notest')
+
+    runs-on: ubuntu-20.04-self-hosted
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: test
+        run: ./tools/check-commits HEAD~${{ github.event.pull_request.commits }}..HEAD
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()

--- a/tools/check-commits
+++ b/tools/check-commits
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+
+import re
+import subprocess
+import sys
+import textwrap
+
+
+def stdout(msg):
+    sys.stdout.write(msg)
+    sys.stdout.flush()
+
+
+def git_rev_list(*revs):
+    if not revs:
+        return []
+    return (subprocess.check_output(('git', 'rev-list') + revs)
+            .decode('utf-8')
+            .strip('\n')
+            .split('\n'))
+
+
+def git_show(rev, *args):
+    return (subprocess.check_output(('git', 'show', rev) + args)
+            .decode('utf-8')
+            .strip('\n'))
+
+
+def git_show_subject(rev):
+    return git_show(rev, '--no-patch', '--format=%s')
+
+
+def git_show_message(rev):
+    return git_show(rev, '--no-patch', '--format=%B')
+
+
+def git_show_modified_files(rev):
+    return git_show(rev, '--name-only', '--format=').split('\n')
+
+
+class GitCommit:
+    def __init__(self, sha):
+        self.sha = sha
+        self.subject = git_show_subject(sha)
+        self.message = git_show_message(sha)
+        self.modified_files = git_show_modified_files(sha)
+
+
+class Fail:
+    def __init__(self, message):
+        self.message = message
+
+
+def check_commit_doc(commit):
+    has_doc = bool(re.search('^@TarantoolBot document$', commit.message,
+                             flags=re.MULTILINE))
+    has_tag = bool(re.search('^NO_DOC=', commit.message, flags=re.MULTILINE))
+    if not has_doc and not has_tag:
+        return Fail("Missing documentation request ('@TarantoolBot document' "
+                    "not found in the commit message). If this commit doesn't "
+                    "need to be documented, please add NO_DOC=<reason> to the "
+                    "commit message.")
+    if has_doc and has_tag:
+        return Fail("Redundant NO_DOC tag in the commit message.")
+
+
+def check_commit_changelog(commit):
+    has_changelog = any(path.startswith('changelogs/unreleased/')
+                        for path in commit.modified_files)
+    has_tag = bool(re.search('^NO_CHANGELOG=', commit.message,
+                             flags=re.MULTILINE))
+    if not has_changelog and not has_tag:
+        return Fail("Changelog not found in changelog/unreleased. "
+                    "If this commit doesn't require changelog, please add "
+                    "NO_CHANGELOG=<reason> to the commit message.")
+    if has_changelog and has_tag:
+        return Fail("Redundant NO_CHANGELOG tag in the commit message.")
+
+
+def check_commit(commit):
+    failures = []
+    stdout('Checking commit {} '.format(commit.sha))
+    for check_func in (
+            check_commit_doc,
+            check_commit_changelog,
+    ):
+        fail = check_func(commit)
+        if fail:
+            failures.append(fail)
+    if failures:
+        stdout('FAIL\n')
+        stdout('SHA:     {}\n'.format(commit.sha))
+        stdout('SUBJECT: {}\n'.format(commit.subject))
+        for fail in failures:
+            indent = ' ' * 2
+            stdout('{}ERROR:\n{}\n'
+                   .format(indent,
+                           textwrap.fill(fail.message, width=64,
+                                         initial_indent=indent * 2,
+                                         subsequent_indent=indent * 2)))
+        return False
+    else:
+        stdout('PASS\n')
+        return True
+
+
+def check_rev_list(*revs):
+    ret = True
+    for sha in git_rev_list(*revs):
+        if not check_commit(GitCommit(sha)):
+            ret = False
+    return ret
+
+
+if __name__ == '__main__':
+    if not check_rev_list(*sys.argv[1:]):
+        sys.exit(1)


### PR DESCRIPTION
This PR adds a new script, tools/check-commits. The script takes git revisions in the same format as git-rev-list (actually, it feeds all its arguments to git-rev-list) and runs some checks on each of the commits.

For example, to check the head commit, run:

```
./tools/check-commits -1 HEAD
```

To check the last five commits, run:

```
./tools/check-commits HEAD~5..HEAD
```

Currently, there are only two checks, but in future we may add more checks, e.g. check diffs for trailing spaces:
 - The commit message contains a documentation request. Can be suppressed with `NO_DOC=<reason>` in the commit message.
 - A new changelog entry is added to changelog/unreleased by the commit. Can be suppressed with `NO_CHANGELOG=<reason>` in the commit message.

This PR also adds a new workflow triggered on pull request, lint/commits. The workflow runs the tools/check-commits script on all the commits added by the pull request. The workflow doesn't run on push, because it's problematic to figure out what commits are new on a branch. Besides, we don't want to run it on push to release branches, because it's a pure dev workflow.

Example output:

```
Checking commit a33f3cc7f1bf6020de95d144d63050894d2d0716 PASS
Checking commit 6f29f9d7725331d74d5e9a57a4922b1c3801ad50 FAIL
SHA:     6f29f9d7725331d74d5e9a57a4922b1c3801ad50
SUBJECT: iproto: introduce graceful shutdown protocol
  ERROR:
    Changelog not found in changelog/unreleased. If this commit
    doesn't require changelog, please add NO_CHANGELOG=<reason>
    to the commit message.
Checking commit fbc25aae895f46f9b078a0fce0ed47c651ad2f5e FAIL
SHA:     fbc25aae895f46f9b078a0fce0ed47c651ad2f5e
SUBJECT: Update small submodule
  ERROR:
    Missing documentation request ('@TarantoolBot document' not
    found in the commit message). If this commit doesn't need to
    be documented, please add NO_DOC=<reason> to the commit
    message.
  ERROR:
    Changelog not found in changelog/unreleased. If this commit
    doesn't require changelog, please add NO_CHANGELOG=<reason>
    to the commit message.
```

Closes #6790