### PR TITLE
raft: fix 'manual' nodes bumping the term excessively

### DIFF
--- a/changelogs/unreleased/gh-8168-double-term-bump-on-promote.md
+++ b/changelogs/unreleased/gh-8168-double-term-bump-on-promote.md
@@ -1,0 +1,4 @@
+## bugfix/raft
+
+* Fixed nodes configured with `election_mode` = "manual" sometimes bumping the
+  election term excessively after their promotion (gh-8168).

--- a/src/lib/raft/raft.c
+++ b/src/lib/raft/raft.c
@@ -333,7 +333,12 @@ raft_sm_schedule_new_election(struct raft *raft);
 static inline void
 raft_sm_election_update(struct raft *raft)
 {
-	if (!raft->is_candidate)
+	/*
+	 * The node might be promoted for current term, in which case
+	 * is_candidate would be true. But it's not enough. If is_cfg_candidate
+	 * is false, the node would give up as soon as new term starts.
+	 */
+	if (!raft->is_cfg_candidate)
 		return;
 	/*
 	 * Pre-vote protection. Every node must agree that the leader is gone.
@@ -614,8 +619,10 @@ raft_process_msg(struct raft *raft, const struct raft_msg *req, uint32_t source)
 			/*
 			 * No need for pre-vote checks when the leader
 			 * deliberately told us it's resigning.
+			 * Note, the only case when automatic elections are
+			 * allowed is when the node is configured candidate.
 			 */
-			if (raft->is_candidate)
+			if (raft->is_cfg_candidate)
 				raft_sm_schedule_new_election(raft);
 		}
 		return 0;
@@ -950,7 +957,7 @@ static void
 raft_sm_schedule_new_election(struct raft *raft)
 {
 	say_info("RAFT: begin new election round");
-	assert(raft->is_candidate);
+	assert(raft->is_cfg_candidate);
 	/* Everyone is a follower until its vote for self is persisted. */
 	raft_sm_schedule_new_term(raft, raft->volatile_term + 1);
 	raft_sm_schedule_new_vote(raft, raft->self, raft->vclock);

--- a/test/replication-luatest/gh_8168_extra_term_bump_test.lua
+++ b/test/replication-luatest/gh_8168_extra_term_bump_test.lua
@@ -1,0 +1,46 @@
+local t = require('luatest')
+local replica_set = require('luatest.replica_set')
+local server = require('luatest.server')
+
+local g = t.group('gh-8168')
+
+g.before_each(function(cg)
+    cg.replica_set = replica_set:new{}
+    local box_cfg = {
+        replication = {
+            server.build_listen_uri('server1'),
+            server.build_listen_uri('server2'),
+        },
+        election_mode = 'manual',
+        replication_timeout = 0.1,
+    }
+    cg.server1 = cg.replica_set:build_and_add_server{
+        alias = 'server1',
+        box_cfg = box_cfg,
+    }
+    box_cfg.election_timeout = 1e-9
+    box_cfg.read_only = true
+    cg.server2 = cg.replica_set:build_and_add_server{
+        alias = 'server2',
+        box_cfg = box_cfg,
+    }
+    cg.replica_set:start()
+end)
+
+g.after_each(function(cg)
+    cg.replica_set:drop()
+end)
+
+g.test_double_term_bump_on_promote = function(cg)
+    cg.server1:wait_for_election_leader()
+    local term = cg.server1:get_election_term()
+    local ok, _ = cg.server2:exec(function()
+        return pcall(box.ctl.promote)
+    end)
+    t.assert(ok, 'Promote succeeded')
+    t.assert_equals(cg.server2:get_election_term(), term + 1,
+                    'Promote bumped term once')
+    t.assert_equals(cg.server2:exec(function()
+        return box.info.election.state
+    end), 'leader', 'Server 2 is the leader')
+end


### PR DESCRIPTION
A node configured in 'manual' mode and promoted by `box.ctl.promote()` stays in is_candidate state for the whole term, even though it is not is_cfg_candidate.

If such a node is the first one to notice leader death or to hit the election timeout, it bumps the term excessively, then immediately becomes a mere follower, because its is_candidate is reset with is_cfg_candidate.

This extra term bump (one term after the node was actually promoted) is unnecessary and might lead to strange errors:

tarantool> box.ctl.promote()
---
- error: 'The term is outdated: old - 3, new - 4' ...

Fix this by checking if a node is configured as a candidate before trying to start new elections.

Closes #8168

NO_DOC=bugfix