### PR TITLE
sql: remove unused variables

### DIFF
--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -499,10 +499,9 @@ int tarantoolsqlEphemeralDelete(BtCursor *pCur)
 	return 0;
 }
 
-int tarantoolsqlDelete(BtCursor *pCur, u8 flags)
+int
+tarantoolsqlDelete(struct BtCursor *pCur)
 {
-	(void)flags;
-
 	assert(pCur->curFlags & BTCF_TaCursor);
 	assert(pCur->iter != NULL);
 	assert(pCur->last_tuple != NULL);

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -740,7 +740,6 @@ sql_create_check_contraint(struct Parse *parser, bool is_field_ck)
 	struct alter_entity_def *alter_def =
 		(struct alter_entity_def *) create_ck_def;
 	assert(alter_def->entity_type == ENTITY_TYPE_CK);
-	(void) alter_def;
 	struct space *space = parser->create_column_def.space;
 	if (space == NULL)
 		space = parser->create_table_def.new_space;

--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -3408,7 +3408,6 @@ sqlExprCacheRemove(Parse * pParse, int iReg, int nReg)
 void
 sqlExprCachePush(Parse * pParse)
 {
-	struct session MAYBE_UNUSED *user_session;
 	pParse->iCacheLevel++;
 }
 
@@ -3421,8 +3420,6 @@ void
 sqlExprCachePop(Parse * pParse)
 {
 	int i = 0;
-	struct session *user_session MAYBE_UNUSED;
-	user_session = current_session();
 	assert(pParse->iCacheLevel >= 1);
 	pParse->iCacheLevel--;
 	while (i < pParse->nColCache) {
@@ -3493,9 +3490,6 @@ void
 sqlExprCacheClear(Parse * pParse)
 {
 	int i;
-	struct session MAYBE_UNUSED *user_session;
-	user_session = current_session();
-
 	for (i = 0; i < pParse->nColCache; i++) {
 		if (pParse->aColCache[i].tempReg
 		    && pParse->nTempReg < ArraySize(pParse->aTempReg)

--- a/src/box/sql/tarantoolInt.h
+++ b/src/box/sql/tarantoolInt.h
@@ -70,7 +70,10 @@ int tarantoolsqlInsert(struct space *space, const char *tuple,
 			   const char *tuple_end);
 int tarantoolsqlReplace(struct space *space, const char *tuple,
 			    const char *tuple_end);
-int tarantoolsqlDelete(BtCursor * pCur, u8 flags);
+
+/** Execute one DELETE operation. */
+int
+tarantoolsqlDelete(struct BtCursor *pCur);
 
 int
 sql_cursor_seek(struct BtCursor *cur, struct Mem *mems, uint32_t len, int *res);

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -2053,7 +2053,6 @@ case OP_ApplyType: {
  */
 case OP_MakeRecord: {
 	Mem *pData0;           /* First field to be combined into the record */
-	Mem MAYBE_UNUSED *pLast;  /* Last field of the record */
 	int nField;            /* Number of fields in the record */
 	u8 bIsEphemeral;
 
@@ -2076,7 +2075,6 @@ case OP_MakeRecord: {
 	assert(nField>0 && pOp->p2>0 && pOp->p2+nField<=(p->nMem+1 - p->nCursor)+1);
 	pData0 = &aMem[nField];
 	nField = pOp->p2;
-	pLast = &pData0[nField-1];
 
 	/* Identify the output register */
 	assert(pOp->p3<pOp->p1 || pOp->p3>=pOp->p1+pOp->p2);
@@ -3032,7 +3030,7 @@ case OP_Delete: {
 	assert(pBtCur->eState == CURSOR_VALID);
 
 	if (pBtCur->curFlags & BTCF_TaCursor) {
-		rc = tarantoolsqlDelete(pBtCur, 0);
+		rc = tarantoolsqlDelete(pBtCur);
 	} else if (pBtCur->curFlags & BTCF_TEphemCursor) {
 		rc = tarantoolsqlEphemeralDelete(pBtCur);
 	} else {
@@ -3730,7 +3728,7 @@ case OP_IdxDelete: {
 	if (res==0) {
 		assert(pCrsr->eState == CURSOR_VALID);
 		if (pCrsr->curFlags & BTCF_TaCursor) {
-			if (tarantoolsqlDelete(pCrsr, 0) != 0)
+			if (tarantoolsqlDelete(pCrsr) != 0)
 				goto abort_due_to_error;
 		} else if (pCrsr->curFlags & BTCF_TEphemCursor) {
 			if (tarantoolsqlEphemeralDelete(pCrsr) != 0)

--- a/src/box/sql/vdbeaux.c
+++ b/src/box/sql/vdbeaux.c
@@ -203,9 +203,6 @@ sqlVdbeAddOp3(Vdbe * p, int op, int p1, int p2, int p3)
 {
 	int i;
 	VdbeOp *pOp;
-	struct session MAYBE_UNUSED *user_session;
-	user_session = current_session();
-
 	i = p->nOp;
 	assert(p->magic == VDBE_MAGIC_INIT);
 	assert(op >= 0 && op < 0xff);


### PR DESCRIPTION
This patch removes unused variables that were not caught by the compiler due to MAYBE_UNUSED or conversion to void.

NO_DOC=refactoring
NO_TEST=refactoring
NO_CHANGELOG=refactoring