### PR TITLE
[1.10] Backport CI improvements

### DIFF
--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -36,9 +36,11 @@ concurrency:
 
 jobs:
   centos_7:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -36,9 +36,11 @@ concurrency:
 
 jobs:
   centos_8:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,9 +34,11 @@ concurrency:
 
 jobs:
   coverage:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -12,6 +12,8 @@ env:
 
 jobs:
   coverity:
+    if: github.repository == 'tarantool/tarantool'
+
     runs-on: ubuntu-18.04
 
     # Image built by .gitlab.mk instructions and targets from .travis.mk.

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,8 +1,6 @@
 name: coverity
 
 on:
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
   schedule:
     - cron:  '0 4 * * 6'

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -36,9 +36,11 @@ concurrency:
 
 jobs:
   debian_10:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -36,9 +36,11 @@ concurrency:
 
 jobs:
   debian_11:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -36,9 +36,11 @@ concurrency:
 
 jobs:
   debian_9:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -2,8 +2,9 @@ name: debug
 
 on:
   push:
-    branches-ignore:
-      - '**-notest'
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
     tags:
       - '**'
   pull_request:
@@ -31,11 +32,12 @@ concurrency:
 
 jobs:
   debug:
-    # Run on pull request only if the 'notest' label is unset and this is
-    # an external PR (internal PRs trigger a run on push).
-    if: github.event_name != 'pull_request' ||
-      ( !contains(github.event.pull_request.labels.*.name, 'notest') &&
-      github.event.pull_request.head.repo.full_name != github.repository )
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'notest' label is not set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          ( github.event_name == 'pull_request' &&
+            !contains(github.event.pull_request.labels.*.name, 'notest') ) )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -39,9 +39,11 @@ env:
 
 jobs:
   default_gcc_centos_7:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/fedora_30.yml
+++ b/.github/workflows/fedora_30.yml
@@ -36,9 +36,11 @@ concurrency:
 
 jobs:
   fedora_30:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/fedora_30.yml
+++ b/.github/workflows/fedora_30.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/fedora_30.yml
+++ b/.github/workflows/fedora_30.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/fedora_31.yml
+++ b/.github/workflows/fedora_31.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/fedora_31.yml
+++ b/.github/workflows/fedora_31.yml
@@ -36,9 +36,11 @@ concurrency:
 
 jobs:
   fedora_31:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/fedora_31.yml
+++ b/.github/workflows/fedora_31.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/fedora_32.yml
+++ b/.github/workflows/fedora_32.yml
@@ -36,9 +36,11 @@ concurrency:
 
 jobs:
   fedora_32:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/fedora_32.yml
+++ b/.github/workflows/fedora_32.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/fedora_32.yml
+++ b/.github/workflows/fedora_32.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/fedora_33.yml
+++ b/.github/workflows/fedora_33.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/fedora_33.yml
+++ b/.github/workflows/fedora_33.yml
@@ -36,9 +36,11 @@ concurrency:
 
 jobs:
   fedora_33:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/fedora_33.yml
+++ b/.github/workflows/fedora_33.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -36,9 +36,11 @@ concurrency:
 
 jobs:
   fedora_34:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/fedora_35.yml
+++ b/.github/workflows/fedora_35.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/fedora_35.yml
+++ b/.github/workflows/fedora_35.yml
@@ -36,9 +36,11 @@ concurrency:
 
 jobs:
   fedora_35:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/fedora_35.yml
+++ b/.github/workflows/fedora_35.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/freebsd-12.yml
+++ b/.github/workflows/freebsd-12.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/freebsd-12.yml
+++ b/.github/workflows/freebsd-12.yml
@@ -7,6 +7,26 @@ on:
     types: [backend_automation]
   workflow_dispatch:
 
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch (1.10,
+  # 2.8, etc.), and tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    github.ref == 'refs/heads/1.10' ||
+    startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
 jobs:
   freebsd-12:
     # We want to run on external PRs, but not on our own internal PRs

--- a/.github/workflows/freebsd-12.yml
+++ b/.github/workflows/freebsd-12.yml
@@ -36,9 +36,11 @@ concurrency:
 
 jobs:
   freebsd-12:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: freebsd-12-mcs
 

--- a/.github/workflows/freebsd-12.yml
+++ b/.github/workflows/freebsd-12.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/freebsd-12.yml
+++ b/.github/workflows/freebsd-12.yml
@@ -2,7 +2,14 @@ name: freebsd-12
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -29,11 +36,9 @@ concurrency:
 
 jobs:
   freebsd-12:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: freebsd-12-mcs
 

--- a/.github/workflows/freebsd-13.yml
+++ b/.github/workflows/freebsd-13.yml
@@ -7,6 +7,26 @@ on:
     types: [backend_automation]
   workflow_dispatch:
 
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch (1.10,
+  # 2.8, etc.), and tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    github.ref == 'refs/heads/1.10' ||
+    startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
 jobs:
   freebsd-13:
     # We want to run on external PRs, but not on our own internal PRs

--- a/.github/workflows/freebsd-13.yml
+++ b/.github/workflows/freebsd-13.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/freebsd-13.yml
+++ b/.github/workflows/freebsd-13.yml
@@ -36,9 +36,11 @@ concurrency:
 
 jobs:
   freebsd-13:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: freebsd-13-mcs
 

--- a/.github/workflows/freebsd-13.yml
+++ b/.github/workflows/freebsd-13.yml
@@ -2,7 +2,14 @@ name: freebsd-13
 
 on:
   push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+      - '**-full-ci'
+    tags:
+      - '**'
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   repository_dispatch:
     types: [backend_automation]
   workflow_dispatch:
@@ -29,11 +36,9 @@ concurrency:
 
 jobs:
   freebsd-13:
-    # We want to run on external PRs, but not on our own internal PRs
-    # as they'll be run by the push to the branch.
-    if: ( github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ) &&
-        ! endsWith(github.ref, '-notest')
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     runs-on: freebsd-13-mcs
 

--- a/.github/workflows/freebsd-13.yml
+++ b/.github/workflows/freebsd-13.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'  # release branches
-      - '**-full-ci'
     tags:
       - '*'
   pull_request:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,9 +34,11 @@ concurrency:
 
 jobs:
   tarantool:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     uses: tarantool/tarantool/.github/workflows/reusable_build.yml@master
     with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,12 +5,39 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'  # release branches
+      - '**-full-ci'
     tags:
       - '*'
+  pull_request:
+    types: [ opened, reopened, synchronize, labeled ]
   workflow_dispatch:
+
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch (1.10,
+  # 2.8, etc.), and tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    github.ref == 'refs/heads/1.10' ||
+    startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
 
 jobs:
   tarantool:
+    # Run on pull request only if the 'full-ci' label is set.
+    if: github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
+
     uses: tarantool/tarantool/.github/workflows/reusable_build.yml@master
     with:
       ref: ${{ github.sha }}

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -36,9 +36,11 @@ concurrency:
 
 jobs:
   opensuse_15_1:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -36,9 +36,11 @@ concurrency:
 
 jobs:
   opensuse_15_2:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/osx_11.yml
+++ b/.github/workflows/osx_11.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/osx_11.yml
+++ b/.github/workflows/osx_11.yml
@@ -39,9 +39,11 @@ env:
 
 jobs:
   osx_11:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: macos-11
 

--- a/.github/workflows/osx_11.yml
+++ b/.github/workflows/osx_11.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/osx_11_lto.yml
+++ b/.github/workflows/osx_11_lto.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/osx_11_lto.yml
+++ b/.github/workflows/osx_11_lto.yml
@@ -39,9 +39,11 @@ env:
 
 jobs:
   osx_11_lto:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: macos-11
 

--- a/.github/workflows/osx_11_lto.yml
+++ b/.github/workflows/osx_11_lto.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/osx_12.yml
+++ b/.github/workflows/osx_12.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/osx_12.yml
+++ b/.github/workflows/osx_12.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/osx_12.yml
+++ b/.github/workflows/osx_12.yml
@@ -39,9 +39,11 @@ env:
 
 jobs:
   osx_12:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: macos-12
 

--- a/.github/workflows/perf_cbench.yml
+++ b/.github/workflows/perf_cbench.yml
@@ -12,10 +12,7 @@ on:
 
 jobs:
   perf_cbench:
-    if: github.event_name == 'push' ||
-        github.event_name == 'repository_dispatch' ||
-        github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'schedule'
+    if: github.repository == 'tarantool/tarantool'
 
     runs-on: perf-sh2
 

--- a/.github/workflows/perf_cbench.yml
+++ b/.github/workflows/perf_cbench.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - '*'
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
   schedule:
     - cron:  '0 */3 * * *'

--- a/.github/workflows/perf_linkbench_ssd.yml
+++ b/.github/workflows/perf_linkbench_ssd.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - '*'
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
   schedule:
     - cron:  '0 */3 * * *'

--- a/.github/workflows/perf_linkbench_ssd.yml
+++ b/.github/workflows/perf_linkbench_ssd.yml
@@ -12,10 +12,7 @@ on:
 
 jobs:
   perf_linkbench_ssd:
-    if: github.event_name == 'push' ||
-        github.event_name == 'repository_dispatch' ||
-        github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'schedule'
+    if: github.repository == 'tarantool/tarantool'
 
     runs-on: perf-sh9
 

--- a/.github/workflows/perf_nosqlbench_hash.yml
+++ b/.github/workflows/perf_nosqlbench_hash.yml
@@ -12,10 +12,7 @@ on:
 
 jobs:
   perf_nosqlbench_hash:
-    if: github.event_name == 'push' ||
-        github.event_name == 'repository_dispatch' ||
-        github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'schedule'
+    if: github.repository == 'tarantool/tarantool'
 
     runs-on: perf-sh1
 

--- a/.github/workflows/perf_nosqlbench_hash.yml
+++ b/.github/workflows/perf_nosqlbench_hash.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - '*'
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
   schedule:
     - cron:  '0 */3 * * *'

--- a/.github/workflows/perf_nosqlbench_tree.yml
+++ b/.github/workflows/perf_nosqlbench_tree.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - '*'
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
   schedule:
     - cron:  '0 */3 * * *'

--- a/.github/workflows/perf_nosqlbench_tree.yml
+++ b/.github/workflows/perf_nosqlbench_tree.yml
@@ -12,10 +12,7 @@ on:
 
 jobs:
   perf_nosqlbench_tree:
-    if: github.event_name == 'push' ||
-        github.event_name == 'repository_dispatch' ||
-        github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'schedule'
+    if: github.repository == 'tarantool/tarantool'
 
     runs-on: perf-sh1
 

--- a/.github/workflows/perf_ycsb_hash.yml
+++ b/.github/workflows/perf_ycsb_hash.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - '*'
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
   schedule:
     - cron:  '0 */3 * * *'

--- a/.github/workflows/perf_ycsb_hash.yml
+++ b/.github/workflows/perf_ycsb_hash.yml
@@ -12,10 +12,7 @@ on:
 
 jobs:
   perf_ycsb_hash:
-    if: github.event_name == 'push' ||
-        github.event_name == 'repository_dispatch' ||
-        github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'schedule'
+    if: github.repository == 'tarantool/tarantool'
 
     runs-on: perf-sh2
 

--- a/.github/workflows/perf_ycsb_tree.yml
+++ b/.github/workflows/perf_ycsb_tree.yml
@@ -12,10 +12,7 @@ on:
 
 jobs:
   perf_ycsb_tree:
-    if: github.event_name == 'push' ||
-        github.event_name == 'repository_dispatch' ||
-        github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'schedule'
+    if: github.repository == 'tarantool/tarantool'
 
     runs-on: perf-sh2
 

--- a/.github/workflows/perf_ycsb_tree.yml
+++ b/.github/workflows/perf_ycsb_tree.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - '*'
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
   schedule:
     - cron:  '0 */3 * * *'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,6 @@ on:
     tags:
       - '**'
   pull_request:
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,9 @@ name: release
 
 on:
   push:
-    branches-ignore:
-      - '**-notest'
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
     tags:
       - '**'
   pull_request:
@@ -36,11 +37,12 @@ env:
 
 jobs:
   release:
-    # Run on pull request only if the 'notest' label is unset and this is
-    # an external PR (internal PRs trigger a run on push).
-    if: github.event_name != 'pull_request' ||
-        ( ! contains(github.event.pull_request.labels.*.name, 'notest') &&
-          github.event.pull_request.head.repo.full_name != github.repository )
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'notest' label is not set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          ( github.event_name == 'pull_request' &&
+            !contains(github.event.pull_request.labels.*.name, 'notest') ) )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -39,9 +39,11 @@ env:
 
 jobs:
   release_asan_clang11:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -39,9 +39,11 @@ env:
 
 jobs:
   release_clang:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -39,9 +39,11 @@ env:
 
 jobs:
   release_lto:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -39,9 +39,11 @@ env:
 
 jobs:
   release_lto_clang11:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - '**'
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -13,6 +13,8 @@ env:
 
 jobs:
   source:
+    if: github.repository == 'tarantool/tarantool'
+
     runs-on: ubuntu-20.04-self-hosted
 
     steps:

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -39,9 +39,11 @@ env:
 
 jobs:
   static_build:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/static_docker_build.yml
+++ b/.github/workflows/static_docker_build.yml
@@ -39,9 +39,11 @@ env:
 
 jobs:
   static_docker_build:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/static_docker_build.yml
+++ b/.github/workflows/static_docker_build.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/static_docker_build.yml
+++ b/.github/workflows/static_docker_build.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -36,9 +36,11 @@ concurrency:
 
 jobs:
   ubuntu_16_04:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -36,9 +36,11 @@ concurrency:
 
 jobs:
   ubuntu_18_04:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -36,9 +36,11 @@ concurrency:
 
 jobs:
   ubuntu_20_04:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ubuntu_21_04.yml
+++ b/.github/workflows/ubuntu_21_04.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - '[0-9].[0-9]+'
-      - '**-full-ci'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/ubuntu_21_04.yml
+++ b/.github/workflows/ubuntu_21_04.yml
@@ -36,9 +36,11 @@ concurrency:
 
 jobs:
   ubuntu_21_04:
-    # Run on pull request only if the 'full-ci' label is set.
-    if: github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'full-ci')
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/ubuntu_21_04.yml
+++ b/.github/workflows/ubuntu_21_04.yml
@@ -9,8 +9,6 @@ on:
       - '**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  repository_dispatch:
-    types: [backend_automation]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
The following commits are added:
- ci: use 'concurrency' feature in freebsd workflows
- ci: run freebsd only on PRs with 'full-ci' label

The following commits are backported:
- ci: run 'integration.yml' WF in pre-commit testing
- ci: not run workflows in forks
- ci: remove logic for 'full-ci' branch suffix
- ci: remove unused 'repository_dispatch' trigger