### PR TITLE
box: fix segfault in box.internal.compact()

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -5099,6 +5099,7 @@ box_init(void)
 	fiber_cond_create(&ro_cond);
 	auth_init();
 	security_init();
+	space_cache_init();
 	user_cache_init();
 	/*
 	 * The order is important: to initialize sessions, we need to access the
@@ -5138,4 +5139,5 @@ box_free(void)
 	/* schema_module_free(); */
 	/* session_free(); */
 	/* user_cache_free(); */
+	/* space_cache_destroy(); */
 }

--- a/src/box/schema.cc
+++ b/src/box/schema.cc
@@ -205,8 +205,6 @@ schema_init(void)
 	for (uint32_t i = 0; i < lengthof(key_parts); i++)
 		key_parts[i] = key_part_def_default;
 
-	/* Initialize the space cache. */
-	space_cache_init();
 	func_cache_init();
 	sequences = mh_i32ptr_new();
 	/*
@@ -348,7 +346,6 @@ schema_init(void)
 void
 schema_free(void)
 {
-	space_cache_destroy();
 	func_cache_destroy();
 
 	while (mh_size(sequences) > 0) {

--- a/src/box/space_cache.c
+++ b/src/box/space_cache.c
@@ -36,8 +36,6 @@ space_cache_init(void)
 void
 space_cache_destroy(void)
 {
-	if (spaces == NULL)
-		return;
 	while (mh_size(spaces) > 0) {
 		mh_int_t i = mh_first(spaces);
 

--- a/test/box-luatest/gh_8196_crash_box_internal_compact_test.lua
+++ b/test/box-luatest/gh_8196_crash_box_internal_compact_test.lua
@@ -1,0 +1,20 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_gh_8196 = function(cg)
+    cg.server:exec(function()
+        t.assert_error_msg_equals("Space '1' does not exist",
+                                  box.internal.compact, 1, 1)
+    end)
+end


### PR DESCRIPTION
There is an internal Lua function `box.internal.compact` that used in `index_object:compact()` [1]. Tarantool has crashed when `box.internal.compact` running with id of non-existent space.

1. https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_index/compact/

Fixes #8196

NO_DOC=bugfix