### PR TITLE
console: fix `-i` being overruled by `!isatty()`

### DIFF
--- a/changelogs/unreleased/gh-5064-ignore-i-flag-without-tty.md
+++ b/changelogs/unreleased/gh-5064-ignore-i-flag-without-tty.md
@@ -1,0 +1,3 @@
+## bugfix/console
+
+* Fixed console ignoring `-i` flag in case stdin is not a tty (gh-5064).

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -936,7 +936,8 @@ run_script_f(va_list ap)
 			goto luajit_error;
 		if (lua_main(L, argc, argv) != 0)
 			goto error;
-	} else if (!is_a_tty || (path && strcmp(path, "-") == 0)) {
+	} else if ((!interactive && !is_a_tty) ||
+			(path && strcmp(path, "-") == 0)) {
 		/* Execute stdin */
 		if (luaL_loadfile(L, NULL) != 0)
 			goto luajit_error;

--- a/test/app-luatest/gh_5064_console_ignore_i_flag_without_tty_test.lua
+++ b/test/app-luatest/gh_5064_console_ignore_i_flag_without_tty_test.lua
@@ -1,0 +1,22 @@
+local t = require('luatest')
+local g = t.group()
+
+local result_str =  [[tarantool> 42
+---
+- 42
+...
+
+tarantool> ]]
+
+local TARANTOOL_PATH = arg[-1]
+
+g.test_console_ignores_i_flag_without_tty = function()
+    local cmd = [[printf '42\n' | ]] .. TARANTOOL_PATH .. [[ -i 2>/dev/null]]
+    local fh = io.popen(cmd, 'r')
+
+    -- Readline on CentOS 7 produces \e[?1034h escape sequence before tarantool> prompt, remove it.
+    local result = fh:read('*a'):gsub('\x1b%[%?1034h', '')
+
+    fh:close()
+    t.assert_equals(result, result_str)
+end

--- a/test/box/gh-4703-on_shutdown-bug.result
+++ b/test/box/gh-4703-on_shutdown-bug.result
@@ -20,9 +20,10 @@ test_run:cmd("setopt delimiter ';'");
  | ---
  | - true
  | ...
+-- Extra \n is required on openSUSE.
 on_shutdown_cmd = "box.ctl.on_shutdown(function() local fio = require('fio') "..
                    "fio.open('"..file_name.."', "..
-                   "{'O_CREAT', 'O_TRUNC', 'O_WRONLY'}, 777):close() end)";
+                   "{'O_CREAT', 'O_TRUNC', 'O_WRONLY'}, 777):close() end)\n";
  | ---
  | ...
 test_run:cmd("setopt delimiter ''");

--- a/test/box/gh-4703-on_shutdown-bug.test.lua
+++ b/test/box/gh-4703-on_shutdown-bug.test.lua
@@ -8,9 +8,10 @@ test_run = env.new()
 --
 file_name = "on_shutdown_triggered.txt"
 test_run:cmd("setopt delimiter ';'");
+-- Extra \n is required on openSUSE.
 on_shutdown_cmd = "box.ctl.on_shutdown(function() local fio = require('fio') "..
                    "fio.open('"..file_name.."', "..
-                   "{'O_CREAT', 'O_TRUNC', 'O_WRONLY'}, 777):close() end)";
+                   "{'O_CREAT', 'O_TRUNC', 'O_WRONLY'}, 777):close() end)\n";
 test_run:cmd("setopt delimiter ''");
 server = io.popen('tarantool -i', 'w')
 server:write(on_shutdown_cmd)


### PR DESCRIPTION
The interactive mode has been overruled by isatty check and is no more.
Now results of another command can be handled by tarantool.
For example:
```
$ echo 42 | tarantool -i
Tarantool 2.5.0-130-ge3cf64a6c
type 'help' for interactive help
tarantool> 42
---
- 42
...

tarantool> $
```
NO_DOC=bugfix
Closes #5064