### PR TITLE
test: update compat options tests with server:exec

### DIFF
--- a/test/app-luatest/gh_3012_yaml_prettier_multiline_output_test.lua
+++ b/test/app-luatest/gh_3012_yaml_prettier_multiline_output_test.lua
@@ -1,9 +1,12 @@
-local compat = require('tarantool').compat
-local yaml = require('yaml')
+local server = require('luatest.server')
 local t = require('luatest')
 local g = t.group()
 
-g.test_encode = function()
+local function server_test_encode()
+    local compat = require('tarantool').compat
+    local yaml = require('yaml')
+    local t = require('luatest')
+
     local str = 'Title: xxx\n - Item 1\n - Item 2\n'
     local old_res = '--- "Title: xxx\\n - Item 1\\n - Item 2\\n"\n...\n'
     local new_res = '--- |\n  Title: xxx\n   - Item 1\n   - Item 2\n...\n'
@@ -14,4 +17,11 @@ g.test_encode = function()
     compat.yaml_pretty_multiline = 'old'
     t.assert_equals(yaml.encode(str), old_res)
     compat.yaml_pretty_multiline = 'default'
+end
+
+g.test_encode = function()
+    g.server = server:new{alias = 'default'}
+    g.server:start()
+    g.server:exec(server_test_encode)
+    g.server:stop()
 end


### PR DESCRIPTION
Before the change all tarantool.compat options' tests were running on the same instance, and because luatest uses multiple threads, they could interfere with compat configuration at the same time as other test checks default behavior. This could cause such tests to flack.

Now all options' tests are being run in a separate instance via server:exec().

Closes #8033

NO_DOC=test fix
NO_CHANGELOG=test fix