### PR TITLE
Delete APPLIER_FETCH_SNAPSHOT

### DIFF
--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -547,7 +547,7 @@ applier_fetch_snapshot(struct applier *applier)
 	row.type = IPROTO_FETCH_SNAPSHOT;
 	coio_write_xrow(io, &row);
 
-	applier_set_state(applier, APPLIER_FETCH_SNAPSHOT);
+	applier_set_state(applier, APPLIER_INITIAL_JOIN);
 	applier_wait_snapshot(applier);
 	applier_set_state(applier, APPLIER_FETCHED_SNAPSHOT);
 	applier_set_state(applier, APPLIER_READY);

--- a/src/box/applier.h
+++ b/src/box/applier.h
@@ -68,10 +68,9 @@ enum { APPLIER_SOURCE_MAXLEN = 1024 }; /* enough to fit URI with passwords */
 	_(APPLIER_STOPPED, 10)                                       \
 	_(APPLIER_DISCONNECTED, 11)                                  \
 	_(APPLIER_LOADING, 12)                                       \
-	_(APPLIER_FETCH_SNAPSHOT, 13)                                \
-	_(APPLIER_FETCHED_SNAPSHOT, 14)                              \
-	_(APPLIER_REGISTER, 15)                                      \
-	_(APPLIER_REGISTERED, 16)                                    \
+	_(APPLIER_FETCHED_SNAPSHOT, 13)                              \
+	_(APPLIER_REGISTER, 14)                                      \
+	_(APPLIER_REGISTERED, 15)                                    \
 
 /** States for the applier */
 ENUM(applier_state, applier_STATE);

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3470,9 +3470,7 @@ bootstrap_from_master(struct replica *master)
 	 */
 
 	assert(!tt_uuid_is_nil(&INSTANCE_UUID));
-	enum applier_state wait_state = replication_anon ?
-					APPLIER_FETCH_SNAPSHOT :
-					APPLIER_INITIAL_JOIN;
+	enum applier_state wait_state = APPLIER_INITIAL_JOIN;
 	applier_resume_to_state(applier, wait_state, TIMEOUT_INFINITY);
 	/*
 	 * Process initial data (snapshot or dirty disk data).


### PR DESCRIPTION
There are two quite similar states, APPLIER_INITIAL_JOIN
and APPLIER_FETCH_SNAPSHOT. Let's delete the latter state,
because we don't wait for it anywhere. We need to set the
state to APPLIER_INITIAL_JOIN here instead, so that
applier_fetch_snapshot() is tracked correctly in
replication.cc.

Needed for workflow in tarantool/tarantool:
tarantool/tarantool#6126