### PR TITLE
static build: fix icu build on Mac OS 11 and newer

### DIFF
--- a/.github/workflows/osx_12_static_cmake.yml
+++ b/.github/workflows/osx_12_static_cmake.yml
@@ -1,4 +1,4 @@
-name: static_build_cmake_osx_15
+name: osx_12_static_cmake
 
 on:
   push:
@@ -32,14 +32,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  static_build_cmake_osx_15:
+  osx_12_static_cmake:
     # Run on push to the 'master' and release branches of tarantool/tarantool
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
-    runs-on: macos-10.15
+    runs-on: macos-12
 
     steps:
       - uses: tarantool/actions/cleanup@master
@@ -62,6 +62,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: static_build_cmake_osx_15
+          name: osx_12_static_cmake
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts

--- a/changelogs/unreleased/static-build-fix-on-mac-os-11-and-newer.md
+++ b/changelogs/unreleased/static-build-fix-on-mac-os-11-and-newer.md
@@ -1,0 +1,5 @@
+## bugfix/build
+
+* Fixed static build on Mac OS 11 and newer (gh-7459).
+
+  See `static-build/README.md` for details about this build type.

--- a/static-build/CMakeLists.txt
+++ b/static-build/CMakeLists.txt
@@ -34,10 +34,12 @@ set(BACKUP_STORAGE https://distrib.hb.bizmrg.com)
 # linker flag assumes that some compilation flag is set. We don't pass
 # CFLAGS from environment, so we should not do it for LDFLAGS too.
 set(DEPENDENCY_CFLAGS "")
+set(DEPENDENCY_CXXFLAGS "")
 set(DEPENDENCY_CPPFLAGS "")
 set(DEPENDENCY_LDFLAGS)
 if (APPLE)
     set(DEPENDENCY_CFLAGS   "${CMAKE_C_SYSROOT_FLAG} ${CMAKE_OSX_SYSROOT}")
+    set(DEPENDENCY_CXXFLAGS "${CMAKE_C_SYSROOT_FLAG} ${CMAKE_OSX_SYSROOT}")
     set(DEPENDENCY_CPPFLAGS "${CMAKE_C_SYSROOT_FLAG} ${CMAKE_OSX_SYSROOT}")
 endif()
 
@@ -85,6 +87,7 @@ ExternalProject_Add(icu
         CC=${CMAKE_C_COMPILER}
         CXX=${CMAKE_CXX_COMPILER}
         CFLAGS=${DEPENDENCY_CFLAGS}
+        CXXFLAGS=${DEPENDENCY_CXXFLAGS}
         CPPFLAGS=${DEPENDENCY_CPPFLAGS}
         LDFLAGS=${DEPENDENCY_LDFLAGS}
 


### PR DESCRIPTION
Without `-isysroot <SDK_PATH>` the build fails:

```
/Library/Developer/CommandLineTools/usr/bin/make[4]: Making `all' in   \
    `makeconv'
/Library/Developer/CommandLineTools/usr/bin/c++ -O2 -W -Wall -pedantic \
    -Wpointer-arith -Wwrite-strings -Wno-long-long -std=c++11          \
    -Wno-ambiguous-reversed-operator     -o ../../bin/makeconv         \
    gencnvex.o genmbcs.o makeconv.o ucnvstat.o -L../../lib -licutu     \
    -L../../lib -licui18n -L../../lib -licuuc -L../../stubdata         \
    -licudata -lpthread -lm
ld: library not found for -lpthread
clang: error: linker command failed with exit code 1 (use -v to see    \
    invocation)
```

ICU is written on C++, so we should pass `CXXFLAGS`, not only `CFLAGS`.

Note: `CPPFLAGS` stands for C preprocessor flags, not C++ flags.

Fixes #7459