### PR TITLE
static-build: bump openssl from 1.1.1n to 1.1.1q

### DIFF
--- a/Dockerfile.staticbuild
+++ b/Dockerfile.staticbuild
@@ -40,9 +40,9 @@ RUN yum -y install python3-devel python3-pip
 
 RUN set -x && \
     cd / && \
-    curl -O -L https://www.openssl.org/source/openssl-1.1.1n.tar.gz && \
-    tar -xvf openssl-1.1.1n.tar.gz && \
-    cd openssl-1.1.1n && \
+    curl -O -L https://www.openssl.org/source/openssl-1.1.1q.tar.gz && \
+    tar -xvf openssl-1.1.1q.tar.gz && \
+    cd openssl-1.1.1q && \
     ./config --libdir=lib && \
     make -j && make install
 

--- a/changelogs/unreleased/bump-openssl-to-111q.md
+++ b/changelogs/unreleased/bump-openssl-to-111q.md
@@ -1,0 +1,3 @@
+## feature/build
+
+* Bump OpenSSL from 1.1.1n to 1.1.1q for static build.


### PR DESCRIPTION
Just regular update to bring openssl security fixes into tarantool.

Changelog: https://www.openssl.org/news/cl111.txt
Vulnerabilities: https://www.openssl.org/news/vulnerabilities.html

NO_TEST=security update of a dependency
NO_DOC=security update of a dependency

(backported from commit fd35f8c799317dcf0a569fac31f77bc802c9975b)