### PR TITLE
build: fix check-dependencies test on OS X

### DIFF
--- a/static-build/test/CheckDependencies.cmake
+++ b/static-build/test/CheckDependencies.cmake
@@ -16,6 +16,8 @@ if (APPLE)
         libSystem
         CoreFoundation
         libc++
+        # Required by bundled libcurl built with c-ares
+        libresolv
     )
 elseif(UNIX)
     set(ALLOWLIST


### PR DESCRIPTION
Commit ed16c1e5780cf355ab9bf923ee6f9daf5b6363f8 ("build: fix bundled
libcurl and c-ares build on OS X") fixed building libcurl with ares by
adding a dependency on libresolv for Mac OS X. It was forgotten to add
libresolv to check-dependencies exceptions for static build. Do this now.

NO_DOC=CI stuff
NO_TEST=CI stuff
NO_CHANGELOG=CI stuff