### PR TITLE
Memtx tree pagination

### DIFF
--- a/extra/exports
+++ b/extra/exports
@@ -66,6 +66,7 @@ box_index_len
 box_index_max
 box_index_min
 box_index_random
+box_index_tuple_position
 box_insert
 box_iterator_free
 box_iterator_next
@@ -86,6 +87,7 @@ box_latch_new
 box_latch_trylock
 box_latch_unlock
 box_on_shutdown
+box_read_ffi_disable
 box_read_ffi_is_disabled
 box_region_aligned_alloc
 box_region_alloc

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -332,12 +332,22 @@ box_promote_qsync(void);
 int
 box_wait_linearization_point(double timeout);
 
-/* box_select is private and used only by FFI */
-API_EXPORT int
+/**
+ * Select data, satisfying filters (key and iterator), and dump it to port.
+ * If packed_pos is not NULL and *packed_pos is not NULL, selection begins
+ * right after tuple with position, described by this argument.
+ * If update_pos is true, packed_pos and packed_pos_end are updated to
+ * position of last selected tuple. Returned position is allocated
+ * on the fiber region.
+ * Pre-requesites: if update_pos is true, packed_pos and packed_pos_end must
+ * not be NULL.
+ */
+int
 box_select(uint32_t space_id, uint32_t index_id,
 	   int iterator, uint32_t offset, uint32_t limit,
 	   const char *key, const char *key_end,
-	   struct port *port);
+	   const char **packed_pos, const char **packed_pos_end,
+	   bool update_pos, struct port *port);
 
 /** \cond public */
 

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -299,6 +299,7 @@ struct errcode_record {
 	/*244 */_(ER_SPLIT_BRAIN,		"Split-Brain discovered: %s") \
 	/*245 */_(ER_OLD_TERM,			"The term is outdated: old - %llu, new - %llu") \
 	/*246 */_(ER_INTERFERING_ELECTIONS,	"Interfering elections started")\
+	/*247 */_(ER_ITERATOR_POSITION,		"Iterator position is invalid") \
 
 /*
  * !IMPORTANT! Please follow instructions at start of the file

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -559,6 +559,20 @@ iterator_next_internal(struct iterator *it, struct tuple **ret)
 	return it->next_internal(it, ret);
 }
 
+int
+iterator_position(struct iterator *it, const char **pos, uint32_t *size)
+{
+	assert(it->position != NULL);
+	assert(pos != NULL);
+	assert(size != NULL);
+	if (!iterator_is_valid(it)) {
+		*pos = NULL;
+		*size = 0;
+		return 0;
+	}
+	return it->position(it, pos, size);
+}
+
 void
 iterator_delete(struct iterator *it)
 {
@@ -770,9 +784,13 @@ generic_index_replace(struct index *index, struct tuple *old_tuple,
 
 struct iterator *
 generic_index_create_iterator(struct index *base, enum iterator_type type,
-			      const char *key, uint32_t part_count)
+			      const char *key, uint32_t part_count,
+			      const char *pos)
 {
-	(void) type; (void) key; (void) part_count;
+	(void)type;
+	(void)key;
+	(void)part_count;
+	(void)pos;
 	diag_set(UnsupportedIndexFeature, base->def, "read view");
 	return NULL;
 }
@@ -870,6 +888,17 @@ exhausted_index_read_view_iterator_next_raw(struct index_read_view_iterator *it,
 	*data = NULL;
 	*size = 0;
 	return 0;
+}
+
+int
+generic_iterator_position(struct iterator *it, const char **pos,
+			  uint32_t *size)
+{
+	(void)it;
+	(void)pos;
+	(void)size;
+	diag_set(UnsupportedIndexFeature, it->index->def, "pagination");
+	return -1;
 }
 
 /* }}} */

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -253,6 +253,16 @@ box_tuple_extract_key(box_tuple_t *tuple, uint32_t space_id,
 /** \endcond public */
 
 /**
+ * Get packed position of tuple in index to pass it to box_select
+ * (multikey and func indexes are not supported). Returned position
+ * is allocated on the fiber region.
+ */
+int
+box_index_tuple_position(uint32_t space_id, uint32_t index_id,
+			 const char *tuple, const char *tuple_end,
+			 const char **packed_pos, const char **packed_pos_end);
+
+/**
  * Index statistics (index:stat())
  *
  * \param space_id space identifier
@@ -444,6 +454,16 @@ key_validate(const struct index_def *index_def, enum iterator_type type,
 int
 exact_key_validate(struct key_def *key_def, const char *key,
 		   uint32_t part_count);
+
+/**
+ * Check that the supplied key is valid for representing iterator
+ * position (i.e. the key must be fully specified, but nulls are allowed).
+ * @retval 0  The key is valid.
+ * @retval -1 The key is invalid.
+ */
+int
+exact_key_validate_nullable(struct key_def *key_def, const char *key,
+			    uint32_t part_count);
 
 /**
  * The manner in which replace in a unique index must treat

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -2088,7 +2088,7 @@ tx_process_select(struct cmsg *m)
 	tx_inject_delay();
 	rc = box_select(req->space_id, req->index_id,
 			req->iterator, req->offset, req->limit,
-			req->key, req->key_end, &port);
+			req->key, req->key_end, NULL, NULL, false, &port);
 	if (rc < 0)
 		goto error;
 

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -107,7 +107,7 @@ enum memtx_reserve_extents_num {
  * allocated for each iterator (except rtree index iterator that
  * is significantly bigger so has own pool).
  */
-#define MEMTX_ITERATOR_SIZE (160)
+#define MEMTX_ITERATOR_SIZE (168)
 
 struct memtx_engine {
 	struct engine base;

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -1427,7 +1427,8 @@ end:
 template <bool USE_HINT>
 static struct iterator *
 memtx_tree_index_create_iterator(struct index *base, enum iterator_type type,
-				 const char *key, uint32_t part_count)
+				 const char *key, uint32_t part_count,
+				 const char *pos)
 {
 	struct memtx_tree_index<USE_HINT> *index =
 		(struct memtx_tree_index<USE_HINT> *)base;
@@ -1438,6 +1439,10 @@ memtx_tree_index_create_iterator(struct index *base, enum iterator_type type,
 	if (type > ITER_GT) {
 		diag_set(UnsupportedIndexFeature, base->def,
 			 "requested iterator type");
+		return NULL;
+	}
+	if (pos != NULL) {
+		diag_set(UnsupportedIndexFeature, base->def, "pagination");
 		return NULL;
 	}
 
@@ -1464,6 +1469,7 @@ memtx_tree_index_create_iterator(struct index *base, enum iterator_type type,
 	it->pool = &memtx->iterator_pool;
 	it->base.next_internal = tree_iterator_start<USE_HINT>;
 	it->base.next = memtx_iterator_next;
+	it->base.position = generic_iterator_position;
 	it->base.free = tree_iterator_free<USE_HINT>;
 	it->type = type;
 	it->key_data.key = key;

--- a/src/box/session_settings.c
+++ b/src/box/session_settings.c
@@ -187,13 +187,19 @@ session_settings_index_destroy(struct index *index)
 	free(index);
 }
 
+/** Implementation of create_iterator for session_settings. */
 static struct iterator *
 session_settings_index_create_iterator(struct index *base,
-				       enum iterator_type type, const char *key,
-				       uint32_t part_count)
+				       enum iterator_type type,
+				       const char *key, uint32_t part_count,
+				       const char *pos)
 {
 	struct session_settings_index *index =
 		(struct session_settings_index *)base;
+	if (pos != NULL) {
+		diag_set(UnsupportedIndexFeature, base->def, "pagination");
+		return NULL;
+	}
 	char *decoded_key = NULL;
 	if (part_count > 0) {
 		assert(part_count == 1);
@@ -216,6 +222,7 @@ session_settings_index_create_iterator(struct index *base,
 		return NULL;
 	}
 	iterator_create(&it->base, base);
+	it->base.position = generic_iterator_position;
 	it->base.free = session_settings_iterator_free;
 	it->key = decoded_key;
 	it->is_eq = type == ITER_EQ || type == ITER_REQ;

--- a/src/box/sysview.c
+++ b/src/box/sysview.c
@@ -110,7 +110,8 @@ sysview_index_destroy(struct index *index)
 
 static struct iterator *
 sysview_index_create_iterator(struct index *base, enum iterator_type type,
-			      const char *key, uint32_t part_count)
+			      const char *key, uint32_t part_count,
+			      const char *pos)
 {
 	struct sysview_index *index = (struct sysview_index *)base;
 	struct sysview_engine *sysview = (struct sysview_engine *)base->engine;
@@ -140,7 +141,8 @@ sysview_index_create_iterator(struct index *base, enum iterator_type type,
 	it->base.next = sysview_iterator_next;
 	it->base.free = sysview_iterator_free;
 
-	it->source = index_create_iterator(pk, type, key, part_count);
+	it->source = index_create_iterator_after(pk, type, key, part_count,
+						 pos);
 	if (it->source == NULL) {
 		mempool_free(&sysview->iterator_pool, it);
 		return NULL;

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -3709,7 +3709,8 @@ vinyl_iterator_free(struct iterator *base)
 
 static struct iterator *
 vinyl_index_create_iterator(struct index *base, enum iterator_type type,
-			    const char *key, uint32_t part_count)
+			    const char *key, uint32_t part_count,
+			    const char *pos)
 {
 	struct vy_lsm *lsm = vy_lsm(base);
 	struct vy_env *env = vy_env(base->engine);
@@ -3717,6 +3718,10 @@ vinyl_index_create_iterator(struct index *base, enum iterator_type type,
 	if (type > ITER_GT) {
 		diag_set(UnsupportedIndexFeature, base->def,
 			 "requested iterator type");
+		return NULL;
+	}
+	if (pos != NULL) {
+		diag_set(UnsupportedIndexFeature, base->def, "pagination");
 		return NULL;
 	}
 
@@ -3744,6 +3749,7 @@ vinyl_index_create_iterator(struct index *base, enum iterator_type type,
 		it->base.next = vinyl_iterator_primary_next;
 	else
 		it->base.next = vinyl_iterator_secondary_next;
+	it->base.position = generic_iterator_position;
 	it->base.free = vinyl_iterator_free;
 	it->pool = &env->iterator_pool;
 

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -465,6 +465,7 @@ t;
  |   244: box.error.SPLIT_BRAIN
  |   245: box.error.OLD_TERM
  |   246: box.error.INTERFERING_ELECTIONS
+ |   247: box.error.ITERATOR_POSITION
  | ...
 
 test_run:cmd("setopt delimiter ''");

--- a/test/engine-luatest/pagination_test.lua
+++ b/test/engine-luatest/pagination_test.lua
@@ -1,0 +1,813 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local tree_g = t.group('Tree index tests',
+    t.helpers.matrix{engine={'memtx'}, disable_ffi={true, false}})
+
+-- TODO(gh-7739): Enable Lua JIT on aarch64.
+local function start_server(server)
+    server:start()
+    server:exec(function()
+        local jit = require('jit')
+        local tarantool = require('tarantool')
+        if string.find(tarantool.build.target, '-aarch64-') then
+            jit.off()
+        end
+    end)
+end
+
+tree_g.before_all(function(cg)
+    cg.server = server:new{
+        alias   = 'default',
+    }
+    start_server(cg.server)
+    cg.server:exec(function(disable_ffi)
+        local ffi = require('ffi')
+        ffi.cdef("extern void box_read_ffi_disable(void);")
+        if disable_ffi then
+            ffi.C.box_read_ffi_disable()
+        end
+    end, {cg.params.disable_ffi})
+
+end)
+
+tree_g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+tree_g.before_each(function(cg)
+    cg.server:exec(function(engine)
+        box.schema.space.create('s', {engine = engine})
+    end, {cg.params.engine})
+end)
+
+tree_g.after_each(function(cg)
+    cg.server:exec(function()
+        box.space.s:drop()
+    end)
+end)
+
+tree_g.test_tree_pagination = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.s
+        s:create_index("pk", {type = "tree"})
+        s:create_index("sk", {parts = {2}, type = "tree", unique=false})
+        s:create_index("sk2", {parts = {3}, type = "tree", unique=false})
+        s:create_index("sk_unique", {parts = {4}, type = "tree", unique=true})
+
+        -- Fetch position in empty space
+        local indexes = {s.index.pk, s.index.sk, s.index.sk2, s.index.sk_unique}
+        for _, index in pairs(indexes) do
+            local tuples, pos = index:select(nil,
+                    {limit=2, fullscan=true, fetch_pos=true})
+            t.assert_equals(tuples, {})
+            t.assert(pos == nil)
+        end
+
+        for i = 1, 11 do
+            s:replace{i, 1, i, i}
+        end
+
+        local tuples1
+        local tuples2
+        local tuples_offset
+        local pos
+        local last_tuple
+        local test_indexes = {s.index.pk, s.index.sk2, s.index.sk_unique}
+
+        -- Test fullscan pagination
+        for _, index in pairs(test_indexes) do
+            pos = ""
+            last_tuple = box.NULL
+            for i = 0, 5 do
+                tuples1, pos = index:select(nil,
+                        {limit=2, fullscan=true, fetch_pos=true, after=pos})
+                tuples2 = index:select(nil,
+                        {limit=2, fullscan=true, after=last_tuple})
+                last_tuple = tuples2[#tuples2]
+                tuples_offset = index:select(nil,
+                        {limit=2, fullscan=true, offset=i*2})
+                t.assert_equals(tuples1, tuples_offset)
+                t.assert_equals(tuples2, tuples_offset)
+            end
+            tuples1, pos = index:select(nil,
+                    {limit=2, fullscan=true, fetch_pos=true, after=pos})
+            t.assert_equals(tuples1, {})
+            t.assert(pos == nil)
+        end
+
+        -- Test pagination on range iterators
+        local key_iter = {
+            ['GE'] = 3,
+            ['GT'] = 2,
+            ['LE'] = 9,
+            ['LT'] = 10,
+        }
+        for _, index in pairs(test_indexes) do
+            for iter, key in pairs(key_iter) do
+                pos = ""
+                last_tuple = box.NULL
+                for i = 0, 4 do
+                    tuples1, pos = index:select(key,
+                            {limit=2, iterator=iter, fetch_pos=true, after=pos})
+                    tuples2 = index:select(key,
+                            {limit=2, iterator=iter, after=last_tuple})
+                    last_tuple = tuples2[#tuples2]
+                    tuples_offset = index:select(key,
+                            {limit=2, iterator=iter, offset=i*2})
+                    t.assert_equals(tuples1, tuples_offset)
+                    t.assert_equals(tuples2, tuples_offset)
+                end
+                tuples1, pos = index:select(key,
+                        {limit=2, iterator=iter, fetch_pos=true, after=pos})
+                t.assert_equals(tuples1, {})
+                t.assert(pos == nil)
+            end
+        end
+
+        -- Test pagination on equality iterators
+        s:replace{0, 0, 0, 0}
+        s:replace{12, 2, 12, 12}
+        for _, iter in pairs({'EQ', 'REQ'}) do
+            pos = ""
+            last_tuple = box.NULL
+            for i = 0, 5 do
+                tuples1, pos = s.index.sk:select(1,
+                        {limit=2, iterator=iter, fetch_pos=true, after=pos})
+                tuples2 = s.index.sk:select(1,
+                        {limit=2, iterator=iter, after=last_tuple})
+                last_tuple = tuples2[#tuples2]
+                tuples_offset = s.index.sk:select(1,
+                        {limit=2, iterator=iter, offset=i*2})
+                t.assert_equals(tuples1, tuples_offset)
+                t.assert_equals(tuples2, tuples_offset)
+            end
+            tuples1, pos = s.index.sk:select(1,
+                    {iterator=iter, limit=2, fetch_pos=true, after=pos})
+            t.assert_equals(tuples1, {})
+            t.assert(pos == nil)
+        end
+    end)
+end
+
+tree_g.test_tree_multikey_pagination = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.s
+        s:create_index("pk", {type = "tree"})
+        local sk = s:create_index("sk",
+                {parts = {{field = 2, type = 'uint', path = '[*]'}},
+                 type = "tree", unique=false})
+
+        -- Fetch position in empty space
+        local tuples, pos = sk:select(nil,
+                {limit=2, fullscan=true, fetch_pos=true})
+        t.assert_equals(tuples, {})
+        t.assert(pos == nil)
+
+        for i = 1, 3 do
+            s:replace{i, {1, 2, 3}}
+        end
+
+        local tuples
+        local tuples_offset
+        local pos = ""
+
+        -- Test fullscan pagination
+        for i = 0, 4 do
+            tuples, pos = sk:select(nil,
+                    {limit=2, fullscan=true, fetch_pos=true, after=pos})
+            tuples_offset = sk:select(nil,
+                    {limit=2, fullscan=true, offset=i*2})
+            t.assert_equals(tuples, tuples_offset)
+        end
+        tuples, pos = sk:select(nil,
+                {limit=2, fullscan=true, fetch_pos=true, after=pos})
+        t.assert_equals(tuples, {})
+        t.assert(pos == nil)
+
+        -- Test pagination on range iterators
+        local key_iter = {
+            ['GE'] = 2,
+            ['GT'] = 1,
+            ['LE'] = 2,
+            ['LT'] = 3,
+        }
+        for iter, key in pairs(key_iter) do
+            pos = ""
+            for i = 0, 2 do
+                tuples, pos = sk:select(key,
+                        {limit=2, iterator=iter, fetch_pos=true, after=pos})
+                tuples_offset = sk:select(key,
+                        {limit=2, iterator=iter, offset=i*2})
+                t.assert_equals(tuples, tuples_offset)
+            end
+            tuples, pos = sk:select(key,
+                    {limit=2, iterator=iter, fetch_pos=true, after=pos})
+            t.assert_equals(tuples, {})
+            t.assert(pos == nil)
+        end
+
+        -- Test pagination on equality iterators
+        for _, iter in pairs({'EQ', 'REQ'}) do
+            pos = ""
+            for i = 0, 1 do
+                tuples, pos = sk:select(2,
+                        {limit=2, iterator=iter, fetch_pos=true, after=pos})
+                tuples_offset = sk:select(2,
+                        {limit=2, iterator=iter, offset=i*2})
+                t.assert_equals(tuples, tuples_offset)
+            end
+            tuples, pos = sk:select(2,
+                    {iterator=iter, limit=2, fetch_pos=true, after=pos})
+            t.assert_equals(tuples, {})
+            t.assert(pos == nil)
+        end
+
+        -- Test that after with tuple in multikey index returns an error
+        local tuple = s.index.pk:get(1)
+        t.assert_error_msg_contains(
+                "Multikey index does not support position by tuple",
+                sk.select, sk, nil, {fullscan=true, after=tuple})
+    end)
+end
+
+tree_g.test_nullable_indexes = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.s
+        s:create_index("pk", {type = "tree"})
+        s:create_index("sk1",
+           {parts = {{field = 2, type = "uint", is_nullable=true}},
+            type = "tree", unique=false})
+        s:create_index("sk2",
+            {parts = {{field = 3, type = "uint", is_nullable=true}},
+            type = "tree", unique=true})
+        s:create_index("sk3",
+            {parts = {{field = 4, type = "uint", exclude_null=true}},
+            type = "tree", unique=false})
+        s:create_index("sk4",
+            {parts = {{field = 5, type = "uint", exclude_null=true}},
+            type = "tree", unique=true})
+
+        -- Fetch position in empty space
+        local indexes = {s.index.sk1, s.index.sk2, s.index.sk3, s.index.sk4}
+        for _, index in pairs(indexes) do
+            local tuples, pos = index:select(nil,
+                    {limit=2, fullscan=true, fetch_pos=true})
+            t.assert_equals(tuples, {})
+            t.assert(pos == nil)
+        end
+
+        for i = 1, 13 do
+            if i % 3 == 0 then
+                s:replace{i}
+            else
+                s:replace{i, i, i, i, i}
+            end
+        end
+
+        local tuples1
+        local tuples2
+        local tuples_offset
+        local pos
+        local last_tuple
+
+        local test_indexes = {s.index.sk1, s.index.sk2}
+
+        for _, index in pairs(test_indexes) do
+            pos = ""
+            last_tuple = box.NULL
+            for i = 0, 6 do
+                tuples1, pos = index:select(nil,
+                        {limit=2, fullscan=true, fetch_pos=true, after=pos})
+                tuples2 = index:select(nil,
+                        {limit=2, fullscan=true, after=last_tuple})
+                last_tuple = tuples2[#tuples2]
+                tuples_offset = index:select(nil,
+                        {limit=2, fullscan=true, offset=i*2})
+                t.assert_equals(tuples1, tuples_offset)
+                t.assert_equals(tuples2, tuples_offset)
+            end
+            tuples1, pos = index:select(nil,
+                    {limit=2, fullscan=true, fetch_pos=true, after=pos})
+            t.assert_equals(tuples1, {})
+            t.assert(pos == nil)
+        end
+
+        test_indexes = {s.index.sk3, s.index.sk4}
+        for _, index in pairs(test_indexes) do
+            pos = ""
+            last_tuple = box.NULL
+            for i = 0, 4 do
+                tuples1, pos = index:select(nil,
+                        {limit=2, fullscan=true, fetch_pos=true, after=pos})
+                tuples2 = index:select(nil,
+                        {limit=2, fullscan=true, after=last_tuple})
+                last_tuple = tuples2[#tuples2]
+                tuples_offset = index:select(nil,
+                        {limit=2, fullscan=true, offset=i*2})
+                t.assert_equals(tuples1, tuples_offset)
+                t.assert_equals(tuples2, tuples_offset)
+            end
+            tuples1, pos = index:select(nil,
+                    {limit=2, fullscan=true, fetch_pos=true, after=pos})
+            t.assert_equals(tuples1, {})
+            t.assert(pos == nil)
+        end
+    end)
+end
+
+-- Check if nil is returned if no tuples were selected.
+tree_g.test_no_tuples_satisfying_filters = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.s
+        s:create_index("pk", {type = "tree"})
+        s:create_index("sk",
+                {parts =
+                 {{field = 2, type = 'uint', path = '[*]'}},
+                 type = "tree",
+                 unique=false})
+
+        local tuples
+        local pos
+
+        s:replace{1, {1, 2}}
+
+        tuples, pos = s:select(3, {limit=1, iterator='GE', fetch_pos=true})
+        t.assert_equals(tuples, {})
+        t.assert(pos == nil)
+        s:replace{2, {1, 2}}
+        s:replace{3, {1, 2}}
+        s:replace{4, {1, 2}}
+        tuples = s:select(3, {limit=1, iterator='GE', after=pos})
+        t.assert_equals(tuples[1], {3, {1, 2}})
+
+        tuples, pos = s.index.sk:select(4,
+                {limit=1, iterator='GE', fetch_pos=true})
+        t.assert_equals(tuples, {})
+        t.assert(pos == nil)
+    end)
+end
+
+tree_g.test_invalid_positions = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.s
+        s:create_index('pk', {type = 'tree'})
+        s:create_index('sk', {
+                parts = {{field = 2, type = 'string'}},
+                type = 'tree', unique=true})
+        s:replace{1, 'Zero'}
+
+        local tuples
+        local pos = {1, 2}
+        local flag, err = pcall(function()
+            s:select(1, {limit=1, iterator='GE', after=pos})
+        end)
+        t.assert_equals(flag, false)
+        t.assert_equals(err.code, box.error.FIELD_TYPE)
+
+        pos = "abcd"
+        flag, err = pcall(function()
+            s:select(1, {limit=1, iterator='GE', after=pos})
+        end)
+        t.assert_equals(flag, false)
+        t.assert_equals(err.code, box.error.ITERATOR_POSITION)
+
+        tuples, pos = s:select(nil, {fullscan=true, limit=1, fetch_pos=true})
+        t.assert_equals(#tuples, 1)
+        t.assert(#pos > 0)
+        flag, err = pcall(function()
+            s.index.sk:select(nil, {fullscan=true, limit=1, after=pos})
+        end)
+        t.assert_equals(flag, false)
+        t.assert_equals(err.code, box.error.EXACT_MATCH)
+    end)
+end
+
+tree_g.test_tree_pagination_no_duplicates = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.s
+        s:create_index("pk", {type = "tree"})
+
+        for i = 1, 4 do
+            s:replace{i}
+        end
+        for i = 6, 10 do
+            s:replace{i}
+        end
+
+        local tuples, pos = s:select(1,
+                {iterator='GE', fetch_pos=true, limit=5})
+        t.assert_equals(#tuples, 5)
+        s:replace{5}
+        tuples = s:select(1, {iterator='GE', after=pos})
+        t.assert_equals(#tuples, 4)
+        t.assert_equals(tuples, s:select(7, {iterator='GE'}))
+
+        tuples, pos = s:select(1, {iterator='GE', fetch_pos=true})
+        t.assert_equals(#tuples, 10)
+        s:delete(10)
+        local last_pos = pos
+        tuples, pos = s:select(1, {iterator='GE', fetch_pos=true, after=pos})
+        t.assert_equals(tuples, {})
+        t.assert(pos == nil)
+        s:replace{10}
+        s:replace{11}
+        pos = last_pos
+        tuples = s:select(1, {iterator='GE', after=pos})
+        t.assert_equals(#tuples, 1)
+        t.assert_equals(tuples[1], {11})
+    end)
+end
+
+tree_g.test_tuple_pos_simple = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.s
+        s:create_index("pk", {type = "tree"})
+        s:create_index("sk", {
+                parts = {{field = 2, type = 'uint', path = '[*]'}},
+                type = "tree", unique=false})
+
+        local tuples
+        local pos = ""
+        local last_pos
+
+        for i = 1, 10 do
+            s:replace{i, {1, 2}}
+        end
+
+        for i = 0, 4 do
+            tuples, last_pos = s:select(nil,
+                    {limit=2, fullscan=true, fetch_pos=true, after=pos})
+            t.assert_equals(tuples[1][1], i * 2 + 1)
+            t.assert_equals(tuples[2][1], i * 2 + 2)
+            t.assert_equals(tuples[3], nil)
+            pos = s.index.pk:tuple_pos(tuples[2])
+            t.assert(pos == last_pos)
+        end
+        tuples, pos = s:select(nil,
+                {limit=2, fullscan=true, fetch_pos=true, after=pos})
+        t.assert_equals(tuples, {})
+        t.assert(pos == nil)
+
+        tuples = s:select(1)
+        t.assert_error_msg_contains(
+                "Multikey index does not support position by tuple",
+                s.index.sk.tuple_pos, s.index.sk, tuples[1])
+    end)
+end
+
+tree_g.test_tuple_pos_corner_cases = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.s
+        s:create_index("pk", {type = "tree"})
+        local sk1 = s:create_index("sk1", {parts = {{field = 2, type = 'uint'}},
+                                           type = "tree", unique=true})
+        local sk2 = s:create_index("sk2", {parts = {{field = 3, type = 'uint'}},
+                                           type = "tree", unique=false})
+        for i = 0, 9 do
+            s:replace{i, i, math.floor(i / 2)}
+        end
+
+        local pos
+        local tuple
+        local tuples1
+        local tuples2
+        for i = 0, 4 do
+            tuple = {i * 2, i * 2, i}
+            pos = sk1:tuple_pos(tuple)
+            tuples1 = sk1:select(nil, {after=pos})
+            pos = sk2:tuple_pos(tuple)
+            tuples2 = sk2:select(nil, {after=pos})
+            t.assert_equals(tuples1, tuples2)
+        end
+    end)
+end
+
+tree_g.test_tuple_pos_invalid_tuple = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.s
+        s:create_index("pk", {type = "tree", parts={{field=1, type='uint'}}})
+
+        local tuples
+        local pos
+
+        for i = 1, 10 do
+            s:replace{i, 0}
+        end
+
+        t.assert_error_msg_contains("Usage index:tuple_pos(tuple)",
+                s.index.pk.tuple_pos, s.index.pk)
+        pos = s.index.pk:tuple_pos({1, 0})
+        tuples = s:select(nil, {fullscan=true, after=pos, limit=1})
+        t.assert_equals(tuples[1], {2, 0})
+        -- test with invalid tuple
+        t.assert_error_msg_contains(
+                "Tuple field 1 type does not match one required by operation",
+                s.index.pk.tuple_pos, s.index.pk, {'a'})
+    end)
+end
+
+tree_g.test_runtime_memory_leak = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        fiber.set_max_slice(fiber.self(), 8)
+        local t = require('luatest')
+        local s = box.space.s
+        local pk = s:create_index("pk")
+        local tuple = s:replace{0, 0}
+        local runtime_used = box.runtime.info().used
+        local delta = 100
+
+        for _ = 1, 1e4 do
+            pk:tuple_pos({0, 0})
+            pk:tuple_pos(tuple)
+        end
+        t.assert_le(box.runtime.info().used, runtime_used + delta)
+
+        local pos = pk:tuple_pos({0, 0})
+        for _ = 1, 1e3 do
+            s:select(0, {after={0, 0}})
+            s:select(0, {after=tuple})
+            s:select(0, {after=pos})
+        end
+        t.assert_le(box.runtime.info().used, runtime_used + delta)
+    end)
+end
+
+-- Tests for memtx tree features, such as functional index
+local func_g = t.group('Memtx tree func index tests')
+
+func_g.before_all(function()
+    func_g.server = server:new{
+        alias   = 'default',
+    }
+    start_server(func_g.server)
+end)
+
+func_g.after_all(function()
+    func_g.server:drop()
+end)
+
+func_g.before_each(function()
+    func_g.server:exec(function()
+        box.schema.space.create('s', {engine = 'memtx'})
+    end)
+end)
+
+func_g.after_each(function()
+    func_g.server:exec(function()
+        box.space.s:drop()
+        box.schema.func.drop('func')
+    end)
+end)
+
+func_g.test_func_index_pagination = function()
+    func_g.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.s
+        s:create_index('pk',{parts={{field = 1, type = 'uint'}}})
+        local lua_code = [[function(tuple) return {tuple[2]} end]]
+        box.schema.func.create('func',
+                {body = lua_code,
+                 is_deterministic = true,
+                 is_sandboxed = true})
+        local sk = s:create_index('func', {
+                unique = false, func = 'func',
+                parts = {{field = 1, type = 'uint'}}})
+
+        -- Fetch position in empty space
+        local tuples, pos = sk:select(nil,
+                {limit=2, fullscan=true, fetch_pos=true})
+        t.assert_equals(tuples, {})
+        t.assert(pos == nil)
+
+        for i = 1, 6 do
+            s:replace{i, i}
+        end
+        for i = 7, 10 do
+            s:replace{i, 6}
+        end
+        s:replace{11, 7}
+
+        local tuples_offset
+
+        -- Test fullscan pagination
+        for i = 0, 5 do
+            tuples, pos = sk:select(nil,
+                    {limit=2, fullscan=true, fetch_pos=true, after=pos})
+            tuples_offset = sk:select(nil,
+                    {limit=2, fullscan=true, offset=i*2})
+            t.assert_equals(tuples, tuples_offset)
+        end
+        tuples, pos = sk:select(nil,
+                {limit=2, fullscan=true, fetch_pos=true, after=pos})
+        t.assert_equals(tuples, {})
+        t.assert(pos == nil)
+
+        -- Test pagination on range iterators
+        local key_iter = {
+            ['GE'] = 6,
+            ['GT'] = 5,
+            ['LE'] = 5,
+            ['LT'] = 6,
+        }
+        for iter, key in pairs(key_iter) do
+            pos = ""
+            for i = 0, 2 do
+                tuples, pos = sk:select(key,
+                        {limit=2, iterator=iter, fetch_pos=true, after=pos})
+                tuples_offset = sk:select(key,
+                        {limit=2, iterator=iter, offset=i*2})
+                t.assert_equals(tuples, tuples_offset)
+            end
+            tuples, pos = sk:select(key,
+                    {limit=2, iterator=iter, fetch_pos=true, after=pos})
+            t.assert_equals(tuples, {})
+            t.assert(pos == nil)
+        end
+
+        -- Test pagination on equality iterators
+        for _, iter in pairs({'EQ', 'REQ'}) do
+            pos = ""
+            for i = 0, 2 do
+                tuples, pos = sk:select(6,
+                        {limit=2, iterator=iter, fetch_pos=true, after=pos})
+                tuples_offset = sk:select(6,
+                        {limit=2, iterator=iter, offset=i*2})
+                t.assert_equals(tuples, tuples_offset)
+            end
+            tuples, pos = sk:select(6,
+                    {iterator=iter, limit=2, fetch_pos=true, after=pos})
+            t.assert_equals(tuples, {})
+            t.assert(pos == nil)
+        end
+        --[[ Test that after with tuple and tuple_pos in
+             functional index returns an error ]]--
+        local tuple = s.index.pk:get(1)
+        t.assert_error_msg_contains(
+                "Functional index does not support position by tuple",
+                sk.select, sk, nil, {fullscan=true, after=tuple})
+        t.assert_error_msg_contains(
+                "Functional index does not support position by tuple",
+                sk.tuple_pos, sk, tuple)
+    end)
+end
+
+func_g.test_func_multikey_index_pagination = function()
+    func_g.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.s
+        s:create_index('pk', {parts = {{field = 1, type = 'uint'}}})
+        local lua_code = [[function(tuple)
+               local ret = {}
+               for i = tuple[2], tuple[2] + 2 do
+                 table.insert(ret, {i})
+               end
+               return ret
+             end]]
+        box.schema.func.create('func',
+                {body = lua_code,
+                 is_deterministic = true,
+                 is_sandboxed = true,
+                 is_multikey = true})
+        local sk = s:create_index('sk', {
+                unique = false, func = 'func',
+                parts = {{field = 1, type = 'uint'}}})
+
+        -- Fetch position in empty space
+        local tuples, pos = sk:select(nil,
+                {limit=2, fullscan=true, fetch_pos=true})
+        t.assert_equals(tuples, {})
+        t.assert(pos == nil)
+
+        for i = 1, 3 do
+            s:replace{i, i}
+        end
+
+        local tuples
+        local tuples_offset
+        local pos = ""
+
+        -- Test fullscan pagination
+        for i = 0, 4 do
+            tuples, pos = sk:select(nil,
+                    {limit=2, fullscan=true, fetch_pos=true, after=pos})
+            tuples_offset = sk:select(nil,
+                    {limit=2, fullscan=true, offset=i*2})
+            t.assert_equals(tuples, tuples_offset)
+        end
+        tuples, pos = sk:select(nil,
+                {limit=2, fullscan=true, fetch_pos=true, after=pos})
+        t.assert_equals(tuples, {})
+        t.assert(pos == nil)
+
+        -- Test pagination on range iterators
+        local key_iter = {
+            ['GE'] = 2,
+            ['GT'] = 1,
+            ['LE'] = 4,
+            ['LT'] = 5,
+        }
+        for iter, key in pairs(key_iter) do
+            pos = ""
+            for i = 0, 3 do
+                tuples, pos = sk:select(key,
+                        {limit=2, iterator=iter, fetch_pos=true, after=pos})
+                tuples_offset = sk:select(key,
+                        {limit=2, iterator=iter, offset=i*2})
+                t.assert_equals(tuples, tuples_offset)
+            end
+            tuples, pos = sk:select(key,
+                    {limit=2, iterator=iter, fetch_pos=true, after=pos})
+            t.assert_equals(tuples, {})
+            t.assert(pos == nil)
+        end
+
+        -- Test pagination on equality iterators
+        for _, iter in pairs({'EQ', 'REQ'}) do
+            pos = ""
+            for i = 0, 1 do
+                tuples, pos = sk:select(3,
+                        {limit=2, iterator=iter, fetch_pos=true, after=pos})
+                tuples_offset = sk:select(3,
+                        {limit=2, iterator=iter, offset=i*2})
+                t.assert_equals(tuples, tuples_offset)
+            end
+            tuples, pos = sk:select(3,
+                    {iterator=iter, limit=2, fetch_pos=true, after=pos})
+            t.assert_equals(tuples, {})
+            t.assert(pos == nil)
+        end
+
+        --[[ Test that after with tuple and tuple_pos in
+             functional multikey index returns an error ]]--
+        local tuple = s.index.pk:get(1)
+        t.assert_error_msg_contains(
+                "Functional index does not support position by tuple",
+                sk.select, sk, nil, {fullscan=true, after=tuple})
+        t.assert_error_msg_contains(
+                "Functional index does not support position by tuple",
+                sk.tuple_pos, sk, tuple)
+    end)
+end
+
+local no_sup = t.group('Unsupported pagination', {
+            {engine = 'memtx', type = 'hash'},
+            {engine = 'memtx', type = 'bitset'},
+            {engine = 'memtx', type = 'rtree'},
+})
+
+no_sup.before_all(function(cg)
+    cg.server = server:new{
+        alias   = 'default',
+    }
+    start_server(cg.server)
+end)
+
+no_sup.after_all(function(cg)
+    cg.server:drop()
+end)
+
+no_sup.before_each(function(cg)
+    cg.server:exec(function(engine, type)
+        local s = box.schema.space.create('s', {engine=engine})
+        s:create_index('pk')
+        s:create_index('sk', {type=type})
+
+    end, {cg.params.engine, cg.params.type})
+end)
+
+no_sup.after_each(function(cg)
+    cg.server:exec(function()
+        box.space.s:drop()
+    end)
+end)
+
+no_sup.test_unsupported_pagination = function(cg)
+    cg.server:exec(function(index_type)
+        local t = require('luatest')
+        t.assert_error_msg_contains('does not support pagination',
+                box.space.s.index.sk.select, box.space.s.index.sk,
+                nil, {fullscan=true, fetch_pos=true})
+        local tuple = {0, 0}
+        if index_type == 'rtree' then
+            tuple = {0, {0, 0}}
+        end
+        t.assert_error_msg_contains('does not support pagination',
+                box.space.s.index.sk.select, box.space.s.index.sk,
+                nil, {fullscan=true, after=tuple})
+        -- tuple_pos works everywhere instead of func and multikey indexes
+        local pos = box.space.s.index.sk:tuple_pos(tuple)
+        t.assert_error_msg_contains('does not support pagination',
+                box.space.s.index.sk.select, box.space.s.index.sk,
+                nil, {fullscan=true, after=pos})
+    end, {cg.params.type})
+end

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -558,3 +558,8 @@ create_unit_test(PREFIX iterator_position
                  SOURCES iterator_position.c box_test_utils.c
                  LIBRARIES unit box core
 )
+
+create_unit_test(PREFIX key_def
+                 SOURCES key_def.c box_test_utils.c
+                 LIBRARIES unit box core
+)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -553,3 +553,8 @@ create_unit_test(PREFIX qsort_arg
                  SOURCES qsort_arg.cc core_test_utils.c
                  LIBRARIES misc unit
 )
+
+create_unit_test(PREFIX iterator_position
+                 SOURCES iterator_position.c box_test_utils.c
+                 LIBRARIES unit box core
+)

--- a/test/unit/iterator_position.c
+++ b/test/unit/iterator_position.c
@@ -1,0 +1,190 @@
+#include "fiber.h"
+#include "memory.h"
+#include "msgpuck.h"
+#include "index.h"
+#include "random.h"
+
+#define UNIT_TAP_COMPATIBLE 1
+#include "unit.h"
+
+#define KEY_BUF_LEN 100
+#define POS_BUF_LEN (KEY_BUF_LEN + 20)
+
+static char key_buf[KEY_BUF_LEN];
+static const char *key_buf_no_header;
+static char pos_buf[POS_BUF_LEN];
+
+/**
+ * Pack random key to key_buf, key_buf_no_header points to key
+ * without MP_ARRAY header.
+ */
+static uint32_t
+pack_random_key(uint32_t size)
+{
+	char *buf = key_buf;
+	buf = mp_encode_array(buf, size);
+	key_buf_no_header = buf;
+	for (uint32_t i = 0; i < size; ++i) {
+		uint32_t key = real_random();
+		buf = mp_encode_uint(buf, key);
+	}
+	return buf - key_buf_no_header;
+}
+
+static void
+simple_check(void)
+{
+	plan(4);
+	header();
+
+	uint32_t part_count = real_random_in_range(1, 10);
+	uint32_t key_len = pack_random_key(part_count);
+	uint32_t pack_size =
+		iterator_position_pack_size(key_buf_no_header,
+					    key_buf_no_header + key_len,
+					    part_count);
+	/* Fail if size of buffer is not enough for the test. */
+	fail_if(pack_size > POS_BUF_LEN);
+	iterator_position_pack(key_buf_no_header, key_buf_no_header + key_len,
+			       part_count, pos_buf, pos_buf + pack_size);
+	const char *begin, *end;
+	uint32_t pos_part_count;
+	int rc = iterator_position_unpack(pos_buf, pos_buf + pack_size,
+					  &begin, &end, &pos_part_count);
+	ok(rc == 0, "Position must be unpacked");
+	ok(end - begin == key_len &&
+	   part_count == pos_part_count &&
+	   memcmp(key_buf_no_header, begin, key_len) == 0,
+	   "Keys must match");
+
+	/*
+	 * Invalidate position (change MP_ARRAY header of key to another one)
+	 * and try to unpack.
+	 */
+	ptrdiff_t offset = begin - pos_buf - 1;
+	mp_encode_map(pos_buf + offset, part_count);
+	rc = iterator_position_unpack(pos_buf, pos_buf + pack_size,
+				      &begin, &end, &pos_part_count);
+	ok(rc != 0, "Invalid position must not be unpacked");
+	mp_encode_strl(pos_buf + offset, key_len);
+	rc = iterator_position_unpack(pos_buf, pos_buf + pack_size,
+				      &begin, &end, &pos_part_count);
+	ok(rc != 0, "Invalid position must not be unpacked");
+
+	footer();
+	check_plan();
+}
+
+static void
+unpack_invalid_check(void)
+{
+	plan(4);
+	header();
+
+	uint32_t part_count = real_random_in_range(1, 10);
+	uint32_t key_len = pack_random_key(part_count);
+	int rc = 0;
+
+	const char *begin, *end;
+	uint32_t pc;
+
+	uint32_t pack_size = iterator_position_pack_size(key_buf,
+							 key_buf + key_len,
+							 part_count);
+	const char *pos_buf_end = pos_buf + pack_size;
+	fail_if(pack_size > POS_BUF_LEN);
+	iterator_position_pack(key_buf, key_buf + key_len, part_count,
+			       pos_buf, pos_buf_end);
+	mp_encode_strl(pos_buf, key_len);
+	rc = iterator_position_unpack(pos_buf, pos_buf_end, &begin, &end, &pc);
+	ok(rc != 0, "Position which is not MP_BIN must not be unpacked");
+
+	iterator_position_pack(key_buf, key_buf + key_len, part_count,
+			       pos_buf, pos_buf_end);
+	mp_encode_array(pos_buf + 2, 1);
+	rc = iterator_position_unpack(pos_buf, pos_buf_end, &begin, &end, &pc);
+	ok(rc != 0, "Position which is not MP_MAP must not be unpacked");
+
+	iterator_position_pack(key_buf, key_buf + key_len, part_count,
+			       pos_buf, pos_buf_end);
+	pos_buf[3] = 1;
+	rc = iterator_position_unpack(pos_buf, pos_buf_end, &begin, &end, &pc);
+	ok(rc != 0, "Position with invalid map key must not be unpacked");
+
+	iterator_position_pack(key_buf, key_buf + key_len, part_count,
+			       pos_buf, pos_buf_end);
+	mp_encode_map(pos_buf + 4, part_count);
+	rc = iterator_position_unpack(pos_buf, pos_buf_end, &begin, &end, &pc);
+	ok(rc != 0, "Position with key that isn't array must not be unpacked");
+
+	footer();
+	check_plan();
+}
+
+static void
+cropped_buffer_check(void)
+{
+	plan(5);
+	header();
+
+	uint32_t part_count = real_random_in_range(2, 10);
+	uint32_t key_len = pack_random_key(part_count);
+	int rc = 0;
+
+	const char *begin, *end;
+	uint32_t pc;
+
+	uint32_t pack_size = iterator_position_pack_size(key_buf,
+							 key_buf + key_len,
+							 part_count);
+	const char *pos_buf_end = pos_buf + pack_size;
+	fail_if(pack_size > POS_BUF_LEN);
+	iterator_position_pack(key_buf, key_buf + key_len, part_count,
+			       pos_buf, pos_buf_end);
+	rc = iterator_position_unpack(pos_buf, pos_buf + 1, &begin, &end, &pc);
+	ok(rc != 0, "Position with cropped MP_BIN must not be unpacked");
+
+	rc = iterator_position_unpack(pos_buf, pos_buf + 2, &begin, &end, &pc);
+	ok(rc != 0, "Position with cropped MP_MAP must not be unpacked");
+
+	rc = iterator_position_unpack(pos_buf, pos_buf + 3, &begin, &end, &pc);
+	ok(rc != 0, "Position with cropped map key must not be unpacked");
+
+	rc = iterator_position_unpack(pos_buf, pos_buf + 4, &begin, &end, &pc);
+	ok(rc != 0, "Position with cropped MP_ARRAY must not be unpacked");
+
+	rc = iterator_position_unpack(pos_buf, pos_buf + 5, &begin, &end, &pc);
+	ok(rc != 0, "Position with cropped key must not be unpacked");
+
+	footer();
+	check_plan();
+}
+
+static int
+test_main(void)
+{
+	plan(3);
+	header();
+
+	simple_check();
+	unpack_invalid_check();
+	cropped_buffer_check();
+
+	footer();
+	return check_plan();
+}
+
+int
+main(void)
+{
+	memory_init();
+	fiber_init(fiber_c_invoke);
+	random_init();
+
+	int rc = test_main();
+
+	random_free();
+	fiber_free();
+	memory_free();
+	return rc;
+}

--- a/test/unit/key_def.c
+++ b/test/unit/key_def.c
@@ -1,0 +1,259 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "fiber.h"
+#include "key_def.h"
+#include "memory.h"
+#include "msgpuck.h"
+#include "small/region.h"
+#include "trivia/util.h"
+#include "tuple.h"
+
+#define UNIT_TAP_COMPATIBLE 1
+#include "unit.h"
+
+static char *
+test_key_new_va(const char *format, va_list ap)
+{
+	struct region *region = &fiber()->gc;
+	size_t region_svp = region_used(region);
+
+	/* Format the MsgPack key definition. */
+	const size_t mp_buf_size = 1024;
+	char *mp_buf = region_alloc(region, mp_buf_size);
+	fail_if(mp_buf == NULL);
+	size_t mp_size = mp_vformat(mp_buf, mp_buf_size, format, ap);
+	fail_if(mp_size > mp_buf_size);
+
+	/* Create a key. */
+	char *key = xmalloc(mp_size);
+	memcpy(key, mp_buf, mp_size);
+
+	region_truncate(region, region_svp);
+	return key;
+}
+
+/** Creates a key from a MsgPack format (see mp_format). */
+static char *
+test_key_new(const char *format, ...)
+{
+	va_list ap;
+	va_start(ap, format);
+	char *key = test_key_new_va(format, ap);
+	fail_unless(mp_typeof(*key) == MP_ARRAY);
+	va_end(ap);
+	return key;
+}
+
+static struct tuple *
+test_tuple_new_va(const char *format, va_list ap)
+{
+	struct region *region = &fiber()->gc;
+	size_t region_svp = region_used(region);
+
+	/* Format the MsgPack key definition. */
+	const size_t mp_buf_size = 1024;
+	char *mp_buf = region_alloc(region, mp_buf_size);
+	fail_if(mp_buf == NULL);
+	size_t mp_size = mp_vformat(mp_buf, mp_buf_size, format, ap);
+	fail_if(mp_size > mp_buf_size);
+
+	/* Create a tuple. */
+	struct tuple *tuple = tuple_new(tuple_format_runtime, mp_buf,
+					mp_buf + mp_size);
+	fail_if(tuple == NULL);
+
+	region_truncate(region, region_svp);
+	return tuple;
+}
+
+/** Creates a tuple from a MsgPack format (see mp_format). */
+static struct tuple *
+test_tuple_new(const char *format, ...)
+{
+	va_list ap;
+	va_start(ap, format);
+	struct tuple *tuple = test_tuple_new_va(format, ap);
+	va_end(ap);
+	return tuple;
+}
+
+static struct key_def *
+test_key_def_new_va(const char *format, va_list ap, bool for_func_index)
+{
+	struct region *region = &fiber()->gc;
+	size_t region_svp = region_used(region);
+
+	/* Format the MsgPack key definition. */
+	const size_t mp_buf_size = 1024;
+	char *mp_buf = region_alloc(region, mp_buf_size);
+	fail_if(mp_buf == NULL);
+	fail_if(mp_vformat(mp_buf, mp_buf_size, format, ap) > mp_buf_size);
+
+	/* Decode the key parts. */
+	const char *parts = mp_buf;
+	uint32_t part_count = mp_decode_array(&parts);
+	struct key_part_def *part_def = region_alloc(
+		region, sizeof(*part_def) * part_count);
+	fail_if(part_def == NULL);
+	fail_if(key_def_decode_parts(part_def, part_count, &parts,
+				     /*fields=*/NULL, /*field_count=*/0,
+				     region) != 0);
+
+	/* Create a key def. */
+	struct key_def *def = key_def_new(part_def, part_count, for_func_index);
+	fail_if(def == NULL);
+	key_def_update_optionality(def, 0);
+
+	region_truncate(region, region_svp);
+	return def;
+}
+
+/** Creates a key_def from a MsgPack format (see mp_format). */
+static struct key_def *
+test_key_def_new(const char *format, ...)
+{
+	va_list ap;
+	va_start(ap, format);
+	struct key_def *def = test_key_def_new_va(format, ap,
+						  /*for_func_index=*/false);
+	va_end(ap);
+	return def;
+}
+
+/** Creates a functional index key_def from a MsgPack format (see mp_format). */
+static struct key_def *
+test_key_def_new_func(const char *format, ...)
+{
+	va_list ap;
+	va_start(ap, format);
+	struct key_def *def = test_key_def_new_va(format, ap,
+						  /*for_func_index=*/true);
+	va_end(ap);
+	return def;
+}
+
+/**
+ * Checks that tuple_compare_with_key with cmp_def of functional index
+ * returns the same result as comparison of concatenated func and primary keys.
+ */
+static void
+test_check_tuple_compare_with_key_func(
+		struct key_def *cmp_def, struct tuple *tuple,
+		struct tuple *func_key, struct key_def *model_def,
+		struct tuple *model, const char *key)
+{
+	fail_unless(cmp_def->for_func_index);
+	fail_if(model_def->for_func_index);
+	const char *key_parts = key;
+	uint32_t part_count = mp_decode_array(&key_parts);
+	int a = tuple_compare_with_key(tuple, (hint_t)func_key, key_parts,
+				       part_count, HINT_NONE, cmp_def);
+	int b = tuple_compare_with_key(model, HINT_NONE, key_parts,
+				       part_count, HINT_NONE, model_def);
+	a = a > 0 ? 1 : a < 0 ? -1 : 0;
+	b = b > 0 ? 1 : b < 0 ? -1 : 0;
+	is(a, b, "tuple_compare_with_key_func(%s/%s, %s) = %d, expected %d",
+	   tuple_str(tuple), tuple_str(func_key), mp_str(key), a, b);
+}
+
+static void
+test_func_compare_with_key(void)
+{
+	plan(14);
+	header();
+
+	struct key_def *def = test_key_def_new_func(
+		"[{%s%u%s%s}{%s%u%s%s}]",
+		"field", 0, "type", "unsigned",
+		"field", 1, "type", "string");
+	/* Skip first field to check if func comparator can handle this. */
+	struct key_def *pk_def = test_key_def_new(
+		"[{%s%u%s%s}{%s%u%s%s}]",
+		"field", 1, "type", "unsigned",
+		"field", 2, "type", "string");
+	struct key_def *cmp_def = key_def_merge(def, pk_def);
+	/*
+	 * Model def is a copy of cmp_def, but not for_func_index, and hence
+	 * it has general implementation of tuple_compare_with_key method.
+	 */
+	struct key_def *model_def = test_key_def_new(
+		"[{%s%u%s%s}{%s%u%s%s}{%s%u%s%s}{%s%u%s%s}]",
+		"field", 0, "type", "unsigned",
+		"field", 1, "type", "string",
+		"field", 3, "type", "unsigned",
+		"field", 4, "type", "string");
+	struct tuple *func_key = test_tuple_new("[%u%s]", 20, "foo");
+	struct tuple *tuple = test_tuple_new("[%u%u%s]", 200, 10, "cpp");
+	/*
+	 * Model tuple is concatenated func_key and tuple's primary key.
+	 * Note that the 3rd field does not take part in comparison, so it
+	 * is intentionally different from the first field of tuple, which is
+	 * not compared too.
+	 */
+	struct tuple *model =
+		test_tuple_new("[%u%s%u%u%s]", 20, "foo", 100, 10, "cpp");
+	char *keys[] = {
+		test_key_new("[]"),
+		test_key_new("[%u]", 10),
+		test_key_new("[%u]", 20),
+		test_key_new("[%u]", 30),
+		test_key_new("[%u%s]", 10, "foo"),
+		test_key_new("[%u%s]", 20, "foo"),
+		test_key_new("[%u%s]", 20, "bar"),
+		test_key_new("[%u%s]", 30, "foo"),
+		test_key_new("[%u%s%u]", 20, "foo", 5),
+		test_key_new("[%u%s%u]", 20, "foo", 10),
+		test_key_new("[%u%s%u]", 20, "foo", 15),
+		test_key_new("[%u%s%u%s]", 20, "foo", 10, "bar"),
+		test_key_new("[%u%s%u%s]", 20, "foo", 10, "cpp"),
+		test_key_new("[%u%s%u%s]", 20, "foo", 10, "foo"),
+	};
+	for (unsigned int i = 0; i < lengthof(keys); i++) {
+		test_check_tuple_compare_with_key_func(
+			cmp_def, tuple, func_key, model_def, model, keys[i]);
+	}
+	for (unsigned int i = 0; i < lengthof(keys); i++)
+		free(keys[i]);
+	tuple_delete(func_key);
+	key_def_delete(def);
+	key_def_delete(pk_def);
+	key_def_delete(cmp_def);
+
+	footer();
+	check_plan();
+}
+
+static int
+test_main(void)
+{
+	plan(1);
+	header();
+
+	test_func_compare_with_key();
+
+	footer();
+	return check_plan();
+}
+
+static uint32_t
+test_field_name_hash(const char *str, uint32_t len)
+{
+	return str[0] + len;
+}
+
+int
+main(void)
+{
+	memory_init();
+	fiber_init(fiber_c_invoke);
+	tuple_init(test_field_name_hash);
+
+	int rc = test_main();
+
+	tuple_free();
+	fiber_free();
+	memory_free();
+	return rc;
+}


### PR DESCRIPTION
This patchset adds helpers, needed for pagination, new options after and fetch_pos for select (both FFI and LuaC), and pagination to memtx tree. All the types of tree indexes (multikey, functional) are suported.

Documentation will be added in a later patchset.

Closes #7633
Closes #7635
Closes #7636