### PR TITLE
vinyl: fix crash during secondary index recovery

### DIFF
--- a/changelogs/unreleased/gh-6778-vinyl-recovery-crash.md
+++ b/changelogs/unreleased/gh-6778-vinyl-recovery-crash.md
@@ -1,0 +1,4 @@
+## bugfix/vinyl
+
+* Fixed crash during recovery of a secondary index in case the primary index
+  contains incompatible phantom tuples (gh-6778).

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -4101,6 +4101,7 @@ err:
 static int
 vy_build_recover_mem(struct vy_lsm *lsm, struct vy_lsm *pk, struct vy_mem *mem)
 {
+	assert(lsm->dump_lsn >= 0);
 	/*
 	 * Recover statements starting from the oldest one.
 	 * Key order doesn't matter so we simply iterate over
@@ -4131,6 +4132,18 @@ vy_build_recover_mem(struct vy_lsm *lsm, struct vy_lsm *pk, struct vy_mem *mem)
 static int
 vy_build_recover(struct vy_env *env, struct vy_lsm *lsm, struct vy_lsm *pk)
 {
+	if (lsm->dump_lsn < 0) {
+		/*
+		 * The new index was never dumped, because the space's empty
+		 * so there's nothing to do.
+		 *
+		 * Note: the primary index may still have some cancelling
+		 * each other statements; we shouldn't try to apply them,
+		 * because they may be incompatible with the new index.
+		 */
+		return 0;
+	}
+
 	int rc = 0;
 	struct vy_mem *mem;
 	size_t mem_used_before, mem_used_after;

--- a/test/vinyl-luatest/gh_6778_recovery_crash_test.lua
+++ b/test/vinyl-luatest/gh_6778_recovery_crash_test.lua
@@ -1,0 +1,33 @@
+local common = require('test.vinyl-luatest.common')
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_test('test_recovery_crash', function()
+    g.server = server:new({
+        alias = 'master',
+        box_cfg = common.default_box_cfg(),
+    })
+    g.server:start()
+end)
+
+g.after_test('test_recovery_crash', function()
+    g.server:drop()
+end)
+
+g.test_recovery_crash = function()
+    g.server:exec(function()
+        local s = box.schema.create_space('test', {engine = 'vinyl'})
+        s:create_index('pk')
+        s:replace{0}
+        s:delete{0}
+        s:create_index('sk', {parts = {{2, 'unsigned'}}})
+    end)
+    g.server:restart()
+    g.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.test
+        t.assert_equals(s.index.pk:select(), {})
+        t.assert_equals(s.index.sk:select(), {})
+    end)
+end


### PR DESCRIPTION
A secondary index creation proceeds as follows:
 1. Build the new index by inserting statements from the primary index, see `vinyl_space_build_index()`.
 2. Dump the new index and wait for the dump to complete.
 3. Commit the index creation record to the WAL.

While the new index is being dumped at step 2, new statements may be inserted into the space. We need to insert those statements during recovery, see `vy_build_recover()`. We identify such statements by comparing LSN to `vy_lsm::dump_lsn`, see `vy_build_recover_stmt()`.

It might occur that the newly built index is empty while the primary index memory level isn't - if all statements cancel each other. In this case, the secondary index won't be dumped during creation and its `dump_lsn` will be set to -1, see the `vy_lsm_is_empty()` check in `vinyl_space_build_index()`. This would break the assumption made on recovery: that all statements with LSN > `vy_lsm::dump_lsn` should be inserted into the secondary index. If a statement like this isn't compatible with the new index, we will get a crash trying to insert it.

Let's fix this issue by skipping `vy_build_recover()` in case the new secondary index was never dumped.

Closes #6778