### PR TITLE
build: clang fails because of -Wnull-pointer-subtraction

### DIFF
--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -832,16 +832,8 @@ typedef u64 uptr;
  * Assert that the pointer X is aligned to an 8-byte boundary.  This
  * macro is used only within assert() to verify that the code gets
  * all alignment restrictions correct.
- *
- * Except, if sql_4_BYTE_ALIGNED_MALLOC is defined, then the
- * underlying malloc() implementation might return us 4-byte aligned
- * pointers.  In that case, only verify 4-byte alignment.
  */
-#ifdef SQL_4_BYTE_ALIGNED_MALLOC
-#define EIGHT_BYTE_ALIGNMENT(X)   ((((char*)(X) - (char*)0)&3)==0)
-#else
-#define EIGHT_BYTE_ALIGNMENT(X)   ((((char*)(X) - (char*)0)&7)==0)
-#endif
+#define EIGHT_BYTE_ALIGNMENT(X)   ((((uintptr_t)((char *)(X))) & 7) == 0)
 
 /*
  * Default maximum size of memory used by memory-mapped I/O in the VFS


### PR DESCRIPTION
The problem was detected on MacOS llvm with `-DCMAKE_BUILD_TYPE=Debug` option. Tarantool fails to build because of `-Wnull-pointer-subtraction` warning in `EIGHT_BYTE_ALIGNMENT` macros.
```
/Users/darthunix/git/tarantool/src/box/sql/malloc.c:125:9: error: performing pointer subtraction with a null pointer has undefined behavior [-Werror,-Wnull-pointer-subtraction]
        assert(EIGHT_BYTE_ALIGNMENT(p));        /* IMP: R-11148-40995 */
               ^~~~~~~~~~~~~~~~~~~~~~~
/Users/darthunix/git/tarantool/src/box/sql/sqlInt.h:839:49: note: expanded from macro 'EIGHT_BYTE_ALIGNMENT'
#define EIGHT_BYTE_ALIGNMENT(X)   ((((char*)(X) - (char*)0)&7)==0)
                                                ^ ~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/assert.h:99:25: note: expanded from macro 'assert'
    (__builtin_expect(!(e), 0) ? __assert_rtn(__func__, __ASSERT_FILE_NAME, __LINE__, #e) : (void)0)
                        ^
/Users/darthunix/git/tarantool/src/box/sql/malloc.c:232:9: error: performing pointer subtraction with a null pointer has undefined behavior [-Werror,-Wnull-pointer-subtraction]
        assert(EIGHT_BYTE_ALIGNMENT(pNew));     /* IMP: R-11148-40995 */
               ^~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/darthunix/git/tarantool/src/box/sql/sqlInt.h:839:49: note: expanded from macro 'EIGHT_BYTE_ALIGNMENT'
#define EIGHT_BYTE_ALIGNMENT(X)   ((((char*)(X) - (char*)0)&7)==0)
                                                ^ ~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/assert.h:99:25: note: expanded from macro 'assert'
    (__builtin_expect(!(e), 0) ? __assert_rtn(__func__, __ASSERT_FILE_NAME, __LINE__, #e) : (void)0)
                        ^
2 errors generated.
```
Fixed.