### PR TITLE
build: add EXTRA_API_HEADERS variable

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -220,6 +220,7 @@ set(api_headers
     ${PROJECT_SOURCE_DIR}/src/lib/core/clock.h
     ${PROJECT_SOURCE_DIR}/src/box/decimal.h
     ${PROJECT_SOURCE_DIR}/src/lua/decimal.h
+    ${EXTRA_API_HEADERS}
 )
 rebuild_module_api(${api_headers})
 


### PR DESCRIPTION
The module API header (module.h) is generated automatically by extracting everything between '\cond public' and '\endcond public' from headers listed in the api_headers CMake variable. We're planning to extend the module API in Tarantool EE. To achieve that, this commit includes all files listed in the new CMake variable EXTRA_API_HEADERS into api_headers.

Needed for https://github.com/tarantool/tarantool-ee/issues/265