### PR TITLE
fiber: add channel graceful close option to compat

### DIFF
--- a/changelogs/unreleased/gh-7746-fiber-channel-graceful-close.md
+++ b/changelogs/unreleased/gh-7746-fiber-channel-graceful-close.md
@@ -1,0 +1,6 @@
+## feature/core/fiber
+
+* Fiber channel now has a compatibility option in tarantool.compat, that
+  provides transition from force channel `close()` to graceful `close()`, i.e.
+  closing channel for writing while existing messages can still be extracted
+  (gh-7746).

--- a/src/lua/compat.c
+++ b/src/lua/compat.c
@@ -5,6 +5,7 @@
  */
 
 #include <lua/compat.h>
+#include <lib/core/fiber_channel.h>
 #include "serializer.h"
 
 /* Toggler for msgpuck escaping change. */
@@ -54,6 +55,21 @@ yaml_pretty_multiline_toggle(struct lua_State *L)
 	return 0;
 }
 
+/* Toggler for fiber channel graceful close change. */
+static int
+fiber_channel_close_mode_toggle(struct lua_State *L)
+{
+	assert(lua_isboolean(L, -1) && "boolean argument expected");
+	bool is_new = lua_toboolean(L, -1);
+	enum fiber_channel_close_mode mode = is_new ?
+		FIBER_CHANNEL_CLOSE_GRACEFUL :
+		FIBER_CHANNEL_CLOSE_FORCEFUL;
+
+	fiber_channel_set_close_mode(mode);
+
+	return 0;
+}
+
 static const struct luaL_Reg internal_compat[] = {
 	{"msgpuck_escape_forward_slash_toggle",
 	 lbox_msgpuck_escape_forward_slash_toggle},
@@ -61,6 +77,8 @@ static const struct luaL_Reg internal_compat[] = {
 	 lbox_json_escape_forward_slash_toggle},
 	{"yaml_pretty_multiline_toggle",
 	 yaml_pretty_multiline_toggle},
+	{"fiber_channel_close_mode_toggle",
+	 fiber_channel_close_mode_toggle},
 	{NULL, NULL},
 };
 

--- a/src/lua/compat.lua
+++ b/src/lua/compat.lua
@@ -32,6 +32,18 @@ with some existing applications that rely on the old style.
 https://github.com/tarantool/tarantool/wiki/compat%3Ayaml_pretty_multiline
 ]]
 
+local FIBER_CHANNEL_GRACEFUL_CLOSE_BRIEF = [[
+Whether fiber channel should be marked read-only on close, instead of being
+destroyed. The new behavior allows user to mark the channel as read-only. This
+way if a message was in the buffer before close, it will remain accessible after
+close. The read-only channel will be closed automatically when the buffer
+becomes empty, or will be deleted by GC if all links to it are lost, as before.
+The new behavior can break code that relies on `ch:get()` returning `nil` after
+channel close.
+
+https://github.com/tarantool/tarantool/wiki/compat%3Afiber_channel_close_mode
+]]
+
 -- Contains options descriptions in following format:
 -- * default  (string)
 -- * brief    (string)
@@ -57,6 +69,12 @@ local options = {
         obsolete = nil,
         brief = YAML_PRETTY_MULTILINE_BRIEF,
         action = internal.yaml_pretty_multiline_toggle,
+    },
+    fiber_channel_close_mode = {
+        default = 'old',
+        obsolete = nil,
+        brief = FIBER_CHANNEL_GRACEFUL_CLOSE_BRIEF,
+        action = internal.fiber_channel_close_mode_toggle,
     },
 }
 

--- a/test/app-luatest/gh_7746_fiber_channel_close_test.lua
+++ b/test/app-luatest/gh_7746_fiber_channel_close_test.lua
@@ -1,0 +1,133 @@
+local compat = require('tarantool').compat
+local t = require('luatest')
+local g = t.group()
+local fiber = require('fiber')
+
+g.test_channel_close_default = function()
+    -- No graceful close (old) by default.
+    local ch = fiber.channel(10)
+    ch:put('one')
+    ch:put('two')
+    t.assert_equals(ch:get(), 'one')
+    ch:close()
+    t.assert(ch:is_closed())
+    t.assert_not(ch:put('three'))
+    t.assert_equals(ch:get(), nil)
+end
+
+g.test_channel_close_old = function()
+    compat.fiber_channel_close_mode = 'old'
+    local ch = fiber.channel(10)
+    ch:put('one')
+    ch:put('two')
+    t.assert_equals(ch:get(), 'one')
+    ch:close()
+    t.assert(ch:is_closed())
+    t.assert_not(ch:put('three'))
+    t.assert_equals(ch:get(), nil)
+end
+
+g.test_channel_close_new = function()
+    -- Graceful close (new) selected.
+    compat.fiber_channel_close_mode = 'new'
+    local ch = fiber.channel(10)
+    ch:put('one')
+    ch:put('two')
+    ch:close()
+
+    t.assert(ch:is_closed())
+    t.assert_not(ch:put('three'))
+
+    t.assert_equals(ch:get(), 'one')
+    t.assert(ch:is_closed())
+
+    t.assert_equals(ch:get(), 'two')
+    t.assert(ch:is_closed())
+
+    t.assert_equals(ch:get(), nil)
+end
+
+g.test_close_graceful_on_empty = function()
+    compat.fiber_channel_close_mode = 'new'
+    local ch = fiber.channel(10)
+    ch:put('one')
+    ch:get()
+    ch:close()
+    t.assert(ch:is_closed())
+end
+
+local test_close_reader_payload = function(mode)
+    compat.fiber_channel_close_mode = mode
+    local ch = fiber.channel(0)
+    local reader = fiber.new(function()
+        t.assert_not(ch:is_closed(),
+                     'reader tries to read from the open channel')
+        -- Try to obtain the message from the zero-length
+        -- channel.
+        -- XXX: <reader> fiber hangs forever, until one of the
+        -- following occurs:
+        -- * <fiber_channel.put> is called from another fiber
+        -- * <channel> is closed from another fiber
+        -- For the latter case <fiber_channel.get> fails (i.e.
+        -- yields nil value).
+        t.assert_is(ch:get(), nil,
+                    'reader fails to read from the zero-length channel')
+        t.assert(ch:is_closed(), 'reader hangs until channel is closed')
+        t.assert_is(ch:get(0), nil,
+                    'reader fails to read from the closed channel')
+    end)
+    reader:set_joinable(true)
+    -- Yield to start tests in <reader> payload.
+    fiber.yield()
+    ch:close()
+    t.assert(ch:is_closed())
+    -- Wait until tests in <writer> payload are finished.
+    local status, err = fiber.join(reader)
+    t.assert(status, err)
+end
+
+g.test_close_reader_old = function()
+    test_close_reader_payload('old')
+end
+
+g.test_close_reader_new = function()
+    test_close_reader_payload('new')
+end
+
+local test_close_writer_payload = function(mode)
+    compat.fiber_channel_close_mode = mode
+    local ch = fiber.channel(0)
+    local writer = fiber.new(function()
+        t.assert_not(ch:is_closed(),
+                     'writer tries to write to the open channel')
+        -- Try to push the message into the zero-length
+        -- channel.
+        -- XXX: <writer> fiber hangs forever, until one of the
+        -- following occurs:
+        -- * <fiber_channel.get> is called from another fiber
+        -- * <channel> is closed from another fiber
+        -- For the latter case <fiber_channel.put> fails (i.e.
+        -- yields false value).
+        t.assert_not(ch:put('one'),
+                     'writer fails to write to the zero-length channel')
+        t.assert(ch:is_closed(), 'writer hangs until channel is closed')
+        t.assert_not(ch:put('one'),
+                     'writer fails to write to the closed channel')
+    end)
+    writer:set_joinable(true)
+    -- Yield to start tests in <writer> payload.
+    fiber.yield()
+    ch:close()
+    t.assert(ch:is_closed())
+    -- Wait until tests in <writer> payload are finished.
+    local status, err = fiber.join(writer)
+    t.assert(status, err)
+end
+
+g.test_close_writer_old = function()
+    test_close_writer_payload('old')
+end
+
+g.test_close_writer_new = function()
+    test_close_writer_payload('new')
+end

--- a/test/unit/fiber_channel.cc
+++ b/test/unit/fiber_channel.cc
@@ -78,12 +78,166 @@ fiber_channel_get()
 	status = check_plan();
 }
 
+static void
+fiber_channel_close_basic(enum fiber_channel_close_mode mode)
+{
+	fiber_channel_set_close_mode(mode);
+
+	bool graceful = mode == FIBER_CHANNEL_CLOSE_GRACEFUL;
+	struct fiber_channel *channel = fiber_channel_new(10);
+
+	char msg_1;
+	char msg_2;
+	char msg_3;
+	void *ptr = NULL;
+
+	ok(fiber_channel_put_timeout(channel, &msg_1, 0) == 0,
+	   "fiber_channel_put(msg_1)");
+
+	ok(fiber_channel_put_timeout(channel, &msg_2, 0) == 0,
+	   "fiber_channel_put(msg_2)");
+
+	fiber_channel_get(channel, &ptr);
+
+	ok(ptr == &msg_1, "fiber_channel_get(1)");
+
+	fiber_channel_close(channel);
+
+	ok(channel->is_closed, "is_closed");
+	ok(channel->is_destroyed == !graceful,
+	   graceful ? "not is_destroyed" : "is_destroyed");
+
+	ok(fiber_channel_put_timeout(channel, &msg_3, 0) != 0,
+	   "not fiber_channel_put(msg_3)");
+
+	ptr = NULL;
+	fiber_channel_get(channel, &ptr);
+
+	ok(ptr == (graceful ? &msg_2 : NULL),
+	   graceful ? "fiber_channel_get(2)" : "not fiber_channel_get(2)");
+	ok(channel->is_destroyed, "is_destroyed");
+
+	fiber_channel_delete(channel);
+}
+
+static int
+reader_f(va_list ap)
+{
+	struct fiber_channel *channel =
+		(struct fiber_channel *)fiber_get_ctx(fiber());
+	void *msg;
+	ok(!channel->is_closed, "reader tries to read from the open channel");
+	/*
+	 * Try to obtain the message from the zero-length channel.
+	 * XXX: <reader> fiber hangs forever, until one of the
+	 * following occurs:
+	 * * <fiber_channel_put> is called from another fiber
+	 * * <channel> is closed from another fiber
+	 * For the latter case <fiber_channel_get> fails (i.e.
+	 * yields non zero status).
+	 */
+	ok(fiber_channel_get(channel, &msg) != 0,
+	   "reader fails to read a message from the zero-length channel");
+	ok(channel->is_closed, "reader hangs until channel is closed");
+	ok(fiber_channel_get_timeout(channel, &msg, 0) != 0,
+	   "reader fails to read a message from the closed channel");
+	return 0;
+}
+
+static void
+fiber_channel_close_reader(enum fiber_channel_close_mode mode)
+{
+	fiber_channel_set_close_mode(mode);
+
+	struct fiber_channel *channel = fiber_channel_new(0);
+	struct fiber *reader = fiber_new("reader", reader_f);
+	fail_if(reader == NULL);
+	fiber_set_ctx(reader, channel);
+	fiber_set_joinable(reader, true);
+	fiber_wakeup(reader);
+	/* Yield to start tests in <reader> payload. */
+	fiber_sleep(0);
+
+	fiber_channel_close(channel);
+	ok(channel->is_closed, "is_closed");
+	/* Wait until tests in <reader> payload are finished. */
+	fiber_join(reader);
+	ok(channel->is_destroyed, "is_destroyed");
+	fiber_channel_delete(channel);
+}
+
+static int
+writer_f(va_list ap)
+{
+	struct fiber_channel *channel =
+		(struct fiber_channel *)fiber_get_ctx(fiber());
+	char msg;
+	ok(!channel->is_closed, "writer tries to write to the open channel");
+	/*
+	 * Try to push the message into the zero-length channel.
+	 * XXX: <writer> fiber hangs forever, until one of the
+	 * following occurs:
+	 * * <fiber_channel_get> is called from another fiber
+	 * * <channel> is closed from another fiber
+	 * For the latter case <fiber_channel_put> fails (i.e.
+	 * yields non zero status).
+	 */
+	ok(fiber_channel_put(channel, &msg) != 0,
+	   "writer fails to write a message to the zero-length channel");
+	ok(channel->is_closed, "writer hangs until channel is closed");
+	ok(fiber_channel_put_timeout(channel, &msg, 0) != 0,
+	   "writer fails to write a message to the closed channel");
+	return 0;
+}
+
+static void
+fiber_channel_close_writer(enum fiber_channel_close_mode mode)
+{
+	fiber_channel_set_close_mode(mode);
+
+	struct fiber_channel *channel = fiber_channel_new(0);
+	struct fiber *writer = fiber_new("writer", writer_f);
+	fail_if(writer == NULL);
+	fiber_set_ctx(writer, channel);
+	fiber_set_joinable(writer, true);
+	fiber_wakeup(writer);
+	/* Yield to start tests in <reader> payload. */
+	fiber_sleep(0);
+
+	fiber_channel_close(channel);
+	ok(channel->is_closed, "is_closed");
+	/* Wait until tests in <writer> payload are finished. */
+	fiber_join(writer);
+	ok(channel->is_destroyed, "is_destroyed");
+	fiber_channel_delete(channel);
+}
+
+static void
+fiber_channel_test_close()
+{
+	header();
+	plan(2 * (8 + 6 + 6));
+
+	fiber_channel_close_basic(FIBER_CHANNEL_CLOSE_FORCEFUL);
+	fiber_channel_close_basic(FIBER_CHANNEL_CLOSE_GRACEFUL);
+
+	fiber_channel_close_reader(FIBER_CHANNEL_CLOSE_FORCEFUL);
+	fiber_channel_close_reader(FIBER_CHANNEL_CLOSE_GRACEFUL);
+
+	fiber_channel_close_writer(FIBER_CHANNEL_CLOSE_FORCEFUL);
+	fiber_channel_close_writer(FIBER_CHANNEL_CLOSE_GRACEFUL);
+
+	footer();
+	status = status && check_plan();
+}
+
 int
 main_f(va_list ap)
 {
 	(void) ap;
 	fiber_channel_basic();
 	fiber_channel_get();
+	fiber_channel_test_close();
 	ev_break(loop(), EVBREAK_ALL);
 	return 0;
 }

--- a/test/unit/fiber_channel.result
+++ b/test/unit/fiber_channel.result
@@ -21,3 +21,46 @@ ok 5 - fiber_channel_get(1)
 ok 6 - fiber_channel_put(closed)
 ok 7 - fiber_channel_get(closed)
 	*** fiber_channel_get: done ***
+	*** fiber_channel_test_close ***
+1..40
+ok 1 - fiber_channel_put(msg_1)
+ok 2 - fiber_channel_put(msg_2)
+ok 3 - fiber_channel_get(1)
+ok 4 - is_closed
+ok 5 - is_destroyed
+ok 6 - not fiber_channel_put(msg_3)
+ok 7 - not fiber_channel_get(2)
+ok 8 - is_destroyed
+ok 9 - fiber_channel_put(msg_1)
+ok 10 - fiber_channel_put(msg_2)
+ok 11 - fiber_channel_get(1)
+ok 12 - is_closed
+ok 13 - not is_destroyed
+ok 14 - not fiber_channel_put(msg_3)
+ok 15 - fiber_channel_get(2)
+ok 16 - is_destroyed
+ok 17 - reader tries to read from the open channel
+ok 18 - is_closed
+ok 19 - reader fails to read a message from the zero-length channel
+ok 20 - reader hangs until channel is closed
+ok 21 - reader fails to read a message from the closed channel
+ok 22 - is_destroyed
+ok 23 - reader tries to read from the open channel
+ok 24 - is_closed
+ok 25 - reader fails to read a message from the zero-length channel
+ok 26 - reader hangs until channel is closed
+ok 27 - reader fails to read a message from the closed channel
+ok 28 - is_destroyed
+ok 29 - writer tries to write to the open channel
+ok 30 - is_closed
+ok 31 - writer fails to write a message to the zero-length channel
+ok 32 - writer hangs until channel is closed
+ok 33 - writer fails to write a message to the closed channel
+ok 34 - is_destroyed
+ok 35 - writer tries to write to the open channel
+ok 36 - is_closed
+ok 37 - writer fails to write a message to the zero-length channel
+ok 38 - writer hangs until channel is closed
+ok 39 - writer fails to write a message to the closed channel
+ok 40 - is_destroyed
+	*** fiber_channel_test_close: done ***


### PR DESCRIPTION
Before the change there was an unexpected behavior when using
channel:close(), as it closed the channel entirely and discarded all
unread events.

This commit introduces graceful channel close option in tarantool.compat
(https://github.com/tarantool/tarantool/issues/7000) that allowes to select new or old behavior.

With the new behavior `close()` marks channel as closed for writing.
Only when all events are extracted, the channel is closed entirely. If
there are no events in the channel, it is closed as usual.

Document that describes new API can be found on notion:
https://www.notion.so/fiber-channel-graceful-close-53b2788ed1f144598c4c0e1229c2eb69

Requires https://github.com/tarantool/tarantool/pull/7060
Closes https://github.com/tarantool/tarantool/issues/7746
See also https://github.com/tarantool/tarantool/issues/7000
NO_DOC=docs on tarantool.wiki