### PR TITLE
http_parser: fix parsing HTTP protocol version

### DIFF
--- a/changelogs/unreleased/gh-7319-fix-http.client-reply-proto-parser.md
+++ b/changelogs/unreleased/gh-7319-fix-http.client-reply-proto-parser.md
@@ -1,0 +1,4 @@
+## bugfix/lib
+
+* Fixed http.client to properly parse HTTP status header like 'HTTP/2 200' where
+  HTTP version does not have minor part (gh-7319).

--- a/src/lib/http_parser/http_parser.c
+++ b/src/lib/http_parser/http_parser.c
@@ -54,11 +54,11 @@ void http_parser_create(struct http_parser *parser)
  * Utility function used in headers parsing
  */
 static int
-http_parse_status_line(struct http_parser *parser, char **bufp,
+http_parse_status_line(struct http_parser *parser, const char **bufp,
 		       const char *end_buf)
 {
 	char ch;
-	char *p = *bufp;
+	const char *p = *bufp;
 	enum {
 		sw_start = 0,
 		sw_H,
@@ -218,13 +218,13 @@ done:
 }
 
 int
-http_parse_header_line(struct http_parser *prsr, char **bufp,
+http_parse_header_line(struct http_parser *prsr, const char **bufp,
 		       const char *end_buf, int max_hname_len)
 {
 	char c;
 	unsigned char ch;
-	char *p = *bufp;
-	char *header_name_start = p;
+	const char *p = *bufp;
+	const char *header_name_start = p;
 	prsr->hdr_name_idx = 0;
 
 	enum {

--- a/src/lib/http_parser/http_parser.c
+++ b/src/lib/http_parser/http_parser.c
@@ -125,6 +125,11 @@ http_parse_status_line(struct http_parser *parser, const char **bufp,
 				state = sw_first_minor_digit;
 				break;
 			}
+			if (ch == ' ') {
+				parser->http_minor = 0;
+				state = sw_status;
+				break;
+			}
 			if (ch < '0' || ch > '9') {
 				return HTTP_PARSE_INVALID;
 			}

--- a/src/lib/http_parser/http_parser.h
+++ b/src/lib/http_parser/http_parser.h
@@ -39,13 +39,31 @@ enum {
 };
 
 struct http_parser {
-	char *hdr_value_start;
-	char *hdr_value_end;
+	/**
+	 * Pointer to header field value start.
+	 */
+	const char *hdr_value_start;
+	/**
+	 * Pointer to header field value end (exlusive).
+	 */
+	const char *hdr_value_end;
 
+	/**
+	 * HTTP protocol version major number.
+	 */
 	int http_major;
+	/**
+	 * HTTP protocol version minor number.
+	 */
 	int http_minor;
 
+	/**
+	 * Pointer to header field name start.
+	 */
 	char *hdr_name;
+	/**
+	 * Length of header field name.
+	 */
 	int hdr_name_idx;
 };
 
@@ -65,7 +83,7 @@ void http_parser_create(struct http_parser *parser);
  *		HTTP_PARSE_INVALID - error during parsing
  */
 int
-http_parse_header_line(struct http_parser *prsr, char **bufp,
+http_parse_header_line(struct http_parser *prsr, const char **bufp,
 		       const char *end_buf, int max_hname_len);
 
 #endif /* TARANTOOL_LIB_HTTP_PARSER_HTTP_PARSER_H_INCLUDED */

--- a/src/lib/http_parser/http_parser.h
+++ b/src/lib/http_parser/http_parser.h
@@ -44,7 +44,7 @@ struct http_parser {
 	 */
 	const char *hdr_value_start;
 	/**
-	 * Pointer to header field value end (exlusive).
+	 * Pointer to header field value end (exclusive).
 	 */
 	const char *hdr_value_end;
 

--- a/src/lua/httpc.c
+++ b/src/lua/httpc.c
@@ -61,7 +61,7 @@ lua_add_key_u64(lua_State *L, const char *key, uint64_t value)
 }
 
 static int
-parse_headers(lua_State *L, char *buffer, size_t len,
+parse_headers(lua_State *L, const char *buffer, size_t len,
 	      int max_header_name_len)
 {
 	struct http_parser parser;
@@ -72,7 +72,7 @@ parse_headers(lua_State *L, char *buffer, size_t len,
 			 "malloc", "hdr_name");
 		return -1;
 	}
-	char *end_buf = buffer + len;
+	const char *end_buf = buffer + len;
 	lua_pushstring(L, "headers");
 	lua_newtable(L);
 	while (true) {

--- a/test/fuzz/http_parser_fuzzer.c
+++ b/test/fuzz/http_parser_fuzzer.c
@@ -6,12 +6,12 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
 	struct http_parser parser;
-	char *buf = (char *)data;
+	const char *buf = (char *)data;
 	http_parser_create(&parser);
 	parser.hdr_name = (char *)calloc(size, sizeof(char));
 	if (parser.hdr_name == NULL)
 		return 0;
-	char *end_buf = buf + size;
+	const char *end_buf = buf + size;
 	http_parse_header_line(&parser, &buf, end_buf, size);
 	free(parser.hdr_name);
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -178,6 +178,9 @@ target_link_libraries(csv.test csv)
 add_executable(json.test json.c)
 target_link_libraries(json.test json unit ${ICU_LIBRARIES})
 
+add_executable(http_parser.test http_parser.c)
+target_link_libraries(http_parser.test unit http_parser)
+
 add_executable(rmean.test rmean.cc core_test_utils.c)
 target_link_libraries(rmean.test stat unit)
 add_executable(histogram.test histogram.c core_test_utils.c)

--- a/test/unit/http_parser.c
+++ b/test/unit/http_parser.c
@@ -1,0 +1,53 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "trivia/util.h"
+#include "http_parser/http_parser.h"
+
+#define UNIT_TAP_COMPATIBLE 1
+#include "unit.h"
+
+static void
+test_protocol_version(void)
+{
+	static const struct {
+		const char *status;
+		int major;
+		int minor;
+	} tests[] = {
+		{ "HTTP/1.1 200\r\n", 1, 1 },
+		{ "HTTP/2.0 301\r\n", 2, 0 },
+		{ "HTTP/2 200\r\n", 2, 0 },
+	};
+	char buf[10];
+
+	plan(6);
+	header();
+
+	for (size_t i = 0; i < lengthof(tests); i++) {
+		struct http_parser p;
+		const char *l;
+
+		http_parser_create(&p);
+		p.hdr_name = buf;
+		l = tests[i].status;
+		http_parse_header_line(&p, &l, l + strlen(l), lengthof(buf));
+		is(tests[i].major, p.http_major,
+		   "expected major number is '%d', received '%d' for '%s'",
+		   tests[i].major, p.http_major, tests[i].status);
+		is(tests[i].minor, p.http_minor,
+		   "expected minor number is '%d', received '%d' for '%s'",
+		   tests[i].minor, p.http_minor, tests[i].status);
+	}
+
+	footer();
+	check_plan();
+}
+
+int
+main(void)
+{
+	plan(1);
+	test_protocol_version();
+	return check_plan();
+}


### PR DESCRIPTION
Handle status header response like 'HTTP/2 200' with version without
dot.

Closes #7319

NO_DOC=bugfix