### PR TITLE
Move default_value_expr from field_def to tuple_field

### DIFF
--- a/src/box/ck_constraint.c
+++ b/src/box/ck_constraint.c
@@ -244,11 +244,11 @@ ck_constraint_new(struct ck_constraint_def *ck_constraint_def,
 	if (ck_constraint->stmt == NULL)
 		goto error;
 
-	sql_expr_delete(sql_get(), expr, false);
+	sql_expr_delete(sql_get(), expr);
 	ck_constraint->def = ck_constraint_def;
 	return ck_constraint;
 error:
-	sql_expr_delete(sql_get(), expr, false);
+	sql_expr_delete(sql_get(), expr);
 	ck_constraint_delete(ck_constraint);
 	return NULL;
 }

--- a/src/box/field_def.c
+++ b/src/box/field_def.c
@@ -198,7 +198,6 @@ const struct field_def field_def_default = {
 	.nullable_action = ON_CONFLICT_ACTION_DEFAULT,
 	.coll_id = COLL_NONE,
 	.default_value = NULL,
-	.default_value_expr = NULL,
 	.constraint_count = 0,
 	.constraint_def = NULL,
 };

--- a/src/box/field_def.h
+++ b/src/box/field_def.h
@@ -146,8 +146,6 @@ struct field_def {
 	uint32_t coll_id;
 	/** 0-terminated SQL expression for DEFAULT value. */
 	char *default_value;
-	/** AST for parsed default value. */
-	struct Expr *default_value_expr;
 	/** Type of comression to this field */
 	enum compression_type compression_type;
 	/** Array of constraints. Can be NULL if constraints_count == 0. */

--- a/src/box/space_def.c
+++ b/src/box/space_def.c
@@ -32,7 +32,6 @@
 #include "space_def.h"
 #include "diag.h"
 #include "error.h"
-#include "sql.h"
 #include "msgpuck.h"
 #include "tt_static.h"
 #include "tuple_constraint_def.h"
@@ -84,27 +83,20 @@ const struct opt_def space_opts_reg[] = {
 size_t
 space_def_sizeof(uint32_t name_len, const struct field_def *fields,
 		 uint32_t field_count, uint32_t *names_offset,
-		 uint32_t *fields_offset, uint32_t *def_expr_offset)
+		 uint32_t *fields_offset)
 {
 	uint32_t field_strs_size = 0;
-	uint32_t def_exprs_size = 0;
 	for (uint32_t i = 0; i < field_count; ++i) {
 		field_strs_size += strlen(fields[i].name) + 1;
 		if (fields[i].default_value != NULL) {
 			int len = strlen(fields[i].default_value);
 			field_strs_size += len + 1;
-			if (fields[i].default_value_expr != NULL) {
-				struct Expr *e = fields[i].default_value_expr;
-				def_exprs_size += sql_expr_sizeof(e, 0);
-			}
 		}
 	}
 	*fields_offset = small_align(sizeof(struct space_def) + name_len + 1,
 				     alignof(typeof(fields[0])));
 	*names_offset = *fields_offset + field_count * sizeof(struct field_def);
-	*def_expr_offset = small_align(*names_offset + field_strs_size,
-				       alignof(uint64_t));
-	return *def_expr_offset + def_exprs_size;
+	return *names_offset + field_strs_size;
 }
 
 struct tuple_format *
@@ -149,10 +141,10 @@ space_def_dup_opts(struct space_def *def, const struct space_opts *opts)
 struct space_def *
 space_def_dup(const struct space_def *src)
 {
-	uint32_t strs_offset, fields_offset, def_expr_offset;
+	uint32_t strs_offset, fields_offset;
 	size_t size = space_def_sizeof(strlen(src->name), src->fields,
 				       src->field_count, &strs_offset,
-				       &fields_offset, &def_expr_offset);
+				       &fields_offset);
 	struct space_def *ret = (struct space_def *) malloc(size);
 	if (ret == NULL) {
 		diag_set(OutOfMemory, size, "malloc", "ret");
@@ -161,7 +153,6 @@ space_def_dup(const struct space_def *src)
 	memcpy(ret, src, size);
 	memset(&ret->opts, 0, sizeof(ret->opts));
 	char *strs_pos = (char *)ret + strs_offset;
-	char *expr_pos = (char *)ret + def_expr_offset;
 	if (src->field_count > 0) {
 		ret->fields = (struct field_def *)((char *)ret + fields_offset);
 		for (uint32_t i = 0; i < src->field_count; ++i) {
@@ -170,22 +161,6 @@ space_def_dup(const struct space_def *src)
 			if (src->fields[i].default_value != NULL) {
 				ret->fields[i].default_value = strs_pos;
 				strs_pos += strlen(strs_pos) + 1;
-			}
-			struct Expr *e = src->fields[i].default_value_expr;
-			if (e != NULL) {
-				char *expr_pos_old = expr_pos;
-				(void) expr_pos_old;
-				e = sql_expr_dup(sql_get(), e, 0, &expr_pos);
-				assert(e != NULL);
-				/* Note: due to SQL legacy
-				 * duplicactor pointer is not
-				 * promoted for REDUCED exprs.
-				 * Will be fixed w/ Expt
-				 * allocation refactoring.
-				 */
-				assert(expr_pos_old == expr_pos);
-				expr_pos += sql_expr_sizeof(e, 0);
-				ret->fields[i].default_value_expr = e;
 			}
 			ret->fields[i].constraint_count =
 				src->fields[i].constraint_count;
@@ -210,10 +185,9 @@ space_def_new(uint32_t id, uint32_t uid, uint32_t exact_field_count,
 	      const struct space_opts *opts, const struct field_def *fields,
 	      uint32_t field_count)
 {
-	uint32_t strs_offset, fields_offset, def_expr_offset;
+	uint32_t strs_offset, fields_offset;
 	size_t size = space_def_sizeof(name_len, fields, field_count,
-				       &strs_offset, &fields_offset,
-				       &def_expr_offset);
+				       &strs_offset, &fields_offset);
 	struct space_def *def = (struct space_def *) malloc(size);
 	if (def == NULL) {
 		diag_set(OutOfMemory, size, "malloc", "def");
@@ -240,7 +214,6 @@ space_def_new(uint32_t id, uint32_t uid, uint32_t exact_field_count,
 		def->fields = NULL;
 	} else {
 		char *strs_pos = (char *)def + strs_offset;
-		char *expr_pos = (char *)def + def_expr_offset;
 		def->fields = (struct field_def *)((char *)def + fields_offset);
 		for (uint32_t i = 0; i < field_count; ++i) {
 			def->fields[i] = fields[i];
@@ -258,24 +231,6 @@ space_def_new(uint32_t id, uint32_t uid, uint32_t exact_field_count,
 				def->fields[i].default_value[len] = 0;
 				strs_pos += len + 1;
 			}
-			struct Expr *e = def->fields[i].default_value_expr;
-			if (e != NULL) {
-				char *expr_pos_old = expr_pos;
-				(void) expr_pos_old;
-				e = sql_expr_dup(sql_get(), e, 0, &expr_pos);
-				assert(e != NULL);
-				/* Note: due to SQL legacy
-				 * duplicactor pointer is
-				 * not promoted for
-				 * REDUCED exprs. Will be
-				 * fixed w/ Expt
-				 * allocation refactoring.
-				 */
-				assert(expr_pos_old == expr_pos);
-				expr_pos += sql_expr_sizeof(e, 0);
-				def->fields[i].default_value_expr = e;
-			}
-
 			def->fields[i].constraint_def =
 				tuple_constraint_def_array_dup(
 					fields[i].constraint_def,
@@ -308,28 +263,16 @@ space_def_new_ephemeral(uint32_t exact_field_count, struct field_def *fields)
 	return space_def;
 }
 
-/** Free a default value's syntax trees of @a defs. */
-void
-space_def_destroy_fields(struct field_def *fields, uint32_t field_count,
-			 bool extern_alloc)
-{
-	for (uint32_t i = 0; i < field_count; ++i) {
-		if (fields[i].default_value_expr != NULL) {
-			sql_expr_delete(sql_get(), fields[i].default_value_expr,
-					extern_alloc);
-		}
-		if (extern_alloc)
-			free(fields[i].constraint_def);
-		TRASH(&fields[i]);
-	}
-}
-
 void
 space_def_delete(struct space_def *def)
 {
+	for (uint32_t i = 0; i < def->field_count; ++i) {
+		struct field_def *field = &def->fields[i];
+		free(field->constraint_def);
+		TRASH(field);
+	}
 	space_opts_destroy(&def->opts);
 	tuple_dictionary_unref(def->dict);
-	space_def_destroy_fields(def->fields, def->field_count, true);
 	TRASH(def);
 	free(def);
 }

--- a/src/box/space_def.h
+++ b/src/box/space_def.h
@@ -135,19 +135,6 @@ struct space_def {
 	char name[0];
 };
 
-/*
- * Free a default value syntax trees and other private data of @a defs.
- * @param fields Fields array to destroy.
- * @param field_count Length of @a fields.
- * @param extern_alloc Fields expression AST allocated externally.
- *                     (specify false when sql_expr_delete should
- *                      release default_value_expr memory,
- *                      true - when shouldn't)
- */
-void
-space_def_destroy_fields(struct field_def *fields, uint32_t field_count,
-			 bool extern_alloc);
-
 /**
  * Delete the space_def object.
  * @param def Def to delete.
@@ -205,14 +192,12 @@ space_def_new_ephemeral(uint32_t exact_field_count, struct field_def *fields);
  *             a field names memory.
  * @param[out] fields_offset Offset from the beginning of a def to
  *             a fields array.
- * @param[out] def_expr_offset Offset from the beginning of a def
- *             to a def_value_expr array.
  * @retval Size in bytes.
  */
 size_t
 space_def_sizeof(uint32_t name_len, const struct field_def *fields,
 		 uint32_t field_count, uint32_t *names_offset,
-		 uint32_t *fields_offset, uint32_t *def_expr_offset);
+		 uint32_t *fields_offset);
 
 struct tuple_format;
 struct tuple_format_vtab;

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -73,7 +73,7 @@ sql_expr_compile_cb(const char *expr, int expr_len)
 static void
 sql_expr_delete_cb(struct Expr *expr)
 {
-	sql_expr_delete(sql_get(), expr, false);
+	sql_expr_delete(sql_get(), expr);
 }
 
 void

--- a/src/box/sql.h
+++ b/src/box/sql.h
@@ -215,10 +215,9 @@ sql_expr_dup(struct sql *db, struct Expr *p, int flags, char **buffer);
  * Free AST pointed by expr.
  * @param db SQL handle.
  * @param expr Root pointer of ASR
- * @param extern_alloc True if skeleton was allocated externally.
  */
 void
-sql_expr_delete(struct sql *db, struct Expr *expr, bool extern_alloc);
+sql_expr_delete(struct sql *db, struct Expr *expr);
 
 /**
  * Create and initialize a new template space object.

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -540,7 +540,7 @@ sqlAddDefaultValue(Parse * pParse, ExprSpan * pSpan)
 			field->default_value[default_length] = '\0';
 		}
 	}
-	sql_expr_delete(db, pSpan->pExpr, false);
+	sql_expr_delete(db, pSpan->pExpr);
 }
 
 static int
@@ -701,7 +701,7 @@ sql_create_check_contraint(struct Parse *parser)
 {
 	struct create_ck_def *create_ck_def = &parser->create_ck_def;
 	struct ExprSpan *expr_span = create_ck_def->expr;
-	sql_expr_delete(parser->db, expr_span->pExpr, false);
+	sql_expr_delete(parser->db, expr_span->pExpr);
 
 	struct alter_entity_def *alter_def =
 		(struct alter_entity_def *) create_ck_def;
@@ -1620,7 +1620,7 @@ sql_id_eq_str_expr(struct Parse *parse, const char *col_name,
 	struct Expr *col_value_expr =
 		sql_expr_new_named(db, TK_STRING, col_value);
 	if (col_value_expr == NULL) {
-		sql_expr_delete(db, col_name_expr, false);
+		sql_expr_delete(db, col_name_expr);
 		parse->is_aborted = true;
 		return NULL;
 	}
@@ -3243,7 +3243,7 @@ sqlSrcListDelete(sql * db, SrcList * pList)
 			!pItem->space->def->opts.is_ephemeral ||
 			pItem->space->index == NULL);
 		sql_select_delete(db, pItem->pSelect);
-		sql_expr_delete(db, pItem->pOn, false);
+		sql_expr_delete(db, pItem->pOn);
 		sqlIdListDelete(db, pItem->pUsing);
 	}
 	sqlDbFree(db, pList);
@@ -3306,7 +3306,7 @@ sqlSrcListAppendFromTerm(Parse * pParse,	/* Parsing context */
 
  append_from_error:
 	assert(p == 0);
-	sql_expr_delete(db, pOn, false);
+	sql_expr_delete(db, pOn);
 	sqlIdListDelete(db, pUsing);
 	sql_select_delete(db, pSubquery);
 	return 0;

--- a/src/box/sql/delete.c
+++ b/src/box/sql/delete.c
@@ -413,7 +413,7 @@ sql_table_delete_from(struct Parse *parse, struct SrcList *tab_list,
 
  delete_from_cleanup:
 	sqlSrcListDelete(db, tab_list);
-	sql_expr_delete(db, where, false);
+	sql_expr_delete(db, where);
 }
 
 void

--- a/src/box/sql/fk_constraint.c
+++ b/src/box/sql/fk_constraint.c
@@ -479,7 +479,7 @@ fk_constraint_scan_children(struct Parse *parser, struct SrcList *src,
 		sqlWhereEnd(info);
 
 	/* Clean up the WHERE clause constructed above. */
-	sql_expr_delete(db, where, false);
+	sql_expr_delete(db, where);
 	if (fkifzero_label != 0)
 		sqlVdbeJumpHere(v, fkifzero_label);
 }
@@ -869,8 +869,8 @@ fk_constraint_action_trigger(struct Parse *pParse, struct space_def *def,
 		}
 	}
 
-	sql_expr_delete(db, where, false);
-	sql_expr_delete(db, when, false);
+	sql_expr_delete(db, where);
+	sql_expr_delete(db, when);
 	sql_expr_list_delete(db, list);
 	sql_select_delete(db, select);
 	if (db->mallocFailed) {

--- a/src/box/sql/fk_constraint.c
+++ b/src/box/sql/fk_constraint.c
@@ -37,6 +37,7 @@
 #include "sqlInt.h"
 #include "box/fk_constraint.h"
 #include "box/schema.h"
+#include "box/tuple_format.h"
 
 /*
  * Deferred and Immediate FKs
@@ -808,7 +809,9 @@ fk_constraint_action_trigger(struct Parse *pParse, struct space_def *def,
 
 		if (action != FKEY_ACTION_RESTRICT &&
 		    (action != FKEY_ACTION_CASCADE || is_update)) {
-			struct Expr *d = child_fields[chcol].default_value_expr;
+			struct tuple_field *field = tuple_format_field(
+				child_space->format, chcol);
+			struct Expr *d = field->default_value_expr;
 			if (action == FKEY_ACTION_CASCADE) {
 				new = sql_expr_new_2part_id(pParse, &t_new,
 							    &t_to_col);

--- a/src/box/sql/insert.c
+++ b/src/box/sql/insert.c
@@ -41,6 +41,7 @@
 #include "bit/bit.h"
 #include "box/box.h"
 #include "box/schema.h"
+#include "box/tuple_format.h"
 
 void
 sql_emit_table_types(struct Vdbe *v, struct space_def *def, int reg)
@@ -588,9 +589,11 @@ sqlInsert(Parse * pParse,	/* Parser context */
 					sqlVdbeAddOp2(v, OP_Integer, -1,
 							  regCols + i + 1);
 				} else {
-					struct Expr *dflt = NULL;
-					dflt = space_def->fields[i].
-						default_value_expr;
+					struct tuple_field *field =
+						tuple_format_field(
+							space->format, i);
+					struct Expr *dflt =
+						field->default_value_expr;
 					sqlExprCode(pParse,
 							dflt,
 							regCols + i + 1);
@@ -650,8 +653,9 @@ sqlInsert(Parse * pParse,	/* Parser context */
 					sqlVdbeAddOp2(v, OP_Null, 0, iRegStore);
 					continue;
 				}
-				struct Expr *dflt = NULL;
-				dflt = space_def->fields[i].default_value_expr;
+				struct tuple_field *field =
+					tuple_format_field(space->format, i);
+				struct Expr *dflt = field->default_value_expr;
 				sqlExprCodeFactorable(pParse,
 							  dflt,
 							  iRegStore);

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -729,7 +729,7 @@ joinop(X) ::= JOIN_KW(A) join_nm(B) join_nm(C) JOIN.
                   {X = sqlJoinType(pParse,&A,&B,&C);/*X-overwrites-A*/}
 
 %type on_opt {Expr*}
-%destructor on_opt {sql_expr_delete(pParse->db, $$, false);}
+%destructor on_opt {sql_expr_delete(pParse->db, $$);}
 on_opt(N) ::= ON expr(E).   {N = E.pExpr;}
 on_opt(N) ::= .             {N = 0;}
 
@@ -823,7 +823,7 @@ groupby_opt(A) ::= .                      {A = 0;}
 groupby_opt(A) ::= GROUP BY nexprlist(X). {A = X;}
 
 %type having_opt {Expr*}
-%destructor having_opt {sql_expr_delete(pParse->db, $$, false);}
+%destructor having_opt {sql_expr_delete(pParse->db, $$);}
 having_opt(A) ::= .                {A = 0;}
 having_opt(A) ::= HAVING expr(X).  {A = X.pExpr;}
 
@@ -866,7 +866,7 @@ cmd ::= TRUNCATE TABLE fullname(X). {
 }
 
 %type where_opt {Expr*}
-%destructor where_opt {sql_expr_delete(pParse->db, $$, false);}
+%destructor where_opt {sql_expr_delete(pParse->db, $$);}
 
 where_opt(A) ::= .                    {A = 0;}
 where_opt(A) ::= WHERE expr(X).       {A = X.pExpr;}
@@ -955,9 +955,9 @@ idlist(A) ::= nm(Y). {
 //
 
 %type expr {ExprSpan}
-%destructor expr {sql_expr_delete(pParse->db, $$.pExpr, false);}
+%destructor expr {sql_expr_delete(pParse->db, $$.pExpr);}
 %type term {ExprSpan}
-%destructor term {sql_expr_delete(pParse->db, $$.pExpr, false);}
+%destructor term {sql_expr_delete(pParse->db, $$.pExpr);}
 
 %include {
   /* This is a utility routine used to set the ExprSpan.zStart and
@@ -1060,7 +1060,7 @@ expr(A) ::= nm(X) DOT nm(Y). {
   }
   struct Expr *temp2 = sql_expr_new_dequoted(pParse->db, TK_ID, &Y);
   if (temp2 == NULL) {
-    sql_expr_delete(pParse->db, temp1, false);
+    sql_expr_delete(pParse->db, temp1);
     pParse->is_aborted = true;
     return;
   }
@@ -1179,7 +1179,7 @@ trim_operands(A) ::= expr(Y). {
 }
 
 %type expr_optional {struct Expr *}
-%destructor expr_optional {sql_expr_delete(pParse->db, $$, false);}
+%destructor expr_optional {sql_expr_delete(pParse->db, $$);}
 
 expr_optional(A) ::= .        { A = NULL; }
 expr_optional(A) ::= expr(X). { A = X.pExpr; }
@@ -1386,7 +1386,7 @@ expr(A) ::= expr(A) in_op(N) LP exprlist(Y) RP(E). [IN] {
     ** simplify to constants 0 (false) and 1 (true), respectively,
     ** regardless of the value of expr1.
     */
-    sql_expr_delete(pParse->db, A.pExpr, false);
+    sql_expr_delete(pParse->db, A.pExpr);
     int tk = N == 0 ? TK_FALSE : TK_TRUE;
     A.pExpr = sql_expr_new_anon(pParse->db, tk);
     if (A.pExpr == NULL) {
@@ -1462,7 +1462,7 @@ expr(A) ::= CASE(C) expr_optional(X) case_exprlist(Y) case_else(Z) END(E). {
     sqlExprSetHeightAndFlags(pParse, A.pExpr);
   }else{
     sql_expr_list_delete(pParse->db, Y);
-    sql_expr_delete(pParse->db, Z, false);
+    sql_expr_delete(pParse->db, Z);
   }
 }
 %type case_exprlist {ExprList*}
@@ -1476,7 +1476,7 @@ case_exprlist(A) ::= WHEN expr(Y) THEN expr(Z). {
   A = sql_expr_list_append(pParse->db,A, Z.pExpr);
 }
 %type case_else {Expr*}
-%destructor case_else {sql_expr_delete(pParse->db, $$, false);}
+%destructor case_else {sql_expr_delete(pParse->db, $$);}
 case_else(A) ::=  ELSE expr(X).         {A = X.pExpr;}
 case_else(A) ::=  .                     {A = 0;} 
 
@@ -1625,7 +1625,7 @@ foreach_clause ::= . {
 foreach_clause ::= FOR EACH ROW.
 
 %type when_clause {Expr*}
-%destructor when_clause {sql_expr_delete(pParse->db, $$, false);}
+%destructor when_clause {sql_expr_delete(pParse->db, $$);}
 when_clause(A) ::= .             { A = 0; }
 when_clause(A) ::= WHEN expr(X). { A = X.pExpr; }
 

--- a/src/box/sql/prepare.c
+++ b/src/box/sql/prepare.c
@@ -226,7 +226,7 @@ sql_parser_destroy(Parse *parser)
 		sql_select_delete(db, parser->parsed_ast.select);
 		break;
 	case AST_TYPE_EXPR:
-		sql_expr_delete(db, parser->parsed_ast.expr, false);
+		sql_expr_delete(db, parser->parsed_ast.expr);
 		break;
 	case AST_TYPE_TRIGGER:
 		sql_trigger_delete(db, parser->parsed_ast.trigger);

--- a/src/box/sql/resolve.c
+++ b/src/box/sql/resolve.c
@@ -124,7 +124,7 @@ resolveAlias(Parse * pParse,	/* Parsing context */
 	 * make a copy of the token before doing the sqlDbFree().
 	 */
 	ExprSetProperty(pExpr, EP_Static);
-	sql_expr_delete(db, pExpr, false);
+	sql_expr_delete(db, pExpr);
 	memcpy(pExpr, pDup, sizeof(*pExpr));
 	if (!ExprHasProperty(pExpr, EP_IntValue) && pExpr->u.zToken != 0) {
 		assert((pExpr->flags & (EP_Reduced | EP_TokenOnly)) == 0);
@@ -457,9 +457,9 @@ lookupName(Parse * pParse,	/* The parsing context */
 
 	/* Clean up and return
 	 */
-	sql_expr_delete(db, pExpr->pLeft, false);
+	sql_expr_delete(db, pExpr->pLeft);
 	pExpr->pLeft = 0;
-	sql_expr_delete(db, pExpr->pRight, false);
+	sql_expr_delete(db, pExpr->pRight);
 	pExpr->pRight = 0;
 	pExpr->op = (isTrigger ? TK_TRIGGER : TK_COLUMN_REF);
  lookupname_end:
@@ -925,7 +925,7 @@ resolveCompoundOrderBy(Parse * pParse,	/* Parsing context.  Leave error messages
 						    resolveOrderByTermToExprList
 						    (pParse, pSelect, pDup);
 					}
-					sql_expr_delete(db, pDup, false);
+					sql_expr_delete(db, pDup);
 				}
 			}
 			if (iCol > 0) {
@@ -951,7 +951,7 @@ resolveCompoundOrderBy(Parse * pParse,	/* Parsing context.  Leave error messages
 					assert(pParent->pLeft == pE);
 					pParent->pLeft = pNew;
 				}
-				sql_expr_delete(db, pE, false);
+				sql_expr_delete(db, pE);
 				pItem->u.x.iOrderByCol = (u16) iCol;
 				pItem->done = 1;
 			} else {
@@ -1300,7 +1300,7 @@ resolveSelectStep(Walker * pWalker, Select * p)
 			 * LIMIT but there is no reason to
 			 * restrict it directly).
 			 */
-			sql_expr_delete(db, p->pLimit, false);
+			sql_expr_delete(db, p->pLimit);
 			p->pLimit = sql_expr_new(db, TK_INTEGER,
 						 &sqlIntTokens[1]);
 			if (p->pLimit == NULL)

--- a/src/box/sql/select.c
+++ b/src/box/sql/select.c
@@ -281,12 +281,12 @@ clearSelect(sql * db, Select * p, int bFree)
 		Select *pPrior = p->pPrior;
 		sql_expr_list_delete(db, p->pEList);
 		sqlSrcListDelete(db, p->pSrc);
-		sql_expr_delete(db, p->pWhere, false);
+		sql_expr_delete(db, p->pWhere);
 		sql_expr_list_delete(db, p->pGroupBy);
-		sql_expr_delete(db, p->pHaving, false);
+		sql_expr_delete(db, p->pHaving);
 		sql_expr_list_delete(db, p->pOrderBy);
-		sql_expr_delete(db, p->pLimit, false);
-		sql_expr_delete(db, p->pOffset, false);
+		sql_expr_delete(db, p->pLimit);
+		sql_expr_delete(db, p->pOffset);
 		if (p->pWith)
 			sqlWithDelete(db, p->pWith);
 		if (bFree)
@@ -3055,7 +3055,7 @@ multiSelect(Parse * pParse,	/* Parsing context */
 							     pPrior->
 							     nSelectRow);
 				}
-				sql_expr_delete(db, p->pLimit, false);
+				sql_expr_delete(db, p->pLimit);
 				p->pLimit = pLimit;
 				p->pOffset = pOffset;
 				p->iLimit = 0;
@@ -3158,7 +3158,7 @@ multiSelect(Parse * pParse,	/* Parsing context */
 				p->pPrior = pPrior;
 				if (p->nSelectRow > pPrior->nSelectRow)
 					p->nSelectRow = pPrior->nSelectRow;
-				sql_expr_delete(db, p->pLimit, false);
+				sql_expr_delete(db, p->pLimit);
 				p->pLimit = pLimit;
 				p->pOffset = pOffset;
 
@@ -3665,9 +3665,9 @@ multiSelectOrderBy(Parse * pParse,	/* Parsing context */
 	} else {
 		regLimitA = regLimitB = 0;
 	}
-	sql_expr_delete(db, p->pLimit, false);
+	sql_expr_delete(db, p->pLimit);
 	p->pLimit = 0;
-	sql_expr_delete(db, p->pOffset, false);
+	sql_expr_delete(db, p->pOffset);
 	p->pOffset = 0;
 
 	regAddrA = ++pParse->nMem;
@@ -3887,7 +3887,7 @@ substExpr(Parse * pParse,	/* Report errors here */
 					    pExpr->iRightJoinTable;
 					pNew->flags |= EP_FromJoin;
 				}
-				sql_expr_delete(db, pExpr, false);
+				sql_expr_delete(db, pExpr);
 				pExpr = pNew;
 			}
 		}

--- a/src/box/sql/trigger.c
+++ b/src/box/sql/trigger.c
@@ -53,7 +53,7 @@ sqlDeleteTriggerStep(sql * db, TriggerStep * pTriggerStep)
 		TriggerStep *pTmp = pTriggerStep;
 		pTriggerStep = pTriggerStep->pNext;
 
-		sql_expr_delete(db, pTmp->pWhere, false);
+		sql_expr_delete(db, pTmp->pWhere);
 		sql_expr_list_delete(db, pTmp->pExprList);
 		sql_select_delete(db, pTmp->pSelect);
 		sqlIdListDelete(db, pTmp->pIdList);
@@ -143,7 +143,7 @@ sql_trigger_begin(struct Parse *parse)
 	sqlDbFree(db, trigger_name);
 	sqlSrcListDelete(db, alter_def->entity_name);
 	sqlIdListDelete(db, trigger_def->cols);
-	sql_expr_delete(db, trigger_def->when, false);
+	sql_expr_delete(db, trigger_def->when);
 	if (parse->parsed_ast.trigger == NULL)
 		sql_trigger_delete(db, trigger);
 	else
@@ -337,7 +337,7 @@ sql_trigger_update_step(struct sql *db, struct Token *table_name,
 		trigger_step->orconf = orconf;
 	}
 	sql_expr_list_delete(db, new_list);
-	sql_expr_delete(db, where, false);
+	sql_expr_delete(db, where);
 	return trigger_step;
 }
 
@@ -351,7 +351,7 @@ sql_trigger_delete_step(struct sql *db, struct Token *table_name,
 		trigger_step->pWhere = sqlExprDup(db, where, EXPRDUP_REDUCE);
 		trigger_step->orconf = ON_CONFLICT_ACTION_DEFAULT;
 	}
-	sql_expr_delete(db, where, false);
+	sql_expr_delete(db, where);
 	return trigger_step;
 }
 
@@ -362,7 +362,7 @@ sql_trigger_delete(struct sql *db, struct sql_trigger *trigger)
 		return;
 	sqlDeleteTriggerStep(db, trigger->step_list);
 	sqlDbFree(db, trigger->zName);
-	sql_expr_delete(db, trigger->pWhen, false);
+	sql_expr_delete(db, trigger->pWhen);
 	sqlIdListDelete(db, trigger->pColumns);
 	sqlDbFree(db, trigger);
 }
@@ -790,7 +790,7 @@ sql_row_trigger_program(struct Parse *parser, struct sql_trigger *trigger,
 						   iEndTrigger,
 						   SQL_JUMPIFNULL);
 			}
-			sql_expr_delete(db, pWhen, false);
+			sql_expr_delete(db, pWhen);
 		}
 
 		/* Code the trigger program into the sub-vdbe. */

--- a/src/box/sql/update.c
+++ b/src/box/sql/update.c
@@ -483,6 +483,6 @@ sqlUpdate(Parse * pParse,		/* The parser context */
  update_cleanup:
 	sqlSrcListDelete(db, pTabList);
 	sql_expr_list_delete(db, pChanges);
-	sql_expr_delete(db, pWhere, false);
+	sql_expr_delete(db, pWhere);
 	return;
 }

--- a/src/box/sql/wherecode.c
+++ b/src/box/sql/wherecode.c
@@ -1346,7 +1346,7 @@ sqlWhereCodeOneLoopStart(WhereInfo * pWInfo,	/* Complete information about the W
 			pLevel->iIdxCur = iCovCur;
 		if (pAndExpr) {
 			pAndExpr->pLeft = 0;
-			sql_expr_delete(db, pAndExpr, false);
+			sql_expr_delete(db, pAndExpr);
 		}
 		sqlVdbeChangeP1(v, iRetInit, sqlVdbeCurrentAddr(v));
 		sqlVdbeGoto(v, pLevel->addrBrk);

--- a/src/box/sql/whereexpr.c
+++ b/src/box/sql/whereexpr.c
@@ -99,7 +99,7 @@ whereClauseInsert(WhereClause * pWC, Expr * p, u16 wtFlags)
 					 sizeof(pWC->a[0]) * pWC->nSlot * 2);
 		if (pWC->a == 0) {
 			if (wtFlags & TERM_DYNAMIC) {
-				sql_expr_delete(db, p, false);
+				sql_expr_delete(db, p);
 			}
 			pWC->a = pOld;
 			return 0;
@@ -1082,7 +1082,7 @@ exprAnalyze(SrcList * pSrc,	/* the FROM clause */
 				int idxNew;
 				pDup = sqlExprDup(db, pExpr, 0);
 				if (db->mallocFailed) {
-					sql_expr_delete(db, pDup, false);
+					sql_expr_delete(db, pDup);
 					return;
 				}
 				idxNew =
@@ -1381,7 +1381,7 @@ sqlWhereClauseClear(WhereClause * pWC)
 	sql *db = pWC->pWInfo->pParse->db;
 	for (i = pWC->nTerm - 1, a = pWC->a; i >= 0; i--, a++) {
 		if (a->wtFlags & TERM_DYNAMIC) {
-			sql_expr_delete(db, a->pExpr, false);
+			sql_expr_delete(db, a->pExpr);
 		}
 		if (a->wtFlags & TERM_ORINFO) {
 			whereOrInfoDelete(db, a->u.pOrInfo);

--- a/src/box/tuple_format.h
+++ b/src/box/tuple_format.h
@@ -68,6 +68,25 @@ struct tuple;
 struct tuple_chunk;
 struct tuple_format;
 struct coll;
+struct Expr;
+
+typedef struct Expr *
+(*tuple_format_expr_compile_f)(const char *expr, int expr_len);
+
+typedef void
+(*tuple_format_expr_delete_f)(struct Expr *expr);
+
+/**
+ * Callback that compiles an SQL expression.
+ * Needed for avoid SQL dependency.
+ */
+extern tuple_format_expr_compile_f tuple_format_expr_compile;
+
+/**
+ * Callback that deletes an SQL expression.
+ * Needed for avoid SQL dependency.
+ */
+extern tuple_format_expr_delete_f tuple_format_expr_delete;
 
 /** Engine-specific tuple format methods. */
 struct tuple_format_vtab {
@@ -142,6 +161,8 @@ struct tuple_field {
 	struct tuple_constraint *constraint;
 	/** Number of constraints. */
 	uint32_t constraint_count;
+	/** AST for parsed default value. */
+	struct Expr *default_value_expr;
 };
 
 /**


### PR DESCRIPTION
`field_def`, like any other `_def` struct, is supposed to be plain and simple - it should map data stored in the `_space` system spaces as is. Complex data structures produced from it, like field dictionary or compiled SQL expression should be stored in tuple_field. This simplifies reasoning about the lifetime of this structure:
 - If it's allocated on the region, as it is the case, when the structure is created from MsgPack data, it will live until the
   region is truncated. It doesn't need to be destroyed in this case.
 - If it's allocated on malloc (by a dup function), it should be explicitly deleted with a delete function.

Why we are doing this now: to implement space upgrade, we'll need to add a new member to `space_opts` struct. The new member will be a struct that may store an array of `field_def`. The problem is `space_opts` created on the region from MsgPack data is never deleted (see `alter.cc`), which means that the expression stored in `field_def` could leak.