### PR TITLE
static-build: fix possible div-by-zero in openssl

### DIFF
--- a/static-build/cmake/AddDependencyProjects.cmake
+++ b/static-build/cmake/AddDependencyProjects.cmake
@@ -77,6 +77,7 @@ ExternalProject_Add(openssl
     PATCH_COMMAND patch -d <SOURCE_DIR> -p1 -i "${PATCHES_DIR}/openssl-111q-gh-18720.patch"
     COMMAND       patch -d <SOURCE_DIR> -p1 -i "${PATCHES_DIR}/openssl-tarantool-security-27.patch"
     COMMAND       patch -d <SOURCE_DIR> -p1 -i "${PATCHES_DIR}/openssl-tarantool-security-54.patch"
+    COMMAND       patch -d <SOURCE_DIR> -p1 -i "${PATCHES_DIR}/openssl-tarantool-security-90.patch"
 )
 set(TARANTOOL_DEPENDS openssl ${TARANTOOL_DEPENDS})
 

--- a/static-build/patches/openssl-tarantool-security-90.patch
+++ b/static-build/patches/openssl-tarantool-security-90.patch
@@ -1,0 +1,11 @@
+--- openssl.old/ssl/record/ssl3_record.c	2023-02-17 11:10:19.399907899 +0300
++++ openssl/ssl/record/ssl3_record.c	2023-02-17 11:12:52.921915746 +0300
+@@ -1201,7 +1201,7 @@
+     }
+ 
+     t = EVP_MD_CTX_size(hash);
+-    if (t < 0)
++    if (t <= 0)
+         return 0;
+     md_size = t;
+     npad = (48 / md_size) * md_size;


### PR DESCRIPTION
n_ssl3_mac(): Fix possible divide by zero.
Fixed in openssl3:
https://github.com/openssl/openssl/commit/624efd2ba6f1dabdcdecf17c77bd206c421efdaf

Closes tarantool/security#90

NO_DOC=security
NO_TEST=security
NO_CHANGELOG=security