### PR TITLE
ci: use `ubuntu-latest` instead of `ubuntu-18.04`

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -9,7 +9,7 @@ jobs:
   coverity:
     if: github.repository == 'tarantool/tarantool'
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     container:
       image: docker.io/tarantool/testing:debian-buster

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -43,7 +43,7 @@ jobs:
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false

--- a/.github/workflows/jepsen-cluster-txm.yml
+++ b/.github/workflows/jepsen-cluster-txm.yml
@@ -7,7 +7,7 @@ jobs:
   jepsen-cluster-txm:
     if: github.repository == 'tarantool/tarantool'
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     container:
       image: docker.io/tarantool/testing:debian-buster

--- a/.github/workflows/jepsen-cluster.yml
+++ b/.github/workflows/jepsen-cluster.yml
@@ -7,7 +7,7 @@ jobs:
   jepsen-cluster:
     if: github.repository == 'tarantool/tarantool'
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     container:
       image: docker.io/tarantool/testing:debian-buster

--- a/.github/workflows/jepsen-single-instance-txm.yml
+++ b/.github/workflows/jepsen-single-instance-txm.yml
@@ -12,7 +12,7 @@ jobs:
   jepsen-single-instance-txm:
     if: github.repository == 'tarantool/tarantool'
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     container:
       image: docker.io/tarantool/testing:debian-buster

--- a/.github/workflows/jepsen-single-instance.yml
+++ b/.github/workflows/jepsen-single-instance.yml
@@ -12,7 +12,7 @@ jobs:
   jepsen-single-instance:
     if: github.repository == 'tarantool/tarantool'
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     container:
       image: docker.io/tarantool/testing:debian-buster


### PR DESCRIPTION
The `ubuntu-18.04` environment is deprecated, so let's switch to
`ubuntu-latest` where it is safe. For more details see [1].

[1] https://github.com/actions/virtual-environments/issues/6002