### PR TITLE
Add option to disable decompression of read view tuples

### DIFF
--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -963,8 +963,10 @@ generic_index_create_iterator(struct index *base, enum iterator_type type,
 
 
 struct index_read_view *
-generic_index_create_read_view(struct index *index)
+generic_index_create_read_view(struct index *index,
+			       const struct read_view_opts *opts)
 {
+	(void)opts;
 	diag_set(UnsupportedIndexFeature, index->def, "consistent read view");
 	return NULL;
 }

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -642,9 +642,12 @@ struct index_read_view_vtab {
 	 * Look up a tuple by a full key in a read view.
 	 *
 	 * The tuple data and size are returned in the data and size arguments.
-	 * Note, the tuple may be allocated from the fiber region so one should
-	 * call region_truncate after using the data. If the key isn't found,
-	 * the data is set to NULL.
+	 * If the key isn't found, the data is set to NULL.
+	 *
+	 * Note, unless the read_view_opts::disable_decompression flag was set
+	 * at read_view_open, the returned data may be allocated on the fiber
+	 * region, and the user is supposed to call region_truncate after using
+	 * the data.
 	 *
 	 * Returns 0 on success. On error returns -1 and sets diag.
 	 */
@@ -685,9 +688,12 @@ struct index_read_view_iterator_base {
 	 * Iterate to the next tuple in the read view.
 	 *
 	 * The tuple data and size are returned in the data and size arguments.
-	 * Note, the tuple may be allocated from the fiber region so one should
-	 * call region_truncate after using the data. On EOF the data is set to
-	 * NULL.
+	 * On EOF the data is set to NULL.
+	 *
+	 * Note, unless the read_view_opts::disable_decompression flag was set
+	 * at read_view_open, the returned data may be allocated on the fiber
+	 * region, and the user is supposed to call region_truncate after using
+	 * the data.
 	 *
 	 * Returns 0 on success. On error returns -1 and sets diag.
 	 */

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -51,6 +51,7 @@ struct index_read_view_iterator;
 struct index_def;
 struct key_def;
 struct info_handler;
+struct read_view_opts;
 
 typedef struct tuple box_tuple_t;
 typedef struct key_def box_key_def_t;
@@ -581,7 +582,8 @@ struct index_vtab {
 					    uint32_t part_count,
 					    const char *pos);
 	/** Create an index read view. */
-	struct index_read_view *(*create_read_view)(struct index *index);
+	struct index_read_view *(*create_read_view)(
+		struct index *index, const struct read_view_opts *opts);
 	/** Introspection (index:stat()) */
 	void (*stat)(struct index *, struct info_handler *);
 	/**
@@ -907,9 +909,9 @@ index_create_iterator(struct index *index, enum iterator_type type,
 }
 
 static inline struct index_read_view *
-index_create_read_view(struct index *index)
+index_create_read_view(struct index *index, const struct read_view_opts *opts)
 {
-	return index->vtab->create_read_view(index);
+	return index->vtab->create_read_view(index, opts);
 }
 
 static inline void
@@ -1023,7 +1025,8 @@ int generic_index_replace(struct index *, struct tuple *, struct tuple *,
 			  enum dup_replace_mode,
 			  struct tuple **, struct tuple **);
 struct index_read_view *
-generic_index_create_read_view(struct index *index);
+generic_index_create_read_view(struct index *index,
+			       const struct read_view_opts *opts);
 void generic_index_stat(struct index *, struct info_handler *);
 void generic_index_compact(struct index *);
 void generic_index_reset_stat(struct index *);

--- a/src/box/memtx_allocator.cc
+++ b/src/box/memtx_allocator.cc
@@ -174,20 +174,20 @@ struct memtx_allocator_open_read_view {
 	/** Opens a read view for the specified MemtxAllocator. */
 	template<typename Allocator>
 	void invoke(memtx_allocators_read_view &rv_all,
-		    const struct memtx_read_view_opts &opts)
+		    const struct read_view_opts &opts)
 	{
 		util::get<typename Allocator::ReadView *>(rv_all) =
-			Allocator::open_read_view(opts);
+			Allocator::open_read_view(&opts);
 	}
 };
 
 memtx_allocators_read_view
-memtx_allocators_open_read_view(struct memtx_read_view_opts opts)
+memtx_allocators_open_read_view(const struct read_view_opts *opts)
 {
 	memtx_allocators_read_view rv;
 	foreach_memtx_allocator<memtx_allocator_open_read_view,
 				memtx_allocators_read_view &,
-				const struct memtx_read_view_opts &>(rv, opts);
+				const struct read_view_opts &>(rv, *opts);
 	return rv;
 }
 

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -514,9 +514,7 @@ memtx_engine_create_read_view(struct engine *engine,
 	struct memtx_read_view *rv =
 		(struct memtx_read_view *)xmalloc(sizeof(*rv));
 	rv->base.vtab = &vtab;
-	struct memtx_read_view_opts memtx_opts;
-	memtx_opts.include_temporary_tuples = opts->enable_temporary_spaces;
-	rv->allocators_rv = memtx_allocators_open_read_view(memtx_opts);
+	rv->allocators_rv = memtx_allocators_open_read_view(opts);
 	return (struct engine_read_view *)rv;
 }
 

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -1652,6 +1652,7 @@ memtx_prepare_result_tuple(struct tuple **result)
 int
 memtx_prepare_read_view_tuple(struct tuple *tuple,
 			      struct memtx_tx_snapshot_cleaner *cleaner,
+			      bool disable_decompression,
 			      const char **data, uint32_t *size)
 {
 	tuple = memtx_tx_snapshot_clarify(cleaner, tuple);
@@ -1661,8 +1662,12 @@ memtx_prepare_read_view_tuple(struct tuple *tuple,
 		return 0;
 	}
 	*data = tuple_data_range(tuple, size);
-	*data = memtx_tuple_decompress_raw(*data, *data + *size, size);
-	return *data == NULL ? -1 : 0;
+	if (!disable_decompression) {
+		*data = memtx_tuple_decompress_raw(*data, *data + *size, size);
+		if (*data == NULL)
+			return -1;
+	}
+	return 0;
 }
 
 int

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -515,7 +515,7 @@ memtx_engine_create_read_view(struct engine *engine,
 		(struct memtx_read_view *)xmalloc(sizeof(*rv));
 	rv->base.vtab = &vtab;
 	struct memtx_read_view_opts memtx_opts;
-	memtx_opts.include_temporary_tuples = opts->needs_temporary_spaces;
+	memtx_opts.include_temporary_tuples = opts->enable_temporary_spaces;
 	rv->allocators_rv = memtx_allocators_open_read_view(memtx_opts);
 	return (struct engine_read_view *)rv;
 }

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -284,17 +284,23 @@ memtx_prepare_result_tuple(struct tuple **result);
  * to the user.
  *
  * A pointer to the raw tuple data and its size are returned in the data and
- * size out argument. The data may be allocated from the fiber region (e.g. if
- * the original tuple is compressed) so the caller should clean up the region
- * after using the data. If the tuple should be skipped (e.g. it's not visible
- * from the read view, because it was dirty when the read view was created),
- * the data is set to NULL.
+ * size out argument.
+ *
+ * This function performs two tasks:
+ *
+ *  1. Eliminates dirty tuples using the provided snapshot cleaner created
+ *     at read_view_open. If the given tuple should be skipped, the data is
+ *     set to NULL.
+ *
+ *  2. Decompresses tuples if required, unless the disable_decompression flag
+ *     is set. Decompressed tuple data is stored on the fiber region.
  *
  * Returns 0 on success. On error returns -1 and sets diag.
  */
 int
 memtx_prepare_read_view_tuple(struct tuple *tuple,
 			      struct memtx_tx_snapshot_cleaner *cleaner,
+			      bool disable_decompression,
 			      const char **data, uint32_t *size);
 
 /**

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -37,6 +37,7 @@
 #include "memtx_tx.h"
 #include "memtx_engine.h"
 #include "memtx_tuple_compression.h"
+#include "read_view.h"
 #include "space.h"
 #include "schema.h" /* space_by_id(), space_cache_find() */
 #include "errinj.h"
@@ -624,8 +625,10 @@ hash_read_view_create_iterator(struct index_read_view *base,
 
 /** Implementation of create_read_view index callback. */
 static struct index_read_view *
-memtx_hash_index_create_read_view(struct index *base)
+memtx_hash_index_create_read_view(struct index *base,
+				  const struct read_view_opts *opts)
 {
+	(void)opts;
 	static const struct index_read_view_vtab vtab = {
 		.free = hash_read_view_free,
 		.get_raw = hash_read_view_get_raw,

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -31,6 +31,7 @@
 #include "memtx_tree.h"
 #include "memtx_engine.h"
 #include "memtx_tuple_compression.h"
+#include "read_view.h"
 #include "space.h"
 #include "schema.h" /* space_by_id(), space_cache_find() */
 #include "errinj.h"
@@ -1987,8 +1988,10 @@ tree_read_view_create_iterator(struct index_read_view *base,
 /** Implementation of create_read_view index callback. */
 template <bool USE_HINT>
 static struct index_read_view *
-memtx_tree_index_create_read_view(struct index *base)
+memtx_tree_index_create_read_view(struct index *base,
+				  const struct read_view_opts *opts)
 {
+	(void)opts;
 	static const struct index_read_view_vtab vtab = {
 		.free = tree_read_view_free<USE_HINT>,
 		.get_raw = tree_read_view_get_raw<USE_HINT>,

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -1851,6 +1851,8 @@ struct tree_read_view {
 	memtx_tree_view_t<USE_HINT> tree_view;
 	/** Used for clarifying read view tuples. */
 	struct memtx_tx_snapshot_cleaner cleaner;
+	/** See read_view_opts::disable_decompression. */
+	bool disable_decompression;
 };
 
 /** Read view iterator implementation. */
@@ -1929,6 +1931,7 @@ tree_read_view_iterator_next_raw(struct index_read_view_iterator *iterator,
 		memtx_tree_view_iterator_next(&rv->tree_view,
 					      &it->tree_iterator);
 		if (memtx_prepare_read_view_tuple(res->tuple, &rv->cleaner,
+						  rv->disable_decompression,
 						  data, size) != 0)
 			return -1;
 		if (*data != NULL)
@@ -1991,7 +1994,6 @@ static struct index_read_view *
 memtx_tree_index_create_read_view(struct index *base,
 				  const struct read_view_opts *opts)
 {
-	(void)opts;
 	static const struct index_read_view_vtab vtab = {
 		.free = tree_read_view_free<USE_HINT>,
 		.get_raw = tree_read_view_get_raw<USE_HINT>,
@@ -2007,6 +2009,7 @@ memtx_tree_index_create_read_view(struct index *base,
 	}
 	struct space *space = space_cache_find(base->def->space_id);
 	memtx_tx_snapshot_cleaner_create(&rv->cleaner, space);
+	rv->disable_decompression = opts->disable_decompression;
 	rv->index = index;
 	index_ref(base);
 	memtx_tree_view_create(&rv->tree_view, &index->tree);

--- a/src/box/read_view.c
+++ b/src/box/read_view.c
@@ -111,7 +111,7 @@ space_read_view_new(struct space *space, const struct read_view_opts *opts)
 		if (index == NULL ||
 		    !opts->filter_index(space, index, opts->filter_arg))
 			continue;
-		space_rv->index_map[i] = index_create_read_view(index);
+		space_rv->index_map[i] = index_create_read_view(index, opts);
 		if (space_rv->index_map[i] == NULL)
 			goto fail;
 		space_rv->index_map[i]->space = space_rv;

--- a/src/box/read_view.c
+++ b/src/box/read_view.c
@@ -49,6 +49,7 @@ read_view_opts_create(struct read_view_opts *opts)
 	opts->enable_field_names = false;
 	opts->enable_space_upgrade = false;
 	opts->enable_temporary_spaces = false;
+	opts->disable_decompression = false;
 }
 
 static void

--- a/src/box/read_view.c
+++ b/src/box/read_view.c
@@ -46,9 +46,9 @@ read_view_opts_create(struct read_view_opts *opts)
 	opts->filter_space = default_space_filter;
 	opts->filter_index = default_index_filter;
 	opts->filter_arg = NULL;
-	opts->needs_field_names = false;
-	opts->needs_space_upgrade = false;
-	opts->needs_temporary_spaces = false;
+	opts->enable_field_names = false;
+	opts->enable_space_upgrade = false;
+	opts->enable_temporary_spaces = false;
 }
 
 static void
@@ -88,7 +88,7 @@ space_read_view_new(struct space *space, const struct read_view_opts *opts)
 
 	space_rv->id = space_id(space);
 	space_rv->group_id = space_group_id(space);
-	if (opts->needs_field_names && space->def->field_count > 0) {
+	if (opts->enable_field_names && space->def->field_count > 0) {
 		space_rv->fields = field_def_array_dup(space->def->fields,
 						       space->def->field_count);
 		assert(space_rv->fields != NULL);
@@ -98,7 +98,7 @@ space_read_view_new(struct space *space, const struct read_view_opts *opts)
 		space_rv->field_count = 0;
 	}
 	space_rv->format = NULL;
-	if (opts->needs_space_upgrade && space->upgrade != NULL) {
+	if (opts->enable_space_upgrade && space->upgrade != NULL) {
 		space_rv->upgrade = space_upgrade_read_view_new(space->upgrade);
 		assert(space_rv->upgrade != NULL);
 	} else {
@@ -137,7 +137,7 @@ read_view_add_space_cb(struct space *space, void *arg_raw)
 	struct read_view *rv = arg->rv;
 	const struct read_view_opts *opts = arg->opts;
 	if ((space->engine->flags & ENGINE_SUPPORTS_READ_VIEW) == 0 ||
-	    (space_is_temporary(space) && !opts->needs_temporary_spaces) ||
+	    (space_is_temporary(space) && !opts->enable_temporary_spaces) ||
 	    !opts->filter_space(space, opts->filter_arg))
 		return 0;
 	struct space_read_view *space_rv = space_read_view_new(space, opts);

--- a/src/box/read_view.h
+++ b/src/box/read_view.h
@@ -140,6 +140,15 @@ struct read_view_opts {
 	 * flag is set.
 	 */
 	bool enable_temporary_spaces;
+	/**
+	 * Memtx-specific. Disables decompression of tuples fetched from
+	 * the read view. Setting this flag makes the raw read view methods
+	 * (get_raw, next_raw) return a pointer to the data stored in
+	 * the read view as is, without any preprocessing or copying to
+	 * the fiber region. The user is supposed to decompress the data
+	 * encoded in the MP_COMPRESSION MsgPack extension manually.
+	 */
+	bool disable_decompression;
 };
 
 /** Sets read view options to default values. */

--- a/src/box/read_view.h
+++ b/src/box/read_view.h
@@ -35,7 +35,7 @@ struct space_read_view {
 	char *name;
 	/**
 	 * Tuple field definition array used by this space. Allocated only if
-	 * read_view_opts::needs_field_names is set, otherwise set to NULL.
+	 * read_view_opts::enable_field_names is set, otherwise set to NULL.
 	 * Used for creation of space_read_view::format.
 	 */
 	struct field_def *fields;
@@ -45,7 +45,7 @@ struct space_read_view {
 	 * Runtime tuple format needed to access tuple field names by name.
 	 * Referenced (ref counter incremented).
 	 *
-	 * A new format is created only if read_view_opts::needs_field_names
+	 * A new format is created only if read_view_opts::enable_field_names
 	 * is set, otherwise runtime_tuple_format is used.
 	 *
 	 * We can't just use the space tuple format as is because it allocates
@@ -59,7 +59,7 @@ struct space_read_view {
 	/**
 	 * Upgrade function for this space read view or NULL if there wasn't
 	 * a space upgrade in progress at the time when this read view was
-	 * created or read_view_opts::needs_space_upgrade wasn't set.
+	 * created or read_view_opts::enable_space_upgrade wasn't set.
 	 */
 	struct space_upgrade_read_view *upgrade;
 	/** Replication group id. See space_opts::group_id. */
@@ -127,19 +127,19 @@ struct read_view_opts {
 	 * otherwise the preallocated name-less runtime tuple format will be
 	 * used instead.
 	 */
-	bool needs_field_names;
+	bool enable_field_names;
 	/**
 	 * If this flag is set and there's a space upgrade in progress at the
 	 * time when this read view is created, create an upgrade function that
 	 * can be applied to tuples retrieved from this read view. See also
 	 * space_read_view::upgrade.
 	 */
-	bool needs_space_upgrade;
+	bool enable_space_upgrade;
 	/**
 	 * Temporary spaces aren't included into this read view unless this
 	 * flag is set.
 	 */
-	bool needs_temporary_spaces;
+	bool enable_temporary_spaces;
 };
 
 /** Sets read view options to default values. */

--- a/src/box/sequence.c
+++ b/src/box/sequence.c
@@ -403,9 +403,10 @@ sequence_data_read_view_free(struct index_read_view *base)
 }
 
 struct index_read_view *
-sequence_data_read_view_create(struct index *index)
+sequence_data_read_view_create(struct index *index,
+			       const struct read_view_opts *opts)
 {
-	(void)index;
+	(void)opts;
 	static const struct index_read_view_vtab vtab = {
 		.free = sequence_data_read_view_free,
 		.get_raw = sequence_data_read_view_get_raw,

--- a/src/box/sequence.h
+++ b/src/box/sequence.h
@@ -45,6 +45,7 @@ extern "C" {
 
 struct index;
 struct index_read_view;
+struct read_view_opts;
 
 /** Sequence metadata. */
 struct sequence_def {
@@ -165,7 +166,8 @@ access_check_sequence(struct sequence *seq);
  * _sequence_data space.
  */
 struct index_read_view *
-sequence_data_read_view_create(struct index *index);
+sequence_data_read_view_create(struct index *index,
+			       const struct read_view_opts *opts);
 
 /**
  * Get last element of given sequence.


### PR DESCRIPTION
This PR adds an internal option that makes read view read methods skip decompression of compressed tuples. If this flag is set, the user is supposed to decompress the `MP_COMPRESSION` message pack extension manually. The purpose of this option is to eliminate all memory allocations in the raw read view API (decompressed data is stored on the fiber region), which is a prerequisite for the basic public read view C API.

Apart from adding the new option, this PR also does some code cleanup: renames a few read view options; drops `memtx_read_view_opts` in favor of the generic `read_view_opts` structure.

Closes #7815

EE part: https://github.com/tarantool/tarantool-ee/pull/268