### PR TITLE
Follow-ups for DATETIME and INTERVAL in SQL

### DIFF
--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -417,6 +417,12 @@ sql_type_result(enum field_type lhs, enum field_type rhs)
 		       rhs == FIELD_TYPE_UNSIGNED);
 		return FIELD_TYPE_UNSIGNED;
 	}
+	if ((lhs == FIELD_TYPE_DATETIME && rhs == FIELD_TYPE_DATETIME) ||
+	    (lhs == FIELD_TYPE_INTERVAL && rhs == FIELD_TYPE_INTERVAL))
+		return FIELD_TYPE_INTERVAL;
+	if ((lhs == FIELD_TYPE_INTERVAL && rhs == FIELD_TYPE_DATETIME) ||
+	    (lhs == FIELD_TYPE_DATETIME && rhs == FIELD_TYPE_INTERVAL))
+		return FIELD_TYPE_DATETIME;
 	return FIELD_TYPE_SCALAR;
 }
 

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -1308,6 +1308,18 @@ map_to_datetime(struct Mem *mem)
 	return 0;
 }
 
+/** Convert MEM from MAP to INTERVAL. */
+static inline int
+map_to_interval(struct Mem *mem)
+{
+	assert(mem->type == MEM_TYPE_MAP);
+	struct interval itv;
+	if (interval_from_map(&itv, mem->z) != 0)
+		return -1;
+	mem_set_interval(mem, &itv);
+	return 0;
+}
+
 int
 mem_to_int(struct Mem *mem)
 {
@@ -1490,6 +1502,8 @@ mem_cast_explicit(struct Mem *mem, enum field_type type)
 		mem->flags = 0;
 		return 0;
 	case FIELD_TYPE_INTERVAL:
+		if (mem->type == MEM_TYPE_MAP)
+			return map_to_interval(mem);
 		if (mem->type != MEM_TYPE_INTERVAL)
 			return -1;
 		mem->flags = 0;

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -1296,6 +1296,18 @@ uuid_to_bin(struct Mem *mem)
 	return mem_copy_bin(mem, (char *)&mem->u.uuid, UUID_LEN);
 }
 
+/** Convert MEM from MAP to DATETIME. */
+static inline int
+map_to_datetime(struct Mem *mem)
+{
+	assert(mem->type == MEM_TYPE_MAP);
+	struct datetime dt;
+	if (datetime_from_map(&dt, mem->z) != 0)
+		return -1;
+	mem_set_datetime(mem, &dt);
+	return 0;
+}
+
 int
 mem_to_int(struct Mem *mem)
 {
@@ -1471,6 +1483,8 @@ mem_cast_explicit(struct Mem *mem, enum field_type type)
 	case FIELD_TYPE_DATETIME:
 		if (mem->type == MEM_TYPE_STR)
 			return str_to_datetime(mem);
+		if (mem->type == MEM_TYPE_MAP)
+			return map_to_datetime(mem);
 		if (mem->type != MEM_TYPE_DATETIME)
 			return -1;
 		mem->flags = 0;

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -858,6 +858,18 @@ str_to_dec(struct Mem *mem)
 	return 0;
 }
 
+/** Convert MEM from STRING to DATETIME. */
+static inline int
+str_to_datetime(struct Mem *mem)
+{
+	assert(mem->type == MEM_TYPE_STR);
+	struct datetime dt;
+	if (datetime_parse_full(&dt, mem->z, mem->n, 0) <= 0)
+		return -1;
+	mem_set_datetime(mem, &dt);
+	return 0;
+}
+
 static inline int
 double_to_int(struct Mem *mem)
 {
@@ -1457,6 +1469,8 @@ mem_cast_explicit(struct Mem *mem, enum field_type type)
 			return bin_to_uuid(mem);
 		return -1;
 	case FIELD_TYPE_DATETIME:
+		if (mem->type == MEM_TYPE_STR)
+			return str_to_datetime(mem);
 		if (mem->type != MEM_TYPE_DATETIME)
 			return -1;
 		mem->flags = 0;

--- a/src/lib/core/datetime.h
+++ b/src/lib/core/datetime.h
@@ -381,6 +381,10 @@ datetime_usec(const struct datetime *date)
 	return datetime_nsec(date) / 1000;
 }
 
+/** Parse MAP value and construct DATETIME value. */
+int
+datetime_from_map(struct datetime *dt, const char *data);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/lib/core/datetime.h
+++ b/src/lib/core/datetime.h
@@ -385,6 +385,10 @@ datetime_usec(const struct datetime *date)
 int
 datetime_from_map(struct datetime *dt, const char *data);
 
+/** Parse MAP value and construct INTERVAL value. */
+int
+interval_from_map(struct interval *itv, const char *data);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/test/sql-luatest/datetime_test.lua
+++ b/test/sql-luatest/datetime_test.lua
@@ -2680,3 +2680,183 @@ g.test_datetime_33_3 = function()
         t.assert_equals(box.execute(sql).rows, {{dt1}})
     end)
 end
+
+-- Make sure cast from MAP to INTERVAL works as intended.
+
+--
+-- The result of CAST() from MAP value to INTERVAL must be equal to the result
+-- of calling require('datetime').interval.new() with the corresponding table as
+-- an argument.
+--
+g.test_datetime_34_1 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local itv = require('datetime').interval
+        local v = setmetatable({}, { __serialize = 'map' })
+        local sql = [[SELECT CAST(#v AS INTERVAL);]]
+        t.assert_equals(box.execute(sql, {{['#v'] = v}}).rows, {{itv.new(v)}})
+
+        v.something = 1
+        t.assert_equals(box.execute(sql, {{['#v'] = v}}).rows, {{itv.new(v)}})
+
+        v = {year = 1, month = 1, week = 1, day = 1, hour = 1, min = 1, sec = 1,
+             nsec = 1, adjust = 'none'}
+        t.assert_equals(box.execute(sql, {{['#v'] = v}}).rows, {{itv.new(v)}})
+    end)
+end
+
+--
+-- Make sure an error is thrown if the INTERVAL value cannot be constructed from
+-- the corresponding table.
+--
+g.test_datetime_34_2 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT CAST(#v AS INTERVAL);]]
+
+        -- "year" cannot be more than 11759221.
+        local v = {year = 11759222}
+        local _, err = box.execute(sql, {{['#v'] = v}})
+        local res = [[Type mismatch: can not convert ]]..
+                    [[map({"year": 11759222}) to interval]]
+        t.assert_equals(err.message, res)
+
+        -- "year" cannot be less than -11759221.
+        v = {year = -11759222}
+        _, err = box.execute(sql, {{['#v'] = v}})
+        res = [[Type mismatch: can not convert ]]..
+              [[map({"year": -11759222}) to interval]]
+        t.assert_equals(err.message, res)
+
+        -- "month" cannot be more than 141110652.
+        v = {month = 141110653}
+        _, err = box.execute(sql, {{['#v'] = v}})
+        res = [[Type mismatch: can not convert ]]..
+              [[map({"month": 141110653}) to interval]]
+        t.assert_equals(err.message, res)
+
+        -- "month" cannot be less than -141110652.
+        v = {month = -141110653}
+        _, err = box.execute(sql, {{['#v'] = v}})
+        res = [[Type mismatch: can not convert ]]..
+              [[map({"month": -141110653}) to interval]]
+        t.assert_equals(err.message, res)
+
+        -- "week" cannot be more than 613579352.
+        v = {week = 613579353}
+        _, err = box.execute(sql, {{['#v'] = v}})
+        res = [[Type mismatch: can not convert ]]..
+              [[map({"week": 613579353}) to interval]]
+        t.assert_equals(err.message, res)
+
+        -- "week" cannot be less than -613579352.
+        v = {week = -613579353}
+        _, err = box.execute(sql, {{['#v'] = v}})
+        res = [[Type mismatch: can not convert ]]..
+              [[map({"week": -613579353}) to interval]]
+        t.assert_equals(err.message, res)
+
+        -- "day" cannot be more than 4295055470.
+        v = {day = 4295055471}
+        _, err = box.execute(sql, {{['#v'] = v}})
+        res = [[Type mismatch: can not convert ]]..
+              [[map({"day": 4295055471}) to interval]]
+        t.assert_equals(err.message, res)
+
+        -- "day" cannot be less than -4295055470.
+        v = {day = -4295055471}
+        _, err = box.execute(sql, {{['#v'] = v}})
+        res = [[Type mismatch: can not convert ]]..
+              [[map({"day": -4295055471}) to interval]]
+        t.assert_equals(err.message, res)
+
+        -- "hour" cannot be more than 103081331286.
+        v = {hour = 103081331287}
+        _, err = box.execute(sql, {{['#v'] = v}})
+        res = [[Type mismatch: can not convert ]]..
+              [[map({"hour": 103081331287}) to interval]]
+        t.assert_equals(err.message, res)
+
+        -- "hour" cannot be less than 103081331286.
+        v = {hour = -103081331287}
+        _, err = box.execute(sql, {{['#v'] = v}})
+        res = [[Type mismatch: can not convert ]]..
+              [[map({"hour": -103081331287}) to interval]]
+        t.assert_equals(err.message, res)
+
+        -- "min" cannot be more than 6184879877160.
+        v = {min = 6184879877161}
+        _, err = box.execute(sql, {{['#v'] = v}})
+        res = [[Type mismatch: can not convert ]]..
+              [[map({"min": 6184879877161}) to interval]]
+        t.assert_equals(err.message, res)
+
+        -- "min" cannot be less than -6184879877160.
+        v = {min = -6184879877161}
+        _, err = box.execute(sql, {{['#v'] = v}})
+        res = [[Type mismatch: can not convert ]]..
+              [[map({"min": -6184879877161}) to interval]]
+        t.assert_equals(err.message, res)
+
+        -- "sec" cannot be more than 371092792629600.
+        v = {sec = 371092792629601}
+        _, err = box.execute(sql, {{['#v'] = v}})
+        res = [[Type mismatch: can not convert ]]..
+              [[map({"sec": 371092792629601}) to interval]]
+        t.assert_equals(err.message, res)
+
+        -- "sec" cannot be less than -371092792629600.
+        v = {sec = -371092792629601}
+        _, err = box.execute(sql, {{['#v'] = v}})
+        res = [[Type mismatch: can not convert ]]..
+              [[map({"sec": -371092792629601}) to interval]]
+        t.assert_equals(err.message, res)
+
+        -- "nsec" cannot be more than 2147483647.
+        v = {nsec = 2147483648}
+        _, err = box.execute(sql, {{['#v'] = v}})
+        res = [[Type mismatch: can not convert map({"nsec": 2147483648}) ]]..
+              [[to interval]]
+        t.assert_equals(err.message, res)
+
+        -- "nsec" cannot be less than -2147483647.
+        v = {nsec = -2147483648}
+        _, err = box.execute(sql, {{['#v'] = v}})
+        res = [[Type mismatch: can not convert map({"nsec": -2147483648}) ]]..
+              [[to interval]]
+        t.assert_equals(err.message, res)
+
+        -- "adjust" cannot be anything other than "none", "excess", "last".
+        v = {adjust = 1}
+        _, err = box.execute(sql, {{['#v'] = v}})
+        res = [[Type mismatch: can not convert map({"adjust": 1}) ]]..
+              [[to interval]]
+        t.assert_equals(err.message, res)
+
+        v = {adjust = 'asd'}
+        _, err = box.execute(sql, {{['#v'] = v}})
+        res = [[Type mismatch: can not convert map({"adjust": "asd"}) ]]..
+              [[to interval]]
+        t.assert_equals(err.message, res)
+    end)
+end
+
+--
+-- Make sure that any of the DECIMAL, INTEGER, and DOUBLE values can be used as
+-- values in the MAP converted to a INTERVAL.
+--
+g.test_datetime_34_3 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local itv = require('datetime').interval
+        local dt1 = itv.new({year = 1})
+        local sql = [[SELECT CAST({'year': 1.0} AS INTERVAL);]]
+        t.assert_equals(box.execute(sql).rows, {{dt1}})
+
+        sql = [[SELECT CAST({'year': 1.e0} AS INTERVAL);]]
+        t.assert_equals(box.execute(sql).rows, {{dt1}})
+
+        sql = [[SELECT CAST({'year': 1} AS INTERVAL);]]
+        t.assert_equals(box.execute(sql).rows, {{dt1}})
+    end)
+end

--- a/test/sql-luatest/datetime_test.lua
+++ b/test/sql-luatest/datetime_test.lua
@@ -931,11 +931,12 @@ end
 g.test_datetime_18_3 = function()
     g.server:exec(function()
         local t = require('luatest')
+        local dt = require('datetime')
+        local dt1 = dt.new({year = 2001, month = 1, day = 1, hour = 1})
         local sql = [[SELECT CAST('2001-01-01T01:00:00Z' AS DATETIME);]]
-        local res = [[Type mismatch: can not convert ]]..
-                    [[string('2001-01-01T01:00:00Z') to datetime]]
-        local _, err = box.execute(sql)
-        t.assert_equals(err.message, res)
+        local res = {{dt1}}
+        local rows = box.execute(sql).rows
+        t.assert_equals(rows, res)
     end)
 end
 
@@ -2360,5 +2361,29 @@ g.test_datetime_31_8 = function()
         local itv3 = itv.new({year = 3, month = 4, day = 5, hour = 6})
         local rows = box.execute([[SELECT $1 + $2;]], {itv2, itv1}).rows
         t.assert_equals(rows, {{itv3}})
+    end)
+end
+
+-- Make sure cast from STRING to DATETIME works as intended.
+g.test_datetime_32_1 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local dt = require('datetime')
+        local dt1 = dt.new({year = 2000, month = 2, day = 29, hour = 1})
+        local sql = [[SELECT CAST('2000-02-29T01:00:00Z' AS DATETIME);]]
+        local res = {{dt1}}
+        local rows = box.execute(sql).rows
+        t.assert_equals(rows, res)
+    end)
+end
+
+g.test_datetime_32_2 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT CAST('2001-02-29T01:00:00Z' AS DATETIME);]]
+        local _, err = box.execute(sql)
+        local res = [[Type mismatch: can not convert ]]..
+                    [[string('2001-02-29T01:00:00Z') to datetime]]
+        t.assert_equals(err.message, res)
     end)
 end


### PR DESCRIPTION
This patch contains one fix and 3 new casts for DATETIME and INTERVAL values.