### PR TITLE
fiber: don't crash on wakeup with dead fibers

### DIFF
--- a/changelogs/unreleased/gh-5843-fiber-wakeup.md
+++ b/changelogs/unreleased/gh-5843-fiber-wakeup.md
@@ -1,0 +1,6 @@
+## bugfix/core
+
+* Remove assertion raised in case of `fiber_wakeup()` get called with
+  dead fibers. Due to backward compatibility we've allowed such calls
+  for release builds but not for debug builds. In result there
+  was inconsistency between program behaviour (gh-5843).

--- a/test/unit/fiber.cc
+++ b/test/unit/fiber.cc
@@ -255,6 +255,21 @@ fiber_wakeup_self_test()
 }
 
 static void
+fiber_wakeup_dead_test()
+{
+	header();
+
+	struct fiber *fiber = fiber_new_xc("wakeup_dead", noop_f);
+	fiber_set_joinable(fiber, true);
+	fiber_start(fiber);
+	fiber_wakeup(fiber);
+	fiber_wakeup(fiber);
+	fiber_join(fiber);
+
+	footer();
+}
+
+static void
 fiber_dead_while_in_cache_test(void)
 {
 	header();
@@ -299,6 +314,7 @@ main_f(va_list ap)
 	fiber_join_test();
 	fiber_stack_test();
 	fiber_wakeup_self_test();
+	fiber_wakeup_dead_test();
 	fiber_dead_while_in_cache_test();
 	fiber_flags_respect_test();
 	ev_break(loop(), EVBREAK_ALL);

--- a/test/unit/fiber.result
+++ b/test/unit/fiber.result
@@ -19,6 +19,8 @@ OutOfMemory: Failed to allocate 42 bytes in allocator for exception
 	*** fiber_stack_test: done ***
 	*** fiber_wakeup_self_test ***
 	*** fiber_wakeup_self_test: done ***
+	*** fiber_wakeup_dead_test ***
+	*** fiber_wakeup_dead_test: done ***
 	*** fiber_dead_while_in_cache_test ***
 	*** fiber_dead_while_in_cache_test: done ***
 	*** fiber_flags_respect_test ***


### PR DESCRIPTION
When fiber has finished its work it ended up in two cases:
1) If no "joinable" attribute set then the fiber is
   simply recycled
2) Otherwise it continue hanging around waiting to be
   joined.

Our API allows to call fiber_wakeup() for dead but joinable
fibers (2) in release builds without any side effects, such
fibers are simply ignored, in turn for debug builds this
cause assertion to trigger. We can't change our API for
backward compatibility sake but same time we must not
preserve different behaviour between release and debug
builds since this brings inconsistency. Thus lets get
rid of assertion call and allow to call fiber_wakeup
in debug build as well.

Fixes #5843

NO_DOC=bug fix

Signed-off-by: Cyrill Gorcunov <gorcunov@gmail.com>