### PR TITLE
xrow: fix crash in xrow_decode_error if msg contains printf specifiers

### DIFF
--- a/changelogs/unreleased/gh-8043-net-box-error.md
+++ b/changelogs/unreleased/gh-8043-net-box-error.md
@@ -1,0 +1,5 @@
+## bugfix/core
+
+* Fixed a crash in net.box that happened if the error message raised by
+  the server contained printf formatting specifiers, such as '%d' or '%s'
+  (gh-8043).

--- a/src/box/xrow.c
+++ b/src/box/xrow.c
@@ -1604,7 +1604,6 @@ xrow_decode_error(const struct xrow_header *row)
 {
 	uint32_t code = row->type & (IPROTO_TYPE_ERROR - 1);
 
-	char error[DIAG_ERRMSG_MAX] = { 0 };
 	const char *pos;
 	uint32_t map_size;
 
@@ -1632,8 +1631,8 @@ xrow_decode_error(const struct xrow_header *row)
 			uint32_t len;
 			const char *str = mp_decode_str(&pos, &len);
 			if (!is_stack_parsed) {
-				snprintf(error, sizeof(error), "%.*s", len, str);
-				box_error_set(__FILE__, __LINE__, code, error);
+				box_error_set(__FILE__, __LINE__, code, "%.*s",
+					      len, str);
 			}
 		} else if (key == IPROTO_ERROR) {
 			struct error *e = error_unpack_unsafe(&pos);
@@ -1649,7 +1648,7 @@ xrow_decode_error(const struct xrow_header *row)
 	return;
 
 error:
-	box_error_set(__FILE__, __LINE__, code, error);
+	box_error_set(__FILE__, __LINE__, code, "");
 }
 
 int

--- a/test/box-luatest/gh_8043_net_box_error_test.lua
+++ b/test/box-luatest/gh_8043_net_box_error_test.lua
@@ -1,0 +1,38 @@
+local net = require('net.box')
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new{alias = 'default'}
+    cg.server:start()
+    cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        s:create_index('primary')
+        s:insert({1, 'with %d %f %n symbols'})
+        rawset(_G, 'test1', function()
+            error('error at %s:%d')
+        end)
+        rawset(_G, 'test2', function()
+            box.error({code = box.error.UNKNOWN, reason = '%x%y%z'})
+        end)
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_net_box_error = function(cg)
+    local c = net.connect(cg.server.net_box_uri)
+    t.assert_error_msg_content_equals(
+        'Duplicate key exists in unique index "primary" in space "test" ' ..
+        'with old tuple - [1, "with %d %f %n symbols"] ' ..
+        'and new tuple - [1, "qwe"]',
+        c.space.test.insert, c.space.test, {1, 'qwe'})
+    t.assert_error_msg_content_equals('error at %s:%d',
+                                      c.call, c, 'test1', {})
+    t.assert_error_msg_content_equals('%x%y%z',
+                                      c.call, c, 'test2', {})
+    c:close()
+end


### PR DESCRIPTION
Closes #8043