### PR TITLE
memtx: fix 'use after free' of garbage collected MVCC stories

### DIFF
--- a/changelogs/unreleased/gh-7449-tuple-is-dirty-assertion-on-replace.md
+++ b/changelogs/unreleased/gh-7449-tuple-is-dirty-assertion-on-replace.md
@@ -1,0 +1,4 @@
+## bugfix/memtx
+
+* Fixed 'use after free' in transaction manager which could occur in certain
+  states (gh-7449).

--- a/src/box/memtx_bitset.cc
+++ b/src/box/memtx_bitset.cc
@@ -211,7 +211,9 @@ bitset_index_iterator_next(struct iterator *iterator, struct tuple **ret)
 		struct index *idx = iterator->index;
 		struct txn *txn = in_txn();
 		struct space *space = space_by_id(iterator->space_id);
+/********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND START*********/
 		*ret = memtx_tx_tuple_clarify(txn, space, tuple, idx, 0);
+/*********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND END**********/
 	} while (*ret == NULL);
 
 	return 0;

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -171,7 +171,9 @@ hash_iterator_eq(struct iterator *it, struct tuple **ret)
 		return 0;
 	struct txn *txn = in_txn();
 	struct space *sp = space_by_id(it->space_id);
+/********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND START*********/
 	*ret = memtx_tx_tuple_clarify(txn, sp, *ret, it->index, 0);
+/*********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND END**********/
 	return 0;
 }
 
@@ -318,9 +320,13 @@ memtx_hash_index_get_internal(struct index *base, const char *key,
 	uint32_t k = light_index_find_key(&index->hash_table, h, key);
 	if (k != light_index_end) {
 		struct tuple *tuple = light_index_get(&index->hash_table, k);
+/********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND START*********/
 		*result = memtx_tx_tuple_clarify(txn, space, tuple, base, 0);
+/*********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND END**********/
 	} else {
+/********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND START*********/
 		memtx_tx_track_point(txn, space, base, key);
+/*********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND END**********/
 	}
 	return 0;
 }
@@ -428,16 +434,20 @@ memtx_hash_index_create_iterator(struct index *base, enum iterator_type type,
 			it->base.next_internal = hash_iterator_ge;
 		}
 		/* This iterator needs to be supported as a legacy. */
+/********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND START*********/
 		memtx_tx_track_full_scan(in_txn(),
 					 space_by_id(it->base.space_id),
 					 &index->base);
+/*********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND END**********/
 		break;
 	case ITER_ALL:
 		light_index_iterator_begin(&index->hash_table, &it->iterator);
 		it->base.next_internal = hash_iterator_ge;
+/********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND START*********/
 		memtx_tx_track_full_scan(in_txn(),
 					 space_by_id(it->base.space_id),
 					 &index->base);
+/*********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND END**********/
 		break;
 	case ITER_EQ:
 		assert(part_count > 0);
@@ -445,9 +455,11 @@ memtx_hash_index_create_iterator(struct index *base, enum iterator_type type,
 				key_hash(key, base->def->key_def), key);
 		it->base.next_internal = hash_iterator_eq;
 		if (it->iterator.slotpos == light_index_end)
+/********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND START*********/
 			memtx_tx_track_point(in_txn(),
 					     space_by_id(it->base.space_id),
 					     &index->base, key);
+/*********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND END**********/
 		break;
 	default:
 		diag_set(UnsupportedIndexFeature, base->def,

--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -159,7 +159,9 @@ index_rtree_iterator_next(struct iterator *i, struct tuple **ret)
 		struct index *idx = i->index;
 		struct txn *txn = in_txn();
 		struct space *space = space_by_id(i->space_id);
+/********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND START*********/
 		*ret = memtx_tx_tuple_clarify(txn, space, *ret, idx, 0);
+/*********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND END**********/
 	} while (*ret == NULL);
 	return 0;
 }
@@ -240,7 +242,9 @@ memtx_rtree_index_get_internal(struct index *base, const char *key,
 			break;
 		struct txn *txn = in_txn();
 		struct space *space = space_by_id(base->def->space_id);
+/********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND START*********/
 		*result = memtx_tx_tuple_clarify(txn, space, tuple, base, 0);
+/*********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND END**********/
 	} while (*result == NULL);
 	rtree_iterator_destroy(&iterator);
 	return 0;

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -725,11 +725,15 @@ tree_iterator_start(struct iterator *iterator, struct tuple **ret)
 		 * We need to clarify the result tuple before story garbage
 		 * collection, otherwise it could get cleaned there.
 		 */
+/********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND START*********/
 		*ret = memtx_tx_tuple_clarify(txn, space, res->tuple, idx,
 					      mk_index);
+/*********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND END**********/
 	}
 	if (key_is_full && !eq_match)
+/********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND START*********/
 		memtx_tx_track_point(txn, space, idx, it->key_data.key);
+/*********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND END**********/
 	if (!key_is_full ||
 	    ((type == ITER_GE || type == ITER_LE) && !equals) ||
 	    (type == ITER_GT || type == ITER_LT))
@@ -922,13 +926,17 @@ memtx_tree_index_get_internal(struct index *base, const char *key,
 	if (res == NULL) {
 		*result = NULL;
 		if (part_count == cmp_def->part_count)
+/********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND START*********/
 			memtx_tx_track_point(txn, space, base, key);
+/*********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND END**********/
 		return 0;
 	}
 	bool is_multikey = base->def->key_def->is_multikey;
 	uint32_t mk_index = is_multikey ? (uint32_t)res->hint : 0;
+/********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND START*********/
 	*result = memtx_tx_tuple_clarify(txn, space, res->tuple, base,
 					 mk_index);
+/*********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND END**********/
 	return 0;
 }
 

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1327,10 +1327,7 @@ memtx_tx_story_gc_step()
 	memtx_tx_story_delete(story);
 }
 
-/**
- * Run several rounds of memtx_tx_story_gc_step()
- */
-static void
+void
 memtx_tx_story_gc()
 {
 	for (size_t i = 0; i < txm.must_do_gc_steps; i++)
@@ -1955,8 +1952,6 @@ memtx_tx_history_add_insert_stmt(struct txn_stmt *stmt,
 		 */
 		tuple_ref(*result);
 	}
-
-	memtx_tx_story_gc();
 	return 0;
 
 fail:
@@ -2024,7 +2019,6 @@ memtx_tx_history_add_delete_stmt(struct txn_stmt *stmt,
 		 */
 		tuple_ref(*result);
 	}
-	memtx_tx_story_gc();
 	return 0;
 }
 
@@ -2038,6 +2032,7 @@ memtx_tx_history_add_stmt(struct txn_stmt *stmt, struct tuple *old_tuple,
 	assert(new_tuple != NULL || old_tuple != NULL);
 	assert(new_tuple == NULL || !tuple_has_flag(new_tuple, TUPLE_IS_DIRTY));
 
+	memtx_tx_story_gc();
 	if (new_tuple != NULL)
 		return memtx_tx_history_add_insert_stmt(stmt, old_tuple,
 							new_tuple, mode,
@@ -2327,6 +2322,7 @@ memtx_tx_history_prepare_stmt(struct txn_stmt *stmt)
 		stmt->add_story->add_psn = stmt->txn->psn;
 	if (stmt->del_story != NULL)
 		stmt->del_story->del_psn = stmt->txn->psn;
+	memtx_tx_story_gc();
 }
 
 void
@@ -2341,6 +2337,7 @@ memtx_tx_history_commit_stmt(struct txn_stmt *stmt, size_t *bsize)
 		*bsize -= tuple_bsize(stmt->del_story->tuple);
 		memtx_tx_story_unlink_deleted_by(stmt->del_story, stmt);
 	}
+	memtx_tx_story_gc();
 }
 
 /**
@@ -2436,8 +2433,11 @@ memtx_tx_tuple_clarify_slow(struct txn *txn, struct space *space,
 			    uint32_t mk_index)
 {
 	bool is_prepared_ok = detect_whether_prepared_ok(txn);
-	return memtx_tx_tuple_clarify_impl(txn, space, tuple, index, mk_index,
-					   is_prepared_ok);
+	struct tuple *res =
+		memtx_tx_tuple_clarify_impl(txn, space, tuple, index, mk_index,
+					    is_prepared_ok);
+	memtx_tx_story_gc();
+	return res;
 }
 
 uint32_t
@@ -2468,6 +2468,7 @@ memtx_tx_index_invisible_count_slow(struct txn *txn,
 		if (visible == NULL)
 			res++;
 	}
+	memtx_tx_story_gc();
 	return res;
 }
 
@@ -2504,6 +2505,7 @@ memtx_tx_on_index_delete(struct index *index)
 					  in_full_scans);
 		memtx_tx_full_scan_item_delete(item);
 	}
+	memtx_tx_story_gc();
 }
 
 void
@@ -2589,7 +2591,6 @@ memtx_tx_track_read_story_slow(struct txn *txn, struct memtx_story *story,
 	}
 	rlist_add(&story->reader_list, &tracker->in_reader_list);
 	rlist_add(&txn->read_set, &tracker->in_read_set);
-	memtx_tx_story_gc();
 	return 0;
 }
 
@@ -2606,6 +2607,11 @@ memtx_tx_track_read_story(struct txn *txn, struct space *space,
 	return memtx_tx_track_read_story_slow(txn, story, index_mask);
 }
 
+/**
+ * Record in TX manager that a transaction @txn have read a @tuple in @space.
+ *
+ * @return 0 on success, -1 on memory error.
+ */
 int
 memtx_tx_track_read(struct txn *txn, struct space *space, struct tuple *tuple)
 {
@@ -2765,6 +2771,7 @@ memtx_tx_track_point_slow(struct txn *txn, struct index *index, const char *key)
 	for (uint32_t i = 0; i < def->part_count; i++)
 		mp_next(&tmp);
 	size_t key_len = tmp - key;
+	memtx_tx_story_gc();
 	return point_hole_storage_new(index, key, key_len, txn);
 }
 
@@ -2813,6 +2820,7 @@ memtx_tx_gap_item_new(struct txn *txn, enum iterator_type type,
  * This function must be used for ordered indexes, such as TREE, for queries
  * when interation type is not EQ or when the key is not full (otherwise
  * it's faster to use memtx_tx_track_point).
+ *
  * @return 0 on success, -1 on memory error.
  */
 int
@@ -2877,6 +2885,7 @@ memtx_tx_full_scan_item_new(struct txn *txn)
  * Record in TX manager that a transaction @a txn have read full @ a index.
  * This function must be used for unordered indexes, such as HASH, for queries
  * when interation type is ALL.
+ *
  * @return 0 on success, -1 on memory error.
  */
 int
@@ -2921,6 +2930,7 @@ memtx_tx_clean_txn(struct txn *txn)
 					  in_full_scan_list);
 		memtx_tx_full_scan_item_delete(item);
 	}
+	memtx_tx_story_gc();
 }
 
 static uint32_t
@@ -2992,7 +3002,6 @@ memtx_tx_snapshot_clarify_slow(struct memtx_tx_snapshot_cleaner *cleaner,
 		assert(entry->from == tuple);
 		tuple = entry->to;
 	}
-
 	return tuple;
 }
 

--- a/test/box-luatest/gh_7449_tuple_is_dirty_assertion_on_replace_test.lua
+++ b/test/box-luatest/gh_7449_tuple_is_dirty_assertion_on_replace_test.lua
@@ -1,0 +1,84 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new{
+        alias   = 'dflt',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    cg.server:start()
+    cg.server:exec(function()
+        local s = box.schema.create_space('s')
+        s:create_index('pk')
+        s:create_index('sk1', {unique = false, parts = {{2, 'uint'}}})
+        s:create_index('sk2', {unique = false, parts = {{3, 'uint'}}})
+        s:insert{0, 0, 0}
+        s:insert{1, 1, 1}
+        box.internal.memtx_tx_gc(100)
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+--[[
+Checks that replaced story (the one that was in primary index) does not suddenly
+get garbage collected during `replace` handling.
+]]
+g.test_replaced_story_does_not_get_garbage_collected = function(cg)
+    local stream1 = cg.server.net_box:new_stream()
+    local stream2 = cg.server.net_box:new_stream()
+
+    stream1:begin()
+    stream2:begin()
+
+    -- Pins {0, 0, 0}'s story so it doesn't get garbage collected.
+    stream1.space.s:select{0}
+    -- A gap tracker is attached to {1, 1, 1}'s story.
+    stream2.space.s.index[1]:select({0}, {iterator = 'GT'})
+
+    cg.server:exec(function()
+        box.space.s:delete{0}
+    end)
+
+    -- Releases {0, 0, 0}'s story so it can potentially get garbage collected.
+    stream1:commit()
+
+    cg.server:exec(function()
+        --[[
+        The replaced tuple's story, {0, 0, 0}, can potentially get garbage
+        collected: a gap write is handled with {1, 1, 1} as a successor and read
+        of {1, 1, 1}'s story is tracked, effectively triggering story garbage
+        collection.
+        ]]
+        box.space.s:replace{0, 1, 1}
+    end)
+end
+
+--[[
+Checks that replaced story (the one that was in secondary index 'sk2') does not
+suddenly get garbage collected during `replace` handling.
+]]
+g.test_replaced_story_does_not_get_garbage_collected = function(cg)
+    local stream1 = cg.server.net_box:new_stream()
+    local stream2 = cg.server.net_box:new_stream()
+
+    stream1:begin()
+    stream2:begin()
+
+    stream1.space.s:select{0}
+    stream2.space.s.index[1]:select({0}, {iterator = 'GT'})
+
+    cg.server:exec(function()
+        box.space.s:delete{0}
+    end)
+
+    stream1:commit()
+
+    cg.server:exec(function()
+        box.space.s:replace{0, 1, 0}
+    end)
+end


### PR DESCRIPTION
`directly_replaced` stories can potentially get garbage collected in
`memtx_tx_handle_gap_write`, which is unexpected and leads to 'use after
free': in order to fix this, limit garbage collection points only to
external API calls.

Wrap all possible garbage collection points with explicit warnings (see
https://github.com/tarantool/tarantool/commit/c9981a567c74d494064499e555c5a995133d7019).

Closes https://github.com/tarantool/tarantool/issues/7449