### PR TITLE
build: fix libunwind.h search in testing files

### DIFF
--- a/changelogs/unreleased/fix-libunwind-h-search.md
+++ b/changelogs/unreleased/fix-libunwind-h-search.md
@@ -1,0 +1,3 @@
+## bugfix/build
+
+* Fixed `libunwind.h` search in testing files (gh-6877).

--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,6 @@ Build-Depends: cdbs (>= 0.4.100), debhelper (>= 9), dpkg-dev (>= 1.16.1~),
  libreadline-dev,
  libncurses5-dev,
  libssl-dev,
- libunwind-dev | libunwind8-dev | libunwind7-dev,
  libicu-dev,
 # libcurl build dependencies
  zlib1g-dev,

--- a/rpm/tarantool.spec
+++ b/rpm/tarantool.spec
@@ -75,7 +75,6 @@ Requires(preun): initscripts
 %undefine __cc
 
 %if %{with backtrace}
-BuildRequires: libunwind-devel
 #
 # Disable stripping of /usr/bin/tarantool to allow the debug symbols
 # in runtime. Tarantool uses the debug symbols to display fiber's stack

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -2096,3 +2096,9 @@ int fiber_stat(fiber_stat_cb cb, void *cb_ctx)
 	}
 	return 0;
 }
+
+struct lua_State *
+fiber_lua_state(struct fiber *f)
+{
+	return f->storage.lua.stack;
+}

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -1156,6 +1156,12 @@ extern bool fiber_abort_on_gc_leak;
 void
 fiber_check_gc(void);
 
+/**
+ * Return fiber's Lua state or NULL if it doesn't exist.
+ */
+struct lua_State *
+fiber_lua_state(struct fiber *f);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -17,6 +17,11 @@
  * Tarantool 2.8.
  *
  * [1]: https://github.com/picodata/tarantool-module
+ *
+ * fiber_lua_state() is used in [2] to eliminate dependency from
+ * fiber.h. See gh-8025.
+ *
+ * [2]: test/box-tap/check_merge_source.c
  */
 
 extern void
@@ -45,6 +50,8 @@ extern void
 ipc_value_delete(void);
 extern void
 ipc_value_new(void);
+extern void
+fiber_lua_state(void);
 
 /** Symbol definition. */
 struct symbol_def {
@@ -68,6 +75,7 @@ static struct symbol_def symbols[] = {
 	{"fiber_channel_put_timeout", fiber_channel_put_timeout},
 	{"ipc_value_delete", ipc_value_delete},
 	{"ipc_value_new", ipc_value_new},
+	{"fiber_lua_state", fiber_lua_state},
 	{NULL, NULL}
 };
 

--- a/test/app-luatest/tnt_internal_symbol_test.lua
+++ b/test/app-luatest/tnt_internal_symbol_test.lua
@@ -24,6 +24,7 @@ g.test_fiber_channel = function()
         'fiber_channel_put_timeout',
         'ipc_value_delete',
         'ipc_value_new',
+        'fiber_lua_state',
     }
     -- Verify only that we can get the address. The functions are
     -- provided 'as is' and we don't guarantee anything regarding

--- a/test/box-tap/CMakeLists.txt
+++ b/test/box-tap/CMakeLists.txt
@@ -1,4 +1,1 @@
-# fiber.h requires tarantool_ev.h from third_party directory.
-include_directories(${PROJECT_SOURCE_DIR}/third_party)
-
 build_module(check_merge_source check_merge_source.c)

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -3,6 +3,13 @@ include_directories(${PROJECT_SOURCE_DIR}/src)
 include_directories(${PROJECT_BINARY_DIR}/src)
 include_directories(${PROJECT_SOURCE_DIR}/src/box)
 
+# fiber.h may require libunwind.h. Add proper header search paths.
+function(add_libunwind_include_directory target)
+  if (ENABLE_BACKTRACE AND ENABLE_BUNDLED_LIBUNWIND)
+    target_include_directories(${target} SYSTEM PRIVATE ${LIBUNWIND_INCLUDE_DIR})
+  endif()
+endfunction()
+
 # A special target with fuzzer and sanitizer flags.
 add_library(fuzzer_config INTERFACE)
 
@@ -40,9 +47,11 @@ target_link_libraries(http_parser_fuzzer PUBLIC http_parser fuzzer_config)
 
 add_executable(swim_proto_member_fuzzer swim_proto_member_fuzzer.c)
 target_link_libraries(swim_proto_member_fuzzer PUBLIC swim fuzzer_config)
+add_libunwind_include_directory(swim_proto_member_fuzzer)
 
 add_executable(swim_proto_meta_fuzzer swim_proto_meta_fuzzer.c)
 target_link_libraries(swim_proto_meta_fuzzer PUBLIC swim fuzzer_config)
+add_libunwind_include_directory(swim_proto_meta_fuzzer)
 
 add_executable(datetime_parse_full_fuzzer datetime_parse_full_fuzzer.c)
 target_link_libraries(datetime_parse_full_fuzzer PUBLIC core fuzzer_config)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -15,6 +15,15 @@ include_directories(${PROJECT_SOURCE_DIR}/src/box)
 include_directories(${PROJECT_SOURCE_DIR}/third_party)
 include_directories(${ICU_INCLUDE_DIRS})
 include_directories(${CURL_INCLUDE_DIRS})
+
+# There are many unit tests that include fiber.h, which may
+# transitively include libunwind.h. When libunwind is built as
+# part of tarantool's build process, we should add libunwind's
+# headers directory into the search path.
+if (ENABLE_BACKTRACE AND ENABLE_BUNDLED_LIBUNWIND)
+  include_directories(SYSTEM ${LIBUNWIND_INCLUDE_DIR})
+endif()
+
 include_directories(${EXTRA_CORE_INCLUDE_DIRS})
 
 include(CMakeParseArguments)

--- a/test/unit/uri.c
+++ b/test/unit/uri.c
@@ -1,10 +1,5 @@
 #include "uri/uri.h"
-#include "lua/utils.h"
 #include "trivia/util.h"
-#include "diag.h"
-#include "memory.h"
-#include "fiber.h"
-#include "tt_static.h"
 
 #include <stdio.h>
 


### PR DESCRIPTION
## The problem

Case: a build host has no libunwind installed into the system. Dispite that tarantool has libunwind bundled as a git submodule (see PR #6877), the build fails in the case:

```c
In file included from <...>/src/lib/core/fiber.h:47,
                 from <..some test/**/*.{c,cc} file..>:
<...>/src/lib/core/backtrace.h:14:10: fatal error: libunwind.h: No such file or directory
   14 | #include "libunwind.h"
      |          ^~~~~~~~~~~~~
```

The problem appears when `ENABLE_BACKTRACE` and `ENABLE_BUNDLED_LIBUNWIND` CMake options are enabled. They're enabled by default for most targets.

The compilation fails for testing files, which include `fiber.h`. The `fiber.h` header includes `backtrace.h`, which includes `libunwind.h`. The `libunwind.h` header couldn't be found if appropriate include directory is not passed to a compiler.

## The solution

* Add libunwind's include directory to compilation of unit tests and fuzzers.
* Eliminate `fiber.h` usage in a merger's test using `tnt_internal_symbol()` (see 395c30e8f85d).
* Drop libunwind build dependency from rpm/deb packages to verify the fix (and because it is unnecessary after #6877).

See details in the commit messages.

Follows up #6877
Part of #6998
Fixes #8025