### PR TITLE
test: fix fail of gh_4669_applier_reconnect_test

### DIFF
--- a/test/replication-luatest/gh_4669_applier_reconnect_test.lua
+++ b/test/replication-luatest/gh_4669_applier_reconnect_test.lua
@@ -8,6 +8,7 @@ g.before_each(function()
     g.cluster = cluster:new({})
     g.master = g.cluster:build_server({alias = 'master'})
     local box_cfg = {
+        bootstrap_strategy = 'legacy',
         replication = server.build_listen_uri('master'),
     }
     g.replica = g.cluster:build_server({alias = 'replica', box_cfg = box_cfg})


### PR DESCRIPTION
In the test we start replicas only with master in box.cfg.replication. We cannot use bootstrap_strategy = 'auto' mode, which is default, as it properly works only when all participants of the cluster are listed in replication parameter. Sometimes, when one replica connects to the master, the other one has already successfully joined, so the first replica sees in ballot, that it doesn't have all nodes from cluster in box.cfg.replication and fails to start.

Let's use 'legacy' boostrap strategy for now.

Closes tarantool/tarantool-qa#310

NO_DOC=test-fix
NO_CHANGELOG=test-fix