### PR TITLE
Add tuple format to read view

### DIFF
--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -612,6 +612,7 @@ index_read_view_create(struct index_read_view *rv,
 	rv->def = index_def_dup(def);
 	if (rv->def == NULL)
 		return -1;
+	rv->space = NULL;
 	return 0;
 }
 

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -44,6 +44,7 @@ extern "C" {
 struct tuple;
 struct engine;
 struct space;
+struct space_read_view;
 struct index;
 struct index_read_view;
 struct index_read_view_iterator;
@@ -586,6 +587,8 @@ struct index_read_view {
 	const struct index_read_view_vtab *vtab;
 	/** Copy of the index definition. */
 	struct index_def *def;
+	/** Pointer to the space read view that owns this index. */
+	struct space_read_view *space;
 };
 
 /** Iterator over an index read view. */

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -590,6 +590,8 @@ struct index_read_view {
 
 /** Iterator over an index read view. */
 struct index_read_view_iterator {
+	/** Pointer to the index read view. */
+	struct index_read_view *index;
 	/** Free an index read view iterator instance. */
 	void
 	(*free)(struct index_read_view_iterator *iterator);

--- a/src/box/lua/misc.cc
+++ b/src/box/lua/misc.cc
@@ -313,9 +313,7 @@ lbox_tuple_format_new(struct lua_State *L)
 	region_truncate(region, region_svp);
 	if (dict == NULL)
 		return luaT_error(L);
-	struct tuple_format *format =
-		tuple_format_new(&tuple_format_runtime->vtab, NULL, NULL, 0,
-				 NULL, 0, 0, dict, false, true, NULL, 0);
+	struct tuple_format *format = runtime_tuple_format_new(dict);
 	/*
 	 * Since dictionary reference counter is 1 from the
 	 * beginning and after creation of the tuple_format

--- a/src/box/read_view.c
+++ b/src/box/read_view.c
@@ -49,8 +49,10 @@ space_read_view_delete(struct space_read_view *space_rv)
 {
 	for (uint32_t i = 0; i <= space_rv->index_id_max; i++) {
 		struct index_read_view *index_rv = space_rv->index_map[i];
-		if (index_rv != NULL)
+		if (index_rv != NULL) {
+			assert(index_rv->space == space_rv);
 			index_read_view_delete(index_rv);
+		}
 	}
 	TRASH(space_rv);
 	free(space_rv);
@@ -84,6 +86,7 @@ space_read_view_new(struct space *space, const struct read_view_opts *opts)
 		space_rv->index_map[i] = index_create_read_view(index);
 		if (space_rv->index_map[i] == NULL)
 			goto fail;
+		space_rv->index_map[i]->space = space_rv;
 	}
 	return space_rv;
 fail:

--- a/src/box/sequence.c
+++ b/src/box/sequence.c
@@ -312,8 +312,6 @@ struct sequence_data_read_view {
 struct sequence_data_iterator {
 	/** Base class. */
 	struct index_read_view_iterator base;
-	/** Read view. */
-	struct sequence_data_read_view *rv;
 	/** Iterator over the data index. */
 	struct light_sequence_iterator iter;
 };
@@ -325,9 +323,11 @@ sequence_data_iterator_next_raw(struct index_read_view_iterator *base,
 {
 	struct sequence_data_iterator *iter =
 		(struct sequence_data_iterator *)base;
+	struct sequence_data_read_view *rv =
+		(struct sequence_data_read_view *)base->index;
 
 	struct sequence_data *sd = light_sequence_view_iterator_get_and_next(
-		&iter->rv->view, &iter->iter);
+		&rv->view, &iter->iter);
 	if (sd == NULL) {
 		*data = NULL;
 		return 0;
@@ -386,9 +386,9 @@ sequence_data_iterator_create(struct index_read_view *base,
 	struct sequence_data_read_view *rv =
 		(struct sequence_data_read_view *)base;
 	struct sequence_data_iterator *iter = xmalloc(sizeof(*iter));
+	iter->base.index = base;
 	iter->base.next_raw = sequence_data_iterator_next_raw;
 	iter->base.free = sequence_data_iterator_free;
-	iter->rv = rv;
 	light_sequence_view_iterator_begin(&rv->view, &iter->iter);
 	return (struct index_read_view_iterator *)iter;
 }

--- a/src/box/tuple.c
+++ b/src/box/tuple.c
@@ -284,6 +284,17 @@ tuple_bigref_tuple_count()
 	return tuple_uploaded_refs->size;
 }
 
+struct tuple_format *
+runtime_tuple_format_new(struct tuple_dictionary *dict)
+{
+	return tuple_format_new(&tuple_format_runtime_vtab, /*engine=*/NULL,
+				/*keys=*/NULL, /*key_count=*/0,
+				/*space_field_count=*/NULL,
+				/*exact_field_count=*/0, 0, dict,
+				/*is_temporary=*/false, /*is_reusable=*/true,
+				/*contraint_def=*/NULL, /*constraint_count=*/0);
+}
+
 int
 tuple_init(field_name_hash_f hash)
 {
@@ -292,9 +303,7 @@ tuple_init(field_name_hash_f hash)
 	/*
 	 * Create a format for runtime tuples
 	 */
-	tuple_format_runtime =
-		simple_tuple_format_new(&tuple_format_runtime_vtab,
-					NULL, NULL, 0);
+	tuple_format_runtime = runtime_tuple_format_new(/*dict=*/NULL);
 	if (tuple_format_runtime == NULL)
 		return -1;
 

--- a/src/box/tuple.h
+++ b/src/box/tuple.h
@@ -75,6 +75,18 @@ tuple_arena_create(struct slab_arena *arena, struct quota *quota,
 void
 tuple_arena_destroy(struct slab_arena *arena);
 
+/**
+ * Creates a new format for standalone tuples.
+ *
+ * Tuples created with the new format are allocated from the runtime arena.
+ * In contrast to the preallocated tuple_format_runtime, which has no field
+ * names, the new format uses the provided field name dictionary.
+ *
+ * On success, returns the new format. On error, returns NULL and sets diag.
+ */
+struct tuple_format *
+runtime_tuple_format_new(struct tuple_dictionary *dict);
+
 /** \cond public */
 
 typedef struct tuple_format box_tuple_format_t;


### PR DESCRIPTION
To support accessing tuple fields by name from the read view Lua API (EE-only), we need to create a runtime tuple format for each space read view, using the space field names to initialize the field dictionary. This PR does the trick. To conveniently access the format from a read view iterator, it also adds back pointers to read view iterator and index read view objects. Since the feature isn't required for snapshot creation or joining a replica, we create tuple formats for space read views only if the corresponding flag was set at the time of read view creation, otherwise we just use the global name-less runtime format.

Needed for https://github.com/tarantool/tarantool-ee/issues/207

EE part: https://github.com/tarantool/tarantool-ee/pull/219