### PR TITLE
test-run: bump to new version

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -5,6 +5,7 @@ runs:
   steps:
     - run: |
         echo VARDIR=/tmp/tnt | tee -a $GITHUB_ENV
+        echo SERVER_START_TIMEOUT=290 | tee -a $GITHUB_ENV
         echo REPLICATION_SYNC_TIMEOUT=300 | tee -a $GITHUB_ENV
         echo TEST_TIMEOUT=310 | tee -a $GITHUB_ENV
         echo NO_OUTPUT_TIMEOUT=320 | tee -a $GITHUB_ENV

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -30,9 +30,7 @@ include_files = {
 
 exclude_files = {
     "build/**/*.lua",
-    "test-run/test/test-tarantool/*.test.lua",
-    "test-run/lib/checks/*",
-    "test-run/lib/luatest/*",
+    "test-run/**/*.lua",
     "test/app/*.test.lua",
     "test/box/*.test.lua",
     "test/engine/*.test.lua",


### PR DESCRIPTION
Bump test-run to new version with the following improvements:
- Add timeout for starting tarantool server (tarantool/test-run#302)
- Kill hanging processes of not started servers (tarantool/test-run#332)
- Rerun all failed tests, not only marked as fragile (tarantool/test-run#329)

Also, set tarantool server start timeout to 290 secs and exclude test-run
tests from validation by luacheck.

NO_DOC=testing
NO_TEST=testing
NO_CHANGELOG=testing