### PR TITLE
recovery: check return value of `fiber_new_system` for watcher fiber

### DIFF
--- a/src/box/recovery.cc
+++ b/src/box/recovery.cc
@@ -528,6 +528,8 @@ recovery_follow_local(struct recovery *r, struct xstream *stream,
 	 */
 	assert(r->watcher == NULL);
 	r->watcher = fiber_new_system(name, hot_standby_f);
+	if (r->watcher == NULL)
+		diag_raise();
 	fiber_set_joinable(r->watcher, true);
 	fiber_start(r->watcher, r, stream, wal_dir_rescan_delay);
 }


### PR DESCRIPTION
Closes tarantool/security#87