### PR TITLE
Fix several bugs: in raft, in qsync, in box.ctl.promote()

### DIFF
--- a/changelogs/unreleased/gh-7253-fiber-hang-on-fencing.md
+++ b/changelogs/unreleased/gh-7253-fiber-hang-on-fencing.md
@@ -1,0 +1,5 @@
+## bugfix/replication
+
+* Fixed a bug when a fiber committing a synchronous transaction could hang if
+  the instance got a term bump during that or its synchro-queue was fenced in
+  any other way (gh-7253).

--- a/changelogs/unreleased/gh-7253-split-brain-early-vote.md
+++ b/changelogs/unreleased/gh-7253-split-brain-early-vote.md
@@ -1,0 +1,5 @@
+## bugfix/raft
+
+* Fixed a bug when a replicaset could be split in parts if a node during
+  elections voted for another instance while having some local WAL writes not
+  finished (gh-7253).

--- a/changelogs/unreleased/promote-hang.md
+++ b/changelogs/unreleased/promote-hang.md
@@ -1,0 +1,4 @@
+## bugfix/raft
+
+* Fixed a bug when a node with `election_mode='voter'` could hang in
+  `box.ctl.promote()` or even become a leader.

--- a/changelogs/unreleased/promote-multiple-infinite.md
+++ b/changelogs/unreleased/promote-multiple-infinite.md
@@ -1,0 +1,4 @@
+## bugfix/raft
+
+* Fixed a bug when `box.ctl.promote()` could hang and bump thousands of terms in
+  a row if called on more than one node at the same time.

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -297,6 +297,7 @@ struct errcode_record {
 	/*242 */_(ER_NO_ELECTION_QUORUM,	"Not enough peers connected to start elections: %d out of minimal required %d")\
 	/*243 */_(ER_SSL,			"%s") \
 	/*244 */_(ER_SPLIT_BRAIN,		"Split-Brain discovered: %s") \
+	/*245 */_(ER_OLD_TERM,			"The term is outdated: old - %llu, new - %llu") \
 
 /*
  * !IMPORTANT! Please follow instructions at start of the file

--- a/src/box/raft.h
+++ b/src/box/raft.h
@@ -132,9 +132,9 @@ box_raft_checkpoint_remote(struct raft_request *req);
 int
 box_raft_process(struct raft_request *req, uint32_t source);
 
-/** Block this fiber until the current term's outcome is known. */
+/** Try to elect this node as a leader in a new term bumped one time. */
 int
-box_raft_wait_term_outcome(void);
+box_raft_try_promote(void);
 
 /** Block this fiber until the current volatile term is persisted. */
 int

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -245,10 +245,10 @@ txn_limbo_wait_complete(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
 		double deadline = start_time + replication_synchro_timeout;
 		double timeout = deadline - fiber_clock();
 		int rc = fiber_cond_wait_timeout(&limbo->wait_cond, timeout);
-		if (txn_limbo_is_frozen(limbo))
-			goto wait;
 		if (txn_limbo_entry_is_complete(entry))
 			goto complete;
+		if (txn_limbo_is_frozen(limbo))
+			goto wait;
 		if (rc != 0)
 			break;
 	}

--- a/src/lib/raft/raft.h
+++ b/src/lib/raft/raft.h
@@ -224,6 +224,12 @@ struct raft {
 	 * subsystems, such as Raft.
 	 */
 	const struct vclock *vclock;
+	/**
+	 * Vclock of the candidate which the current instance is trying to vote
+	 * for right now. It is used to double-check if the instance still can
+	 * vote for the given candidate after own WAL queue was flushed.
+	 */
+	struct vclock candidate_vclock;
 	/** State machine timed event trigger. */
 	struct ev_timer timer;
 	/** The moment of the last communication with the leader. */

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -463,6 +463,7 @@ t;
  |   242: box.error.NO_ELECTION_QUORUM
  |   243: box.error.SSL
  |   244: box.error.SPLIT_BRAIN
+ |   245: box.error.OLD_TERM
  | ...
 
 test_run:cmd("setopt delimiter ''");

--- a/test/replication-luatest/gh_7253_election_long_wal_write_test.lua
+++ b/test/replication-luatest/gh_7253_election_long_wal_write_test.lua
@@ -1,0 +1,143 @@
+local t = require('luatest')
+local server = require('test.luatest_helpers.server')
+local cluster = require('test.luatest_helpers.cluster')
+local fiber = require('fiber')
+
+local wait_timeout = 50
+
+local g = t.group('gh-7253')
+
+local function wait_pair_sync(server1, server2)
+    -- Without retrying it fails sometimes when vclocks are empty and both
+    -- instances are in 'connect' state instead of 'follow'.
+    t.helpers.retrying({timeout = wait_timeout}, function()
+        server1:wait_vclock_of(server2)
+        server2:wait_vclock_of(server1)
+        server1:assert_follows_upstream(server2:instance_id())
+        server2:assert_follows_upstream(server1:instance_id())
+    end)
+end
+
+local function wait_fullmesh(g)
+    wait_pair_sync(g.server1, g.server2)
+end
+
+local function block_next_wal_write_f()
+    box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+end
+
+local function unblock_wal_write_f()
+    box.error.injection.set('ERRINJ_WAL_DELAY', false)
+end
+
+local function server_block_next_wal_write(server)
+    server:exec(block_next_wal_write_f)
+end
+
+local function server_unblock_wal_write(server)
+    server:exec(unblock_wal_write_f)
+end
+
+local function check_wal_is_blocked_f()
+    if not box.error.injection.get('ERRINJ_WAL_DELAY') then
+        error('WAL still is not paused')
+    end
+end
+
+local function server_wait_wal_is_blocked(server)
+    t.helpers.retrying({timeout = wait_timeout}, server.exec, server,
+                       check_wal_is_blocked_f)
+end
+
+g.before_all(function(g)
+    g.cluster = cluster:new({})
+    local box_cfg = {
+        replication_synchro_timeout = 1000,
+        replication_synchro_quorum = 2,
+        replication_timeout = 0.1,
+        replication = {
+            server.build_instance_uri('server1'),
+            server.build_instance_uri('server2'),
+        },
+    }
+    box_cfg.election_mode = 'manual'
+    g.server1 = g.cluster:build_and_add_server({
+        alias = 'server1', box_cfg = box_cfg
+    })
+    box_cfg.election_mode = 'voter'
+    g.server2 = g.cluster:build_and_add_server({
+        alias = 'server2', box_cfg = box_cfg
+    })
+    g.cluster:start()
+
+    g.server1:exec(function()
+        local s = box.schema.create_space('test', {is_sync = true})
+        s:create_index('pk')
+    end)
+    wait_fullmesh(g)
+end)
+
+g.after_all(function(g)
+    g.cluster:drop()
+    g.server1 = nil
+    g.server2 = nil
+end)
+
+g.test_fence_during_confirm_wal_write = function(g)
+    --
+    -- Server1 starts a txn.
+    --
+    server_block_next_wal_write(g.server2)
+    local f = fiber.new(g.server1.exec, g.server1, function()
+        box.space.test:replace({1})
+    end)
+    f:set_joinable(true)
+    --
+    -- The txn is delivered to server2.
+    --
+    server_wait_wal_is_blocked(g.server2)
+    --
+    -- Server1 receives an ack and blocks on CONFIRM WAL write.
+    --
+    server_block_next_wal_write(g.server1)
+    server_unblock_wal_write(g.server2)
+    server_wait_wal_is_blocked(g.server1)
+    --
+    -- Server2 sends a new term to server1.
+    --
+    local term = g.server1:election_term()
+    fiber.create(g.server2.exec, g.server2, function()
+        box.cfg{
+            election_mode = 'manual',
+            election_timeout = 1000,
+        }
+        -- Silence any exceptions. Only term bump matters and it is checked
+        -- below.
+        pcall(box.ctl.promote)
+    end)
+    g.server1:wait_election_term(term + 1)
+    --
+    -- Server1 finishes CONFIRM WAL write and sees that the synchro queue was
+    -- frozen during the WAL write. Shouldn't affect the result.
+    --
+    server_unblock_wal_write(g.server1)
+    local ok, err = f:join(wait_timeout)
+    t.assert_equals(err, nil)
+    t.assert(ok)
+    t.assert(g.server1:exec(function()
+        return box.space.test:get{1} ~= nil
+    end))
+    --
+    -- Cleanup.
+    --
+    g.server2:exec(function()
+        box.cfg{
+            election_mode = 'voter',
+            election_timeout = box.NULL,
+        }
+    end)
+    g.server1:exec(function()
+        box.ctl.promote()
+    end)
+    wait_fullmesh(g)
+end

--- a/test/replication-luatest/suite.ini
+++ b/test/replication-luatest/suite.ini
@@ -2,4 +2,4 @@
 core = luatest
 description = replication luatests
 is_parallel = True
-release_disabled = gh_5295_split_brain_test.lua gh_6036_qsync_order_test.lua gh_6842_qsync_applier_order_test.lua gh_6033_box_promote_demote_test.lua
+release_disabled = gh_5295_split_brain_test.lua gh_6036_qsync_order_test.lua gh_6842_qsync_applier_order_test.lua gh_6033_box_promote_demote_test.lua gh_7253_election_long_wal_write_test.lua

--- a/test/replication/election_basic.result
+++ b/test/replication/election_basic.result
@@ -338,7 +338,7 @@ box.cfg{election_mode='candidate'}
  | ---
  | ...
 
-test_run:wait_cond(function() return #election_tbl == 3 end)
+test_run:wait_cond(function() return #election_tbl == 4 end)
  | ---
  | - true
  | ...
@@ -346,15 +346,28 @@ assert(election_tbl[1].state == 'follower')
  | ---
  | - true
  | ...
-assert(election_tbl[2].state == 'candidate')
+assert(election_tbl[2].state == 'follower')
  | ---
  | - true
  | ...
+assert(election_tbl[2].term > election_tbl[1].term)
+ | ---
+ | - true
+ | ...
+-- Vote is visible here already, but it is volatile.
 assert(election_tbl[2].vote == 1)
  | ---
  | - true
  | ...
-assert(election_tbl[3].state == 'leader')
+assert(election_tbl[3].state == 'candidate')
+ | ---
+ | - true
+ | ...
+assert(election_tbl[3].vote == 1)
+ | ---
+ | - true
+ | ...
+assert(election_tbl[4].state == 'leader')
  | ---
  | - true
  | ...
@@ -362,11 +375,11 @@ assert(election_tbl[3].state == 'leader')
 box.cfg{election_mode='voter'}
  | ---
  | ...
-test_run:wait_cond(function() return #election_tbl == 4 end)
+test_run:wait_cond(function() return #election_tbl == 5 end)
  | ---
  | - true
  | ...
-assert(election_tbl[4].state == 'follower')
+assert(election_tbl[5].state == 'follower')
  | ---
  | - true
  | ...
@@ -374,7 +387,7 @@ assert(election_tbl[4].state == 'follower')
 box.cfg{election_mode='off'}
  | ---
  | ...
-test_run:wait_cond(function() return #election_tbl == 5 end)
+test_run:wait_cond(function() return #election_tbl == 6 end)
  | ---
  | - true
  | ...
@@ -382,11 +395,11 @@ test_run:wait_cond(function() return #election_tbl == 5 end)
 box.cfg{election_mode='manual'}
  | ---
  | ...
-test_run:wait_cond(function() return #election_tbl == 6 end)
+test_run:wait_cond(function() return #election_tbl == 7 end)
  | ---
  | - true
  | ...
-assert(election_tbl[6].state == 'follower')
+assert(election_tbl[7].state == 'follower')
  | ---
  | - true
  | ...
@@ -395,23 +408,32 @@ box.ctl.promote()
  | ---
  | ...
 
-test_run:wait_cond(function() return #election_tbl == 9 end)
+test_run:wait_cond(function() return #election_tbl == 10 end)
  | ---
  | - true
  | ...
-assert(election_tbl[7].state == 'follower')
+assert(election_tbl[8].state == 'follower')
  | ---
  | - true
  | ...
-assert(election_tbl[7].term == election_tbl[6].term + 1)
+assert(election_tbl[8].term == election_tbl[7].term + 1)
  | ---
  | - true
  | ...
-assert(election_tbl[8].state == 'candidate')
+-- Vote is visible here already, but it is volatile.
+assert(election_tbl[8].vote == 1)
  | ---
  | - true
  | ...
-assert(election_tbl[9].state == 'leader')
+assert(election_tbl[9].state == 'candidate')
+ | ---
+ | - true
+ | ...
+assert(election_tbl[9].vote == 1)
+ | ---
+ | - true
+ | ...
+assert(election_tbl[10].state == 'leader')
  | ---
  | - true
  | ...

--- a/test/replication/election_basic.test.lua
+++ b/test/replication/election_basic.test.lua
@@ -144,30 +144,37 @@ _ = box.ctl.on_election(trig)
 box.cfg{replication_synchro_quorum=2}
 box.cfg{election_mode='candidate'}
 
-test_run:wait_cond(function() return #election_tbl == 3 end)
+test_run:wait_cond(function() return #election_tbl == 4 end)
 assert(election_tbl[1].state == 'follower')
-assert(election_tbl[2].state == 'candidate')
+assert(election_tbl[2].state == 'follower')
+assert(election_tbl[2].term > election_tbl[1].term)
+-- Vote is visible here already, but it is volatile.
 assert(election_tbl[2].vote == 1)
-assert(election_tbl[3].state == 'leader')
+assert(election_tbl[3].state == 'candidate')
+assert(election_tbl[3].vote == 1)
+assert(election_tbl[4].state == 'leader')
 
 box.cfg{election_mode='voter'}
-test_run:wait_cond(function() return #election_tbl == 4 end)
-assert(election_tbl[4].state == 'follower')
+test_run:wait_cond(function() return #election_tbl == 5 end)
+assert(election_tbl[5].state == 'follower')
 
 box.cfg{election_mode='off'}
-test_run:wait_cond(function() return #election_tbl == 5 end)
+test_run:wait_cond(function() return #election_tbl == 6 end)
 
 box.cfg{election_mode='manual'}
-test_run:wait_cond(function() return #election_tbl == 6 end)
-assert(election_tbl[6].state == 'follower')
+test_run:wait_cond(function() return #election_tbl == 7 end)
+assert(election_tbl[7].state == 'follower')
 
 box.ctl.promote()
 
-test_run:wait_cond(function() return #election_tbl == 9 end)
-assert(election_tbl[7].state == 'follower')
-assert(election_tbl[7].term == election_tbl[6].term + 1)
-assert(election_tbl[8].state == 'candidate')
-assert(election_tbl[9].state == 'leader')
+test_run:wait_cond(function() return #election_tbl == 10 end)
+assert(election_tbl[8].state == 'follower')
+assert(election_tbl[8].term == election_tbl[7].term + 1)
+-- Vote is visible here already, but it is volatile.
+assert(election_tbl[8].vote == 1)
+assert(election_tbl[9].state == 'candidate')
+assert(election_tbl[9].vote == 1)
+assert(election_tbl[10].state == 'leader')
 
 test_run:cmd('stop server replica')
 test_run:cmd('delete server replica')

--- a/test/unit/raft.result
+++ b/test/unit/raft.result
@@ -1,7 +1,7 @@
 	*** main_f ***
-1..18
+1..19
 	*** raft_test_leader_election ***
-    1..24
+    1..26
     ok 1 - 1 pending message at start
     ok 2 - trigger worked
     ok 3 - broadcast at start
@@ -9,23 +9,25 @@
     ok 5 - elections with a new term
     ok 6 - single vote for self
     ok 7 - trigger worked
-    ok 8 - 1 record in the journal
-    ok 9 - term and vote are on disk
-    ok 10 - 1 pending message
-    ok 11 - vote request is sent
-    ok 12 - vote response from 2
-    ok 13 - 2 votes - 1 self and 1 foreign
-    ok 14 - no work to do - not enough votes yet
-    ok 15 - still candidate, waiting for elections
-    ok 16 - trigger is the same
-    ok 17 - vote response from 3
-    ok 18 - 2 votes - 1 self and 2 foreign
-    ok 19 - became leader
-    ok 20 - trigger worked
-    ok 21 - no work - broadcast should be done
-    ok 22 - no new rows in the journal - state change is not persisted
-    ok 23 - 1 pending message
-    ok 24 - sent new-leader notification
+    ok 8 - 2 records in the journal
+    ok 9 - term is on disk
+    ok 10 - vote is on disk
+    ok 11 - 2 pending messages
+    ok 12 - term bump is sent
+    ok 13 - vote request is sent
+    ok 14 - vote response from 2
+    ok 15 - 2 votes - 1 self and 1 foreign
+    ok 16 - no work to do - not enough votes yet
+    ok 17 - still candidate, waiting for elections
+    ok 18 - trigger is the same
+    ok 19 - vote response from 3
+    ok 20 - 2 votes - 1 self and 2 foreign
+    ok 21 - became leader
+    ok 22 - trigger worked
+    ok 23 - no work - broadcast should be done
+    ok 24 - no new rows in the journal - state change is not persisted
+    ok 25 - 1 pending message
+    ok 26 - sent new-leader notification
 ok 1 - subtests
 	*** raft_test_leader_election: done ***
 	*** raft_test_recovery ***
@@ -113,6 +115,21 @@ ok 4 - subtests
     ok 39 - term is bumped and became candidate
 ok 5 - subtests
 	*** raft_test_vote_skip: done ***
+	*** raft_test_vote_during_wal_write ***
+    1..11
+    ok 1 - became candidate
+    ok 2 - vote response from 2
+    ok 3 - vote response from 3
+    ok 4 - became leader
+    ok 5 - vote request in a new term but WAL is blocked
+    ok 6 - canceled the vote for other node and voted for self
+    ok 7 - became candidate
+    ok 8 - term is 2
+    ok 9 - term is 2
+    ok 10 - volatile term is 3
+    ok 11 - vote for self worked even though the WAL had non-empty queue
+ok 6 - subtests
+	*** raft_test_vote_during_wal_write: done ***
 	*** raft_test_leader_resign ***
     1..24
     ok 1 - message is accepted
@@ -139,7 +156,7 @@ ok 5 - subtests
     ok 22 - vote from 2
     ok 23 - vote from 3
     ok 24 - the leader is elected
-ok 6 - subtests
+ok 7 - subtests
 	*** raft_test_leader_resign: done ***
 	*** raft_test_split_brain ***
     1..4
@@ -147,7 +164,7 @@ ok 6 - subtests
     ok 2 - leader is found
     ok 3 - second leader notification
     ok 4 - split brain, the old leader is kept
-ok 7 - subtests
+ok 8 - subtests
 	*** raft_test_split_brain: done ***
 	*** raft_test_heartbeat ***
     1..12
@@ -163,7 +180,7 @@ ok 7 - subtests
     ok 10 - became leader
     ok 11 - message from leader
     ok 12 - nothing changed - waiting for WAL write
-ok 8 - subtests
+ok 9 - subtests
 	*** raft_test_heartbeat: done ***
 	*** raft_test_election_timeout ***
     1..13
@@ -180,7 +197,7 @@ ok 8 - subtests
     ok 11 - re-enter candidate state
     ok 12 - term is bumped, timeout was truly random
     ok 13 - still candidate
-ok 9 - subtests
+ok 10 - subtests
 	*** raft_test_election_timeout: done ***
 	*** raft_test_election_quorum ***
     1..7
@@ -191,7 +208,7 @@ ok 9 - subtests
     ok 5 - but still candidate
     ok 6 - enter leader state after another quorum lowering
     ok 7 - became leader again immediately with 1 self vote
-ok 10 - subtests
+ok 11 - subtests
 	*** raft_test_election_quorum: done ***
 	*** raft_test_death_timeout ***
     1..9
@@ -204,7 +221,7 @@ ok 10 - subtests
     ok 7 - became follower
     ok 8 - death is detected immediately
     ok 9 - enter candidate state
-ok 11 - subtests
+ok 12 - subtests
 	*** raft_test_death_timeout: done ***
 	*** raft_test_enable_disable ***
     1..11
@@ -219,7 +236,7 @@ ok 11 - subtests
     ok 9 - resigned from leader state
     ok 10 - nothing changed
     ok 11 - term bump when disabled
-ok 12 - subtests
+ok 13 - subtests
 	*** raft_test_enable_disable: done ***
 	*** raft_test_too_long_wal_write ***
     1..22
@@ -245,7 +262,7 @@ ok 12 - subtests
     ok 20 - volatile vote is self
     ok 21 - new election timeout works
     ok 22 - new term is started with vote for self
-ok 13 - subtests
+ok 14 - subtests
 	*** raft_test_too_long_wal_write: done ***
 	*** raft_test_promote_restore ***
     1..12
@@ -261,7 +278,7 @@ ok 13 - subtests
     ok 10 - still old term
     ok 11 - not a candidate
     ok 12 - not a candidate
-ok 14 - subtests
+ok 15 - subtests
 	*** raft_test_promote_restore: done ***
 	*** raft_test_bump_term_before_cfg ***
     1..6
@@ -271,7 +288,7 @@ ok 14 - subtests
     ok 4 - bump term externally
     ok 5 - term write is in progress
     ok 6 - started new term
-ok 15 - subtests
+ok 16 - subtests
 	*** raft_test_bump_term_before_cfg: done ***
 	*** raft_test_split_vote ***
     1..64
@@ -339,7 +356,7 @@ ok 15 - subtests
     ok 62 - planned new election after yield
     ok 63 - vote response for 3 from 3
     ok 64 - still waiting for yield
-ok 16 - subtests
+ok 17 - subtests
 	*** raft_test_split_vote: done ***
 	*** raft_test_pre_vote ***
     1..43
@@ -386,12 +403,12 @@ ok 16 - subtests
     ok 41 - leader accepted
     ok 42 - leader seen notification accepted
     ok 43 - No timer re_start on election timeout reconfig when it's not time for elections yet
-ok 17 - subtests
+ok 18 - subtests
 	*** raft_test_pre_vote: done ***
 	*** raft_test_resign ***
     1..2
     ok 1 - became leader
     ok 2 - resigned from leader state
-ok 18 - subtests
+ok 19 - subtests
 	*** raft_test_resign: done ***
 	*** main_f: done ***


### PR DESCRIPTION
The patchset fixes several unrelated bugs. 2 of them are from the ticket #7253. The ticket contains 3 issues whose solution was designed in an RFC, but one of the bugs couldn't be fixed like proposed. Explanation why and possible solutions will come soon in that RFC and maybe in the ticket.

At the moment of submission I get "error 500" when open any CI job and "debug" just hangs in yellow state. Sending it for review now hoping the debug CI passes later.

Part-of #7253 