### PR TITLE
sql: correctly calculate argument types

### DIFF
--- a/changelogs/unreleased/gh-7992-collation-of-built-in-args.md
+++ b/changelogs/unreleased/gh-7992-collation-of-built-in-args.md
@@ -1,0 +1,3 @@
+## bugfix/sql
+
+* Collation no longer mangles the type of built-in function argument (gh-7992).

--- a/src/box/sql/func.c
+++ b/src/box/sql/func.c
@@ -2155,6 +2155,8 @@ find_compatible(struct Expr *expr, struct sql_func_dictionary *dict,
 		bool is_match = true;
 		for (int j = 0; j < n && is_match; ++j) {
 			struct Expr *e = expr->x.pList->a[j].pExpr;
+			while (e->op == TK_COLLATE)
+				e = e->pLeft;
 			enum field_type a = types[argc != -1 ? j : 0];
 			enum field_type b = sql_expr_type(e);
 			switch (check) {

--- a/test/sql-luatest/gh_7992_update_collate_test.lua
+++ b/test/sql-luatest/gh_7992_update_collate_test.lua
@@ -1,0 +1,20 @@
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'gh_7992'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_ignore_collate_for_builtins = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local res = box.execute([[select abs(NULL collate "unicode_ci");]])
+        t.assert_equals(res.rows, {{box.NULL}})
+    end)
+end


### PR DESCRIPTION
This patch fixes an issue where collation could change the computed type of a built-in function argument when choosing a function implementation.

Closes #7992

NO_DOC=bugfix