### PR TITLE
lua/fio: clearer error msg for pread()

### DIFF
--- a/src/lua/fio.lua
+++ b/src/lua/fio.lua
@@ -100,9 +100,15 @@ end
 -- pread(buf, size, offset) -> len
 fio_methods.pread = function(self, buf, size, offset)
     local tmpbuf
-    if not ffi.istype(const_char_ptr_t, buf) then
+    local has_buf = ffi.istype(const_char_ptr_t, buf)
+    if not has_buf then
         offset = size
         size = buf
+    end
+    if type(size) ~= 'number' or (type(offset) ~= 'number' and offset ~= nil) then
+        error('Usage: fh:pread(buf, size[, offset]) or fh:pread(size[, offset])')
+    end
+    if not has_buf then
         tmpbuf = buffer.ibuf()
         buf = tmpbuf:reserve(size)
     end

--- a/test/app-luatest/gh_4963_fio_pread_err_msg_test.lua
+++ b/test/app-luatest/gh_4963_fio_pread_err_msg_test.lua
@@ -1,0 +1,10 @@
+local fio = require('fio')
+
+local t = require('luatest')
+local g = t.group()
+
+g.test_fio_pread_err_msg = function()
+    local fh = fio.open('/dev/null', {'O_RDONLY'})
+
+    t.assert_error_msg_contains("Usage: fh:pread(buf, size[, offset]) or fh:pread(size[, offset])", fh.pread, fh)
+end


### PR DESCRIPTION
fh:pread() will raise a clear error on wrong arguments.

Closes #4963

NO_DOC=bugfix
NO_CHANGELOG=bugfix