### PR TITLE
[backport/2.10] luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-7230-luajit-fixes.md
+++ b/changelogs/unreleased/gh-7230-luajit-fixes.md
@@ -1,0 +1,6 @@
+## bugfix/luajit
+
+Backported patches from vanilla LuaJIT trunk (gh-7230). In the scope of this
+activity, the following issues have been resolved:
+
+* Fix handling of errors during trace snapshot restore.


### PR DESCRIPTION
* Call error function on rethrow after trace exit.
* Fix handling of errors during snapshot restore.

Part of #7230

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump
