### PR TITLE
doc: proofread changelogs 2.11.0-rc part 2 

### DIFF
--- a/changelogs/unreleased/gh-6986-drop-fk-parsing-rules.md
+++ b/changelogs/unreleased/gh-6986-drop-fk-parsing-rules.md
@@ -1,5 +1,4 @@
 ## bugfix/sql
 
-* Rules "reference trigger action", "constraint check time" and "match type"
-  were dropped.
-* Session setting "sql_defer_foreign_keys" was dropped (gh-6986).
+* Dropped the session setting `sql_defer_foreign_keys` and rules `reference
+  trigger action`, `constraint check time`, and `match type` (gh-6986).

--- a/changelogs/unreleased/gh-6986-introduce-sql-expr-functions.md
+++ b/changelogs/unreleased/gh-6986-introduce-sql-expr-functions.md
@@ -1,3 +1,3 @@
 ## feature/sql
 
-* Functions of type SQL_EXPR were introduced (gh-6986).
+* Introduced a new function type `SQL_EXPR` (gh-6986).

--- a/changelogs/unreleased/gh-7000-compat-module.md
+++ b/changelogs/unreleased/gh-7000-compat-module.md
@@ -1,4 +1,9 @@
 ## feature/lua
 
-* Added tarantool.compat module which allows to deprecate unwanted behavior in a
-  transparent way and provides interface to configure such changes (gh-7000).
+* Introduced the Tarantool compatibility module `tarantool.compat`.
+  It is used for transparent management of behavior changes.
+  `tarantool.compat` stores options that reflect behavior changes. Possible
+  option values are `old`, `new`, and `default`. By default, `tarantool.compat`
+  contains options for certain Tarantool changes that may break compatibility
+  with previous versions. Users can also add their own compatibility options in
+  runtime (gh-7000).

--- a/changelogs/unreleased/gh-7076-tz-attributes.md
+++ b/changelogs/unreleased/gh-7076-tz-attributes.md
@@ -1,11 +1,11 @@
 ## feature/lua/datetime
 
-* Enabled support for timezone names in the constructor and `date:set{}` modifier
-  via `tz` attribute. Currently, only timezone name abbreviations
+* Enabled support for timezone names in the constructor and the `date:set{}`
+  modifier using the `tz` attribute. Currently, only timezone name abbreviations
   are supported (gh-7076).
 
   Timezone abbreviations can be used in addition to the timezone offset.
-  They can be used during constructing or modifying a date object, or while
+  You can use them when constructing or modifying a date object, or while
   parsing datetime literals. Numeric time offsets and named abbreviations
   produce equivalent datetime values:
 
@@ -18,6 +18,5 @@
   d2:set{tz = 'MSK'}
   ```
 
-  Note that the timezone name parser fails if one uses ambiguous names,
+  Note that the timezone name parser fails if you use ambiguous names,
   which could not be translated into timezone offsets directly (for example, 'AT').
-

--- a/changelogs/unreleased/gh-7099-fix-format-description-tarantoolctl-cat.md
+++ b/changelogs/unreleased/gh-7099-fix-format-description-tarantoolctl-cat.md
@@ -1,3 +1,3 @@
 ## bugfix/tarantoolctl
 
-* Fix missing description for the `--format` flag of the tarantoolctl cat command.
+* Added a description for the `--format` flag of the `tarantoolctl cat` command.

--- a/changelogs/unreleased/gh-7125-export-fiber_join_timeout.md
+++ b/changelogs/unreleased/gh-7125-export-fiber_join_timeout.md
@@ -1,3 +1,3 @@
 ## bugfix/core
 
-* Export forgotten fiber_join_timeout symbol (gh-7125).
+* Added the `fiber_join_timeout` symbol to exports (gh-7125).

--- a/changelogs/unreleased/gh-7129-improve-check-for-dangerous-select-calls.md
+++ b/changelogs/unreleased/gh-7129-improve-check-for-dangerous-select-calls.md
@@ -1,6 +1,6 @@
 ## feature/box
 
 * Improved checking for dangerous `select` calls. The calls with
-  `offset + limit <= 1000` are now considered safe, which means a warning is not
-  issued. The 'ALL', 'GE', 'GT', 'LE', 'LT' iterators are now considered dangerous
+  `offset + limit <= 1000` are now considered safe. A warning is not issued on
+  them. The `ALL`, `GE`, `GT`, `LE`, `LT` iterators are now considered dangerous
   by default even with the key present (gh-7129).

--- a/changelogs/unreleased/gh-7149-forbid-ddl-until-box-schema-upgrade.md
+++ b/changelogs/unreleased/gh-7149-forbid-ddl-until-box-schema-upgrade.md
@@ -1,3 +1,4 @@
 ## bugfix/core
 
-* Forbidden DDL operations for the non-upgraded schema (gh-7149).
+* Forbidden DDL operations until the schema is upgraded to the most recent
+  version (gh-7149).

--- a/changelogs/unreleased/gh-7155-uri-optimize-add-param-and-add-param-value.md
+++ b/changelogs/unreleased/gh-7155-uri-optimize-add-param-and-add-param-value.md
@@ -1,3 +1,3 @@
 ## bugfix/uri
 
-* Optimized addition of parameters and parameter values (gh-7155).
+* Optimized addition of URI parameters and their values (gh-7155).

--- a/changelogs/unreleased/gh-7166-box_latch_lock-order.md
+++ b/changelogs/unreleased/gh-7166-box_latch_lock-order.md
@@ -1,4 +1,4 @@
 ## bugfix/core
 
 * Now `box_latch_lock` guarantees the order in which it is acquired by
-  fibers, which requested it (gh-7166).
+  fibers requesting it (gh-7166).

--- a/changelogs/unreleased/gh-7226-admin-grant-error.md
+++ b/changelogs/unreleased/gh-7226-admin-grant-error.md
@@ -1,5 +1,5 @@
 ## bugfix/box
 
-* Fixed internal error on granting rights to admin user. Now granting still
-fail but for proper reason and proper error message like "right is already
-granted" (gh-7226).
+* Fixed an incorrect error message on granting privileges to the `admin` user.
+  Such attempts now fail with proper error messages such as "User 'admin'
+  already has read access on universe" (gh-7226).

--- a/changelogs/unreleased/gh-7231-memtx-hash-idx-gt-iter-deprecation.md
+++ b/changelogs/unreleased/gh-7231-memtx-hash-idx-gt-iter-deprecation.md
@@ -1,3 +1,3 @@
 ## bugfix/memtx
 
-* Deprecated HASH index 'GT' iterator type (gh-7231).
+* Deprecated the `GT` iterator type for `HASH` indexes (gh-7231).

--- a/changelogs/unreleased/gh-7253-split-brain-old-term-txn.md
+++ b/changelogs/unreleased/gh-7253-split-brain-old-term-txn.md
@@ -1,5 +1,6 @@
 ## bugfix/raft
 
-* Fixed a bug when a replicaset could be split in parts if an old leader started
-  a new synchronous txn shortly before a new leader was going to be elected.
-  That was possible if the old leader didn't learn the new term yet (gh-7253).
+* Fixed a bug when a replicaset could be split into parts if an old leader
+  started a new synchronous txn shortly before a new leader was going to be
+  elected. This was possible if the old leader hadn't learned the new term yet
+  (gh-7253).

--- a/changelogs/unreleased/gh-7255-box-info-before-cfg.md
+++ b/changelogs/unreleased/gh-7255-box-info-before-cfg.md
@@ -1,3 +1,3 @@
 ## feature/core
 
-* box.info() can be called before box.cfg() (gh-7255).
+* `box.info()` can now be called before `box.cfg()` (gh-7255).

--- a/changelogs/unreleased/gh-7319-fix-http.client-reply-proto-parser.md
+++ b/changelogs/unreleased/gh-7319-fix-http.client-reply-proto-parser.md
@@ -1,4 +1,4 @@
 ## bugfix/lib
 
-* Fixed http.client to properly parse HTTP status header like 'HTTP/2 200' where
-  HTTP version does not have minor part (gh-7319).
+* Fixed `http.client` to properly parse HTTP status header such as `HTTP/2 200`
+  when the HTTP version does not have a minor part (gh-7319).

--- a/changelogs/unreleased/gh-7375-fix-gap-tracking-corner-cases.md
+++ b/changelogs/unreleased/gh-7375-fix-gap-tracking-corner-cases.md
@@ -1,4 +1,4 @@
 ## bugfix/memtx
 
-* Fixed incorrect handling of corner cases gap tracking in transaction
+* Fixed incorrect handling of gap tracking corner cases in the transaction
   manager (gh-7375).

--- a/changelogs/unreleased/gh-7432-fix-iter-next-clarify-after-track-gap.md
+++ b/changelogs/unreleased/gh-7432-fix-iter-next-clarify-after-track-gap.md
@@ -1,4 +1,4 @@
 ## bugfix/memtx
 
-* Fixed `select` with `LE` iterator in **memtx** **TREE** index returning
-  deleted tuple (gh-7432).
+* Fixed `select` with the `LE` iterator in the memtx ``TREE`` index returning
+  deleted tuples (gh-7432).

--- a/changelogs/unreleased/gh-7447-fix-panic-on-invalid-log.md
+++ b/changelogs/unreleased/gh-7447-fix-panic-on-invalid-log.md
@@ -1,3 +1,4 @@
 ## bugfix/core
 
-* Fixed panic on invalid syslog log configuration (gh-7447).
+* A proper error in now raised on incorrect `syslog` log configuration through
+  `log.cfg` (gh-7447).

--- a/changelogs/unreleased/gh-7539-mvcc-dirty-data-written-to-snapshot.md
+++ b/changelogs/unreleased/gh-7539-mvcc-dirty-data-written-to-snapshot.md
@@ -1,4 +1,4 @@
 ## bugfix/memtx
 
-* Fixed a bug in the memtx hash index implementation that could lead to
-  uncommitted data written to a snapshot file (gh-7539).
+* Fixed a bug in the memtx `HASH` index implementation that could lead to
+  writing uncommitted data to a snapshot file (gh-7539).

--- a/changelogs/unreleased/gh-7590-replicaset-assert.md
+++ b/changelogs/unreleased/gh-7590-replicaset-assert.md
@@ -1,5 +1,5 @@
 ## bugfix/replication
 
-* Fixed a bug when a replicaset state machine, tracking the number of
-  appliers according to their states, could become inconsistent during
+* Fixed a bug when a replicaset state machine that tracks the number of
+  appliers in different states could become inconsistent during
   reconfiguration (gh-7590).

--- a/changelogs/unreleased/gh-7592-write-to-local-spaces-with-synchro.md
+++ b/changelogs/unreleased/gh-7592-write-to-local-spaces-with-synchro.md
@@ -2,4 +2,4 @@
 
 * Fixed local space writes failing with error "Found uncommitted sync
   transactions from other instance with id 1" when synchronous transaction queue
-  belongs to other instance and isn't empty (gh-7592).
+  belongs to another instance and isn't empty (gh-7592).

--- a/changelogs/unreleased/gh-7593-console-debugger.md
+++ b/changelogs/unreleased/gh-7593-console-debugger.md
@@ -1,20 +1,21 @@
 ## feature/debugger
 
-* Created a console debugger `luadebug.lua` for debugging of external and
-  builtin Lua modules;
-* New Lua API created `tarantool.debug.getsources()` which allows
-  to see sources of builtin modules in any external debugger;
+* Introduced a new console debugger `luadebug.lua` for debugging external and
+  builtin Lua modules.
 
-NB! Debugger REPL is not yet compatible with Tarantool console, i.e. this
-code will hang in terminal
+> Note: the debugger REPL is not yet compatible with Tarantool console.
+> This means that this code will hang in the console:
+>
+>```lua
+>tarantool> dbg = require 'luadebug'
+>---
+>...
+>
+>tarantool> dbg()
+>---
+>```
+> Users should call debugger activation only in their instrumented code, not
+> from the interactive console.
 
-```lua
-tarantool> dbg = require 'luadebug'
----
-...
-
-tarantool> dbg()
----
-```
-One should call debugger activation only in their instrumented code, not
-from interactive console.
+* Introduced a new Lua API `tarantool.debug.getsources()` which allows
+  seeing sources of builtin modules in any external debugger.

--- a/changelogs/unreleased/gh-7743-crash-sigterm.md
+++ b/changelogs/unreleased/gh-7743-crash-sigterm.md
@@ -1,4 +1,4 @@
 ## bugfix/core
 
-* Fixed a potential crash when `SIGTERM` was received before `box.cfg` ends
-  (gh-7743).
+* Fixed a potential crash when `SIGTERM` was received before `box.cfg`
+  execution is completed (gh-7743).

--- a/changelogs/unreleased/gh-7746-fiber-channel-graceful-close.md
+++ b/changelogs/unreleased/gh-7746-fiber-channel-graceful-close.md
@@ -1,6 +1,8 @@
 ## feature/core/fiber
 
-* Fiber channel now has a compatibility option in tarantool.compat, that
-  provides transition from force channel `close()` to graceful `close()`, i.e.
-  closing channel for writing while existing messages can still be extracted
-  (gh-7746).
+* Now the `channel:close()` closes the channel gracefully: closing it
+  for writing leaving the possibility to read existing events from it.
+  Previously, `channel:close()` was closing the channel completely and
+  discarding all unread events.
+  A new `tarantool.compat` option `fiber_channel_close_mode`
+  is added for switching to the new behavior (gh-7746).

--- a/changelogs/unreleased/gh-7747-seqscan.md
+++ b/changelogs/unreleased/gh-7747-seqscan.md
@@ -1,4 +1,5 @@
 ## feature/sql
 
-* A new SEQSCAN keyword has been introduced and a new restrictions on scanning
-  SELECTs can now be applied (gh-7747).
+* Introduced a new `SEQSCAN` keyword for usage in scanning `SELECT` queries.
+  A new session setting `sql_seq_scan` can be used to allow or restrict scanning
+  queries without `SEQSCAN` (gh-7747).

--- a/changelogs/unreleased/gh-7755-memtx-rev-iters-repeatable-read-violation.md
+++ b/changelogs/unreleased/gh-7755-memtx-rev-iters-repeatable-read-violation.md
@@ -1,4 +1,3 @@
 ## bugfix/memtx
 
-* Fixed possibility of repeatable read violation with reverse iterators
-  (gh-7755).
+* Fixed a possible repeatable read violation with reverse iterators (gh-7755).

--- a/changelogs/unreleased/gh-7756-memtx-crash-on-series-of-txs.md
+++ b/changelogs/unreleased/gh-7756-memtx-crash-on-series-of-txs.md
@@ -1,3 +1,3 @@
 ## bugfix/memtx
 
-* Fixed crash on series of transactions in memtx (gh-7756).
+* Fixed a crash on series of transactions in memtx (gh-7756).

--- a/changelogs/unreleased/gh-7762-luajit-enable-checkhook.md
+++ b/changelogs/unreleased/gh-7762-luajit-enable-checkhook.md
@@ -1,4 +1,4 @@
 ## feature/luajit
 
-* Enabled LuaJIT CMake option to check instruction/line hooks for compiled code
-  (gh-7762).
+* Enabled LuaJIT CMake option `LUAJIT_ENABLE_CHECKHOOK` for checking instruction
+  and line hooks for compiled code (gh-7762).

--- a/changelogs/unreleased/gh-7814-box-error-in-thread.md
+++ b/changelogs/unreleased/gh-7814-box-error-in-thread.md
@@ -1,4 +1,4 @@
 ## feature/core
 
-* The box error C API (`box_error_set()`, `box_error_last()`, etc) can now be
-  used in threads started by user modules with the pthread library (gh-7814).
+* The box error C API (`box_error_set()`, `box_error_last()`, and so on) can now
+  be used in threads started by user modules with the pthread library (gh-7814).

--- a/changelogs/unreleased/gh-7828-rollback_rebind_read_tracker_wrong_idx_mask.md
+++ b/changelogs/unreleased/gh-7828-rollback_rebind_read_tracker_wrong_idx_mask.md
@@ -1,4 +1,4 @@
 ## bugfix/memtx
 
-* Fixed phantom read possible after reads from different indexes followed by a
-  rollback (gh-7828).
+* Fixed a phantom read that could happen after reads from different indexes
+  followed by a rollback (gh-7828).

--- a/changelogs/unreleased/gh-7886-dont-close-xlog-fd-atfork.md
+++ b/changelogs/unreleased/gh-7886-dont-close-xlog-fd-atfork.md
@@ -1,4 +1,4 @@
 ## bugfix/core
 
 * Fixed a bug when Tarantool could execute random bytes as a Lua code after fork
-  on systems with glibc version < 2.29 (gh-7886).
+  on systems with a glibc version earlier than 2.29 (gh-7886).

--- a/changelogs/unreleased/gh-7895-export-session-id-to-c-api.md
+++ b/changelogs/unreleased/gh-7895-export-session-id-to-c-api.md
@@ -1,3 +1,3 @@
 ## feature/box
 
-* Exported current session's identifier to C API via `box_session_id` (gh-7895).
+* Exported current session identifier to C API via `box_session_id` (gh-7895).

--- a/changelogs/unreleased/gh-7897-sending-arbitrary-iproto-packets.md
+++ b/changelogs/unreleased/gh-7897-sending-arbitrary-iproto-packets.md
@@ -1,4 +1,4 @@
 ## feature/box
 
-* Added API for sending arbitrary IPROTO packets from server to client:
+* Added an API for sending arbitrary IPROTO packets from server to client:
   `box.iproto.send` in Lua and `box_iproto_send` in C (gh-7897).

--- a/changelogs/unreleased/gh-7898-msgpack-object-indexation.md
+++ b/changelogs/unreleased/gh-7898-msgpack-object-indexation.md
@@ -1,6 +1,6 @@
 ## feature/lua/msgpack
 
-* Added `__index` metamethod and `get` method to `msgpack.object` which perform
-  indexation of MsgPack data stored in the object similar to `tuple` from
-  `box.tuple`: `__index` resolves collisions in favor of
+* Added the `__index` metamethod and the `get` method to `msgpack.object`.
+  They both perform indexation of MsgPack data stored in the object similar to
+  `tuple` from `box.tuple`: `__index` resolves collisions in favor of
   `msgpack.object` methods, whereas `get` ignores methods (gh-7898).

--- a/changelogs/unreleased/gh-7917-log-row-on-recovery-error.md
+++ b/changelogs/unreleased/gh-7917-log-row-on-recovery-error.md
@@ -1,3 +1,4 @@
 ## bugfix/core
 
-* Bad row is now logged on snapshot recovery error (gh-7917).
+* If an error occurs during a snapshot recovery, the row that caused it is
+  now written in the log (gh-7917).

--- a/changelogs/unreleased/gh-7931-httpc-params-escaping.md
+++ b/changelogs/unreleased/gh-7931-httpc-params-escaping.md
@@ -1,6 +1,6 @@
 ## feature/lua/http client
 
-* Performed automated percent-encoding of query params passed into URI using a
-  using the params option. Parameters encoded using `uri.QUERY_PART` when `GET`,
-  `DELETE` or `HEAD` HTTP methods are used and `uri.FORM_URLENCODED` in other
-  cases (gh-7931).
+* Query parameters passed into a URI using the `params` option are now
+  percent-encoded automatically. Parameters are encoded with `uri.QUERY_PART`
+  when `GET`, `DELETE`, or `HEAD` HTTP methods are used, and with
+  `uri.FORM_URLENCODED` in other cases (gh-7931).

--- a/changelogs/unreleased/gh-7933-verbose-wrong-index-part-error.md
+++ b/changelogs/unreleased/gh-7933-verbose-wrong-index-part-error.md
@@ -1,4 +1,4 @@
 ## bugfix/core
 
-* Made errors thrown on specifying invalid index parts or format fields more
-  verbose. Now, they include the bad index part or field number (gh-7933).
+* Errors thrown on specifying invalid index parts or format fields are now more
+  verbose. They include the bad index part or field number (gh-7933).

--- a/changelogs/unreleased/gh-7955-improve-logging-of-tables.md
+++ b/changelogs/unreleased/gh-7955-improve-logging-of-tables.md
@@ -1,8 +1,14 @@
 ## bugfix/core
 
-* Fixed modification of a variable with a table passed to the logging function.
-  Fixed the drop of fields with reserved internal names (plain log format).
-  Added 'message' field to tables without that field in JSON log format
-  (gh-3853).
+* Fixed a bug when fields could be removed from a table stored in a variable
+  when a logging function was called on this variable (for example,
+  `log.info(a)`) (gh-3853).
+
+* Fixed a logging bug: when logging tables with fields that have reserved
+  internal names (such as `pid`) in the plain log format, such fields weren't
+  logged (gh-3853).
+
+* Added the `message` field when logging tables without such field in the JSON
+  log format (gh-3853).
 
 * Fixed an assertion on malformed JSON message written to the log (gh-7955).

--- a/changelogs/unreleased/gh-7989-iproto-id-auth-type.md
+++ b/changelogs/unreleased/gh-7989-iproto-id-auth-type.md
@@ -1,5 +1,5 @@
 ## feature/box
 
-* Added `IPROTO_AUTH_TYPE` key to `IPROTO_ID` response. The key contains
+* Added the `IPROTO_AUTH_TYPE` key to the `IPROTO_ID` response. The key contains
   the name of the authentication method that is currently used on the server
   for generating user authentication data (gh-7989).

--- a/changelogs/unreleased/gh-7992-collation-of-built-in-args.md
+++ b/changelogs/unreleased/gh-7992-collation-of-built-in-args.md
@@ -1,3 +1,4 @@
 ## bugfix/sql
 
-* Collation no longer mangles the type of built-in function argument (gh-7992).
+* Fixed a bug when collation could change the type of a built-in function
+  argument (gh-7992).

--- a/changelogs/unreleased/gh-8083-fatal-signal-handler.md
+++ b/changelogs/unreleased/gh-8083-fatal-signal-handler.md
@@ -2,4 +2,4 @@
 
 * Fixed Tarantool being stuck during a crash on macOS (gh-8023).
 
-* Fixed a bug that prevents crash report being collected (gh-8083).
+* Fixed a bug that prevented collection of crash reports (gh-8083).

--- a/changelogs/unreleased/gh_7339_fk_drop_in_one_txn.md
+++ b/changelogs/unreleased/gh_7339_fk_drop_in_one_txn.md
@@ -1,4 +1,4 @@
 ## bugfix/core
 
-* Now referenced space or used function can be dropped in the same
-  transaction with referencing constraint or space (gh-7339).
+* A referenced space or a function being used in a constraint can now be dropped
+ in the same transaction with the referencing constraint or space (gh-7339).

--- a/changelogs/unreleased/gh_7846_before_replace_crash_on_replica_id_alter.md
+++ b/changelogs/unreleased/gh_7846_before_replace_crash_on_replica_id_alter.md
@@ -1,6 +1,8 @@
 ## bugfix/replication
 
-* Say a warning when replica_id is changed by before_replace trigger while
-  adding a new replica (gh-7846). There was an assertion checking this before.
-  Also, handle the case when before_replace set on space `_cluster` returns
-  nil - it caused segmentation fault before.
+* A warning is now raised when `replica_id` is changed by a `before_replace`
+  trigger while adding a new replica. Previously, there was an assertion
+  checking this (gh-7846).
+
+* Fixed a segmentation fault that happened when a `before_replace` trigger set
+  on space `_cluster` returned nil (gh-7846).

--- a/changelogs/unreleased/ghs-5-hide-_collation-from-public.md
+++ b/changelogs/unreleased/ghs-5-hide-_collation-from-public.md
@@ -1,3 +1,3 @@
 ## bugfix/box
 
-* Fixed accidental exposure of \_collation space to public (ghs-5).
+* Fixed accidental exposure of the `_collation` space to public (ghs-5).

--- a/changelogs/unreleased/hide-show-prompt.md
+++ b/changelogs/unreleased/hide-show-prompt.md
@@ -1,4 +1,4 @@
 ## feature/lua/console
 
-* Prevent mixing of background print/log output with current user's input in
-  the interactive console (gh-7169).
+* Prevent mixing of background print and log output with the current user's
+  input in the interactive console (gh-7169).

--- a/changelogs/unreleased/linearizable-read.md
+++ b/changelogs/unreleased/linearizable-read.md
@@ -1,5 +1,5 @@
 ## feature/core
 
-* There is a new transaction isolation level now: "linearizable". Transactions
+* Introduced a new transaction isolation level `linearizable`. Transactions
   started with `box.begin{txn_isolation = "linearizable"}` always see the latest
   data confirmed by the quorum (gh-6707).

--- a/changelogs/unreleased/pagination.md
+++ b/changelogs/unreleased/pagination.md
@@ -1,5 +1,5 @@
 ## feature/core
 
-* Introduced pagination support for memtx and vinyl tree indexes. Now, it's
+* Introduced pagination support for memtx and vinyl tree indexes. It is now
   possible to resume `pairs` and `select` from the position where the last
   call stopped (gh-7639).

--- a/changelogs/unreleased/publish-doxygen-doc.md
+++ b/changelogs/unreleased/publish-doxygen-doc.md
@@ -1,3 +1,4 @@
 ## feature/doxygen
 
-* Doxygen API documentation published automatically on every merge to master branch.
+* Doxygen module API documentation is now published automatically on every merge
+  to the `master` branch.

--- a/changelogs/unreleased/strict_fencing.md
+++ b/changelogs/unreleased/strict_fencing.md
@@ -1,7 +1,7 @@
 ## feature/raft
 
-* Introduce strict fencing, which tries its best to allow at most one
-  leader in cluster in any moment in time. This is achived by setting
-  connection death timeout on current leader to half the time compared to
-  followers (assuming replication_timeout is the same on every replica)
+* Introduced strict fencing, which tries its best to allow at most one
+  leader in cluster in any moment in time. This is achieved by setting
+  connection death timeout on the current leader to half the time compared to
+  followers (assuming the `replication_timeout` is the same on every replica)
   (gh-7110).

--- a/changelogs/unreleased/tt-preload.md
+++ b/changelogs/unreleased/tt-preload.md
@@ -1,4 +1,10 @@
 ## feature/lua
 
-* Run scripts or load modules that are specified in the `TT_PRELOAD`
-  environment variable (gh-7714).
+* It is now possible to run scripts or load modules before the main script by
+  specifying them in the `TT_PRELOAD` environment variable. For example:
+
+  ```shell
+  $ TT_PRELOAD=/path/to/foo.lua tarantool main.lua
+  ```
+
+  (gh-7714).


### PR DESCRIPTION
Proofread changelogs for 2.11.0-rc, part 2
Fix grammar, punctuation, and wording

Resolves https://github.com/tarantool/doc/issues/3297

NO_CHANGELOG=changelog
NO_DOC=changelog
NO_TEST=changelog