### PR TITLE
cmake: detect changes in source files upon static build

### DIFF
--- a/static-build/CMakeLists.txt
+++ b/static-build/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
 
 # Detect system compilers for further dependencies configuring to be
 # built with these compilers. This is used to build tarantool and
@@ -242,6 +242,7 @@ ExternalProject_Add(tarantool
         ${CMAKE_TARANTOOL_ARGS}
     STEP_TARGETS build
     BUILD_COMMAND $(MAKE)
+    BUILD_ALWAYS TRUE
 )
 
 enable_testing()


### PR DESCRIPTION
Currently `make` in `static-build` doesn't rebuild Tarantool when source
files are changed. Fix this by setting BUILD_ALWAYS option, which forces
rescan for changes of the external project [1]:

> This option is not normally needed unless developers are expected to
> modify something the external project's build depends on in a way that
> is not detectable via the step target dependencies (e.g. SOURCE_DIR is
> used without a download method and developers might modify the sources
> in SOURCE_DIR).

It is available since CMake 3.1, so update cmake_minimum_required, as we
already require it (fa8d70c).

[1] https://cmake.org/cmake/help/latest/module/ExternalProject.html

Part of #7536