### PR TITLE
Use fixed-length versions of sprintf, strcpy and strcat

### DIFF
--- a/src/box/lua/serialize_lua.c
+++ b/src/box/lua/serialize_lua.c
@@ -191,7 +191,8 @@ trace_nd_mask_str(unsigned int nd_mask)
 
 		int nd_len = strlen(nd_type_names[i]);
 		if (left >= nd_len + 1) {
-			strcpy(&mask_str[pos], nd_type_names[i]);
+			strncpy(&mask_str[pos], nd_type_names[i],
+				sizeof(mask_str) - pos - 1);
 			pos += nd_len;
 			mask_str[pos++] = '|';
 			left = sizeof(mask_str) - pos;
@@ -201,7 +202,7 @@ trace_nd_mask_str(unsigned int nd_mask)
 	if (pos != 0)
 		mask_str[--pos] = '\0';
 	else
-		strcpy(mask_str, "UNKNOWN");
+		strncpy(mask_str, "UNKNOWN", sizeof(mask_str) - 1);
 
 	return mask_str;
 }

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -345,7 +345,8 @@ sql_ephemeral_space_new(const struct sql_space_info *info)
 	 * plus length of UINT32_MAX turned to string, which is 10 and plus 1
 	 * for '\0'.
 	 */
-	uint32_t size = names_indent + field_count * 19;
+	uint32_t max_len = 19;
+	uint32_t size = names_indent + field_count * max_len;
 
 	struct region *region = &fiber()->gc;
 	size_t svp = region_used(region);
@@ -364,7 +365,7 @@ sql_ephemeral_space_new(const struct sql_space_info *info)
 	for (uint32_t i = 0; i < info->field_count; ++i) {
 		fields[i] = field_def_default;
 		fields[i].name = names;
-		sprintf(names, "_COLUMN_%d", i);
+		snprintf(names, max_len, "_COLUMN_%d", i);
 		names += strlen(fields[i].name) + 1;
 		fields[i].is_nullable = true;
 		fields[i].nullable_action = ON_CONFLICT_ACTION_NONE;

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -229,8 +229,11 @@ sqlStartTable(Parse *pParse, Token *pName)
 	if (new_space == NULL)
 		goto cleanup;
 
-	strcpy(new_space->def->engine_name,
-	       sql_storage_engine_strs[current_session()->sql_default_engine]);
+	size_t max_len = sizeof(new_space->def->engine_name) - 1;
+	strncpy(new_space->def->engine_name,
+		sql_storage_engine_strs[current_session()->sql_default_engine],
+		max_len);
+	new_space->def->engine_name[max_len] = '\0';
 
 	if (!db->init.busy && (v = sqlGetVdbe(pParse)) != 0)
 		sql_set_multi_write(pParse, true);

--- a/src/box/sql/select.c
+++ b/src/box/sql/select.c
@@ -5057,7 +5057,8 @@ selectExpander(Walker * pWalker, Select * p)
 			 * Rewrite old name with correct pointer.
 			 */
 			name = tt_sprintf("sql_sq_%llX", (long long)space);
-			sprintf(space->def->name, "%s", name);
+			snprintf(space->def->name, strlen(name) + 1, "%s",
+				 name);
 			while (pSel->pPrior) {
 				pSel = pSel->pPrior;
 			}

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -589,7 +589,7 @@ sql_expr_compile(sql *db, const char *expr, int expr_len)
 		diag_set(OutOfMemory, len + 1, "region_alloc", "stmt");
 		goto end;
 	}
-	sprintf(stmt, "%s%.*s", outer, expr_len, expr);
+	snprintf(stmt, len + 1, "%s%.*s", outer, expr_len, expr);
 
 	if (sqlRunParser(&parser, stmt) == 0 &&
 	    parser.parsed_ast_type == AST_TYPE_EXPR) {

--- a/src/box/xrow.c
+++ b/src/box/xrow.c
@@ -2065,7 +2065,8 @@ greeting_decode(const char *greetingbuf, struct greeting *greeting)
 		}
 	} else if (greeting->version_id < version_id(1, 6, 7)) {
 		/* Tarantool < 1.6.7 doesn't add "(Binary)" to greeting */
-		strcpy(greeting->protocol, "Binary");
+		strncpy(greeting->protocol, "Binary",
+			sizeof(greeting->protocol) - 1);
 	} else {
 		return -1; /* Sorry, don't want to parse this greeting */
 	}

--- a/src/lib/core/popen.c
+++ b/src/lib/core/popen.c
@@ -173,7 +173,7 @@ handle_new(struct popen_opts *opts)
 {
 	struct popen_handle *handle;
 	size_t size = 0, i;
-	char *pos;
+	char *pos, *pos_max;
 
 	assert(opts->argv != NULL && opts->nr_argv > 0);
 
@@ -204,13 +204,15 @@ handle_new(struct popen_opts *opts)
 	}
 
 	pos = handle->command = (void *)handle + sizeof(*handle);
+	pos_max = pos + size - 1;
+
 	for (i = 0; i < opts->nr_argv-1; i++) {
 		if (opts->argv[i] == NULL)
 			continue;
 		bool is_multiword = strchr(opts->argv[i], ' ') != NULL;
 		if (is_multiword)
 			*pos++ = '\'';
-		strcpy(pos, opts->argv[i]);
+		strncpy(pos, opts->argv[i], pos_max - pos);
 		pos += strlen(opts->argv[i]);
 		if (is_multiword)
 			*pos++ = '\'';

--- a/src/lib/core/sio.c
+++ b/src/lib/core/sio.c
@@ -376,7 +376,8 @@ sio_uri_to_addr(const char *uri, struct sockaddr *addr, bool *is_host_empty)
 		struct sockaddr_un *un = (struct sockaddr_un *) addr;
 		if (strlen(u.service) + 1 > sizeof(un->sun_path))
 			goto invalid_uri;
-		strcpy(un->sun_path, u.service);
+		strncpy(un->sun_path, u.service, sizeof(un->sun_path) - 1);
+		un->sun_path[sizeof(un->sun_path) - 1] = '\0';
 		un->sun_family = AF_UNIX;
 		uri_destroy(&u);
 		return 0;

--- a/src/lib/core/util.c
+++ b/src/lib/core/util.c
@@ -211,9 +211,9 @@ abspath(const char *filename)
 	if (getcwd(abspath, PATH_MAX - strlen(filename) - 1) == NULL)
 		say_syserror("getcwd");
 	else {
-		strcat(abspath, "/");
+		strncat(abspath, "/", PATH_MAX - strlen(abspath));
 	}
-	strcat(abspath, filename);
+	strncat(abspath, filename, PATH_MAX - strlen(abspath));
 	return abspath;
 }
 

--- a/src/lib/tzcode/localtime.c
+++ b/src/lib/tzcode/localtime.c
@@ -367,7 +367,9 @@ tzloadbody(char const *name, struct state *sp, bool doextend,
 		   would pull in stdio (and would fail if the
 		   resulting string length exceeded INT_MAX!).  */
 		memcpy(lsp->fullname, tzdirslash, sizeof tzdirslash);
-		strcpy(lsp->fullname + sizeof tzdirslash, name);
+		strncpy(lsp->fullname + sizeof tzdirslash, name,
+			sizeof(lsp->fullname) - sizeof(tzdirslash) - 1);
+		lsp->fullname[sizeof(lsp->fullname) - 1] = '\0';
 
 		/* Set doaccess if NAME contains a ".." file name
 		   component, as such a name could read a file outside
@@ -598,13 +600,16 @@ tzloadbody(char const *name, struct state *sp, bool doextend,
 				if (!(j < charcnt)) {
 					int tsabbrlen = strlen(tsabbr);
 					if (j + tsabbrlen < TZ_MAX_CHARS) {
-						strcpy(sp->chars + j, tsabbr);
+						strncpy(sp->chars + j, tsabbr,
+							sizeof(sp->chars)
+							- j - 1);
 						charcnt = j + tsabbrlen + 1;
 						ts->ttis[i].tt_desigidx = j;
 						gotabbr++;
 					}
 				}
 			}
+			sp->chars[sizeof(sp->chars) - 1] = '\0';
 			if (gotabbr == ts->typecnt) {
 				sp->charcnt = charcnt;
 
@@ -1351,7 +1356,8 @@ zoneinit(struct state *sp, char const *name)
 		sp->charcnt = 0;
 		sp->goback = sp->goahead = false;
 		init_ttinfo(&sp->ttis[0], 0, false, 0);
-		strcpy(sp->chars, gmt);
+		strncpy(sp->chars, gmt, sizeof(sp->chars) - 1);
+		sp->chars[sizeof(sp->chars) - 1] = '\0';
 		sp->defaulttype = 0;
 		return 0;
 	} else {

--- a/src/lib/tzcode/timezone.c
+++ b/src/lib/tzcode/timezone.c
@@ -105,7 +105,8 @@ timezone_alloc(const char * zonename)
 		tzfree(prev_tz);
 	prev_tz = tzalloc(zonename);
 	assert(strlen(zonename) < lengthof(prev_zonename));
-	strcpy(prev_zonename, zonename);
+	strncpy(prev_zonename, zonename, sizeof(prev_zonename) - 1);
+	prev_zonename[sizeof(prev_zonename) - 1] = '\0';
 	return prev_tz;
 }
 

--- a/src/proc_title.c
+++ b/src/proc_title.c
@@ -361,7 +361,8 @@ proc_title_set(const char *format, ...)
 		if (ident_handle != INVALID_HANDLE_VALUE)
 			CloseHandle(ident_handle);
 
-		sprintf(name, "pgident(%d): %s", MyProcPid, ps_buffer);
+		snprintf(name, sizeof(name), "pgident(%d): %s", MyProcPid,
+			 ps_buffer);
 
 		ident_handle = CreateEvent(NULL, TRUE, FALSE, name);
 	}

--- a/src/systemd.c
+++ b/src/systemd.c
@@ -118,6 +118,7 @@ int systemd_notify(const char *message) {
 	};
 
 	strncpy(sa.sun_path, sd_unix_path, sizeof(sa.sun_path) - 1);
+	sa.sun_path[sizeof(sa.sun_path) - 1] = '\0';
 	if (sa.sun_path[0] == '@')
 		sa.sun_path[0] = '\0';
 


### PR DESCRIPTION
To avoid potential buffer overflows and to make static analyzers happy.

Fixed CWE-120:
- sprintf: does not check for buffer overflows
- strcpy: does not check for buffer overflows when copying to destination
- strcat: does not check for buffer overflows when concatenating to
  destination