### PR TITLE
coro: update `sp` before saving registers to a stack frame

### DIFF
--- a/changelogs/unreleased/gh-7523-sigsegv-on-m1-macs.md
+++ b/changelogs/unreleased/gh-7523-sigsegv-on-m1-macs.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a bug in fiber switching that could lead to a segmentation fault error
+  on M1/M2 Macs (gh-7523).

--- a/third_party/coro/coro.c
+++ b/third_party/coro/coro.c
@@ -289,7 +289,8 @@ trampoline (int sig)
        #elif __aarch64__
 
          #define NUM_SAVED 20
-         "\tsub x2, sp, #8 * 20\n"
+         "\tsub sp, sp, #8 * 20\n"
+         "\tmov x2, sp\n"
          "\tstp x19, x20, [x2, #16 * 0]\n"
          "\tstp x21, x22, [x2, #16 * 1]\n"
          "\tstp x23, x24, [x2, #16 * 2]\n"


### PR DESCRIPTION
Currently AArch64 version of `coro_transfer` stores `x19-x30` and `d8-d15` registers to the stack, but only after that it updates the stack pointer. If a `SIGALRM` signal is delivered during the execution of `coro_transfer`, the signal handler will use the stack starting from current `sp`, thus corrupting the saved registers.

Fix this by updating the stack pointer at the beginning of `coro_transfer`.
`x2` register is still required, because `str sp, [x0, #0]` is invalid in the A64 instruction set.

Closes #7484
Closes #7523