### PR TITLE
box: replace malloc with xmalloc in key_def_dup

### DIFF
--- a/src/box/index_def.c
+++ b/src/box/index_def.c
@@ -100,12 +100,12 @@ index_def_new(uint32_t space_id, uint32_t iid, const char *name,
 		if (opts->is_unique)
 			def->cmp_def->unique_part_count =
 				def->key_def->part_count;
+		if (def->cmp_def == NULL) {
+			index_def_delete(def);
+			return NULL;
+		}
 	} else {
 		def->cmp_def = key_def_dup(key_def);
-	}
-	if (def->key_def == NULL || def->cmp_def == NULL) {
-		index_def_delete(def);
-		return NULL;
 	}
 	def->type = type;
 	def->space_id = space_id;
@@ -135,10 +135,6 @@ index_def_dup(const struct index_def *def)
 	}
 	dup->key_def = key_def_dup(def->key_def);
 	dup->cmp_def = key_def_dup(def->cmp_def);
-	if (dup->key_def == NULL || dup->cmp_def == NULL) {
-		index_def_delete(dup);
-		return NULL;
-	}
 	rlist_create(&dup->link);
 	dup->opts = def->opts;
 	if (def->opts.stat != NULL) {

--- a/src/box/key_def.c
+++ b/src/box/key_def.c
@@ -136,11 +136,7 @@ struct key_def *
 key_def_dup(const struct key_def *src)
 {
 	size_t sz = key_def_copy_size(src);
-	struct key_def *res = malloc(sz);
-	if (res == NULL) {
-		diag_set(OutOfMemory, sz, "malloc", "res");
-		return NULL;
-	}
+	struct key_def *res = xmalloc(sz);
 	key_def_copy_impl(res, src, sz);
 	return res;
 }

--- a/src/box/key_def.h
+++ b/src/box/key_def.h
@@ -277,7 +277,6 @@ struct key_def {
  * @param src Original key_def.
  *
  * @retval not NULL Duplicate of src.
- * @retval     NULL Memory error.
  */
 struct key_def *
 key_def_dup(const struct key_def *src);
@@ -469,7 +468,6 @@ box_key_def_new_v2(box_key_part_def_t *parts, uint32_t part_count);
  * @param key_def Original key_def.
  *
  * @retval not NULL Duplicate of src.
- * @retval     NULL Memory error.
  */
 API_EXPORT box_key_def_t *
 box_key_def_dup(const box_key_def_t *key_def);

--- a/src/box/merger.c
+++ b/src/box/merger.c
@@ -250,10 +250,6 @@ merger_new(struct key_def *key_def, struct merge_source **sources,
 	 * key_def comes from Lua).
 	 */
 	key_def = key_def_dup(key_def);
-	if (key_def == NULL) {
-		free(merger);
-		return NULL;
-	}
 
 	struct tuple_format *format = box_tuple_format_new(&key_def, 1);
 	if (format == NULL) {

--- a/src/box/vy_lsm.c
+++ b/src/box/vy_lsm.c
@@ -141,12 +141,7 @@ vy_lsm_new(struct vy_lsm_env *lsm_env, struct vy_cache_env *cache_env,
 	lsm->env = lsm_env;
 
 	struct key_def *key_def = key_def_dup(index_def->key_def);
-	if (key_def == NULL)
-		goto fail_key_def;
-
 	struct key_def *cmp_def = key_def_dup(index_def->cmp_def);
-	if (cmp_def == NULL)
-		goto fail_cmp_def;
 
 	lsm->cmp_def = cmp_def;
 	lsm->key_def = key_def;
@@ -223,9 +218,7 @@ fail_stat:
 		key_def_delete(lsm->pk_in_cmp_def);
 fail_pk_in_cmp_def:
 	key_def_delete(cmp_def);
-fail_cmp_def:
 	key_def_delete(key_def);
-fail_key_def:
 	free(lsm);
 fail:
 	return NULL;

--- a/src/box/vy_scheduler.c
+++ b/src/box/vy_scheduler.c
@@ -249,16 +249,7 @@ vy_task_new(struct vy_scheduler *scheduler, struct vy_worker *worker,
 	task->start_time = ev_monotonic_now(loop());
 	task->lsm = lsm;
 	task->cmp_def = key_def_dup(lsm->cmp_def);
-	if (task->cmp_def == NULL) {
-		free(task);
-		return NULL;
-	}
 	task->key_def = key_def_dup(lsm->key_def);
-	if (task->key_def == NULL) {
-		key_def_delete(task->cmp_def);
-		free(task);
-		return NULL;
-	}
 	vy_lsm_ref(lsm);
 	diag_create(&task->diag);
 	task->deferred_delete_handler.iface = &vy_task_deferred_delete_iface;


### PR DESCRIPTION
This patch replaces malloc() with xmalloc() in key_def_dup() to avoid the possibility of skipping the malloc() return value check.

Closes tarantool/security#81

NO_DOC=refactoring
NO_TEST=refactoring
NO_CHANGELOG=refactoring