### PR TITLE
sql: fix insertion crash

### DIFF
--- a/changelogs/unreleased/gh-7132-sql-insertion-crash.md
+++ b/changelogs/unreleased/gh-7132-sql-insertion-crash.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Fixed a crash when a table inserted a data into itself with an incorrect
+amount of columns (gh-7132).

--- a/test/sql-luatest/gh_7132_insertion_crash_test.lua
+++ b/test/sql-luatest/gh_7132_insertion_crash_test.lua
@@ -1,0 +1,36 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'insertion_crash'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_insertion_crash_1 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        box.execute([[CREATE TABLE t(i INT PRIMARY KEY, a INT);]])
+        local sql = [[INSERT INTO t(i) SELECT a, i FROM t;]]
+        local res = [[2 values for 1 columns]]
+        local _, err = box.execute(sql)
+        t.assert_equals(err.message, res)
+        box.execute([[DROP TABLE t;]])
+    end)
+end
+
+g.test_insertion_crash_2 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        box.execute([[CREATE TABLE t(i INT PRIMARY KEY, a INT);]])
+        local sql = [[INSERT INTO t SELECT a, i, 1 FROM t;]]
+        local res = [[table T has 2 columns but 3 values were supplied]]
+        local _, err = box.execute(sql)
+        t.assert_equals(err.message, res)
+        box.execute([[DROP TABLE t;]])
+    end)
+end


### PR DESCRIPTION
Previously SQL didn't validate for all cases, that the amount of the source and destination columns during insertion is equal. The problem was detected when we insert an incorrect amount of values into the table. For example, the query
```sql
insert into t(a) select a, b from t
```
produced an instance crash. Fixed.

NO_DOC=bug fix