### PR TITLE
Add copy constructor for error object

### DIFF
--- a/changelogs/unreleased/gh-6632-add-copy-constructor-for-error-object.md
+++ b/changelogs/unreleased/gh-6632-add-copy-constructor-for-error-object.md
@@ -1,0 +1,3 @@
+## feature/lua/error
+
+* Added new methods to make a deep copy of the error object (gh-6632).

--- a/changelogs/unreleased/gh-6632-request-result-returns-a-copy-of-the-internal-error.md
+++ b/changelogs/unreleased/gh-6632-request-result-returns-a-copy-of-the-internal-error.md
@@ -1,0 +1,3 @@
+## feature/net.box
+
+* Request result returns a copy of the internal error (gh-6632).

--- a/extra/exports
+++ b/extra/exports
@@ -193,6 +193,8 @@ csv_next
 csv_setopt
 decimal_from_string
 decimal_unpack
+error_copy_all
+error_copy_one
 error_find_field
 error_ref
 error_set_prev

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -198,6 +198,7 @@ endif()
 set(api_headers
     ${PROJECT_BINARY_DIR}/src/trivia/config.h
     ${PROJECT_SOURCE_DIR}/src/trivia/util.h
+    ${PROJECT_SOURCE_DIR}/src/trivia/util_cxx.h
     ${PROJECT_SOURCE_DIR}/src/on_shutdown.h
     ${PROJECT_SOURCE_DIR}/src/lib/core/say.h
     ${PROJECT_SOURCE_DIR}/src/lib/core/fiber.h

--- a/src/box/error.h
+++ b/src/box/error.h
@@ -185,6 +185,7 @@ extern const struct type_info type_CustomError;
 #if defined(__cplusplus)
 } /* extern "C" */
 #include "exception.h"
+#include "trivia/util_cxx.h"
 
 struct rmean;
 extern "C" struct rmean *rmean_error;
@@ -218,6 +219,8 @@ public:
 	{
 	}
 
+	virtual ClientError *copy() const { return util::copy(this); }
+
 	static uint32_t get_errcode(const struct error *e);
 protected:
 	ClientError(const type_info *type, const char *file, unsigned line,
@@ -234,6 +237,8 @@ public:
 		/* TODO: actually calls ClientError::log */
 		log();
 	}
+
+	virtual LoggedError *copy() const { return util::copy(this); }
 };
 
 /**
@@ -252,6 +257,8 @@ public:
 		:ClientError(&type_AccessDeniedError, NULL, 0, 0)
 	{
 	}
+
+	virtual AccessDeniedError *copy() const { return util::copy(this); }
 
 	const char *
 	object_type() const
@@ -298,6 +305,8 @@ struct XlogError: public Exception
 	{
 	}
 
+	virtual XlogError *copy() const { return util::copy(this); }
+
 	virtual void raise() { throw this; }
 };
 
@@ -310,6 +319,8 @@ struct XlogGapError: public XlogError
 		:XlogError(&type_XlogGapError, NULL, 0)
 	{
 	}
+
+	virtual XlogGapError *copy() const { return util::copy(this); }
 
 	virtual void raise() { throw this; }
 };
@@ -324,6 +335,8 @@ public:
 		:ClientError(&type_CustomError, NULL, 0, 0)
 	{
 	}
+
+	virtual CustomError *copy() const { return util::copy(this); }
 
 	virtual void log() const;
 

--- a/src/box/lua/net_box.c
+++ b/src/box/lua/net_box.c
@@ -456,7 +456,8 @@ netbox_request_push_result(struct netbox_request *request, struct lua_State *L)
 	}
 	if (request->error != NULL) {
 		assert(request->result_ref == LUA_NOREF);
-		diag_set_error(diag_get(), request->error);
+		struct error *copy = error_copy_all(request->error);
+		diag_set_error(diag_get(), copy);
 		return luaT_push_nil_and_error(L);
 	} else {
 		assert(request->result_ref != LUA_NOREF);

--- a/src/lib/core/diag.h
+++ b/src/lib/core/diag.h
@@ -251,11 +251,41 @@ error_log(struct error *e)
 	e->log(e);
 }
 
+/**
+ * Copy a single error.
+ * @param e original error.
+ * @return copy of the original error.
+ */
+struct error *
+error_copy_one(const struct error *e);
+
+/**
+ * Copy an error and all its previous nodes.
+ * @param e original error.
+ * @return copy of the original error and its previous nodes.
+ */
+struct error *
+error_copy_all(const struct error *e);
+
+/**
+ * Create an error by copying another without its nodes.
+ * @param dst destination for copied error.
+ * @param src error to be copied.
+ */
+void
+error_create_copy(struct error *dst, const struct error *src);
+
 void
 error_create(struct error *e,
-	     error_f create, error_f raise, error_f log,
+	     error_f destroy, error_f raise, error_f log,
 	     const struct type_info *type, const char *file,
 	     unsigned line);
+
+/**
+ * Destructor for error object.
+ */
+void
+error_destroy(struct error *e);
 
 void
 error_set_location(struct error *e, const char *file, int line);

--- a/src/lib/core/error_payload.h
+++ b/src/lib/core/error_payload.h
@@ -45,6 +45,11 @@ struct error_payload {
 void
 error_payload_create(struct error_payload *p);
 
+/** Create error payload by copying another error payload. */
+void
+error_payload_create_copy(struct error_payload *dst,
+			  const struct error_payload *src);
+
 /** Destroy error payload. */
 void
 error_payload_destroy(struct error_payload *p);

--- a/src/lib/core/exception.h
+++ b/src/lib/core/exception.h
@@ -65,6 +65,8 @@ exception_get_int(struct error *e, const struct method_info *method);
 #if defined(__cplusplus)
 } /* extern "C" */
 
+#include "trivia/util_cxx.h"
+
 class Exception: public error {
 public:
 	void *operator new(size_t size);
@@ -77,11 +79,16 @@ public:
 
 	NORETURN virtual void raise() = 0;
 	virtual void log() const;
+	/** Copy an exception by using its copy constructor. */
+	virtual Exception *copy() const = 0;
 	virtual ~Exception();
+	/** Make a copy of the exception object and all of its prev nodes. */
+	Exception *copy_all() const;
 
-	Exception(const Exception &) = delete;
 	Exception& operator=(const Exception&) = delete;
 protected:
+	/** Copy constructor for Exception object. */
+	Exception(const Exception &other) { error_create_copy(this, &other); }
 	Exception(const struct type_info *type, const char *file, unsigned line);
 };
 
@@ -97,6 +104,7 @@ public:
 	{
 	}
 
+	virtual SystemError *copy() const { return util::copy(this); }
 protected:
 	SystemError(const struct type_info *type, const char *file, unsigned line);
 };
@@ -111,6 +119,8 @@ public:
 		:SystemError(&type_SocketError, NULL, 0)
 	{
 	}
+
+	virtual SocketError *copy() const { return util::copy(this); }
 
 	virtual void raise()
 	{
@@ -129,6 +139,8 @@ public:
 	{
 	}
 
+	virtual OutOfMemory *copy() const { return util::copy(this); }
+
 	virtual void raise() { throw this; }
 };
 
@@ -141,6 +153,8 @@ public:
 	{
 	}
 
+	virtual TimedOut *copy() const { return util::copy(this); }
+
 	virtual void raise() { throw this; }
 };
 
@@ -152,6 +166,8 @@ public:
 		:Exception(&type_ChannelIsClosed, NULL, 0)
 	{
 	}
+
+	virtual ChannelIsClosed *copy() const { return util::copy(this); }
 
 	virtual void raise() { throw this; }
 };
@@ -168,6 +184,8 @@ public:
 		:Exception(&type_FiberIsCancelled, NULL, 0)
 	{
 	}
+
+	virtual FiberIsCancelled *copy() const { return util::copy(this); }
 
 	virtual void log() const;
 	virtual void raise() { throw this; }
@@ -186,6 +204,8 @@ public:
 	{
 	}
 
+	virtual FiberSliceIsExceeded *copy() const { return util::copy(this); }
+
 	virtual void raise() { throw this; }
 };
 
@@ -199,6 +219,8 @@ public:
 	{
 	}
 
+	virtual LuajitError *copy() const { return util::copy(this); }
+
 	virtual void raise() { throw this; }
 };
 
@@ -210,6 +232,8 @@ public:
 		:Exception(&type_IllegalParams, NULL, 0)
 	{
 	}
+
+	virtual IllegalParams *copy() const { return util::copy(this); }
 
 	virtual void raise() { throw this; }
 };
@@ -224,6 +248,8 @@ public:
 	{
 	}
 
+	virtual CollationError *copy() const { return util::copy(this); }
+
 	virtual void raise() { throw this; }
 };
 
@@ -235,6 +261,8 @@ public:
 		:Exception(&type_SwimError, NULL, 0)
 	{
 	}
+
+	virtual SwimError *copy() const { return util::copy(this); }
 
 	virtual void raise() { throw this; }
 };
@@ -248,12 +276,15 @@ public:
 	{
 	}
 
+	virtual CryptoError *copy() const { return util::copy(this); }
+
 	virtual void raise() { throw this; }
 };
 
 class RaftError: public Exception {
 public:
 	RaftError(const char *file, unsigned line, const char *format, ...);
+	virtual RaftError *copy() const { return util::copy(this); }
 	virtual void raise() { throw this; }
 };
 

--- a/src/lib/core/ssl_error.h
+++ b/src/lib/core/ssl_error.h
@@ -29,11 +29,14 @@ BuildSSLError(const char *file, unsigned line, const char *format, ...);
 #if defined(__cplusplus)
 } /* extern "C" */
 
+#include "trivia/util_cxx.h"
+
 class SSLError: public Exception {
 public:
 	SSLError(const char *file, unsigned line)
 		: Exception(&type_SSLError, file, line) {}
 	SSLError() : SSLError(NULL, 0) {}
+	virtual SSLError *copy() const { return util::copy(this); }
 	virtual void raise() { throw this; }
 };
 

--- a/src/lua/error.lua
+++ b/src/lua/error.lua
@@ -45,6 +45,12 @@ struct error {
     struct error *_effect;
 };
 
+struct error *
+error_copy_one(const struct error *e);
+
+struct error *
+error_copy_all(const struct error *e);
+
 int
 error_set_prev(struct error *e, struct error *prev);
 
@@ -103,6 +109,20 @@ local function error_prev(err)
     else
         return nil
     end
+end
+
+local function error_copy_all(err)
+    if not ffi.istype('const struct error', err) then
+        error("Usage: error:copy_all()")
+    end
+    return ffi.C.error_copy_all(err)
+end
+
+local function error_copy_one(err)
+    if not ffi.istype('const struct error', err) then
+        error("Usage: error:copy_one()")
+    end
+    return ffi.C.error_copy_one(err)
 end
 
 local function error_set_prev(err, prev)
@@ -170,6 +190,8 @@ end
 local error_methods = {
     ["unpack"] = error_unpack;
     ["raise"] = error_raise;
+    ["copy_all"] = error_copy_all;
+    ["copy_one"] = error_copy_one;
     ["match"] = error_match; -- Tarantool 1.6 backward compatibility
     ["__serialize"] = error_serialize;
     ["set_prev"] = error_set_prev;

--- a/src/trivia/util_cxx.h
+++ b/src/trivia/util_cxx.h
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2022, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+namespace util {
+/**
+ * Make a copy of the template object by using its copy constructor.
+ */
+template <class T>
+T *
+copy(const T *to_copy) { return new T(*to_copy); }
+
+} /* namespace util */

--- a/test/app-luatest/gh_6632_add_copy_constructor_for_error_object_test.lua
+++ b/test/app-luatest/gh_6632_add_copy_constructor_for_error_object_test.lua
@@ -1,0 +1,56 @@
+local t = require('luatest')
+local g = t.group()
+local yaml = require('yaml')
+
+local function error_equals(e1, e2)
+    local s1 = yaml.encode(e1:unpack())
+    local s2 = yaml.encode(e2:unpack())
+    return s1 == s2
+end
+
+g.test_copy_one = function()
+    local e1 = box.error.new({code = 42, reason = 'testing', type = 'test_t'})
+    local e2 = e1:copy_one()
+
+    t.assert_not_equals(e1, e2)
+    t.assert(error_equals(e1, e2))
+
+    -- Check independency
+    e1:set_prev(e2)
+    t.assert_equals(e1.prev, e2)
+    t.assert_equals(e2.prev, nil)
+end
+
+g.test_copy_all = function()
+    local e1 = box.error.new({code = 1, reason = "1", type = 'test1'})
+    local e2 = box.error.new({code = 2, reason = "2", type = 'test2'})
+    local e3 = box.error.new({code = 3, reason = "3", type = 'test3'})
+    local e4 = box.error.new({code = 4, reason = "4", type = 'test4'})
+    e1:set_prev(e2)
+    e2:set_prev(e3)
+    e3:set_prev(e4)
+
+    local copy = e1:copy_all()
+    -- Check if the copied list doesn't contain any nodes from the
+    -- original list and if it doesn't have any additional nodes.
+    t.assert_not_equals(copy, nil)
+    t.assert_not_equals(copy, e1)
+    t.assert_not_equals(copy.prev, e2)
+    t.assert_not_equals(copy.prev.prev, e3)
+    t.assert_not_equals(copy.prev.prev.prev, e4)
+    t.assert_equals(copy.prev.prev.prev.prev, nil)
+
+    -- Check whether all errors are the same
+    t.assert(error_equals(copy, e1))
+    t.assert(error_equals(copy.prev, e2))
+    t.assert(error_equals(copy.prev.prev, e3))
+    t.assert(error_equals(copy.prev.prev.prev, e4))
+
+    -- Check independency
+    e3:set_prev(nil)
+    t.assert_not_equals(copy.prev.prev.prev, nil)
+    e2:set_prev(nil)
+    t.assert_not_equals(copy.prev.prev, nil)
+    e1:set_prev(nil)
+    t.assert_not_equals(copy.prev, nil)
+end

--- a/test/box-luatest/gh_6632_result_returns_a_copy_of_the_internal_error_test.lua
+++ b/test/box-luatest/gh_6632_result_returns_a_copy_of_the_internal_error_test.lua
@@ -1,0 +1,31 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all = function()
+    g.server = server:new{
+        alias = 'default',
+    }
+    g.server:start()
+end
+
+g.after_all = function()
+    g.server:drop()
+end
+
+g.test_result_returns_a_copy_of_the_internal_error = function()
+    g.server:exec(function()
+        local net = require('net.box')
+        local t = require('luatest')
+        box.cfg{listen = 3301}
+        local c = net.connect(3301)
+        local f = c:call('foo', {}, {is_async = true})
+        local _, e1 = f:wait_result()
+        t.assert_equals(e1.prev, nil)
+        e1:set_prev(box.error.new(box.error.UNKNOWN))
+        local _, e2 = f:wait_result()
+        t.assert_not_equals(e1, e2)
+        t.assert_not_equals(e2.prev, e1.prev)
+        t.assert_equals(e2.prev, nil)
+    end)
+end


### PR DESCRIPTION
This patch implements new methods in C and Lua modules 
which make a deep copy of the error object.
The copied object does not contain next error fields of the source object.
These methods allow you to return a copy of the original error to a user, 
thus ensuring that the original error object stays intact.
Closes #6632.

Usage example:

```lua
e1 = box.error.new({code = 1, reason = "1"})
e2 = box.error.new({code = 2, reason = "2"})
e3 = box.error.new({code = 3, reason = "3"})
e4 = box.error.new({code = 4, reason = "4"})
e1:set_prev(e2)
e2:set_prev(e3)
e3:set_prev(e4)
-- e1: e1 -> e2 -> e3 -> e4

copy1 = e1:copy_all()
-- copy1: copy(e1) -> copy(e2) -> copy(e3) -> copy(e4)

copy2 = e2:copy_all()
-- copy2: copy(e2) -> copy(e3) -> copy(e4)

copy3 = e3:copy_one()
-- copy3: copy(e3)

```