### PR TITLE
ci: fix RPM package builds with GC64 enabled

### DIFF
--- a/.gitlab.mk
+++ b/.gitlab.mk
@@ -109,7 +109,7 @@ deploy_prepare:
 	rm -rf build
 
 package: deploy_prepare
-	# Set PRODUCT_NAME for the package itself.
+	# Set PRODUCT_NAME for the package itself. Needed for RPM packages.
 	if [ "$$(echo $(GC64) | sed 's/.*=//')" = ON ]; then                                                           \
 		export PRODUCT_NAME=tarantool-gc64; \
 		if [ "${OS}" = "ubuntu" ] || [ "${OS}" = "debian" ]; then \

--- a/rpm/tarantool.spec
+++ b/rpm/tarantool.spec
@@ -128,6 +128,9 @@ Group: Applications/Databases
 Summary: In-memory database and Lua application server
 License: BSD
 
+%if "%{_product}" == "tarantool-gc64"
+Provides: tarantool = %{version}-%{release}
+%endif
 Provides: tarantool-debuginfo = %{version}-%{release}
 Provides: tarantool-common = %{version}-%{release}
 Obsoletes: tarantool-common < 1.6.8.434-1


### PR DESCRIPTION
To avoid dependency conflicts with other packages (e.g. tarantool-http),
the `Provides` field has to be defined in the rpm/tarantool.spec config
file for the 'tarantool-gc64' package.

Follows up: tarantool/tarantool-qa#161

NO_DOC=ci
NO_TEST=ci
NO_CHANGELOG=ci