### PR TITLE
memtx: fix TREE index `get` check for part count

### DIFF
--- a/changelogs/unreleased/gh-7685-memtx-tree-idx-get-with-nullable-field-phantom-read.md
+++ b/changelogs/unreleased/gh-7685-memtx-tree-idx-get-with-nullable-field-phantom-read.md
@@ -1,0 +1,4 @@
+## bugfix/memtx
+
+* Fixed possibility of phantom reads with `get` on TREE index containing
+  nullable part (gh-7685).

--- a/src/box/index_def.c
+++ b/src/box/index_def.c
@@ -97,13 +97,9 @@ index_def_new(uint32_t space_id, uint32_t iid, const char *name,
 	def->key_def = key_def_dup(key_def);
 	if (iid != 0) {
 		def->cmp_def = key_def_merge(key_def, pk_def);
-		if (! opts->is_unique) {
-			def->cmp_def->unique_part_count =
-				def->cmp_def->part_count;
-		} else {
+		if (opts->is_unique)
 			def->cmp_def->unique_part_count =
 				def->key_def->part_count;
-		}
 	} else {
 		def->cmp_def = key_def_dup(key_def);
 	}

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -925,9 +925,9 @@ memtx_tree_index_get_internal(struct index *base, const char *key,
 		memtx_tree_find(&index->tree, &key_data);
 	if (res == NULL) {
 		*result = NULL;
-		if (part_count == cmp_def->part_count)
+		assert(part_count == cmp_def->unique_part_count);
 /********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND START*********/
-			memtx_tx_track_point(txn, space, base, key);
+		memtx_tx_track_point(txn, space, base, key);
 /*********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND END**********/
 		return 0;
 	}

--- a/test/box-luatest/gh_7685_memtx_tree_idx_get_with_nullable_field_phantom_read_test.lua
+++ b/test/box-luatest/gh_7685_memtx_tree_idx_get_with_nullable_field_phantom_read_test.lua
@@ -1,0 +1,66 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new{
+        alias   = 'dflt',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.before_each(function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('s')
+        s:create_index('pk')
+        s:create_index('sk', {parts = {{2, 'uint', is_nullable = true}}})
+    end)
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        box.space.s:drop()
+    end)
+end)
+
+--[[
+Checks that phantom reads with `get` from nullable TREE index are not allowed.
+]]
+g.test_memtx_tree_idx_get_with_nullable_field_phantom_read = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local txn_proxy = require('test.box.lua.txn_proxy')
+
+        local tx = txn_proxy:new()
+        tx:begin()
+
+        tx('box.space.s.index[1]:get{0}')
+        box.space.s:replace{0, 0}
+        t.assert_equals(tx('box.space.s.index[1]:get{0}'), '')
+    end)
+end
+
+--[[
+Checks that reads with `get` from nullable TREE index are tracked correctly.
+]]
+g.test_memtx_tree_idx_get_with_nullable_field_read_tracked = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local txn_proxy = require('test.box.lua.txn_proxy')
+
+        local tx = txn_proxy:new()
+        tx:begin()
+
+        tx('box.space.s.index[1]:get{0}')
+        tx('box.space.s:replace{1, 1}')
+        box.space.s:replace{0, 0}
+        t.assert_equals(tx:commit(),
+                        {{error = 'Transaction has been aborted by conflict'}})
+    end)
+end


### PR DESCRIPTION
**memtx: fix TREE index `get` check for part count**
If TREE index `get` result is empty, the key part count is incorrectly
compared to the tree's `cmp_def->part_count`, though it should be compared
with `cmp_def->unique_part_count`. But we can actually assume that by the
time we get to the index's `get` method the part count is equal to the
unique part count (partial keys are rejected and `get` is not
supported for non-unique indexes): change check to correct assertion.

Closes #7685

**memtx: refactor `index_def_new`**

Since `key_def_merge` sets the merged key definition's unique part count
equal to the new part count, the extra assignment in case the index is not
unique is redundant: remove it.