### PR TITLE
datetime: fix interval arithmetic across DST boundaries

### DIFF
--- a/changelogs/unreleased/gh-7698-datetime-subtraction-with-tz.md
+++ b/changelogs/unreleased/gh-7698-datetime-subtraction-with-tz.md
@@ -1,0 +1,28 @@
+## bugfix/datetime
+
+* Fixed subtractions for datetimes with different timezones (gh-7698).
+
+  We used to ignore timezone difference (im `tzoffset`) for
+  datetime subtraction operation:
+
+  ```
+  tarantool> datetime.new{tz='MSK'} - datetime.new{tz='UTC'}
+  ---
+  - +0 seconds
+  ...
+  tarantool> datetime.new{tz='MSK'}.timestamp -
+             datetime.new{tz='UTC'}.timestamp
+  ---
+  - -10800
+  ...
+  ```
+
+  Now we accumulate that difference to the minute component of
+  a resultant interval:
+
+  ```
+  tarantool> datetime.new{tz='MSK'} - datetime.new{tz='UTC'}
+  ---
+  - -180 minutes
+  ...
+  ```

--- a/changelogs/unreleased/gh-7700-interval-arithmetic-across-dst.md
+++ b/changelogs/unreleased/gh-7700-interval-arithmetic-across-dst.md
@@ -1,0 +1,19 @@
+## bugfix/datetime
+
+* Fixed interval arithmetic for boundaries crossing DST (gh-7700).
+
+  We did not take into consideration the fact that
+  as result of date/time arithmetic we could get
+  in a different timezone, if DST boundary has been
+  crossed during operation.
+
+  ```
+  tarantool> datetime.new{year=2008, month=1, day=1,
+                          tz='Europe/Moscow'} +
+             datetime.interval.new{month=6}
+  ---
+  - 2008-07-01T01:00:00 Europe/Moscow
+  ...
+  ```
+  Now we resolve tzoffset at the end of operation if
+  tzindex is not 0.

--- a/src/lib/core/datetime.c
+++ b/src/lib/core/datetime.c
@@ -844,6 +844,7 @@ datetime_datetime_sub(struct interval *res, const struct datetime *lhs,
 	struct interval inv_rhs;
 	datetime_totable(lhs, res);
 	datetime_totable(rhs, &inv_rhs);
+	res->min -= lhs->tzoffset - rhs->tzoffset;
 	return interval_interval_sub(res, &inv_rhs);
 }
 

--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -12,7 +12,7 @@ local TZ = date.TZ
 --]]
 if jit.arch == 'arm64' then jit.off() end
 
-test:plan(38)
+test:plan(39)
 
 -- minimum supported date - -5879610-06-22
 local MIN_DATE_YEAR = -5879610
@@ -1255,6 +1255,20 @@ test:test("Time interval operations - different adjustments", function(test)
                     ('sub delta to %s with adjust %s'):format(tsbefore, adjust))
         end
     end
+end)
+
+test:test("Time interval operations - different timezones", function(test)
+    test:plan(8)
+    local d1_msk = date.new{tz = 'MSK'}
+    local d1_utc = date.new{tz = 'UTC'}
+    test:is(d1_msk.tzoffset, 180, 'MSK is +180')
+    test:is(d1_utc.tzoffset, 0, 'UTC is 0')
+    test:is(tostring(d1_msk), '1970-01-01T00:00:00 MSK', '1970-01-01 MSK')
+    test:is(tostring(d1_utc), '1970-01-01T00:00:00 UTC', '1970-01-01 UTC')
+    test:is(d1_utc > d1_msk, true, 'utc > msk')
+    test:is(tostring(d1_utc - d1_msk), '+180 minutes', 'utc - msk')
+    test:is(tostring(d1_msk - d1_utc), '-180 minutes', 'msk - utc')
+    test:is(d1_msk.epoch - d1_utc.epoch, -10800, '-10800')
 end)
 
 test:test("Time intervals creation - range checks", function(test)


### PR DESCRIPTION
Interval arithmetic across DST boundaries
===========================

We did not take into consideration the fact that as result of date/time arithmetic we could get in a different timezone, if DST boundary has been crossed during operation.

```
tarantool> datetime.new{year=2008, month=1, day=1, tz='Europe/Moscow'} + datetime.interval.new{month=6}
---
- 2008-07-01T01:00:00 Europe/Moscow
...
```

Now we resolve tzoffset at the end of operation if tzindex is not 0.

Fixes #7700

Timezone differences in subtraction
=======================

We used to ignore timezone difference (im `tzoffset`) for datetime subtraction operation:

```
tarantool> datetime.new{tz='MSK'} - datetime.new{tz='UTC'}
---
- +0 seconds
...

tarantool> datetime.new{tz='MSK'}.timestamp - datetime.new{tz='UTC'}.timestamp
---
- -10800
...
```

Now we use tzoffset difference in the minute component of
resultant interval:

```
tarantool> datetime.new{tz='MSK'} - datetime.new{tz='UTC'}
---
- -180 minutes
...
```

Closes #7698