### PR TITLE
msgpack: fix integer overflow in mp_check

### DIFF
--- a/changelogs/unreleased/ghs-18-mp-check-overflow-fix.md
+++ b/changelogs/unreleased/ghs-18-mp-check-overflow-fix.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a bug in the MsgPack library that could lead to a failure to detect
+  invalid MsgPack input and, as a result, out-of-bounds read (ghs-18).

--- a/test/unit/msgpack.result
+++ b/test/unit/msgpack.result
@@ -2112,7 +2112,7 @@ ok 19 - subtests
     ok 5 - str is correct
     # *** test_mp_print_ext: done ***
 ok 20 - subtests
-    1..69
+    1..71
     # *** test_mp_check ***
     ok 1 - invalid fixmap 1
     ok 2 - invalid fixmap 2
@@ -2175,14 +2175,16 @@ ok 20 - subtests
     ok 59 - invalid array32 2
     ok 60 - invalid map16 1
     ok 61 - invalid map16 2
-    ok 62 - invalid map16 2
-    ok 63 - invalid map32 1
-    ok 64 - invalid map32 2
-    ok 65 - invalid map32 3
-    ok 66 - invalid header 1
-    ok 67 - invalid header 2
-    ok 68 - invalid header 3
-    ok 69 - invalid header 4
+    ok 62 - invalid map16 3
+    ok 63 - invalid map16 4
+    ok 64 - invalid map32 1
+    ok 65 - invalid map32 2
+    ok 66 - invalid map32 3
+    ok 67 - invalid map32 4
+    ok 68 - invalid header 1
+    ok 69 - invalid header 2
+    ok 70 - invalid header 3
+    ok 71 - invalid header 4
     # *** test_mp_check: done ***
 ok 21 - subtests
     1..24


### PR DESCRIPTION
The bug was fixed in https://github.com/tarantool/msgpuck/pull/24. This commit just bumps the submodule.

Closes https://github.com/tarantool/security/issues/18