### PR TITLE
vinyl: fix use after free on key alloc error in iterator constructor

### DIFF
--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -3832,10 +3832,10 @@ vinyl_index_create_iterator(struct index *base, enum iterator_type type,
 		&it->iterator, lsm, tx, type, it->key, last,
 		(const struct vy_read_view **)&tx->read_view);
 	return (struct iterator *)it;
-err_key:
-	mempool_free(&env->iterator_pool, it);
 err_pos:
 	tuple_unref(it->key.stmt);
+err_key:
+	mempool_free(&env->iterator_pool, it);
 	return NULL;
 }
 

--- a/test/vinyl-luatest/gh_8372_key_alloc_error_in_iter_ctor_test.lua
+++ b/test/vinyl-luatest/gh_8372_key_alloc_error_in_iter_ctor_test.lua
@@ -1,0 +1,38 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+    cg.server:exec(function()
+        box.schema.create_space('test', {engine = 'vinyl'})
+        box.space.test:create_index('primary', {parts = {1, 'string'}})
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_key_alloc_error = function(cg)
+    cg.server:exec(function()
+        box.cfg({vinyl_max_tuple_size = 1})
+        t.assert_error_msg_matches(
+            "Failed to allocate [%d]+ bytes for tuple: tuple is too large. " ..
+            "Check 'vinyl_max_tuple_size' configuration option.",
+            box.space.test.select, box.space.test, {'foo'})
+    end)
+end
+
+g.test_pos_alloc_error = function(cg)
+    cg.server:exec(function()
+        box.cfg({vinyl_max_tuple_size = 100})
+        t.assert_error_msg_matches(
+            "Failed to allocate [%d]+ bytes for tuple: tuple is too large. " ..
+            "Check 'vinyl_max_tuple_size' configuration option.",
+            box.space.test.select, box.space.test, {},
+            {after = {string.rep('x', 101)}})
+    end)
+end


### PR DESCRIPTION
Error labes got mixed up. Fix the order and add a test.

Fixes commit 3f0263395bee ("vinyl: implement iterator pagination").

Closes #8372