### PR TITLE
memtx: deprecate HASH index 'GT' iterator type

### DIFF
--- a/changelogs/unreleased/gh-7231-memtx-hash-idx-gt-iter-deprecation.md
+++ b/changelogs/unreleased/gh-7231-memtx-hash-idx-gt-iter-deprecation.md
@@ -1,0 +1,3 @@
+## bugfix/memtx
+
+* Deprecated HASH index 'GT' iterator type (gh-7231).

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -443,7 +443,16 @@ memtx_hash_index_create_iterator(struct index *base, enum iterator_type type,
 	light_index_iterator_begin(&index->hash_table, &it->iterator);
 
 	switch (type) {
-	case ITER_GT:
+	case ITER_GT: {
+		static bool warn_once = false;
+		if (!warn_once) {
+			warn_once = true;
+			say_warn("HASH index 'GT' iterator type is deprecated "
+				 "since Tarantool 2.11 and should not be "
+				 "used. It will be removed in a future "
+				 "Tarantool release.");
+		}
+
 		if (part_count != 0) {
 			light_index_iterator_key(&index->hash_table, &it->iterator,
 					key_hash(key, base->def->key_def), key);
@@ -459,6 +468,7 @@ memtx_hash_index_create_iterator(struct index *base, enum iterator_type type,
 					 &index->base);
 /*********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND END**********/
 		break;
+	}
 	case ITER_ALL:
 		light_index_iterator_begin(&index->hash_table, &it->iterator);
 		it->base.next_internal = hash_iterator_ge;

--- a/test/box-luatest/gh_7231_memtx_hash_idx_gt_iter_deprecation_test.lua
+++ b/test/box-luatest/gh_7231_memtx_hash_idx_gt_iter_deprecation_test.lua
@@ -1,0 +1,40 @@
+local fio = require('fio')
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new {
+        alias   = 'dflt',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    cg.server:start()
+    cg.server:exec(function()
+        local s = box.schema.create_space('s')
+        s:create_index('pk', {type = 'HASH'})
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+-- Checks that a deprecation warning is printed exactly once when using memtx HASH
+-- index 'GT' iterator type.
+g.test_memtx_hash_idx_iter_gt_deprecation = function(cg)
+    cg.server:exec(function()
+        box.space.s:select({}, {iterator = 'GT'})
+    end)
+    local deprecation_warning = "HASH index 'GT' iterator type is " ..
+                                "deprecated since Tarantool 2.11 and should " ..
+                                "not be used. It will be removed in a " ..
+                                "future Tarantool release."
+    t.assert_is_not(cg.server:grep_log(deprecation_warning, 256), nil)
+    local log_file = g.server:exec(function() return box.cfg.log end)
+    fio.truncate(log_file)
+    cg.server:exec(function()
+        box.space.s:select({}, {iterator = 'GT'})
+    end)
+    t.assert_is(cg.server:grep_log(deprecation_warning, 256), nil)
+end


### PR DESCRIPTION
For reasons described in #7231 HASH index 'GT' iterator type is deprecated: print a warning exactly once about the deprecation.

Closes #7231