### PR TITLE
ci: enable for release/x.y.z branches

### DIFF
--- a/.github/actions/pack-and-deploy/action.yml
+++ b/.github/actions/pack-and-deploy/action.yml
@@ -14,9 +14,9 @@ runs:
 
         # Deploy pre-release (since 2.10) and release packages. It's expected
         # that no one will push tags are used for pre-releases and releases.
-          if ${{ ( startsWith(github.ref, 'refs/tags/2.') ||
-                   startsWith(github.ref, 'refs/tags/3.') ) &&
-                 !endsWith(github.ref, '-entrypoint') }}; then
+        if ${{ ( startsWith(github.ref, 'refs/tags/2.') ||
+                 startsWith(github.ref, 'refs/tags/3.') ) &&
+               !endsWith(github.ref, '-entrypoint') }}; then
           case ${{ github.ref }} in
             # It's relevant since 2.10 only.
             refs/tags/*-alpha*|refs/tags/*-beta*|refs/tags/*-rc*)

--- a/.github/actions/report-job-status/action.yml
+++ b/.github/actions/report-job-status/action.yml
@@ -19,6 +19,7 @@ runs:
         # the team chat. Report failures occurred in PRs and other branches
         # to the personal chat.
         if [[ ${{ github.ref }} == refs/heads/master ||
+              ${{ github.ref }} =~ refs/heads/release/* ||
               ${{ github.ref }} =~ refs/heads/[0-9].[0-9]+$ ||
               ${{ github.actor }} == TarantoolBot ]]; then
           echo CHAT_ID="${{ inputs.chat-id }}" | tee -a $GITHUB_ENV

--- a/.github/workflows/alpine_3_16.yml
+++ b/.github/workflows/alpine_3_16.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/alpine_3_16_aarch64.yml
+++ b/.github/workflows/alpine_3_16_aarch64.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/centos_7_aarch64.yml
+++ b/.github/workflows/centos_7_aarch64.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/centos_8_aarch64.yml
+++ b/.github/workflows/centos_8_aarch64.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -23,6 +24,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/debian_10_aarch64.yml
+++ b/.github/workflows/debian_10_aarch64.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/debian_11_aarch64.yml
+++ b/.github/workflows/debian_11_aarch64.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -23,6 +24,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/fedora_34_aarch64.yml
+++ b/.github/workflows/fedora_34_aarch64.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/fedora_35.yml
+++ b/.github/workflows/fedora_35.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/fedora_35_aarch64.yml
+++ b/.github/workflows/fedora_35_aarch64.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/fedora_36.yml
+++ b/.github/workflows/fedora_36.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/fedora_36_aarch64.yml
+++ b/.github/workflows/fedora_36_aarch64.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/freebsd-12.yml
+++ b/.github/workflows/freebsd-12.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/freebsd-13.yml
+++ b/.github/workflows/freebsd-13.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -28,6 +29,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'  # release branches
     tags:
       - '*'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -23,6 +24,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/osx_debug.yml
+++ b/.github/workflows/osx_debug.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/osx_release.yml
+++ b/.github/workflows/osx_release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/osx_release_lto.yml
+++ b/.github/workflows/osx_release_lto.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/osx_static_cmake.yml
+++ b/.github/workflows/osx_static_cmake.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/redos_7_3.yaml
+++ b/.github/workflows/redos_7_3.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -23,6 +24,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/ubuntu_20_04_aarch64.yml
+++ b/.github/workflows/ubuntu_20_04_aarch64.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&

--- a/.github/workflows/ubuntu_22_04_aarch64.yml
+++ b/.github/workflows/ubuntu_22_04_aarch64.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
       - '[0-9].[0-9]+'
     tags:
       - '**'
@@ -24,6 +25,7 @@ concurrency:
   # pushing a tag may cancel a run that works on a branch push event.
   group: ${{ (
     github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/heads/2.') ||
     startsWith(github.ref, 'refs/heads/3.') ||
     startsWith(github.ref, 'refs/tags/')) &&


### PR DESCRIPTION
Enable CI for branches with names `release/x.y.z`. Sometimes we are going to create such branches, and we need to have working CI for them.