### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-8069-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8069-luajit-fixes.md
@@ -1,0 +1,10 @@
+## bugfix/luajit
+
+Backported patches from vanilla LuaJIT trunk (gh-8069). In the scope of this
+activity, the following issues have been resolved:
+
+* Fixed successful `math.min/math.max` call with no args (gh-6163).
+* Fixed inconsistencies in `math.min/math.max` calls with NaN arg (gh-6163).
+* Fixed `pcall()` call without arguments on arm64.
+* Fixed assembling of IR_{AHUV}LOAD specialized to boolean for aarch64.
+* Fixed constant rematerialization on arm64.


### PR DESCRIPTION
* ARM64: Avoid side-effects of constant rematerialization.
* ARM64: Fix {AHUV}LOAD specialized to nil/false/true.
* ARM64: Fix pcall() error case.
* Fix math.min()/math.max() inconsistencies.
* test: add test case for math.modf

Closes #6163
Part of #8069
Follows up #7230

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump
