### PR TITLE
Fast modulus computation in MHash

### DIFF
--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -14,3 +14,8 @@ include_directories(${EXTRA_CORE_INCLUDE_DIRS})
 add_executable(tuple.perftest tuple.cc
                ${PROJECT_SOURCE_DIR}/test/unit/box_test_utils.c)
 target_link_libraries(tuple.perftest core box tuple benchmark::benchmark)
+
+add_executable(mhash.perftest mhash.cc)
+target_include_directories(mhash.perftest PRIVATE
+                           ${PROJECT_SOURCE_DIR}/src/lib/salad)
+target_link_libraries(mhash.perftest salad benchmark::benchmark)

--- a/perf/mhash.cc
+++ b/perf/mhash.cc
@@ -1,0 +1,83 @@
+#include <algorithm>
+#include <array>
+#include <cstdlib>
+#include <numeric>
+#include <vector>
+
+#include <benchmark/benchmark.h>
+
+#define mh_name _u64
+#define mh_key_t uint64_t
+#define mh_node_t uint64_t
+#define mh_arg_t void *
+#define mh_hash(a, arg) (*(a))
+#define mh_hash_key(a, arg) (a)
+#define mh_cmp(a, b, arg) (*(a) != *(b))
+#define mh_cmp_key(a, b, arg) ((a) != *(b))
+#define MH_SOURCE
+#include <salad/mhash.h>
+
+class MHashU64Fixture : public benchmark::Fixture {
+public:
+	MHashU64Fixture() : h{nullptr}, rand_keys{}, filler_keys(max_key_count)
+	{
+		std::srand(0);
+		generate_rand_absent_keys();
+
+		std::iota(filler_keys.begin(), filler_keys.end(), 0);
+	}
+
+	void
+	SetUp(const benchmark::State &state) final
+	{
+		h = ::mh_u64_new();
+		for (std::int64_t i = 0; i < state.range(0); ++i)
+			::mh_u64_put(h, &filler_keys[i], nullptr, nullptr);
+	}
+
+	void
+	TearDown(__attribute__((__unused__)) const benchmark::State &state) final
+	{
+		::mh_u64_delete(h);
+	}
+
+	static constexpr std::size_t max_key_count = 1 << 20;
+
+protected:
+	mh_u64_t *h;
+
+	static constexpr std::size_t rand_keys_count = 1 << 10;
+	std::array<std::uint64_t, rand_keys_count> rand_keys;
+
+	std::vector<std::uint64_t> filler_keys;
+
+	void
+	generate_rand_absent_keys()
+	{
+		std::generate(rand_keys.begin(), rand_keys.end(), []() {
+			/* [max_key_count; UINT64_MAX) */
+			return max_key_count +
+			       std::rand() % (UINT64_MAX - max_key_count);
+		});
+	}
+};
+
+BENCHMARK_DEFINE_F(MHashU64Fixture, FindRandAbsentKey)
+(benchmark::State &state)
+{
+	std::int64_t iterations_count = 0;
+	for (__attribute__((__unused__)) auto _: state) {
+		for (auto &k: rand_keys) {
+			++iterations_count;
+			benchmark::DoNotOptimize(::mh_u64_find(h, k, nullptr));
+		}
+		state.PauseTiming();
+		generate_rand_absent_keys();
+		state.ResumeTiming();
+	}
+	state.SetItemsProcessed(iterations_count);
+}
+
+BENCHMARK_REGISTER_F(MHashU64Fixture, FindRandAbsentKey)->RangeMultiplier(2)->Range(1, MHashU64Fixture::max_key_count);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
# salad: refactor MHash

MHash had a redundant `n_buckets` field, which should always be calculated
from its `prime` field. But there was an inconsistency between them
introduced by `start_resize`: the `prime` field of both the real and
shadow table was updated, while only the shadow table's `n_buckets` field
was updated — apparently, the `prime` field of the real table should also
remain the same.

Fix the described inconsistency and remove the `n_buckets` field from
MHash.

NO_CHANGELOG=refactoring
NO_DOC=refactoring
NO_TEST=refactoring

# salad: fast modulus computation in MHash

Implement fast modulus computation in MHash based on algorithm described
in https://arxiv.org/abs/1902.01961.

Add a micro-benchmark for MHash: it shows a 10% performance improvement
with fast modulus computation enabled.

NO_CHANGELOG=optimization
NO_DOC=optimization
NO_TEST=optimization