### PR TITLE
static-build: fix potential NULL dereference in openssl

### DIFF
--- a/static-build/cmake/AddDependencyProjects.cmake
+++ b/static-build/cmake/AddDependencyProjects.cmake
@@ -75,6 +75,7 @@ ExternalProject_Add(openssl
         no-shared
     INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install_sw
     PATCH_COMMAND patch -d <SOURCE_DIR> -p1 -i "${PATCHES_DIR}/openssl-111q-gh-18720.patch"
+    COMMAND       patch -d <SOURCE_DIR> -p1 -i "${PATCHES_DIR}/openssl-tarantool-security-27.patch"
     COMMAND       patch -d <SOURCE_DIR> -p1 -i "${PATCHES_DIR}/openssl-tarantool-security-54.patch"
 )
 set(TARANTOOL_DEPENDS openssl ${TARANTOOL_DEPENDS})

--- a/static-build/patches/openssl-tarantool-security-27.patch
+++ b/static-build/patches/openssl-tarantool-security-27.patch
@@ -1,0 +1,12 @@
+diff -ru a/ssl/statem/statem_clnt.c b/ssl/statem/statem_clnt.c
+--- a/ssl/statem/statem_clnt.c	2023-02-10 11:02:21.000000000 +0300
++++ b/ssl/statem/statem_clnt.c	2023-02-10 11:02:55.000000000 +0300
+@@ -1375,7 +1375,7 @@
+              * In TLSv1.3 it is valid for the server to select a different
+              * ciphersuite as long as the hash is the same.
+              */
+-            if (ssl_md(c->algorithm2)
++            if (s->session->cipher == NULL || ssl_md(c->algorithm2)
+                     != ssl_md(s->session->cipher->algorithm2)) {
+                 SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER,
+                          SSL_F_SET_CLIENT_CIPHERSUITE,


### PR DESCRIPTION
Closes tarantool/security#27