### PR TITLE
schema: remove assert on wrong insert into _priv

### DIFF
--- a/changelogs/unreleased/gh-6295-assert-on-wrong-insert-into-_priv.md
+++ b/changelogs/unreleased/gh-6295-assert-on-wrong-insert-into-_priv.md
@@ -1,0 +1,5 @@
+## bugfix/core
+
+* Now inserting a tuple with the wrong "id" field into the \_priv space will
+  return the correct error (gh-6295).
+

--- a/src/box/schema.cc
+++ b/src/box/schema.cc
@@ -580,36 +580,51 @@ schema_find_name(enum schema_object_type type, uint32_t object_id)
 	case SC_SPACE:
 		{
 			struct space *space = space_by_id(object_id);
-			if (space == NULL)
-				break;
-			return space->def->name;
+			if (space != NULL)
+				return space->def->name;
+			tnt_raise(ClientError, ER_NO_SUCH_SPACE,
+				  tt_sprintf("%d", object_id));
+			break;
 		}
 	case SC_FUNCTION:
 		{
 			struct func *func = func_by_id(object_id);
-			if (func == NULL)
-				break;
-			return func->def->name;
+			if (func != NULL)
+				return func->def->name;
+			tnt_raise(ClientError, ER_NO_SUCH_FUNCTION,
+				  tt_sprintf("%d", object_id));
+			break;
 		}
 	case SC_SEQUENCE:
 		{
 			struct sequence *seq = sequence_by_id(object_id);
-			if (seq == NULL)
-				break;
-			return seq->def->name;
+			if (seq != NULL)
+				return seq->def->name;
+			tnt_raise(ClientError, ER_NO_SUCH_SEQUENCE,
+				  tt_sprintf("%d", object_id));
+			break;
 		}
 	case SC_ROLE:
-	case SC_USER:
 		{
 			struct user *role = user_by_id(object_id);
-			if (role == NULL)
-				break;
-			return role->def->name;
+			if (role != NULL)
+				return role->def->name;
+			tnt_raise(ClientError, ER_NO_SUCH_ROLE,
+				  tt_sprintf("%d", object_id));
+			break;
+		}
+	case SC_USER:
+		{
+			struct user *user = user_by_id(object_id);
+			if (user != NULL)
+				return user->def->name;
+			tnt_raise(ClientError, ER_NO_SUCH_USER,
+				  tt_sprintf("%d", object_id));
+			break;
 		}
 	default:
-		break;
+		unreachable();
 	}
-	assert(false);
-	return "(nil)";
+	return NULL;
 }
 

--- a/test/box-tap/gh-6295-assert-on-wrong-id.test.lua
+++ b/test/box-tap/gh-6295-assert-on-wrong-id.test.lua
@@ -1,0 +1,34 @@
+#!/usr/bin/env tarantool
+
+local tap = require('tap')
+local test = tap.test('gh-6295-assert-on-wrong-id')
+
+test:plan(5)
+
+local ok, res
+
+box.cfg{}
+
+-- Should be an error, not an assertion.
+local _priv = box.space._priv
+local errmsg = "Function '1000000' does not exist"
+ok, res = pcall(_priv.replace, _priv, {1, 2, 'function', 1000000, box.priv.A})
+test:is_deeply({ok, tostring(res)}, {false, errmsg}, "Proper error is returned")
+
+errmsg = "Sequence '1000000' does not exist"
+ok, res = pcall(_priv.replace, _priv, {1, 2, 'sequence', 1000000, box.priv.A})
+test:is_deeply({ok, tostring(res)}, {false, errmsg}, "Proper error is returned")
+
+errmsg = "Space '1000000' does not exist"
+ok, res = pcall(_priv.replace, _priv, {1, 2, 'space', 1000000, box.priv.A})
+test:is_deeply({ok, tostring(res)}, {false, errmsg}, "Proper error is returned")
+
+errmsg = "User '1000000' is not found"
+ok, res = pcall(_priv.replace, _priv, {1, 2, 'user', 1000000, box.priv.A})
+test:is_deeply({ok, tostring(res)}, {false, errmsg}, "Proper error is returned")
+
+errmsg = "Role '1000000' is not found"
+ok, res = pcall(_priv.replace, _priv, {1, 2, 'role', 1000000, box.priv.A})
+test:is_deeply({ok, tostring(res)}, {false, errmsg}, "Proper error is returned")
+
+os.exit(test:check() and 0 or 1)


### PR DESCRIPTION
Prior to this patch, an assertion was thrown if a tuple with an invalid
id was inserted into the _priv system space. This bug appeared only in
the debug build.

Closes #6295

NO_DOC=Fix for debug build only.

(cherry picked from commit 60f168184b8dfcafa6805a1e00a09012265b58db)