### PR TITLE
sql: properly check fieldno in sql.c

### DIFF
--- a/changelogs/unreleased/gh-8418-asserton-on-select-from-_space.md
+++ b/changelogs/unreleased/gh-8418-asserton-on-select-from-_space.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Fixed an assertion when selecting tuples with incomplete internal
+  format (gh-8418).

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -794,9 +794,11 @@ tarantoolsqlIdxKeyCompare(struct BtCursor *cursor,
 		}
 
 		if (fieldno != next_fieldno) {
-			struct tuple_field *field =
-				tuple_format_field(format, fieldno);
-			if (fieldno >= field_count ||
+			struct tuple_field *field = NULL;
+			if (fieldno < field_count)
+				field = tuple_format_field(format, fieldno);
+
+			if (field == NULL ||
 			    field->offset_slot == TUPLE_OFFSET_SLOT_NIL) {
 				/* Outdated field_map. */
 				uint32_t j = 0;

--- a/test/sql-luatest/gh_8418_select_lead_to_assertion_test.lua
+++ b/test/sql-luatest/gh_8418_select_lead_to_assertion_test.lua
@@ -1,0 +1,20 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_select_lead_to_assertion = function()
+    g.server:exec(function()
+        local res = box.execute([[SELECT * FROM "_space" WHERE "owner" = 1;]])
+        t.assert(res ~= nil)
+    end)
+end


### PR DESCRIPTION
Tuples that have been inserted into system spaces after the _space definition has been inserted into _space have the same format as the space into which they were inserted. However, previously inserted tuples have an incomplete tuple format with parts missing. One piece that is missing information is the JSON token, which is used to determine the number of fields.

The tarantoolsqlIdxKeyCompare() function contains the correct checks for the case when the number of fields from the format is equal to or less than the fieldno field, but uses tuple_format_field() before this check, resulting in an assertion.

This patch forces tarantoolsqlIdxKeyCompare() to call tuple_format_field() only after checking that fieldno is less than field_count.

Closes #8418

NO_DOC=Bugfix in debug.