### PR TITLE
[1.10] Bump curl 7.84.0 1.10

### DIFF
--- a/changelogs/unreleased/bump-libcurl-to-7.84.0.md
+++ b/changelogs/unreleased/bump-libcurl-to-7.84.0.md
@@ -1,0 +1,3 @@
+## feature/build
+
+* Updated libcurl to version 7.84.0.


### PR DESCRIPTION
Changelog: https://curl.se/changes.html#7_84_0

New release contains fixes for 4 security problems [1].

1. https://curl.se/docs/releases.html

NO_DOC=libcurl submodule bump
NO_CHANGELOG=libcurl submodule bump
NO_TEST=libcurl submodule bump