### PR TITLE
sql: syntax for map

### DIFF
--- a/changelogs/unreleased/gh-4763-introduce-map-to-sql.md
+++ b/changelogs/unreleased/gh-4763-introduce-map-to-sql.md
@@ -1,0 +1,4 @@
+## feature/sql
+
+ * Field type MAP is now available in SQL. The syntax has also been implemented
+   to allow the creation of MAP values (gh-4763).

--- a/src/box/sql/mem.h
+++ b/src/box/sql/mem.h
@@ -919,3 +919,19 @@ mem_to_mpstream(const struct Mem *var, struct mpstream *stream);
 char *
 mem_encode_array(const struct Mem *mems, uint32_t count, uint32_t *size,
 		 struct region *region);
+
+/**
+ * Encode array of MEMs as msgpack map on region. Values in even position are
+ * treated as keys in MAP, values in odd position are treated as values in MAP.
+ * number of MEMs should be even.
+ *
+ * @param mems array of MEMs to encode.
+ * @param count number of elements in the array.
+ * @param[out] size Size of encoded msgpack map.
+ * @param region Region to use.
+ * @retval NULL on error, diag message is set.
+ * @retval Pointer to valid msgpack map on success.
+ */
+char *
+mem_encode_map(const struct Mem *mems, uint32_t count, uint32_t *size,
+	       struct region *region);

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2623,6 +2623,17 @@ void sqlExprAssignVarNumber(Parse *, Expr *, u32);
 ExprList *sqlExprListAppendVector(Parse *, ExprList *, IdList *, Expr *);
 
 /**
+ * Parse tokens as a name or a position of bound variable.
+ *
+ * @param parse Parse context.
+ * @param spec Special symbol for bound variable.
+ * @param id Name or position number of bound variable.
+ */
+struct Expr *
+expr_new_variable(struct Parse *parse, const struct Token *spec,
+		  const struct Token *id);
+
+/**
  * Set the sort order for the last element on the given ExprList.
  *
  * @param p Expression list.

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -58,7 +58,9 @@
 #define CC_KYWD       1		/* Alphabetics or '_'.  Usable in a keyword */
 #define CC_ID         2		/* unicode characters usable in IDs */
 #define CC_DIGIT      3		/* Digits */
-/** SQL variables: '@', '#', ':', and '$'. */
+/** Character ':'. */
+#define CC_COLON      4
+/** SQL variable special characters: '@', '#', and '$'. */
 #define CC_VARALPHA   5
 #define CC_VARNUM     6		/* '?'.  Numeric SQL variables */
 #define CC_SPACE      7		/* Space characters */
@@ -85,17 +87,21 @@
 #define CC_LINEFEED  28		/* '\n' */
 #define CC_LB        29		/* '[' */
 #define CC_RB        30		/* ']' */
+/** Character '{'. */
+#define CC_LCB       31
+/** Character '}'. */
+#define CC_RCB       32
 
 static const char sql_ascii_class[] = {
 /*       x0  x1  x2  x3  x4  x5  x6  x7  x8 x9  xa xb  xc xd xe  xf */
 /* 0x */ 27, 27, 27, 27, 27, 27, 27, 27, 27, 7, 28, 7, 7, 7, 27, 27,
 /* 1x */ 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27,
 /* 2x */ 7, 15, 9, 5, 5, 22, 24, 8, 17, 18, 21, 20, 23, 11, 26, 16,
-/* 3x */ 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 5, 19, 12, 14, 13, 6,
+/* 3x */ 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 19, 12, 14, 13, 6,
 /* 4x */ 5, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
 /* 5x */ 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 29, 27, 30, 27, 1,
 /* 6x */ 27, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-/* 7x */ 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 27, 10, 27, 25, 27,
+/* 7x */ 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 31, 10, 32, 25, 27,
 /* 8x */ 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
 /* 9x */ 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
 /* Ax */ 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
@@ -227,6 +233,12 @@ sql_token(const char *z, int *type, bool *is_reserved)
 		return 1;
 	case CC_RB:
 		*type = TK_RB;
+		return 1;
+	case CC_LCB:
+		*type = TK_LCB;
+		return 1;
+	case CC_RCB:
+		*type = TK_RCB;
 		return 1;
 	case CC_SEMI:
 		*type = TK_SEMI;
@@ -370,6 +382,9 @@ sql_token(const char *z, int *type, bool *is_reserved)
 		return i;
 	case CC_VARNUM:
 		*type = TK_VARNUM;
+		return 1;
+	case CC_COLON:
+		*type = TK_COLON;
 		return 1;
 	case CC_VARALPHA:
 		*type = TK_VARIABLE;

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -58,8 +58,8 @@
 #define CC_KYWD       1		/* Alphabetics or '_'.  Usable in a keyword */
 #define CC_ID         2		/* unicode characters usable in IDs */
 #define CC_DIGIT      3		/* Digits */
-#define CC_DOLLAR     4		/* '$' */
-#define CC_VARALPHA   5		/* '@', '#', ':'.  Alphabetic SQL variables */
+/** SQL variables: '@', '#', ':', and '$'. */
+#define CC_VARALPHA   5
 #define CC_VARNUM     6		/* '?'.  Numeric SQL variables */
 #define CC_SPACE      7		/* Space characters */
 #define CC_QUOTE      8		/* '\''. String literals */
@@ -90,7 +90,7 @@ static const char sql_ascii_class[] = {
 /*       x0  x1  x2  x3  x4  x5  x6  x7  x8 x9  xa xb  xc xd xe  xf */
 /* 0x */ 27, 27, 27, 27, 27, 27, 27, 27, 27, 7, 28, 7, 7, 7, 27, 27,
 /* 1x */ 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27,
-/* 2x */ 7, 15, 9, 5, 4, 22, 24, 8, 17, 18, 21, 20, 23, 11, 26, 16,
+/* 2x */ 7, 15, 9, 5, 5, 22, 24, 8, 17, 18, 21, 20, 23, 11, 26, 16,
 /* 3x */ 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 5, 19, 12, 14, 13, 6,
 /* 4x */ 5, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
 /* 5x */ 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 29, 27, 30, 27, 1,
@@ -184,7 +184,7 @@ int
 sql_token(const char *z, int *type, bool *is_reserved)
 {
 	*is_reserved = false;
-	int i, n;
+	int i;
 	char c, delim;
 	/* Switch on the character-class of the first byte
 	 * of the token. See the comment on the CC_ defines
@@ -369,23 +369,11 @@ sql_token(const char *z, int *type, bool *is_reserved)
 		}
 		return i;
 	case CC_VARNUM:
-		*type = TK_VARIABLE;
-		for (i = 1; sqlIsdigit(z[i]); i++) {
-		}
-		return i;
-	case CC_DOLLAR:
+		*type = TK_VARNUM;
+		return 1;
 	case CC_VARALPHA:
-		n = 0;
 		*type = TK_VARIABLE;
-		for (i = 1; (c = z[i]) != 0; i++) {
-			if (IdChar(c))
-				n++;
-			else
-				break;
-		}
-		if (n == 0)
-			*type = TK_ILLEGAL;
-		return i;
+		return 1;
 	case CC_KYWD:
 		for (i = 1; sql_ascii_class[*(unsigned char*)(z+i)] <= CC_KYWD;
 		     i++) {

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -1442,6 +1442,27 @@ case OP_Array: {
 	break;
 }
 
+/**
+ * Opcode: Map P1 P2 P3 * *
+ * Synopsis: r[P2] = map(P3@P1)
+ *
+ * Construct an MAP value from P1 registers starting at reg(P3).
+ */
+case OP_Map: {
+	pOut = &aMem[pOp->p2];
+
+	uint32_t size;
+	struct region *region = &fiber()->gc;
+	size_t svp = region_used(region);
+	char *val = mem_encode_map(&aMem[pOp->p3], pOp->p1, &size, region);
+	if (val == NULL || mem_copy_map(pOut, val, size) != 0) {
+		region_truncate(region, svp);
+		goto abort_due_to_error;
+	}
+	region_truncate(region, svp);
+	break;
+}
+
 /* Opcode: Eq P1 P2 P3 P4 P5
  * Synopsis: IF r[P3]==r[P1]
  *

--- a/test/sql-luatest/bind_test.lua
+++ b/test/sql-luatest/bind_test.lua
@@ -1,0 +1,30 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'bind'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_bind_1 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT @1asd;]]
+        local res = "At line 1 at or near position 9: unrecognized token '1asd'"
+        local _, err = box.execute(sql, {{['@1asd'] = 123}})
+        t.assert_equals(err.message, res)
+    end)
+end
+
+g.test_bind_2 = function()
+    local conn = g.server.net_box
+    local sql = [[SELECT @1asd;]]
+    local res = [[At line 1 at or near position 9: unrecognized token '1asd']]
+    local _, err = pcall(conn.execute, conn, sql, {{['@1asd'] = 123}})
+    t.assert_equals(err.message, res)
+end

--- a/test/sql-luatest/map_test.lua
+++ b/test/sql-luatest/map_test.lua
@@ -1,0 +1,352 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'map'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+--- Make sure syntax for MAP values works as intended.
+g.test_map_1_1 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {'a' : 123};]]
+        local res = {{{a = 123}}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+g.test_map_1_2 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local dec = require('decimal')
+        local sql = [[SELECT {'a' : 123.1};]]
+        local res = {{{a = dec.new('123.1')}}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+g.test_map_1_3 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {'a' : 123.1e0};]]
+        local res = {{{a = 123.1}}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+g.test_map_1_4 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {'a' : CAST(123 AS NUMBER)};]]
+        local res = {{{a = 123}}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+g.test_map_1_5 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {'a' : '123'};]]
+        local res = {{{a = '123'}}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+g.test_map_1_6 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {'a' : x'313233'};]]
+        local res = {{{a = '123'}}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+g.test_map_1_7 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {'a' : true};]]
+        local res = {{{a = true}}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+g.test_map_1_8 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {'a' : CAST(123 AS SCALAR)};]]
+        local res = {{{a = 123}}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+g.test_map_1_9 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local uuid = require('uuid')
+        local sql = [[SELECT {'a' : ]]..
+                    [[CAST('11111111-1111-1111-1111-111111111111' AS UUID)};]]
+        local res = {a = uuid.fromstr('11111111-1111-1111-1111-111111111111')}
+        t.assert_equals(box.execute(sql).rows[1][1], res)
+    end)
+end
+
+g.test_map_1_10 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {'a' : [1, 2, 3]};]]
+        local res = {{{a = {1, 2, 3}}}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+g.test_map_1_11 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {'a' : {'a': 1, 'b' : 2, 'c' : 3}};]]
+        local res = {{{a = {a = 1, b = 2, c = 3}}}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+-- Make sure MAP() accepts only INTEGER, STRING and UUID as keys.
+g.test_map_2_1 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {123 : 123};]]
+        local res = {{{[123] = 123}}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+g.test_map_2_2 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {123.1 : 123};]]
+        local res = [[Only integer, string and uuid can be keys in map]]
+        local _, err = box.execute(sql)
+        t.assert_equals(err.message, res)
+    end)
+end
+
+g.test_map_2_3 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {123.1e0 : 123};]]
+        local res = [[Only integer, string and uuid can be keys in map]]
+        local _, err = box.execute(sql)
+        t.assert_equals(err.message, res)
+    end)
+end
+
+g.test_map_2_4 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {CAST(123 AS NUMBER) : 123};]]
+        local res = [[Only integer, string and uuid can be keys in map]]
+        local _, err = box.execute(sql)
+        t.assert_equals(err.message, res)
+    end)
+end
+
+g.test_map_2_5 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {'a' : 123};]]
+        local res = {{{a = 123}}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+g.test_map_2_6 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {x'313233' : 123};]]
+        local res = [[Only integer, string and uuid can be keys in map]]
+        local _, err = box.execute(sql)
+        t.assert_equals(err.message, res)
+    end)
+end
+
+g.test_map_2_7 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {true : 123};]]
+        local res = [[Only integer, string and uuid can be keys in map]]
+        local _, err = box.execute(sql)
+        t.assert_equals(err.message, res)
+    end)
+end
+
+g.test_map_2_8 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {CAST(123 AS SCALAR) : 123};]]
+        local res = [[Only integer, string and uuid can be keys in map]]
+        local _, err = box.execute(sql)
+        t.assert_equals(err.message, res)
+    end)
+end
+
+g.test_map_2_9 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local uuid = require('uuid')
+        local sql = [[SELECT {CAST('11111111-1111-1111-1111-111111111111' ]]..
+                    [[AS UUID) : 123}]]
+        local res = uuid.fromstr('11111111-1111-1111-1111-111111111111')
+        local val, _ = next(box.execute(sql).rows[1][1])
+        t.assert_equals(val, res);
+    end)
+end
+
+g.test_map_2_10 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {[1, 2, 3]: 123};]]
+        local res = [[Only integer, string and uuid can be keys in map]]
+        local _, err = box.execute(sql)
+        t.assert_equals(err.message, res)
+    end)
+end
+
+g.test_map_2_11 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {{'a': 1, 'b' : 2, 'c' : 3}: 123};]]
+        local res = [[Only integer, string and uuid can be keys in map]]
+        local _, err = box.execute(sql)
+        t.assert_equals(err.message, res)
+    end)
+end
+
+-- Make sure expressions can be used as a key or a value in the MAP constructor.
+g.test_map_3_1 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {'a' : a} FROM (SELECT 123 AS a);]]
+        local res = {{{a = 123}}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+g.test_map_3_2 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {a : 123} FROM (SELECT 123 AS a);]]
+        local res = {{{[123] = 123}}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+g.test_map_3_3 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {1 + 2 : 123};]]
+        local res = {{{[3] = 123}}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+g.test_map_3_4 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {'a' : 1 + 2};]]
+        local res = {{{a = 3}}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+-- Make sure TYPEOF() properly works with the MAP constructor.
+g.test_map_4 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT typeof({'a' : 123});]]
+        local res = {{'map'}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+-- Make sure PRINTF() properly works with the MAP constructor.
+g.test_map_5 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT printf({});]]
+        local res = {{'{}'}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end
+
+-- Make sure that the MAP constructor can create big MAP values.
+g.test_map_6 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local map = {['c0'] = 0}
+        local str = "'c0': 0"
+        for i = 1, 1000 do
+            map['c'..tostring(i)] = i
+            str = str .. string.format(", 'c%d': %d", i, i)
+        end
+        local sql = [[SELECT {]]..str..[[};]]
+        t.assert_equals(box.execute(sql).rows[1][1], map)
+    end)
+end
+
+-- Make sure symbol ':' is properly processed by parser.
+g.test_map_7_1 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {:name};]]
+        local res = [[Syntax error at line 1 near '}']]
+        local _, err = box.execute(sql, {{[':name'] = 1}})
+        t.assert_equals(err.message, res)
+    end)
+end
+
+g.test_map_7_2 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {:name : 5};]]
+        local res = {{{[1] = 5}}}
+        t.assert_equals(box.execute(sql, {{[':name'] = 1}}).rows, res)
+    end)
+end
+
+g.test_map_7_3 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {5::name};]]
+        local res = {{{[5] = 1}}}
+        t.assert_equals(box.execute(sql, {{[':name'] = 1}}).rows, res)
+    end)
+end
+
+-- Make sure that multiple row with maps can be selected properly.
+g.test_map_8 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local maps = {{{a1 = 1}}}
+        local strs = "({'a1': 1})"
+        for i = 2, 1000 do
+            maps[i] = {{['a'..tostring(i)] = i}}
+            strs = strs .. string.format(", ({'a%d': %d})", i, i)
+        end
+        local sql = [[SELECT * FROM (VALUES]]..strs..[[);]]
+        t.assert_equals(box.execute(sql).rows, maps)
+    end)
+end
+
+-- Make sure that the last of values with the same key is set.
+g.test_map_9 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT {'a' : 1, 'a' : 2, 'b' : 3, 'a' : 4};]]
+        local res = {{{b = 3, a = 4}}}
+        t.assert_equals(box.execute(sql).rows, res)
+    end)
+end

--- a/test/sql-tap/misc1.test.lua
+++ b/test/sql-tap/misc1.test.lua
@@ -1052,7 +1052,7 @@ test:do_catchsql_test(
         select''like''like''like#0;
     ]], {
         -- <misc1-21.1>
-        1, [[Syntax error at line 1 near '#0']]
+        1, [[Syntax error at line 1 near '#']]
         -- </misc1-21.1>
     })
 
@@ -1062,7 +1062,7 @@ test:do_catchsql_test(
         VALUES(0,0x0MATCH#0;
     ]], {
         -- <misc1-21.2>
-        1, [[Syntax error at line 1 near '#0']]
+        1, [[Syntax error at line 1 near '#']]
         -- </misc1-21.2>
     })
 

--- a/test/sql/iproto.result
+++ b/test/sql/iproto.result
@@ -351,7 +351,7 @@ cn:execute('drop table if exists test3')
 --
 cn:execute('select ?1, ?2, ?3', {1, 2, 3})
 ---
-- error: Syntax error at line 1 near '?1'
+- error: Syntax error at line 1 near '1'
 ...
 cn:execute('select $name, $name2', {1, 2})
 ---


### PR DESCRIPTION
This patch introduces the syntax for the MAP value constructor in SQL.