### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-7230-luajit-fixes.md
+++ b/changelogs/unreleased/gh-7230-luajit-fixes.md
@@ -4,3 +4,9 @@ Backported patches from vanilla LuaJIT trunk (gh-7230). In the scope of this
 activity, the following issues have been resolved:
 
 * Fix handling of errors during trace snapshot restore.
+
+## feature/luajit
+Backported patches from vanilla LuaJIT trunk (gh-7230). In the scope of this
+activity, the following features is completed:
+
+* `assert()` now accepts any type of error object (from Lua 5.3).


### PR DESCRIPTION
* From Lua 5.3: assert() accepts any type of error object.

Closes #7457
Part of #7230

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump