### PR TITLE
Fix on_shutdown triggers

### DIFF
--- a/changelogs/unreleased/gh-6801-high-cpu-usage-by-on_shutdown-triggers.md
+++ b/changelogs/unreleased/gh-6801-high-cpu-usage-by-on_shutdown-triggers.md
@@ -1,0 +1,3 @@
+## bugfix/box
+
+* Fixed a possible high CPU usage caused by shutdown triggers (gh-6801).

--- a/changelogs/unreleased/gh-7434-yield-in-on_shutdown-trigger.md
+++ b/changelogs/unreleased/gh-7434-yield-in-on_shutdown-trigger.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed a bug when `fiber.yield()` may break the execution of a shutdown
+  trigger (gh-7434).

--- a/src/lua/init.lua
+++ b/src/lua/init.lua
@@ -62,7 +62,8 @@ local function exit(code)
     -- Make sure we yield even if the code after
     -- os.exit() never yields. After on_shutdown
     -- fiber completes, we will never wake up again.
-    while true do fiber.yield() end
+    local TIMEOUT_INFINITY = 500 * 365 * 86400
+    while true do fiber.sleep(TIMEOUT_INFINITY) end
 end
 rawset(os, "exit", exit)
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -139,6 +139,14 @@ static int
 on_shutdown_f(va_list ap)
 {
 	(void) ap;
+	/*
+	 * If event loop is not running, that means that on_shutdown_f was
+	 * called from the end of main. Return control back to main, which
+	 * will start an event loop and reschedule this fiber.
+	 */
+	if (ev_depth(loop()) == 0)
+		fiber_sleep(0.0);
+
 	if (trigger_fiber_run(&box_on_shutdown_trigger_list, NULL,
 			      on_shutdown_trigger_timeout) != 0) {
 		say_error("on_shutdown triggers failed");
@@ -823,11 +831,14 @@ main(int argc, char **argv)
 	if (start_loop)
 		say_info("exiting the event loop");
 	/*
-	 * If Tarantool was stopped using Ctrl+D, then we need to
-	 * call on_shutdown triggers, because Ctrl+D  causes not
-	 * any signals.
+	 * If Tarantool was stopped by Ctrl+D or by reaching the end of the
+	 * init script, and there was neither os.exit nor SIGTERM, then call
+	 * tarantool_exit and start an event loop to run on_shutdown triggers.
 	 */
-	tarantool_exit(exit_code);
+	if (!is_shutting_down) {
+		tarantool_exit(exit_code);
+		ev_run(loop(), 0);
+	}
 	/* freeing resources */
 	tarantool_free();
 	return exit_code;

--- a/test/box-luatest/gh_7434_child.lua
+++ b/test/box-luatest/gh_7434_child.lua
@@ -1,0 +1,38 @@
+local fiber = require('fiber')
+
+local file_name = arg[1]
+local test_mode = arg[2]
+assert(file_name)
+
+-- Create a file to check that shutdown trigger continues execution after yield
+box.ctl.on_shutdown(
+    function()
+        fiber.sleep(0)
+
+        local fio = require('fio')
+        local f = fio.open(file_name, {'O_CREAT', 'O_TRUNC', 'O_WRONLY'},
+                           tonumber('644', 8))
+        f:close()
+    end
+)
+
+-- Unlock ph:read() in the parent process
+print('started')
+io.flush()
+
+if test_mode == 'background' then
+    fiber.create(
+        function()
+            while true do
+                fiber.sleep(0.001)
+            end
+    end)
+end
+
+if test_mode == 'sleep' then
+    fiber.sleep(1000)
+end
+
+if test_mode == 'os_exit' then
+    os.exit(42)
+end

--- a/test/box-luatest/gh_7434_yield_in_on_shutdown_trigger_test.lua
+++ b/test/box-luatest/gh_7434_yield_in_on_shutdown_trigger_test.lua
@@ -1,0 +1,94 @@
+local t = require('luatest')
+local g = t.group('gh-7434')
+local fio = require('fio')
+local popen = require('popen')
+
+-- Check that a child process created a file in the shutdown trigger
+local tarantool = arg[-1]
+local script = os.getenv('SOURCEDIR') .. '/test/box-luatest/gh_7434_child.lua'
+local output_file
+
+g.before_all(function(cg)
+    local server = require('test.luatest_helpers.server')
+    cg.server = server:new({alias = 'master'})
+    output_file = cg.server.workdir .. '/on_shutdown_completed.txt'
+end)
+
+g.after_each(function()
+    os.remove(output_file)
+end)
+
+-- Shutdown by reaching the end of the script
+g.test_finish = function()
+    local ph = popen.new({tarantool, script, output_file})
+    t.assert(ph)
+    ph:wait()
+    ph:close()
+    t.assert(fio.path.lexists(output_file))
+end
+
+-- Shutdown by Ctrl+D (interactive mode)
+g.test_ctrld = function()
+    local ph = popen.new({tarantool, '-i', script, output_file},
+                         {stdout = popen.opts.PIPE, stdin = popen.opts.PIPE})
+    t.assert(ph)
+    ph:read()
+    ph:shutdown({stdin = true})
+    ph:wait()
+    ph:close()
+    t.assert(fio.path.lexists(output_file))
+end
+
+-- Shutdown by os.exit()
+g.test_osexit = function()
+    local ph = popen.new({tarantool, script, output_file, 'os_exit'})
+    t.assert(ph)
+    ph:wait()
+    ph:close()
+    t.assert(fio.path.lexists(output_file))
+end
+
+-- Shutdown by SIGTERM (init fiber is running)
+g.test_sigterm1 = function()
+    local ph = popen.new({tarantool, script, output_file, 'sleep'},
+                         {stdout = popen.opts.PIPE})
+    t.assert(ph)
+    ph:read()
+    ph:terminate()
+    ph:wait()
+    ph:close()
+    t.assert(fio.path.lexists(output_file))
+end
+
+-- Shutdown by SIGTERM (init fiber finished, background is running)
+g.test_sigterm2 = function()
+    local ph = popen.new({tarantool, script, output_file, 'background'},
+                         {stdout = popen.opts.PIPE})
+    t.assert(ph)
+    ph:read()
+    ph:terminate()
+    ph:wait()
+    ph:close()
+    t.assert(fio.path.lexists(output_file))
+end
+
+-- Shutdown by SIGTERM (lua script is passed via the -e option)
+g.test_hyphene = function()
+    local fiber = require('fiber')
+    local f = io.open(script, 'r')
+    t.assert(f)
+    local expr = f:read('*all')
+    f:close()
+    expr = expr:gsub('arg%[1%]', '"' .. output_file .. '"')
+    expr = expr:gsub('arg%[2%]', '"background"')
+    local ph = popen.new({tarantool, '-e', expr}, {stdout = popen.opts.PIPE})
+    t.assert(ph)
+    ph:read()
+    fiber.sleep(0.1)
+    -- Verify that child process is still alive after reaching end of the script
+    t.assert(ph:info().status.state == popen.state.ALIVE)
+    ph:terminate()
+    ph:wait()
+    ph:close()
+    t.assert(fio.path.lexists(output_file))
+end


### PR DESCRIPTION
**main: run an event loop for on_shutdown triggers**
When Tarantool is stopped by Ctrl+D or by reaching the end of the
script, run_script_f() breaks the event loop, then tarantool_exit()
is called from main(), however the fibers that execute on_shutdown
triggers can not be longer scheduled, because the event loop is
already stopped. Fix this by starting an auxiliary event loop for
such cases.

Closes https://github.com/tarantool/tarantool/issues/7434

**box: fix high CPU usage while on_shutdown triggers are running**
Currently this script causes 100% CPU usage for 10 sec, because
os.exit() infinitely yields to the scheduler until on_shutdown
fiber completes and breaks the event loop. Fix this by a sleep.
```
box.ctl.set_on_shutdown_timeout(100)
box.ctl.on_shutdown(function() require('fiber').sleep(10) end)
os.exit()
```

Closes https://github.com/tarantool/tarantool/issues/6801