### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-8069-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8069-luajit-fixes.md
@@ -1,0 +1,6 @@
+## bugfix/luajit
+
+Backported patches from vanilla LuaJIT trunk (gh-7230). In the scope of this
+activity, the following issues have been resolved:
+
+* Fix assembling of IR_{AHUV}LOAD specialized to boolean for aarch64.


### PR DESCRIPTION
* ARM64: Fix {AHUV}LOAD specialized to nil/false/true.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump