### PR TITLE
datetime: make date.new{} and date:set{} equivalent

### DIFF
--- a/changelogs/unreleased/gh-6793-datetime-set-with-tzoffset.md
+++ b/changelogs/unreleased/gh-6793-datetime-set-with-tzoffset.md
@@ -1,0 +1,5 @@
+## bugfix/datetime
+
+ * Fixed a bug in datetime module when `date:set{tzoffset=XXX}` was not
+   producing the same result with `date.new{tzoffset=XXX}` for the same
+   set of attributes passed (gh-6793).


### PR DESCRIPTION
Constructor date.new() and modifier date:set() should always produce same
result for all attributes combinations. Fixed the problem for
`timestamp` with `tzoffset`.

```
tarantool> date.new{ tzoffset = '+0800', timestamp = 1630359071 }
---
- 2021-08-30T21:31:11+0800
...

tarantool> date.new():set{ tzoffset = '+0800', timestamp = 1630359071 }
---
- 2021-08-30T21:31:11+0800
...

```

> Discovered that there was a similar problem with `:set{}` using `tzoffset` attribute not only 
> for `timestamp` but with all the rest date or time attributes. So have modified code flow to
> always "delocalize"/localize time zone upon any relevant attribute manipulation.

Fixes #6793