### PR TITLE
sql: fix string dequoting

### DIFF
--- a/changelogs/unreleased/fix-string-dequoting.md
+++ b/changelogs/unreleased/fix-string-dequoting.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* SQL queries with sub-queries and quoted names now return correct column names
+in projection (gh-7063).

--- a/src/box/sql/util.c
+++ b/src/box/sql/util.c
@@ -80,8 +80,8 @@ sqlStrlen30(const char *z)
  * input does not begin with a quote character, then this routine
  * is a no-op.
  *
- * The input string must be zero-terminated.  A new zero-terminator
- * is added to the dequoted string.
+ * The input string must be zero-terminated. The resulting dequoted
+ * string will also be zero-terminated.
  *
  * The return value is -1 if no dequoting occurs or the length of the
  * dequoted string, exclusive of the zero terminator, if dequoting does
@@ -102,19 +102,19 @@ sqlDequote(char *z)
 	if (!sqlIsquote(quote))
 		return;
 	for (i = 1, j = 0;; i++) {
-		assert(z[i]);
 		if (z[i] == quote) {
 			if (z[i + 1] == quote) {
 				z[j++] = quote;
 				i++;
-			} else {
-				break;
 			}
+		} else if (z[i] == 0) {
+			z[j] = 0;
+			return;
 		} else {
 			z[j++] = z[i];
 		}
+		assert(z[i] != 0);
 	}
-	z[j] = 0;
 }
 
 int

--- a/test/sql-luatest/gh_7063_dequote_test.lua
+++ b/test/sql-luatest/gh_7063_dequote_test.lua
@@ -1,0 +1,22 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'dequote'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_dequote = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        box.execute([[CREATE TABLE "t"("a" INT PRIMARY KEY);]])
+        local sql = [[SELECT "t1"."a" FROM (SELECT "a" FROM "t") AS "t1";]]
+        t.assert_equals(box.execute(sql).metadata[1].name, 't1.a')
+        box.execute([[DROP TABLE "t";]])
+    end)
+end


### PR DESCRIPTION
Current commit fixes issue #7063 with an incorrect column name in a sub-query projection. For example,
```sql
select "t1".a from (select * from t1) as "t1";
```
returned a result column name `t1` instead of `t1.a` because of incorrect work of a dequoting function. The reason was that
previously `sqlDequote()` function finished its work when found the first closing quote.

Old logic worked for simple selects where the column name doesn't contain an explicit scan name (`"a" -> a`). But for the sub-queries results `sqlDequote()` finished its work right after the scan name (`"t1"."a" -> t1`). Now the function continues its deqouting till it gets the null terminator at the end of the string.