### PR TITLE
[1.10] ci: fix uploading coverage results to coveralls.io

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -59,6 +59,12 @@ jobs:
 
       - name: Upload coverage results to coveralls.io
         run: |
+          # Create the src/src link to the src directory to avoid the following
+          # issue:
+          #   /var/lib/gems/2.7.0/gems/coveralls-lcov-1.7.0/lib/coveralls/lcov/converter.rb:64:
+          #   in `initialize': No such file or directory @ rb_sysopen -
+          #   /opt/actions-runner/_work/tarantool/tarantool/src/src/uri.rl (Errno::ENOENT)
+          ln -s $(pwd)/src ./src/src
           coveralls-lcov \
             --service-name=github \
             --repo-token=${{ secrets.GITHUB_TOKEN }} \


### PR DESCRIPTION
After we switched from the `coverallsapp/github-action` action to the
`coveralls-lcov` utility, the following issue started to happen while
uploading coverage results to coveralls.io:

    /var/lib/gems/2.7.0/gems/coveralls-lcov-1.7.0/lib/coveralls/lcov/converter.rb:64:
    in `initialize': No such file or directory @ rb_sysopen - /opt/actions-runner/_work/tarantool/tarantool/src/src/uri.rl (Errno::ENOENT)
        from /var/lib/gems/2.7.0/gems/coveralls-lcov-1.7.0/lib/coveralls/lcov/converter.rb:64:in `open'
        from /var/lib/gems/2.7.0/gems/coveralls-lcov-1.7.0/lib/coveralls/lcov/converter.rb:64:in `generate_source_file'
        from /var/lib/gems/2.7.0/gems/coveralls-lcov-1.7.0/lib/coveralls/lcov/converter.rb:17:in `block in convert'
        from /var/lib/gems/2.7.0/gems/coveralls-lcov-1.7.0/lib/coveralls/lcov/converter.rb:16:in `each'
        from /var/lib/gems/2.7.0/gems/coveralls-lcov-1.7.0/lib/coveralls/lcov/converter.rb:16:in `convert'
        from /var/lib/gems/2.7.0/gems/coveralls-lcov-1.7.0/lib/coveralls/lcov/runner.rb:92:in `run'
        from /var/lib/gems/2.7.0/gems/coveralls-lcov-1.7.0/bin/coveralls-lcov:5:in `<top (required)>'
        from /usr/local/bin/coveralls-lcov:23:in `load'
        from /usr/local/bin/coveralls-lcov:23:in `<main>'

From the coverage report I can see:

                                              |Lines       |Functions  |Branches
    Filename                                  |Rate     Num|Rate    Num|Rate     Num
    ================================================================================
    [/opt/actions-runner/_work/tarantool/tarantool/src/]
    assoc.h                                   | 100%      9| 100%     2|    -      0
    backtrace.cc                              |76.4%    110|75.0%     8|    -      0
    box/alter.cc                              |91.1%   1355|92.2%   129|    -      0
    ...
    src/uri.c                                 |19.8%   4566|    -     0|    -      0
    src/uri.rl                                |92.9%    113| 100%     2|    -      0
    ...

It looks like the `lcov` itility wrongly considers paths for uri.c and
uri.rl files due to make target [1]. Interesting that the target is not
called anywhere while the build process. At least, I didn't find that.

Also interesting that the official `coverallsapp/github-action` action
from coveralls.io just ignored this issue.

[1] https://github.com/tarantool/tarantool/blob/d935fd1cd154bc1a2737fa90265f4cd3ca9c1eae/src/CMakeLists.txt#L69