### PR TITLE
ci: introduce pipeline with enabled GC64

### DIFF
--- a/.github/workflows/debug_gc64.yml
+++ b/.github/workflows/debug_gc64.yml
@@ -1,0 +1,73 @@
+name: debug_gc64
+
+on:
+  push:
+    branches-ignore:
+      - '**-notest'
+    tags:
+      - '**'
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch (1.10,
+  # 2.8, etc.), and tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    github.ref == 'refs/heads/1.10' ||
+    startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+env:
+  CI_MAKE: make -f .travis.mk
+
+jobs:
+  debug_gc64:
+    # Run on pull request only if the 'notest' label is unset and this is
+    # an external PR (internal PRs trigger a run on push).
+    if: github.event_name != 'pull_request' ||
+      ( !contains(github.event.pull_request.labels.*.name, 'notest') &&
+      github.event.pull_request.head.repo.full_name != github.repository )
+
+    runs-on: ubuntu-20.04-self-hosted
+
+    steps:
+      - name: Sources checkout
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set environment
+        uses: ./.github/actions/environment
+
+      - name: Run testing
+        env:
+          CMAKE_EXTRA_PARAMS: -DLUAJIT_ENABLE_GC64=ON
+        run: ${CI_MAKE} debug_ubuntu_ghactions
+
+      - name: Send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+
+      - name: Collect artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: failure-logs-gc64
+          retention-days: 21
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/release_gc64.yml
+++ b/.github/workflows/release_gc64.yml
@@ -1,0 +1,69 @@
+name: release_gc64
+
+on:
+  push:
+    branches-ignore:
+      - '**-notest'
+    tags:
+      - '**'
+  pull_request:
+  repository_dispatch:
+    types: [backend_automation]
+  workflow_dispatch:
+
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch (1.10,
+  # 2.8, etc.), and tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    github.ref == 'refs/heads/1.10' ||
+    startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+env:
+  CI_MAKE: make -f .travis.mk
+
+jobs:
+  release_gc64:
+    # Run on pull request only if the 'notest' label is unset and this is
+    # an external PR (internal PRs trigger a run on push).
+    if: github.event_name != 'pull_request' ||
+        ( ! contains(github.event.pull_request.labels.*.name, 'notest') &&
+          github.event.pull_request.head.repo.full_name != github.repository )
+
+    runs-on: ubuntu-20.04-self-hosted
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: test
+        env:
+          CMAKE_EXTRA_PARAMS: -DLUAJIT_ENABLE_GC64=ON
+        run: ${CI_MAKE} test_ubuntu_ghactions
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: release_gc64
+          retention-days: 21
+          path: ${{ env.VARDIR }}/artifacts


### PR DESCRIPTION
This patch adds debug and release workflows for enabled GC64 in LuaJIT.

PR is a draft PR, due to possibility of flaky tests. PR becomes ready to review, when all GC64 commits with bugfixes from LuaJIT upstream will be backported. See also tarantool/roadmap-internal#104.