### PR TITLE
cd: eliminate OpenSUSE related code from RPM spec

### DIFF
--- a/rpm/tarantool.spec
+++ b/rpm/tarantool.spec
@@ -1,5 +1,5 @@
 # Enable systemd for on RHEL >= 7 and Fedora >= 15
-%if (0%{?fedora} >= 15 || 0%{?rhel} >= 7 || 0%{?sle_version} >= 1500)
+%if (0%{?fedora} >= 15 || 0%{?rhel} >= 7)
 %bcond_without systemd
 %else
 %bcond_with systemd
@@ -28,7 +28,7 @@ BuildRequires: cmake >= 3.3
 %endif
 
 BuildRequires: make
-%if (0%{?fedora} >= 22 || 0%{?rhel} >= 7 || 0%{?sle_version} >= 1500)
+%if (0%{?fedora} >= 22 || 0%{?rhel} >= 7)
 BuildRequires: gcc >= 4.5
 BuildRequires: gcc-c++ >= 4.5
 %endif
@@ -74,12 +74,6 @@ Requires(preun): initscripts
 %endif
 %undefine __cc
 
-# openSuSE sets its own build directory in its macros, but we
-# want to use in-source build there to simplify the RPM spec.
-%if (0%{?sle_version} >= 1500)
-%global __builddir .
-%endif
-
 %if %{with backtrace}
 BuildRequires: libunwind-devel
 #
@@ -97,17 +91,9 @@ BuildRequires: libunwind-devel
 BuildRequires: python3
 BuildRequires: python3-six
 BuildRequires: python3-gevent
-%if (0%{?sle_version} >= 1500)
-BuildRequires: python3-PyYAML
-%else
 BuildRequires: python3-pyyaml
-%endif
 # needed for datetime tests
-%if 0%{?sle_version} >= 1500
-BuildRequires: timezone
-%else
 BuildRequires: tzdata
-%endif
 
 # Install prove to run LuaJIT tests.
 BuildRequires: perl-Test-Harness
@@ -136,12 +122,8 @@ Requires: /etc/services
 # Deps for built-in package manager
 # https://github.com/tarantool/tarantool/issues/2612
 Requires: openssl
-%if 0%{?sle_version} >= 1500
-Requires: timezone
-%else
 Requires: tzdata
-%endif
-%if (0%{?fedora} >= 22 || 0%{?rhel} >= 8 || 0%{?sle_version} >= 1500)
+%if (0%{?fedora} >= 22 || 0%{?rhel} >= 8)
 # RHEL <= 7 doesn't support Recommends:
 Recommends: tarantool-devel
 Recommends: git-core


### PR DESCRIPTION
Support for OpenSUSE 15.1/15.2 has been recently dropped. There is no sense to keep the dead code. So removing it.

Follows up #8021