### PR TITLE
sql: fix error with new field in new index

### DIFF
--- a/changelogs/unreleased/gh-5183-fix-index-field-missing.md
+++ b/changelogs/unreleased/gh-5183-fix-index-field-missing.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Creating index on newly added fields no longer leads to a wrong
+  select (gh-5183).

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -750,7 +750,9 @@ tarantoolsqlIdxKeyCompare(struct BtCursor *cursor,
 	format = tuple_format(tuple);
 	field_map = tuple_field_map(tuple);
 	field_count = tuple_format_field_count(format);
-	field0 = base; mp_decode_array(&field0); p = field0;
+	field0 = base;
+	uint32_t base_len = mp_decode_array(&field0);
+	p = field0;
 	for (i = 0; i < n; i++) {
 		/*
 		 * Tuple contains offset map to make it possible to
@@ -763,8 +765,19 @@ tarantoolsqlIdxKeyCompare(struct BtCursor *cursor,
 		 *  (3) field maps are rebuilt lazily when a new index
 		 *      is added, i.e. it is possible to encounter a
 		 *      tuple with an incomplete offset map.
+		 *  (4) it is possible that the length of the tuple data will be
+		 *      less than the given fieldno of the part, in which case
+		 *      we should just compare the mem from unpacked with NULL.
 		 */
 		uint32_t fieldno = key_def->parts[i].fieldno;
+		struct Mem *mem = &unpacked->aMem[i];
+		struct key_part *part = &unpacked->key_def->parts[i];
+		if (fieldno >= base_len) {
+			if (mem_is_null(mem))
+				continue;
+			rc = part->sort_order == SORT_ORDER_ASC ? -1 : 1;
+			goto out;
+		}
 
 		if (fieldno != next_fieldno) {
 			struct tuple_field *field =
@@ -786,8 +799,6 @@ tarantoolsqlIdxKeyCompare(struct BtCursor *cursor,
 			}
 		}
 		next_fieldno = fieldno + 1;
-		struct key_part *part = &unpacked->key_def->parts[i];
-		struct Mem *mem = unpacked->aMem + i;
 		struct coll *coll = part->coll;
 		if (mem_cmp_msgpack(mem, &p, &rc, coll) != 0)
 			rc = 0;

--- a/test/sql-luatest/gh_5183_fix_index_field_missing_test.lua
+++ b/test/sql-luatest/gh_5183_fix_index_field_missing_test.lua
@@ -1,0 +1,27 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'test_index_field_missing'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_index_field_missing = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local format = {{'I', 'integer'}}
+        local s = box.schema.space.create('T', {format = format})
+        s:create_index('i')
+        box.execute('INSERT INTO t VALUES (1), (2);')
+        format[2] = {'A', 'integer', is_nullable = true}
+        s:format(format)
+        s:create_index('a', {parts={'A'}, unique = false})
+        local rows = box.execute('SELECT * FROM t WHERE a IS NULL;').rows
+        t.assert_equals(rows, {{1, box.NULL}, {2, box.NULL}})
+    end)
+end


### PR DESCRIPTION
In case the space format is changed after inserting tuples, the new format contains new fields, and a new index is created that works with those new fields, it is possible to get an assertion during SELECT. This problem was fixed in this path.

Closes #5183

NO_DOC=bugfix