### PR TITLE
box: don't check return values of some cfg_gets() for NULL

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -935,9 +935,6 @@ static enum election_mode
 box_check_election_mode(void)
 {
 	const char *mode = cfg_gets("election_mode");
-	if (mode == NULL)
-		goto error;
-
 	if (strcmp(mode, "off") == 0)
 		return ELECTION_MODE_OFF;
 	else if (strcmp(mode, "voter") == 0)
@@ -947,7 +944,6 @@ box_check_election_mode(void)
 	else if (strcmp(mode, "candidate") == 0)
 		return ELECTION_MODE_CANDIDATE;
 
-error:
 	diag_set(ClientError, ER_CFG, "election_mode",
 		"the value must be one of the following strings: "
 		"'off', 'voter', 'candidate', 'manual'");
@@ -973,9 +969,6 @@ static election_fencing_mode
 box_check_election_fencing_mode(void)
 {
 	const char *mode = cfg_gets("election_fencing_mode");
-	if (mode == NULL)
-		goto error;
-
 	if (strcmp(mode, "off") == 0)
 		return ELECTION_FENCING_MODE_OFF;
 	else if (strcmp(mode, "soft") == 0)
@@ -983,7 +976,6 @@ box_check_election_fencing_mode(void)
 	else if (strcmp(mode, "strict") == 0)
 		return ELECTION_FENCING_MODE_STRICT;
 
-error:
 	diag_set(ClientError, ER_CFG, "election_fencing_mode",
 		 "the value must be one of the following strings: "
 		 "'off', 'soft', 'strict'");


### PR DESCRIPTION
Sometimes the return value of `cfg_gets()` is checked for NULL, and sometimes not. Actually this is intended, although a bit confusing. If an option can have a nil value, it must be checked for NULL, but if it can't be nil, there is no sense in it. The nil value can be assigned only by default, it cannot be set via `box.cfg{}`.

This patch removes the NULL checks for `cfg_gets("election_mode")` and `cfg_gets("election_fencing_mode")` because they are not nil by default. All other non-nil options (e.g. `cfg_gets("bootstrap_strategy")`) are already implemented without the NULL checks.

Follow-up tarantool/security#75