### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-8069-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8069-luajit-fixes.md
@@ -1,0 +1,7 @@
+## bugfix/luajit
+
+Backported patches from vanilla LuaJIT trunk (gh-8069). In the scope of this
+activity, the following issues have been resolved:
+
+* Fixed loop realigment for dual-number mode
+* Fixed os.date() for wider libc strftime() compatibility.

--- a/changelogs/unreleased/luajit-sysprof-fix-interval-parsing.md
+++ b/changelogs/unreleased/luajit-sysprof-fix-interval-parsing.md
@@ -1,0 +1,3 @@
+## bugfix/luajit
+
+* Fix interval parsing for sysprof for dual-number mode.


### PR DESCRIPTION
* ci: add LUAJIT_ENABLE_CHECKHOOK for exotic matrix
* ci: add ARM64 architecture to exotic testing
* ci: update action/checkout to v3
* Fix os.date() for wider libc strftime() compatibility.
* x86/x64: Fix loop realignment.
* ci: introduce workflow for exotic builds
* sysprof: fix interval parsing in dual-number mode
* test: add test for `string.format('%c', 0)`
* ci: drop obsolete arguments for LuaJIT integration

Part of #8069

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump
