### PR TITLE
sql: introduce OpenSpace opcode

### DIFF
--- a/changelogs/unreleased/gh-7358-prepared-stmt-truncation.md
+++ b/changelogs/unreleased/gh-7358-prepared-stmt-truncation.md
@@ -1,0 +1,3 @@
+## bugfix/sql
+
+* Truncation of a space no longer corrupt prepared statements (gh-7358).

--- a/src/box/sql/alter.c
+++ b/src/box/sql/alter.c
@@ -129,8 +129,10 @@ sql_alter_ck_constraint_enable(struct Parse *parse)
 		      tuple_reg + field_count - 1);
 	sqlVdbeAddOp3(v, OP_MakeRecord, tuple_reg, field_count,
 		      tuple_reg + field_count);
-	sqlVdbeAddOp4(v, OP_IdxReplace, tuple_reg + field_count, 0, 0,
-		      (char *)ck_space, P4_SPACEPTR);
+
+	int reg = ++parse->nMem;
+	sqlVdbeAddOp2(v, OP_OpenSpace, reg, BOX_CK_CONSTRAINT_ID);
+	sqlVdbeAddOp2(v, OP_IdxReplace, tuple_reg + field_count, reg);
 exit_alter_ck_constraint:
 	sqlDbFree(db, constraint_name);
 	sqlSrcListDelete(db, src_tab);

--- a/src/box/sql/delete.c
+++ b/src/box/sql/delete.c
@@ -356,8 +356,9 @@ sql_table_delete_from(struct Parse *parse, struct SrcList *tab_list,
 			int iAddrOnce = 0;
 			if (one_pass == ONEPASS_MULTI)
 				iAddrOnce = sqlVdbeAddOp0(v, OP_Once);
-			sqlVdbeAddOp4(v, OP_IteratorOpen, tab_cursor, 0, 0,
-					  (void *) space, P4_SPACEPTR);
+			int reg = ++parse->nMem;
+			sqlVdbeAddOp2(v, OP_OpenSpace, reg, space->def->id);
+			sqlVdbeAddOp3(v, OP_IteratorOpen, tab_cursor, 0, reg);
 			VdbeComment((v, "%s", space->index[0]->def->name));
 
 			if (one_pass == ONEPASS_MULTI)

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -3197,16 +3197,15 @@ void
 vdbe_emit_ck_constraint(struct Parse *parser, struct Expr *expr,
 			const char *name, const char *expr_str,
 			int vdbe_field_ref_reg);
+
 /**
- * This routine generates code to finish the INSERT or UPDATE
- * operation that was started by a prior call to
- * vdbe_emit_constraint_checks. It encodes raw data which is held
- * in a range of registers starting from @raw_data_reg and length
- * of @tuple_len and inserts this record to space using given
- * @cursor_id.
+ * This routine generates code to finish the INSERT or UPDATE operation that was
+ * started by a prior call to vdbe_emit_constraint_checks(). It encodes raw data
+ * which is held in a range of registers starting from raw_data_reg and length
+ * of tuple_len and inserts this record to space defined by space_id.
  *
  * @param v Virtual database engine.
- * @param space Pointer to space object.
+ * @param space_reg A register containing a pointer of the space.
  * @param raw_data_reg Register with raw data to insert.
  * @param tuple_len Number of registers to hold the tuple.
  * @param on_conflict On conflict action.
@@ -3215,7 +3214,7 @@ vdbe_emit_ck_constraint(struct Parse *parser, struct Expr *expr,
  *                    into the field with AUTOINCREMENT.
  */
 void
-vdbe_emit_insertion_completion(struct Vdbe *v, struct space *space,
+vdbe_emit_insertion_completion(struct Vdbe *v, int space_reg,
 			       int raw_data_reg, uint32_t tuple_len,
 			       enum on_conflict_action on_conflict,
 			       int autoinc_reg);

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -2270,17 +2270,6 @@ case OP_TTransaction: {
 	break;
 }
 
-/* Opcode: IteratorReopen P1 P2 P3 P4 P5
- * Synopsis: index id = P2, space ptr = P4
- *
- * The IteratorReopen opcode works exactly like IteratorOpen except
- * that it first checks to see if the cursor on P1 is already open
- * with the same index and if it is this opcode becomes a no-op.
- * In other words, if the cursor is already open, do not reopen
- * it.
- *
- * The IteratorReopen opcode may only be used with P5 == 0.
- */
 /* Opcode: IteratorOpen P1 P2 P3 P4 P5
  * Synopsis: index id = P2, space ptr = P4 or reg[P3]
  *
@@ -2291,16 +2280,8 @@ case OP_TTransaction: {
  * If P4 was not set, then P3 supposed to be the register
  * containing space pointer.
  */
-case OP_IteratorReopen: {
-	assert(pOp->p5 == 0);
+case OP_IteratorOpen: {
 	struct VdbeCursor *cur = p->apCsr[pOp->p1];
-	if (cur != NULL && cur->uc.pCursor->space == pOp->p4.space &&
-	    cur->uc.pCursor->index->def->iid == (uint32_t)pOp->p2)
-		goto open_cursor_set_hints;
-	/* If the cursor is not currently open or is open on a different
-	 * index, then fall through into OP_OpenCursor to force a reopen
-	 */
-case OP_IteratorOpen:
 	if (box_schema_version() != p->schema_ver &&
 	    (pOp->p5 & OPFLAG_SYSTEMSP) == 0) {
 		p->expired = 1;
@@ -2336,7 +2317,6 @@ case OP_IteratorOpen:
 	/* Key info still contains sorter order and collation. */
 	cur->key_def = index->def->key_def;
 	cur->nullRow = 1;
-open_cursor_set_hints:
 	cur->uc.pCursor->hints = pOp->p5 & OPFLAG_SEEKEQ;
 	break;
 }

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -2270,15 +2270,13 @@ case OP_TTransaction: {
 	break;
 }
 
-/* Opcode: IteratorOpen P1 P2 P3 P4 P5
- * Synopsis: index id = P2, space ptr = P4 or reg[P3]
+/* Opcode: IteratorOpen P1 P2 P3 * P5
+ * Synopsis: index id = P2, space ptr = reg[P3]
  *
- * Open a cursor for a space specified by pointer in P4 and index
- * id in P2. Give the new cursor an identifier of P1. The P1
- * values need not be contiguous but all P1 values should be
- * small integers. It is an error for P1 to be negative.
- * If P4 was not set, then P3 supposed to be the register
- * containing space pointer.
+ * Open a cursor for a space specified by pointer in  the register P3 and index
+ * id in P2. Give the new cursor an identifier of P1. The P1 values need not be
+ * contiguous but all P1 values should be small integers. It is an error for P1
+ * to be negative.
  */
 case OP_IteratorOpen: {
 	struct VdbeCursor *cur = p->apCsr[pOp->p1];
@@ -2289,11 +2287,7 @@ case OP_IteratorOpen: {
 			 "changed: need to re-compile SQL statement");
 		goto abort_due_to_error;
 	}
-	struct space *space;
-	if (pOp->p4type == P4_SPACEPTR)
-		space = pOp->p4.space;
-	else
-		space = aMem[pOp->p3].u.p;
+	struct space *space = aMem[pOp->p3].u.p;
 	assert(space != NULL);
 	if (access_check_space(space, PRIV_R) != 0)
 		goto abort_due_to_error;
@@ -2318,6 +2312,21 @@ case OP_IteratorOpen: {
 	cur->key_def = index->def->key_def;
 	cur->nullRow = 1;
 	cur->uc.pCursor->hints = pOp->p5 & OPFLAG_SEEKEQ;
+	break;
+}
+
+/**
+ * Opcode: OP_OpenSpace P1 P2 * * *
+ * Synopsis: reg[P1] = space_by_id(P2)
+ *
+ * Open the space using its ID stored in register P2 and write a pointer to the
+ * space to register P1.
+ */
+case OP_OpenSpace: {
+	assert(pOp->p1 >= 0 && pOp->p1 > 0);
+	struct space *space = space_by_id(pOp->p2);
+	assert(space != NULL);
+	mem_set_ptr(&aMem[pOp->p1], space);
 	break;
 }
 
@@ -3349,25 +3358,23 @@ case OP_SorterInsert: {      /* in2 */
 	break;
 }
 
-/* Opcode: IdxInsert P1 P2 P3 P4 P5
+/* Opcode: IdxInsert P1 P2 P3 * P5
  * Synopsis: key=r[P1]
  *
  * @param P1 Index of a register with MessagePack data to insert.
- * @param P2 If P4 is not set, then P2 is register containing pointer
- *           to space to insert into.
+ * @param P2 Register containing pointer to space to insert into.
  * @param P3 If not 0, than it is an index of a register that
  *           contains value that will be inserted into field with
  *           AUTOINCREMENT. If the value is NULL, than the newly
  *           generated autoincrement value will be saved to VDBE
  *           context.
- * @param P4 Pointer to the struct space to insert to.
  * @param P5 Flags. If P5 contains OPFLAG_NCHANGE, then VDBE
  *        accounts the change in a case of successful insertion in
  *        nChange counter. If P5 contains OPFLAG_OE_IGNORE, then
  *        we are processing INSERT OR INGORE statement. Thus, in
  *        case of conflict we don't raise an error.
  */
-/* Opcode: IdxReplace2 P1 * * P4 P5
+/* Opcode: IdxReplace P1 P2 P3 * P5
  * Synopsis: key=r[P1]
  *
  * This opcode works exactly as IdxInsert does, but in Tarantool
@@ -3377,11 +3384,7 @@ case OP_IdxReplace:
 case OP_IdxInsert: {
 	pIn2 = &aMem[pOp->p1];
 	assert(mem_is_bin(pIn2));
-	struct space *space;
-	if (pOp->p4type == P4_SPACEPTR)
-		space = pOp->p4.space;
-	else
-		space = aMem[pOp->p2].u.p;
+	struct space *space = aMem[pOp->p2].u.p;
 	assert(space != NULL);
 	if (space->def->id != 0) {
 		/* Make sure that memory has been allocated on region. */
@@ -3448,7 +3451,7 @@ case OP_IdxInsert: {
  *           It's items are numbers of fields to be replaced with
  *           new values from P1. They must be sorted in ascending
  *           order.
- * @param P4 Pointer to the struct space to be updated.
+ * @param P4 Register containing pointer to space to update.
  * @param P5 Flags. If P5 contains OPFLAG_NCHANGE, then VDBE
  *           accounts the change in a case of successful
  *           insertion in nChange counter. If P5 contains
@@ -3461,8 +3464,8 @@ case OP_Update: {
 	if (pOp->p5 & OPFLAG_NCHANGE)
 		p->nChange++;
 
-	struct space *space = pOp->p4.space;
-	assert(pOp->p4type == P4_SPACEPTR);
+	struct space *space = aMem[pOp->p4.i].u.p;
+	assert(pOp->p4type == P4_INT32);
 
 	struct Mem *key_mem = &aMem[pOp->p2];
 	assert(mem_is_bin(key_mem));

--- a/src/box/sql/vdbe.h
+++ b/src/box/sql/vdbe.h
@@ -86,8 +86,6 @@ struct VdbeOp {
 		int (*xAdvance) (BtCursor *, int *);
 		/** Used when p4type is P4_KEYINFO. */
 		struct sql_key_info *key_info;
-		/** Used when p4type is P4_SPACEPTR. */
-		struct space *space;
 		/**
 		 * Used to apply types when making a record, or
 		 * doing a cast.
@@ -142,7 +140,6 @@ struct SubProgram {
 #define P4_BOOL     (-17)	/* P4 is a bool value */
 #define P4_PTR      (-18)	/* P4 is a generic pointer */
 #define P4_KEYINFO  (-19)       /* P4 is a pointer to sql_key_info structure. */
-#define P4_SPACEPTR (-20)       /* P4 is a space pointer */
 
 /* Error message codes for OP_Halt */
 #define P5_ConstraintNotNull 1

--- a/src/box/sql/vdbeaux.c
+++ b/src/box/sql/vdbeaux.c
@@ -1093,10 +1093,6 @@ displayP4(Op * pOp, char *zTemp, int nTemp)
 			zTemp[0] = 0;
 			break;
 		}
-	case P4_SPACEPTR: {
-		sqlXPrintf(&x, "space<name=%s>", space_name(pOp->p4.space));
-		break;
-	}
 	default:{
 			zP4 = pOp->p4.z;
 			if (zP4 == 0) {

--- a/src/box/sql/where.c
+++ b/src/box/sql/where.c
@@ -4625,7 +4625,7 @@ sqlWhereBegin(Parse * pParse,	/* The parser context */
 			} else if (iAuxArg
 				   && (wctrlFlags & WHERE_OR_SUBCLAUSE) != 0) {
 				iIndexCur = iAuxArg;
-				op = OP_IteratorReopen;
+				assert(op == OP_IteratorOpen);
 			} else {
 				iIndexCur = pParse->nTab++;
 			}

--- a/test/sql-luatest/gh_7358_prepared_stmt_truncation_test.lua
+++ b/test/sql-luatest/gh_7358_prepared_stmt_truncation_test.lua
@@ -1,0 +1,37 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'test_prepared_stmt_truncation'})
+    g.server:start()
+    g.server:exec(function()
+        box.execute([[CREATE TABLE t(i INT PRIMARY KEY);]])
+        box.execute([[INSERT INTO t VALUES(1);]])
+    end)
+end)
+
+g.after_all(function()
+    g.server:exec(function()
+        box.execute([[DROP TABLE t;]])
+    end)
+    g.server:stop()
+end)
+
+g.test_prepared_stmt_truncation_1 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local stmt = box.prepare([[SELECT * FROM t;]])
+        box.execute([[TRUNCATE TABLE t;]])
+        t.assert_equals(box.execute(stmt.stmt_id).rows, {})
+    end)
+end
+
+g.test_prepared_stmt_truncation_2 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local stmt = box.prepare([[INSERT INTO t VALUES(?);]])
+        box.execute([[TRUNCATE TABLE t;]])
+        t.assert_equals(box.execute(stmt.stmt_id, {1}), {row_count = 1})
+    end)
+end


### PR DESCRIPTION
Prior to this patch, some opcodes could use a pointer to struct space that was set during parsing. However, the pointer to struct space is not really something that defines spaces. A space can be identified by its ID or name. In most cases, specifying space by pointer works fine, but truncate() changes the pointer to space, resulting in a sigfault for prepared statements using the above opcodes. To avoid this problem, a new opcode has been introduced. This opcode uses the space ID to determine the pointer to the struct space at runtime and stores it in the MEM, which is later used in the mentioned opcodes.

Closes https://github.com/tarantool/tarantool/issues/7358