### PR TITLE
tmx: fix a crash in mvcc with secondary index conflict

### DIFF
--- a/changelogs/unreleased/gh-6452-mvcc-crash-in-prepare.md
+++ b/changelogs/unreleased/gh-6452-mvcc-crash-in-prepare.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fix a crash in mvcc connected with secondary index conflict (gh-6452)

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1784,7 +1784,6 @@ memtx_tx_history_prepare_insert_stmt(struct txn_stmt *stmt)
 			    test_stmt->txn)
 				continue;
 			memtx_tx_handle_conflict(stmt->txn, test_stmt->txn);
-			memtx_tx_story_link_deleted_by(story, test_stmt);
 		}
 	}
 

--- a/test/box-luatest/gh_6452_mvcc_crash_in_prepare_test.lua
+++ b/test/box-luatest/gh_6452_mvcc_crash_in_prepare_test.lua
@@ -1,0 +1,84 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all = function()
+    g.server = server:new{
+        alias   = 'default',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    g.server:start()
+end
+
+g.after_all = function()
+    g.server:drop()
+end
+
+g.test_mvcc_crash_in_prepare_case1 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local txn_proxy = require("test.box.lua.txn_proxy")
+
+        box.cfg{memtx_use_mvcc_engine = true}
+        local s = box.schema.space.create("s", {engine="memtx"})
+        s:create_index("pk", {type="tree"})
+        s:create_index("sk", {parts={2}, type="hash"})
+
+        local tx1 = txn_proxy.new()
+        local tx2 = txn_proxy.new()
+        local tx3 = txn_proxy.new()
+        local tx4 = txn_proxy.new()
+
+        tx1:begin()
+        tx2:begin()
+        tx3:begin()
+        tx4:begin()
+
+        tx1("box.space.s:insert{1, 'A'}")
+        tx1:commit()
+        tx2("box.space.s:replace{2, 'B'}")
+        tx3("box.space.s:replace{1, 'B'}")
+        tx4("box.space.s:replace{3, 'B'}")
+
+        tx2:rollback()
+        t.assert_equals(tx4:commit(), "")
+        t.assert_equals(tx3:commit(),
+                        {{error = "Transaction has been aborted by conflict"}})
+
+        s:drop()
+
+    end)
+end
+
+g.test_mvcc_crash_in_prepare_case2 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local txn_proxy = require("test.box.lua.txn_proxy")
+
+        box.cfg{memtx_use_mvcc_engine = true}
+        local s = box.schema.space.create("s", {engine="memtx"})
+        s:create_index("pk", {type="tree"})
+        s:create_index("sk", {parts={2}, type="hash"})
+
+        local tx1 = txn_proxy.new()
+        local tx2 = txn_proxy.new()
+        local tx3 = txn_proxy.new()
+
+        tx1:begin()
+        tx2:begin()
+        tx3:begin()
+
+        tx1('box.space.s:replace{1, "A"}')
+        tx2('box.space.s:select{1}')
+        tx2('box.space.s:insert{2, "B"}')
+        tx3('box.space.s:replace{3, "A"}')
+        tx3('box.space.s:replace{1, "C"}')
+        t.assert_equals(tx3:commit(), "")
+        tx1:rollback()
+        t.assert_equals(tx2:commit(),
+                        {{error = "Transaction has been aborted by conflict"}})
+
+        s:drop()
+
+    end)
+end


### PR DESCRIPTION
Memtx TX manager stores a pointer to deleting statement in prepared
story. This pointer is set in two cases:
1. a statement deletes (or overwrites) a tuple
2. a story becomes prepared while other inprogress TX overwrites it

By design a tuple can be deleted only by primary index, the case
when a transaction overwrites somehting in secondary index but does
not overwrite the same tuple in primary index is prohibited. That's
why the pointer (to deleting statement) must be set by and only by
the next statement in the primary index chain.

By mistake the pointer is set also in second index chain analysis
after reordering which led to unexpected state of a story.

The patch removes the problem.

Closes #6452
NO_DOC=bugfix