### PR TITLE
changelog: don't mark `fiber_set_cancellable` deprecation as breaking

### DIFF
--- a/changelogs/unreleased/gh-7166-deprecate-fiber_set_cancellable.md
+++ b/changelogs/unreleased/gh-7166-deprecate-fiber_set_cancellable.md
@@ -1,4 +1,4 @@
 ## feature/core
 
-* **[Breaking change]** `fiber_set_cancellable()` is deprecated and
-  now does nothing (gh-7166).
+* `fiber_set_cancellable()` C API function is deprecated and now does
+  nothing (gh-7166).


### PR DESCRIPTION
https://www.notion.so/tarantool/fiber-make-fiber_set_cancellable-a-no-op-28101defb64b4df39baf7afbfd61e540