### PR TITLE
box: let authentication method require encryption

### DIFF
--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -439,6 +439,8 @@ applier_connect(struct applier *applier)
 		auth_method_by_name(method_name, strlen(method_name)) :
 		AUTH_METHOD_DEFAULT;
 	assert(method != NULL);
+	if (auth_method_check_io(method, io) != 0)
+		diag_raise();
 	const char *auth_request, *auth_request_end;
 	assert(greeting.salt_len >= AUTH_SALT_SIZE);
 	auth_request_prepare(method, password, strlen(password), greeting.salt,

--- a/src/box/auth_chap_sha1.c
+++ b/src/box/auth_chap_sha1.c
@@ -273,6 +273,7 @@ auth_chap_sha1_new(void)
 {
 	struct auth_method *method = xmalloc(sizeof(*method));
 	method->name = AUTH_CHAP_SHA1_NAME;
+	method->flags = 0;
 	method->auth_method_delete = auth_chap_sha1_delete;
 	method->auth_data_prepare = auth_chap_sha1_data_prepare;
 	method->auth_request_prepare = auth_chap_sha1_request_prepare;

--- a/src/box/authentication.c
+++ b/src/box/authentication.c
@@ -18,6 +18,7 @@
 #include "errcode.h"
 #include "error.h"
 #include "fiber.h"
+#include "iostream.h"
 #include "msgpuck.h"
 #include "session.h"
 #include "small/region.h"
@@ -120,6 +121,20 @@ ok:
 	    session_run_on_auth_triggers(&auth_res) != 0)
 		return -1;
 	credentials_reset(&current_session()->credentials, user);
+	return 0;
+}
+
+int
+auth_method_check_io(const struct auth_method *method,
+		     const struct iostream *io)
+{
+	if ((method->flags & AUTH_METHOD_REQUIRES_ENCRYPTION) != 0 &&
+	    (io->flags & IOSTREAM_IS_ENCRYPTED) == 0) {
+		diag_set(ClientError, ER_UNSUPPORTED,
+			 tt_sprintf("Authentication method '%s'", method->name),
+			 "unencrypted connection");
+		return -1;
+	}
 	return 0;
 }
 

--- a/src/box/authentication.h
+++ b/src/box/authentication.h
@@ -18,6 +18,7 @@ extern "C" {
 enum { AUTH_SALT_SIZE = 20 };
 
 struct auth_method;
+struct iostream;
 
 /** Default authentication method. */
 extern const struct auth_method *AUTH_METHOD_DEFAULT;
@@ -45,6 +46,15 @@ struct authenticator {
 	const struct auth_method *method;
 };
 
+/** Possible values of auth_method::flags. */
+enum auth_method_flag {
+	/**
+	 * Set if the authentication method may be used only if the
+	 * communication channel is encrypted (e.g. with SSL/TLS).
+	 */
+	AUTH_METHOD_REQUIRES_ENCRYPTION = 1 << 0,
+};
+
 /**
  * Abstract authentication method class.
  *
@@ -54,6 +64,8 @@ struct authenticator {
 struct auth_method {
 	/** Unique authentication method name. */
 	const char *name;
+	/** Bitwise combination of auth_method_flag. */
+	unsigned flags;
 	/** Destroys an authentication method object. */
 	void
 	(*auth_method_delete)(struct auth_method *method);
@@ -218,6 +230,15 @@ authenticate_password(const struct authenticator *auth,
 int
 authenticate(const char *user_name, uint32_t user_name_len,
 	     const char *salt, const char *tuple);
+
+/**
+ * Checks if an authentication method may be used over an IO stream.
+ *
+ * Returns 0 on success. On error, sets diag and returns -1.
+ */
+int
+auth_method_check_io(const struct auth_method *method,
+		     const struct iostream *io);
 
 /**
  * Looks up an authentication method by name.

--- a/src/box/lua/net_box.c
+++ b/src/box/lua/net_box.c
@@ -2632,6 +2632,8 @@ netbox_transport_do_auth(struct netbox_transport *transport,
 	struct netbox_options *opts = &transport->opts;
 	if (opts->user == NULL)
 		return;
+	if (auth_method_check_io(opts->auth_method, &transport->io) != 0)
+		luaT_error(L);
 	netbox_encode_auth(L, &transport->send_buf, transport->next_sync++,
 			   opts->auth_method, opts->user, opts->password,
 			   transport->greeting.salt,

--- a/src/lib/core/iostream.h
+++ b/src/lib/core/iostream.h
@@ -65,6 +65,14 @@ enum iostream_status {
 	IOSTREAM_WANT_WRITE = -3,
 };
 
+/** Possible values of iostream::flags. */
+enum iostream_flag {
+	/**
+	 * Set if the iostream is encrypted (e.g. with SSL/TLS).
+	 */
+	IOSTREAM_IS_ENCRYPTED = 1 << 0,
+};
+
 /**
  * Returns libev events corresponding to a status.
  */
@@ -108,6 +116,8 @@ struct iostream {
 	void *data;
 	/** File descriptor used for IO. Set to -1 on destruction. */
 	int fd;
+	/** Bitwise combination of iostream_flag. */
+	unsigned flags;
 #ifndef NDEBUG
 	/** Thread currently doing an IO operation on this IO stream. */
 	struct cord *owner;
@@ -123,6 +133,7 @@ iostream_clear(struct iostream *io)
 	io->vtab = NULL;
 	io->data = NULL;
 	io->fd = -1;
+	io->flags = 0;
 #ifndef NDEBUG
 	io->owner = NULL;
 #endif


### PR DESCRIPTION
If an IO stream is encrypted, it should set flag `IOSTREAM_IS_ENCRYPTED`. If an authentication method requires the channel to be encrypted, it should set flag `AUTH_METHOD_REQUIRES_ENCRYPTION`. An attempt to use an authentication method that requires encryption over an unencrypted IO stream will raise an error `ER_UNSUPPORTED("Authentication method '%s' does not support unencrypted connection")`. This check is performed by both net.box and applier.

Needed for https://github.com/tarantool/tarantool-ee/issues/322