### PR TITLE
lua/utils: use `index2adr()` instead of index arithmetic

### DIFF
--- a/changelogs/unreleased/gh-8249-lual_checkcdata-with-upvalues.md
+++ b/changelogs/unreleased/gh-8249-lual_checkcdata-with-upvalues.md
@@ -1,0 +1,5 @@
+## bugfix/lua
+
+* Fixed a bug that prevents using C module API methods `luaL_iscallable()`,
+  `luaL_checkcdata()` and `luaL_setcdatagc()` with the upvalue indexes
+  (gh-8249).

--- a/src/lua/utils.h
+++ b/src/lua/utils.h
@@ -126,6 +126,19 @@ luaT_newinterval(struct lua_State *L);
 struct interval *
 luaT_pushinterval(struct lua_State *L, const struct interval *itv);
 
+/**
+ * Returns a pointer to the cdata payload.
+ *
+ * @param L Lua state.
+ * @param idx Acceptable index on the Lua stack.
+ * @param[out] ctypeid FFI's CTypeID of this cdata.
+ *
+ * @retval Pointer to the memory associated with this cdata,
+ * or NULL if the value at the given index is not a cdata.
+ */
+void *
+luaL_tocpointer(lua_State *L, int idx, uint32_t *ctypeid);
+
 /** \cond public */
 
 /**
@@ -411,9 +424,9 @@ static inline bool
 luaL_isnull(struct lua_State *L, int idx)
 {
 	if (lua_type(L, idx) == LUA_TCDATA) {
-		GCcdata *cd = cdataV(L->base + idx - 1);
-		return cd->ctypeid == CTID_P_VOID &&
-			*(void **)cdataptr(cd) == NULL;
+		uint32_t ctypeid;
+		void *cdata = luaL_tocpointer(L, idx, &ctypeid);
+		return ctypeid == CTID_P_VOID && *(void **)cdata == NULL;
 	}
 	return false;
 }

--- a/test/app-tap/module_api.test.lua
+++ b/test/app-tap/module_api.test.lua
@@ -167,6 +167,12 @@ local function test_iscallable(test, module)
     end
 end
 
+local function test_upvalueindex(test, module)
+    test:plan(1)
+    test:ok(module.test_upvalueindex(),
+            'upvalue index passed to various methods')
+end
+
 local function test_iscdata(test, module)
     local ffi = require('ffi')
     ffi.cdef([[
@@ -658,7 +664,7 @@ local function test_box_iproto_override(test, module)
 end
 
 require('tap').test("module_api", function(test)
-    test:plan(47)
+    test:plan(49)
     local status, module = pcall(require, 'module_api')
     test:is(status, true, "module")
     test:ok(status, "module is loaded")
@@ -684,6 +690,7 @@ require('tap').test("module_api", function(test)
 
     test:test("pushcdata", test_pushcdata, module)
     test:test("iscallable", test_iscallable, module)
+    test:test("upvalueindex", test_upvalueindex, module)
     test:test("iscdata", test_iscdata, module)
     test:test("buffers", test_buffers, module)
     test:test("tuple_validate", test_tuple_validate, module)


### PR DESCRIPTION
We have a code that performs calculations to obtain the address from the
given index, the address is then passed to `cdataV()` to get cdata value from
the stack. But this doesn't work for pseudo-indexes (e.g. upvalue indexes).
This patch brings `index2adr()` from `luajit/src/lj_api.c`, which accepts all
kinds of indexes, so that the calculations are no longer needed. Also the
helper function `luaL_tocpointer()` is introduced.

Closes #8249