### PR TITLE
fiber: fix crashes when cord refers to invalid ctx

### DIFF
--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -804,6 +804,13 @@ void
 cord_create(struct cord *cord, const char *name);
 
 /**
+ * Should be called at main thread shutdown start to prevent cord from
+ * starting any new thread, since the context provided can be invalid.
+ */
+void
+cord_shutdown_is_started(void);
+
+/**
  * Perform all the thread-specific deinitialization. Must be called in the
  * exiting thread.
  */

--- a/src/main.cc
+++ b/src/main.cc
@@ -176,6 +176,7 @@ tarantool_exit(int code)
 		return;
 	}
 	is_shutting_down = true;
+	cord_shutdown_is_started();
 	exit_code = code;
 	box_broadcast_fmt("box.shutdown", "%b", true);
 	fiber_wakeup(on_shutdown_fiber);

--- a/test/replication/suite.ini
+++ b/test/replication/suite.ini
@@ -51,9 +51,6 @@ fragile = {
         "replicaset_ro_mostly.test.lua": {
             "issues": [ "gh-5342" ]
         },
-        "gh-3637-misc-error-on-replica-auth-fail.test.lua": {
-            "issues": [ "gh-5343" ]
-        },
         "on_replace.test.lua": {
             "issues": [ "gh-4997", "gh-5344", "gh-5349" ]
         },


### PR DESCRIPTION
Cord function can dereference the main thread context while main thread performing shutdown. Often it can happen when TERM signal arrives during snapshot, so that at_exit notification causes SEGV.

Closes #7743

NO_DOC=bug fix
NO_CHANGELOG=bugfix