### PR TITLE
sql: enhance drop constraint

### DIFF
--- a/src/box/sql/tarantoolInt.h
+++ b/src/box/sql/tarantoolInt.h
@@ -145,6 +145,14 @@ fk_constraint_encode_links(struct region *region,
 			   uint32_t *size);
 
 /**
+ * Drop the check constraint or foreign key. This function drops tuple and field
+ * constraints. If there is more than one constraint with the given name, one of
+ * them will be dropped.
+ */
+int
+sql_constraint_drop(uint32_t space_id, const char *name);
+
+/**
  * Encode index parts of given foreign key constraint into
  * MsgPack on @region.
  * @param region Region to use.

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -2125,6 +2125,21 @@ case OP_Count: {         /* out2 */
 	break;
 }
 
+/**
+ * Opcode: DropTupleConstraint P1 * * P4 *
+ * Synopsis: Drop constraint from box.space[P1]
+ *
+ * Drop constraint named P4.z from space P1.
+ */
+case OP_DropTupleConstraint: {
+	assert(pOp->p1 >= 0 && pOp->p4.z != NULL);
+	if (sql_constraint_drop(pOp->p1, pOp->p4.z) != 0)
+		goto abort_due_to_error;
+	assert(p->nChange == 0);
+	p->nChange = 1;
+	break;
+}
+
 /* Opcode: Savepoint P1 * * P4 *
  *
  * Open, release or rollback the savepoint named by parameter P4, depending

--- a/src/box/tuple_constraint_def.c
+++ b/src/box/tuple_constraint_def.c
@@ -14,6 +14,11 @@
 #include "small/region.h"
 #include "msgpuck.h"
 
+const char *tuple_constraint_type_strs[] = {
+	/* [CONSTR_FUNC]        = */ "constraint",
+	/* [CONSTR_FKEY]        = */ "foreign_key",
+};
+
 /**
  * Compare two tuple_constraint_field_id objects.
  */

--- a/src/box/tuple_constraint_def.h
+++ b/src/box/tuple_constraint_def.h
@@ -20,6 +20,8 @@ enum tuple_constraint_type {
 	CONSTR_FKEY,
 };
 
+extern const char *tuple_constraint_type_strs[];
+
 /**
  * Definition of a func.
  */

--- a/src/lib/core/CMakeLists.txt
+++ b/src/lib/core/CMakeLists.txt
@@ -42,6 +42,7 @@ set(core_sources
     ssl_init.c
     tt_sigaction.c
     tt_strerror.c
+    mp_util.c
 )
 
 if (ENABLE_BACKTRACE)

--- a/src/lib/core/mp_util.c
+++ b/src/lib/core/mp_util.c
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2021, Tarantool AUTHORS, please see AUTHORS file.
+ */
+
+#include "diag.h"
+#include "mp_util.h"
+#include "msgpuck.h"
+#include "small/region.h"
+
+const char *
+mp_vformat_on_region(struct region *region, size_t *size, const char *format,
+		     va_list src)
+{
+	va_list ap;
+	va_copy(ap, src);
+	size_t buf_size = mp_vformat(NULL, 0, format, ap);
+	char *buf = region_alloc(region, buf_size);
+	va_end(ap);
+	if (buf == NULL) {
+		diag_set(OutOfMemory, buf_size, "region_alloc", "buf");
+		return buf;
+	}
+	va_copy(ap, src);
+	*size = mp_vformat(buf, buf_size, format, ap);
+	va_end(ap);
+	assert(*size == buf_size);
+	return buf;
+}
+
+const char *
+mp_format_on_region(struct region *region, size_t *size, const char *format,
+		    ...)
+{
+	va_list ap;
+	va_start(ap, format);
+	const char *res = mp_vformat_on_region(region, size, format, ap);
+	va_end(ap);
+	return res;
+}

--- a/src/lib/core/mp_util.h
+++ b/src/lib/core/mp_util.h
@@ -1,0 +1,54 @@
+#pragma once
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2021, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include <stdarg.h>
+#include <stddef.h>
+
+#if defined(__cplusplus)
+extern "C"
+{
+#endif /* defined(__cplusplus) */
+
+struct region;
+
+/**
+ * Encode variables from the variable argument list according to format string
+ * into a buffer allocated on region.
+ *
+ * @param region Region to allocate buffer for the encoded value.
+ * @param size[out] Size of returned encoded value.
+ * @param format Null-terminated string containing the structure of the
+ * resulting msgpack and the types of the variables from the variable argument
+ * list.
+ * @param src Variable argument list.
+ *
+ * @retval NULL on error.
+ * @retval Address of the buffer with the encoded value.
+ */
+const char *
+mp_vformat_on_region(struct region *region, size_t *size, const char *format,
+		     va_list src);
+
+/**
+ * Encode a sequence of values according to format string into a buffer
+ * allocated on region.
+ *
+ * @param region Region to allocate buffer for the encoded value.
+ * @param size[out] Size of returned encoded value.
+ * @param format Null-terminated string containing the structure of the
+ * resulting msgpack and the types of the next arguments.
+ * @param ... Values to encode.
+ *
+ * @retval NULL on error.
+ * @retval Address of the buffer with the encoded value.
+ */
+const char *
+mp_format_on_region(struct region *region, size_t *size, const char *format,
+		    ...);
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */

--- a/test/sql-luatest/constraint_test.lua
+++ b/test/sql-luatest/constraint_test.lua
@@ -37,3 +37,101 @@ g.test_constraints_1 = function()
         box.schema.func.drop('ck1')
     end)
 end
+
+-- Make sure ALTER TABLE DROP CONSTRAINT drops field and tuple constraints.
+g.test_constraints_2 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+
+        local body = "function(x) return true end"
+        box.schema.func.create('ck1', {is_deterministic = true, body = body})
+        local func_id = box.space._func.index[2]:get{'ck1'}.id
+
+        local fk0 = {one = {field = {a = 'a'}}, two = {field = {b = 'b'}}}
+        local ck0 = {three = 'ck1', four = 'ck1'}
+        local fk1 = {five = {field = 'a'}, six = {field = 'b'}}
+        local ck1 = {seven = 'ck1', eight = 'ck1'}
+
+        local fmt = {{'a', 'integer'}, {'b', 'integer'}}
+        fmt[1].constraint = ck1
+        fmt[2].foreign_key = fk1
+
+        local def = {format = fmt, foreign_key = fk0, constraint = ck0}
+        local s = box.schema.space.create('a', def)
+        ck0.three = func_id
+        ck0.four = func_id
+        ck1.seven = func_id
+        ck1.eight = func_id
+        t.assert_equals(s.foreign_key, fk0)
+        t.assert_equals(s.constraint, ck0)
+        t.assert_equals(s:format()[1].constraint, ck1)
+        t.assert_equals(s:format()[2].foreign_key, fk1)
+
+        local ret = box.execute([[ALTER TABLE "a" DROP CONSTRAINT "one";]])
+        t.assert_equals(ret.row_count, 1)
+        t.assert_equals(s.foreign_key, {two = {field = {b = 'b'}}})
+        t.assert_equals(s.constraint, ck0)
+        t.assert_equals(s:format()[1].constraint, ck1)
+        t.assert_equals(s:format()[2].foreign_key, fk1)
+
+        local _, err = box.execute([[ALTER TABLE "a" DROP CONSTRAINT "one";]])
+        local res = [[Constraint 'one' does not exist in space 'a']]
+        t.assert_equals(err.message, res)
+
+        ret = box.execute([[ALTER TABLE "a" DROP CONSTRAINT "four";]])
+        t.assert_equals(ret.row_count, 1)
+        t.assert_equals(s.foreign_key, {two = {field = {b = 'b'}}})
+        t.assert_equals(s.constraint, {three = func_id})
+        t.assert_equals(s:format()[1].constraint, ck1)
+        t.assert_equals(s:format()[2].foreign_key, fk1)
+
+        ret = box.execute([[ALTER TABLE "a" DROP CONSTRAINT "seven";]])
+        t.assert_equals(ret.row_count, 1)
+        t.assert_equals(s.foreign_key, {two = {field = {b = 'b'}}})
+        t.assert_equals(s.constraint, {three = func_id})
+        t.assert_equals(s:format()[1].constraint, {eight = func_id})
+        t.assert_equals(s:format()[2].foreign_key, fk1)
+
+        ret = box.execute([[ALTER TABLE "a" DROP CONSTRAINT "two";]])
+        t.assert_equals(ret.row_count, 1)
+        t.assert_equals(s.foreign_key, nil)
+        t.assert_equals(s.constraint, {three = func_id})
+        t.assert_equals(s:format()[1].constraint, {eight = func_id})
+        t.assert_equals(s:format()[2].foreign_key, fk1)
+
+        ret = box.execute([[ALTER TABLE "a" DROP CONSTRAINT "five";]])
+        t.assert_equals(ret.row_count, 1)
+        t.assert_equals(s.foreign_key, nil)
+        t.assert_equals(s.constraint, {three = func_id})
+        t.assert_equals(s:format()[1].constraint, {eight = func_id})
+        t.assert_equals(s:format()[2].foreign_key, {six = {field = 'b'}})
+
+        ret = box.execute([[ALTER TABLE "a" DROP CONSTRAINT "eight";]])
+        t.assert_equals(ret.row_count, 1)
+        t.assert_equals(s.foreign_key, nil)
+        t.assert_equals(s.constraint, {three = func_id})
+        t.assert_equals(s:format()[1].constraint, nil)
+        t.assert_equals(s:format()[2].foreign_key, {six = {field = 'b'}})
+
+        ret = box.execute([[ALTER TABLE "a" DROP CONSTRAINT "three";]])
+        t.assert_equals(ret.row_count, 1)
+        t.assert_equals(s.foreign_key, nil)
+        t.assert_equals(s.constraint, nil)
+        t.assert_equals(s:format()[1].constraint, nil)
+        t.assert_equals(s:format()[2].foreign_key, {six = {field = 'b'}})
+
+        ret = box.execute([[ALTER TABLE "a" DROP CONSTRAINT "six";]])
+        t.assert_equals(ret.row_count, 1)
+        t.assert_equals(s.foreign_key, nil)
+        t.assert_equals(s.constraint, nil)
+        t.assert_equals(s:format()[1].constraint, nil)
+        t.assert_equals(s:format()[2].foreign_key, nil)
+
+        _, err = box.execute([[ALTER TABLE "a" DROP CONSTRAINT "eight";]])
+        res = [[Constraint 'eight' does not exist in space 'a']]
+        t.assert_equals(err.message, res)
+
+        box.space.a:drop()
+        box.schema.func.drop('ck1')
+    end)
+end


### PR DESCRIPTION
This patch-set allows to use ALTER TABLE DROP CONSTRAINT to drop BOX field and tuple constraints.

Part of #6986