### PR TITLE
test: do `jit.flush()` after `jit.off()` on arm64

### DIFF
--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -10,7 +10,10 @@ local TZ = date.TZ
     Workaround for #6599 where we may randomly fail on AWS Graviton machines,
     while it's working properly when jit disabled.
 --]]
-if jit.arch == 'arm64' then jit.off() end
+if jit.arch == 'arm64' then
+    jit.off()
+    jit.flush()
+end
 
 test:plan(39)
 

--- a/test/box-luatest/gh_6539_log_user_space_empty_or_nil_select_test.lua
+++ b/test/box-luatest/gh_6539_log_user_space_empty_or_nil_select_test.lua
@@ -10,7 +10,10 @@ g.before_all(function()
     g.server:exec(function()
         require("log").internal.ratelimit.disable()
         -- Workaround for #8011
-        if jit.arch == 'arm64' then jit.off() end
+        if jit.arch == 'arm64' then
+            jit.off()
+            jit.flush()
+        end
     end)
 end)
 

--- a/test/box-luatest/pagination_netbox_test.lua
+++ b/test/box-luatest/pagination_netbox_test.lua
@@ -9,6 +9,18 @@ net_g.before_all(function(cg)
         alias   = 'default',
     }
     cg.server:start()
+    -- Workaround for #7739, note that JIT should be disabled both locally and
+    -- on the server.
+    if jit.arch == 'arm64' then
+        jit.off()
+        jit.flush()
+    end
+    cg.server:exec(function()
+        if jit.arch == 'arm64' then
+            jit.off()
+            jit.flush()
+        end
+    end)
 end)
 
 net_g.after_all(function(cg)

--- a/test/engine-luatest/pagination_test.lua
+++ b/test/engine-luatest/pagination_test.lua
@@ -11,10 +11,9 @@ local tree_g = t.group('Tree index tests', {
 local function start_server(server)
     server:start()
     server:exec(function()
-        local jit = require('jit')
-        local tarantool = require('tarantool')
-        if string.find(tarantool.build.target, '-aarch64-') then
+        if jit.arch == 'arm64' then
             jit.off()
+            jit.flush()
         end
     end)
 end


### PR DESCRIPTION
JIT has been disabled for these 3 tests on arm64 to avoid weird fails, but they are still flaky in CI. Perhaps the JIT traces from other tests affect them. Let's try to do `jit.flush()` together with `jit.off()`.

Also disable JIT for pagination_netbox_test.lua, which suffers from the same problem as pagination_test.lua.

Part of https://github.com/tarantool/tarantool-qa/issues/162
Part of #7739
Part of #8011