### PR TITLE
box: export `box_schema_version` to public API and Lua

### DIFF
--- a/changelogs/unreleased/gh-7904-export-box_schema_version-to-public-api-and-lua.md
+++ b/changelogs/unreleased/gh-7904-export-box_schema_version-to-public-api-and-lua.md
@@ -1,0 +1,4 @@
+## feature/box
+
+* Exported `box_schema_version` to public API and Lua via
+  `box.info.schema_version` (gh-7904).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -211,6 +211,7 @@ set(api_headers
     ${PROJECT_SOURCE_DIR}/src/box/field_def.h
     ${PROJECT_SOURCE_DIR}/src/box/tuple_format.h
     ${PROJECT_SOURCE_DIR}/src/box/schema_def.h
+    ${PROJECT_SOURCE_DIR}/src/box/schema.h
     ${PROJECT_SOURCE_DIR}/src/box/box.h
     ${PROJECT_SOURCE_DIR}/src/box/index.h
     ${PROJECT_SOURCE_DIR}/src/box/iterator_type.h

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -161,7 +161,7 @@ struct errcode_record {
 	/*106 */_(ER_WRONG_INDEX_RECORD,	"Wrong record in _index space: got {%s}, expected {%s}") \
 	/*107 */_(ER_WRONG_INDEX_PARTS,		"Wrong index parts: %s") \
 	/*108 */_(ER_WRONG_INDEX_OPTIONS,	"Wrong index options: %s") \
-	/*109 */_(ER_WRONG_SCHEMA_VERSION,	"Wrong schema version, current: %d, in request: %u") \
+	/*109 */_(ER_WRONG_SCHEMA_VERSION,	"Wrong schema version, current: %d, in request: %llu") \
 	/*110 */_(ER_MEMTX_MAX_TUPLE_SIZE,	"Failed to allocate %u bytes for tuple: tuple is too large. Check 'memtx_max_tuple_size' configuration option.") \
 	/*111 */_(ER_WRONG_SPACE_OPTIONS,	"Wrong space options: %s") \
 	/*112 */_(ER_UNSUPPORTED_INDEX_FEATURE,	"Index '%s' (%s) of space '%s' (%s) does not support %s") \

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -1793,7 +1793,7 @@ net_finish_destroy(struct cmsg *m)
 
 
 static int
-tx_check_schema(uint32_t new_schema_version)
+tx_check_schema(uint64_t new_schema_version)
 {
 	if (new_schema_version && new_schema_version != schema_version) {
 		diag_set(ClientError, ER_WRONG_SCHEMA_VERSION,

--- a/src/box/lua/feedback_daemon.lua
+++ b/src/box/lua/feedback_daemon.lua
@@ -212,7 +212,7 @@ local cached_schema_version = 0
 local cached_schema_features = {}
 
 local function fill_in_schema_stats(features)
-    local schema_version = box.internal.schema_version()
+    local schema_version = box.info.schema_version
     if cached_schema_version < schema_version then
         local schema = {}
         fill_in_schema_stats_impl(schema)

--- a/src/box/lua/info.c
+++ b/src/box/lua/info.c
@@ -51,6 +51,7 @@
 #include "box/box.h"
 #include "box/raft.h"
 #include "box/txn_limbo.h"
+#include "box/schema.h"
 #include "lua/utils.h"
 #include "lua/serializer.h" /* luaL_setmaphint */
 #include "fiber.h"
@@ -656,6 +657,12 @@ lbox_info_synchro(struct lua_State *L)
 	return 1;
 }
 
+static int
+lbox_schema_version(struct lua_State *L)
+{
+	luaL_pushuint64(L, box_schema_version());
+	return 1;
+}
 
 static const struct luaL_Reg lbox_info_dynamic_meta[] = {
 	{"id", lbox_info_id},
@@ -678,6 +685,7 @@ static const struct luaL_Reg lbox_info_dynamic_meta[] = {
 	{"listen", lbox_info_listen},
 	{"election", lbox_info_election},
 	{"synchro", lbox_info_synchro},
+	{"schema_version", lbox_schema_version},
 	{NULL, NULL}
 };
 

--- a/src/box/lua/net_box.c
+++ b/src/box/lua/net_box.c
@@ -2493,7 +2493,7 @@ netbox_transport_do_auth(struct netbox_transport *transport,
  */
 static uint32_t
 netbox_transport_fetch_schema(struct netbox_transport *transport,
-			      struct lua_State *L, uint32_t schema_version)
+			      struct lua_State *L, uint64_t schema_version)
 {
 	if (!transport->opts.fetch_schema) {
 		return schema_version;
@@ -2603,7 +2603,7 @@ restart:
  */
 static uint32_t
 netbox_transport_process_requests(struct netbox_transport *transport,
-				  struct lua_State *L, uint32_t schema_version)
+				  struct lua_State *L, uint64_t schema_version)
 {
 	if (transport->state != NETBOX_ACTIVE &&
 	    transport->state != NETBOX_GRACEFUL_SHUTDOWN) {
@@ -2633,7 +2633,7 @@ netbox_connection_handler_f(struct lua_State *L)
 	struct netbox_transport *transport = (void *)lua_topointer(L, 1);
 	netbox_transport_do_id(transport, L);
 	netbox_transport_do_auth(transport, L);
-	uint32_t schema_version = 0;
+	uint64_t schema_version = 0;
 	while (true) {
 		schema_version = netbox_transport_fetch_schema(
 			transport, L, schema_version);

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -28,7 +28,6 @@ local INT64_MAX = tonumber64('9223372036854775807')
 ffi.cdef[[
     extern bool box_read_ffi_is_disabled;
     struct space *space_by_id(uint32_t id);
-    extern uint32_t box_schema_version();
     void space_run_triggers(struct space *space, bool yesno);
     size_t space_bsize(struct space *space);
 
@@ -1924,7 +1923,14 @@ local function check_ck_constraint_arg(ck_constraint, method)
 end
 box.internal.check_ck_constraint_arg = check_ck_constraint_arg
 
-box.internal.schema_version = builtin.box_schema_version
+local internal_schema_version_warn_once = false
+box.internal.schema_version = function()
+    if not internal_schema_version_warn_once then
+        internal_schema_version_warn_once = true
+        log.warn('box.internal.schema_version will be removed, please use box.info.schema_version instead')
+    end
+    return box.info.schema_version
+end
 
 local function check_iterator_type(opts, key_is_nil)
     local opts_type = type(opts)

--- a/src/box/schema.cc
+++ b/src/box/schema.cc
@@ -69,7 +69,7 @@ struct rlist on_alter_func = RLIST_HEAD_INITIALIZER(on_alter_func);
 
 struct entity_access entity_access;
 
-uint64_t
+API_EXPORT uint64_t
 box_schema_version(void)
 {
 	return schema_version;

--- a/src/box/schema.cc
+++ b/src/box/schema.cc
@@ -57,7 +57,7 @@
 static struct mh_i32ptr_t *sequences;
 /** Public change counter. On its update clients need to fetch
  *  new space data from the instance. */
-uint32_t schema_version = 0;
+uint64_t schema_version = 0;
 
 /** Persistent version of the schema, stored in _schema["version"]. */
 uint32_t dd_version_id = 0;
@@ -69,7 +69,7 @@ struct rlist on_alter_func = RLIST_HEAD_INITIALIZER(on_alter_func);
 
 struct entity_access entity_access;
 
-uint32_t
+uint64_t
 box_schema_version(void)
 {
 	return schema_version;

--- a/src/box/schema.h
+++ b/src/box/schema.h
@@ -43,14 +43,17 @@ extern "C" {
 
 struct func;
 
-extern uint32_t schema_version;
+/**
+ * See `box_schema_version`.
+ */
+extern uint64_t schema_version;
 extern uint32_t dd_version_id;
 
 /** Triggers invoked after schema initialization. */
 extern struct rlist on_schema_init;
 
 /** Return current monotonic schema version. */
-uint32_t
+uint64_t
 box_schema_version(void);
 
 /** Return current persistent schema version. */

--- a/src/box/schema.h
+++ b/src/box/schema.h
@@ -52,9 +52,17 @@ extern uint32_t dd_version_id;
 /** Triggers invoked after schema initialization. */
 extern struct rlist on_schema_init;
 
-/** Return current monotonic schema version. */
-uint64_t
+/** \cond public */
+
+/**
+ * Returns the current version of the database schema, an unsigned number
+ * that goes up when there is a major change in the schema, i.e., on DDL
+ * operations (\sa IPROTO_SCHEMA_VERSION).
+ */
+API_EXPORT uint64_t
 box_schema_version(void);
+
+/** \endcond public */
 
 /** Return current persistent schema version. */
 uint32_t

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -430,7 +430,7 @@ sql_column_is_autoincrement(sql_stmt *stmt, int n);
 const char *
 sql_column_span(sql_stmt *stmt, int n);
 
-uint32_t
+uint64_t
 sql_stmt_schema_version(const struct sql_stmt *stmt);
 
 int

--- a/src/box/sql/vdbeInt.h
+++ b/src/box/sql/vdbeInt.h
@@ -238,7 +238,7 @@ struct Vdbe {
 	int iStatement;		/* Statement number (or 0 if has not opened stmt) */
 	i64 iCurrentTime;	/* Value of julianday('now') for this statement */
 	i64 nFkConstraint;	/* Number of imm. FK constraints this VM */
-	uint32_t schema_ver;	/* Schema version at the moment of VDBE creation. */
+	uint64_t schema_ver;	/* Schema version at the moment of VDBE creation. */
 
 	/*
 	 * In recursive triggers we can execute INSERT/UPDATE OR IGNORE

--- a/src/box/sql/vdbeapi.c
+++ b/src/box/sql/vdbeapi.c
@@ -276,7 +276,7 @@ sql_column_span(sql_stmt *stmt, int n) {
 	return p->metadata[n].span;
 }
 
-uint32_t
+uint64_t
 sql_stmt_schema_version(const struct sql_stmt *stmt)
 {
 	struct Vdbe *v = (struct Vdbe *) stmt;

--- a/src/box/xrow.c
+++ b/src/box/xrow.c
@@ -378,7 +378,7 @@ static_assert(sizeof(struct iproto_header_bin) == IPROTO_HEADER_LEN,
 
 void
 iproto_header_encode(char *out, uint16_t type, uint64_t sync,
-		     uint32_t schema_version, uint32_t body_length)
+		     uint64_t schema_version, uint32_t body_length)
 {
 	struct iproto_header_bin header;
 	header.m_len = 0xce;
@@ -419,7 +419,7 @@ iproto_encode_error(uint32_t error)
 }
 
 int
-iproto_reply_ok(struct obuf *out, uint64_t sync, uint32_t schema_version)
+iproto_reply_ok(struct obuf *out, uint64_t sync, uint64_t schema_version)
 {
 	char *buf = (char *)obuf_alloc(out, IPROTO_HEADER_LEN + 1);
 	if (buf == NULL) {
@@ -433,7 +433,7 @@ iproto_reply_ok(struct obuf *out, uint64_t sync, uint32_t schema_version)
 }
 
 int
-iproto_reply_id(struct obuf *out, uint64_t sync, uint32_t schema_version)
+iproto_reply_id(struct obuf *out, uint64_t sync, uint64_t schema_version)
 {
 	unsigned version = IPROTO_CURRENT_VERSION;
 	struct iproto_features *features = &IPROTO_CURRENT_FEATURES;
@@ -484,7 +484,7 @@ iproto_reply_id(struct obuf *out, uint64_t sync, uint32_t schema_version)
 
 int
 iproto_reply_vclock(struct obuf *out, const struct vclock *vclock,
-		    uint64_t sync, uint32_t schema_version)
+		    uint64_t sync, uint64_t schema_version)
 {
 	size_t max_size = IPROTO_HEADER_LEN + mp_sizeof_map(1) +
 		mp_sizeof_uint(UINT32_MAX) + mp_sizeof_vclock_ignore0(vclock);
@@ -514,7 +514,7 @@ iproto_reply_vclock(struct obuf *out, const struct vclock *vclock,
 
 int
 iproto_reply_vote(struct obuf *out, const struct ballot *ballot,
-		  uint64_t sync, uint32_t schema_version)
+		  uint64_t sync, uint64_t schema_version)
 {
 	size_t max_size = IPROTO_HEADER_LEN + mp_sizeof_map(1) +
 		mp_sizeof_uint(UINT32_MAX) + mp_sizeof_map(6) +
@@ -586,7 +586,7 @@ mpstream_iproto_encode_error(struct mpstream *stream, const struct error *error)
 
 int
 iproto_reply_error(struct obuf *out, const struct error *e, uint64_t sync,
-		   uint32_t schema_version)
+		   uint64_t schema_version)
 {
 	char *header = (char *)obuf_alloc(out, IPROTO_HEADER_LEN);
 	if (header == NULL)
@@ -611,7 +611,7 @@ iproto_reply_error(struct obuf *out, const struct error *e, uint64_t sync,
 
 void
 iproto_do_write_error(struct iostream *io, const struct error *e,
-		      uint32_t schema_version, uint64_t sync)
+		      uint64_t schema_version, uint64_t sync)
 {
 	bool is_error = false;
 	struct mpstream stream;
@@ -666,7 +666,7 @@ iproto_prepare_header(struct obuf *buf, struct obuf_svp *svp, size_t size)
 
 void
 iproto_reply_select(struct obuf *buf, struct obuf_svp *svp, uint64_t sync,
-		    uint32_t schema_version, uint32_t count)
+		    uint64_t schema_version, uint32_t count)
 {
 	char *pos = (char *) obuf_svp_to_ptr(buf, svp);
 	iproto_header_encode(pos, IPROTO_OK, sync, schema_version,
@@ -732,7 +732,7 @@ xrow_decode_sql(const struct xrow_header *row, struct sql_request *request)
 
 void
 iproto_reply_sql(struct obuf *buf, struct obuf_svp *svp, uint64_t sync,
-		 uint32_t schema_version)
+		 uint64_t schema_version)
 {
 	char *pos = (char *) obuf_svp_to_ptr(buf, svp);
 	iproto_header_encode(pos, IPROTO_OK, sync, schema_version,
@@ -741,7 +741,7 @@ iproto_reply_sql(struct obuf *buf, struct obuf_svp *svp, uint64_t sync,
 
 void
 iproto_reply_chunk(struct obuf *buf, struct obuf_svp *svp, uint64_t sync,
-		   uint32_t schema_version)
+		   uint64_t schema_version)
 {
 	char *pos = (char *) obuf_svp_to_ptr(buf, svp);
 	iproto_header_encode(pos, IPROTO_CHUNK, sync, schema_version,

--- a/src/box/xrow.h
+++ b/src/box/xrow.h
@@ -112,7 +112,8 @@ struct xrow_header {
 	};
 
 	int bodycnt;
-	uint32_t schema_version;
+	/* See `IPROTO_SCHEMA_VERSION`. */
+	uint64_t schema_version;
 	struct iovec body[XROW_BODY_IOVMAX];
 };
 
@@ -622,7 +623,7 @@ xrow_encode_type(struct xrow_header *row, uint16_t type);
  */
 void
 iproto_header_encode(char *data, uint16_t type, uint64_t sync,
-		     uint32_t schema_version, uint32_t body_length);
+		     uint64_t schema_version, uint32_t body_length);
 
 struct obuf;
 struct obuf_svp;
@@ -654,7 +655,7 @@ iproto_prepare_select(struct obuf *buf, struct obuf_svp *svp)
  */
 void
 iproto_reply_select(struct obuf *buf, struct obuf_svp *svp, uint64_t sync,
-		    uint32_t schema_version, uint32_t count);
+		    uint64_t schema_version, uint32_t count);
 
 /**
  * Encode iproto header with IPROTO_OK response code.
@@ -666,7 +667,7 @@ iproto_reply_select(struct obuf *buf, struct obuf_svp *svp, uint64_t sync,
  * @retval -1 Memory error.
  */
 int
-iproto_reply_ok(struct obuf *out, uint64_t sync, uint32_t schema_version);
+iproto_reply_ok(struct obuf *out, uint64_t sync, uint64_t schema_version);
 
 /**
  * Encode iproto header with IPROTO_OK response code and protocol features
@@ -679,7 +680,7 @@ iproto_reply_ok(struct obuf *out, uint64_t sync, uint32_t schema_version);
  * @retval -1 Memory error.
  */
 int
-iproto_reply_id(struct obuf *out, uint64_t sync, uint32_t schema_version);
+iproto_reply_id(struct obuf *out, uint64_t sync, uint64_t schema_version);
 
 /**
  * Encode iproto header with IPROTO_OK response code and vclock
@@ -694,7 +695,7 @@ iproto_reply_id(struct obuf *out, uint64_t sync, uint32_t schema_version);
  */
 int
 iproto_reply_vclock(struct obuf *out, const struct vclock *vclock,
-		    uint64_t sync, uint32_t schema_version);
+		    uint64_t sync, uint64_t schema_version);
 
 /**
  * Encode a reply to an IPROTO_VOTE request.
@@ -708,7 +709,7 @@ iproto_reply_vclock(struct obuf *out, const struct vclock *vclock,
  */
 int
 iproto_reply_vote(struct obuf *out, const struct ballot *ballot,
-		  uint64_t sync, uint32_t schema_version);
+		  uint64_t sync, uint64_t schema_version);
 
 /**
  * Write an error packet int output buffer. Doesn't throw if out
@@ -716,7 +717,7 @@ iproto_reply_vote(struct obuf *out, const struct ballot *ballot,
  */
 int
 iproto_reply_error(struct obuf *out, const struct error *e, uint64_t sync,
-		   uint32_t schema_version);
+		   uint64_t schema_version);
 
 /** EXECUTE/PREPARE request. */
 struct sql_request {
@@ -748,7 +749,7 @@ xrow_decode_sql(const struct xrow_header *row, struct sql_request *request);
  */
 void
 iproto_reply_sql(struct obuf *buf, struct obuf_svp *svp, uint64_t sync,
-		 uint32_t schema_version);
+		 uint64_t schema_version);
 
 /**
  * Write an IPROTO_CHUNK header from a specified position in a
@@ -760,7 +761,7 @@ iproto_reply_sql(struct obuf *buf, struct obuf_svp *svp, uint64_t sync,
  */
 void
 iproto_reply_chunk(struct obuf *buf, struct obuf_svp *svp, uint64_t sync,
-		   uint32_t schema_version);
+		   uint64_t schema_version);
 
 /**
  * Encode IPROTO_EVENT packet.
@@ -780,7 +781,7 @@ iproto_send_event(struct obuf *out, const char *key, size_t key_len,
 /** Write error directly to a socket. */
 void
 iproto_do_write_error(struct iostream *io, const struct error *e,
-		      uint32_t schema_version, uint64_t sync);
+		      uint64_t schema_version, uint64_t sync);
 
 enum {
 	/* Maximal length of protocol name in handshake */
@@ -1129,7 +1130,7 @@ xrow_decode_subscribe_response_xc(const struct xrow_header *row,
 
 /** @copydoc iproto_reply_ok. */
 static inline void
-iproto_reply_ok_xc(struct obuf *out, uint64_t sync, uint32_t schema_version)
+iproto_reply_ok_xc(struct obuf *out, uint64_t sync, uint64_t schema_version)
 {
 	if (iproto_reply_ok(out, sync, schema_version) != 0)
 		diag_raise();
@@ -1137,7 +1138,7 @@ iproto_reply_ok_xc(struct obuf *out, uint64_t sync, uint32_t schema_version)
 
 /** @copydoc iproto_reply_id. */
 static inline void
-iproto_reply_id_xc(struct obuf *out, uint64_t sync, uint32_t schema_version)
+iproto_reply_id_xc(struct obuf *out, uint64_t sync, uint64_t schema_version)
 {
 	if (iproto_reply_id(out, sync, schema_version) != 0)
 		diag_raise();
@@ -1146,7 +1147,7 @@ iproto_reply_id_xc(struct obuf *out, uint64_t sync, uint32_t schema_version)
 /** @copydoc iproto_reply_vclock. */
 static inline void
 iproto_reply_vclock_xc(struct obuf *out, const struct vclock *vclock,
-		       uint64_t sync, uint32_t schema_version)
+		       uint64_t sync, uint64_t schema_version)
 {
 	if (iproto_reply_vclock(out, vclock, sync, schema_version) != 0)
 		diag_raise();
@@ -1155,7 +1156,7 @@ iproto_reply_vclock_xc(struct obuf *out, const struct vclock *vclock,
 /** @copydoc iproto_reply_vote. */
 static inline void
 iproto_reply_vote_xc(struct obuf *out, const struct ballot *ballot,
-		       uint64_t sync, uint32_t schema_version)
+		       uint64_t sync, uint64_t schema_version)
 {
 	if (iproto_reply_vote(out, ballot, sync, schema_version) != 0)
 		diag_raise();

--- a/test/app-tap/module_api.c
+++ b/test/app-tap/module_api.c
@@ -2981,6 +2981,19 @@ test_isdecimal_ptr(struct lua_State *L)
 
 /* }}} Helpers for decimal Lua/C API test cases */
 
+/* {{{ Helpers for schema version Lua/C API test cases */
+
+static int
+test_box_schema_version(struct lua_State *L)
+{
+	fail_unless(lua_gettop(L) == 1);
+	fail_unless(lua_isnumber(L, 1));
+	lua_pushboolean(L, luaL_touint64(L, 1) == box_schema_version());
+	return 1;
+}
+
+/* }}} Helpers for schema version Lua/C API test cases */
+
 LUA_API int
 luaopen_module_api(lua_State *L)
 {
@@ -3031,6 +3044,7 @@ luaopen_module_api(lua_State *L)
 		{"decimal_div", test_decimal_div},
 		{"isdecimal", test_isdecimal},
 		{"isdecimal_ptr", test_isdecimal_ptr},
+		{"box_schema_version_matches", test_box_schema_version},
 		{NULL, NULL}
 	};
 	luaL_register(L, "module_api", lib);

--- a/test/app-tap/module_api.test.lua
+++ b/test/app-tap/module_api.test.lua
@@ -475,8 +475,21 @@ local function test_isdecimal(test, module)
     test:ok(ok, 'verify pointer from luaT_isdecimal()')
 end
 
+local function test_box_schema_version_matches(test, module)
+    test:plan(3)
+
+    test:ok(module.box_schema_version_matches(box.info.schema_version),
+            'verify that schema version Lua/C APIs return the same value before DDL')
+    local old_schema_version = box.info.schema_version
+    local s = box.schema.space.create('s')
+    test:isnt(box.info.schema_version, old_schema_version, 'verify that schema version changes after DDL')
+    test:ok(module.box_schema_version_matches(box.info.schema_version),
+            'verify that schema version Lua/C APIs return the same value after DDL')
+    s:drop()
+end
+
 require('tap').test("module_api", function(test)
-    test:plan(43)
+    test:plan(44)
     local status, module = pcall(require, 'module_api')
     test:is(status, true, "module")
     test:ok(status, "module is loaded")
@@ -508,6 +521,7 @@ require('tap').test("module_api", function(test)
     test:test("tuple_field_by_path", test_tuple_field_by_path, module)
     test:test("pushdecimal", test_pushdecimal, module)
     test:test("isdecimal", test_isdecimal, module)
+    test:test("box_schema_version_matches", test_box_schema_version_matches, module)
 
     space:drop()
 end)

--- a/test/box-luatest/gh_7904_export_box_schema_version_to_public_api_test.lua
+++ b/test/box-luatest/gh_7904_export_box_schema_version_to_public_api_test.lua
@@ -1,0 +1,32 @@
+local fio = require('fio')
+local server = require('test.luatest_helpers.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new {
+        alias   = 'dflt',
+    }
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+-- Checks that a deprecation warning is printed, exactly once, when using `box.internal.schema_version`.
+g.test_box_internal_schema_version_deprecation = function(cg)
+    cg.server:exec(function()
+        box.internal.schema_version()
+    end)
+    local deprecation_warning =
+        'box.internal.schema_version will be removed, please use box.info.schema_version instead'
+    t.assert_is_not(cg.server:grep_log(deprecation_warning, 256), nil)
+    local log_file = g.server:exec(function() return box.cfg.log end)
+    fio.truncate(log_file)
+    cg.server:exec(function()
+        box.internal.schema_version()
+    end)
+    t.assert_is(cg.server:grep_log(deprecation_warning, 256), nil)
+end

--- a/test/box/info.result
+++ b/test/box/info.result
@@ -86,6 +86,7 @@ t
   - replication
   - replication_anon
   - ro
+  - schema_version
   - signature
   - sql
   - status

--- a/test/box/schema_reload.result
+++ b/test/box/schema_reload.result
@@ -277,8 +277,8 @@ somefunc = nil
 cn:close()
 ---
 ...
--- box.internal.schema_version()
-schema_version = box.internal.schema_version()
+-- box.info.schema_version
+schema_version = box.info.schema_version
 ---
 ...
 schema_version > 0
@@ -288,7 +288,7 @@ schema_version > 0
 bump_schema_version()
 ---
 ...
-box.internal.schema_version() == schema_version + 1
+box.info.schema_version == schema_version + 1
 ---
 - true
 ...

--- a/test/box/schema_reload.test.lua
+++ b/test/box/schema_reload.test.lua
@@ -136,11 +136,11 @@ somefunc = nil
 cn:close()
 
 
--- box.internal.schema_version()
-schema_version = box.internal.schema_version()
+-- box.info.schema_version
+schema_version = box.info.schema_version
 schema_version > 0
 bump_schema_version()
-box.internal.schema_version() == schema_version + 1
+box.info.schema_version == schema_version + 1
 
 if box.space.bump_schema_version ~= nil then box.space.bump_schema_version:drop() end
 box.schema.user.revoke('guest', 'execute', 'universe')

--- a/test/engine/ddl.result
+++ b/test/engine/ddl.result
@@ -389,16 +389,13 @@ s:drop()
 -- gh-3414: do not increase schema_version on space:truncate()
 --
 -- update schema_version on space.create()
-sch_ver = box.internal.schema_version
----
-...
-v = sch_ver()
+v = box.info.schema_version
 ---
 ...
 s = box.schema.create_space('test')
 ---
 ...
-v + 1 == sch_ver()
+v + 1 == box.info.schema_version
 ---
 - true
 ...
@@ -406,7 +403,7 @@ v + 1 == sch_ver()
 prim = s:create_index("primary")
 ---
 ...
-v + 2 == sch_ver()
+v + 2 == box.info.schema_version
 ---
 - true
 ...
@@ -414,7 +411,7 @@ v + 2 == sch_ver()
 s:truncate()
 ---
 ...
-v + 2 == sch_ver()
+v + 2 == box.info.schema_version
 ---
 - true
 ...
@@ -422,7 +419,7 @@ v + 2 == sch_ver()
 prim:alter{name="new_primary"}
 ---
 ...
-v + 3 == sch_ver()
+v + 3 == box.info.schema_version
 ---
 - true
 ...
@@ -430,7 +427,7 @@ v + 3 == sch_ver()
 box.schema.index.drop(s.id, 0)
 ---
 ...
-v + 4 == sch_ver()
+v + 4 == box.info.schema_version
 ---
 - true
 ...
@@ -438,7 +435,7 @@ v + 4 == sch_ver()
 s:drop()
 ---
 ...
-v + 5 == sch_ver()
+v + 5 == box.info.schema_version
 ---
 - true
 ...

--- a/test/engine/ddl.test.lua
+++ b/test/engine/ddl.test.lua
@@ -141,25 +141,24 @@ s:drop()
 -- gh-3414: do not increase schema_version on space:truncate()
 --
 -- update schema_version on space.create()
-sch_ver = box.internal.schema_version
-v = sch_ver()
+v = box.info.schema_version
 s = box.schema.create_space('test')
-v + 1 == sch_ver()
+v + 1 == box.info.schema_version
 -- update schema_version on space:create_index()
 prim = s:create_index("primary")
-v + 2 == sch_ver()
+v + 2 == box.info.schema_version
 -- do not change schema_version on space.truncate()
 s:truncate()
-v + 2 == sch_ver()
+v + 2 == box.info.schema_version
 -- update schema_version on index.alter()
 prim:alter{name="new_primary"}
-v + 3 == sch_ver()
+v + 3 == box.info.schema_version
 -- update schema_version on index.drop()
 box.schema.index.drop(s.id, 0)
-v + 4 == sch_ver()
+v + 4 == box.info.schema_version
 -- update schema_version on space.drop()
 s:drop()
-v + 5 == sch_ver()
+v + 5 == box.info.schema_version
 
 --
 -- gh-3229: update optionality if a space format is changed too,

--- a/test/unit/vy_point_lookup.c
+++ b/test/unit/vy_point_lookup.c
@@ -10,7 +10,7 @@
 #include "vy_write_iterator.h"
 #include "identifier.h"
 
-uint32_t schema_version;
+uint64_t schema_version;
 uint32_t space_cache_version;
 struct space *space_by_id(uint32_t id) { return NULL; }
 struct vy_lsm *vy_lsm(struct index *index) { return NULL; }


### PR DESCRIPTION
`box_schema_version` symbol is currently exposed via `exports`, but it is not part of the public API: export it to public API and Lua.

Closes #7904