### PR TITLE
Use size-bounded versions of sprintf, strcpy and strcat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,7 @@ check_function_exists(clock_gettime HAVE_CLOCK_GETTIME_WITHOUT_RT)
 
 check_symbol_exists(__get_cpuid cpuid.h HAVE_CPUID)
 check_symbol_exists(strlcpy string.h HAVE_STRLCPY)
+check_symbol_exists(strlcat string.h HAVE_STRLCAT)
 
 # Checks for libev
 include(CheckStructHasMember)

--- a/src/box/lua/serialize_lua.c
+++ b/src/box/lua/serialize_lua.c
@@ -191,7 +191,7 @@ trace_nd_mask_str(unsigned int nd_mask)
 
 		int nd_len = strlen(nd_type_names[i]);
 		if (left >= nd_len + 1) {
-			strcpy(&mask_str[pos], nd_type_names[i]);
+			strlcpy(&mask_str[pos], nd_type_names[i], left);
 			pos += nd_len;
 			mask_str[pos++] = '|';
 			left = sizeof(mask_str) - pos;
@@ -201,7 +201,7 @@ trace_nd_mask_str(unsigned int nd_mask)
 	if (pos != 0)
 		mask_str[--pos] = '\0';
 	else
-		strcpy(mask_str, "UNKNOWN");
+		strlcpy(mask_str, "UNKNOWN", sizeof(mask_str));
 
 	return mask_str;
 }

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -345,7 +345,8 @@ sql_ephemeral_space_new(const struct sql_space_info *info)
 	 * plus length of UINT32_MAX turned to string, which is 10 and plus 1
 	 * for '\0'.
 	 */
-	uint32_t size = names_indent + field_count * 19;
+	uint32_t max_len = 19;
+	uint32_t size = names_indent + field_count * max_len;
 
 	struct region *region = &fiber()->gc;
 	size_t svp = region_used(region);
@@ -364,7 +365,7 @@ sql_ephemeral_space_new(const struct sql_space_info *info)
 	for (uint32_t i = 0; i < info->field_count; ++i) {
 		fields[i] = field_def_default;
 		fields[i].name = names;
-		sprintf(names, "_COLUMN_%d", i);
+		snprintf(names, max_len, "_COLUMN_%d", i);
 		names += strlen(fields[i].name) + 1;
 		fields[i].is_nullable = true;
 		fields[i].nullable_action = ON_CONFLICT_ACTION_NONE;

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -229,8 +229,9 @@ sqlStartTable(Parse *pParse, Token *pName)
 	if (new_space == NULL)
 		goto cleanup;
 
-	strcpy(new_space->def->engine_name,
-	       sql_storage_engine_strs[current_session()->sql_default_engine]);
+	strlcpy(new_space->def->engine_name,
+		sql_storage_engine_strs[current_session()->sql_default_engine],
+		ENGINE_NAME_MAX + 1);
 
 	if (!db->init.busy && (v = sqlGetVdbe(pParse)) != 0)
 		sql_set_multi_write(pParse, true);
@@ -536,9 +537,8 @@ sqlAddDefaultValue(Parse * pParse, ExprSpan * pSpan)
 				pParse->is_aborted = true;
 				return;
 			}
-			strncpy(field->default_value, pSpan->zStart,
-				default_length);
-			field->default_value[default_length] = '\0';
+			strlcpy(field->default_value, pSpan->zStart,
+				default_length + 1);
 		}
 	}
 	sql_expr_delete(db, pSpan->pExpr);

--- a/src/box/sql/select.c
+++ b/src/box/sql/select.c
@@ -5057,7 +5057,8 @@ selectExpander(Walker * pWalker, Select * p)
 			 * Rewrite old name with correct pointer.
 			 */
 			name = tt_sprintf("sql_sq_%llX", (long long)space);
-			sprintf(space->def->name, "%s", name);
+			snprintf(space->def->name, strlen(space->def->name) + 1,
+				 "%s", name);
 			while (pSel->pPrior) {
 				pSel = pSel->pPrior;
 			}

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -589,7 +589,7 @@ sql_expr_compile(sql *db, const char *expr, int expr_len)
 		diag_set(OutOfMemory, len + 1, "region_alloc", "stmt");
 		goto end;
 	}
-	sprintf(stmt, "%s%.*s", outer, expr_len, expr);
+	snprintf(stmt, len + 1, "%s%.*s", outer, expr_len, expr);
 
 	if (sqlRunParser(&parser, stmt) == 0 &&
 	    parser.parsed_ast_type == AST_TYPE_EXPR) {

--- a/src/box/xlog.c
+++ b/src/box/xlog.c
@@ -911,8 +911,7 @@ xlog_open(struct xlog *xlog, const char *name, const struct xlog_opts *opts)
 	if (xlog_init(xlog, opts) != 0)
 		goto err;
 
-	strncpy(xlog->filename, name, sizeof(xlog->filename));
-	xlog->filename[sizeof(xlog->filename) - 1] = '\0';
+	strlcpy(xlog->filename, name, sizeof(xlog->filename));
 
 	xlog->fd = open(xlog->filename, O_RDWR);
 	if (xlog->fd < 0) {

--- a/src/box/xrow.c
+++ b/src/box/xrow.c
@@ -2065,7 +2065,8 @@ greeting_decode(const char *greetingbuf, struct greeting *greeting)
 		}
 	} else if (greeting->version_id < version_id(1, 6, 7)) {
 		/* Tarantool < 1.6.7 doesn't add "(Binary)" to greeting */
-		strcpy(greeting->protocol, "Binary");
+		strlcpy(greeting->protocol, "Binary",
+			sizeof(greeting->protocol));
 	} else {
 		return -1; /* Sorry, don't want to parse this greeting */
 	}

--- a/src/lib/core/popen.c
+++ b/src/lib/core/popen.c
@@ -173,7 +173,7 @@ handle_new(struct popen_opts *opts)
 {
 	struct popen_handle *handle;
 	size_t size = 0, i;
-	char *pos;
+	char *pos, *pos_max;
 
 	assert(opts->argv != NULL && opts->nr_argv > 0);
 
@@ -204,13 +204,15 @@ handle_new(struct popen_opts *opts)
 	}
 
 	pos = handle->command = (void *)handle + sizeof(*handle);
+	pos_max = pos + size;
+
 	for (i = 0; i < opts->nr_argv-1; i++) {
 		if (opts->argv[i] == NULL)
 			continue;
 		bool is_multiword = strchr(opts->argv[i], ' ') != NULL;
 		if (is_multiword)
 			*pos++ = '\'';
-		strcpy(pos, opts->argv[i]);
+		strlcpy(pos, opts->argv[i], pos_max - pos);
 		pos += strlen(opts->argv[i]);
 		if (is_multiword)
 			*pos++ = '\'';

--- a/src/lib/core/sio.c
+++ b/src/lib/core/sio.c
@@ -376,7 +376,7 @@ sio_uri_to_addr(const char *uri, struct sockaddr *addr, bool *is_host_empty)
 		struct sockaddr_un *un = (struct sockaddr_un *) addr;
 		if (strlen(u.service) + 1 > sizeof(un->sun_path))
 			goto invalid_uri;
-		strcpy(un->sun_path, u.service);
+		strlcpy(un->sun_path, u.service, sizeof(un->sun_path));
 		un->sun_family = AF_UNIX;
 		uri_destroy(&u);
 		return 0;

--- a/src/lib/core/util.c
+++ b/src/lib/core/util.c
@@ -265,6 +265,25 @@ strlcpy(char *dst, const char *src, size_t size)
 }
 #endif
 
+#ifndef HAVE_STRLCAT
+size_t
+strlcat(char *dst, const char *src, size_t size)
+{
+	size_t src1_len = strlen(dst);
+	size_t src2_len = strlen(src);
+
+	if (src1_len >= size)
+		return size + src2_len;
+
+	size_t len = src2_len < size - src1_len ?
+		     src2_len : size - src1_len - 1;
+
+	memcpy(dst + src1_len, src, len);
+	dst[src1_len + len] = '\0';
+	return src1_len + src2_len;
+}
+#endif
+
 int
 utf8_check_printable(const char *start, size_t length)
 {

--- a/src/lib/core/util.c
+++ b/src/lib/core/util.c
@@ -211,9 +211,9 @@ abspath(const char *filename)
 	if (getcwd(abspath, PATH_MAX - strlen(filename) - 1) == NULL)
 		say_syserror("getcwd");
 	else {
-		strcat(abspath, "/");
+		strlcat(abspath, "/", PATH_MAX);
 	}
-	strcat(abspath, filename);
+	strlcat(abspath, filename, PATH_MAX);
 	return abspath;
 }
 

--- a/src/lib/tzcode/localtime.c
+++ b/src/lib/tzcode/localtime.c
@@ -17,6 +17,7 @@
 #include "private.h"
 #include "tzfile.h"
 #include "tzcode.h"
+#include "trivia/util.h"
 
 #include <fcntl.h>
 
@@ -367,7 +368,8 @@ tzloadbody(char const *name, struct state *sp, bool doextend,
 		   would pull in stdio (and would fail if the
 		   resulting string length exceeded INT_MAX!).  */
 		memcpy(lsp->fullname, tzdirslash, sizeof tzdirslash);
-		strcpy(lsp->fullname + sizeof tzdirslash, name);
+		strlcpy(lsp->fullname + sizeof tzdirslash, name,
+			sizeof lsp->fullname - sizeof tzdirslash);
 
 		/* Set doaccess if NAME contains a ".." file name
 		   component, as such a name could read a file outside
@@ -598,7 +600,8 @@ tzloadbody(char const *name, struct state *sp, bool doextend,
 				if (!(j < charcnt)) {
 					int tsabbrlen = strlen(tsabbr);
 					if (j + tsabbrlen < TZ_MAX_CHARS) {
-						strcpy(sp->chars + j, tsabbr);
+						strlcpy(sp->chars + j, tsabbr,
+							sizeof sp->chars - j);
 						charcnt = j + tsabbrlen + 1;
 						ts->ttis[i].tt_desigidx = j;
 						gotabbr++;
@@ -1351,7 +1354,7 @@ zoneinit(struct state *sp, char const *name)
 		sp->charcnt = 0;
 		sp->goback = sp->goahead = false;
 		init_ttinfo(&sp->ttis[0], 0, false, 0);
-		strcpy(sp->chars, gmt);
+		strlcpy(sp->chars, gmt, sizeof sp->chars);
 		sp->defaulttype = 0;
 		return 0;
 	} else {

--- a/src/lib/tzcode/strptime.c
+++ b/src/lib/tzcode/strptime.c
@@ -58,6 +58,7 @@ static char sccsid[] __attribute__((unused)) =
 #include "timelocal.h"
 #include "tzcode.h"
 #include "timezone.h"
+#include "trivia/util.h"
 
 enum flags {
 	FLAG_NONE = 1 << 0,
@@ -547,8 +548,7 @@ tnt_strptime(const char *__restrict buf, const char *__restrict fmt,
 				/* empty */;
 			if (cp - buf) {
 				zonestr = alloca(cp - buf + 1);
-				strncpy(zonestr, buf, cp - buf);
-				zonestr[cp - buf] = '\0';
+				strlcpy(zonestr, buf, cp - buf + 1);
 
 				const struct date_time_zone *zone;
 				size_t n = timezone_tm_lookup(zonestr, cp - buf,

--- a/src/lib/tzcode/timezone.c
+++ b/src/lib/tzcode/timezone.c
@@ -105,7 +105,7 @@ timezone_alloc(const char * zonename)
 		tzfree(prev_tz);
 	prev_tz = tzalloc(zonename);
 	assert(strlen(zonename) < lengthof(prev_zonename));
-	strcpy(prev_zonename, zonename);
+	strlcpy(prev_zonename, zonename, sizeof prev_zonename);
 	return prev_tz;
 }
 

--- a/src/proc_title.c
+++ b/src/proc_title.c
@@ -361,7 +361,8 @@ proc_title_set(const char *format, ...)
 		if (ident_handle != INVALID_HANDLE_VALUE)
 			CloseHandle(ident_handle);
 
-		sprintf(name, "pgident(%d): %s", MyProcPid, ps_buffer);
+		snprintf(name, sizeof(name), "pgident(%d): %s", MyProcPid,
+			 ps_buffer);
 
 		ident_handle = CreateEvent(NULL, TRUE, FALSE, name);
 	}

--- a/src/systemd.c
+++ b/src/systemd.c
@@ -117,7 +117,7 @@ int systemd_notify(const char *message) {
 		.sun_family = AF_UNIX,
 	};
 
-	strncpy(sa.sun_path, sd_unix_path, sizeof(sa.sun_path) - 1);
+	strlcpy(sa.sun_path, sd_unix_path, sizeof(sa.sun_path));
 	if (sa.sun_path[0] == '@')
 		sa.sun_path[0] = '\0';
 

--- a/src/trivia/config.h.cmake
+++ b/src/trivia/config.h.cmake
@@ -50,7 +50,12 @@
 /**
  * Defined if strlcpy() string extension helper present.
  */
- #cmakedefine HAVE_STRLCPY 1
+#cmakedefine HAVE_STRLCPY 1
+
+/**
+ * Defined if strlcat() string extension helper present.
+ */
+ #cmakedefine HAVE_STRLCAT 1
 
 /*
  * Defined if gcov instrumentation should be enabled.

--- a/src/trivia/util.h
+++ b/src/trivia/util.h
@@ -517,6 +517,21 @@ size_t
 strlcpy(char *dst, const char *src, size_t size);
 #endif
 
+#ifndef HAVE_STRLCAT
+/**
+ * Append the null-terminated string @a src to the end of @a dst string.
+ * Unlike @a strncat the resulting string is always null-terminated.
+ *
+ * @param dst destination buffer and the first input string
+ * @param src the second input string
+ * @param size destination buffer size
+ *
+ * @return the total length of the string, that it is trying to create
+ */
+size_t
+strlcat(char *dst, const char *src, size_t size);
+#endif
+
 /**
  * Check that @a str is valid utf-8 sequence and can be printed
  * unescaped.

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -323,3 +323,6 @@ target_link_libraries(memtx_allocator.test unit core box)
 
 add_executable(tt_sigaction.test tt_sigaction.c core_test_utils.c)
 target_link_libraries(tt_sigaction.test core unit pthread)
+
+add_executable(string.test string.c core_test_utils.c)
+target_link_libraries(string.test core unit)

--- a/test/unit/string.c
+++ b/test/unit/string.c
@@ -1,0 +1,52 @@
+#include "string.h"
+#include "unit.h"
+#include "trivia/util.h"
+
+static void
+test_strlcat(void)
+{
+	plan(4 * 2);
+	header();
+
+	/* Normal case */
+	char buf[14] = "Hello";
+	size_t len1 = strlen(buf);
+	const char *str2 = ", world!";
+	size_t rc = strlcat(buf, str2, sizeof(buf));
+	ok(rc == len1 + strlen(str2), "normal: length");
+	ok(strcmp(buf, "Hello, world!") == 0, "normal: string");
+
+	/* size == strlen(buf) + 1 */
+	buf[len1] = '\0';
+	rc = strlcat(buf, "aaa", len1 + 1);
+	ok(rc == len1 + strlen("aaa"), "overflow 1: length");
+	ok(strcmp(buf, "Hello") == 0, "overflow 1: string");
+
+	/* size < strlen(buf) */
+	rc = strlcat(buf, "hmm", 2);
+	ok(rc == 2 + strlen("hmm"), "overflow 2: length");
+	ok(strcmp(buf, "Hello") == 0, "overflow 2: string");
+
+	/* Concatenated string bigger than `size` */
+	buf[4] = '\0';
+	len1 = strlen(buf);
+	str2 = " yeah !!!OVERFLOW!!!";
+	rc = strlcat(buf, str2, sizeof(buf));
+	ok(rc == len1 + strlen(str2), "overflow 3: length");
+	ok(strcmp(buf, "Hell yeah !!!") == 0, "overflow 3: string");
+
+	footer();
+	check_plan();
+}
+
+int
+main(void)
+{
+	plan(1);
+	header();
+
+	test_strlcat();
+
+	footer();
+	return check_plan();
+}

--- a/test/unit/string.result
+++ b/test/unit/string.result
@@ -1,0 +1,15 @@
+1..1
+	*** main ***
+    1..8
+	*** test_strlcat ***
+    ok 1 - normal: length
+    ok 2 - normal: string
+    ok 3 - overflow 1: length
+    ok 4 - overflow 1: string
+    ok 5 - overflow 2: length
+    ok 6 - overflow 2: string
+    ok 7 - overflow 3: length
+    ok 8 - overflow 3: string
+	*** test_strlcat: done ***
+ok 1 - subtests
+	*** main: done ***


### PR DESCRIPTION
**util: introduce strlcat utility function**
strlcat is a function from BSD, which is designed to be safer, more
consistent, and less error prone replacement for strcat and strncat.

**Use size-bounded versions of sprintf, strcpy and strcat**
To avoid potential buffer overflows and to make static analyzers happy.

Fixed CWE-120:
- sprintf: does not check for buffer overflows
- strcpy: does not check for buffer overflows when copying to destination
- strcat: does not check for buffer overflows when concatenating to
  destination

Closes https://github.com/tarantool/tarantool/issues/7534