### PR TITLE
ci: fix artifacts gathering for package workflows

### DIFF
--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -71,4 +71,4 @@ jobs:
         with:
           name: centos-7
           retention-days: 21
-          path: build/usr/src/*/tarantool-*/test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -69,6 +69,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: centos-7
+          name: centos-7${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/centos_7_aarch64.yml
+++ b/.github/workflows/centos_7_aarch64.yml
@@ -65,4 +65,4 @@ jobs:
         with:
           name: centos-7
           retention-days: 21
-          path: build/usr/src/*/tarantool-*/test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -71,4 +71,4 @@ jobs:
         with:
           name: centos-8
           retention-days: 21
-          path: build/usr/src/*/tarantool-*/test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -69,6 +69,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: centos-8
+          name: centos-8${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/centos_8_aarch64.yml
+++ b/.github/workflows/centos_8_aarch64.yml
@@ -65,4 +65,4 @@ jobs:
         with:
           name: centos-8
           retention-days: 21
-          path: build/usr/src/*/tarantool-*/test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -69,6 +69,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: debian-buster
+          name: debian-buster${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -71,4 +71,4 @@ jobs:
         with:
           name: debian-buster
           retention-days: 21
-          path: build/usr/src/*/tarantool-*/test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/debian_10_aarch64.yml
+++ b/.github/workflows/debian_10_aarch64.yml
@@ -65,4 +65,4 @@ jobs:
         with:
           name: debian-buster
           retention-days: 21
-          path: build/usr/src/*/tarantool-*/test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -71,4 +71,4 @@ jobs:
         with:
           name: debian-bullseye
           retention-days: 21
-          path: build/usr/src/*/tarantool-*/test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -69,6 +69,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: debian-bullseye
+          name: debian-bullseye${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/debian_11_aarch64.yml
+++ b/.github/workflows/debian_11_aarch64.yml
@@ -65,4 +65,4 @@ jobs:
         with:
           name: debian-bullseye
           retention-days: 21
-          path: build/usr/src/*/tarantool-*/test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -71,4 +71,4 @@ jobs:
         with:
           name: debian-stretch
           retention-days: 21
-          path: build/usr/src/*/tarantool-*/test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -69,6 +69,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: debian-stretch
+          name: debian-stretch${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -32,7 +32,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CI_MAKE: make -f .travis.mk
+  CI_MAKE: make -f .gitlab.mk
 
 jobs:
   default_gcc_centos_7:
@@ -69,4 +69,4 @@ jobs:
         with:
           name: default_gcc_centos_7
           retention-days: 21
-          path: build/usr/src/*/tarantool-*/test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -71,4 +71,4 @@ jobs:
         with:
           name: fedora-34
           retention-days: 21
-          path: build/usr/src/*/tarantool-*/test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -69,6 +69,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: fedora-34
+          name: fedora-34${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/fedora_34_aarch64.yml
+++ b/.github/workflows/fedora_34_aarch64.yml
@@ -65,4 +65,4 @@ jobs:
         with:
           name: fedora-34
           retention-days: 21
-          path: build/usr/src/*/tarantool-*/test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/fedora_35.yml
+++ b/.github/workflows/fedora_35.yml
@@ -69,6 +69,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: fedora-35
+          name: fedora-35${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/fedora_35.yml
+++ b/.github/workflows/fedora_35.yml
@@ -71,4 +71,4 @@ jobs:
         with:
           name: fedora-35
           retention-days: 21
-          path: build/usr/src/*/tarantool-*/test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/fedora_35_aarch64.yml
+++ b/.github/workflows/fedora_35_aarch64.yml
@@ -65,4 +65,4 @@ jobs:
         with:
           name: fedora-35
           retention-days: 21
-          path: build/usr/src/*/tarantool-*/test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/fedora_36.yml
+++ b/.github/workflows/fedora_36.yml
@@ -69,6 +69,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: fedora-36
+          name: fedora-36${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -71,4 +71,4 @@ jobs:
         with:
           name: opensuse-leap-15.1
           retention-days: 21
-          path: build/usr/src/*/tarantool-*/test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -69,6 +69,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: opensuse-leap-15.1
+          name: opensuse-leap-15.1${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -71,4 +71,4 @@ jobs:
         with:
           name: opensuse-leap-15.2
           retention-days: 21
-          path: build/usr/src/*/tarantool-*/test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -69,6 +69,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: opensuse-leap-15.2
+          name: opensuse-leap-15.2${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -69,6 +69,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: ubuntu-xenial
+          name: ubuntu-xenial${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -71,4 +71,4 @@ jobs:
         with:
           name: ubuntu-xenial
           retention-days: 21
-          path: build/usr/src/*/tarantool-*/test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -69,6 +69,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: ubuntu-bionic
+          name: ubuntu-bionic${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -71,4 +71,4 @@ jobs:
         with:
           name: ubuntu-bionic
           retention-days: 21
-          path: build/usr/src/*/tarantool-*/test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -71,4 +71,4 @@ jobs:
         with:
           name: ubuntu-focal
           retention-days: 21
-          path: build/usr/src/*/tarantool-*/test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -69,6 +69,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: ubuntu-focal
+          name: ubuntu-focal${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/ubuntu_20_04_aarch64.yml
+++ b/.github/workflows/ubuntu_20_04_aarch64.yml
@@ -65,4 +65,4 @@ jobs:
         with:
           name: ubuntu-focal
           retention-days: 21
-          path: build/usr/src/*/tarantool-*/test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/ubuntu_21_10.yml
+++ b/.github/workflows/ubuntu_21_10.yml
@@ -69,6 +69,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: ubuntu-impish
+          name: ubuntu-impish${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/ubuntu_21_10.yml
+++ b/.github/workflows/ubuntu_21_10.yml
@@ -71,4 +71,4 @@ jobs:
         with:
           name: ubuntu-impish
           retention-days: 21
-          path: build/usr/src/*/tarantool-*/test/var/artifacts
+          path: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -69,6 +69,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: ubuntu-jammy
+          name: ubuntu-jammy${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts

--- a/.gitlab.mk
+++ b/.gitlab.mk
@@ -115,7 +115,7 @@ package: deploy_prepare
 		export VERSION="$$(echo $(GIT_DESCRIBE) | sed 's/-\([0-9]\+\)-g[0-9a-f]\+$$/.\1/' | sed 's/-/~/').dev"; \
 	fi;                                                                                                             \
 	echo VERSION=$$VERSION;                                                                                         \
-	PACKPACK_EXTRA_DOCKER_RUN_PARAMS="--network=host ${PACKPACK_EXTRA_DOCKER_RUN_PARAMS}"                           \
+	PACKPACK_EXTRA_DOCKER_RUN_PARAMS="--network=host --volume /tmp/t:/tmp/t ${PACKPACK_EXTRA_DOCKER_RUN_PARAMS}"    \
 	TARBALL_EXTRA_ARGS="--exclude=*.exe --exclude=*.dll"                                                            \
 	PRESERVE_ENVVARS="TARBALL_EXTRA_ARGS,${PRESERVE_ENVVARS}" ./packpack/packpack
 


### PR DESCRIPTION
In PR #7090 we forgot to update the path to gather failure artifacts for
many packaging workflows. Now it is fixed.

NO_DOC=ci
NO_TEST=ci
NO_CHANGELOG=ci