### PR TITLE
cfg: change default value of audit_format to json

### DIFF
--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -70,7 +70,7 @@ local default_cfg = {
 
     audit_log           = nil,
     audit_nonblock      = true,
-    audit_format        = 'csv',
+    audit_format        = 'json',
     audit_filter        = 'compatibility',
 
     io_collect_interval = nil,

--- a/test/app-tap/init_script.result
+++ b/test/app-tap/init_script.result
@@ -4,7 +4,7 @@
 
 box.cfg
 audit_filter:compatibility
-audit_format:csv
+audit_format:json
 audit_nonblock:true
 background:false
 checkpoint_count:2

--- a/test/box/admin.result
+++ b/test/box/admin.result
@@ -30,7 +30,7 @@ cfg_filter(box.cfg)
 - - - audit_filter
     - compatibility
   - - audit_format
-    - csv
+    - json
   - - audit_nonblock
     - true
   - - background

--- a/test/box/cfg.result
+++ b/test/box/cfg.result
@@ -18,7 +18,7 @@ cfg_filter(box.cfg)
  | - - - audit_filter
  |     - compatibility
  |   - - audit_format
- |     - csv
+ |     - json
  |   - - audit_nonblock
  |     - true
  |   - - background
@@ -157,7 +157,7 @@ cfg_filter(box.cfg)
  | - - - audit_filter
  |     - compatibility
  |   - - audit_format
- |     - csv
+ |     - json
  |   - - audit_nonblock
  |     - true
  |   - - background


### PR DESCRIPTION
Required for backward compatibility.

Follow-up commit a303b53beb1c ("cfg: add audit_format option").