### PR TITLE
coio: fix memory leaks

### DIFF
--- a/src/lib/core/coio.c
+++ b/src/lib/core/coio.c
@@ -171,7 +171,7 @@ coio_connect_timeout(const char *host, const char *service, int host_hint,
 	if (host != NULL && service != NULL && host_hint != 0) {
 		if (coio_fill_addrinfo(&ai_local, host, service,
 				       host_hint) != 0)
-			return -1;
+			goto out;
 		ai = &ai_local;
 	} else {
 		struct addrinfo hints;

--- a/test/unit/coio.cc
+++ b/test/unit/coio.cc
@@ -180,11 +180,9 @@ test_waitpid_f(va_list ap)
 	fflush(stderr);
 
 	pid_t pid = fork();
-
-	/* Child process: do something for 10ms and exit. */
 	if (pid == 0) {
-		usleep(10000);
-		exit(0);
+		/* Child process. */
+		execlp("true", "", NULL);
 	}
 
 	fail_if(pid == -1);


### PR DESCRIPTION
#### coio: fix memory leak in coio_connect_timeout

coio_fill_addrinfo allocates ai_local->ai_addr, which should be freed in case of error.

#### coio: do exec after fork in unit/coio.test

This makes the test more real-life, and allows not to bother in the child process with the memory allocated prior to fork.

Closes #7370