### PR TITLE
test: use default readline configuration for a test

### DIFF
--- a/test/app-tap/gh-2717-no-quit-sigint.test.lua
+++ b/test/app-tap/gh-2717-no-quit-sigint.test.lua
@@ -19,7 +19,7 @@ local TARANTOOL_PATH = arg[-1]
 local test = tap.test('gh-2717-no-quit-sigint')
 
 test:plan(6)
-local cmd = 'ERRINJ_STDIN_ISATTY=1 ' .. TARANTOOL_PATH .. ' -i 2>&1'
+local cmd = 'ERRINJ_STDIN_ISATTY=1 INPUTRC=Pheiphe2 ' .. TARANTOOL_PATH .. ' -i 2>&1'
 local ph = popen.new({cmd}, {
     shell = true,
     setsid = true,
@@ -150,7 +150,7 @@ os.remove(snap_file)
 --
 -- Testing case when the client and instance are called in the same console.
 --
-cmd = 'ERRINJ_STDIN_ISATTY=1 ' .. TARANTOOL_PATH .. ' -i 2>&1'
+cmd = 'ERRINJ_STDIN_ISATTY=1 INPUTRC=Pheiphe2 ' .. TARANTOOL_PATH .. ' -i 2>&1'
 ph = popen.new({cmd}, {
     shell = true,
     setsid = true,


### PR DESCRIPTION
If readline 'show-mode-in-prompt' is on then test fails because it does
not handle prefix added to prompt in this mode. Let's use default
(compiled in) readline configuration instead of the one provided by
user or system config.

NO_DOC=test changes
NO_CHANGELOG=test changes
NO_TEST=test changes