### PR TITLE
memtx: fixed incorrect calculation of the number of compressed tuples

### DIFF
--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -523,11 +523,12 @@ memtx_engine_commit(struct engine *engine, struct txn *txn)
 	struct txn_stmt *stmt;
 	stailq_foreach_entry(stmt, &txn->stmts, next) {
 		if (stmt->add_story != NULL || stmt->del_story != NULL) {
-			ssize_t bsize = memtx_tx_history_commit_stmt(stmt);
 			assert(stmt->space->engine == engine);
 			struct memtx_space *mspace =
 				(struct memtx_space *)stmt->space;
-			mspace->bsize += bsize;
+			size_t *bsize = &mspace->bsize;
+			uint64_t *ctuples = &mspace->compressed_tuples;
+			memtx_tx_history_commit_stmt(stmt, bsize, ctuples);
 		}
 	}
 }

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -1101,6 +1101,7 @@ memtx_space_drop_primary_key(struct space *space)
 	 */
 	memtx_space->replace = memtx_space_replace_no_keys;
 	memtx_space->bsize = 0;
+	memtx_space->compressed_tuples = 0;
 }
 
 static void

--- a/src/box/memtx_tx.h
+++ b/src/box/memtx_tx.h
@@ -277,10 +277,12 @@ memtx_tx_history_prepare_stmt(struct txn_stmt *stmt);
  * Make the statement's changes permanent. It becomes visible to all.
  *
  * @param stmt current statement.
- * @return the change in space bsize.
+ * @param bsize the space bsize.
+ * @param compressed_tuples count of compressed tuples in space.
  */
-ssize_t
-memtx_tx_history_commit_stmt(struct txn_stmt *stmt);
+void
+memtx_tx_history_commit_stmt(struct txn_stmt *stmt, size_t *bsize,
+			     uint64_t *compressed_tuples);
 
 /** Helper of memtx_tx_tuple_clarify */
 struct tuple *


### PR DESCRIPTION
There was no zeroing of the number of compressed tuples in the case of
space truncation. This patch fix this problem.

Follow up #2695