### PR TITLE
Fix a crash on concurrent `fiber:join()`

### DIFF
--- a/changelogs/unreleased/gh-7489-concurrent-fiber-join.md
+++ b/changelogs/unreleased/gh-7489-concurrent-fiber-join.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fixed a possible crash on concurrent `fiber_object:join()` (gh-7489).

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -999,6 +999,13 @@ fiber_yield_timeout(ev_tstamp delay);
 bool
 fiber_yield_deadline(ev_tstamp deadline);
 
+/**
+ * Add current fiber to f->wake and yield.
+ * Return true if deadline exceeded.
+ */
+bool
+fiber_wait_on_deadline(struct fiber *f, double deadline);
+
 void
 fiber_destroy_all(struct cord *cord);
 

--- a/test/app-luatest/gh_7489_concurrent_fiber_join_test.lua
+++ b/test/app-luatest/gh_7489_concurrent_fiber_join_test.lua
@@ -1,0 +1,81 @@
+local fiber = require('fiber')
+local t = require('luatest')
+local g1 = t.group('gh-7489-concurrent-fiber-join-1',
+                   {{ do_cancel = false },
+                    { do_cancel = true }})
+local g2 = t.group('gh-7489-concurrent-fiber-join-2')
+
+local error_message = 'the fiber is already joined by concurrent fiber:join()'
+
+g1.test_concurrent_fiber_join = function(cg)
+    local block1 = true
+    -- 1. Create f1, but do not start it
+    local f1 = fiber.new(function()
+        -- 4. Wait for unblocking and exit
+        while block1 do
+            fiber.sleep(0.001)
+        end
+    end)
+    f1:set_joinable(true)
+    -- 2. Create f2, but do not start it
+    local f2 = fiber.new(function()
+        block1 = false
+        -- 5. Try to join f1. Yield here until it is unblocked and finished
+        f1:join()
+    end)
+    f2:set_joinable(true)
+    -- 3. Start f1, then f2
+    fiber.yield()
+    -- 6. Optionally cancel f1
+    if cg.params.do_cancel then
+        f1:cancel()
+    end
+    -- 7. Try to join f1. Yield here until it is unblocked and finished.
+    -- This join should raise an error, because f1 is already joined by f2
+    t.assert_error_msg_content_equals(error_message, function() f1:join() end)
+end
+
+g2.test_concurrent_fiber_join = function()
+    local f1 = nil
+    local f2 = nil
+    local function test_f1()
+        -- Do nothing
+    end
+    local function test_f2()
+        while true do
+            fiber.sleep(0.001)
+        end
+    end
+    local function joiner_f1()
+       -- 3. Try to join f1. Yield until it is started and immediately finished
+       local st = f1:join()
+       -- 5. Create a new fiber, which sleeps until it is cancelled
+       f2 = fiber.new(test_f2)
+       f2:set_joinable(true)
+       return st
+    end
+    local function joiner_f2()
+       -- 4. Try to join f1. Yield until it is started and immediately finished
+       local st, err = pcall(fiber.join, f1)
+       -- 6. This join should raise an error, because f1 should be already
+       -- joined by the first joiner.
+       -- In case of a bug, it may hang trying to join f2 instead of f1
+       return not st and err == error_message
+    end
+    -- 1. Create two joiners and one joinee fibers, but do not start them
+    local j1 = fiber.new(joiner_f1)
+    local j2 = fiber.new(joiner_f2)
+    f1 = fiber.new(test_f1)
+    j1:set_joinable(true)
+    j2:set_joinable(true)
+    f1:set_joinable(true)
+    -- 2. Start fibers in the following order: j1, j2, f1
+    fiber.yield()
+    -- 7. Verify that the first join succeeded and the second one failed
+    local _, joiner1_passed = j1:join()
+    local _, joiner2_passed = j2:join()
+    t.assert(joiner1_passed)
+    t.assert(joiner2_passed)
+    f2:cancel()
+    f2:join()
+end

--- a/test/unit/fiber.cc
+++ b/test/unit/fiber.cc
@@ -330,6 +330,31 @@ fiber_flags_respect_test(void)
 }
 
 static void
+fiber_wait_on_deadline_test()
+{
+	header();
+
+	struct fiber *fiber = fiber_new_xc("noop", noop_f);
+	fiber_set_joinable(fiber, true);
+	fiber_wakeup(fiber);
+	bool exceeded = fiber_wait_on_deadline(fiber, fiber_clock() + 100.0);
+	fail_if(exceeded);
+	fail_if(!fiber_is_dead(fiber));
+	fiber_join(fiber);
+
+	fiber = fiber_new_xc("cancel", cancel_f);
+	fiber_set_joinable(fiber, true);
+	fiber_wakeup(fiber);
+	exceeded = fiber_wait_on_deadline(fiber, fiber_clock() + 0.001);
+	fail_if(!exceeded);
+	fail_if(fiber_is_dead(fiber));
+	fiber_cancel(fiber);
+	fiber_join(fiber);
+
+	footer();
+}
+
+static void
 cord_cojoin_test(void)
 {
 	header();
@@ -361,6 +386,7 @@ main_f(va_list ap)
 	fiber_wakeup_dead_test();
 	fiber_dead_while_in_cache_test();
 	fiber_flags_respect_test();
+	fiber_wait_on_deadline_test();
 	cord_cojoin_test();
 	ev_break(loop(), EVBREAK_ALL);
 	return 0;

--- a/test/unit/fiber.result
+++ b/test/unit/fiber.result
@@ -25,5 +25,7 @@ OutOfMemory: Failed to allocate 42 bytes in allocator for exception
 	*** fiber_dead_while_in_cache_test: done ***
 	*** fiber_flags_respect_test ***
 	*** fiber_flags_respect_test: done ***
+	*** fiber_wait_on_deadline_test ***
+	*** fiber_wait_on_deadline_test: done ***
 	*** cord_cojoin_test ***
 	*** cord_cojoin_test: done ***


### PR DESCRIPTION
**fiber: introduce fiber_wait_on_deadline()**
It is separated from fiber_join_timeout(), and will be used
in lbox_fiber_join() too.

**fiber: do not crash on concurrent fiber:join()**
If two or more fibers are yielding in fiber_join_timeout(), one of them
will eventually join and recycle the fiber, while the rest will crash
on accessing the recycled fiber's struct. Fix this by doing fiber_find()
again after each waiting attempt in lbox_fiber_join().

**fiber: do not crash on concurrent C fiber_join()**
Like a previous commit, but fix C module API instead of Lua.

Closes https://github.com/tarantool/tarantool/issues/7489
Closes https://github.com/tarantool/tarantool/issues/7531