### PR TITLE
test: stop server started by `vinyl-luatest/update_optimize` test

### DIFF
--- a/test/vinyl-luatest/update_optimize_test.lua
+++ b/test/vinyl-luatest/update_optimize_test.lua
@@ -22,6 +22,10 @@ g.before_all(function()
     end)
 end)
 
+g.after_all(function()
+    g.server:drop()
+end)
+
 g.before_each(function()
     g.server:exec(function()
         box.schema.space.create('test', {engine = 'vinyl'})


### PR DESCRIPTION
Normally, if a server created by a test isn't stopped it should be forcefully killed by luatest or test-run. For some reason, it doesn't happen sometimes, which may lead to the next test failing to bind, because all test servers that belong to the same luatest suite and have the same alias share the same socket path (although they use different
directories). This looks like a test-run or luatest bug.

The `vinyl-luatest/update_optimize` test doesn't stop the test server so because of this test-run/luatest bug, the next vinyl-luatest test fails occasionally:

```
[001] vinyl-luatest/update_optimize_test.lua                          [ pass ]
[001] vinyl-luatest/gh_6568_replica_initial_join_rem>                 [ fail ]
[001] Test failed! Output from reject file /tmp/t/rejects/vinyl-luatest/gh_6568_replica_initial_join_removal_of_compacted_run_files.reject:
[001] TAP version 13
[001] 1..1
[001] # Started on Tue Jul  5 13:30:37 2022
[001] # Starting group: gh-6568-replica-initial-join-removal-of-compacted-run-files
[001] master | 2022-07-05 13:30:37.530 [189564] main/103/default.lua F> can't initialize storage: unlink, called on fd 25, aka unix/:(socket), peer of unix/:(socket): Address already in use
[001] ok     1  gh-6568-replica-initial-join-removal-of-compacted-run-files.test_replication_compaction_cleanup
[001] not ok 1  gh-6568-replica-initial-join-removal-of-compacted-run-files.test_replication_compaction_cleanup
[001] #   Failure in after_all hook: /home/vlad/.rocks/share/tarantool/luatest/process.lua:100: kill failed: 256
[001] #   stack traceback:
[001] #         .../src/tarantool/tarantool/test/luatest_helpers/server.lua:206: in function 'stop'
[001] #         ...src/tarantool/tarantool/test/luatest_helpers/cluster.lua:44: in function 'drop'
[001] #         ...ica_initial_join_removal_of_compacted_run_files_test.lua:34: in function <...ica_initial_join_removal_of_compacted_run_files_test.lua:33>
[001] #         ...
[001] #         [C]: in function 'xpcall'
[001] # Ran 1 tests in 1.682 seconds, 0 succeeded, 1 errored
```

Let's fix this by stopping the test server started by the `vinyl-luatest/update_optimize` test.