### PR TITLE
sql: fix drop of constraints during ADD COLUMN

### DIFF
--- a/test/sql-luatest/constraint_test.lua
+++ b/test/sql-luatest/constraint_test.lua
@@ -1,0 +1,39 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'constraints'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+-- Make sure ALTER TABLE ADD COLUMN does not drop field constraints.
+g.test_constraints_1 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local fmt = {{'a', 'integer'}, {'b', 'integer'}}
+
+        local body = "function(x) return true end"
+        box.schema.func.create('ck1', {is_deterministic = true, body = body})
+        local func_id = box.func.ck1.id
+        fmt[1].constraint = {ck = 'ck1'}
+
+        local s0 = box.schema.space.create('a', {format = fmt})
+        local fk = {one = {field = 'a'}, two = {space = s0.id, field = 'b'}}
+        fmt[2].foreign_key = fk
+
+        local s = box.schema.space.create('b', {format = fmt})
+        t.assert_equals(s:format()[1].constraint, {ck = func_id})
+        t.assert_equals(s:format()[2].foreign_key, fk)
+        box.execute([[ALTER TABLE "b" ADD COLUMN c INT;]])
+        t.assert_equals(s:format()[1].constraint, {ck = func_id})
+        t.assert_equals(s:format()[2].foreign_key, fk)
+        box.space.b:drop()
+        box.space.a:drop()
+        box.schema.func.drop('ck1')
+    end)
+end


### PR DESCRIPTION
Prior to this patch, ALTER TABLE ADD COLUMN dropped all modified space field constraints, which is a bug. This patch fixed this bug.

Part of #6986

NO_DOC=will be added later
NO_CHANGELOG=will be added later