### PR TITLE
ci: improve `report-job-status` action

### DIFF
--- a/.github/actions/report-job-status/README.md
+++ b/.github/actions/report-job-status/README.md
@@ -25,7 +25,5 @@ Add the following code to the running steps:
     if: failure()
     uses: ./.github/actions/report-job-status
     with:
-      api-url: ${{ secrets.VKTEAMS_API_URL }}
       bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-      chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
 ```

--- a/.github/actions/report-job-status/action.yml
+++ b/.github/actions/report-job-status/action.yml
@@ -2,18 +2,16 @@ name: Send VK Teams notification on failure
 description: Send the message to VK Teams chat on failure
 
 inputs:
-  api-url:
-    required: true
-    description: VK Teams API URL
   bot-token:
     required: true
     description: VK Teams bot token
   chat-id:
-    required: true
-    description: VK Teams team chat ID
+    required: false
+    default: tt_cicd_reports
+    description: VK Teams chat ID
 
 runs:
-  using: 'composite'
+  using: composite
   steps:
     - name: Set chat for reports
       run: |
@@ -32,6 +30,5 @@ runs:
     - name: Send VK Teams message on failure
       uses: tarantool/actions/report-job-status@master
       with:
-        api-url: ${{ inputs.api-url }}
         bot-token: ${{ inputs.bot-token }}
         chat-id: ${{ env.CHAT_ID }}

--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -64,9 +64,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/centos_7_aarch64.yml
+++ b/.github/workflows/centos_7_aarch64.yml
@@ -58,9 +58,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -64,9 +64,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/centos_8_aarch64.yml
+++ b/.github/workflows/centos_8_aarch64.yml
@@ -58,9 +58,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -68,9 +68,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
 
       - name: Collect coverage info
         uses: actions/upload-artifact@v2

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -29,9 +29,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -64,9 +64,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/debian_10_aarch64.yml
+++ b/.github/workflows/debian_10_aarch64.yml
@@ -58,9 +58,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-           api-url: ${{ secrets.VKTEAMS_API_URL }}
            bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-           chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -64,9 +64,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/debian_11_aarch64.yml
+++ b/.github/workflows/debian_11_aarch64.yml
@@ -58,9 +58,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -64,9 +64,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -62,9 +62,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
 
       - name: Collect artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -56,9 +56,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -62,9 +62,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -64,9 +64,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/fedora_34_aarch64.yml
+++ b/.github/workflows/fedora_34_aarch64.yml
@@ -58,9 +58,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/fedora_35.yml
+++ b/.github/workflows/fedora_35.yml
@@ -64,9 +64,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/fedora_35_aarch64.yml
+++ b/.github/workflows/fedora_35_aarch64.yml
@@ -58,9 +58,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/fedora_36.yml
+++ b/.github/workflows/fedora_36.yml
@@ -64,9 +64,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/fedora_36_aarch64.yml
+++ b/.github/workflows/fedora_36_aarch64.yml
@@ -58,9 +58,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/freebsd-12.yml
+++ b/.github/workflows/freebsd-12.yml
@@ -56,9 +56,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/freebsd-13.yml
+++ b/.github/workflows/freebsd-13.yml
@@ -56,9 +56,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -69,9 +69,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: upload crash
         uses: actions/upload-artifact@v1
         if: failure() && steps.build.outcome == 'success'

--- a/.github/workflows/jepsen-cluster-txm.yml
+++ b/.github/workflows/jepsen-cluster-txm.yml
@@ -34,9 +34,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/jepsen-cluster.yml
+++ b/.github/workflows/jepsen-cluster.yml
@@ -34,9 +34,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/jepsen-single-instance-txm.yml
+++ b/.github/workflows/jepsen-single-instance-txm.yml
@@ -38,9 +38,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/jepsen-single-instance.yml
+++ b/.github/workflows/jepsen-single-instance.yml
@@ -38,9 +38,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,9 +55,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
 
   release-notes:
     # Run on push to the 'master' and release branches of tarantool/tarantool
@@ -84,9 +82,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
 
   checkpatch:
     # Run only if the workflow was triggered by a pull request for
@@ -111,6 +107,4 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -58,9 +58,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -64,9 +64,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -64,9 +64,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/osx_11.yml
+++ b/.github/workflows/osx_11.yml
@@ -56,9 +56,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/osx_11_aarch64.yml
+++ b/.github/workflows/osx_11_aarch64.yml
@@ -56,9 +56,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/osx_11_aarch64_debug.yml
+++ b/.github/workflows/osx_11_aarch64_debug.yml
@@ -56,9 +56,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/osx_11_lto.yml
+++ b/.github/workflows/osx_11_lto.yml
@@ -58,9 +58,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/osx_12.yml
+++ b/.github/workflows/osx_12.yml
@@ -56,9 +56,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/osx_12_static_cmake.yml
+++ b/.github/workflows/osx_12_static_cmake.yml
@@ -56,9 +56,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -58,9 +58,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/publish-module-api-doc.yaml
+++ b/.github/workflows/publish-module-api-doc.yaml
@@ -33,6 +33,4 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,9 +56,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -56,9 +56,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -59,9 +59,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -58,9 +58,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -60,9 +60,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -35,6 +35,4 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -56,9 +56,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -56,9 +56,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/submodule_update.yml
+++ b/.github/workflows/submodule_update.yml
@@ -52,6 +52,4 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -64,9 +64,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -64,9 +64,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -64,9 +64,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/ubuntu_20_04_aarch64.yml
+++ b/.github/workflows/ubuntu_20_04_aarch64.yml
@@ -58,9 +58,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -64,9 +64,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/ubuntu_22_04_aarch64.yml
+++ b/.github/workflows/ubuntu_22_04_aarch64.yml
@@ -58,9 +58,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
-          api-url: ${{ secrets.VKTEAMS_API_URL }}
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-          chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       - name: artifacts
         uses: actions/upload-artifact@v2
         if: failure()


### PR DESCRIPTION
This patch allows to call `report-job-status` action with only one
input: `bot-token`. The team chat ID hardcoded, API URL set default in
`tarantool/actions/report-job-status`

NO_DOC=ci
NO_TEST=ci
NO_CHANGELOG=ci
____________________________________________
Tested: 
<img width="458" alt="Снимок экрана 2022-08-19 в 11 52 03" src="https://user-images.githubusercontent.com/88746790/185582529-1eaf8010-fb28-4d07-91b4-28d5ce5a7732.png">
