### PR TITLE
Introduce pagination in memtx tree

### DIFF
--- a/extra/exports
+++ b/extra/exports
@@ -66,6 +66,7 @@ box_index_len
 box_index_max
 box_index_min
 box_index_random
+box_index_tuple_position
 box_insert
 box_iterator_free
 box_iterator_next

--- a/extra/exports
+++ b/extra/exports
@@ -96,6 +96,7 @@ box_return_mp
 box_return_tuple
 box_schema_version
 box_select
+box_select_after
 box_sequence_current
 box_sequence_next
 box_sequence_reset

--- a/extra/exports
+++ b/extra/exports
@@ -415,6 +415,9 @@ PMurHash32
 PMurHash32_Process
 PMurHash32_Result
 port_destroy
+position_pack_on_gc
+position_reset
+position_unpack
 prbuf_create
 prbuf_open
 prbuf_prepare

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -243,6 +243,7 @@ set(box_sources
     lua/key_def.c
     lua/merger.c
     lua/watcher.c
+    position.c
     ${bin_sources})
 
 if(ENABLE_AUDIT_LOG)

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -570,7 +570,8 @@ space_has_data(uint32_t id, uint32_t iid, uint32_t uid, bool *out)
 	char key[6];
 	assert(mp_sizeof_uint(BOX_SYSTEM_ID_MIN) <= sizeof(key));
 	mp_encode_uint(key, uid);
-	struct iterator *it = index_create_iterator(index, ITER_EQ, key, 1);
+	struct iterator *it = index_create_iterator(index, ITER_EQ, key, 1,
+						    NULL);
 	if (it == NULL)
 		return -1;
 	IteratorGuard iter_guard(it);

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -2533,7 +2533,7 @@ box_select(uint32_t space_id, uint32_t index_id,
 		return -1;
 
 	struct iterator *it = index_create_iterator(index, type,
-						    key, part_count);
+						    key, part_count, NULL);
 	if (it == NULL) {
 		txn_rollback_stmt(txn);
 		return -1;

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -52,6 +52,7 @@ struct iostream;
 struct auth_request;
 struct space;
 struct vclock;
+struct position;
 
 /**
  * Pointer to TX thread local vclock.
@@ -330,6 +331,18 @@ box_select(uint32_t space_id, uint32_t index_id,
 	   int iterator, uint32_t offset, uint32_t limit,
 	   const char *key, const char *key_end,
 	   struct port *port);
+
+/**
+ * Version of box_select that supports pagination. If pos is NULL and
+ * update_pos is false, box_select_after has the same behaviour as box_select.
+ * Pre-requesites: if update_pos is true, pos must not be NULL.
+ * box_select_after is private and used only by FFI.
+ */
+API_EXPORT int
+box_select_after(uint32_t space_id, uint32_t index_id,
+		 int iterator, uint32_t offset, uint32_t limit,
+		 const char *key, const char *key_end,
+		 struct position *pos, bool update_pos, struct port *port);
 
 /** \cond public */
 

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -297,6 +297,7 @@ struct errcode_record {
 	/*242 */_(ER_NO_ELECTION_QUORUM,	"Not enough peers connected to start elections: %d out of minimal required %d")\
 	/*243 */_(ER_SSL,			"%s") \
 	/*244 */_(ER_SPLIT_BRAIN,		"Split-Brain discovered: %s") \
+	/*245 */_(ER_INVALID_POSITION,		"Position descriptor is invalid") \
 
 /*
  * !IMPORTANT! Please follow instructions at start of the file

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -153,6 +153,16 @@ exact_key_validate(struct key_def *key_def, const char *key,
 	return key_validate_parts(key_def, key, part_count, false, &key_end);
 }
 
+int
+position_validate(const struct index_def *index_def, const char *key,
+		  uint32_t part_count)
+{
+	int rc = exact_key_validate(index_def->cmp_def, key, part_count);
+	if (rc != 0)
+		diag_set(ClientError, ER_INVALID_POSITION);
+	return rc;
+}
+
 char *
 box_tuple_extract_key(box_tuple_t *tuple, uint32_t space_id, uint32_t index_id,
 		      uint32_t *key_size)

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -734,6 +734,19 @@ generic_index_get(struct index *index, const char *key,
 }
 
 int
+generic_index_tuple_position(struct index *index, struct tuple *tuple,
+			     struct iterator *it, const char **pos,
+			     uint32_t *size)
+{
+	(void)tuple;
+	(void)it;
+	*size = 0;
+	*pos = NULL;
+	diag_set(UnsupportedIndexFeature, index->def, "pagination");
+	return -1;
+}
+
+int
 generic_index_replace(struct index *index, struct tuple *old_tuple,
 		      struct tuple *new_tuple, enum dup_replace_mode mode,
 		      struct tuple **result, struct tuple **successor)

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -413,7 +413,7 @@ box_index_iterator(uint32_t space_id, uint32_t index_id, int type,
 	if (txn_begin_ro_stmt(space, &txn, &svp) != 0)
 		return NULL;
 	struct iterator *it = index_create_iterator(index, itype,
-						    key, part_count);
+						    key, part_count, NULL);
 	if (it == NULL) {
 		txn_rollback_stmt(txn);
 		return NULL;
@@ -662,7 +662,7 @@ generic_index_min(struct index *index, const char *key,
 		  uint32_t part_count, struct tuple **result)
 {
 	struct iterator *it = index_create_iterator(index, ITER_EQ,
-						    key, part_count);
+						    key, part_count, NULL);
 	if (it == NULL)
 		return -1;
 	int rc = iterator_next(it, result);
@@ -675,7 +675,7 @@ generic_index_max(struct index *index, const char *key,
 		  uint32_t part_count, struct tuple **result)
 {
 	struct iterator *it = index_create_iterator(index, ITER_REQ,
-						    key, part_count);
+						    key, part_count, NULL);
 	if (it == NULL)
 		return -1;
 	int rc = iterator_next(it, result);
@@ -697,7 +697,7 @@ generic_index_count(struct index *index, enum iterator_type type,
 		    const char *key, uint32_t part_count)
 {
 	struct iterator *it = index_create_iterator(index, type,
-						    key, part_count);
+						    key, part_count, NULL);
 	if (it == NULL)
 		return -1;
 	int rc = 0;
@@ -749,9 +749,10 @@ generic_index_replace(struct index *index, struct tuple *old_tuple,
 
 struct iterator *
 generic_index_create_iterator(struct index *base, enum iterator_type type,
-			      const char *key, uint32_t part_count)
+			      const char *key, uint32_t part_count,
+			      const char *after)
 {
-	(void) type; (void) key; (void) part_count;
+	(void) type; (void) key; (void) part_count; (void) after;
 	diag_set(UnsupportedIndexFeature, base->def, "read view");
 	return NULL;
 }

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -41,6 +41,7 @@
 #include "info/info.h"
 #include "memtx_tx.h"
 #include "box.h"
+#include "position.h"
 
 struct rlist box_on_select = RLIST_HEAD_INITIALIZER(box_on_select);
 
@@ -190,6 +191,18 @@ check_index(uint32_t space_id, uint32_t index_id,
 	if (*index == NULL)
 		return -1;
 	return 0;
+}
+
+int
+box_index_tuple_position(uint32_t space_id, uint32_t index_id,
+			 struct tuple *tuple, struct position *pos)
+{
+	struct space *space;
+	struct index *index;
+	if (check_index(space_id, index_id, &space, &index) != 0)
+		return -1;
+	return index_tuple_position(index, tuple, NULL, &pos->key,
+				    &pos->key_size);
 }
 
 /* }}} */

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -388,6 +388,16 @@ exact_key_validate(struct key_def *key_def, const char *key,
 		   uint32_t part_count);
 
 /**
+ * Check that the supplied key is valid to uniquely identify
+ * iterator position.
+ * @retval 0  The key is valid.
+ * @retval -1 The key is invalid.
+ */
+int
+position_validate(const struct index_def *index_def, const char *key,
+		  uint32_t part_count);
+
+/**
  * The manner in which replace in a unique index must treat
  * duplicates (tuples with the same value of indexed key),
  * possibly present in the index.

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -479,6 +479,9 @@ struct index_vtab {
 			    uint32_t part_count, struct tuple **result);
 	int (*get)(struct index *index, const char *key,
 		   uint32_t part_count, struct tuple **result);
+	int (*tuple_position)(struct index *index, struct tuple *tuple,
+			      struct iterator *it, const char **pos,
+			      uint32_t *size);
 	/**
 	 * Main entrance point for changing data in index. Once built and
 	 * before deletion this is the only way to insert, replace and delete
@@ -758,6 +761,13 @@ index_get(struct index *index, const char *key,
 }
 
 static inline int
+index_tuple_position(struct index *index, struct tuple *tuple,
+		     struct iterator *it, const char **pos, uint32_t *size)
+{
+	return index->vtab->tuple_position(index, tuple, it, pos, size);
+}
+
+static inline int
 index_replace(struct index *index, struct tuple *old_tuple,
 	      struct tuple *new_tuple, enum dup_replace_mode mode,
 	      struct tuple **result, struct tuple **successor)
@@ -871,6 +881,9 @@ int
 generic_index_get_internal(struct index *index, const char *key,
 			   uint32_t part_count, struct tuple **result);
 int generic_index_get(struct index *, const char *, uint32_t, struct tuple **);
+int
+generic_index_tuple_position(struct index *, struct tuple *,
+			     struct iterator *, const char **, uint32_t *);
 int generic_index_replace(struct index *, struct tuple *, struct tuple *,
 			  enum dup_replace_mode,
 			  struct tuple **, struct tuple **);

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -494,8 +494,8 @@ struct index_vtab {
 		       struct tuple **result, struct tuple **successor);
 	/** Create an index iterator. */
 	struct iterator *(*create_iterator)(struct index *index,
-			enum iterator_type type,
-			const char *key, uint32_t part_count);
+			enum iterator_type type, const char *key,
+			uint32_t part_count, const char *after);
 	/** Create an index read view. */
 	struct index_read_view *(*create_read_view)(struct index *index);
 	/** Introspection (index:stat()) */
@@ -768,9 +768,10 @@ index_replace(struct index *index, struct tuple *old_tuple,
 
 static inline struct iterator *
 index_create_iterator(struct index *index, enum iterator_type type,
-		      const char *key, uint32_t part_count)
+		      const char *key, uint32_t part_count, const char *after)
 {
-	return index->vtab->create_iterator(index, type, key, part_count);
+	return index->vtab->create_iterator(index, type, key, part_count,
+					    after);
 }
 
 static inline struct index_read_view *
@@ -882,7 +883,8 @@ void generic_index_begin_build(struct index *);
 int generic_index_reserve(struct index *, uint32_t);
 struct iterator *
 generic_index_create_iterator(struct index *base, enum iterator_type type,
-			      const char *key, uint32_t part_count);
+			      const char *key, uint32_t part_count,
+			      const char *after);
 int generic_index_build_next(struct index *, struct tuple *);
 void generic_index_end_build(struct index *);
 int

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -50,6 +50,7 @@ struct index_read_view_iterator;
 struct index_def;
 struct key_def;
 struct info_handler;
+struct position;
 
 typedef struct tuple box_tuple_t;
 typedef struct key_def box_key_def_t;
@@ -250,6 +251,10 @@ box_tuple_extract_key(box_tuple_t *tuple, uint32_t space_id,
 		      uint32_t index_id, uint32_t *key_size);
 
 /** \endcond public */
+
+int
+box_index_tuple_position(uint32_t space_id, uint32_t index_id,
+			 box_tuple_t *tuple, struct position *pos);
 
 /**
  * Index statistics (index:stat())

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -114,11 +114,31 @@ ffi.cdef[[
     void
     port_destroy(struct port *port);
 
+    struct position {
+	    uint32_t key_size;
+	    const char *key;
+    };
+
+    void
+    position_reset(struct position *pos);
+
+    int
+    position_unpack(const char *ptr, struct position *pos);
+
+    const char *
+    position_pack_on_gc(struct position *pos, uint32_t *size);
+
     int
     box_select(uint32_t space_id, uint32_t index_id,
                int iterator, uint32_t offset, uint32_t limit,
                const char *key, const char *key_end,
                struct port *port);
+
+    int
+    box_select_after(uint32_t space_id, uint32_t index_id,
+                     int iterator, uint32_t offset, uint32_t limit,
+                     const char *key, const char *key_end,
+                     struct position *pos, bool update_pos, struct port *port);
 
     void password_prepare(const char *password, int len,
                           char *out, int out_len);
@@ -1861,6 +1881,10 @@ end
 local port = ffi.new('struct port')
 local port_c = ffi.cast('struct port_c *', port)
 
+-- global struct position instance to use by select()/pairs()
+local position = ffi.new('struct position')
+local position_len = ffi.new('uint32_t[1]')
+
 -- Helper function to check space:method() usage
 local function check_space_arg(space, method)
     if type(space) ~= 'table' or space.id == nil then
@@ -2413,6 +2437,8 @@ local function check_select_opts(opts, key_is_nil)
     local limit = 4294967295
     local iterator = check_iterator_type(opts, key_is_nil)
     local fullscan = false
+    local after = ""
+    local fetch_pos = false
     if opts ~= nil and type(opts) == "table" then
         if opts.offset ~= nil then
             offset = opts.offset
@@ -2423,8 +2449,20 @@ local function check_select_opts(opts, key_is_nil)
         if opts.fullscan ~= nil then
             fullscan = opts.fullscan
         end
+        if opts.after ~= nil then
+            after = opts.after
+            if after == box.NULL then
+                after = ""
+            end
+            if type(after) ~= "string" then
+                box.error(box.error.INVALID_POSITION)
+            end
+        end
+        if opts.fetch_pos ~= nil then
+            fetch_pos = opts.fetch_pos
+        end
     end
-    return iterator, offset, limit, fullscan
+    return iterator, offset, limit, fullscan, after, fetch_pos
 end
 
 box.internal.check_select_opts = check_select_opts -- for net.box
@@ -2451,12 +2489,19 @@ base_index_mt.select_ffi = function(index, key, opts)
     local ibuf = cord_ibuf_take()
     local key, key_end = tuple_encode(ibuf, key)
     local key_is_nil = key + 1 >= key_end
-    local iterator, offset, limit, fullscan =
+    local iterator, offset, limit, fullscan, after, fetch_pos =
         check_select_opts(opts, key_is_nil)
     check_select_safety(index, key_is_nil, iterator, limit, offset, fullscan)
-
-    local nok = builtin.box_select(index.space_id, index.id, iterator, offset,
-                                   limit, key, key_end, port) ~= 0
+    if after ~= "" then
+        local rc = builtin.position_unpack(after, position)
+        if rc ~= 0 then
+            return box.error(box.error.INVALID_POSITION)
+        end
+    else
+        builtin.position_reset(position)
+    end
+    local nok = builtin.box_select_after(index.space_id, index.id, iterator, offset,
+                                   limit, key, key_end, position, fetch_pos, port) ~= 0
     cord_ibuf_put(ibuf)
     if nok then
         return box.error()
@@ -2469,6 +2514,11 @@ base_index_mt.select_ffi = function(index, key, opts)
         entry = entry.next
     end
     builtin.port_destroy(port);
+    if fetch_pos then
+        local new_pos = builtin.position_pack_on_gc(position, position_len)
+        new_pos = ffi.string(new_pos, position_len[0])
+        return ret, new_pos
+    end
     return ret
 end
 

--- a/src/box/memtx_bitset.cc
+++ b/src/box/memtx_bitset.cc
@@ -336,13 +336,18 @@ memtx_bitset_index_replace(struct index *base, struct tuple *old_tuple,
 
 static struct iterator *
 memtx_bitset_index_create_iterator(struct index *base, enum iterator_type type,
-				   const char *key, uint32_t part_count)
+				   const char *key, uint32_t part_count,
+				   const char *after)
 {
 	struct memtx_bitset_index *index = (struct memtx_bitset_index *)base;
 	struct memtx_engine *memtx = (struct memtx_engine *)base->engine;
 
 	assert(part_count == 0 || key != NULL);
 	(void) part_count;
+	if (unlikely(after != NULL)) {
+		diag_set(UnsupportedIndexFeature, base->def, "pagination");
+		return NULL;
+	}
 
 	struct bitset_index_iterator *it = (struct bitset_index_iterator *)
 		mempool_alloc(&memtx->iterator_pool);

--- a/src/box/memtx_bitset.cc
+++ b/src/box/memtx_bitset.cc
@@ -505,6 +505,7 @@ static const struct index_vtab memtx_bitset_index_vtab = {
 	/* .count = */ memtx_bitset_index_count,
 	/* .get_internal = */ generic_index_get_internal,
 	/* .get = */ generic_index_get,
+	/* .tuple_position = */ generic_index_tuple_position,
 	/* .replace = */ memtx_bitset_index_replace,
 	/* .create_iterator = */ memtx_bitset_index_create_iterator,
 	/* .create_read_view = */ generic_index_create_read_view,

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -127,7 +127,8 @@ memtx_build_secondary_index(struct index *index, struct index *pk)
 			 index->def->name);
 	}
 
-	struct iterator *it = index_create_iterator(pk, ITER_ALL, NULL, 0);
+	struct iterator *it = index_create_iterator(pk, ITER_ALL, NULL, 0,
+						    NULL);
 	if (it == NULL)
 		return -1;
 

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -404,12 +404,17 @@ memtx_hash_index_replace(struct index *base, struct tuple *old_tuple,
 
 static struct iterator *
 memtx_hash_index_create_iterator(struct index *base, enum iterator_type type,
-				 const char *key, uint32_t part_count)
+				 const char *key, uint32_t part_count,
+				 const char *after)
 {
 	struct memtx_hash_index *index = (struct memtx_hash_index *)base;
 	struct memtx_engine *memtx = (struct memtx_engine *)base->engine;
 
 	assert(part_count == 0 || key != NULL);
+	if (unlikely(after != NULL)) {
+		diag_set(UnsupportedIndexFeature, base->def, "pagination");
+		return NULL;
+	}
 
 	struct hash_iterator *it = (struct hash_iterator *)
 		mempool_alloc(&memtx->iterator_pool);

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -601,6 +601,7 @@ static const struct index_vtab memtx_hash_index_vtab = {
 	/* .count = */ memtx_hash_index_count,
 	/* .get_internal = */ memtx_hash_index_get_internal,
 	/* .get = */ memtx_index_get,
+	/* .tuple_position = */ generic_index_tuple_position,
 	/* .replace = */ memtx_hash_index_replace,
 	/* .create_iterator = */ memtx_hash_index_create_iterator,
 	/* .create_read_view = */ memtx_hash_index_create_read_view,

--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -293,10 +293,16 @@ memtx_rtree_index_reserve(struct index *base, uint32_t size_hint)
 
 static struct iterator *
 memtx_rtree_index_create_iterator(struct index *base,  enum iterator_type type,
-				  const char *key, uint32_t part_count)
+				  const char *key, uint32_t part_count,
+				  const char *after)
 {
 	struct memtx_rtree_index *index = (struct memtx_rtree_index *)base;
 	struct memtx_engine *memtx = (struct memtx_engine *)base->engine;
+
+	if (unlikely(after != NULL)) {
+		diag_set(UnsupportedIndexFeature, base->def, "pagination");
+		return NULL;
+	}
 
 	struct rtree_rect rect;
 	if (part_count == 0) {

--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -390,6 +390,7 @@ static const struct index_vtab memtx_rtree_index_vtab = {
 	/* .count = */ memtx_rtree_index_count,
 	/* .get_internal = */ memtx_rtree_index_get_internal,
 	/* .get = */ memtx_index_get,
+	/* .tuple_position = */ generic_index_tuple_position,
 	/* .replace = */ memtx_rtree_index_replace,
 	/* .create_iterator = */ memtx_rtree_index_create_iterator,
 	/* .create_read_view = */ generic_index_create_read_view,

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -975,7 +975,8 @@ memtx_space_check_format(struct space *space, struct tuple_format *format)
 	if (index_size(pk) == 0)
 		return 0;
 
-	struct iterator *it = index_create_iterator(pk, ITER_ALL, NULL, 0);
+	struct iterator *it = index_create_iterator(pk, ITER_ALL, NULL, 0,
+						    NULL);
 	if (it == NULL)
 		return -1;
 
@@ -1226,7 +1227,8 @@ memtx_space_build_index(struct space *src_space, struct index *new_index,
 	}
 
 	/* Now deal with any kind of add index during normal operation. */
-	struct iterator *it = index_create_iterator(pk, ITER_ALL, NULL, 0);
+	struct iterator *it = index_create_iterator(pk, ITER_ALL, NULL, 0,
+						    NULL);
 	if (it == NULL)
 		return -1;
 	/*

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -1410,7 +1410,8 @@ end:
 template <bool USE_HINT>
 static struct iterator *
 memtx_tree_index_create_iterator(struct index *base, enum iterator_type type,
-				 const char *key, uint32_t part_count)
+				 const char *key, uint32_t part_count,
+				 const char *after)
 {
 	struct memtx_tree_index<USE_HINT> *index =
 		(struct memtx_tree_index<USE_HINT> *)base;
@@ -1421,6 +1422,10 @@ memtx_tree_index_create_iterator(struct index *base, enum iterator_type type,
 	if (type > ITER_GT) {
 		diag_set(UnsupportedIndexFeature, base->def,
 			 "requested iterator type");
+		return NULL;
+	}
+	if (unlikely(after != NULL)) {
+		diag_set(UnsupportedIndexFeature, base->def, "pagination");
 		return NULL;
 	}
 

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -1827,6 +1827,7 @@ static const struct index_vtab memtx_tree_disabled_index_vtab = {
 	/* .count = */ generic_index_count,
 	/* .get_internal = */ generic_index_get_internal,
 	/* .get = */ generic_index_get,
+	/* .tuple_position = */ generic_index_tuple_position,
 	/* .replace = */ disabled_index_replace,
 	/* .create_iterator = */ generic_index_create_iterator,
 	/* .create_read_view = */ generic_index_create_read_view,
@@ -1887,6 +1888,7 @@ get_memtx_tree_index_vtab(void)
 		/* .count = */ memtx_tree_index_count<USE_HINT>,
 		/* .get_internal */ memtx_tree_index_get_internal<USE_HINT>,
 		/* .get = */ memtx_index_get,
+		/* .tuple_position = */ generic_index_tuple_position,
 		/* .replace = */ is_mk ? memtx_tree_index_replace_multikey :
 				 is_func ? memtx_tree_func_index_replace :
 				 memtx_tree_index_replace<USE_HINT>,

--- a/src/box/position.c
+++ b/src/box/position.c
@@ -1,0 +1,98 @@
+#include "position.h"
+#include "msgpuck.h"
+#include "trivia/util.h"
+
+/*
+ * Although the structure in C is very simple, it has a more
+ * complex format in MsgPack:
+ * +--------+--------+--------------+========================+
+ * | MP_BIN | MP_MAP | POSITION_KEY | KEY IN MP_ARRAY FORMAT |
+ * +--------+--------+--------------+========================+
+ * MP_BIN - needed to make the object opaque to users working
+ * directly with IPROTO.
+ * MP_MAP - needed for extensibility (at least, we have an idea
+ * to generate a digital signature to make sure that user did
+ * not modify the object).
+ * All the keys of map should be unsigned integer values to
+ * minimize the size of the object.
+ */
+
+/** Keys for position map. All the keys must be uint. */
+enum {
+	/** There must be MP_ARRAY after this key, UB otherwise. */
+	POSITION_KEY,
+	POSITION_MAX,
+};
+
+uint32_t
+position_pack_size(struct position *pos)
+{
+	assert(pos != NULL);
+	if (pos->key == NULL) {
+		assert(pos->key_size == 0);
+		return 0;
+	}
+
+	assert(pos->key_size != 0);
+	uint32_t total = pos->key_size;
+	total += mp_sizeof_uint(POSITION_KEY);
+	total += mp_sizeof_map(POSITION_MAX);
+	total += mp_sizeof_binl(total);
+	return total;
+}
+
+void
+position_pack(struct position *pos, char *buffer)
+{
+	assert(pos != NULL);
+	assert(buffer != NULL);
+	if (pos->key == NULL) {
+		assert(pos->key_size == 0);
+		return;
+	}
+	assert(mp_typeof(pos->key[0]) == MP_ARRAY);
+
+	uint32_t map_len = pos->key_size;
+	map_len += mp_sizeof_uint(POSITION_KEY);
+	map_len += mp_sizeof_map(POSITION_MAX);
+	buffer = mp_encode_binl(buffer, map_len);
+	buffer = mp_encode_map(buffer, POSITION_MAX);
+	buffer = mp_encode_uint(buffer, POSITION_KEY);
+	memcpy(buffer, pos->key, pos->key_size);
+}
+
+int
+position_unpack(const char *ptr, struct position *pos)
+{
+	assert(ptr != NULL);
+	assert(pos != NULL);
+
+	pos->key = NULL;
+	pos->key_size = 0;
+	const char **cptr = &ptr;
+	if (unlikely(mp_typeof(*ptr) != MP_BIN))
+		return -1;
+	mp_decode_binl(cptr);
+	if (unlikely(mp_typeof(*ptr) != MP_MAP))
+		return -1;
+	uint32_t map_len = mp_decode_map(cptr);
+	if (unlikely(map_len > 1))
+		return -1;
+	for (uint32_t i = 0; i < map_len; ++i) {
+		if (unlikely(mp_typeof(*ptr) != MP_UINT))
+			return -1;
+		uint32_t key = mp_decode_uint(cptr);
+		switch (key) {
+		case POSITION_KEY:
+			if (unlikely(mp_typeof(*ptr) != MP_ARRAY))
+				return -1;
+			pos->key = ptr;
+			mp_next(cptr);
+			pos->key_size = ptr - pos->key;
+			break;
+		default:
+			return -1;
+		}
+	}
+	return 0;
+}

--- a/src/box/position.h
+++ b/src/box/position.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+/** Position descriptor. */
+struct position {
+	/** Size of key in bytes. */
+	uint32_t key_size;
+	/** Extracted cmp_def of tuple, with array header. */
+	const char *key;
+};
+
+/** Calculate length of packed position. */
+uint32_t
+position_pack_size(struct position *pos);
+
+/**
+ * Pack position to preallocated buffer. Buffer length must be
+ * more or equal than packed size of position.
+ */
+void
+position_pack(struct position *pos, char *buffer);
+
+/**
+ * Unpack position from MsgPack. Lifetime of returned position is the same
+ * as lifetime of passed ptr. Returns 0 on success, -1 on failure,
+ * diag is not set!
+ */
+int
+position_unpack(const char *ptr, struct position *pos);
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined __cplusplus */

--- a/src/box/position.h
+++ b/src/box/position.h
@@ -33,6 +33,9 @@ position_pack(struct position *pos, char *buffer);
 int
 position_unpack(const char *ptr, struct position *pos);
 
+const char *
+position_pack_on_gc(struct position *pos, uint32_t *size);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined __cplusplus */

--- a/src/box/schema.cc
+++ b/src/box/schema.cc
@@ -168,7 +168,8 @@ schema_find_id(uint32_t system_space_id, uint32_t index_id,
 		return -1;
 	}
 	mp_encode_str(key, name, len);
-	struct iterator *it = index_create_iterator(index, ITER_EQ, key, 1);
+	struct iterator *it = index_create_iterator(index, ITER_EQ, key, 1,
+						    NULL);
 	if (it == NULL) {
 		region_truncate(region, used);
 		return -1;
@@ -379,7 +380,8 @@ schema_find_grants(const char *type, uint32_t id, bool *out)
 	char key[GRANT_NAME_MAX + 10];
 	assert(strlen(type) <= GRANT_NAME_MAX);
 	mp_encode_uint(mp_encode_str(key, type, strlen(type)), id);
-	struct iterator *it = index_create_iterator(index, ITER_EQ, key, 2);
+	struct iterator *it = index_create_iterator(index, ITER_EQ, key, 2,
+						    NULL);
 	if (it == NULL)
 		return -1;
 	IteratorGuard iter_guard(it);

--- a/src/box/session_settings.c
+++ b/src/box/session_settings.c
@@ -190,10 +190,14 @@ session_settings_index_destroy(struct index *index)
 static struct iterator *
 session_settings_index_create_iterator(struct index *base,
 				       enum iterator_type type, const char *key,
-				       uint32_t part_count)
+				       uint32_t part_count, const char *after)
 {
 	struct session_settings_index *index =
 		(struct session_settings_index *)base;
+	if (unlikely(after != NULL)) {
+		diag_set(UnsupportedIndexFeature, base->def, "pagination");
+		return NULL;
+	}
 	char *decoded_key = NULL;
 	if (part_count > 0) {
 		assert(part_count == 1);

--- a/src/box/session_settings.c
+++ b/src/box/session_settings.c
@@ -277,6 +277,7 @@ static const struct index_vtab session_settings_index_vtab = {
 	/* .count = */ generic_index_count,
 	/* .get_internal = */ generic_index_get_internal,
 	/* .get = */ session_settings_index_get,
+	/* .tuple_position = */ generic_index_tuple_position,
 	/* .replace = */ generic_index_replace,
 	/* .create_iterator = */ session_settings_index_create_iterator,
 	/* .create_read_view = */ generic_index_create_read_view,

--- a/src/box/space_cache.c
+++ b/src/box/space_cache.c
@@ -93,7 +93,7 @@ space_foreach(int (*func)(struct space *sp, void *udata), void *udata)
 	struct index *pk = space ? space_index(space, 0) : NULL;
 	if (pk) {
 		struct iterator *it = index_create_iterator(pk, ITER_GE,
-							    key, 1);
+							    key, 1, NULL);
 		if (it == NULL)
 			return -1;
 		int rc;

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -553,7 +553,7 @@ int tarantoolsqlEphemeralClearTable(BtCursor *pCur)
 
 	struct iterator *it = index_create_iterator(*pCur->space->index,
 						    ITER_ALL, nil_key,
-						    0 /* part_count */);
+						    0 /* part_count */, NULL);
 	if (it == NULL) {
 		pCur->eState = CURSOR_INVALID;
 		return -1;
@@ -593,7 +593,8 @@ int tarantoolsqlClearTable(struct space *space, uint32_t *tuple_count)
 	request.type = IPROTO_DELETE;
 	request.space_id = space->def->id;
 	struct index *pk = space_index(space, 0 /* PK */);
-	struct iterator *iter = index_create_iterator(pk, ITER_ALL, nil_key, 0);
+	struct iterator *iter = index_create_iterator(pk, ITER_ALL, nil_key, 0,
+						      NULL);
 	if (iter == NULL)
 		return -1;
 	while (iterator_next(iter, &tuple) == 0 && tuple != NULL) {
@@ -930,7 +931,7 @@ cursor_seek(BtCursor *pCur, int *pRes)
 		return -1;
 	struct iterator *it =
 		index_create_iterator(pCur->index, pCur->iter_type, key,
-				      part_count);
+				      part_count, NULL);
 	if (it == NULL) {
 		if (txn != NULL)
 			txn_rollback_stmt(txn);

--- a/src/box/sysview.c
+++ b/src/box/sysview.c
@@ -110,10 +110,15 @@ sysview_index_destroy(struct index *index)
 
 static struct iterator *
 sysview_index_create_iterator(struct index *base, enum iterator_type type,
-			      const char *key, uint32_t part_count)
+			      const char *key, uint32_t part_count,
+			      const char *after)
 {
 	struct sysview_index *index = (struct sysview_index *)base;
 	struct sysview_engine *sysview = (struct sysview_engine *)base->engine;
+	if (unlikely(after != NULL)) {
+		diag_set(UnsupportedIndexFeature, base->def, "pagination");
+		return NULL;
+	}
 
 	struct space *source = space_cache_find(index->source_space_id);
 	if (source == NULL)
@@ -140,7 +145,7 @@ sysview_index_create_iterator(struct index *base, enum iterator_type type,
 	it->base.next = sysview_iterator_next;
 	it->base.free = sysview_iterator_free;
 
-	it->source = index_create_iterator(pk, type, key, part_count);
+	it->source = index_create_iterator(pk, type, key, part_count, after);
 	if (it->source == NULL) {
 		mempool_free(&sysview->iterator_pool, it);
 		return NULL;

--- a/src/box/sysview.c
+++ b/src/box/sysview.c
@@ -199,6 +199,7 @@ static const struct index_vtab sysview_index_vtab = {
 	/* .count = */ generic_index_count,
 	/* .get_internal = */ generic_index_get_internal,
 	/* .get = */ sysview_index_get,
+	/* .tuple_position = */ generic_index_tuple_position,
 	/* .replace = */ generic_index_replace,
 	/* .create_iterator = */ sysview_index_create_iterator,
 	/* .create_read_view = */ generic_index_create_read_view,

--- a/src/box/user.cc
+++ b/src/box/user.cc
@@ -349,7 +349,7 @@ user_reload_privs(struct user *user)
 		mp_encode_uint(key, user->def->uid);
 
 		struct iterator *it = index_create_iterator(index, ITER_EQ,
-							       key, 1);
+							       key, 1, NULL);
 		if (it == NULL)
 			return -1;
 		IteratorGuard iter_guard(it);

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -4592,6 +4592,7 @@ static const struct index_vtab vinyl_index_vtab = {
 	/* .count = */ generic_index_count,
 	/* .get_internal = */ generic_index_get_internal,
 	/* .get = */ vinyl_index_get,
+	/* .tuple_position = */ generic_index_tuple_position,
 	/* .replace = */ generic_index_replace,
 	/* .create_iterator = */ vinyl_index_create_iterator,
 	/* .create_read_view = */ generic_index_create_read_view,

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -3716,7 +3716,8 @@ vinyl_iterator_free(struct iterator *base)
 
 static struct iterator *
 vinyl_index_create_iterator(struct index *base, enum iterator_type type,
-			    const char *key, uint32_t part_count)
+			    const char *key, uint32_t part_count,
+			    const char *after)
 {
 	struct vy_lsm *lsm = vy_lsm(base);
 	struct vy_env *env = vy_env(base->engine);
@@ -3724,6 +3725,10 @@ vinyl_index_create_iterator(struct index *base, enum iterator_type type,
 	if (type > ITER_GT) {
 		diag_set(UnsupportedIndexFeature, base->def,
 			 "requested iterator type");
+		return NULL;
+	}
+	if (unlikely(after != NULL)) {
+		diag_set(UnsupportedIndexFeature, base->def, "pagination");
 		return NULL;
 	}
 

--- a/test/box-luatest/pagination_test.lua
+++ b/test/box-luatest/pagination_test.lua
@@ -1,0 +1,420 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local tree_g = t.group('Tree index tests')
+
+tree_g.before_all(function()
+    tree_g.server = server:new{
+        alias   = 'default',
+    }
+    tree_g.server:start()
+end)
+
+tree_g.after_all(function()
+    tree_g.server:drop()
+end)
+
+tree_g.before_each(function()
+    tree_g.server:exec(function()
+        box.schema.space.create('s', {engine = 'memtx'})
+    end)
+end)
+
+tree_g.after_each(function()
+    tree_g.server:exec(function()
+        box.space.s:drop()
+    end)
+end)
+
+tree_g.test_tree_pagination = function()
+    tree_g.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.s
+        s:create_index("pk", {type = "tree"})
+        s:create_index("sk", {parts = {2}, type = "tree", unique=false})
+
+        -- Fetch position in empty space
+        local tuples, pos = s:select(nil,
+                {limit=2, fullscan=true, fetch_pos=true})
+        t.assert_equals(tuples, {})
+        t.assert_equals(pos, "")
+
+        for i = 1, 11 do
+            s:replace{i, 1}
+        end
+
+        local tuples1 = nil
+        local tuples2 = nil
+        local tuples_offset = nil
+        local pos = ""
+        local last_tuple = box.NULL
+        local last_pos = nil
+
+        -- Test fullscan pagination
+        for i = 0, 5 do
+            tuples1, pos = s:select(nil,
+                    {limit=2, fullscan=true, fetch_pos=true, after=pos})
+            tuples2 = s:select(nil,
+                    {limit=2, fullscan=true, after=last_tuple})
+            last_tuple = tuples2[2]
+            tuples_offset = s:select(nil,
+                    {limit=2, fullscan=true, offset=i*2})
+            t.assert_equals(tuples1, tuples_offset)
+            t.assert_equals(tuples2, tuples_offset)
+        end
+        tuples1, last_pos = s:select(nil,
+                {limit=2, fullscan=true, fetch_pos=true, after=pos})
+        t.assert_equals(tuples1, {})
+        t.assert_equals(last_pos, pos)
+
+        -- Test pagination on range iterators
+        local key_iter = {
+            [3] = 'GE',
+            [2] = 'GT',
+            [9] = 'LE',
+            [10] = 'LT',
+        }
+        for key, iter in pairs(key_iter) do
+            tuples1 = nil
+            tuples2 = nil
+            tuples_offset = nil
+            pos = ""
+            last_tuple = box.NULL
+            last_pos = nil
+            for i = 0, 4 do
+                tuples1, pos = s:select(key,
+                        {limit=2, iterator=iter, fetch_pos=true, after=pos})
+                tuples2 = s:select(key,
+                        {limit=2, iterator=iter, after=last_tuple})
+                last_tuple = tuples2[2]
+                tuples_offset = s:select(key,
+                        {limit=2, iterator=iter, offset=i*2})
+                t.assert_equals(tuples1, tuples_offset)
+                t.assert_equals(tuples2, tuples_offset)
+            end
+            tuples1, last_pos = s:select(key,
+                    {limit=2, iterator=iter, fetch_pos=true, after=pos})
+            t.assert_equals(tuples1, {})
+            t.assert_equals(last_pos, pos)
+        end
+
+        -- Test pagination on equality iterators
+        s:replace{0, 0}
+        s:replace{12, 2}
+        for _, iter in pairs({'EQ', 'REQ'}) do
+            tuples1 = nil
+            tuples2 = nil
+            tuples_offset = nil
+            pos = ""
+            last_tuple = box.NULL
+            last_pos = nil
+            for i = 0, 5 do
+                tuples1, pos = s.index.sk:select(1,
+                        {limit=2, iterator=iter, fetch_pos=true, after=pos})
+                tuples2 = s.index.sk:select(1,
+                        {limit=2, iterator=iter, after=last_tuple})
+                last_tuple = tuples2[2]
+                tuples_offset = s.index.sk:select(1,
+                        {limit=2, iterator=iter, offset=i*2})
+                t.assert_equals(tuples1, tuples_offset)
+                t.assert_equals(tuples2, tuples_offset)
+            end
+            tuples, last_pos = s.index.sk:select(1,
+                    {iterator=iter, limit=2, fetch_pos=true, after=pos})
+            t.assert_equals(tuples, {})
+            t.assert_equals(last_pos, pos)
+        end
+    end)
+end
+
+tree_g.test_tree_multikey_pagination = function()
+    tree_g.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.s
+        s:create_index("pk", {type = "tree"})
+        local sk = s:create_index("sk",
+                {parts = {{field = 2, type = 'uint', path = '[*]'}},
+                 type = "tree", unique=false})
+
+        -- Fetch position in empty space
+        local tuples, pos = sk:select(nil,
+                {limit=2, fullscan=true, fetch_pos=true})
+        t.assert_equals(tuples, {})
+        t.assert_equals(pos, "")
+
+        for i = 1, 3 do
+            s:replace{i, {1, 2, 3}}
+        end
+
+        local tuples = nil
+        local tuples_offset = nil
+        local pos = ""
+        local last_pos = nil
+
+        -- Test fullscan pagination
+        for i = 0, 4 do
+            tuples, pos = sk:select(nil,
+                    {limit=2, fullscan=true, fetch_pos=true, after=pos})
+            tuples_offset = sk:select(nil,
+                    {limit=2, fullscan=true, offset=i*2})
+            t.assert_equals(tuples, tuples_offset)
+        end
+        tuples, last_pos = sk:select(nil,
+                {limit=2, fullscan=true, fetch_pos=true, after=pos})
+        t.assert_equals(tuples, {})
+        t.assert_equals(last_pos, pos)
+
+        -- Test pagination on range iterators
+        local key_iter = {
+            [2] = 'GE',
+            [1] = 'GT',
+            [2] = 'LE',
+            [3] = 'LT',
+        }
+        for key, iter in pairs(key_iter) do
+            tuples = nil
+            tuples_offset = nil
+            pos = ""
+            last_pos = nil
+            for i = 0, 2 do
+                tuples, pos = sk:select(key,
+                        {limit=2, iterator=iter, fetch_pos=true, after=pos})
+                tuples_offset = sk:select(key,
+                        {limit=2, iterator=iter, offset=i*2})
+                t.assert_equals(tuples, tuples_offset)
+            end
+            tuples, last_pos = sk:select(key,
+                    {limit=2, iterator=iter, fetch_pos=true, after=pos})
+            t.assert_equals(tuples, {})
+            t.assert_equals(last_pos, pos)
+        end
+
+        -- Test pagination on equality iterators
+        for _, iter in pairs({'EQ', 'REQ'}) do
+            tuples = nil
+            tuples_offset = nil
+            pos = ""
+            last_pos = nil
+            for i = 0, 1 do
+                tuples, pos = sk:select(2,
+                        {limit=2, iterator=iter, fetch_pos=true, after=pos})
+                tuples_offset = sk:select(2,
+                        {limit=2, iterator=iter, offset=i*2})
+                t.assert_equals(tuples, tuples_offset)
+            end
+            tuples, last_pos = sk:select(2,
+                    {iterator=iter, limit=2, fetch_pos=true, after=pos})
+            t.assert_equals(tuples, {})
+            t.assert_equals(last_pos, pos)
+        end
+
+        -- Test that after with tuple in multikey index returns an error
+        local tuple = s.index.pk:get(1)
+        t.assert_error_msg_contains(
+                "pagination without iteration context in multikey index",
+                sk.select, sk, nil, {fullscan=true, after=tuple})
+    end)
+end
+
+--[[ We must return an empty position if there are no tuples
+satisfying the filters. ]]--
+tree_g.test_no_tuples_satisfying_filters = function()
+    tree_g.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.s
+        s:create_index("pk", {type = "tree"})
+        s:create_index("sk",
+                {parts =
+                 {{field = 2, type = 'uint', path = '[*]'}},
+                 type = "tree",
+                 unique=false})
+
+        local tuples = nil
+        local pos = ""
+
+        s:replace{1, {1, 2}}
+
+        tuples, pos = s:select(3, {limit=1, iterator='GE', fetch_pos=true})
+        t.assert_equals(pos, "")
+        s:replace{2, {1, 2}}
+        s:replace{3, {1, 2}}
+        s:replace{4, {1, 2}}
+        tuples = s:select(3, {limit=1, iterator='GE', after=pos})
+        t.assert_equals(tuples[1], {3, {1, 2}})
+
+        tuples, pos = s.index.sk:select(4, {limit=1, iterator='GE', fetch_pos=true})
+        t.assert_equals(pos, "")
+        s:replace{5, {3, 4}}
+        tuples = s.index.sk:select(4, {limit=1, iterator='GE', after=pos})
+        t.assert_equals(tuples[1], {5, {3, 4}})
+    end)
+end
+
+tree_g.test_invalid_positions = function()
+    tree_g.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.s
+        s:create_index('pk', {type = 'tree'})
+        s:create_index('sk',
+                {parts = {{field = 2, type = 'string'}}, type = 'tree'})
+        s:replace{1, 'Zero'}
+
+        local tuples = nil
+        local pos = {1}
+        local flag, err = pcall(function()
+            s:select(1, {limit=1, iterator='GE', after=pos})
+        end)
+        t.assert_equals(flag, false)
+        t.assert_equals(err.code, box.error.INVALID_POSITION)
+
+        pos = "abcd"
+        flag, err = pcall(function()
+            s:select(1, {limit=1, iterator='GE', after=pos})
+        end)
+        t.assert_equals(flag, false)
+        t.assert_equals(err.code, box.error.INVALID_POSITION)
+
+        tuples, pos = s:select(nil, {fullscan=true, limit=1, fetch_pos=true})
+        t.assert(#pos > 0)
+        flag, err = pcall(function()
+            s.index.sk:select(nil, {fullscan=true, limit=1, after=pos})
+        end)
+        t.assert_equals(flag, false)
+        t.assert_equals(err.code, box.error.INVALID_POSITION)
+    end)
+end
+
+tree_g.test_tuple_pos_no_duplicates = function()
+    tree_g.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.s
+        s:create_index("pk", {type = "tree"})
+
+        for i = 1, 4 do
+            s:replace{i}
+        end
+        for i = 6, 10 do
+            s:replace{i}
+        end
+
+        local tuples, pos = s:select(1, {iterator='GE', fetch_pos=true, limit=5})
+        s:replace{5}
+        tuples = s:select(1, {iterator='GE', after=pos})
+        t.assert_equals(#tuples, 4)
+        t.assert_equals(tuples, s:select(7, {iterator='GE'}))
+
+        tuples, pos = s:select(1, {iterator='GE', fetch_pos=true})
+        s:delete(10)
+        tuples, pos = s:select(1, {iterator='GE', fetch_pos=true, after=pos})
+        s:replace{10}
+        s:replace{11}
+        tuples, pos = s:select(1, {iterator='GE', fetch_pos=true, after=pos})
+        t.assert_equals(#tuples, 1)
+        t.assert_equals(tuples[1], {11})
+    end)
+end
+
+tree_g.test_tuple_pos_simple = function()
+    tree_g.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.s
+        s:create_index("pk", {type = "tree"})
+        s:create_index("sk", {parts = {{field = 2, type = 'uint', path = '[*]'}}, type = "tree", unique=false})
+
+        local tuples = nil
+        local pos = ""
+        local last_pos = nil
+
+        for i = 1, 10 do
+            s:replace{i, {1, 2}}
+        end
+
+        pos = ""
+        for i = 0, 4 do
+            tuples, last_pos = s:select(nil,
+                    {limit=2, fullscan=true, fetch_pos=true, after=pos})
+            t.assert_equals(tuples[1][1], i * 2 + 1)
+            t.assert_equals(tuples[2][1], i * 2 + 2)
+            t.assert_equals(tuples[3], nil)
+            pos = s.index.pk:tuple_pos(tuples[2])
+            t.assert_equals(pos, last_pos)
+        end
+        tuples, last_pos = s:select(nil,
+                {limit=2, fullscan=true, fetch_pos=true, after=pos})
+        t.assert_equals(tuples, {})
+        t.assert_equals(last_pos, pos)
+
+        tuples = s:select(1)
+        t.assert_error_msg_contains(
+                "pagination without iteration context in multikey index",
+                s.index.sk.tuple_pos, s.index.sk, tuples[1])
+    end)
+end
+
+tree_g.test_tuple_pos_invalid_tuple = function()
+    tree_g.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.s
+        s:create_index("pk", {type = "tree"})
+
+        local tuples = nil
+        local pos = ""
+        local last_pos = nil
+
+        for i = 1, 10 do
+            s:replace{i, 0}
+        end
+
+        local err_msg = "Usage index.tuple_pos(space_id, index_id, tuple)"
+
+        t.assert_error_msg_contains(err_msg, s.index.pk.tuple_pos, s.index.pk)
+        t.assert_error_msg_contains(err_msg, s.index.pk.tuple_pos, s.index.pk,
+                                    {1, 0})
+    end)
+end
+
+
+local no_sup = t.group('Unsupported pagination', {
+            {engine = 'memtx', type = 'hash'},
+            {engine = 'memtx', type = 'bitset'},
+            {engine = 'memtx', type = 'rtree'},
+})
+
+no_sup.before_all(function(cg)
+    cg.server = server:new{
+        alias   = 'default',
+    }
+    cg.server:start()
+end)
+
+no_sup.after_all(function(cg)
+    cg.server:drop()
+end)
+
+no_sup.before_each(function(cg)
+    cg.server:exec(function(engine, type)
+        local s = box.schema.space.create('test', {engine=engine})
+        s:create_index('pk')
+        s:create_index('sk', {type=type})
+        -- An error will not be thrown if space not tuples found.
+        if type == 'rtree' then
+            s:replace{0, {0, 0}}
+        else
+            s:replace{0, 0}
+        end
+    end, {cg.params.engine, cg.params.type})
+end)
+
+no_sup.after_each(function(cg)
+    cg.server:exec(function()
+        box.space.test:drop()
+    end)
+end)
+
+no_sup.test_unsupported_pagination = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        t.assert_error_msg_contains('does not support pagination',
+                box.space.test.index.sk.select, box.space.test.index.sk,
+                nil, {fullscan=true, fetch_pos=true})
+    end)
+end

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -326,3 +326,6 @@ target_link_libraries(tt_sigaction.test core unit pthread)
 
 add_executable(string.test string.c core_test_utils.c)
 target_link_libraries(string.test core unit)
+
+add_executable(position.test position.c box_test_utils.c)
+target_link_libraries(position.test box unit)

--- a/test/unit/position.c
+++ b/test/unit/position.c
@@ -1,0 +1,105 @@
+#include "unit.h"
+#include "position.h"
+#include "msgpuck.h"
+#include "random.h"
+#include "time.h"
+
+#define KEY_BUF_LEN 50
+#define POS_BUF_LEN (KEY_BUF_LEN + 20)
+
+char key_buf[KEY_BUF_LEN];
+char pos_buf[POS_BUF_LEN];
+
+static uint32_t
+pack_random_key(uint32_t size)
+{
+	char *buf = key_buf;
+	buf = mp_encode_array(buf, size);
+	for (uint32_t i = 0; i < size; ++i) {
+		uint32_t key = rand();
+		buf = mp_encode_uint(buf, key);
+	}
+	return buf - key_buf;
+}
+
+static void
+simple_check()
+{
+	header();
+
+	uint32_t size = rand() % 8 + 2;
+	uint32_t key_len = pack_random_key(size);
+	struct position pos;
+	pos.key = key_buf;
+	pos.key_size = key_len;
+	uint32_t pack_size = position_pack_size(&pos);
+	assert(POS_BUF_LEN >= pack_size);
+	position_pack(&pos, pos_buf);
+	int rc = position_unpack(pos_buf, &pos);
+	ok(rc == 0, "Position must be unpacked");
+	ok(pos.key_size == key_len && memcmp(key_buf, pos.key, key_len) == 0,
+	   "Keys must match");
+
+	/** Invalidate position and try to unpack. */
+	ptrdiff_t offset = pos.key - pos_buf;
+	mp_encode_map(pos_buf + offset, size);
+	rc = position_unpack(pos_buf, &pos);
+	ok(rc != 0, "Invalid position must not be unpacked");
+	mp_encode_strl(pos_buf + offset, size);
+	ok(rc != 0, "Invalid position must not be unpacked");
+
+	footer();
+}
+
+static void
+unpack_invalid_check()
+{
+	header();
+
+	uint32_t size = rand() % 8 + 2;
+	uint32_t key_len = pack_random_key(size);
+	struct position pos;
+	struct position ret;
+	int rc = 0;
+
+	pos.key = NULL;
+	pos.key_size = 0;
+	pos_buf[0] = 0;
+	position_pack(&pos, pos_buf);
+	ok(pos_buf[0] == 0, "Empty position must not be packed");
+
+	pos.key = key_buf;
+	pos.key_size = key_len;
+
+	position_pack(&pos, pos_buf);
+	mp_encode_strl(pos_buf, pos.key_size - 2);
+	rc = position_unpack(pos_buf, &ret);
+	ok(rc != 0, "Position which is not MP_BIN must not be unpacked");
+
+	position_pack(&pos, pos_buf);
+	mp_encode_array(pos_buf + 2, 1);
+	rc = position_unpack(pos_buf, &ret);
+	ok(rc != 0, "Position which is not MP_MAP must not be unpacked");
+
+	position_pack(&pos, pos_buf);
+	pos_buf[3] = 1;
+	rc = position_unpack(pos_buf, &ret);
+	ok(rc != 0, "Position with invalid map key must not be unpacked");
+
+	position_pack(&pos, pos_buf);
+	mp_encode_map(pos_buf + 4, size);
+	rc = position_unpack(pos_buf, &ret);
+	ok(rc != 0, "Position with key that isn't array must not be unpacked");
+
+	footer();
+}
+
+int
+main(void)
+{
+	plan(9);
+	srand(time(NULL));
+	simple_check();
+	unpack_invalid_check();
+	check_plan();
+}

--- a/test/unit/position.result
+++ b/test/unit/position.result
@@ -1,0 +1,14 @@
+1..9
+	*** simple_check ***
+ok 1 - Position must be unpacked
+ok 2 - Keys must match
+ok 3 - Invalid position must not be unpacked
+ok 4 - Invalid position must not be unpacked
+	*** simple_check: done ***
+	*** unpack_invalid_check ***
+ok 5 - Empty position must not be packed
+ok 6 - Position which is not MP_BIN must not be unpacked
+ok 7 - Position which is not MP_MAP must not be unpacked
+ok 8 - Position with invalid map key must not be unpacked
+ok 9 - Position with key that isn't array must not be unpacked
+	*** unpack_invalid_check: done ***


### PR DESCRIPTION
This patchset adds helpers, needed for pagination, new options `after` and `fetch_pos` for select (select_ffi only, LuaC will be patched in vinyl pagination patchset), and pagination to memtx tree.