### PR TITLE
vinyl: disable deferred deletes if there are upserts on disk

### DIFF
--- a/changelogs/unreleased/gh-3638-vy-defer-deletes-and-upserts.md
+++ b/changelogs/unreleased/gh-3638-vy-defer-deletes-and-upserts.md
@@ -1,0 +1,7 @@
+## bugfix/vinyl
+
+* Fixed a bug in Vinyl because of which the Vinyl garbage collector (compactor)
+  could skip stale tuples stored in a secondary index in case the secondary
+  index was the first secondary index created for the space and upsert
+  operations were used on the space before the secondary index was created
+  (gh-3638).

--- a/test/vinyl-luatest/gh_3638_defer_deletes_and_upserts_test.lua
+++ b/test/vinyl-luatest/gh_3638_defer_deletes_and_upserts_test.lua
@@ -1,0 +1,64 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new{alias = 'master'}
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+--
+-- Checks that stale tuples are deleted from the secondary index in case there
+-- are UPSERT statements in the space (gh-3638).
+--
+g.test_defer_deletes_and_upserts = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.schema.space.create('test', {
+            engine = 'vinyl',
+            defer_deletes = true,
+        })
+        s:create_index('pk', {
+            run_count_per_level = 100, -- disables auto-compaction
+        })
+        -- Add some padding to make sure that the runs will be assigned to
+        -- different levels.
+        --
+        -- Write the first run with REPLACE in it.
+        s:replace{1, 10, string.rep('x', 1000)}
+        box.snapshot()
+        -- Write the second run with UPSERT in it.
+        s:upsert({1, 10, string.rep('x', 100)}, {{'+', 2, 10}})
+        box.snapshot()
+        -- Create a non-unique secondary index.
+        s:create_index('sk', {parts = {2, 'unsigned'}, unique = false})
+        -- Write the third run with DELETE in it.
+        s:delete{1}
+        box.snapshot()
+        -- Check that no compaction is in progress and the primary index
+        -- have three runs with REPLACE, UPSERT, and DELETE.
+        t.assert_covers(box.stat.vinyl().scheduler, {
+            tasks_inprogress = 0, compaction_queue = 0,
+        })
+        t.assert_equals(s.index.pk:stat().run_count, 3)
+        t.assert_equals(s.index.pk:stat().disk.statement, {
+            inserts = 0, replaces = 1, deletes = 1, upserts = 1,
+        })
+        -- Compact the primary index, then the secondary index.
+        -- Check that all runs are deleted.
+        s.index.pk:compact()
+        t.helpers.retrying({}, function()
+            t.assert_equals(s.index.pk:stat().run_count, 0)
+        end)
+        s.index.sk:compact()
+        t.helpers.retrying({}, function()
+            t.assert_equals(s.index.sk:stat().run_count, 0)
+        end)
+        s:drop()
+    end)
+end


### PR DESCRIPTION
Normally, there shouldn't be any upserts on disk if the space has secondary indexes, because we can't generate an upsert without a lookup in the primary index hence we convert upserts to replace+delete in this case. The deferred delete optimization only makes sense if the space has secondary indexes. So we ignore upserts while generating deferred deletes, see `vy_write_iterator_deferred_delete`.

There's an exception to this rule: a secondary index could be created after some upserts were used on the space. In this case, because of the deferred delete optimization, we may never generate deletes for some tuples for the secondary index, as demonstrated in #3638.

We could fix this issue by properly handle upserts in the write iterator while generating deferred delete, but this wouldn't be easy, because in case of a minor compaction there may be no replace/insert to apply the upsert to so we'd have to keep intermediate upserts even if there is a newer delete statement. Since this situation is rare (happens only once in a space life time), it doesn't look like we should complicate the write iterator to fix it.

Another way to fix it is to force major compaction of the primary index after a secondary index is created. This looks doable, but it could slow down creation of secondary indexes. Let's instead simply disable the deferred delete optimization if the primary index has upsert statements. This way the optimization will be enabled sooner or later, when the primary index major compaction occurs. After all, it's just an optimization and it can be disabled for other reasons (e.g. if the space has on_replace triggers).

Closes #3638