### PR TITLE
Rework parsing of transaction and DDL queries

### DIFF
--- a/src/box/sql/alter.c
+++ b/src/box/sql/alter.c
@@ -40,12 +40,9 @@
 void
 sql_alter_table_rename(struct Parse *parse)
 {
-	struct rename_entity_def *rename_def = &parse->rename_entity_def;
-	struct SrcList *src_tab = rename_def->base.entity_name;
-	assert(rename_def->base.entity_type == ENTITY_TYPE_TABLE);
-	assert(rename_def->base.alter_action == ALTER_ACTION_RENAME);
+	struct SrcList *src_tab = parse->src_list;
 	assert(src_tab->nSrc == 1);
-	char *new_name = sql_name_from_token(&rename_def->new_name);
+	char *new_name = sql_name_from_token(&parse->table_new_name);
 	/* Check that new name isn't occupied by another table. */
 	if (space_by_name(new_name) != NULL) {
 		diag_set(ClientError, ER_SPACE_EXISTS, new_name);
@@ -62,13 +59,10 @@ sql_alter_table_rename(struct Parse *parse)
 	struct Vdbe *v = sqlGetVdbe(parse);
 	sqlVdbeAddOp4(v, OP_RenameTable, space->def->id, 0, 0, new_name,
 			  P4_DYNAMIC);
-exit_rename_table:
-	sqlSrcListDelete(src_tab);
 	return;
 tnt_error:
 	sql_xfree(new_name);
 	parse->is_aborted = true;
-	goto exit_rename_table;
 }
 
 char *

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -326,28 +326,26 @@ error:
 }
 
 void
-sql_create_column_start(struct Parse *parse)
+sql_create_column_start(struct Parse *parse, struct Token *name,
+			enum field_type type)
 {
-	struct create_column_def *create_column_def = &parse->create_column_def;
-	struct alter_entity_def *alter_entity_def =
-		&create_column_def->base.base;
-	assert(alter_entity_def->entity_type == ENTITY_TYPE_COLUMN);
-	assert(alter_entity_def->alter_action == ALTER_ACTION_CREATE);
 	struct space *space = parse->create_table_def.new_space;
 	bool is_alter = space == NULL;
 	if (is_alter) {
-		const char *space_name =
-			alter_entity_def->entity_name->a[0].zName;
+		const char *space_name = parse->src_list->a[0].zName;
 		space = space_by_name(space_name);
 		if (space == NULL) {
 			diag_set(ClientError, ER_NO_SUCH_SPACE, space_name);
-			goto tnt_error;
+			parse->is_aborted = true;
+			return;
 		}
 		space = sql_shallow_space_copy(parse, space);
-		if (space == NULL)
-			goto tnt_error;
+		if (space == NULL) {
+			parse->is_aborted = true;
+			return;
+		}
 	}
-	create_column_def->space = space;
+	parse->space = space;
 	struct space_def *def = space->def;
 	assert(def->opts.is_ephemeral);
 
@@ -355,16 +353,18 @@ sql_create_column_start(struct Parse *parse)
 	if ((int)def->field_count + 1 > SQL_MAX_COLUMN) {
 		diag_set(ClientError, ER_SQL_COLUMN_COUNT_MAX, def->name,
 			 def->field_count + 1, SQL_MAX_COLUMN);
-		goto tnt_error;
+		parse->is_aborted = true;
+		return;
 	}
 #endif
 
 	struct region *region = &parse->region;
-	struct Token *name = &create_column_def->base.name;
 	char *column_name =
 		sql_normalized_name_region_new(region, name->z, name->n);
-	if (column_name == NULL)
-		goto tnt_error;
+	if (column_name == NULL) {
+		parse->is_aborted = true;
+		return;
+	}
 
 	/*
 	 * Format can be set in Lua, then exact_field_count can be
@@ -385,14 +385,8 @@ sql_create_column_start(struct Parse *parse)
 	 */
 	column_def->nullable_action = ON_CONFLICT_ACTION_DEFAULT;
 	column_def->is_nullable = true;
-	column_def->type = create_column_def->type_def->type;
+	column_def->type = type;
 	def->field_count++;
-
-	sqlSrcListDelete(alter_entity_def->entity_name);
-	return;
-tnt_error:
-	parse->is_aborted = true;
-	sqlSrcListDelete(alter_entity_def->entity_name);
 }
 
 static void
@@ -401,7 +395,7 @@ vdbe_emit_create_constraints(struct Parse *parse, int reg_space_id);
 void
 sql_create_column_end(struct Parse *parse)
 {
-	struct space *space = parse->create_column_def.space;
+	struct space *space = parse->space;
 	assert(space != NULL);
 	struct space_def *def = space->def;
 	struct field_def *field = &def->fields[def->field_count - 1];
@@ -462,8 +456,8 @@ void
 sql_column_add_nullable_action(struct Parse *parser,
 			       enum on_conflict_action nullable_action)
 {
-	assert(parser->create_column_def.space != NULL);
-	struct space_def *def = parser->create_column_def.space->def;
+	assert(parser->space != NULL);
+	struct space_def *def = parser->space->def;
 	assert(def->field_count > 0);
 	struct field_def *field = &def->fields[def->field_count - 1];
 	if (field->nullable_action != ON_CONFLICT_ACTION_DEFAULT &&
@@ -496,7 +490,7 @@ sql_column_add_nullable_action(struct Parse *parser,
 void
 sqlAddDefaultValue(Parse * pParse, ExprSpan * pSpan)
 {
-	struct space *p = pParse->create_column_def.space;
+	struct space *p = pParse->space;
 	if (p != NULL) {
 		assert(p->def->opts.is_ephemeral);
 		struct space_def *def = p->def;
@@ -558,7 +552,7 @@ field_def_create_for_pk(struct Parse *parser, struct field_def *field,
 void
 sqlAddPrimaryKey(struct Parse *pParse)
 {
-	struct space *space = pParse->create_column_def.space;
+	struct space *space = pParse->space;
 	assert(space != NULL || pParse->src_list != NULL);
 	if (space == NULL)
 		return sql_create_index(pParse, &pParse->primary_key.name,
@@ -636,7 +630,7 @@ vdbe_emit_ck_constraint_create(struct Parse *parser,
 static char *
 sql_ck_unique_name_new(struct Parse *parse, bool is_field_ck, uint32_t fieldno)
 {
-	struct space *space = parse->create_column_def.space;
+	struct space *space = parse->space;
 	assert(space != NULL);
 	const char *space_name = space->def->name;
 	struct ck_constraint_parse *ck;
@@ -693,7 +687,7 @@ sql_create_check_contraint(struct Parse *parser, struct sql_parse_check *cdef)
 	struct ExprSpan *expr_span = &cdef->expr;
 	sql_expr_delete(expr_span->pExpr);
 
-	struct space *space = parser->create_column_def.space;
+	struct space *space = parser->space;
 	if (space == NULL)
 		space = parser->create_table_def.new_space;
 	bool is_alter_add_constr = space == NULL;
@@ -791,7 +785,7 @@ sql_create_check_contraint(struct Parse *parser, struct sql_parse_check *cdef)
 void
 sqlAddCollateType(Parse * pParse, Token * pToken)
 {
-	struct space *space = pParse->create_column_def.space;
+	struct space *space = pParse->space;
 	assert(space != NULL);
 	uint32_t i = space->def->field_count - 1;
 	char *coll_name = sql_name_from_token(pToken);
@@ -915,7 +909,7 @@ vdbe_emit_create_index(struct Parse *parse, struct space_def *def,
 	index_parts = raw;
 
 	if (parse->create_table_def.new_space != NULL ||
-	    parse->create_column_def.space != NULL) {
+	    parse->space != NULL) {
 		sqlVdbeAddOp2(v, OP_SCopy, space_id_reg, entry_reg);
 		sqlVdbeAddOp2(v, OP_Integer, idx_def->iid, entry_reg + 1);
 	} else {
@@ -1181,7 +1175,7 @@ vdbe_emit_fk_constraint_create(struct Parse *parse_context,
 	 */
 	bool is_alter_add_constr =
 		parse_context->create_table_def.new_space == NULL &&
-		parse_context->create_column_def.space == NULL;
+		parse_context->space == NULL;
 	if (!is_alter_add_constr)
 		sqlVdbeAddOp2(vdbe, OP_SCopy, fk->child_id, regs);
 	else
@@ -1256,7 +1250,7 @@ vdbe_emit_create_constraints(struct Parse *parse, int reg_space_id)
 	 * (inside ephemeral space).
 	 */
 	if (is_alter) {
-		space = parse->create_column_def.space;
+		space = parse->space;
 		i = space_by_name(space->def->name)->index_count;
 	}
 	assert(space != NULL);
@@ -1825,7 +1819,7 @@ columnno_by_name(struct Parse *parse_context, const struct space *space,
 static char *
 sql_fk_unique_name_new(struct Parse *parse, struct sql_parse_foreign_key *cdef)
 {
-	struct space *space = parse->create_column_def.space;
+	struct space *space = parse->space;
 	assert(space != NULL);
 	const char *space_name = space->def->name;
 	struct fk_constraint_parse *fk;
@@ -1897,7 +1891,7 @@ sql_create_foreign_key(struct Parse *parse_context,
 	char *parent_name = NULL;
 	char *constraint_name = NULL;
 	bool is_self_referenced = false;
-	struct space *space = parse_context->create_column_def.space;
+	struct space *space = parse_context->space;
 	struct create_table_def *table_def = &parse_context->create_table_def;
 	if (space == NULL)
 		space = table_def->new_space;
@@ -2383,7 +2377,8 @@ sql_create_index(struct Parse *parse, struct Token *index_name,
 	/* Name of the index. */
 	char *name = NULL;
 	assert(!sql_get()->init.busy);
-	struct SrcList *tbl_name = parse->src_list;
+	struct SrcList *tbl_name = parse->type == PARSE_TYPE_ADD_COLUMN ? NULL :
+				   parse->src_list;
 
 	if (parse->is_aborted)
 		goto exit_create_index;
@@ -2398,7 +2393,7 @@ sql_create_index(struct Parse *parse, struct Token *index_name,
 	 */
 	struct space *space = parse->create_table_def.new_space;
 	if (space == NULL)
-		space = parse->create_column_def.space;
+		space = parse->space;
 	bool is_create_table_or_add_col = space != NULL;
 	if (tbl_name != NULL) {
 		assert(index_name->n > 0 && index_name->z != NULL);
@@ -3156,7 +3151,7 @@ int
 sql_fieldno_by_name(struct Parse *parse_context, struct Expr *field_name,
 		    uint32_t *fieldno)
 {
-	struct space_def *def = parse_context->create_column_def.space->def;
+	struct space_def *def = parse_context->space->def;
 	struct Expr *name = sqlExprSkipCollate(field_name);
 	if (name->op != TK_ID) {
 		diag_set(ClientError, ER_INDEX_DEF_UNSUPPORTED, "Expressions");

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -558,10 +558,10 @@ field_def_create_for_pk(struct Parse *parser, struct field_def *field,
 void
 sqlAddPrimaryKey(struct Parse *pParse)
 {
-	struct space *space = pParse->create_table_def.new_space;
+	struct space *space = pParse->create_column_def.space;
+	assert(space != NULL || pParse->src_list != NULL);
 	if (space == NULL)
-		space = pParse->create_column_def.space;
-	assert(space != NULL);
+		return sql_create_index(pParse);
 	if (sql_space_primary_key(space) != NULL) {
 		diag_set(ClientError, ER_CREATE_SPACE, space->def->name,
 			 "primary key has been already declared");

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -2635,20 +2635,16 @@ sql_create_index(struct Parse *parse, struct Token *index_name,
 void
 sql_drop_index(struct Parse *parse_context)
 {
-	struct drop_entity_def *drop_def = &parse_context->drop_index_def.base;
-	assert(drop_def->base.entity_type == ENTITY_TYPE_INDEX);
-	assert(drop_def->base.alter_action == ALTER_ACTION_DROP);
 	struct Vdbe *v = sqlGetVdbe(parse_context);
 	assert(v != NULL);
 	/* Never called with prior errors. */
 	assert(!parse_context->is_aborted);
-	struct SrcList *table_list = drop_def->base.entity_name;
-	assert(table_list->nSrc == 1);
-	char *table_name = table_list->a[0].zName;
+	assert(parse_context->src_list->nSrc == 1);
+	char *table_name = parse_context->src_list->a[0].zName;
 	char *index_name = NULL;
 	sqlVdbeCountChanges(v);
 	struct space *space = space_by_name(table_name);
-	bool if_exists = drop_def->if_exist;
+	bool if_exists = parse_context->drop_object.if_exists;
 	if (space == NULL) {
 		if (!if_exists) {
 			diag_set(ClientError, ER_NO_SUCH_SPACE, table_name);
@@ -2656,13 +2652,12 @@ sql_drop_index(struct Parse *parse_context)
 		}
 		goto exit_drop_index;
 	}
-	index_name = sql_name_from_token(&drop_def->name);
+	index_name = sql_name_from_token(&parse_context->drop_object.name);
 
 	vdbe_emit_index_drop(parse_context, index_name, space->def,
 			     ER_NO_SUCH_INDEX_NAME, if_exists);
 	sqlVdbeChangeP5(v, OPFLAG_NCHANGE);
  exit_drop_index:
-	sqlSrcListDelete(table_list);
 	sql_xfree(index_name);
 }
 

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -2704,7 +2704,8 @@ sql_create_index(struct Parse *parse) {
 	if (index != NULL && index->def != NULL)
 		index_def_delete(index->def);
 	sql_expr_list_delete(col_list);
-	sqlSrcListDelete(tbl_name);
+	if (parse->src_list != tbl_name)
+		sqlSrcListDelete(tbl_name);
 	sql_xfree(name);
 }
 

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -3156,7 +3156,7 @@ int
 sql_fieldno_by_name(struct Parse *parse_context, struct Expr *field_name,
 		    uint32_t *fieldno)
 {
-	struct space_def *def = parse_context->create_table_def.new_space->def;
+	struct space_def *def = parse_context->create_column_def.space->def;
 	struct Expr *name = sqlExprSkipCollate(field_name);
 	if (name->op != TK_ID) {
 		diag_set(ClientError, ER_INDEX_DEF_UNSUPPORTED, "Expressions");

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -2036,11 +2036,7 @@ tnt_error:
 void
 sql_drop_constraint(struct Parse *parse_context)
 {
-	struct drop_entity_def *drop_def =
-		&parse_context->drop_constraint_def.base;
-	assert(drop_def->base.entity_type == ENTITY_TYPE_CONSTRAINT);
-	assert(drop_def->base.alter_action == ALTER_ACTION_DROP);
-	const char *table_name = drop_def->base.entity_name->a[0].zName;
+	const char *table_name = parse_context->src_list->a[0].zName;
 	assert(table_name != NULL);
 	struct space *space = space_by_name(table_name);
 	if (space == NULL) {
@@ -2048,9 +2044,10 @@ sql_drop_constraint(struct Parse *parse_context)
 		parse_context->is_aborted = true;
 		return;
 	}
+	struct Token *constraint_name = &parse_context->drop_object.name;
 	char *name = sql_normalized_name_region_new(&parse_context->region,
-						    drop_def->name.z,
-						    drop_def->name.n);
+						    constraint_name->z,
+						    constraint_name->n);
 	if (name == NULL) {
 		parse_context->is_aborted = true;
 		return;

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -1742,7 +1742,8 @@ sql_drop_table(struct Parse *parse_context)
 	sql_code_drop_table(parse_context, space, is_view);
 
  exit_drop_table:
-	sqlSrcListDelete(table_name_list);
+	if (table_name_list != parse_context->src_list)
+		sqlSrcListDelete(table_name_list);
 }
 
 /**

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -319,8 +319,7 @@ ccons ::= cconsname(N) UNIQUE. {
 }
 
 ccons ::= cconsname(N) CHECK LP expr(X) RP. {
-  create_ck_def_init(&pParse->create_ck_def, NULL, &N, &X);
-  sql_create_check_contraint(pParse, true);
+  sql_parse_column_check(pParse, &N, &X);
 }
 
 ccons ::= cconsname(N) REFERENCES nm(T) eidlist_opt(TA). {
@@ -346,8 +345,7 @@ tcons ::= cconsname(N) UNIQUE LP sortlist(X) RP. {
   sql_create_index(pParse);
 }
 tcons ::= cconsname(N) CHECK LP expr(X) RP. {
-  create_ck_def_init(&pParse->create_ck_def, NULL, &N, &X);
-  sql_create_check_contraint(pParse, false);
+  sql_parse_table_check(pParse, &N, &X);
 }
 tcons ::= cconsname(N) FOREIGN KEY LP eidlist(FA) RP
           REFERENCES nm(T) eidlist_opt(TA). {
@@ -1688,8 +1686,7 @@ cmd ::= alter_add_constraint(N) FOREIGN KEY LP eidlist(FA) RP REFERENCES
 }
 
 cmd ::= alter_add_constraint(N) CHECK LP expr(X) RP. {
-    create_ck_def_init(&pParse->create_ck_def, N.table_name, &N.name, &X);
-    sql_create_check_contraint(pParse, false);
+  sql_parse_add_check(pParse, N.table_name, &N.name, &X);
 }
 
 cmd ::= alter_add_constraint(N) unique_spec(U) LP sortlist(X) RP. {

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -1581,10 +1581,7 @@ raisetype(A) ::= FAIL.      {A = ON_CONFLICT_ACTION_FAIL;}
 
 ////////////////////////  DROP TRIGGER statement //////////////////////////////
 cmd ::= DROP TRIGGER ifexists(NOERR) fullname(X). {
-  struct Token t = Token_nil;
-  drop_trigger_def_init(&pParse->drop_trigger_def, X, &t, NOERR);
-  pParse->initiateTTrans = true;
-  sql_drop_trigger(pParse);
+  sql_parse_drop_trigger(pParse, X, NOERR);
 }
 
 //////////////////////// ALTER TABLE table ... ////////////////////////////////

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -356,10 +356,7 @@ cmd ::= DROP TABLE ifexists(E) fullname(X) . {
 }
 
 cmd ::= DROP VIEW ifexists(E) fullname(X) . {
-  struct Token t = Token_nil;
-  drop_view_def_init(&pParse->drop_view_def, X, &t, E);
-  pParse->initiateTTrans = true;
-  sql_drop_table(pParse);
+  sql_parse_drop_view(pParse, X, E);
 }
 
 %type ifexists {int}

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -1424,9 +1424,7 @@ eidlist(A) ::= nm(Y). {
 ///////////////////////////// The DROP INDEX command /////////////////////////
 //
 cmd ::= DROP INDEX ifexists(E) nm(X) ON fullname(Y).   {
-  drop_index_def_init(&pParse->drop_index_def, Y, &X, E);
-  pParse->initiateTTrans = true;
-  sql_drop_index(pParse);
+  sql_parse_drop_index(pParse, Y, &X, E);
 }
 
 ///////////////////////////// The SET SESSION command ////////////////////////

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -1651,9 +1651,7 @@ cmd ::= alter_table_start(A) RENAME TO nm(N). {
 }
 
 cmd ::= ALTER TABLE fullname(X) DROP CONSTRAINT nm(Z). {
-  drop_constraint_def_init(&pParse->drop_constraint_def, X, &Z, false);
-  pParse->initiateTTrans = true;
-  sql_drop_constraint(pParse);
+  sql_parse_drop_constraint(pParse, X, &Z);
 }
 
 //////////////////////// COMMON TABLE EXPRESSIONS ////////////////////////////

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -228,9 +228,8 @@ column_name_and_type ::= nm(A) typedef(Y). {
 }
 
 create_column_end ::= autoinc(I). {
-  uint32_t fieldno = pParse->create_column_def.space->def->field_count - 1;
-  if (I == 1 && sql_add_autoincrement(pParse, fieldno) != 0)
-    return;
+  if (I == 1)
+    sql_parse_column_autoincrement(pParse);
 }
 columnlist ::= tcons.
 
@@ -710,24 +709,14 @@ sortlist(A) ::= expr(Y) sortorder(Z). {
 
 col_list_with_autoinc(A) ::= col_list_with_autoinc(A) COMMA expr(Y)
                              autoinc(I). {
-  uint32_t fieldno;
-  if (I == 1) {
-    if (sql_fieldno_by_name(pParse, Y.pExpr, &fieldno) != 0)
-      return;
-    if (sql_add_autoincrement(pParse, fieldno) != 0)
-      return;
-  }
+  if (I == 1)
+    sql_parse_table_autoincrement(pParse, sqlExprDup(Y.pExpr, 0));
   A = sql_expr_list_append(A, Y.pExpr);
 }
 
 col_list_with_autoinc(A) ::= expr(Y) autoinc(I). {
-  if (I == 1) {
-    uint32_t fieldno = 0;
-    if (sql_fieldno_by_name(pParse, Y.pExpr, &fieldno) != 0)
-      return;
-    if (sql_add_autoincrement(pParse, fieldno) != 0)
-      return;
-  }
+  if (I == 1)
+    sql_parse_table_autoincrement(pParse, sqlExprDup(Y.pExpr, 0));
   /* A-overwrites-Y. */
   A = sql_expr_list_append(NULL, Y.pExpr);
 }

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -1458,21 +1458,13 @@ cmd ::= FUNCTION_KW(T) expr(E). {
 }
 //////////////////////////// The CREATE TRIGGER command /////////////////////
 
-cmd ::= createkw trigger_decl(A) BEGIN trigger_cmd_list(S) END(Z). {
+cmd ::= createkw TRIGGER ifnotexists(NOERR) nm(B) trigger_time(C)
+        trigger_event(D) ON fullname(E) foreach_clause when_clause(G)
+        BEGIN trigger_cmd_list(S) END(Z). {
   Token all;
-  all.z = A.z;
-  all.n = (int)(Z.z - A.z) + Z.n;
-  pParse->initiateTTrans = true;
-  sql_trigger_finish(pParse, S, &all);
-}
-
-trigger_decl(A) ::= TRIGGER ifnotexists(NOERR) nm(B)
-                    trigger_time(C) trigger_event(D)
-                    ON fullname(E) foreach_clause when_clause(G). {
-  create_trigger_def_init(&pParse->create_trigger_def, E, &B, C, D.a, D.b, G,
-                          NOERR);
-  sql_trigger_begin(pParse);
-  A = B; /*A-overwrites-T*/
+  all.z = B.z;
+  all.n = (int)(Z.z - B.z) + Z.n;
+  sql_parse_create_trigger(pParse, E, &B, C, D.a, D.b, G, S, &all, NOERR);
 }
 
 %type trigger_time {int}

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -108,10 +108,7 @@ static void disableLookaside(Parse *pParse){
 
 // Input is a single SQL command
 input ::= ecmd.
-ecmd ::= explain cmdx SEMI. {
-	if (!pParse->parse_only)
-		sql_finish_coding(pParse);
-}
+ecmd ::= explain cmdx SEMI.
 ecmd ::= SEMI. {
   diag_set(ClientError, ER_SQL_STATEMENT_EMPTY);
   pParse->is_aborted = true;
@@ -149,20 +146,26 @@ cmdx ::= cmd.
 ///////////////////// Begin and end transactions. ////////////////////////////
 //
 
-cmd ::= START TRANSACTION.  {sql_transaction_begin(pParse);}
-cmd ::= COMMIT.      {sql_transaction_commit(pParse);}
-cmd ::= ROLLBACK.    {sql_transaction_rollback(pParse);}
+cmd ::= START TRANSACTION. {
+  sql_parse_transaction_start(pParse);
+}
+cmd ::= COMMIT. {
+  sql_parse_transaction_commit(pParse);
+}
+cmd ::= ROLLBACK. {
+  sql_parse_transaction_rollback(pParse);
+}
 
 savepoint_opt ::= SAVEPOINT.
 savepoint_opt ::= .
 cmd ::= SAVEPOINT nm(X). {
-  sqlSavepoint(pParse, SAVEPOINT_BEGIN, &X);
+  sql_parse_savepoint_create(pParse, &X);
 }
 cmd ::= RELEASE savepoint_opt nm(X). {
-  sqlSavepoint(pParse, SAVEPOINT_RELEASE, &X);
+  sql_parse_savepoint_release(pParse, &X);
 }
 cmd ::= ROLLBACK TO savepoint_opt nm(X). {
-  sqlSavepoint(pParse, SAVEPOINT_ROLLBACK, &X);
+  sql_parse_savepoint_rollback(pParse, &X);
 }
 
 ///////////////////// The CREATE TABLE statement ////////////////////////////

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -172,9 +172,7 @@ cmd ::= ROLLBACK TO savepoint_opt nm(X). {
 //
 cmd ::= create_table create_table_args with_opts.
 create_table ::= createkw TABLE ifnotexists(E) nm(Y). {
-  create_table_def_init(&pParse->create_table_def, &Y, E);
-  pParse->create_table_def.new_space = sqlStartTable(pParse, &Y);
-  sql_parse_create_table(pParse);
+  sql_parse_create_table(pParse, &Y, E);
 }
 createkw(A) ::= CREATE(A).  {disableLookaside(pParse);}
 
@@ -188,19 +186,7 @@ with_opts ::= WITH engine_opts.
 with_opts ::= .
 
 engine_opts ::= ENGINE EQ STRING(A). {
-  /* Note that specifying engine clause overwrites default engine. */
-  if (A.n > ENGINE_NAME_MAX) {
-    diag_set(ClientError, ER_CREATE_SPACE,
-             pParse->create_table_def.new_space->def->name,
-             "space engine name is too long");
-    pParse->is_aborted = true;
-    return;
-  }
-  /* Need to dequote name. */
-  char *normalized_name = sql_name_from_token(&A);
-  memcpy(pParse->create_table_def.new_space->def->engine_name, normalized_name,
-         strlen(normalized_name) + 1);
-  sql_xfree(normalized_name);
+  sql_parse_table_engine(pParse, &A);
 }
 
 /*

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -349,10 +349,7 @@ resolvetype(A) ::= REPLACE.                  {A = ON_CONFLICT_ACTION_REPLACE;}
 //
 
 cmd ::= DROP TABLE ifexists(E) fullname(X) . {
-  struct Token t = Token_nil;
-  drop_table_def_init(&pParse->drop_table_def, X, &t, E);
-  pParse->initiateTTrans = true;
-  sql_drop_table(pParse);
+  sql_parse_drop_table(pParse, X, E);
 }
 
 cmd ::= DROP VIEW ifexists(E) fullname(X) . {

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -371,9 +371,7 @@ ifexists(A) ::= .            {A = 0;}
 cmd ::= createkw(X) VIEW ifnotexists(E) nm(Y) eidlist_opt(C)
           AS select(S). {
   if (!pParse->parse_only) {
-    create_view_def_init(&pParse->create_view_def, &Y, &X, C, S, E);
-    pParse->initiateTTrans = true;
-    sql_create_view(pParse);
+    sql_parse_create_view(pParse, &Y, &X, C, S, E);
   } else {
     sql_store_select(pParse, S);
   }

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -307,9 +307,7 @@ ccons ::= NULL onconf(R).        {
 }
 ccons ::= NOT NULL onconf(R).    {sql_column_add_nullable_action(pParse, R);}
 ccons ::= cconsname(N) PRIMARY KEY sortorder(Z). {
-  create_index_def_init(&pParse->create_index_def, NULL, &N, NULL,
-                        SQL_INDEX_TYPE_CONSTRAINT_PK, Z, false);
-  sqlAddPrimaryKey(pParse);
+  sql_parse_column_primary_key(pParse, &N, Z);
 }
 ccons ::= cconsname(N) UNIQUE. {
   sql_parse_column_unique(pParse, &N);
@@ -331,9 +329,7 @@ autoinc(X) ::= AUTOINCR.  {X = 1;}
 
 // The next group of rules parses the arguments to a REFERENCES clause.
 tcons ::= cconsname(N) PRIMARY KEY LP col_list_with_autoinc(X) RP. {
-  create_index_def_init(&pParse->create_index_def, NULL, &N, X,
-                        SQL_INDEX_TYPE_CONSTRAINT_PK, SORT_ORDER_ASC, false);
-  sqlAddPrimaryKey(pParse);
+  sql_parse_table_primary_key(pParse, &N, X);
 }
 tcons ::= cconsname(N) UNIQUE LP sortlist(X) RP. {
   sql_parse_table_unique(pParse, &N, X);
@@ -1688,9 +1684,7 @@ cmd ::= alter_add_constraint(N) UNIQUE LP sortlist(X) RP. {
 }
 
 cmd ::= alter_add_constraint(N) PRIMARY KEY LP sortlist(X) RP. {
-  create_index_def_init(&pParse->create_index_def, N.table_name, &N.name, X,
-                        SQL_INDEX_TYPE_CONSTRAINT_PK, SORT_ORDER_ASC, false);
-  sql_create_index(pParse);
+  sql_parse_add_primary_key(pParse, N.table_name, &N.name, X);
 }
 
 cmd ::= alter_table_start(A) RENAME TO nm(N). {

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -1395,18 +1395,14 @@ paren_exprlist(A) ::= LP exprlist(X) RP.  {A = X;}
 
 ///////////////////////////// The CREATE INDEX command ///////////////////////
 //
-cmd ::= createkw uniqueflag(U) INDEX ifnotexists(NE) nm(X)
+cmd ::= createkw is_unique(U) INDEX ifnotexists(NE) nm(X)
         ON nm(Y) LP sortlist(Z) RP. {
-  struct SrcList *src_list = sql_src_list_append(NULL ,&Y);
-  create_index_def_init(&pParse->create_index_def, src_list, &X, Z, U,
-                        SORT_ORDER_ASC, NE);
-  pParse->initiateTTrans = true;
-  sql_create_index(pParse);
+  sql_parse_create_index(pParse, &Y, &X, Z, U, NE);
 }
 
-%type uniqueflag {int}
-uniqueflag(A) ::= UNIQUE.  {A = SQL_INDEX_TYPE_UNIQUE;}
-uniqueflag(A) ::= .        {A = SQL_INDEX_TYPE_NON_UNIQUE;}
+%type is_unique {bool}
+is_unique(A) ::= UNIQUE.  {A = true;}
+is_unique(A) ::= .        {A = false;}
 
 
 // The eidlist non-terminal (Expression Id List) generates an ExprList

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -1647,9 +1647,7 @@ cmd ::= alter_add_constraint(N) PRIMARY KEY LP sortlist(X) RP. {
 }
 
 cmd ::= alter_table_start(A) RENAME TO nm(N). {
-    rename_entity_def_init(&pParse->rename_entity_def, A, &N);
-    pParse->initiateTTrans = true;
-    sql_alter_table_rename(pParse);
+  sql_parse_table_rename(pParse, A, &N);
 }
 
 cmd ::= ALTER TABLE fullname(X) DROP CONSTRAINT nm(Z). {

--- a/src/box/sql/parse_def.c
+++ b/src/box/sql/parse_def.c
@@ -30,7 +30,7 @@
  */
 #include <string.h>
 
-#include "parse_def.h"
+#include "sqlInt.h"
 
 const struct Token sqlIntTokens[] = {
 	{"0", 1, false},
@@ -44,4 +44,43 @@ sqlTokenInit(struct Token *p, char *z)
 {
 	p->z = z;
 	p->n = z == NULL ? 0 : strlen(z);
+}
+
+void
+sql_parse_transaction_start(struct Parse *parse)
+{
+	parse->type = PARSE_TYPE_START_TRANSACTION;
+}
+
+void
+sql_parse_transaction_commit(struct Parse *parse)
+{
+	parse->type = PARSE_TYPE_COMMIT;
+}
+
+void
+sql_parse_transaction_rollback(struct Parse *parse)
+{
+	parse->type = PARSE_TYPE_ROLLBACK;
+}
+
+void
+sql_parse_savepoint_create(struct Parse *parse, const struct Token *name)
+{
+	parse->type = PARSE_TYPE_SAVEPOINT;
+	parse->savepoint.name = *name;
+}
+
+void
+sql_parse_savepoint_release(struct Parse *parse, const struct Token *name)
+{
+	parse->type = PARSE_TYPE_RELEASE_SAVEPOINT;
+	parse->savepoint.name = *name;
+}
+
+void
+sql_parse_savepoint_rollback(struct Parse *parse, const struct Token *name)
+{
+	parse->type = PARSE_TYPE_ROLLBACK_TO_SAVEPOINT;
+	parse->savepoint.name = *name;
 }

--- a/src/box/sql/parse_def.c
+++ b/src/box/sql/parse_def.c
@@ -415,3 +415,27 @@ sql_parse_table_engine(struct Parse *parse, struct Token *engine_name)
 {
 	parse->create_table.engine_name = *engine_name;
 }
+
+void
+sql_parse_create_view(struct Parse *parse, struct Token *name,
+		      struct Token *create_start, struct ExprList *aliases,
+		      struct Select *select, bool if_not_exists)
+{
+	parse->type = PARSE_TYPE_CREATE_VIEW;
+	parse->create_view.name = *name;
+	parse->create_view.aliases = aliases;
+	parse->create_view.select = select;
+	parse->create_view.if_not_exists = if_not_exists;
+
+	struct Token end = parse->sLastToken;
+	assert(end.z[0] != '\0');
+	if (end.z[0] != ';')
+		end.z += end.n;
+	struct Token *begin = create_start;
+	int len = end.z - begin->z;
+	assert(len > 0);
+	while (sqlIsspace(begin->z[len - 1]))
+		len--;
+	parse->create_view.str.z = begin->z;
+	parse->create_view.str.n = len;
+}

--- a/src/box/sql/parse_def.c
+++ b/src/box/sql/parse_def.c
@@ -486,3 +486,12 @@ sql_parse_drop_index(struct Parse *parse, struct SrcList *table_name,
 	parse->drop_object.name = *name;
 	parse->drop_object.if_exists = if_exists;
 }
+
+void
+sql_parse_drop_view(struct Parse *parse, struct SrcList *table_name,
+		    bool if_exists)
+{
+	parse->type = PARSE_TYPE_DROP_VIEW;
+	parse->src_list = table_name;
+	parse->drop_object.if_exists = if_exists;
+}

--- a/src/box/sql/parse_def.c
+++ b/src/box/sql/parse_def.c
@@ -293,3 +293,16 @@ sql_parse_add_primary_key(struct Parse *parse, struct SrcList *table_name,
 	parse->src_list = table_name;
 	primary_key_fill(parse, name, cols);
 }
+
+void
+sql_parse_create_index(struct Parse *parse, struct Token *table_name,
+		       const struct Token *index_name, struct ExprList *cols,
+		       bool is_unique, bool if_not_exists)
+{
+	parse->type = PARSE_TYPE_CREATE_INDEX;
+	parse->src_list = sql_src_list_append(NULL, table_name);
+	parse->create_index.name = *index_name;
+	parse->create_index.cols = cols;
+	parse->create_index.is_unique = is_unique;
+	parse->create_index.if_not_exists = if_not_exists;
+}

--- a/src/box/sql/parse_def.c
+++ b/src/box/sql/parse_def.c
@@ -495,3 +495,12 @@ sql_parse_drop_view(struct Parse *parse, struct SrcList *table_name,
 	parse->src_list = table_name;
 	parse->drop_object.if_exists = if_exists;
 }
+
+void
+sql_parse_drop_table(struct Parse *parse, struct SrcList *table_name,
+		     bool if_exists)
+{
+	parse->type = PARSE_TYPE_DROP_TABLE;
+	parse->src_list = table_name;
+	parse->drop_object.if_exists = if_exists;
+}

--- a/src/box/sql/parse_def.c
+++ b/src/box/sql/parse_def.c
@@ -504,3 +504,12 @@ sql_parse_drop_table(struct Parse *parse, struct SrcList *table_name,
 	parse->src_list = table_name;
 	parse->drop_object.if_exists = if_exists;
 }
+
+void
+sql_parse_drop_trigger(struct Parse *parse, struct SrcList *table_name,
+		       bool if_exists)
+{
+	parse->type = PARSE_TYPE_DROP_TRIGGER;
+	parse->src_list = table_name;
+	parse->drop_object.if_exists = if_exists;
+}

--- a/src/box/sql/parse_def.c
+++ b/src/box/sql/parse_def.c
@@ -439,3 +439,22 @@ sql_parse_create_view(struct Parse *parse, struct Token *name,
 	parse->create_view.str.z = begin->z;
 	parse->create_view.str.n = len;
 }
+
+void
+sql_parse_create_trigger(struct Parse *parse, struct SrcList *table_name,
+			 struct Token *name, int time, int op,
+			 struct IdList *cols, struct Expr *when,
+			 struct TriggerStep *step, struct Token *all,
+			 bool if_not_exists)
+{
+	parse->type = PARSE_TYPE_CREATE_TRIGGER;
+	parse->src_list = table_name;
+	parse->create_trigger.name = *name;
+	parse->create_trigger.time = time;
+	parse->create_trigger.op = op;
+	parse->create_trigger.cols = cols;
+	parse->create_trigger.when = when;
+	parse->create_trigger.step = step;
+	parse->create_trigger.all = *all;
+	parse->create_trigger.if_not_exists = if_not_exists;
+}

--- a/src/box/sql/parse_def.c
+++ b/src/box/sql/parse_def.c
@@ -476,3 +476,13 @@ sql_parse_drop_constraint(struct Parse *parse, struct SrcList *table_name,
 	parse->src_list = table_name;
 	parse->drop_object.name = *name;
 }
+
+void
+sql_parse_drop_index(struct Parse *parse, struct SrcList *table_name,
+		     struct Token *name, bool if_exists)
+{
+	parse->type = PARSE_TYPE_DROP_INDEX;
+	parse->src_list = table_name;
+	parse->drop_object.name = *name;
+	parse->drop_object.if_exists = if_exists;
+}

--- a/src/box/sql/parse_def.c
+++ b/src/box/sql/parse_def.c
@@ -467,3 +467,12 @@ sql_parse_table_rename(struct Parse *parse, struct SrcList *table_name,
 	parse->src_list = table_name;
 	parse->table_new_name = *new_name;
 }
+
+void
+sql_parse_drop_constraint(struct Parse *parse, struct SrcList *table_name,
+			  struct Token *name)
+{
+	parse->type = PARSE_TYPE_DROP_CONSTRAINT;
+	parse->src_list = table_name;
+	parse->drop_object.name = *name;
+}

--- a/src/box/sql/parse_def.c
+++ b/src/box/sql/parse_def.c
@@ -458,3 +458,12 @@ sql_parse_create_trigger(struct Parse *parse, struct SrcList *table_name,
 	parse->create_trigger.all = *all;
 	parse->create_trigger.if_not_exists = if_not_exists;
 }
+
+void
+sql_parse_table_rename(struct Parse *parse, struct SrcList *table_name,
+		       struct Token *new_name)
+{
+	parse->type = PARSE_TYPE_RENAME_TABLE;
+	parse->src_list = table_name;
+	parse->table_new_name = *new_name;
+}

--- a/src/box/sql/parse_def.c
+++ b/src/box/sql/parse_def.c
@@ -96,15 +96,19 @@ last_column_name(struct Parse *parse)
 static const char *
 new_table_name(struct Parse *parse)
 {
-	if (parse->create_table_def.new_space == NULL)
+	if (parse->type != PARSE_TYPE_CREATE_TABLE)
 		return NULL;
-	return parse->create_table_def.new_space->def->name;
+	struct Token *name = &parse->create_table.name;
+	return sql_normalized_name_region_new(&parse->region, name->z, name->n);
 }
 
 void
-sql_parse_create_table(struct Parse *parse)
+sql_parse_create_table(struct Parse *parse, struct Token *name,
+		       bool if_not_exists)
 {
 	parse->type = PARSE_TYPE_CREATE_TABLE;
+	parse->create_table.name = *name;
+	parse->create_table.if_not_exists = if_not_exists;
 }
 
 /** Append a new column to column list. */
@@ -404,4 +408,10 @@ void
 sql_parse_column_default(struct Parse *parse, struct ExprSpan *expr)
 {
 	parse->column_list.a[parse->column_list.n - 1].default_expr = *expr;
+}
+
+void
+sql_parse_table_engine(struct Parse *parse, struct Token *engine_name)
+{
+	parse->create_table.engine_name = *engine_name;
 }

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -100,6 +100,8 @@ enum parse_type {
 	PARSE_TYPE_ADD_CHECK,
 	/** ALTER TABLE ADD CONSTAINT UNIQUE statement. */
 	PARSE_TYPE_ADD_UNIQUE,
+	/** ALTER TABLE ADD CONSTAINT PRIMARY KEY statement. */
+	PARSE_TYPE_ADD_PRIMARY_KEY,
 };
 
 /**
@@ -656,5 +658,20 @@ sql_parse_table_unique(struct Parse *parse, const struct Token *name,
 void
 sql_parse_add_unique(struct Parse *parse, struct SrcList *table_name,
 		     const struct Token *name, struct ExprList *cols);
+
+/** Save parsed column PRIMARY KEY. */
+void
+sql_parse_column_primary_key(struct Parse *parse, const struct Token *name,
+			     enum sort_order sort_order);
+
+/** Save parsed table PRIMARY KEY from CREATE TABLE statement. */
+void
+sql_parse_table_primary_key(struct Parse *parse, const struct Token *name,
+			    struct ExprList *cols);
+
+/** Save parsed table PRIMARY KEY from ALTER TABLE ADD CONSTRAINT statement. */
+void
+sql_parse_add_primary_key(struct Parse *parse, struct SrcList *table_name,
+			  const struct Token *name, struct ExprList *cols);
 
 #endif /* TARANTOOL_BOX_SQL_PARSE_DEF_H_INCLUDED */

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -112,6 +112,8 @@ enum parse_type {
 	PARSE_TYPE_RENAME_TABLE,
 	/** ALTER TABLE RENAME statement. */
 	PARSE_TYPE_DROP_CONSTRAINT,
+	/** DROP INDEX statement. */
+	PARSE_TYPE_DROP_INDEX,
 };
 
 /**
@@ -288,11 +290,14 @@ struct sql_parse_trigger {
 };
 
 /**
- * Description of the object to drop from ALTER TABLE DROP CONSTRAINT statement.
+ * Description of the object to drop from ALTER TABLE DROP CONSTRAINT or
+ * DROP INDEX statement.
  */
 struct sql_parse_drop {
 	/** Drop object name. */
 	struct Token name;
+	/** IF EXISTS flag. */
+	bool if_exists;
 };
 
 /** Constant tokens for integer values. */
@@ -432,10 +437,6 @@ struct drop_trigger_def {
 	struct drop_entity_def base;
 };
 
-struct drop_index_def {
-	struct drop_entity_def base;
-};
-
 /** Basic initialisers of parse structures.*/
 static inline void
 alter_entity_def_init(struct alter_entity_def *alter_def,
@@ -483,15 +484,6 @@ drop_trigger_def_init(struct drop_trigger_def *drop_trigger_def,
 {
 	drop_entity_def_init(&drop_trigger_def->base, parent_name, name,
 			     if_exist, ENTITY_TYPE_TRIGGER);
-}
-
-static inline void
-drop_index_def_init(struct drop_index_def *drop_index_def,
-		    struct SrcList *parent_name, struct Token *name,
-		    bool if_exist)
-{
-	drop_entity_def_init(&drop_index_def->base, parent_name, name, if_exist,
-			     ENTITY_TYPE_INDEX);
 }
 
 static inline void
@@ -674,5 +666,10 @@ sql_parse_table_rename(struct Parse *parse, struct SrcList *table_name,
 void
 sql_parse_drop_constraint(struct Parse *parse, struct SrcList *table_name,
 			  struct Token *name);
+
+/** Save parsed DROP INDEX statement. */
+void
+sql_parse_drop_index(struct Parse *parse, struct SrcList *table_name,
+		     struct Token *name, bool if_exists);
 
 #endif /* TARANTOOL_BOX_SQL_PARSE_DEF_H_INCLUDED */

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -116,6 +116,8 @@ enum parse_type {
 	PARSE_TYPE_DROP_INDEX,
 	/** DROP VIEW statement. */
 	PARSE_TYPE_DROP_VIEW,
+	/** DROP TABLE statement. */
+	PARSE_TYPE_DROP_TABLE,
 };
 
 /**
@@ -293,7 +295,7 @@ struct sql_parse_trigger {
 
 /**
  * Description of the object to drop from ALTER TABLE DROP CONSTRAINT,
- * DROP INDEX or DROP VIEW statement.
+ * DROP INDEX, DROP VIEW or DROP TABLE statement.
  */
 struct sql_parse_drop {
 	/** Drop object name. */
@@ -422,19 +424,6 @@ struct drop_entity_def {
 	bool if_exist;
 };
 
-/**
- * Identical wrappers around drop_entity_def to make hierarchy of
- * structures be consistent. Arguments for drop procedures are
- * the same.
- */
-struct drop_table_def {
-	struct drop_entity_def base;
-};
-
-struct drop_view_def {
-	struct drop_entity_def base;
-};
-
 struct drop_trigger_def {
 	struct drop_entity_def base;
 };
@@ -459,24 +448,6 @@ drop_entity_def_init(struct drop_entity_def *drop_def,
 			      ALTER_ACTION_DROP);
 	drop_def->name = *name;
 	drop_def->if_exist = if_exist;
-}
-
-static inline void
-drop_table_def_init(struct drop_table_def *drop_table_def,
-		    struct SrcList *parent_name, struct Token *name,
-		    bool if_exist)
-{
-	drop_entity_def_init(&drop_table_def->base, parent_name, name, if_exist,
-			     ENTITY_TYPE_TABLE);
-}
-
-static inline void
-drop_view_def_init(struct drop_view_def *drop_view_def,
-		   struct SrcList *parent_name, struct Token *name,
-		   bool if_exist)
-{
-	drop_entity_def_init(&drop_view_def->base, parent_name, name, if_exist,
-			     ENTITY_TYPE_VIEW);
 }
 
 static inline void
@@ -678,5 +649,10 @@ sql_parse_drop_index(struct Parse *parse, struct SrcList *table_name,
 void
 sql_parse_drop_view(struct Parse *parse, struct SrcList *table_name,
 		    bool if_exists);
+
+/** Save parsed DROP TABLE statement. */
+void
+sql_parse_drop_table(struct Parse *parse, struct SrcList *table_name,
+		     bool if_exists);
 
 #endif /* TARANTOOL_BOX_SQL_PARSE_DEF_H_INCLUDED */

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -235,6 +235,16 @@ struct sql_parse_column_list {
 	uint32_t n;
 };
 
+/** Description of the table being created. */
+struct sql_parse_table {
+	/** Table name. */
+	struct Token name;
+	/** Table engine name. */
+	struct Token engine_name;
+	/** IF NOT EXISTS flag. */
+	bool if_not_exists;
+};
+
 /** Constant tokens for integer values. */
 extern const struct Token sqlIntTokens[];
 
@@ -342,11 +352,6 @@ struct create_entity_def {
 	struct Token name;
 	/** Statement comes with IF NOT EXISTS clause. */
 	bool if_not_exist;
-};
-
-struct create_table_def {
-	struct create_entity_def base;
-	struct space *new_space;
 };
 
 struct create_ck_constraint_parse_def {
@@ -524,14 +529,6 @@ create_trigger_def_init(struct create_trigger_def *trigger_def,
 }
 
 static inline void
-create_table_def_init(struct create_table_def *table_def, struct Token *name,
-		      bool if_not_exists)
-{
-	create_entity_def_init(&table_def->base, ENTITY_TYPE_TABLE, NULL, name,
-			       if_not_exists);
-}
-
-static inline void
 create_ck_constraint_parse_def_init(struct create_ck_constraint_parse_def *def)
 {
 	rlist_create(&def->checks);
@@ -592,7 +589,8 @@ sql_parse_savepoint_rollback(struct Parse *parse, const struct Token *name);
 
 /** Save parsed CREATE TABLE statement. */
 void
-sql_parse_create_table(struct Parse *parse);
+sql_parse_create_table(struct Parse *parse, struct Token *name,
+		       bool if_not_exists);
 
 /** Save parsed CREATE INDEX statement. */
 void
@@ -694,5 +692,9 @@ sql_parse_column_nullable_action(struct Parse *parse, int action,
 /** Save parsed column DEFAULT clause. */
 void
 sql_parse_column_default(struct Parse *parse, struct ExprSpan *expr);
+
+/** Save parsed table engine clause. */
+void
+sql_parse_table_engine(struct Parse *parse, struct Token *engine_name);
 
 #endif /* TARANTOOL_BOX_SQL_PARSE_DEF_H_INCLUDED */

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -662,4 +662,12 @@ void
 sql_parse_add_primary_key(struct Parse *parse, struct SrcList *table_name,
 			  const struct Token *name, struct ExprList *cols);
 
+/** Save parsed column AUTOINCREMENT clause. */
+void
+sql_parse_column_autoincrement(struct Parse *parse);
+
+/** Save parsed AUTOINCREMENT clause from table PRIMARY KEY clause. */
+void
+sql_parse_table_autoincrement(struct Parse *parse, struct Expr *column_name);
+
 #endif /* TARANTOOL_BOX_SQL_PARSE_DEF_H_INCLUDED */

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -74,6 +74,24 @@
  * parsing context (struct Parse).
  */
 
+/** Type of parsed statement. */
+enum parse_type {
+	/** Type of the statement is unknown. */
+	PARSE_TYPE_UNKNOWN = 0,
+	/** START TRANSACTION statement. */
+	PARSE_TYPE_START_TRANSACTION,
+	/** COMMIT statement. */
+	PARSE_TYPE_COMMIT,
+	/** ROLLBACK statement. */
+	PARSE_TYPE_ROLLBACK,
+	/** SAVEPOINT statement. */
+	PARSE_TYPE_SAVEPOINT,
+	/** RELEASE SAVEPOINT statement. */
+	PARSE_TYPE_RELEASE_SAVEPOINT,
+	/** ROLLBACK TO SAVEPOINT statement. */
+	PARSE_TYPE_ROLLBACK_TO_SAVEPOINT,
+};
+
 /**
  * Each token coming out of the lexer is an instance of
  * this structure. Tokens are also used as part of an expression.
@@ -84,6 +102,12 @@ struct Token {
 	/** Number of characters in this token. */
 	unsigned int n;
 	bool isReserved;
+};
+
+/** Description of a SAVEPOINT. */
+struct sql_parse_savepoint {
+	/** Name of the SAVEPOINT. */
+	struct Token name;
 };
 
 /** Constant tokens for integer values. */
@@ -503,5 +527,29 @@ create_fk_constraint_parse_def_destroy(struct create_fk_constraint_parse_def *d)
 	rlist_foreach_entry(fk, &d->fkeys, link)
 		sql_expr_list_delete(fk->selfref_cols);
 }
+
+/** Save parsed START TRANSACTION statement. */
+void
+sql_parse_transaction_start(struct Parse *parse);
+
+/** Save parsed COMMIT statement. */
+void
+sql_parse_transaction_commit(struct Parse *parse);
+
+/** Save parsed ROLLBACK statement. */
+void
+sql_parse_transaction_rollback(struct Parse *parse);
+
+/** Save parsed SAVEPOINT statement. */
+void
+sql_parse_savepoint_create(struct Parse *parse, const struct Token *name);
+
+/** Save parsed RELEASE SAVEPOINT statement. */
+void
+sql_parse_savepoint_release(struct Parse *parse, const struct Token *name);
+
+/** Save parsed ROLLBACK TO SAVEPOINT statement. */
+void
+sql_parse_savepoint_rollback(struct Parse *parse, const struct Token *name);
 
 #endif /* TARANTOOL_BOX_SQL_PARSE_DEF_H_INCLUDED */

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -114,6 +114,8 @@ enum parse_type {
 	PARSE_TYPE_DROP_CONSTRAINT,
 	/** DROP INDEX statement. */
 	PARSE_TYPE_DROP_INDEX,
+	/** DROP VIEW statement. */
+	PARSE_TYPE_DROP_VIEW,
 };
 
 /**
@@ -290,8 +292,8 @@ struct sql_parse_trigger {
 };
 
 /**
- * Description of the object to drop from ALTER TABLE DROP CONSTRAINT or
- * DROP INDEX statement.
+ * Description of the object to drop from ALTER TABLE DROP CONSTRAINT,
+ * DROP INDEX or DROP VIEW statement.
  */
 struct sql_parse_drop {
 	/** Drop object name. */
@@ -671,5 +673,10 @@ sql_parse_drop_constraint(struct Parse *parse, struct SrcList *table_name,
 void
 sql_parse_drop_index(struct Parse *parse, struct SrcList *table_name,
 		     struct Token *name, bool if_exists);
+
+/** Save parsed DROP VIEW statement. */
+void
+sql_parse_drop_view(struct Parse *parse, struct SrcList *table_name,
+		    bool if_exists);
 
 #endif /* TARANTOOL_BOX_SQL_PARSE_DEF_H_INCLUDED */

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -98,6 +98,8 @@ enum parse_type {
 	PARSE_TYPE_ADD_FOREIGN_KEY,
 	/** ALTER TABLE ADD CONSTAINT CHECK statement. */
 	PARSE_TYPE_ADD_CHECK,
+	/** ALTER TABLE ADD CONSTAINT UNIQUE statement. */
+	PARSE_TYPE_ADD_UNIQUE,
 };
 
 /**
@@ -171,6 +173,22 @@ struct sql_parse_check_list {
 	/** Array containing all CHECK descriptions from the list. */
 	struct sql_parse_check *a;
 	/** Number of CHECK descriptions in the list. */
+	uint32_t n;
+};
+
+/** Description of the UNIQUE constraint being created. */
+struct sql_parse_unique {
+	/** Constraint name. */
+	struct Token name;
+	/** Unique columns. */
+	struct ExprList *cols;
+};
+
+/** UNIQUE descriptions list. */
+struct sql_parse_unique_list {
+	/** Array containing all UNIQUE descriptions from the list. */
+	struct sql_parse_unique *a;
+	/** Number of UNIQUE descriptions in the list. */
 	uint32_t n;
 };
 
@@ -624,5 +642,19 @@ sql_parse_table_check(struct Parse *parse, const struct Token *name,
 void
 sql_parse_add_check(struct Parse *parse, struct SrcList *table_name,
 		    const struct Token *name, struct ExprSpan *expr);
+
+/** Save parsed column UNIQUE. */
+void
+sql_parse_column_unique(struct Parse *parse, const struct Token *name);
+
+/** Save parsed table UNIQUE from CREATE TABLE statement. */
+void
+sql_parse_table_unique(struct Parse *parse, const struct Token *name,
+		       struct ExprList *cols);
+
+/** Save parsed table UNIQUE from ALTER TABLE ADD CONSTRAINT statement. */
+void
+sql_parse_add_unique(struct Parse *parse, struct SrcList *table_name,
+		     const struct Token *name, struct ExprList *cols);
 
 #endif /* TARANTOOL_BOX_SQL_PARSE_DEF_H_INCLUDED */

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -108,6 +108,8 @@ enum parse_type {
 	PARSE_TYPE_ADD_UNIQUE,
 	/** ALTER TABLE ADD CONSTAINT PRIMARY KEY statement. */
 	PARSE_TYPE_ADD_PRIMARY_KEY,
+	/** ALTER TABLE RENAME statement. */
+	PARSE_TYPE_RENAME_TABLE,
 };
 
 /**
@@ -380,11 +382,6 @@ struct alter_entity_def {
 	struct SrcList *entity_name;
 };
 
-struct rename_entity_def {
-	struct alter_entity_def base;
-	struct Token new_name;
-};
-
 struct create_ck_constraint_parse_def {
 	/** List of ck_constraint_parse_def objects. */
 	struct rlist checks;
@@ -442,15 +439,6 @@ alter_entity_def_init(struct alter_entity_def *alter_def,
 	alter_def->entity_name = entity_name;
 	alter_def->entity_type = type;
 	alter_def->alter_action = action;
-}
-
-static inline void
-rename_entity_def_init(struct rename_entity_def *rename_def,
-		       struct SrcList *table_name, struct Token *new_name)
-{
-	alter_entity_def_init(&rename_def->base, table_name, ENTITY_TYPE_TABLE,
-			      ALTER_ACTION_RENAME);
-	rename_def->new_name = *new_name;
 }
 
 static inline void
@@ -679,5 +667,10 @@ sql_parse_column_default(struct Parse *parse, struct ExprSpan *expr);
 /** Save parsed table engine clause. */
 void
 sql_parse_table_engine(struct Parse *parse, struct Token *engine_name);
+
+/** Save parsed ALTER TABLE RENAME statement. */
+void
+sql_parse_table_rename(struct Parse *parse, struct SrcList *table_name,
+		       struct Token *new_name);
 
 #endif /* TARANTOOL_BOX_SQL_PARSE_DEF_H_INCLUDED */

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -183,14 +183,6 @@ struct alter_entity_def {
 	struct SrcList *entity_name;
 };
 
-struct enable_entity_def {
-	struct alter_entity_def base;
-	/** Name of constraint to be enabled/disabled. */
-	struct Token name;
-	/** A new state to be set for entity found. */
-	bool is_enabled;
-};
-
 struct rename_entity_def {
 	struct alter_entity_def base;
 	struct Token new_name;
@@ -333,17 +325,6 @@ rename_entity_def_init(struct rename_entity_def *rename_def,
 	alter_entity_def_init(&rename_def->base, table_name, ENTITY_TYPE_TABLE,
 			      ALTER_ACTION_RENAME);
 	rename_def->new_name = *new_name;
-}
-
-static inline void
-enable_entity_def_init(struct enable_entity_def *enable_def,
-		       enum entity_type type, struct SrcList *parent_name,
-		       struct Token *name, bool is_enabled)
-{
-	alter_entity_def_init(&enable_def->base, parent_name, type,
-			      ALTER_ACTION_ENABLE);
-	enable_def->name = *name;
-	enable_def->is_enabled = is_enabled;
 }
 
 static inline void

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -110,6 +110,8 @@ enum parse_type {
 	PARSE_TYPE_ADD_PRIMARY_KEY,
 	/** ALTER TABLE RENAME statement. */
 	PARSE_TYPE_RENAME_TABLE,
+	/** ALTER TABLE RENAME statement. */
+	PARSE_TYPE_DROP_CONSTRAINT,
 };
 
 /**
@@ -285,6 +287,14 @@ struct sql_parse_trigger {
 	bool if_not_exists;
 };
 
+/**
+ * Description of the object to drop from ALTER TABLE DROP CONSTRAINT statement.
+ */
+struct sql_parse_drop {
+	/** Drop object name. */
+	struct Token name;
+};
+
 /** Constant tokens for integer values. */
 extern const struct Token sqlIntTokens[];
 
@@ -422,10 +432,6 @@ struct drop_trigger_def {
 	struct drop_entity_def base;
 };
 
-struct drop_constraint_def {
-	struct drop_entity_def base;
-};
-
 struct drop_index_def {
 	struct drop_entity_def base;
 };
@@ -477,15 +483,6 @@ drop_trigger_def_init(struct drop_trigger_def *drop_trigger_def,
 {
 	drop_entity_def_init(&drop_trigger_def->base, parent_name, name,
 			     if_exist, ENTITY_TYPE_TRIGGER);
-}
-
-static inline void
-drop_constraint_def_init(struct drop_constraint_def *drop_constraint_def,
-			 struct SrcList *parent_name, struct Token *name,
-			 bool if_exist)
-{
-	drop_entity_def_init(&drop_constraint_def->base, parent_name, name,
-			     if_exist, ENTITY_TYPE_CONSTRAINT);
 }
 
 static inline void
@@ -672,5 +669,10 @@ sql_parse_table_engine(struct Parse *parse, struct Token *engine_name);
 void
 sql_parse_table_rename(struct Parse *parse, struct SrcList *table_name,
 		       struct Token *new_name);
+
+/** Save parsed ALTER TABLE DROP CONSTRAINT statement. */
+void
+sql_parse_drop_constraint(struct Parse *parse, struct SrcList *table_name,
+			  struct Token *name);
 
 #endif /* TARANTOOL_BOX_SQL_PARSE_DEF_H_INCLUDED */

--- a/src/box/sql/prepare.c
+++ b/src/box/sql/prepare.c
@@ -204,6 +204,8 @@ sql_parser_destroy(Parse *parser)
 	assert(!parser->parse_only || parser->pVdbe == NULL);
 	if (parser->foreign_key_list.n != 0)
 		sql_xfree(parser->foreign_key_list.a);
+	if (parser->check_list.n != 0)
+		sql_xfree(parser->check_list.a);
 	if (parser->src_list != NULL)
 		sqlSrcListDelete(parser->src_list);
 	sql_xfree(parser->aLabel);

--- a/src/box/sql/prepare.c
+++ b/src/box/sql/prepare.c
@@ -202,6 +202,10 @@ sql_parser_destroy(Parse *parser)
 {
 	assert(parser != NULL);
 	assert(!parser->parse_only || parser->pVdbe == NULL);
+	if (parser->foreign_key_list.n != 0)
+		sql_xfree(parser->foreign_key_list.a);
+	if (parser->src_list != NULL)
+		sqlSrcListDelete(parser->src_list);
 	sql_xfree(parser->aLabel);
 	sql_expr_list_delete(parser->pConstExpr);
 	struct create_fk_constraint_parse_def *create_fk_constraint_parse_def =

--- a/src/box/sql/prepare.c
+++ b/src/box/sql/prepare.c
@@ -206,6 +206,8 @@ sql_parser_destroy(Parse *parser)
 		sql_xfree(parser->foreign_key_list.a);
 	if (parser->check_list.n != 0)
 		sql_xfree(parser->check_list.a);
+	if (parser->unique_list.n != 0)
+		sql_xfree(parser->unique_list.a);
 	if (parser->src_list != NULL)
 		sqlSrcListDelete(parser->src_list);
 	sql_xfree(parser->aLabel);

--- a/src/box/sql/prepare.c
+++ b/src/box/sql/prepare.c
@@ -208,6 +208,8 @@ sql_parser_destroy(Parse *parser)
 		sql_xfree(parser->check_list.a);
 	if (parser->unique_list.n != 0)
 		sql_xfree(parser->unique_list.a);
+	if (parser->autoinc_name != NULL)
+		sql_expr_delete(parser->autoinc_name);
 	if (parser->src_list != NULL)
 		sqlSrcListDelete(parser->src_list);
 	sql_xfree(parser->aLabel);

--- a/src/box/sql/resolve.c
+++ b/src/box/sql/resolve.c
@@ -1517,9 +1517,9 @@ sql_resolve_self_reference(struct Parse *parser, struct space_def *def,
 		return;
 	}
 
-	/* Fake SrcList for parser->create_table_def */
+	/* Fake SrcList for CREATE TABLE */
 	SrcList sSrc;
-	/* Name context for parser->create_table_def  */
+	/* Name context for CREATE TABLE */
 	NameContext sNC;
 
 	memset(&sNC, 0, sizeof(sNC));

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2059,6 +2059,8 @@ struct Parse {
 	struct sql_parse_check_list check_list;
 	/** Description of created UNIQUE constraints. */
 	struct sql_parse_unique_list unique_list;
+	/** Description of created PRIMARY KEY constraint. */
+	struct sql_parse_unique primary_key;
 	/** Source list for the statement. */
 	struct SrcList *src_list;
 	/*

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2031,7 +2031,6 @@ struct Parse {
 	 */
 	union {
 		struct create_trigger_def create_trigger_def;
-		struct create_view_def create_view_def;
 		struct rename_entity_def rename_entity_def;
 		struct drop_constraint_def drop_constraint_def;
 		struct drop_index_def drop_index_def;
@@ -2057,6 +2056,8 @@ struct Parse {
 	struct sql_parse_index create_index;
 	/** Description of created table. */
 	struct sql_parse_table create_table;
+	/** Description of created view. */
+	struct sql_parse_view create_view;
 	/** Name of the column with AUTOINCREMENT. */
 	struct Expr *autoinc_name;
 	/** Source list for the statement. */

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2062,6 +2062,8 @@ struct Parse {
 	struct sql_parse_unique primary_key;
 	/** Description of created index. */
 	struct sql_parse_index create_index;
+	/** Name of the column with AUTOINCREMENT. */
+	struct Expr *autoinc_name;
 	/** Source list for the statement. */
 	struct SrcList *src_list;
 	/*

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2052,7 +2052,6 @@ struct Parse {
 		struct drop_table_def drop_table_def;
 		struct drop_trigger_def drop_trigger_def;
 		struct drop_view_def drop_view_def;
-		struct enable_entity_def enable_entity_def;
 	};
 	/**
 	 * Table def or column def is not part of union since

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2030,7 +2030,6 @@ struct Parse {
 	 * from parse.y
 	 */
 	union {
-		struct drop_constraint_def drop_constraint_def;
 		struct drop_index_def drop_index_def;
 		struct drop_table_def drop_table_def;
 		struct drop_trigger_def drop_trigger_def;
@@ -2058,6 +2057,11 @@ struct Parse {
 	struct sql_parse_view create_view;
 	/** Description of created trigger. */
 	struct sql_parse_trigger create_trigger;
+	/**
+	 * Description of the object to drop from ALTER TABLE DROP CONSTRAINT
+	 * statement.
+	 */
+	struct sql_parse_drop drop_object;
 	/** Name of the column with AUTOINCREMENT. */
 	struct Expr *autoinc_name;
 	/** Source list for the statement. */

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2057,6 +2057,8 @@ struct Parse {
 	struct sql_parse_foreign_key_list foreign_key_list;
 	/** Description of created CHECK constraints. */
 	struct sql_parse_check_list check_list;
+	/** Description of created UNIQUE constraints. */
+	struct sql_parse_unique_list unique_list;
 	/** Source list for the statement. */
 	struct SrcList *src_list;
 	/*

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2057,8 +2057,8 @@ struct Parse {
 	/** Description of created trigger. */
 	struct sql_parse_trigger create_trigger;
 	/**
-	 * Description of the object to drop from ALTER TABLE DROP CONSTRAINT or
-	 * DROP INDEX statement.
+	 * Description of the object to drop from ALTER TABLE DROP CONSTRAINT,
+	 * DROP INDEX or DROP VIEW statement.
 	 */
 	struct sql_parse_drop drop_object;
 	/** Name of the column with AUTOINCREMENT. */

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2030,7 +2030,6 @@ struct Parse {
 	 * from parse.y
 	 */
 	union {
-		struct drop_index_def drop_index_def;
 		struct drop_table_def drop_table_def;
 		struct drop_trigger_def drop_trigger_def;
 		struct drop_view_def drop_view_def;
@@ -2058,8 +2057,8 @@ struct Parse {
 	/** Description of created trigger. */
 	struct sql_parse_trigger create_trigger;
 	/**
-	 * Description of the object to drop from ALTER TABLE DROP CONSTRAINT
-	 * statement.
+	 * Description of the object to drop from ALTER TABLE DROP CONSTRAINT or
+	 * DROP INDEX statement.
 	 */
 	struct sql_parse_drop drop_object;
 	/** Name of the column with AUTOINCREMENT. */

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2030,7 +2030,6 @@ struct Parse {
 	 * from parse.y
 	 */
 	union {
-		struct rename_entity_def rename_entity_def;
 		struct drop_constraint_def drop_constraint_def;
 		struct drop_index_def drop_index_def;
 		struct drop_table_def drop_table_def;
@@ -2065,6 +2064,8 @@ struct Parse {
 	struct SrcList *src_list;
 	/** Descriptions of the space used in column creation. */
 	struct space *space;
+	/** New name of the table. */
+	struct Token table_new_name;
 	/*
 	 * FK and CK constraints appeared in a <CREATE TABLE> or
 	 * an <ALTER TABLE ADD COLUMN> statement.

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -1512,17 +1512,6 @@ struct ExprList {
 };
 
 /*
- * An instance of this structure is used by the parser to record both
- * the parse tree for an expression and the span of input text for an
- * expression.
- */
-struct ExprSpan {
-	Expr *pExpr;		/* The expression parse tree */
-	const char *zStart;	/* First character of input text */
-	const char *zEnd;	/* One character past the end of input text */
-};
-
-/*
  * An instance of this structure can hold a simple list of identifiers,
  * such as the list "a,b,c" in the following statements:
  *
@@ -2041,7 +2030,6 @@ struct Parse {
 	 * from parse.y
 	 */
 	union {
-		struct create_ck_def create_ck_def;
 		struct create_index_def create_index_def;
 		struct create_trigger_def create_trigger_def;
 		struct create_view_def create_view_def;
@@ -2067,6 +2055,8 @@ struct Parse {
 	struct sql_parse_savepoint savepoint;
 	/** Description of created FOREIGN KEY constraints. */
 	struct sql_parse_foreign_key_list foreign_key_list;
+	/** Description of created CHECK constraints. */
+	struct sql_parse_check_list check_list;
 	/** Source list for the statement. */
 	struct SrcList *src_list;
 	/*
@@ -2734,7 +2724,7 @@ sqlAddPrimaryKey(struct Parse *parse);
  * @param is_field_ck True if this is a field constraint, false otherwise.
  */
 void
-sql_create_check_contraint(struct Parse *parser, bool is_field_ck);
+sql_create_check_contraint(struct Parse *parser, struct sql_parse_check *cdef);
 
 void sqlAddDefaultValue(Parse *, ExprSpan *);
 void sqlAddCollateType(Parse *, Token *);

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2042,7 +2042,6 @@ struct Parse {
 	 */
 	union {
 		struct create_ck_def create_ck_def;
-		struct create_fk_def create_fk_def;
 		struct create_index_def create_index_def;
 		struct create_trigger_def create_trigger_def;
 		struct create_view_def create_view_def;
@@ -2066,6 +2065,10 @@ struct Parse {
 	enum parse_type type;
 	/** Savepoint description for savepoint-related statements. */
 	struct sql_parse_savepoint savepoint;
+	/** Description of created FOREIGN KEY constraints. */
+	struct sql_parse_foreign_key_list foreign_key_list;
+	/** Source list for the statement. */
+	struct SrcList *src_list;
 	/*
 	 * FK and CK constraints appeared in a <CREATE TABLE> or
 	 * an <ALTER TABLE ADD COLUMN> statement.
@@ -3583,7 +3586,8 @@ int sqlJoinType(Parse *, Token *, Token *, Token *);
  * @param parse_context Parsing context.
  */
 void
-sql_create_foreign_key(struct Parse *parse_context);
+sql_create_foreign_key(struct Parse *parse_context,
+		       struct sql_parse_foreign_key *cdef);
 
 /**
  * Emit code to drop the entry from _index or _ck_contstraint or

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2030,7 +2030,6 @@ struct Parse {
 	 * from parse.y
 	 */
 	union {
-		struct create_index_def create_index_def;
 		struct create_trigger_def create_trigger_def;
 		struct create_view_def create_view_def;
 		struct rename_entity_def rename_entity_def;
@@ -2061,6 +2060,8 @@ struct Parse {
 	struct sql_parse_unique_list unique_list;
 	/** Description of created PRIMARY KEY constraint. */
 	struct sql_parse_unique primary_key;
+	/** Description of created index. */
+	struct sql_parse_index create_index;
 	/** Source list for the statement. */
 	struct SrcList *src_list;
 	/*
@@ -2928,7 +2929,9 @@ sqlIdListDelete(struct IdList *pList);
  * @param parse All information about this parse.
  */
 void
-sql_create_index(struct Parse *parse);
+sql_create_index(struct Parse *parse, struct Token *index_name,
+		 struct ExprList *col_list, enum sql_index_type idx_type,
+		 bool if_not_exist);
 
 /**
  * This routine will drop an existing named index.  This routine

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2030,9 +2030,7 @@ struct Parse {
 	 * from parse.y
 	 */
 	union {
-		struct drop_table_def drop_table_def;
 		struct drop_trigger_def drop_trigger_def;
-		struct drop_view_def drop_view_def;
 	};
 	/** Parsed statement type. */
 	enum parse_type type;
@@ -2058,7 +2056,7 @@ struct Parse {
 	struct sql_parse_trigger create_trigger;
 	/**
 	 * Description of the object to drop from ALTER TABLE DROP CONSTRAINT,
-	 * DROP INDEX or DROP VIEW statement.
+	 * DROP INDEX, DROP VIEW or DROP TABLE statement.
 	 */
 	struct sql_parse_drop drop_object;
 	/** Name of the column with AUTOINCREMENT. */

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2030,7 +2030,6 @@ struct Parse {
 	 * from parse.y
 	 */
 	union {
-		struct create_trigger_def create_trigger_def;
 		struct rename_entity_def rename_entity_def;
 		struct drop_constraint_def drop_constraint_def;
 		struct drop_index_def drop_index_def;
@@ -2058,6 +2057,8 @@ struct Parse {
 	struct sql_parse_table create_table;
 	/** Description of created view. */
 	struct sql_parse_view create_view;
+	/** Description of created trigger. */
+	struct sql_parse_trigger create_trigger;
 	/** Name of the column with AUTOINCREMENT. */
 	struct Expr *autoinc_name;
 	/** Source list for the statement. */

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2047,12 +2047,13 @@ struct Parse {
 	 * sqlEndTable() sql_create_column_end() function).
 	 */
 	struct create_table_def create_table_def;
-	struct create_column_def create_column_def;
 	/** Parsed statement type. */
 	enum parse_type type;
 	/** Savepoint description for savepoint-related statements. */
 	struct sql_parse_savepoint savepoint;
 	/** Description of created FOREIGN KEY constraints. */
+	struct sql_parse_column_list column_list;
+	/** Description of created columns. */
 	struct sql_parse_foreign_key_list foreign_key_list;
 	/** Description of created CHECK constraints. */
 	struct sql_parse_check_list check_list;
@@ -2066,6 +2067,8 @@ struct Parse {
 	struct Expr *autoinc_name;
 	/** Source list for the statement. */
 	struct SrcList *src_list;
+	/** Descriptions of the space used in column creation. */
+	struct space *space;
 	/*
 	 * FK and CK constraints appeared in a <CREATE TABLE> or
 	 * an <ALTER TABLE ADD COLUMN> statement.
@@ -2691,12 +2694,12 @@ struct space *
 sqlStartTable(Parse *, Token *);
 
 /**
- * Add new field to the format of ephemeral space in
- * create_column_def. If it is <ALTER TABLE> create shallow copy
- * of the existing space and add field to its format.
+ * Add new field to the format of ephemeral space. If it is <ALTER TABLE> create
+ * shallow copy of the existing space and add field to its format.
  */
 void
-sql_create_column_start(struct Parse *parse);
+sql_create_column_start(struct Parse *parse, struct Token *name,
+			enum field_type type);
 
 /**
  * Emit code to update entry in _space and code to create

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2062,6 +2062,10 @@ struct Parse {
 	 */
 	struct create_table_def create_table_def;
 	struct create_column_def create_column_def;
+	/** Parsed statement type. */
+	enum parse_type type;
+	/** Savepoint description for savepoint-related statements. */
+	struct sql_parse_savepoint savepoint;
 	/*
 	 * FK and CK constraints appeared in a <CREATE TABLE> or
 	 * an <ALTER TABLE ADD COLUMN> statement.

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2024,14 +2024,6 @@ struct Parse {
 	uint32_t autoname_i;
 	/** Space triggers are being coded for. */
 	struct space *triggered_space;
-	/**
-	 * One of parse_def structures which are used to
-	 * assemble and carry arguments of DDL routines
-	 * from parse.y
-	 */
-	union {
-		struct drop_trigger_def drop_trigger_def;
-	};
 	/** Parsed statement type. */
 	enum parse_type type;
 	/** Savepoint description for savepoint-related statements. */
@@ -2056,7 +2048,7 @@ struct Parse {
 	struct sql_parse_trigger create_trigger;
 	/**
 	 * Description of the object to drop from ALTER TABLE DROP CONSTRAINT,
-	 * DROP INDEX, DROP VIEW or DROP TABLE statement.
+	 * DROP INDEX, DROP VIEW, DROP TABLE or DROP TRIGGER statement.
 	 */
 	struct sql_parse_drop drop_object;
 	/** Name of the column with AUTOINCREMENT. */

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -634,6 +634,15 @@ sql_finish_parsing(struct Parse *parse)
 		if (parse->is_aborted)
 			return;
 		break;
+	case PARSE_TYPE_DROP_VIEW:
+		parse->initiateTTrans = true;
+		struct Token t = Token_nil;
+		drop_view_def_init(&parse->drop_view_def, parse->src_list, &t,
+				   parse->drop_object.if_exists);
+		sql_drop_table(parse);
+		if (parse->is_aborted)
+			return;
+		break;
 	default:
 		assert(parse->type == PARSE_TYPE_UNKNOWN);
 	}

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -482,6 +482,11 @@ static int
 sql_finish_table_properties(struct Parse *parse)
 {
 	assert(!parse->is_aborted);
+	if (parse->autoinc_name != NULL) {
+		if (sql_fieldno_by_name(parse, parse->autoinc_name,
+					&parse->autoinc_fieldno) != 0)
+			return -1;
+	}
 	if (parse->primary_key.cols != NULL) {
 		sqlAddPrimaryKey(parse);
 		if (parse->is_aborted)

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -616,6 +616,12 @@ sql_finish_parsing(struct Parse *parse)
 	case PARSE_TYPE_CREATE_INDEX:
 		sql_finish_create_index(parse);
 		break;
+	case PARSE_TYPE_RENAME_TABLE:
+		parse->initiateTTrans = true;
+		sql_alter_table_rename(parse);
+		if (parse->is_aborted)
+			return;
+		break;
 	default:
 		assert(parse->type == PARSE_TYPE_UNKNOWN);
 	}

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -641,6 +641,12 @@ sql_finish_parsing(struct Parse *parse)
 		if (parse->is_aborted)
 			return;
 		break;
+	case PARSE_TYPE_DROP_TRIGGER:
+		parse->initiateTTrans = true;
+		sql_drop_trigger(parse);
+		if (parse->is_aborted)
+			return;
+		break;
 	default:
 		assert(parse->type == PARSE_TYPE_UNKNOWN);
 	}

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -482,6 +482,11 @@ static int
 sql_finish_table_properties(struct Parse *parse)
 {
 	assert(!parse->is_aborted);
+	for (uint32_t i = 0; i < parse->check_list.n; ++i) {
+		sql_create_check_contraint(parse, &parse->check_list.a[i]);
+		if (parse->is_aborted)
+			return -1;
+	}
 	for (uint32_t i = 0; i < parse->foreign_key_list.n; ++i) {
 		sql_create_foreign_key(parse, &parse->foreign_key_list.a[i]);
 		if (parse->is_aborted)
@@ -528,6 +533,10 @@ sql_finish_parsing(struct Parse *parse)
 	case PARSE_TYPE_ADD_FOREIGN_KEY:
 		assert(parse->foreign_key_list.n == 1);
 		sql_create_foreign_key(parse, &parse->foreign_key_list.a[0]);
+		break;
+	case PARSE_TYPE_ADD_CHECK:
+		assert(parse->check_list.n == 1);
+		sql_create_check_contraint(parse, &parse->check_list.a[0]);
 		break;
 	default:
 		assert(parse->type == PARSE_TYPE_UNKNOWN);

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -622,6 +622,12 @@ sql_finish_parsing(struct Parse *parse)
 		if (parse->is_aborted)
 			return;
 		break;
+	case PARSE_TYPE_DROP_CONSTRAINT:
+		parse->initiateTTrans = true;
+		sql_drop_constraint(parse);
+		if (parse->is_aborted)
+			return;
+		break;
 	default:
 		assert(parse->type == PARSE_TYPE_UNKNOWN);
 	}

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -575,6 +575,12 @@ sql_finish_parsing(struct Parse *parse)
 			return;
 		sqlEndTable(parse);
 		break;
+	case PARSE_TYPE_CREATE_VIEW:
+		parse->initiateTTrans = true;
+		sql_create_view(parse);
+		if (parse->is_aborted)
+			return;
+		break;
 	case PARSE_TYPE_ADD_COLUMN:
 		if (sql_finish_table_properties(parse) != 0)
 			return;

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -628,6 +628,12 @@ sql_finish_parsing(struct Parse *parse)
 		if (parse->is_aborted)
 			return;
 		break;
+	case PARSE_TYPE_DROP_INDEX:
+		parse->initiateTTrans = true;
+		sql_drop_index(parse);
+		if (parse->is_aborted)
+			return;
+		break;
 	default:
 		assert(parse->type == PARSE_TYPE_UNKNOWN);
 	}

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -581,6 +581,16 @@ sql_finish_parsing(struct Parse *parse)
 		if (parse->is_aborted)
 			return;
 		break;
+	case PARSE_TYPE_CREATE_TRIGGER:
+		parse->initiateTTrans = true;
+		sql_trigger_begin(parse);
+		if (parse->is_aborted)
+			return;
+		sql_trigger_finish(parse, parse->create_trigger.step,
+				   &parse->create_trigger.all);
+		if (parse->is_aborted)
+			return;
+		break;
 	case PARSE_TYPE_ADD_COLUMN:
 		if (sql_finish_table_properties(parse) != 0)
 			return;

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -635,10 +635,8 @@ sql_finish_parsing(struct Parse *parse)
 			return;
 		break;
 	case PARSE_TYPE_DROP_VIEW:
+	case PARSE_TYPE_DROP_TABLE:
 		parse->initiateTTrans = true;
-		struct Token t = Token_nil;
-		drop_view_def_init(&parse->drop_view_def, parse->src_list, &t,
-				   parse->drop_object.if_exists);
 		sql_drop_table(parse);
 		if (parse->is_aborted)
 			return;

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -567,6 +567,10 @@ sql_finish_parsing(struct Parse *parse)
 		sqlSavepoint(parse, SAVEPOINT_ROLLBACK, &parse->savepoint.name);
 		break;
 	case PARSE_TYPE_CREATE_TABLE:
+		parse->space = sqlStartTable(parse, &parse->create_table.name,
+					     &parse->create_table.engine_name);
+		if (parse->is_aborted)
+			return;
 		if (sql_finish_table_properties(parse) != 0)
 			return;
 		sqlEndTable(parse);
@@ -624,7 +628,7 @@ sqlRunParser(Parse * pParse, const char *zSql)
 	i = 0;
 	/* sqlParserTrace(stdout, "parser: "); */
 	pEngine = sqlParserAlloc(new_xmalloc);
-	assert(pParse->create_table_def.new_space == NULL);
+	assert(pParse->space == NULL);
 	assert(pParse->parsed_ast.trigger == NULL);
 	assert(pParse->nVar == 0);
 	assert(pParse->pVList == 0);

--- a/src/box/sql/trigger.c
+++ b/src/box/sql/trigger.c
@@ -321,18 +321,13 @@ vdbe_code_drop_trigger(struct Parse *parser, const char *trigger_name,
 void
 sql_drop_trigger(struct Parse *parser)
 {
-	struct drop_entity_def *drop_def = &parser->drop_trigger_def.base;
-	struct alter_entity_def *alter_def = &drop_def->base;
-	assert(alter_def->entity_type == ENTITY_TYPE_TRIGGER);
-	assert(alter_def->alter_action == ALTER_ACTION_DROP);
-	struct SrcList *name = alter_def->entity_name;
-	bool no_err = drop_def->if_exist;
+	bool no_err = parser->drop_object.if_exists;
 
 	struct Vdbe *v = sqlGetVdbe(parser);
 	sqlVdbeCountChanges(v);
 
-	assert(name->nSrc == 1);
-	const char *trigger_name = name->a[0].zName;
+	assert(parser->src_list->nSrc == 1);
+	const char *trigger_name = parser->src_list->a[0].zName;
 	const char *error_msg =
 		tt_sprintf(tnt_errcode_desc(ER_NO_SUCH_TRIGGER),
 			   trigger_name);
@@ -343,7 +338,6 @@ sql_drop_trigger(struct Parse *parser)
 					  1, ER_NO_SUCH_TRIGGER, error_msg,
 					  no_err, OP_Found);
 	vdbe_code_drop_trigger(parser, trigger_name, true);
-	sqlSrcListDelete(name);
 }
 
 int

--- a/test/sql-luatest/gh_8100_parser_separation_test.lua
+++ b/test/sql-luatest/gh_8100_parser_separation_test.lua
@@ -187,3 +187,14 @@ g.test_drop_view_parsing = function()
         t.assert_equals(err.message, "Syntax error at line 1 near '1'")
     end)
 end
+
+--
+-- Make sure that the DROP TABLE statement is processed only after successful
+-- parsing.
+--
+g.test_drop_table_parsing = function()
+    g.server:exec(function()
+        local _, err = box.execute([[DROP TABLE t 1;]])
+        t.assert_equals(err.message, "Syntax error at line 1 near '1'")
+    end)
+end

--- a/test/sql-luatest/gh_8100_parser_separation_test.lua
+++ b/test/sql-luatest/gh_8100_parser_separation_test.lua
@@ -143,3 +143,14 @@ g.test_create_trigger_parsing = function()
         t.assert_equals(err.message, "Syntax error at line 2 near '1'")
     end)
 end
+
+--
+-- Make sure that the ALTER TABLE RENAME statement is processed only after
+-- successful parsing.
+--
+g.test_table_rename_parsing = function()
+    g.server:exec(function()
+        local _, err = box.execute([[ALTER TABLE t RENAME TO t1 1;]])
+        t.assert_equals(err.message, "Syntax error at line 1 near '1'")
+    end)
+end

--- a/test/sql-luatest/gh_8100_parser_separation_test.lua
+++ b/test/sql-luatest/gh_8100_parser_separation_test.lua
@@ -176,3 +176,14 @@ g.test_drop_index_parsing = function()
         t.assert_equals(err.message, "Syntax error at line 1 near '1'")
     end)
 end
+
+--
+-- Make sure that the DROP VIEW statement is processed only after successful
+-- parsing.
+--
+g.test_drop_view_parsing = function()
+    g.server:exec(function()
+        local _, err = box.execute([[DROP VIEW v 1;]])
+        t.assert_equals(err.message, "Syntax error at line 1 near '1'")
+    end)
+end

--- a/test/sql-luatest/gh_8100_parser_separation_test.lua
+++ b/test/sql-luatest/gh_8100_parser_separation_test.lua
@@ -34,3 +34,19 @@ g.test_foreign_key_parsing = function()
         box.execute([[DROP TABLE t;]])
     end)
 end
+
+--
+-- Make sure there is no segmentation fault or assertion in case CHECK is
+-- declared before the first column.
+--
+g.test_check_parsing = function()
+    g.server:exec(function()
+        local sql = [[CREATE TABLE t(CONSTRAINT c1 CHECK(i > 10),
+                                     i INT PRIMARY KEY);]]
+        local res = box.execute(sql)
+        t.assert_equals(res, {row_count = 1})
+        local func_id = box.space._func.index.name:get{'check_T_C1'}.id
+        t.assert_equals(box.space.T.constraint, {C1 = func_id})
+        box.execute([[DROP TABLE t;]])
+    end)
+end

--- a/test/sql-luatest/gh_8100_parser_separation_test.lua
+++ b/test/sql-luatest/gh_8100_parser_separation_test.lua
@@ -119,3 +119,15 @@ g.test_add_column_parsing = function()
         t.assert_equals(err.message, "Syntax error at line 1 near '1'")
     end)
 end
+
+--
+-- Make sure that the CREATE TABLE statement is processed only after successful
+-- parsing.
+--
+g.test_create_table_parsing = function()
+    g.server:exec(function()
+        local _, err = box.execute([[CREATE TABLE t(i INT PRIMARY KEY, a INT)
+                                     WITH ENGINE = 'a1234567890123456' 1;]])
+        t.assert_equals(err.message, "Syntax error at line 2 near '1'")
+    end)
+end

--- a/test/sql-luatest/gh_8100_parser_separation_test.lua
+++ b/test/sql-luatest/gh_8100_parser_separation_test.lua
@@ -81,3 +81,16 @@ g.test_primary_key_parsing = function()
         box.execute([[DROP TABLE t;]])
     end)
 end
+
+--
+-- Make sure that the CREATE INDEX statement is processed only after successful
+-- parsing.
+--
+g.test_create_index_parsing = function()
+    g.server:exec(function()
+        box.execute([[CREATE TABLE t(i INT PRIMARY KEY, a INT);]])
+        local _, err = box.execute([[CREATE INDEX i1 ON t1(a) 1;]])
+        t.assert_equals(err.message, "Syntax error at line 1 near '1'")
+        box.execute([[DROP TABLE t;]])
+    end)
+end

--- a/test/sql-luatest/gh_8100_parser_separation_test.lua
+++ b/test/sql-luatest/gh_8100_parser_separation_test.lua
@@ -64,3 +64,20 @@ g.test_unique_parsing = function()
         box.execute([[DROP TABLE t;]])
     end)
 end
+
+--
+-- Make sure that the creation of the PRIMARY KEY constraint is processed after
+-- the creation of the columns.
+--
+g.test_primary_key_parsing = function()
+    g.server:exec(function()
+        local sql = [[CREATE TABLE t(PRIMARY KEY(a, i), i INT, a INT);]]
+        t.assert_equals(box.execute(sql), {row_count = 1})
+        local id = box.space.T.id
+        t.assert_equals(box.space.T.index[0].name, 'pk_unnamed_T_1')
+        t.assert_equals(#box.space._index:get({id, 0}).parts, 2)
+        t.assert_equals(box.space._index:get({id, 0}).parts[1].field, 1)
+        t.assert_equals(box.space._index:get({id, 0}).parts[2].field, 0)
+        box.execute([[DROP TABLE t;]])
+    end)
+end

--- a/test/sql-luatest/gh_8100_parser_separation_test.lua
+++ b/test/sql-luatest/gh_8100_parser_separation_test.lua
@@ -131,3 +131,15 @@ g.test_create_table_parsing = function()
         t.assert_equals(err.message, "Syntax error at line 2 near '1'")
     end)
 end
+
+--
+-- Make sure that the CREATE TRIGGER statement is processed only after
+-- successful parsing.
+--
+g.test_create_trigger_parsing = function()
+    g.server:exec(function()
+        local _, err = box.execute([[CREATE TRIGGER tr BEFORE INSERT ON t
+                                     FOR EACH ROW BEGIN SELECT 1; END 1;]])
+        t.assert_equals(err.message, "Syntax error at line 2 near '1'")
+    end)
+end

--- a/test/sql-luatest/gh_8100_parser_separation_test.lua
+++ b/test/sql-luatest/gh_8100_parser_separation_test.lua
@@ -154,3 +154,14 @@ g.test_table_rename_parsing = function()
         t.assert_equals(err.message, "Syntax error at line 1 near '1'")
     end)
 end
+
+--
+-- Make sure that the ALTER TABLE DROP CONSTRAINT statement is processed only
+-- after successful parsing.
+--
+g.test_drop_constraint_parsing = function()
+    g.server:exec(function()
+        local _, err = box.execute([[ALTER TABLE t DROP CONSTRAINT t1 1;]])
+        t.assert_equals(err.message, "Syntax error at line 1 near '1'")
+    end)
+end

--- a/test/sql-luatest/gh_8100_parser_separation_test.lua
+++ b/test/sql-luatest/gh_8100_parser_separation_test.lua
@@ -50,3 +50,17 @@ g.test_check_parsing = function()
         box.execute([[DROP TABLE t;]])
     end)
 end
+
+--
+-- Make sure that the creation of the UNIQUE constraint is processed after the
+-- creation of the columns and the processing of the PRIMARY KEY.
+--
+g.test_unique_parsing = function()
+    g.server:exec(function()
+        local sql = [[CREATE TABLE t(UNIQUE(a), i INT PRIMARY KEY, a INT);]]
+        t.assert_equals(box.execute(sql), {row_count = 1})
+        t.assert_equals(box.space.T.index[0].name, 'pk_unnamed_T_1')
+        t.assert_equals(box.space.T.index[1].name, 'unique_unnamed_T_2')
+        box.execute([[DROP TABLE t;]])
+    end)
+end

--- a/test/sql-luatest/gh_8100_parser_separation_test.lua
+++ b/test/sql-luatest/gh_8100_parser_separation_test.lua
@@ -108,3 +108,14 @@ g.test_autoincrement_parsing = function()
         box.execute([[DROP TABLE t;]])
     end)
 end
+
+--
+-- Make sure that the ALTER TABLE ADD COLUMN statement is processed only after
+-- successful parsing.
+--
+g.test_add_column_parsing = function()
+    g.server:exec(function()
+        local _, err = box.execute([[ALTER TABLE t1 ADD COLUMN a INT 1;]])
+        t.assert_equals(err.message, "Syntax error at line 1 near '1'")
+    end)
+end

--- a/test/sql-luatest/gh_8100_parser_separation_test.lua
+++ b/test/sql-luatest/gh_8100_parser_separation_test.lua
@@ -94,3 +94,17 @@ g.test_create_index_parsing = function()
         box.execute([[DROP TABLE t;]])
     end)
 end
+
+--
+-- Make sure that AUTOINCREMENT clause is processed after the creation of the
+-- columns.
+--
+g.test_autoincrement_parsing = function()
+    g.server:exec(function()
+        local sql = [[CREATE TABLE t(PRIMARY KEY(i autoincrement), i INT);]]
+        t.assert_equals(box.execute(sql), {row_count = 1})
+        local res = box.execute([[insert into t values(NULL), (NULL), (NULL);]])
+        t.assert_equals(res, {autoincrement_ids = {1, 2, 3}, row_count = 3})
+        box.execute([[DROP TABLE t;]])
+    end)
+end

--- a/test/sql-luatest/gh_8100_parser_separation_test.lua
+++ b/test/sql-luatest/gh_8100_parser_separation_test.lua
@@ -1,0 +1,36 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+--
+-- Now VDBE for FOREIGN KEY creation is built after column creation, NULL and
+-- NOT NULL constraints, DEFAULT clause, COLLATE clause, PRIMARY KEY constraint,
+-- UNIQUE constraints, CHECK constraints. However, since we no longer have
+-- uniqueness for the constraint name, we can only check that the FOREIGN KEY is
+-- created after the columns are created, no matter where in the SQL query the
+-- FOREIGN KEY creation is.
+--
+-- Also, make sure there is no segmentation fault or assertion in case
+-- FOREIGN KEY is declared before the first column.
+--
+g.test_foreign_key_parsing = function()
+    g.server:exec(function()
+        local sql = [[CREATE TABLE t(CONSTRAINT f1 FOREIGN KEY(a) REFERENCES t,
+                                     i INT PRIMARY KEY, a INT);]]
+        local res = box.execute(sql)
+        t.assert_equals(res, {row_count = 1})
+        local fk_def = {F1 = {field = {[2] = 1}, space = box.space.T.id}}
+        t.assert_equals(box.space.T.foreign_key, fk_def)
+        box.execute([[DROP TABLE t;]])
+    end)
+end

--- a/test/sql-luatest/gh_8100_parser_separation_test.lua
+++ b/test/sql-luatest/gh_8100_parser_separation_test.lua
@@ -165,3 +165,14 @@ g.test_drop_constraint_parsing = function()
         t.assert_equals(err.message, "Syntax error at line 1 near '1'")
     end)
 end
+
+--
+-- Make sure that the DROP INDEX statement is processed only after successful
+-- parsing.
+--
+g.test_drop_index_parsing = function()
+    g.server:exec(function()
+        local _, err = box.execute([[DROP INDEX i1 on t1 1;]])
+        t.assert_equals(err.message, "Syntax error at line 1 near '1'")
+    end)
+end

--- a/test/sql-tap/autoinc.test.lua
+++ b/test/sql-tap/autoinc.test.lua
@@ -890,12 +890,14 @@ test:do_catchsql_test(
         1, "Syntax error at line 1 at or near position 87: table must feature at most one AUTOINCREMENT field"
     })
 
-test:do_catchsql_test(
+test:do_execsql_test(
     "autoinc-11.9",
     [[
         CREATE TABLE t11_9 (i INT, PRIMARY KEY(a AUTOINCREMENT), a INT);
+        INSERT INTO t11_9 VALUES (1, NULL), (2, NULL), (3, NULL);
+        SELECT * FROM t11_9;
     ]], {
-        1, "Can’t resolve field 'A'"
+        1, 1, 2, 2, 3, 3
     })
 
 test:do_catchsql_test(

--- a/test/sql-tap/gh2259-in-stmt-trans.test.lua
+++ b/test/sql-tap/gh2259-in-stmt-trans.test.lua
@@ -17,8 +17,9 @@ for _, prefix in pairs({"BEFORE", "AFTER"}) do
                      BEGIN INSERT INTO t2 VALUES (1,1); END')
 
     test:do_catchsql_test(prefix..'_insert1',
-                          'INSERT INTO t1 VALUES(1, 2)',
-                          {1, "Duplicate key exists in unique index \"pk_unnamed_T2_2\" in space \"T2\" with old tuple - [1, 1] and new tuple - [1, 1]"})
+        'INSERT INTO t1 VALUES(1, 2)',
+        {1, "Duplicate key exists in unique index \"pk_unnamed_T2_1\" in "..
+            "space \"T2\" with old tuple - [1, 1] and new tuple - [1, 1]"})
 
     test:do_execsql_test(prefix..'_insert1_check1',
                          'SELECT *  FROM t1',
@@ -33,8 +34,9 @@ for _, prefix in pairs({"BEFORE", "AFTER"}) do
                      BEGIN INSERT INTO t2 VALUES (1,1); END')
 
     test:do_catchsql_test(prefix..'_update1',
-                          'UPDATE t1 SET s1=1',
-                          {1, "Duplicate key exists in unique index \"pk_unnamed_T2_2\" in space \"T2\" with old tuple - [1, 1] and new tuple - [1, 1]"})
+        'UPDATE t1 SET s1=1',
+        {1, "Duplicate key exists in unique index \"pk_unnamed_T2_1\" in "..
+            "space \"T2\" with old tuple - [1, 1] and new tuple - [1, 1]"})
 
     test:do_execsql_test(prefix..'_update1_check1',
                          'SELECT *  FROM t1',
@@ -51,8 +53,9 @@ for _, prefix in pairs({"BEFORE", "AFTER"}) do
                              INSERT INTO t2 VALUES (2,2); END')
 
     test:do_catchsql_test(prefix..'delete1',
-                          'DELETE FROM t1;',
-                          {1, "Duplicate key exists in unique index \"pk_unnamed_T2_2\" in space \"T2\" with old tuple - [2, 2] and new tuple - [2, 2]"})
+        'DELETE FROM t1;',
+        {1, "Duplicate key exists in unique index \"pk_unnamed_T2_1\" in "..
+            "space \"T2\" with old tuple - [2, 2] and new tuple - [2, 2]"})
 
     -- Nothing should be inserted due to abort
     test:do_execsql_test('delete1_check1',
@@ -68,8 +71,9 @@ end
 
 -- Check multi-insert
 test:do_catchsql_test('insert2',
-                      'INSERT INTO t1 VALUES (5, 6), (6, 7)',
-                      {1, "Duplicate key exists in unique index \"pk_unnamed_T2_2\" in space \"T2\" with old tuple - [1, 1] and new tuple - [1, 1]"})
+    'INSERT INTO t1 VALUES (5, 6), (6, 7)',
+    {1, "Duplicate key exists in unique index \"pk_unnamed_T2_1\" in "..
+        "space \"T2\" with old tuple - [1, 1] and new tuple - [1, 1]"})
 test:do_execsql_test('insert2_check',
                      'SELECT * FROM t1;',
                      {3, 3})

--- a/test/sql-tap/index1.test.lua
+++ b/test/sql-tap/index1.test.lua
@@ -948,7 +948,7 @@ test:do_execsql_test(
         SELECT "_index"."name" FROM "_index" JOIN "_space" WHERE "_index"."id" = "_space"."id" AND "_space"."name"='T7';
     ]], {
         -- <index-17.1>
-        "pk_unnamed_T7_3","unique_unnamed_T7_1","unique_unnamed_T7_2"
+        "pk_unnamed_T7_1","unique_unnamed_T7_2","unique_unnamed_T7_3"
         -- </index-17.1>
     })
 

--- a/test/sql-tap/index7.test.lua
+++ b/test/sql-tap/index7.test.lua
@@ -381,7 +381,7 @@ test:do_catchsql_test(
                 "_index"."id" = "_space"."id" AND
                 "_space"."name"='TEST7';
         ]],
-        {0, {"unique_unnamed_TEST7_1",0}})
+        {0, {"pk_unnamed_TEST7_1",0}})
 
 
 -- This test is the same as previous, but with named UNIQUE
@@ -396,6 +396,6 @@ test:do_catchsql_test(
                 "_index"."id" = "_space"."id" AND
                 "_space"."name"='TEST8';
         ]],
-        {0, {"pk_unnamed_TEST8_2",0,"C1",1}})
+        {0, {"pk_unnamed_TEST8_1",0,"C1",1}})
 
 test:finish_test()

--- a/test/sql-tap/triggerC.test.lua
+++ b/test/sql-tap/triggerC.test.lua
@@ -238,7 +238,9 @@ test:do_catchsql_test(
         UPDATE OR ROLLBACK t1 SET a=100;
     ]], {
         -- <triggerC-1.15>
-        1, "Duplicate key exists in unique index \"unique_unnamed_T1_1\" in space \"T1\" with old tuple - [100, 2, 3, 4, 5] and new tuple - [100, 7, 8, 9, 10]"
+        1, "Duplicate key exists in unique index \"unique_unnamed_T1_2\" in "..
+           "space \"T1\" with old tuple - [100, 2, 3, 4, 5] and new "..
+           "tuple - [100, 7, 8, 9, 10]"
         -- </triggerC-1.15>
     })
 

--- a/test/sql-tap/update.test.lua
+++ b/test/sql-tap/update.test.lua
@@ -917,7 +917,9 @@ test:do_catchsql_test("update-10.3", [[
   SELECT a,b,c,d,e,f FROM t1;
 ]], {
   -- <update-10.3>
-  1, "Duplicate key exists in unique index \"unique_unnamed_T1_1\" in space \"T1\" with old tuple - [1, 2, 3, 4, 9, 6, 1] and new tuple - [1, 3, 4, 4, 10, 7, 2]"
+  1, "Duplicate key exists in unique index \"unique_unnamed_T1_2\" in "..
+     "space \"T1\" with old tuple - [1, 2, 3, 4, 9, 6, 1] and new "..
+     "tuple - [1, 3, 4, 4, 10, 7, 2]"
   -- </update-10.3>
 })
 
@@ -943,7 +945,9 @@ test:do_catchsql_test("update-10.6", [[
   SELECT a,b,c,d,e,f FROM t1;
 ]], {
   -- <update-10.6>
-  1, "Duplicate key exists in unique index \"unique_unnamed_T1_2\" in space \"T1\" with old tuple - [1, 2, 3, 4, 11, 6, 1] and new tuple - [2, 2, 4, 4, 12, 7, 2]"
+  1, "Duplicate key exists in unique index \"unique_unnamed_T1_3\" in "..
+     "space \"T1\" with old tuple - [1, 2, 3, 4, 11, 6, 1] and new "..
+     "tuple - [2, 2, 4, 4, 12, 7, 2]"
   -- </update-10.6>
 })
 
@@ -969,7 +973,9 @@ test:do_catchsql_test("update-10.9", [[
   SELECT a,b,c,d,e,f FROM t1;
 ]], {
   -- <update-10.9>
-  1, "Duplicate key exists in unique index \"unique_unnamed_T1_3\" in space \"T1\" with old tuple - [1, 2, 3, 4, 13, 6, 1] and new tuple - [2, 3, 3, 4, 14, 7, 2]"
+  1, "Duplicate key exists in unique index \"unique_unnamed_T1_4\" in "..
+     "space \"T1\" with old tuple - [1, 2, 3, 4, 13, 6, 1] and new "..
+     "tuple - [2, 3, 3, 4, 14, 7, 2]"
   -- </update-10.9>
 })
 

--- a/test/sql-tap/view.test.lua
+++ b/test/sql-tap/view.test.lua
@@ -925,7 +925,7 @@ test:do_catchsql_test(
         DROP VIEW main.nosuchview
     ]], {
         -- <view-17.2>
-        1, "Space 'MAIN' does not exist"
+        1, "Syntax error at line 1 near '.'"
         -- </view-17.2>
     })
 

--- a/test/sql/on-conflict.result
+++ b/test/sql/on-conflict.result
@@ -71,7 +71,8 @@ box.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, a INTEGER CHECK (a > 5) ON 
 box.execute("CREATE TABLE te17 (s1 INT NULL PRIMARY KEY NOT NULL);")
 ---
 - null
-- Primary index of space 'TE17' can not contain nullable parts
+- 'Failed to execute SQL statement: NULL declaration for column ''S1'' of table ''TE17''
+  has been already set to ''none'''
 ...
 box.execute("CREATE TABLE te17 (s1 INT NULL PRIMARY KEY);")
 ---


### PR DESCRIPTION
This patch-set reworks the parsing of transaction-related queries and DDL queries. These patches will help us separate the parser from the VDBE construction.