### PR TITLE
static-build: fix potential NULL deref in openssl

### DIFF
--- a/static-build/cmake/AddDependencyProjects.cmake
+++ b/static-build/cmake/AddDependencyProjects.cmake
@@ -74,8 +74,10 @@ ExternalProject_Add(openssl
         --libdir=lib
         no-shared
     INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install_sw
-    PATCH_COMMAND patch -d <SOURCE_DIR> -p1 <
+    PATCH_COMMAND cat
         "${PATCHES_DIR}/openssl-111q-gh-18720.patch"
+        "${PATCHES_DIR}/openssl-tarantool-security-54.patch" |
+        patch -d <SOURCE_DIR> -p1
 )
 set(TARANTOOL_DEPENDS openssl ${TARANTOOL_DEPENDS})
 

--- a/static-build/patches/openssl-tarantool-security-54.patch
+++ b/static-build/patches/openssl-tarantool-security-54.patch
@@ -1,0 +1,10 @@
+--- openssl.old/ssl/statem/extensions_clnt.c	2023-02-09 16:18:41.231053686 +0300
++++ openssl/ssl/statem/extensions_clnt.c	2023-02-09 17:33:09.257282077 +0300
+@@ -266,6 +266,7 @@
+         return EXT_RETURN_NOT_SENT;
+ 
+     if (!WPACKET_put_bytes_u16(pkt, TLSEXT_TYPE_session_ticket)
++            || !s->session 
+             || !WPACKET_sub_memcpy_u16(pkt, s->session->ext.tick, ticklen)) {
+         SSLfatal(s, SSL_AD_INTERNAL_ERROR,
+                  SSL_F_TLS_CONSTRUCT_CTOS_SESSION_TICKET, ERR_R_INTERNAL_ERROR);


### PR DESCRIPTION
tls_construct_ctos_session_ticket() has a potential NULL pointer dereference.

Closes tarantool/security#54

NO_DOC=security
NO_TEST=security
NO_CHANGELOG=security