### PR TITLE
memtx: fix reverse iterators gap tracking

### DIFF
--- a/changelogs/unreleased/gh-4709-rev-iters-phantom-reads.md
+++ b/changelogs/unreleased/gh-4709-rev-iters-phantom-reads.md
@@ -1,0 +1,3 @@
+## bugfix/memtx
+
+* Fixed phantom reads in reverse iterators (gh-7409).

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -350,6 +350,33 @@ tree_iterator_set_dummie(struct iterator *iterator)
 	iterator->next_raw = tree_iterator_dummie;
 }
 
+/*
+ * If the iterator's underlying tuple does not match its current tuple, it needs
+ * to be repositioned.
+ */
+template <bool USE_HINT>
+static void
+tree_iterator_prev_reposition(struct tree_iterator<USE_HINT> *iterator,
+			      struct memtx_tree_index<USE_HINT> *index)
+{
+	bool exact = false;
+	iterator->tree_iterator =
+		memtx_tree_lower_bound_elem(&index->tree, iterator->current,
+					    &exact);
+	if (exact) {
+		struct memtx_tree_data<USE_HINT> *successor =
+		memtx_tree_iterator_get_elem(&index->tree,
+					     &iterator->tree_iterator);
+		tree_iterator_set_current(iterator, successor);
+	}
+	/*
+	 * Since we previously clarified a tuple from the iterator
+	 * current tuple's story chain, a tuple with same primary key
+	 * must always exist in the index.
+	 */
+	assert(exact || in_txn() == NULL || !memtx_tx_manager_use_mvcc_engine);
+}
+
 template <bool USE_HINT>
 static int
 tree_iterator_next_raw_base(struct iterator *iterator, struct tuple **ret)
@@ -396,10 +423,8 @@ tree_iterator_prev_raw_base(struct iterator *iterator, struct tuple **ret)
 	assert(it->current.tuple != NULL);
 	struct memtx_tree_data<USE_HINT> *check =
 		memtx_tree_iterator_get_elem(&index->tree, &it->tree_iterator);
-	if (check == NULL || !memtx_tree_data_is_equal(check, &it->current)) {
-		it->tree_iterator = memtx_tree_lower_bound_elem(&index->tree,
-								it->current, NULL);
-	}
+	if (check == NULL || !memtx_tree_data_is_equal(check, &it->current))
+		tree_iterator_prev_reposition(it, index);
 	memtx_tree_iterator_prev(&index->tree, &it->tree_iterator);
 	struct tuple *successor = it->current.tuple;
 	tuple_ref(successor);
@@ -490,10 +515,8 @@ tree_iterator_prev_equal_raw_base(struct iterator *iterator, struct tuple **ret)
 	assert(it->current.tuple != NULL);
 	struct memtx_tree_data<USE_HINT> *check =
 		memtx_tree_iterator_get_elem(&index->tree, &it->tree_iterator);
-	if (check == NULL || !memtx_tree_data_is_equal(check, &it->current)) {
-		it->tree_iterator = memtx_tree_lower_bound_elem(&index->tree,
-								it->current, NULL);
-	}
+	if (check == NULL || !memtx_tree_data_is_equal(check, &it->current))
+		tree_iterator_prev_reposition(it, index);
 	memtx_tree_iterator_prev(&index->tree, &it->tree_iterator);
 	struct tuple *successor = it->current.tuple;
 	tuple_ref(successor);

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -564,7 +564,6 @@ name(struct iterator *iterator, struct tuple **ret)				\
 		}								\
 		*ret = memtx_tx_tuple_clarify(txn, space, *ret, idx, mk_index);	\
 	} while (*ret == NULL);							\
-	tree_iterator_set_current_tuple(it, *ret);				\
 	return 0;								\
 }										\
 struct forgot_to_add_semicolon
@@ -707,12 +706,8 @@ tree_iterator_start_raw(struct iterator *iterator, struct tuple **ret)
 		memtx_tx_track_gap(txn, space, idx, successor, type,
 				   it->key_data.key, it->key_data.part_count);
 /*********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND END**********/
-	if (res == NULL || !eq_match)
-		return 0;
-	if (*ret == NULL)
-		return iterator->next_raw(iterator, ret);
-	tree_iterator_set_current_tuple(it, *ret);
-	return 0;
+	return res == NULL || !eq_match || *ret != NULL ? 0 :
+	       iterator->next_raw(iterator, ret);
 }
 
 /* }}} */

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -2847,6 +2847,7 @@ memtx_tx_track_gap_slow(struct txn *txn, struct space *space, struct index *inde
 			}
 		}
 		assert(index->dense_id < story->index_count);
+		assert(story->link[index->dense_id].in_index != NULL);
 		rlist_add(&story->link[index->dense_id].nearby_gaps,
 			  &item->in_nearby_gaps);
 	} else {

--- a/test/box-luatest/gh_7409_rev_iters_phantom_reads_test.lua
+++ b/test/box-luatest/gh_7409_rev_iters_phantom_reads_test.lua
@@ -1,0 +1,80 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group(nil, t.helpers.matrix{iter = {'LT', 'LE', 'REQ'}})
+
+g.before_all(function(cg)
+    cg.server = server:new{
+        alias   = 'dflt',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.before_each(function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('s')
+        s:create_index('pk')
+    end)
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        box.space.s:drop()
+    end)
+end)
+
+--[[
+Checks that gap tracking is correctly handled for the first key in reverse
+iteration sequence.
+]]
+g.test_rev_iters_phantom_read_first_key = function(cg)
+    local stream1 = cg.server.net_box:new_stream()
+    local stream2 = cg.server.net_box:new_stream()
+    local stream3 = cg.server.net_box:new_stream()
+
+    cg.server:exec(function()
+        box.space.s:insert{1}
+    end)
+
+    stream1:begin()
+    stream2:begin()
+    stream3:begin()
+
+    stream1.space.s:replace{1}
+    stream2.space.s:select({}, {iterator = cg.params.iter})
+    stream3.space.s:insert{0}
+    stream3:commit()
+
+    t.assert_equals(stream2.space.s:select{}, {{1}})
+end
+
+--[[
+Checks that gap tracking is correctly handled for subsequent keys in reverse
+iteration sequence.
+]]
+g.test_rev_iters_phantom_read_subsequent_key = function(cg)
+    local stream1 = cg.server.net_box:new_stream()
+    local stream2 = cg.server.net_box:new_stream()
+    local stream3 = cg.server.net_box:new_stream()
+
+    cg.server:exec(function()
+        box.space.s:insert{2}
+        box.space.s:insert{1}
+    end)
+
+    stream1:begin()
+    stream2:begin()
+    stream3:begin()
+
+    stream1.space.s:replace{1}
+    stream2.space.s:select({}, {iterator = cg.params.iter})
+    stream3.space.s:insert{0}
+    stream3:commit()
+
+    t.assert_equals(stream2.space.s:select{}, {{1}, {2}})
+end


### PR DESCRIPTION
In case of reverse iterators, due to index limitations, we need to clarify
the successor tuple early: this implies that the successor's story is not
always at the top of the history chain, whilst we need to add the gap item
to the story currently present in index — fix this by explicitly retrieving
the top story in the successor's history chain.

CLoses #7409

NO_DOC=bugfix