### PR TITLE
json: don't match any nodes if there's [*] in the path

### DIFF
--- a/changelogs/unreleased/gh-5226-tuple-access-by-any-token.md
+++ b/changelogs/unreleased/gh-5226-tuple-access-by-any-token.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a bug that allowed to access indexed nested tuple fields by `[*]`
+  in Lua (gh-5226).

--- a/src/lib/json/json.h
+++ b/src/lib/json/json.h
@@ -354,6 +354,11 @@ json_tree_lookup_slowpath(struct json_tree *tree, struct json_token *parent,
 /**
  * Look up a token in a JSON tree given a parent token and a key.
  *
+ * Note that if the parent is a multikey node (that is it has the only child
+ * with type '*' aka 'any'), then we return its only child for any key,
+ * including '*'. Otherwise we return the child whose key matches the given
+ * key, assuming no key matches '*'.
+ *
  * Returns NULL if not found.
  */
 static inline struct json_token *
@@ -371,8 +376,6 @@ json_tree_lookup(struct json_tree *tree, struct json_token *parent,
 			ret = parent->children[token->num];
 		break;
 	case JSON_TOKEN_ANY:
-		if (likely(parent->max_child_idx >= 0))
-			ret = parent->children[parent->max_child_idx];
 		break;
 	case JSON_TOKEN_STR:
 		ret = json_tree_lookup_slowpath(tree, parent, token);

--- a/test/box-luatest/gh_5226_tuple_access_by_any_token_test.lua
+++ b/test/box-luatest/gh_5226_tuple_access_by_any_token_test.lua
@@ -1,0 +1,47 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all = function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end
+
+g.after_all = function()
+    g.server:drop()
+end
+
+--
+-- Checks that accessing a tuple field by [*] ('any' token) returns nothing
+-- (gh-5226).
+--
+g.test_tuple_access_by_any_token = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local s = box.schema.space.create('test')
+        s:create_index('pk')
+        s:create_index('sk', {parts = {{'[2][1][1]', 'unsigned'}}})
+        local tuple = s:replace({1, {{1, 2}}, {{3, 4}}})
+        t.assert_equals(tuple['[*]'], nil)
+        t.assert_equals(tuple['[*][1]'], nil)
+        t.assert_equals(tuple['[1]'], 1)
+        t.assert_equals(tuple['[1][*]'], nil)
+        t.assert_equals(tuple['[2]'], {{1, 2}})
+        t.assert_equals(tuple['[2][*]'], nil)
+        t.assert_equals(tuple['[2][*][1]'], nil)
+        t.assert_equals(tuple['[2][1]'], {1, 2})
+        t.assert_equals(tuple['[2][1][*]'], nil)
+        t.assert_equals(tuple['[2][1][1]'], 1)
+        t.assert_equals(tuple['[2][1][2]'], 2)
+        t.assert_equals(tuple['[2][1][2][*]'], nil)
+        t.assert_equals(tuple['[3]'], {{3, 4}})
+        t.assert_equals(tuple['[3][*]'], nil)
+        t.assert_equals(tuple['[3][*][1]'], nil)
+        t.assert_equals(tuple['[3][1]'], {3, 4})
+        t.assert_equals(tuple['[3][1][*]'], nil)
+        t.assert_equals(tuple['[3][1][1]'], 3)
+        t.assert_equals(tuple['[3][1][2]'], 4)
+        t.assert_equals(tuple['[3][1][2][*]'], nil)
+        s:drop()
+    end)
+end

--- a/test/unit/json.c
+++ b/test/unit/json.c
@@ -426,7 +426,7 @@ test_tree()
 	token->type = JSON_TOKEN_ANY;
 	node = json_tree_lookup_entry(&tree, &records[0].node, token,
 				      struct test_struct, node);
-	is(node->node.num, 9, "lookup any token in non-multikey node");
+	is(node, NULL, "lookup any token in non-multikey node");
 
 	/* Can't attach ANY token to non-leaf node. Cleanup. */
 	json_tree_del(&tree, &records[1].node);


### PR DESCRIPTION
If a nested tuple field is indexed, it can be accessed by [*] aka multikey or any token:

  ```Lua
  s = box.schema.create_space('test')
  s:create_index('pk')
  s:create_index('sk', {parts = {{2, 'unsigned', path = '[1][1]'}}})
  t = s:replace{1, {{1}}}
  t['[2][1][*]'] -- returns 1!
  ```

If a nested field isn't indexed (remove creation of the secondary index in the example above), then access by [*] returns nil.

Call graph:

  ```
  lbox_tuple_field_by_path:
    tuple_field_raw_by_full_path
      tuple_field_raw_by_path
        tuple_format_field_by_path
          json_tree_lookup_entry
            json_tree_lookup
  ```

And `json_tree_lookup` matches the first node if the key is [*]. We shouldn't match anything to [*].

Closes #5226