### PR TITLE
console: fix multiline commands saved as oneline

### DIFF
--- a/changelogs/unreleased/gh-7320-restore-multiline-history.md
+++ b/changelogs/unreleased/gh-7320-restore-multiline-history.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed multiline commands being saved to `~/.tarantool_history` as
+  separate lines (gh-7320).

--- a/src/box/lua/console.c
+++ b/src/box/lua/console.c
@@ -692,6 +692,10 @@ tarantool_lua_console_init(struct lua_State *L)
 	lua_pushcclosure(L, lbox_console_readline, 1);
 	lua_setfield(L, -2, "readline");
 
+	/* Readline setup that provides timestamps and multiline history. */
+	history_comment_char = '#';
+	history_write_timestamps = 1;
+
 	serializer_yaml = lua_yaml_new_serializer(L);
 	serializer_yaml->encode_invalid_numbers = 1;
 	serializer_yaml->encode_load_metatables = 1;


### PR DESCRIPTION
When multiline commands were loaded from .tarantool_history, they were
treated as a bunch of oneline commands. Now readline is configured to
write timestamps in .tarantool_history as delimiters and multiline
commands are handled correctly.

If there is already a .tarantool_history file, readline will set
timestamps automatically, nothing will be lost.

Closes #7320
NO_DOC=bugfix
NO_TEST=impossible to check readline history from lua