### PR TITLE
 console: configure printed EOS symbol in Lua console 

### DIFF
--- a/changelogs/unreleased/gh-7031-configure-eos-in-lua-console.md
+++ b/changelogs/unreleased/gh-7031-configure-eos-in-lua-console.md
@@ -1,0 +1,4 @@
+## feature/console
+
+* Introduced a way to configure printed End Of Stream symbol in Lua console.
+  Changed default printed EOS to '' (gh-7031).

--- a/src/box/lua/console.lua
+++ b/src/box/lua/console.lua
@@ -117,40 +117,27 @@ output_handlers["lua"] = function(status, opts, ...)
     return table.concat(collect, ', ') .. output_eos["lua"]
 end
 
-local function output_verify_opts(fmt, opts)
-    if opts == nil then
-        return nil
-    end
-    if fmt == "lua" then
-        if opts ~= "line" and opts ~= "block" then
-            local msg = 'Wrong option "%s", expecting: line or block.'
-            return msg:format(opts)
-        end
-    end
-    return nil
-end
-
 local function parse_output(value)
     local fmt, opts
     if not value then
         return 'Specify output format: lua or yaml.'
     end
-    if value:match("([^,]+),([^,]+)") ~= nil then
-        fmt, opts = value:match("([^,]+),([^,]+)")
-    else
-        fmt = value
-    end
-    for k, _ in pairs(output_handlers) do
-        if k == fmt then
-            local err = output_verify_opts(fmt, opts)
-            if err then
-                return err
-            end
-            return nil, fmt, opts
+    for _, v in ipairs(value:split(',')) do
+        if v == 'yaml' or v == 'lua' then
+            fmt = v
+        elseif v == 'line' or v == 'block' then
+            opts = v
+        else
+            return ('Unknown "\\set output" option: %q'):format(v)
         end
     end
-    local msg = 'Invalid format "%s", supported languages: lua and yaml.'
-    return msg:format(value)
+    if fmt == nil then
+        return 'Specify output format: lua or yaml.'
+    end
+    if opts and fmt ~= 'lua' then
+        return ("Invalid language %s, opts are available only in lua."):format(fmt)
+    end
+    return nil, fmt, opts
 end
 
 local function set_default_output(value)

--- a/test/app-luatest/gh_7031_configure_eos_in_lua_console_test.lua
+++ b/test/app-luatest/gh_7031_configure_eos_in_lua_console_test.lua
@@ -1,0 +1,66 @@
+local server = require('luatest.server')
+local fio = require('fio')
+local it = require('test.interactive_tarantool')
+
+local t = require('luatest')
+local g = t.group()
+
+local child
+
+g.before_each(function()
+    child = it.new()
+end)
+
+g.after_each(function()
+    if g.server ~= nil then
+        g.server:stop()
+    end
+    if child ~= nil then
+        child:close()
+    end
+end)
+
+-- Run a command and assert a single line output from it.
+local function repl(command, exp_line)
+    child:execute_command(command)
+    local response = child:read_line()
+    t.assert_is(response, exp_line)
+end
+
+g.test_empty_default_local_eos = function()
+    repl('\\set output lua', 'true')
+    repl('42', '42')
+end
+
+g.test_configure_local_eos = function()
+    repl('\\set output lua,local_eos=/', 'true/')
+    repl('42', '42/')
+    repl('\\set output lua,local_eos=', 'true')
+    repl('42', '42')
+end
+
+g.test_client_server_local_eos = function()
+    g.server = server:new({alias = 'console_server'})
+    g.server:start()
+
+    local socket_path = fio.pathjoin(g.server.workdir, 'admin.socket')
+    local listen_command  = "require('console').listen('%s')"
+    local connect_command = "require('console').connect('%s')"
+
+    listen_command  = listen_command:format(socket_path)
+    connect_command = connect_command:format(socket_path)
+
+    -- Listen on the server.
+    g.server:eval(listen_command)
+
+    -- Connect the interactive client to the server's console.
+    child:execute_command(connect_command)
+    local response = child:read_response()
+    t.assert_equals(response, true)
+    child:set_prompt(('unix/:%s> '):format(socket_path))
+
+    repl('\\set output lua,local_eos=/', 'true/')
+    repl('42', '42/')
+    repl('\\set output lua,local_eos=', 'true')
+    repl('42', '42')
+end

--- a/test/app-luatest/gh_8136_fix_print_wrapper_not_handling_errors_thrown_from_print_test.lua
+++ b/test/app-luatest/gh_8136_fix_print_wrapper_not_handling_errors_thrown_from_print_test.lua
@@ -21,8 +21,8 @@ g.test_basic_print_with_exception = function()
     ]])
     child:assert_empty_response()
 
-    local exp_line = it.PROMPT .. it.CR .. it.ERASE_IN_LINE ..
-                     it.PROMPT .. it.CR .. it.ERASE_IN_LINE ..
+    local exp_line = child:prompt() .. it.CR .. it.ERASE_IN_LINE ..
+                     child:prompt() .. it.CR .. it.ERASE_IN_LINE ..
                      'flood'
     for _ = 1, 10 do
         child:assert_line(exp_line)

--- a/test/box-luatest/hide_show_prompt_test.lua
+++ b/test/box-luatest/hide_show_prompt_test.lua
@@ -21,7 +21,7 @@ g.test_basic_print = function()
     ]])
     child:assert_empty_response()
 
-    local exp_line = it.PROMPT .. it.CR .. it.ERASE_IN_LINE .. 'flood'
+    local exp_line = child:prompt() .. it.CR .. it.ERASE_IN_LINE .. 'flood'
     for _ = 1, 10 do
         child:assert_line(exp_line)
     end
@@ -48,7 +48,7 @@ g.test_basic_log = function()
     ]])
     child:assert_empty_response()
 
-    local exp_data = it.PROMPT .. it.CR .. it.ERASE_IN_LINE
+    local exp_data = child:prompt() .. it.CR .. it.ERASE_IN_LINE
     for _ = 1, 10 do
         child:assert_data(exp_data)
     end

--- a/test/interactive_tarantool.lua
+++ b/test/interactive_tarantool.lua
@@ -156,8 +156,7 @@ function mt._assert_command_echo(self, prepared_command, opts)
     local opts = opts or {}
     local deadline = opts.deadline or (fiber.clock() + TIMEOUT)
 
-    local prompt = 'tarantool> '
-    local exp_echo = prompt .. prepared_command:rstrip('\n')
+    local exp_echo = self._prompt .. prepared_command:rstrip('\n')
     local echo = self:read_line({deadline = deadline})
 
     -- If readline wraps the line, prepare the commands for
@@ -211,6 +210,15 @@ function mt.assert_empty_response(self, opts)
     end
 end
 
+-- Prompt may be different for remote console.
+function mt.set_prompt(self, prompt)
+    self._prompt = prompt
+end
+
+function mt.prompt(self)
+    return self._prompt
+end
+
 function mt.close(self)
     self:_stop_stderr_logger()
     self.ph:close()
@@ -255,6 +263,7 @@ function M.new(opts)
     local res = setmetatable({
         ph = ph,
         _readahead_buffer = '',
+        _prompt = 'tarantool> ',
     }, mt)
 
     -- Log child's stderr.
@@ -283,10 +292,6 @@ end
 -- }}} Module functions
 
 -- {{{ Module constants
-
--- It may be different for remote console, but the module supports
--- only local console for now.
-M.PROMPT = 'tarantool> '
 
 M.TAB = '\x09'
 M.LF = '\x0a'


### PR DESCRIPTION
There used to be ';' as a default printed End Of Statement in Lua, which
could be confusing for a human. Now the default printed EOS is '' and it
can be configured per session with `\set output lua,eos=`. Works on both
local and remote consoles.

Closes https://github.com/tarantool/tarantool/issues/7031

@TarantoolBot document
Title: configure printed End Of Statement symbol in Lua console

The old behavior was:
```
tarantool> \set output lua
true;
tarantool> 123
123;
```

Now default EOS is '', you can set it like this:
```
tarantool> \set output lua
true
tarantool> 123
123
tarantool> \set output lua,eos=/
true/
tarantool> 123
123/
tarantool> \set output lua,eos=
true
tarantool> 123
123
```

EOS can be only one non-space symbol. If you don't provide a symbol, it
would be configured to ''.