### PR TITLE
memtx: move allocator stuff from `memtx_engine` to `MemtxAllocator`

### DIFF
--- a/src/box/memtx_allocator.cc
+++ b/src/box/memtx_allocator.cc
@@ -30,31 +30,13 @@
  */
 #include "memtx_allocator.h"
 
-struct memtx_allocator_set_mode {
-	template<typename Allocator, typename...Arg>
-	void
-	invoke(Arg&&...mode)
-	{
-		Allocator::set_mode(mode...);
-	}
-};
-
 void
-memtx_allocators_init(struct memtx_engine *memtx,
-		      struct allocator_settings *settings)
+memtx_allocators_init(struct allocator_settings *settings)
 {
 	foreach_allocator<allocator_create,
 		struct allocator_settings *&>(settings);
 
-	foreach_memtx_allocator<allocator_create,
-		enum memtx_engine_free_mode &>(memtx->free_mode);
-}
-
-void
-memtx_allocators_set_mode(enum memtx_engine_free_mode mode)
-{
-	foreach_memtx_allocator<memtx_allocator_set_mode,
-		enum memtx_engine_free_mode &>(mode);
+	foreach_memtx_allocator<allocator_create>();
 }
 
 void
@@ -62,4 +44,34 @@ memtx_allocators_destroy()
 {
 	foreach_memtx_allocator<allocator_destroy>();
 	foreach_allocator<allocator_destroy>();
+}
+
+/** Helper for memtx_allocator_enter_delayed_free_mode(). */
+struct memtx_allocator_enter_delayed_free_mode {
+	template<typename Allocator>
+	void invoke()
+	{
+		Allocator::enter_delayed_free_mode();
+	}
+};
+
+void
+memtx_allocators_enter_delayed_free_mode()
+{
+	foreach_memtx_allocator<memtx_allocator_enter_delayed_free_mode>();
+}
+
+/** Helper for memtx_allocator_leave_delayed_free_mode(). */
+struct memtx_allocator_leave_delayed_free_mode {
+	template<typename Allocator>
+	void invoke()
+	{
+		Allocator::leave_delayed_free_mode();
+	}
+};
+
+void
+memtx_allocators_leave_delayed_free_mode()
+{
+	foreach_memtx_allocator<memtx_allocator_leave_delayed_free_mode>();
 }

--- a/src/box/memtx_allocator.h
+++ b/src/box/memtx_allocator.h
@@ -64,7 +64,7 @@ public:
 
 	static void delayed_free(void *ptr)
 	{
-		lifo_push(&MemtxAllocator<Allocator>::lifo, ptr);
+		lifo_push(&lifo, ptr);
 	}
 
 	static void * alloc(size_t size)
@@ -75,19 +75,19 @@ public:
 
 	static void create(enum memtx_engine_free_mode m)
 	{
-		MemtxAllocator<Allocator>::mode = m;
-		lifo_init(&MemtxAllocator<Allocator>::lifo);
+		mode = m;
+		lifo_init(&lifo);
 	}
 
 	static void set_mode(enum memtx_engine_free_mode m)
 	{
-		MemtxAllocator<Allocator>::mode = m;
+		mode = m;
 	}
 
 	static void destroy()
 	{
 		void *item;
-		while ((item = lifo_pop(&MemtxAllocator<Allocator>::lifo)))
+		while ((item = lifo_pop(&lifo)))
 			free(item);
 	}
 private:
@@ -95,18 +95,17 @@ private:
 
 	static void collect_garbage()
 	{
-		if (MemtxAllocator<Allocator>::mode !=
-		    MEMTX_ENGINE_COLLECT_GARBAGE)
+		if (mode != MEMTX_ENGINE_COLLECT_GARBAGE)
 			return;
-		if (! lifo_is_empty(&MemtxAllocator<Allocator>::lifo)) {
+		if (!lifo_is_empty(&lifo)) {
 			for (int i = 0; i < GC_BATCH_SIZE; i++) {
-				void *item = lifo_pop(&MemtxAllocator<Allocator>::lifo);
+				void *item = lifo_pop(&lifo);
 				if (item == NULL)
 					break;
 				free(item);
 			}
 		} else {
-			MemtxAllocator<Allocator>::mode = MEMTX_ENGINE_FREE;
+			mode = MEMTX_ENGINE_FREE;
 		}
 	}
 	static struct lifo lifo;

--- a/src/box/memtx_allocator.h
+++ b/src/box/memtx_allocator.h
@@ -129,13 +129,13 @@ public:
 	 * it. Otherwise, it's put in the garbage collection list to be free as
 	 * soon as the last snapshot using it is destroyed.
 	 */
-	static void free_tuple(struct tuple *tuple, bool is_temporary)
+	static void free_tuple(struct tuple *tuple)
 	{
 		struct memtx_tuple *memtx_tuple = container_of(
 			tuple, struct memtx_tuple, base);
 		if (mode != MEMTX_ENGINE_DELAYED_FREE ||
 		    memtx_tuple->version == snapshot_version ||
-		    is_temporary) {
+		    tuple_has_flag(tuple, TUPLE_IS_TEMPORARY)) {
 			immediate_free_tuple(memtx_tuple);
 		} else {
 			delayed_free_tuple(memtx_tuple);

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -735,6 +735,7 @@ checkpoint_delete(struct checkpoint *ckpt)
 		entry->iterator->free(entry->iterator);
 		free(entry);
 	}
+	memtx_allocators_leave_delayed_free_mode();
 	xdir_destroy(&ckpt->dir);
 	free(ckpt);
 }
@@ -888,6 +889,7 @@ memtx_engine_begin_checkpoint(struct engine *engine, bool is_scheduled)
 		memtx->checkpoint = NULL;
 		return -1;
 	}
+	memtx_allocators_enter_delayed_free_mode();
 	return 0;
 }
 
@@ -1062,6 +1064,7 @@ memtx_engine_prepare_join(struct engine *engine, void **arg)
 		free(ctx);
 		return -1;
 	}
+	memtx_allocators_enter_delayed_free_mode();
 	*arg = ctx;
 	return 0;
 }
@@ -1139,6 +1142,7 @@ memtx_engine_complete_join(struct engine *engine, void *arg)
 		entry->iterator->free(entry->iterator);
 		free(entry);
 	}
+	memtx_allocators_leave_delayed_free_mode();
 	free(ctx);
 }
 
@@ -1397,20 +1401,6 @@ void
 memtx_engine_set_max_tuple_size(struct memtx_engine *memtx, size_t max_size)
 {
 	memtx->max_tuple_size = max_size;
-}
-
-void
-memtx_enter_delayed_free_mode(struct memtx_engine *memtx)
-{
-	(void)memtx;
-	memtx_allocators_enter_delayed_free_mode();
-}
-
-void
-memtx_leave_delayed_free_mode(struct memtx_engine *memtx)
-{
-	(void)memtx;
-	memtx_allocators_leave_delayed_free_mode();
 }
 
 template<class ALLOC>

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -1457,6 +1457,8 @@ memtx_tuple_new_raw_impl(struct tuple_format *format, const char *data,
 	}
 	tuple_create(tuple, 0, tuple_format_id(format),
 		     data_offset, tuple_len, make_compact);
+	if (format->is_temporary)
+		tuple_set_flag(tuple, TUPLE_IS_TEMPORARY);
 	tuple_format_ref(format);
 	raw = (char *) tuple + data_offset;
 	field_map_build(&builder, raw - field_map_size);
@@ -1480,7 +1482,7 @@ memtx_tuple_delete(struct tuple_format *format, struct tuple *tuple)
 {
 	assert(tuple_is_unreferenced(tuple));
 	say_debug("%s(%p)", __func__, tuple);
-	MemtxAllocator<ALLOC>::free_tuple(tuple, format->is_temporary);
+	MemtxAllocator<ALLOC>::free_tuple(tuple);
 	tuple_format_unref(format);
 }
 

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -219,23 +219,6 @@ memtx_engine_set_memory(struct memtx_engine *memtx, size_t size);
 void
 memtx_engine_set_max_tuple_size(struct memtx_engine *memtx, size_t max_size);
 
-/**
- * Enter tuple delayed free mode: tuple allocated before the call
- * won't be freed until memtx_leave_delayed_free_mode() is called.
- * This function is reentrant, meaning it's okay to call it multiple
- * times from the same or different fibers - one just has to leave
- * the delayed free mode the same amount of times then.
- */
-void
-memtx_enter_delayed_free_mode(struct memtx_engine *memtx);
-
-/**
- * Leave tuple delayed free mode. This function undoes the effect
- * of memtx_enter_delayed_free_mode().
- */
-void
-memtx_leave_delayed_free_mode(struct memtx_engine *memtx);
-
 /** Tuple format vtab for memtx engine. */
 extern struct tuple_format_vtab memtx_tuple_format_vtab;
 

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -52,18 +52,6 @@ struct tuple;
 struct tuple_format;
 
 /**
- * Free mode, determines a strategy for freeing up memory
- */
-enum memtx_engine_free_mode {
-	/** Free objects immediately. */
-	MEMTX_ENGINE_FREE,
-	/** Collect garbage after delayed free. */
-	MEMTX_ENGINE_COLLECT_GARBAGE,
-	/** Postpone deletion of objects. */
-	MEMTX_ENGINE_DELAYED_FREE,
-};
-
-/**
  * Recovery state of memtx engine.
  *
  * For faster recovery an optimization is used: initial recovery
@@ -163,14 +151,6 @@ struct memtx_engine {
 	void *reserved_extents;
 	/** Maximal allowed tuple size, box.cfg.memtx_max_tuple_size. */
 	size_t max_tuple_size;
-	/** Incremented with each next snapshot. */
-	uint32_t snapshot_version;
-	/**
-	 * Unless zero, freeing of tuples allocated before the last
-	 * call to memtx_enter_delayed_free_mode() is delayed until
-	 * memtx_leave_delayed_free_mode() is called.
-	 */
-	uint32_t delayed_free_mode;
 	/** Memory pool for rtree index iterator. */
 	struct mempool rtree_iterator_pool;
 	/**
@@ -189,10 +169,6 @@ struct memtx_engine {
 	 * memtx_gc_task::link.
 	 */
 	struct stailq gc_queue;
-	/**
-	 * Free mode, determines a strategy for freeing up memory
-	 */
-	enum memtx_engine_free_mode free_mode;
 };
 
 struct memtx_gc_task;

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -482,8 +482,6 @@ hash_snapshot_iterator_free(struct snapshot_iterator *iterator)
 	assert(iterator->free == hash_snapshot_iterator_free);
 	struct hash_snapshot_iterator *it =
 		(struct hash_snapshot_iterator *) iterator;
-	memtx_leave_delayed_free_mode((struct memtx_engine *)
-				      it->index->base.engine);
 	light_index_iterator_destroy(&it->index->hash_table, &it->iterator);
 	index_unref(&it->index->base);
 	memtx_tx_snapshot_cleaner_destroy(&it->cleaner);
@@ -547,7 +545,6 @@ memtx_hash_index_create_snapshot_iterator(struct index *base)
 	index_ref(base);
 	light_index_iterator_begin(&index->hash_table, &it->iterator);
 	light_index_iterator_freeze(&index->hash_table, &it->iterator);
-	memtx_enter_delayed_free_mode((struct memtx_engine *)base->engine);
 	return (struct snapshot_iterator *) it;
 }
 

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -1681,8 +1681,6 @@ tree_snapshot_iterator_free(struct snapshot_iterator *iterator)
 	assert(iterator->free == &tree_snapshot_iterator_free<USE_HINT>);
 	struct tree_snapshot_iterator<USE_HINT> *it =
 		(struct tree_snapshot_iterator<USE_HINT> *)iterator;
-	memtx_leave_delayed_free_mode((struct memtx_engine *)
-				      it->index->base.engine);
 	memtx_tree_iterator_destroy(&it->index->tree, &it->tree_iterator);
 	index_unref(&it->index->base);
 	memtx_tx_snapshot_cleaner_destroy(&it->cleaner);
@@ -1752,7 +1750,6 @@ memtx_tree_index_create_snapshot_iterator(struct index *base)
 	index_ref(base);
 	it->tree_iterator = memtx_tree_iterator_first(&index->tree);
 	memtx_tree_iterator_freeze(&index->tree, &it->tree_iterator);
-	memtx_enter_delayed_free_mode((struct memtx_engine *)base->engine);
 	return (struct snapshot_iterator *) it;
 }
 

--- a/src/box/tuple.h
+++ b/src/box/tuple.h
@@ -313,6 +313,11 @@ enum tuple_flag {
 	 * be clarified by transaction engine.
 	 */
 	TUPLE_IS_DIRTY = 1,
+	/**
+	 * The tuple belongs to a temporary space so it can be freed
+	 * immediately while a snapshot is in progress.
+	 */
+	TUPLE_IS_TEMPORARY = 2,
 	tuple_flag_MAX,
 };
 
@@ -682,7 +687,8 @@ tuple_delete(struct tuple *tuple)
 {
 	say_debug("%s(%p)", __func__, tuple);
 	assert(tuple->local_refs == 0);
-	assert(tuple->flags == 0);
+	assert(!tuple_has_flag(tuple, TUPLE_HAS_UPLOADED_REFS));
+	assert(!tuple_has_flag(tuple, TUPLE_IS_DIRTY));
 	struct tuple_format *format = tuple_format(tuple);
 	format->vtab.tuple_delete(format, tuple);
 }

--- a/test/box/gh-3633-tuple-size-increasing.result
+++ b/test/box/gh-3633-tuple-size-increasing.result
@@ -49,7 +49,7 @@ str = digest.urandom(size)
 -- insert tuples, until we get error due to no enough of memory
 for i = 1, 1024 do s:insert({i, str}) end
  | ---
- | - error: Failed to allocate 512023 bytes in slab allocator for memtx_tuple
+ | - error: Failed to allocate 512019 bytes in slab allocator for memtx_tuple
  | ...
 -- truncate space, and collect garbage (free previous allocated memory)
 s:truncate()

--- a/test/box/reconfigure.result
+++ b/test/box/reconfigure.result
@@ -162,7 +162,7 @@ pad = string.rep('x', 100 * 1024)
 ...
 for i = 1, count do s:replace{i, pad} end -- error: not enough memory
 ---
-- error: Failed to allocate 102421 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 102417 bytes in slab allocator for memtx_tuple
 ...
 s:count() < count
 ---

--- a/test/box/upsert_errinj.result
+++ b/test/box/upsert_errinj.result
@@ -19,7 +19,7 @@ errinj.set("ERRINJ_TUPLE_ALLOC", true)
 ...
 s:upsert({111, '111', 222, '222'}, {{'!', 5, '!'}})
 ---
-- error: Failed to allocate 22 bytes in slab allocator for memtx_tuple
+- error: Failed to allocate 18 bytes in slab allocator for memtx_tuple
 ...
 errinj.set("ERRINJ_TUPLE_ALLOC", false)
 ---

--- a/test/wal_off/tuple.result
+++ b/test/wal_off/tuple.result
@@ -52,7 +52,7 @@ n + 32 >= box.cfg.memtx_max_tuple_size
 ...
 reason
 ---
-- 'Failed to allocate 1048601 bytes for tuple: tuple is too large. Check ''memtx_max_tuple_size''
+- 'Failed to allocate 1048597 bytes for tuple: tuple is too large. Check ''memtx_max_tuple_size''
   configuration option.'
 ...
 tester:drop()


### PR DESCRIPTION
The main goal of this PR is to move allocator-specific stuff from `memtx_engine` to `MemtxAllocator`.
See commit descriptions for more details.

Needed for #7364.