### PR TITLE
Use MT-Safe `strerror_r` instead of `strerror`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,13 @@ check_symbol_exists(__get_cpuid cpuid.h HAVE_CPUID)
 check_symbol_exists(strlcpy string.h HAVE_STRLCPY)
 check_symbol_exists(strlcat string.h HAVE_STRLCAT)
 
+# On Linux the GNU version of strerror_r is used, because we define
+# the _GNU_SOURCE macro, see cmake/os.cmake.
+check_c_source_compiles("
+        #include <string.h>
+        int main() { return strerror_r(0, NULL, 0)[0] == 0; }
+    " HAVE_STRERROR_R_GNU)
+
 # Checks for libev
 include(CheckStructHasMember)
 check_struct_has_member("struct stat" "st_mtim" "sys/stat.h"

--- a/changelogs/unreleased/strerror-mt-safe.md
+++ b/changelogs/unreleased/strerror-mt-safe.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Switched from MT-Unsafe `strerror()` to MT-Safe `strerror_r()`. Usage of the
+  unsafe function could result in corrupted error messages.

--- a/extra/exports
+++ b/extra/exports
@@ -531,6 +531,7 @@ tnt_XXH64_copyState
 tnt_XXH64_digest
 tnt_XXH64_reset
 tnt_XXH64_update
+tt_strerror
 tt_uuid_bswap
 tt_uuid_compare
 tt_uuid_create
@@ -544,3 +545,4 @@ uri_set_destroy
 uuid_nil
 uuid_unpack
 _say
+_say_strerror

--- a/src/box/lua/info.c
+++ b/src/box/lua/info.c
@@ -55,6 +55,7 @@
 #include "lua/serializer.h" /* luaL_setmaphint */
 #include "fiber.h"
 #include "sio.h"
+#include "tt_strerror.h"
 
 static void
 lbox_pushvclock(struct lua_State *L, const struct vclock *vclock)
@@ -80,7 +81,7 @@ lbox_push_replication_error_message(struct lua_State *L, struct error *e,
 	if (e->saved_errno == 0)
 		return;
 	lua_pushstring(L, "system_message");
-	lua_pushstring(L, strerror(e->saved_errno));
+	lua_pushstring(L, tt_strerror(e->saved_errno));
 	lua_settable(L, idx - 2);
 }
 

--- a/src/lib/core/CMakeLists.txt
+++ b/src/lib/core/CMakeLists.txt
@@ -41,6 +41,7 @@ set(core_sources
     clock_lowres.c
     ssl_init.c
     tt_sigaction.c
+    tt_strerror.c
 )
 
 if (ENABLE_BACKTRACE)

--- a/src/lib/core/backtrace.c
+++ b/src/lib/core/backtrace.c
@@ -9,6 +9,7 @@
 #ifdef ENABLE_BACKTRACE
 #include "core/fiber.h"
 #include "core/tt_static.h"
+#include "core/tt_strerror.h"
 
 #ifdef __APPLE__
 #include <dlfcn.h>
@@ -308,7 +309,7 @@ backtrace_print(const struct backtrace *bt, int fd)
 					    frame->ip, proc_name, offset);
 		if (chars_written < 0) {
 			say_error("unwinding error: dprintf failed: %s",
-				  strerror(errno));
+				  tt_strerror(errno));
 			break;
 		}
 	}

--- a/src/lib/core/crash.c
+++ b/src/lib/core/crash.c
@@ -20,6 +20,7 @@
 #include "core/backtrace.h"
 #include "crash.h"
 #include "say.h"
+#include "tt_strerror.h"
 #include "tt_uuid.h"
 
 #define pr_fmt(fmt)		"crash: " fmt
@@ -400,9 +401,10 @@ crash_report_feedback_daemon(struct crash_info *cinfo)
 	int rc = posix_spawn(NULL, exec_argv[0], NULL, NULL, exec_argv, environ);
 	if (rc != 0) {
 		pr_crit("posix_spawn with "
-			"exec(%s,[%s,%s,%s,%s,%s,%s,%s]) failed: %s", exec_argv[0],
-			exec_argv[0], exec_argv[1], exec_argv[2], exec_argv[3],
-			exec_argv[4], exec_argv[5], exec_argv[6], strerror(rc));
+			"exec(%s,[%s,%s,%s,%s,%s,%s,%s]) failed: %s",
+			exec_argv[0], exec_argv[0], exec_argv[1], exec_argv[2],
+			exec_argv[3], exec_argv[4], exec_argv[5], exec_argv[6],
+			tt_strerror(rc));
 		return -1;
 	}
 
@@ -573,6 +575,6 @@ crash_signal_init(void)
 		if (sigaction(crash_signals[i], &sa, NULL) == 0)
 			continue;
 		pr_panic("sigaction %d (%s)", crash_signals[i],
-			 strerror(errno));
+			 tt_strerror(errno));
 	}
 }

--- a/src/lib/core/evio.c
+++ b/src/lib/core/evio.c
@@ -39,6 +39,7 @@
 #include <trivia/util.h>
 #include "exception.h"
 #include "iostream.h"
+#include "tt_strerror.h"
 #include "uri/uri.h"
 
 struct evio_service_entry {
@@ -401,14 +402,14 @@ evio_service_entry_stop(struct evio_service_entry *entry)
 		return;
 
 	if (close(service_fd) < 0)
-		say_error("Failed to close socket: %s", strerror(errno));
+		say_error("Failed to close socket: %s", tt_strerror(errno));
 
 	if (entry->addr.sa_family != AF_UNIX)
 		return;
 
 	if (unlink(((struct sockaddr_un *)&entry->addr)->sun_path) < 0) {
 		say_error("Failed to unlink unix "
-			  "socket path: %s", strerror(errno));
+			  "socket path: %s", tt_strerror(errno));
 	}
 }
 

--- a/src/lib/core/exception.cc
+++ b/src/lib/core/exception.cc
@@ -36,6 +36,7 @@
 
 #include "fiber.h"
 #include "reflection.h"
+#include "tt_strerror.h"
 
 extern "C" {
 
@@ -142,7 +143,7 @@ SystemError::SystemError(const char *file, unsigned line,
 	va_start(ap, format);
 	error_vformat_msg(this, format, ap);
 	va_end(ap);
-	error_append_msg(this, ": %s", strerror(saved_errno));
+	error_append_msg(this, ": %s", tt_strerror(saved_errno));
 }
 
 const struct type_info type_SocketError =
@@ -158,7 +159,7 @@ SocketError::SocketError(const char *file, unsigned line,
 	error_vformat_msg(this, format, ap);
 	va_end(ap);
 	error_append_msg(this, ", called on %s: %s", socketname,
-			 strerror(saved_errno));
+			 tt_strerror(saved_errno));
 }
 
 
@@ -363,7 +364,7 @@ BuildSystemError(const char *file, unsigned line, const char *format, ...)
 	va_start(ap, format);
 	error_vformat_msg(e, format, ap);
 	va_end(ap);
-	error_append_msg(e, ": %s", strerror(e->saved_errno));
+	error_append_msg(e, ": %s", tt_strerror(e->saved_errno));
 	return e;
 }
 
@@ -414,7 +415,7 @@ BuildSocketError(const char *file, unsigned line, const char *socketname,
 	error_vformat_msg(e, format, ap);
 	va_end(ap);
 	error_append_msg(e, ", called on %s: %s", socketname,
-			 strerror(e->saved_errno));
+			 tt_strerror(e->saved_errno));
 	return e;
 }
 

--- a/src/lib/core/say.c
+++ b/src/lib/core/say.c
@@ -32,6 +32,7 @@
 #include "fiber.h"
 #include "errinj.h"
 #include "tt_static.h"
+#include "tt_strerror.h"
 
 #include <errno.h>
 #include <stdarg.h>
@@ -106,6 +107,12 @@ static struct log log_std;
 static struct log *log_default = &log_boot;
 
 sayfunc_t _say = say_default;
+
+const char *
+_say_strerror(int errnum)
+{
+	return tt_strerror(errnum);
+}
 
 static const char level_chars[] = {
 	[S_FATAL] = 'F',

--- a/src/lib/core/tt_strerror.c
+++ b/src/lib/core/tt_strerror.c
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2022, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include "tt_strerror.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "tt_static.h"
+#include "trivia/config.h"
+
+const char *
+tt_strerror(int errnum)
+{
+#ifdef HAVE_STRERROR_R_GNU
+	return strerror_r(errnum, tt_static_buf(), TT_STATIC_BUF_LEN);
+#else
+	char *buf = tt_static_buf();
+	if (strerror_r(errnum, buf, TT_STATIC_BUF_LEN) != 0)
+		snprintf(buf, TT_STATIC_BUF_LEN, "Unknown error %03d", errnum);
+	return buf;
+#endif
+}

--- a/src/lib/core/tt_strerror.h
+++ b/src/lib/core/tt_strerror.h
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2022, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+/**
+ * Returns string describing error number.
+ *
+ * The string is allocated from a per-thread static buffer so in contrast
+ * to strerror(), this function is MT-Safe.
+ */
+const char *
+tt_strerror(int errnum);
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */

--- a/src/lua/errno.lua
+++ b/src/lua/errno.lua
@@ -2,14 +2,14 @@ local ffi = require('ffi')
 local errno_list = require('errno')
 
 ffi.cdef[[
-    char *strerror(int errnum);
+    const char *tt_strerror(int errnum);
 ]]
 
 local function strerror(errno)
     if errno == nil then
         errno = ffi.errno()
     end
-    return ffi.string(ffi.C.strerror(tonumber(errno)))
+    return ffi.string(ffi.C.tt_strerror(tonumber(errno)))
 end
 
 return setmetatable({

--- a/src/main.cc
+++ b/src/main.cc
@@ -62,6 +62,7 @@
 #include "trivia/util.h"
 #include "backtrace.h"
 #include "tt_pthread.h"
+#include "tt_strerror.h"
 #include "lua/init.h"
 #include "box/flightrec.h"
 #include "box/box.h"
@@ -707,7 +708,8 @@ main(int argc, char **argv)
 		int save_errno = errno;
 		if (fd >= 0)
 			close(fd);
-		printf("Can't open script %s: %s\n", argv[1], strerror(save_errno));
+		printf("Can't open script %s: %s\n",
+		       argv[1], tt_strerror(save_errno));
 		return save_errno;
 	}
 

--- a/src/module_header.h
+++ b/src/module_header.h
@@ -39,7 +39,6 @@
 #include <stddef.h>
 #include <stdarg.h> /* va_list */
 #include <errno.h>
-#include <string.h> /* strerror(3) */
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h> /* ssize_t for Apple */

--- a/src/trivia/config.h.cmake
+++ b/src/trivia/config.h.cmake
@@ -55,7 +55,12 @@
 /**
  * Defined if strlcat() string extension helper present.
  */
- #cmakedefine HAVE_STRLCAT 1
+#cmakedefine HAVE_STRLCAT 1
+
+/**
+ * Defined if this platform has GNU specific strerror_r().
+ */
+#cmakedefine HAVE_STRERROR_R_GNU 1
 
 /*
  * Defined if gcov instrumentation should be enabled.

--- a/test/unit/say.c
+++ b/test/unit/say.c
@@ -3,6 +3,7 @@
 #include <memory.h>
 #include "unit.h"
 #include "say.h"
+#include "tt_strerror.h"
 #include <pthread.h>
 #include <errinj.h>
 #include <coio_task.h>
@@ -203,7 +204,8 @@ int main()
 	char template[] = "/tmp/tmpdir.XXXXXX";
 	const char *tmp_dir = mkdtemp(template);
 	if (tmp_dir == NULL) {
-		diag("unit/say: failed to create temp dir: %s", strerror(errno));
+		diag("unit/say: failed to create temp dir: %s",
+		     tt_strerror(errno));
 		return check_plan();
 	}
 	char tmp_filename[30];


### PR DESCRIPTION
`strerror()` is MT-Unsafe, because it uses a static buffer under the hood. We should use `strerror_r()` instead, which takes a user-provided buffer. The problem is there are two implementations of `strerror_r()`: XSI and GNU. The first one returns an error code and always writes the message to the beginning of the buffer while the second one returns a pointer to a location within the buffer where the message starts. Let's introduce a macro `HAVE_STRERROR_R_GNU` set if the GNU version is available and define `tt_strerror()` which writes the message to the static buffer, like `tt_cstr()` or `tt_sprintf()`.

Note, we have to export `tt_strerror()`, because it is used by Lua via FFI. We also need to make it available in the module API header, because the `say_syserror()` macro uses `strerror()` directly. In order to avoid adding `tt_strerror()` to the module API, we introduce an internal helper function `_say_strerror()`, which calls `tt_strerror()`.