### PR TITLE
sql: do nothing in ROUND() if precision is too big

### DIFF
--- a/changelogs/unreleased/gh-6650-round-with-big-precision.md
+++ b/changelogs/unreleased/gh-6650-round-with-big-precision.md
@@ -1,0 +1,3 @@
+## bugfix/sql
+
+* Now ROUND() with big precision works properly (gh-6650).

--- a/test/sql-luatest/gh_6650_round_with_big_precision_test.lua
+++ b/test/sql-luatest/gh_6650_round_with_big_precision_test.lua
@@ -1,0 +1,20 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'test_round_double'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_round_double = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT ROUND(1.2345678901234e0, 2147483647);]]
+        t.assert_equals(box.execute(sql).rows, {{1.2345678901234}})
+    end)
+end


### PR DESCRIPTION
The smallest positive double value is 2.225E-307, and the value before the exponent has a maximum of 15 digits after the decimal point. This means that double values cannot have more than 307 + 15 digits after the decimal point.

After this patch, ROUND() will return its first argument unchanged if the first argument is DOUBLE and the second argument is INTEGER greater than 322.

Closes #6650

NO_DOC=bugfix