### PR TITLE
[2.11] sql: fix assertion in case FK or CK declared first

### DIFF
--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -679,6 +679,8 @@ static char *
 sql_ck_unique_name_new(struct Parse *parse, bool is_field_ck)
 {
 	struct space *space = parse->create_column_def.space;
+	if (space == NULL)
+		space = parse->create_table_def.new_space;
 	assert(space != NULL);
 	const char *space_name = space->def->name;
 	struct ck_constraint_parse *ck;
@@ -1866,6 +1868,8 @@ static char *
 sql_fk_unique_name_new(struct Parse *parse)
 {
 	struct space *space = parse->create_column_def.space;
+	if (space == NULL)
+		space = parse->create_table_def.new_space;
 	assert(space != NULL);
 	const char *space_name = space->def->name;
 	struct fk_constraint_parse *fk;


### PR DESCRIPTION
This patch fixes an assertion or segmentation error if a FOREIGN KEY or CHECK constraint is declared before the first column.

Closes #8392

NO_DOC=bugfix of the bug added in the current release
NO_CHANGELOG=bugfix of the bug added in the current release