### PR TITLE
build: in static-build download zlib from backup storage

### DIFF
--- a/static-build/CMakeLists.txt
+++ b/static-build/CMakeLists.txt
@@ -92,7 +92,7 @@ ExternalProject_Add(icu
 # ZLIB
 #
 ExternalProject_Add(zlib
-    URL https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz
+    URL https://packages.hb.bizmrg.com/third_party/zlib-${ZLIB_VERSION}.tar.gz
     URL_MD5 ${ZLIB_HASH}
     CONFIGURE_COMMAND env
         CC=${CMAKE_C_COMPILER}


### PR DESCRIPTION
zlib.net is unavailable, so we have to download zlib distributions
from a backup storage on VKCS S3.