### PR TITLE
Multithread friendly signals

### DIFF
--- a/src/lib/core/CMakeLists.txt
+++ b/src/lib/core/CMakeLists.txt
@@ -40,6 +40,7 @@ set(core_sources
     prbuf.c
     clock_lowres.c
     ssl_init.c
+    tt_sigaction.c
 )
 
 if (ENABLE_BACKTRACE)

--- a/src/lib/core/backtrace.c
+++ b/src/lib/core/backtrace.c
@@ -98,6 +98,8 @@ collect_current_stack(struct backtrace *bt, void *stack)
 /*
  * Restore target fiber context (if needed) and call `collect_current_stack`
  * over it.
+ * It is guaranteed that if NULL passed as fiber argument, fiber
+ * module will not be used.
  */
 NOINLINE void
 backtrace_collect(struct backtrace *bt, const struct fiber *fiber,
@@ -107,7 +109,7 @@ backtrace_collect(struct backtrace *bt, const struct fiber *fiber,
 	/* The user should not see the frame of `collect_current_stack`. */
 	++skip_frames;
 
-	if (fiber == fiber()) {
+	if (fiber == NULL || fiber == fiber()) {
 		collect_current_stack(bt, NULL);
 		goto skip_frames;
 	}

--- a/src/lib/core/backtrace.h
+++ b/src/lib/core/backtrace.h
@@ -50,6 +50,8 @@ struct fiber;
 /*
  * Collect call stack of `fiber` (only C/C++ frames) to `bt`.
  *
+ * It is guaranteed that if NULL passed as fiber argument, fiber
+ * module will not be used.
  * `skip_frames` determines the number of frames skipped, starting from the
  * frame of `backtrace_collect`. It is expected to have a non-negative value.
  * For example, if skip_frames is 0, then the backtrace will contain

--- a/src/lib/core/clock_lowres.c
+++ b/src/lib/core/clock_lowres.c
@@ -3,14 +3,14 @@
  *
  * Copyright 2010-2022, Tarantool AUTHORS, please see AUTHORS file.
  */
-#include <signal.h>
 #include <string.h>
 #include <say.h>
 #include <pthread.h>
+#include "tt_sigaction.h"
 #include "clock.h"
 #include "clock_lowres.h"
 
-#if defined(__APPLE__) || !defined(NDEBUG)
+#ifndef NDEBUG
 /**
  * A thread that initialized this module. Only owner thread
  * is allowed to handle SIGALRM and use methods from this module.
@@ -44,27 +44,15 @@ double clock_lowres_monotonic_clock_value = 0.0;
 static void
 clock_lowres_tick(int signum)
 {
-#ifdef __APPLE__
-	/**
-	 * We cannot guarantee that the signal is delivered
-	 * only to owner thread on MacOS. So use this workaround.
-	 * https://github.com/tarantool/tarantool/issues/7206
-	 */
-	if (!clock_lowres_thread_is_owner()) {
-		pthread_kill(owner, signum);
-		return;
-	}
-#else
 	(void)signum;
 	assert(clock_lowres_thread_is_owner());
-#endif
 	clock_lowres_monotonic_clock_value = clock_monotonic();
 }
 
 void
 clock_lowres_signal_init(void)
 {
-#if defined(__APPLE__) || !defined(NDEBUG)
+#ifndef NDEBUG
 	owner = pthread_self();
 #endif
 	clock_lowres_monotonic_clock_value = clock_monotonic();
@@ -72,7 +60,7 @@ clock_lowres_signal_init(void)
 	memset(&sa, 0, sizeof(sa));
 	sa.sa_handler = clock_lowres_tick;
 	sa.sa_flags = SA_RESTART;
-	if (sigaction(SIGALRM, &sa, NULL) == -1)
+	if (tt_sigaction(SIGALRM, &sa, NULL) == -1)
 		panic_syserror("cannot set low resolution clock timer signal");
 
 	struct itimerval timer;
@@ -93,6 +81,6 @@ clock_lowres_signal_reset(void)
 	struct sigaction sa;
 	memset(&sa, 0, sizeof(sa));
 	sa.sa_handler = SIG_DFL;
-	if (sigaction(SIGALRM, &sa, NULL) == -1)
+	if (tt_sigaction(SIGALRM, &sa, NULL) == -1)
 		say_syserror("cannot reset low resolution clock timer signal");
 }

--- a/src/lib/core/crash.c
+++ b/src/lib/core/crash.c
@@ -214,7 +214,7 @@ crash_collect(int signo, siginfo_t *siginfo, void *ucontext)
 
 #ifdef ENABLE_BACKTRACE
 	struct backtrace bt;
-	backtrace_collect(&bt, fiber(), 1);
+	backtrace_collect(&bt, NULL, 1);
 	backtrace_snprint(cinfo->backtrace_buf,
 			  sizeof(cinfo->backtrace_buf), &bt);
 #endif

--- a/src/lib/core/tt_sigaction.c
+++ b/src/lib/core/tt_sigaction.c
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2022, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include <assert.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include "tt_sigaction.h"
+
+#define SIGMAX 32
+
+/** Flag is set if main_thread_id variable is initialized. */
+static bool main_thread_initialized;
+/** Main thread id, it is set on first tt_sigaction call. */
+static pthread_t main_thread_id;
+
+static void (*sighandlers[SIGMAX])(int signum);
+
+/**
+ * Check that signal has been delivered to the main thread
+ * and call signal handler or redirect it if thread is not main.
+ */
+static void
+sighandler_dispatcher(int signum)
+{
+	if (!pthread_equal(pthread_self(), main_thread_id)) {
+		pthread_kill(main_thread_id, signum);
+		return;
+	}
+	assert(sighandlers[signum] != NULL);
+	sighandlers[signum](signum);
+}
+
+int
+tt_sigaction(int signum, struct sigaction *sa, struct sigaction *osa)
+{
+	assert(signum < SIGMAX);
+	assert(sa != NULL);
+
+	/* Memorize id of main thread at the first call. */
+	if (!main_thread_initialized) {
+		main_thread_id = pthread_self();
+		main_thread_initialized = true;
+	}
+
+	void (*old_handler)(int) = sighandlers[signum];
+	if (sa->sa_handler == SIG_DFL || sa->sa_handler == SIG_IGN) {
+		sighandlers[signum] = NULL;
+	} else {
+		sighandlers[signum] = sa->sa_handler;
+		sa->sa_handler = sighandler_dispatcher;
+	}
+	int rc = sigaction(signum, sa, osa);
+	if (osa != NULL && old_handler != NULL)
+		osa->sa_handler = old_handler;
+	return rc;
+}

--- a/src/lib/core/tt_sigaction.h
+++ b/src/lib/core/tt_sigaction.h
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2022, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+#include <signal.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Set signal handler with the guarantee that it will be delivered
+ * to the main thread (before that, it can also be delivered to
+ * other threads) and executed only on the main thread.
+ */
+int
+tt_sigaction(int signum, struct sigaction *sa, struct sigaction *osa);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -316,3 +316,6 @@ target_link_libraries(latch.test core unit stat)
 
 add_executable(memtx_allocator.test memtx_allocator.cc box_test_utils.c)
 target_link_libraries(memtx_allocator.test unit core box)
+
+add_executable(tt_sigaction.test tt_sigaction.c core_test_utils.c)
+target_link_libraries(tt_sigaction.test core unit pthread)

--- a/test/unit/tt_sigaction.c
+++ b/test/unit/tt_sigaction.c
@@ -1,0 +1,86 @@
+#include "unit.h"
+
+#include <pthread.h>
+#include <string.h>
+#include <sys/time.h>
+#include "tt_sigaction.h"
+#include "clock.h"
+#include "pmatomic.h"
+#include "trivia/util.h"
+
+/** Test duration in seconds. */
+#define TEST_LEN 1.5
+/** Signal sending period in usec. Must be lower than second. */
+#define SIGNAL_PERIOD 1e3
+/** Number of child threads. */
+#define THREADS_NUM 4
+/** Sleep interval in microseconds. */
+#define USLEEP_INTERVAL 1e5
+
+static pthread_t main_thread;
+
+static uint32_t false_handle_cnt;
+
+static void *
+thread_f(void *arg)
+{
+	thread_sleep(TEST_LEN);
+	return NULL;
+}
+
+static void
+handler_f(int signum)
+{
+	(void)signum;
+	if (!pthread_equal(pthread_self(), main_thread))
+		pm_atomic_fetch_add_explicit(&false_handle_cnt, 1,
+					     pm_memory_order_relaxed);
+}
+
+int
+main(void)
+{
+	plan(1);
+
+	int rc;
+	struct sigaction sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = handler_f;
+	rc = tt_sigaction(SIGALRM, &sa, NULL);
+	fail_if(rc != 0);
+
+	struct itimerval timer;
+	struct timeval resolution = {
+		.tv_sec = 0,
+		.tv_usec = SIGNAL_PERIOD,
+	};
+	timer.it_interval = resolution;
+	timer.it_value = resolution;
+	rc = setitimer(ITIMER_REAL, &timer, NULL);
+	fail_if(rc != 0);
+
+	main_thread = pthread_self();
+	pthread_t child_threads[THREADS_NUM];
+	pthread_attr_t attr;
+	rc = pthread_attr_init(&attr);
+	fail_if(rc != 0);
+
+	rc = pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
+	fail_if(rc != 0);
+
+	for (int i = 0; i < THREADS_NUM; ++i) {
+		rc = pthread_create(&child_threads[i], &attr, &thread_f, NULL);
+		fail_if(rc != 0);
+	}
+
+	for (int i = 0; i < THREADS_NUM; ++i) {
+		rc = pthread_join(child_threads[i], NULL);
+		fail_if(rc != 0);
+	}
+
+	uint32_t false_handles = pm_atomic_load_explicit(
+		&false_handle_cnt, pm_memory_order_relaxed);
+	ok(false_handles == 0,
+	   "Child threads haven't executed signal handler");
+	return check_plan();
+}

--- a/test/unit/tt_sigaction.result
+++ b/test/unit/tt_sigaction.result
@@ -1,0 +1,2 @@
+1..1
+ok 1 - Child threads haven't executed signal handler


### PR DESCRIPTION
Currently, tarantool is not designed to allow user to spawn his
own threads with unblocked signals in new modules, applications 
using tarantool and so on. This patch adapts tarantool to this possibility.

This is supposed to solve the problem, described in #7408.

Closes #7408