### PR TITLE
box: fix wrong validation of region_alloc() result

### DIFF
--- a/src/box/lua/misc.cc
+++ b/src/box/lua/misc.cc
@@ -373,12 +373,10 @@ lbox_tuple_format_new(struct lua_State *L)
 	size_t size;
 	struct region *region = &fiber()->gc;
 	size_t region_svp = region_used(region);
-	struct field_def *fields = region_alloc_array(region, typeof(fields[0]),
-						      count, &size);
-	if (fields == NULL) {
-		diag_set(OutOfMemory, size, "region_alloc_array", "fields");
-		return luaT_error(L);
-	}
+	struct field_def *fields =
+		(struct field_def *)xregion_alloc_array(region,
+							struct field_def, count,
+							&size);
 	for (uint32_t i = 0; i < count; ++i) {
 		size_t len;
 
@@ -400,13 +398,7 @@ lbox_tuple_format_new(struct lua_State *L)
 		lua_gettable(L, -2);
 		assert(! lua_isnil(L, -1));
 		const char *name = lua_tolstring(L, -1, &len);
-		fields[i].name = (char *)region_alloc(region, len + 1);
-		if (fields == NULL) {
-			diag_set(OutOfMemory, size, "region_alloc",
-				 "fields[i].name");
-			region_truncate(region, region_svp);
-			return luaT_error(L);
-		}
+		fields[i].name = (char *)xregion_alloc(region, len + 1);
 		memcpy(fields[i].name, name, len);
 		fields[i].name[len] = '\0';
 		lua_pop(L, 1);


### PR DESCRIPTION
Prior to this patch, the return value of region_alloc() in lbox_tuple_format_new() was not checked. This patch fixes this by replacing region_alloc() with xregion_alloc().

Closes tarantool/security#116

NO_DOC=bugfix
NO_TEST=hard to reproduce the bug