### PR TITLE
fiber: don't skip fiber_obj:info() arguments

### DIFF
--- a/changelogs/unreleased/gh-7210-backtrace-for-fiber_obj-info.md
+++ b/changelogs/unreleased/gh-7210-backtrace-for-fiber_obj-info.md
@@ -1,0 +1,3 @@
+## bugfix/lua
+
+* Fixed case when fiber_obj:info() ignored options (gh-7210).

--- a/src/lua/fiber.c
+++ b/src/lua/fiber.c
@@ -317,15 +317,15 @@ lbox_fiber_top_disable(struct lua_State *L)
 
 #ifdef ENABLE_BACKTRACE
 bool
-lbox_do_backtrace(struct lua_State *L)
+lbox_do_backtrace(struct lua_State *L, int index)
 {
-	if (lua_istable(L, 1)) {
+	if (lua_istable(L, index)) {
 		lua_pushstring(L, "backtrace");
-		lua_gettable(L, 1);
-		if (lua_isnil(L, -1)){
+		lua_gettable(L, index);
+		if (lua_isnil(L, -1)) {
 			lua_pop(L, 1);
 			lua_pushstring(L, "bt");
-			lua_gettable(L, 1);
+			lua_gettable(L, index);
 		}
 		if (!lua_isnil(L, -1))
 			return lua_toboolean(L, -1);
@@ -358,7 +358,7 @@ static int
 lbox_fiber_info(struct lua_State *L)
 {
 #ifdef ENABLE_BACKTRACE
-	bool do_backtrace = lbox_do_backtrace(L);
+	bool do_backtrace = lbox_do_backtrace(L, 1);
 	if (do_backtrace) {
 		lua_newtable(L);
 		fiber_stat(lbox_fiber_statof_bt, L);
@@ -519,7 +519,7 @@ lbox_fiber_object_info(struct lua_State *L)
 	if (f == NULL)
 		luaL_error(L, "the fiber is dead");
 #ifdef ENABLE_BACKTRACE
-	bool do_backtrace = lbox_do_backtrace(L);
+	bool do_backtrace = lbox_do_backtrace(L, 2);
 	if (do_backtrace) {
 		lua_newtable(L);
 		lbox_fiber_statof_map(f, L, true);

--- a/test/app-luatest/gh_7210_backtrace_for_fiber_obj_info_test.lua
+++ b/test/app-luatest/gh_7210_backtrace_for_fiber_obj_info_test.lua
@@ -1,0 +1,8 @@
+local fiber = require('fiber')
+local t = require('luatest')
+local g = t.group()
+
+g.test_backtrace_option_for_fiber_obj = function()
+    t.assert_equals(fiber.self():info({backtrace = false}).backtrace, nil)
+    t.assert_equals(fiber.self():info({bt = false}).backtrace, nil)
+end


### PR DESCRIPTION
In b18dd47f50e817be5ef91013c5514fd6226d836d there was introduced a
way to skip backtraces in fiber.info() calls. 9da7e03e88e29b8d38ff8368fda1da4d87f6460b
was introduced `options` function for fiber object that ignored
passed options.
This patch fixed it. Currently fiber:info({backtrace = false})
returns info without backtrace.

Closes #7210