### PR TITLE
NULL dereferences in `enumEitherTrie` and `unum_clone`

### DIFF
--- a/static-build/cmake/AddDependencyProjects.cmake
+++ b/static-build/cmake/AddDependencyProjects.cmake
@@ -116,6 +116,7 @@ ExternalProject_Add(icu
         ${CMAKE_COMMAND} -E copy_if_different <BINARY_DIR>/uconfig.h <INSTALL_DIR>/include/unicode/uconfig.h
     PATCH_COMMAND patch -d <SOURCE_DIR> -p1 -i "${PATCHES_DIR}/icu-tarantool-security-45.patch"
     COMMAND       patch -d <SOURCE_DIR> -p1 -i "${PATCHES_DIR}/icu-tarantool-security-59.patch"
+    COMMAND       patch -d <SOURCE_DIR> -p1 -i "${PATCHES_DIR}/icu-tarantool-security-61.patch"
 )
 set(TARANTOOL_DEPENDS icu ${TARANTOOL_DEPENDS})
 

--- a/static-build/cmake/AddDependencyProjects.cmake
+++ b/static-build/cmake/AddDependencyProjects.cmake
@@ -115,6 +115,7 @@ ExternalProject_Add(icu
         cat <BINARY_DIR>/uconfig.h.prepend <INSTALL_DIR>/include/unicode/uconfig.h >> <BINARY_DIR>/uconfig.h &&
         ${CMAKE_COMMAND} -E copy_if_different <BINARY_DIR>/uconfig.h <INSTALL_DIR>/include/unicode/uconfig.h
     PATCH_COMMAND patch -d <SOURCE_DIR> -p1 -i "${PATCHES_DIR}/icu-tarantool-security-45.patch"
+    COMMAND       patch -d <SOURCE_DIR> -p1 -i "${PATCHES_DIR}/icu-tarantool-security-59.patch"
 )
 set(TARANTOOL_DEPENDS icu ${TARANTOOL_DEPENDS})
 

--- a/static-build/patches/icu-tarantool-security-59.patch
+++ b/static-build/patches/icu-tarantool-security-59.patch
@@ -1,0 +1,21 @@
+diff --git a/source/common/utrie2.cpp b/source/common/utrie2.cpp
+index 24ef578..359952a 100644
+--- a/source/common/utrie2.cpp
++++ b/source/common/utrie2.cpp
+@@ -574,7 +574,15 @@ enumEitherTrie(const UTrie2 *trie,
+                     c+=UTRIE2_DATA_BLOCK_LENGTH;
+                 } else {
+                     for(j=0; j<UTRIE2_DATA_BLOCK_LENGTH; ++j) {
+-                        value=enumValue(context, data32!=NULL ? data32[block+j] : idx[block+j]);
++                        if (data32!=NULL) {
++                            value=enumValue(context, data32[block+j]);
++                        } else if (idx!=NULL) {
++                            value=enumValue(context, idx[block+j]);
++                        } else {
++                            /* data32 and idx are not supposed to be NULL at the same time */
++                            U_ASSERT(false);
++                            return;
++                        }
+                         if(value!=prevValue) {
+                             if(prev<c && !enumRange(context, prev, c-1, prevValue)) {
+                                 return;

--- a/static-build/patches/icu-tarantool-security-61.patch
+++ b/static-build/patches/icu-tarantool-security-61.patch
@@ -1,0 +1,15 @@
+diff --git a/source/i18n/unum.cpp b/source/i18n/unum.cpp
+index 7043f7a..0f70c5c 100644
+--- a/source/i18n/unum.cpp
++++ b/source/i18n/unum.cpp
+@@ -164,7 +164,9 @@ unum_clone(const UNumberFormat *fmt,
+     } else {
+         const RuleBasedNumberFormat* rbnf = dynamic_cast<const RuleBasedNumberFormat*>(nf);
+         U_ASSERT(rbnf != NULL);
+-        res = rbnf->clone();
++        if (rbnf != NULL) {
++            res = rbnf->clone();
++        }
+     }
+ 
+     if(res == 0) {


### PR DESCRIPTION
Closes tarantool/security#59
Closes tarantool/security#61