### PR TITLE
cmake: fix wrong CPU architecture reported on M1/M2 Macs

### DIFF
--- a/changelogs/unreleased/gh-7495-wrong-arch-reported-on-m1-macs.md
+++ b/changelogs/unreleased/gh-7495-wrong-arch-reported-on-m1-macs.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed wrong CPU architecture reported in `tarantool.build.target` on M1/M2
+  Macs (gh-7495).

--- a/cmake/arch.cmake
+++ b/cmake/arch.cmake
@@ -20,15 +20,3 @@ if (${HAVE_BYTE_ORDER_BIG_ENDIAN} OR
     message (FATAL_ERROR "Tarantool currently only supports little-endian hardware")
     message (FATAL_ERROR "with unaligned word access.")
 endif()
-
-#
-# Bug in CMake, Darwin always detect on i386
-# Fixed with check types
-#
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-    if (CMAKE_SIZEOF_VOID_P MATCHES 8)
-        set(CMAKE_SYSTEM_PROCESSOR "x86_64")
-    else(CMAKE_SIZEOF_VOID_P MATCHES 8)
-        set(CMAKE_SYSTEM_PROCESSOR "x86")
-    endif(CMAKE_SIZEOF_VOID_P MATCHES 8)
-endif()

--- a/test/app-luatest/gh_7495_tarantool_build_target_test.lua
+++ b/test/app-luatest/gh_7495_tarantool_build_target_test.lua
@@ -1,0 +1,10 @@
+local t = require('luatest')
+local g = t.group('gh-7495')
+
+-- Check that `tarantool.build.target` contains the same CPU architecture as
+-- reported by `uname -m`.
+g.test_build_target = function()
+    local tarantool = require('tarantool')
+    local arch_name = io.popen('uname -m'):read()
+    t.assert_str_contains(tarantool.build.target, '-' .. arch_name .. '-')
+end


### PR DESCRIPTION
This patch removes an old CMake kludge, which sets `CMAKE_SYSTEM_PROCESSOR` to `x86_64` on all 64-bit architectures, even on ARM (on Darwin).

Closes https://github.com/tarantool/tarantool/issues/7495