### PR TITLE
memtx: fix loss of committed tuple in secondary index

### DIFF
--- a/changelogs/unreleased/gh-7712-loss-of-commited-tuple-in-secondary-index.md
+++ b/changelogs/unreleased/gh-7712-loss-of-commited-tuple-in-secondary-index.md
@@ -1,0 +1,4 @@
+## bugfix/memtx
+
+* Fixed possible loss of committed tuple in secondary index with MVCC
+  transaction manager (gh-7712).

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1403,6 +1403,15 @@ memtx_tx_story_gc_step()
 							  MEMTX_TX_STORY_USED);
 				return;
 			}
+		} else if (i > 0 && link->newer_story->add_stmt != NULL) {
+			/*
+			 * We need to retain the story since the newer story
+			 * can get rolled back (this is maintained by delete
+			 * statement list in case of primary index).
+			 */
+			memtx_tx_story_set_status(story,
+						  MEMTX_TX_STORY_USED);
+			return;
 		}
 		if (!rlist_empty(&link->nearby_gaps)) {
 			memtx_tx_story_set_status(story,

--- a/test/box-luatest/gh_7712_loss_of_commited_tuple_in_secondary_index_test.lua
+++ b/test/box-luatest/gh_7712_loss_of_commited_tuple_in_secondary_index_test.lua
@@ -1,0 +1,39 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local pg = t.group(nil, t.helpers.matrix{idx = {'TREE', 'HASH'}})
+
+pg.before_all(function(cg)
+    cg.server = server:new{
+        alias   = 'dflt',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    cg.server:start()
+    cg.server:exec(function(idx)
+        local s = box.schema.create_space('s')
+        s:create_index('pk')
+        s:create_index('sk', {type = idx, parts = {2}})
+    end, {cg.params.idx})
+end)
+
+pg.after_all(function(cg)
+    cg.server:drop()
+end)
+
+--[[
+Checks that committed tuple is not lost in secondary index.
+]]
+pg.test_idx_random_from_empty_space_tracking = function(cg)
+    local stream = cg.server.net_box:new_stream()
+    stream:begin()
+
+    stream.space.s:insert{0, 1}
+    cg.server:exec(function()
+        local t = require('luatest')
+
+        box.space.s:insert{2, 1}
+        box.internal.memtx_tx_gc(100)
+
+        t.assert_equals(box.space.s.index[1]:select{}, {{2, 1}})
+    end)
+end


### PR DESCRIPTION
Concurrent transactions can try to insert tuples that intersect only by parts of secondary index: in this case when one of them gets prepared, the others get conflicted, but the committed story does not get retained (because the conflicting statements are not added to the committed story's delete statement list as opposed to primary index) and is lost after garbage collection: retain stories if there is a newer uncommitted story in the secondary indexes' history chain.

Closes #7712