### PR TITLE
doc: proofread 1.10.14 changelog

### DIFF
--- a/changelogs/1.10.14.md
+++ b/changelogs/1.10.14.md
@@ -30,34 +30,34 @@ all the new features of the 1.10.x series.
 
 ### Build
 
-* Support fedora-35 build. (gh-6692)
-* Bump OpenSSL from 1.1.1f to 1.1.1n for static build (gh-6947).
+* Fedora 35 is now supported (gh-6692).
+* Updated OpenSSL used for static builds to version 1.1.1n. (gh-6947).
 * Updated libcurl to version 7.83.0 (gh-6029).
-* Support Fedora-36 build.
-* Support Ubuntu Jammy (22.04) build.
-* Stop support of Fedora 30/31/32/33 builds.
-* Stop support of Ubuntu Hirsute (21.04) build.
+* Fedora 36 is now supported.
+* Ubuntu 22.04 (Jammy Jellyfish) is now supported.
+* Fedora 30, 31,32, and 33 are no longer supported.
+* Ubuntu 21.04 (Hirsute Hippo) is no longer supported.
 * Updated libcurl to version 7.84.0.
-* Bump OpenSSL from 1.1.1n to 1.1.1q for static build.
-* Updated libyaml to version with fixed stack overflows.
+* Updated OpenSSL used for static builds to version 1.1.1q.
+* Updated libyaml to the version with fixed stack overflows.
 
 ## Bugs fixed
 
 ### Core
 
-* Fixed memory leak in interactive console (gh-6817).
-* Fixed an assertion fail when passing tuple without primary key fields
-  to before_replace trigger. Now tuple format is checked before execution 
-  of before_replace triggers and after each one (gh-6780).
-* Now inserting a tuple with the wrong "id" field into the \_priv space will
-  return the correct error (gh-6295).
-* Fixed a bug due to which all fibers created with `fiber_attr_setstacksize()`
-  leaked until the thread exit. Their stacks also leaked except when
+* Fixed a memory leak in the interactive console (gh-6817).
+* Fixed an assertion fail when passing a tuple without the primary key fields
+  to a `before_replace` trigger. Now the tuple format is checked before the execution 
+  of `before_replace` triggers and after each of them (gh-6780).
+* Now inserting a tuple with a wrong `id` field into the `\_priv` space returns
+  the correct error (gh-6295).
+* Fixed a bug that was making all fibers created with `fiber_attr_setstacksize()`
+  leak until the thread exit. Their stacks also leaked except when
   `fiber_set_joinable(..., true)` was used.
-* Fixed a crash when tarantool is launched with multiple -e or -l options
-  without a space between the option and the value (gh-5747).
-* Fixed usage of `box.session.peer()` in `box.session.on_disconnect()` trigger.
-  Now, it's safe to assume that `box.session.peer()` returns the address of the
+* Fixed a crash that happened when Tarantool was launched with multiple `-e` or `-l` options
+  without spaces between the options and their values (gh-5747).
+* Fixed the usage of `box.session.peer()` in `box.session.on_disconnect()` triggers.
+  Now it's safe to assume that `box.session.peer()` returns the address of the
   disconnected peer, not nil, as it used to (gh-7014).
 * Fixed a bug in the sequence cache that could result in an error creating
   a new sequence (gh-5306).
@@ -65,57 +65,56 @@ all the new features of the 1.10.x series.
 ### Vinyl
 
 * Immediate removal of compacted run files created after the last checkpoint
-  optimization now works for replica's initial JOIN stage (gh-6568).
-* Fixed crash during recovery of a secondary index in case the primary index
+  optimization now works for the initial JOIN stage of a replica (gh-6568).
+* Fixed a crash during the recovery of a secondary index in case the primary index
   contains incompatible phantom tuples (gh-6778).
-* Fixed a bug in Vinyl upsert squashing optimization that could lead to
+* Fixed a bug in the vinyl upsert squashing optimization that could lead to
   a segmentation fault error (gh-5080).
-* Fixed a bug in Vinyl read iterator that could result in a significant
-  performance degradation of range select requests in presence of an intensive
+* Fixed a bug in the vinyl read iterator that could result in a significant
+  performance degradation of range select requests in the presence of an intensive
   write workload (gh-5700).
 
 ### Replication
 
-* Fixed replicas failing to bootstrap when master is just re-started (gh-6966).
+* Fixed replicas failing to bootstrap when the master has just restarted (gh-6966).
 
 ### LuaJIT
 
-* Fixed top part of Lua stack (red zone, free slots, top slot) unwinding in
-  `lj-stack` command.
+* Fixed the top part of Lua stack (red zone, free slots, top slot) unwinding in
+  the `lj-stack` command.
 * Added the value of `g->gc.mmudata` field to `lj-gc` output.
-* `string.char()` builtin recording is fixed in case when no arguments are
-  given (gh-6371, gh-6548).
-* Actually made JIT respect `maxirconst` trace limit while recording (gh-6548).
-Backported patches from vanilla LuaJIT trunk (gh-6548). In the scope of this
-activity, the following issues have been resolved:
+* Fixed a bug with `string.char()` builtin recording when no arguments are
+  provided (gh-6371, gh-6548).
+* Actually made JIT respect the `maxirconst` trace limit while recording (gh-6548).
+* Backported patches from vanilla LuaJIT trunk (gh-6548, gh-7230). In the scope of this
+ activity, the following issues have been resolved:
 
-* Fixed emitting for fuse load of constant in GC64 mode (gh-4095, gh-4199, gh-4614).
-* Now initialization of zero-filled struct is compiled (gh-4630, gh-5885).
-* Actually implemented `maxirconst` option for tuning JIT compiler.
-* Fixed JIT stack of Lua slots overflow during recording for metamethod calls.
-* Fixed bytecode dump unpatching for JLOOP in up-recursion compiled functions.
-* Fixed FOLD rule for strength reduction of widening in cdata indexing.
-* Fixed `string.char()` recording without arguments.
-* Fixed `print()` behaviour with the reloaded default metatable for numbers.
-* `tonumber("-0")` now saves the sign of number for conversion.
-* `tonumber()` now give predictable results for negative non-base-10 numbers.
-* Fixed write barrier for `debug.setupvalue()` and `lua_setupvalue()`.
-* `jit.p` now flushes and closes output file after run, not at program exit.
-* Fixed `jit.p` profiler interaction with GC finalizers.
-* Fixed the case for partial recording of vararg function body with the fixed
-  number of result values in with `LJ_GC64` (i.e. `LJ_FR2` enabled) (gh-7172).
-Backported patches from vanilla LuaJIT trunk (gh-7230). In the scope of this
-activity, the following issues have been resolved:
-
-* Fix handling of errors during trace snapshot restore.
+  * Fixed emitting for fuse load of constant in GC64 mode (gh-4095, gh-4199, gh-4614).
+  * Now initialization of zero-filled struct is compiled (gh-4630, gh-5885).
+  * Actually implemented `maxirconst` option for tuning JIT compiler.
+  * Fixed JIT stack of Lua slots overflow during recording for metamethod calls.
+  * Fixed bytecode dump unpatching for JLOOP in up-recursion compiled functions.
+  * Fixed FOLD rule for strength reduction of widening in cdata indexing. 
+  * Fixed `string.char()` recording without arguments.
+  * Fixed `print()` behaviour with the reloaded default metatable for numbers.
+  * `tonumber("-0")` now saves the sign of number for conversion.
+  * `tonumber()` now give predictable results for negative non-base-10 numbers.
+  * Fixed write barrier for `debug.setupvalue()` and `lua_setupvalue()`.
+  * `jit.p` now flushes and closes output file after run, not at program exit.
+  * Fixed `jit.p` profiler interaction with GC finalizers.
+  * Fixed the case for partial recording of vararg function body with the fixed
+    number of result values in with `LJ_GC64` (i.e. `LJ_FR2` enabled) (gh-7172).
+  * Fixed handling of errors during trace snapshot restore.
 
 ### Box
 
-* Add iterator type checking and allow to pass iterator as a box.index.{ALL,GT,...} directly (gh-6501).
+* Added the check of the iterator type in the `select`, `count`, and `pairs` methods of
+  the index object. Iterator can now be passed to these methods directly: `box.index.ALL`,
+  `box.index.GT`, and so on (gh-6501).
 
 ### Recovery
 
-* When `force_recovery` cfg option is set, Tarantool is able to boot from
+* With the `force_recovery` cfg option, Tarantool is now able to boot from
   `snap`/`xlog` combinations where `xlog` covers changes committed both before
-  and after `snap` creation. For example, `0...0.xlog`, covering everything up
-  to vclock `{1: 15}` and `0...09.snap`, corresponding to `vclock `{1: 9}` (gh-6794).
+  and after the `snap` was created. For example, `0...0.xlog` that covers everything up
+  to vclock `{1: 15}` and `0...09.snap` corresponding to `vclock `{1: 9}` (gh-6794).


### PR DESCRIPTION
doc: proofread changelog 1.10.14
Resolves https://github.com/tarantool/doc/issues/3045

Fix wording, punctuation, and formatting.

NO_DOC=changelog
NO_TEST=changelog