### PR TITLE
lua/merger: fix use-after-free during iteration

### DIFF
--- a/changelogs/unreleased/merger-use-after-free-in-gen.md
+++ b/changelogs/unreleased/merger-use-after-free-in-gen.md
@@ -1,0 +1,4 @@
+## bugfix/lua/merger
+
+* Fixed use-after-free during iteration over `merge_source:pairs()` or
+  `merger:pairs()` (gh-7657).

--- a/test/box-luatest/gh_7657_merger_use_after_free_in_gen_test.lua
+++ b/test/box-luatest/gh_7657_merger_use_after_free_in_gen_test.lua
@@ -1,0 +1,126 @@
+local buffer = require('buffer')
+local msgpack = require('msgpack')
+local key_def = require('key_def')
+local merger = require('merger')
+
+local t = require('luatest')
+local g = t.group()
+
+-- There are four types of merge sources: tuple, table, buffer and
+-- merger. The test cases below are constructed in the same way,
+-- each for its own type of a merge source.
+--
+-- It would be enough to test only one source type: all were
+-- affected, because the problem was in the common code. However,
+-- we shouldn't make such assumptions in the testing code.
+
+g.test_tuple_source = function()
+    local source = merger.new_tuple_source(pairs({{1, '1'}, {2, '2'}}))
+    local gen, param, state = source:pairs():unwrap()
+
+    -- At this point we have two references to the merge source
+    -- object: `source` and `state`.
+    --
+    -- The buggy `gen` function returns a new `state` object,
+    -- which holds the same pointer, but is not the same cdata
+    -- object. So we loss the `state` reference.
+    --
+    -- In fact, the problem wouldn't occur if the new `state`
+    -- would be pushed to the Lua stack together with increasing
+    -- of the refcounter of the merge source structure and would
+    -- have a GC handler that decreases it. The buggy `gen`
+    -- doesn't touch the refcounter.
+    --
+    -- We should call :unwrap(), because the luafun iterator holds
+    -- the original `state` object.
+    --
+    -- The fixed code returns the same cdata object, so `state`
+    -- remains the same. The reference isn't lost.
+    local tuple
+    state, tuple = gen(param, state)
+    t.assert_equals(tuple, {1, '1'})
+
+    -- Loss the second reference to the merge source object. If it
+    -- is the last reference to this cdata object in Lua, the GC
+    -- handler will be called and will decrease the refcounter in
+    -- the merge source structure to zero. The structure is freed
+    -- in this case.
+    --
+    -- If the `gen` function returns correct `state` above, we
+    -- still have a valid reference and the GC handler will not
+    -- be called.
+    source = nil -- luacheck: no unused
+    collectgarbage()
+
+    -- Access the source to trigger the crash if it was freed.
+    state, tuple = gen(param, state)
+    t.assert_equals(tuple, {2, '2'})
+
+    -- Finish reading of the tuples. It is not necessary for
+    -- reproducing the problem, but will cause a feeling of
+    -- a finished action in one who will read it. Positive
+    -- emotions are important.
+    state, tuple = gen(param, state)
+    t.assert_is(state, nil)
+    t.assert_is(tuple, nil)
+end
+
+g.test_table_source = function()
+    local source = merger.new_source_fromtable({{1, '1'}, {2, '2'}})
+    local gen, param, state = source:pairs():unwrap()
+
+    local tuple
+    state, tuple = gen(param, state)
+    t.assert_equals(tuple, {1, '1'})
+
+    source = nil -- luacheck: no unused
+    collectgarbage()
+
+    state, tuple = gen(param, state)
+    t.assert_equals(tuple, {2, '2'})
+
+    state, tuple = gen(param, state)
+    t.assert_is(state, nil)
+    t.assert_is(tuple, nil)
+end
+
+g.test_buffer_source = function()
+    local buf = buffer.ibuf()
+    msgpack.encode({{1, '1'}, {2, '2'}}, buf)
+    local source = merger.new_source_frombuffer(buf)
+    local gen, param, state = source:pairs():unwrap()
+
+    local tuple
+    state, tuple = gen(param, state)
+    t.assert_equals(tuple, {1, '1'})
+
+    source = nil -- luacheck: no unused
+    collectgarbage()
+
+    state, tuple = gen(param, state)
+    t.assert_equals(tuple, {2, '2'})
+
+    state, tuple = gen(param, state)
+    t.assert_is(state, nil)
+    t.assert_is(tuple, nil)
+end
+
+g.test_merger = function()
+    local kd = key_def.new({{fieldno = 1, type = 'unsigned'}})
+    local source = merger.new_source_fromtable({{1, '1'}, {2, '2'}})
+    local gen, param, state = merger.new(kd, {source}):pairs():unwrap()
+
+    local tuple
+    state, tuple = gen(param, state)
+    t.assert_equals(tuple, {1, '1'})
+
+    source = nil -- luacheck: no unused
+    collectgarbage()
+
+    state, tuple = gen(param, state)
+    t.assert_equals(tuple, {2, '2'})
+
+    state, tuple = gen(param, state)
+    t.assert_is(state, nil)
+    t.assert_is(tuple, nil)
+end


### PR DESCRIPTION
All merge sources (including the merger itself) share the same `<merge source>:pairs()` implementation, which returns `gen, param, state` triplet. `gen` is `lbox_merge_source_gen()`, `param` is `nil`, `state` in the merge source.

The `lbox_merge_source_gen()` returns `source, tuple`. The returned source is supposed to be the same object as one passed to the function (`gen(param, state)`), so the function assumes the object as alive and don't increment source's refcounter at entering, don't decrease it at exitting.

This logic is perfect, but there was a mistake in the implementation: the function returns a new cdata object (which holds the same pointer to the merge source structure) instead of the same cdata object.

The new cdata object neither increases the source's refcounter at pushing to Lua, nor decreases it at collecting. At result, if we'll loss the original merge source object (and the first `state` that is returned from `:pairs()`), the source structure may be freed. The pointer in the new cdata object will be invalid so.

A sketchy code that illustrates the problem:

```lua
gen, param, state0 = source:pairs()
assert(state0 == source)
source = nil
state1, tuple = gen(param, state0)
state0 = nil
-- assert(state1 == source) -- would fails
collectgarbage()
-- The cdata object that is referenced as `source` and as `state`
-- is collected. The GC handler is called and dropped the merge
-- source structure refcounter to zero. The structure is freed.
-- The call below will crash.
gen(param, state1)
```

In the fixed code `state1 == source`, so the GC handler is not called prematurely: we have the merge source object alive till end of the iterator or till stop of the traveral.

Fixes #7657