### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-7230-luajit-fixes.md
+++ b/changelogs/unreleased/gh-7230-luajit-fixes.md
@@ -8,6 +8,7 @@ activity, the following issues have been resolved:
 * Fix recording of `tonumber()` with cdata argument for failed conversions
   (gh-7655).
 * Fix concatenation operation on cdata. It always raises an error now.
+* Fix trace execution and stitching inside vmevent handler (gh-6782).
 
 ## feature/luajit
 Backported patches from vanilla LuaJIT trunk (gh-7230). In the scope of this


### PR DESCRIPTION
* Save trace recorder state around VM event call.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump