### PR TITLE
say: move log_vsay to header

### DIFF
--- a/src/lib/core/say.c
+++ b/src/lib/core/say.c
@@ -77,11 +77,6 @@ say_format_syslog(struct log *log, char *buf, int len, int level,
 		  const char *filename, int line, const char *error,
 		  const char *format, va_list ap);
 
-/** A utility function to handle va_list from different varargs functions. */
-static inline int
-log_vsay(struct log *log, int level, const char *filename, int line,
-	 const char *error, const char *format, va_list ap);
-
 /** Default logger used before logging subsystem is initialized. */
 static struct log log_boot = {
 	.fd = STDERR_FILENO,
@@ -1232,7 +1227,7 @@ log_destroy(struct log *log)
 	fiber_cond_destroy(&log->rotate_cond);
 }
 
-static inline int
+int
 log_vsay(struct log *log, int level, const char *filename, int line,
 	 const char *error, const char *format, va_list ap)
 {
@@ -1263,16 +1258,5 @@ log_vsay(struct log *log, int level, const char *filename, int line,
 		unreachable();
 	}
 	errno = errsv; /* Preserve the errno. */
-	return total;
-}
-
-int
-log_say(struct log *log, int level, const char *filename, int line,
-	const char *error, const char *format, ...)
-{
-	va_list ap;
-	va_start(ap, format);
-	int total = log_vsay(log, level, filename, line, error, format, ap);
-	va_end(ap);
 	return total;
 }

--- a/src/lib/core/say.h
+++ b/src/lib/core/say.h
@@ -191,10 +191,22 @@ log_create(struct log *log, const char *init_str, int nonblock);
 void
 log_destroy(struct log *log);
 
-/** Perform log write. */
+/** A utility function to handle va_list from different varargs functions. */
 int
+log_vsay(struct log *log, int level, const char *filename, int line,
+	 const char *error, const char *format, va_list ap);
+
+/** Perform log write. */
+static inline int
 log_say(struct log *log, int level, const char *filename,
-	int line, const char *error, const char *format, ...);
+	int line, const char *error, const char *format, ...)
+{
+	va_list ap;
+	va_start(ap, format);
+	int total = log_vsay(log, level, filename, line, error, format, ap);
+	va_end(ap);
+	return total;
+}
 
 /**
  * Default logger type info.


### PR DESCRIPTION
We need it for audit log.