### PR TITLE
Log empty or nil `select` calls

### DIFF
--- a/changelogs/unreleased/gh-6539-log-user-space-empty-or-nil-select.md
+++ b/changelogs/unreleased/gh-6539-log-user-space-empty-or-nil-select.md
@@ -1,0 +1,7 @@
+## feature/box
+
+* Changed behaviour of empty or nil `select` calls on user spaces: a critical
+  log entry containing the current stack traceback is created upon such
+  function calls — a user can explicitly request a full scan though by passing
+  `fullscan=true` to `select`'s `options` table argument in which a case a
+  log entry will not be created. (gh-6539).

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -2340,8 +2340,21 @@ end
 
 box.internal.check_select_opts = check_select_opts -- for net.box
 
+local check_select_args_rl = log.internal.ratelimit:new()
+local function check_select_args(index, key, opts)
+    local rl = check_select_args_rl
+
+    if index.space_id >= 512 and
+       (type(key) == 'nil' or (type(key) == 'table' and next(key) == nil)) and
+       (opts == nil or not opts.fullscan) then
+        rl:log_crit('empty or nil `select` call on user space with id=%d\n %s',
+                    index.space_id, debug.traceback())
+    end
+end
+
 base_index_mt.select_ffi = function(index, key, opts)
     check_index_arg(index, 'select')
+    check_select_args(index, key, opts)
     local ibuf = cord_ibuf_take()
     local key, key_end = tuple_encode(ibuf, key)
     local iterator, offset, limit = check_select_opts(opts, key + 1 >= key_end)
@@ -2365,6 +2378,7 @@ end
 
 base_index_mt.select_luac = function(index, key, opts)
     check_index_arg(index, 'select')
+    check_select_args(index, key, opts)
     local key = keify(key)
     local iterator, offset, limit = check_select_opts(opts, #key == 0)
     return internal.select(index.space_id, index.id, iterator,

--- a/test/box-luatest/gh_6539_log_user_space_empty_or_nil_select_test.lua
+++ b/test/box-luatest/gh_6539_log_user_space_empty_or_nil_select_test.lua
@@ -1,0 +1,77 @@
+local fio = require('fio')
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new{alias = 'dflt'}
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:drop()
+end)
+
+local expected_log_entry = 'C> empty or nil `select` call on user space ' ..
+                           'with id=%d+'
+local grep_log_bytes = 256
+local dangerous_call_fmts = {'box.space.%s:select()', 'box.space.%s:select{}',
+                             'box.space.%s:select(nil, {})',
+                             'box.space.%s:select(nil, {fullscan = false})'}
+local log_entry_absence_msg_fmt = 'log must not contain a critical entry ' ..
+                                  'about `%s` call on a %s %s space'
+
+g.test_log_entry_absence_for_sys_space = function()
+    t.fail_if(g.server:eval('return box.space._space.id') > 512,
+              '`_space` space is assumed to be a system space')
+    for _, call_fmt in pairs(dangerous_call_fmts) do
+        local call = call_fmt:format('_space')
+        g.server:eval(call)
+        t.assert_not(g.server:grep_log(expected_log_entry, grep_log_bytes),
+                     log_entry_absence_msg_fmt:format(call, "", "system"))
+    end
+end
+
+for _, eng in pairs{'memtx', 'vinyl'} do
+    g[('test_log_entry_presence_for_%s_user_space'):format(eng)] = function()
+        local space = ('test_%s'):format(eng)
+        g.server:eval(("box.schema.space.create('%s', " ..
+                       "{engine = '%s'})"):format(space, eng))
+        g.server:eval(("box.space.%s:create_index('pk')"):format(space))
+
+        local safe_call_fmts = {'box.space.%s:select{0}',
+                                'box.space.%s:select({0}, {fullscan = false})',
+                                'box.space.%s:select({0}, {fullscan = true})'}
+        for _, call_fmt in pairs(safe_call_fmts) do
+            local call = call_fmt:format(space)
+            g.server:eval(call)
+            t.assert_not(g.server:grep_log(expected_log_entry, grep_log_bytes),
+                         log_entry_absence_msg_fmt:format(call, eng, "user"))
+        end
+
+        local explicit_call_fmts = {'box.space.%s:select(nil, ' ..
+                                    '{fullscan = true})',
+                                    'box.space.%s:select({}, ' ..
+                                    '{fullscan = true})'}
+        for _, call_fmt in pairs(explicit_call_fmts) do
+            local call = call_fmt:format(space)
+            g.server:eval(call)
+            t.assert_not(g.server:grep_log(expected_log_entry, grep_log_bytes),
+                        ('log must not contain a critical entry about ' ..
+                         'an empty or nil `select` call on a %s '..
+                         'user space with `fullscan = true` option '..
+                         'set'):format(eng))
+        end
+
+        local log_file = g.server:eval('return box.cfg.log')
+        for _, call_fmt in pairs(dangerous_call_fmts) do
+            local call = call_fmt:format(space)
+            g.server:eval(call)
+            t.assert(g.server:grep_log(expected_log_entry, grep_log_bytes),
+                     ('log must contain a critical entry ' ..
+                      'about `%s` call on a %s user space'):format(call, eng))
+            fio.truncate(log_file)
+        end
+    end
+end


### PR DESCRIPTION
# lua: introduce `log.crit`

Introduce module-local S_CRIT alias and add crit function to log module
API.

Needed for #6539

# box: log dangerous `select` and calls

Empty or nil `select` calls on user spaces tend to be
dangerous: we see Tarantool crashing with OOM, or Tarantool becoming
unacceptably slow and its transaction thread utilizing 100% CPU usage.
Also, debugging of such killer-requests is often too painful and
exhausting.

To mitigate this, a critical log entry containing the current stack
traceback is created upon such function calls — a user can explicitly
request a full scan though by passing `fullscan = true` to `select`'s
`options` table argument in which a case a log entry will not be created.

Closes #6539