### PR TITLE
box: add option to disable Lua FFI for read operations

### DIFF
--- a/extra/exports
+++ b/extra/exports
@@ -52,6 +52,7 @@ box_latch_new
 box_latch_trylock
 box_latch_unlock
 box_on_shutdown
+box_read_ffi_is_disabled
 box_region_aligned_alloc
 box_region_alloc
 box_region_truncate

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -586,6 +586,36 @@ box_broadcast_election(void);
 void
 box_broadcast_schema(void);
 
+/**
+ * True if FFI must not be used for calling box read operations from Lua, see
+ * box/lua/schema.lua.
+ *
+ * Lua FFI is faster than Lua C API, but it must not be used if the executed C
+ * function may yield or call a Lua function. In particular, we have to disable
+ * FFI during online space upgrade, which installs a Lua handler for each read
+ * operation to return updated data.
+ *
+ * See also box_read_ffi_enable(), box_read_ffi_disable().
+ */
+extern bool box_read_ffi_is_disabled;
+
+/**
+ * Disables Lua FFI for box read operations, see box_read_ffi_is_disabled.
+ *
+ * It's okay to call this function multiple times, because we use a counter
+ * under the hood, not a boolean flag. To re-enable Lua FFI, one should call
+ * box_read_ffi_enable() the same amount of times.
+ */
+void
+box_read_ffi_disable(void);
+
+/**
+ * Re-enables Lua FFI for box read operations, which was disabled with
+ * box_read_ffi_disable().
+ */
+void
+box_read_ffi_enable(void);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/lua/index.c
+++ b/src/box/lua/index.c
@@ -40,7 +40,7 @@
 /** {{{ box.index Lua library: access to spaces and indexes
  */
 
-static int CTID_STRUCT_ITERATOR_REF = 0;
+static uint32_t CTID_STRUCT_ITERATOR_PTR = 0;
 
 static int
 lbox_insert(lua_State *L)
@@ -257,9 +257,9 @@ lbox_index_iterator(lua_State *L)
 	if (it == NULL)
 		return luaT_error(L);
 
-	assert(CTID_STRUCT_ITERATOR_REF != 0);
+	assert(CTID_STRUCT_ITERATOR_PTR != 0);
 	struct iterator **ptr = (struct iterator **) luaL_pushcdata(L,
-		CTID_STRUCT_ITERATOR_REF);
+		CTID_STRUCT_ITERATOR_PTR);
 	*ptr = it; /* NULL handled by Lua, gc also set by Lua */
 	return 1;
 }
@@ -271,10 +271,10 @@ lbox_iterator_next(lua_State *L)
 	if (lua_gettop(L) < 1 || lua_type(L, 1) != LUA_TCDATA)
 		return luaL_error(L, "usage: next(state)");
 
-	assert(CTID_STRUCT_ITERATOR_REF != 0);
+	assert(CTID_STRUCT_ITERATOR_PTR != 0);
 	uint32_t ctypeid;
 	void *data = luaL_checkcdata(L, 1, &ctypeid);
-	if (ctypeid != (uint32_t) CTID_STRUCT_ITERATOR_REF)
+	if (ctypeid != CTID_STRUCT_ITERATOR_PTR)
 		return luaL_error(L, "usage: next(state)");
 
 	struct iterator *itr = *(struct iterator **) data;
@@ -337,8 +337,8 @@ box_lua_index_init(struct lua_State *L)
 	int rc = luaL_cdef(L, "struct iterator;");
 	assert(rc == 0);
 	(void) rc;
-	CTID_STRUCT_ITERATOR_REF = luaL_ctypeid(L, "struct iterator&");
-	assert(CTID_STRUCT_ITERATOR_REF != 0);
+	CTID_STRUCT_ITERATOR_PTR = luaL_ctypeid(L, "struct iterator*");
+	assert(CTID_STRUCT_ITERATOR_PTR != 0);
 
 	static const struct luaL_Reg indexlib [] = {
 		{NULL, NULL}


### PR DESCRIPTION
Box read operations (select, min, max, random, pairs) may call a Lua function via Lua C API if space upgrade (EE feature) is in progress. This is forbidden if the original function was called via FFI, see https://github.com/tarantool/luajit/commit/4f4fd9ebeb10d53c8e67f45170938f052818e64e. Let's add helper functions to disable FFI for box read operations. We will use them in EE code.

Needed for https://github.com/tarantool/tarantool-ee/issues/94