### PR TITLE
memtx: fix tuple garbage collection not resumed after snapshot

### DIFF
--- a/src/box/read_view.c
+++ b/src/box/read_view.c
@@ -126,6 +126,7 @@ read_view_open(struct read_view *rv, const struct read_view_opts *opts)
 			engine_create_read_view(engine);
 		if (engine_rv == NULL)
 			goto fail;
+		rlist_add_tail_entry(&rv->engines, engine_rv, link);
 	}
 	struct read_view_add_space_cb_arg add_space_cb_arg = {
 		.rv = rv,

--- a/test/box-luatest/memtx_gc_after_snapshot_test.lua
+++ b/test/box-luatest/memtx_gc_after_snapshot_test.lua
@@ -1,0 +1,38 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all = function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end
+
+g.after_all = function(cg)
+    cg.server:stop()
+end
+
+-- Checks that memtx tuple garbage collection is resumed after snapshot.
+g.test_memtx_gc_after_snapshot = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        box.schema.space.create('test')
+        box.space.test:create_index('primary')
+        local mem_used_1 = box.info.memory().data
+        box.begin()
+        for i = 1, 100 do
+            box.space.test:insert({i, string.rep('x', 10000)})
+        end
+        box.commit()
+        local mem_used_2 = box.info.memory().data
+        t.assert_gt(mem_used_2 - mem_used_1, 1000000)
+        box.snapshot()
+        box.begin()
+        for i = 1, 100 do
+            box.space.test:delete(i)
+        end
+        box.commit()
+        collectgarbage('collect') -- drop Lua refs
+        local mem_used_3 = box.info.memory().data
+        t.assert_gt(mem_used_2 - mem_used_3, 1000000)
+    end)
+end


### PR DESCRIPTION
This is a degradation introduced by commit 26f7056f9c12: tuple garbage collection is never resumed after a snapshot. This happens, because we don't add engine read views to the read view engine list on read view construction. As a result, `read_view_close()` never closes the memtx engine read view.