### PR TITLE
box: make `space_foreach()` strictly ordered

### DIFF
--- a/changelogs/unreleased/gh-7954-sort-spaces-in-snapshot-by-id.md
+++ b/changelogs/unreleased/gh-7954-sort-spaces-in-snapshot-by-id.md
@@ -1,0 +1,4 @@
+## feature/box
+
+* Now non-system spaces in a snapshot file are sorted by their id. All
+  non-system spaces are stored after system spaces, as before (gh-7954).

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -575,6 +575,14 @@ void
 space_delete(struct space *space);
 
 /**
+ * Call a visitor function on every space. Spaces are visited in order from
+ * lowest space id to the highest, however, system spaces are visited first.
+ * This is essential for correctly recovery from the snapshot.
+ */
+int
+space_foreach(int (*func)(struct space *sp, void *udata), void *udata);
+
+/**
  * Dump space definition (key definitions, key count)
  * for ALTER.
  */

--- a/src/box/space_cache.c
+++ b/src/box/space_cache.c
@@ -72,63 +72,6 @@ space_by_name(const char *name)
 }
 
 /**
- * Visit all spaces and apply 'func'.
- */
-int
-space_foreach(int (*func)(struct space *sp, void *udata), void *udata)
-{
-	mh_int_t i;
-	struct space *space;
-	char key[6];
-	assert(mp_sizeof_uint(BOX_SYSTEM_ID_MIN) <= sizeof(key));
-	mp_encode_uint(key, BOX_SYSTEM_ID_MIN);
-
-	/*
-	 * Make sure we always visit system spaces first,
-	 * in order from lowest space id to the highest..
-	 * This is essential for correctly recovery from the
-	 * snapshot, and harmless otherwise.
-	 */
-	space = space_by_id(BOX_SPACE_ID);
-	struct index *pk = space ? space_index(space, 0) : NULL;
-	if (pk) {
-		struct iterator *it = index_create_iterator(pk, ITER_GE,
-							    key, 1);
-		if (it == NULL)
-			return -1;
-		int rc;
-		struct tuple *tuple;
-		while ((rc = iterator_next(it, &tuple)) == 0 && tuple != NULL) {
-			uint32_t id;
-			if (tuple_field_u32(tuple, BOX_SPACE_FIELD_ID,
-					    &id) != 0)
-				continue;
-			space = space_cache_find(id);
-			if (space == NULL)
-				continue;
-			if (!space_is_system(space))
-				break;
-			rc = func(space, udata);
-			if (rc != 0)
-				break;
-		}
-		iterator_delete(it);
-		if (rc != 0)
-			return -1;
-	}
-
-	mh_foreach(spaces, i) {
-		space = (struct space *)mh_i32ptr_node(spaces, i)->val;
-		if (space_is_system(space))
-			continue;
-		if (func(space, udata) != 0)
-			return -1;
-	}
-
-	return 0;
-}
-
-/**
  * If the @a old_space space is pinned, relink holders of that space to
  * the @a new_space.
  */

--- a/src/box/space_cache.h
+++ b/src/box/space_cache.h
@@ -119,13 +119,6 @@ space_cache_find(uint32_t id)
 }
 
 /**
- * Call a visitor function on every space in the space cache.
- * Traverse system spaces before other.
- */
-int
-space_foreach(int (*func)(struct space *sp, void *udata), void *udata);
-
-/**
  * Update contents of the space cache.
  *
  * If @old_space is NULL, insert @new_space into the cache.

--- a/test/box-luatest/gh_7954_sort_spaces_in_snap_by_id_test.lua
+++ b/test/box-luatest/gh_7954_sort_spaces_in_snap_by_id_test.lua
@@ -1,0 +1,67 @@
+local t = require('luatest')
+local g = t.group('gh-7954')
+
+g.before_all(function(cg)
+    local server = require('luatest.server')
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+-- Check that spaces in the snapshot file are strictly ordered.
+g.test_spaces_in_snap = function(cg)
+    local fio = require('fio')
+    local xlog = require('xlog')
+
+    -- Create some spaces, fill them with data, and write a snapshot.
+    local snap_name, expected_user_ids = cg.server:exec(function()
+        local spaces = {}
+        local ids = {167, 193, 239, 739, 761, 863, 881, 907, 937}
+        for i, id in ipairs(ids) do
+            spaces[i] = box.schema.create_space('test' .. id, {id = id})
+            spaces[i]:create_index('primary')
+        end
+        for i = 1, 100 do
+            spaces[1 + i % #spaces]:insert{i, i*i}
+        end
+        box.snapshot()
+        local checkpoints = box.info.gc().checkpoints
+        local snap_lsn = checkpoints[#checkpoints].signature
+        local snap_name = string.format("%020d.snap", snap_lsn)
+        return snap_name, ids
+    end)
+
+    -- Expected order:
+    -- 1. System spaces (id > 256 && id < 511)
+    -- 2. Spaces 167, 193, 239
+    -- 3. Spaces 739, 761, 863, 881, 907, 937
+    -- For each subgroup id >= prev_id
+    local prev_id = 0
+    local snap_user_ids = {}
+    local switched_to_user = false
+    local snap_path = fio.pathjoin(cg.server.workdir, snap_name)
+    for _, row in xlog.pairs(snap_path) do
+        if row.HEADER.type == "INSERT" then
+            local id = row.BODY.space_id
+            if switched_to_user then
+                -- Checking order of user spaces
+                if id ~= prev_id then
+                    table.insert(snap_user_ids, id)
+                end
+            else
+                -- Checking order of system spaces
+                if id ~= expected_user_ids[1] then
+                    t.assert_ge(id, prev_id)
+                else
+                    switched_to_user = true
+                    table.insert(snap_user_ids, id)
+                end
+            end
+            prev_id = id
+        end
+    end
+    t.assert_equals(snap_user_ids, expected_user_ids)
+end


### PR DESCRIPTION
This also changes the order in which spaces are stored in `.snap` files.

Currently `space_foreach()` iterates over spaces in the following order:
1. Spaces with id in the range [256..510], ordered by id;
2. All other (non-system) spaces in unspecified order.

This patch changes the order to:
1. Spaces with id in the range [256..511], ordered by id;
2. All other (non-system) spaces, ordered by id.

Strict ordered of non-system spaces is required by users who iterate over `.snap` files with `xlog.pairs()`.

Closes #7954

NO_DOC=[[1]](https://www.tarantool.io/en/doc/latest/dev_guide/internals/file_formats/#the-snapshot-file-format) already contains: "the .snap file’s records are ordered by space id"