### PR TITLE
replication: fix local space writes failing when synchro queue isn't empty

### DIFF
--- a/changelogs/unreleased/gh-7592-write-to-local-spaces-with-synchro.md
+++ b/changelogs/unreleased/gh-7592-write-to-local-spaces-with-synchro.md
@@ -1,0 +1,5 @@
+## bugfix/replication
+
+* Fixed local space writes failing with error "Found uncommitted sync
+  transactions from other instance with id 1" when synchronous transaction queue
+  belongs to other instance and isn't empty (gh-7592).

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -848,6 +848,13 @@ txn_end_ro_stmt(struct txn *txn, struct txn_ro_savepoint *svp)
 bool
 txn_is_distributed(struct txn *txn);
 
+static inline bool
+txn_is_fully_local(const struct txn *txn)
+{
+	return txn->n_new_rows == txn->n_local_rows &&
+	       txn->n_applier_rows == 0;
+}
+
 /**
  * End a statement. In autocommit mode, end
  * the current transaction as well.

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -112,7 +112,7 @@ txn_limbo_append(struct txn_limbo *limbo, uint32_t id, struct txn *txn)
 	if  (limbo->owner_id == REPLICA_ID_NIL) {
 		diag_set(ClientError, ER_SYNC_QUEUE_UNCLAIMED);
 		return NULL;
-	} else if (limbo->owner_id != id) {
+	} else if (limbo->owner_id != id && !txn_is_fully_local(txn)) {
 		if (txn_limbo_is_empty(limbo)) {
 			diag_set(ClientError, ER_SYNC_QUEUE_FOREIGN,
 				 limbo->owner_id);

--- a/test/replication-luatest/gh_7592_local_write_with_syncro_test.lua
+++ b/test/replication-luatest/gh_7592_local_write_with_syncro_test.lua
@@ -1,0 +1,93 @@
+local t = require('luatest')
+local server = require('test.luatest_helpers.server')
+local cluster = require('test.luatest_helpers.cluster')
+local fiber = require('fiber')
+
+local g = t.group('gh-7592')
+
+g.before_each(function(cg)
+    cg.cluster = cluster:new{}
+    local box_cfg = {
+        replication_synchro_timeout = 1000,
+        replication_synchro_quorum = 3,
+        replication_timeout = 0.1,
+        election_mode = 'off',
+        replication = {
+            server.build_instance_uri('master'),
+            server.build_instance_uri('replica'),
+        },
+    }
+    cg.master = cg.cluster:build_and_add_server{
+        alias = 'master',
+        box_cfg = box_cfg,
+    }
+    cg.replica = cg.cluster:build_and_add_server{
+        alias = 'replica',
+        box_cfg = box_cfg,
+    }
+    cg.cluster:start()
+    cg.master:exec(function()
+        box.ctl.promote()
+        box.schema.space.create('sync', {is_sync = true})
+        box.space.sync:create_index('pk')
+        box.schema.space.create('loc', {is_local = true})
+        box.space.loc:create_index('pk')
+    end)
+    cg.replica:wait_vclock_of(cg.master)
+end)
+
+g.after_each(function(cg)
+    cg.cluster:drop()
+end)
+
+local function wait_synchro_queue_has_entries(server)
+    t.helpers.retrying({}, function()
+        local len = server:exec(function()
+            return box.info.synchro.queue.len
+        end)
+        t.assert(len > 0, 'Synchro queue is occupied')
+    end)
+end
+
+g.test_local_space_write_on_replica = function(cg)
+    -- Test that replica can write to local spaces when synchro queue is empty:
+    cg.replica:exec(function()
+        local t = require('luatest')
+        t.assert(box.info.synchro.queue.owner ~= 0, 'Queue is claimed')
+        t.assert(box.info.synchro.queue.owner ~= box.info.id,
+                 'Queue is foreign')
+        t.assert(box.info.synchro.queue.len == 0, 'Queue is empty')
+        local ok, _ = pcall(box.space.loc.insert, box.space.loc, {1})
+        t.assert(ok, 'Local space is writeable')
+    end)
+
+    -- Test that replica can write to local spaces when synchro queue is filled:
+    local f = fiber.new(function()
+        cg.master:exec(function()
+            box.space.sync:insert{1}
+        end)
+    end)
+    f:set_joinable(true)
+    wait_synchro_queue_has_entries(cg.replica)
+    local fid = cg.replica:exec(function()
+        local t = require('luatest')
+        t.assert(box.info.synchro.queue.len == 1, 'Queue is filled')
+        t.assert(box.info.synchro.queue.owner ~= box.info.id,
+                 'Queue is foreign')
+        local r_f = require('fiber').create(function()
+            box.space.loc:insert{2}
+        end)
+        r_f:set_joinable(true)
+        t.assert(box.info.synchro.queue.len == 2,
+                 'Local write is placed in the queue')
+        return r_f:id()
+    end)
+    cg.master:exec(function() box.cfg{replication_synchro_quorum = 2} end)
+    f:join()
+    cg.replica:exec(function(fid)
+        local t = require('luatest')
+        require('fiber').find(fid):join()
+        t.assert(box.info.synchro.queue.len == 0, 'Queue is emptied')
+        t.assert_equals(box.space.loc:get{2}, {2}, 'Data is written')
+    end, {fid})
+end


### PR DESCRIPTION
Local spaces can be written to on any replica, even on a read-only one.
This makes sense, because local space data isn't replicated, so it can't
lead to a conflict or violate consistency anyhow.

However, when used together with synchronous replication, local spaces
can't be written to by anyone but the synchro queue owner:
```
tarantool> box.info.synchro.queue.len
---
- 1
...
tarantool> box.space.loc:replace{2}
---
- error: Found uncommitted sync transactions from other instance with id 1
...
```
Fix this and allow to put transactions touching local spaces to the
synchro queue even if it is claimed by someone else.

Note, we can't let local transactions bypass the synchro queue completely.
This would lead to consistency loss in a case when synchro queue
contains a transaction [sync_row, local_row], and another transcation
[local_row], probably based on the sync transaction, bypasses the limbo.

Closes #7592

NO_DOC=bugfix