### PR TITLE
cmake: use project dir instead of cmake dir when building libunwind

### DIFF
--- a/cmake/BuildLibUnwind.cmake
+++ b/cmake/BuildLibUnwind.cmake
@@ -56,7 +56,7 @@ ext_project_autotools(libunwind-build
 unset(LIBUNWIND_CFLAGS)
 unset(LIBUNWIND_CXXFLAGS)
 
-set(LIBUNWIND_BUILD_DIR ${CMAKE_BINARY_DIR}/third_party/libunwind)
+set(LIBUNWIND_BUILD_DIR ${PROJECT_BINARY_DIR}/third_party/libunwind)
 
 add_library(bundled-libunwind STATIC IMPORTED GLOBAL)
 set_target_properties(bundled-libunwind PROPERTIES
@@ -72,7 +72,7 @@ add_dependencies(bundled-libunwind-platform libunwind-build)
 
 set(LIBUNWIND_INCLUDE_DIR
     ${LIBUNWIND_BUILD_DIR}/include
-    ${CMAKE_SOURCE_DIR}/third_party/libunwind/include)
+    ${PROJECT_SOURCE_DIR}/third_party/libunwind/include)
 set(LIBUNWIND_LIBRARIES
     ${LIBUNWIND_BUILD_DIR}/src/.libs/libunwind-${CMAKE_SYSTEM_PROCESSOR}.a
     ${LIBUNWIND_BUILD_DIR}/src/.libs/libunwind.a)

--- a/cmake/ext_project_autotools.cmake
+++ b/cmake/ext_project_autotools.cmake
@@ -46,7 +46,7 @@ function(ext_project_autotools name)
         file(
             GLOB_RECURSE autotool_files_am
             CONFIGURE_DEPENDS
-            RELATIVE "${CMAKE_SOURCE_DIR}"
+            RELATIVE "${PROJECT_SOURCE_DIR}"
             "${ARGS_DIR}/*.am"
         )
 
@@ -55,18 +55,18 @@ function(ext_project_autotools name)
         file(
             GLOB_RECURSE config_files_in
             CONFIGURE_DEPENDS
-            RELATIVE "${CMAKE_SOURCE_DIR}"
+            RELATIVE "${PROJECT_SOURCE_DIR}"
             "${ARGS_DIR}/*.in"
         )
     endif()
 
     list_add_prefix(ARGS_BYPRODUCTS "${ARGS_DIR}/" byproducts)
 
-    file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${ARGS_DIR})
+    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/${ARGS_DIR})
 
     add_custom_command(
-        OUTPUT ${CMAKE_SOURCE_DIR}/${ARGS_DIR}/configure
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/${ARGS_DIR}
+        OUTPUT ${PROJECT_SOURCE_DIR}/${ARGS_DIR}/configure
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${ARGS_DIR}
         COMMAND
             autoreconf -i
         COMMAND
@@ -80,7 +80,7 @@ function(ext_project_autotools name)
     add_custom_command(
         OUTPUT ${ARGS_DIR}/Makefile
         WORKING_DIRECTORY ${ARGS_DIR}
-        COMMAND ${CMAKE_SOURCE_DIR}/${ARGS_DIR}/configure ${ARGS_CONFIGURE}
+        COMMAND ${PROJECT_SOURCE_DIR}/${ARGS_DIR}/configure ${ARGS_CONFIGURE}
         DEPENDS ${ARGS_DIR}/configure
     )
 


### PR DESCRIPTION
The EE CMakeConfig.txt adds CE as a sub-directory. For this to work, we should use project dir instead of cmake dir in CE cmake files, see commit d80973259779 ("cmake: align folders dependencies").

Fixes commit 14f93aee86b8 ("libunwind: improve incremental build/rebuild").

Follow-up #8019