### PR TITLE
ci: freeze luacheck version at 0.25.0

### DIFF
--- a/.travis.mk
+++ b/.travis.mk
@@ -295,7 +295,7 @@ test_debian_docker_luacheck:
 test_debian_install_luacheck:
 	sudo apt update -y
 	sudo apt install -y lua5.1 luarocks
-	sudo luarocks install luacheck
+	sudo luarocks install luacheck 0.25.0
 
 test_debian_luacheck: test_debian_install_luacheck configure_debian
 	make luacheck


### PR DESCRIPTION
The newly released 0.26.0 emits a warning on the `_box` variable.
From luacheck v.0.26.0 release notes:

"Function arguments that start with a single underscore get an "unused hint".
Leaving them unused doesn't result in a warning.
Using them, on the other hand, is a new warning (№ 214)."

NO_DOC=testing
NO_TEST=testing
NO_CHANGELOG=testing