### PR TITLE
[1.10] uuid: use `snprintf` instead of `sprintf`

### DIFF
--- a/src/tt_uuid.c
+++ b/src/tt_uuid.c
@@ -86,7 +86,7 @@ tt_uuid_is_equal(const struct tt_uuid *lhs, const struct tt_uuid *rhs);
 char *
 tt_uuid_str(const struct tt_uuid *uu)
 {
-	assert(TT_STATIC_BUF_LEN >= UUID_STR_LEN);
+	assert(TT_STATIC_BUF_LEN > UUID_STR_LEN);
 	char *buf = tt_static_buf();
 	tt_uuid_to_string(uu, buf);
 	return buf;

--- a/src/tt_uuid.h
+++ b/src/tt_uuid.h
@@ -124,10 +124,12 @@ tt_uuid_compare(const struct tt_uuid *a, const struct tt_uuid *b)
 inline void
 tt_uuid_to_string(const struct tt_uuid *uu, char *out)
 {
-	sprintf(out, "%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-		uu->time_low, uu->time_mid, uu->time_hi_and_version,
-		uu->clock_seq_hi_and_reserved, uu->clock_seq_low, uu->node[0],
-		uu->node[1], uu->node[2], uu->node[3], uu->node[4], uu->node[5]);
+	snprintf(out, UUID_STR_LEN + 1,
+		 "%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+		 uu->time_low, uu->time_mid, uu->time_hi_and_version,
+		 uu->clock_seq_hi_and_reserved, uu->clock_seq_low,
+		 uu->node[0], uu->node[1], uu->node[2],
+		 uu->node[3], uu->node[4], uu->node[5]);
 }
 
 /**


### PR DESCRIPTION
This patch fixes compilation on macOS 12.6.3 with AppleClang 14.0.0:
```
$ cmake .. -DENABLE_WERROR=ON
$ cmake --build .

[ 47%] Building CXX object src/box/CMakeFiles/tuple.dir/tuple_compare.cc.o src/box/tuple_compare.cc:31:
src/box/tuple_compare.h:38:
src/box/tuple.h:37:
src/tt_uuid.h:127:2: error: 'sprintf' is deprecated: This function is provided for compatibility reasons only. Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations]
        sprintf(out, "%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
        ^
```
In Tarantool 2.x this is fixed by commit 368766e697fd ("Fix static buffer align").

Closes #8277