### PR TITLE
Authentication fixes

### DIFF
--- a/changelogs/unreleased/gh-8017-on-auth-no-such-user.md
+++ b/changelogs/unreleased/gh-8017-on-auth-no-such-user.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed the bug because of which `box.session.on_auth` triggers were not
+  invoked if the authenticated user didn't exist (gh-8017).

--- a/changelogs/unreleased/ghs-21-user-enumeration.md
+++ b/changelogs/unreleased/ghs-21-user-enumeration.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Eliminated the possibility of user enumeration by analyzing errors sent in
+  reply to malformed authentication requests (ghs-21).

--- a/src/box/authentication.cc
+++ b/src/box/authentication.cc
@@ -35,8 +35,6 @@
 #include "error.h"
 #include <base64.h>
 
-static char zero_hash[SCRAMBLE_SIZE];
-
 void
 authenticate(const char *user_name, uint32_t len, const char *salt,
 	     const char *tuple)
@@ -55,20 +53,13 @@ authenticate(const char *user_name, uint32_t len, const char *salt,
 	const char *scramble;
 	struct on_auth_trigger_ctx auth_res = { user->def->name, true };
 	/*
-	 * Allow authenticating back to GUEST user without
-	 * checking a password. This is useful for connection
-	 * pooling.
+	 * Allow authenticating back to the guest user without a password,
+	 * because the guest user isn't allowed to have a password, anyway.
+	 * This is useful for connection pooling.
 	 */
 	part_count = mp_decode_array(&tuple);
-	if (part_count == 0 && user->def->uid == GUEST) {
-		if (memcmp(user->def->hash2, zero_hash, SCRAMBLE_SIZE) == 0)
-			goto ok; /* no password is set, OK */
-		char hash2[SCRAMBLE_SIZE];
-		base64_decode(CHAP_SHA1_EMPTY_PASSWORD, SCRAMBLE_BASE64_SIZE,
-			      hash2, SCRAMBLE_SIZE);
-		if (memcmp(user->def->hash2, hash2, SCRAMBLE_SIZE) == 0)
-			goto ok; /* empty password is set, OK */
-	}
+	if (part_count == 0 && user->def->uid == GUEST)
+		goto ok;
 
 	access_check_session_xc(user);
 

--- a/src/box/authentication.h
+++ b/src/box/authentication.h
@@ -31,21 +31,35 @@
  * SUCH DAMAGE.
  */
 
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 /**
  * State passed to authentication trigger.
  */
 struct on_auth_trigger_ctx {
-	/** Authenticated user name. */
-	const char *username;
+	/** Authenticated user name. Not null-terminated! */
+	const char *user_name;
+	/** Length of the user_name string. */
+	size_t user_name_len;
 	/* true if authentication was successful */
 	bool is_authenticated;
 };
 
-
+/**
+ * Authenticates a user.
+ *
+ * Takes the following arguments:
+ * user_name: user name string, not necessarily null-terminated.
+ * user_name_len: length of the user name string.
+ * salt: random salt sent in the greeting message.
+ * tuple: value of the IPROTO_TUPLE key sent in the IPROTO_AUTH request body.
+ *
+ * Raises an exception on error.
+ */
 void
-authenticate(const char *user_name, uint32_t len, const char *salt,
-	     const char *tuple);
+authenticate(const char *user_name, uint32_t user_name_len,
+	     const char *salt, const char *tuple);
 
 #endif /* INCLUDES_TARANTOOL_BOX_AUTHENTICATION_H */

--- a/src/box/lua/session.c
+++ b/src/box/lua/session.c
@@ -293,8 +293,8 @@ lbox_push_on_connect_event(struct lua_State *L, void *event)
 static int
 lbox_push_on_auth_event(struct lua_State *L, void *event)
 {
-	struct on_auth_trigger_ctx *ctx = (struct on_auth_trigger_ctx *) event;
-	lua_pushstring(L, ctx->username);
+	struct on_auth_trigger_ctx *ctx = (struct on_auth_trigger_ctx *)event;
+	lua_pushlstring(L, ctx->user_name, ctx->user_name_len);
 	lua_pushboolean(L, ctx->is_authenticated);
 	return 2;
 }
@@ -342,7 +342,7 @@ static int
 lbox_session_run_on_auth(struct lua_State *L)
 {
 	struct on_auth_trigger_ctx ctx;
-	ctx.username = luaL_optstring(L, 1, "");
+	ctx.user_name = luaL_optlstring(L, 1, "", &ctx.user_name_len);
 	/*
 	 * In earlier versions of tarantool on_auth trigger
 	 * was not invoked on authentication failure and the

--- a/test/box-luatest/gh_8017_on_auth_no_such_user_test.lua
+++ b/test/box-luatest/gh_8017_on_auth_no_such_user_test.lua
@@ -1,0 +1,59 @@
+local net = require('net.box')
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+    cg.server:exec(function()
+        box.schema.user.create('bob', {password = 'secret'})
+        rawset(_G, 'last_auth', {})
+        box.session.on_auth(function(user, status)
+            _G.last_auth = {user, status}
+        end)
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_on_auth_success = function(cg)
+    local c = net.connect(cg.server.net_box_uri,
+                          {user = 'bob', password = 'secret'})
+    t.assert_equals(c.error, nil)
+    c:close()
+    cg.server:exec(function()
+        local t = require('luatest')
+        t.assert_equals(_G.last_auth, {'bob', true})
+        _G.last_auth = {}
+    end)
+end
+
+g.test_on_auth_invalid_password = function(cg)
+    local c = net.connect(cg.server.net_box_uri,
+                          {user = 'bob', password = 'foobar'})
+    t.assert_equals(c.error,
+                    'User not found or supplied credentials are invalid')
+    c:close()
+    cg.server:exec(function()
+        local t = require('luatest')
+        t.assert_equals(_G.last_auth, {'bob', false})
+        _G.last_auth = {}
+    end)
+end
+
+g.test_on_auth_no_such_user = function(cg)
+    local c = net.connect(cg.server.net_box_uri,
+                          {user = 'eve', password = 'foobar'})
+    t.assert_equals(c.error,
+                    'User not found or supplied credentials are invalid')
+    c:close()
+    cg.server:exec(function()
+        local t = require('luatest')
+        t.assert_equals(_G.last_auth, {'eve', false})
+        _G.last_auth = {}
+    end)
+end

--- a/test/box-luatest/ghs_16_user_enumeration_test.lua
+++ b/test/box-luatest/ghs_16_user_enumeration_test.lua
@@ -1,14 +1,54 @@
+local msgpack = require('msgpack')
 local net = require('net.box')
 local server = require('luatest.server')
+local socket = require('socket')
 local urilib = require('uri')
 local t = require('luatest')
 local g = t.group()
+
+local IPROTO_REQUEST_TYPE = 0
+local IPROTO_TYPE_ERROR = bit.lshift(1, 15)
+local IPROTO_AUTH = 7
+local IPROTO_TUPLE = 33
+local IPROTO_USER = 35
+local IPROTO_ERROR = 49
+
+-- Opens a new connection and sends IPROTO_AUTH request.
+-- Returns {code, error}
+local function auth(sock_path, user, tuple)
+    local hdr = msgpack.encode({[IPROTO_REQUEST_TYPE] = IPROTO_AUTH})
+    local body = msgpack.encode({
+        [IPROTO_USER] = user,
+        [IPROTO_TUPLE] = tuple,
+    })
+    local len = hdr:len() + body:len()
+    t.assert_lt(len, 256)
+    local s = socket.tcp_connect('unix/', sock_path)
+    local data = s:read(128) -- greeting
+    t.assert_equals(#data, 128)
+    data = '\xce\00\00\00' .. string.char(len) .. hdr .. body
+    t.assert_equals(s:write(data), #data) -- request
+    data = s:read(5) -- fixheader
+    t.assert_equals(#data, 5)
+    len = msgpack.decode(data)
+    data = s:read(len) -- response
+    t.assert_equals(#data, len)
+    s:close()
+    hdr, len = msgpack.decode(data)
+    body = msgpack.decode(data, len)
+    return {
+        bit.band(hdr[IPROTO_REQUEST_TYPE], bit.bnot(IPROTO_TYPE_ERROR)),
+        body[IPROTO_ERROR],
+    }
+end
 
 g.before_all = function()
     g.server = server:new({alias = 'master'})
     g.server:start()
     g.server:exec(function()
         box.schema.user.create('test', {password = '1111'})
+        box.schema.user.create('disabled')
+        box.schema.user.revoke('disabled', 'session', 'universe')
     end)
 end
 
@@ -30,4 +70,42 @@ g.test_user_enum_on_auth = function()
     c = net.connect('nobody:1112@' .. uri.unix)
     t.assert_error_msg_contains(err_msg, c.eval , c, cmd)
     c:close()
+end
+
+-- Checks that it's impossible to figure out if a user exists by analyzing
+-- the error sent in reply to a malformed authentication request.
+-- https://github.com/tarantool/security/issues/21
+g.test_user_enum_on_malformed_auth = function()
+    local uri = g.server.net_box_uri
+    for _, user in ipairs({'admin', 'test', 'disabled', 'no_such_user'}) do
+        local msg = string.format("Invalid error for user '%s'", user)
+        t.assert_equals(auth(uri, user, 42), {
+            box.error.INVALID_MSGPACK,
+            'Invalid MsgPack - packet body',
+        }, msg)
+        t.assert_equals(auth(uri, user, {}), {
+            box.error.INVALID_MSGPACK,
+            'Invalid MsgPack - authentication request body',
+        }, msg)
+        t.assert_equals(auth(uri, user, {42}), {
+            box.error.INVALID_MSGPACK,
+            'Invalid MsgPack - authentication request body',
+        }, msg)
+        t.assert_equals(auth(uri, user, {'foobar'}), {
+            box.error.INVALID_MSGPACK,
+            'Invalid MsgPack - authentication request body',
+        }, msg)
+        t.assert_equals(auth(uri, user, {'chap-sha1', 42}), {
+            box.error.INVALID_MSGPACK,
+            'Invalid MsgPack - authentication scramble',
+        }, msg)
+        t.assert_equals(auth(uri, user, {'chap-sha1', 'foobar'}), {
+            box.error.INVALID_MSGPACK,
+            'Invalid MsgPack - invalid scramble size',
+        }, msg)
+        t.assert_equals(auth(uri, user, {'chap-sha1', string.rep('x', 20)}), {
+            box.error.CREDS_MISMATCH,
+            'User not found or supplied credentials are invalid',
+        }, msg)
+    end
 end


### PR DESCRIPTION
This PR fixes two authentication-related issues:
- `box.session.on_auth` not invoked if the user doesn't exist.
- Different error is raised for existing and non-existing users if the authentication request is malformed.

Closes #8017
Closes https://github.com/tarantool/security/issues/21
