### PR TITLE
box: use 0 as a space id for FK that refer to the same space

### DIFF
--- a/changelogs/unreleased/gh-7200-use-0-as-space-id-for-self-fkey.md
+++ b/changelogs/unreleased/gh-7200-use-0-as-space-id-for-self-fkey.md
@@ -1,0 +1,4 @@
+## feature/core
+
+* Now it is possible to skip space id in the space format for the
+  foreign key referring to the same space (gh-7200).

--- a/src/box/lua/space.cc
+++ b/src/box/lua/space.cc
@@ -309,7 +309,12 @@ lbox_push_space_foreign_key(struct lua_State *L, struct space *space, int i)
 			continue;
 
 		lua_newtable(L);
-		lua_pushnumber(L, c->def.fkey.space_id);
+		if (c->def.fkey.space_id == 0) {
+			/* No space id - no field. */
+			lua_pushnil(L);
+		} else {
+			lua_pushnumber(L, c->def.fkey.space_id);
+		}
 		lua_setfield(L, -2, "space");
 		lua_newtable(L);
 		for (uint32_t j = 0; j < c->def.fkey.field_mapping_size; j++) {

--- a/src/box/tuple_constraint_fkey.c
+++ b/src/box/tuple_constraint_fkey.c
@@ -588,8 +588,11 @@ tuple_constraint_fkey_init(struct tuple_constraint *constr,
 	constr->space = space;
 	tuple_constraint_fkey_update_local(constr, field_no);
 
-	bool fkey_same_space = constr->def.fkey.space_id == space->def->id;
-	struct space *foreign_space = space_by_id(constr->def.fkey.space_id);
+	bool fkey_same_space = constr->def.fkey.space_id == 0 ||
+			       constr->def.fkey.space_id == space->def->id;
+	uint32_t space_id = fkey_same_space ? space->def->id :
+			    constr->def.fkey.space_id;
+	struct space *foreign_space = space_by_id(space_id);
 	if (fkey_same_space && foreign_space == NULL)
 		foreign_space = space;
 	enum space_cache_holder_type type = SPACE_HOLDER_FOREIGN_KEY;

--- a/test/engine-luatest/gh_6436_field_foreign_key_test.lua
+++ b/test/engine-luatest/gh_6436_field_foreign_key_test.lua
@@ -53,19 +53,9 @@ g.test_bad_foreign_key = function(cg)
             "Illegal parameters, format[2]: foreign key definition must be a table with 'space' and 'field' members",
             function() box.schema.create_space('city', {engine=engine, format=fmt}) end
         )
-        fmt = gen_format({field = 'id'})
-        t.assert_error_msg_content_equals(
-            "Illegal parameters, format[2]: foreign key definition must be a table with 'space' and 'field' members",
-            function() box.schema.create_space('city', {engine=engine, format=fmt}) end
-        )
         fmt = gen_format({fkey={space = 'country'}})
         t.assert_error_msg_content_equals(
             "Illegal parameters, format[2]: foreign key: field must be specified",
-            function() box.schema.create_space('city', {engine=engine, format=fmt}) end
-        )
-        fmt = gen_format({fkey={field = 'id'}})
-        t.assert_error_msg_content_equals(
-            "Illegal parameters, format[2]: foreign key: space must be specified",
             function() box.schema.create_space('city', {engine=engine, format=fmt}) end
         )
         fmt = gen_format({space = 'planet', field = 'id'})

--- a/test/engine-luatest/gh_7200_fkey_without_space_id_test.lua
+++ b/test/engine-luatest/gh_7200_fkey_without_space_id_test.lua
@@ -1,0 +1,108 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group('gh-7200-fkey-without-space-id',
+                  {{engine = 'memtx'}, {engine = 'vinyl'}})
+
+g.before_all(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:stop()
+    cg.server = nil
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.space then box.space.space:drop() end
+        if box.space.complex then box.space.complex:drop() end
+        if box.space.filesystem then box.space.filesystem:drop() end
+    end)
+end)
+
+-- Similar to test_foreign_key_primary in gh_6961_fkey_same_space_test.lua,
+-- but without specifying space id in the format.
+g.test_foreign_key_primary = function(cg)
+    local engine = cg.params.engine
+
+    cg.server:exec(function(engine)
+        local t = require('luatest')
+
+        local fmt = {{name='id', type='unsigned'},
+                     {name='parent_id', type='unsigned',
+                      foreign_key={field='id'}}}
+        local fs = box.schema.create_space('filesystem', {engine=engine,
+                                                          format=fmt})
+        t.assert_equals(fs:format(fs:format()), nil)
+        fs:drop()
+
+        local fmt = {{name='id', type='unsigned'},
+                     {name='parent_id', type='unsigned',
+                      foreign_key={fkey={field='id'}}}}
+        local fs = box.schema.create_space('filesystem', {engine=engine})
+        fs:format(fmt)
+        t.assert_equals(fs:format(), fmt)
+        fs:create_index('pk')
+        fs:create_index('sk', {unique=false, parts={'parent_id'}})
+        t.assert_error_msg_content_equals(
+            "Foreign key constraint 'fkey' failed for field '2 (parent_id)': foreign tuple was not found",
+            function() fs:insert{1, 0} end
+        )
+    end, {engine})
+end
+
+-- Test complex foreign key without specifying space id.
+g.test_complex_foreign_key1 = function(cg)
+    local engine = cg.params.engine
+
+    cg.server:exec(function(engine)
+        local t = require('luatest')
+
+        local fmt = {{name='id1', type='unsigned'},
+                     {name='id2', type='unsigned'}}
+        local fkey = {field={id1='id1', id2='id2'}}
+        local opts = {engine=engine, format=fmt, foreign_key=fkey}
+        local space = box.schema.create_space('complex', opts)
+
+        -- Note that 'space' field is not present in the table
+        t.assert_equals(space.foreign_key,
+                        {complex={field={id1='id1', id2='id2'}}})
+    end, {engine})
+end
+
+g.test_complex_foreign_key2 = function(cg)
+    local engine = cg.params.engine
+
+    cg.server:exec(function(engine)
+        local t = require('luatest')
+
+        local fmt = {{name='id1', type='unsigned'},
+                     {name='id2', type='unsigned'}}
+        local fkey = {name={field={id1='id2', id2='id1'}}}
+        local opts = {engine=engine, format=fmt, foreign_key=fkey}
+        local space = box.schema.create_space('complex', opts)
+
+        -- Note that 'space' field is not present in the table
+        t.assert_equals(space.foreign_key,
+                        {name={field={id1='id2', id2='id1'}}})
+    end, {engine})
+end
+
+-- Test foreign key creation by inserting directly into box.space._space
+g.test_foreign_key_direct_insert = function(cg)
+    local engine = cg.params.engine
+
+    cg.server:exec(function(engine)
+        local t = require('luatest')
+
+        local fmt = {{name = 'i', type = 'integer'},
+                     {name = 'j', type = 'integer'},
+                     {name = 'k', type = 'integer',
+                      foreign_key = {k1 = {field = 'i'}}}}
+        local opts = {foreign_key = {k2 = {field = {i = 'i', j = 'j'}}}}
+        box.space._space:insert{512, 1, 'space', engine, 0, opts, fmt}
+        t.assert_equals(box.space._space:get(512).flags, opts)
+        t.assert_equals(box.space._space:get(512).format, fmt)
+    end, {engine})
+end


### PR DESCRIPTION
It is inconvenient to create self-referencing FK constraints, as the
space ID will only be generated during space creation. This is
especially useful for SQL, since the format for the space is created
at compile time, and the space ID is only obtained at run time.

Closes #7200