### PR TITLE
luajit: bump new version

### DIFF
--- a/.test.mk
+++ b/.test.mk
@@ -151,13 +151,11 @@ pretest-osx:
 test-osx-release: CMAKE_PARAMS = -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_WERROR=ON
 test-osx-release: prebuild-osx build run-luajit-test pretest-osx run-test
 
-# FIXME: Temporary target without tests. Use 'test-release-osx' target instead
-# when all M1 issues are resolved:
-#   LuaJIT tests - https://github.com/tarantool/tarantool/issues/4819
-#   Tarantool tests - https://github.com/tarantool/tarantool/issues/6068
+# FIXME: Temporary target with reduced number of tests. Use 'test-release-osx' target
+# instead when all M1 issues https://github.com/tarantool/tarantool/issues/6068 are resolved.
 .PHONY: test-osx-release-arm64
 test-osx-release-arm64: CMAKE_PARAMS = -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_WERROR=ON
-test-osx-release-arm64: prebuild-osx build
+test-osx-release-arm64: prebuild-osx build run-luajit-test
 
 # Debug build
 
@@ -165,13 +163,11 @@ test-osx-release-arm64: prebuild-osx build
 test-osx-debug: CMAKE_PARAMS = -DCMAKE_BUILD_TYPE=Debug
 test-osx-debug: prebuild-osx build run-luajit-test pretest-osx run-test
 
-# FIXME: Temporary target without tests. Use 'test-release-osx' target instead
-# when all M1 issues are resolved:
-#   LuaJIT tests - https://github.com/tarantool/tarantool/issues/4819
-#   Tarantool tests - https://github.com/tarantool/tarantool/issues/6068
+# FIXME: Temporary target with reduced number of tests. Use 'test-release-osx' target
+# instead when all M1 issues https://github.com/tarantool/tarantool/issues/6068 are resolved.
 .PHONY: test-osx-debug-arm64
 test-osx-debug-arm64: CMAKE_PARAMS = -DCMAKE_BUILD_TYPE=Debug
-test-osx-debug-arm64: prebuild-osx build
+test-osx-debug-arm64: prebuild-osx build run-luajit-test
 
 # Static build
 


### PR DESCRIPTION
* test: disable jit tests at M1 for Tarantool

As far as unpleasant tests are disabled for Tarantool, this patch also
reverts the commit ef7eb61ff180a369e7170c49b398dc034dd5dcec ("ci:
disable LuaJIT tests for OSX arm64 builds").

Relates to #7571

NO_DOC=ci
NO_TEST=ci
NO_CHANGELOG=ci