### PR TITLE
sql: throw error on creation of too many indexes

### DIFF
--- a/changelogs/unreleased/gh-5526-no-error-on-too-many-indexes.md
+++ b/changelogs/unreleased/gh-5526-no-error-on-too-many-indexes.md
@@ -1,0 +1,3 @@
+## bugfix/sql
+
+* An error is now thrown when creating too many indexes in SQL (gh-5526).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -343,7 +343,7 @@ index_def_new_from_tuple(struct tuple *tuple, struct space *space)
 	if (index_def == NULL)
 		return NULL;
 	auto index_def_guard = make_scoped_guard([=] { index_def_delete(index_def); });
-	if (!index_def_is_valid(index_def, space_name(space)))
+	if (index_def_check(index_def, space_name(space)) != 0)
 		return NULL;
 	if (space_check_index_def(space, index_def) != 0)
 		return NULL;

--- a/src/box/index_def.c
+++ b/src/box/index_def.c
@@ -268,46 +268,45 @@ index_def_to_key_def(struct rlist *index_defs, int *size)
 	return keys;
 }
 
-bool
-index_def_is_valid(struct index_def *index_def, const char *space_name)
-
+int
+index_def_check(struct index_def *index_def, const char *space_name)
 {
 	if (index_def->iid >= BOX_INDEX_MAX) {
 		diag_set(ClientError, ER_MODIFY_INDEX, index_def->name,
 			 space_name, "index id too big");
-		return false;
+		return -1;
 	}
 	if (index_def->iid == 0 && index_def->opts.is_unique == false) {
 		diag_set(ClientError, ER_MODIFY_INDEX, index_def->name,
 			 space_name, "primary key must be unique");
-		return false;
+		return -1;
 	}
 	if (index_def->key_def->part_count == 0) {
 		diag_set(ClientError, ER_MODIFY_INDEX, index_def->name,
 			 space_name, "part count must be positive");
-		return false;
+		return -1;
 	}
 	if (index_def->key_def->part_count > BOX_INDEX_PART_MAX) {
 		diag_set(ClientError, ER_MODIFY_INDEX, index_def->name,
 			 space_name, "too many key parts");
-		return false;
+		return -1;
 	}
 	if (index_def->iid == 0 && index_def->key_def->is_multikey) {
 		diag_set(ClientError, ER_MODIFY_INDEX, index_def->name,
 			 space_name, "primary key cannot be multikey");
-		return false;
+		return -1;
 	}
 	if (index_def->iid == 0 && index_def->key_def->for_func_index) {
 		diag_set(ClientError, ER_MODIFY_INDEX, index_def->name,
 			space_name, "primary key can not use a function");
-		return false;
+		return -1;
 	}
 	for (uint32_t i = 0; i < index_def->key_def->part_count; i++) {
 		assert(index_def->key_def->parts[i].type < field_type_MAX);
 		if (index_def->key_def->parts[i].fieldno > BOX_INDEX_FIELD_MAX) {
 			diag_set(ClientError, ER_MODIFY_INDEX, index_def->name,
 				 space_name, "field no is too big");
-			return false;
+			return -1;
 		}
 		for (uint32_t j = 0; j < i; j++) {
 			/*
@@ -323,9 +322,9 @@ index_def_is_valid(struct index_def *index_def, const char *space_name)
 				diag_set(ClientError, ER_MODIFY_INDEX,
 					 index_def->name, space_name,
 					 "same key part is indexed twice");
-				return false;
+				return -1;
 			}
 		}
 	}
-	return true;
+	return 0;
 }

--- a/src/box/index_def.h
+++ b/src/box/index_def.h
@@ -400,11 +400,13 @@ index_def_cmp(const struct index_def *key1, const struct index_def *key2);
 /**
  * Check a key definition for violation of various limits.
  *
- * @param index_def   index definition
- * @param old_space   space definition
+ * @param index_def index definition
+ * @param old_space space definition
+ * @retval 0 Success.
+ * @retval -1 Error. Diag is set.
  */
-bool
-index_def_is_valid(struct index_def *index_def, const char *space_name);
+int
+index_def_check(struct index_def *index_def, const char *space_name);
 
 #if defined(__cplusplus)
 } /* extern "C" */
@@ -421,7 +423,7 @@ index_def_dup_xc(const struct index_def *def)
 static inline void
 index_def_check_xc(struct index_def *index_def, const char *space_name)
 {
-	if (! index_def_is_valid(index_def, space_name))
+	if (index_def_check(index_def, space_name) != 0)
 		diag_raise();
 }
 

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -2848,7 +2848,7 @@ sql_create_index(struct Parse *parse) {
 	}
 	index->def->key_def->part_count = new_part_count;
 
-	if (!index_def_is_valid(index->def, def->name)) {
+	if (index_def_check(index->def, def->name) != 0) {
 		parse->is_aborted = true;
 		goto exit_create_index;
 	}

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -2848,8 +2848,10 @@ sql_create_index(struct Parse *parse) {
 	}
 	index->def->key_def->part_count = new_part_count;
 
-	if (!index_def_is_valid(index->def, def->name))
+	if (!index_def_is_valid(index->def, def->name)) {
+		parse->is_aborted = true;
 		goto exit_create_index;
+	}
 
 	/*
 	 * Here we handle cases, when in CREATE TABLE statement

--- a/test/sql-luatest/gh_5526_no_error_on_too_many_indexes_test.lua
+++ b/test/sql-luatest/gh_5526_no_error_on_too_many_indexes_test.lua
@@ -1,0 +1,27 @@
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'test_no_error_on_too_many_indexes'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_no_error_on_too_many_indexes = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local s = "CREATE TABLE add (c0 INT PRIMARY KEY"
+        for i = 1,128 do
+            s = s .. ", c" .. i .. " INT UNIQUE"
+        end
+        s = s .. ");"
+        local _, err = box.execute(s)
+        local res = [[Can't create or modify index 'unique_unnamed_ADD_129' ]]..
+                    [[in space 'ADD': index id too big]]
+        t.assert_equals(err.message, res)
+    end)
+end


### PR DESCRIPTION
Prior to this patch, there was no error of creating too many indexes in SQL. This led to a situation where indexes with IDs greater than BOX_INDEX_MAX were not created, but no error was thrown. For example, in the case of CREATE TABLE, only indexes with an ID less than BOX_INDEX_MAX were created. Now an error is thrown when creating too many indexes.

Closes #5526

NO_DOC=bugfix