### PR TITLE
box: unify errors about mismatch of password and login during auth

### DIFF
--- a/changelogs/unreleased/ghs_16_user_enumeration.md
+++ b/changelogs/unreleased/ghs_16_user_enumeration.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Now the same error is returned when invalid password or login is entered
+  during authorization to prevent user enumeration (ghs-16).

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -123,7 +123,7 @@ applier_log_error(struct applier *applier, struct error *e)
 	case ER_SYSTEM:
 	case ER_SSL:
 	case ER_UNKNOWN_REPLICA:
-	case ER_PASSWORD_MISMATCH:
+	case ER_CREDS_MISMATCH:
 	case ER_XLOG_GAP:
 	case ER_TOO_EARLY_SUBSCRIBE:
 	case ER_SYNC_QUORUM_TIMEOUT:
@@ -2203,7 +2203,7 @@ applier_f(va_list ap)
 			} else if (e->errcode() == ER_CFG ||
 				   e->errcode() == ER_ACCESS_DENIED ||
 				   e->errcode() == ER_NO_SUCH_USER ||
-				   e->errcode() == ER_PASSWORD_MISMATCH) {
+				   e->errcode() == ER_CREDS_MISMATCH) {
 				/* Invalid configuration */
 				applier_log_error(applier, e);
 				applier_disconnect(applier, APPLIER_LOADING);

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -99,7 +99,7 @@ struct errcode_record {
 	/* 44 */_(ER_DROP_USER,			"Failed to drop user or role '%s': %s") \
 	/* 45 */_(ER_NO_SUCH_USER,		"User '%s' is not found") \
 	/* 46 */_(ER_USER_EXISTS,		"User '%s' already exists") \
-	/* 47 */_(ER_PASSWORD_MISMATCH,		"Incorrect password supplied for user '%s'") \
+	/* 47 */_(ER_CREDS_MISMATCH,		"User not found or supplied credentials are invalid") \
 	/* 48 */_(ER_UNKNOWN_REQUEST_TYPE,	"Unknown request type %u") \
 	/* 49 */_(ER_UNKNOWN_SCHEMA_OBJECT,	"Unknown object type '%s'") \
 	/* 50 */_(ER_CREATE_FUNCTION,		"Failed to create function '%s': %s") \

--- a/test/box-luatest/ghs_16_user_enumeration_test.lua
+++ b/test/box-luatest/ghs_16_user_enumeration_test.lua
@@ -1,0 +1,33 @@
+local net = require('net.box')
+local server = require('test.luatest_helpers.server')
+local urilib = require('uri')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all = function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+    g.server:exec(function()
+        box.schema.user.create('test', {password = '1111'})
+    end)
+end
+
+g.after_all = function()
+    g.server:stop()
+end
+
+-- If we raise different errors in case of entering an invalid password and
+-- entering the login of a non-existent user during authorization, it will
+-- open the door for an unauthorized person to enumerate users.
+-- So raised errors must be the same in the cases described above.
+g.test_user_enum_on_auth = function()
+    local uri = urilib.parse(g.server.net_box_uri)
+    local err_msg = 'User not found or supplied credentials are invalid'
+    local cmd = 'return box.session.info()'
+    local c = net.connect('test:1112@' .. uri.unix)
+    t.assert_error_msg_contains(err_msg, c.eval , c, cmd)
+    c:close()
+    c = net.connect('nobody:1112@' .. uri.unix)
+    t.assert_error_msg_contains(err_msg, c.eval , c, cmd)
+    c:close()
+end

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -267,7 +267,7 @@ t;
  |   44: box.error.DROP_USER
  |   45: box.error.NO_SUCH_USER
  |   46: box.error.USER_EXISTS
- |   47: box.error.PASSWORD_MISMATCH
+ |   47: box.error.CREDS_MISMATCH
  |   48: box.error.UNKNOWN_REQUEST_TYPE
  |   49: box.error.UNKNOWN_SCHEMA_OBJECT
  |   50: box.error.CREATE_FUNCTION

--- a/test/box/net.box_incorrect_iterator_gh-841.result
+++ b/test/box/net.box_incorrect_iterator_gh-841.result
@@ -492,7 +492,7 @@ cn:is_connected()
 ...
 cn.error
 ---
-- User 'netbox' is not found
+- User not found or supplied credentials are invalid
 ...
 cn.state
 ---

--- a/test/box/net.box_uri_first_arg_gh-398.result
+++ b/test/box/net.box_uri_first_arg_gh-398.result
@@ -31,7 +31,7 @@ cn ~= nil, cn.state, cn.error
 ---
 - true
 - error
-- Incorrect password supplied for user 'netbox'
+- User not found or supplied credentials are invalid
 ...
 cn:close()
 ---


### PR DESCRIPTION
If we raise different errors in case of entering an invalid password and entering the login of a non-existent user during authorization, it will open the door for an unauthorized person to enumerate users. So let's unify raised errors in the cases described above.

Closes #tarantool/security#16