### PR TITLE
luajit: bump submodule

### DIFF
--- a/changelogs/unreleased/gh-7264-dump-proto-default-mode.md
+++ b/changelogs/unreleased/gh-7264-dump-proto-default-mode.md
@@ -1,0 +1,5 @@
+## bugfix/luajit
+
+* Disabled proto and trace information dumpers in sysprof's
+default mode. Attempts to use them lead to segmentation fault
+due to uninitialized buffer.


### PR DESCRIPTION
sysprof: disable proto and trace dumps in default

Closes #7264

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump
NO_CHANGELOG=LuaJIT submodule bump