### PR TITLE
Introduce internal database read view API

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -218,6 +218,7 @@ set(box_sources
     ibuf.c
     watcher.c
     decimal.c
+    read_view.c
     ${sql_sources}
     ${lua_sources}
     lua/init.c

--- a/src/box/blackhole.c
+++ b/src/box/blackhole.c
@@ -173,6 +173,7 @@ blackhole_engine_create_space(struct engine *engine, struct space_def *def,
 static const struct engine_vtab blackhole_engine_vtab = {
 	/* .shutdown = */ blackhole_engine_shutdown,
 	/* .create_space = */ blackhole_engine_create_space,
+	/* .create_read_view = */ generic_engine_create_read_view,
 	/* .prepare_join = */ generic_engine_prepare_join,
 	/* .join = */ generic_engine_join,
 	/* .complete_join = */ generic_engine_complete_join,

--- a/src/box/engine.c
+++ b/src/box/engine.c
@@ -266,6 +266,14 @@ engine_reset_stat(void)
 
 /* {{{ Virtual method stubs */
 
+struct engine_read_view *
+generic_engine_create_read_view(struct engine *engine)
+{
+	(void)engine;
+	unreachable();
+	return NULL;
+}
+
 int
 generic_engine_prepare_join(struct engine *engine, void **ctx)
 {

--- a/src/box/read_view.c
+++ b/src/box/read_view.c
@@ -1,0 +1,156 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2022, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include "read_view.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "engine.h"
+#include "index.h"
+#include "salad/grp_alloc.h"
+#include "small/rlist.h"
+#include "space.h"
+#include "space_cache.h"
+#include "trivia/util.h"
+
+static bool
+default_space_filter(struct space *space, void *arg)
+{
+	(void)space;
+	(void)arg;
+	return true;
+}
+
+static bool
+default_index_filter(struct space *space, struct index *index, void *arg)
+{
+	(void)space;
+	(void)index;
+	(void)arg;
+	return true;
+}
+
+void
+read_view_opts_create(struct read_view_opts *opts)
+{
+	opts->filter_space = default_space_filter;
+	opts->filter_index = default_index_filter;
+	opts->filter_arg = NULL;
+}
+
+static void
+space_read_view_delete(struct space_read_view *space_rv)
+{
+	for (uint32_t i = 0; i <= space_rv->index_id_max; i++) {
+		struct index_read_view *index_rv = space_rv->index_map[i];
+		if (index_rv != NULL)
+			index_read_view_delete(index_rv);
+	}
+	TRASH(space_rv);
+	free(space_rv);
+}
+
+static struct space_read_view *
+space_read_view_new(struct space *space, const struct read_view_opts *opts)
+{
+	struct space_read_view *space_rv;
+	size_t index_map_size = sizeof(*space_rv->index_map) *
+				(space->index_id_max + 1);
+	struct grp_alloc all = grp_alloc_initializer();
+	grp_alloc_reserve_data(&all, sizeof(*space_rv));
+	grp_alloc_reserve_data(&all, index_map_size);
+	grp_alloc_use(&all, xmalloc(grp_alloc_size(&all)));
+	space_rv = grp_alloc_create_data(&all, sizeof(*space_rv));
+	space_rv->index_map = grp_alloc_create_data(&all, index_map_size);
+	assert(grp_alloc_size(&all) == 0);
+
+	space_rv->id = space_id(space);
+	space_rv->group_id = space_group_id(space);
+	space_rv->index_id_max = space->index_id_max;
+	memset(space_rv->index_map, 0, index_map_size);
+	for (uint32_t i = 0; i <= space->index_id_max; i++) {
+		struct index *index = space->index_map[i];
+		if (index == NULL ||
+		    !opts->filter_index(space, index, opts->filter_arg))
+			continue;
+		space_rv->index_map[i] = index_create_read_view(index);
+		if (space_rv->index_map[i] == NULL)
+			goto fail;
+	}
+	return space_rv;
+fail:
+	space_read_view_delete(space_rv);
+	return NULL;
+}
+
+/** Argument passed to read_view_add_space_cb(). */
+struct read_view_add_space_cb_arg {
+	/** Read view to add a space to. */
+	struct read_view *rv;
+	/** Read view creation options. */
+	const struct read_view_opts *opts;
+};
+
+static int
+read_view_add_space_cb(struct space *space, void *arg_raw)
+{
+	struct read_view_add_space_cb_arg *arg = arg_raw;
+	struct read_view *rv = arg->rv;
+	const struct read_view_opts *opts = arg->opts;
+	if ((space->engine->flags & ENGINE_SUPPORTS_READ_VIEW) == 0 ||
+	    !opts->filter_space(space, opts->filter_arg))
+		return 0;
+	struct space_read_view *space_rv = space_read_view_new(space, opts);
+	if (space_rv == NULL)
+		return -1;
+	rlist_add_tail_entry(&rv->spaces, space_rv, link);
+	return 0;
+}
+
+int
+read_view_open(struct read_view *rv, const struct read_view_opts *opts)
+{
+	rlist_create(&rv->engines);
+	rlist_create(&rv->spaces);
+	struct engine *engine;
+	engine_foreach(engine) {
+		if ((engine->flags & ENGINE_SUPPORTS_READ_VIEW) == 0)
+			continue;
+		struct engine_read_view *engine_rv =
+			engine_create_read_view(engine);
+		if (engine_rv == NULL)
+			goto fail;
+	}
+	struct read_view_add_space_cb_arg add_space_cb_arg = {
+		.rv = rv,
+		.opts = opts,
+	};
+	if (space_foreach(read_view_add_space_cb, &add_space_cb_arg) != 0)
+		goto fail;
+	return 0;
+fail:
+	read_view_close(rv);
+	return -1;
+}
+
+void
+read_view_close(struct read_view *rv)
+{
+	struct space_read_view *space_rv, *next_space_rv;
+	rlist_foreach_entry_safe(space_rv, &rv->spaces, link,
+				 next_space_rv) {
+		space_read_view_delete(space_rv);
+	}
+	struct engine_read_view *engine_rv, *next_engine_rv;
+	rlist_foreach_entry_safe(engine_rv, &rv->engines, link,
+				 next_engine_rv) {
+		engine_read_view_delete(engine_rv);
+	}
+	TRASH(rv);
+}

--- a/src/box/read_view.h
+++ b/src/box/read_view.h
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2022, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "small/rlist.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+struct index;
+struct index_read_view;
+struct space;
+
+/** Read view of a space. */
+struct space_read_view {
+	/** Link in read_view::spaces. */
+	struct rlist link;
+	/** Space id. */
+	uint32_t id;
+	/** Replication group id. See space_opts::group_id. */
+	uint32_t group_id;
+	/**
+	 * Max index id.
+	 *
+	 * (The number of entries in index_map is index_id_max + 1.)
+	 */
+	uint32_t index_id_max;
+	/**
+	 * Sparse (may contain nulls) array of index read views,
+	 * indexed by index id.
+	 */
+	struct index_read_view **index_map;
+};
+
+static inline struct index_read_view *
+space_read_view_index(struct space_read_view *space_rv, uint32_t id)
+{
+	return id <= space_rv->index_id_max ? space_rv->index_map[id] : NULL;
+}
+
+/** Read view of the entire database. */
+struct read_view {
+	/** List of engine read views, linked by engine_read_view::link. */
+	struct rlist engines;
+	/** List of space read views, linked by space_read_view::link. */
+	struct rlist spaces;
+};
+
+#define read_view_foreach_space(space_rv, rv) \
+	rlist_foreach_entry(space_rv, &(rv)->spaces, link)
+
+/** Read view creation options. */
+struct read_view_opts {
+	/**
+	 * Space filter: should return true if the space should be included
+	 * into the read view.
+	 *
+	 * Default: include all spaces (return true, ignore arguments).
+	 */
+	bool
+	(*filter_space)(struct space *space, void *arg);
+	/**
+	 * Index filter: should return true if the index should be included
+	 * into the read view.
+	 *
+	 * Default: include all indexes (return true, ignore arguments).
+	 */
+	bool
+	(*filter_index)(struct space *space, struct index *index, void *arg);
+	/**
+	 * Argument passed to filter functions.
+	 */
+	void *filter_arg;
+};
+
+/** Sets read view options to default values. */
+void
+read_view_opts_create(struct read_view_opts *opts);
+
+/**
+ * Opens a database read view: all changes done to the database after a read
+ * view was open will not be visible from the read view.
+ *
+ * Engines that don't support read view creation are silently skipped.
+ *
+ * Returns 0 on success. On error, returns -1 and sets diag.
+ */
+int
+read_view_open(struct read_view *rv, const struct read_view_opts *opts);
+
+/**
+ * Closes a database read view.
+ */
+void
+read_view_close(struct read_view *rv);
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */

--- a/src/box/service_engine.c
+++ b/src/box/service_engine.c
@@ -90,6 +90,7 @@ service_engine_create_space(struct engine *engine, struct space_def *def,
 static const struct engine_vtab service_engine_vtab = {
 	/* .shutdown = */ service_engine_shutdown,
 	/* .create_space = */ service_engine_create_space,
+	/* .create_read_view = */ generic_engine_create_read_view,
 	/* .prepare_join = */ generic_engine_prepare_join,
 	/* .join = */ generic_engine_join,
 	/* .complete_join = */ generic_engine_complete_join,

--- a/src/box/sysview.c
+++ b/src/box/sysview.c
@@ -562,6 +562,7 @@ sysview_engine_create_space(struct engine *engine, struct space_def *def,
 static const struct engine_vtab sysview_engine_vtab = {
 	/* .shutdown = */ sysview_engine_shutdown,
 	/* .create_space = */ sysview_engine_create_space,
+	/* .create_read_view = */ generic_engine_create_read_view,
 	/* .prepare_join = */ generic_engine_prepare_join,
 	/* .join = */ generic_engine_join,
 	/* .complete_join = */ generic_engine_complete_join,

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -4520,6 +4520,7 @@ static struct trigger on_replace_vinyl_deferred_delete = {
 static const struct engine_vtab vinyl_engine_vtab = {
 	/* .shutdown = */ vinyl_engine_shutdown,
 	/* .create_space = */ vinyl_engine_create_space,
+	/* .create_read_view = */ generic_engine_create_read_view,
 	/* .prepare_join = */ vinyl_engine_prepare_join,
 	/* .join = */ vinyl_engine_join,
 	/* .complete_join = */ vinyl_engine_complete_join,


### PR DESCRIPTION
Currently, we create a database read view only to create a memtx snapshot or join a replica, but there's already quite a bit of code duplication between these two scenarios. In the future, we will need the same functionality to create a user read view. So let's factor out this code into a separate module - `read_view`.

The API of the `read_view` module is quite simple - there are just two methods: open and close a read view. The user can pass a space and index filter while opening a read view to skip certain spaces. E.g. we skip all temporary spaces and secondary indexes when we create a memtx snapshot. A `read_view` object has a list of `space_read_view` objects, one per each space included into the read view. A `space_read_view` object, in turn, has a map of all `index_read_view` objects (introduced earlier) corresponding to space indexes. There's nothing like a space cache - the user can create one if required.

An engine that supports creation of a read view (currently, only memtx) is supposed to set the `ENGINE_SUPPORTS_READ_VIEW` flag and implement the `create_read_view` engine method in addition to the `create_read_view` index method. The engine method should do some engine-wide read view related preparations. For example, in case of memtx, it suspends tuple garbage collection.

Closes #7363