### PR TITLE
log: introduce per-module `log_level`

### DIFF
--- a/changelogs/unreleased/gh-3211-per-module-log_level.md
+++ b/changelogs/unreleased/gh-3211-per-module-log_level.md
@@ -1,0 +1,7 @@
+## feature/core
+
+* **[Breaking change]** Now the log message contains the name of a module from
+  which the logging function was called (gh-3211).
+
+* Supported per-module log level setting via `log.cfg{modules = {...}}` or via
+  `box.cfg{log_modules = {...}}` (gh-3211).

--- a/extra/exports
+++ b/extra/exports
@@ -428,6 +428,7 @@ prbuf_iterator_create
 prbuf_iterator_next
 random_bytes
 say_check_cfg
+say_from_lua
 say_logger_init
 say_logger_initialized
 say_logrotate

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -68,6 +68,7 @@ local default_cfg = {
     log                 = log.cfg.log,
     log_nonblock        = log.cfg.nonblock,
     log_level           = log.cfg.level,
+    log_modules         = log.cfg.modules,
     log_format          = log.cfg.format,
 
     audit_log           = nil,
@@ -170,6 +171,7 @@ local template_cfg = {
     log                 = 'string',
     log_nonblock        = 'boolean',
     log_level           = 'number, string',
+    log_modules         = 'table',
     log_format          = 'string',
 
     audit_log           = 'string',
@@ -402,6 +404,7 @@ local dynamic_cfg_modules = {
         options = {
             log = true,
             log_level = true,
+            log_modules = true,
             log_format = true,
             log_nonblock = true,
         },
@@ -642,8 +645,8 @@ local function apply_env_cfg(cfg, env_cfg)
     end
 end
 
-local function merge_cfg(cfg, default_cfg)
-    for k,v in pairs(default_cfg) do
+local function merge_cfg(cfg, cur_cfg)
+    for k,v in pairs(cur_cfg) do
         if cfg[k] == nil then
             cfg[k] = v
         elseif type(v) == 'table' then

--- a/src/lib/core/say.h
+++ b/src/lib/core/say.h
@@ -146,7 +146,8 @@ enum syslog_facility {
 struct log;
 
 typedef int (*log_format_func_t)(struct log *log, char *buf, int len, int level,
-				 const char *filename, int line, const char *error,
+				 const char *module, const char *filename,
+				 int line, const char *error,
 				 const char *format, va_list ap);
 
 /**
@@ -201,8 +202,9 @@ log_destroy(struct log *log);
 
 /** A utility function to handle va_list from different varargs functions. */
 int
-log_vsay(struct log *log, int level, const char *filename, int line,
-	 const char *error, const char *format, va_list ap);
+log_vsay(struct log *log, int level, bool check_level, const char *module,
+	 const char *filename, int line, const char *error, const char *format,
+	 va_list ap);
 
 /** Perform log write. */
 static inline int
@@ -211,7 +213,8 @@ log_say(struct log *log, int level, const char *filename,
 {
 	va_list ap;
 	va_start(ap, format);
-	int total = log_vsay(log, level, filename, line, error, format, ap);
+	int total = log_vsay(log, level, true, NULL, filename, line, error,
+			     format, ap);
 	va_end(ap);
 	return total;
 }
@@ -479,6 +482,7 @@ say_free_syslog_opts(struct say_syslog_opts *opts);
  * @param buf buffer where the formatted message should be written to
  * @param len size of buffer
  * @param level log level of message
+ * @param module name of module where log was called
  * @param filename name of file where log was called
  * @param line name of file where log was called
  * @param error error in case of system errors
@@ -488,12 +492,12 @@ say_free_syslog_opts(struct say_syslog_opts *opts);
  */
 int
 say_format_json(struct log *log, char *buf, int len, int level,
-		const char *filename, int line, const char *error,
-		const char *format, va_list ap);
+		const char *module, const char *filename, int line,
+		const char *error, const char *format, va_list ap);
 int
 say_format_plain(struct log *log, char *buf, int len, int level,
-		 const char *filename, int line, const char *error,
-		 const char *format, va_list ap);
+		const char *module, const char *filename, int line,
+		const char *error, const char *format, va_list ap);
 
 /**
  * A type defining a callback that is called before or after

--- a/src/lua/init.lua
+++ b/src/lua/init.lua
@@ -29,6 +29,122 @@ local LUA_TEMPLATES = { '?.lua', '?/init.lua' }
 local ROCKS_LIB_TEMPLATES = { ROCKS_LIB_PATH .. '/?.'..soext }
 local ROCKS_LUA_TEMPLATES = { ROCKS_LUA_PATH .. '/?.lua', ROCKS_LUA_PATH .. '/?/init.lua' }
 
+-- A wrapper with a unique name, used in the call stack traversing.
+local function __tarantool__internal__require__wrapper__()
+    -- This require() may be overloaded.
+    return require('log.get_callstack')
+end
+
+-- Calculate how many times the standard require() function was overloaded.
+-- E.g. if there are three user overloads, the call stack returned by
+-- get_callstack will look like:
+-- 7. the place where require('log') was called
+-- 6. require('log') -- overloaded in this file
+-- 5. __tarantool__internal__require__wrapper__
+-- 4. require('log.get_callstack') -- overloaded in user module 3
+-- 3. require('log.get_callstack') -- overloaded in user module 2
+-- 2. require('log.get_callstack') -- overloaded in user module 1
+-- 1. require('log.get_callstack') -- overloaded in this file
+local function get_require_overload_count(stack)
+    local wrapper_name = '__tarantool__internal__require__wrapper__'
+    local count = 0
+    for _, f in pairs(stack) do
+        if f.name ~= nil and string.find(f.name, wrapper_name) ~= nil then
+            return count + 1
+        end
+        count = count + 1
+    end
+    return 0
+end
+
+-- Make path relative to the current directory.
+local function remove_root_directory(path)
+    local pwd = os.getenv("PWD")
+    if pwd == nil then
+        return path
+    end
+    local cur_dir = pwd .. '/'
+    local start_len = #path
+
+    while #cur_dir > 0 and start_len == #path do
+        if cur_dir == '/' then
+            if path:sub(1, 1) == '/' then
+                path = path:sub(2)
+            end
+            break
+        end
+        path = path:gsub(cur_dir, '')
+        local ind = cur_dir:find('[^/]+/$')
+        cur_dir = cur_dir:sub(1, ind - 1)
+    end
+    return path
+end
+
+-- Obtain the module name from the file name by removing:
+-- 1. builtin/ prefixes
+-- 2. path prefixes contained in package.path, package.cpath
+-- 3. subpaths to the current directory
+-- 4. ROCKS_LIB_PATH, ROCKS_LUA_PATH
+-- 5. /init.lua and .lua suffixes
+-- and by replacing all `/` with `.`
+local function module_name_from_filename(filename)
+    local paths = package.path .. package.cpath
+    local result = filename:gsub('builtin/', '')
+    for path in paths:gmatch'/([^?]+)\\?' do
+        -- Escape magic characters in path.
+        path = path:gsub('([^%w])', '%%%1')
+        result = result:gsub('^/' .. path, '')
+    end
+    result = result:gsub('/init.lua', '')
+    result = result:gsub('%.lua', '')
+    result = remove_root_directory(result)
+    result = result:gsub(ROCKS_LIB_PATH .. '/', '')
+    result = result:gsub(ROCKS_LUA_PATH .. '/', '')
+    result = result:gsub('/', '.')
+    return result
+end
+
+-- Take the function level in the call stack as input and return
+-- the name of the module in which the function is defined.
+local function module_name_by_callstack_level(level)
+    local info = debug.getinfo(level + 1)
+    if info ~= nil and info.source:sub(1, 1) == '@' then
+        local src_name = info.source:sub(2)
+        return module_name_from_filename(src_name)
+    end
+    -- require('log') called from the interactive mode or `tarantool -e`
+    return 'tarantool'
+end
+
+-- Return current call stack.
+local function get_callstack()
+    local i = 2
+    local stack = {}
+    local info = debug.getinfo(i)
+    while info ~= nil do
+        stack[i] = info
+        i = i + 1
+        info = debug.getinfo(i)
+    end
+    return stack
+end
+
+-- Overload the require() function to set the module name during require('log')
+-- Note that the standard require() function may be already overloaded in a user
+-- module, also there can be multiple overloads.
+local real_require = require
+_G.require = function(modname)
+    if modname == 'log' then
+        local callstack = __tarantool__internal__require__wrapper__()
+        local overload_count = get_require_overload_count(callstack)
+        local name = module_name_by_callstack_level(overload_count + 2)
+        return real_require('log').new(name)
+    elseif modname == 'log.get_callstack' then
+        return get_callstack()
+    end
+    return real_require(modname)
+end
+
 local package_searchroot
 
 local function searchroot()

--- a/src/lua/log.lua
+++ b/src/lua/log.lua
@@ -119,6 +119,7 @@ local default_cfg = {
     log             = nil,
     nonblock        = nil,
     level           = S_INFO,
+    modules         = nil,
     format          = fmt_num2str[ffi.C.SF_PLAIN],
 }
 
@@ -131,6 +132,7 @@ local log2box_keys = {
     ['log']             = 'log',
     ['nonblock']        = 'log_nonblock',
     ['level']           = 'log_level',
+    ['modules']         = 'log_modules',
     ['format']          = 'log_format',
 }
 
@@ -145,7 +147,8 @@ end
 -- Main routine which pass data to C logging code.
 local function say(self, level, fmt, ...)
     local name = self and self.name
-    local module_level = log_cfg.level
+    local module_level = name and log_cfg.modules and log_cfg.modules[name] or
+                         log_cfg.level
     if level > log_normalize_level(module_level) then
         return
     end
@@ -305,6 +308,7 @@ local option_types = {
     log = 'string',
     nonblock = 'boolean',
     level = 'number, string',
+    modules = 'table',
     format = 'string',
 }
 
@@ -325,16 +329,33 @@ local function log_C_cfg(cfg)
 end
 
 -- Check that level is a number or a valid string.
-local function log_check_level(level)
+local function log_check_level(level, option_name)
     if type(level) == 'string' and log_level_keys[level] == nil then
         local err = ("expected %s"):format(log_level_list())
-        box.error(box.error.CFG, "log_level", err)
+        box.error(box.error.CFG, option_name, err)
+    end
+end
+
+-- Check that the 'modules' table contains valid log levels.
+local function log_check_modules(modules)
+    if modules == nil then
+        return
+    end
+    for name, level in pairs(modules) do
+        if type(name) ~= 'string' then
+            box.error(box.error.CFG, 'module name', 'should be of type string')
+        end
+        local option_name = 'log_modules.' .. name
+        box.internal.check_cfg_option_type(option_types.level, option_name,
+                                           level)
+        log_check_level(level, option_name)
     end
 end
 
 -- Check cfg is valid and thus can be applied.
 local function log_check_cfg(cfg)
-    log_check_level(cfg.level)
+    log_check_level(cfg.level, 'log_level')
+    log_check_modules(cfg.modules)
 
     if log_initialized then
         if log_cfg.log ~= cfg.log then
@@ -392,9 +413,11 @@ local function set_log_format(format)
     log_debug("log: format set to '%s'", format)
 end
 
-local function log_configure(self, cfg)
-    cfg = box.internal.prepare_cfg(cfg, default_cfg, option_types)
-    box.internal.merge_cfg(cfg, log_cfg);
+local function log_configure(self, cfg, box_api)
+    if not box_api then
+        cfg = box.internal.prepare_cfg(cfg, default_cfg, option_types)
+        box.internal.merge_cfg(cfg, log_cfg);
+    end
 
     log_check_cfg(cfg)
     local cfg_C = log_C_cfg(cfg)
@@ -416,6 +439,7 @@ local function box_to_log_cfg()
     return {
         log = box.cfg.log,
         level = box.cfg.log_level,
+        modules = box.cfg.log_modules,
         format = box.cfg.log_format,
         nonblock = box.cfg.log_nonblock,
     }
@@ -464,10 +488,10 @@ log_main = {
     level = set_log_level,
     log_format = set_log_format,
     cfg = setmetatable(log_cfg, {
-        __call = log_configure,
+        __call = function(self, cfg) log_configure(self, cfg, false) end,
     }),
     box_api = {
-        cfg = function() log_configure(log_cfg, box_to_log_cfg()) end,
+        cfg = function() log_configure(log_cfg, box_to_log_cfg(), true) end,
         cfg_check = function() log_check_cfg(box_to_log_cfg()) end,
     },
     internal = {

--- a/src/lua/log.lua
+++ b/src/lua/log.lua
@@ -456,6 +456,9 @@ local compat_v16 = {
     end;
 }
 
+-- Log registry. It stores loggers, created by log_new, each of them having a
+-- custom name. Allows to return same logger on consequent require('log') calls.
+local log_registry = {}
 -- Forward declaration.
 local log_main
 
@@ -465,6 +468,10 @@ local function log_new(name)
         error('Illegal parameters, name should be a string')
     end
 
+    if log_registry[name] ~= nil then
+        return log_registry[name]
+    end
+
     local log = table.copy(log_main)
     log.name = name
     log.error = say_closure(log, S_ERROR)
@@ -472,6 +479,7 @@ local function log_new(name)
     log.info = say_closure(log, S_INFO)
     log.verbose = say_closure(log, S_VERBOSE)
     log.debug = say_closure(log, S_DEBUG)
+    log_registry[name] = log
     return log
 end
 

--- a/test/box-luatest/gh_3211_module/testmod.lua
+++ b/test/box-luatest/gh_3211_module/testmod.lua
@@ -1,0 +1,6 @@
+return {
+    say_hello = function()
+        local log = require('log')
+        log.info('hello')
+    end
+}

--- a/test/box-luatest/gh_3211_per_module_log_level_test.lua
+++ b/test/box-luatest/gh_3211_per_module_log_level_test.lua
@@ -164,3 +164,15 @@ g2.test_per_module_log_level = function(cg)
     find_in_log(cg, 'info from module3', true)
     find_in_log(cg, 'debug from module3', true)
 end
+
+-- Test automatic module name deduction.
+g1.test_modname_deduction = function(cg)
+    -- Check that consequent calls to require('log') return the same logger.
+    t.assert(require('log') == require('log'))
+
+    cg.server:exec(function()
+        local module = require('test.box-luatest.gh_3211_module.testmod')
+        module.say_hello()
+    end)
+    find_in_log(cg, 'testmod I> hello', true)
+end

--- a/test/box-luatest/gh_3211_per_module_log_level_test.lua
+++ b/test/box-luatest/gh_3211_per_module_log_level_test.lua
@@ -9,13 +9,21 @@ local function find_in_log(cg, str, must_be_present)
 end
 
 local g1 = t.group('gh-3211-1')
-
+local g2 = t.group('gh-3211-2', {{cfg_type = 'log_cfg'},
+                                 {cfg_type = 'box_cfg'}})
 g1.before_each(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end)
+g2.before_each(function(cg)
     cg.server = server:new({alias = 'master'})
     cg.server:start()
 end)
 
 g1.after_each(function(cg)
+    cg.server:drop()
+end)
+g2.after_each(function(cg)
     cg.server:drop()
 end)
 
@@ -39,4 +47,120 @@ g1.test_log_new = function(cg)
     find_in_log(cg, 'info from the default log', true)
     find_in_log(cg, 'module1 I> info from the first module', true)
     find_in_log(cg, 'module2 I> info from the second module', true)
+end
+
+-- Test log.cfg{modules = {...}} and box.cfg{log_modules = {...}}
+g2.test_per_module_log_level = function(cg)
+    local cfg_type = cg.params.cfg_type
+
+    cg.server:exec(function(cfg_type)
+        local t = require('luatest')
+        local log = require('log')
+        local log2box_keys = {
+            ['level']   = 'log_level',
+            ['modules'] = 'log_modules'
+        }
+        local function log2box_cfg(log_params)
+            local box_params = {}
+            for k, v in pairs(log_params) do
+                box_params[log2box_keys[k]] = v
+            end
+            return box_params
+        end
+        local function log_cfg(params)
+            if cfg_type == 'log_cfg' then
+                log.cfg(params)
+            elseif cfg_type == 'box_cfg' then
+                box.cfg(log2box_cfg(params))
+            end
+        end
+        local function assert_log_and_box_cfg_equals()
+            t.assert_equals(log.cfg.level, box.cfg.log_level)
+            t.assert_equals(log.cfg.modules.mod1, box.cfg.log_modules.mod1)
+            t.assert_equals(log.cfg.modules.mod2, box.cfg.log_modules.mod2)
+            t.assert_equals(log.cfg.modules.mod3, box.cfg.log_modules.mod3)
+            t.assert_equals(log.cfg.modules.mod4, box.cfg.log_modules.mod4)
+        end
+
+        t.assert_error_msg_contains(
+           "modules': should be of type table",
+            log_cfg, {modules = 'hello'})
+        t.assert_error_msg_content_equals(
+            "Incorrect value for option 'log_modules.mod1': " ..
+            "should be one of types number, string",
+            log_cfg, {modules = {mod1 = {}}})
+        t.assert_error_msg_content_equals(
+            "Incorrect value for option 'log_modules.mod2': " ..
+            "expected crit,warn,info,debug,syserror,verbose,fatal,error",
+            log_cfg, {modules = {mod2 = 'hello'}})
+        t.assert_error_msg_content_equals(
+            "Incorrect value for option 'module name': should be of type string",
+            log_cfg, {modules = {[123] = 'debug'}})
+
+        t.assert_equals(log.cfg.modules, nil)
+        t.assert_equals(box.cfg.log_modules, nil)
+        log_cfg{level = 'info', modules = {mod1 = 'debug',
+                                           ['mod2'] = 2,
+                                           mod3 = 'error'}}
+        -- Check that log.cfg{} without 'modules' options doesn't affect
+        -- per-module levels.
+        log_cfg{level = 'warn'}
+        t.assert_equals(log.cfg.level, 'warn')
+        t.assert_equals(log.cfg.modules.mod1, 'debug')
+        t.assert_equals(log.cfg.modules.mod2, 2)
+        t.assert_equals(log.cfg.modules.mod3, 'error')
+        assert_log_and_box_cfg_equals()
+        --[[ TODO(gh-7962)
+        -- Check that log.cfg{modules = {...}} with the new modules appends them
+        -- to the existing ones.
+        log_cfg{modules = {mod4 = 4}}
+        t.assert_equals(log.cfg.modules.mod1, 'debug')
+        t.assert_equals(log.cfg.modules.mod2, 2)
+        t.assert_equals(log.cfg.modules.mod3, 'error')
+        t.assert_equals(log.cfg.modules.mod4, 4)
+        assert_log_and_box_cfg_equals()
+        -- Check that log.cfg{modules = {...}} sets levels for the specified
+        -- modules, and doesn't affect other modules.
+        log_cfg{modules = {mod1 = 0, mod3 = 'info'}}
+        t.assert_equals(log.cfg.modules.mod1, 0)
+        t.assert_equals(log.cfg.modules.mod2, 2)
+        t.assert_equals(log.cfg.modules.mod3, 'info')
+        t.assert_equals(log.cfg.modules.mod4, 4)
+        assert_log_and_box_cfg_equals()
+        -- Check that box.NULL and the empty string remove the corresponding
+        -- module from the config.
+        log_cfg{modules = {mod2 = box.NULL, mod4 = ''}}
+        t.assert_equals(log.cfg.modules.mod1, 0)
+        t.assert_equals(log.cfg.modules.mod2, nil)
+        t.assert_equals(log.cfg.modules.mod3, 'info')
+        t.assert_equals(log.cfg.modules.mod4, nil)
+        assert_log_and_box_cfg_equals()
+        -- Check that log.cfg{modules = box.NULL} removes all modules.
+        log_cfg{modules = box.NULL}
+        t.assert_equals(log.cfg.modules, nil)
+        t.assert_equals(box.cfg.log_modules, nil)
+        --]]
+        -- Check that log levels actually affect what is printed to the log.
+        log_cfg{level = 'info', modules = {module2 = 4,
+                                           module3 = 'debug'}}
+        for n = 1, 3 do
+            local logn = log.new('module' .. n)
+            logn.warn('warn from ' .. logn.name)
+            logn.info('info from ' .. logn.name)
+            logn.debug('debug from ' .. logn.name)
+        end
+    end, {cfg_type})
+
+    -- module1 has default log level ('info')
+    find_in_log(cg, 'warn from module1', true)
+    find_in_log(cg, 'info from module1', true)
+    find_in_log(cg, 'debug from module1', false)
+    -- module2 log level is 4 ('warn')
+    find_in_log(cg, 'warn from module2', true)
+    find_in_log(cg, 'info from module2', false)
+    find_in_log(cg, 'debug from module2', false)
+    -- module3 log level is 'debug'
+    find_in_log(cg, 'warn from module3', true)
+    find_in_log(cg, 'info from module3', true)
+    find_in_log(cg, 'debug from module3', true)
 end

--- a/test/box-luatest/gh_3211_per_module_log_level_test.lua
+++ b/test/box-luatest/gh_3211_per_module_log_level_test.lua
@@ -1,0 +1,42 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local function find_in_log(cg, str, must_be_present)
+    t.helpers.retrying({timeout = 0.3, delay = 0.1}, function()
+        local found = cg.server:grep_log(str) ~= nil
+        t.assert(found == must_be_present)
+    end)
+end
+
+local g1 = t.group('gh-3211-1')
+
+g1.before_each(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end)
+
+g1.after_each(function(cg)
+    cg.server:drop()
+end)
+
+-- Test log.new{...}
+g1.test_log_new = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local log = require('log')
+        t.assert_error_msg_content_equals(
+            "Illegal parameters, name should be a string", log.new)
+        t.assert_error_msg_content_equals(
+            "Illegal parameters, name should be a string", log.new, 123)
+
+        local log1 = log.new('module1')
+        local log2 = log.new('module2')
+        log.info('info from the default log')
+        log1.info('info from the first module')
+        log2.info('info from the second module')
+    end)
+
+    find_in_log(cg, 'info from the default log', true)
+    find_in_log(cg, 'module1 I> info from the first module', true)
+    find_in_log(cg, 'module2 I> info from the second module', true)
+end

--- a/test/box-luatest/gh_7860_syslog_json_test.lua
+++ b/test/box-luatest/gh_7860_syslog_json_test.lua
@@ -49,6 +49,7 @@ g.before_all(function(cg)
             line = 28,
             level = 'WARN',
             message = expected_msg,
+            module = "test.box-luatest.gh_7860_syslog_json_test",
             pid = cg.pid,
         })
     end
@@ -59,7 +60,8 @@ g.before_all(function(cg)
         t.assert_str_matches(
             hdr,
             '<%d+>%a+%s+%d%d?%s+%d%d:%d%d:%d%d%s+tt%[' .. cg.pid .. '%]:%s' ..
-            'main/%d+/main%sgh_7860_syslog_json_test%.lua:28')
+            'main/%d+/main/test%.box%-luatest%.gh_7860_syslog_json_test%s' ..
+            'gh_7860_syslog_json_test%.lua:28')
         t.assert_equals(msg, expected_msg .. '\n')
     end
 end)

--- a/test/unit/say.c
+++ b/test/unit/say.c
@@ -53,12 +53,13 @@ parse_syslog_opts(const char *input)
 
 static int
 format_func_custom(struct log *log, char *buf, int len, int level,
-		   const char *filename, int line, const char *error,
-		   const char *format, va_list ap)
+		   const char *module, const char *filename, int line,
+		   const char *error, const char *format, va_list ap)
 {
 	int total = 0;
 	(void) log;
 	(void) level;
+	(void)module;
 	(void) filename;
 	(void) line;
 	(void) error;


### PR DESCRIPTION
**log: add log.new() function that creates a new logger**
It allows to create a new instance of a log module, with a custom name, e.g.:
```lua
local my_log = require('log').new('my_module')
```

The name is added to the log message after fiber name:
```
YYYY-MM-DD hh:mm:ss.ms [PID]: CORD/FID/FIBERNAME/MODULENAME LEVEL> MSG
```

**log: add per-module log level setting via log.cfg() or box.cfg()**
Now it is possible to specify the log level for each module separately, e.g.:
```lua
box.cfg {
    log_level = 5,
    log_modules = {
        ['foo.bar'] = 1,
        expirationd = 'debug'
    }
}
```
The name of a module is determined automatically, or it is possible to create a logger with a custom name by using `log.new()`.

**log: implement automatic module name deduction**
The name of a module is determined automatically during the execution of `require('log')` in the module's source code. The name is derived from its filename, including a part of the path. This is implemented by overriding the built-in `require` function.

Closes #3211