### PR TITLE
vclock: fix ub sanitizer warnings of int shifting by 31 bits

### DIFF
--- a/src/lib/vclock/vclock.c
+++ b/src/lib/vclock/vclock.c
@@ -45,7 +45,7 @@ vclock_follow(struct vclock *vclock, uint32_t replica_id, int64_t lsn)
 	int64_t prev_lsn = vclock_get(vclock, replica_id);
 	assert(lsn > prev_lsn);
 	/* Easier add each time than check. */
-	vclock->map |= 1 << replica_id;
+	vclock->map |= 1U << replica_id;
 	vclock->lsn[replica_id] = lsn;
 	vclock->signature += lsn - prev_lsn;
 	return prev_lsn;
@@ -130,7 +130,7 @@ vclock_from_string(struct vclock *vclock, const char *str)
 			    replica_id >= VCLOCK_MAX ||
 			    vclock_get(vclock, replica_id) > 0)
 				goto error;
-			vclock->map |= 1 << replica_id;
+			vclock->map |= 1U << replica_id;
 			vclock->lsn[replica_id] = lsn;
 			goto comma;
 		}

--- a/src/lib/vclock/vclock.h
+++ b/src/lib/vclock/vclock.h
@@ -159,7 +159,7 @@ vclock_inc(struct vclock *vclock, uint32_t replica_id)
 	/* Easier add each time than check. */
 	if (((vclock->map >> replica_id) & 0x01) == 0) {
 		vclock->lsn[replica_id] = 0;
-		vclock->map |= 1 << replica_id;
+		vclock->map |= 1U << replica_id;
 	}
 	vclock->signature++;
 	return ++vclock->lsn[replica_id];
@@ -182,11 +182,11 @@ vclock_reset(struct vclock *vclock, uint32_t replica_id, int64_t lsn)
 	assert(replica_id < VCLOCK_MAX);
 	vclock->signature -= vclock_get(vclock, replica_id);
 	if (lsn == 0) {
-		vclock->map &= ~(1 << replica_id);
+		vclock->map &= ~(1U << replica_id);
 		return;
 	}
 	vclock->lsn[replica_id] = lsn;
-	vclock->map |= 1 << replica_id;
+	vclock->map |= 1U << replica_id;
 	vclock->signature += lsn;
 }
 


### PR DESCRIPTION
Caught the following error with UB sanitizer after trying to use the 31-st vclock component in one of the tests:

NO_WRAP
```
[040] +/opt/actions-runner/_work/tarantool/tarantool/src/lib/vclock/vclock.c:133:21: runtime error: left shift of 1 by 31 places cannot be represented in type 'int'
[040] +SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /opt/actions-runner/_work/tarantool/tarantool/src/lib/vclock/vclock.c:133:21 in
[040] Test "unit/vclock.test", conf: "None"
[040] 	failed, rerunning ...
[040] unit/vclock.test                                                [ fail ]
```
NO_WRAP

Let's fix this in all the affected places.

NO_DOC=refactoring
NO_TEST=already tested by unit/vclock.cc: test_minmax_ignore0()
NO_CHANGELOG=refactoring