### PR TITLE
tap: inherit strict mode in subtests

### DIFF
--- a/changelogs/unreleased/inherit-strict-mode-for-tap-subtests.md
+++ b/changelogs/unreleased/inherit-strict-mode-for-tap-subtests.md
@@ -1,0 +1,3 @@
+## bugfix/lua
+
+* Tap subtests inherit strict mode from parent (gh-6868).

--- a/src/lua/tap.lua
+++ b/src/lua/tap.lua
@@ -225,7 +225,7 @@ local function test(parent, name, fun, ...)
         failed  = 0;
         planned = 0;
         trace   = parent == nil and true or parent.trace;
-        strict = false;
+        strict = parent ~= nil and parent.strict or false;
     }, test_mt)
     if fun ~= nil then
         test:diag('%s', test.name)

--- a/test/app-tap/tap.result
+++ b/test/app-tap/tap.result
@@ -137,7 +137,7 @@ not ok - failed subtests
   failed: 1
   ...
     # is_deeply
-    1..20
+    1..21
     ok - 1 and 1
     ok - abc and abc
     ok - empty tables
@@ -203,11 +203,31 @@ not ok - failed subtests
       strict: true
       ...
     ok - {a = box.NULL} and {a = box.NULL} strict true
+        # check strict flag inheritance
+        1..2
+        not ok - {} and {a = box.NULL} strict = true
+          ---
+          strict: true
+          expected: key a
+          got: nil
+          ...
+        not ok - nil and box.NULL strict = true
+          ---
+          got: nil
+          expected: cdata
+          strict: true
+          ...
+        # check strict flag inheritance: end
+    not ok - failed subtests
+      ---
+      planned: 2
+      failed: 2
+      ...
     # is_deeply: end
 not ok - failed subtests
   ---
-  planned: 20
-  failed: 8
+  planned: 21
+  failed: 9
   ...
     # like
     1..2

--- a/test/app-tap/tap.test.lua
+++ b/test/app-tap/tap.test.lua
@@ -131,7 +131,7 @@ end)
 
 
 test:test('is_deeply', function(t)
-    t:plan(20)
+    t:plan(21)
 
     t:is_deeply(1, 1, '1 and 1')
     t:is_deeply('abc', 'abc', 'abc and abc')
@@ -165,6 +165,13 @@ test:test('is_deeply', function(t)
     t:is_deeply(box.NULL, nil, 'box.NULL and nil strict = true')
     t:is_deeply({a = box.NULL}, {a = box.NULL},
                 '{a = box.NULL} and {a = box.NULL} strict true')
+
+    t:test('check strict flag inheritance', function(t)
+        t:plan(2)
+        t:is_deeply({}, {a = box.NULL}, '{} and {a = box.NULL} strict = true')
+        t:is_deeply(nil, box.NULL, 'nil and box.NULL strict = true')
+    end)
+
     t.strict = false
 end)
 


### PR DESCRIPTION
Previous behaviour was quite illogical and unexpected. If user
once defined strict mode at start of tests it's expected that all
subtests also will have strict mode. However before this patch it
wasn't so. And wasn't clear at start why enabled strict mode
didn't work.
After this patch subtests strict mode will be the same as for
parent. This behaviour wasn't tested anyhow and wasn't documented.

Follow-up #4125

@TarantoolBot document
Title: clarify 'strict' behaviour in tap tests
Defined for root tap object strict mode will be the same for all
subtests.

Example:
```lua
t = require('tap').test('123')
t.strict = true

t:is_deeply({a = box.NULL}, {}) -- false

t:test('subtest', function(t)
    t:is_deeply({a = box.NULL}, {}) -- also false
end)
```