### PR TITLE
popen: add timeout for :wait()

### DIFF
--- a/changelogs/unreleased/popen-wait-after-close.md
+++ b/changelogs/unreleased/popen-wait-after-close.md
@@ -1,0 +1,5 @@
+## bugfix/lua/popen
+
+* Defined the behavior of in-progress `<popen handle>:wait()` when
+  `<popen handle>:close()` is called in another fiber: now it returns an error
+  instead of accessing a freed memory and, likely, hanging forever (gh-7653).

--- a/changelogs/unreleased/popen-wait-busy-loop.md
+++ b/changelogs/unreleased/popen-wait-busy-loop.md
@@ -1,0 +1,4 @@
+## feature/lua/popen
+
+* Eliminated polling in `<popen handle>:wait()`, so now it reacts to SIGCHLD
+  faster and performs less unnecessary work (gh-4915).

--- a/changelogs/unreleased/popen-wait-timeout.md
+++ b/changelogs/unreleased/popen-wait-timeout.md
@@ -1,0 +1,3 @@
+## feature/lua/popen
+
+* Added the `timeout` parameter for `<popen handle>:wait()` (gh-4916).

--- a/src/lib/core/popen.h
+++ b/src/lib/core/popen.h
@@ -14,6 +14,7 @@ extern "C" {
 
 #include "iostream.h"
 #include "trivia/util.h"
+#include "fiber_cond.h"
 
 /**
  * Describes popen object creation. This is API with Lua.
@@ -125,16 +126,61 @@ enum popen_states {
 };
 
 /**
- * An instance of popen object
+ * An instance of popen object.
  */
 struct popen_handle {
+	/**
+	 * Process ID.
+	 *
+	 * -1 when the process is known to be completed.
+	 */
 	pid_t			pid;
+	/**
+	 * A string representation of the executable and the
+	 * arguments for logging purposes.
+	 *
+	 * It does not precisely follow shell escaping rules, so
+	 * attempt to use it programmatically may lead to an
+	 * unexpected result.
+	 */
 	char			*command;
+	/**
+	 * Last known process status: alive, signaled, exited
+	 * and so on. See wait(2) for details. Zero means alive
+	 * (non-completed) process.
+	 *
+	 * @sa wstatus_str().
+	 */
 	int			wstatus;
+	/**
+	 * libev's SIGCHLD watcher.
+	 */
 	ev_child		ev_sigchld;
+	/**
+	 * Anchor to link all popen handles into a list.
+	 *
+	 * The list is used to kill child processes at exit
+	 * (except handles with the ..._KEEP_CHILD flag).
+	 */
 	struct rlist		list;
+	/**
+	 * Single-bit parameters: whether to do stdin/stdout/stderr
+	 * redirections, whether to use shell, whether to call
+	 * setsid() in the child and so on.
+	 *
+	 * @sa enum popen_flag_bits.
+	 */
 	unsigned int		flags;
+	/**
+	 * Parent's ends of piped stdin/stdout/stderr as iostream
+	 * objects.
+	 */
 	struct iostream		ios[POPEN_FLAG_FD_STDEND_BIT];
+	/**
+	 * A condition variable that is triggered at the process
+	 * completion or the handle deletion.
+	 */
+	struct fiber_cond	completion_cond;
 };
 
 /**
@@ -189,6 +235,27 @@ popen_state(struct popen_handle *handle, int *state, int *exit_code);
 
 extern const char *
 popen_state_str(unsigned int state);
+
+/**
+ * Await process completion.
+ *
+ * The function yields until the process will complete, the handle
+ * will be deleted or the timeout will be reached.
+ *
+ * Note: the process completion and the handle deletion situations
+ * are not differentiated by this function. If a caller needs it,
+ * it should track popen_delete() calls on its own.
+ *
+ * Returns 0 at the process completion or the handle deletion,
+ * otherwise returns -1 and sets a diag.
+ *
+ * Possible errors:
+ *
+ * - TimedOut: @a timeout quota is exceeded.
+ * - FiberIsCancelled: cancelled by an outside code.
+ */
+extern int
+popen_wait_timeout(struct popen_handle *handle, ev_tstamp timeout);
 
 extern int
 popen_send_signal(struct popen_handle *handle, int signo);

--- a/test/app-luatest/popen_wait_test.lua
+++ b/test/app-luatest/popen_wait_test.lua
@@ -1,0 +1,209 @@
+local fiber = require('fiber')
+local ffi = require('ffi')
+local popen = require('popen')
+
+local t = require('luatest')
+local g = t.group()
+
+local function sleep_120()
+    return popen.new({'sleep 120'}, {
+        stdin = popen.opts.CLOSE,
+        stdout = popen.opts.CLOSE,
+        stderr = popen.opts.CLOSE,
+        shell = true,
+        setsid = true,
+        group_signal = true,
+    })
+end
+
+local function assert_popen_wait_raises_illegal_params(f)
+    local ok, err = pcall(f)
+    t.assert_equals({
+        ok = ok,
+        error_type = err.type,
+        error_message = err.message,
+    }, {
+        ok = false,
+        error_type = 'IllegalParams',
+        error_message = 'Bad params, use: ph:wait([{timeout = <number>}])',
+    })
+end
+
+-- The :wait() call must return if the handle is closed.
+g.test_wait_unblock_after_close = function()
+    local ph = sleep_120()
+
+    -- Block the fiber 'f' at :wait() call.
+    local res, err
+    local latch = fiber.channel(1)
+    fiber.create(function()
+        res, err = ph:wait()
+        latch:put(true)
+    end)
+
+    -- Close the handle.
+    ph:close()
+
+    -- Wait 1 second at max.
+    local wait_is_completed = latch:get(1)
+    t.assert(wait_is_completed)
+
+    -- Verify the reported error.
+    t.assert_is(res, nil)
+    t.assert_type(err, 'cdata')
+    t.assert_is(err.type, 'ChannelIsClosed')
+end
+
+-- The :wait() call must overcome spurious wakeups.
+--
+-- The test case checks it in the following way:
+--
+-- * Run `sleep 120` in a child process.
+-- * Run a fiber and block it on :wait().
+-- * Wake up the fiber several times (during ~1 second)
+-- * Verify that the :wait() call doesn't return (during ~1 more
+--   second).
+g.test_wait_spurious_wakeup = function()
+    local ph = sleep_120()
+
+    -- Block the fiber 'f' at :wait() call.
+    local latch = fiber.channel(1)
+    local f = fiber.create(function()
+        ph:wait()
+        latch:put(true)
+    end)
+
+    -- Spurious wakeups.
+    for _ = 1, 10 do
+        f:wakeup()
+        fiber.sleep(0.1)
+    end
+
+    -- Wait 1 second at max.
+    local wait_is_completed = latch:get(1)
+    t.assert_not(wait_is_completed)
+
+    ph:close()
+end
+
+-- The :wait() call must unblock on fiber cancel.
+g.test_wait_cancelled = function()
+    local ph = sleep_120()
+
+    -- Block the fiber 'f' at :wait() call.
+    local ok, err
+    local latch = fiber.channel(1)
+    local f = fiber.create(function()
+        ok, err = pcall(ph.wait, ph)
+        latch:put(true)
+    end)
+
+    -- Cancel the :wait() call.
+    f:cancel()
+
+    -- Wait 1 second at max.
+    local wait_is_completed = latch:get(1)
+    t.assert(wait_is_completed)
+
+    -- Verify that the FiberIsCancelled error is raised.
+    t.assert_is(ok, false)
+    t.assert_type(err, 'cdata')
+    t.assert_is(err.type, 'FiberIsCancelled')
+
+    ph:close()
+end
+
+-- The :wait() call must return when a timeout is reached.
+g.test_wait_timeout = function()
+    local ph = sleep_120()
+
+    -- Block a fiber at :wait() call.
+    local res, err
+    local latch = fiber.channel(1)
+    fiber.create(function()
+        res, err = ph:wait({timeout = 0.1})
+        latch:put(true)
+    end)
+
+    -- Wait 1 second at max.
+    local wait_is_completed = latch:get(1)
+    t.assert(wait_is_completed)
+
+    -- Verify that the TimedOut error is returned.
+    t.assert_is(res, nil)
+    t.assert_type(err, 'cdata')
+    t.assert_is(err.type, 'TimedOut')
+
+    ph:close()
+end
+
+-- Verify how :wait()'s argument (opts) is checked.
+g.test_wait_opts_typecheck = function()
+    local ph = sleep_120()
+
+    assert_popen_wait_raises_illegal_params(function()
+        return ph:wait('not a table')
+    end)
+
+    assert_popen_wait_raises_illegal_params(function()
+        return ph:wait(1)
+    end)
+
+    -- Verify that :wait(nil) is accepted.
+    --
+    -- Block the fiber 'f' at :wait() call and wait 1 second at
+    -- max.
+    local latch = fiber.channel(1)
+    fiber.create(function()
+        ph:wait(nil)
+        latch:put(true)
+    end)
+    local wait_is_completed = latch:get(1)
+    t.assert_not(wait_is_completed)
+
+    -- Verify that :wait({}) is accepted.
+    --
+    -- Block the fiber 'f' at :wait() call and wait 1 second at
+    -- max.
+    local latch = fiber.channel(1)
+    fiber.create(function()
+        ph:wait({})
+        latch:put(true)
+    end)
+    local wait_is_completed = latch:get(1)
+    t.assert_not(wait_is_completed)
+
+    ph:close()
+end
+
+-- Verify how :wait()'s option timeout is checked.
+g.test_wait_timeout_typecheck = function()
+    local ph = sleep_120()
+
+    -- String, cdata, table are invalid timeout values.
+    assert_popen_wait_raises_illegal_params(function()
+        return ph:wait({timeout = '1'})
+    end)
+    assert_popen_wait_raises_illegal_params(function()
+        return ph:wait({timeout = ffi.new('float', 1.1)})
+    end)
+    assert_popen_wait_raises_illegal_params(function()
+        return ph:wait({timeout = {}})
+    end)
+
+    -- gh-9976: accept a negative timeout and interpret it as
+    -- zero.
+    assert_popen_wait_raises_illegal_params(function()
+        return ph:wait({timeout = -2})
+    end)
+
+    -- gh-4911: support number64 for timeout and signal.
+    assert_popen_wait_raises_illegal_params(function()
+        return ph:wait({timeout = 1LL})
+    end)
+    assert_popen_wait_raises_illegal_params(function()
+        return ph:wait({timeout = 1ULL})
+    end)
+
+    ph:close()
+end

--- a/test/app-tap/popen.test.lua
+++ b/test/app-tap/popen.test.lua
@@ -589,6 +589,8 @@ test:test('methods_on_invalid_handle', test_methods_on_invalid_handle)
 --   - info: get both true and false for each opts.<...> boolean
 --     option
 --   - FiberIsCancelled is raised from read(), write() and wait()
+--     NB: It is verified for wait() in
+--     app-luatest/popen_wait_test.lua.
 --
 -- - verify dubious code paths
 --   - popen.new


### PR DESCRIPTION
This patchset solves several problems:

* Eliminates polling with fiber sleeps for a process status in `:wait()`.
  Now the method waits for libev's SIGCHLD watcher (via a fiber cond).
* Fixes use-after-free and crash/infinite hang in `:wait()` when the 
  handle is closed from another fiber.
* Adds `timeout` parameter to `:wait()`.

Usage example:

```lua
local ph = popen.new(<...>)
local res, err = ph:wait({timeout = 1}) 

if res == nil then
    -- Timeout is reached.
    assert(err.type == 'TimedOut')
    <...>
end
```

Also `:wait()` now has defined behavior when the popen handle is closed
from another fiber: the method returns the `ChannelIsClosed` error.

Fixes #4915
Fixes #7653
Fixes #4916