### PR TITLE
replication: add remote peer connection timeout

### DIFF
--- a/changelogs/unreleased/gh-7294-long-reconnection-fix.md
+++ b/changelogs/unreleased/gh-7294-long-reconnection-fix.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed `box.info.replication[...].upstream` hang in "connecting" state for
+  minutes after replica's DNS entry changes (gh-7294).

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -340,9 +340,10 @@ applier_connection_init(struct iostream *io, const struct uri *uri,
 	 * DNS resolution under the hood it is theoretically possible that
 	 * applier->addr_len will be different even for same uri.
 	 */
-	int fd = coio_connect(uri->host != NULL ? uri->host : "",
-			      uri->service != NULL ? uri->service : "",
-			      uri->host_hint, addr, addr_len);
+	int fd = coio_connect_timeout(uri->host != NULL ? uri->host : "",
+				      uri->service != NULL ? uri->service : "",
+				      uri->host_hint, addr, addr_len,
+				      replication_disconnect_timeout());
 	if (fd < 0)
 		diag_raise();
 	if (iostream_create(io, fd, io_ctx) != 0) {

--- a/test/replication-luatest/gh_7294_dont_connect_infinitely_test.lua
+++ b/test/replication-luatest/gh_7294_dont_connect_infinitely_test.lua
@@ -1,0 +1,36 @@
+local luatest = require('luatest')
+local server = require('luatest.server')
+local fio = require('fio')
+
+local g = luatest.group('gh_7294_infinite_connection_to_wrong_ip')
+
+g.before_each(function(cg)
+    cg.server = server:new({
+        alias = 'server',
+        box_cfg = {
+            replication = {
+                -- An address from TEST-NET-1, as described in RFC 5735
+                -- (https://www.rfc-editor.org/rfc/rfc5735).
+                '192.0.2.0:3301',
+            },
+            replication_connect_timeout = 1000,
+            replication_timeout = 0.1,
+        },
+    })
+end)
+
+g.after_each(function(cg)
+    cg.server:drop()
+end)
+
+g.test_no_infinite_connection = function(cg)
+    cg.server:start({wait_until_ready = false})
+
+    luatest.helpers.retrying({}, function()
+        -- Pass log filepath manually, because box.cfg.log is not available.
+        local log = fio.pathjoin(cg.server.workdir, cg.server.alias .. '.log')
+        luatest.assert(cg.server:grep_log('applier/192.0.2.0:3301 .* TimedOut',
+                                          1024, {filename = log}),
+                       'Timeout happened')
+    end)
+end


### PR DESCRIPTION
We use coio_connect() to connect the replica to a remote peer. It implies no timeout, and does a non-blocking connect() to the peer and then waits for the socket to become writable indefinitely.

When the remote peer changes its IP address, connect() might try connecting to the old address for as long as ~ 2 minutes (given the default tcp_syn_retries value of 6).

This blocks replica from trying to reconnect to the updated address and is pretty inconvenient.

Let's use coio_connect_timeout() instead and use
replication_disconnect_timeout() as a timeout, like everywhere else in master-replica communication.

Closes #7294

NO_DOC=bugfix