### PR TITLE
tarantoolctl: fix default host for connect

### DIFF
--- a/changelogs/unreleased/igrishnov/gh-7479-bug-fix-uri-lib.md
+++ b/changelogs/unreleased/igrishnov/gh-7479-bug-fix-uri-lib.md
@@ -1,0 +1,4 @@
+## bugfix/uri
+
+* Fixed a bug in the URI parser, because of which tarantoolctl
+  failed to connect when the host name was skipped (gh-7479).

--- a/src/box/lua/net_box.lua
+++ b/src/box/lua/net_box.lua
@@ -138,8 +138,8 @@ local function parse_connect_params(host_or_uri, ...) -- self? host_or_uri port?
                         type(host_or_uri) == 'number' or
                         type(host_or_uri) == 'table') then
         uri = host_or_uri
-    elseif type(host_or_uri) == 'string' and (type(port) == 'string' or
-                                              type(port) == 'number') then
+    elseif (type(host_or_uri) == 'string' or host_or_uri == nil) and
+            (type(port) == 'string' or type(port) == 'number') then
         uri = urilib.format({host = host_or_uri, service = tostring(port)})
     else
         box.error(E_PROC_LUA,

--- a/src/lib/uri/uri.c
+++ b/src/lib/uri/uri.c
@@ -251,18 +251,22 @@ uri_format(char *str, int len, const struct uri *uri, bool write_password)
 	int total = 0;
 	if (uri->scheme != NULL)
 		SNPRINT(total, snprintf, str, len, "%s://", uri->scheme);
-	if (uri->host != NULL) {
-		if (uri->login != NULL) {
-			SNPRINT(total, snprintf, str, len, "%s", uri->login);
-			if (uri->password != NULL && write_password) {
-				SNPRINT(total, snprintf, str, len, ":%s",
-					uri->password);
-			}
-			SNPRINT(total, snprintf, str, len, "@");
+	if (uri->login != NULL) {
+		SNPRINT(total, snprintf, str, len, "%s", uri->login);
+		if (uri->password != NULL && write_password) {
+			SNPRINT(total, snprintf, str, len, ":%s",
+				uri->password);
 		}
+		SNPRINT(total, snprintf, str, len, "@");
+	}
+	if (uri->host != NULL) {
 		SNPRINT(total, snprintf, str, len, "%s", uri->host);
-		if (uri->service != 0) {
+	}
+	if (uri->service != NULL) {
+		if (uri->host != NULL) {
 			SNPRINT(total, snprintf, str, len, ":%s", uri->service);
+		} else {
+			SNPRINT(total, snprintf, str, len, "%s", uri->service);
 		}
 	}
 	if (uri->path != NULL) {

--- a/test/app-luatest/gh_7479_bug_fix_uri_lib_test.lua
+++ b/test/app-luatest/gh_7479_bug_fix_uri_lib_test.lua
@@ -1,0 +1,66 @@
+local t = require('luatest')
+local g = t.group()
+local fio = require('fio')
+local popen = require('popen')
+local net_box = require('net.box')
+local server = require('test.luatest_helpers.server')
+
+-- Create test instance.
+g.before_all = function()
+    g.server = server:new({alias = 'test-gh-7479'})
+    g.server:start()
+    -- Get port for connection testing.
+    g.server_port = g.server:exec(function()
+        return require('console').listen(0):name()['port']
+    end)
+end
+
+-- Stop test instance.
+g.after_all = function()
+    g.server:stop()
+end
+
+-- Checks whether it is possible to specify only port for tarantoolctl connect.
+g.test_tarantoolctl_connect = function()
+    -- Find tarantoolctl.
+    -- Probably test-run knows the path to tarantoolctl.
+    local TARANTOOLCTL_PATH = os.getenv('TARANTOOLCTL')
+    if TARANTOOLCTL_PATH == nil then
+        -- If test-run dose not know the path to tarantoolctl.
+        -- Assume that current directory is tarantool's build directory.
+        local BUILDDIR = os.getenv('BUILDDIR')
+        TARANTOOLCTL_PATH = ('%s/extra/dist/tarantoolctl'):format(BUILDDIR)
+        if not fio.path.exists(TARANTOOLCTL_PATH) then
+            error("Can't find tarantoolctl")
+        end
+    end
+
+    local cmd_tarantoolctl = {
+        TARANTOOLCTL_PATH,
+        'connect',
+        -- Indicate only port, without localhost:* before the port value.
+        tostring(g.server_port),
+    }
+
+    -- Connection will be established in a separate process.
+    local ph_tarantoolctl = popen.new(cmd_tarantoolctl, {
+        stdin  = 'devnull',
+        stdout = 'devnull',
+        stderr = popen.opts.PIPE,
+    })
+    -- Stderr should contain a message about successful connection.
+    local result = ph_tarantoolctl:read({stderr = true}):rstrip()
+    ph_tarantoolctl:close()
+
+    t.assert_equals(
+        result,
+        'connected to localhost:' .. tostring(g.server_port)
+    )
+end
+
+-- Checks whether it is possible to specify only port for net.box.connect.
+g.test_net_box_connect_with_only_port_indication = function()
+    -- Indicate only port, without localhost:* before the port value.
+    local ok, _ = pcall(net_box.connect, nil, g.server_port)
+    t.assert_equals(ok, true)
+end

--- a/test/app-tap/uri.test.lua
+++ b/test/app-tap/uri.test.lua
@@ -97,11 +97,16 @@ local function test_parse(test)
 end
 
 local function test_format(test)
-    test:plan(13)
+    test:plan(14)
     local u = uri.parse("user:password@localhost")
     test:is(uri.format(u), "user@localhost", "password removed")
     test:is(uri.format(u, false), "user@localhost", "password removed")
     test:is(uri.format(u, true), "user:password@localhost", "password kept")
+
+    -- URI with the specified port only.
+    -- This case is used, for example, to resolve a connection URI to the localhost by default.
+    u = uri.parse(3301)
+    test:is(uri.format(u), "3301", "URI format")
 
     -- URI with empty query
      u = uri.parse({"/tmp/unix.sock?"})


### PR DESCRIPTION
Made host=localhost by default for tarantoolctl connect. Now, when specifying only the port, the connection is made to localhost.

Fixes #7479