### PR TITLE
ci: add CMAKE_EXTRA_PARAMS to LuaJIT workflow

### DIFF
--- a/.github/workflows/luajit-integration.yml
+++ b/.github/workflows/luajit-integration.yml
@@ -10,13 +10,22 @@ name: LuaJIT integration testing
 on:
   workflow_call:
     inputs:
+      # FIXME: Remove this inputs entry when transition to
+      # CMAKE_EXTRA_PARAMS usage is finished.
       buildtype:
-        description: CMake build type value
+        description: CMake build type value (obsolete, use CMAKE_EXTRA_PARAMS)
         required: false
         type: string
         default: Debug
+      CMAKE_EXTRA_PARAMS:
+        description: CMake extra parameters
+        required: false
+        type: string
+        default: ''
+      # FIXME: Remove this inputs entry when transition to
+      # CMAKE_EXTRA_PARAMS usage is finished.
       GC64:
-        description: CMake option value to enable LuaJIT GC64 mode
+        description: CMake option value to enable LuaJIT GC64 mode (obsolete, use CMAKE_EXTRA_PARAMS)
         required: false
         type: string
         default: OFF


### PR DESCRIPTION
It's quite inconvenient to extend LuaJIT integration workflow now: one need to patch GitHub workflow file in Tarantool repository and then setup integration testing in LuaJIT repository.

This patch introduces a new workflow parameter that can replace several existing paramters (e.g. buildtype and GC64) and allow to easy extend integration CI in LuaJIT (with rare little touches in Tarantool).

NO_DOC=ci
NO_TEST=ci
NO_CHANGELOG=ci

P.S. Test results of the changes made can be found here: tarantool/luajit@c807be7.
P.P.S Examples of `CMAKE_EXTRA_PARAMS` usage can be found here: tarantool/luajit@227d1b0 and tarantool/luajit@65b7d7c.