### PR TITLE
test: turn LuaJIT off in tests with dlsym

### DIFF
--- a/static-build/test/static-build/exports.test.lua
+++ b/static-build/test/static-build/exports.test.lua
@@ -129,6 +129,9 @@ local check_symbols = {
     'luaJIT_profile_dumpstack',
 }
 
+-- TODO gh-7640 LuaJIT: ffi.C.dlsym() doesn't work on FreeBSD
+jit.off()
+
 test:plan(#check_symbols)
 for _, sym in ipairs(check_symbols) do
     check_symbol(sym)

--- a/test/box-tap/curl-build.test.lua
+++ b/test/box-tap/curl-build.test.lua
@@ -171,6 +171,9 @@ local curl_symbols = {
     'curl_version_info',
 }
 
+-- TODO gh-7640 LuaJIT: ffi.C.dlsym() doesn't work on FreeBSD
+jit.off()
+
 test:test('curl_symbols', function(t)
     t:plan(#curl_symbols)
     for _, sym in ipairs(curl_symbols) do


### PR DESCRIPTION
`dlsym` is known to be buggy in FreeBSD. See #7640.

NO_DOC=internal
NO_CHANGELOG=internal