### PR TITLE
Fix start of Tarantool with passed TT_BACKGROUND=true

### DIFF
--- a/changelogs/unreleased/gh-6128-fix-crash-with-background-env-option.md
+++ b/changelogs/unreleased/gh-6128-fix-crash-with-background-env-option.md
@@ -1,0 +1,5 @@
+## bugfix/core
+
+* Fixed a crash that could happen when Tarantool is started in the
+  [background mode](https://www.tarantool.io/en/doc/latest/reference/configuration/#confval-background)
+  (gh-6128).

--- a/test/app-luatest/gh_6128_background_mode_test.lua
+++ b/test/app-luatest/gh_6128_background_mode_test.lua
@@ -1,0 +1,108 @@
+local t = require("luatest")
+local popen = require("popen")
+local fio = require("fio")
+local g = t.group()
+
+local msg_opt_processing = "entering the event loop"
+
+local function tarantool_path(arg)
+    local index = -2
+    -- arg[-1] is guaranteed to be non-null
+    while arg[index] do index = index - 1 end
+    return arg[index + 1]
+end
+
+local function check_err_msg(file, msg)
+    local f = io.open(file, "rb")
+    t.assert_not_equals(f, nil)
+    local content = f:read("*all")
+    f:close()
+    return (string.match(content, msg) and true) or false
+end
+
+local TARANTOOL_PATH = tarantool_path(arg)
+
+g.before_test("test_background_mode_box_cfg", function()
+    g.work_dir = fio.tempdir()
+    g.log_path = fio.pathjoin(g.work_dir, "tarantool.log")
+    g.pid_path = fio.pathjoin(g.work_dir, "tarantool.pid")
+
+    t.assert_equals(fio.path.exists(g.log_path), false)
+    t.assert_equals(fio.path.exists(g.pid_path), false)
+
+    local box_cfg = string.format([[-e box.cfg{
+pid_file='%s', background=true, work_dir='%s', log='%s', log_level=7,
+}]], g.pid_path, g.work_dir, g.log_path)
+    local cmd = {
+        TARANTOOL_PATH, box_cfg,
+    }
+    g.ph = popen.new(cmd, {
+        stderr = popen.opts.PIPE,
+        stdin = popen.opts.PIPE,
+        stdout = popen.opts.PIPE,
+    })
+
+    -- Start Tarantool and check that at least a log file has been created.
+    t.assert_is_not(g.ph, nil)
+    t.helpers.retrying({timeout = 2, delay = 0.01}, function(path)
+        assert(fio.path.exists(path) == true)
+    end, g.log_path)
+end)
+
+g.after_test("test_background_mode_box_cfg", function(cg)
+    cg.ph:terminate()
+    cg.ph:wait()
+    cg.ph:close()
+    fio.unlink(cg.pid_path)
+    fio.unlink(cg.log_path)
+    os.remove("*.xlog")
+    os.remove("*.snap")
+end)
+
+g.test_background_mode_box_cfg = function(cg)
+    t.helpers.retrying({timeout = 2, delay = 0.01}, function()
+        assert(check_err_msg(cg.log_path, msg_opt_processing) == true)
+    end, cg.log_path, cg.ph)
+end
+
+g.before_test("test_background_mode_env_vars", function()
+    local cmd = { TARANTOOL_PATH, "-e",  "box.cfg{}" }
+    g.work_dir = fio.tempdir()
+    g.log_path = fio.pathjoin(g.work_dir, "tarantool.log")
+    g.pid_path = fio.pathjoin(g.work_dir, "tarantool.pid")
+    t.assert_equals(fio.path.exists(g.log_path), false)
+    t.assert_equals(fio.path.exists(g.pid_path), false)
+
+    local env = {}
+    env["TT_PID_FILE"] = g.pid_path
+    env["TT_LOG"] = g.log_path
+    env["TT_BACKGROUND"] = "true"
+    env["TT_WORK_DIR"] = g.work_dir
+    g.ph = popen.new(cmd, {
+        stderr = popen.opts.PIPE,
+        stdin = popen.opts.PIPE,
+        stdout = popen.opts.PIPE,
+        env = env,
+    })
+    t.assert_is_not(g.ph, nil)
+    t.helpers.retrying({timeout = 2, delay = 0.01}, function(path)
+        assert(fio.path.exists(path) == true)
+    end, g.log_path)
+end)
+
+g.after_test("test_background_mode_env_vars", function(cg)
+    cg.ph:terminate()
+    cg.ph:wait()
+    cg.ph:close()
+    fio.unlink(cg.pid_path)
+    fio.unlink(cg.log_path)
+    os.remove("*.xlog")
+    os.remove("*.snap")
+end)
+
+g.test_background_mode_env_vars = function(cg)
+    t.helpers.retrying({timeout = 2, delay = 0.01}, function()
+        assert(check_err_msg(cg.log_path, msg_opt_processing) == true)
+    end, cg.log_path, cg.ph)
+    check_err_msg(cg.log_path, msg_opt_processing)
+end


### PR DESCRIPTION
### Commits:

**lua: fix crash on running in background mode**
    
Tarantool with background mode enabled via environment variable could lead a crash:
    
```
$ TT_PID_FILE=tarantool.pid TT_LOG=tarantool.log TT_BACKGROUND=true TT_LISTEN=3301 tarantool -e 'box.cfg{}'
$ tail -3 tarantool.log
2021-11-02 16:05:43.672 [2341202] main init.c:696 E> LuajitError: cannot read stdin: Resource temporarily unavailable
2021-11-02 16:05:43.672 [2341202] main F> fatal error, exiting the event loop
2021-11-02 16:05:43.672 [2341202] main F> fatal error, exiting the event loop
```
    
Patch fixes a crash.

**src: disable raise in cfg**
    
   
Needed for #6128

**lua: use https protocol in a crash report message**

-------

Other testcases were tested too:                                                 

```                                                                                   
$ TT_PID_FILE=tarantool.pid TT_LOG=tarantool.log TT_BACKGROUND=true TT_LISTEN=3301 ./build/src/tarantool < box.cfg.lua
$ echo "box.cfg{}" | TT_PID_FILE=tarantool.pid TT_LOG=tarantool.log TT_BACKGROUND=true TT_LISTEN=3301 ./build/src/tarantool -
$ ./build/src/tarantool -l fiber -e 'fiber.sleep(1) box.cfg{background=true, log="tarantool.log", pid_file="tarantool.pid"}'
                                                                                   
(T="$(realpath ./build/src/tarantool)";                                          
 I=$(realpath third_party/luajit/test/luajit-test-init.lua);                     
 cd third_party/luajit/test/lua-Harness-tests;                                   
 export LUA_PATH="$(realpath .)/?.lua;;";                                        
 "${T}" -e "dofile[[${I}]]" -l profile_tarantool 241-standalone.t)               
```                                                                              
                                                                                  
Git history shows that case with `TT_BACKGROUND=true` never worked.                                                                                 
Related commits:
 
- commit 1b330121ec7d ("box: set box.cfg options via environment variables")        
- commit 9db64aedbfe2 ("lua: add '-' command line option") 

Fixes #6128

------

Regarding chosen way of toggling panics in cfg.

I have considered a number of methods to call `cfg_*` functions without panics.

1. pass an additional parameter to `cfg_*` functions  - it will change function's interface. But it is desirable.
2. [varargs](https://en.cppreference.com/w/c/variadic) is not suitable, because we need to pass two additional parameters to each `cfg_*` functions: params and their length. It will change interface, when it i snot desirable.
```c
static void                                                                                                                                
cfg_get(const char *param, ...)
    int panic = 1;
    va_list args;
    va_start(args, param);
    panic = va_arg(args, int);
    printf("cfg_get background %d\n", panic);
    va_end(args);
    ...
```
3. I chose a way with new functions that enable/disable panics via global variable.