### PR TITLE
box: fix big number encoding by msgpackffi

### DIFF
--- a/changelogs/unreleased/gh-6119-fix-number-mp-encode.md
+++ b/changelogs/unreleased/gh-6119-fix-number-mp-encode.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed a bug when big numbers were incorrectly encoded by msgpackffi,
+  that could lead to wrong select results with big number keys (gh-6119).

--- a/src/lua/msgpackffi.lua
+++ b/src/lua/msgpackffi.lua
@@ -262,7 +262,7 @@ local function encode_r(buf, obj, level)
 ::restart::
     if type(obj) == "number" then
         -- Lua-way to check that number is an integer
-        if obj % 1 == 0 and obj > -1e63 and obj < 1e64 then
+        if obj % 1 == 0 and obj >= -2^63 and obj < 2^64 then
             encode_int(buf, obj)
         else
             encode_double(buf, obj)

--- a/test/app-luatest/gh_6119_number_mp_encode_test.lua
+++ b/test/app-luatest/gh_6119_number_mp_encode_test.lua
@@ -1,0 +1,64 @@
+local t = require('luatest')
+
+local g = t.group('gh-6119-msgpack-numbers',
+                  t.helpers.matrix{msgpack = {require('msgpack'),
+                                              require('msgpackffi')}})
+
+-- Check that integral numbers are encoded as compact integers.
+g.test_number_msgpack_compact_encode = function(cg)
+    local msgpack = cg.params.msgpack
+    -- one-byte pack
+    for _, num in pairs{0, 1, -1, 127, -32} do
+        t.assert_equals(msgpack.decode(msgpack.encode(num)), num);
+        t.assert_equals(msgpack.encode(num):len(), 1, num)
+    end
+    -- several bytes pack
+    for _, s in pairs{8, 16, 32} do
+        -- positive
+        local num = 2 ^ s - 1
+        t.assert_equals(msgpack.decode(msgpack.encode(num)), num);
+        t.assert_equals(msgpack.encode(num):len(), s/8 + 1, num)
+        local num = 2 ^ s
+        t.assert_equals(msgpack.decode(msgpack.encode(num)), num);
+        t.assert_equals(msgpack.encode(num):len(), s/4 + 1, num)
+        -- negative
+        local num = -(2 ^ (s - 1))
+        t.assert_equals(msgpack.decode(msgpack.encode(num)), num);
+        t.assert_equals(msgpack.encode(num):len(), s/8 + 1, num)
+        local num = -(2 ^ (s - 1)) - 1
+        t.assert_equals(msgpack.decode(msgpack.encode(num)), num);
+        t.assert_equals(msgpack.encode(num):len(), s/4 + 1, num)
+    end
+end
+
+-- Check that big (by module) numbers are encoded correctly.
+g.test_big_number_msgpack = function(cg)
+    local msgpack = cg.params.msgpack
+
+    -- Test number encode/decode.
+    local function test(number)
+        local result = msgpack.decode(msgpack.encode(number))
+        t.assert_equals(result, number);
+        -- cast possible cdata to number
+        t.assert_equals(tonumber(result), number);
+    end
+
+    -- Decrease number by least possible decrement.
+    local function decrease(number)
+        local result = number
+        local step = 1
+        while result == number do
+            result = result - step
+            step = step + 1
+        end
+        return result
+    end
+
+    -- numbers near UINT64_MAX
+    test(2^64)
+    test(decrease(2^64))
+
+    -- numbers near INT64_MIN
+    test(-2^63)
+    test(decrease(-2^63))
+end

--- a/test/engine-luatest/gh_6119_select_big_numbers_test.lua
+++ b/test/engine-luatest/gh_6119_select_big_numbers_test.lua
@@ -1,0 +1,41 @@
+local t = require('luatest')
+
+local g = t.group('gh-6119-select-big-numbers', {{engine = 'memtx'},
+                                                 {engine = 'vinyl'}})
+
+g.before_all(function(cg)
+    local server = require('luatest.server')
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:stop()
+    cg.server = nil
+end)
+
+g.before_test('test_select_big_number', function(cg)
+    cg.server:exec(function(engine)
+        local s = box.schema.space.create('test', {engine = engine})
+        s:create_index('primary', {parts = {{1, 'number'}}})
+    end, {cg.params.engine})
+end)
+
+g.after_test('test_select_big_number', function(cg)
+    cg.server:exec(function()
+        box.space.test:drop()
+    end)
+end)
+
+-- Test from #6119, select by big number is space with big numbers.
+g.test_select_big_number = function(cg)
+    cg.server:exec(function()
+        local s = box.space.test
+        local uint_max = -1ULL
+        local big_num = 1e100
+        s:insert({uint_max})
+        s:insert({big_num})
+        t.assert_equals(s:select({1e50}, {iterator = 'GE'}), {{big_num}})
+        t.assert_equals(s:select({1e50}, {iterator = 'LE'}), {{uint_max}})
+    end, {})
+end


### PR DESCRIPTION
Due to a typo some big numbers were coded as MP_(U)INT.

Since msgpackffi is used in selectffi, which is used for memtx, that could lead to strange select results with big number keys.

Closes #6119

NO_DOC=bugfix