### PR TITLE
log: take into account env vars on log.cfg call

### DIFF
--- a/changelogs/unreleased/gh-6011-follow-env-vars-on-log-cfg.md
+++ b/changelogs/unreleased/gh-6011-follow-env-vars-on-log-cfg.md
@@ -1,0 +1,4 @@
+## feature/box
+
+* Env variables are taken into account if log is configured before box thru
+  log.cfg call (gh-6011).

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -634,12 +634,13 @@ local function prepare_cfg(cfg, default_cfg, template_cfg, modify_cfg)
 end
 
 -- Transfer options from env_cfg to cfg.
-local function apply_env_cfg(cfg, env_cfg)
+-- If skip_cfg is given then skip transferring options from this set.
+local function apply_env_cfg(cfg, env_cfg, skip_cfg)
     -- Add options passed through environment variables.
     -- Here we only add options without overloading the ones set
     -- by the user.
     for k, v in pairs(env_cfg) do
-        if cfg[k] == nil then
+        if cfg[k] == nil and (skip_cfg == nil or skip_cfg[k] == nil) then
             cfg[k] = v
         end
     end
@@ -839,6 +840,12 @@ local box_is_configured = false
 -- this moment.
 local pre_load_cfg = table.copy(default_cfg)
 
+-- On first box.cfg{} we need to know options that were already configured
+-- in standalone modules (like log module). We should not apply env vars
+-- for these options. pre_load_cfg is not suitable for this purpose because
+-- of nil values.
+local pre_load_cfg_is_set = {}
+
 local function load_cfg(cfg)
     -- A user may save box.cfg (this function) before box loading
     -- and call it afterwards. We should reconfigure box in the
@@ -851,7 +858,7 @@ local function load_cfg(cfg)
     cfg = upgrade_cfg(cfg, translate_cfg)
 
     -- Set options passed through environment variables.
-    apply_env_cfg(cfg, box.internal.cfg.env)
+    apply_env_cfg(cfg, box.internal.cfg.env, pre_load_cfg_is_set)
 
     cfg = prepare_cfg(cfg, default_cfg, template_cfg, modify_cfg)
     merge_cfg(cfg, pre_load_cfg);
@@ -996,6 +1003,15 @@ local function get_option_from_env(option)
     end
 end
 
+-- Get options from env vars for given set.
+local function env_cfg(options)
+    local cfg = {}
+    for option in pairs(options) do
+        cfg[option] = get_option_from_env(option)
+    end
+    return cfg
+end
+
 -- Used to propagate cfg changes done thru API of distinct modules (
 -- log.cfg of log module for example).
 local function update_cfg(option, value)
@@ -1003,13 +1019,16 @@ local function update_cfg(option, value)
         rawset(box.cfg, option, value)
     else
         pre_load_cfg[option] = value
+        pre_load_cfg_is_set[option] = true
     end
 end
 
 box.internal.prepare_cfg = prepare_cfg
+box.internal.apply_env_cfg = apply_env_cfg
 box.internal.merge_cfg = merge_cfg
 box.internal.check_cfg_option_type = check_cfg_option_type
 box.internal.update_cfg = update_cfg
+box.internal.env_cfg = env_cfg
 
 ---
 --- Read box configuration from environment variables.
@@ -1017,11 +1036,7 @@ box.internal.update_cfg = update_cfg
 box.internal.cfg = setmetatable({}, {
     __index = function(self, key)
         if key == 'env' then
-            local res = {}
-            for option, _ in pairs(template_cfg) do
-                res[option] = get_option_from_env(option)
-            end
-            return res
+            return env_cfg(template_cfg)
         end
         assert(false)
     end,

--- a/test/box-luatest/gh_6011_follow_env_vars_on_log_cfg_test.lua
+++ b/test/box-luatest/gh_6011_follow_env_vars_on_log_cfg_test.lua
@@ -1,0 +1,88 @@
+local server = require('luatest.server')
+local fio = require('fio')
+local t = require('luatest')
+local g = t.group()
+
+local TARANTOOL_PATH = arg[-1]
+
+-- Test 'level' default value so that `test_env_set` success is not because
+-- of 'warn' default.
+local test_default = [[
+    local log = require('log')
+    log.cfg{}
+    os.exit(log.cfg.level == 5 and 0 or 1)
+]]
+
+-- Main test. Test env vars are taken into account in log.cfg().
+local test_env_set = [[
+    local log = require('log')
+    log.cfg{}
+    os.exit(log.cfg.level == 'warn' and 0 or 1)
+]]
+
+-- Test we don't apply env vars again in box.cfg() after log.cfg for
+-- log options.
+local test_box_env_dont_overwrite = [[
+    local log = require('log')
+    log.cfg{level='error'}
+    box.cfg{}
+    os.exit(log.cfg.level == 'error' and 0 or 1)
+]]
+
+-- Test we don't fail in log.cfg() if non log options are specified
+-- incorrectly in env vars.
+local test_other_env_option_error = [[
+    local log = require('log')
+    log.cfg{level='error'}
+    os.exit(log.cfg.level == 'error' and 0 or 1)
+]]
+
+-- Test all log options together.
+local test_all_log_options = [[
+    local log = require('log')
+    log.cfg{}
+    if log.cfg.log ~= 'test.log' or
+        log.cfg.nonblock ~= false or
+        log.cfg.level ~= 'error' or
+        log.cfg.format ~= 'json' then
+        os.exit(1)
+    end
+    box.cfg{}
+    if box.cfg.worker_pool_threads ~= 2 or
+        box.cfg.memtx_use_mvcc_engine ~= true then
+        os.exit(2)
+    end
+    os.exit(0)
+]]
+
+local function run_test(g, test, env)
+    local chdir_expr = string.format("require('fio').chdir('%s')", g.workdir)
+    env = env or ""
+    local cmd = string.format('%s %s -e "%s" -e "%s"',
+                              env, TARANTOOL_PATH, chdir_expr, test)
+    t.assert_equals(os.execute(cmd), 0)
+end
+
+g.test_env_vars_on_log_cfg = function()
+    g.workdir = fio.pathjoin(server.vardir, 'gh-6011')
+    fio.mkdir(g.workdir)
+
+    run_test(g, test_default)
+    run_test(g, test_env_set, 'TT_LOG_LEVEL=warn')
+    run_test(g, test_box_env_dont_overwrite, 'TT_LOG_LEVEL=warn')
+    run_test(g, test_other_env_option_error, 'TT_STRIP_CORE=a')
+
+    -- FIXME (gh-8051)
+    -- Don't test `TT_LOG_MODULES` option as it does not work yet gh-8051.
+    local all_log_options = {
+        'TT_LOG=test.log',
+        'TT_LOG_NONBLOCK=false',
+        'TT_LOG_LEVEL=error',
+        'TT_LOG_FORMAT=json',
+        'TT_WORKER_POOL_THREADS=2',
+        'TT_MEMTX_USE_MVCC_ENGINE=true'
+    }
+    run_test(g, test_all_log_options, table.concat(all_log_options, ' '))
+
+    fio.rmtree(g.workdir)
+end


### PR DESCRIPTION
If env vars like TT_LOG, TT_LOG_LEVEL etc that specify log options are set then log.cfg() should take them into account if called before box.cfg().

Closes #6011
Closes #7461

@TarantoolBot document
Title: log: take into account env vars on log.cfg call Since: 2.11

If env vars like TT_LOG, TT_LOG_LEVEL etc that specify log options are set then log.cfg() take them into account if called before box.cfg().