### PR TITLE
ci, debugger: gracefully handle nil values from popen

### DIFF
--- a/test/app-luatest/console_debugger_session_test.lua
+++ b/test/app-luatest/console_debugger_session_test.lua
@@ -8,7 +8,7 @@ local function normalize_path(s)
 end
 
 local function unescape(s)
-    return s:gsub('[\27\155][][()#;?%d]*[A-PRZcf-ntqry=><~]', '')
+    return s and s:gsub('[\27\155][][()#;?%d]*[A-PRZcf-ntqry=><~]', '') or ''
 end
 
 local function trim(s)


### PR DESCRIPTION
Appeared that ASAN build could return nil values from child process executed via popen. Which sporadically produces error messages:

```
  not ok 1 ..console_debugger_session.test_interactive_debugger_session
  #   ...ntool/test/app-luatest/console_debugger_session_test.lua:11:
  # attempt to index local 's' (a nil value)
  #   stack traceback:
```

Due to used timeouts we are ok to receive nil at one of a loop cycle - we simply repeat read to popen object. So handle this case gracefully.

Closes #7882 