### PR TITLE
core: fix crashes after altering trigger list while it is run

### DIFF
--- a/changelogs/unreleased/gh-4264-trigger-crash-on-nontrivial-change.md
+++ b/changelogs/unreleased/gh-4264-trigger-crash-on-nontrivial-change.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed crashes or undefined behaviour with triggers clearing other triggers
+  (gh-4264).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -5868,68 +5868,20 @@ on_replace_dd_func_index(struct trigger *trigger, void *event)
 	return 0;
 }
 
-struct trigger alter_space_on_replace_space = {
-	RLIST_LINK_INITIALIZER, on_replace_dd_space, NULL, NULL
-};
-
-struct trigger alter_space_on_replace_index = {
-	RLIST_LINK_INITIALIZER, on_replace_dd_index, NULL, NULL
-};
-
-struct trigger on_replace_truncate = {
-	RLIST_LINK_INITIALIZER, on_replace_dd_truncate, NULL, NULL
-};
-
-struct trigger on_replace_schema = {
-	RLIST_LINK_INITIALIZER, on_replace_dd_schema, NULL, NULL
-};
-
-struct trigger on_replace_user = {
-	RLIST_LINK_INITIALIZER, on_replace_dd_user, NULL, NULL
-};
-
-struct trigger on_replace_func = {
-	RLIST_LINK_INITIALIZER, on_replace_dd_func, NULL, NULL
-};
-
-struct trigger on_replace_collation = {
-	RLIST_LINK_INITIALIZER, on_replace_dd_collation, NULL, NULL
-};
-
-struct trigger on_replace_priv = {
-	RLIST_LINK_INITIALIZER, on_replace_dd_priv, NULL, NULL
-};
-
-struct trigger on_replace_cluster = {
-	RLIST_LINK_INITIALIZER, on_replace_dd_cluster, NULL, NULL
-};
-
-struct trigger on_replace_sequence = {
-	RLIST_LINK_INITIALIZER, on_replace_dd_sequence, NULL, NULL
-};
-
-struct trigger on_replace_sequence_data = {
-	RLIST_LINK_INITIALIZER, on_replace_dd_sequence_data, NULL, NULL
-};
-
-struct trigger on_replace_space_sequence = {
-	RLIST_LINK_INITIALIZER, on_replace_dd_space_sequence, NULL, NULL
-};
-
-struct trigger on_replace_trigger = {
-	RLIST_LINK_INITIALIZER, on_replace_dd_trigger, NULL, NULL
-};
-
-struct trigger on_replace_fk_constraint = {
-	RLIST_LINK_INITIALIZER, on_replace_dd_fk_constraint, NULL, NULL
-};
-
-struct trigger on_replace_ck_constraint = {
-	RLIST_LINK_INITIALIZER, on_replace_dd_ck_constraint, NULL, NULL
-};
-
-struct trigger on_replace_func_index = {
-	RLIST_LINK_INITIALIZER, on_replace_dd_func_index, NULL, NULL
-};
-
+TRIGGER(alter_space_on_replace_space, on_replace_dd_space);
+TRIGGER(alter_space_on_replace_index, on_replace_dd_index);
+TRIGGER(on_replace_truncate, on_replace_dd_truncate);
+TRIGGER(on_replace_schema, on_replace_dd_schema);
+TRIGGER(on_replace_user, on_replace_dd_user);
+TRIGGER(on_replace_func, on_replace_dd_func);
+TRIGGER(on_replace_collation, on_replace_dd_collation);
+TRIGGER(on_replace_priv, on_replace_dd_priv);
+TRIGGER(on_replace_cluster, on_replace_dd_cluster);
+TRIGGER(on_replace_sequence, on_replace_dd_sequence);
+TRIGGER(on_replace_sequence_data, on_replace_dd_sequence_data);
+TRIGGER(on_replace_space_sequence, on_replace_dd_space_sequence);
+TRIGGER(on_replace_trigger, on_replace_dd_trigger);
+TRIGGER(on_replace_fk_constraint, on_replace_dd_fk_constraint);
+TRIGGER(on_replace_ck_constraint, on_replace_dd_ck_constraint);
+TRIGGER(on_replace_func_index, on_replace_dd_func_index);
 /* vim: set foldmethod=marker */

--- a/src/box/lua/call.c
+++ b/src/box/lua/call.c
@@ -1124,9 +1124,7 @@ on_msgpack_serializer_update(struct trigger *trigger, void *event)
 	return 0;
 }
 
-static struct trigger on_alter_func_in_lua = {
-	RLIST_LINK_INITIALIZER, lbox_func_new_or_delete, NULL, NULL
-};
+static TRIGGER(on_alter_func_in_lua, lbox_func_new_or_delete);
 
 static const struct luaL_Reg boxlib_internal[] = {
 	{"call_loadproc",  lbox_call_loadproc},

--- a/src/box/lua/space.cc
+++ b/src/box/lua/space.cc
@@ -654,9 +654,7 @@ box_lua_space_new_or_delete(struct trigger *trigger, void *event)
 	return 0;
 }
 
-static struct trigger on_alter_space_in_lua = {
-	RLIST_LINK_INITIALIZER, box_lua_space_new_or_delete, NULL, NULL
-};
+static TRIGGER(on_alter_space_in_lua, box_lua_space_new_or_delete);
 
 /**
  * Make a tuple or a table Lua object by map.

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -4511,9 +4511,7 @@ vy_deferred_delete_on_replace(struct trigger *trigger, void *event)
 	return 0;
 }
 
-static struct trigger on_replace_vinyl_deferred_delete = {
-	RLIST_LINK_INITIALIZER, vy_deferred_delete_on_replace, NULL, NULL
-};
+static TRIGGER(on_replace_vinyl_deferred_delete, vy_deferred_delete_on_replace);
 
 /* }}} Deferred DELETE handling */
 

--- a/src/lib/core/coio_task.c
+++ b/src/lib/core/coio_task.c
@@ -122,6 +122,7 @@ static int
 coio_on_stop(void *data)
 {
 	(void) data;
+	cord_exit(cord());
 	cord_destroy(cord());
 	free(cord());
 	return 0;

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -1798,9 +1798,7 @@ cord_costart_thread_func(void *arg)
 	if (f == NULL)
 		return NULL;
 
-	struct trigger break_ev_loop = {
-		RLIST_LINK_INITIALIZER, break_ev_loop_f, NULL, NULL
-	};
+	TRIGGER(break_ev_loop, break_ev_loop_f);
 	/*
 	 * Got to be in a trigger, to break the loop even
 	 * in case of an exception.

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -1561,6 +1561,13 @@ cord_add_garbage(struct cord *cord, struct fiber *f)
 }
 
 void
+cord_exit(struct cord *cord)
+{
+	assert(cord == cord());
+	(void)cord;
+}
+
+void
 cord_destroy(struct cord *cord)
 {
 	slab_cache_set_thread(&cord->slabc);
@@ -1625,6 +1632,9 @@ void *cord_thread_func(void *p)
 	                                            CORD_ON_EXIT_WONT_RUN);
 	if (!changed)
 		handler->callback(handler->argument);
+
+	cord_exit(cord());
+
 	return res;
 }
 
@@ -1874,6 +1884,7 @@ fiber_init(int (*invoke)(fiber_func f, va_list ap))
 void
 fiber_free(void)
 {
+	cord_exit(&main_cord);
 	cord_destroy(&main_cord);
 }
 

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -1525,6 +1525,7 @@ cord_create(struct cord *cord, const char *name)
 	}
 	cord_set_name(name);
 
+	trigger_init_in_thread();
 #if ENABLE_ASAN
 	/* Record stack extents */
 	tt_pthread_attr_getstack(cord->id, &cord->sched.stack,
@@ -1565,6 +1566,7 @@ cord_exit(struct cord *cord)
 {
 	assert(cord == cord());
 	(void)cord;
+	trigger_free_in_thread();
 }
 
 void

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -771,6 +771,13 @@ extern __thread struct cord *cord_ptr;
 void
 cord_create(struct cord *cord, const char *name);
 
+/**
+ * Perform all the thread-specific deinitialization. Must be called in the
+ * exiting thread.
+ */
+void
+cord_exit(struct cord *cord);
+
 void
 cord_destroy(struct cord *cord);
 

--- a/src/lib/core/trigger.h
+++ b/src/lib/core/trigger.h
@@ -59,6 +59,16 @@ struct trigger
 	trigger_f0 destroy;
 };
 
+#define TRIGGER_INITIALIZER(run) {\
+	RLIST_LINK_INITIALIZER,\
+	(run),\
+	NULL,\
+	NULL\
+}
+
+#define TRIGGER(name, run)\
+	struct trigger name = TRIGGER_INITIALIZER(run)
+
 static inline void
 trigger_create(struct trigger *trigger, trigger_f run, void *data,
 	       trigger_f0 destroy)

--- a/src/lib/core/trigger.h
+++ b/src/lib/core/trigger.h
@@ -139,7 +139,7 @@ trigger_run_reverse(struct rlist *list, void *event);
  * If timeout has expired and function immediately stops,
  * without waiting for other triggers completion.
  */
-void
+int
 trigger_fiber_run(struct rlist *list, void *event, double timeout);
 
 #if defined(__cplusplus)

--- a/src/lua/trigger.c
+++ b/src/lua/trigger.c
@@ -211,9 +211,8 @@ lbox_trigger_reset(struct lua_State *L, int top, struct rlist *list,
 			trg = (struct lbox_trigger *) malloc(sizeof(*trg));
 			if (trg == NULL)
 				luaL_error(L, "failed to allocate trigger");
-			trg->base.run = lbox_trigger_run;
-			trg->base.data = NULL;
-			trg->base.destroy = lbox_trigger_destroy;
+			trigger_create(&trg->base, lbox_trigger_run, NULL,
+				       lbox_trigger_destroy);
 			trg->ref = LUA_NOREF;
 			trg->push_event = push_event;
 			trg->pop_event = pop_event;

--- a/src/main.cc
+++ b/src/main.cc
@@ -139,8 +139,12 @@ static int
 on_shutdown_f(va_list ap)
 {
 	(void) ap;
-	trigger_fiber_run(&box_on_shutdown_trigger_list, NULL,
-			  on_shutdown_trigger_timeout);
+	if (trigger_fiber_run(&box_on_shutdown_trigger_list, NULL,
+			      on_shutdown_trigger_timeout) != 0) {
+		say_error("on_shutdown triggers failed");
+		diag_log();
+		diag_clear(diag_get());
+	}
 	say_logger_free();
 	ev_break(loop(), EVBREAK_ALL);
 	return 0;

--- a/test/box-luatest/gh_4264_recursive_trigger_test.lua
+++ b/test/box-luatest/gh_4264_recursive_trigger_test.lua
@@ -1,0 +1,43 @@
+local t = require('luatest')
+local server = require('test.luatest_helpers.server')
+
+local g = t.group('gh-4264')
+
+g.before_all(function(cg)
+    cg.server = server:new{alias = 'server'}
+    cg.server:start()
+    cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        s:create_index('pk')
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_recursive_trigger_invocation = function(cg)
+    local order = cg.server:exec(function()
+        local order = {}
+        local level = 0
+        local s = box.space.test
+        local f1 = function()
+            level = level + 1
+            table.insert(order, level * 10 + 1)
+            if level >= 3 then
+                return
+            end
+            s:replace{1}
+            level = level - 1
+        end
+        local f2 = function()
+            table.insert(order, level * 10 + 2)
+        end
+        s:on_replace(f2)
+        s:on_replace(f1)
+        s:replace{1}
+        return order
+    end)
+    t.assert_equals(order, {11, 21, 31, 32, 22, 12},
+                    "Correct recursive trigger invocation")
+end

--- a/test/box-luatest/gh_4264_recursive_trigger_test.lua
+++ b/test/box-luatest/gh_4264_recursive_trigger_test.lua
@@ -1,5 +1,6 @@
 local t = require('luatest')
 local server = require('test.luatest_helpers.server')
+local fio = require('fio')
 
 local g = t.group('gh-4264')
 
@@ -40,4 +41,67 @@ g.test_recursive_trigger_invocation = function(cg)
     end)
     t.assert_equals(order, {11, 21, 31, 32, 22, 12},
                     "Correct recursive trigger invocation")
+end
+
+g.test_trigger_clear_from_trigger = function(cg)
+    local order = cg.server:exec(function()
+        local order = {}
+        local s = box.space.test
+        local f2 = function()
+            table.insert(order, 2)
+        end
+        local f1
+        f1 = function()
+            table.insert(order, 1)
+            s:on_replace(nil, f2)
+            s:on_replace(nil, f1)
+        end
+        s:on_replace(f2)
+        s:on_replace(f1)
+        s:replace{2}
+        return order
+    end)
+    t.assert_equals(order, {1}, "Correct trigger invocation when 1st trigger \
+                                 clears 2nd")
+end
+
+local g2 = t.group('gh-4264-on-shutdown')
+
+g2.before_test('test_on_shutdown_trigger_clear', function(cg)
+    cg.server = server:new{alias = 'server'}
+    cg.server:start()
+end)
+
+g2.after_test('test_on_shutdown_trigger_clear', function(cg)
+    cg.server:cleanup()
+end)
+
+g2.test_on_shutdown_trigger_clear = function(cg)
+    cg.server:exec(function()
+        local log = require('log')
+        local f2 = function()
+            log.info('trigger 2 executed')
+        end
+        local f1
+        f1 = function()
+            log.info('trigger 1 executed')
+            box.ctl.on_shutdown(nil, f2)
+            box.ctl.on_shutdown(nil, f1)
+        end
+        box.ctl.on_shutdown(f2)
+        box.ctl.on_shutdown(f1)
+        -- Killing the server with luatest doesn't trigger the issue. Need
+        -- os.exit for that.
+        require('fiber').new(os.exit)
+    end)
+
+    local logfile = fio.pathjoin(cg.server.workdir, 'server.log')
+    t.helpers.retrying({}, function()
+        local found = cg.server:grep_log('trigger 1 executed', nil,
+                                         {filename = logfile})
+        t.assert(found ~= nil, 'first on_shutdown trigger is executed')
+    end)
+    local found = cg.server:grep_log('trigger 2 executed', nil,
+                                     {filename = logfile})
+    t.assert(found == nil, 'second on_shutdown trigger is not executed')
 end

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -104,6 +104,8 @@ add_executable(prbuf.test prbuf.c)
 target_link_libraries(prbuf.test unit core)
 add_executable(clock_lowres.test clock_lowres.c core_test_utils.c)
 target_link_libraries(clock_lowres.test unit core)
+add_executable(trigger.test trigger.c core_test_utils.c)
+target_link_libraries(trigger.test unit core)
 
 if (NOT ENABLE_GCOV)
     # This test is known to be broken with GCOV

--- a/test/unit/trigger.c
+++ b/test/unit/trigger.c
@@ -1,0 +1,202 @@
+#define UNIT_TAP_COMPATIBLE 1
+#include "unit.h"
+#include <stdbool.h>
+#include <assert.h>
+#include "memory.h"
+#include "fiber.h"
+#include "trigger.h"
+
+/* Length of trigger chains to test. */
+#define TEST_LENGTH 5
+#define FUNC_COUNT (TEST_LENGTH + 3)
+
+struct test_trigger {
+	struct trigger base;
+	int id;
+	int target_id;
+};
+
+/* How many times each trigger was run. */
+static int was_run[TEST_LENGTH];
+/* Function codes for each trigger. */
+static int funcs[TEST_LENGTH];
+static struct test_trigger triggers[TEST_LENGTH];
+
+static RLIST_HEAD(list_a);
+static RLIST_HEAD(list_b);
+
+static int
+trigger_nop_f(struct trigger *trigger, void *event)
+{
+	struct test_trigger *trig = (struct test_trigger *)trigger;
+	was_run[trig->id]++;
+	return 0;
+}
+
+static int
+trigger_err_f(struct trigger *trigger, void *event)
+{
+	trigger_nop_f(trigger, event);
+	return -1;
+}
+
+static int
+trigger_swap_f(struct trigger *trigger, void *event)
+{
+	trigger_nop_f(trigger, event);
+	rlist_swap(&list_a, &list_b);
+	return 0;
+}
+
+static int
+trigger_clear_f(struct trigger *trigger, void *event)
+{
+	trigger_nop_f(trigger, event);
+	struct test_trigger *trig = (struct test_trigger *)trigger;
+	int clear_id = trig->target_id;
+	trigger_clear(&triggers[clear_id].base);
+	return 0;
+}
+
+/**
+ * Types of trigger functions which might harm trigger_run one way or another.
+ */
+enum func_type {
+	/** Do nothing. */
+	FUNC_TYPE_NOP,
+	/** Error. */
+	FUNC_TYPE_ERR,
+	/** Swap trigger list heads. */
+	FUNC_TYPE_SWAP,
+	/** Clear one of the triggers: self or other. */
+	FUNC_TYPE_CLEAR,
+};
+
+static int
+func_type_by_no(int func_no)
+{
+	assert(func_no >= 0 && func_no < FUNC_COUNT);
+	if (func_no < TEST_LENGTH)
+		return FUNC_TYPE_CLEAR;
+	else if (func_no == TEST_LENGTH)
+		return FUNC_TYPE_ERR;
+	else if (func_no == TEST_LENGTH + 1)
+		return FUNC_TYPE_NOP;
+	else /* if (func_no == TEST_LENGTH + 2) */
+		return FUNC_TYPE_SWAP;
+}
+
+static void
+fill_trigger_list(struct rlist *list, bool *should_run, int direction)
+{
+	for (int i = 0; i < TEST_LENGTH; i++)
+		should_run[i] = true;
+	rlist_create(list);
+	/*
+	 * Create triggers and deduce which should and which shouldn't run based
+	 * on trigger functions and run direction.
+	 */
+	for (int i = (TEST_LENGTH - 1) * (1 - direction) / 2;
+	     i >= 0 && i < TEST_LENGTH; i += direction) {
+		was_run[i] = 0;
+		triggers[i].id = i;
+		int func_no = funcs[i];
+		switch (func_type_by_no(func_no)) {
+		case FUNC_TYPE_CLEAR:
+			trigger_create(&triggers[i].base,
+				       trigger_clear_f, NULL, NULL);
+			triggers[i].target_id = func_no;
+			if (!should_run[i])
+				break;
+			int target_id = funcs[i];
+			if (direction * i < direction * target_id)
+				should_run[target_id] = false;
+			break;
+		case FUNC_TYPE_ERR:
+			trigger_create(&triggers[i].base, trigger_err_f,
+				       NULL, NULL);
+			if (!should_run[i])
+				break;
+			for (int j = i + direction; j >= 0 && j < TEST_LENGTH;
+			     j += direction) {
+				should_run[j] = false;
+			}
+			break;
+		case FUNC_TYPE_NOP:
+			trigger_create(&triggers[i].base, trigger_nop_f,
+				       NULL, NULL);
+			break;
+		case FUNC_TYPE_SWAP:
+			trigger_create(&triggers[i].base,
+				       trigger_swap_f, NULL, NULL);
+			break;
+		}
+	}
+	/*
+	 * Add triggers in reverse order, so that trigger[0] is first to run in
+	 * direct order and last to run in reverse order.
+	 */
+	for (int i = TEST_LENGTH - 1; i >= 0; i--)
+		trigger_add(list, &triggers[i].base);
+}
+
+static void
+test_trigger_one(void)
+{
+	plan(2 * TEST_LENGTH);
+	for (int direction = -1; direction <= 1; direction += 2) {
+		bool should_run[TEST_LENGTH];
+		fill_trigger_list(&list_a, should_run, direction);
+		if (direction == 1)
+			trigger_run(&list_a, NULL);
+		else
+			trigger_run_reverse(&list_a, NULL);
+		for (int i = 0; i < TEST_LENGTH; i++) {
+			ok((should_run[i] && was_run[i] == 1) ||
+			   (!should_run[i] && was_run[i] == 0),
+			   "Triggers ran correctly");
+		}
+	}
+	check_plan();
+}
+
+static void
+test_trigger(int pos, bool had_clear)
+{
+	if (pos == TEST_LENGTH)
+		return test_trigger_one();
+	int i = had_clear ? TEST_LENGTH : 0;
+	plan(FUNC_COUNT - i);
+	for (i; i < FUNC_COUNT; i++) {
+		funcs[pos] = i;
+		test_trigger(pos + 1, had_clear || func_type_by_no(i) ==
+						   FUNC_TYPE_CLEAR);
+	}
+	check_plan();
+}
+
+static int
+test_trigger_clear_during_run(void)
+{
+	header();
+	plan(1);
+
+	test_trigger(0, false);
+
+	footer();
+	return check_plan();
+}
+
+int
+main(void)
+{
+	memory_init();
+	fiber_init(fiber_c_invoke);
+
+	plan(1);
+	test_trigger_clear_during_run();
+
+	fiber_free();
+	memory_free();
+	return check_plan();
+}

--- a/test/unit/unit.h
+++ b/test/unit/unit.h
@@ -136,6 +136,8 @@ int check_plan(void);
 
 #if UNIT_TAP_COMPATIBLE
 
+#include <stdarg.h> /* va_start(), va_end() */
+
 #define header()					\
 	do { 						\
 		_space(stdout);				\


### PR DESCRIPTION
This patch fixes a number of issues with trigger_clear() while the
trigger list is being run:
1) clearing the next-to-be-run trigger doesn't prevent it from being run
2) clearing the next-to-be-run trigger causes an infinite loop or a
   crash
3) swapping trigger list head before the last trigger is run causes an
   infinite loop or a crash (see space_swap_triggers() in alter.cc, which
   had worked all this time by miracle: space _space on_replace trigger
   swaps its own head during local recovery, and that had only worked
   because the trigger by luck was the last to run)

This is fixed by adding triggers in a separate run list on trigger_run.
This list may be iterated by `rlist_shift_entry`, which doesn't suffer
from any of the problems mentioned above.

While being bad in a number of ways, old approach supported practically
unlimited number of concurrent trigger_runs for the same trigger list.
The new approach requires the trigger to be in as many run lists as
there are concurrent trigger_runs, which results in quite a big
refactoring.

Add a luatest-based test and a unit test.

Closes #4264

NO_DOC=bugfix