### PR TITLE
Linearizable read

### DIFF
--- a/changelogs/unreleased/linearizable-read.md
+++ b/changelogs/unreleased/linearizable-read.md
@@ -1,0 +1,5 @@
+## feature/core
+
+* There is a new transaction isolation level now: "linearizable". Transactions
+  started with `box.begin{txn_isolation = "linearizable"}` always see the latest
+  data confirmed by the quorum (gh-6707).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -2800,7 +2800,7 @@ on_replace_dd_truncate(struct trigger * /* trigger */, void *event)
 	 * spaces truncation.
 	 */
 	if (space_is_temporary(old_space) ||
-	    space_group_id(old_space) == GROUP_LOCAL) {
+	    space_is_local(old_space)) {
 		stmt->row->group_id = GROUP_LOCAL;
 		/*
 		 * The trigger is invoked after txn->n_local_rows

--- a/src/box/applier.h
+++ b/src/box/applier.h
@@ -122,6 +122,8 @@ struct applier_ack_msg {
 	double txn_last_tm;
 	/** Replicaset vclock. */
 	struct vclock vclock;
+	/** The vclock sync this message corresponds to. */
+	uint64_t vclock_sync;
 };
 
 /** The underlying thread behind a number of appliers. */
@@ -159,6 +161,8 @@ struct applier {
 	uint32_t version_id;
 	/** Remote ballot at the time of connect. */
 	struct ballot ballot;
+	/** Last requested vclock sync. */
+	uint64_t last_vclock_sync;
 	/** Remote address */
 	union {
 		struct sockaddr addr;
@@ -250,6 +254,11 @@ struct applier {
 		 * timestamp. Sent in ACK messages. Updated by applier_ack_msg.
 		 */
 		double txn_last_tm;
+		/**
+		 * Last sync value known to applier thread. Sent in ACK
+		 * messages.
+		 */
+		uint64_t last_vclock_sync;
 		/**
 		 * Applier thread's copy of the node's vclock. Sent in ACK
 		 * messages and updated by applier_ack_msg.

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -2448,7 +2448,7 @@ box_process1(struct request *request, box_tuple_t **result)
 	if (space == NULL)
 		return -1;
 	if (!space_is_temporary(space) &&
-	    space_group_id(space) != GROUP_LOCAL &&
+	    !space_is_local(space) &&
 	    box_check_writable() != 0)
 		return -1;
 	if (space_is_memtx(space)) {

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -324,6 +324,14 @@ box_demote(void);
 int
 box_promote_qsync(void);
 
+/**
+ * Wait for a linearization point. That is, wait until every operation that
+ * might be committed on a quorum at the moment this function is called, reaches
+ * this instance.
+ */
+int
+box_wait_linearization_point(double timeout);
+
 /* box_select is private and used only by FFI */
 API_EXPORT int
 box_select(uint32_t space_id, uint32_t index_id,

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -3145,9 +3145,8 @@ static inline int
 iproto_do_cfg(struct iproto_thread *iproto_thread, struct iproto_cfg_msg *msg)
 {
 	msg->iproto_thread = iproto_thread;
-	int rc = cbus_call(&iproto_thread->net_pipe, &iproto_thread->tx_pipe,
-			   msg, iproto_do_cfg_f, NULL, TIMEOUT_INFINITY);
-	return rc;
+	return cbus_call(&iproto_thread->net_pipe, &iproto_thread->tx_pipe, msg,
+			 iproto_do_cfg_f);
 }
 
 static inline void

--- a/src/box/iproto_constants.c
+++ b/src/box/iproto_constants.c
@@ -153,6 +153,7 @@ const unsigned char iproto_key_type[IPROTO_KEY_MAX] =
 	/* 0x57 */	MP_STR, /* IPROTO_EVENT_KEY */
 	/* 0x58 */	MP_NIL, /* IPROTO_EVENT_DATA (can be any) */
 	/* 0x59 */	MP_UINT, /* IPROTO_TXN_ISOLATION */
+	/* 0x5a */	MP_UINT, /* IPROTO_VCLOCK_SYNC */
 	/* }}} */
 };
 

--- a/src/box/iproto_constants.h
+++ b/src/box/iproto_constants.h
@@ -154,6 +154,8 @@ enum iproto_key {
 	IPROTO_EVENT_DATA = 0x58,
 	/** Isolation level, is used only by IPROTO_BEGIN request. */
 	IPROTO_TXN_ISOLATION = 0x59,
+	/** A vclock synchronisation request identifier. */
+	IPROTO_VCLOCK_SYNC = 0x5a,
 	/*
 	 * Be careful to not extend iproto_key values over 0x7f.
 	 * iproto_keys are encoded in msgpack as positive fixnum, which ends at

--- a/src/box/iproto_constants.h
+++ b/src/box/iproto_constants.h
@@ -356,6 +356,20 @@ iproto_type_name(uint16_t type)
 	}
 }
 
+/** Predefined replication group identifiers. */
+enum {
+	/**
+	 * Default replication group: changes made to the space
+	 * are replicated throughout the entire cluster.
+	 */
+	GROUP_DEFAULT = 0,
+	/**
+	 * Replica local space: changes made to the space are
+	 * not replicated.
+	 */
+	GROUP_LOCAL = 1,
+};
+
 /**
  * Returns IPROTO key name by @a key code.
  * @param key IPROTO key.

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -397,20 +397,25 @@ end
 
 box.internal.normalize_txn_isolation_level = normalize_txn_isolation_level
 
+local begin_options = {
+    timeout = function(timeout)
+        if type(timeout) ~= "number" or timeout <= 0 then
+            box.error(box.error.ILLEGAL_PARAMS,
+                      "timeout must be a number greater than 0")
+        end
+        return true
+    end,
+    txn_isolation = normalize_txn_isolation_level,
+}
+
 box.begin = function(options)
     local timeout
     local txn_isolation
     if options then
-        check_param(options, 'options', 'table')
+        check_param_table(options, begin_options)
         timeout = options.timeout
-        if timeout and (type(timeout) ~= "number" or timeout <= 0) then
-            box.error(box.error.ILLEGAL_PARAMS,
-                      "timeout must be a number greater than 0")
-        end
-        txn_isolation = options.txn_isolation
-        if txn_isolation ~= nil then
-            txn_isolation = normalize_txn_isolation_level(txn_isolation)
-        end
+        txn_isolation = options.txn_isolation and
+                        normalize_txn_isolation_level(options.txn_isolation)
     end
     if builtin.box_txn_begin() == -1 then
         box.error()

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -74,8 +74,6 @@ ffi.cdef[[
     box_txn_begin();
     int
     box_txn_set_timeout(double timeout);
-    int
-    box_txn_set_isolation(uint32_t level);
     void
     memtx_tx_story_gc_step();
     /** \endcond public */
@@ -368,6 +366,8 @@ box.txn_isolation_level = {
     ['READ_CONFIRMED'] = 2,
     ['best-effort'] = 3,
     ['BEST_EFFORT'] = 3,
+    ['linearizable'] = 4,
+    ['LINEARIZABLE'] = 4,
 }
 
 -- Create private isolation level map anything-correct -> number.
@@ -424,7 +424,7 @@ box.begin = function(options)
         assert(builtin.box_txn_set_timeout(timeout) == 0)
     end
     if txn_isolation and
-       builtin.box_txn_set_isolation(txn_isolation) ~= 0 then
+       internal.txn_set_isolation(txn_isolation) ~= 0 then
         box.rollback()
         box.error()
     end

--- a/src/box/lua/space.cc
+++ b/src/box/lua/space.cc
@@ -353,7 +353,7 @@ lbox_fillspace(struct lua_State *L, struct space *space, int i)
 
 	/* space.group_id */
 	lua_pushstring(L, "is_local");
-	lua_pushboolean(L, space_group_id(space) == GROUP_LOCAL);
+	lua_pushboolean(L, space_is_local(space));
 	lua_settable(L, i);
 
 	/* space.is_temp */
@@ -373,7 +373,7 @@ lbox_fillspace(struct lua_State *L, struct space *space, int i)
 
 	/* space.is_sync */
 	lua_pushstring(L, "is_sync");
-	lua_pushboolean(L, space->def->opts.is_sync);
+	lua_pushboolean(L, space_is_sync(space));
 	lua_settable(L, i);
 
 	lua_pushstring(L, "enabled");

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -1031,8 +1031,8 @@ memtx_join_space_filter(struct space *space, void *arg)
 {
 	(void)arg;
 	return space_is_memtx(space) &&
-		space_group_id(space) != GROUP_LOCAL &&
-		space_index(space, 0) != NULL;
+	       !space_is_local(space) &&
+	       space_index(space, 0) != NULL;
 }
 
 static int

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -2412,7 +2412,8 @@ detect_whether_prepared_ok(struct txn *txn)
 		return false;
 	else if (txn->isolation == TXN_ISOLATION_READ_COMMITTED)
 		return true;
-	else if (txn->isolation == TXN_ISOLATION_READ_CONFIRMED)
+	else if (txn->isolation == TXN_ISOLATION_READ_CONFIRMED ||
+		 txn->isolation == TXN_ISOLATION_LINEARIZABLE)
 		return false;
 	assert(txn->isolation == TXN_ISOLATION_BEST_EFFORT);
 	/*

--- a/src/box/recovery.cc
+++ b/src/box/recovery.cc
@@ -42,6 +42,7 @@
 #include "session.h"
 #include "coio_file.h"
 #include "error.h"
+#include "iproto_constants.h"
 
 /*
  * Recovery subsystem

--- a/src/box/relay.h
+++ b/src/box/relay.h
@@ -101,6 +101,14 @@ double
 relay_txn_lag(const struct relay *relay);
 
 /**
+ * Makes the relay issue a new vclock sync request and returns the sync to wait
+ * for.
+ */
+int
+relay_trigger_vclock_sync(struct relay *relay, uint64_t *vclock_sync,
+			  double deadline);
+
+/**
  * Send a Raft update request to the relay channel. It is not
  * guaranteed that it will be delivered. The connection may break.
  */

--- a/src/box/replication.cc
+++ b/src/box/replication.cc
@@ -116,6 +116,7 @@ replication_init(int num_threads)
 	rlist_create(&replicaset.applier.on_wal_write);
 
 	rlist_create(&replicaset.on_ack);
+	rlist_create(&replicaset.on_relay_thread_start);
 
 	diag_create(&replicaset.applier.diag);
 
@@ -140,6 +141,7 @@ replication_free(void)
 
 	diag_destroy(&replicaset.applier.diag);
 	trigger_destroy(&replicaset.on_ack);
+	trigger_destroy(&replicaset.on_relay_thread_start);
 
 	applier_free();
 }

--- a/src/box/replication.h
+++ b/src/box/replication.h
@@ -210,6 +210,8 @@ struct replication_ack {
 	uint32_t source;
 	/** Confirmed vclock. */
 	const struct vclock *vclock;
+	/** Vclock sync received with ACK. */
+	uint64_t vclock_sync;
 };
 
 /**

--- a/src/box/replication.h
+++ b/src/box/replication.h
@@ -304,6 +304,8 @@ struct replicaset {
 	} applier;
 	/** Triggers are invoked on each ACK from each replica. */
 	struct rlist on_ack;
+	/** Triggers invoked once relay thread becomes operational. */
+	struct rlist on_relay_thread_start;
 	/** Map of all known replica_id's to correspponding replica's. */
 	struct replica *replica_by_id[VCLOCK_MAX];
 };

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -121,7 +121,7 @@ space_fill_index_map(struct space *space)
 }
 
 bool
-space_is_system(struct space *space)
+space_is_system(const struct space *space)
 {
 	return space->def->id > BOX_SYSTEM_ID_MIN &&
 	       space->def->id < BOX_SYSTEM_ID_MAX;

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -38,6 +38,7 @@
 #include "index.h"
 #include "error.h"
 #include "diag.h"
+#include "iproto_constants.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -309,11 +310,25 @@ space_is_temporary(const struct space *space)
 	return space->def->opts.is_temporary;
 }
 
+/** Return true if space is synchronous. */
+static inline bool
+space_is_sync(const struct space *space)
+{
+	return space->def->opts.is_sync;
+}
+
 /** Return replication group id of a space. */
 static inline uint32_t
 space_group_id(const struct space *space)
 {
 	return space->def->opts.group_id;
+}
+
+/** Return true if space is local. */
+static inline bool
+space_is_local(const struct space *space)
+{
+	return space_group_id(space) == GROUP_LOCAL;
 }
 
 void

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -290,7 +290,10 @@ space_on_final_recovery_complete(struct space *space, void *nothing);
 
 /** Get space ordinal number. */
 static inline uint32_t
-space_id(struct space *space) { return space->def->id; }
+space_id(const struct space *space)
+{
+	return space->def->id;
+}
 
 /** Get space name. */
 static inline const char *
@@ -301,14 +304,14 @@ space_name(const struct space *space)
 
 /** Return true if space is temporary. */
 static inline bool
-space_is_temporary(struct space *space)
+space_is_temporary(const struct space *space)
 {
 	return space->def->opts.is_temporary;
 }
 
 /** Return replication group id of a space. */
 static inline uint32_t
-space_group_id(struct space *space)
+space_group_id(const struct space *space)
 {
 	return space->def->opts.group_id;
 }
@@ -521,18 +524,24 @@ space_invalidate(struct space *space)
 }
 
 static inline bool
-space_is_memtx(struct space *space) { return space->engine->id == 0; }
+space_is_memtx(const struct space *space)
+{
+	return space->engine->id == 0;
+}
 
 /** Return true if space is run under vinyl engine. */
 static inline bool
-space_is_vinyl(struct space *space) { return strcmp(space->engine->name, "vinyl") == 0; }
+space_is_vinyl(const struct space *space)
+{
+	return strcmp(space->engine->name, "vinyl") == 0;
+}
 
 /**
  * Check that the space is a system space, which means that is has a special
  * meaning for tarantool and has predefined insert/remove triggers.
  */
 bool
-space_is_system(struct space *space);
+space_is_system(const struct space *space);
 
 struct field_def;
 /**

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -920,7 +920,7 @@ txn_journal_entry_new(struct txn *txn)
 		if (stmt->row->type != IPROTO_NOP) {
 			is_fully_nop = false;
 			is_sync = is_sync || (stmt->space != NULL &&
-					      stmt->space->def->opts.is_sync);
+					      space_is_sync(stmt->space));
 		}
 
 		if (stmt->row->replica_id == 0)

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -694,10 +694,7 @@ txn_rollback_cb(struct trigger *trigger, void *event)
 	return 0;
 }
 
-/**
- * Wait until the last transaction in the limbo is finished and get its result.
- */
-static int
+int
 txn_limbo_wait_last_txn(struct txn_limbo *limbo, bool *is_rollback,
 			double timeout)
 {

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -393,6 +393,13 @@ txn_limbo_process(struct txn_limbo *limbo, const struct synchro_request *req);
 int
 txn_limbo_wait_confirm(struct txn_limbo *limbo);
 
+/**
+ * Wait until the last transaction in the limbo is finished and gets its result.
+ */
+int
+txn_limbo_wait_last_txn(struct txn_limbo *limbo, bool *is_rollback,
+			double timeout);
+
 /** Wait until the limbo is empty. Regardless of how its transactions end. */
 int
 txn_limbo_wait_empty(struct txn_limbo *limbo, double timeout);

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -3003,7 +3003,7 @@ vy_join_add_space(struct space *space, void *arg)
 	struct vy_join_ctx *ctx = arg;
 	if (!space_is_vinyl(space))
 		return 0;
-	if (space_group_id(space) == GROUP_LOCAL)
+	if (space_is_local(space))
 		return 0;
 	struct index *pk = space_index(space, 0);
 	if (pk == NULL)

--- a/src/box/vy_run.c
+++ b/src/box/vy_run.c
@@ -226,9 +226,7 @@ vy_run_env_coio_call(struct vy_run_env *env, struct cbus_call_msg *msg,
 	env->next_reader %= env->reader_pool_size;
 
 	/* Post the task to the reader thread. */
-	int rc = cbus_call(&reader->reader_pipe, &reader->tx_pipe,
-			   msg, func, NULL, TIMEOUT_INFINITY);
-	if (rc != 0)
+	if (cbus_call(&reader->reader_pipe, &reader->tx_pipe, msg, func) != 0)
 		return -1;
 
 	if (fiber_is_cancelled()) {

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -42,6 +42,7 @@
 #include "cbus.h"
 #include "coio_task.h"
 #include "replication.h"
+#include "iproto_constants.h"
 
 enum {
 	/**

--- a/src/box/wal.h
+++ b/src/box/wal.h
@@ -76,6 +76,12 @@ extern const char *wal_mode_STRS[];
 
 extern int wal_dir_lock;
 
+/**
+ * Triggers ivoked by tx thread's sched fiber upon WAL write confirmation
+ * arrival.
+ */
+extern struct rlist wal_on_write;
+
 #if defined(__cplusplus)
 extern "C" {
 #endif /* defined(__cplusplus) */

--- a/src/lib/core/cbus.c
+++ b/src/lib/core/cbus.c
@@ -437,6 +437,7 @@ cbus_call(struct cpipe *callee, struct cpipe *caller, struct cbus_call_msg *msg,
 	do {
 		bool exceeded = fiber_yield_deadline(deadline);
 		if (exceeded) {
+			msg->caller = NULL;
 			diag_set(TimedOut);
 			return -1;
 		}

--- a/src/lib/core/cbus.c
+++ b/src/lib/core/cbus.c
@@ -409,12 +409,10 @@ cbus_call_done(struct cmsg *m)
 	fiber_wakeup(msg->caller);
 }
 
-/**
- * Execute a synchronous call over cbus.
- */
 int
-cbus_call(struct cpipe *callee, struct cpipe *caller, struct cbus_call_msg *msg,
-	cbus_call_f func, cbus_call_f free_cb, double timeout)
+cbus_call_timeout(struct cpipe *callee, struct cpipe *caller,
+		  struct cbus_call_msg *msg, cbus_call_f func,
+		  cbus_call_f free_cb, double timeout)
 {
 	int rc;
 

--- a/src/lib/core/cbus.h
+++ b/src/lib/core/cbus.h
@@ -374,10 +374,19 @@ struct cbus_call_msg
 	cbus_call_f free_cb;
 };
 
+/** Execute a synchronous call over cbus. */
 int
-cbus_call(struct cpipe *callee, struct cpipe *caller,
-	  struct cbus_call_msg *msg,
-	  cbus_call_f func, cbus_call_f free_cb, double timeout);
+cbus_call_timeout(struct cpipe *callee, struct cpipe *caller,
+		  struct cbus_call_msg *msg, cbus_call_f func,
+		  cbus_call_f free_cb, double timeout);
+
+static inline int
+cbus_call(struct cpipe *callee, struct cpipe *caller, struct cbus_call_msg *msg,
+	  cbus_call_f func)
+{
+	return cbus_call_timeout(callee, caller, msg, func, NULL,
+				 TIMEOUT_INFINITY);
+}
 
 /**
  * Block until all messages queued in a pipe have been processed.

--- a/src/lib/vclock/vclock.h
+++ b/src/lib/vclock/vclock.h
@@ -67,20 +67,6 @@ enum {
 	VCLOCK_STR_LEN_MAX = 1 + VCLOCK_MAX * (2 + 2 + 20 + 2) + 1
 };
 
-/** Predefined replication group identifiers. */
-enum {
-	/**
-	 * Default replication group: changes made to the space
-	 * are replicated throughout the entire cluster.
-	 */
-	GROUP_DEFAULT = 0,
-	/**
-	 * Replica local space: changes made to the space are
-	 * not replicated.
-	 */
-	GROUP_LOCAL = 1,
-};
-
 /** Cluster vector clock */
 struct vclock {
 	/** Map of used components in lsn array */

--- a/test/box-luatest/begin_options_validation_test.lua
+++ b/test/box-luatest/begin_options_validation_test.lua
@@ -1,0 +1,30 @@
+local server = require("test.luatest_helpers.server")
+local t = require("luatest")
+
+local g = t.group("begin-options-validation")
+
+g.before_all = function()
+    g.server = server:new{
+        alias = "default",
+    }
+    g.server:start()
+end
+
+g.after_all = function()
+    g.server:drop()
+end
+
+g.test_begin_options_validation = function()
+    g.server:exec(function()
+        local t = require("luatest")
+        t.assert_error_msg_content_equals(
+            "Illegal parameters, unexpected option 'foo'",
+            box.begin, {foo = "bar"})
+        t.assert_error_msg_content_equals(
+            "Illegal parameters, timeout must be a number greater than 0",
+            box.begin, {timeout = "not-a-number"})
+        t.assert_error_msg_content_equals(
+            "Illegal parameters, timeout must be a number greater than 0",
+            box.begin, {timeout = 0})
+    end)
+end

--- a/test/replication-luatest/gh_6033_box_promote_demote_test.lua
+++ b/test/replication-luatest/gh_6033_box_promote_demote_test.lua
@@ -525,7 +525,7 @@ g_common.test_fail_limbo_ack_promote = function(g)
     end)
     box_cfg_update({g.server_1}, {replication_synchro_timeout = 0.01})
     local ok, err = fiber_join(g.server_1, f)
-    luatest.assert(not ok and err.code == box.error.QUORUM_WAIT,
+    luatest.assert(not ok and err.type == "TimedOut",
         'Promote failed because quorum wait timed out')
 
     box_cfg_update(g.cluster.servers, {replication_synchro_quorum = 2})

--- a/test/replication-luatest/linearizable_test.lua
+++ b/test/replication-luatest/linearizable_test.lua
@@ -1,0 +1,314 @@
+local t = require('luatest')
+local misc = require('test.luatest_helpers.misc')
+local cluster = require('test.luatest_helpers.cluster')
+local server = require('test.luatest_helpers.server')
+local proxy = require('test.luatest_helpers.proxy.proxy')
+local g = t.group('linearizable-read')
+
+local fiber = require('fiber')
+
+local function build_replication(num_instances)
+    local t = {}
+    for i = 1, num_instances do
+        table.insert(t, server.build_instance_uri('server_' .. i .. '_proxy'))
+    end
+    return t
+end
+
+local num_servers = 3
+
+g.before_all(function(cg)
+    cg.cluster = cluster:new({})
+    cg.servers = {}
+    cg.box_cfg = {
+        replication = build_replication(num_servers),
+        replication_timeout = 0.1,
+        memtx_use_mvcc_engine = true,
+    }
+    cg.servers[1] = cg.cluster:build_and_add_server({
+        alias = 'server_1',
+        box_cfg = cg.box_cfg,
+    })
+    -- Servers 2 and 3 are interconnected without a proxy.
+    for i = 2, num_servers do
+        cg.box_cfg.replication[i] = server.build_instance_uri('server_' .. i)
+    end
+    for i = 2, num_servers do
+        cg.servers[i] = cg.cluster:build_and_add_server({
+            alias = 'server_' .. i,
+            box_cfg = cg.box_cfg,
+        })
+    end
+    cg.proxies = {}
+    for i = 1, num_servers do
+        cg.proxies[i] = proxy:new({
+            client_socket_path = server.build_instance_uri('server_' .. i .. '_proxy'),
+            server_socket_path = server.build_instance_uri('server_' .. i),
+        })
+        cg.proxies[i]:start({force = true})
+    end
+    cg.cluster:start()
+    cg.cluster:wait_fullmesh()
+    cg.servers[1]:exec(function()
+        box.schema.space.create('sync', {is_sync=true})
+        box.space.sync:create_index('pk')
+    end)
+    cg.servers[2]:wait_vclock_of(cg.servers[1])
+    cg.servers[3]:wait_vclock_of(cg.servers[1])
+end)
+
+g.after_all(function(cg)
+    cg.cluster:drop()
+end)
+
+g.test_wait_others = function(cg)
+    cg.proxies[1]:pause()
+    local fid = cg.servers[1]:exec(function()
+        local t = require('luatest')
+        local fiber = require('fiber')
+        local f = fiber.new(function()
+            return pcall(box.begin, {txn_isolation = 'linearizable'})
+        end)
+        f:set_joinable(true)
+        fiber.sleep(0.01)
+        t.assert_equals(f:status(), 'suspended', 'begin() waits for replicas')
+        return f:id()
+    end)
+    cg.proxies[1]:resume()
+    local ok = cg.servers[1]:exec(function(fid)
+        local fiber = require('fiber')
+        local _, ok, err =  fiber.join(fiber.find(fid))
+        return ok, err
+    end, {fid})
+    t.assert(ok, 'begin() succeeds after replica connections are established')
+end
+
+g.test_timeout = function(cg)
+    misc.skip_if_not_debug()
+    cg.servers[1]:exec(function()
+        local t = require('luatest')
+        box.error.injection.set('ERRINJ_RELAY_FROM_TX_DELAY', true)
+        local ok, err = pcall(box.begin, {txn_isolation = 'linearizable',
+                                          timeout = 0.01})
+        box.error.injection.set('ERRINJ_RELAY_FROM_TX_DELAY', false)
+        t.assert(not ok, 'Error when relay is unresponsive')
+        t.assert_equals(err.type, 'TimedOut',
+                        'Timeout when relay is unresponsive')
+    end)
+end
+
+g.before_test('test_no_dirty_reads', function(cg)
+    -- Make cluster size 5. Having quorum 3 out of 5 will make the instance
+    -- poll 5 - 3 + 1 == all 3 of the "real" nodes.
+    cg.servers[1]:exec(function()
+        local uuid = require('uuid')
+        box.space._cluster:insert{4, tostring(uuid.new())}
+        box.space._cluster:insert{5, tostring(uuid.new())}
+    end)
+    cg.servers[2]:wait_vclock_of(cg.servers[1])
+    cg.servers[2]:exec(function()
+        box.ctl.promote()
+    end)
+    cg.servers[1]:wait_vclock_of(cg.servers[2])
+    cg.servers[3]:wait_vclock_of(cg.servers[2])
+end)
+
+g.after_test('test_no_dirty_reads', function(cg)
+    cg.servers[2]:exec(function()
+        box.ctl.demote()
+    end)
+    cg.servers[1]:wait_vclock_of(cg.servers[2])
+    cg.servers[1]:exec(function()
+        box.space._cluster:delete{4}
+        box.space._cluster:delete{5}
+    end)
+    cg.servers[2]:wait_vclock_of(cg.servers[1])
+    cg.servers[3]:wait_vclock_of(cg.servers[1])
+end)
+
+g.test_no_dirty_reads = function(cg)
+    local quorum = cg.servers[2]:exec(function()
+        local t = require('luatest')
+        local lsn = box.info.lsn
+        local q = box.cfg.replication_synchro_quorum
+        box.cfg{replication_synchro_quorum = 4}
+        require('fiber').new(box.space.sync.insert, box.space.sync, {1})
+        t.helpers.retrying({}, function() assert(box.info.lsn > lsn) end)
+        return q
+    end)
+    cg.servers[1]:exec(function()
+        local t = require('luatest')
+        local ok, err = pcall(box.begin, {txn_isolation = 'linearizable',
+                                          timeout = 0.1})
+        t.assert(not ok, 'Error with unconfirmed transaction')
+        t.assert_equals(err.type, 'TimedOut', 'Timeout waiting for confirm')
+        t.assert_equals(box.info.synchro.queue.len, 1,
+                        'Pending transaction is seen')
+        t.assert_equals(box.space.sync:get{1}, nil, 'No dirty reads')
+    end)
+    cg.servers[2]:exec(function(q)
+        box.cfg{replication_synchro_quorum = q}
+    end, {quorum})
+    cg.servers[1]:exec(function()
+        local t = require('luatest')
+        box.begin{txn_isolation = 'linearizable'}
+        local len = box.info.synchro.queue.len
+        local get = box.space.sync:get{1}
+        box.commit()
+        -- If the assertion fails before box.commit(), ER_FUNCTION_TX_ACTIVE
+        -- shadows the real error. So save the values inside the txn and check
+        -- them outside.
+        t.assert_equals(len, 0, 'Waited for confirm')
+        t.assert_equals(get, {1}, 'Confirmed data is seen')
+    end)
+end
+
+g.test_reconnect_while_waiting = function(cg)
+    for i = 2, num_servers do
+        cg.servers[i]:exec(function()
+            local repl = table.copy(box.cfg.replication)
+            table.remove(repl, 1)
+            box.cfg{replication = repl}
+        end)
+    end
+    local f = fiber.new(cg.servers[1].exec, cg.servers[1], function()
+        local ok, err = pcall(box.begin, {txn_isolation = 'linearizable'})
+        if ok then
+            box.commit()
+        end
+        return ok, err
+    end)
+    f:set_joinable(true)
+    for i = 2, num_servers do
+        cg.servers[i]:exec(function(repl)
+            box.cfg{replication = repl}
+        end, {cg.box_cfg.replication})
+    end
+    local success, ok, _ = f:join()
+    t.assert(success, 'fiber joined successfully')
+    t.assert(ok, 'reconnect while begin() waits for vclocks is tolerated')
+end
+
+g.test_leader_change = function(cg)
+    cg.servers[1]:exec(function()
+        box.ctl.promote()
+    end)
+    cg.servers[2]:wait_vclock_of(cg.servers[1])
+    cg.servers[3]:wait_vclock_of(cg.servers[1])
+    for i = 1, num_servers do
+        cg.proxies[i]:pause()
+    end
+    cg.servers[2]:exec(function()
+        box.ctl.promote()
+        box.space.sync:insert{2}
+    end)
+    local fid = cg.servers[1]:exec(function()
+        local f = require('fiber').new(function()
+            box.begin{txn_isolation = 'linearizable'}
+            local owner = box.info.synchro.queue.owner
+            local get = box.space.sync:get{2}
+            box.commit()
+            return owner, get
+        end)
+        f:set_joinable(true)
+        local t = require('luatest')
+        t.assert_equals(f:status(), 'suspended', 'begin waits for others')
+        return f:id()
+    end)
+    for i = 1, num_servers do
+        cg.proxies[i]:resume()
+    end
+    local owner, get = cg.servers[1]:exec(function(fid)
+        local fiber = require('fiber')
+        local _, owner, get = fiber.join(fiber.find(fid))
+        return owner, get
+    end, {fid})
+    t.assert_equals(owner, cg.servers[2]:instance_id(),
+                    'leader change is noticed in box.begin()')
+    t.assert_equals(get, {2}, 'Transaction committed by new leader is seen')
+end
+
+local g_basic = t.group('linearizable-read-basic')
+
+g_basic.before_all(function(cg)
+    cg.cluster = cluster:new({})
+    cg.nomvcc = cg.cluster:build_and_add_server({alias = 'nomvcc'})
+    cg.mvcc = cg.cluster:build_and_add_server({
+        alias = 'mvcc',
+        box_cfg = {
+            memtx_use_mvcc_engine = true,
+        },
+    })
+    cg.cluster:start()
+    cg.mvcc:exec(function()
+        box.schema.space.create('async'):create_index('pk')
+        box.schema.space.create('sync', {is_sync = true}):create_index('pk')
+        box.schema.space.create('local', {is_local = true}):create_index('pk')
+        box.schema.space.create('temporary', {temporary = true})
+        box.space.temporary:create_index('pk')
+        box.schema.space.create('vinyl', {engine = 'vinyl', is_sync = true})
+        box.space.vinyl:create_index('pk')
+        -- For the sake of writes to the sync space.
+        box.ctl.promote()
+    end)
+end)
+
+g_basic.after_all(function(cg)
+    cg.cluster:drop()
+end)
+
+local function begin(opts)
+    return pcall(box.begin, opts)
+end
+
+local function linearizable_read_from_space(spacename)
+    box.begin{txn_isolation = 'linearizable'}
+    local ok, err = pcall(box.space[spacename].select, box.space[spacename])
+    box.commit()
+    return ok, err
+end
+
+local function linearizable_write_to_space(spacename)
+    box.begin{txn_isolation = 'linearizable'}
+    local ok, err = pcall(box.space[spacename].replace,
+                          box.space[spacename], {1})
+    box.commit()
+    return ok, err
+end
+
+local function test_linearizable_access(node, spacename, is_ok, msg)
+    local ok, err = node:exec(linearizable_read_from_space, {spacename})
+    t.assert_equals(ok, is_ok, 'Expected result with read from ' .. spacename)
+    if not ok then
+        t.assert_equals(err.message, msg, 'Expected error message with ' ..
+                                          'read from ' .. spacename)
+    end
+    ok, err = node:exec(linearizable_write_to_space, {spacename})
+    t.assert_equals(ok, is_ok, 'Expected result with write to ' .. spacename)
+    if not ok then
+        t.assert_equals(err.message, msg, 'Expected error message with ' ..
+                                          'write to ' .. spacename)
+    end
+end
+
+g_basic.test_basic = function(cg)
+    local ok, err = pcall(box.cfg, {txn_isolation = 'linearizable'})
+    t.assert(not ok, 'Cannot set default isolation level to linearizable')
+    local msg = "Incorrect value for option 'txn_isolation': cannot set " ..
+                "default transaction isolation to 'linearizable'"
+    t.assert_equals(err.message, msg,
+                    'Correct error when trying to set default isolation')
+    ok, err = cg.nomvcc:exec(begin, {{txn_isolation = 'linearizable'}})
+    t.assert(not ok, 'Error without mvcc enabled')
+    t.assert_equals(err.message, 'Linearizable transaction does not support ' ..
+                                 'disabled memtx mvcc engine',
+                    'Correct error without mvcc enabled')
+
+    local errmsg = 'space "async" does not support linearizable operations'
+    test_linearizable_access(cg.mvcc, 'async', false, errmsg)
+    errmsg = 'space "vinyl" does not support linearizable operations'
+    test_linearizable_access(cg.mvcc, 'vinyl', false, errmsg)
+    test_linearizable_access(cg.mvcc, 'temporary', true)
+    test_linearizable_access(cg.mvcc, 'local', true)
+    test_linearizable_access(cg.mvcc, 'sync', true)
+end

--- a/test/unit/cbus_call.c
+++ b/test/unit/cbus_call.c
@@ -21,8 +21,7 @@ static void
 test_cbus_call(void)
 {
 	struct cbus_call_msg msg;
-	int rc = cbus_call(&pipe_to_callee, &pipe_to_caller, &msg, func, NULL,
-			   TIMEOUT_INFINITY);
+	int rc = cbus_call(&pipe_to_callee, &pipe_to_caller, &msg, func);
 	is(rc, 0, "cbus_call ordinary");
 }
 
@@ -37,8 +36,7 @@ static void
 barrier(void)
 {
 	struct cbus_call_msg msg;
-	int rc = cbus_call(&pipe_to_callee, &pipe_to_caller, &msg, empty, NULL,
-			   TIMEOUT_INFINITY);
+	int rc = cbus_call(&pipe_to_callee, &pipe_to_caller, &msg, empty);
 	fail_if(rc != 0);
 }
 
@@ -61,8 +59,8 @@ test_cbus_call_timeout(void)
 {
 	plan(3);
 	struct test_msg msg;
-	int rc = cbus_call(&pipe_to_callee, &pipe_to_caller, &msg.base, func,
-			   free_cb, 0.01);
+	int rc = cbus_call_timeout(&pipe_to_callee, &pipe_to_caller, &msg.base,
+				   func, free_cb, 0.01);
 	struct error *err = diag_last_error(diag_get());
 	bool pass = (rc == -1) && err && (err->type == &type_TimedOut);
 	ok(pass, "cbus_call timeout");
@@ -89,8 +87,7 @@ test_cbus_call_wakeup(void)
 	fiber_wakeup(waker_fiber);
 
 	struct cbus_call_msg msg;
-	int rc = cbus_call(&pipe_to_callee, &pipe_to_caller, &msg, func, NULL,
-			   TIMEOUT_INFINITY);
+	int rc = cbus_call(&pipe_to_callee, &pipe_to_caller, &msg, func);
 	is(rc, 0, "cbus_call wakeup");
 	barrier();
 }
@@ -112,8 +109,7 @@ test_cbus_call_cancel(void)
 	fiber_wakeup(canceler_fiber);
 
 	struct cbus_call_msg msg;
-	int rc = cbus_call(&pipe_to_callee, &pipe_to_caller, &msg, func, NULL,
-			   TIMEOUT_INFINITY);
+	int rc = cbus_call(&pipe_to_callee, &pipe_to_caller, &msg, func);
 	is(rc, 0, "cbus_call cancel");
 	barrier();
 }

--- a/test/unit/vclock.cc
+++ b/test/unit/vclock.cc
@@ -402,16 +402,53 @@ test_fromstring_invalid()
 
 #undef test
 
+#define test(fun, a, b, exp) ({						\
+	struct vclock va;						\
+	vclock_create(&va);						\
+	struct vclock vb;						\
+	vclock_create(&vb);						\
+	struct vclock vexp;						\
+	vclock_create(&vexp);						\
+	vclock_from_string(&va, (a));					\
+	vclock_from_string(&vb, (b));					\
+	vclock_from_string(&vexp, (exp));				\
+	vclock_##fun##_ignore0(&va, &vb);				\
+	is(vclock_compare(&va, &vexp), 0,				\
+	   #fun " between %s and %s is %s", a, b, exp);			\
+})
+
+int
+test_minmax_ignore0(void)
+{
+	plan(4);
+	header();
+
+	test(max, "{0: 1, 1: 17, 2: 3}", "{0: 10, 1: 5, 2: 7}",
+	     "{0: 1, 1: 17, 2: 7}");
+	test(min, "{0: 10, 1: 17, 2: 3}", "{0: 1, 1: 5, 2: 7}",
+	     "{0: 10, 1: 5, 2: 3}");
+	test(max, "{1: 1, 2: 1, 3: 1}", "{1: 100, 2: 100, 31: 100}",
+	     "{1: 100, 2: 100, 3: 1, 31: 100}");
+	test(min, "{1: 1, 2: 1, 3: 1}", "{1: 100, 2: 100, 31: 100}",
+	     "{1:1, 2: 1}");
+
+	footer();
+	return check_plan();
+}
+
+#undef test
+
 int
 main(void)
 {
-	plan(5);
+	plan(6);
 
 	test_compare();
 	test_isearch();
 	test_tostring();
 	test_fromstring();
 	test_fromstring_invalid();
+	test_minmax_ignore0();
 
 	return check_plan();
 }

--- a/test/unit/vclock.result
+++ b/test/unit/vclock.result
@@ -1,4 +1,4 @@
-1..5
+1..6
     1..40
 	*** test_compare ***
     ok 1 - compare (), () => 0
@@ -147,3 +147,11 @@ ok 4 - subtests
     ok 32 - fromstring "{1:20, 1:10}" => 12
 	*** test_fromstring_invalid: done ***
 ok 5 - subtests
+    1..4
+	*** test_minmax_ignore0 ***
+    ok 1 - max between {0: 1, 1: 17, 2: 3} and {0: 10, 1: 5, 2: 7} is {0: 1, 1: 17, 2: 7}
+    ok 2 - min between {0: 10, 1: 17, 2: 3} and {0: 1, 1: 5, 2: 7} is {0: 10, 1: 5, 2: 3}
+    ok 3 - max between {1: 1, 2: 1, 3: 1} and {1: 100, 2: 100, 31: 100} is {1: 100, 2: 100, 3: 1, 31: 100}
+    ok 4 - min between {1: 1, 2: 1, 3: 1} and {1: 100, 2: 100, 31: 100} is {1:1, 2: 1}
+	*** test_minmax_ignore0: done ***
+ok 6 - subtests


### PR DESCRIPTION
Linearizability is a property of operations when operation performed on
any node sees all the operations performed earlier on any other node of
the cluster.

More strictly speaking, it's a property, demanding, that if a response
for some write request arrived earlier than some read request was made,
this read request must see the results of that (or any earlier) write
request.

This patch introduces "linearizable" isolation level to box.begin(). When
the option is set, the begin() is stalled until the node receives the
latest data from at least one member of the quorum. This is needed to
make sure that the node sees all the writes committed on a quorum.
The transaction is served only after the node sees the relevant data,
thus implementing linearizable semantics.

Closes #6707