### PR TITLE
Strict fencing

### DIFF
--- a/changelogs/unreleased/strict_fencing.md
+++ b/changelogs/unreleased/strict_fencing.md
@@ -1,0 +1,7 @@
+## feature/raft
+
+* Introduce strict fencing, which tries its best to allow at most one
+  leader in cluster in any moment in time. This is achived by setting
+  connection death timeout on current leader to half the time compared to
+  followers (assuming replication_timeout is the same on every replica)
+  (gh-7110).

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -283,7 +283,7 @@ void box_set_vinyl_cache(void);
 void box_set_vinyl_timeout(void);
 int box_set_election_mode(void);
 int box_set_election_timeout(void);
-int box_set_election_fencing_enabled(void);
+int box_set_election_fencing_mode(void);
 void box_set_replication_timeout(void);
 void box_set_replication_connect_timeout(void);
 void box_set_replication_connect_quorum(void);

--- a/src/box/lua/cfg.cc
+++ b/src/box/lua/cfg.cc
@@ -299,9 +299,9 @@ lbox_cfg_set_election_timeout(struct lua_State *L)
 }
 
 static int
-lbox_cfg_set_election_fencing_enabled(struct lua_State *L)
+lbox_cfg_set_election_fencing_mode(struct lua_State *L)
 {
-	if (box_set_election_fencing_enabled() != 0)
+	if (box_set_election_fencing_mode() != 0)
 		luaT_error(L);
 	return 0;
 }
@@ -447,7 +447,7 @@ box_lua_cfg_init(struct lua_State *L)
 		{"cfg_set_vinyl_timeout", lbox_cfg_set_vinyl_timeout},
 		{"cfg_set_election_mode", lbox_cfg_set_election_mode},
 		{"cfg_set_election_timeout", lbox_cfg_set_election_timeout},
-		{"cfg_set_election_fencing_enabled", lbox_cfg_set_election_fencing_enabled},
+		{"cfg_set_election_fencing_mode", lbox_cfg_set_election_fencing_mode},
 		{"cfg_set_replication_timeout", lbox_cfg_set_replication_timeout},
 		{"cfg_set_replication_connect_quorum", lbox_cfg_set_replication_connect_quorum},
 		{"cfg_set_replication_connect_timeout", lbox_cfg_set_replication_connect_timeout},

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -112,7 +112,7 @@ local default_cfg = {
     worker_pool_threads = 4,
     election_mode       = 'off',
     election_timeout    = 5,
-    election_fencing_enabled = true,
+    election_fencing_mode = 'soft',
     replication_timeout = 1,
     replication_sync_lag = 10,
     replication_sync_timeout = 300,
@@ -240,7 +240,7 @@ local template_cfg = {
     worker_pool_threads = 'number',
     election_mode       = 'string',
     election_timeout    = 'number',
-    election_fencing_enabled = 'boolean',
+    election_fencing_mode = 'string',
     replication_timeout = 'number',
     replication_sync_lag = 'number',
     replication_sync_timeout = 'number',
@@ -363,7 +363,7 @@ local dynamic_cfg = {
     force_recovery          = function() end,
     election_mode           = private.cfg_set_election_mode,
     election_timeout        = private.cfg_set_election_timeout,
-    election_fencing_enabled = private.cfg_set_election_fencing_enabled,
+    election_fencing_mode = private.cfg_set_election_fencing_mode,
     replication_timeout     = private.cfg_set_replication_timeout,
     replication_connect_timeout = private.cfg_set_replication_connect_timeout,
     replication_connect_quorum = private.cfg_set_replication_connect_quorum,
@@ -441,7 +441,7 @@ local dynamic_cfg_order = {
     wal_cleanup_delay       = 260,
     election_mode           = 300,
     election_timeout        = 320,
-    election_fencing_enabled = 320,
+    election_fencing_mode   = 320,
 }
 
 local function sort_cfg_cb(l, r)
@@ -461,7 +461,7 @@ local dynamic_cfg_skip_at_load = {
     too_long_threshold      = true,
     election_mode           = true,
     election_timeout        = true,
-    election_fencing_enabled = true,
+    election_fencing_mode   = true,
     replication             = true,
     replication_timeout     = true,
     replication_connect_timeout = true,
@@ -510,6 +510,12 @@ local translate_cfg = {
     replication_source = {'replication'},
     rows_per_wal = {'wal_max_size', function(old, new)
         return old, new
+    end},
+    election_fencing_enabled = {'election_fencing_mode', function(old, new)
+        if new ~= nil then return nil, new
+        elseif old == false then return nil, 'off'
+        elseif old == true then return nil, 'soft'
+        end
     end},
 }
 

--- a/src/box/raft.h
+++ b/src/box/raft.h
@@ -50,6 +50,26 @@ enum election_mode {
 	ELECTION_MODE_CANDIDATE = 3,
 };
 
+/**
+ * Election fencing mode.
+ */
+enum election_fencing_mode {
+	ELECTION_FENCING_MODE_INVALID = -1,
+	/** Leader won't resign leadership when quorum is lost. */
+	ELECTION_FENCING_MODE_OFF = 0,
+	/**
+	 * Leader will resign leadership when quorum is lost.
+	 * Quite possible it will happen after new leader is already elected.
+	 */
+	ELECTION_FENCING_MODE_SOFT = 1,
+	/**
+	 * Leader will resign leadership when quorum is lost, it will resign
+	 * before automatic elections should start in any part of cluster
+	 * (assuming replication_timeout is same on every replica).
+	 */
+	ELECTION_FENCING_MODE_STRICT = 2,
+};
+
 struct raft_request;
 
 /**
@@ -60,6 +80,11 @@ struct raft_request;
  * candidate for some period of time when user calls `box.ctl.promote()`
  */
 extern enum election_mode box_election_mode;
+
+/**
+ * Current leader fencing mode.
+ */
+extern enum election_fencing_mode box_election_fencing_mode;
 
 /** Raft state of this instance. */
 static inline struct raft *
@@ -115,12 +140,9 @@ box_raft_wait_term_outcome(void);
 int
 box_raft_wait_term_persisted(void);
 
-/**
- * Enable/disable fencing. If enabled: instance will resign its leader role,
- * when it looses quorum.
- */
+/** Set the node's election_fencing_mode to @a mode. */
 void
-box_raft_set_election_fencing_enabled(bool enabled);
+box_raft_set_election_fencing_mode(enum election_fencing_mode mode);
 
 /**
  * Pause fencing. Instance will not resign its leader role when it looses

--- a/src/box/raft.h
+++ b/src/box/raft.h
@@ -68,10 +68,9 @@ box_raft(void)
 	extern struct raft box_raft_global;
 	/**
 	 * Ensure the raft node can be used. I.e. that it is properly
-	 * initialized. Entirely for debug purposes.
+	 * initialized.
 	 */
-	assert(box_raft_global.state != 0);
-	return &box_raft_global;
+	return box_raft_global.state != 0 ? &box_raft_global : NULL;
 }
 
 /**

--- a/src/box/replication.cc
+++ b/src/box/replication.cc
@@ -80,6 +80,16 @@ rb_gen(MAYBE_UNUSED static, replica_hash_, replica_hash_t,
 	     item != NULL && ((next = replica_hash_next(hash, item)) || 1); \
 	     item = next)
 
+double
+replication_disconnect_timeout(void)
+{
+	struct raft *raft = box_raft();
+	if (raft != NULL && raft->state == RAFT_STATE_LEADER &&
+	    box_election_fencing_mode == ELECTION_FENCING_MODE_STRICT)
+		return replication_timeout * 2;
+	return replication_timeout * 4;
+}
+
 /**
  * Return the number of replicas that have to be synchronized
  * in order to form a quorum in the replica set.

--- a/src/box/replication.h
+++ b/src/box/replication.h
@@ -183,12 +183,11 @@ replication_reconnect_interval(void)
 /**
  * Disconnect a replica if no heartbeat message has been
  * received from it within the given period.
+ * This timeout might be different for Raft leader. Used in strict fencing,
+ * to provide best effort to achieve leader uniqueness.
  */
-static inline double
-replication_disconnect_timeout(void)
-{
-	return replication_timeout * 4;
-}
+double
+replication_disconnect_timeout(void);
 
 void
 replication_init(int num_threads);

--- a/test/app-tap/init_script.result
+++ b/test/app-tap/init_script.result
@@ -11,7 +11,7 @@ checkpoint_count:2
 checkpoint_interval:3600
 checkpoint_wal_threshold:1e+18
 coredump:false
-election_fencing_enabled:true
+election_fencing_mode:soft
 election_mode:off
 election_timeout:5
 feedback_crashinfo:true

--- a/test/box/admin.result
+++ b/test/box/admin.result
@@ -43,8 +43,8 @@ cfg_filter(box.cfg)
     - 1000000000000000000
   - - coredump
     - false
-  - - election_fencing_enabled
-    - true
+  - - election_fencing_mode
+    - soft
   - - election_mode
     - off
   - - election_timeout

--- a/test/box/cfg.result
+++ b/test/box/cfg.result
@@ -31,8 +31,8 @@ cfg_filter(box.cfg)
  |     - 1000000000000000000
  |   - - coredump
  |     - false
- |   - - election_fencing_enabled
- |     - true
+ |   - - election_fencing_mode
+ |     - soft
  |   - - election_mode
  |     - off
  |   - - election_timeout
@@ -190,8 +190,8 @@ cfg_filter(box.cfg)
  |     - 1000000000000000000
  |   - - coredump
  |     - false
- |   - - election_fencing_enabled
- |     - true
+ |   - - election_fencing_mode
+ |     - soft
  |   - - election_mode
  |     - off
  |   - - election_timeout

--- a/test/luatest_helpers/proxy/connection.lua
+++ b/test/luatest_helpers/proxy/connection.lua
@@ -1,0 +1,145 @@
+local checks = require('checks')
+local fiber = require('fiber')
+local socket = require('socket')
+
+local TIMEOUT = 0.001
+
+local Connection = {
+    constructor_checks = {
+        client_socket = '?table',
+        server_socket_path = 'string',
+        process_client = '?table',
+        process_server = '?table',
+    },
+}
+
+function Connection:inherit(object)
+    setmetatable(object, self)
+    self.__index = self
+    return object
+end
+
+function Connection:new(object)
+    checks('table', self.constructor_checks)
+    self:inherit(object)
+    object:initialize()
+    return object
+end
+
+function Connection:initialize()
+    self.running = false
+    self.client_connected = true
+    self.server_connected = false
+    self.client_fiber = nil
+    self.server_fiber = nil
+
+    if self.process_client == nil then
+        self.process_client = {
+            pre = nil,
+            func = self.forward_to_server,
+            post = self.close_client_socket,
+        }
+    end
+
+    if self.process_server == nil then
+        self.process_server = {
+            pre = nil,
+            func = self.forward_to_client,
+            post = self.close_server_socket,
+        }
+    end
+
+    self:connect_server_socket()
+end
+
+function Connection:connect_server_socket()
+    self.server_socket = socket('PF_UNIX', 'SOCK_STREAM', 0)
+    if self.server_socket:sysconnect('unix/',self.server_socket_path) == false
+    then
+        self.server_socket:close()
+        self.server_socket = nil
+        return
+    end
+    self.server_socket:nonblock(true)
+    self.server_connected = true
+
+    self.server_fiber = self:process_socket(self.server_socket,
+                                            self.process_server)
+end
+
+function Connection:process_socket(sock, process)
+    local f = fiber.new(function()
+        if process.pre ~= nil then process.pre(self) end
+
+        while sock:peer() do
+            if not self.running then
+                fiber.sleep(TIMEOUT)
+            elseif sock:readable(TIMEOUT) then
+                local request = sock:recv()
+                if request == nil or #request == 0 then break end
+                if process.func ~= nil then process.func(self, request) end
+            end
+        end
+
+        if process.post ~= nil then process.post(self) end
+    end)
+    f:set_joinable(true)
+    f:name('ProxyConnectionIO')
+    return f
+end
+
+function Connection:start()
+    self.running = true
+    if self.client_fiber == nil or self.client_fiber:status() == 'dead' then
+        self.client_fiber = self:process_socket(self.client_socket,
+                                                self.process_client)
+    end
+end
+
+function Connection:pause()
+    self.running = false
+end
+
+function Connection:resume()
+    self.running = true
+end
+
+function Connection:stop()
+    self:close_client_socket()
+    self:close_server_socket()
+end
+
+function Connection:forward_to_server(data)
+    if not self.server_connected then
+        self:connect_server_socket()
+    end
+    if self.server_connected and self.server_socket:writable() then
+        self.server_socket:write(data)
+    end
+end
+
+function Connection:forward_to_client(data)
+    if self.client_connected and self.client_socket:writable() then
+        self.client_socket:write(data)
+    end
+end
+
+function Connection:close_server_socket()
+    if self.server_connected then
+        self.server_socket:shutdown(socket.SHUT_RW)
+        self.server_socket:close()
+        self.server_connected = false
+        self.server_fiber:join()
+    end
+end
+
+function Connection:close_client_socket()
+    if self.client_connected then
+        self.client_socket:shutdown(socket.SHUT_RW)
+        self.client_socket:close()
+        self.client_connected = false
+        self.client_fiber:join()
+    end
+end
+
+return Connection

--- a/test/luatest_helpers/proxy/proxy.lua
+++ b/test/luatest_helpers/proxy/proxy.lua
@@ -1,0 +1,117 @@
+local socket = require('socket')
+local fiber = require('fiber')
+local checks = require('checks')
+local Connection = require('test.luatest_helpers.proxy.connection')
+local log = require('log')
+
+local TIMEOUT = 0.001
+local BACKLOG = 512
+
+local Proxy = {
+    constructor_checks = {
+        client_socket_path = 'string',
+        server_socket_path = 'string',
+        process_client = '?table',
+        process_server = '?table',
+    },
+}
+
+function Proxy:inherit(object)
+    setmetatable(object, self)
+    self.__index = self
+    return object
+end
+
+function Proxy:new(object)
+    checks('table', self.constructor_checks)
+    self:inherit(object)
+    object:initialize()
+    return object
+end
+
+function Proxy:initialize()
+    self.connections = {}
+    self.accept_new_connections = true
+    self.running = false
+
+    self.client_socket = socket('PF_UNIX', 'SOCK_STREAM', 0)
+end
+
+function Proxy:stop()
+    self.running = false
+    self.worker:join()
+    for _, c in pairs(self.connections) do
+        c:stop()
+    end
+end
+
+function Proxy:pause()
+    self.accept_new_connections = false
+    for _, c in pairs(self.connections) do
+        c:pause()
+    end
+end
+
+function Proxy:resume()
+    for _, c in pairs(self.connections) do
+        c:resume()
+    end
+    self.accept_new_connections = true
+end
+
+function Proxy:start(opts)
+    checks('table', {force = '?boolean'})
+    if opts ~= nil and opts.force then
+        os.remove(self.client_socket_path)
+    end
+
+    if not self.client_socket:bind('unix/', self.client_socket_path) then
+        log.error("Failed to bind client socket: %s", self.client_socket:error())
+        return false
+    end
+
+    self.client_socket:nonblock(true)
+    if not self.client_socket:listen(BACKLOG) then
+        log.error("Failed to listen on client socket: %s",
+            self.client_socket:error())
+        return false
+    end
+
+    self.running = true
+    self.worker = fiber.new(function()
+        while self.running do
+            if not self.accept_new_connections then
+                fiber.sleep(TIMEOUT)
+                goto continue
+            end
+
+            if not self.client_socket:readable(TIMEOUT) then
+                goto continue
+            end
+
+            local client = self.client_socket:accept()
+            if client == nil then goto continue end
+            client:nonblock(true)
+
+            local conn = Connection:new({
+                client_socket = client,
+                server_socket_path = self.server_socket_path,
+                process_client = self.process_client,
+                process_server = self.process_server,
+            })
+            table.insert(self.connections, conn)
+            conn:start()
+            ::continue::
+        end
+
+        self.client_socket:shutdown(socket.SHUT_RW)
+        self.client_socket:close()
+        os.remove(self.client_socket_path)
+    end)
+    self.worker:set_joinable(true)
+    self.worker:name('ProxyWorker')
+
+    return true
+end
+
+return Proxy

--- a/test/luatest_helpers/server.lua
+++ b/test/luatest_helpers/server.lua
@@ -118,6 +118,12 @@ function Server:wait_for_readiness()
     end)
 end
 
+function Server:wait_election_state(state)
+    return wait_cond('election state', self, self.exec, self, function(state)
+        return box.info.election.state == state
+    end, {state})
+end
+
 function Server:wait_election_leader()
     -- Include read-only property too because if an instance is a leader, it
     -- does not mean it finished the synchro queue ownership transition. It is

--- a/test/replication/election_replica.lua
+++ b/test/replication/election_replica.lua
@@ -6,7 +6,7 @@ local SYNCHRO_QUORUM = arg[1] and tonumber(arg[1]) or 3
 local ELECTION_TIMEOUT = arg[2] and tonumber(arg[2]) or 0.1
 local ELECTION_MODE = arg[3] or 'candidate'
 local CONNECT_QUORUM = arg[4] and tonumber(arg[4]) or 3
-local ELECTION_FENCING_ENABLED = arg[5] and true or false
+local ELECTION_FENCING_MODE = arg[5] or 'off'
 
 local function instance_uri(instance_id)
     return SOCKET_DIR..'/election_replica'..instance_id..'.sock';
@@ -25,7 +25,7 @@ box.cfg({
     replication_connect_quorum = CONNECT_QUORUM,
     election_mode = ELECTION_MODE,
     election_timeout = ELECTION_TIMEOUT,
-    election_fencing_enabled = ELECTION_FENCING_ENABLED,
+    election_fencing_mode = ELECTION_FENCING_MODE,
     replication_synchro_quorum = SYNCHRO_QUORUM,
     replication_synchro_timeout = 0.1,
     -- To reveal more election logs.

--- a/test/replication/gh-3055-election-promote.result
+++ b/test/replication/gh-3055-election-promote.result
@@ -10,7 +10,7 @@ SERVERS = {'election_replica1', 'election_replica2', 'election_replica3'}
  | ---
  | ...
 -- Start in candidate state in order for bootstrap to work.
-test_run:create_cluster(SERVERS, 'replication', {args='2 0.1 candidate'})
+test_run:create_cluster(SERVERS, 'replication', {args='2 0.1 candidate 3 off'})
  | ---
  | ...
 test_run:wait_fullmesh(SERVERS)

--- a/test/replication/gh-3055-election-promote.test.lua
+++ b/test/replication/gh-3055-election-promote.test.lua
@@ -5,7 +5,7 @@ test_run = require('test_run').new()
 -- in order to promote it to leader.
 SERVERS = {'election_replica1', 'election_replica2', 'election_replica3'}
 -- Start in candidate state in order for bootstrap to work.
-test_run:create_cluster(SERVERS, 'replication', {args='2 0.1 candidate'})
+test_run:create_cluster(SERVERS, 'replication', {args='2 0.1 candidate 3 off'})
 test_run:wait_fullmesh(SERVERS)
 
 cfg_set_voter =\

--- a/test/replication/gh-5445-leader-inconsistency.result
+++ b/test/replication/gh-5445-leader-inconsistency.result
@@ -51,7 +51,7 @@ test_run:cmd('setopt delimiter ""');
 SERVERS = {'election_replica1', 'election_replica2' ,'election_replica3'}
  | ---
  | ...
-test_run:create_cluster(SERVERS, "replication", {args='2 0.4'})
+test_run:create_cluster(SERVERS, "replication", {args='2 0.4 candidate 3 off'})
  | ---
  | ...
 test_run:wait_fullmesh(SERVERS)
@@ -195,7 +195,7 @@ is_possible_leader[other_nr] = false
 -- Otherwise it would stall for replication_sync_timeout. This is due to the
 -- nature of the test and may be ignored (we restart the instance to simulate
 -- a situation when some rows from the old leader were not received).
-test_run:cmd('start server '..next_leader..' with args="1 0.4 candidate 1"')
+test_run:cmd('start server '..next_leader..' with args="1 0.4 candidate 1 off"')
  | ---
  | - true
  | ...
@@ -203,7 +203,7 @@ assert(get_leader(is_possible_leader) == next_leader_nr)
  | ---
  | - true
  | ...
-test_run:cmd('start server '..other..' with args="1 0.4 voter 2"')
+test_run:cmd('start server '..other..' with args="1 0.4 voter 2 off"')
  | ---
  | - true
  | ...
@@ -240,7 +240,7 @@ test_run:switch('default')
  | ...
 -- Old leader returns and old unconfirmed rows from it must be ignored.
 -- Note, it wins the elections fairly.
-test_run:cmd('start server '..leader..' with args="3 0.4 voter"')
+test_run:cmd('start server '..leader..' with args="3 0.4 voter 3 off"')
  | ---
  | - true
  | ...

--- a/test/replication/gh-5445-leader-inconsistency.test.lua
+++ b/test/replication/gh-5445-leader-inconsistency.test.lua
@@ -34,7 +34,7 @@ test_run:cmd('setopt delimiter ""');
 -- to cluster.
 --
 SERVERS = {'election_replica1', 'election_replica2' ,'election_replica3'}
-test_run:create_cluster(SERVERS, "replication", {args='2 0.4'})
+test_run:create_cluster(SERVERS, "replication", {args='2 0.4 candidate 3 off'})
 test_run:wait_fullmesh(SERVERS)
 
 -- Any of the three instances may bootstrap the cluster and become leader.
@@ -94,9 +94,9 @@ is_possible_leader[other_nr] = false
 -- Otherwise it would stall for replication_sync_timeout. This is due to the
 -- nature of the test and may be ignored (we restart the instance to simulate
 -- a situation when some rows from the old leader were not received).
-test_run:cmd('start server '..next_leader..' with args="1 0.4 candidate 1"')
+test_run:cmd('start server '..next_leader..' with args="1 0.4 candidate 1 off"')
 assert(get_leader(is_possible_leader) == next_leader_nr)
-test_run:cmd('start server '..other..' with args="1 0.4 voter 2"')
+test_run:cmd('start server '..other..' with args="1 0.4 voter 2 off"')
 is_possible_leader[other_nr] = true
 test_run:switch(other)
 -- New leader didn't know about the unconfirmed rows but still rolled them back.
@@ -110,7 +110,7 @@ box.space.test:select{} -- 1
 test_run:switch('default')
 -- Old leader returns and old unconfirmed rows from it must be ignored.
 -- Note, it wins the elections fairly.
-test_run:cmd('start server '..leader..' with args="3 0.4 voter"')
+test_run:cmd('start server '..leader..' with args="3 0.4 voter 3 off"')
 test_run:wait_lsn(leader, next_leader)
 test_run:switch(leader)
 test_run:wait_cond(function() return box.space.test:get{2} == nil end)


### PR DESCRIPTION
Current leader fencing implementation didn't really guarantee that old
leader would resing it's leadership before new leader could be elected.
That made it possible for several "leaders" coexist in cluster for some
time.

I changed replication_disconnect_timeout so that it is twice
as short for current raft leader (2*replication_timeout) if strict
fencing is enabled. Assuming that replication_timeout is the same for every
replica in replicaset this guarantees that leader will resign it's
leadership before anyone could start elections.

Old fencing behaviour can be enabled by setting fencing to soft mode.
This is useful when connection death timeouts shouldn't be affected
(e.g. different replication_timeouts are set to prioritize some replicas
as leader over the others).

Closes #7110