### PR TITLE
ci: add Fedora 36 workflow 

### DIFF
--- a/.github/workflows/fedora_36.yml
+++ b/.github/workflows/fedora_36.yml
@@ -1,0 +1,74 @@
+name: fedora_36
+
+on:
+  push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+    tags:
+      - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
+
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch (1.10,
+  # 2.8, etc.), and tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    github.ref == 'refs/heads/1.10' ||
+    startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+jobs:
+  fedora_36:
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+
+    runs-on: ubuntu-20.04-self-hosted
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build-type: [ '', 'gc64' ]
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: packaging
+        env:
+          RWS_AUTH: ${{ secrets.RWS_AUTH }}
+          OS: 'fedora'
+          DIST: '36'
+          GC64: ${{ matrix.build-type == 'gc64' }}
+        uses: ./.github/actions/pack_and_deploy
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: fedora-36
+          retention-days: 21
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/fedora_36_aarch64.yml
+++ b/.github/workflows/fedora_36_aarch64.yml
@@ -1,0 +1,68 @@
+name: fedora_36_aarch64
+
+on:
+  push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+    tags:
+      - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
+
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch (1.10,
+  # 2.8, etc.), and tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    github.ref == 'refs/heads/1.10' ||
+    startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+jobs:
+  fedora_36_aarch64:
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+
+    runs-on: graviton
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: packaging
+        env:
+          RWS_AUTH: ${{ secrets.RWS_AUTH }}
+          OS: 'fedora'
+          DIST: '36'
+        uses: ./.github/actions/pack_and_deploy
+      - name: call action to send Telegram message on failure
+        env:
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_CORE_TOKEN }}
+          TELEGRAM_TO: ${{ secrets.TELEGRAM_CORE_TO }}
+        uses: ./.github/actions/send-telegram-notify
+        if: failure()
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: fedora-36
+          retention-days: 21
+          path: ${{ env.VARDIR }}/artifacts

--- a/changelogs/unreleased/add-fedora-36-ci-cd.md
+++ b/changelogs/unreleased/add-fedora-36-ci-cd.md
@@ -1,0 +1,3 @@
+## feature/build
+
+* Support Fedora-36 build.

--- a/changelogs/unreleased/add-ubuntu-jammy-ci-cd.md
+++ b/changelogs/unreleased/add-ubuntu-jammy-ci-cd.md
@@ -1,0 +1,3 @@
+## feature/build
+
+* Support Ubuntu Jammy (22.04) build.

--- a/rpm/tarantool.spec
+++ b/rpm/tarantool.spec
@@ -35,7 +35,14 @@ BuildRequires: gcc-c++ >= 4.5
 BuildRequires: coreutils
 BuildRequires: sed
 BuildRequires: readline-devel
+%if 0%{?fedora} >= 36
+# In Fedora 36 the default version of the openssl-devel package is 3.
+# But for now Tarantool doesn't work with this version. See for details:
+# https://github.com/tarantool/tarantool/issues/6477
+BuildRequires: openssl1.1-devel
+%else
 BuildRequires: openssl-devel
+%endif
 BuildRequires: libicu-devel
 #BuildRequires: msgpuck-devel
 %if 0%{?fedora} > 0
@@ -127,7 +134,14 @@ Requires: /etc/protocols
 Requires: /etc/services
 # Deps for built-in package manager
 # https://github.com/tarantool/tarantool/issues/2612
+%if 0%{?fedora} >= 36
+# In Fedora 36 the default version of the openssl-devel package is 3.
+# But for now Tarantool doesn't work with this version. See for details:
+# https://github.com/tarantool/tarantool/issues/6477
+Requires: openssl1.1
+%else
 Requires: openssl
+%endif
 %if (0%{?fedora} >= 22 || 0%{?rhel} >= 8 || 0%{?sle_version} >= 1500)
 # RHEL <= 7 doesn't support Recommends:
 Recommends: tarantool-devel
@@ -208,7 +222,13 @@ make %{?_smp_mflags}
 rm -rf %{buildroot}%{_datarootdir}/doc/tarantool/
 
 %check
+%if 0%{?fedora} >= 36
+# Workaround to make app/crypto.test.lua and app/digest.test.lua tests work.
+# See for details: https://github.com/tarantool/tarantool/issues/6477
+OPENSSL_CONF=/dev/null make test-force
+%else
 make test-force
+%endif
 
 %pre
 /usr/sbin/groupadd -r tarantool > /dev/null 2>&1 || :


### PR DESCRIPTION
Add the fedora_36.yml and fedora_36_aarch64.yml workflow files to build
Tarantool packages for x86_64 and aarch64 systems.

Closes https://github.com/tarantool/tarantool-qa/issues/239