### PR TITLE
sql: refactor memory allocation system

### DIFF
--- a/extra/lemon.c
+++ b/extra/lemon.c
@@ -3608,7 +3608,7 @@ PRIVATE int translate_code(struct lemon *lemp, struct rule *rp){
     lhsdirect = 1;
     if( has_destructor(rp->rhs[0],lemp) ){
       append_str(0,0,0,0);
-      append_str("  yy_destructor(yypParser,%d,&yymsp[%d].minor);\n", 0,
+      append_str("  yy_destructor(%d,&yymsp[%d].minor);\n", 0,
                  rp->rhs[0]->index,1-rp->nrhs);
       rp->codePrefix = Strsafe(append_str(0,0,0,0));
       rp->noCode = 0;
@@ -3744,7 +3744,7 @@ PRIVATE int translate_code(struct lemon *lemp, struct rule *rp){
         lemp->errorcnt++;
       }
     }else if( i>0 && has_destructor(rp->rhs[i],lemp) ){
-      append_str("  yy_destructor(yypParser,%d,&yymsp[%d].minor);\n", 0,
+      append_str("  yy_destructor(%d,&yymsp[%d].minor);\n", 0,
          rp->rhs[i]->index,i-rp->nrhs+1);
     }
   }

--- a/extra/lempar.c
+++ b/extra/lempar.c
@@ -365,11 +365,9 @@ void *ParseAlloc(void *(*mallocProc)(YYMALLOCARGTYPE)){
 ** directives of the input grammar.
 */
 static void yy_destructor(
-  yyParser *yypParser,    /* The parser */
   YYCODETYPE yymajor,     /* Type code for object to destroy */
   YYMINORTYPE *yypminor   /* The object to be destroyed */
 ){
-  ParseARG_FETCH;
   switch( yymajor ){
     /* Here is inserted the actions which take place when a
     ** terminal or non-terminal is destroyed.  This can happen
@@ -406,7 +404,7 @@ static void yy_pop_parser_stack(yyParser *pParser){
       yyTokenName[yytos->major]);
   }
 #endif
-  yy_destructor(pParser, yytos->major, &yytos->minor);
+  yy_destructor(yytos->major, &yytos->minor);
 }
 
 /* 
@@ -875,7 +873,7 @@ void Parse(
              yyTracePrompt,yyTokenName[yymajor]);
         }
 #endif
-        yy_destructor(yypParser, (YYCODETYPE)yymajor, &yyminorunion);
+        yy_destructor((YYCODETYPE)yymajor, &yyminorunion);
         yymajor = YYNOCODE;
       }else{
         while( yypParser->yytos >= yypParser->yystack
@@ -887,7 +885,7 @@ void Parse(
           yy_pop_parser_stack(yypParser);
         }
         if( yypParser->yytos < yypParser->yystack || yymajor==0 ){
-          yy_destructor(yypParser,(YYCODETYPE)yymajor,&yyminorunion);
+          yy_destructor((YYCODETYPE)yymajor, &yyminorunion);
           yy_parse_failed(yypParser);
 #ifndef YYNOERRORRECOVERY
           yypParser->yyerrcnt = -1;
@@ -908,7 +906,7 @@ void Parse(
       ** they intend to abandon the parse upon the first syntax error seen.
       */
       yy_syntax_error(yypParser,yymajor, yyminor);
-      yy_destructor(yypParser,(YYCODETYPE)yymajor,&yyminorunion);
+      yy_destructor((YYCODETYPE)yymajor, &yyminorunion);
       yymajor = YYNOCODE;
       
 #else  /* YYERRORSYMBOL is not defined */
@@ -925,7 +923,7 @@ void Parse(
         yy_syntax_error(yypParser,yymajor, yyminor);
       }
       yypParser->yyerrcnt = 3;
-      yy_destructor(yypParser,(YYCODETYPE)yymajor,&yyminorunion);
+      yy_destructor((YYCODETYPE)yymajor, &yyminorunion);
       if( yyendofinput ){
         yy_parse_failed(yypParser);
 #ifndef YYNOERRORRECOVERY

--- a/src/box/lua/execute.c
+++ b/src/box/lua/execute.c
@@ -171,7 +171,6 @@ port_sql_dump_lua(struct port *port, struct lua_State *L, bool is_flat)
 	(void) is_flat;
 	assert(is_flat == false);
 	assert(port->vtab == &port_sql_vtab);
-	struct sql *db = sql_get();
 	struct port_sql *port_sql = (struct port_sql *)port;
 	struct sql_stmt *stmt = port_sql->stmt;
 	switch (port_sql->serialization_format) {
@@ -189,7 +188,7 @@ port_sql_dump_lua(struct port *port, struct lua_State *L, bool is_flat)
 			vdbe_autoinc_id_list((struct Vdbe *) stmt);
 		lua_createtable(L, 0, stailq_empty(autoinc_id_list) ? 1 : 2);
 
-		luaL_pushuint64(L, db->nChange);
+		luaL_pushuint64(L, sql_get()->nChange);
 		lua_setfield(L, -2, sql_info_key_strs[SQL_INFO_ROW_COUNT]);
 
 		if (!stailq_empty(autoinc_id_list)) {

--- a/src/box/sql.h
+++ b/src/box/sql.h
@@ -78,7 +78,7 @@ struct func;
  * surrounding the expression w/ 'SELECT ' prefix and perform
  * convetional parsing. Then extract result expression value from
  * stuct Select and return it.
- * @param db SQL context handle.
+ *
  * @param expr Expression to parse.
  * @param expr_len Length of @an expr.
  *
@@ -86,18 +86,17 @@ struct func;
  * @retval not NULL Expr AST pointer on success.
  */
 struct Expr *
-sql_expr_compile(struct sql *db, const char *expr, int expr_len);
+sql_expr_compile(const char *expr, int expr_len);
 
 /**
  * This routine executes parser on 'CREATE VIEW ...' statement
  * and loads content of SELECT into internal structs as result.
  *
- * @param db Current SQL context.
  * @param view_stmt String containing 'CREATE VIEW' statement.
  * @retval AST of SELECT statement on success, NULL otherwise.
  */
 struct Select *
-sql_view_compile(struct sql *db, const char *view_stmt);
+sql_view_compile(const char *view_stmt);
 
 /**
  * Perform parsing of provided SQL request and construct trigger AST.
@@ -108,15 +107,15 @@ sql_view_compile(struct sql *db, const char *view_stmt);
  * @retval not NULL sql_trigger AST pointer on success.
  */
 struct sql_trigger *
-sql_trigger_compile(struct sql *db, const char *sql);
+sql_trigger_compile(const char *sql);
 
 /**
  * Free AST pointed by trigger.
- * @param db SQL handle.
+ *
  * @param trigger AST object.
  */
 void
-sql_trigger_delete(struct sql *db, struct sql_trigger *trigger);
+sql_trigger_delete(struct sql_trigger *trigger);
 
 /**
  * Get server triggers list by space_id.
@@ -190,27 +189,12 @@ int
 sql_expr_sizeof(struct Expr *p, int flags);
 
 /**
- * This function is similar to sqlExprDup(), except that if pzBuffer
- * is not NULL then *pzBuffer is assumed to point to a buffer large enough
- * to store the copy of expression p, the copies of p->u.zToken
- * (if applicable), and the copies of the p->pLeft and p->pRight expressions,
- * if any. Before returning, *pzBuffer is set to the first byte past the
- * portion of the buffer copied into by this function.
- * @param db SQL handle.
- * @param p Root of expression's AST.
- * @param dupFlags EXPRDUP_REDUCE or 0.
- * @param pzBuffer If not NULL, then buffer to store duplicate.
- */
-struct Expr *
-sql_expr_dup(struct sql *db, struct Expr *p, int flags, char **buffer);
-
-/**
  * Free AST pointed by expr.
- * @param db SQL handle.
+ *
  * @param expr Root pointer of ASR
  */
 void
-sql_expr_delete(struct sql *db, struct Expr *expr);
+sql_expr_delete(struct Expr *expr);
 
 /**
  * Create and initialize a new template space object.
@@ -229,34 +213,32 @@ sql_template_space_new(struct Parse *parser, const char *name);
  * returned is a truncated version of the usual Expr structure
  * that will be stored as part of the in-memory representation of
  * the database schema.
- * @param db The database connection.
+ *
  * @param p The ExprList to duplicate.
  * @param flags EXPRDUP_XXX flags.
- * @retval NULL on memory allocation error.
+ * @retval NULL if original expr list is NULL.
  * @retval not NULL on success.
  */
 struct ExprList *
-sql_expr_list_dup(struct sql *db, struct ExprList *p, int flags);
+sql_expr_list_dup(struct ExprList *p, int flags);
 
 /**
  * Free AST pointed by expr list.
- * @param db SQL handle.
+ *
  * @param expr_list Root pointer of ExprList.
  */
 void
-sql_expr_list_delete(struct sql *db, struct ExprList *expr_list);
+sql_expr_list_delete(struct ExprList *expr_list);
 
 /**
  * Add a new element to the end of an expression list.
- * @param db SQL handle.
+ *
  * @param expr_list List to which to append. Might be NULL.
  * @param expr Expression to be appended. Might be NULL.
- * @retval NULL on memory allocation error. The list is freed.
  * @retval not NULL on success.
  */
 struct ExprList *
-sql_expr_list_append(struct sql *db, struct ExprList *expr_list,
-		     struct Expr *expr);
+sql_expr_list_append(struct ExprList *expr_list, struct Expr *expr);
 
 /**
  * Resolve names in expressions that can only reference a single
@@ -281,11 +263,10 @@ sql_resolve_self_reference(struct Parse *parser, struct space_def *def,
  * A number of service allocations are performed on the region,
  * which is also cleared in the destroy function.
  * @param parser object to initialize.
- * @param db sql object.
  * @param sql_flags flags to control parser behaviour.
  */
 void
-sql_parser_create(struct Parse *parser, struct sql *db, uint32_t sql_flags);
+sql_parser_create(struct Parse *parser, uint32_t sql_flags);
 
 /**
  * Release the parser object resources.
@@ -298,11 +279,10 @@ sql_parser_destroy(struct Parse *parser);
  * Release memory allocated for given SELECT and all of its
  * substructures. It accepts NULL pointers.
  *
- * @param db Database handler.
  * @param select Select to be freed.
  */
 void
-sql_select_delete(struct sql *db, struct Select *select);
+sql_select_delete(struct Select *select);
 
 /**
  * Collect all table names within given select, including
@@ -352,7 +332,7 @@ sql_src_list_entry_name(const struct SrcList *list, int i);
 
 /** Delete an entire SrcList including all its substructure. */
 void
-sqlSrcListDelete(struct sql *db, struct SrcList *list);
+sqlSrcListDelete(struct SrcList *list);
 
 /**
  * Auxiliary VDBE structure to speed-up tuple data field access.

--- a/src/box/sql/main.c
+++ b/src/box/sql/main.c
@@ -161,7 +161,7 @@ sql_initialize(void)
  *
  * The sz parameter is the number of bytes in each lookaside slot.
  * The cnt parameter is the number of slots.  If pStart is NULL the
- * space for the lookaside memory is obtained from sql_malloc().
+ * space for the lookaside memory is obtained from malloc().
  * If pStart is not NULL then it is sz*cnt bytes of memory to use for
  * the lookaside memory.
  */
@@ -176,7 +176,7 @@ setupLookaside(sql * db, void *pBuf, int sz, int cnt)
 	 * both at the same time.
 	 */
 	if (db->lookaside.bMalloced)
-		sql_free(db->lookaside.pStart);
+		free(db->lookaside.pStart);
 	/* The size of a lookaside slot after ROUNDDOWN8 needs to be larger
 	 * than a pointer to be useful.
 	 */
@@ -189,9 +189,7 @@ setupLookaside(sql * db, void *pBuf, int sz, int cnt)
 		sz = 0;
 		pStart = 0;
 	} else if (pBuf == 0) {
-		pStart = sqlMalloc(sz * cnt);	/* IMP: R-61949-35727 */
-		if (pStart)
-			cnt = sqlMallocSize(pStart) / sz;
+		pStart = xmalloc(sz * cnt);
 	} else {
 		pStart = pBuf;
 	}
@@ -241,7 +239,7 @@ sqlCloseSavepoints(Vdbe * pVdbe)
 void
 sqlRollbackAll(Vdbe * pVdbe)
 {
-	sql *db = pVdbe->db;
+	struct sql *db = sql_get();
 
 	/* If one has been configured, invoke the rollback-hook callback */
 	if (db->xRollbackCallback && (!pVdbe->auto_commit)) {
@@ -301,54 +299,6 @@ static const int aHardLimit[] = {
 #error SQL_MAX_TRIGGER_DEPTH must be at least 1
 #endif
 
-/*
- * Change the value of a limit.  Report the old value.
- * If an invalid limit index is supplied, report -1.
- * Make no changes but still report the old value if the
- * new limit is negative.
- *
- * A new lower limit does not shrink existing constructs.
- * It merely prevents new constructs that exceed the limit
- * from forming.
- */
-int
-sql_limit(sql * db, int limitId, int newLimit)
-{
-	int oldLimit;
-
-	/* EVIDENCE-OF: R-30189-54097 For each limit category SQL_LIMIT_NAME
-	 * there is a hard upper bound set at compile-time by a C preprocessor
-	 * macro called SQL_MAX_NAME. (The "_LIMIT_" in the name is changed to
-	 * "_MAX_".)
-	 */
-	assert(aHardLimit[SQL_LIMIT_LENGTH] == SQL_MAX_LENGTH);
-	assert(aHardLimit[SQL_LIMIT_SQL_LENGTH] == SQL_MAX_SQL_LENGTH);
-	assert(aHardLimit[SQL_LIMIT_COLUMN] == SQL_MAX_COLUMN);
-	assert(aHardLimit[SQL_LIMIT_EXPR_DEPTH] == SQL_MAX_EXPR_DEPTH);
-	assert(aHardLimit[SQL_LIMIT_COMPOUND_SELECT] ==
-	       SQL_MAX_COMPOUND_SELECT);
-	assert(aHardLimit[SQL_LIMIT_VDBE_OP] == SQL_MAX_VDBE_OP);
-	assert(aHardLimit[SQL_LIMIT_FUNCTION_ARG] ==
-	       SQL_MAX_FUNCTION_ARG);
-	assert(aHardLimit[SQL_LIMIT_ATTACHED] == SQL_MAX_ATTACHED);
-	assert(aHardLimit[SQL_LIMIT_LIKE_PATTERN_LENGTH] ==
-	       SQL_MAX_LIKE_PATTERN_LENGTH);
-	assert(aHardLimit[SQL_LIMIT_TRIGGER_DEPTH] ==
-	       SQL_MAX_TRIGGER_DEPTH);
-
-	if (limitId < 0 || limitId >= SQL_N_LIMIT) {
-		return -1;
-	}
-	oldLimit = db->aLimit[limitId];
-	if (newLimit >= 0) {	/* IMP: R-52476-28732 */
-		if (newLimit > aHardLimit[limitId]) {
-			newLimit = aHardLimit[limitId];	/* IMP: R-51463-25634 */
-		}
-		db->aLimit[limitId] = newLimit;
-	}
-	return oldLimit;	/* IMP: R-53341-35419 */
-}
-
 /**
  * This routine does the work of initialization of main
  * SQL connection instance.
@@ -365,11 +315,7 @@ sql_init_db(sql **out_db)
 		return -1;
 
 	/* Allocate the sql data structure */
-	db = sqlMallocZero(sizeof(sql));
-	if (db == NULL) {
-		*out_db = NULL;
-		return -1;
-	}
+	db = xcalloc(1, sizeof(*db));
 	db->magic = SQL_MAGIC_BUSY;
 
 	db->pVfs = sql_vfs_find(0);
@@ -381,11 +327,6 @@ sql_init_db(sql **out_db)
 	db->nMaxSorterMmap = 0x7FFFFFFF;
 
 	db->magic = SQL_MAGIC_OPEN;
-	if (db->mallocFailed) {
-		sql_free(db);
-		*out_db = NULL;
-		return -1;
-	}
 
 	/* Enable the lookaside-malloc subsystem */
 	setupLookaside(db, 0, LOOKASIDE_SLOT_SIZE, LOOKASIDE_SLOT_NUMBER);

--- a/src/box/sql/malloc.c
+++ b/src/box/sql/malloc.c
@@ -36,289 +36,36 @@
 #include "sqlInt.h"
 #include <stdarg.h>
 
-/*
- * Like malloc(), but remember the size of the allocation
- * so that we can find it later using sqlMemSize().
- *
- * For this low-level routine, we are guaranteed that nByte>0 because
- * cases of nByte<=0 will be intercepted and dealt with by higher level
- * routines.
- */
-static void *
-sql_sized_malloc(int nByte)
-{
-	sql_int64 *p;
-	assert(nByte > 0);
-	nByte = ROUND8(nByte);
-	p = malloc(nByte + 8);
-	if (p == NULL) {
-		sql_get()->mallocFailed = 1;
-		diag_set(OutOfMemory, nByte, "malloc", "p");
-		return NULL;
-	}
-	p[0] = nByte;
-	p++;
-	return (void *)p;
-}
-
-/*
- * Report the allocated size of a prior return from sql_sized_malloc()
- * or sql_sized_realloc().
- */
-static int
-sql_sized_sizeof(void *pPrior)
-{
-	sql_int64 *p;
-	assert(pPrior != 0);
-	p = (sql_int64 *) pPrior;
-	p--;
-	return (int)p[0];
-}
-
-/*
- * Like realloc().  Resize an allocation previously obtained from
- * sqlMemMalloc().
- *
- * For this low-level interface, we know that pPrior!=0.  Cases where
- * pPrior==0 while have been intercepted by higher-level routine and
- * redirected to sql_sized_malloc.  Similarly, we know that nByte>0 because
- * cases where nByte<=0 will have been intercepted by higher-level
- * routines and redirected to sql_sized_free.
- */
-static void *
-sql_sized_realloc(void *pPrior, int nByte)
-{
-	sql_int64 *p = (sql_int64 *) pPrior;
-	assert(pPrior != 0 && nByte > 0);
-	assert(nByte == ROUND8(nByte));	/* EV: R-46199-30249 */
-	p--;
-	p = realloc(p, nByte + 8);
-	if (p == NULL) {
-		sql_get()->mallocFailed = 1;
-		diag_set(OutOfMemory, nByte, "realloc", "p");
-		return NULL;
-	}
-	p[0] = nByte;
-	p++;
-	return (void *)p;
-}
-
-/*
- * Allocate memory.  This routine is like sql_malloc() except that it
- * assumes the memory subsystem has already been initialized.
- */
-void *
-sqlMalloc(u64 n)
-{
-	void *p;
-	if (n == 0 || n >= 0x7fffff00) {
-		/* A memory allocation of a number of bytes which is near the maximum
-		 * signed integer value might cause an integer overflow inside of the
-		 * sql_sized_malloc().  Hence we limit the maximum size to 0x7fffff00, giving
-		 * 255 bytes of overhead.  sql itself will never use anything near
-		 * this amount.  The only way to reach the limit is with sql_malloc()
-		 */
-		p = 0;
-	} else {
-		p = sql_sized_malloc((int)n);
-	}
-	assert(EIGHT_BYTE_ALIGNMENT(p));	/* IMP: R-11148-40995 */
-	return p;
-}
-
-/*
- * This version of the memory allocation is for use by the application.
- * First make sure the memory subsystem is initialized, then do the
- * allocation.
- */
-void *
-sql_malloc(int n)
-{
-	return n <= 0 ? 0 : sqlMalloc(n);
-}
-
-void *
-sql_malloc64(sql_uint64 n)
-{
-	return sqlMalloc(n);
-}
-
-/*
- * TRUE if p is a lookaside memory allocation from db
- */
-static int
-isLookaside(sql * db, void *p)
-{
-	return SQL_WITHIN(p, db->lookaside.pStart, db->lookaside.pEnd);
-}
-
-/*
- * Return the size of a memory allocation previously obtained from
- * sqlMalloc() or sql_malloc().
- */
-int
-sqlMallocSize(void *p)
-{
-	return sql_sized_sizeof(p);
-}
-
-int
-sqlDbMallocSize(sql * db, void *p)
-{
-	assert(p != 0);
-	if (db == 0 || !isLookaside(db, p))
-		return sql_sized_sizeof(p);
-	else
-		return db->lookaside.sz;
-}
-
-/*
- * Free memory previously obtained from sqlMalloc().
- */
 void
-sql_free(void *p)
+sql_xfree(void *buf)
 {
-	if (p == NULL)
+	struct sql *db = sql_get();
+	assert(db != NULL);
+	if (buf >= db->lookaside.pStart && buf < db->lookaside.pEnd) {
+		LookasideSlot *pBuf = (LookasideSlot *)buf;
+		pBuf->pNext = db->lookaside.pFree;
+		db->lookaside.pFree = pBuf;
+		db->lookaside.nOut--;
 		return;
-	sql_int64 *raw_p = (sql_int64 *) p;
-	raw_p--;
-	free(raw_p);
-}
-
-/*
- * Free memory that might be associated with a particular database
- * connection.
- */
-void
-sqlDbFree(sql * db, void *p)
-{
-	if (db != NULL) {
-		if (isLookaside(db, p)) {
-			LookasideSlot *pBuf = (LookasideSlot *) p;
-			pBuf->pNext = db->lookaside.pFree;
-			db->lookaside.pFree = pBuf;
-			db->lookaside.nOut--;
-			return;
-		}
 	}
-	sql_free(p);
-}
-
-/*
- * Change the size of an existing memory allocation
- */
-void *
-sqlRealloc(void *pOld, u64 nBytes)
-{
-	int nOld, nNew;
-	void *pNew;
-	if (pOld == 0) {
-		return sqlMalloc(nBytes);	/* IMP: R-04300-56712 */
-	}
-	if (nBytes == 0) {
-		sql_free(pOld);	/* IMP: R-26507-47431 */
-		return 0;
-	}
-	if (nBytes >= 0x7fffff00) {
-		/* The 0x7ffff00 limit term is explained in comments on sqlMalloc() */
-		return 0;
-	}
-	nOld = sqlMallocSize(pOld);
-	nNew = ROUND8((int)nBytes);
-	if (nOld == nNew)
-		pNew = pOld;
-	else
-		pNew = sql_sized_realloc(pOld, nNew);
-	assert(EIGHT_BYTE_ALIGNMENT(pNew));	/* IMP: R-11148-40995 */
-	return pNew;
+	free(buf);
 }
 
 void *
-sql_realloc64(void *pOld, sql_uint64 n)
+sql_xmalloc0(size_t n)
 {
-	return sqlRealloc(pOld, n);
-}
-
-/*
- * Allocate and zero memory.
- */
-void *
-sqlMallocZero(u64 n)
-{
-	void *p = sqlMalloc(n);
-	if (p) {
-		memset(p, 0, (size_t) n);
-	}
-	return p;
-}
-
-/*
- * Allocate and zero memory.  If the allocation fails, make
- * the mallocFailed flag in the connection pointer.
- */
-void *
-sqlDbMallocZero(sql * db, u64 n)
-{
-	void *p;
-	p = sqlDbMallocRaw(db, n);
-	if (p)
-		memset(p, 0, (size_t) n);
-	return p;
-}
-
-/* Finish the work of sqlDbMallocRawNN for the unusual and
- * slower case when the allocation cannot be fulfilled using lookaside.
- */
-static SQL_NOINLINE void *
-dbMallocRawFinish(sql * db, u64 n)
-{
-	void *p;
-	assert(db != 0);
-	p = sqlMalloc(n);
-	if (!p)
-		sqlOomFault(db);
-	return p;
-}
-
-/*
- * Allocate memory, either lookaside (if possible) or heap.
- * If the allocation fails, set the mallocFailed flag in
- * the connection pointer.
- *
- * If db!=0 and db->mallocFailed is true (indicating a prior malloc
- * failure on the same database connection) then always return 0.
- * Hence for a particular database connection, once malloc starts
- * failing, it fails consistently until mallocFailed is reset.
- * This is an important assumption.  There are many places in the
- * code that do things like this:
- *
- *         int *a = (int*)sqlDbMallocRaw(db, 100);
- *         int *b = (int*)sqlDbMallocRaw(db, 200);
- *         if( b ) a[10] = 9;
- *
- * In other words, if a subsequent malloc (ex: "b") worked, it is assumed
- * that all prior mallocs (ex: "a") worked too.
- *
- * The sqlMallocRawNN() variant guarantees that the "db" parameter is
- * not a NULL pointer.
- */
-void *
-sqlDbMallocRaw(sql * db, u64 n)
-{
-	void *p;
-	if (db)
-		return sqlDbMallocRawNN(db, n);
-	p = sqlMalloc(n);
+	void *p = sql_xmalloc(n);
+	memset(p, 0, n);
 	return p;
 }
 
 void *
-sqlDbMallocRawNN(sql * db, u64 n)
+sql_xmalloc(size_t n)
 {
+	struct sql *db = sql_get();
 	assert(db != NULL);
 	LookasideSlot *pBuf;
 	if (db->lookaside.bDisable == 0) {
-		assert(db->mallocFailed == 0);
 		if (n > db->lookaside.sz) {
 			db->lookaside.anStat[1]++;
 		} else if ((pBuf = db->lookaside.pFree) == 0) {
@@ -332,120 +79,46 @@ sqlDbMallocRawNN(sql * db, u64 n)
 			}
 			return (void *)pBuf;
 		}
-	} else if (db->mallocFailed) {
-		return 0;
 	}
-	return dbMallocRawFinish(db, n);
+	return xmalloc(n);
 }
 
-/* Forward declaration */
-static SQL_NOINLINE void *dbReallocFinish(sql * db, void *p, u64 n);
-
-/*
- * Resize the block of memory pointed to by p to n bytes. If the
- * resize fails, set the mallocFailed flag in the connection object.
- */
 void *
-sqlDbRealloc(sql * db, void *p, u64 n)
+sql_xrealloc(void *buf, size_t n)
 {
-	assert(db != 0);
-	if (p == 0)
-		return sqlDbMallocRawNN(db, n);
-	if (isLookaside(db, p) && n <= db->lookaside.sz)
-		return p;
-	return dbReallocFinish(db, p, n);
-}
-
-static SQL_NOINLINE void *
-dbReallocFinish(sql * db, void *p, u64 n)
-{
-	void *pNew = 0;
-	assert(db != 0);
-	assert(p != 0);
-	if (db->mallocFailed == 0) {
-		if (isLookaside(db, p)) {
-			pNew = sqlDbMallocRawNN(db, n);
-			if (pNew) {
-				memcpy(pNew, p, db->lookaside.sz);
-				sqlDbFree(db, p);
-			}
-		} else {
-			pNew = sql_realloc64(p, n);
-			if (!pNew)
-				sqlOomFault(db);
-		}
+	struct sql *db = sql_get();
+	assert(db != NULL);
+	if (buf == NULL)
+		return sql_xmalloc(n);
+	if (buf >= db->lookaside.pStart && buf < db->lookaside.pEnd) {
+		if (n <= (size_t)db->lookaside.sz)
+			return buf;
+		void *new_buf = sql_xmalloc(n);
+		memcpy(new_buf, buf, db->lookaside.sz);
+		sql_xfree(buf);
+		return new_buf;
 	}
-	return pNew;
-}
-
-/*
- * Attempt to reallocate p.  If the reallocation fails, then free p
- * and set the mallocFailed flag in the database connection.
- */
-void *
-sqlDbReallocOrFree(sql * db, void *p, u64 n)
-{
-	void *pNew;
-	pNew = sqlDbRealloc(db, p, n);
-	if (!pNew) {
-		sqlDbFree(db, p);
-	}
-	return pNew;
-}
-
-/*
- * Make a copy of a string in memory obtained from sqlMalloc(). These
- * functions call sqlMallocRaw() directly instead of sqlMalloc(). This
- * is because when memory debugging is turned on, these two functions are
- * called via macros that record the current file and line number in the
- * ThreadData structure.
- */
-char *
-sqlDbStrDup(sql * db, const char *z)
-{
-	char *zNew;
-	size_t n;
-	if (z == 0) {
-		return 0;
-	}
-	n = strlen(z) + 1;
-	zNew = sqlDbMallocRaw(db, n);
-	if (zNew) {
-		memcpy(zNew, z, n);
-	}
-	return zNew;
+	return xrealloc(buf, n);
 }
 
 char *
-sqlDbStrNDup(sql * db, const char *z, u64 n)
+sql_xstrdup(const char *str)
 {
-	char *zNew;
-	assert(db != 0);
-	if (z == 0) {
-		return 0;
-	}
-	assert((n & 0x7fffffff) == n);
-	zNew = sqlDbMallocRawNN(db, n + 1);
-	if (zNew) {
-		memcpy(zNew, z, (size_t) n);
-		zNew[n] = 0;
-	}
-	return zNew;
+	if (str == NULL)
+		return NULL;
+	size_t size = strlen(str) + 1;
+	char *new_str = sql_xmalloc(size);
+	memcpy(new_str, str, size);
+	return new_str;
 }
 
-/*
- * This routine reactivates the memory allocator and clears the
- * db->mallocFailed flag as necessary.
- *
- * The memory allocator is not restarted if there are running
- * VDBEs.
- */
-void
-sqlOomClear(sql * db)
+char *
+sql_xstrndup(const char *str, size_t len)
 {
-	if (db->mallocFailed && db->nVdbeExec == 0) {
-		db->mallocFailed = 0;
-		assert(db->lookaside.bDisable > 0);
-		db->lookaside.bDisable--;
-	}
+	if (str == NULL)
+		return NULL;
+	char *new_str = sql_xmalloc(len + 1);
+	memcpy(new_str, str, len);
+	new_str[len] = '\0';
+	return new_str;
 }

--- a/src/box/sql/mem.h
+++ b/src/box/sql/mem.h
@@ -93,7 +93,6 @@ struct Mem {
 	char *zMalloc;		/* Space to hold MEM_Str or MEM_Blob if szMalloc>0 */
 	int szMalloc;		/* Size of the zMalloc allocation */
 	u32 uTemp;		/* Transient storage for serial_type in OP_MakeRecord */
-	sql *db;		/* The associated database connection */
 #ifdef SQL_DEBUG
 	Mem *pScopyFrom;	/* This Mem is a shallow copy of pScopyFrom */
 	void *pFiller;		/* So that sizeof(Mem) is a multiple of 8 */
@@ -300,7 +299,7 @@ mem_snprintf(char *buf, uint32_t size, const struct Mem *mem);
 
 /**
  * Returns a NULL-terminated string representation of a MEM. Memory for the
- * result was allocated using sqlDbMallocRawNN() and should be freed.
+ * result was allocated using sql_xmalloc() and should be freed.
  */
 char *
 mem_strdup(const struct Mem *mem);
@@ -855,7 +854,6 @@ int sqlVdbeCheckMemInvariants(struct Mem *);
 int sqlVdbeMemClearAndResize(struct Mem * pMem, int n);
 
 void sqlValueFree(struct Mem *);
-struct Mem *sqlValueNew(struct sql *);
 
 /*
  * Release an array of N Mem elements

--- a/src/box/sql/os.c
+++ b/src/box/sql/os.c
@@ -153,20 +153,13 @@ sqlOsOpenMalloc(sql_vfs * pVfs,
 		    const char *zFile,
 		    sql_file ** ppFile, int flags, int *pOutFlags)
 {
-	int rc;
-	sql_file *pFile;
-	pFile = (sql_file *) sqlMallocZero(pVfs->szOsFile);
-	if (pFile) {
-		rc = sqlOsOpen(pVfs, zFile, pFile, flags, pOutFlags);
-		if (rc != 0) {
-			sql_free(pFile);
-		} else {
-			*ppFile = pFile;
-		}
-	} else {
-		rc = -1;
+	sql_file *pFile = xcalloc(1, pVfs->szOsFile);
+	if (sqlOsOpen(pVfs, zFile, pFile, flags, pOutFlags) != 0) {
+		free(pFile);
+		return -1;
 	}
-	return rc;
+	*ppFile = pFile;
+	return 0;
 }
 
 void
@@ -174,7 +167,7 @@ sqlOsCloseFree(sql_file * pFile)
 {
 	assert(pFile);
 	sqlOsClose(pFile);
-	sql_free(pFile);
+	free(pFile);
 }
 
 /*

--- a/src/box/sql/os.h
+++ b/src/box/sql/os.h
@@ -145,7 +145,7 @@ int sqlOsCurrentTimeInt64(sql_vfs *, sql_int64 *);
 
 /*
  * Convenience functions for opening and closing files using
- * sql_malloc() to obtain space for the file-handle structure.
+ * malloc() to obtain space for the file-handle structure.
  */
 int sqlOsOpenMalloc(sql_vfs *, const char *, sql_file **, int,
 			int *);

--- a/src/box/sql/os_unix.c
+++ b/src/box/sql/os_unix.c
@@ -339,7 +339,7 @@ closePendingFds(unixFile * pFile)
 	for (p = pInode->pUnused; p; p = pNext) {
 		pNext = p->pNext;
 		close(p->fd);
-		sql_free(p);
+		free(p);
 	}
 	pInode->pUnused = 0;
 }
@@ -366,7 +366,7 @@ releaseInodeInfo(unixFile * pFile)
 				assert(pInode->pNext->pPrev == pInode);
 				pInode->pNext->pPrev = pInode->pPrev;
 			}
-			sql_free(pInode);
+			free(pInode);
 		}
 	}
 }
@@ -407,10 +407,7 @@ findInodeInfo(unixFile * pFile,	/* Unix file with file desc used in the key */
 		pInode = pInode->pNext;
 	}
 	if (pInode == 0) {
-		pInode = sql_malloc64(sizeof(*pInode));
-		if (pInode == 0) {
-			return -1;
-		}
+		pInode = xmalloc(sizeof(*pInode));
 		memset(pInode, 0, sizeof(*pInode));
 		memcpy(&pInode->fileId, &fileId, sizeof(fileId));
 		pInode->nRef = 1;
@@ -646,7 +643,7 @@ closeUnixFile(sql_file * id)
 		close(pFile->h);
 		pFile->h = -1;
 	}
-	sql_free(pFile->pUnused);
+	free(pFile->pUnused);
 	memset(pFile, 0, sizeof(unixFile));
 	return 0;
 }
@@ -1014,13 +1011,9 @@ unixFileControl(sql_file * id, int op, void *pArg)
 			return 0;
 		}
 	case SQL_FCNTL_TEMPFILENAME:{
-			char *zTFile =
-			    sql_malloc64(pFile->pVfs->mxPathname);
-			if (zTFile) {
-				unixGetTempname(pFile->pVfs->mxPathname,
-						zTFile);
-				*(char **)pArg = zTFile;
-			}
+			char *zTFile = xmalloc(pFile->pVfs->mxPathname);
+			unixGetTempname(pFile->pVfs->mxPathname, zTFile);
+			*(char **)pArg = zTFile;
 			return 0;
 		}
 	case SQL_FCNTL_HAS_MOVED:{
@@ -1696,10 +1689,7 @@ unixOpen(sql_vfs * pVfs,	/* The VFS for which this is the xOpen method */
 		if (pUnused) {
 			fd = pUnused->fd;
 		} else {
-			pUnused = sql_malloc64(sizeof(*pUnused));
-			if (!pUnused) {
-				return -1;
-			}
+			pUnused = xmalloc(sizeof(*pUnused));
 		}
 		p->pUnused = pUnused;
 
@@ -1798,7 +1788,7 @@ unixOpen(sql_vfs * pVfs,	/* The VFS for which this is the xOpen method */
 
  open_finished:
 	if (rc != 0)
-		sql_free(p->pUnused);
+		free(p->pUnused);
 	return rc;
 }
 

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -521,7 +521,7 @@ create_fk_constraint_parse_def_destroy(struct create_fk_constraint_parse_def *d)
 		return;
 	struct fk_constraint_parse *fk;
 	rlist_foreach_entry(fk, &d->fkeys, link)
-		sql_expr_list_delete(sql_get(), fk->selfref_cols);
+		sql_expr_list_delete(fk->selfref_cols);
 }
 
 #endif /* TARANTOOL_BOX_SQL_PARSE_DEF_H_INCLUDED */

--- a/src/box/sql/port.c
+++ b/src/box/sql/port.c
@@ -249,7 +249,6 @@ static int
 port_sql_dump_msgpack(struct port *port, struct obuf *out)
 {
 	assert(port->vtab == &port_sql_vtab);
-	sql *db = sql_get();
 	struct port_sql *sql_port = (struct port_sql *)port;
 	struct sql_stmt *stmt = sql_port->stmt;
 	switch (sql_port->serialization_format) {
@@ -293,7 +292,7 @@ port_sql_dump_msgpack(struct port *port, struct obuf *out)
 		pos = mp_encode_uint(pos, IPROTO_SQL_INFO);
 		pos = mp_encode_map(pos, map_size);
 		uint64_t id_count = 0;
-		int changes = db->nChange;
+		int changes = sql_get()->nChange;
 		size = mp_sizeof_uint(SQL_INFO_ROW_COUNT) +
 		       mp_sizeof_uint(changes);
 		if (!stailq_empty(autoinc_id_list)) {

--- a/src/box/sql/pragma.c
+++ b/src/box/sql/pragma.c
@@ -327,33 +327,16 @@ sqlPragma(struct Parse *pParse, struct Token *pragma, struct Token *table,
 {
 	char *table_name = NULL;
 	char *index_name = NULL;
-	struct sql *db = pParse->db;
 	struct Vdbe *v = sqlGetVdbe(pParse);
 
-	if (v == NULL)
-		return;
 	sqlVdbeRunOnlyOnce(v);
 	pParse->nMem = 2;
 
-	char *pragma_name = sql_name_from_token(db, pragma);
-	if (pragma_name == NULL) {
-		pParse->is_aborted = true;
-		goto pragma_out;
-	}
-	if (table != NULL) {
-		table_name = sql_name_from_token(db, table);
-		if (table_name == NULL) {
-			pParse->is_aborted = true;
-			goto pragma_out;
-		}
-	}
-	if (index != NULL) {
-		index_name = sql_name_from_token(db, index);
-		if (index_name == NULL) {
-			pParse->is_aborted = true;
-			goto pragma_out;
-		}
-	}
+	char *pragma_name = sql_name_from_token(pragma);
+	if (table != NULL)
+		table_name = sql_name_from_token(table);
+	if (index != NULL)
+		index_name = sql_name_from_token(index);
 
 	/* Locate the pragma in the lookup table */
 	const struct PragmaName *pPragma = pragmaLocate(pragma_name);
@@ -390,7 +373,7 @@ sqlPragma(struct Parse *pParse, struct Token *pragma, struct Token *table,
 	}
 
  pragma_out:
-	sqlDbFree(db, pragma_name);
-	sqlDbFree(db, table_name);
-	sqlDbFree(db, index_name);
+	sql_xfree(pragma_name);
+	sql_xfree(table_name);
+	sql_xfree(index_name);
 }

--- a/src/box/sql/tarantoolInt.h
+++ b/src/box/sql/tarantoolInt.h
@@ -134,7 +134,6 @@ sql_encode_table_opts(struct region *region, struct space_def *def,
  * @param fk FK def to encode links of.
  * @param[out] Size size of result allocation.
  *
- * @retval NULL Error.
  * @retval not NULL Pointer to msgpack on success.
  */
 char *

--- a/src/box/sql/treeview.c
+++ b/src/box/sql/treeview.c
@@ -49,9 +49,7 @@ static TreeView *
 sqlTreeViewPush(TreeView * p, u8 moreToFollow)
 {
 	if (p == 0) {
-		p = sql_malloc64(sizeof(*p));
-		if (p == 0)
-			return 0;
+		p = xmalloc(sizeof(*p));
 		memset(p, 0, sizeof(*p));
 	} else {
 		p->iLevel++;
@@ -72,7 +70,7 @@ sqlTreeViewPop(TreeView * p)
 		return;
 	p->iLevel--;
 	if (p->iLevel < 0)
-		sql_free(p);
+		free(p);
 }
 
 /*
@@ -86,7 +84,7 @@ sqlTreeViewLine(TreeView * p, const char *zFormat, ...)
 	int i;
 	StrAccum acc;
 	char zBuf[500];
-	sqlStrAccumInit(&acc, 0, zBuf, sizeof(zBuf), 0);
+	sqlStrAccumInit(&acc, zBuf, sizeof(zBuf), 0);
 	if (p) {
 		for (i = 0;
 		     i < p->iLevel && (unsigned int)i < sizeof(p->bLine) - 1;
@@ -140,7 +138,7 @@ sqlTreeViewWith(TreeView * pView, const With * pWith)
 			StrAccum x;
 			char zLine[1000];
 			const struct Cte *pCte = &pWith->a[i];
-			sqlStrAccumInit(&x, 0, zLine, sizeof(zLine), 0);
+			sqlStrAccumInit(&x, zLine, sizeof(zLine), 0);
 			sqlXPrintf(&x, "%s", pCte->zName);
 			if (pCte->pCols && pCte->pCols->nExpr > 0) {
 				char cSep = '(';
@@ -216,8 +214,7 @@ sqlTreeViewSelect(TreeView * pView, const Select * p, u8 moreToFollow)
 				struct SrcList_item *pItem = &p->pSrc->a[i];
 				StrAccum x;
 				char zLine[100];
-				sqlStrAccumInit(&x, 0, zLine, sizeof(zLine),
-						    0);
+				sqlStrAccumInit(&x, zLine, sizeof(zLine), 0);
 				sqlXPrintf(&x, "{%d,*}", pItem->iCursor);
 				if (pItem->zName) {
 					sqlXPrintf(&x, " %s", pItem->zName);

--- a/src/box/sql/update.c
+++ b/src/box/sql/update.c
@@ -56,7 +56,6 @@ sqlUpdate(Parse * pParse,		/* The parser context */
 	int addrTop = 0;	/* VDBE instruction address of the start of the loop */
 	WhereInfo *pWInfo;	/* Information about the WHERE clause */
 	Vdbe *v;		/* The virtual database engine */
-	sql *db;		/* The database structure */
 	int *aXRef = 0;		/* aXRef[i] is the index in pChanges->a[] of the
 				 * an expression for the i-th column of the table.
 				 * aXRef[i]==-1 if the i-th column is not changed.
@@ -84,10 +83,8 @@ sqlUpdate(Parse * pParse,		/* The parser context */
 	/* Count of changed rows. Match aXRef items != -1. */
 	int upd_cols_cnt = 0;
 
-	db = pParse->db;
-	if (pParse->is_aborted || db->mallocFailed) {
+	if (pParse->is_aborted)
 		goto update_cleanup;
-	}
 	assert(pTabList->nSrc == 1);
 
 	/* Locate the table which we want to update.
@@ -438,9 +435,7 @@ sqlUpdate(Parse * pParse,		/* The parser context */
 
 			/* Prepare array of changed fields. */
 			uint32_t upd_cols_sz = upd_cols_cnt * sizeof(uint32_t);
-			uint32_t *upd_cols = sqlDbMallocRaw(db, upd_cols_sz);
-			if (upd_cols == NULL)
-				goto update_cleanup;
+			uint32_t *upd_cols = sql_xmalloc(upd_cols_sz);
 			upd_cols_cnt = 0;
 			for (uint32_t i = 0; i < def->field_count; i++) {
 				if (aXRef[i] == -1)
@@ -474,8 +469,8 @@ sqlUpdate(Parse * pParse,		/* The parser context */
 	sqlVdbeResolveLabel(v, labelBreak);
 
  update_cleanup:
-	sqlSrcListDelete(db, pTabList);
-	sql_expr_list_delete(db, pChanges);
-	sql_expr_delete(db, pWhere);
+	sqlSrcListDelete(pTabList);
+	sql_expr_list_delete(pChanges);
+	sql_expr_delete(pWhere);
 	return;
 }

--- a/src/box/sql/vdbetrace.c
+++ b/src/box/sql/vdbetrace.c
@@ -70,7 +70,7 @@ findNextHostParameter(const char *zSql, int *pnToken)
 
 /*
  * This function returns a pointer to a nul-terminated string in memory
- * obtained from sqlDbMalloc(). If sql.nVdbeExec is 1, then the
+ * obtained from sql_xmalloc(). If sql.nVdbeExec is 1, then the
  * string contains a copy of zRawSql but with host parameters expanded to
  * their current bindings. Or, if sql.nVdbeExec is greater than 1,
  * then the returned string holds a copy of zRawSql with "-- " prepended
@@ -92,7 +92,6 @@ sqlVdbeExpandSql(Vdbe * p,	/* The prepared statement being evaluated */
 		     const char *zRawSql	/* Raw text of the SQL statement */
     )
 {
-	sql *db;		/* The database connection */
 	int idx = 0;		/* Index of a host parameter */
 	int nextIndex = 1;	/* Index of next ? host parameter */
 	int n;			/* Length of a token prefix */
@@ -100,10 +99,8 @@ sqlVdbeExpandSql(Vdbe * p,	/* The prepared statement being evaluated */
 	StrAccum out;		/* Accumulate the output here */
 	char zBase[100];	/* Initial working space */
 
-	db = p->db;
-	sqlStrAccumInit(&out, 0, zBase, sizeof(zBase),
-			    db->aLimit[SQL_LIMIT_LENGTH]);
-	if (db->nVdbeExec > 1) {
+	sqlStrAccumInit(&out, zBase, sizeof(zBase), SQL_MAX_LENGTH);
+	if (sql_get()->nVdbeExec > 1) {
 		while (*zRawSql) {
 			const char *zStart = zRawSql;
 			while (*(zRawSql++) != '\n' && *zRawSql) ;


### PR DESCRIPTION
This patch refactors the SQL memory allocation system. There are three main changes:
1) now, when allocating memory, no additional 8 bytes are allocated to remember the size of the allocated memory, so instead of sql_malloc()/sqlRealloc()/sql_free(), the malloc()/realloc()/free() functions are used;
2) the malloc()/realloc() functions were used through the xmalloc()/xrealloc() macros, so checks for memory allocation errors were removed;
3) there is no need for an explicit "sql *db" argument for most of the functions, so it has been omitted.

Part of #1544

NO_DOC=refactoring
NO_TEST=refactoring
NO_CHANGELOG=refactoring