### PR TITLE
Implemention of encoding params in http client

### DIFF
--- a/changelogs/unreleased/gh-6832-httpc-params-encoding.md
+++ b/changelogs/unreleased/gh-6832-httpc-params-encoding.md
@@ -1,0 +1,4 @@
+## feature/lua/http client
+
+* Added a new option to add query parameters into URI using a Lua table. These
+  parameters are encoded to a query string and passed to HTTP request (gh-6832).

--- a/changelogs/unreleased/gh-6832-uri-values.md
+++ b/changelogs/unreleased/gh-6832-uri-values.md
@@ -1,0 +1,18 @@
+## feature/lua/uri
+
+* Add method `uri.values()` that allows a user to represent multivalue
+  parameter's (gh-6832).
+
+```
+> uri.parse({"/tmp/unix.sock", params = params)
+---
+- host: unix/
+  service: /tmp/unix.sock
+  unix: /tmp/unix.sock
+  params:
+    q1:
+    - v1
+    - v2
+...
+
+```

--- a/src/lua/httpc.lua
+++ b/src/lua/httpc.lua
@@ -342,8 +342,7 @@ end
 --
 --      proxy_port - set a port number the proxy listens on;
 --
---      proxy_user_pwd - set a user name and a password to use
---          in authentication;
+--      proxy_user_pwd - set a user name and a password to use in authentication;
 --
 --      no_proxy - disable proxy use for specific hosts;
 --
@@ -353,18 +352,13 @@ end
 --          non-universal keepalive knobs (Linux, AIX, HP-UX, more);
 --
 --      low_speed_time & low_speed_limit -
---          If the download receives less than
---          "low speed limit" bytes/second
---          during "low speed time" seconds,
---          the operations is aborted.
---          You could i.e if you have
---          a pretty high speed connection, abort if
---          it is less than 2000 bytes/sec
---          during 20 seconds;
+--          If the download receives less than "low speed limit" bytes/second
+--          during "low speed time" seconds, the operations is aborted.
+--          You could i.e if you have a pretty high speed connection, abort if
+--          it is less than 2000 bytes/sec during 20 seconds;
 --
 --      timeout - time-out the read operation and
---          waiting for the curl api request
---          after this amount of seconds;
+--          waiting for the curl api request after this amount of seconds;
 --
 --      max_header_name_length - maximum length of a response header;
 --
@@ -372,12 +366,10 @@ end
 --
 --      interface - source interface for outgoing traffic;
 --
---      follow_location - whether the client will follow
---          'Location' header that a server sends as part of an
---          3xx response;
+--      follow_location - whether the client will follow 'Location' header that
+--          a server sends as part of an 3xx response;
 --
---      accept_encoding - enables automatic decompression of HTTP
---          responses;
+--      accept_encoding - enables automatic decompression of HTTP responses;
 --
 --  Returns:
 --      {

--- a/src/lua/httpc.lua
+++ b/src/lua/httpc.lua
@@ -157,53 +157,6 @@ local option_keys = {
     ["SameSite"] = true,
 }
 
---local function process_set_cookies(value, result)
---    local key_start, value_start
---    local key, val
---    local symbols = value:gmatch('.')
---    local options = {}
---    local cur = 0
---    for v in symbols do
---        cur = cur + 1
---        if v == ' ' or v == '\t' then
---            goto continue
---        end
---        key_start = cur
---        -- parse cookie name
---        while not special_characters[v] do
---            if v == nil then
---                return
---            end
---            v = symbols()
---            cur = cur + 1
---        end
---        key = value:sub(key_start, cur)
---        if not v or v ~= '=' then
---            -- invalid header
---            return
---        end
---        while v == ' ' do
---            v = symbols()
---            cur = cur + 1
---        end
---
---        if v == nil then
---            return
---        end
---
---        while v and v ~= ';' do
---            if v == nil then
---                break
---            end
---            v = symbols()
---            cur = cur + 1
---        end
---
---        result[key] = {val, options}
---        ::continue::
---    end
---end
-
 local function process_cookie(cookie, result)
     local vals = cookie:split(';')
     local val = vals[1]:split('=')

--- a/src/lua/uri.lua
+++ b/src/lua/uri.lua
@@ -211,10 +211,18 @@ local function params(opts)
     return table.concat(res, '&')
 end
 
+-- Function allows specify multivalue keys to be added to the query string with
+-- params option.
+-- { key = uri.values("param1", "param2") }
+local function values(...)
+    return {...}
+end
+
 return {
     parse_many = parse_many,
     parse = parse,
     format = format,
+    values = values,
     _internal = {
         params = params,
         encode_kv = encode_kv,

--- a/test/app-luatest/uri_unit_test.lua
+++ b/test/app-luatest/uri_unit_test.lua
@@ -44,3 +44,25 @@ uri_encode_kv_g.test_encode_kv = function(cg)
     encode_kv(cg.params.key, cg.params.values, res)
     t.assert_items_equals(res, cg.params.res)
 end
+
+local uri_values_g = t.group("uri_values", {
+    { values = nil, encoded = {} },
+    { values = "test", encoded = {"test"} },
+    { values = "", encoded = {""} },
+    { values = "a", encoded = {"a"} },
+})
+
+uri_values_g.test_values = function(cg)
+    local values = uri.values(cg.params.values)
+    t.assert_equals(values, cg.params.encoded)
+end
+
+g.test_uri_values_multi_arg = function(_)
+    local values = uri.values("twedledee", "tweedledum")
+    t.assert_items_equals(values, {"twedledee", "tweedledum"})
+end
+
+g.test_uri_values_nil = function(_)
+    local values = uri.values()
+    t.assert_items_equals(values, {})
+end

--- a/test/app-luatest/uri_unit_test.lua
+++ b/test/app-luatest/uri_unit_test.lua
@@ -1,0 +1,46 @@
+local build_path = os.getenv("BUILDDIR")
+package.cpath = build_path .. '/src/lua/?.lua;' .. package.cpath
+local uri = require('src.lua.uri')
+local t = require('luatest')
+
+local decimal = require('decimal')
+local datetime = require('datetime')
+
+local g = t.group('uri_unit')
+
+local uri_params_g = t.group("uri_params", {
+    { params = { }, query_string = "" },
+    { params = nil, query_string = "" },
+    { params = { key = {} }, query_string = "key" },
+    { params = { key = "" }, query_string = "key=" },
+    { params = { db1 = "tarantool",  db2 = "redis" }, query_string = "db1=tarantool&db2=redis" },
+    { params = { key = "tarantool" }, query_string = "key=tarantool" },
+    { params = { boolean_type = false }, query_string = "boolean_type=false" },
+    { params = { boolean_type = true }, query_string = "boolean_type=true" },
+    { params = { integer_type = 50 }, query_string = "integer_type=50" },
+    { params = { decimal_type = decimal.new(10) }, query_string = "decimal_type=10" },
+    { params = { datetime_type = datetime.new() }, query_string = "datetime_type=1970-01-01T00:00:00Z" },
+    { params = { int64_type = tonumber64(-1LL) }, query_string = "int64_type=-1LL" },
+    { params = { key = {""} }, query_string = "key=" },
+    { params = { key = "test" }, query_string = "key=test" },
+    { params = { key = {"test"} }, query_string = "key=test" },
+    { params = { key = {"ping", "pong"} }, query_string = "key=ping&key=pong" },
+})
+
+uri_params_g.test_params = function(cg)
+    local uri_params = uri._internal.params
+    t.assert_equals(uri_params(cg.params.params), cg.params.query_string)
+end
+
+local uri_encode_kv_g = t.group("uri_encode_kv", {
+    { key = "a", values = { }, res = {"a"} },
+    { key = "a", values = "b", res = {"a=b"} },
+    { key = "a", values = { "b", "c" }, res = {"a=b", "a=c"} },
+})
+
+uri_encode_kv_g.test_encode_kv = function(cg)
+    local encode_kv = uri._internal.encode_kv
+    local res = {}
+    encode_kv(cg.params.key, cg.params.values, res)
+    t.assert_items_equals(res, cg.params.res)
+end


### PR DESCRIPTION
Closes #6832

Spec: https://www.notion.so/tarantool/http-add-support-of-encoding-table-with-parameters-to-query-string-in-request-c192bdeeaf5c46b2bb7f1e5731f42ed8