### PR TITLE
ci: update version of upload-artifact action

### DIFF
--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: centos-7${{ matrix.build-type == 'gc64' && '-gc64' || '' }}

--- a/.github/workflows/centos_7_aarch64.yml
+++ b/.github/workflows/centos_7_aarch64.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: centos-7

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: centos-8${{ matrix.build-type == 'gc64' && '-gc64' || '' }}

--- a/.github/workflows/centos_8_aarch64.yml
+++ b/.github/workflows/centos_8_aarch64.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: centos-8

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -77,14 +77,14 @@ jobs:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
 
       - name: Collect coverage info
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: coverage
           retention-days: 21
           path: ./coverage.info
 
       - name: Collect failure logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: failure-logs

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: debug

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: debian-buster${{ matrix.build-type == 'gc64' && '-gc64' || '' }}

--- a/.github/workflows/debian_10_aarch64.yml
+++ b/.github/workflows/debian_10_aarch64.yml
@@ -60,7 +60,7 @@ jobs:
         with:
            bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: debian-buster

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: debian-bullseye${{ matrix.build-type == 'gc64' && '-gc64' || '' }}

--- a/.github/workflows/debian_11_aarch64.yml
+++ b/.github/workflows/debian_11_aarch64.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: debian-bullseye

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: debian-stretch${{ matrix.build-type == 'gc64' && '-gc64' || '' }}

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -65,7 +65,7 @@ jobs:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
 
       - name: Collect artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: failure-logs

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: failure-logs

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: default_gcc_centos_7

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: fedora-34${{ matrix.build-type == 'gc64' && '-gc64' || '' }}

--- a/.github/workflows/fedora_34_aarch64.yml
+++ b/.github/workflows/fedora_34_aarch64.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: fedora-34

--- a/.github/workflows/fedora_35.yml
+++ b/.github/workflows/fedora_35.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: fedora-35${{ matrix.build-type == 'gc64' && '-gc64' || '' }}

--- a/.github/workflows/fedora_35_aarch64.yml
+++ b/.github/workflows/fedora_35_aarch64.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: fedora-35

--- a/.github/workflows/fedora_36.yml
+++ b/.github/workflows/fedora_36.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: fedora-36${{ matrix.build-type == 'gc64' && '-gc64' || '' }}

--- a/.github/workflows/fedora_36_aarch64.yml
+++ b/.github/workflows/fedora_36_aarch64.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: fedora-36

--- a/.github/workflows/freebsd-12.yml
+++ b/.github/workflows/freebsd-12.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: freebsd-12

--- a/.github/workflows/freebsd-13.yml
+++ b/.github/workflows/freebsd-13.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: freebsd-13

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: upload crash
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         if: failure() && steps.build.outcome == 'success'
         with:
           name: ${{ matrix.sanitizer }}-artifacts

--- a/.github/workflows/jepsen-cluster-txm.yml
+++ b/.github/workflows/jepsen-cluster-txm.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: jepsen-cluster-txm

--- a/.github/workflows/jepsen-cluster.yml
+++ b/.github/workflows/jepsen-cluster.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: jepsen-cluster

--- a/.github/workflows/jepsen-single-instance-txm.yml
+++ b/.github/workflows/jepsen-single-instance-txm.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: jepsen-single-instance-txm

--- a/.github/workflows/jepsen-single-instance.yml
+++ b/.github/workflows/jepsen-single-instance.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: jepsen-single-instance

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: memtx_allocator_based_on_malloc

--- a/.github/workflows/opensuse_15_1.yml
+++ b/.github/workflows/opensuse_15_1.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: opensuse-leap-15.1${{ matrix.build-type == 'gc64' && '-gc64' || '' }}

--- a/.github/workflows/opensuse_15_2.yml
+++ b/.github/workflows/opensuse_15_2.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: opensuse-leap-15.2${{ matrix.build-type == 'gc64' && '-gc64' || '' }}

--- a/.github/workflows/osx_11.yml
+++ b/.github/workflows/osx_11.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: osx_11

--- a/.github/workflows/osx_11_aarch64.yml
+++ b/.github/workflows/osx_11_aarch64.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: osx_11_aarch64

--- a/.github/workflows/osx_11_aarch64_debug.yml
+++ b/.github/workflows/osx_11_aarch64_debug.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: osx_11_aarch64_debug

--- a/.github/workflows/osx_11_lto.yml
+++ b/.github/workflows/osx_11_lto.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: osx_11_lto

--- a/.github/workflows/osx_12.yml
+++ b/.github/workflows/osx_12.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: osx_12

--- a/.github/workflows/osx_12_static_cmake.yml
+++ b/.github/workflows/osx_12_static_cmake.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: osx_12_static_cmake

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: out_of_source

--- a/.github/workflows/perf_cbench.yml
+++ b/.github/workflows/perf_cbench.yml
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/actions/send-telegram-notify
         if: failure()
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: perf_cbench

--- a/.github/workflows/perf_linkbench_ssd.yml
+++ b/.github/workflows/perf_linkbench_ssd.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/send-telegram-notify
         if: failure()
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: perf_linkbench_ssd

--- a/.github/workflows/perf_nosqlbench_hash.yml
+++ b/.github/workflows/perf_nosqlbench_hash.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/send-telegram-notify
         if: failure()
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: perf_nosqlbench_hash

--- a/.github/workflows/perf_nosqlbench_tree.yml
+++ b/.github/workflows/perf_nosqlbench_tree.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/send-telegram-notify
         if: failure()
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: perf_nosqlbench_tree

--- a/.github/workflows/perf_sysbench.yml
+++ b/.github/workflows/perf_sysbench.yml
@@ -147,7 +147,7 @@ jobs:
         if: failure()
 
       - name: Collect artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: perf_sysbench_${{ matrix.branch }}

--- a/.github/workflows/perf_tpcc.yml
+++ b/.github/workflows/perf_tpcc.yml
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/actions/send-telegram-notify
         if: failure()
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: perf_tpcc

--- a/.github/workflows/perf_tpch.yml
+++ b/.github/workflows/perf_tpch.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/send-telegram-notify
         if: failure()
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: perf_tpch

--- a/.github/workflows/perf_ycsb_hash.yml
+++ b/.github/workflows/perf_ycsb_hash.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/send-telegram-notify
         if: failure()
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: perf_ycsb_hash

--- a/.github/workflows/perf_ycsb_tree.yml
+++ b/.github/workflows/perf_ycsb_tree.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/send-telegram-notify
         if: failure()
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: perf_ycsb_tree

--- a/.github/workflows/redos_7_3.yaml
+++ b/.github/workflows/redos_7_3.yaml
@@ -66,7 +66,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: redos-7.3${{ matrix.build-type == 'gc64' && '-gc64' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: release

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: release_asan_clang11

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: release_clang

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: release_lto

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: release_lto_clang11

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -45,7 +45,7 @@ jobs:
           PRESERVE_ENVVARS: 'MAKE_CHECK,${{ env.PRESERVE_ENVVARS }}'
         run: make -f .pack.mk package
       - name: 'Upload build artifacts'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: tarantool-${{ env.OS }}-${{ env.DIST }}-${{ steps.get_sha.outputs.sha }}
           retention-days: 21
@@ -55,7 +55,7 @@ jobs:
           if-no-files-found: error
       - name: 'Upload logs if the build failed'
         if: failure() && steps.run_build.conclusion == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: tarantool-build-log-${{ env.OS }}-${{ env.DIST }}-${{ steps.get_sha.outputs.sha }}
           retention-days: 21

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: static_build

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: static_build_cmake_linux

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: ubuntu-xenial${{ matrix.build-type == 'gc64' && '-gc64' || '' }}

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: ubuntu-bionic${{ matrix.build-type == 'gc64' && '-gc64' || '' }}

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: ubuntu-focal${{ matrix.build-type == 'gc64' && '-gc64' || '' }}

--- a/.github/workflows/ubuntu_20_04_aarch64.yml
+++ b/.github/workflows/ubuntu_20_04_aarch64.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: ubuntu-focal

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: ubuntu-jammy${{ matrix.build-type == 'gc64' && '-gc64' || '' }}

--- a/.github/workflows/ubuntu_22_04_aarch64.yml
+++ b/.github/workflows/ubuntu_22_04_aarch64.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: ubuntu-jammy


### PR DESCRIPTION
Fix the following warning:

    Node.js 12 actions are deprecated. For more information see:
    https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
    Please update the following actions to use Node.js 16: actions/upload-artifact

Fixes tarantool/tarantool-qa#280