### PR TITLE
backtrace: update `sp` before saving registers to a stack frame

### DIFF
--- a/changelogs/unreleased/gh-7523-sigsegv-on-m1-macs.md
+++ b/changelogs/unreleased/gh-7523-sigsegv-on-m1-macs.md
@@ -1,4 +1,4 @@
 ## bugfix/core
 
 * Fixed a bug in fiber switching that could lead to a segmentation fault error
-  on M1/M2 Macs (gh-7523).
+  on AArch64 systems (gh-7523, gh-7985).


### PR DESCRIPTION
`backtrace_collect()` is suffering from the same issue as `coro_transfer()`, see commit https://github.com/tarantool/tarantool/commit/215630e6f6c429f96c7d210b200d9d241c374f9a ("coro: update sp before saving registers to a stack frame").

It stores `x19-x30` and `d8-d15` registers to the stack, but only after that it updates the stack pointer. If a `SIGALRM` signal is delivered during the execution of `backtrace_collect`, the signal handler will use the stack starting from current `sp`, thus corrupting the saved registers.

Fix this by updating the stack pointer at the beginning of `backtrace_collect`. The constraint of the input operand `bt` is changed from `"m"` to `"r"` to force `bt` always be passed to the inline assembly via the register. Passing on stack will not work after this fix.

Closes https://github.com/tarantool/tarantool/issues/7985