### PR TITLE
http: escape encoded params

### DIFF
--- a/changelogs/unreleased/gh-7931-httpc-params-escaping.md
+++ b/changelogs/unreleased/gh-7931-httpc-params-escaping.md
@@ -1,0 +1,6 @@
+## feature/lua/http client
+
+* Performed automated percent-encoding of query params passed into URI using a
+  using the params option. Parameters encoded using `uri.QUERY_PART` when `GET`,
+  `DELETE` or `HEAD` HTTP methods are used and `uri.FORM_URLENCODED` in other
+  cases (gh-7931).

--- a/src/lua/httpc.lua
+++ b/src/lua/httpc.lua
@@ -311,9 +311,18 @@ local function decode_body(response)
     return res
 end
 
-local function encode_url_params(params)
-    local query_encoder = require("uri")._internal.params
-    local ok, res = pcall(query_encoder, params)
+local function encode_url_params(params, http_method)
+    assert(http_method ~= nil)
+    local uri = require("uri")
+    local uri_escape_opts = uri.FORM_URLENCODED
+    if http_method == "GET" or
+       http_method == "HEAD" or
+       http_method == "DELETE" then
+        uri_escape_opts = uri.QUERY_PART
+    end
+
+    local query_encoder = uri._internal.params
+    local ok, res = pcall(query_encoder, params, uri_escape_opts)
     if not ok then
         error(res)
     end
@@ -410,7 +419,7 @@ curl_mt = {
 
             local encoded_params
             if opts.params then
-                encoded_params = encode_url_params(opts.params)
+                encoded_params = encode_url_params(opts.params, method)
             end
             local url_with_params = url
             if encoded_params then

--- a/test/app-luatest/http_client_test.lua
+++ b/test/app-luatest/http_client_test.lua
@@ -986,3 +986,39 @@ g.test_http_params_request_post = function(cg)
     t.assert_equals(resp.body, "k=2&v=3&v=4")
     t.assert_equals(resp.headers['content_type'], "application/x-www-form-urlencoded")
 end
+
+g.test_http_params_escaped_request_post = function(cg)
+    local http = client.new()
+    t.assert(http ~= nil, "client is created")
+
+    local opts = table.deepcopy(cg.opts)
+    opts.params = {
+        [2] = 4,
+        ["k&"] = "&2",
+        ["v&"] = uri.values("3", "4", "5=", "6 ")
+    }
+
+    -- HTTP method in uppercase.
+    local resp = http:request("POST", cg.url, nil, opts)
+    t.assert_equals(resp.status, 200)
+    local expected_body = "2=4&k%26=%262&v%26=3&v%26=4&v%26=5%3D&v%26=6+"
+    t.assert_equals(resp.body, expected_body)
+end
+
+g.test_http_params_escaped_request_get = function(cg)
+    local http = client.new()
+    t.assert(http ~= nil, "client is created")
+
+    local opts = table.deepcopy(cg.opts)
+    opts.params = {
+        [2] = 4,
+        ["k&"] = "&2",
+        ["v&"] = uri.values("5=", "6 "),
+    }
+
+    local resp = http:request("GET", cg.url, nil, opts)
+    t.assert_equals(resp.status, 200)
+    t.assert_equals(resp.body, "hello world")
+    local expected_query_path = "?2=4&k%26=%262&v%26=5%3D&v%26=6%20"
+    t.assert_str_contains(resp.url, expected_query_path)
+end

--- a/test/app-luatest/uri_unit_test.lua
+++ b/test/app-luatest/uri_unit_test.lua
@@ -19,7 +19,7 @@ local uri_params_g = t.group("uri_params", {
     { params = { boolean_type = true }, query_string = "boolean_type=true" },
     { params = { integer_type = 50 }, query_string = "integer_type=50" },
     { params = { decimal_type = decimal.new(10) }, query_string = "decimal_type=10" },
-    { params = { datetime_type = datetime.new() }, query_string = "datetime_type=1970-01-01T00:00:00Z" },
+    { params = { datetime_type = datetime.new() }, query_string = "datetime_type=1970-01-01T00%3A00%3A00Z" },
     { params = { int64_type = tonumber64(-1LL) }, query_string = "int64_type=-1LL" },
     { params = { key = {""} }, query_string = "key=" },
     { params = { key = "test" }, query_string = "key=test" },
@@ -30,6 +30,16 @@ local uri_params_g = t.group("uri_params", {
 uri_params_g.test_params = function(cg)
     local uri_params = uri._internal.params
     t.assert_equals(uri_params(cg.params.params), cg.params.query_string)
+end
+
+g.test_params_escaping = function(_)
+    local uri_params = uri._internal.params
+    local params = {
+        [1] = {"ы", "d&" },
+        ["k%"] = "d%"
+    }
+    t.assert_equals(uri_params(params, uri.RFC3986),
+                    "1=%D1%8B&1=d%26&k%25=d%25")
 end
 
 local uri_encode_kv_g = t.group("uri_encode_kv", {
@@ -43,6 +53,13 @@ uri_encode_kv_g.test_encode_kv = function(cg)
     local res = {}
     encode_kv(cg.params.key, cg.params.values, res)
     t.assert_items_equals(res, cg.params.res)
+end
+
+g.test_encode_kv_escaping = function(_)
+    local encode_kv = uri._internal.encode_kv
+    local res = {}
+    encode_kv("т", { "б", "д" }, res, uri.RFC3986)
+    t.assert_items_equals(res, { "%D1%82=%D0%B1", "%D1%82=%D0%B4" })
 end
 
 local uri_values_g = t.group("uri_values", {


### PR DESCRIPTION
**Requires commits in #3682 and thus blocked by #3682**

Commits to be reviewed:

```
commit 1950807fdf18fadac99a592eaf9ee238d4bf745a (HEAD -> ligurio/gh-7931-encode-query-params)
Author: Sergey Bronnikov <sergeyb@tarantool.org>
Date:   Mon Dec 12 15:50:42 2022 +0300

    http: escape encoded params
    
    @TarantoolBot document
    Title: Document a percent-encoding of params passed to http client
    
    The HTTP client has `params` option, where a user may provide a table of
    query parameters (added in #6832). Those parameters are encoded into a
    `?foo=bar&twedledoo=tweedledee` string verbatim. If a name or a value of
    a query parameter contains `&`, `=` (or any another symbol with specific
    meaning in the URI query component), the query may be interpreted
    incorrectly by a server. Now key and values passed in a table as
    `params` option are percent-encoded and then encoded to a query string.
    This will be made automatically. Percent-encoding depends on used HTTP
    method: with `GET`, `HEAD` and `DELETE` parameters `uri.QUERY_STRING`
    are used and with other HTTP method `uri.FORM_URLENCODED` is used.
    
    Closes #7931
```

```
commit 6166d650d25ac9361df56670c209e053d7a99eeb
Author: Sergey Bronnikov <sergeyb@tarantool.org>
Date:   Fri Dec 9 18:23:05 2022 +0300

    uri: escape params
    
    NO_CHANGELOG=internal
    NO_DOC=internal
    
    Needed for #7931
```

Fixes #7931