### PR TITLE
test: fix flaky gh_6539_log_user_space_empty_or_nil_select_test

### DIFF
--- a/test/box-luatest/gh_6539_log_user_space_empty_or_nil_select_test.lua
+++ b/test/box-luatest/gh_6539_log_user_space_empty_or_nil_select_test.lua
@@ -119,9 +119,11 @@ for _, eng in pairs{'memtx', 'vinyl'} do
         for _, call_fmt in pairs(dangerous_call_fmts) do
             local call = call_fmt:format(space)
             g.server:eval(call)
-            t.assert(g.server:grep_log(expected_log_entry, grep_log_bytes),
-                     ('log must contain a critical entry ' ..
-                      'about `%s` call on a %s user space'):format(call, eng))
+            t.helpers.retrying({}, function()
+                t.assert(g.server:grep_log(expected_log_entry, grep_log_bytes),
+                         ('log must contain a critical entry ' ..
+                          'about `%s` call on a %s user space'):format(call, eng))
+            end)
             fio.truncate(log_file)
         end
     end


### PR DESCRIPTION
The test fails with:
```
not ok 2 box-luatest.gh_6539_log_user_space_empty_or_nil_select.test_log_entry_presence_for_memtx_user_space
gh_6539_log_user_space_empty_or_nil_select_test.lua:122: log must contain a critical entry about `box.space.test_memtx:select({0}, {limit = 1001, iterator = "ALL"})` call on a memtx user space
expected: a value evaluating to true, actual: nil
```
Looks like it happens, because `g.server:grep_log()` is executed before `g.server:eval(call)` completes writing to the log. In other tests `grep_log()` is wrapped into `t.helpers.retrying()` in order to avoid such issues, so do the same here.

May _close tarantool/tarantool-qa#264
Let's commit it and wait a bit to see whether it stops flaking.