### PR TITLE
replication: fix bootstrap failing with ER_READONLY

### DIFF
--- a/changelogs/unreleased/gh-6966-readonly-bootstrap.md
+++ b/changelogs/unreleased/gh-6966-readonly-bootstrap.md
@@ -1,0 +1,3 @@
+## bugfix/replication
+
+* Fixed replicas failing to bootstrap when master is just re-started (gh-6966).

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -114,6 +114,7 @@ applier_log_error(struct applier *applier, struct error *e)
 	error_log(e);
 	switch (errcode) {
 	case ER_LOADING:
+	case ER_READONLY:
 	case ER_CFG:
 	case ER_ACCESS_DENIED:
 	case ER_NO_SUCH_USER:
@@ -2144,7 +2145,8 @@ applier_f(va_list ap)
 				/* Connection to itself, stop applier */
 				applier_disconnect(applier, APPLIER_OFF);
 				return 0;
-			} else if (e->errcode() == ER_LOADING) {
+			} else if (e->errcode() == ER_LOADING ||
+				   e->errcode() == ER_READONLY) {
 				/* Autobootstrap */
 				applier_log_error(applier, e);
 				applier_disconnect(applier, APPLIER_LOADING);

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -2768,6 +2768,12 @@ box_process_register(struct iostream *io, const struct xrow_header *header)
 		tnt_raise(ClientError, ER_REPLICA_NOT_ANON,
 			  tt_uuid_str(&instance_uuid));
 	}
+
+	if (replication_anon) {
+		tnt_raise(ClientError, ER_UNSUPPORTED, "Anonymous replica",
+			  "registration of non-anonymous nodes.");
+	}
+
 	/* See box_process_join() */
 	box_check_writable_xc();
 	struct space *space = space_cache_find_xc(BOX_CLUSTER_ID);
@@ -2891,6 +2897,11 @@ box_process_join(struct iostream *io, const struct xrow_header *header)
 
 	/* Check permissions */
 	access_check_universe_xc(PRIV_R);
+
+	if (replication_anon) {
+		tnt_raise(ClientError, ER_UNSUPPORTED, "Anonymous replica",
+			  "registration of non-anonymous nodes.");
+	}
 
 	/*
 	 * Unless already registered, the new replica will be

--- a/test/replication-luatest/gh_6966_readonly_bootstrap_test.lua
+++ b/test/replication-luatest/gh_6966_readonly_bootstrap_test.lua
@@ -1,0 +1,60 @@
+local t = require('luatest')
+local cluster = require('test.luatest_helpers.cluster')
+local server = require('test.luatest_helpers.server')
+
+local fio = require('fio')
+
+local g = t.group('gh-6966-readonly-bootstrap')
+
+g.before_all(function(cg)
+    cg.cluster = cluster:new({})
+
+    local cfg = {
+        replication_timeout = 0.1,
+        replication = server.build_instance_uri('master'),
+    }
+    -- XXX: the order of add_server() is important. First add replica, then
+    -- master. This way they are stopped by cluster:stop() in correct order,
+    -- and the test runs 3 seconds faster. See gh-6820 (comment) for details:
+    -- https://github.com/tarantool/tarantool/issues/6820#issuecomment-1082914500
+    cg.replica = cg.cluster:build_and_add_server({
+        alias = 'replica',
+        box_cfg = cfg
+    })
+    cg.master = cg.cluster:build_and_add_server({
+        alias = 'master',
+        box_cfg = cfg
+    })
+    cg.master:start()
+end)
+
+g.after_all(function(cg)
+    cg.cluster:drop()
+end)
+
+-- Test that joining replica tolerates ER_READONLY errors from master, and joins
+-- once it becomes writeable.
+g.test_ro_bootstrap = function(cg)
+    cg.master:eval('box.cfg{read_only = true}')
+    cg.replica:start({wait_for_readiness = false})
+    -- The replica isn't booted yet so any attempts to eval box.cfg.log on it
+    -- result in an error (net_box is not connected).
+    local logfile = fio.pathjoin(cg.replica.workdir, 'replica.log')
+    t.helpers.retrying({}, function()
+        t.assert(cg.replica:grep_log('ER_READONLY', nil, {filename = logfile}),
+                 'Replica receives the ER_READONLY error')
+    end)
+    cg.master:exec(function()
+        require('luatest').assert(box.space._cluster:count() == 1,
+                                  'No join while master is read-only')
+    end)
+    cg.master:eval('box.cfg{read_only = false}')
+    cg.replica:wait_for_readiness()
+    t.helpers.retrying({}, function()
+        cg.master:exec(function()
+            require('luatest').assert(box.space._cluster:count() == 2,
+                                      'Join after master became writeable')
+        end)
+        cg.replica:assert_follows_upstream(1)
+    end)
+end

--- a/test/replication-py/cluster.test.py
+++ b/test/replication-py/cluster.test.py
@@ -234,13 +234,14 @@ failed.script = "replication-py/failed.lua"
 failed.vardir = server.vardir
 failed.rpl_master = master
 failed.name = "failed"
-failed.crash_expected = True
-try:
-    failed.deploy()
-except Exception as e:
-    line = "ER_READONLY"
-    if failed.logfile_pos.seek_once(line) >= 0:
-        print("'{}' exists in server log".format(line))
+
+failed.deploy(True, wait=False)
+line = "ER_READONLY"
+if failed.logfile_pos.seek_wait(line) >= 0:
+    print("'{}' exists in server log".format(line))
+
+failed.stop()
+failed.cleanup()
 
 master.admin("box.cfg { read_only = false }")
 

--- a/test/replication-py/init_storage.skipcond
+++ b/test/replication-py/init_storage.skipcond
@@ -1,2 +1,0 @@
-# Disabled until bug tarantool/tarantool#6966 is resolved.
-self.skip = 1

--- a/test/replication/gh-5613-bootstrap-prefer-booted.result
+++ b/test/replication/gh-5613-bootstrap-prefer-booted.result
@@ -43,19 +43,22 @@ test_run:cmd('create server replica2 with script="replication/gh-5613-replica2.l
  | ---
  | - true
  | ...
--- It returns false, but it is expected.
-test_run:cmd('start server replica2 with crash_expected=True')
+test_run:cmd('start server replica2 with wait=False')
  | ---
- | - false
+ | - true
  | ...
 opts = {filename = 'gh-5613-replica2.log'}
  | ---
  | ...
-assert(test_run:grep_log(nil, 'ER_READONLY', nil, opts) ~= nil)
+assert(test_run:wait_log(nil, 'ER_READONLY', nil, nil, opts) ~= nil)
  | ---
  | - true
  | ...
 
+test_run:cmd('stop server replica2')
+ | ---
+ | - true
+ | ...
 test_run:cmd('delete server replica2')
  | ---
  | - true

--- a/test/replication/gh-5613-bootstrap-prefer-booted.test.lua
+++ b/test/replication/gh-5613-bootstrap-prefer-booted.test.lua
@@ -17,11 +17,11 @@ box.cfg{read_only = true}
 test_run:switch('default')
 
 test_run:cmd('create server replica2 with script="replication/gh-5613-replica2.lua"')
--- It returns false, but it is expected.
-test_run:cmd('start server replica2 with crash_expected=True')
+test_run:cmd('start server replica2 with wait=False')
 opts = {filename = 'gh-5613-replica2.log'}
-assert(test_run:grep_log(nil, 'ER_READONLY', nil, opts) ~= nil)
+assert(test_run:wait_log(nil, 'ER_READONLY', nil, nil, opts) ~= nil)
 
+test_run:cmd('stop server replica2')
 test_run:cmd('delete server replica2')
 test_run:cmd('stop server replica1')
 test_run:cmd('delete server replica1')

--- a/test/replication/suite.ini
+++ b/test/replication/suite.ini
@@ -46,9 +46,6 @@ fragile = {
         "on_schema_init.test.lua": {
             "issues": [ "gh-5291" ]
         },
-        "ddl.test.lua": {
-            "issues": [ "gh-5337" ]
-        },
         "qsync_advanced.test.lua": {
             "issues": [ "gh-5340" ]
         },


### PR DESCRIPTION
When the master is just starting up it's possible for replica's JOIN
request to arrive right in time to bypass ER_LOADING check (after master
is fully recovered) but still fail due to ER_READONLY: box.cfg.read_only
is only read and set after box_cfg() (its C part) returns.

In this case the joining replica simply exits with an error and doesn't
retry JOIN.

Let's fix that. Make ER_READONLY a recoverable error and let replica
retry joining after receiving ER_READONLY.

Anonymous nodes relied on ER_READONLY to forbid replication from
anonymous to normal replicas. That check doesn't work anymore.
So introduce explicit checks banning replication from anonymous nodes.

Note, there were some alternatives to this fix.

First of all, theoretically, we could stop firing ER_LOADING later,
after box_cfg() is complete. This solution wouldn't work because it
would lead to deadlocks: the nodes would be stuck in replicaset_sync(),
because each of them rejects replication with ER_LOADING.

Another solution would be to read the real box.cfg.read_only value
earlier, in order to allow replication right after the node finishes
recovery.
This would also be bad, because we should never let a node become
writeable before box.cfg is finished. Even after local_recovery is
complete, the node should stay read-only until it synchronizes with
other replicas.

That said, neither of the two alternatives fit, so the solution with
retrying JOIN on ER_READONLY was chosen.

Since the bug is fixed, re-enable the test in which it was discovered:
replication-py/init_storage.test.py

Closes #6966
Closes #5337
Closes #5380
Closes #6445

NO_DOC=minor bugfix