### PR TITLE
Split brain detection

### DIFF
--- a/changelogs/unreleased/fix-relay-being-stuck.md
+++ b/changelogs/unreleased/fix-relay-being-stuck.md
@@ -1,0 +1,3 @@
+## bugfix/replication
+
+* Fix replication being stuck occasionally for no obvious reasons.

--- a/changelogs/unreleased/gh-5295-split-brain-detection.md
+++ b/changelogs/unreleased/gh-5295-split-brain-detection.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed a possible split-brain when old synchro queue owner might finalize the
+  transactions in presence of a new synchro queue owner (gh-5295).

--- a/changelogs/unreleased/gh-5295-split-brain-detection.md
+++ b/changelogs/unreleased/gh-5295-split-brain-detection.md
@@ -2,3 +2,8 @@
 
 * Fixed a possible split-brain when old synchro queue owner might finalize the
   transactions in presence of a new synchro queue owner (gh-5295).
+
+* Fixed servers not noticing possible split-brain situations, for example when
+  multiple leaders were working independently due to manually lowered quorum.
+  Once a node discovers that it received some foreign data, it immediately
+  stops replication from such a node with ER_SPLIT_BRAIN error (gh-5295).

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -1183,14 +1183,6 @@ apply_final_join_tx(uint32_t replica_id, struct stailq *rows)
 static void
 applier_synchro_filter_tx(struct stailq *rows)
 {
-	/*
-	 * XXX: in case raft is disabled, synchronous replication still works
-	 * but without any filtering. That might lead to issues with
-	 * unpredictable confirms after rollbacks which are supposed to be
-	 * fixed by the filtering.
-	 */
-	if (!raft_is_enabled(box_raft()))
-		return;
 	struct xrow_header *row;
 	/*
 	 * It  may happen that we receive the instance's rows via some third

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3996,6 +3996,13 @@ box_cfg_xc(void)
 	if (box_set_election_mode() != 0)
 		diag_raise();
 
+	/*
+	 * Enable split brain detection once node is fully recovered or
+	 * bootstrapped. No split brain could happen during bootstrap or local
+	 * recovery.
+	 */
+	txn_limbo_filter_enable(&txn_limbo);
+
 	title("running");
 	say_info("ready to accept requests");
 

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -296,6 +296,7 @@ struct errcode_record {
 	/*241 */_(ER_WRONG_SPACE_UPGRADE_OPTIONS, "Wrong space upgrade options: %s") \
 	/*242 */_(ER_NO_ELECTION_QUORUM,	"Not enough peers connected to start elections: %d out of minimal required %d")\
 	/*243 */_(ER_SSL,			"%s") \
+	/*244 */_(ER_SPLIT_BRAIN,		"Split-Brain discovered: %s") \
 
 /*
  * !IMPORTANT! Please follow instructions at start of the file

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -330,8 +330,7 @@ memtx_engine_recover_synchro(const struct xrow_header *row)
 	 * because all its rows have a zero replica_id.
 	 */
 	req.origin_id = req.replica_id;
-	txn_limbo_process(&txn_limbo, &req);
-	return 0;
+	return txn_limbo_process(&txn_limbo, &req);
 }
 
 static int

--- a/src/box/raft.c
+++ b/src/box/raft.c
@@ -287,7 +287,7 @@ box_raft_fence(void)
 	    !election_fencing_enabled || box_raft_election_fencing_paused)
 		return;
 
-	txn_limbo_freeze(&txn_limbo);
+	txn_limbo_fence(&txn_limbo);
 	raft_resign(raft);
 }
 
@@ -563,7 +563,7 @@ box_raft_set_election_fencing_enabled(bool enabled)
 	election_fencing_enabled = enabled;
 	say_info("RAFT: fencing %s", enabled ? "enabled" : "disabled");
 	if (!enabled)
-		txn_limbo_unfreeze(&txn_limbo);
+		txn_limbo_unfence(&txn_limbo);
 	replicaset_on_health_change();
 }
 

--- a/src/box/relay.h
+++ b/src/box/relay.h
@@ -141,6 +141,6 @@ relay_final_join(struct iostream *io, uint64_t sync,
 void
 relay_subscribe(struct replica *replica, struct iostream *io, uint64_t sync,
 		struct vclock *replica_vclock, uint32_t replica_version_id,
-		uint32_t replica_id_filter);
+		uint32_t replica_id_filter, uint64_t sent_raft_term);
 
 #endif /* TARANTOOL_REPLICATION_RELAY_H_INCLUDED */

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -464,6 +464,13 @@ txn_limbo_read_confirm(struct txn_limbo *limbo, int64_t lsn)
 		assert(e->txn->signature >= 0);
 		txn_complete_success(e->txn);
 	}
+	/*
+	 * Track CONFIRM lsn on replica in order to detect split-brain by
+	 * comparing existing confirm_lsn with the one arriving from a remote
+	 * instance.
+	 */
+	if (limbo->confirmed_lsn < lsn)
+		limbo->confirmed_lsn = lsn;
 }
 
 /**

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -365,7 +365,7 @@ txn_limbo_rollback(struct txn_limbo *limbo)
  * Prepare a limbo request for WAL write and commit. Similar to txn_stmt
  * prepare.
  */
-void
+int
 txn_limbo_req_prepare(struct txn_limbo *limbo,
 		      const struct synchro_request *req);
 
@@ -386,7 +386,7 @@ txn_limbo_req_commit(struct txn_limbo *limbo,
 		     const struct synchro_request *req);
 
 /** Process a synchronous replication request. */
-void
+int
 txn_limbo_process(struct txn_limbo *limbo, const struct synchro_request *req);
 
 /**
@@ -411,14 +411,14 @@ txn_limbo_checkpoint(const struct txn_limbo *limbo,
  * Write a PROMOTE request, which has the same effect as CONFIRM(@a lsn) and
  * ROLLBACK(@a lsn + 1) combined.
  */
-void
+int
 txn_limbo_write_promote(struct txn_limbo *limbo, int64_t lsn, uint64_t term);
 
 /**
  * Write a DEMOTE request.
  * It has the same effect as PROMOTE and additionally clears limbo ownership.
  */
-void
+int
 txn_limbo_write_demote(struct txn_limbo *limbo, int64_t lsn, uint64_t term);
 
 /**

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -207,6 +207,12 @@ struct txn_limbo {
 			 * remote instance.
 			 */
 			bool is_frozen_due_to_fencing : 1;
+			/*
+			 * This mode is always on upon node start and is turned
+			 * off by any new PROMOTE arriving either via
+			 * replication or issued by the node.
+			 */
+			bool is_frozen_until_promotion : 1;
 		};
 	};
 };

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -462,6 +462,7 @@ t;
  |   241: box.error.WRONG_SPACE_UPGRADE_OPTIONS
  |   242: box.error.NO_ELECTION_QUORUM
  |   243: box.error.SSL
+ |   244: box.error.SPLIT_BRAIN
  | ...
 
 test_run:cmd("setopt delimiter ''");

--- a/test/replication-luatest/gh_5295_split_brain_test.lua
+++ b/test/replication-luatest/gh_5295_split_brain_test.lua
@@ -1,0 +1,240 @@
+local t = require('luatest')
+local cluster = require('test.luatest_helpers.cluster')
+local server = require('test.luatest_helpers.server')
+
+local g = t.group('gh-5295')
+
+-- To distinguish replicas by name
+local test_id = 0
+
+-- gh-5295: the server should stop replication from an upstream which sends data
+-- conflicting in terms of promote / confirmed_lsn.
+--
+-- The test requires one instance in replicaset per each split-brain case, plus
+-- one "main" instance. The idea of each test case is first to join the instance
+-- and then partition it from the main server. Once partitioned, create a
+-- split-brain situation between the partitioned node and main. Then check that
+-- the partitioned node can't reconnect.
+
+g.before_all(function(cg)
+    cg.cluster = cluster:new({})
+
+    cg.box_cfg = {
+        replication_timeout         = 0.1,
+        replication_synchro_quorum  = 1,
+        replication_synchro_timeout = 0.01,
+        election_mode               = 'manual',
+        election_timeout            = 0.1,
+        election_fencing_enabled    = false,
+        log_level                   = 6,
+    }
+
+    cg.main = cg.cluster:build_and_add_server{
+        alias = 'main',
+        box_cfg = cg.box_cfg,
+    }
+    cg.cluster:start()
+
+    cg.main:exec(function()
+        box.ctl.promote()
+        box.ctl.wait_rw()
+        local s = box.schema.space.create('sync', {is_sync = true})
+        s:create_index('pk')
+        s = box.schema.space.create('async')
+        s:create_index('pk')
+        -- Check the test correctness.
+        assert(box.info.id == 1)
+    end)
+end)
+
+local function update_replication(...)
+    return box.cfg{replication = {...}}
+end
+
+g.before_each(function(cg)
+    -- Check that the servers start synced and with main being leader.
+    -- It's a prerequisite for each test.
+    cg.main:exec(function()
+        require('luatest').assert_equals(box.info.synchro.queue.owner,
+                                         box.info.id, 'main node is leader')
+    end)
+
+    test_id = test_id + 1
+    cg.box_cfg.replication = {
+            server.build_instance_uri('main'),
+            server.build_instance_uri('split_replica'..test_id),
+    }
+    cg.split_replica = cg.cluster:build_and_add_server{
+        alias = 'split_replica'..test_id,
+        box_cfg = cg.box_cfg,
+    }
+    cg.split_replica:start()
+    t.helpers.retrying({}, function()
+        cg.split_replica:assert_follows_upstream(1)
+    end)
+
+    cg.main:exec(update_replication, cg.box_cfg.replication)
+    t.helpers.retrying({}, function()
+        cg.main:assert_follows_upstream(2)
+    end)
+end)
+
+-- Drop the partitioned server after each case of split-brain.
+g.after_each(function(cg)
+    cg.split_replica:stop()
+    cg.split_replica:cleanup()
+    -- Drop the replica's cluster entry, so that next one receives same id.
+    cg.main:exec(function() box.space._cluster:delete{2} end)
+    cg.cluster.servers[2] = nil
+end)
+
+g.after_all(function(cg)
+    cg.cluster:drop()
+    cg.cluster.servers = nil
+end)
+
+local function partition_replica(cg)
+    -- Each partitioning starts on synced servers.
+    cg.split_replica:wait_vclock_of(cg.main)
+    cg.main:wait_vclock_of(cg.split_replica)
+    cg.split_replica:exec(update_replication, {})
+    cg.main:exec(update_replication, {})
+end
+
+local function reconnect_and_check_split_brain(srv)
+    srv:exec(update_replication, {server.build_instance_uri('main')})
+    t.helpers.retrying({}, srv.exec, srv, function()
+        local upstream = box.info.replication[1].upstream
+        local t = require('luatest')
+        t.assert_equals(upstream.status, 'stopped', 'replication is stopped')
+        t.assert_str_contains(upstream.message, 'Split-Brain discovered: ',
+                              false, 'split-brain is discovered')
+    end)
+end
+
+local function write_promote()
+    local t = require('luatest')
+    t.assert_not_equals(box.info.synchro.queue.owner,  box.info.id,
+                        "Promoting a follower")
+    box.ctl.promote()
+    box.ctl.wait_rw()
+    t.helpers.retrying({}, function()
+        t.assert_equals(box.info.synchro.queue.owner, box.info.id,
+                        "Promote succeeded")
+    end)
+end
+
+local function write_demote()
+    local t = require('luatest')
+    t.assert_equals(box.info.synchro.queue.owner, box.info.id,
+                    "Demoting the leader")
+    box.cfg{election_mode = 'off'}
+    box.ctl.demote()
+    box.cfg{election_mode = 'manual'}
+    t.assert_equals(box.info.synchro.queue.owner, 0, "Demote succeeded")
+end
+
+-- Any async transaction performed in an obsolete term means a split-brain.
+g.test_async_old_term = function(cg)
+    partition_replica(cg)
+    cg.split_replica:exec(write_promote)
+    cg.main:exec(function() box.space.async:replace{1} end)
+    reconnect_and_check_split_brain(cg.split_replica)
+end
+
+-- Any unseen sync transaction confirmation from an obsolete term means a
+-- split-brain.
+g.test_confirm_old_term = function(cg)
+    partition_replica(cg)
+    cg.split_replica:exec(write_promote)
+    cg.main:exec(function() box.space.sync:replace{1} end)
+    reconnect_and_check_split_brain(cg.split_replica)
+end
+
+-- Any unseen sync transaction rollback from an obsolete term means a
+-- split-brain.
+g.test_rollback_old_term = function(cg)
+    partition_replica(cg)
+    cg.split_replica:exec(write_promote)
+    cg.main:exec(function()
+        box.cfg{replication_synchro_quorum = 31}
+        pcall(box.space.sync.replace, box.space.sync, {1})
+        box.cfg{replication_synchro_quorum = 1}
+    end)
+    reconnect_and_check_split_brain(cg.split_replica)
+end
+
+-- Conflicting demote for the same term is a split-brain.
+g.test_demote_same_term = function(cg)
+    partition_replica(cg)
+    cg.split_replica:exec(write_promote)
+    cg.main:exec(write_demote)
+    reconnect_and_check_split_brain(cg.split_replica)
+    cg.main:exec(write_promote)
+end
+
+-- Conflicting promote for the same term is a split-brain.
+g.test_promote_same_term = function(cg)
+    cg.main:exec(write_demote)
+    partition_replica(cg)
+    cg.split_replica:exec(write_promote)
+    cg.main:exec(write_promote)
+    reconnect_and_check_split_brain(cg.split_replica)
+end
+
+-- Promote from a bigger term with lsn < confirmed_lsn is a split brain.
+g.test_promote_new_term_small_lsn = function(cg)
+    cg.split_replica:exec(write_promote)
+    partition_replica(cg)
+    cg.split_replica:exec(function() box.space.sync:replace{1} end)
+    cg.main:exec(write_promote)
+    reconnect_and_check_split_brain(cg.split_replica)
+end
+
+local function fill_queue_and_write(server)
+    local wal_write_count = server:exec(function()
+        local fiber = require('fiber')
+        box.cfg{
+            replication_synchro_quorum = 31,
+            replication_synchro_timeout = 1000,
+        }
+        local write_cnt = box.error.injection.get('ERRINJ_WAL_WRITE_COUNT')
+        fiber.new(box.space.sync.replace, box.space.sync, {1})
+        return write_cnt
+    end)
+    t.helpers.retrying({}, server.exec, server, function(cnt)
+        local t = require('luatest')
+        local new_cnt = box.error.injection.get('ERRINJ_WAL_WRITE_COUNT')
+        t.assert(new_cnt > cnt, 'WAL write succeeded')
+    end, {wal_write_count})
+end
+
+local function perform_rollback(server)
+    assert(server:exec(function() return box.info.synchro.queue.len end) > 0)
+    server:exec(function() box.cfg{replication_synchro_timeout = 0.01} end)
+    t.helpers.retrying({delay = 0.1}, server.exec, server, function()
+        require('luatest').assert_equals(box.info.synchro.queue.len, 0,
+                                         'Rollback happened')
+    end)
+end
+
+-- Promote from a bigger term with lsn > confirmed_lsn is a split brain.
+g.test_promote_new_term_big_lsn = function(cg)
+    cg.split_replica:exec(write_promote)
+    fill_queue_and_write(cg.split_replica)
+    partition_replica(cg)
+    perform_rollback(cg.split_replica)
+    cg.main:exec(write_promote)
+    reconnect_and_check_split_brain(cg.split_replica)
+end
+
+-- Promote from a bigger term with conflicting queue contents is a split brain.
+g.test_promote_new_term_conflicting_queue = function(cg)
+    cg.split_replica:exec(write_promote)
+    fill_queue_and_write(cg.split_replica)
+    partition_replica(cg)
+    perform_rollback(cg.split_replica)
+    cg.main:exec(write_promote)
+    fill_queue_and_write(cg.split_replica)
+    reconnect_and_check_split_brain(cg.split_replica)
+end

--- a/test/replication-luatest/gh_5295_split_brain_test.lua
+++ b/test/replication-luatest/gh_5295_split_brain_test.lua
@@ -23,7 +23,6 @@ g.before_all(function(cg)
         replication_timeout         = 0.1,
         replication_synchro_quorum  = 1,
         replication_synchro_timeout = 0.01,
-        election_mode               = 'manual',
         election_timeout            = 0.1,
         election_fencing_enabled    = false,
         log_level                   = 6,

--- a/test/replication-luatest/suite.ini
+++ b/test/replication-luatest/suite.ini
@@ -2,4 +2,4 @@
 core = luatest
 description = replication luatests
 is_parallel = True
-release_disabled = gh_6036_qsync_order_test.lua gh_6842_qsync_applier_order_test.lua
+release_disabled = gh_5295_split_brain_test.lua gh_6036_qsync_order_test.lua gh_6842_qsync_applier_order_test.lua

--- a/test/replication/gh-5140-qsync-casc-rollback.result
+++ b/test/replication/gh-5140-qsync-casc-rollback.result
@@ -206,6 +206,10 @@ box.space.sync:select{}
  |   - [4]
  | ...
 
+box.ctl.promote()
+ | ---
+ | ...
+
 box.space.sync:drop()
  | ---
  | ...

--- a/test/replication/gh-5140-qsync-casc-rollback.test.lua
+++ b/test/replication/gh-5140-qsync-casc-rollback.test.lua
@@ -97,6 +97,8 @@ test_run:switch('default')
 box.space.async:select{}
 box.space.sync:select{}
 
+box.ctl.promote()
+
 box.space.sync:drop()
 box.space.async:drop()
 

--- a/test/replication/gh-5163-qsync-restart-crash.result
+++ b/test/replication/gh-5163-qsync-restart-crash.result
@@ -30,6 +30,9 @@ box.space.sync:select{}
  | ---
  | - - [1]
  | ...
+box.ctl.promote()
+ | ---
+ | ...
 box.space.sync:drop()
  | ---
  | ...

--- a/test/replication/gh-5163-qsync-restart-crash.test.lua
+++ b/test/replication/gh-5163-qsync-restart-crash.test.lua
@@ -12,5 +12,6 @@ box.ctl.promote()
 box.space.sync:replace{1}
 test_run:cmd('restart server default')
 box.space.sync:select{}
+box.ctl.promote()
 box.space.sync:drop()
 box.ctl.demote()

--- a/test/replication/gh-5288-qsync-recovery.result
+++ b/test/replication/gh-5288-qsync-recovery.result
@@ -25,6 +25,9 @@ box.snapshot()
  | ...
 test_run:cmd('restart server default')
  | 
+box.ctl.promote()
+ | ---
+ | ...
 box.space.sync:drop()
  | ---
  | ...

--- a/test/replication/gh-5288-qsync-recovery.test.lua
+++ b/test/replication/gh-5288-qsync-recovery.test.lua
@@ -9,5 +9,6 @@ box.ctl.promote()
 s:insert{1}
 box.snapshot()
 test_run:cmd('restart server default')
+box.ctl.promote()
 box.space.sync:drop()
 box.ctl.demote()

--- a/test/replication/gh-5298-qsync-recovery-snap.result
+++ b/test/replication/gh-5298-qsync-recovery-snap.result
@@ -43,58 +43,16 @@ box.snapshot()
 test_run:cmd("restart server default")
  | 
 
--- Could hang if the limbo would incorrectly handle the snapshot end.
-box.space.sync:replace{11}
+-- Would be non-empty if limbo would incorrectly handle the snapshot end.
+box.info.synchro.queue.len
  | ---
- | - [11]
+ | - 0
  | ...
 
-old_synchro_quorum = box.cfg.replication_synchro_quorum
- | ---
- | ...
-old_synchro_timeout = box.cfg.replication_synchro_timeout
+box.ctl.promote()
  | ---
  | ...
 
-box.cfg{                                                                        \
-    replication_synchro_timeout = 0.001,                                        \
-    replication_synchro_quorum = 2,                                             \
-}
- | ---
- | ...
-box.space.sync:replace{12}
- | ---
- | - error: Quorum collection for a synchronous transaction is timed out
- | ...
-
-box.cfg{                                                                        \
-    replication_synchro_timeout = 1000,                                         \
-    replication_synchro_quorum = 1,                                             \
-}
- | ---
- | ...
-box.space.sync:replace{13}
- | ---
- | - [13]
- | ...
-box.space.sync:get({11})
- | ---
- | - [11]
- | ...
-box.space.sync:get({12})
- | ---
- | ...
-box.space.sync:get({13})
- | ---
- | - [13]
- | ...
-
-box.cfg{                                                                        \
-    replication_synchro_timeout = old_synchro_timeout,                          \
-    replication_synchro_quorum = old_synchro_quorum,                            \
-}
- | ---
- | ...
 box.space.sync:drop()
  | ---
  | ...

--- a/test/replication/gh-5298-qsync-recovery-snap.test.lua
+++ b/test/replication/gh-5298-qsync-recovery-snap.test.lua
@@ -20,31 +20,11 @@ box.snapshot()
 
 test_run:cmd("restart server default")
 
--- Could hang if the limbo would incorrectly handle the snapshot end.
-box.space.sync:replace{11}
+-- Would be non-empty if limbo would incorrectly handle the snapshot end.
+box.info.synchro.queue.len
 
-old_synchro_quorum = box.cfg.replication_synchro_quorum
-old_synchro_timeout = box.cfg.replication_synchro_timeout
+box.ctl.promote()
 
-box.cfg{                                                                        \
-    replication_synchro_timeout = 0.001,                                        \
-    replication_synchro_quorum = 2,                                             \
-}
-box.space.sync:replace{12}
-
-box.cfg{                                                                        \
-    replication_synchro_timeout = 1000,                                         \
-    replication_synchro_quorum = 1,                                             \
-}
-box.space.sync:replace{13}
-box.space.sync:get({11})
-box.space.sync:get({12})
-box.space.sync:get({13})
-
-box.cfg{                                                                        \
-    replication_synchro_timeout = old_synchro_timeout,                          \
-    replication_synchro_quorum = old_synchro_quorum,                            \
-}
 box.space.sync:drop()
 box.space.loc:drop()
 box.ctl.demote()

--- a/test/replication/gh-5874-qsync-txn-recovery.result
+++ b/test/replication/gh-5874-qsync-txn-recovery.result
@@ -154,6 +154,10 @@ loc:select()
  |   - [2]
  |   - [3]
  | ...
+
+box.ctl.promote()
+ | ---
+ | ...
 async:drop()
  | ---
  | ...

--- a/test/replication/gh-5874-qsync-txn-recovery.test.lua
+++ b/test/replication/gh-5874-qsync-txn-recovery.test.lua
@@ -80,6 +80,8 @@ loc = box.space.loc
 async:select()
 sync:select()
 loc:select()
+
+box.ctl.promote()
 async:drop()
 sync:drop()
 loc:drop()

--- a/test/replication/suite.cfg
+++ b/test/replication/suite.cfg
@@ -18,6 +18,7 @@
     "gh-4424-misc-orphan-on-reconfiguration-error.test.lua": {},
     "gh-5213-qsync-applier-order.test.lua": {},
     "gh-5213-qsync-applier-order-3.test.lua": {},
+    "gh-5288-qsync-recovery.test.lua": {},
     "gh-5426-election-on-off.test.lua": {},
     "gh-5430-cluster-mvcc.test.lua": {},
     "gh-5433-election-restart-recovery.test.lua": {},


### PR DESCRIPTION
Split-brain machinery: filters that monitor PROMOTE, DEMOTE, CONFIRM, ROLLBACK coming from remote nodes, and raise an error, when the requests are conflicting with the node's local state.
Note, any asynchronous transaction coming from an obsolete journal term is treated as a sign of split-brain.

Closes #5295
Closes #6133 