### PR TITLE
Add CALL/EVAL triggers

### DIFF
--- a/src/box/call.h
+++ b/src/box/call.h
@@ -31,12 +31,34 @@
  * SUCH DAMAGE.
  */
 
+#include <stdbool.h>
+
+#include "small/rlist.h"
+
 #if defined(__cplusplus)
 extern "C" {
 #endif /* defined(__cplusplus) */
 
 struct port;
 struct call_request;
+
+/** Context passed to box_on_call trigger callback. */
+struct box_on_call_ctx {
+	/** True for EVAL, false for CALL. */
+	bool is_eval;
+	/** CALL function name or EVAL expression. */
+	const char *expr;
+	/** Length of the expr string. */
+	int expr_len;
+	/** Arguments (MsgPack array). */
+	const char *args;
+};
+
+/**
+ * Triggers invoked by box_process_call and box_process_eval.
+ * Trigger callback is passed on_box_call_ctx.
+ */
+extern struct rlist box_on_call;
 
 /**
  * Reload loadable module by name.

--- a/src/box/func.c
+++ b/src/box/func.c
@@ -508,8 +508,7 @@ func_delete(struct func *func)
 	free(def);
 }
 
-/** Check "EXECUTE" permissions for a given function. */
-static int
+int
 func_access_check(struct func *func)
 {
 	struct credentials *credentials = effective_user();
@@ -541,10 +540,9 @@ func_access_check(struct func *func)
 }
 
 int
-func_call(struct func *base, struct port *args, struct port *ret)
+func_call_no_access_check(struct func *base, struct port *args,
+			  struct port *ret)
 {
-	if (func_access_check(base) != 0)
-		return -1;
 	/**
 	 * Change the current user id if the function is
 	 * a set-definer-uid one. If the function is not

--- a/src/box/func.h
+++ b/src/box/func.h
@@ -91,6 +91,10 @@ func_new(struct func_def *def);
 void
 func_delete(struct func *func);
 
+/** Check "EXECUTE" permissions for a given function. */
+int
+func_access_check(struct func *func);
+
 /**
  * Call function @a func with arguments @a args, put return value to @a ret.
  * Return 0 on success and nonzero on failure.
@@ -100,7 +104,16 @@ func_delete(struct func *func);
  * if and only if func_call returns 0;
  */
 int
-func_call(struct func *func, struct port *args, struct port *ret);
+func_call_no_access_check(struct func *func, struct port *args,
+			  struct port *ret);
+
+static inline int
+func_call(struct func *func, struct port *args, struct port *ret)
+{
+	if (func_access_check(func) != 0)
+		return -1;
+	return func_call_no_access_check(func, args, ret);
+}
 
 /**
  * Reload dynamically loadable schema module.

--- a/src/box/lua/console.c
+++ b/src/box/lua/console.c
@@ -51,6 +51,8 @@
 #include <stdlib.h>
 #include <ctype.h>
 
+struct rlist on_console_eval = RLIST_HEAD_INITIALIZER(on_console_eval);
+
 static struct luaL_serializer *serializer_yaml;
 static struct luaL_serializer *serializer_lua;
 
@@ -472,6 +474,18 @@ lbox_console_format_yaml(struct lua_State *L)
 	return lua_yaml_encode(L, serializer_yaml, NULL, NULL);
 }
 
+/**
+ * Runs registered on_console_eval triggers.
+ * Takes eval expression string, which is passed to trigger callback.
+ */
+static int
+lbox_console_run_on_eval(struct lua_State *L)
+{
+	const char *expr = lua_tostring(L, 1);
+	trigger_run(&on_console_eval, (void *)expr);
+	return 0;
+}
+
 int
 console_session_fd(struct session *session)
 {
@@ -641,6 +655,7 @@ tarantool_lua_console_init(struct lua_State *L)
 		{"completion_handler",	lbox_console_completion_handler},
 		{"format_yaml",		lbox_console_format_yaml},
 		{"format_lua",		lbox_console_format_lua},
+		{"run_on_eval",		lbox_console_run_on_eval},
 		{NULL, NULL}
 	};
 	luaL_register_module(L, "console", consolelib);

--- a/src/box/lua/console.h
+++ b/src/box/lua/console.h
@@ -30,9 +30,18 @@
  * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
+
+#include "small/rlist.h"
+
 #if defined(__cplusplus)
 extern "C" {
 #endif /* defined(__cplusplus) */
+
+/**
+ * Triggers invoked on console eval.
+ * Passed eval expression string.
+ */
+extern struct rlist on_console_eval;
 
 struct lua_State;
 

--- a/src/box/lua/console.lua
+++ b/src/box/lua/console.lua
@@ -380,6 +380,7 @@ local function local_eval(storage, line)
     if not line then
         return nil
     end
+    internal.run_on_eval(line)
     local command = get_command(line)
     if command then
         return preprocess(storage, command)


### PR DESCRIPTION
The new triggers will be used in the Enterprise version for logging CALL/EVAL events.

Enterprise part: https://github.com/tarantool/tarantool-ee/pull/83
Needed for https://github.com/tarantool/tarantool-ee/issues/68