### PR TITLE
Add build RedOS linux package

### DIFF
--- a/.github/workflows/redos_7_3.yaml
+++ b/.github/workflows/redos_7_3.yaml
@@ -1,0 +1,74 @@
+name: redos_7_3
+
+on:
+  push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+    tags:
+      - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
+
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch (1.10,
+  # 2.8, etc.), and tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    github.ref == 'refs/heads/1.10' ||
+    startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+jobs:
+  redos_7_3:
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+
+    runs-on: ubuntu-20.04-self-hosted
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build-type: [ '', 'gc64' ]
+
+    steps:
+      - uses: tarantool/actions/cleanup@master
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: packaging
+        env:
+          RWS_AUTH: ${{ secrets.RWS_AUTH }}
+          OS: 'redos'
+          DIST: '7.3'
+          GC64: ${{ matrix.build-type == 'gc64' }}
+        uses: ./.github/actions/pack_and_deploy
+      - name: Send VK Teams message on failure
+        if: failure()
+        uses: ./.github/actions/report-job-status
+        with:
+          bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
+      - name: artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: redos-7.3${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
+          retention-days: 21
+          path: ${{ env.VARDIR }}/artifacts

--- a/changelogs/unreleased/add-redos-7.3-ci-cd.md
+++ b/changelogs/unreleased/add-redos-7.3-ci-cd.md
@@ -1,0 +1,3 @@
+## feature/build
+
+* Support RedOS 7.3 build.


### PR DESCRIPTION
Add the redos_7.3.yml workflow to build Tarantool packages (x86_64) for
the RedOS 7.3 system.

Packages are created by https://github.com/packpack/packpack.

Closes tarantool/tarantool-qa#260