### PR TITLE
memtx: track read story in when conflicting full scans due to gap write

### DIFF
--- a/changelogs/unreleased/gh-7493-memtx-hash-idx-repeatable-read-violation.md
+++ b/changelogs/unreleased/gh-7493-memtx-hash-idx-repeatable-read-violation.md
@@ -1,0 +1,4 @@
+## bugfix/memtx
+
+* Fixed gap writes from different transaction incorrectly handled for hash index
+  full scans (gh-7493).

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1729,9 +1729,12 @@ memtx_tx_handle_gap_write(struct txn *txn, struct space *space,
 	struct index *index = space->index[ind];
 	struct full_scan_item *fsc_item, *fsc_tmp;
 	struct rlist *fsc_list = &index->full_scans;
+	uint64_t index_mask = 1ull << (ind & 63);
 	rlist_foreach_entry_safe(fsc_item, fsc_list, in_full_scans, fsc_tmp) {
 		if (fsc_item->txn != txn &&
-		    memtx_tx_cause_conflict(txn, fsc_item->txn) != 0)
+		    (memtx_tx_cause_conflict(txn, fsc_item->txn) != 0 ||
+		     memtx_tx_track_read_story(fsc_item->txn, space, story,
+					       index_mask) != 0))
 			return -1;
 	}
 	if (successor != NULL && !tuple_has_flag(successor, TUPLE_IS_DIRTY))
@@ -1745,7 +1748,6 @@ memtx_tx_handle_gap_write(struct txn *txn, struct space *space,
 		list = &succ_story->link[ind].nearby_gaps;
 		assert(list->next != NULL && list->prev != NULL);
 	}
-	uint64_t index_mask = 1ull << (ind & 63);
 	struct gap_item *item, *tmp;
 	rlist_foreach_entry_safe(item, list, in_nearby_gaps, tmp) {
 		int cmp = 0;

--- a/test/box-luatest/gh_7493_memtx_hash_idx_repeatable_read_violation_test.lua
+++ b/test/box-luatest/gh_7493_memtx_hash_idx_repeatable_read_violation_test.lua
@@ -1,0 +1,55 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new{
+        alias   = 'dflt',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.before_each(function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('s')
+        s:create_index('pk', {type = 'HASH'})
+    end)
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        box.space.s:drop()
+    end)
+end)
+
+--[[
+Checks that commit of a tuple replacing a gap-inserted tuple from a concurrent
+transaction is correctly handled.
+]]
+g.test_replace_of_gap_inserted_tuple_into_hash_idx = function(cg)
+    local stream1 = cg.server.net_box:new_stream()
+    local stream2 = cg.server.net_box:new_stream()
+    local stream3 = cg.server.net_box:new_stream()
+
+    stream1:begin()
+    stream2:begin()
+    stream3:begin()
+
+    stream1.space.s:select({})
+    -- Gap write is handled here.
+    stream2.space.s:insert{0}
+    --[[
+    {0} is present in index, hence this insertion is not considered a gap write.
+    ]]
+    stream3.space.s:insert{0}
+
+    stream3:commit()
+
+    t.assert_equals(stream1.space.s:select({}), {})
+end


### PR DESCRIPTION
When conflicting transactions that made full scans in
`memtx_tx_handle_gap_write`, we need to also track that the conflicted
transaction has read the inserted tuple, just like we do in gap tracking
for ordered indexes — otherwise another transaction can overwrite the
inserted tuple in which case no gap tracking will be handled.

Closes #7493

NO_DOC=bugfix