### PR TITLE
sql: fix wrong flag is_res_neg in sql_rem_int()

### DIFF
--- a/changelogs/unreleased/gh-6575-assertion-in-modulo.md
+++ b/changelogs/unreleased/gh-6575-assertion-in-modulo.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Fixed assertion due to the % operation when the left value is negative and the
+  result is 0 (gh-6575).

--- a/src/box/sql/util.c
+++ b/src/box/sql/util.c
@@ -1093,7 +1093,7 @@ sql_rem_int(int64_t lhs, bool is_lhs_neg, int64_t rhs, bool is_rhs_neg,
 		uint64_t u_lhs = (uint64_t) (-lhs);
 		uint64_t u_res = u_lhs % u_rhs;
 		*res = -u_res;
-		*is_res_neg = true;
+		*is_res_neg = u_res != 0;
 		return 0;
 	}
 	/*

--- a/test/sql-luatest/gh_6575_assertion_in_modulo_test.lua
+++ b/test/sql-luatest/gh_6575_assertion_in_modulo_test.lua
@@ -1,0 +1,20 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'test_assertion_in_modulo'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_assertion_in_modulo = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        t.assert_equals(box.execute([[SELECT -5 % -1;]]).rows, {{0}})
+        t.assert_equals(box.execute([[SELECT -5 % 1;]]).rows, {{0}})
+    end)
+end


### PR DESCRIPTION
This patch makes the is_res_neg flag false in the sql_rem_int() function if the left value is negative and the result is 0. Prior to this patch, the value of the flag was true, which resulted in an assertion during encoding 0 as MP_INT.

Closes #6575

NO_DOC=bugfix