### PR TITLE
memtx: fix potential NULL dereference in memtx_space_ephemeral_delete

### DIFF
--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -690,11 +690,12 @@ memtx_space_ephemeral_delete(struct space *space, const char *key)
 	struct tuple *old_tuple;
 	if (index_get(primary_index, key, part_count, &old_tuple) != 0)
 		return -1;
-	if (old_tuple != NULL &&
-	    memtx_space->replace(space, old_tuple, NULL,
-				 DUP_REPLACE, &old_tuple) != 0)
-		return -1;
-	tuple_unref(old_tuple);
+	if (old_tuple != NULL) {
+		if (memtx_space->replace(space, old_tuple, NULL,
+					 DUP_REPLACE, &old_tuple) != 0)
+			return -1;
+		tuple_unref(old_tuple);
+	}
 	return 0;
 }
 


### PR DESCRIPTION
Now, delete in ephemeral space is obviously incorrect - if we try to delete a tuple, which is not present in index, NULL dereference will happen. Fortunately, ephemeral spaces are used for internal purposes only, so, most likely, this never happens. Let's fix this part not to confuse code analyzers.

Closes https://github.com/tarantool/security/issues/38