### PR TITLE
ci: use separate repo for gc64 packages 

### DIFF
--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF" ]
+        gc64: [ "GC64=OFF", "GC64=ON" ]
 
     steps:
       - uses: actions/checkout@v2.3.4

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF" ]
+        gc64: [ "GC64=OFF", "GC64=ON" ]
 
     steps:
       - uses: actions/checkout@v2.3.4

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF" ]
+        gc64: [ "GC64=OFF", "GC64=ON" ]
 
     steps:
       - uses: actions/checkout@v2.3.4

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -41,6 +41,11 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    strategy:
+      fail-fast: false
+      matrix:
+        gc64: [ "GC64=OFF", "GC64=ON" ]
+
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -52,6 +57,7 @@ jobs:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'opensuse-leap'
           DIST: '15.1'
+          GC64: -DLUAJIT_ENABLE_${{ matrix.gc64 }}
         uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -41,6 +41,11 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    strategy:
+      fail-fast: false
+      matrix:
+        gc64: [ "GC64=OFF", "GC64=ON" ]
+
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -52,6 +57,7 @@ jobs:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'opensuse-leap'
           DIST: '15.2'
+          GC64: -DLUAJIT_ENABLE_${{ matrix.gc64 }}
         uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF" ]
+        gc64: [ "GC64=OFF", "GC64=ON" ]
 
     steps:
       - uses: actions/checkout@v2.3.4

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF" ]
+        gc64: [ "GC64=OFF", "GC64=ON" ]
 
     steps:
       - uses: actions/checkout@v2.3.4

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF" ]
+        gc64: [ "GC64=OFF", "GC64=ON" ]
 
     steps:
       - uses: actions/checkout@v2.3.4

--- a/.github/workflows/ubuntu_21_04.yml
+++ b/.github/workflows/ubuntu_21_04.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF" ]
+        gc64: [ "GC64=OFF", "GC64=ON" ]
 
     steps:
       - uses: actions/checkout@v2.3.4

--- a/.github/workflows/ubuntu_21_10.yml
+++ b/.github/workflows/ubuntu_21_10.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF" ]
+        gc64: [ "GC64=OFF", "GC64=ON" ]
 
     steps:
       - uses: actions/checkout@v2.3.4

--- a/.gitlab.mk
+++ b/.gitlab.mk
@@ -100,7 +100,7 @@ S3_SOURCE_REPO_URL=s3://tarantool_repo/sources
 endif
 
 RWS_BASE_URL=https://rws.tarantool.org
-RWS_ENDPOINT=${RWS_BASE_URL}/${REPO_TYPE}/${TARANTOOL_SERIES}/${OS}/${DIST}
+PRODUCT_NAME=tarantool
 
 deploy_prepare:
 	rm -rf packpack
@@ -109,15 +109,6 @@ deploy_prepare:
 	rm -rf build
 
 package: deploy_prepare
-	# Set PRODUCT_NAME for the package itself.
-	if [ "$$(echo $(GC64) | sed 's/.*=//')" = ON ]; then                                                           \
-		export PRODUCT_NAME=tarantool-gc64; \
-		if [ "${OS}" = "ubuntu" ] || [ "${OS}" = "debian" ]; then \
-		    $$(sed -i'' -e 's/Package: tarantool$$/Package: tarantool-gc64/' debian/control); \
-		fi; \
-	else \
-		export PRODUCT_NAME=tarantool; \
-	fi; \
 	if [ -n "$(GIT_TAG)" ]; then                                                                                    \
 		export VERSION="$$(echo $(GIT_TAG) | sed 's/-/~/')";                                                    \
 	else                                                                                                            \
@@ -126,18 +117,18 @@ package: deploy_prepare
 	echo VERSION=$$VERSION;                                                                                         \
 	PACKPACK_EXTRA_DOCKER_RUN_PARAMS="--network=host ${PACKPACK_EXTRA_DOCKER_RUN_PARAMS}"                           \
 	TARBALL_EXTRA_ARGS="--exclude=*.exe --exclude=*.dll"                                                            \
-	PRESERVE_ENVVARS="PRODUCT_NAME,TARBALL_EXTRA_ARGS,${PRESERVE_ENVVARS}" ./packpack/packpack
+	PRESERVE_ENVVARS="TARBALL_EXTRA_ARGS,${PRESERVE_ENVVARS}" ./packpack/packpack
 
 deploy:
 	if [ -z "${REPO_TYPE}" ]; then \
 		echo "Env variable 'REPO_TYPE' must be defined!"; \
 		exit 1; \
 	fi; \
-	# Set PRODUCT_NAME for the package in the repository.
-	if [ "$$(echo $(GC64) | sed 's/.*=//')" = ON ]; then                                                                                    \
-		PRODUCT_NAME=tarantool-gc64; \
+	# Use different repos for vanilla and GC64 version.
+	if [ "$$(echo ${GC64} | sed 's/.*=//')" = ON ]; then \
+		RWS_ENDPOINT=${RWS_BASE_URL}/${REPO_TYPE}/${TARANTOOL_SERIES}-gc64/${OS}/${DIST}; \
 	else \
-		PRODUCT_NAME=tarantool; \
+		RWS_ENDPOINT=${RWS_BASE_URL}/${REPO_TYPE}/${TARANTOOL_SERIES}/${OS}/${DIST}; \
 	fi; \
 	CURL_CMD="curl \
 		--location \
@@ -146,9 +137,9 @@ deploy:
 		--show-error \
 		--retry 5 \
 		--retry-delay 5 \
-		--request PUT ${RWS_ENDPOINT} \
+		--request PUT $${RWS_ENDPOINT} \
 		--user $${RWS_AUTH} \
-		--form product=$${PRODUCT_NAME}"; \
+		--form product=${PRODUCT_NAME}"; \
 	for f in $$(ls -I '*build*' -I '*.changes' ./build); do \
 		CURL_CMD="$${CURL_CMD} --form $$(basename $${f})=@./build/$${f}"; \
 	done; \

--- a/rpm/tarantool.spec
+++ b/rpm/tarantool.spec
@@ -110,16 +110,7 @@ BuildRequires: python3-pyyaml
 # Install prove to run LuaJIT tests.
 BuildRequires: perl-Test-Harness
 
-# Set product name from env variable or use default "tarantool".
-# It is a temporary solution to define special name of the package
-# to "tarantool-gc64" in CI. It is required to set up Tarantool
-# with GC64 enabled by "yum install tarantool-gc64"
-%define _product %{getenv:PRODUCT_NAME}
-%if "%{_product}"
-Name: %{_product}
-%else
 Name: tarantool
-%endif
 # ${major}.${major}.${minor}.${patch}, e.g. 1.6.8.175
 # Version is updated automaically using git describe --long --always
 Version: 1.7.2.385


### PR DESCRIPTION
It looks like the simplest solution to deliver gc64 tarantool builds
is to have a separate repo for it. So this patch removes old stuff
related to the 'tarantool-gc64' package and adds the new logic to
store gc64 packages in a separate repo.

Closes: https://github.com/tarantool/tarantool-qa/issues/161

NO_DOC=ci
NO_TEST=ci
NO_CHANGELOG=ci

Co-authored-by: Yaroslav Lobankov <y.lobankov@tarantool.org>