### PR TITLE
compat: make compat a top level module

### DIFF
--- a/changelogs/unreleased/gh-3012-yaml-prettier-multiline-output.md
+++ b/changelogs/unreleased/gh-3012-yaml-prettier-multiline-output.md
@@ -1,5 +1,5 @@
 ## feature/yaml
 
-* Now `yaml.encode` can encode multiline strings in literal-scalar style
-  for better readability. A new `tarantool.compat` option `yaml_pretty_multiline`
-  is added for switching to the new behavior (gh-3012).
+* Now `yaml.encode` can encode multiline strings in literal-scalar style for
+  better readability. A new `compat` option `yaml_pretty_multiline` is added
+  for switching to the new behavior (gh-3012).

--- a/changelogs/unreleased/gh-6200-lua_cjson-encode-escapes-slash.md
+++ b/changelogs/unreleased/gh-6200-lua_cjson-encode-escapes-slash.md
@@ -1,6 +1,6 @@
 ## bugfix/lua/json
 
-* A new `tarantool.compat` option `json_escape_forward_slash` was added. This
-  option configures whether the internal JSON encoder escapes the forward slash
+* A new `compat` option `json_escape_forward_slash` was added. This option
+  configures whether the internal JSON encoder escapes the forward slash
   character (old behavior) or not (new behavior). This option affects the
   `json.encode()` Lua function and the JSON logger (gh-6200).

--- a/changelogs/unreleased/gh-7000-compat-module.md
+++ b/changelogs/unreleased/gh-7000-compat-module.md
@@ -1,9 +1,8 @@
 ## feature/lua
 
-* Introduced the Tarantool compatibility module `tarantool.compat`.
-  It is used for transparent management of behavior changes.
-  `tarantool.compat` stores options that reflect behavior changes. Possible
-  option values are `old`, `new`, and `default`. By default, `tarantool.compat`
-  contains options for certain Tarantool changes that may break compatibility
-  with previous versions. Users can also add their own compatibility options in
-  runtime (gh-7000).
+* Introduced the Tarantool compatibility module `compat`. It is used for
+  transparent management of behavior changes. `compat` stores options that
+  reflect behavior changes. Possible option values are `old`, `new`, and
+  `default`. By default, `compat` contains options for certain Tarantool
+  changes that may break compatibility with previous versions. Users can also
+  add their own compatibility options in runtime (gh-7000).

--- a/changelogs/unreleased/gh-7746-fiber-channel-graceful-close.md
+++ b/changelogs/unreleased/gh-7746-fiber-channel-graceful-close.md
@@ -4,5 +4,6 @@
   for writing leaving the possibility to read existing events from it.
   Previously, `channel:close()` was closing the channel completely and
   discarding all unread events.
-  A new `tarantool.compat` option `fiber_channel_close_mode`
-  is added for switching to the new behavior (gh-7746).
+
+  A new `compat` option `fiber_channel_close_mode` is added for switching to
+  the new behavior (gh-7746).

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -7,7 +7,7 @@ local urilib = require('uri')
 local math = require('math')
 local fiber = require('fiber')
 local fio = require('fio')
-local compat = require('tarantool').compat
+local compat = require('compat')
 
 local function nop() end
 

--- a/src/lua/compat.lua
+++ b/src/lua/compat.lua
@@ -1,5 +1,5 @@
--- compat.lua -- internal module intended to solve compatibility problems in
--- different parts of Tarantool. Introduced in gh-7000, see also gh-6912.
+-- compat.lua -- module intended to solve compatibility problems in different
+-- parts of Tarantool. Introduced in gh-7000, see also gh-6912.
 
 local NEW = true
 local OLD = false
@@ -235,7 +235,7 @@ function compat.dump(mode)
     else
         error("usage: compat.dump('new'/'old'/'default'/'current'/nil)")
     end
-    local result = [[require('tarantool').compat({]]
+    local result = [[require('compat')({]]
     local max_key_len = 0
     for _, key in pairs(options_order) do
         max_key_len = (#key > max_key_len) and #key or max_key_len

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -273,7 +273,7 @@ extern char minifio_lua[],
 static const char *lua_modules[] = {
 	/* Make it first to affect load of all other modules */
 	"strict", strict_lua,
-	"internal.compat", compat_lua,
+	"compat", compat_lua,
 	"fun", fun_lua,
 	"debug", debug_lua,
 	"tarantool", init_lua,

--- a/src/lua/init.lua
+++ b/src/lua/init.lua
@@ -3,7 +3,6 @@
 
 local ffi = require('ffi')
 local loaders = require('internal.loaders')
-local compat = require('internal.compat')
 
 ffi.cdef[[
 struct method_info;
@@ -215,7 +214,6 @@ local mt = {
 return setmetatable({
     uptime = uptime,
     pid = pid,
-    compat = compat,
     _internal = {
         strip_cwd_from_path = strip_cwd_from_path,
         module_name_from_filename = module_name_from_filename,

--- a/test/app-luatest/gh_3012_yaml_prettier_multiline_output_test.lua
+++ b/test/app-luatest/gh_3012_yaml_prettier_multiline_output_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 local function server_test_encode()
-    local compat = require('tarantool').compat
+    local compat = require('compat')
     local yaml = require('yaml')
 
     local str = 'Title: xxx\n - Item 1\n - Item 2\n'

--- a/test/app-luatest/gh_6200_lua_cjson_escapes_slash_test.lua
+++ b/test/app-luatest/gh_6200_lua_cjson_escapes_slash_test.lua
@@ -2,7 +2,7 @@ local server = require('luatest.server')
 local t = require('luatest')
 
 local function server_test_json_encode()
-    local compat = require('tarantool').compat
+    local compat = require('compat')
     local json = require('json')
 
     -- Test that '/' is escaped with default setting.
@@ -44,7 +44,7 @@ local function server_test_json_encode()
 end
 
 local function server_test_json_new_encode()
-    local compat = require('tarantool').compat
+    local compat = require('compat')
     local json = require('json')
 
     compat.json_escape_forward_slash = 'old'
@@ -83,7 +83,7 @@ local function popen_test_json_log()
     t.assert(ph, 'process is not up')
 
     -- Set up compat and log.cfg.
-    ph:write('require("tarantool").compat.json_escape_forward_slash = "old"\n')
+    ph:write('require("compat").json_escape_forward_slash = "old"\n')
     ph:write('require("log").cfg{format = "json"}\n')
 
     -- Test old log.info behavior.
@@ -101,7 +101,7 @@ local function popen_test_json_log()
 
     t.assert_str_contains(output, '"message": "\\/"')
 
-    ph:write('require("tarantool").compat.json_escape_forward_slash = "new"\n')
+    ph:write('require("compat").json_escape_forward_slash = "new"\n')
     start_time = clock.monotonic();
     output = ''
     -- Test new log.info behavior.

--- a/test/app-luatest/gh_7000_compat_module_test.lua
+++ b/test/app-luatest/gh_7000_compat_module_test.lua
@@ -1,5 +1,5 @@
 local t = require('luatest')
-local compat = require('tarantool').compat
+local compat = require('compat')
 
 local g = t.group()
 

--- a/test/app-luatest/gh_7746_fiber_channel_close_test.lua
+++ b/test/app-luatest/gh_7746_fiber_channel_close_test.lua
@@ -16,7 +16,7 @@ local function server_test_channel_close_default()
 end
 
 local function server_test_channel_close(mode)
-    local compat = require('tarantool').compat
+    local compat = require('compat')
     local fiber = require('fiber')
 
     -- Graceful close (new) selected.
@@ -44,7 +44,7 @@ local function server_test_channel_close(mode)
 end
 
 local server_test_close_reader_payload = function(mode)
-    local compat = require('tarantool').compat
+    local compat = require('compat')
     local fiber = require('fiber')
 
     compat.fiber_channel_close_mode = mode
@@ -77,7 +77,7 @@ local server_test_close_reader_payload = function(mode)
 end
 
 local server_test_close_writer_payload = function(mode)
-    local compat = require('tarantool').compat
+    local compat = require('compat')
     local fiber = require('fiber')
 
     compat.fiber_channel_close_mode = mode


### PR DESCRIPTION
Now it is accessible using `require('compat')` instead of `require('tarantool').compat`.

It follows our usual way to expose built-in modules.

It was not done initially due to doubts about projects, which have its own `myproject/compat.lua` and have modified `package.loaded` to obtain the project's compat as `require('compat')`.

It is not recommended and should be avoided. Project's modules should be imported using `require('myproject.<...>')`. Otherwise it may clash with a future built-in module or any external one.

Follows up #7000