### PR TITLE
box: return 1-based fkey field numbers to Lua

### DIFF
--- a/changelogs/unreleased/gh-7350-1-based-fkey-field-no.md
+++ b/changelogs/unreleased/gh-7350-1-based-fkey-field-no.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed incorrect number of a foreign key field returned by
+  `space_object:format()` or `space_object.foreign_key` (gh-7350).

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -550,24 +550,25 @@ local function normalize_foreign_key_one(def, error_prefix, is_complex,
         box.error(box.error.ILLEGAL_PARAMS,
                   error_prefix .. "foreign key: space must be string or number")
     end
+    local field = def.field
     if not is_complex then
-        if type(def.field) ~= 'string' and type(def.field) ~= 'number' then
+        if type(field) ~= 'string' and type(field) ~= 'number' then
             box.error(box.error.ILLEGAL_PARAMS,
                       error_prefix .. "foreign key: field must be string or number")
         end
-        if type(def.field) == 'number' then
+        if type(field) == 'number' then
             -- convert to zero-based index.
-            def.field = def.field - 1
+            field = field - 1
         end
     else
-        if type(def.field) ~= 'table' then
+        if type(field) ~= 'table' then
             box.error(box.error.ILLEGAL_PARAMS,
                       error_prefix .. "foreign key: field must be a table " ..
                       "with local field -> foreign field mapping")
         end
         local count = 0
         local converted = {}
-        for k,v in pairs(def.field) do
+        for k,v in pairs(field) do
             count = count + 1
             if type(k) ~= 'string' and type(k) ~= 'number' then
                 box.error(box.error.ILLEGAL_PARAMS,
@@ -594,7 +595,7 @@ local function normalize_foreign_key_one(def, error_prefix, is_complex,
                       error_prefix .. "foreign key: field must be a table " ..
                       "with local field -> foreign field mapping")
         end
-        def.field = setmap(converted)
+        field = setmap(converted)
     end
     if not box.space[def.space] and not fkey_same_space then
         box.error(box.error.ILLEGAL_PARAMS,
@@ -609,9 +610,9 @@ local function normalize_foreign_key_one(def, error_prefix, is_complex,
         end
     end
     if fkey_same_space then
-        return {field = def.field}
+        return {field = field}
     else
-        return {space = box.space[def.space].id, field = def.field}
+        return {space = box.space[def.space].id, field = field}
     end
 end
 

--- a/src/box/lua/space.cc
+++ b/src/box/lua/space.cc
@@ -269,13 +269,14 @@ lbox_push_space_constraint(struct lua_State *L, struct space *space, int i)
 /**
  * Helper function of lbox_push_space_foreign_key.
  * Push a value @a def to the top of lua stack @a L.
+ * ID-defined fields are converted to one-based index.
  */
 static void
 lbox_push_field_id(struct lua_State *L,
 		   struct tuple_constraint_field_id *def)
 {
 	if (def->name_len == 0)
-		lua_pushnumber(L, def->id);
+		lua_pushnumber(L, def->id + 1);
 	else
 		lua_pushstring(L, def->name);
 }

--- a/test/engine-luatest/gh_6436_complex_foreign_key_test.lua
+++ b/test/engine-luatest/gh_6436_complex_foreign_key_test.lua
@@ -283,9 +283,7 @@ g.test_complex_foreign_key_numeric = function(cg)
         local fkey = {cntr = {space=country.id,
                               field={[4]=4, [3]=2, [2]=3}}}
         local city = box.schema.create_space('city', city_space_opts(fkey))
-        t.assert_equals(city.foreign_key,
-                        {cntr = {field = {[1] = 2, [2] = 1, [3] = 3},
-                                 space = country.id}});
+        t.assert_equals(city.foreign_key, fkey)
         city:create_index('pk')
 
         t.assert_equals(country:select{}, {{100, 1, 'earth', 'ru', 'Russia'},

--- a/test/engine-luatest/gh_6436_field_foreign_key_test.lua
+++ b/test/engine-luatest/gh_6436_field_foreign_key_test.lua
@@ -287,12 +287,8 @@ g.test_foreign_key_numeric = function(cg)
         local city = box.schema.create_space('city', {engine=engine, format=fmt})
         -- Check that fmt is not modified by create_space()
         t.assert_equals(fmt_copy, fmt)
-        -- Note that the format was normalized and field converted to zero-based.
-        t.assert_equals(city:format(),
-                        { { name = "id", type = "unsigned"},
-                          { foreign_key = {country = {field = 1, space = country.id}},
-                            name = "country_code", type = "string"},
-                          { name = "name", type = "string"} });
+        -- Check that format() returns one-based field number
+        t.assert_equals(city:format(), fmt)
         city:create_index('pk')
 
         t.assert_equals(country:select{}, {{1, 'ru', 'Russia'}, {2, 'fr', 'France'}})

--- a/test/engine-luatest/gh_6436_field_foreign_key_test.lua
+++ b/test/engine-luatest/gh_6436_field_foreign_key_test.lua
@@ -283,7 +283,10 @@ g.test_foreign_key_numeric = function(cg)
                      {name='country_code', type='string',
                       foreign_key={country={space=country.id, field=2}}},
                      {name='name', type='string'} }
+        local fmt_copy = table.deepcopy(fmt)
         local city = box.schema.create_space('city', {engine=engine, format=fmt})
+        -- Check that fmt is not modified by create_space()
+        t.assert_equals(fmt_copy, fmt)
         -- Note that the format was normalized and field converted to zero-based.
         t.assert_equals(city:format(),
                         { { name = "id", type = "unsigned"},

--- a/test/engine-luatest/gh_7350_fkey_field_no_mismatch_test.lua
+++ b/test/engine-luatest/gh_7350_fkey_field_no_mismatch_test.lua
@@ -1,0 +1,42 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group('gh-7350-fkey-field-no-mismatch',
+                  {{engine = 'memtx'}, {engine = 'vinyl'}})
+
+g.before_all(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:stop()
+    cg.server = nil
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.s2 then box.space.s2:drop() end
+        if box.space.s1 then box.space.s1:drop() end
+    end)
+end)
+
+g.test_fkey_field_no = function(cg)
+    local engine = cg.params.engine
+
+    cg.server:exec(function(engine)
+        local t = require('luatest')
+        local s1 = box.schema.create_space('s1', {engine=engine})
+
+        local fmt = {{name='f1', type='any', foreign_key={k1={space=s1.id, field=2}}},
+                     {name='f2', type='any', foreign_key={k2={space=s1.id, field='f3'}}},
+                     {name='f3', type='any', foreign_key={k3={space=s1.id, field=4}}}}
+        local fkey = {k4={space=s1.id, field={[5]=7, ['f6']='f5', [4]=6}}}
+
+        local opts = {engine=engine, format=fmt, foreign_key=fkey}
+        local s2 = box.schema.create_space('s2', opts)
+
+        t.assert_equals(s2:format(), fmt)
+        t.assert_equals(s2.foreign_key, fkey)
+        t.assert_equals(s2:format(s2:format()), nil)
+    end, {engine})
+end


### PR DESCRIPTION
In Lua field's numbers are counted from base 1, however currently
space:format() and space.foreign_key return zero-based foreign key
fields, which leads to an error on space:format(space:format()).

Closes #7350