### PR TITLE
core: return procedure name hash table to speed up frame resolving

### DIFF
--- a/changelogs/unreleased/gh-7207-backtrace-perf-degrade.md
+++ b/changelogs/unreleased/gh-7207-backtrace-perf-degrade.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed performance degrade of fiber backtrace collection
+  after backtrace rework (gh-7207).

--- a/cmake/BuildLibUnwind.cmake
+++ b/cmake/BuildLibUnwind.cmake
@@ -23,6 +23,8 @@ macro(libunwind_build)
     set(LIBUNWIND_BUILD_DIR ${PROJECT_BINARY_DIR}/build/libunwind)
     set(LIBUNWIND_BINARY_DIR ${LIBUNWIND_BUILD_DIR}/work)
     set(LIBUNWIND_INSTALL_DIR ${LIBUNWIND_BUILD_DIR}/dest)
+    set(LIBUNWIND_CFLAGS "-g -O2")
+    set(LIBUNWIND_CXXFLAGS "-g -O2")
 
     include(ExternalProject)
     ExternalProject_Add(bundled-libunwind-project
@@ -36,8 +38,11 @@ macro(libunwind_build)
 
                         CONFIGURE_COMMAND
                         <SOURCE_DIR>/configure
+                        AR=${CMAKE_AR}
                         CC=${CMAKE_C_COMPILER}
                         CXX=${CMAKE_CXX_COMPILER}
+                        CFLAGS=${LIBUNWIND_CFLAGS}
+                        CXXFLAGS=${LIBUNWIND_CXXFLAGS}
                         --prefix=<INSTALL_DIR>
                         # Bundled libraries are linked statically.
                         --disable-shared
@@ -74,6 +79,8 @@ macro(libunwind_build)
 
                         BUILD_BYPRODUCTS ${LIBUNWIND_INSTALL_DIR}/lib/libunwind-x86_64.a
                         BUILD_BYPRODUCTS ${LIBUNWIND_INSTALL_DIR}/lib/libunwind.a)
+    unset(LIBUNWIND_CFLAGS)
+    unset(LIBUNWIND_CXXFLAGS)
 
     add_library(bundled-libunwind STATIC IMPORTED GLOBAL)
     set_target_properties(bundled-libunwind PROPERTIES

--- a/src/lib/core/CMakeLists.txt
+++ b/src/lib/core/CMakeLists.txt
@@ -42,6 +42,10 @@ set(core_sources
     ssl_init.c
 )
 
+if (ENABLE_BACKTRACE)
+    list(APPEND core_sources  proc_name_cache.cc)
+endif()
+
 if(ENABLE_TUPLE_COMPRESSION)
     list(APPEND core_sources ${TUPLE_COMPRESSION_CORE_SOURCES})
 else()

--- a/src/lib/core/backtrace.h
+++ b/src/lib/core/backtrace.h
@@ -66,6 +66,9 @@ backtrace_collect(struct backtrace *bt, const struct fiber *fiber,
 
 /*
  * Resolve C/C++ function name and `offset` from `frame`.
+ *
+ * Returns pointer to a temporary buffer storing the demangled function name:
+ * the caller is responsible for making a copy of it.
  */
 const char *
 backtrace_frame_resolve(const struct backtrace_frame *frame,

--- a/src/lib/core/proc_name_cache.cc
+++ b/src/lib/core/proc_name_cache.cc
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2022, Tarantool AUTHORS, please see AUTHORS file.
+ */
+
+#include "assoc.h"
+#include "fiber.h"
+#include "proc_name_cache.h"
+
+#include "small/region.h"
+
+enum {
+	PROC_NAME_MAX = 64,
+};
+
+/* Procedure name hash table entry. */
+struct proc_name_cache_entry {
+	/* Demangled procedure name. */
+	char name[PROC_NAME_MAX];
+	/* Procedure offset. */
+	unw_word_t offset;
+};
+
+/*
+ * RAII wrapper around the procedure name cache and its region.
+ */
+struct ProcNameCache final {
+public:
+	ProcNameCache(ProcNameCache &other) = delete;
+
+	ProcNameCache &operator=(ProcNameCache &other) = delete;
+
+	static ProcNameCache &instance() noexcept
+	{
+		thread_local ProcNameCache singleton;
+		return singleton;
+	}
+
+	mh_i64ptr_t *proc_name_cache;
+	region proc_name_cache_entry_region;
+
+private:
+	ProcNameCache() noexcept : proc_name_cache{mh_i64ptr_new()},
+				   proc_name_cache_entry_region{}
+	{
+		region_create(&proc_name_cache_entry_region, &cord()->slabc);
+	}
+
+	~ProcNameCache()
+	{
+		region_destroy(&proc_name_cache_entry_region);
+		mh_i64ptr_delete(proc_name_cache);
+	}
+};
+
+const char *
+proc_name_cache_find(unw_word_t ip, unw_word_t *offs)
+{
+	mh_i64ptr_t *proc_name_cache =
+		ProcNameCache::instance().proc_name_cache;
+	mh_int_t k = mh_i64ptr_find(proc_name_cache, ip, nullptr);
+	if (k == mh_end(proc_name_cache))
+		return nullptr;
+	void *val = mh_i64ptr_node(proc_name_cache, k)->val;
+	auto *entry = static_cast<proc_name_cache_entry *>(val);
+	*offs = entry->offset;
+	return entry->name;
+}
+
+void
+proc_name_cache_insert(unw_word_t ip, const char *name, unw_word_t offs)
+{
+	region *proc_name_cache_entry_region =
+		&ProcNameCache::instance().proc_name_cache_entry_region;
+	size_t sz;
+	proc_name_cache_entry *entry =
+		region_alloc_object(proc_name_cache_entry_region,
+				    typeof(*entry), &sz);
+	if (unlikely(entry == nullptr))
+		return;
+	entry->offset = offs;
+	strlcpy(entry->name, name, PROC_NAME_MAX);
+	mh_i64ptr_node_t node = {ip, entry};
+	mh_i64ptr_t *proc_name_cache =
+		ProcNameCache::instance().proc_name_cache;
+	mh_i64ptr_put(proc_name_cache, &node, nullptr, nullptr);
+}

--- a/src/lib/core/proc_name_cache.h
+++ b/src/lib/core/proc_name_cache.h
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2022, Tarantool AUTHORS, please see AUTHORS file.
+ */
+
+#pragma once
+
+#include "trivia/config.h"
+
+#ifdef ENABLE_BACKTRACE
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+#include "libunwind.h"
+
+/* Find procedure name and offset in hash table based on RIP register value. */
+const char *
+proc_name_cache_find(unw_word_t ip, unw_word_t *offs);
+
+/* Insert procedure name and offset into hash table. */
+void
+proc_name_cache_insert(unw_word_t ip, const char *name, unw_word_t offs);
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
+#endif /* ENABLE_BACKTRACE */


### PR DESCRIPTION
Procedure name hash table was removed during refactoring in 8ce76364 based
off the interpretation that libunwind caches procedure names internally —
turned out it only caches unwinding info, which causes a severe performance
downgrade (gh-7207): return procedure name hash table to speed up frame
resolving.

Closes #7207