### PR TITLE
box: move flightrec configuration out of CE repository

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -918,36 +918,6 @@ box_check_auth_type(void)
 	return method;
 }
 
-void
-box_get_flightrec_cfg(struct flight_recorder_cfg *cfg)
-{
-	memset(cfg, 0, sizeof(*cfg));
-	cfg->enabled = cfg_getb("flightrec_enabled");
-	cfg->dir = cfg_gets("memtx_dir");
-	cfg->logs_size = cfg_geti64("flightrec_logs_size");
-	cfg->log_max_msg_size = cfg_geti64("flightrec_logs_max_msg_size");
-	cfg->logs_log_level = cfg_geti("flightrec_logs_log_level");
-	cfg->metrics_interval = cfg_getd("flightrec_metrics_interval");
-	cfg->metrics_period = cfg_geti("flightrec_metrics_period");
-	cfg->requests_size = cfg_geti("flightrec_requests_size");
-	cfg->requests_max_req_size =
-		cfg_geti("flightrec_requests_max_req_size");
-	cfg->requests_max_res_size =
-		cfg_geti("flightrec_requests_max_res_size");
-}
-
-/**
- * Raises error if flight recorder configuration is incorrect.
- */
-static void
-box_check_flightrec(void)
-{
-	struct flight_recorder_cfg cfg;
-	box_get_flightrec_cfg(&cfg);
-	if (flightrec_check_cfg(&cfg) != 0)
-		diag_raise();
-}
-
 static enum election_mode
 box_check_election_mode(void)
 {
@@ -1578,7 +1548,8 @@ box_check_config(void)
 	struct tt_uuid uuid;
 	box_check_say();
 	box_check_audit();
-	box_check_flightrec();
+	if (box_check_flightrec() != 0)
+		diag_raise();
 	if (box_check_listen() != 0)
 		diag_raise();
 	if (box_check_auth_type() == NULL)
@@ -2761,20 +2732,6 @@ box_set_txn_isolation(void)
 	if (level == txn_isolation_level_MAX)
 		return -1;
 	txn_default_isolation = level;
-	return 0;
-}
-
-int
-box_configure_flightrec(void)
-{
-	struct flight_recorder_cfg cfg;
-	box_get_flightrec_cfg(&cfg);
-
-	if (flightrec_check_cfg(&cfg) != 0)
-		return -1;
-	if (flightrec_cfg(&cfg) != 0)
-		return -1;
-
 	return 0;
 }
 

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -313,18 +313,6 @@ int box_set_auth_type(void);
 int box_set_bootstrap_strategy(void);
 
 /**
- * Populate cfg from box.cfg.flightrec_* parameters.
- */
-void
-box_get_flightrec_cfg(struct flight_recorder_cfg *cfg);
-
-/**
- * Configure flight recoder from box.cfg.flightrec_* parameters.
- */
-int
-box_configure_flightrec(void);
-
-/**
  * Initialize logger on box init.
  */
 int

--- a/src/box/flightrec.h
+++ b/src/box/flightrec.h
@@ -15,71 +15,20 @@
 extern "C" {
 #endif /* defined(__cplusplus) */
 
-#include <assert.h>
-#include <stdarg.h>
-#include <stdbool.h>
 #include <stddef.h>
-#include <stdint.h>
 
-/** Flight recorder config options. */
-struct flight_recorder_cfg {
-	/**
-	 * Whether flight recorder should be enabled or disabled.
-	 */
-	bool enabled;
-	/**
-	 * Directory to store flight_records.ttfr file.
-	 */
-	const char *dir;
-	/** Total size of stored logs. */
-	int64_t logs_size;
-	/** Max size of one log message. */
-	int64_t log_max_msg_size;
-	/** Flight recorder log level; may be different from say log level. */
-	int logs_log_level;
-	/**
-	 * Time interval (in seconds) between metrics
-	 * dump to flight recorder.
-	 */
-	double metrics_interval;
-	/**
-	 * Period (in seconds) of metrics storage, i.e. how long
-	 * metrics are stored before being overwritten.
-	 */
-	int64_t metrics_period;
-	/** Total size of stored requests and responses. */
-	int64_t requests_size;
-	/** Max size per request. */
-	int64_t requests_max_req_size;
-	/** Max size per response. */
-	int64_t requests_max_res_size;
-};
+struct obuf;
+struct obuf_svp;
 
-/** No-op in OS version. */
-static inline int
-flightrec_cfg(const struct flight_recorder_cfg *cfg)
-{
-	assert(!cfg->enabled);
-	(void)cfg;
-	return 0;
-}
-
-/** No-op in OS version. */
+/**
+ * Release resources and clean-up flight recorder.
+ */
 static inline void
 flightrec_free(void)
 {
 }
 
-/** No-op in OS version. */
-static inline int
-flightrec_check_cfg(const struct flight_recorder_cfg *cfg)
-{
-	assert(!cfg->enabled);
-	(void)cfg;
-	return 0;
-}
-
-/** No-op in OS version. */
+/** Dump request (which is already packed into msgapck) to flight recorder. */
 static inline void
 flightrec_write_request(const char *request_msgpack, size_t len)
 {
@@ -87,15 +36,35 @@ flightrec_write_request(const char *request_msgpack, size_t len)
 	(void)len;
 }
 
-struct obuf;
-struct obuf_svp;
-
-/** No-op in OS version. */
+/**
+ * Dump response to flight recorder. Given savepoint points to the start of
+ * response stored into buffer.
+ */
 static inline void
 flightrec_write_response(struct obuf *buf, struct obuf_svp *svp)
 {
 	(void)buf;
 	(void)svp;
+}
+
+/**
+ * Checks box.cfg flight recorder parameters.
+ * On success, returns 0. On error, sets diag and returns -1.
+ */
+static inline int
+box_check_flightrec(void)
+{
+	return 0;
+}
+
+/**
+ * Applies box.cfg flight recorder parameters.
+ * On success, returns 0. On error, sets diag and returns -1.
+ */
+static inline int
+box_set_flightrec(void)
+{
+	return 0;
 }
 
 #if defined(__cplusplus)

--- a/src/box/lua/cfg.cc
+++ b/src/box/lua/cfg.cc
@@ -429,14 +429,6 @@ lbox_cfg_set_txn_isolation(struct lua_State *L)
 }
 
 static int
-lbox_cfg_configure_flightrec(struct lua_State *L)
-{
-	if (box_configure_flightrec() != 0)
-		luaT_error(L);
-	return 0;
-}
-
-static int
 lbox_cfg_set_auth_type(struct lua_State *L)
 {
 	if (box_set_auth_type() != 0)
@@ -487,7 +479,6 @@ box_lua_cfg_init(struct lua_State *L)
 		{"cfg_set_crash", lbox_cfg_set_crash},
 		{"cfg_set_txn_timeout", lbox_cfg_set_txn_timeout},
 		{"cfg_set_txn_isolation", lbox_cfg_set_txn_isolation},
-		{"cfg_configure_flightrec", lbox_cfg_configure_flightrec},
 		{"cfg_set_auth_type", lbox_cfg_set_auth_type},
 		{NULL, NULL}
 	};

--- a/src/main.cc
+++ b/src/main.cc
@@ -478,9 +478,7 @@ load_cfg(void)
 	 * Initialize flight recorder after say logger as we might use
 	 * say API.
 	 */
-	struct flight_recorder_cfg cfg_fr;
-	box_get_flightrec_cfg(&cfg_fr);
-	if (flightrec_cfg(&cfg_fr) != 0) {
+	if (box_set_flightrec() != 0) {
 		diag_log();
 		exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
We define `flight_recorder_cfg` struct, `box_get_flightrec_cfg` function, and `box.internal.cfg_configure_flightrec` Lua function in the CE repository although they are actually needed only in the EE repository. Let's drop them all from the CE repository and instead define stub functions `box_check_flightrec` and `box_set_flightrec` that would check/apply `box.cfg` flight recorder parameters.

While we are at it, add missing comments to flightrec function stubs.

EE part: https://github.com/tarantool/tarantool-ee/pull/351