### PR TITLE
ci: update version of checkout action

### DIFF
--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/centos_7_aarch64.yml
+++ b/.github/workflows/centos_7_aarch64.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/centos_8_aarch64.yml
+++ b/.github/workflows/centos_8_aarch64.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: tarantool/actions/cleanup@master
       - name: Sources checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -19,7 +19,7 @@ jobs:
       options: '--init'
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/environment
       - name: test
         run: make -f .test.mk test-coverity

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/debian_10_aarch64.yml
+++ b/.github/workflows/debian_10_aarch64.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/debian_11_aarch64.yml
+++ b/.github/workflows/debian_11_aarch64.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: tarantool/actions/cleanup@master
       - name: Sources checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/fedora_34_aarch64.yml
+++ b/.github/workflows/fedora_34_aarch64.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/fedora_35.yml
+++ b/.github/workflows/fedora_35.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/fedora_35_aarch64.yml
+++ b/.github/workflows/fedora_35_aarch64.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/fedora_36.yml
+++ b/.github/workflows/fedora_36.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/fedora_36_aarch64.yml
+++ b/.github/workflows/fedora_36_aarch64.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/freebsd-12.yml
+++ b/.github/workflows/freebsd-12.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/freebsd-13.yml
+++ b/.github/workflows/freebsd-13.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/jepsen-cluster-txm.yml
+++ b/.github/workflows/jepsen-cluster-txm.yml
@@ -16,7 +16,7 @@ jobs:
         - 2222:22
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install deps
         uses: ./.github/actions/install-deps-jepsen
       - name: long_test

--- a/.github/workflows/jepsen-cluster.yml
+++ b/.github/workflows/jepsen-cluster.yml
@@ -16,7 +16,7 @@ jobs:
         - 2222:22
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install deps
         uses: ./.github/actions/install-deps-jepsen
       - name: long_test

--- a/.github/workflows/jepsen-single-instance-txm.yml
+++ b/.github/workflows/jepsen-single-instance-txm.yml
@@ -21,7 +21,7 @@ jobs:
         - 2222:22
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install deps
         uses: ./.github/actions/install-deps-jepsen
       - name: long_test

--- a/.github/workflows/jepsen-single-instance.yml
+++ b/.github/workflows/jepsen-single-instance.yml
@@ -21,7 +21,7 @@ jobs:
         - 2222:22
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install deps
         uses: ./.github/actions/install-deps-jepsen
       - name: long_test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: tarantool/actions/cleanup@master
       # We don't need neither deep fetch, nor submodules here.
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       # Don't use actions/setup-python to don't bother with proper
       # setup of our self-hosted machines, see [1].
       #
@@ -95,7 +95,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/luajit-integration.yml
+++ b/.github/workflows/luajit-integration.yml
@@ -51,7 +51,7 @@ jobs:
         uses: tarantool/actions/cleanup@master
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: tarantool/tarantool
           fetch-depth: 0

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/osx_11.yml
+++ b/.github/workflows/osx_11.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/osx_11_aarch64.yml
+++ b/.github/workflows/osx_11_aarch64.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/osx_11_aarch64_debug.yml
+++ b/.github/workflows/osx_11_aarch64_debug.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/osx_11_lto.yml
+++ b/.github/workflows/osx_11_lto.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/osx_12.yml
+++ b/.github/workflows/osx_12.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/osx_12_static_cmake.yml
+++ b/.github/workflows/osx_12_static_cmake.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/publish-module-api-doc.yaml
+++ b/.github/workflows/publish-module-api-doc.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/redos_7_3.yaml
+++ b/.github/workflows/redos_7_3.yaml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -27,7 +27,7 @@ jobs:
       OS: ${{ inputs.os }}
       DIST: ${{ inputs.dist }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
           # Fetch the entire history for all branches and tags.

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/ubuntu_20_04_aarch64.yml
+++ b/.github/workflows/ubuntu_20_04_aarch64.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/ubuntu_22_04_aarch64.yml
+++ b/.github/workflows/ubuntu_22_04_aarch64.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - uses: tarantool/actions/cleanup@master
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive


### PR DESCRIPTION
Fix the following warning:

    Node.js 12 actions are deprecated. For more information see:
    https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
    Please update the following actions to use Node.js 16: actions/checkout

Fixes tarantool/tarantool-qa#279