### PR TITLE
sql: recompile expired prepared statements

### DIFF
--- a/src/box/execute.c
+++ b/src/box/execute.c
@@ -583,8 +583,11 @@ sql_execute_prepared(uint32_t stmt_id, const struct sql_bind *bind,
 	struct sql_stmt *stmt = sql_stmt_cache_find(stmt_id);
 	assert(stmt != NULL);
 	if (!sql_stmt_schema_version_is_valid(stmt)) {
-		diag_set(ClientError, ER_SQL_EXECUTE, "statement has expired");
-		return -1;
+		if (sql_reprepare(&stmt) != 0) {
+			diag_set(ClientError, ER_SQL_EXECUTE,
+				 "statement reprepare failed");
+			return -1;
+		}
 	}
 	if (sql_stmt_busy(stmt)) {
 		const char *sql_str = sql_stmt_query_str(stmt);

--- a/test/sql/prepared.result
+++ b/test/sql/prepared.result
@@ -212,7 +212,7 @@ execute(s.stmt_id)
  | ...
 execute(s.stmt_id)
  | ---
- | - error: 'Failed to execute SQL statement: statement has expired'
+ | - error: 'Failed to execute SQL statement: statement reprepare failed'
  | ...
 unprepare(s.stmt_id)
  | ---
@@ -228,7 +228,7 @@ execute(s.stmt_id)
  | ...
 execute(s.stmt_id)
  | ---
- | - error: 'Failed to execute SQL statement: statement has expired'
+ | - error: No index 'I1' is defined in space 'TEST'
  | ...
 unprepare(s.stmt_id)
  | ---
@@ -244,7 +244,7 @@ execute(s.stmt_id)
  | ...
 execute(s.stmt_id)
  | ---
- | - error: 'Failed to execute SQL statement: statement has expired'
+ | - error: Space 'V' already exists
  | ...
 unprepare(s.stmt_id)
  | ---
@@ -260,7 +260,7 @@ execute(s.stmt_id)
  | ...
 execute(s.stmt_id)
  | ---
- | - error: 'Failed to execute SQL statement: statement has expired'
+ | - error: 'Failed to execute SQL statement: statement reprepare failed'
  | ...
 unprepare(s.stmt_id)
  | ---
@@ -276,7 +276,7 @@ execute(s.stmt_id)
  | ...
 execute(s.stmt_id)
  | ---
- | - error: 'Failed to execute SQL statement: statement has expired'
+ | - error: 'Failed to execute SQL statement: statement reprepare failed'
  | ...
 unprepare(s.stmt_id)
  | ---
@@ -296,7 +296,7 @@ execute(s.stmt_id)
  | ...
 execute(s.stmt_id)
  | ---
- | - error: 'Failed to execute SQL statement: statement has expired'
+ | - error: FOREIGN KEY constraint 'FK1' already exists in space 'TEST2'
  | ...
 unprepare(s.stmt_id)
  | ---
@@ -315,7 +315,7 @@ execute(s.stmt_id)
  | ...
 execute(s.stmt_id)
  | ---
- | - error: 'Failed to execute SQL statement: statement has expired'
+ | - error: Trigger 'TR1' already exists
  | ...
 unprepare(s.stmt_id)
  | ---
@@ -331,7 +331,7 @@ execute(s.stmt_id)
  | ...
 execute(s.stmt_id)
  | ---
- | - error: 'Failed to execute SQL statement: statement has expired'
+ | - error: Trigger 'TR1' doesn't exist
  | ...
 unprepare(s.stmt_id)
  | ---
@@ -347,7 +347,7 @@ execute(s.stmt_id)
  | ...
 execute(s.stmt_id)
  | ---
- | - error: 'Failed to execute SQL statement: statement has expired'
+ | - error: 'Failed to execute SQL statement: statement reprepare failed'
  | ...
 unprepare(s.stmt_id)
  | ---
@@ -670,7 +670,10 @@ sp:drop()
  | ...
 execute(s.stmt_id)
  | ---
- | - error: 'Failed to execute SQL statement: statement has expired'
+ | - metadata:
+ |   - name: A
+ |     type: number
+ |   rows: []
  | ...
 _ = prepare("SELECT a FROM test WHERE b = ?;")
  | ---


### PR DESCRIPTION
Actually there is no reason to throw an error and make a user manually recreate prepared statement when it expires. A much more user friendly way is to recreate it under hood when statement's schema version differs from the box one.