### PR TITLE
ci: make module.h generation command more specific

### DIFF
--- a/.github/workflows/publish-module-api-doc.yaml
+++ b/.github/workflows/publish-module-api-doc.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Build module API documentation using Doxygen
         run: |
             cmake .
-            make module_api
+            make api
             sed -e "s%@PROJECT_.\+_DIR@/%%" Doxyfile.API.in > Doxyfile.API
             doxygen Doxyfile.API
 


### PR DESCRIPTION
`make api` generates `src/module.h`. `make module_api` is the target for
compiling a library for testing of the module API:
`test/app-tap/module_api.so`. It depends on the `api` target.

Both works for generating `module.h`, but `make api` don't do extra
unneeded actions.