### PR TITLE
iostream: shutdown socket fd before close

### DIFF
--- a/changelogs/unreleased/gh-7256-iostream-shutdown.md
+++ b/changelogs/unreleased/gh-7256-iostream-shutdown.md
@@ -1,0 +1,6 @@
+## bugfix/core
+
+* Fixed a bug because of which a net.box connection was not properly terminated
+  when the process had a child (for example, started with `popen`) sharing the
+  connection socket fd. The bug could lead to a server hanging at exit while
+  executing the graceful shutdown protocol (gh-7256).

--- a/src/lib/core/iostream.c
+++ b/src/lib/core/iostream.c
@@ -9,6 +9,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <stddef.h>
+#include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -33,6 +34,12 @@ iostream_close(struct iostream *io)
 {
 	int fd = io->fd;
 	iostream_destroy(io);
+	/*
+	 * Explicitly shut down the socket before closing its fd so that
+	 * the connection will be terminated even if the Tarantool process
+	 * forked and the child process did not close parent fds.
+	 */
+	shutdown(fd, SHUT_RDWR);
 	close(fd);
 }
 


### PR DESCRIPTION
If a socket fd is shared by a child process, closing it in the parent will not shut down the underlying connection. As a result, the server may hang executing the graceful shutdown protocol. Fix this problem by explicitly shutting down the connection socket fd before closing it.

This is a recommended way to terminate a Unix socket connection, see http://www.faqs.org/faqs/unix-faq/socket/#:~:text=2.6.%20%20When%20should%20I%20use%20shutdown()%3F

While we are at it, let's also set the shutdown timeout for instances created by Luatest to infinity so that we can catch bugs like this early.

Closes #6820
Closes #7256