### PR TITLE
tuple: add JSON path field accessor to module API

### DIFF
--- a/changelogs/unreleased/get-tuple-field-by-json-path-from-c.md
+++ b/changelogs/unreleased/get-tuple-field-by-json-path-from-c.md
@@ -1,0 +1,4 @@
+## feature/tuple
+
+* Added `box_tuple_field_by_path()` function into the module API to allow to
+  access a tuple field from C code using a JSON path (gh-7228).

--- a/extra/exports
+++ b/extra/exports
@@ -74,6 +74,7 @@ box_tuple_compare
 box_tuple_compare_with_key
 box_tuple_extract_key
 box_tuple_field
+box_tuple_field_by_path
 box_tuple_field_count
 box_tuple_format
 box_tuple_format_default

--- a/src/box/lua/tuple.c
+++ b/src/box/lua/tuple.c
@@ -661,7 +661,8 @@ lbox_tuple_field_by_path(struct lua_State *L)
 					     tuple_data(tuple),
 					     tuple_field_map(tuple),
 					     path, (uint32_t)len,
-					     lua_hashstring(L, 2));
+					     lua_hashstring(L, 2),
+					     TUPLE_INDEX_BASE);
 	if (field == NULL)
 		return 0;
 	luamp_decode(L, luaL_msgpack_default, &field);

--- a/src/box/request.c
+++ b/src/box/request.c
@@ -179,7 +179,8 @@ request_handle_sequence(struct request *request, struct space *space)
 	}
 
 	if (path != NULL) {
-		tuple_go_to_path(&key, path, strlen(path), MULTIKEY_NONE);
+		tuple_go_to_path(&key, path, strlen(path), TUPLE_INDEX_BASE,
+				 MULTIKEY_NONE);
 		if (key == NULL)
 			return 0; /* field not found */
 	}

--- a/src/box/tuple.c
+++ b/src/box/tuple.c
@@ -650,6 +650,24 @@ box_tuple_field(box_tuple_t *tuple, uint32_t fieldno)
 	return tuple_field(tuple, fieldno);
 }
 
+const char *
+box_tuple_field_by_path(box_tuple_t *tuple, const char *path,
+			uint32_t path_len, int index_base)
+{
+	assert(tuple != NULL);
+	assert(path != NULL);
+
+	if (path_len == 0)
+		return NULL;
+
+	uint32_t path_hash = field_name_hash(path, path_len);
+	return tuple_field_raw_by_full_path(tuple_format(tuple),
+					    tuple_data(tuple),
+					    tuple_field_map(tuple),
+					    path, path_len, path_hash,
+					    index_base);
+}
+
 typedef struct tuple_iterator box_tuple_iterator_t;
 
 box_tuple_iterator_t *

--- a/src/box/tuple.c
+++ b/src/box/tuple.c
@@ -458,12 +458,12 @@ tuple_field_go_to_key(const char **field, const char *key, int len)
 
 int
 tuple_go_to_path(const char **data, const char *path, uint32_t path_len,
-		 int multikey_idx)
+		 int index_base, int multikey_idx)
 {
 	int rc;
 	struct json_lexer lexer;
 	struct json_token token;
-	json_lexer_create(&lexer, path, path_len, TUPLE_INDEX_BASE);
+	json_lexer_create(&lexer, path, path_len, index_base);
 	while ((rc = json_lexer_next_token(&lexer, &token)) == 0) {
 		switch (token.type) {
 		case JSON_TOKEN_ANY:
@@ -492,7 +492,8 @@ tuple_go_to_path(const char **data, const char *path, uint32_t path_len,
 const char *
 tuple_field_raw_by_full_path(struct tuple_format *format, const char *tuple,
 			     const uint32_t *field_map, const char *path,
-			     uint32_t path_len, uint32_t path_hash)
+			     uint32_t path_len, uint32_t path_hash,
+			     int index_base)
 {
 	assert(path_len > 0);
 	uint32_t fieldno;
@@ -507,7 +508,7 @@ tuple_field_raw_by_full_path(struct tuple_format *format, const char *tuple,
 		return tuple_field_raw(format, tuple, field_map, fieldno);
 	struct json_lexer lexer;
 	struct json_token token;
-	json_lexer_create(&lexer, path, path_len, TUPLE_INDEX_BASE);
+	json_lexer_create(&lexer, path, path_len, index_base);
 	if (json_lexer_next_token(&lexer, &token) != 0)
 		return NULL;
 	switch(token.type) {
@@ -542,7 +543,7 @@ tuple_field_raw_by_full_path(struct tuple_format *format, const char *tuple,
 	return tuple_field_raw_by_path(format, tuple, field_map, fieldno,
 				       path + lexer.offset,
 				       path_len - lexer.offset,
-				       NULL, MULTIKEY_NONE);
+				       index_base, NULL, MULTIKEY_NONE);
 }
 
 uint32_t
@@ -556,6 +557,7 @@ tuple_raw_multikey_count(struct tuple_format *format, const char *data,
 					key_def->multikey_fieldno,
 					key_def->multikey_path,
 					key_def->multikey_path_len,
+					TUPLE_INDEX_BASE,
 					NULL, MULTIKEY_NONE);
 	if (array_raw == NULL)
 		return 0;

--- a/src/box/tuple.h
+++ b/src/box/tuple.h
@@ -753,6 +753,9 @@ tuple_field_count(struct tuple *tuple)
  *                      with NULL.
  * @param path The path to process.
  * @param path_len The length of the @path.
+ * @param index_base 0 if array element indexes in @a path are
+ *        zero-based (like in C) or 1 if they're one-based (like
+ *        in Lua).
  * @param multikey_idx The multikey index hint - index of
  *                     multikey index key to retrieve when array
  *                     index placeholder "[*]" is met.
@@ -761,7 +764,7 @@ tuple_field_count(struct tuple *tuple)
  */
 int
 tuple_go_to_path(const char **data, const char *path, uint32_t path_len,
-		 int multikey_idx);
+		 int index_base, int multikey_idx);
 
 /**
  * Propagate @a field to MessagePack(field)[index].
@@ -792,8 +795,12 @@ tuple_field_go_to_key(const char **field, const char *key, int len);
  * @param format Tuple format.
  * @param tuple MessagePack tuple's body.
  * @param field_map Tuple field map.
+ * @param fieldno The index of a root field.
  * @param path Relative JSON path to field.
  * @param path_len Length of @a path.
+ * @param index_base 0 if array element indexes in @a path are
+ *        zero-based (like in C) or 1 if they're one-based (like
+ *        in Lua).
  * @param offset_slot_hint The pointer to a variable that contains
  *                         an offset slot. May be NULL.
  *                         If specified AND value by pointer is
@@ -809,7 +816,8 @@ static inline const char *
 tuple_field_raw_by_path(struct tuple_format *format, const char *tuple,
 			const uint32_t *field_map, uint32_t fieldno,
 			const char *path, uint32_t path_len,
-			int32_t *offset_slot_hint, int multikey_idx)
+			int index_base, int32_t *offset_slot_hint,
+			int multikey_idx)
 {
 	int32_t offset_slot;
 	if (offset_slot_hint != NULL &&
@@ -825,7 +833,7 @@ tuple_field_raw_by_path(struct tuple_format *format, const char *tuple,
 			return tuple;
 		}
 		field = tuple_format_field_by_path(format, fieldno, path,
-						   path_len);
+						   path_len, index_base);
 		assert(field != NULL || path != NULL);
 		if (path != NULL && field == NULL)
 			goto parse;
@@ -871,7 +879,7 @@ parse:
 			mp_next(&tuple);
 		if (path != NULL &&
 		    unlikely(tuple_go_to_path(&tuple, path, path_len,
-					      multikey_idx) != 0))
+					      index_base, multikey_idx) != 0))
 			return NULL;
 	}
 	return tuple;
@@ -949,13 +957,17 @@ tuple_field(struct tuple *tuple, uint32_t fieldno)
  * @param path Full JSON path to field.
  * @param path_len Length of @a path.
  * @param path_hash Hash of @a path.
+ * @param index_base 0 if array element indexes in @a path are
+ *        zero-based (like in C) or 1 if they're one-based (like
+ *        in Lua).
  *
  * @retval field data if field exists or NULL
  */
 const char *
 tuple_field_raw_by_full_path(struct tuple_format *format, const char *tuple,
 			     const uint32_t *field_map, const char *path,
-			     uint32_t path_len, uint32_t path_hash);
+			     uint32_t path_len, uint32_t path_hash,
+			     int index_base);
 
 /**
  * Get a tuple field pointed to by an index part and multikey
@@ -983,6 +995,7 @@ tuple_field_raw_by_part(struct tuple_format *format, const char *data,
 	}
 	return tuple_field_raw_by_path(format, data, field_map, part->fieldno,
 				       part->path, part->path_len,
+				       TUPLE_INDEX_BASE,
 				       &part->offset_slot_cache, multikey_idx);
 }
 

--- a/src/box/tuple.h
+++ b/src/box/tuple.h
@@ -171,6 +171,37 @@ const char *
 box_tuple_field(box_tuple_t *tuple, uint32_t fieldno);
 
 /**
+ * Return a raw tuple field in the MsgPack format pointed by
+ * a JSON path.
+ *
+ * The JSON path includes the outmost field. For example, "c" in
+ * ["a", ["b", "c"], "d"] can be accessed using "[2][2]" path (if
+ * index_base is 1, as in Lua). If index_base is set to 0, the
+ * same field will be pointed by the "[1][1]" path.
+ *
+ * The first JSON path token may be a field name if the tuple
+ * has associated format with named fields. A field of a nested
+ * map can be accessed in the same way: "foo.bar" or ".foo.bar".
+ *
+ * The return value is valid until the tuple is destroyed, see
+ * box_tuple_ref().
+ *
+ * Return NULL if the field does not exist or if the JSON path is
+ * malformed or invalid. Multikey JSON path token [*] is treated
+ * as invalid in this context.
+ *
+ * \param tuple a tuple
+ * \param path a JSON path
+ * \param path_len a length of @a path
+ * \param index_base 0 if array element indexes in @a path are
+ *        zero-based (like in C) or 1 if they're one-based (like
+ *        in Lua)
+ * \retval a pointer to a field data if the field exists or NULL
+ */
+API_EXPORT const char *
+box_tuple_field_by_path(box_tuple_t *tuple, const char *path,
+			uint32_t path_len, int index_base);
+/**
  * Tuple iterator
  */
 typedef struct tuple_iterator box_tuple_iterator_t;

--- a/src/box/tuple_extract_key.cc
+++ b/src/box/tuple_extract_key.cc
@@ -329,6 +329,7 @@ tuple_extract_key_slowpath_raw(const char *data, const char *data_end,
 		const char *src_end = field_end;
 		if (has_json_paths && part->path != NULL) {
 			if (tuple_go_to_path(&src, part->path, part->path_len,
+					     TUPLE_INDEX_BASE,
 					     multikey_idx) != 0) {
 				/*
 				 * The path must be correct as

--- a/src/box/tuple_format.h
+++ b/src/box/tuple_format.h
@@ -300,7 +300,7 @@ tuple_format_field_count(struct tuple_format *format)
  */
 static inline struct tuple_field *
 tuple_format_field_by_path(struct tuple_format *format, uint32_t fieldno,
-			   const char *path, uint32_t path_len)
+			   const char *path, uint32_t path_len, int index_base)
 {
 	assert(fieldno < tuple_format_field_count(format));
 	struct json_token token;
@@ -313,7 +313,7 @@ tuple_format_field_by_path(struct tuple_format *format, uint32_t fieldno,
 	if (path == NULL)
 		return root;
 	return json_tree_lookup_path_entry(&format->fields, &root->token,
-					   path, path_len, TUPLE_INDEX_BASE,
+					   path, path_len, index_base,
 					   struct tuple_field, token);
 }
 
@@ -324,7 +324,7 @@ tuple_format_field_by_path(struct tuple_format *format, uint32_t fieldno,
 static inline struct tuple_field *
 tuple_format_field(struct tuple_format *format, uint32_t fieldno)
 {
-	return tuple_format_field_by_path(format, fieldno, NULL, 0);
+	return tuple_format_field_by_path(format, fieldno, NULL, 0, 0);
 }
 
 extern struct tuple_format **tuple_formats;

--- a/test/app-tap/module_api.c
+++ b/test/app-tap/module_api.c
@@ -2379,6 +2379,40 @@ test_tuple_validate_formatted(lua_State *L)
 	return 1;
 }
 
+/**
+ * Get a pointer to a tuple field pointed by a JSON path.
+ *
+ * It is a helper to test box_tuple_field_by_path().
+ *
+ * Accepts a tuple, a JSON path (string) and an index base
+ * (0 or 1).
+ *
+ * Returns the field as a string in the msgpack format if the
+ * field exists, nil otherwise.
+ */
+static int
+tuple_field_by_path(struct lua_State *L)
+{
+	assert(lua_gettop(L) == 3);
+
+	box_tuple_t *tuple = luaT_istuple(L, 1);
+	size_t len;
+	const char *path = lua_tolstring(L, 2, &len);
+	int index_base = lua_tointeger(L, 3);
+
+	const char *field = box_tuple_field_by_path(tuple, path, len,
+						    index_base);
+	if (field == NULL) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	const char *field_end = field;
+	mp_next(&field_end);
+	lua_pushlstring(L, field, field_end - field);
+	return 1;
+}
+
 LUA_API int
 luaopen_module_api(lua_State *L)
 {
@@ -2422,6 +2456,7 @@ luaopen_module_api(lua_State *L)
 		{"tuple_validate_def", test_tuple_validate_default},
 		{"tuple_validate_fmt", test_tuple_validate_formatted},
 		{"test_key_def_dup", test_key_def_dup},
+		{"tuple_field_by_path", tuple_field_by_path},
 		{NULL, NULL}
 	};
 	luaL_register(L, "module_api", lib);


### PR DESCRIPTION
Added a function, which reflects the `tuple[json_path]` Lua API (see #1285).

```c
/**
 * Return a raw tuple field in the MsgPack format pointed by
 * a JSON path.
 *
 * The JSON path includes the outmost field. For example, "c" in
 * ["a", ["b", "c"], "d"] can be accessed using "[2][2]" path (if 
 * index_base is 1, as in Lua). If index_base is set to 0, the 
 * same field will be pointed by the "[1][1]" path.
 *
 * The first JSON path token may be a field name if the tuple
 * has associated format with named fields. A field of a nested
 * map can be accessed in the same way: "foo.bar" or ".foo.bar".
 *
 * The return value is valid until the tuple is destroyed, see 
 * box_tuple_ref().
 *
 * Return NULL if the field does not exist or if the JSON path is
 * malformed or invalid. Multikey JSON path token [*] is treated
 * as invalid in this context.
 *
 * \param tuple a tuple
 * \param path a JSON path
 * \param path_len a length of @a path
 * \param index_base 0 if array element indexes in @a path are 
 *        zero-based (like in C) or 1 if they're one-based (like
 *        in Lua)
 * \retval a pointer to a field data if the field exists or NULL
 */
API_EXPORT const char *
box_tuple_field_by_path(box_tuple_t *tuple, const char *path,
                        uint32_t path_len, int index_base);
```