### PR TITLE
Generate changelog for 2.10.3

### DIFF
--- a/changelogs/2.10.3.md
+++ b/changelogs/2.10.3.md
@@ -1,0 +1,103 @@
+Date: 2022-09-30
+Tag: 2.10.3
+
+## Overview
+
+2.10.3 is the 4th [stable][release_policy] version of the 2.10 release
+series. It introduces 2 improvements and resolves 19 bugs since
+2.10.2.
+
+The "stable" label means that we have all planned features implemented and we
+see no high-impact issues. However, if you encounter an issue, feel free to
+[report it][issues] on GitHub.
+
+[release_policy]: https://www.tarantool.io/en/doc/latest/dev_guide/release_management/#release-policy
+[issues]: https://github.com/tarantool/tarantool/issues
+
+## Compatibility
+
+Tarantool 2.x is backward compatible with Tarantool 1.10.x in the binary data
+layout, client-server protocol, and replication protocol.
+
+Please [upgrade][upgrade] using the `box.schema.upgrade()` procedure to unlock
+all the new features of the 2.x series.
+
+[upgrade]: https://www.tarantool.io/en/doc/latest/book/admin/upgrades/
+
+## Functionality added or changed
+
+### Build
+
+* RedOS 7.3 is now supported.
+* Added the `-DENABLE_HARDENING=ON/OFF` CMake option that enables hardening
+  against memory corruption attacks (gh-7536).
+
+## Bugs fixed
+
+### Core
+
+* Fixed a bug introduced in Tarantool 2.10.2: log messages
+  could be written to data files thus causing data corruption.
+  The issue was fixed by reverting the fix for gh-4450.
+* Switched from MT-Unsafe `strerror()` to MT-Safe `strerror_r()`. The usage
+  of the unsafe function could result in corrupted error messages.
+* Fixed a bug when a single JSON update couldn't insert and update a field of a map or
+  an array in two sequential calls. It would either crash or return an error (gh-7705).
+
+### Memtx
+
+* Fixed incorrect handling of transaction conflicts in full scans
+  by HASH indexes (gh-7493).
+* Fixed `use after free` that could occur in the transaction manager
+  in certain states (gh-7449).
+* Fixed possible phantom reads with `get` on TREE indexes containing
+  nullable parts (gh-7685).
+* Fixed an inconsistency in `index:random` in the context of transaction management
+  (gh-7670).
+* Fixed unserializable reads tracked incorrectly after transaction rollbacks
+  (gh-7343).
+
+### Replication
+
+* Fixed a bug when a fiber committing a synchronous transaction could hang if
+  the instance got a term bump during that or its synchro-queue was fenced in
+  any other way (gh-7253).
+* Fixed master occasionally deleting xlogs needed by replicas even without a
+  restart (gh-7584).
+
+### Raft
+
+* Fixed a bug when `box.ctl.promote()` could hang and bump thousands of terms in
+  a row if called on more than one node at the same time (part of gh-7253).
+* Fixed a bug when a node with `election_mode='voter'` could hang in
+  `box.ctl.promote()` or become a leader (part of gh-7253).
+* Fixed a bug when a replicaset could be split into parts if a node voted
+  for another instance while having local WAL writes unfinished (part of gh-7253).
+
+### Lua
+
+#### Merger
+
+* Fixed `use after free` that could occur during iteration over `merge_source:pairs()` or
+  `merger:pairs()` (gh-7657).
+
+#### Popen
+
+* Fixed a race condition in `<popen handle>:signal()` on Mac OS 12 and newer (gh-7658).
+
+### Box
+
+* Fixed a bug when `fiber.yield()` might break the execution of a shutdown
+  trigger (gh-7434).
+* Fixed a possible high CPU usage caused by shutdown triggers (gh-6801).
+
+### Synchro
+
+* Fixed assertions in debug builds and undefined behaviour in release builds
+  when simultaneous elections started or another instance was promoted while
+  an instance was acquiring or releasing the synchro queue (gh-7086).
+
+### Uri
+
+* Fixed a bug in the URI parser: tarantoolctl could not
+  connect when the host name was skipped (gh-7479).

--- a/changelogs/unreleased/add-redos-7.3-ci-cd.md
+++ b/changelogs/unreleased/add-redos-7.3-ci-cd.md
@@ -1,3 +1,0 @@
-## feature/build
-
-* RedOS 7.3 is now supported.

--- a/changelogs/unreleased/gh-4450-logger-sigsegv-revert.md
+++ b/changelogs/unreleased/gh-4450-logger-sigsegv-revert.md
@@ -1,5 +1,0 @@
-## bugfix/core
-
-* Fixed a bug introduced in Tarantool 2.10.2: log messages
-  could be written to data files thus causing data corruption.
-  The issue was fixed by reverting the fix for gh-4450.

--- a/changelogs/unreleased/gh-6801-high-cpu-usage-by-on_shutdown-triggers.md
+++ b/changelogs/unreleased/gh-6801-high-cpu-usage-by-on_shutdown-triggers.md
@@ -1,3 +1,0 @@
-## bugfix/box
-
-* Fixed a possible high CPU usage caused by shutdown triggers (gh-6801).

--- a/changelogs/unreleased/gh-7086-box_issue_promote_demote_asserts.md
+++ b/changelogs/unreleased/gh-7086-box_issue_promote_demote_asserts.md
@@ -1,5 +1,0 @@
-## bugfix/synchro
-
-* Fixed assertions in debug builds and undefined behaviour in release builds
-  when simultaneous elections started or another instance was promoted while
-  an instance was acquiring or releasing the synchro queue (gh-7086).

--- a/changelogs/unreleased/gh-7253-fiber-hang-on-fencing.md
+++ b/changelogs/unreleased/gh-7253-fiber-hang-on-fencing.md
@@ -1,5 +1,0 @@
-## bugfix/replication
-
-* Fixed a bug when a fiber committing a synchronous transaction could hang if
-  the instance got a term bump during that or its synchro-queue was fenced in
-  any other way (gh-7253).

--- a/changelogs/unreleased/gh-7253-split-brain-early-vote.md
+++ b/changelogs/unreleased/gh-7253-split-brain-early-vote.md
@@ -1,4 +1,0 @@
-## bugfix/raft
-
-* Fixed a bug when a replicaset could be split into parts if a node voted
-  for another instance while having local WAL writes unfinished (gh-7253).

--- a/changelogs/unreleased/gh-7343-unserializable-read-tracked-incorrectly-after-rollback.md
+++ b/changelogs/unreleased/gh-7343-unserializable-read-tracked-incorrectly-after-rollback.md
@@ -1,4 +1,0 @@
-## bugfix/memtx
-
-* Fixed unserializable reads tracked incorrectly after transaction rollbacks
-  (gh-7343).

--- a/changelogs/unreleased/gh-7434-yield-in-on_shutdown-trigger.md
+++ b/changelogs/unreleased/gh-7434-yield-in-on_shutdown-trigger.md
@@ -1,4 +1,0 @@
-## bugfix/box
-
-* Fixed a bug when `fiber.yield()` might break the execution of a shutdown
-  trigger (gh-7434).

--- a/changelogs/unreleased/gh-7449-tuple-is-dirty-assertion-on-replace.md
+++ b/changelogs/unreleased/gh-7449-tuple-is-dirty-assertion-on-replace.md
@@ -1,4 +1,0 @@
-## bugfix/memtx
-
-* Fixed `use after free` that could occur in the transaction manager
-  in certain states (gh-7449).

--- a/changelogs/unreleased/gh-7493-memtx-hash-idx-repeatable-read-violation.md
+++ b/changelogs/unreleased/gh-7493-memtx-hash-idx-repeatable-read-violation.md
@@ -1,4 +1,0 @@
-## bugfix/memtx
-
-* Fixed incorrect handling of transaction conflicts in full scans
-  by HASH indexes (gh-7493).

--- a/changelogs/unreleased/gh-7536-add-cmake-enable_hardening-option.md
+++ b/changelogs/unreleased/gh-7536-add-cmake-enable_hardening-option.md
@@ -1,4 +1,0 @@
-## feature/build
-
-* Added the `-DENABLE_HARDENING=ON/OFF` CMake option that enables hardening
-  against memory corruption attacks (gh-7536).

--- a/changelogs/unreleased/gh-7584-missing-xlog-fix.md
+++ b/changelogs/unreleased/gh-7584-missing-xlog-fix.md
@@ -1,4 +1,0 @@
-## bugfix/replication
-
-* Fixed master occasionally deleting xlogs needed by replicas even without a
-  restart (gh-7584).

--- a/changelogs/unreleased/gh-7670-memtx-tx-manager-idx-rand-inconsistency.md
+++ b/changelogs/unreleased/gh-7670-memtx-tx-manager-idx-rand-inconsistency.md
@@ -1,4 +1,0 @@
-## bugfix/memtx
-
-* Fixed an inconsistency in `index:random` in the context of transaction management
-  (gh-7670).

--- a/changelogs/unreleased/gh-7685-memtx-tree-idx-get-with-nullable-field-phantom-read.md
+++ b/changelogs/unreleased/gh-7685-memtx-tree-idx-get-with-nullable-field-phantom-read.md
@@ -1,4 +1,0 @@
-## bugfix/memtx
-
-* Fixed possible phantom reads with `get` on TREE indexes containing
-  nullable parts (gh-7685).

--- a/changelogs/unreleased/gh-7705-json-update-crash.md
+++ b/changelogs/unreleased/gh-7705-json-update-crash.md
@@ -1,4 +1,0 @@
-## bugfix/core
-
-* Fixed a bug when a single JSON update couldn't insert and update a field of a map or
-  an array in two sequential calls. It would either crash or return an error (gh-7705).

--- a/changelogs/unreleased/igrishnov/gh-7479-bug-fix-uri-lib.md
+++ b/changelogs/unreleased/igrishnov/gh-7479-bug-fix-uri-lib.md
@@ -1,4 +1,0 @@
-## bugfix/uri
-
-* Fixed a bug in the URI parser: tarantoolctl could not
-  connect when the host name was skipped (gh-7479).

--- a/changelogs/unreleased/merger-use-after-free-in-gen.md
+++ b/changelogs/unreleased/merger-use-after-free-in-gen.md
@@ -1,4 +1,0 @@
-## bugfix/lua/merger
-
-* Fixed `use after free` that could occur during iteration over `merge_source:pairs()` or
-  `merger:pairs()` (gh-7657).

--- a/changelogs/unreleased/popen-mac-os-race.md
+++ b/changelogs/unreleased/popen-mac-os-race.md
@@ -1,3 +1,0 @@
-## bugfix/lua/popen
-
-* Fixed a race condition in `<popen handle>:signal()` on Mac OS 12 and newer (gh-7658).

--- a/changelogs/unreleased/promote-hang.md
+++ b/changelogs/unreleased/promote-hang.md
@@ -1,4 +1,0 @@
-## bugfix/raft
-
-* Fixed a bug when a node with `election_mode='voter'` could hang in
-  `box.ctl.promote()` or become a leader.

--- a/changelogs/unreleased/promote-multiple-infinite.md
+++ b/changelogs/unreleased/promote-multiple-infinite.md
@@ -1,4 +1,0 @@
-## bugfix/raft
-
-* Fixed a bug when `box.ctl.promote()` could hang and bump thousands of terms in
-  a row if called on more than one node at the same time.

--- a/changelogs/unreleased/strerror-mt-safe.md
+++ b/changelogs/unreleased/strerror-mt-safe.md
@@ -1,4 +1,0 @@
-## bugfix/core
-
-* Switched from MT-Unsafe `strerror()` to MT-Safe `strerror_r()`. The usage
-  of the unsafe function could result in corrupted error messages.


### PR DESCRIPTION
Generate changelog for 2.10.3 release.
Also, clean changelogs/unreleased folder.

NO_DOC=no code changes
NO_TEST=no code changes
NO_CHANGELOG=no code changes