### PR TITLE
memtx: tuple read view improvements

### DIFF
--- a/test/unit/memtx_allocator.cc
+++ b/test/unit/memtx_allocator.cc
@@ -88,10 +88,8 @@ alloc_tuple_count_cb(const void *stats_, void *ctx_)
 static int
 alloc_tuple_count()
 {
-	/* Trigger garbage collection before checking count. */
-	struct tuple *tuple = alloc_tuple();
-	fail_if(tuple == NULL);
-	free_tuple(tuple);
+	while (MemtxAllocator<SmallAlloc>::collect_garbage()) {
+	}
 	struct alloc_tuple_count_ctx ctx;
 	struct allocator_stats unused;
 	ctx.count = 0;

--- a/test/unit/memtx_allocator.result
+++ b/test/unit/memtx_allocator.result
@@ -1,4 +1,4 @@
-1..7
+1..8
 	*** test_main ***
     1..5
 	*** test_alloc_stats ***
@@ -69,4 +69,24 @@ ok 6 - subtests
     ok 10 - count after rv1 closed
 	*** test_temp_tuple_gc: done ***
 ok 7 - subtests
+    1..16
+	*** test_reuse_read_view ***
+    ok 1 - count before alloc
+    ok 2 - count after rv1 opened
+    ok 3 - count after rv2 opened
+    ok 4 - count after rv3 opened
+    ok 5 - count after rv4 opened
+    ok 6 - count after rv5 opened
+    ok 7 - count after rv6 opened
+    ok 8 - count after rv7 opened
+    ok 9 - count before rv7 closed
+    ok 10 - count after rv7 closed
+    ok 11 - count after rv6 closed
+    ok 12 - count after rv2 closed
+    ok 13 - count after rv1 closed
+    ok 14 - count after rv3 closed
+    ok 15 - count after rv5 closed
+    ok 16 - count after rv4 closed
+	*** test_reuse_read_view: done ***
+ok 8 - subtests
 	*** test_main: done ***

--- a/test/unit/memtx_allocator.result
+++ b/test/unit/memtx_allocator.result
@@ -1,4 +1,4 @@
-1..5
+1..6
 	*** test_main ***
     1..5
 	*** test_alloc_stats ***
@@ -40,4 +40,19 @@ ok 4 - subtests
     ok 3 - count after free
 	*** test_free_not_delayed_if_temporary: done ***
 ok 5 - subtests
+    1..11
+	*** test_tuple_gc ***
+    ok 1 - count before alloc
+    ok 2 - count after rv1 opened
+    ok 3 - count after rv2 opened
+    ok 4 - count after rv3 opened
+    ok 5 - count before rv2 closed
+    ok 6 - count after rv2 closed
+    ok 7 - count after rv4 opened
+    ok 8 - count before rv4 closed
+    ok 9 - count after rv4 closed
+    ok 10 - count after rv1 closed
+    ok 11 - count after rv3 closed
+	*** test_tuple_gc: done ***
+ok 6 - subtests
 	*** test_main: done ***

--- a/test/unit/memtx_allocator.result
+++ b/test/unit/memtx_allocator.result
@@ -1,4 +1,4 @@
-1..6
+1..7
 	*** test_main ***
     1..5
 	*** test_alloc_stats ***
@@ -55,4 +55,18 @@ ok 5 - subtests
     ok 11 - count after rv3 closed
 	*** test_tuple_gc: done ***
 ok 6 - subtests
+    1..10
+	*** test_temp_tuple_gc ***
+    ok 1 - count before alloc
+    ok 2 - count after rv1 opened
+    ok 3 - count after rv2 opened
+    ok 4 - count after rv3 opened
+    ok 5 - count after rv4 opened
+    ok 6 - count before rv4 closed
+    ok 7 - count after rv4 closed
+    ok 8 - count after rv3 closed
+    ok 9 - count after rv2 closed
+    ok 10 - count after rv1 closed
+	*** test_temp_tuple_gc: done ***
+ok 7 - subtests
 	*** test_main: done ***


### PR DESCRIPTION
This PR address a few issues that the current implementation of `MemtxAllocator::ReadView` has, namely:
- #7185
- #7412
- #7189

This is needed to make the memtx tuple read view infrastructure suitable for creating user read views.