### PR TITLE
datetime: fix for setting when `hour=nil`

### DIFF
--- a/changelogs/unreleased/gh-7298-datetime-set-with-hour-nil.md
+++ b/changelogs/unreleased/gh-7298-datetime-set-with-hour-nil.md
@@ -1,0 +1,4 @@
+## bugfix/datetime
+
+* Fixed a bug in datetime module when `date:set{hour=nil,min=XXX}`
+  did not retain original `hour` value. (gh-7298).

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -1023,7 +1023,7 @@ local function datetime_set(self, obj)
     end
 
     local lsecs = local_secs(self)
-    local h0 = math_floor(lsecs / (24 * 60)) % 24
+    local h0 = math_floor(lsecs / (60 * 60)) % 24
     local m0 = math_floor(lsecs / 60) % 60
     local sec0 = lsecs % 60
 

--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -1740,11 +1740,11 @@ test:test("Time :set{} operations", function(test)
             'day 9')
     test:is(tostring(ts:set{ hour = 6 }),  '2020-11-09T06:31:11+0300',
             'hour 6')
-    test:is(tostring(ts:set{ min = 12, sec = 23 }), '2020-11-09T04:12:23+0300',
+    test:is(tostring(ts:set{ min = 12, sec = 23 }), '2020-11-09T06:12:23+0300',
             'min 12, sec 23')
-    test:is(tostring(ts:set{ tzoffset = -8*60 }), '2020-11-09T04:12:23-0800',
+    test:is(tostring(ts:set{ tzoffset = -8*60 }), '2020-11-09T06:12:23-0800',
             'offset -0800' )
-    test:is(tostring(ts:set{ tzoffset = '+0800' }), '2020-11-09T04:12:23+0800',
+    test:is(tostring(ts:set{ tzoffset = '+0800' }), '2020-11-09T06:12:23+0800',
             'offset +0800' )
     -- timestamp 1630359071.125 is 2021-08-30T21:31:11.125Z
     test:is(tostring(ts:set{ timestamp = 1630359071.125 }),


### PR DESCRIPTION
We did not retain correctly `hour` attribute if modified
via `:set` method attributes `min`, `sec` or `nsec`.

```
tarantool> a = dt.parse '2022-05-05T00:00:00'

tarantool> a:set{min = 0, sec = 0, nsec = 0}
--
- 2022-05-05T12:00:00Z
...
```

Closes #7298
