### PR TITLE
coro: fix dereferencing of `void *` pointer warning

### DIFF
--- a/third_party/coro/coro.c
+++ b/third_party/coro/coro.c
@@ -124,7 +124,7 @@ coro_init (void)
   "\tmovq %0, %%rdi\n"
   "\tcallq *%1\n"
   :
-  : "rm" (arg), "rm" (func), "m" (*arg)
+  : "rm" (arg), "rm" (func)
   : "rbp", "rax", "rcx", "rdx", "rsi", "rdi", "r8", "r9", "r10", "r11",
     "xmm0","xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7",
     "xmm8","xmm9", "xmm10", "xmm11", "xmm12", "xmm13", "xmm14", "xmm15",


### PR DESCRIPTION
Closes #8125