### PR TITLE
[backport/1.10] luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-7230-luajit-fixes.md
+++ b/changelogs/unreleased/gh-7230-luajit-fixes.md
@@ -12,3 +12,7 @@ activity, the following issues have been resolved:
 * Fixed `emit_loadi()` on x86/x64 emitting xor between condition check
   and jump instructions.
 * Fix stack top for error message when raising the OOM error (gh-3840).
+* Disabled math.modf compilation due to its rare usage and difficulties with
+  proper implementation of the corresponding JIT machinery.
+* Fixed inconsistent behaviour on signed zeros for JIT-compiled unary minus
+  (gh-6976).


### PR DESCRIPTION
* Fix narrowing of unary minus.
* Don't compile math.modf() anymore.
* test: relax JIT setup in lj-430-maxirconst test

Closes #6976
Relates to #7762
Part of #7230

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump
