### PR TITLE
ci: fix deps installation for FreeBSD systems

### DIFF
--- a/.travis.mk
+++ b/.travis.mk
@@ -460,9 +460,10 @@ test_static_build_cmake_osx_github_actions: base_deps_osx_github_actions test_st
 ###########
 
 deps_freebsd:
-	sudo pkg install -y git cmake gmake icu libiconv \
-		python38 py38-yaml py38-six py38-gevent
+	sudo pkg install -y git cmake gmake icu libiconv python38
 	which python3 || sudo ln -s /usr/local/bin/python3.8 /usr/local/bin/python3
+	python3 -m pip -V || curl -fsSL https://bootstrap.pypa.io/get-pip.py | python3
+	python3 -m pip install -r test-run/requirements.txt
 
 build_freebsd:
 	if [ "$$(swapctl -l | wc -l)" != "1" ]; then sudo swapoff -a ; fi ; swapctl -l

--- a/.travis.mk
+++ b/.travis.mk
@@ -358,7 +358,7 @@ test_odroid_arm64: deps_odroid_arm64 test_odroid_arm64_no_deps
 # FIXME: Temporary pinned python3 to specific version (i.e. python@3.8) to
 # avoid gevent package installation failure described in gevent/gevent#1721.
 # Revert this back when the issue is resolved.
-OSX_PKGS=openssl readline curl icu4c libiconv zlib cmake python@3.8
+OSX_PKGS=openssl readline curl icu4c libiconv zlib cmake python@3.8 autoconf automake libtool
 
 deps_osx:
 	# install brew using command from Homebrew repository instructions:
@@ -521,9 +521,9 @@ luajit_Linux_x86_64_test: tarantool_linux_tests
 
 tarantool_darwin_deps:
 	${ARCH} brew install --force openssl readline curl icu4c libiconv zlib \
-		cmake python@3.8 \
+		cmake python@3.8 autoconf automake libtool \
 	|| ${ARCH} brew upgrade openssl readline curl icu4c libiconv zlib \
-		cmake python@3.8
+		cmake python@3.8 autoconf automake libtool
 	${ARCH} pip3 install --force-reinstall -r test-run/requirements.txt
 
 tarantool_darwin_prebuild:

--- a/.travis.mk
+++ b/.travis.mk
@@ -87,10 +87,11 @@ deps_tests:
 
 deps_ubuntu_ghactions: deps_tests
 	sudo apt-get update ${APT_EXTRA_FLAGS} && \
-		sudo apt-get install -y -f libreadline-dev libunwind-dev autoconf automake
+		sudo apt-get install -y -f libreadline-dev libunwind-dev \
+		autoconf automake libtool
 
 deps_coverage_ubuntu_ghactions: deps_ubuntu_ghactions
-	sudo apt-get install -y -f lcov ninja-build autoconf automake
+	sudo apt-get install -y -f lcov ninja-build autoconf automake libtool
 	sudo gem install coveralls-lcov
 	# Link src/lib/uri/src to local src dircetory to avoid of issue:
 	# /var/lib/gems/2.7.0/gems/coveralls-lcov-1.7.0/lib/coveralls/lcov/converter.rb:64:in
@@ -261,7 +262,7 @@ deps_debian_static: deps_tests
 	# while liblzma dynamic library exists. So the build dynamicaly has no
 	# issues, while static build fails. To fix it we need to install
 	# liblzma-dev package with static library only for static build.
-	sudo apt-get install -y -f liblzma-dev autoconf automake
+	sudo apt-get install -y -f liblzma-dev autoconf automake libtool
 
 test_static_build: deps_debian_static
 	CMAKE_EXTRA_PARAMS=-DBUILD_STATIC=ON make -f .travis.mk test_debian_no_deps
@@ -337,7 +338,7 @@ test_oos_build:
 deps_odroid_arm64:
 	sudo apt update -y && sudo apt -y install git build-essential cmake make zlib1g-dev \
 		libreadline-dev libncurses5-dev libssl-dev libunwind-dev libicu-dev python3 \
-		python3-six python3-pip autoconf automake
+		python3-six python3-pip autoconf automake libtool
 	pip3 install -r test-run/requirements.txt
 
 build_odroid_arm64:
@@ -503,7 +504,7 @@ test_run_tarantool_test:
 tarantool_linux_deps:
 	sudo apt update -y && sudo apt -y install git build-essential cmake \
 		make ninja-build zlib1g-dev libreadline-dev libncurses5-dev \
-		libssl-dev libunwind-dev libicu-dev autoconf automake \
+		libssl-dev libunwind-dev libicu-dev autoconf automake libtool \
 		python3 python3-six python3-pip
 	pip3 install -r test-run/requirements.txt
 


### PR DESCRIPTION
The issue was in the `deps_freebsd` target that installed test-run deps
(py38-yaml, py38-six, py38-gevent) via the `pkg` package manager.

At some moment these packages were upgraded to 39 version on the mirrors
and became not available for installation anymore.

Now test-run deps are installed via `pip` package installer to avoid
such issues in the future. Installation via `pip` is more robust because
we have deps versions pinned in test-run and also we have python version
pinned to 3.8.

Also, this change adds missing `libtool` package dependency.
Installing the `autoconf` and `automake` packages is not enough.
We need to install the `libtool` package as well to avoid errors
like this:

    configure:7323: error: possibly undefined macro: AC_LIBTOOL_WIN32_DLL
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
    configure:7324: error: possibly undefined macro: AC_PROG_LIBTOOL
    autoreconf: /usr/bin/autoconf failed with exit status: 1