### PR TITLE
box: fix exclude_null for json and multikey indexes

### DIFF
--- a/changelogs/unreleased/gh-5861-exclude-null.md
+++ b/changelogs/unreleased/gh-5861-exclude-null.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fixed `exclude_null` index option for multikey and JSON indexes (gh-5861).

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -598,23 +598,6 @@ index_delete(struct index *index)
 	index_def_delete(def);
 }
 
-struct tuple *
-index_filter_tuple_slow(struct index *index, struct tuple *tuple)
-{
-	if (tuple == NULL)
-		return tuple;
-	struct key_def* key_def = index->def->key_def;
-	struct key_part* parts = key_def->parts;
-	for (uint32_t i = 0; i < key_def->part_count; ++i) {
-		if (!parts[i].exclude_null)
-			continue;
-		const char* field = tuple_field(tuple, parts[i].fieldno);
-		if (field != NULL && mp_typeof(*field) == MP_NIL)
-			return NULL;
-	}
-	return tuple;
-}
-
 /* }}} */
 
 /* {{{ Virtual method stubs */

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -726,35 +726,11 @@ index_get(struct index *index, const char *key,
 	return index->vtab->get(index, key, part_count, result);
 }
 
-/**
- * Get tuple to be inserted in index, based on index-specific constraints
- * (current constraint: if exclude_null = true, return NULL)
- */
-struct tuple *
-index_filter_tuple_slow(struct index *index, struct tuple *tuple);
-
-/**
- * @copydoc index_filter_tuple_slow()
- */
-static inline struct tuple *
-index_filter_tuple(struct index *index, struct tuple *tuple) {
-	struct key_def* key_def = index->def->key_def;
-	if (!key_def->has_exclude_null)
-		return tuple;
-	return index_filter_tuple_slow(index, tuple);
-}
-
 static inline int
 index_replace(struct index *index, struct tuple *old_tuple,
 	      struct tuple *new_tuple, enum dup_replace_mode mode,
 	      struct tuple **result, struct tuple **successor)
 {
-	old_tuple = index_filter_tuple(index, old_tuple);
-	new_tuple = index_filter_tuple(index, new_tuple);
-	if (old_tuple == NULL && new_tuple == NULL) {
-		*result = NULL;
-		return 0;
-	}
 	return index->vtab->replace(index, old_tuple, new_tuple, mode,
 				    result, successor);
 }

--- a/src/box/key_def.h
+++ b/src/box/key_def.h
@@ -879,6 +879,30 @@ bool
 tuple_key_contains_null(struct tuple *tuple, struct key_def *def,
 			int multikey_idx);
 
+/** Slow path of tuple_key_is_excluded(). */
+bool
+tuple_key_is_excluded_slow(struct tuple *tuple, struct key_def *def,
+			   int multikey_idx);
+
+/**
+ * Check if a tuple should be excluded from an index.
+ * @param tuple Tuple to check.
+ * @param def Key definition to check the tuple against.
+ * @param multikey_idx Multikey index hint.
+ * @retval true if the tuple key should be excluded from the index.
+ *
+ * We exclude a tuple if any of its key fields contains null and
+ * the index has the 'exclude_null' flag set.
+ */
+static inline bool
+tuple_key_is_excluded(struct tuple *tuple, struct key_def *def,
+		      int multikey_idx)
+{
+	if (likely(!def->has_exclude_null))
+		return false;
+	return tuple_key_is_excluded_slow(tuple, def, multikey_idx);
+}
+
 /**
  * Check that tuple fields match with given key definition
  * key_def.

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -1854,14 +1854,12 @@ vy_perform_update(struct vy_env *env, struct vy_tx *tx, struct txn_stmt *stmt,
 		return -1;
 
 	for (uint32_t i = 1; i < space->index_count; ++i) {
-		struct tuple *new_tuple = index_filter_tuple(space->index[i],
-							     stmt->new_tuple);
 		struct vy_lsm *lsm = vy_lsm(space->index[i]);
 		if (vy_is_committed(env, lsm))
 			continue;
 		if (vy_tx_set(tx, lsm, delete) != 0)
 			goto error;
-		if (new_tuple != NULL && vy_tx_set(tx, lsm, new_tuple) != 0)
+		if (vy_tx_set(tx, lsm, stmt->new_tuple) != 0)
 			goto error;
 	}
 	tuple_unref(delete);
@@ -1964,8 +1962,6 @@ vy_insert_first_upsert(struct vy_env *env, struct vy_tx *tx,
 	if (vy_tx_set(tx, pk, stmt) != 0)
 		return -1;
 	for (uint32_t i = 1; i < space->index_count; ++i) {
-		if (index_filter_tuple(space->index[i], stmt) == NULL)
-			continue;
 		struct vy_lsm *lsm = vy_lsm(space->index[i]);
 		if (vy_tx_set(tx, lsm, stmt) != 0)
 			return -1;
@@ -2238,12 +2234,10 @@ vy_insert(struct vy_env *env, struct vy_tx *tx, struct txn_stmt *stmt,
 		return -1;
 
 	for (uint32_t iid = 1; iid < space->index_count; ++iid) {
-		struct tuple *new_tuple = index_filter_tuple(space->index[iid],
-							     stmt->new_tuple);
 		struct vy_lsm *lsm = vy_lsm(space->index[iid]);
 		if (vy_is_committed(env, lsm))
 			continue;
-		if (new_tuple != NULL && vy_tx_set(tx, lsm, new_tuple) != 0)
+		if (vy_tx_set(tx, lsm, stmt->new_tuple) != 0)
 			return -1;
 	}
 	return 0;
@@ -2327,8 +2321,6 @@ vy_replace(struct vy_env *env, struct vy_tx *tx, struct txn_stmt *stmt,
 			return -1;
 	}
 	for (uint32_t i = 1; i < space->index_count; i++) {
-		struct tuple *new_tuple = index_filter_tuple(space->index[i],
-							     stmt->new_tuple);
 		struct vy_lsm *lsm = vy_lsm(space->index[i]);
 		if (vy_is_committed(env, lsm))
 			continue;
@@ -2337,11 +2329,9 @@ vy_replace(struct vy_env *env, struct vy_tx *tx, struct txn_stmt *stmt,
 			if (rc != 0)
 				break;
 		}
-		if (new_tuple != NULL) {
-			rc = vy_tx_set(tx, lsm, new_tuple);
-			if (rc != 0)
-				break;
-		}
+		rc = vy_tx_set(tx, lsm, stmt->new_tuple);
+		if (rc != 0)
+			break;
 	}
 	if (delete != NULL)
 		tuple_unref(delete);
@@ -3860,9 +3850,6 @@ vy_build_on_replace(struct trigger *trigger, void *event)
 	struct tuple_format *format = ctx->format;
 	struct vy_lsm *lsm = ctx->lsm;
 
-	stmt->old_tuple = index_filter_tuple(&lsm->base, stmt->old_tuple);
-	stmt->new_tuple = index_filter_tuple(&lsm->base, stmt->new_tuple);
-
 	if (ctx->is_failed)
 		return 0; /* already failed, nothing to do */
 
@@ -4038,8 +4025,6 @@ vy_build_recover_stmt(struct vy_lsm *lsm, struct vy_lsm *pk,
 		      struct vy_entry mem_entry)
 {
 	struct tuple *mem_stmt = mem_entry.stmt;
-	if (index_filter_tuple(&lsm->base, mem_stmt) == NULL)
-		return 0;
 	int64_t lsn = vy_stmt_lsn(mem_stmt);
 	if (lsn <= lsm->dump_lsn)
 		return 0; /* statement was dumped, nothing to do */
@@ -4269,9 +4254,6 @@ vinyl_space_build_index(struct space *src_space, struct index *new_index,
 		struct tuple *tuple = entry.stmt;
 		if (tuple == NULL)
 			break;
-		struct tuple* new_tuple = index_filter_tuple(new_index, tuple);
-		if (new_tuple == NULL)
-			continue;
 		/*
 		 * Insert the tuple into the new index unless it
 		 * was inserted into the space after we started
@@ -4285,13 +4267,13 @@ vinyl_space_build_index(struct space *src_space, struct index *new_index,
 		 * could be overwritten by a concurrent transaction,
 		 * in which case we would insert an outdated tuple.
 		 */
-		if (vy_stmt_lsn(new_tuple) <= build_lsn) {
+		if (vy_stmt_lsn(tuple) <= build_lsn) {
 			rc = vy_build_insert_tuple(env, new_lsm,
 						   space_name(src_space),
 						   new_index->def->name,
 						   new_format,
 						   check_unique_constraint,
-						   new_tuple);
+						   tuple);
 			if (rc != 0)
 				break;
 		}

--- a/src/box/vy_stmt.h
+++ b/src/box/vy_stmt.h
@@ -782,7 +782,9 @@ vy_entry_compare_with_raw_key(struct vy_entry entry,
 	      ((entry).hint = !(key_def)->is_multikey ?			\
 			vy_stmt_hint((src_stmt), (key_def)) :		\
 			multikey_idx), true);				\
-	     ++multikey_idx)
+	     ++multikey_idx)						\
+		if (!tuple_key_is_excluded(src_stmt, key_def,		\
+					   multikey_idx))
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/test/engine-luatest/gh_5861_exclude_null_test.lua
+++ b/test/engine-luatest/gh_5861_exclude_null_test.lua
@@ -1,0 +1,189 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group('gh-5861-exclude-null',
+                  {{engine = 'memtx'}, {engine = 'vinyl'}})
+
+g.before_all(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:stop()
+    cg.server = nil
+end)
+
+g.before_each(function(cg)
+    cg.server:exec(function(engine)
+        local s = box.schema.space.create('test', {engine = engine})
+        s:create_index('pk')
+    end, {cg.params.engine})
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        box.space.test:drop()
+    end)
+end)
+
+g.test_unsupported = function(cg)
+    t.skip_if(cg.params.engine == 'vinyl', 'Not supported by Vinyl')
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.test
+        t.assert_error_msg_equals(
+            "HASH does not support nullable parts",
+            s.create_index, s, 'sk',
+            {type = 'hash', parts = {{2, 'unsigned', exclude_null = true}}})
+        t.assert_error_msg_equals(
+            "BITSET does not support nullable parts",
+            s.create_index, s, 'sk',
+            {type = 'bitset', parts = {{2, 'unsigned', exclude_null = true}}})
+        t.assert_error_msg_equals(
+            "RTREE does not support nullable parts",
+            s.create_index, s, 'sk',
+            {type = 'rtree', parts = {{2, 'array', exclude_null = true}}})
+    end)
+end
+
+g.test_basic = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.test
+        s:create_index('sk', {
+            type = 'tree',
+            parts = {{2, 'unsigned', exclude_null = true}},
+        })
+        s:insert({1, 10})
+        s:insert({2})
+        s:insert({3, box.NULL})
+        s:insert({4, box.NULL, 5})
+        t.assert_equals(s.index.sk:select(), {{1, 10}})
+    end)
+    cg.server:restart()
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.test
+        t.assert_equals(s.index.sk:select(), {{1, 10}})
+        s:replace({1})
+        s:replace({2, 20})
+        s:replace({3})
+        s:delete({4})
+        t.assert_equals(s.index.sk:select(), {{2, 20}})
+    end)
+end
+
+g.test_multipart = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.test
+        s:create_index('sk', {
+            type = 'tree',
+            parts = {
+                {2, 'unsigned', is_nullable = true},
+                {3, 'unsigned', exclude_null = true},
+            },
+        })
+        s:insert({1, 10, 100})
+        s:insert({2, 20})
+        s:insert({3})
+        s:insert({4, box.NULL, box.NULL})
+        s:insert({5, 50, box.NULL})
+        s:insert({6, box.NULL, 600})
+        s:insert({7, box.NULL})
+        t.assert_equals(s.index.sk:select(), {{6, nil, 600}, {1, 10, 100}})
+    end)
+    cg.server:restart()
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.test
+        t.assert_equals(s.index.sk:select(), {{6, nil, 600}, {1, 10, 100}})
+        s:replace({1, 10})
+        s:replace({2, 20, 200})
+        s:replace({3, 30, box.NULL})
+        s:delete({6})
+        t.assert_equals(s.index.sk:select(), {{2, 20, 200}})
+    end)
+end
+
+g.test_json = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.test
+        s:create_index('sk', {
+            type = 'tree',
+            parts = {{'[2].a.b', 'unsigned', exclude_null = true}},
+        })
+        s:insert({1})
+        s:insert({2, {x = 1}})
+        s:insert({3, {a = {x = 1}}})
+        s:insert({4, {a = {b = box.NULL}}})
+        s:insert({5, {a = {b = 50}}})
+        t.assert_equals(s.index.sk:select(), {{5, {a = {b = 50}}}})
+    end)
+    cg.server:restart()
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.test
+        t.assert_equals(s.index.sk:select(), {{5, {a = {b = 50}}}})
+        s:replace({3, {a = {b = 30}}})
+        s:replace({4, {a = {x = 40}}})
+        s:delete({5})
+        t.assert_equals(s.index.sk:select(), {{3, {a = {b = 30}}}})
+    end)
+end
+
+g.test_multipart = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.test
+        s:create_index('sk', {
+            type = 'tree',
+            parts = {{'[2][*]', 'unsigned', exclude_null = true}},
+        })
+        s:insert({1})
+        s:insert({2, {box.NULL}})
+        s:insert({3, {box.NULL, box.NULL}})
+        s:insert({4, {40}})
+        s:insert({5, {50, 500}})
+        s:insert({6, {60, box.NULL}})
+        s:insert({7, {box.NULL, 70, box.NULL}})
+        t.assert_error_msg_contains(
+            'Duplicate key exists in unique index',
+            s.insert, s, {8, {box.NULL, 80, box.NULL, 40, box.NULL, 800}})
+        t.assert_equals(s.index.sk:select(), {
+            {4, {40}},
+            {5, {50, 500}},
+            {6, {60, box.NULL}},
+            {7, {box.NULL, 70, box.NULL}},
+            {5, {50, 500}},
+        })
+    end)
+    cg.server:restart()
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.test
+        t.assert_equals(s.index.sk:select(), {
+            {4, {40}},
+            {5, {50, 500}},
+            {6, {60, box.NULL}},
+            {7, {box.NULL, 70, box.NULL}},
+            {5, {50, 500}},
+        })
+        s:delete({1})
+        s:replace({2, {box.NULL, 20, box.NULL}})
+        s:replace({3})
+        s:delete({4})
+        s:replace({5, {box.NULL}})
+        s:replace({6, {60, box.NULL, 600}})
+        s:replace({7, {70, 700}})
+        t.assert_equals(s.index.sk:select(), {
+            {2, {box.NULL, 20, box.NULL}},
+            {6, {60, box.NULL, 600}},
+            {7, {70, 700}},
+            {6, {60, box.NULL, 600}},
+            {7, {70, 700}},
+        })
+    end)
+end

--- a/test/engine/null.result
+++ b/test/engine/null.result
@@ -2253,7 +2253,7 @@ s:replace{1}
 ...
 sk:select{}
 ---
-- - [1]
+- []
 ...
 s:select{}
 ---

--- a/test/engine/null.result
+++ b/test/engine/null.result
@@ -941,7 +941,7 @@ format[1] = {name = 'field1', type = 'unsigned'}
 format[2] = {name = 'field2', type = 'unsigned'}
 ---
 ...
-s = box.schema.create_space('test', {format = format})
+s = box.schema.create_space('test', {engine = engine, format = format})
 ---
 ...
 pk = s:create_index('pk')
@@ -994,7 +994,7 @@ s:select{}
 s:drop()
 ---
 ...
-s = box.schema.create_space('test')
+s = box.schema.create_space('test', {engine = engine})
 ---
 ...
 pk = s:create_index('pk')
@@ -1520,7 +1520,7 @@ s:drop()
 -- The main case of absent nullable fields - create an index over
 -- them on not empty space (available on memtx only).
 --
-s = box.schema.space.create('test', {engine = 'memtx'})
+s = box.schema.space.create('test', {engine = engine})
 ---
 ...
 pk = s:create_index('pk')
@@ -1594,7 +1594,7 @@ s:drop()
 -- optional and turn on comparators for optional fields. See the
 -- big comment in alter.cc in index_def_new_from_tuple().
 --
-s = box.schema.create_space('test', {engine = 'memtx'})
+s = box.schema.create_space('test', {engine = engine})
 ---
 ...
 pk = s:create_index('pk')
@@ -1657,7 +1657,7 @@ s:drop()
 -- this field is used in another index, then this another index
 -- is updated too. Case of @locker.
 --
-s = box.schema.space.create('test', {engine = 'memtx'})
+s = box.schema.space.create('test', {engine = engine})
 ---
 ...
 _ = s:create_index('pk')
@@ -2238,7 +2238,7 @@ s:drop()
 ---
 ...
 -- Tuple without the field
-s = box.schema.space.create('test')
+s = box.schema.space.create('test', {engine = engine})
 ---
 ...
 pk = s:create_index('pk', {type='tree', parts={{1, 'uint'}}})

--- a/test/engine/null.test.lua
+++ b/test/engine/null.test.lua
@@ -330,7 +330,7 @@ s:drop()
 format = {}
 format[1] = {name = 'field1', type = 'unsigned'}
 format[2] = {name = 'field2', type = 'unsigned'}
-s = box.schema.create_space('test', {format = format})
+s = box.schema.create_space('test', {engine = engine, format = format})
 pk = s:create_index('pk')
 s:replace{1, 1}
 s:replace{100, 100}
@@ -345,7 +345,7 @@ s:replace{150, box.NULL}
 s:select{}
 s:drop()
 
-s = box.schema.create_space('test')
+s = box.schema.create_space('test', {engine = engine})
 pk = s:create_index('pk')
 sk = s:create_index('sk', {parts = {{2, 'unsigned', is_nullable = false}}})
 s:replace{1, 1}
@@ -481,7 +481,7 @@ s:drop()
 -- The main case of absent nullable fields - create an index over
 -- them on not empty space (available on memtx only).
 --
-s = box.schema.space.create('test', {engine = 'memtx'})
+s = box.schema.space.create('test', {engine = engine})
 pk = s:create_index('pk')
 s:replace{1}
 s:replace{2}
@@ -502,7 +502,7 @@ s:drop()
 -- optional and turn on comparators for optional fields. See the
 -- big comment in alter.cc in index_def_new_from_tuple().
 --
-s = box.schema.create_space('test', {engine = 'memtx'})
+s = box.schema.create_space('test', {engine = engine})
 pk = s:create_index('pk')
 sk = s:create_index('sk', {parts = {2, 'unsigned'}})
 s:replace{1, 1}
@@ -522,7 +522,7 @@ s:drop()
 -- this field is used in another index, then this another index
 -- is updated too. Case of @locker.
 --
-s = box.schema.space.create('test', {engine = 'memtx'})
+s = box.schema.space.create('test', {engine = engine})
 _ = s:create_index('pk')
 i1 = s:create_index('i1', {parts = {2, 'unsigned', 3, 'unsigned'}})
 i2 = s:create_index('i2', {parts = {3, 'unsigned', 2, 'unsigned'}})
@@ -716,7 +716,7 @@ s:select{}
 s:drop()
 
 -- Tuple without the field
-s = box.schema.space.create('test')
+s = box.schema.space.create('test', {engine = engine})
 pk = s:create_index('pk', {type='tree', parts={{1, 'uint'}}})
 sk = s:create_index('sk', {type='tree', parts={{2, 'uint', exclude_null=true}}})
 s:replace{1}


### PR DESCRIPTION
`exclude_null` is a special index option, which makes the index ignore tuples that contain null in any of the indexed fields. Currently, it doesn't work for json and multikey indexes, because:
 1. `index_filter_tuple` ignores json path.
 2. `index_filter_tuple` ignores multikey index.

Issue no. 1 is easy to fix - we just need to use `tuple_field_by_part` instead of `tuple_field` when checking if a key field is null.

Issue no. 2 is more complicated, because when we call `index_filter_tuple` we don't know the multikey index. We address this issue by pushing the `index_filter_tuple` call down to engine-specific index implementation.

For Vinyl, we make `vy_stmt_foreach_entry`, which iterates over multikey tuple entries, skip entries that contain nulls.

For memtx, we move the check to index-specific `index_replace` function implementation. Fortunately, only tree indexes support nullable fields so we just need to update the memtx tree implementation.

Ideally, we should handle multikey indexes in memtx at the top level, because the implementation should essentially be the same for all kinds of indexes, but this refactoring is complicated and will be done later. For now, just fix the bug.

Closes #5861