### PR TITLE
[backport/2.10] luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-6481-luajit-gdb-fix-lightuserdata.md
+++ b/changelogs/unreleased/gh-6481-luajit-gdb-fix-lightuserdata.md
@@ -1,0 +1,3 @@
+## bugfix/luajit
+
+* Added full-range lightuserdata support to luajit-gdb.py extension (gh-6481).

--- a/changelogs/unreleased/gh-7230-luajit-fixes.md
+++ b/changelogs/unreleased/gh-7230-luajit-fixes.md
@@ -14,3 +14,5 @@ activity, the following issues have been resolved:
   proper implementation of the corresponding JIT machinery.
 * Fixed inconsistent behaviour on signed zeros for JIT-compiled unary minus
   (gh-6976).
+* Fixed `IR_HREF` hash calculations for non-string GC objects for GC64.
+* Fixed assembling of type-check-only variant of `IR_SLOAD`.


### PR DESCRIPTION
* cmake: introduce CheckUnwindTables helper
* x64/LJ_GC64: Fix type-check-only variant of SLOAD.
* LJ_GC64: Fix ir_khash for non-string GCobj.
* gdb: support full-range 64-bit lightuserdata

Relates to #6481
Part of #7230

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump
