### PR TITLE
ci: change runner dispatch for LuaJIT testing

### DIFF
--- a/.github/workflows/luajit-integration.yml
+++ b/.github/workflows/luajit-integration.yml
@@ -10,6 +10,17 @@ name: LuaJIT integration testing
 on:
   workflow_call:
     inputs:
+      # FIXME: Make this inputs entry obligatory when transition
+      # to arch + os parameters is finished.
+      arch:
+        description: Name of the arch family to be used as a runner label
+        required: false
+        type: string
+        # XXX: Temporary ugly hack: use 'self-hosted' as a default
+        # value to fool GitHub Actions machinery choosing the
+        # appropriate runner for the workflow (since the empty
+        # string is not a valid parameter).
+        default: self-hosted
       # FIXME: Remove this inputs entry when transition to
       # CMAKE_EXTRA_PARAMS usage is finished.
       buildtype:
@@ -29,10 +40,28 @@ on:
         required: false
         type: string
         default: OFF
+      # FIXME: Remove this inputs entry when transition to
+      # arch + os parameters is finished.
       host:
         description: Type of machine to run the GitHub job on
-        required: true
+        required: false
         type: string
+        # XXX: Temporary ugly hack: use 'self-hosted' as a default
+        # value to fool GitHub Actions machinery choosing the
+        # appropriate runner for the workflow (since the empty
+        # string is not a valid parameter).
+        default: self-hosted
+      # FIXME: Make this inputs entry obligatory when transition
+      # to arch + os parameters is finished.
+      os:
+        description: Name of the OS family to be used as a runner label
+        required: false
+        type: string
+        # XXX: Temporary ugly hack: use 'self-hosted' as a default
+        # value to fool GitHub Actions machinery choosing the
+        # appropriate runner for the workflow (since the empty
+        # string is not a valid parameter).
+        default: self-hosted
       release:
         description: Git revision from tarantool/tarantool repository
         required: false
@@ -45,7 +74,7 @@ on:
 
 jobs:
   luajit-integration:
-    runs-on: [ self-hosted, '${{ inputs.host }}' ]
+    runs-on: [regular, '${{ inputs.os }}', '${{ inputs.arch }}', '${{ inputs.host }}']
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master


### PR DESCRIPTION
Before the patch the LuaJIT integration workflow was dispatched to the runner with the name given via <inputs.host> parameter. Unfortunately, as a result of runners renaming we can't continue to dispatch the workflow this way.

As a result of the patch there are two new workflow parameters: <inputs.arch> to pass the host architecture name (i.e. x86_64 or ARM64) and <inputs.os> to pass the OS family name (either Linux or macOS). Considering two values we can choose the proper runner in LuaJIT integration workflow. Besides, this change bring LuaJIT CI closer to matrix usage for its integration workflow.

All three workflow parameters are not obligatory for now to avoid tarantool/luajit CI break on both long-term and working branches. When all branches are rebased on the new approach, <inputs.host> parameter will be removed and both <inputs.arch> and <inputs.os> will become obligatory.

Moreover, the new 'regular' label is also added to <runs-on> list, since the new "lightweight" runners have been introduced to ghacts-shared-* pool. There are a couple of LuaJIT tests that requires more memory than provided by "lightweight" runners, so only "regular" ones need to be chosen for LuaJIT integration testing.

Last but not least: attentive reader might notice there are strange values used as a default for <inputs.host> as well as <inputs.arch> and <inputs.os>. This is ugly hack required for the transition period, since one can't use empty string or unknown label name within <runs-on> label list. Hence 'self-hosted' looks like the most robust option for both old and new behaviours.

---

P.S. LuaJIT CI is [green](https://github.com/tarantool/luajit/commit/79abe5b) as a result of this patch.