### PR TITLE
debugger: extend tarantool.debug.getsources for box modules

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -167,6 +167,7 @@ set (server_sources
      lua/decimal.c
      lua/uri.c
      lua/backtrace.c
+     lua/builtin_modcache.c
      ${lua_sources}
      ${PROJECT_SOURCE_DIR}/third_party/lua-yaml/lyaml.cc
      ${PROJECT_SOURCE_DIR}/third_party/lua-yaml/b64.c

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -39,6 +39,7 @@
 #include "lua/utils.h" /* luaT_error() */
 #include "lua/trigger.h"
 #include "lua/msgpack.h"
+#include "lua/builtin_modcache.h"
 
 #include "box/box.h"
 #include "box/txn.h"
@@ -563,6 +564,7 @@ box_lua_init(struct lua_State *L)
 			panic("Error loading Lua module %s...: %s",
 			      modname, lua_tostring(L, -1));
 		lua_pop(L, 1); /* modfile */
+		builtin_modcache_put(modname, modsrc);
 	}
 
 	assert(lua_gettop(L) == 0);

--- a/src/lua/builtin_modcache.c
+++ b/src/lua/builtin_modcache.c
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2022, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include "builtin_modcache.h"
+#include "assoc.h"
+
+static struct mh_strnptr_t *builtin_modules = NULL;
+
+void
+builtin_modcache_init(void)
+{
+	if (builtin_modules == NULL)
+		builtin_modules = mh_strnptr_new();
+}
+
+void
+builtin_modcache_free(void)
+{
+	if (builtin_modules == NULL)
+		return;
+	mh_strnptr_delete(builtin_modules);
+	builtin_modules = NULL;
+}
+
+void
+builtin_modcache_put(const char *modname, const char *code)
+{
+	assert(code != NULL && *code);
+	assert(modname != NULL);
+	uint32_t len = strlen(modname);
+	assert(len > 0);
+
+	uint32_t hash = mh_strn_hash(modname, len);
+	const struct mh_strnptr_node_t strnode = {
+		modname, len, hash, (void *)code
+	};
+	mh_strnptr_put(builtin_modules, &strnode, NULL, NULL);
+}
+
+const char*
+builtin_modcache_find(const char *modname)
+{
+	uint32_t len = strlen(modname);
+	mh_int_t k = mh_strnptr_find_str(builtin_modules, modname, len);
+	if (k == mh_end(builtin_modules))
+		return NULL;
+	return (const char *)mh_strnptr_node(builtin_modules, k)->val;
+}

--- a/src/lua/builtin_modcache.h
+++ b/src/lua/builtin_modcache.h
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2022, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+/**
+ * Inititalize builtin modules cache.
+ */
+void
+builtin_modcache_init(void);
+
+/**
+ * Destruct builtin modules cache.
+ */
+void
+builtin_modcache_free(void);
+
+/**
+ * Add a new element to the builtin modules cache.
+ * @param modname short name of a module.
+ * @param code Lua code to be saved for the given module.
+ */
+void
+builtin_modcache_put(const char *modname, const char *code);
+
+/**
+ * Return saved Lua code for a builtin module.
+ * @param modname short name of a module.
+ */
+const char*
+builtin_modcache_find(const char *modname);
+
+#ifdef __cplusplus
+}
+#endif /* defined(__cplusplus) */

--- a/test/app-luatest/tnt_debug_getsources_test.lua
+++ b/test/app-luatest/tnt_debug_getsources_test.lua
@@ -15,6 +15,14 @@ local files = {
     'fiber',
     'env',
     'datetime',
+    'box/session',
+    'box/tuple',
+    'box/key_def',
+    'box/schema',
+    'box/xlog',
+    'box/net_box',
+    'box/console',
+    'box/merger',
 }
 
 -- calculate reporsitory root using directory of a current
@@ -32,6 +40,9 @@ g.test_tarantool_debug_getsources = function()
     local lua_src_dir = fio.pathjoin(git_root, '/src/lua')
     t.assert_is_not(lua_src_dir, nil)
     t.assert(fio.stat(lua_src_dir):is_dir())
+    local box_lua_dir = fio.pathjoin(git_root, '/src/box/lua')
+    t.assert_is_not(box_lua_dir, nil)
+    t.assert(fio.stat(box_lua_dir):is_dir())
 
     local tnt = require('tarantool')
     t.assert_is_not(tnt, nil)
@@ -39,7 +50,14 @@ g.test_tarantool_debug_getsources = function()
     t.assert_is_not(luadebug, nil)
 
     for _, file in pairs(files) do
-        local path = ('%s/%s.lua'):format(lua_src_dir, file)
+        local box_prefix = 'box/'
+        local path
+        if file:match(box_prefix) ~= nil then
+            path = ('%s/%s.lua'):format(box_lua_dir,
+                                        file:sub(#box_prefix + 1, #file))
+        else
+            path = ('%s/%s.lua'):format(lua_src_dir, file)
+        end
         local text = readfile(path)
         t.assert_is_not(text, nil)
         local source = luadebug.getsources(file)


### PR DESCRIPTION
We did not support box lua modules, while were supporting lua sources embedded into `libserver.a`. Now we extended `tarantool.debug.getsources()` to support both cases:

```lua
local files = {
    'strict',
    'debug',
    'errno',
    'fiber',
    'env',
    'datetime',
    'box/session',
    'box/tuple',
    'box/key_def',
    'box/schema',
    'box/xlog',
    'box/net_box',
    'box/console',
    'box/merger',
}

local tnt = require('tarantool')
local luadebug = tnt.debug

for _, file in pairs(files) do
    local src1 = luadebug.getsources(file)
    local src2 = luadebug.getsources(('@builtin/%s.lua'):format(file))
    print(file, src1 ~= nil, src2 ~= nil)
end

os.exit(0)
``` 

```
strict  true    true
debug   true    true
errno   true    true
fiber   true    true
env     true    true
datetime        true    true
box/session     true    true
box/tuple       true    true
box/key_def     true    true
box/schema      true    true
box/xlog        true    true
box/net_box     true    true
box/console     true    true
box/merger      true    true
```

Closes #7839 