### PR TITLE
[2.8] fiber: use `clock_monotonic64` instead of `__rdtscp`

### DIFF
--- a/changelogs/unreleased/gh-5869-fix-crash-without-rdtscp.md
+++ b/changelogs/unreleased/gh-5869-fix-crash-without-rdtscp.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a crash that could happen on x86 systems without the
+  `RDTSCP` instruction (gh-5869).


### PR DESCRIPTION
clock_gettime(CLOCK_MONOTONIC) is implemented via the RDTSCP instruction on x86 an has the following advantages over the raw instruction:

* It checks for RDTSCP availability in CPUID. If RDTSCP is not supported, it switches to RDTSC.
* Linux guarantee that clock is monotonic, hence, the CPU miss detection is not needed.
* It works on ARM.

As for disadvantage, this function is about 2x slower compared to a single RDTSCP instruction. Performance degradation measured by the fiber switch benchmark [1] is about 3-7% for num_fibers == 10-1000.

Backport of #5869

[1] https://github.com/tarantool/tarantool/issues/2694#issuecomment-546381304

(cherry picked from commit 2fb7ffc502888c173484ec3fe594cee81cac0e8d)