### PR TITLE
lua: panic on suspicious built-in modules manipulations

### DIFF
--- a/src/lua/utils.c
+++ b/src/lua/utils.c
@@ -335,12 +335,12 @@ luaT_newmodule(struct lua_State *L, const char *modname,
 	/* Get loaders.builtin. */
 	lua_getfield(L, LUA_REGISTRYINDEX, "_TARANTOOL_BUILTIN");
 
-#ifndef NDEBUG
 	/* Verify that the module is not already registered. */
 	lua_getfield(L, -1, modname);
-	assert(lua_isnil(L, -1));
+	if (!lua_isnil(L, -1))
+		panic("%s(%s): the module is already registered",
+		      __func__, modname);
 	lua_pop(L, 1);
-#endif
 
 	/* Create a module table. */
 	lua_newtable(L);
@@ -398,7 +398,9 @@ luaT_setmodule(struct lua_State *L, const char *modname)
 	 * Verify that the module is not already registered with
 	 * another value.
 	 */
-	assert(lua_isnil(L, -1));
+	if (!lua_isnil(L, -1))
+		panic("%s(%s): the module is already registered "
+		      "with another value", __func__, modname);
 	lua_pop(L, 1);
 
 	/* Stack: module table, loaders.builtin. */

--- a/src/lua/utils.h
+++ b/src/lua/utils.h
@@ -264,6 +264,8 @@ luaL_register_type(struct lua_State *L, const char *type_name,
  * Create a table with functions and register it as a built-in
  * tarantool module.
  *
+ * Panic if the module is already registered.
+ *
  * Leave the table on top of the stack.
  *
  * Pseudocode:
@@ -289,8 +291,8 @@ luaT_newmodule(struct lua_State *L, const char *modname,
  * Register a table on top of the stack as a built-in tarantool
  * module.
  *
- * Can be called several times with the same value, but raises
- * assertion fail if called with different values.
+ * Can be called several times with the same value, but panics
+ * if called with different values.
  *
  * Can be used after luaT_newmodule() if, again, the table of the
  * module is the same.

--- a/test/app-luatest/override_panic_test.lua
+++ b/test/app-luatest/override_panic_test.lua
@@ -1,0 +1,74 @@
+local t = require('luatest')
+local treegen = require('test.treegen')
+local justrun = require('test.justrun')
+
+local g = t.group()
+
+g.before_all(function(g)
+    treegen.init(g)
+end)
+
+g.after_all(function(g)
+    treegen.clean(g)
+end)
+
+-- Trigger luaT_newmodule() panic.
+--
+-- fio is required internally before box initialization, so we can
+-- register fake box module from its override module. Then, when
+-- box starts to register itself, luaT_newmodule() finds it as
+-- already registered.
+--
+-- luaT_newmodule() must panic in the case.
+g.test_newmodule_panic = function(g)
+    local dir = treegen.prepare_directory(g, {}, {})
+    treegen.write_script(dir, 'override/fio.lua', [[
+        local loaders = require('internal.loaders')
+        loaders.builtin.box = {}
+        return loaders.builtin.fio
+    ]])
+    treegen.write_script(dir, 'main.lua', '')
+    local opts = {nojson = true, stderr = true}
+    local res = justrun.tarantool(dir, {}, {'main.lua'}, opts)
+    t.assert_equals(res, {
+        exit_code = 1,
+        stderr = 'luaT_newmodule(box): the module is already registered',
+    })
+end
+
+-- Trigger luaT_setmodule() panic.
+--
+-- src/lua/fio.c registers `fio` module.
+--
+-- Then src/lua/fio.lua is loaded. It is structured like so:
+--
+--  | local fio = require('fio') -- from fio.c
+--  |
+--  | function fio.foo(<...>)
+--  |     <...>
+--  | end
+--  |
+--  | return fio
+--
+-- fio.lua's return value is passed to luaT_setmodule() and it
+-- must be the same as one that is already registered by fio.c.
+--
+-- We can change what the require call returns (and so what
+-- fio.lua returns) using an override module.
+--
+-- luaT_setmodule() must panic if it meets attempt to register
+-- different values as the same built-in module.
+g.test_setmodule_panic = function(g)
+    local dir = treegen.prepare_directory(g, {}, {})
+    treegen.write_script(dir, 'override/fio.lua', [[
+        return {}
+    ]])
+    treegen.write_script(dir, 'main.lua', '')
+    local opts = {nojson = true, stderr = true}
+    local res = justrun.tarantool(dir, {}, {'main.lua'}, opts)
+    t.assert_equals(res, {
+        exit_code = 1,
+        stderr = 'luaT_setmodule(fio): the module is already registered ' ..
+            'with another value',
+    })
+end

--- a/test/justrun.lua
+++ b/test/justrun.lua
@@ -1,18 +1,76 @@
 local fun = require('fun')
 local log = require('log')
 local json = require('json')
+local fiber = require('fiber')
 local popen = require('popen')
 
 local justrun = {}
 
+local function collect_stderr(ph)
+    local f = fiber.new(function()
+        local fiber_name = "child's stderr collector"
+        fiber.name(fiber_name, {truncate = true})
+
+        local chunks = {}
+
+        while true do
+            local chunk, err = ph:read({stderr = true})
+            if chunk == nil then
+                log.warn(('%s: got error, exiting: %s'):format(
+                    fiber_name, tostring(err)))
+                break
+            end
+            if chunk == '' then
+                log.info(('%s: got EOF, exiting'):format(fiber_name))
+                break
+            end
+            table.insert(chunks, chunk)
+        end
+
+        -- Glue all chunks, strip trailing newline.
+        return table.concat(chunks):rstrip()
+    end)
+    f:set_joinable(true)
+    return f
+end
+
+local function cancel_stderr_fiber(stderr_fiber)
+    if stderr_fiber == nil then
+        return
+    end
+    stderr_fiber:cancel()
+end
+
+local function join_stderr_fiber(stderr_fiber)
+    if stderr_fiber == nil then
+        return
+    end
+    return select(2, assert(stderr_fiber:join()))
+end
+
 -- Run tarantool in given directory with given environment and
 -- command line arguments and catch its output.
 --
--- Expects JSON lines as the output and parses it into an array.
-function justrun.tarantool(dir, env, args)
+-- Expects JSON lines as the output and parses it into an array
+-- (it can be disabled using `nojson` option).
+--
+-- Options:
+--
+-- - nojson (boolean, default: false)
+--
+--   Don't attempt to decode stdout as a stream of JSON lines,
+--   return as is.
+--
+-- - stderr (boolean, default: false)
+--
+--   Collect stderr and place it into the `stderr` field of the
+--   return value
+function justrun.tarantool(dir, env, args, opts)
     assert(type(dir) == 'string')
     assert(type(env) == 'table')
     assert(type(args) == 'table')
+    local opts = opts or {}
+    assert(type(opts) == 'table')
 
     local tarantool_exe = arg[-1]
     -- Use popen.shell() instead of popen.new() due to lack of
@@ -23,13 +81,20 @@ function justrun.tarantool(dir, env, args)
     local command = ('cd %s && %s %s %s'):format(dir, env_str, tarantool_exe,
                                                  table.concat(args, ' '))
     log.info(('Running a command: %s'):format(command))
-    local ph = popen.shell(command, 'r')
+    local mode = opts.stderr and 'rR' or 'r'
+    local ph = popen.shell(command, mode)
+
+    local stderr_fiber
+    if opts.stderr then
+        stderr_fiber = collect_stderr(ph)
+    end
 
     -- Read everything until EOF.
     local chunks = {}
     while true do
         local chunk, err = ph:read()
         if chunk == nil then
+            cancel_stderr_fiber(stderr_fiber)
             ph:close()
             error(err)
         end
@@ -40,23 +105,35 @@ function justrun.tarantool(dir, env, args)
     end
 
     local exit_code = ph:wait().exit_code
+    local stderr = join_stderr_fiber(stderr_fiber)
     ph:close()
 
     -- If an error occurs, discard the output and return only the
-    -- exit code.
+    -- exit code. However, return stderr.
     if exit_code ~= 0 then
-        return {exit_code = exit_code}
+        return {
+            exit_code = exit_code,
+            stderr = stderr,
+        }
     end
 
     -- Glue all chunks, strip trailing newline.
     local res = table.concat(chunks):rstrip()
     log.info(('Command output:\n%s'):format(res))
 
-    -- Decode JSON object per line into array of tables.
-    local decoded = fun.iter(res:split('\n')):map(json.decode):totable()
+    -- Decode JSON object per line into array of tables (if
+    -- `nojson` option is not passed).
+    local decoded
+    if opts.nojson then
+        decoded = res
+    else
+        decoded = fun.iter(res:split('\n')):map(json.decode):totable()
+    end
+
     return {
         exit_code = exit_code,
         stdout = decoded,
+        stderr = stderr,
     }
 end
 


### PR DESCRIPTION
The built-in module registration process performs several assertions:

- luaT_newmodule() checks for attempts to register an already registered module.
- luaT_setmodule() does the same, but it allows the same value be 'registered' several times.

Attempt to register different values as the same built-in module is definitely an error. Once a module is registered, it may be required and captured. If its value is changed afterwards, different parts of tarantool's code will capture different values for the same built-in module. It is very unlikely that such effect may be intended.

Anyway, tarantool's code doesn't do this. However, now, after implementing the override modules feature, it is possible to influence tarantool's initialization from a user provided code.

It means that we can't assume the situations described above as impossible ones. A developer of an override module should receive an error if the code of the module leads to such a situation.

`assert()` works only in Debug build, but most of user's code is tested on RelWithDebInfo builds. So incorrect override module may be implemented and distributed. It is undesirable.

Let's replace `assert()` with explicit `panic()`.

----

Adjusted testing helpers:

* `treegen` now allows to just write given script into given directory without using templates. Sometimes it is more convenient.
* `justrun` can return pure stdout (without JSONL decoding) and can return stderr if requested.

`nojson` option in `justrun` may look unneded for given test cases, but it provides better diagnostics if something going wrong and one of the test cases fails (say, if tarantool runs successfully instead of going to panic).

----

Follows up #7774