### PR TITLE
prbuf: fix prbuf_open for empty buffer

### DIFF
--- a/src/lib/core/prbuf.c
+++ b/src/lib/core/prbuf.c
@@ -206,6 +206,8 @@ prbuf_check(struct prbuf *buf)
 		return false;
 	if (buf->header->end > prbuf_size(buf))
 		return false;
+	if (prbuf_is_empty(buf))
+		return true;
 	struct prbuf_record *current;
 	current = prbuf_first_record(buf);
 	uint32_t total_size = current->size;

--- a/test/unit/prbuf.c
+++ b/test/unit/prbuf.c
@@ -239,6 +239,11 @@ test_buffer_empty(void)
 	prbuf_iterator_create(&buf, &iter);
 	int rc = prbuf_iterator_next(&iter, &entry);
 	is(rc, -1, "Buffer is empty");
+	rc = prbuf_open(&buf, mem);
+	is(rc, 0, "Opened empty buffer");
+	prbuf_iterator_create(&buf, &iter);
+	rc = prbuf_iterator_next(&iter, &entry);
+	is(rc, -1, "Buffer is empty");
 	footer();
 }
 
@@ -331,7 +336,7 @@ test_buffer_prepared_large(void)
 int
 main(void)
 {
-	plan(37);
+	plan(39);
 	payload_large_init();
 	test_buffer_foreach_size();
 	test_buffer_bad_version();

--- a/test/unit/prbuf.result
+++ b/test/unit/prbuf.result
@@ -1,4 +1,4 @@
-1..37
+1..39
 	*** test_buffer_foreach_copy_number ***
 ok 1 - prbuf(size=128, payload=4, iterations=16) has been validated
 ok 2 - prbuf(size=128, payload=4, iterations=32) has been validated
@@ -58,13 +58,15 @@ ok 31 - Failed to allocate too large entry
 	*** test_buffer_too_large_entry: done ***
 	*** test_buffer_empty ***
 ok 32 - Buffer is empty
+ok 33 - Opened empty buffer
+ok 34 - Buffer is empty
 	*** test_buffer_empty: done ***
 	*** test_buffer_prepared ***
-ok 33 - Prepare has not failed
-ok 34 - Entry count has decreased
+ok 35 - Prepare has not failed
+ok 36 - Entry count has decreased
 	*** test_buffer_prepared: done ***
 	*** test_buffer_prepared_large ***
-ok 35 - Prepare has not failed
-ok 36 - Buffer is empty
-ok 37 - Buffer is in correct state
+ok 37 - Prepare has not failed
+ok 38 - Buffer is empty
+ok 39 - Buffer is in correct state
 	*** test_buffer_prepared_large: done ***


### PR DESCRIPTION
prbuf_check, which is called by prbuf_open, proceeds to scanning the buffer even if it's empty. On debug build, this results in prbuf_open reporting that the buffer is corrupted, because we trash the buffer in prbuf_create. On a release build, this may lead to a hang, in case the buffer is zeroed out. Let's fix this by returning success from prbuf_check if the buffer is empty. Note, prbuf_iterator_next doesn't call prbuf_first_record if the buffer is empty, either.

Needed for https://github.com/tarantool/tarantool-ee/issues/187