### PR TITLE
memtx: fix self-conflicting of transactions

### DIFF
--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -543,6 +543,7 @@ memtx_tx_abort_all_for_ddl(struct txn *ddl_owner)
 int
 memtx_tx_cause_conflict(struct txn *breaker, struct txn *victim)
 {
+	assert(breaker != victim);
 	struct tx_conflict_tracker *tracker = NULL;
 	struct rlist *r1 = breaker->conflict_list.next;
 	struct rlist *r2 = victim->conflicted_by_list.next;
@@ -620,7 +621,9 @@ memtx_tx_adjust_position_in_read_view_list(struct txn *txn)
 void
 memtx_tx_handle_conflict(struct txn *breaker, struct txn *victim)
 {
+	assert(breaker != victim);
 	assert(breaker->psn != 0);
+	assert(victim->psn == 0);
 	if (victim->status != TXN_INPROGRESS &&
 	    victim->status != TXN_IN_READ_VIEW) {
 		/* Was conflicted by somebody else. */
@@ -1405,6 +1408,7 @@ static int
 memtx_tx_save_conflict(struct txn *breaker, struct txn *victim,
 		       struct memtx_tx_conflict **conflicts_head)
 {
+	assert(breaker != victim);
 	struct memtx_tx_conflict *next_conflict;
 	next_conflict = memtx_tx_region_alloc_object(breaker,
 						     MEMTX_TX_OBJECT_CONFLICT);

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1499,7 +1499,8 @@ check_hole(struct space *space, uint32_t index,
 
 	struct point_hole_item *item = list;
 	do {
-		if (memtx_tx_save_conflict(inserter, item->txn,
+		if (inserter != item->txn &&
+		    memtx_tx_save_conflict(inserter, item->txn,
 					   collected_conflicts) != 0)
 			return -1;
 		item = rlist_entry(item->ring.next,

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1705,7 +1705,8 @@ memtx_tx_handle_gap_write(struct txn *txn, struct space *space,
 	struct full_scan_item *fsc_item, *fsc_tmp;
 	struct rlist *fsc_list = &index->full_scans;
 	rlist_foreach_entry_safe(fsc_item, fsc_list, in_full_scans, fsc_tmp) {
-		if (memtx_tx_cause_conflict(txn, fsc_item->txn) != 0)
+		if (fsc_item->txn != txn &&
+		    memtx_tx_cause_conflict(txn, fsc_item->txn) != 0)
 			return -1;
 	}
 	if (successor != NULL && !successor->is_dirty)

--- a/test/box-luatest/gh_7221_memtx_tx_dml_self_conflict_after_fsc_in_hash_idx_test.lua
+++ b/test/box-luatest/gh_7221_memtx_tx_dml_self_conflict_after_fsc_in_hash_idx_test.lua
@@ -1,0 +1,62 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new{
+        alias   = 'dflt',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    g.server:start()
+    g.server:exec(function()
+        local s = box.schema.create_space('s')
+        s:create_index('pk', {type = 'HASH'})
+    end)
+end)
+
+g.after_all(function()
+    g.server:drop()
+end)
+
+g.test_replace_self_conflict_after_fsc_in_hash_idx = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local txn_proxy = require('test.box.lua.txn_proxy')
+
+        local tx = txn_proxy:new()
+
+        tx('box.begin()')
+        tx('box.space.s:select{}')
+        tx('box.space.s:replace{0}')
+        t.assert_equals(tx:commit(), "")
+    end)
+end
+
+g.test_insert_self_conflict_after_fsc_in_hash_idx = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local txn_proxy = require('test.box.lua.txn_proxy')
+
+        local tx = txn_proxy:new()
+
+        tx('box.begin()')
+        tx('box.space.s:select{}')
+        tx('box.space.s:insert{0}')
+        t.assert_equals(tx:commit(), "")
+    end)
+end
+
+g.test_upsert_self_conflict_after_fsc_in_hash_idx = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local txn_proxy = require('test.box.lua.txn_proxy')
+
+        local tx = txn_proxy:new()
+
+        tx('box.begin()')
+        tx('box.space.s:select{}')
+        tx('box.space.s:upsert({0}, {{"=", 1, 0}})')
+        t.assert_equals(tx:commit(), "")
+    end)
+end

--- a/test/box-luatest/memtx_tx_dml_self_conflict_after_selecting_same_key_test.lua
+++ b/test/box-luatest/memtx_tx_dml_self_conflict_after_selecting_same_key_test.lua
@@ -1,0 +1,63 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local pg = t.group(nil, {{idx = 'TREE'}, {idx = 'HASH'}})
+
+pg.before_each(function(cg)
+    cg.server = server:new{
+        alias   = 'dflt',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    cg.server:start()
+    cg.server:exec(function()
+        box.schema.create_space('s')
+    end)
+    local fmt = 'box.space.s:create_index("pk", {type = "%s"})'
+    cg.server:eval(fmt:format(cg.params.idx))
+end)
+
+pg.after_each(function(cg)
+    cg.server:drop()
+end)
+
+pg.test_replace_self_conflict_after_selecting_same_key = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local txn_proxy = require('test.box.lua.txn_proxy')
+
+        local tx = txn_proxy:new()
+
+        tx('box.begin()')
+        tx('box.space.s:select{0}')
+        tx('box.space.s:replace{0}')
+        t.assert_equals(tx:commit(), "")
+    end)
+end
+
+pg.test_insert_self_conflict_after_selecting_same_key = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local txn_proxy = require('test.box.lua.txn_proxy')
+
+        local tx = txn_proxy:new()
+
+        tx('box.begin()')
+        tx('box.space.s:select{0}')
+        tx('box.space.s:insert{0}')
+        t.assert_equals(tx:commit(), "")
+    end)
+end
+
+pg.test_upsert_self_conflict_after_selecting_same_key = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local txn_proxy = require('test.box.lua.txn_proxy')
+
+        local tx = txn_proxy:new()
+
+        tx('box.begin()')
+        tx('box.space.s:select{0}')
+        tx('box.space.s:upsert({0}, {{"=", 1, 0}})')
+        t.assert_equals(tx:commit(), "")
+    end)
+end


### PR DESCRIPTION
### memtx: fix DML causing transaction self-conflict after full scan in HASH

When full scans are checked on writes, we must only conflict transactions
other than the one that did the full scan.

Closes #7221

### memtx: fix DML causing transaction self-conflict after selecting same key

On insertion, when point holes are checked on insertion, we must only
conflict transactions other than the one that read the hole.

NO_CHANGELOG=internal bugfix
NO_DOC=bugfix

Closes #7234
Closes #7235

### memtx: add assertions for self-conflicting of transactions

We assume that a transaction cannot conflict itself and that only a
non-prepared transaction can be conflicted: track these assumptions with
appropriate assertions.