### PR TITLE
lua: gracefully fail space on/before replace trigger if txn was aborted

### DIFF
--- a/changelogs/unreleased/gh-8027-txn-handle-abort-in-trigger.md
+++ b/changelogs/unreleased/gh-8027-txn-handle-abort-in-trigger.md
@@ -1,0 +1,5 @@
+## bugfix/core
+
+* Fixed a crash that happened if the transaction was aborted (for example,
+  by fiber yield with MVCC off) while space `on_replace` or `before_replace`
+  was running (gh-8027).

--- a/src/lua/trigger.h
+++ b/src/lua/trigger.h
@@ -38,8 +38,10 @@ extern "C" {
 struct lua_State;
 
 /**
- * The job of lbox_push_event_f is to push trigger arguments
- * to Lua stack.
+ * If not NULL, lbox_push_event_f will be called before execution
+ * of the trigger callback. It's supposed to push trigger arguments
+ * to Lua stack and return the number of pushed values on success.
+ * On error, it should set diag and return a negative number.
  */
 typedef int
 (*lbox_push_event_f)(struct lua_State *L, void *event);

--- a/test/box-luatest/gh_8027_txn_handle_abort_in_trigger_test.lua
+++ b/test/box-luatest/gh_8027_txn_handle_abort_in_trigger_test.lua
@@ -1,0 +1,92 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new({
+        alias = 'default',
+        box_cfg = {memtx_use_mvcc_engine = false},
+    })
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:stop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+g.test_yield_before_replace = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        local t = require('luatest')
+        local s = box.schema.create_space('test')
+        s:create_index('primary')
+        s:before_replace(function(_, new)
+            if new[1] == 10 then
+                fiber.yield()
+            end
+            return new
+        end)
+        s:before_replace(function(_, new)
+            if new[2] == 10 then
+                fiber.yield()
+            end
+            return new
+        end)
+        local errmsg = 'Transaction has been aborted by a fiber yield'
+        t.assert_error_msg_equals(errmsg, s.insert, s, {10, 1})
+        t.assert_error_msg_equals(errmsg, s.insert, s, {1, 10})
+        box.begin()
+        s:insert({1, 1})
+        t.assert_error_msg_equals(errmsg, s.insert, s, {10, 1})
+        t.assert_error_msg_equals(errmsg, box.commit)
+        t.assert_equals(s:select(), {})
+        box.begin()
+        s:insert({1, 1})
+        t.assert_error_msg_equals(errmsg, s.insert, s, {2, 10})
+        t.assert_error_msg_equals(errmsg, box.commit)
+        t.assert_equals(s:select(), {})
+    end)
+end
+
+g.test_yield_on_replace = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        local t = require('luatest')
+        local s = box.schema.create_space('test')
+        s:create_index('primary')
+        s:on_replace(function(_, new)
+            if new[1] == 10 then
+                fiber.yield()
+            end
+            return new
+        end)
+        s:on_replace(function(_, new)
+            if new[2] == 10 then
+                fiber.yield()
+            end
+            return new
+        end)
+        local errmsg = 'Transaction has been aborted by a fiber yield'
+        t.assert_error_msg_equals(errmsg, s.insert, s, {10, 1})
+        t.assert_error_msg_equals(errmsg, s.insert, s, {1, 10})
+        box.begin()
+        s:insert({1, 1})
+        s:insert({10, 1})
+        t.assert_error_msg_equals(errmsg, box.commit)
+        t.assert_equals(s:select(), {})
+        box.begin()
+        s:insert({1, 1})
+        t.assert_error_msg_equals(errmsg, s.insert, s, {2, 10})
+        t.assert_error_msg_equals(errmsg, box.commit)
+        t.assert_equals(s:select(), {})
+    end)
+end


### PR DESCRIPTION
`lbox_push_event_f` and `lbox_push_event_f` callback functions used for passing the statement between txn and space on/before replace Lua triggers don't assume that the transaction may be aborted by yield after the current statement began (this may happen if a trigger callback yields). In this case, all statements in txn would be rolled back and `txn_current_stmt` would return `NULL`, leading to a crash.

Let's fix this by checking if the transaction is still active and raising an error immediately if it isn't, thus skipping Lua triggers.

Notes:
 - We merged `lbox_pop_txn_stmt_and_check_format` into `lbox_pop_txn_stmt`, because the latter is only called by the former.
 - Since `lbox_push_event_f` callback may now fail, we have to update `lbox_trigger_run` to handle it.

Closes #8027