### PR TITLE
tarantoolctl: fix command in help messages

### DIFF
--- a/changelogs/unreleased/gh-6983-fix-command-in-help-messages.md
+++ b/changelogs/unreleased/gh-6983-fix-command-in-help-messages.md
@@ -1,0 +1,3 @@
+## bugfix/tarantoolctl
+
+* Fix missing `rocks` keyword in tarantoolctl rocks help messages.

--- a/extra/dist/tarantoolctl.in
+++ b/extra/dist/tarantoolctl.in
@@ -25,6 +25,8 @@ int getppid(void);
 
 local TIMEOUT_INFINITY = 100 * 365 * 86400
 
+-- path of tarantoolctl binary
+local command_path = arg[0]
 -- name of tarantoolctl binary
 local self_name = fio.basename(arg[0])
 -- command that we're executing
@@ -945,6 +947,9 @@ local function rocks()
     util.see_help = function(command, program) -- luacheck: no unused args
         -- TODO: print extended help message here
         return "See Tarantool documentation for help."
+    end
+    util.this_program = function(default) -- luacheck: no unused args
+        return command_path .. " rocks"
     end
 
     -- Disabled: path, upload


### PR DESCRIPTION
Currently `tarantoolctl rocks --help` generate such help message:

NAME
	/usr/bin/tarantoolctl - LuaRocks main command-line interface

SYNOPSIS
	/usr/bin/tarantoolctl [<flags...>] [VAR=VALUE]...

This is wrong.

This patch makes the output look like this:

NAME
	/usr/bin/tarantoolctl rocks - LuaRocks main command-line interface

SYNOPSIS
	/usr/bin/tarantoolctl rocks [<flags...>] [VAR=VALUE]...

NO_DOC=bugfix