### PR TITLE
Fix false-positive ER_SPLIT_BRAIN after processing a DEMOTE request.

### DIFF
--- a/changelogs/unreleased/gh-7286-false-positive-split-brain.md
+++ b/changelogs/unreleased/gh-7286-false-positive-split-brain.md
@@ -1,0 +1,3 @@
+## bugfix/replication
+
+* Fixed a false positive split-brain error after `box.ctl.demote()` (gh-7286).

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -1174,10 +1174,9 @@ apply_final_join_tx(uint32_t replica_id, struct stailq *rows)
 }
 
 /**
- * When elections are enabled we must filter out synchronous rows coming
- * from an instance that fell behind the current leader. This includes
- * both synchronous tx rows and rows for txs following unconfirmed
- * synchronous transactions.
+ * We must filter out synchronous rows coming from an instance that fell behind
+ * the current synchro queue owner. This includes both synchronous tx rows and
+ * rows for txs following unconfirmed synchronous transactions.
  * The rows are replaced with NOPs to preserve the vclock consistency.
  */
 static void

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -268,7 +268,7 @@ txn_limbo_replica_term(const struct txn_limbo *limbo, uint32_t replica_id)
 
 /**
  * Check whether replica with id @a source_id is too old to apply synchronous
- * data from it. The check is only valid when elections are enabled.
+ * data from it.
  */
 static inline bool
 txn_limbo_is_replica_outdated(struct txn_limbo *limbo, uint32_t replica_id)

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -267,20 +267,6 @@ txn_limbo_replica_term(const struct txn_limbo *limbo, uint32_t replica_id)
 }
 
 /**
- * Check whether replica with id @a source_id is too old to apply synchronous
- * data from it.
- */
-static inline bool
-txn_limbo_is_replica_outdated(struct txn_limbo *limbo, uint32_t replica_id)
-{
-	latch_lock(&limbo->promote_latch);
-	uint64_t v = vclock_get(&limbo->promote_term_map, replica_id);
-	bool res = v < limbo->promote_greatest_term;
-	latch_unlock(&limbo->promote_latch);
-	return res;
-}
-
-/**
  * Return the last synchronous transaction in the limbo or NULL when it is
  * empty.
  */

--- a/test/replication-luatest/gh_7286_split_brain_false_positive_test.lua
+++ b/test/replication-luatest/gh_7286_split_brain_false_positive_test.lua
@@ -1,0 +1,47 @@
+local t = require('luatest')
+local cluster = require('test.luatest_helpers.cluster')
+local server = require('test.luatest_helpers.server')
+
+local g = t.group('gh-7286')
+
+-- gh-7286: false positive ER_SPLIT_BRAIN error after box.ctl.demote() with
+-- disabled elections.
+g.before_all(function(cg)
+    cg.cluster = cluster:new{}
+
+    cg.box_cfg = {
+        -- Just in case it's turned on by default sometime.
+        election_mode = 'off',
+        replication_timeout = 0.1,
+        replication = {
+            server.build_instance_uri('node1'),
+            server.build_instance_uri('node2'),
+        },
+    }
+    cg.node1 = cg.cluster:build_and_add_server{
+        alias = 'node1',
+        box_cfg = cg.box_cfg,
+    }
+    cg.node2 = cg.cluster:build_and_add_server{
+        alias = 'node2',
+        box_cfg = cg.box_cfg,
+    }
+    cg.cluster:start()
+end)
+
+g.after_all(function(cg)
+    cg.cluster:drop()
+end)
+
+g.test_false_positive_split_brain = function(cg)
+    cg.node1:exec(function()
+        box.ctl.promote()
+        box.ctl.demote()
+    end)
+    cg.node2:wait_vclock_of(cg.node1)
+    cg.node2:exec(function()
+        box.space._schema:replace{'smth'}
+    end)
+    cg.node1:wait_vclock_of(cg.node2)
+    cg.node1:assert_follows_upstream(cg.node2:instance_id())
+end


### PR DESCRIPTION
Our txn_limbo_is_replica_outdated check works correctly only when there
is a stream of PROMOTE requests. Only the author of the latest PROMOTE
is writable and may issue transactions. No matter synchronous or
asynchronous.

So txn_limbo_is_replica_outdated assumes that everyone but the node with
the greatest PROMOTE/DEMOTE term is outdated.

This isn't true for DEMOTE requests. There is only one server which
issues the DEMOTE request, but once it's written, it's fine to accept
asynchronous transactions from everyone.

Now the check is too strict. Every time there is an asynchronous
transaction from someone, who isn't the author of the latest PROMOTE or
DEMOTE, replication is broken with ER_SPLIT_BRAIN.

Let's relax it: when limbo owner is 0, it's fine to accept asynchronous
transactions from everyone, no matter the term of their latest PROMOTE
and DEMOTE.

This means that now after a DEMOTE we will miss one case of true
split-brain: when old leader continues writing data in an obsolete term,
and the new leader first issues PROMOTE and then DEMOTE.

This is a tradeoff for making async master-master work after DEMOTE.

The completely correct fix would be to write the term the transaction
was written in with each transaction and replace
txn_limbo_is_replica_outdated with txn_limbo_is_request_outdated, so
that we decide whether to filter the request or not judging by the term
it was applied in, not by the term we seen in some past PROMOTE from the
node. This fix seems too costy though, given that we only miss one case
of split-brain at the moment when the user enables master-master
replication (by writing a DEMOTE). And in master-master there is no such
thing as a split-brain.

Follow-up #5295
Closes #7286
