### PR TITLE
ci: back up artifacts to S3

### DIFF
--- a/.github/actions/s3-upload-artifact/action.yml
+++ b/.github/actions/s3-upload-artifact/action.yml
@@ -1,0 +1,62 @@
+name: Upload test artifact to S3
+description: >
+  Pack test artifact to a zip archive with name <workflow job id>.zip and
+  upload it to S3 to <bucket>/<github.repository>/artifacts/<github.run_id>/
+  destination. Print a warning if the provided artifact path doesn't exist
+
+inputs:
+  job-name:
+    description: >
+      Full job name with matrix combinations. For example, job `test` with
+      matrix options `foo='a'` and `bar='b'` will be named `test (a, b)`.
+      This is required for finding ID of the current running job.
+    required: true
+  access-key-id:
+    description: S3 access key ID
+    required: true
+  secret-access-key:
+    description: S3 secret access key
+    required: true
+  source:
+    description: Source artifact path
+    required: true
+  bucket:
+    description: S3 bucket name
+    required: false
+    default: multivac
+
+runs:
+  using: composite
+  steps:
+    - name: Set 'ARTIFACT_EXISTS' env variable
+      shell: bash
+      run: |
+        if [ -e ${{ inputs.source }} ]; then
+          echo "ARTIFACT_EXISTS=true" >> $GITHUB_ENV
+        else
+          echo "::warning::s3-upload-artifact: No such file or directory: ${{ inputs.source }}"
+        fi
+
+    - name: Get job ID
+      if: env.ARTIFACT_EXISTS
+      uses: tarantool/actions/get-job-id@master
+      with:
+        job-name: ${{ inputs.job-name }}
+        throw-error: true
+
+    - name: Archive artifact
+      if: env.ARTIFACT_EXISTS
+      shell: bash
+      run: |
+        archive_name=${{ env.JOB_ID }}.zip
+        tar -a -C $(dirname ${{ inputs.source }}) -cf ${archive_name} $(basename ${{ inputs.source }})
+
+    - name: Upload archive to S3
+      if: env.ARTIFACT_EXISTS
+      uses: tarantool/actions/s3-upload-file@master
+      with:
+        access-key-id: ${{ inputs.access-key-id }}
+        secret-access-key: ${{ inputs.secret-access-key }}
+        source: ${{ env.JOB_ID }}.zip
+        destination: ${{ github.repository }}/artifacts/${{ github.run_id }}/${{ env.JOB_ID }}.zip
+        bucket: ${{ inputs.bucket }}

--- a/.github/workflows/alpine_3_16.yml
+++ b/.github/workflows/alpine_3_16.yml
@@ -95,3 +95,15 @@ jobs:
           name: alpine-3.16${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/alpine_3_16_aarch64.yml
+++ b/.github/workflows/alpine_3_16_aarch64.yml
@@ -88,3 +88,15 @@ jobs:
           name: alpine-3.16
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -75,3 +75,14 @@ jobs:
           name: centos-7${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/centos_7_aarch64.yml
+++ b/.github/workflows/centos_7_aarch64.yml
@@ -69,3 +69,14 @@ jobs:
           name: centos-7
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -75,3 +75,14 @@ jobs:
           name: centos-8${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/centos_8_aarch64.yml
+++ b/.github/workflows/centos_8_aarch64.yml
@@ -69,3 +69,14 @@ jobs:
           name: centos-8
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -92,3 +92,15 @@ jobs:
           name: failure-logs
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+
+      - name: Upload logs to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -75,3 +75,14 @@ jobs:
           name: debian-buster${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/debian_10_aarch64.yml
+++ b/.github/workflows/debian_10_aarch64.yml
@@ -69,3 +69,14 @@ jobs:
           name: debian-buster
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -75,3 +75,14 @@ jobs:
           name: debian-bullseye${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/debian_11_aarch64.yml
+++ b/.github/workflows/debian_11_aarch64.yml
@@ -69,3 +69,14 @@ jobs:
           name: debian-bullseye
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -75,3 +75,14 @@ jobs:
           name: debian-stretch${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -74,3 +74,15 @@ jobs:
           name: failure-logs
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -67,3 +67,14 @@ jobs:
           name: failure-logs
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -73,3 +73,14 @@ jobs:
           name: default_gcc_centos_7
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          s3-secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -75,3 +75,14 @@ jobs:
           name: fedora-34${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/fedora_34_aarch64.yml
+++ b/.github/workflows/fedora_34_aarch64.yml
@@ -69,3 +69,14 @@ jobs:
           name: fedora-34
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/fedora_35.yml
+++ b/.github/workflows/fedora_35.yml
@@ -75,3 +75,14 @@ jobs:
           name: fedora-35${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/fedora_35_aarch64.yml
+++ b/.github/workflows/fedora_35_aarch64.yml
@@ -69,3 +69,14 @@ jobs:
           name: fedora-35
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/fedora_36.yml
+++ b/.github/workflows/fedora_36.yml
@@ -75,3 +75,14 @@ jobs:
           name: fedora-36${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/fedora_36_aarch64.yml
+++ b/.github/workflows/fedora_36_aarch64.yml
@@ -69,3 +69,14 @@ jobs:
           name: fedora-36
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/freebsd-12.yml
+++ b/.github/workflows/freebsd-12.yml
@@ -67,3 +67,14 @@ jobs:
           name: freebsd-12
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/freebsd-13.yml
+++ b/.github/workflows/freebsd-13.yml
@@ -67,3 +67,14 @@ jobs:
           name: freebsd-13
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -67,6 +67,8 @@ jobs:
           fuzz-seconds: 600
           dry-run: false
           sanitizer: ${{ matrix.sanitizer }}
+      - uses: actions/checkout@v3
+        if: failure()
       - name: Send VK Teams message on failure
         if: failure()
         uses: ./.github/actions/report-job-status

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -69,3 +69,14 @@ jobs:
           name: memtx_allocator_based_on_malloc
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          s3-access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          s3-secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/osx_debug.yml
+++ b/.github/workflows/osx_debug.yml
@@ -73,3 +73,14 @@ jobs:
           name: osx-${{ matrix.version }}-debug-${{ matrix.arch }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/osx_release.yml
+++ b/.github/workflows/osx_release.yml
@@ -73,3 +73,14 @@ jobs:
           name: osx-${{ matrix.version }}-release-${{ matrix.arch }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/osx_release_lto.yml
+++ b/.github/workflows/osx_release_lto.yml
@@ -75,3 +75,14 @@ jobs:
           name: osx-${{ matrix.version }}-release-lto-${{ matrix.arch }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/osx_static_cmake.yml
+++ b/.github/workflows/osx_static_cmake.yml
@@ -74,3 +74,14 @@ jobs:
           name: osx-${{ matrix.version }}-static-cmake-${{ matrix.arch }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -69,3 +69,14 @@ jobs:
           name: out_of_source
           retention-days: 21
           path: artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/redos_7_3.yaml
+++ b/.github/workflows/redos_7_3.yaml
@@ -75,3 +75,14 @@ jobs:
           name: redos-7.3${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,3 +67,14 @@ jobs:
           name: release
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -67,3 +67,14 @@ jobs:
           name: release_asan_clang11
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -70,3 +70,14 @@ jobs:
           name: release_clang
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -69,3 +69,14 @@ jobs:
           name: release_lto
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/release_lto_clang11.yml
+++ b/.github/workflows/release_lto_clang11.yml
@@ -71,3 +71,14 @@ jobs:
           name: release_lto_clang11
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -68,3 +68,14 @@ jobs:
           name: static_build
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -68,3 +68,14 @@ jobs:
           name: static_build_cmake_linux
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -75,3 +75,14 @@ jobs:
           name: ubuntu-xenial${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -75,3 +75,14 @@ jobs:
           name: ubuntu-bionic${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -75,3 +75,14 @@ jobs:
           name: ubuntu-focal${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/ubuntu_20_04_aarch64.yml
+++ b/.github/workflows/ubuntu_20_04_aarch64.yml
@@ -69,3 +69,14 @@ jobs:
           name: ubuntu-focal
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -75,3 +75,14 @@ jobs:
           name: ubuntu-jammy${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/ubuntu_22_04_aarch64.yml
+++ b/.github/workflows/ubuntu_22_04_aarch64.yml
@@ -69,3 +69,14 @@ jobs:
           name: ubuntu-jammy
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts


### PR DESCRIPTION
**ci: add s3-upload-artifact action**

Add a local GitHub action to save test artifacts to S3.
Print a warning if the provided artifact path doesn't exist.

Part of https://github.com/tarantool/multivac/issues/116

---

**ci: save test artifacts to S3**

Add the step to all workflows with test-run tests to save
test artifacts to S3 for providing artifact link from Multivac 
Grafana dashboard.

Resolves https://github.com/tarantool/multivac/issues/116