### PR TITLE
ci: run integration WF on 'integration-ci' label

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,10 +34,11 @@ concurrency:
 jobs:
   tarantool:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
+    # or on pull request if the 'full-ci' or 'integration-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'full-ci') ||
+          contains(github.event.pull_request.labels.*.name, 'integration-ci') )
 
     uses: tarantool/tarantool/.github/workflows/reusable_build.yml@master
     with:


### PR DESCRIPTION
Sometimes we would like to run only integration testing and not touch
other tests. Now it can be done by setting the 'integration-ci' label
on a pull request.