### PR TITLE
memtx: fix HASH index 'GT' iterator `next` method set incorrectly

### DIFF
--- a/changelogs/unreleased/gh-7477-memtx-hash-idx-gt-iter-dirty-reads.md
+++ b/changelogs/unreleased/gh-7477-memtx-hash-idx-gt-iter-dirty-reads.md
@@ -1,0 +1,3 @@
+## bugfix/memtx
+
+* Fixed dirty reads in HASH index 'GT' iterator (gh-7477).

--- a/test/box-luatest/gh_7477_memtx_hash_idx_gt_iter_dirty_reads_test.lua
+++ b/test/box-luatest/gh_7477_memtx_hash_idx_gt_iter_dirty_reads_test.lua
@@ -1,0 +1,43 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new{
+        alias   = 'dflt',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    cg.server:start()
+    cg.server:exec(function()
+        local s = box.schema.create_space('s')
+        s:create_index('pk', {type = 'HASH'})
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+--[[
+Checks that HASH index `select` with `GT` iterator does not return dirty tuples.
+]]
+g.test_memtx_hash_idx_gt_iterator_dirty_reads = function(cg)
+    local stream1 = cg.server.net_box:new_stream()
+    local stream2 = cg.server.net_box:new_stream()
+    local stream3 = cg.server.net_box:new_stream()
+    local stream4 = cg.server.net_box:new_stream()
+
+    stream1:begin()
+    stream2:begin()
+    stream3:begin()
+    stream4:begin()
+
+    stream1.space.s:insert{4}
+    stream2.space.s:insert{8}
+
+    stream3.space.s:insert{2}
+    stream3:commit()
+
+    t.assert_equals(stream4.space.s:select({8}, {iterator = 'GT'}), {{2}})
+end


### PR DESCRIPTION
The `next` method of memtx HASH index 'GT' iterator is initially set to
'GT' and is supposed to be set to 'GE' after first iteration: it is
mistakenly set to the 'base' method instead of the full method which also
does tuple clarification — this allows dirty reads. Move the `next` method
change on first iteration to `WRAP_ITERATOR_METHOD` for clarity and
correctness.

Closes #7477