### PR TITLE
feat: fully-temporary spaces with temporary metadata

### DIFF
--- a/changelogs/unreleased/fully-temporary-spaces.md
+++ b/changelogs/unreleased/fully-temporary-spaces.md
@@ -1,0 +1,6 @@
+## feature/space
+
+* Introduces the fully temporary space type. It is the same as data-temporary
+  but also has temporary metadata. Temporary spaces can now be created in
+  read_only mode, they disappear after server restart and don't exist on
+  replicas (gh-8323).

--- a/changelogs/unreleased/space-type.md
+++ b/changelogs/unreleased/space-type.md
@@ -1,0 +1,3 @@
+## feature/space
+
+* Introduces space type: a new space definition field.

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -2155,10 +2155,13 @@ on_replace_dd_space(struct trigger * /* trigger */, void *event)
 			    BOX_SPACE_FIELD_ID, &old_id) != 0)
 		return -1;
 	struct space *old_space = space_by_id(old_id);
+	struct space_def *def = NULL;
+	if (new_tuple != NULL) {
+		uint32_t errcode = (old_tuple == NULL) ?
+			ER_CREATE_SPACE : ER_ALTER_SPACE;
+		def = space_def_new_from_tuple(new_tuple, errcode, region);
+	}
 	if (new_tuple != NULL && old_space == NULL) { /* INSERT */
-		struct space_def *def =
-			space_def_new_from_tuple(new_tuple, ER_CREATE_SPACE,
-						 region);
 		if (def == NULL)
 			return -1;
 		auto def_guard =
@@ -2326,9 +2329,6 @@ on_replace_dd_space(struct trigger * /* trigger */, void *event)
 				 "view can not be altered");
 			return -1;
 		}
-		struct space_def *def =
-			space_def_new_from_tuple(new_tuple, ER_ALTER_SPACE,
-						 region);
 		if (def == NULL)
 			return -1;
 		auto def_guard =

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3571,23 +3571,24 @@ box_process1(struct request *request, box_tuple_t **result)
 	if (space == NULL)
 		return -1;
 	/*
-	 * Allow to write to temporary and local spaces in the read-only mode.
-	 * To handle space truncation, we postpone the read-only check for the
-	 * _truncate system space till the on_replace trigger is called, when
-	 * we know which space is truncated.
+	 * Allow to write to data-temporary and local spaces in the read-only
+	 * mode. To handle space truncation, we postpone the read-only check for
+	 * the _truncate system space till the on_replace trigger is called,
+	 * when we know which space is truncated.
 	 */
 	if (space_id(space) != BOX_TRUNCATE_ID &&
-	    !space_is_temporary(space) &&
+	    !space_is_data_temporary(space) &&
 	    !space_is_local(space) &&
 	    box_check_writable() != 0)
 		return -1;
 	if (space_is_memtx(space)) {
 		/*
 		 * Due to on_init_schema triggers set on system spaces,
-		 * we can insert data during recovery to local and temporary
-		 * spaces. However, until recovery is finished, we can't
-		 * check key uniqueness (since indexes are still not yet built).
-		 * So reject any attempts to write into these spaces.
+		 * we can insert data during recovery to local and
+		 * data-temporary spaces. However, until recovery is finished,
+		 * we can't check key uniqueness (since indexes are still not
+		 * yet built). So reject any attempts to write into these
+		 * spaces.
 		 */
 		if (memtx_space_is_recovering(space)) {
 			diag_set(ClientError, ER_UNSUPPORTED, "Snapshot recovery",

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -767,7 +767,7 @@ boxk(int type, uint32_t space_id, const char *format, ...);
 
 /** Generate unique id for non-system space. */
 int
-box_generate_space_id(uint32_t *new_space_id);
+box_generate_space_id(uint32_t *new_space_id, bool is_temporary);
 
 /**
  * Broadcast the identification of the instance

--- a/src/box/engine.h
+++ b/src/box/engine.h
@@ -245,8 +245,8 @@ struct engine_vtab {
 	void (*reset_stat)(struct engine *);
 	/**
 	 * Check definition of a new space for engine-specific
-	 * limitations. E.g. not all engines support temporary
-	 * tables.
+	 * limitations. E.g. not all engines support data-temporary
+	 * spaces.
 	 */
 	int (*check_space_def)(struct space_def *);
 };

--- a/src/box/lua/misc.cc
+++ b/src/box/lua/misc.cc
@@ -238,8 +238,11 @@ port_msgpack_dump_lua(struct port *base, struct lua_State *L, bool is_flat)
 static int
 lbox_generate_space_id(lua_State *L)
 {
+	assert(lua_gettop(L) >= 1);
+	assert(lua_isboolean(L, 1) == 1);
+	bool is_temporary = lua_toboolean(L, 1) != 0;
 	uint32_t ret = 0;
-	if (box_generate_space_id(&ret) != 0)
+	if (box_generate_space_id(&ret, is_temporary) != 0)
 		return luaT_error(L);
 	lua_pushnumber(L, ret);
 	return 1;

--- a/src/box/lua/space.cc
+++ b/src/box/lua/space.cc
@@ -897,6 +897,8 @@ box_lua_space_init(struct lua_State *L)
 	lua_setfield(L, -2, "REPLICA_MAX");
 	lua_pushnumber(L, SQL_BIND_PARAMETER_MAX);
 	lua_setfield(L, -2, "SQL_BIND_PARAMETER_MAX");
+	lua_pushnumber(L, BOX_SPACE_ID_TEMPORARY_MIN);
+	lua_setfield(L, -2, "SPACE_ID_TEMPORARY_MIN");
 	lua_pop(L, 2); /* box, schema */
 
 	static const struct luaL_Reg space_internal_lib[] = {

--- a/src/box/lua/space.cc
+++ b/src/box/lua/space.cc
@@ -421,9 +421,14 @@ lbox_fillspace(struct lua_State *L, struct space *space, int i)
 	lua_pushboolean(L, space_is_local(space));
 	lua_settable(L, i);
 
-	/* space.is_temp */
+	/* space.temporary */
 	lua_pushstring(L, "temporary");
 	lua_pushboolean(L, space_is_temporary(space));
+	lua_settable(L, i);
+
+	/* space.type */
+	lua_pushstring(L, "type");
+	lua_pushstring(L, space_type_name(space->def->opts.type));
 	lua_settable(L, i);
 
 	/* space.name */

--- a/src/box/lua/space.cc
+++ b/src/box/lua/space.cc
@@ -423,7 +423,7 @@ lbox_fillspace(struct lua_State *L, struct space *space, int i)
 
 	/* space.temporary */
 	lua_pushstring(L, "temporary");
-	lua_pushboolean(L, space_is_temporary(space));
+	lua_pushboolean(L, space_is_data_temporary(space));
 	lua_settable(L, i);
 
 	/* space.type */

--- a/src/box/memtx_allocator.h
+++ b/src/box/memtx_allocator.h
@@ -139,9 +139,9 @@ memtx_tuple_rv_version(struct memtx_tuple_rv *rv)
  * for each type maintain an independent list.
  */
 enum memtx_tuple_rv_type {
-	/** Tuples from non-temporary spaces. */
+	/** Tuples from non-data-temporary spaces. */
 	memtx_tuple_rv_default,
-	/** Tuples from temporary spaces. */
+	/** Tuples from data-temporary spaces. */
 	memtx_tuple_rv_temporary,
 	memtx_tuple_rv_type_MAX,
 };
@@ -257,7 +257,7 @@ public:
 		}
 		ReadView *rv = (ReadView *)xcalloc(1, sizeof(*rv));
 		for (int type = 0; type < memtx_tuple_rv_type_MAX; type++) {
-			if (!opts->enable_temporary_spaces &&
+			if (!opts->enable_data_temporary_spaces &&
 			    type == memtx_tuple_rv_temporary)
 				continue;
 			rv->rv[type] = memtx_tuple_rv_new(read_view_version,

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -58,6 +58,7 @@
 #include "memtx_space.h"
 #include "memtx_space_upgrade.h"
 #include "tt_sort.h"
+#include "assoc.h"
 
 #include <type_traits>
 
@@ -797,6 +798,46 @@ primary_index_filter(struct space *space, struct index *index, void *arg)
 	return index->def->iid == 0;
 }
 
+/*
+ * Return true if tuple @a data represents temporary space's metadata.
+ * @a space_id is used to determine the tuple's format.
+ */
+static bool
+is_tuple_temporary(const char *data, uint32_t space_id,
+		   struct mh_i32_t *temp_space_ids)
+{
+	static_assert(BOX_SPACE_ID < BOX_INDEX_ID &&
+		      BOX_SPACE_ID < BOX_TRUNCATE_ID,
+		      "in this function temporary space ids are collected "
+		      "while processing tuples of _space and then this info is "
+		      "used when going over _index & _truncate");
+	switch (space_id) {
+	case BOX_SPACE_ID: {
+		uint32_t space_id = BOX_ID_NIL;
+		bool t = space_def_tuple_is_temporary(data, &space_id);
+		if (t)
+			mh_i32_put(temp_space_ids, &space_id,
+				   NULL, NULL);
+		return t;
+	}
+	case BOX_INDEX_ID:
+	case BOX_TRUNCATE_ID: {
+		static_assert(BOX_INDEX_FIELD_SPACE_ID == 0 &&
+			      BOX_TRUNCATE_FIELD_SPACE_ID == 0,
+			      "the following code assumes this is true");
+		uint32_t field_count = mp_decode_array(&data);
+		if (field_count < 1 || mp_typeof(*data) != MP_UINT)
+			return false;
+		uint32_t space_id = mp_decode_uint(&data);
+		mh_int_t pos = mh_i32_find(temp_space_ids, space_id,
+					   NULL);
+		return pos != mh_end(temp_space_ids);
+	}
+	default:
+		return false;
+	}
+}
+
 static struct checkpoint *
 checkpoint_new(const char *snap_dirname, uint64_t snap_io_rate_limit)
 {
@@ -969,6 +1010,8 @@ checkpoint_f(va_list ap)
 	if (xdir_create_xlog(&ckpt->dir, &snap, &ckpt->vclock) != 0)
 		return -1;
 
+	struct mh_i32_t *temp_space_ids = mh_i32_new();
+
 	say_info("saving snapshot `%s'", snap.filename);
 	ERROR_INJECT_SLEEP(ERRINJ_SNAP_WRITE_DELAY);
 	ERROR_INJECT(ERRINJ_SNAP_SKIP_ALL_ROWS, goto done);
@@ -996,6 +1039,10 @@ checkpoint_f(va_list ap)
 			rc = index_read_view_iterator_next_raw(&it, &result);
 			if (rc != 0 || result.data == NULL)
 				break;
+			if (is_tuple_temporary(result.data,
+					       space_rv->id,
+					       temp_space_ids))
+				continue;
 			rc = checkpoint_write_tuple(&snap, space_rv->id,
 						    space_rv->group_id,
 						    result.data, result.size);
@@ -1006,6 +1053,7 @@ checkpoint_f(va_list ap)
 		if (rc != 0)
 			break;
 	}
+	mh_i32_delete(temp_space_ids);
 	if (rc != 0)
 		goto fail;
 	ERROR_INJECT(ERRINJ_SNAP_WRITE_CORRUPTED_INSERT_ROW, {
@@ -1235,6 +1283,7 @@ memtx_join_f(va_list ap)
 {
 	int rc = 0;
 	struct memtx_join_ctx *ctx = va_arg(ap, struct memtx_join_ctx *);
+	struct mh_i32_t *temp_space_ids = mh_i32_new();
 	struct space_read_view *space_rv;
 	read_view_foreach_space(space_rv, &ctx->rv) {
 		FiberGCChecker gc_check;
@@ -1253,6 +1302,10 @@ memtx_join_f(va_list ap)
 			rc = index_read_view_iterator_next_raw(&it, &result);
 			if (rc != 0 || result.data == NULL)
 				break;
+			if (is_tuple_temporary(result.data,
+					       space_rv->id,
+					       temp_space_ids))
+				continue;
 			rc = memtx_join_send_tuple(ctx->stream, space_rv->id,
 						   result.data, result.size);
 			if (rc != 0)
@@ -1262,6 +1315,7 @@ memtx_join_f(va_list ap)
 		if (rc != 0)
 			break;
 	}
+	mh_i32_delete(temp_space_ids);
 	return rc;
 }
 

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -1362,9 +1362,11 @@ memtx_space_prepare_alter(struct space *old_space, struct space *new_space)
 	struct memtx_space *new_memtx_space = (struct memtx_space *)new_space;
 
 	if (old_memtx_space->bsize != 0 &&
-	    space_is_temporary(old_space) != space_is_temporary(new_space)) {
+	    space_is_data_temporary(old_space) !=
+	    space_is_data_temporary(new_space)) {
 		diag_set(ClientError, ER_ALTER_SPACE, old_space->def->name,
-			 "can not switch temporary flag on a non-empty space");
+			 "can not change data-temporariness on a non-empty "
+			 "space");
 		return -1;
 	}
 

--- a/src/box/read_view.c
+++ b/src/box/read_view.c
@@ -67,7 +67,7 @@ read_view_opts_create(struct read_view_opts *opts)
 	opts->filter_arg = NULL;
 	opts->enable_field_names = false;
 	opts->enable_space_upgrade = false;
-	opts->enable_temporary_spaces = false;
+	opts->enable_data_temporary_spaces = false;
 	opts->disable_decompression = false;
 }
 
@@ -157,7 +157,8 @@ read_view_add_space_cb(struct space *space, void *arg_raw)
 	struct read_view *rv = arg->rv;
 	const struct read_view_opts *opts = arg->opts;
 	if ((space->engine->flags & ENGINE_SUPPORTS_READ_VIEW) == 0 ||
-	    (space_is_temporary(space) && !opts->enable_temporary_spaces) ||
+	    (space_is_data_temporary(space) &&
+	     !opts->enable_data_temporary_spaces) ||
 	    !opts->filter_space(space, opts->filter_arg))
 		return 0;
 	struct space_read_view *space_rv = space_read_view_new(space, opts);

--- a/src/box/read_view.h
+++ b/src/box/read_view.h
@@ -163,10 +163,10 @@ struct read_view_opts {
 	 */
 	bool enable_space_upgrade;
 	/**
-	 * Temporary spaces aren't included into this read view unless this
+	 * Data-temporary spaces aren't included into this read view unless this
 	 * flag is set.
 	 */
-	bool enable_temporary_spaces;
+	bool enable_data_temporary_spaces;
 	/**
 	 * Memtx-specific. Disables decompression of tuples fetched from
 	 * the read view. Setting this flag makes the raw read view methods

--- a/src/box/schema_def.h
+++ b/src/box/schema_def.h
@@ -57,7 +57,14 @@ enum {
 	/** Yet another arbitrary limit which simply needs to
 	 * exist.
 	 */
-	BOX_INDEX_PART_MAX = UINT8_MAX
+	BOX_INDEX_PART_MAX = UINT8_MAX,
+	/**
+	 * Start of the range of default temporary space ids.
+	 * By default they get ids from a special range to avoid conflicts with
+	 * spaces which could arrive via replication. But the user is free to
+	 * choose an id from outside this range.
+	 */
+	BOX_SPACE_ID_TEMPORARY_MIN = (1 << 30),
 };
 static_assert(BOX_INVALID_NAME_MAX <= BOX_NAME_MAX,
 	      "invalid name max is less than name max");

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -476,7 +476,7 @@ space_new(struct space_def *def, struct rlist *key_list)
 struct space *
 space_new_ephemeral(struct space_def *def, struct rlist *key_list)
 {
-	assert(space_opts_is_temporary(&def->opts));
+	assert(space_opts_is_data_temporary(&def->opts));
 	assert(def->opts.is_ephemeral);
 	struct space *space = space_new(def, key_list);
 	if (space == NULL)

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -476,7 +476,7 @@ space_new(struct space_def *def, struct rlist *key_list)
 struct space *
 space_new_ephemeral(struct space_def *def, struct rlist *key_list)
 {
-	assert(def->opts.is_temporary);
+	assert(space_opts_is_temporary(&def->opts));
 	assert(def->opts.is_ephemeral);
 	struct space *space = space_new(def, key_list);
 	if (space == NULL)

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -353,6 +353,13 @@ space_is_data_temporary(const struct space *space)
 	return space_opts_is_data_temporary(&space->def->opts);
 }
 
+/** Return true if space is temporary. */
+static inline bool
+space_is_temporary(const struct space *space)
+{
+	return space_opts_is_temporary(&space->def->opts);
+}
+
 /** Return true if space is synchronous. */
 static inline bool
 space_is_sync(const struct space *space)

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -350,7 +350,7 @@ space_name(const struct space *space)
 static inline bool
 space_is_temporary(const struct space *space)
 {
-	return space->def->opts.is_temporary;
+	return space_opts_is_temporary(&space->def->opts);
 }
 
 /** Return true if space is synchronous. */

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -346,11 +346,11 @@ space_name(const struct space *space)
 	return space->def->name;
 }
 
-/** Return true if space is temporary. */
+/** Return true if space is data-temporary. */
 static inline bool
-space_is_temporary(const struct space *space)
+space_is_data_temporary(const struct space *space)
 {
-	return space_opts_is_temporary(&space->def->opts);
+	return space_opts_is_data_temporary(&space->def->opts);
 }
 
 /** Return true if space is synchronous. */

--- a/src/box/space_def.c
+++ b/src/box/space_def.c
@@ -113,7 +113,7 @@ space_tuple_format_new(struct tuple_format_vtab *vtab, void *engine,
 	return tuple_format_new(vtab, engine, keys, key_count,
 				def->fields, def->field_count,
 				def->exact_field_count, def->dict,
-				space_opts_is_temporary(&def->opts),
+				space_opts_is_data_temporary(&def->opts),
 				def->opts.is_ephemeral,
 				def->opts.constraint_def,
 				def->opts.constraint_count, def->format_data,
@@ -297,8 +297,7 @@ space_opts_parse_temporary(const char **data, void *vopts,
 			 "only one of 'type' or 'temporary' may be specified");
 		return -1;
 	}
-	bool is_temporary = mp_decode_bool(data);
-	opts->type = is_temporary ?
+	opts->type = mp_decode_bool(data) ?
 		SPACE_TYPE_DATA_TEMPORARY : SPACE_TYPE_NORMAL;
 	return 0;
 }

--- a/src/box/space_def.c
+++ b/src/box/space_def.c
@@ -40,7 +40,7 @@
 
 const struct space_opts space_opts_default = {
 	/* .group_id = */ 0,
-	/* .is_temporary = */ false,
+	/* .type = */ SPACE_TYPE_NORMAL,
 	/* .is_ephemeral = */ false,
 	/* .view = */ false,
 	/* .is_sync = */ false,
@@ -75,9 +75,25 @@ static int
 space_opts_parse_upgrade(const char **data, void *vopts,
 			 struct region *region);
 
+/**
+ * Callback to parse a value with 'temporary' key in msgpack space opts
+ * definition. See function definition below.
+ */
+static int
+space_opts_parse_temporary(const char **data, void *vopts,
+			   struct region *region);
+
+/**
+ * Callback to parse a value with 'type' key in msgpack space opts
+ * definition. See function definition below.
+ */
+static int
+space_opts_parse_type(const char **data, void *vopts, struct region *region);
+
 const struct opt_def space_opts_reg[] = {
+	OPT_DEF_CUSTOM("type", space_opts_parse_type),
 	OPT_DEF("group_id", OPT_UINT32, struct space_opts, group_id),
-	OPT_DEF("temporary", OPT_BOOL, struct space_opts, is_temporary),
+	OPT_DEF_CUSTOM("temporary", space_opts_parse_temporary),
 	OPT_DEF("view", OPT_BOOL, struct space_opts, is_view),
 	OPT_DEF("is_sync", OPT_BOOL, struct space_opts, is_sync),
 	OPT_DEF("defer_deletes", OPT_BOOL, struct space_opts, defer_deletes),
@@ -97,7 +113,8 @@ space_tuple_format_new(struct tuple_format_vtab *vtab, void *engine,
 	return tuple_format_new(vtab, engine, keys, key_count,
 				def->fields, def->field_count,
 				def->exact_field_count, def->dict,
-				def->opts.is_temporary, def->opts.is_ephemeral,
+				space_opts_is_temporary(&def->opts),
+				def->opts.is_ephemeral,
 				def->opts.constraint_def,
 				def->opts.constraint_count, def->format_data,
 				def->format_data_len);
@@ -187,7 +204,7 @@ struct space_def*
 space_def_new_ephemeral(uint32_t exact_field_count, struct field_def *fields)
 {
 	struct space_opts opts = space_opts_default;
-	opts.is_temporary = true;
+	opts.type = SPACE_TYPE_DATA_TEMPORARY;
 	opts.is_ephemeral = true;
 	uint32_t field_count = exact_field_count;
 	if (fields == NULL) {
@@ -262,4 +279,57 @@ space_opts_parse_upgrade(const char **data, void *vopts,
 	struct space_opts *opts = (struct space_opts *)vopts;
 	opts->upgrade_def = space_upgrade_def_decode(data, region);
 	return opts->upgrade_def == NULL ? -1 : 0;
+}
+
+static int
+space_opts_parse_temporary(const char **data, void *vopts,
+			   struct region *region)
+{
+	(void)region;
+	if (mp_typeof(**data) != MP_BOOL) {
+		diag_set(IllegalParams, "'temporary' must be boolean");
+		return -1;
+	}
+	struct space_opts *opts = vopts;
+	if (opts->type != SPACE_TYPE_DEFAULT) {
+		/* This means 'type' was specified. */
+		diag_set(IllegalParams,
+			 "only one of 'type' or 'temporary' may be specified");
+		return -1;
+	}
+	bool is_temporary = mp_decode_bool(data);
+	opts->type = is_temporary ?
+		SPACE_TYPE_DATA_TEMPORARY : SPACE_TYPE_NORMAL;
+	return 0;
+}
+
+const char *space_type_strs[] = {
+	/* [SPACE_TYPE_NORMAL]         = */ "normal",
+	/* [SPACE_TYPE_DATA_TEMPORARY] = */ "data-temporary",
+};
+
+static int
+space_opts_parse_type(const char **data, void *vopts, struct region *region)
+{
+	(void)region;
+	if (mp_typeof(**data) != MP_STR) {
+		diag_set(IllegalParams, "'type' must be a string");
+		return -1;
+	}
+	uint32_t str_len = 0;
+	const char *str = mp_decode_str(data, &str_len);
+	enum space_type space_type = STRN2ENUM(space_type, str, str_len);
+	if (space_type == SPACE_TYPE_DEFAULT) {
+		diag_set(IllegalParams, "unknown space type");
+		return -1;
+	}
+	struct space_opts *opts = vopts;
+	if (opts->type != SPACE_TYPE_DEFAULT) {
+		/* This means 'temporary' was specified. */
+		diag_set(IllegalParams,
+			 "only one of 'type' or 'temporary' may be specified");
+		return -1;
+	}
+	opts->type = space_type;
+	return 0;
 }

--- a/src/box/space_def.h
+++ b/src/box/space_def.h
@@ -129,10 +129,10 @@ space_opts_create(struct space_opts *opts)
 }
 
 /**
- * Check if the space is temporary.
+ * Check if the space is data-temporary.
  */
 static inline bool
-space_opts_is_temporary(const struct space_opts *opts)
+space_opts_is_data_temporary(const struct space_opts *opts)
 {
 	assert(opts->type != SPACE_TYPE_DEFAULT);
 	return opts->type != SPACE_TYPE_NORMAL;

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -281,7 +281,7 @@ sql_shallow_space_copy(struct Parse *parse, struct space *space)
 	memcpy(ret->index, space->index,
 	       sizeof(struct index *) * space->index_count);
 	memcpy(ret->def, space->def, sizeof(struct space_def));
-	ret->def->opts.is_temporary = true;
+	ret->def->opts.type = SPACE_TYPE_DATA_TEMPORARY;
 	ret->def->opts.is_ephemeral = true;
 	if (ret->def->field_count != 0) {
 		ret->def->fields =

--- a/src/box/sql/select.c
+++ b/src/box/sql/select.c
@@ -4850,7 +4850,7 @@ selectExpander(Walker * pWalker, Select * p)
 	ExprList *pEList;
 	struct SrcList_item *pFrom;
 	Expr *pE, *pRight, *pExpr;
-	u16 selFlags = p->selFlags;
+	u32 selFlags = p->selFlags;
 
 	p->selFlags |= SF_Expanded;
 	if (NEVER(p->pSrc == 0) || (selFlags & SF_Expanded) != 0) {

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -4324,7 +4324,7 @@ case OP_GenSpaceid: {
 	assert(pOp->p1 > 0);
 	pOut = vdbe_prepare_null_out(p, pOp->p1);
 	uint32_t u;
-	if (box_generate_space_id(&u) != 0)
+	if (box_generate_space_id(&u, false) != 0)
 		goto abort_due_to_error;
 	mem_set_uint(pOut, u);
 	break;

--- a/src/box/tuple.h
+++ b/src/box/tuple.h
@@ -399,7 +399,7 @@ enum tuple_flag {
 	 */
 	TUPLE_IS_DIRTY = 1,
 	/**
-	 * The tuple belongs to a temporary space so it can be freed
+	 * The tuple belongs to a data-temporary space so it can be freed
 	 * immediately while a snapshot is in progress.
 	 */
 	TUPLE_IS_TEMPORARY = 2,

--- a/src/box/tuple_constraint_fkey.c
+++ b/src/box/tuple_constraint_fkey.c
@@ -629,6 +629,12 @@ tuple_constraint_fkey_check_spaces(struct tuple_constraint *constr,
 				   struct space *space,
 				   struct space *foreign_space)
 {
+	if (space_is_temporary(foreign_space)) {
+		diag_set(ClientError, ER_CREATE_FOREIGN_KEY,
+			 constr->def.name, constr->space->def->name,
+			 "foreign space can't be temporary");
+		return -1;
+	}
 	if (space_is_data_temporary(foreign_space) &&
 	    !space_is_data_temporary(space)) {
 		diag_set(ClientError, ER_CREATE_FOREIGN_KEY,

--- a/src/box/tuple_constraint_fkey.c
+++ b/src/box/tuple_constraint_fkey.c
@@ -629,11 +629,12 @@ tuple_constraint_fkey_check_spaces(struct tuple_constraint *constr,
 				   struct space *space,
 				   struct space *foreign_space)
 {
-	if (space_is_temporary(foreign_space) && !space_is_temporary(space)) {
+	if (space_is_data_temporary(foreign_space) &&
+	    !space_is_data_temporary(space)) {
 		diag_set(ClientError, ER_CREATE_FOREIGN_KEY,
 			 constr->def.name, constr->space->def->name,
-			 "foreign key from non-temporary space"
-			 " can't refer to temporary space");
+			 "foreign key from non-data-temporary space"
+			 " can't refer to data-temporary space");
 		return -1;
 	}
 	if (space_is_local(foreign_space) && !space_is_local(space)) {

--- a/src/box/tuple_format.h
+++ b/src/box/tuple_format.h
@@ -245,7 +245,7 @@ struct tuple_format {
 	/** Reference counter */
 	int refs;
 	/**
-	 * Tuples of this format belong to a temporary space and
+	 * Tuples of this format belong to a data-temporary space and
 	 * hence can be freed immediately while checkpointing is
 	 * in progress.
 	 */
@@ -417,7 +417,7 @@ tuple_format_unref(struct tuple_format *format)
  * @param space_fields Array of fields, defined in a space format.
  * @param space_field_count Length of @a space_fields.
  * @param exact_field_count Exact field count for format.
- * @param is_temporary Set if format belongs to temporary space.
+ * @param is_temporary Set if format belongs to data-temporary space.
  * @param is_reusable Set if format may be reused.
  * @param constraint_def - Array of constraint definitions.
  * @param constraint_count - Number of constraints above.

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -606,10 +606,10 @@ txn_commit_stmt(struct txn *txn, struct request *request)
 
 	/*
 	 * Create WAL record for the write requests in
-	 * non-temporary spaces. stmt->space can be NULL for
+	 * non-data-temporary spaces. stmt->space can be NULL for
 	 * IRPOTO_NOP or IPROTO_RAFT_CONFIRM.
 	 */
-	if (stmt->space == NULL || !space_is_temporary(stmt->space)) {
+	if (stmt->space == NULL || !space_is_data_temporary(stmt->space)) {
 		if (txn_add_redo(txn, stmt, request) != 0)
 			goto fail;
 		assert(stmt->row != NULL);
@@ -1307,10 +1307,10 @@ txn_check_space_linearizability(const struct txn *txn,
 	 * require checking whether **any** node in the replicaset has
 	 * committed something, which's impossible as soon as at least one node
 	 * becomes unavailable.
-	 * The only exception are local and temporary spaces, which only store
-	 * updates present on this particular node.
+	 * The only exception are local and data-temporary spaces, which only
+	 * store updates present on this particular node.
 	 */
-	if (!space_is_sync(space) && !space_is_temporary(space) &&
+	if (!space_is_sync(space) && !space_is_data_temporary(space) &&
 	    !space_is_local(space)) {
 		diag_set(ClientError, ER_UNSUPPORTED,
 			 tt_sprintf("space \"%s\"", space_name(space)),

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -836,6 +836,24 @@ txn_is_fully_local(const struct txn *txn)
 }
 
 /**
+ * Mark @a stmt as temporary by removing the associated stmt->row
+ * and update @a txn accordingly.
+ *
+ * This function is called from on_replace_dd_* triggers to filter
+ * temporary space's metadata updates from WAL.
+ *
+ * NOTE: This could also be implemented by just not creating the stmt->row
+ * when txn_commit_stmt is called, but it would be less efficient that way
+ * as it would require putting an expensive check on a hot path.
+ * Doing the check inside the on_replace trigger is much cheaper
+ * as the data we're interested in (result of space_is_temporary(space))
+ * is readily available at that point.
+ * The downside of confusing control flow is outweighed by the efficiency.
+ */
+void
+txn_stmt_mark_as_temporary(struct txn *txn, struct txn_stmt *stmt);
+
+/**
  * End a statement. In autocommit mode, end
  * the current transaction as well.
  *

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -586,9 +586,10 @@ vinyl_engine_check_space_def(struct space_def *def)
 			return -1;
 		}
 	}
-	if (space_opts_is_temporary(&def->opts)) {
+	if (space_opts_is_data_temporary(&def->opts)) {
 		diag_set(ClientError, ER_ALTER_SPACE,
-			 def->name, "engine does not support temporary flag");
+			 def->name,
+			 "engine does not support data-temporary spaces");
 		return -1;
 	}
 	return 0;

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -586,7 +586,7 @@ vinyl_engine_check_space_def(struct space_def *def)
 			return -1;
 		}
 	}
-	if (def->opts.is_temporary) {
+	if (space_opts_is_temporary(&def->opts)) {
 		diag_set(ClientError, ER_ALTER_SPACE,
 			 def->name, "engine does not support temporary flag");
 		return -1;

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -969,7 +969,7 @@ wal_assign_lsn(struct vclock *vclock_diff, struct vclock *base,
 			 * instance id. This is also true for
 			 * anonymous replicas, since they are
 			 * only capable of writing to local and
-			 * temporary spaces.
+			 * data-temporary spaces.
 			 */
 			if ((*row)->group_id != GROUP_LOCAL)
 				(*row)->replica_id = instance_id;

--- a/src/lib/core/tt_sort.c
+++ b/src/lib/core/tt_sort.c
@@ -179,7 +179,7 @@ sort_bucket(va_list ap)
 		  worker->bucket_size, sort->elem_size,
 		  sort->cmp, sort->cmp_arg);
 
-	/* Move sorted data back from temporary space. */
+	/* Move sorted data back from data-temporary space. */
 	memcpy(sort->data + worker->bucket_begin * sort->elem_size,
 	       sort->buffer + worker->bucket_begin * sort->elem_size,
 	       worker->bucket_size * sort->elem_size);

--- a/test/box-luatest/fully-temporary_spaces_test.lua
+++ b/test/box-luatest/fully-temporary_spaces_test.lua
@@ -1,0 +1,523 @@
+local fio = require('fio')
+local xlog = require('xlog')
+local server = require('luatest.server')
+local replica_set = require('luatest.replica_set')
+local t = require('luatest')
+local g = t.group()
+local _ = nil
+
+g.before_all(function()
+    g.server = server:new({alias = 'master'})
+end
+)
+g.after_all(function()
+    _ = g.server.process and g.server:stop()
+    _ = g.replica_set and g.replica_set:drop()
+end)
+
+g.before_each(function()
+    if not g.server.process then
+        g.server:start()
+    end
+end)
+
+g.after_each(function()
+    _ = g.server.process and g.server:exec(function()
+        box.cfg { read_only = false }
+        for _, s in pairs({'test', 'datatemp', 'temp'}) do
+            local _ = box.space[s] and box.space[s]:drop()
+        end
+    end)
+end)
+
+-- check basic invariants of temporary spaces
+g.test_temporary_create = function()
+    g.server:exec(function()
+        local _space = box.space._space
+
+        local s = box.schema.space.create('temp', { type = 'temporary' })
+        t.assert_equals(s.temporary, true)
+        t.assert_equals(s.type, 'temporary')
+
+        --
+        -- Check automatic/manual space id.
+        --
+        s = box.schema.space.create('temp2', { type = 'temporary', id = 9999 })
+        t.assert_equals(s.type, 'temporary')
+        s:drop()
+
+        -- If id is not specified, it will be chosen in the special range.
+        s = box.schema.space.create('temp2', { type = 'temporary' })
+        t.assert_equals(s.id, box.space.temp.id + 1)
+
+        s = box.schema.space.create('temp3', { type = 'temporary' })
+        t.assert_equals(s.id, box.space.temp.id + 2)
+
+        -- Now we have an unoccupied space id box.space.temp.id + 1
+        box.space.temp2:drop()
+
+        -- But it's not chosen, because space ids grow, until they can't
+        s = box.schema.space.create('temp4', { type = 'temporary' })
+        t.assert_equals(s.id, box.space.temp.id + 3)
+        s:drop()
+
+        -- Now there's no more room to grow...
+        local BOX_SPACE_MAX = 0x7fffffff
+        box.schema.space.create('temp2', { type = 'temporary',
+                                           id = BOX_SPACE_MAX })
+
+        -- ... therefore we start filling in the gaps
+        s = box.schema.space.create('temp4', { type = 'temporary' })
+        t.assert_equals(s.id, box.space.temp.id + 1)
+        s:drop()
+
+        box.space.temp2:drop()
+        box.space.temp3:drop()
+
+        --
+        -- Here's all the ways you can create a data-temporary space now
+        --
+        s = box.schema.space.create('datatemp', { temporary = true })
+        t.assert_equals(s.temporary, true)
+        t.assert_equals(s.type, 'data-temporary')
+        s:drop()
+
+        s = box.schema.space.create('datatemp', { type = 'data-temporary' })
+        t.assert_equals(s.temporary, true)
+        t.assert_equals(s.type, 'data-temporary')
+        s:drop()
+
+        t.assert_error_msg_contains(
+            "only one of 'type' or 'temporary' may be specified",
+            box.schema.space.create, 'temp',
+            { type = 'data-temporary', temporary = true }
+        )
+
+        --
+        -- Here's all the ways you can create a normal space now
+        --
+        s = box.schema.space.create('normal', { temporary = false })
+        t.assert_equals(s.temporary, false)
+        t.assert_equals(s.type, 'normal')
+        s:drop()
+
+        s = box.schema.space.create('normal', { type = 'normal' })
+        t.assert_equals(s.temporary, false)
+        t.assert_equals(s.type, 'normal')
+        s:drop()
+
+        t.assert_error_msg_contains(
+            "only one of 'type' or 'temporary' may be specified",
+            box.schema.space.create, 'temp',
+            { type = 'normal', temporary = false }
+        )
+
+
+        t.assert_error_msg_contains(
+            "only one of 'type' or 'temporary' may be specified",
+            box.schema.space.create, 'temp',
+            { type = 'temporary', temporary = true }
+        )
+
+        t.assert_error_msg_contains(
+            "unknown space type, must be one of: 'normal', 'data-temporary'," ..
+            " 'temporary'",
+            box.schema.space.create, 'super', { type = 'super-temporary' }
+        )
+
+        t.assert_error_msg_contains(
+            "engine does not support data-temporary spaces",
+            box.schema.space.create,
+                'no-vinyl', { engine = 'vinyl', type = 'temporary' }
+        )
+
+        s = box.schema.space.create('datatemp', { type = 'data-temporary' })
+        t.assert_error_msg_contains(
+            "temporariness cannot change",
+            s.alter, s, { type = 'temporary' }
+        )
+        t.assert_error_msg_contains(
+            "temporariness cannot change",
+            _space.update,
+                _space, s.id, {{'=', 6, { type = 'temporary' }}}
+        )
+
+        s = box.space.temp
+        t.assert_error_msg_contains(
+            "temporariness cannot change",
+            s.alter, s, { type = 'data-temporary' }
+        )
+        t.assert_error_msg_contains(
+            "temporariness cannot change",
+            _space.update,
+                _space, s.id, {{'=', 6, { type = 'data-temporary' }}}
+        )
+    end)
+end
+
+-- check which features aren't supported for temporary spaces
+g.test_temporary_dont_support = function()
+    g.server:exec(function()
+        local s = box.schema.space.create('temp', { type = 'temporary',
+                                                        id = 1111111111 })
+        s:format {{'k', 'unsigned'}}
+        s:create_index('pk')
+        box.schema.func.create('foo', {
+            is_sandboxed = true,
+            is_deterministic = true,
+            body = "function() end"
+        })
+        t.assert_error_msg_equals(
+            "temporary space does not support functional indexes",
+            s.create_index, s, 'func', { func = 'foo' }
+        )
+
+        t.assert_error_msg_equals(
+            "temporary space does not support privileges",
+            box.schema.user.grant, 'guest', 'read', 'space', s.name
+        )
+    end)
+end
+
+-- check which sql features aren't supported for temporary spaces
+g.test_temporary_sql_dont_support = function()
+    g.server:exec(function()
+        local _space = box.space._space
+
+        box.schema.space.create('temp', { type = 'temporary',
+                                              id = 1111111112 })
+        box.schema.space.create('test', { format = { 'k', 'unsigned' } })
+
+        local function sql(stmt)
+            local ok, err = box.execute(stmt)
+            local _ = ok == nil and error(err)
+        end
+
+        t.assert_error_msg_contains(
+            "triggers are not supported for temporary spaces",
+            sql, [[
+                create trigger "my_trigger" before insert on "temp"
+                for each row begin
+                    insert into "temp" values (1);
+                end;
+            ]]
+        )
+
+        t.assert_error_msg_contains(
+            "sequences are not supported for temporary spaces",
+            sql, [[
+                alter table "temp"
+                    add column "k" integer primary key autoincrement
+            ]]
+        )
+
+        -- alter table works though
+        sql([[ alter table "temp" add column "k" int primary key ]])
+
+        t.assert_error_msg_contains(
+            "foreign space can't be temporary",
+            sql, [[
+                create table "my_table" (
+                    "id" integer primary key,
+                    "k" integer,
+                    foreign key ("k") references "temp" ("k")
+                )
+            ]]
+        )
+
+        t.assert_error_msg_contains(
+            "temporary space does not support constraints",
+            sql, [[
+                alter table "temp"
+                add constraint "fk" foreign key ("k") references "test" ("k")
+            ]]
+        )
+
+        -- CREATE VIEW
+
+        local function assert_create_view_not_supported(create_view_sql)
+            t.assert_error_msg_contains(
+                "CREATE VIEW does not support temporary spaces",
+                sql, create_view_sql
+            )
+            t.assert_error_msg_contains(
+                "CREATE VIEW does not support temporary spaces",
+                _space.insert,
+                    _space, {
+                        9999, 1, 'my_view', 'memtx', 1,
+                        { sql = create_view_sql, view = true },
+                        {{ type = 'unsigned', name = 'ID',
+                           nullable_action = 'none', is_nullable = true }},
+                    }
+            )
+        end
+
+        box.space._session_settings:update({'sql_seq_scan'}, {{'=', 2, true}})
+        assert_create_view_not_supported([[
+            create view "my_view" as select * from "temp"
+        ]])
+
+        assert_create_view_not_supported([[
+            create view "my_view" as
+            select * from (select * from (select * from "temp"))
+        ]])
+
+        assert_create_view_not_supported([[
+            create view "my_view" as
+            select * from (select 1 x) where x in (select * from "temp")
+        ]])
+
+        assert_create_view_not_supported([[
+            create view "my_view" as values ((select * from "temp"))
+        ]])
+
+        assert_create_view_not_supported([[
+            create view "my_view" as
+            values (1) union select * from "temp"
+        ]])
+
+        -- CHECK constraints
+
+        t.assert_error_msg_contains(
+            "temporary space does not support constraints",
+            sql, [[
+                alter table "temp" add constraint "c2" check ( "k" > 0 )
+            ]]
+        )
+    end)
+end
+
+-- check that CRUD operations on space meta-data works in read-only mode
+g.test_temporary_read_only = function()
+    g.server:exec(function()
+        local _space, _index = box.space._space, box.space._index
+        box.cfg { read_only = true }
+        t.assert(box.info.ro)
+
+        t.assert_error_msg_contains(
+            "Can't modify data on a read-only instance",
+            box.schema.space.create, 'datatemp', { temporary = true }
+        )
+
+        -- space create works
+        local s = box.schema.space.create('temp', { type = 'temporary',
+                                                        id = 1111111113 })
+
+        -- space rename works
+        s:rename('newname')
+        t.assert_equals(s.name, box.space.newname.name)
+        _space:update(s.id, {{'=', 3, 'temp'}})
+        t.assert_equals(s.name, box.space.temp.name)
+
+        -- format change works
+        t.assert_equals(s:format(), {})
+        s:format {{'k', 'number'}}
+        t.assert_equals(s:format(), {{name = 'k', type = 'number'}})
+        s:alter { format = {{'k', 'number'}, {'v', 'any'}} }
+        t.assert_equals(
+            s:format(),
+            {{name = 'k', type = 'number'}, {name = 'v', type = 'any'}}
+        )
+
+        -- index create works
+        local i = s:create_index('first', { type = 'HASH' })
+        t.assert(s.index.first)
+
+        -- index rename works
+        i:rename('pk')
+        t.assert_equals(i.name, s.index.pk.name)
+        _index:update({s.id, i.id}, {{'=', 3, 'first'}})
+        t.assert_equals(i.name, s.index.first.name)
+
+        -- index alter works
+        t.assert_equals(i.type, 'HASH')
+        i:alter { type = 'TREE' }
+        t.assert_equals(i.type, 'TREE')
+
+        -- on_replace triggers even work
+        local tbl = {}
+        s:on_replace(function(_, new_tuple) table.insert(tbl, new_tuple) end)
+        t.assert_equals(#s:on_replace(), 1)
+        s:auto_increment{'foo'}
+        t.assert_equals(tbl, {{1, 'foo'}})
+        s:on_replace(nil, s:on_replace()[1])
+        t.assert_equals(#s:on_replace(), 0)
+
+        -- truncate works
+        t.assert_equals(s:len(), 1)
+        s:truncate()
+        t.assert_equals(s:len(), 0)
+
+        box.space._session_settings:update({'sql_seq_scan'}, {{'=', 2, true}})
+        -- basic sql works
+        box.execute [[ insert into "temp" values (420, 69), (13, 37) ]]
+        t.assert_equals(
+            box.execute [[ select * from "temp" ]].rows,
+            {{13, 37}, {420, 69}}
+        )
+        box.execute [[ truncate table "temp" ]]
+        local count = box.execute [[ select count(*) from "temp" ]].rows[1]
+        t.assert_equals(count, {0})
+        box.execute [[ drop table "temp" ]]
+        t.assert(not box.space.temp)
+
+        s = box.schema.space.create('temp', { type = 'temporary',
+                                                  id = 1111111114 })
+
+        -- all kinds of indexes work
+        s:create_index('tree', { type = 'TREE' })
+        s:create_index('hash', { type = 'HASH' })
+        s:create_index('rtree', {
+            type = 'RTREE', unique = false, parts = {2, 'array'}
+        })
+        s:create_index('bitset', {
+            type = 'BITSET', unique = false, parts = {3, 'unsigned'}
+        })
+
+        local row = box.tuple.new {1, {2, 3}, 4}
+        s:insert(row)
+
+        t.assert_equals(s.index.hash:get(1), row)
+        t.assert_equals(s.index.tree:get(1), row)
+        t.assert_equals(s.index.rtree:select({2, 3}), {row})
+        t.assert_equals(s.index.bitset:select(4), {row})
+
+        s:truncate()
+
+        -- index drop works
+        s.index.bitset:drop()
+        s.index.rtree:drop()
+        s.index.hash:drop()
+        s.index.tree:drop()
+
+        -- space drop works
+        s:drop()
+    end)
+end
+
+-- check temporary space definitions aren't replicated
+g.test_meta_data_not_replicated = function()
+    g.server:stop()
+    g.replica_set = replica_set:new{}
+    local replication = {
+        server.build_listen_uri('master', g.replica_set.id),
+        server.build_listen_uri('replica_1', g.replica_set.id),
+    }
+    g.replica_set:build_and_add_server{
+        alias = 'master',
+        box_cfg = { read_only = false, replication = replication },
+    }
+    g.replica_set:build_and_add_server{
+        alias = 'replica_1',
+        box_cfg = { read_only = true, replication = replication },
+    }
+    g.replica_set:start()
+
+    g.master = g.replica_set:get_server('master')
+    g.master:exec(function()
+        box.schema.space.create('temp', { type = 'temporary',
+                                              id = 1111111115 })
+        box.schema.space.create('datatemp', { temporary = true })
+    end)
+
+    g.replica_1 = g.replica_set:get_server('replica_1')
+    g.replica_1:wait_for_vclock_of(g.master)
+    -- temporary is not replicated via relay
+    g.replica_1:exec(function()
+        t.assert(box.space.datatemp)
+        t.assert(not box.space.temp)
+    end)
+
+    g.replica_2 = g.replica_set:build_and_add_server{
+        alias = 'replica_2',
+        box_cfg = { replication = replication },
+    }
+    g.replica_2:start{wait_until_ready = true}
+    g.replica_2:wait_for_vclock_of(g.master)
+    -- temporary is not replicated via snapshot
+    g.replica_2:exec(function()
+        t.assert(box.space.datatemp)
+        t.assert(not box.space.temp)
+    end)
+end
+
+g.after_test('test_meta_data_not_replicated', function()
+    g.replica_set:drop()
+end)
+
+local function check_wal_and_snap(expected)
+    local id_min = g.server:eval 'return box.schema.SPACE_ID_TEMPORARY_MIN'
+
+    local function is_meta_local_space_id(id)
+        return type(id) == 'number' and (id >= id_min or id == 9999)
+    end
+
+    local function contains_meta_local_space_id(entry)
+        local key, tuple = entry.BODY.key, entry.BODY.tuple
+        return key and key:pairs():any(is_meta_local_space_id)
+            or tuple and tuple:pairs():any(is_meta_local_space_id)
+    end
+
+    for _, f in pairs(fio.listdir(g.server.workdir)) do
+        if not f:endswith('.xlog') and not f:endswith('.xlog') then
+            goto continue
+        end
+
+        local path = fio.pathjoin(g.server.workdir, f)
+        local x = xlog.pairs(path)
+            :filter(contains_meta_local_space_id)
+            :totable()
+        if #x > 0 then
+            x = x[1]
+            x = {
+                type = x.HEADER.type,
+                space_id = x.BODY.space_id,
+                tuple = x.BODY.tuple,
+                key = x.BODY.key,
+            }
+            t.assert_equals({f, x}, {f, expected})
+        end
+
+        ::continue::
+    end
+end
+
+-- check temporary space definitions aren't persisted
+g.test_meta_data_not_persisted = function()
+    g.server:exec(function()
+        -- temporary space's metadata will go into WAL and snapshot
+        local s = box.schema.space.create('datatemp', { temporary = true })
+        s:create_index('pk')
+        s:put{1,2,3}
+        s:truncate()
+
+        -- temporary space's metadata will not go into WAL or snapshot
+        s = box.schema.space.create('temp', { type = 'temporary',
+                                                  id = 1111111116 })
+        s:create_index('pk')
+        s:put{1,2,3}
+        s:truncate()
+
+        -- there's nothing special about space ids
+        s = box.schema.space.create('test', { type = 'temporary',
+                                              id = 9999 })
+        s:create_index('pk')
+        s:put{1,2,3}
+        s:truncate()
+    end)
+
+    check_wal_and_snap({})
+
+    g.server:restart()
+
+    g.server:exec(function()
+        -- temporary space exists after restart
+        t.assert(box.space.datatemp)
+        -- temporary space doesn't
+        t.assert(not box.space.temp)
+
+        box.snapshot()
+    end)
+
+    check_wal_and_snap({})
+end

--- a/test/box-luatest/gh_5616_temp_space_truncate_ro_test.lua
+++ b/test/box-luatest/gh_5616_temp_space_truncate_ro_test.lua
@@ -21,7 +21,7 @@ g_single.after_each(function(cg)
     end)
 end)
 
--- Checks that a temporary space can be truncated in the read-only mode.
+-- Checks that a data-temporary space can be truncated in the read-only mode.
 g_single.test_temp_space_truncate_ro = function(cg)
     cg.server:exec(function()
         local s = box.schema.create_space('test', {temporary = true})
@@ -89,8 +89,8 @@ g_replication.after_each(function(cg)
     cg.replica:wait_for_vclock_of(cg.master)
 end)
 
--- Checks that a truncate operation for a temporary space isn't replicated to
--- a read-only replica.
+-- Checks that a truncate operation for a data-temporary space isn't replicated
+-- to a read-only replica.
 g_replication.test_temp_space_truncate_ro = function(cg)
     cg.master:exec(function()
         local s = box.schema.create_space('test', {temporary = true})

--- a/test/box/access.result
+++ b/test/box/access.result
@@ -1519,6 +1519,9 @@ box.schema.user.grant("tester", "read", "space", "_user")
 box.schema.user.grant("tester", "read", "space", "_func")
 ---
 ...
+box.schema.user.grant("tester", "read", "space", "_truncate")
+---
+...
 -- failed create
 box.session.su("tester")
 ---

--- a/test/box/access.test.lua
+++ b/test/box/access.test.lua
@@ -588,6 +588,7 @@ box.schema.func.create('test_func')
 box.session.su("admin")
 box.schema.user.grant("tester", "read", "space", "_user")
 box.schema.user.grant("tester", "read", "space", "_func")
+box.schema.user.grant("tester", "read", "space", "_truncate")
 -- failed create
 box.session.su("tester")
 box.schema.space.create("test_space")

--- a/test/box/access_misc.result
+++ b/test/box/access_misc.result
@@ -78,7 +78,7 @@ s:delete(1)
 ...
 s:drop()
 ---
-- error: Write access to space '_space_sequence' is denied for user 'testus'
+- error: Read access to space '_space_sequence' is denied for user 'testus'
 ...
 --
 -- Check double revoke
@@ -126,7 +126,7 @@ s:insert({3})
 ...
 s:drop()
 ---
-- error: Write access to space '_space_sequence' is denied for user 'testus'
+- error: Read access to space '_space_sequence' is denied for user 'testus'
 ...
 session.su('admin')
 ---
@@ -169,7 +169,7 @@ s:delete({3})
 ...
 s:drop()
 ---
-- error: Write access to space '_space_sequence' is denied for user 'guest'
+- error: Read access to space '_space_sequence' is denied for user 'guest'
 ...
 gs = box.schema.space.create('guest_space')
 ---

--- a/test/box/alter.result
+++ b/test/box/alter.result
@@ -1410,7 +1410,7 @@ s:alter({format = {{{1, 2, 3, 4}}}})
 - error: 'Illegal parameters, format[1]: name (string) is expected'
 ...
 --
--- Alter temporary.
+-- Alter data-temporary.
 --
 s:alter({temporary = true})
 ---

--- a/test/box/alter.result
+++ b/test/box/alter.result
@@ -102,7 +102,7 @@ _space:update({_space.id}, {{'-', 1, 2}})
 --
 -- Create a space
 --
-t = _space:insert{box.internal.generate_space_id(), ADMIN, 'hello', 'memtx', 0, EMPTY_MAP, {}}
+t = _space:insert{box.internal.generate_space_id(false), ADMIN, 'hello', 'memtx', 0, EMPTY_MAP, {}}
 ---
 ...
 -- Check that a space exists

--- a/test/box/alter.test.lua
+++ b/test/box/alter.test.lua
@@ -45,7 +45,7 @@ _space:update({_space.id}, {{'-', 1, 2}})
 --
 -- Create a space
 --
-t = _space:insert{box.internal.generate_space_id(), ADMIN, 'hello', 'memtx', 0, EMPTY_MAP, {}}
+t = _space:insert{box.internal.generate_space_id(false), ADMIN, 'hello', 'memtx', 0, EMPTY_MAP, {}}
 -- Check that a space exists
 space = box.space[t[1]]
 space.id

--- a/test/box/alter.test.lua
+++ b/test/box/alter.test.lua
@@ -560,7 +560,7 @@ s:alter({format = true})
 s:alter({format = {{{1, 2, 3, 4}}}})
 
 --
--- Alter temporary.
+-- Alter data-temporary.
 --
 s:alter({temporary = true})
 assert(s.temporary)

--- a/test/box/before_replace.result
+++ b/test/box/before_replace.result
@@ -834,7 +834,7 @@ s:drop()
 ---
 ...
 --
--- gh-4266 triggers on temporary space fail
+-- gh-4266 triggers on data-temporary space fail
 --
 s = box.schema.space.create('test', {temporary = true})
 ---

--- a/test/box/before_replace.test.lua
+++ b/test/box/before_replace.test.lua
@@ -293,7 +293,7 @@ save_type
 s:drop()
 
 --
--- gh-4266 triggers on temporary space fail
+-- gh-4266 triggers on data-temporary space fail
 --
 s = box.schema.space.create('test', {temporary = true})
 

--- a/test/box/errinj.result
+++ b/test/box/errinj.result
@@ -1401,7 +1401,7 @@ _ = box.space.test:create_index('pk')
 for i = 1, 100 do box.space.test:insert{i} end
 ---
 ...
--- Create a temporary space.
+-- Create a data-temporary space.
 count = 500
 ---
 ...
@@ -1428,7 +1428,7 @@ box.error.injection.set('ERRINJ_SNAP_WRITE_DELAY', true)
 _ = fiber.create(function() box.snapshot() c:put(true) end)
 ---
 ...
--- Overwrite data stored in the temporary space while snapshot
+-- Overwrite data stored in the data-temporary space while snapshot
 -- is in progress to make sure that tuples stored in it are freed
 -- immediately.
 for i = 1, count do box.space.tmp:delete{i} end

--- a/test/box/errinj.test.lua
+++ b/test/box/errinj.test.lua
@@ -468,7 +468,7 @@ _ = box.schema.space.create('test')
 _ = box.space.test:create_index('pk')
 for i = 1, 100 do box.space.test:insert{i} end
 
--- Create a temporary space.
+-- Create a data-temporary space.
 count = 500
 pad = string.rep('x', 100 * 1024)
 _ = box.schema.space.create('tmp', {temporary = true})
@@ -480,7 +480,7 @@ c = fiber.channel(1)
 box.error.injection.set('ERRINJ_SNAP_WRITE_DELAY', true)
 _ = fiber.create(function() box.snapshot() c:put(true) end)
 
--- Overwrite data stored in the temporary space while snapshot
+-- Overwrite data stored in the data-temporary space while snapshot
 -- is in progress to make sure that tuples stored in it are freed
 -- immediately.
 for i = 1, count do box.space.tmp:delete{i} end

--- a/test/box/on_replace.result
+++ b/test/box/on_replace.result
@@ -749,7 +749,7 @@ s:drop()
 ---
 ...
 --
--- gh-4266 triggers on temporary space fail
+-- gh-4266 triggers on data-temporary space fail
 --
 s = box.schema.space.create('test', {temporary = true})
 ---

--- a/test/box/on_replace.test.lua
+++ b/test/box/on_replace.test.lua
@@ -299,7 +299,7 @@ save_type
 s:drop()
 
 --
--- gh-4266 triggers on temporary space fail
+-- gh-4266 triggers on data-temporary space fail
 --
 s = box.schema.space.create('test', {temporary = true})
 

--- a/test/box/stat.result
+++ b/test/box/stat.result
@@ -33,6 +33,11 @@ box.stat.ERROR.total
 space = box.schema.space.create('tweedledum')
 ---
 ...
+-- create_space performs a select when choosing a new space id
+box.stat.SELECT.total
+---
+- 1
+...
 index = space:create_index('primary', { type = 'hash' })
 ---
 ...
@@ -59,7 +64,7 @@ box.stat.REPLACE.total
 ...
 box.stat.SELECT.total
 ---
-- 4
+- 5
 ...
 -- check exceptions
 space:get('Impossible value')
@@ -77,14 +82,14 @@ space:get(1)
 ...
 box.stat.SELECT.total
 ---
-- 5
+- 6
 ...
 space:get(11)
 ---
 ...
 box.stat.SELECT.total
 ---
-- 6
+- 7
 ...
 space:select(5)
 ---
@@ -92,7 +97,7 @@ space:select(5)
 ...
 box.stat.SELECT.total
 ---
-- 7
+- 8
 ...
 space:select(15)
 ---
@@ -100,14 +105,14 @@ space:select(15)
 ...
 box.stat.SELECT.total
 ---
-- 8
+- 9
 ...
 for _ in space:pairs() do end
 ---
 ...
 box.stat.SELECT.total
 ---
-- 9
+- 10
 ...
 -- reset
 box.stat.reset()

--- a/test/box/stat.test.lua
+++ b/test/box/stat.test.lua
@@ -11,6 +11,9 @@ box.stat.SELECT.total
 box.stat.ERROR.total
 
 space = box.schema.space.create('tweedledum')
+-- create_space performs a select when choosing a new space id
+box.stat.SELECT.total
+
 index = space:create_index('primary', { type = 'hash' })
 
 -- check stat_cleanup

--- a/test/box/temp_spaces.result
+++ b/test/box/temp_spaces.result
@@ -1,8 +1,8 @@
--- temporary spaces
+-- data-temporary spaces
 _space = box.space._space
 ---
 ...
--- not a temporary
+-- not a data-temporary
 FLAGS = 6
 ---
 ...
@@ -16,7 +16,7 @@ s.temporary
 s:drop()
 ---
 ...
--- not a temporary, too
+-- not a data-temporary, too
 s = box.schema.space.create('t', { temporary = false })
 ---
 ...
@@ -27,7 +27,7 @@ s.temporary
 s:drop()
 ---
 ...
--- not a temporary, too
+-- not a data-temporary, too
 s = box.schema.space.create('t', { temporary = nil })
 ---
 ...
@@ -65,14 +65,14 @@ s.temporary
 ...
 _ = _space:update(s.id, {{'=', FLAGS, {temporary = false}}})
 ---
-- error: 'Can''t modify space ''t'': can not switch temporary flag on a non-empty
+- error: 'Can''t modify space ''t'': can not change data-temporariness on a non-empty
     space'
 ...
 s.temporary
 ---
 - true
 ...
--- check that temporary space can be modified in read-only mode (gh-1378)
+-- check that data-temporary space can be modified in read-only mode (gh-1378)
 box.cfg{read_only=true}
 ---
 ...

--- a/test/box/temp_spaces.test.lua
+++ b/test/box/temp_spaces.test.lua
@@ -1,17 +1,17 @@
--- temporary spaces
+-- data-temporary spaces
 _space = box.space._space
--- not a temporary
+-- not a data-temporary
 FLAGS = 6
 s = box.schema.space.create('t', { temporary = true })
 s.temporary
 s:drop()
 
--- not a temporary, too
+-- not a data-temporary, too
 s = box.schema.space.create('t', { temporary = false })
 s.temporary
 s:drop()
 
--- not a temporary, too
+-- not a data-temporary, too
 s = box.schema.space.create('t', { temporary = nil })
 s.temporary
 s:drop()
@@ -28,7 +28,7 @@ s.temporary
 _ = _space:update(s.id, {{'=', FLAGS, {temporary = false}}})
 s.temporary
 
--- check that temporary space can be modified in read-only mode (gh-1378)
+-- check that data-temporary space can be modified in read-only mode (gh-1378)
 box.cfg{read_only=true}
 box.cfg.read_only
 s:insert{2, 3, 4}

--- a/test/engine-luatest/gh_8936_foreign_key_wrong_reference_test.lua
+++ b/test/engine-luatest/gh_8936_foreign_key_wrong_reference_test.lua
@@ -1,5 +1,5 @@
 -- https://github.com/tarantool/tarantool/issues/8936
--- Test foreign keys to temporary and local spaces.
+-- Test foreign keys to data-temporary and local spaces.
 local server = require('luatest.server')
 local t = require('luatest')
 
@@ -37,7 +37,7 @@ g.after_each(function(cg)
     end)
 end)
 
--- Foreign key must not refer to temporary space from normal space.
+-- Foreign key must not refer to data-temporary space from normal space.
 g.test_field_foreign_key_temporary = function(cg)
     local engine = cg.params.engine
     local country_is_temporary = cg.params.country_variant
@@ -46,7 +46,8 @@ g.test_field_foreign_key_temporary = function(cg)
     t.skip_if(engine == 'vinyl')
 
     cg.server:exec(function(engine, country_is_temporary, city_is_temporary)
-        -- foreign key must not point for non-temporary to temporary space.
+        -- foreign key must not point for non-data-temporary to data-temporary
+        -- space.
         local must_be_prohibited =
             country_is_temporary and not city_is_temporary
 
@@ -72,8 +73,8 @@ g.test_field_foreign_key_temporary = function(cg)
         if must_be_prohibited then
             t.assert_error_msg_content_equals(
                 "Failed to create foreign key 'country' in space 'city': " ..
-                "foreign key from non-temporary space " ..
-                "can't refer to temporary space",
+                "foreign key from non-data-temporary space " ..
+                "can't refer to data-temporary space",
                 box.schema.create_space, 'city', city_opts
             )
             return nil
@@ -87,8 +88,8 @@ g.test_field_foreign_key_temporary = function(cg)
         if country_is_temporary and city_is_temporary then
             t.assert_error_msg_content_equals(
                 "Failed to create foreign key 'country' in space 'city': " ..
-                "foreign key from non-temporary space " ..
-                "can't refer to temporary space",
+                "foreign key from non-data-temporary space " ..
+                "can't refer to data-temporary space",
                 city.alter, city, {temporary = false}
             )
             country:alter{temporary = false}
@@ -97,7 +98,8 @@ g.test_field_foreign_key_temporary = function(cg)
         if not country_is_temporary and not city_is_temporary then
             t.assert_error_msg_content_equals(
                 "Can't modify space 'country': foreign key 'country' from " ..
-                "non-temporary space 'city' can't refer to temporary space",
+                "non-data-temporary space 'city' can't refer to " ..
+                "data-temporary space",
                 country.alter, country, {temporary = true}
             )
             city:alter{temporary = true}
@@ -142,7 +144,8 @@ g.test_field_foreign_key_local = function(cg)
     local city_is_local = cg.params.city_variant
 
     cg.server:exec(function(engine, country_is_local, city_is_local)
-        -- foreign key must not point for non-temporary to temporary space.
+        -- foreign key must not point for non-data-temporary to data-temporary
+        -- space.
         local must_be_prohibited =
             country_is_local and not city_is_local
 

--- a/test/replication/local_spaces.result
+++ b/test/replication/local_spaces.result
@@ -55,8 +55,8 @@ box.space._space:insert{9000, 1, 'test', engine, 0, {group_id = 2}, {}} -- error
 ---
 - error: Replication group '2' does not exist
 ...
--- Temporary local spaces should behave in the same fashion as
--- plain temporary spaces, i.e. neither replicated nor persisted.
+-- Data-temporary local spaces should behave in the same fashion as
+-- plain data-temporary spaces, i.e. neither replicated nor persisted.
 s3 = box.schema.space.create('test3', {is_local = true, temporary = true})
 ---
 ...
@@ -71,7 +71,7 @@ s3.temporary
 ---
 - true
 ...
--- gh-4263 The truncation of the local & temporary space
+-- gh-4263 The truncation of the local & data-temporary space
 -- should not spread among the replicas
 s4 = box.schema.space.create('test4', {is_local = true})
 ---

--- a/test/replication/local_spaces.test.lua
+++ b/test/replication/local_spaces.test.lua
@@ -26,14 +26,14 @@ box.space._space:update(s2.id, {{'=', 6, {group_id = 0}}}) -- error
 -- 0 (global) and 1 (local)
 box.space._space:insert{9000, 1, 'test', engine, 0, {group_id = 2}, {}} -- error
 
--- Temporary local spaces should behave in the same fashion as
--- plain temporary spaces, i.e. neither replicated nor persisted.
+-- Data-temporary local spaces should behave in the same fashion as
+-- plain data-temporary spaces, i.e. neither replicated nor persisted.
 s3 = box.schema.space.create('test3', {is_local = true, temporary = true})
 _ = s3:create_index('pk')
 s3.is_local
 s3.temporary
 
--- gh-4263 The truncation of the local & temporary space
+-- gh-4263 The truncation of the local & data-temporary space
 -- should not spread among the replicas
 s4 = box.schema.space.create('test4', {is_local = true})
 _ = s4:create_index('pk')

--- a/test/sql/misc.result
+++ b/test/sql/misc.result
@@ -136,7 +136,7 @@ box.execute('SELECT X\'4D6564766564\'')
   - [!!binary TWVkdmVk]
 ...
 --
--- gh-4139: assertion when reading a temporary space.
+-- gh-4139: assertion when reading a data-temporary space.
 --
 format = {{name = 'id', type = 'integer'}}
 ---

--- a/test/sql/misc.test.lua
+++ b/test/sql/misc.test.lua
@@ -31,7 +31,7 @@ box.execute('SELECT \'abc\';')
 box.execute('SELECT X\'4D6564766564\'')
 
 --
--- gh-4139: assertion when reading a temporary space.
+-- gh-4139: assertion when reading a data-temporary space.
 --
 format = {{name = 'id', type = 'integer'}}
 s = box.schema.space.create('s',{format=format, temporary=true})

--- a/test/unit/memtx_allocator.cc
+++ b/test/unit/memtx_allocator.cc
@@ -318,7 +318,7 @@ test_temp_tuple_gc()
 	struct tuple *tuple12 = alloc_tuple();
 	struct tuple *tuple13 = alloc_tuple();
 	struct tuple *tuple14 = alloc_tuple();
-	opts.enable_temporary_spaces = false;
+	opts.enable_data_temporary_spaces = false;
 	memtx_allocators_read_view rv1 = memtx_allocators_open_read_view(&opts);
 	is(alloc_tuple_count(), 8, "count after rv1 opened");
 	free_tuple(temp_tuple11);
@@ -329,7 +329,7 @@ test_temp_tuple_gc()
 	struct tuple *tuple22 = alloc_tuple();
 	struct tuple *tuple23 = alloc_tuple();
 	struct tuple *tuple24 = alloc_tuple();
-	opts.enable_temporary_spaces = true;
+	opts.enable_data_temporary_spaces = true;
 	memtx_allocators_read_view rv2 = memtx_allocators_open_read_view(&opts);
 	/* temp_tuple11 is freed */
 	is(alloc_tuple_count(), 13, "count after rv2 opened");
@@ -341,7 +341,7 @@ test_temp_tuple_gc()
 	struct tuple *temp_tuple34 = alloc_temp_tuple();
 	struct tuple *tuple33 = alloc_tuple();
 	struct tuple *tuple34 = alloc_tuple();
-	opts.enable_temporary_spaces = false;
+	opts.enable_data_temporary_spaces = false;
 	memtx_allocators_read_view rv3 = memtx_allocators_open_read_view(&opts);
 	is(alloc_tuple_count(), 17, "count after rv3 opened");
 	free_tuple(temp_tuple13);
@@ -352,7 +352,7 @@ test_temp_tuple_gc()
 	free_tuple(tuple33);
 	struct tuple *temp_tuple44 = alloc_temp_tuple();
 	struct tuple *tuple44 = alloc_tuple();
-	opts.enable_temporary_spaces = true;
+	opts.enable_data_temporary_spaces = true;
 	memtx_allocators_read_view rv4 = memtx_allocators_open_read_view(&opts);
 	/* temp_tuple33 is freed */
 	is(alloc_tuple_count(), 18, "count after rv4 opened");
@@ -402,14 +402,14 @@ test_reuse_read_view()
 	is(alloc_tuple_count(), 0, "count before alloc");
 	struct tuple *tuple1 = alloc_tuple();
 	struct tuple *temp_tuple1 = alloc_temp_tuple();
-	opts.enable_temporary_spaces = false;
+	opts.enable_data_temporary_spaces = false;
 	memtx_allocators_read_view rv1 = memtx_allocators_open_read_view(&opts);
 	is(alloc_tuple_count(), 2, "count after rv1 opened");
 	free_tuple(tuple1);
 	free_tuple(temp_tuple1);
 	struct tuple *tuple2 = alloc_tuple();
 	struct tuple *temp_tuple2 = alloc_temp_tuple();
-	opts.enable_temporary_spaces = true;
+	opts.enable_data_temporary_spaces = true;
 	memtx_allocators_read_view rv2 = memtx_allocators_open_read_view(&opts);
 	/* temp_tuple1 is freed */
 	is(alloc_tuple_count(), 3, "count after rv2 opened");
@@ -417,21 +417,21 @@ test_reuse_read_view()
 	free_tuple(temp_tuple2);
 	struct tuple *tuple3 = alloc_tuple();
 	struct tuple *temp_tuple3 = alloc_temp_tuple();
-	opts.enable_temporary_spaces = true;
+	opts.enable_data_temporary_spaces = true;
 	memtx_allocators_read_view rv3 = memtx_allocators_open_read_view(&opts);
 	is(alloc_tuple_count(), 5, "count after rv3 opened");
 	free_tuple(tuple3);
 	free_tuple(temp_tuple3);
 	struct tuple *tuple4 = alloc_tuple();
 	struct tuple *temp_tuple4 = alloc_temp_tuple();
-	opts.enable_temporary_spaces = false;
+	opts.enable_data_temporary_spaces = false;
 	memtx_allocators_read_view rv4 = memtx_allocators_open_read_view(&opts);
 	is(alloc_tuple_count(), 7, "count after rv4 opened");
 	free_tuple(tuple4);
 	free_tuple(temp_tuple4);
 	struct tuple *tuple5 = alloc_tuple();
 	struct tuple *temp_tuple5 = alloc_temp_tuple();
-	opts.enable_temporary_spaces = false;
+	opts.enable_data_temporary_spaces = false;
 	memtx_allocators_read_view rv5 = memtx_allocators_open_read_view(&opts);
 	is(alloc_tuple_count(), 9, "count after rv5 opened");
 	free_tuple(tuple5);
@@ -439,7 +439,7 @@ test_reuse_read_view()
 	thread_sleep(0.2);
 	struct tuple *tuple6 = alloc_tuple();
 	struct tuple *temp_tuple6 = alloc_temp_tuple();
-	opts.enable_temporary_spaces = true;
+	opts.enable_data_temporary_spaces = true;
 	memtx_allocators_read_view rv6 = memtx_allocators_open_read_view(&opts);
 	is(alloc_tuple_count(), 11, "count after rv6 opened");
 	free_tuple(tuple6);
@@ -447,7 +447,7 @@ test_reuse_read_view()
 	thread_sleep(0.2);
 	struct tuple *tuple7 = alloc_tuple();
 	struct tuple *temp_tuple7 = alloc_temp_tuple();
-	opts.enable_temporary_spaces = false;
+	opts.enable_data_temporary_spaces = false;
 	memtx_allocators_read_view rv7 = memtx_allocators_open_read_view(&opts);
 	is(alloc_tuple_count(), 13, "count after rv7 opened");
 	free_tuple(tuple7);

--- a/test/vinyl/gh.result
+++ b/test/vinyl/gh.result
@@ -72,10 +72,10 @@ s:insert{'a'}
 s:drop()
 ---
 ...
--- gh-436: No error when creating temporary vinyl space
+-- gh-436: No error when creating data-temporary vinyl space
 s = box.schema.space.create('tester',{engine='vinyl', temporary=true})
 ---
-- error: 'Can''t modify space ''tester'': engine does not support temporary flag'
+- error: 'Can''t modify space ''tester'': engine does not support data-temporary spaces'
 ...
 -- gh-432: ignored limit
 s = box.schema.space.create('tester',{engine='vinyl'})

--- a/test/vinyl/gh.test.lua
+++ b/test/vinyl/gh.test.lua
@@ -29,7 +29,7 @@ s:insert{'a'}
 s:drop()
 
 
--- gh-436: No error when creating temporary vinyl space
+-- gh-436: No error when creating data-temporary vinyl space
 s = box.schema.space.create('tester',{engine='vinyl', temporary=true})
 
 


### PR DESCRIPTION
Introduce meta-temporary spaces: same as temporary space but with temporary metadata. Basically meta-temporary spaces do not exist on restart and do not exist on replicas. They can also be created, altered and deleted when box.cfg.read_only = true.

To avoid conflicts with spaces created on replicas, the meta-temporary space ids by default start in a special range starting at BOX_SPACE_ID_META_TEMPORARY_MIN.

Meta-temporary spaces currently do not support several features e.g. foreign key references (to and from), functional indexes, sql sequences, sql triggers, etc. This may change in the future.

Implementing meta-temporary spaces requires temporary tuples to be inserted into system spaces: tuples which are neither replicated or persisted. These are implemented in a general way using a new skip_wal flag in the request struct, which can be passed into the new box_request_process public api for processing DML requests. Effectively this commit introduces an ability to make temporary records into any space, but it is currently only intended for creation, alteration and deletion of meta-temporary spaces, their indexes and a few other entities.

Closes #8323 

@TarantoolBot document
Title: Introduce meta-temporary spaces with temporary metadata

Meta-temporary spaces are temporary spaces with temporary metadata. Meta-temporary spaces will not exist upon server restart and will not exist on replicas. They can also be created on a read-only instance.