### PR TITLE
box: check iterator position against search criteria

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3147,8 +3147,10 @@ box_select(uint32_t space_id, uint32_t index_id,
 			return -1;
 		uint32_t pos_part_count = mp_decode_array(&pos);
 		if (exact_key_validate_nullable(index->def->cmp_def, pos,
-						pos_part_count) != 0)
+						pos_part_count) != 0) {
+			diag_set(ClientError, ER_ITERATOR_POSITION);
 			return -1;
+		}
 	} else {
 		pos = NULL;
 		pos_end = NULL;

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3146,11 +3146,10 @@ box_select(uint32_t space_id, uint32_t index_id,
 					     &pos, &pos_end) != 0)
 			return -1;
 		uint32_t pos_part_count = mp_decode_array(&pos);
-		if (exact_key_validate_nullable(index->def->cmp_def, pos,
-						pos_part_count) != 0) {
-			diag_set(ClientError, ER_ITERATOR_POSITION);
+		if (iterator_position_validate(pos, pos_part_count,
+					       key, part_count,
+					       index->def->cmp_def, type) != 0)
 			return -1;
-		}
 	} else {
 		pos = NULL;
 		pos_end = NULL;

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -217,14 +217,18 @@ box_index_tuple_position(uint32_t space_id, uint32_t index_id,
 			 "position by tuple");
 		return -1;
 	}
-	if (tuple_validate_raw(space->format, tuple) != 0)
+	if (tuple_validate_raw(space->format, tuple) != 0) {
+		diag_set(ClientError, ER_ITERATOR_POSITION);
 		return -1;
+	}
 	struct key_def *cmp_def = index->def->cmp_def;
 	uint32_t key_size;
 	const char *key = tuple_extract_key_raw(tuple, tuple_end, cmp_def,
 						MULTIKEY_NONE, &key_size);
-	if (key == NULL)
+	if (key == NULL) {
+		diag_set(ClientError, ER_ITERATOR_POSITION);
 		return -1;
+	}
 	const char *key_end = key + key_size;
 	uint32_t buf_size = iterator_position_pack_bufsize(key, key_end);
 	char *buf = (char *)xregion_alloc(&fiber()->gc, buf_size);
@@ -474,8 +478,10 @@ box_index_iterator_after(uint32_t space_id, uint32_t index_id, int type,
 			return NULL;
 		uint32_t pos_part_count = mp_decode_array(&pos);
 		if (exact_key_validate_nullable(index->def->cmp_def, pos,
-						pos_part_count) != 0)
+						pos_part_count) != 0) {
+			diag_set(ClientError, ER_ITERATOR_POSITION);
 			return NULL;
+		}
 	} else {
 		pos = NULL;
 		pos_end = NULL;

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -427,6 +427,17 @@ iterator_position_unpack(const char *packed_pos, const char *packed_pos_end,
 			 const char **pos_end);
 
 /**
+ * Check an unpacked iterator position against the search criteria.
+ * Note that both the position and the search key are given without
+ * MP_ARRAY header.
+ * Returns 0 on success, -1 on failure, diag is set.
+ */
+int
+iterator_position_validate(const char *pos, uint32_t pos_part_count,
+			   const char *key, uint32_t key_part_count,
+			   struct key_def *cmp_def, enum iterator_type type);
+
+/**
  * Get position of iterator - extracted cmp_def of last fetched
  * tuple (with MP_ARRAY header). If iterator is exhausted,
  * it returns position of last tuple, if there were no tuples

--- a/src/box/key_def.h
+++ b/src/box/key_def.h
@@ -999,9 +999,9 @@ tuple_compare_field(const char *field_a, const char *field_b,
 
 /**
  * Compare keys using the key definition and comparison hints.
- * @param key_a key parts with MessagePack array header
+ * @param key_a key parts without MessagePack array header
  * @param key_a_hint comparison hint of @a key_a
- * @param key_b key_parts with MessagePack array header
+ * @param key_b key_parts without MessagePack array header
  * @param key_b_hint comparison hint of @a key_b
  * @param key_def key definition
  *
@@ -1010,8 +1010,8 @@ tuple_compare_field(const char *field_a, const char *field_b,
  * @retval >0 if key_a > key_b
  */
 int
-key_compare(const char *key_a, hint_t key_a_hint,
-	    const char *key_b, hint_t key_b_hint,
+key_compare(const char *key_a, uint32_t part_count_a, hint_t key_a_hint,
+	    const char *key_b, uint32_t part_count_b, hint_t key_b_hint,
 	    struct key_def *key_def);
 
 /**

--- a/src/box/tuple_compare.cc
+++ b/src/box/tuple_compare.cc
@@ -938,14 +938,13 @@ tuple_compare_with_key_sequential(struct tuple *tuple, hint_t tuple_hint,
 }
 
 int
-key_compare(const char *key_a, hint_t key_a_hint,
-	    const char *key_b, hint_t key_b_hint, struct key_def *key_def)
+key_compare(const char *key_a, uint32_t part_count_a, hint_t key_a_hint,
+	    const char *key_b, uint32_t part_count_b, hint_t key_b_hint,
+	    struct key_def *key_def)
 {
 	int rc = hint_cmp(key_a_hint, key_b_hint);
 	if (rc != 0)
 		return rc;
-	uint32_t part_count_a = mp_decode_array(&key_a);
-	uint32_t part_count_b = mp_decode_array(&key_b);
 	assert(part_count_a <= key_def->part_count);
 	assert(part_count_b <= key_def->part_count);
 	uint32_t part_count = MIN(part_count_a, part_count_b);

--- a/src/box/vy_range.c
+++ b/src/box/vy_range.c
@@ -478,9 +478,9 @@ vy_range_needs_split(struct vy_range *range, int64_t range_size,
 						slice->first_page_no);
 
 	/* No point in splitting if a new range is going to be empty. */
-	if (key_compare(first_page->min_key, first_page->min_key_hint,
-			mid_page->min_key, mid_page->min_key_hint,
-			range->cmp_def) == 0)
+	if (vy_key_compare(first_page->min_key, first_page->min_key_hint,
+			   mid_page->min_key, mid_page->min_key_hint,
+			   range->cmp_def) == 0)
 		return false;
 	/*
 	 * In extreme cases the median key can be < the beginning

--- a/src/box/vy_stmt.h
+++ b/src/box/vy_stmt.h
@@ -392,6 +392,20 @@ vy_stmt_hint(struct tuple *stmt, struct key_def *key_def)
 }
 
 /**
+ * Compare two keys with MessagePack array header.
+ */
+static inline int
+vy_key_compare(const char *key_a, hint_t key_a_hint,
+	       const char *key_b, hint_t key_b_hint,
+	       struct key_def *key_def)
+{
+	uint32_t part_count_a = mp_decode_array(&key_a);
+	uint32_t part_count_b = mp_decode_array(&key_b);
+	return key_compare(key_a, part_count_a, key_a_hint,
+			   key_b, part_count_b, key_b_hint, key_def);
+}
+
+/**
  * Compare two vinyl statements taking into account their
  * formats (key or tuple) and using comparison hints.
  */
@@ -416,8 +430,8 @@ vy_stmt_compare(struct tuple *a, hint_t a_hint,
 					       a_hint, key_def);
 	} else {
 		assert(!a_is_tuple && !b_is_tuple);
-		return key_compare(tuple_data(a), a_hint,
-				   tuple_data(b), b_hint, key_def);
+		return vy_key_compare(tuple_data(a), a_hint,
+				      tuple_data(b), b_hint, key_def);
 	}
 }
 
@@ -436,7 +450,8 @@ vy_stmt_compare_with_raw_key(struct tuple *stmt, hint_t stmt_hint,
 					      part_count, key_hint,
 					      key_def);
 	}
-	return key_compare(tuple_data(stmt), stmt_hint, key, key_hint, key_def);
+	return vy_key_compare(tuple_data(stmt), stmt_hint,
+			      key, key_hint, key_def);
 }
 
 /**

--- a/test/box-luatest/pagination_netbox_test.lua
+++ b/test/box-luatest/pagination_netbox_test.lua
@@ -340,13 +340,10 @@ net_g.test_net_box_invalid_position = function(cg)
     s:replace{1, 0}
     s:replace{2, 0}
     local _, pos = sk:select(nil, {limit=1, fetch_pos=true})
-    local msg = "Invalid key part count in an exact match (expected 1, got 2)"
+    local msg = "Iterator position is invalid"
     t.assert_error_msg_equals(msg, s.select, s, nil, {after=pos})
     _, pos = s:select(nil, {limit=1, fetch_pos=true})
-    msg = "Invalid key part count in an exact match (expected 2, got 1)"
     t.assert_error_msg_equals(msg, sk.select, sk, nil, {after=pos})
-    msg = "Tuple field 2 type does not match one required by operation:" ..
-        " expected unsigned, got string"
     t.assert_error_msg_equals(msg, sk.select, sk, nil, {after={0, 'Zero'}})
     msg = "Illegal parameters, options parameter 'after'" ..
         " should be of type string, table, tuple"

--- a/test/engine-luatest/pagination_test.lua
+++ b/test/engine-luatest/pagination_test.lua
@@ -366,7 +366,7 @@ tree_g.test_invalid_positions = function(cg)
             s:select(1, {limit=1, iterator='GE', after=pos})
         end)
         t.assert_equals(flag, false)
-        t.assert_equals(err.code, box.error.FIELD_TYPE)
+        t.assert_equals(err.code, box.error.ITERATOR_POSITION)
 
         pos = "abcd"
         flag, err = pcall(function()
@@ -382,7 +382,7 @@ tree_g.test_invalid_positions = function(cg)
             s.index.sk:select(nil, {fullscan=true, limit=1, after=pos})
         end)
         t.assert_equals(flag, false)
-        t.assert_equals(err.code, box.error.EXACT_MATCH)
+        t.assert_equals(err.code, box.error.ITERATOR_POSITION)
     end)
 end
 
@@ -504,9 +504,8 @@ tree_g.test_tuple_pos_invalid_tuple = function(cg)
         tuples = s:select(nil, {fullscan=true, after=pos, limit=1})
         t.assert_equals(tuples[1], {2, 0})
         -- test with invalid tuple
-        t.assert_error_msg_contains(
-                "Tuple field 1 type does not match one required by operation",
-                s.index.pk.tuple_pos, s.index.pk, {'a'})
+        t.assert_error_msg_contains("Iterator position is invalid",
+                                    s.index.pk.tuple_pos, s.index.pk, {'a'})
     end)
 end
 

--- a/test/unit/key_def.c
+++ b/test/unit/key_def.c
@@ -240,8 +240,13 @@ test_check_tuple_extract_key_raw(struct key_def *key_def, struct tuple *tuple,
 	 */
 	void *alloc = region_alloc(&fiber()->gc, 10);
 	memset(alloc, 0, 10);
-	ok(key_compare(tuple_key, HINT_NONE, key, HINT_NONE, key_def) == 0 &&
-	   mp_decode_array(&key) == mp_decode_array(&tuple_key),
+	const char *key_a = tuple_key;
+	uint32_t part_count_a = mp_decode_array(&key_a);
+	const char *key_b = key;
+	uint32_t part_count_b = mp_decode_array(&key_b);
+	ok(key_compare(key_a, part_count_a, HINT_NONE,
+		       key_b, part_count_b, HINT_NONE, key_def) == 0 &&
+	   part_count_a == part_count_b,
 	   "Extracted key of tuple %s is %s, expected %s",
 	   tuple_str(tuple), mp_str(tuple_key), mp_str(key));
 }


### PR DESCRIPTION
If the 'after' key is less than the search key in case of ge/gt or greater than the search key in case of le/lt, the iterator either
crashes (vinyl) or returns invalid result (memtx). This happens because the engine implementation doesn't expect an invalid 'after' key. Let's fix this by raising an error at the top level in case the 'after' key doesn't meet the search criteria.

Closes #8403
Closes #8404