### PR TITLE
log: allow "tarantool" as module name in `box.cfg{log_modules = {...}}`

### DIFF
--- a/src/lib/core/say.c
+++ b/src/lib/core/say.c
@@ -51,8 +51,9 @@
 
 pid_t log_pid = 0;
 /**
- * It is calculated as MAX(level, log_level_flightrec) where level - is log
- * level value to be set.
+ * The global log level. Used as an optimization by the say() macro to
+ * avoid unnecessary calls to say_default().
+ * Calculated as MAX(log_default->level, log_level_flightrec).
  */
 int log_level = S_INFO;
 /**

--- a/src/lua/log.lua
+++ b/src/lua/log.lua
@@ -334,7 +334,8 @@ local log_initialized = false
 -- Convert cfg options to types suitable for ffi say_ functions.
 local function log_C_cfg(cfg)
     local cfg_C = table.copy(cfg)
-    cfg_C.level = log_normalize_level(cfg.level)
+    local level = cfg.modules and cfg.modules.tarantool or cfg.level
+    cfg_C.level = log_normalize_level(level)
     local nonblock
     if cfg.nonblock ~= nil then
         nonblock = cfg.nonblock and 1 or 0


### PR DESCRIPTION
Currently it's possible to set the log level for a particular Lua module, or to change the default log level, however there is no way to change it only for Tarantool system messages. This patch introduces a fake module name "tarantool" for this purpose.

Closes #8320