### PR TITLE
lua: preliminary refactoring for built-in modules overloading [2/2]

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ endif()
 
 # Compile src/lua/*.lua files into src/lua/*.lua.c sources
 set(lua_sources)
+lua_source(lua_sources lua/loaders.lua loaders_lua)
 lua_source(lua_sources lua/init.lua init_lua)
 lua_source(lua_sources lua/debug.lua debug_lua)
 lua_source(lua_sources lua/string.lua string_lua)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ endif()
 
 # Compile src/lua/*.lua files into src/lua/*.lua.c sources
 set(lua_sources)
+lua_source(lua_sources lua/minifio.lua minifio_lua)
 lua_source(lua_sources lua/loaders.lua loaders_lua)
 lua_source(lua_sources lua/init.lua init_lua)
 lua_source(lua_sources lua/debug.lua debug_lua)
@@ -160,6 +161,7 @@ set (server_sources
      lua/error.c
      lua/socket.c
      lua/pickle.c
+     lua/minifio.c
      lua/fio.c
      lua/popen.c
      lua/httpc.c

--- a/src/box/lua/console.lua
+++ b/src/box/lua/console.lua
@@ -948,7 +948,7 @@ local function listen(uri)
     return s
 end
 
-package.loaded['console'] = {
+return {
     start = start;
     eval = eval;
     delimiter = delimiter;

--- a/src/box/lua/net_box.lua
+++ b/src/box/lua/net_box.lua
@@ -1339,4 +1339,4 @@ setmetatable(this_module.self, {
     end
 })
 
-package.loaded['net.box'] = this_module
+return this_module

--- a/src/box/lua/xlog.lua
+++ b/src/box/lua/xlog.lua
@@ -4,6 +4,6 @@ local function xlog_pairs(...)
     return fun.wrap(internal.pairs(...))
 end
 
-package.loaded['xlog'] = {
+return {
     pairs = xlog_pairs,
 }

--- a/src/lua/fio.c
+++ b/src/lua/fio.c
@@ -617,21 +617,6 @@ lbox_fio_tempdir(struct lua_State *L)
 }
 
 static int
-lbox_fio_cwd(struct lua_State *L)
-{
-	char *buf = (char *)lua_newuserdata(L, PATH_MAX);
-	if (!buf) {
-		errno = ENOMEM;
-		return lbox_fio_pushsyserror(L);
-	}
-	if (getcwd(buf, PATH_MAX) == NULL)
-		return lbox_fio_pushsyserror(L);
-	lua_pushstring(L, buf);
-	lua_remove(L, -2);
-	return 1;
-}
-
-static int
 lbox_fio_fsync(struct lua_State *L)
 {
 	int fd = lua_tointeger(L, 1);
@@ -694,7 +679,6 @@ tarantool_lua_fio_init(struct lua_State *L)
 		{ "chmod",		lbox_fio_chmod			},
 		{ "truncate",		lbox_fio_truncate		},
 		{ "tempdir",		lbox_fio_tempdir		},
-		{ "cwd",		lbox_fio_cwd			},
 		{ "sync",		lbox_fio_sync			},
 		{ NULL,			NULL				}
 	};

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -110,7 +110,8 @@ struct fiber *script_fiber;
 bool start_loop = true;
 
 /* contents of src/lua/ files */
-extern char strict_lua[],
+extern char loaders_lua[],
+	strict_lua[],
 	compat_lua[],
 	uuid_lua[],
 	msgpackffi_lua[],
@@ -273,6 +274,7 @@ static const char *lua_modules[] = {
 	"internal.compat", compat_lua,
 	"fun", fun_lua,
 	"debug", debug_lua,
+	"internal.loaders", loaders_lua,
 	"tarantool", init_lua,
 	"errno", errno_lua,
 	"fiber", fiber_lua,

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -810,8 +810,6 @@ static void
 luaT_set_module_from_source(struct lua_State *L, const char *modname,
 			    const char *modsrc)
 {
-	lua_getfield(L, LUA_REGISTRYINDEX, "_LOADED");
-
 	/*
 	 * TODO: Use a file name, not a module name for the
 	 * luaL_loadbuffer() parameter.
@@ -826,15 +824,10 @@ luaT_set_module_from_source(struct lua_State *L, const char *modname,
 	lua_pushstring(L, modname);
 	lua_call(L, 1, 1);
 
-	if (!lua_isnil(L, -1)) {
-		/* package.loaded.modname = t */
-		lua_setfield(L, -3, modname);
-	} else {
-		lua_pop(L, 1); /* nil */
-	}
+	luaT_setmodule(L, modname);
 
 	builtin_modcache_put(modname, modsrc);
-	lua_pop(L, 2); /* modfile, _LOADED */
+	lua_pop(L, 1); /* modfile */
 }
 
 void

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -60,6 +60,7 @@
 #include <lua-yaml/lyaml.h>
 #include "lua/msgpack.h"
 #include "lua/pickle.h"
+#include "lua/minifio.h"
 #include "lua/fio.h"
 #include "lua/popen.h"
 #include "lua/httpc.h"
@@ -110,7 +111,8 @@ struct fiber *script_fiber;
 bool start_loop = true;
 
 /* contents of src/lua/ files */
-extern char loaders_lua[],
+extern char minifio_lua[],
+	loaders_lua[],
 	strict_lua[],
 	compat_lua[],
 	uuid_lua[],
@@ -274,6 +276,7 @@ static const char *lua_modules[] = {
 	"internal.compat", compat_lua,
 	"fun", fun_lua,
 	"debug", debug_lua,
+	"internal.minifio", minifio_lua,
 	"internal.loaders", loaders_lua,
 	"tarantool", init_lua,
 	"errno", errno_lua,
@@ -826,6 +829,7 @@ tarantool_lua_init(const char *tarantool_bin, int argc, char **argv)
 	tarantool_lua_fiber_channel_init(L);
 	tarantool_lua_errno_init(L);
 	tarantool_lua_error_init(L);
+	tarantool_lua_minifio_init(L);
 	tarantool_lua_fio_init(L);
 	tarantool_lua_popen_init(L);
 	tarantool_lua_socket_init(L);

--- a/src/lua/init.lua
+++ b/src/lua/init.lua
@@ -2,6 +2,7 @@
 -- init.lua -- internal file
 
 local ffi = require('ffi')
+local loaders = require('internal.loaders')
 local compat = require('internal.compat')
 
 ffi.cdef[[
@@ -21,15 +22,6 @@ tarantool_exit(int);
 ]]
 
 local fio = require("fio")
-
-local soext = (jit.os == "OSX" and "dylib" or "so")
-
-local ROCKS_LIB_PATH = '.rocks/lib/tarantool'
-local ROCKS_LUA_PATH = '.rocks/share/tarantool'
-local LIB_TEMPLATES = { '?.'..soext }
-local LUA_TEMPLATES = { '?.lua', '?/init.lua' }
-local ROCKS_LIB_TEMPLATES = { ROCKS_LIB_PATH .. '/?.'..soext }
-local ROCKS_LUA_TEMPLATES = { ROCKS_LUA_PATH .. '/?.lua', ROCKS_LUA_PATH .. '/?/init.lua' }
 
 -- A wrapper with a unique name, used in the call stack traversing.
 local function __tarantool__internal__require__wrapper__()
@@ -103,8 +95,8 @@ local function module_name_from_filename(filename)
     result = result:gsub('/init.lua', '')
     result = result:gsub('%.lua', '')
     result = strip_cwd_from_path(fio.cwd(), result)
-    result = result:gsub(ROCKS_LIB_PATH .. '/', '')
-    result = result:gsub(ROCKS_LUA_PATH .. '/', '')
+    result = result:gsub(loaders.ROCKS_LIB_PATH .. '/', '')
+    result = result:gsub(loaders.ROCKS_LUA_PATH .. '/', '')
     result = result:gsub('/', '.')
     return result
 end
@@ -150,24 +142,6 @@ _G.require = function(modname)
     return real_require(modname)
 end
 
-local package_searchroot
-
-local function searchroot()
-    return package_searchroot or fio.cwd()
-end
-
-local function setsearchroot(path)
-    if not path then
-        -- Here we need to get this function caller's sourcedir.
-        path = debug.sourcedir(3)
-    elseif path == box.NULL then
-        path = nil
-    else
-        assert(type(path) == 'string', 'Search root must be a string')
-    end
-    package_searchroot = path and fio.abspath(path)
-end
-
 dostring = function(s, ...)
     local chunk, message = loadstring(s)
     if chunk == nil then
@@ -195,134 +169,6 @@ end
 local function pid()
     return tonumber(ffi.C.getpid())
 end
-
-local function mksymname(name)
-    local mark = string.find(name, "-")
-    if mark then name = string.sub(name, mark + 1) end
-    return "luaopen_" .. string.gsub(name, "%.", "_")
-end
-
-local function load_lib(file, name)
-    return package.loadlib(file, mksymname(name))
-end
-
-local function load_lua(file)
-    return loadfile(file)
-end
-
-local function traverse_path(path)
-    path = fio.abspath(path)
-    local paths = { path }
-
-    while path ~= '/' do
-        path = fio.dirname(path)
-        table.insert(paths, path)
-    end
-
-    return paths
-end
-
--- Generate a search function, which performs searching through
--- templates setup in options.
---
--- @param path_fn function which returns a base path for the
---     resulting template
--- @param templates table with lua search templates
--- @param need_traverse bool flag which tells search function to
---     build multiple paths by expanding base path up to the
---     root ('/')
--- @return a searcher function which builds a path template and
---     calls package.searchpath
-local function gen_search_func(path_fn, templates, need_traverse)
-    assert(type(path_fn) == 'function', 'path_fn must be a function')
-    assert(type(templates) == 'table', 'templates must be a table')
-
-    return function(name)
-        local path = path_fn() or '.'
-        local paths = need_traverse and traverse_path(path) or { path }
-
-        local searchpaths = {}
-
-        for _, path in ipairs(paths) do
-            for _, template in pairs(templates) do
-                table.insert(searchpaths, fio.pathjoin(path, template))
-            end
-        end
-
-        local searchpath = table.concat(searchpaths, ';')
-
-        return package.searchpath(name, searchpath)
-    end
-end
-
--- Compose a loader function from options.
---
--- @param search_fn function will be used to search a file from
---     path template
--- @param load_fn function will be used to load a file, found by
---     search function
--- @return function a loader, which first search for the file and
---     then loads it
-local function gen_loader_func(search_fn, load_fn)
-    assert(type(search_fn) == 'function', 'search_fn must be defined')
-    assert(type(load_fn) == 'function', 'load_fn must be defined')
-
-    return function(name)
-        if not name then
-            return "empty name of module"
-        end
-        local file, err = search_fn(name)
-        if not file then
-            return err
-        end
-        local loaded, err = load_fn(file, name)
-        if err == nil then
-            return loaded
-        else
-            return err
-        end
-    end
-end
-
-local search_lua = gen_search_func(searchroot, LUA_TEMPLATES)
-local search_lib = gen_search_func(searchroot, LIB_TEMPLATES)
-local search_rocks_lua = gen_search_func(searchroot, ROCKS_LUA_TEMPLATES, true)
-local search_rocks_lib = gen_search_func(searchroot, ROCKS_LIB_TEMPLATES, true)
-
-local search_funcs = {
-    search_lua,
-    search_lib,
-    search_rocks_lua,
-    search_rocks_lib,
-    function(name) return package.searchpath(name, package.path) end,
-    function(name) return package.searchpath(name, package.cpath) end,
-}
-
-local function search(name)
-    if not name then
-        return "empty name of module"
-    end
-    for _, searcher in ipairs(search_funcs) do
-        local file = searcher(name)
-        if file ~= nil then
-            return file
-        end
-    end
-    return nil
-end
-
--- loader_preload 1
-table.insert(package.loaders, 2, gen_loader_func(search_lua, load_lua))
-table.insert(package.loaders, 3, gen_loader_func(search_lib, load_lib))
-table.insert(package.loaders, 4, gen_loader_func(search_rocks_lua, load_lua))
-table.insert(package.loaders, 5, gen_loader_func(search_rocks_lib, load_lib))
--- package.path   6
--- package.cpath  7
--- croot          8
-
-rawset(package, "search", search)
-rawset(package, "searchroot", searchroot)
-rawset(package, "setsearchroot", setsearchroot)
 
 -- Execute scripts or load modules pointed by TT_PRELOAD
 -- environment variable.

--- a/src/lua/loaders.lua
+++ b/src/lua/loaders.lua
@@ -1,0 +1,166 @@
+local fio = require("fio")
+
+local soext = (jit.os == "OSX" and "dylib" or "so")
+
+local ROCKS_LIB_PATH = '.rocks/lib/tarantool'
+local ROCKS_LUA_PATH = '.rocks/share/tarantool'
+local LIB_TEMPLATES = { '?.'..soext }
+local LUA_TEMPLATES = { '?.lua', '?/init.lua' }
+local ROCKS_LIB_TEMPLATES = {
+    ROCKS_LIB_PATH .. '/?.'..soext,
+}
+local ROCKS_LUA_TEMPLATES = {
+    ROCKS_LUA_PATH .. '/?.lua',
+    ROCKS_LUA_PATH .. '/?/init.lua',
+}
+
+local package_searchroot
+
+local function searchroot()
+    return package_searchroot or fio.cwd()
+end
+
+local function setsearchroot(path)
+    if not path then
+        -- Here we need to get this function caller's sourcedir.
+        path = debug.sourcedir(3)
+    elseif path == box.NULL then
+        path = nil
+    else
+        assert(type(path) == 'string', 'Search root must be a string')
+    end
+    package_searchroot = path and fio.abspath(path)
+end
+
+local function mksymname(name)
+    local mark = string.find(name, "-")
+    if mark then name = string.sub(name, mark + 1) end
+    return "luaopen_" .. string.gsub(name, "%.", "_")
+end
+
+local function load_lib(file, name)
+    return package.loadlib(file, mksymname(name))
+end
+
+local function load_lua(file)
+    return loadfile(file)
+end
+
+local function traverse_path(path)
+    path = fio.abspath(path)
+    local paths = { path }
+
+    while path ~= '/' do
+        path = fio.dirname(path)
+        table.insert(paths, path)
+    end
+
+    return paths
+end
+
+-- Generate a search function, which performs searching through
+-- templates setup in options.
+--
+-- @param path_fn function which returns a base path for the
+--     resulting template
+-- @param templates table with lua search templates
+-- @param need_traverse bool flag which tells search function to
+--     build multiple paths by expanding base path up to the
+--     root ('/')
+-- @return a searcher function which builds a path template and
+--     calls package.searchpath
+local function gen_search_func(path_fn, templates, need_traverse)
+    assert(type(path_fn) == 'function', 'path_fn must be a function')
+    assert(type(templates) == 'table', 'templates must be a table')
+
+    return function(name)
+        local path = path_fn() or '.'
+        local paths = need_traverse and traverse_path(path) or { path }
+
+        local searchpaths = {}
+
+        for _, path in ipairs(paths) do
+            for _, template in pairs(templates) do
+                table.insert(searchpaths, fio.pathjoin(path, template))
+            end
+        end
+
+        local searchpath = table.concat(searchpaths, ';')
+
+        return package.searchpath(name, searchpath)
+    end
+end
+
+-- Compose a loader function from options.
+--
+-- @param search_fn function will be used to search a file from
+--     path template
+-- @param load_fn function will be used to load a file, found by
+--     search function
+-- @return function a loader, which first search for the file and
+--     then loads it
+local function gen_loader_func(search_fn, load_fn)
+    assert(type(search_fn) == 'function', 'search_fn must be defined')
+    assert(type(load_fn) == 'function', 'load_fn must be defined')
+
+    return function(name)
+        if not name then
+            return "empty name of module"
+        end
+        local file, err = search_fn(name)
+        if not file then
+            return err
+        end
+        local loaded, err = load_fn(file, name)
+        if err == nil then
+            return loaded
+        else
+            return err
+        end
+    end
+end
+
+local search_lua = gen_search_func(searchroot, LUA_TEMPLATES)
+local search_lib = gen_search_func(searchroot, LIB_TEMPLATES)
+local search_rocks_lua = gen_search_func(searchroot, ROCKS_LUA_TEMPLATES, true)
+local search_rocks_lib = gen_search_func(searchroot, ROCKS_LIB_TEMPLATES, true)
+
+local search_funcs = {
+    search_lua,
+    search_lib,
+    search_rocks_lua,
+    search_rocks_lib,
+    function(name) return package.searchpath(name, package.path) end,
+    function(name) return package.searchpath(name, package.cpath) end,
+}
+
+local function search(name)
+    if not name then
+        return "empty name of module"
+    end
+    for _, searcher in ipairs(search_funcs) do
+        local file = searcher(name)
+        if file ~= nil then
+            return file
+        end
+    end
+    return nil
+end
+
+-- loader_preload 1
+table.insert(package.loaders, 2, gen_loader_func(search_lua, load_lua))
+table.insert(package.loaders, 3, gen_loader_func(search_lib, load_lib))
+table.insert(package.loaders, 4, gen_loader_func(search_rocks_lua, load_lua))
+table.insert(package.loaders, 5, gen_loader_func(search_rocks_lib, load_lib))
+-- package.path   6
+-- package.cpath  7
+-- croot          8
+
+rawset(package, "search", search)
+rawset(package, "searchroot", searchroot)
+rawset(package, "setsearchroot", setsearchroot)
+
+return {
+    ROCKS_LIB_PATH = ROCKS_LIB_PATH,
+    ROCKS_LUA_PATH = ROCKS_LUA_PATH,
+}

--- a/src/lua/loaders.lua
+++ b/src/lua/loaders.lua
@@ -1,4 +1,4 @@
-local fio = require("fio")
+local minifio = require('internal.minifio')
 
 local soext = (jit.os == "OSX" and "dylib" or "so")
 
@@ -17,7 +17,7 @@ local ROCKS_LUA_TEMPLATES = {
 local package_searchroot
 
 local function searchroot()
-    return package_searchroot or fio.cwd()
+    return package_searchroot or minifio.cwd()
 end
 
 local function setsearchroot(path)
@@ -29,7 +29,7 @@ local function setsearchroot(path)
     else
         assert(type(path) == 'string', 'Search root must be a string')
     end
-    package_searchroot = path and fio.abspath(path)
+    package_searchroot = path and minifio.abspath(path)
 end
 
 local function mksymname(name)
@@ -47,11 +47,11 @@ local function load_lua(file)
 end
 
 local function traverse_path(path)
-    path = fio.abspath(path)
+    path = minifio.abspath(path)
     local paths = { path }
 
     while path ~= '/' do
-        path = fio.dirname(path)
+        path = minifio.dirname(path)
         table.insert(paths, path)
     end
 
@@ -81,7 +81,7 @@ local function gen_search_func(path_fn, templates, need_traverse)
 
         for _, path in ipairs(paths) do
             for _, template in pairs(templates) do
-                table.insert(searchpaths, fio.pathjoin(path, template))
+                table.insert(searchpaths, minifio.pathjoin(path, template))
             end
         end
 

--- a/src/lua/minifio.c
+++ b/src/lua/minifio.c
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include "lua/minifio.h"
+
+#include <unistd.h>
+#include <lua.h>
+#include <lauxlib.h>
+
+#include "diag.h"
+#include "lua/utils.h"
+#include "lua/error.h"
+
+/**
+ * Push nil and an error with strerror() based message.
+ */
+static int
+luaT_minifio_pushsyserror(struct lua_State *L)
+{
+	/*
+	 * It is used in functions exposed into the fio module,
+	 * so use "fio" diagnostics instead of "minifio".
+	 */
+	diag_set(SystemError, "fio");
+	return luaT_push_nil_and_error(L);
+}
+
+/**
+ * minifio.cwd() -- get current working directory.
+ */
+static int
+lbox_minifio_cwd(struct lua_State *L)
+{
+	char *buf = (char *)lua_newuserdata(L, PATH_MAX);
+	if (!buf) {
+		errno = ENOMEM;
+		return luaT_minifio_pushsyserror(L);
+	}
+	if (getcwd(buf, PATH_MAX) == NULL)
+		return luaT_minifio_pushsyserror(L);
+	lua_pushstring(L, buf);
+	lua_remove(L, -2);
+	return 1;
+}
+
+void
+tarantool_lua_minifio_init(struct lua_State *L)
+{
+	static const struct luaL_Reg minifio_methods[] = {
+		{"cwd", lbox_minifio_cwd},
+		{NULL, NULL}
+	};
+
+	luaT_newmodule(L, "internal.minifio", minifio_methods);
+	lua_pop(L, 1);
+}

--- a/src/lua/minifio.h
+++ b/src/lua/minifio.h
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+struct lua_State;
+
+void
+tarantool_lua_minifio_init(struct lua_State *L);
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */

--- a/src/lua/minifio.lua
+++ b/src/lua/minifio.lua
@@ -1,0 +1,113 @@
+local ffi = require('ffi')
+local minifio = require('internal.minifio')
+
+-- Several file manipulation functions without dependencies on
+-- tarantool's built-in modules to use at early initialization
+-- stage.
+
+ffi.cdef([[
+    char *
+    dirname(char *path);
+]])
+
+-- {{{ Functions exposed by fio
+
+-- NB: minifio.cwd() is defined in src/lua/minifio.c.
+
+function minifio.pathjoin(...)
+    local i, path = 1, nil
+
+    local len = select('#', ...)
+    while i <= len do
+        local sp = select(i, ...)
+        if sp == nil then
+            error("fio.pathjoin(): undefined path part "..i, 0)
+        end
+
+        sp = tostring(sp)
+        if sp ~= '' then
+            path = sp
+            break
+        else
+            i = i + 1
+        end
+    end
+
+    if path == nil then
+        return '.'
+    end
+
+    i = i + 1
+    while i <= len do
+        local sp = select(i, ...)
+        if sp == nil then
+            error("fio.pathjoin(): undefined path part "..i, 0)
+        end
+
+        sp = tostring(sp)
+        if sp ~= '' then
+            path = path .. '/' .. sp
+        end
+
+        i = i + 1
+    end
+
+    path = path:gsub('/+', '/')
+    if path ~= '/' then
+        path = path:gsub('/$', '')
+    end
+
+    return path
+end
+
+function minifio.abspath(path)
+    if path == nil then
+        error("Usage: fio.abspath(path)", 0)
+    end
+    path = path
+    local joined_path
+    local path_tab = {}
+    if string.sub(path, 1, 1) == '/' then
+        joined_path = path
+    else
+        joined_path = minifio.pathjoin(minifio.cwd(), path)
+    end
+    for sp in string.gmatch(joined_path, '[^/]+') do
+        if sp == '..' then
+            table.remove(path_tab)
+        elseif sp ~= '.' then
+            table.insert(path_tab, sp)
+        end
+    end
+    return '/' .. table.concat(path_tab, '/')
+end
+
+-- }}} Functions exposed by fio
+
+-- {{{ Functions replaced by fio
+
+-- Similar to fio.dirname, but it doesn't use
+-- cord_ibuf_take()/cord_ibuf_put().
+function minifio.dirname(path)
+    if type(path) ~= 'string' then
+        error("Usage: minifio.dirname(path)", 0)
+    end
+    -- Can't just cast path to char * - on Linux dirname modifies
+    -- its argument.
+    local bsize = #path + 1
+    local buf = ffi.new('char[?]', bsize)
+    ffi.copy(buf, ffi.cast('const char *', path), bsize)
+    return ffi.string(ffi.C.dirname(buf))
+end
+
+-- }}} Functions replaced by fio
+
+-- Functions to expose from fio as is. List them separately to
+-- reduce probability of a mistake.
+minifio.expose_from_fio = {
+    cwd = minifio.cwd,
+    pathjoin = minifio.pathjoin,
+    abspath = minifio.abspath,
+}
+
+return minifio

--- a/src/lua/utils.h
+++ b/src/lua/utils.h
@@ -278,6 +278,35 @@ int
 luaT_newmodule(struct lua_State *L, const char *modname,
 	       const struct luaL_Reg *funcs);
 
+/**
+ * Register a table on top of the stack as a built-in tarantool
+ * module.
+ *
+ * Can be called several times with the same value, but raises
+ * assertion fail if called with different values.
+ *
+ * Can be used after luaT_newmodule() if, again, the table of the
+ * module is the same.
+ *
+ * Pops the table.
+ *
+ * Pseudocode:
+ *
+ *  | local function setmodule(modname, mod)
+ *  |     assert(modname ~= nil)
+ *  |     if mod == nil then
+ *  |         return
+ *  |     end
+ *  |     if package.loaded[modname] == mod then
+ *  |         return
+ *  |     end
+ *  |     assert(package.loaded[modname] == nil)
+ *  |     package.loaded[modname] = mod
+ *  | end
+ */
+int
+luaT_setmodule(struct lua_State *L, const char *modname);
+
 /** \cond public */
 
 /**

--- a/test/app/fio.result
+++ b/test/app/fio.result
@@ -1405,15 +1405,15 @@ fio.open(tmp1, { 'O_RDWR', 'O_TRUNC', 'O_CREAT' }, {'A'})
 ...
 fio.pathjoin(nil)
 ---
-- error: 'builtin/fio.lua: fio.pathjoin(): undefined path part 1'
+- error: 'fio.pathjoin(): undefined path part 1'
 ...
 fio.pathjoin('abc', nil)
 ---
-- error: 'builtin/fio.lua: fio.pathjoin(): undefined path part 2'
+- error: 'fio.pathjoin(): undefined path part 2'
 ...
 fio.pathjoin('abc', 'cde', nil)
 ---
-- error: 'builtin/fio.lua: fio.pathjoin(): undefined path part 3'
+- error: 'fio.pathjoin(): undefined path part 3'
 ...
 fio.basename(nil)
 ---
@@ -1421,7 +1421,7 @@ fio.basename(nil)
 ...
 fio.abspath(nil)
 ---
-- error: 'builtin/fio.lua: Usage: fio.abspath(path)'
+- error: 'Usage: fio.abspath(path)'
 ...
 fio.chdir(1)
 ---


### PR DESCRIPTION
This patchset continues the [series][1] of preliminary commits for implementing the built-in module overriding (so called dual-life modules, see #7774 for the problem statement).

The core idea of the future functionality is that if there is the `override.foo` module on the filesystem, it automatically replaces the built-in module `foo`.

Several changes are needed to implement the overriding:

* Move Lua loaders implementation into its own file `loaders.lua`.
* Split `fio` to `minifio` (needed by the loaders) and `fio`.
* Move the loaders into an early initialization stage.
* Eliminate direct `package.loaded` assignments in src/box/lua/*.lua files.
* Hide built-in module registration process behind a function (to modify it later).

The overriding itself will go as a separate pull request.

Part of #7774

[1]: https://github.com/tarantool/tarantool/pull/8173