### PR TITLE
msgpack: add iterator.take_array

### DIFF
--- a/test/app-luatest/msgpack_test.lua
+++ b/test/app-luatest/msgpack_test.lua
@@ -317,6 +317,28 @@ g.test_object_iterator = function()
     t.assert_equals(it2:decode(), 123)
     t.assert_error_msg_content_equals(
         "iteration ended", function() it2:decode() end)
+
+    -- iterator.take_array
+    it = msgpack.object({1, 2, 3}):iterator()
+    t.assert_error_msg_content_equals("iteration ended", it.take_array, it, 2)
+    t.assert_equals(it:take_array(0):decode(), {})
+    t.assert_equals(it:take_array(1):decode(), {{1, 2, 3}})
+    t.assert_equals(it:take_array(0):decode(), {})
+    t.assert_error_msg_content_equals("iteration ended", it.take_array, it, 1)
+
+    it = msgpack.object({10, 20, {30, 40}, 50, {60, 70, 80}, 90}):iterator()
+    t.assert_equals(it:decode_array_header(), 6)
+    t.assert_equals(it:decode(), 10)
+    t.assert_equals(it:take_array(3):decode(), {20, {30, 40}, 50})
+    t.assert_equals(it:decode_array_header(), 3)
+    t.assert_equals(it:decode(), 60)
+    t.assert_equals(it:take_array(3):decode(), {70, 80, 90})
+    t.assert_error_msg_content_equals("iteration ended", it.take, it)
+
+    it = msgpack.object({foo = 123}):iterator()
+    t.assert_equals(it:decode_map_header(), 1)
+    t.assert_equals(it:take_array(2):decode(), {'foo', 123})
+    t.assert_error_msg_content_equals("iteration ended", it.take_array, it, 1)
 end
 
 g.test_object_cfg = function()


### PR DESCRIPTION
The new method copies the given number of msgpack values starting from the iterator cursor position to a new msgpack array object. On success it returns the new msgpack object and advances the iterator cursor. If there isn't enough values to decode, it raises a Lua error and leaves the iterator cursor unchanged.

This function could be implemented in Lua like this:

```lua
function take_array(iter, count)
    local array = {}
    for _ = 1, count do
        table.insert(array, iter:take())
    end
    return msgpack.object(array)
end
```

Usage example:

```lua
local mp = msgpack.object({10, 20, 30, 40})
local it = mp:iterator()
it:decode_array_header()       -- returns 4
it:decode()                    -- returns 10
local mp2 = it:take_array(2)
mp2:decode()                   -- returns {20, 30}
it:decode()                    -- returns 40
```

Closes #6823