### PR TITLE
applier: make SSLError retryable

### DIFF
--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -60,6 +60,7 @@
 #include "small/static.h"
 #include "tt_static.h"
 #include "memory.h"
+#include "ssl_error.h"
 
 STRS(applier_state, applier_STATE);
 
@@ -119,6 +120,7 @@ applier_log_error(struct applier *applier, struct error *e)
 	case ER_ACCESS_DENIED:
 	case ER_NO_SUCH_USER:
 	case ER_SYSTEM:
+	case ER_SSL:
 	case ER_UNKNOWN_REPLICA:
 	case ER_PASSWORD_MISMATCH:
 	case ER_XLOG_GAP:
@@ -2184,7 +2186,8 @@ applier_f(va_list ap)
 				applier_log_error(applier, e);
 				applier_disconnect(applier, APPLIER_LOADING);
 				goto reconnect;
-			} else if (e->errcode() == ER_SYSTEM) {
+			} else if (e->errcode() == ER_SYSTEM ||
+				   e->errcode() == ER_SSL) {
 				/* System error from master instance. */
 				applier_log_error(applier, e);
 				applier_disconnect(applier, APPLIER_DISCONNECTED);
@@ -2234,6 +2237,10 @@ applier_f(va_list ap)
 			applier_disconnect(applier, APPLIER_DISCONNECTED);
 			goto reconnect;
 		} catch (SystemError *e) {
+			applier_log_error(applier, e);
+			applier_disconnect(applier, APPLIER_DISCONNECTED);
+			goto reconnect;
+		} catch (SSLError *e) {
 			applier_log_error(applier, e);
 			applier_disconnect(applier, APPLIER_DISCONNECTED);
 			goto reconnect;

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -295,6 +295,7 @@ struct errcode_record {
 	/*240 */_(ER_COMPLEX_FOREIGN_KEY_FAILED, "Foreign key constraint '%s' failed: %s") \
 	/*241 */_(ER_WRONG_SPACE_UPGRADE_OPTIONS, "Wrong space upgrade options: %s") \
 	/*242 */_(ER_NO_ELECTION_QUORUM,	"Not enough peers connected to start elections: %d out of minimal required %d")\
+	/*243 */_(ER_SSL,			"%s") \
 
 /*
  * !IMPORTANT! Please follow instructions at start of the file

--- a/src/box/error.cc
+++ b/src/box/error.cc
@@ -36,6 +36,7 @@
 #include "trigger.h"
 #include "vclock/vclock.h"
 #include "schema.h"
+#include "ssl_error.h"
 
 /* {{{ public API */
 
@@ -213,6 +214,8 @@ ClientError::get_errcode(const struct error *e)
 		return ER_MEMORY_ISSUE;
 	if (type_cast(SystemError, e))
 		return ER_SYSTEM;
+	if (type_cast(SSLError, e))
+		return ER_SSL;
 	if (type_cast(CollationError, e))
 		return ER_CANT_CREATE_COLLATION;
 	if (type_cast(XlogGapError, e))

--- a/src/lib/core/ssl_error.cc
+++ b/src/lib/core/ssl_error.cc
@@ -5,13 +5,28 @@
  */
 #include "ssl_error.h"
 
+#include <stdarg.h>
 #include <stddef.h>
 
+#include "diag.h"
 #include "reflection.h"
 #include "trivia/config.h"
+#include "trivia/util.h"
 
 #if defined(ENABLE_SSL)
 # error unimplemented
 #endif
 
 const struct type_info type_SSLError = make_type("SSLError", NULL);
+
+struct error *
+BuildSSLError(const char *file, unsigned line, const char *format, ...)
+{
+	void *ptr = xmalloc(sizeof(SSLError));
+	SSLError *err = new(ptr) SSLError(file, line);
+	va_list ap;
+	va_start(ap, format);
+	error_vformat_msg(err, format, ap);
+	va_end(ap);
+	return err;
+}

--- a/src/lib/core/ssl_error.h
+++ b/src/lib/core/ssl_error.h
@@ -22,12 +22,18 @@ extern "C" {
 
 extern const struct type_info type_SSLError;
 
+/** Builds an instance of SSLError with the given message. */
+struct error *
+BuildSSLError(const char *file, unsigned line, const char *format, ...);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 
 class SSLError: public Exception {
 public:
-	SSLError(): Exception(&type_SSLError, NULL, 0) {}
+	SSLError(const char *file, unsigned line)
+		: Exception(&type_SSLError, file, line) {}
+	SSLError() : SSLError(NULL, 0) {}
 	virtual void raise() { throw this; }
 };
 

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -461,6 +461,7 @@ t;
  |   240: box.error.COMPLEX_FOREIGN_KEY_FAILED
  |   241: box.error.WRONG_SPACE_UPGRADE_OPTIONS
  |   242: box.error.NO_ELECTION_QUORUM
+ |   243: box.error.SSL
  | ...
 
 test_run:cmd("setopt delimiter ''");

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -64,7 +64,7 @@ target_link_libraries(xmalloc.test unit)
 add_executable(datetime.test datetime.c)
 target_link_libraries(datetime.test tzcode core cdt unit)
 add_executable(error.test error.c core_test_utils.c)
-target_link_libraries(error.test unit core)
+target_link_libraries(error.test unit core box_error)
 add_executable(interval.test interval.c core_test_utils.c)
 target_link_libraries(interval.test core unit)
 

--- a/test/unit/error.result
+++ b/test/unit/error.result
@@ -1,5 +1,5 @@
 	*** main ***
-1..9
+1..10
 	*** test_payload_field_str ***
     1..15
     ok 1 - no fields in the beginning
@@ -158,4 +158,17 @@ ok 8 - subtests
     ok 7 - key
 ok 9 - subtests
 	*** test_payload_move: done ***
+	*** test_error_code ***
+    1..9
+    ok 1 - ClientError
+    ok 2 - OutOfMemory
+    ok 3 - SystemError
+    ok 4 - SocketError
+    ok 5 - TimedOut
+    ok 6 - SSLError
+    ok 7 - CollationError
+    ok 8 - XlogGapError
+    ok 9 - FiberIsCancelled
+ok 10 - subtests
+	*** test_error_code: done ***
 	*** main: done ***


### PR DESCRIPTION
A certificate used for an encrypted replication connection may expire, in which case the user will be forced to reconfigure the connection both on the master and on the replica to use the new certificate. If the replica completes the reconfiguration first, it will fail to connect to the master and never retry, even though the master should complete its reconfiguration in a moment.

To avoid that, we should make the applier retry to connect on `SSLError`, just like it does on `SocketError`.

Needed for https://github.com/tarantool/tarantool-ee/issues/107
Needed for 2.10

A test is added in the EE PR: https://github.com/tarantool/tarantool-ee/pull/125