### PR TITLE
ci: add workflow for LuaJIT integration tests

### DIFF
--- a/.github/workflows/luajit-integration.yml
+++ b/.github/workflows/luajit-integration.yml
@@ -1,0 +1,88 @@
+# This workflow is used within tarantool/luajit repository CI to
+# implement integration testing without manual LuaJIT submodule
+# bump and draft PR creation.
+# It bumps the given LuaJIT revision for the given Tarantool
+# release, builds Tarantool with the given buildtype and GC64
+# option and runs Tarantool testing suite.
+
+name: LuaJIT integration testing
+
+on:
+  workflow_call:
+    inputs:
+      buildtype:
+        description: CMake build type value
+        required: false
+        type: string
+        default: Debug
+      GC64:
+        description: CMake option value to enable LuaJIT GC64 mode
+        required: false
+        type: string
+        default: OFF
+      host:
+        description: Type of machine to run the GitHub job on
+        required: true
+        type: string
+      release:
+        description: Git revision from tarantool/tarantool repository
+        required: false
+        type: string
+        default: master
+      revision:
+        description: Git revision from tarantool/luajit repository
+        required: true
+        type: string
+
+jobs:
+  luajit-integration:
+    runs-on: ${{ inputs.host }}
+    steps:
+      - name: Prepare workspace
+        uses: tarantool/actions/cleanup@master
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: tarantool/tarantool
+          fetch-depth: 0
+          submodules: recursive
+          ref: ${{ inputs.release }}
+
+      - name: LuaJIT bump
+        run: |
+          pushd third_party/luajit
+          git fetch origin
+          git checkout ${{ inputs.revision }}
+          popd
+          # XXX: export the following environment variables to
+          # suppress git config warning. The commit is required to
+          # avoid resetting dirty changes in LuaJIT submodule.
+          export GIT_COMMITTER_NAME="LuaJIT integration testing workflow"
+          export GIT_COMMITTER_EMAIL="noreply@tarantool.org"
+          export GIT_AUTHOR_NAME="LuaJIT integration testing workflow"
+          export GIT_AUTHOR_EMAIL="noreply@tarantool.org"
+          git commit -m "luajit: integration testing bump" third_party/luajit
+
+      - name: Set environment
+        uses: ./.github/actions/environment
+
+      - name: Run tests
+        env:
+          CMAKE_BUILD_TYPE: ${{ inputs.buildtype }}
+          CMAKE_EXTRA_PARAMS: -DLUAJIT_ENABLE_GC64=${{ inputs.GC64 }}
+        run: |
+          # XXX: sysctl.proc_translated is the only hack for M1
+          # machines to check whether GitHub agent is being run
+          # under Rosetta 2 or not (since it changes the output of
+          # <uname -m> and other similar methods to detect the
+          # architecture of the host given in <runs-on> field).
+          # If sysctl.proc_translated is not provided by the
+          # system, assume it's being disabled (i.e. yields 0).
+          ARCH=$([[ $(sysctl -n sysctl.proc_translated || echo 0) == 0 ]] \
+            && uname -m || echo "Rosetta")
+          # XXX: To avoid many <if> statements right in this
+          # section, the branching is moved to .travis.mk and
+          # the required Makefile target is chosen by the kernel
+          # name and machine name yielded by <uname>.
+          make -f .travis.mk "luajit_$(uname -s)_${ARCH}_test"

--- a/.travis.mk
+++ b/.travis.mk
@@ -485,3 +485,65 @@ test_jepsen: deps_debian_jepsen
 	git config --get user.email || git config --global user.email "nobody@nowhere.com"
 	cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_WERROR=ON -DWITH_JEPSEN=ON
 	make run-jepsen
+
+# LuaJIT integration testing
+
+cmake_build:
+	${ARCH} cmake . -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} ${CMAKE_EXTRA_PARAMS}
+	${ARCH} cmake --build . --parallel ${NPROC}
+
+cmake_luajit_test:
+	${ARCH} cmake --build . --parallel ${NPROC} --target LuaJIT-test
+
+test_run_tarantool_test:
+	cd test && ${ARCH} ./test-run.py --vardir ${VARDIR} --force $(TEST_RUN_EXTRA_PARAMS)
+
+tarantool_linux_deps:
+	sudo apt update -y && sudo apt -y install git build-essential cmake \
+		make ninja-build zlib1g-dev libreadline-dev libncurses5-dev \
+		libssl-dev libunwind-dev libicu-dev \
+		python3 python3-six python3-gevent python3-pip
+
+tarantool_linux_tests: tarantool_linux_deps cmake_build cmake_luajit_test test_run_tarantool_test
+
+# XXX: No arch need to be set for Linux runners.
+luajit_Linux_aarch64_test: ARCH=
+luajit_Linux_aarch64_test: NPROC=$$(nproc)
+luajit_Linux_aarch64_test: tarantool_linux_tests
+# XXX: No arch need to be set for Linux runners.
+luajit_Linux_x86_64_test: ARCH=
+luajit_Linux_x86_64_test: NPROC=$$(nproc)
+luajit_Linux_x86_64_test: tarantool_linux_tests
+
+tarantool_darwin_deps:
+	${ARCH} brew install --force openssl readline curl icu4c libiconv zlib \
+		cmake python@3.8 \
+	|| ${ARCH} brew upgrade openssl readline curl icu4c libiconv zlib \
+		cmake python@3.8
+	${ARCH} pip3 install --force-reinstall -r test-run/requirements.txt
+
+tarantool_darwin_prebuild:
+	${ARCH} sysctl vm.swapusage
+
+tarantool_darwin_pretest:
+	ulimit -n ${MAX_FILES} || : && ulimit -n ;
+	ulimit -u ${MAX_PROC}  || : && ulimit -u ;
+	rm -rf ${VARDIR}
+
+# TODO: add tarantool_darwin_posttest rule to return default
+# settings back (e.g. when running tests via .travis.mk on the
+# local machine).
+
+# XXX: Tarantool tests are skipped for M1 until #6068 is resolved.
+tarantool_darwin_M1_tests: tarantool_darwin_deps tarantool_darwin_prebuild cmake_build cmake_luajit_test
+tarantool_darwin_tests: tarantool_darwin_deps tarantool_darwin_prebuild cmake_build cmake_luajit_test tarantool_darwin_pretest test_run_tarantool_test
+
+# XXX: No arch need to be set for x86_64 runners.
+luajit_Darwin_x86_64_test: ARCH=
+luajit_Darwin_x86_64_test: NPROC=$$(sysctl -n hw.ncpu)
+luajit_Darwin_x86_64_test: tarantool_darwin_tests
+# XXX: GitHub agent is run via Rosetta on M1 hosts, hence we need
+# to explicitly set ARM64 arch for all subcommands.
+luajit_Darwin_Rosetta_test: ARCH=arch -arm64
+luajit_Darwin_Rosetta_test: NPROC=$$(sysctl -n hw.ncpu)
+luajit_Darwin_Rosetta_test: tarantool_darwin_M1_tests


### PR DESCRIPTION
This patch introduces reusable workflow used by integration testing
machinery run within tarantool/luajit repository.

For the first attempt GitHub action has been used, but its fetch (or
more precisely unpack) phase fails due to test/test-run.py symlink into
test-run submodule (the action being used doesn't fetch it while packing
tarantool repository). As the alternative for removing this symlink, it
was decided to use reusable workflows despite its known limitations
(e.g. inability to use the testing matrix) until the issue with symlink
is resolved in any possible way.

NO_DOC=ci
NO_TEST=ci
NO_CHANGELOG=ci

---

You can find the usage of the new workflow [here](https://github.com/tarantool/luajit/commit/765a0ce).