### PR TITLE
log: move info messages to info logging level

### DIFF
--- a/changelogs/unreleased/gh-4675-move-info-messages-to-info-logging-level.md
+++ b/changelogs/unreleased/gh-4675-move-info-messages-to-info-logging-level.md
@@ -1,0 +1,4 @@
+## feature/core
+
+* Changed log level of some information messages from critical to info
+  (gh-4675).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -376,10 +376,10 @@ box_set_orphan(bool orphan)
 	box_do_set_orphan(orphan);
 	/* Update the title to reflect the new status. */
 	if (is_orphan) {
-		say_crit("entering orphan mode");
+		say_info("entering orphan mode");
 		title("orphan");
 	} else {
-		say_crit("leaving orphan mode");
+		say_info("leaving orphan mode");
 		title("running");
 	}
 }

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -637,7 +637,7 @@ checkpoint_write_row(struct xlog *l, struct xrow_header *row)
 		return -1;
 
 	if ((l->rows + l->tx_rows) % 100000 == 0) {
-		say_crit_ratelimited("%.1fM rows written",
+		say_info_ratelimited("%.1fM rows written",
 				     (l->rows + l->tx_rows) / 1e6);
 	}
 	return 0;

--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -950,7 +950,7 @@ relay_subscribe_f(va_list ap)
 	assert(!diag_is_empty(&relay->diag));
 	diag_set_error(diag_get(), diag_last_error(&relay->diag));
 	diag_log();
-	say_crit("exiting the relay loop");
+	say_info("exiting the relay loop");
 
 	return -1;
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -456,8 +456,8 @@ load_cfg(void)
 	 * after (optional) daemonising to avoid confusing messages with
 	 * different pids
 	 */
-	say_crit("%s %s", tarantool_package(), tarantool_version());
-	say_crit("log level %i", cfg_geti("log_level"));
+	say_info("%s %s", tarantool_package(), tarantool_version());
+	say_info("log level %i", cfg_geti("log_level"));
 
 	if (pid_file_handle != NULL) {
 		if (pidfile_write(pid_file_handle) == -1)
@@ -766,7 +766,7 @@ main(int argc, char **argv)
 		start_loop = start_loop && ev_activecnt(loop()) > events;
 		region_free(&fiber()->gc);
 		if (start_loop) {
-			say_crit("entering the event loop");
+			say_info("entering the event loop");
 			systemd_snotify("READY=1");
 			ev_now_update(loop());
 			ev_run(loop(), 0);
@@ -782,7 +782,7 @@ main(int argc, char **argv)
 	}
 
 	if (start_loop)
-		say_crit("exiting the event loop");
+		say_info("exiting the event loop");
 	/*
 	 * If Tarantool was stopped using Ctrl+D, then we need to
 	 * call on_shutdown triggers, because Ctrl+D  causes not


### PR DESCRIPTION
Information messages have been moved from the critical logging level
to info to avoid false alarms when reading logs.

Closes #4675