### PR TITLE
vinyl: implement transaction isolation levels

### DIFF
--- a/changelogs/unreleased/gh-5522-vy-tx-isolation-level.md
+++ b/changelogs/unreleased/gh-5522-vy-tx-isolation-level.md
@@ -1,0 +1,5 @@
+## feature/vinyl
+
+* Added support of transaction isolation levels for the Vinyl engine.
+  The `txn_isolation` option passed to `box.begin()` now has the same
+  effect for Vinyl and memtx (gh-5522).

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -2424,7 +2424,7 @@ vinyl_engine_begin(struct engine *engine, struct txn *txn)
 {
 	struct vy_env *env = vy_env(engine);
 	assert(txn->engine_tx == NULL);
-	txn->engine_tx = vy_tx_begin(env->xm);
+	txn->engine_tx = vy_tx_begin(env->xm, txn->isolation);
 	if (txn->engine_tx == NULL)
 		return -1;
 	return 0;
@@ -3045,7 +3045,7 @@ vinyl_engine_prepare_join(struct engine *engine, void **arg)
 		return -1;
 	}
 	rlist_create(&ctx->entries);
-	ctx->rv = vy_tx_manager_read_view(env->xm);
+	ctx->rv = vy_tx_manager_read_view(env->xm, /*plsn=*/INT64_MAX);
 	if (ctx->rv == NULL) {
 		free(ctx);
 		return -1;

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -3417,7 +3417,7 @@ vy_squash_process(struct vy_squash *squash)
 		if (vy_entry_compare(result, mem_entry, lsm->cmp_def) != 0 ||
 		    vy_stmt_type(mem_entry.stmt) != IPROTO_UPSERT)
 			break;
-		assert(vy_stmt_lsn(mem_entry.stmt) >= MAX_LSN);
+		assert(vy_stmt_is_prepared(mem_entry.stmt));
 		vy_stmt_set_n_upserts(mem_entry.stmt, n_upserts);
 		if (n_upserts <= VY_UPSERT_THRESHOLD)
 			++n_upserts;

--- a/src/box/vy_cache.h
+++ b/src/box/vy_cache.h
@@ -252,6 +252,11 @@ struct vy_cache_iterator {
 	uint32_t version;
 	/* Is false until first .._get or .._next_.. method is called */
 	bool search_started;
+	/**
+	 * The iterator may return prepared (unconfirmed) statements only if
+	 * this flag is set.
+	 */
+	bool is_prepared_ok;
 };
 
 /**
@@ -260,12 +265,13 @@ struct vy_cache_iterator {
  * @param cache - the cache.
  * @param iterator_type - iterator type (EQ, GT, GE, LT, LE or ALL)
  * @param key - search key data in terms of vinyl, vy_entry_compare argument
- * @param vlsn - LSN visibility, iterator shows values with lsn <= vlsn
+ * @param rv - read view.
+ * @param is_prepared_ok - if set, the iterator may return prepared statements.
  */
 void
 vy_cache_iterator_open(struct vy_cache_iterator *itr, struct vy_cache *cache,
 		       enum iterator_type iterator_type, struct vy_entry key,
-		       const struct vy_read_view **rv);
+		       const struct vy_read_view **rv, bool is_prepared_ok);
 
 /**
  * Advance a cache iterator to the next key.

--- a/src/box/vy_lsm.c
+++ b/src/box/vy_lsm.c
@@ -965,7 +965,7 @@ vy_lsm_commit_upsert(struct vy_lsm *lsm, struct vy_mem *mem,
 		     struct vy_entry entry)
 {
 	assert(vy_stmt_type(entry.stmt) == IPROTO_UPSERT);
-	assert(vy_stmt_lsn(entry.stmt) < MAX_LSN);
+	assert(!vy_stmt_is_prepared(entry.stmt));
 	/*
 	 * UPSERT is enabled only for the spaces with the single
 	 * index.

--- a/src/box/vy_mem.h
+++ b/src/box/vy_mem.h
@@ -364,6 +364,19 @@ struct vy_mem_iterator {
 
 	/* Is false until first .._next_.. method is called */
 	bool search_started;
+	/**
+	 * The iterator may return prepared (unconfirmed) statements only if
+	 * this flag is set. If any prepared statements are skipped because of
+	 * this flag, min_skipped_plsn will be set to the min LSN among all
+	 * skipped prepared statements. The transaction is supposed to update
+	 * its read view accordingly to guarantee serializability.
+	 */
+	bool is_prepared_ok;
+	/**
+	 * Initialized to INT64_MAX. Set to the min LSN among all skipped
+	 * prepared statements if is_prepared_ok is false.
+	 */
+	int64_t min_skipped_plsn;
 };
 
 /**
@@ -372,7 +385,8 @@ struct vy_mem_iterator {
 void
 vy_mem_iterator_open(struct vy_mem_iterator *itr, struct vy_mem_iterator_stat *stat,
 		     struct vy_mem *mem, enum iterator_type iterator_type,
-		     struct vy_entry key, const struct vy_read_view **rv);
+		     struct vy_entry key, const struct vy_read_view **rv,
+		     bool is_prepared_ok);
 
 /**
  * Advance a mem iterator to the next key.

--- a/src/box/vy_point_lookup.c
+++ b/src/box/vy_point_lookup.c
@@ -97,7 +97,7 @@ vy_point_lookup_scan_mem(struct vy_lsm *lsm, struct vy_mem *mem,
 {
 	struct vy_mem_iterator mem_itr;
 	vy_mem_iterator_open(&mem_itr, &lsm->stat.memory.iterator,
-			     mem, ITER_EQ, key, rv);
+			     mem, ITER_EQ, key, rv, /*is_prepared_ok=*/true);
 	struct vy_history mem_history;
 	vy_history_create(&mem_history, &lsm->env->history_node_pool);
 	int rc = vy_mem_iterator_next(&mem_itr, &mem_history);

--- a/src/box/vy_read_iterator.c
+++ b/src/box/vy_read_iterator.c
@@ -615,9 +615,9 @@ vy_read_iterator_add_cache(struct vy_read_iterator *itr)
 	enum iterator_type iterator_type = (itr->iterator_type != ITER_REQ ?
 					    itr->iterator_type : ITER_LE);
 	struct vy_read_src *sub_src = vy_read_iterator_add_src(itr);
-	vy_cache_iterator_open(&sub_src->cache_iterator,
-			       &itr->lsm->cache, iterator_type,
-			       itr->key, itr->read_view);
+	vy_cache_iterator_open(&sub_src->cache_iterator, &itr->lsm->cache,
+			       iterator_type, itr->key, itr->read_view,
+			       /*is_prepared_ok=*/true);
 }
 
 static void

--- a/src/box/vy_read_iterator.c
+++ b/src/box/vy_read_iterator.c
@@ -632,7 +632,8 @@ vy_read_iterator_add_mem(struct vy_read_iterator *itr)
 	assert(lsm->mem != NULL);
 	sub_src = vy_read_iterator_add_src(itr);
 	vy_mem_iterator_open(&sub_src->mem_iterator, &lsm->stat.memory.iterator,
-			     lsm->mem, iterator_type, itr->key, itr->read_view);
+			     lsm->mem, iterator_type, itr->key, itr->read_view,
+			     /*is_prepared_ok=*/true);
 	/* Add sealed in-memory indexes. */
 	struct vy_mem *mem;
 	rlist_foreach_entry(mem, &lsm->sealed, in_sealed) {
@@ -640,7 +641,7 @@ vy_read_iterator_add_mem(struct vy_read_iterator *itr)
 		vy_mem_iterator_open(&sub_src->mem_iterator,
 				     &lsm->stat.memory.iterator,
 				     mem, iterator_type, itr->key,
-				     itr->read_view);
+				     itr->read_view, /*is_prepared_ok=*/true);
 	}
 }
 

--- a/src/box/vy_stmt.h
+++ b/src/box/vy_stmt.h
@@ -201,6 +201,13 @@ vy_stmt_set_lsn(struct tuple *stmt, int64_t lsn)
 	((struct vy_stmt *) stmt)->lsn = lsn;
 }
 
+/** Return true if the statement was prepared, but not yet written to WAL. */
+static inline bool
+vy_stmt_is_prepared(struct tuple *stmt)
+{
+	return vy_stmt_lsn(stmt) >= MAX_LSN;
+}
+
 /** Get type of the vinyl statement. */
 static inline enum iproto_type
 vy_stmt_type(struct tuple *stmt)

--- a/src/box/vy_tx.h
+++ b/src/box/vy_tx.h
@@ -142,6 +142,8 @@ write_set_search_key(write_set_t *tree, struct vy_lsm *lsm,
 struct vy_tx {
 	/** Link in vy_tx_manager::writers. */
 	struct rlist in_writers;
+	/** Link in vy_tx_manager::prepared. */
+	struct rlist in_prepared;
 	/** Transaction manager. */
 	struct vy_tx_manager *xm;
 	/**
@@ -223,14 +225,14 @@ struct vy_tx_manager {
 	 */
 	int64_t psn;
 	/**
-	 * The last prepared (but not committed) transaction,
-	 * or NULL if there are no prepared transactions.
-	 */
-	struct vy_tx *last_prepared_tx;
-	/**
 	 * List of rw transactions, linked by vy_tx::in_writers.
 	 */
 	struct rlist writers;
+	/**
+	 * List of prepared (but not committed) transaction,
+	 * sorted by PSN ascending, linked by vy_tx::in_prepared.
+	 */
+	struct rlist prepared;
 	/**
 	 * The list of TXs with a read view in order of vlsn.
 	 */

--- a/test/box-luatest/suite.ini
+++ b/test/box-luatest/suite.ini
@@ -2,5 +2,5 @@
 core = luatest
 description = Database tests
 is_parallel = True
-release_disabled = gh_6819_iproto_watch_not_implemented_test.lua gh_6930_mvcc_net_box_iso_test.lua
+release_disabled = gh_6819_iproto_watch_not_implemented_test.lua
 long_run = gh_7605_qsort_recovery_test.lua gh_7670_memtx_tx_manager_idx_rand_inconsistency_test.lua

--- a/test/replication/gh-5167-qsync-rollback-snap.result
+++ b/test/replication/gh-5167-qsync-rollback-snap.result
@@ -71,7 +71,20 @@ test_run:switch('replica')
 fiber = require('fiber')
  | ---
  | ...
-test_run:wait_cond(function() return box.space.sync:count() == 1 end)
+test_run:cmd("setopt delimiter ';'")
+ | ---
+ | - true
+ | ...
+test_run:wait_cond(function()
+    box.begin({txn_isolation = 'read-committed'})
+    local ret = box.space.sync:count()
+    box.commit()
+    return ret == 1
+end);
+ | ---
+ | - true
+ | ...
+test_run:cmd("setopt delimiter ''");
  | ---
  | - true
  | ...

--- a/test/replication/gh-5167-qsync-rollback-snap.test.lua
+++ b/test/replication/gh-5167-qsync-rollback-snap.test.lua
@@ -29,7 +29,14 @@ end)
 
 test_run:switch('replica')
 fiber = require('fiber')
-test_run:wait_cond(function() return box.space.sync:count() == 1 end)
+test_run:cmd("setopt delimiter ';'")
+test_run:wait_cond(function()
+    box.begin({txn_isolation = 'read-committed'})
+    local ret = box.space.sync:count()
+    box.commit()
+    return ret == 1
+end);
+test_run:cmd("setopt delimiter ''");
 -- Snapshot will stuck in WAL thread on rotation before starting wait on the
 -- limbo.
 box.error.injection.set("ERRINJ_WAL_DELAY", true)

--- a/test/replication/qsync_snapshots.result
+++ b/test/replication/qsync_snapshots.result
@@ -213,7 +213,20 @@ fiber = require('fiber')
 box.cfg{replication_synchro_timeout=1000}
  | ---
  | ...
-test_run:wait_cond(function() return box.space.sync:count() == 1 end)
+test_run:cmd("setopt delimiter ';'")
+ | ---
+ | - true
+ | ...
+test_run:wait_cond(function()
+    box.begin({txn_isolation = 'read-committed'})
+    local ret = box.space.sync:count()
+    box.commit()
+    return ret == 1
+end);
+ | ---
+ | - true
+ | ...
+test_run:cmd("setopt delimiter ''");
  | ---
  | - true
  | ...

--- a/test/replication/qsync_snapshots.test.lua
+++ b/test/replication/qsync_snapshots.test.lua
@@ -100,7 +100,14 @@ end)
 test_run:switch('replica')
 fiber = require('fiber')
 box.cfg{replication_synchro_timeout=1000}
-test_run:wait_cond(function() return box.space.sync:count() == 1 end)
+test_run:cmd("setopt delimiter ';'")
+test_run:wait_cond(function()
+    box.begin({txn_isolation = 'read-committed'})
+    local ret = box.space.sync:count()
+    box.commit()
+    return ret == 1
+end);
+test_run:cmd("setopt delimiter ''");
 ok, err = nil
 f = fiber.create(function() ok, err = pcall(box.snapshot) end)
 

--- a/test/sql/errinj.result
+++ b/test/sql/errinj.result
@@ -137,6 +137,12 @@ box.execute('drop table test')
 -- policy, SQL responses could be corrupted, when DDL/DML is mixed
 -- with DQL. Same as gh-3255.
 --
+txn_isolation_default = box.cfg.txn_isolation
+---
+...
+box.cfg{txn_isolation = 'read-committed'}
+---
+...
 box.execute('CREATE TABLE test (id integer primary key)')
 ---
 - row_count: 1
@@ -169,6 +175,9 @@ box.execute('DROP TABLE test')
 - row_count: 1
 ...
 box.schema.user.revoke('guest', 'read,write,execute', 'universe')
+---
+...
+box.cfg{txn_isolation = txn_isolation_default}
 ---
 ...
 ----

--- a/test/sql/errinj.test.lua
+++ b/test/sql/errinj.test.lua
@@ -48,6 +48,9 @@ box.execute('drop table test')
 -- policy, SQL responses could be corrupted, when DDL/DML is mixed
 -- with DQL. Same as gh-3255.
 --
+txn_isolation_default = box.cfg.txn_isolation
+box.cfg{txn_isolation = 'read-committed'}
+
 box.execute('CREATE TABLE test (id integer primary key)')
 cn = remote.connect(box.cfg.listen)
 
@@ -60,6 +63,7 @@ errinj.set("ERRINJ_IPROTO_TX_DELAY", false)
 
 box.execute('DROP TABLE test')
 box.schema.user.revoke('guest', 'read,write,execute', 'universe')
+box.cfg{txn_isolation = txn_isolation_default}
 
 ----
 ---- gh-3273: Move SQL TRIGGERs into server.

--- a/test/unit/vy_cache.c
+++ b/test/unit/vy_cache.c
@@ -83,7 +83,8 @@ test_basic(void)
 	struct vy_read_view rv;
 	rv.vlsn = INT64_MAX;
 	const struct vy_read_view *rv_p = &rv;
-	vy_cache_iterator_open(&itr, &cache, ITER_GE, select_all, &rv_p);
+	vy_cache_iterator_open(&itr, &cache, ITER_GE, select_all, &rv_p,
+			       /*is_prepared_ok=*/true);
 
 	/* Start iterator and make several steps. */
 	struct vy_entry ret;
@@ -128,14 +129,234 @@ test_basic(void)
 	footer();
 }
 
+static const char *
+lsn_str(int64_t lsn)
+{
+	char *buf = tt_static_buf();
+	if (lsn == INT64_MAX) {
+		return "INT64_MAX";
+	} else if (lsn > MAX_LSN) {
+		snprintf(buf, TT_STATIC_BUF_LEN, "MAX_LSN+%lld",
+			 (long long)(lsn - MAX_LSN));
+	} else {
+		snprintf(buf, TT_STATIC_BUF_LEN, "%lld", (long long)lsn);
+	}
+	return buf;
+}
+
+static const char *
+iterator_type_str(int type)
+{
+	switch (type) {
+	case ITER_EQ: return "EQ";
+	case ITER_GE: return "GE";
+	case ITER_GT: return "GT";
+	case ITER_LE: return "LE";
+	case ITER_LT: return "LT";
+	default:
+		unreachable();
+	}
+}
+
+struct test_iterator_expected {
+	struct vy_stmt_template stmt;
+	bool stop;
+};
+
+static void
+test_iterator_helper(
+		struct vy_cache *cache, struct key_def *key_def,
+		struct tuple_format *format, enum iterator_type type,
+		const struct vy_stmt_template *key_template,
+		int64_t vlsn, bool is_prepared_ok,
+		const struct test_iterator_expected *expected,
+		int expected_count, bool expected_stop)
+{
+	struct vy_read_view rv;
+	rv.vlsn = vlsn;
+	const struct vy_read_view *prv = &rv;
+	struct vy_cache_iterator it;
+	struct vy_history history;
+	vy_history_create(&history, &history_node_pool);
+	struct vy_entry key = vy_new_simple_stmt(format, key_def,
+						 key_template);
+	vy_cache_iterator_open(&it, cache, type, key, &prv, is_prepared_ok);
+	int i;
+	bool stop;
+	for (i = 0; ; i++) {
+		stop = false;
+		fail_unless(vy_cache_iterator_next(&it, &history, &stop) == 0);
+		struct vy_entry entry = vy_history_last_stmt(&history);
+		if (vy_entry_is_equal(entry, vy_entry_none()))
+			break;
+		ok(i < expected_count && stop == expected[i].stop &&
+		   vy_stmt_are_same(entry, &expected[i].stmt, format, key_def),
+		   "type=%s key=%s vlsn=%s stmt=%s stop=%s",
+		   iterator_type_str(type), tuple_str(key.stmt), lsn_str(vlsn),
+		   vy_stmt_str(entry.stmt), stop ? "true" : "false");
+	}
+	ok(i == expected_count && stop == expected_stop,
+	   "type=%s key=%s vlsn=%s eof stop=%s",
+	   iterator_type_str(type), tuple_str(key.stmt), lsn_str(vlsn),
+	   stop ? "true" : "false");
+	vy_cache_iterator_close(&it);
+	vy_history_cleanup(&history);
+	tuple_unref(key.stmt);
+}
+
+static void
+test_iterator_skip_prepared(void)
+{
+	header();
+	plan(34);
+	struct vy_cache cache;
+	uint32_t fields[] = { 0 };
+	uint32_t types[] = { FIELD_TYPE_UNSIGNED };
+	struct key_def *key_def;
+	struct tuple_format *format;
+	create_test_cache(fields, types, lengthof(fields), &cache, &key_def,
+			  &format);
+	struct vy_stmt_template chain[] = {
+		STMT_TEMPLATE(10, REPLACE, 100),
+		STMT_TEMPLATE(20, REPLACE, 200),
+		STMT_TEMPLATE(MAX_LSN + 10, REPLACE, 300),
+		STMT_TEMPLATE(MAX_LSN + 20, REPLACE, 400),
+		STMT_TEMPLATE(15, REPLACE, 500),
+		STMT_TEMPLATE(25, REPLACE, 600),
+		STMT_TEMPLATE(MAX_LSN + 15, REPLACE, 700),
+	};
+	vy_cache_insert_templates_chain(&cache, format, chain, lengthof(chain),
+					&key_template, ITER_GE);
+	/* type=GE vlsn=20 is_prepared_ok=false */
+	{
+		struct test_iterator_expected expected[] = {
+			{STMT_TEMPLATE(10, REPLACE, 100), true},
+			{STMT_TEMPLATE(20, REPLACE, 200), true},
+			{STMT_TEMPLATE(15, REPLACE, 500), false},
+		};
+		test_iterator_helper(&cache, key_def, format, ITER_GE,
+				     &key_template, /*vlsn=*/20,
+				     /*is_prepared_ok=*/false,
+				     expected, lengthof(expected),
+				     /*expected_stop=*/false);
+	}
+	/* type=GE vlsn=MAX_LSN+10 is_prepared_ok=false */
+	{
+		struct test_iterator_expected expected[] = {
+			{STMT_TEMPLATE(10, REPLACE, 100), true},
+			{STMT_TEMPLATE(20, REPLACE, 200), true},
+			{STMT_TEMPLATE(15, REPLACE, 500), false},
+			{STMT_TEMPLATE(25, REPLACE, 600), true},
+		};
+		test_iterator_helper(&cache, key_def, format, ITER_GE,
+				     &key_template, /*vlsn=*/MAX_LSN + 10,
+				     /*is_prepared_ok=*/false,
+				     expected, lengthof(expected),
+				     /*expected_stop=*/false);
+	}
+	/* type=GE vlsn=MAX_LSN+10 is_prepared_ok=true */
+	{
+		struct test_iterator_expected expected[] = {
+			{STMT_TEMPLATE(10, REPLACE, 100), true},
+			{STMT_TEMPLATE(20, REPLACE, 200), true},
+			{STMT_TEMPLATE(MAX_LSN + 10, REPLACE, 300), true},
+			{STMT_TEMPLATE(15, REPLACE, 500), false},
+			{STMT_TEMPLATE(25, REPLACE, 600), true},
+		};
+		test_iterator_helper(&cache, key_def, format, ITER_GE,
+				     &key_template, /*vlsn=*/MAX_LSN + 10,
+				     /*is_prepared_ok=*/true,
+				     expected, lengthof(expected),
+				     /*expected_stop=*/false);
+	}
+	/* type=LE vlsn=20 is_prepared_ok=false */
+	{
+		struct test_iterator_expected expected[] = {
+			{STMT_TEMPLATE(15, REPLACE, 500), false},
+			{STMT_TEMPLATE(20, REPLACE, 200), false},
+			{STMT_TEMPLATE(10, REPLACE, 100), true},
+		};
+		test_iterator_helper(&cache, key_def, format, ITER_LE,
+				     &key_template, /*vlsn=*/20,
+				     /*is_prepared_ok=*/false,
+				     expected, lengthof(expected),
+				     /*expected_stop=*/true);
+	}
+	/* type=LE vlsn=MAX_LSN+10 is_prepared_ok=false */
+	{
+		struct test_iterator_expected expected[] = {
+			{STMT_TEMPLATE(25, REPLACE, 600), false},
+			{STMT_TEMPLATE(15, REPLACE, 500), true},
+			{STMT_TEMPLATE(20, REPLACE, 200), false},
+			{STMT_TEMPLATE(10, REPLACE, 100), true},
+		};
+		test_iterator_helper(&cache, key_def, format, ITER_LE,
+				     &key_template, /*vlsn=*/MAX_LSN + 10,
+				     /*is_prepared_ok=*/false,
+				     expected, lengthof(expected),
+				     /*expected_stop=*/true);
+	}
+	/* type=LE vlsn=MAX_LSN+10 is_prepared_ok=true */
+	{
+		struct test_iterator_expected expected[] = {
+			{STMT_TEMPLATE(25, REPLACE, 600), false},
+			{STMT_TEMPLATE(15, REPLACE, 500), true},
+			{STMT_TEMPLATE(MAX_LSN + 10, REPLACE, 300), false},
+			{STMT_TEMPLATE(20, REPLACE, 200), true},
+			{STMT_TEMPLATE(10, REPLACE, 100), true},
+		};
+		test_iterator_helper(&cache, key_def, format, ITER_LE,
+				     &key_template, /*vlsn=*/MAX_LSN + 10,
+				     /*is_prepared_ok=*/true,
+				     expected, lengthof(expected),
+				     /*expected_stop=*/true);
+	}
+	/* type=EQ key=300 vlsn=20 is_prepared_ok=false */
+	{
+		struct vy_stmt_template key = STMT_TEMPLATE(0, SELECT, 300);
+		struct test_iterator_expected expected[] = {};
+		test_iterator_helper(&cache, key_def, format, ITER_EQ,
+				     &key, /*vlsn=*/20,
+				     /*is_prepared_ok=*/false,
+				     expected, lengthof(expected),
+				     /*expected_stop=*/false);
+	}
+	/* type=EQ key=300 vlsn=MAX_LSN+10 is_prepared_ok=false */
+	{
+		struct vy_stmt_template key = STMT_TEMPLATE(0, SELECT, 300);
+		struct test_iterator_expected expected[] = {};
+		test_iterator_helper(&cache, key_def, format, ITER_EQ,
+				     &key, /*vlsn=*/MAX_LSN + 10,
+				     /*is_prepared_ok=*/false,
+				     expected, lengthof(expected),
+				     /*expected_stop=*/false);
+	}
+	/* type=EQ key=300 vlsn=MAX_LSN+10 is_prepared_ok=true */
+	{
+		struct vy_stmt_template key = STMT_TEMPLATE(0, SELECT, 300);
+		struct test_iterator_expected expected[] = {
+			{STMT_TEMPLATE(MAX_LSN + 10, REPLACE, 300), true},
+		};
+		test_iterator_helper(&cache, key_def, format, ITER_EQ,
+				     &key, /*vlsn=*/MAX_LSN + 10,
+				     /*is_prepared_ok=*/true,
+				     expected, lengthof(expected),
+				     /*expected_stop=*/true);
+	}
+	destroy_test_cache(&cache, key_def, format);
+	footer();
+	check_plan();
+}
+
 int
 main(void)
 {
 	vy_iterator_C_test_init(1LLU * 1024LLU * 1024LLU * 1024LLU);
 
-	plan(1);
+	plan(2);
 
 	test_basic();
+	test_iterator_skip_prepared();
 
 	vy_iterator_C_test_finish();
 	return check_plan();

--- a/test/unit/vy_cache.c
+++ b/test/unit/vy_cache.c
@@ -1,12 +1,11 @@
 #include "trivia/util.h"
 #include "vy_iterators_helper.h"
-#include "vy_history.h"
 #include "fiber.h"
 
 const struct vy_stmt_template key_template = STMT_TEMPLATE(0, SELECT, vyend);
 
 static void
-test_basic()
+test_basic(void)
 {
 	header();
 	plan(6);
@@ -19,10 +18,6 @@ test_basic()
 			  &format);
 	struct vy_entry select_all = vy_new_simple_stmt(format, key_def,
 							&key_template);
-
-	struct mempool history_node_pool;
-	mempool_create(&history_node_pool, cord_slab_cache(),
-		       sizeof(struct vy_history_node));
 
 	/*
 	 * Fill the cache with 3 chains.
@@ -127,8 +122,6 @@ test_basic()
 
 	vy_history_cleanup(&history);
 	vy_cache_iterator_close(&itr);
-
-	mempool_destroy(&history_node_pool);
 	tuple_unref(select_all.stmt);
 	destroy_test_cache(&cache, key_def, format);
 	check_plan();
@@ -136,12 +129,14 @@ test_basic()
 }
 
 int
-main()
+main(void)
 {
 	vy_iterator_C_test_init(1LLU * 1024LLU * 1024LLU * 1024LLU);
+
+	plan(1);
 
 	test_basic();
 
 	vy_iterator_C_test_finish();
-	return 0;
+	return check_plan();
 }

--- a/test/unit/vy_iterators_helper.c
+++ b/test/unit/vy_iterators_helper.c
@@ -2,6 +2,7 @@
 #include "memory.h"
 #include "fiber.h"
 #include "say.h"
+#include "small/mempool.h"
 #include "tt_uuid.h"
 
 struct tt_uuid INSTANCE_UUID;
@@ -9,6 +10,7 @@ struct tt_uuid INSTANCE_UUID;
 struct vy_stmt_env stmt_env;
 struct vy_mem_env mem_env;
 struct vy_cache_env cache_env;
+struct mempool history_node_pool;
 
 void
 vy_iterator_C_test_init(size_t cache_size)
@@ -24,11 +26,14 @@ vy_iterator_C_test_init(size_t cache_size)
 	vy_cache_env_set_quota(&cache_env, cache_size);
 	size_t mem_size = 64 * 1024 * 1024;
 	vy_mem_env_create(&mem_env, mem_size);
+	mempool_create(&history_node_pool, cord_slab_cache(),
+		       sizeof(struct vy_history_node));
 }
 
 void
 vy_iterator_C_test_finish()
 {
+	mempool_destroy(&history_node_pool);
 	vy_mem_env_destroy(&mem_env);
 	vy_cache_env_destroy(&cache_env);
 	vy_stmt_env_destroy(&stmt_env);

--- a/test/unit/vy_iterators_helper.h
+++ b/test/unit/vy_iterators_helper.h
@@ -37,6 +37,7 @@
 #include "small/lsregion.h"
 #include "vy_mem.h"
 #include "vy_cache.h"
+#include "vy_history.h"
 #include "vy_read_view.h"
 
 #define UNIT_TAP_COMPATIBLE 1
@@ -56,6 +57,7 @@ STMT_TEMPLATE_FLAGS(lsn, type, VY_STMT_DEFERRED_DELETE, __VA_ARGS__)
 extern struct vy_stmt_env stmt_env;
 extern struct vy_mem_env mem_env;
 extern struct vy_cache_env cache_env;
+extern struct mempool history_node_pool;
 
 #if defined(__cplusplus)
 extern "C" {

--- a/test/vinyl/errinj.result
+++ b/test/vinyl/errinj.result
@@ -766,6 +766,9 @@ wait_replace = true
 _ = fiber.create(function() s:replace{1, 1} wait_replace = false end)
 ---
 ...
+box.begin({txn_isolation = 'read-committed'})
+---
+...
 gen,param,state = s:pairs({1}, {iterator = 'GE'})
 ---
 ...
@@ -789,6 +792,9 @@ state, value = gen(param, state)
 value
 ---
 - [2, 0]
+...
+box.commit()
+---
 ...
 s:drop()
 ---

--- a/test/vinyl/errinj.test.lua
+++ b/test/vinyl/errinj.test.lua
@@ -274,6 +274,7 @@ s:select{0}
 errinj.set("ERRINJ_WAL_DELAY", true)
 wait_replace = true
 _ = fiber.create(function() s:replace{1, 1} wait_replace = false end)
+box.begin({txn_isolation = 'read-committed'})
 gen,param,state = s:pairs({1}, {iterator = 'GE'})
 state, value = gen(param, state)
 value
@@ -281,6 +282,7 @@ errinj.set("ERRINJ_WAL_DELAY", false)
 while wait_replace do fiber.sleep(0.01) end
 state, value = gen(param, state)
 value
+box.commit()
 s:drop()
 
 --

--- a/test/vinyl/errinj_tx.result
+++ b/test/vinyl/errinj_tx.result
@@ -13,6 +13,12 @@ create_iterator = require('utils').create_iterator
 errinj = box.error.injection
 ---
 ...
+txn_isolation_default = box.cfg.txn_isolation
+---
+...
+box.cfg{txn_isolation = 'read-committed'}
+---
+...
 --
 -- gh-1681: vinyl: crash in vy_rollback on ER_WAL_WRITE
 --
@@ -460,6 +466,9 @@ _ = fiber.create(function() pcall(s.replace, s, {1}) ch:put(true) end)
 ---
 ...
 -- Read the tuple from another transaction.
+box.begin({txn_isolation = 'read-committed'})
+---
+...
 itr = create_iterator(s)
 ---
 ...
@@ -519,6 +528,9 @@ c:commit()
 itr = nil
 ---
 ...
+box.rollback()
+---
+...
 s:drop()
 ---
 ...
@@ -531,4 +543,7 @@ collectgarbage()
 box.stat.vinyl().tx.read_views -- 0
 ---
 - 0
+...
+box.cfg{txn_isolation = txn_isolation_default}
+---
 ...

--- a/test/vinyl/gh-3395-read-prepared-uncommitted.result
+++ b/test/vinyl/gh-3395-read-prepared-uncommitted.result
@@ -41,17 +41,29 @@ box.snapshot()
  | - ok
  | ...
 
-c = fiber.channel(1)
+c1 = fiber.channel(1)
+ | ---
+ | ...
+c2 = fiber.channel(1)
  | ---
  | ...
 
 function do_write() s:replace{1, 2} end
  | ---
  | ...
-function init_read() end
+
+test_run:cmd("setopt delimiter ';'")
  | ---
+ | - true
  | ...
-function do_read() local ret = sk:select{2} c:put(ret) end
+function do_read()
+    c1:get()
+    c2:put(true)
+    box.begin({txn_isolation = 'read-committed'})
+    local ret = sk:select{2}
+    box.commit()
+    c2:put(ret)
+end;
  | ---
  | ...
 
@@ -68,10 +80,6 @@ function do_read() local ret = sk:select{2} c:put(ret) end
 -- mem doesn't change and the statement is returned in the result set
 -- (i.e. dirty read takes place).
 --
-test_run:cmd("setopt delimiter ';'");
- | ---
- | - true
- | ...
 -- is_tx_faster_than_wal determines whether wal thread has time
 -- to finish its routine or not. In the first case we add extra
 -- time gap to make sure that  WAL thread finished work and
@@ -79,10 +87,11 @@ test_run:cmd("setopt delimiter ';'");
 --
 function read_prepared_with_delay(is_tx_faster_than_wal)
     errinj.set("ERRINJ_WAL_DELAY", true)
-    fiber.create(do_write, s)
-    init_read()
+    fiber.create(do_write)
+    fiber.create(do_read)
     errinj.set("ERRINJ_VY_READ_PAGE_DELAY", true)
-    fiber.create(do_read, sk, c)
+    c1:put(true)
+    c2:get()
     errinj.set("ERRINJ_WAL_WRITE", true)
     if is_tx_faster_than_wal then
         errinj.set("ERRINJ_RELAY_FASTER_THAN_TX", true)
@@ -90,7 +99,7 @@ function read_prepared_with_delay(is_tx_faster_than_wal)
     errinj.set("ERRINJ_WAL_DELAY", false)
     fiber.sleep(0.1)
     errinj.set("ERRINJ_VY_READ_PAGE_DELAY", false)
-    local res = c:get()
+    local res = c2:get()
     errinj.set("ERRINJ_WAL_WRITE", false)
     if is_tx_faster_than_wal then
         errinj.set("ERRINJ_RELAY_FASTER_THAN_TX", false)
@@ -188,11 +197,26 @@ state = nil
 function do_write() s:replace{3, 20} end
  | ---
  | ...
-function init_read() gen, param, state = sk:pairs({20}, {iterator = box.index.EQ}) gen(param, state) end
+
+test_run:cmd("setopt delimiter ';'")
+ | ---
+ | - true
+ | ...
+function do_read()
+    box.begin({txn_isolation = 'read-committed'})
+    gen, param, state = sk:pairs({20}, {iterator = box.index.EQ})
+    c1:get()
+    c2:put(true)
+    gen(param, state)
+    local _, ret = gen(param, state)
+    box.commit()
+    c2:put(ret)
+end;
  | ---
  | ...
-function do_read() local _, ret = gen(param, state) c:put(ret) end
+test_run:cmd("setopt delimiter ''");
  | ---
+ | - true
  | ...
 
 read_prepared_with_delay(false)
@@ -215,7 +239,7 @@ fiber.sleep(0.1)
 --
 gen(param, state)
  | ---
- | - error: The read view is aborted
+ | - error: The transaction the cursor belongs to has ended
  | ...
 
 fiber.sleep(0.1)

--- a/test/vinyl/stat.result
+++ b/test/vinyl/stat.result
@@ -407,7 +407,6 @@ stat_diff(istat(), st)
     put:
       rows: 1
       bytes: 1053
-  lookup: 1
   disk:
     iterator:
       read:
@@ -419,9 +418,13 @@ stat_diff(istat(), st)
       get:
         rows: 1
         bytes: 1053
+  txw:
+    iterator:
+      lookup: 1
   memory:
     iterator:
       lookup: 1
+  lookup: 1
   get:
     rows: 1
     bytes: 1053
@@ -444,6 +447,9 @@ stat_diff(istat(), st)
     get:
       rows: 1
       bytes: 1053
+  txw:
+    iterator:
+      lookup: 1
   lookup: 1
   get:
     rows: 1
@@ -491,13 +497,16 @@ stat_diff(istat(), st)
     put:
       rows: 1
       bytes: 1053
+  txw:
+    iterator:
+      lookup: 1
+  lookup: 1
   memory:
     iterator:
       lookup: 1
       get:
         rows: 1
         bytes: 1053
-  lookup: 1
   get:
     rows: 1
     bytes: 1053

--- a/test/vinyl/upsert.result
+++ b/test/vinyl/upsert.result
@@ -824,7 +824,11 @@ test_run:cmd("setopt delimiter ';'")
 ---
 - true
 ...
-_ = fiber.create(function() ch:put(s:select()) end)
+_ = fiber.create(function()
+    box.begin({txn_isolation = 'read-committed'})
+    ch:put(s:select())
+    box.commit()
+end)
 s:upsert({10, 10}, {{'+', 2, 10}})
 test_run:cmd("setopt delimiter ''");
 ---

--- a/test/vinyl/upsert.test.lua
+++ b/test/vinyl/upsert.test.lua
@@ -339,7 +339,11 @@ box.snapshot()
 s:get(10) -- add [10, 10] to the cache
 ch = fiber.channel(1)
 test_run:cmd("setopt delimiter ';'")
-_ = fiber.create(function() ch:put(s:select()) end)
+_ = fiber.create(function()
+    box.begin({txn_isolation = 'read-committed'})
+    ch:put(s:select())
+    box.commit()
+end)
 s:upsert({10, 10}, {{'+', 2, 10}})
 test_run:cmd("setopt delimiter ''");
 ch:get() -- should see the UPSERT and return [10, 20]


### PR DESCRIPTION
This commit adds support of transaction isolation levels introduced earlier for memtx mvcc by commit ec750af66d9497207b358d0bc4a465163283f7ab. The isolation levels work exactly in the same way as in memtx.

Closes #5522