### PR TITLE
box: make ffi select work on M1

### DIFF
--- a/extra/exports
+++ b/extra/exports
@@ -101,7 +101,7 @@ box_replace
 box_return_mp
 box_return_tuple
 box_schema_version
-box_select
+box_select_ffi
 box_sequence_current
 box_sequence_next
 box_sequence_reset

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3075,6 +3075,22 @@ fail:
 	return -1;
 }
 
+/**
+ * A special wrapper for FFI - workaround for M1.
+ * Use 64-bit integers beyond the 8th argument.
+ * See https://github.com/LuaJIT/LuaJIT/issues/205 for details.
+ */
+extern "C" int
+box_select_ffi(uint32_t space_id, uint32_t index_id, const char *key,
+	       const char *key_end, const char **packed_pos,
+	       const char **packed_pos_end, bool update_pos, struct port *port,
+	       int64_t iterator, uint64_t offset, uint64_t limit)
+{
+	return box_select(space_id, index_id, iterator, offset, limit, key,
+			  key_end, packed_pos, packed_pos_end, update_pos,
+			  port);
+}
+
 API_EXPORT int
 box_insert(uint32_t space_id, const char *tuple, const char *tuple_end,
 	   box_tuple_t **result)

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -118,11 +118,11 @@ ffi.cdef[[
                              const char **pos, const char **pos_end);
 
     int
-    box_select(uint32_t space_id, uint32_t index_id,
-               int iterator, uint32_t offset, uint32_t limit,
-               const char *key, const char *key_end,
-               const char **after, const char **after_end,
-               bool update_pos, struct port *port);
+    box_select_ffi(uint32_t space_id, uint32_t index_id, const char *key,
+                   const char *key_end, const char **packed_pos,
+                   const char **packed_pos_end, bool update_pos,
+                   struct port *port, int64_t iterator, uint64_t offset,
+                   uint64_t limit);
 
     enum priv_type {
         PRIV_R = 1,
@@ -2537,9 +2537,9 @@ base_index_mt.select_ffi = function(index, key, opts)
     check_select_safety(index, key_is_nil, iterator, limit, offset, fullscan)
     local region_svp = builtin.box_region_used()
     normalize_position(index, after, iterator_pos, iterator_pos_end)
-    nok = builtin.box_select(index.space_id, index.id, iterator, offset, limit,
-                             key, key_end, iterator_pos, iterator_pos_end,
-                             fetch_pos, port) ~= 0
+    nok = builtin.box_select_ffi(index.space_id, index.id, key, key_end,
+                                 iterator_pos, iterator_pos_end, fetch_pos,
+                                 port, iterator, offset, limit) ~= 0
     if not nok and fetch_pos and iterator_pos[0] ~= nil then
         new_position = ffi.string(iterator_pos[0],
                                   iterator_pos_end[0] - iterator_pos[0])

--- a/static-build/test/exports.test.lua
+++ b/static-build/test/exports.test.lua
@@ -114,7 +114,6 @@ local check_symbols = {
     'coio_getaddrinfo',
     'luaT_call',
     'box_txn',
-    'box_select',
     'clock_realtime',
     'string_strip_helper',
 


### PR DESCRIPTION
Recently, ffi select was broken on M1 - it turned out that ffi on M1 poorly supports a big quantity of arguments, which was used for pagination. Fortunately, there is a workaround - we can pass only 64-bit integer arguments beyond the 8th argument. Let's do it.

Closes #7946