### PR TITLE
space_upgrade: use old format for non-upgraded read view tuples - CE part

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -255,7 +255,7 @@ endif()
 if(ENABLE_SPACE_UPGRADE)
     list(APPEND box_sources ${SPACE_UPGRADE_SOURCES})
 else()
-    list(APPEND box_sources space_upgrade.c)
+    list(APPEND box_sources space_upgrade.c memtx_space_upgrade.c)
 endif()
 
 if(ENABLE_FLIGHT_RECORDER)

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -931,8 +931,6 @@ alter_space_do(struct txn_stmt *stmt, struct alter_space *alter)
 	 */
 	rlist_foreach_entry(op, &alter->ops, link)
 		op->alter_def(alter);
-	if (space_upgrade_check_alter(alter->old_space, alter->space_def) != 0)
-		diag_raise();
 	/*
 	 * Create a new (empty) space for the new definition.
 	 * Sic: the triggers are not moved over yet.
@@ -952,6 +950,8 @@ alter_space_do(struct txn_stmt *stmt, struct alter_space *alter)
 	alter->new_space->sequence_path = alter->old_space->sequence_path;
 	memcpy(alter->new_space->access, alter->old_space->access,
 	       sizeof(alter->old_space->access));
+
+	space_prepare_upgrade_xc(alter->old_space, alter->new_space);
 
 	/*
 	 * Build new indexes, check if tuples conform to

--- a/src/box/blackhole.c
+++ b/src/box/blackhole.c
@@ -126,6 +126,7 @@ static const struct space_vtab blackhole_space_vtab = {
 	/* .build_index = */ generic_space_build_index,
 	/* .swap_index = */ generic_space_swap_index,
 	/* .prepare_alter = */ generic_space_prepare_alter,
+	/* .prepare_upgrade = */ generic_space_prepare_upgrade,
 	/* .invalidate = */ generic_space_invalidate,
 };
 

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -1046,11 +1046,10 @@ exhausted_iterator_next(struct iterator *it, struct tuple **ret)
 
 int
 exhausted_index_read_view_iterator_next_raw(struct index_read_view_iterator *it,
-					    const char **data, uint32_t *size)
+					    struct read_view_tuple *result)
 {
 	(void)it;
-	*data = NULL;
-	*size = 0;
+	*result = read_view_tuple_none();
 	return 0;
 }
 

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -959,10 +959,8 @@ generic_index_create_iterator(struct index *base, enum iterator_type type,
 
 
 struct index_read_view *
-generic_index_create_read_view(struct index *index,
-			       const struct read_view_opts *opts)
+generic_index_create_read_view(struct index *index)
 {
-	(void)opts;
 	diag_set(UnsupportedIndexFeature, index->def, "consistent read view");
 	return NULL;
 }

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -647,6 +647,12 @@ struct index {
  * Auxiliary struct used for returning tuple data fetched from a read view.
  */
 struct read_view_tuple {
+	/**
+	 * If a read view was created while a space upgrade was running,
+	 * a tuple fetched from the read view may be either upgraded or not.
+	 * This flag is set if the tuple needs to be upgraded.
+	 */
+	bool needs_upgrade;
 	/** Pointer to tuple data. */
 	const char *data;
 	/** Size of tuple data. */
@@ -658,6 +664,7 @@ static inline struct read_view_tuple
 read_view_tuple_none(void)
 {
 	struct read_view_tuple tuple;
+	tuple.needs_upgrade = false;
 	tuple.data = NULL;
 	tuple.size = 0;
 	return tuple;

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -51,7 +51,6 @@ struct index_read_view_iterator;
 struct index_def;
 struct key_def;
 struct info_handler;
-struct read_view_opts;
 
 typedef struct tuple box_tuple_t;
 typedef struct key_def box_key_def_t;
@@ -594,8 +593,7 @@ struct index_vtab {
 					    uint32_t part_count,
 					    const char *pos);
 	/** Create an index read view. */
-	struct index_read_view *(*create_read_view)(
-		struct index *index, const struct read_view_opts *opts);
+	struct index_read_view *(*create_read_view)(struct index *index);
 	/** Introspection (index:stat()) */
 	void (*stat)(struct index *, struct info_handler *);
 	/**
@@ -947,9 +945,9 @@ index_create_iterator(struct index *index, enum iterator_type type,
 }
 
 static inline struct index_read_view *
-index_create_read_view(struct index *index, const struct read_view_opts *opts)
+index_create_read_view(struct index *index)
 {
-	return index->vtab->create_read_view(index, opts);
+	return index->vtab->create_read_view(index);
 }
 
 static inline void
@@ -1063,8 +1061,7 @@ int generic_index_replace(struct index *, struct tuple *, struct tuple *,
 			  enum dup_replace_mode,
 			  struct tuple **, struct tuple **);
 struct index_read_view *
-generic_index_create_read_view(struct index *index,
-			       const struct read_view_opts *opts);
+generic_index_create_read_view(struct index *index);
 void generic_index_stat(struct index *, struct info_handler *);
 void generic_index_compact(struct index *);
 void generic_index_reset_stat(struct index *);

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -645,6 +645,26 @@ struct index {
 	struct rlist full_scans;
 };
 
+/**
+ * Auxiliary struct used for returning tuple data fetched from a read view.
+ */
+struct read_view_tuple {
+	/** Pointer to tuple data. */
+	const char *data;
+	/** Size of tuple data. */
+	uint32_t size;
+};
+
+/** Object returned if there's no more tuples matching the search criteria. */
+static inline struct read_view_tuple
+read_view_tuple_none(void)
+{
+	struct read_view_tuple tuple;
+	tuple.data = NULL;
+	tuple.size = 0;
+	return tuple;
+}
+
 /** Index read view virtual function table. */
 struct index_read_view_vtab {
 	/** Free an index read view instance. */
@@ -653,7 +673,7 @@ struct index_read_view_vtab {
 	/**
 	 * Look up a tuple by a full key in a read view.
 	 *
-	 * The tuple data and size are returned in the data and size arguments.
+	 * The tuple data and size are returned in the result argument.
 	 * If the key isn't found, the data is set to NULL.
 	 *
 	 * Note, unless the read_view_opts::disable_decompression flag was set
@@ -665,7 +685,7 @@ struct index_read_view_vtab {
 	 */
 	int (*get_raw)(struct index_read_view *rv,
 		       const char *key, uint32_t part_count,
-		       const char **data, uint32_t *size);
+		       struct read_view_tuple *result);
 	/** Create an index read view iterator. */
 	int
 	(*create_iterator)(struct index_read_view *rv, enum iterator_type type,
@@ -699,7 +719,7 @@ struct index_read_view_iterator_base {
 	/**
 	 * Iterate to the next tuple in the read view.
 	 *
-	 * The tuple data and size are returned in the data and size arguments.
+	 * The tuple data and size are returned in the result argument.
 	 * On EOF the data is set to NULL.
 	 *
 	 * Note, unless the read_view_opts::disable_decompression flag was set
@@ -711,7 +731,7 @@ struct index_read_view_iterator_base {
 	 */
 	int
 	(*next_raw)(struct index_read_view_iterator *iterator,
-		    const char **data, uint32_t *size);
+		    struct read_view_tuple *result);
 };
 
 /** Size of the index_read_view_iterator struct. */
@@ -990,9 +1010,9 @@ index_read_view_delete(struct index_read_view *rv);
 static inline int
 index_read_view_get_raw(struct index_read_view *rv,
 			const char *key, uint32_t part_count,
-			const char **data, uint32_t *size)
+			struct read_view_tuple *result)
 {
-	return rv->vtab->get_raw(rv, key, part_count, data, size);
+	return rv->vtab->get_raw(rv, key, part_count, result);
 }
 
 static inline int
@@ -1012,9 +1032,9 @@ index_read_view_iterator_destroy(struct index_read_view_iterator *iterator)
 
 static inline int
 index_read_view_iterator_next_raw(struct index_read_view_iterator *iterator,
-				  const char **data, uint32_t *size)
+				  struct read_view_tuple *result)
 {
-	return iterator->base.next_raw(iterator, data, size);
+	return iterator->base.next_raw(iterator, result);
 }
 
 /*
@@ -1066,7 +1086,7 @@ int
 exhausted_iterator_next(struct iterator *it, struct tuple **ret);
 int
 exhausted_index_read_view_iterator_next_raw(struct index_read_view_iterator *it,
-					    const char **data, uint32_t *size);
+					    struct read_view_tuple *result);
 /** Unsupported feature error is returned. */
 int
 generic_iterator_position(struct iterator *it, const char **pos,

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -1697,8 +1697,8 @@ memtx_prepare_result_tuple(struct tuple **result)
 
 int
 memtx_prepare_read_view_tuple(struct tuple *tuple,
+			      struct index_read_view *index,
 			      struct memtx_tx_snapshot_cleaner *cleaner,
-			      bool disable_decompression,
 			      struct read_view_tuple *result)
 {
 	tuple = memtx_tx_snapshot_clarify(cleaner, tuple);
@@ -1707,7 +1707,7 @@ memtx_prepare_read_view_tuple(struct tuple *tuple,
 		return 0;
 	}
 	result->data = tuple_data_range(tuple, &result->size);
-	if (!disable_decompression) {
+	if (!index->space->rv->disable_decompression) {
 		result->data = memtx_tuple_decompress_raw(
 				result->data, result->data + result->size,
 				&result->size);

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -302,14 +302,15 @@ memtx_prepare_result_tuple(struct tuple **result);
  *     set to NULL.
  *
  *  2. Decompresses tuples if required, unless the disable_decompression flag
- *     is set. Decompressed tuple data is stored on the fiber region.
+ *     was set in the read view options. Decompressed tuple data is stored on
+ *     the fiber region.
  *
  * Returns 0 on success. On error returns -1 and sets diag.
  */
 int
 memtx_prepare_read_view_tuple(struct tuple *tuple,
+			      struct index_read_view *index,
 			      struct memtx_tx_snapshot_cleaner *cleaner,
-			      bool disable_decompression,
 			      struct read_view_tuple *result);
 
 /**

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -292,8 +292,8 @@ memtx_prepare_result_tuple(struct tuple **result);
  * Prepares a tuple retrieved from a consistent index read view to be returned
  * to the user.
  *
- * A pointer to the raw tuple data and its size are returned in the data and
- * size out argument.
+ * A pointer to the raw tuple data and its size are returned in the result
+ * argument.
  *
  * This function performs two tasks:
  *
@@ -310,7 +310,7 @@ int
 memtx_prepare_read_view_tuple(struct tuple *tuple,
 			      struct memtx_tx_snapshot_cleaner *cleaner,
 			      bool disable_decompression,
-			      const char **data, uint32_t *size);
+			      struct read_view_tuple *result);
 
 /**
  * Common function for all memtx indexes. Get tuple from memtx @a index

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -555,13 +555,12 @@ hash_read_view_free(struct index_read_view *base)
 static int
 hash_read_view_get_raw(struct index_read_view *rv,
 		       const char *key, uint32_t part_count,
-		       const char **data, uint32_t *size)
+		       struct read_view_tuple *result)
 {
 	(void)rv;
 	(void)key;
 	(void)part_count;
-	(void)data;
-	(void)size;
+	(void)result;
 	unreachable();
 	return 0;
 }
@@ -569,7 +568,7 @@ hash_read_view_get_raw(struct index_read_view *rv,
 /** Implementation of next_raw index_read_view_iterator callback. */
 static int
 hash_read_view_iterator_next_raw(struct index_read_view_iterator *iterator,
-				 const char **data, uint32_t *size)
+				 struct read_view_tuple *result)
 {
 	struct hash_read_view_iterator *it =
 		(struct hash_read_view_iterator *)iterator;
@@ -579,14 +578,14 @@ hash_read_view_iterator_next_raw(struct index_read_view_iterator *iterator,
 		struct tuple **res = light_index_view_iterator_get_and_next(
 			&rv->view, &it->iterator);
 		if (res == NULL) {
-			*data = NULL;
+			*result = read_view_tuple_none();
 			return 0;
 		}
 		if (memtx_prepare_read_view_tuple(*res, &rv->cleaner,
 						  rv->disable_decompression,
-						  data, size) != 0)
+						  result) != 0)
 			return -1;
-		if (*data != NULL)
+		if (result->data != NULL)
 			return 0;
 	}
 	return 0;

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -37,7 +37,6 @@
 #include "memtx_tx.h"
 #include "memtx_engine.h"
 #include "memtx_tuple_compression.h"
-#include "read_view.h"
 #include "space.h"
 #include "schema.h" /* space_by_id(), space_cache_find() */
 #include "errinj.h"
@@ -632,10 +631,8 @@ hash_read_view_create_iterator(struct index_read_view *base,
 
 /** Implementation of create_read_view index callback. */
 static struct index_read_view *
-memtx_hash_index_create_read_view(struct index *base,
-				  const struct read_view_opts *opts)
+memtx_hash_index_create_read_view(struct index *base)
 {
-	(void)opts;
 	static const struct index_read_view_vtab vtab = {
 		.free = hash_read_view_free,
 		.get_raw = hash_read_view_get_raw,

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -43,6 +43,7 @@
 #include "memtx_engine.h"
 #include "column_mask.h"
 #include "sequence.h"
+#include "memtx_space_upgrade.h"
 #include "memtx_tuple_compression.h"
 #include "schema.h"
 #include "result.h"
@@ -1392,6 +1393,7 @@ static const struct space_vtab memtx_space_vtab = {
 	/* .build_index = */ memtx_space_build_index,
 	/* .swap_index = */ generic_space_swap_index,
 	/* .prepare_alter = */ memtx_space_prepare_alter,
+	/* .prepare_upgrade = */ memtx_space_prepare_upgrade,
 	/* .invalidate = */ generic_space_invalidate,
 };
 

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -371,6 +371,8 @@ memtx_space_replace_tuple(struct space *space, struct txn_stmt *stmt,
 		tuple_ref(stmt->old_tuple);
 		tuple_unref(orig_old_tuple);
 	}
+	if (space->upgrade != NULL && new_tuple != NULL)
+		memtx_space_upgrade_track_tuple(space->upgrade, new_tuple);
 finish:
 	/*
 	 * Regardless of whether the function ended with success or

--- a/src/box/memtx_space_upgrade.c
+++ b/src/box/memtx_space_upgrade.c
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include "memtx_space_upgrade.h"
+
+#include <stddef.h>
+
+#include "diag.h"
+#include "errcode.h"
+#include "space.h"
+#include "space_def.h"
+
+#if defined(ENABLE_SPACE_UPGRADE)
+# error unimplemented
+#endif
+
+int
+memtx_space_prepare_upgrade(struct space *old_space, struct space *new_space)
+{
+	(void)old_space;
+	if (new_space->def->opts.upgrade_def != NULL) {
+		diag_set(ClientError, ER_UNSUPPORTED, "Community edition",
+			 "space upgrade");
+		return -1;
+	}
+	return 0;
+}

--- a/src/box/memtx_space_upgrade.h
+++ b/src/box/memtx_space_upgrade.h
@@ -11,15 +11,62 @@
 # include "memtx_space_upgrade_impl.h"
 #else /* !defined(ENABLE_SPACE_UPGRADE) */
 
+#include <stdbool.h>
+
+#include "trivia/util.h"
+
 #if defined(__cplusplus)
 extern "C" {
 #endif /* defined(__cplusplus) */
 
 struct space;
+struct space_upgrade;
+struct space_upgrade_read_view;
+struct tuple;
 
 /** Memtx implementation of space_vtab::prepare_upgrade. */
 int
 memtx_space_prepare_upgrade(struct space *old_space, struct space *new_space);
+
+/**
+ * Adds a tuple to the upgraded tuple set.
+ * The tuple must not be in the set.
+ */
+static inline void
+memtx_space_upgrade_track_tuple(struct space_upgrade *upgrade,
+				struct tuple *tuple)
+{
+	(void)upgrade;
+	(void)tuple;
+	unreachable();
+}
+
+/**
+ * Removes a tuple from the upgraded tuple set.
+ * Does nothing if the tuple isn't in the set.
+ */
+static inline void
+memtx_space_upgrade_untrack_tuple(struct space_upgrade *upgrade,
+				  struct tuple *tuple)
+{
+	(void)upgrade;
+	(void)tuple;
+	unreachable();
+}
+
+/**
+ * Returns true if a tuple fetched from a read view needs to be upgraded.
+ * See the comment to read_view_tuple::needs_upgrade.
+ */
+static inline bool
+memtx_read_view_tuple_needs_upgrade(struct space_upgrade_read_view *rv,
+				    struct tuple *tuple)
+{
+	(void)rv;
+	(void)tuple;
+	unreachable();
+	return false;
+}
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/box/memtx_space_upgrade.h
+++ b/src/box/memtx_space_upgrade.h
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include "trivia/config.h"
+
+#if defined(ENABLE_SPACE_UPGRADE)
+# include "memtx_space_upgrade_impl.h"
+#else /* !defined(ENABLE_SPACE_UPGRADE) */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+struct space;
+
+/** Memtx implementation of space_vtab::prepare_upgrade. */
+int
+memtx_space_prepare_upgrade(struct space *old_space, struct space *new_space);
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */
+
+#endif /* !defined(ENABLE_SPACE_UPGRADE) */

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -31,7 +31,6 @@
 #include "memtx_tree.h"
 #include "memtx_engine.h"
 #include "memtx_tuple_compression.h"
-#include "read_view.h"
 #include "space.h"
 #include "schema.h" /* space_by_id(), space_cache_find() */
 #include "errinj.h"
@@ -1993,10 +1992,8 @@ tree_read_view_create_iterator(struct index_read_view *base,
 /** Implementation of create_read_view index callback. */
 template <bool USE_HINT>
 static struct index_read_view *
-memtx_tree_index_create_read_view(struct index *base,
-				  const struct read_view_opts *opts)
+memtx_tree_index_create_read_view(struct index *base)
 {
-	(void)opts;
 	static const struct index_read_view_vtab vtab = {
 		.free = tree_read_view_free<USE_HINT>,
 		.get_raw = tree_read_view_get_raw<USE_HINT>,

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -1902,13 +1902,12 @@ template <bool USE_HINT>
 static int
 tree_read_view_get_raw(struct index_read_view *rv,
 		       const char *key, uint32_t part_count,
-		       const char **data, uint32_t *size)
+		       struct read_view_tuple *result)
 {
 	(void)rv;
 	(void)key;
 	(void)part_count;
-	(void)data;
-	(void)size;
+	(void)result;
 	unreachable();
 	return 0;
 }
@@ -1917,7 +1916,7 @@ tree_read_view_get_raw(struct index_read_view *rv,
 template <bool USE_HINT>
 static int
 tree_read_view_iterator_next_raw(struct index_read_view_iterator *iterator,
-				 const char **data, uint32_t *size)
+				 struct read_view_tuple *result)
 {
 	struct tree_read_view_iterator<USE_HINT> *it =
 		(struct tree_read_view_iterator<USE_HINT> *)iterator;
@@ -1930,7 +1929,7 @@ tree_read_view_iterator_next_raw(struct index_read_view_iterator *iterator,
 							  &it->tree_iterator);
 
 		if (res == NULL) {
-			*data = NULL;
+			*result = read_view_tuple_none();
 			return 0;
 		}
 
@@ -1938,9 +1937,9 @@ tree_read_view_iterator_next_raw(struct index_read_view_iterator *iterator,
 					      &it->tree_iterator);
 		if (memtx_prepare_read_view_tuple(res->tuple, &rv->cleaner,
 						  rv->disable_decompression,
-						  data, size) != 0)
+						  result) != 0)
 			return -1;
-		if (*data != NULL)
+		if (result->data != NULL)
 			return 0;
 	}
 }

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -2382,6 +2382,7 @@ memtx_tx_history_remove_stmt(struct txn_stmt *stmt)
 		memtx_tx_history_remove_added_story(stmt);
 	if (stmt->del_story != NULL)
 		memtx_tx_history_remove_deleted_story(stmt);
+	stmt->engine_savepoint = NULL;
 }
 
 /**

--- a/src/box/read_view.c
+++ b/src/box/read_view.c
@@ -131,7 +131,7 @@ space_read_view_new(struct space *space, const struct read_view_opts *opts)
 		if (index == NULL ||
 		    !opts->filter_index(space, index, opts->filter_arg))
 			continue;
-		space_rv->index_map[i] = index_create_read_view(index, opts);
+		space_rv->index_map[i] = index_create_read_view(index);
 		if (space_rv->index_map[i] == NULL)
 			goto fail;
 		space_rv->index_map[i]->space = space_rv;

--- a/src/box/read_view.c
+++ b/src/box/read_view.c
@@ -204,6 +204,7 @@ read_view_open(struct read_view *rv, const struct read_view_opts *opts)
 	assert(opts->name != NULL);
 	rv->name = xstrdup(opts->name);
 	rv->is_system = opts->is_system;
+	rv->disable_decompression = opts->disable_decompression;
 	rv->timestamp = ev_monotonic_now(loop());
 	vclock_copy(&rv->vclock, box_vclock);
 	rv->owner = NULL;

--- a/src/box/read_view.h
+++ b/src/box/read_view.h
@@ -95,6 +95,11 @@ struct read_view {
 	 * make a checkpoint). Initialized with read_view_opts::is_system.
 	 */
 	bool is_system;
+	/**
+	 * Set if tuples read from the read view don't need to be decompressed.
+	 * Initialized with read_view_opts::disable_decompression.
+	 */
+	bool disable_decompression;
 	/** Monotonic clock at the time when the read view was created. */
 	double timestamp;
 	/** Replicaset vclock at the time when the read view was created. */

--- a/src/box/sequence.c
+++ b/src/box/sequence.c
@@ -402,10 +402,9 @@ sequence_data_read_view_free(struct index_read_view *base)
 }
 
 struct index_read_view *
-sequence_data_read_view_create(struct index *index,
-			       const struct read_view_opts *opts)
+sequence_data_read_view_create(struct index *index)
 {
-	(void)opts;
+	(void)index;
 	static const struct index_read_view_vtab vtab = {
 		.free = sequence_data_read_view_free,
 		.get_raw = sequence_data_read_view_get_raw,

--- a/src/box/sequence.c
+++ b/src/box/sequence.c
@@ -324,7 +324,7 @@ static_assert(sizeof(struct sequence_data_iterator) <=
 /** Implementation of next_raw index_read_view_iterator callback. */
 static int
 sequence_data_iterator_next_raw(struct index_read_view_iterator *iterator,
-				const char **data, uint32_t *size)
+				struct read_view_tuple *result)
 {
 	struct sequence_data_iterator *iter =
 		(struct sequence_data_iterator *)iterator;
@@ -334,7 +334,7 @@ sequence_data_iterator_next_raw(struct index_read_view_iterator *iterator,
 	struct sequence_data *sd = light_sequence_view_iterator_get_and_next(
 		&rv->view, &iter->iter);
 	if (sd == NULL) {
-		*data = NULL;
+		*result = read_view_tuple_none();
 		return 0;
 	}
 
@@ -348,21 +348,20 @@ sequence_data_iterator_next_raw(struct index_read_view_iterator *iterator,
 		   mp_encode_uint(buf_end, sd->value) :
 		   mp_encode_int(buf_end, sd->value));
 	assert(buf_end <= buf + buf_size);
-	*data = buf;
-	*size = buf_end - buf;
+	result->data = buf;
+	result->size = buf_end - buf;
 	return 0;
 }
 
 static inline int
 sequence_data_read_view_get_raw(struct index_read_view *rv,
 				const char *key, uint32_t part_count,
-				const char **data, uint32_t *size)
+				struct read_view_tuple *result)
 {
 	(void)rv;
 	(void)key;
 	(void)part_count;
-	(void)data;
-	(void)size;
+	(void)result;
 	diag_set(ClientError, ER_UNSUPPORTED,
 		 "_sequence_data read view", "get()");
 	return -1;

--- a/src/box/sequence.h
+++ b/src/box/sequence.h
@@ -45,7 +45,6 @@ extern "C" {
 
 struct index;
 struct index_read_view;
-struct read_view_opts;
 
 /** Sequence metadata. */
 struct sequence_def {
@@ -166,8 +165,7 @@ access_check_sequence(struct sequence *seq);
  * _sequence_data space.
  */
 struct index_read_view *
-sequence_data_read_view_create(struct index *index,
-			       const struct read_view_opts *opts);
+sequence_data_read_view_create(struct index *index);
 
 /**
  * Get last element of given sequence.

--- a/src/box/session_settings.c
+++ b/src/box/session_settings.c
@@ -445,6 +445,7 @@ const struct space_vtab session_settings_space_vtab = {
 	/* .build_index = */ generic_space_build_index,
 	/* .swap_index = */ generic_space_swap_index,
 	/* .prepare_alter = */ generic_space_prepare_alter,
+	/* .prepare_upgrade = */ generic_space_prepare_upgrade,
 	/* .invalidate = */ generic_space_invalidate,
 };
 

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -300,16 +300,6 @@ space_create(struct space *space, struct engine *engine,
 	}
 	space_fill_index_map(space);
 
-	if (space->def->opts.upgrade_def != NULL) {
-		struct index *pk = space_index(space, 0);
-		assert(pk != NULL);
-		space->upgrade = space_upgrade_new(
-			space->def->opts.upgrade_def, space->def->name,
-			pk->def->key_def, format);
-		if (space->upgrade == NULL)
-			goto fail_free_indexes;
-	}
-
 	rlist_create(&space->space_cache_pin_list);
 	if (space_init_constraints(space) != 0)
 		goto fail_free_indexes;
@@ -351,8 +341,6 @@ fail_free_indexes:
 fail:
 	free(space->index_map);
 	free(space->check_unique_constraint_map);
-	if (space->upgrade != NULL)
-		space_upgrade_unref(space->upgrade);
 	if (space->def != NULL)
 		space_def_delete(space->def);
 	if (space->format != NULL) {
@@ -987,6 +975,18 @@ generic_space_prepare_alter(struct space *old_space, struct space *new_space)
 {
 	(void)old_space;
 	(void)new_space;
+	return 0;
+}
+
+int
+generic_space_prepare_upgrade(struct space *old_space, struct space *new_space)
+{
+	(void)old_space;
+	if (new_space->def->opts.upgrade_def != NULL) {
+		diag_set(ClientError, ER_UNSUPPORTED, new_space->engine->name,
+			 "space upgrade");
+		return -1;
+	}
 	return 0;
 }
 

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -144,6 +144,9 @@ struct space_vtab {
 	 */
 	int (*prepare_alter)(struct space *old_space,
 			     struct space *new_space);
+	/** Prepares a space for online upgrade on alter. */
+	int (*prepare_upgrade)(struct space *old_space,
+			       struct space *new_space);
 	/**
 	 * Called right after removing a space from the cache.
 	 * The engine should abort all transactions involving
@@ -521,6 +524,13 @@ space_prepare_alter(struct space *old_space, struct space *new_space)
 	return new_space->vtab->prepare_alter(old_space, new_space);
 }
 
+static inline int
+space_prepare_upgrade(struct space *old_space, struct space *new_space)
+{
+	assert(old_space->vtab == new_space->vtab);
+	return new_space->vtab->prepare_upgrade(old_space, new_space);
+}
+
 static inline void
 space_invalidate(struct space *space)
 {
@@ -627,6 +637,8 @@ int generic_space_check_format(struct space *, struct tuple_format *);
 int generic_space_build_index(struct space *, struct index *,
 			      struct tuple_format *, bool);
 int generic_space_prepare_alter(struct space *, struct space *);
+int generic_space_prepare_upgrade(struct space *old_space,
+				  struct space *new_space);
 void generic_space_invalidate(struct space *);
 
 #if defined(__cplusplus)
@@ -726,6 +738,13 @@ static inline void
 space_prepare_alter_xc(struct space *old_space, struct space *new_space)
 {
 	if (space_prepare_alter(old_space, new_space) != 0)
+		diag_raise();
+}
+
+static inline void
+space_prepare_upgrade_xc(struct space *old_space, struct space *new_space)
+{
+	if (space_prepare_upgrade(old_space, new_space) != 0)
 		diag_raise();
 }
 

--- a/src/box/space_upgrade.c
+++ b/src/box/space_upgrade.c
@@ -8,8 +8,7 @@
 #include <assert.h>
 #include <stddef.h>
 
-#include "diag.h"
-#include "error.h"
+#include "msgpuck.h"
 #include "space.h"
 #include "space_def.h"
 #include "trivia/config.h"
@@ -26,7 +25,7 @@ space_upgrade_def_decode(const char **data, struct region *region)
 	(void)region;
 	/**
 	 * Option decoder may only fail with IllegalParams error so we return
-	 * a non-NULL ptr here and abort later, in space_upgrade_check_alter.
+	 * a non-NULL ptr here and abort later, in space_prepare_upgrade.
 	 */
 	mp_next(data);
 	return &dummy_def;
@@ -44,21 +43,6 @@ space_upgrade_def_delete(struct space_upgrade_def *def)
 {
 	assert(def == NULL || def == &dummy_def);
 	(void)def;
-}
-
-int
-space_upgrade_check_alter(struct space *space, struct space_def *new_def)
-{
-	assert(space->upgrade == NULL);
-	assert(new_def->opts.upgrade_def == NULL ||
-	       new_def->opts.upgrade_def == &dummy_def);
-	(void)space;
-	if (new_def->opts.upgrade_def != NULL) {
-		diag_set(ClientError, ER_UNSUPPORTED,
-			 "Community edition", "space upgrade");
-		return -1;
-	}
-	return 0;
 }
 
 void

--- a/src/box/space_upgrade.h
+++ b/src/box/space_upgrade.h
@@ -19,15 +19,12 @@
 extern "C" {
 #endif /* defined(__cplusplus) */
 
-struct key_def;
 struct region;
 struct space;
-struct space_def;
 struct space_upgrade;
 struct space_upgrade_def;
 struct space_upgrade_read_view;
 struct tuple;
-struct tuple_format;
 
 /**
  * Decodes space upgrade definition from MsgPack data.
@@ -51,23 +48,6 @@ space_upgrade_def_dup(const struct space_upgrade_def *def);
  */
 void
 space_upgrade_def_delete(struct space_upgrade_def *def);
-
-/**
- * Creates a space upgrade state from a definition, space name, primary key
- * definition and the new space format. Returns NULL and sets diag on error.
- * The reference count of the new state is set to 1.
- */
-static inline struct space_upgrade *
-space_upgrade_new(const struct space_upgrade_def *def, const char *space_name,
-		  const struct key_def *pk_def, struct tuple_format *format)
-{
-	(void)def;
-	(void)space_name;
-	(void)pk_def;
-	(void)format;
-	unreachable();
-	return NULL;
-}
 
 /**
  * Increments the reference counter of a space upgrade state,
@@ -108,13 +88,6 @@ space_upgrade_apply(struct space_upgrade *upgrade, struct tuple *tuple)
 	unreachable();
 	return NULL;
 }
-
-/**
- * Checks if a space alter operation may proceed.
- * Returns -1 and sets diag if it may not.
- */
-int
-space_upgrade_check_alter(struct space *space, struct space_def *new_def);
 
 /**
  * Starts space upgrade in the background if required.

--- a/src/box/sysview.c
+++ b/src/box/sysview.c
@@ -514,6 +514,7 @@ static const struct space_vtab sysview_space_vtab = {
 	/* .build_index = */ generic_space_build_index,
 	/* .swap_index = */ generic_space_swap_index,
 	/* .prepare_alter = */ generic_space_prepare_alter,
+	/* .prepare_upgrade = */ generic_space_prepare_upgrade,
 	/* .invalidate = */ generic_space_invalidate,
 };
 

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -4634,6 +4634,7 @@ static const struct space_vtab vinyl_space_vtab = {
 	/* .build_index = */ vinyl_space_build_index,
 	/* .swap_index = */ vinyl_space_swap_index,
 	/* .prepare_alter = */ vinyl_space_prepare_alter,
+	/* .prepare_upgrade = */ generic_space_prepare_upgrade,
 	/* .invalidate = */ vinyl_space_invalidate,
 };
 

--- a/test/box-luatest/space_upgrade_test.lua
+++ b/test/box-luatest/space_upgrade_test.lua
@@ -7,7 +7,8 @@ g.before_all(function()
     g.server = server:new({alias = 'master'})
     g.server:start()
     g.server:exec(function()
-        box.schema.create_space('test')
+        box.schema.create_space('memtx')
+        box.schema.create_space('vinyl', {engine = 'vinyl'})
     end)
 end)
 
@@ -21,15 +22,27 @@ g.test_low_level_api = function()
         t.assert_error_msg_equals(
             "Community edition does not support space upgrade",
             box.space._space.update, box.space._space,
-            box.space.test.id, {{'=', 'flags.upgrade', {}}})
+            box.space.memtx.id, {{'=', 'flags.upgrade', {}}})
+        t.assert_error_msg_equals(
+            "vinyl does not support space upgrade",
+            box.space._space.update, box.space._space,
+            box.space.vinyl.id, {{'=', 'flags.upgrade', {}}})
+        t.assert_error_msg_equals(
+            "sysview does not support space upgrade",
+            box.space._space.update, box.space._space,
+            box.space._vspace.id, {{'=', 'flags.upgrade', {}}})
     end)
 end
 
 g.test_high_level_api = function()
     t.tarantool.skip_if_enterprise()
     g.server:exec(function()
-        t.assert_error_msg_equals(
-            "Community edition does not support space upgrade",
-            box.space.test.upgrade, box.space.test, {})
+        local errmsg = "Community edition does not support space upgrade"
+        t.assert_error_msg_equals(errmsg, box.space.memtx.upgrade,
+                                  box.space.memtx, {})
+        t.assert_error_msg_equals(errmsg, box.space.vinyl.upgrade,
+                                  box.space.vinyl, {})
+        t.assert_error_msg_equals(errmsg, box.space._vspace.upgrade,
+                                  box.space._vspace, {})
     end)
 end


### PR DESCRIPTION
If a read view is created while a space upgrade is in progress, the space upgrade function should be applied to all tuples retrieved from the space read view. A tuple passed to the space upgrade function should have proper field names: tuples that had been upgraded by the time when the read view was created should have new field names while tuples that hadn't been upgraded should have old field names. Currently, all tuples use new field names. This works fine as long as fields aren't renamed (e.g. a new field is appended), but if a field is renamed (e.g. a new field is inserted in the middle), the space upgrade function will see invalid field names and, as a result, may not work as expected.

This PR is intended to fix this issue.

Needed for https://github.com/tarantool/tarantool-ee/issues/236

EE part: https://github.com/tarantool/tarantool-ee/pull/407