### PR TITLE
box: do not use space for extracting iterator position

### DIFF
--- a/src/box/index_def.c
+++ b/src/box/index_def.c
@@ -96,6 +96,8 @@ index_def_new(uint32_t space_id, uint32_t iid, const char *name,
 	}
 	def->key_def = key_def_dup(key_def);
 	if (iid != 0) {
+		assert(pk_def != NULL);
+		def->pk_def = key_def_dup(pk_def);
 		def->cmp_def = key_def_merge(key_def, pk_def);
 		if (opts->is_unique)
 			def->cmp_def->unique_part_count =
@@ -106,6 +108,7 @@ index_def_new(uint32_t space_id, uint32_t iid, const char *name,
 		}
 	} else {
 		def->cmp_def = key_def_dup(key_def);
+		def->pk_def = key_def_dup(key_def);
 	}
 	def->type = type;
 	def->space_id = space_id;
@@ -135,6 +138,7 @@ index_def_dup(const struct index_def *def)
 	}
 	dup->key_def = key_def_dup(def->key_def);
 	dup->cmp_def = key_def_dup(def->cmp_def);
+	dup->pk_def = key_def_dup(def->pk_def);
 	rlist_create(&dup->link);
 	dup->opts = def->opts;
 	if (def->opts.stat != NULL) {
@@ -219,6 +223,11 @@ index_def_delete(struct index_def *index_def)
 	if (index_def->cmp_def) {
 		TRASH(index_def->cmp_def);
 		free(index_def->cmp_def);
+	}
+
+	if (index_def->pk_def) {
+		TRASH(index_def->pk_def);
+		free(index_def->pk_def);
 	}
 
 	TRASH(index_def);

--- a/src/box/index_def.h
+++ b/src/box/index_def.h
@@ -242,6 +242,14 @@ struct index_def {
 	 * iterator position.
 	 */
 	struct key_def *cmp_def;
+	/**
+	 * Primary key definition. Despite the fact that cmp_def already
+	 * contains primary key definition, our key_def machinery does not
+	 * allow to work with it in any convenient way. This field allows
+	 * to use primary key definition easily without any dependencies on
+	 * space and its primary index.
+	 */
+	struct key_def *pk_def;
 };
 
 struct index_def *

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -1063,11 +1063,7 @@ tree_iterator_position_func(struct iterator *it, const char **pos,
 						&func_key_size);
 	uint32_t func_key_len = mp_decode_array(&func_key);
 	/* Extract primary key. */
-	struct space *space = space_by_id(it->index->def->space_id);
-	assert(space != NULL);
-	struct index *pk = space->index[0];
-	assert(pk != NULL);
-	struct key_def *pk_def = pk->def->key_def;
+	struct key_def *pk_def = it->index->def->pk_def;
 	uint32_t pk_size;
 	const char *pk_key = tuple_extract_key(tree_it->last.tuple, pk_def,
 					       MULTIKEY_NONE, &pk_size);


### PR DESCRIPTION
Currently, we use space to get primary key definition for extracting
iterator position in functional index. It was not a good solution - we
are not allowed to use space for pagination over read view because
space can be dropped. Let's add primary key defintion to `index_def`
and use it.

Part of tarantool/tarantool-ee#285