### PR TITLE
ci: run static-build workflows on 'static-build-ci' label

### DIFF
--- a/.github/workflows/osx_12_static_cmake.yml
+++ b/.github/workflows/osx_12_static_cmake.yml
@@ -34,10 +34,11 @@ concurrency:
 jobs:
   osx_12_static_cmake:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
+    # or on pull request if the 'full-ci' or 'static-build-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'full-ci') ||
+          contains(github.event.pull_request.labels.*.name, 'static-build-ci') )
 
     runs-on: [ macos-12-self-hosted, x86_64 ]
 

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -34,10 +34,11 @@ concurrency:
 jobs:
   static_build:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
+    # or on pull request if the 'full-ci' or 'static-build-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'full-ci') ||
+          contains(github.event.pull_request.labels.*.name, 'static-build-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -34,10 +34,11 @@ concurrency:
 jobs:
   static_build_cmake_linux:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
+    # or on pull request if the 'full-ci' or 'static-build-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'full-ci') ||
+          contains(github.event.pull_request.labels.*.name, 'static-build-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 


### PR DESCRIPTION
Sometimes, we only need to test static-build, e.g. when we apply a patch to a third party sub-project. Let's introduce a new label to run the ci checks faster in this case.