### PR TITLE
lua: track memory occupied by runtime tuples

### DIFF
--- a/changelogs/unreleased/box-runtime-info-tuple.md
+++ b/changelogs/unreleased/box-runtime-info-tuple.md
@@ -1,0 +1,7 @@
+## feature/lua
+
+* Add `box.runtime.info().tuple` metric to track amount of memory occupied by
+  tuples allocated on runtime arena (gh-5872).
+
+  It does not count tuples that arrive from memtx or vinyl, but count tuples
+  created on-the-fly: say, using `box.tuple.new(<...>)`.

--- a/src/box/lua/slab.cc
+++ b/src/box/lua/slab.cc
@@ -45,6 +45,7 @@
 #include "box/engine.h"
 #include "box/memtx_engine.h"
 #include "box/allocator.h"
+#include "box/tuple.h"
 
 static int
 small_stats_lua_cb(const void *stats, void *cb_ctx)
@@ -250,6 +251,9 @@ lbox_runtime_info(struct lua_State *L)
 	lua_pushstring(L, "lua");
 	lua_pushinteger(L, G(L)->gc.total);
 	lua_settable(L, -3);
+
+	luaL_pushuint64(L, tuple_runtime_memory_used());
+	lua_setfield(L, -2, "tuple");
 
 	return 1;
 }

--- a/src/box/tuple.c
+++ b/src/box/tuple.c
@@ -378,6 +378,22 @@ tuple_free(void)
 	mh_tuple_uploaded_refs_delete(tuple_uploaded_refs);
 }
 
+static int
+small_stats_noop_cb(const void *stats, void *cb_ctx)
+{
+	(void)stats;
+	(void)cb_ctx;
+	return 0;
+}
+
+size_t
+tuple_runtime_memory_used(void)
+{
+	struct small_stats data_stats;
+	small_stats(&runtime_alloc, &data_stats, small_stats_noop_cb, NULL);
+	return data_stats.used;
+}
+
 /* {{{ tuple_field_* getters */
 
 int

--- a/src/box/tuple.h
+++ b/src/box/tuple.h
@@ -1339,6 +1339,18 @@ tuple_bless(struct tuple *tuple)
 ssize_t
 tuple_to_buf(struct tuple *tuple, char *buf, size_t size);
 
+/**
+ * Amount of memory allocated on runtime arena for tuples.
+ *
+ * This metric disregards the internal fragmentation: it does not
+ * count unused parts of slabs.
+ *
+ * Example: a tuple created using `box.tuple.new(<...>)` from Lua
+ * uses this memory.
+ */
+size_t
+tuple_runtime_memory_used(void);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 

--- a/test/box-luatest/box_runtime_info_tuple_test.lua
+++ b/test/box-luatest/box_runtime_info_tuple_test.lua
@@ -1,0 +1,38 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_each(function()
+    g.server = server:new({alias = 'box_runtime_info_memory'})
+    g.server:start()
+end)
+
+g.after_each(function()
+    g.server:drop()
+end)
+
+g.test_basic = function()
+    g.server:exec(function()
+        local t = require('luatest')
+
+        -- Keep references to tuples to ensure that they're not
+        -- suddenly garbage collected.
+        local tuples = {}
+
+        -- The statistics increased when new runtime tuples are
+        -- allocated.
+        local memory_a = box.runtime.info().tuple
+        for i = 1, 100 do
+            table.insert(tuples, box.tuple.new({i}))
+        end
+        local memory_b = box.runtime.info().tuple
+        t.assert_gt(memory_b, memory_a)
+
+        -- The statistics decreased when runtime tuples are
+        -- collected as garbage.
+        tuples = nil -- luacheck: no unused
+        collectgarbage()
+        local memory_c = box.runtime.info().tuple
+        t.assert_lt(memory_c, memory_b)
+    end)
+end


### PR DESCRIPTION
It allows to track memory allocated for tuples on runtime arena. It does
not count tuples owned by memtx and vinyl, but tracks so called runtime
tuples. The most common example is a tuple created by the
`box.tuple.new(<...>)` function.

Example:

```lua
tarantool> box.runtime.info().tuple -- 0
tarantool> box.tuple.new({})
tarantool> box.runtime.info().tuple -- 160
tarantool> box.tuple.new({})
tarantool> box.runtime.info().tuple -- 320
tarantool> collectgarbage()
tarantool> box.runtime.info().tuple -- 160
```

Fixes #5872