### PR TITLE
build: fix error on FreeBSD 13.1

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -305,7 +305,7 @@ target_link_libraries(popen.test misc unit core)
 add_executable(serializer.test serializer.c box_test_utils.c)
 target_link_libraries(serializer.test unit box ${LUAJIT_LIBRARIES})
 
-add_executable(watcher.test watcher.c)
+add_executable(watcher.test watcher.c box_test_utils.c)
 target_link_libraries(watcher.test unit box)
 
 add_executable(grp_alloc.test grp_alloc.c box_test_utils.c)


### PR DESCRIPTION
This patch fixes the following error while tarantool build on
FreeBSD 13.1:

    [100%] Linking CXX executable watcher.test
    ld: error: undefined symbol: set_sigint_cb
    >>> referenced by console.c:261 (lua/console.c:261)
    >>>               console.c.o:(lbox_console_readline) in
                        archive ../../src/box/libbox.a
    >>> referenced by console.c:342 (lua/console.c:342)
    >>>               console.c.o:(lbox_console_readline) in
                        archive ../../src/box/libbox.a
    >>> referenced by console.c:352 (lua/console.c:352)
    >>>               console.c.o:(lbox_console_readline) in
                        archive ../../src/box/libbox.a
    >>> referenced 1 more times
    c++: error: linker command failed with exit code 1
        (use -v to see invocation)
    gmake[2]: *** [test/unit/CMakeFiles/watcher.test.dir/build.make:152:
        test/unit/watcher.test] Error 1
    gmake[1]: *** [CMakeFiles/Makefile2:10528:
        test/unit/CMakeFiles/watcher.test.dir/all] Error 2
    gmake: *** [Makefile:156: all] Error 2

NO_DOC=minor changes
NO_TEST=minor changes
NO_CHANGELOG=minor changes