### PR TITLE
Show linking type in tarantool.build.linking

### DIFF
--- a/changelogs/unreleased/show-linking-in-tarantool-info.md
+++ b/changelogs/unreleased/show-linking-in-tarantool-info.md
@@ -1,0 +1,3 @@
+## feature/core
+
+* Added linking type (dynamic or static) to tarantool build info.

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -656,6 +656,15 @@ luaopen_tarantool(lua_State *L)
 	lua_pushstring(L, TARANTOOL_C_FLAGS);
 	lua_settable(L, -3);
 
+	/* build.linking */
+	lua_pushstring(L, "linking");
+#if defined(BUILD_STATIC)
+	lua_pushstring(L, "static");
+#else
+	lua_pushstring(L, "dynamic");
+#endif
+	lua_settable(L, -3);
+
 	lua_settable(L, -3);    /* box.info.build */
 	return 1;
 }

--- a/src/trivia/config.h.cmake
+++ b/src/trivia/config.h.cmake
@@ -262,6 +262,7 @@
 
 #cmakedefine EXPORT_LIBCURL_SYMBOLS 1
 
+#cmakedefine BUILD_STATIC 1
 #cmakedefine EMBED_LUAZLIB 1
 #cmakedefine EMBED_LUAZIP 1
 #cmakedefine EMBED_LUAROCKS 1

--- a/test/app-tap/info.test.lua
+++ b/test/app-tap/info.test.lua
@@ -3,7 +3,7 @@
 local tarantool = require('tarantool')
 
 require('tap').test("info", function(test)
-    test:plan(9)
+    test:plan(10)
     test:like(tarantool.version, '^[1-9]', "version")
     test:isstring(tarantool.package, "package")
     test:ok(_TARANTOOL == tarantool.version, "version")
@@ -11,6 +11,9 @@ require('tap').test("info", function(test)
     test:isstring(tarantool.build.compiler, "build.compiler")
     test:isstring(tarantool.build.flags, "build.flags")
     test:isstring(tarantool.build.options, "build.options")
+    test:ok(tarantool.build.linking == 'static' or
+            tarantool.build.linking == 'dynamic',
+            "build.linking")
     test:ok(tarantool.uptime() > 0, "uptime")
     test:ok(tarantool.pid() > 0, "pid")
 end)


### PR DESCRIPTION
```
tarantool> require('tarantool').build.linking
---
- dynamic
...
```

Useful to run some tests only on static build.