### PR TITLE
net.box: fix crash when remote space field has unknown type

### DIFF
--- a/changelogs/unreleased/gh-4632-net-box-unknown-field-type.md
+++ b/changelogs/unreleased/gh-4632-net-box-unknown-field-type.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a net.box client crash when a remote space has a field type that isn't
+  supported by the client version (gh-4632).

--- a/src/box/lua/misc.cc
+++ b/src/box/lua/misc.cc
@@ -381,21 +381,9 @@ lbox_tuple_format_new(struct lua_State *L)
 	}
 	for (uint32_t i = 0; i < count; ++i) {
 		size_t len;
-
 		fields[i] = field_def_default;
-
 		lua_pushinteger(L, i + 1);
 		lua_gettable(L, 1);
-
-		lua_pushstring(L, "type");
-		lua_gettable(L, -2);
-		if (! lua_isnil(L, -1)) {
-			const char *type_name = lua_tolstring(L, -1, &len);
-			fields[i].type = field_type_by_name(type_name, len);
-			assert(fields[i].type != field_type_MAX);
-		}
-		lua_pop(L, 1);
-
 		lua_pushstring(L, "name");
 		lua_gettable(L, -2);
 		assert(! lua_isnil(L, -1));

--- a/test/box-luatest/gh_4632_net_box_unknown_field_type_test.lua
+++ b/test/box-luatest/gh_4632_net_box_unknown_field_type_test.lua
@@ -1,0 +1,53 @@
+local net = require('net.box')
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+    cg.server:exec(function()
+        box.schema.create_space('test')
+        box.space.test:create_index('primary')
+        box.space.test:insert({1, 10})
+        box.iproto.override(box.iproto.type.SELECT, function(header, body)
+            if body.space_id ~= box.space._vspace.id then
+                return false
+            end
+            local data = {}
+            for _, tuple in box.space._vspace:pairs() do
+                tuple = tuple:totable()
+                if tuple[1] == box.space.test.id then
+                    tuple[7] = {
+                        {name = 'a', type = 'unsigned'},
+                        {name = 'b', type = 'foobar', is_fake = true},
+                    }
+                end
+                table.insert(data, tuple)
+            end
+            box.iproto.send(box.session.id(), {
+                request_type = box.iproto.type.OK,
+                sync = header.sync,
+                schema_version = header.schema_version,
+            }, {data = data})
+            return true
+        end)
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_net_box_unknown_field_type = function()
+    local conn = net.connect(g.server.net_box_uri)
+    t.assert_equals(conn.space.test:format(), {
+        {name = 'a', type = 'unsigned'},
+        {name = 'b', type = 'foobar', is_fake = true},
+    })
+    local tuple = conn.space.test:get(1)
+    t.assert_is_not(tuple, nil)
+    t.assert_equals(tuple:tomap(), {1, 10, a = 1, b = 10})
+    conn:close()
+end


### PR DESCRIPTION
This commit fixes the following assertion failure that happens on a client in case a remote schema contains an unknown field type:

```
src/box/lua/misc.cc:395: int lbox_tuple_format_new(lua_State*): Assertion `fields[i].type != field_type_MAX' failed.
```

To fix the bug we remove the code that tries to set field types from `box.internal.new_tuple_format`. Actually, the format is used solely for providing field names so types are ignored anyway.

Closes #4632