### PR TITLE
box: fix unexpected error on granting privileges to admin

### DIFF
--- a/changelogs/unreleased/gh-7226-admin-grant-error.md
+++ b/changelogs/unreleased/gh-7226-admin-grant-error.md
@@ -1,0 +1,5 @@
+## bugfix/box
+
+* Fixed internal error on granting rights to admin user. Now granting still
+fail but for proper reason and proper error message like "right is already
+granted" (gh-7226).

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -3310,6 +3310,7 @@ local function grant(uid, name, privilege, object_type,
         old_privilege = 0
     end
     privilege_hex = bit.bor(privilege_hex, old_privilege)
+    privilege_hex = tonumber(ffi.cast('uint32_t', privilege_hex))
     -- do not execute a replace if it does not change anything
     -- XXX bug if we decide to add a grant option: new grantor
     -- replaces the old one, old grantor is lost

--- a/test/box-luatest/gh_7226_admin_grant_error_test.lua
+++ b/test/box-luatest/gh_7226_admin_grant_error_test.lua
@@ -1,0 +1,24 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all = function()
+    g.server = server:new{alias = 'default'}
+    g.server:start()
+end
+
+g.after_all = function()
+    g.server:drop()
+end
+
+g.test_grainting_to_admin = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local function grant()
+            box.schema.user.grant('admin', 'read', 'universe', nil, nil)
+        end
+        local msg = "User 'admin' already has read access on universe"
+        t.assert_error_msg_content_equals(msg, grant)
+    end)
+end


### PR DESCRIPTION
We use LuaJIT 'bit' module for bitwise operations. Due to platform
interoperability it truncates arguments to 32bit and returns signed
result. Thus on granting rights using bit.bor to admin user which
have 0xffffffff rights (from bootstrap snapshot) we get -1 as a result.
This leads to type check error given in issue later in execution.

Closes #7226

NO_DOC=minor bugfix