### PR TITLE
build: enable unjustifiably disabled compiler warnings

### DIFF
--- a/src/box/tuple_compare.cc
+++ b/src/box/tuple_compare.cc
@@ -192,8 +192,12 @@ mp_compare_double_any_number(double lhs, const char *rhs,
 	 * Both NaNs. Compare signaling and quiet NaNs by
 	 * 'quiet bit'.
 	 */
-	uint64_t lqbit = *((uint64_t *)&lhs) & (uint64_t)0x8000000000000;
-	uint64_t rqbit = *((uint64_t *)&v) & (uint64_t)0x8000000000000;
+	uint64_t lqbit;
+	memcpy(&lqbit, &lhs, sizeof(lhs));
+	lqbit &= UINT64_C(0x8000000000000);
+	uint64_t rqbit;
+	memcpy(&rqbit, &v, sizeof(v));
+	rqbit &= UINT64_C(0x8000000000000);
 	/*
 	 * Lets consider the quiet NaN (fraction first bit == 1)
 	 * to be bigger than signaling NaN (fraction first

--- a/test/sql-luatest/gh_6572_nan_is_not_null_test.c
+++ b/test/sql-luatest/gh_6572_nan_is_not_null_test.c
@@ -17,7 +17,8 @@ get_nan(box_function_ctx_t *ctx, const char *args, const char *args_end)
 	char res[BUF_SIZE];
 	memset(res, 0, BUF_SIZE);
 	double d;
-	*(uint64_t *)&d = 0xfff8000000000000;
+	uint64_t val = 0xfff8000000000000;
+	memcpy(&d, &val, sizeof(val));
 	assert(isnan(d));
 	char *end = mp_encode_double(res, d);
 	box_return_mp(ctx, res, end);

--- a/third_party/tarantool_ev.h
+++ b/third_party/tarantool_ev.h
@@ -28,6 +28,9 @@
  * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
+
+#pragma GCC system_header
+
 #include "trivia/config.h"
 #include <time.h>
 #include <sys/types.h>


### PR DESCRIPTION
After revisiting the list of currently disabled compiler warnings it seems like the following are unjustifiably disabled:
* `-Wunknown-pragmas`;
* `-Wstrict-aliasing`;
* `-Wunused-value`;
* `-Wchar-subscripts`;
* `-Wformat-truncation`.

Enable them for the sake of code health.

Closes #7862

NO_CHANGELOG=build
NO_DOC=build
NO_TEST=build