### PR TITLE
memtx: refactor statistics reporting

### DIFF
--- a/changelogs/unreleased/gh-8448-box-stat-memtx-func.md
+++ b/changelogs/unreleased/gh-8448-box-stat-memtx-func.md
@@ -1,0 +1,5 @@
+## bugfix/lua
+
+* Made `box.stat.memtx` callable. `box.stat.memtx()` now returns all memtx
+  statistics while `box.stat.memtx.tx()` is equivalent to `box.stat.memtx().tx`
+  (gh-8448).

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -47,7 +47,11 @@ extern "C" {
 #endif /* defined(__cplusplus) */
 
 struct index;
+struct index_read_view;
+struct info_handler;
+struct iterator;
 struct fiber;
+struct read_view_tuple;
 struct tuple;
 struct tuple_format;
 struct memtx_tx_snapshot_cleaner;
@@ -219,6 +223,12 @@ memtx_engine_new(const char *snap_dirname, bool force_recovery,
 		 bool dontdump, unsigned granularity,
 		 const char *allocator, float alloc_factor,
 		 memtx_on_indexes_built_cb on_indexes_built);
+
+/**
+ * Memtx engine statistics (box.stat.memtx()).
+ */
+void
+memtx_engine_stat(struct memtx_engine *memtx, struct info_handler *h);
 
 int
 memtx_engine_recover_snapshot(struct memtx_engine *memtx,

--- a/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
+++ b/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
@@ -431,3 +431,10 @@ g.test_user_data = function()
     }
     tx_gc(g.server, 1, diff)
 end
+
+g.test_gh_8448_box_stat_memtx_func = function()
+    g.server:exec(function()
+        t.assert_type(box.stat.memtx.tx, 'function')
+        t.assert_equals(box.stat.memtx().tx, box.stat.memtx.tx())
+    end)
+end


### PR DESCRIPTION
`box.stat.memtx` is a table that contains the 'tx' function. This is confusing because other stat entries are callable: `box.stat.net()`, `box.stat.vinyl()`, `box.stat.sql()`.

Let's make `box.stat.memtx` callable for consistency. The function returns a table with the only field 'tx'. Note, we can't drop `box.stat.memtx.tx()` without breaking backward compatibility so we now return `box.stat.memtx().tx` when it's called.

Also, let's use `info_handler` instead of pushing statistics directly to Lua for better encapsulation.

Needed for https://github.com/tarantool/tarantool-ee/issues/143
Closes #8448