### PR TITLE
sql: fix assert when MP_EXT received via netbox

### DIFF
--- a/changelogs/unreleased/gh-6766-fix-error-in-extension-via-netbox.md
+++ b/changelogs/unreleased/gh-6766-fix-error-in-extension-via-netbox.md
@@ -1,0 +1,3 @@
+## bugfix/sql
+
+* Fixed assertion or segfault when MP_EXT received via net.box (gh-6766).

--- a/test/sql-luatest/gh_6766_mp_ext_via_netbox_test.lua
+++ b/test/sql-luatest/gh_6766_mp_ext_via_netbox_test.lua
@@ -1,0 +1,44 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'gh-6766'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_6766_1 = function()
+    local conn = g.server.net_box
+    local val = require('uuid').new()
+    local res = {{'uuid'}}
+    local rows = conn:execute([[SELECT typeof(?);]], {val}).rows
+    t.assert_equals(rows, res)
+end
+
+g.test_6766_2 = function()
+    local conn = g.server.net_box
+    local val = require('decimal').new(1.5)
+    local res = {{'decimal'}}
+    local rows = conn:execute([[SELECT typeof(?);]], {val}).rows
+    t.assert_equals(rows, res)
+end
+
+g.test_6766_3 = function()
+    local conn = g.server.net_box
+    local val = require('datetime').now()
+    local res = {{'datetime'}}
+    local rows = conn:execute([[SELECT typeof(?);]], {val}).rows
+    t.assert_equals(rows, res)
+end
+
+g.test_6766_4 = function()
+    local conn = g.server.net_box
+    local val = require('msgpack').object_from_raw('\xc7\x00\x0f')
+    local res = "Bind value type USERDATA for parameter 1 is not supported"
+    local _, err = pcall(conn.execute, conn, [[SELECT typeof(?);]], {val})
+    t.assert_equals(err.message, res)
+end


### PR DESCRIPTION
This patch fixes an assertion or segmentation fault when getting the
value of MP_EXT via netbox.

Closes tarantool#6766

NO_DOC=Bugfix