### PR TITLE
test: limit test-run jobs number to CPU count

### DIFF
--- a/.test.mk
+++ b/.test.mk
@@ -17,6 +17,7 @@ MAX_PROCS ?= 2048
 MAX_FILES ?= 4096
 
 VARDIR ?= /tmp/t
+TEST_RUN_JOBS ?= ${NPROC}
 TEST_RUN_PARAMS = --builddir ${PWD}/${BUILD_DIR}
 
 COVERITY_DIR = cov-int
@@ -54,7 +55,8 @@ install-test-deps:
 
 .PHONY: run-test
 run-test: install-test-deps
-	cd test && ${TEST_RUN_ENV} ./test-run.py --force --vardir ${VARDIR} ${TEST_RUN_PARAMS} ${TEST_RUN_EXTRA_PARAMS}
+	cd test && ${TEST_RUN_ENV} ./test-run.py --force --jobs ${TEST_RUN_JOBS} --vardir ${VARDIR} \
+		${TEST_RUN_PARAMS} ${TEST_RUN_EXTRA_PARAMS}
 
 ##############################
 # Linux                      #

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,9 +48,19 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/small
 add_custom_target(symlink_libsmall_test_binaries ALL
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/small)
 
+# Get the test-run jobs count from the env variable. If the variable is not
+# defined, use the CPU count instead. If the ProcessorCount fails to determine
+# the number of cores, it yields 0, which means for test-run 2 x CPU count.
+set(TEST_RUN_JOBS $ENV{TEST_RUN_JOBS})
+if(NOT TEST_RUN_JOBS)
+    include(ProcessorCount)
+    ProcessorCount(TEST_RUN_JOBS)
+endif()
+
 add_custom_target(test-unit
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/small
     COMMAND ${PROJECT_SOURCE_DIR}/test/test-run.py
+        --jobs ${TEST_RUN_JOBS}
         --builddir=${PROJECT_BINARY_DIR}
         small/
         unit/)
@@ -58,6 +68,7 @@ add_custom_target(test-unit
 add_custom_target(test-unit-force
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/small
     COMMAND ${PROJECT_SOURCE_DIR}/test/test-run.py
+        --jobs ${TEST_RUN_JOBS}
         --builddir=${PROJECT_BINARY_DIR}
         --force
         small/
@@ -65,12 +76,14 @@ add_custom_target(test-unit-force
 
 add_custom_target(test-func
     COMMAND ${PROJECT_SOURCE_DIR}/test/test-run.py
+        --jobs ${TEST_RUN_JOBS}
         --builddir=${PROJECT_BINARY_DIR}
         --exclude small/
         --exclude unit/)
 
 add_custom_target(test-func-force
     COMMAND ${PROJECT_SOURCE_DIR}/test/test-run.py
+        --jobs ${TEST_RUN_JOBS}
         --builddir=${PROJECT_BINARY_DIR}
         --exclude small/
         --exclude unit/
@@ -80,12 +93,14 @@ add_custom_target(test
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/small
             LuaJIT-test
     COMMAND ${PROJECT_SOURCE_DIR}/test/test-run.py
+        --jobs ${TEST_RUN_JOBS}
         --builddir=${PROJECT_BINARY_DIR})
 
 add_custom_target(test-force
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/small
             LuaJIT-test
     COMMAND ${PROJECT_SOURCE_DIR}/test/test-run.py
+        --jobs ${TEST_RUN_JOBS}
         --builddir=${PROJECT_BINARY_DIR}
         --force)
 


### PR DESCRIPTION
This patch is intended to limit the number of test-run jobs to the CPU
count. Before this change test-run always ran with its default value
for jobs number - `2 x CPU count`. However, such a value may potentially
lead to flaking test results and it really annoys everyone. So it was
decided to give a chance to this patch and see what would happen.

NO_DOC=testing stuff
NO_TEST=testing stuff
NO_CHANGELOG=testing stuff