### PR TITLE
replication: retry join automatically

### DIFF
--- a/changelogs/unreleased/gh-6126-retry-join-automatically.md
+++ b/changelogs/unreleased/gh-6126-retry-join-automatically.md
@@ -1,0 +1,10 @@
+## feature/core
+
+* Now if join fails with some non-critical error, like `ER_READONLY`,
+  `ER_ACCESS_DENIED` or something network-related, the instance tries
+  to find a new master to join off and tries again (gh-6126).
+
+* States when joining a replica are renamed. So now when querying
+  `box.info.replication[id].upstream.status` during join, you will
+  see either `wait_snapshot` or `fetch_snapshot` instead of
+  `initial_join` (gh-6126).

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -105,7 +105,7 @@ applier_log_error(struct applier *applier, struct error *e)
 		break;
 	case APPLIER_SYNC:
 	case APPLIER_FOLLOW:
-	case APPLIER_INITIAL_JOIN:
+	case APPLIER_WAIT_SNAPSHOT:
 	case APPLIER_FINAL_JOIN:
 		say_info("can't read row");
 		break;
@@ -547,7 +547,7 @@ applier_fetch_snapshot(struct applier *applier)
 	row.type = IPROTO_FETCH_SNAPSHOT;
 	coio_write_xrow(io, &row);
 
-	applier_set_state(applier, APPLIER_FETCH_SNAPSHOT);
+	applier_set_state(applier, APPLIER_WAIT_SNAPSHOT);
 	applier_wait_snapshot(applier);
 	applier_set_state(applier, APPLIER_FETCHED_SNAPSHOT);
 	applier_set_state(applier, APPLIER_READY);
@@ -728,7 +728,7 @@ applier_join(struct applier *applier)
 	xrow_encode_join_xc(&row, &INSTANCE_UUID);
 	coio_write_xrow(io, &row);
 
-	applier_set_state(applier, APPLIER_INITIAL_JOIN);
+	applier_set_state(applier, APPLIER_WAIT_SNAPSHOT);
 
 	row_count = applier_wait_snapshot(applier);
 

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -106,6 +106,7 @@ applier_log_error(struct applier *applier, struct error *e)
 	case APPLIER_SYNC:
 	case APPLIER_FOLLOW:
 	case APPLIER_WAIT_SNAPSHOT:
+	case APPLIER_FETCH_SNAPSHOT:
 	case APPLIER_FINAL_JOIN:
 		say_info("can't read row");
 		break;
@@ -498,6 +499,8 @@ applier_wait_snapshot(struct applier *applier)
 		} while (row.type != IPROTO_JOIN_SNAPSHOT);
 		coio_read_xrow(io, ibuf, &row);
 	}
+
+	applier_set_state(applier, APPLIER_FETCH_SNAPSHOT);
 
 	/*
 	 * Receive initial data.

--- a/src/box/applier.h
+++ b/src/box/applier.h
@@ -60,16 +60,16 @@ enum { APPLIER_SOURCE_MAXLEN = 1024 }; /* enough to fit URI with passwords */
 	_(APPLIER_CONNECTED, 2)                                      \
 	_(APPLIER_AUTH, 3)                                           \
 	_(APPLIER_READY, 4)                                          \
-	_(APPLIER_INITIAL_JOIN, 5)                                   \
-	_(APPLIER_FINAL_JOIN, 6)                                     \
-	_(APPLIER_JOINED, 7)                                         \
-	_(APPLIER_SYNC, 8)                                           \
-	_(APPLIER_FOLLOW, 9)                                         \
-	_(APPLIER_STOPPED, 10)                                       \
-	_(APPLIER_DISCONNECTED, 11)                                  \
-	_(APPLIER_LOADING, 12)                                       \
-	_(APPLIER_FETCH_SNAPSHOT, 13)                                \
-	_(APPLIER_FETCHED_SNAPSHOT, 14)                              \
+	_(APPLIER_FINAL_JOIN, 5)                                     \
+	_(APPLIER_JOINED, 6)                                         \
+	_(APPLIER_SYNC, 7)                                           \
+	_(APPLIER_FOLLOW, 8)                                         \
+	_(APPLIER_STOPPED, 9)                                        \
+	_(APPLIER_DISCONNECTED, 10)                                  \
+	_(APPLIER_LOADING, 11)                                       \
+	_(APPLIER_FETCH_SNAPSHOT, 12)                                \
+	_(APPLIER_FETCHED_SNAPSHOT, 13)                              \
+	_(APPLIER_WAIT_SNAPSHOT, 14)                                 \
 	_(APPLIER_REGISTER, 15)                                      \
 	_(APPLIER_REGISTERED, 16)                                    \
 

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3470,15 +3470,21 @@ bootstrap_master(const struct tt_uuid *replicaset_uuid)
  * \pre  master->applier->state == APPLIER_CONNECTED
  * \post master->applier->state == APPLIER_READY
  *
- * @param[out] start_vclock  the vector time of the master
- *                           at the moment of replica bootstrap
+ * \throws an exception in case an unrecoverable error
+ * \return false in case of a transient error
+ *         true in case everything is fine
  */
-static void
+static bool
 bootstrap_from_master(struct replica *master)
 {
 	struct applier *applier = master->applier;
 	assert(applier != NULL);
-	applier_resume_to_state(applier, APPLIER_READY, TIMEOUT_INFINITY);
+	try {
+		applier_resume_to_state(applier, APPLIER_READY,
+					TIMEOUT_INFINITY);
+	} catch (...) {
+		return false;
+	}
 	assert(applier->state == APPLIER_READY);
 
 	say_info("bootstrapping replica from %s at %s",
@@ -3489,15 +3495,20 @@ bootstrap_from_master(struct replica *master)
 	 * Send JOIN request to master
 	 * See box_process_join().
 	 */
-
 	assert(!tt_uuid_is_nil(&INSTANCE_UUID));
-	enum applier_state wait_state = APPLIER_WAIT_SNAPSHOT;
-	applier_resume_to_state(applier, wait_state, TIMEOUT_INFINITY);
+	try {
+		applier_resume_to_state(applier, APPLIER_FETCH_SNAPSHOT,
+					TIMEOUT_INFINITY);
+	} catch (...) {
+		return false;
+	}
+
 	/*
 	 * Process initial data (snapshot or dirty disk data).
 	 */
 	engine_begin_initial_recovery_xc(NULL);
-	wait_state = replication_anon ? APPLIER_FETCHED_SNAPSHOT :
+	enum applier_state wait_state = replication_anon ?
+					APPLIER_FETCHED_SNAPSHOT :
 					APPLIER_FINAL_JOIN;
 	applier_resume_to_state(applier, wait_state, TIMEOUT_INFINITY);
 
@@ -3534,6 +3545,8 @@ bootstrap_from_master(struct replica *master)
 	/* Make the initial checkpoint */
 	if (gc_checkpoint() != 0)
 		panic("failed to create a checkpoint");
+
+	return true;
 }
 
 /**
@@ -3574,23 +3587,49 @@ bootstrap(const struct tt_uuid *instance_uuid,
 	 * with connecting to 'replication_connect_quorum' masters.
 	 * If this also fails, throw an error.
 	 */
-	box_restart_replication();
+	struct replica *master;
+	/*
+	 * Rebootstrap
+	 *
+	 * 1) Try to connect to all nodes in the replicaset during
+	 *    the waiting period in order to update their ballot.
+	 *
+	 * 2) After updated the ballot of all nodes, it are looking
+	 *    for a new master.
+	 *
+	 * 3) Wait until bootstrap_from_master succeeds.
+	 */
+	double timeout = replication_timeout;
+	bool say_once = false;
 
-	struct replica *master = replicaset_find_join_master();
-	assert(master == NULL || master->applier != NULL);
+	while (true) {
+		box_restart_replication();
+		master = replicaset_find_join_master();
+		if (master == NULL ||
+		    tt_uuid_is_equal(&master->uuid, &INSTANCE_UUID)) {
+			bootstrap_master(replicaset_uuid);
+			*is_bootstrap_leader = true;
+			break;
+		}
 
-	if (master != NULL && !tt_uuid_is_equal(&master->uuid, &INSTANCE_UUID)) {
-		bootstrap_from_master(master);
-		/* Check replica set UUID */
-		if (!tt_uuid_is_nil(replicaset_uuid) &&
+		bool is_bootstrapped = bootstrap_from_master(master);
+		if (is_bootstrapped && !tt_uuid_is_nil(replicaset_uuid) &&
 		    !tt_uuid_is_equal(replicaset_uuid, &REPLICASET_UUID)) {
 			tnt_raise(ClientError, ER_REPLICASET_UUID_MISMATCH,
 				  tt_uuid_str(replicaset_uuid),
 				  tt_uuid_str(&REPLICASET_UUID));
 		}
-	} else {
-		bootstrap_master(replicaset_uuid);
-		*is_bootstrap_leader = true;
+		if (is_bootstrapped) {
+			*is_bootstrap_leader = false;
+			break;
+		}
+		if (!say_once) {
+			say_info("rebootstrap failed, will retry "
+				 "every %.2lf second", timeout);
+		}
+
+		say_once = true;
+		fiber_sleep(timeout);
 	}
 }
 
@@ -3654,9 +3693,26 @@ local_recovery(const struct tt_uuid *instance_uuid,
 		box_update_replication();
 
 		struct replica *master;
-		if (replicaset_needs_rejoin(&master)) {
-			say_crit("replica is too old, initiating rebootstrap");
-			return bootstrap_from_master(master);
+		double timeout = replication_timeout;
+		bool say_once = false;
+
+		while (replicaset_needs_rejoin(&master)) {
+			if (!say_once) {
+				say_crit("replica is too old, initiating "
+					 "rebootstrap");
+			}
+
+			if (bootstrap_from_master(master))
+				return;
+			box_restart_replication();
+
+			if (!say_once) {
+				say_info("rebootstrap failed, will retry "
+					 "every %.2lf second", timeout);
+			}
+
+			say_once = true;
+			fiber_sleep(timeout);
 		}
 	}
 

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3491,9 +3491,7 @@ bootstrap_from_master(struct replica *master)
 	 */
 
 	assert(!tt_uuid_is_nil(&INSTANCE_UUID));
-	enum applier_state wait_state = replication_anon ?
-					APPLIER_FETCH_SNAPSHOT :
-					APPLIER_INITIAL_JOIN;
+	enum applier_state wait_state = APPLIER_WAIT_SNAPSHOT;
 	applier_resume_to_state(applier, wait_state, TIMEOUT_INFINITY);
 	/*
 	 * Process initial data (snapshot or dirty disk data).

--- a/src/box/replication.cc
+++ b/src/box/replication.cc
@@ -534,7 +534,7 @@ replica_on_applier_state_f(struct trigger *trigger, void *event)
 			struct replica, on_applier_state);
 	replica_update_applier_health(replica);
 	switch (replica->applier->state) {
-	case APPLIER_INITIAL_JOIN:
+	case APPLIER_WAIT_SNAPSHOT:
 		replicaset.is_joining = true;
 		break;
 	case APPLIER_JOINED:

--- a/test/replication-luatest/gh_6126_auto_rejoin_test.lua
+++ b/test/replication-luatest/gh_6126_auto_rejoin_test.lua
@@ -1,0 +1,101 @@
+local t = require('luatest')
+local cluster = require('test.luatest_helpers.cluster')
+local server = require('test.luatest_helpers.server')
+local fio = require('fio')
+
+local g = t.group('gh_6126')
+
+g.before_each(function(cg)
+    cg.cluster = cluster:new({})
+
+    local box_cfg = {
+        replication = {
+            server.build_instance_uri('instance_1'),
+        },
+        instance_uuid = t.helpers.uuid('b'),
+    }
+    cg.instance_1 = cg.cluster:build_and_add_server(
+        {alias = 'instance_1', box_cfg = box_cfg})
+
+    box_cfg = {
+        replication = {
+            server.build_instance_uri('anon'),
+            server.build_instance_uri('instance_1'),
+        },
+        instance_uuid = t.helpers.uuid('a'),
+        read_only = true,
+        replication_anon = true,
+    }
+    cg.anon = cg.cluster:build_and_add_server(
+        {alias = 'anon', box_cfg = box_cfg})
+
+    box_cfg = {
+        replication = {
+            server.build_instance_uri('anon'),
+            server.build_instance_uri('instance_1'),
+            server.build_instance_uri('instance_2'),
+        },
+        instance_uuid = t.helpers.uuid('c'),
+    }
+    cg.instance_2 = cg.cluster:build_and_add_server(
+        {alias = 'instance_2', box_cfg = box_cfg})
+end)
+
+g.after_each(function(cg)
+    cg.cluster:drop()
+end)
+
+g.test_auto_rejoin = function(cg)
+    cg.instance_1:start()
+    cg.instance_1:exec(function() box.cfg{read_only = true} end)
+    cg.anon:start()
+    cg.instance_2:start({wait_for_readiness = false})
+
+    local logfile = fio.pathjoin(cg.instance_2.workdir, 'instance_2.log')
+    t.helpers.retrying({}, function()
+        t.assert(cg.instance_2:grep_log('ER_UNSUPPORTED', nil,
+            {filename = logfile}), 'Anonymous replica does not support'..
+            'registration of non-anonymous nodes.')
+        t.assert(cg.instance_2:grep_log('rebootstrap failed, will '..
+            'retry every 1.00 second', nil, {filename = logfile}),
+            'reboootstrap failed')
+    end)
+    t.assert(cg.instance_1:exec(function()
+        return box.space._cluster:count() == 1
+    end),  'No join while instance_1 is read-only')
+
+    cg.instance_1:exec(function() box.cfg{read_only = false} end)
+    cg.instance_1:exec(function()
+        local s1 = box.schema.create_space('test1', {engine = 'vinyl'})
+        s1:create_index('pk')
+        s1:replace{1}
+        local s2 = box.schema.create_space('test2')
+        s2:create_index('pk')
+        s2:replace{2}
+        box.snapshot()
+        s1:replace{3}
+        s2:replace{4}
+    end)
+
+    cg.instance_2:wait_for_readiness()
+    t.helpers.retrying({}, function()
+        t.assert(cg.instance_1:exec(function()
+            return box.space._cluster:count() == 2
+        end), 'Join after instance_1 became writeable')
+        cg.instance_2:assert_follows_upstream(1)
+    end)
+
+    -- Check
+    t.assert_equals(cg.instance_2:exec(function()
+        return box.space.test1:select()
+    end), {{1}, {3}})
+    t.assert_equals(cg.instance_2:exec(function()
+        return box.space.test2:select()
+    end), {{2}, {4}})
+    t.assert_equals(cg.anon:exec(function()
+        return box.space.test1:select()
+    end), {{1}, {3}})
+    t.assert_equals(cg.anon:exec(function()
+        return box.space.test2:select()
+    end), {{2}, {4}})
+end

--- a/test/replication/anon.result
+++ b/test/replication/anon.result
@@ -411,9 +411,18 @@ test_run:cmd([[create server replica with rpl_master=replica_anon1,\
  | ---
  | - true
  | ...
-test_run:cmd('start server replica with crash_expected=True')
+test_run:cmd('start server replica with wait_load=False, wait=False')
  | ---
- | - false
+ | - true
+ | ...
+test_run:wait_log('replica', 'ER_UNSUPPORTED: Anonymous replica does not support registration of non%-anonymous nodes.', nil, 10)
+ | ---
+ | - 'ER_UNSUPPORTED: Anonymous replica does not support registration of non-anonymous
+ |   nodes.'
+ | ...
+test_run:cmd('stop server replica')
+ | ---
+ | - true
  | ...
 test_run:cmd('delete server replica')
  | ---

--- a/test/replication/anon.test.lua
+++ b/test/replication/anon.test.lua
@@ -147,7 +147,9 @@ test_run:cmd('delete server replica_anon2')
 -- Check that joining to an anonymous replica is prohibited.
 test_run:cmd([[create server replica with rpl_master=replica_anon1,\
              script="replication/replica.lua"]])
-test_run:cmd('start server replica with crash_expected=True')
+test_run:cmd('start server replica with wait_load=False, wait=False')
+test_run:wait_log('replica', 'ER_UNSUPPORTED: Anonymous replica does not support registration of non%-anonymous nodes.', nil, 10)
+test_run:cmd('stop server replica')
 test_run:cmd('delete server replica')
 
 -- A normal instance (already joined) can't follow an anonymous


### PR DESCRIPTION
If the error is non-critical, the instance retries join
automatically.

@TarantoolBot document
Title: Retry join automatically (for a timeout)

If the error is non-critical, the instance retries join automatically.
For example, if automatic election is used, then a new instance can
find the leader, but while it is sending a join request, the leader
can resign. The join will fail saying the former leader is read-only.
The waiting make sense in this case.

Closes #6126