### PR TITLE
[backport/2.10] luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-7230-luajit-fixes.md
+++ b/changelogs/unreleased/gh-7230-luajit-fixes.md
@@ -8,3 +8,9 @@ activity, the following issues have been resolved:
 * Fixed `emit_loadi()` on x86/x64 emitting xor between condition check
   and jump instructions.
 * Fix stack top for error message when raising the OOM error (gh-3840).
+* Enabled external unwinding on several LuaJIT platforms. Now it is possible to
+  handle ABI exceptions from Lua code (gh-6096).
+* Disabled math.modf compilation due to its rare usage and difficulties with
+  proper implementation of the corresponding JIT machinery.
+* Fixed inconsistent behaviour on signed zeros for JIT-compiled unary minus
+  (gh-6976).

--- a/changelogs/unreleased/gh-7919-sysprof-gc64.md
+++ b/changelogs/unreleased/gh-7919-sysprof-gc64.md
@@ -1,0 +1,3 @@
+## bugfix/luajit
+
+* Enabled the platform profiler for Tarantool built with GC64 mode (gh-7919).


### PR DESCRIPTION
* Fix narrowing of unary minus.
* Don't compile math.modf() anymore.
* OSX/ARM64: Fix external unwinding.
* Fix build with busybox grep.
* BSD: Fix build with BSD grep.
* OSX/ARM64: Disable unwind info.
* ARM64: Reorder interpreter stack frame and fix unwinding.
* OSX/ARM64: Disable external unwinding for now.
* OSX: Fix build by hardcoding external frame unwinding.
* Cleanup and enable external unwinding for more platforms.
* test: remove TAP side effects in getmetrics tests
* test: relax JIT setup in misc.getmetrics test
* test: relax JIT setup in lj-430-maxirconst test
* GC64: enable sysprof support

Closes #6096
Closes #6976
Closes #7919
Relates to #781
Relates to #7762
Part of #7230

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump
