### PR TITLE
static-build: fix readline read of uninit variable

### DIFF
--- a/static-build/cmake/AddDependencyProjects.cmake
+++ b/static-build/cmake/AddDependencyProjects.cmake
@@ -190,6 +190,7 @@ ExternalProject_Add(readline
         --prefix=<INSTALL_DIR>
         --disable-shared
     PATCH_COMMAND patch -d <SOURCE_DIR> -p0 -i "${PATCHES_DIR}/readline80-001.patch"
+    COMMAND       patch -d <SOURCE_DIR> -p1 -i "${PATCHES_DIR}/readline-tarantool-security-95.patch"
 )
 set(TARANTOOL_DEPENDS readline ${TARANTOOL_DEPENDS})
 

--- a/static-build/patches/readline-tarantool-security-95.patch
+++ b/static-build/patches/readline-tarantool-security-95.patch
@@ -1,0 +1,18 @@
+--- readline.old/histfile.c	2023-02-17 13:01:18.515248292 +0300
++++ readline/histfile.c	2023-02-17 13:02:42.034252562 +0300
+@@ -492,6 +492,7 @@
+   tempname = 0;
+   file = filename ? open (filename, O_RDONLY|O_BINARY, 0666) : -1;
+   rv = exists = 0;
++  orig_lines = lines;
+ 
+   /* Don't try to truncate non-regular files. */
+   if (file == -1 || fstat (file, &finfo) == -1)
+@@ -547,7 +548,6 @@
+       goto truncate_exit;
+     }
+ 
+-  orig_lines = lines;
+   /* Count backwards from the end of buffer until we have passed
+      LINES lines.  bp1 is set funny initially.  But since bp[1] can't
+      be a comment character (since it's off the end) and *bp can't be


### PR DESCRIPTION
This patch fixes potential read of uninitialized variable in history_truncate_file()

Fixed in upstream:
https://git.savannah.gnu.org/cgit/readline.git/commit/?h=devel&id=b4ebdc06601fb54297435d2e286d901cba1cd6c6

Closes tarantool/security#95

NO_DOC=security
NO_TEST=security
NO_CHANGELOG=security