### PR TITLE
net.box: support tab complete for stream and future v2

### DIFF
--- a/changelogs/unreleased/gh-6305-net-box-autocomplete.md
+++ b/changelogs/unreleased/gh-6305-net-box-autocomplete.md
@@ -1,0 +1,4 @@
+## feature/lua
+
+* Added support of console autocompletion for net.box objects `stream`
+  and `future` (gh-6305).

--- a/src/box/lua/net_box.lua
+++ b/src/box/lua/net_box.lua
@@ -165,7 +165,8 @@ local function stream_wrap_index(stream_id, src)
         _src = src,
     }, {
         __index = src,
-        __serialize = stream_index_serialize
+        __serialize = stream_index_serialize,
+        __autocomplete = stream_index_serialize
     })
 end
 
@@ -188,7 +189,8 @@ local stream_indexes_mt = {
         self[key] = res
         return res
     end,
-    __serialize = stream_indexes_serialize
+    __serialize = stream_indexes_serialize,
+    __autocomplete = stream_indexes_serialize
 }
 
 -- Create stream space, which is same as connection space,
@@ -202,7 +204,8 @@ local function stream_wrap_space(stream, src)
         }, stream_indexes_mt)
     }, {
         __index = src,
-        __serialize = stream_space_serialize
+        __serialize = stream_space_serialize,
+        __autocomplete = stream_space_serialize
     })
     res.index._space = res
     return res
@@ -234,7 +237,8 @@ local stream_spaces_mt = {
         self._stream_space_cache[key] = res
         return res
     end,
-    __serialize = stream_spaces_serialize
+    __serialize = stream_spaces_serialize,
+    __autocomplete = stream_spaces_serialize
 }
 
 -- This callback is invoked in a new fiber upon receiving 'box.shutdown' event

--- a/test/app-luatest/gh_6305_autocomplete_metamethod_test.lua
+++ b/test/app-luatest/gh_6305_autocomplete_metamethod_test.lua
@@ -1,0 +1,60 @@
+local t = require('luatest')
+local g = t.group()
+local console = require('console')
+
+local function tabcomplete(s)
+    return console.completion_handler(s, 0, #s)
+end
+
+g.test_no_metatable = function()
+    local tab = {first = true, second = true}
+    rawset(_G, 'table11', tab)
+    t.assert_items_equals(tabcomplete('table1'), {'table11', 'table11'})
+    t.assert_items_equals(tabcomplete('table11.'), {'table11.',
+                                                        'table11.first',
+                                                        'table11.second',
+                                                        })
+end
+
+g.test__index = function()
+    local tab = {first = true, second = true}
+    rawset(_G, 'table11', tab)
+    setmetatable(tab, {__index = {index = true}})
+    t.assert_items_equals(tabcomplete('table11.'), {'table11.',
+                                                    'table11.first',
+                                                    'table11.second',
+                                                    'table11.index',
+                                                    })
+end
+
+g.test__autocomplete = function()
+    local tab = {first = true, second = true}
+    rawset(_G, 'table11', tab)
+    -- __autocomplete should always be a function, no extra completions
+    setmetatable(tab, {__autocomplete = {auto = true}})
+   t.assert_items_equals(tabcomplete('table11.'), {'table11.',
+                                                   'table11.first',
+                                                   'table11.second',
+                                                   })
+   -- __autocomplete function can throw an error - should be Ok
+   setmetatable(tab, {__autocomplete = function() error('test error') end})
+   t.assert_items_equals(tabcomplete('table11.'), {'table11.',
+                                                   'table11.first',
+                                                   'table11.second',
+                                                   })
+   -- the right way - should add 'auto' comletion
+   setmetatable(tab, {__autocomplete = function() return {auto = true} end})
+   t.assert_items_equals(tabcomplete('table11.'), {'table11.',
+                                                   'table11.first',
+                                                   'table11.second',
+                                                   'table11.auto',
+                                                   })
+   -- __autocomplete supercedes __index, no completions from the latter
+   setmetatable(tab, {__autocomplete = function() return {auto = true} end,
+                      __index = {index = true}})
+   t.assert_items_equals(tabcomplete('table11.'), {'table11.',
+                                                   'table11.first',
+                                                   'table11.second',
+                                                   'table11.auto',
+                                                   })
+end

--- a/test/box-luatest/gh_6305_net_box_autocomplete_test.lua
+++ b/test/box-luatest/gh_6305_net_box_autocomplete_test.lua
@@ -1,0 +1,129 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+local net = require('net.box')
+local console = require('console')
+
+g.before_all = function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+    g.server:exec(function()
+        box.schema.create_space('space1'):create_index('primary')
+    end)
+end
+
+g.after_all = function()
+    g.server:stop()
+end
+
+local function tabcomplete(s)
+    return console.completion_handler(s, 0, #s)
+end
+
+g.test_autocomplete = function()
+    local c = net:connect(g.server.net_box_uri)
+    -- tabcomplete always uses global table
+    rawset(_G, 'conn1', c)
+
+    -- connection should provide all functions available
+    local r = tabcomplete('conn1:')
+    t.assert_equals(r, {'conn1:',
+                        'conn1:eval_16(',
+                        'conn1:call(',
+                        'conn1:reload_schema(',
+                        'conn1:on_disconnect(',
+                        'conn1:on_shutdown(',
+                        'conn1:wait_connected(',
+                        'conn1:watch(',
+                        'conn1:call_16(',
+                        'conn1:execute(',
+                        'conn1:prepare(',
+                        'conn1:wait_state(',
+                        'conn1:unprepare(',
+                        'conn1:close(',
+                        'conn1:on_connect(',
+                        'conn1:ping(',
+                        'conn1:new_stream(',
+                        'conn1:is_connected(',
+                        'conn1:eval(',
+                        'conn1:on_schema_reload(',
+                        })
+
+    -- it should return all spaces and indexes
+    r = tabcomplete('conn1.space.s')
+    t.assert_equals(r, {'conn1.space.space1',
+                        'conn1.space.space1',
+                        })
+
+    r = tabcomplete('conn1.space.space1.ind')
+    t.assert_equals(r, {'conn1.space.space1.index',
+                        'conn1.space.space1.index',
+                        })
+
+    r = tabcomplete('conn1.space.space1.index.p')
+    t.assert_equals(r, {'conn1.space.space1.index.primary',
+                        'conn1.space.space1.index.primary',
+                        })
+
+    r = tabcomplete('conn1.space.space1.index.primary:')
+    t.assert_equals(r, {'conn1.space.space1.index.primary:',
+                        'conn1.space.space1.index.primary:max(',
+                        'conn1.space.space1.index.primary:select(',
+                        'conn1.space.space1.index.primary:update(',
+                        'conn1.space.space1.index.primary:delete(',
+                        'conn1.space.space1.index.primary:count(',
+                        'conn1.space.space1.index.primary:min(',
+                        'conn1.space.space1.index.primary:get(',
+                        })
+
+    -- sreams are pretty the same
+    local s = c:new_stream()
+    rawset(_G, 'stream1', s)
+    r = tabcomplete('stream1.space.s')
+    t.assert_equals(r, {'stream1.space.space1',
+                        'stream1.space.space1',
+                        })
+
+    r = tabcomplete('stream1.space.space1.ind')
+    t.assert_equals(r, {'stream1.space.space1.index',
+                        'stream1.space.space1.index',
+                        })
+
+    r = tabcomplete('stream1.space.space1.index.p')
+    t.assert_equals(r, {'stream1.space.space1.index.primary',
+                        'stream1.space.space1.index.primary',
+                        })
+
+    r = tabcomplete('stream1.space.space1.index.primary:')
+    t.assert_equals(r, {'stream1.space.space1.index.primary:',
+                        'stream1.space.space1.index.primary:max(',
+                        'stream1.space.space1.index.primary:select(',
+                        'stream1.space.space1.index.primary:update(',
+                        'stream1.space.space1.index.primary:delete(',
+                        'stream1.space.space1.index.primary:count(',
+                        'stream1.space.space1.index.primary:min(',
+                        'stream1.space.space1.index.primary:get(',
+                        })
+
+    -- futures
+    local f = c.space.space1:select({}, {is_async = true})
+    f.user1 = 123
+    rawset(_G, 'future1', f)
+    r = tabcomplete('future1:')
+    t.assert_equals(r, {'future1:',
+                        'future1:wait_result(',
+                        'future1:result(',
+                        'future1:discard(',
+                        'future1:pairs(',
+                        'future1:is_ready(',
+                        })
+    r = tabcomplete('future1.')
+    t.assert_equals(r, {'future1.',
+                        'future1.user1',
+                        'future1.wait_result(',
+                        'future1.result(',
+                        'future1.discard(',
+                        'future1.pairs(',
+                        'future1.is_ready(',
+                        })
+end


### PR DESCRIPTION
Provide console tab completion support for net.box objects of 'stream' and 'future'.

Closes #6305