### PR TITLE
mvcc: track nothing-found range read

### DIFF
--- a/changelogs/unreleased/gh-7025-mvcc-dirty-range.md
+++ b/changelogs/unreleased/gh-7025-mvcc-dirty-range.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fixed a bug when MVCC fails to track nothing-found range select (gh-7025).

--- a/test/box-luatest/gh_7025_mvcc_dirty_range_test.lua
+++ b/test/box-luatest/gh_7025_mvcc_dirty_range_test.lua
@@ -1,0 +1,112 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all = function()
+    g.server = server:new{
+        alias   = 'default',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    g.server:start()
+end
+
+g.after_all = function()
+    g.server:drop()
+end
+
+g.before_each(function()
+    g.server:exec(function()
+        local s = box.schema.space.create('test')
+        s:create_index('primary', {parts = {{1, 'uint'}, {2, 'uint'}}})
+    end)
+end)
+
+g.after_each(function()
+    g.server:exec(function()
+        if box.space.test then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+g.test_empty_range_select_left = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.test
+        local key = 1
+        s:replace{2, 0}
+        s:replace{3, 0}
+
+        local txn_proxy = require("test.box.lua.txn_proxy")
+        local tx = txn_proxy.new()
+
+        tx:begin()
+        local strkey = tostring(key)
+        local select_req = 'box.space.test:select{' .. strkey .. '}'
+        local replace_req = 'box.space.test:replace{' .. strkey .. ', 1}'
+        t.assert_equals(tx(select_req), {{}})
+        s:replace{key, 0}
+        t.assert_equals(tx(select_req), {{}})
+        t.assert_equals(tx(replace_req), {{key, 1}})
+        t.assert_equals(tx(select_req), {{{key, 1}}})
+        t.assert_equals(tx:commit(),
+            {{error = "Transaction has been aborted by conflict"}})
+
+        t.assert_equals(s:select{}, {{1, 0}, {2, 0}, {3, 0}})
+    end)
+end
+
+g.test_empty_range_select_middle = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.test
+        local key = 2
+        s:replace{1, 0}
+        s:replace{3, 0}
+
+        local txn_proxy = require("test.box.lua.txn_proxy")
+        local tx = txn_proxy.new()
+
+        tx:begin()
+        local strkey = tostring(key)
+        local select_req = 'box.space.test:select{' .. strkey .. '}'
+        local replace_req = 'box.space.test:replace{' .. strkey .. ', 1}'
+        t.assert_equals(tx(select_req), {{}})
+        s:replace{key, 0}
+        t.assert_equals(tx(select_req), {{}})
+        t.assert_equals(tx(replace_req), {{key, 1}})
+        t.assert_equals(tx(select_req), {{{key, 1}}})
+        t.assert_equals(tx:commit(),
+            {{error = "Transaction has been aborted by conflict"}})
+
+        t.assert_equals(s:select{}, {{1, 0}, {2, 0}, {3, 0}})
+    end)
+end
+
+g.test_empty_range_select_right = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.test
+        local key = 3
+        s:replace{1, 0}
+        s:replace{2, 0}
+
+        local txn_proxy = require("test.box.lua.txn_proxy")
+        local tx = txn_proxy.new()
+
+        tx:begin()
+        local strkey = tostring(key)
+        local select_req = 'box.space.test:select{' .. strkey .. '}'
+        local replace_req = 'box.space.test:replace{' .. strkey .. ', 1}'
+        t.assert_equals(tx(select_req), {{}})
+        s:replace{key, 0}
+        t.assert_equals(tx(select_req), {{}})
+        t.assert_equals(tx(replace_req), {{key, 1}})
+        t.assert_equals(tx(select_req), {{{key, 1}}})
+        t.assert_equals(tx:commit(),
+            {{error = "Transaction has been aborted by conflict"}})
+
+        t.assert_equals(s:select{}, {{1, 0}, {2, 0}, {3, 0}})
+    end)
+end


### PR DESCRIPTION
MVCC must track a read set of transaction, including cases when
the select returns an empty result. In this case MVCC has two
options: to store a point key if the select has a full key or
to store a gap otherwise.

By a mistake the second variant was not implemented. Fix it now.

Closes #7025