### PR TITLE
Move OpenSSL initialization to lib/core/ssl

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ include_directories(${CURL_INCLUDE_DIRS})
 include_directories(${ICU_INCLUDE_DIRS})
 include_directories(${ICONV_INCLUDE_DIRS})
 include_directories(${DECNUMBER_INCLUDE_DIR})
+include_directories(${EXTRA_CORE_INCLUDE_DIRS})
 
 set(LIBUTIL_FREEBSD_SRC ${PROJECT_SOURCE_DIR}/third_party/libutil_freebsd)
 include_directories(${LIBUTIL_FREEBSD_SRC})

--- a/src/lib/core/CMakeLists.txt
+++ b/src/lib/core/CMakeLists.txt
@@ -62,7 +62,8 @@ target_link_libraries(core salad small uri decNumber bit tzcode
                       ${LIBEV_LIBRARIES}
                       ${LIBEIO_LIBRARIES} ${LIBCORO_LIBRARIES}
                       ${MSGPUCK_LIBRARIES} ${ICU_LIBRARIES}
-                      ${LIBCDT_LIBRARIES})
+                      ${LIBCDT_LIBRARIES} ${OPENSSL_LIBRARIES}
+                      ${EXTRA_CORE_LINK_LIBRARIES})
 
 if (ENABLE_BACKTRACE AND NOT TARGET_OS_DARWIN)
     target_link_libraries(core gcc_s ${UNWIND_LIBRARIES})
@@ -74,8 +75,4 @@ endif()
 # HAVE_CLOCK_GETTIME_WITHOUT_RT in ${REPO}/CMakeLists.txt.
 if ("${HAVE_CLOCK_GETTIME}" AND NOT "${HAVE_CLOCK_GETTIME_WITHOUT_RT}")
     target_link_libraries(core rt)
-endif()
-
-if(ENABLE_SSL)
-    target_link_libraries(core ${OPENSSL_LIBRARIES})
 endif()

--- a/src/lib/core/ssl.c
+++ b/src/lib/core/ssl.c
@@ -5,6 +5,10 @@
  */
 #include "ssl.h"
 
+#include <openssl/crypto.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/ssl.h>
 #include <stddef.h>
 
 #include "diag.h"
@@ -14,6 +18,27 @@
 #if defined(ENABLE_SSL)
 # error unimplemented
 #endif
+
+void
+ssl_init(void)
+{
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+	OpenSSL_add_all_digests();
+	OpenSSL_add_all_ciphers();
+	ERR_load_crypto_strings();
+#else
+	OPENSSL_init_crypto(0, NULL);
+	OPENSSL_init_ssl(0, NULL);
+#endif
+}
+
+void
+ssl_free(void)
+{
+#ifdef OPENSSL_cleanup
+	OPENSSL_cleanup();
+#endif
+}
 
 struct ssl_iostream_ctx *
 ssl_iostream_ctx_new(enum iostream_mode mode, const struct uri *uri)

--- a/src/lib/core/ssl.h
+++ b/src/lib/core/ssl.h
@@ -21,6 +21,12 @@ extern "C" {
 struct uri;
 struct ssl_iostream_ctx;
 
+void
+ssl_init(void);
+
+void
+ssl_free(void);
+
 struct ssl_iostream_ctx *
 ssl_iostream_ctx_new(enum iostream_mode mode, const struct uri *uri);
 

--- a/src/lib/crypto/crypto.c
+++ b/src/lib/crypto/crypto.c
@@ -323,27 +323,6 @@ crypto_codec_delete(struct crypto_codec *c)
 	free(c);
 }
 
-void
-crypto_init(void)
-{
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-	OpenSSL_add_all_digests();
-	OpenSSL_add_all_ciphers();
-	ERR_load_crypto_strings();
-#else
-	OPENSSL_init_crypto(0, NULL);
-	OPENSSL_init_ssl(0, NULL);
-#endif
-}
-
-void
-crypto_free(void)
-{
-#ifdef OPENSSL_cleanup
-	OPENSSL_cleanup();
-#endif
-}
-
 EVP_MD_CTX *
 crypto_EVP_MD_CTX_new(void)
 {

--- a/src/lib/crypto/crypto.h
+++ b/src/lib/crypto/crypto.h
@@ -271,12 +271,6 @@ crypto_codec_decrypt(struct crypto_codec *c, const char *iv,
 void
 crypto_codec_delete(struct crypto_codec *c);
 
-void
-crypto_init(void);
-
-void
-crypto_free(void);
-
 #if defined(__cplusplus)
 }
 #endif

--- a/src/main.cc
+++ b/src/main.cc
@@ -79,7 +79,7 @@
 #include "box/module_cache.h"
 #include "box/watcher.h"
 #include "systemd.h"
-#include "crypto/crypto.h"
+#include "core/ssl.h"
 #include "core/popen.h"
 #include "core/crash.h"
 #include "ssl_cert_paths_discover.h"
@@ -547,7 +547,7 @@ tarantool_free(void)
 	memory_free();
 	random_free();
 #endif
-	crypto_free();
+	ssl_free();
 	memtx_tx_manager_free();
 	coll_free();
 	systemd_free();
@@ -704,7 +704,7 @@ main(int argc, char **argv)
 	coll_init();
 	memtx_tx_manager_init();
 	module_init();
-	crypto_init();
+	ssl_init();
 	systemd_init();
 
 	const int override_cert_paths_env_vars = 0;

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -15,6 +15,7 @@ include_directories(${PROJECT_SOURCE_DIR}/src/box)
 include_directories(${PROJECT_SOURCE_DIR}/third_party)
 include_directories(${ICU_INCLUDE_DIRS})
 include_directories(${CURL_INCLUDE_DIRS})
+include_directories(${EXTRA_CORE_INCLUDE_DIRS})
 
 add_library(unit STATIC unit.c)
 

--- a/test/unit/crypto.c
+++ b/test/unit/crypto.c
@@ -29,6 +29,7 @@
  * SUCH DAMAGE.
  */
 #include "crypto/crypto.h"
+#include "core/ssl.h"
 #include "core/random.h"
 #include "unit.h"
 #include "trivia/util.h"
@@ -286,7 +287,7 @@ main(void)
 	header();
 	plan(5);
 	random_init();
-	crypto_init();
+	ssl_init();
 	memory_init();
 	fiber_init(fiber_c_invoke);
 
@@ -300,7 +301,7 @@ main(void)
 
 	fiber_free();
 	memory_free();
-	crypto_free();
+	ssl_free();
 	random_free();
 	int rc = check_plan();
 	footer();


### PR DESCRIPTION
Currently, the library is initialized in lib/crypto. Let's move it to lib/core/ssl, because:
 - lib/crypto links lib/core/ssl so it looks more logical to have OpenSSL initialized in the core lib.
 - We need to extend the OpenSSL initialization code in the EE build, which doesn't affect lib/crypto, but replaces lib/core/ssl.

While we are at it, let's also allow the EE build to link extra libraries to lib/core by setting `EXTRA_CORE_LINK_LIBRARIES`.

Needed for https://github.com/tarantool/tarantool-ee/issues/40