### PR TITLE
changelog: don't mark additional module name in the log as breaking

### DIFF
--- a/changelogs/unreleased/gh-3211-per-module-log_level.md
+++ b/changelogs/unreleased/gh-3211-per-module-log_level.md
@@ -1,7 +1,7 @@
 ## feature/core
 
-* **[Breaking change]** Now the log message contains the name of a module from
-  which the logging function was called (gh-3211).
+* Now the log message contains the name of a Lua module from which the logging
+  function was called (gh-3211).
 
 * Now the log level can be set for specific modules using `log.cfg{modules = {...}}`
   or `box.cfg{log_modules = {...}}` (gh-3211).


### PR DESCRIPTION
https://www.notion.so/tarantool/log-implement-automatic-module-name-deduction-92198a0f86d342dbbec0da32f27863fe