### PR TITLE
box: fix typo in tuple_field_map_create_plain

### DIFF
--- a/src/box/tuple_format.c
+++ b/src/box/tuple_format.c
@@ -1016,7 +1016,7 @@ tuple_field_map_create_plain(struct tuple_format *format, const char *tuple,
 
 	void *required_fields = NULL;
 	uint32_t required_fields_sz = BITMAP_SIZE(format->total_field_count);
-	size_t region_svp = region_svp = region_used(&fiber()->gc);
+	size_t region_svp = region_used(&fiber()->gc);
 
 	if (unlikely(defined_field_count == 0)) {
 		required_fields = format->required_fields;


### PR DESCRIPTION
Discovered by Coverity:

https://scan7.scan.coverity.com/reports.htm#v43693/p13437/fileInstanceId=130384650&defectInstanceId=18636974&mergedDefectId=1527607

Follow-up #5665

NO_TEST=nit
NO_CHANGELOG=nit
NO_DOC=nit