### PR TITLE
build: fix build fail on clang 15

### DIFF
--- a/changelogs/unreleased/clang-15.md
+++ b/changelogs/unreleased/clang-15.md
@@ -1,0 +1,3 @@
+## bugfix/build
+
+* Fixed `-Werror` build fail on clang 15 (gh-8110).

--- a/cmake/thread.cmake
+++ b/cmake/thread.cmake
@@ -12,26 +12,43 @@ function (do_pthread_checks)
     check_c_source_compiles("
         #include <pthread.h>
         ${INCLUDE_MISC_PTHREAD_HEADERS}
-        int main() { pthread_setname_np(pthread_self(), \"\"); }
-        " HAVE_PTHREAD_SETNAME_NP)
+
+        int main(void)
+        {
+            pthread_setname_np(pthread_self(), \"\");
+            return 0;
+        }" HAVE_PTHREAD_SETNAME_NP)
     # pthread_setname_np(<name>) - OSX
     check_c_source_compiles("
         #include <pthread.h>
         ${INCLUDE_MISC_PTHREAD_HEADERS}
-        int main() { pthread_setname_np(\"\"); }
-        " HAVE_PTHREAD_SETNAME_NP_1)
+
+        int main(void)
+        {
+            pthread_setname_np(\"\");
+            return 0;
+        }" HAVE_PTHREAD_SETNAME_NP_1)
     # pthread_set_name_np(<thread_id>, <name>) - *BSD
     check_c_source_compiles("
         #include <pthread.h>
         ${INCLUDE_MISC_PTHREAD_HEADERS}
-        int main() { pthread_set_name_np(pthread_self(), \"\"); }
-        " HAVE_PTHREAD_SET_NAME_NP)
+
+        int main(void)
+        {
+            pthread_set_name_np(pthread_self(), \"\");
+            return 0;
+        }" HAVE_PTHREAD_SET_NAME_NP)
     # pthread_getattr_np - Glibc
     check_c_source_compiles("
         #include <pthread.h>
         ${INCLUDE_MISC_PTHREAD_HEADERS}
-        int main() { pthread_attr_t a; pthread_getattr_np(pthread_self(), &a); }
-        " HAVE_PTHREAD_GETATTR_NP)
+
+        int main(void)
+        {
+            pthread_attr_t a;
+            pthread_getattr_np(pthread_self(), &a);
+            return 0;
+        }" HAVE_PTHREAD_GETATTR_NP)
     # pthread_stackseg_np - OpenBSD
     check_c_source_compiles("
         #include <pthread.h>
@@ -40,27 +57,44 @@ function (do_pthread_checks)
         #include <pthread_np.h>
         #endif
         ${INCLUDE_MISC_PTHREAD_HEADERS}
+
         stack_t ss;
-        int main() { pthread_stackseg_np(pthread_self(), &ss);
-        " HAVE_PTHREAD_STACKSEG_NP)
+
+        int main(void)
+        {
+            pthread_stackseg_np(pthread_self(), &ss);
+            return 0;
+        }" HAVE_PTHREAD_STACKSEG_NP)
     # pthread_attr_get_np - xBSD/macOS
     check_c_source_compiles("
         #include <pthread.h>
         ${INCLUDE_MISC_PTHREAD_HEADERS}
-        int main() { pthread_attr_t a; pthread_attr_get_np(pthread_self(), &a); }
-        " HAVE_PTHREAD_ATTR_GET_NP)
+
+        int main(void)
+        {
+            pthread_attr_t a;
+            pthread_attr_get_np(pthread_self(), &a);
+            return 0;
+        }" HAVE_PTHREAD_ATTR_GET_NP)
     # pthread_get_stacksize_np - OSX
     check_c_source_compiles("
         #include <pthread.h>
         ${INCLUDE_MISC_PTHREAD_HEADERS}
-        int main() { (void)pthread_get_stacksize_np(pthread_self()); }
-        " HAVE_PTHREAD_GET_STACKSIZE_NP)
+
+        int main(void)
+        {
+            (void)pthread_get_stacksize_np(pthread_self());
+            return 0;
+        }" HAVE_PTHREAD_GET_STACKSIZE_NP)
     # pthread_get_stackaddr_np - OSX
     check_c_source_compiles("
         #include <pthread.h>
         ${INCLUDE_MISC_PTHREAD_HEADERS}
-        int main() { (void)pthread_get_stackaddr_np(pthread_self()); }
-        " HAVE_PTHREAD_GET_STACKADDR_NP)
+
+        int main(void)
+        {
+            (void)pthread_get_stackaddr_np(pthread_self());
+            return 0;
+        }" HAVE_PTHREAD_GET_STACKADDR_NP)
 endfunction (do_pthread_checks)
 do_pthread_checks()
-

--- a/extra/lemon.c
+++ b/extra/lemon.c
@@ -170,12 +170,12 @@ static struct action *Action_new(void);
 static struct action *Action_sort(struct action *);
 
 /********** From the file "build.h" ************************************/
-void FindRulePrecedences();
-void FindFirstSets();
-void FindStates();
-void FindLinks();
-void FindFollowSets();
-void FindActions();
+void FindRulePrecedences(struct lemon *xp);
+void FindFirstSets(struct lemon *lemp);
+void FindStates(struct lemon *lemp);
+void FindLinks(struct lemon *lemp);
+void FindFollowSets(struct lemon *lemp);
+void FindActions(struct lemon *lemp);
 
 /********* From the file "configlist.h" *********************************/
 void Configlist_init(void);

--- a/src/box/sql/vdbeaux.c
+++ b/src/box/sql/vdbeaux.c
@@ -169,6 +169,7 @@ test_addop_breakpoint(void)
 {
 	static int n = 0;
 	n++;
+	(void)n;
 }
 #endif
 


### PR DESCRIPTION
Fixed pthread-related CMake checks. The checks code is built with `-pedantic-errors` and it leads to errors of the following kind on clang 15:

```c
<...>/CMakeFiles/CMakeScratch/TryCompile-78KaOK/src.c:4:17: error: a
    function declaration without a prototype is deprecated in all
    versions of C [-Werror,-Wstrict-prototypes]
        int main() { pthread_setname_np(pthread_self(), ""); }
                ^
                 void
```

Fixed a warning in the SQL code (it's an error in Debug build):

```c
<...>/src/box/sql/vdbeaux.c:170:13: error: variable 'n' set but not used
    [-Werror,-Wunused-but-set-variable]
        static int n = 0;
```

Fixed several warnings from lemon.c of the following kind:

```c
<...>/extra/lemon.c:173:6: warning: a function declaration without a
    prototype is deprecated in all versions of C and is treated as a
    zero-parameter prototype in C2x, conflicting with a subsequent
    definition [-Wdeprecated-non-prototype]
void FindRulePrecedences();
     ^
<...>/extra/lemon.c:766:6: note: conflicting prototype is here
void FindRulePrecedences(struct lemon *xp)
```

See also https://github.com/tarantool/small/issues/57

Fixes #8110