### PR TITLE
datetime: fix precision overlflow

### DIFF
--- a/changelogs/unreleased/fix-datetime-width-overflow.md
+++ b/changelogs/unreleased/fix-datetime-width-overflow.md
@@ -1,0 +1,4 @@
+## bugfix/datetime
+
+* Fixed segmentation fault when too big value is passed to "%f" modifier of
+  datetime_object:format() (ghs-31).

--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -738,7 +738,7 @@ Zone Europe/Moscow  2:30:17 -       LMT 1880
 end)
 
 test:test("Datetime string formatting", function(test)
-    test:plan(10)
+    test:plan(11)
     local t = date.new()
     test:is(t.epoch, 0, ('t.epoch == %d'):format(tonumber(t.epoch)))
     test:is(t.nsec, 0, ('t.nsec == %d'):format(t.nsec))
@@ -749,6 +749,7 @@ test:test("Datetime string formatting", function(test)
     test:is(t:format('%FT%T.%f%z'), '1970-01-01T00:00:00.000+0000', 'format #4')
     test:is(t:format('%FT%T.%4f%z'), '1970-01-01T00:00:00.0000+0000', 'format #5')
     test:is(t:format(), '1970-01-01T00:00:00Z', 'format #6')
+    test:is(t:format('%64424509441f'), '000000000', 'format #7')
     assert_raises(test, expected_str('datetime.strftime()', 1234),
                   function() t:format(1234) end)
 end)


### PR DESCRIPTION
We didn't take into consideration the fact, that precision
value passed to control the width of nanoseconds part in
datetime_object:format could be more than maximum positive
value, integer may have. Currently it leads to segfault.

```
tarantool> require('datetime').new{}:format('%2147483648f')
```

We should check errno in order to find out, if overflow
occurs. The problem is the fact, that `width` variable must
have int type due to snprintf requirements ("%*d") and
strtol returns long. Errno won't be set if returned value
is in bounds [INT_MAX, LONG_MAX], but it will overflow
int resulting in inconsistent behavior.

So, let's save the result of strotl to the temp value.
If this value doesn't belong to the above-mentioned set,
or errno was set, we assign to `width` maximum value, it
may have: 9.

Closes https://github.com/tarantool/security/issues/31

NO_DOC=bugfix