### PR TITLE
test: fix flaky when has unfinished final join

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3698,7 +3698,7 @@ box_process_register(struct iostream *io, const struct xrow_header *header)
 	 * (req.vclock, stop_vclock) so that it gets its
 	 * registration.
 	 */
-	relay_final_join(io, header->sync, &req.vclock, &stop_vclock);
+	relay_final_join(io, header->sync, &req.vclock, &stop_vclock, replica->relay);
 	say_info("final data sent.");
 
 	RegionGuard region_guard(&fiber()->gc);
@@ -3853,7 +3853,7 @@ box_process_join(struct iostream *io, const struct xrow_header *header)
 	 * Final stage: feed replica with WALs in range
 	 * (start_vclock, stop_vclock).
 	 */
-	relay_final_join(io, header->sync, &start_vclock, &stop_vclock);
+	relay_final_join(io, header->sync, &start_vclock, &stop_vclock, replica->relay);
 	say_info("final data sent.");
 
 	/* Send end of WAL stream marker */

--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -526,16 +526,15 @@ relay_final_join_f(va_list ap)
 
 void
 relay_final_join(struct iostream *io, uint64_t sync,
-		 struct vclock *start_vclock, struct vclock *stop_vclock)
+		 struct vclock *start_vclock, struct vclock *stop_vclock,
+		 struct relay *relay)
 {
-	struct relay *relay = relay_new(NULL);
 	if (relay == NULL)
 		diag_raise();
 
 	relay_start(relay, io, sync, relay_send_row, relay_yield, UINT64_MAX);
 	auto relay_guard = make_scoped_guard([=] {
 		relay_stop(relay);
-		relay_delete(relay);
 	});
 	/*
 	 * Save the first vclock as 'received'. Because it was really received.

--- a/src/box/relay.h
+++ b/src/box/relay.h
@@ -139,7 +139,8 @@ relay_initial_join(struct iostream *io, uint64_t sync, struct vclock *vclock,
  */
 void
 relay_final_join(struct iostream *io, uint64_t sync,
-		 struct vclock *start_vclock, struct vclock *stop_vclock);
+		 struct vclock *start_vclock, struct vclock *stop_vclock,
+		 struct relay *relay);
 
 /**
  * Subscribe a replica to updates.


### PR DESCRIPTION
The final join makes a new cord to perform the replication of the data accumulated while the initial join performed. The cord can be bound to the already existing relay, so need update to the interface.