### PR TITLE
box: fix problem with SCALAR and UUID

### DIFF
--- a/src/box/field_def.c
+++ b/src/box/field_def.c
@@ -145,7 +145,7 @@ static const bool field_type_compatibility[] = {
 /* VARBINARY*/ true,   false,   false,   false,   false,   false,   false,   true,   true,   false,  false,   false,    false,   false,
 /*  SCALAR  */ true,   false,   false,   false,   false,   false,   false,   false,  true,   false,  false,   false,    false,   false,
 /*  DECIMAL */ true,   false,   false,   true,    false,   false,   false,   false,  true,   true,   false,   false,    false,   false,
-/*   UUID   */ true,   false,   false,   false,   false,   false,   false,   false,  false,  false,  true,    false,    false,   false,
+/*   UUID   */ true,   false,   false,   false,   false,   false,   false,   false,  true,   false,  true,    false,    false,   false,
 /* DATETIME */ true,   false,   false,   false,   false,   false,   false,   false,  true,   false,  false,   true,     false,   false,
 /*   ARRAY  */ true,   false,   false,   false,   false,   false,   false,   false,  false,  false,  false,   false,    true,    false,
 /*    MAP   */ true,   false,   false,   false,   false,   false,   false,   false,  false,  false,  false,   false,    false,   true,

--- a/test/box-luatest/gh_6042_uuid_and_scalar_test.lua
+++ b/test/box-luatest/gh_6042_uuid_and_scalar_test.lua
@@ -1,0 +1,29 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'uuid_scalar'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_uuid_scalar = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local s = box.schema.space.create('a', {format = {{'u', 'uuid'}}})
+        local _ = s:create_index('i', {parts = {{'u', 'scalar'}}})
+        t.assert_equals(s:format()[1].type, 'uuid')
+        t.assert_equals(s.index[0].parts[1].type, 'scalar')
+        s:drop()
+
+        s = box.schema.space.create('a', {format = {{'u', 'scalar'}}})
+        _ = s:create_index('i', {parts = {{'u', 'uuid'}}})
+        t.assert_equals(s:format()[1].type, 'scalar')
+        t.assert_equals(s.index[0].parts[1].type, 'uuid')
+        s:drop()
+    end)
+end


### PR DESCRIPTION
This patch fixes an error that occurred when a UUID index was created
on a SCALAR field or a SCALAR index was created on a UUID field.

Follow-up #6042

NO_DOC=Follow up.
NO_CHANGELOG=Follow up.