### PR TITLE
test: replace Lua assertions with luatest assertions in luatest tests

### DIFF
--- a/test/app-luatest/gh_6817_console_memory_leak_test.lua
+++ b/test/app-luatest/gh_6817_console_memory_leak_test.lua
@@ -14,10 +14,10 @@ ffi.cdef([[
 g.before_test('test_console_mem_leak', function()
     -- Replace stdin fd with a pipe fd so that we can emulate user input.
     local fd = ffi.new([[ int[2] ]])
-    assert(ffi.C.pipe(fd) == 0)
+    t.assert_equals(ffi.C.pipe(fd), 0)
     if fd[0] ~= 0 then
-        assert(ffi.C.dup2(fd[0], 0) == 0)
-        assert(ffi.C.close(fd[0]) == 0)
+        t.assert_equals(ffi.C.dup2(fd[0], 0), 0)
+        t.assert_equals(ffi.C.close(fd[0]), 0)
     end
     g.console_write_fd = fd[1]
     g.console_write = function(command)
@@ -26,8 +26,8 @@ g.before_test('test_console_mem_leak', function()
 end)
 
 g.after_test('test_console_mem_leak', function()
-    assert(ffi.C.close(g.console_write_fd) == 0)
-    assert(ffi.C.close(0) == 0)
+    t.assert_equals(ffi.C.close(g.console_write_fd), 0)
+    t.assert_equals(ffi.C.close(0), 0)
     g.console_write = nil
     g.console_write_fd = nil
 end)

--- a/test/app-luatest/gh_7288_console_flavours_vs_txn_test.lua
+++ b/test/app-luatest/gh_7288_console_flavours_vs_txn_test.lua
@@ -102,7 +102,7 @@ TestConsole.__index.connect = function(self)
         -- write console fiber exit message
         self.och:put(true)
     end)
-    assert(on_start:get(3))
+    t.assert(on_start:get(3))
     if self.flavour.connect then
         self.flavour:connect(self)
     end
@@ -110,7 +110,7 @@ end
 
 TestConsole.__index.send = function(self, input)
     self.ich:put(input)
-    return assert(self.och:get(3))
+    return t.assert(self.och:get(3))
 end
 
 TestConsole.__index.disconnect = function(self)
@@ -119,7 +119,7 @@ TestConsole.__index.disconnect = function(self)
     end
     self.ich:close()
     -- read console fiber exit message
-    assert(self.och:get(3))
+    t.assert(self.och:get(3))
     self.och:close()
     self.ich = nil
     self.och = nil

--- a/test/app-luatest/http_client_test.lua
+++ b/test/app-luatest/http_client_test.lua
@@ -411,7 +411,7 @@ g.test_request_headers = function(cg)
             t.assert(ok, case[1])
         else
             -- expect fail
-            assert(type(err) == 'string')
+            t.assert_type(err, 'string')
             err = err:gsub('^builtin/[a-z._]+.lua:[0-9]+: ', '')
             t.assert_equals({ok, err}, {false, case.exp_err}, case[1])
         end

--- a/test/app-luatest/http_client_unit_test.lua
+++ b/test/app-luatest/http_client_unit_test.lua
@@ -195,7 +195,7 @@ g.test_unit_decode_body_content_type_passed = function(_)
         },
         decoders = {
             ['application/json'] = function(body, type_value)
-                assert(type_value == content_type)
+                t.assert_equals(type_value, content_type)
                 return json.decode(body)
             end,
         },

--- a/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
+++ b/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
@@ -50,7 +50,7 @@ local function tx_gc(server, steps, related_changes)
     if related_changes then
         table_apply_change(current_stat, related_changes)
     end
-    assert(table.equals(current_stat, server:eval('return box.stat.memtx.tx()')))
+    t.assert_equals(server:eval('return box.stat.memtx.tx()'), current_stat)
 end
 
 local function tx_step(server, txn_name, op, related_changes)
@@ -58,7 +58,7 @@ local function tx_step(server, txn_name, op, related_changes)
     if related_changes then
         table_apply_change(current_stat, related_changes)
     end
-    assert(table.equals(current_stat, server:eval('return box.stat.memtx.tx()')))
+    t.assert_equals(server:eval('return box.stat.memtx.tx()'), current_stat)
 end
 
 g.before_each(function()
@@ -76,7 +76,7 @@ g.before_each(function()
     -- CREATING CURRENT STAT
     current_stat = g.server:eval('return box.stat.memtx.tx()')
     -- Check if txm use no memory
-    assert(table_values_are_zeros(current_stat))
+    t.assert(table_values_are_zeros(current_stat))
 end)
 
 g.after_each(function()
@@ -167,8 +167,7 @@ g.test_simple = function()
     }
     tx_step(g.server, 'tx2', "s:replace{2, 2}", diff)
     tx_gc(g.server, 100, nil)
-    local err = g.server:eval('return tx2:commit()')
-    assert(not err[1])
+    t.assert_equals(g.server:eval('return tx2:commit()'), '')
     diff = {
         ["txn"] = {
             ["statements"] = {
@@ -194,8 +193,7 @@ g.test_simple = function()
         }
     }
     tx_gc(g.server, 10, diff)
-    err = g.server:eval('return tx1:commit()')
-    assert(not err[1])
+    t.assert_equals(g.server:eval('return tx1:commit()'), '')
     diff = {
         ["txn"] = {
             ["statements"] = {
@@ -225,7 +223,7 @@ g.test_simple = function()
         }
     }
     tx_gc(g.server, 100, diff)
-    assert(table_values_are_zeros(current_stat))
+    t.assert(table_values_are_zeros(current_stat))
 end
 
 g.test_read_view = function()
@@ -236,7 +234,7 @@ g.test_read_view = function()
     g.server:eval('s:replace{1, 1}')
     g.server:eval('s:replace{2, 1}')
     g.server:eval('box.internal.memtx_tx_gc(10)')
-    assert(table_values_are_zeros(g.server:eval('return box.stat.memtx.tx()')))
+    t.assert(table_values_are_zeros(g.server:eval('return box.stat.memtx.tx()')))
     g.server:eval('tx1("s:get(1)")')
     g.server:eval('tx2("s:replace{1, 2}")')
     g.server:eval('tx2("s:replace{2, 2}")')
@@ -283,7 +281,7 @@ g.test_read_view_with_empty_space = function()
     g.server:eval('s:replace{1, 1}')
     g.server:eval('s:replace{2, 1}')
     g.server:eval('box.internal.memtx_tx_gc(10)')
-    assert(table_values_are_zeros(g.server:eval('return box.stat.memtx.tx()')))
+    t.assert(table_values_are_zeros(g.server:eval('return box.stat.memtx.tx()')))
     g.server:eval('tx1("s:get(1)")')
     g.server:eval('tx2("s:delete(1)")')
     g.server:eval('tx2("s:delete(2)")')
@@ -361,7 +359,7 @@ g.test_conflict = function()
     g.server:eval('tx1 = txn_proxy.new()')
     g.server:eval('tx2 = txn_proxy.new()')
     g.server:eval('box.internal.memtx_tx_gc(10)')
-    assert(table_values_are_zeros(g.server:eval('return box.stat.memtx.tx()')))
+    t.assert(table_values_are_zeros(g.server:eval('return box.stat.memtx.tx()')))
     g.server:eval('tx1:begin()')
     g.server:eval('tx2:begin()')
     g.server:eval('tx1("s:get(1)")')
@@ -421,8 +419,7 @@ g.test_user_data = function()
         },
     }
     tx_step(g.server, 'tx', 'ffi.C.box_txn_alloc(' .. alloc_size .. ')', diff)
-    local err = g.server:eval('return tx:commit()')
-    assert(not err[1])
+    t.assert_equals(g.server:eval('return tx:commit()'), '')
     diff = {
         ["txn"] = {
             ["user"] = {

--- a/test/box-luatest/gh_6260_add_builtin_events_test.lua
+++ b/test/box-luatest/gh_6260_add_builtin_events_test.lua
@@ -13,7 +13,7 @@ g.test_subscriptions_outside_box_cfg = function()
         local result_no = 0
         local watcher = box.watch(val,
                                   function(name, state)
-                                      assert(name == val)
+                                      t.assert_equals(name, val)
                                       result = state
                                       result_no = result_no + 1
                                   end)
@@ -68,7 +68,7 @@ g.test_box_status = function(cg)
     local result_no = 0
     local watcher = c:watch('box.status',
                             function(name, state)
-                                assert(name == 'box.status')
+                                t.assert_equals(name, 'box.status')
                                 result = state
                                 result_no = result_no + 1
                             end)
@@ -255,7 +255,7 @@ g.test_box_schema = function(cg)
 
     local watcher = c:watch('box.schema',
                             function(n, s)
-                                assert(n == 'box.schema')
+                                t.assert_equals(n, 'box.schema')
                                 version = s.version
                                 version_n = version_n + 1
                             end)
@@ -307,7 +307,7 @@ g.test_box_id = function(cg)
 
     local watcher = c:watch('box.id',
                             function(name, state)
-                                assert(name == 'box.id')
+                                t.assert_equals(name, 'box.id')
                                 result = state
                                 result_no = result_no + 1
                             end)

--- a/test/replication-luatest/election_split_vote_test.lua
+++ b/test/replication-luatest/election_split_vote_test.lua
@@ -65,10 +65,12 @@ g.test_split_vote = function(g)
     -- Wait for the votes to actually happen.
     t.helpers.retrying({timeout = wait_timeout}, function()
         local func = function()
-            return box.info.election.vote == box.info.id
+            local t = require('luatest')
+
+            t.assert_equals(box.info.election.vote, box.info.id)
         end
-        assert(g.node1:exec(func))
-        assert(g.node2:exec(func))
+        g.node1:exec(func)
+        g.node2:exec(func)
     end)
 
     -- Now let the nodes notice the split vote.
@@ -81,7 +83,7 @@ g.test_split_vote = function(g)
 
     t.helpers.retrying({timeout = wait_timeout}, function()
         local msg = 'split vote is discovered'
-        assert(g.node1:grep_log(msg) or g.node2:grep_log(msg))
+        t.assert(g.node1:grep_log(msg) or g.node2:grep_log(msg))
     end)
 
     -- Ensure a leader is eventually elected. Nothing is broken for good.

--- a/test/replication-luatest/gh_5295_split_brain_test.lua
+++ b/test/replication-luatest/gh_5295_split_brain_test.lua
@@ -35,6 +35,8 @@ g.before_all(function(cg)
     cg.cluster:start()
 
     cg.main:exec(function()
+        local t = require('luatest')
+
         box.ctl.promote()
         box.ctl.wait_rw()
         local s = box.schema.space.create('sync', {is_sync = true})
@@ -42,7 +44,7 @@ g.before_all(function(cg)
         s = box.schema.space.create('async')
         s:create_index('pk')
         -- Check the test correctness.
-        assert(box.info.id == 1)
+        t.assert_equals(box.info.id, 1)
     end)
 end)
 
@@ -209,7 +211,7 @@ local function fill_queue_and_write(server)
 end
 
 local function perform_rollback(server)
-    assert(server:exec(function() return box.info.synchro.queue.len end) > 0)
+    t.assert_gt(server:exec(function() return box.info.synchro.queue.len end), 0)
     server:exec(function() box.cfg{replication_synchro_timeout = 0.01} end)
     t.helpers.retrying({delay = 0.1}, server.exec, server, function()
         require('luatest').assert_equals(box.info.synchro.queue.len, 0,


### PR DESCRIPTION
Some luatest framework tests use Lua assertions which are incomprehensible when failed (the only information provided is 'assertion failed!'), making debugging difficult: replace them with luatest assertions and their context-specific varieties.

Closes #7713