### PR TITLE
Fix undefined reference to `set_sigint_cb` function

### DIFF
--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -11,5 +11,6 @@ include_directories(${PROJECT_SOURCE_DIR}/src/box)
 include_directories(${PROJECT_SOURCE_DIR}/third_party)
 include_directories(${EXTRA_CORE_INCLUDE_DIRS})
 
-add_executable(tuple.perftest tuple.cc)
+add_executable(tuple.perftest tuple.cc
+               ${PROJECT_SOURCE_DIR}/test/unit/box_test_utils.c)
 target_link_libraries(tuple.perftest core box tuple benchmark::benchmark)


### PR DESCRIPTION
We should link box_test_utils to tuple perf test to
prevent this error.

Follow up #2717

NO_CHANGELOG=build fix
NO_DOC=build fix
NO_TEST=build fix