### PR TITLE
ci: add integration testing for ddl and crud

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -135,3 +135,15 @@ jobs:
     uses: tarantool/go-tarantool/.github/workflows/reusable_testing.yml@master
     with:
       artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+
+  crud:
+    needs: tarantool
+    uses: tarantool/crud/.github/workflows/reusable_test.yml@master
+    with:
+      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+
+  ddl:
+    needs: tarantool
+    uses: tarantool/ddl/.github/workflows/reusable_test.yml@master
+    with:
+      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}


### PR DESCRIPTION
Add workflow for integration testing of ddl
and crud modules.

Resolves tarantool/tarantool#6619
Resolves tarantool/tarantool#6620
