### PR TITLE
[2.10] memtx: fix size calculation in functional index chunks

### DIFF
--- a/changelogs/unreleased/gh-6786-crash-func-index.md
+++ b/changelogs/unreleased/gh-6786-crash-func-index.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fixed a crash when functional indexes were used with very specific chunk size (gh-6786).

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -91,7 +91,7 @@ memtx_alloc_impl(uint32_t size)
 {
 	void *ptr = MemtxAllocator<ALLOC>::alloc(size + sizeof(uint32_t));
 	if (ptr != NULL) {
-		*(uint32_t *)ptr = size;
+		*(uint32_t *)ptr = size + sizeof(uint32_t);
 		return (uint32_t *)ptr + 1;
 	}
 	return NULL;

--- a/test/box-luatest/gh-6786_func_index_iterator_stable_test.lua
+++ b/test/box-luatest/gh-6786_func_index_iterator_stable_test.lua
@@ -57,3 +57,53 @@ g.test_func_index_iterator_stable = function()
         t.assert_equals(s.index.f:select(), {})
     end)
 end
+
+g.before_test('test_func_index_allocator', function()
+    g.server:exec(function()
+        box.schema.func.create('test', {
+            body = [[function(t)
+                return {{string.sub(t[1], 1, t[2])}}
+            end]],
+            is_deterministic = true,
+            is_sandboxed = true,
+            opts = { is_multikey = true },
+        })
+        local s = box.schema.create_space('test')
+        s:create_index('pk', {
+            parts = {{1, 'string'}},
+        })
+        s:create_index('f', {
+            func = 'test',
+            parts = {{1, 'string'}},
+        })
+    end)
+end)
+
+g.after_test('test_func_index_allocator', function()
+    g.server:exec(function()
+        box.space.test:drop()
+        box.schema.func.drop('test')
+    end)
+end)
+
+-- Test different sizes of functional index.
+g.test_func_index_allocator = function()
+    g.server:exec(function()
+        local s = box.space.test
+        local MIN_STRING_LEN = 8
+        local MAX_STRING_LEN = 256
+        local STRING_LEN_STEP = 4
+        local MAX_ALLOCS = 128
+        local str = string.rep('a', MAX_STRING_LEN)
+
+        for i = MIN_STRING_LEN, MAX_STRING_LEN, STRING_LEN_STEP do
+            for j = 1, MAX_ALLOCS do
+                s:insert{j .. str,  i}
+            end
+            t.assert_equals(s.index.f:count(), MAX_ALLOCS)
+            for j = 1, MAX_ALLOCS do
+                s:delete{j .. str}
+            end
+        end
+    end)
+end


### PR DESCRIPTION
When function of a functional index is called, the result is stored in memtx allocator chunks among data tuples. By design, memtx allocator requires size of allocation for deallocation, so the size has to be stored along with the data (actually right before it). By a mistake, when being deleted, the size of data was retrieved slightly wrong, giving the value of 4 bytes less. Due to the allocator specific design the size error leads to a rare crashes when the size of functional index function result was about 160 bytes (157..160 bytes with default config). It seems that sizes about 320 etc are affected to.

Fix it by correct size evaluation of functional index chunks.

Hotfix of https://github.com/tarantool/tarantool/issues/6786