### PR TITLE
net.box: fix connection's `error_reconnect` state

### DIFF
--- a/changelogs/unreleased/gh-7473-system-fibers.md
+++ b/changelogs/unreleased/gh-7473-system-fibers.md
@@ -1,0 +1,4 @@
+## feature/core
+
+* Some of the internal fibers (e.g. connection's worker fiber, vinyl fibers
+  and others) cannot be cancelled from the Lua public API anymore (gh-7473).

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -163,9 +163,9 @@ applier_check_sync(struct applier *applier)
 
 /**
  * A helper function to create an applier fiber. Basically, it's a wrapper
- * around fiber_new_xc(), which appends the applier URI to the fiber name and
- * makes the new fiber joinable. Note, this function creates a new fiber, but
- * doesn't start it.
+ * around fiber_new_system_xc(), which appends the applier URI to the fiber name
+ * and makes the new fiber joinable. Note, this function creates a new fiber,
+ * but doesn't start it.
  */
 static struct fiber *
 applier_fiber_new(struct applier *applier, const char *name, fiber_func func)
@@ -173,7 +173,7 @@ applier_fiber_new(struct applier *applier, const char *name, fiber_func func)
 	char buf[FIBER_NAME_MAX];
 	int pos = snprintf(buf, sizeof(buf), "%s/", name);
 	uri_format(buf + pos, sizeof(buf) - pos, &applier->uri, false);
-	struct fiber *f = fiber_new_xc(buf, func);
+	struct fiber *f = fiber_new_system_xc(buf, func);
 	fiber_set_joinable(f, true);
 	return f;
 }

--- a/src/box/gc.c
+++ b/src/box/gc.c
@@ -118,12 +118,12 @@ gc_init(void)
 	fiber_cond_create(&gc.cleanup_cond);
 	checkpoint_schedule_cfg(&gc.checkpoint_schedule, 0, 0);
 
-	gc.cleanup_fiber = fiber_new("gc", gc_cleanup_fiber_f);
+	gc.cleanup_fiber = fiber_new_system("gc", gc_cleanup_fiber_f);
 	if (gc.cleanup_fiber == NULL)
 		panic("failed to start garbage collection fiber");
 
-	gc.checkpoint_fiber = fiber_new("checkpoint_daemon",
-					gc_checkpoint_fiber_f);
+	gc.checkpoint_fiber = fiber_new_system("checkpoint_daemon",
+					       gc_checkpoint_fiber_f);
 	if (gc.checkpoint_fiber == NULL)
 		panic("failed to start checkpoint daemon fiber");
 

--- a/src/box/lua/net_box.c
+++ b/src/box/lua/net_box.c
@@ -2709,7 +2709,7 @@ luaT_netbox_transport_start(struct lua_State *L)
 	const char *name = tt_sprintf("%s:%s (net.box)",
 				      transport->opts.uri.host ?: "",
 				      transport->opts.uri.service ?: "");
-	transport->worker = fiber_new(name, netbox_worker_f);
+	transport->worker = fiber_new_system(name, netbox_worker_f);
 	if (transport->worker == NULL) {
 		luaL_unref(L, LUA_REGISTRYINDEX, transport->coro_ref);
 		transport->coro_ref = LUA_NOREF;

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -1309,7 +1309,7 @@ memtx_engine_new(const char *snap_dirname, bool force_recovery,
 	}
 
 	stailq_create(&memtx->gc_queue);
-	memtx->gc_fiber = fiber_new("memtx.gc", memtx_engine_gc_f);
+	memtx->gc_fiber = fiber_new_system("memtx.gc", memtx_engine_gc_f);
 	if (memtx->gc_fiber == NULL)
 		goto fail;
 

--- a/src/box/raft.c
+++ b/src/box/raft.c
@@ -158,7 +158,8 @@ box_raft_schedule_async(struct raft *raft)
 {
 	assert(raft == box_raft());
 	if (box_raft_worker == NULL) {
-		box_raft_worker = fiber_new("raft_worker", box_raft_worker_f);
+		box_raft_worker = fiber_new_system("raft_worker",
+						   box_raft_worker_f);
 		if (box_raft_worker == NULL) {
 			/*
 			 * XXX: should be handled properly, no need to panic.

--- a/src/box/recovery.cc
+++ b/src/box/recovery.cc
@@ -528,7 +528,7 @@ recovery_follow_local(struct recovery *r, struct xstream *stream,
 	 * xlog.
 	 */
 	assert(r->watcher == NULL);
-	r->watcher = fiber_new_xc(name, hot_standby_f);
+	r->watcher = fiber_new_system(name, hot_standby_f);
 	fiber_set_joinable(r->watcher, true);
 	fiber_start(r->watcher, r, stream, wal_dir_rescan_delay);
 }

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -3501,7 +3501,8 @@ vy_squash_schedule(struct vy_lsm *lsm, struct vy_entry entry, void *arg)
 
 	/* Start the upsert squashing fiber on demand. */
 	if (sq->fiber == NULL) {
-		sq->fiber = fiber_new("vinyl.squash_queue", vy_squash_queue_f);
+		sq->fiber = fiber_new_system("vinyl.squash_queue",
+					     vy_squash_queue_f);
 		if (sq->fiber == NULL)
 			goto fail;
 		fiber_start(sq->fiber, sq);

--- a/src/box/vy_log.c
+++ b/src/box/vy_log.c
@@ -767,8 +767,8 @@ vy_log_init(const char *dir)
 	diag_create(&vy_log.tx_diag);
 	wal_init_vy_log();
 	fiber_cond_create(&vy_log.flusher_cond);
-	vy_log.flusher = fiber_new("vinyl.vylog_flusher",
-				   vy_log_flusher_f);
+	vy_log.flusher = fiber_new_system("vinyl.vylog_flusher",
+					  vy_log_flusher_f);
 	if (vy_log.flusher == NULL)
 		panic("failed to allocate vylog flusher fiber");
 	fiber_wakeup(vy_log.flusher);

--- a/src/box/vy_scheduler.c
+++ b/src/box/vy_scheduler.c
@@ -435,8 +435,8 @@ vy_scheduler_create(struct vy_scheduler *scheduler, int write_threads,
 	scheduler->run_env = run_env;
 	scheduler->quota = quota;
 
-	scheduler->scheduler_fiber = fiber_new("vinyl.scheduler",
-					       vy_scheduler_f);
+	scheduler->scheduler_fiber = fiber_new_system("vinyl.scheduler",
+						      vy_scheduler_f);
 	if (scheduler->scheduler_fiber == NULL)
 		panic("failed to allocate vinyl scheduler fiber");
 

--- a/src/box/watcher.c
+++ b/src/box/watcher.c
@@ -118,8 +118,8 @@ static void
 watchable_wakeup_worker(struct watchable *watchable)
 {
 	if (watchable->worker == NULL) {
-		watchable->worker = fiber_new("box.watchable",
-					      watchable_worker_f);
+		watchable->worker = fiber_new_system("box.watchable",
+						     watchable_worker_f);
 		if (watchable->worker == NULL) {
 			diag_log();
 			panic("failed to start box.watchable worker fiber");

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -1310,6 +1310,22 @@ fiber_new(const char *name, fiber_func f)
 	return fiber_new_ex(name, &fiber_attr_default, f);
 }
 
+/**
+ * Create a new system fiber.
+ *
+ * Works the same way as fiber_new(), but uses fiber_attr_default
+ * supplemented by the FIBER_IS_SYSTEM flag in order to create a
+ * fiber.
+ */
+struct fiber *
+fiber_new_system(const char *name, fiber_func f)
+{
+	struct fiber_attr system_attrs;
+	fiber_attr_create(&system_attrs);
+	system_attrs.flags |= FIBER_IS_SYSTEM;
+	return fiber_new_ex(name, &system_attrs, f);
+}
+
 /** Free all fiber's resources. */
 static void
 fiber_destroy(struct cord *cord, struct fiber *f)

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -170,6 +170,10 @@ enum {
 	 * This flag is set when fiber has custom max slice.
 	 */
 	FIBER_CUSTOM_SLICE	= 1 << 8,
+	/**
+	 * This flag idicates, if the fiber can be killed from the Lua world.
+	 */
+	FIBER_IS_SYSTEM         = 1 << 9,
 	FIBER_DEFAULT_FLAGS = FIBER_IS_CANCELLABLE
 };
 
@@ -850,6 +854,20 @@ cord_is_main(void);
 void
 cord_collect_garbage(struct cord *cord);
 
+/**
+ * @brief Create a new system fiber.
+ *
+ * @details
+ * Works the same way as fiber_new(), but uses fiber_attr_default
+ * supplemented by the FIBER_IS_SYSTEM flag in order to create a
+ * fiber.
+ *
+ * @param name       string with fiber name
+ * @param fiber_func func for run inside fiber
+ */
+struct fiber *
+fiber_new_system(const char *name, fiber_func f);
+
 void
 fiber_init(int (*fiber_invoke)(fiber_func f, va_list ap));
 
@@ -1035,19 +1053,19 @@ void
 fiber_top_disable(void);
 
 #ifdef ENABLE_BACKTRACE
-/*
+/**
  * Returns current value of fiber parent backtrace collection option.
  */
 bool
 fiber_parent_backtrace_is_enabled(void);
 
-/*
+/**
  * Enables collection of fiber parent's backtrace.
  */
 void
 fiber_parent_backtrace_enable(void);
 
-/*
+/**
  * Disables collection of fiber parent's backtrace.
  */
 void
@@ -1064,7 +1082,7 @@ fiber_c_invoke(fiber_func f, va_list ap)
 #if defined(__cplusplus)
 } /* extern "C" */
 
-/*
+/**
  * Test if this fiber is in a cancellable state and was indeed
  * cancelled, and raise an exception (FiberIsCancelled) if
  * that's the case.
@@ -1087,6 +1105,20 @@ static inline struct fiber *
 fiber_new_xc(const char *name, fiber_func func)
 {
 	struct fiber *f = fiber_new(name, func);
+	if (f == NULL) {
+		diag_raise();
+		unreachable();
+	}
+	return f;
+}
+
+/**
+ * The same as fiber_new_system(), but throws an exception
+ */
+static inline struct fiber *
+fiber_new_system_xc(const char *name, fiber_func func)
+{
+	struct fiber *f = fiber_new_system(name, func);
 	if (f == NULL) {
 		diag_raise();
 		unreachable();

--- a/src/lib/swim/swim.c
+++ b/src/lib/swim/swim.c
@@ -1920,8 +1920,8 @@ swim_new(uint64_t generation)
 	rlist_create(&swim->dissemination_queue);
 	rlist_create(&swim->on_member_event);
 	stailq_create(&swim->event_queue);
-	swim->event_handler = fiber_new("SWIM event handler",
-					swim_event_handler_f);
+	swim->event_handler = fiber_new_system("SWIM event handler",
+					       swim_event_handler_f);
 	if (swim->event_handler == NULL) {
 		swim_delete(swim);
 		return NULL;

--- a/src/lua/fiber.c
+++ b/src/lua/fiber.c
@@ -667,6 +667,10 @@ static int
 lbox_fiber_cancel(struct lua_State *L)
 {
 	struct fiber *f = lbox_checkfiber(L, 1);
+	if ((f->flags & FIBER_IS_SYSTEM) != 0) {
+		/* System fibers can't be cancelled from Lua. */
+		return 0;
+	}
 	fiber_cancel(f);
 	/*
 	 * Check if we're ourselves cancelled.

--- a/src/main.cc
+++ b/src/main.cc
@@ -127,7 +127,7 @@ static void
 sig_checkpoint(ev_loop * /* loop */, struct ev_signal * /* w */,
 	     int /* revents */)
 {
-	struct fiber *f = fiber_new("checkpoint", sig_checkpoint_f);
+	struct fiber *f = fiber_new_system("checkpoint", sig_checkpoint_f);
 	if (f == NULL) {
 		say_warn("failed to allocate checkpoint fiber");
 		return;
@@ -763,6 +763,7 @@ main(int argc, char **argv)
 		 */
 		struct fiber_attr attr;
 		fiber_attr_create(&attr);
+		attr.flags |= FIBER_IS_SYSTEM;
 		attr.flags &= ~FIBER_IS_CANCELLABLE;
 		on_shutdown_fiber = fiber_new_ex("on_shutdown",
 						 &attr,

--- a/test/app-luatest/system_fiber_test.lua
+++ b/test/app-luatest/system_fiber_test.lua
@@ -1,0 +1,41 @@
+local server = require('test.luatest_helpers.server')
+local g = require('luatest').group()
+
+g.before_all = function()
+    g.server = server:new{alias = 'default'}
+    g.server:start()
+end
+
+g.after_all = function()
+    g.server:drop()
+end
+
+g.test_system_fibers = function()
+    g.server:exec(function(uri)
+        local fiber = require('fiber')
+        local t = require('luatest')
+
+        local conn = require('net.box').connect(uri)
+        local is_system = function(name)
+            return name:endswith('(net.box)') or
+                   name == 'gc' or name == 'checkpoint_daemon' or
+                   name:startswith('vinyl.')
+        end
+
+        local system_fibers = {}
+        for fid, f in pairs(fiber.info()) do
+            if is_system(f.name) then
+                -- fiber.find() + fiber:cancel() == fiber.kill()
+                local fiber_temp = fiber.find(fid)
+                table.insert(system_fibers, fiber_temp)
+                fiber_temp:cancel()
+            end
+        end
+
+        fiber.yield()
+        t.assert(conn:ping())
+        for _, f in pairs(system_fibers) do
+            t.assert(f:status() ~= 'dead')
+        end
+    end, {g.server.net_box_uri})
+end


### PR DESCRIPTION
Currently if we kill worker fiber of the connection, which was
initialized with `reconnect_after` option, we get `error_reconnect`
state. But reconnect obviously doesn't happen.

Let's try to solve that problem) 

Closes #7448
Closes  #7473 