### PR TITLE
test: fix execpl call in unit/coio test

### DIFF
--- a/test/unit/coio.cc
+++ b/test/unit/coio.cc
@@ -182,7 +182,7 @@ test_waitpid_f(va_list ap)
 	pid_t pid = fork();
 	if (pid == 0) {
 		/* Child process. */
-		execlp("true", "", NULL);
+		execlp("true", "true", NULL);
 	}
 
 	fail_if(pid == -1);


### PR DESCRIPTION
According to man 3 exec: "The first argument, by convention, should point to the filename associated with the file being executed.". Using empty string as the first argument while calling `true` program, provided by coreutils led to error message being printed to stderr, which failed the test.

This patch passes 'true' as the first argument.

Closes #7452.