### PR TITLE
[1.10] test: bump test-run to new version

### DIFF
--- a/test/app/suite.ini
+++ b/test/app/suite.ini
@@ -3,7 +3,6 @@ core = tarantool
 description = application server tests
 script = app.lua
 lua_libs = lua/fiber.lua
-use_unix_sockets = True
 use_unix_sockets_iproto = True
 is_parallel = True
 fragile = {

--- a/test/box-py/suite.ini
+++ b/test/box-py/suite.ini
@@ -3,7 +3,6 @@ core = tarantool
 description = legacy python tests
 script = box.lua
 lua_libs = lua/fiber.lua lua/fifo.lua
-use_unix_sockets = True
 is_parallel = True
 fragile = {
     "retries": 10,

--- a/test/box/suite.ini
+++ b/test/box/suite.ini
@@ -7,7 +7,6 @@ long_run = huge_field_map_long.test.lua
 config = engine.cfg
 release_disabled = errinj.test.lua errinj_index.test.lua rtree_errinj.test.lua upsert_errinj.test.lua iproto_stress.test.lua gh-4648-func-load-unload.test.lua net.box_discard_console_request_gh-6249.test.lua gh-6092-invalid-listen-uri.test.lua
 lua_libs = lua/fifo.lua lua/utils.lua lua/bitset.lua lua/index_random_test.lua lua/push.lua lua/identifier.lua
-use_unix_sockets = True
 use_unix_sockets_iproto = True
 is_parallel = True
 fragile = {

--- a/test/engine/suite.ini
+++ b/test/engine/suite.ini
@@ -2,7 +2,6 @@
 core = tarantool
 description = tarantool multiengine tests
 script = box.lua
-use_unix_sockets = True
 use_unix_sockets_iproto = True
 release_disabled = errinj.test.lua
 config = engine.cfg

--- a/test/engine_long/suite.ini
+++ b/test/engine_long/suite.ini
@@ -4,7 +4,6 @@ description = tarantool engine stress tests
 script = box.lua
 long_run =  delete_replace_update.test.lua delete_insert.test.lua
 lua_libs = suite.lua
-use_unix_sockets = True
 use_unix_sockets_iproto = True
 config = engine.cfg
 is_parallel = True

--- a/test/long_run-py/suite.ini
+++ b/test/long_run-py/suite.ini
@@ -6,6 +6,5 @@ long_run =  finalizers.test.py
 valgrind_disabled =
 release_disabled =
 lua_libs = suite.lua
-use_unix_sockets = True
 use_unix_sockets_iproto = True
 is_parallel = True

--- a/test/replication-py/init_storage.test.py
+++ b/test/replication-py/init_storage.test.py
@@ -1,7 +1,5 @@
 from __future__ import print_function
 
-import os
-import glob
 from lib.tarantool_server import TarantoolStartError
 from lib.tarantool_server import TarantoolServer
 
@@ -10,19 +8,20 @@ master = server
 master_id = master.get_param("id")
 master.admin("box.schema.user.grant('guest', 'replication')")
 
+# replica server
+replica = TarantoolServer(server.ini)
+replica.script = "replication-py/replica.lua"
+replica.vardir = server.vardir
+replica.rpl_master = master
+
 print("-------------------------------------------------------------")
 print("gh-484: JOIN doesn't save data to snapshot with TREE index")
 print("-------------------------------------------------------------")
 
 master.admin("space = box.schema.space.create('test', {id =  42})")
 master.admin("index = space:create_index('primary', { type = 'tree'})")
-
 master.admin("for k = 1, 9 do space:insert{k, k*k} end")
 
-replica = TarantoolServer(server.ini)
-replica.script = "replication-py/replica.lua"
-replica.vardir = server.vardir
-replica.rpl_master = master
 replica.deploy()
 replica.admin("box.space.test:select()")
 
@@ -40,12 +39,7 @@ master.admin("for k = 10, 19 do box.space[42]:insert{k, k*k*k} end")
 master.admin("for k = 20, 29 do box.space[42]:upsert({k}, {}) end")
 lsn = master.get_lsn(master_id)
 
-replica = TarantoolServer(server.ini)
-replica.script = "replication-py/replica.lua"
-replica.vardir = server.vardir
-replica.rpl_master = master
 replica.deploy()
-
 replica.admin("space = box.space.test");
 replica.wait_lsn(master_id, lsn)
 for i in range(1, 20):
@@ -59,10 +53,6 @@ print("reconnect on JOIN/SUBSCRIBE")
 print("-------------------------------------------------------------")
 
 server.stop()
-replica = TarantoolServer(server.ini)
-replica.script = "replication-py/replica.lua"
-replica.vardir = server.vardir
-replica.rpl_master = master
 replica.deploy(wait=False)
 
 print("waiting reconnect on JOIN...")

--- a/test/replication-py/multi.test.py
+++ b/test/replication-py/multi.test.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 
-import sys
 import os
 from lib.tarantool_server import TarantoolServer
 import yaml
@@ -36,7 +35,7 @@ for i in range(REPLICA_N - 1):
 # Make a list of servers
 sources = []
 for server in cluster:
-    sources.append(yaml.safe_load(server.admin("box.cfg.listen", silent = True))[0])
+    sources.append(server.iproto.uri)
     server.id = server.get_param("id")
 
 print("done")

--- a/test/replication-py/suite.ini
+++ b/test/replication-py/suite.ini
@@ -2,7 +2,7 @@
 core = tarantool
 script =  master.lua
 description = tarantool/box, replication
-use_unix_sockets = True
+use_unix_sockets_iproto = True
 is_parallel = True
 fragile = {
     "retries": 10,

--- a/test/replication-py/swap.test.py
+++ b/test/replication-py/swap.test.py
@@ -1,10 +1,7 @@
 from __future__ import print_function
 
 import os
-import tarantool
 from lib.tarantool_server import TarantoolServer
-import re
-import yaml
 
 REPEAT = 20
 ID_BEGIN = 0

--- a/test/replication-py/swap.test.py
+++ b/test/replication-py/swap.test.py
@@ -43,7 +43,7 @@ master.uri = "{}:{}@{}".format(LOGIN, PASSWORD, master.iproto.uri)
 os.putenv("MASTER", master.uri)
 
 # replica server
-replica = TarantoolServer()
+replica = TarantoolServer(server.ini)
 replica.script = "replication-py/replica.lua"
 replica.vardir = server.vardir
 replica.deploy()

--- a/test/replication/suite.ini
+++ b/test/replication/suite.ini
@@ -6,7 +6,6 @@ disabled = consistent.test.lua
 release_disabled = catch.test.lua errinj.test.lua gc.test.lua gc_no_space.test.lua before_replace.test.lua recover_missing_xlog.test.lua sync.test.lua gh-4040-invalid-msgpack.test.lua
 config = suite.cfg
 lua_libs = lua/fast_replica.lua lua/rlimit.lua
-use_unix_sockets = True
 use_unix_sockets_iproto = True
 long_run = prune.test.lua
 is_parallel = True

--- a/test/vinyl/suite.ini
+++ b/test/vinyl/suite.ini
@@ -5,7 +5,6 @@ script = vinyl.lua
 release_disabled = errinj.test.lua errinj_ddl.test.lua errinj_gc.test.lua errinj_stat.test.lua errinj_tx.test.lua errinj_vylog.test.lua partial_dump.test.lua quota_timeout.test.lua recovery_quota.test.lua replica_rejoin.test.lua gh-4864-stmt-alloc-fail-compact.test.lua gh-4805-open-run-err-recovery.test.lua gh-4821-ddl-during-throttled-dump.test.lua gh-3395-read-prepared-uncommitted.test.lua gh-4957-too-many-upserts.test.lua gh-5823-skip-newer-than-snap-vylog.test.lua gh-5436-vylog-gc-during-compaction.test.lua gh-6448-deferred-delete-in-dropped-space.test.lua
 config = suite.cfg
 lua_libs = suite.lua stress.lua large.lua txn_proxy.lua ../box/lua/utils.lua
-use_unix_sockets = True
 use_unix_sockets_iproto = True
 long_run = stress.test.lua large.test.lua write_iterator_rand.test.lua dump_stress.test.lua select_consistency.test.lua throttle.test.lua
 is_parallel = False

--- a/test/wal_off/suite.ini
+++ b/test/wal_off/suite.ini
@@ -2,7 +2,6 @@
 core = tarantool
 script = wal.lua
 description = tarantool/box, wal_mode = none
-use_unix_sockets = True
 use_unix_sockets_iproto = True
 is_parallel = True
 disabled = iterator_lt_gt.test.lua

--- a/test/xlog-py/suite.ini
+++ b/test/xlog-py/suite.ini
@@ -3,6 +3,5 @@ core = tarantool
 description = legacy python tests
 script = box.lua
 lua_libs = lua/fiber.lua lua/fifo.lua
-use_unix_sockets = True
 use_unix_sockets_iproto = True
 is_parallel = True

--- a/test/xlog/suite.ini
+++ b/test/xlog/suite.ini
@@ -6,7 +6,6 @@ disabled = snap_io_rate.test.lua
 valgrind_disabled =
 release_disabled = errinj.test.lua panic_on_lsn_gap.test.lua panic_on_broken_lsn.test.lua
 config = suite.cfg
-use_unix_sockets = True
 use_unix_sockets_iproto = True
 long_run = snap_io_rate.test.lua
 is_parallel = True


### PR DESCRIPTION
Bump test-run to new version with the following improvements:

- Report job summary on GitHub Actions [1]
- Free port auto resolving for TarantoolServer and AppServer [2]
- Improve getting iproto port for tarantool < 2.4.1 [3]

Also, this patch includes the following changes:

- removing `use_unix_sockets` option from all suite.ini config files
  due to permanent using Unix sockets for admin connection recently
  introduced in test-run
- switching replication-py tests to Unix sockets for iproto connection
- fixing replication-py/swap.test.py test

[1] tarantool/test-run#341
[2] tarantool/test-run#348
[3] tarantool/test-run#349