### PR TITLE
test: fix flakiness in app-luatest/http_client_test.lua

### DIFF
--- a/test/app-luatest/suite.ini
+++ b/test/app-luatest/suite.ini
@@ -2,11 +2,3 @@
 core = luatest
 description = application server tests on luatest
 is_parallel = True
-fragile = {
-    "retries": 10,
-    "tests": {
-        "http_client_test.lua": {
-            "issues": [ "gh-5346", "gh-5574" ]
-        }
-    }
-  }

--- a/test/app-tap/suite.ini
+++ b/test/app-tap/suite.ini
@@ -9,22 +9,7 @@ fragile = {
     "retries": 10,
     "tests": {
         "tarantoolctl.test.lua": {
-            "issues": [ "gh-5059", "gh-5346" ]
+            "issues": [ "gh-5059" ]
         },
-        "debug.test.lua": {
-            "issues": [ "gh-5346" ]
-        },
-        "inspector.test.lua": {
-            "issues": [ "gh-5346" ]
-        },
-        "logger.test.lua": {
-            "issues": [ "gh-5346" ]
-        },
-        "transitive1.test.lua": {
-            "issues": [ "gh-5346" ]
-        },
-        "csv.test.lua": {
-            "issues": [ "gh-5346" ]
-        }
     }
   }

--- a/test/box-tap/suite.ini
+++ b/test/box-tap/suite.ini
@@ -9,16 +9,7 @@ fragile = {
     "retries": 10,
     "tests": {
         "cfg.test.lua": {
-            "issues": [ "gh-5346", "gh-4344" ]
-        },
-        "net.box.test.lua": {
-            "issues": [ "gh-5346" ]
-        },
-        "session.storage.test.lua": {
-            "issues": [ "gh-5346" ]
-        },
-        "session.test.lua": {
-            "issues": [ "gh-5346" ]
+            "issues": [ "gh-4344" ]
         },
         "gh-4231-box-execute-locking.test.lua": {
             "issues": [ "gh-5558" ]


### PR DESCRIPTION
In commit 5710204804 ("test: migrate app-tap/http_client test to
luates") app-luatest/http_client.test.lua has been rewritten for luatest
and tickets were blindly migrated to a new test suite too.

Rarely test failed with exception "Address already in use":

```
[007] ok     9  http_client.sock_family:"AF_INET".test_special_methods
[007] Traceback (most recent call last):
[007]   File "/home/sergeyb/sources/MRG/tarantool/test/app-luatest/httpd.py", line 142, in <module>
[007]     sock.bind(sock_addr)
[007]   File "/usr/lib/python3/dist-packages/gevent/_socketcommon.py", line 563, in bind
[007]     return self._sock.bind(address)
[007] OSError: [Errno 98] Address already in use
```

Failure could be reproduced with following command line:
"./test/test-run.py $(yes app-luatest/http_client_test.lua | head -n 1000)".
With proposed retries around socket.bind() test is passed 100 times
without any problems.

P.S. The problem with rerunning test is that it hides other problems.
[1] is about "Address already in use" and [2] is about hangs in test.
I made a pull request with changes in http client module and triggered
CI run. Job has been passed, but in log [3] I see three test restarts due to
fails in http_client test related to my changes:

```
[032] Test failed! Output from reject file /tmp/t/rejects/app-luatest/http_client.reject:
[032] TAP version 13
[032] 1..28
[032] # Started on Mon Aug  8 13:27:02 2022
[032] # Starting group: http_client.sock_family:"AF_INET"
[032] Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
[032] BrokenPipeError: [Errno 32] Broken pipe
[032] ok     1	http_client.sock_family:"AF_INET".test_http_client
[032] ok     2	http_client.sock_family:"AF_INET".test_follow_location
[032] ok     3	http_client.sock_family:"AF_INET".test_http_client_headers_redefine
[032] ok     4	http_client.sock_family:"AF_INET".test_cancel_and_errinj
[032] ok     5	http_client.sock_family:"AF_INET".test_post_and_get
[032] ok     6	http_client.sock_family:"AF_INET".test_errors
[032] ok     7	http_client.sock_family:"AF_INET".test_request_headers
[032] ok     8	http_client.sock_family:"AF_INET".test_headers
[032] ok     9	http_client.sock_family:"AF_INET".test_special_methods
[032] ok     10	http_client.sock_family:"AF_INET".test_concurrent
[032] ok     11	http_client.sock_family:"AF_INET".test_http_params_get
[032] ok     12	http_client.sock_family:"AF_INET".test_http_params_post
[032] ok     13	http_client.sock_family:"AF_INET".test_http_params_request_get
[032] ok     14	http_client.sock_family:"AF_INET".test_http_params_request_post
[032] # Starting group: http_client.sock_family:"AF_UNIX"
[032] Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
[032] BrokenPipeError: [Errno 32] Broken pipe
[032] ok     15	http_client.sock_family:"AF_UNIX".test_http_client
[032] ok     16	http_client.sock_family:"AF_UNIX".test_follow_location
[032] ok     17	http_client.sock_family:"AF_UNIX".test_http_client_headers_redefine
[032] ok     18	http_client.sock_family:"AF_UNIX".test_cancel_and_errinj
[032] ok     19	http_client.sock_family:"AF_UNIX".test_post_and_get
[032] ok     20	http_client.sock_family:"AF_UNIX".test_errors
[032] ok     21	http_client.sock_family:"AF_UNIX".test_request_headers
[032] ok     22	http_client.sock_family:"AF_UNIX".test_headers
[032] ok     23	http_client.sock_family:"AF_UNIX".test_special_methods
[032] ok     24	http_client.sock_family:"AF_UNIX".test_concurrent
[032] not ok 25	http_client.sock_family:"AF_UNIX".test_http_params_get
[032] #   ...arantool/tarantool/test/app-luatest/http_client_test.lua:666: expected: 200, actual: 408
[032] #   stack traceback:
[032] #   	...arantool/tarantool/test/app-luatest/http_client_test.lua:666: in function 'http_client.sock_family:"AF_UNIX".test_http_params_get'
[032] #   	...
[032] #   	[C]: in function 'xpcall'
[032] ok     26	http_client.sock_family:"AF_UNIX".test_http_params_post
[032] ok     27	http_client.sock_family:"AF_UNIX".test_http_params_request_get
[032] ok     28	http_client.sock_family:"AF_UNIX".test_http_params_request_post
[032] # Ran 28 tests in 308.166 seconds, 27 succeeded, 1 failed
[032] Test "app-luatest/http_client_test.lua", conf: "None"
[032] 	from "fragile" list failed, rerunning ...
No output during 10 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 20 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 30 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 40 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 51 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 61 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 71 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 81 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 91 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 101 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 111 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 121 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 131 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 141 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 151 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 162 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 172 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 182 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 192 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 202 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 212 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 222 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 232 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 242 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 252 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 263 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 273 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 283 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
No output during 293 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 032_app-luatest [app-luatest/http_client_test.lua, None] at /tmp/t/032_app-luatest/http_client.result:0
[032] app-luatest/http_client_test.lua                                [ fail ]
[032] Test failed! Output from reject file /tmp/t/rejects/app-luatest/http_client.reject:
[032] TAP version 13
[032] 1..28
[032] # Started on Mon Aug  8 13:32:11 2022
[032] # Starting group: http_client.sock_family:"AF_INET"
[032] Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
[032] BrokenPipeError: [Errno 32] Broken pipe
[032] ok     1	http_client.sock_family:"AF_INET".test_http_client
[032] ok     2	http_client.sock_family:"AF_INET".test_follow_location
[032] ok     3	http_client.sock_family:"AF_INET".test_http_client_headers_redefine
[032] ok     4	http_client.sock_family:"AF_INET".test_cancel_and_errinj
[032] ok     5	http_client.sock_family:"AF_INET".test_post_and_get
[032] ok     6	http_client.sock_family:"AF_INET".test_errors
[032] ok     7	http_client.sock_family:"AF_INET".test_request_headers
[032] ok     8	http_client.sock_family:"AF_INET".test_headers
[032] ok     9	http_client.sock_family:"AF_INET".test_special_methods
[032] ok     10	http_client.sock_family:"AF_INET".test_concurrent
[032] ok     11	http_client.sock_family:"AF_INET".test_http_params_get
[032] ok     12	http_client.sock_family:"AF_INET".test_http_params_post
[032] ok     13	http_client.sock_family:"AF_INET".test_http_params_request_get
[032] ok     14	http_client.sock_family:"AF_INET".test_http_params_request_post
[032] # Starting group: http_client.sock_family:"AF_UNIX"
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] SystemError: curl: Failure when receiving data from the peer: Connection reset by peer
[032] Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
[032] BrokenPipeError: [Errno 32] Broken pipe
[032] ok     15	http_client.sock_family:"AF_UNIX".test_http_client
[032] ok     16	http_client.sock_family:"AF_UNIX".test_follow_location
[032] ok     17	http_client.sock_family:"AF_UNIX".test_http_client_headers_redefine
[032] ok     18	http_client.sock_family:"AF_UNIX".test_cancel_and_errinj
[032] ok     19	http_client.sock_family:"AF_UNIX".test_post_and_get
[032] ok     20	http_client.sock_family:"AF_UNIX".test_errors
[032] ok     21	http_client.sock_family:"AF_UNIX".test_request_headers
[032] ok     22	http_client.sock_family:"AF_UNIX".test_headers
[032] ok     23	http_client.sock_family:"AF_UNIX".test_special_methods
[032] ok     24	http_client.sock_family:"AF_UNIX".test_concurrent
[032] not ok 25	http_client.sock_family:"AF_UNIX".test_http_params_get
[032] #   ...arantool/tarantool/test/app-luatest/http_client_test.lua:666: expected: 200, actual: 408
[032] #   stack traceback:
[032] #   	...arantool/tarantool/test/app-luatest/http_client_test.lua:666: in function 'http_client.sock_family:"AF_UNIX".test_http_params_get'
[032] #   	...
[032] #   	[C]: in function 'xpcall'
[032] ok     26	http_client.sock_family:"AF_UNIX".test_http_params_post
[032] ok     27	http_client.sock_family:"AF_UNIX".test_http_params_request_get
[032] ok     28	http_client.sock_family:"AF_UNIX".test_http_params_request_post
[032] # Ran 28 tests in 303.294 seconds, 27 succeeded, 1 failed
[032] Test "app-luatest/http_client_test.lua", conf: "None"
[032] 	from "fragile" list failed, rerunning ...
[032] app-luatest/http_client_test.lua                                [ pass ]
[079] small/arena_mt.test                                             [ pass ]
[079] small/ibuf.test                                                 [ pass ]
[079] small/lf_lifo.test                                              [ pass ]
[079] small/lsregion.test                                             [ pass ]
[079] small/matras.test                                               [ pass ]
[079] small/mempool.test                                              [ pass ]
[079] small/obuf.test                                                 [ pass ]
[079] small/quota.test                                                [ pass ]
[079] small/quota_lessor.test                                         [ pass ]
[079] small/rb.test                                                   [ pass ]
[079] small/rb_aug.test                                               [ pass ]
[079] small/rb_rand.test                                              [ pass ]
```

1. https://github.com/tarantool/tarantool-qa/issues/186
2. https://github.com/tarantool/tarantool-qa/issues/31
3. https://github.com/tarantool/tarantool/runs/7726358823?check_suite_focus=true

Closes https://github.com/tarantool/tarantool-qa/issues/186
Closes https://github.com/tarantool/tarantool-qa/issues/31

NO_CHANGELOG=testing
NO_DOC=testing
NO_TEST=testing