### PR TITLE
memtx: fix dirty data written to snapshot for hash index

### DIFF
--- a/changelogs/unreleased/gh-7539-mvcc-dirty-data-written-to-snapshot.md
+++ b/changelogs/unreleased/gh-7539-mvcc-dirty-data-written-to-snapshot.md
@@ -1,0 +1,4 @@
+## bugfix/memtx
+
+* Fixed a bug in the memtx hash index implementation that could lead to
+  uncommitted data written to a snapshot file (gh-7539).

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -515,7 +515,7 @@ hash_snapshot_iterator_next(struct snapshot_iterator *iterator,
 		tuple = memtx_tx_snapshot_clarify(&it->cleaner, tuple);
 
 		if (tuple != NULL) {
-			*data = tuple_data_range(*res, size);
+			*data = tuple_data_range(tuple, size);
 			*data = memtx_tuple_decompress_raw(
 				*data, *data + *size, size);
 			return *data == NULL ? -1 : 0;
@@ -540,6 +540,9 @@ memtx_hash_index_create_snapshot_iterator(struct index *base)
 			 "memtx_hash_index", "iterator");
 		return NULL;
 	}
+
+	struct space *space = space_cache_find(base->def->space_id);
+	memtx_tx_snapshot_cleaner_create(&it->cleaner, space);
 
 	it->base.next = hash_snapshot_iterator_next;
 	it->base.free = hash_snapshot_iterator_free;

--- a/test/box-luatest/gh_7539_mvcc_dirty_data_written_to_snapshot_test.lua
+++ b/test/box-luatest/gh_7539_mvcc_dirty_data_written_to_snapshot_test.lua
@@ -1,0 +1,45 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group(nil, {{index_type = 'tree'}, {index_type = 'hash'}})
+
+g.before_all(function(cg)
+    cg.server = server:new({
+        alias = 'master',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    })
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.before_each(function(cg)
+    cg.server:exec(function(index_type)
+        box.schema.space.create('test')
+        box.space.test:create_index('primary', {type = index_type})
+    end, {cg.params.index_type})
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        box.space.test:drop()
+    end)
+end)
+
+g.test_mvcc_dirty_data_written_to_snapshot = function(cg)
+    cg.server:exec(function()
+        box.space.test:replace({1, 1})
+        box.begin()
+        box.space.test:replace({1, 2})
+        box.space.test:replace({2, 3})
+        box.snapshot()
+        box.rollback()
+    end)
+    cg.server:restart()
+    cg.server:exec(function()
+        local t = require('luatest')
+        t.assert_equals(box.space.test:select(), {{1, 1}})
+    end)
+end


### PR DESCRIPTION
The hash index doesn't create a snapshot clarifier, which is used for filtering out uncommitted tuples from a snapshot. Fix this. Also fix a bug in hash_snapshot_iterator_next, where we passed a wrong argument to tuple_data_range. It hasn't fired, because the clarifier didn't work.

Fixes commit ee8ed0653993 ("txm: clarify all fetched tuples").
Fixes commit f167c1afb38e ("memtx: decompress tuples in snapshot iterator").

Closes #7539