### PR TITLE
console flavours vs txn

### DIFF
--- a/changelogs/unreleased/gh-7288-txn-and-eval-error.md
+++ b/changelogs/unreleased/gh-7288-txn-and-eval-error.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed expression evaluation error overwritten by "Transaction is active at
+  return from function" error in case expression begins a transaction (gh-7288).

--- a/changelogs/unreleased/gh-7413-use-streams-in-binary-console.md
+++ b/changelogs/unreleased/gh-7413-use-streams-in-binary-console.md
@@ -1,0 +1,3 @@
+## feature/core
+
+* Supported interactive transactions for remote binary console (gh-7413).

--- a/src/box/lua/console.lua
+++ b/src/box/lua/console.lua
@@ -634,10 +634,6 @@ end
 -- Print result to stdout
 --
 local function local_print(self, output)
-    if output == nil then
-        self.running = nil
-        return
-    end
     print(output)
 end
 
@@ -669,14 +665,6 @@ end
 -- Print result to connected client from console.listen()
 --
 local function client_print(self, output)
-    if not self.client then
-        return
-    elseif not output then
-        -- disconnect peer
-        self.client = nil -- socket will be closed by tcp_server() function
-        self.running = nil
-        return
-    end
     self.client:write(output)
 end
 
@@ -708,8 +696,10 @@ local function repl(self)
     while self.running do
         local command = self:read()
         local output = self:eval(command)
+        if output == nil then break end
         self:print(output)
     end
+    self.running = false
     fiber.self().storage.console = nil
 end
 

--- a/src/box/lua/console.lua
+++ b/src/box/lua/console.lua
@@ -374,6 +374,13 @@ local function get_command(line)
 end
 
 --
+-- return args as table with 'n' set to args number
+--
+local function table_pack(...)
+    return {n = select('#', ...), ...}
+end
+
+--
 -- Evaluate command on local instance
 --
 local function local_eval(storage, line)
@@ -401,7 +408,22 @@ local function local_eval(storage, line)
     if not fun then
         return format(false, errmsg)
     end
-    return format(pcall(fun))
+    -- box.is_in_txn() is stubbed to throw a error before call to box.cfg{}
+    local in_txn_before = ffi.C.box_txn()
+    local res = table_pack(pcall(fun))
+    --
+    -- Rollback if transaction was began in the failed expression.
+    --
+    -- In case of remote binary console if eval leaves an active transaction
+    -- then later a error is thrown overwriting error thrown by eval thus the
+    -- rollback. Also the check if we were already in transaction allows for
+    -- local and remote text console to preserve interactive transactions.
+    --
+    if not res[1] and not in_txn_before and ffi.C.box_txn() then
+        box.rollback()
+    end
+    -- specify length to preserve trailing nils
+    return format(unpack(res, 1, res.n))
 end
 
 local function eval(line)

--- a/test/app-luatest/gh_7288_console_flavours_vs_txn_test.lua
+++ b/test/app-luatest/gh_7288_console_flavours_vs_txn_test.lua
@@ -1,0 +1,184 @@
+local server = require('test.luatest_helpers.server')
+local console = require('console')
+local fiber = require('fiber')
+local fio = require('fio')
+local string = require('string')
+local t = require('luatest')
+
+local function configure_box()
+    local workdir = fio.pathjoin(server.vardir, 'gh-7288')
+    fio.rmtree(workdir)
+    fio.mkdir(workdir)
+    box.cfg{
+        memtx_use_mvcc_engine = true,
+        work_dir = workdir,
+        log = fio.pathjoin(workdir, 'self.log'),
+    }
+end
+
+local remote_mt = {
+    start = function(self)
+        local server = server:new{
+            alias = 'default',
+            box_cfg = {memtx_use_mvcc_engine = true},
+        }
+        server:start()
+        if not self.bin then
+            self.uri = fio.pathjoin(server.vardir, 'gh-7288.sock')
+            server:eval(string.format('require("console").listen("%s")', self.uri))
+        else
+            self.uri = server.net_box_uri
+        end
+        self.server = server
+    end,
+
+    stop = function(self)
+        self.server:stop()
+        self.server = nil
+        self.uri = nil
+    end,
+
+    connect = function(self, console)
+        console:send(string.format('require("console").connect("%s")', self.uri))
+    end,
+
+    disconnect = true,
+}
+
+local flavours = {
+    alocal = {},
+    remote_txt = setmetatable({bin = false}, {__index = remote_mt}),
+    remote_bin = setmetatable({bin = true}, {__index = remote_mt}),
+}
+
+local g = t.group('gh-7288', {
+    {name = 'alocal'},
+    {name = 'remote_txt'},
+    {name = 'remote_bin'},
+})
+
+
+--
+-- Mock read/print methods to run a console. Without running console we can't
+-- call console.connect to test remote consoles.
+--
+local TestConsole = {}
+
+TestConsole.new = function(self, flavour)
+    local o = { flavour = flavour }
+    setmetatable(o, self)
+    return o
+end
+
+TestConsole.__index = {}
+TestConsole.__index.start = function(self)
+    if self.flavour.start then
+        self.flavour:start()
+    end
+end
+
+TestConsole.__index.stop = function(self)
+    if self.flavour.stop then
+        self.flavour:stop()
+    end
+end
+
+TestConsole.__index.connect = function(self)
+    self.ich = fiber.channel(10)
+    self.och = fiber.channel(10)
+    local on_start = fiber.channel()
+    console.on_start(function(console)
+        console.read = function(_)
+            return self.ich:get()
+        end
+        console.print = function(_, output)
+            self.och:put(output)
+        end
+        on_start:put(true)
+    end)
+    fiber.create(function()
+        console.start()
+        -- write console fiber exit message
+        self.och:put(true)
+    end)
+    assert(on_start:get(3))
+    if self.flavour.connect then
+        self.flavour:connect(self)
+    end
+end
+
+TestConsole.__index.send = function(self, input)
+    self.ich:put(input)
+    return assert(self.och:get(3))
+end
+
+TestConsole.__index.disconnect = function(self)
+    if self.flavour.disconnect then
+        self:send(nil)
+    end
+    self.ich:close()
+    -- read console fiber exit message
+    assert(self.och:get(3))
+    self.och:close()
+    self.ich = nil
+    self.och = nil
+    console.on_start(nil)
+end
+
+configure_box()
+
+g.before_all(function(cg)
+    cg.console = TestConsole:new(flavours[cg.params.name])
+    cg.console:start()
+end)
+
+g.after_all(function(cg)
+    cg.console:stop()
+    cg.console = nil
+end)
+
+g.before_each(function(cg)
+    cg.console:connect()
+end)
+
+g.after_each(function(cg)
+    cg.console:disconnect()
+end)
+
+local true_output = [[
+---
+- true
+...
+]]
+
+local false_output = [[
+---
+- false
+...
+]]
+
+g.test_begin_in_expr_without_error = function(cg)
+    t.xfail_if(cg.params.name == "remote_bin")
+    local console = cg.console
+    console:send('box.begin()')
+    t.assert_equals(console:send('box.is_in_txn()'), true_output)
+end
+
+g.test_begin_in_expr_with_error = function(cg)
+    local console = cg.console
+    local expected = [[
+---
+- error: '[string "box.begin() error("test error")"]:1: test error'
+...
+]]
+    t.assert_equals(console:send('box.begin() error("test error")'), expected)
+    t.assert_equals(console:send('box.is_in_txn()'), false_output)
+end
+
+g.test_error_in_different_expr = function(cg)
+    t.xfail_if(cg.params.name == "remote_bin")
+    local console = cg.console
+    console:send('box.begin()')
+    console:send('error("test error")')
+    t.assert_equals(console:send('box.is_in_txn()'), true_output)
+end

--- a/test/box/transaction.result
+++ b/test/box/transaction.result
@@ -593,34 +593,20 @@ box.commit();
 ...
 -- DDL and select from a vinyl space. Multi-engine transaction
 -- is not allowed.
--- A transaction is left open due to an exception in the Lua fragment
 box.begin()
 box.space.test:truncate()
-box.space.vinyl:select{}
-
-box.rollback();
+box.space.vinyl:select{};
 ---
 - error: A multi-statement transaction can not use multiple storage engines
 ...
--- DDL as a second statement - doesn't work
-box.begin()
-box.space.memtx:insert{2, 'truncate'}
-box.space.test:truncate();
----
-- error: 'Operation is not permitted when there is an active transaction '
-...
 -- A transaction is left open due to an exception in the Lua fragment
 box.rollback();
 ---
 ...
-box.space.memtx:select{};
----
-- - [1, 'memtx']
-...
--- DML as a second statement - works if the engine is the same
+-- DDL as a second statement - works if the egine is the same
 box.begin()
-box.space.test:truncate()
 box.space.memtx:insert{2, 'truncate'}
+box.space.test:truncate()
 box.commit();
 ---
 ...
@@ -630,6 +616,19 @@ box.space.memtx:select{};
   - [2, 'truncate']
 ...
 -- DML as a second statement - works if the engine is the same
+box.begin()
+box.space.test:truncate()
+box.space.memtx:insert{3, 'truncate'}
+box.commit();
+---
+...
+box.space.memtx:select{};
+---
+- - [1, 'memtx']
+  - [2, 'truncate']
+  - [3, 'truncate']
+...
+-- DML as a second statement. Multi-engine transaction is not allowed.
 box.begin()
 box.space.test:truncate()
 box.space.vinyl:insert{2, 'truncate'};
@@ -662,6 +661,7 @@ box.space.memtx:select{};
 ---
 - - [1, 'memtx']
   - [2, 'truncate']
+  - [3, 'truncate']
 ...
 box.space.vinyl:select{};
 ---

--- a/test/box/transaction.test.lua
+++ b/test/box/transaction.test.lua
@@ -301,30 +301,28 @@ box.commit();
 -- is not allowed.
 box.begin()
 box.space.test:truncate()
-box.space.vinyl:select{}
+box.space.vinyl:select{};
 
 -- A transaction is left open due to an exception in the Lua fragment
 box.rollback();
 
--- DDL as a second statement - doesn't work
+-- DDL as a second statement - works if the egine is the same
 box.begin()
 box.space.memtx:insert{2, 'truncate'}
-box.space.test:truncate();
-
--- A transaction is left open due to an exception in the Lua fragment
-box.rollback();
+box.space.test:truncate()
+box.commit();
 
 box.space.memtx:select{};
 
 -- DML as a second statement - works if the engine is the same
 box.begin()
 box.space.test:truncate()
-box.space.memtx:insert{2, 'truncate'}
+box.space.memtx:insert{3, 'truncate'}
 box.commit();
 
 box.space.memtx:select{};
 
--- DML as a second statement - works if the engine is the same
+-- DML as a second statement. Multi-engine transaction is not allowed.
 box.begin()
 box.space.test:truncate()
 box.space.vinyl:insert{2, 'truncate'};

--- a/test/luatest_helpers/server.lua
+++ b/test/luatest_helpers/server.lua
@@ -40,10 +40,10 @@ Server.constructor_checks = fun.chain(Server.constructor_checks, {
     engine = '?string',
 }):tomap()
 
-Server.socketdir = fio.abspath(os.getenv('VARDIR') or '/tmp/t')
+Server.vardir = fio.abspath(os.getenv('VARDIR') or '/tmp/t')
 
 function Server.build_instance_uri(alias)
-    return ('%s/%s.iproto'):format(Server.socketdir, alias)
+    return ('%s/%s.iproto'):format(Server.vardir, alias)
 end
 
 function Server:initialize()
@@ -55,7 +55,7 @@ function Server:initialize()
         self.command = 'test/instances/default.lua'
     end
     if self.workdir == nil then
-        self.workdir = ('%s/%s-%s'):format(self.socketdir, self.alias, self.id)
+        self.workdir = ('%s/%s-%s'):format(self.vardir, self.alias, self.id)
         fio.rmtree(self.workdir)
         fio.mktree(self.workdir)
     end
@@ -68,7 +68,7 @@ function Server:initialize()
     end
     if self.net_box_port == nil and self.net_box_uri == nil then
         self.net_box_uri = self.build_instance_uri(self.alias)
-        fio.mktree(self.socketdir)
+        fio.mktree(self.vardir)
     end
 
     -- AFAIU, the inner getmetatable() returns our helpers.Server

--- a/test/luatest_helpers/server.lua
+++ b/test/luatest_helpers/server.lua
@@ -20,6 +20,8 @@ local Server = luatest.Server:inherit({})
 
 local WAIT_TIMEOUT = 60
 local WAIT_DELAY = 0.1
+local SOURCE_DIR = fio.abspath(os.getenv('SOURCEDIR') or '.')
+local DEFAULT_COMMAND = fio.pathjoin(SOURCE_DIR, 'test/instances/default.lua')
 
 -- Differences from luatest.Server:
 --
@@ -52,7 +54,7 @@ function Server:initialize()
         self.id = digest.base64_encode(random, {urlsafe = true})
     end
     if self.command == nil then
-        self.command = 'test/instances/default.lua'
+        self.command = DEFAULT_COMMAND
     end
     if self.workdir == nil then
         self.workdir = ('%s/%s-%s'):format(self.vardir, self.alias, self.id)

--- a/test/replication-luatest/gh_4669_applier_reconnect_test.lua
+++ b/test/replication-luatest/gh_4669_applier_reconnect_test.lua
@@ -35,7 +35,7 @@ g.test_applier_connection_on_reconfig = function(g)
                 box.cfg.replication[1],
                 "%s/replica2.iproto",
             }
-        }]]):format(server.socketdir))
+        }]]):format(server.vardir))
     g.replica:eval([[
         box.cfg{
             replication = {


### PR DESCRIPTION
The issue is if in binary remote console a error is thrown in expression like "box.begin() error('something') box.commit()" then it is overwritten by iproto check for active transactions at the end of eval. The solution is to rollback active transaction in this case in console code before iproto check.

Closes #7288
Closes #7413