### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-7172-fix-ir-varg-offset.md
+++ b/changelogs/unreleased/gh-7172-fix-ir-varg-offset.md
@@ -1,0 +1,4 @@
+## bugfix/luajit
+
+* Fixed the case for partial recording of vararg function body with the fixed
+  number of result values in with `LJ_GC64` (i.e. `LJ_FR2` enabled) (gh-7172).

--- a/changelogs/unreleased/gh-7244-sysprof-sandwich.md
+++ b/changelogs/unreleased/gh-7244-sysprof-sandwich.md
@@ -1,0 +1,5 @@
+## bugfix/luajit
+
+* Added `/proc/self/exe` symlink resolution to the symtab module, to obtain the
+  .symtab section for tarantool executable.
+* Introduced stack sandwich support to sysprof's parser (gh-7244).

--- a/changelogs/unreleased/gh-7264-dump-proto-default-mode.md
+++ b/changelogs/unreleased/gh-7264-dump-proto-default-mode.md
@@ -1,0 +1,5 @@
+## bugfix/luajit
+
+* Disabled proto and trace information dumpers in sysprof's default mode.
+  Attempts to use them lead to segmentation fault due to uninitialized buffer
+  (gh-7264).


### PR DESCRIPTION
* test: make sysprof tests more deterministic
* test: increase sampling interval in sysprof tests
* LJ_GC64: Fix IR_VARG offset for fixed number of results.
* sysprof: implement stack sandwich support
* symtab: fix .symtab section dump of the executable
* sysprof: disable proto and trace dumps in default
* ci: introduce GitHub action for environment setup
* build: configure parallel jobs
* ci: replace hw.ncpu with hw.logicalcpu for macOS
* ci: add Tarantool integration testing
* ci: remove GC64 matrix entries for ARM64 workflows
* ci: fix --parallel argument for MacOS runners

Closes #7172
Closes #7244
Closes #7264
Part of #7230
Needed for #7472

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump