### PR TITLE
[2.8] Hot fix Tarantool and LuaJIT

### DIFF
--- a/changelogs/unreleased/fix-error-throw-from-__gc.md
+++ b/changelogs/unreleased/fix-error-throw-from-__gc.md
@@ -1,0 +1,3 @@
+## bugfix/luajit
+
+Fix error throwing from GC finalizers, when exit from a JIT trace.

--- a/changelogs/unreleased/gh-6786-crash-func-index.md
+++ b/changelogs/unreleased/gh-6786-crash-func-index.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fixed a crash when functional indexes were used with very specific chunk size (gh-6786).

--- a/src/box/memtx_engine.c
+++ b/src/box/memtx_engine.c
@@ -86,7 +86,7 @@ memtx_alloc(uint32_t size)
 {
 	void *ptr = smalloc(memtx_allocator, size + sizeof(uint32_t));
 	if (ptr != NULL) {
-		*(uint32_t *)ptr = size;
+		*(uint32_t *)ptr = size + sizeof(uint32_t);
 		return (uint32_t *)ptr + 1;
 	}
 	return NULL;


### PR DESCRIPTION
This PR incorporates two hotfixes:
- protecting call to lj_gc_step on trace exit
- size calculation in functional index chunks