### PR TITLE
memtx: fix handling of corner cases gap tracking in transaction manager

### DIFF
--- a/changelogs/unreleased/gh-7375-fix-gap-tracking-corner-cases.md
+++ b/changelogs/unreleased/gh-7375-fix-gap-tracking-corner-cases.md
@@ -1,0 +1,4 @@
+## bugfix/memtx
+
+* Fixed incorrect handling of corner cases gap tracking in transaction
+  manager (gh-7375).

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -588,9 +588,6 @@ tree_iterator_set_next_method(struct tree_iterator<USE_HINT> *it)
 	case ITER_REQ:
 		it->base.next_raw = tree_iterator_prev_equal_raw<USE_HINT>;
 		break;
-	case ITER_ALL:
-		it->base.next_raw = tree_iterator_next_raw<USE_HINT>;
-		break;
 	case ITER_LT:
 	case ITER_LE:
 		it->base.next_raw = tree_iterator_prev_raw<USE_HINT>;
@@ -647,8 +644,7 @@ tree_iterator_start_raw(struct iterator *iterator, struct tuple **ret)
 		 * efficiently equals to the empty key. */
 		equals = memtx_tree_size(tree) != 0;
 	} else {
-		if (type == ITER_ALL || type == ITER_EQ ||
-		    type == ITER_GE || type == ITER_LT) {
+		if (type == ITER_EQ || type == ITER_GE || type == ITER_LT) {
 			it->tree_iterator =
 				memtx_tree_lower_bound(tree, &it->key_data,
 						       &equals);
@@ -701,8 +697,8 @@ tree_iterator_start_raw(struct iterator *iterator, struct tuple **ret)
 	if (key_is_full && !eq_match)
 		memtx_tx_track_point(txn, space, idx, it->key_data.key);
 	if (!key_is_full ||
-	    ((type == ITER_ALL || type == ITER_GE || type == ITER_LE) &&
-	     !equals) || (type == ITER_GT || type == ITER_LT))
+	    ((type == ITER_GE || type == ITER_LE) && !equals) ||
+	    (type == ITER_GT || type == ITER_LT))
 /********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND START*********/
 		memtx_tx_track_gap(txn, space, idx, successor, type,
 				   it->key_data.key, it->key_data.part_count);
@@ -1399,6 +1395,9 @@ memtx_tree_index_create_iterator(struct index *base, enum iterator_type type,
 		type = iterator_type_is_reverse(type) ? ITER_LE : ITER_GE;
 		key = NULL;
 	}
+
+	if (type == ITER_ALL)
+		type = ITER_GE;
 
 	struct tree_iterator<USE_HINT> *it = (struct tree_iterator<USE_HINT> *)
 		mempool_alloc(&memtx->iterator_pool);

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1748,47 +1748,36 @@ memtx_tx_handle_gap_write(struct txn *txn, struct space *space,
 	uint64_t index_mask = 1ull << (ind & 63);
 	struct gap_item *item, *tmp;
 	rlist_foreach_entry_safe(item, list, in_nearby_gaps, tmp) {
-		bool is_split = false;
-		if (item->key == NULL) {
-			if (memtx_tx_track_read_story(item->txn, space, story,
-						      index_mask) != 0)
-				return -1;
-			is_split = true;
-		} else {
+		int cmp = 0;
+		if (item->key != NULL) {
 			struct key_def *def = index->def->key_def;
-			hint_t oh = def->key_hint(item->key, item->part_count, def);
+			hint_t oh =
+				def->key_hint(item->key, item->part_count, def);
 			hint_t kh = def->tuple_hint(tuple, def);
-			int cmp = def->tuple_compare_with_key(tuple, kh,
-							      item->key,
-							      item->part_count,
-							      oh, def);
-			int dir = iterator_direction(item->type);
-			if (cmp == 0 && (item->type == ITER_EQ ||
-					 item->type == ITER_REQ ||
-					 item->type == ITER_GE ||
-					 item->type == ITER_LE)) {
-				if (memtx_tx_track_read_story(item->txn, space,
-							      story,
-							      index_mask) != 0)
-					return -1;
-			}
-			if (cmp * dir > 0 &&
-			    item->type != ITER_EQ && item->type != ITER_REQ) {
-				if (memtx_tx_track_read_story(item->txn, space,
-							      story,
-							      index_mask) != 0)
-					return -1;
-				is_split = true;
-			}
-			if (cmp > 0 && dir < 0) {
-				/* The tracker must be moved to the left gap. */
-				rlist_del(&item->in_nearby_gaps);
-				rlist_add(&story->link[ind].nearby_gaps,
-					  &item->in_nearby_gaps);
-			}
+			cmp = def->tuple_compare_with_key(tuple, kh, item->key,
+							  item->part_count, oh,
+							  def);
 		}
-
-		if (is_split) {
+		int dir = iterator_direction(item->type);
+		bool is_full_key = item->part_count ==
+				   index->def->cmp_def->part_count;
+		bool is_eq = item->type == ITER_EQ || item->type == ITER_REQ;
+		bool is_e = item->type == ITER_LE || item->type == ITER_GE;
+		bool need_split = item->key == NULL ||
+				  (dir * cmp > 0 && !is_eq) ||
+				  (!is_full_key && cmp == 0 && (is_e || is_eq));
+		bool need_move = !need_split &&
+				 ((dir < 0 && cmp > 0) ||
+				  (cmp > 0 && item->type == ITER_EQ) ||
+				  (cmp == 0 && ((dir < 0 && is_full_key) ||
+						item->type == ITER_LT)));
+		bool need_track = need_split ||
+				  (is_full_key && cmp == 0 && is_e);
+		if (need_track && memtx_tx_track_read_story(item->txn, space,
+							    story,
+							    index_mask) != 0)
+			return -1;
+		if (need_split) {
 			/*
 			 * The insertion divided the gap into two parts.
 			 * Old tracker is left in one gap, let's copy tracker
@@ -1803,6 +1792,16 @@ memtx_tx_handle_gap_write(struct txn *txn, struct space *space,
 
 			rlist_add(&story->link[ind].nearby_gaps,
 				  &copy->in_nearby_gaps);
+		} else if (need_move) {
+			/* The tracker must be moved to the left gap. */
+			rlist_del(&item->in_nearby_gaps);
+			rlist_add(&story->link[ind].nearby_gaps,
+				  &item->in_nearby_gaps);
+		} else {
+			assert((dir > 0 && cmp < 0) ||
+			       (cmp < 0 && item->type == ITER_REQ) ||
+			       (cmp == 0 && ((dir > 0 && is_full_key) ||
+					     item->type == ITER_GT)));
 		}
 	}
 	return 0;

--- a/test/box-luatest/gh_7375_fix_gap_tracking_corner_cases_test.lua
+++ b/test/box-luatest/gh_7375_fix_gap_tracking_corner_cases_test.lua
@@ -1,0 +1,83 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group(nil, t.helpers.matrix{iter = {'LT', 'LE', 'REQ', 'EQ', 'GE',
+                                                'ALL'}})
+
+g.before_all(function(cg)
+    cg.server = server:new{
+        alias   = 'dflt',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.before_each(function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('s')
+        s:create_index('pk', {parts = {{1, 'uint'}, {2, 'uint'}}})
+    end)
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        box.space.s:drop()
+    end)
+end)
+
+--[[
+Checks that gap tracking correctly handles insertion of a key with the same
+value as the gap item (full key).
+]]
+g.test_gap_tracking_full_key_corner_cases = function(cg)
+    t.skip_if(cg.params.iter == 'REQ' or cg.params.iter == 'EQ')
+
+    local stream1 = cg.server.net_box:new_stream()
+    local stream2 = cg.server.net_box:new_stream()
+
+    stream1:begin()
+    stream2:begin()
+
+    stream1.space.s:select({1, 1}, {iterator = cg.params.iter})
+    stream1.space.s:insert{1, 1}
+
+    stream2.space.s:insert{1, 0}
+    stream2.space.s:insert{1, 2}
+    stream2.space.s:insert{0, 0}
+
+    stream2:commit()
+
+    local conflict_err_msg = 'Transaction has been aborted by conflict'
+    t.assert_error_msg_content_equals(conflict_err_msg, function()
+        stream1:commit()
+    end)
+end
+
+--[[
+Checks that gap tracking correctly handles insertion of a key with the same
+value as the gap item (partial key).
+]]
+g.test_gap_tracking_partial_key_corner_cases = function(cg)
+    local stream1 = cg.server.net_box:new_stream()
+    local stream2 = cg.server.net_box:new_stream()
+
+    stream1:begin()
+    stream2:begin()
+
+    stream1.space.s:select({1}, {iterator = cg.params.iter})
+    stream1.space.s:insert{1, 1}
+
+    stream2.space.s:insert{1, 0}
+    stream2.space.s:insert{0, 0}
+
+    stream2:commit()
+
+    local conflict_err_msg = 'Transaction has been aborted by conflict'
+    t.assert_error_msg_content_equals(conflict_err_msg, function()
+        stream1:commit()
+    end)
+end


### PR DESCRIPTION
Gap tracking does not handle gap writes when the key has the same value as
the gap item: review the whole gap write handling process, refactor it and
fix handling of corner cases along the way.

Closes #7375