### PR TITLE
lua: fix table.equals result when booleans compared

### DIFF
--- a/changelogs/unreleased/gh-6386-fix-table-equals-for-booleans.md
+++ b/changelogs/unreleased/gh-6386-fix-table-equals-for-booleans.md
@@ -1,0 +1,3 @@
+## bugfix/lua
+
+* Fixed ``table.equals`` result when booleans compared (gh-6386).

--- a/src/lua/table.lua
+++ b/src/lua/table.lua
@@ -78,7 +78,7 @@ local function table_equals(a, b)
         end
     end
     for k, _ in pairs(b) do
-        if not a[k] then
+        if type(a[k]) == 'nil' then
             return false
         end
     end

--- a/test/app-tap/table.test.lua
+++ b/test/app-tap/table.test.lua
@@ -8,7 +8,7 @@ yaml.cfg{
     encode_invalid_as_nil  = true,
 }
 local test = require('tap').test('table')
-test:plan(44)
+test:plan(49)
 
 do -- check basic table.copy (deepcopy)
     local example_table = {
@@ -268,6 +268,19 @@ do -- check table.equals
     local tbl_f = setmetatable({a = 15}, {__eq = function() return true end})
     test:is(table.equals(tbl_d, tbl_f), false,
             "table.equals when metatables don't match")
+end
+
+do -- check table.equals with booleans (gh-6386)
+    test:is(table.equals({a = false}, {a = false}), true,
+            "table.equals when booleans are used")
+    test:is(table.equals({a = false}, {}), false,
+            "table.equals when booleans are used")
+    test:is(table.equals({}, {a = false}), false,
+            "table.equals when booleans are used")
+    test:is(table.equals({a = box.NULL}, {a = false}), false,
+            "table.equals when booleans are used")
+    test:is(table.equals({a = false}, {a = box.NULL}), false,
+            "table.equals when booleans are used")
 end
 
 os.exit(test:check() == true and 0 or 1)


### PR DESCRIPTION
Before this patch comparison of two `false` values produced
incorrect result. That because nil and false are consieded in the
same way by if operator. This patch fixes an issue and introduces
corresponding tests.

Closes #6386