### PR TITLE
box: add stub function to register extra security methods

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -276,6 +276,10 @@ if(ENABLE_READ_VIEW)
     list(APPEND box_sources ${READ_VIEW_SOURCES})
 endif()
 
+if(ENABLE_SECURITY)
+    list(APPEND box_sources ${SECURITY_SOURCES})
+endif()
+
 add_library(box STATIC ${box_sources})
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/src/box/authentication.c
+++ b/src/box/authentication.c
@@ -103,6 +103,7 @@ authenticate(const char *user_name, uint32_t user_name_len,
 	if (auth_request_check(method, auth_request, auth_request_end) != 0)
 		return -1;
 	if (user == NULL || user->def->auth == NULL ||
+	    user->def->auth->method != method ||
 	    !authenticate_request(user->def->auth, salt,
 				  auth_request, auth_request_end)) {
 		auth_res.is_authenticated = false;

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -71,6 +71,7 @@
 #include "xrow_io.h"
 #include "xstream.h"
 #include "authentication.h"
+#include "security.h"
 #include "path_lock.h"
 #include "gc.h"
 #include "sql.h"
@@ -4728,6 +4729,7 @@ box_init(void)
 	msgpack_init();
 	fiber_cond_create(&ro_cond);
 	auth_init();
+	security_init();
 	user_cache_init();
 	/*
 	 * The order is important: to initialize sessions, we need to access the
@@ -4754,6 +4756,7 @@ void
 box_free(void)
 {
 	box_storage_free();
+	security_free();
 	auth_free();
 	wal_ext_free();
 	box_watcher_free();

--- a/src/box/security.h
+++ b/src/box/security.h
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2022, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include "trivia/config.h"
+
+#if defined(ENABLE_SECURITY)
+# include "security_impl.h"
+#else /* !defined(ENABLE_SECURITY) */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+static inline void
+security_init(void) {}
+
+static inline void
+security_free(void) {}
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */
+
+#endif /* !defined(ENABLE_SECURITY) */

--- a/src/trivia/config.h.cmake
+++ b/src/trivia/config.h.cmake
@@ -279,6 +279,7 @@
 #cmakedefine ENABLE_FEEDBACK_DAEMON 1
 #cmakedefine ENABLE_WAL_EXT 1
 #cmakedefine ENABLE_READ_VIEW 1
+#cmakedefine ENABLE_SECURITY 1
 
 #cmakedefine EXPORT_LIBCURL_SYMBOLS 1
 


### PR DESCRIPTION
This PR adds a stub function that will add extra authentication methods in Tarantool Enterprise Edition. Also, it fixes a bug in `authenticate()` that can result in a crash if there's more than one authentication method available.

Needed for https://github.com/tarantool/tarantool-ee/issues/295
Follow-up #7986