### PR TITLE
ci: use `coveralls-lcov` instead of GitHub action 

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -59,10 +59,15 @@ jobs:
         run: make -f .test.mk test-coverage
 
       - name: Upload coverage results to coveralls.io
-        uses: coverallsapp/github-action@v1.1.2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./coverage.info
+        run: |
+          coveralls-lcov \
+            --service-name=github \
+            --repo-token=${{ secrets.GITHUB_TOKEN }} \
+            --service-job-id=${{ github.run_id }} \
+            --branch=${{ github.ref }} \
+            ${{ github.event_name == 'pull_request' &&
+            format('--service-pull-request={0}', github.event.number) || '' }} \
+            ./coverage.info
 
       - name: Send VK Teams message on failure
         if: failure()


### PR DESCRIPTION
In PR #7791 the coverage stuff is slightly updated. The changes are
related to excluding some directories where the coverage will not be
calculated. The patch itself is straightforward enough, but I can see
the problems with uploading the results to coveralls.io:

    Using lcov file: ./coverage.info
    FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory

    <--- Last few GCs --->

    [2683200:0x327c000]    27836 ms: Scavenge 2033.4 (2038.7) -> 2033.2 (2044.2) MB, 6.8 / 0.0 ms  (average mu = 0.258, current mu = 0.243) allocation failure
    [2683200:0x327c000]    27854 ms: Scavenge 2036.7 (2044.2) -> 2037.1 (2044.4) MB, 15.6 / 0.0 ms  (average mu = 0.258, current mu = 0.243) allocation failure
    [2683200:0x327c000]    27871 ms: Scavenge 2037.2 (2044.4) -> 2036.7 (2055.9) MB, 17.1 / 0.0 ms  (average mu = 0.258, current mu = 0.243) allocation failure

    <--- JS stacktrace --->

    ==== JS stack trace =========================================

        0: ExitFrame [pc: 0x140dc19]
    Security context: 0x2481918808d1 <JSObject>
        1: encode(aka encode) [0x23ec5e514a11] [/opt/actions-runner/_work/_actions/coverallsapp/github-action/v1.1.2/node_modules/qs/lib/utils.js:~118] [pc=0x193ecd3d5d82](this=0x35d34e4804b1 <undefined>,0x1e5895380119 <Very long string[60387428]>)
        2: stringify(aka stringify) [0x23ec5e5174c9] [/opt/actions-runner/_work/_actions/coverallsapp/github-action/v1.1.2/n...

     1: 0xa1a640 node::Abort() [/opt/actions-runner/externals/node12/bin/node]
     2: 0xa1aa4c node::OnFatalError(char const*, char const*) [/opt/actions-runner/externals/node12/bin/node]
     3: 0xb9a62e v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, bool) [/opt/actions-runner/externals/node12/bin/node]
     4: 0xb9a9a9 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [/opt/actions-runner/externals/node12/bin/node]
     5: 0xd57c25  [/opt/actions-runner/externals/node12/bin/node]
     6: 0xd582b6 v8::internal::Heap::RecomputeLimits(v8::internal::GarbageCollector) [/opt/actions-runner/externals/node12/bin/node]
     7: 0xd64b75 v8::internal::Heap::PerformGarbageCollection(v8::internal::GarbageCollector, v8::GCCallbackFlags) [/opt/actions-runner/externals/node12/bin/node]
     8: 0xd65a25 v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [/opt/actions-runner/externals/node12/bin/node]
     9: 0xd670cf v8::internal::Heap::HandleGCRequest() [/opt/actions-runner/externals/node12/bin/node]
    10: 0xd15b35 v8::internal::StackGuard::HandleInterrupts() [/opt/actions-runner/externals/node12/bin/node]
    11: 0x1071176 v8::internal::Runtime_StackGuard(int, unsigned long*, v8::internal::Isolate*) [/opt/actions-runner/externals/node12/bin/node]
    12: 0x140dc19  [/opt/actions-runner/externals/node12/bin/node]

I have tried to use the latest version of the action (1.1.3), but I have
got the same issue.

It looks like it is a `coverallsapp/github-action` issue due to issue
in JavaScript due to inefficient amount of memory. The corresponding
[bug](https://github.com/coverallsapp/github-action/issues/133) was filed against the repo.

So I suggest switching to the console utility `coveralls-lcov`. I did
some internal testing and it works fine.

Fixes tarantool/tarantool-qa#278