### PR TITLE
ci: add `ninja` package to deps for FreeBSD/OSX

### DIFF
--- a/.github/actions/install-deps-freebsd/action.yml
+++ b/.github/actions/install-deps-freebsd/action.yml
@@ -11,6 +11,7 @@ runs:
         pkg install -y \
           cmake \
           gmake \
+          ninja \
           icu \
           libiconv \
           python38 \

--- a/.github/actions/install-deps-osx/action.yml
+++ b/.github/actions/install-deps-osx/action.yml
@@ -16,6 +16,7 @@ runs:
               libiconv
               zlib
               cmake
+              ninja
               python@3.8
               autoconf
               automake


### PR DESCRIPTION
This patch adds missing `ninja` package to deps for FreeBSD and OSX
systems to provide possibility to use `ninja` as a build system on
them.

NO_DOC=ci
NO_TEST=ci
NO_CHANGELOG=ci