### PR TITLE
libunwind: use latest release v1.6.2 as a base

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -59,7 +59,7 @@
 [submodule "third_party/libunwind"]
 	path = third_party/libunwind
 	url = https://github.com/tarantool/libunwind.git
-	branch = libunwind-f67ef28-tarantool
+	branch = libunwind-1.6.2-tarantool
 [submodule "third_party/tz"]
 	path = third_party/tz
 	url = https://github.com/tarantool/tz.git

--- a/cmake/BuildLibUnwind.cmake
+++ b/cmake/BuildLibUnwind.cmake
@@ -37,6 +37,7 @@ macro(libunwind_build)
                         DOWNLOAD_COMMAND ""
 
                         CONFIGURE_COMMAND
+                        autoreconf -i <SOURCE_DIR> &&
                         <SOURCE_DIR>/configure
                         AR=${CMAKE_AR}
                         CC=${CMAKE_C_COMPILER}
@@ -69,7 +70,6 @@ macro(libunwind_build)
                         # See https://github.com/libunwind/libunwind/blob/e07b43c02d5cf1ea060c018fdf2e2ad34b7c7d80/configure.ac#L319-L334
                         --disable-zlibdebuginfo
 
-                        LOG_CONFIGURE TRUE
                         LOG_BUILD TRUE
                         LOG_INSTALL TRUE
                         LOG_MERGED_STDOUTERR TRUE

--- a/debian/control
+++ b/debian/control
@@ -33,6 +33,8 @@ Build-Depends: cdbs (>= 0.4.100), debhelper (>= 9), dpkg-dev (>= 1.16.1~),
  python3-yaml,
 # needed for datetime tests
  tzdata,
+# For third-party subprojects that are built with autotools.
+ autoconf, automake, libtool,
 Section: database
 Standards-Version: 4.5.1
 Homepage: http://tarantool.org/

--- a/rpm/tarantool.spec
+++ b/rpm/tarantool.spec
@@ -112,6 +112,11 @@ BuildRequires: tzdata
 # Install prove to run LuaJIT tests.
 BuildRequires: perl-Test-Harness
 
+# For third-party subprojects that are built with autotools.
+BuildRequires: autoconf
+BuildRequires: automake
+BuildRequires: libtool
+
 Name: tarantool
 # ${major}.${major}.${minor}.${patch}, e.g. 1.6.8.175
 # Version is updated automaically using git describe --long --always


### PR DESCRIPTION
Now we base on on some unreleased state of libunwind. This is by itself not a good practice. Yet the main motivation is that in the current version of libunwind fast path for backtrace detection on x86_64 does not work. I guess it is because of f67ef2867bc5 (" x86_64: Stop aliasing RSP and CFA"). See libunwind/libunwind#440. Fortunately this commit is not present it the latest release.

Using fast or slow path has a great impact on performance of debug build where collecting fiber gc allocation backtrace is turned on by default. It surely depends on frequency and pattern of allocation. Test sql/delete3 depends on backtrace performance most dramatically. On some installations collecting backtraces slowed down the test up to 10 times.

If fast path is available then collecting backtrace does not affect performance in a noticeable way.

I propose not to keep autotools products in the libunwind fork repo as it is done previously. LOG_CONFIGURE is removed because it somehow incompatible with using && in CONFIGURE_COMMAND command and not critical to the build.

Follow-up #5665

NO_DOC=internal
NO_TEST=internal
NO_CHANGELOG=internal