### PR TITLE
debugger: `tarantool -d` option, step.4

### DIFF
--- a/changelogs/unreleased/gh-7456-console-debugger-option.md
+++ b/changelogs/unreleased/gh-7456-console-debugger-option.md
@@ -1,0 +1,18 @@
+## feature/debugger
+
+* Introduced command-line option which runs debugger console
+  instead of standard interactive console (gh-7456).
+
+```sh
+$ tarantool -d debug-target.lua
+Tarantool debugger 2.11.0-entrypoint-852-g9e6ed28ae
+type 'help' for interactive help
+luadebug: Loaded for 2.11.0-entrypoint-852-g9e6ed28ae
+break via debug-target.lua => debug-target.lua:1 in chunk at debug-target.lua:0
+   1 => local date = require 'datetime'
+   4
+luadebug>
+```
+This is more convenient way to initiate debugger session, instead
+of an older, more invasive approach of instrumenting code with
+`require 'luadebug'()` call.

--- a/src/lua/init.h
+++ b/src/lua/init.h
@@ -45,6 +45,7 @@ extern struct lua_State *tarantool_L;
 
 #define O_INTERACTIVE 0x1
 #define O_BYTECODE    0x2
+#define O_DEBUGGING   0x4
 
 /**
  * Create tarantool_L and initialize built-in Lua modules.
@@ -66,9 +67,12 @@ tarantool_lua_free();
 /**
  * Load and execute start-up file
  *
- * @param interactive force interactive mode
- * @param argc argc the number of command line arguments
- * @param argv argv command line arguments
+ * @param path path to the script to be run
+ * @param opt_mask mask for forcing of an interactive or debugging mode
+ * @param optc the number of lua interpreter command line arguments
+ * @param optv separate list of arguments for lua interpreter
+ * @param argc argc the number of command line arguments, beyond those in optc
+ * @param argv argv command line arguments, beyond those in optv
  *
  * @retval 0 The script is successfully finished.
  * @retval -1 Error during the script execution. Diagnostics area

--- a/src/main.cc
+++ b/src/main.cc
@@ -627,6 +627,7 @@ print_help(const char *program)
 	puts("  -l NAME\t\t\trequire library 'NAME'");
 	puts("  -j cmd\t\t\tperform LuaJIT control command");
 	puts("  -b ...\t\t\tsave or list bytecode");
+	puts("  -d\t\t\t\tactivate debugging session for 'SCRIPT'");
 	puts("  -i\t\t\t\tenter interactive mode after executing 'SCRIPT'");
 	puts("  --\t\t\t\tstop handling options");
 	puts("  -\t\t\t\texecute stdin and stop handling options");
@@ -659,7 +660,7 @@ main(int argc, char **argv)
 		{"version", no_argument, 0, 'v'},
 		{NULL, 0, 0, 0},
 	};
-	static const char *opts = "+hVvb::ij:e:l:";
+	static const char *opts = "+hVvb::ij:e:l:d";
 
 	int ch;
 	bool lj_arg = false;
@@ -675,6 +676,9 @@ main(int argc, char **argv)
 		case 'i':
 			/* Force interactive mode */
 			opt_mask |= O_INTERACTIVE;
+			break;
+		case 'd':
+			opt_mask |= O_DEBUGGING;
 			break;
 		case 'b':
 			opt_mask |= O_BYTECODE;

--- a/test/app-luatest/console_debugger_session_test.lua
+++ b/test/app-luatest/console_debugger_session_test.lua
@@ -11,7 +11,7 @@ local function unescape(s)
 end
 
 local function trim(s)
-    return s:gsub('%s+$', '')
+    return s and s:gsub('%s+$', '') or ''
 end
 
 local function tarantool_path(arg)
@@ -23,10 +23,9 @@ end
 
 local TARANTOOL_PATH = tarantool_path(arg)
 local path_to_script = normalize_path(debug.getinfo(1, 'S').source)
-local debug_target_script = path_to_script .. 'debug-target.lua'
 
-local DEBUGGER = 'luadebug.lua'
-local dbg_header = DEBUGGER .. ": Loaded for " .. tnt.version
+local DEBUGGER = 'luadebug'
+local dbg_header = "Tarantool debugger " .. tnt.version
 local dbg_prompt = DEBUGGER .. '>'
 local dbg_failed_bp = 'command expects argument in format filename:NN or ' ..
                       'filename+NN, where NN should be a positive number.'
@@ -91,7 +90,7 @@ local sequences = {
 
     -- full, complex sequence
     ['full scenario'] = {
-        { ['\t'] = dbg_header }, -- \t is a special value for start
+        { ['\t'] = '' }, -- \t is a special value for start
         { ['n'] = dbg_prompt },
         { ['s'] = dbg_prompt },
         { ['n'] = dbg_prompt },
@@ -104,8 +103,11 @@ local sequences = {
         { ['bogus;'] = 'is not recognized.' },
         { ['h'] = dbg_prompt },
         { ['t'] = '=> builtin/datetime.lua' },
-        { ['u'] = 'debug-target.lua:5 in chunk at' },
-        { ['u'] = 'Already at the bottom of the stack.' },
+        { ['u'] = 'debug-target.lua:3 in chunk at' },
+        -- FIXME (gh-8190) - we should not show calling side at luadebug.lua
+        -- { ['u'] = 'Already at the bottom of the stack.' },
+        { ['u'] = 'Inspecting frame: builtin/luadebug.lua' },
+        { ['d'] = 'debug-target.lua:3 in chunk at' },
         { ['d'] = 'Inspecting frame: builtin/datetime.lua' },
         { ['l'] = 'obj => {"tzoffset" = "+0300", "hour" = 3}' },
         { ['f'] = dbg_prompt },
@@ -121,9 +123,9 @@ local sequences = {
 
     -- partial sequence with successful breakpoints added
     ['successful breakpoints additions'] = {
-        { ['\t'] = dbg_header }, -- \t is a special value for start
-        { ['b +11'] = dbg_prompt },
-        { ['c'] = 'debug-target.lua:11' },
+        { ['\t'] = '' }, -- \t is a special value for start
+        { ['b +10'] = dbg_prompt },
+        { ['c'] = 'debug-target.lua:10' },
         { ['n'] = dbg_prompt },
         { ['p S'] = 'S => "1970-01-01T0300+0300"' },
         { ['p T'] = 'T => 1970-01-01T03:00:00+0300' },
@@ -132,7 +134,7 @@ local sequences = {
 
     -- partial sequence with failed breakpoint additions
     ['failed breakpoints additions'] = {
-        { ['\t'] = dbg_header }, -- \t is a special value for start
+        { ['\t'] = '' }, -- \t is a special value for start
         { ['b'] = 'expects argument, but none received' },
         { ['b 11'] = dbg_failed_bp },
         { ['b debug-target.lua'] = dbg_failed_bp },
@@ -146,7 +148,7 @@ local sequences = {
 
     -- partial sequence with breakpoints additions and removals
     ['successful breakpoints removals'] = {
-        { ['\t'] = dbg_header }, -- \t is a special value for start
+        { ['\t'] = '' }, -- \t is a special value for start
         { ['b +7'] = 'debug-target.lua:7' },
         { ['bl'] = 'debug-target.lua:7' },
         { ['b :5'] = 'debug-target.lua:5' },
@@ -161,7 +163,7 @@ local sequences = {
     },
     -- partial sequence with failed breakpoints removals
     ['failed breakpoints removals'] = {
-        { ['\t'] = dbg_header }, -- \t is a special value for start
+        { ['\t'] = '' }, -- \t is a special value for start
         { ['bd'] = 'expects argument, but none received' },
         { ['bd 11'] = dbg_failed_bpd },
         { ['bd debug-target.lua'] = dbg_failed_bpd },
@@ -170,18 +172,20 @@ local sequences = {
     },
 }
 
-local function debug_session(sequence)
-    local cmd = { TARANTOOL_PATH, debug_target_script }
+local function run_debug_session(cmdline, sequence, header)
     --[[
         repeat multiple times to check all command aliases
     ]]
     for i = 1, MAX_ALIASES_COUNT do
-        local fh = popen.new(cmd, {
+        local fh = popen.new(cmdline, {
             stdout = popen.opts.PIPE,
             stderr = popen.opts.PIPE,
             stdin = popen.opts.PIPE,
         })
         t.assert_is_not(fh, nil)
+        -- for -d option we expect debugger banner in the stderr,
+        -- but for self invoke debugger there is no extra header.
+        local first = header ~= nil
         for _, row in pairs(sequence) do
             local cmd, expected = next(row)
             if cmd ~= '\t' then
@@ -199,10 +203,17 @@ local function debug_session(sequence)
             local clean_cmd = trim(cmd)
             -- there should be empty stderr - check it before stdout
             local errout = fh:read({ timeout = 0.05, stderr = true})
-            t.assert(errout == nil or trim(errout) == '', errout)
+            if first and errout then
+                -- we do not expect anything on stderr
+                -- with exception of initial debugger header
+                t.assert_str_contains(trim(errout), header, false)
+                first = false
+            else
+                t.assert(errout == nil or trim(errout) == '')
+            end
             repeat
                 result = trim(unescape(fh:read({ timeout = 0.5 })))
-            until result ~= '' and result ~= clean_cmd
+            until result ~= '' or result ~= clean_cmd
             if expected ~= '' then
                 t.assert_str_contains(result, expected, false)
             end
@@ -211,9 +222,38 @@ local function debug_session(sequence)
     end
 end
 
+-- `tarantool -d debug-target.lua`
 g.test_debugger = function(cg)
+    local debug_target_script = path_to_script .. 'debug-target.lua'
+    local cmd = { TARANTOOL_PATH, '-d', debug_target_script }
     local scenario_name = cg.params.sequence
     t.assert(scenario_name)
     t.assert(sequences[scenario_name])
-    debug_session(sequences[scenario_name])
+    run_debug_session(cmd, sequences[scenario_name], dbg_header)
+end
+
+local g_self = t.group('self-debug')
+
+local shorter_sequence = {
+    { ['\t'] = '' }, -- \t is a special value for start
+    { ['n'] = dbg_prompt },
+    { ['s'] = dbg_prompt },
+    { ['n'] = dbg_prompt },
+    { ['n'] = dbg_prompt },
+    { ['p'] = 'expects argument, but none received' },
+    { ['p obj'] = 'obj => {"tzoffset" = "+0300", "hour" = 3}' },
+    { ['u'] = 'debug-self-target.lua:5 in chunk at' },
+    { ['u'] = 'Already at the bottom of the stack.' },
+    { ['d'] = 'Inspecting frame: builtin/datetime.lua' },
+    { ['l'] = 'obj => {"tzoffset" = "+0300", "hour" = 3}' },
+    { ['f'] = 'debug-self-target.lua:6 in chunk at' },
+    { ['c'] = '' },
+}
+
+-- `tarantool debug-self-target.lua`, where
+-- initiate debugging session via `require 'luadebug'()`
+g_self.test_debug_self_invoke = function()
+    local debug_target_script = path_to_script .. 'debug-self-target.lua'
+    local cmd = { TARANTOOL_PATH, debug_target_script }
+    run_debug_session(cmd, shorter_sequence)
 end

--- a/test/app-luatest/debug-self-target.lua
+++ b/test/app-luatest/debug-self-target.lua
@@ -1,0 +1,8 @@
+local dbg = require 'luadebug'
+dbg()
+local date = require 'datetime'
+
+local T = date.new{hour = 3, tzoffset = '+0300'}
+print(T)
+
+os.exit(0)

--- a/test/app-luatest/debug-target.lua
+++ b/test/app-luatest/debug-target.lua
@@ -1,5 +1,3 @@
-local debugger = require 'luadebug'
-debugger()
 local date = require 'datetime'
 
 local T = date.new{hour = 3, tzoffset = '+0300'}

--- a/test/box-py/args.result
+++ b/test/box-py/args.result
@@ -11,6 +11,7 @@ When no script name is provided, the server responds to:
   -l NAME			require library 'NAME'
   -j cmd			perform LuaJIT control command
   -b ...			save or list bytecode
+  -d				activate debugging session for 'SCRIPT'
   -i				enter interactive mode after executing 'SCRIPT'
   --				stop handling options
   -				execute stdin and stop handling options
@@ -31,6 +32,7 @@ When no script name is provided, the server responds to:
   -l NAME			require library 'NAME'
   -j cmd			perform LuaJIT control command
   -b ...			save or list bytecode
+  -d				activate debugging session for 'SCRIPT'
   -i				enter interactive mode after executing 'SCRIPT'
   --				stop handling options
   -				execute stdin and stop handling options

--- a/third_party/lua/README-luadebug.md
+++ b/third_party/lua/README-luadebug.md
@@ -51,6 +51,29 @@ int main(int argc, char **argv){
 
 Now in your Lua code you can just use the global variable or `require` the module name you passed to the `dbg_setup()` call.
 
+Debugger activation
+-
+
+Debugger could be activated either from inside of debuggee code itself:
+
+```lua
+local dbg = require 'luadebug'
+dbg()
+```
+
+Or from command-line using option `-d`:
+
+```
+$ tarantool -d debug-target.lua
+Tarantool debugger 2.11.0-entrypoint-852-g9e6ed28ae
+type 'help' for interactive help
+luadebug: Loaded for 2.11.0-entrypoint-852-g9e6ed28ae
+break via debug-target.lua => debug-target.lua:1 in chunk at debug-target.lua:0
+   1 => local date = require 'datetime'
+   4
+luadebug>
+```
+
 Debugger Commands:
 -
 

--- a/third_party/lua/luadebug.lua
+++ b/third_party/lua/luadebug.lua
@@ -26,7 +26,7 @@
 
 local dbg
 
-local DEBUGGER = 'luadebug.lua'
+local DEBUGGER = 'luadebug'
 -- Use ANSI color codes in the prompt by default.
 local COLOR_GRAY = ""
 local COLOR_RED = ""
@@ -1155,6 +1155,18 @@ function dbg.call(f, ...)
 
         return err
     end, ...)
+end
+
+-- Start an interactive debugging console.
+function dbg.start(path, ...)
+    assert(path ~= nil and type(path) == 'string')
+    assert(fio.stat(path) ~= nil)
+
+    stack_inspect_offset = 0
+    stack_top = 0
+    local hook_step = hook_factory(math.huge)
+    debug.sethook(hook_step(path), "l")
+    dofile(path, ...);
 end
 
 -- Error message handler that can be used with lua_pcall().


### PR DESCRIPTION
Added `-d` option for convenient activation of a debugger shell:
- it calls `luadebug.lua::start` instead of  `console.lua::start` for interactive shell.

> **NB!** 84b54be is temporal, while there is no
> yet committed #7790 where behaviour of commands `cmd_up`/`cmd_down` have been
> properly fixed.

Part of #7456