### PR TITLE
iproto: log error before iproto_write_error

### DIFF
--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -1230,8 +1230,8 @@ iproto_connection_resume(struct iproto_connection *con)
 	 */
 	if (iproto_enqueue_batch(con, con->p_ibuf) != 0) {
 		struct error *e = box_error_last();
-		iproto_write_error(&con->io, e, ::schema_version, 0);
 		error_log(e);
+		iproto_write_error(&con->io, e, ::schema_version, 0);
 		iproto_connection_close(con);
 	}
 }
@@ -1317,9 +1317,9 @@ iproto_connection_on_input(ev_loop *loop, struct ev_io *watcher,
 		if (iproto_enqueue_batch(con, in) != 0)
 			diag_raise();
 	} catch (Exception *e) {
+		e->log();
 		/* Best effort at sending the error message to the client. */
 		iproto_write_error(io, e, ::schema_version, 0);
-		e->log();
 		iproto_connection_close(con);
 	}
 }

--- a/test/box-luatest/gh_6890_iproto_error_use_after_free_test.lua
+++ b/test/box-luatest/gh_6890_iproto_error_use_after_free_test.lua
@@ -1,0 +1,31 @@
+local msgpack = require('msgpack')
+local server = require('test.luatest_helpers.server')
+local socket = require('socket')
+local uri = require('uri')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:drop()
+end)
+
+g.test_iproto_error_use_after_free = function()
+    -- Connect to the server.
+    local u = uri.parse(g.server.net_box_uri)
+    local s = socket.tcp_connect(u.host, u.service)
+    t.assert_is_not(s, nil)
+    -- Skip the greeting.
+    t.assert_equals(#s:read(128), 128)
+    -- Send an invalid request and immediately close the socket so that
+    -- the server fails to send the error back.
+    local d = msgpack.encode('foo')
+    t.assert_equals(s:write(d), #d)
+    s:close()
+    -- Check that the server logs the proper error.
+    t.assert(g.server:grep_log('ER_INVALID_MSGPACK'))
+end


### PR DESCRIPTION
`iproto_write_error()` may reset diag (for example, if the client closes the socket), thus invalidating the error we are going to log and leading to a use after free bug. We must log the error before trying to send it to the client.

The bug was introduced by commit 9b4ab9fe0ef05, which switched `iproto_write_error()` from plain `write()` to the `iostream_write()`, which may set diag.

Closes #6890
Needed for https://github.com/tarantool/tarantool-ee/issues/109
Needed for 2.10