### PR TITLE
read_view: add option to include temporary spaces

### DIFF
--- a/src/box/engine.c
+++ b/src/box/engine.c
@@ -267,9 +267,11 @@ engine_reset_stat(void)
 /* {{{ Virtual method stubs */
 
 struct engine_read_view *
-generic_engine_create_read_view(struct engine *engine)
+generic_engine_create_read_view(struct engine *engine,
+				const struct read_view_opts *opts)
 {
 	(void)engine;
+	(void)opts;
 	unreachable();
 	return NULL;
 }

--- a/src/box/engine.h
+++ b/src/box/engine.h
@@ -44,6 +44,7 @@ struct engine;
 struct engine_read_view;
 struct txn;
 struct txn_stmt;
+struct read_view_opts;
 struct space;
 struct space_def;
 struct vclock;
@@ -108,7 +109,8 @@ struct engine_vtab {
 	 * May be called only if the engine has the ENGINE_SUPPORTS_READ_VIEW
 	 * flag set.
 	 */
-	struct engine_read_view *(*create_read_view)(struct engine *engine);
+	struct engine_read_view *(*create_read_view)(
+		struct engine *engine, const struct read_view_opts *opts);
 	/**
 	 * Freeze a read view to feed to a new replica.
 	 * Setup and return a context that will be used
@@ -328,9 +330,10 @@ engine_create_space(struct engine *engine, struct space_def *def,
 }
 
 static inline struct engine_read_view *
-engine_create_read_view(struct engine *engine)
+engine_create_read_view(struct engine *engine,
+			const struct read_view_opts *opts)
 {
-	return engine->vtab->create_read_view(engine);
+	return engine->vtab->create_read_view(engine, opts);
 }
 
 static inline int
@@ -462,7 +465,8 @@ engine_reset_stat(void);
  * Virtual method stubs.
  */
 struct engine_read_view *
-generic_engine_create_read_view(struct engine *engine);
+generic_engine_create_read_view(struct engine *engine,
+				const struct read_view_opts *opts);
 int generic_engine_prepare_join(struct engine *, void **);
 int generic_engine_join(struct engine *, void *, struct xstream *);
 void generic_engine_complete_join(struct engine *, void *);

--- a/src/box/read_view.h
+++ b/src/box/read_view.h
@@ -122,6 +122,11 @@ struct read_view_opts {
 	 * space_read_view::upgrade.
 	 */
 	bool needs_space_upgrade;
+	/**
+	 * Temporary spaces aren't included into this read view unless this
+	 * flag is set.
+	 */
+	bool needs_temporary_spaces;
 };
 
 /** Sets read view options to default values. */


### PR DESCRIPTION
 - Filter out temporary spaces on read view creation unless the `read_view_opts::needs_temporary_spaces` flag is set and drop temporary space filter from checkpoint and join code.
 - Pass `read_view_opts` to `engine_create_read_view`. In case of memtx, delay garbage collection of temporary tuples if the flag is set.

Needed for https://github.com/tarantool/tarantool-ee/issues/213