### PR TITLE
tx: set session and user for commit/rollback triggers

### DIFF
--- a/changelogs/unreleased/gh-7005-session-on-commit-rollback.md
+++ b/changelogs/unreleased/gh-7005-session-on-commit-rollback.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed effective session and user not propagated to `box.on_commit` and
+  `box.on_rollback` trigger callbacks (gh-7005).

--- a/src/box/session.h
+++ b/src/box/session.h
@@ -205,15 +205,32 @@ fiber_get_session(struct fiber *fiber)
  * @param session a value to set
  */
 static inline void
-fiber_set_user(struct fiber *fiber, struct credentials *cr)
-{
-	fiber->storage.credentials = cr;
-}
-
-static inline void
 fiber_set_session(struct fiber *fiber, struct session *session)
 {
 	fiber->storage.session = session;
+}
+
+/**
+ * Get the current user from @a fiber
+ * @param fiber fiber
+ * @return user if any
+ * @retval NULL if there is no active user
+ */
+static inline struct credentials *
+fiber_get_user(struct fiber *fiber)
+{
+	return fiber->storage.credentials;
+}
+
+/**
+ * Set the current user in @a fiber
+ * @param fiber fiber
+ * @param cr a value to set
+ */
+static inline void
+fiber_set_user(struct fiber *fiber, struct credentials *cr)
+{
+	fiber->storage.credentials = cr;
 }
 
 /*

--- a/test/box-luatest/gh_7005_session_on_commit_rollback_test.lua
+++ b/test/box-luatest/gh_7005_session_on_commit_rollback_test.lua
@@ -1,0 +1,92 @@
+local misc = require('test.luatest_helpers.misc')
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all = function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+    g.server:exec(function()
+        box.schema.space.create('T')
+        box.space.T:create_index('primary')
+        box.schema.user.create('eve')
+        box.schema.user.grant('eve', 'write', 'space', 'T')
+    end)
+end
+
+g.after_all = function()
+    g.server:drop()
+end
+
+-- Checks session and user in box.on_commit trigger callback.
+g.test_session_on_commit = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        box.session.su('eve', function()
+            t.assert_equals(box.session.effective_user(), 'eve')
+            local id, user
+            box.begin()
+            box.on_commit(function()
+                id = box.session.id()
+                user = box.session.effective_user()
+            end)
+            box.space.T:replace{1}
+            box.commit()
+            t.assert_equals(id, box.session.id())
+            t.assert_equals(user, box.session.effective_user())
+        end)
+    end)
+end
+
+-- Checks session and user in box.on_rollback trigger callback in case
+-- transaction is rolled back with box.rollback().
+g.test_session_on_graceful_rollback = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        box.session.su('eve', function()
+            t.assert_equals(box.session.effective_user(), 'eve')
+            local id, user
+            box.begin()
+            box.on_rollback(function()
+                id = box.session.id()
+                user = box.session.effective_user()
+            end)
+            box.space.T:replace{1}
+            box.rollback()
+            t.assert_equals(id, box.session.id())
+            t.assert_equals(user, box.session.effective_user())
+            t.assert_equals(user, 'eve')
+        end)
+    end)
+end
+
+-- Checks session and user in box.on_rollback trigger callback in case
+-- transaction is rolled back on WAL error.
+g.test_session_on_wal_error_rollback = function()
+    misc.skip_if_not_debug()
+    g.server:exec(function()
+        local t = require('luatest')
+        box.session.su('eve', function()
+            t.assert_equals(box.session.effective_user(), 'eve')
+            local id, user
+            box.begin()
+            box.on_rollback(function()
+                id = box.session.id()
+                user = box.session.effective_user()
+            end)
+            box.space.T:replace{1}
+            box.error.injection.set('ERRINJ_WAL_WRITE', true)
+            t.assert_error_msg_equals("Failed to write to disk", box.commit)
+            box.error.injection.set('ERRINJ_WAL_WRITE', false)
+            t.assert_equals(id, box.session.id())
+            t.assert_equals(user, box.session.effective_user())
+            t.assert_equals(user, 'eve')
+        end)
+    end)
+end
+
+g.after_test('test_session_on_wal_error_rollback', function()
+    g.server:exec(function()
+        box.error.injection.set('ERRINJ_WAL_WRITE', false)
+    end)
+end)

--- a/test/luatest_helpers/misc.lua
+++ b/test/luatest_helpers/misc.lua
@@ -1,0 +1,16 @@
+local luatest = require('luatest')
+local tarantool = require('tarantool')
+
+-- Returns true if Tarantool build type is Debug.
+local function is_debug_build()
+    return tarantool.build.target:endswith('-Debug')
+end
+
+-- Skips a running test unless Tarantool build type is Debug.
+local function skip_if_not_debug()
+    luatest.skip_if(not is_debug_build(), 'build type is not Debug')
+end
+
+return {
+    skip_if_not_debug = skip_if_not_debug,
+}


### PR DESCRIPTION
Commit/rollback triggers are run asynchronously, upon receiving the write status from WAL. We can't run them in the original fiber that submitted the WAL request, because it would open a time window between writing a transaction to WAL and committing it in tx, which could lead to violating the cascading rolback principles. As a result, commit/rollback triggers run with admin privileges.

Let's fix this issue by temporarily setting session and credentials to the original fiber's for running commit/rollback triggers.

Closes #7005