### PR TITLE
luajit: bump submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -489,12 +489,58 @@ set(ICU_FIND_REQUIRED ON)
 find_package(ICU)
 
 #
+# libunwind
+#
+
+if(ENABLE_BACKTRACE)
+    if(NOT HAVE_FORCE_ALIGN_ARG_POINTER_ATTR)
+        message(SEND_ERROR "backtrace feature requires \
+                            `force_align_arg_pointer` function attribute \
+                            support from C/C++ compiler")
+    endif()
+
+    if(NOT HAVE_CFI_ASM)
+        message(SEND_ERROR "backtrace feature requires CFI assembly support \
+                            from C/C++ compiler")
+    endif()
+
+    if(ENABLE_BUNDLED_LIBUNWIND)
+        if(APPLE)
+            message(SEND_ERROR "libunwind does not support macOS")
+        endif()
+        if(NOT HAVE_STDATOMIC_H)
+            message(SEND_ERROR "building bundled libunwind requires stdatomic.h \
+                                support from C compiler")
+        endif()
+
+        include(BuildLibUnwind)
+        libunwind_build()
+        add_dependencies(build_bundled_libs
+                         bundled-libunwind
+                         bundled-libunwind-platform)
+    else()
+        find_package(LibUnwind MODULE REQUIRED)
+    endif()
+    if(NOT APPLE AND NOT ENABLE_BUNDLED_LIBUNWIND AND
+        LIBUNWIND_VERSION VERSION_LESS "1.3" AND
+        ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
+        message(SEND_ERROR "versions of libunwind earlier than 1.3.0 are \
+                            broken on AARCH64 architecture")
+    endif()
+endif()
+
+#
 # LuaJIT
 #
 # Patched.
 #
 set(ENABLE_BUNDLED_LUAJIT ON)
 set(LUAJIT_ENABLE_GC64_DEFAULT OFF)
+
+if(NOT ENABLE_BACKTRACE)
+    set(LUAJIT_DISABLE_SYSPROF ON)
+    message(STATUS "Sysprof is not available without backtrace.")
+endif()
 if (TARGET_OS_DARWIN)
     # LuaJIT is unusable on OS X without enabled GC64
     # See https://github.com/tarantool/tarantool/issues/2643
@@ -598,47 +644,6 @@ add_dependencies(build_bundled_libs cdt)
 include(BuildMisc)
 libmisc_build()
 add_dependencies(build_bundled_libs misc)
-
-#
-# libunwind
-#
-
-if(ENABLE_BACKTRACE)
-    if(NOT HAVE_FORCE_ALIGN_ARG_POINTER_ATTR)
-        message(SEND_ERROR "backtrace feature requires \
-                            `force_align_arg_pointer` function attribute \
-                            support from C/C++ compiler")
-    endif()
-
-    if(NOT HAVE_CFI_ASM)
-        message(SEND_ERROR "backtrace feature requires CFI assembly support \
-                            from C/C++ compiler")
-    endif()
-
-    if(ENABLE_BUNDLED_LIBUNWIND)
-        if(APPLE)
-            message(SEND_ERROR "libunwind does not support macOS")
-        endif()
-        if(NOT HAVE_STDATOMIC_H)
-            message(SEND_ERROR "building bundled libunwind requires stdatomic.h \
-                                support from C compiler")
-        endif()
-
-        include(BuildLibUnwind)
-        libunwind_build()
-        add_dependencies(build_bundled_libs
-                         bundled-libunwind
-                         bundled-libunwind-platform)
-    else()
-        find_package(LibUnwind MODULE REQUIRED)
-    endif()
-    if(NOT APPLE AND NOT ENABLE_BUNDLED_LIBUNWIND AND
-        LIBUNWIND_VERSION VERSION_LESS "1.3" AND
-        ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
-        message(SEND_ERROR "versions of libunwind earlier than 1.3.0 are \
-                            broken on AARCH64 architecture")
-    endif()
-endif()
 
 # cpack config. called package.cmake to avoid
 # conflicts with the global CPack.cmake (On MacOS X

--- a/extra/exports
+++ b/extra/exports
@@ -258,8 +258,10 @@ luaL_typerror
 luaL_unref
 luaL_where
 luaM_metrics
-luaM_sysprof_configure
 luaM_sysprof_report
+luaM_sysprof_set_backtracer
+luaM_sysprof_set_on_stop
+luaM_sysprof_set_writer
 luaM_sysprof_start
 luaM_sysprof_stop
 luaopen_base


### PR DESCRIPTION
luajit: bump submodule

LuaJIT submodule is bumped to introduce the following changes:
* sysprof: change C configuration API
* sysprof: enrich symtab on a new trace or a proto
* sysprof: fix SYSPROF_HANDLER_STACK_DEPTH
* sysprof: make internal API functions static
* sysprof: add LUAJIT_DISABLE_SYSPROF to Makefile
* symtab: check the _GNU_SOURCE definition

Within this changeset Tarantool-specific backtrace handler is introduced
and set to be used by sysprof machinery.

Besides, all new public Lua C API introduced within this changeset is
added to extra/exports.

Follows up #781

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump
NO_CHANGELOG=LuaJIT submodule bump
