### PR TITLE
export lua_tonumberx and lua_tointegerx symbols

### DIFF
--- a/changelogs/unreleased/gh-3680-export-lua_tonumberx_and_lua_tointegerx.md
+++ b/changelogs/unreleased/gh-3680-export-lua_tonumberx_and_lua_tointegerx.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Export lua_tonumberx and lua_tointegerx symbols (gh-3680).

--- a/extra/exports
+++ b/extra/exports
@@ -397,8 +397,10 @@ lua_status
 lua_toboolean
 lua_tocfunction
 lua_tointeger
+lua_tointegerx
 lua_tolstring
 lua_tonumber
+lua_tonumberx
 lua_topointer
 lua_tothread
 lua_touserdata


### PR DESCRIPTION
Some external libraries, like lua-protobuf, depend on the symbols
lua_tonumberx and lua_tointegerx.

Closes #3680

NO_DOC=bugfix
NO_TEST=only useful for external libraries