### PR TITLE
Factor out field_def_array_dup

### DIFF
--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -701,8 +701,6 @@ alter_space_new(struct space *old_space)
 	rlist_create(&alter->ops);
 	alter->old_space = old_space;
 	alter->space_def = space_def_dup(alter->old_space->def);
-	if (alter->space_def == NULL)
-		return NULL;
 	if (old_space->format != NULL)
 		alter->new_min_field_count = old_space->format->min_field_count;
 	else

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -459,7 +459,7 @@ space_def_new_from_tuple(struct tuple *tuple, uint32_t errcode,
 		return NULL;
 	struct field_def *fields = NULL;
 	uint32_t field_count;
-	if (space_format_decode(format, &field_count, region, &fields) != 0)
+	if (field_def_array_decode(format, &field_count, region, &fields) != 0)
 		return NULL;
 	if (exact_field_count != 0 &&
 	    exact_field_count < field_count) {

--- a/src/box/field_def.c
+++ b/src/box/field_def.c
@@ -367,8 +367,8 @@ field_def_decode(struct field_def *field, const char **data,
 }
 
 int
-space_format_decode(const char *data, uint32_t *out_count,
-		    struct region *region, struct field_def **fields)
+field_def_array_decode(const char *data, uint32_t *out_count,
+		       struct region *region, struct field_def **fields)
 {
 	/* Type is checked by _space format. */
 	assert(mp_typeof(*data) == MP_ARRAY);

--- a/src/box/field_def.h
+++ b/src/box/field_def.h
@@ -209,8 +209,8 @@ action_is_nullable(enum on_conflict_action nullable_action)
  * @retval Error code.
  */
 int
-space_format_decode(const char *data, uint32_t *out_count,
-		    struct region *region, struct field_def **fields);
+field_def_array_decode(const char *data, uint32_t *out_count,
+		       struct region *region, struct field_def **fields);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/box/field_def.h
+++ b/src/box/field_def.h
@@ -212,6 +212,19 @@ int
 field_def_array_decode(const char *data, uint32_t *out_count,
 		       struct region *region, struct field_def **fields);
 
+/**
+ * Duplicates array of fields using malloc. Never fails.
+ * Returns NULL if zero-size array is passed.
+ */
+struct field_def *
+field_def_array_dup(const struct field_def *fields, uint32_t field_count);
+
+/**
+ * Frees array of fields that was allocated with field_def_array_dup().
+ */
+void
+field_def_array_delete(struct field_def *fields, uint32_t field_count);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -230,8 +230,6 @@ space_create(struct space *space, struct engine *engine,
 		tuple_format_ref(format);
 
 	space->def = space_def_dup(def);
-	if (space->def == NULL)
-		goto fail;
 
 	/* Create indexes and fill the index map. */
 	space->index_map = (struct index **)

--- a/src/box/space_def.c
+++ b/src/box/space_def.c
@@ -269,18 +269,11 @@ space_def_delete(struct space_def *def)
 		free(field->constraint_def);
 		TRASH(field);
 	}
-	space_opts_destroy(&def->opts);
 	tuple_dictionary_unref(def->dict);
+	free(def->opts.sql);
+	free(def->opts.constraint_def);
 	TRASH(def);
 	free(def);
-}
-
-void
-space_opts_destroy(struct space_opts *opts)
-{
-	free(opts->sql);
-	free(opts->constraint_def);
-	TRASH(opts);
 }
 
 /**

--- a/src/box/space_def.h
+++ b/src/box/space_def.h
@@ -177,22 +177,6 @@ space_def_new(uint32_t id, uint32_t uid, uint32_t exact_field_count,
 struct space_def *
 space_def_new_ephemeral(uint32_t exact_field_count, struct field_def *fields);
 
-/**
- * Size of the space_def.
- * @param name_len Length of the space name.
- * @param fields Fields array of space format.
- * @param field_count Space field count.
- * @param[out] names_offset Offset from the beginning of a def to
- *             a field names memory.
- * @param[out] fields_offset Offset from the beginning of a def to
- *             a fields array.
- * @retval Size in bytes.
- */
-size_t
-space_def_sizeof(uint32_t name_len, const struct field_def *fields,
-		 uint32_t field_count, uint32_t *names_offset,
-		 uint32_t *fields_offset);
-
 struct tuple_format;
 struct tuple_format_vtab;
 struct key_def;

--- a/src/box/space_def.h
+++ b/src/box/space_def.h
@@ -140,6 +140,8 @@ space_def_delete(struct space_def *def);
  * Duplicate space_def object.
  * @param src Def to duplicate.
  * @retval Copy of the @src.
+ *
+ * The function never fails (never returns NULL).
  */
 struct space_def *
 space_def_dup(const struct space_def *src);
@@ -197,15 +199,6 @@ space_tuple_format_new(struct tuple_format_vtab *vtab, void *engine,
 } /* extern "C" */
 
 #include "diag.h"
-
-static inline struct space_def *
-space_def_dup_xc(const struct space_def *src)
-{
-	struct space_def *ret = space_def_dup(src);
-	if (ret == NULL)
-		diag_raise();
-	return ret;
-}
 
 static inline struct space_def *
 space_def_new_xc(uint32_t id, uint32_t uid, uint32_t exact_field_count,

--- a/src/box/space_def.h
+++ b/src/box/space_def.h
@@ -100,12 +100,6 @@ space_opts_create(struct space_opts *opts)
 	*opts = space_opts_default;
 }
 
-/**
- * Destroy space options
- */
-void
-space_opts_destroy(struct space_opts *opts);
-
 /** Space metadata. */
 struct space_def {
 	/** Space id. */

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -1253,8 +1253,7 @@ sql_template_space_def_new(struct Parse *parser, const char *name)
 {
 	struct space_def *def = NULL;
 	size_t name_len = name != NULL ? strlen(name) : 0;
-	uint32_t dummy;
-	size_t size = space_def_sizeof(name_len, NULL, 0, &dummy, &dummy);
+	size_t size = sizeof(*def) + name_len + 1;
 	def = (struct space_def *)region_aligned_alloc(&parser->region, size,
 						       alignof(*def));
 	if (def == NULL) {

--- a/src/lib/salad/grp_alloc.h
+++ b/src/lib/salad/grp_alloc.h
@@ -90,6 +90,16 @@ grp_alloc_reserve_str(struct grp_alloc *bank, size_t size)
 }
 
 /**
+ * Phase 1: account a null-terminated string that is needed to be allocated,
+ * including char for null-termination.
+ */
+static inline void
+grp_alloc_reserve_str0(struct grp_alloc *bank, const char *src)
+{
+	grp_alloc_reserve_str(bank, strlen(src));
+}
+
+/**
  * Phase 1 end: get total memory size required for all data.
  */
 static inline size_t
@@ -131,6 +141,16 @@ grp_alloc_create_str(struct grp_alloc *bank, const char *src, size_t src_size)
 	bank->data_end -= src_size;
 	memcpy(bank->data_end, src, src_size);
 	return bank->data_end;
+}
+
+/**
+ * Phase 2: allocate and fill a null-terminated string with given data @a src,
+ * including null-termination. Return new string.
+ */
+static inline char *
+grp_alloc_create_str0(struct grp_alloc *bank, const char *src)
+{
+	return grp_alloc_create_str(bank, src, strlen(src));
 }
 
 #ifdef __cplusplus

--- a/test/unit/grp_alloc.c
+++ b/test/unit/grp_alloc.c
@@ -4,6 +4,9 @@
  * Copyright 2010-2021, Tarantool AUTHORS, please see AUTHORS file.
  */
 
+#include <stddef.h>
+#include <string.h>
+
 #include "salad/grp_alloc.h"
 #include "trivia/util.h"
 
@@ -14,18 +17,21 @@ struct test {
 	size_t array_size;
 	const char *name;
 	const char *description;
+	const char *extra;
 };
 
 struct test *
 test_new(int *array, size_t array_size,
 	 const char *name, size_t name_len,
-	 const char *description, size_t description_len)
+	 const char *description, size_t description_len,
+	 const char *extra)
 {
 	struct grp_alloc bank = grp_alloc_initializer();
 	size_t array_data_size = array_size * sizeof(*array);
 	grp_alloc_reserve_data(&bank, array_data_size);
 	grp_alloc_reserve_str(&bank, name_len);
 	grp_alloc_reserve_str(&bank, description_len);
+	grp_alloc_reserve_str0(&bank, extra);
 	size_t total_size = sizeof(struct test) + grp_alloc_size(&bank);
 	struct test *res = xmalloc(total_size);
 	grp_alloc_use(&bank, res + 1);
@@ -34,22 +40,24 @@ test_new(int *array, size_t array_size,
 	res->name = grp_alloc_create_str(&bank, name, name_len);
 	res->description = grp_alloc_create_str(&bank, description,
 						description_len);
+	res->extra = grp_alloc_create_str0(&bank, extra);
 	return res;
 }
 
 static void
 check_test_new(int *array, size_t array_size,
 	       const char *name, size_t name_len,
-	       const char *description, size_t description_len)
+	       const char *description, size_t description_len,
+	       const char *extra)
 {
 	header();
-	plan(11);
+	plan(15);
 
 	struct test *t = test_new(array, array_size, name, name_len,
-				  description, description_len);
+				  description, description_len, extra);
 	size_t array_data_size = array_size * sizeof(*array);
 	size_t total = array_data_size + sizeof(*t) +
-		       name_len + 1 + description_len + 1;
+		       name_len + 1 + description_len + 1 + strlen(extra) + 1;
 	char *b = (char *)t;
 	char *e = b + total;
 
@@ -59,11 +67,15 @@ check_test_new(int *array, size_t array_size,
 	ok((char *)t->name < e, "location");
 	ok((char *)t->description > b, "location");
 	ok((char *)t->description < e, "location");
+	ok((char *)t->extra > b, "location");
+	ok((char *)t->extra < e, "location");
 	is(memcmp(t->array, array, array_data_size), 0, "data");
 	is(memcmp(t->name, name, name_len), 0, "data");
 	is(t->name[name_len], 0, "null-termination symbol");
 	is(memcmp(t->description, description, description_len), 0, "data");
 	is(t->description[description_len], 0, "null-termination symbol");
+	is(memcmp(t->extra, extra, strlen(extra)), 0, "data");
+	is(t->extra[strlen(extra)], 0, "null-termination symbol");
 
 	check_plan();
 	footer();
@@ -76,9 +88,9 @@ test_simple(void)
 	plan(3);
 
 	int arr[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-	check_test_new(arr, 3, "test", 4, "abc", 3);
-	check_test_new(arr, 10, "alligator", 9, "x", 1);
-	check_test_new(arr, 1, "qwerty", 6, "as", 2);
+	check_test_new(arr, 3, "test", 4, "abc", 3, "foo");
+	check_test_new(arr, 10, "alligator", 9, "x", 1, "bar");
+	check_test_new(arr, 1, "qwerty", 6, "as", 2, "buzz");
 
 	check_plan();
 	footer();

--- a/test/unit/grp_alloc.result
+++ b/test/unit/grp_alloc.result
@@ -3,48 +3,60 @@
 	*** test_simple ***
     1..3
 	*** check_test_new ***
-        1..11
+        1..15
         ok 1 - location
         ok 2 - location
         ok 3 - location
         ok 4 - location
         ok 5 - location
         ok 6 - location
-        ok 7 - data
-        ok 8 - data
-        ok 9 - null-termination symbol
+        ok 7 - location
+        ok 8 - location
+        ok 9 - data
         ok 10 - data
         ok 11 - null-termination symbol
+        ok 12 - data
+        ok 13 - null-termination symbol
+        ok 14 - data
+        ok 15 - null-termination symbol
     ok 1 - subtests
 	*** check_test_new: done ***
 	*** check_test_new ***
-        1..11
+        1..15
         ok 1 - location
         ok 2 - location
         ok 3 - location
         ok 4 - location
         ok 5 - location
         ok 6 - location
-        ok 7 - data
-        ok 8 - data
-        ok 9 - null-termination symbol
+        ok 7 - location
+        ok 8 - location
+        ok 9 - data
         ok 10 - data
         ok 11 - null-termination symbol
+        ok 12 - data
+        ok 13 - null-termination symbol
+        ok 14 - data
+        ok 15 - null-termination symbol
     ok 2 - subtests
 	*** check_test_new: done ***
 	*** check_test_new ***
-        1..11
+        1..15
         ok 1 - location
         ok 2 - location
         ok 3 - location
         ok 4 - location
         ok 5 - location
         ok 6 - location
-        ok 7 - data
-        ok 8 - data
-        ok 9 - null-termination symbol
+        ok 7 - location
+        ok 8 - location
+        ok 9 - data
         ok 10 - data
         ok 11 - null-termination symbol
+        ok 12 - data
+        ok 13 - null-termination symbol
+        ok 14 - data
+        ok 15 - null-termination symbol
     ok 3 - subtests
 	*** check_test_new: done ***
 ok 1 - subtests


### PR DESCRIPTION
To implement space upgrade, we need a function that duplicates `field_def` array, because we will store a new space format in space options. To factor out `field_def_array_dup` from `space_def_dup`, let's allocate it with a separate `malloc` rather than after `struct space_def`.

Needed for https://github.com/tarantool/tarantool-ee/issues/94