### PR TITLE
vinyl: fix potential null-ptr dereference in `vy_read_view_merge`

### DIFF
--- a/src/box/vy_write_iterator.c
+++ b/src/box/vy_write_iterator.c
@@ -957,12 +957,12 @@ vy_read_view_merge(struct vy_write_iterator *stream, struct vy_entry prev,
 		 * compaction.
 		 */
 		struct tuple *copy = vy_stmt_dup(rv->entry.stmt);
+		if (copy == NULL)
+			return -1;
 		if (is_first_insert)
 			vy_stmt_set_type(copy, IPROTO_INSERT);
 		else
 			vy_stmt_set_type(copy, IPROTO_REPLACE);
-		if (copy == NULL)
-			return -1;
 		vy_stmt_set_lsn(copy, vy_stmt_lsn(rv->entry.stmt));
 		vy_stmt_unref_if_possible(rv->entry.stmt);
 		rv->entry.stmt = copy;


### PR DESCRIPTION
The `copy` ptr is checked for `NULL` after dereferencing. Found by PVS.

https://jira.vk.team/browse/TNT-698

It can hardly result in a null-ptr dereference, because `vy_stmt_dup()` uses `malloc()`, which doesn't normally fail (instead, the OOM killer just kills the process if there's a severe shortage of memory, see #3534). Still, PVS rightfully complains about it so let's fix it.

Fixes commit 902d212b6e544.