### PR TITLE
box: remove dont_check option

### DIFF
--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -686,10 +686,6 @@ local function prepare_cfg(cfg, default_cfg, template_cfg, modify_cfg)
     if type(cfg) ~= 'table' then
         error("Error: cfg should be a table")
     end
-    -- just pass {.. dont_check = true, ..} to disable check below
-    if cfg.dont_check then
-        return
-    end
     local new_cfg = {}
     for k, v in pairs(cfg) do
         if template_cfg[k] == nil then

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -264,8 +264,6 @@ end
  1)that parameters table is a table (or nil)
  2)all keys in parameters are present in template
  3)type of every parameter fits (one of) types described in template
- Check (2) and (3) could be disabled by adding {, dont_check = <smth is true>, }
-  into parameters table
  The functions calls box.error(box.error.ILLEGAL_PARAMS, ..) on error
  @example
  check_param_table(options, { user = 'string',
@@ -285,10 +283,6 @@ local function check_param_table(table, template)
     if type(table) ~= 'table' then
         box.error(box.error.ILLEGAL_PARAMS,
                   "options should be a table")
-    end
-    -- just pass {.. dont_check = true, ..} to disable checks below
-    if table.dont_check then
-        return
     end
     for k,v in pairs(table) do
         if template[k] == nil then


### PR DESCRIPTION
Commit 3fb0f7f1b713 ("fix gh-362 and lots of error messages fixes") intriduces an option "dont_check" that disables checks for a certain parameter. This option is not documented anywhere and looks unusable. This commit removes it.

Follows up #362

NO_CHANGELOG=internal
NO_DOC=internal
NO_TEST=internal