### PR TITLE
ci: change macos runners labels

### DIFF
--- a/.github/workflows/osx_11.yml
+++ b/.github/workflows/osx_11.yml
@@ -39,7 +39,7 @@ jobs:
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
-    runs-on: macos-11
+    runs-on: [ macos-11-self-hosted, x86_64 ]
 
     steps:
       - name: Prepare checkout

--- a/.github/workflows/osx_11_aarch64.yml
+++ b/.github/workflows/osx_11_aarch64.yml
@@ -39,7 +39,7 @@ jobs:
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
-    runs-on: macos-11-m1
+    runs-on: [ macos-11-self-hosted, aarch64 ]
 
     steps:
       - name: Prepare checkout

--- a/.github/workflows/osx_11_aarch64_debug.yml
+++ b/.github/workflows/osx_11_aarch64_debug.yml
@@ -39,7 +39,7 @@ jobs:
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
-    runs-on: macos-11-m1
+    runs-on: [ macos-11-self-hosted, aarch64 ]
 
     steps:
       - name: Prepare checkout

--- a/.github/workflows/osx_11_lto.yml
+++ b/.github/workflows/osx_11_lto.yml
@@ -39,7 +39,7 @@ jobs:
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
-    runs-on: macos-11
+    runs-on: [ macos-11-self-hosted, x86_64 ]
 
     steps:
       - name: Prepare checkout

--- a/.github/workflows/osx_12.yml
+++ b/.github/workflows/osx_12.yml
@@ -39,7 +39,7 @@ jobs:
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
-    runs-on: macos-12
+    runs-on: [ macos-12-self-hosted, x86_64 ]
 
     steps:
       - name: Prepare checkout

--- a/.github/workflows/osx_12_static_cmake.yml
+++ b/.github/workflows/osx_12_static_cmake.yml
@@ -39,7 +39,7 @@ jobs:
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
-    runs-on: macos-12
+    runs-on: [ macos-12-self-hosted, x86_64 ]
 
     steps:
       - name: Prepare checkout


### PR DESCRIPTION
Change runner label 'macos-11' to 'macos-11-self-hosted' and 'macos-12' to 'macos-12-self-hosted' to distinguish between self-hosted and GitHub-hosted runners. We want to use only self-hosted macOS runners because of test-run problems with python3.11 on GitHub-hosted macOS runners.

NO_DOC=ci
NO_TEST=ci
NO_CHANGELOG=ci