### PR TITLE
static-build: bump ncurses from 6.2 to 6.3-20220716

### DIFF
--- a/changelogs/unreleased/bump-ncurses-to-6.3-20220716.md
+++ b/changelogs/unreleased/bump-ncurses-to-6.3-20220716.md
@@ -1,0 +1,3 @@
+## feature/build
+
+* Bumped Ncurses from 6.2 to 6.3-20220716 for static build.

--- a/static-build/CMakeLists.txt
+++ b/static-build/CMakeLists.txt
@@ -16,8 +16,8 @@ set(OPENSSL_VERSION 1.1.1q)
 set(OPENSSL_HASH c685d239b6a6e1bd78be45624c092f51)
 set(ZLIB_VERSION 1.2.11)
 set(ZLIB_HASH 1c9f62f0778697a09d36121ead88e08e)
-set(NCURSES_VERSION 6.2)
-set(NCURSES_HASH e812da327b1c2214ac1aed440ea3ae8d)
+set(NCURSES_VERSION 6.3-20220716)
+set(NCURSES_HASH 2b7a0e31ebbd8144680f985d61f5bbd5)
 set(READLINE_VERSION 8.0)
 set(READLINE_HASH 7e6c1f16aee3244a69aba6e438295ca3)
 set(BACKUP_STORAGE https://distrib.hb.bizmrg.com)
@@ -114,7 +114,7 @@ ExternalProject_Add(zlib
 # Ncurses
 #
 ExternalProject_Add(ncurses
-    URL https://ftp.gnu.org/gnu/ncurses/ncurses-${NCURSES_VERSION}.tar.gz
+    URL ${BACKUP_STORAGE}/ncurses/ncurses-${NCURSES_VERSION}.tgz
     URL_MD5 ${NCURSES_HASH}
     CONFIGURE_COMMAND <SOURCE_DIR>/configure
         CC=${CMAKE_C_COMPILER}


### PR DESCRIPTION
Just regular update to bring ncurses security fixes into tarantool.

New version brings a number of functional and security fixes:
- ncurses 6.3 before patch 20220416 has an out-of-bounds read and
segmentation violation in convert_strings in tinfo/read_entry.c in the
terminfo library (CVE-2022-29458).
- ncurses through v6.2-1. _nc_captoinfo in captoinfo.c has a heap-based
buffer overflow (CVE-2021-39537).

CVE-2022-29458 Detail: https://nvd.nist.gov/vuln/detail/CVE-2022-29458
CVE-2021-39537 Detail: https://nvd.nist.gov/vuln/detail/CVE-2021-39537
Release announcement: https://lists.gnu.org/archive/html/bug-ncurses/2022-07/msg00008.html

NO_TEST=security update of a dependency
NO_DOC=security update of a dependency