### PR TITLE
[backport/1.10] fiber: fix assertion fail in `cord_on_yield`

### DIFF
--- a/changelogs/unreleased/gh-6647-yield-gc-hook.md
+++ b/changelogs/unreleased/gh-6647-yield-gc-hook.md
@@ -1,0 +1,3 @@
+## bugfix/fiber
+
+* Fixed the assertion fail in `cord_on_yield` (gh-6647).

--- a/src/lua/utils.c
+++ b/src/lua/utils.c
@@ -696,7 +696,7 @@ void cord_on_yield(void)
 		 * world and one can obtain the corresponding Lua
 		 * coroutine from the fiber storage.
 		 */
-		struct lua_State *L = fiber()->storage.lua.stack;
+		struct lua_State *L = gco2th(gcref(g->cur_L));
 		assert(L != NULL);
 		lua_pushfstring(L, "fiber %d is switched while running the"
 				" compiled code (it's likely a function with"
@@ -726,7 +726,7 @@ void cord_on_yield(void)
 	 * GC hook is active and the platform is forced to stop.
 	 */
 	if (unlikely(g->hookmask & HOOK_GC)) {
-		struct lua_State *L = fiber()->storage.lua.stack;
+		struct lua_State *L = gco2th(gcref(g->cur_L));
 		assert(L != NULL);
 		lua_pushfstring(L, "fiber %d is switched while running GC"
 				" finalizer (i.e. __gc metamethod)",

--- a/test/box-luatest/gh_6647_yield_gc_hook_test.lua
+++ b/test/box-luatest/gh_6647_yield_gc_hook_test.lua
@@ -1,0 +1,83 @@
+#!/usr/bin/env tarantool
+
+local t = require('luatest')
+local g = t.group('gh-6647-yield-gc-hook')
+local fio = require('fio')
+
+local tarantool_bin = arg[-1]
+local PANIC = 256
+local ERRMSG = 'fiber [0-9]+ is switched while running GC finalizer'
+
+local function check_log(t, filename, pattern)
+    local file = fio.open(filename, {'O_RDONLY'})
+    assert(file ~= nil)
+
+    local size = file:stat().size
+    assert(size ~= 0)
+
+    local log_contents = file:pread(size, 0)
+    file:close()
+    assert(log_contents ~= '')
+    t.assert_str_contains(log_contents, pattern, true, 'invalid error message')
+end
+
+local function check_case(t, code, logfile, case_name)
+    local dir = fio.tempdir()
+    local script_path = fio.pathjoin(dir, 'script.lua')
+    local script = fio.open(script_path, {'O_CREAT', 'O_WRONLY', 'O_TRUNC'},
+        tonumber('0777', 8))
+    script:write(code)
+    script:write("\nos.exit(0)")
+    script:close()
+    local cmd = [[/bin/sh -c 'cd "%s" && "%s" ./script.lua 2>&1 /dev/null']]
+    local res = os.execute(string.format(cmd, dir, tarantool_bin))
+
+    check_log(t, fio.pathjoin(dir, logfile), ERRMSG)
+    t.assert_equals(res, PANIC,
+        'fail on fiber switch in GC finalizer: ' .. case_name)
+
+    fio.rmtree(dir)
+    return res
+end
+
+g.test_lua_iproto_call = function()
+    local lua_iproto_call = [[
+    box.cfg({listen = 'unix/:./tarantool.sock', log = 'gh-6647.log'})
+    box.schema.user.grant('guest', 'super')
+    local ffi = require('ffi')
+    local fiber = require('fiber')
+    local net_box = require('net.box')
+    local c = net_box.connect('unix/:./tarantool.sock')
+    function f()
+        local t = {__gh_hook = ffi.gc(ffi.new('void *'), fiber.yield)}
+        t = nil
+        collectgarbage()
+    end
+    c:call('f')
+    ]]
+    check_case(t, lua_iproto_call, 'gh-6647.log', 'lua_iproto_call')
+end
+
+g.test_space_trigger = function()
+    local space_trigger = [[
+    box.cfg({listen = 'unix/:./tarantool.sock', log = 'gh-6647.log'})
+    box.schema.user.grant('guest', 'super')
+    local ffi = require('ffi')
+    local net_box = require('net.box')
+    local fiber = require('fiber')
+
+    local function on_replace()
+      local t = {__gh_hook = ffi.gc(ffi.new('void *'), fiber.yield)}
+      t = nil
+      collectgarbage()
+    end
+
+    box.schema.space.create('myspace')
+    box.space.myspace:create_index('test_index',{})
+    box.space.myspace:on_replace(on_replace)
+    local c = net_box.connect('unix/:./tarantool.sock')
+    c.space.myspace:insert{1,'Hi'}
+    ]]
+    check_case(t, space_trigger, 'gh-6647.log', 'space trigger')
+end
+


### PR DESCRIPTION
Background fibers (they serve binary protocol requests) do not store a Lua state in the fiber storage even for Lua call / eval requests.

Before the patch, fiber->storage.lua.stack is filled only for the main fiber and fibers created from Lua using fiber.create() or fiber.new(), but not for background fibers (which serve binary protocol requests). That may lead to a PANIC in `cord_on_yield`.

This patch fills fiber->storage.lua.stack for background fibers that serve a Lua call or eval.

For more, see https://github.com/tarantool/tarantool/commit/0d81bc5d0742ef6660fe001fcf3e9d2a2b0166dd