### PR TITLE
Space upgrade related fixes

### DIFF
--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -118,6 +118,10 @@ static const char *lua_sources[] = {
 	"box/feedback_daemon", feedback_daemon_lua,
 #endif
 #if ENABLE_SPACE_UPGRADE
+	/*
+	 * Must be loaded after schema_lua, because it redefines
+	 * box.schema.space.upgrade.
+	 */
 	"box/space_upgrade", space_upgrade_lua,
 #endif
 #if ENABLE_AUDIT_LOG

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -812,12 +812,9 @@ function box.schema.space.format(id, format)
     end
 end
 
-function box.schema.space.upgrade(id, ...)
+function box.schema.space.upgrade(id)
     check_param(id, 'id', 'number')
-    if not box.internal.space.upgrade then
-        box.error(box.error.UNSUPPORTED, "Community edition", "space upgrade")
-    end
-    return box.internal.space.upgrade(id, ...)
+    box.error(box.error.UNSUPPORTED, "Community edition", "space upgrade")
 end
 
 box.schema.create_space = box.schema.space.create
@@ -1468,6 +1465,7 @@ local function func_id_by_name(func_name)
     end
     return func.id
 end
+box.internal.func_id_by_name = func_id_by_name -- for space.upgrade
 
 box.schema.index.create = function(space_id, name, options)
     check_param(space_id, 'space_id', 'number')

--- a/src/lib/core/fiber_cond.h
+++ b/src/lib/core/fiber_cond.h
@@ -58,6 +58,9 @@ struct fiber_cond {
 	struct rlist waiters;
 };
 
+#define FIBER_COND_INITIALIZER(name) { RLIST_HEAD_INITIALIZER(name.waiters) }
+#define FIBER_COND(name) struct fiber_cond name = FIBER_COND_INITIALIZER(name)
+
 /**
  * Initialize the fiber condition variable.
  *


### PR DESCRIPTION
- Add `func_id_by_name` to `box.internal`. It will be used in EE.
- Don't call `box.internal.space.upgrade` from `box.schema.space.upgrade` - we will redefine box.schema.space.upgrade in EE instead.
- Add static initializer for `fiber_cond`. It will be used in EE, but it's good to have anyway.

Needed for https://github.com/tarantool/tarantool-ee/issues/94