### PR TITLE
libunwind: add new submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -56,3 +56,7 @@
 [submodule "third_party/nghttp2"]
 	path = third_party/nghttp2
 	url = https://github.com/tarantool/nghttp2.git
+[submodule "third_party/libunwind"]
+	path = third_party/libunwind
+	url = https://github.com/tarantool/libunwind.git
+	branch = libunwind-1.6.2-tarantool

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -599,6 +599,47 @@ include(BuildMisc)
 libmisc_build()
 add_dependencies(build_bundled_libs misc)
 
+#
+# libunwind
+#
+
+if(ENABLE_BACKTRACE)
+    if(NOT HAVE_FORCE_ALIGN_ARG_POINTER_ATTR)
+        message(SEND_ERROR "backtrace feature requires \
+                            `force_align_arg_pointer` function attribute \
+                            support from C/C++ compiler")
+    endif()
+
+    if(NOT HAVE_CFI_ASM)
+        message(SEND_ERROR "backtrace feature requires CFI assembly support \
+                            from C/C++ compiler")
+    endif()
+
+    if(ENABLE_BUNDLED_LIBUNWIND)
+        if(APPLE)
+            message(SEND_ERROR "libunwind does not support macOS")
+        endif()
+        if(NOT HAVE_STDATOMIC_H)
+            message(SEND_ERROR "building bundled libunwind requires stdatomic.h \
+                                support from C compiler")
+        endif()
+
+        include(BuildLibUnwind)
+        libunwind_build()
+        add_dependencies(build_bundled_libs
+                         bundled-libunwind
+                         bundled-libunwind-platform)
+    else()
+        find_package(LibUnwind MODULE REQUIRED)
+    endif()
+    if(NOT APPLE AND NOT ENABLE_BUNDLED_LIBUNWIND AND
+        LIBUNWIND_VERSION VERSION_LESS "1.3" AND
+        ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
+        message(SEND_ERROR "versions of libunwind earlier than 1.3.0 are \
+                            broken on AARCH64 architecture")
+    endif()
+endif()
+
 # cpack config. called package.cmake to avoid
 # conflicts with the global CPack.cmake (On MacOS X
 # file names are case-insensitive)
@@ -690,7 +731,8 @@ set(options PACKAGE VERSION BUILD C_COMPILER CXX_COMPILER C_FLAGS CXX_FLAGS
     ENABLE_DIST
     ENABLE_BUNDLED_LIBCURL
     ENABLE_BUNDLED_LIBYAML
-    ENABLE_BUNDLED_MSGPUCK)
+    ENABLE_BUNDLED_MSGPUCK
+    ENABLE_BUNDLED_LIBUNWIND)
 foreach(option IN LISTS options)
     if (NOT DEFINED ${option})
         set(value "${TARANTOOL_${option}}")

--- a/changelogs/unreleased/add-libunwind-submodule.md
+++ b/changelogs/unreleased/add-libunwind-submodule.md
@@ -1,0 +1,8 @@
+## feature/build
+
+* Added bundling of _GNU libunwind_ to support backtrace feature on
+  _AARCH64_ architecture and distributives that don't provide _libunwind_
+  package.
+* Re-enabled backtrace feature for all _RHEL_ distributions by default, except
+  for _AARCH64_ architecture and ancient _GCC_ versions, which lack compiler
+  features required for backtrace (gh-4611).

--- a/cmake/BuildLibUnwind.cmake
+++ b/cmake/BuildLibUnwind.cmake
@@ -1,0 +1,98 @@
+#[========================================================================[.rst:
+libunwind_build
+--------
+Builds the libunwind library.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+``LIBUNWIND_INCLUDE_DIR``
+  Include directory needed to use libunwind.
+``LIBUNWIND_LIBRARIES``
+  Libraries needed to link to libunwind.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+``LIBUNWIND_INCLUDE_DIR``
+  The directory containing ``libunwind.h``.
+``LIBUNWIND_LIBRARIES``
+  The paths to the libunwind libraries.
+#]========================================================================]
+
+macro(libunwind_build)
+    set(LIBUNWIND_SOURCE_DIR ${PROJECT_SOURCE_DIR}/third_party/libunwind)
+    set(LIBUNWIND_BUILD_DIR ${PROJECT_BINARY_DIR}/build/libunwind)
+    set(LIBUNWIND_BINARY_DIR ${LIBUNWIND_BUILD_DIR}/work)
+    set(LIBUNWIND_INSTALL_DIR ${LIBUNWIND_BUILD_DIR}/dest)
+
+    include(ExternalProject)
+    ExternalProject_Add(bundled-libunwind-project
+                        TMP_DIR ${LIBUNWIND_BUILD_DIR}/tmp
+                        STAMP_DIR ${LIBUNWIND_BUILD_DIR}/stamp
+                        SOURCE_DIR ${LIBUNWIND_SOURCE_DIR}
+                        BINARY_DIR ${LIBUNWIND_BINARY_DIR}
+                        INSTALL_DIR ${LIBUNWIND_INSTALL_DIR}
+
+                        DOWNLOAD_COMMAND ""
+
+                        CONFIGURE_COMMAND
+                        <SOURCE_DIR>/configure
+                        CC=${CMAKE_C_COMPILER}
+                        CXX=${CMAKE_CXX_COMPILER}
+                        --prefix=<INSTALL_DIR>
+                        # Bundled libraries are linked statically.
+                        --disable-shared
+                        # Ditto.
+                        --enable-static
+                        # See https://github.com/libunwind/libunwind/blob/e07b43c02d5cf1ea060c018fdf2e2ad34b7c7d80/configure.ac#L122-L125.
+                        --disable-coredump
+                        # See https://github.com/libunwind/libunwind/blob/e07b43c02d5cf1ea060c018fdf2e2ad34b7c7d80/configure.ac#L130-L133.
+                        --disable-ptrace
+                        # See https://github.com/libunwind/libunwind/blob/e07b43c02d5cf1ea060c018fdf2e2ad34b7c7d80/configure.ac#L138-L141.
+                        --disable-setjmp
+                        # See https://github.com/libunwind/libunwind/blob/e07b43c02d5cf1ea060c018fdf2e2ad34b7c7d80/configure.ac#L143-L145
+                        --disable-documentation
+                        # See https://github.com/libunwind/libunwind/blob/e07b43c02d5cf1ea060c018fdf2e2ad34b7c7d80/configure.ac#L147-L149
+                        --disable-tests
+                        # By default libunwind provides a weak alias to
+                        # `backtrace` function: this can lead to a conflict with
+                        # glibc's `backtrace`, see https://github.com/libunwind/libunwind/blob/e07b43c02d5cf1ea060c018fdf2e2ad34b7c7d80/configure.ac#L151-L153
+                        --disable-weak-backtrace
+                        # See https://github.com/libunwind/libunwind/blob/e07b43c02d5cf1ea060c018fdf2e2ad34b7c7d80/configure.ac#L155-L157
+                        --disable-unwind-header
+                        # See https://github.com/libunwind/libunwind/blob/e07b43c02d5cf1ea060c018fdf2e2ad34b7c7d80/configure.ac#L302-L317
+                        --disable-minidebuginfo
+                        # See https://github.com/libunwind/libunwind/blob/e07b43c02d5cf1ea060c018fdf2e2ad34b7c7d80/configure.ac#L319-L334
+                        --disable-zlibdebuginfo
+
+                        LOG_CONFIGURE TRUE
+                        LOG_BUILD TRUE
+                        LOG_INSTALL TRUE
+                        LOG_MERGED_STDOUTERR TRUE
+                        LOG_OUTPUT_ON_FAILURE TRUE
+
+                        EXCLUDE_FROM_ALL)
+
+    add_library(bundled-libunwind STATIC IMPORTED GLOBAL)
+    set_target_properties(bundled-libunwind PROPERTIES
+                          IMPORTED_LOCATION
+                          ${LIBUNWIND_INSTALL_DIR}/lib/libunwind.a)
+    add_dependencies(bundled-libunwind bundled-libunwind-project)
+
+    add_library(bundled-libunwind-platform STATIC IMPORTED GLOBAL)
+    set_target_properties(bundled-libunwind-platform PROPERTIES
+                          IMPORTED_LOCATION
+                          ${LIBUNWIND_INSTALL_DIR}/lib/libunwind-${CMAKE_SYSTEM_PROCESSOR}.a)
+    add_dependencies(bundled-libunwind-platform bundled-libunwind-project)
+
+    set(LIBUNWIND_INCLUDE_DIR ${LIBUNWIND_INSTALL_DIR}/include)
+    set(LIBUNWIND_LIBRARIES
+        ${LIBUNWIND_INSTALL_DIR}/lib/libunwind-${CMAKE_SYSTEM_PROCESSOR}.a
+        ${LIBUNWIND_INSTALL_DIR}/lib/libunwind.a)
+
+    message(STATUS "Using bundled libunwind")
+
+    unset(LIBUNWIND_SOURCE_DIR)
+    unset(LIBUNWIND_BUILD_DIR)
+    unset(LIBUNWIND_BINARY_DIR)
+    unset(LIBUNWIND_INSTALL_DIR)
+endmacro()

--- a/cmake/FindLibUnwind.cmake
+++ b/cmake/FindLibUnwind.cmake
@@ -1,0 +1,86 @@
+#[========================================================================[.rst:
+FindLibUnwind
+--------
+Finds the libunwind library.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+``LIBUNWIND_FOUND``
+  True if the system has the libunwind library.
+``LIBUNWIND_VERSION``
+  The version of the libunwind library which was found.
+``LIBUNWIND_INCLUDE_DIR``
+  Include directory needed to use libunwind.
+``LIBUNWIND_LIBRARIES``
+  Libraries needed to link to libunwind.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+``LIBUNWIND_INCLUDE_DIR``
+  The directory containing ``libunwind.h``.
+``LIBUNWIND_LIBRARIES``
+  The paths to the libunwind libraries.
+#]========================================================================]
+
+include(FindPackageHandleStandardArgs)
+include(GetLibUnwindVersion)
+
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_LIBUNWIND QUIET libunwind)
+
+find_path(LIBUNWIND_INCLUDE_DIR libunwind.h ${PC_LIBUNWIND_INCLUDE_DIRS})
+if(LIBUNWIND_INCLUDE_DIR)
+    include_directories(${LIBUNWIND_INCLUDE_DIR})
+endif()
+
+if(BUILD_STATIC AND NOT APPLE)
+    set(LIBUNWIND_LIBRARY_NAME libunwind.a)
+else()
+    # Only a dynamic version of libunwind is available on macOS: also, we
+    # should link against the umbrella framework `System` — otherwise `ld` will
+    # complain that it cannot link directly with libunwind.tbd.
+    set(LIBUNWIND_LIBRARY_NAME System unwind)
+endif()
+find_library(LIBUNWIND_LIBRARY NAMES ${LIBUNWIND_LIBRARY_NAME}
+             PATHS ${PC_LIBUNWIND_LIBRARY_DIRS})
+
+if(APPLE)
+    set(LIBUNWIND_LIBRARIES ${LIBUNWIND_LIBRARY})
+else()
+    if(BUILD_STATIC)
+        set(LIBUNWIND_PLATFORM_LIBRARY_NAME
+            "libunwind-${CMAKE_SYSTEM_PROCESSOR}.a")
+    else()
+        set(LIBUNWIND_PLATFORM_LIBRARY_NAME
+            "unwind-${CMAKE_SYSTEM_PROCESSOR}")
+    endif()
+    find_library(LIBUNWIND_PLATFORM_LIBRARY ${LIBUNWIND_PLATFORM_LIBRARY_NAME}
+                 ${PC_LIBUNWIND_LIBRARY_DIRS})
+    set(LIBUNWIND_LIBRARIES ${LIBUNWIND_LIBRARY} ${LIBUNWIND_PLATFORM_LIBRARY})
+endif()
+
+if(BUILD_STATIC)
+    # libunwind could have been built with liblzma dependency:
+    # https://github.com/libunwind/libunwind/blob/4feb1152d1c4aaafbb2d504dbe34c6db5b6fe9f2/configure.ac#L302-L317
+    pkg_check_modules(PC_LIBLZMA QUIET liblzma)
+    find_library(LIBLZMA_LIBRARY liblzma.a ${PC_LIBLZMA_LIBRARY_DIRS})
+    if(NOT LIBLZMA_LIBRARY STREQUAL "LIBLZMA_LIBRARY-NOTFOUND")
+        message(STATUS "liblzma found")
+        set(LIBUNWIND_LIBRARIES ${LIBUNWIND_LIBRARIES} ${LIBLZMA_LIBRARY})
+    endif()
+    # Ditto,
+    # https://github.com/libunwind/libunwind/blob/4feb1152d1c4aaafbb2d504dbe34c6db5b6fe9f2/configure.ac#L319-L334
+    set(LIBUNWIND_LIBRARIES ${LIBUNWIND_LIBRARIES} ZLIB::ZLIB)
+endif()
+
+if(PC_LIBUNWIND_VERSION)
+    set(LIBUNWIND_VERSION ${PC_LIBUNWIND_VERSION})
+else()
+    GetLibUnwindVersion(LIBUNWIND_VERSION)
+endif()
+
+find_package_handle_standard_args(GetLIBUNWINDVersion.cmake
+      VERSION_VAR LIBUNWIND_VERSION
+      REQUIRED_VARS LIBUNWIND_INCLUDE_DIR LIBUNWIND_LIBRARIES)
+
+mark_as_advanced(LIBUNWIND_INCLUDE_DIR LIBUNWIND_LIBRARIES)

--- a/cmake/GetLibUnwindVersion.cmake
+++ b/cmake/GetLibUnwindVersion.cmake
@@ -1,0 +1,12 @@
+function(GetLibUnwindVersion _LIBUNWIND_VERSION)
+    set(_LIBUNWIND_VERSION_HEADER "${LIBUNWIND_INCLUDE_DIR}/libunwind-common.h")
+    if(LIBUNWIND_LIBRARY AND EXISTS ${_LIBUNWIND_VERSION_HEADER})
+        file(READ ${_LIBUNWIND_VERSION_HEADER}
+             _LIBUNWIND_VERSION_HEADER_CONTENTS)
+        string(REGEX MATCH
+               "#define UNW_VERSION_MAJOR[ \t]+([0-9]+)\n#define UNW_VERSION_MINOR[ \t]+([0-9]+)"
+               _VERSION_REGEX "${_LIBUNWIND_VERSION_HEADER_CONTENTS}")
+        set(${_LIBUNWIND_VERSION} "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}"
+            PARENT_SCOPE)
+    endif()
+endfunction()

--- a/rpm/tarantool.spec
+++ b/rpm/tarantool.spec
@@ -57,18 +57,22 @@ Requires(preun): chkconfig
 Requires(preun): initscripts
 %endif
 
-%if 0%{?rhel} >= 8
-# gh-4611: Disable backtraces on CentOS 8 by default due to lack
-# of libunwind package in the base system.
+# Enable backtraces everywhere, except AARCH64 and ancient GCC versions, which
+# lack compiler features required for backtrace.
+%define __cc "%{getenv:CC}"
+%if %{__cc} == ""
+%define __cc "cc"
+%endif
+%if "%(printf '%%s\n' "5.3.0" "$(%{__cc} -dumpfullversion -dumpversion)" | sort -V | head -n1)" != "5.3.0"
 %bcond_with backtrace
 %else
-# Enable backtraces everywhere except arm64.
 %ifnarch aarch64
 %bcond_without backtrace
 %else
 %bcond_with backtrace
 %endif
 %endif
+%undefine __cc
 
 # openSuSE sets its own build directory in its macros, but we
 # want to use in-source build there to simplify the RPM spec.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ include_directories(${ICU_INCLUDE_DIRS})
 include_directories(${ICONV_INCLUDE_DIRS})
 include_directories(${DECNUMBER_INCLUDE_DIR})
 include_directories(${EXTRA_CORE_INCLUDE_DIRS})
+include_directories(SYSTEM ${LIBUNWIND_INCLUDE_DIR})
 
 set(LIBUTIL_FREEBSD_SRC ${PROJECT_SOURCE_DIR}/third_party/libutil_freebsd)
 include_directories(${LIBUTIL_FREEBSD_SRC})

--- a/src/lib/core/CMakeLists.txt
+++ b/src/lib/core/CMakeLists.txt
@@ -68,8 +68,11 @@ target_link_libraries(core salad small uri decNumber bit tzcode
                       ${LIBCDT_LIBRARIES} ${OPENSSL_LIBRARIES}
                       ${EXTRA_CORE_LINK_LIBRARIES})
 
-if (ENABLE_BACKTRACE AND NOT TARGET_OS_DARWIN)
-    target_link_libraries(core gcc_s ${UNWIND_LIBRARIES})
+if (ENABLE_BACKTRACE)
+    target_link_libraries(core ${LIBUNWIND_LIBRARIES})
+    if(ENABLE_BUNDLED_LIBUNWIND)
+        add_dependencies(core bundled-libunwind bundled-libunwind-platform)
+    endif()
 endif()
 
 if (ENABLE_TUPLE_COMPRESSION)

--- a/static-build/CMakeLists.txt
+++ b/static-build/CMakeLists.txt
@@ -20,8 +20,6 @@ set(NCURSES_VERSION 6.2)
 set(NCURSES_HASH e812da327b1c2214ac1aed440ea3ae8d)
 set(READLINE_VERSION 8.0)
 set(READLINE_HASH 7e6c1f16aee3244a69aba6e438295ca3)
-set(UNWIND_VERSION 1.3-rc1)
-set(UNWIND_HASH f09b670de5db6430a3de666e6aed60e3)
 
 # Pass -isysroot=<SDK_PATH> option on Mac OS to a preprocessor and a C
 # compiler to find header files installed with an SDK.
@@ -203,77 +201,9 @@ else()
     )
 endif()
 
-#
-# Unwind
-#
-if (APPLE)
-    # On macOS libunwind is a part of MacOSX.sdk
-    # So we need to find library and header and
-    # copy it locally
-    find_path(UNWIND_INCLUDE_DIR libunwind.h)
-    find_library(UNWIND_LIBRARY libunwind.tbd
-        PATH_SUFFIXES system
-    )
-
-    set(UNWIND_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/unwind-prefix")
-
-    set(UNWIND_DEPENDENCIES)
-
-    if (UNWIND_INCLUDE_DIR AND UNWIND_LIBRARY)
-        add_custom_command(
-            OUTPUT "${UNWIND_INSTALL_PREFIX}/include/unwind.h"
-            OUTPUT "${UNWIND_INSTALL_PREFIX}/include/libunwind.h"
-            COMMAND ${CMAKE_COMMAND} -E make_directory
-                "${UNWIND_INSTALL_PREFIX}/include"
-            COMMAND ${CMAKE_COMMAND} -E copy
-                "${UNWIND_INCLUDE_DIR}/libunwind.h"
-                "${UNWIND_INCLUDE_DIR}/unwind.h"
-                "${UNWIND_INSTALL_PREFIX}/include/"
-        )
-        add_custom_command(
-            OUTPUT "${UNWIND_INSTALL_PREFIX}/lib/libunwind.tbd"
-            COMMAND ${CMAKE_COMMAND} -E make_directory
-                "${UNWIND_INSTALL_PREFIX}/lib"
-            COMMAND ${CMAKE_COMMAND} -E copy
-                "${UNWIND_LIBRARY}"
-                "${UNWIND_INSTALL_PREFIX}/lib/"
-        )
-        set(UNWIND_DEPENDENCIES
-            ${UNWIND_DEPENDENCIES}
-            "${UNWIND_INSTALL_PREFIX}/lib/libunwind.tbd"
-            "${UNWIND_INSTALL_PREFIX}/include/libunwind.h"
-        )
-    else()
-        message(STATUS "Unwind not found")
-    endif()
-
-    add_custom_target(unwind DEPENDS ${UNWIND_DEPENDENCIES})
-    # This is a hack for further getting install directory of library
-    # by ExternalProject_Get_Property
-    set_target_properties(unwind
-        PROPERTIES _EP_INSTALL_DIR ${UNWIND_INSTALL_PREFIX}
-    )
-else()
-    ExternalProject_Add(unwind
-        URL https://download.savannah.nongnu.org/releases/libunwind/libunwind-${UNWIND_VERSION}.tar.gz
-        URL_MD5 ${UNWIND_HASH}
-        CONFIGURE_COMMAND <SOURCE_DIR>/configure
-            CC=${CMAKE_C_COMPILER}
-            CXX=${CMAKE_CXX_COMPILER}
-            CFLAGS=${DEPENDENCY_CFLAGS}
-            CPPFLAGS=${DEPENDENCY_CPPFLAGS}
-            LDFLAGS=${DEPENDENCY_LDFLAGS}
-            --prefix=<INSTALL_DIR>
-            --disable-shared
-            --enable-static
-            --disable-minidebuginfo # to prevent linking with liblzma
-        STEP_TARGETS download
-    )
-endif()
-
 # Get install directories of builded libraries for building
 # tarantool with custon CMAKE_PREFIX_PATH
-foreach(PROJ openssl icu zlib ncurses readline iconv unwind)
+foreach(PROJ openssl icu zlib ncurses readline iconv)
     ExternalProject_Get_Property(${PROJ} install_dir)
     set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH}:${install_dir})
     set(TARANTOOL_DEPENDS ${PROJ} ${TARANTOOL_DEPENDS})
@@ -290,7 +220,6 @@ ExternalProject_Add(tarantool
         -DCMAKE_INSTALL_LOCALSTATEDIR=<INSTALL_DIR>/var
         -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
         -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
-        -DCMAKE_FIND_USE_CMAKE_SYSTEM_PATH=FALSE
         -DOPENSSL_USE_STATIC_LIBS=TRUE
         -DBUILD_STATIC=TRUE
         -DENABLE_DIST=TRUE


### PR DESCRIPTION
Investigation of GNU libunwind problems on the aarch64-linux-gnu
platform drive us to the conclusion that libunwind-1.2.1 provided by
major distribution packages is broken. Not to mention that its test
suite fails with SEGFAULTs.

Last but not least, some distributions, e.g. CentOS 8 (see #4611) do
not provide a libunwind package.

Hence, bundle libunwind: bundling is enabled by default on all
platforms, except for macOS — a system package can be used if its
version is greater or equal than 1.3.0 (minimal version that does not
seem to be broken on aarch64-linux-gnu).

* Add new submodule: bump it to current master
* Refactor libunwind package search logic out of compiler.cmake.
* Add CMake script for building bundled libunwind
* Add CMake script for extracting version of libunwind
* Re-enable backtrace for all RHEL distributions by default

Needed for #4002
Closes #4611