### PR TITLE
Use matras statistics for memtx memory info

### DIFF
--- a/perf/light.cc
+++ b/perf/light.cc
@@ -476,8 +476,8 @@ class Light {
 public:
 	Light()
 	{
-		light_create(&ht, light_extent_size, light_malloc_extend,
-			     light_free_extend, &extents_count, 0);
+		light_create(&ht, 0, light_extent_size, light_malloc_extend,
+			     light_free_extend, &extents_count, nullptr);
 	}
 	~Light()
 	{
@@ -519,8 +519,8 @@ public:
 	clear()
 	{
 		light_destroy(&ht);
-		light_create(&ht, light_extent_size, light_malloc_extend,
-			     light_free_extend, &extents_count, 0);
+		light_create(&ht, 0, light_extent_size, light_malloc_extend,
+			     light_free_extend, &extents_count, nullptr);
 	}
 
 	void

--- a/src/box/memtx_bitset.cc
+++ b/src/box/memtx_bitset.cc
@@ -548,7 +548,7 @@ memtx_bitset_index_new(struct memtx_engine *memtx, struct index_def *def)
 		panic("failed to allocate memtx bitset index");
 	matras_create(index->id_to_tuple, MEMTX_EXTENT_SIZE, sizeof(struct tuple *),
 		      memtx_index_extent_alloc, memtx_index_extent_free, memtx,
-		      NULL);
+		      &memtx->index_extent_stats);
 
 	index->tuple_to_id = mh_bitset_index_new();
 #endif /* #ifndef OLD_GOOD_BITSET */

--- a/src/box/memtx_bitset.cc
+++ b/src/box/memtx_bitset.cc
@@ -547,7 +547,8 @@ memtx_bitset_index_new(struct memtx_engine *memtx, struct index_def *def)
 	if (index->id_to_tuple == NULL)
 		panic("failed to allocate memtx bitset index");
 	matras_create(index->id_to_tuple, MEMTX_EXTENT_SIZE, sizeof(struct tuple *),
-		      memtx_index_extent_alloc, memtx_index_extent_free, memtx);
+		      memtx_index_extent_alloc, memtx_index_extent_free, memtx,
+		      NULL);
 
 	index->tuple_to_id = mh_bitset_index_new();
 #endif /* #ifndef OLD_GOOD_BITSET */

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -36,6 +36,7 @@
 #include <small/quota.h>
 #include <small/small.h>
 #include <small/mempool.h>
+#include <small/matras.h>
 
 #include "engine.h"
 #include "xlog.h"
@@ -89,9 +90,6 @@ enum memtx_recovery_state {
 	 */
 	MEMTX_OK,
 };
-
-/** Memtx extents pool, available to statistics. */
-extern struct mempool memtx_index_extent_pool;
 
 enum memtx_reserve_extents_num {
 	/**
@@ -153,6 +151,8 @@ struct memtx_engine {
 	struct slab_cache index_slab_cache;
 	/** Index extent allocator. */
 	struct mempool index_extent_pool;
+	/** Index extent allocator statistics. */
+	struct matras_stats index_extent_stats;
 	/**
 	 * To ensure proper statement-level rollback in case
 	 * of out of memory conditions, we maintain a number

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -700,9 +700,9 @@ memtx_hash_index_new(struct memtx_engine *memtx, struct index_def *def)
 		return NULL;
 	}
 
-	light_index_create(&index->hash_table, MEMTX_EXTENT_SIZE,
-			   memtx_index_extent_alloc, memtx_index_extent_free,
-			   memtx, index->base.def->key_def);
+	light_index_create(&index->hash_table, index->base.def->key_def,
+			   MEMTX_EXTENT_SIZE, memtx_index_extent_alloc,
+			   memtx_index_extent_free, memtx, NULL);
 	return &index->base;
 }
 

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -702,7 +702,8 @@ memtx_hash_index_new(struct memtx_engine *memtx, struct index_def *def)
 
 	light_index_create(&index->hash_table, index->base.def->key_def,
 			   MEMTX_EXTENT_SIZE, memtx_index_extent_alloc,
-			   memtx_index_extent_free, memtx, NULL);
+			   memtx_index_extent_free, memtx,
+			   &memtx->index_extent_stats);
 	return &index->base;
 }
 

--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -454,6 +454,6 @@ memtx_rtree_index_new(struct memtx_engine *memtx, struct index_def *def)
 	index->dimension = def->opts.dimension;
 	rtree_init(&index->tree, index->dimension, distance_type,
 		   MEMTX_EXTENT_SIZE, memtx_index_extent_alloc,
-		   memtx_index_extent_free, memtx, NULL);
+		   memtx_index_extent_free, memtx, &memtx->index_extent_stats);
 	return &index->base;
 }

--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -452,8 +452,8 @@ memtx_rtree_index_new(struct memtx_engine *memtx, struct index_def *def)
 	}
 
 	index->dimension = def->opts.dimension;
-	rtree_init(&index->tree, index->dimension, MEMTX_EXTENT_SIZE,
-		   memtx_index_extent_alloc, memtx_index_extent_free, memtx,
-		   distance_type);
+	rtree_init(&index->tree, index->dimension, distance_type,
+		   MEMTX_EXTENT_SIZE, memtx_index_extent_alloc,
+		   memtx_index_extent_free, memtx, NULL);
 	return &index->base;
 }

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -2142,7 +2142,7 @@ memtx_tree_index_new_tpl(struct memtx_engine *memtx, struct index_def *def,
 			index->base.def->key_def : index->base.def->cmp_def;
 
 	memtx_tree_create(&index->tree, cmp_def, memtx_index_extent_alloc,
-			  memtx_index_extent_free, memtx);
+			  memtx_index_extent_free, memtx, NULL);
 	return &index->base;
 }
 

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -2142,7 +2142,8 @@ memtx_tree_index_new_tpl(struct memtx_engine *memtx, struct index_def *def,
 			index->base.def->key_def : index->base.def->cmp_def;
 
 	memtx_tree_create(&index->tree, cmp_def, memtx_index_extent_alloc,
-			  memtx_index_extent_free, memtx, NULL);
+			  memtx_index_extent_free, memtx,
+			  &memtx->index_extent_stats);
 	return &index->base;
 }
 

--- a/src/box/sequence.c
+++ b/src/box/sequence.c
@@ -115,9 +115,10 @@ sequence_init(void)
 {
 	mempool_create(&sequence_data_extent_pool, &cord()->slabc,
 		       SEQUENCE_DATA_EXTENT_SIZE);
-	light_sequence_create(&sequence_data_index, SEQUENCE_DATA_EXTENT_SIZE,
+	light_sequence_create(&sequence_data_index, 0,
+			      SEQUENCE_DATA_EXTENT_SIZE,
 			      sequence_data_extent_alloc,
-			      sequence_data_extent_free, NULL, 0);
+			      sequence_data_extent_free, NULL, NULL);
 }
 
 void

--- a/src/box/vy_cache.c
+++ b/src/box/vy_cache.c
@@ -144,7 +144,7 @@ vy_cache_create(struct vy_cache *cache, struct vy_cache_env *env,
 	cache->version = 1;
 	vy_cache_tree_create(&cache->cache_tree, cmp_def,
 			     vy_cache_tree_page_alloc,
-			     vy_cache_tree_page_free, env);
+			     vy_cache_tree_page_free, env, NULL);
 }
 
 void

--- a/src/box/vy_mem.c
+++ b/src/box/vy_mem.c
@@ -116,7 +116,7 @@ vy_mem_new(struct vy_mem_env *env, struct key_def *cmp_def,
 	tuple_format_ref(format);
 	vy_mem_tree_create(&index->tree, cmp_def,
 			   vy_mem_tree_extent_alloc,
-			   vy_mem_tree_extent_free, index);
+			   vy_mem_tree_extent_free, index, NULL);
 	rlist_create(&index->in_sealed);
 	fiber_cond_create(&index->pin_cond);
 	return index;

--- a/src/lib/salad/bps_tree.h
+++ b/src/lib/salad/bps_tree.h
@@ -1303,7 +1303,7 @@ bps_tree_create(struct bps_tree *t, bps_tree_arg_t arg,
 	memset(&tree->max_elem, 0, sizeof(tree->max_elem));
 	matras_create(&t->matras,
 		      BPS_TREE_EXTENT_SIZE, BPS_TREE_BLOCK_SIZE,
-		      extent_alloc_func, extent_free_func, alloc_ctx);
+		      extent_alloc_func, extent_free_func, alloc_ctx, NULL);
 	matras_head_read_view(&t->view);
 	tree->matras = &t->matras;
 	tree->view = &t->view;

--- a/src/lib/salad/light.h
+++ b/src/lib/salad/light.h
@@ -457,7 +457,7 @@ LIGHT(create)(struct LIGHT(core) *htab, size_t extent_size,
 	ht->arg = arg;
 	matras_create(&htab->mtable,
 		      extent_size, sizeof(struct LIGHT(record)),
-		      extent_alloc_func, extent_free_func, alloc_ctx);
+		      extent_alloc_func, extent_free_func, alloc_ctx, NULL);
 	matras_head_read_view(&htab->view);
 	ht->mtable = &htab->mtable;
 	ht->view = &htab->view;

--- a/src/lib/salad/rtree.c
+++ b/src/lib/salad/rtree.c
@@ -970,7 +970,7 @@ rtree_init(struct rtree *tree, unsigned dimension, uint32_t extent_size,
 		/ sizeof(struct rtree_neighbor);
 
 	matras_create(&tree->mtab, extent_size, tree->page_size,
-		      extent_alloc, extent_free, alloc_ctx);
+		      extent_alloc, extent_free, alloc_ctx, NULL);
 	return 0;
 }
 

--- a/src/lib/salad/rtree.c
+++ b/src/lib/salad/rtree.c
@@ -940,10 +940,11 @@ rtree_iterator_next(struct rtree_iterator *itr)
 /* R-tree methods */
 /*------------------------------------------------------------------------- */
 
-int
-rtree_init(struct rtree *tree, unsigned dimension, uint32_t extent_size,
-	   rtree_extent_alloc_t extent_alloc, rtree_extent_free_t extent_free,
-	   void *alloc_ctx, enum rtree_distance_type distance_type)
+void
+rtree_init(struct rtree *tree, unsigned dimension,
+	   enum rtree_distance_type distance_type, uint32_t extent_size,
+	   matras_alloc_func extent_alloc, matras_free_func extent_free,
+	   void *alloc_ctx, struct matras_stats *alloc_stats)
 {
 	tree->n_records = 0;
 	tree->height = 0;
@@ -970,8 +971,7 @@ rtree_init(struct rtree *tree, unsigned dimension, uint32_t extent_size,
 		/ sizeof(struct rtree_neighbor);
 
 	matras_create(&tree->mtab, extent_size, tree->page_size,
-		      extent_alloc, extent_free, alloc_ctx, NULL);
-	return 0;
+		      extent_alloc, extent_free, alloc_ctx, alloc_stats);
 }
 
 void

--- a/src/lib/salad/rtree.h
+++ b/src/lib/salad/rtree.h
@@ -98,10 +98,6 @@ enum spatial_search_op
 	SOP_NEIGHBOR
 };
 
-/* pointers to page allocation and deallocations functions */
-typedef void *(*rtree_extent_alloc_t)(void *ctx);
-typedef void (*rtree_extent_free_t)(void *ctx, void *extent);
-
 /* A box in RTREE_DIMENSION space */
 struct rtree_rect
 {
@@ -228,16 +224,19 @@ rtree_set2dp(struct rtree_rect *rect, coord_t x, coord_t y);
 /**
  * @brief Initialize a tree
  * @param tree - pointer to a tree
+ * @param dimension - tree dimension
+ * @param distance_type - distance type
  * @param extent_size - size of extents allocated by extent_alloc (see next)
  * @param extent_alloc - extent allocation function
  * @param extent_free - extent deallocation function
  * @param alloc_ctx - argument passed to extent allocator
- * @return 0 on success, -1 on error
+ * @param alloc_stats - optional extent allocator statistics
  */
-int
-rtree_init(struct rtree *tree, unsigned dimension, uint32_t extent_size,
-	   rtree_extent_alloc_t extent_alloc, rtree_extent_free_t extent_free,
-	   void *alloc_ctx, enum rtree_distance_type distance_type);
+void
+rtree_init(struct rtree *tree, unsigned dimension,
+	   enum rtree_distance_type distance_type, uint32_t extent_size,
+	   matras_alloc_func extent_alloc, matras_free_func extent_free,
+	   void *alloc_ctx, struct matras_stats *alloc_stats);
 
 /**
  * @brief Destroy a tree

--- a/test/box-luatest/gh_934_memory_info_test.lua
+++ b/test/box-luatest/gh_934_memory_info_test.lua
@@ -1,0 +1,32 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_memtx_index = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('test')
+        s:create_index('i1')
+        s:create_index('i2', {type = 'hash', parts = {2, 'unsigned'}})
+        s:create_index('i3', {unique = false, type = 'bitset',
+                              parts = {3, 'unsigned'}})
+        s:create_index('i4', {unique = false, type = 'rtree',
+                              parts = {4, 'array'}})
+        local stat1 = box.info.memory()
+        s:insert({1, 1, 1, {1, 1}})
+        local stat2 = box.info.memory()
+        -- The first insertion triggers allocation of 3 extents of size 16384
+        -- bytes per each index.
+        t.assert_equals(stat2.index - stat1.index, 3 * 16384 * (#s.index + 1))
+        s:drop()
+    end)
+end

--- a/test/unit/bps_tree.cc
+++ b/test/unit/bps_tree.cc
@@ -169,9 +169,14 @@ simple_check()
 {
 	header();
 
+	struct matras_stats stats;
+	matras_stats_create(&stats);
+	stats.extent_count = extents_count;
+
 	const unsigned int rounds = 2000;
 	test tree;
-	test_create(&tree, 0, extent_alloc, extent_free, &extents_count);
+	test_create(&tree, 0, extent_alloc, extent_free, &extents_count,
+		    &stats);
 
 	printf("Insert 1..X, remove 1..X\n");
 	for (unsigned int i = 0; i < rounds; i++) {
@@ -186,6 +191,8 @@ simple_check()
 	}
 	if (test_size(&tree) != rounds)
 		fail("Tree count mismatch (1)", "true");
+	if ((int)stats.extent_count != extents_count)
+		fail("Extent count mismatch (1)", "true");
 
 	for (unsigned int i = 0; i < rounds; i++) {
 		type_t v = i;
@@ -199,6 +206,8 @@ simple_check()
 	}
 	if (test_size(&tree) != 0)
 		fail("Tree count mismatch (2)", "true");
+	if ((int)stats.extent_count != extents_count)
+		fail("Extent count mismatch (2)", "true");
 
 	printf("Insert 1..X, remove X..1\n");
 	for (unsigned int i = 0; i < rounds; i++) {
@@ -213,6 +222,8 @@ simple_check()
 	}
 	if (test_size(&tree) != rounds)
 		fail("Tree count mismatch (3)", "true");
+	if ((int)stats.extent_count != extents_count)
+		fail("Extent count mismatch (3)", "true");
 
 	for (unsigned int i = 0; i < rounds; i++) {
 		type_t v = rounds - 1 - i;
@@ -226,6 +237,8 @@ simple_check()
 	}
 	if (test_size(&tree) != 0)
 		fail("Tree count mismatch (4)", "true");
+	if ((int)stats.extent_count != extents_count)
+		fail("Extent count mismatch (4)", "true");
 
 	printf("Insert X..1, remove 1..X\n");
 	for (unsigned int i = 0; i < rounds; i++) {
@@ -240,6 +253,8 @@ simple_check()
 	}
 	if (test_size(&tree) != rounds)
 		fail("Tree count mismatch (5)", "true");
+	if ((int)stats.extent_count != extents_count)
+		fail("Extent count mismatch (5)", "true");
 
 	for (unsigned int i = 0; i < rounds; i++) {
 		type_t v = i;
@@ -253,6 +268,8 @@ simple_check()
 	}
 	if (test_size(&tree) != 0)
 		fail("Tree count mismatch (6)", "true");
+	if ((int)stats.extent_count != extents_count)
+		fail("Extent count mismatch (6)", "true");
 
 	printf("Insert X..1, remove X..1\n");
 	for (unsigned int i = 0; i < rounds; i++) {
@@ -267,6 +284,8 @@ simple_check()
 	}
 	if (test_size(&tree) != rounds)
 		fail("Tree count mismatch (7)", "true");
+	if ((int)stats.extent_count != extents_count)
+		fail("Extent count mismatch (7)", "true");
 
 	for (unsigned int i = 0; i < rounds; i++) {
 		type_t v = rounds - 1 - i;
@@ -280,6 +299,8 @@ simple_check()
 	}
 	if (test_size(&tree) != 0)
 		fail("Tree count mismatch (8)", "true");
+	if ((int)stats.extent_count != extents_count)
+		fail("Extent count mismatch (8)", "true");
 
 	test_destroy(&tree);
 
@@ -316,7 +337,7 @@ compare_with_sptree_check()
 	sptree_test_init(&spt_test, sizeof(type_t), 0, 0, 0, &node_comp, 0, 0);
 
 	test tree;
-	test_create(&tree, 0, extent_alloc, extent_free, &extents_count);
+	test_create(&tree, 0, extent_alloc, extent_free, &extents_count, NULL);
 
 	const int rounds = 16 * 1024;
 	const int elem_limit = 	1024;
@@ -358,7 +379,7 @@ compare_with_sptree_check_branches()
 	sptree_test_init(&spt_test, sizeof(type_t), 0, 0, 0, &node_comp, 0, 0);
 
 	test tree;
-	test_create(&tree, 0, extent_alloc, extent_free, &extents_count);
+	test_create(&tree, 0, extent_alloc, extent_free, &extents_count, NULL);
 
 	const int elem_limit = 1024;
 
@@ -602,7 +623,7 @@ loading_test()
 
 	for (type_t i = 0; i <= test_count; i++) {
 		test_create(&tree, 0, extent_alloc, extent_free,
-			    &extents_count);
+			    &extents_count, NULL);
 
 		if (test_build(&tree, arr, i))
 			fail("building failed", "true");
@@ -633,7 +654,7 @@ printing_test()
 	header();
 
 	test tree;
-	test_create(&tree, 0, extent_alloc, extent_free, &extents_count);
+	test_create(&tree, 0, extent_alloc, extent_free, &extents_count, NULL);
 
 	const type_t rounds = 22;
 
@@ -659,7 +680,7 @@ white_box_test()
 	header();
 
 	test tree;
-	test_create(&tree, 0, extent_alloc, extent_free, &extents_count);
+	test_create(&tree, 0, extent_alloc, extent_free, &extents_count, NULL);
 
 	assert(BPS_TREE_test_MAX_COUNT_IN_LEAF == 14);
 	assert(BPS_TREE_test_MAX_COUNT_IN_INNER == 10);
@@ -695,7 +716,7 @@ white_box_test()
 	test_print(&tree, TYPE_F);
 
 	test_destroy(&tree);
-	test_create(&tree, 0, extent_alloc, extent_free, &extents_count);
+	test_create(&tree, 0, extent_alloc, extent_free, &extents_count, NULL);
 	type_t arr[140];
 	for (type_t i = 0; i < 140; i++)
 		arr[i] = i;
@@ -719,7 +740,8 @@ approximate_count()
 	srand(0);
 
 	approx tree;
-	approx_create(&tree, 0, extent_alloc, extent_free, &extents_count);
+	approx_create(&tree, 0, extent_alloc, extent_free, &extents_count,
+		      NULL);
 
 	uint32_t in_leaf_max_count = BPS_TREE_approx_MAX_COUNT_IN_LEAF;
 	uint32_t in_leaf_min_count = in_leaf_max_count * 2 / 3;
@@ -822,7 +844,7 @@ insert_get_iterator()
 	header();
 
 	test tree;
-	test_create(&tree, 0, extent_alloc, extent_free, &extents_count);
+	test_create(&tree, 0, extent_alloc, extent_free, &extents_count, NULL);
 	type_t value = 100000;
 
 	bps_insert_and_check(test, &tree, value, NULL)
@@ -842,7 +864,8 @@ delete_value_check()
 {
 	header();
 	struct_tree tree;
-	struct_tree_create(&tree, 0, extent_alloc, extent_free, &extents_count);
+	struct_tree_create(&tree, 0, extent_alloc, extent_free, &extents_count,
+			   NULL);
 	struct elem_t e1 = {1, 1};
 	struct_tree_insert(&tree, e1, NULL, NULL);
 	struct elem_t e2 = {1, 2};
@@ -868,7 +891,8 @@ insert_successor_test()
 
 	for (size_t i = 0; i < sizeof(limits) / sizeof(limits[0]); i++) {
 		size_t limit = limits[i];
-		test_create(&tree, 0, extent_alloc, extent_free, &extents_count);
+		test_create(&tree, 0, extent_alloc, extent_free, &extents_count,
+			    NULL);
 
 		for (size_t j = 0; j < limit; j++) {
 			type_t v = 1 + rand() % (limit - 1);

--- a/test/unit/bps_tree_iterator.cc
+++ b/test/unit/bps_tree_iterator.cc
@@ -70,7 +70,7 @@ iterator_check()
 
 	test tree;
 	test_create(&tree, 0, extent_alloc, extent_free,
-		    &total_extents_allocated);
+		    &total_extents_allocated, NULL);
 
 	/* Stupid tests */
 	{
@@ -299,7 +299,7 @@ iterator_invalidate_check()
 		if (del_pos + del_cnt > test_size)
 			del_cnt = test_size - del_pos;
 		test_create(&tree, 0, extent_alloc, extent_free,
-			    &total_extents_allocated);
+			    &total_extents_allocated, NULL);
 
 		for (long i = 0; i < test_size; i++) {
 			elem_t e;
@@ -344,7 +344,7 @@ iterator_invalidate_check()
 		long ins_pos = rand() % test_size;
 		long ins_cnt = rand() % max_insert_count + 1;
 		test_create(&tree, 0, extent_alloc, extent_free,
-			    &total_extents_allocated);
+			    &total_extents_allocated, NULL);
 
 		for (long i = 0; i < test_size; i++) {
 			elem_t e;
@@ -400,7 +400,7 @@ iterator_invalidate_check()
 		if (del_pos + del_cnt > test_size)
 			del_cnt = test_size - del_pos;
 		test_create(&tree, 0, extent_alloc, extent_free,
-			    &total_extents_allocated);
+			    &total_extents_allocated, NULL);
 
 		for (long i = 0; i < test_size; i++) {
 			elem_t e;
@@ -471,7 +471,7 @@ iterator_freeze_check()
 
 	for (int i = 0; i < 10; i++) {
 		test_create(&tree, 0, extent_alloc, extent_free,
-			    &total_extents_allocated);
+			    &total_extents_allocated, NULL);
 		int comp_buf_size1 = 0;
 		int comp_buf_size2 = 0;
 		for (int j = 0; j < test_data_size; j++) {

--- a/test/unit/bps_tree_view.c
+++ b/test/unit/bps_tree_view.c
@@ -32,7 +32,7 @@ extent_free(void *ctx, void *extent)
 static void
 test_tree_do_create(struct test_tree *tree)
 {
-	test_tree_create(tree, NULL, extent_alloc, extent_free, NULL);
+	test_tree_create(tree, NULL, extent_alloc, extent_free, NULL, NULL);
 }
 
 static void

--- a/test/unit/light.cc
+++ b/test/unit/light.cc
@@ -63,9 +63,13 @@ simple_test()
 {
 	header();
 
+	struct matras_stats stats;
+	matras_stats_create(&stats);
+	stats.extent_count = extents_count;
+
 	struct light_core ht;
-	light_create(&ht, light_extent_size,
-		     my_light_alloc, my_light_free, &extents_count, 0);
+	light_create(&ht, 0, light_extent_size, my_light_alloc, my_light_free,
+		     &extents_count, &stats);
 	std::vector<bool> vect;
 	size_t count = 0;
 	const size_t rounds = 1000;
@@ -98,6 +102,8 @@ simple_test()
 
 			if (count != light_count(&ht))
 				fail("count check failed!", "true");
+			if (stats.extent_count != extents_count)
+				fail("extent count check failed!", "true");
 
 			bool identical = true;
 			for (hash_value_t test = 0; test < limits; test++) {
@@ -128,8 +134,8 @@ collision_test()
 	header();
 
 	struct light_core ht;
-	light_create(&ht, light_extent_size,
-		     my_light_alloc, my_light_free, &extents_count, 0);
+	light_create(&ht, 0, light_extent_size, my_light_alloc, my_light_free,
+		     &extents_count, NULL);
 	std::vector<bool> vect;
 	size_t count = 0;
 	const size_t rounds = 100;
@@ -192,8 +198,8 @@ iterator_test()
 	header();
 
 	struct light_core ht;
-	light_create(&ht, light_extent_size,
-		     my_light_alloc, my_light_free, &extents_count, 0);
+	light_create(&ht, 0, light_extent_size, my_light_alloc, my_light_free,
+		     &extents_count, NULL);
 	const size_t rounds = 1000;
 	const size_t start_limits = 20;
 
@@ -255,8 +261,8 @@ iterator_freeze_check()
 	struct light_core ht;
 
 	for (int i = 0; i < 10; i++) {
-		light_create(&ht, light_extent_size,
-			     my_light_alloc, my_light_free, &extents_count, 0);
+		light_create(&ht, 0, light_extent_size, my_light_alloc,
+			     my_light_free, &extents_count, NULL);
 		int comp_buf_size = 0;
 		int comp_buf_size2 = 0;
 		for (int j = 0; j < test_data_size; j++) {

--- a/test/unit/light_view.c
+++ b/test/unit/light_view.c
@@ -55,7 +55,8 @@ free_extent(void *ctx, void *p)
 static void
 light_do_create(struct light_core *ht)
 {
-	light_create(ht, extent_size, alloc_extent, free_extent, NULL, NULL);
+	light_create(ht, NULL, extent_size, alloc_extent, free_extent,
+		     NULL, NULL);
 }
 
 static void

--- a/test/unit/rtree.cc
+++ b/test/unit/rtree.cc
@@ -38,10 +38,13 @@ simple_check()
 
 	header();
 
+	struct matras_stats stats;
+	matras_stats_create(&stats);
+	stats.extent_count = page_count;
+
 	struct rtree tree;
-	rtree_init(&tree, 2, extent_size,
-		   extent_alloc, extent_free, &page_count,
-		   RTREE_EUCLID);
+	rtree_init(&tree, 2, RTREE_EUCLID, extent_size,
+		   extent_alloc, extent_free, &page_count, &stats);
 
 	printf("Insert 1..X, remove 1..X\n");
 	for (size_t i = 1; i <= rounds; i++) {
@@ -56,6 +59,9 @@ simple_check()
 	}
 	if (rtree_number_of_records(&tree) != rounds) {
 		fail("Tree count mismatch (1)", "true");
+	}
+	if ((int)stats.extent_count != page_count) {
+		fail("Extent count mismatch (1)", "true");
 	}
 	for (size_t i = 1; i <= rounds; i++) {
 		record_t rec = (record_t)i;
@@ -81,6 +87,9 @@ simple_check()
 	if (rtree_number_of_records(&tree) != 0) {
 		fail("Tree count mismatch (1)", "true");
 	}
+	if ((int)stats.extent_count != page_count) {
+		fail("Extent count mismatch (1)", "true");
+	}
 
 	printf("Insert 1..X, remove X..1\n");
 	for (size_t i = 1; i <= rounds; i++) {
@@ -95,6 +104,9 @@ simple_check()
 	}
 	if (rtree_number_of_records(&tree) != rounds) {
 		fail("Tree count mismatch (2)", "true");
+	}
+	if ((int)stats.extent_count != page_count) {
+		fail("Extent count mismatch (2)", "true");
 	}
 	for (size_t i = rounds; i != 0; i--) {
 		record_t rec = (record_t)i;
@@ -120,7 +132,9 @@ simple_check()
 	if (rtree_number_of_records(&tree) != 0) {
 		fail("Tree count mismatch (2)", "true");
 	}
-
+	if ((int)stats.extent_count != page_count) {
+		fail("Extent count mismatch (2)", "true");
+	}
 
 	printf("Insert X..1, remove 1..X\n");
 	for (size_t i = rounds; i != 0; i--) {
@@ -135,6 +149,9 @@ simple_check()
 	}
 	if (rtree_number_of_records(&tree) != rounds) {
 		fail("Tree count mismatch (3)", "true");
+	}
+	if ((int)stats.extent_count != page_count) {
+		fail("Extent count mismatch (3)", "true");
 	}
 	for (size_t i = 1; i <= rounds; i++) {
 		record_t rec = (record_t)i;
@@ -160,7 +177,9 @@ simple_check()
 	if (rtree_number_of_records(&tree) != 0) {
 		fail("Tree count mismatch (3)", "true");
 	}
-
+	if ((int)stats.extent_count != page_count) {
+		fail("Extent count mismatch (3)", "true");
+	}
 
 	printf("Insert X..1, remove X..1\n");
 	for (size_t i = rounds; i != 0; i--) {
@@ -175,6 +194,9 @@ simple_check()
 	}
 	if (rtree_number_of_records(&tree) != rounds) {
 		fail("Tree count mismatch (4)", "true");
+	}
+	if ((int)stats.extent_count != page_count) {
+		fail("Extent count mismatch (4)", "true");
 	}
 	for (size_t i = rounds; i != 0; i--) {
 		record_t rec = (record_t)i;
@@ -199,6 +221,9 @@ simple_check()
 	}
 	if (rtree_number_of_records(&tree) != 0) {
 		fail("Tree count mismatch (4)", "true");
+	}
+	if ((int)stats.extent_count != page_count) {
+		fail("Extent count mismatch (4)", "true");
 	}
 
 	rtree_purge(&tree);
@@ -233,9 +258,8 @@ neighbor_test()
 
 	for (size_t i = 0; i <= test_count; i++) {
 		struct rtree tree;
-		rtree_init(&tree, 2, extent_size,
-			   extent_alloc, extent_free, &page_count,
-			   RTREE_EUCLID);
+		rtree_init(&tree, 2, RTREE_EUCLID, extent_size,
+			   extent_alloc, extent_free, &page_count, NULL);
 
 		rtree_test_build(&tree, arr, i);
 
@@ -258,8 +282,8 @@ neighbor_test()
 	struct rtree_iterator iterator;
 	rtree_iterator_init(&iterator);
 	struct rtree tree;
-	rtree_init(&tree, 2, extent_size, extent_alloc, extent_free, &page_count, 
-			RTREE_EUCLID);
+	rtree_init(&tree, 2, RTREE_EUCLID, extent_size,
+		   extent_alloc, extent_free, &page_count, NULL);
 	if (rtree_search(&tree, &basis, SOP_NEIGHBOR, &iterator)) {
 		fail("found in empty", "true");
 	}

--- a/test/unit/rtree_iterator.cc
+++ b/test/unit/rtree_iterator.cc
@@ -33,9 +33,8 @@ iterator_check()
 	header();
 
 	struct rtree tree;
-	rtree_init(&tree, 2, extent_size,
-		   extent_alloc, extent_free, &extent_count,
-		   RTREE_EUCLID);
+	rtree_init(&tree, 2, RTREE_EUCLID, extent_size,
+		   extent_alloc, extent_free, &extent_count, NULL);
 
 	/* Filling tree */
 	const size_t count1 = 10000;
@@ -216,9 +215,8 @@ iterator_invalidate_check()
 			del_cnt = test_size - del_pos;
 		}
 		struct rtree tree;
-		rtree_init(&tree, 2, extent_size,
-			   extent_alloc, extent_free, &extent_count,
-			   RTREE_EUCLID);
+		rtree_init(&tree, 2, RTREE_EUCLID, extent_size,
+			   extent_alloc, extent_free, &extent_count, NULL);
 		struct rtree_iterator iterators[test_size];
 		for (size_t i = 0; i < test_size; i++)
 			rtree_iterator_init(iterators + i);
@@ -262,9 +260,8 @@ iterator_invalidate_check()
 		size_t ins_cnt = rand() % max_insert_count + 1;
 
 		struct rtree tree;
-		rtree_init(&tree, 2, extent_size,
-			   extent_alloc, extent_free, &extent_count,
-			   RTREE_EUCLID);
+		rtree_init(&tree, 2, RTREE_EUCLID, extent_size,
+			   extent_alloc, extent_free, &extent_count, NULL);
 		struct rtree_iterator iterators[test_size];
 		for (size_t i = 0; i < test_size; i++)
 			rtree_iterator_init(iterators + i);

--- a/test/unit/rtree_multidim.cc
+++ b/test/unit/rtree_multidim.cc
@@ -485,9 +485,8 @@ rand_test()
 	CBoxSet<DIMENSION> set;
 
 	struct rtree tree;
-	rtree_init(&tree, DIMENSION, extent_size,
-		   extent_alloc, extent_free, &page_count,
-		   RTREE_EUCLID);
+	rtree_init(&tree, DIMENSION, RTREE_EUCLID, extent_size,
+		   extent_alloc, extent_free, &page_count, NULL);
 
 	printf("\tDIMENSION: %u, page size: %u, max fill good: %d\n",
 	       DIMENSION, tree.page_size, tree.page_max_fill >= 10);


### PR DESCRIPTION
This PR bumps the small submodule to pull matras statistics and makes memtx use the new statistics for `box.info.memory()`.

Needed for https://github.com/tarantool/tarantool-ee/issues/143

Related PRs: https://github.com/tarantool/small/pull/60 https://github.com/tarantool/small/pull/61 https://github.com/tarantool/tarantool-ee/pull/424