### PR TITLE
core: fix potential misorder of latch waiters

### DIFF
--- a/changelogs/unreleased/gh-7166-box_latch_lock-order.md
+++ b/changelogs/unreleased/gh-7166-box_latch_lock-order.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Now `box_latch_lock` guarantees the order in which it is acquired by
+  fibers, which requested it (gh-7166).

--- a/src/lib/core/latch.h
+++ b/src/lib/core/latch.h
@@ -144,7 +144,6 @@ latch_lock_timeout(struct latch *l, ev_tstamp timeout)
 	if (timeout <= 0)
 		return 1;
 
-	bool was_cancellable = fiber_set_cancellable(false);
 	int result = 0;
 	struct latch_waiter waiter;
 	waiter.fiber = fiber();
@@ -163,7 +162,6 @@ latch_lock_timeout(struct latch *l, ev_tstamp timeout)
 		}
 	}
 	rlist_del_entry(&waiter, link);
-	fiber_set_cancellable(was_cancellable);
 	return result;
 }
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -310,3 +310,6 @@ target_link_libraries(watcher.test unit box)
 
 add_executable(grp_alloc.test grp_alloc.c box_test_utils.c)
 target_link_libraries(grp_alloc.test unit)
+
+add_executable(latch.test latch.c core_test_utils.c)
+target_link_libraries(latch.test core unit stat)

--- a/test/unit/latch.c
+++ b/test/unit/latch.c
@@ -1,0 +1,113 @@
+#include "memory.h"
+#include "fiber.h"
+#include "latch.h"
+#include "unit.h"
+
+const size_t num_fibers = 3;
+
+static int
+order_f(va_list ap)
+{
+	size_t fid = *va_arg(ap, size_t *);
+	size_t *check = va_arg(ap, size_t *);
+	struct latch *latch = va_arg(ap, struct latch *);
+	latch_lock(latch);
+
+	is(fid, *check, "check order");
+	++*check;
+
+	latch_unlock(latch);
+	return 0;
+}
+
+static int
+sleep_f(va_list ap)
+{
+	struct latch *latch = va_arg(ap, struct latch *);
+	latch_lock(latch);
+	fiber_set_cancellable(true);
+
+	while (!fiber_is_cancelled())
+		fiber_sleep(0.001);
+
+	latch_unlock(latch);
+	return 0;
+}
+
+static void
+latch_order_test(bool wakeup_before_unlock)
+{
+	header();
+	size_t check = 0;
+	struct latch latch;
+	latch_create(&latch);
+	latch_lock(&latch);
+
+	struct fiber *fibers[num_fibers];
+	for (size_t i = 0; i < num_fibers; i++) {
+		fibers[i] = fiber_new("ordered", order_f);
+		fail_if(fibers[i] == NULL);
+		fiber_set_joinable(fibers[i], true);
+		fiber_start(fibers[i], &i, &check, &latch);
+	}
+
+	/*
+	 * Try to break the order of waiters on the latch.
+	 */
+	if (wakeup_before_unlock)
+		fiber_wakeup(fibers[1]);
+	latch_unlock(&latch);
+	if (!wakeup_before_unlock)
+		fiber_wakeup(fibers[1]);
+
+	for (size_t i = 0; i < num_fibers; i++)
+		fiber_join(fibers[i]);
+	latch_destroy(&latch);
+	footer();
+}
+
+static void
+latch_timeout_test(void)
+{
+	header();
+	struct latch latch;
+	latch_create(&latch);
+
+	struct fiber *fiber = fiber_new("sleeping", sleep_f);
+	fail_if(fiber == NULL);
+	fiber_set_joinable(fiber, true);
+	fiber_start(fiber, &latch);
+
+	int exceeded = latch_lock_timeout(&latch, -0.1);
+	is(exceeded, 1, "check timeout");
+
+	fiber_cancel(fiber);
+	fiber_join(fiber);
+	latch_destroy(&latch);
+	footer();
+}
+
+static int
+main_f(va_list ap)
+{
+	latch_order_test(true);
+	latch_order_test(false);
+	latch_timeout_test();
+
+	ev_break(loop(), EVBREAK_ALL);
+	return 0;
+}
+
+int
+main(void)
+{
+	plan(num_fibers * 2 + 1);
+	memory_init();
+	fiber_init(fiber_c_invoke);
+	struct fiber *f = fiber_new("main", main_f);
+	fiber_wakeup(f);
+	ev_run(loop(), 0);
+	fiber_free();
+	memory_free();
+	return check_plan();
+}

--- a/test/unit/latch.result
+++ b/test/unit/latch.result
@@ -1,0 +1,14 @@
+1..7
+	*** latch_order_test ***
+ok 1 - check order
+ok 2 - check order
+ok 3 - check order
+	*** latch_order_test: done ***
+	*** latch_order_test ***
+ok 4 - check order
+ok 5 - check order
+ok 6 - check order
+	*** latch_order_test: done ***
+	*** latch_timeout_test ***
+ok 7 - check timeout
+	*** latch_timeout_test: done ***


### PR DESCRIPTION
#### core: fix potential misorder of latch waiters

Currently the latch doesn't guarantee the order in which it is acquired
by fibers, which requested it. E.g. it is possible to wake up spuriously
a fiber which is yielding in the latch_lock, it will be removed from
l->queue by fiber_make_ready, then it will be inserted to l->queue
again, but for this time, to the head of the list instead of its
original place in the queue.

Fix this by using latch_waiter structure, which is linked into l->queue.

Part of #7166