### PR TITLE
msgpack: add translation of first-level `MP_MAP` keys during encoding

### DIFF
--- a/src/box/tuple_dictionary.c
+++ b/src/box/tuple_dictionary.c
@@ -29,36 +29,13 @@
  * SUCH DAMAGE.
  */
 #include "tuple_dictionary.h"
+#include "assoc.h"
 #include "error.h"
 #include "diag.h"
 
 #include "PMurHash.h"
 
 field_name_hash_f field_name_hash;
-
-#define mh_name _strnu32
-struct mh_strnu32_key_t {
-	const char *str;
-	size_t len;
-	uint32_t hash;
-};
-#define mh_key_t struct mh_strnu32_key_t *
-struct mh_strnu32_node_t {
-	const char *str;
-	size_t len;
-	uint32_t hash;
-	uint32_t val;
-};
-#define mh_node_t struct mh_strnu32_node_t
-
-#define mh_arg_t void *
-#define mh_hash(a, arg) ((a)->hash)
-#define mh_hash_key(a, arg) mh_hash(a, arg)
-#define mh_cmp(a, b, arg) ((a)->len != (b)->len || \
-			   memcmp((a)->str, (b)->str, (a)->len))
-#define mh_cmp_key(a, b, arg) mh_cmp(a, b, arg)
-#define MH_SOURCE 1
-#include "salad/mhash.h" /* Create mh_strnu32_t hash. */
 
 /** Free names hash and its content. */
 static inline void

--- a/src/lib/core/assoc.h
+++ b/src/lib/core/assoc.h
@@ -134,8 +134,60 @@ mh_strnptr_find_str(struct mh_strnptr_t *h, const char *str, uint32_t len)
 	uint32_t hash = mh_strn_hash(str, len);
 	struct mh_strnptr_key_t key = {str, len, hash};
 	return mh_strnptr_find(h, &key, NULL);
+}
+
+/*
+ * Map: (char * with length) => (uint32_t)
+ */
+#define mh_name _strnu32
+/**
+ * Key of `mh_strnu32_node_t` hash table.
+ */
+struct mh_strnu32_key_t {
+	/* Key string. */
+	const char *str;
+	/* Key length. */
+	size_t len;
+	/* Key hash calculated using `mh_strn_hash`. */
+	uint32_t hash;
 };
 
+#define mh_key_t struct mh_strnu32_key_t *
+
+/**
+ * Node of `mh_strnu32_node_t` hash table.
+ */
+struct mh_strnu32_node_t {
+	/* Key string. */
+	const char *str;
+	/* Key length. */
+	size_t len;
+	/* Key hash calculated using `mh_strn_hash`. */
+	uint32_t hash;
+	/* Mapped value. */
+	uint32_t val;
+};
+
+#define mh_node_t struct mh_strnu32_node_t
+
+#define mh_arg_t void *
+#define mh_hash(a, arg) ((a)->hash)
+#define mh_hash_key(a, arg) mh_hash(a, arg)
+#define mh_cmp(a, b, arg) ((a)->len != (b)->len || \
+			   memcmp((a)->str, (b)->str, (a)->len))
+#define mh_cmp_key(a, b, arg) mh_cmp(a, b, arg)
+#include "salad/mhash.h"
+
+/**
+ * Helper for looking up strings in `mh_strnu32_t` hash table.
+ */
+static inline mh_int_t
+mh_strnu32_find_str(struct mh_strnu32_t *h, const char *str, uint32_t len)
+{
+	uint32_t hash = mh_strn_hash(str, len);
+	struct mh_strnu32_key_t key = {str, len, hash};
+	return mh_strnu32_find(h, &key, NULL);
+}
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -577,3 +577,12 @@ create_unit_test(PREFIX lua_utils
                            ${LIBYAML_LIBRARIES}
                            ${READLINE_LIBRARIES}
 )
+
+create_unit_test(PREFIX lua_msgpack
+                 SOURCES lua_msgpack.c
+                 LIBRARIES unit core server
+                           ${LUAJIT_LIBRARIES}
+                           ${CURL_LIBRARIES}
+                           ${LIBYAML_LIBRARIES}
+                           ${READLINE_LIBRARIES}
+)

--- a/test/unit/lua_msgpack.c
+++ b/test/unit/lua_msgpack.c
@@ -1,0 +1,134 @@
+#include <lualib.h>
+
+#include "core/assoc.h"
+#include "core/cord_buf.h"
+#include "core/fiber.h"
+#include "core/memory.h"
+
+#include "lua/msgpack.h"
+#include "lua/serializer.h"
+
+#include "mpstream/mpstream.h"
+
+#include "small/ibuf.h"
+
+#define UNIT_TAP_COMPATIBLE 1
+#include "unit.h"
+
+static void
+mpstream_error_mock(void *ctx)
+{
+	(void)ctx;
+}
+
+/**
+ * Checks that translation of first-level `MP_MAP` keys is done correctly.
+ */
+static void
+test_translation_in_encoding(lua_State *L)
+{
+	plan(4);
+	header();
+
+	struct mh_strnu32_t *translation = mh_strnu32_new();
+	const char *alias = "x";
+	struct mh_strnu32_node_t node = {
+		.str = alias,
+		.len = strlen(alias),
+		.hash = mh_strn_hash(alias, strlen(alias)),
+		.val = 0
+	};
+	mh_strnu32_put(translation, &node, NULL, NULL);
+
+	struct ibuf *ibuf = cord_ibuf_take();
+	struct mpstream stream;
+	mpstream_init(&stream, ibuf, ibuf_reserve_cb, ibuf_alloc_cb,
+		      mpstream_error_mock, L);
+
+	lua_createtable(L, 0, 1);
+	lua_pushboolean(L, true);
+	lua_setfield(L, 1, alias);
+	luamp_encode_with_translation(L, luaL_msgpack_default, &stream, 1,
+				      translation);
+	lua_pop(L, 1);
+	mpstream_flush(&stream);
+	ok(strncmp(ibuf->buf, "\x81\x00\xc3", ibuf_used(ibuf)) == 0,
+	   "first-level MP_MAP key is translated");
+	ibuf_reset(ibuf);
+	mpstream_reset(&stream);
+
+	lua_createtable(L, 0, 1);
+	lua_createtable(L, 0, 1);
+	lua_pushboolean(L, true);
+	lua_setfield(L, -2, alias);
+	lua_setfield(L, -2, "k");
+	luamp_encode_with_translation(L, luaL_msgpack_default, &stream, 1,
+				      translation);
+	lua_pop(L, 1);
+	mpstream_flush(&stream);
+	ok(strncmp(ibuf->buf, "\x81\xa1k\x81\xa1x\xc3", ibuf_used(ibuf)) == 0,
+	   "only first-level MP_MAP key is translated");
+	ibuf_reset(ibuf);
+	mpstream_reset(&stream);
+
+	lua_createtable(L, 0, 1);
+	lua_pushnumber(L, 0);
+	lua_pushboolean(L, true);
+	lua_settable(L, -3);
+	luamp_encode_with_translation(L, luaL_msgpack_default, &stream, 1,
+				      translation);
+	mpstream_flush(&stream);
+	ok(strncmp(ibuf->buf, "\x81\x00\xc3", ibuf_used(ibuf)) == 0,
+	   "only keys with MP_STRING type are translated");
+	ibuf_reset(ibuf);
+	mpstream_reset(&stream);
+
+	lua_createtable(L, 0, 1);
+	lua_pushboolean(L, true);
+	lua_setfield(L, 1, alias);
+	lua_pushnumber(L, 0);
+	lua_pushboolean(L, false);
+	lua_settable(L, -3);
+	luamp_encode_with_translation(L, luaL_msgpack_default, &stream, 1,
+				      translation);
+	lua_pop(L, 1);
+	mpstream_flush(&stream);
+	ok(strncmp(ibuf->buf, "\x82\x00\xc2\x00\xc3", ibuf_used(ibuf)) == 0,
+	   "first-level MP_MAP key that has translation along with first-level "
+	   "MP_MAP key that is the value of the translation are translated "
+	   "correctly");
+	ibuf_reset(ibuf);
+	mpstream_reset(&stream);
+
+	cord_ibuf_drop(ibuf);
+	mh_strnu32_delete(translation);
+
+	footer();
+	check_plan();
+}
+
+int
+main(void)
+{
+	plan(1);
+	header();
+
+	struct lua_State *L = luaL_newstate();
+	luaL_openlibs(L);
+	tarantool_L = L;
+	memory_init();
+	fiber_init(fiber_c_invoke);
+	tarantool_lua_serializer_init(L);
+	luaopen_msgpack(L);
+	lua_pop(L, 1);
+
+	test_translation_in_encoding(L);
+
+	fiber_free();
+	memory_free();
+	lua_close(L);
+	tarantool_L = NULL;
+
+	footer();
+	return check_plan();
+}


### PR DESCRIPTION
Needed for #7897