### PR TITLE
console: don't mix stdout/stderr with readline prompt

### DIFF
--- a/changelogs/unreleased/hide-show-prompt.md
+++ b/changelogs/unreleased/hide-show-prompt.md
@@ -1,0 +1,4 @@
+## feature/lua/console
+
+* Prevent mixing of background print/log output with current user's input in
+  the interactive console (gh-7169).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,6 +64,7 @@ lua_source(lua_sources lua/iconv.lua iconv_lua)
 lua_source(lua_sources lua/swim.lua swim_lua)
 lua_source(lua_sources lua/datetime.lua datetime_lua)
 lua_source(lua_sources lua/timezones.lua timezones_lua)
+lua_source(lua_sources lua/print.lua print_lua)
 
 # LuaJIT jit.* library
 lua_source(lua_sources ${LUAJIT_SOURCE_ROOT}/src/jit/bc.lua jit_bc_lua)

--- a/src/lib/core/say.h
+++ b/src/lib/core/say.h
@@ -483,6 +483,20 @@ say_format_plain(struct log *log, char *buf, int len, int level,
 		 const char *filename, int line, const char *error,
 		 const char *format, va_list ap);
 
+/**
+ * A type defining a callback that is called before or after
+ * writing to stderr.
+ */
+typedef void
+(*say_stderr_callback_t)(void);
+
+/**
+ * Set callback functions called before/after writing to stderr.
+ */
+void
+say_set_stderr_callback(say_stderr_callback_t before,
+			say_stderr_callback_t after);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -154,7 +154,8 @@ extern char strict_lua[],
 	sysprof_collapse_lua[],
 	sysprof_lua[],
 	datetime_lua[],
-	timezones_lua[]
+	timezones_lua[],
+	print_lua[]
 #if defined(EMBED_LUAROCKS)
 	, luarocks_core_hardcoded_lua[],
 	luarocks_admin_cache_lua[],
@@ -308,6 +309,7 @@ static const char *lua_modules[] = {
 	"sysprof", sysprof_lua,
 	"timezones", timezones_lua,
 	"datetime", datetime_lua,
+	"internal.print", print_lua,
 	NULL
 };
 

--- a/src/lua/print.lua
+++ b/src/lua/print.lua
@@ -1,0 +1,17 @@
+local M = {}
+
+M.raw_print = print
+
+-- before_cb() and after_cb() must not raise an error, must not
+-- yield. It would break expectations about the print() function.
+_G.print = function(...)
+    if M.before_cb ~= nil then
+        M.before_cb()
+    end
+    M.raw_print(...)
+    if M.after_cb ~= nil then
+        M.after_cb()
+    end
+end
+
+return M

--- a/test/box-luatest/hide_show_prompt_test.lua
+++ b/test/box-luatest/hide_show_prompt_test.lua
@@ -1,0 +1,57 @@
+local it = require('test.luatest_helpers.interactive_tarantool')
+
+local t = require('luatest')
+local g = t.group()
+
+-- Basic case: prompt is shown and hid.
+--
+-- It does not check that tarantool preserves current input line
+-- and cursor position.
+g.test_basic_print = function()
+    local child = it.new({args = {'-l', 'fiber'}})
+
+    child:execute_command([[
+        _ = fiber.create(function()
+            fiber.name('print_flood', {truncate = true})
+            while true do
+                print('flood')
+                fiber.sleep(0.001)
+            end
+        end)
+    ]])
+    child:assert_empty_response()
+
+    local exp_line = it.PROMPT .. it.CR .. it.ERASE_IN_LINE .. 'flood'
+    for _ = 1, 10 do
+        child:assert_line(exp_line)
+    end
+
+    child:close()
+end
+
+-- The same as the basic case, but prints flood using logger to
+-- stderr.
+--
+-- We don't check for presence of 'flood' lines in the log, but
+-- verify that prompt on stdout is shown and hid.
+g.test_basic_log = function()
+    local child = it.new({args = {'-l', 'fiber', '-l', 'log'}})
+
+    child:execute_command([[
+        _ = fiber.create(function()
+            fiber.name('log_flood', {truncate = true})
+            while true do
+                log.info('flood')
+                fiber.sleep(0.001)
+            end
+        end)
+    ]])
+    child:assert_empty_response()
+
+    local exp_data = it.PROMPT .. it.CR .. it.ERASE_IN_LINE
+    for _ = 1, 10 do
+        child:assert_data(exp_data)
+    end
+
+    child:close()
+end

--- a/test/luatest_helpers/interactive_tarantool.lua
+++ b/test/luatest_helpers/interactive_tarantool.lua
@@ -1,0 +1,300 @@
+-- A set of helpers to ease testing of tarantool's interactive
+-- mode.
+
+local fun = require('fun')
+local fiber = require('fiber')
+local log = require('log')
+local yaml = require('yaml')
+local popen = require('popen')
+
+-- Default timeout for expecting an input on child's stdout.
+--
+-- Testing code shouldn't just hang, it rather should raise a
+-- meaningful error for debugging.
+local TIMEOUT = 5
+
+local M = {}
+
+local mt = {}
+mt.__index = mt
+
+-- {{{ Instance methods
+
+function mt._start_stderr_logger(self)
+    local f = fiber.create(function()
+        local fiber_name = "child's stderr logger"
+        fiber.name(fiber_name, {truncate = true})
+
+        while true do
+            local chunk, err = self.ph:read({stderr = true})
+            if chunk == nil then
+                log.warn(('%s: got error, exitting: %s'):format(
+                    fiber_name, tostring(err)))
+                break
+            end
+            if chunk == '' then
+                log.info(('%s: got EOF, exitting'):format(fiber_name))
+                break
+            end
+            for _, line in ipairs(chunk:rstrip('\n'):split('\n')) do
+                log.warn(('%s: %s'):format(fiber_name, line))
+            end
+        end
+    end)
+    self._stderr_logger = f
+end
+
+function mt._stop_stderr_logger(self)
+    self._stderr_logger:cancel()
+    self._stderr_logger = nil
+end
+
+function mt.read_chunk(self, opts)
+    local opts = opts or {}
+    local deadline = opts.deadline or (fiber.clock() + TIMEOUT)
+
+    local chunk, err = self.ph:read({timeout = TIMEOUT})
+    if chunk == nil then
+        error(err)
+    end
+    if chunk == '' then
+        error('Unexpected EOF')
+    end
+    if fiber.clock() > deadline then
+        error('Timed out')
+    end
+    self._readahead_buffer = self._readahead_buffer .. chunk
+    log.info(("child's stdout logger: %s"):format(M.escape_control(chunk)))
+end
+
+function mt.read_line(self, opts)
+    local opts = opts or {}
+    local deadline = opts.deadline or (fiber.clock() + TIMEOUT)
+
+    while not self._readahead_buffer:find('\n') do
+        self:read_chunk({deadline = deadline})
+    end
+    local line, new_buffer = unpack(self._readahead_buffer:split('\n', 1))
+    self._readahead_buffer = new_buffer
+    return line
+end
+
+-- Returns all readed lines (including expected one).
+function mt.read_until_line(self, exp_line, opts)
+    local opts = opts or {}
+    local deadline = opts.deadline or (fiber.clock() + TIMEOUT)
+
+    local res = {}
+
+    repeat
+        local line = self:read_line({deadline = deadline})
+        table.insert(res, line)
+    until line == exp_line
+
+    return res
+end
+
+function mt.assert_line(self, exp_line, opts)
+    local opts = opts or {}
+    local deadline = opts.deadline or (fiber.clock() + TIMEOUT)
+
+    local line = self:read_line({deadline = deadline})
+    if line ~= exp_line then
+        error(('Unexpected line %q, expected %q'):format(line, exp_line))
+    end
+end
+
+function mt.assert_data(self, exp_data, opts)
+    local opts = opts or {}
+    local deadline = opts.deadline or (fiber.clock() + TIMEOUT)
+
+    while #self._readahead_buffer < #exp_data do
+        self:read_chunk({deadline = deadline})
+    end
+    local data = self._readahead_buffer:sub(1, #exp_data)
+    local new_buffer = self._readahead_buffer:sub(#exp_data + 1)
+    self._readahead_buffer = new_buffer
+    if data ~= exp_data then
+        error(('Unexpected data %q, expected %q'):format(data, exp_data))
+    end
+end
+
+-- ReadLine echoes commands to stdout. It is easier to match the
+-- echo against the original command, when the command is a
+-- one-liner. Let's replace newlines with spaces.
+--
+-- Add a line feed at the end to send the command for execution.
+local function _prepare_command_for_write(command)
+    return command:rstrip('\n'):gsub('\n', ' ') .. '\n'
+end
+
+-- ReadLine determines terminal's ability to wrap long lines and
+-- may perform the wrapping on its own. It adds carriage return,
+-- spaces and may duplicate some characters.
+--
+-- Observed behavior is different on different readline version:
+--
+-- * ReadLine 8: lean on terminal's wrapping.
+-- * ReadLine 7: x<CR><duplicate x>, extra spaces.
+-- * ReadLine 6: <space><CR>.
+--
+-- This function drop duplicates that goes in row, strips <CR> and
+-- spaces. Applying of this function to a source command and
+-- readline's echoed command allows to compare them for equality.
+local function _prepare_command_for_compare(x)
+    x = x:gsub(' ', ''):gsub(M.CR, '')
+    local acc = fun.iter(x):reduce(function(acc, c)
+        if acc[#acc] ~= c then
+            table.insert(acc, c)
+        end
+        return acc
+    end, {})
+    return table.concat(acc)
+end
+
+function mt._assert_command_echo(self, prepared_command, opts)
+    local opts = opts or {}
+    local deadline = opts.deadline or (fiber.clock() + TIMEOUT)
+
+    local prompt = 'tarantool> '
+    local exp_echo = prompt .. prepared_command:rstrip('\n')
+    local echo = self:read_line({deadline = deadline})
+
+    -- If readline wraps the line, prepare the commands for
+    -- compare.
+    local comment = ''
+    if echo:find(M.CR) ~= nil then
+        exp_echo = _prepare_command_for_compare(exp_echo)
+        echo = _prepare_command_for_compare(echo)
+        comment = ' (the commands are mangled for the comparison)'
+    end
+
+    if echo ~= exp_echo then
+        error(('Unexpected command echo %q, expected %q%s'):format(
+            echo, exp_echo, comment))
+    end
+end
+
+function mt.execute_command(self, command, opts)
+    local opts = opts or {}
+    local deadline = opts.deadline or (fiber.clock() + TIMEOUT)
+
+    local prepared_command = _prepare_command_for_write(command)
+    self.ph:write(prepared_command)
+    self:_assert_command_echo(prepared_command, {deadline = deadline})
+end
+
+-- Ignores output before yaml start document marks, because
+-- print() output may appear before it.
+function mt.read_response(self, opts)
+    local opts = opts or {}
+    local deadline = opts.deadline or (fiber.clock() + TIMEOUT)
+
+    self:read_until_line('---', {deadline = deadline})
+    local lines = self:read_until_line('...', {deadline = deadline})
+    self:assert_line('', {deadline = deadline})
+
+    -- Handle empty response.
+    if #lines == 1 then
+        return
+    end
+
+    local raw_reply = '---\n' .. table.concat(lines, '\n') .. '\n'
+    local reply = yaml.decode(raw_reply)
+    return unpack(reply, 1, table.maxn(reply))
+end
+
+function mt.assert_empty_response(self, opts)
+    local reply = {self:read_response(opts)}
+    if table.maxn(reply) ~= 0 then
+        error(('Unexpected non-empty response:\n%s'):format(yaml.encode(reply)))
+    end
+end
+
+function mt.close(self)
+    self:_stop_stderr_logger()
+    self.ph:close()
+end
+
+-- }}} Instance methods
+
+-- {{{ Module functions
+
+function M.escape_control(str)
+    return str
+        :gsub(M.TAB, '<TAB>')
+        :gsub(M.LF, '<LF>')
+        :gsub(M.CR, '<CR>')
+        :gsub(M.ESC, '<ESC>')
+end
+
+function M.new(opts)
+    local opts = opts or {}
+    local args = opts.args or {}
+
+    local tarantool_exe = arg[-1]
+    local ph = popen.new(fun.chain({tarantool_exe, '-i'}, args):totable(), {
+        stdin = popen.opts.PIPE,
+        stdout = popen.opts.PIPE,
+        stderr = popen.opts.PIPE,
+        env = {
+            -- Don't know why, but without defined TERM environment
+            -- variable readline doesn't accept INPUTRC environment
+            -- variable.
+            TERM = 'xterm',
+            -- Prevent system/user inputrc configuration file from
+            -- influence testing code. In particular, if
+            -- horizontal-scroll-mode is enabled,
+            -- _assert_command_echo() on a long command will fail
+            -- (because the command in the echo output will be
+            -- trimmed).
+            INPUTRC = '/dev/null',
+        },
+    })
+
+    local res = setmetatable({
+        ph = ph,
+        _readahead_buffer = '',
+    }, mt)
+
+    -- Log child's stderr.
+    res:_start_stderr_logger()
+
+    -- Write a command and ignore the echoed output.
+    --
+    -- ReadLine 6 writes <ESC>[?1034h at beginning, it may hit
+    -- assertions on the child's output.
+    --
+    -- This sequence of charcters is smm ('set meta mode')
+    -- terminal capacity value. It has relation to writing
+    -- characters out of the ASCII range -- ones with 8th bit set,
+    -- but its description is vague. See terminfo(5).
+    res.ph:write("'Hello!'\n")
+    res:read_line()
+    assert(res:read_response() == 'Hello!')
+
+    -- Disable stdout line buffering in the child.
+    res:execute_command("io.stdout:setvbuf('no')")
+    assert(res:read_response(), true)
+
+    return res
+end
+
+-- }}} Module functions
+
+-- {{{ Module constants
+
+-- It may be different for remote console, but the module supports
+-- only local console for now.
+M.PROMPT = 'tarantool> '
+
+M.TAB = '\x09'
+M.LF = '\x0a'
+M.CR = '\x0d'
+M.ESC = '\x1b'
+
+M.ERASE_IN_LINE = M.ESC .. '[K'
+
+-- }}} Module constants
+
+return M


### PR DESCRIPTION
The idea is borrowed from [1]: hide and save prompt, user's input and
cursor position before writing to stdout/stderr and return everything
back afterwards.

Not every stdout/stderr write is handled this way: only tarantool's
logger (when it writes to stderr) and tarantool's print() Lua function
performs the prompt hide/show actions. For example,
`io.stdout:write(<...>)` Lua call or `write(STDOUT_FILENO, <...>)` C
call may mix readline's prompt with actual output. However the logger
and print() is likely enough for the vast majority of usages.

The readline's interactive search state (usually invoked by Ctrl+R) is
not covered by this patch. Sadly, I didn't find a way to properly save
and restore readline's output in this case.

Implementation details
----------------------

Several words about the allocation strategy. On the first glance it may
look worthful to pre-allocate a buffer to store prompt and user's input
data and reallocate it on demand. However rl_set_prompt() already
performs free() plus malloc() at each call[^1], so avoid doing malloc()
on our side would not change the picture much. Moreover, this code
interacts with a human, which is on many orders of magnitude slower that
a machine and will not notice a difference. So I decided to keep the
code simpler.

[^1]: Verified on readline 8.1 sources. However it worth to note that
      rl_replace_line() keeps the buffer and performs realloc() on
      demand.

The code is organized to make say and print modules calling some
callbacks without knowledge about its origin and dependency on the
console module (or whatever else module would implement this interaction
with readline). The downside here is that console needs to know all
places to set the callbacks. OTOH, it offers explicit list of such
callbacks in one place and, at whole, keep the relevant code together.

We can redefine the print() function from every place in the code, but I
prefer to make it as explicit as possible, so added the new internal
print.lua module.

We could redefine _G.print on demand instead of setting callbacks for a
function assigned to _G.print once. The downside here is that if a user
save/capture the old _G.print value, it'll use the raw print() directly
instead of our replacement. Current implementation seems to be more
safe.

Alternatives considered
-----------------------

I guess we can clear readline's prompt and user input manually and don't
let readline know that something was changed (and restore the
prompt/user input afterwards). It would save allocations and string
copying, but likely would lean on readline internals too much and repeat
some of its functionality. I considered this option as unstable and
declined.

We can redefine behavior for all writes to stdout and stderr. There are
different ways to do so:

1. Redefine libc's write() with our own implementation, which will call
   the original libc's write()[^2]. It is defined as a weak symbol in
   libc (at least in glibc), so there is no problem to do so.
2. Use pipe(), dup() and dup2() to execute our own code at
   STDOUT_FILENO, STDERR_FILENO writes.

[^2]: There is a good article about pitfalls on this road: [2]. It is
      about LD_PRELOAD, but I guess everything is very similar with
      wrapping libc's function from an executable.

In my opinion, those options are dangerous, because they implicitly
change behavior of a lot of code, which unlikely expects something of
this kind. The second option (use pipe()) adds more user space/kernel
space context switches, more copying and also would add possible
implicit fiber yield at any `write(STD*_FILENO, <...>)` call -- unlikely
all user's code is ready for that.

Fixes #7169