### PR TITLE
memtx: fix eq pagination in case after tuple is absent

### DIFF
--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -756,11 +756,12 @@ tree_iterator_start(struct iterator *iterator, struct tuple **ret)
 	}
 	/* If we skip tuple, flag equals is not actual - need to refresh it. */
 	if (skip_equal_tuple && res != NULL &&
-	    (type == ITER_EQ || type == ITER_REQ) &&
-	    tuple_compare_with_key(res->tuple, res->hint, it->key_data.key,
-				   it->key_data.part_count, it->key_data.hint,
-				   index->base.def->key_def) != 0) {
-		equals = false;
+	    (type == ITER_EQ || type == ITER_REQ)) {
+		equals = tuple_compare_with_key(res->tuple, res->hint,
+						it->key_data.key,
+						it->key_data.part_count,
+						it->key_data.hint,
+						index->base.def->key_def) == 0;
 	}
 	/*
 	 * Equality iterators requires exact key match: if the result does not

--- a/test/engine-luatest/pagination_test.lua
+++ b/test/engine-luatest/pagination_test.lua
@@ -616,6 +616,27 @@ tree_g.test_gh_7943 = function(cg)
     end)
 end
 
+-- Paignation in case the tuple pointed to by 'after' isn't in the space.
+tree_g.test_gh_8373_after_missing = function(cg)
+    cg.server:exec(function()
+        local s = box.space.s
+        s:create_index('primary')
+        local i = s:create_index('secondary',
+                                 {unique = false, parts = {2, 'unsigned'}})
+        s:insert({1, 10})
+        s:insert({3, 30})
+        s:insert({5, 50})
+        t.assert_equals(i:select({30}, {iterator = 'ge', after = {2, 30}}),
+                        {{3, 30}, {5, 50}})
+        t.assert_equals(i:select({30}, {iterator = 'eq', after = {2, 30}}),
+                        {{3, 30}})
+        t.assert_equals(i:select({30}, {iterator = 'le', after = {4, 30}}),
+                        {{3, 30}, {1, 10}})
+        t.assert_equals(i:select({30}, {iterator = 'req', after = {4, 30}}),
+                        {{3, 30}})
+    end)
+end
+
 -- Tests for memtx tree features, such as functional index
 local func_g = t.group('Memtx tree func index tests')
 


### PR DESCRIPTION
If the tuple pointed to by 'after' isn't in the space, eq pagination would skip it because of the broken 'equals' flag update in the memtx iterator.

Closes #8373