### PR TITLE
memtx: split `memtx_tx_story_unlink_both` logic in two separate contexts

### DIFF
--- a/changelogs/unreleased/gh-7757-memtx-space-drop-triggers-assertion.md
+++ b/changelogs/unreleased/gh-7757-memtx-space-drop-triggers-assertion.md
@@ -1,0 +1,3 @@
+## bugfix/memtx
+
+* Fixed assertion being triggered on `space:drop` (gh-7757).

--- a/test/box-luatest/gh_7757_memtx_space_drop_triggers_assertion_test.lua
+++ b/test/box-luatest/gh_7757_memtx_space_drop_triggers_assertion_test.lua
@@ -1,0 +1,29 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new {
+        alias   = 'dflt',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+--[[
+Checks that `space:drop` does not trigger assertion.
+]]
+g.test_space_drop_does_not_trigger_assertion = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('s')
+        s:create_index('pk')
+        s:insert{0}
+        s:get{0}
+        s:drop()
+    end)
+end


### PR DESCRIPTION
`memtx_tx_story_unlink_both` is called in two separate contexts: on space delete and on rollback. In the former case we need to simply unlink the story, while in the latter case we need to rebind read and gap trackers, and, perhaps do some other logic in the future. Calling `memtx_tx_story_unlink_both` in the former context can trigger assertion: split the function and its helpers into two separate functions for each case, grouping the common logic into third `*_common` functions.

Closes #7757