### PR TITLE
ffi(fiber): add fiber_set_arg & fiber_get_arg functions to enable cus…

### DIFF
--- a/changelogs/unreleased/add-fiber_set_ctx.md
+++ b/changelogs/unreleased/add-fiber_set_ctx.md
@@ -1,0 +1,4 @@
+## feature/fiber
+
+* Add fiber_set_ctx/fiber_get_ctx api functions to pass data to fibers without
+yielding immediately.

--- a/extra/exports
+++ b/extra/exports
@@ -206,6 +206,7 @@ fiber_cond_new
 fiber_cond_signal
 fiber_cond_wait
 fiber_cond_wait_timeout
+fiber_get_ctx
 fiber_is_cancelled
 fiber_join
 fiber_join_timeout
@@ -214,6 +215,7 @@ fiber_new_ex
 fiber_reschedule
 fiber_self
 fiber_set_cancellable
+fiber_set_ctx
 fiber_set_joinable
 fiber_sleep
 fiber_start

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -492,6 +492,18 @@ fiber_make_ready(struct fiber *f)
 }
 
 void
+fiber_set_ctx(struct fiber *f, void *f_arg)
+{
+	f->f_arg = f_arg;
+}
+
+void *
+fiber_get_ctx(struct fiber *f)
+{
+	return f->f_arg;
+}
+
+void
 fiber_wakeup(struct fiber *f)
 {
 	/*

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -284,6 +284,27 @@ API_EXPORT void
 fiber_start(struct fiber *callee, ...);
 
 /**
+ * Set a pointer to context for the fiber. Can be used to avoid calling
+ * fiber_start which means no yields.
+ *
+ * \param f     fiber to set the context for
+ * \param f_arg context for the fiber function
+ */
+API_EXPORT void
+fiber_set_ctx(struct fiber *f, void *f_arg);
+
+/**
+ * Get the context for the fiber which was set via the fiber_set_ctx
+ * function. Can be used to avoid calling fiber_start which means no yields.
+ *
+ * \retval      context for the fiber function set by fiber_set_ctx function
+ *
+ * \sa fiber_set_ctx
+ */
+API_EXPORT void *
+fiber_get_ctx(struct fiber *f);
+
+/**
  * Interrupt a synchronous wait of a fiber. Nop for the currently running fiber.
  *
  * \param f fiber to be woken up

--- a/test/app-tap/module_api.test.lua
+++ b/test/app-tap/module_api.test.lua
@@ -476,7 +476,7 @@ local function test_isdecimal(test, module)
 end
 
 require('tap').test("module_api", function(test)
-    test:plan(42)
+    test:plan(43)
     local status, module = pcall(require, 'module_api')
     test:is(status, true, "module")
     test:ok(status, "module is loaded")


### PR DESCRIPTION
…tom closures

Before this change there was no way to create a fiber that accepts
parameters without yielding from the current fiber using the c api. You
could pass the function arguments when calling fiber_start, but that
forces you to yield, which is not acceptable in some scenarios (e.g.
within a transaction).

This commit introduces 2 new functions to the api: fiber_set_arg for
setting an pointer to an argument of the given fiber and fiber_get for
accessing that argument.

Closes #7669