### PR TITLE
vinyl: explicitly disable hot standby mode

### DIFF
--- a/changelogs/unreleased/gh-6565-vy-hot-standby-unsupported.md
+++ b/changelogs/unreleased/gh-6565-vy-hot-standby-unsupported.md
@@ -1,0 +1,5 @@
+## bugfix/vinyl
+
+* Explicitly disabled the hot standby mode for Vinyl. Now, an attempt to enable
+  the hot standby mode in case the master instance has Vinyl spaces results in
+  an error. Before this change, the behavior was undefined (gh-6565).

--- a/src/box/recovery.cc
+++ b/src/box/recovery.cc
@@ -483,9 +483,12 @@ hot_standby_f(va_list ap)
 		int64_t start, end;
 		do {
 			start = vclock_sum(&r->vclock);
-
-			recover_remaining_wals(r, stream, NULL, scan_dir);
-
+			try {
+				recover_remaining_wals(r, stream, NULL,
+						       scan_dir);
+			} catch (Exception *e) {
+				e->log();
+			}
 			end = vclock_sum(&r->vclock);
 			/*
 			 * Continue, given there's been progress *and* there is a

--- a/test/vinyl-luatest/gh_6565_hot_standby_unsupported_test.lua
+++ b/test/vinyl-luatest/gh_6565_hot_standby_unsupported_test.lua
@@ -1,0 +1,53 @@
+local fio = require('fio')
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_each(function(cg)
+    cg.master = server:new({alias = 'master'})
+    cg.master:start()
+    cg.replica = server:new({
+        alias = 'replica',
+        workdir = cg.master.workdir,
+        box_cfg = {hot_standby = true},
+    })
+    cg.replica_log = fio.pathjoin(cg.replica.workdir,
+                                  cg.replica.alias .. '.log')
+end)
+
+g.after_each(function(cg)
+    cg.master:drop()
+end)
+
+g.test_panic_if_vinyl_space_exists = function(cg)
+    cg.master:exec(function()
+        box.schema.create_space('test', {engine = 'vinyl'})
+        box.space.test:create_index('pk')
+    end)
+    cg.replica:start({wait_for_readiness = false})
+    t.helpers.retrying({}, function()
+        t.assert(cg.replica:grep_log("Entering hot standby mode",
+                                     nil, {filename = cg.replica_log}))
+        t.assert(cg.replica:grep_log("Vinyl does not support hot standby mode",
+                                     nil, {filename = cg.replica_log}))
+    end)
+end
+
+g.test_panic_if_vinyl_space_is_created = function(cg)
+    cg.replica:start({wait_for_readiness = false})
+    t.helpers.retrying({}, function()
+        t.assert(cg.replica:grep_log("Entering hot standby mode",
+                                     nil, {filename = cg.replica_log}))
+    end)
+    cg.master:exec(function()
+        box.schema.create_space('test', {engine = 'vinyl'})
+        box.space.test:create_index('pk')
+    end)
+    t.helpers.retrying({}, function()
+        t.assert(cg.replica:grep_log("couldn't apply the request",
+                                     nil, {filename = cg.replica_log}))
+        t.assert(cg.replica:grep_log("Vinyl does not support hot standby mode",
+                                     nil, {filename = cg.replica_log}))
+    end)
+end


### PR DESCRIPTION
Vinyl doesn't support the hot standby mode. There's a ticket to implement it, see #2013. The behavior is undefined if running an instance in the hot standby mode in case the master has Vinyl spaces. It may result in a crash or even data corruption.

Let's raise an explicit error in this case.

Closes #6565