### PR TITLE
doc: proofread 2.10.3 changelog

### DIFF
--- a/changelogs/unreleased/add-redos-7.3-ci-cd.md
+++ b/changelogs/unreleased/add-redos-7.3-ci-cd.md
@@ -1,3 +1,3 @@
 ## feature/build
 
-* Support RedOS 7.3 build.
+* RedOS 7.3 is now supported.

--- a/changelogs/unreleased/gh-4450-logger-sigsegv-revert.md
+++ b/changelogs/unreleased/gh-4450-logger-sigsegv-revert.md
@@ -1,5 +1,5 @@
 ## bugfix/core
 
-* Fixed degradation introduced in Tarantool 2.10.2 that could cause log
-  messages to be written to data files thus causing data corruption.
+* Fixed a bug introduced in Tarantool 2.10.2: log messages
+  could be written to data files thus causing data corruption.
   The issue was fixed by reverting the fix for gh-4450.

--- a/changelogs/unreleased/gh-7086-box_issue_promote_demote_asserts.md
+++ b/changelogs/unreleased/gh-7086-box_issue_promote_demote_asserts.md
@@ -1,5 +1,5 @@
 ## bugfix/synchro
 
-* Fixed asserts in debug build/undefined behaviour in release when simulteneous
-  elections started/another instance promoted while instance was acquiring
-  or releasing synchro queue (gh-7086).
+* Fixed assertions in debug builds and undefined behaviour in release builds
+  when simultaneous elections started or another instance was promoted while
+  an instance was acquiring or releasing the synchro queue (gh-7086).

--- a/changelogs/unreleased/gh-7253-split-brain-early-vote.md
+++ b/changelogs/unreleased/gh-7253-split-brain-early-vote.md
@@ -1,5 +1,4 @@
 ## bugfix/raft
 
-* Fixed a bug when a replicaset could be split in parts if a node during
-  elections voted for another instance while having some local WAL writes not
-  finished (gh-7253).
+* Fixed a bug when a replicaset could be split into parts if a node voted
+  for another instance while having local WAL writes unfinished (gh-7253).

--- a/changelogs/unreleased/gh-7343-unserializable-read-tracked-incorrectly-after-rollback.md
+++ b/changelogs/unreleased/gh-7343-unserializable-read-tracked-incorrectly-after-rollback.md
@@ -1,4 +1,4 @@
 ## bugfix/memtx
 
-* Fixed unserializable reads tracked incorrectly after transaction rollback
+* Fixed unserializable reads tracked incorrectly after transaction rollbacks
   (gh-7343).

--- a/changelogs/unreleased/gh-7434-yield-in-on_shutdown-trigger.md
+++ b/changelogs/unreleased/gh-7434-yield-in-on_shutdown-trigger.md
@@ -1,4 +1,4 @@
 ## bugfix/box
 
-* Fixed a bug when `fiber.yield()` may break the execution of a shutdown
+* Fixed a bug when `fiber.yield()` might break the execution of a shutdown
   trigger (gh-7434).

--- a/changelogs/unreleased/gh-7449-tuple-is-dirty-assertion-on-replace.md
+++ b/changelogs/unreleased/gh-7449-tuple-is-dirty-assertion-on-replace.md
@@ -1,4 +1,4 @@
 ## bugfix/memtx
 
-* Fixed 'use after free' in transaction manager which could occur in certain
-  states (gh-7449).
+* Fixed `use after free` that could occur in the transaction manager
+  in certain states (gh-7449).

--- a/changelogs/unreleased/gh-7493-memtx-hash-idx-repeatable-read-violation.md
+++ b/changelogs/unreleased/gh-7493-memtx-hash-idx-repeatable-read-violation.md
@@ -1,4 +1,4 @@
 ## bugfix/memtx
 
-* Fixed gap writes from different transaction incorrectly handled for hash index
-  full scans (gh-7493).
+* Fixed incorrect handling of transaction conflicts in full scans
+  by HASH indexes (gh-7493).

--- a/changelogs/unreleased/gh-7670-memtx-tx-manager-idx-rand-inconsistency.md
+++ b/changelogs/unreleased/gh-7670-memtx-tx-manager-idx-rand-inconsistency.md
@@ -1,4 +1,4 @@
 ## bugfix/memtx
 
-* Fixed inconsistency of `index:random` in context of transaction management
+* Fixed an inconsistency in `index:random` in the context of transaction management
   (gh-7670).

--- a/changelogs/unreleased/gh-7685-memtx-tree-idx-get-with-nullable-field-phantom-read.md
+++ b/changelogs/unreleased/gh-7685-memtx-tree-idx-get-with-nullable-field-phantom-read.md
@@ -1,4 +1,4 @@
 ## bugfix/memtx
 
-* Fixed possibility of phantom reads with `get` on TREE index containing
-  nullable part (gh-7685).
+* Fixed possible phantom reads with `get` on TREE indexes containing
+  nullable parts (gh-7685).

--- a/changelogs/unreleased/gh-7705-json-update-crash.md
+++ b/changelogs/unreleased/gh-7705-json-update-crash.md
@@ -1,4 +1,4 @@
 ## bugfix/core
 
-* Fixed a bug that a single JSON update couldn't insert and update a map/array
-  field in 2 sequential ops. It would either crash or return an error (gh-7705).
+* Fixed a bug when a single JSON update couldn't insert and update a field of a map or
+  an array in two sequential calls. It would either crash or return an error (gh-7705).

--- a/changelogs/unreleased/igrishnov/gh-7479-bug-fix-uri-lib.md
+++ b/changelogs/unreleased/igrishnov/gh-7479-bug-fix-uri-lib.md
@@ -1,4 +1,4 @@
 ## bugfix/uri
 
-* Fixed a bug in the URI parser, because of which tarantoolctl
-  failed to connect when the host name was skipped (gh-7479).
+* Fixed a bug in the URI parser: tarantoolctl could not
+  connect when the host name was skipped (gh-7479).

--- a/changelogs/unreleased/merger-use-after-free-in-gen.md
+++ b/changelogs/unreleased/merger-use-after-free-in-gen.md
@@ -1,4 +1,4 @@
 ## bugfix/lua/merger
 
-* Fixed use-after-free during iteration over `merge_source:pairs()` or
+* Fixed `use after free` that could occur during iteration over `merge_source:pairs()` or
   `merger:pairs()` (gh-7657).

--- a/changelogs/unreleased/popen-mac-os-race.md
+++ b/changelogs/unreleased/popen-mac-os-race.md
@@ -1,3 +1,3 @@
 ## bugfix/lua/popen
 
-* Handle a race in `<popen handle>:signal()` on Mac OS 12 and newer (gh-7658).
+* Fixed a race condition in `<popen handle>:signal()` on Mac OS 12 and newer (gh-7658).

--- a/changelogs/unreleased/promote-hang.md
+++ b/changelogs/unreleased/promote-hang.md
@@ -1,4 +1,4 @@
 ## bugfix/raft
 
 * Fixed a bug when a node with `election_mode='voter'` could hang in
-  `box.ctl.promote()` or even become a leader.
+  `box.ctl.promote()` or become a leader.

--- a/changelogs/unreleased/strerror-mt-safe.md
+++ b/changelogs/unreleased/strerror-mt-safe.md
@@ -1,4 +1,4 @@
 ## bugfix/core
 
-* Switched from MT-Unsafe `strerror()` to MT-Safe `strerror_r()`. Usage of the
-  unsafe function could result in corrupted error messages.
+* Switched from MT-Unsafe `strerror()` to MT-Safe `strerror_r()`. The usage
+  of the unsafe function could result in corrupted error messages.


### PR DESCRIPTION
Fix wording, punctuation, and formatting.

NO_CHANGELOG=changelog
NO_DOC=changelog
NO_TEST=changelog