### PR TITLE
Adapt tool/gen-release-notes for Enterprise Edition changelogs

### DIFF
--- a/tools/gen-release-notes
+++ b/tools/gen-release-notes
@@ -134,16 +134,13 @@ all the new features of the 1.10.x series.
 # }}} Templates
 
 
-# {{{ Collecting
+# {{{ Helpers
 
-def changelog_entries_sorted(entries_dir):
-    """ Acquire order of appearance from ```git log``.
-
-        Misses uncommitted entries and contains files that were
-        deleted.
+def popen(cmdline):
+    """ Wrapper around Popen.subprocess() that redirects the output to a pipe,
+        correctly handles encoding and raises a RuntimeError if the executable
+        was not found. Works on both Python 2 and 3.
     """
-    cmdline = ['git', '-C', entries_dir, 'log', '--reverse', '--pretty=',
-               '--name-only', '--relative']
     popen_kwargs = {
         'stdout': subprocess.PIPE,
     }
@@ -154,19 +151,32 @@ def changelog_entries_sorted(entries_dir):
         global FileNotFoundError
         FileNotFoundError = OSError
 
+    try:
+        return subprocess.Popen(cmdline, **popen_kwargs)
+    except FileNotFoundError as e:
+        raise RuntimeError("Unable to find '{}' executable: {}".format(
+            cmdline[0], str(e)))
+
+# }}} Helpers
+
+
+# {{{ Collecting
+
+def changelog_entries_sorted(entries_dir):
+    """ Acquire order of appearance from ```git log``.
+
+        Misses uncommitted entries and contains files that were
+        deleted.
+    """
     processed = set()
     res = []
-    try:
-        process = subprocess.Popen(cmdline, **popen_kwargs)
+    with popen(['git', '-C', entries_dir, 'log', '--reverse', '--pretty=',
+                '--name-only', '--relative']) as process:
         for line in process.stdout:
             entry_file = line.rstrip()
             if entry_file not in processed and entry_file.endswith('.md'):
                 processed.add(entry_file)
                 res.append(os.path.join(entries_dir, entry_file))
-        process.wait()
-    except FileNotFoundError as e:
-        raise RuntimeError("Unable to find '{}' executable: {}".format(
-            cmdline[0], str(e)))
     return res
 
 

--- a/tools/gen-release-notes
+++ b/tools/gen-release-notes
@@ -162,6 +162,18 @@ def popen(cmdline):
 
 # {{{ Collecting
 
+def changelog_dirs():
+    """ Return a list of directories where changelog entries are stored.
+    """
+    # Be immutable to a caller current working directory.
+    res = []
+    script_file = os.path.realpath(__file__)
+    script_dir = os.path.dirname(script_file)
+    source_dir = os.path.dirname(script_dir)
+    res.append(os.path.join(source_dir, 'changelogs', 'unreleased'))
+    return res
+
+
 def changelog_entries_sorted(entries_dir):
     """ Acquire order of appearance from ```git log``.
 
@@ -180,19 +192,13 @@ def changelog_entries_sorted(entries_dir):
     return res
 
 
-def changelog_entries():
-    """ Return a list of changelog entry files.
+def changelog_entries(entries_dir):
+    """ Return a list of changelog entry files in the given directory.
 
     Sort the entries according to ``git log`` (by a time of the
     first appearance) and append ones out of the git tracking
     afterwards with the alphabetical order.
     """
-    # Be immutable to a caller current working directory.
-    script_file = os.path.realpath(__file__)
-    script_dir = os.path.dirname(script_file)
-    source_dir = os.path.dirname(script_dir)
-
-    entries_dir = os.path.join(source_dir, 'changelogs', 'unreleased')
     if not os.path.exists(entries_dir):
         raise RuntimeError('The changelog entries directory {} does not '
                            'exist'.format(entries_dir))
@@ -496,7 +502,9 @@ def print_release_notes(entry_section, comments, redefinitions):
 
 if __name__ == '__main__':
     try:
-        entries = changelog_entries()
+        entries = []
+        for entries_dir in changelog_dirs():
+            entries += changelog_entries(entries_dir)
         entry_section, comments = parse_changelog_entries(entries)
         print_release_notes(entry_section, comments, REDEFINITIONS)
     except RuntimeError as e:

--- a/tools/gen-release-notes
+++ b/tools/gen-release-notes
@@ -136,17 +136,16 @@ all the new features of the 1.10.x series.
 
 # {{{ Collecting
 
-def changelog_entries_sorted(source_dir, entries_dir_relative):
+def changelog_entries_sorted(entries_dir):
     """ Acquire order of appearance from ```git log``.
 
         Misses uncommitted entries and contains files that were
         deleted.
     """
-    cmdline = ['git', 'log', '--reverse', '--pretty=', '--name-only',
-               entries_dir_relative]
+    cmdline = ['git', '-C', entries_dir, 'log', '--reverse', '--pretty=',
+               '--name-only', '--relative']
     popen_kwargs = {
         'stdout': subprocess.PIPE,
-        'cwd': source_dir,
     }
     if sys.version_info[0] == 3:
         popen_kwargs['encoding'] = 'utf-8'
@@ -163,7 +162,7 @@ def changelog_entries_sorted(source_dir, entries_dir_relative):
             entry_file = line.rstrip()
             if entry_file not in processed and entry_file.endswith('.md'):
                 processed.add(entry_file)
-                res.append(os.path.join(source_dir, entry_file))
+                res.append(os.path.join(entries_dir, entry_file))
         process.wait()
     except FileNotFoundError as e:
         raise RuntimeError("Unable to find '{}' executable: {}".format(
@@ -183,8 +182,7 @@ def changelog_entries():
     script_dir = os.path.dirname(script_file)
     source_dir = os.path.dirname(script_dir)
 
-    entries_dir_relative = os.path.join('changelogs', 'unreleased')
-    entries_dir = os.path.join(source_dir, entries_dir_relative)
+    entries_dir = os.path.join(source_dir, 'changelogs', 'unreleased')
     if not os.path.exists(entries_dir):
         raise RuntimeError('The changelog entries directory {} does not '
                            'exist'.format(entries_dir))
@@ -195,7 +193,7 @@ def changelog_entries():
 
     # Uncommitted entries are not present here. Deleted entries
     # are present.
-    entries_sorted = changelog_entries_sorted(source_dir, entries_dir_relative)
+    entries_sorted = changelog_entries_sorted(entries_dir)
     entries_known = set(entries_sorted)
 
     res = []

--- a/tools/gen-release-notes
+++ b/tools/gen-release-notes
@@ -12,8 +12,8 @@ import subprocess
 # {{{ Redefinitions
 
 # Ensure certain order for known sections.
-SECTIONS_TOP = ['core', 'memtx', 'vinyl', 'replication', 'swim', 'raft',
-                'luajit', 'lua', 'sql']
+SECTIONS_TOP = ['enterprise', 'core', 'memtx', 'vinyl', 'replication', 'swim',
+                'raft', 'luajit', 'lua', 'sql']
 SECTIONS_BOTTOM = ['build', 'testing', 'misc']
 
 # Prettify headers, apply the ordering.
@@ -157,6 +157,16 @@ def popen(cmdline):
         raise RuntimeError("Unable to find '{}' executable: {}".format(
             cmdline[0], str(e)))
 
+
+def git_superproject_dir(source_dir):
+    """ Return the absolute path of the root of the superproject’s tree that
+        uses the given repository as its submodule. If the repository isn't
+        used as a submodule, returns none.
+    """
+    with popen(['git', '-C', source_dir, 'rev-parse',
+                '--show-superproject-working-tree']) as process:
+        return process.stdout.read().rstrip() or None
+
 # }}} Helpers
 
 
@@ -171,6 +181,9 @@ def changelog_dirs():
     script_dir = os.path.dirname(script_file)
     source_dir = os.path.dirname(script_dir)
     res.append(os.path.join(source_dir, 'changelogs', 'unreleased'))
+    superproject_dir = git_superproject_dir(source_dir)
+    if superproject_dir:
+        res.append(os.path.join(superproject_dir, 'changelogs', 'unreleased'))
     return res
 
 


### PR DESCRIPTION
We're going to reuse the existing [tools/gen-release-notes script](https://github.com/tarantool/tarantool/blob/master/tools/gen-release-notes) for generation of Enterprise Edition (EE) changelogs. To do that, we need to

 1. Add `enterprise` to the head of the sections list. The new section will be used by EE changelog entries. We want them to go before open-source changelog entries.
 2. Gather changelog entries from the `changelog/unreleased` directory of the superproject directory. EE uses the open-source repository as its submodule.

Needed for https://github.com/tarantool/tarantool-ee/issues/14