### PR TITLE
Fix Tarantool terminations on non-printable error messages

### DIFF
--- a/changelogs/unreleased/gh-6934-nonprintable-error-message.md
+++ b/changelogs/unreleased/gh-6934-nonprintable-error-message.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed tarantool terminations on error messages with invalid UTF-8
+  sequences (gh-6781 and gh-6934).

--- a/src/box/lua/console.c
+++ b/src/box/lua/console.c
@@ -471,7 +471,17 @@ lbox_console_format_yaml(struct lua_State *L)
 	}
 	lua_replace(L, 1);
 	lua_settop(L, 1);
-	return lua_yaml_encode(L, serializer_yaml, NULL, NULL);
+	int ret = lua_yaml_encode(L, serializer_yaml, NULL, NULL);
+	if (ret == 2) {
+		/*
+		 * Nil and error object are pushed onto the stack.
+		 */
+		assert(lua_isnil(L, -2));
+		assert(lua_isstring(L, -1));
+		return luaL_error(L, lua_tostring(L, -1));
+	}
+	assert(ret == 1);
+	return ret;
 }
 
 /**

--- a/src/box/lua/console.c
+++ b/src/box/lua/console.c
@@ -118,7 +118,17 @@ lbox_console_format_lua(struct lua_State *L)
 
 	lua_replace(L, 1);
 	lua_settop(L, 1);
-	return lua_encode(L, serializer_lua, &opts);
+	int ret = lua_encode(L, serializer_lua, &opts);
+	if (ret == 2) {
+		/*
+		 * Nil and error object are pushed onto the stack.
+		 */
+		assert(lua_isnil(L, -2));
+		assert(lua_isstring(L, -1));
+		return luaL_error(L, lua_tostring(L, -1));
+	}
+	assert(ret == 1);
+	return ret;
 }
 
 /*

--- a/src/box/lua/console.lua
+++ b/src/box/lua/console.lua
@@ -74,22 +74,20 @@ end
 --
 -- Format a Lua value.
 local function format_lua_value(status, internal_opts, value)
-    local err
-    if status then
-        status, err = pcall(internal.format_lua, internal_opts, value)
-        if status then
-            return err
-        else
-            local m = 'console: exception while formatting output: "%s"'
-            err = m:format(tostring(err))
+    if not status then
+        if value == nil then
+            value = box.NULL
         end
-    else
-        err = value
-        if err == nil then
-            err = box.NULL
-        end
+        value = { error = value }
     end
-    return internal.format_lua(internal_opts, { error = err })
+    local ok, res = pcall(internal.format_lua, internal_opts, value)
+    if ok then
+        return res
+    else
+        local m = 'console: exception while formatting the output: "%s"'
+        local err = m:format(tostring(res))
+        return internal.format_lua(internal_opts, { error = err })
+    end
 end
 
 --

--- a/src/box/lua/serialize_lua.c
+++ b/src/box/lua/serialize_lua.c
@@ -955,7 +955,7 @@ dump_root(struct lua_dumper *d)
 
 	luaL_checkfield(d->L, d->cfg, lua_gettop(d->L), &nd.field);
 
-	if (nd.field.type != MP_ARRAY || nd.field.size != 1) {
+	if (nd.field.type != MP_ARRAY || nd.field.size > 1) {
 		d->err = EINVAL;
 		snprintf(d->err_msg, sizeof(d->err_msg),
 			 "serializer: unexpected data "

--- a/test/box-luatest/gh_6934_nonprintable_error_message_test.lua
+++ b/test/box-luatest/gh_6934_nonprintable_error_message_test.lua
@@ -1,0 +1,17 @@
+local console = require('console')
+local t = require('luatest')
+local g = t.group()
+
+-- Check that an error message with invalid UTF-8 sequences is encoded to Base64
+
+g.test_bad_utf8_in_error_msg1 = function()
+    local res = console.eval("box.error.new(box.error.ILLEGAL_PARAMS, 'bad: \x80')")
+    local ref = "---\n- !!binary SWxsZWdhbCBwYXJhbWV0ZXJzLCBiYWQ6IIA=\n...\n"
+    t.assert_equals(res, ref)
+end
+
+g.test_bad_utf8_in_error_msg2 = function()
+    local res = console.eval("require('net.box').self:call('bad: \x8a')")
+    local ref = "---\n- error: !!binary UHJvY2VkdXJlICdiYWQ6IIonIGlzIG5vdCBkZWZpbmVk\n...\n"
+    t.assert_equals(res, ref)
+end

--- a/third_party/lua-yaml/lyaml.cc
+++ b/third_party/lua-yaml/lyaml.cc
@@ -711,6 +711,14 @@ static int dump_node(struct lua_yaml_dumper *dumper)
       case MP_ERROR:
          str = field.errorval->errmsg;
          len = strlen(str);
+         if (!utf8_check_printable(str, len)) {
+            is_binary = 1;
+            lua_pop(dumper->L, 1);
+            lua_pushlstring(dumper->L, str, len);
+            tobase64(dumper->L, -1);
+            str = lua_tolstring(dumper->L, -1, &len);
+            tag = (yaml_char_t *) LUAYAML_TAG_PREFIX "binary";
+         }
          break;
       case MP_DATETIME:
          len = datetime_to_string(field.dateval, buf, sizeof(buf));


### PR DESCRIPTION
### box: check lua_yaml_encode error in lbox_console_format_yaml

This patch adds a missed check for `lua_yaml_encode` return value,
similar to the check in `console_dump_plain`.
Now Lua error is raised if YAML encoding failed for any reason.

Before:
```
tarantool> box.error.new(box.error.ILLEGAL_PARAMS, '\x80')
~/test$ echo $?
0
~/test$
```

After:
```
tarantool> box.error.new(box.error.ILLEGAL_PARAMS, '\x80')
---
- error: 'console: an exception occurred when formatting the output: expected SCALAR,
    SEQUENCE-START, MAPPING-START, or ALIAS'
...

tarantool>
```

### box: handle internal.format_yaml exceptions

Currently the call to `internal.format_yaml` in `output_handlers["yaml"]`
is covered by `pcall` only for `status == true`, however the opposite
case also can raise an exception. This patch adds the missed exception
handling. Two distinct calls are required, because it is not possible to
assing variadic arguments (`...`) to a variable if some of them is `nil`.
If the first call fails, `internal.format_yaml` will be called for the
second time. Hopefully, it will not fail during formatting of the error
message received from libyaml.

Before:
```
tarantool> require('net.box').self:call('\x80')
LuajitError: builtin/box/console.lua:710: expected SCALAR, SEQUENCE-START, MAPPING-START, or ALIAS
fatal error, exiting the event loop
~/test$
```

After:
```
tarantool> require('net.box').self:call('\x80')
---
- error: 'console: an exception occurred when formatting the output: expected SCALAR,
    SEQUENCE-START, MAPPING-START, or ALIAS'
...

tarantool>
```

### lua-yaml: filter invalid UTF-8 sequences in MP_ERROR

Replace them by the unicode replacement character (U+FFFD) to
obtain printable error message.

Closes #6781
Closes #6934