### PR TITLE
luatest helpers: add copy directory semantics

### DIFF
--- a/test/box-luatest/gh_6794_recover_nonmatching_xlogs_test.lua
+++ b/test/box-luatest/gh_6794_recover_nonmatching_xlogs_test.lua
@@ -4,9 +4,8 @@ local g = t.group()
 local fio = require('fio')
 
 g.before_each(function()
-    g.server = server:new({alias = 'master'})
-    -- Initialize server's workdir with specially crafted snap/xlog pair.
-    fio.copytree('./test/box-luatest/gh_6794_data', g.server.workdir)
+    g.server = server:new({alias = 'master',
+                          datadir = 'test/box-luatest/gh_6794_data'})
 end)
 
 g.after_test("test_panic_without_force_recovery", function()


### PR DESCRIPTION
Currently, one can only specify a work directory that will be directly
passed to box.cfg (via workdir option passed to luatest.Server, via the
TARANTOOL_WORKDIR environment variable, or via explicitly specifying
work_dir in box.cfg), which implies that the test server will be run in
the specified directory.

One might need to start a Tarantool instance from a certain snapshot or
set of xlogs — for instance, to test Tarantool over an older schema
version.

For diff-tests the test-run harness provided a 'workdir=' option when
calling inspector:cmd('create server ...'), which solved this issue by
copying the specified directory's contents into the test server's
actual working directory (see tarantool/test-run/blob/
d16cbdc2702e7d939d5d34e41730fd83d2c65879/lib/preprocessor.py#L274-L284).

To solve this issue using the luatest_helpers harness we introduce a
copydir option for luatest_helpers.Server with the same semantics.

Needed for #6571
Closes tarantool/luatest#214