### PR TITLE
test: fix bootstrap_strategy_auto_test hang

### DIFF
--- a/test/replication-luatest/bootstrap_strategy_auto_test.lua
+++ b/test/replication-luatest/bootstrap_strategy_auto_test.lua
@@ -167,6 +167,7 @@ g.test_sync_waits_for_all_connected = function(cg)
         box.error.injection.set('ERRINJ_WAL_DELAY', true)
         box.cfg{
             replication_connect_timeout = 1000,
+            replication_sync_timeout = 0.01,
             replication = replication,
         }
         t.assert_equals(box.info.status, 'orphan', 'Replica is orphan until ' ..


### PR DESCRIPTION
The test started hanging after commit d560fb3f0fed ("Revert "replication: set default replication_sync_timeout to 0"") because it still expected a zero replication_sync_timeout. This wasn't caught by PR's full-ci for some reason.

Follow-up #8223

NO_DOC=test fix
NO_CHANGELOG=test fix