### PR TITLE
 box: fix inheriting format options for old-style parts

### DIFF
--- a/changelogs/unreleased/gh-7614-fix-nullable-from-format.md
+++ b/changelogs/unreleased/gh-7614-fix-nullable-from-format.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed inheriting format options when specifying index parts with 1.6 style
+  (like {<field>, <type>, ...}) (gh-7614).

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -1033,7 +1033,7 @@ local function update_index_parts_1_6_0(parts)
             box.error(box.error.ILLEGAL_PARAMS,
                       "options.parts: expected field_no (number), type (string) pairs")
         end
-        table.insert(result, {field = parts[i] - 1, type = parts[i + 1]})
+        table.insert(result, {field = parts[i], type = parts[i + 1]})
         ::continue::
     end
     return result
@@ -1124,7 +1124,7 @@ local function update_index_parts(format, parts)
         if parts[3] == nil then
             parts = {parts} -- one part only
         else
-            return update_index_parts_1_6_0(parts), true
+            parts = update_index_parts_1_6_0(parts)
         end
     end
 

--- a/test/box-luatest/gh_7614_fix_nullable_from_format_test.lua
+++ b/test/box-luatest/gh_7614_fix_nullable_from_format_test.lua
@@ -1,0 +1,30 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all = function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end
+
+g.after_all = function(cg)
+    cg.server:stop()
+end
+
+g.test_1_6_style_parts_with_format = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+
+        box.schema.space.create('test')
+        box.space.test:format({
+            {name = 'id', type = 'number'},
+            {name = 'data', type = 'string', is_nullable = true},
+        })
+        box.space.test:create_index('primary')
+        box.space.test:create_index('sec1', {parts = {2, 'string'}})
+        t.assert(box.space.test.index.sec1.parts[1].is_nullable)
+        box.space.test:create_index('sec2',
+                                    {parts = {1, 'number', 2, 'string' }})
+        t.assert(box.space.test.index.sec2.parts[2].is_nullable)
+    end)
+end


### PR DESCRIPTION
If index parts are specified using old syntax like:

    parts = {1, 'number', 2, 'string'},

then (except if parts count is 1) index options set in space format
are not taken into account. Solution is to continue after parsing 1.6.0
style parts so to use code that check format options.

Closes #7614