### PR TITLE
Checks override prepare

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,7 @@ endif()
 # 3rd party lua sources
 lua_source(lua_sources ../third_party/luafun/fun.lua fun_lua)
 lua_source(lua_sources ../third_party/lua/luadebug.lua luadebug_lua)
+lua_source(lua_sources ../third_party/checks/checks/version.lua checks_version_lua)
 lua_source(lua_sources ../third_party/checks/checks.lua checks_lua)
 lua_source(lua_sources ../third_party/metrics/metrics/api.lua metrics_api_lua)
 lua_source(lua_sources ../third_party/metrics/metrics/cartridge/failover.lua metrics_cartridge_failover_lua)

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -132,6 +132,7 @@ extern char session_lua[],
 	upgrade_lua[],
 	console_lua[],
 	merger_lua[],
+	checks_version_lua[],
 	checks_lua[],
 	metrics_api_lua[],
 	metrics_cartridge_failover_lua[],
@@ -235,7 +236,10 @@ static const char *lua_sources[] = {
 	 * and after box.tuple and box.error box modules. (Beware
 	 * that it won't fail to load if modules not found since
 	 * checks supports pure luajit and older tarantool versions).
+	 * Module components order is important here.
 	 */
+	"third_party/checks/checks/version",
+	"checks.version", checks_version_lua,
 	"third_party/checks/checks", "checks", checks_lua,
 	/*
 	 * Metrics uses checks. Module components order is also important here

--- a/test/app-luatest/checks_test.lua
+++ b/test/app-luatest/checks_test.lua
@@ -1,7 +1,4 @@
-local checks = require('checks')
-
-local package_source = debug.getinfo(checks).source
-assert(package_source:match('^@builtin') ~= nil,
-       "Run tests for built-in checks package")
+local rock_utils = require('third_party.checks.test.rock_utils')
+rock_utils.assert_builtin('checks')
 
 require('third_party.checks.test.test')

--- a/test/app-luatest/checks_test.lua
+++ b/test/app-luatest/checks_test.lua
@@ -1,4 +1,9 @@
+-- luatest installs external checks module.
+-- After https://github.com/tarantool/checks/pull/54,
+-- external checks will override built-in one, yet
+-- we want to test built-in one here.
 local rock_utils = require('third_party.checks.test.rock_utils')
+rock_utils.remove_override('checks')
 rock_utils.assert_builtin('checks')
 
 require('third_party.checks.test.test')

--- a/test/app-luatest/tnt_debug_getsources_test.lua
+++ b/test/app-luatest/tnt_debug_getsources_test.lua
@@ -23,6 +23,7 @@ local files = {
     'box/net_box',
     'box/console',
     'box/merger',
+    'third_party/checks/checks/version',
     'third_party/checks/checks',
     'third_party/metrics/metrics/api',
     'third_party/metrics/metrics/cartridge/failover',


### PR DESCRIPTION
Prepare for checks PR https://github.com/tarantool/checks/pull/54. Without this patch, after https://github.com/tarantool/checks/pull/54 merge master and 2.11 branch integration CI would start to fail, so we need to deal with it first. This patch also bumps embedded `checks` version.