### PR TITLE
ci: enable tests for Debian

### DIFF
--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -41,15 +41,8 @@ jobs:
       - name: 'Build tarantool packages for ${{ env.OS }}(${{ env.DIST }})'
         id: run_build
         env:
-          # Our testing expects that the init process (PID 1) will
-          # reap orphan processes. At least the following test leans
-          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: --init
-          # There are packages like tzdata or postfix, whose configuration
-          # is interactive by default. The environment variable below
-          # forbids interactive configuration phase. Otherwise the CI gets
-          # stuck from time to time on `apt-get update`.
-          DEBIAN_FRONTEND: noninteractive
+          MAKE_CHECK: false
+          PRESERVE_ENVVARS: 'MAKE_CHECK,${{ env.PRESERVE_ENVVARS }}'
         run: make -f .gitlab.mk package
       - name: 'Upload build artifacts'
         uses: actions/upload-artifact@v2

--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,7 @@ test/enterprise-unit
 test/lib/
 test/unit/*.test
 test/unit/fiob
-test/small
+test/small/*.test
 test/var
 test/luajit-tap
 test/unit/popen-child

--- a/debian/control
+++ b/debian/control
@@ -72,7 +72,7 @@ Package: tarantool
 Architecture: i386 amd64 armhf arm64
 Priority: optional
 Depends: ${shlibs:Depends}, ${misc:Depends}, netbase, libgomp1,
-  openssl, tarantool-common (>= 2.2.1),
+  openssl, tarantool-common (>= 2.2.1), tzdata,
 # libcurl dependencies (except ones we have already)
  zlib1g
 Replaces: tarantool-lts

--- a/debian/control
+++ b/debian/control
@@ -28,6 +28,11 @@ Build-Depends: cdbs (>= 0.4.100), debhelper (>= 9), dpkg-dev (>= 1.16.1~),
  zlib1g-dev,
 # Install prove to run LuaJIT tests.
  libtest-harness-perl,
+# Install dependencies for functional tests.
+ python3-gevent,
+ python3-yaml,
+# needed for datetime tests
+ tzdata,
 Section: database
 Standards-Version: 4.5.1
 Homepage: http://tarantool.org/

--- a/debian/rules
+++ b/debian/rules
@@ -24,7 +24,9 @@ ifeq ($(GC64), true)
 	DEB_CMAKE_EXTRA_FLAGS += -DLUAJIT_ENABLE_GC64=ON
 endif
 
-DEB_MAKE_CHECK_TARGET := test-force
+ifneq ($(MAKE_CHECK), false)
+	DEB_MAKE_CHECK_TARGET := test-force
+endif
 
 # Install tarantool.service within tarantool-common package, but does not
 # install it within tarantool and tarantool-dev packages.

--- a/debian/rules
+++ b/debian/rules
@@ -24,6 +24,8 @@ ifeq ($(GC64), true)
 	DEB_CMAKE_EXTRA_FLAGS += -DLUAJIT_ENABLE_GC64=ON
 endif
 
+DEB_MAKE_CHECK_TARGET := test-force
+
 # Install tarantool.service within tarantool-common package, but does not
 # install it within tarantool and tarantool-dev packages.
 DEB_DH_INSTALLINIT_ARGS                     := --name=tarantool

--- a/rpm/tarantool.spec
+++ b/rpm/tarantool.spec
@@ -105,6 +105,8 @@ BuildRequires: python3-PyYAML
 %else
 BuildRequires: python3-pyyaml
 %endif
+# needed for datetime tests
+BuildRequires: tzdata
 
 # Install prove to run LuaJIT tests.
 BuildRequires: perl-Test-Harness

--- a/rpm/tarantool.spec
+++ b/rpm/tarantool.spec
@@ -218,8 +218,10 @@ make %{?_smp_mflags}
 # %%doc and %%license macroses are used instead
 rm -rf %{buildroot}%{_datarootdir}/doc/tarantool/
 
+%if "%{getenv:MAKE_CHECK}" != "false"
 %check
 make test-force
+%endif
 
 %pre
 /usr/sbin/groupadd -r tarantool > /dev/null 2>&1 || :

--- a/rpm/tarantool.spec
+++ b/rpm/tarantool.spec
@@ -106,7 +106,11 @@ BuildRequires: python3-PyYAML
 BuildRequires: python3-pyyaml
 %endif
 # needed for datetime tests
+%if 0%{?sle_version} >= 1500
+BuildRequires: timezone
+%else
 BuildRequires: tzdata
+%endif
 
 # Install prove to run LuaJIT tests.
 BuildRequires: perl-Test-Harness
@@ -130,6 +134,11 @@ Requires: /etc/services
 # Deps for built-in package manager
 # https://github.com/tarantool/tarantool/issues/2612
 Requires: openssl
+%if 0%{?sle_version} >= 1500
+Requires: timezone
+%else
+Requires: tzdata
+%endif
 %if (0%{?fedora} >= 22 || 0%{?rhel} >= 8 || 0%{?sle_version} >= 1500)
 # RHEL <= 7 doesn't support Recommends:
 Recommends: tarantool-devel

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,13 +35,18 @@ if(POLICY CMP0037)
     endif()
 endif(POLICY CMP0037)
 
+# The symlink is needed for out-of-source builds. In the case of in-source
+# builds ${CMAKE_CURRENT_BINARY_DIR} == ${PROJECT_SOURCE_DIR}/test and the
+# symlink already exists. It creates the symlink if the destination doesn't
+# exist.
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/small
     COMMAND ${CMAKE_COMMAND} -E create_symlink
-        ${PROJECT_SOURCE_DIR}/src/lib/small/test/
+        ${CMAKE_CURRENT_BINARY_DIR}/../src/lib/small/test/
         ${CMAKE_CURRENT_BINARY_DIR}/small
-        COMMENT Create a symlink for libsmall to fix out-of-source tests)
-add_custom_target(symlink_small_tests ALL
-   DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/small)
+        COMMENT Create the symlink for libsmall test binaries)
+
+add_custom_target(symlink_libsmall_test_binaries ALL
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/small)
 
 add_custom_target(test
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/small

--- a/test/small
+++ b/test/small
@@ -1,0 +1,1 @@
+../src/lib/small/test/


### PR DESCRIPTION
Now the test-run dependencies (pyyaml, gevent) have the corresponding
deb packages installable via the 'apt' package manager and finally it's
time to enable running tests in the package build process.

Closes #1341