### PR TITLE
test: fix readline dependent tests

### DIFF
--- a/test/app-luatest/gh_5064_console_ignore_i_flag_without_tty_test.lua
+++ b/test/app-luatest/gh_5064_console_ignore_i_flag_without_tty_test.lua
@@ -11,7 +11,9 @@ tarantool> ]]
 local TARANTOOL_PATH = arg[-1]
 
 g.test_console_ignores_i_flag_without_tty = function()
-    local cmd = [[printf '42\n' | ]] .. TARANTOOL_PATH .. [[ -i 2>/dev/null]]
+    -- Suppress prompt changes by custom readline config to simplify assertions.
+    local cmd = [[printf '42\n' | ]] .. 'INPUTRC=non_existent_file ' ..
+                TARANTOOL_PATH .. [[ -i 2>/dev/null]]
     local fh = io.popen(cmd, 'r')
 
     -- Readline on CentOS 7 produces \e[?1034h escape sequence before tarantool> prompt, remove it.

--- a/test/app-tap/gh-2717-no-quit-sigint.test.lua
+++ b/test/app-tap/gh-2717-no-quit-sigint.test.lua
@@ -61,7 +61,7 @@ ph:close()
 --
 -- gh-7109: Ctrl+C does not break multiline input.
 --
-cmd = TARANTOOL_PATH .. ' -i 2>&1'
+local cmd = 'INPUTRC=non_existent_file ' .. TARANTOOL_PATH .. ' -i 2>&1'
 ph = popen.new({cmd}, {
     shell = true,
     setsid = true,

--- a/test/app-tap/gh-2717-no-quit-sigint.test.lua
+++ b/test/app-tap/gh-2717-no-quit-sigint.test.lua
@@ -19,7 +19,7 @@ local TARANTOOL_PATH = arg[-1]
 local test = tap.test('gh-2717-no-quit-sigint')
 
 test:plan(8)
-local cmd = 'INPUTRC=Pheiphe2 ' .. TARANTOOL_PATH .. ' -i 2>&1'
+local cmd = 'INPUTRC=non_existent_file ' .. TARANTOOL_PATH .. ' -i 2>&1'
 local ph = popen.new({cmd}, {
     shell = true,
     setsid = true,
@@ -214,7 +214,7 @@ os.remove(snap_file)
 --
 -- Testing case when the client and instance are called in the same console.
 --
-cmd = 'INPUTRC=Pheiphe2 ' .. TARANTOOL_PATH .. ' -i 2>&1'
+cmd = 'INPUTRC=non_existent_file ' .. TARANTOOL_PATH .. ' -i 2>&1'
 ph = popen.new({cmd}, {
     shell = true,
     setsid = true,


### PR DESCRIPTION
The tests fail on dev installation if it's readline configuration
(.inputrc) changes prompt. Use default readline configuration for
the tests.

Closes #7620

NO_DOC=test changes
NO_TEST=test changes
NO_CHANGELOG=test changes