### PR TITLE
test: replication/transaction flakiness fix

### DIFF
--- a/test/replication/transaction.result
+++ b/test/replication/transaction.result
@@ -62,6 +62,11 @@ test_run:cmd("switch replica")
 ---
 - true
 ...
+-- check replication status
+test_run:wait_upstream(1,{status = 'stopped', message_re = 'Duplicate key'})
+---
+- true
+...
 -- nothing was applied
 v1[1] == box.info.vclock[1]
 ---
@@ -72,16 +77,6 @@ box.space.test:select()
 - - [1, 'm']
   - [2, 'm']
   - [4, 'r']
-...
--- check replication status
-box.info.replication[1].upstream.status
----
-- stopped
-...
-box.info.replication[1].upstream.message
----
-- Duplicate key exists in unique index "pk" in space "test" with old tuple - [4, "r"]
-  and new tuple - [4, "m"]
 ...
 -- set conflict to third transaction
 _ = box.space.test:delete({4})

--- a/test/replication/transaction.test.lua
+++ b/test/replication/transaction.test.lua
@@ -26,12 +26,11 @@ box.begin() s:insert({3, 'm'}) s:insert({4, 'm'}) box.commit()
 box.begin() s:insert({5, 'm'}) s:insert({6, 'm'}) s:insert({7, 'm'}) box.commit()
 
 test_run:cmd("switch replica")
+-- check replication status
+test_run:wait_upstream(1,{status = 'stopped', message_re = 'Duplicate key'})
 -- nothing was applied
 v1[1] == box.info.vclock[1]
 box.space.test:select()
--- check replication status
-box.info.replication[1].upstream.status
-box.info.replication[1].upstream.message
 -- set conflict to third transaction
 _ = box.space.test:delete({4})
 box.space.test:replace({6, 'r'})


### PR DESCRIPTION
The test is expected the replication is broken by the time of the server switch. Apparently, switch won the race, so the expectation is changed for waiting.

Closes https://github.com/tarantool/tarantool-qa/issues/271

NO_CHANGELOG=testing
NO_DOC=testing
NO_TEST=testing

(cherry picked from commit 0e181b35e837dca0604f088830f8b4e6bdf96df4)