### PR TITLE
prbuf: add reader from file

### DIFF
--- a/src/lib/core/diag.h
+++ b/src/lib/core/diag.h
@@ -424,6 +424,14 @@ BuildCryptoError(const char *file, unsigned line, const char *format, ...);
 struct error *
 BuildRaftError(const char *file, unsigned line, const char *format, ...);
 
+/**
+ * Allocate and create new FileFormatError. In case of OOM return OutOfMemory.
+ * filetype - file format string
+ */
+struct error *
+BuildFileFormatError(const char *file, unsigned line, const char *filetype,
+		     const char *format, ...);
+
 struct index_def;
 
 struct error *

--- a/src/lib/core/exception.cc
+++ b/src/lib/core/exception.cc
@@ -293,6 +293,21 @@ RaftError::RaftError(const char *file, unsigned line, const char *format, ...)
 	va_end(ap);
 }
 
+const struct type_info type_FileFormatError =
+	make_type("FileFormatError", &type_Exception);
+
+FileFormatError::FileFormatError(const char *file, unsigned line,
+				 const char *fileformat,
+				 const char *format, ...)
+	: Exception(&type_FileFormatError, file, line)
+{
+	va_list ap;
+	va_start(ap, format);
+	error_vformat_msg(this, format, ap);
+	va_end(ap);
+	error_append_msg(this, ", file format=%s", fileformat);
+}
+
 #define BuildAlloc(type)				\
 	void *p = malloc(sizeof(type));			\
 	if (p == NULL)					\
@@ -424,6 +439,20 @@ BuildRaftError(const char *file, unsigned line, const char *format, ...)
 {
 	BuildAlloc(RaftError);
 	RaftError *e =  new (p) RaftError(file, line, "");
+	va_list ap;
+	va_start(ap, format);
+	error_vformat_msg(e, format, ap);
+	va_end(ap);
+	return e;
+}
+
+struct error *
+BuildFileFormatError(const char *file, unsigned line, const char *fileformat,
+		     const char *format, ...)
+{
+	BuildAlloc(FileFormatError);
+	FileFormatError *e = new(p) FileFormatError(file, line, fileformat,
+						    "");
 	va_list ap;
 	va_start(ap, format);
 	error_vformat_msg(e, format, ap);

--- a/src/lib/core/exception.h
+++ b/src/lib/core/exception.h
@@ -257,6 +257,13 @@ public:
 	virtual void raise() { throw this; }
 };
 
+class FileFormatError: public Exception {
+public:
+	FileFormatError(const char *file, unsigned line, const char *filetype,
+			const char *format, ...);
+	virtual void raise() { throw this; }
+};
+
 /**
  * Initialize the exception subsystem.
  */

--- a/src/lib/core/prbuf.c
+++ b/src/lib/core/prbuf.c
@@ -325,7 +325,8 @@ prbuf_prepare(struct prbuf *buf, size_t size)
 	struct prbuf_record *next_overwritten =
 		prbuf_skip_record(buf, head, alloc_size);
 	buf->header->begin = prbuf_record_offset(buf, next_overwritten);
-	buf->header->end = 0;
+	if (next_overwritten == head)
+		buf->header->end = 0;
 	return prbuf_prepare_record(head, size);
 }
 

--- a/src/lib/core/prbuf.h
+++ b/src/lib/core/prbuf.h
@@ -5,15 +5,15 @@
  * Copyright 2010-2022, Tarantool AUTHORS, please see AUTHORS file.
  */
 #include <stddef.h>
+#include <sys/types.h>
 
-/** Data entry of prbuf. Public analogue of struct prbuf_record. */
+#include "small/ibuf.h"
+
+/** Data entry of prbuf. */
 struct prbuf_entry {
-	/**
-	 * Size of data which is stored in a chunk; it doesn't account
-	 * memory overhead per entry.
-	 */
+	/** Size of the data pointed by ptr field. */
 	size_t size;
-	/** Pointer to stored user data. */
+	/** Pointer to the entry data. */
 	char *ptr;
 };
 
@@ -87,3 +87,79 @@ prbuf_iterator_create(struct prbuf *buf, struct prbuf_iterator *iter);
  */
 int
 prbuf_iterator_next(struct prbuf_iterator *iter, struct prbuf_entry *res);
+
+struct prbuf_reader {
+	/**
+	 * File with buffer data. It is not owned by the reader.
+	 */
+	int fd;
+	/**
+	 * File offset of next record to be read in case EOF is not reached
+	 * yet.
+	 */
+	off_t pos;
+	/**
+	 * File is read ahead into `buf `and here we store the position we
+	 * read up to last time. Equals to `pos` if we don't read anything yet
+	 * or reset previous readings.
+	 */
+	off_t read_pos;
+	/**
+	 * Number of buffer bytes to be processed. It is size of unread payload
+	 * bytes. It also includes size of unused area at the end of the buffer
+	 * if we not skip it yet.
+	 *
+	 * If it is 0 then we read all the data.
+	 */
+	size_t unread_size;
+	/**
+	 * File offset of the beginning of the data area.
+	 * Data area is the area after header till the end of the buffer.
+	 */
+	off_t data_begin;
+	/**
+	 * File offset of the end of the data area.
+	 */
+	off_t data_end;
+	/*
+	 * Buffer to store data read from file.
+	 */
+	struct ibuf buf;
+};
+
+/**
+ * Initialize buffer reader.
+ * fd - file descriptor to read buffer from. It is not owned by the reader.
+ * offset - starting offset of buffer in file.
+ *
+ * Return:
+ *   0 - success
+ *  -1 - failure (diag is set)
+ */
+int
+prbuf_reader_create(struct prbuf_reader *reader, int fd, off_t offset);
+
+/**
+ * Read the next record into entry argument. If there are no more records
+ * then returned record will be a terminator (EOF, ptr == NULL && size == 0).
+ *
+ * After EOF the function can be called again and will return EOF.
+ *
+ * After failure reader is invalid and can only be closed.
+ *
+ * Return:
+ *   0 - success
+ *  -1 - failure (diag is set)
+ */
+int
+prbuf_reader_next(struct prbuf_reader *reader,
+		  struct prbuf_entry *entry);
+
+/**
+ * Free reader resources. Should be called only once.
+ *
+ * If function is called on reader which is not successfully created then
+ * behaviour is undefined.
+ */
+void
+prbuf_reader_destroy(struct prbuf_reader *reader);

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -209,7 +209,7 @@ create_unit_test(PREFIX func_cache
                  LIBRARIES box unit
 )
 create_unit_test(PREFIX prbuf
-                 SOURCES prbuf.c
+                 SOURCES prbuf.c core_test_utils.c
                  LIBRARIES unit core
 )
 create_unit_test(PREFIX clock_lowres

--- a/test/unit/prbuf.c
+++ b/test/unit/prbuf.c
@@ -1,13 +1,31 @@
 #include <assert.h>
 #include <stdint.h>
 #include <string.h>
+#include <fcntl.h>
 
 #define UNIT_TAP_COMPATIBLE 1
 #include "unit.h"
 #include "core/prbuf.h"
 #include "trivia/util.h"
+#include "fiber.h"
+#include "memory.h"
 
-const size_t buffer_size_arr[] = { 128, 256, 512 };
+/**
+ * The below buffer size/payload size variants give next unused space at
+ * the end of buffer sizes:
+ *
+ * payload_sizes:   4, 16, 40
+ * --------------------------
+ * buffer_size=128: 0, 12, 24
+ * buffer_size=256: 0,  0, 20
+ * buffer_size=507: 3, 11,  7
+ *
+ * So we test next end of the buffer scenarios:
+ *  - no unused space
+ *  - not enough space to put end mark
+ *  - enough space to put end mark
+ */
+const size_t buffer_size_arr[] = { 128, 256, 507 };
 const size_t copy_number_arr[] = { 16, 32, 64 };
 const char payload_small[] = { 0xab, 0xdb, 0xee, 0xcc };
 const char payload_avg[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -20,7 +38,6 @@ enum test_buffer_status {
 	WRONG_PAYLOAD_SIZE,
 	WRONG_PAYLOAD_CONTENT,
 	RECOVERY_ERROR,
-	ALLOCATION_ERROR,
 	TEST_BUFFER_STATUS_COUNT
 };
 
@@ -31,7 +48,6 @@ const char *test_buffer_status_strs[TEST_BUFFER_STATUS_COUNT] = {
 	"failed due to wrong size of payload after recovery",
 	"failed due to wrong content of payload after recovery",
 	"failed to recover",
-	"failed to allocate memory"
 };
 
 static void
@@ -41,37 +57,128 @@ payload_large_init(void)
 		payload_large[i] = (char)i;
 }
 
+/** Just some offset to test reader with. */
+#define BUFFER_OFFSET 33
+
+static inline const char *
+diagmsg(void)
+{
+	return diag_last_error(diag_get())->errmsg;
+}
+
+static int
+save_buffer(void *buf, int size)
+{
+	int fd = open("prbuf.bin", O_CREAT | O_TRUNC | O_RDWR, 0644);
+	unlink("prbuf.bin");
+	if (fd == -1)
+		fail("open(prbuf.bin)", "== -1");
+
+	int rc = write(fd, payload_large, BUFFER_OFFSET);
+	if (rc != BUFFER_OFFSET)
+		fail("write(prbuf.bin)", "incomplete write");
+	rc = write(fd, buf, size);
+	if (rc != size)
+		fail("write(prbuf.bin)", "incomplete write");
+
+	return fd;
+}
+
+void
+fill_buffer(struct prbuf *buf, const char *payload, int payload_size,
+	    int count)
+{
+	for (int i = 0; i < count; i++) {
+		char *p = prbuf_prepare(buf, payload_size);
+		if (p == NULL)
+			fail("prbuf_prepare", "failure");
+		memcpy(p, payload, payload_size);
+		prbuf_commit(buf);
+	}
+}
+
+static void
+test_reader_create_failure(void *buf, size_t size, const char *errmsg)
+{
+	plan(2);
+	header();
+
+	int fd = save_buffer(buf, size);
+	struct prbuf_reader reader;
+	int rc = prbuf_reader_create(&reader, fd, BUFFER_OFFSET);
+	ok(rc == -1, "rc is %d", rc);
+	ok(strstr(diagmsg(), errmsg) != NULL,
+	   "diag message is '%s'", diagmsg());
+	close(fd);
+
+	footer();
+	check_plan();
+}
+
+static void
+test_reader_create_ok(void *buf, size_t size)
+{
+	int fd = save_buffer(buf, size);
+	struct prbuf_reader reader;
+	int rc = prbuf_reader_create(&reader, fd, BUFFER_OFFSET);
+	ok(rc == 0, "rc is %d", rc);
+	close(fd);
+	prbuf_reader_destroy(&reader);
+}
+
+static void
+test_reader_iterate_failure(void *buf, size_t size, const char *errmsg)
+{
+	plan(2);
+	header();
+
+	int fd = save_buffer(buf, size);
+	struct prbuf_reader reader;
+	struct prbuf_entry entry;
+	int rc = prbuf_reader_create(&reader, fd, BUFFER_OFFSET);
+	if (rc != 0)
+		fail("prbuf_reader_create", "failure");
+
+	while ((rc = prbuf_reader_next(&reader, &entry)) == 0 && entry.size != 0)
+		;
+
+	ok(rc == -1, "rc is %d", rc);
+	ok(strstr(diagmsg(), errmsg) != NULL,
+	   "diag message is '%s'", diagmsg());
+	close(fd);
+	prbuf_reader_destroy(&reader);
+
+	footer();
+	check_plan();
+}
+
 static int
 test_buffer(uint32_t buffer_size, const char *payload, uint32_t payload_size,
 	    size_t copy_number)
 {
 	int rc = OK;
 	char *mem = xmalloc(buffer_size);
-	assert(mem != NULL);
-
 	struct prbuf buf;
+	struct prbuf_reader reader;
+	int fd = -1;
+	bool created = false;
+
 	prbuf_create(&buf, mem, buffer_size);
+	fill_buffer(&buf, payload, payload_size, copy_number);
 
-	for (size_t i = 0; i < copy_number; ++i) {
-		char *p = prbuf_prepare(&buf, payload_size);
-		if (p == NULL) {
-			rc = ALLOCATION_ERROR;
-			goto finish;
-		}
-		memcpy(p, payload, payload_size);
-		prbuf_commit(&buf);
-	}
-
-	struct prbuf recovered_buf;
-	if (prbuf_open(&recovered_buf, mem) != 0) {
+	struct prbuf_entry entry;
+	fd = save_buffer(mem, buffer_size);
+	if (prbuf_reader_create(&reader, fd, BUFFER_OFFSET) < 0) {
+		diag_log();
 		rc = RECOVERY_ERROR;
 		goto finish;
 	}
+	created = true;
+	int res;
+	int count = 0;
+	while ((res = prbuf_reader_next(&reader, &entry)) == 0 &&
+	       entry.size != 0) {
 
-	struct prbuf_iterator iter;
-	struct prbuf_entry entry;
-	prbuf_iterator_create(&recovered_buf, &iter);
-	while (prbuf_iterator_next(&iter, &entry) == 0) {
 		if (entry.size != payload_size) {
 			rc = WRONG_PAYLOAD_SIZE;
 			goto finish;
@@ -80,18 +187,35 @@ test_buffer(uint32_t buffer_size, const char *payload, uint32_t payload_size,
 			rc = WRONG_PAYLOAD_CONTENT;
 			goto finish;
 		}
+		count++;
 	};
-	for (size_t i = 0; i < copy_number; ++i) {
-		char *p = prbuf_prepare(&recovered_buf, payload_size);
-		if (p == NULL) {
-			rc = ALLOCATION_ERROR;
-			goto finish;
-		}
-		memcpy(p, payload, payload_size);
-		prbuf_commit(&recovered_buf);
+	if (res < 0)
+		diag_log();
+
+	/*
+	 * 16 is size of the header. 4 is size of record overhead.
+	 */
+	int expected_capacity = MIN((buffer_size - 16) / (payload_size + 4),
+				    copy_number);
+	if (res < 0 || entry.size != 0 || entry.ptr != NULL ||
+	    count != expected_capacity) {
+		rc = RECOVERY_ERROR;
+		goto finish;
+	}
+
+	/* Check we continue to read EOF. */
+	if (prbuf_reader_next(&reader, &entry) != 0 ||
+	    entry.size != 0 || entry.ptr != NULL) {
+		rc = RECOVERY_ERROR;
+		goto finish;
 	}
 
 finish:
+	if (fd != -1) {
+		if (created)
+			prbuf_reader_destroy(&reader);
+		close(fd);
+	}
 	free(mem);
 	return rc;
 }
@@ -100,7 +224,6 @@ static void
 test_buffer_foreach_copy_number(uint32_t buffer_size,
 				const char *payload, uint32_t payload_size)
 {
-	header();
 	int rc = 0;
 	for (size_t i = 0; i < lengthof(copy_number_arr); ++i) {
 		rc = test_buffer(buffer_size, payload, payload_size,
@@ -108,7 +231,6 @@ test_buffer_foreach_copy_number(uint32_t buffer_size,
 		is(rc, 0, info_msg, buffer_size, payload_size,
 		   copy_number_arr[i], test_buffer_status_strs[rc]);
 	}
-	footer();
 }
 
 static void
@@ -125,95 +247,94 @@ test_buffer_foreach_payload(uint32_t buffer_size)
 static void
 test_buffer_foreach_size(void)
 {
+	plan(27);
+	header();
+
 	for (size_t i = 0; i < lengthof(buffer_size_arr); ++i)
 		test_buffer_foreach_payload(buffer_size_arr[i]);
-}
 
-static void
-test_buffer_bad_version(void)
-{
-	header();
-	size_t buffer_size = buffer_size_arr[0];
-	size_t copy_number = copy_number_arr[0];
-	size_t payload_size = lengthof(payload_small);
-	char mem[buffer_size];
-
-	struct prbuf buf;
-	prbuf_create(&buf, mem, buffer_size);
-
-	for (size_t i = 0; i < copy_number; ++i) {
-		char *p = prbuf_prepare(&buf, payload_size);
-		memcpy(p, payload_small, payload_size);
-		prbuf_commit(&buf);
-	}
-	uint32_t bad_version = 666;
-	memcpy(buf.header, &bad_version, sizeof(uint32_t));
-
-	struct prbuf recovered_buf;
-	int rc = prbuf_open(&recovered_buf, mem);
-	is(rc, -1, "Failed to open buffer with malformed version");
 	footer();
+	check_plan();
 }
 
 static void
 test_buffer_bad_header(void)
 {
+	plan(4);
 	header();
+
 	size_t buffer_size = buffer_size_arr[0];
 	size_t copy_number = copy_number_arr[0];
 	size_t payload_size = lengthof(payload_small);
 	char mem[buffer_size];
 
 	struct prbuf buf;
+
 	prbuf_create(&buf, mem, buffer_size);
+	fill_buffer(&buf, payload_small, payload_size, copy_number);
+	uint32_t bad_version = 666;
+	memcpy(buf.header, &bad_version, sizeof(uint32_t));
+	test_reader_create_failure(mem, buffer_size, "unknown format version");
 
-	for (size_t i = 0; i < copy_number; ++i) {
-		char *p = prbuf_prepare(&buf, payload_size);
-		memcpy(p, payload_small, payload_size);
-		prbuf_commit(&buf);
-	}
-
-	/* Change begin and end to wrong values. */
-	mem[15] = 0xDD;
+	prbuf_create(&buf, mem, buffer_size);
+	fill_buffer(&buf, payload_small, payload_size, copy_number);
+	/* Change begin to wrong value. */
 	mem[10] = 0xDD;
+	test_reader_create_failure(mem, buffer_size, "inconsistent header");
 
-	struct prbuf recovered_buf;
-	int rc = prbuf_open(&recovered_buf, mem);
-	is(rc, -1, "Failed to open buffer with malformed header");
+	prbuf_create(&buf, mem, buffer_size);
+	fill_buffer(&buf, payload_small, payload_size, copy_number);
+	/* Change end to wrong value. */
+	mem[15] = 0xDD;
+	test_reader_create_failure(mem, buffer_size, "inconsistent header");
+
+	prbuf_create(&buf, mem, buffer_size);
+	fill_buffer(&buf, payload_small, payload_size, copy_number);
+	/* Truncate buffer so that header is incomplete. */
+	test_reader_create_failure(mem, 10, "can't read buffer header");
+
 	footer();
+	check_plan();
 }
 
 static void
-test_buffer_corrupted_record(void)
+test_buffer_corrupted_record_metadata(void)
 {
 	header();
+	plan(2);
+
 	size_t buffer_size = buffer_size_arr[0];
 	size_t copy_number = copy_number_arr[0];
 	size_t payload_size = lengthof(payload_small);
 	char mem[buffer_size];
 
 	struct prbuf buf;
+
 	prbuf_create(&buf, mem, buffer_size);
-
-	for (size_t i = 0; i < copy_number; ++i) {
-		char *p = prbuf_prepare(&buf, payload_size);
-		memcpy(p, payload_small, payload_size);
-		prbuf_commit(&buf);
-	}
-
-	/* Corrupt first record. */
+	fill_buffer(&buf, payload_small, payload_size, copy_number);
+	/*
+	 * Corrupt the first record. First in sense it's position in memory
+	 * is before all others yet it is not first in the read order.
+	 */
 	mem[17] = 0xDD;
+	test_reader_iterate_failure(mem, buffer_size, "invalid record length");
 
-	struct prbuf recovered_buf;
-	int rc = prbuf_open(&recovered_buf, mem);
-	is(rc, -1, "Failed to open buffer with malformed record");
+	prbuf_create(&buf, mem, buffer_size);
+	fill_buffer(&buf, payload_small, payload_size, copy_number);
+	/* Corrupt same record. Zero size records are invalid. */
+	mem[16] = 0;
+	test_reader_iterate_failure(mem, buffer_size, "invalid record length");
+
 	footer();
+	check_plan();
 }
 
 static void
 test_buffer_too_large_entry(void)
 {
 	header();
+	plan(1);
+
 	size_t buffer_size = buffer_size_arr[0];
 	char mem[buffer_size];
 
@@ -221,111 +342,222 @@ test_buffer_too_large_entry(void)
 	prbuf_create(&buf, mem, buffer_size);
 
 	char *p = prbuf_prepare(&buf, buffer_size);
-	is(p, NULL, "Failed to allocate too large entry");
+	ok(p == NULL, "NULL is expected");
+
 	footer();
+	check_plan();
 }
 
 static void
 test_buffer_empty(void)
 {
+	plan(7);
 	header();
+
 	size_t buffer_size = buffer_size_arr[0];
 	char mem[buffer_size];
 
 	struct prbuf buf;
 	prbuf_create(&buf, mem, buffer_size);
 
-	struct prbuf_iterator iter;
+	struct prbuf_reader reader;
 	struct prbuf_entry entry;
-	prbuf_iterator_create(&buf, &iter);
-	int rc = prbuf_iterator_next(&iter, &entry);
-	is(rc, -1, "Buffer is empty");
-	rc = prbuf_open(&buf, mem);
-	is(rc, 0, "Opened empty buffer");
-	prbuf_iterator_create(&buf, &iter);
-	rc = prbuf_iterator_next(&iter, &entry);
-	is(rc, -1, "Buffer is empty");
+
+	int fd = save_buffer(mem, buffer_size);
+	int rc = prbuf_reader_create(&reader, fd, BUFFER_OFFSET);
+	ok(rc == 0, "create rc is %d", rc);
+
+	rc = prbuf_reader_next(&reader, &entry);
+	ok(rc == 0, "next rc is %d", rc);
+	ok(entry.size == 0, "entry size is %zd", entry.size);
+	ok(entry.ptr == NULL, "NULL is expected");
+
+	/* Check we continue to read EOF. */
+	rc = prbuf_reader_next(&reader, &entry);
+	ok(rc == 0, "next rc is %d", rc);
+	ok(entry.size == 0, "entry size is %zd", entry.size);
+	ok(entry.ptr == NULL, "NULL is expected");
+
+	close(fd);
+	prbuf_reader_destroy(&reader);
+
 	footer();
+	check_plan();
+}
+
+/**
+ * Count the number of records in the buffer when reading it.
+ */
+static int
+count_records(void *buf, size_t size)
+{
+	struct prbuf_reader reader;
+	struct prbuf_entry entry;
+
+	int fd = save_buffer(buf, size);
+	int rc = prbuf_reader_create(&reader, fd, BUFFER_OFFSET);
+	if (rc != 0) {
+		diag_log();
+		fail("prbuf_reader_create", "!= 0");
+	}
+	int entry_count = 0;
+	while ((rc = prbuf_reader_next(&reader, &entry)) == 0 && entry.size != 0)
+		entry_count++;
+	if (rc != 0) {
+		diag_log();
+		fail("prbuf_reader_next", "!= 0");
+	}
+	close(fd);
+	prbuf_reader_destroy(&reader);
+	return entry_count;
 }
 
 static void
 test_buffer_prepared(void)
 {
+	plan(2);
 	header();
+
 	size_t buffer_size = buffer_size_arr[0];
 	char mem[buffer_size];
 	size_t payload_size = lengthof(payload_small);
 
 	struct prbuf buf;
 	prbuf_create(&buf, mem, buffer_size);
+	fill_buffer(&buf, payload_small, payload_size, 32);
 
-	size_t copy_count = 32;
-	for (size_t i = 0; i < copy_count; ++i) {
-		char *p = prbuf_prepare(&buf, payload_size);
-		memcpy(p, payload_small, payload_size);
-		prbuf_commit(&buf);
-	}
-	/* Count the actual number of entries stored in the buffer. */
-	struct prbuf_iterator iter;
-	struct prbuf_entry entry;
-	prbuf_iterator_create(&buf, &iter);
-	size_t entry_count = 0;
-	while (prbuf_iterator_next(&iter, &entry) == 0)
-		entry_count++;
+	int entry_count = count_records(mem, buffer_size);
 	char *p = prbuf_prepare(&buf, payload_size);
-	isnt(p, NULL, "Prepare has not failed");
+	ok(p != NULL, "not NULL is expected");
+	int new_entry_count = count_records(mem, buffer_size);
 	/*
 	 * The number of entries after prepare should decrease since
 	 * it must overwrite some of the old records.
 	 */
-	prbuf_iterator_create(&buf, &iter);
-	size_t new_entry_count = 0;
-	while (prbuf_iterator_next(&iter, &entry) == 0)
-		new_entry_count++;
-	is(new_entry_count < entry_count, true, "Entry count has decreased")
+	ok(entry_count - new_entry_count == 1, "old is %d, new is %d",
+	   entry_count, new_entry_count);
+
 	footer();
+	check_plan();
 }
 
 static void
 test_buffer_prepared_large(void)
 {
+	plan(3);
 	header();
+
 	size_t buffer_size = buffer_size_arr[0];
 	char mem[buffer_size];
 	size_t payload_size = lengthof(payload_small);
 
 	struct prbuf buf;
 	prbuf_create(&buf, mem, buffer_size);
-
 	/* Fill more than a half of the buffer. */
-	size_t entry_count = 8;
-	for (size_t i = 0; i < entry_count; ++i) {
-		char *p = prbuf_prepare(&buf, payload_size);
-		memcpy(p, payload_small, payload_size);
-		prbuf_commit(&buf);
-	}
+	int entry_count = 8;
+	fill_buffer(&buf, payload_small, payload_size, entry_count);
+
 	/*
 	 * Prepare one single entry which is going to overwrite
 	 * all other records so in fact buffer should be empty until commit.
 	 */
 	char *p = prbuf_prepare(&buf, 90);
-	isnt(p, NULL, "Prepare has not failed");
-	struct prbuf_iterator iter;
-	struct prbuf_entry entry;
-	prbuf_iterator_create(&buf, &iter);
-	int rc = prbuf_iterator_next(&iter, &entry);
-	is(rc, -1, "Buffer is empty");
-	for (size_t i = 0; i < entry_count; ++i) {
-		p = prbuf_prepare(&buf, payload_size);
-		memcpy(p, payload_small, payload_size);
-		prbuf_commit(&buf);
-	}
-	prbuf_iterator_create(&buf, &iter);
-	size_t entry_count_after = 0;
-	while (prbuf_iterator_next(&iter, &entry) == 0)
-		entry_count_after++;
-	is(entry_count_after, entry_count, "Buffer is in correct state")
+	ok(p != NULL, "not NULL is expected");
+	int entry_count_before = count_records(mem, buffer_size);
+	ok(entry_count_before == 0, "entry count before is %d",
+	   entry_count_before);
+
+	fill_buffer(&buf, payload_small, payload_size, entry_count);
+	int entry_count_after = count_records(mem, buffer_size);
+	ok(entry_count_after == entry_count, "entry count after is %d",
+	   entry_count_after)
+
 	footer();
+	check_plan();
+}
+
+static void
+test_buffer_truncated(void)
+{
+	plan(3);
+	header();
+
+	size_t buffer_size = 128;
+	char mem[128];
+	size_t payload_size = lengthof(payload_avg);
+
+	struct prbuf buf;
+
+	prbuf_create(&buf, mem, buffer_size);
+	fill_buffer(&buf, payload_avg, payload_size, 4);
+	/* Truncate in the middle of length metadata of 2d record. */
+	test_reader_iterate_failure(mem, 38, "can't read enough data");
+
+	prbuf_create(&buf, mem, buffer_size);
+	fill_buffer(&buf, payload_avg, payload_size, 6);
+	/* Truncate in the middle of length metadata of record after wrap. */
+	test_reader_iterate_failure(mem, 17, "can't read enough data");
+
+	prbuf_create(&buf, mem, buffer_size);
+	fill_buffer(&buf, payload_avg, payload_size, 4);
+	/* Truncate in the middle of 3d record. */
+	test_reader_iterate_failure(mem, 66, "can't read enough data");
+
+	footer();
+	check_plan();
+}
+
+static void
+test_buffer_begin_border_values(void)
+{
+	plan(2);
+	header();
+
+	char mem[41];
+	size_t size = sizeof(mem);
+
+	struct prbuf buf;
+	prbuf_create(&buf, mem, size);
+	/*
+	 * Fill the buffer in such a way that the `header.begin` is as close
+	 * to the end of the buffer as possible.
+	 */
+	char c = '!';
+	fill_buffer(&buf, &c, 1, 9);
+	test_reader_create_ok(mem, size);
+
+	/* Increase begin offset by 1. */
+	mem[8] += 1;
+	test_reader_create_failure(mem, size, "inconsistent header");
+
+	footer();
+	check_plan();
+}
+
+static void
+test_buffer_end_border_values(void)
+{
+	plan(2);
+	header();
+
+	char mem[40];
+	size_t size = sizeof(mem);
+
+	struct prbuf buf;
+	prbuf_create(&buf, mem, size);
+	/*
+	 * Fill the buffer in such a way that the `header.end` is exactly
+	 * at the end of the buffer.
+	 */
+	fill_buffer(&buf, payload_small, 4, 3);
+	test_reader_create_ok(mem, size);
+
+	/* Increase end offset by 1. */
+	mem[12] += 1;
+	test_reader_create_failure(mem, size, "inconsistent header");
+
+	footer();
+	check_plan();
 }
 
 /**
@@ -337,6 +569,7 @@ test_buffer_prepared_large(void)
 static void
 test_max_record_size(void)
 {
+	plan(6);
 	header();
 
 	struct prbuf buf;
@@ -356,14 +589,14 @@ test_max_record_size(void)
 	prbuf_commit(&buf);
 
 	struct prbuf rbuf;
-	struct prbuf_iterator iter;
+	struct prbuf_iterator reader;
 	struct prbuf_entry entry;
 
 	if (prbuf_open(&rbuf, mem) != 0)
 		fail("prbuf_open", "not 0");
-	prbuf_iterator_create(&rbuf, &iter);
+	prbuf_iterator_create(&rbuf, &reader);
 
-	int rc = prbuf_iterator_next(&iter, &entry);
+	int rc = prbuf_iterator_next(&reader, &entry);
 	ok(rc == 0, "rc is %d", rc);
 	ok(entry.size == (size_t)max_size,
 	   "expected %d got %zd", max_size, entry.size);
@@ -372,34 +605,41 @@ test_max_record_size(void)
 	ok(memcmp(entry.ptr, payload, max_size) == 0,
 	   "0 is expected");
 
-	rc = prbuf_iterator_next(&iter, &entry);
+	rc = prbuf_iterator_next(&reader, &entry);
 	ok(rc == -1, "rc is %d", rc);
 
 	p = prbuf_prepare(&buf, max_size + 1);
 	ok(p == NULL, "NULL is expected");
 
 	footer();
+	check_plan();
+
 }
 
-/**
- * There are three possible configurations of test:
- * 1. The size of buffer;
- * 2. The size of payload;
- * 3. The number of saves to the buffer.
- */
 int
 main(void)
 {
-	plan(45);
+	plan(11);
+
+	memory_init();
+	fiber_init(fiber_c_invoke);
 	payload_large_init();
+
 	test_buffer_foreach_size();
-	test_buffer_bad_version();
 	test_buffer_bad_header();
-	test_buffer_corrupted_record();
+	test_buffer_corrupted_record_metadata();
 	test_buffer_too_large_entry();
 	test_buffer_empty();
 	test_buffer_prepared();
 	test_buffer_prepared_large();
 	test_max_record_size();
+	test_buffer_truncated();
+	test_buffer_begin_border_values();
+	test_buffer_end_border_values();
+
+	fiber_free();
+	memory_free();
+
+	footer();
 	return check_plan();
 }

--- a/test/unit/prbuf.c
+++ b/test/unit/prbuf.c
@@ -613,13 +613,37 @@ test_max_record_size(void)
 
 	footer();
 	check_plan();
+}
 
+static void
+test_buffer_wrap_on_prepare(void)
+{
+	plan(1);
+	header();
+
+	size_t payload_size = lengthof(payload_avg);
+	char mem[128];
+	size_t size = sizeof(mem);
+
+	struct prbuf buf;
+	prbuf_create(&buf, mem, size);
+	fill_buffer(&buf, payload_avg, payload_size, 5);
+	/* Preparing will wrap and allocate place at the beginning. */
+	char *p = prbuf_prepare(&buf, payload_size);
+	if (p == NULL)
+		fail("prbuf_prepare", "failure");
+
+	int num = count_records(mem, size);
+	ok(num == 4, "num is %d", num);
+
+	footer();
+	check_plan();
 }
 
 int
 main(void)
 {
-	plan(11);
+	plan(12);
 
 	memory_init();
 	fiber_init(fiber_c_invoke);
@@ -636,6 +660,7 @@ main(void)
 	test_buffer_truncated();
 	test_buffer_begin_border_values();
 	test_buffer_end_border_values();
+	test_buffer_wrap_on_prepare();
 
 	fiber_free();
 	memory_free();


### PR DESCRIPTION
New prbuf reader API is intended to be used in flight recorder reader API implementation.

Currently prbuf has API to read records memory buffer. It is used for testing purposes only. 
We aim to drop this reader eventually. This patch in particular switch prbuf unit test to use new reader API.

Also fix a minor bug in prbuf on writing.

Part of https://github.com/tarantool/tarantool-ee/issues/319