### PR TITLE
box: check constraint name against identifier rules

### DIFF
--- a/src/box/tuple_constraint_def.c
+++ b/src/box/tuple_constraint_def.c
@@ -7,6 +7,8 @@
 
 #include "diag.h"
 #include "error.h"
+#include "schema_def.h"
+#include "identifier.h"
 #include "trivia/util.h"
 #include "salad/grp_alloc.h"
 #include "small/region.h"
@@ -118,6 +120,13 @@ tuple_constraint_def_decode(const char **data,
 		}
 		uint32_t str_len;
 		const char *str = mp_decode_str(data, &str_len);
+		if (str_len > BOX_NAME_MAX) {
+			diag_set(ClientError, errcode,
+				 "constraint name is too long");
+			return -1;
+		}
+		if (identifier_check(str, str_len) != 0)
+			return -1;
 		char *str_copy = region_alloc(region, str_len + 1);
 		if (str_copy == NULL) {
 			diag_set(OutOfMemory, str_len + 1, "region",
@@ -273,6 +282,13 @@ tuple_constraint_def_decode_fkey(const char **data,
 		}
 		uint32_t str_len;
 		const char *str = mp_decode_str(data, &str_len);
+		if (str_len > BOX_NAME_MAX) {
+			diag_set(ClientError, errcode,
+				 "foreign key name is too long");
+			return -1;
+		}
+		if (identifier_check(str, str_len) != 0)
+			return -1;
 		char *str_copy = region_alloc(region, str_len + 1);
 		if (str_copy == NULL) {
 			diag_set(OutOfMemory, bytes, "region",

--- a/test/engine-luatest/gh_6436_complex_foreign_key_test.lua
+++ b/test/engine-luatest/gh_6436_complex_foreign_key_test.lua
@@ -63,6 +63,16 @@ g.test_bad_complex_foreign_key = function(cg)
             "Illegal parameters, foreign key: foreign field must be string or number",
             function() box.schema.create_space('city', opts) end
         )
+        opts = space_opts({[string.rep('a', 66666)]={space='country',field={p_id='planet_id', c_id='country_id'}}})
+        t.assert_error_msg_content_equals(
+            "Wrong space options: foreign key name is too long",
+            function() box.schema.create_space('city', opts) end
+        )
+        opts = space_opts({['']={space='country',field={p_id='planet_id', c_id='country_id'}}})
+        t.assert_error_msg_content_equals(
+            "Invalid identifier '' (expected printable symbols only or it is too long)",
+            function() box.schema.create_space('city', opts) end
+        )
         opts = space_opts({cntr={space='country',field={p_id='planet_id', c_id='country_id'}}})
         box.schema.create_space('city', opts)
         t.assert_equals(box.space.city.foreign_key,

--- a/test/engine-luatest/gh_6436_field_constraint_test.lua
+++ b/test/engine-luatest/gh_6436_field_constraint_test.lua
@@ -268,6 +268,19 @@ g.test_wrong_field_constraint = function(cg)
                 box.space.test:format({{"id1", constraint = {"field_constr3"}}, {"id2"}})
             end)
 
+        t.assert_error_msg_content_equals(
+            "Wrong space format: constraint name is too long",
+            function()
+                box.space.test:format({{"id1", constraint = {[string.rep('a', 66666)] = "field_constr1"}},
+                                       {"id2"}})
+            end)
+
+        t.assert_error_msg_content_equals(
+            "Invalid identifier '' (expected printable symbols only or it is too long)",
+            function()
+                box.space.test:format({{"id1", constraint = {[''] = "field_constr1"}}, {"id2"}})
+            end)
+
         local func_id = box.func.field_constr1.id
         t.assert_equals(box.space.test:format(),
                         { {constraint = {field_constr1 = func_id},

--- a/test/engine-luatest/gh_6436_field_foreign_key_test.lua
+++ b/test/engine-luatest/gh_6436_field_foreign_key_test.lua
@@ -98,6 +98,16 @@ g.test_bad_foreign_key = function(cg)
             "Illegal parameters, format[2]: foreign key: unexpected parameter 'mood'",
             function() box.schema.create_space('city', {engine=engine, format=fmt}) end
         )
+        fmt = gen_format({[string.rep('a', 66666)] = {space = 'country', field = 'id'}})
+        t.assert_error_msg_content_equals(
+            "Wrong space format: foreign key name is too long",
+            function() box.schema.create_space('city', {engine=engine, format=fmt}) end
+        )
+        fmt = gen_format({[''] = {space = 'country', field = 'id'}})
+        t.assert_error_msg_content_equals(
+            "Invalid identifier '' (expected printable symbols only or it is too long)",
+            function() box.schema.create_space('city', {engine=engine, format=fmt}) end
+        )
     end, {engine})
 end
 

--- a/test/engine-luatest/gh_6436_tuple_constraint_test.lua
+++ b/test/engine-luatest/gh_6436_tuple_constraint_test.lua
@@ -217,6 +217,16 @@ g.test_wrong_tuple_constraint = function(cg)
             box.schema.create_space, 'test',
             {engine = engine, constraint = {check = "tuple_constr3"}})
 
+        t.assert_error_msg_content_equals(
+            "Wrong space options: constraint name is too long",
+            box.schema.create_space, 'test',
+            {engine = engine, constraint = {[string.rep('a', 66666)] = "tuple_constr1"}})
+
+        t.assert_error_msg_content_equals(
+            "Invalid identifier '' (expected printable symbols only or it is too long)",
+            box.schema.create_space, 'test',
+            {engine = engine, constraint = {[''] = "tuple_constr1"}})
+
         local s = box.schema.create_space('test', {engine = engine,
                                                    constraint = 'tuple_constr1'})
         t.assert_equals(s.constraint, {tuple_constr1 = box.func.tuple_constr1.id})


### PR DESCRIPTION
Currently, it is possible to create a constraint with a name that does
not match the rules for identifiers. Fix this by validating them by
identifier_check.

Closes #7201