### PR TITLE
ci: eliminate 1.10 related logic, introduce 3.x

### DIFF
--- a/.github/actions/pack-and-deploy/action.yml
+++ b/.github/actions/pack-and-deploy/action.yml
@@ -14,8 +14,9 @@ runs:
 
         # Deploy pre-release (since 2.10) and release packages. It's expected
         # that no one will push tags are used for pre-releases and releases.
-        if ${{ startsWith(github.ref, 'refs/tags/2.') &&
-               !endsWith(github.ref, '-entrypoint') }}; then
+          if ${{ ( startsWith(github.ref, 'refs/tags/2.') ||
+                   startsWith(github.ref, 'refs/tags/3.') ) &&
+                 !endsWith(github.ref, '-entrypoint') }}; then
           case ${{ github.ref }} in
             # It's relevant since 2.10 only.
             refs/tags/*-alpha*|refs/tags/*-beta*|refs/tags/*-rc*)

--- a/.github/actions/pack-and-deploy/action.yml
+++ b/.github/actions/pack-and-deploy/action.yml
@@ -12,22 +12,15 @@ runs:
         # Create packages.
         make -f .pack.mk package
 
-        # Deploy live packages. Enabled only for 1.10 branch.
-        if ${{ github.ref == 'refs/heads/1.10' }}; then
-          REPO_TYPE=live make -f .pack.mk deploy
-        fi
-
         # Deploy pre-release (since 2.10) and release packages. It's expected
         # that no one will push tags are used for pre-releases and releases.
-        if ${{ ( startsWith(github.ref, 'refs/tags/1.10.') ||
-                 startsWith(github.ref, 'refs/tags/2.') ) &&
+        if ${{ startsWith(github.ref, 'refs/tags/2.') &&
                !endsWith(github.ref, '-entrypoint') }}; then
           case ${{ github.ref }} in
             # It's relevant since 2.10 only.
             refs/tags/*-alpha*|refs/tags/*-beta*|refs/tags/*-rc*)
               REPO_TYPE=pre-release make -f .pack.mk deploy
               ;;
-
             refs/tags/*)
               REPO_TYPE=release make -f .pack.mk deploy
               ;;

--- a/.github/workflows/alpine_3_16.yml
+++ b/.github/workflows/alpine_3_16.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/alpine_3_16.yml
+++ b/.github/workflows/alpine_3_16.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/alpine_3_16_aarch64.yml
+++ b/.github/workflows/alpine_3_16_aarch64.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/alpine_3_16_aarch64.yml
+++ b/.github/workflows/alpine_3_16_aarch64.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/centos_7_aarch64.yml
+++ b/.github/workflows/centos_7_aarch64.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/centos_7_aarch64.yml
+++ b/.github/workflows/centos_7_aarch64.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/centos_8_aarch64.yml
+++ b/.github/workflows/centos_8_aarch64.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/centos_8_aarch64.yml
+++ b/.github/workflows/centos_8_aarch64.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,6 +24,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/debian_10_aarch64.yml
+++ b/.github/workflows/debian_10_aarch64.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/debian_10_aarch64.yml
+++ b/.github/workflows/debian_10_aarch64.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/debian_11_aarch64.yml
+++ b/.github/workflows/debian_11_aarch64.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/debian_11_aarch64.yml
+++ b/.github/workflows/debian_11_aarch64.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -23,7 +23,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -24,6 +24,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/fedora_34_aarch64.yml
+++ b/.github/workflows/fedora_34_aarch64.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/fedora_34_aarch64.yml
+++ b/.github/workflows/fedora_34_aarch64.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/fedora_35.yml
+++ b/.github/workflows/fedora_35.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/fedora_35.yml
+++ b/.github/workflows/fedora_35.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/fedora_35_aarch64.yml
+++ b/.github/workflows/fedora_35_aarch64.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/fedora_35_aarch64.yml
+++ b/.github/workflows/fedora_35_aarch64.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/fedora_36.yml
+++ b/.github/workflows/fedora_36.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/fedora_36.yml
+++ b/.github/workflows/fedora_36.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/fedora_36_aarch64.yml
+++ b/.github/workflows/fedora_36_aarch64.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/fedora_36_aarch64.yml
+++ b/.github/workflows/fedora_36_aarch64.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/freebsd-12.yml
+++ b/.github/workflows/freebsd-12.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/freebsd-12.yml
+++ b/.github/workflows/freebsd-12.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/freebsd-13.yml
+++ b/.github/workflows/freebsd-13.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/freebsd-13.yml
+++ b/.github/workflows/freebsd-13.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -29,6 +29,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -28,7 +28,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/osx_debug.yml
+++ b/.github/workflows/osx_debug.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/osx_debug.yml
+++ b/.github/workflows/osx_debug.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/osx_release.yml
+++ b/.github/workflows/osx_release.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/osx_release.yml
+++ b/.github/workflows/osx_release.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/osx_release_lto.yml
+++ b/.github/workflows/osx_release_lto.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/osx_release_lto.yml
+++ b/.github/workflows/osx_release_lto.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/osx_static_cmake.yml
+++ b/.github/workflows/osx_static_cmake.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/osx_static_cmake.yml
+++ b/.github/workflows/osx_static_cmake.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/publish-module-api-doc.yaml
+++ b/.github/workflows/publish-module-api-doc.yaml
@@ -20,7 +20,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/publish-module-api-doc.yaml
+++ b/.github/workflows/publish-module-api-doc.yaml
@@ -21,6 +21,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/redos_7_3.yaml
+++ b/.github/workflows/redos_7_3.yaml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/redos_7_3.yaml
+++ b/.github/workflows/redos_7_3.yaml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -2,8 +2,8 @@ name: source
 
 on:
   push:
-    tags:
-      - '**'
+    tags-ignore:
+      - '**-entrypoint'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/ubuntu_20_04_aarch64.yml
+++ b/.github/workflows/ubuntu_20_04_aarch64.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/ubuntu_20_04_aarch64.yml
+++ b/.github/workflows/ubuntu_20_04_aarch64.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}

--- a/.github/workflows/ubuntu_22_04_aarch64.yml
+++ b/.github/workflows/ubuntu_22_04_aarch64.yml
@@ -24,7 +24,6 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
-    github.ref == 'refs/heads/1.10' ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||

--- a/.github/workflows/ubuntu_22_04_aarch64.yml
+++ b/.github/workflows/ubuntu_22_04_aarch64.yml
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ (
     github.ref == 'refs/heads/master' ||
     startsWith(github.ref, 'refs/heads/2.') ||
+    startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
     format('{0}-{1}', github.workflow, github.ref) }}


### PR DESCRIPTION
- ci: not to push sources on `*-entrypoint` tag
- ci: eliminate 1.10 related logic for workflows 
- ci: introduce 3.x related logic for workflows