### PR TITLE
Remove workaround for backtracing with PAC on AARCH64

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -59,7 +59,7 @@
 [submodule "third_party/libunwind"]
 	path = third_party/libunwind
 	url = https://github.com/tarantool/libunwind.git
-	branch = libunwind-1.6.2-tarantool
+	branch = libunwind-f67ef28-tarantool
 [submodule "third_party/tz"]
 	path = third_party/tz
 	url = https://github.com/tarantool/tz.git

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -174,14 +174,6 @@ endif()
 
 add_compile_flags("C;CXX" "-fexceptions" "-funwind-tables")
 
-if(ENABLE_BACKTRACE)
-    string(FIND ${CMAKE_C_FLAGS} "-mbranch-protection"
-           WITH_BRANCH_PROTECTION)
-    if(WITH_BRANCH_PROTECTION EQUAL -1)
-        set(WITH_BRANCH_PROTECTION FALSE)
-    endif()
-endif()
-
 # In C a global variable without a storage specifier (static/extern) and
 # without an initialiser is called a ’tentative definition’. The
 # language permits multiple tentative definitions in the single

--- a/src/lib/core/backtrace.c
+++ b/src/lib/core/backtrace.c
@@ -15,10 +15,6 @@
 #include <dlfcn.h>
 #endif /* __APPLE__ */
 
-#ifdef WITH_BRANCH_PROTECTION
-#include <execinfo.h>
-#endif /* WITH_BRANCH_PROTECTION */
-
 #include "cxx_abi.h"
 #include "proc_name_cache.h"
 
@@ -49,14 +45,8 @@ static NOINLINE void *
 collect_current_stack(struct backtrace *bt, void *stack)
 {
 #ifndef __APPLE__
-	int (*backtrace_alias)(void **, int);
-#ifndef WITH_BRANCH_PROTECTION
-	backtrace_alias = unw_backtrace;
-#else /* WITH_BRANCH_PROTECTION */
-	backtrace_alias = backtrace;
-#endif /* WITH_BRANCH_PROTECTION */
-	bt->frame_count = backtrace_alias((void **)bt->frames,
-					  BACKTRACE_FRAME_COUNT_MAX);
+	bt->frame_count = unw_backtrace((void **)bt->frames,
+					BACKTRACE_FRAME_COUNT_MAX);
 #else /* __APPLE__ */
 	/*
 	 * Unfortunately, glibc `backtrace` does not work on macOS.

--- a/src/trivia/config.h.cmake
+++ b/src/trivia/config.h.cmake
@@ -73,12 +73,6 @@
 #cmakedefine ENABLE_BACKTRACE 1
 
 /*
- * Defined if configured with ENABLE_BACKTRACE on AARCH64 and
- * '-mbranch-protection' compile flag is passed.
- */
-#cmakedefine WITH_BRANCH_PROTECTION
-
-/*
  * Set if the system has bfd.h header and GNU bfd library.
  */
 #cmakedefine HAVE_BFD 1


### PR DESCRIPTION
**libunwind: bump new version**

libunwind/libunwind@f67ef28 adds the ability for libunwind to unwind a
stack where the return address obtained from the AARCH6 link register (x30)
has a pointer authentication code (PAC).

Needed for #7285

**core: remove workaround for backtracing with PAC on AARCH64**

With libunwind/libunwind@f67ef28 we can now use `unw_backtrace` with
PAC enabled on AARCH64 and remove the workaround with glibc's `backtrace` for
this case.

Closes #7285