### PR TITLE
test: partially disable election_pre_vote test

### DIFF
--- a/test/replication-luatest/election_pre_vote_test.lua
+++ b/test/replication-luatest/election_pre_vote_test.lua
@@ -108,6 +108,7 @@ end
 -- when it lacks a quorum of peers.
 --
 g.test_promote_no_quorum = function(g)
+    t.skip('Enable once gh-8217 is fixed')
     g.follower1:exec(function() box.cfg{replication = ''} end)
     local term = g.follower1:exec(get_election_term)
     t.assert_error_msg_content_equals(


### PR DESCRIPTION
test_promote_no_quorum testcase in election_pre_vote test started flaky hanging after commit 5765fdc4e4ec ("raft: fix 'manual' nodes bumping the term excessively").

Disable it until the issue (#8217) is resolved.

In-scope-of #8217

NO_DOC=tests
NO_CHANGELOG=tests