### PR TITLE
Several fixes before implement tuple compression

### DIFF
--- a/perf/tuple.cc
+++ b/perf/tuple.cc
@@ -63,11 +63,10 @@ private:
 	{
 		key_def_delete(kd);
 		tuple_format_unref(fmt);
+		tuple_free();
 		SmallAlloc::destroy();
 		slab_cache_destroy(&memtx.slab_cache);
 		tuple_arena_destroy(&memtx.arena);
-		box_tuple_last = NULL;
-		tuple_free();
 		fiber_free();
 		memory_free();
 	}
@@ -183,7 +182,7 @@ bench_tuple_new(benchmark::State& state)
 	total_count += i;
 	state.SetItemsProcessed(total_count);
 
-	for (size_t k = i; NUM_TEST_TUPLES < i; k++)
+	for (size_t k = 0; k < i; k++)
 		tuple_unref(tuples[k]);
 }
 

--- a/src/box/msgpack.c
+++ b/src/box/msgpack.c
@@ -40,7 +40,7 @@
 static int
 msgpack_fprint_ext(FILE *file, const char **data, int depth)
 {
-	const char **orig = data;
+	const char *orig = *data;
 	int8_t type;
 	uint32_t len = mp_decode_extl(data, &type);
 	switch(type) {
@@ -53,14 +53,15 @@ msgpack_fprint_ext(FILE *file, const char **data, int depth)
 	case MP_ERROR:
 		return mp_fprint_error(file, data, depth);
 	default:
-		return mp_fprint_ext_default(file, orig, depth);
+		*data = orig;
+		return mp_fprint_ext_default(file, data, depth);
 	}
 }
 
 static int
 msgpack_snprint_ext(char *buf, int size, const char **data, int depth)
 {
-	const char **orig = data;
+	const char *orig = *data;
 	int8_t type;
 	uint32_t len = mp_decode_extl(data, &type);
 	switch(type) {
@@ -73,7 +74,8 @@ msgpack_snprint_ext(char *buf, int size, const char **data, int depth)
 	case MP_ERROR:
 		return mp_snprint_error(buf, size, data, depth);
 	default:
-		return mp_snprint_ext_default(buf, size, orig, depth);
+		*data = orig;
+		return mp_snprint_ext_default(buf, size, data, depth);
 	}
 }
 

--- a/test/box/errinj.result
+++ b/test/box/errinj.result
@@ -7,6 +7,10 @@ box.error.last() == nil
 ---
 - true
 ...
+test_run:cmd("push filter 'Failed to allocate [0-9]+' to 'Failed to allocate <NUM>'")
+---
+- true
+...
 errinj = box.error.injection
 ---
 ...
@@ -473,7 +477,7 @@ errinj.set("ERRINJ_TUPLE_ALLOC", true)
 ...
 s:auto_increment{}
 ---
-- error: Failed to allocate 12 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate <NUM> bytes in slab allocator for memtx_tuple
 ...
 s:select{}
 ---
@@ -481,7 +485,7 @@ s:select{}
 ...
 s:auto_increment{}
 ---
-- error: Failed to allocate 12 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate <NUM> bytes in slab allocator for memtx_tuple
 ...
 s:select{}
 ---
@@ -489,7 +493,7 @@ s:select{}
 ...
 s:auto_increment{}
 ---
-- error: Failed to allocate 12 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate <NUM> bytes in slab allocator for memtx_tuple
 ...
 s:select{}
 ---
@@ -503,7 +507,7 @@ box.begin()
     s:insert{1}
 box.commit();
 ---
-- error: Failed to allocate 12 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate <NUM> bytes in slab allocator for memtx_tuple
 ...
 box.rollback();
 ---
@@ -517,7 +521,7 @@ box.begin()
     s:insert{2}
 box.commit();
 ---
-- error: Failed to allocate 12 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate <NUM> bytes in slab allocator for memtx_tuple
 ...
 s:select{};
 ---
@@ -531,7 +535,7 @@ box.begin()
     s:insert{2}
 box.commit();
 ---
-- error: Failed to allocate 12 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate <NUM> bytes in slab allocator for memtx_tuple
 ...
 s:select{};
 ---
@@ -550,7 +554,7 @@ box.begin()
     s:insert{2}
 box.commit();
 ---
-- error: Failed to allocate 12 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate <NUM> bytes in slab allocator for memtx_tuple
 ...
 errinj.set("ERRINJ_TUPLE_ALLOC", false);
 ---
@@ -812,7 +816,7 @@ errinj.set("ERRINJ_TUPLE_ALLOC", true)
 ...
 s:replace{1, "test"}
 ---
-- error: Failed to allocate 17 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate <NUM> bytes in slab allocator for memtx_tuple
 ...
 s:bsize()
 ---
@@ -824,7 +828,7 @@ utils.space_bsize(s)
 ...
 s:update({1}, {{'=', 3, '!'}})
 ---
-- error: Failed to allocate 16 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate <NUM> bytes in slab allocator for memtx_tuple
 ...
 s:bsize()
 ---
@@ -1935,7 +1939,7 @@ disturber:join()
 creator:join()
 ---
 - false
-- Failed to allocate 56 bytes in region_aligned_alloc for struct on_rollback_trigger_with_data
+- Failed to allocate <NUM> bytes in region_aligned_alloc for struct on_rollback_trigger_with_data
 ...
 -- Replace must happen
 assert(s:get{0} ~= nil)

--- a/test/box/errinj.test.lua
+++ b/test/box/errinj.test.lua
@@ -3,6 +3,8 @@ test_run = require('test_run').new()
 test_run:cmd("restart server default")
 box.error.last() == nil
 
+test_run:cmd("push filter 'Failed to allocate [0-9]+' to 'Failed to allocate <NUM>'")
+
 errinj = box.error.injection
 net_box = require('net.box')
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -140,6 +140,9 @@ if (ENABLE_BUNDLED_MSGPUCK)
     target_link_libraries(msgpack.test ${MSGPUCK_LIBRARIES})
 endif ()
 
+add_executable(mp_print_unknown_ext.test mp_print_unknown_ext.c)
+target_link_libraries(mp_print_unknown_ext.test unit box core)
+
 add_executable(scramble.test scramble.c core_test_utils.c)
 target_link_libraries(scramble.test scramble)
 

--- a/test/unit/mp_print_unknown_ext.c
+++ b/test/unit/mp_print_unknown_ext.c
@@ -1,0 +1,58 @@
+#include "msgpack.h"
+#include "mp_extension_types.h"
+
+#include "trivia/util.h"
+#include "unit.h"
+#include <stdio.h>
+
+static int
+test_mp_print(const char *sample, const char *ext_data)
+{
+	plan(2);
+
+	char str[200] = {0};
+
+	mp_snprint(str, sizeof(str), ext_data);
+	is(strcmp(sample, str), 0, "mp_snprint unknown extension");
+
+	memset(str, 0, sizeof(str));
+	FILE *f  = tmpfile();
+	assert(f != NULL);
+	mp_fprint(f, ext_data);
+	rewind(f);
+	fread(str, 1, sizeof(str), f);
+	is(strcmp(sample, str), 0, "mp_fprint unknown extension");
+
+	return check_plan();
+}
+
+static int
+test_mp_print_unknown_extention(void)
+{
+	plan(1);
+
+	char sample[] = "(extension: type 0, len 10)";
+	char data[] = { 0xca, 0xca, 0xca, 0xca, 0xca, 0xca, 0xca, 0xca, 0xca, 0xca };
+	char *ext_data = xmalloc(mp_sizeof_ext(sizeof(data)));
+
+	char *data_end = ext_data;
+	data_end = mp_encode_ext(data_end, MP_UNKNOWN_EXTENSION, data, sizeof(data));
+
+	test_mp_print(sample, ext_data);
+
+	free(ext_data);
+
+	return check_plan();
+}
+
+int
+main(void)
+{
+	plan(1);
+
+	msgpack_init();
+
+	test_mp_print_unknown_extention();
+
+	return check_plan();
+}

--- a/test/unit/mp_print_unknown_ext.result
+++ b/test/unit/mp_print_unknown_ext.result
@@ -1,0 +1,7 @@
+1..1
+    1..1
+        1..2
+        ok 1 - mp_snprint unknown extension
+        ok 2 - mp_fprint unknown extension
+    ok 1 - subtests
+ok 1 - subtests


### PR DESCRIPTION
This patch set includes several fixes:
- fix incorrect resource release in preformance test
- fixed incorrect print of msgpack field with MP_UNKNOWN_EXTENTION type
- add filters in test to remove dependence on tuple size

