### PR TITLE
cmake: allow to add extra test suites to build

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,3 +68,8 @@ if(ENABLE_FUZZER)
     add_subdirectory(fuzz)
 endif()
 add_subdirectory(unit)
+foreach(TEST_SUITE ${EXTRA_TEST_SUITES})
+    add_subdirectory(
+        "${EXTRA_TEST_SUITES_SOURCE_DIR}/${TEST_SUITE}"
+        "${EXTRA_TEST_SUITES_BINARY_DIR}/${TEST_SUITE}")
+endforeach()


### PR DESCRIPTION
To build EE tests, we need to add some new CMake variables:

 - Set `EXTRA_TEST_SUITES_{BINARY,SOURCE}_DIR` to the binary/source directory that contains extra test suites.
 - Set `EXTRA_TEST_SUITES` to the list of extra test suites to build.

For how the new options will be used, see https://github.com/tarantool/tarantool-ee/pull/46