### PR TITLE
datetime: do not mess with nsec in interval

### DIFF
--- a/changelogs/unreleased/gh-7045-interval-nanoseconds.md
+++ b/changelogs/unreleased/gh-7045-interval-nanoseconds.md
@@ -1,0 +1,17 @@
+## feature/datetime
+
+* Changed format of a string representation of date/time intervals.
+  There is no seconds/nano-seconds normalization done anymore, and
+  interval to be displayed as-is.
+
+  Instead of former:
+```lua
+    local ival = date.interval.new{year = 12345, hour = 48, min = 3, sec = 1,
+                                   nsec = 12345678}
+    print(tostring(ival)) -- '+12345 years, 48 hours, 3 minutes, '..
+                          -- '1.012345678 seconds'
+```
+we now output
+```
+   --  '+12345 years, 48 hours, 3 minutes, 1 seconds, 12345678 nanoseconds'
+```

--- a/src/lib/core/datetime.c
+++ b/src/lib/core/datetime.c
@@ -577,63 +577,55 @@ interval_to_string(const struct interval *ival, char *buf, ssize_t len)
 		"%+d",	/* true */
 	};
 
-	bool need_sign = true;
 	size_t sz = 0;
 	if (ival->year != 0) {
 		SNPRINT(sz, snprintf, buf, len, "%+d years", ival->year);
-		need_sign = false;
 	}
 	if (ival->month != 0) {
 		SPACE();
-		SNPRINT(sz, snprintf, buf, len, signed_fmt[need_sign],
+		SNPRINT(sz, snprintf, buf, len, signed_fmt[sz == 0],
 			ival->month);
 		SNPRINT(sz, snprintf, buf, len, " months");
-		need_sign = false;
 	}
 	if (ival->week != 0) {
 		SPACE();
-		SNPRINT(sz, snprintf, buf, len, signed_fmt[need_sign],
+		SNPRINT(sz, snprintf, buf, len, signed_fmt[sz == 0],
 			ival->week);
 		SNPRINT(sz, snprintf, buf, len, " weeks");
-		need_sign = false;
 	}
 	int64_t days = (int64_t)ival->day;
 	if (days != 0) {
 		SPACE();
-		SNPRINT(sz, snprintf, buf, len, long_signed_fmt[need_sign],
+		SNPRINT(sz, snprintf, buf, len, long_signed_fmt[sz == 0],
 			days);
 		SNPRINT(sz, snprintf, buf, len, " days");
-		need_sign = false;
 	}
 	int64_t hours = (int64_t)ival->hour;
 	if (ival->hour != 0) {
 		SPACE();
-		SNPRINT(sz, snprintf, buf, len, long_signed_fmt[need_sign],
+		SNPRINT(sz, snprintf, buf, len, long_signed_fmt[sz == 0],
 			hours);
 		SNPRINT(sz, snprintf, buf, len, " hours");
-		need_sign = false;
 	}
 	int64_t minutes = (int64_t)ival->min;
 	if (minutes != 0) {
 		SPACE();
-		SNPRINT(sz, snprintf, buf, len, long_signed_fmt[need_sign],
+		SNPRINT(sz, snprintf, buf, len, long_signed_fmt[sz == 0],
 			minutes);
 		SNPRINT(sz, snprintf, buf, len, " minutes");
-		need_sign = false;
 	}
 
 	int64_t secs = (int64_t)ival->sec;
 	if (secs != 0 || sz == 0) {
 		SPACE();
-		SNPRINT(sz, snprintf, buf, len, long_signed_fmt[need_sign],
+		SNPRINT(sz, snprintf, buf, len, long_signed_fmt[sz == 0],
 			secs);
 		SNPRINT(sz, snprintf, buf, len, " seconds");
-		need_sign = false;
 	}
 	int32_t nsec = ival->nsec;
 	if (nsec != 0) {
 		SPACE();
-		SNPRINT(sz, snprintf, buf, len, signed_fmt[need_sign],
+		SNPRINT(sz, snprintf, buf, len, signed_fmt[sz == 0],
 			nsec);
 		SNPRINT(sz, snprintf, buf, len, " nanoseconds");
 	}

--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -964,8 +964,9 @@ test:test("Time interval __index fields", function(test)
     local ival = date.interval.new{year = 12345, month = 123, week = 100,
                                    day = 45, hour = 48, min = 3, sec = 1,
                                    nsec = 12345678}
-    test:is(tostring(ival), '+12345 years, 123 months, 100 weeks, 45 days, 48 hours, '..
-            '3 minutes, 1.012345678 seconds', '__tostring')
+    test:is(tostring(ival), '+12345 years, 123 months, 100 weeks, 45 days, '..
+            '48 hours, 3 minutes, 1 seconds, 12345678 nanoseconds',
+            '__tostring')
 
     test:is(ival.nsec, 12345678, 'nsec')
     test:is(ival.usec, 12345, 'usec')
@@ -1115,10 +1116,12 @@ test:test("Time interval operations", function(test)
     local i1, i2
     i1 = ival_new{nsec = 1e9 - 1}
     i2 = ival_new{nsec = 2}
-    test:is(tostring(i1 + i2), '+1.000000001 seconds', 'nsec: 999999999 + 2')
+    test:is(tostring(i1 + i2), '+0 seconds, 1000000001 nanoseconds',
+            'nsec: 999999999 + 2')
     i1 = ival_new{nsec = -1e9 + 1}
     i2 = ival_new{nsec = -2}
-    test:is(tostring(i1 + i2), '-1.000000001 seconds', 'nsec: -999999999 - 2')
+    test:is(tostring(i1 + i2), '+0 seconds, -1000000001 nanoseconds',
+            'nsec: -999999999 - 2')
 
     local specific_errors = {
         {only_one_of, { nsec = 123456, usec = 123}},

--- a/test/sql-luatest/interval_test.lua
+++ b/test/sql-luatest/interval_test.lua
@@ -667,7 +667,7 @@ g.test_interval_17_3 = function()
         local t = require('luatest')
         local sql = [[SELECT CAST(itv AS STRING) FROM t0;]]
         local res = {{'+1 years, 2 months, 3 days, 4 hours'},
-                     {'+5 minutes, 6.000000007 seconds'}}
+                     {'+5 minutes, 6 seconds, 7 nanoseconds'}}
         local rows = box.execute(sql).rows
         t.assert_equals(rows, res)
     end)


### PR DESCRIPTION
Do not even try to humanize secs/nsec output, but rather
output them directly as is, without any [de]normalization.

Closes #7045