### PR TITLE
lua/datetime: clearer error msg for new()

### DIFF
--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -583,6 +583,9 @@ local function datetime_new(obj)
         if hms then
             error('timestamp is not allowed if hour/min/sec provided', 2)
         end
+        if type(ts) ~= 'number' then
+            error(("bad timestamp ('number' expected, got '%s')"):format(type(ts)))
+        end
         local fraction
         s, fraction = math_modf(ts)
         -- if there are separate nsec, usec, or msec provided then

--- a/test/app-luatest/gh_7273_dt_new_err_on_cdata_test.lua
+++ b/test/app-luatest/gh_7273_dt_new_err_on_cdata_test.lua
@@ -1,0 +1,8 @@
+local datetime = require('datetime')
+
+local t = require('luatest')
+local g = t.group()
+
+g.test_dt_new_err_on_cdata = function()
+    t.assert_error_msg_contains("bad timestamp ('number' expected, got 'cdata'", datetime.new, {timestamp = 1LL})
+end


### PR DESCRIPTION
dt.new() will raise a clear error on wrong timestamp type.

Closes #7273

NO_DOC=bugfix
NO_CHANGELOG=bugfix