### PR TITLE
cmake: don't include EXTRA_CORE_INCLUDE_DIRS in test/CMakeLists.txt

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,6 @@ enable_tnt_compile_flags()
 
 include_directories(${LUAJIT_INCLUDE_DIRS})
 include_directories(${MSGPUCK_INCLUDE_DIRS})
-include_directories(${EXTRA_CORE_INCLUDE_DIRS})
 
 function(build_module module files)
     add_library(${module} SHARED ${files})


### PR DESCRIPTION
We need to include EXTRA_CORE_INCLUDE_DIRS in order to build unit tests. Including it into test/CMakeLists.txt is useless. Moreover, it may break EE build in case EXTRA_CORE_INCLUDE_DIRS includes a system directory that contains a file that has the same name as one of our internal headers, see https://github.com/tarantool/tarantool-ee/issues/71.