### PR TITLE
net.box: explicitly forbid synchronous requests in triggers

### DIFF
--- a/changelogs/unreleased/gh-5358-net-box-sync-request-in-trigger.md
+++ b/changelogs/unreleased/gh-5358-net-box-sync-request-in-trigger.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a hang when a synchronous request is issued from a net.box `on_connect`
+  or `on_schema_reload` trigger. Now, an error is raised instead (gh-5358).


### PR DESCRIPTION
Net.box triggers (`on_connect`, `on_schema_reload`) are executed by the net.box connection worker fiber so a request issued by a trigger callback can't be processed until the trigger returns execution to the net.box fiber. Currently, an attempt to issue a synchronous request from a net.box trigger leads to a silent hang of the connection, which is confusing. Let's instead raise an error until #7291 is implemented.

We need to add the check to three places in the code:
 1. `luaT_netbox_wait_result` for `future:wait_result()`
 2. `luaT_netbox_iterator_next` for `future:pairs()`
 3. `conn._request` for all synchronous requests.
    (We can't add the check to `luaT_netbox_transport_perform_request`, because `conn._request` may also call `conn.wait_state`, which would hang if called from `on_connect` or `on_schema_reload` trigger.)

We also add an assertion to `netbox_request_wait` to ensure that we never wait for a request completion in the net.box worker fiber.

Closes #5358