### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-8069-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8069-luajit-fixes.md
@@ -1,0 +1,9 @@
+## bugfix/luajit
+
+Backported patches from vanilla LuaJIT trunk (gh-8069). In the scope of this
+activity, the following issues have been resolved:
+
+* Fixed loop realigment for dual-number mode
+
+Also, resolve the following issues:
+* Fix interval parsing for sysprof for dual-number mode.


### PR DESCRIPTION
* sysprof: fix interval parsing in dual-number mode
* ci: introduce workflow for exotic builds
* x86/x64: Fix loop realignment.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump