### PR TITLE
test: fix flaky box-luatest/gh_7917_log_row_on_recovery_error_test

### DIFF
--- a/test/box-luatest/gh_7917_log_row_on_recovery_error_test.lua
+++ b/test/box-luatest/gh_7917_log_row_on_recovery_error_test.lua
@@ -6,7 +6,7 @@ local g = t.group(nil, {{type = 'xlog'}, {type = 'snap'}})
 
 g.before_each(function(cg)
     cg.server = server:new({
-        alias = 'master',
+        alias = 'gh_7917_' .. cg.params.type,
         datadir = fio.pathjoin('test/box-luatest/gh_7917_data',
                                cg.params.type),
     })


### PR DESCRIPTION
The test fails with:

```
master | 2022-11-11 09:03:32.093 [4128822] main/103/default.lua F> can't initialize storage: unlink, called on fd 30, aka unix/:(socket), peer of unix/:(socket): Address already in use
```

Looks like it happens, because both test cases share the socket path. The fix is the same as in commit 3f86cd045527 ("test: fix flaky 'test_ignore_with_force_recovery'") - use different socket paths.

Follow-up commit b2dab5f4270d ("memtx: log bad row on snapshot recovery error").