### PR TITLE
Refactoring of log.cfg() and box.cfg() from the POV of log configuration

### DIFF
--- a/changelogs/unreleased/gh-7447-fix-panic-on-invalid-log.md
+++ b/changelogs/unreleased/gh-7447-fix-panic-on-invalid-log.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fixed panic on invalid syslog log configuration (gh-7447).

--- a/extra/exports
+++ b/extra/exports
@@ -236,7 +236,6 @@ lbox_socket_nonblock
 log_format
 log_level
 log_pid
-log_type
 luaJIT_profile_dumpstack
 luaJIT_profile_start
 luaJIT_profile_stop
@@ -426,10 +425,10 @@ prbuf_commit
 prbuf_iterator_create
 prbuf_iterator_next
 random_bytes
+say_check_cfg
 say_logger_init
 say_logger_initialized
 say_logrotate
-say_parse_logger_type
 say_set_log_format
 say_set_log_level
 SHA1internal

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -735,43 +735,53 @@ wal_stream_create(struct wal_stream *ctx)
 
 /* {{{ configuration bindings */
 
-static void
-box_check_say(void)
+/*
+ * Check log configuration validity.
+ *
+ * Used thru Lua FFI.
+ */
+extern "C" int
+say_check_cfg(const char *log,
+	      MAYBE_UNUSED int level,
+	      int nonblock,
+	      const char *format_str)
 {
-	enum say_logger_type type = SAY_LOGGER_STDERR; /* default */
-	const char *log = cfg_gets("log");
+	enum say_logger_type type = SAY_LOGGER_STDERR;
 	if (log != NULL && say_parse_logger_type(&log, &type) < 0) {
-		tnt_raise(ClientError, ER_CFG, "log",
-			  diag_last_error(diag_get())->errmsg);
+		diag_set(ClientError, ER_CFG, "log",
+			 diag_last_error(diag_get())->errmsg);
+		return -1;
 	}
 	if (type == SAY_LOGGER_SYSLOG) {
 		struct say_syslog_opts opts;
 		if (say_parse_syslog_opts(log, &opts) < 0) {
 			if (diag_last_error(diag_get())->type ==
-			    &type_IllegalParams) {
-				tnt_raise(ClientError, ER_CFG, "log",
-					  diag_last_error(diag_get())->errmsg);
-			}
-			diag_raise();
+			    &type_IllegalParams)
+				diag_set(ClientError, ER_CFG, "log",
+					 diag_last_error(diag_get())->errmsg);
+			return -1;
 		}
 		say_free_syslog_opts(&opts);
 	}
 
-	const char *log_format = cfg_gets("log_format");
-	enum say_format format = say_format_by_name(log_format);
-	if (format == say_format_MAX)
-		tnt_raise(ClientError, ER_CFG, "log_format",
+	enum say_format format = say_format_by_name(format_str);
+	if (format == say_format_MAX) {
+		diag_set(ClientError, ER_CFG, "log_format",
 			 "expected 'plain' or 'json'");
+		return -1;
+	}
 	if (type == SAY_LOGGER_SYSLOG && format == SF_JSON) {
-		tnt_raise(ClientError, ER_CFG, "log_format",
-			  "'json' can't be used with syslog logger");
+		diag_set(ClientError, ER_CFG, "log_format",
+			 "'json' can't be used with syslog logger");
+		return -1;
 	}
-	int log_nonblock = cfg_getb("log_nonblock");
-	if (log_nonblock == 1 &&
+	if (nonblock == 1 &&
 	    (type == SAY_LOGGER_FILE || type == SAY_LOGGER_STDERR)) {
-		tnt_raise(ClientError, ER_CFG, "log_nonblock",
-			  "the option is incompatible with file/stderr logger");
+		diag_set(ClientError, ER_CFG, "log_nonblock",
+			 "the option is incompatible with file/stderr logger");
+		return -1;
 	}
+	return 0;
 }
 
 /**
@@ -1397,6 +1407,26 @@ box_check_txn_isolation(void)
 		return txn_isolation_level_MAX;
 	}
 	return (enum txn_isolation_level)level;
+}
+
+static void
+box_check_say()
+{
+	if (luaT_dostring(tarantool_L,
+			  "require('log').box_api.cfg_check()") != 0)
+		diag_raise();
+}
+
+int
+box_init_say()
+{
+	if (luaT_dostring(tarantool_L, "require('log').box_api.cfg()") != 0)
+		return -1;
+
+	if (cfg_geti("background") && say_set_background() != 0)
+		return -1;
+
+	return 0;
 }
 
 void

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -319,6 +319,12 @@ box_get_flightrec_cfg(struct flight_recorder_cfg *cfg);
 int
 box_configure_flightrec(void);
 
+/**
+ * Initialize logger on box init.
+ */
+int
+box_init_say();
+
 extern "C" {
 #endif /* defined(__cplusplus) */
 

--- a/src/lib/core/say.c
+++ b/src/lib/core/say.c
@@ -81,7 +81,7 @@ static const char logger_syntax_reminder[] =
  * True if Tarantool process runs in background mode, i.e. has no
  * controlling terminal.
  */
-static bool log_background = true;
+static bool log_background;
 
 static void
 say_default(int level, const char *filename, int line, const char *error,
@@ -722,14 +722,17 @@ say_logger_initialized(void)
 
 void
 say_logger_init(const char *init_str, int level, int nonblock,
-		const char *format, int background)
+		const char *format)
 {
 	/*
 	 * The logger may be early configured
 	 * by hands without configuing the whole box.
 	 */
-	if (say_logger_initialized())
+	if (say_logger_initialized()) {
+		say_set_log_level(level);
+		say_set_log_format(say_format_by_name(format));
 		return;
+	}
 
 	if (log_create(&log_std, init_str, nonblock) < 0)
 		goto fail;
@@ -749,31 +752,47 @@ say_logger_init(const char *init_str, int level, int nonblock,
 	}
 	_say = say_default;
 	say_set_log_level(level);
-	log_background = background;
 	log_pid = log_default->pid;
 	say_set_log_format(say_format_by_name(format));
 
-	if (background) {
-		fflush(stderr);
-		fflush(stdout);
-		if (log_default->fd == STDERR_FILENO) {
-			int fd = open("/dev/null", O_WRONLY);
-			if (fd < 0) {
-				diag_set(SystemError, "open /dev/null");
-				goto fail;
-			}
-			dup2(fd, STDERR_FILENO);
-			dup2(fd, STDOUT_FILENO);
-			close(fd);
-		} else {
-			dup2(log_default->fd, STDERR_FILENO);
-			dup2(log_default->fd, STDOUT_FILENO);
-		}
-	}
 	return;
 fail:
 	diag_log();
 	panic("failed to initialize logging subsystem");
+}
+
+int
+say_set_background(void)
+{
+	assert(say_logger_initialized());
+
+	if (log_background)
+		return 0;
+
+	log_background = true;
+
+	fflush(stderr);
+	fflush(stdout);
+
+	int fd;
+	int fd_null = -1;
+	if (log_default->fd == STDERR_FILENO) {
+		fd_null = open("/dev/null", O_WRONLY);
+		if (fd_null < 0) {
+			diag_set(SystemError, "open(/dev/null)");
+			return -1;
+		}
+		fd = fd_null;
+	} else {
+		fd = log_default->fd;
+	}
+
+	dup2(fd, STDERR_FILENO);
+	dup2(fd, STDOUT_FILENO);
+	if (fd_null != -1)
+		close(fd_null);
+
+	return 0;
 }
 
 void

--- a/src/lib/core/say.h
+++ b/src/lib/core/say.h
@@ -297,8 +297,19 @@ say_logrotate(struct ev_loop *, struct ev_signal *, int /* revents */);
 void
 say_logger_init(const char *init_str,
 		int log_level, int nonblock,
-		const char *log_format,
-		int background);
+		const char *log_format);
+
+/**
+ * Turn on background mode for logger. Should be called after say_logger_init.
+ *
+ * If logger is NULL (writes to stderr) then stdout and stderr will be
+ * redirected to /dev/null.
+ *
+ * Otherwise (logger writes to file, pipe etc) stdout and stderr will be
+ * redirected to logger fd.
+ */
+int
+say_set_background(void);
 
 /** Test if logger is initialized. */
 bool

--- a/src/lua/log.lua
+++ b/src/lua/log.lua
@@ -5,26 +5,21 @@ ffi.cdef[[
     typedef void (*sayfunc_t)(int level, const char *filename, int line,
                const char *error, const char *format, ...);
 
-    enum say_logger_type {
-        SAY_LOGGER_BOOT,
-        SAY_LOGGER_STDERR,
-        SAY_LOGGER_FILE,
-        SAY_LOGGER_PIPE,
-        SAY_LOGGER_SYSLOG
-    };
-
-    enum say_logger_type
-    log_type();
-
     void
     say_set_log_level(int new_level);
 
     void
     say_set_log_format(enum say_format format);
 
+    int
+    say_check_cfg(const char *log,
+                  int level,
+                  int nonblock,
+                  const char *format);
+
     extern void
     say_logger_init(const char *init_str, int level, int nonblock,
-                    const char *format, int background);
+                    const char *format);
 
     extern bool
     say_logger_initialized(void);
@@ -54,9 +49,6 @@ ffi.cdef[[
     pid_t log_pid;
     extern int log_level;
     extern int log_format;
-
-    int
-    say_parse_logger_type(const char **str, enum say_logger_type *type);
 ]]
 
 local S_CRIT = ffi.C.S_CRIT
@@ -97,14 +89,6 @@ local fmt_str2num = {
     ["json"]            = ffi.C.SF_JSON,
 }
 
-local function fmt_list()
-    local keyset = {}
-    for k in pairs(fmt_str2num) do
-        keyset[#keyset + 1] = k
-    end
-    return table.concat(keyset, ',')
-end
-
 -- Logging levels symbolic representation.
 local log_level_keys = {
     ['fatal']       = ffi.C.S_FATAL,
@@ -127,12 +111,14 @@ end
 
 -- Default options. The keys are part of
 -- user API , so change with caution.
-local log_cfg = {
+local default_cfg = {
     log             = nil,
     nonblock        = nil,
     level           = S_INFO,
     format          = fmt_num2str[ffi.C.SF_PLAIN],
 }
+
+local log_cfg = table.copy(default_cfg)
 
 -- Name mapping from box to log module and
 -- back. Make sure all required fields
@@ -143,141 +129,6 @@ local log2box_keys = {
     ['level']           = 'log_level',
     ['format']          = 'log_format',
 }
-
-local box2log_keys = {
-    ['log']             = 'log',
-    ['log_nonblock']    = 'nonblock',
-    ['log_level']       = 'level',
-    ['log_format']      = 'format',
-}
-
--- Update cfg value(s) in box.cfg instance conditionally
-local function box_cfg_update(log_key)
-    -- if it is not yet even exist just exit early
-    if type(box.cfg) ~= 'table' then
-        return
-    end
-
-    local update = function(log_key, box_key)
-        -- the box entry may be under configuration
-        -- process thus equal to nil, skip it then
-        if log_cfg[log_key] ~= nil and
-            box.cfg[box_key] ~= nil and
-            box.cfg[box_key] ~= log_cfg[log_key] then
-            box.cfg[box_key] = log_cfg[log_key]
-        end
-    end
-
-    if log_key == nil then
-        for k, v in pairs(log2box_keys) do
-            update(k, v)
-        end
-    else
-        assert(log2box_keys[log_key] ~= nil)
-        update(log_key, log2box_keys[log_key])
-    end
-end
-
--- Log options which can be set ony once.
-local cfg_static_keys = {
-    log         = true,
-    nonblock    = true,
-}
-
--- Test if static key is not changed.
-local function verify_static(k, v)
-    assert(cfg_static_keys[k] ~= nil)
-
-    if ffi.C.say_logger_initialized() == true then
-        if log_cfg[k] ~= v then
-            return false, "can't be set dynamically"
-        end
-    end
-
-    return true
-end
-
-local function parse_format(log)
-    -- There is no easy way to get pointer to ponter via FFI
-    local str_p = ffi.new('const char*[1]')
-    str_p[0] = ffi.cast('char*', log)
-    local logger_type = ffi.new('enum say_logger_type[1]')
-    local rc = ffi.C.say_parse_logger_type(str_p, logger_type)
-
-    if rc ~= 0 then
-        box.error()
-    end
-
-    return logger_type[0]
-end
-
--- Test if format is valid.
-local function verify_format(key, name, cfg)
-    assert(log_cfg[key] ~= nil)
-
-    if not fmt_str2num[name] then
-        local m = "expected %s"
-        return false, m:format(fmt_list())
-    end
-
-    local log_type = ffi.C.log_type()
-
-    -- When comes from log.cfg{} or box.cfg{}
-    -- initial call we might be asked to setup
-    -- syslog with json which is not allowed.
-    --
-    -- Note the cfg table comes from two places:
-    -- box api interface and log module itself.
-    -- The good thing that we're only needed log
-    -- entry which is the same key for both.
-    if cfg ~= nil and cfg['log'] ~= nil then
-        log_type = parse_format(cfg['log'])
-    end
-
-    if fmt_str2num[name] == ffi.C.SF_JSON then
-        if log_type == ffi.C.SAY_LOGGER_SYSLOG then
-            local m = "%s can't be used with syslog logger"
-            return false, m:format(fmt_num2str[ffi.C.SF_JSON])
-        end
-    end
-
-    return true
-end
-
--- Test if level is a valid string. The
--- number may be any for to backward compatibility.
-local function verify_level(key, level)
-    assert(log_cfg[key] ~= nil)
-
-    if type(level) == 'string' then
-        if not log_level_keys[level] then
-            local m = "expected %s"
-            return false, m:format(log_level_list())
-        end
-    elseif type(level) ~= 'number' then
-            return false, "must be a number or a string"
-    end
-
-    return true
-end
-
-local verify_ops = {
-    ['log']         = verify_static,
-    ['nonblock']    = verify_static,
-    ['format']      = verify_format,
-    ['level']       = verify_level,
-}
-
--- Verify a value for the particular key.
-local function verify_option(k, v, ...)
-    assert(k ~= nil)
-
-    if verify_ops[k] ~= nil then
-        return verify_ops[k](k, v, ...)
-    end
-
-    return true
-end
 
 -- Main routine which pass data to C logging code.
 local function say(level, fmt, ...)
@@ -325,70 +176,16 @@ local function say_closure(lvl)
     end
 end
 
+local log_error = say_closure(S_ERROR)
+local log_warn = say_closure(S_WARN)
+local log_info = say_closure(S_INFO)
+local log_verbose = say_closure(S_VERBOSE)
+local log_debug = say_closure(S_DEBUG)
+
 -- Rotate log (basically reopen the log file and
 -- start writting into it).
 local function log_rotate()
     ffi.C.say_logrotate(nil, nil, 0)
-end
-
--- Set new logging level, the level must be valid!
-local function set_log_level(level, update_box_cfg)
-    assert(type(level) == 'number')
-
-    ffi.C.say_set_log_level(level)
-
-    rawset(log_cfg, 'level', level)
-
-    if update_box_cfg then
-        box_cfg_update('level')
-    end
-
-    local m = "log: level set to %s"
-    say(S_DEBUG, m:format(level))
-end
-
--- Tries to set a new level, or print an error.
-local function log_level(level)
-    local ok, msg = verify_option('level', level)
-    if not ok then
-        error(msg)
-    end
-
-    if type(level) == 'string' then
-        level = log_level_keys[level]
-    end
-
-    set_log_level(level, true)
-end
-
--- Set a new logging format, the name must be valid!
-local function set_log_format(name, update_box_cfg)
-    assert(fmt_str2num[name] ~= nil)
-
-    if fmt_str2num[name] == ffi.C.SF_JSON then
-        ffi.C.say_set_log_format(ffi.C.SF_JSON)
-    else
-        ffi.C.say_set_log_format(ffi.C.SF_PLAIN)
-    end
-
-    rawset(log_cfg, 'format', name)
-
-    if update_box_cfg then
-        box_cfg_update('format')
-    end
-
-    local m = "log: format set to '%s'"
-    say(S_DEBUG, m:format(name))
-end
-
--- Tries to set a new format, or print an error.
-local function log_format(name)
-    local ok, msg = verify_option('format', name)
-    if not ok then
-        error(msg)
-    end
-
-    set_log_format(name, true)
 end
 
 -- Returns pid of a pipe process.
@@ -470,170 +267,122 @@ end
 
 Ratelimit.log_crit = log_ratelimited_closure(S_CRIT)
 
--- Fetch a value from log to box.cfg{}.
-local function box_api_cfg_get(key)
-    return log_cfg[box2log_keys[key]]
-end
+local option_types = {
+    log = 'string',
+    nonblock = 'boolean',
+    level = 'number, string',
+    format = 'string',
+}
 
--- Set value to log from box.cfg{}.
-local function box_api_cfg_set(cfg, key, value)
-    local log_key = box2log_keys[key]
+local log_initialized = false
 
-    -- a special case where we need to restore
-    -- nil value from previous setup attempt.
-    if value == box.NULL then
-        log_cfg[log_key] = nil
-        return true
+-- Convert cfg options to types suitable for ffi say_ functions.
+local function log_C_cfg(cfg)
+    local cfg_C = table.copy(cfg)
+    if type(cfg.level) == 'string' then
+        cfg_C.level = log_level_keys[cfg.level]
     end
-
-    local ok, msg = verify_option(log_key, value, cfg)
-    if not ok then
-        return false, msg
-    end
-
-    log_cfg[log_key] = value
-    return true
-end
-
--- Set logging level from reloading box.cfg{}
-local function box_api_cfg_set_log_level()
-    local log_key = box2log_keys['log_level']
-    local v = box.cfg['log_level']
-
-    local ok, msg = verify_option(log_key, v)
-    if not ok then
-        box.error(box.error.CFG, 'log_level', msg)
-    end
-
-    if type(v) == 'string' then
-        v = log_level_keys[v]
-    end
-
-    set_log_level(v, false)
-end
-
--- Set logging format from reloading box.cfg{}
-local function box_api_set_log_format()
-    local log_key = box2log_keys['log_format']
-    local v = box.cfg['log_format']
-
-    local ok, msg = verify_option(log_key, v)
-    if not ok then
-        box.error(box.error.CFG, 'log_format', msg)
-    end
-
-    set_log_format(v, false)
-end
-
--- Reload dynamic options.
-local function reload_cfg(cfg)
-    for k in pairs(cfg_static_keys) do
-        if cfg[k] ~= nil then
-            local ok, msg = verify_static(k, cfg[k])
-            if not ok then
-                local m = "log.cfg: \'%s\' %s"
-                error(m:format(k, msg))
-            end
-        end
-    end
-
-    if cfg.level ~= nil then
-        log_level(cfg.level)
-    end
-
-    if cfg.format ~= nil then
-        log_format(cfg.format)
-    end
-end
-
--- Load or reload configuration via log.cfg({}) call.
-local function load_cfg(self, cfg)
-    cfg = cfg or {}
-
-    -- log option might be zero length string, which
-    -- is fine, we should treat it as nil.
-    if cfg.log ~= nil then
-        if type(cfg.log) ~= 'string' or cfg.log:len() == 0 then
-            cfg.log = nil
-        end
-    end
-
-    if cfg.format ~= nil then
-        local ok, msg = verify_option('format', cfg.format, cfg)
-        if not ok then
-            local m = "log.cfg: \'%s\' %s"
-            error(m:format('format', msg))
-        end
-    end
-
-    if cfg.level ~= nil then
-        local ok, msg = verify_option('level', cfg.level)
-        if not ok then
-            local m = "log.cfg: \'%s\' %s"
-            error(m:format('level', msg))
-        end
-        -- Convert level to a numeric value since
-        -- low level api operates with numbers only.
-        if type(cfg.level) == 'string' then
-            assert(log_level_keys[cfg.level] ~= nil)
-            cfg.level = log_level_keys[cfg.level]
-        end
-    end
-
+    local nonblock
     if cfg.nonblock ~= nil then
-        if type(cfg.nonblock) ~= 'boolean' then
-            error("log.cfg: 'nonblock' option must be 'true' or 'false'")
+        nonblock = cfg.nonblock and 1 or 0
+    else
+        nonblock = -1
+    end
+    cfg_C.nonblock = nonblock
+    return cfg_C
+end
+
+-- Check cfg is valid and thus can be applied
+local function log_check_cfg(cfg)
+    if type(cfg.level) == 'string' and
+       log_level_keys[cfg.level] == nil then
+        local err = ("expected %s"):format(log_level_list())
+        box.error(box.error.CFG, "log_level", err)
+    end
+
+    if log_initialized then
+        if log_cfg.log ~= cfg.log then
+            box.error(box.error.RELOAD_CFG, 'log');
+        end
+        if log_cfg.nonblock ~= cfg.nonblock then
+            box.error(box.error.RELOAD_CFG, 'log_nonblock');
         end
     end
 
-    if ffi.C.say_logger_initialized() == true then
-        return reload_cfg(cfg)
+    local cfg_C = log_C_cfg(cfg)
+    if ffi.C.say_check_cfg(cfg_C.log, cfg_C.level,
+                           cfg_C.nonblock, cfg_C.format) ~= 0 then
+        box.error()
     end
+end
 
-    cfg.level = cfg.level or log_cfg.level
-    cfg.format = cfg.format or log_cfg.format
-    cfg.nonblock = cfg.nonblock or log_cfg.nonblock
-
-    -- nonblock is special: it has to become integer
-    -- for ffi call but in config we have to save
-    -- true value only for backward compatibility!
-    local nonblock = cfg.nonblock
-
-    if nonblock == nil or nonblock == false then
-        nonblock = 0
+-- Update box.internal.cfg on log config changes
+local function box_cfg_update(key)
+    if key == nil then
+        for km, kb  in pairs(log2box_keys) do
+            box.internal.update_cfg(kb, log_cfg[km])
+        end
     else
-        nonblock = 1
+        box.internal.update_cfg(log2box_keys[key], log_cfg[key])
+    end
+end
+
+local function set_log_level(level)
+    box.internal.check_cfg_option_type(option_types.level, 'level', level)
+    local cfg = table.copy(log_cfg)
+    cfg.level = level
+    log_check_cfg(cfg)
+
+    local cfg_C = log_C_cfg(cfg)
+    ffi.C.say_set_log_level(cfg_C.level)
+    log_cfg.level = level
+
+    box_cfg_update('level')
+
+    log_debug("log: level set to %s", level)
+end
+
+local function set_log_format(format)
+    box.internal.check_cfg_option_type(option_types.format, 'format', format)
+    local cfg = table.copy(log_cfg)
+    cfg.format = format
+    log_check_cfg(cfg)
+
+    ffi.C.say_set_log_format(fmt_str2num[format])
+    log_cfg.format = format
+
+    box_cfg_update('format')
+
+    log_debug("log: format set to '%s'", format)
+end
+
+local function log_configure(self, cfg)
+    cfg = box.internal.prepare_cfg(cfg, default_cfg, option_types)
+    box.internal.merge_cfg(cfg, log_cfg);
+
+    log_check_cfg(cfg)
+    local cfg_C = log_C_cfg(cfg)
+    ffi.C.say_logger_init(cfg_C.log, cfg_C.level,
+                          cfg_C.nonblock, cfg_C.format)
+    log_initialized = true
+
+    for o in pairs(option_types) do
+        log_cfg[o] = cfg[o]
     end
 
-    -- Parsing for validation purposes
-    if cfg.log ~= nil then
-        parse_format(cfg.log)
-    end
-
-    -- We never allow confgure the logger in background
-    -- mode since we don't know how the box will be configured
-    -- later.
-    ffi.C.say_logger_init(cfg.log, cfg.level,
-                          nonblock, cfg.format, 0)
-
-    if nonblock == 1 then
-        nonblock = true
-    else
-        nonblock = nil
-    end
-
-    -- Update log_cfg vars to show them in module
-    -- configuration output.
-    rawset(log_cfg, 'log', cfg.log)
-    rawset(log_cfg, 'level', cfg.level)
-    rawset(log_cfg, 'nonblock', nonblock)
-    rawset(log_cfg, 'format', cfg.format)
-
-    -- and box.cfg output as well.
     box_cfg_update()
 
-    local m = "log.cfg({log=%s,level=%s,nonblock=%s,format=\'%s\'})"
-    say(S_DEBUG, m:format(cfg.log, cfg.level, cfg.nonblock, cfg.format))
+    log_debug("log.cfg({log=%s, level=%s, nonblock=%s, format=%s})",
+              cfg.log, cfg.level, cfg.nonblock, cfg.format)
+end
+
+local function box_to_log_cfg()
+    return {
+        log = box.cfg.log,
+        level = box.cfg.log_level,
+        format = box.cfg.log_format,
+        nonblock = box.cfg.log_nonblock,
+    }
 end
 
 local compat_warning_said = false
@@ -648,23 +397,21 @@ local compat_v16 = {
 }
 
 local log = {
-    warn = say_closure(S_WARN),
-    info = say_closure(S_INFO),
-    verbose = say_closure(S_VERBOSE),
-    debug = say_closure(S_DEBUG),
-    error = say_closure(S_ERROR),
+    warn = log_warn,
+    info = log_info,
+    verbose = log_verbose,
+    debug = log_debug,
+    error = log_error,
     rotate = log_rotate,
     pid = log_pid,
-    level = log_level,
-    log_format = log_format,
+    level = set_log_level,
+    log_format = set_log_format,
     cfg = setmetatable(log_cfg, {
-        __call = load_cfg,
+        __call = log_configure,
     }),
     box_api = {
-        cfg_get = box_api_cfg_get,
-        cfg_set = box_api_cfg_set,
-        cfg_set_log_level = box_api_cfg_set_log_level,
-        cfg_set_log_format = box_api_set_log_format,
+        cfg = function() log_configure(log_cfg, box_to_log_cfg()) end,
+        cfg_check = function() log_check_cfg(box_to_log_cfg()) end,
     },
     internal = {
         ratelimit = {

--- a/src/lua/utils.c
+++ b/src/lua/utils.c
@@ -500,6 +500,22 @@ luaT_call(struct lua_State *L, int nargs, int nreturns)
 }
 
 int
+luaT_dostring(struct lua_State *L, const char *str)
+{
+	int top = lua_gettop(L);
+	if (luaL_loadstring(L, str) != 0) {
+		diag_set(LuajitError, lua_tostring(L, -1));
+		lua_settop(L, top);
+		return -1;
+	}
+	if (luaT_call(L, 0, LUA_MULTRET) != 0) {
+		lua_settop(L, top);
+		return -1;
+	}
+	return 0;
+}
+
+int
 luaT_cpcall(lua_State *L, lua_CFunction func, void *ud)
 {
 	if (lua_cpcall(L, func, ud))

--- a/src/lua/utils.h
+++ b/src/lua/utils.h
@@ -317,6 +317,13 @@ luaL_toint64(struct lua_State *L, int idx);
 LUA_API int
 luaT_call(lua_State *L, int nargs, int nreturns);
 
+/*
+ * Like luaL_dostring(), but in case of error sets fiber diag instead
+ * of putting error on stack.
+ */
+int
+luaT_dostring(struct lua_State *L, const char *str);
+
 /**
  * Like lua_cpcall(), but with the proper support of Tarantool errors.
  * \sa lua_cpcall()

--- a/static-build/test/static-build/exports.test.lua
+++ b/static-build/test/static-build/exports.test.lua
@@ -72,7 +72,6 @@ local check_symbols = {
     'crc32_calc',
     'decimal_unpack',
 
-    'log_type',
     'say_set_log_level',
     'say_logrotate',
     'say_set_log_format',

--- a/test/app-tap/gh-5130-panic-on-invalid-log.test.lua
+++ b/test/app-tap/gh-5130-panic-on-invalid-log.test.lua
@@ -18,6 +18,6 @@ test:ok(ok)
 
 -- Dynamic reconfiguration - error, no info about invalid logger type
 _, err = pcall(log.cfg, {log=' :invalid'})
-test:like(err, "can't be set dynamically")
+test:like(err, "Can't set option 'log' dynamically")
 
 os.exit(test:check() and 0 or 1)

--- a/test/app-tap/logger.test.lua
+++ b/test/app-tap/logger.test.lua
@@ -1,21 +1,90 @@
 #!/usr/bin/env tarantool
 
+local log = require('log')
+
 local test = require('tap').test('log')
-test:plan(64)
+test:plan(104)
+
+local function test_invalid_cfg(cfg_method, cfg, name, expected)
+    local _, err = pcall(cfg_method, cfg)
+    test:ok(tostring(err):find(expected) ~= nil, name)
+end
+
+local function test_allowed_types(cfg_method, cfg, name, allowed_types)
+    local prefix
+    if string.find(allowed_types, ',') then
+        prefix = 'should be one of types '
+    else
+        prefix = 'should be of type '
+    end
+    test_invalid_cfg(cfg_method, cfg, name, prefix .. allowed_types)
+end
+
+-- Test allowed types for options
+test_allowed_types(log.cfg, {log =  1},
+                   'log.cfg allowed log types', 'string')
+test_allowed_types(log.cfg, {level = true},
+                   'log.cfg allowed level types', 'number, string')
+test_allowed_types(log.cfg, {format = true},
+                   'log.cfg allowed format types', 'string')
+test_allowed_types(log.cfg, {nonblock = 'hi'},
+                   'log.cfg allowed nonblock types', 'boolean')
+test_allowed_types(box.cfg, {log = 1},
+                   'box.cfg allowed log types', 'string')
+test_allowed_types(box.cfg,{log_level = true},
+                   'box.cfg allowed log_level types', 'number, string')
+test_allowed_types(box.cfg, {log_format = true},
+                   'box.cfg allowed log_format types', 'string')
+test_allowed_types(box.cfg, {log_nonblock = 'hi'},
+                   'box.cfg allowed log_nonblock types', 'boolean')
+
+-- Test other invalid inputs
+
+test_invalid_cfg(log.cfg, {log = 'syslog:', format = 'json'},
+                 "log.cfg syslog and json",
+                 "'json' can't be used with syslog logger")
+test_invalid_cfg(box.cfg, {log = 'syslog:', log_format = 'json'},
+                 "box.cfg syslog and json",
+                 "'json' can't be used with syslog logger")
+
+-- Don't check all invalid inputs for both box.cfg and log.cfg as
+-- now they use same check function.
+
+-- gh-7447
+test_invalid_cfg(log.cfg, {log = 'syslog:xxx'},
+                 "log.cfg invalid syslog",
+                 "bad option 'xxx'")
+
+test_invalid_cfg(log.cfg, {log = 'xxx:'},
+                 "log.cfg invalid logger prefix",
+                 "expecting a file name or a prefix, such as " ..
+                    "'|', 'pipe:', 'syslog:'")
+
+test_invalid_cfg(log.cfg, {format = 'xxx'},
+                 "log.cfg invalid format",
+                 "expected 'plain' or 'json'")
+
+test_invalid_cfg(log.cfg, {nonblock = true},
+                 "log.cfg nonblock and stderr",
+                 'the option is incompatible with file/stderr logger')
+
+test_invalid_cfg(log.cfg, {log = '1.log', nonblock = true},
+                 "log.cfg nonblock and file",
+                 'the option is incompatible with file/stderr logger')
+
+test_invalid_cfg(log.cfg, {format = 'xxx'},
+                 "log.cfg invalid format",
+                 "expected 'plain' or 'json'")
+
+test_invalid_cfg(log.cfg, {xxx = 1},
+                 "log.cfg unexpected option",
+                 'unexpected option')
 
 --
 -- gh-5121: Allow to use 'json' output before box.cfg()
 --
-local log = require('log')
 local _, err = pcall(log.log_format, 'json')
 test:ok(err == nil)
-
--- We're not allowed to use json with syslog though.
-_, err = pcall(log.cfg, {log='syslog:', format='json'})
-test:ok(tostring(err):find("can\'t be used with syslog logger") ~= nil)
-
-_, err = pcall(box.cfg, {log='syslog:', log_format='json'})
-test:ok(tostring(err):find("can\'t be used with syslog logger") ~= nil)
 
 -- switch back to plain to next tests
 log.log_format('plain')
@@ -71,6 +140,14 @@ local line = file:read()
 local s = json.decode(line)
 test:ok(s['message'] == message, "message match")
 
+-- Try to change options that can't be changed on first box.cfg()
+test_invalid_cfg(box.cfg, {log = '2.log'},
+                 "reconfigure logger thru first box.cfg",
+                 "Can't set option 'log' dynamically")
+test_invalid_cfg(box.cfg, {log_nonblock = true},
+                 "reconfigure nonblock thru first box.cfg",
+                 "Can't set option 'log_nonblock' dynamically")
+
 -- Now switch to box.cfg interface
 box.cfg{
     log = filename,
@@ -83,21 +160,41 @@ verify_keys("box.cfg")
 
 -- Test symbolic names for loglevels
 log.cfg({level='fatal'})
-test:ok(log.cfg.level == 0 and box.cfg.log_level == 0, 'both got fatal')
+test:ok(log.cfg.level == 'fatal' and box.cfg.log_level == 'fatal',
+        'both got fatal')
 log.cfg({level='syserror'})
-test:ok(log.cfg.level == 1 and box.cfg.log_level == 1, 'both got syserror')
+test:ok(log.cfg.level == 'syserror' and box.cfg.log_level == 'syserror',
+        'both got syserror')
 log.cfg({level='error'})
-test:ok(log.cfg.level == 2 and box.cfg.log_level == 2, 'both got error')
+test:ok(log.cfg.level == 'error' and box.cfg.log_level == 'error',
+        'both got error')
 log.cfg({level='crit'})
-test:ok(log.cfg.level == 3 and box.cfg.log_level == 3, 'both got crit')
+test:ok(log.cfg.level == 'crit' and box.cfg.log_level == 'crit',
+        'both got crit')
 log.cfg({level='warn'})
-test:ok(log.cfg.level == 4 and box.cfg.log_level == 4, 'both got warn')
+test:ok(log.cfg.level == 'warn' and box.cfg.log_level == 'warn',
+        'both got warn')
 log.cfg({level='info'})
-test:ok(log.cfg.level == 5 and box.cfg.log_level == 5, 'both got info')
+test:ok(log.cfg.level == 'info' and box.cfg.log_level == 'info',
+        'both got info')
 log.cfg({level='verbose'})
-test:ok(log.cfg.level == 6 and box.cfg.log_level == 6, 'both got verbose')
+test:ok(log.cfg.level == 'verbose' and box.cfg.log_level == 'verbose',
+        'both got verbose')
 log.cfg({level='debug'})
-test:ok(log.cfg.level == 7 and box.cfg.log_level == 7, 'both got debug')
+test:ok(log.cfg.level == 'debug' and box.cfg.log_level == 'debug',
+        'both got debug')
+
+log.cfg{level = 4}
+test:ok(log.cfg.level == 4, "log.cfg number level then read log.cfg")
+test:ok(box.cfg.log_level == 4, "log.cfg number level then read box.cfg")
+
+box.cfg{log_level = 5}
+test:ok(log.cfg.level == 5, "box.cfg number level then read log.cfg")
+test:ok(box.cfg.log_level == 5, "box.cfg number level then read box.cfg")
+
+box.cfg{log_level = 'warn'}
+test:ok(log.cfg.level == 'warn', "box.cfg string level then read log.cfg")
+test:ok(box.cfg.log_level == 'warn', "box.cfg string level then read box.cfg")
 
 box.cfg{
     log = filename,
@@ -105,24 +202,51 @@ box.cfg{
     memtx_memory = 107374182,
 }
 
--- Now try to change a static field.
-_, err = pcall(box.cfg, {log_level = 5, log = "2.txt"})
-test:ok(tostring(err):find("Can't set option 'log' dynamically") ~= nil,
-        "box.cfg.log cannot be set dynamically")
+-- Try to change options that can't be changed on non-first box.cfg()
+test_invalid_cfg(box.cfg, {log = '2.log'},
+                 "reconfigure logger thru non-first box.cfg",
+                 "Can't set option 'log' dynamically")
 test:ok(box.cfg.log == filename, "filename match")
 test:ok(box.cfg.log_level == 6, "loglevel match")
 verify_keys("box.cfg static error")
 
--- Change format and levels.
-_, err = pcall(log.log_format, 'json')
-test:ok(err == nil, "change to json")
-_, err = pcall(log.level, 1)
-test:ok(err == nil, "change log level")
-verify_keys("log change json and level")
+test_invalid_cfg(box.cfg, {log_nonblock = true},
+                 "reconfigure nonblock thru non-first box.cfg",
+                 "Can't set option 'log_nonblock' dynamically")
 
--- Restore defaults
-log.log_format('plain')
-log.level(5)
+-- Test invalid values for setters
+
+_, err = pcall(log.log_format, {})
+test:ok(tostring(err):find('should be of type string') ~= nil,
+        "invalid format setter value type")
+
+_, err = pcall(log.level, {})
+test:ok(tostring(err):find('should be one of types number, string') ~= nil,
+        "invalid format setter value type")
+
+-- Change format and levels.
+
+_, err = pcall(log.log_format, 'json')
+test:ok(err == nil, "format setter result")
+test:ok(log.cfg.format == 'json', "format setter cfg")
+verify_keys("format setter verify keys")
+
+_, err = pcall(log.level, 1)
+test:ok(err == nil, "level setter number result")
+test:ok(log.cfg.level == 1, "level setter number cfg")
+verify_keys("level setter number verify keys")
+
+_, err = pcall(log.level, 'warn')
+test:ok(err == nil, "change log level")
+test:ok(log.cfg.level == 'warn', "level setter string")
+verify_keys("level setter string verify keys")
+
+-- Check reset works thru log.cfg
+log.cfg{level = box.NULL}
+test:ok(log.cfg.level == 5, "reset of level thru log.cfg")
+
+log.cfg{format = ""}
+test:ok(log.cfg.format == 'plain', "reset of plain thru log.cfg")
 
 --
 -- Check that Tarantool creates ADMIN session for #! script

--- a/test/app-tap/logmod.test.lua
+++ b/test/app-tap/logmod.test.lua
@@ -9,27 +9,27 @@ log.log_format('plain')
 
 -- Test symbolic names for loglevels
 local _, err = pcall(log.cfg, {level='fatal'})
-test:ok(err == nil and log.cfg.level == 0, 'both got fatal')
+test:ok(err == nil and log.cfg.level == 'fatal', 'got fatal')
 
 _, err = pcall(log.cfg, {level='syserror'})
-test:ok(err == nil and log.cfg.level == 1, 'got syserror')
+test:ok(err == nil and log.cfg.level == 'syserror', 'got syserror')
 
 _, err = pcall(log.cfg, {level='error'})
-test:ok(err == nil and log.cfg.level == 2, 'got error')
+test:ok(err == nil and log.cfg.level == 'error', 'got error')
 
 _, err = pcall(log.cfg, {level='crit'})
-test:ok(err == nil and log.cfg.level == 3, 'got crit')
+test:ok(err == nil and log.cfg.level == 'crit', 'got crit')
 
 _, err = pcall(log.cfg, {level='warn'})
-test:ok(err == nil and log.cfg.level == 4, 'got warn')
+test:ok(err == nil and log.cfg.level == 'warn', 'got warn')
 
 _, err = pcall(log.cfg, {level='info'})
-test:ok(err == nil and log.cfg.level == 5, 'got info')
+test:ok(err == nil and log.cfg.level == 'info', 'got info')
 
 _, err = pcall(log.cfg, {level='verbose'})
-test:ok(err == nil and log.cfg.level == 6, 'got verbose')
+test:ok(err == nil and log.cfg.level == 'verbose', 'got verbose')
 
 _, err = pcall(log.cfg, {level='debug'})
-test:ok(err == nil and log.cfg.level == 7, 'got debug')
+test:ok(err == nil and log.cfg.level == 'debug', 'got debug')
 
 os.exit(test:check() and 0 or 1)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -568,3 +568,12 @@ create_unit_test(PREFIX getenv_safe
                  SOURCES getenv_safe.c core_test_utils.c
                  LIBRARIES unit core
 )
+
+create_unit_test(PREFIX lua_utils
+                 SOURCES lua_utils.c
+                 LIBRARIES unit core server
+                           ${LUAJIT_LIBRARIES}
+                           ${CURL_LIBRARIES}
+                           ${LIBYAML_LIBRARIES}
+                           ${READLINE_LIBRARIES}
+)

--- a/test/unit/lua_utils.c
+++ b/test/unit/lua_utils.c
@@ -1,0 +1,140 @@
+#include <stdio.h>
+
+#include "diag.h"
+#include "fiber.h"
+#include "lualib.h"
+#include "memory.h"
+#include "reflection.h"
+
+#include "lua/utils.h"
+
+#define UNIT_TAP_COMPATIBLE 1
+#include "unit.h"
+
+static void
+check_error(const char *type, const char *msg)
+{
+	struct error *err = diag_last_error(&fiber()->diag);
+	ok(strcmp(err->type->name, type) == 0,
+	   "expected %s, got %s", type, err->type->name);
+	ok(strcmp(err->errmsg, msg) == 0,
+	   "expected '%s', got '%s'", msg, err->errmsg);
+}
+
+static void
+test_toerror(lua_State *L)
+{
+	plan(4);
+	header();
+
+	/* test NON Tarantool error on stack */
+	lua_pushstring(L, "test Lua error");
+	luaT_toerror(L);
+	check_error("LuajitError", "test Lua error");
+	/*
+	 * luaT_toerror adds param on stack thru luaT_tolstring.
+	 * Unfortunately the latter is public API.
+	 */
+	lua_pop(L, 2);
+
+	/* test Tarantool error on stack */
+	struct error *e = BuildIllegalParams(__FILE__, __LINE__,
+					     "test non-Lua error");
+	luaT_pusherror(L, e);
+	luaT_toerror(L);
+	check_error("IllegalParams", "test non-Lua error");
+	lua_pop(L, 1);
+
+	footer();
+	check_plan();
+}
+
+static void
+test_call(lua_State *L)
+{
+	plan(6);
+	header();
+
+	int v;
+	const char *expr;
+
+	/* test no error on call */
+	expr = "local a = {...} return a[1], a[2]";
+	fail_unless(luaL_loadstring(L, expr) == 0);
+	lua_pushinteger(L, 3);
+	lua_pushinteger(L, 5);
+	ok(luaT_call(L, 2, 2) == 0, "call no error");
+	fail_if(lua_gettop(L) != 2);
+	v = lua_tointeger(L, -2);
+	is(v, 3, "got %d", v);
+	v = lua_tointeger(L, -1);
+	is(v, 5, "got %d", v);
+	lua_pop(L, 2);
+
+	/* test with error on call */
+	expr = "return error('test error')";
+	fail_unless(luaL_loadstring(L, expr) == 0);
+	ok(luaT_call(L, 0, 0) != 0, "call with error");
+	check_error("LuajitError", "test error");
+	/* See comment is test_toerror about stack size. */
+	lua_pop(L, 2);
+
+	footer();
+	check_plan();
+}
+
+static void
+test_dostring(lua_State *L)
+{
+	plan(11);
+	header();
+
+	int v;
+	/* test no error on call */
+	ok(luaT_dostring(L, "return 3, 5") == 0, "call no error");
+	fail_if(lua_gettop(L) != 2);
+	v = lua_tointeger(L, -2);
+	is(v, 3, "got %d", v);
+	v = lua_tointeger(L, -1);
+	is(v, 5, "got %d", v);
+	lua_pop(L, 2);
+
+	/* test with error on call */
+	const char *expr = "return error('test error')";
+	ok(luaT_dostring(L, expr) != 0, "call with error");
+	check_error("LuajitError", "test error");
+	ok(lua_gettop(L) == 0, "got %d", lua_gettop(L));
+
+	/* test code loading error */
+	ok(luaT_dostring(L, "*") != 0, "code loading error");
+	check_error("LuajitError",
+		    "[string \"*\"]:1: unexpected symbol near '*'");
+	ok(lua_gettop(L) == 0, "got %d", lua_gettop(L));
+
+	footer();
+	check_plan();
+}
+
+int
+main(void)
+{
+	plan(3);
+	header();
+
+	struct lua_State *L = luaL_newstate();
+	luaL_openlibs(L);
+	memory_init();
+	fiber_init(fiber_c_invoke);
+	tarantool_lua_error_init(L);
+
+	test_toerror(L);
+	test_call(L);
+	test_dostring(L);
+
+	fiber_free();
+	memory_free();
+	lua_close(L);
+
+	footer();
+	return check_plan();
+}

--- a/test/unit/memtx_allocator.cc
+++ b/test/unit/memtx_allocator.cc
@@ -499,8 +499,7 @@ test_main()
 int
 main()
 {
-	say_logger_init("/dev/null", S_INFO, /*nonblock=*/true, "plain",
-			/*background=*/false);
+	say_logger_init("/dev/null", S_INFO, /*nonblock=*/true, "plain");
 	clock_lowres_signal_init();
 	memory_init();
 	fiber_init(fiber_c_invoke);

--- a/test/unit/popen.c
+++ b/test/unit/popen.c
@@ -236,7 +236,7 @@ int
 main(int argc, char *argv[])
 {
 #if 0
-	say_logger_init(NULL, S_DEBUG, 0, "plain", 0);
+	say_logger_init(NULL, S_DEBUG, 0, "plain");
 #endif
 	memory_init();
 

--- a/test/unit/raft_test_utils.c
+++ b/test/unit/raft_test_utils.c
@@ -627,7 +627,7 @@ raft_run_test(const char *log_file, fiber_func test)
 	int fd = open(log_file, O_TRUNC);
 	if (fd != -1)
 		close(fd);
-	say_logger_init(log_file, 5, 1, "plain", 0);
+	say_logger_init(log_file, 5, 1, "plain");
 	/* Print the seed to be able to reproduce a bug with the same seed. */
 	say_info("Random seed = %llu", (unsigned long long) seed);
 

--- a/test/unit/say.c
+++ b/test/unit/say.c
@@ -167,7 +167,7 @@ int main()
 {
 	memory_init();
 	fiber_init(fiber_c_invoke);
-	say_logger_init("/dev/null", S_INFO, 0, "plain", 0);
+	say_logger_init("/dev/null", S_INFO, 0, "plain");
 
 	plan(33);
 

--- a/test/unit/swim_proto.c
+++ b/test/unit/swim_proto.c
@@ -257,7 +257,7 @@ main()
 	int fd = open("log.txt", O_TRUNC);
 	if (fd != -1)
 		close(fd);
-	say_logger_init("log.txt", 6, 1, "plain", 0);
+	say_logger_init("log.txt", 6, 1, "plain");
 
 	swim_test_member_def();
 	swim_test_meta();

--- a/test/unit/swim_test_utils.c
+++ b/test/unit/swim_test_utils.c
@@ -866,7 +866,7 @@ swim_run_test(const char *log_file, fiber_func test)
 	int fd = open(log_file, O_TRUNC);
 	if (fd != -1)
 		close(fd);
-	say_logger_init(log_file, 5, 1, "plain", 0);
+	say_logger_init(log_file, 5, 1, "plain");
 	/*
 	 * Print the seed to be able to reproduce a bug with the
 	 * same seed.


### PR DESCRIPTION
- Log configuration on first configuration thru box.cfg() is really painful:

    1. check log cfg validity in scope of private.cfg_check (1)
    2. set log option values to log.cfg in update_module_cfg. We also check log cfg validity (2) here in api.cfg_set and have rollback logic (why he have to?)
    3. make actual log initialization in private.cfg_load()
    4. update dynamic options of log cfg once again. Why? Probably only to make conversions like for log_level from 'warn' to number. We make cfg validity checks here too! (3)

I guess we'd better have only one validity check and don't run step 4 which actually reconfigure log once again only to perform conversion.

- Log API is painfully bloated:

    - log.level - to set log level by user
    - log.box_api.cfg_get - private API to just get log level (why not use just log.cfg.level? Well cfg_get works for 'log_level', a bit different name!)
    - log.box_api.cfg_set - private API to just SAVE log level (do not change log level actually, only saves values to log.cfg)
    - log.box_api.cfg_set_log_level - really change log level, the difference from log.level is it does not get value as argument but reads it from global box.cfg.log_level and throws box.error() instead of error())

And the same for log_format!

I propose to drop box_api completely and use log.cfg (function/table) from load_cfg.lua.

The PR does not fix multiple log config validity check issue completly. I do not include all the patches to keep PR commits number small.

Closes #7447