### PR TITLE
Fix issues from static analyzers and fuzzer

### DIFF
--- a/changelogs/unreleased/ghs-120-use-after-free.md
+++ b/changelogs/unreleased/ghs-120-use-after-free.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Fixed a Use-After-Free vulnerability in the `WITH RECURSIVE` clause
+  (ghs-119).

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -304,8 +304,6 @@ sql_space_info_new_from_space_def(const struct space_def *def)
 {
 	uint32_t field_count = def->field_count + 1;
 	struct sql_space_info *info = sql_space_info_new(field_count, 0);
-	if (info == NULL)
-		return NULL;
 	for (uint32_t i = 0; i < def->field_count; ++i) {
 		info->types[i] = def->fields[i].type;
 		info->coll_ids[i] = def->fields[i].coll_id;
@@ -322,8 +320,6 @@ sql_space_info_new_from_index_def(const struct index_def *def, bool has_rowid)
 	if (has_rowid)
 		++field_count;
 	struct sql_space_info *info = sql_space_info_new(field_count, 0);
-	if (info == NULL)
-		return NULL;
 	for (uint32_t i = 0; i < def->key_def->part_count; ++i) {
 		info->types[i] = def->key_def->parts[i].type;
 		info->coll_ids[i] = def->key_def->parts[i].coll_id;
@@ -1681,10 +1677,7 @@ sql_check_create(const char *name, uint32_t space_id, uint32_t func_id,
 		 uint32_t fieldno, bool is_field_ck)
 {
 	const struct space *space = space_by_id(space_id);
-	if (space == NULL) {
-		diag_set(ClientError, ER_NO_SUCH_SPACE, space_name(space));
-		return -1;
-	}
+	assert(space != NULL);
 	struct tuple_constraint_def *cdefs;
 	uint32_t count;
 	const char *path;

--- a/src/box/sql/delete.c
+++ b/src/box/sql/delete.c
@@ -238,10 +238,6 @@ sql_table_delete_from(struct Parse *parse, struct SrcList *tab_list,
 			info = sql_space_info_new_from_index_def(index_def,
 								 false);
 		}
-		if (info == NULL) {
-			parse->is_aborted = true;
-			goto delete_from_cleanup;
-		}
 		parse->nMem += pk_len;
 		sqlVdbeAddOp4(v, OP_OpenTEphemeral, reg_eph, 0, 0, (char *)info,
 			      P4_DYNAMIC);

--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -2662,8 +2662,6 @@ sqlCodeSubselect(Parse * pParse,	/* Parsing context */
 			int reg_eph = ++pParse->nMem;
 			struct sql_space_info *info =
 				sql_space_info_new(nVal, 0);
-			if (info == NULL)
-				return 0;
 			sqlVdbeAddOp4(v, OP_OpenTEphemeral, reg_eph, 0, 0,
 				      (char *)info, P4_DYNAMIC);
 			sqlVdbeAddOp3(v, OP_IteratorOpen, pExpr->iTable, 0,
@@ -4046,10 +4044,6 @@ sqlExprCodeTarget(Parse * pParse, Expr * pExpr, int target)
 			if (func->def->language == FUNC_LANGUAGE_SQL_BUILTIN) {
 				struct sql_context *ctx =
 					sql_context_new(func, coll);
-				if (ctx == NULL) {
-					pParse->is_aborted = true;
-					return -1;
-				}
 				sqlVdbeAddOp4(v, OP_BuiltinFunction, nFarg,
 					      r1, target, (char *)ctx,
 					      P4_FUNCCTX);

--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -3180,13 +3180,10 @@ expr_code_int(struct Parse *parse, struct Expr *expr, bool is_neg,
 	const char *sign = is_neg ? "-" : "";
 	if (z[0] == '0' && (z[1] == 'x' || z[1] == 'X')) {
 		errno = 0;
-		if (is_neg) {
+		if (is_neg)
 			value = strtoll(z, NULL, 16);
-		} else {
+		else
 			value = strtoull(z, NULL, 16);
-			if (value > INT64_MAX)
-				goto int_overflow;
-		}
 		if (errno != 0) {
 			diag_set(ClientError, ER_HEX_LITERAL_MAX, sign, z,
 				 strlen(z) - 2, 16);
@@ -3198,7 +3195,6 @@ expr_code_int(struct Parse *parse, struct Expr *expr, bool is_neg,
 		bool unused;
 		if (sql_atoi64(z, &value, &unused, len) != 0 ||
 		    (is_neg && (uint64_t) value > (uint64_t) INT64_MAX + 1)) {
-int_overflow:
 			diag_set(ClientError, ER_INT_LITERAL_MAX, sign, z);
 			parse->is_aborted = true;
 			return;

--- a/src/box/sql/insert.c
+++ b/src/box/sql/insert.c
@@ -61,8 +61,6 @@ sql_space_info_new_from_id_list(const struct space_def *def, int len,
 				const struct IdList *list)
 {
 	struct sql_space_info *info = sql_space_info_new(len + 1, 1);
-	if (info == NULL)
-		return NULL;
 	assert(len > 0 && len <= (int)def->field_count);
 	struct field_def *fields = def->fields;
 	for (int i = 0; i < len; ++i) {
@@ -502,10 +500,6 @@ sqlInsert(Parse * pParse,	/* Parser context */
 		struct sql_space_info *info =
 			sql_space_info_new_from_id_list(space_def, nColumn,
 							pColumn);
-		if (info == NULL) {
-			pParse->is_aborted = true;
-			goto insert_cleanup;
-		}
 		sqlVdbeAddOp4(v, OP_OpenTEphemeral, reg_eph, 0, 0,
 			      (char *)info, P4_DYNAMIC);
 		addrL = sqlVdbeAddOp1(v, OP_Yield, dest.iSDParm);

--- a/src/box/sql/main.c
+++ b/src/box/sql/main.c
@@ -95,8 +95,6 @@ enum {
 int
 sql_initialize(void)
 {
-	int rc = 0;
-
 	/* If the following assert() fails on some obscure processor/compiler
 	 * combination, the work-around is to set the correct pointer
 	 * size at compile-time using -DSQL_PTRSIZE=n compile-time option
@@ -110,12 +108,6 @@ sql_initialize(void)
 	 */
 	if (sqlGlobalConfig.isInit)
 		return 0;
-
-	/* If rc is not 0 at this point, then the malloc
-	 * subsystem could not be initialized.
-	 */
-	if (rc != 0)
-		return rc;
 
 	/* Do the rest of the initialization
 	 * that we will be able to handle recursive calls into

--- a/src/box/sql/malloc.c
+++ b/src/box/sql/malloc.c
@@ -39,6 +39,8 @@
 void
 sql_xfree(void *buf)
 {
+	if (buf == NULL)
+		return;
 	struct sql *db = sql_get();
 	assert(db != NULL);
 	if (buf >= db->lookaside.pStart && buf < db->lookaside.pEnd) {

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -975,7 +975,7 @@ term(A) ::= INTEGER(X). {
   A.pExpr->type = FIELD_TYPE_INTEGER;
   A.zStart = X.z;
   A.zEnd = X.z + X.n;
-  if( A.pExpr ) A.pExpr->flags |= EP_Leaf;
+  A.pExpr->flags |= EP_Leaf;
 }
 expr(A) ::= VARNUM(X). {
   A.pExpr = expr_new_variable(pParse, &X, NULL);

--- a/src/box/sql/select.c
+++ b/src/box/sql/select.c
@@ -128,8 +128,6 @@ sql_space_info_new_from_expr_list(struct Parse *parser, struct ExprList *list,
 	if (has_rowid)
 		++n;
 	struct sql_space_info *info = sql_space_info_new(n, 0);
-	if (info == NULL)
-		return NULL;
 	for (int i = 0; i < list->nExpr; ++i) {
 		bool b;
 		struct coll *coll;
@@ -159,8 +157,6 @@ sql_space_info_new_from_order_by(struct Parse *parser, struct Select *select,
 {
 	int n = order_by->nExpr + 2;
 	struct sql_space_info *info = sql_space_info_new(n, 0);
-	if (info == NULL)
-		return NULL;
 	for (int i = 0; i < order_by->nExpr; ++i) {
 		struct Expr *expr = order_by->a[i].pExpr;
 		enum field_type type = sql_expr_type(expr);
@@ -216,8 +212,6 @@ sql_space_info_new_for_sorting(struct Parse *parser, struct ExprList *order_by,
 
 	struct sql_space_info *info =
 		sql_space_info_new(field_count, part_count);
-	if (info == NULL)
-		return NULL;
 	int k;
 	for (k = 0; k < order_by->nExpr - start; ++k) {
 		bool b;
@@ -3125,10 +3119,6 @@ multiSelect(Parse * pParse,	/* Parsing context */
 		assert(p->pNext == NULL);
 		int nCol = p->pEList->nExpr;
 		struct sql_space_info *info = sql_space_info_new(nCol, 0);
-		if (info == NULL) {
-			pParse->is_aborted = true;
-			goto multi_select_end;
-		}
 		for (int i = 0; i < nCol; ++i)
 			info->coll_ids[i] = multi_select_coll_seq(pParse, p, i);
 		bool is_info_used = false;
@@ -5459,10 +5449,6 @@ updateAccumulator(Parse * pParse, AggInfo * pAggInfo)
 			sqlVdbeAddOp1(v, OP_SkipLoad, regHit);
 		}
 		struct sql_context *ctx = sql_context_new(pF->func, coll);
-		if (ctx == NULL) {
-			pParse->is_aborted = true;
-			return;
-		}
 		if (pF->func->def->language == FUNC_LANGUAGE_SQL_BUILTIN) {
 			sqlVdbeAddOp3(v, OP_AggStep, nArg, regAgg, pF->iMem);
 			sqlVdbeAppendP4(v, ctx, P4_FUNCCTX);

--- a/src/box/sql/select.c
+++ b/src/box/sql/select.c
@@ -2577,6 +2577,8 @@ generateWithRecursiveQuery(Parse * pParse,	/* Parsing context */
 		info = sql_space_info_new_from_expr_list(pParse, p->pEList,
 							 true);
 	}
+	/* Detach the ORDER BY clause from the compound SELECT */
+	p->pOrderBy = NULL;
 	if (info == NULL) {
 		pParse->is_aborted = true;
 		goto end_of_recursive_query;
@@ -2591,9 +2593,6 @@ generateWithRecursiveQuery(Parse * pParse,	/* Parsing context */
 		p->selFlags |= SF_UsesEphemeral;
 		VdbeComment((v, "Distinct table"));
 	}
-
-	/* Detach the ORDER BY clause from the compound SELECT */
-	p->pOrderBy = 0;
 
 	/* Store the results of the setup-query in Queue. */
 	pSetup->pNext = 0;

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2692,11 +2692,10 @@ sql_space_column_is_in_pk(struct space *space, uint32_t);
  * @param parse Parsing context.
  * @param expr_list  Expr list from which to derive column names.
  * @param space_def Destination space definition.
- * @retval 0 on success.
- * @retval error codef on error.
  */
-int sqlColumnsFromExprList(Parse *parse, ExprList *expr_list,
-			   struct space_def *space_def);
+void
+sqlColumnsFromExprList(struct Parse *parse, struct ExprList *expr_list,
+		       struct space_def *space_def);
 
 void
 sqlSelectAddColumnTypeAndCollation(Parse *, struct space_def *, Select *);

--- a/src/box/sql/update.c
+++ b/src/box/sql/update.c
@@ -226,10 +226,6 @@ sqlUpdate(Parse * pParse,		/* The parser context */
 		info = sql_space_info_new_from_space_def(def);
 	else
 		info = sql_space_info_new_from_index_def(pPk->def, false);
-	if (info == NULL) {
-		pParse->is_aborted = true;
-		goto update_cleanup;
-	}
 	/* Address of the OpenEphemeral instruction. */
 	int addrOpen = sqlVdbeAddOp4(v, OP_OpenTEphemeral, reg_eph, 0, 0,
 				     (char *)info, P4_DYNAMIC);

--- a/src/box/sql/where.c
+++ b/src/box/sql/where.c
@@ -915,10 +915,6 @@ constructAutomaticIndex(Parse * pParse,			/* The parsing context */
 	pLevel->iIdxCur = pParse->nTab++;
 	struct sql_space_info *info = sql_space_info_new_from_index_def(idx_def,
 									true);
-	if (info == NULL) {
-		pParse->is_aborted = true;
-		return;
-	}
 	int reg_eph = sqlGetTempReg(pParse);
 	sqlVdbeAddOp4(v, OP_OpenTEphemeral, reg_eph, 0, 0, (char *)info,
 		      P4_DYNAMIC);
@@ -4614,13 +4610,11 @@ sqlWhereBegin(Parse * pParse,	/* The parser context */
 	/* Done. */
 	return pWInfo;
 
-	/* Jump here if malloc fails */
- whereBeginError:
-	if (pWInfo) {
-		pParse->nQueryLoop = pWInfo->savedNQueryLoop;
-		whereInfoFree(pWInfo);
-	}
-	return 0;
+whereBeginError:
+	assert(pWInfo != NULL);
+	pParse->nQueryLoop = pWInfo->savedNQueryLoop;
+	whereInfoFree(pWInfo);
+	return NULL;
 }
 
 /*

--- a/src/box/sql/wherecode.c
+++ b/src/box/sql/wherecode.c
@@ -1070,10 +1070,6 @@ sqlWhereCodeOneLoopStart(WhereInfo * pWInfo,	/* Complete information about the W
 			struct sql_space_info *info =
 				sql_space_info_new_from_index_def(index_def,
 								  false);
-			if (info == NULL) {
-				pParse->is_aborted = true;
-				return notReady;
-			}
 			sqlVdbeAddOp4(v, OP_OpenTEphemeral, reg_row_set,
 				      pk_part_count, 0, (char *)info,
 				      P4_DYNAMIC);

--- a/src/box/sql/wherecode.c
+++ b/src/box/sql/wherecode.c
@@ -131,15 +131,7 @@ explainIndexRange(StrAccum * pStr, WhereLoop * pLoop)
 		return;
 	sqlStrAccumAppend(pStr, " (", 2);
 	for (i = 0; i < nEq; i++) {
-		const char *z;
-		if (def != NULL) {
-			z = explainIndexColumnName(def, i);
-		} else {
-			struct space *space = space_cache_find(def->space_id);
-			assert(space != NULL);
-			uint32_t fieldno = def->key_def->parts[i].fieldno;
-			z = space->def->fields[fieldno].name;
-		}
+		const char *z = explainIndexColumnName(def, i);
 		if (i)
 			sqlStrAccumAppend(pStr, " AND ", 5);
 		sqlXPrintf(pStr, i >= nSkip ? "%s=?" : "ANY(%s)", z);

--- a/test/sql-luatest/ghs_120_use_after_free_test.lua
+++ b/test/sql-luatest/ghs_120_use_after_free_test.lua
@@ -1,0 +1,26 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_use_after_free = function()
+    g.server:exec(function()
+        local sql = [[WITH RECURSIVE t(x) AS
+                      (VALUES('1' collate "binary") UNION ALL SELECT '2' FROM t
+                       WHERE 'x' != '2' ORDER BY 1 collate "asd")
+                      SELECT x FROM t;]]
+        local ret, err = box.execute(sql)
+        t.assert(ret == nil)
+        local msg = [[Collation 'asd' does not exist]]
+        t.assert_equals(err.message, msg)
+    end)
+end


### PR DESCRIPTION
This patch fixes some issues found by static analyzers and the fuzzer. Most issues are false-positives, but some refactoring is needed to avoid warnings in the future. Some memory leaks and possible bugs have also been found and fixed. However, there are no tests, no docs, no changelog, as our tests current tests can't reproduce or catch any of found bugs.

Closes tarantool/security#120