### PR TITLE
main: fix wrong log level printed during first `box.cfg{}`

### DIFF
--- a/src/lib/core/say.c
+++ b/src/lib/core/say.c
@@ -237,6 +237,12 @@ say_set_log_level(int new_level)
 	log_set_level(log_default, (enum say_level) new_level);
 }
 
+int
+say_get_log_level(void)
+{
+	return log_default->level;
+}
+
 void
 say_set_log_format(enum say_format format)
 {

--- a/src/lib/core/say.h
+++ b/src/lib/core/say.h
@@ -266,6 +266,12 @@ void
 say_set_log_level(int new_level);
 
 /**
+ * Get log level of the default logger.
+ */
+int
+say_get_log_level(void);
+
+/**
  * Set log format for default logger. Can be used dynamically.
  *
  * Can't be applied in case syslog or boot (will be ignored)

--- a/src/main.cc
+++ b/src/main.cc
@@ -503,7 +503,7 @@ load_cfg(void)
 	 */
 	say_info("%s %s %s", tarantool_package(), tarantool_version(),
 		 BUILD_INFO);
-	say_info("log level %i", cfg_geti("log_level"));
+	say_info("log level %d", say_get_log_level());
 
 	if (pid_file_handle != NULL) {
 		if (pidfile_write(pid_file_handle) == -1)

--- a/test/app-luatest/gh_8287_wrong_initial_log_level_printed_test.lua
+++ b/test/app-luatest/gh_8287_wrong_initial_log_level_printed_test.lua
@@ -1,0 +1,21 @@
+local t = require('luatest')
+local g = t.group('gh-8287')
+
+g.before_all(function(cg)
+    -- Set initial log level as a string
+    local box_cfg = {log_level = 'verbose'}
+    local server = require('luatest.server')
+    cg.server = server:new({alias = 'gh_8287', box_cfg = box_cfg})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+-- Check that log level printed to the log during first box.cfg{} is correct
+g.test_log_level = function(cg)
+    t.helpers.retrying({}, function()
+        t.assert(cg.server:grep_log("I> log level 6") ~= nil)
+    end)
+end


### PR DESCRIPTION
The `log_level` configuration parameter can be set as a number or a string. When it is a string, `cfg_geti()` returns 0.

Closes #8287