### PR TITLE
box: add detailed invalid-key-part error

### DIFF
--- a/changelogs/unreleased/gh-7223-update-invalid-key-part-error.md
+++ b/changelogs/unreleased/gh-7223-update-invalid-key-part-error.md
@@ -1,0 +1,4 @@
+## feature/box
+
+* Updated "invalid key part count" error to include current space and index
+  names when possible (gh-7223).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3146,7 +3146,7 @@ box_select(uint32_t space_id, uint32_t index_id,
 					     &pos, &pos_end) != 0)
 			return -1;
 		uint32_t pos_part_count = mp_decode_array(&pos);
-		if (exact_key_validate_nullable(index->def->cmp_def, pos,
+		if (exact_key_validate_nullable(index->def, pos,
 						pos_part_count) != 0)
 			return -1;
 	} else {

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -71,7 +71,7 @@ struct errcode_record {
 	/* 16 */_(ER_TUPLE_FORMAT_LIMIT,	"Tuple format limit reached: %u") \
 	/* 17 */_(ER_DROP_PRIMARY_KEY,		"Can't drop primary key in space '%s' while secondary keys exist") \
 	/* 18 */_(ER_KEY_PART_TYPE,		"Supplied key type of part %u does not match index part type: expected %s") \
-	/* 19 */_(ER_EXACT_MATCH,		"Invalid key part count in an exact match (expected %u, got %u)") \
+	/* 19 */_(ER_EXACT_MATCH,		"Invalid key part count in an exact match %s(expected %u, got %u)") \
 	/* 20 */_(ER_INVALID_MSGPACK,		"Invalid MsgPack - %s") \
 	/* 21 */_(ER_PROC_RET,			"msgpack.encode: can not encode Lua type '%s'") \
 	/* 22 */_(ER_TUPLE_NOT_ARRAY,		"Tuple/Key must be MsgPack array") \

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -460,22 +460,27 @@ key_validate(const struct index_def *index_def, enum iterator_type type,
 
 /**
  * Check that the supplied key is valid for a search in a unique
- * index (i.e. the key must be fully specified).
+ * index, i.e. the key must be fully specified and correspond to
+ * index_def->key_def.
  * @retval 0  The key is valid.
  * @retval -1 The key is invalid.
  */
 int
-exact_key_validate(struct key_def *key_def, const char *key,
+exact_key_validate(struct index_def *index_def, const char *key,
 		   uint32_t part_count);
 
 /**
  * Check that the supplied key is valid for representing iterator
- * position (i.e. the key must be fully specified, but nulls are allowed).
+ * position, i.e. the key must be fully specified and correspond to
+ * index_def->cmp_def, where nulls are allowed.
+ * Note that since this function is designed to check a key for
+ * precise iterator position, it relies on index_def->cmp_def,
+ * in contrast to `key_validate` which relies on index_def->key_def.
  * @retval 0  The key is valid.
  * @retval -1 The key is invalid.
  */
 int
-exact_key_validate_nullable(struct key_def *key_def, const char *key,
+exact_key_validate_nullable(struct index_def *index_def, const char *key,
 			    uint32_t part_count);
 
 /**

--- a/src/box/key_def.c
+++ b/src/box/key_def.c
@@ -665,7 +665,7 @@ box_key_def_validate_full_key(const box_key_def_t *key_def, const char *key,
 	const char *pos = key;
 	uint32_t part_count = mp_decode_array(&pos);
 	if (part_count != key_def->part_count) {
-		diag_set(ClientError, ER_EXACT_MATCH, key_def->part_count,
+		diag_set(ClientError, ER_EXACT_MATCH, "", key_def->part_count,
 			 part_count);
 		return -1;
 	}

--- a/src/box/key_list.c
+++ b/src/box/key_list.c
@@ -160,8 +160,8 @@ key_list_iterator_next(struct key_list_iterator *it, struct tuple **value)
 		 */
 		diag_set(ClientError, ER_FUNC_INDEX_FORMAT, it->index_def->name,
 			 space ? space_name(space) : "",
-			 tt_sprintf(tnt_errcode_desc(ER_EXACT_MATCH),
-				   key_def->part_count, part_count));
+			 tt_sprintf(tnt_errcode_desc(ER_EXACT_MATCH), "",
+				    key_def->part_count, part_count));
 		return -1;
 	}
 	if (key_validate_parts(key_def, rptr, part_count, true,

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -419,7 +419,7 @@ memtx_space_execute_delete(struct space *space, struct txn *txn,
 		return -1;
 	const char *key = request->key;
 	uint32_t part_count = mp_decode_array(&key);
-	if (exact_key_validate(pk->def->key_def, key, part_count) != 0)
+	if (exact_key_validate(pk->def, key, part_count) != 0)
 		return -1;
 	struct tuple *old_tuple;
 	if (index_get_internal(pk, key, part_count, &old_tuple) != 0)
@@ -454,7 +454,7 @@ memtx_space_execute_update(struct space *space, struct txn *txn,
 		return -1;
 	const char *key = request->key;
 	uint32_t part_count = mp_decode_array(&key);
-	if (exact_key_validate(pk->def->key_def, key, part_count) != 0)
+	if (exact_key_validate(pk->def, key, part_count) != 0)
 		return -1;
 	struct tuple *old_tuple;
 	if (index_get_internal(pk, key, part_count, &old_tuple) != 0)

--- a/src/box/session_settings.c
+++ b/src/box/session_settings.c
@@ -343,7 +343,10 @@ session_settings_space_execute_update(struct space *space, struct txn *txn,
 	const char *new_key, *key = request->key;
 	uint32_t new_size, new_key_len, key_len = mp_decode_array(&key);
 	if (key_len == 0) {
-		diag_set(ClientError, ER_EXACT_MATCH, 1, 0);
+		diag_set(ClientError, ER_EXACT_MATCH,
+			 tt_sprintf("in space \"%s\", index \"%s\" ",
+				    space_name(space), pk_def->name),
+			 1, 0);
 		return -1;
 	}
 	if (key_len > 1 || mp_typeof(*key) != MP_STR) {

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -540,7 +540,7 @@ space_before_replace(struct space *space, struct txn *txn,
 		return 0;
 	}
 
-	if (exact_key_validate(index->def->key_def, key, part_count) != 0 ||
+	if (exact_key_validate(index->def, key, part_count) != 0 ||
 	    index_get(index, key, part_count, &old_tuple) != 0) {
 		region_truncate(&fiber()->gc, region_svp);
 		return -1;

--- a/src/box/sysview.c
+++ b/src/box/sysview.c
@@ -166,7 +166,7 @@ sysview_index_get(struct index *base, const char *key,
 		diag_set(ClientError, ER_MORE_THAN_ONE_TUPLE);
 		return -1;
 	}
-	if (exact_key_validate(pk->def->key_def, key, part_count) != 0)
+	if (exact_key_validate(pk->def, key, part_count) != 0)
 		return -1;
 	struct tuple *tuple;
 	if (index_get(pk, key, part_count, &tuple) != 0)

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -1712,7 +1712,10 @@ vy_unique_key_validate(struct vy_lsm *lsm, const char *key,
 	 */
 	uint32_t original_part_count = lsm->key_def->part_count;
 	if (original_part_count != part_count) {
+		struct space *space = space_by_id(lsm->space_id);
 		diag_set(ClientError, ER_EXACT_MATCH,
+			 tt_sprintf("in space \"%s\", index \"%s\" ",
+				    space_name(space), lsm->base.def->name),
 			 original_part_count, part_count);
 		return -1;
 	}

--- a/test/box-luatest/box_read_ffi_disable_test.lua
+++ b/test/box-luatest/box_read_ffi_disable_test.lua
@@ -72,7 +72,8 @@ g.test_get = function(cg)
             "Use index:get(...) instead of index.get(...)",
             s.index.primary.get)
         t.assert_error_msg_content_equals(
-            "Invalid key part count in an exact match (expected 1, got 0)",
+            "Invalid key part count in an exact match in space \"test\"," ..
+            " index \"primary\" (expected 1, got 0)",
             s.index.primary.get, s.index.primary)
         t.assert_error_msg_content_equals(
             "Get() doesn't support partial keys and non-unique indexes",

--- a/test/box-luatest/pagination_netbox_test.lua
+++ b/test/box-luatest/pagination_netbox_test.lua
@@ -340,10 +340,12 @@ net_g.test_net_box_invalid_position = function(cg)
     s:replace{1, 0}
     s:replace{2, 0}
     local _, pos = sk:select(nil, {limit=1, fetch_pos=true})
-    local msg = "Invalid key part count in an exact match (expected 1, got 2)"
+    local msg = "Invalid key part count in an exact match in space \"s\"," ..
+                " index \"pk\" (expected 1, got 2)"
     t.assert_error_msg_equals(msg, s.select, s, nil, {after=pos})
     _, pos = s:select(nil, {limit=1, fetch_pos=true})
-    msg = "Invalid key part count in an exact match (expected 2, got 1)"
+    msg = "Invalid key part count in an exact match in space \"s\"," ..
+          " index \"sk\" (expected 2, got 1)"
     t.assert_error_msg_equals(msg, sk.select, sk, nil, {after=pos})
     msg = "Tuple field 2 type does not match one required by operation:" ..
         " expected unsigned, got string"

--- a/test/box/access_bin.result
+++ b/test/box/access_bin.result
@@ -187,7 +187,8 @@ test:drop()
 --
 box.space._priv:get{1}
 ---
-- error: Invalid key part count in an exact match (expected 3, got 1)
+- error: Invalid key part count in an exact match in space "_priv", index "primary"
+    (expected 3, got 1)
 ...
 u = box.space._user:get{1}
 ---

--- a/test/box/hash_32bit_delete.result
+++ b/test/box/hash_32bit_delete.result
@@ -62,7 +62,8 @@ hash:delete{'invalid key'}
  | ...
 hash:delete{1, 2}
  | ---
- | - error: Invalid key part count in an exact match (expected 1, got 2)
+ | - error: Invalid key part count in an exact match in space "tweedledum", index "primary"
+ |     (expected 1, got 2)
  | ...
 
 hash:drop()

--- a/test/box/hash_32bit_select.result
+++ b/test/box/hash_32bit_select.result
@@ -62,7 +62,8 @@ hash.index['primary']:get{'invalid key'}
  | ...
 hash.index['primary']:get{1, 2}
  | ---
- | - error: Invalid key part count in an exact match (expected 1, got 2)
+ | - error: Invalid key part count in an exact match in space "tweedledum", index "primary"
+ |     (expected 1, got 2)
  | ...
 
 hash:drop()

--- a/test/box/hash_64bit_delete.result
+++ b/test/box/hash_64bit_delete.result
@@ -103,7 +103,8 @@ hash:delete{'invalid key'}
  | ...
 hash:delete{'00000001', '00000002'}
  | ---
- | - error: Invalid key part count in an exact match (expected 1, got 2)
+ | - error: Invalid key part count in an exact match in space "tweedledum", index "primary"
+ |     (expected 1, got 2)
  | ...
 
 hash:drop()

--- a/test/box/hash_64bit_select.result
+++ b/test/box/hash_64bit_select.result
@@ -86,7 +86,8 @@ hash.index['primary']:get{'invalid key'}
  | ...
 hash.index['primary']:get{'00000001', '00000002'}
  | ---
- | - error: Invalid key part count in an exact match (expected 1, got 2)
+ | - error: Invalid key part count in an exact match in space "tweedledum", index "primary"
+ |     (expected 1, got 2)
  | ...
 
 hash:drop()

--- a/test/box/hash_multipart.result
+++ b/test/box/hash_multipart.result
@@ -100,12 +100,14 @@ hash.index['primary']:get{1, 'bar', 0}
 -- primary index select with missing part
 hash.index['primary']:get{1, 'foo'}
 ---
-- error: Invalid key part count in an exact match (expected 3, got 2)
+- error: Invalid key part count in an exact match in space "tweedledum", index "primary"
+    (expected 3, got 2)
 ...
 -- primary index select with extra part
 hash.index['primary']:get{1, 'foo', 0, 0}
 ---
-- error: Invalid key part count in an exact match (expected 3, got 4)
+- error: Invalid key part count in an exact match in space "tweedledum", index "primary"
+    (expected 3, got 4)
 ...
 -- primary index select with wrong type
 hash.index['primary']:get{1, 'foo', 'baz'}
@@ -124,7 +126,8 @@ hash.index['unique']:get{1, 5}
 -- secondary index select with missing part
 hash.index['unique']:get{1}
 ---
-- error: Invalid key part count in an exact match (expected 2, got 1)
+- error: Invalid key part count in an exact match in space "tweedledum", index "unique"
+    (expected 2, got 1)
 ...
 -- secondary index select with wrong type
 hash.index['unique']:select{1, 'baz'}

--- a/test/box/hash_string_delete.result
+++ b/test/box/hash_string_delete.result
@@ -55,7 +55,8 @@ hash:delete{'key 5'}
 -- delete by invalid keys
 hash:delete{'key 1', 'key 2'}
  | ---
- | - error: Invalid key part count in an exact match (expected 1, got 2)
+ | - error: Invalid key part count in an exact match in space "tweedledum", index "primary"
+ |     (expected 1, got 2)
  | ...
 hash:drop()
  | ---

--- a/test/box/hash_string_select.result
+++ b/test/box/hash_string_select.result
@@ -55,7 +55,8 @@ hash.index['primary']:get{'key 5'}
 -- select by invalid keys
 hash.index['primary']:get{'key 1', 'key 2'}
  | ---
- | - error: Invalid key part count in an exact match (expected 1, got 2)
+ | - error: Invalid key part count in an exact match in space "tweedledum", index "primary"
+ |     (expected 1, got 2)
  | ...
 
 hash:drop()

--- a/test/box/lua.result
+++ b/test/box/lua.result
@@ -42,7 +42,8 @@ space.index['minmax']:get{'new', 'world'}
 --  https://bugs.launchpad.net/tarantool/+bug/904208
 space.index['minmax']:get{'new', 'world', 'order'}
 ---
-- error: Invalid key part count in an exact match (expected 2, got 3)
+- error: Invalid key part count in an exact match in space "tweedledum", index "minmax"
+    (expected 2, got 3)
 ...
 space:delete{'brave'}
 ---
@@ -57,7 +58,8 @@ space:insert{'item 1', 'alabama', 'song'}
 ...
 space.index['minmax']:get{'alabama'}
 ---
-- error: Invalid key part count in an exact match (expected 2, got 1)
+- error: Invalid key part count in an exact match in space "tweedledum", index "minmax"
+    (expected 2, got 1)
 ...
 space:insert{'item 2', 'california', 'dreaming '}
 ---

--- a/test/box/select.result
+++ b/test/box/select.result
@@ -55,15 +55,18 @@ s.index[0].get == s.index[0].get_ffi or s.index[0].get == s.index[0].get_luac
 ...
 test.get(s.index[0])
 ---
-- error: Invalid key part count in an exact match (expected 1, got 0)
+- error: Invalid key part count in an exact match in space "select", index "primary"
+    (expected 1, got 0)
 ...
 test.get(s.index[0], {})
 ---
-- error: Invalid key part count in an exact match (expected 1, got 0)
+- error: Invalid key part count in an exact match in space "select", index "primary"
+    (expected 1, got 0)
 ...
 test.get(s.index[0], nil)
 ---
-- error: Invalid key part count in an exact match (expected 1, got 0)
+- error: Invalid key part count in an exact match in space "select", index "primary"
+    (expected 1, got 0)
 ...
 test.get(s.index[0], 1)
 ---
@@ -75,7 +78,8 @@ test.get(s.index[0], {1})
 ...
 test.get(s.index[0], {1, 2})
 ---
-- error: Invalid key part count in an exact match (expected 1, got 2)
+- error: Invalid key part count in an exact match in space "select", index "primary"
+    (expected 1, got 2)
 ...
 test.get(s.index[0], 0)
 ---
@@ -95,11 +99,13 @@ test.get(s.index[0], {"0"})
 ...
 test.get(s.index[1], 1)
 ---
-- error: Invalid key part count in an exact match (expected 2, got 1)
+- error: Invalid key part count in an exact match in space "select", index "second"
+    (expected 2, got 1)
 ...
 test.get(s.index[1], {1})
 ---
-- error: Invalid key part count in an exact match (expected 2, got 1)
+- error: Invalid key part count in an exact match in space "select", index "second"
+    (expected 2, got 1)
 ...
 test.get(s.index[1], {1, 2})
 ---

--- a/test/box/tree_pk_multipart.result
+++ b/test/box/tree_pk_multipart.result
@@ -304,12 +304,14 @@ space:delete{'Vincent', 'The Wolf!', 3}
 -- try to delete patrial defined key
 space:delete{'Vincent', 'The Wolf!'}
 ---
-- error: Invalid key part count in an exact match (expected 3, got 2)
+- error: Invalid key part count in an exact match in space "tweedledum", index "primary"
+    (expected 3, got 2)
 ...
 -- try to delete by invalid key
 space:delete{'The Wolf!', 'Vincent', 1, 'Come again?'}
 ---
-- error: Invalid key part count in an exact match (expected 3, got 4)
+- error: Invalid key part count in an exact match in space "tweedledum", index "primary"
+    (expected 3, got 4)
 ...
 --
 -- Update test
@@ -346,12 +348,14 @@ space:update({'Vincent', 'The Wolf!', 4}, {{'=', 4, '<ooops>'}})
 -- try to update patrial defined key
 space:update({'Vincent', 'The Wolf!'}, {{'=', 4, '<ooops>'}})
 ---
-- error: Invalid key part count in an exact match (expected 3, got 2)
+- error: Invalid key part count in an exact match in space "tweedledum", index "primary"
+    (expected 3, got 2)
 ...
 -- try to update by invalid key
 space:update({'The Wolf!', 'Vincent', 1, 'Come again?'}, {{'=', 4, '<ooops>'}})
 ---
-- error: Invalid key part count in an exact match (expected 3, got 4)
+- error: Invalid key part count in an exact match in space "tweedledum", index "primary"
+    (expected 3, got 4)
 ...
 space:len()
 ---

--- a/test/engine/delete.result
+++ b/test/engine/delete.result
@@ -593,7 +593,8 @@ tmp = index1:delete({1})
 ...
 tmp = index2:delete({'weif'}) -- must fail
 ---
-- error: Invalid key part count in an exact match (expected 2, got 1)
+- error: Invalid key part count in an exact match in space "test", index "secondary"
+    (expected 2, got 1)
 ...
 tmp = index2:delete({'weif', 345})
 ---

--- a/test/engine/tree.result
+++ b/test/engine/tree.result
@@ -295,7 +295,8 @@ pk:select({10}, { iterator = 'GT' })
 ...
 pk:get({})
 ---
-- error: Invalid key part count in an exact match (expected 1, got 0)
+- error: Invalid key part count in an exact match in space "uint", index "primary"
+    (expected 1, got 0)
 ...
 pk:get({0})
 ---
@@ -309,7 +310,8 @@ pk:get({10})
 ...
 pk:get({10, 15})
 ---
-- error: Invalid key part count in an exact match (expected 1, got 2)
+- error: Invalid key part count in an exact match in space "uint", index "primary"
+    (expected 1, got 2)
 ...
 space:drop()
 ---
@@ -525,7 +527,8 @@ pk:select({10}, { iterator = 'GT' })
 ...
 pk:get({})
 ---
-- error: Invalid key part count in an exact match (expected 1, got 0)
+- error: Invalid key part count in an exact match in space "sparse_uint", index "primary"
+    (expected 1, got 0)
 ...
 pk:get({0})
 ---
@@ -539,7 +542,8 @@ pk:get({10})
 ...
 pk:get({10, 15})
 ---
-- error: Invalid key part count in an exact match (expected 1, got 2)
+- error: Invalid key part count in an exact match in space "sparse_uint", index "primary"
+    (expected 1, got 2)
 ...
 space:drop()
 ---
@@ -750,7 +754,8 @@ pk:select({'10'}, { iterator = 'GT' })
 ...
 pk:get({})
 ---
-- error: Invalid key part count in an exact match (expected 1, got 0)
+- error: Invalid key part count in an exact match in space "string", index "primary"
+    (expected 1, got 0)
 ...
 pk:get({'0'})
 ---
@@ -763,7 +768,8 @@ pk:get({'10'})
 ...
 pk:get({'10', '15'})
 ---
-- error: Invalid key part count in an exact match (expected 1, got 2)
+- error: Invalid key part count in an exact match in space "string", index "primary"
+    (expected 1, got 2)
 ...
 space:drop()
 ---
@@ -1077,11 +1083,13 @@ pk:select({10}, { iterator = 'GT' })
 ...
 pk:get({})
 ---
-- error: Invalid key part count in an exact match (expected 2, got 0)
+- error: Invalid key part count in an exact match in space "uint_str", index "primary"
+    (expected 2, got 0)
 ...
 pk:get({'5'})
 ---
-- error: Invalid key part count in an exact match (expected 2, got 1)
+- error: Invalid key part count in an exact match in space "uint_str", index "primary"
+    (expected 2, got 1)
 ...
 --
 -- two parts
@@ -1391,7 +1399,8 @@ pk:get({4, '03'})
 ...
 pk:get({4, '03', 100})
 ---
-- error: Invalid key part count in an exact match (expected 2, got 3)
+- error: Invalid key part count in an exact match in space "uint_str", index "primary"
+    (expected 2, got 3)
 ...
 space:drop()
 ---
@@ -1705,19 +1714,23 @@ pk:select({'10'}, { iterator = 'GT' })
 ...
 pk:get({})
 ---
-- error: Invalid key part count in an exact match (expected 2, got 0)
+- error: Invalid key part count in an exact match in space "str_uint", index "primary"
+    (expected 2, got 0)
 ...
 pk:get({'00'})
 ---
-- error: Invalid key part count in an exact match (expected 2, got 1)
+- error: Invalid key part count in an exact match in space "str_uint", index "primary"
+    (expected 2, got 1)
 ...
 pk:get({'05'})
 ---
-- error: Invalid key part count in an exact match (expected 2, got 1)
+- error: Invalid key part count in an exact match in space "str_uint", index "primary"
+    (expected 2, got 1)
 ...
 pk:get({'10'})
 ---
-- error: Invalid key part count in an exact match (expected 2, got 1)
+- error: Invalid key part count in an exact match in space "str_uint", index "primary"
+    (expected 2, got 1)
 ...
 --
 -- two parts
@@ -2027,7 +2040,8 @@ pk:get({'04', 3})
 ...
 pk:get({'04', 3, 100})
 ---
-- error: Invalid key part count in an exact match (expected 2, got 3)
+- error: Invalid key part count in an exact match in space "str_uint", index "primary"
+    (expected 2, got 3)
 ...
 space:drop()
 ---
@@ -2359,19 +2373,23 @@ pk:select({'10'}, { iterator = 'GT' })
 ...
 pk:get({})
 ---
-- error: Invalid key part count in an exact match (expected 2, got 0)
+- error: Invalid key part count in an exact match in space "sparse_str_uint", index
+    "primary" (expected 2, got 0)
 ...
 pk:get({'00'})
 ---
-- error: Invalid key part count in an exact match (expected 2, got 1)
+- error: Invalid key part count in an exact match in space "sparse_str_uint", index
+    "primary" (expected 2, got 1)
 ...
 pk:get({'05'})
 ---
-- error: Invalid key part count in an exact match (expected 2, got 1)
+- error: Invalid key part count in an exact match in space "sparse_str_uint", index
+    "primary" (expected 2, got 1)
 ...
 pk:get({'10'})
 ---
-- error: Invalid key part count in an exact match (expected 2, got 1)
+- error: Invalid key part count in an exact match in space "sparse_str_uint", index
+    "primary" (expected 2, got 1)
 ...
 --
 -- two parts
@@ -2688,7 +2706,8 @@ pk:get({'04', 3})
 ...
 pk:get({'04', 3, 100})
 ---
-- error: Invalid key part count in an exact match (expected 2, got 3)
+- error: Invalid key part count in an exact match in space "sparse_str_uint", index
+    "primary" (expected 2, got 3)
 ...
 space:drop()
 ---

--- a/test/engine/update.result
+++ b/test/engine/update.result
@@ -570,7 +570,8 @@ space:insert({6, 'nrhjrt', -1231.234})
 ...
 index1:update({1}, {{'+', 3, 10}})
 ---
-- error: Invalid key part count in an exact match (expected 2, got 1)
+- error: Invalid key part count in an exact match in space "test", index "primary"
+    (expected 2, got 1)
 ...
 index1:update({1, 'fwoen'}, {{'+', 3, 10}})
 ---

--- a/test/vinyl/constraint.result
+++ b/test/vinyl/constraint.result
@@ -97,11 +97,13 @@ space:replace{1}
 ...
 space:delete{1}
 ---
-- error: Invalid key part count in an exact match (expected 2, got 1)
+- error: Invalid key part count in an exact match in space "test", index "primary"
+    (expected 2, got 1)
 ...
 space:update(1, {{'=', 1, 101}})
 ---
-- error: Invalid key part count in an exact match (expected 2, got 1)
+- error: Invalid key part count in an exact match in space "test", index "primary"
+    (expected 2, got 1)
 ...
 space:upsert({1}, {{'+', 1, 10}})
 ---
@@ -109,7 +111,8 @@ space:upsert({1}, {{'+', 1, 10}})
 ...
 space:get{1}
 ---
-- error: Invalid key part count in an exact match (expected 2, got 1)
+- error: Invalid key part count in an exact match in space "test", index "primary"
+    (expected 2, got 1)
 ...
 index:select({1}, {iterator = box.index.GT})
 ---


### PR DESCRIPTION
Add ER_EXACT_MATCH_DETAILED ("Invalid key part count in an exact match") error code, as old version wasn't informative enough in some cases. Now it displays space and index names too.

Refactor exac_key_validate() and exac_key_validate_nullable() to receive wider context to provide names for the error msg. Now they are specialised to primary key and user-defined key accordingly.

NO_DOC=error is not described in doc