### PR TITLE
test: add rule to ignore Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ extra/luarocks/hardcoded.lua.c
 perf/Makefile
 test/Makefile
 test/*/Makefile
+test/*/*/Makefile
 Doxyfile.API
 RPM
 *.src.rpm


### PR DESCRIPTION
This patch adds a rule to ignore the Makefile on the path test/*/*.