### PR TITLE
fiber: make fiber_set_cancellable a no-op

### DIFF
--- a/changelogs/unreleased/gh-7166-deprecate-fiber_set_cancellable.md
+++ b/changelogs/unreleased/gh-7166-deprecate-fiber_set_cancellable.md
@@ -1,0 +1,4 @@
+## feature/core
+
+* **[Breaking change]** `fiber_set_cancellable()` is deprecated and
+  now does nothing (gh-7166).

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -509,20 +509,6 @@ fiber_wakeup(struct fiber *f)
 		fiber_make_ready(f);
 }
 
-/** Cancel the subject fiber.
-*
- * Note: cancelation is asynchronous. Use fiber_join() to wait for the
- * cancelation to complete.
- *
- * A fiber may opt to set FIBER_IS_CANCELLABLE to false, and never test
- * that it was cancelled.  Such fiber can not ever be cancelled.
- * However, as long as most of the cooperative code calls
- * fiber_testcancel(), most of the fibers are cancellable.
- *
- * The fiber which is cancelled, has FiberIsCancelled raised
- * in it. For cancellation to work, this exception type should be
- * re-raised whenever (if) it is caught.
- */
 void
 fiber_cancel(struct fiber *f)
 {
@@ -541,27 +527,13 @@ fiber_cancel(struct fiber *f)
 	}
 
 	f->flags |= FIBER_IS_CANCELLED;
-
-	/**
-	 * Don't wake self and zombies.
-	 */
-	if ((f->flags & FIBER_IS_CANCELLABLE) != 0)
-		fiber_wakeup(f);
+	fiber_wakeup(f);
 }
 
-/**
- * Change the current cancellation state of a fiber. This is not
- * a cancellation point.
- */
 bool
-fiber_set_cancellable(bool yesno)
+fiber_set_cancellable(MAYBE_UNUSED bool yesno)
 {
-	bool prev = fiber()->flags & FIBER_IS_CANCELLABLE;
-	if (yesno == true)
-		fiber()->flags |= FIBER_IS_CANCELLABLE;
-	else
-		fiber()->flags &= ~FIBER_IS_CANCELLABLE;
-	return prev;
+	return true;
 }
 
 bool

--- a/src/lua/fiber.c
+++ b/src/lua/fiber.c
@@ -724,12 +724,7 @@ static int
 lbox_fiber_wakeup(struct lua_State *L)
 {
 	struct fiber *f = lbox_checkfiber(L, 1);
-	/*
-	 * It's unsafe to wakeup fibers which don't expect
-	 * it.
-	 */
-	if (f->flags & FIBER_IS_CANCELLABLE)
-		fiber_wakeup(f);
+	fiber_wakeup(f);
 	return 0;
 }
 

--- a/test/app-luatest/gh_7166_wakeup_on_shutdown_fiber_test.lua
+++ b/test/app-luatest/gh_7166_wakeup_on_shutdown_fiber_test.lua
@@ -1,0 +1,9 @@
+local t = require('luatest')
+local g = t.group('gh-7166')
+
+-- Check that wake up of the shutdown fiber doesn't crash Tarantool
+g.test_wakeup_on_shutdown_fiber = function()
+    local lt_fiber = require('test.luatest_helpers.fiber')
+    local f = lt_fiber.find_by_name('on_shutdown')
+    f:wakeup()
+end

--- a/test/luatest_helpers/fiber.lua
+++ b/test/luatest_helpers/fiber.lua
@@ -1,0 +1,15 @@
+local fiber = require('fiber')
+
+-- Searches for a fiber with the specified name and returns the fiber object
+local function find_by_name(name)
+    for id, f in pairs(fiber.info()) do
+        if f.name == name then
+            return fiber.find(id)
+        end
+    end
+    return nil
+end
+
+return {
+    find_by_name = find_by_name
+}

--- a/test/unit/fiber.cc
+++ b/test/unit/fiber.cc
@@ -29,7 +29,6 @@ noop_f(va_list ap)
 static int
 cancel_f(va_list ap)
 {
-	fiber_set_cancellable(true);
 	while (true) {
 		fiber_sleep(0.001);
 		fiber_testcancel();
@@ -67,7 +66,6 @@ static int
 cancel_dead_f(va_list ap)
 {
 	note("cancel dead has started");
-	fiber_set_cancellable(true);
 	tnt_raise(OutOfMemory, 42, "allocator", "exception");
 	return 0;
 }
@@ -318,7 +316,7 @@ fiber_flags_respect_test(void)
 	/* Fibers taken from the cache need to respect the passed flags. */
 	struct fiber_attr attr;
 	fiber_attr_create(&attr);
-	uint32_t flags = FIBER_IS_JOINABLE | FIBER_IS_CANCELLABLE;
+	uint32_t flags = FIBER_IS_JOINABLE;
 	attr.flags |= flags;
 	f = fiber_new_ex("wait_cancel", &attr, wait_cancel_f);
 	fail_unless((f->flags & flags) == flags);

--- a/test/unit/latch.c
+++ b/test/unit/latch.c
@@ -25,7 +25,6 @@ sleep_f(va_list ap)
 {
 	struct latch *latch = va_arg(ap, struct latch *);
 	latch_lock(latch);
-	fiber_set_cancellable(true);
 
 	while (!fiber_is_cancelled())
 		fiber_sleep(0.001);


### PR DESCRIPTION
Currently this function is not used inside Tarantool, however it is
available via C module API. Deprecate it, because it is very confusing
and has nothing to do with the fiber cancellation.

[Approved by PM here](https://github.com/tarantool/tarantool/issues/7166#issuecomment-1212069052).

Closes #7166