### PR TITLE
memtx: decompress tuples in snapshot iterator

### DIFF
--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -827,6 +827,7 @@ checkpoint_f(va_list ap)
 			if (checkpoint_write_tuple(&snap, entry->space_id,
 					entry->group_id, data, size) != 0)
 				goto fail;
+			fiber_gc();
 		}
 		if (rc != 0)
 			goto fail;
@@ -1077,6 +1078,7 @@ memtx_join_f(va_list ap)
 			if (memtx_join_send_tuple(ctx->stream, entry->space_id,
 						  data, size) != 0)
 				return -1;
+			fiber_gc();
 		}
 		if (rc != 0)
 			return -1;

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -1224,11 +1224,9 @@ memtx_set_tuple_format_vtab(const char *allocator_name)
 int
 memtx_tuple_validate(struct tuple_format *format, struct tuple *tuple)
 {
-	if (tuple_is_compressed(tuple)) {
-		tuple = memtx_tuple_decompress(tuple);
-		if (tuple == NULL)
-			return -1;
-	}
+	tuple = memtx_tuple_decompress(tuple);
+	if (tuple == NULL)
+		return -1;
 	tuple_ref(tuple);
 	int rc = tuple_validate_raw(format, tuple_data(tuple));
 	tuple_unref(tuple);
@@ -1612,7 +1610,7 @@ int
 memtx_prepare_result_tuple(struct tuple **result)
 {
 	if (*result != NULL) {
-		*result = memtx_tuple_maybe_decompress(*result);
+		*result = memtx_tuple_decompress(*result);
 		if (*result == NULL)
 			return -1;
 		tuple_bless(*result);

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -36,6 +36,7 @@
 #include "txn.h"
 #include "memtx_tx.h"
 #include "memtx_engine.h"
+#include "memtx_tuple_compression.h"
 #include "space.h"
 #include "schema.h" /* space_by_id(), space_cache_find() */
 #include "errinj.h"
@@ -516,7 +517,9 @@ hash_snapshot_iterator_next(struct snapshot_iterator *iterator,
 
 		if (tuple != NULL) {
 			*data = tuple_data_range(*res, size);
-			return 0;
+			*data = memtx_tuple_decompress_raw(
+				*data, *data + *size, size);
+			return *data == NULL ? -1 : 0;
 		}
 	}
 	return 0;

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -363,7 +363,7 @@ memtx_space_replace_tuple(struct space *space, struct txn_stmt *stmt,
 	stmt->old_tuple = result;
 	if (stmt->old_tuple != NULL) {
 		struct tuple *orig_old_tuple = stmt->old_tuple;
-		stmt->old_tuple = memtx_tuple_maybe_decompress(stmt->old_tuple);
+		stmt->old_tuple = memtx_tuple_decompress(stmt->old_tuple);
 		if (stmt->old_tuple == NULL)
 			return -1;
 		tuple_ref(stmt->old_tuple);
@@ -464,7 +464,7 @@ memtx_space_execute_update(struct space *space, struct txn *txn,
 		return 0;
 	}
 
-	struct tuple *decompressed = memtx_tuple_maybe_decompress(old_tuple);
+	struct tuple *decompressed = memtx_tuple_decompress(old_tuple);
 	if (decompressed == NULL)
 		return -1;
 	tuple_bless(decompressed);
@@ -563,8 +563,7 @@ memtx_space_execute_upsert(struct space *space, struct txn *txn,
 			return -1;
 		tuple_ref(new_tuple);
 	} else {
-		struct tuple *decompressed =
-			memtx_tuple_maybe_decompress(old_tuple);
+		struct tuple *decompressed = memtx_tuple_decompress(old_tuple);
 		if (decompressed == NULL)
 			return -1;
 		tuple_bless(decompressed);

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -30,6 +30,7 @@
  */
 #include "memtx_tree.h"
 #include "memtx_engine.h"
+#include "memtx_tuple_compression.h"
 #include "space.h"
 #include "schema.h" /* space_by_id(), space_cache_find() */
 #include "errinj.h"
@@ -1679,7 +1680,9 @@ tree_snapshot_iterator_next(struct snapshot_iterator *iterator,
 
 		if (tuple != NULL) {
 			*data = tuple_data_range(tuple, size);
-			return 0;
+			*data = memtx_tuple_decompress_raw(
+				*data, *data + *size, size);
+			return *data == NULL ? -1 : 0;
 		}
 	}
 

--- a/src/box/memtx_tuple_compression.h
+++ b/src/box/memtx_tuple_compression.h
@@ -32,6 +32,14 @@ memtx_tuple_decompress(struct tuple *tuple)
 	return tuple;
 }
 
+static inline const char *
+memtx_tuple_decompress_raw(const char *tuple, const char *tuple_end,
+			   uint32_t *p_size)
+{
+	*p_size = tuple_end - tuple;
+	return tuple;
+}
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/memtx_tuple_compression.h
+++ b/src/box/memtx_tuple_compression.h
@@ -28,17 +28,8 @@ memtx_tuple_compress(struct tuple *tuple)
 static inline struct tuple *
 memtx_tuple_decompress(struct tuple *tuple)
 {
-	(void)tuple;
-	unreachable();
-	return NULL;
-}
-
-static inline struct tuple *
-memtx_tuple_maybe_decompress(struct tuple *tuple)
-{
-        if (!tuple_is_compressed(tuple))
-                return tuple;
-        return memtx_tuple_decompress(tuple);
+	assert(!tuple_is_compressed(tuple));
+	return tuple;
 }
 
 #if defined(__cplusplus)


### PR DESCRIPTION
Compressed tuples aren't supposed to be seen outside memtx internals: we always decompresses tuples before returning them to the user; tuples are written decompressed to xlog. We should also decompress tuples before writing them to a snapshot or sending them to a remote replica, but currently we don't, which results in a crash trying to recover from a snapshot that contains compressed spaces.

This patch fixes this by decompressing all tuples in snapshot iterator. Since the decompressed tuples are allocated on the region, we should also call `fiber_gc()` after each snapshot iterator iteration. Note that the decompression is unconditional, i.e. we try to decompress all tuples stored in an index. In general we can't figure out if a tuple is compressed, because its format may be unavailable (when a tuple is freed, its `format_id` is overwritten).

EE part https://github.com/tarantool/tarantool-ee/pull/174
Needed for https://github.com/tarantool/tarantool-ee/issues/171