### PR TITLE
relay: send heartbeats on top of replication stream

### DIFF
--- a/changelogs/unreleased/gh-7515-syncing-follower-notices-leader-hang.md
+++ b/changelogs/unreleased/gh-7515-syncing-follower-notices-leader-hang.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed nodes syncing with a hung leader reporting it as alive and thus delaying
+  new elections (gh-7515).

--- a/test/replication-luatest/gh_7515_sync_node_sees_leader_hang_test.lua
+++ b/test/replication-luatest/gh_7515_sync_node_sees_leader_hang_test.lua
@@ -1,0 +1,98 @@
+local t = require('luatest')
+local replica_set = require('luatest.replica_set')
+local server = require('luatest.server')
+
+local fio = require('fio')
+
+local g = t.group('gh_7515_notice_leader_hang_during_sync')
+
+g.before_each(function(cg)
+    cg.replica_set = replica_set:new{}
+    local box_cfg = {
+        replication_timeout = 0.1,
+        replication = {
+            server.build_listen_uri('server1'),
+            server.build_listen_uri('server2'),
+            server.build_listen_uri('server3'),
+        },
+    }
+    for i = 1, 3 do
+        local alias = 'server' .. i
+        if i == 1 then
+            box_cfg.election_mode = 'candidate'
+        else
+            box_cfg.election_mode = 'voter'
+        end
+        cg[alias] = cg.replica_set:build_and_add_server{
+            alias = alias,
+            box_cfg = box_cfg,
+        }
+    end
+    cg.replica_set:start()
+    cg.unique_filename = server.build_listen_uri('unique_filename')
+    fio.unlink(cg.unique_filename)
+end)
+
+g.after_each(function(cg)
+    cg.replica_set:drop()
+    fio.unlink(cg.unique_filename)
+end)
+
+local function block(filename)
+    local fiber = require('fiber')
+    fiber.new(function(filename)
+        -- Can't use fio, because it yields.
+        local cmd = 'sleep 0.1 && ls ' .. filename .. ' > /dev/null 2>&1'
+        while os.execute(cmd) ~= 0 do end
+    end, filename)
+end
+
+g.test_notice_leader_hang_during_sync = function(cg)
+    t.tarantool.skip_if_not_debug()
+
+    cg.server1:wait_for_election_leader()
+
+    cg.server2:stop()
+    -- Generate some data so that server2 starts syncing with the leader after
+    -- restart. Generate transactions, to make sure heartbeats do not interfere
+    -- with transactions, and make relay sleep after each sent row to make sure
+    -- it takes server2 long enough to sync.
+    local old_term = cg.server1:exec(function()
+        box.schema.space.create('test')
+        box.space.test:create_index('pk')
+        for i = 1, 5 do
+            box.begin()
+            for j = 1, 5 do
+                box.space.test:replace{j, i}
+            end
+            box.commit()
+        end
+        box.error.injection.set('ERRINJ_RELAY_TIMEOUT',
+                                box.cfg.replication_timeout)
+        return box.info.election.term
+    end)
+    cg.server2.box_cfg.replication_sync_timeout = 0
+    table.remove(cg.server2.box_cfg.replication, 3)
+    cg.server2:start()
+    t.helpers.retrying({}, cg.server2.exec, cg.server2, function()
+        t.assert_equals(box.info.replication[1].upstream.status, 'sync',
+                        'Server is syncing with the leader')
+    end)
+
+    cg.server1:exec(block, {cg.unique_filename})
+
+    t.helpers.retrying({}, cg.server2.exec, cg.server2, function(term)
+        local timeout = box.cfg.replication_timeout
+        t.assert_le(box.info.replication[1].upstream.idle, timeout,
+                    'A hung leader sends data')
+        t.assert_ge(box.info.election.leader_idle, 4 * timeout,
+                    'A hung leader doesn\'t send heartbeats during sync')
+        t.assert_ge(box.info.election.term, term, 'Leader hang is noticed')
+    end, {old_term})
+
+    -- Unblock server1.
+    fio.open(cg.unique_filename, {'O_CREAT'}):close()
+    cg.server1:exec(function()
+        box.error.injection.set('ERRINJ_RELAY_TIMEOUT', 0)
+    end)
+end


### PR DESCRIPTION
There was a problem with the leader's relay continuing to ping the remote followers even when the leader's tx thread is hung. This tricked the followers into thinking the leader is alive and well, even though it couldn't serve any new requests.

The problem was partially fixed by commit 56571d83172f ("raft: make followers notice leader hang"): that commit made relay thread stop sending heartbeats in case tx thread is unresponsive.

Up to now we didn't differentiate between heartbeats and data rows: the receipt of both was considered a sign the master is alive. So if some replicas are not up to date with the master, they will continue thinking it's alive until they are fully synced and notice there are no more heartbeats from it.

In order to fix this, stop treating all data as heartbeats and start sending heartbeats on top of an active replication stream.

Add a feature bit for heartbeats in an active replication stream, so that replicas know how to treat the absence of heartbeats: either normal operation (for old versions) or tx thread hang (for new versions).

Closes #7515

@TarantoolBot document
Title: New iproto protocol feature: heartbeats_in_replication_stream

IPROTO_FEATURE_HEARTBEATS_IN_REPLICATION_STREAM = 5 is a feature bit set
when the master sends heartbeats not only in absence of other data to
send, but in between of data rows dispatch as well. This feature is used
by replicas to determine when to expect heartbeats from the master.

The version of the protocol (returned via the IPROTO_VERSION key) is now 5.

The user may set the corresponding feature -
`heartbeats_in_replication_stream` in the required_protocol_features
parameter of `net.box` `connect()` and `new()` methods.