### PR TITLE
Add 2.11.0-rc issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-11-0-rc.md
+++ b/.github/ISSUE_TEMPLATE/2-11-0-rc.md
@@ -1,0 +1,32 @@
+---
+name: 2.11.0-rc
+about: Users's feedback regarding 2.11.0 release candidates
+title: "[2.11.0-rc] <...>"
+labels: 2.11.0-rc
+---
+
+Tarantool version: 2.11.0-rc<...>.
+
+**Problem description**
+
+<..OS/architecture/other metainformation..>
+
+<..a description of the problem..>
+
+**Steps to reproduce**
+
+test.lua file:
+
+```lua
+#!/usr/bin/env tarantool
+
+<...>
+```
+
+**Actual behavior**
+
+<..a clear and concise description of what you see..>
+
+**Expected behavior**
+
+<..a clear and concise description of what you expected to happen..>


### PR DESCRIPTION
We want to explicitly collect feedback that regards 2.11 release candidates.

The template automatically adds `2.11.0-rc` label to the new issue, so it'll be easier to filter issues relevant for the release candidates.