### PR TITLE
lua: exclude _ prefix loop vars from unused check

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -23,6 +23,8 @@ ignore = {
     "432",
     -- Unused variable with `_` prefix.
     "212/_.*",
+    -- Unused loop variable with `_` prefix.
+    "213/_.*",
 }
 
 include_files = {


### PR DESCRIPTION
Update luacheckrc to suppress all warnings from lua loop vars with `_` prefix. This allows to make loops more verbose.

Closes #8006

NO_CHANGELOG=luacheckrc fix
NO_DOC=luacheckrc fix
NO_TEST=luacheckrc fix