### PR TITLE
box: fix space creation with fkey pointing to itself

### DIFF
--- a/changelogs/unreleased/gh-6961-foreign-key-same-space.md
+++ b/changelogs/unreleased/gh-6961-foreign-key-same-space.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed creation of a space with a foreign key pointing to the same space
+  (gh-6961).

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -260,6 +260,7 @@ space_create(struct space *space, struct engine *engine,
 	}
 	space_fill_index_map(space);
 
+	rlist_create(&space->space_cache_pin_list);
 	if (space_init_constraints(space) != 0)
 		goto fail_free_indexes;
 
@@ -292,7 +293,6 @@ space_create(struct space *space, struct engine *engine,
 		}
 	}
 	space->constraint_ids = mh_strnptr_new();
-	rlist_create(&space->space_cache_pin_list);
 	rlist_create(&space->memtx_stories);
 	return 0;
 
@@ -570,8 +570,8 @@ after_old_tuple_lookup:;
 	if (old_tuple != NULL) {
 		/*
 		 * Before deleting we must check that there are no tuples
-		 * in other spaces that refer to this tuple via foreign key
-		 * constraint.
+		 * in this space or in other spaces that refer to this tuple
+		 * via foreign key constraint.
 		 */
 		struct space_cache_holder *h;
 		rlist_foreach_entry(h, &space->space_cache_pin_list, link) {

--- a/src/box/space_cache.h
+++ b/src/box/space_cache.h
@@ -64,6 +64,8 @@ struct space_cache_holder {
 	 * used for proper container_of application.
 	 */
 	enum space_cache_holder_type type;
+	/** True for a space that had pinned itself. */
+	bool selfpin;
 };
 
 /**
@@ -159,11 +161,12 @@ space_cache_on_replace_noop(struct space_cache_holder *holder,
  * If a space has holders, it must not be deleted (asserted). It can be
  * replaced though, the holder will hold the new space in that case and
  * @a on_replace callback is called.
+ * @a selfpin expected to be true if a space pins itself.
  */
 void
 space_cache_pin(struct space *space, struct space_cache_holder *holder,
 		space_cache_on_replace on_replace,
-		enum space_cache_holder_type type);
+		enum space_cache_holder_type type, bool selfpin);
 
 /**
  * Notify that a @a holder does not depend anymore on @a space.

--- a/src/box/tuple_constraint_fkey.c
+++ b/src/box/tuple_constraint_fkey.c
@@ -571,14 +571,16 @@ tuple_constraint_fkey_init(struct tuple_constraint *constr,
 	constr->space = space;
 	tuple_constraint_fkey_update_local(constr, field_no);
 
-	struct space *foreign_space;
-	foreign_space = space_by_id(constr->def.fkey.space_id);
+	bool fkey_same_space = constr->def.fkey.space_id == space->def->id;
+	struct space *foreign_space = space_by_id(constr->def.fkey.space_id);
+	if (fkey_same_space && foreign_space == NULL)
+		foreign_space = space;
 	enum space_cache_holder_type type = SPACE_HOLDER_FOREIGN_KEY;
 	if (foreign_space != NULL) {
 		/* Space was found, use it. */
 		space_cache_pin(foreign_space, &constr->space_cache_holder,
 				tuple_constraint_fkey_space_cache_on_replace,
-				type);
+				type, fkey_same_space);
 		tuple_constraint_fkey_update_foreign(constr);
 		constr->check = tuple_constraint_fkey_check;
 		constr->destroy = tuple_constraint_fkey_unpin;

--- a/src/box/tuple_format.c
+++ b/src/box/tuple_format.c
@@ -1064,7 +1064,7 @@ tuple_field_map_create(struct tuple_format *format, const char *tuple,
 				     region) != 0)
 		return -1;
 
-	if (tuple_check_constraint(format, tuple) != 0)
+	if (validate && tuple_check_constraint(format, tuple) != 0)
 		return -1;
 
 	if (tuple_format_field_count(format) == 0)

--- a/test/engine-luatest/gh_6961_fkey_same_space_test.lua
+++ b/test/engine-luatest/gh_6961_fkey_same_space_test.lua
@@ -1,0 +1,235 @@
+-- https://github.com/tarantool/tarantool/issues/6961
+-- Can't create space with foreign key pointing to itself
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group('gh-6961-fkey-same-space-test',
+                  {{engine = 'memtx'}, {engine = 'vinyl'}})
+
+g.before_all(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:stop()
+    cg.server = nil
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.tasks then box.space.tasks:drop() end
+        if box.space.filesystem then box.space.filesystem:drop() end
+        if box.space.population then box.space.population:drop() end
+        if box.func.check_parent then box.func.check_parent:drop() end
+    end)
+end)
+
+-- Test with foreign key to the same space by primary index
+-- and a key from the other space.
+g.test_foreign_key_primary = function(cg)
+    local engine = cg.params.engine
+
+    cg.server:exec(function(engine)
+        local t = require('luatest')
+
+        local fmt = {{name='id', type='unsigned'},
+                     {name='name', type='string'},
+                     {name='parent_id', type='unsigned', is_nullable=true,
+                      foreign_key={fkey={space='filesystem', field='id'}}}
+                    }
+        local fs = box.schema.create_space('filesystem', {engine=engine,
+                                                          format=fmt})
+        fs:create_index('pk')
+        fs:create_index('sk', {unique=false, parts={'parent_id'}})
+        fs:insert{0, 'root'}
+        fs:insert{1, 'bin', 0}
+        fs:insert{2, 'usr', 0}
+        fs:insert{3, 'etc', 0}
+        fs:insert{10, 'dd', 1}
+        fs:insert{11, 'df', 1}
+        fs:insert{20, 'bin', 2}
+        t.assert_error_msg_content_equals(
+            "Foreign key constraint 'fkey' failed for field '3 (parent_id)': foreign tuple was not found",
+            function() fs:insert{8, 'boot', 666} end
+        )
+
+        local fmt = {{name='pid', type='unsigned'},
+                     {name='comm_id', type='unsigned',
+                     foreign_key={space='filesystem', field='id'}}
+                    }
+        local tasks = box.schema.create_space('tasks', {engine=engine,
+                                                        format=fmt})
+        tasks:create_index('pk')
+        tasks:create_index('sk', {parts={'comm_id'}})
+        tasks:insert{1234, 11}
+    end, {engine})
+
+    cg.server:restart()
+
+    cg.server:exec(function()
+        local t = require('luatest')
+        local fs = box.space.filesystem
+
+        fs.index.sk:drop()
+        fs:create_index('sk', {unique=false, parts={'parent_id'}})
+
+        t.assert_error_msg_content_equals(
+            "Foreign key constraint 'fkey' failed for field '3 (parent_id)': foreign tuple was not found",
+            function() fs:replace{10, 'dd', 404} end
+        )
+        fs:replace{10, 'dd', 20} -- mv /bin/dd /usr/bin/dd
+
+        t.assert_error_msg_content_equals(
+            "Foreign key 'fkey' integrity check failed: tuple is referenced",
+            function() fs:delete{2} end
+        )
+        fs:delete{10} -- rm /usr/bin/dd
+        fs:delete{20} -- rm /usr/bin
+        fs:delete{2} -- Now /usr can be deleted
+
+        t.assert_error_msg_content_equals(
+            "Foreign key 'filesystem' integrity check failed: tuple is referenced",
+            function() fs:delete{11} end
+        )
+    end, {engine})
+end
+
+-- Test with fkey to the same space by secondary index and some variations
+g.test_foreign_key_secondary = function(cg)
+    local engine = cg.params.engine
+
+    cg.server:exec(function(engine)
+        local t = require('luatest')
+
+        local fn_check_parent = "function(field) return field:sub(1, 1) == '/' end"
+        box.schema.func.create('check_parent', {language='LUA',
+                                                is_deterministic=true,
+                                                body=fn_check_parent})
+        local fmt = {{name='id', type='unsigned'},
+                     {name='path', type='string'},
+                     {name='parent', type='string', is_nullable=true,
+                      constraint='check_parent',
+                      foreign_key={space='filesystem', field='path'}}
+                    }
+        local fs = box.schema.create_space('filesystem', {engine=engine,
+                                                          format=fmt})
+        fs:create_index('id')
+        fs:create_index('path', {parts={'path'}})
+        fs:create_index('parent', {unique=false, parts={'parent'}})
+        fs:insert{0, '/'}
+        fs:insert{1, '/bin', '/'}
+        fs:insert{2, '/usr', '/'}
+        fs:insert{3, '/etc', '/'}
+        fs:insert{4, '/bin/dd', '/bin'}
+        fs:insert{5, '/bin/df', '/bin'}
+        fs:insert{6, '/usr/bin', '/usr'}
+        fs:insert{7, '???'}
+        t.assert_error_msg_content_equals(
+            "Check constraint 'check_parent' failed for field '3 (parent)'",
+            function() fs:insert{8, '/boot', '???'} end
+        )
+
+        fs.index.parent:drop()
+        fs:create_index('parent', {unique=false, parts={'parent'}})
+    end, {engine})
+
+    cg.server:eval('box.snapshot()')
+    cg.server:restart()
+
+    cg.server:exec(function()
+        local t = require('luatest')
+        local fs = box.space.filesystem.index.path
+
+        t.assert_error_msg_content_equals(
+            "Foreign key constraint 'filesystem' failed for field '3 (parent)': foreign tuple was not found",
+            function() fs:update('/bin/dd', {{'=', 'parent', '/nanan'}}) end
+        )
+        fs:update('/bin/dd', {{'=', 'parent', '/usr/bin'}, {'=', 'path', '/usr/bin/dd'}})
+
+        t.assert_error_msg_content_equals(
+            "Foreign key 'filesystem' integrity check failed: tuple is referenced",
+            function() fs:delete{'/usr/bin'} end
+        )
+        fs:delete{'/usr/bin/dd'}
+        fs:delete{'/usr/bin'}
+    end, {engine})
+end
+
+-- Test with 2 foreign keys by primary index
+g.test_two_fkeys_primary = function(cg)
+    local engine = cg.params.engine
+
+    cg.server:exec(function(engine)
+        local t = require('luatest')
+
+        local fmt = {{name='id', type='unsigned'},
+                     {name='name', type='string'},
+                     {name='mother', type='unsigned', is_nullable=true,
+                      foreign_key={fkey1={space='population', field='id'}}},
+                     {name='father', type='unsigned', is_nullable=true,
+                      foreign_key={fkey2={space='population', field='id'}}}
+                    }
+        local s = box.schema.create_space('population', {engine=engine,
+                                                         format=fmt})
+        s:create_index('pk')
+        s:create_index('sk1', {unique=false, parts={'mother'}})
+        s:create_index('sk2', {unique=false, parts={'father'}})
+        s:insert{0, 'Eve'}
+        s:insert{1, 'Adam'}
+        s:insert{2, 'Cain', 0, 1}
+        s:insert{3, 'Abel', 0, 1}
+
+        t.assert_error_msg_content_equals(
+            "Foreign key 'fkey1' integrity check failed: tuple is referenced",
+            function() s:delete{0} end
+        )
+        t.assert_error_msg_content_equals(
+            "Foreign key 'fkey2' integrity check failed: tuple is referenced",
+            function() s:delete{1} end
+        )
+    end, {engine})
+end
+
+-- Test with 2 foreign keys by secondary index
+g.test_two_fkeys_secondary = function(cg)
+    local engine = cg.params.engine
+
+    cg.server:exec(function(engine)
+        local t = require('luatest')
+
+        local fmt = {{name='id', type='unsigned'},
+                     {name='name', type='string'},
+                     {name='mother', type='string', is_nullable=true,
+                      foreign_key={fkey1={space='population', field='name'}}},
+                     {name='father', type='string', is_nullable=true,
+                      foreign_key={fkey2={space='population', field='name'}}}
+                    }
+        local s = box.schema.create_space('population', {engine=engine,
+                                                         format=fmt})
+        s:create_index('pk')
+        s:create_index('name', {parts={'name'}})
+        s:create_index('sk1', {unique=false, parts={'mother'}})
+        s:create_index('sk2', {unique=false, parts={'father'}})
+        s:insert{0, 'Eve'}
+        s:insert{1, 'Adam'}
+        s:insert{2, 'Cain', 'Eve', 'Adam'}
+        s:insert{3, 'Abel', 'Eve', 'Adam'}
+
+        t.assert_error_msg_content_equals(
+            "Foreign key 'fkey1' integrity check failed: tuple is referenced",
+            function() s:replace{0, 'eve'} end
+        )
+        t.assert_error_msg_content_equals(
+            "Foreign key 'fkey2' integrity check failed: tuple is referenced",
+            function() s:replace{1, 'adam'} end
+        )
+        t.assert_error_msg_content_equals(
+            "Foreign key 'fkey2' integrity check failed: tuple is referenced",
+            function() s.index.name:delete{'Adam'} end
+        )
+        t.assert_error_msg_content_equals(
+            "Foreign key 'fkey1' integrity check failed: tuple is referenced",
+            function() s.index.name:delete{'Eve'} end
+        )
+    end, {engine})
+end


### PR DESCRIPTION
This patch enables creation of a space with a foreign key pointing
to the same space. Such spaces are marked with a `selfpin` flag in
the `space_cache_pin_list`. If a space is pinned only by selfpins,
it is allowed to be deleted from the space cache.

When an old space is replaced by the new one, it's self-pinned for the
second time, then all old pins are moved to the new space's pin list
(see `space_cache_repin_pinned`), then the first self-pin is removed
by `space_cleanup_constraints` of the old space.

Closes https://github.com/tarantool/tarantool/issues/6961

NO_DOC=bugfix