### PR TITLE
A changelog for buffer overflow in decimal_unpack

### DIFF
--- a/changelogs/unreleased/ghs-17-fix-decimal-unpack-overflow.md
+++ b/changelogs/unreleased/ghs-17-fix-decimal-unpack-overflow.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a possible buffer overflow in `mp_decode_decimal()` and
+  `decimal_unpack()` when an input string is too long (ghs-17).


### PR DESCRIPTION
Add a forgotten changelog entry.

Follow-up https://github.com/tarantool/security/issues/17

NO_DOC=changelog
NO_TEST=changelog