### PR TITLE
Fix a crash on x86 systems without `RDTSCP` instruction

### DIFF
--- a/changelogs/unreleased/gh-4573-implement-fiber-top-for-arm.md
+++ b/changelogs/unreleased/gh-4573-implement-fiber-top-for-arm.md
@@ -1,0 +1,3 @@
+## feature/core
+
+* Implemented `fiber.top()` for ARM64 (gh-4573).

--- a/changelogs/unreleased/gh-5869-fix-crash-without-rdtscp.md
+++ b/changelogs/unreleased/gh-5869-fix-crash-without-rdtscp.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a crash that could happen on x86 systems without the
+  `RDTSCP` instruction (gh-5869).

--- a/changelogs/unreleased/gh-5869-remove-fiber-top-cpu_misses.md
+++ b/changelogs/unreleased/gh-5869-remove-fiber-top-cpu_misses.md
@@ -1,0 +1,4 @@
+## feature/core
+
+* **[Breaking change]** Removed `cpu_misses` entry from `fiber.top()`
+  output (gh-5869).

--- a/src/lib/core/clock.c
+++ b/src/lib/core/clock.c
@@ -28,6 +28,7 @@
  * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
+#include "say.h"
 #include "clock.h"
 
 #include "trivia/util.h"
@@ -35,23 +36,31 @@ double
 clock_realtime(void)
 {
 	struct timespec ts;
-	clock_gettime(CLOCK_REALTIME, &ts);
+	int rc = clock_gettime(CLOCK_REALTIME, &ts);
+	if (rc != 0)
+		panic_syserror("clock_gettime failed");
 	return (double) ts.tv_sec + ts.tv_nsec / 1e9;
 
 }
+
 double
 clock_monotonic(void)
 {
 	struct timespec ts;
-	clock_gettime(CLOCK_MONOTONIC, &ts);
+	int rc = clock_gettime(CLOCK_MONOTONIC, &ts);
+	if (rc != 0)
+		panic_syserror("clock_gettime failed");
 	return (double) ts.tv_sec + ts.tv_nsec / 1e9;
 }
+
 double
 clock_process(void)
 {
 #if defined(CLOCK_PROCESS_CPUTIME_ID)
 	struct timespec ts;
-	clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts);
+	int rc = clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts);
+	if (rc != 0)
+		panic_syserror("clock_gettime failed");
 	return (double) ts.tv_sec + ts.tv_nsec / 1e9;
 #else
 	return (double) clock() / CLOCKS_PER_SEC;
@@ -63,7 +72,9 @@ clock_thread(void)
 {
 #if defined(CLOCK_THREAD_CPUTIME_ID)
 	struct timespec ts;
-	clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts);
+	int rc = clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts);
+	if (rc != 0)
+		panic_syserror("clock_gettime failed");
 	return (double) ts.tv_sec + ts.tv_nsec / 1e9;
 #else
 	return (double) clock() / CLOCKS_PER_SEC;
@@ -74,16 +85,19 @@ int64_t
 clock_realtime64(void)
 {
 	struct timespec ts;
-	clock_gettime(CLOCK_REALTIME, &ts);
+	int rc = clock_gettime(CLOCK_REALTIME, &ts);
+	if (rc != 0)
+		panic_syserror("clock_gettime failed");
 	return ((int64_t)ts.tv_sec) * 1000000000 + ts.tv_nsec;
-
 }
 
 int64_t
 clock_monotonic64(void)
 {
 	struct timespec ts;
-	clock_gettime(CLOCK_MONOTONIC, &ts);
+	int rc = clock_gettime(CLOCK_MONOTONIC, &ts);
+	if (rc != 0)
+		panic_syserror("clock_gettime failed");
 	return ((int64_t)ts.tv_sec) * 1000000000 + ts.tv_nsec;
 }
 
@@ -92,7 +106,9 @@ clock_process64(void)
 {
 #if defined(CLOCK_PROCESS_CPUTIME_ID)
 	struct timespec ts;
-	clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts);
+	int rc = clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts);
+	if (rc != 0)
+		panic_syserror("clock_gettime failed");
 	return ((int64_t)ts.tv_sec) * 1000000000 + ts.tv_nsec;
 #else
 	return (int64_t)clock() * 1000000000 / CLOCKS_PER_SEC;
@@ -104,7 +120,9 @@ clock_thread64(void)
 {
 #if defined(CLOCK_THREAD_CPUTIME_ID)
 	struct timespec ts;
-	clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts);
+	int rc = clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts);
+	if (rc != 0)
+		panic_syserror("clock_gettime failed");
 	return ((int64_t)ts.tv_sec) * 1000000000 + ts.tv_nsec;
 #else
 	return (int64_t)clock() * 1000000000 / CLOCKS_PER_SEC;

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -86,7 +86,6 @@ static void
 cpu_stat_start(struct cpu_stat *stat)
 {
 	stat->prev_clock = clock_monotonic64();
-	stat->cpu_miss_count = 0;
 	/*
 	 * We want to measure thread cpu time here to calculate
 	 * each fiber's cpu time, so don't use libev's ev_now() or
@@ -99,7 +98,6 @@ cpu_stat_start(struct cpu_stat *stat)
 static inline void
 cpu_stat_reset(struct cpu_stat *stat)
 {
-	stat->prev_cpu_miss_count = 0;
 	cpu_stat_start(stat);
 }
 
@@ -124,9 +122,6 @@ cpu_stat_on_csw(struct cpu_stat *stat)
 static double
 cpu_stat_end(struct cpu_stat *stat, struct clock_stat *cord_clock_stat)
 {
-	stat->prev_cpu_miss_count = stat->cpu_miss_count;
-	stat->cpu_miss_count = 0;
-
 	double nsec_per_clock = 0;
 	uint64_t delta_time = clock_thread64();
 	if (delta_time > stat->prev_cputime && cord_clock_stat->delta > 0) {

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -47,7 +47,6 @@
 extern void cord_on_yield(void);
 
 #if ENABLE_FIBER_TOP
-#include <x86intrin.h> /* __rdtscp() */
 
 static inline void
 clock_stat_add_delta(struct clock_stat *stat, uint64_t clock_delta)
@@ -86,7 +85,7 @@ clock_stat_reset(struct clock_stat *stat)
 static void
 cpu_stat_start(struct cpu_stat *stat)
 {
-	stat->prev_clock = __rdtscp(&stat->prev_cpu_id);
+	stat->prev_clock = clock_monotonic64();
 	stat->cpu_miss_count = 0;
 	/*
 	 * We want to measure thread cpu time here to calculate
@@ -107,18 +106,18 @@ cpu_stat_reset(struct cpu_stat *stat)
 static uint64_t
 cpu_stat_on_csw(struct cpu_stat *stat)
 {
-	uint32_t cpu_id;
-	uint64_t delta, clock = __rdtscp(&cpu_id);
-
-	if (cpu_id == stat->prev_cpu_id) {
-		delta = clock - stat->prev_clock;
-	} else {
+	uint64_t delta, clock = clock_monotonic64();
+	/*
+	 * Just in case. On Linux CLOCK_MONOTONIC guarantee that the
+	 * time returned by consecutive calls to clock_gettime will not
+	 * go backwards, however for other systems it might not be true.
+	 */
+	if (clock < stat->prev_clock)
 		delta = 0;
-		stat->prev_cpu_id = cpu_id;
-		stat->cpu_miss_count++;
-	}
-	stat->prev_clock = clock;
+	else
+		delta = clock - stat->prev_clock;
 
+	stat->prev_clock = clock;
 	return delta;
 }
 

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -114,9 +114,6 @@ struct cpu_stat {
 	 * 1 / FIBER_TIME_RES seconds.
 	 */
 	uint64_t prev_cputime;
-	uint32_t prev_cpu_id;
-	uint32_t cpu_miss_count;
-	uint32_t prev_cpu_miss_count;
 };
 
 #endif /* ENABLE_FIBER_TOP */

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -55,21 +55,10 @@
  */
 #define FIBER_LUA_NOREF (-2)
 
-/*
- * Fiber top doesn't work on ARM processors at the moment,
- * because we haven't chosen an alternative to rdtsc.
- */
-#if !defined(__amd64__) && !defined(__i386__) && !defined(__x86_64__)
-#define ENABLE_FIBER_TOP 0
-#else
-#define ENABLE_FIBER_TOP 1
-#endif
-
 #if defined(__cplusplus)
 extern "C" {
 #endif /* defined(__cplusplus) */
 
-#if ENABLE_FIBER_TOP
 /* A fiber reports used up CPU time with nanosecond resolution. */
 #define FIBER_TIME_RES 1000000000
 
@@ -115,8 +104,6 @@ struct cpu_stat {
 	 */
 	uint64_t prev_cputime;
 };
-
-#endif /* ENABLE_FIBER_TOP */
 
 enum {
 	/** Both limits include terminating 0. */
@@ -567,9 +554,7 @@ struct fiber {
 	uint64_t fid;
 	/** Fiber flags */
 	uint32_t flags;
-#if ENABLE_FIBER_TOP
 	struct clock_stat clock_stat;
-#endif /* ENABLE_FIBER_TOP */
 	/** Link in cord->alive or cord->dead list. */
 	struct rlist link;
 	/** Link in cord->ready list. */
@@ -685,10 +670,8 @@ struct cord {
 	 * reserved.
 	 */
 	uint64_t next_fid;
-#if ENABLE_FIBER_TOP
 	struct clock_stat clock_stat;
 	struct cpu_stat cpu_stat;
-#endif /* ENABLE_FIBER_TOP */
 	pthread_t id;
 	const struct cord_on_exit *on_exit;
 	/** A helper hash to map id -> fiber. */
@@ -725,7 +708,6 @@ struct cord {
 	 * is no 1 ms delay in case of zero sleep timeout.
 	 */
 	ev_idle idle_event;
-#if ENABLE_FIBER_TOP
 	/** An event triggered on every event loop iteration start. */
 	ev_check check_event;
 	/**
@@ -734,7 +716,6 @@ struct cord {
 	 * time calculations.
 	 */
 	ev_prepare prepare_event;
-#endif /* ENABLE_FIBER_TOP */
 	/** A memory cache for (struct fiber) */
 	struct mempool fiber_mempool;
 	/** A runtime slab cache for general use in this cord. */
@@ -895,7 +876,6 @@ typedef int (*fiber_stat_cb)(struct fiber *f, void *ctx);
 int
 fiber_stat(fiber_stat_cb cb, void *cb_ctx);
 
-#if ENABLE_FIBER_TOP
 bool
 fiber_top_is_enabled(void);
 
@@ -904,7 +884,6 @@ fiber_top_enable(void);
 
 void
 fiber_top_disable(void);
-#endif /* ENABLE_FIBER_TOP */
 
 #ifdef ENABLE_BACKTRACE
 /*

--- a/src/lua/fiber.c
+++ b/src/lua/fiber.c
@@ -285,10 +285,6 @@ lbox_fiber_top(struct lua_State *L)
 			      " fiber.top_enable() first");
 	}
 	lua_newtable(L);
-	lua_pushliteral(L, "cpu_misses");
-	lua_pushnumber(L, cord()->cpu_stat.prev_cpu_miss_count);
-	lua_settable(L, -3);
-
 	lua_pushliteral(L, "cpu");
 	lua_newtable(L);
 	lbox_fiber_top_entry(&cord()->sched, L);

--- a/src/lua/fiber.c
+++ b/src/lua/fiber.c
@@ -182,11 +182,9 @@ lbox_fiber_statof_map(struct fiber *f, void *cb_ctx, bool backtrace)
 	lua_pushnumber(L, f->csw);
 	lua_settable(L, -3);
 
-#if ENABLE_FIBER_TOP
 	lua_pushliteral(L, "time");
 	lua_pushnumber(L, f->clock_stat.cputime / (double) FIBER_TIME_RES);
 	lua_settable(L, -3);
-#endif /* ENABLE_FIBER_TOP */
 
 	lua_pushliteral(L, "memory");
 	lua_newtable(L);
@@ -240,7 +238,6 @@ lbox_fiber_statof_nobt(struct fiber *f, void *cb_ctx)
 	return lbox_fiber_statof(f, cb_ctx, false);
 }
 
-#if ENABLE_FIBER_TOP
 static int
 lbox_fiber_top_entry(struct fiber *f, void *cb_ctx)
 {
@@ -309,7 +306,6 @@ lbox_fiber_top_disable(struct lua_State *L)
 	fiber_top_disable();
 	return 0;
 }
-#endif /* ENABLE_FIBER_TOP */
 
 #ifdef ENABLE_BACKTRACE
 bool
@@ -825,11 +821,9 @@ static const struct luaL_Reg lbox_fiber_meta [] = {
 
 static const struct luaL_Reg fiberlib[] = {
 	{"info", lbox_fiber_info},
-#if ENABLE_FIBER_TOP
 	{"top", lbox_fiber_top},
 	{"top_enable", lbox_fiber_top_enable},
 	{"top_disable", lbox_fiber_top_disable},
-#endif /* ENABLE_FIBER_TOP */
 #ifdef ENABLE_BACKTRACE
 	{"parent_backtrace_enable", lbox_fiber_parent_backtrace_enable},
 	{"parent_backtrace_disable", lbox_fiber_parent_backtrace_disable},

--- a/test/app/fiber.result
+++ b/test/app/fiber.result
@@ -1487,7 +1487,7 @@ if is_fiber_top then\
 end
 ---
 ...
-a = is_fiber_top and fiber.top() or {cpu = {["1/sched"] = {}}, cpu_misses = 0}
+a = is_fiber_top and fiber.top() or {cpu = {["1/sched"] = {}}}
 ---
 ...
 type(a) == 'table'
@@ -1497,10 +1497,6 @@ type(a) == 'table'
 -- scheduler is present in fiber.top()
 -- and is indexed by name
 a.cpu["1/sched"] ~= nil
----
-- true
-...
-type(a.cpu_misses) == 'number'
 ---
 - true
 ...

--- a/test/app/fiber.test.lua
+++ b/test/app/fiber.test.lua
@@ -647,12 +647,11 @@ if is_fiber_top then\
     while fiber.top().cpu["1/sched"].instant == 0 do fiber.yield() end\
 end
 
-a = is_fiber_top and fiber.top() or {cpu = {["1/sched"] = {}}, cpu_misses = 0}
+a = is_fiber_top and fiber.top() or {cpu = {["1/sched"] = {}}}
 type(a) == 'table'
 -- scheduler is present in fiber.top()
 -- and is indexed by name
 a.cpu["1/sched"] ~= nil
-type(a.cpu_misses) == 'number'
 sum_inst = 0
 sum_avg = is_fiber_top and 0 or 100
 


### PR DESCRIPTION
###     fiber: use clock_monotonic64 instead of __rdtscp

clock_gettime(CLOCK_MONOTONIC) is implemented via the RDTSCP instruction
on x86 an has the following advantages over the raw instruction:

* It checks for RDTSCP availability in CPUID.
  If RDTSCP is not supported, it switches to RDTSC.
* Linux guarantee that clock is monotonic, hence, the CPU miss
  detection is not needed.
* It works on ARM.

As for disadvantage, this function is about 2x slower compared to a
single RDTSCP instruction. Performance degradation measured by the
[fiber switch benchmark](https://github.com/tarantool/tarantool/issues/2694#issuecomment-546381304) is about 7% for num_fibers = 100/1000.

Closes #4573
Closes #5869