### PR TITLE
fiber: initialize thread-local cord on demand

### DIFF
--- a/changelogs/unreleased/gh-7814-box-error-in-thread.md
+++ b/changelogs/unreleased/gh-7814-box-error-in-thread.md
@@ -1,0 +1,4 @@
+## feature/core
+
+* The box error C API (`box_error_set()`, `box_error_last()`, etc) can now be
+  used in threads started by user modules with the pthread library (gh-7814).

--- a/src/lib/core/CMakeLists.txt
+++ b/src/lib/core/CMakeLists.txt
@@ -43,6 +43,7 @@ set(core_sources
     tt_sigaction.c
     tt_strerror.c
     mp_util.c
+    cord_on_demand.cc
 )
 
 if (ENABLE_BACKTRACE)

--- a/src/lib/core/cord_on_demand.cc
+++ b/src/lib/core/cord_on_demand.cc
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2022, Tarantool AUTHORS, please see AUTHORS file.
+ */
+
+#include "cord_on_demand.h"
+
+#include <stdlib.h>
+
+#include "fiber.h"
+#include "trivia/util.h"
+
+/**
+ * RAII wrapper around a cord object.
+ *
+ * A thread-local cord object is created on the first call to the get() method
+ * and destroyed when the thread exits.
+ */
+class CordOnDemand final {
+public:
+	static cord *get() noexcept
+	{
+		thread_local CordOnDemand singleton;
+		return singleton.cord_ptr;
+	}
+
+private:
+	struct cord *cord_ptr;
+
+	CordOnDemand() noexcept
+	{
+		cord_ptr = static_cast<struct cord *>(
+				xcalloc(1, sizeof(*cord_ptr)));
+		cord_create(cord_ptr, "unknown");
+	}
+
+	~CordOnDemand()
+	{
+		cord_exit(cord_ptr);
+		cord_destroy(cord_ptr);
+		free(cord_ptr);
+	}
+
+	CordOnDemand(CordOnDemand &other) = delete;
+	CordOnDemand &operator=(CordOnDemand &other) = delete;
+};
+
+struct cord *
+cord_on_demand(void)
+{
+	return CordOnDemand::get();
+}

--- a/src/lib/core/cord_on_demand.h
+++ b/src/lib/core/cord_on_demand.h
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2022, Tarantool AUTHORS, please see AUTHORS file.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+struct cord;
+
+/**
+ * On the first call, creates and returns a new thread-local cord object.
+ * On all subsequent calls in the same thread, returns the object created
+ * earlier. The cord object is destroyed at thread exit.
+ */
+struct cord *
+cord_on_demand(void);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -1481,7 +1481,7 @@ box_region_truncate(size_t size)
 void
 cord_create(struct cord *cord, const char *name)
 {
-	cord() = cord;
+	cord_ptr = cord;
 	slab_cache_set_thread(&cord()->slabc);
 
 	cord->id = pthread_self();

--- a/src/lib/core/say.c
+++ b/src/lib/core/say.c
@@ -821,14 +821,10 @@ say_format_plain_tail(char *buf, int len, int level, const char *filename,
 {
 	int total = 0;
 
-	struct cord *cord = cord();
-	if (cord) {
-		SNPRINT(total, snprintf, buf, len, " %s", cord->name);
-		if (fiber() && fiber()->fid != FIBER_ID_SCHED) {
-			SNPRINT(total, snprintf, buf, len, "/%llu/%s",
-				(long long)fiber()->fid,
-				fiber_name(fiber()));
-		}
+	SNPRINT(total, snprintf, buf, len, " %s", cord()->name);
+	if (fiber() && fiber()->fid != FIBER_ID_SCHED) {
+		SNPRINT(total, snprintf, buf, len, "/%llu/%s",
+			(long long)fiber()->fid, fiber_name(fiber()));
 	}
 
 	if (level == S_WARN || level == S_ERROR || level == S_SYSERROR) {
@@ -944,22 +940,15 @@ say_format_json(struct log *log, char *buf, int len, int level, const char *file
 	}
 
 	SNPRINT(total, snprintf, buf, len, "\"pid\": %i ", getpid());
-
-	struct cord *cord = cord();
-	if (cord) {
-		SNPRINT(total, snprintf, buf, len, ", \"cord_name\": \"");
-		SNPRINT(total, json_escape, buf, len, cord->name);
+	SNPRINT(total, snprintf, buf, len, ", \"cord_name\": \"");
+	SNPRINT(total, json_escape, buf, len, cord()->name);
+	SNPRINT(total, snprintf, buf, len, "\"");
+	if (fiber() && fiber()->fid != FIBER_ID_SCHED) {
+		SNPRINT(total, snprintf, buf, len, ", \"fiber_id\": %llu, ",
+			(long long)fiber()->fid);
+		SNPRINT(total, snprintf, buf, len, "\"fiber_name\": \"");
+		SNPRINT(total, json_escape, buf, len, fiber()->name);
 		SNPRINT(total, snprintf, buf, len, "\"");
-		if (fiber() && fiber()->fid != FIBER_ID_SCHED) {
-			SNPRINT(total, snprintf, buf, len,
-				", \"fiber_id\": %llu, ",
-				(long long)fiber()->fid);
-			SNPRINT(total, snprintf, buf, len,
-				"\"fiber_name\": \"");
-			SNPRINT(total, json_escape, buf, len,
-				fiber()->name);
-			SNPRINT(total, snprintf, buf, len, "\"");
-		}
 	}
 
 	if (filename) {


### PR DESCRIPTION
We're planning to introduce a basic C API for user read views (EE-only). Like all other box C API functions, the new API functions will use the existing box error C API for reporting errors. The problem is that a read view created using C API should be usable from user threads (started with the pthread lib) while the box error C API doesn't work in user threads, because those threads don't have the cord pointer initialized (a diagnostic area is stored in a cord object).

To address this issue, let's create a new cord object automatically on first use of `cord()` if it wasn't created explicitly. Automatically created object is destroyed at thread exit (to achieve that, we use the C++ RAII concept).

Closes #7814