### PR TITLE
sql: fix assertion in JOIN using unsupported index

### DIFF
--- a/changelogs/unreleased/gh-5678-assertion-in-JOIN-using-unsupported-index.md
+++ b/changelogs/unreleased/gh-5678-assertion-in-JOIN-using-unsupported-index.md
@@ -1,0 +1,3 @@
+## bugfix/sql
+
+* Fixed assertion in JOIN in case of using unsupported index (gh-5678).

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -866,7 +866,7 @@ sql_column_collation(struct space_def *def, uint32_t column, uint32_t *coll_id)
 	return field->coll;
 }
 
-int
+void
 vdbe_emit_open_cursor(struct Parse *parse_context, int cursor, int index_id,
 		      struct space *space)
 {
@@ -878,12 +878,12 @@ vdbe_emit_open_cursor(struct Parse *parse_context, int cursor, int index_id,
 			 "using non-TREE index type. Please, use " \
 			 "INDEXED BY clause to force using proper index.");
 		parse_context->is_aborted = true;
-		return -1;
+		return;
 	}
 	struct Vdbe *vdbe = parse_context->pVdbe;
 	int reg = ++parse_context->nMem;
 	sqlVdbeAddOp2(vdbe, OP_OpenSpace, reg, space->def->id);
-	return sqlVdbeAddOp3(vdbe, OP_IteratorOpen, cursor, index_id, reg);
+	sqlVdbeAddOp3(vdbe, OP_IteratorOpen, cursor, index_id, reg);
 }
 
 /*

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2743,9 +2743,8 @@ sqlEndTable(struct Parse *parse);
  * @param index_id index id. In future will be replaced with
  *        pointer to struct index.
  * @param space Pointer to space object.
- * @retval address of last opcode.
  */
-int
+void
 vdbe_emit_open_cursor(struct Parse *parse, int cursor, int index_id,
 		      struct space *space);
 

--- a/src/box/sql/vdbeaux.c
+++ b/src/box/sql/vdbeaux.c
@@ -779,8 +779,6 @@ static void
 vdbeVComment(Vdbe * p, const char *zFormat, va_list ap)
 {
 	assert(p->nOp > 0 || p->aOp == 0);
-	assert(p->aOp == 0 || p->aOp[p->nOp - 1].zComment == 0
-	       || p->db->mallocFailed);
 	if (p->nOp) {
 		assert(p->aOp);
 		sqlDbFree(p->db, p->aOp[p->nOp - 1].zComment);

--- a/test/sql-luatest/gh_5678_join_with_unsupported_index_test.lua
+++ b/test/sql-luatest/gh_5678_join_with_unsupported_index_test.lua
@@ -1,0 +1,25 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'test_join_with_unsupported_index'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_join_with_unsupported_index = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local s = box.schema.space.create('T', {format = {'I'}})
+        s:create_index('ii', {type = 'hash'})
+        local _, err = box.execute([[SELECT a.i FROM t AS a, t;]])
+        local msg = [[SQL does not support using non-TREE index type. ]]..
+            [[Please, use INDEXED BY clause to force using proper index.]]
+        t.assert_equals(err.message, msg)
+        s:drop()
+    end)
+end


### PR DESCRIPTION
This patch fixed the assertion when JOIN uses index of unsupported type.

Closes #5678

NO_DOC=bugfix