### PR TITLE
Proofread changelogs for 2.11.0-rc2

### DIFF
--- a/changelogs/unreleased/gh-7294-long-reconnection-fix.md
+++ b/changelogs/unreleased/gh-7294-long-reconnection-fix.md
@@ -1,4 +1,4 @@
 ## bugfix/replication
 
-* Fixed `box.info.replication[...].upstream` hang in "connecting" state for
-  minutes after replica's DNS entry changes (gh-7294).
+* Fixed a bug related to `box.info.replication[...].upstream` being stuck in the "connecting"
+  state for several minutes after a replica DNS record change (gh-7294).

--- a/changelogs/unreleased/gh-7974-force-recovery-without-user-spaces.md
+++ b/changelogs/unreleased/gh-7974-force-recovery-without-user-spaces.md
@@ -1,4 +1,4 @@
 ## bugfix/box
 
-* Fixed bug rendering force recovery feature inoperable when there were no user
-  spaces in snapshot (gh-7974).
+* Fixed a bug where `box.cfg.force_recovery` doesn't work when there are
+  no user spaces in a snapshot (gh-7974).

--- a/changelogs/unreleased/gh-8252-disable-jit-on-macOS-by-default.md
+++ b/changelogs/unreleased/gh-8252-disable-jit-on-macOS-by-default.md
@@ -1,6 +1,4 @@
 ## bugfix/luajit
 
-* To improve customer experience it was decided to disable JIT engine on
-  Tarantool startup for macOS builds. Either way, JIT will be aboard as a
-  result of the changes and more adventurous users will be able to enable
-  it via `jit.on` in their code (gh-8252).
+* The JIT engine was disabled by default on macOS platforms to improve
+  the user experience. If necessary, you can enable it with `jit.on` (gh-8252).

--- a/changelogs/unreleased/gh-8363-unable-decode-body.md
+++ b/changelogs/unreleased/gh-8363-unable-decode-body.md
@@ -1,3 +1,3 @@
 ## bugfix/lua/http client
 
-* Fixed a bug when body cannot be decoded in a response (gh-8363).
+* Fixed a bug where a response body cannot be decoded (gh-8363).

--- a/changelogs/unreleased/gh-8391-bump-zstd.md
+++ b/changelogs/unreleased/gh-8391-bump-zstd.md
@@ -1,3 +1,3 @@
 ## feature/build
 
-* Updated zstd to version pre-1.5.5 (gh-8391).
+*  The `zstd` version was updated to pre-1.5.5 (gh-8391).


### PR DESCRIPTION
Proofread changelogs for 2.11.0-rc2
Fix grammar, punctuation, and wording

NO_CHANGELOG=changelog
NO_DOC=changelog
NO_TEST=changelog