### PR TITLE
ci: workspace cleanup on startup

### DIFF
--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -47,6 +47,7 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/centos_7_aarch64.yml
+++ b/.github/workflows/centos_7_aarch64.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: graviton
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -47,6 +47,7 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/centos_8_aarch64.yml
+++ b/.github/workflows/centos_8_aarch64.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: graviton
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - name: Sources checkout
         uses: actions/checkout@v2.3.4
         with:

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -47,6 +47,7 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/debian_10_aarch64.yml
+++ b/.github/workflows/debian_10_aarch64.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: graviton
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -47,6 +47,7 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/debian_11_aarch64.yml
+++ b/.github/workflows/debian_11_aarch64.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: graviton
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -47,6 +47,7 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - name: Sources checkout
         uses: actions/checkout@v2.3.4
         with:

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: graviton
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -47,6 +47,7 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_34_aarch64.yml
+++ b/.github/workflows/fedora_34_aarch64.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: graviton
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_35.yml
+++ b/.github/workflows/fedora_35.yml
@@ -47,6 +47,7 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_35_aarch64.yml
+++ b/.github/workflows/fedora_35_aarch64.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: graviton
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_36.yml
+++ b/.github/workflows/fedora_36.yml
@@ -47,6 +47,7 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_36_aarch64.yml
+++ b/.github/workflows/fedora_36_aarch64.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: graviton
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/freebsd-12.yml
+++ b/.github/workflows/freebsd-12.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: freebsd-12-mcs
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/freebsd-13.yml
+++ b/.github/workflows/freebsd-13.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: freebsd-13-mcs
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0
@@ -69,6 +70,7 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       # We don't need neither deep fetch, nor submodules here.
       - uses: actions/checkout@v2.3.4
       # Don't use actions/setup-python to don't bother with proper
@@ -95,6 +97,7 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -46,6 +46,7 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -47,6 +47,7 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -47,6 +47,7 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/osx_11.yml
+++ b/.github/workflows/osx_11.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: macos-11
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/osx_11_aarch64.yml
+++ b/.github/workflows/osx_11_aarch64.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: macos-11-m1
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/osx_11_aarch64_debug.yml
+++ b/.github/workflows/osx_11_aarch64_debug.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: macos-11-m1
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/osx_11_lto.yml
+++ b/.github/workflows/osx_11_lto.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: macos-11
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/osx_12.yml
+++ b/.github/workflows/osx_12.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: macos-12
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/static_build_cmake_osx_15.yml
+++ b/.github/workflows/static_build_cmake_osx_15.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: macos-10.15
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -47,6 +47,7 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -47,6 +47,7 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -47,6 +47,7 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_20_04_aarch64.yml
+++ b/.github/workflows/ubuntu_20_04_aarch64.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: graviton
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_21_10.yml
+++ b/.github/workflows/ubuntu_21_10.yml
@@ -47,6 +47,7 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_21_10_aarch64.yml
+++ b/.github/workflows/ubuntu_21_10_aarch64.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: graviton
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -47,6 +47,7 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_22_04_aarch64.yml
+++ b/.github/workflows/ubuntu_22_04_aarch64.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: graviton
 
     steps:
+      - uses: tarantool/actions/cleanup@master
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0


### PR DESCRIPTION
Added `tarantool/actions/cleanup` action to each job which uses
self-hosted runners.
    
The action cleans workspace directory of self-hosted runner after
previous run. The main reason to add this action is 'Need a single
revision' error [1] caused by a conflict of submodule versions,
the standard `actions/checkout` action fails with this error. It's a
well-known problem and related issue [2] is still opened.
    
[1] https://github.com/tarantool/tarantool-qa/issues/145
[2] https://github.com/actions/checkout/issues/418

Closes tarantool/tarantool-qa#145