### PR TITLE
Maintenance of LuaJIT integration CI

### DIFF
--- a/.github/workflows/luajit-integration.yml
+++ b/.github/workflows/luajit-integration.yml
@@ -2,7 +2,7 @@
 # implement integration testing without manual LuaJIT submodule
 # bump and draft PR creation.
 # It bumps the given LuaJIT revision for the given Tarantool
-# release, builds Tarantool with the given buildtype and GC64
+# release, builds Tarantool with the given CMAKE_EXTRA_PARAMS
 # option and runs Tarantool testing suite.
 
 name: LuaJIT integration testing
@@ -96,7 +96,5 @@ jobs:
 
       - name: Run tests
         env:
-          CMAKE_EXTRA_PARAMS: >
-            -DCMAKE_BUILD_TYPE=${{ inputs.buildtype }}
-            -DLUAJIT_ENABLE_GC64=${{ inputs.GC64 }}
+          CMAKE_EXTRA_PARAMS: ${{ inputs.CMAKE_EXTRA_PARAMS }}
         run: make -f .test.mk test-luajit-${{ inputs.os }}-${{ inputs.arch }}

--- a/.github/workflows/luajit-integration.yml
+++ b/.github/workflows/luajit-integration.yml
@@ -10,17 +10,10 @@ name: LuaJIT integration testing
 on:
   workflow_call:
     inputs:
-      # FIXME: Make this inputs entry obligatory when transition
-      # to arch + os parameters is finished.
       arch:
         description: Name of the arch family to be used as a runner label
-        required: false
+        required: true
         type: string
-        # XXX: Temporary ugly hack: use 'self-hosted' as a default
-        # value to fool GitHub Actions machinery choosing the
-        # appropriate runner for the workflow (since the empty
-        # string is not a valid parameter).
-        default: self-hosted
       # FIXME: Remove this inputs entry when transition to
       # CMAKE_EXTRA_PARAMS usage is finished.
       buildtype:
@@ -40,28 +33,10 @@ on:
         required: false
         type: string
         default: OFF
-      # FIXME: Remove this inputs entry when transition to
-      # arch + os parameters is finished.
-      host:
-        description: Type of machine to run the GitHub job on
-        required: false
-        type: string
-        # XXX: Temporary ugly hack: use 'self-hosted' as a default
-        # value to fool GitHub Actions machinery choosing the
-        # appropriate runner for the workflow (since the empty
-        # string is not a valid parameter).
-        default: self-hosted
-      # FIXME: Make this inputs entry obligatory when transition
-      # to arch + os parameters is finished.
       os:
         description: Name of the OS family to be used as a runner label
-        required: false
+        required: true
         type: string
-        # XXX: Temporary ugly hack: use 'self-hosted' as a default
-        # value to fool GitHub Actions machinery choosing the
-        # appropriate runner for the workflow (since the empty
-        # string is not a valid parameter).
-        default: self-hosted
       release:
         description: Git revision from tarantool/tarantool repository
         required: false
@@ -74,7 +49,7 @@ on:
 
 jobs:
   luajit-integration:
-    runs-on: [regular, '${{ inputs.os }}', '${{ inputs.arch }}', '${{ inputs.host }}']
+    runs-on: [self-hosted, regular, '${{ inputs.os }}', '${{ inputs.arch }}']
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
@@ -111,23 +86,17 @@ jobs:
       - name: Set environment
         uses: ./.github/actions/environment
 
-      - name: Get machine platform and arch
-        run: |
-          echo PLATFORM=$(uname -s | tr '[:upper:]' '[:lower:]') | \
-            tee -a ${GITHUB_ENV}
-          echo ARCH=$(uname -m) | tee -a ${GITHUB_ENV}
-
       - name: Install deps on Linux
         uses: ./.github/actions/install-deps-debian
-        if: ${{ env.PLATFORM == 'linux' }}
+        if: ${{ inputs.os == 'Linux' }}
 
       - name: Install deps on Darwin
         uses: ./.github/actions/install-deps-osx
-        if: ${{ env.PLATFORM == 'darwin' }}
+        if: ${{ inputs.os == 'macOS' }}
 
       - name: Run tests
         env:
           CMAKE_EXTRA_PARAMS: >
             -DCMAKE_BUILD_TYPE=${{ inputs.buildtype }}
             -DLUAJIT_ENABLE_GC64=${{ inputs.GC64 }}
-        run: make -f .test.mk test-luajit-${{ env.PLATFORM }}-${{ env.ARCH }}
+        run: make -f .test.mk test-luajit-${{ inputs.os }}-${{ inputs.arch }}

--- a/.test.mk
+++ b/.test.mk
@@ -275,10 +275,10 @@ test-coverity: build-coverity
 # LuaJIT integration testing #
 ##############################
 
-test-luajit-linux-x86_64: build run-luajit-test run-test
+test-luajit-Linux-x86_64: build run-luajit-test run-test
 
-test-luajit-linux-aarch64: build run-luajit-test run-test
+test-luajit-Linux-ARM64: build run-luajit-test run-test
 
-test-luajit-darwin-x86_64: prebuild-osx build run-luajit-test pretest-osx run-test
+test-luajit-macOS-x86_64: prebuild-osx build run-luajit-test pretest-osx run-test
 
-test-luajit-darwin-arm64: prebuild-osx build run-luajit-test
+test-luajit-macOS-ARM64: prebuild-osx build run-luajit-test


### PR DESCRIPTION
Small changes to remove the old code from LuaJIT integration CI:
* Removed the obsolete `inputs.host` parameter
* Enabled `CMAKE_EXTRA_PARAMS` for .test.mk (since #8026 has been fixed)

---

P.S. LuaJIT CI is [green](https://github.com/tarantool/luajit/commit/52ff4c3) as a result of this patch.