### PR TITLE
third_party: update libcurl from 7.84.0 to 7.87.0

### DIFF
--- a/changelogs/unreleased/bump-libcurl-to-7.87.0.md
+++ b/changelogs/unreleased/bump-libcurl-to-7.87.0.md
@@ -1,0 +1,3 @@
+## feature/build
+
+* Updated libcurl to version 7.87.0 (gh-8150).

--- a/cmake/BuildLibCURL.cmake
+++ b/cmake/BuildLibCURL.cmake
@@ -187,6 +187,7 @@ macro(curl_build)
     list(APPEND LIBCURL_CMAKE_FLAGS "-DENABLE_CURLDEBUG=OFF")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DENABLE_DEBUG=OFF")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DUSE_MSH3=OFF")
+    list(APPEND LIBCURL_CMAKE_FLAGS "-DENABLE_WEBSOCKETS=OFF")
 
     # We need PIC at least to enable build for Fedora on
     # ARM64 CPU. Without it configuration with Fedora

--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Build-Depends: cdbs (>= 0.4.100), debhelper (>= 9), dpkg-dev (>= 1.16.1~),
 # make package manager seek for cmake3 package at first and use it
 # if found or fallback to cmake package (that provides CMake 3+
 # for modern distributions) otherwise.
- cmake3 (>= 3.3) | cmake (>= 3.3),
+ cmake3 (>= 3.3) | cmake (>= 3.7),
  libreadline-dev,
  libncurses5-dev,
  libssl-dev,

--- a/debian/prebuild.sh
+++ b/debian/prebuild.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -exu
+
+# Ubuntu Xenial has a CMake version that doesn't support
+# keywords used in curl's CMake.
+if [[ $DIST == "xenial" ]]; then
+  wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+  echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ xenial main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
+  sudo apt-get update
+fi


### PR DESCRIPTION
Changelog: https://curl.se/changes.html#7_87_0

New release contains fixes for 7 security problems [1]:

https://curl.se/docs/CVE-2022-35252.html
https://curl.se/docs/CVE-2022-32221.html
https://curl.se/docs/CVE-2022-35260.html
https://curl.se/docs/CVE-2022-42915.html
https://curl.se/docs/CVE-2022-42916.html
https://curl.se/docs/CVE-2022-43551.html
https://curl.se/docs/CVE-2022-43552.html

Patch adds a new option ENABLE_WEBSOCKETS defined in curl build
infrastructure with it's default value used in 7.87.0.

1. https://curl.se/docs/releases.html

Closes #8150 

**NOTE:** CodeQL alerts found in libcurl have been dismissed, I found them not important.
See details in https://github.com/tarantool/tarantool/pull/8151/checks?check_run_id=10613562871

**NOTE:** Depends on PR with fixes in smtp module https://github.com/tarantool/smtp/pull/71