### PR TITLE
test: remove tests from fragile list

### DIFF
--- a/test/box/suite.ini
+++ b/test/box/suite.ini
@@ -13,12 +13,6 @@ is_parallel = True
 fragile = {
     "retries": 10,
     "tests": {
-        "bitset.test.lua": {
-            "issues": [ "gh-4095" ]
-        },
-        "function1.test.lua": {
-            "issues": [ "gh-4199" ]
-        },
         "push.test.lua": {
             "issues": [ "gh-4882" ]
         },


### PR DESCRIPTION
Since "x64/LJ_GC64: Fix fallback case of asm_fuseloadk64()."
(42853793ec3e6e36bc0f7dff9d483d64ba0d8d28) is backported into
tarantool/luajit trunk, box/bitset.test.lua and box/function1.test.lua
tests are no more fragile.

Follows up tarantool/tarantool-qa#234
Follows up tarantool/tarantool-qa#235

NO_DOC=test changes
NO_CHANGELOG=test changes
NO_TEST=test changes
