### PR TITLE
test: fix flaky box/gh-6293-implement-new-net-stat

### DIFF
--- a/test/box/gh-6293-implement-new-net-stat.result
+++ b/test/box/gh-6293-implement-new-net-stat.result
@@ -142,7 +142,14 @@ test_run:switch("default")
 server_addr = test_run:cmd("eval test 'return box.cfg.listen'")[1]
 ---
 ...
-conn = net_box.new(server_addr)
+-- To enable graceful shutdown a client sends an IPROTO_WATCH request.
+-- The server replies to the client with IPROTO_EVENT. Upon receiving
+-- the event, the client sends another IPROTO_WATCH request to ack it.
+-- The whole procedure is fully asynchronous, which means it may finish
+-- after we start processing user requests over the connection.
+-- To correctly account service requests, we disable this feature.
+-- https://github.com/tarantool/tarantool-qa/issues/269
+conn = net_box.new(server_addr, {_disable_graceful_shutdown = true})
 ---
 ...
 stream = conn:new_stream()


### PR DESCRIPTION
The test checks that the number of IPROTO requests handled by a test server is reported correctly in statistics. Since a net.box connection sends a few "service" requests (e.g. to fetch schema), the test excludes them from the total count. The problem is this doesn't always work with service requests sent to enable graceful shutdown.

To enable graceful shutdown a client sends an IPROTO_WATCH request. The server replies to the client with IPROTO_EVENT. Upon receiving the event, the client sends another IPROTO_WATCH request to ack it. The whole procedure is fully asynchronous, which means it may finish after we start processing user requests over the connection.

To correctly account service requests, let's disable this feature.

Closes tarantool/tarantool-qa#269