### PR TITLE
sql: properly check result of sql_get_coll_seq()

### DIFF
--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -292,7 +292,7 @@ sql_expr_coll(Parse *parse, Expr *p, bool *is_explicit_coll, uint32_t *coll_id,
 		if (op == TK_COLLATE ||
 		    (op == TK_REGISTER && p->op2 == TK_COLLATE)) {
 			*coll = sql_get_coll_seq(parse, p->u.zToken, coll_id);
-			if (coll == NULL)
+			if (*coll == NULL)
 				return -1;
 			*is_explicit_coll = true;
 			break;

--- a/test/sql-luatest/collation_test.lua
+++ b/test/sql-luatest/collation_test.lua
@@ -1,0 +1,21 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_ghs_80 = function()
+    g.server:exec(function()
+        local sql = [[select 'a' collate a union select 'b' collate "binary";]]
+        local _, err = box.execute(sql)
+        t.assert_equals(err.message, "Collation 'A' does not exist")
+    end)
+end

--- a/test/sql/collation.result
+++ b/test/sql/collation.result
@@ -312,7 +312,8 @@ box.execute("SELECT 'abc' COLLATE \"binary\" UNION SELECT 'ABC' COLLATE \"unicod
 - null
 - Illegal mix of collations
 ...
-box.execute("SELECT 'abc' COLLATE \"unicode_ci\" UNION SELECT 'ABC' COLLATE binary")
+box.execute([[SELECT 'abc' COLLATE "unicode_ci" UNION ]]..\
+            [[SELECT 'ABC' COLLATE "binary"]])
 ---
 - null
 - Illegal mix of collations

--- a/test/sql/collation.test.lua
+++ b/test/sql/collation.test.lua
@@ -91,7 +91,8 @@ box.execute("SELECT * FROM t WHERE a COLLATE \"binary\" = substr();")
 -- Hence, rules for collations compatibilities are the same.
 --
 box.execute("SELECT 'abc' COLLATE \"binary\" UNION SELECT 'ABC' COLLATE \"unicode_ci\"")
-box.execute("SELECT 'abc' COLLATE \"unicode_ci\" UNION SELECT 'ABC' COLLATE binary")
+box.execute([[SELECT 'abc' COLLATE "unicode_ci" UNION ]]..\
+            [[SELECT 'ABC' COLLATE "binary"]])
 box.execute("SELECT c FROM t UNION SELECT b FROM t;")
 box.execute("SELECT b FROM t UNION SELECT a FROM t;")
 box.execute("SELECT a FROM t UNION SELECT c FROM t;")


### PR DESCRIPTION
This patch fixes an issue with checking the result of sql_get_coll_seq() in sql_expr_coll(). This fix only changes the error if the collation combination is invalid because sql_get_coll_seq() sets the is_aborted flag and error will be thrown in any case.

Closes tarantool/security#80

NO_DOC=change of returned error in rare case
NO_CHANGELOG=change of returned error in rare case