### PR TITLE
ci: call reusable_build.yml from 1.10 branch

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,7 +40,7 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'full-ci') ||
           contains(github.event.pull_request.labels.*.name, 'integration-ci') )
 
-    uses: tarantool/tarantool/.github/workflows/reusable_build.yml@master
+    uses: tarantool/tarantool/.github/workflows/reusable_build.yml@1.10
     with:
       ref: ${{ github.sha }}
       os: ubuntu


### PR DESCRIPTION
This patch fixes the integration.yml workflow by calling the
reusable_build.yml workflow from the 1.10 branch. This commit
should be reverted before cherry-picking commits related to
the `.pack.mk` file changes [1] as the cherry-pick will fix
the problem.

Of course, we can cherry-pick [1] and resolve conflicts.
But it is better to keep historical timeline: first merge openssl
fixes [2], then enable testing on Debian [3], then cherry-pick
`.pack.mk` file changes [1]. Merging commits in this order will
not produce merge conflicts.

[1] https://github.com/tarantool/tarantool/pull/7406
[2] https://github.com/tarantool/tarantool/pull/7475
[3] https://github.com/tarantool/tarantool/pull/7462