### PR TITLE
test-run: bump to new version

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -5,11 +5,12 @@ runs:
   steps:
     - run: |
         echo VARDIR=/tmp/tnt | tee -a $GITHUB_ENV
+        echo TEST_RUN_RETRIES=3 | tee -a $GITHUB_ENV
         echo SERVER_START_TIMEOUT=290 | tee -a $GITHUB_ENV
         echo REPLICATION_SYNC_TIMEOUT=300 | tee -a $GITHUB_ENV
         echo TEST_TIMEOUT=310 | tee -a $GITHUB_ENV
         echo NO_OUTPUT_TIMEOUT=320 | tee -a $GITHUB_ENV
-        echo PRESERVE_ENVVARS=SERVER_START_TIMEOUT,REPLICATION_SYNC_TIMEOUT,TEST_TIMEOUT,NO_OUTPUT_TIMEOUT | tee -a $GITHUB_ENV
+        echo PRESERVE_ENVVARS=TEST_RUN_RETRIES,SERVER_START_TIMEOUT,REPLICATION_SYNC_TIMEOUT,TEST_TIMEOUT,NO_OUTPUT_TIMEOUT | tee -a $GITHUB_ENV
         # Configure AWS Region to avoid of issue:
         #   https://github.com/tarantool/tarantool-qa/issues/111
         echo AWS_DEFAULT_REGION=MS | tee -a $GITHUB_ENV


### PR DESCRIPTION
Bump test-run to new version with the following improvements:

- Add option to tune test run retries after failure [1]
- Set 0 as default value for retries after failure [1]
- Add an option to show test-run's environment vars [2]
- Prettify `test-run.py --help` output [3]

[1] https://github.com/tarantool/test-run/pull/336
[2] https://github.com/tarantool/test-run/pull/326
[3] https://github.com/tarantool/test-run/pull/337

NO_DOC=testing stuff
NO_TEST=testing stuff
NO_CHANGELOG=testing stuff