### PR TITLE
ci: install test-run deps via pip instead of apt

### DIFF
--- a/.travis.mk
+++ b/.travis.mk
@@ -337,7 +337,8 @@ test_oos_build:
 deps_odroid_arm64:
 	sudo apt update -y && sudo apt -y install git build-essential cmake make zlib1g-dev \
 		libreadline-dev libncurses5-dev libssl-dev libunwind-dev libicu-dev python3 \
-		python3-six python3-gevent python3-pip
+		python3-six python3-pip
+	pip3 install -r test-run/requirements.txt
 
 build_odroid_arm64:
 	cmake . -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} ${CMAKE_EXTRA_PARAMS}
@@ -502,7 +503,8 @@ tarantool_linux_deps:
 	sudo apt update -y && sudo apt -y install git build-essential cmake \
 		make ninja-build zlib1g-dev libreadline-dev libncurses5-dev \
 		libssl-dev libunwind-dev libicu-dev \
-		python3 python3-six python3-gevent python3-pip
+		python3 python3-six python3-pip
+	pip3 install -r test-run/requirements.txt
 
 tarantool_linux_tests: tarantool_linux_deps cmake_build cmake_luajit_test test_run_tarantool_test
 


### PR DESCRIPTION
This patch fixes the following issue:

    Installing collected packages: greenlet, gevent
      Attempting uninstall: greenlet
        Found existing installation: greenlet 0.4.15
    ERROR: Cannot uninstall 'greenlet'. It is a distutils installed
        project and thus we cannot accurately determine which files
        belong to it which would lead to only a partial uninstall.
    make: *** [.travis.mk:86: deps_tests] Error 1
    Error: Process completed with exit code 2.

This happens because the `python3-gevent` package is installed via the
`apt` package manager in some test targets. Let's install test-run deps
via `pip` everywhere.

NO_DOC=ci
NO_TEST=ci
NO_CHANGELOG=ci