### PR TITLE
core: check event loop creation in fiber_init()

### DIFF
--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -2027,6 +2027,8 @@ fiber_init(int (*invoke)(fiber_func f, va_list ap))
 	fiber_invoke = invoke;
 	main_thread_id = pthread_self();
 	main_cord.loop = ev_default_loop(EVFLAG_AUTO | EVFLAG_ALLOCFD);
+	if (main_cord.loop == NULL)
+		panic("can't init event loop");
 	cord_create(&main_cord, "main");
 	fiber_signal_init();
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -793,9 +793,6 @@ main(int argc, char **argv)
 		 */
 		atexit(tarantool_atexit);
 
-		if (!loop())
-			panic("%s", "can't init event loop");
-
 		int events = ev_activecnt(loop());
 		/*
 		 * Load user init script.  The script should have access


### PR DESCRIPTION
The main cord's event loop is initialized by fiber_init(), but for some reason successful initialization is only checked in main() after other initialization code might try to use the event loop already.

For example, some of the loop users are coio_enable(), signal_init(), tarantooL_lua_init(), and they are all run before we actually check that loop is not NULL.

Closes https://github.com/tarantool/security/issues/28