### PR TITLE
sql: allow LIMIT with different sorting order

### DIFF
--- a/changelogs/unreleased/gh-6664-limit-in-oder-by.md
+++ b/changelogs/unreleased/gh-6664-limit-in-oder-by.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* LIMIT is now allowed in ORDER BY where sort order is in both
+  directions (gh-6664).

--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -1913,25 +1913,6 @@ sqlExprListSetSortOrder(struct ExprList *p, enum sort_order sort_order)
 	p->a[p->nExpr - 1].sort_order = sort_order;
 }
 
-void
-sql_expr_check_sort_orders(struct Parse *parse,
-			   const struct ExprList *expr_list)
-{
-	if(expr_list == NULL)
-		return;
-	enum sort_order reference_order = expr_list->a[0].sort_order;
-	for (int i = 1; i < expr_list->nExpr; i++) {
-		assert(expr_list->a[i].sort_order != SORT_ORDER_UNDEF);
-		if (expr_list->a[i].sort_order != reference_order) {
-			diag_set(ClientError, ER_UNSUPPORTED,
-				 "ORDER BY with LIMIT",
-				 "different sorting orders");
-			parse->is_aborted = true;
-			return;
-		}
-	}
-}
-
 /*
  * Set the ExprList.a[].zName element of the most recently added item
  * on the expression list.

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -548,8 +548,6 @@ oneselect(A) ::= SELECT(S) distinct(D) selcollist(W) from(X) where_opt(Y)
 #ifdef SQL_DEBUG
   Token s = S; /*A-overwrites-S*/
 #endif
-  if (L.pLimit != NULL)
-    sql_expr_check_sort_orders(pParse, Z);
   A = sqlSelectNew(pParse,W,X,Y,P,Q,Z,D,L.pLimit,L.pOffset);
 #ifdef SQL_DEBUG
   /* Populate the Select.zSelName[] string that is used to help with

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2629,24 +2629,6 @@ ExprList *sqlExprListAppendVector(Parse *, ExprList *, IdList *, Expr *);
  */
 void sqlExprListSetSortOrder(ExprList *, enum sort_order sort_order);
 
-/**
- * Check if sorting orders are the same in ORDER BY and raise an
- * error if they are not.
- *
- * This check is needed only for ORDER BY + LIMIT, because
- * currently ORDER BY + LIMIT + ASC + DESC produces incorrectly
- * sorted results and thus forbidden. In future, we will
- * support different sorting orders in
- * ORDER BY + LIMIT (e.g. ORDER BY col1 ASC, col2 DESC LIMIT ...)
- * and remove this check.
- * @param parse Parsing context.
- * @param expr_list Expression list with  ORDER BY clause
- * at the end.
- */
-void
-sql_expr_check_sort_orders(struct Parse *parse,
-			   const struct ExprList *expr_list);
-
 void sqlExprListSetName(Parse *, ExprList *, Token *, int);
 void sqlExprListSetSpan(Parse *, ExprList *, ExprSpan *);
 u32 sqlExprListFlags(const ExprList *);

--- a/test/sql-luatest/gh_6664_allow_limit_in_order_by_test.lua
+++ b/test/sql-luatest/gh_6664_allow_limit_in_order_by_test.lua
@@ -1,0 +1,94 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'limit'})
+    g.server:start()
+    g.server:exec(function()
+        box.execute([[CREATE TABLE t(i INT PRIMARY KEY, A INT, B INT);]])
+        box.execute([[INSERT INTO t VALUES(1, 1, 1), (2, 1, 2);]])
+        box.execute([[INSERT INTO t VALUES(3, 2, 1), (4, 2, 2);]])
+        box.execute([[INSERT INTO t VALUES(5, 3, 1), (6, 3, 2);]])
+    end)
+end)
+
+g.after_all(function()
+    g.server:exec(function()
+        box.execute([[DROP TABLE t;]])
+    end)
+    g.server:stop()
+end)
+
+g.test_limit_1 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT * FROM t ORDER BY a ASC, b DESC LIMIT 3;]]
+        local res = {{2, 1, 2}, {1, 1, 1}, {4, 2, 2}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+g.test_limit_2 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT * FROM t ORDER BY a DESC, b ASC LIMIT 3;]]
+        local res = {{5, 3, 1}, {6, 3, 2}, {3, 2, 1}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+g.test_limit_3 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT * FROM t ORDER BY i DESC, a ASC LIMIT 3;]]
+        local res = {{6, 3, 2}, {5, 3, 1}, {4, 2, 2}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+g.test_limit_4 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT * FROM t ORDER BY a ASC, i DESC, b ASC LIMIT 3;]]
+        local res = {{2, 1, 2}, {1, 1, 1}, {4, 2, 2}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+g.test_limit_5 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT * FROM t ORDER BY a ASC, b DESC LIMIT 3 OFFSET 2;]]
+        local res = {{4, 2, 2}, {3, 2, 1}, {6, 3, 2}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+g.test_limit_6 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT * FROM t ORDER BY a DESC, b ASC LIMIT 3 OFFSET 3;]]
+        local res = {{4, 2, 2}, {1, 1, 1}, {2, 1, 2}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+g.test_limit_7 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT * FROM t ORDER BY i DESC, a ASC LIMIT 3 OFFSET 4;]]
+        local res = {{2, 1, 2}, {1, 1, 1}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+g.test_limit_8 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql =
+            [[SELECT * FROM t ORDER BY a ASC, i DESC, b ASC LIMIT 3 OFFSET 7;]]
+        local res = {}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end

--- a/test/sql-luatest/suite.ini
+++ b/test/sql-luatest/suite.ini
@@ -1,0 +1,3 @@
+[default]
+core = luatest
+description = SQL tests on luatest

--- a/test/sql-tap/orderby8.test.lua
+++ b/test/sql-tap/orderby8.test.lua
@@ -55,22 +55,22 @@ end
 -- It will be fixed when multi-directional would be introduced:
 -- https://github.com/tarantool/tarantool/issues/3309
 
-test:do_catchsql_test(
+test:do_execsql_test(
     "1.201",
     [[
         CREATE TABLE t2 (id INT PRIMARY KEY, a INT, b INT);
         INSERT INTO t2 VALUES (1, 2, 1), (2, -3, 5), (3, 2, -3), (4, 2, 12);
         SELECT * FROM t2 ORDER BY a ASC, b DESC LIMIT 5;
     ]],
-    {1, "ORDER BY with LIMIT does not support different sorting orders"}
+    {2, -3, 5, 4, 2, 12, 1, 2, 1, 3, 2, -3}
 )
 
-test:do_catchsql_test(
+test:do_execsql_test(
     "1.202",
     [[
         SELECT * FROM t2 ORDER BY a, b DESC LIMIT 5;
     ]],
-    {1, "ORDER BY with LIMIT does not support different sorting orders"}
+    {2, -3, 5, 4, 2, 12, 1, 2, 1, 3, 2, -3}
 
 )
 


### PR DESCRIPTION
This patch allows LIMIT to be used with a different sort order in
ORDER BY. This is a temporary solution and should be changed after
issue #3309 is fixed.

Closes #6664