### PR TITLE
[1.10] ci: report PRs from TarantoolBot to main chat

### DIFF
--- a/.github/actions/report-job-status/action.yml
+++ b/.github/actions/report-job-status/action.yml
@@ -19,7 +19,8 @@ runs:
         # the team chat. Report failures occurred in PRs and other branches
         # to the personal chat.
         if [[ ${{ github.ref }} == refs/heads/master ||
-              ${{ github.ref }} =~ refs/heads/[0-9].[0-9]+$ ]]; then
+              ${{ github.ref }} =~ refs/heads/[0-9].[0-9]+$ ||
+              ${{ github.actor }} == TarantoolBot ]]; then
           echo CHAT_ID="${{ inputs.chat-id }}" | tee -a $GITHUB_ENV
         else
           echo CHAT_ID="${{ inputs.chat-id }}_${{ github.actor }}" \


### PR DESCRIPTION
Report workflow failures in PRs made by TarantoolBot to the same chat
as with stable branches. Such PRs are used for automated integration
testing, so it's important for the team to notice failures in them.
There is no personal chat for TarantoolBot and no need to make one.

NO_DOC=CI reporting
NO_TEST=CI reporting
NO_CHANGELOG=CI reporting

(cherry picked from commit 8ebfa6113898ccc69e9f6513e2a205d8f99536ff)