### PR TITLE
replication: fix race in accessing vclock by applier and tx threads

### DIFF
--- a/changelogs/unreleased/gh-7089-applier-vclock-race.md
+++ b/changelogs/unreleased/gh-7089-applier-vclock-race.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed a case when replication was broken on master side with
+  `ER_INVALID_MSGPACK` (gh-7089).

--- a/perf/gh-7089-vclock-copy/Makefile
+++ b/perf/gh-7089-vclock-copy/Makefile
@@ -1,0 +1,23 @@
+SHELL := /bin/bash
+
+test: test_none stop
+
+test_wal: test_write stop
+
+dirs:
+	for i in {1..11}; do mkdir $${i} || true; done
+
+start_swarm:
+	for i in {2..11}; do ./swarm.lua $${i}; done
+
+test_none: clean dirs start_swarm
+	./speedtest.lua none 1
+
+test_write: clean dirs start_swarm
+	./speedtest.lua write 1
+
+stop stop1:
+	for i in {2..11}; do pkill -F $${i}/$${i}.pid || true; done
+
+clean: stop1
+	for i in {1..11}; do rm -rf $${i}; done

--- a/perf/gh-7089-vclock-copy/Readme.md
+++ b/perf/gh-7089-vclock-copy/Readme.md
@@ -1,0 +1,3 @@
+gh-7089 extra vclock copy for each ack test.
+
+Issue `make test` to run.

--- a/perf/gh-7089-vclock-copy/speedtest.lua
+++ b/perf/gh-7089-vclock-copy/speedtest.lua
@@ -1,0 +1,88 @@
+#!/usr/bin/env tarantool
+
+-- An instance file for the node which tests applier thread ack speed.
+-- There are 10 threads, one per each replication source, so each WAL write
+-- results in an ack message for each thread. This magnifies the possible
+-- performance drawbacks of copying vclocks for each thread.
+
+local mode = arg[1] or 'none'
+assert(mode == 'write' or mode == 'none',
+       "mode should be either 'write' or 'none'")
+
+local id = tonumber(arg[2]) or 1
+
+assert(id < 2 or id > 11,
+       'The id should be outside of the occupied range [2, 11]')
+
+local fiber = require('fiber')
+
+box.cfg{
+    listen = 3300 + id,
+    replication = {
+        3302,
+        3303,
+        3304,
+        3305,
+        3306,
+        3307,
+        3308,
+        3309,
+        3310,
+        3311,
+    },
+    replication_threads = 10,
+    -- Disable WAL on a node to notice slightest differences in TX thread
+    -- performance. It's okay to replicate TO a node with disabled WAL. You only
+    -- can't replicate FROM it.
+    wal_mode = mode,
+    work_dir = tostring(id),
+    log = id..'.log',
+}
+
+box.schema.space.create('test', {if_not_exists = true})
+box.space.test:create_index('pk', {if_not_exists = true})
+box.snapshot()
+
+local function replace_func(num_iters)
+    for i = 1, num_iters do
+        box.space.test:replace{i, i}
+    end
+end
+
+local function test(num_fibers)
+    local fibers = {}
+    local num_replaces = 1e6
+    local num_iters = num_replaces / num_fibers
+    local start = fiber.time()
+    for _ = 1, num_fibers do
+        local fib = fiber.new(replace_func, num_iters)
+        fib:set_joinable(true)
+        table.insert(fibers, fib)
+    end
+    assert(#fibers == num_fibers, "Fibers created successfully")
+    for _, fib in pairs(fibers) do
+        fib:join()
+    end
+    -- Update fiber.time() if there were no yields.
+    fiber.yield()
+    local dt = fiber.time() - start
+    return dt, num_replaces / dt
+end
+
+local mean_time = 0
+local mean_rps = 0
+local num_iters = 100
+
+-- Fiber count > 1 makes no sense for wal_mode = 'none'. There are no yields
+-- on replace when there are no wal writes.
+local num_fibers = mode == 'none' and 1 or 100
+
+for test_iter = 1,num_iters do
+    local time, rps = test(num_fibers)
+    print(('Iteration #%d finished in %f seconds. RPS: %f'):format(test_iter,
+                                                                   time, rps))
+    mean_time = mean_time + time / num_iters
+    mean_rps = mean_rps + rps / num_iters
+end
+print(('Mean iteraion time: %f, mean RPS: %f'):format(mean_time, mean_rps))
+os.exit()

--- a/perf/gh-7089-vclock-copy/swarm.lua
+++ b/perf/gh-7089-vclock-copy/swarm.lua
@@ -1,0 +1,38 @@
+#!/usr/bin/env tarantool
+
+-- Instance file for one of the 10 swarm nodes. They bootstrap the cluster, each
+-- bump their vclock component and then do nothing and serve as replication
+-- masters for the eleventh node.
+
+local id = tonumber(arg[1])
+assert(id ~= nil, 'Please pass a numeric instance id')
+assert(id >= 2 and id <= 11, 'The id should be in ramge [2, 11]')
+
+box.cfg{
+    listen = 3300 + id,
+    replication = {
+        3302,
+        3303,
+        3304,
+        3305,
+        3306,
+        3307,
+        3308,
+        3309,
+        3310,
+        3311,
+    },
+    background = true,
+    work_dir = tostring(id),
+    pid_file = id..'.pid',
+    log = id..'.log',
+}
+
+box.once('bootstrap', function()
+    box.schema.user.grant('guest', 'replication')
+end)
+
+-- This is executed on every instance so that vclock is non-empty in each
+-- component. This will make the testing instance copy a larger portion of data
+-- on each write and make the performance degradation, if any, more obvious.
+box.space._schema:replace{'Something to bump vclock '..id}

--- a/src/box/applier.h
+++ b/src/box/applier.h
@@ -120,6 +120,8 @@ struct applier_ack_msg {
 	 * Set to replica::applier_txn_last_tm.
 	 */
 	double txn_last_tm;
+	/** Replicaset vclock. */
+	struct vclock vclock;
 };
 
 /** The underlying thread behind a number of appliers. */
@@ -248,6 +250,11 @@ struct applier {
 		 * timestamp. Sent in ACK messages. Updated by applier_ack_msg.
 		 */
 		double txn_last_tm;
+		/**
+		 * Applier thread's copy of the node's vclock. Sent in ACK
+		 * messages and updated by applier_ack_msg.
+		 */
+		struct vclock ack_vclock;
 	} thread;
 };
 


### PR DESCRIPTION
When applier ack writer was moved to applier thread, it was overlooked
that it would start sharing replicaset.vclock between two threads.

This could lead to the following replication errors on master:

 relay//102/main:reader V> Got a corrupted row:
 relay//102/main:reader V> 00000000: 81 00 00 81 26 81 01 09 02 01

Such a row has an incorrectly-encoded vclock: `81 01 09 02 01`.
When writer fiber encoded the vclock length (`81`), there was only one
vclock component: {1: 9}, but at the moment of iterating over the
components, another WAL write was reported to TX thread, which bumped
the second vclock component {1: 9, 2: 1}.

Let's fix the race by delivering a copy of current replicaset vclock to
the applier thread.

Closes #7089
Part-of tarantool/tarantool-qa#166

NO_DOC=internal fix
NO_CHANGELOG=internal fix
NO_TEST=hard to test

# A note on why such a seemingly slow fix was chosen:
I was afraid that adding another `vclock_copy` on each wal_write would slow tarantool considerably.
That's why I conducted some tests:

I ran tarantool in wal_mode='None' and wal_mode='Write', the server was connected to 10 remote masters, it had 10 applier threads. So each "wal_write" (even in wal_mode='none') on it would result in copying over 10 extra vclock. Which should be quite slow.
But I couldn't notice any difference in RPS.

Here's the test:
Start 10 nodes in a fullmesh, insert something on each of them so that their vclock becomes huge:
`tarantool swarm.lua 2`, `tarantool swarm lua 3`, ... `tarantool swarm.lua 11`

<details><summary>swarm.lua</summary>

```lua
local id = tonumber(arg[1])
assert(id >= 2 and id <= 31)

box.cfg{
    listen = 3300 + id,
    replication = {
        3302,
        3303,
        3304,
        3305,
        3306,
        3307,
        3308,
        3309,
        3310,
        3311,
    },
    wal_dir = './'..id,
    memtx_dir = './'..id,
    background = true,
    log = './'..id..'.log',
    pid_file = './'..id..'.pid',
}

box.once('bootstrap', function()
    box.schema.user.grant('guest', 'replication')
end)

box.space._schema:replace{"smth to bump vclock "..id}
```

</details>

Now start the testing Tarantool:
`tarantool -i speedtest.lua`
and issue `test(num_fibers_to_test)` as many times as you want.
<details><summary>speedtest.lua</summary>

```lua
local fiber = require('fiber')

box.cfg{
    listen = 3301,
    replication = {
        3302,
        3303,
        3304,
        3305,
        3306,
        3307,
        3308,
        3309,
        3310,
        3311,
    },
    replication_threads = 10,
    -- Disable WAL on a node to notice slightest differences in TX thread
    -- performance. It's okay to replicate TO a node with disabled WAL. You only
    -- can't replicate FROM it.
    --wal_mode = 'None',
    log='./1.log',
}

box.schema.space.create('test', {if_not_exists = true})
box.space.test:create_index('pk', {if_not_exists = true})
box.snapshot()

local function replace_func(num_iters)
    for i = 1, num_iters do
        box.space.test:replace{i, i}
    end
end

function test(num_fibers)
    local fibers = {}
    local num_replaces = 1e6
    local num_iters = num_replaces / num_fibers
    local start = fiber.time()
    for i = 1, num_fibers do
        local fib = fiber.new(replace_func, num_iters)
        fib:set_joinable(true)
        table.insert(fibers, fib)
    end
    assert(#fibers == num_fibers, "Fibers created successfully")
    for _, fib in pairs(fibers) do
        fib:join()
    end
    fiber.yield()
    local dt = fiber.time() - start
    return dt, num_replaces / dt
end
```

</details>

On my machine both patched and canonical Tarantool have around 1 300 000 RPS +- 1 % when wal_mode is 'none'.
When wal_mode is 'write', both Tarantools have around 920 000 RPS +- 1 %.