### PR TITLE
test: tarantoolctl.test flakiness fixup

### DIFF
--- a/test/app-tap/tarantoolctl.test.lua
+++ b/test/app-tap/tarantoolctl.test.lua
@@ -44,12 +44,14 @@ local function recursive_rmdir(path)
     end
     for _, file in ipairs(path_content) do
         local stat = fio.stat(file)
-        if stat:is_dir() then
-            recursive_rmdir(file)
-        else
-            if fio.unlink(file) == false then
-                print(string.format('!!! failed to unlink file "%s"', file))
-                print(string.format('!!! [errno %s]: %s', errno(), errno.strerror()))
+        if stat ~= nil then
+            if stat:is_dir() then
+                recursive_rmdir(file)
+            else
+                if fio.unlink(file) == false then
+                    print(string.format('!!! failed to unlink file "%s"', file))
+                    print(string.format('!!! [errno %s]: %s', errno(), errno.strerror()))
+                end
             end
         end
     end


### PR DESCRIPTION
The `recursive_rmdir` can start execution while tarantool instance started by the tarantoolctl is in the process of shutdown. As a result the instance pid file can be available at the name collection, but by the time of its removal the instance deletes it by itself.

NO_DOC=test
NO_CHANGELOG=test