### PR TITLE
raft: fix box.ctl.promote() hanging when cannot gather a quorum

### DIFF
--- a/src/box/raft.c
+++ b/src/box/raft.c
@@ -494,9 +494,12 @@ box_raft_try_promote(void)
 			 (unsigned long long)raft->volatile_term);
 	} else {
 		assert(!raft->is_candidate);
-		assert(box_election_mode != ELECTION_MODE_MANUAL &&
-		       box_election_mode != ELECTION_MODE_CANDIDATE);
-		diag_set(ClientError, ER_ELECTION_DISABLED);
+		if (box_election_mode == ELECTION_MODE_MANUAL) {
+			diag_set(TimedOut);
+		} else {
+			assert(box_election_mode != ELECTION_MODE_CANDIDATE);
+			diag_set(ClientError, ER_ELECTION_DISABLED);
+		}
 	}
 	raft_restore(raft);
 	return -1;

--- a/src/lib/raft/raft.c
+++ b/src/lib/raft/raft.c
@@ -977,6 +977,8 @@ raft_sm_election_update_cb(struct ev_loop *loop, struct ev_timer *timer,
 	assert(raft_is_fully_on_disk(raft));
 	raft_ev_timer_stop(loop, timer);
 	bit_clear(&raft->leader_witness_map, raft->self);
+	/* If this was a manual promotion, transition back to follower. */
+	raft_restore(raft);
 	raft_schedule_broadcast(raft);
 	raft_sm_election_update(raft);
 }

--- a/test/replication-luatest/election_pre_vote_test.lua
+++ b/test/replication-luatest/election_pre_vote_test.lua
@@ -108,7 +108,6 @@ end
 -- when it lacks a quorum of peers.
 --
 g.test_promote_no_quorum = function(g)
-    t.skip('Enable once gh-8217 is fixed')
     g.follower1:exec(function() box.cfg{replication = ''} end)
     local term = g.follower1:exec(get_election_term)
     t.assert_error_msg_content_equals(

--- a/test/replication-luatest/gh_8168_extra_term_bump_test.lua
+++ b/test/replication-luatest/gh_8168_extra_term_bump_test.lua
@@ -25,6 +25,7 @@ g.before_each(function(cg)
         box_cfg = box_cfg,
     }
     cg.replica_set:start()
+    cg.replica_set:wait_for_fullmesh()
 end)
 
 g.after_each(function(cg)
@@ -32,15 +33,26 @@ g.after_each(function(cg)
 end)
 
 g.test_double_term_bump_on_promote = function(cg)
+    t.tarantool.skip_if_not_debug()
     cg.server1:wait_for_election_leader()
     local term = cg.server1:get_election_term()
-    local ok, _ = cg.server2:exec(function()
+    -- Even with a tiny election timeout, server1 might be in time to vote for
+    -- server2. Prevent it from doing so.
+    cg.server1:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+    end)
+    local ok, err = cg.server2:exec(function()
         return pcall(box.ctl.promote)
     end)
-    t.assert(ok, 'Promote succeeded')
+    t.assert(not ok, 'Promote failed')
+    t.assert_equals(err.type, 'TimedOut', 'Failure reason is election timeout')
+    cg.server2:wait_for_election_term(term + 1);
     t.assert_equals(cg.server2:get_election_term(), term + 1,
-                    'Promote bumped term once')
+                    'Promote bumped term only once')
     t.assert_equals(cg.server2:exec(function()
         return box.info.election.state
-    end), 'leader', 'Server 2 is the leader')
+    end), 'follower', 'Server 2 is the follower')
+    cg.server1:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+    end)
 end

--- a/test/unit/raft.c
+++ b/test/unit/raft.c
@@ -1634,7 +1634,7 @@ raft_test_promote_restore(void)
 	raft_run_next_event();
 	ok(raft_time() - ts >= node.raft.election_timeout,
 	   "election timeout passed");
-	is(node.raft.state, RAFT_STATE_CANDIDATE, "still a candidate");
+	is(node.raft.state, RAFT_STATE_FOLLOWER, "resigned from candidate");
 	is(node.raft.term, 5, "do not bump term");
 
 	is(raft_node_send_leader(


### PR DESCRIPTION
Fixing a bug with nodes in 'manual' election mode bumping the term excessively revealed a hang in election_pre_vote test. Turns out the test passed thanks to the previous buggy behaviour.

The following behaviour is expected: when a node is configured in manual election mode, calling box.ctl.promote() on it should make it bump term once, try to gather votes and fail on timeout.

Once the extra term bump on timeout was removed in commit 5765fdc4e4ec ("raft: fix 'manual' nodes bumping the term excessively"), box.ctl.promote() without a quorum started hanging.

Let's return the correct behaviour: 'manual' nodes should transition back to follower if an election timeout passes after the promotion without any term outcome.

Enable the test_promote_no_quorum testcase of election_pre_vote test back, since it's fixed now.

Follow-up #8168
Closes #8217

NO_DOC=bugfix
NO_CHANGELOG=changes not released behaviour