### PR TITLE
ci: remove libtool from build requirements

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -33,7 +33,7 @@ Build-Depends: cdbs (>= 0.4.100), debhelper (>= 9), dpkg-dev (>= 1.16.1~),
 # needed for datetime tests
  tzdata,
 # For third-party subprojects that are built with autotools.
- autoconf, automake, libtool,
+ autoconf, automake
 Section: database
 Standards-Version: 4.5.1
 Homepage: http://tarantool.org/

--- a/rpm/tarantool.spec
+++ b/rpm/tarantool.spec
@@ -100,7 +100,6 @@ BuildRequires: perl-Test-Harness
 # For third-party subprojects that are built with autotools.
 BuildRequires: autoconf
 BuildRequires: automake
-BuildRequires: libtool
 
 Name: tarantool
 # ${major}.${major}.${minor}.${patch}, e.g. 1.6.8.175


### PR DESCRIPTION
The commit 5b08d71ab474 ("libunwind: use latest release v1.6.2 as a base") started using autotools for building bundled libunwind. In particular it added libtool as in CI pipeline build requirements. We need libtool because of use `make install` in ExternalProject_Add macro.

Later we switch to our own macro in the commit 14f93aee86b8 ("libunwind: improve incremental build/rebuild") which do not use `make install`. So let's drop libtool dependency.

Follow-up #5665

NO_TEST=ci
NO_DOC=ci
NO_CHANGELOG=ci