### PR TITLE
test: remove checksums from suite.ini config files

### DIFF
--- a/test/app-tap/suite.ini
+++ b/test/app-tap/suite.ini
@@ -9,32 +9,25 @@ fragile = {
     "retries": 10,
     "tests": {
         "tarantoolctl.test.lua": {
-            "issues": [ "gh-5059", "gh-5346" ],
-            "checksums": [ "1eea8234b18bf107271b2a973f32a10e", "5e9064e8640a5106967c4737523364ee", "d41d8cd98f00b204e9800998ecf8427e", "56437ae4d37b3bb3a93570ec02cfc666" ]
+            "issues": [ "gh-5059", "gh-5346" ]
         },
         "debug.test.lua": {
-            "issues": [ "gh-5346" ],
-            "checksums": [ "d41d8cd98f00b204e9800998ecf8427e", "70466b869ea41dbefe9147a0d37b9225" ]
+            "issues": [ "gh-5346" ]
         },
         "http_client.test.lua": {
-            "issues": [ "gh-5346", "gh-5574" ],
-            "checksums": [ "d41d8cd98f00b204e9800998ecf8427e", "46b77d3b0681ba31647c7349b2241b14", "52622501dc6895d779029beaea91924a", "7367680503771e3541f6b31ce9295431", "5785cbcd0ea50706650d6caa0db8f6d7", "45f534b3be3550f1c6ec24f9d5004611", "4098c6ba0538b0c8c3ef50b027947eff", "a813aadeb7237ad5061f5514e564eb48", "a9b69bbc05c35bf238e727f7653119fe", "92c0ec2b62a80606d7644063fafb1593", "41410c23359741402f799256f311f9f8", "4c449403fcb6f4a061bb89e1d4a93204", "a29bf8b0382d115e3e74d488ed953666" ]
+            "issues": [ "gh-5346", "gh-5574" ]
         },
         "inspector.test.lua": {
-            "issues": [ "gh-5346" ],
-            "checksums": [ "d41d8cd98f00b204e9800998ecf8427e", "03d5332b4ee423cffb2c52f4a2c79e7b" ]
+            "issues": [ "gh-5346" ]
         },
         "logger.test.lua": {
-            "issues": [ "gh-5346" ],
-            "checksums": [ "d41d8cd98f00b204e9800998ecf8427e" ]
+            "issues": [ "gh-5346" ]
         },
         "transitive1.test.lua": {
-            "issues": [ "gh-5346" ],
-            "checksums": [ "d41d8cd98f00b204e9800998ecf8427e" ]
+            "issues": [ "gh-5346" ]
         },
         "csv.test.lua": {
-            "issues": [ "gh-5346" ],
-            "checksums": [ "d41d8cd98f00b204e9800998ecf8427e" ]
+            "issues": [ "gh-5346" ]
         }
     }
   }

--- a/test/app/suite.ini
+++ b/test/app/suite.ini
@@ -10,12 +10,10 @@ fragile = {
     "retries": 10,
     "tests": {
         "socket.test.lua": {
-            "issues": [ "gh-4978" ],
-            "checksums": [ "08dccf8bc443353e32999a98b3894589", "357fc829b1d0c4b9dd6163a928fba419" ]
+            "issues": [ "gh-4978" ]
         },
         "fiber.test.lua": {
-            "issues": [ "gh-4987", "gh-5341" ],
-            "checksums": [ "fe10aeb6841cae7f47c5e3bb8256dee9", "bb1832309dc4ed39640ae6a11ac7e3a8", "b7c666348a88713e348164d63d5a8a45", "6633fc1d56a3487fe5dec0ee494bf30d", "bfd26e488513e8e99c10077abc5b782d", "238c57bd5d0d933adbeeee638ba27214" ]
+            "issues": [ "gh-4987", "gh-5341" ]
         }
     }
   }

--- a/test/box-py/suite.ini
+++ b/test/box-py/suite.ini
@@ -9,12 +9,10 @@ fragile = {
     "retries": 10,
     "tests": {
         "snapshot.test.py": {
-            "issues": [ "gh-4514" ],
-            "checksums": [ "0e9db9dd391ea124bc5181089350a36e", "5da377d6e89684df711ab7d37b481530" ]
+            "issues": [ "gh-4514" ]
         },
         "iproto.test.py": {
-            "issues": [ "gh-qa-132" ],
-            "checksums": [ "80811acaa0de1bea50ced7297fc3d3f8", "58f675fba3ea072b40c0899771f12252" ]
+            "issues": [ "gh-qa-132" ]
         }
     }
   }

--- a/test/box-tap/suite.ini
+++ b/test/box-tap/suite.ini
@@ -9,24 +9,19 @@ fragile = {
     "retries": 10,
     "tests": {
         "cfg.test.lua": {
-            "issues": [ "gh-5346", "gh-4344" ],
-            "checksums": [ "d41d8cd98f00b204e9800998ecf8427e", "53be182412baa1509cb7a3e27beca3ed" ]
+            "issues": [ "gh-5346", "gh-4344" ]
         },
         "net.box.test.lua": {
-            "issues": [ "gh-5346" ],
-            "checksums": [ "d41d8cd98f00b204e9800998ecf8427e" ]
+            "issues": [ "gh-5346" ]
         },
         "session.storage.test.lua": {
-            "issues": [ "gh-5346" ],
-            "checksums": [ "d41d8cd98f00b204e9800998ecf8427e" ]
+            "issues": [ "gh-5346" ]
         },
         "session.test.lua": {
-            "issues": [ "gh-5346" ],
-            "checksums": [ "d41d8cd98f00b204e9800998ecf8427e" ]
+            "issues": [ "gh-5346" ]
         },
         "gh-4231-box-execute-locking.test.lua": {
-            "issues": [ "gh-5558" ],
-            "checksums": [ "6b5be514a65e8d115afa5e8ae6093b40" ]
+            "issues": [ "gh-5558" ]
         }
     }
   }

--- a/test/box/suite.ini
+++ b/test/box/suite.ini
@@ -26,8 +26,7 @@ fragile = {
             "issues": [ "gh-4882" ]
         },
         "misc.test.lua": {
-            "issues": [ "gh-4982" ],
-            "checksums": [ "851dcc5dfd0cc77456ce1d9e6ec7d38f" ]
+            "issues": [ "gh-4982" ]
         },
         "tuple.test.lua": {
             "issues": [ "gh-4988" ]
@@ -39,8 +38,7 @@ fragile = {
             "issues": [ "gh-4994" ]
         },
         "sequence.test.lua": {
-            "issues": [ "gh-4996" ],
-            "checksums": [ "062ab51f8b36bad59ba5a137f1c48b8e" ]
+            "issues": [ "gh-4996" ]
         },
         "on_replace.test.lua": {
             "issues": [ "gh-4997" ]
@@ -49,24 +47,19 @@ fragile = {
             "issues": [ "gh-4998" ]
         },
         "net.box_disconnect_gh-3859.test.lua": {
-            "issues": [ "gh-5156" ],
-            "checksums": [ "345f55562f152e52d79f78e2920b28a2" ]
+            "issues": [ "gh-5156" ]
         },
         "access_sysview.test.lua": {
-            "issues": [ "gh-5327" ],
-            "checksums": [ "d6136f214b81556b1858e05970a90963" ]
+            "issues": [ "gh-5327" ]
         },
         "net.box_reconnect_after.test.lua": {
-            "issues": [ "gh-5333" ],
-            "checksums": [ "cca5df51000ec0076450a6b1a8b21053" ]
+            "issues": [ "gh-5333" ]
         },
         "lua.test.lua": {
-            "issues": [ "gh-5351" ],
-            "checksums": [ "6b0a398df80683a968d270fdc0efdf50", "5d6a9c9a1b08cf5cd3f9bbdc2e0dfe3a" ]
+            "issues": [ "gh-5351" ]
         },
         "net.box_on_schema_reload-gh-1904.test.lua": {
-            "issues": [ "gh-5354" ],
-            "checksums": [ "cf81a7329eaf70938dabe1a58d3c3bbd" ]
+            "issues": [ "gh-5354" ]
         },
         "protocol.test.lua": {
             "issues": [ "gh-5247" ]
@@ -75,180 +68,136 @@ fragile = {
             "issues": [ "gh-5247" ]
         },
         "hash_collation.test.lua": {
-            "issues": [ "gh-5247" ],
-            "checksums": [ "f39a3bc3155e4a7783350c0392bf3529" ]
+            "issues": [ "gh-5247" ]
         },
         "net.box_connect_triggers_gh-2858.test.lua": {
-            "issues": [ "gh-5247" ],
-            "checksums": [ "9f4c330241df7d93f521b505a7fb9647" ]
+            "issues": [ "gh-5247" ]
         },
         "net.box_incompatible_index-gh-1729.test.lua": {
-            "issues": [ "gh-5360" ],
-            "checksums": [ "1390e6d8adfa1b29a05df031f91884c6" ]
+            "issues": [ "gh-5360" ]
         },
         "gh-2763-session-credentials-update.test.lua": {
-            "issues": [ "gh-5363" ],
-            "checksums": [ "3caab61b50328a1b8bdaa0b2d857d95b" ]
+            "issues": [ "gh-5363" ]
         },
         "huge_field_map_long.test.lua": {
-            "issues": [ "gh-5375" ],
-            "checksums": [ "57e0451794c2b55625e5c0b2483d1b26" ]
+            "issues": [ "gh-5375" ]
         },
         "gh-5135-invalid-upsert.test.lua": {
-            "issues": [ "gh-5376" ],
-            "checksums": [ "5f0424778fda5bd30f48d707eebe1983" ]
+            "issues": [ "gh-5376" ]
         },
         "hash_replace.test.lua": {
-            "issues": [ "gh-5400" ],
-            "checksums": [ "3d618f5e562147395dc288b443dc4c0b" ]
+            "issues": [ "gh-5400" ]
         },
         "access_misc.test.lua": {
-            "issues": [ "gh-5401" ],
-            "checksums": [ "da9f6f9172f41083d8ae3eda3565a58e" ]
+            "issues": [ "gh-5401" ]
         },
         "net.box_huge_data_gh-983.test.lua": {
-            "issues": [ "gh-5402" ],
-            "checksums": [ "cff17b099fe42519c69da09d7a2c6691" ]
+            "issues": [ "gh-5402" ]
         },
         "hash_64bit_replace.test.lua": {
-            "issues": [ "gh-5410" ],
-            "checksums": [ "11eefd2021fa435c1893ab1584031e5d" ]
+            "issues": [ "gh-5410" ]
         },
         "access.test.lua": {
-            "issues": [ "gh-5373", "gh-5411" ],
-            "checksums": [ "f94a9c1e206e1db81b9f39666ea14cf7" ]
+            "issues": [ "gh-5373", "gh-5411" ]
         },
         "net.box_incorrect_iterator_gh-841.test.lua": {
-            "issues": [ "gh-5434" ],
-            "checksums": [ "3c2b74ee82a7689f29f8a8e50d804ecb", "cff17b099fe42519c69da09d7a2c6691" ]
+            "issues": [ "gh-5434" ]
         },
         "hash_gh-1467.test.lua": {
-            "issues": [ "gh-5476" ],
-            "checksums": [ "47fb00af79ba20d33b6e9b8fc1a7320e" ]
+            "issues": [ "gh-5476" ]
         },
         "hash_gh-1467.test.lua": {
-            "issues": [ "gh-5504" ],
-            "checksums": [ "6ea05ab1092cb7ed225aaa617b2c0832" ]
+            "issues": [ "gh-5504" ]
         },
         "iterator.test.lua": {
-            "issues": [ "gh-5523" ],
-            "checksums": [ "c29fa9a2c90fd99a252aaa163ba384db" ]
+            "issues": [ "gh-5523" ]
         },
         "tree_pk_multipart.test.lua": {
-            "issues": [ "gh-5528" ],
-            "checksums": [ "e8c7465cac97fab9157025694c1eabea", "ceb912a9c88a35bd1622f30989eaca95" ]
+            "issues": [ "gh-5528" ]
         },
         "cfg.test.lua": {
-            "issues": [ "gh-5530" ],
-            "checksums": [ "6562ddce4c4d8d42e2a81c7e452434b8" ]
+            "issues": [ "gh-5530" ]
         },
         "net.box_count_inconsistent_gh-3262.test.lua": {
-            "issues": [ "gh-5532" ],
-            "checksums": [ "54cb0a7773f633dc7212a944d43c7b56", "89db5b8808cd7361d9d7ee5faf0aa0a8" ]
+            "issues": [ "gh-5532" ]
         },
         "before_replace.test.lua": {
-            "issues": [ "gh-5546" ],
-            "checksums": [ "6379f11bde87b463059911b670a29906" ]
+            "issues": [ "gh-5546" ]
         },
         "net.box_iproto_hangs_gh-3464.test.lua": {
-            "issues": [ "gh-5548" ],
-            "checksums": [ "78e53d88a92708766af55557fc5889b2" ]
+            "issues": [ "gh-5548" ]
         },
         "net.box_connect_timeout_gh-2054.test.lua": {
-            "issues": [ "gh-5548" ],
-            "checksums": [ "78e53d88a92708766af55557fc5889b2" ]
+            "issues": [ "gh-5548" ]
         },
         "net.box_gibberish_gh-3900.test.lua": {
-            "issues": [ "gh-5548" ],
-            "checksums": [ "78e53d88a92708766af55557fc5889b2" ]
+            "issues": [ "gh-5548" ]
         },
         "net.box_log_corrupted_rows_gh-4040.test.lua": {
-            "issues": [ "gh-5548" ],
-            "checksums": [ "78e53d88a92708766af55557fc5889b2" ]
+            "issues": [ "gh-5548" ]
         },
         "leak.test.lua": {
-            "issues": [ "gh-5548" ],
-            "checksums": [ "78e53d88a92708766af55557fc5889b2" ]
+            "issues": [ "gh-5548" ]
         },
         "select.test.lua": {
-            "issues": [ "gh-5548", "gh-5553" ],
-            "checksums": [ "78e53d88a92708766af55557fc5889b2", "7a48e9ad1c4981a3bceebb0e71586376" ]
+            "issues": [ "gh-5548", "gh-5553" ]
         },
         "net.box_get_connection_object.test.lua": {
-            "issues": [ "gh-5549" ],
-            "checksums": [ "80f104406a762aed2119108aa33be73d" ]
+            "issues": [ "gh-5549" ]
         },
         "net.box_reload_schema_gh-636.test.lua": {
-            "issues": [ "gh-5550" ],
-            "checksums": [ "42720b688500eb4dc77f2d4b4eda305d", "263ac84314fd1b2585ad1ee81e8d0dd0" ]
+            "issues": [ "gh-5550" ]
         },
         "net.box_index_unique_flag_gh-4091.test.lua": {
-            "issues": [ "gh-5551" ],
-            "checksums": [ "1f53f6926961c55931128ae1f3f7a03c" ]
+            "issues": [ "gh-5551" ]
         },
         "schema_reload.test.lua": {
-            "issues": [ "gh-5552" ],
-            "checksums": [ "e07fa0f0d38ad1619c6206b30f8c8e8f" ]
+            "issues": [ "gh-5552" ]
         },
         "net.box_field_names_gh-2978.test.lua": {
-            "issues": [ "gh-5554" ],
-            "checksums": [ "1371cceed747c5a4875ba8ff7047fa3a" ]
+            "issues": [ "gh-5554" ]
         },
         "ddl_collation_deleted_gh-3290.test.lua": {
-            "issues": [ "gh-5555" ],
-            "checksums": [ "4a0a0ea618b9baf9fdd9826e83191576" ]
+            "issues": [ "gh-5555" ]
         },
         "tree_pk_multipart.test.lua": {
-            "issues": [ "gh-5556" ],
-            "checksums": [ "a30bba1908e52bc9fc31f6c33565cdc1" ]
+            "issues": [ "gh-5556" ]
         },
         "alter.test.lua": {
-            "issues": [ "gh-5557" ],
-            "checksums": [ "26e862f898badb0fd45c429ace27cd92" ]
+            "issues": [ "gh-5557" ]
         },
         "ddl_call_twice_gh-2336.test.lua": {
-            "issues": [ "gh-5560" ],
-            "checksums": [ "33e685a1e7a346ceb3749fa0bd0528a2" ]
+            "issues": [ "gh-5560" ]
         },
         "gh-4703-on_shutdown-bug.test.lua": {
-            "issues": [ "gh-5560" ],
-            "checksums": [ "33e685a1e7a346ceb3749fa0bd0528a2" ]
+            "issues": [ "gh-5560" ]
         },
         "on_shutdown.test.lua": {
-            "issues": [ "gh-5562" ],
-            "checksums": [ "4c18b44583b1a169f0fff5baed531efd" ]
+            "issues": [ "gh-5562" ]
         },
         "net.box_msgpack_gh-2195.test.lua": {
-            "issues": [ "gh-5548" ],
-            "checksums": [ "78e53d88a92708766af55557fc5889b2" ]
+            "issues": [ "gh-5548" ]
         },
         "net.box_uri_first_arg_gh-398.test.lua": {
-            "issues": [ "gh-5548" ],
-            "checksums": [ "78e53d88a92708766af55557fc5889b2" ]
+            "issues": [ "gh-5548" ]
         },
         "indices_any_type.test.lua": {
-            "issues": [ "gh-5575" ],
-            "checksums": [ "16f825949adba95163cd2641fd9f8c05" ]
+            "issues": [ "gh-5575" ]
         },
         "call.test.lua": {
-            "issues": [ "gh-5576" ],
-            "checksums": [ "10288ad585ec99f0e8d121d6a933ab5e" ]
+            "issues": [ "gh-5576" ]
         },
         "net.box_discard_gh-3107.test.lua": {
-            "issues": [ "gh-5577" ],
-            "checksums": [ "314f85aa0efa27c15446910c950d68c9" ]
+            "issues": [ "gh-5577" ]
         },
         "rtree_misc.test.lua": {
-            "issues": [ "gh-5578" ],
-            "checksums": [ "af719d79ce29e0d15a1ab6449830c59f" ]
+            "issues": [ "gh-5578" ]
         },
         "ddl_collation.test.lua": {
-            "issues": [ "gh-5579" ],
-            "checksums": [ "72a91771dd0a3e4a1a4052f61e4b72e9" ]
+            "issues": [ "gh-5579" ]
         },
         "tx_man.test.lua": {
-            "issues": [ "gh-5579" ],
-            "checksums": [ "72a91771dd0a3e4a1a4052f61e4b72e9" ]
+            "issues": [ "gh-5579" ]
         }
     }
   }

--- a/test/engine/suite.ini
+++ b/test/engine/suite.ini
@@ -13,24 +13,19 @@ fragile = {
     "retries": 10,
     "tests": {
         "gh-4973-concurrent-alter-fails.test.lua": {
-            "issues": [ "gh-5157" ],
-            "checksums": [ "4e797e63335cebe24dab15eae4aa8044" ]
+            "issues": [ "gh-5157" ]
         },
         "tuple.test.lua": {
-            "issues": [ "gh-5480" ],
-            "checksums": [ "8fdb38e170c7c1e0c2353a0e76547081" ]
+            "issues": [ "gh-5480" ]
         },
         "conflict.test.lua": {
-            "issues": [ "gh-5516" ],
-            "checksums": [ "187434595fcf4e4d22f2ecee707f5e50", "20842c99301b23e71a6365550333da87" ]
+            "issues": [ "gh-5516" ]
         },
         "errinj_ddl.test.lua": {
-            "issues": [ "gh-5585" ],
-            "checksums": [ "294f6d8da54e492470eb916b862a6dbb", "a148543ed86721e72d55bb877f53ac4b" ]
+            "issues": [ "gh-5585" ]
         },
         "replica_join.test.lua": {
-            "issues": [ "gh-5504" ],
-            "checksums": [ "07ec112339c7ceb0418b85ce9cf2abcc" ]
+            "issues": [ "gh-5504" ]
         }
     }
   }

--- a/test/engine_long/suite.ini
+++ b/test/engine_long/suite.ini
@@ -12,12 +12,10 @@ fragile = {
     "retries": 10,
     "tests": {
         "delete_replace_update.test.lua": {
-            "issues": [ "gh-5570" ],
-            "checksums": [ "87a84fe5ec49e15981dd52d7cfaea22e", "a4203ec9b3ed711aceb0944259de79ce", "7a2e5c3cd2500fb7ce232a9ce93be628", "6fd4a1176e1462dfed015a9bc728d883", "c7a0eef1b716969e5a015f52912612a1", "eb31939c4411a8c2734068d785bd60a3" ]
+            "issues": [ "gh-5570" ]
         },
         "delete_insert.test.lua": {
-            "issues": [ "gh-5504" ],
-            "checksums": [ "e175a300db2e8cf4cb6f2e2ddfe75b8f" ]
+            "issues": [ "gh-5504" ]
         }
     }
   }

--- a/test/replication-py/suite.ini
+++ b/test/replication-py/suite.ini
@@ -7,20 +7,16 @@ fragile = {
     "retries": 10,
     "tests": {
         "init_storage.test.py": {
-            "issues": [ "gh-4949" ],
-            "checksums": [ "9b4235bb6bb9d76aa6a1f7dc8f088075", "4c5fc871955a3166d67fbfa9f254f68a", "bc2781acdb5745d01da2f533a0d519f9" ]
+            "issues": [ "gh-4949" ]
         },
         "conflict.test.py": {
-            "issues": [ "gh-4980" ],
-            "checksums": [ "68a38d9d838f8b0dbf72a02fcfb5451d" ]
+            "issues": [ "gh-4980" ]
         },
         "cluster.test.py": {
-            "issues": [ "gh-5109" ],
-            "checksums": [ "0ee35fafd167b81134a40347173af91a", "e08ee8e11ee9b493c77a858a550d737b", "6e137a706dccf22ad74f4fb765275ce4" ]
+            "issues": [ "gh-5109" ]
         },
         "multi.test.py": {
-            "issues": [ "gh-5362" ],
-            "checksums": [ "0ee35fafd167b81134a40347173af91a", "6f1115c6de0e5a4dd720e6021bc647a4" ]
+            "issues": [ "gh-5362" ]
         }
     }
   }

--- a/test/replication/suite.ini
+++ b/test/replication/suite.ini
@@ -14,160 +14,121 @@ fragile = {
     "retries": 10,
     "tests": {
         "errinj.test.lua": {
-            "issues": [ "gh-3870" ],
-            "checksums": [ "5d3f58323aafc1a11d9b9264258f7acf", "919921e13968b108d342555746ba55c9" ]
+            "issues": [ "gh-3870" ]
         },
         "skip_conflict_row.test.lua": {
-            "issues": [ "gh-4958" ],
-            "checksums": [ "a21f07339237cd9d0b8c74e144284449", "0359b0b1cc80052faf96972959513694", "ef104dfd04afa7c75087de13246e3eb0" ]
+            "issues": [ "gh-4958" ]
         },
         "sync.test.lua": {
-            "issues": [ "gh-3835" ],
-            "checksums": [ "1bf966198e1521a8a230d9f53e244056", "251df1dfcab4a19508cbe4c3333c9bc6", "2fedbbfc8267f2aa1321683a23534bbb", "0b509192767a75639582e68efa9c4ac4", "4a0fff059cbb7ea097e0ee920c266950", "f1a824f43436d1c0117577ba2932a970", "29a67ed6320e1d7887198ea8b7f47817", "aa7e32bcf0b4ffaffab9c87b7507b544", "ff211f29d3153ebdca518545e992b635", "f6b4e9b5c4c4f4d59ddea45a9c4ae76e", "1a5a388f933995a664c670c259e40fa8" ]
+            "issues": [ "gh-3835" ]
         },
         "transaction.test.lua": {
-            "issues": [ "gh-4312", "gh-5331" ],
-            "checksums": [ "302cbcfde971bc8cb65b059165509d20", "a488d1f66d4d0325c28746db77cf5e17", "7072465a0fc9453a128eb343f91b0688", "b5461bb005c14823fbb80e75977bdc67", "7ca7041a32330f3a6152b3eb4049cd9c", "962c3e79f44fd28f3b59c0846b298789", "73f992a886de2f4bef751bd6bfef1b56", "15aa1572d24151434b3a1bfcf5549b72", "727a033eb0b837a2e89e4d43f83ac5c3", "a68cbc7ea7e8414d140dae4390d90e11" ]
+            "issues": [ "gh-4312", "gh-5331" ]
         },
         "autobootstrap.test.lua": {
-            "issues": [ "gh-4533" ],
-            "checksums": [ "2bafb1762a8e6ad60a32d47d3906eb1d", "cc622d5adf3552f8b5fae4efcd279598", "5f53b1939f7a5f4480a8950d0e8546da", "12489e29b7b2dc0ddceb5f596d8fb1a4", "7a9f80f69680c04f1032a1c8195c8f0f", "0e29faab3f2fbc5d0e725bc44e804db3" ]
+            "issues": [ "gh-4533" ]
         },
         "autobootstrap_guest.test.lua": {
-            "issues": [ "gh-4533" ],
-            "checksums": [ "424bba9bfa0d6a8a050c096bb3223eec", "ba7d7d301a3c2c342cb96abfa6e5d324" ]
+            "issues": [ "gh-4533" ]
         },
         "replica_rejoin.test.lua": {
-            "issues": [ "gh-4985" ],
-            "checksums": [ "e5d6bdd11404b9f2566023a46085c520", "0daa2fa7990e7f3e0d360b0b53e7ccf0", "ed0761ecd676f9463418cdcd7cd568cc", "663e04e458a93304ad2f1db23e4b4a4d", "5635423a327bd57a8592e45a730ac753", "f221fa7dfe5cb4f8789896e41077cedd" ]
+            "issues": [ "gh-4985" ]
         },
         "recover_missing_xlog.test.lua": {
-            "issues": [ "gh-4989" ],
-            "checksums": [ "e88f791d1276b1ba9b041dfd6b4187d2" ]
+            "issues": [ "gh-4989" ]
         },
         "box_set_replication_stress.test.lua": {
-            "issues": [ "gh-4992", "gh-4986" ],
-            "checksums": [ "58cd2e36248c230e96c02397af5d7dbd", "295cc60d4fbd223d5b6e44f88afac46a", "feb0b3a434cd215bf7330579ebed1cc9" ]
+            "issues": [ "gh-4992", "gh-4986" ]
         },
         "gh-4605-empty-password.test.lua": {
-            "issues": [ "gh-5030" ],
-            "checksums": [ "c66489c25cba5b147c4a76c12bd11690" ]
+            "issues": [ "gh-5030" ]
         },
         "on_schema_init.test.lua": {
-            "issues": [ "gh-5291" ],
-            "checksums": [ "1cb01c103258e26c8a80458f6c40fd44", "6d30a3446222758c621030a3e90b25a7" ]
+            "issues": [ "gh-5291" ]
         },
         "ddl.test.lua": {
-            "issues": [ "gh-5337" ],
-            "checksums": [ "a006d40205b9a67ddbbb8206b4e1764c", "1e818590bfe01a683a4fcbef565ba821", "a3962e843889def7f61d6f1f71461bf1", "9fcdc6f51d031e5d6568793bdcdbb7fb" ]
+            "issues": [ "gh-5337" ]
         },
         "qsync_advanced.test.lua": {
-            "issues": [ "gh-5340" ],
-            "checksums": [ "51ee48072d103509eca347ecfc4ca26a", "2fad792074314e4d7bc3c5d5e7db610f", "fc050bfb6afa3dc4a3f7bc74c4e5b688", "3ce5a2d40066ef2842cbc135f904dae2" ]
+            "issues": [ "gh-5340" ]
         },
         "replicaset_ro_mostly.test.lua": {
-            "issues": [ "gh-5342" ],
-            "checksums": [ "b2647b5bdbda47efe5b1add57285d226" ]
+            "issues": [ "gh-5342" ]
         },
         "gh-3637-misc-error-on-replica-auth-fail.test.lua": {
-            "issues": [ "gh-5343" ],
-            "checksums": [ "4cefa5f4c770cfc4f807c4a860e61d14"]
+            "issues": [ "gh-5343" ]
         },
         "on_replace.test.lua": {
-            "issues": [ "gh-4997", "gh-5344", "gh-5349" ],
-            "checksums": [ "407b670018516464e5b74469915a4739", "a4bfe23bccfe95a314ebb61695f30e80", "965a21d065b14759fcf7ce3f183bb89b" ]
+            "issues": [ "gh-4997", "gh-5344", "gh-5349" ]
         },
         "wal_rw_stress.test.lua": {
-            "issues": [ "gh-5347" ],
-            "checksums": [ "940daa5748af1ec13da8705614af6d39", "335d7ea3593bf06f44cc7da83d4fde46" ]
+            "issues": [ "gh-5347" ]
         },
         "qsync_basic.test.lua": {
-            "issues": [ "gh-5355" ],
-            "checksums": [ "aa0f68d40ef64fa9690d20e652d7f47c", "b47d6b13798ba8357f67785c51e190ba", "d24a0e990dba9bbc84fbf92a1ca2d614", "bd4909e619e23606f57f14a9fa52a4c2", "515f6a5fc601d2bb6c4de61b7c5720af", "a3920c8ee8ea9c158272bb4980b604aa", "2fffa40d65f349386975bc0e1871756c" ]
+            "issues": [ "gh-5355" ]
         },
         "gh-3247-misc-iproto-sequence-value-not-replicated.test.lua": {
-            "issues": [ "gh-5357", "gh-5380" ],
-            "checksums": [ "4a4f2db6802e1b2fa2e31bb9948e7440", "d5176f84099100801f8a67fa25cd2c06", "0ace3828631588c937878cd91b2ecbd8", "bbea372ce9d8723c906b62e81a7cc1cf", "d41d8cd98f00b204e9800998ecf8427e", "a6b806508572189415c6aab014353cf8" ]
+            "issues": [ "gh-5357", "gh-5380" ]
         },
         "prune.test.lua": {
-            "issues": [ "gh-5361" ],
-            "checksums": [ "2dd52fed642b0132ccef3853ad96a807", "7efe2d7cb3a869a1ea5fb954f323d06d", "6c3d27ffafa2eb1b380c07286ca8d8f1", "96246fc9e418b077adcf09ce284d432d", "f77353970dc69556ffc0226e68fa2ee9", "8f151e1c3daeb53934de985d266a99a3" ]
+            "issues": [ "gh-5361" ]
         },
         "gh-4402-info-errno.test.lua": {
-            "issues": [ "gh-5366" ],
-            "checksums": [ "4a7286b7141c6a15556990ead3bf26b0" ]
+            "issues": [ "gh-5366" ]
         },
         "show_error_on_disconnect.test.lua": {
-            "issues": [ "gh-5371" ],
-            "checksums": [ "304214225ce2a0238cc583059733f73a", "7bb4a0f8d3f82fa998462ea8120983fb", "67ca0a848e3e0f3c213e9c9e74514dc1", "7bb4a0f8d3f82fa998462ea8120983fb" ]
+            "issues": [ "gh-5371" ]
         },
         "gh-5298-qsync-recovery-snap.test.lua.test.lua": {
-            "issues": [ "gh-5379" ],
-            "checksums": [ "bf05ad24b40e88195563a61bfd1fceef" ]
+            "issues": [ "gh-5379" ]
         },
         "anon.test.lua": {
-            "issues": [ "gh-5381" ],
-            "checksums": [ "a73b46d27fc48d2d7016597eeadbed2c", "567f5634906c746ef8c64b15f86f12aa", "c78e5136c44f204d3873745f5977d742", "17216e28adfc7462020593edbd0e0f9b", "316ed2b4fbe84e551b278404439e027a", "791e5b45e8fe281a764ad379fb8226d5" ]
+            "issues": [ "gh-5381" ]
         },
         "election_qsync_stress.test.lua": {
-            "issues": [ "gh-5395" ],
-            "checksums": [ "ddb40b0c6bccc03bcbe7d1ec4090cf42", "1e798a732fbc94f7565b3751f787817c", "600268ded5d7b846f4da1992f6d67fee", "37e671aea27e3396098f9d13c7fa7316", "8358455e208f453a1132eee565951403", "2781e9a4da2392345b2ed85a911acd50", "ca38ff2cdfa65b3defb26607b24454c6", "54c06e29747b0d110555f78b2b704e8b", "14c84e1a913423ebc7cf5a322d881722", "9823327be2cb55b96f35acf4f357cbd7", "8d3f067f0d177f44d9f1ca6a43106fd9" ]
+            "issues": [ "gh-5395" ]
         },
         "gh-3711-misc-no-restart-on-same-configuration.test.lua": {
-            "issues": [ "gh-5407" ],
-            "checksums": [ "701279bf227f341db6bb32d20d86ae0e" ]
+            "issues": [ "gh-5407" ]
         },
         "status.test.lua": {
-            "issues": [ "gh-5409" ],
-            "checksums": [ "1bc90c82de8f8dc7939d78aff4054daf", "f246a11d13bb9e53ed465048b1dbd172" ]
+            "issues": [ "gh-5409" ]
         },
         "gh-5287-boot-anon.test.lua": {
-            "issues": [ "gh-5412" ],
-            "checksums": [ "5b8cfb17c89195a02ac44fb59e6e0e2f" ]
+            "issues": [ "gh-5412" ]
         },
         "election_qsync.test.lua": {
-            "issues": [ "gh-5430" ],
-            "checksums": [ "afaa5d0f392c8de5420a05b268d04741", "6331fe0c2a39d040494598cdcd0dd5da", "ab99808cf72850d3a6892f452550b66a", "da28a9b678ba3ab177f0ddada8387f64", "afed6dfe04e7da2c870fcf5e85e8389d", "64d83114e166124d2abd8fed6b726712", "0587c125b85ee9ba534b8c9ff0bf31c0", "1b1957e609d7a743633740f3f7d55f9c", "de2ecf8380d0d16c383afc24e48cec9b", "349b921dfd4e8620d67dbecbc9938c3f", "8d4e08a8dcfa4b45235f156774996743", "b8eb71402209c137b41e9a91aaf36328", "c5793b55d46a00cb8fca67dfd4cd44dc", "6ca381b09d057be926d31395770f3fba", "57f11c4a1f4984109003f3fcbfd506a4", "a02580af3738d36ca4a9b8394e4f415d", "f6fb450b29fc09cfca81056684e305d8", "c2e95ac3a9693c2a91f92ba6d82ecd8f", "64ba98974e579470ff1794c23cc93a9b", "0ecfae5f61365ea6ccf89fce13680683", "490e6858dad50affea16d589a662692b", "6c50af8efe652141eb98f55c230b9835", "5fcc54b5813d31bd1fc71a007046f4bb", "829a8911c5a3e7562e2c20a33857fa90", "cf12573d1df6ba0fd9c2a32f511a13df", "549f43a900fcbc27ff095940e5be3f28", "0e66122cffb38ae57242b2ac43b066a8", "5fadbd8380401271dd6aa5d11950772e", "21aef49c0a7fe8b74c7e93a8cbd5a475", "fa571911c78f411484444ba72d587005", "1c68d778b6e78dff37609b55d536cfd8", "3e201907cb5545cc07b5d6773236a936" ]
+            "issues": [ "gh-5430" ]
         },
         "gc.test.lua": {
-            "issues": [ "gh-5474" ],
-            "checksums": [ "b71b49a2066375eab34891f82c1ea013", "ba5a30981d31d060be39a3880422f915", "641731a65ba65c6bbd32437a45ca55d3" ]
+            "issues": [ "gh-5474" ]
         },
         "bootstrap_leader.test.lua": {
-            "issues": [ "gh-5478" ],
-            "checksums": [ "e1a4aafd227fc5e41ce74a92bb7fa5ad" ]
+            "issues": [ "gh-5478" ]
         },
         "gh-5426-election-on-off.test.lua": {
-            "issues": [ "gh-5506" ],
-            "checksums": [ "626c96b22943d3857511b0e81a82596d", "c57db4211832e9dea3e2092f19a9fdb8", "b456e98e5e4c8a1c5a3b49b9e213cb40", "0e5d7ed0cbc6d7e02361bcd310c8ddda", "741073bf1b731f7b3d2287d40b1325ac" ]
+            "issues": [ "gh-5506" ]
         },
         "rebootstrap.test.lua": {
-            "issues": [ "gh-5524" ],
-            "checksums": [ "9b51988ec68ae417433ec41bb7285ac4", "dcc2b38bd7e670176dc8a5eb29193570" ]
+            "issues": [ "gh-5524" ]
         },
         "qsync_with_anon.test.lua": {
-            "issues": [ "gh-5582" ],
-            "checksums": [ "9b4dfde7e23f265ffb9eb750c273262e", "2b3bca7d520dc844419009afe36c7fa3", "4d35fb2dfd7e3a783636071941a27444" ]
+            "issues": [ "gh-5582" ]
         },
         "qsync_errinj.test.lua": {
-            "issues": [ "gh-5504" ],
-            "checksums": [ "c3d15a50c04937538451c143b979942e", "79541ae84bfd81d078c0aad021fb7d02" ]
+            "issues": [ "gh-5504" ]
         },
         "gh-5435-qsync-clear-synchro-queue-commit-all.test.lua": {
-            "issues": [ "gh-qa-129" ],
-            "checksums": [ "d1c9565e92bca6bce6f5e0f23ad26dbe" ]
+            "issues": [ "gh-qa-129" ]
         },
         "gh-5445-leader-inconsistency.test.lua": {
-            "issues": [ "gh-qa-129" ],
-            "checksums": [ "0190a633604717a954288d6d19371be5" ]
+            "issues": [ "gh-qa-129" ]
         },
         "gh-3055-election-promote.test.lua": {
-            "issues": [ "gh-qa-127" ],
-            "checksums": [ "87cc6835ae36d276fd57a164991cd5da", "f8dda6c93d692f3fcbe6b53d5c5963a9" ]
+            "issues": [ "gh-qa-127" ]
         },
         "election_basic.test.lua": {
-            "issues": [ "gh-qa-133" ],
-            "checksums": [ "bd79c8e45a7b307b815c54f8390b074f" ]
+            "issues": [ "gh-qa-133" ]
         }
     }
   }

--- a/test/sql-tap/suite.ini
+++ b/test/sql-tap/suite.ini
@@ -37,28 +37,22 @@ fragile = {
             "issues": [ "gh-5350" ]
         },
         "in2.test.lua": {
-            "issues": [ "gh-5580" ],
-            "checksums": [ "d44ffefb3e395506fd92e149c3a53bd6", "584b53019f93b71741d9524ef1929b8c", "faf4261e88fb10b6cd5d695035ee16ed", "60de07a667aaf1f78339898a6f3c47e0", "8cc64d031118b492744dd87baa16c68b" ]
+            "issues": [ "gh-5580" ]
         },
         "index4.test.lua": {
-            "issues": [ "gh-5581" ],
-            "checksums": [ "d41d8cd98f00b204e9800998ecf8427e" ]
+            "issues": [ "gh-5581" ]
         },
         "count.test.lua": {
-            "issues": [ "gh-5581" ],
-            "checksums": [ "d41d8cd98f00b204e9800998ecf8427e" ]
+            "issues": [ "gh-5581" ]
         },
         "gh-3083-ephemeral-unref-tuples.test.lua": {
-            "issues": [ "gh-5581" ],
-            "checksums": [ "d41d8cd98f00b204e9800998ecf8427e" ]
+            "issues": [ "gh-5581" ]
         },
         "transitive1.test.lua": {
-            "issues": [ "gh-5581" ],
-            "checksums": [ "d41d8cd98f00b204e9800998ecf8427e" ]
+            "issues": [ "gh-5581" ]
         },
         "collation.test.lua": {
-            "issues": [ "gh-5504" ],
-            "checksums": [ "7d7a9ef7a1184ab414838d6b17e9d12b" ]
+            "issues": [ "gh-5504" ]
         }
     }
   }

--- a/test/sql/suite.ini
+++ b/test/sql/suite.ini
@@ -16,16 +16,13 @@ fragile = {
             "issues": [ "gh-4384" ]
         },
         "prepared.test.lua": {
-            "issues": [ "gh-5359" ],
-            "checksums": [ "417a95fc995bbfbf7115bbde5c42028e", "16472636b3dcd186007b89f76912fa12", "7a76ead31624e6e017f1e7b816c00cfe" ]
+            "issues": [ "gh-5359" ]
         },
         "checks.test.lua": {
-            "issues": [ "gh-5477" ],
-            "checksums": [ "0d7ddbb3d34c38745104fbbaf03f8e1f" ]
+            "issues": [ "gh-5477" ]
         },
         "gh2808-inline-unique-persistency-check.test.lua": {
-            "issues": [ "gh-5479" ],
-            "checksums": [ "c1538444c0151b8490c5df386f8d37a2" ]
+            "issues": [ "gh-5479" ]
         }
     }
   }

--- a/test/swim/suite.ini
+++ b/test/swim/suite.ini
@@ -8,8 +8,7 @@ fragile = {
     "retries": 10,
     "tests": {
         "swim.test.lua": {
-            "issues": [ "gh-5403", "gh-5561" ],
-            "checksums": [ "9f1423cf502adfd16611dd5e839b57e4", "a127e3c07b933d5e6602cb14e0f6e728", "867bb2d251a387c53875442f71410e7f" ]
+            "issues": [ "gh-5403", "gh-5561" ]
         }
     }
   }

--- a/test/vinyl/suite.ini
+++ b/test/vinyl/suite.ini
@@ -15,39 +15,31 @@ fragile = {
     "retries": 10,
     "tests": {
         "tx_gap_lock.test.lua": {
-            "issues": [ "gh-4309" ],
-            "checksums": [ "99dbd33845b40f5399a657fe40abe826", "3d2799ef503feb6f6f636b93187d4dee", "d41d8cd98f00b204e9800998ecf8427e", "0fd6dc0786e45067fae536db3520bbd6", "fa6c5df32c6cf6a355f654950a0cbe0d" ]
+            "issues": [ "gh-4309" ]
         },
         "select_consistency.test.lua": {
-            "issues": [ "gh-4385" ],
-            "checksums": [ "ea50883a8a5372d492644efa917650b7" ]
+            "issues": [ "gh-4385" ]
         },
         "throttle.test.lua": {
             "issues": [ "gh-4168" ]
         },
         "errinj_ddl.test.lua": {
-            "issues": [ "gh-4993" ],
-            "checksums": [ "64cc53b41f5a6ee281bce71212741277", "3254a8d1a983fa7c0f166692e078a7cb", "f0c445d28517206a3af2b69ca94e8d25" ]
+            "issues": [ "gh-4993" ]
         },
         "ddl.test.lua": {
-            "issues": [ "gh-5338" ],
-            "checksums": [ "6df64ebe4780edf2c7b46777b809efdc", "c7ad2c6363a3ef0dae9ed02d8ab777c8", "ccd4240f0d72c99fce04479b2881aaff", "202855e6988f29eef792e989672ddbec", "e6f2c5e523ecf105fe88269f7c92a4e5", "202855e6988f29eef792e989672ddbec" ]
+            "issues": [ "gh-5338" ]
         },
         "gh-3395-read-prepared-uncommitted.test.lua": {
-            "issues": [ "gh-5197" ],
-            "checksums": [ "82156b1f64522ca82685c56e4803a3f7", "6ab639ce38b94231c6f0be9a8380d2ff", "af815eb253434134bfc96ded9b501e78", "36dfb19d83fd9c9926294edc4c37a702", "a43c82084a09f98b80ffa6181996705d", "58f9724327a3c990f8caabb835ed6466", "f1f110ce67a7bdc3a42bf7223f067d7b", "49c8a8de85ad4086a5837904ba910df4", "026c7664d0022e3d0f92d918e422ee44", "c2ffda73f76b16d97985dd0edeabaeed", "a83d8875c40c56b263dd6aef3e0f0c9d" ]
+            "issues": [ "gh-5197" ]
         },
         "upsert.test.lua": {
-            "issues": [ "gh-5398" ],
-            "checksums": [ "753255681b39a0f31e4ab4af0d694ec3", "17c147f920425be52060791da1aaff5c", "3c6aeec7448c6bbedd66e9d7dd8cb7b9", "a4145512c15a33b78d2c11b8bf719b33", "5d3dc7d85f9d0d9ccbc1eed5f9f525ae" ]
+            "issues": [ "gh-5398" ]
         },
         "replica_rejoin.test.lua": {
-            "issues": [ "gh-4985" ],
-            "checksums": [ "3d388b75ab402c226c900014fc9c8ef8", "809875027a5221b48fc64a3823b9d667" ]
+            "issues": [ "gh-4985" ]
         },
         "errinj_tx.test.lua": {
-            "issues": [ "gh-5539" ],
-            "checksums": [ "0f9de3eaa09260df452704d431a174b9" ]
+            "issues": [ "gh-5539" ]
         }
     }
   }

--- a/test/wal_off/suite.ini
+++ b/test/wal_off/suite.ini
@@ -13,8 +13,7 @@ fragile = {
             "issues": [ "gh-3925" ]
         },
         "alter.test.lua": {
-            "issues": [ "gh-5504" ],
-            "checksums": [ "d835070c9629348f9046cdea5d27f70a" ]
+            "issues": [ "gh-5504" ]
         }
     }
   }

--- a/test/xlog/suite.ini
+++ b/test/xlog/suite.ini
@@ -13,12 +13,10 @@ fragile = {
     "retries": 10,
     "tests": {
         "checkpoint_daemon.test.lua": {
-            "issues": [ "gh-4952" ],
-            "checksums": [ "7c9571a53f3025f02ab23703939a02d6" ]
+            "issues": [ "gh-4952" ]
         },
         "panic_on_wal_error.test.lua": {
-            "issues": [ "gh-5348" ],
-            "checksums": [ "b874bcc6f69faa2c5654ecc9fe8474de", "7bebfd82b2419c3cf2235f222e835af8" ]
+            "issues": [ "gh-5348" ]
         }
     }
   }


### PR DESCRIPTION
We have recently dropped 'checksum' machinery in test-run
(tarantool/test-run#321) and now there is no need to keep
checksums in suite.ini config files. So removing them.

Closes tarantool/tarantool-qa#152