### PR TITLE
build: bump libyaml

### DIFF
--- a/changelogs/unreleased/bump-libyaml-with-cve-fix.md
+++ b/changelogs/unreleased/bump-libyaml-with-cve-fix.md
@@ -1,0 +1,3 @@
+## feature/build
+
+* Updated libyaml to version with fixed stack overflows.


### PR DESCRIPTION
NO_DOC=internal
NO_TEST=internal

PR in tarantool/libyaml: https://github.com/tarantool/libyaml/pull/1

Updated version contains fixes of security issues:

- Security issue: https://github.com/yaml/libyaml/issues/107
- PR in upstream with original patch: https://github.com/yaml/libyaml/pull/127