### PR TITLE
Eliminate dependency of core lib headers on `libunwind.h`

### DIFF
--- a/src/lib/core/backtrace.h
+++ b/src/lib/core/backtrace.h
@@ -9,9 +9,10 @@
 #include "trivia/config.h"
 
 #ifdef ENABLE_BACKTRACE
-#include "trivia/util.h"
 
-#include "libunwind.h"
+#include <inttypes.h>
+
+#include "trivia/util.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -19,7 +20,7 @@ extern "C" {
 /*
  * Format for printing C/C++ frames.
  */
-#define C_FRAME_STR_FMT "#%-2d %p in %s+%zu"
+#define C_FRAME_STR_FMT "#%-2d %p in %s+%" PRIuPTR
 
 enum {
 	/* Maximal number of frames collected. */
@@ -76,7 +77,7 @@ backtrace_collect(struct backtrace *bt, const struct fiber *fiber,
  */
 const char *
 backtrace_frame_resolve(const struct backtrace_frame *frame,
-			unw_word_t *offset);
+			uintptr_t *offset);
 
 /*
  * Dump collected C/C++ frames to `buf`, is `SNPRINT`-compatible

--- a/src/lib/core/proc_name_cache.h
+++ b/src/lib/core/proc_name_cache.h
@@ -6,21 +6,23 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include "trivia/config.h"
 
 #ifdef ENABLE_BACKTRACE
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
-#include "libunwind.h"
 
 /* Find procedure name and offset in hash table based on RIP register value. */
 const char *
-proc_name_cache_find(unw_word_t ip, unw_word_t *offs);
+proc_name_cache_find(void *ip, uintptr_t *offs);
 
 /* Insert procedure name and offset into hash table. */
 void
-proc_name_cache_insert(unw_word_t ip, const char *name, unw_word_t offs);
+proc_name_cache_insert(void *ip, const char *name, uintptr_t offs);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif /* __cplusplus */

--- a/src/lua/backtrace.c
+++ b/src/lua/backtrace.c
@@ -10,6 +10,8 @@
 #include "core/fiber.h"
 #include "core/tt_static.h"
 
+#include "libunwind.h"
+
 #include "lua.h"
 
 /*
@@ -164,7 +166,7 @@ backtrace_lua_stack_push(const struct backtrace_lua *bt, struct lua_State *L)
 		const char *frame_str;
 		switch (frame->type) {
 		case BACKTRACE_LUA_FRAME_C: {
-			unw_word_t offset = 0;
+			uintptr_t offset = 0;
 			const char *proc_name =
 				backtrace_frame_resolve(&frame->c, &offset);
 			proc_name = proc_name != NULL ? proc_name : "??";

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -3,13 +3,6 @@ include_directories(${PROJECT_SOURCE_DIR}/src)
 include_directories(${PROJECT_BINARY_DIR}/src)
 include_directories(${PROJECT_SOURCE_DIR}/src/box)
 
-# fiber.h may require libunwind.h. Add proper header search paths.
-function(add_libunwind_include_directory target)
-  if (ENABLE_BACKTRACE AND ENABLE_BUNDLED_LIBUNWIND)
-    target_include_directories(${target} SYSTEM PRIVATE ${LIBUNWIND_INCLUDE_DIR})
-  endif()
-endfunction()
-
 # A special target with fuzzer and sanitizer flags.
 add_library(fuzzer_config INTERFACE)
 
@@ -47,11 +40,9 @@ target_link_libraries(http_parser_fuzzer PUBLIC http_parser fuzzer_config)
 
 add_executable(swim_proto_member_fuzzer swim_proto_member_fuzzer.c)
 target_link_libraries(swim_proto_member_fuzzer PUBLIC swim fuzzer_config)
-add_libunwind_include_directory(swim_proto_member_fuzzer)
 
 add_executable(swim_proto_meta_fuzzer swim_proto_meta_fuzzer.c)
 target_link_libraries(swim_proto_meta_fuzzer PUBLIC swim fuzzer_config)
-add_libunwind_include_directory(swim_proto_meta_fuzzer)
 
 add_executable(datetime_parse_full_fuzzer datetime_parse_full_fuzzer.c)
 target_link_libraries(datetime_parse_full_fuzzer PUBLIC core fuzzer_config)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -16,14 +16,6 @@ include_directories(${PROJECT_SOURCE_DIR}/third_party)
 include_directories(${ICU_INCLUDE_DIRS})
 include_directories(${CURL_INCLUDE_DIRS})
 
-# There are many unit tests that include fiber.h, which may
-# transitively include libunwind.h. When libunwind is built as
-# part of tarantool's build process, we should add libunwind's
-# headers directory into the search path.
-if (ENABLE_BACKTRACE AND ENABLE_BUNDLED_LIBUNWIND)
-  include_directories(SYSTEM ${LIBUNWIND_INCLUDE_DIR})
-endif()
-
 include_directories(${EXTRA_CORE_INCLUDE_DIRS})
 
 include(CMakeParseArguments)


### PR DESCRIPTION
The only reason why `libunwind.h` is included into `backtrace.h` (and then transitively into `fiber.h`) is use of `unw_word_t` type. Let's replace it with `uintptr_t` and use `unw_word_t` only for interacting with the unwind library.

This commit partially reverts commit 6d088b56ac34, because we don't need to include libunwind.h into tests anymore.

Fixes #8025