### PR TITLE
test: bump test-run to version w/ updated luatest

### DIFF
--- a/test/replication-luatest/gh_8121_memtx_mvcc_replication_stream_test.lua
+++ b/test/replication-luatest/gh_8121_memtx_mvcc_replication_stream_test.lua
@@ -28,7 +28,7 @@ g.before_all(function(cg)
         local s = box.schema.space.create('s', {engine = engine})
         s:create_index('pk')
         s:insert{0}
-    end, {engine = cg.params.engine})
+    end, {cg.params.engine})
     t.helpers.retrying({}, function()
         cg.replica:assert_follows_upstream(cg.master:get_instance_id())
     end)


### PR DESCRIPTION
Bump test-run to new version with the following improvements:

- Bump luatest to 0.5.7-29-geef05dd [1]

[1] tarantool/test-run@cc3c38e