### PR TITLE
app: fix crash with multiple -e -l options

### DIFF
--- a/changelogs/unreleased/gh-5747-crash-multiple-args.md
+++ b/changelogs/unreleased/gh-5747-crash-multiple-args.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a crash when tarantool is launched with multiple -e or -l options
+  without a space between the option and the value (gh-5747).

--- a/src/main.cc
+++ b/src/main.cc
@@ -615,6 +615,8 @@ main(int argc, char **argv)
 	/* Lua interpeter options, e.g. -e and -l */
 	int optc = 0;
 	const char **optv = NULL;
+	/* The maximum possible number of Lua interpeter options */
+	int optc_max = (argc - 1) * 2;
 	auto guard = make_scoped_guard([&optc, &optv]{ if (optc) free(optv); });
 
 	static struct option longopts[] = {
@@ -641,12 +643,9 @@ main(int argc, char **argv)
 		case 'l':
 		case 'e':
 			/* Save Lua interepter options to optv as is */
-			if (optc == 0) {
-				optv = (const char **) calloc(argc,
+			if (optc == 0)
+				optv = (const char **)xcalloc(optc_max,
 							      sizeof(optv[0]));
-				if (optv == NULL)
-					panic_syserror("No enough memory for arguments");
-			}
 			optv[optc++] = ch == 'l' ? "-l" : "-e";
 			optv[optc++] = optarg;
 			break;

--- a/test/app-luatest/gh_5747_crash_multiple_args_test.lua
+++ b/test/app-luatest/gh_5747_crash_multiple_args_test.lua
@@ -1,0 +1,8 @@
+local t = require('luatest')
+local g = t.group()
+
+g.test_multiple_args = function()
+    local handle = io.popen('tarantool -ea=10 -e b=20 -ec=30 -e d=40 -e"print(a+b+c+d)"')
+    local result = handle:read()
+    t.assert_equals(result, '100')
+end


### PR DESCRIPTION
Tarantool used to crash if launched with multiple -e or -l options without
a space between the option and the value, e.g.: `tarantool -ea -eb`.
It happened because optv[] was allocated for argc==3 items, while 4
options were written to it after parsing (-e, a, -e, b).
This patch allocates optv[] for the maximum possible number of options:
(argc - 1) * 2.

Closes #5747