### PR TITLE
module api: fix formatting in comments for Doxygen

### DIFF
--- a/.github/workflows/publish-module-api-doc.yaml
+++ b/.github/workflows/publish-module-api-doc.yaml
@@ -1,10 +1,10 @@
-name: Publish module API documentation
+name: Build and publish module API documentation
 
 on:
   push:
     branches: [master]
   pull_request:
-    types: [opened, reopened, synchronize, labeled]
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 concurrency:
@@ -28,12 +28,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  publish-api-doc:
-    # Run on push to the branch 'master' or on pull request if the 'full-ci'
-    # label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+  build-api-doc:
     runs-on: ubuntu-latest
     steps:
       - name: Prepare checkout
@@ -57,7 +52,8 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4.4.0
         with:
           folder: doc/
-        if: github.ref == 'refs/heads/master' &&
+        if: github.repository == 'tarantool/tarantool' &&
+            github.ref == 'refs/heads/master' &&
             github.event_name != 'pull_request'
 
       - name: Send VK Teams message on failure

--- a/Doxyfile
+++ b/Doxyfile
@@ -195,13 +195,6 @@ TAB_SIZE               = 8
 
 ALIASES                =
 
-# This tag can be used to specify a number of word-keyword mappings (TCL only).
-# A mapping has the form "name=value". For example adding
-# "class=itcl::class" will allow you to use the command class in the
-# itcl::class meaning.
-
-TCL_SUBST              =
-
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C
 # sources only. Doxygen will then generate output that is more tailored for C.
 # For instance, some of the names that are used will be different. The list
@@ -594,6 +587,22 @@ QUIET                  = NO
 
 WARNINGS               = YES
 
+# If the WARN_AS_ERROR tag is set to YES then doxygen will immediately stop when
+# a warning is encountered. If the WARN_AS_ERROR tag is set to FAIL_ON_WARNINGS
+# then doxygen will continue running as if WARN_AS_ERROR tag is set to NO, but at
+# the end of the doxygen process doxygen will return with a non-zero status. If
+# the WARN_AS_ERROR tag is set to FAIL_ON_WARNINGS_PRINT then doxygen behaves
+# like FAIL_ON_WARNINGS but in case no WARN_LOGFILE is defined doxygen will not
+# write the warning messages in between other messages but write them at the end
+# of a run, in case a WARN_LOGFILE is defined the warning messages will be
+# besides being in the defined file also be shown at the end of a run, unless the
+# WARN_LOGFILE is defined as - i.e. standard output (stdout) in that case the
+# behavior will remain as with the setting FAIL_ON_WARNINGS.
+#
+# Possible values are: NO, YES, FAIL_ON_WARNINGS and FAIL_ON_WARNINGS_PRINT.
+
+WARN_AS_ERROR = FAIL_ON_WARNINGS
+
 # If WARN_IF_UNDOCUMENTED is set to YES, then doxygen will generate warnings
 # for undocumented members. If EXTRACT_ALL is set to YES then this flag will
 # automatically be disabled.
@@ -822,12 +831,6 @@ VERBATIM_HEADERS       = YES
 # contains a lot of classes, structs, unions or interfaces.
 
 ALPHABETICAL_INDEX     = YES
-
-# If the alphabetical index is enabled (see ALPHABETICAL_INDEX) then
-# the COLS_IN_ALPHA_INDEX tag can be used to specify the number of columns
-# in which this list will be split (can be a number in the range [1..20])
-
-COLS_IN_ALPHA_INDEX    = 5
 
 # In case all classes in a project start with a common prefix, all
 # classes will be put under the same header in the alphabetical index.
@@ -1541,11 +1544,6 @@ ALLEXTERNALS           = NO
 
 EXTERNAL_GROUPS        = YES
 
-# The PERL_PATH should be the absolute path and name of the perl script
-# interpreter (i.e. the result of `which perl').
-
-PERL_PATH              = /usr/bin/perl
-
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
@@ -1557,15 +1555,6 @@ PERL_PATH              = /usr/bin/perl
 # install and use dot, since it yields more powerful graphs.
 
 CLASS_DIAGRAMS         = YES
-
-# You can define message sequence charts within doxygen comments using the \msc
-# command. Doxygen will then run the mscgen tool (see
-# http://www.mcternan.me.uk/mscgen/) to produce the chart and insert it in the
-# documentation. The MSCGEN_PATH tag allows you to specify the directory where
-# the mscgen tool resides. If left empty the tool is assumed to be found in the
-# default search path.
-
-MSCGEN_PATH            =
 
 # If set to YES, the inheritance and collaboration graphs will hide
 # inheritance and usage relations if the target is undocumented

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -626,7 +626,8 @@ API_EXPORT int
 box_session_push(const char *data, const char *data_end);
 
 /**
- * \return current session's unique monotonic identifier (\sa box.session.id)
+ * \return current session's unique monotonic identifier
+ * \sa box.session.id
  */
 API_EXPORT uint64_t
 box_session_id(void);

--- a/src/box/decimal.h
+++ b/src/box/decimal.h
@@ -247,7 +247,7 @@ box_decimal_to_uint64(const box_decimal_t *dec, uint64_t *num);
  * If @a scale if greater than current @a dec scale, do nothing.
  *
  * @param dec decimal number
- * @oaram scale target scale
+ * @param scale target scale
  * @return NULL if @a scale is out of supported range
  * @return @a dec (changed)
  */
@@ -269,7 +269,7 @@ box_decimal_round(box_decimal_t *dec, int scale);
  * @sa box_decimal_round
  *
  * @param dec decimal number
- * @oaram scale target scale
+ * @param scale target scale
  * @return NULL if @a scale is out of supported range
  * @return @a dec (changed)
  */
@@ -296,7 +296,7 @@ box_decimal_trim(box_decimal_t *dec);
  * @sa box_decimal_trim
  *
  * @param dec decimal number
- * @oaram scale target scale
+ * @param scale target scale
  * @return NULL if scale is out of supported range (less than zero
  *              or too big)
  * @return @a dec (changed)
@@ -353,7 +353,7 @@ box_decimal_minus(box_decimal_t *res, const box_decimal_t *dec);
  * @param lhs left hand side operand
  * @param rhs right hand side operand
  * @return NULL on an error (an overflow for example)
- * @return decimal result (@res)
+ * @return decimal result (@a res)
  */
 API_EXPORT box_decimal_t *
 box_decimal_add(box_decimal_t *res, const box_decimal_t *lhs,
@@ -366,7 +366,7 @@ box_decimal_add(box_decimal_t *res, const box_decimal_t *lhs,
  * @param lhs left hand side operand
  * @param rhs right hand side operand
  * @return NULL on an error (an overflow for example)
- * @return decimal result (@res)
+ * @return decimal result (@a res)
  */
 API_EXPORT box_decimal_t *
 box_decimal_sub(box_decimal_t *res, const box_decimal_t *lhs,
@@ -379,7 +379,7 @@ box_decimal_sub(box_decimal_t *res, const box_decimal_t *lhs,
  * @param lhs left hand side operand
  * @param rhs right hand side operand
  * @return NULL on an error (an overflow for example)
- * @return decimal result (@res)
+ * @return decimal result (@a res)
  */
 API_EXPORT box_decimal_t *
 box_decimal_mul(box_decimal_t *res, const box_decimal_t *lhs,
@@ -392,7 +392,7 @@ box_decimal_mul(box_decimal_t *res, const box_decimal_t *lhs,
  * @param lhs left hand side operand
  * @param rhs right hand side operand
  * @return NULL on an error
- * @return decimal result (@res)
+ * @return decimal result (@a res)
  */
 API_EXPORT box_decimal_t *
 box_decimal_div(box_decimal_t *res, const box_decimal_t *lhs,
@@ -407,7 +407,7 @@ box_decimal_div(box_decimal_t *res, const box_decimal_t *lhs,
  * @param lhs left hand side operand
  * @param rhs right hand side operand
  * @return NULL on an error
- * @return decimal result (@res)
+ * @return decimal result (@a res)
  */
 API_EXPORT box_decimal_t *
 box_decimal_remainder(box_decimal_t *res, const box_decimal_t *lhs,
@@ -423,7 +423,7 @@ box_decimal_remainder(box_decimal_t *res, const box_decimal_t *lhs,
  * @param res where to hold the result
  * @param dec decimal operand
  * @return NULL on an error
- * @return decimal result (@res)
+ * @return decimal result (@a res)
  */
 API_EXPORT box_decimal_t *
 box_decimal_log10(box_decimal_t *res, const box_decimal_t *dec);
@@ -434,7 +434,7 @@ box_decimal_log10(box_decimal_t *res, const box_decimal_t *dec);
  * @param res where to hold the result
  * @param dec decimal operand
  * @return NULL on an error
- * @return decimal result (@res)
+ * @return decimal result (@a res)
  */
 API_EXPORT box_decimal_t *
 box_decimal_ln(box_decimal_t *res, const box_decimal_t *dec);
@@ -446,7 +446,7 @@ box_decimal_ln(box_decimal_t *res, const box_decimal_t *dec);
  * @param lhs left hand side operand, base
  * @param rhs right hand side operand, power
  * @return NULL on an error
- * @return decimal result (@res)
+ * @return decimal result (@a res)
  */
 API_EXPORT box_decimal_t *
 box_decimal_pow(box_decimal_t *res, const box_decimal_t *lhs,
@@ -458,7 +458,7 @@ box_decimal_pow(box_decimal_t *res, const box_decimal_t *lhs,
  * @param res where to hold the result
  * @param dec decimal operand
  * @return NULL on an error
- * @return decimal result (@res)
+ * @return decimal result (@a res)
  */
 API_EXPORT box_decimal_t *
 box_decimal_exp(box_decimal_t *res, const box_decimal_t *dec);
@@ -469,7 +469,7 @@ box_decimal_exp(box_decimal_t *res, const box_decimal_t *dec);
  * @param res where to hold the result
  * @param dec decimal operand
  * @return NULL on an error
- * @return decimal result (@res)
+ * @return decimal result (@a res)
  */
 API_EXPORT box_decimal_t *
 box_decimal_sqrt(box_decimal_t *res, const box_decimal_t *dec);
@@ -515,19 +515,23 @@ box_decimal_mp_decode(box_decimal_t *dec, const char **data);
  * Decode a decimal from msgpack @a data without the msgpack
  * extension header.
  *
- *  | box_decimal_mp_decode_data() must be called for this position
- *  |                                        |
- *  |                                        v
- *  | <msgpack type> <size> <extension type> <data>
- *  | ^
- *  | |
- *  | box_decimal_mp_decode() must be called for this position
+ * \code
+ * box_decimal_mp_decode_data() must be called for this position
+ *                                        |
+ *                                        v
+ * <msgpack type> <size> <extension type> <data>
+ * ^
+ * |
+ * box_decimal_mp_decode() must be called for this position
+ * \endcode
  *
  * This function is suitable to finish decoding after calling
  * mp_decode_extl() (from the msgpuck library).
  *
  * @param dec where to store the decoded decimal
  * @param data pointer to a buffer with the msgpack data
+ * @param size size of the decimal data in the buffer; this value
+ *             is returned by mp_decode_extl()
  * @return NULL if the msgpack data does not represent a valid
  *         decimal value
  * @return the decoded decimal

--- a/src/box/error.h
+++ b/src/box/error.h
@@ -122,6 +122,8 @@ box_error_clear(void);
 /**
  * Set the last error.
  *
+ * \param file file name, usually __FILE__ macro
+ * \param line line number in the file, usually __LINE__ macro
  * \param code IPROTO error code (enum \link box_error_code \endlink)
  * \param format (const char * ) - printf()-like format string
  * \param ... - format arguments

--- a/src/box/field_def.h
+++ b/src/box/field_def.h
@@ -73,6 +73,9 @@ enum field_type {
 	field_type_MAX
 };
 
+/**
+ * Possible actions on conflict.
+ */
 enum on_conflict_action {
 	ON_CONFLICT_ACTION_NONE = 0,
 	ON_CONFLICT_ACTION_ROLLBACK,

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -243,6 +243,8 @@ box_index_count(uint32_t space_id, uint32_t index_id, int type,
  * @param tuple Tuple from which need to extract key.
  * @param space_id Space identifier.
  * @param index_id Index identifier.
+ * @param[out] key_size where to store the size of the extracted
+ *             key; pass NULL here if it is not needed
  * @retval not NULL Success
  * @retval     NULL Memory Allocation error
  */

--- a/src/box/key_def.h
+++ b/src/box/key_def.h
@@ -310,30 +310,33 @@ enum {
 };
 
 /**
- * It is recommended to verify size of <box_key_part_def_t>
+ * It is recommended to verify size of box_key_part_def_t
  * against this constant on the module side at build time.
  * Example:
  *
- * | #if !defined(__cplusplus) && !defined(static_assert)
- * | #define static_assert _Static_assert
- * | #endif
- * |
- * | (slash)*
- * |  * Verify that <box_key_part_def_t> has the same size when
- * |  * compiled within tarantool and within the module.
- * |  *
- * |  * It is important, because the module allocates an array of key
- * |  * parts and passes it to <box_key_def_new_v2>() tarantool
- * |  * function.
- * |  *(slash)
- * | static_assert(sizeof(box_key_part_def_t) == BOX_KEY_PART_DEF_T_SIZE,
- * |               "sizeof(box_key_part_def_t)");
+ * \code
+ * #if !defined(__cplusplus) && !defined(static_assert)
+ * #define static_assert _Static_assert
+ * #endif
+ *
+ * (slash)*
+ *  * Verify that box_key_part_def_t has the same size when
+ *  * compiled within tarantool and within the module.
+ *  *
+ *  * It is important, because the module allocates an array of key
+ *  * parts and passes it to box_key_def_new_v2() tarantool
+ *  * function.
+ *  *(slash)
+ * static_assert(sizeof(box_key_part_def_t) == BOX_KEY_PART_DEF_T_SIZE,
+ *               "sizeof(box_key_part_def_t)");
+ * \endcode
  *
  * This snippet is not part of module.h, because portability of
  * static_assert() / _Static_assert() is dubious. It should be
  * decision of a module author how portable its code should be.
  */
 enum {
+	/** The constant. */
 	BOX_KEY_PART_DEF_T_SIZE = 64,
 };
 
@@ -341,22 +344,22 @@ enum {
  * Public representation of a key part definition.
  *
  * Usage: Allocate an array of such key parts, initialize each
- * key part (call <box_key_part_def_create>() and set necessary
- * fields), pass the array into <box_key_def_new_v2>() function.
+ * key part (call box_key_part_def_create() and set necessary
+ * fields), pass the array into box_key_def_new_v2() function.
  *
- * Important: A module should call <box_key_part_def_create>()
+ * Important: A module should call box_key_part_def_create()
  * to initialize the structure with default values. There is no
  * guarantee that all future default values for fields and flags
  * will be remain the same.
  *
- * The idea of separation from internal <struct key_part_def> is
+ * The idea of separation from internal "struct key_part_def" is
  * to provide stable API and ABI for modules.
  *
  * New fields may be added into the end of the structure in later
  * tarantool versions. Also new flags may be introduced within
- * <flags> field. <collation> cannot be changed to a union (to
+ * \a flags field. \a collation cannot be changed to a union (to
  * reuse for some other value), because it is verified even for
- * a non-string key part by <box_key_def_new_v2>().
+ * a non-string key part by box_key_def_new_v2().
  *
  * Fields that are unknown at given tarantool version are ignored
  * in general, but filled with zeros when initialized.
@@ -387,7 +390,7 @@ typedef union PACKED {
 		 *
 		 * => key: ["bar"]
 		 *
-		 * Note: When the path is given, <field_type>
+		 * Note: When the path is given, \a field_type
 		 * means type of the nested field.
 		 */
 		const char *path;
@@ -404,7 +407,7 @@ typedef union PACKED {
  *
  * May be used for tuple format creation and/or tuple comparison.
  *
- * \sa <box_key_def_new_v2>().
+ * \sa box_key_def_new_v2()
  *
  * \param fields array with key field identifiers
  * \param types array with key field types (see enum field_type)
@@ -420,7 +423,7 @@ box_key_def_new(uint32_t *fields, uint32_t *types, uint32_t part_count);
  *  | Field       | Default value   | Details |
  *  | ----------- | --------------- | ------- |
  *  | fieldno     | 0               |         |
- *  | flags       | <default flags> |         |
+ *  | flags       |\a default flags |         |
  *  | field_type  | NULL            | [^1]    |
  *  | collation   | NULL            |         |
  *  | path        | NULL            |         |
@@ -440,10 +443,10 @@ box_key_def_new(uint32_t *fields, uint32_t *types, uint32_t part_count);
  * validation, key extraction, comparisons and so on.
  *
  * All trailing padding bytes are set to zero. The same for
- * unknown <flags> bits.
+ * unknown \a flags bits.
  *
- * [^1]: <box_key_def_new_v2>() does not accept NULL as a
- *       <field_type>, so it should be filled explicitly.
+ * [^1]: box_key_def_new_v2() does not accept NULL as a
+ *       \a field_type, so it should be filled explicitly.
  */
 API_EXPORT void
 box_key_part_def_create(box_key_part_def_t *part);
@@ -451,14 +454,14 @@ box_key_part_def_create(box_key_part_def_t *part);
 /**
  * Create a key_def from given key parts.
  *
- * Unlike <box_key_def_new>() this function allows to define
+ * Unlike box_key_def_new() this function allows to define
  * nullability, collation and other options for each key part.
  *
- * <box_key_part_def_t> fields that are unknown at given tarantool
- * version are ignored. The same for unknown <flags> bits.
+ * box_key_part_def_t fields that are unknown at given tarantool
+ * version are ignored. The same for unknown \a flags bits.
  *
  * In case of an error set a diag and return NULL.
- * @sa <box_error_last>().
+ * @sa box_error_last()
  */
 API_EXPORT box_key_def_t *
 box_key_def_new_v2(box_key_part_def_t *parts, uint32_t part_count);
@@ -485,13 +488,13 @@ box_key_def_delete(box_key_def_t *key_def);
  *
  * The function allocates key parts and storage for pointer fields
  * (e.g. collation names) on the box region.
- * @sa <box_region_truncate>().
+ * @sa box_region_truncate()
  *
- * <box_key_part_def_t> fields that are unknown at given tarantool
- * version are set to zero. The same for unknown <flags> bits.
+ * box_key_part_def_t fields that are unknown at given tarantool
+ * version are set to zero. The same for unknown \a flags bits.
  *
  * In case of an error set a diag and return NULL.
- * @sa <box_error_last>().
+ * @sa box_error_last()
  */
 API_EXPORT box_key_part_def_t *
 box_key_def_dump_parts(const box_key_def_t *key_def, uint32_t *part_count_ptr);
@@ -506,7 +509,7 @@ box_key_def_dump_parts(const box_key_def_t *key_def, uint32_t *part_count_ptr);
  * @retval -1  The tuple is invalid.
  *
  * In case of an invalid tuple set a diag and return -1.
- * @sa <box_error_last>().
+ * @sa box_error_last()
  */
 API_EXPORT int
 box_key_def_validate_tuple(box_key_def_t *key_def, box_tuple_t *tuple);
@@ -523,11 +526,10 @@ box_key_def_validate_tuple(box_key_def_t *key_def, box_tuple_t *tuple);
 API_EXPORT int
 box_tuple_compare(box_tuple_t *tuple_a, box_tuple_t *tuple_b,
 		  box_key_def_t *key_def);
-
 /**
  * @brief Compare tuple with key using the key definition.
- * @param tuple tuple
- * @param key key with MessagePack array header
+ * @param tuple_a tuple
+ * @param key_b key with MessagePack array header
  * @param key_def key definition
  *
  * @retval 0  if key_fields(tuple) == parts(key)
@@ -551,7 +553,7 @@ box_tuple_compare_with_key(box_tuple_t *tuple_a, const char *key_b,
  * @retval NULL      Memory error.
  *
  * In case of an error set a diag and return NULL.
- * @sa <box_error_last>().
+ * @sa box_error_last()
  */
 API_EXPORT box_key_def_t *
 box_key_def_merge(const box_key_def_t *first, const box_key_def_t *second);
@@ -559,7 +561,7 @@ box_key_def_merge(const box_key_def_t *first, const box_key_def_t *second);
 /**
  * Extract key from tuple by given key definition and return
  * buffer allocated on the box region with this key.
- * @sa <box_region_truncate>().
+ * @sa box_region_truncate()
  *
  * This function has O(n) complexity, where n is the number of key
  * parts.
@@ -573,7 +575,7 @@ box_key_def_merge(const box_key_def_t *first, const box_key_def_t *second);
  * @retval NULL      Memory allocation error.
  *
  * In case of an error set a diag and return NULL.
- * @sa <box_error_last>().
+ * @sa box_error_last()
  */
 API_EXPORT char *
 box_key_def_extract_key(box_key_def_t *key_def, box_tuple_t *tuple,
@@ -599,7 +601,7 @@ box_key_def_extract_key(box_key_def_t *key_def, box_tuple_t *tuple,
  * @retval -1  The key is invalid.
  *
  * In case of an invalid key set a diag and return -1.
- * @sa <box_error_last>().
+ * @sa box_error_last()
  */
 API_EXPORT int
 box_key_def_validate_key(const box_key_def_t *key_def, const char *key,
@@ -624,7 +626,7 @@ box_key_def_validate_key(const box_key_def_t *key_def, const char *key,
  * @retval -1  The key is invalid.
  *
  * In case of an invalid key set a diag and return -1.
- * @sa <box_error_last>().
+ * @sa box_error_last()
  */
 API_EXPORT int
 box_key_def_validate_full_key(const box_key_def_t *key_def, const char *key,

--- a/src/box/lua/tuple.h
+++ b/src/box/lua/tuple.h
@@ -63,6 +63,7 @@ luaT_checktuple(struct lua_State *L, int idx);
 /**
  * Push a tuple onto the stack.
  * @param L Lua State
+ * @param tuple
  * @sa luaT_istuple
  * @throws on OOM
  */
@@ -89,7 +90,7 @@ luaT_istuple(struct lua_State *L, int idx);
  *                       (or NULL).
  *
  * The storage for data is allocated on the box region. A caller
- * should call <box_region_truncate>() to release the data.
+ * should call box_region_truncate() to release the data.
  *
  * In case of an error set a diag and return NULL.
  *
@@ -103,14 +104,14 @@ luaT_tuple_encode(struct lua_State *L, int idx, size_t *tuple_len_ptr);
  * tuple.
  *
  * The new tuple is referenced in the same way as one created by
- * <box_tuple_new>(). There are two possible usage scenarios:
+ * box_tuple_new(). There are two possible usage scenarios:
  *
  * 1. A short living tuple may not be referenced explicitly and
  *    will be collected automatically at the next module API call
  *    that yields or returns a tuple.
  * 2. A long living tuple must be referenced using
- *    <box_tuple_ref>() and unreferenced then with
- *    <box_tuple_unref>().
+ *    box_tuple_ref() and unreferenced then with
+ *    box_tuple_unref().
  *
  * @sa box_tuple_ref()
  *

--- a/src/box/schema.h
+++ b/src/box/schema.h
@@ -57,7 +57,8 @@ extern struct rlist on_schema_init;
 /**
  * Returns the current version of the database schema, an unsigned number
  * that goes up when there is a major change in the schema, i.e., on DDL
- * operations (\sa IPROTO_SCHEMA_VERSION).
+ * operations.
+ * \sa IPROTO_SCHEMA_VERSION
  */
 API_EXPORT uint64_t
 box_schema_version(void);

--- a/src/box/tuple.h
+++ b/src/box/tuple.h
@@ -77,7 +77,6 @@ tuple_arena_destroy(struct slab_arena *arena);
 
 /**
  * Creates a new format for standalone tuples.
- *
  * Tuples created with the new format are allocated from the runtime arena.
  * In contrast to the preallocated tuple_format_runtime, which has no field
  * names, the new format uses the provided field name dictionary.
@@ -250,7 +249,7 @@ box_tuple_iterator_t *
 box_tuple_iterator(box_tuple_t *tuple);
 
 /**
- * Destroy and free tuple iterator
+ * Destroy and free tuple iterator.
  */
 void
 box_tuple_iterator_free(box_tuple_iterator_t *it);
@@ -258,8 +257,8 @@ box_tuple_iterator_free(box_tuple_iterator_t *it);
 /**
  * Return zero-based next position in iterator.
  * That is, this function return the field id of field that will be
- * returned by the next call to box_tuple_next(it). Returned value is zero
- * after initialization or rewind and box_tuple_field_count(tuple)
+ * returned by the next call to box_tuple_next(). Returned value is zero
+ * after initialization or rewind and box_tuple_field_count()
  * after the end of iteration.
  *
  * \param it tuple iterator
@@ -281,7 +280,7 @@ box_tuple_rewind(box_tuple_iterator_t *it);
  * Seek the tuple iterator.
  *
  * The returned buffer is valid until next call to box_tuple_* API.
- * Requested fieldno returned by next call to box_tuple_next(it).
+ * Requested fieldno returned by next call to box_tuple_next().
  *
  * \param it tuple iterator
  * \param fieldno - zero-based position in MsgPack array.
@@ -320,9 +319,46 @@ box_tuple_next(box_tuple_iterator_t *it);
 box_tuple_t *
 box_tuple_new(box_tuple_format_t *format, const char *data, const char *end);
 
+/**
+ * Update a tuple.
+ *
+ * Function returns a copy of tuple with updated fields.
+ * Pay attention that original tuple is left without changes.
+ *
+ * @param tuple Tuple to update.
+ * @param expr MessagePack array of operations.
+ * @param expr_end End of the @a expr.
+ *
+ * @retval NULL The tuple was not updated.
+ * @retval box_tuple_t A copy of original tuple with updated fields.
+ *
+ * @sa box_update()
+ */
 box_tuple_t *
 box_tuple_update(box_tuple_t *tuple, const char *expr, const char *expr_end);
 
+/**
+ * Update a tuple.
+ *
+ * The same as box_tuple_update(), but ignores errors. In case of an error the
+ * tuple is left intact, but an error message is printed. Only client errors are
+ * ignored, such as a bad field type, or wrong field index/name. System errors,
+ * such as OOM, are not ignored and raised just like with a normal
+ * box_tuple_update(). Note that only bad operations are ignored. All correct
+ * operations are applied.
+ *
+ * Despite the function name (upsert, update and insert), the function does not
+ * insert any tuple.
+ *
+ * @param tuple Tuple to update.
+ * @param expr MessagePack array of operations.
+ * @param expr_end End of the @a expr.
+ *
+ * @retval NULL The tuple was not updated.
+ * @retval box_tuple_t A copy of original tuple with updated fields.
+ *
+ * @sa box_upsert()
+ */
 box_tuple_t *
 box_tuple_upsert(box_tuple_t *tuple, const char *expr, const char *expr_end);
 

--- a/src/box/tuple_format.h
+++ b/src/box/tuple_format.h
@@ -446,7 +446,7 @@ typedef struct tuple_format box_tuple_format_t;
  * Return new in-memory tuple format based on passed key definitions.
  *
  * \param keys array of keys defined for the format
- * \key_count count of keys
+ * \param key_count count of keys
  * \retval new tuple format if success
  * \retval NULL for error
  */
@@ -456,7 +456,7 @@ box_tuple_format_new(struct key_def **keys, uint16_t key_count);
 /**
  * Increment tuple format ref count.
  *
- * \param tuple_format the tuple format to ref
+ * \param format the tuple format to ref
  */
 void
 box_tuple_format_ref(box_tuple_format_t *format);
@@ -464,7 +464,7 @@ box_tuple_format_ref(box_tuple_format_t *format);
 /**
  * Decrement tuple format ref count.
  *
- * \param tuple_format the tuple format to unref
+ * \param format the tuple format to unref
  */
 void
 box_tuple_format_unref(box_tuple_format_t *format);

--- a/src/box/xrow_update.c
+++ b/src/box/xrow_update.c
@@ -133,7 +133,7 @@ struct xrow_update
  *
  * @param[out] update Update meta.
  * @param expr MessagePack array of operations.
- * @param expr_end End of the @expr.
+ * @param expr_end End of the @a expr.
  * @param dict Dictionary to lookup field number by a name.
  * @param field_count_hint Field count in the updated tuple. If
  *        there is no tuple at hand (for example, when we are

--- a/src/lib/core/clock.h
+++ b/src/lib/core/clock.h
@@ -44,7 +44,7 @@ extern "C" {
  * A settable system-wide clock that measures real (i.e.,
  * wall-clock) time.
  *
- * See clock_gettime(2), CLOCK_REALTIME.
+ * \sa clock_gettime(2), CLOCK_REALTIME.
  */
 double
 clock_realtime(void);
@@ -52,7 +52,7 @@ clock_realtime(void);
 /**
  * A nonsettable system-wide clock that represents monotonic time.
  *
- * See clock_gettime(2), CLOCK_MONOTONIC.
+ * \sa clock_gettime(2), CLOCK_MONOTONIC.
  */
 double
 clock_monotonic(void);
@@ -61,7 +61,7 @@ clock_monotonic(void);
  * A clock that measures CPU time consumed by this process (by all
  * threads in the process).
  *
- * See clock_gettime(2), CLOCK_PROCESS_CPUTIME_ID.
+ * \sa clock_gettime(2), CLOCK_PROCESS_CPUTIME_ID.
  */
 double
 clock_process(void);
@@ -69,7 +69,7 @@ clock_process(void);
 /**
  * A clock that measures CPU time consumed by this thread.
  *
- * See clock_gettime(2), CLOCK_THREAD_CPUTIME_ID.
+ * \sa clock_gettime(2), CLOCK_THREAD_CPUTIME_ID.
  */
 double
 clock_thread(void);

--- a/src/lib/core/coio.h
+++ b/src/lib/core/coio.h
@@ -168,12 +168,12 @@ enum {
 
 /**
  * Wait until READ or WRITE event on socket (\a fd). Yields.
- * \param fd - non-blocking socket file description
- * \param events - requested events to wait.
+ * \param fd non-blocking socket file description
+ * \param event requested events to wait.
  * Combination of TNT_IO_READ | TNT_IO_WRITE bit flags.
- * \param timeout - timeout in seconds.
- * \retval 0 - timeout
- * \retval >0 - returned events. Combination of TNT_IO_READ | TNT_IO_WRITE
+ * \param timeout timeout in seconds.
+ * \retval 0 timeout
+ * \retval >0 returned events. Combination of TNT_IO_READ | TNT_IO_WRITE
  * bit flags.
  */
 API_EXPORT int

--- a/src/lib/core/coio_task.h
+++ b/src/lib/core/coio_task.h
@@ -165,7 +165,7 @@ struct addrinfo;
  * @param host host name, i.e. "tarantool.org"
  * @param port service name, i.e. "80" or "http"
  * @param hints hints, see getaddrinfo(3)
- * @param res[out] result, see getaddrinfo(3)
+ * @param[out] res result, see getaddrinfo(3)
  * @param timeout timeout
  * @retval  0 on success, please free @a res using freeaddrinfo(3).
  * @retval -1 on error, check diag.

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -200,8 +200,8 @@ fiber_attr_delete(struct fiber_attr *fiber_attr);
 /**
  * Set stack size for the fiber attribute.
  *
- * \param fiber_attribute fiber attribute container
- * \param stacksize stack size for new fibers
+ * \param fiber_attr fiber attribute container
+ * \param stack_size stack size for new fibers
  */
 API_EXPORT int
 fiber_attr_setstacksize(struct fiber_attr *fiber_attr, size_t stack_size);
@@ -209,7 +209,7 @@ fiber_attr_setstacksize(struct fiber_attr *fiber_attr, size_t stack_size);
 /**
  * Get stack size from the fiber attribute.
  *
- * \param fiber_attribute fiber attribute container or NULL for default
+ * \param fiber_attr fiber attribute container or NULL for default
  * \retval stack size
  */
 API_EXPORT size_t
@@ -240,7 +240,7 @@ fiber_self(void);
  * completes.
  *
  * \param name       string with fiber name
- * \param fiber_func func for run inside fiber
+ * \param f          func for run inside fiber
  *
  * \sa fiber_start
  */
@@ -259,7 +259,7 @@ fiber_new(const char *name, fiber_func f);
  *
  * \param name       string with fiber name
  * \param fiber_attr fiber attributes
- * \param fiber_func func for run inside fiber
+ * \param f          func for run inside fiber
  *
  * \sa fiber_start
  */
@@ -340,6 +340,7 @@ fiber_set_cancellable(bool yesno);
 
 /**
  * Set fiber to be joinable (false by default).
+ * \param fiber to (un)set the joinable property
  * \param yesno status to set
  */
 API_EXPORT void
@@ -363,7 +364,7 @@ fiber_join(struct fiber *f);
  * same as fiber_join function.
  * Return fiber execution status to the caller or -1
  * if timeout exceeded and set diag.
- * The fiber must not be detached (@sa fiber_set_joinable()).
+ * The fiber must not be detached @sa fiber_set_joinable()
  * @pre FIBER_IS_JOINABLE flag is set.
  *
  * \param f fiber to be woken up
@@ -378,7 +379,7 @@ fiber_join_timeout(struct fiber *f, double timeout);
  *
  * \param s time to sleep
  *
- * \note this is a cancellation point (\sa fiber_is_cancelled)
+ * \note this is a cancellation point \sa fiber_is_cancelled
  */
 API_EXPORT void
 fiber_sleep(double s);
@@ -424,10 +425,11 @@ fiber_clock64(void);
 API_EXPORT void
 fiber_reschedule(void);
 
+struct slab_cache;
+
 /**
  * Return slab_cache suitable to use with tarantool/small library
  */
-struct slab_cache;
 API_EXPORT struct slab_cache *
 cord_slab_cache(void);
 
@@ -439,21 +441,25 @@ cord_slab_cache(void);
  *
  * Typical usage is illustrated in the sketch below.
  *
- *  | size_t region_svp = box_region_used();
- *  | while (<...>) {
- *  |     char *buf = box_region_alloc(<...>);
- *  |     <...>
- *  | }
- *  | box_region_truncate(region_svp);
+ * \code
+ * size_t region_svp = box_region_used();
+ * while (<...>) {
+ *     char *buf = box_region_alloc(<...>);
+ *     <...>
+ * }
+ * box_region_truncate(region_svp);
+ * \endcode
  *
  * There are module API functions that return a result on
  * this region. In this case a caller is responsible to free the
  * result:
  *
- *  | size_t region_svp = box_region_used();
- *  | char *buf = box_<...>(<...>);
- *  | <...>
- *  | box_region_truncate(region_svp);
+ * \code
+ * size_t region_svp = box_region_used();
+ * char *buf = box_<...>(<...>);
+ * <...>
+ * box_region_truncate(region_svp);
+ * \endcode
  *
  * This API provides better compatibility guarantees over using
  * the small library directly in a module. A binary layout of
@@ -461,13 +467,13 @@ cord_slab_cache(void);
  * <box_region_*>() functions will remain API and ABI compatible.
  *
  * Each fiber has its own box region. It means that a call of,
- * say, <box_region_used>() will give its own value in different
+ * say, box_region_used() will give its own value in different
  * fibers. It also means that a yield does not invalidate data in
  * the box region.
  *
  * Prior to version 2.11, the box region was implicitly cleaned up
- * on transaction commit (see <box_txn_commit>()) so that
- * <box_region_truncate>() wasn't strictly necessary. Starting from
+ * on transaction commit (see box_txn_commit()) so that
+ * box_region_truncate() wasn't strictly necessary. Starting from
  * version 2.11, it isn't true anymore, and the client code must free
  * all its allocations explicitly.
  */
@@ -485,7 +491,7 @@ box_region_used(void);
  * behaviour.
  *
  * In case of a memory error set a diag and return NULL.
- * @sa <box_error_last>().
+ * @sa box_error_last().
  */
 API_EXPORT void *
 box_region_alloc(size_t size);
@@ -496,7 +502,7 @@ box_region_alloc(size_t size);
  * Alignment must be a power of 2.
  *
  * In case of a memory error set a diag and return NULL.
- * @sa <box_error_last>().
+ * @sa box_error_last().
  */
 API_EXPORT void *
 box_region_aligned_alloc(size_t size, size_t alignment);
@@ -913,7 +919,7 @@ cord_cancel_and_join(struct cord *cord);
  * fiber.
  *
  * @param name       string with fiber name
- * @param fiber_func func for run inside fiber
+ * @param f          func for run inside fiber
  */
 struct fiber *
 fiber_new_system(const char *name, fiber_func f);

--- a/src/lib/core/say.h
+++ b/src/lib/core/say.h
@@ -69,6 +69,9 @@ enum say_format {
 	say_format_MAX
 };
 
+/**
+ * Logging level.
+ */
 extern int log_level;
 
 /**
@@ -79,6 +82,9 @@ extern void
 (*log_write_flightrec)(int level, const char *filename, int line,
 		       const char *error, const char *format, va_list ap);
 
+/**
+ * Function checks whether passed log level is enabled.
+ */
 static inline bool
 say_log_level_is_enabled(int level)
 {

--- a/src/lua/error.h
+++ b/src/lua/error.h
@@ -59,6 +59,12 @@ luaT_error(lua_State *L);
 LUA_API int
 luaT_push_nil_and_error(lua_State *L);
 
+/**
+ * Push error to a Lua stack.
+ *
+ * @param L Lua stack.
+ * @param e error.
+ */
 void
 luaT_pusherror(struct lua_State *L, struct error *e);
 /** \endcond public */

--- a/src/lua/utils.h
+++ b/src/lua/utils.h
@@ -151,7 +151,7 @@ luaL_tocpointer(lua_State *L, int idx, uint32_t *ctypeid);
 /**
  * Checks whether a value on the Lua stack is a cdata.
  *
- * Unlike <luaL_checkcdata>() this function does not raise an
+ * Unlike luaL_checkcdata() this function does not raise an
  * error. It is useful to raise a domain specific error.
  *
  * Lua API and module API don't expose LUA_TCDATA constant.
@@ -332,7 +332,7 @@ luaT_setmodule(struct lua_State *L, const char *modname);
 /** \cond public */
 
 /**
- * Push uint64_t onto the stack
+ * Push uint64_t onto the stack.
  *
  * @param L is a Lua State
  * @param val is a value to push
@@ -341,7 +341,7 @@ LUA_API void
 luaL_pushuint64(struct lua_State *L, uint64_t val);
 
 /**
- * Push int64_t onto the stack
+ * Push int64_t onto the stack.
  *
  * @param L is a Lua State
  * @param val is a value to push
@@ -388,9 +388,12 @@ luaL_toint64(struct lua_State *L, int idx);
 LUA_API int
 luaT_call(lua_State *L, int nargs, int nreturns);
 
-/*
+/**
  * Like luaL_dostring(), but in case of error sets fiber diag instead
  * of putting error on stack.
+ *
+ * @param L Lua state
+ * @param str string with Lua code to load and run
  */
 int
 luaT_dostring(struct lua_State *L, const char *str);

--- a/src/trivia/util.h
+++ b/src/trivia/util.h
@@ -147,12 +147,28 @@ strnindex(const char *const *haystack, const char *needle, uint32_t len,
 #ifndef __has_feature
 #  define __has_feature(x) 0
 #endif
+/**
+ * The special operator __has_builtin (operand) may be used in constant integer
+ * contexts and in preprocessor "#if" and "#elif" expressions to test whether
+ * the symbol named by its operand is recognized as a built-in function by GCC
+ * in the current language and conformance mode.
+ */
 #ifndef __has_builtin
 #  define __has_builtin(x) 0
 #endif
+/**
+ * The special operator __has_attribute (operand) may be used in "#if"
+ * and "#elif" expressions to test whether the attribute referenced by its
+ * operand is recognized by GCC.
+ */
 #ifndef __has_attribute
 #  define __has_attribute(x) 0
 #endif
+/**
+ * The special operator __has_cpp_attribute (operand) may be used in "#if" and
+ * "#elif" expressions in C++ code to test whether the attribute referenced by
+ * it operand is recognized by GCC.
+ */
 #ifndef __has_cpp_attribute
 #  define __has_cpp_attribute(x) 0
 #endif
@@ -169,12 +185,17 @@ strnindex(const char *const *haystack, const char *needle, uint32_t len,
  * You may use likely()/unlikely() to provide the compiler with branch
  * prediction information.
  */
-
 #if __has_builtin(__builtin_expect) || defined(__GNUC__)
 #  define likely(x)    __builtin_expect(!! (x),1)
 #  define unlikely(x)  __builtin_expect(!! (x),0)
 #else
 #  define likely(x)    (x)
+/**
+ * You may use likely()/unlikely() to provide the compiler with branch
+ * prediction information.
+ *
+ * @sa https://en.cppreference.com/w/cpp/language/attributes/likely
+ */
 #  define unlikely(x)  (x)
 #endif
 
@@ -242,7 +263,11 @@ strnindex(const char *const *haystack, const char *needle, uint32_t len,
  *
  * Sic: alignas() doesn't work on anonymous structs on gcc < 4.9
  *
- * \example struct obuf { int a; int b; alignas(16) int c; };
+ * Example:
+ *
+ * \code
+ * struct obuf { int a; int b; alignas(16) int c; };
+ * \endcode
  */
 #if defined(__cplusplus)
 #  include <stdalign.h>
@@ -258,20 +283,24 @@ strnindex(const char *const *haystack, const char *needle, uint32_t len,
 #  endif
 #endif
 
-/**
- * C11/C++11 operator. Returns the alignment, in bytes, required for any
- * instance of the type indicated by type-id, which is either complete type,
- * an array type, or a reference type.
- */
 #if !defined(alignof) && !defined(__alignof_is_defined)
 #  if __has_feature(c_alignof) || (defined(__GNUC__) && __GNUC__ >= 5)
 #    include <stdalign.h>
 #  elif defined(__GNUC__)
 #    define alignof(_T) __alignof(_T)
+/*! @cond Doxygen_Suppress */
 #    define __alignof_is_defined 1
+/*! @endcond */
 #  else
+/**
+ * C11/C++11 operator. Returns the alignment, in bytes, required for any
+ * instance of the type indicated by type-id, which is either complete type,
+ * an array type, or a reference type.
+ */
 #    define alignof(_T) offsetof(struct { char c; _T member; }, member)
+/*! @cond Doxygen_Suppress */
 #    define __alignof_is_defined 1
+/*! @endcond */
 #  endif
 #endif
 
@@ -293,7 +322,11 @@ strnindex(const char *const *haystack, const char *needle, uint32_t len,
  * variable may exist solely for use in an assert() statement, which makes
  * the local variable unused when NDEBUG is defined.
  *
- * \example int fun(MAYBE_UNUSED int unused_arg);
+ * Example:
+ *
+ * \code
+ * int fun(MAYBE_UNUSED int unused_arg);
+ * \endcode
  */
 #if defined(__cplusplus) && __has_cpp_attribute(maybe_unused)
 #  define MAYBE_UNUSED [[maybe_unused]]
@@ -308,7 +341,11 @@ strnindex(const char *const *haystack, const char *needle, uint32_t len,
  * the function call appears as a potentially-evaluated discarded-value
  * expression that is not explicitly cast to void.
  *
- * \example NODISCARD int function() { return -1 };
+ * Example:
+ *
+ * \code
+ * NODISCARD int function() { return -1 };
+ * \endcode
  */
 #if defined(__cplusplus) && __has_cpp_attribute(nodiscard)
 #  define NODISCARD [[nodiscard]]
@@ -322,7 +359,11 @@ strnindex(const char *const *haystack, const char *needle, uint32_t len,
  * This function attribute prevents a function from being considered for
  * inlining.
  *
- * \example NOINLINE int function() { return 0; };
+ * Example:
+ *
+ * \code
+ * NOINLINE int function() { return 0; };
+ * \endcode
  */
 #if __has_attribute(noinline) || defined(__GNUC__)
 #  define NOINLINE __attribute__((noinline))
@@ -335,7 +376,11 @@ strnindex(const char *const *haystack, const char *needle, uint32_t len,
  * The compiler will generate a diagnostic for a function declared as
  * NORETURN that appears to be capable of returning to its caller.
  *
- * \example NORETURN void abort();
+ * Example:
+ *
+ * \code
+ * NORETURN void abort();
+ * \endcode
  */
 #if defined(__cplusplus) && __has_cpp_attribute(noreturn)
 #  define NORETURN [[noreturn]]
@@ -391,7 +436,11 @@ strnindex(const char *const *haystack, const char *needle, uint32_t len,
  * useful to save data size because of the relatively high cost of
  * unaligned access on some architectures.
  *
- * \example struct PACKED name { char a; int b; };
+ * Example:
+ *
+ * \code
+ * struct PACKED name { char a; int b; };
+ * \endcode
  */
 #if __has_attribute(packed) || defined(__GNUC__)
 #  define PACKED  __attribute__((packed))


### PR DESCRIPTION


    src: fix formatting comments for Doxygen
    
    - remove < and > around function names to make them resolvable
    - place @sa and \sa to the new lines and remove round parenthesis around
    - add missed dots
    - added comments for box_tuple_upsert, box_tuple_update, luaT_pusherror
      etc.
    - replace \example tags with \code and \endcode, because \example
      requires a file name with example, when \code allows to place a code
      inline
    - comments for macroses alignof and likely/unlikely looks a bit ugly,
      but I couldn't find a better way to resolve doxygen warning


Closes #8194

NO_CHANGELOG=fix doxygen
NO_DOC=fix doxygen
NO_TEST=fix doxygen