### PR TITLE
Fix crash in space on_replace triggers.

### DIFF
--- a/changelogs/unreleased/gh-6920-fix-crash-in-on-replace-triggers.md
+++ b/changelogs/unreleased/gh-6920-fix-crash-in-on-replace-triggers.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Banned DDL operations in space on_replace triggers, since they could lead
+  to a crash (gh-6920).

--- a/src/box/schema.cc
+++ b/src/box/schema.cc
@@ -39,6 +39,7 @@
 #include "vclock/vclock.h"
 #include "fiber.h"
 #include "memtx_tx.h"
+#include "txn.h"
 
 /**
  * @module Data Dictionary
@@ -260,6 +261,11 @@ on_replace_dd_system_space(struct trigger *trigger, void *event)
 {
 	(void) trigger;
 	struct txn *txn = (struct txn *) event;
+	if (txn->space_on_replace_triggers_depth > 1) {
+		diag_set(ClientError, ER_UNSUPPORTED,
+			 "Space on_replace trigger", "DDL operations");
+		return -1;
+	}
 	memtx_tx_acquire_ddl(txn);
 	return 0;
 }

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -458,6 +458,10 @@ struct txn {
 	 * to complete within the timeout specified when it was created.
 	 */
 	struct ev_timer *rollback_timer;
+	/**
+	 * Nesting level of space on_replace triggers for current txn.
+	 */
+	int space_on_replace_triggers_depth;
 };
 
 static inline bool

--- a/test/box/on_replace.result
+++ b/test/box/on_replace.result
@@ -474,75 +474,67 @@ t = s:on_replace(function () box.schema.space.create('some_space') end)
 ...
 s:replace({1, 2})
 ---
-- [1, 2]
+- error: Space on_replace trigger does not support DDL operations
 ...
 t = s:on_replace(function () s:format({{'a', 'unsigned'}, {'b', 'unsigned'}}) end, t)
 ---
 ...
 s:replace({2, 3})
 ---
-- [2, 3]
+- error: Space on_replace trigger does not support DDL operations
 ...
 t = s:on_replace(function () box.schema.user.create('newu') box.schema.role.create('newr') end, t)
 ---
 ...
 s:replace({3, 4})
 ---
-- [3, 4]
+- error: Space on_replace trigger does not support DDL operations
 ...
 t = s:on_replace(function () box.schema.user.drop('newu') box.schema.role.drop('newr') end, t)
 ---
 ...
 s:replace({4, 5})
 ---
-- [4, 5]
+- error: User 'newu' is not found
 ...
 t = s:on_replace(function () s.index.sk:drop() end, t)
 ---
 ...
 s:replace({5, 6})
 ---
-- [5, 6]
+- error: Space on_replace trigger does not support DDL operations
 ...
 t = s:on_replace(function () box.schema.func.create('newf') end, t)
 ---
 ...
 s:replace({6, 7})
 ---
-- [6, 7]
+- error: Space on_replace trigger does not support DDL operations
 ...
 t = s:on_replace(function () box.schema.user.grant('guest', 'read,write', 'space', 'test_on_repl_ddl') end, t)
 ---
 ...
 s:replace({7, 8})
 ---
-- [7, 8]
+- error: Space on_replace trigger does not support DDL operations
 ...
 t = s:on_replace(function () s:rename('newname') end, t)
 ---
 ...
 s:replace({8, 9})
 ---
-- [8, 9]
+- error: Space on_replace trigger does not support DDL operations
 ...
 t = s:on_replace(function () s.index.pk:rename('newname') end, t)
 ---
 ...
 s:replace({9, 10})
 ---
-- [9, 10]
+- error: Space on_replace trigger does not support DDL operations
 ...
 s:select()
 ---
-- - [1, 2]
-  - [2, 3]
-  - [3, 4]
-  - [4, 5]
-  - [5, 6]
-  - [6, 7]
-  - [7, 8]
-  - [8, 9]
-  - [9, 10]
+- []
 ...
 s:drop() -- test_on_repl_ddl
 ---


### PR DESCRIPTION
During ddl operations triggers of old space and new created space
are swapped. This leads to crash in case if this swap occurs from
space on_replace triggers. This patch banned all ddl operations
from on_replace triggers.

Closes #6920