### PR TITLE
New rules to determine type of result of NULLIF() and CASE

### DIFF
--- a/changelogs/unreleased/gh-6989-type-of-NULLIF.md
+++ b/changelogs/unreleased/gh-6989-type-of-NULLIF.md
@@ -1,0 +1,4 @@
+## feature/sql
+
+* Now the type of result of NULLIF() is the same as the type of the first
+  argument (gh-6989).

--- a/changelogs/unreleased/gh-6990-type-of-CASE-operation.md
+++ b/changelogs/unreleased/gh-6990-type-of-CASE-operation.md
@@ -1,0 +1,3 @@
+## feature/sql
+
+* New rules are applied to determine the type of CASE operation (gh-6990).

--- a/src/box/sql/func.c
+++ b/src/box/sql/func.c
@@ -355,6 +355,12 @@ func_nullif(struct sql_context *ctx, int argc, const struct Mem *argv)
 {
 	assert(argc == 2);
 	(void)argc;
+	if (!mem_is_comparable(&argv[1])) {
+		ctx->is_aborted = true;
+		diag_set(ClientError, ER_SQL_TYPE_MISMATCH, mem_str(&argv[1]),
+			 "scalar");
+		return;
+	}
 	if (mem_cmp_scalar(&argv[0], &argv[1], ctx->coll) == 0)
 		return;
 	if (mem_copy(ctx->pOut, &argv[0]) != 0)
@@ -1954,8 +1960,27 @@ static struct sql_func_definition definitions[] = {
 	{"MIN", 1, {FIELD_TYPE_SCALAR}, FIELD_TYPE_SCALAR, step_minmax, NULL},
 	{"NOW", 0, {}, FIELD_TYPE_DATETIME, func_now, NULL},
 
-	{"NULLIF", 2, {FIELD_TYPE_SCALAR, FIELD_TYPE_SCALAR}, FIELD_TYPE_SCALAR,
+	{"NULLIF", 2, {FIELD_TYPE_SCALAR, field_type_MAX}, FIELD_TYPE_SCALAR,
 	 func_nullif, NULL},
+	{"NULLIF", 2, {FIELD_TYPE_UNSIGNED, field_type_MAX},
+	 FIELD_TYPE_UNSIGNED, func_nullif, NULL},
+	{"NULLIF", 2, {FIELD_TYPE_STRING, field_type_MAX}, FIELD_TYPE_STRING,
+	 func_nullif, NULL},
+	{"NULLIF", 2, {FIELD_TYPE_DOUBLE, field_type_MAX}, FIELD_TYPE_DOUBLE,
+	 func_nullif, NULL},
+	{"NULLIF", 2, {FIELD_TYPE_INTEGER, field_type_MAX},
+	 FIELD_TYPE_INTEGER, func_nullif, NULL},
+	{"NULLIF", 2, {FIELD_TYPE_BOOLEAN, field_type_MAX},
+	 FIELD_TYPE_BOOLEAN, func_nullif, NULL},
+	{"NULLIF", 2, {FIELD_TYPE_VARBINARY, field_type_MAX},
+	 FIELD_TYPE_VARBINARY, func_nullif, NULL},
+	{"NULLIF", 2, {FIELD_TYPE_DECIMAL, field_type_MAX},
+	 FIELD_TYPE_DECIMAL, func_nullif, NULL},
+	{"NULLIF", 2, {FIELD_TYPE_UUID, field_type_MAX}, FIELD_TYPE_UUID,
+	 func_nullif, NULL},
+	{"NULLIF", 2, {FIELD_TYPE_DATETIME, field_type_MAX},
+	 FIELD_TYPE_DATETIME, func_nullif, NULL},
+
 	{"POSITION", 2, {FIELD_TYPE_STRING, FIELD_TYPE_STRING},
 	 FIELD_TYPE_INTEGER, func_position_characters, NULL},
 	{"POSITION", 2, {FIELD_TYPE_VARBINARY, FIELD_TYPE_VARBINARY},

--- a/test/sql-luatest/gh_6989_nullif_result_type_test.lua
+++ b/test/sql-luatest/gh_6989_nullif_result_type_test.lua
@@ -1,0 +1,36 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'test_assertion_in_modulo'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_assertion_in_modulo = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = "SELECT nullif(1, '2');"
+        local res = "integer"
+        t.assert_equals(box.execute(sql).metadata[1].type, res)
+
+        sql = "SELECT nullif('1', '1');"
+        res = "string"
+        t.assert_equals(box.execute(sql).metadata[1].type, res)
+
+        sql = "SELECT nullif([1], '2');"
+        res = "Failed to execute SQL statement: wrong arguments for function "..
+              "NULLIF()"
+        local _, err = box.execute(sql)
+        t.assert_equals(err.message, res)
+
+        sql = "SELECT nullif(1, [2]);"
+        res = "Type mismatch: can not convert array([2]) to scalar"
+        _, err = box.execute(sql)
+        t.assert_equals(err.message, res)
+    end)
+end

--- a/test/sql-luatest/gh_6990_case_operation_type_test.lua
+++ b/test/sql-luatest/gh_6990_case_operation_type_test.lua
@@ -1,0 +1,69 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'test_case_operation_type'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_case_operation_type = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local sql = [[SELECT CASE 1 WHEN 1 THEN NULL ELSE NULL END;]]
+        local res = "any"
+        t.assert_equals(box.execute(sql).metadata[1].type, res)
+
+        sql = [[SELECT CASE 1 WHEN 1 THEN 1 ELSE ? END;]]
+        res = "any"
+        t.assert_equals(box.execute(sql, {1}).metadata[1].type, res)
+
+        sql = [[SELECT CASE 1 WHEN 1 THEN [1] ELSE [2, 2] END;]]
+        res = "array"
+        t.assert_equals(box.execute(sql).metadata[1].type, res)
+
+        sql = [[SELECT CASE 1 WHEN 1 THEN 1 ELSE {1 : 1} END;]]
+        res = "any"
+        t.assert_equals(box.execute(sql).metadata[1].type, res)
+
+        sql = [[SELECT CASE 1 WHEN 1 THEN 1 ELSE {1 : 1} END;]]
+        res = "any"
+        t.assert_equals(box.execute(sql).metadata[1].type, res)
+
+        sql = [[SELECT CASE 1 WHEN 1 THEN 1 ELSE 'asd' END;]]
+        res = "scalar"
+        t.assert_equals(box.execute(sql).metadata[1].type, res)
+
+        sql = [[SELECT CASE 1 WHEN 1 THEN 1 ELSE CAST(1 AS NUMBER) END;]]
+        res = "number"
+        t.assert_equals(box.execute(sql).metadata[1].type, res)
+
+        sql = [[SELECT CASE 1 WHEN 1 THEN -1 ELSE CAST(1 AS UNSIGNED) END;]]
+        res = "integer"
+        t.assert_equals(box.execute(sql).metadata[1].type, res)
+
+        sql = [[SELECT CASE 1 WHEN 1 THEN -1 ELSE 1.5e0 END;]]
+        res = "double"
+        t.assert_equals(box.execute(sql).metadata[1].type, res)
+
+        sql = [[SELECT CASE 1 WHEN 1 THEN -1 WHEN 2 THEN 1.5 ELSE 2e0 END;]]
+        res = "decimal"
+        t.assert_equals(box.execute(sql).metadata[1].type, res)
+
+        sql = [[SELECT typeof(CASE 1 WHEN 1 THEN 1 ELSE {1 : 1} END);]]
+        res = "any"
+        t.assert_equals(box.execute(sql).rows[1][1], res)
+
+        sql = [[SELECT typeof(CASE 1 WHEN 1 THEN 1 ELSE 'asd' END);]]
+        res = "scalar"
+        t.assert_equals(box.execute(sql).rows[1][1], res)
+
+        sql = [[SELECT typeof(CASE 1 WHEN 1 THEN -1 ELSE 1.5e0 END);]]
+        res = "double"
+        t.assert_equals(box.execute(sql).rows[1][1], res)
+    end)
+end

--- a/test/sql-tap/array.test.lua
+++ b/test/sql-tap/array.test.lua
@@ -827,8 +827,7 @@ test:do_catchsql_test(
     [[
         SELECT NULLIF(1, a) FROM t;
     ]], {
-        1,
-        "Failed to execute SQL statement: wrong arguments for function NULLIF()"
+        1, "Type mismatch: can not convert array([123]) to scalar"
     })
 
 test:do_catchsql_test(

--- a/test/sql-tap/map.test.lua
+++ b/test/sql-tap/map.test.lua
@@ -830,8 +830,7 @@ test:do_catchsql_test(
     [[
         SELECT NULLIF(1, m) FROM t;
     ]], {
-        1,
-        "Failed to execute SQL statement: wrong arguments for function NULLIF()"
+        1, [[Type mismatch: can not convert map({"abc": 123}) to scalar]]
     })
 
 test:do_catchsql_test(


### PR DESCRIPTION
This patch-set introduces new rules to determine type of result of NULLIF() built-in function and CASE operator.

Closes #6990