### PR TITLE
ci: fix email subject in perf_sysbench.yml

### DIFF
--- a/.github/workflows/perf_sysbench.yml
+++ b/.github/workflows/perf_sysbench.yml
@@ -129,7 +129,7 @@ jobs:
           server_address: ${{ secrets.PERF_EMAIL_SERVER }}
           server_port: 25
           subject: >
-            Tarantool Perf Testing. Branch: ${{ github.ref_name }}.
+            Tarantool Perf Testing. Branch: ${{ matrix.branch }}.
             Build: ${{ steps.tarantool-version.outputs.value }}.
             Test: sysbench
           to: ${{ github.event.inputs.debug == 'true' &&


### PR DESCRIPTION
The `${{ github.ref_name }}` expression is always evaluated to 'master'
because the workflow is running on the 'master' branch. But it is wrong
in the case of the '2.10' branch. Now it's fixed.