### PR TITLE
Triggers on recovery state

### DIFF
--- a/changelogs/unreleased/gh-3159-recovery-triggers.md
+++ b/changelogs/unreleased/gh-3159-recovery-triggers.md
@@ -1,0 +1,7 @@
+## feature/box
+
+* It is now possible to register triggers for various recovery stages: use
+  `box.ctl.on_recovery_state()` before initial `box.cfg()` call. The trigger
+  receives one parameter - a string resembling reached recovery stage. Possible
+  values are "snapshot_recovered", "wal_recovered", "indexes_built", "synced"
+  (gh-3159).

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -71,6 +71,11 @@ extern double on_shutdown_trigger_timeout;
 extern struct rlist box_on_shutdown_trigger_list;
 
 /**
+ * Triggers invoked during initial `box.cfg` call on various recovery stages.
+ */
+extern struct rlist box_on_recovery_state;
+
+/**
  * Timeout during which the transaction must complete,
  * otherwise it will be rolled back.
  */

--- a/src/box/lua/ctl.c
+++ b/src/box/lua/ctl.c
@@ -83,6 +83,19 @@ lbox_ctl_on_schema_init(struct lua_State *L)
 }
 
 static int
+lbox_push_recovery_state(struct lua_State *L, void *event)
+{
+	lua_pushstring(L, (const char *)event);
+	return 1;
+}
+
+static int
+lbox_ctl_on_recovery_state(struct lua_State *L)
+{
+	return lbox_trigger_reset(L, 2, &box_on_recovery_state,
+				  lbox_push_recovery_state, NULL);
+}
+static int
 lbox_ctl_on_election(struct lua_State *L)
 {
 	return lbox_trigger_reset(L, 2, &box_raft_on_broadcast, NULL, NULL);
@@ -139,6 +152,7 @@ static const struct luaL_Reg lbox_ctl_lib[] = {
 	{"wait_rw", lbox_ctl_wait_rw},
 	{"on_shutdown", lbox_ctl_on_shutdown},
 	{"on_schema_init", lbox_ctl_on_schema_init},
+	{"on_recovery_state", lbox_ctl_on_recovery_state},
 	{"on_election", lbox_ctl_on_election},
 	{"promote", lbox_ctl_promote},
 	/* An old alias. */

--- a/test/instances/default.lua
+++ b/test/instances/default.lua
@@ -38,6 +38,12 @@ end
 -- such bad tests hang and fail.
 box.ctl.set_on_shutdown_timeout(TIMEOUT_INFINITY)
 
+local exec_arg = os.getenv('TARANTOOL_RUN_BEFORE_CFG')
+if exec_arg then
+    local run_before_cfg = loadstring(exec_arg)
+    run_before_cfg()
+end
+
 box.cfg(box_cfg())
 box.schema.user.grant('guest', 'super', nil, nil, {if_not_exists = true})
 

--- a/test/luatest_helpers/server.lua
+++ b/test/luatest_helpers/server.lua
@@ -321,7 +321,8 @@ function Server:grep_log(what, bytes, opts)
                     line = table.concat(buf)
                     buf = nil
                 end
-                if string.match(line, "Starting instance") and not noreset then
+                if string.match(line, "Tarantool %d+.%d+.%d+-.*%d+-g.*") and
+                   not noreset then
                     found = nil -- server was restarted, reset search
                 else
                     found = string.match(line, what) or found

--- a/test/replication-luatest/recovery_triggers_test.lua
+++ b/test/replication-luatest/recovery_triggers_test.lua
@@ -1,0 +1,111 @@
+local t = require('luatest')
+local cluster = require('test.luatest_helpers.cluster')
+local server = require('test.luatest_helpers.server')
+
+local g = t.group('gh-5272')
+
+local run_before_cfg = [[
+    rawset(_G, 'test_states', {})
+    box.ctl.on_recovery_state(function(state)
+        table.insert(test_states, state)
+    end)
+]]
+
+g.before_all(function(cg)
+    cg.cluster = cluster:new({})
+    cg.server = cg.cluster:build_and_add_server({
+        alias = 'server',
+        env = {
+            ['TARANTOOL_RUN_BEFORE_CFG'] = run_before_cfg,
+        },
+    })
+    cg.replica = cg.cluster:build_and_add_server({
+        alias = 'replica',
+        box_cfg = {
+            replication = server.build_instance_uri('server'),
+        },
+        env = {
+            ['TARANTOOL_RUN_BEFORE_CFG'] = run_before_cfg,
+        },
+    })
+end)
+
+g.after_all(function(cg)
+    cg.cluster:drop()
+end)
+
+local function is_state_reached(server, state)
+    return server:exec(function(state)
+        for _, s in pairs(_G.test_states) do
+            if s == state then
+                return true
+            end
+        end
+        return false
+    end, {state})
+end
+
+local function wait_state(server, state)
+    t.helpers.retrying({}, function()
+        t.assert(is_state_reached(server, state),
+                 'State ' .. state .. ' triggers fired')
+    end)
+end
+
+local function assert_state_not_reached(server, state)
+    t.assert(not is_state_reached(server, state),
+             'State ' .. state .. ' not reached')
+end
+
+local function wait_all_states(server)
+    wait_state(server, 'snapshot_recovered')
+    -- wal_recovered and indexes_built can come in any order.
+    wait_state(server, 'wal_recovered')
+    wait_state(server, 'indexes_built')
+    wait_state(server, 'synced')
+end
+
+g.test_recovery_stages = function(cg)
+    -- Test stages on bootstrap.
+    cg.server:start()
+    wait_all_states(cg.server)
+    cg.server:stop()
+    -- Test same stages on recovery.
+    cg.server:start()
+    wait_all_states(cg.server)
+    -- Test the stages on replica join.
+    cg.replica:start()
+    wait_all_states(cg.replica)
+    cg.replica:stop()
+    -- Test sync state.
+    cg.replica.box_cfg = {
+        replication_sync_timeout = 0.01,
+        replication_connect_timeout = 0.1,
+        replication_timeout = 0.1,
+        replication = {
+            server.build_instance_uri('server'),
+            server.build_instance_uri('non-existent-uri'),
+        },
+    }
+    cg.replica:start()
+    wait_state(cg.replica, 'snapshot_recovered')
+    wait_state(cg.replica, 'wal_recovered')
+    wait_state(cg.replica, 'indexes_built')
+    assert_state_not_reached(cg.replica, 'synced')
+    cg.replica:exec(function()
+        box.cfg{
+            replication_connect_quorum = 1,
+        }
+    end)
+    wait_state(cg.replica, 'synced')
+    -- Check that triggers on 'synced' stage are executed only once.
+    cg.replica:exec(function()
+        local t = require('luatest')
+        local num_events = #_G.test_states
+        local old_repl = box.cfg.replication
+        box.cfg{replication = ''}
+        box.cfg{replication = old_repl}
+        t.assert_equals(#_G.test_states, num_events,
+                        "Triggers on sync aren't re-run")
+    end)
+end


### PR DESCRIPTION
Introduce triggers which are run during various stages of box.cfg{}.
See the docbot request below for more info.

Part-of #5272
Part-of #3159

@TarantoolBot document
Title: new triggers -- `box.ctl.on_recovery_state`

`box.ctl.on_recovery_state` is a handle to register triggers that will
be executed on different stages of recovery/initial configuration.
A trigger registered this way is run on each of the supported recovery
stages, and receives the stage name as a parameter. The possible stages
are:
 - "snapshot_recovered": the node has recovered the snapshot file. This
   is the fist state seen by triggers.
 - "wal_recovered": the node has recovered all the .xlog files.
 - "indexes_built": the node has built secondary indexes for memtx spaces.
   Depending on a number of box.cfg options, "indexes_built" might come
   before or after "wal_recovered".
 - "synced": the node has synced with enough remote peers and has left
   orphan state. This is the last state seen by the triggers.

All these stages are passed during initial `box.cfg` call when recovering
from .snap and .xlog files.

When bootstrapping a fresh cluster with no data, all the instances in it
will still execute triggers on the same stages for consistency.
For example, "snapshot_recovered" and "wal_recovered" will
be run once the node finishes cluster bootstrap or finishes joining to an
existing cluster.

Anyway, by the time the initial `box.cfg` call finishes, regardless of
recovery or bootstrap, the triggers will be called with parameters
"snapshot_recovery", "wal_recovered" and "indexes_built". The triggers
on "synced" state might execute later, when the node leaves the orphan
mode.

Note, that you must set `box.ctl.on_recovery_state` triggers before the
initial `box.cfg` call for them to take effect.
Example:

NO_WRAP
```
Tarantool 2.11.0
type 'help' for interactive help
tarantool> log = require('log')
---
...

tarantool> trigger_f = function(state) log.info('State "' .. state .. '" reached') end
---
...

tarantool> box.ctl.on_recovery_state(trigger_f)
---
- 'function: 0x0104662788'
...

tarantool> box.cfg{}
<stripped some messages>
2022-11-15 13:21:43.149 [98398] main/103/interactive I> recovering from `./00000000000000000004.snap'
2022-11-15 13:21:43.166 [98398] main/103/interactive I> cluster uuid 75c5c40e-c795-4c6f-b602-25fe5b1c9f3b
2022-11-15 13:21:43.187 [98398] main/103/interactive I> assigned id 1 to replica 1fbcb1d7-f600-4cc6-83b4-8d409d2937a9
2022-11-15 13:21:43.187 [98398] main/103/interactive I> update replication_synchro_quorum = 1
2022-11-15 13:21:43.187 [98398] main/103/interactive I> State "snapshot_recovered" reached
                                                               ^^^^^^^^^^^^^^^^^^
2022-11-15 13:21:43.187 [98398] main/103/interactive I> recover from `./00000000000000000004.xlog'
2022-11-15 13:21:43.188 [98398] main/103/interactive I> done `./00000000000000000004.xlog'
2022-11-15 13:21:43.188 [98398] main/103/interactive I> recover from `./00000000000000000006.xlog'
2022-11-15 13:21:43.188 [98398] main/103/interactive I> done `./00000000000000000006.xlog'
2022-11-15 13:21:43.188 [98398] main/103/interactive I> Building secondary indexes in space 'test'...
2022-11-15 13:21:43.188 [98398] main/103/interactive I> Adding 2 keys to TREE index 'sk' ...
2022-11-15 13:21:43.188 [98398] main/103/interactive I> Space 'test': done
2022-11-15 13:21:43.188 [98398] main/103/interactive I> State "indexes_built" reached
                                                               ^^^^^^^^^^^^^
2022-11-15 13:21:43.189 [98398] main/103/interactive I> State "wal_recovered" reached
                                                               ^^^^^^^^^^^^^
2022-11-15 13:21:43.189 [98398] main/103/interactive I> ready to accept requests
2022-11-15 13:21:43.189 [98398] main/103/interactive I> State "synced" reached
                                                               ^^^^^^
2022-11-15 13:21:43.189 [98398] main/103/interactive I> leaving orphan mode
<stripped some messages>
---
...

tarantool>

```
NO_WRAP                                                                                            