### PR TITLE
memtx: allocate functional index key parts as tuples

### DIFF
--- a/src/box/memtx_allocator.h
+++ b/src/box/memtx_allocator.h
@@ -59,17 +59,6 @@ struct PACKED memtx_tuple {
 template<class Allocator>
 class MemtxAllocator {
 public:
-	static void free(void *ptr, size_t size)
-	{
-		Allocator::free(ptr, size);
-	}
-
-	static void *alloc(size_t size)
-	{
-		collect_garbage();
-		return Allocator::alloc(size);
-	}
-
 	static void create()
 	{
 		mode = MEMTX_ENGINE_FREE;
@@ -144,6 +133,17 @@ public:
 
 private:
 	static constexpr int GC_BATCH_SIZE = 100;
+
+	static void free(void *ptr, size_t size)
+	{
+		Allocator::free(ptr, size);
+	}
+
+	static void *alloc(size_t size)
+	{
+		collect_garbage();
+		return Allocator::alloc(size);
+	}
 
 	static void immediate_free_tuple(struct memtx_tuple *memtx_tuple)
 	{

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -77,34 +77,9 @@ template <class ALLOC>
 static inline void
 create_memtx_tuple_format_vtab(struct tuple_format_vtab *vtab);
 
-void *
-(*memtx_alloc)(uint32_t size);
-void
-(*memtx_free)(void *ptr);
 struct tuple *
 (*memtx_tuple_new_raw)(struct tuple_format *format, const char *data,
 		       const char *end, bool validate);
-
-template <class ALLOC>
-static void *
-memtx_alloc_impl(uint32_t size)
-{
-	void *ptr = MemtxAllocator<ALLOC>::alloc(size + sizeof(uint32_t));
-	if (ptr != NULL) {
-		*(uint32_t *)ptr = size;
-		return (uint32_t *)ptr + 1;
-	}
-	return NULL;
-}
-
-template <class ALLOC>
-static void
-memtx_free_impl(void *ptr)
-{
-	ptr = (uint32_t *)ptr - 1;
-	uint32_t size = *(uint32_t *)ptr;
-	MemtxAllocator<ALLOC>::free(ptr, size);
-}
 
 template <class ALLOC>
 static inline struct tuple *
@@ -115,8 +90,6 @@ template <class ALLOC>
 static void
 memtx_alloc_init(void)
 {
-	memtx_alloc = memtx_alloc_impl<ALLOC>;
-	memtx_free = memtx_free_impl<ALLOC>;
 	memtx_tuple_new_raw = memtx_tuple_new_raw_impl<ALLOC>;
 }
 

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -232,35 +232,12 @@ enum {
 };
 
 /**
- * Allocates size bytes using the memtx allocator (MemtxAllocator::alloc).
- * On error returns NULL. Does not set diag.
- */
-extern void *
-(*memtx_alloc)(uint32_t size);
-
-/**
- * Frees memory allocated with memtx_alloc.
- */
-extern void
-(*memtx_free)(void *ptr);
-
-/**
  * Allocate and return new memtx tuple. Data validation depends
  * on @a validate value. On error returns NULL and set diag.
  */
 extern struct tuple *
 (*memtx_tuple_new_raw)(struct tuple_format *format, const char *data,
 		       const char *end, bool validate);
-
-/**
- * Returns the size of an allocation done with memtx_alloc.
- * (The size is stored before the data.)
- */
-static inline uint32_t
-memtx_alloc_size(void *ptr)
-{
-	return *((uint32_t *)ptr - 1);
-}
 
 /**
  * Allocate a block of size MEMTX_EXTENT_SIZE for memtx index

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -106,7 +106,7 @@ enum memtx_reserve_extents_num {
  * allocated for each iterator (except rtree index iterator that
  * is significantly bigger so has own pool).
  */
-#define MEMTX_ITERATOR_SIZE (192)
+#define MEMTX_ITERATOR_SIZE (160)
 
 struct memtx_engine {
 	struct engine base;
@@ -169,6 +169,10 @@ struct memtx_engine {
 	 * memtx_gc_task::link.
 	 */
 	struct stailq gc_queue;
+	/**
+	 * Format used for allocating functional index keys.
+	 */
+	struct tuple_format *func_key_format;
 };
 
 struct memtx_gc_task;

--- a/src/box/tuple_compare.cc
+++ b/src/box/tuple_compare.cc
@@ -1411,8 +1411,8 @@ func_index_compare(struct tuple *tuple_a, hint_t tuple_a_hint,
 	assert(cmp_def->for_func_index);
 	assert(is_nullable == cmp_def->is_nullable);
 
-	const char *key_a = (const char *)tuple_a_hint;
-	const char *key_b = (const char *)tuple_b_hint;
+	const char *key_a = tuple_data((struct tuple *)tuple_a_hint);
+	const char *key_b = tuple_data((struct tuple *)tuple_b_hint);
 	assert(mp_typeof(*key_a) == MP_ARRAY);
 	uint32_t part_count_a = mp_decode_array(&key_a);
 	assert(mp_typeof(*key_b) == MP_ARRAY);
@@ -1469,7 +1469,7 @@ func_index_compare_with_key(struct tuple *tuple, hint_t tuple_hint,
 	(void)tuple; (void)key_hint;
 	assert(key_def->for_func_index);
 	assert(is_nullable == key_def->is_nullable);
-	const char *tuple_key = (const char *)tuple_hint;
+	const char *tuple_key = tuple_data((struct tuple *)tuple_hint);
 	assert(mp_typeof(*tuple_key) == MP_ARRAY);
 
 	uint32_t tuple_key_count = mp_decode_array(&tuple_key);

--- a/test/wal_off/alter.result
+++ b/test/wal_off/alter.result
@@ -28,7 +28,7 @@ end;
 ...
 #spaces;
 ---
-- 65501
+- 65500
 ...
 -- cleanup
 for k, v in pairs(spaces) do


### PR DESCRIPTION
Functional index keys are allocated and freed with `MemtxAllocator`'s `alloc` and `free` methods. In contrast to tuples, which are allocated and freed with `alloc_tuple` and `free_tuple`, freeing a functional index key happens immediately, irrespective of whether there's a snapshot in progress or not. It's acceptable, because snapshot only uses primary indexes, which can't be functional. However, to reuse the snapshot infrastructure for creating general purpose user read views, we will need to guarantee that functional index keys stay alive until all read views using them are closed.

To achieve that, this commit turns functional index keys into tuples, which automatically makes them linger if there's an open read view. We use the same global tuple format for allocating functional keys, because the key format is checked in `key_list_iterator_next`.

Closes #7376