### PR TITLE
[backport/1.10] luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-7230-luajit-fixes.md
+++ b/changelogs/unreleased/gh-7230-luajit-fixes.md
@@ -16,3 +16,5 @@ activity, the following issues have been resolved:
   proper implementation of the corresponding JIT machinery.
 * Fixed inconsistent behaviour on signed zeros for JIT-compiled unary minus
   (gh-6976).
+* Fixed `IR_HREF` hash calculations for non-string GC objects for GC64.
+* Fixed assembling of type-check-only variant of `IR_SLOAD`.


### PR DESCRIPTION
* x64/LJ_GC64: Fix type-check-only variant of SLOAD.
* LJ_GC64: Fix ir_khash for non-string GCobj.

Part of #7230

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump
