### PR TITLE
test: fix cleanup in `vinyl-luatest/gh_6565_hot_standby_unsupported` test

### DIFF
--- a/test/vinyl-luatest/gh_6565_hot_standby_unsupported_test.lua
+++ b/test/vinyl-luatest/gh_6565_hot_standby_unsupported_test.lua
@@ -17,6 +17,10 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
+    -- The replica should fail to initialize and exit by itself, but let's
+    -- still try to kill it to prevent it from lingering until the next test,
+    -- because the next test may try to connect to the same URI.
+    pcall(cg.replica.stop, cg.replica)
     cg.master:drop()
 end)
 


### PR DESCRIPTION
The `gh_6565` test doesn't stop the hot standby replica it started, because the replica should fail to initialize and exit eventually
anyway. However, if the replica lingers until the next test due to https://github.com/tarantool/test-run/issues/345, the next test may successfully connect to it, which is likely to lead to a failure, because UNIX socket paths used by luatest servers are not randomized.

For example, here `gh_6568` test fails after `gh_6565`, because it uses the same alias for the test instance ('replica'):

```
[008] vinyl-luatest/gh_6565_hot_standby_unsupported_>                 [ pass ]
[008] vinyl-luatest/gh_6568_replica_initial_join_rem>                 [ fail ]
[008] Test failed! Output from reject file /tmp/t/rejects/vinyl-luatest/gh_6568_replica_initial_join_removal_of_compacted_run_files.reject:
[008] TAP version 13
[008] 1..1
[008] # Started on Fri Jul  8 15:30:47 2022
[008] # Starting group: gh-6568-replica-initial-join-removal-of-compacted-run-files
[008] not ok 1  gh-6568-replica-initial-join-removal-of-compacted-run-files.test_replication_compaction_cleanup
[008] #   builtin/fio.lua:242: fio.pathjoin(): undefined path part 1
[008] #   stack traceback:
[008] #         builtin/fio.lua:242: in function 'pathjoin'
[008] #         ...ica_initial_join_removal_of_compacted_run_files_test.lua:43: in function 'gh-6568-replica-initial-join-removal-of-compacted-run-files.test_replication_compaction_cleanup'
[008] #         ...
[008] #         [C]: in function 'xpcall'
[008] replica | 2022-07-08 15:30:48.311 [832856] main/103/default.lua F> can't initialize storage: unlink, called on fd 30, aka unix/:(socket), peer of unix/:(socket): Address already in use
[008] # Ran 1 tests in 0.722 seconds, 0 succeeded, 1 errored
```

Let's fix this by explicitly killing the hot standby replica. Since it could have exited voluntarily, we need to use `pcall`, because server.stop fails if the instance is already dead.

This issue is similar to the one fixed by #7359.