### PR TITLE
replication: make ER_READONLY non-retriable for applier

### DIFF
--- a/changelogs/unreleased/fix-bootstrap-with-er-readonly.md
+++ b/changelogs/unreleased/fix-bootstrap-with-er-readonly.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed replicaset bootstrap getting stuck on some nodes with `ER_READONLY` when
+  there are connectivity problems (gh-7737).

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -2170,8 +2170,7 @@ applier_f(va_list ap)
 				/* Connection to itself, stop applier */
 				applier_disconnect(applier, APPLIER_OFF);
 				return 0;
-			} else if (e->errcode() == ER_LOADING ||
-				   e->errcode() == ER_READONLY) {
+			} else if (e->errcode() == ER_LOADING) {
 				/* Autobootstrap */
 				applier_log_error(applier, e);
 				applier_disconnect(applier, APPLIER_LOADING);

--- a/test/replication-luatest/gh_7377_bootstrap_connection_failure_test.lua
+++ b/test/replication-luatest/gh_7377_bootstrap_connection_failure_test.lua
@@ -1,0 +1,91 @@
+local t = require('luatest')
+local cluster = require('test.luatest_helpers.cluster')
+local server = require('test.luatest_helpers.server')
+local proxy = require('test.luatest_helpers.proxy.proxy')
+
+local fio = require('fio')
+local fiber = require('fiber')
+
+local g = t.group('bootstrap-connection-failure')
+
+local timeout = 0.1
+
+g.before_all(function(cg)
+    cg.cluster = cluster:new{}
+    cg.servers = {}
+    local box_cfg = {
+        replication = {
+            server.build_instance_uri('server_1'),
+            server.build_instance_uri('server_2'),
+            server.build_instance_uri('server_3'),
+        },
+        replication_timeout = timeout,
+    }
+    cg.uuids = {
+        'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        'cccccccc-cccc-cccc-cccc-cccccccccccc',
+    }
+
+    -- Connection server_3 -> server_1 is proxied, others are not.
+    cg.proxy = proxy:new{
+        client_socket_path = server.build_instance_uri('server_1_proxy'),
+        server_socket_path = server.build_instance_uri('server_1'),
+    }
+    t.assert(cg.proxy:start{force = true}, 'Proxy started successfully')
+    for i = 1, 3 do
+        box_cfg.instance_uuid = cg.uuids[i]
+        if i == 3 then
+            box_cfg.replication[1] = server.build_instance_uri('server_1_proxy')
+        end
+        cg.servers[i] = cg.cluster:build_and_add_server({
+            alias = 'server_' .. i,
+            box_cfg = box_cfg,
+        })
+    end
+end)
+
+g.after_all(function(cg)
+    cg.cluster:drop()
+end)
+
+local bootstrap_msg = 'bootstrapping replica from '
+local ready_msg = 'ready to accept requests'
+
+local function wait_bootstrapped(server, uuidstr)
+    local logfile = fio.pathjoin(server.workdir, server.alias .. '.log')
+    -- Prepare the search pattern for grep log.
+    local query = string.gsub(uuidstr, '%-', '%%-')
+    t.helpers.retrying({}, function()
+        t.assert(server:grep_log(bootstrap_msg .. query, nil,
+                                 {filename = logfile}),
+                 'Server ' .. server.alias .. ' chose ' .. uuidstr ..
+                 ' as bootstrap leader')
+        t.assert(server:grep_log(ready_msg, nil, {filename = logfile}),
+                 'Server ' .. server.alias .. ' is bootstrapped')
+    end)
+end
+
+--
+-- Make sure there is no deadlock when bootstrapping 3 nodes with connectivity
+-- problems.
+-- The issue might appear when some node manages to connect only part of the
+-- cluster before bootstrap happens. Once the node connects to everyone, the
+-- remote ballots it has fetched will be inconsistent to choose a bootstrap
+-- leader. The real leader might still have ballot.is_booted = false in its old
+-- ballot, while the node might choose someone with ballot.is_booted = true as
+-- its bootstrap leader.
+-- So the node has to re-fetch everyone's ballots in order to choose the same
+-- bootstrap leader as everyone else.
+g.test_bootstrap_with_bad_connection = function(cg)
+    cg.proxy:pause()
+    cg.cluster:start{wait_for_readiness = false}
+    wait_bootstrapped(cg.servers[1], cg.uuids[2])
+    fiber.sleep(timeout)
+    local logfile = fio.pathjoin(cg.servers[3].workdir, 'server_3.log')
+    t.assert(not cg.servers[3]:grep_log(bootstrap_msg, nil,
+                                        {filename = logfile}),
+             'Server 3 waits for connection')
+    cg.proxy:resume()
+    wait_bootstrapped(cg.servers[3], cg.uuids[2])
+end


### PR DESCRIPTION
The commit c1c77782215e ("replication: fix bootstrap failing with ER_READONLY") made applier retry connection infinitely upon receiving a ER_READONLY error on join. At the time of writing that commit, this was the only way to make join retriable. Because there were no retries in scope of bootstrap_from_master. The join either succeeded or failed.

Later on, bootstrap_from_master was made retriable in commit f2ad1deecbea ("replication: retry join automatically"). Now when bootstrap_from_master fails, replica reconnects to all the remote nodes, thus updating their ballots, chooses a new (probably different from the previous approach) bootstrap leader, and retries booting from it.

The second approach is more preferable, and here's why. Imagine bootstrapping a cluster of 3 nodes, A, B and C in a full-mesh topology. B and C connect to all the remote peers almost instantly, and both independently decide that B will be the bootstrap leader (it means it has the smallest uuid among A, B, C).

At the same time, A can't connect to C. B bootstraps the cluster, and joins C. After C is joined, A finally connects to C. Now A can choose a bootstrap leader. It has an old B's ballot (smallest uuid, but not yet booted) and C's ballot (already booted). This is because C's ballot is received after cluster bootstrap, and B's ballot was received earlier than that. So A believes C is a better bootstrap leader, and tries to boot from it.

A will fail joining to C, because at the same time C tries to sync with everyone, including A, and thus stays read-only. Since A retries joining to the same instance over and over again, this situation makes the A and C stuck forever.

Let's retry ER_READONLY on another level: instead of trying to join to the same bootstrap leader over and over, try to choose a new bootstrap leader and boot from it.

In the situation described above, this means that A would try to join to C once, fail due to ER_READONLY, re-fetch new ballots from everyone and choose B as a join master (now it has smallest uuid and is booted).

The issue was discovered due to linearizable_test.lua hanging occasionally with the following output:
NO_WRAP
 No output during 40 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
- 059_replication-luatest [replication-luatest/linearizable_test.lua, None] at /tmp/t/059_replication-luatest/linearizable.result:0
[059] replication-luatest/linearizable_test.lua                       [ fail ]
[059] Test failed! Output from reject file /tmp/t/rejects/replication-luatest/linearizable.reject:
[059] TAP version 13
[059] 1..6
[059] # Started on Thu Sep 29 10:30:45 2022
[059] # Starting group: linearizable-read
[059] not ok 1	linearizable-read.test_wait_others
[059] #   ....11.0~entrypoint.531.dev/test/luatest_helpers/server.lua:104: Waiting for "readiness" on server server_1-q7berSRY4Q_E (PID 53608) timed out
[059] #   stack traceback:
[059] #   	....11.0~entrypoint.531.dev/test/luatest_helpers/server.lua:104: in function 'wait_for_readiness'
[059] #   	...11.0~entrypoint.531.dev/test/luatest_helpers/cluster.lua:92: in function 'start'
[059] #   	...t.531.dev/test/replication-luatest/linearizable_test.lua:50: in function <...t.531.dev/test/replication-luatest/linearizable_test.lua:20>
[059] #   	...
[059] #   	[C]: in function 'xpcall'
NO_WRAP

NO_DOC=bugfix