### PR TITLE
[2.10] sql: fix another cursor invalidation

### DIFF
--- a/changelogs/unreleased/gh-5310-fix-cursor-invalidation.md
+++ b/changelogs/unreleased/gh-5310-fix-cursor-invalidation.md
@@ -1,4 +1,4 @@
 ## bugfix/sql
 
 * Fixed a crash that could occur when tuples longer than specified in
-  the format were selected (gh-5310).
+  the space format were selected (gh-5310, gh-4666).

--- a/src/box/ck_constraint.c
+++ b/src/box/ck_constraint.c
@@ -200,6 +200,7 @@ ck_constraint_on_replace_trigger(struct trigger *trigger, void *event)
 			 "field_ref");
 		return -1;
 	}
+	vdbe_field_ref_create(field_ref, space->def->field_count);
 	vdbe_field_ref_prepare_tuple(field_ref, new_tuple);
 
 	struct ck_constraint *ck_constraint;

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -1300,16 +1300,16 @@ sql_template_space_new(Parse *parser, const char *name)
 }
 
 /**
- * Initialize a new vdbe_field_ref instance with given tuple
- * data.
+ * Fill vdbe_field_ref instance with given tuple data.
+ *
  * @param field_ref The vdbe_field_ref instance to initialize.
  * @param tuple The tuple object pointer or NULL when undefined.
  * @param data The tuple data (is always defined).
  * @param data_sz The size of tuple data (is always defined).
  */
 static void
-vdbe_field_ref_create(struct vdbe_field_ref *field_ref, struct tuple *tuple,
-		      const char *data, uint32_t data_sz)
+vdbe_field_ref_fill(struct vdbe_field_ref *field_ref, struct tuple *tuple,
+		    const char *data, uint32_t data_sz)
 {
 	field_ref->tuple = tuple;
 	field_ref->data = data;
@@ -1317,13 +1317,7 @@ vdbe_field_ref_create(struct vdbe_field_ref *field_ref, struct tuple *tuple,
 
 	const char *field0 = data;
 	uint32_t mp_count = mp_decode_array(&field0);
-	if (tuple != NULL) {
-		assert(tuple_format(tuple) != NULL);
-		uint32_t field_count = tuple_format(tuple)->total_field_count;
-		field_ref->field_count = MIN(field_count, mp_count);
-	} else {
-		field_ref->field_count = mp_count;
-	}
+	field_ref->field_count = MIN(field_ref->field_capacity, mp_count);
 	field_ref->slots[0] = (uint32_t)(field0 - data);
 	memset(&field_ref->slots[1], 0,
 	       field_ref->field_count * sizeof(field_ref->slots[0]));
@@ -1335,15 +1329,22 @@ void
 vdbe_field_ref_prepare_data(struct vdbe_field_ref *field_ref, const char *data,
 			    uint32_t data_sz)
 {
-	vdbe_field_ref_create(field_ref, NULL, data, data_sz);
+	vdbe_field_ref_fill(field_ref, NULL, data, data_sz);
 }
 
 void
 vdbe_field_ref_prepare_tuple(struct vdbe_field_ref *field_ref,
 			     struct tuple *tuple)
 {
-	vdbe_field_ref_create(field_ref, tuple, tuple_data(tuple),
-			      tuple_bsize(tuple));
+	vdbe_field_ref_fill(field_ref, tuple, tuple_data(tuple),
+			    tuple_bsize(tuple));
+}
+
+void
+vdbe_field_ref_create(struct vdbe_field_ref *ref, uint32_t capacity)
+{
+	memset(ref, 0, sizeof(*ref) + capacity * sizeof(ref->slots[0]));
+	ref->field_capacity = capacity;
 }
 
 ssize_t

--- a/src/box/sql.h
+++ b/src/box/sql.h
@@ -384,6 +384,8 @@ struct vdbe_field_ref {
 	uint32_t data_sz;
 	/** Count of fields in tuple. */
 	uint32_t field_count;
+	/** Number of allocated slots. */
+	uint32_t field_capacity;
 	/**
 	 * Bitmask of initialized slots. The fieldno == 0 slot
 	 * must be initialized in vdbe_field_ref constructor.
@@ -400,8 +402,8 @@ struct vdbe_field_ref {
 };
 
 /**
- * Initialize a new vdbe_field_ref instance with given tuple
- * data.
+ * Fill vdbe_field_ref instance with given tuple data.
+ *
  * @param field_ref The vdbe_field_ref instance to initialize.
  * @param data The tuple data.
  * @param data_sz The size of tuple data.
@@ -411,14 +413,18 @@ vdbe_field_ref_prepare_data(struct vdbe_field_ref *field_ref, const char *data,
 			    uint32_t data_sz);
 
 /**
- * Initialize a new vdbe_field_ref instance with given tuple
- * data.
+ * Fill vdbe_field_ref instance with given tuple data.
+ *
  * @param field_ref The vdbe_field_ref instance to initialize.
  * @param tuple The tuple object pointer.
  */
 void
 vdbe_field_ref_prepare_tuple(struct vdbe_field_ref *field_ref,
 			     struct tuple *tuple);
+
+/** Initialize a new vdbe_field_ref instance. */
+void
+vdbe_field_ref_create(struct vdbe_field_ref *ref, uint32_t capacity);
 
 #if defined(__cplusplus)
 } /* extern "C" { */

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -243,6 +243,7 @@ allocateCursor(
 		memset(pCx, 0, offsetof(VdbeCursor,uc));
 		pCx->eCurType = eCurType;
 		pCx->nField = nField;
+		vdbe_field_ref_create(&pCx->field_ref, nField);
 		if (eCurType==CURTYPE_TARANTOOL) {
 			pCx->uc.pCursor = (BtCursor*)&pMem->z[bt_offset];
 			sqlCursorZero(pCx->uc.pCursor);

--- a/test/sql-luatest/gh_5310_cursor_invalidation_test.lua
+++ b/test/sql-luatest/gh_5310_cursor_invalidation_test.lua
@@ -11,7 +11,8 @@ g.after_all(function()
     g.server:stop()
 end)
 
-g.test_cursor_invalidation = function()
+-- Make sure that tuples with undescribed fields do not cause an error.
+g.test_cursor_invalidation_1 = function()
     g.server:exec(function()
         local t = require('luatest')
         local s = box.schema.space.create('T', {format = {'A'}})
@@ -19,6 +20,22 @@ g.test_cursor_invalidation = function()
         s:insert({1,2,3,4,5})
         s:insert({2})
         t.assert_equals(box.execute([[SELECT * FROM t;]]).rows, {{1}, {2}})
+        s:drop()
+    end)
+end
+
+--
+-- Make sure that tuples with fields described in tuple format but not described
+-- in space format do not cause an error.
+--
+g.test_cursor_invalidation_2 = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local s = box.schema.space.create('T', {format = {{'A', 'integer'}}})
+        s:create_index('ii', {parts = {{1, 'integer'}, {2, 'integer'},
+                                       {3, 'integer'}, {4, 'integer'}}})
+        s:insert({1,2,3,4})
+        t.assert_equals(box.execute([[SELECT * FROM t;]]).rows, {{1}})
         s:drop()
     end)
 end


### PR DESCRIPTION
This patch fixes the issue described in issue #5310 when the tuple format has more fields than the space format. This solution is more general than the solution in 89057a21b.

Follow-up #5310
Closes #4666

NO_DOC=bugfix

(cherry picked from commit 5a38c5c90072e15e03f9578c0933537c74721334)

Backport of #7819 