### PR TITLE
net.box: fix hang in graceful shutdown protocol

### DIFF
--- a/changelogs/unreleased/gh-7225-net-box-graceful-shutdown-hang.md
+++ b/changelogs/unreleased/gh-7225-net-box-graceful-shutdown-hang.md
@@ -1,0 +1,5 @@
+## bugfix/core
+
+* Fixed a bug in the net.box connector because of which a client could fail to
+  close its connection on receiving a shutdown request from the server, which
+  would lead to the server hanging at exit (gh-7225).


### PR DESCRIPTION
The graceful shutdown protocol works as follows:
1. The server sends a shutdown request (the box.shutdown event) to all its clients that subscribed to it.
2. Upon receiving a shutdown request, a client is supposed to close its connection.
3. The server waits for all clients subscribed to box.shutdown event to exit.
4. The server exits.

In net.box, the box.shutdown event is processed by `remote._callback`. The problem is it may occur that `remote._callback` is garbage collected while the `remote` object isn't. If this happens, the shutdown request will never get processed, and the server won't exit until the `remote` object is garbage collected, which may take forever.

Let's fix this issue by breaking the worker loop if we see that the callback was garbage collected.

Closes #7225