### PR TITLE
replication: invalid recovery from xlog

### DIFF
--- a/changelogs/unreleased/gh-5158-invalid-recovery-from-xlog.md
+++ b/changelogs/unreleased/gh-5158-invalid-recovery-from-xlog.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed an assertion failure on master when replica resubscribes with a
+  smaller vclock than previously seen (gh-5158).

--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -1063,16 +1063,24 @@ relay_subscribe(struct replica *replica, struct iostream *io, uint64_t sync,
 	struct relay *relay = replica->relay;
 	assert(relay->state != RELAY_FOLLOW);
 	/*
-	 * Register the replica with the garbage collector
-	 * unless it has already been registered by initial
-	 * join.
+	 * Register the replica with the garbage collector.
+	 * In case some of the replica's WAL files were deleted, it might
+	 * subscribe with a smaller vclock than the master remembers, so
+	 * recreate the gc consumer unconditionally to make sure it holds
+	 * the correct vclock.
 	 */
-	if (replica->gc == NULL && !replica->anon) {
+	if (!replica->anon) {
+		bool had_gc = false;
+		if (replica->gc != NULL) {
+			gc_consumer_unregister(replica->gc);
+			had_gc = true;
+		}
 		replica->gc = gc_consumer_register(replica_clock, "replica %s",
 						   tt_uuid_str(&replica->uuid));
 		if (replica->gc == NULL)
 			diag_raise();
-		gc_delay_unref();
+		if (!had_gc)
+			gc_delay_unref();
 	}
 
 	if (replica_version_id < version_id(2, 6, 0) || replica->anon)

--- a/test/replication-luatest/gh_5158_invalid_recovery_from_xlog_test.lua
+++ b/test/replication-luatest/gh_5158_invalid_recovery_from_xlog_test.lua
@@ -1,0 +1,83 @@
+local t = require('luatest')
+local cluster = require('test.luatest_helpers.cluster')
+local server = require('test.luatest_helpers.server')
+local fio = require('fio')
+
+local g = t.group('gh_5158')
+
+g.before_each(function(cg)
+    cg.cluster = cluster:new({})
+    cg.master = cg.cluster:build_and_add_server{
+        alias = 'master',
+        box_cfg = {
+            checkpoint_count = 5,
+        },
+    }
+    cg.replica = cg.cluster:build_and_add_server{
+        alias = 'replica',
+        box_cfg = {
+            replication = {
+                server.build_instance_uri('master'),
+            },
+        },
+    }
+    cg.cluster:start()
+end)
+
+g.after_each(function(cg)
+    cg.cluster:drop()
+end)
+
+g.test_invalid_recovery_from_xlog = function(cg)
+    cg.master:exec(function()
+        box.schema.space.create("test")
+        box.snapshot()
+        box.space.test:create_index("pk")
+        box.snapshot()
+    end)
+
+    -- Wait until everything is replicated from the master to the replica
+    t.helpers.retrying({}, function()
+        cg.replica:wait_vclock_of(cg.master)
+    end)
+
+    -- Delete all *.xlogs on the replica
+    cg.replica:stop()
+    local glob = fio.pathjoin(cg.replica.workdir, '*.xlog')
+    local xlogs = fio.glob(glob)
+    for _, file in pairs(xlogs) do fio.unlink(file) end
+
+    -- We start the replica without replication so that the replica
+    -- does not catch up to the maximum vclock. Next, set
+    -- ERRINJ_WAL_DELAY_COUNTDOWN. And then we replicate.
+    -- The replica acknowledges that it has received part of the data
+    -- due to ERRINJ_WAL_DELAY_COUNTDOWN. As a result, on the intermediate
+    -- xlog on which the assert is fired (signature < prev_signature),
+    -- the GC is started.
+    --
+    -- A batch from WAL can immediately come to the replica. Accordingly,
+    -- ERRINJ_WAL_DELAY_COUNTDOWN stops the entire batch (the test
+    -- freezes), because the entire batch has arrived and the vclock
+    -- will catch up to the maximum value. Therefore, it is necessary
+    -- to use wal_queue_max_size. If wal_queue_max_size is equal to 1,
+    -- then transactions will come to WAL one at a time. The
+    -- replication_sync_timeout is set to 0.1 to avoid waiting 300
+    -- seconds when trying to synchronize with the master after updating
+    -- the replica configuration.
+    cg.replica.box_cfg.replication = nil
+    cg.replica:start()
+    cg.replica:exec(function(uri)
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 2)
+        box.cfg{wal_queue_max_size = 1}
+        box.cfg{replication = uri, replication_sync_timeout = 0.1}
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+    end, {server.build_instance_uri('master')})
+
+    -- Check that the master isn't dead
+    t.assert_equals(cg.master:exec(function()
+        return box.info.status
+    end), 'running')
+    t.helpers.retrying({}, function()
+        cg.replica:assert_follows_upstream(1)
+    end)
+end


### PR DESCRIPTION
If you shut down the replica and delete all xlog files on it, and it reconnect to the master, may occur the restore error. Because there are intermediate xlog files between the snap on the replica and the last xlog on the master. When restoring xlog files on the replica, it can be occurred that `prev_signature < signature` and this will lead to the crash of the master.

Closes #5158

NO_DOC=bugfix