### PR TITLE
box: fix transaction "read-view" and "conflicted" states

### DIFF
--- a/changelogs/unreleased/gh-7238-fix-conflicted-txs-in-memtx-ro-operations.md
+++ b/changelogs/unreleased/gh-7238-fix-conflicted-txs-in-memtx-ro-operations.md
@@ -1,0 +1,4 @@
+## bugfix/memtx
+
+* Fixed conflicted transactions in memtx being able to perform read-only
+  operations which gave spurious results (gh-7238).

--- a/changelogs/unreleased/gh-7240-conflicted-transactions-error-on-all-crud-operations.md
+++ b/changelogs/unreleased/gh-7240-conflicted-transactions-error-on-all-crud-operations.md
@@ -1,0 +1,10 @@
+## feature/core
+
+* **[Breaking change]** Made conflicted transactions unconditionally
+  throw `Transaction has been aborted by conflict` error on any CRUD operations
+  until they are either rolled back (which will return no error) or committed
+  (which will return the same error) (gh-7240).
+
+* Made read-view transactions become conflicted on attempt to perform DML
+  statements immediately: previously this was detected only on transaction
+  preparation stage, i.e., when calling `box.commit` (gh-7240).

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -782,6 +782,10 @@ txn_begin_ro_stmt(struct space *space, struct txn **txn,
 {
 	*txn = in_txn();
 	if (*txn != NULL) {
+		if ((*txn)->status == TXN_CONFLICTED) {
+			diag_set(ClientError, ER_TRANSACTION_CONFLICT);
+			return -1;
+		}
 		struct engine *engine = space->engine;
 		return txn_begin_in_engine(engine, *txn);
 	}

--- a/test/box-luatest/gh_6246_mvcc_different_select_behavior_test.lua
+++ b/test/box-luatest/gh_6246_mvcc_different_select_behavior_test.lua
@@ -112,7 +112,9 @@ g.test_mvcc_different_select_behavior_ro_rw = function()
         local res1 = s:select()
         local res2 = s:select(1)
         local res3 = s:count()
-        s:replace{2}
+        t.assert_error_msg_content_equals(
+            "Transaction has been aborted by conflict",
+            function() s:replace{2} end)
         t.assert_error_msg_content_equals(
             "Transaction has been aborted by conflict",
             function() box.commit() end)
@@ -146,7 +148,9 @@ g.test_mvcc_different_select_behavior_ro_rw_delete = function()
         local res1 = s:select()
         local res2 = s:select(1)
         local res3 = s:count()
-        s:replace{2}
+        t.assert_error_msg_content_equals(
+            "Transaction has been aborted by conflict",
+            function() s:replace{2} end)
         t.assert_error_msg_content_equals(
             "Transaction has been aborted by conflict",
             function() box.commit() end)

--- a/test/box-luatest/gh_6930_mvcc_isolation_levels_test.lua
+++ b/test/box-luatest/gh_6930_mvcc_isolation_levels_test.lua
@@ -148,7 +148,9 @@ g.test_mvcc_isolation_level_basics = function()
         -- With default best-effort isolation RO->RW transaction can be aborted:
         box.begin()
         res1 = s:select(1) -- read confirmed {}
-        s:replace{2}
+        t.assert_error_msg_content_equals(
+            "Transaction has been aborted by conflict",
+            function() s:replace{2} end)
         t.assert_error_msg_content_equals(
             "Transaction has been aborted by conflict",
             function() box.commit() end)

--- a/test/box-luatest/gh_6930_mvcc_net_box_iso_test.lua
+++ b/test/box-luatest/gh_6930_mvcc_net_box_iso_test.lua
@@ -98,7 +98,9 @@ g.test_mvcc_netbox_isolation_level_basics = function()
     -- With default best-effort isolation RO->RW transaction can be aborted:
     strm:begin()
     t.assert_equals(strm.space.test:select{1}, {})
-    strm.space.test:replace{2}
+    t.assert_error_msg_content_equals(
+        "Transaction has been aborted by conflict",
+        function() strm.space.test:replace{2} end)
     t.assert_error_msg_content_equals(
         "Transaction has been aborted by conflict",
         function() strm:commit() end)

--- a/test/box-luatest/gh_7025_mvcc_dirty_range_test.lua
+++ b/test/box-luatest/gh_7025_mvcc_dirty_range_test.lua
@@ -48,8 +48,10 @@ g.test_empty_range_select_left = function()
         t.assert_equals(tx(select_req), {{}})
         s:replace{key, 0}
         t.assert_equals(tx(select_req), {{}})
-        t.assert_equals(tx(replace_req), {{key, 1}})
-        t.assert_equals(tx(select_req), {{{key, 1}}})
+        t.assert_equals(tx(replace_req),
+                        {{error = "Transaction has been aborted by conflict"}})
+        t.assert_equals(tx(select_req),
+                        {{error = "Transaction has been aborted by conflict"}})
         t.assert_equals(tx:commit(),
             {{error = "Transaction has been aborted by conflict"}})
 
@@ -75,8 +77,10 @@ g.test_empty_range_select_middle = function()
         t.assert_equals(tx(select_req), {{}})
         s:replace{key, 0}
         t.assert_equals(tx(select_req), {{}})
-        t.assert_equals(tx(replace_req), {{key, 1}})
-        t.assert_equals(tx(select_req), {{{key, 1}}})
+        t.assert_equals(tx(replace_req),
+                        {{error = "Transaction has been aborted by conflict"}})
+        t.assert_equals(tx(select_req),
+                        {{error = "Transaction has been aborted by conflict"}})
         t.assert_equals(tx:commit(),
             {{error = "Transaction has been aborted by conflict"}})
 
@@ -102,8 +106,10 @@ g.test_empty_range_select_right = function()
         t.assert_equals(tx(select_req), {{}})
         s:replace{key, 0}
         t.assert_equals(tx(select_req), {{}})
-        t.assert_equals(tx(replace_req), {{key, 1}})
-        t.assert_equals(tx(select_req), {{{key, 1}}})
+        t.assert_equals(tx(replace_req),
+                        {{error = "Transaction has been aborted by conflict"}})
+        t.assert_equals(tx(select_req),
+                        {{error = "Transaction has been aborted by conflict"}})
         t.assert_equals(tx:commit(),
             {{error = "Transaction has been aborted by conflict"}})
 

--- a/test/box/tx_man.result
+++ b/test/box/tx_man.result
@@ -409,11 +409,11 @@ tx1("s:select{}")
  | ...
 tx1("s:replace{3, 13}")
  | ---
- | - - [3, 13]
+ | - - {'error': 'Transaction has been aborted by conflict'}
  | ...
 tx1("s:select{}")
  | ---
- | - - [[1, 1], [2, 2], [3, 13]]
+ | - - {'error': 'Transaction has been aborted by conflict'}
  | ...
 tx1:commit()
  | ---
@@ -2089,7 +2089,7 @@ tx2:commit()
  | ...
 tx1("s:update({1}, {{'=', 2, 3}})")
  | ---
- | - - [1, 3]
+ | - - {'error': 'Transaction has been aborted by conflict'}
  | ...
 tx1:commit()
  | ---
@@ -2369,7 +2369,8 @@ conn:execute([[UPDATE u SET column2 = 21;]])
 
 box.execute([[UPDATE u SET column2 = 22;]])
  | ---
- | - row_count: 1
+ | - null
+ | - Transaction has been aborted by conflict
  | ...
 box.execute([[COMMIT;]])
  | ---
@@ -3495,7 +3496,7 @@ s:delete{1}
  | ...
 tx1('s:replace{10, 10}') -- make an op to become RW
  | ---
- | - - [10, 10]
+ | - - {'error': 'Transaction has been aborted by conflict'}
  | ...
 tx1:commit() -- must fail since it actually saw {1, 1, "original"}
  | ---
@@ -3503,7 +3504,7 @@ tx1:commit() -- must fail since it actually saw {1, 1, "original"}
  | ...
 tx2('s:replace{11, 11}') -- make an op to become RW
  | ---
- | - - [11, 11]
+ | - - {'error': 'Transaction has been aborted by conflict'}
  | ...
 tx2:commit() -- must fail since it actually saw {1, 1, "original"}
  | ---

--- a/test/engine-luatest/gh_7238_memtx_fix_conflicted_txs_ro_operations_test.lua
+++ b/test/engine-luatest/gh_7238_memtx_fix_conflicted_txs_ro_operations_test.lua
@@ -1,0 +1,53 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local pg = t.group(nil, t.helpers.matrix({engine = {'memtx', 'vinyl'},
+                                          op = {'select', 'pairs', 'get'}}))
+
+pg.before_all(function(cg)
+    cg.server = server:new{
+        alias   = 'dflt',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    cg.server:start()
+end)
+
+pg.after_all(function(cg)
+    cg.server:drop()
+end)
+
+pg.before_each(function(cg)
+    cg.server:exec(function(engine)
+        box.schema.create_space('s', {engine = engine})
+        box.space.s:create_index('pk')
+    end, {cg.params.engine})
+end)
+
+pg.after_each(function(cg)
+    cg.server:exec(function()
+        box.space.s:drop()
+    end)
+end)
+
+--[[
+Checks that transactions in "conflicted" state unconditionally throw
+`Transaction has been aborted by conflict` error on read-only operations.
+]]
+pg.test_conflicted_txs_ro_operations = function(cg)
+    local stream1 = cg.server.net_box:new_stream()
+    local stream2 = cg.server.net_box:new_stream()
+
+    stream1:begin()
+    stream2:begin()
+
+    stream1.space.s:select{}
+    stream2.space.s:replace{0}
+    stream1.space.s:delete{0}
+    stream2:commit()
+
+    local conflict_err_msg = 'Transaction has been aborted by conflict'
+    local call = ('box.space.s:%s{0}'):format(cg.params.op)
+     t.assert_error_msg_content_equals(conflict_err_msg, function()
+         stream1:eval(call)
+     end)
+end

--- a/test/engine-luatest/gh_7239_rv_txs_conflict_on_dml_test.lua
+++ b/test/engine-luatest/gh_7239_rv_txs_conflict_on_dml_test.lua
@@ -1,0 +1,74 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local pg = t.group(nil, t.helpers.matrix({engine = {'memtx', 'vinyl'},
+                                          op = {'replace', 'insert', 'delete',
+                                                'upsert'}}))
+
+pg.before_all(function(cg)
+    cg.server = server:new{
+        alias   = 'dflt',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    cg.server:start()
+end)
+
+pg.after_all(function(cg)
+    cg.server:drop()
+end)
+
+pg.before_each(function(cg)
+    cg.server:exec(function(engine)
+        box.schema.create_space('s', {engine = engine})
+        box.space.s:create_index('pk')
+    end, {cg.params.engine})
+end)
+
+pg.after_each(function(cg)
+    cg.server:exec(function()
+        box.space.s:drop()
+    end)
+end)
+
+--[[
+Checks that transactions in "read-view" state are conflicted on attempt to
+perform DML operations.
+]]
+pg.test_gh_7239_rv_txs_conflict_on_dml = function(cg)
+    local stream1 = cg.server.net_box:new_stream()
+    local stream2 = cg.server.net_box:new_stream()
+
+    stream1:begin()
+    stream1.space.s:select{}
+
+    stream2:begin()
+    stream2.space.s:replace{0}
+    stream2:commit()
+
+    local conflict_err_msg = 'Transaction has been aborted by conflict'
+    local args = {{0}}
+    if cg.params.op == 'upsert' then
+        table.insert(args, {{'=', 2, 0}})
+    end
+    t.assert_error_msg_content_equals(conflict_err_msg, function()
+        stream1.space.s[cg.params.op](stream1.space.s, args[1], args[2])
+    end)
+end
+
+--[[
+Checks that transactions in "read-view" state which do not perform DML
+operations get committed successfully.
+]]
+pg.test_rv_txs_ro_committed_successfully = function(cg)
+    local stream1 = cg.server.net_box:new_stream()
+    local stream2 = cg.server.net_box:new_stream()
+
+    stream1:begin()
+    stream1.space.s:select{}
+
+    stream2:begin()
+    stream2.space.s:replace{0}
+    stream2:commit()
+
+    t.assert_is(stream1:commit(), nil)
+end

--- a/test/vinyl/deferred_delete.result
+++ b/test/vinyl/deferred_delete.result
@@ -560,7 +560,7 @@ sk:select{1}
 ...
 s:replace{10, 10}
 ---
-- [10, 10]
+- error: Transaction has been aborted by conflict
 ...
 box.commit() -- error
 ---

--- a/test/vinyl/hermitage.result
+++ b/test/vinyl/hermitage.result
@@ -131,7 +131,7 @@ c1:commit()
 ...
 c2("t:update(2, {{'=', 2, 22}})")
 ---
-- - [2, 22]
+- - {'error': 'Transaction has been aborted by conflict'}
 ...
 c2:commit() -- rollback
 ---
@@ -451,7 +451,7 @@ c1:commit() -- ok
 ...
 c2("t:get{1}") -- {1, 10}
 ---
-- - [1, 10]
+- - {'error': 'Transaction has been aborted by conflict'}
 ...
 c2:commit() -- rollback -- conflict
 ---
@@ -619,11 +619,11 @@ c2:commit() -- T2
 ...
 c1("t:delete{2}")
 ---
-- 
+- - {'error': 'Transaction has been aborted by conflict'}
 ...
 c1("t:get{2}") -- finds nothing
 ---
-- 
+- - {'error': 'Transaction has been aborted by conflict'}
 ...
 c1:commit() -- rollback
 ---
@@ -792,7 +792,7 @@ c3:commit() -- ok
 ...
 c1("t:replace{1, 0}")
 ---
-- - [1, 0]
+- - {'error': 'Transaction has been aborted by conflict'}
 ...
 c1:commit() -- rollback
 ---

--- a/test/vinyl/iterator.result
+++ b/test/vinyl/iterator.result
@@ -2128,14 +2128,15 @@ c("s:replace{0, 1}")
 ...
 s:upsert({1, 1}, {{'+', 2, 5}})
 ---
+- error: Transaction has been aborted by conflict
 ...
 s:select{0}
 ---
-- - [0, 0]
+- error: Transaction has been aborted by conflict
 ...
 s:select{1}
 ---
-- - [1, 15]
+- error: Transaction has been aborted by conflict
 ...
 box.commit()
 ---


### PR DESCRIPTION
Currently, there is a fundamental logical inconsistency with read-view and
conflicted states of transactions.

Conflicted transactions see all prepared changes (e.g., #7238), because
they are handled differently than read-view ones. At the same time, one
does not know the state of the transaction until `box.commit` is called.

A similar problem arises with read-view transactions: if such transactions
do any DML statements, they are de-facto conflicted, but this will only be
determined at preparation stage:
https://github.com/tarantool/tarantool/blob/79245573dabf3c1eb4eb904fd80ee84270360476/src/box/txn.c#L1006-L1013

Fix this inconsistency by the following changes:
1. Conflict "read-view" transactions on attempt to perform DML statements
immediately — guarantee this with an assertion at preparation stage.
2. Make conflicted transactions unconditionally throw "Transaction has been
aborted by conflict" error on any CRUD operations (including read-only
ones) until they are either rolled back (which will return no error) or
committed (which will return the same error).

Closes #7238
Closes #7239
Closes #7240