### PR TITLE
box: fix finding snapshot in upgrade script

### DIFF
--- a/changelogs/unreleased/gh-7232-upgrade-script-work-dir.md
+++ b/changelogs/unreleased/gh-7232-upgrade-script-work-dir.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed Tarantool not being able to recover from old snapshots when
+  `box.cfg.work_dir` and `box.cfg.memtx_dir` were both set (gh-7232).

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -6,6 +6,7 @@ local private = require('box.internal')
 local urilib = require('uri')
 local math = require('math')
 local fiber = require('fiber')
+local fio = require('fio')
 
 -- Function decorator that is used to prevent box.cfg() from
 -- being called concurrently by different fibers.
@@ -806,7 +807,11 @@ local function load_cfg(cfg)
     -- When recovering from such an old snapshot, special recovery triggers on
     -- system spaces are needed in order to be able to recover and upgrade
     -- the schema then.
+    -- This code is executed before load_cfg, so work_dir is not yet set.
     local snap_dir = box.cfg.memtx_dir
+    if not snap_dir:startswith('/') and box.cfg.work_dir ~= nil then
+        snap_dir = fio.pathjoin(box.cfg.work_dir, snap_dir)
+    end
     local snap_version = private.get_snapshot_version(snap_dir)
     if snap_version then
         private.set_recovery_triggers(snap_version)

--- a/test/xlog/gh-5894-pre-1.7.7-upgrade.result
+++ b/test/xlog/gh-5894-pre-1.7.7-upgrade.result
@@ -102,6 +102,46 @@ test_run:cmd('delete server upgrade')
  | - true
  | ...
 
+-- Check that various combinations of box.cfg.work_dir and box.cfg.memtx_dir are
+-- handled correctly.
+-- work_dir - empty, memtx_dir - absolute tested above.
+-- work_dir - relative, memtx_dir - absolute (set by test-run).
+test_run:cmd('create server upgrade with script="xlog/upgrade.lua", \
+             workdir="xlog/upgrade/1.6.8/gh-5894-pre-1.7.7-upgrade"')
+ | ---
+ | - true
+ | ...
+test_run:cmd('start server upgrade with args="upgrade"')
+ | ---
+ | - true
+ | ...
+test_run:cmd('stop server upgrade')
+ | ---
+ | - true
+ | ...
+test_run:cmd('delete server upgrade')
+ | ---
+ | - true
+ | ...
+-- work_dir - relative, memtx_dir - relative.
+test_run:cmd('create server upgrade with script="xlog/upgrade.lua", \
+             workdir="xlog/upgrade/1.6.8/gh-5894-pre-1.7.7-upgrade"')
+ | ---
+ | - true
+ | ...
+test_run:cmd('start server upgrade with args="upgrade ."')
+ | ---
+ | - true
+ | ...
+test_run:cmd('stop server upgrade')
+ | ---
+ | - true
+ | ...
+test_run:cmd('delete server upgrade')
+ | ---
+ | - true
+ | ...
+
 -- Upgrade from 1.7.1.
 test_run:cmd('create server upgrade with script="xlog/upgrade.lua", \
              workdir="xlog/upgrade/1.7.1/gh-5894-pre-1.7.7-upgrade"')

--- a/test/xlog/gh-5894-pre-1.7.7-upgrade.test.lua
+++ b/test/xlog/gh-5894-pre-1.7.7-upgrade.test.lua
@@ -19,6 +19,22 @@ test_run:switch('default')
 test_run:cmd('stop server upgrade')
 test_run:cmd('delete server upgrade')
 
+-- Check that various combinations of box.cfg.work_dir and box.cfg.memtx_dir are
+-- handled correctly.
+-- work_dir - empty, memtx_dir - absolute tested above.
+-- work_dir - relative, memtx_dir - absolute (set by test-run).
+test_run:cmd('create server upgrade with script="xlog/upgrade.lua", \
+             workdir="xlog/upgrade/1.6.8/gh-5894-pre-1.7.7-upgrade"')
+test_run:cmd('start server upgrade with args="upgrade"')
+test_run:cmd('stop server upgrade')
+test_run:cmd('delete server upgrade')
+-- work_dir - relative, memtx_dir - relative.
+test_run:cmd('create server upgrade with script="xlog/upgrade.lua", \
+             workdir="xlog/upgrade/1.6.8/gh-5894-pre-1.7.7-upgrade"')
+test_run:cmd('start server upgrade with args="upgrade ."')
+test_run:cmd('stop server upgrade')
+test_run:cmd('delete server upgrade')
+
 -- Upgrade from 1.7.1.
 test_run:cmd('create server upgrade with script="xlog/upgrade.lua", \
              workdir="xlog/upgrade/1.7.1/gh-5894-pre-1.7.7-upgrade"')

--- a/test/xlog/upgrade.lua
+++ b/test/xlog/upgrade.lua
@@ -1,8 +1,20 @@
 #!/usr/bin/env tarantool
 
+local work_dir = nil
+local memtx_dir = nil
+
+if arg[1] ~= nil then
+    -- When no args are passed to the script test-run fills args with
+    -- "nil upgrade.lua" for some reason.
+    work_dir = arg[1]
+    memtx_dir = arg[2]
+end
+
 box.cfg {
     listen              = os.getenv("LISTEN"),
-    memtx_memory        = 107374182
+    memtx_memory        = 107374182,
+    work_dir            = work_dir,
+    memtx_dir           = memtx_dir,
 }
 
 require('console').listen(os.getenv('ADMIN'))


### PR DESCRIPTION
The upgrade script first tries to determine if the node is booted from
old snaps not recoverable on current Tarantool versions. If this is the
case, it sets up special triggers so that snaps are automatically
converted to a suitable format.

This happens before box.cfg{}, so the workdir is not set at this point
in time, and the upgrade script should take configured work_dir into
account explicitly. Fix this.

Closes #7232

NO_DOC=bugfix