### PR TITLE
Add compat option for default fiber slice

### DIFF
--- a/changelogs/unreleased/gh-6085-log-and-limit-iteration.md
+++ b/changelogs/unreleased/gh-6085-log-and-limit-iteration.md
@@ -1,13 +1,9 @@
 ## feature/core
 
-* **[Breaking change]** Introduced the mechanism for catching fibers running
-  without yielding for too long. Now box operations, such as `select` and
-  `replace`, will throw an error if the fiber execution time since yield
-  exceeds the limit. The limit can also be checked from the application code
-  with `fiber.check_slice()`. The default limit is one second; you can
-  overwrite it with `fiber.set_slice()` (gh-6085).
-
-----
-
-Breaking change: long-running non-yielding fibers can be interrupted because of
-the fiber execution time slice limit.
+* Introduced the mechanism for catching fibers running without yielding for too
+  long. Now box operations, such as `select` and `replace`, will throw an error
+  if the fiber execution time since yield exceeds the limit. The limit can also
+  be checked from the application code with `fiber.check_slice()`. The default
+  limit is controlled by the new `compat` option `fiber_slice_default`. The old
+  default is no limit. The new default is one second. You can overwrite it with
+  `fiber.set_slice()` (gh-6085).

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -1030,6 +1030,17 @@ fiber_set_max_slice(struct fiber *fib, struct fiber_slice slice)
 }
 
 /**
+ * Returns the max effective slice applied to the given fiber.
+ */
+static inline struct fiber_slice
+fiber_get_max_slice(struct fiber *fib)
+{
+	assert(cord_is_main());
+	return (fib->flags & FIBER_CUSTOM_SLICE) != 0 ?
+	       fib->max_slice : cord()->max_slice;
+}
+
+/**
  * Check if slice is over for current cord.
  */
 static inline int

--- a/src/lua/fiber.c
+++ b/src/lua/fiber.c
@@ -186,6 +186,24 @@ lbox_fiber_statof_map(struct fiber *f, void *cb_ctx, bool backtrace)
 	lua_pushnumber(L, f->clock_stat.cputime / (double) FIBER_TIME_RES);
 	lua_settable(L, -3);
 
+	struct fiber_slice slice = fiber_get_max_slice(f);
+	if (slice.warn < TIMEOUT_INFINITY ||
+	    slice.err < TIMEOUT_INFINITY) {
+		lua_pushliteral(L, "max_slice");
+		lua_newtable(L);
+		if (slice.warn < TIMEOUT_INFINITY) {
+			lua_pushliteral(L, "warn");
+			lua_pushnumber(L, slice.warn);
+			lua_settable(L, -3);
+		}
+		if (slice.err < TIMEOUT_INFINITY) {
+			lua_pushliteral(L, "err");
+			lua_pushnumber(L, slice.err);
+			lua_settable(L, -3);
+		}
+		lua_settable(L, -3);
+	}
+
 	lua_pushliteral(L, "memory");
 	lua_newtable(L);
 	lua_pushstring(L, "used");

--- a/src/lua/fiber.c
+++ b/src/lua/fiber.c
@@ -856,19 +856,25 @@ lbox_fiber_slice_parse(struct lua_State *L, int idx)
 	struct fiber_slice slice;
 	if (lua_istable(L, idx)) {
 		lua_getfield(L, idx, "warn");
-		slice.warn = luaL_checknumber(L, -1);
+		if (!lua_isnumber(L, -1))
+			goto err;
+		slice.warn = lua_tonumber(L, -1);
 		lua_getfield(L, idx, "err");
-		slice.err = luaL_checknumber(L, -1);
+		if (!lua_isnumber(L, -1))
+			goto err;
+		slice.err = lua_tonumber(L, -1);
 		lua_pop(L, 2);
 	} else if (lua_isnumber(L, idx)) {
 		slice.warn = TIMEOUT_INFINITY;
 		slice.err = lua_tonumber(L, idx);
 	} else {
-		luaL_error(L, "slice must be a table or a number");
+err:
+		luaL_error(L, "slice must be a number or a table "
+			   "{warn = <number>, err = <number>}");
 		unreachable();
 	}
 	if (!fiber_slice_is_valid(slice))
-		luaL_error(L, "slice must be greater than 0");
+		luaL_error(L, "slice value must be >= 0");
 	return slice;
 }
 

--- a/src/lua/fiber.lua
+++ b/src/lua/fiber.lua
@@ -1,5 +1,6 @@
 -- fiber.lua (internal file)
 
+local compat = require('compat')
 local fiber = require('fiber')
 local ffi = require('ffi')
 ffi.cdef[[
@@ -13,6 +14,34 @@ int64_t
 fiber_clock64(void);
 ]]
 local C = ffi.C
+
+local TIMEOUT_INFINITY = 100 * 365 * 86400
+
+local FIBER_SLICE_DEFAULT_BRIEF = [[
+Sets the default value for the max fiber slice. The old value is infinity
+(no warnings or errors). The new value is {warn = 0.5, err = 1.0}.
+
+https://tarantool.io/compat/fiber_slice_default
+]]
+
+compat.add_option({
+    name = 'fiber_slice_default',
+    default = 'old',
+    obsolete = nil,
+    brief = FIBER_SLICE_DEFAULT_BRIEF,
+    action = function(is_new)
+        local slice = {}
+        if is_new then
+            slice.warn = 0.5
+            slice.err = 1.0
+        else
+            slice.warn = TIMEOUT_INFINITY
+            slice.err = TIMEOUT_INFINITY
+        end
+        fiber.set_max_slice(slice)
+    end,
+    run_action_now = true,
+})
 
 local function fiber_time()
     return tonumber(C.fiber_time())

--- a/test/app-luatest/fiber_slice_test.lua
+++ b/test/app-luatest/fiber_slice_test.lua
@@ -171,3 +171,26 @@ g.test_info = function()
         check_default(slice, info)
     end
 end
+
+g.before_test('test_compat', function()
+    g.server = server:new({alias = 'default'})
+    g.server:start()
+end)
+
+g.after_test('test_compat', function()
+    g.server:drop()
+end)
+
+g.test_compat = function()
+    g.server:exec(function()
+        local compat = require('compat')
+        local fiber = require('fiber')
+        t.assert_equals(compat.fiber_slice_default.current, 'default')
+        t.assert_equals(compat.fiber_slice_default.default, 'old')
+        t.assert_equals(fiber.self():info().max_slice, nil)
+        compat.fiber_slice_default = 'new'
+        t.assert_equals(fiber.self():info().max_slice, {warn = 0.5, err = 1.0})
+        compat.fiber_slice_default = 'old'
+        t.assert_equals(fiber.self():info().max_slice, nil)
+    end)
+end


### PR DESCRIPTION
This PR adds the new `compat` option [`fiber_slice_default`](https://tarantool.io/compat/fiber_slice_default). The old default is no limit. The new default is `{warn = 0.5, err = 1.0}`.

Apart from adding the option, this PR also fixes errors raised on invalid slice argument and adds the current value of the max slice to `fiber.info()`, which is useful for introspection and testing.

[Link](https://www.notion.so/tarantool/Fiber-slice-3673c044cb3b445f886970b8e5229bb9) to the discussion behind this decision.

Follow-up #6085