### PR TITLE
luajit: proxy -j and -b flags

### DIFF
--- a/src/lua/init.h
+++ b/src/lua/init.h
@@ -75,6 +75,12 @@ tarantool_lua_run_script(char *path, bool force_interactive,
 			 int optc, const char **optv,
 			 int argc, char **argv);
 
+/**
+ * Dump bytecode for a specified Lua script.
+ */
+int
+tarantool_lua_dump_bytecode(char **argv);
+
 extern char *history;
 
 struct slab_cache *

--- a/src/main.cc
+++ b/src/main.cc
@@ -617,6 +617,8 @@ print_help(const char *program)
 	puts("  -v, --version\t\t\tprint program version and exit");
 	puts("  -e EXPR\t\t\texecute string 'EXPR'");
 	puts("  -l NAME\t\t\trequire library 'NAME'");
+	puts("  -j cmd\t\t\tperform LuaJIT control command");
+	puts("  -b ...\t\t\tsave or list bytecode");
 	puts("  -i\t\t\t\tenter interactive mode after executing 'SCRIPT'");
 	puts("  --\t\t\t\tstop handling options");
 	puts("  -\t\t\t\texecute stdin and stop handling options");
@@ -624,6 +626,9 @@ print_help(const char *program)
 	puts("Please visit project home page at https://tarantool.org");
 	puts("to see online documentation, submit bugs or contribute a patch.");
 }
+
+#define O_INTERACTIVE 0x1
+#define O_BYTECODE    0x2
 
 int
 main(int argc, char **argv)
@@ -636,7 +641,7 @@ main(int argc, char **argv)
 	fpconv_check();
 
 	/* Enter interactive mode after executing 'script' */
-	bool interactive = false;
+	uint32_t opt_mask = 0;
 	/* Lua interpeter options, e.g. -e and -l */
 	int optc = 0;
 	const char **optv = NULL;
@@ -649,9 +654,10 @@ main(int argc, char **argv)
 		{"version", no_argument, 0, 'v'},
 		{NULL, 0, 0, 0},
 	};
-	static const char *opts = "+hVvie:l:";
+	static const char *opts = "+hVvb::ij:e:l:";
 
 	int ch;
+	bool lj_arg = false;
 	while ((ch = getopt_long(argc, argv, opts, longopts, NULL)) != -1) {
 		switch (ch) {
 		case 'V':
@@ -663,21 +669,35 @@ main(int argc, char **argv)
 			return 0;
 		case 'i':
 			/* Force interactive mode */
-			interactive = true;
+			opt_mask |= O_INTERACTIVE;
 			break;
+		case 'b':
+			opt_mask |= O_BYTECODE;
+			lj_arg = true;
+			optind--;
+			break;
+		case 'j':
 		case 'l':
 		case 'e':
 			/* Save Lua interepter options to optv as is */
 			if (optc == 0)
 				optv = (const char **)xcalloc(optc_max,
-							      sizeof(optv[0]));
-			optv[optc++] = ch == 'l' ? "-l" : "-e";
+							sizeof(optv[0]));
+			if (ch == 'l')
+				optv[optc++] = "-l";
+			else if (ch == 'j')
+				optv[optc++] = "-j";
+			else
+				optv[optc++] = "-e";
 			optv[optc++] = optarg;
 			break;
 		default:
 			/* "invalid option" is printed by getopt */
 			return EX_USAGE;
 		}
+
+		if (lj_arg)
+			break;
 	}
 
 	/* Shift arguments */
@@ -685,7 +705,8 @@ main(int argc, char **argv)
 	for (int i = 1; i < argc; i++)
 		argv[i] = argv[optind + i - 1];
 
-	if (argc > 1 && strcmp(argv[1], "-") && access(argv[1], R_OK) != 0) {
+	if (!(opt_mask & O_BYTECODE) && argc > 1 &&
+	    strcmp(argv[1], "-") && access(argv[1], R_OK) != 0) {
 		/*
 		 * Somebody made a mistake in the file
 		 * name. Be nice: open the file to set
@@ -696,7 +717,7 @@ main(int argc, char **argv)
 		if (fd >= 0)
 			close(fd);
 		printf("Can't open script %s: %s\n",
-		       argv[1], tt_strerror(save_errno));
+			argv[1], tt_strerror(save_errno));
 		return save_errno;
 	}
 
@@ -782,14 +803,18 @@ main(int argc, char **argv)
 			panic("%s", "can't init event loop");
 
 		int events = ev_activecnt(loop());
+
+		if (opt_mask & O_BYTECODE)
+			return tarantool_lua_dump_bytecode(argv);
 		/*
 		 * Load user init script.  The script should have access
 		 * to Tarantool Lua API (box.cfg, box.fiber, etc...) that
 		 * is why script must run only after the server was fully
 		 * initialized.
 		 */
-		if (tarantool_lua_run_script(script, interactive, optc, optv,
-					     main_argc, main_argv) != 0)
+		if (tarantool_lua_run_script(script, opt_mask & O_INTERACTIVE,
+					     optc, optv, main_argc, main_argv)
+		    != 0)
 			diag_raise();
 		/*
 		 * Start event loop after executing Lua script if signal_cb()

--- a/test/box-py/args.result
+++ b/test/box-py/args.result
@@ -9,6 +9,8 @@ When no script name is provided, the server responds to:
   -v, --version			print program version and exit
   -e EXPR			execute string 'EXPR'
   -l NAME			require library 'NAME'
+  -j cmd			perform LuaJIT control command
+  -b ...			save or list bytecode
   -i				enter interactive mode after executing 'SCRIPT'
   --				stop handling options
   -				execute stdin and stop handling options
@@ -27,6 +29,8 @@ When no script name is provided, the server responds to:
   -v, --version			print program version and exit
   -e EXPR			execute string 'EXPR'
   -l NAME			require library 'NAME'
+  -j cmd			perform LuaJIT control command
+  -b ...			save or list bytecode
   -i				enter interactive mode after executing 'SCRIPT'
   --				stop handling options
   -				execute stdin and stop handling options
@@ -152,3 +156,28 @@ arg[2] => 2
 arg[3] => 3
 arg[4] => --help
 
+-b
+Save Tarantool bytecode: tarantool -b[options] input output
+  -l        Only list bytecode.
+  -s        Strip debug info (default).
+  -g        Keep debug info.
+  -n name   Set module name (default: auto-detect from input name).
+  -t type   Set output file type (default: auto-detect from output name).
+  -a arch   Override architecture for object files (default: native).
+  -o os     Override OS for object files (default: native).
+  -e chunk  Use chunk string as input.
+  --        Stop handling options.
+  -         Use stdin as input and/or stdout as output.
+
+File types: c h obj o raw (default)
+-bl -e ''
+-- BYTECODE -- "":0-1
+0001    RET0     0   1
+
+-b -l -e ''
+-- BYTECODE -- "":0-1
+0001    RET0     0   1
+
+-b -e '' output
+-jon -e ''
+-j on -e ''

--- a/test/box-py/args.test.py
+++ b/test/box-py/args.test.py
@@ -59,4 +59,16 @@ server.test_option("-e \"print(rawget(_G, 'log') == nil)\" " + \
                    script + \
                    " 1 2 3 --help")
 
+b_cmds = ["-b", "-bl -e ''", "-b -l -e ''", "-b -e '' output"]
+for cmd in b_cmds:
+    res = server.test_option_get(cmd, silent=True)
+    print(cmd)
+    print(res, end='')
+
+j_cmds = ["-jon -e ''", "-j on -e ''"]
+for cmd in j_cmds:
+    res = server.test_option_get(cmd, silent=True)
+    assert res == ""
+    print(cmd)
+
 sys.stdout.clear_all_filters()


### PR DESCRIPTION
There are two flags in the LuaJIT useful for debugging and runtime configuration purposes: `-j` and `-b`. However, if you want to check the same Lua code from the Tarantool, you will need to make some adjustments in the script itself, as those flags are not present in the Tarantool's CLI.

This patch introduces those flags to the Tarantool, so debugging is much more convenient now. Flags are working the same as they do in the LuaJIT.

Closes #5541