### PR TITLE
ci: disable tarantool-php/client tests due to bug

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -117,11 +117,12 @@ jobs:
     with:
       artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
 
-  php-client:
-    needs: tarantool
-    uses: tarantool-php/client/.github/workflows/reusable_qa.yml@master
-    with:
-      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+# TODO: Enable testing when tarantool-php/client/issues/79 is resolved.
+#  php-client:
+#    needs: tarantool
+#    uses: tarantool-php/client/.github/workflows/reusable_qa.yml@master
+#    with:
+#      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
 
   php-queue:
     needs: tarantool


### PR DESCRIPTION
This change disables tarantool-php/client integration testing due to
https://github.com/tarantool-php/client/issues/79.

NO_DOC=testing stuff
NO_TEST=testing stuff
NO_CHANGELOG=testing stuff