### PR TITLE
box: expose box.info() before box.cfg()

### DIFF
--- a/changelogs/unreleased/gh-7255-box-info-before-cfg.md
+++ b/changelogs/unreleased/gh-7255-box-info-before-cfg.md
@@ -1,0 +1,3 @@
+## feature/core
+
+* box.info() can be called before box.cfg() (gh-7255).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -90,7 +90,7 @@
 #include "flightrec.h"
 #include "wal_ext.h"
 
-static char status[64] = "unknown";
+static char status[64] = "unconfigured";
 
 /** box.stat rmean */
 struct rmean *rmean_box;

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -824,6 +824,7 @@ local box_cfg_guard_whitelist = {
     broadcast = true;
     txn_isolation_level = true;
     NULL = true;
+    info = true;
 };
 
 -- List of box members that requires full box loading.

--- a/test/box-luatest/gh_7255_box_info_before_cfg_test.lua
+++ b/test/box-luatest/gh_7255_box_info_before_cfg_test.lua
@@ -1,0 +1,8 @@
+local t = require('luatest')
+
+local g = t.group()
+
+g.test_box_info_before_box_cfg = function()
+    local info = box.info()
+    t.assert_equals(info.status, "unconfigured")
+end


### PR DESCRIPTION
So one can easily check current box status.

See discussion in previous [PR](https://github.com/tarantool/tarantool/pull/7407) on why box.info() and not box.is_configured.

Closes #7255