### PR TITLE
xrow: use `xregion_alloc` in encoders

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3286,7 +3286,7 @@ box_process_fetch_snapshot(struct iostream *io,
 	/* Send end of snapshot data marker */
 	struct xrow_header row;
 	RegionGuard region_guard(&fiber()->gc);
-	xrow_encode_vclock_xc(&row, &stop_vclock);
+	xrow_encode_vclock(&row, &stop_vclock);
 	row.sync = header->sync;
 	coio_write_xrow(io, &row);
 }
@@ -3366,7 +3366,7 @@ box_process_register(struct iostream *io, const struct xrow_header *header)
 	RegionGuard region_guard(&fiber()->gc);
 	struct xrow_header row;
 	/* Send end of WAL stream marker */
-	xrow_encode_vclock_xc(&row, &replicaset.vclock);
+	xrow_encode_vclock(&row, &replicaset.vclock);
 	row.sync = header->sync;
 	coio_write_xrow(io, &row);
 
@@ -3507,7 +3507,7 @@ box_process_join(struct iostream *io, const struct xrow_header *header)
 	/* Send end of initial stage data marker */
 	struct xrow_header row;
 	RegionGuard region_guard(&fiber()->gc);
-	xrow_encode_vclock_xc(&row, &stop_vclock);
+	xrow_encode_vclock(&row, &stop_vclock);
 	row.sync = header->sync;
 	coio_write_xrow(io, &row);
 
@@ -3519,7 +3519,7 @@ box_process_join(struct iostream *io, const struct xrow_header *header)
 	say_info("final data sent.");
 
 	/* Send end of WAL stream marker */
-	xrow_encode_vclock_xc(&row, &replicaset.vclock);
+	xrow_encode_vclock(&row, &replicaset.vclock);
 	row.sync = header->sync;
 	coio_write_xrow(io, &row);
 
@@ -3629,7 +3629,7 @@ box_process_subscribe(struct iostream *io, const struct xrow_header *header)
 	rsp.replicaset_uuid = REPLICASET_UUID;
 	struct xrow_header row;
 	RegionGuard region_guard(&fiber()->gc);
-	xrow_encode_subscribe_response_xc(&row, &rsp);
+	xrow_encode_subscribe_response(&row, &rsp);
 	/*
 	 * Identify the message with the replica id of this
 	 * instance, this is the only way for a replica to find

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -803,8 +803,7 @@ checkpoint_write_raft(struct xlog *l, const struct raft_request *req)
 	struct xrow_header row;
 	struct region *region = &fiber()->gc;
 	RegionGuard region_guard(&fiber()->gc);
-	if (xrow_encode_raft(&row, region, req) != 0)
-		return -1;
+	xrow_encode_raft(&row, region, req);
 	if (checkpoint_write_row(l, &row) != 0)
 		return -1;
 	return 0;

--- a/src/box/raft.c
+++ b/src/box/raft.c
@@ -393,8 +393,7 @@ box_raft_write(struct raft *raft, const struct raft_msg *msg)
 	struct journal_entry *entry = (struct journal_entry *)buf;
 	entry->rows[0] = &row;
 
-	if (xrow_encode_raft(&row, region, &req) != 0)
-		goto fail;
+	xrow_encode_raft(&row, region, &req);
 	journal_entry_create(entry, 1, xrow_approx_len(&row),
 			     journal_entry_fiber_wakeup_cb, fiber());
 	bool is_err = journal_write(entry) != 0;

--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -479,7 +479,7 @@ relay_initial_join(struct iostream *io, uint64_t sync, struct vclock *vclock,
 	/* Respond to the JOIN request with the current vclock. */
 	struct xrow_header row;
 	RegionGuard region_guard(&fiber()->gc);
-	xrow_encode_vclock_xc(&row, vclock);
+	xrow_encode_vclock(&row, vclock);
 	row.sync = sync;
 	coio_write_xrow(relay->io, &row);
 
@@ -786,7 +786,7 @@ relay_send_heartbeat(struct relay *relay)
 	try {
 		++relay->last_sent_ack.vclock_sync;
 		RegionGuard region_guard(&fiber()->gc);
-		xrow_encode_relay_heartbeat_xc(&row, &relay->last_sent_ack);
+		xrow_encode_relay_heartbeat(&row, &relay->last_sent_ack);
 		row.tm = ev_now(loop());
 		row.replica_id = instance_id;
 		relay_send(relay, &row);

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -295,11 +295,9 @@ txn_add_redo(struct txn *txn, struct txn_stmt *stmt, struct request *request)
 	if (space != NULL && space->wal_ext != NULL)
 		space_wal_ext_process_request(space->wal_ext, stmt, request);
 	struct region *txn_region = tx_region_acquire(txn);
-	row->bodycnt = xrow_encode_dml(request, txn_region, row->body);
+	xrow_encode_dml(request, txn_region, row->body, &row->bodycnt);
 	tx_region_release(txn, TX_ALLOC_SYSTEM);
 	txn_region = NULL;
-	if (row->bodycnt < 0)
-		return -1;
 	stmt->row = row;
 	return 0;
 }

--- a/src/box/vy_log.c
+++ b/src/box/vy_log.c
@@ -543,7 +543,7 @@ vy_log_record_encode(const struct vy_log_record *record,
 	req.tuple_end = pos;
 	memset(row, 0, sizeof(*row));
 	row->type = req.type;
-	row->bodycnt = xrow_encode_dml(&req, &fiber()->gc, row->body);
+	xrow_encode_dml(&req, &fiber()->gc, row->body, &row->bodycnt);
 	return 0;
 }
 

--- a/src/box/vy_stmt.c
+++ b/src/box/vy_stmt.c
@@ -664,9 +664,7 @@ vy_stmt_encode_primary(struct tuple *value, struct key_def *key_def,
 	}
 	if (vy_stmt_meta_encode(value, &request, true) != 0)
 		return -1;
-	xrow->bodycnt = xrow_encode_dml(&request, &fiber()->gc, xrow->body);
-	if (xrow->bodycnt < 0)
-		return -1;
+	xrow_encode_dml(&request, &fiber()->gc, xrow->body, &xrow->bodycnt);
 	return 0;
 }
 
@@ -699,11 +697,8 @@ vy_stmt_encode_secondary(struct tuple *value, struct key_def *cmp_def,
 	}
 	if (vy_stmt_meta_encode(value, &request, false) != 0)
 		return -1;
-	xrow->bodycnt = xrow_encode_dml(&request, &fiber()->gc, xrow->body);
-	if (xrow->bodycnt < 0)
-		return -1;
-	else
-		return 0;
+	xrow_encode_dml(&request, &fiber()->gc, xrow->body, &xrow->bodycnt);
+	return 0;
 }
 
 struct tuple *

--- a/src/box/xlog.c
+++ b/src/box/xlog.c
@@ -1351,11 +1351,9 @@ xlog_write_row(struct xlog *log, const struct xrow_header *packet)
 	struct iovec iov[XROW_IOVMAX];
 	/** don't write sync to the disk */
 	size_t region_svp = region_used(&fiber()->gc);
-	int iovcnt = xrow_header_encode(packet, 0, iov, 0);
-	if (iovcnt < 0) {
-		obuf_rollback_to_svp(&log->obuf, &svp);
-		return -1;
-	}
+	int iovcnt;
+	xrow_header_encode(packet, /*sync=*/0, /*fixheader_len=*/0,
+			   iov, &iovcnt);
 	for (int i = 0; i < iovcnt; ++i) {
 		struct errinj *inj = errinj(ERRINJ_WAL_WRITE_PARTIAL,
 					    ERRINJ_INT);

--- a/src/box/xrow_io.cc
+++ b/src/box/xrow_io.cc
@@ -99,8 +99,9 @@ void
 coio_write_xrow(struct iostream *io, const struct xrow_header *row)
 {
 	RegionGuard region_guard(&fiber()->gc);
+	int iovcnt;
 	struct iovec iov[XROW_IOVMAX];
-	int iovcnt = xrow_to_iovec_xc(row, iov);
+	xrow_to_iovec(row, iov, &iovcnt);
 	if (coio_writev(io, iov, iovcnt, 0) < 0)
 		diag_raise();
 }

--- a/test/unit/xrow.cc
+++ b/test/unit/xrow.cc
@@ -227,8 +227,11 @@ test_xrow_header_encode_decode()
 		header.is_commit = opt_idx & 0x01;
 		header.wait_sync = opt_idx >> 1 & 0x01;
 		header.wait_ack = opt_idx >> 2 & 0x01;
+		int iovcnt;
 		struct iovec vec[1];
-		is(1, xrow_header_encode(&header, sync, vec, 200), "encode");
+		xrow_header_encode(&header, sync, /*fixheader_len=*/200,
+				   vec, &iovcnt);
+		is(1, iovcnt, "encode");
 		int fixheader_len = 200;
 		pos = (char *)vec[0].iov_base + fixheader_len;
 		uint32_t exp_map_size = 6;
@@ -375,8 +378,10 @@ test_xrow_encode_dml(void)
 	r.new_tuple = "new tuple";
 	r.new_tuple_end = r.new_tuple + strlen(r.new_tuple);
 
+	int iovcnt;
 	struct iovec iov[1];
-	is(xrow_encode_dml(&r, &fiber()->gc, iov), 1, "xrow_encode_dml rc");
+	xrow_encode_dml(&r, &fiber()->gc, iov, &iovcnt);
+	is(iovcnt, 1, "xrow_encode_dml rc");
 	const char *data = (const char *)iov[0].iov_base;
 	int map_size = mp_decode_map(&data);
 	is(map_size, 9, "decoded request map");


### PR DESCRIPTION
An encoder function may only fail if it fails to allocate memory from `fiber->gc`. The amount of memory it allocates is fairly small. It's used as an extra stack to return the encoded data. This should never fail, because there's no hard limit for runtime memory (and we're not planning to ever add one). Let's make all encoder functions return `void` and drop the untested checks for OOM.

To avoid confusion, we make `xrow_header_encode`, `xrow_encode_dml`, and `xrow_to_iovec` return the number of io vectors in a new out argument, because a return value of type `int` is usually used to indicate an error.

See also #3534