### PR TITLE
[backport/2.10] luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-7230-luajit-fixes.md
+++ b/changelogs/unreleased/gh-7230-luajit-fixes.md
@@ -1,0 +1,9 @@
+## bugfix/luajit
+
+Backported patches from vanilla LuaJIT trunk (gh-7230). In the scope of this
+activity, the following issues have been resolved:
+
+* Fix overflow check in `unpack()` optimized by a compiler.
+* Fix recording of `tonumber()` with cdata argument for failed conversions
+  (gh-7655).
+* Fix concatenation operation on cdata. It always raises an error now.

--- a/changelogs/unreleased/gh-7458-fix-lj-stack-command-on-Python2.md
+++ b/changelogs/unreleased/gh-7458-fix-lj-stack-command-on-Python2.md
@@ -1,0 +1,4 @@
+## bugfix/luajit
+
+Fix Lua stack dump command (`lj-stack`), since unpacking arguments within the
+list initialization is not supported in Python 2 (gh-7458).


### PR DESCRIPTION
* FFI: Always fall back to metamethods for cdata length/concat.
* FFI: Add tonumber() specialization for failed conversions.
* build: introduce LUAJIT_ENABLE_CHECKHOOK option
* Fix overflow check in unpack().
* gdb: refactor iteration over frames while dumping stack
* gdb: adjust to support Python 2 (CentOS 7)

Closes #7458
Closes #7655
Needed for #7762
Part of #7230

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump
