### PR TITLE
[backport/1.10] luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-6548-luajit-fixes.md
+++ b/changelogs/unreleased/gh-6548-luajit-fixes.md
@@ -1,0 +1,18 @@
+## bugfix/luajit
+
+Backported patches from vanilla LuaJIT trunk (gh-6548). In the scope of this
+activity, the following issues have been resolved:
+
+* Fixed emitting for fuse load of constant in GC64 mode (gh-4095, gh-4199, gh-4614).
+* Now initialization of zero-filled struct is compiled (gh-4630, gh-5885).
+* Actually implemented `maxirconst` option for tuning JIT compiler.
+* Fixed JIT stack of Lua slots overflow during recording for metamethod calls.
+* Fixed bytecode dump unpatching for JLOOP in up-recursion compiled functions.
+* Fixed FOLD rule for strength reduction of widening in cdata indexing.
+* Fixed `string.char()` recording without arguments.
+* Fixed `print()` behaviour with the reloaded default metatable for numbers.
+* `tonumber("-0")` now saves the sign of number for conversion.
+* `tonumber()` now give predictable results for negative non-base-10 numbers.
+* Fixed write barrier for `debug.setupvalue()` and `lua_setupvalue()`.
+* `jit.p` now flushes and closes output file after run, not at program exit.
+* Fixed `jit.p` profiler interaction with GC finalizers.


### PR DESCRIPTION
* test: fix path storage for non-concatable objects
* test: set DYLD_LIBRARY_PATH environment variable
* x64/LJ_GC64: Fix fallback case of asm_fuseloadk64().
* FFI: Handle zero-fill of struct-of-NYI.
* Fix interaction between profiler hooks and finalizers.
* Flush and close output file after profiling run.
* Fix debug.debug() for non-string errors.
* Fix write barrier for lua_setupvalue() and debug.setupvalue().
* Fix FOLD rule for strength reduction of widening.
* Fix bytecode dump unpatching.
* Fix tonumber("-0") in dual-number mode.
* Fix tonumber("-0").
* Give expected results for negative non-base-10 numbers in tonumber().
* Add missing LJ_MAX_JSLOTS check.
* Add stricter check for print() vs. tostring() shortcut.

Closes #6548
Fixes #4614
Fixes #4630
Fixes #5885
Fixes tarantool/tarantool-qa#234
Fixes tarantool/tarantool-qa#235

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump
