### PR TITLE
cmake: support build using Ninja

### DIFF
--- a/.travis.mk
+++ b/.travis.mk
@@ -90,7 +90,7 @@ deps_ubuntu_ghactions: deps_tests
 		sudo apt-get install -y -f libreadline-dev libunwind-dev
 
 deps_coverage_ubuntu_ghactions: deps_ubuntu_ghactions
-	sudo apt-get install -y -f lcov
+	sudo apt-get install -y -f lcov ninja-build
 	sudo gem install coveralls-lcov
 	# Link src/lib/uri/src to local src dircetory to avoid of issue:
 	# /var/lib/gems/2.7.0/gems/coveralls-lcov-1.7.0/lib/coveralls/lcov/converter.rb:64:in
@@ -176,11 +176,11 @@ debug_ubuntu_ghactions: deps_ubuntu_ghactions test_debug_debian_no_deps
 # Coverage
 
 build_coverage_debian:
-	cmake . -DCMAKE_BUILD_TYPE=Debug -DENABLE_GCOV=ON
-	make -j $$(nproc)
+	cmake . -G Ninja -DCMAKE_BUILD_TYPE=Debug -DENABLE_GCOV=ON
+	cmake --build . --parallel $$(nproc)
 
 test_coverage_debian_no_deps: build_coverage_debian
-	make LuaJIT-test
+	cmake --build . --parallel $$(nproc) -t LuaJIT-test
 	# Enable --long tests for coverage
 	cd test && ./test-run.py --vardir ${VARDIR} --force $(TEST_RUN_EXTRA_PARAMS) --long
 	lcov --compat-libtool --directory src/ --capture --output-file coverage.info.tmp \

--- a/cmake/BuildAres.cmake
+++ b/cmake/BuildAres.cmake
@@ -47,7 +47,8 @@ macro(ares_build)
         TMP_DIR ${ARES_BINARY_DIR}/tmp
         STAMP_DIR ${ARES_BINARY_DIR}/stamp
         BINARY_DIR ${ARES_BINARY_DIR}
-        CMAKE_ARGS ${ARES_CMAKE_FLAGS})
+        CMAKE_ARGS ${ARES_CMAKE_FLAGS}
+        BUILD_BYPRODUCTS ${ARES_INSTALL_DIR}/lib/libcares.a)
 
     add_library(bundled-ares STATIC IMPORTED GLOBAL)
     set_target_properties(bundled-ares PROPERTIES IMPORTED_LOCATION

--- a/cmake/BuildLibCURL.cmake
+++ b/cmake/BuildLibCURL.cmake
@@ -203,10 +203,12 @@ macro(curl_build)
         STAMP_DIR ${LIBCURL_BINARY_DIR}/stamp
         BINARY_DIR ${LIBCURL_BINARY_DIR}/curl
         CONFIGURE_COMMAND
-            cd <BINARY_DIR> && ${CMAKE_COMMAND} <SOURCE_DIR>
-                ${LIBCURL_CMAKE_FLAGS}
-        BUILD_COMMAND cd <BINARY_DIR> && $(MAKE)
-        INSTALL_COMMAND cd <BINARY_DIR> && $(MAKE) install)
+            ${CMAKE_COMMAND} -B <BINARY_DIR> -S <SOURCE_DIR>
+                -G ${CMAKE_GENERATOR} ${LIBCURL_CMAKE_FLAGS}
+        BUILD_COMMAND cd <BINARY_DIR> && ${CMAKE_MAKE_PROGRAM}
+        INSTALL_COMMAND cd <BINARY_DIR> && ${CMAKE_MAKE_PROGRAM} install
+        CMAKE_GENERATOR ${CMAKE_GENERATOR}
+        BUILD_BYPRODUCTS ${LIBCURL_INSTALL_DIR}/lib/libcurl.a)
 
     add_library(bundled-libcurl STATIC IMPORTED GLOBAL)
     set_target_properties(bundled-libcurl PROPERTIES IMPORTED_LOCATION

--- a/cmake/BuildLibUnwind.cmake
+++ b/cmake/BuildLibUnwind.cmake
@@ -70,7 +70,10 @@ macro(libunwind_build)
                         LOG_MERGED_STDOUTERR TRUE
                         LOG_OUTPUT_ON_FAILURE TRUE
 
-                        EXCLUDE_FROM_ALL)
+                        EXCLUDE_FROM_ALL
+
+                        BUILD_BYPRODUCTS ${LIBUNWIND_INSTALL_DIR}/lib/libunwind-x86_64.a
+                        BUILD_BYPRODUCTS ${LIBUNWIND_INSTALL_DIR}/lib/libunwind.a)
 
     add_library(bundled-libunwind STATIC IMPORTED GLOBAL)
     set_target_properties(bundled-libunwind PROPERTIES

--- a/cmake/BuildNghttp2.cmake
+++ b/cmake/BuildNghttp2.cmake
@@ -59,7 +59,8 @@ macro(nghttp2_build)
         TMP_DIR ${NGHTTP2_BINARY_DIR}/tmp
         STAMP_DIR ${NGHTTP2_BINARY_DIR}/stamp
         BINARY_DIR ${NGHTTP2_BINARY_DIR}
-        CMAKE_ARGS ${NGHTTP2_CMAKE_FLAGS})
+        CMAKE_ARGS ${NGHTTP2_CMAKE_FLAGS}
+        BUILD_BYPRODUCTS ${NGHTTP2_INSTALL_DIR}/lib/libnghttp2.a)
 
     add_library(bundled-nghttp2 STATIC IMPORTED GLOBAL)
     set_target_properties(bundled-nghttp2 PROPERTIES IMPORTED_LOCATION

--- a/cmake/rpm.cmake
+++ b/cmake/rpm.cmake
@@ -20,7 +20,7 @@ if (RPMBUILD)
 
     add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/tarantool-${PACKAGE_VERSION}.tar.gz
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-        COMMAND $(MAKE) package_source)
+        COMMAND ${CMAKE_MAKE_COMMAND} package_source)
 
     add_custom_command(OUTPUT ${RPM_BUILDROOT}
         COMMAND ${MKDIR} -p ${RPM_BUILDROOT})


### PR DESCRIPTION
NOTE: For building Tarantool with Ninja it is needed to apply patch to LuaJIT - 

https://lists.tarantool.org/tarantool-patches/ee1a1146963fe6aad5bff59884e00b6cf24eaf1a.1653307030.git.sergeyb@tarantool.org/T/#u

Branch: https://github.com/tarantool/luajit/tree/ligurio/ninja-support

----------------

By default, CMake generates Makefiles for building a project. However, it
allows generating Ninja files. Ninja [1] may build project a bit faster
than Make, see [2]. Patch adds fixes for CMake files allowing to use
Ninja for building Tarantool.

There are two kind of fixes:

1. Fix dependencies in `ExternalProject_Add()`, see explanation in [3]
2. Fix '$' symbols in `cmake/rpm.cmake`

How-to build wit Ninja:

```sh
$ cmake -G Ninja -B build -S .
$ ninja -C build/
```

On my laptop Ninja reduces building time by 14% (with Make it takes 76
sec, with Ninja 66 sec).

1. https://ninja-build.org/
2. https://mesonbuild.com/Simple-comparison.html
3. https://stackoverflow.com/a/65803911/3665613