### PR TITLE
httpc: introduce stream input/output interface

### DIFF
--- a/changelogs/unreleased/gh-7845-httpc-stream-io-interface.md
+++ b/changelogs/unreleased/gh-7845-httpc-stream-io-interface.md
@@ -1,0 +1,3 @@
+## feature/lua/http client
+
+* Introduce stream input/output interface for http.client (gh-7845).

--- a/src/curl.h
+++ b/src/curl.h
@@ -63,6 +63,12 @@ struct curl_env {
 };
 
 /**
+ * CURL request completed handler
+ */
+typedef void
+(*curl_done_handler)(void *arg);
+
+/**
  * CURL Request
  */
 struct curl_request {
@@ -77,6 +83,15 @@ struct curl_request {
 	 * until the handler (callback function) gives a signal within variable.
 	 * */
 	struct fiber_cond cond;
+	/**
+	 * The curl-driver calls the handler after the request execution has
+	 * been completed.
+	 */
+	curl_done_handler done_handler;
+	/**
+	 * The argument for done_handler.
+	 */
+	void *done_handler_arg;
 };
 
 /**
@@ -113,13 +128,22 @@ void
 curl_request_destroy(struct curl_request *curl_request);
 
 /**
- * Execute CURL request
+ * Start executing the CURL request
+ * @param curl_request request
+ * @param env environment
+ * @param curl_request request
+ */
+CURLMcode
+curl_request_start(struct curl_request *curl_request, struct curl_env *env);
+
+/**
+ * Wait for the CURL request to be completed or aborts the request by timeout
  * @param curl_request request
  * @param env environment
  * @param timeout - timeout of waiting for libcurl api
  */
 CURLMcode
-curl_execute(struct curl_request *curl_request, struct curl_env *env,
-	     double timeout);
+curl_request_finish(struct curl_request *curl_request, struct curl_env *env,
+		    double timeout);
 
 #endif /* TARANTOOL_CURL_H_INCLUDED */


### PR DESCRIPTION
Add a streaming data input/output object for http.client. The input/output object can be created using the same methods and the same options as a normal request, but with a new option {chunked = true}.

An uncompleted io object has only headers and cookies fields. A completed io object has the same fields as a normal request, but without the `body` field.

The io object interface looks like the socket object interface and should have the same description:

```
io_object:read(chunk[, timeout])
io_object:read(delimiter[, timeout])
io_object:read({chunk = chunk, delimiter = delimiter}[, timeout])
io_object:write(data[, timeout])
```

The difference is in the method `finish`. Unlike socket:close() it has an optional parameter `timeout`:

```
io_object:finish([timeout])
```

Be careful, the call may yield a fiber. The idea is to wait until a HTTP connection is finished by the server-side or force finish the connection from client-time after a timeout value.

The default timeout value is 10 seconds for all methods.

Usage example:

```lua
local io = httpc:post(url, nil, {chunked = true})

local write_chan = fiber.channel()
fiber.new(function()
    fiber.name("write to " .. url)
    while true do
        local data = write_chan:get()
        if data == nil then
            break
        end
        io:write(data, 1)
    end
end)

local recvdata
while recvdata = io:read('\r\n', 1) do
    local decoded = json.decode(recvdata)
    if condition(decoded) then
        write_chan:put(data)
    end
    if condition(decoded) then
        io:finish(1)
    end
end
write_chan:close()
```

See also:
* https://www.tarantool.io/en/doc/latest/reference/reference_lua/socket/#lua-function.socket_object.read
* https://github.com/tarantool/tarantool/issues/7845#issuecomment-1298538412
* https://github.com/tarantool/tarantool/issues/7845#issuecomment-1298821779

Closes #7845