### PR TITLE
 [2.10] ci: add integration testing for ddl and crud 

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -135,3 +135,15 @@ jobs:
     uses: tarantool/go-tarantool/.github/workflows/reusable_testing.yml@master
     with:
       artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+
+  crud:
+    needs: tarantool
+    uses: tarantool/crud/.github/workflows/reusable_test.yml@master
+    with:
+      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+
+  ddl:
+    needs: tarantool
+    uses: tarantool/ddl/.github/workflows/reusable_test.yml@master
+    with:
+      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}


### PR DESCRIPTION
Add workflow for integration testing of ddl
and crud modules.

Part of #6619, #6620

Integration workflow: https://github.com/tarantool/tarantool/actions/runs/3799692185/jobs/6462450346