### PR TITLE
ci: prepare workspace before actions/checkout

### DIFF
--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -47,7 +47,8 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/centos_7_aarch64.yml
+++ b/.github/workflows/centos_7_aarch64.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: graviton
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -47,7 +47,8 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/centos_8_aarch64.yml
+++ b/.github/workflows/centos_8_aarch64.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: graviton
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,6 +28,9 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
+    - name: Prepare checkout
+      uses: tarantool/actions/prepare-checkout@master
+
     - name: Checkout repository
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,8 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - name: Sources checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -19,6 +19,8 @@ jobs:
       options: '--init'
 
     steps:
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -47,7 +47,8 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/debian_10_aarch64.yml
+++ b/.github/workflows/debian_10_aarch64.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: graviton
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -47,7 +47,8 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/debian_11_aarch64.yml
+++ b/.github/workflows/debian_11_aarch64.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: graviton
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -47,7 +47,8 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - name: Sources checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: graviton
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -45,7 +45,8 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -47,7 +47,8 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_34_aarch64.yml
+++ b/.github/workflows/fedora_34_aarch64.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: graviton
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_35.yml
+++ b/.github/workflows/fedora_35.yml
@@ -47,7 +47,8 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_35_aarch64.yml
+++ b/.github/workflows/fedora_35_aarch64.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: graviton
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_36.yml
+++ b/.github/workflows/fedora_36.yml
@@ -47,7 +47,8 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/fedora_36_aarch64.yml
+++ b/.github/workflows/fedora_36_aarch64.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: graviton
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/freebsd-12.yml
+++ b/.github/workflows/freebsd-12.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: freebsd-12-mcs
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/freebsd-13.yml
+++ b/.github/workflows/freebsd-13.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: freebsd-13-mcs
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/jepsen-cluster-txm.yml
+++ b/.github/workflows/jepsen-cluster-txm.yml
@@ -16,6 +16,8 @@ jobs:
         - 2222:22
 
     steps:
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/jepsen-cluster.yml
+++ b/.github/workflows/jepsen-cluster.yml
@@ -16,6 +16,8 @@ jobs:
         - 2222:22
 
     steps:
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/jepsen-single-instance-txm.yml
+++ b/.github/workflows/jepsen-single-instance-txm.yml
@@ -21,6 +21,8 @@ jobs:
         - 2222:22
 
     steps:
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/jepsen-single-instance.yml
+++ b/.github/workflows/jepsen-single-instance.yml
@@ -21,6 +21,8 @@ jobs:
         - 2222:22
 
     steps:
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -68,7 +69,8 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       # We don't need neither deep fetch, nor submodules here.
       - uses: actions/checkout@v3
       # Don't use actions/setup-python to don't bother with proper
@@ -94,7 +96,8 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/luajit-integration.yml
+++ b/.github/workflows/luajit-integration.yml
@@ -47,8 +47,8 @@ jobs:
   luajit-integration:
     runs-on: [ self-hosted, '${{ inputs.host }}' ]
     steps:
-      - name: Prepare workspace
-        uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/osx_11.yml
+++ b/.github/workflows/osx_11.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: macos-11
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/osx_11_aarch64.yml
+++ b/.github/workflows/osx_11_aarch64.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: macos-11-m1
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/osx_11_aarch64_debug.yml
+++ b/.github/workflows/osx_11_aarch64_debug.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: macos-11-m1
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/osx_11_lto.yml
+++ b/.github/workflows/osx_11_lto.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: macos-11
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/osx_12.yml
+++ b/.github/workflows/osx_12.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: macos-12
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/osx_12_static_cmake.yml
+++ b/.github/workflows/osx_12_static_cmake.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: macos-12
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/publish-module-api-doc.yaml
+++ b/.github/workflows/publish-module-api-doc.yaml
@@ -36,7 +36,8 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'full-ci') )
     runs-on: ubuntu-latest
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/redos_7_3.yaml
+++ b/.github/workflows/redos_7_3.yaml
@@ -47,7 +47,8 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -27,6 +27,8 @@ jobs:
       OS: ${{ inputs.os }}
       DIST: ${{ inputs.dist }}
     steps:
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -16,7 +16,8 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -47,7 +47,8 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -47,7 +47,8 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -47,7 +47,8 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_20_04_aarch64.yml
+++ b/.github/workflows/ubuntu_20_04_aarch64.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: graviton
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -47,7 +47,8 @@ jobs:
         build-type: [ '', 'gc64' ]
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/ubuntu_22_04_aarch64.yml
+++ b/.github/workflows/ubuntu_22_04_aarch64.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: graviton
 
     steps:
-      - uses: tarantool/actions/cleanup@master
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0


### PR DESCRIPTION
* Prepare workspace before actions/checkout to prevent
  git-related workflow failures.
* Replace tarantool/actions/cleanup, because it solves 
  just the same problem.

Resolves tarantool/tarantool-qa#285