### PR TITLE
zlib CE part

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,8 +408,18 @@ endif()
 #
 # ZLIB
 #
-set(ZLIB_FIND_REQUIRED ON)
-find_package(ZLIB)
+
+#
+# If tarantool is built as a part of enterpirse version,
+# zlib package will be found there and the second attempt
+# to find it will cause an error. Search for it only if it
+# has not been found before.
+#
+
+if (NOT ZLIB_FOUND)
+    set(ZLIB_FIND_REQUIRED ON)
+    find_package(ZLIB)
+endif()
 
 #
 # ZZIP


### PR DESCRIPTION
Since we are going to introduce zlib compression in enterprise version, we need to find zlib package there, so let's search for zlib package only if it has not been found before.