### PR TITLE
ci: run coverage workflows on 4-CPU runners

### DIFF
--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -37,9 +37,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     strategy:
       fail-fast: false

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -37,9 +37,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     strategy:
       fail-fast: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,9 +37,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: ['self-hosted', 'flavor-4-8']
 
     steps:
       - uses: tarantool/actions/cleanup@master

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,7 @@ jobs:
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ['self-hosted', 'flavor-4-8']
+    runs-on: ['self-hosted', 'flavor-8-16']
 
     steps:
       - uses: tarantool/actions/cleanup@master

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -37,9 +37,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     strategy:
       fail-fast: false

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -37,9 +37,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     strategy:
       fail-fast: false

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -37,9 +37,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     strategy:
       fail-fast: false

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -39,7 +39,7 @@ jobs:
           ( github.event_name == 'pull_request' &&
             !contains(github.event.pull_request.labels.*.name, 'notest') ) )
 
-    runs-on: flavor-4-8
+    runs-on: flavor-8-16
 
     steps:
       - uses: tarantool/actions/cleanup@master

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -39,7 +39,7 @@ jobs:
           ( github.event_name == 'pull_request' &&
             !contains(github.event.pull_request.labels.*.name, 'notest') ) )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     steps:
       - uses: tarantool/actions/cleanup@master

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -40,9 +40,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     steps:
       - uses: tarantool/actions/cleanup@master

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -39,7 +39,7 @@ jobs:
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: flavor-4-8
+    runs-on: flavor-8-16
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -37,9 +37,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_35.yml
+++ b/.github/workflows/fedora_35.yml
@@ -39,7 +39,7 @@ jobs:
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: flavor-4-8
+    runs-on: flavor-8-16
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_35.yml
+++ b/.github/workflows/fedora_35.yml
@@ -37,9 +37,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_36.yml
+++ b/.github/workflows/fedora_36.yml
@@ -39,7 +39,7 @@ jobs:
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: flavor-4-8
+    runs-on: flavor-8-16
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora_36.yml
+++ b/.github/workflows/fedora_36.yml
@@ -37,9 +37,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     strategy:
       fail-fast: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
           ( github.event_name == 'pull_request' &&
             !contains(github.event.pull_request.labels.*.name, 'notest') ) )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-1-2
 
     steps:
       - uses: tarantool/actions/cleanup@master
@@ -67,7 +67,7 @@ jobs:
           ( github.event_name == 'pull_request' &&
             !contains(github.event.pull_request.labels.*.name, 'notest') ) )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-1-2
 
     steps:
       - uses: tarantool/actions/cleanup@master
@@ -94,7 +94,7 @@ jobs:
         ( github.event_name == 'pull_request' &&
           !contains(github.event.pull_request.labels.*.name, 'notest') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-1-2
 
     steps:
       - uses: tarantool/actions/cleanup@master

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -37,9 +37,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     strategy:
       fail-fast: false

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -37,9 +37,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     strategy:
       fail-fast: false

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -40,9 +40,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     steps:
       - uses: tarantool/actions/cleanup@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           ( github.event_name == 'pull_request' &&
             !contains(github.event.pull_request.labels.*.name, 'notest') ) )
 
-    runs-on: flavor-4-8
+    runs-on: flavor-8-16
 
     steps:
       - uses: tarantool/actions/cleanup@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           ( github.event_name == 'pull_request' &&
             !contains(github.event.pull_request.labels.*.name, 'notest') ) )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     steps:
       - uses: tarantool/actions/cleanup@master

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -40,9 +40,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     steps:
       - uses: tarantool/actions/cleanup@master

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -42,7 +42,7 @@ jobs:
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: flavor-4-8
+    runs-on: flavor-8-16
 
     steps:
       - uses: tarantool/actions/cleanup@master

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -40,9 +40,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     steps:
       - uses: tarantool/actions/cleanup@master

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -40,9 +40,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     steps:
       - uses: tarantool/actions/cleanup@master

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -42,7 +42,7 @@ jobs:
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: flavor-4-8
+    runs-on: flavor-8-16
 
     steps:
       - uses: tarantool/actions/cleanup@master

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -40,9 +40,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     steps:
       - uses: tarantool/actions/cleanup@master

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -42,7 +42,7 @@ jobs:
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: flavor-4-8
+    runs-on: flavor-8-16
 
     steps:
       - uses: tarantool/actions/cleanup@master

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -40,9 +40,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     steps:
       - uses: tarantool/actions/cleanup@master

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -40,9 +40,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     steps:
       - uses: tarantool/actions/cleanup@master

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -37,9 +37,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -37,9 +37,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -37,9 +37,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ubuntu_21_10.yml
+++ b/.github/workflows/ubuntu_21_10.yml
@@ -37,9 +37,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -37,9 +37,9 @@ jobs:
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'test') )
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: flavor-4-8
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Running coverage workflows on 4-CPU runners reduces run time from approximately 35 to 17.5 minutes, making it the same as average time of other jobs. As a result, coverage workflow stops being the bottleneck which limits lead time of testing to 35+ minutes.

For example, see this workflow. https://github.com/tarantool/tarantool/runs/7039453923?check_suite_focus=true

There are 3 runners with `flavor-4-8` label at this moment and we can deploy more when they're needed.

---

Update 1.

Two more extra-long jobs are 

* https://github.com/tarantool/tarantool/actions/workflows/release_lto.yml
* https://github.com/tarantool/tarantool/actions/workflows/release_lto_clang11.yml

So it makes sense to speed them up as well.
