### PR TITLE
uri: optimize allocation of parameters and their values dynamic arrays

### DIFF
--- a/changelogs/unreleased/gh-7155-uri-optimize-add-param-and-add-param-value.md
+++ b/changelogs/unreleased/gh-7155-uri-optimize-add-param-and-add-param-value.md
@@ -1,0 +1,3 @@
+## bugfix/uri
+
+* Optimized addition of parameters and parameter values (gh-7155).

--- a/src/lib/uri/uri.h
+++ b/src/lib/uri/uri.h
@@ -15,6 +15,10 @@ extern "C" {
 
 struct uri_param;
 
+/**
+ * WARNING: this structure is exposed in Lua via FFI (see src/lua/uri.lua): any
+ * change  must be reflected in `ffi.cdef`.
+ */
 struct uri {
 	char *scheme;
 	char *login;
@@ -25,6 +29,11 @@ struct uri {
 	char *query;
 	char *fragment;
 	int host_hint;
+	/**
+	 * Capacity of URI parameters dynamic array (used for exponential
+	 * reallocation).
+	 */
+	int params_capacity;
 	/** Count of URI parameters */
 	int param_count;
 	/** Different URI parameters */

--- a/src/lua/uri.lua
+++ b/src/lua/uri.lua
@@ -7,6 +7,7 @@ local uri = require('uri')
 local uri_cdef = [[
 struct uri_param {
     const char *name;
+    int values_capacity;
     int value_count;
     const char **values;
 };
@@ -28,6 +29,7 @@ struct uri {
     const char *query;
     const char *fragment;
     int host_hint;
+    int params_capacity;
     int param_count;
     struct uri_param *params;
 };


### PR DESCRIPTION
**uri: add warnings about exposure of structs in Lua via FFI**

`struct uri_param` and `struct uri` are exposed in Lua via FFI
(see src/lua/uri.lua): add warnings about the necessity of reflecting
changes to them in `ffi.cdecl`.

**uri: optimize allocation of parameters and their values dynamic arrays**

Allocation of URI parameters and their values dynamic arrays is done
inefficiently: they are reallocated each time a new parameter or parameter
value is added — grow them exponentially instead.

Closes #7155