### PR TITLE
Spelling errors in module.h

### DIFF
--- a/src/box/box.h
+++ b/src/box/box.h
@@ -427,7 +427,7 @@ box_delete(uint32_t space_id, uint32_t index_id, const char *key,
  * \param index_id index identifier
  * \param key encoded key in MsgPack Array format ([part1, part2, ...]).
  * \param key_end the end of encoded \a key.
- * \param ops encoded operations in MsgPack Arrat format, e.g.
+ * \param ops encoded operations in MsgPack Array format, e.g.
  * [ [ '=', fieldno,  value ],  ['!', 2, 'xxx'] ]
  * \param ops_end the end of encoded \a ops
  * \param index_base 0 if fieldnos in update operations are zero-based
@@ -448,7 +448,7 @@ box_update(uint32_t space_id, uint32_t index_id, const char *key,
  *
  * \param space_id space identifier
  * \param index_id index identifier
- * \param ops encoded operations in MsgPack Arrat format, e.g.
+ * \param ops encoded operations in MsgPack Array format, e.g.
  * [ [ '=', fieldno,  value ],  ['!', 2, 'xxx'] ]
  * \param ops_end the end of encoded \a ops
  * \param tuple encoded tuple in MsgPack Array format ([ field1, field2, ...])

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -72,7 +72,7 @@ box_iterator_t *
 box_index_iterator(uint32_t space_id, uint32_t index_id, int type,
 		   const char *key, const char *key_end);
 /**
- * Retrive the next item from the \a iterator.
+ * Retrieve the next item from the \a iterator.
  *
  * \param iterator an iterator returned by box_index_iterator().
  * \param[out] result a tuple or NULL if there is no more data.
@@ -85,7 +85,7 @@ box_iterator_next(box_iterator_t *iterator, box_tuple_t **result);
 /**
  * Destroy and deallocate iterator.
  *
- * \param iterator an interator returned by box_index_iterator()
+ * \param iterator an iterator returned by box_index_iterator()
  */
 void
 box_iterator_free(box_iterator_t *iterator);

--- a/src/box/key_def.h
+++ b/src/box/key_def.h
@@ -611,7 +611,7 @@ box_key_def_validate_key(const box_key_def_t *key_def, const char *key,
  * respect to nullability.
  *
  * Imposes the same parts count in @a key as in @a key_def.
- * Absense of trailing key parts fails the check.
+ * Absence of trailing key parts fails the check.
  *
  * Note: nil is accepted for nullable fields, but only for them.
  *

--- a/src/box/lua/tuple.h
+++ b/src/box/lua/tuple.h
@@ -103,7 +103,7 @@ luaT_tuple_encode(struct lua_State *L, int idx, size_t *tuple_len_ptr);
  * tuple.
  *
  * The new tuple is referenced in the same way as one created by
- * <box_tuple_new>(). There are two possible usage scenarious:
+ * <box_tuple_new>(). There are two possible usage scenarios:
  *
  * 1. A short living tuple may not be referenced explicitly and
  *    will be collected automatically at the next module API call

--- a/src/box/tuple.h
+++ b/src/box/tuple.h
@@ -137,7 +137,7 @@ size_t
 box_tuple_bsize(box_tuple_t *tuple);
 
 /**
- * Dump raw MsgPack data to the memory byffer \a buf of size \a size.
+ * Dump raw MsgPack data to the memory buffer \a buf of size \a size.
  *
  * Store tuple fields in the memory buffer.
  * \retval -1 on error.
@@ -256,7 +256,7 @@ box_tuple_seek(box_tuple_iterator_t *it, uint32_t fieldno);
  * \param it tuple iterator.
  * \retval NULL if there are no more fields.
  * \retval MsgPack otherwise
- * \pre box_tuple_position(it) is zerod-based id of returned field
+ * \pre box_tuple_position(it) is zero-based id of returned field
  * \post box_tuple_position(it) == box_tuple_field_count(tuple) if returned
  * value is NULL.
  */
@@ -988,7 +988,7 @@ tuple_multikey_count(struct tuple *tuple, struct key_def *key_def)
 }
 
 /**
- * @brief Tuple Interator
+ * @brief Tuple iterator
  */
 struct tuple_iterator {
 	/** @cond false **/

--- a/src/lib/core/coio.h
+++ b/src/lib/core/coio.h
@@ -171,7 +171,7 @@ enum {
  * \param fd - non-blocking socket file description
  * \param events - requested events to wait.
  * Combination of TNT_IO_READ | TNT_IO_WRITE bit flags.
- * \param timeoout - timeout in seconds.
+ * \param timeout - timeout in seconds.
  * \retval 0 - timeout
  * \retval >0 - returned events. Combination of TNT_IO_READ | TNT_IO_WRITE
  * bit flags.

--- a/src/lua/utils.h
+++ b/src/lua/utils.h
@@ -242,7 +242,7 @@ LUA_API void
 luaL_pushint64(struct lua_State *L, int64_t val);
 
 /**
- * Checks whether the argument idx is a uint64 or a convertable string and
+ * Checks whether the argument idx is a uint64 or a convertible string and
  * returns this number.
  * \throws error if the argument can't be converted.
  */
@@ -250,7 +250,7 @@ LUA_API uint64_t
 luaL_checkuint64(struct lua_State *L, int idx);
 
 /**
- * Checks whether the argument idx is a int64 or a convertable string and
+ * Checks whether the argument idx is a int64 or a convertible string and
  * returns this number.
  * \throws error if the argument can't be converted.
  */
@@ -258,7 +258,7 @@ LUA_API int64_t
 luaL_checkint64(struct lua_State *L, int idx);
 
 /**
- * Checks whether the argument idx is a uint64 or a convertable string and
+ * Checks whether the argument idx is a uint64 or a convertible string and
  * returns this number.
  * \return the converted number or 0 of argument can't be converted.
  */
@@ -266,7 +266,7 @@ LUA_API uint64_t
 luaL_touint64(struct lua_State *L, int idx);
 
 /**
- * Checks whether the argument idx is a int64 or a convertable string and
+ * Checks whether the argument idx is a int64 or a convertible string and
  * returns this number.
  * \return the converted number or 0 of argument can't be converted.
  */

--- a/src/on_shutdown.h
+++ b/src/on_shutdown.h
@@ -44,7 +44,7 @@ extern "C" {
  *            case this argument is NULL, function finds
  *            and destroys old on_shutdown handler.
  * @param[in] old_handler Old on_shutdown handler.
- * @retval return 0 if success othrewise return -1 and sets
+ * @retval return 0 if success otherwise return -1 and sets
  *                  errno. There are three cases when
  *                  function fails:
  *                  - both old_handler and new_handler are equal to
@@ -55,7 +55,7 @@ extern "C" {
  *                    return NULL (errno sets by malloc to ENOMEM).
  */
 API_EXPORT int
-box_on_shutdown(void *arg, int (*new_hadler)(void *),
+box_on_shutdown(void *arg, int (*new_handler)(void *),
 		int (*old_handler)(void *));
 
 /** \endcond public */

--- a/src/trivia/util.h
+++ b/src/trivia/util.h
@@ -129,7 +129,7 @@ strnindex(const char **haystack, const char *needle, uint32_t len, uint32_t hmax
 /** \cond public */
 
 /**
- * Feature test macroses for -std=c11 / -std=c++11
+ * Feature test macros for -std=c11 / -std=c++11
  *
  * Sic: clang aims to be gcc-compatible and thus defines __GNUC__
  */
@@ -229,7 +229,7 @@ strnindex(const char **haystack, const char *needle, uint32_t len, uint32_t hmax
  * specifiers to modify the alignment requirement of the object being
  * declared.
  *
- * Sic: alignas() doesn't work on anonymous strucrs on gcc < 4.9
+ * Sic: alignas() doesn't work on anonymous structs on gcc < 4.9
  *
  * \example struct obuf { int a; int b; alignas(16) int c; };
  */
@@ -267,7 +267,7 @@ strnindex(const char **haystack, const char *needle, uint32_t len, uint32_t hmax
 /** Built-ins }}} */
 
 /**
- * Compiler-indepedent function attributes.
+ * Compiler-independent function attributes.
  *
  * \see https://gcc.gnu.org/onlinedocs/gcc/Type-Attributes.html
  * \see http://clang.llvm.org/docs/AttributeReference.html#function-attributes


### PR DESCRIPTION
Some fixes have been made according to issue [#6061](https://github.com/tarantool/tarantool/issues/6061):

scenarious is changed to scenarios in `src/box/lua/tuple.h`
Arrat is changed to Array in `src/box/box.h`
Retrive is changed to Retrieve、interator is changed to iterator in `src/box/index.h`
byffer is changed to buffer、zerod-based is changed to zero-based、Interator is changed to iterator in  `src/box/tuple.h`
timeoout  is changed to timeout in `src/lib/core/coio.h`
convertable  is changed to  convertible in `src/lua/utils.h`
macroses is changed to macros、strucrs is changed to structs、indepedent is changed to independent in `src/trivia/util.h`
othrewise is changed to otherwise、hadler is changed to handler in `src/on_shutdown.h`
Absense  is changed to Absence  in ` src/box/key_def.h`

Closes [#6061](https://github.com/tarantool/tarantool/issues/6061)