### PR TITLE
box: fix usage of pcall/box.error idiom

### DIFF
--- a/src/box/lua/net_box.lua
+++ b/src/box/lua/net_box.lua
@@ -297,9 +297,9 @@ end
 local space_metatable, index_metatable
 
 local function new_sm(uri, opts)
-    local parsed_uri = urilib.parse(uri)
+    local parsed_uri, err = urilib.parse(uri)
     if not parsed_uri then
-        box.error()
+        error(err)
     end
     if opts.user == nil and opts.password == nil then
         opts.user, opts.password = parsed_uri.login, parsed_uri.password
@@ -1256,7 +1256,7 @@ this_module.self = {
             call_loadproc, proc_name)
         if not status then
             rollback()
-            return box.error() -- re-throw
+            return error(proc) -- re-throw
         end
         if obj ~= nil then
             return handle_eval_result(pcall(proc, obj, unpack(args)))


### PR DESCRIPTION
In most places (schema.lua for example) we use box.error() to throw error after error return from C function. Function is supposed to set diag and box.error() will throw error based on the diag. For example (crypto.lua):

    local ctx = ffi.C.crypto_stream_new(algo, mode, direction)
    if ctx == nil then
        box.error()
    end

This code is nice in case C function does not forget to set a diag.

But we have a different usage idiom of box.error().

    local result = pcall(module.cfg)
    if not result and oldvals ~= nil then
        rollback_module(module, oldcfg, keys, oldvals)
        return box.error()
    end

How it can go wrong? module.cfg is not necessary a C function. If it is a Lua function it can throw error without diag. And if diag is not set then box.error() is NOOP. So if there is a bug in code then Lua generates error and it will be hided in this idiom. Or code can intentionally throw Lua error() and again it will be hided. Or diag can be set in some other place before and error will not be hided but instead we will receive incorrect diagnosis.

One can argue that all these cases are some kind of bugs. But in this case it will be useful to have correct diagnosis given it does not involve much effort.

In short let's abandon pcall/box.error usage and use pcall/error(err) instead.

Follow-up https://github.com/tarantool/tarantool-ee/issues/200

NO_DOC=internal
NO_TEST=internal
NO_CHANGELOG=internal