### PR TITLE
test: fix flaky `gh_6539_log_user_space_empty_or_nil_select_test`

### DIFF
--- a/test/box-luatest/gh_6539_log_user_space_empty_or_nil_select_test.lua
+++ b/test/box-luatest/gh_6539_log_user_space_empty_or_nil_select_test.lua
@@ -9,6 +9,8 @@ g.before_all(function()
     g.server:start()
     g.server:exec(function()
         require("log").internal.ratelimit.disable()
+        -- Workaround for #8011
+        if jit.arch == 'arm64' then jit.off() end
     end)
 end)
 
@@ -18,7 +20,7 @@ end)
 
 local expected_log_entry_fmt =
     "C> Potentially long select from space '%s' %%(%d%%)"
-local grep_log_bytes = 256
+local grep_log_bytes = 1024
 local dangerous_call_fmts = {
     'box.space.%s:select(nil)',
     'box.space.%s:select({})',


### PR DESCRIPTION
Turn LuaJIT off for this test on AArch64 in the scope of the issue [1].

Also increase `grep_log_bytes`. Currently the message is 235 byte long, which is pretty close to 256. If one more item is added to the traceback, the test will fail.

```
C> Potentially long select from space 'test_memtx' (512)
 stack traceback:
        builtin/box/schema.lua:2528: in function 'check_select_safety'
        builtin/box/schema.lua:2545: in function 'select'
        eval:1: in main chunk
        [C]: at 0x556e8ffd5c
```

[1] Related to #8011 
Closes tarantool/tarantool-qa#264