### PR TITLE
sql: fix error in ORDER BY ephemeral space format

### DIFF
--- a/changelogs/unreleased/gh-7345-any-in-order-by-ephem.md
+++ b/changelogs/unreleased/gh-7345-any-in-order-by-ephem.md
@@ -1,0 +1,3 @@
+## bugfix/sql
+
+* Fixed bug with ANY type in ephemeral space format in ORDER BY (gh-7043).

--- a/src/box/sql/select.c
+++ b/src/box/sql/select.c
@@ -229,8 +229,6 @@ sql_space_info_new_for_sorting(struct Parse *parser, struct ExprList *order_by,
 		bool b;
 		struct Expr *expr = list->a[i].pExpr;
 		enum field_type type = sql_expr_type(expr);
-		if (type == FIELD_TYPE_ANY)
-			type = FIELD_TYPE_SCALAR;
 		uint32_t id;
 		struct coll *coll;
 		if (sql_expr_coll(parser, expr, &b, &id, &coll) != 0)

--- a/test/sql-luatest/gh_7345_any_in_order_by_ephem_test.lua
+++ b/test/sql-luatest/gh_7345_any_in_order_by_ephem_test.lua
@@ -1,0 +1,26 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'test_any_in_order_by_ephem'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_any_in_order_by_ephem = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        box.execute([[CREATE TABLE t(i INT PRIMARY KEY, a ANY, b INTEGER);]])
+        box.execute([[INSERT INTO t VALUES(1, [1, 2], 2);]])
+        box.execute([[INSERT INTO t VALUES(2, {'a': 1, 'b': 2}, 1);]])
+        local sql = [[SELECT a FROM t ORDER BY b LIMIT 1;]]
+        t.assert_equals(box.execute(sql).rows, {{{a = 1, b = 2}}})
+        local sql = [[SELECT a FROM t ORDER BY b LIMIT 1 OFFSET 1;]]
+        t.assert_equals(box.execute(sql).rows, {{{1, 2}}})
+        box.execute([[DROP TABLE t;]])
+    end)
+end


### PR DESCRIPTION
This patch fixes a bug where the ANY field type was replaced by the
SCALAR field type in the ephemeral space used in ORDER BY.

Closes #7345

NO_DOC=bugfix