### PR TITLE
msgpack: fix crash on decode of 0xc1

### DIFF
--- a/changelogs/unreleased/gh-7818-msgpack-0xc1-fix.md
+++ b/changelogs/unreleased/gh-7818-msgpack-0xc1-fix.md
@@ -1,0 +1,4 @@
+## bugfix/lua
+
+* Fixed a crash in `msgpack.decode` in case the input string contains invalid
+  MsgPack header `0xc1` (gh-7818).

--- a/test/app-luatest/msgpack_test.lua
+++ b/test/app-luatest/msgpack_test.lua
@@ -122,19 +122,24 @@ g.test_encode_decode_buffer = function()
 end
 
 g.test_invalid_msgpack = function()
+    local err = "msgpack.decode: invalid MsgPack"
+
     -- Invalid msgpack.
     local first_buffer = {1, 2, 3}
     local s = msgpack.encode(first_buffer)
     s = s:sub(1, -2)
-    t.assert_error_msg_content_equals(
-        "msgpack.decode: invalid MsgPack",
-        function() msgpack.decode(s) end)
+    t.assert_error_msg_content_equals(err, msgpack.decode, s)
 
     local buf = buffer.ibuf()
     t.assert_equals(msgpack.encode(first_buffer, buf), 4)
-    t.assert_error_msg_content_equals(
-        "msgpack.decode: invalid MsgPack",
-        function() msgpack.decode(buf.rpos, buf:size() - 1) end)
+    t.assert_error_msg_content_equals(err, msgpack.decode,
+                                      buf.rpos, buf:size() - 1)
+
+    -- 0xc1 cannot be used in a valid MsgPack.
+    t.assert_error_msg_content_equals(err, msgpack.decode, '\xc1')
+    t.assert_error_msg_content_equals(err, msgpack.decode, '\x91\xc1')
+    t.assert_error_msg_content_equals(err, msgpack.decode, '\x81\xff\xc1')
+    t.assert_error_msg_content_equals(err, msgpack.decode, '\x93\xff\xc1\xff')
 end
 
 g.test_encode_decode_struct_buffer = function()

--- a/test/unit/msgpack.result
+++ b/test/unit/msgpack.result
@@ -2112,7 +2112,7 @@ ok 19 - subtests
     ok 5 - str is correct
     # *** test_mp_print_ext: done ***
 ok 20 - subtests
-    1..65
+    1..69
     # *** test_mp_check ***
     ok 1 - invalid fixmap 1
     ok 2 - invalid fixmap 2
@@ -2179,6 +2179,10 @@ ok 20 - subtests
     ok 63 - invalid map32 1
     ok 64 - invalid map32 2
     ok 65 - invalid map32 3
+    ok 66 - invalid header 1
+    ok 67 - invalid header 2
+    ok 68 - invalid header 3
+    ok 69 - invalid header 4
     # *** test_mp_check: done ***
 ok 21 - subtests
     1..24


### PR DESCRIPTION
0xc1 isn't a valid MsgPack header, but it was allowed by mp_check. As a result, `msgpack.decode` crashed while trying to decode it. This commit updates the msgpuck library to fix this issue.

Closes #7818