### PR TITLE
lua: fix sigint behavior in multiline input mode

### DIFF
--- a/changelogs/unreleased/gh-7109-fix-ctrl-c-in-multiline-input-mode.md
+++ b/changelogs/unreleased/gh-7109-fix-ctrl-c-in-multiline-input-mode.md
@@ -1,0 +1,3 @@
+## bugfix/lua
+
+* Fixed a bug when ctrl+c doesn't discard the input in multiline mode (gh-7109).

--- a/src/box/lua/console.lua
+++ b/src/box/lua/console.lua
@@ -617,12 +617,15 @@ local function local_read(self)
     local prompt = self.prompt
     while true do
         local delim = self.delimiter
-        local line = internal.readline({
+        local line, discard_buffer = internal.readline({
             prompt = prompt.. "> ",
             completion = self.ac and self.completion or nil
         })
         if not line then
             return nil
+        end
+        if discard_buffer then
+            return ''
         end
         buf = buf..line
         if buf:sub(1, 1) == '\\' then


### PR DESCRIPTION
This patch fixes the ctrl+c behavior in multiline mode.
The old behavior was ignoring sigint in this mode.
The new behavior is quitting this mode and printing the new
default prompt.
Added a new test for covering the mentioned case.

Follows up #2717
Closes #7109