### PR TITLE
memtx: add assertion and test for gap tracker retention during rollback

### DIFF
--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -2212,6 +2212,8 @@ memtx_tx_history_rollback_added_story(struct txn_stmt *stmt)
 	memtx_tx_story_unlink_added_by(story, stmt);
 	if (!story->rollbacked) {
 		assert(rlist_empty(&story->reader_list));
+		for (uint32_t idx = 0; idx < story->index_count; ++idx)
+			assert(rlist_empty(&story->link[idx].nearby_gaps));
 		memtx_tx_story_delete(story);
 	}
 }

--- a/test/box-luatest/gh_7343_unserializable_read_tracked_incorrectly_after_rollback_test.lua
+++ b/test/box-luatest/gh_7343_unserializable_read_tracked_incorrectly_after_rollback_test.lua
@@ -51,3 +51,46 @@ pg.test_unserializable_read_after_rollback = function(cg)
         stream2:commit()
     end)
 end
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new{
+        alias   = 'dflt',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    cg.server:start()
+    cg.server:exec(function()
+        local s = box.schema.create_space('s')
+        s:create_index('pk')
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+--[[
+Checks that gap are tracked correctly after transaction rollback.
+]]
+g.test_gap_tracked_correctly_rollback = function(cg)
+    local stream1 = cg.server.net_box:new_stream()
+    local stream2 = cg.server.net_box:new_stream()
+
+    stream1:begin()
+    stream2:begin()
+
+    stream1.space.s:insert{1}
+    -- Gap from {0} to {1} is tracked.
+    stream2.space.s:select({0}, {iterator = 'LE'})
+    -- {1} containing gap tracker is rolled back.
+    stream1:rollback()
+
+    cg.server:exec(function()
+        -- Gap write into [0; 1].
+        box.space.s:insert{0}
+    end)
+    t.assert_equals(stream2.space.s:select({0}, {iterator = 'LE'}), {})
+    t.assert_error_msg_content_equals('Transaction has been aborted by conflict',
+                                      function() stream2.space.s:insert{1} end)
+end


### PR DESCRIPTION
Gap trackers are stored in the story at the top of the history chain (see `memtx_tx_story_{un}link_top_light`): following this logic, during rollback we need to rebind them to the older story. We already maintain this in 8c24259, since a story is not retained iff it has a newer story (which means it does not store trackers) or if it has an older story (in which case rebinding is done in `memtx_tx_story_{un}link_top_light`): add an assertion that a story deleted during rollback does not have any gap trackers and a test for this case.

Follow-up 8c24259

NO_CHANGELOG=internal
NO_CHANGELOG=internal