### PR TITLE
replication: retry join automatically

### DIFF
--- a/changelogs/unreleased/gh-6126-retry-join-automatically.md
+++ b/changelogs/unreleased/gh-6126-retry-join-automatically.md
@@ -1,0 +1,4 @@
+## feature/core
+
+* If the error is non-critical, the instance retries retry join
+  automatically. (gh-6126)

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -442,9 +442,9 @@ applier_wait_snapshot(struct applier *applier)
 	struct xrow_header row;
 
 	/**
-	 * Tarantool < 1.7.0: if JOIN is successful, there is no "OK"
-	 * response, but a stream of rows from checkpoint.
-	 */
+	* Tarantool < 1.7.0: if JOIN is successful, there is no "OK"
+	* response, but a stream of rows from checkpoint.
+	*/
 	if (applier->version_id >= version_id(1, 7, 0)) {
 		/* Decode JOIN/FETCH_SNAPSHOT response */
 		coio_read_xrow(io, ibuf, &row);
@@ -452,14 +452,14 @@ applier_wait_snapshot(struct applier *applier)
 			xrow_decode_error_xc(&row); /* re-throw error */
 		} else if (row.type != IPROTO_OK) {
 			tnt_raise(ClientError, ER_UNKNOWN_REQUEST_TYPE,
-				  (uint32_t) row.type);
+				(uint32_t) row.type);
 		}
 		/*
-		 * Start vclock. The vclock of the checkpoint
-		 * the master is sending to the replica.
-		 * Used to initialize the replica's initial
-		 * vclock in bootstrap_from_master()
-		 */
+		* Start vclock. The vclock of the checkpoint
+		* the master is sending to the replica.
+		* Used to initialize the replica's initial
+		* vclock in bootstrap_from_master()
+		*/
 		xrow_decode_vclock_xc(&row, &replicaset.vclock);
 	}
 
@@ -472,21 +472,30 @@ applier_wait_snapshot(struct applier *applier)
 				xrow_decode_error_xc(&row);
 			} else if (iproto_type_is_promote_request(row.type)) {
 				struct synchro_request req;
-				if (xrow_decode_synchro(&row, &req) != 0)
+				if (xrow_decode_synchro(&row, &req) != 0) {
 					diag_raise();
+					//fiber_cancel(applier->fiber);
+					//fiber_gc();
+				}
+
 				txn_limbo_process(&txn_limbo, &req);
 			} else if (iproto_type_is_raft_request(row.type)) {
 				struct raft_request req;
-				if (xrow_decode_raft(&row, &req, NULL) != 0)
+				if (xrow_decode_raft(&row, &req, NULL) != 0) {
 					diag_raise();
+					//fiber_cancel(applier->fiber);
+					//fiber_gc();
+				}
 				box_raft_recover(&req);
 			} else if (row.type != IPROTO_JOIN_SNAPSHOT) {
 				tnt_raise(ClientError, ER_UNKNOWN_REQUEST_TYPE,
-					  (uint32_t)row.type);
+					(uint32_t)row.type);
 			}
 		} while (row.type != IPROTO_JOIN_SNAPSHOT);
 		coio_read_xrow(io, ibuf, &row);
 	}
+
+	applier_set_state(applier, APPLIER_CONTINUE_SNAPSHOT);
 
 	/*
 	 * Receive initial data.

--- a/src/box/applier.h
+++ b/src/box/applier.h
@@ -72,6 +72,7 @@ enum { APPLIER_SOURCE_MAXLEN = 1024 }; /* enough to fit URI with passwords */
 	_(APPLIER_FETCHED_SNAPSHOT, 14)                              \
 	_(APPLIER_REGISTER, 15)                                      \
 	_(APPLIER_REGISTERED, 16)                                    \
+	_(APPLIER_CONTINUE_SNAPSHOT, 17)                             \
 
 /** States for the applier */
 ENUM(applier_state, applier_STATE);

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3443,12 +3443,19 @@ bootstrap_master(const struct tt_uuid *replicaset_uuid)
  * @param[out] start_vclock  the vector time of the master
  *                           at the moment of replica bootstrap
  */
-static void
+static int
 bootstrap_from_master(struct replica *master)
 {
 	struct applier *applier = master->applier;
 	assert(applier != NULL);
-	applier_resume_to_state(applier, APPLIER_READY, TIMEOUT_INFINITY);
+
+	try {
+		applier_resume_to_state(applier, APPLIER_READY,
+					TIMEOUT_INFINITY);
+	} catch (...) {
+		return -1;
+	}
+
 	assert(applier->state == APPLIER_READY);
 
 	say_info("bootstrapping replica from %s at %s",
@@ -3459,18 +3466,34 @@ bootstrap_from_master(struct replica *master)
 	 * Send JOIN request to master
 	 * See box_process_join().
 	 */
-
 	assert(!tt_uuid_is_nil(&INSTANCE_UUID));
 	enum applier_state wait_state = replication_anon ?
 					APPLIER_FETCH_SNAPSHOT :
 					APPLIER_INITIAL_JOIN;
-	applier_resume_to_state(applier, wait_state, TIMEOUT_INFINITY);
+	try {
+		applier_resume_to_state(applier, wait_state,
+					TIMEOUT_INFINITY);
+	} catch (...) {
+		return -1;
+	}
+
+
+	try {
+		applier_resume_to_state(applier, APPLIER_CONTINUE_SNAPSHOT,
+					box_check_replication_timeout());
+		say_info("box.cc 5");
+	} catch (...) {
+		say_info("box.cc 6");
+		return -1;
+	}
+
 	/*
 	 * Process initial data (snapshot or dirty disk data).
 	 */
 	engine_begin_initial_recovery_xc(NULL);
 	wait_state = replication_anon ? APPLIER_FETCHED_SNAPSHOT :
 					APPLIER_FINAL_JOIN;
+
 	applier_resume_to_state(applier, wait_state, TIMEOUT_INFINITY);
 
 	/*
@@ -3483,6 +3506,7 @@ bootstrap_from_master(struct replica *master)
 		applier_resume_to_state(applier, APPLIER_JOINED,
 					TIMEOUT_INFINITY);
 	}
+
 	/* Finalize the new replica */
 	engine_end_recovery_xc();
 
@@ -3506,6 +3530,28 @@ bootstrap_from_master(struct replica *master)
 	/* Make the initial checkpoint */
 	if (gc_checkpoint() != 0)
 		panic("failed to create a checkpoint");
+
+	return 0;
+}
+
+/**
+ * If bootstrap failed from remote master rebootstrap it,
+ * in the case of non-critical error.
+ */
+static void
+rebootstrap_from_master(struct replica *master)
+{
+	do {
+		box_restart_replication();
+
+		master = replicaset_find_join_master();
+		assert(master == NULL || master->applier != NULL);
+
+		if (master == NULL || master->applier == NULL ||
+			master->applier->state != APPLIER_CONNECTED) {
+				tnt_raise(ClientError, ER_CANNOT_REGISTER);
+		}
+	} while (bootstrap_from_master(master) != 0);
 }
 
 /**
@@ -3552,7 +3598,7 @@ bootstrap(const struct tt_uuid *instance_uuid,
 	assert(master == NULL || master->applier != NULL);
 
 	if (master != NULL && !tt_uuid_is_equal(&master->uuid, &INSTANCE_UUID)) {
-		bootstrap_from_master(master);
+		rebootstrap_from_master(master);
 		/* Check replica set UUID */
 		if (!tt_uuid_is_nil(replicaset_uuid) &&
 		    !tt_uuid_is_equal(replicaset_uuid, &REPLICASET_UUID)) {
@@ -3628,7 +3674,7 @@ local_recovery(const struct tt_uuid *instance_uuid,
 		struct replica *master;
 		if (replicaset_needs_rejoin(&master)) {
 			say_crit("replica is too old, initiating rebootstrap");
-			return bootstrap_from_master(master);
+			return rebootstrap_from_master(master);
 		}
 	}
 

--- a/test/replication-luatest/gh_6126_auto_rejoin_test.lua
+++ b/test/replication-luatest/gh_6126_auto_rejoin_test.lua
@@ -1,0 +1,58 @@
+local t = require('luatest')
+local cluster = require('test.luatest_helpers.cluster')
+local server = require('test.luatest_helpers.server')
+local fio = require('fio')
+
+local g = t.group('gh_6126')
+
+g.before_each(function(cg)
+    cg.cluster = cluster:new({})
+    local master_uri = server.build_instance_uri('master')
+    local replica_uri = server.build_instance_uri('replica')
+    local replication = {master_uri, replica_uri}
+    local box_cfg = {
+        listen = replica_uri,
+        replication = replication,
+        replication_timeout = 3,
+    }
+    cg.replica = cg.cluster:build_and_add_server(
+        {alias = 'replica', box_cfg = box_cfg})
+
+    box_cfg.listen = master_uri
+    box_cfg.replication = {master_uri}
+    cg.master = cg.cluster:build_and_add_server(
+        {alias = 'master', box_cfg = box_cfg})
+
+    cg.master:start()
+end)
+
+g.after_each(function(cg)
+    cg.cluster.servers = nil
+    cg.cluster:drop()
+end)
+
+g.test_auto_rejoin = function(cg)
+    -- Test that joining replica tolerates ER_READONLY errors from master
+    cg.master:exec(function() box.cfg{read_only = true} end)
+    cg.replica:start({wait_for_readiness = false})
+    local logfile = fio.pathjoin(cg.replica.workdir, 'replica.log')
+    t.helpers.retrying({}, function()
+        t.assert(cg.replica:grep_log('ER_READONLY', nil,
+            {filename = logfile}), 'Can\'t modify data on a read-only'..
+            'instance - box.cfg.read_only is true')
+
+        t.assert(g.master:exec(function()
+            return box.space._cluster:count() == 1
+        end),  'No join while master is read-only')
+    end)
+
+    -- Test that replica joins after master became writeable
+    cg.master:exec(function() box.cfg{read_only = false} end)
+    cg.replica:wait_for_readiness()
+    t.helpers.retrying({}, function()
+        t.assert(g.master:exec(function()
+            return box.space._cluster:count() == 2
+        end), 'Join after master became writeable')
+        cg.replica:assert_follows_upstream(1)
+    end)
+end


### PR DESCRIPTION
If the error is non-critical, the instance retries retry join
automatically.

Closes #6126

@TarantoolBot document
Title: Retry join automatically (for a timeout)

If the error is non-critical, the instance retries retry join
automatically. For example, if automatic election is used, then a new
instance can find the leader, but while it is sending a join request,
the leader can resign. The join will fail saying the former leader is
read-only. The waiting make sense in this case.