### PR TITLE
ci: add Ubuntu Groovy (20.10) workflow

### DIFF
--- a/.github/workflows/ubuntu_20_10.yml
+++ b/.github/workflows/ubuntu_20_10.yml
@@ -1,0 +1,74 @@
+name: ubuntu_20_10
+
+on:
+  push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+    tags:
+      - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
+
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch (1.10,
+  # 2.8, etc.), and tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    github.ref == 'refs/heads/1.10' ||
+    startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+jobs:
+  ubuntu_20_10:
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+
+    runs-on: ubuntu-20.04-self-hosted
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build-type: [ '', 'gc64' ]
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: packaging
+        env:
+          RWS_AUTH: ${{ secrets.RWS_AUTH }}
+          OS: 'ubuntu'
+          DIST: 'groovy'
+          GC64: ${{ matrix.build-type == 'gc64' }}
+        uses: ./.github/actions/pack_and_deploy
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ubuntu-groovy
+          retention-days: 21
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/ubuntu_20_10_aarch64.yml
+++ b/.github/workflows/ubuntu_20_10_aarch64.yml
@@ -1,0 +1,68 @@
+name: ubuntu_20_10_aarch64
+
+on:
+  push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+    tags:
+      - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
+
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch (1.10,
+  # 2.8, etc.), and tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    github.ref == 'refs/heads/1.10' ||
+    startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+jobs:
+  ubuntu_20_10_aarch64:
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+
+    runs-on: graviton
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: packaging
+        env:
+          RWS_AUTH: ${{ secrets.RWS_AUTH }}
+          OS: 'ubuntu'
+          DIST: 'groovy'
+        uses: ./.github/actions/pack_and_deploy
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ubuntu-groovy
+          retention-days: 21
+          path: ${{ env.VARDIR }}/artifacts


### PR DESCRIPTION
Add the ubuntu_20_10.yml and ubuntu_20_10_aarch64.yml workflow files to
build Tarantool packages for x86_64 and aarch64 systems.

Actually, it was already added in https://github.com/tarantool/tarantool/commit/980d7676b97e130b68f945e363e7e8ee08274a33 (2.9.0-100-g980d7676b) in the
scope of https://github.com/tarantool/tarantool/issues/5824 and removed then in https://github.com/tarantool/tarantool/commit/19a161b5f675d628dad2f376fc05b86ea7a81bc1 (2.10.0-beta2-4-g19a161b5f)
and https://github.com/tarantool/tarantool/commit/dc19be406e36bbfa5761a64c2fb53f7c3dd346b1 (2.10.0-beta2-5-gdc19be406).

But, eventually, it was decided to add this workflow again to release
Tarantool packages for Ubuntu Groovy as well.

Follows-up https://github.com/tarantool/tarantool/issues/5824

NO_DOC=ci
NO_TEST=ci
NO_CHANGELOG=ci