### PR TITLE
mpstream: fix NULL dereference in `mpstream_encode_double`

### DIFF
--- a/src/lib/mpstream/mpstream.c
+++ b/src/lib/mpstream/mpstream.c
@@ -1,37 +1,17 @@
 /*
- * Copyright 2010-2018, Tarantool AUTHORS, please see AUTHORS file.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
- * Redistribution and use in source and binary forms, with or
- * without modification, are permitted provided that the following
- * conditions are met:
- *
- * 1. Redistributions of source code must retain the above
- *    copyright notice, this list of conditions and the
- *    following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above
- *    copyright notice, this list of conditions and the following
- *    disclaimer in the documentation and/or other materials
- *    provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
- * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
- * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
  */
-
 #include "mpstream.h"
+
 #include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <string.h>
+
+#include "diag.h"
 #include "msgpuck.h"
 #include "mp_decimal.h"
 #include "mp_uuid.h"
@@ -41,27 +21,27 @@
 void
 mpstream_reserve_slow(struct mpstream *stream, size_t size)
 {
-    stream->alloc(stream->ctx, stream->pos - stream->buf);
-    stream->buf = (char *) stream->reserve(stream->ctx, &size);
-    if (stream->buf == NULL) {
-        diag_set(OutOfMemory, size, "mpstream", "reserve");
-        stream->error(stream->error_ctx);
-    }
-    stream->pos = stream->buf;
-    stream->end = stream->pos + size;
+	stream->alloc(stream->ctx, stream->pos - stream->buf);
+	stream->buf = stream->reserve(stream->ctx, &size);
+	if (stream->buf == NULL) {
+		diag_set(OutOfMemory, size, "mpstream", "reserve");
+		stream->error(stream->error_ctx);
+	}
+	stream->pos = stream->buf;
+	stream->end = stream->pos + size;
 }
 
 void
 mpstream_reset(struct mpstream *stream)
 {
-    size_t size = 0;
-    stream->buf = (char *) stream->reserve(stream->ctx, &size);
-    if (stream->buf == NULL) {
-        diag_set(OutOfMemory, size, "mpstream", "reset");
-        stream->error(stream->error_ctx);
-    }
-    stream->pos = stream->buf;
-    stream->end = stream->pos + size;
+	size_t size = 0;
+	stream->buf = stream->reserve(stream->ctx, &size);
+	if (stream->buf == NULL) {
+		diag_set(OutOfMemory, size, "mpstream", "reset");
+		stream->error(stream->error_ctx);
+	}
+	stream->pos = stream->buf;
+	stream->end = stream->pos + size;
 }
 
 /**
@@ -73,111 +53,111 @@ mpstream_init(struct mpstream *stream, void *ctx,
               mpstream_reserve_f reserve, mpstream_alloc_f alloc,
               mpstream_error_f error, void *error_ctx)
 {
-    stream->ctx = ctx;
-    stream->reserve = reserve;
-    stream->alloc = alloc;
-    stream->error = error;
-    stream->error_ctx = error_ctx;
-    mpstream_reset(stream);
+	stream->ctx = ctx;
+	stream->reserve = reserve;
+	stream->alloc = alloc;
+	stream->error = error;
+	stream->error_ctx = error_ctx;
+	mpstream_reset(stream);
 }
 
 void
 mpstream_encode_array(struct mpstream *stream, uint32_t size)
 {
-    assert(mp_sizeof_array(size) <= 5);
-    char *data = mpstream_reserve(stream, 5);
-    if (data == NULL)
-        return;
-    char *pos = mp_encode_array(data, size);
-    mpstream_advance(stream, pos - data);
+	assert(mp_sizeof_array(size) <= 5);
+	char *data = mpstream_reserve(stream, 5);
+	if (data == NULL)
+		return;
+	char *pos = mp_encode_array(data, size);
+	mpstream_advance(stream, pos - data);
 }
 
 void
 mpstream_encode_map(struct mpstream *stream, uint32_t size)
 {
-    assert(mp_sizeof_map(size) <= 5);
-    char *data = mpstream_reserve(stream, 5);
-    if (data == NULL)
-        return;
-    char *pos = mp_encode_map(data, size);
-    mpstream_advance(stream, pos - data);
+	assert(mp_sizeof_map(size) <= 5);
+	char *data = mpstream_reserve(stream, 5);
+	if (data == NULL)
+		return;
+	char *pos = mp_encode_map(data, size);
+	mpstream_advance(stream, pos - data);
 }
 
 void
 mpstream_encode_uint(struct mpstream *stream, uint64_t num)
 {
-    assert(mp_sizeof_uint(num) <= 9);
-    char *data = mpstream_reserve(stream, 9);
-    if (data == NULL)
-        return;
-    char *pos = mp_encode_uint(data, num);
-    mpstream_advance(stream, pos - data);
+	assert(mp_sizeof_uint(num) <= 9);
+	char *data = mpstream_reserve(stream, 9);
+	if (data == NULL)
+		return;
+	char *pos = mp_encode_uint(data, num);
+	mpstream_advance(stream, pos - data);
 }
 
 void
 mpstream_encode_int(struct mpstream *stream, int64_t num)
 {
-    assert(mp_sizeof_int(num) <= 9);
-    char *data = mpstream_reserve(stream, 9);
-    if (data == NULL)
-        return;
-    char *pos = mp_encode_int(data, num);
-    mpstream_advance(stream, pos - data);
+	assert(mp_sizeof_int(num) <= 9);
+	char *data = mpstream_reserve(stream, 9);
+	if (data == NULL)
+		return;
+	char *pos = mp_encode_int(data, num);
+	mpstream_advance(stream, pos - data);
 }
 
 void
 mpstream_encode_float(struct mpstream *stream, float num)
 {
-    assert(mp_sizeof_float(num) <= 5);
-    char *data = mpstream_reserve(stream, 5);
-    if (data == NULL)
-        return;
-    char *pos = mp_encode_float(data, num);
-    mpstream_advance(stream, pos - data);
+	assert(mp_sizeof_float(num) <= 5);
+	char *data = mpstream_reserve(stream, 5);
+	if (data == NULL)
+		return;
+	char *pos = mp_encode_float(data, num);
+	mpstream_advance(stream, pos - data);
 }
 
 void
 mpstream_encode_double(struct mpstream *stream, double num)
 {
-    assert(mp_sizeof_double(num) <= 9);
-    char *data = mpstream_reserve(stream, 9);
-    char *pos = mp_encode_double(data, num);
-    if (data == NULL)
-        return;
-    mpstream_advance(stream, pos - data);
+	assert(mp_sizeof_double(num) <= 9);
+	char *data = mpstream_reserve(stream, 9);
+	char *pos = mp_encode_double(data, num);
+	if (data == NULL)
+		return;
+	mpstream_advance(stream, pos - data);
 }
 
 void
 mpstream_encode_strn(struct mpstream *stream, const char *str, uint32_t len)
 {
-    assert(mp_sizeof_str(len) <= 5 + len);
-    char *data = mpstream_reserve(stream, 5 + len);
-    if (data == NULL)
-        return;
-    char *pos = mp_encode_str(data, str, len);
-    mpstream_advance(stream, pos - data);
+	assert(mp_sizeof_str(len) <= 5 + len);
+	char *data = mpstream_reserve(stream, 5 + len);
+	if (data == NULL)
+		return;
+	char *pos = mp_encode_str(data, str, len);
+	mpstream_advance(stream, pos - data);
 }
 
 void
 mpstream_encode_nil(struct mpstream *stream)
 {
-    assert(mp_sizeof_nil() <= 1);
-    char *data = mpstream_reserve(stream, 1);
-    if (data == NULL)
-        return;
-    char *pos = mp_encode_nil(data);
-    mpstream_advance(stream, pos - data);
+	assert(mp_sizeof_nil() <= 1);
+	char *data = mpstream_reserve(stream, 1);
+	if (data == NULL)
+		return;
+	char *pos = mp_encode_nil(data);
+	mpstream_advance(stream, pos - data);
 }
 
 void
 mpstream_encode_bool(struct mpstream *stream, bool val)
 {
-    assert(mp_sizeof_bool(val) <= 1);
-    char *data = mpstream_reserve(stream, 1);
-    if (data == NULL)
-        return;
-    char *pos = mp_encode_bool(data, val);
-    mpstream_advance(stream, pos - data);
+	assert(mp_sizeof_bool(val) <= 1);
+	char *data = mpstream_reserve(stream, 1);
+	if (data == NULL)
+		return;
+	char *pos = mp_encode_bool(data, val);
+	mpstream_advance(stream, pos - data);
 }
 
 void

--- a/src/lib/mpstream/mpstream.c
+++ b/src/lib/mpstream/mpstream.c
@@ -121,9 +121,9 @@ mpstream_encode_double(struct mpstream *stream, double num)
 {
 	assert(mp_sizeof_double(num) <= 9);
 	char *data = mpstream_reserve(stream, 9);
-	char *pos = mp_encode_double(data, num);
 	if (data == NULL)
 		return;
+	char *pos = mp_encode_double(data, num);
 	mpstream_advance(stream, pos - data);
 }
 

--- a/src/lib/mpstream/mpstream.h
+++ b/src/lib/mpstream/mpstream.h
@@ -1,37 +1,16 @@
-#ifndef TARANTOOL_LIB_CORE_MPSTREAM_H_INCLUDED
-#define TARANTOOL_LIB_CORE_MPSTREAM_H_INCLUDED
 /*
- * Copyright 2010-2015, Tarantool AUTHORS, please see AUTHORS file.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
- * Redistribution and use in source and binary forms, with or
- * without modification, are permitted provided that the following
- * conditions are met:
- *
- * 1. Redistributions of source code must retain the above
- *    copyright notice, this list of conditions and the
- *    following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above
- *    copyright notice, this list of conditions and the following
- *    disclaimer in the documentation and/or other materials
- *    provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
- * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
- * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
  */
+#pragma once
 
-#include "diag.h"
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
 #include "core/decimal.h"
 
 #if defined(__cplusplus)
@@ -42,30 +21,30 @@ struct tt_uuid;
 struct datetime;
 struct interval;
 
-/**
-* Ask the allocator to reserve at least size bytes. It can reserve
-* more, and update *size with the new size.
-*/
 typedef void *(*mpstream_reserve_f)(void *ctx, size_t *size);
-
-/** Actually use the bytes. */
 typedef void *(*mpstream_alloc_f)(void *ctx, size_t size);
-
-/** Actually use the bytes. */
 typedef void (*mpstream_error_f)(void *error_ctx);
 
 struct mpstream {
-    /**
-     * When pos >= end, or required size doesn't fit in
-     * pos..end range alloc() is called to advance the stream
-     * and reserve() to get a new chunk.
-     */
-    char *buf, *pos, *end;
-    void *ctx;
-    mpstream_reserve_f reserve;
-    mpstream_alloc_f alloc;
-    mpstream_error_f error;
-    void *error_ctx;
+	/**
+	 * When pos >= end, or required size doesn't fit in
+	 * pos..end range alloc() is called to advance the stream
+	 * and reserve() to get a new chunk.
+	 */
+	char *buf, *pos, *end;
+	/** Context passed to the reserve and alloc callbacks. */
+	void *ctx;
+	/**
+	 * Ask the allocator to reserve at least size bytes.
+	 * It can reserve more, and update *size with the new size.
+	 */
+	mpstream_reserve_f reserve;
+	/** Actually use the bytes. */
+	mpstream_alloc_f alloc;
+	/** Called on allocation error. */
+	mpstream_error_f error;
+	/** Argument passed to the error callback. */
+	void *error_ctx;
 };
 
 void
@@ -165,5 +144,3 @@ mpstream_memset(struct mpstream *stream, int c, uint32_t n);
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */
-
-#endif /* TARANTOOL_LIB_CORE_MPSTREAM_H_INCLUDED */


### PR DESCRIPTION
Closes tarantool/security#63