### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-5813-resolving-of-c-symbols.md
+++ b/changelogs/unreleased/gh-5813-resolving-of-c-symbols.md
@@ -1,0 +1,6 @@
+## feature/luajit
+
+* Now memory profiler dumps symbol table for C functions. As a result memory
+  profiler parser can enrich its symbol table with C symbols (gh-5813).
+  Furthermore, now memprof dumps special events for symbol table when it
+  encounters a new C symbol, that hasn't been dumped yet.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,6 +80,7 @@ lua_source(lua_sources ${LUAJIT_SOURCE_ROOT}/tools/memprof.lua memprof_lua)
 lua_source(lua_sources ${LUAJIT_SOURCE_ROOT}/tools/memprof/humanize.lua memprof_humanize_lua)
 lua_source(lua_sources ${LUAJIT_SOURCE_ROOT}/tools/memprof/parse.lua memprof_parse_lua)
 lua_source(lua_sources ${LUAJIT_SOURCE_ROOT}/tools/memprof/process.lua memprof_process_lua)
+lua_source(lua_sources ${LUAJIT_SOURCE_ROOT}/tools/utils/avl.lua utils_avl_lua)
 lua_source(lua_sources ${LUAJIT_SOURCE_ROOT}/tools/utils/bufread.lua utils_bufread_lua)
 lua_source(lua_sources ${LUAJIT_SOURCE_ROOT}/tools/utils/symtab.lua utils_symtab_lua)
 

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -137,6 +137,7 @@ extern char strict_lua[],
 	jit_p_lua[], /* LuaJIT 2.1 profiler */
 	jit_zone_lua[], /* LuaJIT 2.1 profiler */
 	/* tools.* libraries. */
+	utils_avl_lua[],
 	utils_bufread_lua[],
 	utils_symtab_lua[],
 	memprof_parse_lua[],
@@ -285,6 +286,7 @@ static const char *lua_modules[] = {
 	"jit.p", jit_p_lua,
 	"jit.zone", jit_zone_lua,
 	/* tools.* libraries. Order is important. */
+	"utils.avl", utils_avl_lua,
 	"utils.bufread", utils_bufread_lua,
 	"utils.symtab", utils_symtab_lua,
 	"memprof.parse", memprof_parse_lua,


### PR DESCRIPTION
LuaJIT submodule is bumped to introduce the following changes:
* memprof: enrich symtab with newly loaded symbols
* memprof: extend symtab with C symbols
    
Within this changeset the new Lua module providing minimalistic AVL tree
implementation required for processing C symbols is introduced:
* utils/avl.lua: minimalistic AVL tree implementation
   
Closes #5813
    
NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump