### PR TITLE
box: fix a crash on unknown function option

### DIFF
--- a/changelogs/unreleased/gh-8463-crash-on-create-function
+++ b/changelogs/unreleased/gh-8463-crash-on-create-function
@@ -1,0 +1,3 @@
+## bugfix/box
+
+* Fixed a crash on unknown function option (gh-8463).

--- a/src/box/func_def.c
+++ b/src/box/func_def.c
@@ -55,6 +55,7 @@ const struct func_opts func_opts_default = {
 const struct opt_def func_opts_reg[] = {
 	OPT_DEF("is_multikey", OPT_BOOL, struct func_opts, is_multikey),
 	OPT_DEF("takes_raw_args", OPT_BOOL, struct func_opts, takes_raw_args),
+	OPT_END,
 };
 
 struct func_def *


### PR DESCRIPTION
`func_opts_reg` definition misses a `OPT_END` termintator item. This leads to UB on iterating it. Particularly when `func_opts_reg` is used as argument to `opts_decode` in `func_def_new_from_tuple`.

Closes #8463

NO_DOC=bugfix