### PR TITLE
build: satisfy -Wunused-but-set-variable check

### DIFF
--- a/src/box/tuple_update.c
+++ b/src/box/tuple_update.c
@@ -902,7 +902,7 @@ update_write_tuple(struct tuple_update *update, char *buffer, char *buffer_end)
 		}
 		total_field_count += field_count;
 	}
-
+	(void)total_field_count;
 	assert(rope_size(update->rope) == total_field_count);
 	assert(new_data <= buffer_end);
 	return new_data - buffer; /* real_tuple_size */


### PR DESCRIPTION
Newer compilers have -Wunused-but-set-variable check enabled by default:
our codebase requires necessary fixes to satisfy it.

Follow up adf8779e, 760319ea, 678e47ee.

Closes #7386

NO_CHANGELOG=build
NO_DOC=build
NO_TEST=build