### PR TITLE
libcoro fibers unwind information fixes

### DIFF
--- a/cmake/BuildLibCORO.cmake
+++ b/cmake/BuildLibCORO.cmake
@@ -4,6 +4,8 @@ macro(libcoro_build)
     set(coro_src
         ${PROJECT_SOURCE_DIR}/third_party/coro/coro.c
     )
+    set_source_files_properties(${coro_src} PROPERTIES
+                                COMPILE_FLAGS -fomit-frame-pointer)
 
     add_library(coro STATIC ${coro_src})
 
@@ -20,4 +22,3 @@ macro(libcoro_build)
 
     unset(coro_src)
 endmacro(libcoro_build)
-

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -179,17 +179,6 @@ endif()
 
 add_compile_flags("C;CXX" "-fexceptions" "-funwind-tables")
 
-# We must set -fno-omit-frame-pointer here, since we rely
-# on frame pointer when getting a backtrace, and it must
-# be used consistently across all object files.
-# The same reasoning applies to -fno-stack-protector switch.
-
-if (ENABLE_BACKTRACE)
-    add_compile_flags("C;CXX"
-        "-fno-omit-frame-pointer"
-        "-fno-stack-protector")
-endif()
-
 # In C a global variable without a storage specifier (static/extern) and
 # without an initialiser is called a ’tentative definition’. The
 # language permits multiple tentative definitions in the single


### PR DESCRIPTION
# coro: fix `coro_{init,startup}` unwind information

Fiber call-chains end at `coro_{init, startup}`, but unwinders don't
stop there, trying to use `coro_{init, startup}` stack frame's return
address (which points to some garbage) and, in turn, failing. A similar
issue was experienced by seastar and julia (see JuliaLang/julia#23074
and scylladb/scylla#1909).

In order to make unwinding stop at `coro_{init, startup}`'s stack frame
we need to annotate it with CFI assembly: previously, annotation was
provided only for gcc on x86_64 — also provide it for clang.

For some reason unwinders ignore platform ABIs regarding ending of
call-chains: instead of trying to follow platform ABIs, explicitly
invalidate the topmost (`coro_{init, startup}`) stack frame information
for both x86_64 and AARCH64.

# core: fix `coro_unwcontext` invalid unwind info

During the context switch required for backtracing a suspended fiber,
unwinders go crazy, as the unwind information they had gets implicitly
invalidated: provide an annotation for a dummy frame for
`coro_unwcontext`, as if it were at the bottom of the call-chain — that
way unwinders can normally proceed further.

We need to know the exact location of the stack pointer: replace the
16-byte stack alignment instruction on x86_64 macOS by adding the
`force_align_arg_pointer` attribute to `unw_getcontext_f`.

Needed for #4002