### PR TITLE
memtx: rework transaction rollback

### DIFF
--- a/changelogs/unreleased/gh-7343-unserializable-read-tracked-incorrectly-after-rollback.md
+++ b/changelogs/unreleased/gh-7343-unserializable-read-tracked-incorrectly-after-rollback.md
@@ -1,0 +1,4 @@
+## bugfix/memtx
+
+* Fixed unserializable reads tracked incorrectly after transaction rollback
+  (gh-7343).

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -2044,6 +2044,25 @@ memtx_tx_history_add_stmt(struct txn_stmt *stmt, struct tuple *old_tuple,
 							result);
 }
 
+/*
+ * Push story down the history chain to the level of prepared stories in each
+ * index.
+ */
+static void
+memtx_tx_history_sink_story(struct memtx_story *story)
+{
+	for (uint32_t i = 0; i < story->index_count; ) {
+		struct memtx_story *old_story = story->link[i].older_story;
+		if (old_story == NULL || old_story->add_psn != 0 ||
+		    old_story->add_stmt == NULL) {
+			/* Old story is absent or prepared or committed. */
+			i++; /* Go to the next index. */
+			continue;
+		}
+		memtx_tx_story_reorder(story, old_story, i);
+	}
+}
+
 void
 memtx_tx_history_rollback_stmt(struct txn_stmt *stmt)
 {
@@ -2105,20 +2124,7 @@ memtx_tx_history_prepare_insert_stmt(struct txn_stmt *stmt)
 	 */
 	struct memtx_story *story = stmt->add_story;
 	uint32_t index_count = story->index_count;
-	/*
-	 * That's a common loop for both index iteration and sequential push
-	 * of the story down in lists of stories.
-	 */
-	for (uint32_t i = 0; i < story->index_count; ) {
-		struct memtx_story *old_story = story->link[i].older_story;
-		if (old_story == NULL || old_story->add_psn != 0 ||
-		    old_story->add_stmt == NULL) {
-			/* Old story is absent or prepared or committed. */
-			i++; /* Go to the next index. */
-			continue;
-		}
-		memtx_tx_story_reorder(story, old_story, i);
-	}
+	memtx_tx_history_sink_story(story);
 
 	struct memtx_story *old_story = story->link[0].older_story;
 	if (stmt->del_story == NULL)

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -801,6 +801,7 @@ memtx_tx_story_new(struct space *space, struct tuple *tuple,
 		rlist_create(&story->link[i].nearby_gaps);
 		story->link[i].in_index = space->index[i];
 	}
+	story->rollbacked = false;
 	return story;
 }
 
@@ -1147,28 +1148,31 @@ memtx_tx_story_unlink_both(struct memtx_story *story, uint32_t idx)
 	assert(idx < story->index_count);
 	struct memtx_story_link *link = &story->link[idx];
 
+	struct memtx_story *newer_story = link->newer_story;
+	struct memtx_story *older_story = link->older_story;
 	if (link->newer_story == NULL) {
 		memtx_tx_story_unlink_top(story, idx);
 	} else {
-		struct memtx_story *newer_story = link->newer_story;
-		struct memtx_story *older_story = link->older_story;
 		memtx_tx_story_unlink(newer_story, story, idx);
 		memtx_tx_story_unlink(story, older_story, idx);
 		memtx_tx_story_link(newer_story, older_story, idx);
-
-		/*
-		 * Rebind read trackers in order to conflict
-		 * readers in case of rollback of this txn.
-		 */
-		struct tx_read_tracker *tracker, *tmp;
-		uint64_t index_mask = 1ull << (idx & 63);
-		rlist_foreach_entry_safe(tracker, &story->reader_list,
-					 in_reader_list, tmp) {
-			if ((tracker->index_mask & index_mask) != 0) {
-				memtx_tx_track_read_story_slow(tracker->reader,
-							       newer_story,
-							       index_mask);
-			}
+	}
+	/*
+	 * Rebind read trackers in order to conflict
+	 * readers in case of rollback of this txn.
+	 */
+	struct memtx_story *rebind_story =
+		newer_story != NULL ? newer_story : older_story;
+	struct tx_read_tracker *tracker, *tmp;
+	uint64_t index_mask = 1ull << (idx & 63);
+	rlist_foreach_entry_safe(tracker, &story->reader_list,
+				 in_reader_list, tmp) {
+		if ((tracker->index_mask & index_mask) != 0) {
+			memtx_tx_track_read_story_slow(tracker->reader,
+						       rebind_story,
+						       index_mask);
+			rlist_del(&tracker->in_reader_list);
+			rlist_del(&tracker->in_read_set);
 		}
 	}
 }
@@ -1231,6 +1235,9 @@ memtx_tx_story_full_unlink(struct memtx_story *story)
 			 * index.
 			 */
 			if (story->del_psn > 0 && link->in_index != NULL) {
+				assert(!story->rollbacked ||
+				       link->older_story == NULL);
+
 				struct index *index = link->in_index;
 				struct tuple *removed, *unused;
 				if (index_replace(index, story->tuple, NULL,
@@ -1348,6 +1355,9 @@ memtx_tx_story_is_visible(struct memtx_story *story, struct txn *txn,
 {
 	*is_own_change = false;
 	*visible_tuple = NULL;
+
+	if (story->rollbacked)
+		return false;
 
 	int64_t rv_psn = INT64_MAX;
 	if (txn != NULL && txn->rv_psn != 0)
@@ -2094,9 +2104,19 @@ memtx_tx_history_rollback_added_story(struct txn_stmt *stmt)
 	assert(stmt->add_story->tuple == stmt->rollback_info.new_tuple);
 	struct memtx_story *story = stmt->add_story;
 	memtx_tx_history_remove_story_del_stmts(story);
-	for (uint32_t i = 0; i < story->index_count; i++)
+	for (uint32_t i = 0; i < story->index_count; i++) {
+		struct memtx_story_link *link = &story->link[i];
+		if (link->newer_story == NULL && link->older_story == NULL) {
+			story->rollbacked = true;
+			continue;
+		}
 		memtx_tx_story_unlink_both(story, i);
+	}
 	memtx_tx_story_unlink_added_by(story, stmt);
+	if (!story->rollbacked) {
+		assert(rlist_empty(&story->reader_list));
+		memtx_tx_story_delete(story);
+	}
 }
 
 /*
@@ -2112,8 +2132,12 @@ memtx_tx_history_rollback_deleted_story(struct txn_stmt *stmt)
 void
 memtx_tx_history_rollback_stmt(struct txn_stmt *stmt)
 {
-	if (stmt->add_story != NULL)
+	assert(stmt->txn->psn != 0);
+	if (stmt->add_story != NULL) {
+		stmt->add_story->add_psn = stmt->txn->psn;
+		stmt->add_story->del_psn = stmt->txn->psn;
 		memtx_tx_history_rollback_added_story(stmt);
+	}
 	if (stmt->del_story != NULL)
 		memtx_tx_history_rollback_deleted_story(stmt);
 	assert(stmt->add_story == NULL && stmt->del_story == NULL);
@@ -2125,7 +2149,13 @@ memtx_tx_history_rollback_stmt(struct txn_stmt *stmt)
 static void
 memtx_tx_history_remove_added_story(struct txn_stmt *stmt)
 {
-	memtx_tx_history_rollback_added_story(stmt);
+	assert(stmt->add_story != NULL);
+	assert(stmt->add_story->tuple == stmt->rollback_info.new_tuple);
+	struct memtx_story *story = stmt->add_story;
+	memtx_tx_history_remove_story_del_stmts(story);
+	for (uint32_t i = 0; i < story->index_count; i++)
+		memtx_tx_story_unlink_both(story, i);
+	memtx_tx_story_unlink_added_by(story, stmt);
 }
 
 /*
@@ -2163,10 +2193,18 @@ memtx_tx_history_prepare_insert_stmt(struct txn_stmt *stmt)
 	 * The list begins with several (or zero) of stories that are added by
 	 * in-progress transactions, then the list continues with several
 	 * (or zero) of prepared stories, which are followed by several
-	 * (or zero) of committed stories.
-	 * If a statement becomes prepared, its story must be moved to the
-	 * point in list exactly between all still in-progress and all already
-	 * prepared.
+	 * (or zero) of committed stories, interleaved by rollbacked stories. We
+	 * have the following totally ordered set over tuple stories:
+	 *
+	 * —————————————————————————————————————————————————> serialization time
+	 * |- - - - - - - -|— — — — — -|— — — — — |— — — — — — -|— — — — — — — -
+	 * | No more than  | Committed | Prepared | In-progress | One dirty
+	 * | one rollbacked|           |          |             | story in index
+	 * | story         |           |          |             |
+	 * |- - - - - - - -|— — — — — -| — — — — —|— — — — — — -|— — — — — — — —
+	 *
+	 * If a statement becomes prepared, the story it adds must be 'sunk' to
+	 * the level of prepared stories.
 	 */
 	struct memtx_story *story = stmt->add_story;
 	uint32_t index_count = story->index_count;
@@ -2174,9 +2212,11 @@ memtx_tx_history_prepare_insert_stmt(struct txn_stmt *stmt)
 
 	struct memtx_story *old_story = story->link[0].older_story;
 	if (stmt->del_story == NULL)
-		assert(old_story == NULL || old_story->del_psn != 0);
+		assert(old_story == NULL || old_story->rollbacked ||
+		       old_story->del_psn != 0);
 	else
-		assert(stmt->del_story == story->link[0].older_story);
+		assert(old_story != NULL &&
+		       (old_story->rollbacked || stmt->del_story == old_story));
 
 	if (stmt->del_story == NULL) {
 		/*
@@ -2208,6 +2248,11 @@ memtx_tx_history_prepare_insert_stmt(struct txn_stmt *stmt)
 
 			memtx_tx_story_link_deleted_by(story, test_stmt);
 		}
+	}
+
+	if (old_story != NULL && old_story->rollbacked) {
+		assert(old_story->link[0].older_story == NULL);
+		old_story = NULL;
 	}
 
 	if (old_story != NULL) {
@@ -2507,8 +2552,13 @@ memtx_tx_index_invisible_count_slow(struct txn *txn,
 		 * A history chain is represented by the top story, which is
 		 * stored in index.
 		 */
-		if (link->in_index == NULL)
+		if (link->in_index == NULL) {
+			assert(link->newer_story != NULL ||
+			       (story->rollbacked &&
+				link->older_story == NULL));
 			continue;
+		}
+		assert(link->newer_story == NULL);
 
 		struct tuple *visible = NULL;
 		bool is_prepared_ok = detect_whether_prepared_ok(txn);

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -2122,6 +2122,36 @@ memtx_tx_history_rollback_stmt(struct txn_stmt *stmt)
 	assert(stmt->add_story == NULL && stmt->del_story == NULL);
 }
 
+/*
+ * Completely remove statement that adds a story.
+ */
+static void
+memtx_tx_history_remove_added_story(struct txn_stmt *stmt)
+{
+	memtx_tx_history_rollback_added_story(stmt);
+}
+
+/*
+ * Completely remove statement that deletes a story.
+ */
+static void
+memtx_tx_history_remove_deleted_story(struct txn_stmt *stmt)
+{
+	memtx_tx_history_rollback_deleted_story(stmt);
+}
+
+/*
+ * Completely (as opposed to rollback) remove statement from history.
+ */
+static void
+memtx_tx_history_remove_stmt(struct txn_stmt *stmt)
+{
+	if (stmt->add_story != NULL)
+		memtx_tx_history_remove_added_story(stmt);
+	if (stmt->del_story != NULL)
+		memtx_tx_history_remove_deleted_story(stmt);
+}
+
 /**
  * Helper of memtx_tx_history_prepare_stmt. Do the job in case when
  * stmt->add_story != NULL, that is REPLACE, INSERT, UPDATE etc.
@@ -2551,10 +2581,9 @@ memtx_tx_on_space_delete(struct space *space)
 		 * should be destroyed immediately.
 		 */
 		if (story->add_stmt != NULL)
-			memtx_tx_history_rollback_stmt(story->add_stmt);
+			memtx_tx_history_remove_stmt(story->add_stmt);
 		if (story->del_stmt != NULL)
-			memtx_tx_history_rollback_stmt(story->del_stmt);
-		rlist_del(&story->in_space_stories);
+			memtx_tx_history_remove_stmt(story->del_stmt);
 		memtx_tx_story_full_unlink(story);
 		memtx_tx_story_delete(story);
 	}

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -2045,6 +2045,28 @@ memtx_tx_history_add_stmt(struct txn_stmt *stmt, struct tuple *old_tuple,
 }
 
 /*
+ * Relink those who delete this story and make them delete older story.
+ */
+static void
+memtx_tx_history_remove_story_del_stmts(struct memtx_story *story)
+{
+	struct memtx_story *old_story = story->link[0].older_story;
+	while (story->del_stmt) {
+		struct txn_stmt *del_stmt = story->del_stmt;
+
+		/* Unlink from old list in any case. */
+		story->del_stmt = del_stmt->next_in_del_list;
+		del_stmt->next_in_del_list = NULL;
+		del_stmt->del_story = NULL;
+
+		/* Link to old story's list. */
+		if (old_story != NULL)
+			memtx_tx_story_link_deleted_by(old_story,
+						       del_stmt);
+	}
+}
+
+/*
  * Push story down the history chain to the level of prepared stories in each
  * index.
  */
@@ -2070,25 +2092,7 @@ memtx_tx_history_rollback_stmt(struct txn_stmt *stmt)
 		assert(stmt->add_story->tuple == stmt->rollback_info.new_tuple);
 		struct memtx_story *story = stmt->add_story;
 
-		/*
-		 * Relink those who delete this story and make them
-		 * delete older story.
-		 */
-		struct memtx_story_link *link = &story->link[0];
-		struct memtx_story *old_story = link->older_story;
-		while (story->del_stmt) {
-			struct txn_stmt *del_stmt = story->del_stmt;
-
-			/* Unlink from old list in any case. */
-			story->del_stmt = del_stmt->next_in_del_list;
-			del_stmt->next_in_del_list = NULL;
-			del_stmt->del_story = NULL;
-
-			/* Link to old story's list. */
-			if (old_story != NULL)
-				memtx_tx_story_link_deleted_by(old_story,
-							       del_stmt);
-		}
+		memtx_tx_history_remove_story_del_stmts(story);
 
 		for (uint32_t i = 0; i < story->index_count; i++)
 			memtx_tx_story_unlink_both(story, i);

--- a/src/box/memtx_tx.h
+++ b/src/box/memtx_tx.h
@@ -207,6 +207,14 @@ struct memtx_story {
 	 * the story is the only reason why @a tuple cannot be deleted.
 	 */
 	bool tuple_is_retained;
+	/*
+	 * Transaction that added this story was rollbacked: this story is
+	 * absolutely invisible — its only purpose is to retain the reader list.
+	 * It is present at the end of some history chains and completely
+	 * unlinked from others, which also implies it is not present in the
+	 * corresponding indexes.
+	 */
+	bool rollbacked;
 	/**
 	 * Link with older and newer stories (and just tuples) for each
 	 * index respectively.

--- a/src/box/memtx_tx.h
+++ b/src/box/memtx_tx.h
@@ -193,10 +193,6 @@ struct memtx_story {
 	 */
 	struct rlist in_space_stories;
 	/**
-	 * The space where the tuple is supposed to be.
-	 */
-	struct space *space;
-	/**
 	 * Number of indexes in this space - and the count of link[].
 	 */
 	uint32_t index_count;

--- a/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
+++ b/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
@@ -6,7 +6,7 @@ local g = t.group()
 -- Please update them, if you changed the relevant structures.
 local SIZE_OF_STMT = 136
 -- Size of story with one link (for spaces with 1 index).
-local SIZE_OF_STORY = 152
+local SIZE_OF_STORY = 144
 -- Size of tuple with 2 number fields
 local SIZE_OF_TUPLE = 9
 -- Size of xrow for tuples with 2 number fields

--- a/test/box-luatest/gh_7343_unserializable_read_tracked_incorrectly_after_rollback_test.lua
+++ b/test/box-luatest/gh_7343_unserializable_read_tracked_incorrectly_after_rollback_test.lua
@@ -1,0 +1,53 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local pg = t.group(nil, t.helpers.matrix({op = {'get', 'delete', 'update'}}))
+
+pg.before_all(function(cg)
+    cg.server = server:new{
+        alias   = 'dflt',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    cg.server:start()
+    cg.server:exec(function()
+        box.schema.create_space('s')
+        box.space.s:create_index('pk')
+    end)
+end)
+
+pg.after_all(function(cg)
+    cg.server:drop()
+end)
+
+--[[
+Checks that unserializable reads are tracked correctly after transaction
+rollback.
+]]
+pg.test_unserializable_read_after_rollback = function(cg)
+    local stream1 = cg.server.net_box:new_stream()
+    local stream2 = cg.server.net_box:new_stream()
+    local stream3 = cg.server.net_box:new_stream()
+
+    stream1:begin()
+    stream2:begin()
+    stream3:begin()
+
+    stream1.space.s:replace{0, 0}
+
+    local args = {{0}}
+    if cg.params.op == 'update' then
+        table.insert(args, {{'=', 2, 0}})
+    end
+    stream2.space.s[cg.params.op](stream2.space.s, unpack(args))
+    stream2.space.s:replace{1, 0}
+
+    stream1:rollback()
+
+    stream3.space.s:insert{0, 1}
+    stream3:commit()
+
+    local conflict_err_msg = 'Transaction has been aborted by conflict'
+    t.assert_error_msg_content_equals(conflict_err_msg, function()
+        stream2:commit()
+    end)
+end

--- a/test/box-luatest/gh_7490_memtx_tx_manager_mvcc_invariant_violation_test.lua
+++ b/test/box-luatest/gh_7490_memtx_tx_manager_mvcc_invariant_violation_test.lua
@@ -1,0 +1,51 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new{
+        alias   = 'dflt',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    cg.server:start()
+    cg.server:exec(function()
+        local s = box.schema.create_space('s')
+        s:create_index('pk')
+        box.internal.memtx_tx_gc(100)
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+--[[
+Checks that assertion is fired if memtx transaction manager MVCC invariant is
+violated.
+]]
+g.test_memtx_tx_manager_mvcc_invariant_violation = function(cg)
+    local stream = cg.server.net_box:new_stream()
+    stream:begin()
+
+    cg.server:exec(function()
+        box.space.s:insert{0, 0}
+    end)
+
+    -- Pins {0, 0} so it doesn't get garbage collected early.
+    stream.space.s:select{0}
+
+    cg.server:exec(function()
+        box.space.s:replace{0, 1}
+    end)
+
+    -- Releases {0, 0}.
+    stream:commit()
+    -- Now {0, 1} which is at the top of {0} key's history chain can get garbage
+    -- collected.
+    cg.server:exec(function()
+        box.space.s:delete{0}
+    end)
+
+    box.internal.memtx_tx_gc(100)
+end

--- a/test/box/tx_man.result
+++ b/test/box/tx_man.result
@@ -1914,6 +1914,60 @@ tx2:commit()
  | - - {'error': 'Transaction has been aborted by conflict'}
  | ...
 
+-- Check that rolled back story is accounted correctly.
+s:truncate()
+ | ---
+ | ...
+tx1:begin()
+ | ---
+ | - 
+ | ...
+tx1('s:replace{0, 0}')
+ | ---
+ | - - [0, 0]
+ | ...
+tx1:rollback()
+ | ---
+ | - 
+ | ...
+s:count()
+ | ---
+ | - 0
+ | ...
+
+-- Check that invisible read-view story is accounted correctly.
+s:truncate()
+ | ---
+ | ...
+s:insert{0, 0}
+ | ---
+ | - [0, 0]
+ | ...
+tx1:begin()
+ | ---
+ | - 
+ | ...
+tx1('s:select{0}')
+ | ---
+ | - - [[0, 0]]
+ | ...
+s:replace{0, 1}
+ | ---
+ | - [0, 1]
+ | ...
+tx1:commit()
+ | ---
+ | - 
+ | ...
+s:delete{0}
+ | ---
+ | - [0, 1]
+ | ...
+s:count()
+ | ---
+ | - 0
+ | ...
+
 -- Check different orders
 s:truncate()
  | ---
@@ -3832,4 +3886,3 @@ test_run:cmd("cleanup server tx_man")
  | ---
  | - true
  | ...
-

--- a/test/box/tx_man.test.lua
+++ b/test/box/tx_man.test.lua
@@ -596,6 +596,23 @@ check()
 tx1:commit()
 tx2:commit()
 
+-- Check that rolled back story is accounted correctly.
+s:truncate()
+tx1:begin()
+tx1('s:replace{0, 0}')
+tx1:rollback()
+s:count()
+
+-- Check that invisible read-view story is accounted correctly.
+s:truncate()
+s:insert{0, 0}
+tx1:begin()
+tx1('s:select{0}')
+s:replace{0, 1}
+tx1:commit()
+s:delete{0}
+s:count()
+
 -- Check different orders
 s:truncate()
 tx1:begin()
@@ -1241,4 +1258,3 @@ tx1:commit()
 test_run:cmd("switch default")
 test_run:cmd("stop server tx_man")
 test_run:cmd("cleanup server tx_man")
-


### PR DESCRIPTION
When we rollback a transaction statement, we relink its read trackers
to a newer story in the history chain, if present (6c990a7), but we do not
handle the case when there is no newer story.

In order to fix this, we need to retain stories added by rollbacked
transactions, because they store the reader list needed for conflict
resolution.

There are several nuances we need to account for:

Firstly, such stories must be impossible to read from an index: this is
ensured by `memtx_tx_tuple_clarify`.

Secondly, rollbacked transactions need to be treated as prepared with
stories that have `add_psn == del_psn` the stories they add need to be
'sunk' to the level of prepared transactions, so now we have the following
totally ordered set over tuple stories:
———————————————————————————————————————————————————————> serialization time
|— — — — — —|— — — — — |— — — — — — | — — — — — — — —
|Committed +|Prepared +| In-progress| One dirty story
|rollbacked |rollbacked|            | in index
|— — — — — —| — — — — —|— — — — — — |— — — — — — — — —

Last, but not least, we also need to consider the following shadowing
effect: if a rollbacked story is on top of the history chain and there are
older stories in the history chain, it can possibly shadow a story of a
prepared or committed tuple, which is not de jure deleted, so instead of
simply deleting the story's tuple from the index, we need to replaced with
the tuple of an older story. In order for this to work, though, we also
need to retain stories of committed and prepared tuples which are not
de jure deleted (have a zero `del_psn`), if there are newer stories in the
history chain which could possibly shadow them.

Closes #7343

**memtx: fix transaction manager MVCC invariant violation**

We hold the following invariant in MVCC: the story at the top of the
history chain is present in index.

If a story is subject to be deleted from index and there is an older story
in the history chain, the older story starts to be at the top of the
history chain and is not present in index, which violates our invariant:
explicitly check for this case when evaluating whether a story can be
garbage collected and add an assertion to check the invariant above is not
violated.

`memtx_tx_story_full_unlink` is called in two context: space deletion, in
which we delete all stories, and garbage collection step — the former case
can break the invariant described above, while the latter must preserve it,
hence add two different functions for the corresponding contexts.

Closes #7490