### PR TITLE
raft: fix an assertion failure in raft_stop_candidate

### DIFF
--- a/changelogs/unreleased/gh-8169-raft-assert-on-wal-write.md
+++ b/changelogs/unreleased/gh-8169-raft-assert-on-wal-write.md
@@ -1,0 +1,4 @@
+## bugfix/raft
+
+* Fixed an assertion failure in case an election candidate is reconfigured to a
+  voter during an ongoning WAL write (gh-8169).

--- a/src/lib/raft/raft.c
+++ b/src/lib/raft/raft.c
@@ -1163,9 +1163,11 @@ raft_stop_candidate(struct raft *raft)
 	} else {
 		/*
 		 * Leader is seen and node is waiting for its death. Do not stop
-		 * the timer.
+		 * the timer. If there is a write in progress the timer is
+		 * stopped now, but will be re-started once the write completes.
 		 */
-		assert(raft_ev_timer_is_active(&raft->timer));
+		assert(raft_ev_timer_is_active(&raft->timer) ||
+		       raft->is_write_in_progress);
 	}
 	raft->state = RAFT_STATE_FOLLOWER;
 	raft_schedule_broadcast(raft);


### PR DESCRIPTION
There is a false assertion in raft_stop_candidate(): it assumes that the node must always have a running timer whenever it sees the leader. This is not true when the node is busy writing the new term on disk.

Cover the mentioned case in the assertion.

Closes #8169

NO_DOC=bugfix

Co-authored-by: Sergey Ostanevich <sergos@tarantool.org>