### PR TITLE
box: fix usage error messages if FFI is disabled for index read ops

### DIFF
--- a/src/box/lua/index.c
+++ b/src/box/lua/index.c
@@ -269,13 +269,13 @@ lbox_iterator_next(lua_State *L)
 {
 	/* first argument is key buffer */
 	if (lua_gettop(L) < 1 || lua_type(L, 1) != LUA_TCDATA)
-		return luaL_error(L, "usage: next(state)");
+		return luaL_error(L, "usage: next(param, state)");
 
 	assert(CTID_STRUCT_ITERATOR_PTR != 0);
 	uint32_t ctypeid;
 	void *data = luaL_checkcdata(L, 1, &ctypeid);
 	if (ctypeid != CTID_STRUCT_ITERATOR_PTR)
-		return luaL_error(L, "usage: next(state)");
+		return luaL_error(L, "usage: next(param, state)");
 
 	struct iterator *itr = *(struct iterator **) data;
 	struct tuple *tuple;

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -2272,7 +2272,7 @@ base_index_mt.__len = base_index_mt.len
 -- min and max
 base_index_mt.min_ffi = function(index, key)
     if builtin.box_read_ffi_is_disabled then
-        return index:min_luac(key)
+        return base_index_mt.min_luac(index, key)
     end
     check_index_arg(index, 'min')
     local ibuf = cord_ibuf_take()
@@ -2295,7 +2295,7 @@ base_index_mt.min_luac = function(index, key)
 end
 base_index_mt.max_ffi = function(index, key)
     if builtin.box_read_ffi_is_disabled then
-        return index:max_luac(key)
+        return base_index_mt.max_luac(index, key)
     end
     check_index_arg(index, 'max')
     local ibuf = cord_ibuf_take()
@@ -2318,7 +2318,7 @@ base_index_mt.max_luac = function(index, key)
 end
 base_index_mt.random_ffi = function(index, rnd)
     if builtin.box_read_ffi_is_disabled then
-        return index:random_luac(rnd)
+        return base_index_mt.random_luac(index, rnd)
     end
     check_index_arg(index, 'random')
     rnd = rnd or math.random()
@@ -2388,7 +2388,7 @@ end
 
 base_index_mt.get_ffi = function(index, key)
     if builtin.box_read_ffi_is_disabled then
-        return index:get_luac(key)
+        return base_index_mt.get_luac(index, key)
     end
     check_index_arg(index, 'get')
     local ibuf = cord_ibuf_take()
@@ -2487,7 +2487,7 @@ end
 
 base_index_mt.select_ffi = function(index, key, opts)
     if builtin.box_read_ffi_is_disabled then
-        return index:select_luac(key, opts)
+        return base_index_mt.select_luac(index, key, opts)
     end
     local nok
     check_index_arg(index, 'select')

--- a/test/box-luatest/box_read_ffi_disable_test.lua
+++ b/test/box-luatest/box_read_ffi_disable_test.lua
@@ -1,0 +1,122 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group(nil, {{disable_ffi = true}, {disable_ffi = false}})
+
+g.before_all(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+    cg.server:exec(function(disable_ffi)
+        local s = box.schema.space.create('test')
+        s:create_index('primary')
+        s:create_index('secondary', {unique = false, parts = {2, 'unsigned'}})
+        for i = 1, 5 do
+            s:insert({i * 2 - 1, i})
+            s:insert({i * 2, 6 - i})
+        end
+        if disable_ffi then
+            local ffi = require('ffi')
+            ffi.cdef('void box_read_ffi_disable(void);')
+            ffi.C.box_read_ffi_disable()
+        end
+    end, {cg.params.disable_ffi})
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_min = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.test
+        t.assert_error_msg_content_equals(
+            "Use index:min(...) instead of index.min(...)",
+            s.index.primary.min)
+        t.assert_equals(s.index.primary:min(), {1, 1})
+        t.assert_equals(s.index.primary:min(2), {2, 5})
+        t.assert_equals(s.index.secondary:min(), {1, 1})
+        t.assert_equals(s.index.secondary:min(2), {3, 2})
+    end)
+end
+
+g.test_max = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.test
+        t.assert_error_msg_content_equals(
+            "Use index:max(...) instead of index.max(...)",
+            s.index.primary.max)
+        t.assert_equals(s.index.primary:max(), {10, 1})
+        t.assert_equals(s.index.primary:max(2), {2, 5})
+        t.assert_equals(s.index.secondary:max(), {9, 5})
+        t.assert_equals(s.index.secondary:max(2), {8, 2})
+    end)
+end
+
+g.test_random = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.test
+        t.assert_error_msg_content_equals(
+            "Use index:random(...) instead of index.random(...)",
+            s.index.primary.random)
+        t.assert_equals(s.index.primary:random(1), {2, 5})
+        t.assert_equals(s.index.primary:random(2), {3, 2})
+        t.assert_equals(s.index.secondary:random(3), {8, 2})
+        t.assert_equals(s.index.secondary:random(4), {5, 3})
+    end)
+end
+
+g.test_get = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.test
+        t.assert_error_msg_content_equals(
+            "Use index:get(...) instead of index.get(...)",
+            s.index.primary.get)
+        t.assert_error_msg_content_equals(
+            "Invalid key part count in an exact match (expected 1, got 0)",
+            s.index.primary.get, s.index.primary)
+        t.assert_error_msg_content_equals(
+            "Get() doesn't support partial keys and non-unique indexes",
+            s.index.secondary.get, s.index.secondary, 1)
+        t.assert_equals(s:get(1), {1, 1})
+        t.assert_equals(s.index.primary:get(1), {1, 1})
+    end)
+end
+
+g.test_select = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        local s = box.space.test
+        t.assert_error_msg_content_equals(
+            "Use index:select(...) instead of index.select(...)",
+            s.index.primary.select)
+        t.assert_error_msg_content_equals(
+            "Unknown iterator type 'foo'",
+            s.index.primary.select, s.index.primary,  {}, {iterator = 'foo'})
+        t.assert_equals(s:select(2, {iterator = 'lt'}), {{1, 1}})
+        t.assert_equals(s.index.primary:select(1), {{1, 1}})
+        t.assert_equals(s.index.secondary:select(1), {{1, 1}, {10, 1}})
+    end)
+end
+
+g.test_pairs = function(cg)
+    cg.server:exec(function()
+        local fun = require('fun')
+        local t = require('luatest')
+        local s = box.space.test
+        t.assert_error_msg_content_equals(
+            "Use index:pairs(...) instead of index.pairs(...)",
+            s.index.primary.pairs)
+        t.assert_error_msg_content_equals(
+            "Unknown iterator type 'foo'",
+            s.index.primary.pairs, s.index.primary,  {}, {iterator = 'foo'})
+        local gen = s.index.secondary:pairs(2)
+        t.assert_error_msg_content_equals("usage: next(param, state)", gen)
+        t.assert_equals(fun.totable(s:pairs(2, {iterator = 'lt'})), {{1, 1}})
+        t.assert_equals(fun.totable(s.index.primary:pairs(1)), {{1, 1}})
+        t.assert_equals(fun.totable(s.index.secondary:pairs(1)),
+                        {{1, 1}, {10, 1}})
+    end)
+end


### PR DESCRIPTION
This PR fixes a minor error reporting bug when `box_read_ffi_is_disabled` is set, which was introduced by commit 7f2c760967e40. It also adds a bunch of tests that ensure that FFI and Lua C version of index read operations are equivalent.

Fixes https://github.com/tarantool/tarantool-ee/issues/254