### PR TITLE
build: bump zstd submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 
-project(tarantool C CXX)
+project(tarantool C CXX ASM)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 set(CMAKE_INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_INCLUDE_PATH})

--- a/changelogs/unreleased/bump-zstd.md
+++ b/changelogs/unreleased/bump-zstd.md
@@ -1,0 +1,3 @@
+## feature/build
+
+* Updated zstd to version 1.5.2.

--- a/cmake/BuildZSTD.cmake
+++ b/cmake/BuildZSTD.cmake
@@ -9,6 +9,7 @@ macro(zstd_build)
         third_party/zstd/lib/common/debug.c
         third_party/zstd/lib/decompress/zstd_decompress.c
         third_party/zstd/lib/decompress/huf_decompress.c
+        third_party/zstd/lib/decompress/huf_decompress_amd64.S
         third_party/zstd/lib/decompress/zstd_ddict.c
         third_party/zstd/lib/decompress/zstd_decompress_block.c
         third_party/zstd/lib/compress/zstd_double_fast.c

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -788,6 +788,8 @@ static inline int
 txn_begin_ro_stmt(struct space *space, struct txn **txn,
 		  struct txn_ro_savepoint *svp)
 {
+	svp->region = &fiber()->gc;
+	svp->region_used = region_used(svp->region);
 	*txn = in_txn();
 	if (*txn != NULL) {
 		if ((*txn)->status == TXN_CONFLICTED) {
@@ -797,8 +799,6 @@ txn_begin_ro_stmt(struct space *space, struct txn **txn,
 		struct engine *engine = space->engine;
 		return txn_begin_in_engine(engine, *txn);
 	}
-	svp->region = &fiber()->gc;
-	svp->region_used = region_used(svp->region);
 	return 0;
 }
 


### PR DESCRIPTION
Updated third_party/zstd submodule from v1.5.0 to 1.5.2 version. The new version fixes a few bugs found by fuzzing testing.

Note, the new zstd version contains a .S source file so we need to include ASM to the CMake project languages.