### PR TITLE
test: add cleanup to digest_crc32_recording_test

### DIFF
--- a/test/app-luatest/digest_crc32_recording_test.lua
+++ b/test/app-luatest/digest_crc32_recording_test.lua
@@ -173,6 +173,10 @@ g.before_all(function()
     g.server:start()
 end)
 
+g.after_all(function()
+    g.server:drop()
+end)
+
 local conn
 local function r()
     pcall(function()


### PR DESCRIPTION
Add missing `server:drop()` to digest_crc32_recording_test.lua to avoid running tarantool processes after the test.