### PR TITLE
Fix a couple of crashes in tuple update

### DIFF
--- a/changelogs/unreleased/gh-8216-tuple-update-crash.md
+++ b/changelogs/unreleased/gh-8216-tuple-update-crash.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* An attempt to update the same field in `tuple/space/index:update()` more than
+  once could crash (gh-8216).

--- a/src/box/xrow_update_field.h
+++ b/src/box/xrow_update_field.h
@@ -723,6 +723,8 @@ xrow_update_op_do_field_##op_type(struct xrow_update_op *op,			\
 				  struct xrow_update_field *field)		\
 {										\
 	switch (field->type) {							\
+	case XUPDATE_SCALAR:							\
+		return xrow_update_err_double(op);				\
 	case XUPDATE_ARRAY:							\
 		return xrow_update_op_do_array_##op_type(op, field);		\
 	case XUPDATE_NOP:							\

--- a/src/box/xrow_update_field.h
+++ b/src/box/xrow_update_field.h
@@ -262,6 +262,50 @@ xrow_update_op_is_term(const struct xrow_update_op *op)
 
 /* }}} xrow_update_op */
 
+/** {{{ Error helpers. */
+/**
+ * All the error helpers below set diag with appropriate error
+ * code, taking into account field_no < 0, complex paths. They all
+ * return -1 to shorten error returning in a caller function to
+ * single line.
+ */
+
+/** Error 'no such field'. */
+int
+xrow_update_err_no_such_field(const struct xrow_update_op *op);
+
+/** Generic error with arbitrary reason. */
+int
+xrow_update_err(const struct xrow_update_op *op, const char *reason);
+
+static inline int
+xrow_update_err_double(const struct xrow_update_op *op)
+{
+	return xrow_update_err(op, "double update of the same field");
+}
+
+static inline int
+xrow_update_err_bad_json(const struct xrow_update_op *op, int pos)
+{
+	return xrow_update_err(
+		op, tt_sprintf("invalid JSON in position %d", pos));
+}
+
+static inline int
+xrow_update_err_delete1(const struct xrow_update_op *op)
+{
+	return xrow_update_err(
+		op, "can delete only 1 field from a map in a row");
+}
+
+static inline int
+xrow_update_err_duplicate(const struct xrow_update_op *op)
+{
+	return xrow_update_err(op, "the key exists already");
+}
+
+/** }}} Error helpers. */
+
 /* {{{ xrow_update_field */
 
 /** Types of field update. */
@@ -741,47 +785,5 @@ int
 xrow_update_op_do_splice(struct xrow_update_op *op, const char *old);
 
 /* }}} Scalar helpers. */
-
-/** {{{ Error helpers. */
-/**
- * All the error helpers below set diag with appropriate error
- * code, taking into account field_no < 0, complex paths. They all
- * return -1 to shorten error returning in a caller function to
- * single line.
- */
-
-int
-xrow_update_err_no_such_field(const struct xrow_update_op *op);
-
-int
-xrow_update_err(const struct xrow_update_op *op, const char *reason);
-
-static inline int
-xrow_update_err_double(const struct xrow_update_op *op)
-{
-	return xrow_update_err(op, "double update of the same field");
-}
-
-static inline int
-xrow_update_err_bad_json(const struct xrow_update_op *op, int pos)
-{
-	return xrow_update_err(op, tt_sprintf("invalid JSON in position %d",
-					      pos));
-}
-
-static inline int
-xrow_update_err_delete1(const struct xrow_update_op *op)
-{
-	return xrow_update_err(op, "can delete only 1 field from a map in a "\
-			       "row");
-}
-
-static inline int
-xrow_update_err_duplicate(const struct xrow_update_op *op)
-{
-	return xrow_update_err(op, "the key exists already");
-}
-
-/** }}} Error helpers. */
 
 #endif /* TARANTOOL_BOX_TUPLE_UPDATE_FIELD_H */

--- a/src/box/xrow_update_route.c
+++ b/src/box/xrow_update_route.c
@@ -207,6 +207,15 @@ xrow_update_route_branch(struct xrow_update_field *field,
 			xrow_update_err_bad_json(new_op, rc);
 			return NULL;
 		}
+		if (old_token.type == JSON_TOKEN_END) {
+			/*
+			 * The bar path ended. It means the new operation either
+			 * is trying to update exactly the same field, or go
+			 * even deeper.
+			 */
+			xrow_update_err_double(new_op);
+			return NULL;
+		}
 		if (json_token_cmp(&old_token, &new_token) != 0)
 			break;
 		const char *next_pos = parent;
@@ -219,15 +228,7 @@ xrow_update_route_branch(struct xrow_update_field *field,
 						   new_token.len);
 			break;
 		default:
-			/*
-			 * Can't be JSON_TOKEN_ANY, because old
-			 * and new tokens are equal, but '*' is
-			 * considered invalid and the old was
-			 * already checked for that. So the new is
-			 * valid too. And can't have type ANY.
-			 */
-			assert(new_token.type == JSON_TOKEN_END);
-			xrow_update_err_double(new_op);
+			unreachable();
 			return NULL;
 		}
 		if (rc != 0) {

--- a/test/box/update.result
+++ b/test/box/update.result
@@ -1807,6 +1807,18 @@ t:upsert(ops)
 - [1, {}, [[1000, 2000]], [1, 2, 3, [4, 5, 6, 7, [8, 9, [10, 11, 12], 13, 14], 15,
       16, [17, 18, 19]], 20, {'b': 22, 'a': 21, 'c': {'d': 23, 'e': 24}}, 25]]
 ...
+--
+-- gh-8216: attempt to make an update inside a just created array field could
+-- crash.
+--
+t:update({{'=', '[3]', {a = 33}}, {'+', '[3].a', 1}})
+---
+- error: 'Field ''[3].a'' UPDATE error: double update of the same field'
+...
+t:update({{'=', '[4]', {1}}, {'+', '[4][1]', 1}})
+---
+- error: 'Field ''[4][1]'' UPDATE error: double update of the same field'
+...
 -- Try more than 2 levels of nested insertions.
 ops = {{'=', '[2].key1', {key11 = 1}}, {'=', '[2].key1.key12', {key21 = 2}},    \
        {'=', '[2].key1.key12.key22', {key31 = 3}},                              \

--- a/test/box/update.result
+++ b/test/box/update.result
@@ -1753,7 +1753,7 @@ ops = {{'+', '[4][3]', 0.5}, {'+', '[4][3][2]', 0.5}}
 ...
 t:update(ops)
 ---
-- error: Field ''[4][3][2]'' was not found in the tuple
+- error: 'Field ''[4][3][2]'' UPDATE error: double update of the same field'
 ...
 t:upsert(ops)
 ---
@@ -1818,6 +1818,15 @@ t:update({{'=', '[3]', {a = 33}}, {'+', '[3].a', 1}})
 t:update({{'=', '[4]', {1}}, {'+', '[4][1]', 1}})
 ---
 - error: 'Field ''[4][1]'' UPDATE error: double update of the same field'
+...
+-- Same about updating internals of a newly created bar field.
+t:update({{'=', '[4][6]', {a = 33}}, {'+', '[4][6].aa', 1}})
+---
+- error: 'Field ''[4][6].aa'' UPDATE error: double update of the same field'
+...
+t:update({{'=', '[4][4]', {3}}, {'+', '[4][4][1]', 1}})
+---
+- error: 'Field ''[4][4][1]'' UPDATE error: double update of the same field'
 ...
 -- Try more than 2 levels of nested insertions.
 ops = {{'=', '[2].key1', {key11 = 1}}, {'=', '[2].key1.key12', {key21 = 2}},    \

--- a/test/box/update.test.lua
+++ b/test/box/update.test.lua
@@ -631,6 +631,9 @@ t:upsert(ops)
 --
 t:update({{'=', '[3]', {a = 33}}, {'+', '[3].a', 1}})
 t:update({{'=', '[4]', {1}}, {'+', '[4][1]', 1}})
+-- Same about updating internals of a newly created bar field.
+t:update({{'=', '[4][6]', {a = 33}}, {'+', '[4][6].aa', 1}})
+t:update({{'=', '[4][4]', {3}}, {'+', '[4][4][1]', 1}})
 
 -- Try more than 2 levels of nested insertions.
 ops = {{'=', '[2].key1', {key11 = 1}}, {'=', '[2].key1.key12', {key21 = 2}},    \

--- a/test/box/update.test.lua
+++ b/test/box/update.test.lua
@@ -625,6 +625,13 @@ ops = {{'=', '[3][1]', {1000}}, {'=', '[3][1][2]', 2000}}
 t:update(ops)
 t:upsert(ops)
 
+--
+-- gh-8216: attempt to make an update inside a just created array field could
+-- crash.
+--
+t:update({{'=', '[3]', {a = 33}}, {'+', '[3].a', 1}})
+t:update({{'=', '[4]', {1}}, {'+', '[4][1]', 1}})
+
 -- Try more than 2 levels of nested insertions.
 ops = {{'=', '[2].key1', {key11 = 1}}, {'=', '[2].key1.key12', {key21 = 2}},    \
        {'=', '[2].key1.key12.key22', {key31 = 3}},                              \


### PR DESCRIPTION
```
xrow: fix bar new field update crash
    
    A tuple update with the first operation creating a new field
    somewhere deep in the tuple and the second operation trying to go
    into that new field could crash. This happened because the route
    branching function xrow_update_route_branch() missed this case.
    
    It can be detected when see that the bar path is already fully
    used (the next JSON token is END), and the new operation's path
    is still not END.
```
```
xrow: fix array new field update crash
    
    A tuple update with the first operation creating a new field
    inside an array and the second operation trying to go into that
    field could crash. This happened because the branching function
    xrow_update_op_do_field_##op_type() didn't take into account newly
    set scalar fields and an `unreachable()` was hit.
    
    Part of #8216
```