### PR TITLE
test: fix flaky test_cancel_and_errinj

### DIFF
--- a/test/app-luatest/http_client_test.lua
+++ b/test/app-luatest/http_client_test.lua
@@ -217,7 +217,7 @@ g.test_cancel_and_errinj = function(cg)
                     "After cancel fiber timeout is returned - status")
     t.assert_str_contains(r.reason, "Timeout",
                           "After cancel fiber timeout is returned - reason")
-    r = http:get(url, merge(opts, {timeout = 0.0001}))
+    r = http:get(url .. 'long_query', merge(opts, {timeout = 0.0001}))
     t.assert_equals(r.status, 408, "Timeout check - status")
     t.assert_str_contains(r.reason, "Timeout", "Timeout check - reason")
     local errinj = box.error.injection


### PR DESCRIPTION
This change tries to fix the following sporadic test error:

    [007] not ok 4	http_client.sock_family:"AF_INET".test_cancel_and_errinj
    [007] #   ...arantool/tarantool/test/app-luatest/http_client_test.lua:221: Timeout check - status
    [007] #   expected: 408, actual: 200

Fixes tarantool/tarantool-qa#154

NO_DOC=testing
NO_TEST=testing
NO_CHANGELOG=testing