### PR TITLE
cmake: eliminate warning about source properties

### DIFF
--- a/cmake/module.cmake
+++ b/cmake/module.cmake
@@ -41,4 +41,5 @@ function(rebuild_module_api)
     add_custom_target(api ALL DEPENDS ${dstfile})
     install(FILES ${dstfile} DESTINATION ${MODULE_INCLUDEDIR})
 endfunction()
-set_source_files_properties("${CMAKE_CURRENT_BINARY_DIR}/module.h" PROPERTIES GENERATED HEADER_FILE_ONLY)
+set_source_files_properties("${CMAKE_CURRENT_BINARY_DIR}/module.h"
+    PROPERTIES GENERATED TRUE HEADER_FILE_ONLY TRUE)


### PR DESCRIPTION
The GENERATED and HEADER_FILE_ONLY source file properties should be
followed by a boolean value. CMake 3.20+ warns if it is not so, see [1].

It seems, the module.h properties do not actually change anything
visible in our case.

[1]: https://cmake.org/cmake/help/latest/policy/CMP0118.html