### PR TITLE
Generate changelog for 2.10.2

### DIFF
--- a/changelogs/2.10.2.md
+++ b/changelogs/2.10.2.md
@@ -1,0 +1,57 @@
+Date: 2022-09-01
+Tag: 2.10.2
+
+## Overview
+
+2.10.2 is the third [stable][release_policy] version of the 2.10 release
+series. It introduces 1 improvements and resolves 8 bugs since
+2.10.1.
+
+The "stable" label means that we have all planned features implemented and we
+see no high-impact issues. However, if you encounter an issue, feel free to
+[report it][issues] on GitHub.
+
+[release_policy]: https://www.tarantool.io/en/doc/latest/dev_guide/release_management/#release-policy
+[issues]: https://github.com/tarantool/tarantool/issues
+
+## Compatibility
+
+Tarantool 2.x is backward compatible with Tarantool 1.10.x in the binary data
+layout, client-server protocol, and replication protocol.
+
+Please [upgrade][upgrade] using the `box.schema.upgrade()` procedure to unlock
+all the new features of the 2.x series.
+
+[upgrade]: https://www.tarantool.io/en/doc/latest/book/admin/upgrades/
+
+## Functionality added or changed
+
+### Core
+
+* Certain internal fibers, such as the connection's worker fiber, vinyl fibers,
+  and some other fibers, cannot be cancelled from the Lua public API
+  anymore (gh-7473).
+
+## Bugs fixed
+
+### Core
+
+* Fixed a possible crash on concurrent `fiber_object:join()` (gh-7489).
+* Fixed a potential nil dereference and a crash in case of an active
+  log rotation during the program exit stage (gh-4450).
+* Fixed crashes and undefined behaviour of triggers clearing other triggers
+  (gh-4264).
+* Fixed a crash of secondary indexes without hints (gh-7605)
+
+### Replication
+
+* Fixed `box.info.replication[id].downstream.lag` growing indefinitely on a
+  server when it's not writing any new transactions (gh-7581).
+
+### Box
+
+* Fixed multiline commands being saved to `~/.tarantool_history` as
+  separate lines (gh-7320).
+* Fixed inheritance of field options in indexes when index parts are
+  specified the old Tarantool 1.6 style: `{<field>, <type>, ...}` (gh-7614).
+* Fixed unauthorized inserts into the `_truncate` space (ghs-5).

--- a/changelogs/unreleased/gh-4264-trigger-crash-on-nontrivial-change.md
+++ b/changelogs/unreleased/gh-4264-trigger-crash-on-nontrivial-change.md
@@ -1,4 +1,0 @@
-## bugfix/core
-
-* Fixed crashes and undefined behaviour of triggers clearing other triggers
-  (gh-4264).

--- a/changelogs/unreleased/gh-4450-logger-sigsegv.md
+++ b/changelogs/unreleased/gh-4450-logger-sigsegv.md
@@ -1,4 +1,0 @@
-## bugfix/core
-
-*  Fixed a potential nil dereference and a crash in case of an active
-   log rotation during the program exit stage (gh-4450).

--- a/changelogs/unreleased/gh-7320-restore-multiline-history.md
+++ b/changelogs/unreleased/gh-7320-restore-multiline-history.md
@@ -1,4 +1,0 @@
-## bugfix/box
-
-* Fixed multiline commands being saved to `~/.tarantool_history` as
-  separate lines (gh-7320).

--- a/changelogs/unreleased/gh-7473-system-fibers.md
+++ b/changelogs/unreleased/gh-7473-system-fibers.md
@@ -1,4 +1,0 @@
-## feature/core
-
-* Certain internal fibers, such as the connection's worker fiber, vinyl fibers,
-  and some other fibers, cannot be cancelled from the Lua public API anymore (gh-7473).

--- a/changelogs/unreleased/gh-7489-concurrent-fiber-join.md
+++ b/changelogs/unreleased/gh-7489-concurrent-fiber-join.md
@@ -1,3 +1,0 @@
-## bugfix/core
-
-* Fixed a possible crash on concurrent `fiber_object:join()` (gh-7489).

--- a/changelogs/unreleased/gh-7581-downstream-lag-calculation-fix.md
+++ b/changelogs/unreleased/gh-7581-downstream-lag-calculation-fix.md
@@ -1,4 +1,0 @@
-## bugfix/replication
-
-* Fixed `box.info.replication[id].downstream.lag` growing indefinitely on a
-  server when it's not writing any new transactions (gh-7581).

--- a/changelogs/unreleased/gh-7605-fix-qsort.md
+++ b/changelogs/unreleased/gh-7605-fix-qsort.md
@@ -1,3 +1,0 @@
-## bugfix/core
-
-* Fixed a crash of secondary indexes without hints (gh-7605)

--- a/changelogs/unreleased/gh-7614-fix-nullable-from-format.md
+++ b/changelogs/unreleased/gh-7614-fix-nullable-from-format.md
@@ -1,4 +1,0 @@
-## bugfix/box
-
-* Fixed inheritance of field options in indexes when index parts are
-  specified the old Tarantool 1.6 style: `{<field>, <type>, ...}` (gh-7614).

--- a/changelogs/unreleased/ghs-5-fix-auth-check-on-truncate.md
+++ b/changelogs/unreleased/ghs-5-fix-auth-check-on-truncate.md
@@ -1,3 +1,0 @@
-## bugfix/box
-
-* Fixed unauthorized inserts into the `_truncate` space (ghs-5).


### PR DESCRIPTION
Generate changelog for 2.10.2 release.
Also, clean changelogs/unreleased folder.

NO_DOC=no code changes
NO_TEST=no code changes
NO_CHANGELOG=no code changes