### PR TITLE
ci: use new approach for returning step output

### DIFF
--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -38,7 +38,7 @@ jobs:
           submodules: recursive
       - name: 'Get the commit SHA'
         id: get_sha
-        run: echo "::set-output name=sha::$(git log -1 --format='%H')"
+        run: echo "sha=$(git log -1 --format='%H')" >> $GITHUB_OUTPUT
       - uses: ./.github/actions/environment
       - name: 'Build tarantool packages for ${{ env.OS }}(${{ env.DIST }})'
         id: run_build


### PR DESCRIPTION
The approach

	- name: Set output 
	  run: echo "::set-output name={name}::{value}"

is deprecated [1].

Switching to the new approach:

	- name: Set output 
	  run: echo "{name}={value}" >> $GITHUB_OUTPUT

[1] https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands