### PR TITLE
netbox: allow to disable schema fetch

### DIFF
--- a/changelogs/unreleased/gh-4789-net-box-fetch-schema.md
+++ b/changelogs/unreleased/gh-4789-net-box-fetch-schema.md
@@ -1,0 +1,4 @@
+## feature/core
+
+* Added `fetch_schema` flag to netbox.connect to control schema fetching
+  from remote instance (gh-4789).

--- a/src/box/lua/net_box.lua
+++ b/src/box/lua/net_box.lua
@@ -388,7 +388,8 @@ local function new_sm(uri, opts)
     remote._callback = callback
     local transport = internal.new_transport(
             uri, user, password, weak_callback,
-            opts.connect_timeout, opts.reconnect_after)
+            opts.connect_timeout, opts.reconnect_after,
+            opts.fetch_schema)
     remote._transport = transport
     remote._gc_hook = ffi.gc(ffi.new('char[1]'), function()
         pcall(transport.stop, transport);


### PR DESCRIPTION
Before this patch each connection reload server schema if it
changed. However in some cases it's actually redundant e.g. user
performs only call and eval operations. This patch introduces
"fetch_schema" option (true by default to keep backward
compatibility) that allows to ignore schema changes on the server.
As result remote spaces are unavailable and on_schema_reload
trigger doesn't work.

@TarantoolBot document
Title: Document fetch_schema netbox option

Currently user could specify "fetch_schema" flag in netbox
connection to control schema fetching from remote instance.
In case if this option is false remote spaces will be unavailable
and on_schema_reload trigger won't work.

```
c = netbox.connect(uri, {fetch_schema = false})
c.space -- always will be nil
c:on_schema_reload(function() end) -- never will be triggered
```

Closes #4789