### PR TITLE
cmake: enable leak backtraces on AArch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -740,14 +740,6 @@ option(TEST_BUILD "Abort if memory leak is found." OFF)
 set(ABORT_ON_LEAK_DEFAULT ${TEST_BUILD})
 option(ABORT_ON_LEAK "Abort if memory leak is found." ${ABORT_ON_LEAK_DEFAULT})
 
-# TODO Enable aarch64 when gh-7960 "Crash in libunwind when collecting
-# backtrace for fiber gc leak check" is fixed.
-if (ENABLE_BACKTRACE AND NOT ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
-    set(ENABLE_LEAK_BACKTRACE ON)
-else()
-    set(ENABLE_LEAK_BACKTRACE OFF)
-endif()
-
 #
 # tarantool info summary (used in server version output)
 #

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -110,6 +110,20 @@ set (CMAKE_CXX_FLAGS_RELWITHDEBINFO
 
 unset(CC_DEBUG_OPT)
 
+# Set flags for all include files: those maintained by us and
+# coming from third parties.
+# Since we began using luajit, which uses gcc stack unwind
+# internally, we also need to make sure all code is compiled
+# with unwind info.
+add_compile_flags("C;CXX" "-fexceptions" "-funwind-tables")
+
+# Enable emission of the DWARF CFI (Call Frame Information) directives to the
+# assembler. This option is enabled by default on most compilers, but on GCC 7
+# for AArch64 and older it wasn't, so turn it on explicitly. When enabled, the
+# compiler emits .cfi_* directives that are required for the stack unwinding,
+# and defines __GCC_HAVE_DWARF2_CFI_ASM, which is checked below.
+add_compile_flags("C;CXX" "-fasynchronous-unwind-tables")
+
 check_c_source_compiles(
     "
     #if defined(__x86_64__) && !__has_attribute(force_align_arg_pointer)
@@ -157,16 +171,6 @@ if(BUILD_STATIC AND NOT TARGET_OS_DARWIN)
     # Static linking for c++ routines
     add_compile_flags("C;CXX" "-static-libstdc++")
 endif()
-
-#
-# Set flags for all include files: those maintained by us and
-# coming from third parties.
-# Since we began using luajit, which uses gcc stack unwind
-# internally, we also need to make sure all code is compiled
-# with unwind info.
-#
-
-add_compile_flags("C;CXX" "-fexceptions" "-funwind-tables")
 
 # In C a global variable without a storage specifier (static/extern) and
 # without an initialiser is called a ’tentative definition’. The

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -195,7 +195,7 @@ fiber_mprotect(void *addr, size_t len, int prot)
 
 static __thread bool fiber_top_enabled = false;
 
-#ifdef ENABLE_LEAK_BACKTRACE
+#ifdef ENABLE_BACKTRACE
 #ifndef NDEBUG
 bool fiber_leak_backtrace_enable = true;
 #else
@@ -903,8 +903,6 @@ fiber_recycle(struct fiber *fiber)
 	region_free(&fiber->gc);
 #ifdef ENABLE_BACKTRACE
 	fiber->parent_bt = NULL;
-#endif
-#ifdef ENABLE_LEAK_BACKTRACE
 	fiber->first_alloc_bt = NULL;
 	region_set_callbacks(&fiber->gc, NULL, NULL, NULL);
 #endif
@@ -915,7 +913,7 @@ fiber_recycle(struct fiber *fiber)
 	}
 }
 
-#ifdef ENABLE_LEAK_BACKTRACE
+#ifdef ENABLE_BACKTRACE
 /**
  * Called on allocation on region gc. Saves allocation caller backtrace
  * to report it later if region gc leak is found.
@@ -949,7 +947,7 @@ fiber_on_gc_truncate(struct region *region, size_t used, void *opaque)
 	if (used == fiber->gc_initial_size)
 		fiber->first_alloc_bt->frame_count = 0;
 }
-#endif /* ENABLE_LEAK_BACKTRACE */
+#endif /* ENABLE_BACKTRACE */
 
 void
 fiber_check_gc(void)
@@ -960,7 +958,7 @@ fiber_check_gc(void)
 	if (region_used(&fiber->gc) == fiber->gc_initial_size)
 		return;
 
-#ifdef ENABLE_LEAK_BACKTRACE
+#ifdef ENABLE_BACKTRACE
 	if (fiber->first_alloc_bt) {
 		char *buf = tt_static_buf();
 		int rc = snprintf(buf, TT_STATIC_BUF_LEN,
@@ -1299,7 +1297,7 @@ fiber_stack_create(struct fiber *fiber, struct slab_cache *slabc,
 static void
 fiber_gc_checker_init(struct fiber *fiber)
 {
-#ifdef ENABLE_LEAK_BACKTRACE
+#ifdef ENABLE_BACKTRACE
 	if (!fiber_leak_backtrace_enable) {
 		fiber->first_alloc_bt = NULL;
 		fiber->gc_initial_size = 0;

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -579,7 +579,7 @@ struct fiber {
 	unsigned int stack_id;
 	/** A garbage-collected memory pool. */
 	struct region gc;
-#ifdef ENABLE_LEAK_BACKTRACE
+#ifdef ENABLE_BACKTRACE
 	/**
 	 * Backtrace of the first fiber gc allocation that does not
 	 * truncated yet. NULL if backtrace is not supported by the
@@ -1124,7 +1124,7 @@ fiber_c_invoke(fiber_func f, va_list ap)
 	return f(ap);
 }
 
-#ifdef ENABLE_LEAK_BACKTRACE
+#ifdef ENABLE_BACKTRACE
 /**
  * Whether leak backtrace is provided when leak is found or not.
  *

--- a/src/lua/fiber.c
+++ b/src/lua/fiber.c
@@ -341,9 +341,7 @@ lbox_fiber_parent_backtrace_disable(struct lua_State *L)
 	fiber_parent_backtrace_disable();
 	return 0;
 }
-#endif /* ENABLE_BACKTRACE */
 
-#ifdef ENABLE_LEAK_BACKTRACE
 static int
 lbox_fiber_leak_backtrace_enable(struct lua_State *L)
 {
@@ -359,7 +357,7 @@ lbox_fiber_leak_backtrace_disable(struct lua_State *L)
 	fiber_leak_backtrace_enable = false;
 	return 0;
 }
-#endif /* ENABLE_LEAK_BACKTRACE */
+#endif /* ENABLE_BACKTRACE */
 
 /**
  * Return fiber statistics.
@@ -952,11 +950,9 @@ static const struct luaL_Reg fiberlib[] = {
 #ifdef ENABLE_BACKTRACE
 	{"parent_backtrace_enable", lbox_fiber_parent_backtrace_enable},
 	{"parent_backtrace_disable", lbox_fiber_parent_backtrace_disable},
-#endif /* ENABLE_BACKTRACE */
-#ifdef ENABLE_LEAK_BACKTRACE
 	{"leak_backtrace_enable", lbox_fiber_leak_backtrace_enable},
 	{"leak_backtrace_disable", lbox_fiber_leak_backtrace_disable},
-#endif
+#endif /* ENABLE_BACKTRACE */
 	{"sleep", lbox_fiber_sleep},
 	{"yield", lbox_fiber_yield},
 	{"self", lbox_fiber_self},

--- a/src/trivia/config.h.cmake
+++ b/src/trivia/config.h.cmake
@@ -75,10 +75,6 @@
  * Defined if configured with ABORT_ON_LEAK.
  */
 #cmakedefine ABORT_ON_LEAK 1
-/*
- * Defined if collecting leak backtrace have no issues.
- */
-#cmakedefine ENABLE_LEAK_BACKTRACE 1
 
 /*
  * Set if the system has bfd.h header and GNU bfd library.

--- a/test/unit/fiber.cc
+++ b/test/unit/fiber.cc
@@ -381,7 +381,7 @@ fiber_test_defaults()
 {
 	header();
 
-#ifdef ENABLE_LEAK_BACKTRACE
+#ifdef ENABLE_BACKTRACE
 #ifndef NDEBUG
 	fail_if(!fiber_leak_backtrace_enable);
 #else
@@ -410,7 +410,7 @@ fiber_test_leak(bool backtrace_enabled)
 {
 	header();
 
-#ifdef ENABLE_LEAK_BACKTRACE
+#ifdef ENABLE_BACKTRACE
 	bool leak_save = fiber_leak_backtrace_enable;
 	fiber_leak_backtrace_enable = backtrace_enabled;
 #endif
@@ -427,7 +427,7 @@ fiber_test_leak(bool backtrace_enabled)
 	fiber_wakeup(fiber);
 	fiber_join(fiber);
 
-#ifdef ENABLE_LEAK_BACKTRACE
+#ifdef ENABLE_BACKTRACE
 	fiber_leak_backtrace_enable = leak_save;
 #endif
 	fiber_abort_on_gc_leak = abort_save;
@@ -438,7 +438,7 @@ fiber_test_leak(bool backtrace_enabled)
 	fail_if(rc == -1);
 	buf[rc] = '\0';
 
-#ifdef ENABLE_LEAK_BACKTRACE
+#ifdef ENABLE_BACKTRACE
 	if (backtrace_enabled) {
 		const char *msg = "Fiber gc leak is found. "
 				  "First leaked fiber gc allocation"
@@ -481,7 +481,7 @@ fiber_test_leak_modes()
 			/* nonblock =*/ 0, "plain");
 
 	/*
-	 * Run two times even when ENABLE_LEAK_BACKTRACE is not defined as
+	 * Run two times even when ENABLE_BACKTRACE is not defined as
 	 * we have .result file.
 	 */
 	fiber_test_leak(/* backtrace_enabled =*/ true);


### PR DESCRIPTION
**cmake: add -fasynchronous-unwind-tables compiler flag**

This option enables emission of the DWARF CFI (Call Frame Information) directives to the assembler.
It is enabled by default on most compilers, but on GCC 7 for AArch64 and older it wasn't [^1], so turn it on explicitly.
When enabled, the compiler emits `.cfi_*` directives that are required for the stack unwinding, and defines `__GCC_HAVE_DWARF2_CFI_ASM`.

**cmake: enable leak backtraces on AArch64**

This feature was disabled due to a crash in libunwind. After commit https://github.com/tarantool/tarantool/commit/5b08d71ab47474f4278cdddf481bb8e50df074a5 ("libunwind: use latest release v1.6.2 as a base") the crash is gone.

Closes https://github.com/tarantool/tarantool/issues/7960

[^1]: https://gcc.gnu.org/pipermail/gcc-patches/2018-March/495549.html