### PR TITLE
[backport/1.10] luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-7172-fix-ir-varg-offset.md
+++ b/changelogs/unreleased/gh-7172-fix-ir-varg-offset.md
@@ -1,0 +1,4 @@
+## bugfix/luajit
+
+* Fixed the case for partial recording of vararg function body with the fixed
+  number of result values in with `LJ_GC64` (i.e. `LJ_FR2` enabled) (gh-7172).


### PR DESCRIPTION
* LJ_GC64: Fix IR_VARG offset for fixed number of results.
* ci: introduce GitHub action for environment setup
* build: configure parallel jobs
* ci: replace hw.ncpu with hw.logicalcpu for macOS
* ci: add Tarantool integration testing
* ci: fix --parallel argument for MacOS runners

Closes #7172
Part of #7230

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump
