### PR TITLE
log: call log_write_flightrec regardless of the log level

### DIFF
--- a/extra/exports
+++ b/extra/exports
@@ -237,7 +237,9 @@ lbox_socket_local_resolve
 lbox_socket_nonblock
 log_format
 log_level
+log_level_flightrec
 log_pid
+log_write_flightrec_from_lua
 luaJIT_profile_dumpstack
 luaJIT_profile_start
 luaJIT_profile_stop

--- a/src/lua/log.lua
+++ b/src/lua/log.lua
@@ -53,6 +53,11 @@ ffi.cdef[[
     pid_t log_pid;
     extern int log_level;
     extern int log_format;
+
+    extern int log_level_flightrec;
+    extern void
+    log_write_flightrec_from_lua(int level, const char *filename, int line,
+                                 ...);
 ]]
 
 local S_CRIT = ffi.C.S_CRIT
@@ -149,7 +154,8 @@ local function say(self, level, fmt, ...)
     local name = self and self.name
     local module_level = name and log_cfg.modules and log_cfg.modules[name] or
                          log_cfg.level
-    if level > log_normalize_level(module_level) then
+    if level > log_normalize_level(module_level) and
+       level > ffi.C.log_level_flightrec then
         return
     end
     local type_fmt = type(fmt)
@@ -203,7 +209,12 @@ local function say(self, level, fmt, ...)
         file = frame.short_src or frame.src or 'eval'
     end
 
-    ffi.C.say_from_lua(level, name, file, line, format, msg)
+    if level <= ffi.C.log_level_flightrec then
+        ffi.C.log_write_flightrec_from_lua(level, file, line, msg)
+    end
+    if level <= log_normalize_level(module_level) then
+        ffi.C.say_from_lua(level, name, file, line, format, msg)
+    end
 end
 
 -- Just a syntactic sugar over say routine.


### PR DESCRIPTION
Before commit 243234483ae8 ("log: add log.new() function that creates a new logger"), `log_write_flightrec()` was called from `log_vsay()` regardless of the log level. After, the log level is checked in Lua, so `log_vsay()` may not be called.
This patch restores the original behaviour by moving `log_write_flightrec()` calls to `say_default()` and `say()`.

Part of https://github.com/tarantool/tarantool-ee/issues/320
