### PR TITLE
Fix box.session.peer in box.session.on_disconnect triggers

### DIFF
--- a/changelogs/unreleased/gh-7014-session-disconnect-peer.md
+++ b/changelogs/unreleased/gh-7014-session-disconnect-peer.md
@@ -1,0 +1,5 @@
+## bugfix/core
+
+* Fixed usage of `box.session.peer()` in `box.session.on_disconnect()` trigger.
+  Now, it's safe to assume that `box.session.peer()` returns the address of the
+  disconnected peer, not nil, as it used to (gh-7014).

--- a/src/box/lua/session.c
+++ b/src/box/lua/session.c
@@ -51,17 +51,25 @@ static const char *sessionlib_name = "box.session";
 static int
 lbox_session_create(struct lua_State *L)
 {
+	int fd = luaL_optinteger(L, 1, -1);
+	enum session_type type = STR2ENUM(session_type,
+					  luaL_optstring(L, 2, "console"));
 	struct session *session = fiber_get_session(fiber());
 	if (session == NULL) {
 		session = session_create_on_demand();
 		if (session == NULL)
 			return luaT_error(L);
-		session->meta.fd = luaL_optinteger(L, 1, -1);
+		session->meta.fd = fd;
+		if (fd >= 0 && type != SESSION_TYPE_REPL) {
+			struct sockaddr_storage addrstorage;
+			struct sockaddr *addr = (struct sockaddr *)&addrstorage;
+			socklen_t addrlen = sizeof(addrstorage);
+			if (sio_getpeername(fd, addr, &addrlen) == 0)
+				session_set_peer_addr(session, addr, addrlen);
+		}
 	}
 	/* If a session already exists, simply reset its type */
-	session_set_type(session, STR2ENUM(session_type,
-					   luaL_optstring(L, 2, "console")));
-
+	session_set_type(session, type);
 	lua_pushnumber(L, session->id);
 	return 1;
 }
@@ -257,7 +265,6 @@ lbox_session_peer(struct lua_State *L)
 	if (lua_gettop(L) > 1)
 		luaL_error(L, "session.peer(sid): bad arguments");
 
-	int fd;
 	struct session *session;
 	if (lua_gettop(L) == 1)
 		session = session_find(luaL_checkint(L, 1));
@@ -265,21 +272,12 @@ lbox_session_peer(struct lua_State *L)
 		session = current_session();
 	if (session == NULL)
 		luaL_error(L, "session.peer(): session does not exist");
-	fd = session_fd(session);
-	if (fd < 0) {
+	const char *peer = session_peer(session);
+	if (peer == NULL) {
 		lua_pushnil(L); /* no associated peer */
 		return 1;
 	}
-
-	struct sockaddr_storage addr;
-	socklen_t addrlen = sizeof(addr);
-	struct sockaddr *addr_base = (struct sockaddr *)&addr;
-	if (sio_getpeername(fd, addr_base, &addrlen) < 0)
-		luaL_error(L, "session.peer(): getpeername() failed");
-
-	char addrbuf[SERVICE_NAME_MAXLEN];
-	sio_addr_snprintf(addrbuf, sizeof(addrbuf), addr_base, addrlen);
-	lua_pushstring(L, addrbuf);
+	lua_pushstring(L, peer);
 	return 1;
 }
 

--- a/src/box/session.cc
+++ b/src/box/session.cc
@@ -31,6 +31,7 @@
 #include "session.h"
 #include "fiber.h"
 #include "fiber_cond.h"
+#include "sio.h"
 #include "memory.h"
 #include "assoc.h"
 #include "trigger.h"
@@ -386,6 +387,15 @@ session_find(uint64_t sid)
 		return NULL;
 	return (struct session *)
 		mh_i64ptr_node(session_registry, k)->val;
+}
+
+const char *
+session_peer(const struct session *session)
+{
+	if (session->meta.peer.addrlen == 0)
+		return NULL;
+	return sio_strfaddr(&session->meta.peer.addr,
+			    session->meta.peer.addrlen);
 }
 
 extern "C" void

--- a/test/box-luatest/gh_7014_session_disconnect_peer_test.lua
+++ b/test/box-luatest/gh_7014_session_disconnect_peer_test.lua
@@ -1,0 +1,37 @@
+local net = require('net.box')
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all = function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+    g.server:exec(function()
+        box.schema.user.create('alice')
+        box.schema.user.passwd('alice', 'ALICE')
+        box.session.su('admin', box.schema.user.grant,
+                       'alice', 'execute', 'universe')
+        box.session.on_disconnect(function()
+            rawset(_G, 'peer', box.session.peer())
+        end)
+    end)
+end
+
+g.after_all = function()
+    g.server:drop()
+end
+
+g.test_session_disconnect_peer = function()
+    local c = net.connect(g.server.net_box_uri,
+                          {user = 'alice', password = 'ALICE'})
+    local peer = c:call('box.session.peer')
+    t.assert_is_not(peer, nil)
+    c:close()
+    g.server:exec(function(expected_peer)
+        local t = require('luatest')
+        t.helpers.retrying({}, function()
+            local peer = rawget(_G, 'peer')
+            t.assert_equals(peer, expected_peer)
+        end)
+    end, {peer})
+end

--- a/test/box-tap/session.test.lua
+++ b/test/box-tap/session.test.lua
@@ -15,7 +15,7 @@ session = box.session
 space = box.schema.space.create('tweedledum')
 space:create_index('primary', { type = 'hash' })
 
-test:plan(56)
+test:plan(54)
 
 ---
 --- Check that Tarantool creates ADMIN session for #! script
@@ -69,15 +69,12 @@ session.on_connect(nil, fail)
 session.on_disconnect(nil, fail)
 
 -- check how connect/disconnect triggers work
-local peer_name = "peer_name"
 local active_connections = 0
 local function inc() active_connections = active_connections + 1 end
 local function dec() active_connections = active_connections - 1 end
-local function peer() peer_name = box.session.peer() end
 local net = { box = require('net.box') }
 test:is(type(session.on_connect(inc)), "function", "type of trigger inc on_connect")
 test:is(type(session.on_disconnect(dec)), "function", "type of trigger dec on_disconnect")
-test:is(type(session.on_disconnect(peer)), "function", "type of trigger peer on_disconnect")
 local c = net.box.connect(HOST, PORT)
 while active_connections < 1 do fiber.sleep(0.001) end
 test:is(active_connections, 1, "active_connections after 1 connection")
@@ -88,11 +85,9 @@ c:close()
 c1:close()
 while active_connections > 0 do fiber.sleep(0.001) end
 test:is(active_connections, 0, "active_connections after closing")
-test:isnil(peer_name, "peer_name after closing")
 
 session.on_connect(nil, inc)
 session.on_disconnect(nil, dec)
-session.on_disconnect(nil, peer)
 
 -- write audit trail of connect/disconnect into a space
 local function audit_connect() box.space['tweedledum']:insert{session.id()} end


### PR DESCRIPTION
`iproto_connection_close()` closes the connection fd and then pushes the disconnect message to tx, which runs session disconnect triggers. As a result, `box.session.peer()` return nil, when called from a `box.session.on_disconnect()` trigger, which prevents us from using the trigger for auditing the disconnect event in the EE version.

Postponing `close()` until after the disconnect triggers have finished wouldn't help, because on OS X and BSD, in contrast to Linux, `getpeername()` fails if the socket was closed by the other end.

To fix this issue, let's store the peer address in the session meta.

Note, we need to remove `box.session.peer()` check from `box-tap/session` test. The check was added by commit https://github.com/tarantool/tarantool/commit/d68050b9b408ceb2accc78b5d66957027d231a43 ("Fix on_disconnect trigger"), which fixed a crash on attempt to use `box.session.peer()` from `box.session.on_disconnect()` trigger. This patch doesn't reintroduce the crash, but instead fixes the bug in a more extensive way and adds a dedicated test.

Closes #7014
Needed for https://github.com/tarantool/tarantool-ee/issues/75