### PR TITLE
Fix alias detection in YAML serializer in case `__serialize` method is available

### DIFF
--- a/changelogs/unreleased/gh-8240-yaml-alias-serialize-fix.md
+++ b/changelogs/unreleased/gh-8240-yaml-alias-serialize-fix.md
@@ -1,0 +1,4 @@
+## bugfix/lua
+
+* Fixed alias detection in the YAML serializer in case the input contains
+  objects that implement the `__serialize` meta method (gh-8240).

--- a/src/lua/serializer.c
+++ b/src/lua/serializer.c
@@ -324,6 +324,7 @@ lua_field_try_serialize(struct lua_State *L, struct luaL_serializer *cfg,
 		if (luaL_tofield(L, cfg, -1, field) != 0)
 			return -1;
 		lua_replace(L, idx);
+		field->serialized = true;
 		return 0;
 	}
 	if (!lua_isstring(L, -1)) {
@@ -433,6 +434,11 @@ int
 luaL_tofield(struct lua_State *L, struct luaL_serializer *cfg, int index,
 	     struct luaL_field *field)
 {
+	field->type = MP_NIL;
+	field->ext_type = MP_UNKNOWN_EXTENSION;
+	field->compact = false;
+	field->serialized = false;
+
 	if (index < 0)
 		index = lua_gettop(L) + index + 1;
 
@@ -568,10 +574,7 @@ luaL_tofield(struct lua_State *L, struct luaL_serializer *cfg, int index,
 		field->type = MP_STR;
 		return 0;
 	case LUA_TTABLE:
-	{
-		field->compact = false;
 		return lua_field_inspect_table(L, cfg, index, field);
-	}
 	case LUA_TLIGHTUSERDATA:
 	case LUA_TUSERDATA:
 		field->sval.data = NULL;

--- a/src/lua/serializer.h
+++ b/src/lua/serializer.h
@@ -241,6 +241,8 @@ struct luaL_field {
 	/* subtypes of MP_EXT */
 	enum mp_extension_type ext_type;
 	bool compact;                /* a flag used by YAML serializer */
+	/** Set if __serialize metamethod was called for this field. */
+	bool serialized;
 };
 
 /**

--- a/test/app-luatest/gh_8240_yaml_alias_serialize_test.lua
+++ b/test/app-luatest/gh_8240_yaml_alias_serialize_test.lua
@@ -27,3 +27,17 @@ g.test_objects_that_implement_serialize_are_aliased = function()
     t.assert_is(nested2[1], nested2.a[1][1])
     t.assert_is(nested2[1], nested2.a.b.c)
 end
+
+g.test_objects_returned_by_serialize_are_aliased = function()
+    local o1 = {}
+    local o2 = serialize(setmetatable({}, {
+        __serialize = function() return {o1, {a = o1}} end,
+    }))
+    local o3 = serialize(setmetatable({}, {
+        __serialize = function() return {o2, o2} end
+    }))
+    t.assert_equals(o2, {o1, {a = o1}})
+    t.assert_is(o2[1], o2[2].a)
+    t.assert_equals(o3, {{o1, {a = o1}}, {o1, {a = o1}}})
+    t.assert_is(o3[1], o3[2])
+end

--- a/test/app-luatest/gh_8240_yaml_alias_serialize_test.lua
+++ b/test/app-luatest/gh_8240_yaml_alias_serialize_test.lua
@@ -1,0 +1,29 @@
+local yaml = require('yaml')
+local t = require('luatest')
+local g = t.group()
+
+local function serialize(o)
+    return yaml.decode(yaml.encode(o))
+end
+
+g.test_objects_that_implement_serialize_are_aliased = function()
+    local o = setmetatable({}, {
+        __serialize = function() return {} end,
+    })
+    local arr1 = {o, o}
+    local arr2 = serialize(arr1)
+    t.assert_equals(arr2, arr1)
+    t.assert_is_not(arr2[1], arr1[1])
+    t.assert_is(arr2[1], arr2[2])
+    local map1 = {a = o, b = o}
+    local map2 = serialize(map1)
+    t.assert_equals(map2, map1)
+    t.assert_is_not(map2.a, map1.a)
+    t.assert_is(map2.a, map2.b)
+    local nested1 = {o, a = {{o}, b = {c = o}}}
+    local nested2 = serialize(nested1)
+    t.assert_equals(nested2, nested1)
+    t.assert_is_not(nested2[1], nested1[1])
+    t.assert_is(nested2[1], nested2.a[1][1])
+    t.assert_is(nested2[1], nested2.a.b.c)
+end

--- a/test/swim/swim.result
+++ b/test/swim/swim.result
@@ -1340,16 +1340,13 @@ m_list
     incarnation: cdata {generation = 0ULL, version = 1ULL}
     uuid: 00000000-0000-1000-8000-000000000002
     payload_size: 0
-  - uri: 127.0.0.1:<port>
+  - &0
+    uri: 127.0.0.1:<port>
     status: alive
     incarnation: cdata {generation = 0ULL, version = 2ULL}
     uuid: 00000000-0000-1000-8000-000000000001
     payload_size: 8
-  - uri: 127.0.0.1:<port>
-    status: alive
-    incarnation: cdata {generation = 0ULL, version = 2ULL}
-    uuid: 00000000-0000-1000-8000-000000000001
-    payload_size: 8
+  - *0
 ...
 e_list
 ---
@@ -1392,16 +1389,13 @@ fiber.sleep(0)
 -- Two events - status update to 'left', and 'drop'.
 m_list
 ---
-- - uri: 127.0.0.1:<port>
+- - &0
+    uri: 127.0.0.1:<port>
     status: left
     incarnation: cdata {generation = 0ULL, version = 1ULL}
     uuid: 00000000-0000-1000-8000-000000000002
     payload_size: 0
-  - uri: 127.0.0.1:<port>
-    status: left
-    incarnation: cdata {generation = 0ULL, version = 1ULL}
-    uuid: 00000000-0000-1000-8000-000000000002
-    payload_size: 0
+  - *0
 ...
 e_list
 ---

--- a/third_party/lua-yaml/lyaml.cc
+++ b/third_party/lua-yaml/lyaml.cc
@@ -616,6 +616,8 @@ static int yaml_is_flow_mode(struct lua_yaml_dumper *dumper) {
    return 0;
 }
 
+static void find_references(struct lua_yaml_dumper *dumper);
+
 static int dump_node(struct lua_yaml_dumper *dumper)
 {
    size_t len = 0;
@@ -635,6 +637,8 @@ static int dump_node(struct lua_yaml_dumper *dumper)
 
    int top = lua_gettop(dumper->L);
    luaL_checkfield(dumper->L, dumper->cfg, top, &field);
+   if (field.serialized)
+      find_references(dumper);
    switch(field.type) {
    case MP_UINT:
       snprintf(buf, sizeof(buf) - 1, "%" PRIu64, field.ival);

--- a/third_party/lua-yaml/lyaml.cc
+++ b/third_party/lua-yaml/lyaml.cc
@@ -511,6 +511,8 @@ usage_error:
 static int dump_node(struct lua_yaml_dumper *dumper);
 
 static yaml_char_t *get_yaml_anchor(struct lua_yaml_dumper *dumper) {
+   if (lua_type(dumper->L, -1) != LUA_TTABLE)
+      return NULL;
    const char *s = "";
    lua_pushvalue(dumper->L, -1);
    lua_rawget(dumper->L, dumper->anchortable_index);
@@ -540,11 +542,9 @@ static yaml_char_t *get_yaml_anchor(struct lua_yaml_dumper *dumper) {
    return (yaml_char_t *)s;
 }
 
-static int dump_table(struct lua_yaml_dumper *dumper, struct luaL_field *field){
+static int dump_table(struct lua_yaml_dumper *dumper, struct luaL_field *field,
+                      yaml_char_t *anchor){
    yaml_event_t ev;
-   yaml_char_t *anchor = get_yaml_anchor(dumper);
-
-   if (anchor && !*anchor) return 1;
 
    yaml_mapping_style_t yaml_style = (field->compact)
       ? (YAML_FLOW_MAPPING_STYLE) : YAML_BLOCK_MAPPING_STYLE;
@@ -567,13 +567,10 @@ static int dump_table(struct lua_yaml_dumper *dumper, struct luaL_field *field){
           yaml_emitter_emit(&dumper->emitter, &ev) != 0 ? 1 : 0;
 }
 
-static int dump_array(struct lua_yaml_dumper *dumper, struct luaL_field *field){
+static int dump_array(struct lua_yaml_dumper *dumper, struct luaL_field *field,
+                      yaml_char_t *anchor){
    unsigned i;
    yaml_event_t ev;
-   yaml_char_t *anchor = get_yaml_anchor(dumper);
-
-   if (anchor && !*anchor)
-      return 1;
 
    yaml_sequence_style_t yaml_style = (field->compact)
       ? (YAML_FLOW_SEQUENCE_STYLE) : YAML_BLOCK_SEQUENCE_STYLE;
@@ -632,6 +629,10 @@ static int dump_node(struct lua_yaml_dumper *dumper)
    bool unused;
    (void) unused;
 
+   yaml_char_t *anchor = get_yaml_anchor(dumper);
+   if (anchor && !*anchor)
+      return 1;
+
    int top = lua_gettop(dumper->L);
    luaL_checkfield(dumper->L, dumper->cfg, top, &field);
    switch(field.type) {
@@ -658,9 +659,9 @@ static int dump_node(struct lua_yaml_dumper *dumper)
       len = strlen(buf);
       break;
    case MP_ARRAY:
-      return dump_array(dumper, &field);
+      return dump_array(dumper, &field, anchor);
    case MP_MAP:
-      return dump_table(dumper, &field);
+      return dump_table(dumper, &field, anchor);
    case MP_STR:
       str = lua_tolstring(dumper->L, -1, &len);
       if (yaml_is_null(str, len) || yaml_is_bool(str, len, &unused) ||


### PR DESCRIPTION
YAML format supports aliases, which are useful in case the same object is referenced more than once (for instance spaces are referenced by name and id in the `box.space` table):

```
tarantool> x = {}
---
...

tarantool> {a = x, b = x}
---
- a: &0 []
  b: *0
...
```

The implementation has two bugs:

1. Aliases aren't detected in objects returned by the `__serialize` method:
   ```
   tarantool> x = {}
   ---
   ...
   
   tarantool> setmetatable({}, {
            >     __serialize = function() return {a = x, b = x} end,
            > })
   ---
   - a: []
     b: []
   ...
   ```

2. An object that implements the `__serialize` method isn't aliased:
   ```
   tarantool> x = setmetatable({}, {
            >     __serialize = function() return {} end,
            > })
   ---
   ...
   
   tarantool> {a = x, b = x}
   ---
   - a: []
     b: []
   ...
   ```

This PR fixes both issue.

Needed for https://github.com/tarantool/tarantool-ee/issues/221
Closes #8240