### PR TITLE
sql: check column name in index definition

### DIFF
--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -2367,11 +2367,7 @@ index_fill_def(struct Parse *parse, struct index *index,
 			goto cleanup;
 
 		struct Expr *column_expr = sqlExprSkipCollate(expr);
-		if (column_expr->op != TK_COLUMN_REF) {
-			diag_set(ClientError, ER_UNSUPPORTED, "Tarantool",
-				 "functional indexes");
-			goto tnt_error;
-		}
+		assert(column_expr->op == TK_COLUMN_REF);
 
 		uint32_t fieldno = column_expr->iColumn;
 		uint32_t coll_id;

--- a/test/sql-luatest/gh_8365_no_func_in_index_def_test.lua
+++ b/test/sql-luatest/gh_8365_no_func_in_index_def_test.lua
@@ -1,0 +1,31 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'no_func_in_idx_def'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+--
+-- Make sure there is no assert() when a function is given instead of a column
+-- name. Also, aggregate functions should throw the same error as non-aggregate
+-- functions.
+--
+g.test_no_func_in_idx_def = function()
+    g.server:exec(function()
+        local sql = "CREATE TABLE t(i INT PRIMARY KEY, UNIQUE(abs(i)));"
+        local _, err = box.execute(sql)
+        local res = "Expressions are prohibited in an index definition"
+        t.assert_equals(err.message, res)
+
+        sql = "CREATE TABLE t(i INT PRIMARY KEY, UNIQUE(max(i)));"
+        _, err = box.execute(sql)
+        t.assert_equals(err.message, res)
+    end)
+end

--- a/test/sql-tap/colname.test.lua
+++ b/test/sql-tap/colname.test.lua
@@ -622,14 +622,14 @@ test:do_catchsql_test(
     "colname-11.2",
     [[CREATE TABLE t1(a INT, b INT, c INT, d INT, e INT,
       PRIMARY KEY(a), UNIQUE('b' COLLATE "unicode_ci" DESC));]],
-    {1, "/Tarantool does not support functional indexes/"})
+    {1, "Expressions are prohibited in an index definition"})
 
 test:execsql("create table table1(a  INT primary key, b INT, c INT)")
 
 test:do_catchsql_test(
     "colname-11.3",
     [[ CREATE INDEX t1c ON table1('c'); ]],
-    {1, "/Tarantool does not support functional indexes/"})
+    {1, "Expressions are prohibited in an index definition"})
 
 --
 -- gh-3962: Check auto generated names in different selects.

--- a/test/sql-tap/sql-errors.test.lua
+++ b/test/sql-tap/sql-errors.test.lua
@@ -335,7 +335,7 @@ test:do_catchsql_test(
 		CREATE INDEX i29 ON t0($1);
 	]], {
 		-- <sql-errors-1.29>
-		1,"Parameter markers are prohibited in an index definition"
+        1, "Expressions are prohibited in an index definition"
 		-- </sql-errors-1.29>
 	})
 

--- a/test/sql/message-func-indexes.result
+++ b/test/sql/message-func-indexes.result
@@ -21,7 +21,7 @@ box.execute("CREATE TABLE t2(object INTEGER PRIMARY KEY, price INTEGER, count IN
 box.execute("CREATE INDEX i1 ON t1(a+1)")
 ---
 - null
-- Tarantool does not support functional indexes
+- Expressions are prohibited in an index definition
 ...
 box.execute("CREATE INDEX i2 ON t1(a)")
 ---
@@ -30,7 +30,7 @@ box.execute("CREATE INDEX i2 ON t1(a)")
 box.execute("CREATE INDEX i3 ON t2(price + 100)")
 ---
 - null
-- Tarantool does not support functional indexes
+- Expressions are prohibited in an index definition
 ...
 box.execute("CREATE INDEX i4 ON t2(price)")
 ---
@@ -39,12 +39,12 @@ box.execute("CREATE INDEX i4 ON t2(price)")
 box.execute("CREATE INDEX i5 ON t2(count + 1)")
 ---
 - null
-- Tarantool does not support functional indexes
+- Expressions are prohibited in an index definition
 ...
 box.execute("CREATE INDEX i6 ON t2(count * price)")
 ---
 - null
-- Tarantool does not support functional indexes
+- Expressions are prohibited in an index definition
 ...
 -- Cleaning up.
 box.execute("DROP TABLE t1")


### PR DESCRIPTION
After this patch, the column name will be checked for being an ID before
resolution, not after.

Closes https://github.com/tarantool/tarantool/issues/8365

NO_DOC=bugfix in debug
NO_CHANGELOG=bugfix in debug