### PR TITLE
httpc: added a decoders to a http response

### DIFF
--- a/changelogs/unreleased/gh-8363-unable-decode-body.md
+++ b/changelogs/unreleased/gh-8363-unable-decode-body.md
@@ -1,0 +1,3 @@
+## bugfix/lua/http client
+
+* Fixed a bug when body cannot be decoded in a response (gh-8363).

--- a/test/app-luatest/http_client_test.lua
+++ b/test/app-luatest/http_client_test.lua
@@ -886,6 +886,17 @@ g.test_decode_body = function(cg)
     t.assert_equals(r:decode(), body)
 end
 
+g.test_decode_body_gh_8363 = function(cg)
+    local opts = table.deepcopy(cg.opts)
+    local http = client:new()
+    local resp = http:get(cg.url .. "json_body", opts)
+    t.assert_equals(resp.status, 200, "HTTP code is not 200")
+    t.assert_equals(resp.headers["content-type"],
+                    "application/json; charset=utf-8",
+                    "content-type check")
+    t.assert_equals(resp:decode(), {1, 2})
+end
+
 g.test_decode_body_with_content_type_camel_case = function(cg)
     local url = cg.url
     local content_type = 'Application/JSON' -- Camel case.

--- a/test/app-luatest/http_client_test.lua
+++ b/test/app-luatest/http_client_test.lua
@@ -897,6 +897,22 @@ g.test_decode_body_gh_8363 = function(cg)
     t.assert_equals(resp:decode(), {1, 2})
 end
 
+g.test_decode_body_custom_decoder = function(cg)
+    local opts = table.deepcopy(cg.opts)
+    local http = client:new()
+    -- Define a new custom decoder, it adds a "team" word.
+    http.decoders["application/lango"] = function(body, _)
+        return string.format("%s team", body)
+    end
+
+    local resp = http:get(cg.url .. "lango_body", opts)
+    t.assert_equals(resp.status, 200, "HTTP code is not 200")
+    t.assert_equals(resp.headers["content-type"],
+                    "application/lango",
+                    "content-type check")
+    t.assert_equals(resp:decode(), "lango team")
+end
+
 g.test_decode_body_with_content_type_camel_case = function(cg)
     local url = cg.url
     local content_type = 'Application/JSON' -- Camel case.

--- a/test/app-luatest/http_client_unit_test.lua
+++ b/test/app-luatest/http_client_unit_test.lua
@@ -178,6 +178,7 @@ g.test_unit_decode_body = function(_)
             },
             decoders = decoders,
         }
+        resp._decoders = decoders
         local res = decode_body(resp)
         t.assert_equals(res, body)
     end
@@ -232,7 +233,7 @@ g.test_unit_decode_body_unknown_decoder = function(_)
         headers = {
             ["content-type"] = "application/unknown",
         },
-        decoders = decoders,
+        _decoders = decoders,
     }
     local ok, err = pcall(decode_body, resp)
     t.assert_equals(ok, false)
@@ -257,7 +258,7 @@ g.test_unit_decode_body_custom_decoder = function(_)
         headers = {
             ["content-type"] = "application/tarantool",
         },
-        decoders = decoders,
+        _decoders = decoders,
     }
     local ok, res = pcall(decode_body, resp)
     t.assert_equals(ok, true)
@@ -280,7 +281,7 @@ g.test_unit_decode_body_broken_decoder = function(_)
         headers = {
             ["content-type"] = "application/broken",
         },
-        decoders = decoders,
+        _decoders = decoders,
     }
     local ok, err = pcall(decode_body, resp)
     t.assert_equals(ok, false)

--- a/test/app-luatest/httpd.py
+++ b/test/app-luatest/httpd.py
@@ -52,6 +52,12 @@ def redirect():
     headers = [("Location", "/")]
     return code, body, headers
 
+def json_body():
+    code = "200 OK"
+    body = [b'[1,2]']
+    headers = [("Content-Type", "application/json; charset=utf-8")]
+    return code, body, headers
+
 paths = {
         "/": hello,
         "/abc": hello1,
@@ -59,6 +65,7 @@ paths = {
         "/headers": headers,
         "/long_query": long_query,
         "/redirect": redirect,
+        "/json_body": json_body,
         }
 
 def read_handle(env, response):

--- a/test/app-luatest/httpd.py
+++ b/test/app-luatest/httpd.py
@@ -52,6 +52,12 @@ def redirect():
     headers = [("Location", "/")]
     return code, body, headers
 
+def lango_body():
+    code = "200 OK"
+    body = [b'lango']
+    headers = [("Content-Type", "application/lango")]
+    return code, body, headers
+
 def json_body():
     code = "200 OK"
     body = [b'[1,2]']
@@ -66,6 +72,7 @@ paths = {
         "/long_query": long_query,
         "/redirect": redirect,
         "/json_body": json_body,
+        "/lango_body": lango_body,
         }
 
 def read_handle(env, response):


### PR DESCRIPTION
Patch fixes a bug when body in response couldn't be decoded:

```
tarantool> httpc = require('http.client').new()
tarantool> response = httpc:get('https://jsonplaceholder.typicode.com/todos/1')
tarantool> response:decode()

---
- error: 'builtin/http.client.lua:301: attempt to index field ''decoders'' (a nil
    value)'
...
```

Reported-by: Alexander Turenko <alexander.turenko@tarantool.org>

Fixes #8363

NO_DOC=bugfix