### PR TITLE
backtrace: introduce parent backtrace collection

### DIFF
--- a/changelogs/unreleased/fiber-parent-backtrace.md
+++ b/changelogs/unreleased/fiber-parent-backtrace.md
@@ -1,0 +1,5 @@
+## feature/backtrace
+
+* Introduce new `fiber.parent_backtrace_enable` and 
+  `fiber.parent_backtrace_disable` handles for toggling collection of parent
+  backtraces for newly created fibers (disabled by default).

--- a/src/lib/core/backtrace.cc
+++ b/src/lib/core/backtrace.cc
@@ -44,20 +44,35 @@
 #define CRLF "\n"
 
 #ifdef ENABLE_BACKTRACE
+#define UNW_LOCAL_ONLY
 #include <libunwind.h>
+#undef UNW_LOCAL_ONLY
 
-#include "small/region.h"
-#include "small/static.h"
+#include "lua/fiber.h"
+
+#ifdef __APPLE__
+#include <dlfcn.h>
+#endif
+
 /*
  * We use a static buffer interface because it is too late to do any
  * allocation when we are printing backtrace and fiber stack is
  * small.
  */
+#include "small/region.h"
+#include "small/static.h"
+
+#include "tt_static.h"
 
 #define BACKTRACE_NAME_MAX 200
 
 static __thread struct region cache_region;
 static __thread struct mh_i64ptr_t *proc_cache = NULL;
+
+/* Lua stack beginning, used for detecting Lua frames. */
+static void *backtrace_lua_stk_start_ip = (void *)lj_BC_FUNCC;
+/* Lua stack ending, ditto. */
+static void *backtrace_lua_stk_end_ip;
 
 struct proc_cache_entry {
 	char name[BACKTRACE_NAME_MAX];
@@ -186,49 +201,208 @@ out:
 	return start;
 }
 
+void
+backtrace_init(void)
+{
+#ifndef __APPLE__
+	unw_proc_info_t proc_info;
+	if (backtrace_lua_stk_start_ip != NULL) {
+		int rc = unw_get_proc_info_by_ip(unw_local_addr_space,
+					    (unw_word_t)lj_BC_FUNCC,
+					    &proc_info, NULL);
+		if (rc != 0) {
+			say_error("unwinding error: unw_get_proc_info_by_ip "
+				  "failed with: %s", unw_strerror(rc));
+			return;
+		}
+		backtrace_lua_stk_start_ip = (void *)proc_info.start_ip;
+		backtrace_lua_stk_end_ip = (void *)proc_info.end_ip;
+	}
+#else /* __APPLE__ */
+	backtrace_lua_stk_start_ip = (void *)lj_BC_FUNCC;
+	backtrace_lua_stk_end_ip = NULL;
+#endif /* __APPLE__ */
+}
+
+/* Resolve function name and offset based on `ip`. */
+int
+backtrace_resolve_from_ip(unw_word_t ip, const char **proc_name,
+			  unw_word_t *offs)
+{
+	*proc_name = backtrace_proc_cache_find(ip, offs);
+	if (*proc_name != NULL)
+		return 0;
+#ifndef __APPLE__
+	unw_accessors_t *acc = unw_get_accessors(unw_local_addr_space);
+	assert(acc->get_proc_name != NULL);
+	char *proc_name_buf = tt_static_buf();
+	int rc = acc->get_proc_name(unw_local_addr_space, ip, proc_name_buf,
+				    TT_STATIC_BUF_LEN, offs, NULL);
+	if (rc != 0) {
+		say_error("unwinding error: get_proc_name accessor failed "
+			  "with: %s", unw_strerror(rc));
+		return -1;
+	}
+	*proc_name = proc_name_buf;
+#else /* __APPLE__ */
+	Dl_info dli;
+	if (dladdr((void *)ip, &dli) == 0) {
+		say_error("unwinding error: dladdr failed");
+		return -1;
+	}
+
+	*offs = ip - (unw_word_t)dli.dli_saddr;
+	*proc_name = dli.dli_sname;
+#endif /* __APPLE__ */
+	backtrace_proc_cache_put(ip, *proc_name, *offs);
+	return 0;
+}
+
+static void
+backtrace_collect_lua_frames_cb(struct backtrace *bt, struct fiber *f)
+{
+	struct lua_State *L = f->storage.lua.stack;
+	if (L != NULL)
+		fiber_backtrace_collect_lua_frames_foreach(L, bt);
+	else
+		backtrace_append_lua_frame(bt, "<lua stack>", "<lua stack>",
+					   -1);
+}
+
+#ifndef __APPLE__
 /*
- * Libunwind unw_getcontext wrapper.
- * unw_getcontext can be a macros on some platform and can not be called
- * directly from asm code. Stack variable pass through the wrapper to
- * preserve a old stack pointer during the wrapper call.
+ * Append 'rip' of a C/C++ frame and its corresponding Lua frames (if any) to
+ * 'bt'.
+ */
+static void
+backtrace_append_ip(struct backtrace *bt, struct fiber *fiber, void *ip)
+{
+	if (ip > backtrace_lua_stk_start_ip &&
+	    ip < backtrace_lua_stk_end_ip)
+		backtrace_collect_lua_frames_cb(bt, fiber);
+	backtrace_append_c_frame(bt, ip);
+}
+#else /* __APPLE__ */
+/*
+ * Ditto.
+ */
+static int
+backtrace_append_ip(struct backtrace *bt, struct fiber *fiber,
+		    unw_cursor_t *unw_cur)
+{
+	unw_word_t ip_word;
+	int rc = unw_get_reg(unw_cur, UNW_REG_IP, &ip_word);
+	if (rc != 0) {
+		say_error("unwinding error: unw_get_reg failed with: %d", rc);
+		return -1;
+	}
+	void *ip = (void *)ip_word;
+
+	/* Try to obtain a value for `backtrace_lua_stk_end_ip` */
+	if (backtrace_lua_stk_end_ip == NULL) {
+		unw_proc_info_t proc_info;
+		rc = unw_get_proc_info(unw_cur, &proc_info);
+		if (rc != 0) {
+			say_error("unwinding error: unw_get_proc_info failed "
+				  "with: %d", rc);
+			return -1;
+		}
+		if ((void *)proc_info.start_ip <= backtrace_lua_stk_start_ip &&
+		    backtrace_lua_stk_start_ip <= (void *)proc_info.end_ip) {
+			backtrace_lua_stk_start_ip = (void *)proc_info.start_ip;
+			backtrace_lua_stk_end_ip = (void *)proc_info.end_ip;
+		}
+	}
+	if (ip > backtrace_lua_stk_start_ip &&
+	    ip < backtrace_lua_stk_end_ip)
+		backtrace_collect_lua_frames_cb(bt, fiber);
+	backtrace_append_c_frame(bt, ip);
+	return 0;
+}
+#endif /* __APPLE__ */
+
+/*
+ * Performs backtrace collection on current stack.
  *
- * @param unw_context unwind context to store execution state
- * @param stack pointer to preserve.
- * @retval preserved stack pointer.
+ * Returns the 'stk' parameter to simplify context switch.
  */
 #ifdef __x86_64__
 __attribute__ ((__force_align_arg_pointer__))
 #endif /* __x86_64__ */
-static void *
-unw_getcontext_f(unw_context_t *unw_context, void *stack)
+static NOINLINE void *
+backtrace_collect_curr_stk(struct backtrace *bt, struct fiber *fiber, void *stk)
 {
-	unw_getcontext(unw_context);
-	return stack;
+	bt->frames_cnt = 0;
+#ifndef __APPLE__
+	void *rips[BACKTRACE_FRAMES_CNT_MAX + 2];
+	int frames_count = unw_backtrace(rips, BACKTRACE_FRAMES_CNT_MAX + 2);
+	for (int frame_no = 2; frame_no < frames_count; ++frame_no) {
+		backtrace_append_ip(bt, fiber, rips[frame_no]);
+	}
+#else /* __APPLE__ */
+	unw_context_t unw_ctx;
+	int rc = unw_getcontext(&unw_ctx);
+	if (rc != 0) {
+		say_error("unwinding error: unw_getcontext failed");
+		return stk;
+	}
+	unw_cursor_t unw_cur;
+	rc = unw_init_local(&unw_cur, &unw_ctx);
+	if (rc != 0) {
+		say_error("unwinding error: unw_init_local failed");
+		return stk;
+	}
+	for (int frame_no = 0; frame_no < BACKTRACE_FRAMES_CNT_MAX + 2;
+	     ++frame_no) {
+		if (frame_no >= 2) {
+			if (backtrace_append_ip(bt, fiber, &unw_cur) != 0)
+				break;
+		}
+		int rc = unw_step(&unw_cur);
+		if (rc < 0) {
+#ifndef __APPLE__
+			say_error("unwinding error: unw_step_failed with: %s",
+				  unw_strerror(rc));
+#else /* __APPLE__ */
+			say_error("unwinding error: unw_step failed with: %d",
+				  rc);
+#endif /* __APPLE__ */
+		}
+		if (rc == 0) {
+			++frame_no;
+			break;
+		}
+	}
+#endif /* __APPLE__ */
+	return stk;
 }
 
 /*
- * Restore target coro context and call unw_getcontext over it.
- * Work is done in four parts:
- * 1. Save current fiber context to a stack and save a stack pointer
- * 2. Restore target fiber context, stack pointer is not incremented because
- *    all target stack context should be preserved across a call. No stack
- *    changes are allowed until unwinding is done.
- * 3. Setup new stack frame and call unw_getcontext wrapper. All callee-safe
- *    registers are used by target fiber context, so old stack pointer is
- *    passed as second arg to wrapper func.
- * 4. Restore old stack pointer from wrapper return and restore old fiber
- *    contex.
- *
- * @param @unw_context unwind context to store execution state.
- * @param @coro_ctx fiber context to unwind.
- *
- * Note, this function needs a separate stack frame and therefore
- * MUST NOT be inlined.
+ * Restore target fiber context (if needed) and call
+ * `backtrace_collect_curr_stk` over it.
  */
-static void NOINLINE
-coro_unwcontext(unw_context_t *unw_context, struct coro_context *coro_ctx)
+NOINLINE void
+backtrace_collect(struct backtrace *bt, struct fiber *fiber)
 {
-#if __amd64
+	if (fiber == fiber()) {
+		backtrace_collect_curr_stk(bt, fiber, NULL);
+		return;
+	} else if ((fiber->flags & FIBER_IS_CANCELLABLE) == 0) {
+		/*
+		 * Fiber stacks can't be traced for non-cancellable fibers
+		 * due to the limited capabilities of libcoro in CORO_ASM mode.
+		 */
+		bt->frames_cnt = 0;
+		return;
+	}
+	/*
+	 * 1. Save current fiber context on stack.
+	 * 2. Restore target fiber context.
+	 * 3. Setup stack frame and call `backtrace_collect_curr_stk`.
+	 * 4. Restore original stack pointer from `backtrace_collect_curr_stk`
+	 *    return value and restore original fiber context.
+	 */
+#if __amd64__
 __asm__ volatile(
 	/* Preserve current context */
 	"\tpushq %%rbp\n"
@@ -237,21 +411,23 @@ __asm__ volatile(
 	"\tpushq %%r13\n"
 	"\tpushq %%r14\n"
 	"\tpushq %%r15\n"
-	/* Setup second arg as old sp */
-	"\tmovq %%rsp, %%rsi\n"
+	/* Set first arg */
+	"\tmovq %0, %%rdi\n"
+	/* Set second arg */
+	"\tmovq %1, %%rsi\n"
+	/* Setup third arg as old sp */
+	"\tmovq %%rsp, %%rdx\n"
 	/* Restore target context, but not increment sp to preserve it */
-	"\tmovq 0(%1), %%rsp\n"
+	"\tmovq 0(%2), %%rsp\n"
 	"\tmovq 0(%%rsp), %%r15\n"
 	"\tmovq 8(%%rsp), %%r14\n"
 	"\tmovq 16(%%rsp), %%r13\n"
 	"\tmovq 24(%%rsp), %%r12\n"
 	"\tmovq 32(%%rsp), %%rbx\n"
 	"\tmovq 40(%%rsp), %%rbp\n"
-	/* Set first arg and call */
-	"\tmovq %0, %%rdi\n"
 	".cfi_remember_state\n"
 	".cfi_def_cfa %%rsp, 8 * 7\n"
-	"\tleaq %P2(%%rip), %%rax\n"
+	"\tleaq %P3(%%rip), %%rax\n"
 	"\tcall *%%rax\n"
 	".cfi_restore_state\n"
 	/* Restore old sp and context */
@@ -263,105 +439,45 @@ __asm__ volatile(
 	"\tpopq %%rbx\n"
 	"\tpopq %%rbp\n"
 	:
-	: "r" (unw_context), "r" (coro_ctx), "i" (unw_getcontext_f)
-	: "rdi", "rsi", "rax"//, "r8"//"rsp", "r11", "r10", "r9", "r8"
-	);
-
-#elif __i386
-__asm__ volatile(
-	/* Save current context */
-	"\tpushl %%ebp\n"
-	"\tpushl %%ebx\n"
-	"\tpushl %%esi\n"
-	"\tpushl %%edi\n"
-	/* Setup second arg as old sp */
-	"\tmovl %%esp, %%ecx\n"
-	/* Restore target context ,but not increment sp to preserve it */
-	"\tmovl (%1), %%esp\n"
-	"\tmovl 0(%%esp), %%edi\n"
-	"\tmovl 4(%%esp), %%esi\n"
-	"\tmovl 8(%%esp), %%ebx\n"
-	"\tmovl 12(%%esp), %%ebp\n"
-	/* Setup first arg and call */
-	"\tpushl %%ecx\n"
-	"\tpushl %0\n"
-	"\tmovl %2, %%ecx\n"
-	"\tcall *%%ecx\n"
-	/* Restore old sp and context */
-	"\tmovl %%eax, %%esp\n"
-	"\tpopl %%edi\n"
-	"\tpopl %%esi\n"
-	"\tpopl %%ebx\n"
-	"\tpopl %%ebp\n"
-	:
-	: "r" (unw_context), "r" (coro_ctx), "i" (unw_getcontext_f)
-	: "ecx", "eax"
-	);
-
-#elif __ARM_ARCH==7
-__asm__ volatile(
-	/* Save current context */
-	".syntax unified\n"
-	"\tvpush {d8-d15}\n"
-	"\tpush {r4-r11,lr}\n"
-	/* Save sp */
-	"\tmov r1, sp\n"
-	/* Restore target context, but not increment sp to preserve it */
-	"\tldr sp, [%1]\n"
-	"\tldmia sp, {r4-r11,lr}\n"
-	"\tvldmia sp, {d8-d15}\n"
-	/* Setup first arg */
-	"\tmov r0, %0\n"
-	/* Setup stack frame */
-	"\tpush {r7, lr}\n"
-	"\tsub sp, #8\n"
-	"\tstr r0, [sp, #4]\n"
-	"\tstr r1, [sp, #0]\n"
-	"\tmov r7, sp\n"
-	"\tbl %2\n"
-	/* Old sp is returned via r0 */
-	"\tmov sp, r0\n"
-	"\tpop {r4-r11,lr}\n"
-	"\tvpop {d8-d15}\n"
-	:
-	: "r" (unw_context), "r" (coro_ctx), "i" (unw_getcontext_f)
-	: "lr", "r0", "r1", "ip"
-	);
-
+	: "r" (bt), "r" (fiber), "r" (&fiber->ctx),
+	  "i" (backtrace_collect_curr_stk)
+	: "rdi", "rsi", "rdx", "rax", "memory");
 #elif __aarch64__
 __asm__ volatile(
-	/* Save current context */
-	"\tsub x1, sp, #8 * 20\n"
-	"\tstp x19, x20, [x1, #16 * 0]\n"
-	"\tstp x21, x22, [x1, #16 * 1]\n"
-	"\tstp x23, x24, [x1, #16 * 2]\n"
-	"\tstp x25, x26, [x1, #16 * 3]\n"
-	"\tstp x27, x28, [x1, #16 * 4]\n"
-	"\tstp x29, x30, [x1, #16 * 5]\n"
-	"\tstp d8,  d9,  [x1, #16 * 6]\n"
-	"\tstp d10, d11, [x1, #16 * 7]\n"
-	"\tstp d12, d13, [x1, #16 * 8]\n"
-	"\tstp d14, d15, [x1, #16 * 9]\n"
-	/* Restore target context */
-	"\tldr x2, [%1]\n"
-	"\tldp x19, x20, [x2, #16 * 0]\n"
-	"\tldp x21, x22, [x2, #16 * 1]\n"
-	"\tldp x23, x24, [x2, #16 * 2]\n"
-	"\tldp x25, x26, [x2, #16 * 3]\n"
-	"\tldp x27, x28, [x2, #16 * 4]\n"
-	"\tldp x29, x30, [x2, #16 * 5]\n"
-	"\tldp d8,  d9,  [x2, #16 * 6]\n"
-	"\tldp d10, d11, [x2, #16 * 7]\n"
-	"\tldp d12, d13, [x2, #16 * 8]\n"
-	"\tldp d14, d15, [x2, #16 * 9]\n"
-	"\tmov sp, x2\n"
-	/* Setup fisrst arg */
+	/* Setup first arg */
 	"\tmov x0, %0\n"
+	/* Setup second arg */
+	"\tmov x1, %1\n"
+	/* Save current context */
+	"\tsub x2, sp, #8 * 20\n"
+	"\tstp x19, x20, [x2, #16 * 0]\n"
+	"\tstp x21, x22, [x2, #16 * 1]\n"
+	"\tstp x23, x24, [x2, #16 * 2]\n"
+	"\tstp x25, x26, [x2, #16 * 3]\n"
+	"\tstp x27, x28, [x2, #16 * 4]\n"
+	"\tstp x29, x30, [x2, #16 * 5]\n"
+	"\tstp d8,  d9,  [x2, #16 * 6]\n"
+	"\tstp d10, d11, [x2, #16 * 7]\n"
+	"\tstp d12, d13, [x2, #16 * 8]\n"
+	"\tstp d14, d15, [x2, #16 * 9]\n"
+	/* Restore target context */
+	"\tldr x3, [%2]\n"
+	"\tldp x19, x20, [x3, #16 * 0]\n"
+	"\tldp x21, x22, [x3, #16 * 1]\n"
+	"\tldp x23, x24, [x3, #16 * 2]\n"
+	"\tldp x25, x26, [x3, #16 * 3]\n"
+	"\tldp x27, x28, [x3, #16 * 4]\n"
+	"\tldp x29, x30, [x3, #16 * 5]\n"
+	"\tldp d8,  d9,  [x3, #16 * 6]\n"
+	"\tldp d10, d11, [x3, #16 * 7]\n"
+	"\tldp d12, d13, [x3, #16 * 8]\n"
+	"\tldp d14, d15, [x3, #16 * 9]\n"
+	"\tmov sp, x3\n"
 	".cfi_remember_state\n"
 	".cfi_def_cfa sp, 16 * 10\n"
 	".cfi_offset x29, -16 * 5\n"
 	".cfi_offset x30, -16 * 5 + 8\n"
-	"\tbl %2\n"
+	"\tbl %3\n"
 	".cfi_restore_state\n"
 	/* Restore context (old sp in x0) */
 	"\tldp x19, x20, [x0, #16 * 0]\n"
@@ -376,78 +492,93 @@ __asm__ volatile(
 	"\tldp d14, d15, [x0, #16 * 9]\n"
 	"\tadd sp, x0, #8 * 20\n"
 	:
-	: "r" (unw_context), "r" (coro_ctx), "S" (unw_getcontext_f)
-	: /*"lr", "r0", "r1", "ip" */
-	 "x0", "x1", "x2", "x30"
-	);
+	: "r" (bt), "r" (fiber), "r" (&fiber->ctx),
+	  "S" (backtrace_collect_curr_stk)
+	: "x0", "x1", "x2", "x3", "x30", "memory");
 #endif
 }
 
-/**
- * Call `cb' callback for each `coro_ctx' contained frame or the current
- * executed coroutine if `coro_ctx' is NULL. A coro_context is a structure
- * created on each coroutine yield to store execution context so for an
- * on-CPU coroutine there is no valid coro_context could be defined and
- * NULL is passed.
- */
 void
-backtrace_foreach(backtrace_cb cb, coro_context *coro_ctx, void *cb_ctx)
+backtrace_foreach(struct backtrace *bt)
 {
-	unw_cursor_t unw_cur;
-	unw_context_t unw_ctx_bt;
-	if (coro_ctx == NULL) {
-		/*
-		 * Current executing coroutine and simple unw_getcontext
-		 * should function.
-		 */
-		unw_getcontext(&unw_ctx_bt);
-	} else {
-		/*
-		 * Execution context is stored in the coro_ctx
-		 * so use special context-switching handler to
-		 * capture an unwind context.
-		 */
-		coro_unwcontext(&unw_ctx_bt, coro_ctx);
-	}
-	unw_init_local(&unw_cur, &unw_ctx_bt);
-	int frame_no = 0;
-	unw_word_t sp = 0, old_sp = 0, ip, offset;
-	int unw_status, demangle_status;
 	char *demangle_buf = NULL;
 	size_t demangle_buf_len = 0;
 
-	while ((unw_status = unw_step(&unw_cur)) > 0) {
-		const char *proc;
-		old_sp = sp;
-		unw_get_reg(&unw_cur, UNW_REG_IP, &ip);
-		unw_get_reg(&unw_cur, UNW_REG_SP, &sp);
-		if (sp == old_sp) {
-			say_debug("unwinding error: previous frame "
-				  "identical to this frame (corrupt stack?)");
-			goto out;
+	int frame_no = 0;
+	const struct backtrace_frame *frame = bt->frames;
+	const struct backtrace_frame *end_frame = bt->frames + bt->frames_cnt;
+	for (; frame != end_frame; ++frame) {
+		switch (frame->type) {
+		case BACKTRACE_FRAME_TYPE_LUA:
+			fiber_backtrace_foreach_lua_frame_cb(frame->proc_name,
+							     frame->src_name,
+							     frame->line, bt);
+			break;
+		case BACKTRACE_FRAME_TYPE_C: {
+			unw_word_t offs;
+			const char *proc_name = NULL;
+			if (backtrace_resolve_from_ip((unw_word_t)frame->ip,
+						      &proc_name, &offs) != 0) {
+				goto out;
+			}
+			if (proc_name != NULL) {
+				int status;
+				char *demangled_name =
+					abi::__cxa_demangle(proc_name,
+							    demangle_buf,
+							    &demangle_buf_len,
+							    &status);
+				if (status != 0 && status != -2) {
+					say_error("unwinding error: "
+						  "__cxa_demangle failed with "
+						  "status: %d", status);
+					goto out;
+				}
+				if (demangled_name != NULL) {
+					demangle_buf = demangled_name;
+					proc_name = demangled_name;
+				}
+			}
+			fiber_backtrace_foreach_c_frame_cb(frame_no++,
+							   frame->ip, proc_name,
+							   offs, bt);
+			break;
 		}
-		proc = get_proc_name(&unw_cur, &offset, false);
-
-		char *cxxname = abi::__cxa_demangle(proc, demangle_buf,
-						    &demangle_buf_len,
-						    &demangle_status);
-		if (cxxname != NULL)
-			demangle_buf = cxxname;
-		if (frame_no > 0 &&
-		    (cb(frame_no - 1, (void *)ip, cxxname != NULL ? cxxname : proc,
-			offset, cb_ctx) != 0))
-			goto out;
-		++frame_no;
+		default:
+			unreachable();
+		}
 	}
-#ifndef TARGET_OS_DARWIN
-	if (unw_status != 0)
-		say_debug("unwinding error: %s", unw_strerror(unw_status));
-#else
-	if (unw_status != 0)
-		say_debug("unwinding error: %i", unw_status);
-#endif
 out:
 	free(demangle_buf);
+}
+
+void
+backtrace_append_c_frame(struct backtrace *bt, void *rip)
+{
+	if (bt->frames_cnt < BACKTRACE_FRAMES_CNT_MAX) {
+		struct backtrace_frame *frame = bt->frames + bt->frames_cnt;
+		frame->type = BACKTRACE_FRAME_TYPE_C;
+		frame->ip = rip;
+		++bt->frames_cnt;
+	}
+}
+
+void
+backtrace_append_lua_frame(struct backtrace *bt, const char *proc_name,
+			   const char *src_name, int line_no)
+{
+	if (bt->frames_cnt < BACKTRACE_FRAMES_CNT_MAX) {
+		struct backtrace_frame *frame = bt->frames + bt->frames_cnt;
+		frame->type = BACKTRACE_FRAME_TYPE_LUA;
+		frame->line = line_no;
+		strncpy(frame->proc_name, proc_name,
+			BACKTRACE_LUA_LEN_MAX - 1);
+		frame->proc_name[BACKTRACE_LUA_LEN_MAX - 1] = '\0';
+		strncpy(frame->src_name, src_name,
+			BACKTRACE_LUA_LEN_MAX - 1);
+		frame->src_name[BACKTRACE_LUA_LEN_MAX - 1] = '\0';
+		++bt->frames_cnt;
+	}
 }
 
 void

--- a/src/lib/core/backtrace.cc
+++ b/src/lib/core/backtrace.cc
@@ -196,6 +196,9 @@ out:
  * @param stack pointer to preserve.
  * @retval preserved stack pointer.
  */
+#ifdef __x86_64__
+__attribute__ ((__force_align_arg_pointer__))
+#endif /* __x86_64__ */
 static void *
 unw_getcontext_f(unw_context_t *unw_context, void *stack)
 {
@@ -246,11 +249,11 @@ __asm__ volatile(
 	"\tmovq 40(%%rsp), %%rbp\n"
 	/* Set first arg and call */
 	"\tmovq %0, %%rdi\n"
-#ifdef TARGET_OS_DARWIN
-	"\tandq $0xfffffffffffffff0, %%rsp\n"
-#endif
+	".cfi_remember_state\n"
+	".cfi_def_cfa %%rsp, 8 * 7\n"
 	"\tleaq %P2(%%rip), %%rax\n"
 	"\tcall *%%rax\n"
+	".cfi_restore_state\n"
 	/* Restore old sp and context */
 	"\tmov %%rax, %%rsp\n"
 	"\tpopq %%r15\n"
@@ -354,7 +357,12 @@ __asm__ volatile(
 	"\tmov sp, x2\n"
 	/* Setup fisrst arg */
 	"\tmov x0, %0\n"
+	".cfi_remember_state\n"
+	".cfi_def_cfa sp, 16 * 10\n"
+	".cfi_offset x29, -16 * 5\n"
+	".cfi_offset x30, -16 * 5 + 8\n"
 	"\tbl %2\n"
+	".cfi_restore_state\n"
 	/* Restore context (old sp in x0) */
 	"\tldp x19, x20, [x0, #16 * 0]\n"
 	"\tldp x21, x22, [x0, #16 * 1]\n"

--- a/src/lib/core/backtrace.cc
+++ b/src/lib/core/backtrace.cc
@@ -582,6 +582,15 @@ backtrace_append_lua_frame(struct backtrace *bt, const char *proc_name,
 }
 
 void
+backtrace_cat(struct backtrace *to, const struct backtrace *add) {
+	int additional_frames = MIN(BACKTRACE_FRAMES_CNT_MAX - to->frames_cnt,
+				    add->frames_cnt);
+	memcpy(to->frames + to->frames_cnt, add->frames,
+	       sizeof(to->frames[0]) * additional_frames);
+	to->frames_cnt += additional_frames;
+}
+
+void
 print_backtrace(void)
 {
 	char *start = (char *)static_alloc(SMALL_STATIC_SIZE);

--- a/src/lib/core/backtrace.h
+++ b/src/lib/core/backtrace.h
@@ -138,6 +138,12 @@ void
 backtrace_append_lua_frame(struct backtrace *bt, const char *proc_name,
 			   const char *src_name, int line_no);
 
+/*
+ * Append frames from 'add' to the end of 'to'.
+ */
+void
+backtrace_cat(struct backtrace *to, const struct backtrace *add);
+
 #endif /* ENABLE_BACKTRACE */
 
 #if defined(__cplusplus)

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -45,6 +45,10 @@
 
 extern void cord_on_yield(void);
 
+#ifdef ENABLE_BACKTRACE
+#include "backtrace.h"
+#endif /* ENABLE_BACKTRACE */
+
 #if ENABLE_FIBER_TOP
 #include <x86intrin.h> /* __rdtscp() */
 
@@ -214,6 +218,10 @@ fiber_mprotect(void *addr, size_t len, int prot)
 #if ENABLE_FIBER_TOP
 static __thread bool fiber_top_enabled = false;
 #endif /* ENABLE_FIBER_TOP */
+
+#ifdef ENABLE_BACKTRACE
+static __thread bool fiber_parent_backtrace_enabled = false;
+#endif /* ENABLE_BACKTRACE */
 
 /**
  * An action performed each time a context switch happens.
@@ -1265,6 +1273,19 @@ fiber_new_ex(const char *name, const struct fiber_attr *fiber_attr,
 	fiber_set_name(fiber, name);
 	register_fid(fiber);
 	fiber->csw = 0;
+#ifdef ENABLE_BACKTRACE
+	if (fiber_parent_backtrace_enabled) {
+		struct fiber *parent = fiber();
+		fiber->parent_bt =
+			region_alloc(&fiber->gc, sizeof(*fiber->parent_bt));
+		if (fiber->parent_bt != NULL) {
+			backtrace_collect(fiber->parent_bt, parent);
+			if (parent->parent_bt != NULL)
+				backtrace_cat(fiber->parent_bt,
+					      parent->parent_bt);
+		}
+	}
+#endif /* ENABLE_BACKTRACE */
 
 	cord->next_fid++;
 	assert(cord->next_fid > FIBER_ID_MAX_RESERVED);
@@ -1409,6 +1430,26 @@ fiber_top_disable(void)
 	}
 }
 #endif /* ENABLE_FIBER_TOP */
+
+#ifdef ENABLE_BACKTRACE
+bool
+fiber_parent_backtrace_is_enabled(void)
+{
+	return fiber_parent_backtrace_enabled;
+}
+
+void
+fiber_parent_backtrace_enable(void)
+{
+	fiber_parent_backtrace_enabled = true;
+}
+
+void
+fiber_parent_backtrace_disable(void)
+{
+	fiber_parent_backtrace_enabled = false;
+}
+#endif /* ENABLE_BACKTRACE */
 
 size_t
 box_region_used(void)

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -533,6 +533,7 @@ struct txn;
 struct credentials;
 struct lua_State;
 struct ipc_wait_pad;
+struct backtrace;
 
 struct fiber {
 	coro_context ctx;
@@ -662,6 +663,10 @@ struct fiber {
 	 */
 	char *name;
 	char inline_name[FIBER_NAME_INLINE];
+#ifdef ENABLE_BACKTRACE
+	/* Fiber parent's backtrace allocated on the 'gc' region. */
+	struct backtrace *parent_bt;
+#endif /* ENABLE_BACKTRACE */
 };
 
 /** Invoke on_stop triggers and delete them. */
@@ -876,6 +881,17 @@ fiber_top_enable(void);
 void
 fiber_top_disable(void);
 #endif /* ENABLE_FIBER_TOP */
+
+#ifdef ENABLE_BACKTRACE
+bool
+fiber_parent_backtrace_is_enabled(void);
+
+void
+fiber_parent_backtrace_enable(void);
+
+void
+fiber_parent_backtrace_disable(void);
+#endif /* ENABLE_BACKTRACE */
 
 /** Useful for C unit tests */
 static inline int

--- a/src/lua/fiber.c
+++ b/src/lua/fiber.c
@@ -205,6 +205,9 @@ lbox_fiber_statof_map(struct fiber *f, void *cb_ctx, bool backtrace)
 		lua_newtable(L);
 		struct backtrace bt;
 		backtrace_collect(&bt, f);
+		if (fiber_parent_backtrace_is_enabled() &&
+		    f->parent_bt != NULL)
+			backtrace_cat(&bt, f->parent_bt);
 		bt.L = L;
 		bt.total_frame_cnt = 0;
 		backtrace_foreach(&bt);
@@ -401,6 +404,22 @@ lbox_do_backtrace(struct lua_State *L)
 		lua_pop(L, 1);
 	}
 	return true;
+}
+
+static int
+lbox_fiber_parent_backtrace_enable(struct lua_State *L)
+{
+	(void) L;
+	fiber_parent_backtrace_enable();
+	return 0;
+}
+
+static int
+lbox_fiber_parent_backtrace_disable(struct lua_State *L)
+{
+	(void) L;
+	fiber_parent_backtrace_disable();
+	return 0;
 }
 #endif /* ENABLE_BACKTRACE */
 
@@ -879,6 +898,10 @@ static const struct luaL_Reg fiberlib[] = {
 	{"top_enable", lbox_fiber_top_enable},
 	{"top_disable", lbox_fiber_top_disable},
 #endif /* ENABLE_FIBER_TOP */
+#ifdef ENABLE_BACKTRACE
+	{"parent_backtrace_enable", lbox_fiber_parent_backtrace_enable},
+	{"parent_backtrace_disable", lbox_fiber_parent_backtrace_disable},
+#endif /* ENABLE_BACKTRACE */
 	{"sleep", lbox_fiber_sleep},
 	{"yield", lbox_fiber_yield},
 	{"self", lbox_fiber_self},

--- a/src/lua/fiber.h
+++ b/src/lua/fiber.h
@@ -34,7 +34,22 @@
 extern "C" {
 #endif /* defined(__cplusplus) */
 
+#include "trivia/config.h"
+
+#ifdef ENABLE_BACKTRACE
+#include "backtrace.h"
+
+/*
+ * This is the declaration of the Lua stack entry function: it does not exactly
+ * `lj_BC_FUNCC`'s signature and its only aim is to provide the `lj_BC_FUNCC`
+ * symbol's address to the backtrace subsystem for detecting Lua frames.
+ */
+void
+lj_BC_FUNCC(void);
+#endif /* ENABLE_BACKTRACE */
+
 struct lua_State;
+struct backtrace;
 
 /**
 * Initialize box.fiber system
@@ -44,6 +59,22 @@ tarantool_lua_fiber_init(struct lua_State *L);
 
 void
 luaL_testcancel(struct lua_State *L);
+
+#ifdef ENABLE_BACKTRACE
+void
+fiber_backtrace_collect_lua_frames_foreach(struct lua_State *L,
+					   struct backtrace *bt);
+
+void
+fiber_backtrace_foreach_c_frame_cb(int frame_no, void *frame_ip,
+				   const char *proc_name, size_t offs,
+				   struct backtrace *bt);
+
+void
+fiber_backtrace_foreach_lua_frame_cb(const char *proc_name,
+				     const char *src_name, int line_no,
+				     struct backtrace *bt);
+#endif /* ENABLE_BACKTRACE */
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -724,6 +724,9 @@ tarantool_lua_init(const char *tarantool_bin, int argc, char **argv)
 	rl_catch_signals = 0;
 	rl_catch_sigwinch = 0;
 #endif
+#ifdef ENABLE_BACKTRACE
+	backtrace_init();
+#endif
 
 	lua_getfield(L, LUA_REGISTRYINDEX, "_LOADED");
 	for (const char **s = lua_modules; *s; s += 2) {

--- a/test/app-luatest/fiber_parent_backtrace_test.lua
+++ b/test/app-luatest/fiber_parent_backtrace_test.lua
@@ -1,0 +1,75 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all = function()
+    g.dflt = server:new({alias = 'dflt'})
+    g.dflt:start()
+    g.dflt:exec(function()
+        local t = require('luatest')
+        local tarantool = require('tarantool')
+
+        local _, _, enable_bt = string.find(tarantool.build.options,
+                                            "-DENABLE_BACKTRACE=(%a+)")
+        local bt_enabled = enable_bt == "ON" or enable_bt == "TRUE"
+        t.skip_if(not bt_enabled, "requires backtrace feature")
+    end)
+end
+
+g.after_all = function()
+    g.dflt:drop()
+end
+
+g.test_fiber_parent_backtrace = function()
+    g.dflt:exec(function()
+        local fiber = require('fiber')
+        local t = require('luatest')
+        local yaml = require('yaml')
+
+        local bt_frames_cnt
+        local bt_frames_str
+        local function fiber_child()
+            local fiber_info = fiber.info()[fiber.self():id()]
+            local bt = fiber_info.backtrace
+            t.fail_if(not bt, "nil backtrace table indicates unwinding error")
+            bt_frames_cnt = #bt
+            bt_frames_str = yaml.encode(bt)
+        end
+        local function fiber_parent()
+            fiber.create(fiber_child)
+        end
+        local function fiber_grandparent()
+            fiber.create(fiber_parent)
+        end
+
+        fiber_grandparent()
+        local bt_frames_cnt_dflt = bt_frames_cnt
+        t.assert_ge(bt_frames_cnt_dflt, 1)
+
+        -- Match `coro_init` or `coro_start`.
+        local coro_entry_fn_pattern = "coro_%a%a%a%a%a?"
+
+        fiber:parent_backtrace_enable()
+        fiber_grandparent()
+        local bt_frames_cnt_w_parent_bt = bt_frames_cnt
+        t.assert_ge(bt_frames_cnt_w_parent_bt, bt_frames_cnt_dflt)
+        t.assert_ge(bt_frames_cnt_w_parent_bt, 3)
+        local coro_entry_fn_matches = 0
+        for match in string.gmatch(bt_frames_str, coro_entry_fn_pattern) do
+            coro_entry_fn_matches = coro_entry_fn_matches + 1
+        end
+        t.assert_equals(coro_entry_fn_matches, 3)
+
+        fiber:parent_backtrace_disable()
+        fiber_grandparent()
+        local bt_frames_cnt_wo_parent_bt = bt_frames_cnt
+        t.assert_equals(bt_frames_cnt_wo_parent_bt, bt_frames_cnt_dflt,
+                        "parent backtrace is disabled by default")
+        coro_entry_fn_matches = 0
+        for match in string.gmatch(bt_frames_str, coro_entry_fn_pattern) do
+            coro_entry_fn_matches = coro_entry_fn_matches + 1
+        end
+        t.assert_equals(coro_entry_fn_matches, 1)
+    end)
+end

--- a/third_party/coro/coro.h
+++ b/third_party/coro/coro.h
@@ -420,4 +420,3 @@ void coro_destroy (coro_context *ctx);
 #endif
 
 #endif
-


### PR DESCRIPTION
With backtrace implementation reworked in 70e02430, we can now
efficiently collect unwinding information about parents at fiber
creation time:

* Add `backtrace_cat` helper for concatenating backtraces.
* Add 'parent_bt' field to `struct fiber` for storing fiber parent's
  backtrace.
* Add `fiber_parent_backtrace_enabled` and corresponding C/Lua toggles
  for controlling parent backtrace collection for newly created fibers.

Closes #4002

@TarantoolBot document
Title: new handles for fiber parent backtrace feature

Newly introduced `fiber.parent_backtrace_enable()` and
`fiber.parent_backtrace_disable()` toggle
collection of parent backtraces for newly created fibers (disabled by
default).