### PR TITLE
sql: incomparable types in ORDER BY and GROUP BY

### DIFF
--- a/changelogs/unreleased/gh-6668-ordering-incomparable-types.md
+++ b/changelogs/unreleased/gh-6668-ordering-incomparable-types.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* ARRAY, MAP, and INTERVAL values can no longer be used as ORDER BY
+  arguments (gh-6668).

--- a/src/box/sql/resolve.c
+++ b/src/box/sql/resolve.c
@@ -981,6 +981,18 @@ sqlResolveOrderGroupBy(Parse * pParse,	/* Parsing context.  Leave error messages
 			resolveAlias(pEList, pItem->u.x.iOrderByCol - 1,
 				     pItem->pExpr, zType, 0);
 		}
+		/*
+		 * Currently, we cannot disallow ANY here, as values of ANY type
+		 * may be resolved later.
+		 */
+		enum field_type type = sql_expr_type(pItem->pExpr);
+		if (!field_type1_contains_type2(FIELD_TYPE_SCALAR, type) &&
+		    type != FIELD_TYPE_ANY) {
+			diag_set(ClientError, ER_SQL_TYPE_MISMATCH,
+				 field_type_strs[type], "comparable type");
+			pParse->is_aborted = true;
+			return -1;
+		}
 	}
 	return 0;
 }

--- a/test/sql-luatest/interval_test.lua
+++ b/test/sql-luatest/interval_test.lua
@@ -60,13 +60,14 @@ g.test_interval_3 = function()
     end)
 end
 
--- Make sure that INTERVAL cannot be used in GROUP BY.
+-- Make sure that INTERVAL cannot be used in GROUP BY and ORDER BY.
 g.test_interval_4 = function()
     g.server:exec(function()
         local sql = [[SELECT itv FROM t0 GROUP BY itv;]]
-        local res = "Type mismatch: can not convert interval(+1 years, "..
-                    "2 months, 3 days, 4 hours) to comparable type"
+        local res = "Type mismatch: can not convert interval to comparable type"
         local _, err = box.execute(sql)
+        t.assert_equals(err.message, res)
+        _, err = box.execute([[SELECT itv FROM t0 ORDER BY itv;]])
         t.assert_equals(err.message, res)
     end)
 end

--- a/test/sql-tap/uuid.test.lua
+++ b/test/sql-tap/uuid.test.lua
@@ -3,7 +3,7 @@ local build_path = os.getenv("BUILDDIR")
 package.cpath = build_path..'/test/sql-tap/?.so;'..build_path..'/test/sql-tap/?.dylib;'..package.cpath
 
 local test = require("sqltester")
-test:plan(147)
+test:plan(145)
 
 local uuid = require("uuid")
 local uuid1 = uuid.fromstr("11111111-1111-1111-1111-111111111111")
@@ -1227,24 +1227,6 @@ s:create_index('i15')
 s:insert({1, {['1'] = 1, ['2'] = 2, ['3']= 3}, {1,2,3}})
 s:insert({2, {['1'] = 1, ['2'] = 2}, {1,2,3,4}})
 s:insert({3, {['1'] = 1}, {1,2,3,4,5}})
-
--- Make sure that addition of UUID does not change behaviour of MAP and ARRAY.
--- Currently it works wrong, but there should not segmentation faults.
-test:do_execsql_test(
-    "uuid-15.1",
-    [[
-        SELECT i FROM t15 ORDER BY m;
-    ]], {
-        3,2,1
-    })
-
-test:do_execsql_test(
-    "uuid-15.2",
-    [[
-        SELECT i FROM t15 ORDER BY a;
-    ]], {
-        3,2,1
-    })
 
 -- Check function uuid().
 test:do_execsql_test(


### PR DESCRIPTION
This patch prohibits the use of ARRAY, MAP and INTERVAL in ORDER BY. In addition, GROUP BY now also checks the types of the arguments when building the VDBE.

Closes #6668

NO_DOC=bugfix