### PR TITLE
luajit: bump submodule and add sysprof integration

### DIFF
--- a/extra/exports
+++ b/extra/exports
@@ -258,7 +258,9 @@ luaL_typerror
 luaL_unref
 luaL_where
 luaM_metrics
-luaM_sysprof_configure
+luaM_sysprof_set_writer
+luaM_sysprof_set_on_stop
+luaM_sysprof_set_backtracer
 luaM_sysprof_report
 luaM_sysprof_start
 luaM_sysprof_stop

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -160,6 +160,7 @@ set (server_sources
      lua/string.c
      lua/swim.c
      lua/decimal.c
+     lua/sysprof.c
      lua/uri.c
      lua/backtrace.c
      ${lua_sources}

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -64,6 +64,7 @@
 #include "lua/utf8.h"
 #include "lua/swim.h"
 #include "lua/decimal.h"
+#include "lua/sysprof.h"
 #include "lua/uri.h"
 #include "digest.h"
 #include "errinj.h"
@@ -713,6 +714,7 @@ tarantool_lua_init(const char *tarantool_bin, int argc, char **argv)
 	tarantool_lua_swim_init(L);
 	tarantool_lua_decimal_init(L);
 	luaopen_http_client_driver(L);
+	tarantool_lua_sysprof_init();
 	lua_pop(L, 1);
 	luaopen_msgpack(L);
 	lua_pop(L, 1);

--- a/src/lua/sysprof.c
+++ b/src/lua/sysprof.c
@@ -1,0 +1,30 @@
+#include "lua/sysprof.h"
+
+#ifdef ENABLE_BACKTRACE
+
+#include "core/fiber.h"
+#include "core/backtrace.h"
+
+void
+fiber_backtracer(void *(*frame_writer)(int frame_no, void *addr))
+{
+	struct backtrace bt = {};
+	int frame_no = 0;
+	backtrace_collect(&bt, fiber_self(), 0);
+	for (frame_no = 0; frame_no < bt.frame_count; ++frame_no) {
+		frame_writer(frame_no, bt.frames[frame_no].ip);
+	}
+}
+
+void
+tarantool_lua_sysprof_init(void)
+{
+	luaM_sysprof_set_backtracer(fiber_backtracer);
+}
+
+#else
+
+void
+tarantool_lua_sysprof_init(void) {};
+
+#endif /* ENABLE_BACKTRACE */

--- a/src/lua/sysprof.h
+++ b/src/lua/sysprof.h
@@ -1,0 +1,18 @@
+#ifndef TARANTOOL_LUA_SYSPROF_H_INCLUDED
+#define TARANTOOL_LUA_SYSPROF_H_INCLUDED
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+struct lua_State;
+/**
+ * Initialize misc.sysprof module.
+ */
+void
+tarantool_lua_sysprof_init(void);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* TARANTOOL_LUA_SYSPROF_H_INCLUDED */


### PR DESCRIPTION
sysprof: make sysprof internal API funcs static
sysprof: fix `SYSPROF_HANDLER_STACK_DEPTH`
sysprof: change C configuration API
sysprof: enrich symtab on a new trace or a proto
sysprof: add `LUAJIT_DISABLE_SYSPROF` to Makefile

Part of #781