### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-7230-luajit-fixes.md
+++ b/changelogs/unreleased/gh-7230-luajit-fixes.md
@@ -4,3 +4,4 @@ Backported patches from vanilla LuaJIT trunk (gh-7230). In the scope of this
 activity, the following issues have been resolved:
 
 * Fix handling of errors during trace snapshot restore.
+* Fix overflow check in unpack() optimized by a compiler.


### PR DESCRIPTION
* Fix overflow check in unpack().

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump