### PR TITLE
test: fix election_pre_vote flaky failure

### DIFF
--- a/test/replication-luatest/election_pre_vote_test.lua
+++ b/test/replication-luatest/election_pre_vote_test.lua
@@ -36,6 +36,7 @@ g.before_each(function()
     t.assert(g.leader ~= nil, 'Cluster elected a leader')
     g.follower1 = g.node1 ~= g.leader and g.node1 or g.node2
     g.follower2 = g.node3 ~= g.leader and g.node3 or g.node2
+    g.cluster:wait_fullmesh()
 end)
 
 local function get_election_term()


### PR DESCRIPTION
The test failed at the moment when one of the followers disconnects from
the leader and expects its `box.info.election.leader_idle` to grow.

It wasn't taken into account that this disconnect might lead to leader
resign due to fencing, and then a new leader would emerge and
`leader_idle` would still be small.

IOW, leader resumes fencing, once it has connected to at least one
replica in this test. If this replica happens to be the one we
disconnect, the leader might fence, since it hasn't yet connected to the
other replica and has thus lost the quorum of connections.

Fix this by waiting until everyone follows everyone in the test.

The test, of course, could be fixed by turning fencing off, but this
might hide any possible future problems with fencing.

Follow-up #6654
Follow-up #6661

NO_CHANGELOG=test fix
NO_DOC=test fix