### PR TITLE
vinyl: fix read stalled by write

### DIFF
--- a/changelogs/unreleased/gh-5700-vy-fix-read-stalled-by-write.md
+++ b/changelogs/unreleased/gh-5700-vy-fix-read-stalled-by-write.md
@@ -1,0 +1,5 @@
+## bugfix/vinyl
+
+* Fixed a bug in Vinyl read iterator that could result in a significant
+  performance degradation of range select requests in presence of an intensive
+  write workload (gh-5700).

--- a/src/box/vy_read_iterator.c
+++ b/src/box/vy_read_iterator.c
@@ -243,6 +243,32 @@ vy_read_iterator_evaluate_src(struct vy_read_iterator *itr,
 	}
 }
 
+/**
+ * Reevaluate scanned (not skipped) read sources and position 'next' to
+ * the statement that is minimal from this read iterator's perspective.
+ * This function assumes that all scanned read sources are up-to-date.
+ * See also vy_read_iterator_evaluate_src().
+ */
+static void
+vy_read_iterator_reevaluate_srcs(struct vy_read_iterator *itr,
+				 struct vy_entry *next)
+{
+	*next = vy_entry_none();
+	for (uint32_t i = 0; i < itr->src_count; i++) {
+		if (i >= itr->skipped_src)
+			break;
+		struct vy_read_src *src = &itr->src[i];
+		struct vy_entry entry = vy_history_last_stmt(&src->history);
+		int cmp = vy_read_iterator_cmp_stmt(itr, entry, *next);
+		if (cmp < 0) {
+			*next = entry;
+			itr->front_id++;
+		}
+		if (cmp <= 0)
+			src->front_id = itr->front_id;
+	}
+}
+
 /*
  * Each of the functions from the vy_read_iterator_scan_* family
  * is used by vy_read_iterator_advance() to:
@@ -402,11 +428,16 @@ vy_read_iterator_restore_mem(struct vy_read_iterator *itr,
 	cmp = vy_read_iterator_cmp_stmt(itr, entry, *next);
 	if (cmp > 0) {
 		/*
-		 * Memory trees are append-only so if the
-		 * source is not on top of the heap after
-		 * restoration, it was not before.
+		 * Normally, memory trees are append-only so if the source is
+		 * not on top of the heap after restoration, it was not before.
+		 * There's one exception to this rule though: a statement may
+		 * be deleted from a memory tree on rollback after a WAL write
+		 * failure. If the deleted statement was on top of the heap,
+		 * we need to reevaluate all read sources to reposition the
+		 * iterator to the minimal statement.
 		 */
-		assert(src->front_id < itr->front_id);
+		if (src->front_id == itr->front_id)
+			vy_read_iterator_reevaluate_srcs(itr, next);
 		return 0;
 	}
 	if (cmp < 0) {

--- a/src/box/vy_read_iterator.c
+++ b/src/box/vy_read_iterator.c
@@ -378,6 +378,58 @@ vy_read_iterator_scan_disk(struct vy_read_iterator *itr, uint32_t disk_src,
 	return 0;
 }
 
+/**
+ * Restore the position of the active in-memory tree iterator
+ * after a yield caused by a disk read and update 'next'
+ * if necessary.
+ */
+static NODISCARD int
+vy_read_iterator_restore_mem(struct vy_read_iterator *itr,
+			     struct vy_entry *next)
+{
+	int rc;
+	int cmp;
+	struct vy_read_src *src = &itr->src[itr->mem_src];
+
+	rc = vy_mem_iterator_restore(&src->mem_iterator,
+				     itr->last, &src->history);
+	if (rc < 0)
+		return -1; /* memory allocation error */
+	if (rc == 0)
+		return 0; /* nothing changed */
+
+	struct vy_entry entry = vy_history_last_stmt(&src->history);
+	cmp = vy_read_iterator_cmp_stmt(itr, entry, *next);
+	if (cmp > 0) {
+		/*
+		 * Memory trees are append-only so if the
+		 * source is not on top of the heap after
+		 * restoration, it was not before.
+		 */
+		assert(src->front_id < itr->front_id);
+		return 0;
+	}
+	if (cmp < 0) {
+		/*
+		 * The new statement precedes the current
+		 * candidate for the next key.
+		 */
+		*next = entry;
+		itr->front_id++;
+	} else {
+		/*
+		 * The new statement updates the next key.
+		 * Make sure we don't read the old value
+		 * from the cache while applying UPSERTs.
+		 */
+		struct vy_read_src *cache_src = &itr->src[itr->cache_src];
+		if (cache_src->front_id == itr->front_id)
+			vy_history_cleanup(&cache_src->history);
+	}
+	src->front_id = itr->front_id;
+	return 0;
+}
+
 static void
 vy_read_iterator_restore(struct vy_read_iterator *itr);
 
@@ -477,11 +529,8 @@ rescan_disk:
 	 * as it is owned exclusively by the current fiber so the only
 	 * source to check is the active in-memory tree.
 	 */
-	struct vy_mem_iterator *mem_itr = &itr->src[itr->mem_src].mem_iterator;
-	if (mem_itr->version != mem_itr->mem->version) {
-		vy_read_iterator_restore(itr);
-		goto restart;
-	}
+	if (vy_read_iterator_restore_mem(itr, &next) != 0)
+		return -1;
 	/*
 	 * Scan the next range in case we transgressed the current
 	 * range's boundaries.


### PR DESCRIPTION
The Vinyl read iterator, which is used for serving range select requests, works as follows:
1. Scan in-memory sources. If found an exact match or a chain in the cache, return it.
2. If not found, scan disk sources. This operation may yield.
3. If any new data was inserted into the active memory tree, go to step 1, effectively restarting the iteration from the same key.

Apparently, such an algorithm doesn't guarantee any progress of a read operation at all - when we yield reading disk on step 2 after a restart, even newer data may be inserted into the active memory tree, forcing us to restart again. In other words, in presence of an intensive write workload, read ops rate may drop down to literally 0.

It hasn't always been like so. Before commit 83462a5cf163, we only restored the memory tree iterator after a yield, without restarting the whole procedure. This makes sense, because only memory tree may change after a yield so there's no point in rescanning other sources, including disk. By restarting iteration after a yield, the above-mentioned commit fixed bug #3395: initially we assumed that statements may never be deleted from a memory tree while actually they can be deleted by rollback after a failed WAL write.

This PR reverts the above-mentioned commit and re-fixes bug #3395 in a proper way.

Closes #5700