### PR TITLE
net.box: add opts check to net.box requests

### DIFF
--- a/changelogs/unreleased/gh-6530-netbox-opts-type-is-not-checked.md
+++ b/changelogs/unreleased/gh-6530-netbox-opts-type-is-not-checked.md
@@ -1,0 +1,3 @@
+## bugfix/net.box
+
+* Added option type check in remote queries in net.box (gh-6530).

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -334,6 +334,8 @@ local function update_param_table(table, defaults)
     return new_table
 end
 
+box.internal.check_param_table = check_param_table
+
 local function feedback_save_event(event)
     if internal.feedback_daemon ~= nil then
         internal.feedback_daemon.save_event(event)

--- a/test/box-luatest/gh_6530_netbox_opts_type_is_not_checked_test.lua
+++ b/test/box-luatest/gh_6530_netbox_opts_type_is_not_checked_test.lua
@@ -1,0 +1,79 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all = function()
+    g.server = server:new{alias   = 'default'}
+    g.server:start()
+end
+
+g.after_all = function()
+    g.server:drop()
+end
+
+g.before_test('test_netbox_opts_type_is_not_checked', function()
+    g.server:exec(function()
+        local s = box.schema.space.create('test')
+        s:format({
+                  {name = 'id',   type = 'unsigned'},
+                  {name = 'data', type = 'string'},
+                 })
+        s:create_index('primary', {parts = {'id'}})
+        box.schema.user.grant('guest', 'read,write', 'space', 'test')
+    end)
+end)
+
+g.test_netbox_opts_type_is_not_checked = function()
+    local t = require('luatest')
+    local netbox = require('net.box')
+    local conn = netbox.connect(g.server.net_box_uri)
+
+    t.assert_equals(conn.space.test:select(), {})
+    t.assert_error_msg_contains("should be of C type struct ibuf", function()
+        conn:call('echo', {1}, {buffer = 'abcd'})
+    end)
+    t.assert_error_msg_contains("parameter 'timeout' should be of type number", function()
+        conn:ping({timeout = 'abcd'})
+    end)
+    t.assert_error_msg_contains("unexpected option 'some_opt'", function()
+        conn:ping({some_opt = true})
+    end)
+    t.assert_error_msg_contains("parameter 'is_async' should be of type boolean", function()
+        conn:ping({is_async = 'abc'})
+    end)
+    t.assert_error_msg_contains("parameter 'return_raw' should be of type boolean", function()
+        conn:ping({return_raw = 5})
+    end)
+    t.assert_error_msg_contains("parameter 'limit' should be of type number", function()
+        conn.space.test:select({}, {limit = 'abc'})
+    end)
+    t.assert_error_msg_contains("parameter 'offset' should be of type number", function()
+        conn.space.test:select({}, {offset = 'abc'})
+    end)
+    t.assert_error_msg_contains("Unknown iterator type 'abc'", function()
+        conn.space.test:select({}, {iterator = 'abc'})
+    end)
+    t.assert_error_msg_contains("parameter 'timeout' should be of type number", function()
+        conn.space.test:replace({5, 'data'}, {timeout = 'ldk'})
+    end)
+    conn.space.test:insert({1, 'some info'})
+    t.assert_error_msg_contains("parameter 'timeout' should be of type number", function()
+        conn.space.test:insert({6, 'data'}, {timeout = 'abc'})
+    end)
+    t.assert_error_msg_contains("'buffer' should be of C type struct ibuf", function()
+        conn.space.test:delete({1}, {buffer = 5})
+    end)
+    t.assert_error_msg_contains("parameter 'timeout' should be of type number", function()
+        conn.space.test:get({6}, {timeout = 'abc'})
+    end)
+end
+
+g.after_test('test_netbox_opts_type_is_not_checked', function()
+    g.server:exec(function()
+        local s = box.space.test
+        if s then
+            s:drop()
+        end
+    end)
+end)


### PR DESCRIPTION
Added option type check in remote queries in net.box
to give graceful errors if options are passed incorrectly.
Added a new sub-module box.utils designed for common functions
often used in code.

Closes #6530
