### PR TITLE
datetime: handle timezone names in tz

### DIFF
--- a/changelogs/unreleased/gh-7076-tz-attributes.md
+++ b/changelogs/unreleased/gh-7076-tz-attributes.md
@@ -1,0 +1,22 @@
+## feature/lua/datetime
+
+* Support for timezone names enabled in constructor and `date:set{}` modifier
+  via `tz` attribute. At the moment it supports only timezone names
+  abbreviations (gh-7076)
+
+Timezone abbreviations can be used in addition to the timezone offset at the
+moment of construction or modifying of date object, or while parsing datetime
+literals. Numeric time offsets and named abbreviations produce equivalent
+datetime values:
+
+```
+local date = require('datetime')
+local d2 = date.parse('2000-01-01T02:00:00 MSK')
+
+local d1 = date.new{year = 1980, tz = 'MSK'}
+d2 = date.new{year = 1980, tzoffset = 180}
+d2:set{tz = 'MSK'}
+```
+
+Beware, that timezone name parser fails if one uses ambiguous names
+(e.g. 'AT') which could not be directly translated into timezone offsets.

--- a/extra/exports
+++ b/extra/exports
@@ -432,6 +432,7 @@ tnt_datetime_datetime_sub
 tnt_datetime_increment_by
 tnt_datetime_now
 tnt_datetime_parse_full
+tnt_datetime_parse_tz
 tnt_datetime_strftime
 tnt_datetime_strptime
 tnt_datetime_to_string

--- a/src/lib/core/datetime.c
+++ b/src/lib/core/datetime.c
@@ -294,6 +294,23 @@ exit:
 	return str - svp;
 }
 
+ssize_t
+datetime_parse_tz(const char *str, size_t len, int16_t *tzoffset,
+		  int16_t *tzindex)
+{
+	const struct date_time_zone *zone;
+	ssize_t l = timezone_lookup(str, len, &zone);
+	if (l <= 0)
+		return l;
+
+	assert(l <= (ssize_t)len);
+	assert(zone != NULL);
+	assert(((TZ_AMBIGUOUS | TZ_NYI) & timezone_flags(zone)) == 0);
+	*tzoffset = timezone_offset(zone);
+	*tzindex = timezone_index(zone);
+	return l;
+}
+
 int
 datetime_compare(const struct datetime *lhs, const struct datetime *rhs)
 {

--- a/src/lib/core/datetime.h
+++ b/src/lib/core/datetime.h
@@ -176,6 +176,21 @@ datetime_to_tm(const struct datetime *date, struct tnt_tm *tm);
 ssize_t
 datetime_parse_full(struct datetime *date, const char *str, size_t len,
 		    int32_t offset);
+
+/** Parse timezone suffix
+ * @param str input text in relaxed ISO-8601 format (0-terminated)
+ * @param len length of str buffer
+ * @param[out] tzoffset return timezone offset if recognized
+ * @param[out] tzindex return timzeon index if recognized
+ * @retval Upon successful completion returns length of accepted
+ *         substring. Returns 0 if text is not recognizable as timzeone.
+ *         Returns negative value is there is unaccepted timezone.
+ * @sa datetime_parse_full()
+ */
+ssize_t
+datetime_parse_tz(const char *str, size_t len, int16_t *tzoffset,
+		  int16_t *tzindex);
+
 /**
  * Parse buffer given format, and construct datetime value
  * @param date output datetime value

--- a/src/lib/tzcode/strftime.c
+++ b/src/lib/tzcode/strftime.c
@@ -71,9 +71,11 @@ tnt_strftime(char *s, size_t maxsize, const char *format,
 	tzset();
 	enum warn warn = IN_NONE;
 
+	if (s != NULL && maxsize > 0)
+		s[0] = '\0';
 	ssize_t total = _fmt(s, maxsize, format, t, &warn);
 	assert(total >= 0);
-	assert(maxsize == 0 || s[MIN((size_t)total, maxsize - 1)] == 0);
+	assert(maxsize == 0 || s[MIN((size_t)total, maxsize - 1)] == '\0');
 
 	return (size_t)total;
 }
@@ -478,7 +480,8 @@ _fmt(char *buf, ssize_t size, const char *format, const struct tnt_tm *t,
 					t->tm_year, TM_YEAR_BASE, true, true);
 				continue;
 			case 'Z':
-				assert(t->tm_tzindex != 0);
+				if (t->tm_tzindex == 0)
+					continue;
 				assert(timezone_name(t->tm_tzindex) != NULL);
 				SNPRINT(total, snprintf, buf, size,
 					"%s", timezone_name(t->tm_tzindex));

--- a/src/lua/tnt_datetime.c
+++ b/src/lua/tnt_datetime.c
@@ -40,6 +40,13 @@ tnt_datetime_parse_full(struct datetime *date, const char *str, size_t len,
 	return datetime_parse_full(date, str, len, offset);
 }
 
+ssize_t
+tnt_datetime_parse_tz(const char *str, size_t len, int16_t *tzoffset,
+		      int16_t *tzindex)
+{
+	return datetime_parse_tz(str, len, tzoffset, tzindex);
+}
+
 struct datetime *
 tnt_datetime_unpack(const char **data, uint32_t len, struct datetime *date)
 {


### PR DESCRIPTION
Since recently we partially support timezone names (e.g. as
abbreviations) so we may modify `tz` attribute support for
datetime constructors or `:set()` operations.

Closes #7076
Relates to #7007