### PR TITLE
ci: improve `report-job-status` README

### DIFF
--- a/.github/actions/report-job-status/README.md
+++ b/.github/actions/report-job-status/README.md
@@ -8,6 +8,10 @@ the `master` or release branch (`1.10`, `2.10`, etc);
 * a personal chat, created by the committer – if the job started on
 creating/updating a pull request or any event in other branches.
 
+__IMPORTANT__: The secrets are [not passed](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow)
+to workflows that are triggered by a pull request from a fork. Due to
+this limitation, this action will not work for pull requests from forks.
+
 ## How to create personal chat
 
 1. Create a new public chat in VK Teams (access can be limited by enabling


### PR DESCRIPTION
This patch adds a warning about using the action in pull requests
created from forks. GitHub secrets are not passed to workflows in
this case [1] and due to this limitation the action will not work
correctly for such pull requests.

[1] https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow
                                                  
NO_DOC=ci                                         
NO_TEST=ci                                        
NO_CHANGELOG=ci 