### PR TITLE
session: panic if failed to allocate session

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -191,7 +191,7 @@ set(box_sources
     alter.cc
     schema.cc
     schema_def.c
-    session.cc
+    session.c
     port.c
     txn.c
     txn_limbo.c

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -2107,8 +2107,6 @@ applier_f(va_list ap)
 	 * triggers.
 	 */
 	struct session *session = session_new_on_demand();
-	if (session == NULL)
-		return -1;
 	session_set_type(session, SESSION_TYPE_APPLIER);
 
 	/*

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -2106,7 +2106,7 @@ applier_f(va_list ap)
 	 * Set correct session type for use in on_replace()
 	 * triggers.
 	 */
-	struct session *session = session_create_on_demand();
+	struct session *session = session_new_on_demand();
 	if (session == NULL)
 		return -1;
 	session_set_type(session, SESSION_TYPE_APPLIER);

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -1767,7 +1767,7 @@ tx_process_destroy(struct cmsg *m)
 		container_of(m, struct iproto_connection, destroy_msg);
 	assert(con->state == IPROTO_CONNECTION_DESTROYED);
 	if (con->session) {
-		session_destroy(con->session);
+		session_delete(con->session);
 		con->session = NULL; /* safety */
 	}
 	/*
@@ -2578,7 +2578,7 @@ tx_process_connect(struct cmsg *m)
 	struct iproto_connection *con = msg->connection;
 	struct obuf *out = msg->connection->tx.p_obuf;
 	try {              /* connect. */
-		con->session = session_create(SESSION_TYPE_BINARY);
+		con->session = session_new(SESSION_TYPE_BINARY);
 		if (con->session == NULL)
 			diag_raise();
 		con->session->meta.connection = con;

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -2579,8 +2579,6 @@ tx_process_connect(struct cmsg *m)
 	struct obuf *out = msg->connection->tx.p_obuf;
 	try {              /* connect. */
 		con->session = session_new(SESSION_TYPE_BINARY);
-		if (con->session == NULL)
-			diag_raise();
 		con->session->meta.connection = con;
 		session_set_peer_addr(con->session, &msg->connect.addr,
 				      msg->connect.addrlen);

--- a/src/box/lua/session.c
+++ b/src/box/lua/session.c
@@ -56,7 +56,7 @@ lbox_session_create(struct lua_State *L)
 					  luaL_optstring(L, 2, "console"));
 	struct session *session = fiber_get_session(fiber());
 	if (session == NULL) {
-		session = session_create_on_demand();
+		session = session_new_on_demand();
 		if (session == NULL)
 			return luaT_error(L);
 		session->meta.fd = fd;

--- a/src/box/lua/session.c
+++ b/src/box/lua/session.c
@@ -57,8 +57,6 @@ lbox_session_create(struct lua_State *L)
 	struct session *session = fiber_get_session(fiber());
 	if (session == NULL) {
 		session = session_new_on_demand();
-		if (session == NULL)
-			return luaT_error(L);
 		session->meta.fd = fd;
 		if (fd >= 0 && type != SESSION_TYPE_REPL) {
 			struct sockaddr_storage addrstorage;

--- a/src/box/session.c
+++ b/src/box/session.c
@@ -245,14 +245,7 @@ session_set_type(struct session *session, enum session_type type)
 struct session *
 session_new(enum session_type type)
 {
-	struct session *session =
-		(struct session *) mempool_alloc(&session_pool);
-	if (session == NULL) {
-		diag_set(OutOfMemory, session_pool.objsize, "mempool",
-			 "new slab");
-		return NULL;
-	}
-
+	struct session *session = xmempool_alloc(&session_pool);
 	session->id = sid_max();
 	memset(&session->meta, 0, sizeof(session->meta));
 	session_set_type(session, type);
@@ -278,8 +271,6 @@ session_new_on_demand(void)
 
 	/* Create session on demand */
 	struct session *s = session_new(SESSION_TYPE_BACKGROUND);
-	if (s == NULL)
-		return NULL;
 	/* Add a trigger to destroy session on fiber stop */
 	trigger_create(&s->fiber_on_stop, session_on_stop, NULL, NULL);
 	trigger_add(&fiber()->on_stop, &s->fiber_on_stop);

--- a/src/box/session.c
+++ b/src/box/session.c
@@ -99,7 +99,7 @@ session_on_stop(struct trigger *trigger, void *event)
 	 */
 	trigger_clear(trigger);
 	/* Destroy the session */
-	session_destroy(fiber_get_session(fiber()));
+	session_delete(fiber_get_session(fiber()));
 	return 0;
 }
 
@@ -243,7 +243,7 @@ session_set_type(struct session *session, enum session_type type)
 }
 
 struct session *
-session_create(enum session_type type)
+session_new(enum session_type type)
 {
 	struct session *session =
 		(struct session *) mempool_alloc(&session_pool);
@@ -272,12 +272,12 @@ session_create(enum session_type type)
 }
 
 struct session *
-session_create_on_demand(void)
+session_new_on_demand(void)
 {
 	assert(fiber_get_session(fiber()) == NULL);
 
 	/* Create session on demand */
-	struct session *s = session_create(SESSION_TYPE_BACKGROUND);
+	struct session *s = session_new(SESSION_TYPE_BACKGROUND);
 	if (s == NULL)
 		return NULL;
 	/* Add a trigger to destroy session on fiber stop */
@@ -359,7 +359,7 @@ session_run_on_auth_triggers(const struct on_auth_trigger_ctx *result)
 }
 
 void
-session_destroy(struct session *session)
+session_delete(struct session *session)
 {
 	/* Watchers are unregistered in session_close(). */
 	assert(session->watchers == NULL);

--- a/src/box/session.h
+++ b/src/box/session.h
@@ -274,8 +274,7 @@ current_session(void)
 	struct session *session = fiber_get_session(fiber());
 	if (session == NULL) {
 		session = session_new_on_demand();
-		if (session == NULL)
-			diag_raise();
+		assert(session != NULL);
 	}
 	return session;
 }

--- a/src/box/session.h
+++ b/src/box/session.h
@@ -256,7 +256,7 @@ extern struct credentials admin_credentials;
  * trigger to destroy it when this fiber ends.
  */
 struct session *
-session_create_on_demand(void);
+session_new_on_demand(void);
 
 /*
  * When creating a new fiber, the database (box)
@@ -273,7 +273,7 @@ current_session(void)
 {
 	struct session *session = fiber_get_session(fiber());
 	if (session == NULL) {
-		session = session_create_on_demand();
+		session = session_new_on_demand();
 		if (session == NULL)
 			diag_raise();
 	}
@@ -292,7 +292,7 @@ effective_user(void)
 	struct fiber *f = fiber();
 	struct credentials *u = f->storage.credentials;
 	if (u == NULL) {
-		session_create_on_demand();
+		session_new_on_demand();
 		u = f->storage.credentials;
 	}
 	return u;
@@ -306,17 +306,10 @@ session_storage_cleanup(int sid);
 
 /**
  * Create a session.
- * Invokes a Lua trigger box.session.on_connect if it is
- * defined. Issues a new session identifier.
- * Must called by the networking layer
- * when a new connection is established.
- *
  * @return handle for a created session
- * @exception tnt_Exception or lua error if session
- * trigger fails or runs out of resources.
  */
 struct session *
-session_create(enum session_type type);
+session_new(enum session_type type);
 
 /** Return true if given statement id belongs to the session. */
 bool
@@ -333,14 +326,10 @@ session_remove_stmt_id(struct session *session, uint32_t stmt_id);
 /**
  * Destroy a session.
  * Must be called by the networking layer on disconnect.
- * Invokes a Lua trigger box.session.on_disconnect if it
- * is defined.
- * @param session   session to destroy. may be NULL.
- *
- * @exception none
+ * @param session session to destroy.
  */
 void
-session_destroy(struct session *);
+session_delete(struct session *session);
 
 /**
  * Set session peer address.

--- a/src/box/space_cache.h
+++ b/src/box/space_cache.h
@@ -119,18 +119,6 @@ space_cache_find(uint32_t id)
 }
 
 /**
- * Exception-throwing version of space_cache_find(..)
- */
-static inline struct space *
-space_cache_find_xc(uint32_t id)
-{
-	struct space *space = space_cache_find(id);
-	if (space == NULL)
-		diag_raise();
-	return space;
-}
-
-/**
  * Call a visitor function on every space in the space cache.
  * Traverse system spaces before other.
  */
@@ -187,4 +175,17 @@ space_cache_is_pinned(struct space *space, enum space_cache_holder_type *type);
 
 #if defined(__cplusplus)
 } /* extern "C" */
+
+/**
+ * Exception-throwing version of space_cache_find(..)
+ */
+static inline struct space *
+space_cache_find_xc(uint32_t id)
+{
+	struct space *space = space_cache_find(id);
+	if (space == NULL)
+		diag_raise();
+	return space;
+}
+
 #endif /* defined(__cplusplus) */

--- a/src/box/user.h
+++ b/src/box/user.h
@@ -143,9 +143,6 @@ credentials_reset(struct credentials *cr, struct user *new_user)
 	credentials_create(cr, new_user);
 }
 
-#if defined(__cplusplus)
-} /* extern "C" */
-
 /**
  * For best performance, all users are maintained in this array.
  * Position in the array is store in user->auth_token and also
@@ -158,6 +155,9 @@ credentials_reset(struct credentials *cr, struct user *new_user)
  * objects, such as spaces and functions.
  */
 extern struct user *guest_user, *admin_user;
+
+#if defined(__cplusplus)
+} /* extern "C" */
 
 /*
  * Insert or update user object (a cache entry

--- a/src/lib/core/diag.h
+++ b/src/lib/core/diag.h
@@ -245,13 +245,6 @@ error_unlink_effect(struct error *e)
 int
 error_set_prev(struct error *e, struct error *prev);
 
-NORETURN static inline void
-error_raise(struct error *e)
-{
-	e->raise(e);
-	unreachable();
-}
-
 static inline void
 error_log(struct error *e)
 {
@@ -396,14 +389,6 @@ diag_last_error(struct diag *diag)
 struct diag *
 diag_get(void);
 
-NORETURN static inline void
-diag_raise(void)
-{
-	struct error *e = diag_last_error(diag_get());
-	assert(e != NULL);
-	error_raise(e);
-}
-
 static inline void
 diag_log(void)
 {
@@ -473,6 +458,22 @@ BuildSocketError(const char *file, unsigned line, const char *socketname,
 
 #if defined(__cplusplus)
 } /* extern "C" */
+
+NORETURN static inline void
+error_raise(struct error *e)
+{
+	e->raise(e);
+	unreachable();
+}
+
+NORETURN static inline void
+diag_raise(void)
+{
+	struct error *e = diag_last_error(diag_get());
+	assert(e != NULL);
+	error_raise(e);
+}
+
 #endif /* defined(__cplusplus) */
 
 #endif /* TARANTOOL_LIB_CORE_DIAG_H_INCLUDED */

--- a/src/trivia/util.h
+++ b/src/trivia/util.h
@@ -126,6 +126,7 @@ strnindex(const char *const *haystack, const char *needle, uint32_t len,
 #define xrealloc(ptr, size)	xalloc_impl((size), realloc, (ptr), (size))
 #define xstrdup(s)		xalloc_impl(strlen((s)) + 1, strdup, (s))
 #define xstrndup(s, n)		xalloc_impl((n) + 1, strndup, (s), (n))
+#define xmempool_alloc(p)	xalloc_impl((p)->objsize, mempool_alloc, (p))
 
 /** \cond public */
 


### PR DESCRIPTION
`current_session()` is called from C code so it must not throw, but it may if it fails to allocate a session. Practically, this is hardly possible, because we don't limit the runtime arena, which is used for allocation of session objects. Still, this looks potentially dangerous.

Gracefully handling an allocation failure in all places where `current_session()` may be called would be complicated. Since it's more of a theoretical issue, let's panic on a session allocation error, like we do if we fail to allocate other mission critical system objects.

Closes #4735