### PR TITLE
Fix calling class method before it is initialized 

### DIFF
--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -1451,7 +1451,11 @@ RebuildIndex::~RebuildIndex()
  */
 class RebuildFuncIndex: public RebuildIndex
 {
-	struct index_def *
+	/*
+	 * This method is used before the class is built (is used to calculate
+	 * an argument for base class constructor), so it should be static.
+	 */
+	static struct index_def *
 	func_index_def_new(struct index_def *index_def, struct func *func)
 	{
 		struct index_def *new_index_def = index_def_dup_xc(index_def);

--- a/static-build/cmake/AddDependencyProjects.cmake
+++ b/static-build/cmake/AddDependencyProjects.cmake
@@ -118,6 +118,7 @@ ExternalProject_Add(icu
     PATCH_COMMAND patch -d <SOURCE_DIR> -p1 -i "${PATCHES_DIR}/icu-tarantool-security-45.patch"
     COMMAND       patch -d <SOURCE_DIR> -p1 -i "${PATCHES_DIR}/icu-tarantool-security-59.patch"
     COMMAND       patch -d <SOURCE_DIR> -p1 -i "${PATCHES_DIR}/icu-tarantool-security-61.patch"
+    COMMAND       patch -d <SOURCE_DIR> -p1 -i "${PATCHES_DIR}/icu-tarantool-security-96.patch"
 )
 set(TARANTOOL_DEPENDS icu ${TARANTOOL_DEPENDS})
 

--- a/static-build/patches/icu-tarantool-security-96.patch
+++ b/static-build/patches/icu-tarantool-security-96.patch
@@ -1,0 +1,26 @@
+diff --git a/source/i18n/dangical.cpp b/source/i18n/dangical.cpp
+index 234c44b..f5343d0 100644
+--- a/source/i18n/dangical.cpp
++++ b/source/i18n/dangical.cpp
+@@ -136,7 +136,7 @@ static void U_CALLCONV initDangiCalZoneAstroCalc(UErrorCode &status) {
+     ucln_i18n_registerCleanup(UCLN_I18N_DANGI_CALENDAR, calendar_dangi_cleanup);
+ }
+ 
+-const TimeZone* DangiCalendar::getDangiCalZoneAstroCalc(UErrorCode &status) const {
++const TimeZone* DangiCalendar::getDangiCalZoneAstroCalc(UErrorCode &status) {
+     umtx_initOnce(gDangiCalendarInitOnce, &initDangiCalZoneAstroCalc, status);
+     return gDangiCalendarZoneAstroCalc;
+ }
+diff --git a/source/i18n/dangical.h b/source/i18n/dangical.h
+index 128f3af..e240272 100644
+--- a/source/i18n/dangical.h
++++ b/source/i18n/dangical.h
+@@ -74,7 +74,7 @@ class DangiCalendar : public ChineseCalendar {
+ 
+  private:
+ 
+-  const TimeZone* getDangiCalZoneAstroCalc(UErrorCode &status) const;
++  static const TimeZone* getDangiCalZoneAstroCalc(UErrorCode &status);
+ 
+   // UObject stuff
+  public: 


### PR DESCRIPTION
There are two cases when class method is used to calculate an argument for base
class constructor when it is not built yet. Fortunately, they does not
use class fields - let's make them static to use them before class
initialization legitimately.

Closes tarantool/security#96