### PR TITLE
.gitignore: add .lua.c suppression in third party

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ lcov
 src/box/bootstrap.h
 src/lua/*.lua.c
 src/box/lua/*.lua.c
+third_party/lua/*.lua.c
 src/tarantool
 src/module.h
 tarantool-*.tar.gz


### PR DESCRIPTION
Add missing .gitignore entry for autogenerated .lua.c translation units located in <third_party/lua> directory.

Follows up #7593

NO_DOC=.gitignore
NO_TEST=.gitignore
NO_CHANGELOG=.gitignore

Signed-off-by: Igor Munkin <imun@tarantool.org>