### PR TITLE
ci: fix running full testing on any label when `full-ci` is set

### DIFF
--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   centos_7:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/centos_7_aarch64.yml
+++ b/.github/workflows/centos_7_aarch64.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   centos_7_aarch64:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: graviton
 

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   centos_8:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/centos_8_aarch64.yml
+++ b/.github/workflows/centos_8_aarch64.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   centos_8_aarch64:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: graviton
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,6 @@ on:
     tags:
       - '**'
   pull_request:
-    types: [ opened, reopened, synchronize, labeled ]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   debian_10:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/debian_10_aarch64.yml
+++ b/.github/workflows/debian_10_aarch64.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   debian_10_aarch64:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: graviton
 

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   debian_11:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/debian_11_aarch64.yml
+++ b/.github/workflows/debian_11_aarch64.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   debian_11_aarch64:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: graviton
 

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   debian_9:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   debug_aarch64:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: graviton
 

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -37,10 +37,16 @@ env:
 jobs:
   default_gcc_centos_7:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   fedora_34:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/fedora_34_aarch64.yml
+++ b/.github/workflows/fedora_34_aarch64.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   fedora_34_aarch64:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: graviton
 

--- a/.github/workflows/fedora_35.yml
+++ b/.github/workflows/fedora_35.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   fedora_35:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/fedora_35_aarch64.yml
+++ b/.github/workflows/fedora_35_aarch64.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   fedora_35_aarch64:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: graviton
 

--- a/.github/workflows/fedora_36.yml
+++ b/.github/workflows/fedora_36.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   fedora_36:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/fedora_36_aarch64.yml
+++ b/.github/workflows/fedora_36_aarch64.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   fedora_36_aarch64:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: graviton
 

--- a/.github/workflows/freebsd-12.yml
+++ b/.github/workflows/freebsd-12.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   freebsd-12:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: freebsd-12-mcs
 

--- a/.github/workflows/freebsd-13.yml
+++ b/.github/workflows/freebsd-13.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   freebsd-13:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: freebsd-13-mcs
 

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -38,10 +38,16 @@ concurrency:
 jobs:
   fuzzing:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,11 +34,19 @@ concurrency:
 jobs:
   tarantool:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' or 'integration-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') ||
-          contains(github.event.pull_request.labels.*.name, 'integration-ci') )
+    # or on pull request if the 'full-ci' or 'integration-ci' label is set or
+    # already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' && (
+            github.event.label.name == 'full-ci' ||
+            github.event.label.name == 'integration-ci' ) ) ||
+          ( github.event.action != 'labeled' && (
+            contains(github.event.pull_request.labels.*.name, 'full-ci') ||
+            contains(github.event.pull_request.labels.*.name, 'integration-ci') ) )
+        )
+      )
 
     uses: tarantool/tarantool/.github/workflows/reusable_build.yml@master
     with:

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   memtx_allocator_based_on_malloc:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/osx_11.yml
+++ b/.github/workflows/osx_11.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   osx_11:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: macos-11
 

--- a/.github/workflows/osx_11_aarch64.yml
+++ b/.github/workflows/osx_11_aarch64.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   osx_11_aarch64:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: macos-11-m1
 

--- a/.github/workflows/osx_11_aarch64_debug.yml
+++ b/.github/workflows/osx_11_aarch64_debug.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   osx_11_aarch64_debug:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: macos-11-m1
 

--- a/.github/workflows/osx_11_lto.yml
+++ b/.github/workflows/osx_11_lto.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   osx_11_lto:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: macos-11
 

--- a/.github/workflows/osx_12.yml
+++ b/.github/workflows/osx_12.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   osx_12:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: macos-12
 

--- a/.github/workflows/osx_12_static_cmake.yml
+++ b/.github/workflows/osx_12_static_cmake.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   osx_12_static_cmake:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: macos-12
 

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   out_of_source:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/publish-module-api-doc.yaml
+++ b/.github/workflows/publish-module-api-doc.yaml
@@ -29,11 +29,17 @@ concurrency:
 
 jobs:
   publish-api-doc:
-    # Run on push to the branch 'master' or on pull request if the 'full-ci'
-    # label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Prepare checkout

--- a/.github/workflows/redos_7_3.yaml
+++ b/.github/workflows/redos_7_3.yaml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   redos_7_3:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   release_asan_clang11:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   release_clang:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   release_lto:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   release_lto_clang11:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   static_build:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   static_build_cmake_linux:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   ubuntu_16_04:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   ubuntu_18_04:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   ubuntu_20_04:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/ubuntu_20_04_aarch64.yml
+++ b/.github/workflows/ubuntu_20_04_aarch64.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   ubuntu_20_04_aarch64:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: graviton
 

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   ubuntu_22_04:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/ubuntu_22_04_aarch64.yml
+++ b/.github/workflows/ubuntu_22_04_aarch64.yml
@@ -34,10 +34,16 @@ concurrency:
 jobs:
   ubuntu_22_04_aarch64:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+    # or on pull request if the 'full-ci' label is set or already exists.
+    if: |
+      github.repository == 'tarantool/tarantool' && (
+        github.event_name != 'pull_request' || (
+          ( github.event.action == 'labeled' &&
+            github.event.label.name == 'full-ci' ) ||
+          ( github.event.action != 'labeled' &&
+            contains(github.event.pull_request.labels.*.name, 'full-ci') )
+        )
+      )
 
     runs-on: graviton
 


### PR DESCRIPTION
Previously, setting any label on a pull request with the `full-ci` label
triggered running the full testing. The reason was in not enough strict
condition for running workflows.

Now the full testing will be run only when pull requests are labeled by
the 'full-ci' label, or it already exists, but event's activity type is
not related to labeling.