### PR TITLE
test: use unix sockets in replication-py tests

### DIFF
--- a/test/replication-py/suite.ini
+++ b/test/replication-py/suite.ini
@@ -2,6 +2,7 @@
 core = tarantool
 script =  master.lua
 description = tarantool/box, replication
+use_unix_sockets = True
 is_parallel = True
 fragile = {
     "retries": 10,

--- a/test/swim/suite.ini
+++ b/test/swim/suite.ini
@@ -3,6 +3,7 @@ core = tarantool
 description = SWIM tests
 script = box.lua
 release_disabled = errinj.test.lua
+use_unix_sockets = True
 is_parallel = True
 fragile = {
     "retries": 10,


### PR DESCRIPTION
To reduce the chance to encounter the tarantool/test-run#141 issue in
replication-py/swim tests, let's switch to using unix sockets instead
of TCP ports for tarantool console.

NO_DOC=testing stuff
NO_TEST=testing stuff
NO_CHANGELOG=testing stuff