### PR TITLE
Fixes syslog facility

### DIFF
--- a/changelogs/unreleased/gh-8269-log-syslog-incorrect-facility.md
+++ b/changelogs/unreleased/gh-8269-log-syslog-incorrect-facility.md
@@ -1,0 +1,3 @@
+## bugfix/log
+
+* Fixed incorrect facility value in syslog on Alpine and OpenBSD (gh-8269).

--- a/src/lib/core/say.c
+++ b/src/lib/core/say.c
@@ -1001,12 +1001,8 @@ format_syslog_header(char *buf, int len, int level,
 	int total = 0;
 
 	/* Format syslog header according to RFC */
-	int prio = level_to_syslog_priority(level);
-#if defined(__OpenBSD__)
-#define LOG_MAKEPRI(fac, pri)        (((fac) << 3) | (pri))
-#endif
-	SNPRINT(total, snprintf, buf, len, "<%d>",
-		LOG_MAKEPRI(8 * facility, prio));
+	int prio = (facility << 3) | level_to_syslog_priority(level);
+	SNPRINT(total, snprintf, buf, len, "<%d>", prio);
 	SNPRINT(total, strftime, buf, len, "%h %e %T ", &tm);
 	SNPRINT(total, snprintf, buf, len, "%s[%d]: ", ident,
 		getpid());


### PR DESCRIPTION
~Fixes syslog facility. Multiplying does not need there because `LOG_MAKEPRI` will make it byself or defined constants already have bit offset, depending on the OS.~

See the linked issue for the problem description. Affects musl based Linux distros (Apline), distros with glibc prior to 2.17 (CentOS 6) and OpenBSD.

Fixes #8269