### PR TITLE
 sql: fix wrong int to dec conversion

### DIFF
--- a/changelogs/unreleased/gh-8460-wrong-int-to-dec-convertion-in-arithmetic.md
+++ b/changelogs/unreleased/gh-8460-wrong-int-to-dec-convertion-in-arithmetic.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Fixed incorrect conversion of an integer greater than INT64_MAX or
+  less than 0 to decimal during SQL arithmetic operations (gh-8460).

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -1855,11 +1855,11 @@ mem_get_dec(const struct Mem *mem, decimal_t *d)
 		return 0;
 	}
 	if (mem->type == MEM_TYPE_INT) {
-		decimal_from_int64(d, mem->u.r);
+		decimal_from_int64(d, mem->u.i);
 		return 0;
 	}
 	if (mem->type == MEM_TYPE_UINT) {
-		decimal_from_int64(d, mem->u.u);
+		decimal_from_uint64(d, mem->u.u);
 		return 0;
 	}
 	if (mem->type == MEM_TYPE_DEC) {

--- a/test/sql-luatest/gh_8460_wrong_int_to_dec_test.lua
+++ b/test/sql-luatest/gh_8460_wrong_int_to_dec_test.lua
@@ -1,0 +1,28 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_wrong_big_uint_to_dec_convertion = function()
+    g.server:exec(function()
+        local ret = box.execute([[SELECT 1.0 + 18446744073709551615;]])
+        local res = require('decimal').new('18446744073709551616')
+        t.assert_equals(ret.rows[1][1], res)
+    end)
+end
+
+g.test_wrong_neg_int_to_dec_convertion = function()
+    g.server:exec(function()
+        local ret = box.execute([[SELECT 1.0 + -1;]])
+        t.assert_equals(ret.rows[1][1], require('decimal').new(0))
+    end)
+end


### PR DESCRIPTION
This patch fixes incorrect conversion of an integer greater than INT64_MAX or less than 0 to decimal during SQL arithmetic operations.

Closes https://github.com/tarantool/tarantool/issues/8460