### PR TITLE
Add box.cfg.audit_format configuration option

### DIFF
--- a/src/box/audit.c
+++ b/src/box/audit.c
@@ -13,9 +13,10 @@
 #endif
 
 void
-audit_log_init(const char *init_str, int log_nonblock)
+audit_log_init(const char *init_str, int log_nonblock, const char *format)
 {
 	(void)log_nonblock;
+	(void)format;
 	if (init_str != NULL)
 		say_error("audit log is not available in this build");
 }

--- a/src/box/audit.h
+++ b/src/box/audit.h
@@ -15,8 +15,15 @@
 extern "C" {
 #endif /* defined(__cplusplus) */
 
+static inline int
+audit_log_check_format(const char *format)
+{
+	(void)format;
+	return 0;
+}
+
 void
-audit_log_init(const char *init_str, int log_nonblock);
+audit_log_init(const char *init_str, int log_nonblock, const char *format);
 
 static inline void
 audit_log_free(void) {}

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -748,6 +748,18 @@ box_check_say(void)
 	}
 }
 
+/**
+ * Raises error if audit log configuration is incorrect.
+ */
+static void
+box_check_audit(void)
+{
+	if (audit_log_check_format(cfg_gets("audit_format")) != 0) {
+		tnt_raise(ClientError, ER_CFG, "audit_format",
+			  diag_last_error(diag_get())->errmsg);
+	}
+}
+
 static enum election_mode
 box_check_election_mode(void)
 {
@@ -1268,6 +1280,7 @@ box_check_config(void)
 {
 	struct tt_uuid uuid;
 	box_check_say();
+	box_check_audit();
 	if (box_check_listen() != 0)
 		diag_raise();
 	box_check_instance_uuid(&uuid);
@@ -3809,7 +3822,8 @@ box_cfg_xc(void)
 	/* Follow replica */
 	replicaset_follow();
 
-	audit_log_init(cfg_gets("audit_log"), cfg_geti("audit_nonblock"));
+	audit_log_init(cfg_gets("audit_log"), cfg_geti("audit_nonblock"),
+		       cfg_gets("audit_format"));
 
 	fiber_gc();
 	is_box_configured = true;

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -70,6 +70,7 @@ local default_cfg = {
 
     audit_log           = nil,
     audit_nonblock      = true,
+    audit_format        = 'csv',
 
     io_collect_interval = nil,
     readahead           = 16320,
@@ -182,6 +183,7 @@ local template_cfg = {
 
     audit_log           = 'string',
     audit_nonblock      = 'boolean',
+    audit_format        = 'string',
 
     io_collect_interval = 'number',
     readahead           = 'number',

--- a/src/lib/core/util.c
+++ b/src/lib/core/util.c
@@ -59,7 +59,7 @@
  * @return  string index or hmax if the string is not found.
  */
 uint32_t
-strindex(const char **haystack, const char *needle, uint32_t hmax)
+strindex(const char *const *haystack, const char *needle, uint32_t hmax)
 {
 	for (unsigned index = 0; index != hmax && haystack[index]; index++)
 		if (strcasecmp(haystack[index], needle) == 0)
@@ -72,7 +72,8 @@ strindex(const char **haystack, const char *needle, uint32_t hmax)
  * Used, when @a needle is not 0 terminated.
  */
 uint32_t
-strnindex(const char **haystack, const char *needle, uint32_t len, uint32_t hmax)
+strnindex(const char *const *haystack, const char *needle, uint32_t len,
+	  uint32_t hmax)
 {
 	if (len == 0)
 		return hmax;

--- a/src/trivia/util.h
+++ b/src/trivia/util.h
@@ -94,10 +94,11 @@ extern "C" {
 #define STRN2ENUM(enum_name, str, len) ((enum enum_name) strnindex(enum_name##_strs, str, len, enum_name##_MAX))
 
 uint32_t
-strindex(const char **haystack, const char *needle, uint32_t hmax);
+strindex(const char *const *haystack, const char *needle, uint32_t hmax);
 
 uint32_t
-strnindex(const char **haystack, const char *needle, uint32_t len, uint32_t hmax);
+strnindex(const char *const *haystack, const char *needle, uint32_t len,
+	  uint32_t hmax);
 
 #define nelem(x)     (sizeof((x))/sizeof((x)[0]))
 #define field_sizeof(compound_type, field) sizeof(((compound_type *)NULL)->field)

--- a/test/app-tap/init_script.result
+++ b/test/app-tap/init_script.result
@@ -3,6 +3,7 @@
 --
 
 box.cfg
+audit_format:csv
 audit_nonblock:true
 background:false
 checkpoint_count:2

--- a/test/box/admin.result
+++ b/test/box/admin.result
@@ -27,7 +27,9 @@ help()
 ...
 cfg_filter(box.cfg)
 ---
-- - - audit_nonblock
+- - - audit_format
+    - csv
+  - - audit_nonblock
     - true
   - - background
     - false

--- a/test/box/cfg.result
+++ b/test/box/cfg.result
@@ -15,7 +15,9 @@ box.cfg.nosuchoption = 1
  | ...
 cfg_filter(box.cfg)
  | ---
- | - - - audit_nonblock
+ | - - - audit_format
+ |     - csv
+ |   - - audit_nonblock
  |     - true
  |   - - background
  |     - false
@@ -148,7 +150,9 @@ box.cfg()
  | ...
 cfg_filter(box.cfg)
  | ---
- | - - - audit_nonblock
+ | - - - audit_format
+ |     - csv
+ |   - - audit_nonblock
  |     - true
  |   - - background
  |     - false


### PR DESCRIPTION
This PR adds a new configuration option, `box.cfg.audit_format`. The value of this option is never used in the open-source version. It is needed to configure the audit log format in the enterprise version.

EE PR: https://github.com/tarantool/tarantool-ee/pull/70

Needed for https://github.com/tarantool/tarantool-ee/issues/66