### PR TITLE
http client: return back CA certificates search

### DIFF
--- a/changelogs/unreleased/add-https-certificate-validation-back.md
+++ b/changelogs/unreleased/add-https-certificate-validation-back.md
@@ -1,0 +1,6 @@
+## bugfix/http client
+
+* Enable runtime autodetection of system CA certificates back (gh-7372).
+
+  Otherwise HTTPS can't be used without `verify_peer = false` option. It is the
+  regression from 2.10.0.

--- a/cmake/BuildLibCURL.cmake
+++ b/cmake/BuildLibCURL.cmake
@@ -89,7 +89,13 @@ macro(curl_build)
     list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_DISABLE_GOPHER=ON")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_DISABLE_CRYPTO_AUTH=ON")
 
-    # Switch on ca-fallback feature.
+    # Don't attempt to find system CA bundle/certificates at
+    # libcurl configuration step (build time). Fallback to
+    # OpenSSL's SSL_CTX_set_default_verify_paths() instead and
+    # configure the default paths in runtime (see
+    # tnt_ssl_cert_paths_discover()).
+    list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_CA_BUNDLE=none")
+    list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_CA_PATH=none")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_CA_FALLBACK=ON")
 
     # Even though we set the external project's install dir
@@ -123,11 +129,6 @@ macro(curl_build)
     list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_USE_MBEDTLS=OFF")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_USE_WOLFSSL=OFF")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_USE_NSS=OFF")
-    list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_CA_BUNDLE=none")
-    list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_CA_BUNDLE_SET=ON")
-    list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_CA_PATH=none")
-    list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_CA_PATH_SET=ON")
-    list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_CA_FALLBACK=OFF")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DUSE_LIBRTMP=OFF")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DHAVE_LIBIDN2=OFF")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DUSE_LIBIDN2=ON")


### PR DESCRIPTION
Without CA certificates the HTTP client will unable to verify server's
certificate, so the only way to perform an HTTPS request would be use
the `verify_peer = false` option -- disable certificate validation at
all.

The runtime search of system CA bundle/certificates was unintentionally
disabled in 2.10.0 (PR #7119). The patch enabled is back.

The main motivation behind the runtime search is difference in paths on
different systems. Since we ship Tarantool Enterprise Edition as
executable with ability to run on different Linux distributions, we
can't choose one particular path at build time. See details in #5746.

The `CURL_CA_BUNDLE_SET` and `CURL_CA_PATH_SET` options were removed,
because they are not 'real' curl configuration options, but rather
cached values to don't repeat file/directory search at re-configuration.
It looks as internal logic of Curl's CMake script.

Fixes #7372
Supersedes PR #7373