### PR TITLE
memtx: fix isolation level of BITSET and RTREE indexes

### DIFF
--- a/changelogs/unreleased/gh-7478-memtx-bitset-rtree-read-tracking.md
+++ b/changelogs/unreleased/gh-7478-memtx-bitset-rtree-read-tracking.md
@@ -1,0 +1,4 @@
+## bugfix/memtx
+
+* Fixed isolation level of **memtx** **BITSET** and **RTREE** indexes from 'read
+  committed' to 'serializable' (gh-7478).

--- a/src/box/memtx_bitset.cc
+++ b/src/box/memtx_bitset.cc
@@ -411,6 +411,12 @@ memtx_bitset_index_create_iterator(struct index *base, enum iterator_type type,
 	}
 
 	tt_bitset_expr_destroy(&expr);
+
+/********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND START*********/
+	memtx_tx_track_full_scan(in_txn(), space_by_id(it->base.space_id),
+				 &index->base);
+/*********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND END**********/
+
 	return (struct iterator *)it;
 fail:
 	tt_bitset_expr_destroy(&expr);

--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -224,6 +224,11 @@ memtx_rtree_index_get_raw(struct index *base, const char *key,
 	struct rtree_iterator iterator;
 	rtree_iterator_init(&iterator);
 
+/********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND START*********/
+	memtx_tx_track_full_scan(in_txn(), space_by_id(base->def->space_id),
+				 &index->base);
+/*********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND END**********/
+
 	struct rtree_rect rect;
 	if (mp_decode_rect_from_key(&rect, index->dimension, key, part_count))
 		unreachable();
@@ -355,6 +360,12 @@ memtx_rtree_index_create_iterator(struct index *base,  enum iterator_type type,
 	it->base.next = memtx_iterator_next;
 	it->base.free = index_rtree_iterator_free;
 	rtree_iterator_init(&it->impl);
+
+/********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND START*********/
+	memtx_tx_track_full_scan(in_txn(), space_by_id(it->base.space_id),
+				 &index->base);
+/*********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND END**********/
+
 	/*
 	 * We don't care if rtree_search() does or does not find anything
 	 * as far as we are fine anyway: iterator is initialized correctly

--- a/test/box-luatest/gh_7478_memtx_bitset_rtree_read_tracking_test.lua
+++ b/test/box-luatest/gh_7478_memtx_bitset_rtree_read_tracking_test.lua
@@ -1,0 +1,124 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g_bitset = t.group(nil, t.helpers.matrix{idx  = {'BITSET'},
+                                               iter = {'ALL', 'EQ', 'BITS_ALL_SET',
+                                                'BITS_ANY_SET',
+                                                'BITS_ALL_NOT_SET'}})
+
+g_bitset.before_all(function(cg)
+    cg.server = server:new{
+        alias   = 'dflt',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    cg.server:start()
+end)
+
+g_bitset.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g_bitset.before_each(function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('s')
+        s:create_index('pk')
+        s:create_index('sk', {type = 'BITSET', unique = false,
+                              parts = {{2, 'uint'}}})
+    end)
+end)
+
+g_bitset.after_each(function(cg)
+    cg.server:exec(function()
+        box.space.s:drop()
+    end)
+end)
+
+-- Checks that reads are tracked correctly for all BITSET index iterator types.
+g_bitset.test_read_tracking = function(cg)
+    local stream1 = cg.server.net_box:new_stream()
+    local stream2 = cg.server.net_box:new_stream()
+
+    stream1:begin()
+    stream2:begin()
+
+    stream1.space.s.index[1]:select(0, {iterator = cg.params.iter})
+    stream2.space.s:insert{0, 0}
+    stream1.space.s:insert{1, 0}
+
+    stream2:commit()
+
+    local conflict_err_msg = 'Transaction has been aborted by conflict'
+    t.assert_error_msg_content_equals(conflict_err_msg, function()
+        stream1:commit()
+    end)
+end
+
+local g_rtree = t.group(nil, t.helpers.matrix{idx  = {'RTREE'},
+                                              iter = {'ALL', 'EQ', 'GT', 'GE',
+                                                      'LT', 'LE', 'OVERLAPS',
+                                                      'NEIGHBOR'}})
+
+g_rtree.before_all(function(cg)
+    cg.server = server:new{
+        alias   = 'dflt',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    cg.server:start()
+end)
+
+g_rtree.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g_rtree.before_each(function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('s')
+        s:create_index('pk')
+        s:create_index('sk', {type = 'RTREE', unique = false,
+                              parts = {{2, 'array'}}})
+    end)
+end)
+
+g_rtree.after_each(function(cg)
+    cg.server:exec(function()
+        box.space.s:drop()
+    end)
+end)
+
+-- Checks that reads are tracked correctly for all RTREE index iterator types.
+g_rtree.test_read_tracking = function(cg)
+    local stream1 = cg.server.net_box:new_stream()
+    local stream2 = cg.server.net_box:new_stream()
+
+    stream1:begin()
+    stream2:begin()
+
+    stream1.space.s.index[1]:select({0, 0, 1, 1}, {iterator = cg.params.iter})
+    stream2.space.s:insert{0, {0, 0}}
+    stream1.space.s:insert{1, {0, 0}}
+
+    stream2:commit()
+
+    local conflict_err_msg = 'Transaction has been aborted by conflict'
+    t.assert_error_msg_content_equals(conflict_err_msg, function()
+        stream1:commit()
+    end)
+
+    cg.server:exec(function()
+        box.space.s:delete{0}
+    end)
+
+    stream1:begin()
+    stream2:begin()
+
+    stream1.space.s.index[1]:select({0, 0}, {iterator = cg.params.iter})
+    stream2.space.s:insert{0, {0, 0}}
+    stream1.space.s:insert{1, {0, 0}}
+
+    stream2:commit()
+
+    local conflict_err_msg = 'Transaction has been aborted by conflict'
+    t.assert_error_msg_content_equals(conflict_err_msg, function()
+        stream1:commit()
+    end)
+end


### PR DESCRIPTION
RTREE and BITSET indexes have inconsistent isolation levels ('read
committed' instead of 'serializable', as stated): tracking reads for these
indexes is quite sophisticated, so for now let's treat any index read as a
'full scan'.

Closes #7478

NO_DOC=bugfix