### PR TITLE
sql: reset autoincrement IDs before execution

### DIFF
--- a/changelogs/unreleased/gh-6422-autoinc-ids-reset.md
+++ b/changelogs/unreleased/gh-6422-autoinc-ids-reset.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Re-running a prepared statement that generates new auto-increment IDs no
+  longer causes an error (gh-6422).

--- a/src/box/execute.c
+++ b/src/box/execute.c
@@ -219,12 +219,13 @@ sql_execute_prepared(uint32_t stmt_id, const struct sql_bind *bind,
 					       bind_count, port, region);
 	}
 	/*
-	 * Clear all set from previous execution cycle
-	 * values to be bound.
+	 * Clear all set from previous execution cycle values to be bound and
+	 * remove autoincrement IDs generated in that cycle.
 	 */
 	sql_unbind(stmt);
 	if (sql_bind(stmt, bind, bind_count) != 0)
 		return -1;
+	sql_reset_autoinc_id_list(stmt);
 	enum sql_serialization_format format = sql_column_count(stmt) > 0 ?
 					       DQL_EXECUTE : DML_EXECUTE;
 	port_sql_create(port, stmt, format, false);

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -506,6 +506,13 @@ sql_vfs_register(sql_vfs *, int makeDflt);
 void
 sql_unbind(struct sql_stmt *stmt);
 
+/**
+ * Reset the list of identifiers generated during the auto-increment of this
+ * prepared statement.
+ */
+void
+sql_reset_autoinc_id_list(struct sql_stmt *stmt);
+
 int
 sql_bind_double(sql_stmt *, int, double);
 

--- a/src/box/sql/vdbeapi.c
+++ b/src/box/sql/vdbeapi.c
@@ -445,6 +445,13 @@ sql_unbind(struct sql_stmt *stmt)
 	}
 }
 
+void
+sql_reset_autoinc_id_list(struct sql_stmt *stmt)
+{
+	struct Vdbe *v = (struct Vdbe *)stmt;
+	stailq_create(&v->autoinc_id_list);
+}
+
 int
 sql_bind_double(sql_stmt * pStmt, int i, double rValue)
 {

--- a/test/sql-luatest/gh_6422_autoinc_ids_reset_test.lua
+++ b/test/sql-luatest/gh_6422_autoinc_ids_reset_test.lua
@@ -1,0 +1,23 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'test_autoinc_id_reset'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_autoinc_id_reset = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        box.execute([[CREATE TABLE t(i INT PRIMARY KEY AUTOINCREMENT, a INT);]])
+        local stmt_id = box.prepare([[INSERT INTO t(a) VALUES (?);]]).stmt_id
+        t.assert_equals(box.execute(stmt_id, {1}).autoincrement_ids, {1})
+        t.assert_equals(box.execute(stmt_id, {1}).autoincrement_ids, {2})
+        box.execute([[DROP TABLE t;]])
+    end)
+end


### PR DESCRIPTION
After this patch, the list of auto-increment IDs will be reset before executing the prepared statement.

Closes #6422

NO_DOC=bugfix
NO_CHANGELOG=bugfix