### PR TITLE
applier: name ballot_watcher fiber properly

### DIFF
--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -700,8 +700,9 @@ applier_connect(struct applier *applier)
 	if (method_default == NULL)
 		method_default = AUTH_METHOD_DEFAULT;
 
-	applier->ballot_watcher = fiber_new_system("applier_ballot_watcher",
-						   applier_ballot_watcher_f);
+	applier->ballot_watcher = applier_fiber_new(applier, "ballot_watcher",
+						    applier_ballot_watcher_f,
+						    false);
 	applier->ballot_watcher->f_arg = applier;
 	fiber_wakeup(applier->ballot_watcher);
 

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -170,13 +170,14 @@ applier_check_sync(struct applier *applier)
  * but doesn't start it.
  */
 static struct fiber *
-applier_fiber_new(struct applier *applier, const char *name, fiber_func func)
+applier_fiber_new(struct applier *applier, const char *name, fiber_func func,
+		  bool is_joinable)
 {
 	char buf[FIBER_NAME_MAX];
 	int pos = snprintf(buf, sizeof(buf), "%s/", name);
 	uri_format(buf + pos, sizeof(buf) - pos, &applier->uri, false);
 	struct fiber *f = fiber_new_system_xc(buf, func);
-	fiber_set_joinable(f, true);
+	fiber_set_joinable(f, is_joinable);
 	return f;
 }
 
@@ -2158,12 +2159,13 @@ applier_thread_fiber_init(struct applier *applier)
 	assert(applier->thread.reader == NULL);
 	assert(applier->thread.writer == NULL);
 	applier->thread.reader = applier_fiber_new(applier, "reader",
-						   applier_thread_reader_f);
+						   applier_thread_reader_f,
+						   true);
 	fiber_start(applier->thread.reader, applier);
 	if (applier->version_id >= version_id(1, 7, 4)) {
 		/* Enable replication ACKs for newer servers */
 		applier->thread.writer = applier_fiber_new(
-			applier, "writer", applier_thread_writer_f);
+			applier, "writer", applier_thread_writer_f, true);
 		fiber_start(applier->thread.writer, applier);
 	}
 
@@ -2617,7 +2619,7 @@ void
 applier_start(struct applier *applier)
 {
 	assert(applier->fiber == NULL);
-	applier->fiber = applier_fiber_new(applier, "applier", applier_f);
+	applier->fiber = applier_fiber_new(applier, "applier", applier_f, true);
 	fiber_start(applier->fiber, applier);
 }
 


### PR DESCRIPTION
Currently all ballot_watcher fibers for different appliers have identical names: "applier_ballot_watcher". It's hard to distinguish them in logs and to know which ballot_watcher belongs to which applier, and that complicates debugging quite a bit.

Let's fix this and name the fibers properly. With master's uri at the end.

NO_DOC=no behaviour changed
NO_CHANGELOG=no behaviour changed
NO_TEST=doesn't need one