### PR TITLE
sql: fix assertion during INDEXED BY

### DIFF
--- a/changelogs/unreleased/gh-5976-fix-assertion-during-indexed-by.md
+++ b/changelogs/unreleased/gh-5976-fix-assertion-during-indexed-by.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Fixed assertion when INDEXED BY was used with an index that was at
+  least third in space (gh-5976).

--- a/src/box/sql/where.c
+++ b/src/box/sql/where.c
@@ -4606,10 +4606,10 @@ sqlWhereBegin(Parse * pParse,	/* The parser context */
 					assert(wctrlFlags &
 					       WHERE_ONEPASS_DESIRED);
 					while (pJ->def->iid != idx_def->iid) {
-						iIndexCur++;
 						iid++;
 						pJ = pTabItem->space->index[iid];
 					}
+					iIndexCur++;
 				} else {
 					for(uint32_t i = 0;
 					    i < space->index_count; ++i) {

--- a/test/sql-luatest/gh_5976_indexed_by_assertion_test.lua
+++ b/test/sql-luatest/gh_5976_indexed_by_assertion_test.lua
@@ -1,0 +1,24 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'test_assertion_in_indexed_by'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_assertion_in_indexed_by = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        box.execute([[CREATE TABLE t (i INT PRIMARY KEY, s STRING);]])
+        box.space.T:create_index('I1', {parts = {2, 'string'}})
+        box.space.T:create_index('I2', {parts = {2, 'string'}})
+        local sql = [[UPDATE t INDEXED BY i2 SET s = 'a' WHERE s = 'z';]]
+        t.assert_equals(box.execute(sql), {row_count = 0})
+        box.execute([[DROP TABLE t;]])
+    end)
+end


### PR DESCRIPTION
This patch fixed the assertion when using INDEXED BY with an index that is at least the third in space.

Closes #5976

NO_DOC=bugfix