### PR TITLE
address latest coverity complains

### DIFF
--- a/src/lib/salad/stailq.h
+++ b/src/lib/salad/stailq.h
@@ -80,6 +80,15 @@ stailq_create(struct stailq *head)
 }
 
 /**
+ * return TRUE if list is empty
+ */
+static inline int
+stailq_empty(struct stailq *head)
+{
+	return head->first.value == NULL;
+}
+
+/**
  * Add an item to list head
  */
 inline static void
@@ -97,6 +106,7 @@ stailq_add(struct stailq *head, struct stailq_entry *item)
 inline static struct stailq_entry *
 stailq_shift(struct stailq *head)
 {
+	assert(!stailq_empty(head));
 	struct stailq_entry_ptr shift = head->first;
 	head->first = head->first.value->next;
 	if (head->first.value == NULL)
@@ -154,15 +164,6 @@ inline static struct stailq_entry *
 stailq_next(struct stailq_entry *item)
 {
 	return item->next.value;
-}
-
-/**
- * return TRUE if list is empty
- */
-inline static int
-stailq_empty(struct stailq *head)
-{
-	return head->first.value == NULL;
 }
 
 /*


### PR DESCRIPTION
**stailq: add non empty list assertion to stailq_shift**

stailq_shift expects list to be non empty. Let's add assertion.

This patch addresses coverity complain [1526815](https://scan7.scan.coverity.com/reports.htm#v43693/p13437/fileInstanceId=129122176&defectInstanceId=18601010&mergedDefectId=1526815).

Closes #7913

**say: check size before write**

We potentially pass negative size to safe_write in say_default if total
is negative. We can't hit this issue currently because formatting
functions currently do not return -1. Yet let's check total value where
appropriate.

By the way fix restoring errno in log_vsay. format_log_entry_full is
introduced for this purpuse as SNPRINT macro returns in case of error.

Also add assertion to safe_write.

This patch addresses coverity complain [1527154](https://scan7.scan.coverity.com/reports.htm#v43693/p13437/fileInstanceId=129123623&defectInstanceId=18608452&mergedDefectId=1527154).

Part of #7913