### PR TITLE
ci: fix pull_request trigger for coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,6 @@ on:
     tags:
       - '**'
   pull_request:
-    types: [ opened, reopened, synchronize, labeled ]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
The coverage workflow is a part of the default testing, so there is no sense to run this workflow when the 'full-ci' label is set. Moreover, it cancelled the run of the default testing and started the run of the full testing due to workflow `concurrency`.

By default, a workflow only runs when a `pull_request` event's activity type is `opened`, `synchronize`, or `reopened`. That's why there is no sense in the following construction:

```yml
  pull_request:
    types: [ opened, reopened, synchronize ]
```

So just removed the line related to event's activity type.