### PR TITLE
lua_cjson: fix encode() escaping slash

### DIFF
--- a/changelogs/unreleased/gh-6200-lua_cjson-encode-escapes-slash.md
+++ b/changelogs/unreleased/gh-6200-lua_cjson-encode-escapes-slash.md
@@ -1,0 +1,4 @@
+## bugfix/lua/json
+
+* Added `json_escape_forward_slash` option to tarantool.compat and implemented
+  corresponding changes in json and msgpuck built-in modules (gh-6200).

--- a/src/lua/compat.c
+++ b/src/lua/compat.c
@@ -5,8 +5,43 @@
  */
 
 #include <lua/compat.h>
+#include "serializer.h"
+
+/* Toggler for msgpuck escaping change. */
+static int
+lbox_msgpuck_escape_forward_slash_toggle(struct lua_State *L)
+{
+	assert(lua_isboolean(L, -1));
+	bool esc_slash = lua_toboolean(L, -1);
+
+	/*
+	 * The table is changed outright, because runtime check (like one in
+	 * json serializer) is slower, more complicated and is not required here
+	 * as there is no need to have different behavior for different mp
+	 * instances, unlike in json.
+	 */
+	mp_char2escape['/'] = esc_slash ? "\\/" : NULL;
+
+	return 0;
+}
+
+/* Toggler for json.encode escaping change. */
+static int
+lbox_json_escape_forward_slash_toggle(struct lua_State *L)
+{
+	assert(lua_isboolean(L, -1));
+	bool esc_slash = lua_toboolean(L, -1);
+
+	serializer_set_option_default("encode_escape_forward_slash", esc_slash);
+
+	return 0;
+}
 
 static const struct luaL_Reg internal_compat[] = {
+	{"msgpuck_escape_forward_slash_toggle",
+	 lbox_msgpuck_escape_forward_slash_toggle},
+	{"json_escape_forward_slash_toggle",
+	 lbox_json_escape_forward_slash_toggle},
 	{NULL, NULL},
 };
 

--- a/src/lua/compat.lua
+++ b/src/lua/compat.lua
@@ -4,7 +4,6 @@
 local NEW = true
 local OLD = false
 
--- luacheck: no unused
 local internal = require('internal.compat')
 
 local options_format = {
@@ -15,6 +14,15 @@ local options_format = {
     action         = 'function/nil',
 }
 
+local JSON_ESCAPE_BRIEF = [[
+Whether to escape the forward slash symbol '/' using a backslash in a
+json.encode() result. The old and the new behavior produce a result, which
+is compatible ith the JSON specification. However most of other JSON encoders
+don't escape the forward slash, so the new behavior is considered more safe.
+
+https://github.com/tarantool/tarantool/wiki/compat%3Ajson_escape_forward_slash
+]]
+
 -- Contains options descriptions in following format:
 -- * default  (string)
 -- * brief    (string)
@@ -22,7 +30,20 @@ local options_format = {
 -- * current  (boolean, true for 'new')
 -- * selected (boolean)
 -- * action   (function)
-local options = { }
+local options = {
+    json_escape_forward_slash = {
+        default = 'old',
+        obsolete = nil,
+        brief = JSON_ESCAPE_BRIEF,
+        run_action_now = true,
+        action = function(is_new)
+            local esc_slash = not is_new
+            require('json').cfg{encode_escape_forward_slash = esc_slash}
+            internal.json_escape_forward_slash_toggle(esc_slash)
+            internal.msgpuck_escape_forward_slash_toggle(esc_slash)
+        end,
+    },
+}
 
 -- Array with option names in order of addition.
 local options_order = { }

--- a/src/lua/serializer.c
+++ b/src/lua/serializer.c
@@ -76,11 +76,25 @@ static struct {
 	OPTION(LUA_TBOOLEAN, encode_use_tostring, 0),
 	OPTION(LUA_TBOOLEAN, encode_invalid_as_nil, 0),
 	OPTION(LUA_TBOOLEAN, encode_error_as_ext, 1),
+	OPTION(LUA_TBOOLEAN, encode_escape_forward_slash, 0),
 	OPTION(LUA_TBOOLEAN, decode_invalid_numbers, 1),
 	OPTION(LUA_TBOOLEAN, decode_save_metatables, 1),
 	OPTION(LUA_TNUMBER,  decode_max_depth, 128),
 	{ NULL, 0, 0, 0},
 };
+
+void
+serializer_set_option_default(const char *name, int value)
+{
+	assert(name != NULL);
+	for (int i = 0; OPTIONS[i].name != NULL; i++) {
+		if (!strcmp(OPTIONS[i].name, name)) {
+			OPTIONS[i].defvalue = value;
+			return;
+		}
+	}
+	unreachable();
+}
 
 void
 luaL_serializer_create(struct luaL_serializer *cfg)

--- a/src/lua/serializer.h
+++ b/src/lua/serializer.h
@@ -136,6 +136,8 @@ struct luaL_serializer {
 	int encode_invalid_as_nil;
 	/** Encode error object as MP_ERROR extension (MsgPack only). */
 	int encode_error_as_ext;
+	/** Encode escape forward slash (for compat). */
+	int encode_escape_forward_slash;
 
 	/** Enables decoding NaN and Inf numbers */
 	int decode_invalid_numbers;
@@ -164,6 +166,14 @@ struct luaL_serializer {
 	 */
 	struct rlist on_update;
 };
+
+/**
+ * @brief helper that sets cfg options default to value.
+ * @param name option to change
+ * @param value new default value
+ */
+void
+serializer_set_option_default(const char *name, int value);
 
 /**
  * @brief serializer.new() Lua binding.

--- a/test/app-luatest/gh_6200_lua_cjson_escapes_slash_test.lua
+++ b/test/app-luatest/gh_6200_lua_cjson_escapes_slash_test.lua
@@ -1,0 +1,119 @@
+local compat = require('tarantool').compat
+local json = require('json')
+local popen = require('popen')
+local clock = require('clock')
+local t = require('luatest')
+local g = t.group()
+
+g.test_json_encode = function()
+    -- Test that '/' is escaped with default setting.
+    t.assert_equals(json.encode({url = 'https://srv:7777'}),
+                    '{"url":"https:\\/\\/srv:7777"}')
+    t.assert_equals(json.encode('/home/user/tarantool'),
+                                [["\/home\/user\/tarantool"]])
+    -- Test that other escape symbols are not affected by the setting.
+    t.assert_equals(json.encode('\t'), [["\t"]])
+    t.assert_equals(json.encode('\\'), [["\\"]])
+
+    compat.json_escape_forward_slash = 'old'
+    -- Test that '/' is escaped with 'old' setting.
+    t.assert_equals(json.encode({url = 'https://srv:7777'}),
+                    '{"url":"https:\\/\\/srv:7777"}')
+    t.assert_equals(json.encode('/home/user/tarantool'),
+                    [["\/home\/user\/tarantool"]])
+    -- Test that other escape symbols are not affected by the setting.
+    t.assert_equals(json.encode('\t'), [["\t"]])
+    t.assert_equals(json.encode('\\'), [["\\"]])
+
+    compat.json_escape_forward_slash = 'new'
+    -- Test that '/' is not escaped with 'new' setting.
+    t.assert_equals(json.encode({url = 'https://srv:7777'}),
+                                [[{"url":"https://srv:7777"}]])
+    t.assert_equals(json.encode('/home/user/tarantool'),
+                    [["/home/user/tarantool"]])
+    -- Test that other escape symbols are not affected by the setting.
+    t.assert_equals(json.encode('\t'), [["\t"]])
+    t.assert_equals(json.encode('\\'), [["\\"]])
+
+    -- Restore options defaults.
+    compat.json_escape_forward_slash = 'default'
+    -- Test that default is restored.
+    t.assert_equals(json.encode({url = 'https://srv:7777'}),
+                    '{"url":"https:\\/\\/srv:7777"}')
+    t.assert_equals(json.encode('/home/user/tarantool'),
+                    [["\/home\/user\/tarantool"]])
+end
+
+g.test_json_new_encode = function()
+    compat.json_escape_forward_slash = 'old'
+    -- Test that '/' is escaped with 'old' setting.
+    t.assert_equals(json.encode('/'), [["\/"]])
+
+    -- Create new serializer and check that it has correct defaults
+    -- and doesn't change behavior.
+    local json_old = json.new()
+    t.assert_equals(json_old.encode('/'), [["\/"]])
+    compat.json_escape_forward_slash = 'new'
+    t.assert_equals(json_old.encode('/'), [["\/"]])
+    t.assert_equals(json.encode('/'), [["/"]])
+
+    -- Create new serializer and check that it has correct defaults.
+    local json_new = json.new()
+    t.assert_equals(json_new.encode('/'), [["/"]])
+
+    -- Restore options defaults.
+    compat.json_escape_forward_slash = 'default'
+end
+
+-- log.info in json format mode uses internal encoder that takes msgpuck
+-- char2escape table, while mp_char2escape is changed by compat.
+g.test_mp_encode = function()
+    -- Start external tarantool session.
+    local TARANTOOL_PATH = arg[-1]
+    local cmd = TARANTOOL_PATH .. ' -i 2>&1'
+    local ph = popen.new({cmd}, {
+        shell = true,
+        setsid = true,
+        group_signal = true,
+        stdout = popen.opts.PIPE,
+        stderr = popen.opts.PIPE,
+        stdin = popen.opts.PIPE,
+    })
+    t.assert(ph, 'process is not up')
+
+    -- Set up compat and log.cfg.
+    ph:write('require("tarantool").compat.json_escape_forward_slash = "old"\n')
+    ph:write('require("log").cfg{format = "json"}\n')
+
+    -- Test old log.info behavior.
+    ph:write('require("log").info("/")\n')
+    local output = '';
+    local time_quota = 2.0
+    local start_time = clock.monotonic();
+    while output:find('message') == nil
+        and clock.monotonic() - start_time < time_quota do
+        local data = ph:read({timeout = 1.0})
+        if data ~= nil then
+            output = output .. data
+        end
+    end
+
+    t.assert_str_contains(output, '"message": "\\/"')
+
+    ph:write('require("tarantool").compat.json_escape_forward_slash = "new"\n')
+    start_time = clock.monotonic();
+    output = ''
+    -- Test new log.info behavior.
+    ph:write('require("log").info("/")\n')
+    while output:find('message') == nil
+        and clock.monotonic() - start_time < time_quota do
+        local data = ph:read({timeout = 1.0})
+        if data ~= nil then
+            output = output .. data
+        end
+    end
+
+    t.assert_str_contains(output, '"message": "/"')
+
+    ph:close()
+end

--- a/third_party/lua-cjson/lua_cjson.c
+++ b/third_party/lua-cjson/lua_cjson.c
@@ -124,7 +124,7 @@ typedef struct {
     int string_len;
 } json_token_t;
 
-static const char *char2escape[256] = {
+static const char *char2escape_escape_forward_slash[256] = {
     "\\u0000", "\\u0001", "\\u0002", "\\u0003",
     "\\u0004", "\\u0005", "\\u0006", "\\u0007",
     "\\b", "\\t", "\\n", "\\u000b",
@@ -162,6 +162,46 @@ static const char *char2escape[256] = {
     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
 };
+
+static const char *char2escape_no_escape_forward_slash[256] = {
+    "\\u0000", "\\u0001", "\\u0002", "\\u0003",
+    "\\u0004", "\\u0005", "\\u0006", "\\u0007",
+    "\\b", "\\t", "\\n", "\\u000b",
+    "\\f", "\\r", "\\u000e", "\\u000f",
+    "\\u0010", "\\u0011", "\\u0012", "\\u0013",
+    "\\u0014", "\\u0015", "\\u0016", "\\u0017",
+    "\\u0018", "\\u0019", "\\u001a", "\\u001b",
+    "\\u001c", "\\u001d", "\\u001e", "\\u001f",
+    NULL, NULL, "\\\"", NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, "\\\\", NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, "\\u007f",
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+};
+
 
 #if 0
 static int json_destroy_config(lua_State *l)
@@ -241,6 +281,10 @@ static void json_append_string(struct luaL_serializer *cfg, strbuf_t *json,
     (void) cfg;
     const char *escstr;
     size_t i;
+
+    const char **char2escape = (cfg->encode_escape_forward_slash ?
+            char2escape_escape_forward_slash :
+            char2escape_no_escape_forward_slash);
 
     /* Worst case is len * 6 (all unicode escapes).
      * This buffer is reused constantly for small strings


### PR DESCRIPTION
For unknown reason in upstream lua_cjson '/' was escaped
while according to the standard [rfc4627] it is unnecessary and is
questionably compatible with other implementations.

It was decided that the change will be introduced using
tarantool.compat (https://github.com/tarantool/tarantool/issues/7000). The patch adds json-escape-forward-slash
option to compat and its logic in lua_cjson and msgpuck.

Requires changes in tarantool.compat [1].
[1]: https://github.com/tarantool/tarantool/pull/7060

Fixes https://github.com/tarantool/tarantool/issues/6200
See also https://github.com/tarantool/tarantool/issues/7000
NO_DOC=[docs on tarantool.wiki](https://github.com/tarantool/tarantool/wiki/compat%3Ajson_escape_forward_slash)