### PR TITLE
luajit: bump submodule

### DIFF
--- a/changelogs/unreleased/fix-build-on-non-bash.md
+++ b/changelogs/unreleased/fix-build-on-non-bash.md
@@ -1,0 +1,3 @@
+## bugfix/build
+
+* Fixed build with external unwinding for system shells other than bash.


### PR DESCRIPTION
cmake: fix build for non-bash shells

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump