### PR TITLE
static-build: bump readline from 8.0 to 8.0p1

### DIFF
--- a/changelogs/unreleased/bump-readline-to-80p1.md
+++ b/changelogs/unreleased/bump-readline-to-80p1.md
@@ -1,0 +1,3 @@
+## feature/build
+
+* Bump Readline from 8.0 to 8.0p1 for static build.

--- a/static-build/CMakeLists.txt
+++ b/static-build/CMakeLists.txt
@@ -147,6 +147,8 @@ ExternalProject_Add(ncurses
 #
 # ReadLine
 #
+# Patched to fix file descriptor leak with zero-length history file.
+#
 ExternalProject_Add(readline
     URL https://ftp.gnu.org/gnu/readline/readline-${READLINE_VERSION}.tar.gz
     URL_MD5 ${READLINE_HASH}
@@ -158,6 +160,8 @@ ExternalProject_Add(readline
 
         --prefix=<INSTALL_DIR>
         --disable-shared
+    PATCH_COMMAND patch -d <SOURCE_DIR> -p0 <
+        "${CMAKE_CURRENT_SOURCE_DIR}/readline80-001.patch"
 )
 
 #

--- a/static-build/readline80-001.patch
+++ b/static-build/readline80-001.patch
@@ -1,0 +1,38 @@
+			   READLINE PATCH REPORT
+			   =====================
+
+Readline-Release: 8.0
+Patch-ID: readline80-001
+
+Bug-Reported-by:	chet.ramey@case.edu
+Bug-Reference-ID:
+Bug-Reference-URL:
+
+Bug-Description:
+
+The history file reading code doesn't close the file descriptor open to
+the history file when it encounters a zero-length file.
+
+Patch (apply with `patch -p0'):
+
+*** ../readline-8.0-patched/histfile.c	2018-06-11 09:14:52.000000000 -0400
+--- histfile.c	2019-05-16 15:55:57.000000000 -0400
+***************
+*** 306,309 ****
+--- 312,316 ----
+      {
+        free (input);
++       close (file);
+        return 0;	/* don't waste time if we don't have to */
+      }
+*** ../readline-8.0/patchlevel	2013-11-15 08:11:11.000000000 -0500
+--- patchlevel	2014-03-21 08:28:40.000000000 -0400
+***************
+*** 1,3 ****
+  # Do not edit -- exists only for use by patch
+  
+! 0
+--- 1,3 ----
+  # Do not edit -- exists only for use by patch
+  
+! 1


### PR DESCRIPTION
Just regular update to bring readline security fixes into tarantool.

Added a patch to fix file descriptor leak with zero-length history file.

Source of patch: https://ftp.gnu.org/gnu/readline/readline-8.0-patches/
Announcement: https://lists.gnu.org/archive/html/bug-readline/2019-08/msg00004.html

NO_TEST=security update of a dependency
NO_DOC=security update of a dependency