### PR TITLE
test: disable init_storage.test.py due to bug

### DIFF
--- a/test/replication-py/init_storage.skipcond
+++ b/test/replication-py/init_storage.skipcond
@@ -1,0 +1,2 @@
+# Disabled until bug tarantool/tarantool#6966 is resolved.
+self.skip = 1


### PR DESCRIPTION
Disable the init_storage.test.py test due to the bug #6966.
After a bug fix the test should be enabled again.