### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-8069-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8069-luajit-fixes.md
@@ -1,0 +1,6 @@
+## bugfix/luajit
+
+Backported patches from vanilla LuaJIT trunk (gh-8069). In the scope of this
+activity, the following issues have been resolved:
+
+* Fix `pcall()` call without arguments on arm64.


### PR DESCRIPTION
* ARM64: Fix pcall() error case.

NO_TEST=LuaJIT submodule bump
NO_DOC=LuaJIT submodule bump