### PR TITLE
datetime: removed redundant normalization in date intervals

### DIFF
--- a/changelogs/unreleased/gh-6882-fix-negative-datetime-intervals.md
+++ b/changelogs/unreleased/gh-6882-fix-negative-datetime-intervals.md
@@ -1,0 +1,13 @@
+## bugfix/datetime
+
+ * Intervals received after datetime arithmetic operations may be improperly
+   normalized if result was negative
+
+```
+   tarantool> date.now() - date.now()
+---
+- -1.000026000 seconds
+...
+```
+   i.e. 2 immediately called `date.now()` produce very close values, whose
+   difference should be close to 0, not 1 second. (gh-6882);

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -808,8 +808,7 @@ local function datetime_interval_sub(lhs, rhs)
     -- left is date, right is date
     elseif not left_is_interval and not right_is_interval then
         local obj = interval_new()
-        obj.sec, obj.nsec = normalize_nsec(lhs.epoch - rhs.epoch,
-                                           lhs.nsec - rhs.nsec)
+        obj.sec, obj.nsec = lhs.epoch - rhs.epoch, lhs.nsec - rhs.nsec
         return obj
     -- both left and right are intervals
     elseif left_is_interval and right_is_interval then

--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -11,7 +11,7 @@ local ffi = require('ffi')
 --]]
 if jit.arch == 'arm64' then jit.off() end
 
-test:plan(22)
+test:plan(23)
 
 -- minimum supported date - -5879610-06-22
 local MIN_DATE_YEAR = -5879610
@@ -755,6 +755,25 @@ test:test("Time interval operations", function(test)
     assert_raises_like(test, expected_interval_but, function() tsub_t:sub('bogus') end)
     assert_raises_like(test, expected_interval_but, function() tsub_t:sub(123) end)
 end)
+
+test:test("Time interval operations - determinism", function(test)
+    test:plan(4)
+    local d1 = date.new()
+    local d2 = date.new()
+    local negsec0 = d1 - d2
+    local possec0 = d2 - d1
+    test:is(negsec0.sec, 0, "date.now() - date.now() should be 0")
+    test:is(possec0.sec, 0, "date.now() - date.now() should be 0 in reverse")
+
+    d1 = date.new{year = 2021, mon = 1, day = 12, hour = 12, min = 10, sec = 10,
+                  nsec = 4e6}
+    d2 = date.new{year = 2021, mon = 1, day = 12, hour = 12, min = 10, sec = 10,
+                  nsec = 5e6}
+    negsec0 = d1 - d2
+    possec0 = d2 - d1
+    test:is(negsec0.sec, 0, "nsec = 4e6 - 5e6 should be 0")
+    test:is(possec0.sec, 0, "nsec = 5e6 - 4e6 should be 0")
+    end)
 
 test:test("Time interval operations - different adjustments", function(test)
     test:plan(60)


### PR DESCRIPTION
Normalization was unnecessary in negative interval values
close to 0. This led to extra second in result, like:

```
tarantool> date.now() - date.now()
---
- -1.000026000 seconds
...
```

We do need to normalize when assign to datetime values, but not for
intermediate intervals.

Closes #6882