### PR TITLE
crash: expand log message about crashdump

### DIFF
--- a/changelogs/unreleased/crashdump_log_level.md
+++ b/changelogs/unreleased/crashdump_log_level.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Now log message with crashdump, written for debug of feedback daemon, explains its purpose.

--- a/src/lib/core/crash.c
+++ b/src/lib/core/crash.c
@@ -382,7 +382,7 @@ crash_report_feedback_daemon(struct crash_info *cinfo)
 	snprintf_safe("}");
 	snprintf_safe("}");
 
-	pr_debug("crash dump: %s", head);
+	pr_debug("crash dump for feedback daemon: %s", head);
 
 	char *exec_argv[7] = {
 		[0] = tarantool_path,


### PR DESCRIPTION
Crashdump is written to debug log before it is sent
to feedback daemon. The problem is that the user may
see this message and think that crashdump is logged
for him, while it is logged only for debug of feedback
daemon. This patch adds an explanation to log message
with coredump.

Closes https://github.com/tarantool/tarantool-ee/issues/199