### PR TITLE
memtx secondary index uniqueness violation

### DIFF
--- a/changelogs/unreleased/gh-7761-memtx-sk-index-uniqueness-violation.md
+++ b/changelogs/unreleased/gh-7761-memtx-sk-index-uniqueness-violation.md
@@ -1,0 +1,4 @@
+## bugfix/memtx
+
+* Fixed possibility of secondary index uniqueness violation with transaction
+  manager enabled (gh-7761).

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -2405,11 +2405,6 @@ memtx_tx_history_prepare_insert_stmt(struct txn_stmt *stmt)
 				continue;
 			if (test_stmt->del_story == story)
 				continue;
-			if (test_stmt->del_story != NULL &&
-			    test_stmt->del_story->add_stmt != NULL &&
-			    test_stmt->del_story->add_stmt->txn ==
-			    test_stmt->txn)
-				continue;
 			memtx_tx_handle_conflict(stmt->txn, test_stmt->txn);
 			/*
 			 * Note that it's a secondary index and there's no

--- a/test/box-luatest/gh_7761_memtx_sk_index_uniqueness_violation_test.lua
+++ b/test/box-luatest/gh_7761_memtx_sk_index_uniqueness_violation_test.lua
@@ -1,0 +1,42 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group(nil, t.helpers.matrix({pk_type = {'TREE', 'HASH'},
+                                        sk_type = {'TREE', 'HASH'}}))
+
+g.before_all(function(cg)
+    cg.server = server:new {
+        alias   = 'dflt',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    cg.server:start()
+    cg.server:exec(function(pk_type, sk_type)
+        local s = box.schema.create_space('s')
+        s:create_index('pk', {type = pk_type})
+        s:create_index('sk', {type = sk_type, parts = {2}})
+    end, {cg.params.pk_type, cg.params.sk_type})
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+--[[
+Checks that memtx secondary index uniqueness is not violated.
+]]
+g.test_memtx_sk_index_unique_violation = function(cg)
+    local stream1 = cg.server.net_box:new_stream()
+    local stream2 = cg.server.net_box:new_stream()
+
+    stream1:begin()
+    stream2:begin()
+
+    stream1.space.s:insert{0, 1}
+    stream2.space.s:insert{1, 0}
+    stream2.space.s:replace{1, 1}
+
+    stream1:commit()
+    local conflict_err_msg = 'Transaction has been aborted by conflict'
+    t.assert_error_msg_content_equals(conflict_err_msg,
+                                      function() stream2:commit() end)
+end


### PR DESCRIPTION
memtx: fix conflict handling of stories in secondary indexes

If we find a newer story in the secondary index, the statement of which
deletes a story added in the same transaction, there can be two cases: if
the secondary index is not unique, this is impossible (since it's `cmp_def`
is extended with the primary index's `key_def` and there can only be story
chains in the primary index). Otherwise, the prepared story conflicts the
newer one: remove the incorrect check.

Closes https://github.com/tarantool/tarantool/issues/7761