### PR TITLE
sql: fix wrong ephemeral space format

### DIFF
--- a/changelogs/unreleased/gh-7043-ephem-space-format.md
+++ b/changelogs/unreleased/gh-7043-ephem-space-format.md
@@ -1,0 +1,3 @@
+## bugfix/sql
+
+* Fixed creation of ephemeral space format in ORDER BY (gh-7043).

--- a/test/sql-luatest/gh_7043_temp_space_format_test.lua
+++ b/test/sql-luatest/gh_7043_temp_space_format_test.lua
@@ -1,0 +1,23 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'test_space_format'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_test_space_format = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        box.execute([[CREATE TABLE t(i INT PRIMARY KEY, a STRING, b DOUBLE);]])
+        box.execute([[INSERT INTO t VALUES(1, '1', 1.0);]])
+        local sql = [[SELECT a, b, i FROM t ORDER BY a, b LIMIT 1;]]
+        t.assert_equals(box.execute(sql).rows, {{'1', 1, 1}})
+        box.execute([[DROP TABLE "t";]])
+    end)
+end


### PR DESCRIPTION
This patch fixes format building when an ephemeral space was used in
ORDER BY and ORDER BY uses at least two variables from the list of
selected columns.

Closes #7042

NO_DOC=Bugfix