### PR TITLE
ffi: export forgotten fiber_join_timeout symbol

### DIFF
--- a/changelogs/unreleased/gh-7125-export-fiber_join_timeout.md
+++ b/changelogs/unreleased/gh-7125-export-fiber_join_timeout.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Export forgotten fiber_join_timeout symbol (gh-7125).

--- a/extra/exports
+++ b/extra/exports
@@ -173,6 +173,7 @@ fiber_cond_wait
 fiber_cond_wait_timeout
 fiber_is_cancelled
 fiber_join
+fiber_join_timeout
 fiber_new
 fiber_new_ex
 fiber_reschedule

--- a/test/app-luatest/gh_7125-export-fiber_join_timeout_test.lua
+++ b/test/app-luatest/gh_7125-export-fiber_join_timeout_test.lua
@@ -1,0 +1,20 @@
+local t = require('luatest')
+local g = t.group()
+
+-- Check that fiber_join_timeout is accessible from ffi.
+g.test_ffi_fiber_join_timeout = function()
+    local t = require('luatest')
+    local ffi = require('ffi')
+    local fiber = require('fiber')
+    ffi.cdef([[
+        struct fiber;
+        struct fiber * fiber_self(void);
+        int fiber_join_timeout(struct fiber *f, double timeout);
+    ]])
+    local fiber_ptr = nil
+    fiber.create(function()
+        fiber_ptr = ffi.C.fiber_self()
+        fiber.self():set_joinable(true)
+    end)
+    t.assert_equals(ffi.C.fiber_join_timeout(fiber_ptr, 100500), 0)
+end


### PR DESCRIPTION
By a mistake it was marked as API_EXPORT but was forgotten to
be added to exports.

Closes #7125