### PR TITLE
log: print build target triplet alongside with the version

### DIFF
--- a/changelogs/unreleased/log-build-target-triplet.md
+++ b/changelogs/unreleased/log-build-target-triplet.md
@@ -1,0 +1,4 @@
+## feature/core
+
+* Now the log produced during `box.cfg{}` contains the build target triplet
+  (e.g. `Linux-x86_64-RelWithDebInfo`).

--- a/src/main.cc
+++ b/src/main.cc
@@ -501,7 +501,8 @@ load_cfg(void)
 	 * after (optional) daemonising to avoid confusing messages with
 	 * different pids
 	 */
-	say_info("%s %s", tarantool_package(), tarantool_version());
+	say_info("%s %s %s", tarantool_package(), tarantool_version(),
+		 BUILD_INFO);
 	say_info("log level %i", cfg_geti("log_level"));
 
 	if (pid_file_handle != NULL) {


### PR DESCRIPTION
This is useful for example for the analysis of performance complaints from users, when they claim that one version of Tarantool is slower than another, in fact comparing debug and release builds.

The log format is approved by @Mons and @unera.