### PR TITLE
test: fix flaky viny/tx_gap_lock test

### DIFF
--- a/test/vinyl/tx_gap_lock.result
+++ b/test/vinyl/tx_gap_lock.result
@@ -1311,13 +1311,13 @@ function gen_tuple(payload)
 end;
 ---
 ...
-function cmp_tuple(t1, t2)
+function tuple_equals(t1, t2)
     for i = 1, PAYLOAD_FIELD do
         if t1[i] ~= t2[i] then
-            return t1[i] > t2[i] and 1 or -1
+            return false
         end
     end
-    return 0
+    return true
 end;
 ---
 ...
@@ -1373,7 +1373,7 @@ for i = 1, TX_COUNT do
         local result = loadstring('return ' .. sel.cmd)()
         if #result == #sel.result then
             for k, v in ipairs(result) do
-                if cmp_tuple(v, sel.result[k]) ~= 0 then
+                if not tuple_equals(v, sel.result[k]) then
                     tx.should_abort = true
                     break
                 end

--- a/test/vinyl/tx_gap_lock.test.lua
+++ b/test/vinyl/tx_gap_lock.test.lua
@@ -438,13 +438,13 @@ function gen_tuple(payload)
     return t
 end;
 
-function cmp_tuple(t1, t2)
+function tuple_equals(t1, t2)
     for i = 1, PAYLOAD_FIELD do
         if t1[i] ~= t2[i] then
-            return t1[i] > t2[i] and 1 or -1
+            return false
         end
     end
-    return 0
+    return true
 end;
 
 function gen_select()
@@ -493,7 +493,7 @@ for i = 1, TX_COUNT do
         local result = loadstring('return ' .. sel.cmd)()
         if #result == #sel.result then
             for k, v in ipairs(result) do
-                if cmp_tuple(v, sel.result[k]) ~= 0 then
+                if not tuple_equals(v, sel.result[k]) then
                     tx.should_abort = true
                     break
                 end


### PR DESCRIPTION
The `cmp_tuple` helper function is broken - it assumes that all tuple fields, including the payload, are numeric. It isn't true - the payload field is either nil or string. This results in a false-positive test failure:

```
error: '[string "function cmp_tuple(t1, t2)     for i = 1, PAY..."]:1:
       attempt to compare nil with string'
```

Closes #6336