### PR TITLE
gc: replace vclockset_psearch with _match in wal_collect_garbage_f

### DIFF
--- a/changelogs/unreleased/gh-7584-missing-xlog-fix.md
+++ b/changelogs/unreleased/gh-7584-missing-xlog-fix.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed master occasionally deleting xlogs needed by replicas even without a
+  restart (gh-7584).

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -794,7 +794,7 @@ wal_collect_garbage_f(struct cbus_call_msg *data)
 		 * required by registered consumers and delete all
 		 * older WAL files.
 		 */
-		vclock = vclockset_psearch(&writer->wal_dir.index, vclock);
+		vclock = vclockset_match(&writer->wal_dir.index, vclock);
 	}
 	if (vclock != NULL)
 		xdir_collect_garbage(&writer->wal_dir, vclock_sum(vclock),

--- a/src/lib/vclock/vclock.h
+++ b/src/lib/vclock/vclock.h
@@ -432,7 +432,7 @@ rb_proto(, vclockset_, vclockset_t, struct vclock);
  * @return a vclock that <= than \a key
  */
 static inline struct vclock *
-vclockset_match(vclockset_t *set, struct vclock *key)
+vclockset_match(vclockset_t *set, const struct vclock *key)
 {
 	struct vclock *match = vclockset_psearch(set, key);
 	/**

--- a/test/replication-luatest/gh_7584_missing_xlog_test.lua
+++ b/test/replication-luatest/gh_7584_missing_xlog_test.lua
@@ -1,0 +1,48 @@
+local t = require('luatest')
+local cluster = require('test.luatest_helpers.cluster')
+local server = require('test.luatest_helpers.server')
+
+local g = t.group('gh-7584')
+
+g.before_all(function(cg)
+    cg.cluster = cluster:new{}
+    cg.master = cg.cluster:build_and_add_server{
+        alias = 'master',
+        box_cfg = {
+            checkpoint_count = 1,
+        },
+    }
+    cg.replica = cg.cluster:build_and_add_server{
+        alias = 'replica',
+        box_cfg = {
+            replication = {
+                server.build_instance_uri('master'),
+            },
+        },
+    }
+    cg.cluster:start()
+    cg.master:exec(function()
+        box.schema.space.create('loc', {is_local = true})
+        box.space.loc:create_index('pk')
+        box.schema.space.create('glob')
+        box.space.glob:create_index('pk')
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.cluster:drop()
+end)
+
+g.test_xlog_gap = function(cg)
+    t.helpers.retrying({}, cg.replica.assert_follows_upstream, cg.replica, 1)
+    cg.replica:stop()
+    cg.master:exec(function()
+        for _ = 1, 2 do
+            box.space.loc:replace{1}
+            box.space.glob:replace{1}
+            box.snapshot()
+        end
+    end)
+    cg.replica:start()
+    t.helpers.retrying({}, cg.replica.assert_follows_upstream, cg.replica, 1)
+end


### PR DESCRIPTION
When using vclockset_psearch, the resulting vclock may be incomparable to the search key. For example, with a vclock set { } (empty vclock), {0: 1, 1: 10}, {0: 2, 1:11} vclockset_psearch(set, {0:2, 1: 9}) might return {0: 1, 1: 10}, and not { }.
This is known and avoided in other places, for example recover_remaining_wals(), where vclockset_match() is used instead. vclockset_match() starts with the same result as vclockset_psearch() and then unwinds the result until the first vclock which is less or equal to the search key is found.

Having vclockset_psearch in wal_collect_garbage_f could lead to issues even before local space changes became written to 0-th vclock component. Once replica subscribes, its' gc consumer is set to the vclock, which the replica sent in subscribe request. This vclock might be incomparable with xlog vclocks of the master, leading to the same issue of potentially deleting a needed xlog during gc.

Closes #7584

NO_DOC=bugfix