### PR TITLE
[1.10] ci: enable tests while building deb packages

### DIFF
--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -41,15 +41,8 @@ jobs:
       - name: 'Build tarantool packages for ${{ env.OS }}(${{ env.DIST }})'
         id: run_build
         env:
-          # Our testing expects that the init process (PID 1) will
-          # reap orphan processes. At least the following test leans
-          # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-          PACKPACK_EXTRA_DOCKER_RUN_PARAMS: --init
-          # There are packages like tzdata or postfix, whose configuration
-          # is interactive by default. The environment variable below
-          # forbids interactive configuration phase. Otherwise the CI gets
-          # stuck from time to time on `apt-get update`.
-          DEBIAN_FRONTEND: noninteractive
+          MAKE_CHECK: false
+          PRESERVE_ENVVARS: 'MAKE_CHECK,${{ env.PRESERVE_ENVVARS }}'
         run: make -f .gitlab.mk package
       - name: 'Upload build artifacts'
         uses: actions/upload-artifact@v2

--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,7 @@ tarantool-*.tar.gz
 test/lib/
 test/unit/*.test
 test/unit/fiob
-test/small
+test/small/*.test
 test/var
 test/luajit-tap
 third_party/luajit/src/luajit

--- a/debian/control
+++ b/debian/control
@@ -26,6 +26,9 @@ Build-Depends: cdbs (>= 0.4.100), debhelper (>= 9), dpkg-dev (>= 1.16.1~),
  autoconf, automake, libtool, zlib1g-dev,
 # Install prove to run LuaJIT tests.
  libtest-harness-perl,
+# Install dependencies for functional tests.
+ python3-gevent,
+ python3-yaml,
 Section: database
 Standards-Version: 3.9.8
 Homepage: http://tarantool.org/

--- a/debian/rules
+++ b/debian/rules
@@ -19,6 +19,8 @@ DEB_CMAKE_EXTRA_FLAGS := \
 	-DWITH_SYSVINIT=ON \
 	-DWITH_SYSTEMD=$(WITH_SYSTEMD)
 
+DEB_MAKE_CHECK_TARGET := test-force
+
 # Install tarantool.service within tarantool-common package, but does not
 # install it within tarantool and tarantool-dev packages.
 DEB_DH_INSTALLINIT_ARGS                     := --name=tarantool

--- a/debian/rules
+++ b/debian/rules
@@ -19,7 +19,9 @@ DEB_CMAKE_EXTRA_FLAGS := \
 	-DWITH_SYSVINIT=ON \
 	-DWITH_SYSTEMD=$(WITH_SYSTEMD)
 
-DEB_MAKE_CHECK_TARGET := test-force
+ifneq ($(MAKE_CHECK), false)
+	DEB_MAKE_CHECK_TARGET := test-force
+endif
 
 # Install tarantool.service within tarantool-common package, but does not
 # install it within tarantool and tarantool-dev packages.

--- a/rpm/tarantool.spec
+++ b/rpm/tarantool.spec
@@ -199,8 +199,10 @@ make %{?_smp_mflags}
 # %%doc and %%license macroses are used instead
 rm -rf %{buildroot}%{_datarootdir}/doc/tarantool/
 
+%if "%{getenv:MAKE_CHECK}" != "false"
 %check
 make test-force
+%endif
 
 %pre
 /usr/sbin/groupadd -r tarantool > /dev/null 2>&1 || :

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,13 +28,18 @@ if(POLICY CMP0037)
     cmake_policy(SET CMP0037 OLD)
 endif(POLICY CMP0037)
 
+# The symlink is needed for out-of-source builds. In the case of in-source
+# builds ${CMAKE_CURRENT_BINARY_DIR} == ${PROJECT_SOURCE_DIR}/test and the
+# symlink already exists. It creates the symlink if the destination doesn't
+# exist.
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/small
     COMMAND ${CMAKE_COMMAND} -E create_symlink
-        ${PROJECT_SOURCE_DIR}/src/lib/small/test/
+        ${CMAKE_CURRENT_BINARY_DIR}/../src/lib/small/test/
         ${CMAKE_CURRENT_BINARY_DIR}/small
-        COMMENT Create a symlink for libsmall to fix out-of-source tests)
-add_custom_target(symlink_small_tests ALL
-   DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/small)
+        COMMENT Create the symlink for libsmall test binaries)
+
+add_custom_target(symlink_libsmall_test_binaries ALL
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/small)
 
 add_custom_target(test-unit
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/small

--- a/test/small
+++ b/test/small
@@ -1,0 +1,1 @@
+../src/lib/small/test/


### PR DESCRIPTION
Just a regular backport to bring new infra/test fixes into tarantool 1.10.