### PR TITLE
sql: introduce operator []

### DIFF
--- a/changelogs/unreleased/gh-6251-operator-brackets.md
+++ b/changelogs/unreleased/gh-6251-operator-brackets.md
@@ -1,0 +1,3 @@
+## feature/sql
+
+* Operator [] for MAP and ARRAY values is now introduced (gh-6251).

--- a/extra/addopcodes.sh
+++ b/extra/addopcodes.sh
@@ -53,6 +53,7 @@ extras="            \
     LINEFEED        \
     SPACE           \
     ILLEGAL         \
+    GETITEM         \
 "
 
 IFS=" "

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -3326,6 +3326,65 @@ error:
 	return NULL;
 }
 
+/* Locate an element in a MAP or ARRAY using the given key.*/
+static int
+mp_getitem(const char **data, const struct Mem *key)
+{
+	if (mp_typeof(**data) != MP_ARRAY && mp_typeof(**data) != MP_MAP) {
+		*data = NULL;
+		return 0;
+	}
+	if (mp_typeof(**data) == MP_ARRAY) {
+		uint32_t size = mp_decode_array(data);
+		if (!mem_is_uint(key) || key->u.u == 0 || key->u.u > size) {
+			*data = NULL;
+			return 0;
+		}
+		for (uint32_t i = 0; i < key->u.u - 1; ++i)
+			mp_next(data);
+		return 0;
+	}
+	struct Mem mem;
+	mem_create(&mem);
+	uint32_t size = mp_decode_map(data);
+	for (uint32_t i = 0; i < size; ++i) {
+		uint32_t len;
+		if (mem_from_mp_ephemeral(&mem, *data, &len) != 0)
+			return -1;
+		assert(mem_is_trivial(&mem) && !mem_is_metatype(&mem));
+		*data += len;
+		if (mem_is_comparable(&mem) &&
+		    mem_cmp_scalar(&mem, key, NULL) == 0)
+			return 0;
+		mp_next(data);
+	}
+	*data = NULL;
+	return 0;
+}
+
+int
+mem_getitem(const struct Mem *mem, const struct Mem *keys, int count,
+	    struct Mem *res)
+{
+	assert(count > 0);
+	assert(mem_is_map(mem) || mem_is_array(mem));
+	const char *data = mem->z;
+	for (int i = 0; i < count && data != NULL; ++i) {
+		if (mp_getitem(&data, &keys[i]) != 0)
+			return -1;
+	}
+	if (data == NULL) {
+		mem_set_null(res);
+		return 0;
+	}
+	uint32_t len;
+	if (mem_from_mp(res, data, &len) != 0)
+		return -1;
+	res->flags |= MEM_Any;
+	assert((res->flags & (MEM_Number | MEM_Scalar)) == 0);
+	return 0;
+}
+
 /**
  * Allocate a sequence of initialized vdbe memory registers
  * on region.

--- a/src/box/sql/mem.h
+++ b/src/box/sql/mem.h
@@ -143,6 +143,18 @@ mem_is_num(const struct Mem *mem)
 }
 
 static inline bool
+mem_is_any(const struct Mem *mem)
+{
+	return (mem->flags & MEM_Any) != 0;
+}
+
+static inline bool
+mem_is_container(const struct Mem *mem)
+{
+	return (mem->type & (MEM_TYPE_MAP | MEM_TYPE_ARRAY)) != 0;
+}
+
+static inline bool
 mem_is_metatype(const struct Mem *mem)
 {
 	return (mem->flags & (MEM_Number | MEM_Scalar | MEM_Any)) != 0;
@@ -935,3 +947,8 @@ mem_encode_array(const struct Mem *mems, uint32_t count, uint32_t *size,
 char *
 mem_encode_map(const struct Mem *mems, uint32_t count, uint32_t *size,
 	       struct region *region);
+
+/** Return a value from ANY, MAP, or ARRAY MEM using the MEM array as keys. */
+int
+mem_getitem(const struct Mem *mem, const struct Mem *keys, int count,
+	    struct Mem *res);

--- a/test/sql-luatest/containers_test.lua
+++ b/test/sql-luatest/containers_test.lua
@@ -1,0 +1,134 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'containers'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+-- Make sure that it is possible to get elements from MAP и ARRAY.
+g.test_containers_success = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT [123, 234, 356, 467][2];]]
+        t.assert_equals(box.execute(sql).rows, {{234}})
+
+        sql = [[SELECT {'one' : 123, 3 : 'two', '123' : true}[3];]]
+        t.assert_equals(box.execute(sql).rows, {{'two'}})
+
+        sql = [[SELECT {'one' : [11, 22, 33], 3 : 'two'}['one'][2];]]
+        t.assert_equals(box.execute(sql).rows, {{22}})
+
+        sql = [[SELECT {'one' : 123, 3 : 'two', '123' : true}['three'];]]
+        t.assert_equals(box.execute(sql).rows, {{}})
+    end)
+end
+
+--
+-- Make sure that operator [] cannot get elements from values of types other
+-- than MAP and ARRAY. Also, selecting from NULL throws an error.
+--
+g.test_containers_error = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local _, err = box.execute([[SELECT 1[1];]])
+        local res = "Selecting is only possible from map and array values"
+        t.assert_equals(err.message, res)
+
+        _, err = box.execute([[SELECT -1[1];]])
+        t.assert_equals(err.message, res)
+
+        _, err = box.execute([[SELECT 1.1[1];]])
+        t.assert_equals(err.message, res)
+
+        _, err = box.execute([[SELECT 1.2e0[1];]])
+        t.assert_equals(err.message, res)
+
+        _, err = box.execute([[SELECT '1'[1];]])
+        t.assert_equals(err.message, res)
+
+        _, err = box.execute([[SELECT x'31'[1];]])
+        t.assert_equals(err.message, res)
+
+        _, err = box.execute([[SELECT true[1];]])
+        t.assert_equals(err.message, res)
+
+        _, err = box.execute([[SELECT uuid()[1];]])
+        t.assert_equals(err.message, res)
+
+        _, err = box.execute([[SELECT now()[1];]])
+        t.assert_equals(err.message, res)
+
+        _, err = box.execute([[SELECT (now() - now())[1];]])
+        t.assert_equals(err.message, res)
+
+        _, err = box.execute([[SELECT CAST(1 AS NUMBER)[1];]])
+        t.assert_equals(err.message, res)
+
+        _, err = box.execute([[SELECT CAST(1 AS SCALAR)[1];]])
+        t.assert_equals(err.message, res)
+
+        _, err = box.execute([[SELECT CAST(1 AS ANY)[1];]])
+        t.assert_equals(err.message, res)
+
+        _, err = box.execute([[SELECT CAST([1] AS ANY)[1];]])
+        t.assert_equals(err.message, res)
+
+        _, err = box.execute([[SELECT NULL[1];]])
+        t.assert_equals(err.message, res)
+
+        res = [[Failed to execute SQL statement: Selecting is not possible ]]..
+              [[from NULL]]
+        _, err = box.execute([[SELECT CAST(NULL AS ARRAY)[1];]])
+        t.assert_equals(err.message, res)
+    end)
+end
+
+--
+-- Make sure that the second and the following operators do not throw type
+-- error.
+--
+g.test_containers_followers = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT [1, 2, 3][1][2];]]
+        t.assert_equals(box.execute(sql).rows, {{}})
+
+        sql = [[SELECT [1, 2, 3][1][2][3][4][5][6][7];]]
+        t.assert_equals(box.execute(sql).rows, {{}})
+
+        sql = [[SELECT ([1, 2, 3][1])[2];]]
+        local _, err = box.execute(sql)
+        local res = "Selecting is only possible from map and array values"
+        t.assert_equals(err.message, res)
+    end)
+end
+
+-- Make sure that the received element is of type ANY.
+g.test_containers_elem_type = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT typeof([123, 234, 356, 467][2]);]]
+        t.assert_equals(box.execute(sql).rows, {{'any'}})
+
+        sql = [[SELECT [123, 234, 356, 467][2];]]
+        t.assert_equals(box.execute(sql).metadata[1].type, 'any')
+
+        sql = [[SELECT typeof({'one' : 123, 3 : 'two', '123' : true}[3]);]]
+        t.assert_equals(box.execute(sql).rows, {{'any'}})
+
+        sql = [[SELECT {'one' : 123, 3 : 'two', '123' : true}[3];]]
+        t.assert_equals(box.execute(sql).metadata[1].type, 'any')
+
+        sql = [[SELECT typeof({'one' : [11, 22, 33], 3 : 'two'}['one']);]]
+        t.assert_equals(box.execute(sql).rows, {{'any'}})
+
+        sql = [[SELECT {'one' : [11, 22, 33], 3 : 'two'}['one'];]]
+        t.assert_equals(box.execute(sql).metadata[1].type, 'any')
+    end)
+end


### PR DESCRIPTION
This patch introduces operator [] that allows to get elements from MAP
and ARRAY values.

Closes #4762
Closes #4763
Part of #6251

@TarantoolBot document
Title: Operator [] in SQL

Operator `[]` allows to get an element of MAP and ARRAY values.
Examples:
```
tarantool> box.execute([[SELECT [1, 2, 3, 4, 5][3];]])
---
- metadata:
  - name: COLUMN_1
    type: any
  rows:
  - [3]
...

tarantool> box.execute([[SELECT {'a' : 123, 7: 'asd'}['a'];]])
---
- metadata:
  - name: COLUMN_1
    type: any
  rows:
  - [123]
...
```

The returned values is of type ANY.

If the operator is applied to a value that is not a MAP or ARRAY or is
NULL, an error is thrown.

Example:
```
tarantool> box.execute([[SELECT 1[1];]])
---
- null
- Selecting is only possible from map and array values
...
```

However, if there are two or more operators next to each other, the
second or following operators do not throw an error, but instead
return NULL.

Example:
```
tarantool> box.execute([[select [1][1][2][3][4];]])
---
- metadata:
  - name: COLUMN_1
    type: any
  rows:
  - [null]
...
```