### PR TITLE
flaky: follow-up for qsync_basic test

### DIFF
--- a/test/replication/qsync_basic.result
+++ b/test/replication/qsync_basic.result
@@ -636,6 +636,9 @@ test_run:cmd('switch replica')
  | ---
  | - true
  | ...
+test_run:wait_lsn('replica', 'default')
+ | ---
+ | ...
 box.space.sync:count()
  | ---
  | - 100
@@ -658,6 +661,9 @@ for i = 1, 100 do box.space.sync:delete{i} end
 test_run:cmd('switch replica')
  | ---
  | - true
+ | ...
+test_run:wait_lsn('replica', 'default')
+ | ---
  | ...
 box.space.sync:count()
  | ---

--- a/test/replication/qsync_basic.test.lua
+++ b/test/replication/qsync_basic.test.lua
@@ -247,6 +247,7 @@ test_run:switch('default')
 box.cfg{replication_synchro_timeout = 1000}
 for i = 1, 100 do box.space.sync:replace{i} end
 test_run:cmd('switch replica')
+test_run:wait_lsn('replica', 'default')
 box.space.sync:count()
 -- Rows could be corrupted during WAL writes. Restart should
 -- reveal the problem during recovery.
@@ -255,6 +256,7 @@ box.space.sync:count()
 test_run:cmd('switch default')
 for i = 1, 100 do box.space.sync:delete{i} end
 test_run:cmd('switch replica')
+test_run:wait_lsn('replica', 'default')
 box.space.sync:count()
 
 --


### PR DESCRIPTION
Two more places where replica didn't wait until data is replicated.

Follow-up to tarantool/tarantool-qa#274

NO_CHANGELOG=test fix
NO_DOC=test fix