### PR TITLE
gcov: use __gcov_dump + __gcov_reset instead of __gcov_flush

### DIFF
--- a/cmake/profile.cmake
+++ b/cmake/profile.cmake
@@ -1,5 +1,12 @@
 set(CMAKE_REQUIRED_FLAGS "-fprofile-arcs -ftest-coverage")
-check_library_exists("" __gcov_flush "" HAVE_GCOV)
+if (CMAKE_C_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 11)
+    check_library_exists("" __gcov_dump "" HAVE_GCOV)
+    if (HAVE_GCOV)
+        check_library_exists("" __gcov_reset "" HAVE_GCOV)
+      endif()
+else()
+    check_library_exists("" __gcov_flush "" HAVE_GCOV)
+endif()
 set(CMAKE_REQUIRED_FLAGS "")
 
 set(ENABLE_GCOV_DEFAULT OFF)

--- a/src/main.cc
+++ b/src/main.cc
@@ -567,7 +567,7 @@ tarantool_free(void)
 	free(pid_file);
 	signal_free();
 #ifdef ENABLE_GCOV
-	__gcov_flush();
+	gcov_flush();
 #endif
 	cbus_free();
 #if 0

--- a/src/trivia/util.h
+++ b/src/trivia/util.h
@@ -420,7 +420,32 @@ strnindex(const char *const *haystack, const char *needle, uint32_t len,
 
 void close_all_xcpt(int fdc, ...);
 
-void __gcov_flush();
+#if defined(__GNUC__) && __GNUC__ >= 11
+/** Import __gcov_dump function. */
+void
+__gcov_dump(void);
+
+/** Import __gcov_reset function. */
+void
+__gcov_reset(void);
+
+static inline void
+gcov_flush(void)
+{
+	__gcov_dump();
+	__gcov_reset();
+}
+#else
+/** Import __gcov_flush function. */
+void
+__gcov_flush(void);
+
+static inline void
+gcov_flush(void)
+{
+	__gcov_flush();
+}
+#endif
 
 /**
  * Async-signal-safe implementation of printf(), to


### PR DESCRIPTION
__gcov_flush was removed in gcc11.

Since gcc11 __gcov_dump calls __gcov_lock at the start and __gcov_unlock before returning. Same is true for __gcov_reset. Because of that using __gcov_reset right after __gcov_dump since gcc11 is the same as using __gcov_flush before gcc11.

Closes #7302