### PR TITLE
Tuple compression fixes

### DIFF
--- a/src/box/memtx_bitset.cc
+++ b/src/box/memtx_bitset.cc
@@ -335,7 +335,6 @@ memtx_bitset_index_replace(struct index *base, struct tuple *old_tuple,
 	return 0;
 }
 
-template <bool UNCHANGED>
 static struct iterator *
 memtx_bitset_index_create_iterator(struct index *base, enum iterator_type type,
 				   const char *key, uint32_t part_count)
@@ -357,7 +356,7 @@ memtx_bitset_index_create_iterator(struct index *base, enum iterator_type type,
 	iterator_create(&it->base, base);
 	it->pool = &memtx->iterator_pool;
 	it->base.next_raw = bitset_index_iterator_next_raw;
-	it->base.next = UNCHANGED ? it->base.next_raw : memtx_iterator_next;
+	it->base.next = memtx_iterator_next;
 	it->base.free = bitset_index_iterator_free;
 
 	tt_bitset_iterator_create(&it->bitset_it, realloc);
@@ -484,62 +483,36 @@ memtx_bitset_index_count(struct index *base, enum iterator_type type,
 	return generic_index_count(base, type, key, part_count);
 }
 
-/**
- * Get index vtab by @a UNCHANGED, template version.
- * If UNCHANGED == true iterator->next and index->get
- * functions are the same as it's raw versions.
- */
-template <bool UNCHANGED>
-static const struct index_vtab *
-get_memtx_bitset_index_vtab(void)
-{
-	static const struct index_vtab vtab = {
-		/* .destroy = */ memtx_bitset_index_destroy,
-		/* .commit_create = */ generic_index_commit_create,
-		/* .abort_create = */ generic_index_abort_create,
-		/* .commit_modify = */ generic_index_commit_modify,
-		/* .commit_drop = */ generic_index_commit_drop,
-		/* .update_def = */ generic_index_update_def,
-		/* .depends_on_pk = */ generic_index_depends_on_pk,
-		/* .def_change_requires_rebuild = */
-			memtx_index_def_change_requires_rebuild,
-		/* .size = */ memtx_bitset_index_size,
-		/* .bsize = */ memtx_bitset_index_bsize,
-		/* .min = */ generic_index_min,
-		/* .max = */ generic_index_max,
-		/* .random = */ generic_index_random,
-		/* .count = */ memtx_bitset_index_count,
-		/* .get_raw = */ generic_index_get_raw,
-		/* .get = */ UNCHANGED ? generic_index_get_raw :
-			     generic_index_get,
-		/* .replace = */ memtx_bitset_index_replace,
-		/* .create_iterator = */
-			memtx_bitset_index_create_iterator<UNCHANGED>,
-		/* .create_snapshot_iterator = */
-			generic_index_create_snapshot_iterator,
-		/* .stat = */ generic_index_stat,
-		/* .compact = */ generic_index_compact,
-		/* .reset_stat = */ generic_index_reset_stat,
-		/* .begin_build = */ generic_index_begin_build,
-		/* .reserve = */ generic_index_reserve,
-		/* .build_next = */ generic_index_build_next,
-		/* .end_build = */ generic_index_end_build,
-	};
-	return &vtab;
-}
-
-/**
- * Get index vtab by @a unchanged, argument version.
- */
-static const struct index_vtab *
-get_memtx_bitset_index_vtab(bool unchanged)
-{
-	static const index_vtab *choice[2] = {
-		get_memtx_bitset_index_vtab<false>(),
-		get_memtx_bitset_index_vtab<true>()
-	};
-	return choice[unchanged];
-}
+static const struct index_vtab memtx_bitset_index_vtab = {
+	/* .destroy = */ memtx_bitset_index_destroy,
+	/* .commit_create = */ generic_index_commit_create,
+	/* .abort_create = */ generic_index_abort_create,
+	/* .commit_modify = */ generic_index_commit_modify,
+	/* .commit_drop = */ generic_index_commit_drop,
+	/* .update_def = */ generic_index_update_def,
+	/* .depends_on_pk = */ generic_index_depends_on_pk,
+	/* .def_change_requires_rebuild = */
+		memtx_index_def_change_requires_rebuild,
+	/* .size = */ memtx_bitset_index_size,
+	/* .bsize = */ memtx_bitset_index_bsize,
+	/* .min = */ generic_index_min,
+	/* .max = */ generic_index_max,
+	/* .random = */ generic_index_random,
+	/* .count = */ memtx_bitset_index_count,
+	/* .get_raw = */ generic_index_get_raw,
+	/* .get = */ generic_index_get,
+	/* .replace = */ memtx_bitset_index_replace,
+	/* .create_iterator = */ memtx_bitset_index_create_iterator,
+	/* .create_snapshot_iterator = */
+		generic_index_create_snapshot_iterator,
+	/* .stat = */ generic_index_stat,
+	/* .compact = */ generic_index_compact,
+	/* .reset_stat = */ generic_index_reset_stat,
+	/* .begin_build = */ generic_index_begin_build,
+	/* .reserve = */ generic_index_reserve,
+	/* .build_next = */ generic_index_build_next,
+	/* .end_build = */ generic_index_end_build,
+};
 
 struct index *
 memtx_bitset_index_new(struct memtx_engine *memtx, struct index_def *def)
@@ -554,9 +527,8 @@ memtx_bitset_index_new(struct memtx_engine *memtx, struct index_def *def)
 			 "malloc", "struct memtx_bitset_index");
 		return NULL;
 	}
-	const struct index_vtab *vtab = get_memtx_bitset_index_vtab(true);
 	if (index_create(&index->base, (struct engine *)memtx,
-			 vtab, def) != 0) {
+			 &memtx_bitset_index_vtab, def) != 0) {
 		free(index);
 		return NULL;
 	}
@@ -574,10 +546,4 @@ memtx_bitset_index_new(struct memtx_engine *memtx, struct index_def *def)
 
 	tt_bitset_index_create(&index->index, realloc);
 	return &index->base;
-}
-
-void
-memtx_bitset_index_set_vtab(struct index *index, bool unchanged)
-{
-	index->vtab = get_memtx_bitset_index_vtab(unchanged);
 }

--- a/src/box/memtx_bitset.h
+++ b/src/box/memtx_bitset.h
@@ -42,15 +42,6 @@ struct memtx_engine;
 struct index *
 memtx_bitset_index_new(struct memtx_engine *memtx, struct index_def *def);
 
-/**
- * Change @a index vtab according to @a unchanged argument.
- * If @a unchanged is false it's mean that tuple in index should
- * be transformed before return it to user, so we need special
- * `index_get` and `iterator_next` functions version.
- */
-void
-memtx_bitset_index_set_vtab(struct index *index, bool unchanged);
-
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -535,8 +535,7 @@ memtx_engine_commit(struct engine *engine, struct txn *txn)
 			struct memtx_space *mspace =
 				(struct memtx_space *)stmt->space;
 			size_t *bsize = &mspace->bsize;
-			uint64_t *ctuples = &mspace->compressed_tuples;
-			memtx_tx_history_commit_stmt(stmt, bsize, ctuples);
+			memtx_tx_history_commit_stmt(stmt, bsize);
 		}
 	}
 }
@@ -586,7 +585,6 @@ memtx_engine_rollback_statement(struct engine *engine, struct txn *txn,
 	}
 
 	memtx_space_update_bsize(space, new_tuple, old_tuple);
-	memtx_space_update_compressed_tuples(space, new_tuple, old_tuple);
 	if (old_tuple != NULL)
 		tuple_ref(old_tuple);
 	if (new_tuple != NULL)

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -102,7 +102,6 @@ hash_iterator_free(struct iterator *iterator)
 	mempool_free(it->pool, it);
 }
 
-template <bool UNCHANGED>
 static int
 hash_iterator_ge_raw_base(struct iterator *ptr, struct tuple **ret)
 {
@@ -115,14 +114,11 @@ hash_iterator_ge_raw_base(struct iterator *ptr, struct tuple **ret)
 	return 0;
 }
 
-template <bool UNCHANGED>
 static int
 hash_iterator_gt_raw_base(struct iterator *ptr, struct tuple **ret)
 {
 	assert(ptr->free == hash_iterator_free);
-	ptr->next_raw = hash_iterator_ge_raw_base<UNCHANGED>;
-	if (UNCHANGED)
-		ptr->next = ptr->next_raw;
+	ptr->next_raw = hash_iterator_ge_raw_base;
 	struct hash_iterator *it = (struct hash_iterator *) ptr;
 	struct memtx_hash_index *index = (struct memtx_hash_index *)ptr->index;
 	struct tuple **res = light_index_iterator_get_and_next(&index->hash_table,
@@ -135,7 +131,6 @@ hash_iterator_gt_raw_base(struct iterator *ptr, struct tuple **ret)
 }
 
 #define WRAP_ITERATOR_METHOD(name)						\
-template <bool UNCHANGED>							\
 static int									\
 name(struct iterator *iterator, struct tuple **ret)				\
 {										\
@@ -146,8 +141,8 @@ name(struct iterator *iterator, struct tuple **ret)				\
 	bool is_first = true;							\
 	do {									\
 		int rc = is_first ?						\
-			name##_base<UNCHANGED>(iterator, ret) :			\
-			hash_iterator_ge_raw_base<UNCHANGED>(iterator, ret);	\
+			name##_base(iterator, ret) :				\
+			hash_iterator_ge_raw_base(iterator, ret);		\
 		if (rc != 0 || *ret == NULL)					\
 			return rc;						\
 		is_first = false;						\
@@ -169,15 +164,12 @@ tree_iterator_dummie(MAYBE_UNUSED struct iterator *it, struct tuple **ret)
 	return 0;
 }
 
-template <bool UNCHANGED>
 static int
 hash_iterator_raw_eq(struct iterator *it, struct tuple **ret)
 {
 	it->next_raw = tree_iterator_dummie;
-	if (UNCHANGED)
-		it->next = it->next_raw;
 	/* always returns zero. */
-	hash_iterator_ge_raw_base<UNCHANGED>(it, ret);
+	hash_iterator_ge_raw_base(it, ret);
 	if (*ret == NULL)
 		return 0;
 	struct txn *txn = in_txn();
@@ -413,7 +405,6 @@ memtx_hash_index_replace(struct index *base, struct tuple *old_tuple,
 	return 0;
 }
 
-template <bool UNCHANGED>
 static struct iterator *
 memtx_hash_index_create_iterator(struct index *base, enum iterator_type type,
 				 const char *key, uint32_t part_count)
@@ -440,10 +431,10 @@ memtx_hash_index_create_iterator(struct index *base, enum iterator_type type,
 		if (part_count != 0) {
 			light_index_iterator_key(&index->hash_table, &it->iterator,
 					key_hash(key, base->def->key_def), key);
-			it->base.next_raw = hash_iterator_gt_raw<UNCHANGED>;
+			it->base.next_raw = hash_iterator_gt_raw;
 		} else {
 			light_index_iterator_begin(&index->hash_table, &it->iterator);
-			it->base.next_raw = hash_iterator_ge_raw<UNCHANGED>;
+			it->base.next_raw = hash_iterator_ge_raw;
 		}
 		/* This iterator needs to be supported as a legacy. */
 		memtx_tx_track_full_scan(in_txn(),
@@ -452,7 +443,7 @@ memtx_hash_index_create_iterator(struct index *base, enum iterator_type type,
 		break;
 	case ITER_ALL:
 		light_index_iterator_begin(&index->hash_table, &it->iterator);
-		it->base.next_raw = hash_iterator_ge_raw<UNCHANGED>;
+		it->base.next_raw = hash_iterator_ge_raw;
 		memtx_tx_track_full_scan(in_txn(),
 					 space_by_id(it->base.space_id),
 					 &index->base);
@@ -461,7 +452,7 @@ memtx_hash_index_create_iterator(struct index *base, enum iterator_type type,
 		assert(part_count > 0);
 		light_index_iterator_key(&index->hash_table, &it->iterator,
 				key_hash(key, base->def->key_def), key);
-		it->base.next_raw = hash_iterator_raw_eq<UNCHANGED>;
+		it->base.next_raw = hash_iterator_raw_eq;
 		if (it->iterator.slotpos == light_index_end)
 			memtx_tx_track_point(in_txn(),
 					     space_by_id(it->base.space_id),
@@ -473,7 +464,7 @@ memtx_hash_index_create_iterator(struct index *base, enum iterator_type type,
 		mempool_free(&memtx->iterator_pool, it);
 		return NULL;
 	}
-	it->base.next = UNCHANGED ? it->base.next_raw : memtx_iterator_next;
+	it->base.next = memtx_iterator_next;
 	return (struct iterator *)it;
 }
 
@@ -564,62 +555,36 @@ memtx_hash_index_create_snapshot_iterator(struct index *base)
 	return (struct snapshot_iterator *) it;
 }
 
-/**
- * Get index vtab by @a UNCHANGED, template version.
- * If UNCHANGED == true iterator->next and index->get
- * functions are the same as it's raw versions.
- */
-template <bool UNCHANGED>
-static const struct index_vtab *
-get_memtx_hash_index_vtab(void)
-{
-	static const struct index_vtab vtab = {
-		/* .destroy = */ memtx_hash_index_destroy,
-		/* .commit_create = */ generic_index_commit_create,
-		/* .abort_create = */ generic_index_abort_create,
-		/* .commit_modify = */ generic_index_commit_modify,
-		/* .commit_drop = */ generic_index_commit_drop,
-		/* .update_def = */ memtx_hash_index_update_def,
-		/* .depends_on_pk = */ generic_index_depends_on_pk,
-		/* .def_change_requires_rebuild = */
-			memtx_index_def_change_requires_rebuild,
-		/* .size = */ memtx_hash_index_size,
-		/* .bsize = */ memtx_hash_index_bsize,
-		/* .min = */ generic_index_min,
-		/* .max = */ generic_index_max,
-		/* .random = */ memtx_hash_index_random,
-		/* .count = */ memtx_hash_index_count,
-		/* .get_raw = */ memtx_hash_index_get_raw,
-		/* .get = */ UNCHANGED ? memtx_hash_index_get_raw :
-			memtx_index_get,
-		/* .replace = */ memtx_hash_index_replace,
-		/* .create_iterator = */
-			memtx_hash_index_create_iterator<UNCHANGED>,
-		/* .create_snapshot_iterator = */
-			memtx_hash_index_create_snapshot_iterator,
-		/* .stat = */ generic_index_stat,
-		/* .compact = */ generic_index_compact,
-		/* .reset_stat = */ generic_index_reset_stat,
-		/* .begin_build = */ generic_index_begin_build,
-		/* .reserve = */ generic_index_reserve,
-		/* .build_next = */ generic_index_build_next,
-		/* .end_build = */ generic_index_end_build,
-	};
-	return &vtab;
-}
-
-/**
- * Get index vtab by @a unchanged, argument version.
- */
-static const struct index_vtab *
-get_memtx_hash_index_vtab(bool unchanged)
-{
-	static const index_vtab *choice[2] = {
-		get_memtx_hash_index_vtab<false>(),
-		get_memtx_hash_index_vtab<true>()
-	};
-	return choice[unchanged];
-}
+static const struct index_vtab memtx_hash_index_vtab = {
+	/* .destroy = */ memtx_hash_index_destroy,
+	/* .commit_create = */ generic_index_commit_create,
+	/* .abort_create = */ generic_index_abort_create,
+	/* .commit_modify = */ generic_index_commit_modify,
+	/* .commit_drop = */ generic_index_commit_drop,
+	/* .update_def = */ memtx_hash_index_update_def,
+	/* .depends_on_pk = */ generic_index_depends_on_pk,
+	/* .def_change_requires_rebuild = */
+		memtx_index_def_change_requires_rebuild,
+	/* .size = */ memtx_hash_index_size,
+	/* .bsize = */ memtx_hash_index_bsize,
+	/* .min = */ generic_index_min,
+	/* .max = */ generic_index_max,
+	/* .random = */ memtx_hash_index_random,
+	/* .count = */ memtx_hash_index_count,
+	/* .get_raw = */ memtx_hash_index_get_raw,
+	/* .get = */ memtx_index_get,
+	/* .replace = */ memtx_hash_index_replace,
+	/* .create_iterator = */ memtx_hash_index_create_iterator,
+	/* .create_snapshot_iterator = */
+		memtx_hash_index_create_snapshot_iterator,
+	/* .stat = */ generic_index_stat,
+	/* .compact = */ generic_index_compact,
+	/* .reset_stat = */ generic_index_reset_stat,
+	/* .begin_build = */ generic_index_begin_build,
+	/* .reserve = */ generic_index_reserve,
+	/* .build_next = */ generic_index_build_next,
+	/* .end_build = */ generic_index_end_build,
+};
 
 struct index *
 memtx_hash_index_new(struct memtx_engine *memtx, struct index_def *def)
@@ -631,9 +596,8 @@ memtx_hash_index_new(struct memtx_engine *memtx, struct index_def *def)
 			 "malloc", "struct memtx_hash_index");
 		return NULL;
 	}
-	const struct index_vtab *vtab = get_memtx_hash_index_vtab(true);
 	if (index_create(&index->base, (struct engine *)memtx,
-			 vtab, def) != 0) {
+			 &memtx_hash_index_vtab, def) != 0) {
 		free(index);
 		return NULL;
 	}
@@ -642,12 +606,6 @@ memtx_hash_index_new(struct memtx_engine *memtx, struct index_def *def)
 			   memtx_index_extent_alloc, memtx_index_extent_free,
 			   memtx, index->base.def->key_def);
 	return &index->base;
-}
-
-void
-memtx_hash_index_set_vtab(struct index *index, bool unchanged)
-{
-	index->vtab = get_memtx_hash_index_vtab(unchanged);
 }
 
 /* }}} */

--- a/src/box/memtx_hash.h
+++ b/src/box/memtx_hash.h
@@ -42,15 +42,6 @@ struct memtx_engine;
 struct index *
 memtx_hash_index_new(struct memtx_engine *memtx, struct index_def *def);
 
-/**
- * Change @a index vtab according to @a unchanged argument.
- * If @a unchanged is false it's mean that tuple in index should
- * be transformed before return it to user, so we need special
- * `index_get` and `iterator_next` functions version.
- */
-void
-memtx_hash_index_set_vtab(struct index *index, bool unchanged);
-
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -294,7 +294,6 @@ memtx_rtree_index_reserve(struct index *base, uint32_t size_hint)
 	return memtx_index_extent_reserve(memtx, RESERVE_EXTENTS_BEFORE_REPLACE);
 }
 
-template <bool UNCHANGED>
 static struct iterator *
 memtx_rtree_index_create_iterator(struct index *base,  enum iterator_type type,
 				  const char *key, uint32_t part_count)
@@ -356,8 +355,7 @@ memtx_rtree_index_create_iterator(struct index *base,  enum iterator_type type,
 	iterator_create(&it->base, base);
 	it->pool = &memtx->rtree_iterator_pool;
 	it->base.next_raw = index_rtree_iterator_next_raw;
-	it->base.next = UNCHANGED ? index_rtree_iterator_next_raw :
-		memtx_iterator_next;
+	it->base.next = memtx_iterator_next;
 	it->base.free = index_rtree_iterator_free;
 	rtree_iterator_init(&it->impl);
 	/*
@@ -371,62 +369,36 @@ memtx_rtree_index_create_iterator(struct index *base,  enum iterator_type type,
 	return (struct iterator *)it;
 }
 
-/**
- * Get index vtab by @a UNCHANGED, template version.
- * If UNCHANGED == true iterator->next and index->get
- * functions are the same as it's raw versions.
- */
-template <bool UNCHANGED>
-static const struct index_vtab *
-get_memtx_rtree_index_vtab(void)
-{
-	static const struct index_vtab vtab = {
-		/* .destroy = */ memtx_rtree_index_destroy,
-		/* .commit_create = */ generic_index_commit_create,
-		/* .abort_create = */ generic_index_abort_create,
-		/* .commit_modify = */ generic_index_commit_modify,
-		/* .commit_drop = */ generic_index_commit_drop,
-		/* .update_def = */ generic_index_update_def,
-		/* .depends_on_pk = */ generic_index_depends_on_pk,
-		/* .def_change_requires_rebuild = */
-			memtx_rtree_index_def_change_requires_rebuild,
-		/* .size = */ memtx_rtree_index_size,
-		/* .bsize = */ memtx_rtree_index_bsize,
-		/* .min = */ generic_index_min,
-		/* .max = */ generic_index_max,
-		/* .random = */ generic_index_random,
-		/* .count = */ memtx_rtree_index_count,
-		/* .get_raw = */ memtx_rtree_index_get_raw,
-		/* .get = */ UNCHANGED ? memtx_rtree_index_get_raw :
-			memtx_index_get,
-		/* .replace = */ memtx_rtree_index_replace,
-		/* .create_iterator = */
-			memtx_rtree_index_create_iterator<UNCHANGED>,
-		/* .create_snapshot_iterator = */
-			generic_index_create_snapshot_iterator,
-		/* .stat = */ generic_index_stat,
-		/* .compact = */ generic_index_compact,
-		/* .reset_stat = */ generic_index_reset_stat,
-		/* .begin_build = */ generic_index_begin_build,
-		/* .reserve = */ memtx_rtree_index_reserve,
-		/* .build_next = */ generic_index_build_next,
-		/* .end_build = */ generic_index_end_build,
-	};
-	return &vtab;
-}
-
-/**
- * Get index vtab by @a unchanged, argument version.
- */
-static const struct index_vtab *
-get_memtx_rtree_index_vtab(bool unchanged)
-{
-	static const index_vtab *choice[2] = {
-		get_memtx_rtree_index_vtab<false>(),
-		get_memtx_rtree_index_vtab<true>()
-	};
-	return choice[unchanged];
-}
+static const struct index_vtab memtx_rtree_index_vtab = {
+	/* .destroy = */ memtx_rtree_index_destroy,
+	/* .commit_create = */ generic_index_commit_create,
+	/* .abort_create = */ generic_index_abort_create,
+	/* .commit_modify = */ generic_index_commit_modify,
+	/* .commit_drop = */ generic_index_commit_drop,
+	/* .update_def = */ generic_index_update_def,
+	/* .depends_on_pk = */ generic_index_depends_on_pk,
+	/* .def_change_requires_rebuild = */
+		memtx_rtree_index_def_change_requires_rebuild,
+	/* .size = */ memtx_rtree_index_size,
+	/* .bsize = */ memtx_rtree_index_bsize,
+	/* .min = */ generic_index_min,
+	/* .max = */ generic_index_max,
+	/* .random = */ generic_index_random,
+	/* .count = */ memtx_rtree_index_count,
+	/* .get_raw = */ memtx_rtree_index_get_raw,
+	/* .get = */ memtx_index_get,
+	/* .replace = */ memtx_rtree_index_replace,
+	/* .create_iterator = */ memtx_rtree_index_create_iterator,
+	/* .create_snapshot_iterator = */
+		generic_index_create_snapshot_iterator,
+	/* .stat = */ generic_index_stat,
+	/* .compact = */ generic_index_compact,
+	/* .reset_stat = */ generic_index_reset_stat,
+	/* .begin_build = */ generic_index_begin_build,
+	/* .reserve = */ memtx_rtree_index_reserve,
+	/* .build_next = */ generic_index_build_next,
+	/* .end_build = */ generic_index_end_build,
+};
 
 struct index *
 memtx_rtree_index_new(struct memtx_engine *memtx, struct index_def *def)
@@ -463,9 +435,8 @@ memtx_rtree_index_new(struct memtx_engine *memtx, struct index_def *def)
 			 "malloc", "struct memtx_rtree_index");
 		return NULL;
 	}
-	const struct index_vtab *vtab = get_memtx_rtree_index_vtab(true);
 	if (index_create(&index->base, (struct engine *)memtx,
-			 vtab, def) != 0) {
+			 &memtx_rtree_index_vtab, def) != 0) {
 		free(index);
 		return NULL;
 	}
@@ -475,10 +446,4 @@ memtx_rtree_index_new(struct memtx_engine *memtx, struct index_def *def)
 		   memtx_index_extent_alloc, memtx_index_extent_free, memtx,
 		   distance_type);
 	return &index->base;
-}
-
-void
-memtx_rtree_index_set_vtab(struct index *index, bool unchanged)
-{
-	index->vtab = get_memtx_rtree_index_vtab(unchanged);
 }

--- a/src/box/memtx_rtree.h
+++ b/src/box/memtx_rtree.h
@@ -42,15 +42,6 @@ struct memtx_engine;
 struct index *
 memtx_rtree_index_new(struct memtx_engine *memtx, struct index_def *def);
 
-/**
- * Change @a index vtab according to @a unchanged argument.
- * If @a unchanged is false it's mean that tuple in index should
- * be transformed before return it to user, so we need special
- * `index_get` and `iterator_next` functions version.
- */
-void
-memtx_rtree_index_set_vtab(struct index *index, bool unchanged);
-
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/memtx_space.h
+++ b/src/box/memtx_space.h
@@ -50,8 +50,6 @@ struct memtx_space {
 	 * tuples within one unique primary key.
 	 */
 	uint64_t rowid;
-        /** Count of compressed tuples contained in this space. */
-        uint64_t compressed_tuples;
 	/**
 	 * A pointer to replace function, set to different values
 	 * at different stages of recovery.
@@ -73,18 +71,6 @@ void
 memtx_space_update_bsize(struct space *space, struct tuple *old_tuple,
 			 struct tuple *new_tuple);
 
-/**
- * Undate count of compressed tuples in @a space. If @a old_tuple
- * is compressed wwe decrement count of compressed tuples. If @a
- * new_tuple is compressed we increment count of compressed tuples.
- * If count of compressed tuples is equal to zero we update vtabs
- * of all space indexes.
- */
-void
-memtx_space_update_compressed_tuples(struct space *space,
-                                     struct tuple *old_tuple,
-                                     struct tuple *new_tuple);
-
 int
 memtx_space_replace_no_keys(struct space *, struct tuple *, struct tuple *,
 			    enum dup_replace_mode, struct tuple **);
@@ -101,13 +87,6 @@ memtx_space_replace_all_keys(struct space *, struct tuple *, struct tuple *,
 struct space *
 memtx_space_new(struct memtx_engine *memtx,
 		struct space_def *def, struct rlist *key_list);
-
-/**
- * Update vtabs of all indexes in @a space according to
- * @a space format and count of compressed tuples.
- */
-void
-memtx_space_update_indexes_vtab(struct space *space);
 
 static inline bool
 memtx_space_is_recovering(struct space *space)

--- a/src/box/memtx_tree.h
+++ b/src/box/memtx_tree.h
@@ -42,15 +42,6 @@ struct memtx_engine;
 struct index *
 memtx_tree_index_new(struct memtx_engine *memtx, struct index_def *def);
 
-/**
- * Change @a index vtab according to @a unchanged argument.
- * If @a unchanged is false it's mean that tuple in index should
- * be transformed before return it to user, so we need special
- * `index_get` and `iterator_next` functions version.
- */
-void
-memtx_tree_index_set_vtab(struct index *index, bool unchanged);
-
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1884,20 +1884,15 @@ memtx_tx_history_prepare_stmt(struct txn_stmt *stmt)
 }
 
 void
-memtx_tx_history_commit_stmt(struct txn_stmt *stmt, size_t *bsize,
-			     uint64_t *compressed_tuples)
+memtx_tx_history_commit_stmt(struct txn_stmt *stmt, size_t *bsize)
 {
 	if (stmt->add_story != NULL) {
 		assert(stmt->add_story->add_stmt == stmt);
 		*bsize += tuple_bsize(stmt->add_story->tuple);
-		if (tuple_is_compressed(stmt->add_story->tuple))
-			(*compressed_tuples)++;
 		memtx_tx_story_unlink_added_by(stmt->add_story, stmt);
 	}
 	if (stmt->del_story != NULL) {
 		*bsize -= tuple_bsize(stmt->del_story->tuple);
-		if (tuple_is_compressed(stmt->del_story->tuple))
-			(*compressed_tuples)--;
 		memtx_tx_story_unlink_deleted_by(stmt->del_story, stmt);
 	}
 }

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1625,7 +1625,7 @@ void
 memtx_tx_history_rollback_stmt(struct txn_stmt *stmt)
 {
 	if (stmt->add_story != NULL) {
-		assert(stmt->add_story->tuple == stmt->new_tuple);
+		assert(stmt->add_story->tuple == stmt->rollback_info.new_tuple);
 		struct memtx_story *story = stmt->add_story;
 
 		/*

--- a/src/box/memtx_tx.h
+++ b/src/box/memtx_tx.h
@@ -278,11 +278,9 @@ memtx_tx_history_prepare_stmt(struct txn_stmt *stmt);
  *
  * @param stmt current statement.
  * @param bsize the space bsize.
- * @param compressed_tuples count of compressed tuples in space.
  */
 void
-memtx_tx_history_commit_stmt(struct txn_stmt *stmt, size_t *bsize,
-			     uint64_t *compressed_tuples);
+memtx_tx_history_commit_stmt(struct txn_stmt *stmt, size_t *bsize);
 
 /** Helper of memtx_tx_tuple_clarify */
 struct tuple *


### PR DESCRIPTION
The PR fixes two issues with tuple compression:
1. Invalid assertion in the memtx transaction manager.
2. Bug in index vtab selection logic.

Needed for https://github.com/tarantool/tarantool-ee/issues/61
Enterprise PR: https://github.com/tarantool/tarantool-ee/pull/62