### PR TITLE
test: speedup replication/election_qsync_stress

### DIFF
--- a/test/replication/election_qsync_stress.result
+++ b/test/replication/election_qsync_stress.result
@@ -95,6 +95,7 @@ for i = 1,10 do
     r2_nr = (old_leader_nr + 1) % 3 + 1
     test_run:wait_lsn('election_replica'..r1_nr, 'election_replica'..old_leader_nr)
     test_run:wait_lsn('election_replica'..r2_nr, 'election_replica'..old_leader_nr)
+    c:close()
     test_run:cmd('stop server '..old_leader)
     nrs[old_leader_nr] = false
     new_leader_nr = get_leader(nrs)

--- a/test/replication/election_qsync_stress.test.lua
+++ b/test/replication/election_qsync_stress.test.lua
@@ -57,6 +57,7 @@ for i = 1,10 do
     r2_nr = (old_leader_nr + 1) % 3 + 1
     test_run:wait_lsn('election_replica'..r1_nr, 'election_replica'..old_leader_nr)
     test_run:wait_lsn('election_replica'..r2_nr, 'election_replica'..old_leader_nr)
+    c:close()
     test_run:cmd('stop server '..old_leader)
     nrs[old_leader_nr] = false
     new_leader_nr = get_leader(nrs)


### PR DESCRIPTION
The test ran for ~40 seconds, and instance logs were filled with
"on_shutdown triggers timed out" messages on each node shutdown.

This is because the test left a lingering netbox connection with a started
but not finished insert into a synchronous space with huge
replication_synchro_quorum. Since the introduction of graceful shutdown
Tarantool tries to wait for a timeout (3 seconds by default) before
stopping the instance, when there are unfinished requests.
There is always an unfinished request in this test by design, so there's
no point in waiting for its completion.
Close the connection explicitly to save a lot of time.

The test includes stopping instances 10 times in a loop, so the test was
slowed down by 30 seconds.

At the moment of writing, the only replication* test, which also has
this issue, is replication-luatest/no_quorum_test.lua.

This was tested by setting on_shutdown_trigger_timeout to 300 seconds
and finding hanged tests.

The no_quorum test is deliberately not fixed, since it doesn't make use
of net_box explicitly, and is mysteriously fixed by reordering rows with
server creation. So this might be a bug in luatest. See the following
comment for details:
https://github.com/tarantool/tarantool/issues/6820#issuecomment-1082914500

Part-of #6820

NO_DOC=test fix
NO_CHANGELOG=test fix