### PR TITLE
debugger: proper readline support, step.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ coverage.info
 *.swp*
 .gitignore
 .gdb_history
+.tdbg_history*
 CMakeFiles
 CMakeCache.txt
 CPackConfig.cmake

--- a/changelogs/unreleased/gh-7593-console-debugger.md
+++ b/changelogs/unreleased/gh-7593-console-debugger.md
@@ -1,0 +1,3 @@
+## feature/debugger
+
+* Introduced readline support to tarantool debugger (gh-7738).

--- a/test/interactive_tarantool.lua
+++ b/test/interactive_tarantool.lua
@@ -6,6 +6,7 @@ local fiber = require('fiber')
 local log = require('log')
 local yaml = require('yaml')
 local popen = require('popen')
+local tnt = require('tarantool')
 
 -- Default timeout for expecting an input on child's stdout.
 --
@@ -17,6 +18,8 @@ local M = {}
 
 local mt = {}
 mt.__index = mt
+
+local dbg_header = tnt.package .. " debugger " .. tnt.version
 
 -- {{{ Instance methods
 
@@ -45,7 +48,14 @@ function mt._start_stderr_logger(self)
 end
 
 function mt._stop_stderr_logger(self)
-    self._stderr_logger:cancel()
+    if self._stderr_logger == nil then
+        return
+    end
+    -- The server could have finished already, thus
+    -- kill only what needs to be killed.
+    if self._stderr_logger:status() ~= 'dead' then
+        self._stderr_logger:cancel()
+    end
     self._stderr_logger = nil
 end
 
@@ -79,7 +89,7 @@ function mt.read_line(self, opts)
     return line
 end
 
--- Returns all readed lines (including expected one).
+-- Returns all read lines (including expected one).
 function mt.read_until_line(self, exp_line, opts)
     local opts = opts or {}
     local deadline = opts.deadline or (fiber.clock() + TIMEOUT)
@@ -90,6 +100,31 @@ function mt.read_until_line(self, exp_line, opts)
         local line = self:read_line({deadline = deadline})
         table.insert(res, line)
     until line == exp_line
+
+    return res
+end
+
+-- Returns all read lines (excluding one with expected prompt, with deadline).
+-- Checks if stderr is empty.
+function mt.read_until_prompt(self, opts)
+    local opts = opts or {}
+    local deadline = opts.deadline or (fiber.clock() + TIMEOUT)
+
+    while not self._readahead_buffer:find(self._prompt) do
+        self:read_chunk({deadline = deadline})
+    end
+
+    local res, new_buffer = unpack(self._readahead_buffer:split(self._prompt,
+                                                                1))
+    new_buffer = self._prompt .. new_buffer
+
+    self._readahead_buffer = new_buffer
+
+    local stderr, err = self.ph:read({timeout = 0.05, stderr = true})
+    if stderr ~= "" and not (stderr == nil and
+                             tostring(err) == "timed out") then
+        error(("Unexpected stderr output: %s"):format(stderr))
+    end
 
     return res
 end
@@ -119,6 +154,14 @@ function mt.assert_data(self, exp_data, opts)
     end
 end
 
+local function decolor(string)
+    assert(type(string) == 'string')
+    -- The gsub is meant to clean ANSI color codes, for more details on
+    -- the format see the doc:
+    -- https://www.xfree86.org/current/ctlseqs.html
+    return string:gsub(M.ESC .. '%[[0-9;]*m', '')
+end
+
 -- ReadLine echoes commands to stdout. It is easier to match the
 -- echo against the original command, when the command is a
 -- one-liner. Let's replace newlines with spaces.
@@ -138,11 +181,16 @@ end
 -- * ReadLine 7: x<CR><duplicate x>, extra spaces.
 -- * ReadLine 6: <space><CR>.
 --
--- This function drop duplicates that goes in row, strips <CR> and
--- spaces. Applying of this function to a source command and
--- readline's echoed command allows to compare them for equality.
+-- This function drop duplicates that goes in row, strips <CR>,
+-- spaces, tabs and ANSI color codes. Applying of this function
+-- to a source command and readline's echoed command allows to
+-- compare them for equality.
 local function _prepare_command_for_compare(x)
-    x = x:gsub(' ', ''):gsub(M.CR, '')
+    x = x:gsub(' ', '')
+         :gsub(M.CR, '')
+         :gsub(M.TAB, '')
+
+    x = decolor(x)
     local acc = fun.iter(x):reduce(function(acc, c)
         if acc[#acc] ~= c then
             table.insert(acc, c)
@@ -161,12 +209,9 @@ function mt._assert_command_echo(self, prepared_command, opts)
 
     -- If readline wraps the line, prepare the commands for
     -- compare.
-    local comment = ''
-    if echo:find(M.CR) ~= nil then
-        exp_echo = _prepare_command_for_compare(exp_echo)
-        echo = _prepare_command_for_compare(echo)
-        comment = ' (the commands are mangled for the comparison)'
-    end
+    exp_echo = _prepare_command_for_compare(exp_echo)
+    echo = _prepare_command_for_compare(echo)
+    local comment = ' (the commands are mangled for the comparison)'
 
     if echo ~= exp_echo then
         error(('Unexpected command echo %q, expected %q%s'):format(
@@ -236,9 +281,10 @@ function M.escape_control(str)
         :gsub(M.ESC, '<ESC>')
 end
 
-function M.new(opts)
+function M._new_internal(opts)
     local opts = opts or {}
     local args = opts.args or {}
+    local prompt = opts.prompt
 
     local tarantool_exe = arg[-1]
     local ph = popen.new(fun.chain({tarantool_exe, '-i'}, args):totable(), {
@@ -263,18 +309,35 @@ function M.new(opts)
     local res = setmetatable({
         ph = ph,
         _readahead_buffer = '',
-        _prompt = 'tarantool> ',
+        _prompt = prompt or 'tarantool> ',
     }, mt)
 
-    -- Log child's stderr.
-    res:_start_stderr_logger()
+    return res
+end
+
+function M.new_debugger(opts)
+    opts = opts or {}
+    opts.prompt = opts.prompt or 'luadebug> '
+    local debugger = M._new_internal(opts)
+    if opts.expect_header then
+        local stderr, err = debugger.ph:read({timeout = TIMEOUT, stderr = true})
+        if (stderr == nil) then
+            error(err)
+        end
+        assert(stderr:find(dbg_header, 0, true))
+    end
+    return debugger
+end
+
+function M.new(opts)
+    local res = M._new_internal(opts)
 
     -- Write a command and ignore the echoed output.
     --
     -- ReadLine 6 writes <ESC>[?1034h at beginning, it may hit
     -- assertions on the child's output.
     --
-    -- This sequence of charcters is smm ('set meta mode')
+    -- This sequence of characters is smm ('set meta mode')
     -- terminal capacity value. It has relation to writing
     -- characters out of the ASCII range -- ones with 8th bit set,
     -- but its description is vague. See terminfo(5).
@@ -285,6 +348,9 @@ function M.new(opts)
     -- Disable stdout line buffering in the child.
     res:execute_command("io.stdout:setvbuf('no')")
     assert(res:read_response(), true)
+
+    -- Log child's stderr.
+    res:_start_stderr_logger()
 
     return res
 end

--- a/third_party/lua/README-luadebug.md
+++ b/third_party/lua/README-luadebug.md
@@ -198,16 +198,6 @@ Want to disable ANSI color support or disable GNU readline? Set the `NO_COLOR`.
 Known Issues:
 -
 
-- Debugger REPL is not yet compatible with Tarantool console, i.e. this
-  code will hang in terminal
-
-```lua
-tarantool> dbg = require 'luadebug'
-tarantool> dbg()
-```
-  One should call debugger activation only in their instrumented code, not
-  from interactive console.
-
 - Lua 5.1 lacks the API to access varargs. The workaround is to do something like `local args = {...}` and then use `unpack(args)` when you want to access them. In Lua 5.2+ and LuaJIT, you can simply use `...` in your expressions with the print command.
 - You can't add breakpoints to a running program or remove them. Currently the only way to set them is by explicitly calling the `dbg()` function explicitly in your code. (This is sort of by design and sort of because it's difficult/slow otherwise.)
 - Different interpreters (and versions) print out slightly different stack trace information.

--- a/third_party/lua/luadebug.lua
+++ b/third_party/lua/luadebug.lua
@@ -1122,15 +1122,6 @@ dbg = setmetatable({
             return
         end
 
-        --[[
-            Prevent debugger from running from inside of Tarantool console.
-            Check pointer, which Tarantool console stored to the console object
-            in the fiber.self().storage.console while inside of
-            REPL loop.
-        --]]
-        assert(require('fiber').self().storage.console == nil, DEBUGGER ..
-            ' is not yet compatible with interactive Tarantool console')
-
         top_offset = top_offset or 0
         stack_inspect_offset = top_offset
         stack_top = top_offset


### PR DESCRIPTION
Implemented readline history and autocomplete via reusing of Tarantool console readline facilities. They were hidden once Lua 'console' module loaded, now they kept visible as 'console_internal'.

Followup #7593 
Closes #7738