### PR TITLE
ci: follow-up improvements for gc64 builds

### DIFF
--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF", "GC64=ON" ]
+        build-type: [ '', 'gc64' ]
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -57,7 +57,7 @@ jobs:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'el'
           DIST: '7'
-          GC64: -DLUAJIT_ENABLE_${{ matrix.gc64 }}
+          GC64: ${{ matrix.build-type == 'gc64' }}
         uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF", "GC64=ON" ]
+        build-type: [ '', 'gc64' ]
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -57,7 +57,7 @@ jobs:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'el'
           DIST: '8'
-          GC64: -DLUAJIT_ENABLE_${{ matrix.gc64 }}
+          GC64: ${{ matrix.build-type == 'gc64' }}
         uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF", "GC64=ON" ]
+        build-type: [ '', 'gc64' ]
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -57,7 +57,7 @@ jobs:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'debian'
           DIST: 'buster'
-          GC64: -DLUAJIT_ENABLE_${{ matrix.gc64 }}
+          GC64: ${{ matrix.build-type == 'gc64' }}
         uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF", "GC64=ON" ]
+        build-type: [ '', 'gc64' ]
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -57,7 +57,7 @@ jobs:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'debian'
           DIST: 'bullseye'
-          GC64: -DLUAJIT_ENABLE_${{ matrix.gc64 }}
+          GC64: ${{ matrix.build-type == 'gc64' }}
         uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF", "GC64=ON" ]
+        build-type: [ '', 'gc64' ]
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -57,7 +57,7 @@ jobs:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'debian'
           DIST: 'stretch'
-          GC64: -DLUAJIT_ENABLE_${{ matrix.gc64 }}
+          GC64: ${{ matrix.build-type == 'gc64' }}
         uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/fedora_30.yml
+++ b/.github/workflows/fedora_30.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF", "GC64=ON" ]
+        build-type: [ '', 'gc64' ]
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -57,7 +57,7 @@ jobs:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'fedora'
           DIST: '30'
-          GC64: -DLUAJIT_ENABLE_${{ matrix.gc64 }}
+          GC64: ${{ matrix.build-type == 'gc64' }}
         uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/fedora_31.yml
+++ b/.github/workflows/fedora_31.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF", "GC64=ON" ]
+        build-type: [ '', 'gc64' ]
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -57,7 +57,7 @@ jobs:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'fedora'
           DIST: '31'
-          GC64: -DLUAJIT_ENABLE_${{ matrix.gc64 }}
+          GC64: ${{ matrix.build-type == 'gc64' }}
         uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/fedora_32.yml
+++ b/.github/workflows/fedora_32.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF", "GC64=ON" ]
+        build-type: [ '', 'gc64' ]
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -57,7 +57,7 @@ jobs:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'fedora'
           DIST: '32'
-          GC64: -DLUAJIT_ENABLE_${{ matrix.gc64 }}
+          GC64: ${{ matrix.build-type == 'gc64' }}
         uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/fedora_33.yml
+++ b/.github/workflows/fedora_33.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF", "GC64=ON" ]
+        build-type: [ '', 'gc64' ]
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -57,7 +57,7 @@ jobs:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'fedora'
           DIST: '33'
-          GC64: -DLUAJIT_ENABLE_${{ matrix.gc64 }}
+          GC64: ${{ matrix.build-type == 'gc64' }}
         uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF", "GC64=ON" ]
+        build-type: [ '', 'gc64' ]
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -57,7 +57,7 @@ jobs:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'fedora'
           DIST: '34'
-          GC64: -DLUAJIT_ENABLE_${{ matrix.gc64 }}
+          GC64: ${{ matrix.build-type == 'gc64' }}
         uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/fedora_35.yml
+++ b/.github/workflows/fedora_35.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF", "GC64=ON" ]
+        build-type: [ '', 'gc64' ]
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -57,7 +57,7 @@ jobs:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'fedora'
           DIST: '35'
-          GC64: -DLUAJIT_ENABLE_${{ matrix.gc64 }}
+          GC64: ${{ matrix.build-type == 'gc64' }}
         uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF", "GC64=ON" ]
+        build-type: [ '', 'gc64' ]
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -57,7 +57,7 @@ jobs:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'opensuse-leap'
           DIST: '15.1'
-          GC64: -DLUAJIT_ENABLE_${{ matrix.gc64 }}
+          GC64: ${{ matrix.build-type == 'gc64' }}
         uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF", "GC64=ON" ]
+        build-type: [ '', 'gc64' ]
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -57,7 +57,7 @@ jobs:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'opensuse-leap'
           DIST: '15.2'
-          GC64: -DLUAJIT_ENABLE_${{ matrix.gc64 }}
+          GC64: ${{ matrix.build-type == 'gc64' }}
         uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF", "GC64=ON" ]
+        build-type: [ '', 'gc64' ]
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -57,7 +57,7 @@ jobs:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'ubuntu'
           DIST: 'xenial'
-          GC64: -DLUAJIT_ENABLE_${{ matrix.gc64 }}
+          GC64: ${{ matrix.build-type == 'gc64' }}
         uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF", "GC64=ON" ]
+        build-type: [ '', 'gc64' ]
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -57,7 +57,7 @@ jobs:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'ubuntu'
           DIST: 'bionic'
-          GC64: -DLUAJIT_ENABLE_${{ matrix.gc64 }}
+          GC64: ${{ matrix.build-type == 'gc64' }}
         uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF", "GC64=ON" ]
+        build-type: [ '', 'gc64' ]
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -57,7 +57,7 @@ jobs:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'ubuntu'
           DIST: 'focal'
-          GC64: -DLUAJIT_ENABLE_${{ matrix.gc64 }}
+          GC64: ${{ matrix.build-type == 'gc64' }}
         uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/ubuntu_21_04.yml
+++ b/.github/workflows/ubuntu_21_04.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF", "GC64=ON" ]
+        build-type: [ '', 'gc64' ]
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -57,7 +57,7 @@ jobs:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'ubuntu'
           DIST: 'hirsute'
-          GC64: -DLUAJIT_ENABLE_${{ matrix.gc64 }}
+          GC64: ${{ matrix.build-type == 'gc64' }}
         uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:

--- a/.github/workflows/ubuntu_21_10.yml
+++ b/.github/workflows/ubuntu_21_10.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gc64: [ "GC64=OFF", "GC64=ON" ]
+        build-type: [ '', 'gc64' ]
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -57,7 +57,7 @@ jobs:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'ubuntu'
           DIST: 'impish'
-          GC64: -DLUAJIT_ENABLE_${{ matrix.gc64 }}
+          GC64: ${{ matrix.build-type == 'gc64' }}
         uses: ./.github/actions/pack_and_deploy
       - name: call action to send Telegram message on failure
         env:

--- a/.gitlab.mk
+++ b/.gitlab.mk
@@ -125,7 +125,7 @@ deploy:
 		exit 1; \
 	fi; \
 	# Use different repos for vanilla and GC64 version.
-	if [ "$$(echo ${GC64} | sed 's/.*=//')" = ON ]; then \
+	if [ "${GC64}" = "true" ]; then \
 		RWS_ENDPOINT=${RWS_BASE_URL}/${REPO_TYPE}/${TARANTOOL_SERIES}-gc64/${OS}/${DIST}; \
 	else \
 		RWS_ENDPOINT=${RWS_BASE_URL}/${REPO_TYPE}/${TARANTOOL_SERIES}/${OS}/${DIST}; \

--- a/debian/rules
+++ b/debian/rules
@@ -19,10 +19,9 @@ DEB_CMAKE_EXTRA_FLAGS := \
 	-DWITH_SYSVINIT=ON \
 	-DWITH_SYSTEMD=$(WITH_SYSTEMD)
 
-# Append CMAKE flag with -DLUAJIT_ENABLE_GC64 value. It is required
-# for CI to build Tarantool with GC64 enabled or disabled dynamically.
-ifneq ($(GC64),)
-	DEB_CMAKE_EXTRA_FLAGS += $(GC64)
+# Append -DLUAJIT_ENABLE_GC64=ON flag if ${GC64} env variable is 'true'.
+ifeq ($(GC64), true)
+	DEB_CMAKE_EXTRA_FLAGS += -DLUAJIT_ENABLE_GC64=ON
 endif
 
 # Install tarantool.service within tarantool-common package, but does not

--- a/rpm/tarantool.spec
+++ b/rpm/tarantool.spec
@@ -11,10 +11,9 @@
 # need to use cmake3 package to build Tarantool on old systems.
 %define use_cmake3 0%{?rhel} == 7
 
-# Get GC64 variable which can keep compiler flag -DLUAJIT_ENABLE_GC64
-# with a value of ON or OFF to enable or disable luajit gc64.
-# It needs to build Tarantool in CI dynamically.
-%define _gc64 %{getenv:GC64}
+# Get ${GC64} env variable which can keep the value of 'true' or 'false' to
+# enable or disable luajit gc64.
+%define _gc64 "%{getenv:GC64}"
 
 %if %use_cmake3
 # XXX: Unfortunately there is no way to make rpmbuild install and
@@ -196,8 +195,8 @@ C and Lua/C modules.
 %if 0%{?fedora} >= 33
          -DENABLE_LTO=ON \
 %endif
-%if "%{_gc64}"
-         %{_gc64} \
+%if %{_gc64} == "true"
+         -DLUAJIT_ENABLE_GC64:BOOL=ON \
 %endif
          -DENABLE_WERROR:BOOL=ON \
          -DENABLE_DIST:BOOL=ON


### PR DESCRIPTION
This change contains the following improvements:

1. Prettify view in the job list.

   Before:
     - centos_7 / centos_7 (GC64=OFF)
     - centos_7 / centos_7 (GC64=ON)

   After:
     - centos_7 / centos_7
     - centos_7 / centos_7 (gc64)

2. Change possible values for the ${GC64} env variable to
   `true/false` instead of `ON/OFF` which is more traditional.

3. Use `-DLUAJIT_ENABLE_GC64=ON` flag in the `debian/rules` and
   `rpm/tarantool.spec` files directly instead of providing it
   in the workflow files.

Follows-up tarantool/tarantool-qa#159
Follows-up tarantool/tarantool-qa#161