### PR TITLE
test: skip box-luatest/gh_7743_term_initial_cfg_snap_test

### DIFF
--- a/test/box-luatest/gh_7743_term_initial_cfg_snap_test.lua
+++ b/test/box-luatest/gh_7743_term_initial_cfg_snap_test.lua
@@ -12,6 +12,7 @@ local g = t.group('gh-7743')
 --
 g.test_sigterm_during_initial_snapshot = function()
     t.tarantool.skip_if_not_debug()
+    t.skip('https://github.com/tarantool/tarantool-qa/issues/297')
     g.server = server:new({
         alias = 'master',
         env = {


### PR DESCRIPTION
The test is extremely flaky, especially on coverage builds. Let's skip it until https://github.com/tarantool/tarantool-qa/issues/297 is fixed.