### PR TITLE
memtx: say address of memtx_tuple in memtx_tuple_delete()

### DIFF
--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -1492,10 +1492,10 @@ static void
 memtx_tuple_delete(struct tuple_format *format, struct tuple *tuple)
 {
 	struct memtx_engine *memtx = (struct memtx_engine *)format->engine;
-	say_debug("%s(%p)", __func__, tuple);
 	assert(tuple_is_unreferenced(tuple));
 	struct memtx_tuple *memtx_tuple =
 		container_of(tuple, struct memtx_tuple, base);
+	say_debug("%s(%p)", __func__, memtx_tuple);
 	if (memtx->free_mode != MEMTX_ENGINE_DELAYED_FREE ||
 	    memtx_tuple->version == memtx->snapshot_version ||
 	    format->is_temporary) {

--- a/test/box-luatest/gh_6634_different_log_on_tuple_new_and_free_test.lua
+++ b/test/box-luatest/gh_6634_different_log_on_tuple_new_and_free_test.lua
@@ -1,0 +1,41 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all = function()
+    g.server = server:new{
+        alias   = 'default',
+    }
+    g.server:start()
+end
+
+g.after_all = function()
+    g.server:drop()
+end
+
+g.test_different_logs_on_new_and_free = function()
+    g.server:exec(function()
+        local s = box.schema.create_space('test')
+        s:create_index('pk')
+        box.cfg{log_level = 7}
+        s:replace{0, 0, 0, 0, 0, 0, 0}
+        box.cfg{log_level = 5}
+    end)
+
+    local str = g.server:grep_log('tuple_new[%w_]*%(%d+%) = 0x%x+$', 1024)
+    local new_tuple_address = string.match(str, '0x%x+$')
+    new_tuple_address = string.sub(new_tuple_address, 3)
+
+    g.server:exec(function()
+        box.cfg{log_level = 7}
+        box.space.test:replace{0, 1}
+        collectgarbage('collect')
+        box.cfg{log_level = 5}
+    end)
+
+    str = g.server:grep_log('tuple_delete%w*%(0x%x+%)', 1024)
+    local deleted_tuple_address = string.match(str, '0x%x+%)')
+    deleted_tuple_address = string.sub(deleted_tuple_address, 3, -2)
+    t.assert_equals(new_tuple_address, deleted_tuple_address)
+end


### PR DESCRIPTION
The problem is memtx_tuple_new() says address of memtx_tuple, while
memtx_tuple_delete() says address of an actual tuple (field of memtx_tuple).
Different addresses in logs may be confusing so this patch fixes the problem.

Closes #6634