### PR TITLE
Include default auth method into `IPROTO_ID` response

### DIFF
--- a/changelogs/unreleased/gh-7989-iproto-id-auth-type.md
+++ b/changelogs/unreleased/gh-7989-iproto-id-auth-type.md
@@ -1,0 +1,5 @@
+## feature/box
+
+* Added `IPROTO_AUTH_TYPE` key to `IPROTO_ID` response. The key contains
+  the name of the authentication method that is currently used on the server
+  for generating user authentication data (gh-7989).

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -64,6 +64,12 @@ struct vclock;
  */
 extern const struct vclock *box_vclock;
 
+/**
+ * Name of the authentication method that is currently used on
+ * the server (value of box.cfg.auth_type).
+ */
+extern const char *box_auth_type;
+
 /** Time to wait for shutdown triggers finished */
 extern double on_shutdown_trigger_timeout;
 

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -2291,7 +2291,7 @@ tx_process_misc(struct cmsg *m)
 			break;
 		case IPROTO_ID:
 			tx_process_id(con, &msg->id);
-			iproto_reply_id_xc(out, msg->header.sync,
+			iproto_reply_id_xc(out, box_auth_type, msg->header.sync,
 					   ::schema_version);
 			break;
 		case IPROTO_VOTE_DEPRECATED:

--- a/src/box/iproto_constants.c
+++ b/src/box/iproto_constants.c
@@ -151,6 +151,7 @@ const unsigned char iproto_key_type[IPROTO_KEY_MAX] =
 	/* 0x58 */	MP_NIL, /* IPROTO_EVENT_DATA (can be any) */
 	/* 0x59 */	MP_UINT, /* IPROTO_TXN_ISOLATION */
 	/* 0x5a */	MP_UINT, /* IPROTO_VCLOCK_SYNC */
+	/* 0x5b */	MP_STR, /* IPROTO_AUTH_TYPE */
 	/* }}} */
 };
 

--- a/src/box/iproto_constants.h
+++ b/src/box/iproto_constants.h
@@ -172,6 +172,13 @@ enum iproto_key {
 	IPROTO_TXN_ISOLATION = 0x59,
 	/** A vclock synchronisation request identifier. */
 	IPROTO_VCLOCK_SYNC = 0x5a,
+	/**
+	 * Name of the authentication method that is currently used on
+	 * the server (value of box.cfg.auth_type). It's sent in reply
+	 * to IPROTO_ID request. A client can use it as the default
+	 * authentication method.
+	 */
+	IPROTO_AUTH_TYPE = 0x5b,
 	/*
 	 * Be careful to not extend iproto_key values over 0x7f.
 	 * iproto_keys are encoded in msgpack as positive fixnum, which ends at

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -497,6 +497,7 @@ local dynamic_cfg_skip_at_load = {
     replicaset_uuid         = true,
     net_msg_max             = true,
     readahead               = true,
+    auth_type               = true,
 }
 
 -- Options that are not part of dynamic_cfg_modules and applied individually

--- a/src/box/xrow.c
+++ b/src/box/xrow.c
@@ -1126,6 +1126,30 @@ error:
 }
 
 void
+xrow_encode_id(struct xrow_header *row)
+{
+	memset(row, 0, sizeof(*row));
+	row->type = IPROTO_ID;
+	size_t size = mp_sizeof_map(2);
+	size += mp_sizeof_uint(IPROTO_VERSION) +
+		mp_sizeof_uint(IPROTO_CURRENT_VERSION);
+	size += mp_sizeof_uint(IPROTO_FEATURES) +
+		mp_sizeof_iproto_features(&IPROTO_CURRENT_FEATURES);
+	char *buf = xregion_alloc(&fiber()->gc, size);
+	char *p = buf;
+	p = mp_encode_map(p, 2);
+	p = mp_encode_uint(p, IPROTO_VERSION);
+	p = mp_encode_uint(p, IPROTO_CURRENT_VERSION);
+	p = mp_encode_uint(p, IPROTO_FEATURES);
+	p = mp_encode_iproto_features(p, &IPROTO_CURRENT_FEATURES);
+	assert((size_t)(p - buf) == size);
+	(void)p;
+	row->bodycnt = 1;
+	row->body[0].iov_base = buf;
+	row->body[0].iov_len = size;
+}
+
+void
 xrow_encode_synchro(struct xrow_header *row, char *body,
 		    const struct synchro_request *req)
 {

--- a/src/box/xrow.h
+++ b/src/box/xrow.h
@@ -253,6 +253,14 @@ struct id_request {
 	uint64_t version;
 	/** IPROTO protocol features. */
 	struct iproto_features features;
+	/**
+	 * Name of the authentication type that is currently used on
+	 * the server (value of box.cfg.auth_type). Not null-terminated.
+	 * May be NULL. Set only in response.
+	 */
+	const char *auth_type;
+	/** Length of auth_type. */
+	uint32_t auth_type_len;
 };
 
 /**
@@ -710,6 +718,7 @@ iproto_reply_ok(struct obuf *out, uint64_t sync, uint64_t schema_version);
  * Encode iproto header with IPROTO_OK response code and protocol features
  * in the body.
  * @param out Encode to.
+ * @param auth_type Authentication type.
  * @param sync Request sync.
  * @param schema_version.
  *
@@ -717,7 +726,8 @@ iproto_reply_ok(struct obuf *out, uint64_t sync, uint64_t schema_version);
  * @retval -1 Memory error.
  */
 int
-iproto_reply_id(struct obuf *out, uint64_t sync, uint64_t schema_version);
+iproto_reply_id(struct obuf *out, const char *auth_type,
+		uint64_t sync, uint64_t schema_version);
 
 /**
  * Encode iproto header with IPROTO_OK response code and vclock
@@ -1088,9 +1098,10 @@ iproto_reply_ok_xc(struct obuf *out, uint64_t sync, uint64_t schema_version)
 
 /** @copydoc iproto_reply_id. */
 static inline void
-iproto_reply_id_xc(struct obuf *out, uint64_t sync, uint64_t schema_version)
+iproto_reply_id_xc(struct obuf *out, const char *auth_type,
+		   uint64_t sync, uint64_t schema_version)
 {
-	if (iproto_reply_id(out, sync, schema_version) != 0)
+	if (iproto_reply_id(out, auth_type, sync, schema_version) != 0)
 		diag_raise();
 }
 

--- a/src/box/xrow.h
+++ b/src/box/xrow.h
@@ -266,6 +266,13 @@ int
 xrow_decode_id(const struct xrow_header *xrow, struct id_request *request);
 
 /**
+ * Encode IPROTO_ID request on the fiber region.
+ * @param[out] row request header.
+ */
+void
+xrow_encode_id(struct xrow_header *row);
+
+/**
  * Synchronous replication request - confirmation or rollback of
  * pending synchronous transactions.
  */
@@ -973,6 +980,14 @@ xrow_decode_dml_xc(struct xrow_header *row, struct request *request,
 		   uint64_t key_map)
 {
 	if (xrow_decode_dml(row, request, key_map) != 0)
+		diag_raise();
+}
+
+/** @copydoc xrow_decode_id. */
+static inline void
+xrow_decode_id_xc(const struct xrow_header *row, struct id_request *request)
+{
+	if (xrow_decode_id(row, request) != 0)
 		diag_raise();
 }
 

--- a/test/box-py/iproto.result
+++ b/test/box-py/iproto.result
@@ -207,10 +207,12 @@ space:drop()
 Invalid MsgPack - request body
 # Invalid features
 Invalid MsgPack - request body
+# Invalid auth_type
+Invalid MsgPack - request body
 # Empty request body
-version=4, features=[0, 1, 2, 3, 4]
+version=4, features=[0, 1, 2, 3, 4], auth_type=chap-sha1
 # Unknown version and features
-version=4, features=[0, 1, 2, 3, 4]
+version=4, features=[0, 1, 2, 3, 4], auth_type=chap-sha1
 
 #
 # gh-6257 Watchers

--- a/test/replication-luatest/iproto_id_error_test.lua
+++ b/test/replication-luatest/iproto_id_error_test.lua
@@ -1,0 +1,44 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.master = server:new({alias = 'master'})
+    cg.master:start()
+    cg.replica = server:new({
+        alias = 'replica',
+        box_cfg = {
+            replication = cg.master.net_box_uri,
+            replication_connect_quorum = 0,
+        },
+    })
+    cg.replica:start()
+end)
+
+g.after_all(function(cg)
+    cg.replica:drop()
+    cg.master:drop()
+end)
+
+g.test_iproto_id_error = function(cg)
+    cg.master:exec(function()
+        box.error.injection.set('ERRINJ_IPROTO_DISABLE_ID', true)
+    end)
+    cg.replica:exec(function(uri)
+        local t = require('luatest')
+        t.assert_is_not(box.info.replication[1].upstream, nil)
+        t.assert_equals(box.info.replication[1].upstream.status, 'follow')
+        box.cfg({replication = {}})
+        t.assert_is(box.info.replication[1].upstream, nil)
+        box.cfg({replication = uri})
+        t.helpers.retrying({}, function()
+            t.assert_is_not(box.info.replication[1].upstream, nil)
+            t.assert_equals(box.info.replication[1].upstream.status, 'follow')
+        end)
+    end, {g.master.net_box_uri})
+    t.assert(g.replica:grep_log(
+        'ER_UNKNOWN_REQUEST_TYPE: Unknown request type 73'))
+    t.assert(g.replica:grep_log('IPROTO_ID failed'))
+end


### PR DESCRIPTION
This PR adds a new key to the `IPROTO_ID` response: `IPROTO_AUTH_TYPE`. Its code is 0x5b, its type is `MP_STR`. It contains the name of the default authentication method used by the server (value of `box.cfg.auth_type`). A client can use this information to properly select the default authentication method in case it isn't specified explicitly with the user credentials. In the scope of this PR, we also patch net.box and applier code to use this feature.

Notes:
- Before this PR, applier didn't send `IPROTO_ID` request to the master at all, now it does. This may be useful for other things, too, e.g. retrieving the master instance name.
- Tarantool CE supports the only authentication method - 'chap-sha1'. So the feature can't be tested properly in CE. The test will be added to the EE respository (see https://github.com/tarantool/tarantool-ee/pull/330).

Closes #7989