### PR TITLE
lua/decimal: add Lua value accessors to module API

### DIFF
--- a/changelogs/unreleased/decimal-lua-module-api.md
+++ b/changelogs/unreleased/decimal-lua-module-api.md
@@ -1,0 +1,3 @@
+## feature/decimal
+
+* Added Lua/C accessors for decimals into the module API (gh-7228).

--- a/extra/exports
+++ b/extra/exports
@@ -316,7 +316,10 @@ luaT_call
 luaT_checktuple
 luaT_cpcall
 luaT_error
+luaT_isdecimal
 luaT_istuple
+luaT_newdecimal
+luaT_pushdecimal
 luaT_pushtuple
 luaT_state
 luaT_toibuf

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -214,6 +214,7 @@ set(api_headers
     ${PROJECT_SOURCE_DIR}/src/lib/core/latch.h
     ${PROJECT_SOURCE_DIR}/src/lib/core/clock.h
     ${PROJECT_SOURCE_DIR}/src/box/decimal.h
+    ${PROJECT_SOURCE_DIR}/src/lua/decimal.h
 )
 rebuild_module_api(${api_headers})
 

--- a/src/box/lua/info.c
+++ b/src/box/lua/info.c
@@ -176,7 +176,7 @@ lbox_pushreplica(lua_State *L, struct replica *replica)
 	lua_settable(L, -3);
 
 	lua_pushstring(L, "uuid");
-	luaL_pushuuidstr(L, &replica->uuid);
+	luaT_pushuuidstr(L, &replica->uuid);
 	lua_settable(L, -3);
 
 	lua_pushstring(L, "lsn");
@@ -235,7 +235,7 @@ lbox_info_replication_anon_call(struct lua_State *L)
 		if (!replica->anon)
 			continue;
 
-		luaL_pushuuidstr(L, &replica->uuid);
+		luaT_pushuuidstr(L, &replica->uuid);
 		lbox_pushreplica(L, replica);
 
 		lua_settable(L, -3);
@@ -290,7 +290,7 @@ lbox_info_id(struct lua_State *L)
 static int
 lbox_info_uuid(struct lua_State *L)
 {
-	luaL_pushuuidstr(L, &INSTANCE_UUID);
+	luaT_pushuuidstr(L, &INSTANCE_UUID);
 	return 1;
 }
 
@@ -384,7 +384,7 @@ lbox_info_cluster(struct lua_State *L)
 {
 	lua_createtable(L, 0, 2);
 	lua_pushliteral(L, "uuid");
-	luaL_pushuuidstr(L, &REPLICASET_UUID);
+	luaT_pushuuidstr(L, &REPLICASET_UUID);
 	lua_settable(L, -3);
 	return 1;
 }

--- a/src/box/lua/net_box.c
+++ b/src/box/lua/net_box.c
@@ -2441,7 +2441,7 @@ out:
 	lua_setfield(L, -2, "version_id");
 	lua_pushstring(L, greeting->protocol);
 	lua_setfield(L, -2, "protocol");
-	luaL_pushuuidstr(L, &greeting->uuid);
+	luaT_pushuuidstr(L, &greeting->uuid);
 	lua_setfield(L, -2, "uuid");
 	/* Push the protocol version and features. */
 	lua_pushinteger(L, id.version);

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -3443,7 +3443,7 @@ port_vdbemem_dump_lua(struct port *base, struct lua_State *L, bool is_flat)
 			*luaL_pushuuid(L) = mem->u.uuid;
 			break;
 		case MEM_TYPE_DEC:
-			*lua_pushdecimal(L) = mem->u.d;
+			*luaT_pushdecimal(L) = mem->u.d;
 			break;
 		case MEM_TYPE_DATETIME:
 			*luaT_pushdatetime(L) = mem->u.dt;

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -3440,7 +3440,7 @@ port_vdbemem_dump_lua(struct port *base, struct lua_State *L, bool is_flat)
 			lua_pushboolean(L, mem->u.b);
 			break;
 		case MEM_TYPE_UUID:
-			*luaL_pushuuid(L) = mem->u.uuid;
+			luaT_pushuuid(L, &mem->u.uuid);
 			break;
 		case MEM_TYPE_DEC:
 			luaT_pushdecimal(L, &mem->u.d);

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -3446,7 +3446,7 @@ port_vdbemem_dump_lua(struct port *base, struct lua_State *L, bool is_flat)
 			luaT_pushdecimal(L, &mem->u.d);
 			break;
 		case MEM_TYPE_DATETIME:
-			*luaT_pushdatetime(L) = mem->u.dt;
+			luaT_pushdatetime(L, &mem->u.dt);
 			break;
 		case MEM_TYPE_INTERVAL:
 			*luaT_pushinterval(L) = mem->u.itv;

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -3449,7 +3449,7 @@ port_vdbemem_dump_lua(struct port *base, struct lua_State *L, bool is_flat)
 			luaT_pushdatetime(L, &mem->u.dt);
 			break;
 		case MEM_TYPE_INTERVAL:
-			*luaT_pushinterval(L) = mem->u.itv;
+			luaT_pushinterval(L, &mem->u.itv);
 			break;
 		default:
 			unreachable();

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -3443,7 +3443,7 @@ port_vdbemem_dump_lua(struct port *base, struct lua_State *L, bool is_flat)
 			*luaL_pushuuid(L) = mem->u.uuid;
 			break;
 		case MEM_TYPE_DEC:
-			*luaT_pushdecimal(L) = mem->u.d;
+			luaT_pushdecimal(L, &mem->u.d);
 			break;
 		case MEM_TYPE_DATETIME:
 			*luaT_pushdatetime(L) = mem->u.dt;

--- a/src/lua/decimal.c
+++ b/src/lua/decimal.c
@@ -82,15 +82,15 @@ ldecimal_##name(struct lua_State *L) {						\
 
 uint32_t CTID_DECIMAL;
 
-decimal_t *
+box_decimal_t *
 luaT_newdecimal(struct lua_State *L)
 {
 	decimal_t *res = luaL_pushcdata(L, CTID_DECIMAL);
 	return res;
 }
 
-decimal_t *
-luaT_pushdecimal(struct lua_State *L, const decimal_t *dec)
+box_decimal_t *
+luaT_pushdecimal(struct lua_State *L, const box_decimal_t *dec)
 {
 	decimal_t *res = luaT_newdecimal(L);
 	memcpy(res, dec, sizeof(decimal_t));
@@ -113,7 +113,7 @@ luaT_pushdecimalstr(struct lua_State *L, const decimal_t *dec)
  * Returns pointer to decimal_t if a value at a given index is
  * a decimal and NULL otherwise.
  */
-static decimal_t *
+box_decimal_t *
 luaT_isdecimal(struct lua_State *L, int index)
 {
 	assert(CTID_DECIMAL != 0);

--- a/src/lua/decimal.c
+++ b/src/lua/decimal.c
@@ -102,20 +102,21 @@ luaT_pushdecimalstr(struct lua_State *L, const decimal_t *dec)
 }
 
 /**
- * Returns true if a value at a given index is a decimal
- * and false otherwise
+ * Returns pointer to decimal_t if a value at a given index is
+ * a decimal and NULL otherwise.
  */
-static bool
+static decimal_t *
 luaT_isdecimal(struct lua_State *L, int index)
 {
+	assert(CTID_DECIMAL != 0);
 	if (lua_type(L, index) != LUA_TCDATA)
-		return false;
+		return NULL;
 
 	uint32_t ctypeid;
-	luaL_checkcdata(L, index, &ctypeid);
+	void *res = luaL_checkcdata(L, index, &ctypeid);
 	if (ctypeid != CTID_DECIMAL)
-		return false;
-	return true;
+		return NULL;
+	return res;
 }
 
 /** Check whether a value at a given index is a decimal. */
@@ -308,7 +309,7 @@ ldecimal_isdecimal(struct lua_State *L)
 {
 	if (lua_gettop(L) < 1)
 		luaL_error(L, "usage: decimal.is_decimal(value)");
-	bool is_decimal = luaT_isdecimal(L, 1);
+	bool is_decimal = luaT_isdecimal(L, 1) != NULL;
 	lua_pushboolean(L, is_decimal);
 	return 1;
 }

--- a/src/lua/decimal.h
+++ b/src/lua/decimal.h
@@ -42,10 +42,7 @@ extern uint32_t CTID_DECIMAL;
 struct lua_State;
 
 decimal_t *
-lua_pushdecimal(struct lua_State *L);
-
-void
-lua_pushdecimalstr(struct lua_State *L, const decimal_t *dec);
+luaT_pushdecimal(struct lua_State *L);
 
 void
 tarantool_lua_decimal_init(struct lua_State *L);

--- a/src/lua/decimal.h
+++ b/src/lua/decimal.h
@@ -32,6 +32,7 @@
 #define TARANTOOL_LUA_DECIMAL_H_INCLUDED
 
 #include "lib/core/decimal.h"
+#include "trivia/util.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -41,19 +42,41 @@ extern uint32_t CTID_DECIMAL;
 
 struct lua_State;
 
+/*
+ * Alias box_decimal_t to decimal_t to use luaT_*decimal()
+ * functions within tarantool source code without type
+ * casting.
+ *
+ * The module API has its own box_decimal_t definition.
+ */
+typedef decNumber box_decimal_t;
+
+/** \cond public */
+
 /**
  * Allocate a new decimal on the Lua stack and return
  * a pointer to it.
  */
-decimal_t *
+API_EXPORT box_decimal_t *
 luaT_newdecimal(struct lua_State *L);
 
 /**
  * Allocate a new decimal on the Lua stack with copy of given
  * decimal and return a pointer to it.
  */
-decimal_t *
-luaT_pushdecimal(struct lua_State *L, const decimal_t *dec);
+API_EXPORT box_decimal_t *
+luaT_pushdecimal(struct lua_State *L, const box_decimal_t *dec);
+
+/**
+ * Check whether a value on the Lua stack is a decimal.
+ *
+ * Returns a pointer to the decimal on a successful check,
+ * NULL otherwise.
+ */
+API_EXPORT box_decimal_t *
+luaT_isdecimal(struct lua_State *L, int index);
+
+/** \endcond public */
 
 void
 tarantool_lua_decimal_init(struct lua_State *L);

--- a/src/lua/decimal.h
+++ b/src/lua/decimal.h
@@ -41,8 +41,19 @@ extern uint32_t CTID_DECIMAL;
 
 struct lua_State;
 
+/**
+ * Allocate a new decimal on the Lua stack and return
+ * a pointer to it.
+ */
 decimal_t *
-luaT_pushdecimal(struct lua_State *L);
+luaT_newdecimal(struct lua_State *L);
+
+/**
+ * Allocate a new decimal on the Lua stack with copy of given
+ * decimal and return a pointer to it.
+ */
+decimal_t *
+luaT_pushdecimal(struct lua_State *L, const decimal_t *dec);
 
 void
 tarantool_lua_decimal_init(struct lua_State *L);

--- a/src/lua/msgpack.c
+++ b/src/lua/msgpack.c
@@ -43,7 +43,7 @@
 #include <small/ibuf.h>
 
 #include "core/decimal.h" /* decimal_unpack() */
-#include "lua/decimal.h" /* luaT_pushdecimal() */
+#include "lua/decimal.h" /* luaT_newdecimal() */
 #include "mp_extension_types.h"
 #include "mp_uuid.h" /* mp_decode_uuid() */
 #include "mp_datetime.h"
@@ -388,7 +388,7 @@ luamp_decode(struct lua_State *L, struct luaL_serializer *cfg,
 		switch (ext_type) {
 		case MP_DECIMAL:
 		{
-			decimal_t *dec = luaT_pushdecimal(L);
+			decimal_t *dec = luaT_newdecimal(L);
 			dec = decimal_unpack(data, len, dec);
 			if (dec == NULL)
 				goto ext_decode_err;

--- a/src/lua/msgpack.c
+++ b/src/lua/msgpack.c
@@ -396,7 +396,7 @@ luamp_decode(struct lua_State *L, struct luaL_serializer *cfg,
 		}
 		case MP_UUID:
 		{
-			struct tt_uuid *uuid = luaL_pushuuid(L);
+			struct tt_uuid *uuid = luaT_newuuid(L);
 			*data = svp;
 			uuid = mp_decode_uuid(data, uuid);
 			if (uuid == NULL)

--- a/src/lua/msgpack.c
+++ b/src/lua/msgpack.c
@@ -43,7 +43,7 @@
 #include <small/ibuf.h>
 
 #include "core/decimal.h" /* decimal_unpack() */
-#include "lua/decimal.h" /* lua_pushdecimal() */
+#include "lua/decimal.h" /* luaT_pushdecimal() */
 #include "mp_extension_types.h"
 #include "mp_uuid.h" /* mp_decode_uuid() */
 #include "mp_datetime.h"
@@ -388,7 +388,7 @@ luamp_decode(struct lua_State *L, struct luaL_serializer *cfg,
 		switch (ext_type) {
 		case MP_DECIMAL:
 		{
-			decimal_t *dec = lua_pushdecimal(L);
+			decimal_t *dec = luaT_pushdecimal(L);
 			dec = decimal_unpack(data, len, dec);
 			if (dec == NULL)
 				goto ext_decode_err;

--- a/src/lua/msgpack.c
+++ b/src/lua/msgpack.c
@@ -413,7 +413,7 @@ luamp_decode(struct lua_State *L, struct luaL_serializer *cfg,
 		}
 		case MP_INTERVAL:
 		{
-			struct interval *itv = luaT_pushinterval(L);
+			struct interval *itv = luaT_newinterval(L);
 			itv = interval_unpack(data, itv);
 			if (itv == NULL)
 				goto ext_decode_err;

--- a/src/lua/msgpack.c
+++ b/src/lua/msgpack.c
@@ -405,7 +405,7 @@ luamp_decode(struct lua_State *L, struct luaL_serializer *cfg,
 		}
 		case MP_DATETIME:
 		{
-			struct datetime *date = luaT_pushdatetime(L);
+			struct datetime *date = luaT_newdatetime(L);
 			date = datetime_unpack(data, len, date);
 			if (date == NULL)
 				goto ext_decode_err;

--- a/src/lua/utils.c
+++ b/src/lua/utils.c
@@ -147,9 +147,17 @@ luaT_pushdatetime(struct lua_State *L, const struct datetime *dt)
 }
 
 struct interval *
-luaT_pushinterval(struct lua_State *L)
+luaT_newinterval(struct lua_State *L)
 {
 	return luaL_pushcdata(L, CTID_INTERVAL);
+}
+
+struct interval *
+luaT_pushinterval(struct lua_State *L, const struct interval *itv)
+{
+	struct interval *res = luaT_newinterval(L);
+	memcpy(res, itv, sizeof(struct interval));
+	return res;
 }
 
 int

--- a/src/lua/utils.c
+++ b/src/lua/utils.c
@@ -39,6 +39,7 @@
 #include <diag.h>
 #include <fiber.h>
 #include "tt_uuid.h"
+#include "core/datetime.h"
 
 int luaL_nil_ref = LUA_REFNIL;
 
@@ -132,9 +133,17 @@ luaT_pushuuidstr(struct lua_State *L, const struct tt_uuid *uuid)
 }
 
 struct datetime *
-luaT_pushdatetime(struct lua_State *L)
+luaT_newdatetime(struct lua_State *L)
 {
 	return luaL_pushcdata(L, CTID_DATETIME);
+}
+
+struct datetime *
+luaT_pushdatetime(struct lua_State *L, const struct datetime *dt)
+{
+	struct datetime *res = luaT_newdatetime(L);
+	memcpy(res, dt, sizeof(struct datetime));
+	return res;
 }
 
 struct interval *

--- a/src/lua/utils.c
+++ b/src/lua/utils.c
@@ -31,6 +31,7 @@
 #include "lua/utils.h"
 #include <lj_trace.h>
 
+#include <string.h>
 #include <assert.h>
 #include <errno.h>
 
@@ -105,13 +106,21 @@ luaL_pushcdata(struct lua_State *L, uint32_t ctypeid)
 }
 
 struct tt_uuid *
-luaL_pushuuid(struct lua_State *L)
+luaT_newuuid(struct lua_State *L)
 {
 	return luaL_pushcdata(L, CTID_UUID);
 }
 
+struct tt_uuid *
+luaT_pushuuid(struct lua_State *L, const struct tt_uuid *uuid)
+{
+	struct tt_uuid *res = luaT_newuuid(L);
+	memcpy(res, uuid, sizeof(struct tt_uuid));
+	return res;
+}
+
 void
-luaL_pushuuidstr(struct lua_State *L, const struct tt_uuid *uuid)
+luaT_pushuuidstr(struct lua_State *L, const struct tt_uuid *uuid)
 {
 	/*
 	 * Do not use a global buffer. It might be overwritten if GC starts

--- a/src/lua/utils.h
+++ b/src/lua/utils.h
@@ -99,7 +99,18 @@ luaT_pushuuidstr(struct lua_State *L, const struct tt_uuid *uuid);
  * @return memory associated with this datetime data
  */
 struct datetime *
-luaT_pushdatetime(struct lua_State *L);
+luaT_newdatetime(struct lua_State *L);
+
+/**
+ * @brief Push cdata of a datetime type onto the stack and
+ * copy given datetime value into it.
+ * @param L Lua State
+ * @param dt datetime value to copy from
+ * @sa luaL_pushcdata
+ * @return memory associated with this datetime data
+ */
+struct datetime *
+luaT_pushdatetime(struct lua_State *L, const struct datetime *dt);
 
 /** Push an interval cdata onto the stack. */
 struct interval *

--- a/src/lua/utils.h
+++ b/src/lua/utils.h
@@ -112,9 +112,19 @@ luaT_newdatetime(struct lua_State *L);
 struct datetime *
 luaT_pushdatetime(struct lua_State *L, const struct datetime *dt);
 
-/** Push an interval cdata onto the stack. */
+/**
+ * Allocate a new time interval on the Lua stack and return
+ * a pointer to it.
+ */
 struct interval *
-luaT_pushinterval(struct lua_State *L);
+luaT_newinterval(struct lua_State *L);
+
+/**
+ * Allocate a new time interval on the Lua stack with copy of
+ * given interval and return a pointer to it.
+ */
+struct interval *
+luaT_pushinterval(struct lua_State *L, const struct interval *itv);
 
 /** \cond public */
 

--- a/src/lua/utils.h
+++ b/src/lua/utils.h
@@ -76,11 +76,21 @@ extern uint32_t CTID_DATETIME;
 /** Type ID of struct interval. */
 extern uint32_t CTID_INTERVAL;
 
+/**
+ * Allocate a new uuid on the Lua stack and return a pointer to it.
+ */
 struct tt_uuid *
-luaL_pushuuid(struct lua_State *L);
+luaT_newuuid(struct lua_State *L);
+
+/**
+ * Allocate a new uuid on the Lua stack with copy of given
+ * uuid and return a pointer to it.
+ */
+struct tt_uuid *
+luaT_pushuuid(struct lua_State *L, const struct tt_uuid *uuid);
 
 void
-luaL_pushuuidstr(struct lua_State *L, const struct tt_uuid *uuid);
+luaT_pushuuidstr(struct lua_State *L, const struct tt_uuid *uuid);
 
 /**
  * @brief Push cdata of a datetime type onto the stack.


### PR DESCRIPTION
Added the following functions to the module API:

```c
/**
 * Allocate a new decimal on the Lua stack and return
 * a pointer to it.
 */
API_EXPORT box_decimal_t *
luaT_newdecimal(struct lua_State *L);

/**
 * Allocate a new decimal on the Lua stack with copy of given
 * decimal and return a pointer to it.
 */
API_EXPORT box_decimal_t *
luaT_pushdecimal(struct lua_State *L, const box_decimal_t *dec);

/**
 * Check whether a value on the Lua stack is a decimal.
 *
 * Returns a pointer to the decimal on a successful check,
 * NULL otherwise.
 */
API_EXPORT box_decimal_t *
luaT_isdecimal(struct lua_State *L, int index);
```

This pull request also contains several preparatory changes. One is worth to highlight: we had a set of `luaT_pushfoo()` function, which allocates `cdata<struct foo>` on the Lua stack. Now such functions are named `luaT_newfoo()`. The new `luaT_pushfoo()` functions are introduced: they accept an argument of `const struct *foo` type -- what to push to the stack. See declarations above for example.

Part of #7228