### PR TITLE
sql: support collation for ANY

### DIFF
--- a/changelogs/unreleased/gh-8070-collation-for-any.md
+++ b/changelogs/unreleased/gh-8070-collation-for-any.md
@@ -1,0 +1,3 @@
+## bugfix/sql
+
+* Now field type ANY supports collation in SQL (gh-8070).

--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -265,7 +265,7 @@ check_collate_arg(struct Parse *parse, struct Expr *expr)
 	while (left->op == TK_COLLATE)
 		left = left->pLeft;
 	enum field_type type = sql_expr_type(left);
-	if (type != FIELD_TYPE_STRING && type != FIELD_TYPE_SCALAR) {
+	if (!field_type1_contains_type2(type, FIELD_TYPE_STRING)) {
 		diag_set(ClientError, ER_SQL_PARSER_GENERIC,
 			 "COLLATE clause can't be used with non-string "
 			 "arguments");

--- a/test/sql-luatest/gh_8070_collation_for_any_test.lua
+++ b/test/sql-luatest/gh_8070_collation_for_any_test.lua
@@ -1,0 +1,24 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_collation_for_any = function()
+    g.server:exec(function()
+        local _, err = box.execute([[CREATE TABLE t(i INT PRIMARY KEY,
+                                                    a ANY COLLATE "unicode");]])
+        t.assert(err == nil)
+
+        _, err = box.execute([[SELECT CAST(1 AS ANY) COLLATE "unicode_ci"]]);
+        t.assert(err == nil)
+    end)
+end


### PR DESCRIPTION
This patch makes SQL to support collations for the ANY type.

Closes #8070

NO_DOC=ANY already supports collations in BOX.