### PR TITLE
box: fix fkey creation together with new field names

### DIFF
--- a/changelogs/unreleased/gh-7652-complex-fkey-new-field-name.md
+++ b/changelogs/unreleased/gh-7652-complex-fkey-new-field-name.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed a bug in foreign key creation together with fields that participate
+  in that foreign key (gh-7652).

--- a/test/engine-luatest/gh_6436_field_constraint_test.lua
+++ b/test/engine-luatest/gh_6436_field_constraint_test.lua
@@ -536,7 +536,7 @@ g.test_field_constraint_integrity = function(cg)
         t.assert_equals(s:replace{1, 2, 300}, {1, 2, 300})
 
         t.assert_error_msg_content_equals(
-            "Check constraint 'field_constr3' failed for field '3'",
+            "Check constraint 'field_constr3' failed for field '3 (id3)'",
             function() s:format{{"id1"},
                                 {"id2", constraint='field_constr2'},
                                 {"id3", constraint='field_constr3'}} end

--- a/test/engine-luatest/gh_7652_complex_fkey_new_field_name_test.lua
+++ b/test/engine-luatest/gh_7652_complex_fkey_new_field_name_test.lua
@@ -1,0 +1,92 @@
+local t = require('luatest')
+local g = t.group('gh-7652', {{engine = 'memtx'}, {engine = 'vinyl'}})
+
+g.before_all(function(cg)
+    local server = require('test.luatest_helpers.server')
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:stop()
+    cg.server = nil
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.space2 then box.space.space2:drop() end
+        if box.space.space1 then box.space.space1:drop() end
+    end)
+end)
+
+-- Check that s2:insert{} doesn't fail with:
+-- "Foreign key constraint 'one' failed: wrong local field name"
+g.test_space_replace = function(cg)
+    local engine = cg.params.engine
+
+    cg.server:exec(function(engine)
+        local fmt = {{'id', 'integer'}}
+        local opts = {engine = engine, format = fmt}
+        local s1 = box.schema.space.create('space1', opts)
+        s1:create_index('i1')
+        s1:insert{1}
+
+        opts = {engine = engine}
+        local s2 = box.schema.space.create('space2', opts)
+        s2:create_index('i2')
+        opts = {foreign_key = {one = {space = s1.id,
+                                      field = {ext_id = 'id'}}}}
+        fmt = {{name = 'id', type = 'integer'},
+               {name = 'ext_id', type = 'integer'}}
+        box.space._space:replace({s2.id, 1, 'space2', engine, 0, opts, fmt})
+        s2:insert{11, 1}
+    end, {engine})
+end
+
+-- Check that s2:insert{} doesn't fail with:
+-- "Foreign key constraint 'one' failed: wrong local field name"
+g.test_space_update = function(cg)
+    local engine = cg.params.engine
+
+    cg.server:exec(function(engine)
+        local fmt = {{'id1', 'integer'}, {'id2', 'integer'}}
+        local opts = {engine = engine, format = fmt}
+        local s1 = box.schema.space.create('space1', opts)
+        s1:create_index('i1', {parts={{1}, {2}}})
+        s1:insert{1, 1}
+
+        fmt = {{name = 'id', type = 'integer'},
+               {name = 'ext_id1', type = 'integer'}}
+        opts = {engine = engine, format = fmt}
+        local s2 = box.schema.space.create('space2', opts)
+        s2:create_index('i2')
+        opts = {foreign_key = {one = {space = s1.id,
+                                      field = {ext_id2 = 'id2',
+                                               ext_id1 = 'id1'}}}}
+        fmt = {{name = 'id', type = 'integer'},
+               {name = 'ext_id1', type = 'integer'},
+               {name = 'ext_id2', type = 'integer'}}
+        box.space._space:update(s2.id, {{'=', 7, fmt}, {'=', 6, opts}})
+        s2:insert{11, 1, 1}
+    end, {engine})
+end
+
+-- Check that new_name doesn't leak through box.rollback()
+g.test_dict_rollback = function(cg)
+    local engine = cg.params.engine
+
+    cg.server:exec(function(engine)
+        local fmt = {{'id'}, {'old_name'}}
+        local opts = {engine = engine, format = fmt}
+        local s1 = box.schema.space.create('space1', opts)
+        s1:create_index('pk')
+
+        box.begin()
+        s1:format({{'id'}, {'new_name'}})
+        box.rollback()
+        local t = require('luatest')
+        t.assert_error_msg_content_equals(
+            "Tuple field 2 (old_name) required by space format is missing",
+            function() s1:insert{1} end)
+    end, {engine})
+end

--- a/test/engine/ddl.result
+++ b/test/engine/ddl.result
@@ -1567,7 +1567,7 @@ format[7] = {name = 'field7', type = 'unsigned'}
 -- Fail, the tuple {1, ... 1} is invalid for a new format.
 s:format(format)
 ---
-- error: Tuple field 7 required by space format is missing
+- error: Tuple field 7 (field7) required by space format is missing
 ...
 s:drop()
 ---

--- a/test/engine/json.result
+++ b/test/engine/json.result
@@ -59,7 +59,7 @@ format = {{'id', 'unsigned'}, {'meta', 'unsigned'}, {'data', 'array'}, {'age', '
 ...
 s:format(format)
 ---
-- error: Field 3 has type 'array' in one index, but type 'map' in another
+- error: Field 3 (data) has type 'array' in one index, but type 'map' in another
 ...
 format = {{'id', 'unsigned'}, {'meta', 'unsigned'}, {'data', 'map'}, {'age', 'unsigned'}, {'level', 'unsigned'}}
 ---

--- a/test/vinyl/errinj_ddl.result
+++ b/test/vinyl/errinj_ddl.result
@@ -380,7 +380,7 @@ fiber.sleep(0)
 ...
 s:format{{'key', 'unsigned'}, {'value', 'unsigned'}} -- must fail
 ---
-- error: Tuple field 2 required by space format is missing
+- error: Tuple field 2 (value) required by space format is missing
 ...
 s:select()
 ---


### PR DESCRIPTION
If a complex (tuple) foreign key is added along with a new field name that participates in that foreign key, the foreign key does not work correctly. This happens because the new name of a local field is added to `new_space->def->dict` only in `ModifySpace::alter()`, while before that, `new_space->def->dict` points to the old dictionary with old names (see `ModifySpace::alter_def()`). So when `local_field_no` is initialized earlier in `alter_space_do` -> `space_create` -> `tuple_constraint_fkey_init`, it's unable to find the new field number in the old dictionary.

Fix this by moving `new_def->dict = alter->old_space->def->dict;` from `ModifySpace::alter_def()` to `ModifySpace::alter()`. Note that, as before, we refer to the old dictionary from the new space (just put new names into it), because that dict is referenced by existing tuple formats.

Closes #7652