### PR TITLE
datetime: move interval arithmetics to C from Lua

### DIFF
--- a/changelogs/unreleased/gh-6923-interval-arithmetic.md
+++ b/changelogs/unreleased/gh-6923-interval-arithmetic.md
@@ -1,0 +1,9 @@
+## feature/lua/datetime
+
+ * Datetime interval support has been reimplemented in C
+   to make possible future Olson/tzdata and SQL extensions (gh-6923);
+
+All components of interval values now kept and operated separately
+(i.e. years, months, weeks, days, hours, seconds and nanoseconds) this
+allows to correctly apply date/time arithmetic at the moment we add/subtract
+intervals to datetime values.

--- a/extra/exports
+++ b/extra/exports
@@ -423,6 +423,7 @@ title_set_interpretor_name
 title_set_script_name
 title_set_status
 title_update
+tnt_datetime_datetime_sub
 tnt_datetime_increment_by
 tnt_datetime_now
 tnt_datetime_parse_full
@@ -450,6 +451,8 @@ tnt_iconv
 tnt_iconv_close
 tnt_iconv_open
 tnt_interval_to_string
+tnt_interval_interval_sub
+tnt_interval_interval_add
 tnt_mp_decode_double
 tnt_mp_decode_extl
 tnt_mp_decode_float

--- a/extra/exports
+++ b/extra/exports
@@ -423,6 +423,7 @@ title_set_interpretor_name
 title_set_script_name
 title_set_status
 title_update
+tnt_datetime_increment_by
 tnt_datetime_now
 tnt_datetime_parse_full
 tnt_datetime_strftime

--- a/extra/exports
+++ b/extra/exports
@@ -430,6 +430,7 @@ tnt_datetime_parse_full
 tnt_datetime_strftime
 tnt_datetime_strptime
 tnt_datetime_to_string
+tnt_datetime_totable
 tnt_datetime_unpack
 tnt_default_cert_dir_paths
 tnt_default_cert_file_paths

--- a/extra/exports
+++ b/extra/exports
@@ -448,6 +448,7 @@ tnt_dt_year
 tnt_iconv
 tnt_iconv_close
 tnt_iconv_open
+tnt_interval_to_string
 tnt_mp_decode_double
 tnt_mp_decode_extl
 tnt_mp_decode_float

--- a/src/lib/core/datetime.c
+++ b/src/lib/core/datetime.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <time.h>
+#include <inttypes.h>
 
 #define DT_PARSE_ISO_TNT
 #include "c-dt/dt.h"
@@ -416,4 +417,155 @@ int64_t
 datetime_nsec(const struct datetime *date)
 {
 	return date->nsec;
+}
+
+/**
+ * Interval support functions: stringization and operations
+ */
+
+#define NANOS_PER_SEC 1000000000
+
+static inline int64_t
+interval_seconds(const struct interval *ival)
+{
+	return (int64_t)ival->sec + ival->nsec / NANOS_PER_SEC;
+}
+
+static inline int
+interval_days(const struct interval *ival)
+{
+	return interval_seconds(ival) / SECS_PER_DAY;
+}
+
+static inline int
+interval_hours(const struct interval *ival)
+{
+	return interval_seconds(ival) / (60 * 60);
+}
+
+static inline int
+interval_minutes(const struct interval *ival)
+{
+	return interval_seconds(ival) / 60;
+}
+
+/**
+ * If |nsec| is larger than allowed range 1e9 then modify passed
+ * sec accordingly.
+ */
+static void
+denormalize_interval_nsec(int64_t *psec, int *pnsec)
+{
+	assert(psec != NULL);
+	assert(pnsec != NULL);
+	int64_t sec = *psec;
+	int nsec = *pnsec;
+	/*
+	 * There is nothing to change:
+	 * - if there is a small nsec with 0 in sec;
+	 * - or if both sec and nsec have the same sign, and nsec is
+	 *   small enough.
+	 */
+	if (nsec == 0)
+		return;
+
+	bool zero_or_same_sign = sec == 0 || (sec < 0) == (nsec < 0);
+	if (zero_or_same_sign && labs(nsec) < NANOS_PER_SEC)
+		return;
+
+	int64_t normalized_nsec = sec * NANOS_PER_SEC + nsec;
+	sec = normalized_nsec / NANOS_PER_SEC;
+	nsec = normalized_nsec % NANOS_PER_SEC;
+
+	*psec = sec;
+	*pnsec = nsec;
+}
+
+/**
+ * SNPRINT-like function to generate textual representation of a sec.nsec
+ * given buffer and size of buffer
+ */
+static size_t
+seconds_str(char *buf, ssize_t len, bool need_sign, long sec, int nsec)
+{
+	sec %= 60;
+	denormalize_interval_nsec(&sec, &nsec);
+	size_t sz = 0;
+	bool is_neg = sec < 0 || (sec == 0 && nsec < 0);
+
+	SNPRINT(sz, snprintf, buf, len, is_neg ? "-" : (need_sign ? "+" : ""));
+	sec = labs(sec);
+	if (nsec != 0) {
+		SNPRINT(sz, snprintf, buf, len, "%" PRId64 ".%09ld seconds",
+			sec, labs(nsec));
+	} else {
+		SNPRINT(sz, snprintf, buf, len, "%" PRId64 " seconds", sec);
+	}
+	return sz;
+}
+
+#define SPACE() \
+	do { \
+		if (sz > 0) { \
+			SNPRINT(sz, snprintf, buf, len, ", "); \
+		} \
+	} while (0)
+
+size_t
+interval_to_string(const struct interval *ival, char *buf, ssize_t len)
+{
+	static const char *const signed_fmt[] = {
+		"%d",	/* false */
+		"%+d",	/* true */
+	};
+	static const char zero_secs[] = "0 seconds";
+
+	bool need_sign = true;
+	size_t sz = 0;
+	if (ival->year != 0) {
+		SNPRINT(sz, snprintf, buf, len, "%+d years", ival->year);
+		need_sign = false;
+	}
+	if (ival->month != 0) {
+		SPACE();
+		SNPRINT(sz, snprintf, buf, len, signed_fmt[need_sign],
+			ival->month);
+		SNPRINT(sz, snprintf, buf, len, " months");
+		need_sign = false;
+	}
+	int64_t secs = (int64_t)ival->sec;
+	int nsec = ival->nsec;
+	if (secs == 0 && nsec == 0) {
+		if (sz != 0)
+			return sz;
+		SNPRINT(sz, snprintf, buf, len, zero_secs);
+		return sizeof(zero_secs) - 1;
+	}
+	long abs_s = labs(secs);
+	if (abs_s < 60) {
+		SPACE();
+		SNPRINT(sz, seconds_str, buf, len, need_sign, secs, nsec);
+	} else if (abs_s < 60 * 60) {
+		SPACE();
+		SNPRINT(sz, snprintf, buf, len, signed_fmt[need_sign],
+			interval_minutes(ival));
+		SNPRINT(sz, snprintf, buf, len, " minutes, ");
+		SNPRINT(sz, seconds_str, buf, len, false, secs, nsec);
+	} else if (abs_s < SECS_PER_DAY) {
+		SPACE();
+		SNPRINT(sz, snprintf, buf, len, signed_fmt[need_sign],
+			interval_hours(ival));
+		SNPRINT(sz, snprintf, buf, len, " hours, %d minutes, ",
+			interval_minutes(ival) % 60);
+		SNPRINT(sz, seconds_str, buf, len, false, secs, nsec);
+	} else {
+		SPACE();
+		SNPRINT(sz, snprintf, buf, len, signed_fmt[need_sign],
+			interval_days(ival));
+		SNPRINT(sz, snprintf, buf, len, " days, %d hours, %d minutes, ",
+			interval_hours(ival) % 24,
+			interval_minutes(ival) % 60);
+		SNPRINT(sz, seconds_str, buf, len, false, secs, nsec);
+	}
+	return sz;
 }

--- a/src/lib/core/datetime.c
+++ b/src/lib/core/datetime.c
@@ -685,3 +685,42 @@ datetime_increment_by(struct datetime *self, int direction,
 	self->nsec = nsec;
 	return 0;
 }
+
+bool
+datetime_datetime_sub(struct interval *res, const struct datetime *lhs,
+		      const struct datetime *rhs)
+{
+	assert(res != NULL);
+	assert(lhs != NULL);
+	assert(rhs != NULL);
+	res->year = 0;
+	res->month = 0;
+	res->adjust = DT_LIMIT;
+	res->sec = lhs->epoch - rhs->epoch;
+	res->nsec = lhs->nsec - rhs->nsec;
+	return true;
+}
+
+bool
+interval_interval_sub(struct interval *lhs, const struct interval *rhs)
+{
+	assert(lhs != NULL);
+	assert(rhs != NULL);
+	lhs->year -= rhs->year;
+	lhs->month -= rhs->month;
+	lhs->sec -= rhs->sec;
+	lhs->nsec -= rhs->nsec;
+	return true;
+}
+
+bool
+interval_interval_add(struct interval *lhs, const struct interval *rhs)
+{
+	assert(lhs != NULL);
+	assert(rhs != NULL);
+	lhs->year += rhs->year;
+	lhs->month += rhs->month;
+	lhs->sec += rhs->sec;
+	lhs->nsec += rhs->nsec;
+	return true;
+}

--- a/src/lib/core/datetime.h
+++ b/src/lib/core/datetime.h
@@ -204,6 +204,32 @@ int
 datetime_increment_by(struct datetime *self, int direction,
 		      const struct interval *ival);
 
+/**
+ * Subtract datetime values and return interval between epoch seconds
+ * @param[out] res resultant interval
+ * @param[in] lhs left datetime operand
+ * @param[in] rhs right datetime operand
+ */
+bool
+datetime_datetime_sub(struct interval *res, const struct datetime *lhs,
+		      const struct datetime *rhs);
+
+/**
+ * Subtract interval values, modify left operand for returning value
+ * @param[in,out] lhs left interval operand, return resultant value
+ * @param[in] rhs right interval operand
+ */
+bool
+interval_interval_sub(struct interval *lhs, const struct interval *rhs);
+
+/**
+ * Add interval values, modify left operand for returning value
+ * @param[in,out] lhs left interval operand, return resultant value
+ * @param[in] rhs right interval operand
+ */
+bool
+interval_interval_add(struct interval *lhs, const struct interval *rhs);
+
 /** Return the year from a date. */
 int64_t
 datetime_year(const struct datetime *date);

--- a/src/lib/core/datetime.h
+++ b/src/lib/core/datetime.h
@@ -36,6 +36,14 @@ struct tnt_tm;
 #define DT_TO_STRING_BUFSIZE 48
 
 /**
+ * Length of "-5879610 years, 10000 months, 10000 days, 23 hours, "\
+ * "59 minutes, 59.999999999 seconds"
+ * is 84, but both months and days could have arbitrary values, so let
+ * use something larger.
+ */
+#define DT_IVAL_TO_STRING_BUFSIZE 96
+
+/**
  * c-dt library uses int as type for dt value, which
  * represents the number of days since Rata Die date.
  * This implies limits to the number of seconds we
@@ -173,6 +181,16 @@ datetime_parse_full(struct datetime *date, const char *str, size_t len,
  */
 size_t
 datetime_strptime(struct datetime *date, const char *buf, const char *fmt);
+
+/**
+ * Convert datetime interval to string using default format
+ * @param ival source interval value
+ * @param buf output buffer
+ * @param len size of output buffer
+ * @retval length of resultant text
+ */
+size_t
+interval_to_string(const struct interval *ival, char *buf, ssize_t len);
 
 /** Return the year from a date. */
 int64_t

--- a/src/lib/core/datetime.h
+++ b/src/lib/core/datetime.h
@@ -8,6 +8,7 @@
 #include <limits.h>
 #include <stdint.h>
 #include <sys/types.h>
+#include "c-dt/dt.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -68,6 +69,33 @@ struct datetime {
 	int16_t tzoffset;
 	/** Olson timezone id */
 	int16_t tzindex;
+};
+
+/**
+ * To be able to perform arithmetics on time intervals and receive
+ * deterministic results, we have to keep months and years separately
+ * from seconds.
+ * Weeks, days, hours and minutes, all could be _precisely_ converted
+ * to seconds, but it's not the case for months (which might be 28, 29,
+ * 30, or 31 days long), or years (which could be leap year or not).
+ * Approach used here - to add/subtract months or years intervals only
+ * at the moment when we have particular date we operate on.
+ * Determinism of results is achieved due to the order we apply
+ * operations (from larger to smaller quantities):
+ * - years, then months, then weeks, days, hours, minutes,
+ *   seconds, and nanoseconds.
+ */
+struct interval {
+	/** Duration in seconds. */
+	double sec;
+	/** Fraction part of duration in seconds. */
+	int nsec;
+	/** Number of months, if specified. */
+	int month;
+	/** Number of years, if specified. */
+	int year;
+	/** Adjustment mode for day in month operations, @sa dt_adjust_t */
+	dt_adjust_t adjust;
 };
 
 /*

--- a/src/lib/core/datetime.h
+++ b/src/lib/core/datetime.h
@@ -192,6 +192,18 @@ datetime_strptime(struct datetime *date, const char *buf, const char *fmt);
 size_t
 interval_to_string(const struct interval *ival, char *buf, ssize_t len);
 
+/**
+ * Add/subtract datetime value by passed interval using direction as a hint
+ * @param[in,out] self left source operand and target for binary operation
+ * @param[in] direction addition (0) or subtraction (-1)
+ * @param[in] ival interval objects (right operand)
+ * @retval 0 if there is no overflow, negative value if there is underflow
+ *         or positive if there is overflow.
+ */
+int
+datetime_increment_by(struct datetime *self, int direction,
+		      const struct interval *ival);
+
 /** Return the year from a date. */
 int64_t
 datetime_year(const struct datetime *date);

--- a/src/lib/core/datetime.h
+++ b/src/lib/core/datetime.h
@@ -220,12 +220,30 @@ datetime_increment_by(struct datetime *self, int direction,
 		      const struct interval *ival);
 
 /**
+ * Error code multipliers for interval operations
+ */
+enum check_attr_multiplier {
+	CHECK_YEARS = 1,
+	CHECK_MONTHS = 2,
+	CHECK_WEEKS = 3,
+	CHECK_DAYS = 4,
+	CHECK_HOURS = 5,
+	CHECK_MINUTES = 6,
+	CHECK_SECONDS = 7,
+	CHECK_NANOSECS = 8,
+};
+
+/**
  * Subtract datetime values and return interval between epoch seconds
  * @param[out] res resultant interval
  * @param[in] lhs left datetime operand
  * @param[in] rhs right datetime operand
+ * @retval 0 if there is no overflow, negative value if there is underflow
+ *         in particular attribute, or positive if there is overflow.
+ *         Return value is multiplied by @sa check_attr_multiplier to
+ *         indicate which particular attributed is overflowed/underflowed.
  */
-bool
+int
 datetime_datetime_sub(struct interval *res, const struct datetime *lhs,
 		      const struct datetime *rhs);
 
@@ -233,16 +251,24 @@ datetime_datetime_sub(struct interval *res, const struct datetime *lhs,
  * Subtract interval values, modify left operand for returning value
  * @param[in,out] lhs left interval operand, return resultant value
  * @param[in] rhs right interval operand
+ * @retval 0 if there is no overflow, negative value if there is underflow
+ *         in particular attribute, or positive if there is overflow.
+ *         Return value is multiplied by @sa check_attr_multiplier to
+ *         indicate which particular attributed is overflowed/underflowed.
  */
-bool
+int
 interval_interval_sub(struct interval *lhs, const struct interval *rhs);
 
 /**
  * Add interval values, modify left operand for returning value
  * @param[in,out] lhs left interval operand, return resultant value
  * @param[in] rhs right interval operand
+ * @retval 0 if there is no overflow, negative value if there is underflow
+ *         in particular attribute, or positive if there is overflow.
+ *         Return value is multiplied by @sa check_attr_multiplier to
+ *         indicate which particular attributed is overflowed/underflowed.
  */
-bool
+int
 interval_interval_add(struct interval *lhs, const struct interval *rhs);
 
 /** Return the year from a date. */

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -56,13 +56,6 @@ int     tnt_dt_month        (dt_t dt);
 int     tnt_dt_doy          (dt_t dt);
 int     tnt_dt_dom          (dt_t dt);
 
-/* dt_arithmetic.h definitions */
-typedef enum {
-    DT_EXCESS,
-    DT_LIMIT,
-    DT_SNAP
-} dt_adjust_t;
-
 dt_t   tnt_dt_add_months   (dt_t dt, int delta, dt_adjust_t adjust);
 
 /* dt_parse_iso.h definitions */
@@ -145,31 +138,7 @@ local date_dt_stash_take = date_dt_stash.take
 local date_dt_stash_put = date_dt_stash.put
 
 local datetime_t = ffi.typeof('struct datetime')
-
---[[
-    To be able to perform arithmetics on time intervals and receive
-    deterministic results, we have to keep months and years separately
-    from seconds.
-    Weeks, days, hours and minutes, all could be _precisely_ converted
-    to seconds, but it's not the case for months (which might be 28, 29,
-    30, or 31 days long), or years (which could be leap year or not).
-    Approach used here - to add/subtract months or years intervals only
-    at the moment when we have particular date we operate on.
-    Determinism of results is achieved due to the order we apply
-    operations (from larger to smaller quantities):
-    - years, then months, then weeks, days, hours, minutes,
-      seconds, and nanoseconds.
-]]
-ffi.cdef [[
-    struct datetime_interval {
-        double sec;
-        int nsec;
-        int month;
-        int year;
-        dt_adjust_t adjust;
-    };
-]]
-local interval_t = ffi.typeof('struct datetime_interval')
+local interval_t = ffi.typeof('struct interval')
 
 local function is_interval(o)
     return ffi.istype(interval_t, o)

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -334,9 +334,17 @@ local adjust_xlat = {
     excess = builtin.DT_EXCESS,
 }
 
-local function interval_decouple_args(obj)
+local function interval_init(year, month, sec, nsec, adjust)
+    return ffi.new(interval_t, sec, nsec, month, year, adjust)
+end
+
+local function interval_new_copy(obj)
+    return interval_init(obj.year, obj.month, obj.sec, obj.nsec, obj.adjust)
+end
+
+local function interval_decode_args(obj)
     if is_interval(obj) then
-        return obj.year, obj.month, obj.sec, obj.nsec, obj.adjust
+        return obj
     end
     local year = checked_max_value(obj.year, MAX_YEAR_RANGE, 'year', 0)
     local month = checked_max_value(obj.month, MAX_MONTH_RANGE, 'month', 0)
@@ -365,22 +373,15 @@ local function interval_decouple_args(obj)
     secs = secs + sec
     nsec = (msec or 0) * 1e6 + (usec or 0) * 1e3 + (nsec or 0)
 
-    return year, month, secs, nsec, adjust
+    return interval_init(year, month, secs, nsec, adjust)
 end
 
 local function interval_new(obj)
-    local ival = ffi.new(interval_t, 0, 0, 0, 0, DEF_DT_ADJUST)
     if obj == nil then
-        return ival
+        return ffi.new(interval_t, 0, 0, 0, 0, DEF_DT_ADJUST)
     end
     check_table(obj, 'interval.new()')
-    ival.year, ival.month, ival.sec, ival.nsec, ival.adjust =
-        interval_decouple_args(obj)
-    return ival
-end
-
-local function interval_init(year, month, sec, nsec, adjust)
-    return ffi.new(interval_t, sec, nsec, month, year, adjust)
+    return interval_decode_args(obj)
 end
 
 local function nyi(msg)
@@ -723,8 +724,7 @@ local function interval_tostring(o)
     return s
 end
 
-local function datetime_increment_by(self, direction, years, months,
-                                     seconds, nanoseconds, adjust)
+local function datetime_increment_by(self, direction, ival)
     -- operations with intervals should be done using local human dates
     -- not UTC dates, thus normalize to local timezone before operations.
     local dt = local_dt(self)
@@ -732,7 +732,9 @@ local function datetime_increment_by(self, direction, years, months,
     local offset = self.tzoffset
 
     local is_ym_updated = false
-    adjust = adjust or DEF_DT_ADJUST
+    local years, months = ival.year, ival.month
+    local seconds, nanoseconds = ival.sec, ival.nsec
+    local adjust = ival.adjust or DEF_DT_ADJUST
 
     if years ~= 0 then
         check_range(years, MIN_DATE_YEAR, MAX_DATE_YEAR, 'years')
@@ -794,13 +796,11 @@ local function datetime_interval_sub(lhs, rhs)
     check_date_interval_table(rhs, "operator -")
     local left_is_interval = is_table(lhs) or is_interval(lhs)
     local right_is_interval = is_table(rhs) or is_interval(rhs)
-    local year, month, secs, nsec, adjust
 
     -- left is date, right is interval
     if not left_is_interval and right_is_interval then
-        year, month, secs, nsec, adjust = interval_decouple_args(rhs)
-        return datetime_increment_by(datetime_new_copy(lhs), -1, year, month,
-                                     secs, nsec, adjust)
+        return datetime_increment_by(datetime_new_copy(lhs), -1,
+                                     interval_decode_args(rhs))
     -- left is date, right is date
     elseif not left_is_interval and not right_is_interval then
         local obj = interval_new()
@@ -808,14 +808,13 @@ local function datetime_interval_sub(lhs, rhs)
         return obj
     -- both left and right are intervals
     elseif left_is_interval and right_is_interval then
-        year, month, secs, nsec, adjust = interval_decouple_args(lhs)
-        local obj = interval_init(year, month, secs, nsec, adjust)
-        year, month, secs, nsec = interval_decouple_args(rhs)
-        obj.year = obj.year - year
-        obj.month = obj.month - month
+        local lobj = interval_decode_args(interval_new_copy(lhs))
+        local robj = interval_decode_args(rhs)
+        lobj.year = lobj.year - robj.year
+        lobj.month = lobj.month - robj.month
         -- do not normalize nsec yet - leave till the operation with date
-        obj.sec, obj.nsec = obj.sec - secs, obj.nsec - nsec
-        return obj
+        lobj.sec, lobj.nsec = lobj.sec - robj.sec, lobj.nsec - robj.nsec
+        return lobj
     else
         error_incompatible("operator -")
     end
@@ -837,23 +836,20 @@ local function datetime_interval_add(lhs, rhs)
     check_interval_table(rhs, "operator +")
     local left_is_interval = is_table(lhs) or is_interval(lhs)
     local right_is_interval = is_table(rhs) or is_interval(rhs)
-    local year, month, secs, nsec, adjust
 
     -- left is date, right is interval
     if not left_is_interval and right_is_interval then
         local obj = datetime_new_copy(lhs)
-        year, month, secs, nsec, adjust = interval_decouple_args(rhs)
-        return datetime_increment_by(obj, 1, year, month, secs, nsec, adjust)
+        return datetime_increment_by(obj, 1, interval_decode_args(rhs))
     -- both left and right are intervals
     elseif left_is_interval and right_is_interval then
-        year, month, secs, nsec, adjust = interval_decouple_args(lhs)
-        local obj = interval_init(year, month, secs, nsec, adjust)
-        year, month, secs, nsec = interval_decouple_args(rhs)
-        obj.year = obj.year + year
-        obj.month = obj.month + month
+        local lobj = interval_decode_args(interval_new_copy(lhs))
+        local robj = interval_decode_args(rhs)
+        lobj.year = lobj.year + robj.year
+        lobj.month = lobj.month + robj.month
         -- do not normalize nsec yet - leave till the operation with date
-        obj.sec, obj.nsec = obj.sec + secs, obj.nsec + nsec
-        return obj
+        lobj.sec, lobj.nsec = lobj.sec + robj.sec, lobj.nsec + robj.nsec
+        return lobj
     else
         error_incompatible("operator +")
     end
@@ -959,9 +955,7 @@ local function datetime_shift(self, o, direction)
     local title = direction > 0 and "datetime.add" or "datetime.sub"
     check_interval_table(o, title)
 
-    local year, month, secs, nsec, adjust = interval_decouple_args(o)
-    return datetime_increment_by(self, direction, year, month, secs, nsec,
-                                 adjust)
+    return datetime_increment_by(self, direction, interval_decode_args(o))
 end
 
 --[[

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -74,8 +74,9 @@ size_t tnt_datetime_strptime(struct datetime *date, const char *buf,
 void   tnt_datetime_now(struct datetime *now);
 
 /* Tarantool interval support functions */
-size_t
-tnt_interval_to_string(const struct interval *, char *, ssize_t);
+size_t tnt_interval_to_string(const struct interval *, char *, ssize_t);
+int    tnt_datetime_increment_by(struct datetime *self, int direction,
+                                 const struct interval *ival);
 
 ]]
 
@@ -87,7 +88,6 @@ local math_floor = math.floor
 local DAYS_EPOCH_OFFSET = 719163
 local SECS_PER_DAY      = 86400
 local SECS_EPOCH_OFFSET = DAYS_EPOCH_OFFSET * SECS_PER_DAY
-local NANOS_PER_SEC     = 1e9
 local TOSTRING_BUFSIZE  = 48
 local IVAL_TOSTRING_BUFSIZE = 96
 local STRFTIME_BUFSIZE  = 128
@@ -104,10 +104,8 @@ local MAX_DATE_DAY = 11
 -- 365 1/4 days = 365.25 days. This gives an error of
 -- about 1 day in 128 years.
 local AVERAGE_DAYS_YEAR = 365.25
-local AVERAGE_DAYS_MONTH = AVERAGE_DAYS_YEAR / 12
 local AVERAGE_WEEK_YEAR = AVERAGE_DAYS_YEAR / 7
 local INT_MAX = 2147483647
-local INT_MIN = -2147483648
 -- -5879610-06-22
 local MIN_DATE_TEXT = ('%d-%02d-%02d'):format(MIN_DATE_YEAR, MIN_DATE_MONTH,
                                               MIN_DATE_DAY)
@@ -246,24 +244,6 @@ local function check_range(v, from, to, txt, extra)
     end
 end
 
-local function check_dt(dt_v, direction, v, unit)
-    if dt_v >= INT_MIN and dt_v <= INT_MAX then
-        return
-    end
-    local operation = direction >= 0 and 'addition' or 'subtraction'
-    local title = unit ~= nil and ('%s of %d %s'):format(operation, v, unit) or
-                                  operation
-    if dt_v < INT_MIN then
-        error(('%s makes date less than minimum allowed %s'):
-                format(title, MIN_DATE_TEXT), 3)
-    elseif dt_v > INT_MAX then
-        error(('%s makes date greater than maximum allowed %s'):
-                format(title, MAX_DATE_TEXT), 3)
-    else
-        assert(false)
-    end
-end
-
 local function dt_from_ymd_checked(y, M, d)
     local pdt = date_dt_stash_take()
     local is_valid = builtin.tnt_dt_from_ymd_checked(y, M, d, pdt)
@@ -295,14 +275,6 @@ end
 
 local function bool2int(b)
     return b and 1 or 0
-end
-
-local function normalize_nsec(secs, nsec)
-    if nsec < 0 or nsec >= NANOS_PER_SEC then
-        secs = secs + math_floor(nsec / NANOS_PER_SEC)
-        nsec = nsec % NANOS_PER_SEC
-    end
-    return secs, nsec
 end
 
 local adjust_xlat = {
@@ -634,48 +606,18 @@ local function interval_tostring(self)
 end
 
 local function datetime_increment_by(self, direction, ival)
-    -- operations with intervals should be done using local human dates
-    -- not UTC dates, thus normalize to local timezone before operations.
-    local dt = local_dt(self)
-    local secs, nsec = local_secs(self), self.nsec
-    local offset = self.tzoffset
-
-    local is_ym_updated = false
-    local years, months = ival.year, ival.month
-    local seconds, nanoseconds = ival.sec, ival.nsec
-    local adjust = ival.adjust or DEF_DT_ADJUST
-
-    if years ~= 0 then
-        check_range(years, MIN_DATE_YEAR, MAX_DATE_YEAR, 'years')
-        local approx_dt = dt + direction * years * AVERAGE_DAYS_YEAR
-        check_dt(approx_dt, direction, years, 'years')
-        -- tnt_dt_add_years() not handle properly DT_SNAP or DT_LIMIT mode
-        -- so use tnt_dt_add_months() as a work-around
-        dt = builtin.tnt_dt_add_months(dt, direction * years * 12, adjust)
-        is_ym_updated = true
+    local rc = builtin.tnt_datetime_increment_by(self, direction, ival)
+    if rc == 0 then
+        return self
     end
-    if months ~= 0 then
-        local new_dt = dt + direction * months * AVERAGE_DAYS_MONTH
-        check_dt(new_dt, direction, months, 'months')
-        dt = builtin.tnt_dt_add_months(dt, direction * months, adjust)
-        is_ym_updated = true
+    local operation = direction >= 0 and 'addition' or 'subtraction'
+    if rc < 0 then
+        error(('%s makes date less than minimum allowed %s'):
+                format(operation, MIN_DATE_TEXT), 3)
+    else -- rc > 0
+        error(('%s makes date greater than maximum allowed %s'):
+                format(operation, MAX_DATE_TEXT), 3)
     end
-    if is_ym_updated then
-        secs = (dt - DAYS_EPOCH_OFFSET) * SECS_PER_DAY + secs % SECS_PER_DAY
-    end
-
-    if seconds ~= 0 then
-        secs = secs + direction * seconds
-    end
-
-    if nanoseconds ~= 0 then
-        nsec = nsec + direction * nanoseconds
-    end
-
-    secs, self.nsec = normalize_nsec(secs, nsec)
-    check_dt((secs + SECS_EPOCH_OFFSET) / SECS_PER_DAY, direction)
-    self.epoch = utc_secs(secs, offset)
-    return self
 end
 
 local function date_first(lhs, rhs)

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -62,7 +62,7 @@ dt_t   tnt_dt_add_months   (dt_t dt, int delta, dt_adjust_t adjust);
 size_t tnt_dt_parse_iso_date(const char *str, size_t len, dt_t *dt);
 size_t tnt_dt_parse_iso_zone_lenient(const char *str, size_t len, int *offset);
 
-/* Tarantool functions - datetime.c */
+/* Tarantool datetime functions - datetime.c */
 size_t tnt_datetime_to_string(const struct datetime * date, char *buf,
                               ssize_t len);
 size_t tnt_datetime_strftime(const struct datetime *date, char *buf,
@@ -73,13 +73,15 @@ size_t tnt_datetime_strptime(struct datetime *date, const char *buf,
                              const char *fmt);
 void   tnt_datetime_now(struct datetime *now);
 
+/* Tarantool interval support functions */
+size_t
+tnt_interval_to_string(const struct interval *, char *, ssize_t);
+
 ]]
 
 local builtin = ffi.C
 local math_modf = math.modf
 local math_floor = math.floor
-local math_fmod = math.fmod
-local math_abs = math.abs
 
 -- Unix, January 1, 1970, Thursday
 local DAYS_EPOCH_OFFSET = 719163
@@ -87,6 +89,7 @@ local SECS_PER_DAY      = 86400
 local SECS_EPOCH_OFFSET = DAYS_EPOCH_OFFSET * SECS_PER_DAY
 local NANOS_PER_SEC     = 1e9
 local TOSTRING_BUFSIZE  = 48
+local IVAL_TOSTRING_BUFSIZE = 96
 local STRFTIME_BUFSIZE  = 128
 
 -- minimum supported date - -5879610-06-22
@@ -127,6 +130,11 @@ local date_tostr_stash =
     buffer.ffi_stash_new(string.format('char[%s]', TOSTRING_BUFSIZE))
 local date_tostr_stash_take = date_tostr_stash.take
 local date_tostr_stash_put = date_tostr_stash.put
+
+local ival_tostr_stash =
+    buffer.ffi_stash_new(string.format('char[%s]', IVAL_TOSTRING_BUFSIZE))
+local ival_tostr_stash_take = ival_tostr_stash.take
+local ival_tostr_stash_put = ival_tostr_stash.put
 
 local date_strf_stash =
     buffer.ffi_stash_new(string.format('char[%s]', STRFTIME_BUFSIZE))
@@ -595,60 +603,11 @@ local function datetime_tostring(self)
     return s
 end
 
-local function qtail(s)
-    return #s ~= 0 and (s .. ', ') or s
-end
-
--- if |nsec| is larger than allowed range 1e9 then modify passed
--- sec accordingly
-local function denormalize_interval_nsec(sec, nsec)
-    if nsec == 0 then
-        return sec, nsec
-    end
-    -- nothing to change:
-    -- - if there is small nsec with 0 in sec
-    -- - or if both sec and nsec have the same sign, and nsec is
-    --   small enough
-    local same_sign = (sec < 0) == (nsec < 0)
-    if (sec == 0 or same_sign) and math_abs(nsec) < 1e9 then
-        return sec, nsec
-    end
-
-    sec = sec + math_modf(nsec / NANOS_PER_SEC)
-    if sec >= 0 then
-        nsec = nsec % NANOS_PER_SEC
-    else
-        nsec = NANOS_PER_SEC - nsec % NANOS_PER_SEC
-    end
-    return sec, nsec
-end
-
--- signed or unsigned textual representation of sec and nsec
-local function seconds_str(need_sign, sec, nsec)
-    sec = math_fmod(sec, 60)
-    sec, nsec = denormalize_interval_nsec(sec, nsec)
-    local is_negative = sec < 0 or (sec == 0 and nsec < 0)
-    local str = is_negative and '-' or (need_sign and '+' or '')
-    sec = math_abs(sec)
-    if nsec ~= 0 then
-        str = str .. ('%d.%09d seconds'):format(sec, math_abs(nsec))
-    else
-        str = str .. ('%d seconds'):format(sec)
-    end
-    return str
-end
-
-
-local signed_fmt = {
-    [false] = '%d',
-    [true]  = '%+d',
-}
-
 --[[
     Convert to text interval values of different types
 
     - depending on a values stored there generic interval
-      values may display in following format:
+      values may be displayed in the following format:
         +12 secs
         -23 minutes, 0 seconds
         +12 hours, 23 minutes, 1 seconds
@@ -656,41 +615,22 @@ local signed_fmt = {
     - years will be displayed as
         +10 years
     - months will be displayed as:
-         +2 months
+        +2 months
 ]]
-local function interval_tostring(o)
-    check_interval(o, 'datetime.interval.tostring')
-    local s = ''
-    local need_sign = true
-    if o.year ~= 0 then
-        s = qtail(s) .. ('%+d years'):format(o.year)
-        need_sign = false
+local function interval_tostring(self)
+    check_interval(self, 'datetime.interval.tostring')
+    local buff = ival_tostr_stash_take()
+    local len = builtin.tnt_interval_to_string(self, buff, IVAL_TOSTRING_BUFSIZE)
+    if len < IVAL_TOSTRING_BUFSIZE then
+        local s = ffi.string(buff)
+        ival_tostr_stash_put(buff)
+        return s
     end
-    if o.month ~= 0 then
-        s = qtail(s) .. (signed_fmt[need_sign] .. ' months'):format(o.month)
-        need_sign = false
-    end
-    local sec, nsec = o.sec, o.nsec
-    if sec == 0 and nsec == 0 then
-        return #s > 0 and s or '0 seconds'
-    end
-    local abs_s = math_abs(sec)
-    if abs_s < 60 then
-        s = qtail(s) .. seconds_str(need_sign, sec, nsec)
-    elseif abs_s < (60 * 60) then
-        s = qtail(s) .. (signed_fmt[need_sign] .. ' minutes, %s'):
-                        format(o.min, seconds_str(false, sec, nsec))
-    elseif abs_s < SECS_PER_DAY then
-        s = qtail(s) .. (signed_fmt[need_sign] .. ' hours, %d minutes, %s'):
-                        format(o.hour, math_fmod(o.min, 60),
-                               seconds_str(false, sec, nsec))
-    else
-        s = qtail(s) .. (signed_fmt[need_sign] .. ' days, %d hours, %d minutes, %s'):
-                        format(o.day, math_fmod(o.hour, 24),
-                               math_fmod(o.min, 60),
-                               seconds_str(false, sec, nsec))
-    end
-    return s
+    -- slow path - reallocate for a fuller size, and then restart interval_to_string
+    ival_tostr_stash_put(buff)
+    buff = ffi.new('char[?]', len + 1)
+    builtin.tnt_interval_to_string(self, buff, len + 1)
+    return ffi.string(buff)
 end
 
 local function datetime_increment_by(self, direction, ival)

--- a/src/lua/tnt_datetime.c
+++ b/src/lua/tnt_datetime.c
@@ -57,3 +57,22 @@ tnt_datetime_increment_by(struct datetime *self, int direction,
 {
 	return datetime_increment_by(self, direction, ival);
 }
+
+bool
+tnt_datetime_datetime_sub(struct interval *res, const struct datetime *lhs,
+			  const struct datetime *rhs)
+{
+	return datetime_datetime_sub(res, lhs, rhs);
+}
+
+bool
+tnt_interval_interval_sub(struct interval *lhs, const struct interval *rhs)
+{
+	return interval_interval_sub(lhs, rhs);
+}
+
+bool
+tnt_interval_interval_add(struct interval *lhs, const struct interval *rhs)
+{
+	return interval_interval_add(lhs, rhs);
+}

--- a/src/lua/tnt_datetime.c
+++ b/src/lua/tnt_datetime.c
@@ -44,3 +44,9 @@ tnt_datetime_unpack(const char **data, uint32_t len, struct datetime *date)
 {
 	return datetime_unpack(data, len, date);
 }
+
+size_t
+tnt_interval_to_string(const struct interval *ival, char *buf, ssize_t len)
+{
+	return interval_to_string(ival, buf, len);
+}

--- a/src/lua/tnt_datetime.c
+++ b/src/lua/tnt_datetime.c
@@ -64,20 +64,20 @@ tnt_datetime_increment_by(struct datetime *self, int direction,
 	return datetime_increment_by(self, direction, ival);
 }
 
-bool
+int
 tnt_datetime_datetime_sub(struct interval *res, const struct datetime *lhs,
 			  const struct datetime *rhs)
 {
 	return datetime_datetime_sub(res, lhs, rhs);
 }
 
-bool
+int
 tnt_interval_interval_sub(struct interval *lhs, const struct interval *rhs)
 {
 	return interval_interval_sub(lhs, rhs);
 }
 
-bool
+int
 tnt_interval_interval_add(struct interval *lhs, const struct interval *rhs)
 {
 	return interval_interval_add(lhs, rhs);

--- a/src/lua/tnt_datetime.c
+++ b/src/lua/tnt_datetime.c
@@ -50,3 +50,10 @@ tnt_interval_to_string(const struct interval *ival, char *buf, ssize_t len)
 {
 	return interval_to_string(ival, buf, len);
 }
+
+int
+tnt_datetime_increment_by(struct datetime *self, int direction,
+			  const struct interval *ival)
+{
+	return datetime_increment_by(self, direction, ival);
+}

--- a/src/lua/tnt_datetime.c
+++ b/src/lua/tnt_datetime.c
@@ -45,6 +45,12 @@ tnt_datetime_unpack(const char **data, uint32_t len, struct datetime *date)
 	return datetime_unpack(data, len, date);
 }
 
+bool
+tnt_datetime_totable(const struct datetime *date, struct interval *out)
+{
+	return datetime_totable(date, out);
+}
+
 size_t
 tnt_interval_to_string(const struct interval *ival, char *buf, ssize_t len)
 {

--- a/src/lua/utils.c
+++ b/src/lua/utils.c
@@ -754,9 +754,13 @@ tarantool_lua_utils_init(struct lua_State *L)
 
 	rc = luaL_cdef(L, "struct interval {"
 				  "double sec;"
-				  "int nsec;"
-				  "int month;"
-				  "int year;"
+				  "double min;"
+				  "double hour;"
+				  "double day;"
+				  "int32_t week;"
+				  "int32_t month;"
+				  "int32_t year;"
+				  "int32_t nsec;"
 				  "dt_adjust_t adjust;"
 			  "};");
 	assert(rc == 0);

--- a/src/lua/utils.c
+++ b/src/lua/utils.c
@@ -49,6 +49,7 @@ uint32_t CTID_CHAR_PTR;
 uint32_t CTID_CONST_CHAR_PTR;
 uint32_t CTID_UUID;
 uint32_t CTID_DATETIME = 0;
+uint32_t CTID_INTERVAL = 0;
 
 void *
 luaL_pushcdata(struct lua_State *L, uint32_t ctypeid)
@@ -733,15 +734,35 @@ tarantool_lua_utils_init(struct lua_State *L)
 	assert(CTID_UUID != 0);
 
 	rc = luaL_cdef(L, "struct datetime {"
-			  "double epoch;"
-			  "int32_t nsec;"
-			  "int16_t tzoffset;"
-			  "int16_t tzindex;"
+				  "double epoch;"
+				  "int32_t nsec;"
+				  "int16_t tzoffset;"
+				  "int16_t tzindex;"
 			  "};");
 	assert(rc == 0);
 	(void) rc;
 	CTID_DATETIME = luaL_ctypeid(L, "struct datetime");
 	assert(CTID_DATETIME != 0);
+
+	rc = luaL_cdef(L, "typedef enum {"
+				  "DT_EXCESS,"
+				  "DT_LIMIT,"
+				  "DT_SNAP"
+			  "} dt_adjust_t;");
+	assert(rc == 0);
+	(void)rc;
+
+	rc = luaL_cdef(L, "struct interval {"
+				  "double sec;"
+				  "int nsec;"
+				  "int month;"
+				  "int year;"
+				  "dt_adjust_t adjust;"
+			  "};");
+	assert(rc == 0);
+	(void)rc;
+	CTID_INTERVAL = luaL_ctypeid(L, "struct interval");
+	assert(CTID_INTERVAL != 0);
 
 	lua_pushcfunction(L, luaT_newthread_wrapper);
 	luaT_newthread_ref = luaL_ref(L, LUA_REGISTRYINDEX);

--- a/test/luajit-test-init.lua
+++ b/test/luajit-test-init.lua
@@ -41,3 +41,7 @@ end
 function _dofile(filename)
   return dofile(path_to_sources..filename)
 end
+
+-- This is workaround introduced for flaky macosx tests reported by
+-- https://github.com/tarantool/tarantool/issues/7058
+collectgarbage('collect')


### PR DESCRIPTION
* All ffi-related defines, necessary for intervals, now created from C-side;
* "Stringization" facilities at `interval_tostring` moved to C;
* Core interval arithmetic routine `datetime_increment_by` moved to C;

Part.1 of #6751 
Followup to b0463da834784cc3b1545661a2ca48900ef54569, as part of #5941