### PR TITLE
`func` and `func_def` construction refactoring

### DIFF
--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -3406,7 +3406,6 @@ on_replace_dd_func(struct trigger * /* trigger */, void *event)
 		struct func *func = func_new(def);
 		if (func == NULL)
 			return -1;
-		def_guard.is_active = false;
 		func_cache_insert(func);
 		on_rollback->data = func;
 		txn_stmt_on_rollback(stmt, on_rollback);

--- a/src/box/func.c
+++ b/src/box/func.c
@@ -412,7 +412,7 @@ static struct func *
 func_c_new(const struct func_def *def);
 
 struct func *
-func_new(struct func_def *def)
+func_new(const struct func_def *def)
 {
 	struct func *func;
 	switch (def->language) {
@@ -438,7 +438,7 @@ func_new(struct func_def *def)
 	}
 	if (func == NULL)
 		return NULL;
-	func->def = def;
+	func->def = func_def_dup(def);
 	rlist_create(&func->func_cache_pin_list);
 	/** Nobody has access to the function but the owner. */
 	memset(func->access, 0, sizeof(func->access));

--- a/src/box/func.c
+++ b/src/box/func.c
@@ -381,7 +381,7 @@ restore_fail:
 }
 
 static struct func *
-func_c_new(struct func_def *def);
+func_c_new(const struct func_def *def);
 
 struct func *
 func_new(struct func_def *def)
@@ -422,7 +422,7 @@ func_new(struct func_def *def)
 }
 
 static struct func *
-func_c_new(MAYBE_UNUSED struct func_def *def)
+func_c_new(MAYBE_UNUSED const struct func_def *def)
 {
 	assert(def->language == FUNC_LANGUAGE_C);
 	assert(def->body == NULL && !def->is_sandboxed);

--- a/src/box/func.h
+++ b/src/box/func.h
@@ -85,9 +85,16 @@ schema_module_init(void);
 void
 schema_module_free(void);
 
+/**
+ * Allocates and initializes a function, given a function definition.
+ * Returns the new function on success. On error, returns NULL and sets diag.
+ * Note, this function copies the given function definition so it may be safely
+ * freed after calling this function.
+ */
 struct func *
-func_new(struct func_def *def);
+func_new(const struct func_def *def);
 
+/** Frees a function object. */
 void
 func_delete(struct func *func);
 

--- a/src/box/func_def.c
+++ b/src/box/func_def.c
@@ -145,6 +145,24 @@ func_def_cmp(const struct func_def *def1, const struct func_def *def2)
 	return func_opts_cmp(&def1->opts, &def2->opts);
 }
 
+struct func_def *
+func_def_dup(const struct func_def *def)
+{
+	struct func_def *copy = func_def_new(
+		def->fid, def->uid, def->name, def->name_len, def->language,
+		def->body, def->body != NULL ? strlen(def->body) : 0,
+		def->comment, def->comment != NULL ? strlen(def->comment) : 0);
+	copy->setuid = def->setuid;
+	copy->is_deterministic = def->is_deterministic;
+	copy->is_sandboxed = def->is_sandboxed;
+	copy->param_count = def->param_count;
+	copy->returns = def->returns;
+	copy->aggregate = def->aggregate;
+	copy->exports.all = def->exports.all;
+	copy->opts = def->opts;
+	return copy;
+}
+
 /**
  * Check if a function definition is valid.
  * @retval  0 the definition is correct

--- a/src/box/func_def.c
+++ b/src/box/func_def.c
@@ -50,8 +50,8 @@ const struct opt_def func_opts_reg[] = {
 	OPT_DEF("takes_raw_args", OPT_BOOL, struct func_opts, takes_raw_args),
 };
 
-int
-func_opts_cmp(struct func_opts *o1, struct func_opts *o2)
+static int
+func_opts_cmp(const struct func_opts *o1, const struct func_opts *o2)
 {
 	if (o1->is_multikey != o2->is_multikey)
 		return o1->is_multikey - o2->is_multikey;
@@ -61,7 +61,7 @@ func_opts_cmp(struct func_opts *o1, struct func_opts *o2)
 }
 
 int
-func_def_cmp(struct func_def *def1, struct func_def *def2)
+func_def_cmp(const struct func_def *def1, const struct func_def *def2)
 {
 	if (def1->fid != def2->fid)
 		return def1->fid - def2->fid;
@@ -103,7 +103,7 @@ func_def_cmp(struct func_def *def1, struct func_def *def2)
  *            diagnostics message is provided
  */
 int
-func_def_check(struct func_def *def)
+func_def_check(const struct func_def *def)
 {
 	switch (def->language) {
 	case FUNC_LANGUAGE_C:

--- a/src/box/func_def.h
+++ b/src/box/func_def.h
@@ -163,15 +163,15 @@ func_def_sizeof(uint32_t name_len, uint32_t body_len, uint32_t comment_len,
 
 /** Compare two given function definitions. */
 int
-func_def_cmp(struct func_def *def1, struct func_def *def2);
+func_def_cmp(const struct func_def *def1, const struct func_def *def2);
 
 /** Duplicate a given function defintion object. */
 struct func_def *
-func_def_dup(struct func_def *def);
+func_def_dup(const struct func_def *def);
 
 /** Check if a non-empty function body is correct. */
 int
-func_def_check(struct func_def *def);
+func_def_check(const struct func_def *def);
 
 #ifdef __cplusplus
 }

--- a/src/box/func_def.h
+++ b/src/box/func_def.h
@@ -34,7 +34,9 @@
 #include "trivia/util.h"
 #include "field_def.h"
 #include "opt_def.h"
+
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -94,6 +96,10 @@ struct func_def {
 	uint32_t fid;
 	/** Owner of the function. */
 	uint32_t uid;
+	/** Function name. */
+	const char *name;
+	/** The length of the function name. */
+	uint32_t name_len;
 	/** Definition of the persistent function. */
 	char *body;
 	/** User-defined comment for a function. */
@@ -124,8 +130,6 @@ struct func_def {
 	 * The language of the stored function.
 	 */
 	enum func_language language;
-	/** The length of the function name. */
-	uint32_t name_len;
 	/** Frontends where function must be available. */
 	union {
 		struct {
@@ -136,30 +140,21 @@ struct func_def {
 	} exports;
 	/** The function options. */
 	struct func_opts opts;
-	/** Function name. */
-	char name[0];
 };
 
 /**
- * @param name_len length of func_def->name
- * @returns size in bytes needed to allocate for struct func_def
- * for a function of length @a a name_len, body @a body_len and
- * with comment @a comment_len.
+ * Allocates and initializes a function definition.
+ * Fields unspecified in the arguments are set to their default values.
+ * This function never fails (never returns NULL).
  */
-static inline size_t
-func_def_sizeof(uint32_t name_len, uint32_t body_len, uint32_t comment_len,
-		uint32_t *body_offset, uint32_t *comment_offset)
-{
-	/* +1 for '\0' name terminating. */
-	size_t sz = sizeof(struct func_def) + name_len + 1;
-	*body_offset = sz;
-	if (body_len > 0)
-		sz += body_len + 1;
-	*comment_offset = sz;
-	if (comment_len > 0)
-		sz += comment_len + 1;
-	return sz;
-}
+struct func_def *
+func_def_new(uint32_t fid, uint32_t uid, const char *name, uint32_t name_len,
+	     enum func_language language, const char *body, uint32_t body_len,
+	     const char *comment, uint32_t comment_len);
+
+/** Frees a function definition object. */
+void
+func_def_delete(struct func_def *def);
 
 /** Compare two given function definitions. */
 int

--- a/src/box/func_def.h
+++ b/src/box/func_def.h
@@ -160,7 +160,10 @@ func_def_delete(struct func_def *def);
 int
 func_def_cmp(const struct func_def *def1, const struct func_def *def2);
 
-/** Duplicate a given function defintion object. */
+/**
+ * Duplicates a given function definition object.
+ * This function never fails (never returns NULL).
+ */
 struct func_def *
 func_def_dup(const struct func_def *def);
 

--- a/src/box/lua/call.c
+++ b/src/box/lua/call.c
@@ -760,7 +760,7 @@ end:
  * On error, returns LUA_NOREF and sets diag.
  */
 static int
-func_persistent_lua_load(struct func_def *def)
+func_persistent_lua_load(const struct func_def *def)
 {
 	assert(def->body != NULL);
 	int func_ref = LUA_NOREF;
@@ -832,7 +832,7 @@ end:
 }
 
 struct func *
-func_lua_new(struct func_def *def)
+func_lua_new(const struct func_def *def)
 {
 	assert(def->language == FUNC_LANGUAGE_LUA);
 	struct func_lua *func =

--- a/src/box/lua/call.h
+++ b/src/box/lua/call.h
@@ -60,7 +60,7 @@ box_lua_eval(const char *expr, uint32_t expr_len,
 
 /** Construct a Lua function object. */
 struct func *
-func_lua_new(struct func_def *def);
+func_lua_new(const struct func_def *def);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/box/sql/func.c
+++ b/src/box/sql/func.c
@@ -2354,7 +2354,7 @@ struct func_sql_expr {
 };
 
 struct func *
-func_sql_expr_new(struct func_def *def)
+func_sql_expr_new(const struct func_def *def)
 {
 	struct sql *db = sql_get();
 	const char *body = def->body;

--- a/src/box/sql/func.c
+++ b/src/box/sql/func.c
@@ -2256,32 +2256,19 @@ sql_built_in_functions_cache_init(void)
 		assert(dict != NULL);
 
 		uint32_t len = strlen(name);
-		uint32_t size = sizeof(struct func_def) + len + 1;
-		struct func_def *def = malloc(size);
-		if (def == NULL)
-			panic("Out of memory on creating SQL built-in");
-		def->fid = i;
-		def->uid = 1;
-		def->body = NULL;
-		def->comment = NULL;
+		struct func_def *def = func_def_new(i, ADMIN, name, len,
+						    FUNC_LANGUAGE_SQL_BUILTIN,
+						    NULL, 0, NULL, 0);
 		def->setuid = true;
 		def->is_deterministic = dict->is_deterministic;
-		def->is_sandboxed = false;
 		assert(desc->argc != -1 || dict->argc_min != dict->argc_max);
 		def->param_count = desc->argc;
 		def->returns = desc->result;
 		def->aggregate = (dict->flags & SQL_FUNC_AGG) == 0 ?
 				 FUNC_AGGREGATE_NONE : FUNC_AGGREGATE_GROUP;
-		def->language = FUNC_LANGUAGE_SQL_BUILTIN;
-		def->name_len = len;
 		def->exports.sql = true;
-		func_opts_create(&def->opts);
-		memcpy(def->name, name, len + 1);
 
-		struct func_sql_builtin *func = malloc(sizeof(*func));
-		if (func == NULL)
-			panic("Out of memory on creating SQL built-in");
-
+		struct func_sql_builtin *func = xmalloc(sizeof(*func));
 		func->base.def = def;
 		rlist_create(&func->base.func_cache_pin_list);
 		func->base.vtab = &func_sql_builtin_vtab;

--- a/src/box/sql/func.h
+++ b/src/box/sql/func.h
@@ -14,7 +14,7 @@ struct func_def;
 
 /** Create new SQL user-defined function. */
 struct func *
-func_sql_expr_new(struct func_def *def);
+func_sql_expr_new(const struct func_def *def);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/test/unit/func_cache.c
+++ b/test/unit/func_cache.c
@@ -9,11 +9,9 @@ struct func *
 test_func_new(uint32_t id, const char *name)
 {
 	uint32_t name_len = strlen(name);
-	struct func_def *def = xmalloc(offsetof(struct func_def,
-						name[name_len + 1]));
-	def->fid = id;
-	strcpy(def->name, name);
-	def->name_len = strlen(name);
+	struct func_def *def = func_def_new(id, ADMIN, name, name_len,
+					    FUNC_LANGUAGE_LUA,
+					    NULL, 0, NULL, 0);
 	struct func *f = xmalloc(sizeof(*f));
 	f->def = def;
 	rlist_create(&f->func_cache_pin_list);
@@ -23,7 +21,7 @@ test_func_new(uint32_t id, const char *name)
 static void
 test_func_delete(struct func *f)
 {
-	free(f->def);
+	func_def_delete(f->def);
 	free(f);
 }
 


### PR DESCRIPTION
To handle space upgrade in read view, we'll need to make a copy of the space upgrade function. This PR is to refactors `func` and `func_def` construction to make it easy to do.

Needed for https://github.com/tarantool/tarantool-ee/issues/163