### PR TITLE
applier: add timeout to greeting read

### DIFF
--- a/changelogs/unreleased/gh-7204-replication-greeting-timeout.md
+++ b/changelogs/unreleased/gh-7204-replication-greeting-timeout.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed the bug because of which the error reason was not logged on a replica
+  in case when the master didn't send a greeting message (gh-7204).

--- a/test/replication-luatest/gh_7204_greeting_timeout_test.lua
+++ b/test/replication-luatest/gh_7204_greeting_timeout_test.lua
@@ -1,0 +1,37 @@
+local fiber = require('fiber')
+local server = require('test.luatest_helpers.server')
+local socket = require('socket')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(g)
+    g.server = server:new({
+        alias = 'master',
+        box_cfg = {
+            replication_timeout = 0.1,
+            replication_connect_timeout = 0.5,
+        },
+    })
+    g.server:start()
+end)
+
+g.after_all(function(g)
+    g.server:drop()
+end)
+
+g.test_greeting_timeout = function(g)
+    local uri = server.build_instance_uri('server')
+    local s = socket.tcp_server('unix/', uri, {
+        handler = function() fiber.sleep(9000) end
+    })
+    t.assert(s)
+    g.server:exec(function(uri)
+        box.cfg{replication = uri}
+    end, {uri})
+    t.helpers.retrying({}, function()
+        t.assert(g.server:grep_log('timed out'))
+        t.assert(g.server:grep_log('will retry'))
+    end)
+    s:close()
+end


### PR DESCRIPTION
A Tarantool server is supposed to send a greeting message right after accepting a new client so the first thing an applier does after connecting to the master is reads the greeting. It does this without timeouts. The problem is that if by mistake we connect to a wrong instance, which doesn't send anything to clients, the applier will hang forever (until the remote closes the socket), without logging any errors.

This may happen even with a valid Tarantool instance - if SSL encryption is enabled on the master, but not on the client, because the SSL protocol assumes that the client initiates a connection by writing to the socket first (before the server).

Let's add a timeout to the operation reading the greeting. The timeout is set to replication_disconnect_timeout(), after which a connection is broken if the master doesn't send heartbeats for that long. Note, we don't add a timeout to other read/write operations issued to initiate a replication connection, because if we received a greeting and it's valid, then the master is likely to be fine.

Closes #7204
Needed for https://github.com/tarantool/tarantool-ee/issues/137