### PR TITLE
Make `ER_WRONG_INDEX_PARTS` and `ER_WRONG_SPACE_FORMAT` messages more verbose

### DIFF
--- a/changelogs/unreleased/gh-7933-verbose-wrong-index-part-error.md
+++ b/changelogs/unreleased/gh-7933-verbose-wrong-index-part-error.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Made errors thrown on specifying invalid index parts or format fields more
+  verbose. Now, they include the bad index part or field number (gh-7933).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -213,9 +213,11 @@ index_opts_decode(struct index_opts *opts, const char *map,
 		  struct region *region)
 {
 	index_opts_create(opts);
-	if (opts_decode(opts, index_opts_reg, &map, ER_WRONG_INDEX_OPTIONS,
-			region) != 0)
+	if (opts_decode(opts, index_opts_reg, &map, region) != 0) {
+		diag_set(ClientError, ER_WRONG_INDEX_OPTIONS,
+			 diag_last_error(diag_get())->errmsg);
 		return -1;
+	}
 	if (opts->distance == rtree_index_distance_type_MAX) {
 		diag_set(ClientError, ER_WRONG_INDEX_OPTIONS,
 			 "distance must be either 'euclid' or 'manhattan'");
@@ -389,8 +391,12 @@ space_opts_decode(struct space_opts *opts, const char *map,
 		  struct region *region)
 {
 	space_opts_create(opts);
-	return opts_decode(opts, space_opts_reg, &map, ER_WRONG_SPACE_OPTIONS,
-			   region);
+	if (opts_decode(opts, space_opts_reg, &map, region) != 0) {
+		diag_set(ClientError, ER_WRONG_SPACE_OPTIONS,
+			 diag_last_error(diag_get())->errmsg);
+		return -1;
+	}
+	return 0;
 }
 
 /**
@@ -3340,9 +3346,11 @@ func_def_new_from_tuple(struct tuple *tuple)
 		}
 		def->param_count = argc;
 		const char *opts = tuple_field(tuple, BOX_FUNC_FIELD_OPTS);
-		if (opts_decode(&def->opts, func_opts_reg, &opts,
-				ER_WRONG_SPACE_OPTIONS, NULL) != 0)
+		if (opts_decode(&def->opts, func_opts_reg, &opts, NULL) != 0) {
+			diag_set(ClientError, ER_WRONG_SPACE_OPTIONS,
+				 diag_last_error(diag_get())->errmsg);
 			return NULL;
+		}
 	} else {
 		/* By default export to Lua, but not other frontends. */
 		def->exports.lua = true;
@@ -3550,9 +3558,11 @@ coll_id_def_new_from_tuple(struct tuple *tuple, struct coll_id_def *def)
 					BOX_COLLATION_FIELD_OPTIONS, MP_MAP);
 	if (options == NULL)
 		return -1;
-	if (opts_decode(&base->icu, coll_icu_opts_reg, &options,
-			ER_WRONG_COLLATION_OPTIONS, NULL) != 0)
+	if (opts_decode(&base->icu, coll_icu_opts_reg, &options, NULL) != 0) {
+		diag_set(ClientError, ER_WRONG_COLLATION_OPTIONS,
+			 diag_last_error(diag_get())->errmsg);
 		return -1;
+	}
 
 	if (base->icu.french_collation == coll_icu_on_off_MAX) {
 		diag_set(ClientError, ER_CANT_CREATE_COLLATION,

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -159,7 +159,7 @@ struct errcode_record {
 	/*104 */_(ER_PROTOCOL,			"%s") \
 	/*105 */_(ER_UPSERT_UNIQUE_SECONDARY_KEY, "Space %s has a unique secondary index and does not support UPSERT") \
 	/*106 */_(ER_WRONG_INDEX_RECORD,	"Wrong record in _index space: got {%s}, expected {%s}") \
-	/*107 */_(ER_WRONG_INDEX_PARTS,		"Wrong index parts: %s") \
+	/*107 */_(ER_WRONG_INDEX_PARTS,		"Wrong index part %u: %s") \
 	/*108 */_(ER_WRONG_INDEX_OPTIONS,	"Wrong index options: %s") \
 	/*109 */_(ER_WRONG_SCHEMA_VERSION,	"Wrong schema version, current: %d, in request: %llu") \
 	/*110 */_(ER_MEMTX_MAX_TUPLE_SIZE,	"Failed to allocate %u bytes for tuple: tuple is too large. Check 'memtx_max_tuple_size' configuration option.") \

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -193,7 +193,7 @@ struct errcode_record {
 	/*138 */_(ER_LOAD_MODULE,		"Failed to dynamically load module '%.*s': %s") \
 	/*139 */_(ER_VINYL_MAX_TUPLE_SIZE,	"Failed to allocate %u bytes for tuple: tuple is too large. Check 'vinyl_max_tuple_size' configuration option.") \
 	/*140 */_(ER_WRONG_DD_VERSION,		"Wrong _schema version: expected 'major.minor[.patch]'") \
-	/*141 */_(ER_WRONG_SPACE_FORMAT,	"Wrong space format: %s") \
+	/*141 */_(ER_WRONG_SPACE_FORMAT,	"Wrong space format field %u: %s") \
 	/*142 */_(ER_CREATE_SEQUENCE,		"Failed to create sequence '%s': %s") \
 	/*143 */_(ER_ALTER_SEQUENCE,		"Can't modify sequence '%s': %s") \
 	/*144 */_(ER_DROP_SEQUENCE,		"Can't drop sequence '%s': %s") \

--- a/src/box/key_def.c
+++ b/src/box/key_def.c
@@ -936,9 +936,11 @@ key_def_decode_parts(struct key_part_def *parts, uint32_t part_count,
 			uint32_t key_len;
 			const char *key = mp_decode_str(data, &key_len);
 			if (opts_parse_key(part, part_def_reg, key, key_len,
-					   data, ER_WRONG_INDEX_PARTS,
-					   region, false) != 0)
+					   data, region, false) != 0) {
+				diag_set(ClientError, ER_WRONG_INDEX_PARTS,
+					 diag_last_error(diag_get())->errmsg);
 				return -1;
+			}
 			if (is_action_missing &&
 			    key_len == action_literal_len &&
 			    memcmp(key, "nullable_action",

--- a/src/box/opt_def.c
+++ b/src/box/opt_def.c
@@ -98,12 +98,7 @@ opt_set(void *opts, const struct opt_def *def, const char **val,
 			goto type_mismatch_err;
 		str = mp_decode_str(val, &str_len);
 		if (str_len > 0) {
-			ptr = (char *) region_alloc(region, str_len + 1);
-			if (ptr == NULL) {
-				diag_set(OutOfMemory, str_len + 1, "region",
-					 "opt string");
-				return -1;
-			}
+			ptr = xregion_alloc(region, str_len + 1);
 			memcpy(ptr, str, str_len);
 			ptr[str_len] = '\0';
 			assert (strlen(ptr) == str_len);

--- a/src/box/space_def.c
+++ b/src/box/space_def.c
@@ -57,7 +57,7 @@ const struct space_opts space_opts_default = {
  */
 static int
 space_opts_parse_constraint(const char **data, void *vopts,
-			    struct region *region, uint32_t errcode);
+			    struct region *region);
 
 /**
  * Callback to parse a value with 'foreign_key' key in msgpack space opts
@@ -65,7 +65,7 @@ space_opts_parse_constraint(const char **data, void *vopts,
  */
 static int
 space_opts_parse_foreign_key(const char **data, void *vopts,
-			     struct region *region, uint32_t errcode);
+			     struct region *region);
 
 /**
  * Callback to parse a value with 'upgrade' key in msgpack space opts
@@ -73,7 +73,7 @@ space_opts_parse_foreign_key(const char **data, void *vopts,
  */
 static int
 space_opts_parse_upgrade(const char **data, void *vopts,
-			 struct region *region, uint32_t errcode);
+			 struct region *region);
 
 const struct opt_def space_opts_reg[] = {
 	OPT_DEF("group_id", OPT_UINT32, struct space_opts, group_id),
@@ -202,17 +202,16 @@ space_def_delete(struct space_def *def)
  * By convention @a opts must point to corresponding struct space_opts.
  * Allocate a temporary constraint array on @a region and set pointer to it
  *  as field_def->constraint, also setting field_def->constraint_count.
- * Return 0 on success or -1 on error (diag is set to @a errcode).
+ * Return 0 on success or -1 on error (diag is set to IllegalParams).
  */
 int
 space_opts_parse_constraint(const char **data, void *vopts,
-			    struct region *region, uint32_t errcode)
+			    struct region *region)
 {
 	/* Expected normal form of constraints: {name1=func1, name2=func2..}. */
 	struct space_opts *opts = (struct space_opts *)vopts;
 	return tuple_constraint_def_decode(data, &opts->constraint_def,
-					   &opts->constraint_count, region,
-					   errcode);
+					   &opts->constraint_count, region);
 }
 
 /**
@@ -222,24 +221,23 @@ space_opts_parse_constraint(const char **data, void *vopts,
  * By convention @a opts must point to corresponding struct space_opts.
  * Allocate a temporary constraint array on @a region and set pointer to it
  *  as field_def->constraint, also setting field_def->constraint_count.
- * Return 0 on success or -1 on error (diag is set to @a errcode).
+ * Return 0 on success or -1 on error (diag is set to IllegalParams).
  */
 int
 space_opts_parse_foreign_key(const char **data, void *vopts,
-			     struct region *region, uint32_t errcode)
+			     struct region *region)
 {
 	/* Expected normal form of constraints: {name1={space=.., field=..}.. */
 	struct space_opts *opts = (struct space_opts *)vopts;
 	return tuple_constraint_def_decode_fkey(data, &opts->constraint_def,
 						&opts->constraint_count,
-						region, errcode, true);
+						region, true);
 }
 
 static int
 space_opts_parse_upgrade(const char **data, void *vopts,
-			 struct region *region, uint32_t errcode)
+			 struct region *region)
 {
-	(void)errcode;
 	struct space_opts *opts = (struct space_opts *)vopts;
 	opts->upgrade_def = space_upgrade_def_decode(data, region);
 	return opts->upgrade_def == NULL ? -1 : 0;

--- a/src/box/space_upgrade.h
+++ b/src/box/space_upgrade.h
@@ -42,24 +42,15 @@ space_upgrade_def_decode(const char **data, struct region *region);
  * The copy is allocated on malloc. It's okay to pass NULL to this
  * function, in which case it returns NULL. The function never fails.
  */
-static inline struct space_upgrade_def *
-space_upgrade_def_dup(const struct space_upgrade_def *def)
-{
-	assert(def == NULL);
-	(void)def;
-	return NULL;
-}
+struct space_upgrade_def *
+space_upgrade_def_dup(const struct space_upgrade_def *def);
 
 /**
  * Frees memory occupied by a space_upgrade_def object.
  * It's okay to pass NULL to this function.
  */
-static inline void
-space_upgrade_def_delete(struct space_upgrade_def *def)
-{
-	assert(def == NULL);
-	(void)def;
-}
+void
+space_upgrade_def_delete(struct space_upgrade_def *def);
 
 /**
  * Creates a space upgrade state from a definition, space name, primary key

--- a/src/box/tuple_constraint_def.c
+++ b/src/box/tuple_constraint_def.c
@@ -126,8 +126,11 @@ tuple_constraint_def_decode(const char **data,
 				 "constraint name is too long");
 			return -1;
 		}
-		if (identifier_check(str, str_len) != 0)
+		if (identifier_check(str, str_len) != 0) {
+			diag_set(ClientError, errcode,
+				 "constraint name isn't a valid identifier");
 			return -1;
+		}
 		char *str_copy = xregion_alloc(region, str_len + 1);
 		memcpy(str_copy, str, str_len);
 		str_copy[str_len] = 0;
@@ -268,8 +271,11 @@ tuple_constraint_def_decode_fkey(const char **data,
 				 "foreign key name is too long");
 			return -1;
 		}
-		if (identifier_check(str, str_len) != 0)
+		if (identifier_check(str, str_len) != 0) {
+			diag_set(ClientError, errcode,
+				 "foreign key name isn't a valid identifier");
 			return -1;
+		}
 		char *str_copy = xregion_alloc(region, str_len + 1);
 		memcpy(str_copy, str, str_len);
 		str_copy[str_len] = 0;

--- a/src/box/tuple_constraint_def.c
+++ b/src/box/tuple_constraint_def.c
@@ -104,12 +104,8 @@ tuple_constraint_def_decode(const char **data,
 		return 0;
 
 	size_t bytes;
-	*def = region_alloc_array(region, struct tuple_constraint_def,
-				  *count, &bytes);
-	if (*def == NULL) {
-		diag_set(OutOfMemory, bytes, "region", "array of constraints");
-		return -1;
-	}
+	*def = xregion_alloc_array(region, struct tuple_constraint_def,
+				   *count, &bytes);
 	for (uint32_t i = 0; i < old_count; i++)
 		(*def)[i] = old_def[i];
 	struct tuple_constraint_def *new_def = *def + old_count;
@@ -132,13 +128,7 @@ tuple_constraint_def_decode(const char **data,
 		}
 		if (identifier_check(str, str_len) != 0)
 			return -1;
-		char *str_copy = region_alloc(region, str_len + 1);
-		if (str_copy == NULL) {
-			diag_set(OutOfMemory, str_len + 1, "region",
-				 i % 2 == 0 ? "constraint name"
-					    : "constraint func");
-			return -1;
-		}
+		char *str_copy = xregion_alloc(region, str_len + 1);
 		memcpy(str_copy, str, str_len);
 		str_copy[str_len] = 0;
 		new_def[i].name = str_copy;
@@ -185,12 +175,7 @@ field_id_decode(const char **data, struct tuple_constraint_field_id *def,
 		def->name_len = 0;
 	} else if (mp_typeof(**data) == MP_STR) {
 		const char *str = mp_decode_str(data, &def->name_len);
-		char *str_copy = region_alloc(region, def->name_len + 1);
-		if (str_copy == NULL) {
-			diag_set(OutOfMemory, def->name_len + 1,
-				 "region", "string");
-			return -1;
-		}
+		char *str_copy = xregion_alloc(region, def->name_len + 1);
 		memcpy(str_copy, str, def->name_len);
 		str_copy[def->name_len] = 0;
 		def->name = str_copy;
@@ -226,14 +211,9 @@ field_mapping_decode(const char **data,
 	}
 	fkey->field_mapping_size = mapping_size;
 	size_t sz;
-	fkey->field_mapping =
-		region_alloc_array(region,
-				   struct tuple_constraint_fkey_field_mapping,
-				   mapping_size, &sz);
-	if (fkey->field_mapping == NULL) {
-		diag_set(OutOfMemory, sz, "region", "field mapping");
-		return -1;
-	}
+	fkey->field_mapping = xregion_alloc_array(
+		region, struct tuple_constraint_fkey_field_mapping,
+		mapping_size, &sz);
 	for (uint32_t i = 0 ; i < 2 * mapping_size; i++) {
 		struct tuple_constraint_field_id *def = i % 2 == 0 ?
 			&fkey->field_mapping[i / 2].local_field :
@@ -269,12 +249,8 @@ tuple_constraint_def_decode_fkey(const char **data,
 		return 0;
 
 	size_t bytes;
-	*def = region_alloc_array(region, struct tuple_constraint_def,
-				  *count, &bytes);
-	if (*def == NULL) {
-		diag_set(OutOfMemory, bytes, "region", "array of constraints");
-		return -1;
-	}
+	*def = xregion_alloc_array(region, struct tuple_constraint_def,
+				   *count, &bytes);
 	for (uint32_t i = 0; i < old_count; i++)
 		(*def)[i] = old_def[i];
 	struct tuple_constraint_def *new_def = *def + old_count;
@@ -294,12 +270,7 @@ tuple_constraint_def_decode_fkey(const char **data,
 		}
 		if (identifier_check(str, str_len) != 0)
 			return -1;
-		char *str_copy = region_alloc(region, str_len + 1);
-		if (str_copy == NULL) {
-			diag_set(OutOfMemory, bytes, "region",
-				 "constraint name");
-			return -1;
-		}
+		char *str_copy = xregion_alloc(region, str_len + 1);
 		memcpy(str_copy, str, str_len);
 		str_copy[str_len] = 0;
 		new_def[i].name = str_copy;

--- a/src/box/tuple_constraint_def.h
+++ b/src/box/tuple_constraint_def.h
@@ -115,8 +115,7 @@ tuple_constraint_def_cmp(const struct tuple_constraint_def *def1,
  *
  * Return:
  *   0 - success.
- *  -1 - failure, diag is set. It can be an OutOfMemory or ClientError with
- *   given @a errcode.
+ *  -1 - failure, diag is set (ClientError with given @a errcode).
  */
 int
 tuple_constraint_def_decode(const char **data,
@@ -138,8 +137,7 @@ tuple_constraint_def_decode(const char **data,
  *
  * Return:
  *   0 - success.
- *  -1 - failure, diag is set. It can be an OutOfMemory or ClientError with
- *   given @a errcode.
+ *  -1 - failure, diag is set (ClientError with given @a errcode).
  */
 int
 tuple_constraint_def_decode_fkey(const char **data,

--- a/src/box/tuple_constraint_def.h
+++ b/src/box/tuple_constraint_def.h
@@ -115,12 +115,12 @@ tuple_constraint_def_cmp(const struct tuple_constraint_def *def1,
  *
  * Return:
  *   0 - success.
- *  -1 - failure, diag is set (ClientError with given @a errcode).
+ *  -1 - failure, diag is set (IllegalParams).
  */
 int
 tuple_constraint_def_decode(const char **data,
 			    struct tuple_constraint_def **def, uint32_t *count,
-			    struct region *region, uint32_t errcode);
+			    struct region *region);
 
 /**
  * Parse constraint array from msgpack @a *data with the following format:
@@ -137,13 +137,13 @@ tuple_constraint_def_decode(const char **data,
  *
  * Return:
  *   0 - success.
- *  -1 - failure, diag is set (ClientError with given @a errcode).
+ *  -1 - failure, diag is set (IllegalParams).
  */
 int
 tuple_constraint_def_decode_fkey(const char **data,
 				 struct tuple_constraint_def **def,
 				 uint32_t *count, struct region *region,
-				 uint32_t errcode, bool is_complex);
+				 bool is_complex);
 
 /**
  * Allocate a single memory block needed for given @a count of constraint

--- a/src/trivia/util.h
+++ b/src/trivia/util.h
@@ -130,6 +130,9 @@ strnindex(const char *const *haystack, const char *needle, uint32_t len,
 #define xregion_alloc(p, size)	xalloc_impl((size), region_alloc, (p), (size))
 #define xregion_alloc_object(region, T, size) \
 		xalloc_impl(size, region_alloc_object, region, T, size)
+#define xregion_alloc_array(p, T, count, size)				\
+	xalloc_impl(sizeof(T) * (count), region_alloc_array, (p), T,	\
+		    (count), (size))
 
 /** \cond public */
 

--- a/test/box-luatest/alter_with_compression_test.lua
+++ b/test/box-luatest/alter_with_compression_test.lua
@@ -23,7 +23,7 @@ g.test_invalid_compression_type_during_space_creation = function(cg)
             name = 'x', type = 'unsigned', compression = compression
         }}
         t.assert_error_msg_content_equals(
-            "Wrong space format: field 1 has unknown compression type",
+            "Wrong space format field 1: unknown compression type",
             box.schema.space.create, 'T', {engine = engine, format = format})
     end, {cg.params.engine, cg.params.compression})
 end
@@ -42,10 +42,10 @@ g.test_invalid_compression_type_during_setting_format = function(cg)
             name = 'x', type = 'unsigned', compression = compression
         }}
         t.assert_error_msg_content_equals(
-            "Wrong space format: field 1 has unknown compression type",
+            "Wrong space format field 1: unknown compression type",
             box.space.space.format, box.space.space, format)
         t.assert_error_msg_content_equals(
-            "Wrong space format: field 1 has unknown compression type",
+            "Wrong space format field 1: unknown compression type",
             box.space.space.alter, box.space.space, {format = format})
     end, {cg.params.compression})
 end

--- a/test/box-luatest/gh_5940_partial_field_type_test.lua
+++ b/test/box-luatest/gh_5940_partial_field_type_test.lua
@@ -15,7 +15,7 @@ g.test_ddl_ops = function()
     g.server:exec(function()
         local t = require('luatest')
         local field_types = { '', 'n', 'nu', 's', 'st' }
-        local error_msg = 'Wrong space format: field 1 has unknown field type'
+        local error_msg = 'Wrong space format field 1: unknown field type'
 
         for _, type in pairs(field_types) do
             t.assert_error_msg_content_equals(error_msg, function()

--- a/test/box-tap/key_def.test.lua
+++ b/test/box-tap/key_def.test.lua
@@ -17,7 +17,7 @@ local usage_error = 'Bad params, use: key_def.new({' ..
 
 local function coll_not_found(collation)
     if type(collation) == 'number' then
-        return 'Wrong index parts: collation was not found by ID'
+        return 'Wrong index part 1: collation not found by id'
     end
 
     return ('Unknown collation: "%s"'):format(collation)

--- a/test/box/alter.result
+++ b/test/box/alter.result
@@ -1068,7 +1068,7 @@ format[2] = {name = 'field2', 'unsigned', 'unknown'}
 ...
 s:format(format)
 ---
-- error: 'Wrong space format: field 2 format is not map with string keys'
+- error: 'Wrong space format field 2: expected a map with string keys'
 ...
 s:format()
 ---

--- a/test/box/alter_limits.result
+++ b/test/box/alter_limits.result
@@ -429,7 +429,7 @@ index = s:create_index('test', { type = 'hash', parts = {}})
 -- unknown field type
 index = s:create_index('test', { type = 'hash', parts = { 2, 'nosuchtype' }})
 ---
-- error: 'Wrong index parts: unknown field type'
+- error: 'Wrong index part 1: unknown field type'
 ...
 index = s:create_index('test', { type = 'hash', parts = { 2, 'any' }})
 ---
@@ -448,7 +448,7 @@ index = s:create_index('test', { type = 'hash', parts = { 2, 'map' }})
 ...
 index = s:create_index('test', { type = 'rtree', parts = { 2, 'nosuchtype' }})
 ---
-- error: 'Wrong index parts: unknown field type'
+- error: 'Wrong index part 1: unknown field type'
 ...
 index = s:create_index('test', { type = 'rtree', parts = { 2, 'any' }})
 ---

--- a/test/box/ddl_collation_types.result
+++ b/test/box/ddl_collation_types.result
@@ -8,14 +8,14 @@ format[1] = {'field1', 'unsigned', collation = 'unicode'}
  | ...
 s = box.schema.create_space('test', {format = format})
  | ---
- | - error: 'Wrong space format: collation is reasonable only for string, scalar and
- |     any fields'
+ | - error: 'Wrong space format field 1: collation is reasonable only for ''string'',
+ |     ''scalar'', and ''any'' fields'
  | ...
 format[1] = {'field2', 'array', collation = 'unicode_ci'}
  | ---
  | ...
 s = box.schema.create_space('test', {format = format})
  | ---
- | - error: 'Wrong space format: collation is reasonable only for string, scalar and
- |     any fields'
+ | - error: 'Wrong space format field 1: collation is reasonable only for ''string'',
+ |     ''scalar'', and ''any'' fields'
  | ...

--- a/test/box/misc.result
+++ b/test/box/misc.result
@@ -901,19 +901,23 @@ s = box.schema.space.create('test')
 ...
 not not s:create_index('test1', {parts = {{1, 'number', collation = 'unicode_ci'}}})
 ---
-- error: 'Wrong index parts: collation is reasonable only for string and scalar parts'
+- error: 'Wrong index part 1: collation is only reasonable for ''string'' and ''scalar''
+    parts'
 ...
 not not s:create_index('test2', {parts = {{2, 'unsigned', collation = 'unicode_ci'}}})
 ---
-- error: 'Wrong index parts: collation is reasonable only for string and scalar parts'
+- error: 'Wrong index part 1: collation is only reasonable for ''string'' and ''scalar''
+    parts'
 ...
 not not s:create_index('test3', {parts = {{3, 'integer', collation = 'unicode_ci'}}})
 ---
-- error: 'Wrong index parts: collation is reasonable only for string and scalar parts'
+- error: 'Wrong index part 1: collation is only reasonable for ''string'' and ''scalar''
+    parts'
 ...
 not not s:create_index('test4', {parts = {{4, 'boolean', collation = 'unicode_ci'}}})
 ---
-- error: 'Wrong index parts: collation is reasonable only for string and scalar parts'
+- error: 'Wrong index part 1: collation is only reasonable for ''string'' and ''scalar''
+    parts'
 ...
 s:drop()
 ---
@@ -1089,11 +1093,11 @@ s = box.schema.space.create('test')
 ...
 i = s:create_index('test1', {parts = {1, 'unsigned', unique=false}})
 ---
-- error: 'Wrong index parts: unexpected option ''unique'''
+- error: 'Wrong index part 1: unexpected option ''unique'''
 ...
 i = s:create_index('test1', {parts = {1, 'unsigned', distance=3}})
 ---
-- error: 'Wrong index parts: unexpected option ''distance'''
+- error: 'Wrong index part 1: unexpected option ''distance'''
 ...
 i = s:create_index('test1', {parts = {2, 'string', 3, 'string', unique=false}})
 ---
@@ -1107,11 +1111,11 @@ i = s:create_index('test1', {parts = {2, 'string', 3, 'string', distance=3}})
 ...
 i = s:create_index('test1', {parts = {{1,'int', distance=3}, {field=2, type='int'}}})
 ---
-- error: 'Wrong index parts: unexpected option ''distance'''
+- error: 'Wrong index part 1: unexpected option ''distance'''
 ...
 i = s:create_index('test1', {parts = {{1,'int'}, {field=2, type='int', type='hash'}}})
 ---
-- error: 'Wrong index parts: unknown field type'
+- error: 'Wrong index part 2: unknown field type'
 ...
 i = s:create_index('test1', {parts = {{1,'int'}, {2, field=2, type='int'}}})
 ---
@@ -1144,7 +1148,7 @@ i = s:create_index('test1', {parts = {{'asd', 2, type='unsigned'}}})
 ...
 i = s:create_index('test1', {parts = {{1, 'int'}, {2, type='asd'}}})
 ---
-- error: 'Wrong index parts: unknown field type'
+- error: 'Wrong index part 2: unknown field type'
 ...
 s:drop()
 ---

--- a/test/box/rtree_misc.result
+++ b/test/box/rtree_misc.result
@@ -588,11 +588,11 @@ box.space._index:insert{s.id, 2, 's', 'rtree', {unique = false}, {{2, 'unsigned'
 ...
 box.space._index:insert{s.id, 2, 's', 'rtree', {unique = false}, {{2, 'time'}}}
 ---
-- error: 'Wrong index parts: unknown field type'
+- error: 'Wrong index part 1: unknown field type'
 ...
 box.space._index:insert{s.id, 2, 's', 'rtree', {unique = false}, {{'no','time'}}}
 ---
-- error: 'Wrong index parts: field id must be an integer'
+- error: 'Wrong index part 1: field id must be an integer'
 ...
 box.space._index:insert{s.id, 2, 's', 'rtree', {unique = false, distance = 'lobachevsky'}, {{2, 'array'}}}
 ---
@@ -604,7 +604,7 @@ box.space._index:insert{s.id, 2, 's', 'rtee', {unique = false}, {{2, 'array'}}}
 ...
 box.space._index:insert{s.id, 2, 's', 'rtree', {unique = false}, {{}}}
 ---
-- error: 'Wrong index parts: expected a non-empty array'
+- error: 'Wrong index part 1: expected a non-empty array'
 ...
 -- unknown args checked
 f(box.space._index:insert{s.id, 2, 's', 'rtree', {unique = false, holy = 'cow'}, {{2, 'array'}}})
@@ -614,7 +614,7 @@ f(box.space._index:insert{s.id, 2, 's', 'rtree', {unique = false, holy = 'cow'},
 -- unknown part args are no more ignored (#2649)
 f(box.space._index:insert{s.id, 2, 's', 'rtree', {unique = false}, {{field=2, type='array', part = 'opts'}}})
 ---
-- error: 'Wrong index parts: unexpected option ''part'''
+- error: 'Wrong index part 1: unexpected option ''part'''
 ...
 -- alter
 i = s:create_index('s', {type = 'rtree', parts = {2, 'array'}})

--- a/test/engine-luatest/gh_6436_complex_foreign_key_test.lua
+++ b/test/engine-luatest/gh_6436_complex_foreign_key_test.lua
@@ -70,7 +70,7 @@ g.test_bad_complex_foreign_key = function(cg)
         )
         opts = space_opts({['']={space='country',field={p_id='planet_id', c_id='country_id'}}})
         t.assert_error_msg_content_equals(
-            "Invalid identifier '' (expected printable symbols only or it is too long)",
+            "Wrong space options: foreign key name isn't a valid identifier",
             function() box.schema.create_space('city', opts) end
         )
         opts = space_opts({cntr={space='country',field={p_id='planet_id', c_id='country_id'}}})

--- a/test/engine-luatest/gh_6436_field_constraint_test.lua
+++ b/test/engine-luatest/gh_6436_field_constraint_test.lua
@@ -269,14 +269,14 @@ g.test_wrong_field_constraint = function(cg)
             end)
 
         t.assert_error_msg_content_equals(
-            "Wrong space format: constraint name is too long",
+            "Wrong space format field 1: constraint name is too long",
             function()
                 box.space.test:format({{"id1", constraint = {[string.rep('a', 66666)] = "field_constr1"}},
                                        {"id2"}})
             end)
 
         t.assert_error_msg_content_equals(
-            "Wrong space format: constraint name isn't a valid identifier",
+            "Wrong space format field 1: constraint name isn't a valid identifier",
             function()
                 box.space.test:format({{"id1", constraint = {[''] = "field_constr1"}}, {"id2"}})
             end)

--- a/test/engine-luatest/gh_6436_field_constraint_test.lua
+++ b/test/engine-luatest/gh_6436_field_constraint_test.lua
@@ -276,7 +276,7 @@ g.test_wrong_field_constraint = function(cg)
             end)
 
         t.assert_error_msg_content_equals(
-            "Invalid identifier '' (expected printable symbols only or it is too long)",
+            "Wrong space format: constraint name isn't a valid identifier",
             function()
                 box.space.test:format({{"id1", constraint = {[''] = "field_constr1"}}, {"id2"}})
             end)

--- a/test/engine-luatest/gh_6436_field_foreign_key_test.lua
+++ b/test/engine-luatest/gh_6436_field_foreign_key_test.lua
@@ -100,12 +100,12 @@ g.test_bad_foreign_key = function(cg)
         )
         fmt = gen_format({[string.rep('a', 66666)] = {space = 'country', field = 'id'}})
         t.assert_error_msg_content_equals(
-            "Wrong space format: foreign key name is too long",
+            "Wrong space format field 2: foreign key name is too long",
             function() box.schema.create_space('city', {engine=engine, format=fmt}) end
         )
         fmt = gen_format({[''] = {space = 'country', field = 'id'}})
         t.assert_error_msg_content_equals(
-            "Wrong space format: foreign key name isn't a valid identifier",
+            "Wrong space format field 2: foreign key name isn't a valid identifier",
             function() box.schema.create_space('city', {engine=engine, format=fmt}) end
         )
     end, {engine})

--- a/test/engine-luatest/gh_6436_field_foreign_key_test.lua
+++ b/test/engine-luatest/gh_6436_field_foreign_key_test.lua
@@ -105,7 +105,7 @@ g.test_bad_foreign_key = function(cg)
         )
         fmt = gen_format({[''] = {space = 'country', field = 'id'}})
         t.assert_error_msg_content_equals(
-            "Invalid identifier '' (expected printable symbols only or it is too long)",
+            "Wrong space format: foreign key name isn't a valid identifier",
             function() box.schema.create_space('city', {engine=engine, format=fmt}) end
         )
     end, {engine})

--- a/test/engine-luatest/gh_6436_tuple_constraint_test.lua
+++ b/test/engine-luatest/gh_6436_tuple_constraint_test.lua
@@ -223,7 +223,7 @@ g.test_wrong_tuple_constraint = function(cg)
             {engine = engine, constraint = {[string.rep('a', 66666)] = "tuple_constr1"}})
 
         t.assert_error_msg_content_equals(
-            "Invalid identifier '' (expected printable symbols only or it is too long)",
+            "Wrong space options: constraint name isn't a valid identifier",
             box.schema.create_space, 'test',
             {engine = engine, constraint = {[''] = "tuple_constr1"}})
 

--- a/test/engine/ddl.result
+++ b/test/engine/ddl.result
@@ -303,7 +303,7 @@ pk = space:create_index('pk', {parts={{field = 0, type = 'unsigned'}}})
 ...
 pk = space:create_index('pk', {parts={{field = 1, type = 'const char *'}}})
 ---
-- error: 'Wrong index parts: unknown field type'
+- error: 'Wrong index part 1: unknown field type'
 ...
 pk = space:create_index('pk', {parts={{field = 1, type = 'unsigned'}}})
 ---

--- a/test/engine/ddl.result
+++ b/test/engine/ddl.result
@@ -647,14 +647,14 @@ format = { { name = long } }
 ...
 s = box.schema.space.create('test', { engine = engine, format = format })
 ---
-- error: 'Wrong space format: field 1 name is too long'
+- error: 'Wrong space format field 1: field name is too long'
 ...
 format = { { name = 'id', type = '100' } }
 ---
 ...
 s = box.schema.space.create('test', { engine = engine, format = format })
 ---
-- error: 'Wrong space format: field 1 has unknown field type'
+- error: 'Wrong space format field 1: unknown field type'
 ...
 format = { setmetatable({}, { __serialize = 'map' }) }
 ---

--- a/test/engine/json.result
+++ b/test/engine/json.result
@@ -18,7 +18,7 @@ s:create_index('test1', {parts = {{2, 'number'}, {3, 'str', path = 'FIO["fname"]
 ...
 s:create_index('test1', {parts = {{2, 'number'}, {3, 'str', path = 666}, {3, 'str', path = '["FIO"]["fname"]'}}})
 ---
-- error: 'Wrong index parts: ''path'' must be string'
+- error: 'Wrong index part 2: ''path'' must be string'
 ...
 s:create_index('test1', {parts = {{2, 'number'}, {3, 'map', path = 'FIO'}}})
 ---
@@ -40,7 +40,7 @@ s:create_index('test1', {parts = {{2, 'number'}, {3, 'str', path = '[1].sname'},
 ...
 s:create_index('test1', {parts = {{2, 'number'}, {3, 'str', path = 'FIO....fname'}}})
 ---
-- error: 'Wrong index parts: invalid path'
+- error: 'Wrong index part 2: invalid path'
 ...
 idx = s:create_index('test1', {parts = {{2, 'number'}, {3, 'str', path = 'FIO.fname', is_nullable = false}, {3, 'str', path = '["FIO"]["sname"]'}}})
 ---

--- a/test/engine/multikey.result
+++ b/test/engine/multikey.result
@@ -22,16 +22,16 @@ pk = s:create_index('pk')
 -- Test incompatible multikey index parts.
 _ = s:create_index('idx3', {parts = {{3, 'str', path = '[*].fname'}, {3, 'str', path = '["data"][*].sname'}}})
 ---
-- error: 'Wrong index parts: incompatible multikey index path'
+- error: 'Wrong index part 2: incompatible multikey index path'
 ...
 _ = s:create_index('idx2', {parts = {{3, 'str', path = '[*].fname'}, {3, 'str', path = '[*].sname[*].a'}}})
 ---
-- error: 'Wrong index parts: no more than one array index placeholder [*] is allowed
+- error: 'Wrong index part 2: no more than one array index placeholder [*] is allowed
     in JSON path'
 ...
 _ = s:create_index('idx2', {parts = {{2, 'str', path = '[*]'}, {3, 'str', path = '[*]'}}})
 ---
-- error: 'Wrong index parts: incompatible multikey index path'
+- error: 'Wrong index part 2: incompatible multikey index path'
 ...
 idx0 = s:create_index('idx0', {parts = {{3, 'str', path = '[1].fname'}}})
 ---

--- a/test/engine/null.result
+++ b/test/engine/null.result
@@ -44,7 +44,7 @@ format[2].is_nullable = 100
 ...
 s:format(format) -- Fail.
 ---
-- error: 'Wrong space format: ''is_nullable'' must be boolean'
+- error: 'Wrong space format field 2: ''is_nullable'' must be boolean'
 ...
 -- Primary can not be nullable.
 parts = {}
@@ -770,7 +770,7 @@ format[2].nullable_action = 'none'
 ...
 s:format(format) -- Fail.
 ---
-- error: 'Wrong space format: field 2 has conflicting nullability and nullable action
+- error: 'Wrong space format field 2: conflicting nullability and nullable action
     properties'
 ...
 format[2].is_nullable = false
@@ -817,7 +817,7 @@ format[2].nullable_action = 'none'
 ...
 s:format(format) -- Fail.
 ---
-- error: 'Wrong space format: field 2 has conflicting nullability and nullable action
+- error: 'Wrong space format field 2: conflicting nullability and nullable action
     properties'
 ...
 parts = {}

--- a/test/engine/null.result
+++ b/test/engine/null.result
@@ -828,42 +828,42 @@ parts[1] = {field = 2, type = 'unsigned', is_nullable = true, nullable_action = 
 ...
 sk = s:create_index('sk', { parts = parts }) -- Fail.
 ---
-- error: 'Wrong index parts: conflicting nullability and nullable action properties'
+- error: 'Wrong index part 1: conflicting nullability and nullable action properties'
 ...
 parts[1].nullable_action = 'rollback'
 ---
 ...
 sk = s:create_index('sk', { parts = parts }) -- Fail.
 ---
-- error: 'Wrong index parts: conflicting nullability and nullable action properties'
+- error: 'Wrong index part 1: conflicting nullability and nullable action properties'
 ...
 parts[1].nullable_action = 'fail'
 ---
 ...
 sk = s:create_index('sk', { parts = parts }) -- Fail.
 ---
-- error: 'Wrong index parts: conflicting nullability and nullable action properties'
+- error: 'Wrong index part 1: conflicting nullability and nullable action properties'
 ...
 parts[1].nullable_action = 'ignore'
 ---
 ...
 sk = s:create_index('sk', { parts = parts }) -- Fail.
 ---
-- error: 'Wrong index parts: conflicting nullability and nullable action properties'
+- error: 'Wrong index part 1: conflicting nullability and nullable action properties'
 ...
 parts[1].nullable_action = 'replace'
 ---
 ...
 sk = s:create_index('sk', { parts = parts }) -- Fail.
 ---
-- error: 'Wrong index parts: conflicting nullability and nullable action properties'
+- error: 'Wrong index part 1: conflicting nullability and nullable action properties'
 ...
 parts[1].nullable_action = 'default'
 ---
 ...
 sk = s:create_index('sk', { parts = parts }) -- Fail.
 ---
-- error: 'Wrong index parts: conflicting nullability and nullable action properties'
+- error: 'Wrong index part 1: conflicting nullability and nullable action properties'
 ...
 parts[1].nullable_action = 'none'
 ---
@@ -882,7 +882,7 @@ parts[1].nullable_action = 'none'
 ...
 sk = s:create_index('sk', { parts = parts }) -- Fail.
 ---
-- error: 'Wrong index parts: conflicting nullability and nullable action properties'
+- error: 'Wrong index part 1: conflicting nullability and nullable action properties'
 ...
 parts[1].nullable_action = 'abort'
 ---

--- a/test/sql-tap/autoinc.test.lua
+++ b/test/sql-tap/autoinc.test.lua
@@ -863,7 +863,7 @@ test:do_catchsql_test(
     [[
         CREATE TABLE t11_5 (i INT, a INT, PRIMARY KEY(a, i COLLATE "unicode_ci" AUTOINCREMENT));
     ]], {
-        1, "Wrong index parts: collation is reasonable only for string and scalar parts"
+        1, "Wrong index part 2: collation is only reasonable for 'string' and 'scalar' parts"
     })
 
 test:do_catchsql_test(

--- a/test/vinyl/ddl.result
+++ b/test/vinyl/ddl.result
@@ -537,7 +537,7 @@ pk = space:create_index('primary')
 ...
 index = space:create_index('test', { type = 'tree', parts = { 2, 'nosuchtype' }})
 ---
-- error: 'Wrong index parts: unknown field type'
+- error: 'Wrong index part 1: unknown field type'
 ...
 index = space:create_index('test', { type = 'tree', parts = { 2, 'any' }})
 ---


### PR DESCRIPTION
Let's include part and field number into them to make it easier to pinpoint the problem.
To achieve that, we have to rework the way the `opts_decode` function sets errors.

Closes #7933