### PR TITLE
lua: embed checks module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -63,3 +63,6 @@
 [submodule "third_party/tz"]
 	path = third_party/tz
 	url = https://github.com/tarantool/tz.git
+[submodule "third_party/checks"]
+	path = third_party/checks
+	url = https://github.com/tarantool/checks.git

--- a/changelogs/unreleased/gh-7726-embed-checks.md
+++ b/changelogs/unreleased/gh-7726-embed-checks.md
@@ -1,0 +1,3 @@
+## feature/lua
+
+* Embed tarantool/checks module for function input validation (gh-7726).

--- a/debian/copyright
+++ b/debian/copyright
@@ -382,6 +382,13 @@ Files: src/proc_title.c
 Copyright: 2000-2010, PostgreSQL Global Development Group
 License: BSD-2-Clause
 
+Files: third_party/checks/*
+The MIT License
+
+Copyright: 2012 Sierra Wireless, Fabien Fleutot
+           2018-2021 Tarantool
+License: MIT
+
 License: BSD-2-Clause
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,7 @@ endif()
 # 3rd party lua sources
 lua_source(lua_sources ../third_party/luafun/fun.lua fun_lua)
 lua_source(lua_sources ../third_party/lua/luadebug.lua luadebug_lua)
+lua_source(lua_sources ../third_party/checks/checks.lua checks_lua)
 
 # LuaJIT jit.* library
 lua_source(lua_sources ${LUAJIT_SOURCE_ROOT}/src/jit/bc.lua jit_bc_lua)

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -126,7 +126,8 @@ extern char session_lua[],
 	net_box_lua[],
 	upgrade_lua[],
 	console_lua[],
-	merger_lua[];
+	merger_lua[],
+	checks_lua[];
 
 /**
  * List of box's built-in modules written using Lua.
@@ -184,6 +185,14 @@ static const char *lua_sources[] = {
 	"box/load_cfg", NULL, load_cfg_lua,
 	"box/key_def", "key_def", key_def_lua,
 	"box/merger", "merger", merger_lua,
+	/*
+	 * To support tarantool-only types with checks, the module
+	 * must be loaded after decimal and datetime lua modules
+	 * and after box.tuple and box.error box modules. (Beware
+	 * that it won't fail to load if modules not found since
+	 * checks supports pure luajit and older tarantool versions).
+	 */
+	"third_party/checks/checks", "checks", checks_lua,
 	NULL
 };
 

--- a/test/app-luatest/checks_test.lua
+++ b/test/app-luatest/checks_test.lua
@@ -1,0 +1,7 @@
+local checks = require('checks')
+
+local package_source = debug.getinfo(checks).source
+assert(package_source:match('^@builtin') ~= nil,
+       "Run tests for built-in checks package")
+
+require('third_party.checks.test.test')

--- a/test/app-luatest/tnt_debug_getsources_test.lua
+++ b/test/app-luatest/tnt_debug_getsources_test.lua
@@ -23,6 +23,7 @@ local files = {
     'box/net_box',
     'box/console',
     'box/merger',
+    'third_party/checks/checks',
 }
 
 -- calculate reporsitory root using directory of a current
@@ -43,6 +44,9 @@ g.test_tarantool_debug_getsources = function()
     local box_lua_dir = fio.pathjoin(git_root, '/src/box/lua')
     t.assert_is_not(box_lua_dir, nil)
     t.assert(fio.stat(box_lua_dir):is_dir())
+    local third_party_dir = fio.pathjoin(git_root, '/third_party')
+    t.assert_is_not(third_party_dir, nil)
+    t.assert(fio.stat(third_party_dir):is_dir())
 
     local tnt = require('tarantool')
     t.assert_is_not(tnt, nil)
@@ -51,10 +55,15 @@ g.test_tarantool_debug_getsources = function()
 
     for _, file in pairs(files) do
         local box_prefix = 'box/'
+        local third_party_prefix = 'third_party/'
         local path
         if file:match(box_prefix) ~= nil then
             path = ('%s/%s.lua'):format(box_lua_dir,
                                         file:sub(#box_prefix + 1, #file))
+        elseif file:match(third_party_prefix) ~= nil then
+            path = ('%s/%s.lua'):format(third_party_dir,
+                                        file:sub(#third_party_prefix + 1,
+                                                 #file))
         else
             path = ('%s/%s.lua'):format(lua_src_dir, file)
         end


### PR DESCRIPTION
[tarantool/checks](https://github.com/tarantool/checks) is a lua module (distributed as a separate rock) for function input validation.
After this patch, it will a part of the tarantool binary.

Closes #7726
Needed for #7725