### PR TITLE
console: fix :endswith() err in tntctl connection

### DIFF
--- a/changelogs/unreleased/gh-8374-local-print-accepts-non-strings.md
+++ b/changelogs/unreleased/gh-8374-local-print-accepts-non-strings.md
@@ -1,0 +1,6 @@
+## bugfix/console
+
+* Fixed `console.local_print()` accepting only string arguments. It backfired in
+  some rare cases, e.g. when connecting via tarantoolctl to cartridged tarantool
+  and using wrong credentials, a cdata error was passed through the
+  `local_print()`, that failed to interpret it (gh-8374).

--- a/src/box/lua/console.lua
+++ b/src/box/lua/console.lua
@@ -712,7 +712,11 @@ end
 -- Print result to stdout
 --
 local function local_print(self, output)
-    if output:endswith(output_eos["lua"]) then
+    --
+    -- Be cautious, `output` may be any printable object, e.g. tarantoolctl
+    -- passes cdata errors in some cases.
+    --
+    if type(output) == 'string' and output:endswith(output_eos["lua"]) then
         local new_local_eos
         if self.remote ~= nil then
             new_local_eos = self.remote.local_eos


### PR DESCRIPTION
There used to be a rare error when failed to connect via tarantoolctl to listening cartridge console. It was caused by unclear console.local_print() contract. Starting from gh-7031 fix, the function assumed string-only arguments, while in some cases cdata error was passed.

Now console.local_print() prints all non-string arguments as is, without modifying potential local_eos.

Closes #8374

NO_DOC=bugfix
NO_TEST=very hard to test