### PR TITLE
build: bump zstd submodule

### DIFF
--- a/changelogs/unreleased/gh-8391-bump-zstd.md
+++ b/changelogs/unreleased/gh-8391-bump-zstd.md
@@ -1,0 +1,3 @@
+## feature/build
+
+* Updated zstd to version pre-1.5.5 (gh-8391).


### PR DESCRIPTION
Updated third_party/zstd submodule from v1.5.2 to pre-1.5.5 version. The new version fixes a rare bug that was introduced in 1.5.0 [1].

A v1.5.5 release version will be produced in March.

1. https://github.com/facebook/zstd/pull/3517

Fixes #8391

NO_DOC=build
NO_TEST=build