### PR TITLE
Destroy main cord on return from main()

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3341,7 +3341,6 @@ box_free(void)
 		schema_free();
 		schema_module_free();
 		tuple_free();
-		port_free();
 #endif
 		wal_ext_free();
 		box_watcher_free();
@@ -3355,6 +3354,7 @@ box_free(void)
 		flightrec_free();
 		audit_log_free();
 		sql_built_in_functions_cache_free();
+		port_free();
 	}
 }
 

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -1316,18 +1316,11 @@ fiber_new(const char *name, fiber_func f)
 	return fiber_new_ex(name, &fiber_attr_default, f);
 }
 
-/**
- * Free as much memory as possible taken by the fiber.
- *
- * Sic: cord()->sched needs manual destruction in
- * cord_destroy().
- */
+/** Free all fiber's resources. */
 static void
-fiber_delete(struct cord *cord, struct fiber *f)
+fiber_destroy(struct cord *cord, struct fiber *f)
 {
 	assert(f != cord->fiber);
-	assert(f != &cord->sched);
-
 	trigger_destroy(&f->on_yield);
 	trigger_destroy(&f->on_stop);
 	rlist_del(&f->state);
@@ -1338,6 +1331,14 @@ fiber_delete(struct cord *cord, struct fiber *f)
 	if (f->name != f->inline_name)
 		free(f->name);
 	TRASH(f);
+}
+
+/** Free all fiber's resources and the fiber itself. */
+static void
+fiber_delete(struct cord *cord, struct fiber *f)
+{
+	assert(f != &cord->sched);
+	fiber_destroy(cord, f);
 	mempool_free(&cord->fiber_mempool, f);
 }
 
@@ -1509,6 +1510,8 @@ cord_create(struct cord *cord, const char *name)
 	cord->fiber_registry = mh_i64ptr_new();
 
 	/* sched fiber is not present in alive/ready/dead list. */
+	rlist_create(&cord->sched.state);
+	rlist_create(&cord->sched.link);
 	cord->sched.fid = FIBER_ID_SCHED;
 	fiber_reset(&cord->sched);
 	diag_create(&cord->sched.diag);
@@ -1582,10 +1585,12 @@ cord_destroy(struct cord *cord)
 		fiber_delete_all(cord);
 		mh_i64ptr_delete(cord->fiber_registry);
 	}
-	region_destroy(&cord->sched.gc);
-	diag_destroy(&cord->sched.diag);
-	if (cord->sched.name != cord->sched.inline_name)
-		free(cord->sched.name);
+	cord->fiber = NULL;
+#if ENABLE_ASAN
+	cord->sched.stack = NULL;
+	cord->sched.stack_size = 0;
+#endif
+	fiber_destroy(cord, &cord->sched);
 	slab_cache_destroy(&cord->slabc);
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -578,8 +578,6 @@ tarantool_free(void)
 	tarantool_lua_free();
 	session_free();
 	user_cache_free();
-	memory_free();
-	random_free();
 #endif
 	ssl_free();
 	memtx_tx_manager_free();
@@ -587,6 +585,8 @@ tarantool_free(void)
 	systemd_free();
 	say_logger_free();
 	fiber_free();
+	memory_free();
+	random_free();
 }
 
 static void

--- a/src/main.cc
+++ b/src/main.cc
@@ -578,7 +578,6 @@ tarantool_free(void)
 	tarantool_lua_free();
 	session_free();
 	user_cache_free();
-	fiber_free();
 	memory_free();
 	random_free();
 #endif
@@ -587,6 +586,7 @@ tarantool_free(void)
 	coll_free();
 	systemd_free();
 	say_logger_free();
+	fiber_free();
 }
 
 static void


### PR DESCRIPTION
Fiber module was not destroyed before return from `main()`. That made all the resources allocated for the main cord leak. Apparently, it was either fine for ASAN for quite some time, or it wasn't and the problem was noticed just now. Anyway, fiber `on_stop` trigger was reported as leaking. The patchset fixes this particular issue.

But it also discovers a much bigger problem with what a mess is our current process cleanup code. Here is a cite from the second commit's message with first and biggest problems which I could spot:
```
    There are still a lot of other modules whose freeing is not that
    easy. A few hard to untangle knots, and there are more:
    
    - Session, credentials, iproto, and fibers are tied together via
      the latter. Each fiber potentially has a session, its current
      credentials object. Each iproto connection has a session and a
      file descriptor which is stored in the session too.
    
      The possible solution would be to walk all the fibers and
      destroy them before proceeding to destroy everything else.
    
    - Tuples depend on memtx, and Lua depends on tuples. Because there
      are tuples allocated on memtx->arena. Hence destruction of memtx
      and its arena makes the tuples still stored in Lua invalid.
    
      It seems Lua should be destroyed first, not last. It would free
      all the refs which might be kept at objects in C in the other
      modules.

    - IProto connections leak when iproto is destroyed. They are not
      freed and their descriptors are not closed properly. That
      requires additional preparatory work to destroy them correctly
      on iproto module deconstruction.
```
I am not sure what to do here. One option would be to submit this patchset and file new tickets for the other problems. Another option would be to fix them all in my patch, but it would require notably more time.

There is also another option to give up on most of the destructions since they don't work anyway. But it would make ASAN even more useless as it is now.

I need a decision what to do here.

#7259