### PR TITLE
doc: fix 2.10.1 changelog text

### DIFF
--- a/changelogs/2.10.1.md
+++ b/changelogs/2.10.1.md
@@ -135,7 +135,7 @@ all the new features of the 2.x series.
 * Fixed the foreign key check on `space_object:truncate()` calls (gh-7309).
 * Fixed a crash when `box.stat.net.thread[i]` is called with invalid `i`
   values (gh-7196).
-* Fixed a low-probability stack overlow bug in the qsort implementation.
+* Fixed a low-probability stack overflow bug in the qsort implementation.
 
 ### Memtx
 
@@ -186,7 +186,7 @@ all the new features of the 2.x series.
 
 ### LuaJIT
 
-Backported patches from vanilla LuaJIT trunk (gh-6548). In the scope of this
+Backported patches from vanilla LuaJIT trunk (gh-6548 and gh-7230). In the scope of this
 activity, the following issues have been resolved:
 
 * Fixed emitting for fuse load of constant in GC64 mode (gh-4095, gh-4199, gh-4614).
@@ -213,10 +213,7 @@ activity, the following issues have been resolved:
 * Disabled proto and trace information dumpers in sysprof's default mode.
   Attempts to use them lead to a segmentation fault due to an uninitialized buffer
   (gh-7264).
-Backported patches from vanilla LuaJIT trunk (gh-7230). In the scope of this
-activity, the following issues have been resolved:
-
-* Fix handling of errors during trace snapshot restore.
+* Fixed handling of errors during trace snapshot restore.
 
 ### Lua
 


### PR DESCRIPTION
Fix typo and bad markup.

NO_CHANGELOG=changelog
NO_DOC=changelog
NO_TEST=changelog