### PR TITLE
ci: make LuaJIT integration workflow rerunnable

### DIFF
--- a/.github/workflows/luajit-integration.yml
+++ b/.github/workflows/luajit-integration.yml
@@ -62,7 +62,13 @@ jobs:
           export GIT_COMMITTER_EMAIL="noreply@tarantool.org"
           export GIT_AUTHOR_NAME="LuaJIT integration testing workflow"
           export GIT_AUTHOR_EMAIL="noreply@tarantool.org"
-          git commit -m "luajit: integration testing bump" third_party/luajit
+          # XXX: --allow-empty is required to rerun flaky tests
+          # for tarantool/luajit HEAD when it is already bumped
+          # in tarantool/tarantool repo to the same revision.
+          # Otherwise the command below fails with "nothing to
+          # commit" reason.
+          git commit --allow-empty -m "luajit: integration testing bump" \
+            third_party/luajit
 
       - name: Set environment
         uses: ./.github/actions/environment


### PR DESCRIPTION
If Tarantool tests fail in LuaJIT integration workflow used in
tarantool/luajit repository and LuaJIT submodule is already bumped in
tarantool/tarantool repository, one can't rerun the failed job since
"LuaJIT bump" step brings down the whole pipeline with "nothing to
commit" reason.

There are still many flaky tests, so to make these integration workflow
rerunnable from tarantool/luajit repository --allow-empty option is
added to git commit command.

NO_DOC=ci
NO_TEST=ci
NO_CHANGELOG=ci