### PR TITLE
box: populate `index_object.parts` with `key_def` module methods

### DIFF
--- a/changelogs/unreleased/gh-7356-populate-index-with-keydef.md
+++ b/changelogs/unreleased/gh-7356-populate-index-with-keydef.md
@@ -1,0 +1,5 @@
+## feature/core
+
+* Now `index_object.parts` contains the following methods, similar to the
+  `key_def` Lua module: `extract_key()`, `compare()`, `compare_with_key()`,
+  `merge()` (gh-7356).

--- a/src/box/lua/key_def.h
+++ b/src/box/lua/key_def.h
@@ -39,6 +39,13 @@ struct lua_State;
 struct key_def;
 
 /**
+ * Push a copy of key_def as a cdata object to a Lua stack, and set finalizer
+ * function lbox_key_def_gc for it.
+ */
+void
+luaT_push_key_def(struct lua_State *L, const struct key_def *key_def);
+
+/**
  * Push a new table representing a key_def to a Lua stack.
  * Table is consists of key_def::parts tables that describe
  * each part correspondingly.
@@ -46,7 +53,7 @@ struct key_def;
  * object doesn't declare them where not necessary.
  */
 void
-luaT_push_key_def(struct lua_State *L, const struct key_def *key_def);
+luaT_push_key_def_parts(struct lua_State *L, const struct key_def *key_def);
 
 /**
  * Check key_def pointer in LUA stack by specified index.
@@ -54,7 +61,62 @@ luaT_push_key_def(struct lua_State *L, const struct key_def *key_def);
  * Returns not NULL tuple pointer on success, NULL otherwise.
  */
 struct key_def *
-luaT_check_key_def(struct lua_State *L, int idx);
+luaT_is_key_def(struct lua_State *L, int idx);
+
+/**
+ * Extract key from tuple by given key definition and return
+ * tuple representing this key.
+ * Push the new key tuple as cdata to a LUA stack on success.
+ * Raise error otherwise.
+ */
+int
+luaT_key_def_extract_key(struct lua_State *L, int idx);
+
+/**
+ * Compare tuples using the key definition.
+ * Push 0  if key_fields(tuple_a) == key_fields(tuple_b)
+ *      <0 if key_fields(tuple_a) < key_fields(tuple_b)
+ *      >0 if key_fields(tuple_a) > key_fields(tuple_b)
+ * integer to a LUA stack on success.
+ * Raise error otherwise.
+ */
+int
+luaT_key_def_compare(struct lua_State *L, int idx);
+
+/**
+ * Compare tuple with key using the key definition.
+ * Push 0  if key_fields(tuple) == parts(key)
+ *      <0 if key_fields(tuple) < parts(key)
+ *      >0 if key_fields(tuple) > parts(key)
+ * integer to a LUA stack on success.
+ * Raise error otherwise.
+ */
+int
+luaT_key_def_compare_with_key(struct lua_State *L, int idx);
+
+/**
+ * Construct and export to LUA a new key definition with a set
+ * union of key parts from first and second key defs. Parts of
+ * the new key_def consist of the first key_def's parts and those
+ * parts of the second key_def that were not among the first
+ * parts.
+ * Push the new key_def as cdata to a LUA stack on success.
+ * Raise error otherwise.
+ */
+int
+luaT_key_def_merge(struct lua_State *L, int idx_a, int idx_b);
+
+/**
+ * Create a new key_def from a Lua table.
+ *
+ * Expected a table of key parts on the Lua stack. The format is
+ * the same as box.space.<...>.index.<...>.parts or corresponding
+ * net.box's one.
+ *
+ * Push the new key_def as cdata to a Lua stack.
+ */
+int
+lbox_key_def_new(struct lua_State *L);
 
 /**
  * Register the module.

--- a/src/box/lua/merger.c
+++ b/src/box/lua/merger.c
@@ -50,7 +50,7 @@
 #include "lua/utils.h"       /* luaL_pushcdata(),
 				luaL_iterator_*() */
 
-#include "box/lua/key_def.h" /* luaT_check_key_def() */
+#include "box/lua/key_def.h" /* luaT_is_key_def() */
 #include "box/lua/tuple.h"   /* luaT_tuple_new() */
 
 #include "small/ibuf.h"      /* struct ibuf */
@@ -352,7 +352,7 @@ lbox_merger_new(struct lua_State *L)
 	int top = lua_gettop(L);
 	bool ok = (top == 2 || top == 3) &&
 		/* key_def. */
-		(key_def = luaT_check_key_def(L, 1)) != NULL &&
+		(key_def = luaT_is_key_def(L, 1)) != NULL &&
 		/* Sources. */
 		lua_istable(L, 2) == 1 &&
 		/* Opts. */

--- a/test/box-luatest/gh_7356_index_parts_methods_test.lua
+++ b/test/box-luatest/gh_7356_index_parts_methods_test.lua
@@ -1,0 +1,161 @@
+local t = require('luatest')
+local g = t.group('gh-7356')
+
+g.before_all(function(cg)
+    local server = require('luatest.server')
+    cg.server = server:new({alias = 'gh_7356'})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test then box.space.test:drop() end
+    end)
+end)
+
+-- Test index_object.parts:extract_key(tuple)
+g.test_extract_key = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        local pk = s:create_index('pk')
+        s:insert{1, 99.5, 'X', nil, {'a', 'b'}}
+        local sk = s:create_index('sk', {parts = {3, 'string', 1, 'unsigned'}})
+        local k = sk.parts:extract_key(pk:get{1})
+        t.assert_equals(k, {'X', 1})
+
+        t.assert_error_msg_content_equals(
+            'Usage: index.parts:extract_key(tuple)',
+            sk.parts.extract_key)
+        t.assert_error_msg_content_equals(
+            'Usage: index.parts:extract_key(tuple)',
+            sk.parts.extract_key, sk.parts)
+        t.assert_error_msg_content_equals(
+            'A tuple or a table expected, got number',
+            sk.parts.extract_key, sk.parts, 0)
+        t.assert_error_msg_content_equals(
+            'Tuple field [3] required by space format is missing',
+            sk.parts.extract_key, sk.parts, {0})
+
+        local mk = s:create_index('mk', {parts = {{path = '[*]', field = 5}}})
+        t.assert_error_msg_content_equals(
+            'multikey path is unsupported',
+            mk.parts.extract_key, mk.parts, pk:get{1})
+
+        -- Check that extract_key() method is recreated with the correct key_def
+        -- object after alter().
+        sk:alter({parts = {1, 'unsigned', 2, 'double'}})
+        t.assert_equals(sk.parts:extract_key(pk:get{1}), {1, 99.5})
+    end)
+end
+
+-- Test index_object.parts:compare(tuple_a, tuple_b)
+g.test_compare = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        local i = s:create_index('i', {parts = {
+            {field = 3, type = 'string', collation = 'unicode_ci'},
+            {field = 1, type = 'unsigned'}
+        }})
+        local tuple_a = {1, 99.5, 'x', nil, {'a', 'b'}}
+        local tuple_b = {1, 99.5, 'X', nil, {'a', 'b'}}
+        local tuple_c = {2, 99.5, 'X', nil, {'a', 'b'}}
+        t.assert_equals(i.parts:compare(tuple_a, tuple_b), 0)
+        t.assert_equals(i.parts:compare(tuple_a, tuple_c), -1)
+        t.assert_equals(i.parts.compare(nil, tuple_c, tuple_a), 1)
+
+        t.assert_error_msg_content_equals(
+            'Usage: index.parts:compare(tuple_a, tuple_b)',
+            i.parts.compare)
+        t.assert_error_msg_content_equals(
+            'Usage: index.parts:compare(tuple_a, tuple_b)',
+            i.parts.compare, i.parts, tuple_a)
+        t.assert_error_msg_content_equals(
+            'A tuple or a table expected, got cdata',
+            i.parts.compare, i.parts, tuple_a, box.NULL)
+        t.assert_error_msg_content_equals(
+            'Supplied key type of part 0 does not match index part type: ' ..
+            'expected string', i.parts.compare, nil, {0, [3]=0}, tuple_b)
+
+        local mk = s:create_index('mk', {parts = {{path = '[*]', field = 5}}})
+        t.assert_error_msg_content_equals(
+            'multikey path is unsupported',
+            mk.parts.compare, mk.parts, tuple_a, tuple_b)
+    end)
+end
+
+-- Test index_object.parts:compare_with_key(tuple_a, tuple_b)
+g.test_compare_with_key = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        local i = s:create_index('i', {parts = {
+            {field = 3, type = 'string', collation = 'unicode_ci'},
+            {field = 1, type = 'unsigned'}
+        }})
+        local tuple = {1, 99.5, 'x', nil, {'a', 'b'}}
+        t.assert_equals(i.parts:compare_with_key(tuple, {'x', 1}), 0)
+        t.assert_equals(i.parts:compare_with_key(tuple, {'X', 1}), 0)
+        t.assert_equals(i.parts:compare_with_key(tuple, {'X', 2}), -1)
+
+        t.assert_error_msg_content_equals(
+            'Usage: index.parts:compare_with_key(tuple, key)',
+            i.parts.compare_with_key)
+        t.assert_error_msg_content_equals(
+            'Usage: index.parts:compare_with_key(tuple, key)',
+            i.parts.compare_with_key, box.NULL)
+        t.assert_error_msg_content_equals(
+            'Usage: index.parts:compare_with_key(tuple, key)',
+            i.parts.compare_with_key, box.NULL, {0, nil, ''})
+        t.assert_error_msg_content_equals(
+            'Supplied key type of part 1 does not match index part type: ' ..
+            'expected unsigned',
+            i.parts.compare_with_key, box.NULL, {0, nil, ''}, {'', ''})
+
+        local mk = s:create_index('mk', {parts = {{path = '[*]', field = 5}}})
+        t.assert_error_msg_content_equals(
+            'multikey path is unsupported',
+            mk.parts.compare_with_key, mk.parts, tuple, {'x', 1})
+    end)
+end
+
+-- Test index_object.parts:merge(second_index_parts)
+g.test_merge = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        local i = s:create_index('i', {parts = {{type = 'string', field = 3},
+                                                {type = 'scalar', field = 2}}})
+        local j = s:create_index('j', {parts = {{type = 'unsigned', field = 1},
+                                                {type = 'string', field = 3}}})
+        local exp = {{fieldno = 3, type = 'string', is_nullable = false},
+                     {fieldno = 2, type = 'scalar', is_nullable = false},
+                     {fieldno = 1, type = 'unsigned', is_nullable = false}}
+        t.assert_equals(i.parts:merge(j.parts):totable(), exp)
+
+        t.assert_error_msg_content_equals(
+            'Usage: index.parts:merge(second_index_parts)',
+            i.parts.merge)
+        t.assert_error_msg_content_equals(
+            'Usage: index.parts:merge(second_index_parts)',
+            i.parts.merge, i.parts)
+        t.assert_error_msg_content_equals(
+            'Usage: index.parts:merge(second_index_parts)',
+            i.parts.merge, i.parts, j.parts, box.NULL)
+        t.assert_error_msg_content_equals(
+            "Can't create key_def from the second index.parts",
+            i.parts.merge, i.parts, 100)
+        t.assert_error_msg_content_equals(
+            "Can't create key_def from the second index.parts",
+            i.parts.merge, i.parts, {{type = 'scalar'}})
+
+        local mk = s:create_index('mk', {parts = {{path = '[*]', field = 5}}})
+        t.assert_error_msg_content_equals(
+            'multikey path is unsupported',
+            mk.parts.merge, mk.parts, j.parts)
+        t.assert_error_msg_content_equals(
+            "Can't create key_def from the second index.parts",
+            i.parts.merge, i.parts, mk.parts)
+    end)
+end

--- a/test/box-tap/key_def.test.lua
+++ b/test/box-tap/key_def.test.lua
@@ -182,7 +182,7 @@ local key_def_new_cases = {
 
 local test = tap.test('key_def')
 
-test:plan(#key_def_new_cases - 1 + 7)
+test:plan(#key_def_new_cases - 1 + 8)
 for _, case in ipairs(key_def_new_cases) do
     if type(case) == 'function' then
         case()
@@ -555,6 +555,27 @@ test:test('merge()', function(test)
     }
     test:is_deeply(key_def_array_map:totable(), exp_parts,
         'composite case')
+end)
+
+-- Check the usage error messages.
+test:test('Usage errors', function(test)
+    test:plan(5)
+    -- key_def_lib.new() is tested above.
+    test:is_deeply({pcall(key_def_lib.extract_key)},
+                   {false, 'Usage: key_def:extract_key(tuple)'},
+                   'extract_key()')
+    test:is_deeply({pcall(key_def_lib.compare)},
+                   {false, 'Usage: key_def:compare(tuple_a, tuple_b)'},
+                   'compare()')
+    test:is_deeply({pcall(key_def_lib.compare_with_key)},
+                   {false, 'Usage: key_def:compare_with_key(tuple, key)'},
+                   'compare_with_key()')
+    test:is_deeply({pcall(key_def_lib.merge)},
+                   {false, 'Usage: key_def:merge(second_key_def)'},
+                   'merge()')
+    test:is_deeply({pcall(key_def_lib.totable)},
+                   {false, 'Usage: key_def:totable()'},
+                   'totable()')
 end)
 
 os.exit(test:check() and 0 or 1)


### PR DESCRIPTION
**box: populate index_object.parts with key_def module methods**

This patch adds 4 methods of the `key_def` module instance to the
`index_object.parts`, see the docbot request for details. The rest
methods (`new()` and `totable()`) are not applicable here, because the
instance is already created and pushed to the stack as a table.

@TarantoolBot document
Title: `index_object.parts` methods
Product: Tarantool
Since: 3.0
Root document: https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_index/parts/

`index_object.parts` has the following methods: `extract_key()`, `compare()`, `compare_with_key()`, `merge()`.
For their description and usage examples, refer to [Module key_def](https://www.tarantool.io/en/doc/latest/reference/reference_lua/key_def/#lua-object.key_def.key_def_object).

Root document: https://www.tarantool.io/en/doc/latest/reference/reference_lua/key_def/

`index_object.parts` can be used as a key_def module instance for calling the corresponding methods.

Example:

```lua
box.schema.space.create('T')
i = box.space.T:create_index('I', {parts={3, 'string', 1, 'unsigned'}})
box.space.T:insert{1, 99.5, 'X', nil, 99.5}
i.parts:extract_key(box.space.T:get({'X', 1}))
```

The code above is equivalent to:

```lua
key_def = require('key_def')
box.schema.space.create('T')
i = box.space.T:create_index('I', {parts={3, 'string', 1, 'unsigned'}})
box.space.T:insert{1, 99.5, 'X', nil, 99.5}
k = key_def.new(i.parts)
k:extract_key(box.space.T:get({'X', 1}))
```

Closes https://github.com/tarantool/tarantool/issues/7356