### PR TITLE
Fix split-brain on a late CONFIRM from an old leader

### DIFF
--- a/changelogs/unreleased/gh-7253-split-brain-old-term-txn.md
+++ b/changelogs/unreleased/gh-7253-split-brain-old-term-txn.md
@@ -1,0 +1,5 @@
+## bugfix/raft
+
+* Fixed a bug when a replicaset could be split in parts if an old leader started
+  a new synchronous txn shortly before a new leader was going to be elected.
+  That was possible if the old leader didn't learn the new term yet (gh-7253).

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -1374,6 +1374,7 @@ applier_signal_ack(struct applier *applier)
 		applier->ack_msg.txn_last_tm = (r == NULL ? 0 :
 						r->applier_txn_last_tm);
 		applier->ack_msg.vclock_sync = applier->last_vclock_sync;
+		applier->ack_msg.term = box_raft()->term;
 		vclock_copy(&applier->ack_msg.vclock, &replicaset.vclock);
 		cmsg_init(&applier->ack_msg.base, applier->ack_route);
 		cpipe_push(&applier->applier_thread->thread_pipe,
@@ -1397,6 +1398,7 @@ applier_thread_signal_ack(struct cmsg *base)
 	applier->thread.txn_last_tm = msg->txn_last_tm;
 	struct applier_heartbeat *ack = &applier->thread.next_ack;
 	ack->vclock_sync = msg->vclock_sync;
+	ack->term = msg->term;
 	vclock_copy(&ack->vclock, &msg->vclock);
 }
 

--- a/src/box/applier.h
+++ b/src/box/applier.h
@@ -120,6 +120,8 @@ struct applier_ack_msg {
 	 * Set to replica::applier_txn_last_tm.
 	 */
 	double txn_last_tm;
+	/** Last known raft term. */
+	uint64_t term;
 	/** Replicaset vclock. */
 	struct vclock vclock;
 	/** The vclock sync this message corresponds to. */

--- a/src/box/applier.h
+++ b/src/box/applier.h
@@ -255,15 +255,10 @@ struct applier {
 		 */
 		double txn_last_tm;
 		/**
-		 * Last sync value known to applier thread. Sent in ACK
-		 * messages.
+		 * Appler's next ACK to send to relay. Updated by
+		 * applier_ack_msg.
 		 */
-		uint64_t last_vclock_sync;
-		/**
-		 * Applier thread's copy of the node's vclock. Sent in ACK
-		 * messages and updated by applier_ack_msg.
-		 */
-		struct vclock ack_vclock;
+		struct applier_heartbeat next_ack;
 	} thread;
 };
 

--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -541,11 +541,8 @@ relay_final_join(struct iostream *io, uint64_t sync,
 		relay_stop(relay);
 		relay_delete(relay);
 	});
-
 	/*
-	 * Save the first vclock as 'received'. Because firstly, it was really
-	 * received. Secondly, recv_vclock is used by recovery restart and must
-	 * always be valid.
+	 * Save the first vclock as 'received'. Because it was really received.
 	 */
 	vclock_copy(&relay->recv_vclock, start_vclock);
 	relay->r = recovery_new(wal_dir(), false, start_vclock);
@@ -1067,9 +1064,7 @@ relay_subscribe(struct replica *replica, struct iostream *io, uint64_t sync,
 
 	vclock_copy(&relay->local_vclock_at_subscribe, &replicaset.vclock);
 	/*
-	 * Save the first vclock as 'received'. Because firstly, it was really
-	 * received. Secondly, recv_vclock is used by recovery restart and must
-	 * always be valid.
+	 * Save the first vclock as 'received'. Because it was really received.
 	 */
 	vclock_copy(&relay->recv_vclock, replica_clock);
 	relay->r = recovery_new(wal_dir(), false, replica_clock);
@@ -1124,11 +1119,6 @@ relay_raft_msg_push(struct cmsg *base)
 	struct xrow_header row;
 	xrow_encode_raft(&row, &fiber()->gc, &msg->req);
 	try {
-		/*
-		 * Send the message before restarting the recovery. Otherwise
-		 * all the rows would be sent from under a non-leader role and
-		 * would be ignored again.
-		 */
 		relay_send(msg->relay, &row);
 		msg->relay->sent_raft_term = msg->req.term;
 	} catch (Exception *e) {

--- a/src/box/xrow.h
+++ b/src/box/xrow.h
@@ -572,6 +572,8 @@ struct applier_heartbeat {
 	struct vclock vclock;
 	/** Last vclock sync received from relay. */
 	uint64_t vclock_sync;
+	/** Replica's last known raft term. */
+	uint64_t term;
 };
 
 /** Encode applier heartbeat. */

--- a/src/lib/raft/raft.h
+++ b/src/lib/raft/raft.h
@@ -412,6 +412,13 @@ void
 raft_new_term(struct raft *raft);
 
 /**
+ * Handle a term reported by the instance with the given ID. Might cause local
+ * term bump.
+ */
+void
+raft_process_term(struct raft *raft, uint64_t term, uint32_t source);
+
+/**
  * Save complete Raft state into a request to be sent to other instances of the
  * cluster. It is allowed to save anything here, not only persistent state.
  */

--- a/test/luatest_helpers/misc.lua
+++ b/test/luatest_helpers/misc.lua
@@ -22,6 +22,7 @@ local function skip_if_enterprise()
 end
 
 return {
+    is_debug_build = is_debug_build,
     skip_if_not_debug = skip_if_not_debug,
     skip_if_enterprise = skip_if_enterprise,
 }

--- a/test/replication-luatest/gh_5295_split_brain_test.lua
+++ b/test/replication-luatest/gh_5295_split_brain_test.lua
@@ -85,7 +85,10 @@ g.after_each(function(cg)
     cg.split_replica:stop()
     cg.split_replica:cleanup()
     -- Drop the replica's cluster entry, so that next one receives same id.
-    cg.main:exec(function() box.space._cluster:delete{2} end)
+    cg.main:exec(function()
+        box.ctl.promote()
+        box.space._cluster:delete{2}
+    end)
     cg.cluster.servers[2] = nil
 end)
 

--- a/test/replication-luatest/gh_7253_election_long_wal_write_test.lua
+++ b/test/replication-luatest/gh_7253_election_long_wal_write_test.lua
@@ -59,12 +59,20 @@ local function server_wait_wal_is_blocked(server)
                        check_wal_is_blocked_f)
 end
 
+local function server_set_replication(server, replication)
+    server:exec(function(replication)
+        box.cfg{replication = replication}
+    end, {replication})
+end
+
 g.before_all(function(g)
     g.cluster = cluster:new({})
     local box_cfg = {
         replication_synchro_timeout = 1000,
         replication_synchro_quorum = 2,
         replication_timeout = 0.1,
+        election_timeout = 1000,
+        election_fencing_enabled = false,
         replication = {
             server.build_instance_uri('server1'),
             server.build_instance_uri('server2'),
@@ -158,6 +166,10 @@ g.test_fence_during_confirm_wal_write = function(g)
     g.server1:exec(function()
         box.ctl.promote()
     end)
+    g.server1:wait_election_leader()
+    g.server1:exec(function()
+        box.space.test:truncate()
+    end)
     wait_fullmesh(g)
 end
 
@@ -245,5 +257,267 @@ g.test_vote_during_txn_wal_write = function(g)
         box.cfg{replication = _G.old_replication}
         _G.old_replication = nil
     end)
+    g.server1:wait_election_leader()
+    g.server1:exec(function()
+        box.space.test:truncate()
+    end)
+    wait_fullmesh(g)
+end
+
+--
+-- Old leader doesn't know about a new term, makes a sync transaction in the old
+-- term. The transaction is not yet delivered anywhere. At the same time another
+-- instance bumps the term, wins elections, starts writing PROMOTE.
+--
+-- The transaction from the old leader shouldn't be CONFIRMed by it. At least
+-- one of the surrounding instances from quorum should respond "we ack this, but
+-- there is a new term - you can't write CONFIRM".
+--
+-- New leader PROMOTE would rollback that txn eventually with a non-critical
+-- error. Not split-brain.
+--
+g.test_old_leader_txn_during_promote_write = function(g)
+    --
+    -- Build the topology:
+    --   server1  server2 <-> server3
+    --
+    local server2_uri = server.build_instance_uri('server2')
+    local server3_uri = server.build_instance_uri('server3')
+    server_set_replication(g.server1, {})
+    server_set_replication(g.server2, {server2_uri, server3_uri})
+    server_set_replication(g.server3, {server2_uri, server3_uri})
+    --
+    -- Server3 bumps raft term, but takes a long time to write PROMOTE.
+    --
+    server_block_next_wal_write(g.server3)
+    local f_promote = fiber.new(g.server3.exec, g.server3, function()
+        box.cfg{election_mode = 'manual'}
+        box.ctl.promote()
+    end)
+    f_promote:set_joinable(true)
+    g.server3:play_wal_until_synchro_queue_is_busy()
+    local new_term, old_term = g.server3:exec(function()
+        local info = box.info
+        return info.election.term, info.synchro.queue.term
+    end)
+    t.assert_equals(old_term + 1, new_term)
+    g.server2:wait_election_term(new_term)
+    --
+    -- Server1 doesn't see the new term yet and makes an attempt to do a sync
+    -- transaction.
+    --
+    local f_insert = fiber.new(g.server1.exec, g.server1, function()
+        box.space.test:replace{1}
+    end)
+    f_insert:set_joinable(true)
+    --
+    -- Restore connectivity server1 -> server2.
+    --
+    server_set_replication(g.server2, g.server2.box_cfg.replication)
+    --
+    -- Server2 gets the bad txn.
+    --
+    g.server1:wait_downstream_to(g.server2)
+    t.assert_equals(g.server2:exec(function()
+        return box.space.test:count()
+    end), 1)
+    --
+    -- PROMOTE finally is written. The server1's transaction is rolled back
+    -- gracefully and no split brain has happened.
+    --
+    server_unblock_wal_write(g.server3)
+    local ok, err = f_promote:join()
+    t.assert_equals(err, nil)
+    t.assert(ok)
+    g.server3:wait_election_leader()
+    --
+    -- Server1 gets the PROMOTE and fails its rogue txn.
+    --
+    server_set_replication(g.server1, g.server1.box_cfg.replication)
+    ok, err = f_insert:join()
+    t.assert_not_equals(err, nil)
+    t.assert(not ok)
+    t.assert_equals(g.server1:exec(function()
+        return box.space.test:count()
+    end), 0)
+    --
+    -- Cleanup.
+    --
+    server_set_replication(g.server3, g.server3.box_cfg.replication)
+    g.server3:exec(function()
+        box.cfg{election_mode = 'voter'}
+    end)
+    g.server1:exec(function()
+        box.ctl.promote()
+    end)
+    g.server1:wait_election_leader()
+    wait_fullmesh(g)
+end
+
+--
+-- Similar to the test case without '_complex' suffix. But the transaction is
+-- delivered to a conflicting node in an intricate way. Server1 - old leader,
+-- server3 - new leader, server2 - between them.
+--
+-- In this test server2 gets the bad txn not directly from server1, but via
+-- another instance (server4). Server4 gets the txn from server1, then gets
+-- its term bumped by server2, then sends the txn to server2. This way server2
+-- sees that the txn is coming from an instance having the new term.
+--
+-- The purpose is to ensure that server2 anyway later will send ACK with a new
+-- term to server1. It wouldn't be enough to simply reject any txns from nodes
+-- having an old term, because in this test server4 has a new term but still
+-- forwards the bad txn.
+--
+g.test_old_leader_txn_during_promote_write_complex = function(g)
+    local server1_uri = server.build_instance_uri('server1')
+    local server2_uri = server.build_instance_uri('server2')
+    local server3_uri = server.build_instance_uri('server3')
+    local server4_uri = server.build_instance_uri('server4')
+    local server5_uri = server.build_instance_uri('server5')
+    --
+    -- Build the topology:
+    --   server4 <- fullmesh(server1, server2, server3)
+    --   server3 <-> server5
+    --
+    g.server4 = g.cluster:build_and_add_server({
+        alias = 'server4', box_cfg = g.server3.box_cfg
+    })
+    g.server4:start()
+    -- Server5 is needed only to make server3 able to win elections without
+    -- participation of server1. Could also lower the quorum, but it wouldn't be
+    -- fair. The test is too complex for these tricks.
+    g.server5 = g.cluster:build_and_add_server({
+        alias = 'server5', box_cfg = g.server3.box_cfg
+    })
+    g.server5:start()
+    server_set_replication(g.server5, {server3_uri})
+    server_set_replication(g.server3, {server1_uri, server2_uri, server5_uri})
+    for _, s in pairs({
+        g.server1, g.server2, g.server3, g.server4, g.server5
+    }) do
+        s:exec(function()
+            box.cfg{replication_synchro_quorum = 3}
+        end)
+    end
+    --
+    -- Build the topology:
+    --   server1  server2 <-> server3 <-> server5
+    --      V
+    --   server4
+    --
+    server_set_replication(g.server1, {})
+    server_set_replication(g.server2, {server3_uri})
+    server_set_replication(g.server3, {server2_uri, server5_uri})
+    server_set_replication(g.server4, {server1_uri})
+    --
+    -- Server3 bumps raft term, gets stuck writing PROMOTE to WAL.
+    --
+    local old_term = g.server3:election_term()
+    server_block_next_wal_write(g.server3)
+    local f_promote = fiber.new(g.server3.exec, g.server3, function()
+        box.cfg{election_mode = 'manual'}
+        box.ctl.promote()
+    end)
+    f_promote:set_joinable(true)
+    g.server3:play_wal_until_synchro_queue_is_busy()
+    local new_term = old_term + 1
+    t.assert_equals(g.server2:election_term(), new_term)
+    --
+    -- Server1 doesn't see the new term yet and makes an attempt to do a sync
+    -- transaction.
+    --
+    local f_insert = fiber.new(g.server1.exec, g.server1, function()
+        box.space.test:replace{1}
+    end)
+    f_insert:set_joinable(true)
+    --
+    -- Server4 gets the transaction.
+    --
+    g.server4:wait_vclock_of(g.server1)
+    t.assert_equals(g.server4:exec(function()
+        return box.space.test:count()
+    end), 1)
+    t.assert_equals(g.server4:election_term(), old_term)
+    --
+    -- Build the topology:
+    --   server1  server2 <-> server3 <-> server5
+    --              V
+    --            server4
+    --
+    -- Server4 gets new term from server2.
+    server_set_replication(g.server4, {server2_uri})
+    g.server4:wait_election_term(new_term)
+    --
+    -- Build the topology:
+    --   server1  server2 <-> server3 <-> server5
+    --              ^
+    --              v
+    --            server4
+    --
+    -- Server2 gets bad txn from server4 which has a new term too.
+    server_set_replication(g.server2, {server3_uri, server4_uri})
+    g.server2:wait_vclock_of(g.server4)
+    t.assert_equals(g.server2:exec(function()
+        return box.space.test:count()
+    end), 1)
+    --
+    -- Build the topology:
+    --   server1 -> server2 <-> server3 <-> server5
+    --
+    server_set_replication(g.server4, {})
+    server_set_replication(g.server2, {server1_uri, server3_uri})
+    g.server1:wait_downstream_to(g.server2)
+    --
+    -- Server3 ends PROMOTE. All should be fine and dandy.
+    --
+    server_unblock_wal_write(g.server3)
+    g.server3:wait_election_leader()
+    --
+    -- Restore the original topology.
+    --
+    server_set_replication(g.server5, {})
+    server_set_replication(g.server1, g.server1.box_cfg.replication)
+    server_set_replication(g.server2, g.server2.box_cfg.replication)
+    server_set_replication(g.server3, g.server3.box_cfg.replication)
+    wait_fullmesh(g)
+    local ok, err = f_promote:join()
+    t.assert_equals(err, nil)
+    t.assert(ok)
+    ok, err = f_insert:join()
+    t.assert_not_equals(err, nil)
+    t.assert(not ok)
+    t.assert_equals(g.server1:exec(function()
+        return box.space.test:count()
+    end), 0)
+    --
+    -- Cleanup.
+    --
+    local server4_id = g.server4:instance_id()
+    local server5_id = g.server5:instance_id()
+    for _, s in pairs({g.server4, g.server5}) do
+        s:stop()
+        s:cleanup()
+        g.cluster:delete_server(s)
+        g[s.alias] = nil
+    end
+    g.server3:exec(function()
+        box.cfg{
+            replication_synchro_quorum = 2,
+            election_mode = 'voter',
+        }
+    end)
+    g.server2:exec(function()
+        box.cfg{replication_synchro_quorum = 2}
+    end)
+    g.server1:exec(function()
+        box.cfg{replication_synchro_quorum = 2}
+        box.ctl.promote()
+    end)
+    g.server1:wait_election_leader()
+    g.server1:exec(function(server4_id, server5_id)
+        box.space._cluster:delete(server4_id)
+        box.space._cluster:delete(server5_id)
+    end, {server4_id, server5_id})
     wait_fullmesh(g)
 end

--- a/test/replication/gh-5195-qsync-replica-write.result
+++ b/test/replication/gh-5195-qsync-replica-write.result
@@ -14,6 +14,9 @@ old_synchro_quorum = box.cfg.replication_synchro_quorum
 old_synchro_timeout = box.cfg.replication_synchro_timeout
  | ---
  | ...
+old_replication_timeout = box.cfg.replication_timeout
+ | ---
+ | ...
 
 box.schema.user.grant('guest', 'super')
  | ---
@@ -44,7 +47,11 @@ box.ctl.promote()
  | ---
  | ...
 
-box.cfg{replication_synchro_timeout = 1000, replication_synchro_quorum = 3}
+box.cfg{                                                                        \
+    replication_synchro_timeout = 1000,                                         \
+    replication_synchro_quorum = 3,                                             \
+    replication_timeout = 0.1,                                                  \
+}
  | ---
  | ...
 lsn = box.info.lsn
@@ -66,45 +73,12 @@ test_run:wait_cond(function() return box.info.lsn == lsn end)
  | - true
  | ...
 
-test_run:switch('replica')
- | ---
- | - true
- | ...
 test_run:wait_lsn('replica', 'default')
  | ---
  | ...
--- Normal DML is blocked - the limbo is not empty and does not belong to the
--- replica. But promote also does a WAL write, and propagates LSN
--- of the instance.
-box.cfg{replication_synchro_timeout = 0.001, replication_synchro_quorum = 1}
+-- Wait for a keep-alive ACK, with the same LSN as before.
+require('fiber').sleep(box.cfg.replication_timeout + 0.01)
  | ---
- | ...
-box.ctl.promote()
- | ---
- | ...
-
-test_run:switch('default')
- | ---
- | - true
- | ...
--- Wait second ACK receipt.
-replica_id = test_run:get_server_id('replica')
- | ---
- | ...
-replica_lsn = test_run:get_lsn('replica', replica_id)
- | ---
- | ...
-test_run:wait_downstream(replica_id, {status='follow'})
- | ---
- | - true
- | ...
-test_run:wait_cond(function()                                                   \
-        local vclock = box.info.replication[replica_id].downstream.vclock       \
-        return (vclock and vclock[replica_id] and                               \
-                vclock[replica_id] >= replica_lsn)                              \
-    end) or require('log').error(box.info)
- | ---
- | - true
  | ...
 
 box.cfg{replication_synchro_quorum = 2}
@@ -160,6 +134,7 @@ box.schema.user.revoke('guest', 'super')
 box.cfg{                                                                        \
     replication_synchro_quorum = old_synchro_quorum,                            \
     replication_synchro_timeout = old_synchro_timeout,                          \
+    replication_timeout = old_replication_timeout,                              \
 }
  | ---
  | ...

--- a/test/replication/gh-5195-qsync-replica-write.test.lua
+++ b/test/replication/gh-5195-qsync-replica-write.test.lua
@@ -3,6 +3,7 @@ fiber = require('fiber')
 engine = test_run:get_cfg('engine')
 old_synchro_quorum = box.cfg.replication_synchro_quorum
 old_synchro_timeout = box.cfg.replication_synchro_timeout
+old_replication_timeout = box.cfg.replication_timeout
 
 box.schema.user.grant('guest', 'super')
 
@@ -19,7 +20,11 @@ _ = box.schema.space.create('sync', {engine = engine, is_sync = true})
 _ = box.space.sync:create_index('pk')
 box.ctl.promote()
 
-box.cfg{replication_synchro_timeout = 1000, replication_synchro_quorum = 3}
+box.cfg{                                                                        \
+    replication_synchro_timeout = 1000,                                         \
+    replication_synchro_quorum = 3,                                             \
+    replication_timeout = 0.1,                                                  \
+}
 lsn = box.info.lsn
 ok, err = nil
 f = fiber.create(function()                                                     \
@@ -28,24 +33,9 @@ end)
 lsn = lsn + 1
 test_run:wait_cond(function() return box.info.lsn == lsn end)
 
-test_run:switch('replica')
 test_run:wait_lsn('replica', 'default')
--- Normal DML is blocked - the limbo is not empty and does not belong to the
--- replica. But promote also does a WAL write, and propagates LSN
--- of the instance.
-box.cfg{replication_synchro_timeout = 0.001, replication_synchro_quorum = 1}
-box.ctl.promote()
-
-test_run:switch('default')
--- Wait second ACK receipt.
-replica_id = test_run:get_server_id('replica')
-replica_lsn = test_run:get_lsn('replica', replica_id)
-test_run:wait_downstream(replica_id, {status='follow'})
-test_run:wait_cond(function()                                                   \
-        local vclock = box.info.replication[replica_id].downstream.vclock       \
-        return (vclock and vclock[replica_id] and                               \
-                vclock[replica_id] >= replica_lsn)                              \
-    end) or require('log').error(box.info)
+-- Wait for a keep-alive ACK, with the same LSN as before.
+require('fiber').sleep(box.cfg.replication_timeout + 0.01)
 
 box.cfg{replication_synchro_quorum = 2}
 test_run:wait_cond(function() return f:status() == 'dead' end)
@@ -67,4 +57,5 @@ box.schema.user.revoke('guest', 'super')
 box.cfg{                                                                        \
     replication_synchro_quorum = old_synchro_quorum,                            \
     replication_synchro_timeout = old_synchro_timeout,                          \
+    replication_timeout = old_replication_timeout,                              \
 }

--- a/test/replication/gh-5213-qsync-applier-order-3.result
+++ b/test/replication/gh-5213-qsync-applier-order-3.result
@@ -255,6 +255,13 @@ test_run:cmd('delete server replica2')
  | ---
  | - true
  | ...
+-- Restore leadership to make the default instance writable.
+box.cfg{replication_synchro_quorum = 1}
+ | ---
+ | ...
+box.ctl.promote()
+ | ---
+ | ...
 s:drop()
  | ---
  | ...

--- a/test/replication/gh-5213-qsync-applier-order-3.test.lua
+++ b/test/replication/gh-5213-qsync-applier-order-3.test.lua
@@ -119,6 +119,9 @@ test_run:cmd('stop server replica1')
 test_run:cmd('delete server replica1')
 test_run:cmd('stop server replica2')
 test_run:cmd('delete server replica2')
+-- Restore leadership to make the default instance writable.
+box.cfg{replication_synchro_quorum = 1}
+box.ctl.promote()
 s:drop()
 box.schema.user.revoke('guest', 'super')
 box.cfg{                                                                        \


### PR DESCRIPTION
The patchset gets rid of a potential split-brain case, which could happen if an old leader would make a txn and CONFIRM it while a new term was already going on #7253.

In the last commit I update test 6036, but it doesn't seem related to #7785. The latter fails extremely rare and in logs I can see something about split brain.

Also the linearizable read test fails occasionally, it is a known problem.