### PR TITLE
box: inherit index collation from the space format

### DIFF
--- a/changelogs/unreleased/gh-5104-inherit-index-collation-from-format.md
+++ b/changelogs/unreleased/gh-5104-inherit-index-collation-from-format.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed a bug in `space_object:create_index()` when `collation` option is not
+  set. Now it is inherited from the space format (gh-5104).

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -1216,6 +1216,9 @@ local function update_index_parts(format, parts)
             box.error(box.error.ILLEGAL_PARAMS,
                       "options.parts[" .. i .. "]: type (string) is expected")
         end
+        if part.collation == nil and fmt then
+            part.collation = fmt.collation
+        end
         if part.is_nullable == nil then
             if fmt and fmt.is_nullable then
                 part.is_nullable = true

--- a/test/engine-luatest/gh_5104_inherit_index_collation_from_format_test.lua
+++ b/test/engine-luatest/gh_5104_inherit_index_collation_from_format_test.lua
@@ -1,0 +1,31 @@
+local t = require('luatest')
+local g = t.group('gh-5104', {{engine = 'memtx'},
+                              {engine = 'vinyl'}})
+
+g.before_all(function(cg)
+    local server = require('test.luatest_helpers.server')
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:stop()
+    cg.server = nil
+end)
+
+-- Check that index collation is inherited from the space format.
+g.test_collation = function(cg)
+    local engine = cg.params.engine
+
+    cg.server:exec(function(engine)
+        local t = require('luatest')
+        local s = box.schema.space.create('test', {engine = engine})
+        s:format({{name = 'a', type = 'string', collation = 'unicode_ci'}})
+        s:create_index('pk', {parts = {{'a', 'string'}}})
+
+        s:insert{'ЕЛь'}
+        t.assert_equals(s.index.pk.parts[1].collation, 'unicode_ci')
+        t.assert_error_msg_contains('Duplicate key exists in unique index',
+                                    s.insert, s, {'ель'})
+    end, {engine})
+end


### PR DESCRIPTION
If `create_index('...', {parts = {...}})` is called without the `collation` option, then use collation from the space format.

Closes #5104