### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-7230-luajit-fixes.md
+++ b/changelogs/unreleased/gh-7230-luajit-fixes.md
@@ -4,3 +4,5 @@ Backported patches from vanilla LuaJIT trunk (gh-7230). In the scope of this
 activity, the following issues have been resolved:
 
 * Fix handling of errors during trace snapshot restore.
+* Fix recording of `tonumber()` with cdata argument for failed conversions
+  (gh-7655).


### PR DESCRIPTION
* FFI: Add tonumber() specialization for failed conversions.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump