### PR TITLE
Don't replace `stdin` with `/dev/urandom` after fork

### DIFF
--- a/changelogs/unreleased/gh-7886-dont-close-xlog-fd-atfork.md
+++ b/changelogs/unreleased/gh-7886-dont-close-xlog-fd-atfork.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a bug when Tarantool could execute random bytes as a Lua code after fork
+  on systems with glibc version < 2.29 (gh-7886).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -4490,16 +4490,6 @@ box_cfg(void)
 	}
 }
 
-/**
- * box.coredump() forks to save a core. The entire
- * server forks in box.cfg{} if background=true.
- */
-void
-box_atfork(void)
-{
-	wal_atfork();
-}
-
 int
 box_checkpoint(void)
 {

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -107,12 +107,6 @@ box_cfg(void);
 bool
 box_is_configured(void);
 
-/**
- * A pthread_atfork() callback for box
- */
-void
-box_atfork(void);
-
 /** Check if the slice of main cord has expired. */
 int
 box_check_slice_slow(void);

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -1519,19 +1519,3 @@ wal_notify_watchers(struct wal_writer *writer, unsigned events)
 	rlist_foreach_entry(watcher, &writer->watchers, next)
 		wal_watcher_notify(watcher, events);
 }
-
-
-/**
- * After fork, the WAL writer thread disappears.
- * Make sure that atexit() handlers in the child do
- * not try to stop a non-existent thread or write
- * a second EOF marker to an open file.
- */
-void
-wal_atfork(void)
-{
-	if (xlog_is_open(&wal_writer_singleton.current_wal))
-		xlog_atfork(&wal_writer_singleton.current_wal);
-	if (xlog_is_open(&vy_log_writer.xlog))
-		xlog_atfork(&vy_log_writer.xlog);
-}

--- a/src/box/wal.h
+++ b/src/box/wal.h
@@ -205,9 +205,6 @@ void
 wal_clear_watcher(struct wal_watcher *watcher,
 		  void (*process_cb)(struct cbus_endpoint *));
 
-void
-wal_atfork(void);
-
 enum wal_mode
 wal_mode(void);
 

--- a/src/box/xlog.h
+++ b/src/box/xlog.h
@@ -558,13 +558,6 @@ xlog_sync(struct xlog *l);
 int
 xlog_close(struct xlog *l, bool reuse_fd);
 
-/**
- * atfork() handler function to close the log pointed
- * at by xlog in the child.
- */
-void
-xlog_atfork(struct xlog *xlog);
-
 /* {{{ xlog_tx_cursor - iterate over rows in xlog transaction */
 
 /**

--- a/src/main.cc
+++ b/src/main.cc
@@ -263,13 +263,6 @@ signal_reset(void)
 		say_syserror("pthread_sigmask");
 }
 
-static void
-tarantool_atfork(void)
-{
-	signal_reset();
-	box_atfork();
-}
-
 /**
  * Adjust the process signal mask and add handlers for signals.
  */
@@ -296,7 +289,7 @@ signal_init(void)
 	for (int i = 0; i < ev_sig_count; i++)
 		ev_signal_start(loop(), &ev_sigs[i]);
 
-	(void) tt_pthread_atfork(NULL, NULL, tarantool_atfork);
+	tt_pthread_atfork(NULL, NULL, signal_reset);
 }
 
 /** Run in the background. */


### PR DESCRIPTION
**box: do not close xlog file descriptors in the atfork handler**

Use `O_CLOEXEC` flag instead.

If Tarantool is forked before executing `box.cfg{}`, e.g. using `io.popen()`, the child process could start with `stdin` linked to `/dev/urandom`. This happens because `wal_writer_singleton` and `vy_log_writer` are not yet initialized, i.e. `fd` fields are 0, then atfork child handler `wal_atfork()` is called. It checks that xlog is opened (the check succeeded as 0 != -1) and closes its fd 0, in fact closing `stdin` (twice). Next, Tarantool opens the file `/dev/urandom` during initialization, and it receives the lowest unused file descriptor, which is 0. Then `luaL_loadfile()` loads `stdin` as a Lua chunk, in effect reading random numbers.

This happens on glibc 2.28 and older, as newer versions do not invoke atfork handlers during `io.popen()`: https://sourceware.org/bugzilla/show_bug.cgi?id=17490

Closes #7886