### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-7230-luajit-fixes.md
+++ b/changelogs/unreleased/gh-7230-luajit-fixes.md
@@ -8,6 +8,11 @@ activity, the following issues have been resolved:
 * Fix recording of `tonumber()` with cdata argument for failed conversions
   (gh-7655).
 * Fix concatenation operation on cdata. It always raises an error now.
+* Fix `io.close()` for already closed standard output.
+* Fix trace execution and stitching inside vmevent handler (gh-6782).
+* Fixed `emit_loadi()` on x86/x64 emitting xor between condition check
+  and jump instructions.
+* Fix stack top for error message when raising the OOM error (gh-3840).
 
 ## feature/luajit
 Backported patches from vanilla LuaJIT trunk (gh-7230). In the scope of this


### PR DESCRIPTION
* Ensure correct stack top for OOM error message.
* x86/x64: Check for jcc when using xor r,r in emit_loadi().
* Save trace recorder state around VM event call.
* Fix io.close() error message.
* Fix io.close().
* Cleanup math function compilation and fix inconsistencies.

Closes #3840
Closes #6782
Part of #7230

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump
