### PR TITLE
third_party: update nghttp2 from 1.48.0 to 1.52.0

### DIFF
--- a/cmake/BuildNghttp2.cmake
+++ b/cmake/BuildNghttp2.cmake
@@ -25,6 +25,7 @@ macro(nghttp2_build)
     list(APPEND NGHTTP2_CMAKE_FLAGS "-DENABLE_SHARED_LIB:BOOL=OFF")
     list(APPEND NGHTTP2_CMAKE_FLAGS "-DENABLE_STATIC_CRT:BOOL=OFF")
     list(APPEND NGHTTP2_CMAKE_FLAGS "-DENABLE_HTTP3:BOOL=OFF")
+    list(APPEND NGHTTP2_CMAKE_FLAGS "-DENABLE_DOC:BOOL=OFF")
 
     # Even though we set the external project's install dir
     # below, we still need to pass the corresponding install


### PR DESCRIPTION
Updating libcurl from 7.84.0 to 7.87.0 in commit 09f4eca1ef79 ("third_party: update libcurl from 7.84.0 to 7.87.0") made it impossible to built tarantool with bundled curl with nghttp2, because nghttp2 was not updated to fit libcurl 7.87.0, this led to missing function `nghttp2_option_set_no_rfc9113_leading_and_trailing_ws_validation` during linking step.

https://github.com/nghttp2/nghttp2/releases/tag/v1.51.0

Closes #8268

NO_DOC=there is no known behavior changes, consider the change as not
       visible for a user
NO_TEST=can only reproduce in specific environment
NO_CHANGELOG=see NO_DOC