### PR TITLE
lua: allow to override a module only for application's code

### DIFF
--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -967,6 +967,27 @@ tarantool_lua_init(const char *tarantool_bin, const char *script, int argc,
 	tarantool_L = L;
 }
 
+int
+tarantool_lua_postinit(struct lua_State *L)
+{
+	/*
+	 * loaders.initializing = nil
+	 *
+	 * The loaders module set the `initializing` field to
+	 * `true` at first load (during tarantool_lua_init()).
+	 * Now it is time to set it to `nil` to state that all
+	 * the built-in modules are loaded.
+	 */
+	lua_getfield(L, LUA_GLOBALSINDEX, "require");
+	lua_pushstring(L, "internal.loaders");
+	lua_call(L, 1, 1);
+	lua_pushnil(L);
+	lua_setfield(L, -2, "initializing");
+	/* Pop internal.loaders table. */
+	lua_pop(L, 1);
+	return 0;
+}
+
 char *history = NULL;
 
 struct slab_cache *

--- a/src/lua/init.h
+++ b/src/lua/init.h
@@ -53,6 +53,12 @@ void
 tarantool_lua_init(const char *tarantool_bin, const char *script, int argc,
 		   char **argv);
 
+/**
+ * A code that runs after loading of all built-in modules.
+ */
+int
+tarantool_lua_postinit(struct lua_State *L);
+
 /** Free Lua subsystem resources. */
 void
 tarantool_lua_free();

--- a/src/lua/loaders.lua
+++ b/src/lua/loaders.lua
@@ -383,4 +383,7 @@ return {
     override_builtin_disable = function()
         override_loader_is_enabled = false
     end,
+    -- It is `true` during tarantool initialization, but once all
+    -- the built-in modules are ready, will be set to `nil`.
+    initializing = true,
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -804,6 +804,7 @@ main(int argc, char **argv)
 	try {
 		box_init();
 		box_lua_init(tarantool_L);
+		tarantool_lua_postinit(tarantool_L);
 		/*
 		 * Reserve a fiber to run on_shutdown triggers.
 		 */

--- a/test/app-luatest/override_misc_test.lua
+++ b/test/app-luatest/override_misc_test.lua
@@ -1,0 +1,67 @@
+local t = require('luatest')
+local treegen = require('test.treegen')
+local justrun = require('test.justrun')
+
+local g = t.group()
+
+local OVERRIDE_SCRIPT_TEMPLATE = [[
+local loaders = require('internal.loaders')
+
+return {
+    whoami = 'override.<module_name>',
+    initializing = loaders.initializing,
+}
+]]
+
+-- Print a result of the require call.
+local MAIN_SCRIPT_TEMPLATE = [[
+local json = require('json')
+local loaders = require('internal.loaders')
+
+print(json.encode({
+    ['<module_name>'] = require('<module_name>'),
+    ['<script>'] = {
+        whoami = '<script>',
+        initializing = loaders.initializing,
+    }
+}))
+]]
+
+g.before_all(function(g)
+    treegen.init(g)
+    treegen.add_template(g, '^override/.*%.lua$', OVERRIDE_SCRIPT_TEMPLATE)
+    treegen.add_template(g, '^main%.lua$', MAIN_SCRIPT_TEMPLATE)
+end)
+
+g.after_all(function(g)
+    treegen.clean(g)
+end)
+
+local function expected_output(module_name)
+    local res = {
+        {
+            [module_name] = {
+                whoami = ('override.%s'):format(module_name),
+                initializing = true,
+            },
+            ['main.lua'] = {
+                whoami = 'main.lua',
+                -- initializing is nil
+            }
+        }
+    }
+
+    return {
+        exit_code = 0,
+        stdout = res,
+    }
+end
+
+g.test_initializing = function(g)
+    local scripts = {'override/socket.lua', 'main.lua'}
+    local replacements = {module_name = 'socket'}
+    local dir = treegen.prepare_directory(g, scripts, replacements)
+    local res = justrun.tarantool(dir, {}, {'main.lua'})
+    local exp = expected_output('socket')
+    t.assert_equals(res, exp)
+end

--- a/test/app-luatest/override_misc_test.lua
+++ b/test/app-luatest/override_misc_test.lua
@@ -65,3 +65,26 @@ g.test_initializing = function(g)
     local exp = expected_output('socket')
     t.assert_equals(res, exp)
 end
+
+g.test_no_package_loaded = function()
+    local LOAD_LIMIT = 3
+    local LOAD_ATTEMPTS = LOAD_LIMIT + 1
+
+    local load_cnt = 0
+    local foo = {whoami = 'foo'}
+    package.preload.foo = function()
+        local loaders = require('internal.loaders')
+        load_cnt = load_cnt + 1
+        if load_cnt < LOAD_LIMIT then
+            loaders.no_package_loaded.foo = true
+        end
+        return foo
+    end
+
+    for _ = 1, LOAD_ATTEMPTS do
+        require('foo')
+    end
+
+    package.preload.foo = nil
+    t.assert_equals(load_cnt, LOAD_LIMIT)
+end


### PR DESCRIPTION
Use case: an override module is designed to replace a built-in module only when the module is required from an application, not from the platform itself.
    
Now it is possible:
    
```lua
-- override/fio.lua
local loaders = require('internal.loaders')

if loaders.initializing then
    loaders.no_package_loaded.fio = true
    return loaders.builtin.fio
end

return {
    whoami = 'override.fio',
}
```

Follows up #7774