### PR TITLE
changelog: mark vinyl transaction isolation level support as breaking

### DIFF
--- a/changelogs/unreleased/gh-5522-vy-tx-isolation-level.md
+++ b/changelogs/unreleased/gh-5522-vy-tx-isolation-level.md
@@ -1,5 +1,7 @@
 ## feature/vinyl
 
-* Added support of transaction isolation levels for the Vinyl engine.
-  The `txn_isolation` option passed to `box.begin()` now has the same
-  effect for Vinyl and memtx (gh-5522).
+* **[Breaking change]** Added support of transaction isolation levels for the
+  Vinyl engine. The `txn_isolation` option passed to `box.begin()` now has the
+  same effect for Vinyl and memtx. Note, this effectively changes the default
+  isolation level of Vinyl transactions from 'read-committed' to 'best-effort',
+  which may cause more conflicts (gh-5522).


### PR DESCRIPTION
[Link to the discussion](https://www.notion.so/tarantool/vinyl-implement-transaction-isolation-levels-ccb542efa0b24b5b8eb99d7365ae086d)

The transaction isolation level used by Tarantool by default is 'best-effort' so adding support of transaction isolation levels to Vinyl effectively switched the isolation level used by Vinyl transactions from 'read-committed' to 'best-effort', which potentially may cause more conflicts. Let's mention it in the changelog and mark this change as breaking.


Follow-up commit 588170a77c9a ("vinyl: implement transaction isolation levels")
Follow-up #5522