### PR TITLE
lua: use cur_L in cord_on_yield

### DIFF
--- a/changelogs/unreleased/gh-6647-yield-gc-hook.md
+++ b/changelogs/unreleased/gh-6647-yield-gc-hook.md
@@ -1,0 +1,3 @@
+## bugfix/fiber
+
+* Fixed the assertion fail in `cord_on_yield` (gh-6647).

--- a/src/lua/utils.c
+++ b/src/lua/utils.c
@@ -882,7 +882,7 @@ void cord_on_yield(void)
 		 * world and one can obtain the corresponding Lua
 		 * coroutine from the fiber storage.
 		 */
-		struct lua_State *L = fiber()->storage.lua.stack;
+		struct lua_State *L = gco2th(gcref(g->cur_L));
 		assert(L != NULL);
 		snprintf(buf, sizeof(buf),
 			 "fiber %llu is switched while running the"
@@ -915,7 +915,7 @@ void cord_on_yield(void)
 	 */
 	if (unlikely(g->hookmask & HOOK_GC)) {
 		char buf[128];
-		struct lua_State *L = fiber()->storage.lua.stack;
+		struct lua_State *L = gco2th(gcref(g->cur_L));
 		assert(L != NULL);
 		snprintf(buf, sizeof(buf),
 			 "fiber %llu is switched while running GC"

--- a/test/box-luatest/gh_6647_yield_gc_hook_test.lua
+++ b/test/box-luatest/gh_6647_yield_gc_hook_test.lua
@@ -1,0 +1,80 @@
+local t = require('luatest')
+local g = t.group('gh-6647-yield-gc-hook')
+local fio = require('fio')
+
+local tarantool_bin = arg[-1]
+local PANIC = 256
+local ERRMSG = 'fiber [0-9]+ is switched while running GC finalizer'
+
+local function check_log(t, filename, pattern)
+    local file = fio.open(filename, {'O_RDONLY'})
+    assert(file ~= nil)
+
+    local size = file:stat().size
+    assert(size ~= 0)
+
+    local log_contents = file:pread(size, 0)
+    file:close()
+    assert(log_contents ~= '')
+    t.assert_str_contains(log_contents, pattern, true, 'invalid error message')
+end
+
+local function check_case(t, code, logfile, case_name)
+    local dir = fio.tempdir()
+    local script_path = fio.pathjoin(dir, 'script.lua')
+    local script = fio.open(script_path, {'O_CREAT', 'O_WRONLY', 'O_TRUNC'},
+        tonumber('0777', 8))
+    script:write(code)
+    script:write("\nos.exit(0)")
+    script:close()
+    local cmd = [[/bin/sh -c 'cd "%s" && "%s" ./script.lua 2>&1 /dev/null']]
+    local res = os.execute(string.format(cmd, dir, tarantool_bin))
+
+    check_log(t, fio.pathjoin(dir, logfile), ERRMSG)
+    t.assert_equals(res, PANIC,
+        'fail on fiber switch in GC finalizer: ' .. case_name)
+
+    fio.rmtree(dir)
+    return res
+end
+
+g.test_lua_iproto_call = function()
+    local lua_iproto_call = [[
+    box.cfg({listen = 'unix/:./tarantool.sock', log = 'gh-6647.log'})
+    box.schema.user.grant('guest', 'super')
+    local ffi = require('ffi')
+    local fiber = require('fiber')
+    local net_box = require('net.box')
+    local c = net_box.connect('unix/:./tarantool.sock')
+    function f()
+        local junk = {__gh_hook = ffi.gc(ffi.new('void *'), fiber.yield)}
+        junk = nil
+        collectgarbage()
+    end
+    c:call('f')
+    ]]
+    check_case(t, lua_iproto_call, 'gh-6647.log', 'lua_iproto_call')
+end
+
+g.test_space_trigger = function()
+    local space_trigger = [[
+    box.cfg({listen = 'unix/:./tarantool.sock', log = 'gh-6647.log'})
+    box.schema.user.grant('guest', 'super')
+    local ffi = require('ffi')
+    local net_box = require('net.box')
+    local fiber = require('fiber')
+
+    local function on_replace()
+        local junk = {__gh_hook = ffi.gc(ffi.new('void *'), fiber.yield)}
+        junk = nil
+        collectgarbage()
+    end
+
+    box.schema.space.create('myspace')
+    box.space.myspace:create_index('test_index',{})
+    box.space.myspace:on_replace(on_replace)
+    local c = net_box.connect('unix/:./tarantool.sock')
+    c.space.myspace:insert{1,'Hi'}
+    ]]
+    check_case(t, space_trigger, 'gh-6647.log', 'space trigger')
+end


### PR DESCRIPTION
Before the patch, fiber->storage.lua.stack is used for `panic` calls. However, some fibers don't have any Lua state saved in their storage (for example, space
triggers).

After the patch, the Lua state pointed by `cur_L` is used to make those calls, as it is always present.

As proposed by @Totktonada in https://github.com/tarantool/tarantool/pull/7976, I've checked a few cases, that could lead to the same behavior.
- fiber_new() from C -- Can't occur here, either no lua_State at all, or it is invoked from a lua fiber.
- IPROTO_CALL for a C function -- Again, no lua_State here at all.
- IPROTO_EXECUTE for a query that calls a Lua function -- Handled well for 2.x.x, not present for 1.10
- IPROTO_INSERT for a space with a trigger -- fails, added corresponding test