### PR TITLE
upgrade: enable system triggers back on errors

### DIFF
--- a/src/box/lua/upgrade.lua
+++ b/src/box/lua/upgrade.lua
@@ -104,6 +104,15 @@ local function set_system_triggers(val)
     foreach_system_space(function(s) s:run_triggers(val) end)
 end
 
+local function with_disabled_system_triggers(func)
+    set_system_triggers(false)
+    local status, err = pcall(func)
+    set_system_triggers(true)
+    if not status then
+        error(err)
+    end
+end
+
 -- Clears formats of all system spaces. It is used to disable system space
 -- format checking before creation of a bootstrap snapshot.
 local function clear_system_formats()
@@ -1561,18 +1570,18 @@ local function restore_sql_builtin_functions(issue_handler)
     local _func = box.space._func
     -- Otherwise we can't insert SQL_BUILTIN function. It is prohibited
     -- to add since 2.9.0.
-    set_system_triggers(false)
-    for _, func in ipairs(sql_builtin_list) do
-        if _func.index.name:get(func) == nil then
-            local t = _func:auto_increment{
-                ADMIN, func, 1, 'SQL_BUILTIN', '', 'function', {}, 'any',
-                'none', 'none', false, false, true, {}, setmap({}), '',
-                datetime, datetime}
-            box.space._priv:replace{ADMIN, PUBLIC, 'function', t.id,
-                                    box.priv.X}
+    with_disabled_system_triggers(function()
+        for _, func in ipairs(sql_builtin_list) do
+            if _func.index.name:get(func) == nil then
+                local t = _func:auto_increment{
+                    ADMIN, func, 1, 'SQL_BUILTIN', '', 'function', {}, 'any',
+                    'none', 'none', false, false, true, {}, setmap({}), '',
+                    datetime, datetime}
+                box.space._priv:replace{ADMIN, PUBLIC, 'function', t.id,
+                                        box.priv.X}
+            end
         end
-    end
-    set_system_triggers(true)
+    end)
 end
 
 local function downgrade_from_2_9_1(issue_handler)
@@ -1701,14 +1710,14 @@ local function drop_vspace_sequence_space(issue_handler)
     box.space._priv:delete{PUBLIC, 'space', box.schema.VSPACE_SEQUENCE_ID}
     local indexes = box.space._index:select(box.schema.VSPACE_SEQUENCE_ID)
     -- Otherwise we can't drop neither the primary index nor the space.
-    set_system_triggers(false)
-    for _, index in pairs(indexes) do
-        log.info("drop index %s on _vspace_sequence", index[3])
-        box.space._index:delete{index[1], index[2]}
-    end
-    log.info("drop view _vspace_sequence")
-    box.space._space:delete{box.schema.VSPACE_SEQUENCE_ID}
-    set_system_triggers(true)
+    with_disabled_system_triggers(function()
+        for _, index in pairs(indexes) do
+            log.info("drop index %s on _vspace_sequence", index[3])
+            box.space._index:delete{index[1], index[2]}
+        end
+        log.info("drop view _vspace_sequence")
+        box.space._space:delete{box.schema.VSPACE_SEQUENCE_ID}
+    end)
 end
 
 local function downgrade_from_2_10_5(issue_handler)
@@ -1938,16 +1947,16 @@ local function bootstrap()
     -- sequence, we clear all formats so that we can insert any data
     -- into system spaces and reset them back after we're done.
     clear_system_formats()
-    set_system_triggers(false)
 
-    -- erase current schema
-    erase()
-    -- insert initial schema
-    initial_1_7_5()
-    -- upgrade schema to the latest version
-    upgrade_from(mkversion(1, 7, 5))
+    with_disabled_system_triggers(function()
+        -- erase current schema
+        erase()
+        -- insert initial schema
+        initial_1_7_5()
+        -- upgrade schema to the latest version
+        upgrade_from(mkversion(1, 7, 5))
+    end)
 
-    set_system_triggers(true)
     reset_system_formats()
 
     -- save new bootstrap.snap


### PR DESCRIPTION
Sometimes we need to disable system triggers to perform a tricky change in system spaces. Later we enable them back. But in case of error in between we miss the enabling. With system triggers off the application behaviour will be quite surpising. Let's fix it.

Follow-up #7718

NO_DOC=minor
NO_TEST=minor
NO_CHANGELOG=minor