### PR TITLE
test: correct use of before_all() and after_all()

### DIFF
--- a/test/app-luatest/digest_crc32_recording_test.lua
+++ b/test/app-luatest/digest_crc32_recording_test.lua
@@ -167,10 +167,10 @@ jit.off(bucket_id_strcrc32_2)
 
 -- }}} from vshard
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new({alias = 'master'})
     g.server:start()
-end
+end)
 
 local conn
 local function r()

--- a/test/app-luatest/fiber_parent_backtrace_test.lua
+++ b/test/app-luatest/fiber_parent_backtrace_test.lua
@@ -3,7 +3,7 @@ local t = require('luatest')
 
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.dflt = server:new({alias = 'dflt'})
     g.dflt:start()
     g.dflt:exec(function()
@@ -14,11 +14,11 @@ g.before_all = function()
                                             "-DENABLE_BACKTRACE=(%a+)")
         t.skip_if(enable_bt == "FALSE", "requires backtrace feature")
     end)
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.dflt:drop()
-end
+end)
 
 g.test_fiber_parent_backtrace = function()
     g.dflt:exec(function()

--- a/test/app-luatest/gh_7479_bug_fix_uri_lib_test.lua
+++ b/test/app-luatest/gh_7479_bug_fix_uri_lib_test.lua
@@ -6,19 +6,19 @@ local net_box = require('net.box')
 local server = require('luatest.server')
 
 -- Create test instance.
-g.before_all = function()
+g.before_all(function()
     g.server = server:new({alias = 'test-gh-7479'})
     g.server:start()
     -- Get port for connection testing.
     g.server_port = g.server:exec(function()
         return require('console').listen(0):name()['port']
     end)
-end
+end)
 
 -- Stop test instance.
-g.after_all = function()
+g.after_all(function()
     g.server:stop()
-end
+end)
 
 -- Checks whether it is possible to specify only port for tarantoolctl connect.
 g.test_tarantoolctl_connect = function()

--- a/test/app-luatest/preload_test.lua
+++ b/test/app-luatest/preload_test.lua
@@ -51,7 +51,7 @@ local tempdirs = {}
 -- Remove all temporary directories created by the test
 -- unless KEEP_DATA environment variable is set to a
 -- non-empty value.
-g.after_all = function()
+g.after_all(function()
     local dirs = table.copy(tempdirs)
     tempdirs = {}
 

--- a/test/app-luatest/system_fiber_test.lua
+++ b/test/app-luatest/system_fiber_test.lua
@@ -1,14 +1,14 @@
 local server = require('luatest.server')
 local g = require('luatest').group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new{alias = 'default'}
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:drop()
-end
+end)
 
 g.test_system_fibers = function()
     g.server:exec(function(uri)

--- a/test/app-luatest/tnt_internal_symbol_test.lua
+++ b/test/app-luatest/tnt_internal_symbol_test.lua
@@ -2,12 +2,12 @@ local ffi = require('ffi')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     ffi.cdef([[
         void *
         tnt_internal_symbol(const char *name);
     ]])
-end
+end)
 
 g.test_fiber_channel = function()
     local symbols = {

--- a/test/box-luatest/begin_options_validation_test.lua
+++ b/test/box-luatest/begin_options_validation_test.lua
@@ -3,16 +3,16 @@ local t = require("luatest")
 
 local g = t.group("begin-options-validation")
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new{
         alias = "default",
     }
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:drop()
-end
+end)
 
 g.test_begin_options_validation = function()
     g.server:exec(function()

--- a/test/box-luatest/func_test.lua
+++ b/test/box-luatest/func_test.lua
@@ -3,14 +3,14 @@ local server = require('luatest.server')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new({alias = 'master'})
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:stop()
-end
+end)
 
 g.after_test('test_legacy_opts', function()
     g.server:exec(function()

--- a/test/box-luatest/gh-6786_func_index_iterator_stable_test.lua
+++ b/test/box-luatest/gh-6786_func_index_iterator_stable_test.lua
@@ -2,14 +2,14 @@ local server = require('luatest.server')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new({alias = 'master'})
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:stop()
-end
+end)
 
 g.before_test('test_func_index_iterator_stable', function()
     g.server:exec(function()

--- a/test/box-luatest/gh_5226_tuple_access_by_any_token_test.lua
+++ b/test/box-luatest/gh_5226_tuple_access_by_any_token_test.lua
@@ -2,14 +2,14 @@ local server = require('luatest.server')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new({alias = 'master'})
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:drop()
-end
+end)
 
 --
 -- Checks that accessing a tuple field by [*] ('any' token) returns nothing

--- a/test/box-luatest/gh_5940_partial_field_type_test.lua
+++ b/test/box-luatest/gh_5940_partial_field_type_test.lua
@@ -2,14 +2,14 @@ local t = require('luatest')
 local g = t.group('gh-5940')
 local server = require('luatest.server')
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new{alias = 'default'}
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:drop()
-end
+end)
 
 g.test_ddl_ops = function()
     g.server:exec(function()

--- a/test/box-luatest/gh_6246_mvcc_different_select_behavior_test.lua
+++ b/test/box-luatest/gh_6246_mvcc_different_select_behavior_test.lua
@@ -3,17 +3,17 @@ local t = require('luatest')
 
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new{
         alias   = 'default',
         box_cfg = {memtx_use_mvcc_engine = true}
     }
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:drop()
-end
+end)
 
 g.before_each(function()
     g.server:exec(function()

--- a/test/box-luatest/gh_6305_net_box_autocomplete_test.lua
+++ b/test/box-luatest/gh_6305_net_box_autocomplete_test.lua
@@ -4,17 +4,17 @@ local g = t.group()
 local net = require('net.box')
 local console = require('console')
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new({alias = 'master'})
     g.server:start()
     g.server:exec(function()
         box.schema.create_space('space1'):create_index('primary')
     end)
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:stop()
-end
+end)
 
 local function tabcomplete(s)
     return console.completion_handler(s, 0, #s)

--- a/test/box-luatest/gh_6344_mvcc_txm_story_gc_breaks_memtx_tree_iter_test.lua
+++ b/test/box-luatest/gh_6344_mvcc_txm_story_gc_breaks_memtx_tree_iter_test.lua
@@ -3,17 +3,17 @@ local t = require('luatest')
 
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new{
         alias   = 'default',
         box_cfg = {memtx_use_mvcc_engine = true}
     }
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:drop()
-end
+end)
 
 g.test_mvcc_txm_story_gc_does_not_break_memtx_tree_iter = function()
     g.server:exec(function()

--- a/test/box-luatest/gh_6421_mvcc_wrong_index_count_test.lua
+++ b/test/box-luatest/gh_6421_mvcc_wrong_index_count_test.lua
@@ -3,17 +3,17 @@ local t = require('luatest')
 
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new{
         alias   = 'default',
         box_cfg = {memtx_use_mvcc_engine = true}
     }
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:drop()
-end
+end)
 
 g.before_each(function()
     g.server:exec(function()

--- a/test/box-luatest/gh_6452_mvcc_crash_in_prepare_test.lua
+++ b/test/box-luatest/gh_6452_mvcc_crash_in_prepare_test.lua
@@ -2,17 +2,17 @@ local server = require('luatest.server')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new{
         alias   = 'default',
         box_cfg = {memtx_use_mvcc_engine = true}
     }
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:drop()
-end
+end)
 
 g.before_each(function()
     g.server:exec(function()

--- a/test/box-luatest/gh_6506_wakeup_writing_to_wal_fiber_test.lua
+++ b/test/box-luatest/gh_6506_wakeup_writing_to_wal_fiber_test.lua
@@ -2,14 +2,14 @@ local server = require('luatest.server')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new{alias = 'master'}
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:drop()
-end
+end)
 
 g.test_wakeup_writing_to_wal_fiber = function()
     g.server:exec(function()

--- a/test/box-luatest/gh_6530_net_box_opts_check_test.lua
+++ b/test/box-luatest/gh_6530_net_box_opts_check_test.lua
@@ -4,7 +4,7 @@ local net = require('net.box')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new{alias = 'default'}
     g.server:start()
     g.server:exec(function()
@@ -18,9 +18,9 @@ g.before_all = function()
     end)
 
     g.conn = net.connect(g.server.net_box_uri)
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:exec(function()
         if box.space.test then
             box.space.test:drop()
@@ -29,7 +29,7 @@ g.after_all = function()
 
     g.conn:close()
     g.server:drop()
-end
+end)
 
 g.test_netbox_connect_opts = function()
     t.assert_error_msg_contains("unexpected option 'some_opt'", function()

--- a/test/box-luatest/gh_6634_different_log_on_tuple_new_and_free_test.lua
+++ b/test/box-luatest/gh_6634_different_log_on_tuple_new_and_free_test.lua
@@ -3,16 +3,16 @@ local t = require('luatest')
 
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new{
         alias   = 'default',
     }
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:drop()
-end
+end)
 
 g.test_different_logs_on_new_and_free = function()
     g.server:exec(function()

--- a/test/box-luatest/gh_6635_garbage_of_last_prep_txn_test.lua
+++ b/test/box-luatest/gh_6635_garbage_of_last_prep_txn_test.lua
@@ -3,17 +3,17 @@ local t = require('luatest')
 
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new{
         alias   = 'default',
         box_cfg = {memtx_use_mvcc_engine = true}
     }
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:drop()
-end
+end)
 
 g.test_garbage_of_last_prepared_txn_cannot_be_deleted = function()
     g.server:exec(function()

--- a/test/box-luatest/gh_6818_iproto_resumes_input_if_no_output_test.lua
+++ b/test/box-luatest/gh_6818_iproto_resumes_input_if_no_output_test.lua
@@ -4,7 +4,7 @@ local server = require('luatest.server')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new({
         alias = 'master',
         box_cfg = {
@@ -12,11 +12,11 @@ g.before_all = function()
         }
     })
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:drop()
-end
+end)
 
 -- Checks that IPROTO resumes input stopped upon reaching the net_msg_max
 -- limit even if nothing was sent on output. This is needed to guarantee

--- a/test/box-luatest/gh_6819_iproto_watch_not_implemented_test.lua
+++ b/test/box-luatest/gh_6819_iproto_watch_not_implemented_test.lua
@@ -4,14 +4,14 @@ local server = require('luatest.server')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new({alias = 'master'})
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:drop()
-end
+end)
 
 g.before_test('test_iproto_watch_not_reported', function()
     g.server:exec(function()

--- a/test/box-luatest/gh_6824_net_box_close_on_connect_after_watch_test.lua
+++ b/test/box-luatest/gh_6824_net_box_close_on_connect_after_watch_test.lua
@@ -3,14 +3,14 @@ local server = require('luatest.server')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new({alias = 'master'})
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:drop()
-end
+end)
 
 -- Checks that close() doesn't hang if called from on_connect trigger
 -- of a connection that has watchers.

--- a/test/box-luatest/gh_6857_tuple_ext_validation_test.lua
+++ b/test/box-luatest/gh_6857_tuple_ext_validation_test.lua
@@ -12,7 +12,7 @@ local decimal = require('decimal')
 local uuid = require('uuid')
 local datetime = require('datetime')
 
-g.before_all = function()
+g.before_all(function()
     g.cluster = cluster:new({})
     local box_cfg = {
         log_level = 6,
@@ -23,11 +23,11 @@ g.before_all = function()
     })
     g.cluster:start()
     g.server:eval('function test(val) return true end')
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.cluster:drop()
-end
+end)
 
 -- Iproto keys to encode custom call request.
 local IPROTO_REQUEST_TYPE = 0x00

--- a/test/box-luatest/gh_7005_session_on_commit_rollback_test.lua
+++ b/test/box-luatest/gh_7005_session_on_commit_rollback_test.lua
@@ -2,7 +2,7 @@ local server = require('luatest.server')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new({alias = 'master'})
     g.server:start()
     g.server:exec(function()
@@ -11,11 +11,11 @@ g.before_all = function()
         box.schema.user.create('eve')
         box.schema.user.grant('eve', 'write', 'space', 'T')
     end)
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:drop()
-end
+end)
 
 -- Checks session and user in box.on_commit trigger callback.
 g.test_session_on_commit = function()

--- a/test/box-luatest/gh_7014_session_disconnect_peer_test.lua
+++ b/test/box-luatest/gh_7014_session_disconnect_peer_test.lua
@@ -3,7 +3,7 @@ local server = require('luatest.server')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new({alias = 'master'})
     g.server:start()
     g.server:exec(function()
@@ -15,11 +15,11 @@ g.before_all = function()
             rawset(_G, 'peer', box.session.peer())
         end)
     end)
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:drop()
-end
+end)
 
 g.test_session_disconnect_peer = function()
     local c = net.connect(g.server.net_box_uri,

--- a/test/box-luatest/gh_7025_mvcc_dirty_range_test.lua
+++ b/test/box-luatest/gh_7025_mvcc_dirty_range_test.lua
@@ -3,17 +3,17 @@ local t = require('luatest')
 
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new{
         alias   = 'default',
         box_cfg = {memtx_use_mvcc_engine = true}
     }
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:drop()
-end
+end)
 
 g.before_each(function()
     g.server:exec(function()

--- a/test/box-luatest/gh_7226_admin_grant_error_test.lua
+++ b/test/box-luatest/gh_7226_admin_grant_error_test.lua
@@ -3,14 +3,14 @@ local t = require('luatest')
 
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new{alias = 'default'}
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:drop()
-end
+end)
 
 g.test_grainting_to_admin = function()
     g.server:exec(function()

--- a/test/box-luatest/gh_7605_qsort_recovery_test.lua
+++ b/test/box-luatest/gh_7605_qsort_recovery_test.lua
@@ -3,16 +3,16 @@ local t = require('luatest')
 
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new{
         alias = 'default',
     }
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:drop()
-end
+end)
 
 g.before_each(function(cg)
     cg.server:exec(function()

--- a/test/box-luatest/gh_7614_fix_nullable_from_format_test.lua
+++ b/test/box-luatest/gh_7614_fix_nullable_from_format_test.lua
@@ -2,14 +2,14 @@ local server = require('luatest.server')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function(cg)
+g.before_all(function(cg)
     cg.server = server:new({alias = 'master'})
     cg.server:start()
-end
+end)
 
-g.after_all = function(cg)
+g.after_all(function(cg)
     cg.server:stop()
-end
+end)
 
 g.test_1_6_style_parts_with_format = function(cg)
     cg.server:exec(function()

--- a/test/box-luatest/ghs_16_user_enumeration_test.lua
+++ b/test/box-luatest/ghs_16_user_enumeration_test.lua
@@ -42,7 +42,7 @@ local function auth(sock_path, user, tuple)
     }
 end
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new({alias = 'master'})
     g.server:start()
     g.server:exec(function()
@@ -50,11 +50,11 @@ g.before_all = function()
         box.schema.user.create('disabled')
         box.schema.user.revoke('disabled', 'session', 'universe')
     end)
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:stop()
-end
+end)
 
 -- If we raise different errors in case of entering an invalid password and
 -- entering the login of a non-existent user during authorization, it will

--- a/test/box-luatest/ghs_5_exclude__collation_from_public_access_test.lua
+++ b/test/box-luatest/ghs_5_exclude__collation_from_public_access_test.lua
@@ -2,18 +2,18 @@ local server = require('luatest.server')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function(cg)
+g.before_all(function(cg)
     cg.server = server:new({alias = 'master'})
     cg.server:start()
     cg.server:exec(function()
         box.schema.user.create('criminal')
         box.schema.user.passwd('criminal', '123')
     end)
-end
+end)
 
-g.after_all = function(cg)
+g.after_all(function(cg)
     cg.server:stop()
-end
+end)
 
 g.test_no__collation_in_public_access = function(cg)
     cg.server:exec(function()

--- a/test/box-luatest/ghs_5_fix_auth_check_on_truncate_test.lua
+++ b/test/box-luatest/ghs_5_fix_auth_check_on_truncate_test.lua
@@ -2,14 +2,14 @@ local server = require('luatest.server')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function(cg)
+g.before_all(function(cg)
     cg.server = server:new({alias = 'master'})
     cg.server:start()
-end
+end)
 
-g.after_all = function(cg)
+g.after_all(function(cg)
     cg.server:stop()
-end
+end)
 
 g.test__truncate_insert_as_guest = function(cg)
     cg.server:exec(function()

--- a/test/box-luatest/graceful_shutdown_test.lua
+++ b/test/box-luatest/graceful_shutdown_test.lua
@@ -5,13 +5,13 @@ local server = require('luatest.server')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new({alias = 'master'})
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:stop()
-end
+end)
 
 g.before_each(function()
     if not g.server.process then

--- a/test/box-luatest/interval_test.lua
+++ b/test/box-luatest/interval_test.lua
@@ -2,14 +2,14 @@ local server = require('luatest.server')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new({alias = 'master'})
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:stop()
-end
+end)
 
 g.test_interval_create_space = function()
     g.server:exec(function()

--- a/test/box-luatest/memtx_gc_after_snapshot_test.lua
+++ b/test/box-luatest/memtx_gc_after_snapshot_test.lua
@@ -2,14 +2,14 @@ local server = require('luatest.server')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function(cg)
+g.before_all(function(cg)
     cg.server = server:new({alias = 'master'})
     cg.server:start()
-end
+end)
 
-g.after_all = function(cg)
+g.after_all(function(cg)
     cg.server:stop()
-end
+end)
 
 -- Checks that memtx tuple garbage collection is resumed after snapshot.
 g.test_memtx_gc_after_snapshot = function(cg)

--- a/test/box-luatest/net_box_test.lua
+++ b/test/box-luatest/net_box_test.lua
@@ -6,14 +6,14 @@ local urilib = require('uri')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new({alias = 'master'})
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:stop()
-end
+end)
 
 g.before_test('test_msgpack_object_args', function()
     g.server:eval('function echo(...) return ... end')

--- a/test/box-luatest/read_view_test.lua
+++ b/test/box-luatest/read_view_test.lua
@@ -2,14 +2,14 @@ local server = require('luatest.server')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function(cg)
+g.before_all(function(cg)
     cg.server = server:new({alias = 'master'})
     cg.server:start()
-end
+end)
 
-g.after_all = function(cg)
+g.after_all(function(cg)
     cg.server:stop()
-end
+end)
 
 g.test_read_view = function(cg)
     t.tarantool.skip_if_enterprise()

--- a/test/box-luatest/space_upgrade_test.lua
+++ b/test/box-luatest/space_upgrade_test.lua
@@ -2,17 +2,17 @@ local server = require('luatest.server')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new({alias = 'master'})
     g.server:start()
     g.server:exec(function()
         box.schema.create_space('test')
     end)
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:stop()
-end
+end)
 
 g.test_low_level_api = function()
     t.tarantool.skip_if_enterprise()

--- a/test/box-luatest/transport_test.lua
+++ b/test/box-luatest/transport_test.lua
@@ -3,14 +3,14 @@ local server = require('luatest.server')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new({alias = 'master'})
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:stop()
-end
+end)
 
 g.test_listen = function()
     g.server:exec(function()


### PR DESCRIPTION
Change approach of before_all() and after_all()
functions in luatest tests.

Resolves #8066