### PR TITLE
2 minor fixes

### DIFF
--- a/src/box/xlog.c
+++ b/src/box/xlog.c
@@ -1151,7 +1151,11 @@ xlog_tx_write_zstd(struct xlog *log)
 {
 	char *fixheader = (char *)obuf_alloc(&log->zbuf,
 					     XLOG_FIXHEADER_SIZE);
-
+	if (fixheader == NULL) {
+		diag_set(OutOfMemory, XLOG_FIXHEADER_SIZE, "runtime arena",
+			 "compression buffer");
+		goto error;
+	}
 	uint32_t crc32c = 0;
 	struct iovec *iov;
 	/* 3 is compression level. */

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -2022,7 +2022,7 @@ check_stack_direction(void *prev_stack_frame)
 void
 fiber_init(int (*invoke)(fiber_func f, va_list ap))
 {
-	page_size = sysconf(_SC_PAGESIZE);
+	page_size = small_getpagesize();
 	stack_direction = check_stack_direction(__builtin_frame_address(0));
 	fiber_invoke = invoke;
 	main_thread_id = pthread_self();


### PR DESCRIPTION
**box: check return value of `obuf_alloc()` in `xlog_tx_write_zstd()`**

`obuf_alloc(&log->zbuf, XLOG_FIXHEADER_SIZE)` can potentially fail, because there is no `obuf_reserve()` prior to it.

Closes https://github.com/tarantool/security/issues/74

---

**core: replace `sysconf(_SC_PAGESIZE)` with `small_getpagesize()`**

Bump the small submodule and use `small_getpagesize()`, which is a wrapper over `sysconf(_SC_PAGESIZE)` with a proper error checking.

Closes https://github.com/tarantool/security/issues/78