### PR TITLE
lua: search modules next to the main script

### DIFF
--- a/changelogs/unreleased/gh-8182-module-search-next-to-script.md
+++ b/changelogs/unreleased/gh-8182-module-search-next-to-script.md
@@ -1,0 +1,3 @@
+## feature/lua
+
+*  Default module search paths now include the main script directory (gh-8182).

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -835,7 +835,8 @@ luaT_set_module_from_source(struct lua_State *L, const char *modname,
 }
 
 void
-tarantool_lua_init(const char *tarantool_bin, int argc, char **argv)
+tarantool_lua_init(const char *tarantool_bin, const char *script, int argc,
+		   char **argv)
 {
 	lua_State *L = luaL_newstate();
 	if (L == NULL) {
@@ -872,6 +873,7 @@ tarantool_lua_init(const char *tarantool_bin, int argc, char **argv)
 	 */
 	tarantool_lua_setpaths(L);
 	tarantool_lua_minifio_init(L);
+	minifio_set_script(script);
 	luaT_set_module_from_source(L, "internal.minifio", minifio_lua);
 	luaT_set_module_from_source(L, "internal.loaders", loaders_lua);
 

--- a/src/lua/init.h
+++ b/src/lua/init.h
@@ -47,16 +47,11 @@ extern struct lua_State *tarantool_L;
 #define O_BYTECODE    0x2
 
 /**
- * Create an instance of Lua interpreter and load it with
- * Tarantool modules.  Creates a Lua state, imports global
- * Tarantool modules, then calls box_lua_init(), which performs
- * module-specific imports. The created state can be freed as any
- * other, with lua_close().
- *
- * @return  L on success, 0 if out of memory
+ * Create tarantool_L and initialize built-in Lua modules.
  */
 void
-tarantool_lua_init(const char *tarantool_bin, int argc, char **argv);
+tarantool_lua_init(const char *tarantool_bin, const char *script, int argc,
+		   char **argv);
 
 /** Free Lua subsystem resources. */
 void

--- a/src/lua/minifio.h
+++ b/src/lua/minifio.h
@@ -11,6 +11,12 @@ extern "C" {
 
 struct lua_State;
 
+/**
+ * Set path to the main script.
+ */
+void
+minifio_set_script(const char *script);
+
 void
 tarantool_lua_minifio_init(struct lua_State *L);
 

--- a/src/lua/minifio.lua
+++ b/src/lua/minifio.lua
@@ -12,7 +12,11 @@ ffi.cdef([[
 
 -- {{{ Functions exposed by fio
 
--- NB: minifio.cwd() is defined in src/lua/minifio.c.
+-- Several functions are defined in src/lua/minifio.c.
+--
+-- List them to ease searching by a function name.
+assert(type(minifio.cwd) == 'function')
+assert(type(minifio.script) == 'function')
 
 function minifio.pathjoin(...)
     local i, path = 1, nil

--- a/src/main.cc
+++ b/src/main.cc
@@ -797,7 +797,7 @@ main(int argc, char **argv)
 #ifndef NDEBUG
 	errinj_set_with_environment_vars();
 #endif
-	tarantool_lua_init(tarantool_bin, main_argc, main_argv);
+	tarantool_lua_init(tarantool_bin, script, main_argc, main_argv);
 
 	start_time = ev_monotonic_time();
 

--- a/test/app-luatest/module_search_test.lua
+++ b/test/app-luatest/module_search_test.lua
@@ -1,0 +1,94 @@
+local fio = require('fio')
+
+local t = require('luatest')
+local treegen = require('test.treegen')
+local justrun = require('test.justrun')
+
+local g = t.group()
+
+local MODULE_SCRIPT_TEMPLATE = [[
+print(require('json').encode({
+    ['script'] = '<script>',
+}))
+return {whoami = '<module_name>'}
+]]
+
+-- Print a result of the require call.
+local MAIN_SCRIPT_TEMPLATE = [[
+print(require('json').encode({
+    ['script'] = '<script>',
+    ['<module_name>'] = require('<module_name>'),
+}))
+]]
+
+g.before_all(function(g)
+    treegen.init(g)
+    treegen.add_template(g, '^main%.lua$', MAIN_SCRIPT_TEMPLATE)
+    treegen.add_template(g, '^.*%.lua$', MODULE_SCRIPT_TEMPLATE)
+end)
+
+g.after_all(function(g)
+    treegen.clean(g)
+end)
+
+local function expected_output(module_relpath, module_name)
+    local res = {
+        {
+            ['script'] = module_relpath,
+        },
+        {
+            ['script'] = 'main.lua',
+            [module_name] = {
+                whoami = module_name,
+            },
+        },
+    }
+
+    return {
+        exit_code = 0,
+        stdout = res,
+    }
+end
+
+-- Create an 'application directory' with a main script and a
+-- module. Run the main script and ensure that the module is
+-- successfully required.
+for _, case in ipairs({
+    -- Application's 'foo' module.
+    {'foo.lua', 'foo'},
+    {'foo/init.lua', 'foo'},
+    {'app/foo.lua', 'app.foo'},
+    {'app/foo/init.lua', 'app.foo'},
+    {'.rocks/share/tarantool/foo.lua', 'foo'},
+    {'.rocks/share/tarantool/foo/init.lua', 'foo'},
+    {'.rocks/share/tarantool/app/foo.lua', 'app.foo'},
+    {'.rocks/share/tarantool/app/foo/init.lua', 'app.foo'},
+    -- Application's socket override module.
+    --
+    -- See also override_test.lua.
+    {'override/socket.lua', 'socket'},
+    {'.rocks/share/tarantool/override/socket.lua', 'socket'},
+}) do
+    local module_relpath = case[1]
+    local module_name = case[2]
+
+    local module_slug = module_relpath
+        :gsub('^%.rocks/share/tarantool/', 'rocks/'):gsub('/', '_'):sub(1, -5)
+
+    g['test_' .. module_slug] = function(g)
+        local scripts = {module_relpath, 'main.lua'}
+        local replacements = {module_name = module_name}
+        local dir = treegen.prepare_directory(g, scripts, replacements)
+        local main_script = fio.pathjoin(dir, 'main.lua')
+        -- The current working directory is in the filesystem
+        -- root, so the only way to reach the modules is to search
+        -- for them next to the script.
+        --
+        -- If we would run tarantool from inside the application
+        -- directory, the module would be found just because it is
+        -- in the current directory.
+        local res = justrun.tarantool('/', {}, {main_script})
+        local exp = expected_output(module_relpath, module_name)
+        t.assert_equals(res, exp)
+    end
+end


### PR DESCRIPTION
It eliminates a need to call `package.setsearchroot()` in the main script to find modules in the application's directory.

Such layout is typical for cartridge based applications. It it also used, when different versions of modules are in use in different applications and installing the modules into the system is not an option.

Let's assume that there is an application in the directory /path/to/myapp with modules inside:

```
+ /path/to/myapp/
  +- .rocks/share/tarantool/
     +- foo.lua
  +- init.lua
  +- myapp/
     +- bar.lua
```

Now the following command automatically adds the path to the main script directory to search paths for modules:

```sh
$ tarantool /path/to/app/init.lua
```

So `require('foo')` and `require('myapp.bar')` works without any additional work.


Follows up #7774
Fixes #8182