### PR TITLE
sql: fix another cursor invalidation

### DIFF
--- a/changelogs/unreleased/gh-5310-fix-cursor-invalidation.md
+++ b/changelogs/unreleased/gh-5310-fix-cursor-invalidation.md
@@ -1,4 +1,4 @@
 ## bugfix/sql
 
 * Fixed a crash that could occur when tuples longer than specified in
-  the format were selected (gh-5310).
+  the space format were selected (gh-5310, gh-4666).

--- a/src/box/ck_constraint.c
+++ b/src/box/ck_constraint.c
@@ -200,6 +200,7 @@ ck_constraint_on_replace_trigger(struct trigger *trigger, void *event)
 			 "field_ref");
 		return -1;
 	}
+	vdbe_field_ref_create(field_ref, space->def->field_count);
 	vdbe_field_ref_prepare_tuple(field_ref, new_tuple);
 
 	struct ck_constraint *ck_constraint;

--- a/src/box/sql.h
+++ b/src/box/sql.h
@@ -376,6 +376,8 @@ struct vdbe_field_ref {
 	uint32_t data_sz;
 	/** Count of fields in tuple. */
 	uint32_t field_count;
+	/** Number of allocated slots. */
+	uint32_t field_capacity;
 	/** Format that match data in field data. */
 	struct tuple_format *format;
 	/**
@@ -394,8 +396,8 @@ struct vdbe_field_ref {
 };
 
 /**
- * Initialize a new vdbe_field_ref instance with given tuple
- * data.
+ * Fill vdbe_field_ref instance with given tuple data.
+ *
  * @param field_ref The vdbe_field_ref instance to initialize.
  * @param data The tuple data.
  * @param data_sz The size of tuple data.
@@ -405,14 +407,18 @@ vdbe_field_ref_prepare_data(struct vdbe_field_ref *field_ref, const char *data,
 			    uint32_t data_sz);
 
 /**
- * Initialize a new vdbe_field_ref instance with given tuple
- * data.
+ * Fill vdbe_field_ref instance with given tuple data.
+ *
  * @param field_ref The vdbe_field_ref instance to initialize.
  * @param tuple The tuple object pointer.
  */
 void
 vdbe_field_ref_prepare_tuple(struct vdbe_field_ref *field_ref,
 			     struct tuple *tuple);
+
+/** Initialize a new vdbe_field_ref instance. */
+void
+vdbe_field_ref_create(struct vdbe_field_ref *ref, uint32_t capacity);
 
 #if defined(__cplusplus)
 } /* extern "C" { */

--- a/src/box/sql/func.c
+++ b/src/box/sql/func.c
@@ -2443,6 +2443,7 @@ func_sql_expr_call(struct func *func, struct port *args, struct port *ret)
 	struct vdbe_field_ref *ref;
 	size_t size = sizeof(ref->slots[0]) * count + sizeof(*ref);
 	ref = region_aligned_alloc(region, size, alignof(*ref));
+	vdbe_field_ref_create(ref, count);
 	vdbe_field_ref_prepare_data(ref, data, mp_size);
 	ref->format = format;
 	if (sql_bind_ptr(stmt, 1, ref) != 0)

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -206,6 +206,7 @@ allocateCursor(
 		memset(pCx, 0, offsetof(VdbeCursor,uc));
 		pCx->eCurType = eCurType;
 		pCx->nField = nField;
+		vdbe_field_ref_create(&pCx->field_ref, nField);
 		if (eCurType==CURTYPE_TARANTOOL) {
 			pCx->uc.pCursor = (BtCursor*)&pMem->z[bt_offset];
 			sqlCursorZero(pCx->uc.pCursor);

--- a/test/sql-luatest/gh_5310_cursor_invalidation_test.lua
+++ b/test/sql-luatest/gh_5310_cursor_invalidation_test.lua
@@ -11,7 +11,8 @@ g.after_all(function()
     g.server:stop()
 end)
 
-g.test_cursor_invalidation = function()
+-- Make sure that tuples with undescribed fields do not cause an error.
+g.test_cursor_invalidation_1 = function()
     g.server:exec(function()
         local t = require('luatest')
         local s = box.schema.space.create('T', {format = {'A'}})
@@ -19,6 +20,22 @@ g.test_cursor_invalidation = function()
         s:insert({1,2,3,4,5})
         s:insert({2})
         t.assert_equals(box.execute([[SELECT * FROM t;]]).rows, {{1}, {2}})
+        s:drop()
+    end)
+end
+
+--
+-- Make sure that tuples with fields described in tuple format but not described
+-- in space format do not cause an error.
+--
+g.test_cursor_invalidation_2 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local s = box.schema.space.create('T', {format = {{'A', 'integer'}}})
+        s:create_index('ii', {parts = {{1, 'integer'}, {2, 'integer'},
+                                       {3, 'integer'}, {4, 'integer'}}})
+        s:insert({1,2,3,4})
+        t.assert_equals(box.execute([[SELECT * FROM t;]]).rows, {{1}})
         s:drop()
     end)
 end


### PR DESCRIPTION
This patch fixes the issue described in issue #5310 when the tuple format has more fields than the space format. This solution is more general than the solution in 89057a21b.

Follow-up #5310
Closes #4666

NO_DOC=bugfix