### PR TITLE
ci: recursive checkout in coverity action

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -20,6 +20,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: recursive
       - uses: ./.github/actions/environment
       - name: test
         run: make -f .test.mk test-coverity


### PR DESCRIPTION
Fixes tarantool/tarantool-qa#281

Coverity job: https://github.com/tarantool/tarantool/actions/runs/3360841659/jobs/5570516149. It successfully passed the checkout stage, but failed because of `secrets.COVERITY_TOKEN` being unavailable in a fork-based PR.