### PR TITLE
[2.10] ci: use actions/checkout@v3.1.0 with FreeBSD

### DIFF
--- a/.github/workflows/freebsd-12.yml
+++ b/.github/workflows/freebsd-12.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/freebsd-13.yml
+++ b/.github/workflows/freebsd-13.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
           submodules: recursive


### PR DESCRIPTION
ChristopherHX/github-act-runner@0.4.1, which we use on FreeBSD, is incompatible with newest actions/checkout@v3.2.0, aliased to @v3. Until this is resolved, FreeBSD workflows will use fixed version actions/checkout@v3.1.0.

actions/checkout@v3.2.0 fails with an unclear error:

> ⭐  Run actions/checkout@v3
>   ☁  git clone 'https://github.com/actions/checkout' # ref=v3
> Error: Unable to resolve v3: unsupported object type
> Error: Unable to resolve v3: unsupported object type
> Error:   ❌  Failure - actions/checkout@v3
> Error: unsupported object type

(cherry picked from commit a79d32b107d7958a772c11fc739c36ec0c1e571e)