### PR TITLE
ci: add workaround for LuaJit profiling tests

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -85,4 +85,31 @@ runs:
         # files from previous runs, to avoid of it need to run:
         git clean -xffd
         git submodule foreach --recursive 'git clean -xffd'
+
+        # A temporary workaround that should be removed after the corresponding
+        # issue is fixed. See for details:
+        #   https://github.com/tarantool/tarantool/issues/7472.
+        if ${{ runner.os == 'Linux' && github.workflow == 'coverage' }}; then
+            LUAJIT_TEST_VARDIR=/tmp/luajit-test-vardir
+            LUAJIT_TEST_VARDIR_DISK=/tmp/luajit-test-vardir-disk/disk.ext4
+
+            # Create ${LUAJIT_TEST_VARDIR}.
+            umount ${LUAJIT_TEST_VARDIR} || true
+            rm -rf ${LUAJIT_TEST_VARDIR}
+            mkdir -p ${LUAJIT_TEST_VARDIR}
+
+            # Create a 1GB file (disk image).
+            mkdir -p $(dirname ${LUAJIT_TEST_VARDIR_DISK})
+            dd if=/dev/zero of=${LUAJIT_TEST_VARDIR_DISK} bs=4096 count=256000
+
+            # Format this file as an ext4 filesystem.
+            mkfs -t ext4 -q ${LUAJIT_TEST_VARDIR_DISK} -F
+
+            # Mount this filesystem to ${LUAJIT_TEST_VARDIR}.
+            mount -o loop,rw,usrquota,grpquota \
+                ${LUAJIT_TEST_VARDIR_DISK} \
+                ${LUAJIT_TEST_VARDIR}
+
+            echo LUAJIT_TEST_VARDIR=${LUAJIT_TEST_VARDIR} | tee -a $GITHUB_ENV
+        fi
       shell: bash


### PR DESCRIPTION
This patch adds a temporary workaround for LuaJIT profiling tests to
avoid runners shutdown due to no space left on the disk. The profiling
tests may produce profiles until fully fill up the runner [1].

The workaround is based on implementing disk quotas.

In two words, it creates a 1GB file (disk image), formats this file as
an ext4 filesystem, mounts this filesystem to some mount pont and sets
`LUAJIT_TEST_VARDIR=<mount point>`. In this case LuaJIT tests will use
this dir for storing various test data/profiles and not be able to fill
up the runner.

[1] https://github.com/tarantool/tarantool/issues/7472

NO_DOC=ci
NO_TEST=ci
NO_CHANGELOG=ci