### PR TITLE
box: apply space upgrade function before updating tuple

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -321,7 +321,7 @@ box_process_rw(struct request *request, struct space *space,
 	rc = space_execute_dml(space, txn, request, &tuple);
 	if (result == NULL)
 		tuple = NULL;
-	result_process(&res_proc, &rc, &tuple);
+	result_process_perform(&res_proc, &rc, &tuple);
 	if (rc != 0) {
 		txn_rollback_stmt(txn);
 		goto rollback;
@@ -2523,7 +2523,7 @@ box_select(uint32_t space_id, uint32_t index_id,
 		struct result_processor res_proc;
 		result_process_prepare(&res_proc, space);
 		rc = iterator_next(it, &tuple);
-		result_process(&res_proc, &rc, &tuple);
+		result_process_perform(&res_proc, &rc, &tuple);
 		if (rc != 0 || tuple == NULL)
 			break;
 		if (offset > 0) {

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -220,7 +220,7 @@ box_index_random(uint32_t space_id, uint32_t index_id, uint32_t rnd,
 	struct result_processor res_proc;
 	result_process_prepare(&res_proc, space);
 	int rc = index_random(index, rnd, result);
-	result_process(&res_proc, &rc, result);
+	result_process_perform(&res_proc, &rc, result);
 	if (rc != 0)
 		return -1;
 	if (*result != NULL)
@@ -255,7 +255,7 @@ box_index_get(uint32_t space_id, uint32_t index_id, const char *key,
 	struct result_processor res_proc;
 	result_process_prepare(&res_proc, space);
 	int rc = index_get(index, key, part_count, result);
-	result_process(&res_proc, &rc, result);
+	result_process_perform(&res_proc, &rc, result);
 	if (rc != 0) {
 		txn_rollback_stmt(txn);
 		return -1;
@@ -296,7 +296,7 @@ box_index_min(uint32_t space_id, uint32_t index_id, const char *key,
 	struct result_processor res_proc;
 	result_process_prepare(&res_proc, space);
 	int rc = index_min(index, key, part_count, result);
-	result_process(&res_proc, &rc, result);
+	result_process_perform(&res_proc, &rc, result);
 	if (rc != 0) {
 		txn_rollback_stmt(txn);
 		return -1;
@@ -335,7 +335,7 @@ box_index_max(uint32_t space_id, uint32_t index_id, const char *key,
 	struct result_processor res_proc;
 	result_process_prepare(&res_proc, space);
 	int rc = index_max(index, key, part_count, result);
-	result_process(&res_proc, &rc, result);
+	result_process_perform(&res_proc, &rc, result);
 	if (rc != 0) {
 		txn_rollback_stmt(txn);
 		return -1;
@@ -433,7 +433,7 @@ box_iterator_next(box_iterator_t *itr, box_tuple_t **result)
 	struct result_processor res_proc;
 	result_process_prepare(&res_proc, space);
 	int rc = iterator_next(itr, result);
-	result_process(&res_proc, &rc, result);
+	result_process_perform(&res_proc, &rc, result);
 	if (rc != 0)
 		return -1;
 	if (*result != NULL)

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -45,6 +45,7 @@
 #include "sequence.h"
 #include "memtx_tuple_compression.h"
 #include "schema.h"
+#include "result.h"
 
 /*
  * Yield every 1K tuples while building a new index or checking
@@ -437,8 +438,8 @@ memtx_space_execute_delete(struct space *space, struct txn *txn,
 	if (memtx_space_replace_tuple(space, stmt, old_tuple, NULL,
 				      DUP_REPLACE_OR_INSERT) != 0)
 		return -1;
-	*result = stmt->old_tuple;
-	return 0;
+	*result = result_process(space, stmt->old_tuple);
+	return *result == NULL ? -1 : 0;
 }
 
 static int

--- a/src/box/result.h
+++ b/src/box/result.h
@@ -60,6 +60,23 @@ result_process_perform(struct result_processor *p, int *rc,
 	space_upgrade_unref(p->upgrade);
 }
 
+/**
+ * A shortcut for
+ *
+ *   int rc = 0;
+ *   struct result_processor res_proc;
+ *   result_process_prepare(&res_proc, space);
+ *   result_process_perform(&res_proc, &rc, &tuple);
+ */
+static inline struct tuple *
+result_process(struct space *space, struct tuple *tuple)
+{
+	if (unlikely(space->upgrade != NULL))
+		return space_upgrade_apply(space->upgrade, tuple);
+	else
+		return tuple;
+}
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/result.h
+++ b/src/box/result.h
@@ -28,9 +28,9 @@ extern "C" {
  *   struct result_processor res_proc;
  *   result_process_prepare(&res_proc, space);
  *   rc = index_get(index, key, part_count, result);
- *   result_process(&res_proc, &rc, result);
+ *   result_process_perform(&res_proc, &rc, result);
  *
- * Note, if result_process_prepare() was called, then result_process()
+ * Note, if result_process_prepare() was called, then result_process_perform()
  * must be called as well, because it may need to free some resources.
  */
 struct result_processor {
@@ -47,7 +47,8 @@ result_process_prepare(struct result_processor *p, struct space *space)
 }
 
 static inline void
-result_process(struct result_processor *p, int *rc, struct tuple **result)
+result_process_perform(struct result_processor *p, int *rc,
+		       struct tuple **result)
 {
 	if (likely(p->upgrade == NULL))
 		return;


### PR DESCRIPTION
If the space is being upgraded, UPDATE/UPSERT requests matching the new space format should work. However, currently they wouldn't work unless the target tuple has already been upgraded, because we don't apply the upgrade function to a tuple fetched from the space before applying UPDATE operations. Fix this.

The fix is only for memtx, because vinyl doesn't support space upgrade yet, see https://github.com/tarantool/tarantool-ee/issues/103.

Needed for https://github.com/tarantool/tarantool-ee/issues/111