### PR TITLE
test: use unix sockets for iproto in box-py tests

### DIFF
--- a/test/box-py/iproto.test.py
+++ b/test/box-py/iproto.test.py
@@ -76,7 +76,7 @@ def repr_dict(todump):
 
 def test(header, body):
     # Connect and authenticate
-    c = Connection("localhost", server.iproto.port)
+    c = Connection(None, server.iproto.port)
     c.connect()
     print("query", repr_dict(header), repr_dict(body))
     header = msgpack.dumps(header)
@@ -124,7 +124,7 @@ admin("space = box.schema.space.create('test', { id = 567 })")
 admin("index = space:create_index('primary', { type = 'hash' })")
 admin("box.schema.user.grant('guest', 'read,write,execute', 'space', 'test')")
 
-c = Connection("localhost", server.iproto.port)
+c = Connection(None, server.iproto.port)
 c.connect()
 request1 = RequestInsert(c, 567, [1, "baobab"])
 request2 = RequestInsert(c, 567, [2, "obbaba"])
@@ -244,7 +244,7 @@ for test in TESTS:
 
 
 print("Test of schema_id in iproto.")
-c = Connection("localhost", server.iproto.port)
+c = Connection(None, server.iproto.port)
 c.connect()
 s = c._socket
 
@@ -389,7 +389,7 @@ print("""
 # an error code and do not close connection
 """)
 
-c = Connection("localhost", server.iproto.port)
+c = Connection(None, server.iproto.port)
 c.connect()
 s = c._socket
 header = { "hello": "world"}
@@ -414,7 +414,7 @@ admin("space = box.schema.space.create('test_index_base', { id = 568 })")
 admin("index = space:create_index('primary', { type = 'hash' })")
 admin("box.schema.user.grant('guest', 'read,write,execute', 'space', 'test_index_base')")
 
-c = Connection("localhost", server.iproto.port)
+c = Connection(None, server.iproto.port)
 c.connect()
 s = c._socket
 
@@ -457,7 +457,7 @@ c.close()
 admin("function kek() return 'kek' end")
 admin("box.schema.user.grant('guest', 'read,write,execute', 'universe')")
 
-c = Connection("localhost", server.iproto.port)
+c = Connection(None, server.iproto.port)
 c.connect()
 s = c._socket
 
@@ -489,7 +489,7 @@ def print_id_response(resp):
     else:
         print(str(resp["body"][IPROTO_ERROR].decode("utf-8")))
 
-c = Connection("localhost", server.iproto.port)
+c = Connection(None, server.iproto.port)
 c.connect()
 s = c._socket
 header = { IPROTO_CODE: REQUEST_TYPE_ID }
@@ -543,7 +543,7 @@ def check_no_event():
     receive_event()
     s.settimeout(None)
 
-c = Connection("localhost", server.iproto.port)
+c = Connection(None, server.iproto.port)
 c.connect()
 s = c._socket
 
@@ -595,7 +595,7 @@ admin("space = box.schema.space.create('test', { id = 567 })")
 admin("index = space:create_index('primary', { type = 'tree' })")
 admin("box.schema.user.grant('guest', 'read,write,execute', 'space', 'test')")
 
-c = Connection("localhost", server.iproto.port)
+c = Connection(None, server.iproto.port)
 c.connect()
 request = bytes()
 for i in range(1, 11):
@@ -620,7 +620,7 @@ class RequestSelectAfter(Request):
             body[IPROTO_AFTER_POSITION] = after_pos
         self._body = msgpack.dumps(body)
 
-c = Connection("localhost", server.iproto.port)
+c = Connection(None, server.iproto.port)
 c.connect()
 s = c._socket
 pos = ""

--- a/test/box-py/suite.ini
+++ b/test/box-py/suite.ini
@@ -3,6 +3,7 @@ core = tarantool
 description = legacy python tests
 script = box.lua
 lua_libs = lua/fiber.lua lua/fifo.lua
+use_unix_sockets_iproto = True
 is_parallel = True
 fragile = {
     "retries": 10,


### PR DESCRIPTION
To improve the stability of the tests, let's use unix sockets for iproto connection instead of ports.