### PR TITLE
Add mp_encode_str0() into msgpuck.h

### DIFF
--- a/src/box/mp_error.cc
+++ b/src/box/mp_error.cc
@@ -169,12 +169,6 @@ mp_sizeof_error_one(const struct error *error)
 	return data_size;
 }
 
-static inline char *
-mp_encode_str0(char *data, const char *str)
-{
-	return mp_encode_str(data, str, strlen(str));
-}
-
 static char *
 mp_encode_error_one(char *data, const struct error *error)
 {

--- a/test/unit/mp_error.cc
+++ b/test/unit/mp_error.cc
@@ -94,12 +94,6 @@ enum {
 		sizeof(standard_errors) / sizeof(standard_errors[0]),
 };
 
-static inline char *
-mp_encode_str0(char *data, const char *str)
-{
-	return mp_encode_str(data, str, strlen(str));
-}
-
 /** Note, not the same as mp_encode_error(). */
 static char *
 mp_encode_mp_error(const struct mp_test_error *e, char *data)

--- a/test/unit/msgpack.result
+++ b/test/unit/msgpack.result
@@ -2281,11 +2281,12 @@ ok 21 - subtests
     ok 96 - mp_read_double(mp_encode_strl(100)) check pos unchanged
     # *** test_numbers: done ***
 ok 22 - subtests
-    1..4
+    1..5
     # *** test_overflow ***
     ok 1 - mp_check array overflow
     ok 2 - mp_check map overflow
     ok 3 - mp_check str overflow
     ok 4 - mp_check bin overflow
+    ok 5 - mp_check str overflow
     # *** test_overflow: done ***
 ok 23 - subtests


### PR DESCRIPTION
Msgpuck is a submodule for tarantool and is needed while packaging.
Moved function of mp_encode_str0() from mp_error.cc into a common
place is msgpuck.h.

Needed for packaging workflow in tarantool/tarantool:
tarantool/tarantool#6260