### PR TITLE
ci: update submodule to HEAD of remote branch

### DIFF
--- a/.github/workflows/submodule_update.yml
+++ b/.github/workflows/submodule_update.yml
@@ -19,7 +19,7 @@ jobs:
       CHECKOUT_BRANCH: ${{ github.ref_name }}
       FEATURE_BRANCH: 'TarantoolBot/update-tarantool-${{ github.ref_name }}'
       SUBMODULE: 'tarantool'
-      UPDATE_TO: ${{ github.ref_name }}
+      UPDATE_TO: origin/${{ github.ref_name }}
       PR_AGAINST_BRANCH: ${{ github.ref_name }}
       PR_TITLE_PREFIX: ${{ github.ref_name != 'master' &&
         format('[{0}] ', github.ref_name) || '' }}


### PR DESCRIPTION
Workflow submodule_update used the HEAD of local branch on the runner as a git reference for updating the submodule. If the repository was already checked out on the runner before, it had the same old `master` branch from the first checkout.
Now the workflow will force action tarantool/actions/update-submodule to use the HEAD of remote branch. This remote branch must be up-to-date.