### PR TITLE
third_party: update nghttp2 from 1.46.0 to 1.47.0

### DIFF
--- a/changelogs/unreleased/gh-7292-fix-gcc-build-with-libbpf-installed.md
+++ b/changelogs/unreleased/gh-7292-fix-gcc-build-with-libbpf-installed.md
@@ -1,0 +1,3 @@
+## bugfix/build
+
+* Fix build failure with gcc if libpbf is installed. (gh-7292)


### PR DESCRIPTION
This will fix compilation on recent Archlinux. The issue is this distro
installs libbpf in base configuration and nghttp2 1.46.0 tries to
compile eBPF code if this library is present and failed if compiler is
gcc.

Closes #7292