### PR TITLE
replication: say warning if before_replace trigger changed replica_id

### DIFF
--- a/changelogs/unreleased/gh_7846_before_replace_crash_on_replica_id_alter.md
+++ b/changelogs/unreleased/gh_7846_before_replace_crash_on_replica_id_alter.md
@@ -1,0 +1,6 @@
+## bugfix/replication
+
+* Say a warning when replica_id is changed by before_replace trigger while
+  adding a new replica (gh-7846). There was an assertion checking this before.
+  Also, handle the case when before_replace set on space `_cluster` returns
+  nil - it caused segmentation fault before.

--- a/test/box-luatest/gh_7846_crash_on_replica_id_alter_test.lua
+++ b/test/box-luatest/gh_7846_crash_on_replica_id_alter_test.lua
@@ -1,0 +1,56 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local urilib = require('uri')
+
+local g = t.group('before_replace alter',
+    t.helpers.matrix{ret_nil = {true, false}})
+
+g.test_before_replace_alter_replica_id = function(cg)
+    local ret_nil = cg.params.ret_nil
+    local server1 = server:new{
+        alias = 'server1',
+    }
+    server1:start()
+    server1:exec(function(ret_nil)
+        local trigger
+        if ret_nil == false then
+            trigger = function(_old, new)
+                return new:update({{'+', 1, 10}})
+            end
+        else
+            trigger = function(_old, _new)
+                return nil
+            end
+        end
+        box.space._cluster:before_replace(trigger)
+    end, {ret_nil})
+    local uri = urilib.parse(server1.net_box_uri)
+    local server2 = server:new{
+        alias = 'server2',
+        box_cfg = {replication = uri.unix}
+    }
+
+    if ret_nil == false then
+        server2:start()
+        local msg = server1:grep_log('Replica ID is changed by a trigger', 1024)
+        t.assert_not_equals(msg, nil)
+    else
+        -- We cannot wait until ready because server2 will not be started at all,
+        -- so we will retry until we find a log entry we need.
+        server2:start({wait_for_readiness=false})
+        t.helpers.retrying({}, function()
+            local msg = server1:grep_log('Replica ID is changed by a trigger', 1024)
+            if msg == nil then
+                error('Cannot find replica connection error')
+            end
+        end)
+    end
+
+    if ret_nil == false then
+        server2:drop()
+    else
+        -- Cannot drop server because it was not started.
+        server2:cleanup()
+    end
+    server1:drop()
+end


### PR DESCRIPTION
Currently, there is an assertion that checks if replica_id haven't been changed after it's registration. Let's replace this assertion with warning message about id being altered - new id will be used for affected replica.

Closes #7846