### PR TITLE
test: fix comparing bool to int in cluster.test.py

### DIFF
--- a/test/replication-py/cluster.test.py
+++ b/test/replication-py/cluster.test.py
@@ -237,7 +237,7 @@ failed.name = "failed"
 
 failed.deploy(True, wait=False)
 line = "ER_READONLY"
-if failed.logfile_pos.seek_wait(line) >= 0:
+if failed.logfile_pos.seek_wait(line):
     print("'{}' exists in server log".format(line))
 
 failed.stop()


### PR DESCRIPTION
In commit c1c77782215e ("replication: fix bootstrap failing with ER_READONLY") seek_once was changed to seek_wait. Seek_once returned a non-negative int on success and -1 if failed, seek_wait returns True on success and False if failed. Therefore no need to compare it to 0 anymore.