### PR TITLE
datetime: implement comparison operations of datetime to string

### DIFF
--- a/changelogs/unreleased/gh-7445-datetime-string-comparison.md
+++ b/changelogs/unreleased/gh-7445-datetime-string-comparison.md
@@ -1,0 +1,3 @@
+## feature/datetime
+
+* Implemented comparison of datetime object with string (gh-7445).

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -186,6 +186,10 @@ local function is_table(o)
     return type(o) == 'table'
 end
 
+local function is_string(o)
+    return type(o) == 'string'
+end
+
 local function check_date(o, message)
     if not is_datetime(o) then
         return error(("%s: expected datetime, but received %s"):
@@ -395,30 +399,6 @@ end
 -- since Rata Die date)
 local function local_dt(obj)
     return builtin.tnt_dt_from_rdn(local_rd(local_secs(obj)))
-end
-
-local function datetime_cmp(lhs, rhs, is_raising)
-    if not is_datetime(lhs) or not is_datetime(rhs) then
-        if is_raising then
-            error('incompatible types for datetime comparison', 3)
-        else
-            return nil
-        end
-    end
-    local sdiff = lhs.epoch - rhs.epoch
-    return sdiff ~= 0 and sdiff or (lhs.nsec - rhs.nsec)
-end
-
-local function datetime_eq(lhs, rhs)
-    return datetime_cmp(lhs, rhs, false) == 0
-end
-
-local function datetime_lt(lhs, rhs)
-    return datetime_cmp(lhs, rhs, true) < 0
-end
-
-local function datetime_le(lhs, rhs)
-    return datetime_cmp(lhs, rhs, true) <= 0
 end
 
 --[[
@@ -872,19 +852,24 @@ end
        date [T] time [ ] time_zone
     Returns constructed datetime object and length of accepted string.
 ]]
-local function datetime_parse_full(str, tzname, offset)
+local function datetime_parse_full(str, tzname, offset, parse_fully)
     check_str(str, 'datetime.parse()')
     local date = ffi.new(datetime_t)
     local len = builtin.tnt_datetime_parse_full(date, str, #str, tzname, offset)
     if len > 0 then
-        return date, tonumber(len)
+        if parse_fully and len ~= #str then
+            goto couldnot_parse_fully
+        else
+            return date, tonumber(len)
+        end
     elseif len == -builtin.TZ_NYI then
         error(("could not parse '%s' - nyi timezone"):format(str))
     elseif len == -builtin.TZ_AMBIGUOUS then
         error(("could not parse '%s' - ambiguous timezone"):format(str))
-    else -- len <= 0
-        error(("could not parse '%s'"):format(str))
     end
+    -- len <= 0 or partially parsed
+::couldnot_parse_fully::
+    error(("could not parse '%s'"):format(str))
 end
 
 --[[
@@ -930,6 +915,36 @@ local function datetime_parse_from(str, obj)
     else
         return datetime_parse_format(str, fmt)
     end
+end
+
+local function datetime_cmp(lhs, rhs, is_raising)
+    if is_string(lhs) then
+        lhs = datetime_parse_full(lhs, nil, 0, true)
+    end
+    if is_string(rhs) then
+        rhs = datetime_parse_full(rhs, nil, 0, true)
+    end
+    if not is_datetime(lhs) or not is_datetime(rhs) then
+        if is_raising then
+            error('incompatible types for datetime comparison', 3)
+        else
+            return nil
+        end
+    end
+    local sdiff = lhs.epoch - rhs.epoch
+    return sdiff ~= 0 and sdiff or (lhs.nsec - rhs.nsec)
+end
+
+local function datetime_eq(lhs, rhs)
+    return datetime_cmp(lhs, rhs, false) == 0
+end
+
+local function datetime_lt(lhs, rhs)
+    return datetime_cmp(lhs, rhs, true) < 0
+end
+
+local function datetime_le(lhs, rhs)
+    return datetime_cmp(lhs, rhs, true) <= 0
 end
 
 --[[


### PR DESCRIPTION
Both `uuid` and `decimal` implement comparison operations of their objects with string literals, but `datetime` object was incompatible with that.

For consistency reasons, implement it similarly:
- equality operators (== and ~=) are silently compared with strings and if we could parse then we compare datetime values, if we could not parse then silently return false;
- all other operators (<, <=, >, >=) are _raising_, i.e. they will raise error if they could not parse given operand according to the extended ISO-8601 format.

```
tarantool> datetime.parse('2022-07-20T11:51:57.531005+0300') ==
'2022-07-20T11:51:57.531005+0300'
---
- true
...
```

Closes #7445
