### PR TITLE
log: fix inability to start from the root directory

### DIFF
--- a/test/app-luatest/gh_8158_start_from_root_dir_test.lua
+++ b/test/app-luatest/gh_8158_start_from_root_dir_test.lua
@@ -1,0 +1,17 @@
+local t = require('luatest')
+local g = t.group('gh-8158')
+
+-- Check that Tarantool can be successfully started from the root directory.
+g.test_start_from_root_dir = function()
+    local popen = require('popen')
+    local tarantool_exe = arg[-1]
+
+    -- Use `cd' and `shell = true' due to lack of cwd option in popen (gh-5633).
+    local cmd = string.format('cd / && %s -e "os.exit()"', tarantool_exe)
+    local ph = popen.new({cmd}, {shell = true})
+    t.assert(ph)
+    local status = ph:wait()
+    t.assert(status.state == popen.state.EXITED)
+    t.assert(status.exit_code == 0)
+    ph:close()
+end

--- a/test/app-luatest/per_module_log_unit_test.lua
+++ b/test/app-luatest/per_module_log_unit_test.lua
@@ -1,0 +1,36 @@
+local t = require('luatest')
+local g = t.group('per_module_log_unit')
+
+local tarantool = require('tarantool')
+local strip_cwd_from_path = tarantool._internal.strip_cwd_from_path
+local module_name_from_filename = tarantool._internal.module_name_from_filename
+
+g.test_strip_cwd_from_path = function()
+    local testcases = {
+        { cwd = '/', path = '/', expected = '' },
+        { cwd = '/', path = '/aaa/bbb/ccc', expected = 'aaa/bbb/ccc' },
+        { cwd = '/home/aaa/bbb', path = '/home/aaa/bbb/ccc/ddd', expected = 'ccc/ddd' },
+        { cwd = '/home/some/other/path', path = '/home/aaa/bbb', expected = 'aaa/bbb' },
+        { cwd = '/totally/different', path = '/home/aaa/bbb', expected = 'home/aaa/bbb' },
+        { cwd = '/doesnt/matter', path = 'aaa/bbb', expected = 'aaa/bbb' },
+        { cwd = '/qwerty', path = '/aaa/qwerty/bbb', expected = 'aaa/qwerty/bbb' },
+        { cwd = '/home/a-aa/bbb', path = '/home/a-aa/bbbccc/ddd', expected = 'bbbccc/ddd' },
+        { cwd = '/home/common_qwe', path = '/home/common_asd/aaa', expected = 'common_asd/aaa' },
+    }
+    for _, test in pairs(testcases) do
+        t.assert_equals(strip_cwd_from_path(test.cwd, test.path), test.expected)
+    end
+end
+
+g.test_module_name_from_filename = function()
+    local fio = require('fio')
+    local testcases = {
+        { filename = 'my/modules/test1.lua', expected = 'my.modules.test1' },
+        { filename = '/etc/modules/test2/init.lua', expected = 'etc.modules.test2' },
+        { filename = fio.pathjoin(fio.cwd(), 'mod/test3.lua'), expected = 'mod.test3' },
+        { filename = 'builtin/box/feedback_daemon.lua', expected = 'box.feedback_daemon' },
+    }
+    for _, test in pairs(testcases) do
+        t.assert_equals(module_name_from_filename(test.filename), test.expected)
+    end
+end


### PR DESCRIPTION
The function `remove_root_directory`, which is used for obtaining module names for per-module logging, throws an error when current working directory is `/`. Rewrite it to fix the bug and rename it to `strip_cwd_from_path` to make the name more clear.

Closes #8158