### PR TITLE
fiber: return always-zero `cpu_misses` entry to `fiber.top()`

### DIFF
--- a/changelogs/unreleased/gh-5869-remove-fiber-top-cpu_misses.md
+++ b/changelogs/unreleased/gh-5869-remove-fiber-top-cpu_misses.md
@@ -1,4 +1,3 @@
 ## feature/core
 
-* **[Breaking change]** Removed the `cpu_misses` entry from the `fiber.top()`
-  output (gh-5869).
+* The `cpu_misses` entry in `fiber.top()` output is deprecated (gh-5869).

--- a/src/lua/fiber.c
+++ b/src/lua/fiber.c
@@ -282,6 +282,10 @@ lbox_fiber_top(struct lua_State *L)
 			      " fiber.top_enable() first");
 	}
 	lua_newtable(L);
+	lua_pushliteral(L, "cpu_misses");
+	lua_pushnumber(L, 0);
+	lua_settable(L, -3);
+
 	lua_pushliteral(L, "cpu");
 	lua_newtable(L);
 	lbox_fiber_top_entry(&cord()->sched, L);

--- a/test/app/fiber.result
+++ b/test/app/fiber.result
@@ -1487,7 +1487,7 @@ if is_fiber_top then\
 end
 ---
 ...
-a = is_fiber_top and fiber.top() or {cpu = {["1/sched"] = {}}}
+a = is_fiber_top and fiber.top() or {cpu = {["1/sched"] = {}}, cpu_misses = 0}
 ---
 ...
 type(a) == 'table'
@@ -1497,6 +1497,10 @@ type(a) == 'table'
 -- scheduler is present in fiber.top()
 -- and is indexed by name
 a.cpu["1/sched"] ~= nil
+---
+- true
+...
+a.cpu_misses == 0
 ---
 - true
 ...

--- a/test/app/fiber.test.lua
+++ b/test/app/fiber.test.lua
@@ -647,11 +647,12 @@ if is_fiber_top then\
     while fiber.top().cpu["1/sched"].instant == 0 do fiber.yield() end\
 end
 
-a = is_fiber_top and fiber.top() or {cpu = {["1/sched"] = {}}}
+a = is_fiber_top and fiber.top() or {cpu = {["1/sched"] = {}}, cpu_misses = 0}
 type(a) == 'table'
 -- scheduler is present in fiber.top()
 -- and is indexed by name
 a.cpu["1/sched"] ~= nil
+a.cpu_misses == 0
 sum_inst = 0
 sum_avg = is_fiber_top and 0 or 100
 


### PR DESCRIPTION
https://www.notion.so/tarantool/fiber-get-rid-of-cpu_misses-in-fiber-top-f5c3af62cb7d4fb1bb09dbf575c2109f