### PR TITLE
Allow to specify different auth mechanisms

### DIFF
--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -434,7 +434,11 @@ applier_connect(struct applier *applier)
 	if (password == NULL)
 		password = "";
 	RegionGuard region_guard(&fiber()->gc);
-	const struct auth_method *method = AUTH_METHOD_DEFAULT;
+	const char *method_name = uri_param(uri, "auth_type", 0);
+	const struct auth_method *method = method_name != NULL ?
+		auth_method_by_name(method_name, strlen(method_name)) :
+		AUTH_METHOD_DEFAULT;
+	assert(method != NULL);
 	const char *auth_request, *auth_request_end;
 	assert(greeting.salt_len >= AUTH_SALT_SIZE);
 	auth_request_prepare(method, password, strlen(password), greeting.salt,

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -302,17 +302,11 @@ void box_set_replication_sync_timeout(void);
 void box_set_replication_skip_conflict(void);
 void box_set_replication_anon(void);
 void box_set_net_msg_max(void);
+int box_set_prepared_stmt_cache_size(void);
 int box_set_crash(void);
 int box_set_txn_timeout(void);
-/**
- * Set default isolation level from cfg option txn_isolation.
- * @return 0 on success, -1 on error.
- */
-int
-box_set_txn_isolation(void);
-
-int
-box_set_prepared_stmt_cache_size(void);
+int box_set_txn_isolation(void);
+int box_set_auth_type(void);
 
 /**
  * Populate cfg from box.cfg.flightrec_* parameters.

--- a/src/box/lua/cfg.cc
+++ b/src/box/lua/cfg.cc
@@ -428,6 +428,14 @@ lbox_cfg_configure_flightrec(struct lua_State *L)
 	return 0;
 }
 
+static int
+lbox_cfg_set_auth_type(struct lua_State *L)
+{
+	if (box_set_auth_type() != 0)
+		luaT_error(L);
+	return 0;
+}
+
 void
 box_lua_cfg_init(struct lua_State *L)
 {
@@ -471,6 +479,7 @@ box_lua_cfg_init(struct lua_State *L)
 		{"cfg_set_txn_timeout", lbox_cfg_set_txn_timeout},
 		{"cfg_set_txn_isolation", lbox_cfg_set_txn_isolation},
 		{"cfg_configure_flightrec", lbox_cfg_configure_flightrec},
+		{"cfg_set_auth_type", lbox_cfg_set_auth_type},
 		{NULL, NULL}
 	};
 

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -76,6 +76,8 @@ local default_cfg = {
     audit_format        = 'json',
     audit_filter        = 'compatibility',
 
+    auth_type           = 'chap-sha1',
+
     flightrec_enabled = false,
     flightrec_logs_size = 10485760,
     flightrec_logs_max_msg_size = 4096,
@@ -178,6 +180,8 @@ local template_cfg = {
     audit_nonblock      = 'boolean',
     audit_format        = 'string',
     audit_filter        = 'string',
+
+    auth_type           = 'string',
 
     flightrec_enabled = 'boolean',
     flightrec_logs_size = 'number',
@@ -352,6 +356,7 @@ local dynamic_cfg = {
     sql_cache_size          = private.cfg_set_sql_cache_size,
     txn_timeout             = private.cfg_set_txn_timeout,
     txn_isolation           = private.cfg_set_txn_isolation,
+    auth_type               = private.cfg_set_auth_type,
     wal_ext                 = private.cfg_set_wal_ext
 }
 

--- a/src/box/lua/net_box.lua
+++ b/src/box/lua/net_box.lua
@@ -96,6 +96,7 @@ local CONNECT_OPTION_TYPES = {
     console                     = "boolean",
     connect_timeout             = "number",
     fetch_schema                = "boolean",
+    auth_type                   = "string",
     required_protocol_version   = "number",
     required_protocol_features  = "table",
     _disable_graceful_shutdown  = "boolean",
@@ -315,6 +316,10 @@ local function new_sm(uri, opts)
     if opts.user == nil and opts.password == nil then
         opts.user, opts.password = parsed_uri.login, parsed_uri.password
     end
+    if opts.auth_type == nil and parsed_uri.params ~= nil and
+       parsed_uri.params.auth_type ~= nil then
+        opts.auth_type = parsed_uri.params.auth_type[1]
+    end
     local host, port = parsed_uri.host, parsed_uri.service
     local user, password = opts.user, opts.password; opts.password = nil
     local last_reconnect_error
@@ -450,7 +455,7 @@ local function new_sm(uri, opts)
     local transport = internal.new_transport(
             uri, user, password, weak_callback,
             opts.connect_timeout, opts.reconnect_after,
-            opts.fetch_schema)
+            opts.fetch_schema, opts.auth_type)
     weak_refs.transport = transport
     remote._transport = transport
     remote._gc_hook = ffi.gc(ffi.new('char[1]'), function()

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -3373,11 +3373,13 @@ end
 box.schema.user = {}
 
 box.schema.user.password = function(password)
-    return internal.prepare_auth('chap-sha1', password)
+    return internal.prepare_auth(box.cfg.auth_type, password)
 end
 
 local function prepare_auth_list(password)
-    return {['chap-sha1'] = internal.prepare_auth('chap-sha1', password)}
+    return {
+        [box.cfg.auth_type] = internal.prepare_auth(box.cfg.auth_type, password)
+    }
 end
 
 local function chpasswd(uid, new_password)

--- a/test/app-tap/init_script.result
+++ b/test/app-tap/init_script.result
@@ -6,6 +6,7 @@ box.cfg
 audit_filter:compatibility
 audit_format:json
 audit_nonblock:true
+auth_type:chap-sha1
 background:false
 checkpoint_count:2
 checkpoint_interval:3600

--- a/test/box-luatest/gh_7988_auth_type_test.lua
+++ b/test/box-luatest/gh_7988_auth_type_test.lua
@@ -1,0 +1,26 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_box_cfg = function(cg)
+    cg.server:exec(function()
+        local t = require('luatest')
+        t.assert_equals(box.cfg.auth_type, 'chap-sha1')
+        t.assert_error_msg_equals(
+            "Incorrect value for option 'auth_type': should be of type string",
+            box.cfg, {auth_type = 42})
+        t.assert_error_msg_equals(
+            "Incorrect value for option 'auth_type': chap-sha128",
+            box.cfg, {auth_type = 'chap-sha128'})
+    end)
+end

--- a/test/box/admin.result
+++ b/test/box/admin.result
@@ -33,6 +33,8 @@ cfg_filter(box.cfg)
     - json
   - - audit_nonblock
     - true
+  - - auth_type
+    - chap-sha1
   - - background
     - false
   - - checkpoint_count

--- a/test/box/cfg.result
+++ b/test/box/cfg.result
@@ -21,6 +21,8 @@ cfg_filter(box.cfg)
  |     - json
  |   - - audit_nonblock
  |     - true
+ |   - - auth_type
+ |     - chap-sha1
  |   - - background
  |     - false
  |   - - checkpoint_count
@@ -180,6 +182,8 @@ cfg_filter(box.cfg)
  |     - json
  |   - - audit_nonblock
  |     - true
+ |   - - auth_type
+ |     - chap-sha1
  |   - - background
  |     - false
  |   - - checkpoint_count


### PR DESCRIPTION
This commit adds configuration options that allow to use different authentication mechanisms:
- For generating user authentication data in `box.schema.user.passwd` - `box.cfg.auth_type`.
- For configuring replication - new uri param `auth_type`.
- For connecting via net.box - new connection option `auth_type`.

The only authentication method supported by Community Edition (CE) is 'chap-sha1' so we don't document or announce this feature in CE. More methods and tests will be added to Enterprise Edition (EE).

Closes #7988