### PR TITLE
Add box.cfg.audit_filter configuration option

### DIFF
--- a/src/box/audit.c
+++ b/src/box/audit.c
@@ -13,10 +13,12 @@
 #endif
 
 void
-audit_log_init(const char *init_str, int log_nonblock, const char *format)
+audit_log_init(const char *init_str, int log_nonblock, const char *format,
+	       const char *filter)
 {
 	(void)log_nonblock;
 	(void)format;
+	(void)filter;
 	if (init_str != NULL)
 		say_error("audit log is not available in this build");
 }

--- a/src/box/audit.h
+++ b/src/box/audit.h
@@ -22,8 +22,16 @@ audit_log_check_format(const char *format)
 	return 0;
 }
 
+static inline int
+audit_log_check_filter(const char *filter)
+{
+	(void)filter;
+	return 0;
+}
+
 void
-audit_log_init(const char *init_str, int log_nonblock, const char *format);
+audit_log_init(const char *init_str, int log_nonblock, const char *format,
+	       const char *filter);
 
 static inline void
 audit_log_free(void) {}

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -758,6 +758,10 @@ box_check_audit(void)
 		tnt_raise(ClientError, ER_CFG, "audit_format",
 			  diag_last_error(diag_get())->errmsg);
 	}
+	if (audit_log_check_filter(cfg_gets("audit_filter")) != 0) {
+		tnt_raise(ClientError, ER_CFG, "audit_filter",
+			  diag_last_error(diag_get())->errmsg);
+	}
 }
 
 static enum election_mode
@@ -3855,7 +3859,7 @@ box_cfg_xc(void)
 	replicaset_follow();
 
 	audit_log_init(cfg_gets("audit_log"), cfg_geti("audit_nonblock"),
-		       cfg_gets("audit_format"));
+		       cfg_gets("audit_format"), cfg_gets("audit_filter"));
 
 	fiber_gc();
 	is_box_configured = true;

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -2017,20 +2017,6 @@ box_listen(void)
 }
 
 void
-box_set_log_level(void)
-{
-	say_set_log_level(cfg_geti("log_level"));
-}
-
-void
-box_set_log_format(void)
-{
-	box_check_say();
-	enum say_format format = say_format_by_name(cfg_gets("log_format"));
-	say_set_log_format(format);
-}
-
-void
 box_set_io_collect_interval(void)
 {
 	ev_set_io_collect_interval(loop(), cfg_getd("io_collect_interval"));

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -247,8 +247,6 @@ box_check_config(void);
 
 int box_listen(void);
 void box_set_replication(void);
-void box_set_log_level(void);
-void box_set_log_format(void);
 void box_set_io_collect_interval(void);
 void box_set_snap_io_rate_limit(void);
 void box_set_too_long_threshold(void);

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -71,6 +71,7 @@ local default_cfg = {
     audit_log           = nil,
     audit_nonblock      = true,
     audit_format        = 'csv',
+    audit_filter        = 'compatibility',
 
     io_collect_interval = nil,
     readahead           = 16320,
@@ -185,6 +186,7 @@ local template_cfg = {
     audit_log           = 'string',
     audit_nonblock      = 'boolean',
     audit_format        = 'string',
+    audit_filter        = 'string',
 
     io_collect_interval = 'number',
     readahead           = 'number',

--- a/test/app-tap/init_script.result
+++ b/test/app-tap/init_script.result
@@ -3,6 +3,7 @@
 --
 
 box.cfg
+audit_filter:compatibility
 audit_format:csv
 audit_nonblock:true
 background:false

--- a/test/box/admin.result
+++ b/test/box/admin.result
@@ -27,7 +27,9 @@ help()
 ...
 cfg_filter(box.cfg)
 ---
-- - - audit_format
+- - - audit_filter
+    - compatibility
+  - - audit_format
     - csv
   - - audit_nonblock
     - true

--- a/test/box/cfg.result
+++ b/test/box/cfg.result
@@ -15,7 +15,9 @@ box.cfg.nosuchoption = 1
  | ...
 cfg_filter(box.cfg)
  | ---
- | - - - audit_format
+ | - - - audit_filter
+ |     - compatibility
+ |   - - audit_format
  |     - csv
  |   - - audit_nonblock
  |     - true
@@ -152,7 +154,9 @@ box.cfg()
  | ...
 cfg_filter(box.cfg)
  | ---
- | - - - audit_format
+ | - - - audit_filter
+ |     - compatibility
+ |   - - audit_format
  |     - csv
  |   - - audit_nonblock
  |     - true


### PR DESCRIPTION
This PR adds a new configuration option, `box.cfg.audit_filter`. The value of this option is never used in the open-source version. It is needed to configure the audit log filter in the enterprise version.

EE PR: https://github.com/tarantool/tarantool-ee/pull/72

Needed for https://github.com/tarantool/tarantool-ee/issues/67