### PR TITLE
luacheck: fix W214 for src/box/lua/net_box.lua

### DIFF
--- a/.travis.mk
+++ b/.travis.mk
@@ -295,7 +295,7 @@ test_debian_docker_luacheck:
 test_debian_install_luacheck:
 	sudo apt update -y
 	sudo apt install -y lua5.1 luarocks
-	sudo luarocks install luacheck 0.25.0
+	sudo luarocks install luacheck 0.26.1
 
 test_debian_luacheck: test_debian_install_luacheck configure_debian
 	make luacheck

--- a/src/box/lua/net_box.lua
+++ b/src/box/lua/net_box.lua
@@ -1180,8 +1180,8 @@ this_module.self = {
     timeout = function(self) return self end,
     wait_connected = function(self) return true end,
     is_connected = function(self) return true end,
-    call = function(_box, proc_name, args)
-        check_remote_arg(_box, 'call')
+    call = function(__box, proc_name, args)
+        check_remote_arg(__box, 'call')
         check_call_args(args)
         args = args or {}
         proc_name = tostring(proc_name)
@@ -1197,8 +1197,8 @@ this_module.self = {
             return handle_eval_result(pcall(proc, unpack(args)))
         end
     end,
-    eval = function(_box, expr, args)
-        check_remote_arg(_box, 'eval')
+    eval = function(__box, expr, args)
+        check_remote_arg(__box, 'eval')
         check_eval_args(args)
         args = args or {}
         local proc, errmsg = loadstring(expr)


### PR DESCRIPTION
Since 0.26.0 luacheck emits a warning on the `_box` variable.

From luacheck v.0.26.0 release notes:
"Function arguments that start with a single underscore get an "unused hint". Leaving them unused doesn't result in a warning. Using them, on the other hand, is a new warning (№ 214)."

Renamed `_box` to `__box`, which works just fine and updated luacheck to 0.26.1 in CI.

Closes #7304