### PR TITLE
box: fix `thread_id` check in `box.stat.net.thread[]`

### DIFF
--- a/changelogs/unreleased/gh-7196-fix-box-stat-net-thread.md
+++ b/changelogs/unreleased/gh-7196-fix-box-stat-net-thread.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a crash when `box.stat.net.thread[i]` is called with invalid `i`
+  (gh-7196).

--- a/src/box/lua/stat.c
+++ b/src/box/lua/stat.c
@@ -242,7 +242,7 @@ static int
 lbox_stat_net_thread_index(struct lua_State *L)
 {
 	const int thread_id = luaL_checkinteger(L, -1) - 1;
-	if (thread_id < 0 || thread_id > iproto_threads_count)
+	if (thread_id < 0 || thread_id >= iproto_threads_count)
 		return 0;
 
 	lua_newtable(L);

--- a/test/box/gh-6293-implement-new-net-stat.result
+++ b/test/box/gh-6293-implement-new-net-stat.result
@@ -269,6 +269,15 @@ assert(
 ---
 - true
 ...
+-- Check that box.stat.net.thread[i] does not crash for incorrect i
+test_run:cmd("eval test 'return box.stat.net.thread[0]'");
+---
+- [null]
+...
+test_run:cmd(string.format("eval test 'return box.stat.net.thread[%d]'", thread_count + 1));
+---
+- [null]
+...
 test_run:cmd("setopt delimiter ''");
 ---
 - true

--- a/test/box/gh-6293-implement-new-net-stat.test.lua
+++ b/test/box/gh-6293-implement-new-net-stat.test.lua
@@ -192,6 +192,10 @@ assert(
     total_t_call == request_count + service_total_msg_count and
     in_progress_t_call  == request_count + service_in_progress_msg_count
 );
+-- Check that box.stat.net.thread[i] does not crash for incorrect i
+test_run:cmd("eval test 'return box.stat.net.thread[0]'");
+test_run:cmd(string.format("eval test 'return box.stat.net.thread[%d]'", thread_count + 1));
+
 test_run:cmd("setopt delimiter ''");
 
 test_run:cmd("stop server test")


### PR DESCRIPTION
The valid range for `thread_id` is `[0, iproto_threads_count - 1]`.

Closes #7196