### PR TITLE
sql: fix assert when compare a tuple with a key

### DIFF
--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -778,7 +778,25 @@ out:
 	if (key != NULL) {
 		int new_rc = sqlVdbeRecordCompareMsgpack(key, unpacked);
 		region_truncate(&fiber()->gc, original_size);
-		assert(rc == new_rc);
+		/*
+		 * Here we compare two results from memcmp() alike
+		 * calls. A particular implementation depends on
+		 * a type of msgpack values to compare. For some
+		 * of them we actually call memcmp().
+		 *
+		 * memcmp() only guarantees that a result will be
+		 * less than zero, zero or more than zero. It
+		 * DOES NOT guarantee that the result will be
+		 * subtraction of the first non-equal bytes or
+		 * something else about the result aside of its
+		 * sign.
+		 *
+		 * So we don't compare `rc` and `new_rc` for
+		 * equivalence.
+		 */
+		assert((rc == 0 && new_rc == 0) ||
+		       (rc < 0 && new_rc < 0) ||
+		       (rc > 0 && new_rc > 0));
 	}
 #endif
 	return rc;


### PR DESCRIPTION
The function of the question (`tarantoolsqlIdxKeyCompare()`) compares a
tuple with a key. It extracts necessary fields from the tuple and runs
the compare function, which is basically `memcmp()` of two buffers (for
`varbinary` values -- numeric comparisons are different).

In the Debug build the function also re-verifies the result using a
separate comparison code. And here we compare two `memcmp()` return
values.

We shouldn't do it directly, because `memcmp()` only guarantees sign of
the result. Please, consider the linked issue for details.

NO_DOC=only debug build is affected
NO_CHANGELOG=only debug build is affected
NO_TEST=hard to create a stable reproducer

Fixes #6849