### PR TITLE
Add SELECT trigger

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -2412,9 +2412,12 @@ box_select(uint32_t space_id, uint32_t index_id,
 		return -1;
 
 	enum iterator_type type = (enum iterator_type) iterator;
+	const char *key_array = key;
 	uint32_t part_count = key ? mp_decode_array(&key) : 0;
 	if (key_validate(index->def, type, key, part_count))
 		return -1;
+
+	box_run_on_select(space, index, type, key_array);
 
 	ERROR_INJECT(ERRINJ_TESTING, {
 		diag_set(ClientError, ER_INJECTION, "ERRINJ_TESTING");


### PR DESCRIPTION
The trigger is invoked on min/max/get/select/iterator. The trigger callback is passed a context with space, index, iterator type, and key (MsgPack array). The trigger is run only if access and sanity checks have passed. It will be used for auditing SELECT events in the EE version.

Needed for https://github.com/tarantool/tarantool-ee/issues/68