### PR TITLE
Preparations for format-less tuple comparison

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -265,6 +265,10 @@ if(ENABLE_WAL_EXT)
     list(APPEND box_sources ${WAL_EXT_SOURCES})
 endif()
 
+if(ENABLE_READ_VIEW)
+    list(APPEND box_sources ${READ_VIEW_SOURCES})
+endif()
+
 add_library(box STATIC ${box_sources})
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/src/box/key_def.h
+++ b/src/box/key_def.h
@@ -959,6 +959,19 @@ tuple_extract_key_raw(const char *data, const char *data_end,
 }
 
 /**
+ * @brief Compare two fields parts using a type definition
+ * @param field_a field
+ * @param field_b field
+ * @param field_type field type definition
+ * @retval 0  if field_a == field_b
+ * @retval <0 if field_a < field_b
+ * @retval >0 if field_a > field_b
+ */
+int
+tuple_compare_field(const char *field_a, const char *field_b,
+		    int8_t type, struct coll *coll);
+
+/**
  * Compare keys using the key definition and comparison hints.
  * @param key_a key parts with MessagePack array header
  * @param key_a_hint comparison hint of @a key_a

--- a/src/box/tuple_compare.cc
+++ b/src/box/tuple_compare.cc
@@ -41,25 +41,6 @@
 
 /* {{{ tuple_compare */
 
-/**
- * Compare two tuple hints.
- *
- * Returns:
- *
- *   -1 if the first tuple is less than the second tuple
- *   +1 if the first tuple is greater than the second tuple
- *    0 if the first tuple may be less than, equal to, or
- *      greater than the second tuple, and a full tuple
- *      comparison is needed to determine the order.
- */
-static inline int
-hint_cmp(hint_t hint_a, hint_t hint_b)
-{
-	if (hint_a != HINT_NONE && hint_b != HINT_NONE && hint_a != hint_b)
-		return hint_a < hint_b ? -1 : 1;
-	return 0;
-}
-
 /*
  * Compare two tuple fields.
  * Separate version exists since compare is a very
@@ -488,7 +469,7 @@ mp_compare_scalar_coll(const char *field_a, const char *field_b,
  * @retval <0 if field_a < field_b
  * @retval >0 if field_a > field_b
  */
-static int
+int
 tuple_compare_field(const char *field_a, const char *field_b,
 		    int8_t type, struct coll *coll)
 {

--- a/src/box/tuple_compare.h
+++ b/src/box/tuple_compare.h
@@ -70,6 +70,25 @@ typedef uint64_t hint_t;
 #define HINT_NONE ((hint_t)UINT64_MAX)
 
 /**
+ * Compare two tuple hints.
+ *
+ * Returns:
+ *
+ *   -1 if the first tuple is less than the second tuple
+ *   +1 if the first tuple is greater than the second tuple
+ *    0 if the first tuple may be less than, equal to, or
+ *      greater than the second tuple, and a full tuple
+ *      comparison is needed to determine the order.
+ */
+static inline int
+hint_cmp(hint_t hint_a, hint_t hint_b)
+{
+	if (hint_a != HINT_NONE && hint_b != HINT_NONE && hint_a != hint_b)
+		return hint_a < hint_b ? -1 : 1;
+	return 0;
+}
+
+/**
  * Initialize comparator functions for the key_def.
  * @param key_def key definition
  */

--- a/src/trivia/config.h.cmake
+++ b/src/trivia/config.h.cmake
@@ -275,6 +275,7 @@
 #cmakedefine ENABLE_AUDIT_LOG 1
 #cmakedefine ENABLE_FEEDBACK_DAEMON 1
 #cmakedefine ENABLE_WAL_EXT 1
+#cmakedefine ENABLE_READ_VIEW 1
 
 #cmakedefine EXPORT_LIBCURL_SYMBOLS 1
 


### PR DESCRIPTION
Format-less tuple comparison is required to do lookups in a memtx index read view, see https://github.com/tarantool/tarantool-ee/issues/191. The feature itself will be done in EE. This PR just does some preparations necessary for the EE part.

EE part: https://github.com/tarantool/tarantool-ee/pull/195