### PR TITLE
sql: fix memory leak when calling user functions

### DIFF
--- a/changelogs/unreleased/gh-6789-fix-memleak-in-vdbe.md
+++ b/changelogs/unreleased/gh-6789-fix-memleak-in-vdbe.md
@@ -1,0 +1,3 @@
+## bugfix/sql
+
+* Fixed memleak in SQL during calling of user-defined function (gh-6789).

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -1264,12 +1264,15 @@ case OP_FunctionByName: {
 	pOut = vdbe_prepare_null_out(p, pOp->p3);
 	uint32_t size;
 	struct Mem *mem = (struct Mem *)port_get_vdbemem(&ret, &size);
-	if (mem != NULL && size > 0)
-		*pOut = mem[0];
 	port_destroy(&ret);
-	region_truncate(region, region_svp);
-	if (mem == NULL)
+	if (mem == NULL) {
+		region_truncate(region, region_svp);
 		goto abort_due_to_error;
+	}
+	assert(size == 1);
+	mem_move(pOut, &mem[0]);
+	assert(mem_is_null(&mem[0]) && mem_is_trivial(&mem[0]));
+	region_truncate(region, region_svp);
 	if (!mem_is_field_compatible(pOut, returns)) {
 		diag_set(ClientError, ER_FUNC_INVALID_RETURN_TYPE, pOp->p4.z,
 			 field_type_strs[returns],


### PR DESCRIPTION
In some cases, when calling a user-defined function, some of the memory
allocated earlier could be lost. This patch fixes this problem.

NO_DOC=No need for doc in this case
NO_TEST=Currently there is no proper way to catch the missing memory

Closes #6789