### PR TITLE
luajit: bump submodule

### DIFF
--- a/changelogs/unreleased/gh-7919-sysprof-gc64.md
+++ b/changelogs/unreleased/gh-7919-sysprof-gc64.md
@@ -1,0 +1,3 @@
+## bugfix/sysprof
+
+* Enabled sysprof for GC64 mode.


### PR DESCRIPTION
GC64: enable sysprof support

Closes #7919
Related to #781

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump