### PR TITLE
doc: proofread changelogs for the latest version

### DIFF
--- a/changelogs/unreleased/gh-4632-net-box-unknown-field-type.md
+++ b/changelogs/unreleased/gh-4632-net-box-unknown-field-type.md
@@ -1,4 +1,4 @@
 ## bugfix/core
 
-* Fixed a net.box client crash when a remote space has a field type that isn't
-  supported by the client version (gh-4632).
+* Fixed a crash in the `net.box` client when a remote space had
+  a field type that the client version did not support (gh-4632).

--- a/changelogs/unreleased/gh-6119-fix-number-mp-encode.md
+++ b/changelogs/unreleased/gh-6119-fix-number-mp-encode.md
@@ -1,4 +1,4 @@
 ## bugfix/box
 
-* Fixed a bug when big numbers were incorrectly encoded by msgpackffi,
-  that could lead to wrong select results with big number keys (gh-6119).
+* Fixed a bug when large numbers were encoded incorrectly by `msgpackffi`.
+  It could lead to wrong select results with large number keys (gh-6119).

--- a/changelogs/unreleased/gh-6668-ordering-incomparable-types.md
+++ b/changelogs/unreleased/gh-6668-ordering-incomparable-types.md
@@ -1,4 +1,4 @@
 ## bugfix/sql
 
-* ARRAY, MAP, and INTERVAL values can no longer be used as ORDER BY
-  arguments (gh-6668).
+* Now the `ARRAY`, `MAP`, and `INTERVAL` values cannot be used as
+  arguments in the `ORDER BY` clause (gh-6668).

--- a/changelogs/unreleased/gh-7515-syncing-follower-notices-leader-hang.md
+++ b/changelogs/unreleased/gh-7515-syncing-follower-notices-leader-hang.md
@@ -1,4 +1,5 @@
 ## bugfix/replication
 
-* Fixed nodes syncing with a hung leader reporting it as alive and thus delaying
-  new elections (gh-7515).
+* Fixed an issue when the nodes synchronizing with
+  a hung leader reported the leader as alive.
+  This behavior led to the delay of the new elections (gh-7515).

--- a/changelogs/unreleased/gh-7725-embed-metrics.md
+++ b/changelogs/unreleased/gh-7725-embed-metrics.md
@@ -1,4 +1,4 @@
 ## feature/lua
 
-* Embed tarantool/metrics module for metrics aggregation and export (gh-7725).
-* Configure metrics with box.cfg (gh-7725).
+* Embedded the `tarantool/metrics` module for metrics aggregation and export (gh-7725).
+* Metrics can now be configured using the `box.cfg()` function (gh-7725).

--- a/changelogs/unreleased/gh-8070-collation-for-any.md
+++ b/changelogs/unreleased/gh-8070-collation-for-any.md
@@ -1,3 +1,3 @@
 ## bugfix/sql
 
-* Now field type ANY supports collation in SQL (gh-8070).
+* The `ANY` field type now supports collation in SQL (gh-8070).

--- a/changelogs/unreleased/gh-8441-remove-vinyl-root-directory-after-gc.md
+++ b/changelogs/unreleased/gh-8441-remove-vinyl-root-directory-after-gc.md
@@ -1,4 +1,4 @@
 ## bugfix/vinyl
 
-* Vinyl space and index directories are now created on demand and removed
-  as soon as they become empty (gh-8441).
+* Vinyl space and index directories are now created on demand.
+  They are removed as soon as they become empty (gh-8441).

--- a/changelogs/unreleased/gh-8448-box-stat-memtx-func.md
+++ b/changelogs/unreleased/gh-8448-box-stat-memtx-func.md
@@ -1,5 +1,5 @@
 ## bugfix/lua
 
-* Made `box.stat.memtx` callable. `box.stat.memtx()` now returns all memtx
-  statistics while `box.stat.memtx.tx()` is equivalent to `box.stat.memtx().tx`
-  (gh-8448).
+* The `box.stat.memtx` function is now callable, it returns
+  all memtx statistics. The `box.stat.memtx.tx()` function
+  is now equivalent to the `box.stat.memtx().tx` function (gh-8448).

--- a/changelogs/unreleased/gh-8457-downgrade-handle-takes-raw-args.md
+++ b/changelogs/unreleased/gh-8457-downgrade-handle-takes-raw-args.md
@@ -1,4 +1,4 @@
 ## bugfix/box
 
-* Fixed a missed case of downgrading a function with `takes_raw_args` option
-  (gh-8457).
+* The `takes_raw_args` option is now handled correctly
+  during downgrading (gh-8457).

--- a/changelogs/unreleased/gh-8460-wrong-int-to-dec-convertion-in-arithmetic.md
+++ b/changelogs/unreleased/gh-8460-wrong-int-to-dec-convertion-in-arithmetic.md
@@ -1,4 +1,4 @@
 ## bugfix/sql
 
-* Fixed incorrect conversion of an integer greater than INT64_MAX or
-  less than 0 to decimal during SQL arithmetic operations (gh-8460).
+* Fixed incorrect conversion of an integer greater than `INT64_MAX` or
+  less than `0` to a decimal number during SQL arithmetic operations (gh-8460).

--- a/changelogs/unreleased/gh-8463-crash-on-create-function.md
+++ b/changelogs/unreleased/gh-8463-crash-on-create-function.md
@@ -1,3 +1,3 @@
 ## bugfix/box
 
-* Fixed a crash on unknown function option (gh-8463).
+* Fixed a crash on an unknown option of the function (gh-8463).

--- a/changelogs/unreleased/gh_5997_get_rid_of_schema_max_id.md
+++ b/changelogs/unreleased/gh_5997_get_rid_of_schema_max_id.md
@@ -1,4 +1,4 @@
 ## feature/core
 
-* Tarantool does not use `_schema.max_id` anymore, so this field is
-  dropped (gh-5997).
+* The `_schema.max_id` field in the `box.space._schema` function is now deprecated.
+  Now the `_space:max()` function is used instead of `_schema.max_id` (gh-5997).

--- a/changelogs/unreleased/gh_8036_mix_explicit_and_implicit_space_id.md
+++ b/changelogs/unreleased/gh_8036_mix_explicit_and_implicit_space_id.md
@@ -1,5 +1,5 @@
 ## bugfix/core
 
-* Fixed a problem when space creation failed with duplication error when
-  explicit and implicit space id were mixed. Now, actual maximal space id
-  is used to generate a new one (gh-8036).
+* Fixed a bug when a space creation failed with a duplication error.
+  The issue occurred if the explicit and implicit space IDs were mixed.
+  Now the actual maximal space `id` is used to generate a new one (gh-8036).

--- a/changelogs/unreleased/luajit-grammar-fuzzer.md
+++ b/changelogs/unreleased/luajit-grammar-fuzzer.md
@@ -1,3 +1,3 @@
 ## feature/test/fuzz
 
-* LuaJIT now can be fuzzed using grammar-based fuzzer (gh-4823).
+* Now LuaJIT can be fuzzed using grammar-based fuzzer (gh-4823).

--- a/changelogs/unreleased/no-gh-add-tt-dependency.md
+++ b/changelogs/unreleased/no-gh-add-tt-dependency.md
@@ -1,5 +1,5 @@
 ## feature/build
 
-* Added `tt` weak dependency. `tt` command line utility combines
+* Added `tt` weak dependency. The `tt` command line utility combines
   `tarantoolctl` and `cartridge-cli` functionality into one tool.
-  This change is a part of pushing `tt` to public ( tarantool/tt#286 ).
+  The change is a part of pushing `tt` to the public (tarantool/tt#286).


### PR DESCRIPTION
Fix grammar, punctuation, and wording

NO_CHANGELOG=changelog
NO_DOC=changelog
NO_TEST=changelog