### PR TITLE
Rework struct Mem

### DIFF
--- a/src/box/bind.c
+++ b/src/box/bind.c
@@ -221,15 +221,15 @@ sql_bind_column(struct Vdbe *stmt, const struct sql_bind *p, uint32_t pos)
 		 * there is no need to copy the packet and we can
 		 * use SQL_STATIC.
 		 */
-		return sql_bind_str_static(stmt, pos, p->s, p->bytes);
+		return sql_bind_str(stmt, pos, p->s, p->bytes);
 	case MP_NIL:
 		return sql_bind_null(stmt, pos);
 	case MP_BIN:
-		return sql_bind_bin_static(stmt, pos, p->s, p->bytes);
+		return sql_bind_bin(stmt, pos, p->s, p->bytes);
 	case MP_ARRAY:
-		return sql_bind_array_static(stmt, pos, p->s, p->bytes);
+		return sql_bind_array(stmt, pos, p->s, p->bytes);
 	case MP_MAP:
-		return sql_bind_map_static(stmt, pos, p->s, p->bytes);
+		return sql_bind_map(stmt, pos, p->s, p->bytes);
 	case MP_EXT:
 		switch (p->ext_type) {
 		case MP_UUID:

--- a/src/box/lua/call.c
+++ b/src/box/lua/call.c
@@ -607,7 +607,7 @@ port_lua_destroy(struct port *base)
 extern const char *
 port_lua_dump_plain(struct port *port, uint32_t *size);
 
-extern struct Mem *
+extern struct sql_mem *
 port_lua_get_vdbemem(struct port *base, uint32_t *size);
 
 static const struct port_vtab port_lua_vtab = {

--- a/src/box/port.c
+++ b/src/box/port.c
@@ -295,7 +295,7 @@ port_c_get_msgpack(struct port *base, uint32_t *size)
 extern void
 port_c_dump_lua(struct port *port, struct lua_State *L, bool is_flat);
 
-extern struct Mem *
+extern struct sql_mem *
 port_c_get_vdbemem(struct port *base, uint32_t *size);
 
 const struct port_vtab port_c_vtab = {

--- a/src/box/port.h
+++ b/src/box/port.h
@@ -92,7 +92,7 @@ port_lua_create(struct port *port, struct lua_State *L);
 /** Port implementation used with vdbe memory variables. */
 struct port_vdbemem {
     const struct port_vtab *vtab;
-    struct Mem *mem;
+	struct sql_mem *mem;
     uint32_t mem_count;
 };
 
@@ -101,7 +101,7 @@ static_assert(sizeof(struct port_vdbemem) <= sizeof(struct port),
 
 /** Initialize a port to dump data in sql vdbe memory. */
 void
-port_vdbemem_create(struct port *base, struct Mem *mem,
+port_vdbemem_create(struct port *base, struct sql_mem *mem,
 		    uint32_t mem_count);
 
 struct port_c_entry {

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -228,7 +228,8 @@ int tarantoolsqlPrevious(BtCursor *pCur, int *pRes)
 }
 
 int
-sql_cursor_seek(struct BtCursor *cur, struct Mem *mems, uint32_t len, int *res)
+sql_cursor_seek(struct BtCursor *cur, struct sql_mem *mems, uint32_t len,
+		int *res)
 {
 	struct region *region = &fiber()->gc;
 	size_t used = region_used(region);
@@ -784,7 +785,7 @@ tarantoolsqlIdxKeyCompare(struct BtCursor *cursor,
 		 *      we should just compare the mem from unpacked with NULL.
 		 */
 		uint32_t fieldno = key_def->parts[i].fieldno;
-		struct Mem *mem = &unpacked->aMem[i];
+		struct sql_mem *mem = &unpacked->aMem[i];
 		struct key_part *part = &unpacked->key_def->parts[i];
 		if (fieldno >= base_len) {
 			if (mem_is_null(mem))

--- a/src/box/sql/func.c
+++ b/src/box/sql/func.c
@@ -60,7 +60,7 @@ static struct func_sql_builtin **functions;
 
 /** Implementation of the SUM() function. */
 static void
-step_sum(struct sql_context *ctx, int argc, const struct Mem *argv)
+step_sum(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 1);
 	(void)argc;
@@ -75,7 +75,7 @@ step_sum(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 /** Implementation of the TOTAL() function. */
 static void
-step_total(struct sql_context *ctx, int argc, const struct Mem *argv)
+step_total(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 1);
 	(void)argc;
@@ -90,7 +90,7 @@ step_total(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 /** Finalizer for the TOTAL() function. */
 static int
-fin_total(struct Mem *mem)
+fin_total(struct sql_mem *mem)
 {
 	assert(mem_is_null(mem) || mem_is_double(mem));
 	if (mem_is_null(mem))
@@ -100,17 +100,17 @@ fin_total(struct Mem *mem)
 
 /** Implementation of the AVG() function. */
 static void
-step_avg(struct sql_context *ctx, int argc, const struct Mem *argv)
+step_avg(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 1);
 	(void)argc;
 	assert(mem_is_null(ctx->pOut) || mem_is_bin(ctx->pOut));
 	if (mem_is_null(&argv[0]))
 		return;
-	struct Mem *mem;
+	struct sql_mem *mem;
 	uint32_t *count;
 	if (mem_is_null(ctx->pOut)) {
-		uint32_t size = sizeof(struct Mem) + sizeof(uint32_t);
+		uint32_t size = sizeof(struct sql_mem) + sizeof(uint32_t);
 		mem = sql_xmalloc(size);
 		count = (uint32_t *)(mem + 1);
 		mem_create(mem);
@@ -120,7 +120,7 @@ step_avg(struct sql_context *ctx, int argc, const struct Mem *argv)
 		mem_set_dynamic(ctx->pOut);
 		return;
 	}
-	mem = (struct Mem *)ctx->pOut->u.z;
+	mem = (struct sql_mem *)ctx->pOut->u.z;
 	count = (uint32_t *)(mem + 1);
 	++*count;
 	if (mem_add(mem, &argv[0], mem) != 0)
@@ -129,15 +129,15 @@ step_avg(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 /** Finalizer for the AVG() function. */
 static int
-fin_avg(struct Mem *mem)
+fin_avg(struct sql_mem *mem)
 {
 	assert(mem_is_null(mem) || mem_is_bin(mem));
 	if (mem_is_null(mem))
 		return 0;
-	struct Mem *sum = (struct Mem *)mem->u.z;
+	struct sql_mem *sum = (struct sql_mem *)mem->u.z;
 	uint32_t *count_val = (uint32_t *)(sum + 1);
 	assert(mem_is_trivial(sum));
-	struct Mem count;
+	struct sql_mem count;
 	mem_create(&count);
 	mem_set_uint(&count, *count_val);
 	return mem_div(sum, &count, mem);
@@ -145,7 +145,7 @@ fin_avg(struct Mem *mem)
 
 /** Implementation of the COUNT() function. */
 static void
-step_count(struct sql_context *ctx, int argc, const struct Mem *argv)
+step_count(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 0 || argc == 1);
 	if (mem_is_null(ctx->pOut))
@@ -158,7 +158,7 @@ step_count(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 /** Finalizer for the COUNT() function. */
 static int
-fin_count(struct Mem *mem)
+fin_count(struct sql_mem *mem)
 {
 	assert(mem_is_null(mem) || mem_is_uint(mem));
 	if (mem_is_null(mem))
@@ -168,7 +168,7 @@ fin_count(struct Mem *mem)
 
 /** Implementation of the MIN() and MAX() functions. */
 static void
-step_minmax(struct sql_context *ctx, int argc, const struct Mem *argv)
+step_minmax(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 1);
 	(void)argc;
@@ -201,7 +201,7 @@ step_minmax(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 /** Implementation of the GROUP_CONCAT() function. */
 static void
-step_group_concat(struct sql_context *ctx, int argc, const struct Mem *argv)
+step_group_concat(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 1 || argc == 2);
 	(void)argc;
@@ -236,11 +236,11 @@ step_group_concat(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 /** Implementations of the ABS() function. */
 static void
-func_abs_int(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_abs_int(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 1);
 	(void)argc;
-	const struct Mem *arg = &argv[0];
+	const struct sql_mem *arg = &argv[0];
 	if (mem_is_null(arg))
 		return;
 	assert(mem_is_int(arg));
@@ -248,24 +248,26 @@ func_abs_int(struct sql_context *ctx, int argc, const struct Mem *argv)
 	mem_set_uint(ctx->pOut, u);
 }
 
+/** Implementations of the ABS() function for DOUBLE argument. */
 static void
-func_abs_double(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_abs_double(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 1);
 	(void)argc;
-	const struct Mem *arg = &argv[0];
+	const struct sql_mem *arg = &argv[0];
 	if (mem_is_null(arg))
 		return;
 	assert(mem_is_double(arg));
 	mem_set_double(ctx->pOut, arg->u.r < 0 ? -arg->u.r : arg->u.r);
 }
 
+/** Implementations of the ABS() function for DECIMAL argument. */
 static void
-func_abs_dec(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_abs_dec(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 1);
 	(void)argc;
-	const struct Mem *arg = &argv[0];
+	const struct sql_mem *arg = &argv[0];
 	if (mem_is_null(arg))
 		return;
 	assert(mem_is_dec(arg));
@@ -275,11 +277,11 @@ func_abs_dec(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 /** Implementation of the CHAR_LENGTH() function. */
 static void
-func_char_length(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_char_length(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 1);
 	(void)argc;
-	const struct Mem *arg = &argv[0];
+	const struct sql_mem *arg = &argv[0];
 	if (mem_is_null(arg))
 		return;
 	assert(mem_is_str(arg));
@@ -295,11 +297,11 @@ func_char_length(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 /** Implementation of the UPPER() and LOWER() functions. */
 static void
-func_lower_upper(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_lower_upper(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 1);
 	(void)argc;
-	const struct Mem *arg = &argv[0];
+	const struct sql_mem *arg = &argv[0];
 	if (mem_is_null(arg))
 		return;
 	assert(mem_is_str(arg));
@@ -338,7 +340,7 @@ func_lower_upper(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 /** Implementation of the NULLIF() function. */
 static void
-func_nullif(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_nullif(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 2);
 	(void)argc;
@@ -393,7 +395,7 @@ trim_bin_start(const char *str, int end, const char *octets, int octets_size,
 }
 
 static void
-func_trim_bin(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_trim_bin(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	if (mem_is_null(&argv[0]) || (argc == 3 && mem_is_null(&argv[2])))
 		return;
@@ -472,7 +474,7 @@ trim_str_start(const char *str, int end, const char *chars, uint8_t *chars_len,
 }
 
 static void
-func_trim_str(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_trim_str(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	if (mem_is_null(&argv[0]) || (argc == 3 && mem_is_null(&argv[2])))
 		return;
@@ -522,7 +524,7 @@ func_trim_str(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 /** Implementation of the POSITION() function. */
 static void
-func_position_octets(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_position_octets(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 2);
 	(void)argc;
@@ -542,7 +544,7 @@ func_position_octets(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 static void
 func_position_characters(struct sql_context *ctx, int argc,
-			 const struct Mem *argv)
+			 const struct sql_mem *argv)
 {
 	assert(argc == 2);
 	(void)argc;
@@ -622,7 +624,7 @@ substr_normalize(int64_t base_start, bool is_start_neg, uint64_t base_length,
 }
 
 static void
-func_substr_octets(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_substr_octets(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 2 || argc == 3);
 	if (mem_is_any_null(&argv[0], &argv[1]))
@@ -679,7 +681,7 @@ func_substr_octets(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 static void
 func_substr_characters(struct sql_context *ctx, int argc, const
-		       struct Mem *argv)
+		       struct sql_mem *argv)
 {
 	assert(argc == 2 || argc == 3);
 	(void)argc;
@@ -752,7 +754,7 @@ func_substr_characters(struct sql_context *ctx, int argc, const
  * Symbol '\0' used instead of NULL argument.
  */
 static void
-func_char(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_char(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	if (argc == 0)
 		return mem_set_str0(ctx->pOut, "");
@@ -798,7 +800,7 @@ func_char(struct sql_context *ctx, int argc, const struct Mem *argv)
  * The LEAST() function returns the smallest of the given arguments.
  */
 static void
-func_greatest_least(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_greatest_least(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc > 1);
 	int mask = ctx->func->def->name[0] == 'G' ? -1 : 0;
@@ -819,22 +821,21 @@ func_greatest_least(struct sql_context *ctx, int argc, const struct Mem *argv)
 		ctx->is_aborted = true;
 }
 
-/**
- * Implementation of the HEX() function.
- *
- * The HEX() function returns the hexadecimal representation of the argument.
- */
 static const char hexdigits[] = {
 	'0', '1', '2', '3', '4', '5', '6', '7',
 	'8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
 };
 
+/**
+ * Implementation of the HEX() function. The HEX() function returns the
+ * hexadecimal representation of the argument.
+ */
 static void
-func_hex(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_hex(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 1);
 	(void)argc;
-	const struct Mem *arg = &argv[0];
+	const struct sql_mem *arg = &argv[0];
 	if (mem_is_null(arg))
 		return;
 
@@ -855,11 +856,11 @@ func_hex(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 /** Implementation of the OCTET_LENGTH() function. */
 static void
-func_octet_length(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_octet_length(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 1);
 	(void)argc;
-	const struct Mem *arg = &argv[0];
+	const struct sql_mem *arg = &argv[0];
 	if (mem_is_null(arg))
 		return;
 	assert(mem_is_bytes(arg));
@@ -868,7 +869,7 @@ func_octet_length(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 /** Implementation of the PRINTF() function. */
 static void
-func_printf(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_printf(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	if (argc < 1 || mem_is_null(&argv[0]))
 		return;
@@ -901,7 +902,7 @@ func_printf(struct sql_context *ctx, int argc, const struct Mem *argv)
  * This function returns a random INT64 value.
  */
 static void
-func_random(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_random(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	(void)argc;
 	(void)argv;
@@ -917,11 +918,11 @@ func_random(struct sql_context *ctx, int argc, const struct Mem *argv)
  * specified as an argument of the function.
  */
 static void
-func_randomblob(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_randomblob(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 1);
 	(void)argc;
-	const struct Mem *arg = &argv[0];
+	const struct sql_mem *arg = &argv[0];
 	assert(mem_is_null(arg) || mem_is_int(arg));
 	if (mem_is_null(arg) || !mem_is_uint(arg))
 		return;
@@ -941,11 +942,11 @@ func_randomblob(struct sql_context *ctx, int argc, const struct Mem *argv)
  * is specified as an argument of the function.
  */
 static void
-func_zeroblob(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_zeroblob(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 1);
 	(void)argc;
-	const struct Mem *arg = &argv[0];
+	const struct sql_mem *arg = &argv[0];
 	assert(mem_is_null(arg) || mem_is_int(arg));
 	if (mem_is_null(arg) || !mem_is_uint(arg))
 		return;
@@ -959,7 +960,7 @@ func_zeroblob(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 /** Implementation of the TYPEOF() function. */
 static void
-func_typeof(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_typeof(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 1);
 	(void)argc;
@@ -968,7 +969,7 @@ func_typeof(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 /** Implementation of the ROUND() function for DOUBLE argument. */
 static void
-func_round_double(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_round_double(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 1 || argc == 2);
 	if (mem_is_null(&argv[0]) || (argc == 2 && mem_is_null(&argv[1])))
@@ -986,7 +987,7 @@ func_round_double(struct sql_context *ctx, int argc, const struct Mem *argv)
 		return mem_copy_as_ephemeral(ctx->pOut, &argv[0]);
 
 	double d = argv[0].u.r;
-	struct Mem *res = ctx->pOut;
+	struct sql_mem *res = ctx->pOut;
 	if (n != 0) {
 		d = atof(tt_sprintf("%.*lf", (int)n, d));
 		return mem_set_double(res, d);
@@ -1004,7 +1005,7 @@ func_round_double(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 /** Implementation of the ROUND() function for DECIMAL argument. */
 static void
-func_round_dec(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_round_dec(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 1 || argc == 2);
 	if (mem_is_null(&argv[0]) || (argc == 2 && mem_is_null(&argv[1])))
@@ -1020,7 +1021,7 @@ func_round_dec(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 /** Implementation of the ROUND() function for INTEGER argument. */
 static void
-func_round_int(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_round_int(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 1 || argc == 2);
 	if (mem_is_null(&argv[0]) || (argc == 2 && mem_is_null(&argv[1])))
@@ -1032,7 +1033,7 @@ func_round_int(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 /** Implementation of the ROW_COUNT() function. */
 static void
-func_row_count(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_row_count(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	(void)argc;
 	(void)argv;
@@ -1046,7 +1047,7 @@ func_row_count(struct sql_context *ctx, int argc, const struct Mem *argv)
  * Returns a randomly generated UUID value.
  */
 static void
-func_uuid(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_uuid(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	if (argc == 1) {
 		if (mem_is_null(&argv[0]))
@@ -1065,7 +1066,7 @@ func_uuid(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 /** Implementation of the VERSION() function. */
 static void
-func_version(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_version(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	(void)argc;
 	(void)argv;
@@ -1079,11 +1080,11 @@ func_version(struct sql_context *ctx, int argc, const struct Mem *argv)
  * string.
  */
 static void
-func_unicode(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_unicode(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 1);
 	(void)argc;
-	const struct Mem *arg = &argv[0];
+	const struct sql_mem *arg = &argv[0];
 	if (mem_is_null(arg))
 		return;
 	assert(mem_is_str(arg));
@@ -1102,7 +1103,7 @@ func_unicode(struct sql_context *ctx, int argc, const struct Mem *argv)
  * Return the current date and time.
  */
 static void
-func_now(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_now(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 0);
 	(void)argc;
@@ -1118,12 +1119,12 @@ func_now(struct sql_context *ctx, int argc, const struct Mem *argv)
  * Returns the requested information from a DATETIME value.
  */
 static void
-func_date_part(struct sql_context *ctx, int argc, const struct Mem *argv)
+func_date_part(struct sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 2);
 	(void)argc;
-	const struct Mem *part = &argv[0];
-	const struct Mem *date = &argv[1];
+	const struct sql_mem *part = &argv[0];
+	const struct sql_mem *date = &argv[1];
 	if (mem_is_any_null(part, date))
 		return;
 	assert(mem_is_str(part) && mem_is_datetime(date));
@@ -1387,7 +1388,7 @@ sql_utf8_pattern_compare(const char *pattern,
  * is NULL then result is NULL as well.
  */
 static void
-likeFunc(sql_context *context, int argc, const struct Mem *argv)
+likeFunc(sql_context *context, int argc, const struct sql_mem *argv)
 {
 	u32 escape = SQL_END_OF_STRING;
 	int nPat;
@@ -1456,7 +1457,7 @@ likeFunc(sql_context *context, int argc, const struct Mem *argv)
  * single-quote escapes.
  */
 static void
-quoteFunc(struct sql_context *context, int argc, const struct Mem *argv)
+quoteFunc(struct sql_context *context, int argc, const struct sql_mem *argv)
 {
 	assert(argc == 1);
 	UNUSED_PARAMETER(argc);
@@ -1561,7 +1562,7 @@ quoteFunc(struct sql_context *context, int argc, const struct Mem *argv)
  * must be exact.  Collating sequences are not used.
  */
 static void
-replaceFunc(struct sql_context *context, int argc, const struct Mem *argv)
+replaceFunc(struct sql_context *context, int argc, const struct sql_mem *argv)
 {
 	const unsigned char *zStr;	/* The input string A */
 	const unsigned char *zPattern;	/* The pattern string B */
@@ -1625,7 +1626,7 @@ replaceFunc(struct sql_context *context, int argc, const struct Mem *argv)
  * soundex encoding of the string X.
  */
 static void
-soundexFunc(struct sql_context *context, int argc, const struct Mem *argv)
+soundexFunc(struct sql_context *context, int argc, const struct sql_mem *argv)
 {
 	(void) argc;
 	char zResult[8];
@@ -1698,7 +1699,7 @@ func_sql_builtin_call_stub(struct func *func, struct port *args,
 }
 
 static void
-sql_builtin_stub(sql_context *ctx, int argc, const struct Mem *argv)
+sql_builtin_stub(sql_context *ctx, int argc, const struct sql_mem *argv)
 {
 	(void) argc; (void) argv;
 	diag_set(ClientError, ER_SQL_EXECUTE,
@@ -1802,9 +1803,9 @@ struct sql_func_definition {
 	/** Type of the result of the implementation. */
 	enum field_type result;
 	/** Call implementation with given arguments. */
-	void (*call)(sql_context *ctx, int argc, const struct Mem *argv);
+	void (*call)(sql_context *ctx, int argc, const struct sql_mem *argv);
 	/** Call finalization function for this implementation. */
-	int (*finalize)(struct Mem *mem);
+	int (*finalize)(struct sql_mem *mem);
 };
 
 /**

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -262,7 +262,7 @@ mem_clear(struct Mem *mem)
 		frame->v->pDelFrame = frame;
 	}
 	mem->type = MEM_TYPE_NULL;
-	mem->flags = 0;
+	mem->group = MEM_GROUP_DATA;
 }
 
 void
@@ -299,7 +299,7 @@ mem_set_int(struct Mem *mem, int64_t value, bool is_neg)
 	mem_clear(mem);
 	mem->u.i = value;
 	mem->type = is_neg ? MEM_TYPE_INT : MEM_TYPE_UINT;
-	assert(mem->flags == 0);
+	assert(mem->group == MEM_GROUP_DATA);
 }
 
 void
@@ -308,7 +308,7 @@ mem_set_uint(struct Mem *mem, uint64_t value)
 	mem_clear(mem);
 	mem->u.u = value;
 	mem->type = MEM_TYPE_UINT;
-	assert(mem->flags == 0);
+	assert(mem->group == MEM_GROUP_DATA);
 }
 
 void
@@ -318,7 +318,7 @@ mem_set_nint(struct Mem *mem, int64_t value)
 	mem_clear(mem);
 	mem->u.i = value;
 	mem->type = MEM_TYPE_INT;
-	assert(mem->flags == 0);
+	assert(mem->group == MEM_GROUP_DATA);
 }
 
 void
@@ -327,14 +327,14 @@ mem_set_bool(struct Mem *mem, bool value)
 	mem_clear(mem);
 	mem->u.b = value;
 	mem->type = MEM_TYPE_BOOL;
-	assert(mem->flags == 0);
+	assert(mem->group == MEM_GROUP_DATA);
 }
 
 void
 mem_set_double(struct Mem *mem, double value)
 {
 	mem_clear(mem);
-	assert(mem->flags == 0);
+	assert(mem->group == MEM_GROUP_DATA);
 	if (sqlIsNaN(value))
 		return;
 	mem->u.r = value;
@@ -347,7 +347,7 @@ mem_set_dec(struct Mem *mem, const decimal_t *d)
 	mem_clear(mem);
 	mem->u.d = *d;
 	mem->type = MEM_TYPE_DEC;
-	assert(mem->flags == 0);
+	assert(mem->group == MEM_GROUP_DATA);
 }
 
 void
@@ -356,7 +356,7 @@ mem_set_uuid(struct Mem *mem, const struct tt_uuid *uuid)
 	mem_clear(mem);
 	mem->u.uuid = *uuid;
 	mem->type = MEM_TYPE_UUID;
-	assert(mem->flags == 0);
+	assert(mem->group == MEM_GROUP_DATA);
 }
 
 void
@@ -365,7 +365,7 @@ mem_set_datetime(struct Mem *mem, const struct datetime *dt)
 	mem_clear(mem);
 	mem->u.dt = *dt;
 	mem->type = MEM_TYPE_DATETIME;
-	assert(mem->flags == 0);
+	assert(mem->group == MEM_GROUP_DATA);
 }
 
 void
@@ -374,7 +374,7 @@ mem_set_interval(struct Mem *mem, const struct interval *itv)
 	mem_clear(mem);
 	mem->u.itv = *itv;
 	mem->type = MEM_TYPE_INTERVAL;
-	assert(mem->flags == 0);
+	assert(mem->group == MEM_GROUP_DATA);
 }
 
 void
@@ -384,7 +384,7 @@ mem_set_str(struct Mem *mem, char *value, uint32_t len)
 	mem->u.z = value;
 	mem->u.n = len;
 	mem->type = MEM_TYPE_STR;
-	assert(mem->flags == 0);
+	assert(mem->group == MEM_GROUP_DATA);
 }
 
 void
@@ -394,7 +394,7 @@ mem_set_str0(struct Mem *mem, char *value)
 	mem->u.z = value;
 	mem->u.n = strlen(value);
 	mem->type = MEM_TYPE_STR;
-	assert(mem->flags == 0);
+	assert(mem->group == MEM_GROUP_DATA);
 }
 
 static int
@@ -406,7 +406,7 @@ mem_copy_bytes(struct Mem *mem, const char *value, uint32_t size,
 		if (sqlVdbeMemGrow(mem, size, 1) != 0)
 			return -1;
 		mem->type = type;
-		mem->flags = 0;
+		mem->group = MEM_GROUP_DATA;
 		return 0;
 	}
 	mem_clear(mem);
@@ -415,7 +415,7 @@ mem_copy_bytes(struct Mem *mem, const char *value, uint32_t size,
 	memcpy(mem->u.z, value, size);
 	mem->u.n = size;
 	mem->type = type;
-	assert(mem->flags == 0);
+	assert(mem->group == MEM_GROUP_DATA);
 	return 0;
 }
 
@@ -442,7 +442,7 @@ mem_set_bin(struct Mem *mem, char *value, uint32_t size)
 	mem->u.z = value;
 	mem->u.n = size;
 	mem->type = MEM_TYPE_BIN;
-	assert(mem->flags == 0);
+	assert(mem->group == MEM_GROUP_DATA);
 }
 
 int
@@ -459,7 +459,7 @@ mem_set_map(struct Mem *mem, char *value, uint32_t size)
 	mem->u.z = value;
 	mem->u.n = size;
 	mem->type = MEM_TYPE_MAP;
-	assert(mem->flags == 0);
+	assert(mem->group == MEM_GROUP_DATA);
 }
 
 int
@@ -476,7 +476,7 @@ mem_set_array(struct Mem *mem, char *value, uint32_t size)
 	mem->u.z = value;
 	mem->u.n = size;
 	mem->type = MEM_TYPE_ARRAY;
-	assert(mem->flags == 0);
+	assert(mem->group == MEM_GROUP_DATA);
 }
 
 int
@@ -490,7 +490,7 @@ mem_set_invalid(struct Mem *mem)
 {
 	mem_clear(mem);
 	mem->type = MEM_TYPE_INVALID;
-	assert(mem->flags == 0);
+	assert(mem->group == MEM_GROUP_DATA);
 }
 
 void
@@ -498,7 +498,7 @@ mem_set_ptr(struct Mem *mem, void *ptr)
 {
 	mem_clear(mem);
 	mem->type = MEM_TYPE_PTR;
-	assert(mem->flags == 0);
+	assert(mem->group == MEM_GROUP_DATA);
 	mem->u.p = ptr;
 }
 
@@ -507,7 +507,7 @@ mem_set_frame(struct Mem *mem, struct VdbeFrame *frame)
 {
 	mem_clear(mem);
 	mem->type = MEM_TYPE_FRAME;
-	assert(mem->flags == 0);
+	assert(mem->group == MEM_GROUP_DATA);
 	mem->u.pFrame = frame;
 }
 
@@ -529,7 +529,7 @@ int_to_double(struct Mem *mem)
 		d = (double)mem->u.i;
 	mem->u.r = d;
 	mem->type = MEM_TYPE_DOUBLE;
-	mem->flags = 0;
+	mem->group = MEM_GROUP_DATA;
 	return 0;
 }
 
@@ -543,7 +543,7 @@ int_to_double_precise(struct Mem *mem)
 		return -1;
 	mem->u.r = d;
 	mem->type = MEM_TYPE_DOUBLE;
-	mem->flags = 0;
+	mem->group = MEM_GROUP_DATA;
 	return 0;
 }
 
@@ -560,7 +560,7 @@ int_to_double_forced(struct Mem *mem)
 	double d = (double)i;
 	mem->u.r = d;
 	mem->type = MEM_TYPE_DOUBLE;
-	mem->flags = 0;
+	mem->group = MEM_GROUP_DATA;
 	return CMP_OLD_NEW(i, d, int64_t);
 }
 
@@ -571,7 +571,7 @@ int_to_dec(struct Mem *mem)
 	int64_t i = mem->u.i;
 	decimal_from_int64(&mem->u.d, i);
 	mem->type = MEM_TYPE_DEC;
-	mem->flags = 0;
+	mem->group = MEM_GROUP_DATA;
 	return 0;
 }
 
@@ -584,7 +584,7 @@ uint_to_double_precise(struct Mem *mem)
 	if (d == (double)UINT64_MAX || mem->u.u != (uint64_t)d)
 		return -1;
 	mem->u.r = d;
-	mem->flags = 0;
+	mem->group = MEM_GROUP_DATA;
 	mem->type = MEM_TYPE_DOUBLE;
 	return 0;
 }
@@ -601,7 +601,7 @@ uint_to_double_forced(struct Mem *mem)
 	uint64_t u = mem->u.u;
 	double d = (double)u;
 	mem->u.r = d;
-	mem->flags = 0;
+	mem->group = MEM_GROUP_DATA;
 	mem->type = MEM_TYPE_DOUBLE;
 	return CMP_OLD_NEW(u, d, uint64_t);
 }
@@ -613,7 +613,7 @@ uint_to_dec(struct Mem *mem)
 	int64_t u = mem->u.u;
 	decimal_from_uint64(&mem->u.d, u);
 	mem->type = MEM_TYPE_DEC;
-	mem->flags = 0;
+	mem->group = MEM_GROUP_DATA;
 	return 0;
 }
 
@@ -634,7 +634,7 @@ str_to_bin(struct Mem *mem)
 {
 	assert(mem->type == MEM_TYPE_STR);
 	mem->type = MEM_TYPE_BIN;
-	mem->flags &= ~(MEM_Scalar | MEM_Any);
+	mem->group = MEM_GROUP_DATA;
 	return 0;
 }
 
@@ -681,7 +681,7 @@ bin_to_str(struct Mem *mem)
 {
 	assert(mem->type == MEM_TYPE_BIN);
 	mem->type = MEM_TYPE_STR;
-	mem->flags &= ~(MEM_Scalar | MEM_Any);
+	mem->group = MEM_GROUP_DATA;
 	return 0;
 }
 
@@ -766,13 +766,13 @@ double_to_int(struct Mem *mem)
 	if (d <= -1.0 && d >= (double)INT64_MIN) {
 		mem->u.i = (int64_t)d;
 		mem->type = MEM_TYPE_INT;
-		mem->flags = 0;
+		mem->group = MEM_GROUP_DATA;
 		return 0;
 	}
 	if (d > -1.0 && d < (double)UINT64_MAX) {
 		mem->u.u = (uint64_t)d;
 		mem->type = MEM_TYPE_UINT;
-		mem->flags = 0;
+		mem->group = MEM_GROUP_DATA;
 		return 0;
 	}
 	return -1;
@@ -786,13 +786,13 @@ double_to_int_precise(struct Mem *mem)
 	if (d <= -1.0 && d >= (double)INT64_MIN && (double)(int64_t)d == d) {
 		mem->u.i = (int64_t)d;
 		mem->type = MEM_TYPE_INT;
-		mem->flags = 0;
+		mem->group = MEM_GROUP_DATA;
 		return 0;
 	}
 	if (d > -1.0 && d < (double)UINT64_MAX && (double)(uint64_t)d == d) {
 		mem->u.u = (uint64_t)d;
 		mem->type = MEM_TYPE_UINT;
-		mem->flags = 0;
+		mem->group = MEM_GROUP_DATA;
 		return 0;
 	}
 	return -1;
@@ -831,7 +831,7 @@ double_to_int_forced(struct Mem *mem)
 	}
 	mem->u.i = i;
 	mem->type = type;
-	mem->flags = 0;
+	mem->group = MEM_GROUP_DATA;
 	return res;
 }
 
@@ -843,7 +843,7 @@ double_to_uint(struct Mem *mem)
 	if (d > -1.0 && d < (double)UINT64_MAX) {
 		mem->u.u = (uint64_t)d;
 		mem->type = MEM_TYPE_UINT;
-		mem->flags = 0;
+		mem->group = MEM_GROUP_DATA;
 		return 0;
 	}
 	return -1;
@@ -857,7 +857,7 @@ double_to_uint_precise(struct Mem *mem)
 	if (d > -1.0 && d < (double)UINT64_MAX && (double)(uint64_t)d == d) {
 		mem->u.u = (uint64_t)d;
 		mem->type = MEM_TYPE_UINT;
-		mem->flags = 0;
+		mem->group = MEM_GROUP_DATA;
 		return 0;
 	}
 	return -1;
@@ -887,7 +887,7 @@ double_to_uint_forced(struct Mem *mem)
 	}
 	mem->u.u = u;
 	mem->type = MEM_TYPE_UINT;
-	mem->flags = 0;
+	mem->group = MEM_GROUP_DATA;
 	return res;
 }
 
@@ -901,7 +901,7 @@ double_to_dec(struct Mem *mem)
 		return -1;
 	mem->u.d = dec;
 	mem->type = MEM_TYPE_DEC;
-	mem->flags = 0;
+	mem->group = MEM_GROUP_DATA;
 	return 0;
 }
 
@@ -916,7 +916,7 @@ double_to_dec_precise(struct Mem *mem)
 		return -1;
 	mem->u.d = dec;
 	mem->type = MEM_TYPE_DEC;
-	mem->flags = 0;
+	mem->group = MEM_GROUP_DATA;
 	return 0;
 }
 
@@ -931,7 +931,7 @@ double_to_dec_forced(struct Mem *mem)
 	assert(mem->type == MEM_TYPE_DOUBLE);
 	double d = mem->u.r;
 	mem->type = MEM_TYPE_DEC;
-	mem->flags = 0;
+	mem->group = MEM_GROUP_DATA;
 	if (d >= 1e38) {
 		const char *val = "99999999999999999999999999999999999999";
 		assert(strlen(val) == 38);
@@ -963,7 +963,7 @@ double_to_str0(struct Mem *mem)
 	sql_snprintf(BUF_SIZE, mem->u.z, "%!.15g", r);
 	mem->u.n = strlen(mem->u.z);
 	mem->type = MEM_TYPE_STR;
-	mem->flags = 0;
+	mem->group = MEM_GROUP_DATA;
 	return 0;
 }
 
@@ -978,7 +978,7 @@ dec_to_int(struct Mem *mem)
 		assert(i <= 0);
 		mem->u.i = i;
 		mem->type = i == 0 ? MEM_TYPE_UINT : MEM_TYPE_INT;
-		mem->flags = 0;
+		mem->group = MEM_GROUP_DATA;
 		return 0;
 	}
 	uint64_t u;
@@ -986,7 +986,7 @@ dec_to_int(struct Mem *mem)
 		return -1;
 	mem->u.u = u;
 	mem->type = MEM_TYPE_UINT;
-	mem->flags = 0;
+	mem->group = MEM_GROUP_DATA;
 	return 0;
 }
 
@@ -1006,7 +1006,7 @@ dec_to_int_forced(struct Mem *mem)
 	bool is_dec_int = decimal_is_int(&mem->u.d);
 	if (decimal_is_neg(&mem->u.d)) {
 		int64_t i;
-		mem->flags = 0;
+		mem->group = MEM_GROUP_DATA;
 		if (decimal_to_int64(&mem->u.d, &i) == NULL) {
 			mem->u.i = INT64_MIN;
 			mem->type = MEM_TYPE_INT;
@@ -1023,7 +1023,7 @@ dec_to_int_forced(struct Mem *mem)
 	}
 	uint64_t u;
 	mem->type = MEM_TYPE_UINT;
-	mem->flags = 0;
+	mem->group = MEM_GROUP_DATA;
 	if (decimal_to_uint64(&mem->u.d, &u) == NULL) {
 		mem->u.u = UINT64_MAX;
 		return 1;
@@ -1045,7 +1045,7 @@ dec_to_uint(struct Mem *mem)
 		return -1;
 	mem->u.u = u;
 	mem->type = MEM_TYPE_UINT;
-	mem->flags = 0;
+	mem->group = MEM_GROUP_DATA;
 	return 0;
 }
 
@@ -1064,7 +1064,7 @@ dec_to_uint_forced(struct Mem *mem)
 	assert(mem->type == MEM_TYPE_DEC);
 	uint64_t u;
 	mem->type = MEM_TYPE_UINT;
-	mem->flags = 0;
+	mem->group = MEM_GROUP_DATA;
 	if (decimal_to_uint64(&mem->u.d, &u) == NULL) {
 		if (decimal_is_neg(&mem->u.d)) {
 			mem->u.u = 0;
@@ -1092,7 +1092,7 @@ dec_to_double(struct Mem *mem)
 	double r = atof(decimal_str(&mem->u.d));
 	mem->u.r = r;
 	mem->type = MEM_TYPE_DOUBLE;
-	mem->flags = 0;
+	mem->group = MEM_GROUP_DATA;
 	return 0;
 }
 
@@ -1107,7 +1107,7 @@ dec_to_double_precise(struct Mem *mem)
 		return -1;
 	mem->u.r = r;
 	mem->type = MEM_TYPE_DOUBLE;
-	mem->flags = 0;
+	mem->group = MEM_GROUP_DATA;
 	return 0;
 }
 
@@ -1116,7 +1116,7 @@ dec_to_double_forced(struct Mem *mem)
 {
 	assert(mem->type == MEM_TYPE_DEC);
 	mem->type = MEM_TYPE_DOUBLE;
-	mem->flags = 0;
+	mem->group = MEM_GROUP_DATA;
 	double r = atof(decimal_str(&mem->u.d));
 	int res;
 	decimal_t d;
@@ -1215,7 +1215,7 @@ mem_to_int(struct Mem *mem)
 {
 	assert(mem->type < MEM_TYPE_INVALID);
 	if ((mem->type & (MEM_TYPE_INT | MEM_TYPE_UINT)) != 0) {
-		mem->flags = 0;
+		mem->group = MEM_GROUP_DATA;
 		return 0;
 	}
 	if (mem->type == MEM_TYPE_STR)
@@ -1232,7 +1232,7 @@ mem_to_int_precise(struct Mem *mem)
 {
 	assert(mem->type < MEM_TYPE_INVALID);
 	if ((mem->type & (MEM_TYPE_INT | MEM_TYPE_UINT)) != 0) {
-		mem->flags = 0;
+		mem->group = MEM_GROUP_DATA;
 		return 0;
 	}
 	if (mem->type == MEM_TYPE_STR)
@@ -1249,7 +1249,7 @@ mem_to_double(struct Mem *mem)
 {
 	assert(mem->type < MEM_TYPE_INVALID);
 	if (mem->type == MEM_TYPE_DOUBLE) {
-		mem->flags = 0;
+		mem->group = MEM_GROUP_DATA;
 		return 0;
 	}
 	if ((mem->type & (MEM_TYPE_INT | MEM_TYPE_UINT)) != 0)
@@ -1266,13 +1266,13 @@ mem_to_number(struct Mem *mem)
 {
 	assert(mem->type < MEM_TYPE_INVALID);
 	if (mem_is_num(mem)) {
-		mem->flags = MEM_Number;
+		mem->group = MEM_GROUP_NUMBER;
 		return 0;
 	}
 	if (mem->type == MEM_TYPE_STR) {
 		if (str_to_int(mem) != 0 && str_to_double(mem) != 0)
 			return -1;
-		mem->flags = MEM_Number;
+		mem->group = MEM_GROUP_NUMBER;
 		return 0;
 	}
 	return -1;
@@ -1284,7 +1284,7 @@ mem_to_str(struct Mem *mem)
 	assert(mem->type < MEM_TYPE_INVALID);
 	switch (mem->type) {
 	case MEM_TYPE_STR:
-		mem->flags &= ~(MEM_Scalar | MEM_Any);
+		mem->group = MEM_GROUP_DATA;
 		return 0;
 	case MEM_TYPE_INT:
 	case MEM_TYPE_UINT:
@@ -1317,7 +1317,7 @@ mem_cast_explicit(struct Mem *mem, enum field_type type)
 	case FIELD_TYPE_UNSIGNED:
 		switch (mem->type) {
 		case MEM_TYPE_UINT:
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 			return 0;
 		case MEM_TYPE_STR:
 			return str_to_uint(mem);
@@ -1337,7 +1337,7 @@ mem_cast_explicit(struct Mem *mem, enum field_type type)
 	case FIELD_TYPE_BOOLEAN:
 		switch (mem->type) {
 		case MEM_TYPE_BOOL:
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 			return 0;
 		case MEM_TYPE_STR:
 			return str_to_bool(mem);
@@ -1348,7 +1348,7 @@ mem_cast_explicit(struct Mem *mem, enum field_type type)
 		if (mem->type == MEM_TYPE_STR)
 			return str_to_bin(mem);
 		if (mem_is_bin(mem)) {
-			mem->flags &= ~(MEM_Scalar | MEM_Any);
+			mem->group = MEM_GROUP_DATA;
 			return 0;
 		}
 		if (mem->type == MEM_TYPE_UUID)
@@ -1367,14 +1367,14 @@ mem_cast_explicit(struct Mem *mem, enum field_type type)
 		case MEM_TYPE_DOUBLE:
 			return double_to_dec(mem);
 		case MEM_TYPE_DEC:
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 			return 0;
 		default:
 			return -1;
 		}
 	case FIELD_TYPE_UUID:
 		if (mem->type == MEM_TYPE_UUID) {
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 			return 0;
 		}
 		if (mem->type == MEM_TYPE_STR)
@@ -1389,35 +1389,33 @@ mem_cast_explicit(struct Mem *mem, enum field_type type)
 			return map_to_datetime(mem);
 		if (mem->type != MEM_TYPE_DATETIME)
 			return -1;
-		mem->flags = 0;
+		mem->group = MEM_GROUP_DATA;
 		return 0;
 	case FIELD_TYPE_INTERVAL:
 		if (mem->type == MEM_TYPE_MAP)
 			return map_to_interval(mem);
 		if (mem->type != MEM_TYPE_INTERVAL)
 			return -1;
-		mem->flags = 0;
+		mem->group = MEM_GROUP_DATA;
 		return 0;
 	case FIELD_TYPE_ARRAY:
 		if (mem->type != MEM_TYPE_ARRAY)
 			return -1;
-		mem->flags &= ~MEM_Any;
+		mem->group = MEM_GROUP_DATA;
 		return 0;
 	case FIELD_TYPE_MAP:
 		if (mem->type != MEM_TYPE_MAP)
 			return -1;
-		mem->flags &= ~MEM_Any;
+		mem->group = MEM_GROUP_DATA;
 		return 0;
 	case FIELD_TYPE_SCALAR:
 		if ((mem->type &
 		     (MEM_TYPE_MAP | MEM_TYPE_ARRAY | MEM_TYPE_INTERVAL)) != 0)
 			return -1;
-		mem->flags |= MEM_Scalar;
-		mem->flags &= ~(MEM_Number | MEM_Any);
+		mem->group = MEM_GROUP_SCALAR;
 		return 0;
 	case FIELD_TYPE_ANY:
-		mem->flags |= MEM_Any;
-		mem->flags &= ~(MEM_Number | MEM_Scalar);
+		mem->group = MEM_GROUP_ANY;
 		return 0;
 	default:
 		break;
@@ -1430,25 +1428,28 @@ mem_cast_implicit(struct Mem *mem, enum field_type type)
 {
 	if (mem->type == MEM_TYPE_NULL || type == field_type_MAX)
 		return 0;
-	if (mem_is_metatype(mem) && type != FIELD_TYPE_ANY) {
-		if ((mem->flags & MEM_Number) != 0) {
-			if (type != FIELD_TYPE_NUMBER &&
-			    type != FIELD_TYPE_SCALAR &&
-			    type != FIELD_TYPE_ANY)
-				return -1;
-		} else if ((mem->flags & MEM_Scalar) != 0) {
-			if (type != FIELD_TYPE_SCALAR &&
-			    type != FIELD_TYPE_ANY)
-				return -1;
-		} else {
-			if (type != FIELD_TYPE_ANY)
-				return -1;
-		}
+	if (type == FIELD_TYPE_ANY) {
+		mem->group = MEM_GROUP_ANY;
+		return 0;
+	}
+	switch (mem->group) {
+	case MEM_GROUP_ANY:
+		return -1;
+	case MEM_GROUP_SCALAR:
+		if (type != FIELD_TYPE_SCALAR)
+			return -1;
+		break;
+	case MEM_GROUP_NUMBER:
+		if (type != FIELD_TYPE_NUMBER && type != FIELD_TYPE_SCALAR)
+			return -1;
+		break;
+	default:
+		assert(mem->group == MEM_GROUP_DATA);
 	}
 	switch (type) {
 	case FIELD_TYPE_UNSIGNED:
 		if (mem->type == MEM_TYPE_UINT) {
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 			return 0;
 		}
 		if (mem->type == MEM_TYPE_DOUBLE)
@@ -1458,13 +1459,13 @@ mem_cast_implicit(struct Mem *mem, enum field_type type)
 		return -1;
 	case FIELD_TYPE_STRING:
 		if (mem->type == MEM_TYPE_STR) {
-			mem->flags &= ~(MEM_Scalar | MEM_Any);
+			mem->group = MEM_GROUP_DATA;
 			return 0;
 		}
 		return -1;
 	case FIELD_TYPE_DOUBLE:
 		if (mem->type == MEM_TYPE_DOUBLE) {
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 			return 0;
 		}
 		if (mem->type == MEM_TYPE_INT)
@@ -1476,7 +1477,7 @@ mem_cast_implicit(struct Mem *mem, enum field_type type)
 		return -1;
 	case FIELD_TYPE_INTEGER:
 		if ((mem->type & (MEM_TYPE_INT | MEM_TYPE_UINT)) != 0) {
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 			return 0;
 		}
 		if (mem->type == MEM_TYPE_DOUBLE)
@@ -1486,20 +1487,20 @@ mem_cast_implicit(struct Mem *mem, enum field_type type)
 		return -1;
 	case FIELD_TYPE_BOOLEAN:
 		if (mem->type == MEM_TYPE_BOOL) {
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 			return 0;
 		}
 		return -1;
 	case FIELD_TYPE_VARBINARY:
 		if (mem->type == MEM_TYPE_BIN) {
-			mem->flags &= ~(MEM_Scalar | MEM_Any);
+			mem->group = MEM_GROUP_DATA;
 			return 0;
 		}
 		return -1;
 	case FIELD_TYPE_NUMBER:
 		if (!mem_is_num(mem))
 			return -1;
-		mem->flags = MEM_Number;
+		mem->group = MEM_GROUP_NUMBER;
 		return 0;
 	case FIELD_TYPE_DECIMAL:
 		switch (mem->type) {
@@ -1510,7 +1511,7 @@ mem_cast_implicit(struct Mem *mem, enum field_type type)
 		case MEM_TYPE_DOUBLE:
 			return double_to_dec_precise(mem);
 		case MEM_TYPE_DEC:
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 			return 0;
 		default:
 			return -1;
@@ -1527,27 +1528,22 @@ mem_cast_implicit(struct Mem *mem, enum field_type type)
 		if ((mem->type &
 		     (MEM_TYPE_MAP | MEM_TYPE_ARRAY | MEM_TYPE_INTERVAL)) != 0)
 			return -1;
-		mem->flags |= MEM_Scalar;
-		mem->flags &= ~(MEM_Number | MEM_Any);
+		mem->group = MEM_GROUP_SCALAR;
 		return 0;
 	case FIELD_TYPE_UUID:
 		if (mem->type != MEM_TYPE_UUID)
 			return -1;
-		mem->flags = 0;
+		mem->group = MEM_GROUP_DATA;
 		return 0;
 	case FIELD_TYPE_DATETIME:
 		if (mem->type != MEM_TYPE_DATETIME)
 			return -1;
-		mem->flags = 0;
+		mem->group = MEM_GROUP_DATA;
 		return 0;
 	case FIELD_TYPE_INTERVAL:
 		if (mem->type != MEM_TYPE_INTERVAL)
 			return -1;
-		mem->flags = 0;
-		return 0;
-	case FIELD_TYPE_ANY:
-		mem->flags |= MEM_Any;
-		mem->flags &= ~(MEM_Number | MEM_Scalar);
+		mem->group = MEM_GROUP_DATA;
 		return 0;
 	default:
 		break;
@@ -1563,11 +1559,11 @@ mem_cast_implicit_number(struct Mem *mem, enum field_type type)
 	case FIELD_TYPE_UNSIGNED:
 		switch (mem->type) {
 		case MEM_TYPE_UINT:
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 			return 0;
 		case MEM_TYPE_INT:
 			mem->u.u = 0;
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 			mem->type = MEM_TYPE_UINT;
 			return -1;
 		case MEM_TYPE_DOUBLE:
@@ -1587,7 +1583,7 @@ mem_cast_implicit_number(struct Mem *mem, enum field_type type)
 		case MEM_TYPE_DEC:
 			return dec_to_double_forced(mem);
 		case MEM_TYPE_DOUBLE:
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 			return 0;
 		default:
 			unreachable();
@@ -1597,7 +1593,7 @@ mem_cast_implicit_number(struct Mem *mem, enum field_type type)
 		switch (mem->type) {
 		case MEM_TYPE_UINT:
 		case MEM_TYPE_INT:
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 			return 0;
 		case MEM_TYPE_DOUBLE:
 			return double_to_int_forced(mem);
@@ -1614,7 +1610,7 @@ mem_cast_implicit_number(struct Mem *mem, enum field_type type)
 		case MEM_TYPE_UINT:
 			return uint_to_dec(mem);
 		case MEM_TYPE_DEC:
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 			return 0;
 		case MEM_TYPE_DOUBLE:
 			return double_to_dec_forced(mem);
@@ -1805,7 +1801,7 @@ mem_copy(struct Mem *to, const struct Mem *from)
 	mem_clear(to);
 	to->u = from->u;
 	to->type = from->type;
-	to->flags = from->flags;
+	to->group = from->group;
 	to->u.n = from->u.n;
 	to->u.z = from->u.z;
 	if (!mem_is_ephemeral(from) && !mem_is_dynamic(from))
@@ -1815,7 +1811,7 @@ mem_copy(struct Mem *to, const struct Mem *from)
 	to->size = size;
 	memcpy(to->buf, to->u.z, to->u.n);
 	to->u.z = to->buf;
-	to->flags = 0;
+	to->group = MEM_GROUP_DATA;
 	return 0;
 }
 
@@ -1825,7 +1821,7 @@ mem_copy_as_ephemeral(struct Mem *to, const struct Mem *from)
 	mem_clear(to);
 	to->u = from->u;
 	to->type = from->type;
-	to->flags = from->flags;
+	to->group = from->group;
 	to->u.n = from->u.n;
 	to->u.z = from->u.z;
 	if (!mem_is_dynamic(from))
@@ -1840,7 +1836,7 @@ mem_move(struct Mem *to, struct Mem *from)
 	mem_destroy(to);
 	memcpy(to, from, sizeof(*to));
 	from->type = MEM_TYPE_NULL;
-	from->flags = 0;
+	from->group = MEM_GROUP_DATA;
 	from->size = 0;
 	from->buf = NULL;
 }
@@ -1902,7 +1898,7 @@ mem_concat(const struct Mem *a, const struct Mem *b, struct Mem *result)
 		return -1;
 
 	result->type = a->type;
-	result->flags = 0;
+	result->group = MEM_GROUP_DATA;
 	if (result != a)
 		memcpy(result->u.z, a->u.z, a->u.n);
 	memcpy(&result->u.z[a->u.n], b->u.z, b->u.n);
@@ -2649,7 +2645,8 @@ mem_cmp(const struct Mem *a, const struct Mem *b, int *result,
 			 "comparable type");
 		return -1;
 	}
-	if (((a->flags | b->flags) & MEM_Scalar) != 0) {
+	if (a->group == MEM_GROUP_SCALAR ||
+	    b->group == MEM_GROUP_SCALAR) {
 		*result = mem_cmp_scalar(a, b, coll);
 		return 0;
 	}
@@ -2687,12 +2684,16 @@ char *
 mem_type_to_str(const struct Mem *p)
 {
 	assert(p != NULL);
-	if ((p->flags & MEM_Any) != 0)
+	switch (p->group) {
+	case MEM_GROUP_ANY:
 		return "any";
-	if ((p->flags & MEM_Scalar) != 0)
+	case MEM_GROUP_SCALAR:
 		return "scalar";
-	if ((p->flags & MEM_Number) != 0)
+	case MEM_GROUP_NUMBER:
 		return "number";
+	default:
+		assert(p->group == MEM_GROUP_DATA);
+	}
 	switch (p->type) {
 	case MEM_TYPE_NULL:
 		return "NULL";
@@ -2820,7 +2821,7 @@ releaseMemArray(Mem * p, int N)
 		do {
 			mem_destroy(p);
 			p->type = MEM_TYPE_INVALID;
-			assert(p->flags == 0);
+			assert(p->group == MEM_GROUP_DATA);
 		} while ((++p) < pEnd);
 	}
 }
@@ -2893,14 +2894,14 @@ mem_from_mp_ephemeral(struct Mem *mem, const char *buf, uint32_t *len)
 				return -1;
 			}
 			mem->type = MEM_TYPE_UUID;
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 			break;
 		} else if (type == MP_DECIMAL) {
 			buf = svp;
 			if (mp_decode_decimal(&buf, &mem->u.d) == NULL)
 				return -1;
 			mem->type = MEM_TYPE_DEC;
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 			break;
 		} else if (type == MP_DATETIME) {
 			if (datetime_unpack(&buf, size, &mem->u.dt) == NULL) {
@@ -2909,7 +2910,7 @@ mem_from_mp_ephemeral(struct Mem *mem, const char *buf, uint32_t *len)
 				return -1;
 			}
 			mem->type = MEM_TYPE_DATETIME;
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 			break;
 		} else if (type == MP_INTERVAL) {
 			if (interval_unpack(&buf, size, &mem->u.itv) == NULL) {
@@ -2918,7 +2919,7 @@ mem_from_mp_ephemeral(struct Mem *mem, const char *buf, uint32_t *len)
 				return -1;
 			}
 			mem->type = MEM_TYPE_INTERVAL;
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 			break;
 		}
 		buf += size;
@@ -2930,26 +2931,26 @@ mem_from_mp_ephemeral(struct Mem *mem, const char *buf, uint32_t *len)
 	case MP_NIL: {
 		mp_decode_nil(&buf);
 		mem->type = MEM_TYPE_NULL;
-		mem->flags = 0;
+		mem->group = MEM_GROUP_DATA;
 		break;
 	}
 	case MP_BOOL: {
 		mem->u.b = mp_decode_bool(&buf);
 		mem->type = MEM_TYPE_BOOL;
-		mem->flags = 0;
+		mem->group = MEM_GROUP_DATA;
 		break;
 	}
 	case MP_UINT: {
 		uint64_t v = mp_decode_uint(&buf);
 		mem->u.u = v;
 		mem->type = MEM_TYPE_UINT;
-		mem->flags = 0;
+		mem->group = MEM_GROUP_DATA;
 		break;
 	}
 	case MP_INT: {
 		mem->u.i = mp_decode_int(&buf);
 		mem->type = MEM_TYPE_INT;
-		mem->flags = 0;
+		mem->group = MEM_GROUP_DATA;
 		break;
 	}
 	case MP_STR: {
@@ -2969,10 +2970,10 @@ install_blob:
 		mem->u.r = mp_decode_float(&buf);
 		if (sqlIsNaN(mem->u.r)) {
 			mem->type = MEM_TYPE_NULL;
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 		} else {
 			mem->type = MEM_TYPE_DOUBLE;
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 		}
 		break;
 	}
@@ -2980,10 +2981,10 @@ install_blob:
 		mem->u.r = mp_decode_double(&buf);
 		if (sqlIsNaN(mem->u.r)) {
 			mem->type = MEM_TYPE_NULL;
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 		} else {
 			mem->type = MEM_TYPE_DOUBLE;
-			mem->flags = 0;
+			mem->group = MEM_GROUP_DATA;
 		}
 		break;
 	}
@@ -3201,8 +3202,7 @@ mem_getitem(const struct Mem *mem, const struct Mem *keys, int count,
 	uint32_t len;
 	if (mem_from_mp(res, data, &len) != 0)
 		return -1;
-	res->flags |= MEM_Any;
-	assert((res->flags & (MEM_Number | MEM_Scalar)) == 0);
+	res->group = MEM_GROUP_ANY;
 	return 0;
 }
 
@@ -3364,11 +3364,11 @@ port_lua_get_vdbemem(struct port *base, uint32_t *size)
 		switch (field.type) {
 		case MP_BOOL:
 			val[i].type = MEM_TYPE_BOOL;
-			assert(val[i].flags == 0);
+			assert(val[i].group == MEM_GROUP_DATA);
 			val[i].u.b = field.bval;
 			break;
 		case MP_FLOAT:
-			assert(val[i].flags == 0);
+			assert(val[i].group == MEM_GROUP_DATA);
 			if (sqlIsNaN(field.fval)) {
 				val[i].type = MEM_TYPE_NULL;
 				break;
@@ -3377,7 +3377,7 @@ port_lua_get_vdbemem(struct port *base, uint32_t *size)
 			val[i].u.r = field.fval;
 			break;
 		case MP_DOUBLE:
-			assert(val[i].flags == 0);
+			assert(val[i].group == MEM_GROUP_DATA);
 			if (sqlIsNaN(field.dval)) {
 				val[i].type = MEM_TYPE_NULL;
 				break;
@@ -3387,12 +3387,12 @@ port_lua_get_vdbemem(struct port *base, uint32_t *size)
 			break;
 		case MP_INT:
 			val[i].type = MEM_TYPE_INT;
-			assert(val[i].flags == 0);
+			assert(val[i].group == MEM_GROUP_DATA);
 			val[i].u.i = field.ival;
 			break;
 		case MP_UINT:
 			val[i].type = MEM_TYPE_UINT;
-			assert(val[i].flags == 0);
+			assert(val[i].group == MEM_GROUP_DATA);
 			val[i].u.i = field.ival;
 			break;
 		case MP_STR:
@@ -3502,12 +3502,12 @@ port_c_get_vdbemem(struct port *base, uint32_t *size)
 		switch (mp_typeof(*data)) {
 		case MP_BOOL:
 			val[i].type = MEM_TYPE_BOOL;
-			assert(val[i].flags == 0);
+			assert(val[i].group == MEM_GROUP_DATA);
 			val[i].u.b = mp_decode_bool(&data);
 			break;
 		case MP_FLOAT:
 			d = mp_decode_float(&data);
-			assert(val[i].flags == 0);
+			assert(val[i].group == MEM_GROUP_DATA);
 			if (sqlIsNaN(d)) {
 				val[i].type = MEM_TYPE_NULL;
 				break;
@@ -3517,7 +3517,7 @@ port_c_get_vdbemem(struct port *base, uint32_t *size)
 			break;
 		case MP_DOUBLE:
 			d = mp_decode_double(&data);
-			assert(val[i].flags == 0);
+			assert(val[i].group == MEM_GROUP_DATA);
 			if (sqlIsNaN(d)) {
 				val[i].type = MEM_TYPE_NULL;
 				break;
@@ -3527,12 +3527,12 @@ port_c_get_vdbemem(struct port *base, uint32_t *size)
 			break;
 		case MP_INT:
 			val[i].type = MEM_TYPE_INT;
-			assert(val[i].flags == 0);
+			assert(val[i].group == MEM_GROUP_DATA);
 			val[i].u.i = mp_decode_int(&data);
 			break;
 		case MP_UINT:
 			val[i].type = MEM_TYPE_UINT;
-			assert(val[i].flags == 0);
+			assert(val[i].group == MEM_GROUP_DATA);
 			val[i].u.u = mp_decode_uint(&data);
 			break;
 		case MP_STR:

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -515,7 +515,7 @@ void
 mem_set_null_clear(struct Mem *mem)
 {
 	mem_clear(mem);
-	mem->flags = MEM_Cleared;
+	mem->is_cleared = true;
 }
 
 static inline int
@@ -2635,7 +2635,7 @@ mem_cmp(const struct Mem *a, const struct Mem *b, int *result,
 	enum mem_class class_b = mem_type_class(b->type);
 	if (mem_is_any_null(a, b)) {
 		*result = class_a - class_b;
-		if ((a->flags & b->flags & MEM_Cleared) != 0)
+		if (a->is_cleared && b->is_cleared)
 			*result = 1;
 		return 0;
 	}

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -2803,7 +2803,7 @@ sqlVdbeMemGrow(struct Mem *pMem, int n, int bPreserve)
  * Return 0 on success or -1 if unable to complete the resizing.
  */
 int
-sqlVdbeMemClearAndResize(Mem * pMem, int szNew)
+sqlVdbeMemClearAndResize(struct Mem *pMem, int szNew)
 {
 	assert(szNew > 0);
 	if (pMem->size < szNew) {
@@ -2814,28 +2814,16 @@ sqlVdbeMemClearAndResize(Mem * pMem, int szNew)
 }
 
 void
-releaseMemArray(Mem * p, int N)
+releaseMemArray(struct Mem *p, int N)
 {
 	if (p && N) {
-		Mem *pEnd = &p[N];
+		struct Mem *pEnd = &p[N];
 		do {
 			mem_destroy(p);
 			p->type = MEM_TYPE_INVALID;
 			assert(p->group == MEM_GROUP_DATA);
 		} while ((++p) < pEnd);
 	}
-}
-
-/*
- * Return true if the Mem object contains a TEXT or BLOB that is
- * too large - whose size exceeds SQL_MAX_LENGTH.
- */
-int
-sqlVdbeMemTooBig(Mem * p)
-{
-	if (mem_is_bytes(p))
-		return p->u.n > SQL_MAX_LENGTH;
-	return 0;
 }
 
 int

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -392,64 +392,24 @@ mem_set_interval(struct Mem *mem, const struct interval *itv)
 	assert(mem->flags == 0);
 }
 
-static inline void
-set_str_const(struct Mem *mem, char *value, uint32_t len, int alloc_type)
+void
+mem_set_str(struct Mem *mem, char *value, uint32_t len)
 {
-	assert((alloc_type & (MEM_Static | MEM_Ephem)) != 0);
 	mem_clear(mem);
 	mem->z = value;
 	mem->n = len;
 	mem->type = MEM_TYPE_STR;
-	mem->flags = alloc_type;
+	assert(mem->flags == 0);
 }
 
-static inline void
-set_str_dynamic(struct Mem *mem, char *value, uint32_t len, int alloc_type)
+void
+mem_set_str0(struct Mem *mem, char *value)
 {
-	assert(mem->szMalloc == 0 || value != mem->zMalloc);
-	mem_destroy(mem);
+	mem_clear(mem);
 	mem->z = value;
-	mem->n = len;
+	mem->n = strlen(value);
 	mem->type = MEM_TYPE_STR;
-	mem->flags = alloc_type;
-	mem->zMalloc = mem->z;
-	mem->szMalloc = len;
-}
-
-void
-mem_set_str_ephemeral(struct Mem *mem, char *value, uint32_t len)
-{
-	set_str_const(mem, value, len, MEM_Ephem);
-}
-
-void
-mem_set_str_static(struct Mem *mem, char *value, uint32_t len)
-{
-	set_str_const(mem, value, len, MEM_Static);
-}
-
-void
-mem_set_str_allocated(struct Mem *mem, char *value, uint32_t len)
-{
-	set_str_dynamic(mem, value, len, 0);
-}
-
-void
-mem_set_str0_ephemeral(struct Mem *mem, char *value)
-{
-	set_str_const(mem, value, strlen(value), MEM_Ephem);
-}
-
-void
-mem_set_str0_static(struct Mem *mem, char *value)
-{
-	set_str_const(mem, value, strlen(value), MEM_Static);
-}
-
-void
-mem_set_str0_allocated(struct Mem *mem, char *value)
-{
-	set_str_dynamic(mem, value, strlen(value), 0);
+	assert(mem->flags == 0);
 }
 
 static int
@@ -490,46 +450,14 @@ mem_copy_str0(struct Mem *mem, const char *value)
 	return 0;
 }
 
-static inline void
-set_bin_const(struct Mem *mem, char *value, uint32_t size, int alloc_type)
+void
+mem_set_bin(struct Mem *mem, char *value, uint32_t size)
 {
-	assert((alloc_type & (MEM_Static | MEM_Ephem)) != 0);
 	mem_clear(mem);
 	mem->z = value;
 	mem->n = size;
 	mem->type = MEM_TYPE_BIN;
-	mem->flags = alloc_type;
-}
-
-static inline void
-set_bin_dynamic(struct Mem *mem, char *value, uint32_t size, int alloc_type)
-{
-	assert(mem->szMalloc == 0 || value != mem->zMalloc);
-	mem_destroy(mem);
-	mem->z = value;
-	mem->n = size;
-	mem->type = MEM_TYPE_BIN;
-	mem->flags = alloc_type;
-	mem->zMalloc = mem->z;
-	mem->szMalloc = mem->n;
-}
-
-void
-mem_set_bin_ephemeral(struct Mem *mem, char *value, uint32_t size)
-{
-	set_bin_const(mem, value, size, MEM_Ephem);
-}
-
-void
-mem_set_bin_static(struct Mem *mem, char *value, uint32_t size)
-{
-	set_bin_const(mem, value, size, MEM_Static);
-}
-
-void
-mem_set_bin_allocated(struct Mem *mem, char *value, uint32_t size)
-{
-	set_bin_dynamic(mem, value, size, 0);
+	assert(mem->flags == 0);
 }
 
 int
@@ -538,36 +466,15 @@ mem_copy_bin(struct Mem *mem, const char *value, uint32_t size)
 	return mem_copy_bytes(mem, value, size, MEM_TYPE_BIN);
 }
 
-static inline void
-set_msgpack_value(struct Mem *mem, char *value, uint32_t size, int alloc_type,
-		  enum mem_type type)
-{
-	if (alloc_type == MEM_Ephem || alloc_type == MEM_Static)
-		set_bin_const(mem, value, size, alloc_type);
-	else
-		set_bin_dynamic(mem, value, size, alloc_type);
-	mem->type = type;
-}
-
 void
-mem_set_map_ephemeral(struct Mem *mem, char *value, uint32_t size)
+mem_set_map(struct Mem *mem, char *value, uint32_t size)
 {
 	assert(mp_typeof(*value) == MP_MAP);
-	set_msgpack_value(mem, value, size, MEM_Ephem, MEM_TYPE_MAP);
-}
-
-void
-mem_set_map_static(struct Mem *mem, char *value, uint32_t size)
-{
-	assert(mp_typeof(*value) == MP_MAP);
-	set_msgpack_value(mem, value, size, MEM_Static, MEM_TYPE_MAP);
-}
-
-void
-mem_set_map_allocated(struct Mem *mem, char *value, uint32_t size)
-{
-	assert(mp_typeof(*value) == MP_MAP);
-	set_msgpack_value(mem, value, size, 0, MEM_TYPE_MAP);
+	mem_clear(mem);
+	mem->z = value;
+	mem->n = size;
+	mem->type = MEM_TYPE_MAP;
+	assert(mem->flags == 0);
 }
 
 int
@@ -577,24 +484,14 @@ mem_copy_map(struct Mem *mem, const char *value, uint32_t size)
 }
 
 void
-mem_set_array_ephemeral(struct Mem *mem, char *value, uint32_t size)
+mem_set_array(struct Mem *mem, char *value, uint32_t size)
 {
 	assert(mp_typeof(*value) == MP_ARRAY);
-	set_msgpack_value(mem, value, size, MEM_Ephem, MEM_TYPE_ARRAY);
-}
-
-void
-mem_set_array_static(struct Mem *mem, char *value, uint32_t size)
-{
-	assert(mp_typeof(*value) == MP_ARRAY);
-	set_msgpack_value(mem, value, size, MEM_Static, MEM_TYPE_ARRAY);
-}
-
-void
-mem_set_array_allocated(struct Mem *mem, char *value, uint32_t size)
-{
-	assert(mp_typeof(*value) == MP_ARRAY);
-	set_msgpack_value(mem, value, size, 0, MEM_TYPE_ARRAY);
+	mem_clear(mem);
+	mem->z = value;
+	mem->n = size;
+	mem->type = MEM_TYPE_ARRAY;
+	assert(mem->flags == 0);
 }
 
 int
@@ -1924,9 +1821,7 @@ mem_copy(struct Mem *to, const struct Mem *from)
 	to->flags = from->flags;
 	to->n = from->n;
 	to->z = from->z;
-	if (!mem_is_bytes(to))
-		return 0;
-	if ((to->flags & MEM_Static) != 0)
+	if (!mem_is_ephemeral(from) && !mem_is_dynamic(from))
 		return 0;
 	size_t size = MAX(32, to->n);
 	to->zMalloc = sql_xrealloc(to->zMalloc, size);
@@ -1946,12 +1841,9 @@ mem_copy_as_ephemeral(struct Mem *to, const struct Mem *from)
 	to->flags = from->flags;
 	to->n = from->n;
 	to->z = from->z;
-	if (!mem_is_bytes(to))
+	if (!mem_is_dynamic(from))
 		return;
-	if ((to->flags & (MEM_Static | MEM_Ephem)) != 0)
-		return;
-	to->flags = 0;
-	to->flags |= MEM_Ephem;
+	to->flags = MEM_Ephem;
 	return;
 }
 
@@ -1973,8 +1865,7 @@ mem_append(struct Mem *mem, const char *value, uint32_t len)
 	if (len == 0)
 		return 0;
 	int new_size = mem->n + len;
-	if (((mem->flags & (MEM_Static | MEM_Ephem)) != 0) ||
-	    mem->szMalloc < new_size) {
+	if (!mem_is_dynamic(mem) || mem->szMalloc < new_size) {
 		/*
 		 * Force exponential buffer size growth to avoid having to call
 		 * this routine too often.
@@ -2882,38 +2773,9 @@ mem_mp_type(const struct Mem *mem)
 	return MP_NIL;
 }
 
-#ifdef SQL_DEBUG
-/*
- * Check invariants on a Mem object.
- *
- * This routine is intended for use inside of assert() statements, like
- * this:    assert( sqlVdbeCheckMemInvariants(pMem) );
- */
-int
-sqlVdbeCheckMemInvariants(Mem * p)
-{
-	/* If p holds a string or blob, the Mem.z must point to exactly
-	 * one of the following:
-	 *
-	 *   (1) Memory in Mem.zMalloc and managed by the Mem object
-	 *   (2) Memory to be freed using Mem.xDel
-	 *   (3) An ephemeral string or blob
-	 *   (4) A static string or blob
-	 */
-	if ((p->type & (MEM_TYPE_STR | MEM_TYPE_BIN)) != 0 && p->n > 0) {
-		assert(((p->szMalloc > 0 && p->z == p->zMalloc) ? 1 : 0) +
-		       ((p->flags & MEM_Ephem) != 0 ? 1 : 0) +
-		       ((p->flags & MEM_Static) != 0 ? 1 : 0) == 1);
-	}
-	return 1;
-}
-#endif
-
 static int
 sqlVdbeMemGrow(struct Mem *pMem, int n, int bPreserve)
 {
-	assert(sqlVdbeCheckMemInvariants(pMem));
-
 	/* If the bPreserve flag is set to true, then the memory cell must already
 	 * contain a valid string or blob value.
 	 */
@@ -2939,7 +2801,7 @@ sqlVdbeMemGrow(struct Mem *pMem, int n, int bPreserve)
 	}
 
 	pMem->z = pMem->zMalloc;
-	pMem->flags &= ~(MEM_Ephem | MEM_Static);
+	pMem->flags &= ~MEM_Ephem;
 	return 0;
 }
 
@@ -2971,7 +2833,6 @@ releaseMemArray(Mem * p, int N)
 	if (p && N) {
 		Mem *pEnd = &p[N];
 		do {
-			assert(sqlVdbeCheckMemInvariants(p));
 			mem_destroy(p);
 			p->type = MEM_TYPE_INVALID;
 			assert(p->flags == 0);

--- a/src/box/sql/mem.h
+++ b/src/box/sql/mem.h
@@ -106,7 +106,6 @@ struct Mem {
 /** MEM is of ANY meta-type. */
 #define MEM_Any       0x0004
 #define MEM_Cleared   0x0200	/* NULL set by OP_Null, not from data */
-#define MEM_Static    0x1000	/* Mem.z points to a static string */
 #define MEM_Ephem     0x2000	/* Mem.z points to an ephemeral string */
 
 static inline bool
@@ -233,21 +232,13 @@ mem_is_invalid(const struct Mem *mem)
 }
 
 static inline bool
-mem_is_static(const struct Mem *mem)
-{
-	assert(mem_is_bytes(mem));
-	return (mem->flags & MEM_Static) != 0;
-}
-
-static inline bool
 mem_is_ephemeral(const struct Mem *mem)
 {
-	assert(mem_is_bytes(mem));
-	return (mem->flags & MEM_Ephem) != 0;
+	return mem_is_bytes(mem) && (mem->flags & MEM_Ephem) != 0;
 }
 
 static inline bool
-mem_is_allocated(const struct Mem *mem)
+mem_is_dynamic(const struct Mem *mem)
 {
 	return mem_is_bytes(mem) && mem->z == mem->zMalloc;
 }
@@ -374,42 +365,13 @@ mem_set_datetime(struct Mem *mem, const struct datetime *dt);
 void
 mem_set_interval(struct Mem *mem, const struct interval *itv);
 
-/** Clear MEM and set it to STRING. The string belongs to another object. */
+/** Clear MEM and set it to STRING. */
 void
-mem_set_str_ephemeral(struct Mem *mem, char *value, uint32_t len);
+mem_set_str(struct Mem *mem, char *value, uint32_t len);
 
-/** Clear MEM and set it to STRING. The string is static. */
+/** Clear MEM and set it to NULL-terminated STRING. */
 void
-mem_set_str_static(struct Mem *mem, char *value, uint32_t len);
-
-/**
- * Clear MEM and set it to STRING. The string was allocated by another object
- * and passed to MEM. MEMs with this allocation type only deallocate the string
- * on destruction. Also, the memory may be reallocated if MEM is set to a
- * different value of this allocation type.
- */
-void
-mem_set_str_allocated(struct Mem *mem, char *value, uint32_t len);
-
-/**
- * Clear MEM and set it to NULL-terminated STRING. The string belongs to
- * another object.
- */
-void
-mem_set_str0_ephemeral(struct Mem *mem, char *value);
-
-/** Clear MEM and set it to NULL-terminated STRING. The string is static. */
-void
-mem_set_str0_static(struct Mem *mem, char *value);
-
-/**
- * Clear MEM and set it to NULL-terminated STRING. The string was allocated by
- * another object and passed to MEM. MEMs with this allocation type only
- * deallocate the string on destruction. Also, the memory may be reallocated if
- * MEM is set to a different value of this allocation type.
- */
-void
-mem_set_str0_allocated(struct Mem *mem, char *value);
+mem_set_str0(struct Mem *mem, char *value);
 
 /** Copy string to a newly allocated memory. The MEM type becomes STRING. */
 int
@@ -422,25 +384,9 @@ mem_copy_str(struct Mem *mem, const char *value, uint32_t len);
 int
 mem_copy_str0(struct Mem *mem, const char *value);
 
-/**
- * Clear MEM and set it to VARBINARY. The binary value belongs to another
- * object.
- */
+/** Clear MEM and set it to VARBINARY. */
 void
-mem_set_bin_ephemeral(struct Mem *mem, char *value, uint32_t size);
-
-/** Clear MEM and set it to VARBINARY. The binary value is static. */
-void
-mem_set_bin_static(struct Mem *mem, char *value, uint32_t size);
-
-/**
- * Clear MEM and set it to VARBINARY. The binary value was allocated by another
- * object and passed to MEM. MEMs with this allocation type only deallocate the
- * string on destruction. Also, the memory may be reallocated if MEM is set to a
- * different value of this allocation type.
- */
-void
-mem_set_bin_allocated(struct Mem *mem, char *value, uint32_t size);
+mem_set_bin(struct Mem *mem, char *value, uint32_t size);
 
 /**
  * Copy binary value to a newly allocated memory. The MEM type becomes
@@ -450,56 +396,21 @@ int
 mem_copy_bin(struct Mem *mem, const char *value, uint32_t size);
 
 /**
- * Clear MEM and set it to MAP. The binary value belongs to another object. The
- * binary value must be msgpack of MAP type.
+ * Clear MEM and set it to MAP. The binary value must be msgpack of MAP type.
  */
 void
-mem_set_map_ephemeral(struct Mem *mem, char *value, uint32_t size);
-
-/**
- * Clear MEM and set it to MAP. The binary value is static. The binary value
- * must be msgpack of MAP type.
- */
-void
-mem_set_map_static(struct Mem *mem, char *value, uint32_t size);
-
-/**
- * Clear MEM and set it to MAP. The binary value was allocated by another object
- * and passed to MEM. The binary value must be msgpack of MAP type. MEMs with
- * this allocation type only deallocate the string on destruction. Also, the
- * memory may be reallocated if MEM is set to a different value of this
- * allocation type.
- */
-void
-mem_set_map_allocated(struct Mem *mem, char *value, uint32_t size);
+mem_set_map(struct Mem *mem, char *value, uint32_t size);
 
 /** Copy MAP value to a newly allocated memory. The MEM type becomes MAP. */
 int
 mem_copy_map(struct Mem *mem, const char *value, uint32_t size);
 
 /**
- * Clear MEM and set it to ARRAY. The binary value belongs to another object.
- * The binary value must be msgpack of ARRAY type.
+ * Clear MEM and set it to ARRAY. The binary value must be msgpack of ARRAY
+ * type.
  */
 void
-mem_set_array_ephemeral(struct Mem *mem, char *value, uint32_t size);
-
-/**
- * Clear MEM and set it to ARRAY. The binary value is static. The binary value
- * must be msgpack of ARRAY type.
- */
-void
-mem_set_array_static(struct Mem *mem, char *value, uint32_t size);
-
-/**
- * Clear MEM and set it to ARRAY. The binary value was allocated by another
- * object and passed to MEM. The binary value must be msgpack of ARRAY type.
- * MEMs with this allocation type only deallocate the string on destruction.
- * Also, the memory may be reallocated if MEM is set to a different value of
- * this allocation type.
- */
-void
-mem_set_array_allocated(struct Mem *mem, char *value, uint32_t size);
+mem_set_array(struct Mem *mem, char *value, uint32_t size);
 
 /** Copy ARRAY value to a newly allocated memory. The MEM type becomes ARRAY. */
 int
@@ -527,6 +438,26 @@ mem_set_agg(struct Mem *mem, struct func *func, int size);
 /** Clear MEM and set it to special, "cleared", NULL. */
 void
 mem_set_null_clear(struct Mem *mem);
+
+static inline void
+mem_set_ephemeral(struct Mem *mem)
+{
+	mem->flags |= MEM_Ephem;
+}
+
+/**
+ * Make the MEM containing the variable length value manage the memory where the
+ * value is located.
+ */
+static inline void
+mem_set_dynamic(struct Mem *mem)
+{
+	if (!mem_is_bytes(mem))
+		return;
+	sql_xfree(mem->zMalloc);
+	mem->zMalloc = mem->z;
+	mem->szMalloc = mem->n;
+}
 
 /**
  * Copy content of MEM from one MEM to another. In case source MEM contains
@@ -845,8 +776,6 @@ enum mp_type
 mem_mp_type(const struct Mem *mem);
 
 #ifdef SQL_DEBUG
-int sqlVdbeCheckMemInvariants(struct Mem *);
-
 /*
  * Return true if a memory cell is not marked as invalid.  This macro
  * is for use inside assert() statements only.

--- a/src/box/sql/mem.h
+++ b/src/box/sql/mem.h
@@ -97,6 +97,8 @@ struct Mem {
 	 * another MEM.
 	 */
 	bool is_ephemeral;
+	/** Flag indicating NULL set by OP_Null, not from data. */
+	bool is_cleared;
 	u32 flags;		/* Some combination of MEM_Null, MEM_Str, MEM_Dyn, etc. */
 	/* The memory managed by this MEM. */
 	char *buf;
@@ -115,7 +117,6 @@ struct Mem {
 #define MEM_Scalar    0x0002
 /** MEM is of ANY meta-type. */
 #define MEM_Any       0x0004
-#define MEM_Cleared   0x0200	/* NULL set by OP_Null, not from data */
 
 static inline bool
 mem_is_null(const struct Mem *mem)
@@ -262,8 +263,8 @@ mem_is_trivial(const struct Mem *mem)
 static inline bool
 mem_is_cleared(const struct Mem *mem)
 {
-	assert((mem->flags & MEM_Cleared) == 0 || mem->type == MEM_TYPE_NULL);
-	return (mem->flags & MEM_Cleared) != 0;
+	assert(!mem->is_cleared || mem->type == MEM_TYPE_NULL);
+	return mem->is_cleared;
 }
 
 static inline bool

--- a/src/box/sql/mem.h
+++ b/src/box/sql/mem.h
@@ -40,7 +40,7 @@ struct region;
 struct mpstream;
 struct VdbeFrame;
 
-enum mem_type {
+enum sql_mem_type {
 	MEM_TYPE_NULL		= 1,
 	MEM_TYPE_UINT		= 1 << 1,
 	MEM_TYPE_INT		= 1 << 2,
@@ -66,39 +66,42 @@ enum sql_mem_group {
 	MEM_GROUP_ANY,
 };
 
-/*
- * Internally, the vdbe manipulates nearly all SQL values as Mem
- * structures. Each Mem struct may cache multiple representations (string,
- * integer etc.) of the same value.
- */
-struct Mem {
-	union MemValue {
-		double r;	/* Real value used when MEM_Real is set in flags */
-		i64 i;		/* Integer value used when MEM_Int is set in flags */
-		uint64_t u;	/* Unsigned integer used when MEM_UInt is set. */
-		bool b;         /* Boolean value used when MEM_Bool is set in flags */
-		void *p;	/* Generic pointer */
-		/**
-		 * A pointer to function implementation.
-		 * Used only when flags==MEM_Agg.
-		 */
-		struct func *func;
-		struct VdbeFrame *pFrame;	/* Used when flags==MEM_Frame */
-		struct tt_uuid uuid;
+/** Object that is used to store all value types managed by the VDBE. */
+struct sql_mem {
+	union sql_mem_value {
+		/** BOOLEAN value. */
+		bool b;
+		/** POINTER value. */
+		void *p;
+		/** DOUBLE value. */
+		double r;
+		/** Negative INTEGER value. */
+		int64_t i;
+		/** Unsigned INTEGER value. */
+		uint64_t u;
+		/** DECIMAL value. */
 		decimal_t d;
-		/** DATETIME value. */
-		struct datetime dt;
-		/** INTERVAL value. */
-		struct interval itv;
 		struct {
 			/** STRING, VARBINARY, MAP or ARRAY value. */
 			char *z;
 			/** Length of variable length value. */
 			size_t n;
 		};
+		/** DATETIME value. */
+		struct datetime dt;
+		/** UUID value. */
+		struct tt_uuid uuid;
+		/** INTERVAL value. */
+		struct interval itv;
+		/** FRAME value. */
+		struct VdbeFrame *frame;
 	} u;
+	/* The memory managed by this MEM. */
+	char *buf;
+	/* Size of the buf allocation. */
+	size_t size;
 	/** Type of the value this MEM contains. */
-	enum mem_type type;
+	enum sql_mem_type type;
 	/** DATA, NUMBER, SCALAR or ANY group. */
 	enum sql_mem_group group;
 	/**
@@ -108,188 +111,184 @@ struct Mem {
 	bool is_ephemeral;
 	/** Flag indicating NULL set by OP_Null, not from data. */
 	bool is_cleared;
-	/* The memory managed by this MEM. */
-	char *buf;
-	/* Size of the buf allocation. */
-	int size;
-	u32 uTemp;		/* Transient storage for serial_type in OP_MakeRecord */
 #ifdef SQL_DEBUG
-	struct Mem *pScopyFrom;	/* This Mem is a shallow copy of pScopyFrom */
-	void *pFiller;		/* So that sizeof(Mem) is a multiple of 8 */
+	/**
+	 * MEM that manages memory for variable length value of ephemeral MEM.
+	 */
+	struct sql_mem *copy_from;
 #endif
 };
 
 static inline bool
-mem_is_null(const struct Mem *mem)
+mem_is_null(const struct sql_mem *mem)
 {
 	return mem->type == MEM_TYPE_NULL;
 }
 
 static inline bool
-mem_is_uint(const struct Mem *mem)
+mem_is_uint(const struct sql_mem *mem)
 {
 	return mem->type == MEM_TYPE_UINT;
 }
 
 static inline bool
-mem_is_nint(const struct Mem *mem)
+mem_is_nint(const struct sql_mem *mem)
 {
 	return mem->type == MEM_TYPE_INT;
 }
 
 static inline bool
-mem_is_str(const struct Mem *mem)
+mem_is_str(const struct sql_mem *mem)
 {
 	return mem->type == MEM_TYPE_STR;
 }
 
 static inline bool
-mem_is_num(const struct Mem *mem)
+mem_is_num(const struct sql_mem *mem)
 {
-	enum mem_type type = mem->type;
-	return (type & (MEM_TYPE_UINT | MEM_TYPE_INT | MEM_TYPE_DOUBLE |
-			MEM_TYPE_DEC)) != 0;
+	return (mem->type & (MEM_TYPE_UINT | MEM_TYPE_INT | MEM_TYPE_DOUBLE |
+			     MEM_TYPE_DEC)) != 0;
 }
 
 static inline bool
-mem_is_any(const struct Mem *mem)
+mem_is_any(const struct sql_mem *mem)
 {
 	return mem->group == MEM_GROUP_ANY;
 }
 
 static inline bool
-mem_is_container(const struct Mem *mem)
+mem_is_container(const struct sql_mem *mem)
 {
 	return (mem->type & (MEM_TYPE_MAP | MEM_TYPE_ARRAY)) != 0;
 }
 
 static inline bool
-mem_is_metatype(const struct Mem *mem)
+mem_is_metatype(const struct sql_mem *mem)
 {
 	return mem->group != MEM_GROUP_DATA;
 }
 
 static inline bool
-mem_is_double(const struct Mem *mem)
+mem_is_double(const struct sql_mem *mem)
 {
 	return mem->type == MEM_TYPE_DOUBLE;
 }
 
 static inline bool
-mem_is_dec(const struct Mem *mem)
+mem_is_dec(const struct sql_mem *mem)
 {
 	return mem->type == MEM_TYPE_DEC;
 }
 
 static inline bool
-mem_is_int(const struct Mem *mem)
+mem_is_int(const struct sql_mem *mem)
 {
 	return (mem->type & (MEM_TYPE_UINT | MEM_TYPE_INT)) != 0;
 }
 
 static inline bool
-mem_is_bool(const struct Mem *mem)
+mem_is_bool(const struct sql_mem *mem)
 {
 	return mem->type == MEM_TYPE_BOOL;
 }
 
 static inline bool
-mem_is_bin(const struct Mem *mem)
+mem_is_bin(const struct sql_mem *mem)
 {
 	return mem->type == MEM_TYPE_BIN;
 }
 
 static inline bool
-mem_is_map(const struct Mem *mem)
+mem_is_map(const struct sql_mem *mem)
 {
 	return mem->type == MEM_TYPE_MAP;
 }
 
 static inline bool
-mem_is_array(const struct Mem *mem)
+mem_is_array(const struct sql_mem *mem)
 {
 	return mem->type == MEM_TYPE_ARRAY;
 }
 
 static inline bool
-mem_is_datetime(const struct Mem *mem)
+mem_is_datetime(const struct sql_mem *mem)
 {
 	return mem->type == MEM_TYPE_DATETIME;
 }
 
 static inline bool
-mem_is_interval(const struct Mem *mem)
+mem_is_interval(const struct sql_mem *mem)
 {
 	return mem->type == MEM_TYPE_INTERVAL;
 }
 
 static inline bool
-mem_is_bytes(const struct Mem *mem)
+mem_is_bytes(const struct sql_mem *mem)
 {
 	return (mem->type & (MEM_TYPE_BIN | MEM_TYPE_STR |
 			     MEM_TYPE_MAP | MEM_TYPE_ARRAY)) != 0;
 }
 
 static inline bool
-mem_is_frame(const struct Mem *mem)
+mem_is_frame(const struct sql_mem *mem)
 {
 	return mem->type == MEM_TYPE_FRAME;
 }
 
 static inline bool
-mem_is_invalid(const struct Mem *mem)
+mem_is_invalid(const struct sql_mem *mem)
 {
 	return mem->type == MEM_TYPE_INVALID;
 }
 
 static inline bool
-mem_is_ephemeral(const struct Mem *mem)
+mem_is_ephemeral(const struct sql_mem *mem)
 {
 	return mem_is_bytes(mem) && mem->is_ephemeral;
 }
 
 static inline bool
-mem_is_dynamic(const struct Mem *mem)
+mem_is_dynamic(const struct sql_mem *mem)
 {
 	return mem_is_bytes(mem) && mem->u.z == mem->buf;
 }
 
 /** Return TRUE if MEM does not need to be freed or destroyed. */
 static inline bool
-mem_is_trivial(const struct Mem *mem)
+mem_is_trivial(const struct sql_mem *mem)
 {
 	return mem->size == 0 && mem->type != MEM_TYPE_FRAME;
 }
 
 static inline bool
-mem_is_cleared(const struct Mem *mem)
+mem_is_cleared(const struct sql_mem *mem)
 {
 	assert(!mem->is_cleared || mem->type == MEM_TYPE_NULL);
 	return mem->is_cleared;
 }
 
 static inline bool
-mem_is_comparable(const struct Mem *mem)
+mem_is_comparable(const struct sql_mem *mem)
 {
 	uint32_t incmp = MEM_TYPE_ARRAY | MEM_TYPE_MAP | MEM_TYPE_INTERVAL;
 	return mem->group != MEM_GROUP_ANY && (mem->type & incmp) == 0;
 }
 
 static inline bool
-mem_is_same_type(const struct Mem *mem1, const struct Mem *mem2)
+mem_is_same_type(const struct sql_mem *mem1, const struct sql_mem *mem2)
 {
 	return mem1->type == mem2->type;
 }
 
 static inline bool
-mem_is_any_null(const struct Mem *mem1, const struct Mem *mem2)
+mem_is_any_null(const struct sql_mem *mem1, const struct sql_mem *mem2)
 {
 	return ((mem1->type| mem2->type) & MEM_TYPE_NULL) != 0;
 }
 
 /** Check if MEM is compatible with field type. */
 bool
-mem_is_field_compatible(const struct Mem *mem, enum field_type type);
+mem_is_field_compatible(const struct sql_mem *mem, enum field_type type);
 
 /**
  * Write a NULL-terminated string representation of a MEM to buf. Returns the
@@ -297,14 +296,14 @@ mem_is_field_compatible(const struct Mem *mem, enum field_type type);
  * value is equal to or greater than size, then the value has been truncated.
  */
 int
-mem_snprintf(char *buf, uint32_t size, const struct Mem *mem);
+mem_snprintf(char *buf, uint32_t size, const struct sql_mem *mem);
 
 /**
  * Returns a NULL-terminated string representation of a MEM. Memory for the
  * result was allocated using sql_xmalloc() and should be freed.
  */
 char *
-mem_strdup(const struct Mem *mem);
+mem_strdup(const struct sql_mem *mem);
 
 /**
  * Return a string that contains description of type and value of MEM. String is
@@ -313,11 +312,11 @@ mem_strdup(const struct Mem *mem);
  * description of errors.
  */
 const char *
-mem_str(const struct Mem *mem);
+mem_str(const struct sql_mem *mem);
 
 /** Initialize MEM and set NULL. */
 static inline void
-mem_create(struct Mem *mem)
+mem_create(struct sql_mem *mem)
 {
 	memset(mem, 0, sizeof(*mem));
 	mem->type = MEM_TYPE_NULL;
@@ -325,30 +324,30 @@ mem_create(struct Mem *mem)
 
 /** Free all allocated memory in MEM and set MEM to NULL. */
 void
-mem_destroy(struct Mem *mem);
+mem_destroy(struct sql_mem *mem);
 
 void
-mem_delete(struct Mem *);
+mem_delete(struct sql_mem *);
 
 /** Clear MEM and set it to NULL. */
 void
-mem_set_null(struct Mem *mem);
+mem_set_null(struct sql_mem *mem);
 
 /** Clear MEM and set it to INTEGER. */
 void
-mem_set_int(struct Mem *mem, int64_t value, bool is_neg);
+mem_set_int(struct sql_mem *mem, int64_t value, bool is_neg);
 
 /** Clear MEM and set it to UNSIGNED. */
 void
-mem_set_uint(struct Mem *mem, uint64_t value);
+mem_set_uint(struct sql_mem *mem, uint64_t value);
 
 /** Clear MEM and set it to NEGATIVE INTEGER. */
 void
-mem_set_nint(struct Mem *mem, int64_t value);
+mem_set_nint(struct sql_mem *mem, int64_t value);
 
 /** Clear MEM and set it to INT64. */
 static inline void
-mem_set_int64(struct Mem *mem, int64_t value)
+mem_set_int64(struct sql_mem *mem, int64_t value)
 {
 	if (value < 0)
 		mem_set_nint(mem, value);
@@ -358,104 +357,104 @@ mem_set_int64(struct Mem *mem, int64_t value)
 
 /** Clear MEM and set it to BOOLEAN. */
 void
-mem_set_bool(struct Mem *mem, bool value);
+mem_set_bool(struct sql_mem *mem, bool value);
 
 /** Clear MEM and set it to DOUBLE. */
 void
-mem_set_double(struct Mem *mem, double value);
+mem_set_double(struct sql_mem *mem, double value);
 
 /** Clear MEM and set it to UUID. */
 void
-mem_set_uuid(struct Mem *mem, const struct tt_uuid *uuid);
+mem_set_uuid(struct sql_mem *mem, const struct tt_uuid *uuid);
 
 /** Clear MEM and set it to DECIMAL. */
 void
-mem_set_dec(struct Mem *mem, const decimal_t *dec);
+mem_set_dec(struct sql_mem *mem, const decimal_t *dec);
 
 /** Clear MEM and set it to DATETIME. */
 void
-mem_set_datetime(struct Mem *mem, const struct datetime *dt);
+mem_set_datetime(struct sql_mem *mem, const struct datetime *dt);
 
 /** Clear MEM and set it to INTERVAL. */
 void
-mem_set_interval(struct Mem *mem, const struct interval *itv);
+mem_set_interval(struct sql_mem *mem, const struct interval *itv);
 
 /** Clear MEM and set it to STRING. */
 void
-mem_set_str(struct Mem *mem, char *value, uint32_t len);
+mem_set_str(struct sql_mem *mem, char *value, uint32_t len);
 
 /** Clear MEM and set it to NULL-terminated STRING. */
 void
-mem_set_str0(struct Mem *mem, char *value);
+mem_set_str0(struct sql_mem *mem, char *value);
 
 /** Copy string to a newly allocated memory. The MEM type becomes STRING. */
 int
-mem_copy_str(struct Mem *mem, const char *value, uint32_t len);
+mem_copy_str(struct sql_mem *mem, const char *value, uint32_t len);
 
 /**
  * Copy NULL-terminated string to a newly allocated memory. The MEM type becomes
  * STRING.
  */
 int
-mem_copy_str0(struct Mem *mem, const char *value);
+mem_copy_str0(struct sql_mem *mem, const char *value);
 
 /** Clear MEM and set it to VARBINARY. */
 void
-mem_set_bin(struct Mem *mem, char *value, uint32_t size);
+mem_set_bin(struct sql_mem *mem, char *value, uint32_t size);
 
 /**
  * Copy binary value to a newly allocated memory. The MEM type becomes
  * VARBINARY.
  */
 int
-mem_copy_bin(struct Mem *mem, const char *value, uint32_t size);
+mem_copy_bin(struct sql_mem *mem, const char *value, uint32_t size);
 
 /**
  * Clear MEM and set it to MAP. The binary value must be msgpack of MAP type.
  */
 void
-mem_set_map(struct Mem *mem, char *value, uint32_t size);
+mem_set_map(struct sql_mem *mem, char *value, uint32_t size);
 
 /** Copy MAP value to a newly allocated memory. The MEM type becomes MAP. */
 int
-mem_copy_map(struct Mem *mem, const char *value, uint32_t size);
+mem_copy_map(struct sql_mem *mem, const char *value, uint32_t size);
 
 /**
  * Clear MEM and set it to ARRAY. The binary value must be msgpack of ARRAY
  * type.
  */
 void
-mem_set_array(struct Mem *mem, char *value, uint32_t size);
+mem_set_array(struct sql_mem *mem, char *value, uint32_t size);
 
 /** Copy ARRAY value to a newly allocated memory. The MEM type becomes ARRAY. */
 int
-mem_copy_array(struct Mem *mem, const char *value, uint32_t size);
+mem_copy_array(struct sql_mem *mem, const char *value, uint32_t size);
 
 /** Clear MEM and set it to invalid state. */
 void
-mem_set_invalid(struct Mem *mem);
+mem_set_invalid(struct sql_mem *mem);
 
 /** Clear MEM and set pointer to be its value. */
 void
-mem_set_ptr(struct Mem *mem, void *ptr);
+mem_set_ptr(struct sql_mem *mem, void *ptr);
 
 /** Clear MEM and set frame to be its value. */
 void
-mem_set_frame(struct Mem *mem, struct VdbeFrame *frame);
+mem_set_frame(struct sql_mem *mem, struct VdbeFrame *frame);
 
 /**
  * Clear the MEM, set the function as its value, and allocate enough memory to
  * hold the accumulation structure for the aggregate function.
  */
 int
-mem_set_agg(struct Mem *mem, struct func *func, int size);
+mem_set_agg(struct sql_mem *mem, struct func *func, int size);
 
 /** Clear MEM and set it to special, "cleared", NULL. */
 void
-mem_set_null_clear(struct Mem *mem);
+mem_set_null_clear(struct sql_mem *mem);
 
 static inline void
-mem_set_ephemeral(struct Mem *mem)
+mem_set_ephemeral(struct sql_mem *mem)
 {
 	mem->is_ephemeral = true;
 }
@@ -465,7 +464,7 @@ mem_set_ephemeral(struct Mem *mem)
  * value is located.
  */
 static inline void
-mem_set_dynamic(struct Mem *mem)
+mem_set_dynamic(struct sql_mem *mem)
 {
 	if (!mem_is_bytes(mem))
 		return;
@@ -480,7 +479,7 @@ mem_set_dynamic(struct Mem *mem)
  * newly allocated by destination MEM memory.
  */
 int
-mem_copy(struct Mem *to, const struct Mem *from);
+mem_copy(struct sql_mem *to, const struct sql_mem *from);
 
 /**
  * Copy content of MEM from one MEM to another. In case source MEM contains
@@ -488,13 +487,13 @@ mem_copy(struct Mem *to, const struct Mem *from);
  * value with ephemeral allocation type.
  */
 void
-mem_copy_as_ephemeral(struct Mem *to, const struct Mem *from);
+mem_copy_as_ephemeral(struct sql_mem *to, const struct sql_mem *from);
 
 /**
  * Move all content of source MEM to destination MEM. Source MEM is set to NULL.
  */
 void
-mem_move(struct Mem *to, struct Mem *from);
+mem_move(struct sql_mem *to, struct sql_mem *from);
 
 /**
  * Append the given string to the end of the STRING or VARBINARY contained in
@@ -502,7 +501,7 @@ mem_move(struct Mem *to, struct Mem *from);
  * memory is allocated in an attempt to reduce the total number of allocations.
  */
 int
-mem_append(struct Mem *mem, const char *value, uint32_t len);
+mem_append(struct sql_mem *mem, const char *value, uint32_t len);
 
 /**
  * Concatenate strings or binaries from the first and the second MEMs and write
@@ -510,77 +509,84 @@ mem_append(struct Mem *mem, const char *value, uint32_t len);
  * result MEM is set to NULL even if the result MEM is actually the first MEM.
  */
 int
-mem_concat(const struct Mem *a, const struct Mem *b, struct Mem *result);
+mem_concat(const struct sql_mem *a, const struct sql_mem *b,
+	   struct sql_mem *result);
 
 /**
  * Add the first MEM to the second MEM and write the result to the third MEM.
  */
 int
-mem_add(const struct Mem *left, const struct Mem *right, struct Mem *result);
+mem_add(const struct sql_mem *left, const struct sql_mem *right,
+	struct sql_mem *result);
 
 /**
  * Subtract the second MEM from the first MEM and write the result to the third
  * MEM.
  */
 int
-mem_sub(const struct Mem *left, const struct Mem *right, struct Mem *result);
+mem_sub(const struct sql_mem *left, const struct sql_mem *right,
+	struct sql_mem *result);
 
 /**
  * Multiply the first MEM by the second MEM and write the result to the third
  * MEM.
  */
 int
-mem_mul(const struct Mem *left, const struct Mem *right, struct Mem *result);
+mem_mul(const struct sql_mem *left, const struct sql_mem *right,
+	struct sql_mem *result);
 
 /**
  * Divide the first MEM by the second MEM and write the result to the third
  * MEM.
  */
 int
-mem_div(const struct Mem *left, const struct Mem *right, struct Mem *result);
+mem_div(const struct sql_mem *left, const struct sql_mem *right,
+	struct sql_mem *result);
 
 /**
  * Divide the first MEM by the second MEM and write integer part of the result
  * to the third MEM.
  */
 int
-mem_rem(const struct Mem *left, const struct Mem *right, struct Mem *result);
+mem_rem(const struct sql_mem *left, const struct sql_mem *right,
+	struct sql_mem *result);
 
 /** Perform a bitwise AND for two MEMs and write the result to the third MEM. */
 int
-mem_bit_and(const struct Mem *left, const struct Mem *right,
-	    struct Mem *result);
+mem_bit_and(const struct sql_mem *left, const struct sql_mem *right,
+	    struct sql_mem *result);
 
 /** Perform a bitwise OR for two MEMs and write the result to the third MEM. */
 int
-mem_bit_or(const struct Mem *left, const struct Mem *right, struct Mem *result);
+mem_bit_or(const struct sql_mem *left, const struct sql_mem *right,
+	   struct sql_mem *result);
 
 /**
  * Perform a bitwise left shift for the first MEM by value from the second MEM
  * and write the result to the third MEM.
  */
 int
-mem_shift_left(const struct Mem *left, const struct Mem *right,
-	       struct Mem *result);
+mem_shift_left(const struct sql_mem *left, const struct sql_mem *right,
+	       struct sql_mem *result);
 
 /**
  * Perform a bitwise right shift for the first MEM by value from the second MEM
  * and write the result to the third MEM.
  */
 int
-mem_shift_right(const struct Mem *left, const struct Mem *right,
-		struct Mem *result);
+mem_shift_right(const struct sql_mem *left, const struct sql_mem *right,
+		struct sql_mem *result);
 
 /** Perform a bitwise NOT to the MEM and write the result to the second MEM. */
 int
-mem_bit_not(const struct Mem *mem, struct Mem *result);
+mem_bit_not(const struct sql_mem *mem, struct sql_mem *result);
 
 /**
  * Compare two MEMs using SCALAR rules and return the result of comparison. MEMs
  * should be scalars. Original MEMs are not changed.
  */
 int
-mem_cmp_scalar(const struct Mem *a, const struct Mem *b,
+mem_cmp_scalar(const struct sql_mem *a, const struct sql_mem *b,
 	       const struct coll *coll);
 
 /**
@@ -590,7 +596,7 @@ mem_cmp_scalar(const struct Mem *a, const struct Mem *b,
  * following the specified packed value.
  */
 int
-mem_cmp_msgpack(const struct Mem *a, const char **b, int *result,
+mem_cmp_msgpack(const struct sql_mem *a, const char **b, int *result,
 		const struct coll *coll);
 
 /**
@@ -598,7 +604,7 @@ mem_cmp_msgpack(const struct Mem *a, const char **b, int *result,
  * comparison. MEMs should be scalars. Original MEMs are not changed.
  */
 int
-mem_cmp(const struct Mem *a, const struct Mem *b, int *result,
+mem_cmp(const struct sql_mem *a, const struct sql_mem *b, int *result,
 	const struct coll *coll);
 
 /**
@@ -608,7 +614,7 @@ mem_cmp(const struct Mem *a, const struct Mem *b, int *result,
  * precision.
  */
 int
-mem_to_int(struct Mem *mem);
+mem_to_int(struct sql_mem *mem);
 
 /**
  * Convert the given MEM to INTEGER. This function and the function above define
@@ -617,21 +623,21 @@ mem_to_int(struct Mem *mem);
  * is lossless.
  */
 int
-mem_to_int_precise(struct Mem *mem);
+mem_to_int_precise(struct sql_mem *mem);
 
 /**
  * Convert the given MEM to DOUBLE. This function defines the rules that are
  * used to convert values of all other types to DOUBLE.
  */
 int
-mem_to_double(struct Mem *mem);
+mem_to_double(struct sql_mem *mem);
 
 /**
  * Convert the given MEM to NUMBER. This function defines the rules that are
  * used to convert values of all other types to NUMBER.
  */
 int
-mem_to_number(struct Mem *mem);
+mem_to_number(struct sql_mem *mem);
 
 /**
  * Convert the given MEM to STRING. This function and the function below define
@@ -640,15 +646,15 @@ mem_to_number(struct Mem *mem);
  * NULL-terminated.
  */
 int
-mem_to_str(struct Mem *mem);
+mem_to_str(struct sql_mem *mem);
 
 /** Convert the given MEM to given type according to explicit cast rules. */
 int
-mem_cast_explicit(struct Mem *mem, enum field_type type);
+mem_cast_explicit(struct sql_mem *mem, enum field_type type);
 
 /** Convert the given MEM to given type according to implicit cast rules. */
 int
-mem_cast_implicit(struct Mem *mem, enum field_type type);
+mem_cast_implicit(struct sql_mem *mem, enum field_type type);
 
 /**
  * Cast MEM with numeric value to given numeric type. Doesn't fail. The return
@@ -656,7 +662,7 @@ mem_cast_implicit(struct Mem *mem, enum field_type type);
  * original value is greater than the result, and 0 if the cast is precise.
  */
 int
-mem_cast_implicit_number(struct Mem *mem, enum field_type type);
+mem_cast_implicit_number(struct sql_mem *mem, enum field_type type);
 
 /**
  * Return value for MEM of INTEGER type. For MEM of all other types convert
@@ -664,7 +670,7 @@ mem_cast_implicit_number(struct Mem *mem, enum field_type type);
  * MEM is not changed.
  */
 int
-mem_get_int(const struct Mem *mem, int64_t *i, bool *is_neg);
+mem_get_int(const struct sql_mem *mem, int64_t *i, bool *is_neg);
 
 /**
  * Return value of MEM converted to int64_t. This function is not safe, since it
@@ -672,7 +678,7 @@ mem_get_int(const struct Mem *mem, int64_t *i, bool *is_neg);
  * Also it works incorrectly with integer values that are more than INT64_MAX.
  */
 static inline int64_t
-mem_get_int_unsafe(const struct Mem *mem)
+mem_get_int_unsafe(const struct sql_mem *mem)
 {
 	int64_t i;
 	bool is_neg;
@@ -687,14 +693,14 @@ mem_get_int_unsafe(const struct Mem *mem)
  * MEM is not changed.
  */
 int
-mem_get_uint(const struct Mem *mem, uint64_t *u);
+mem_get_uint(const struct sql_mem *mem, uint64_t *u);
 
 /**
  * Return value of MEM converted to uint64_t. This function is not safe, since it
  * returns 0 if mem_get_uint() fails. There is no proper handling for this case.
  */
 static inline uint64_t
-mem_get_uint_unsafe(const struct Mem *mem)
+mem_get_uint_unsafe(const struct sql_mem *mem)
 {
 	uint64_t u;
 	if (mem_get_uint(mem, &u) != 0)
@@ -708,7 +714,7 @@ mem_get_uint_unsafe(const struct Mem *mem)
  * MEM is not changed.
  */
 int
-mem_get_double(const struct Mem *mem, double *d);
+mem_get_double(const struct sql_mem *mem, double *d);
 
 /**
  * Return value of MEM converted to double. This function is not safe since
@@ -716,7 +722,7 @@ mem_get_double(const struct Mem *mem, double *d);
  * this case this functions returns 0.
  */
 static inline double
-mem_get_double_unsafe(const struct Mem *mem)
+mem_get_double_unsafe(const struct sql_mem *mem)
 {
 	double d;
 	if (mem_get_double(mem, &d) != 0)
@@ -730,7 +736,7 @@ mem_get_double_unsafe(const struct Mem *mem)
  * MEM is not changed.
  */
 int
-mem_get_bool(const struct Mem *mem, bool *b);
+mem_get_bool(const struct sql_mem *mem, bool *b);
 
 /**
  * Return value of MEM converted to boolean. This function is not safe since
@@ -738,7 +744,7 @@ mem_get_bool(const struct Mem *mem, bool *b);
  * this case this function returns FALSE.
  */
 static inline bool
-mem_get_bool_unsafe(const struct Mem *mem)
+mem_get_bool_unsafe(const struct sql_mem *mem)
 {
 	bool b;
 	if (mem_get_bool(mem, &b) != 0)
@@ -752,14 +758,14 @@ mem_get_bool_unsafe(const struct Mem *mem)
  * Original MEM is not changed.
  */
 int
-mem_get_bin(const struct Mem *mem, const char **s);
+mem_get_bin(const struct sql_mem *mem, const char **s);
 
 /**
  * Return length of value for MEM of STRING or VARBINARY type. Original MEM is
  * not changed.
  */
 int
-mem_len(const struct Mem *mem, uint32_t *len);
+mem_len(const struct sql_mem *mem, uint32_t *len);
 
 /**
  * Return length of value for MEM of STRING or VARBINARY type. This function is
@@ -767,7 +773,7 @@ mem_len(const struct Mem *mem, uint32_t *len);
  * error. In this case this function returns 0.
  */
 static inline int
-mem_len_unsafe(const struct Mem *mem)
+mem_len_unsafe(const struct sql_mem *mem)
 {
 	uint32_t len;
 	if (mem_len(mem, &len) != 0)
@@ -780,7 +786,7 @@ mem_len_unsafe(const struct Mem *mem)
  * error reporting.
  */
 char *
-mem_type_to_str(const struct Mem *p);
+mem_type_to_str(const struct sql_mem *p);
 
 /*
  * Return the MP_type of the value of the MEM.
@@ -788,7 +794,7 @@ mem_type_to_str(const struct Mem *p);
  * transparent memory cell.
  */
 enum mp_type
-mem_mp_type(const struct Mem *mem);
+mem_mp_type(const struct sql_mem *mem);
 
 #ifdef SQL_DEBUG
 /*
@@ -798,23 +804,28 @@ mem_mp_type(const struct Mem *mem);
 #define memIsValid(M)  ((M)->type != MEM_TYPE_INVALID)
 #endif
 
-int sqlVdbeMemClearAndResize(struct Mem * pMem, int n);
+/**
+ * Change the mem->buf allocation to be at least n bytes. If mem->buf already
+ * meets or exceeds the requested size, this routine is a no-op.
+ */
+int
+sqlVdbeMemClearAndResize(struct sql_mem *mem, int n);
 
 /*
  * Release an array of N Mem elements
  */
 void
-releaseMemArray(struct Mem *p, int N);
+releaseMemArray(struct sql_mem *p, int N);
 
 #define VdbeFrameMem(p) \
-	((struct Mem *)&((u8 *)p)[ROUND8(sizeof(struct VdbeFrame))])
+	((struct sql_mem *)&((u8 *)p)[ROUND8(sizeof(struct VdbeFrame))])
 
 /**
  * Return true if Mem contains a variable length with length value greater than
  * SQL_MAX_LENGTH.
  */
 static inline bool
-sqlVdbeMemTooBig(struct Mem *mem)
+sqlVdbeMemTooBig(struct sql_mem *mem)
 {
 	return mem_is_bytes(mem) ? mem->u.n > SQL_MAX_LENGTH : false;
 }
@@ -846,7 +857,7 @@ int sqlVdbeRecordCompareMsgpack(const void *key1,
  * @retval 0 on success.
  */
 int
-mem_from_mp_ephemeral(struct Mem *mem, const char *buf, uint32_t *len);
+mem_from_mp_ephemeral(struct sql_mem *mem, const char *buf, uint32_t *len);
 
 /**
  * Decode msgpack and save value into VDBE memory cell. String and binary string
@@ -859,7 +870,7 @@ mem_from_mp_ephemeral(struct Mem *mem, const char *buf, uint32_t *len);
  * @retval 0 on success.
  */
 int
-mem_from_mp(struct Mem *mem, const char *buf, uint32_t *len);
+mem_from_mp(struct sql_mem *mem, const char *buf, uint32_t *len);
 
 /**
  * Perform encoding of MEM to stream.
@@ -868,11 +879,11 @@ mem_from_mp(struct Mem *mem, const char *buf, uint32_t *len);
  * @param stream Initialized mpstream encoder object.
  */
 void
-mem_to_mpstream(const struct Mem *var, struct mpstream *stream);
+mem_to_mpstream(const struct sql_mem *var, struct mpstream *stream);
 
 /** Encode MEM as msgpack value on region. */
 char *
-mem_to_mp(const struct Mem *mem, uint32_t *size, struct region *region);
+mem_to_mp(const struct sql_mem *mem, uint32_t *size, struct region *region);
 
 /**
  * Encode array of MEMs as msgpack array on region.
@@ -885,7 +896,7 @@ mem_to_mp(const struct Mem *mem, uint32_t *size, struct region *region);
  * @retval Pointer to valid msgpack array on success.
  */
 char *
-mem_encode_array(const struct Mem *mems, uint32_t count, uint32_t *size,
+mem_encode_array(const struct sql_mem *mems, uint32_t count, uint32_t *size,
 		 struct region *region);
 
 /**
@@ -901,10 +912,10 @@ mem_encode_array(const struct Mem *mems, uint32_t count, uint32_t *size,
  * @retval Pointer to valid msgpack map on success.
  */
 char *
-mem_encode_map(const struct Mem *mems, uint32_t count, uint32_t *size,
+mem_encode_map(const struct sql_mem *mems, uint32_t count, uint32_t *size,
 	       struct region *region);
 
 /** Return a value from ANY, MAP, or ARRAY MEM using the MEM array as keys. */
 int
-mem_getitem(const struct Mem *mem, const struct Mem *keys, int count,
-	    struct Mem *res);
+mem_getitem(const struct sql_mem *mem, const struct sql_mem *keys, int count,
+	    struct sql_mem *res);

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -1194,7 +1194,7 @@ sql_space_tuple_log_count(struct space *space);
 struct UnpackedRecord {
 	/** Collation and sort-order information. */
 	struct key_def *key_def;
-	Mem *aMem;		/* Values */
+	struct Mem *aMem;		/* Values */
 	u16 nField;		/* Number of entries in apMem[] */
 	i8 default_rc;		/* Comparison result if keys are equal */
 	i8 r1;			/* Value to return if (lhs > rhs) */

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -521,19 +521,19 @@ sql_bind_null(struct Vdbe *v, int i);
 
 /** Perform string parameter binding for the sql statement. */
 int
-sql_bind_str_static(struct Vdbe *v, int i, const char *str, uint32_t len);
+sql_bind_str(struct Vdbe *v, int i, const char *str, uint32_t len);
 
 /** Perform binary string parameter binding for the sql statement. */
 int
-sql_bind_bin_static(struct Vdbe *v, int i, const char *str, uint32_t size);
+sql_bind_bin(struct Vdbe *v, int i, const char *str, uint32_t size);
 
 /** Perform array parameter binding for the sql statement. */
 int
-sql_bind_array_static(struct Vdbe *v, int i, const char *str, uint32_t size);
+sql_bind_array(struct Vdbe *v, int i, const char *str, uint32_t size);
 
 /** Perform map parameter binding for the sql statement. */
 int
-sql_bind_map_static(struct Vdbe *v, int i, const char *str, uint32_t size);
+sql_bind_map(struct Vdbe *v, int i, const char *str, uint32_t size);
 
 /** Perform UUID parameter binding for the sql statement. */
 int

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -1194,7 +1194,7 @@ sql_space_tuple_log_count(struct space *space);
 struct UnpackedRecord {
 	/** Collation and sort-order information. */
 	struct key_def *key_def;
-	struct Mem *aMem;		/* Values */
+	struct sql_mem *aMem;		/* Values */
 	u16 nField;		/* Number of entries in apMem[] */
 	i8 default_rc;		/* Comparison result if keys are equal */
 	i8 r1;			/* Value to return if (lhs > rhs) */
@@ -2423,7 +2423,7 @@ struct PrintfArguments {
 	int nArg;		/* Total number of arguments */
 	int nUsed;		/* Number of arguments used so far */
 	/** The argument values. */
-	const struct Mem *apArg;
+	const struct sql_mem *apArg;
 };
 
 void sqlVXPrintf(StrAccum *, const char *, va_list);
@@ -4261,12 +4261,13 @@ struct func_sql_builtin {
 	 * Access checks are redundant, because all SQL built-ins
 	 * are predefined and are executed on SQL privilege level.
 	 */
-	void (*call)(struct sql_context *ctx, int argc, const struct Mem *argv);
+	void (*call)(struct sql_context *ctx, int argc,
+		     const struct sql_mem *argv);
 	/**
 	 * A VDBE-memory-compatible finalize method
 	 * (is valid only for aggregate function).
 	 */
-	int (*finalize)(struct Mem *mem);
+	int (*finalize)(struct sql_mem *mem);
 };
 
 /**

--- a/src/box/sql/tarantoolInt.h
+++ b/src/box/sql/tarantoolInt.h
@@ -75,8 +75,14 @@ int tarantoolsqlReplace(struct space *space, const char *tuple,
 int
 tarantoolsqlDelete(struct BtCursor *pCur);
 
+/**
+ * Create a new Tarantool iterator and set it to the first entry found for the
+ * given key. The key is given as an array of MEMs. If the cursor already
+ * contains an iterator, it will be freed.
+ */
 int
-sql_cursor_seek(struct BtCursor *cur, struct Mem *mems, uint32_t len, int *res);
+sql_cursor_seek(struct BtCursor *cur, struct sql_mem *mems, uint32_t len,
+		int *res);
 
 /**
  * Delete entry from space by its key.

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -68,19 +68,19 @@
  * copies are not misused.
  */
 static void
-sqlVdbeMemAboutToChange(struct Vdbe *pVdbe, struct Mem *pMem)
+sqlVdbeMemAboutToChange(struct Vdbe *pVdbe, struct sql_mem *pMem)
 {
 	int i;
-	struct Mem *pX;
+	struct sql_mem *pX;
 	for (i = 0, pX = pVdbe->aMem; i < pVdbe->nMem; i++, pX++) {
 		if (mem_is_dynamic(pX)) {
-			if (pX->pScopyFrom == pMem) {
+			if (pX->copy_from == pMem) {
 				mem_set_invalid(pX);
-				pX->pScopyFrom = 0;
+				pX->copy_from = 0;
 			}
 		}
 	}
-	pMem->pScopyFrom = 0;
+	pMem->copy_from = 0;
 }
 
 # define memAboutToChange(P,M) sqlVdbeMemAboutToChange(P,M)
@@ -130,7 +130,7 @@ int sql_sort_count = 0;
 #ifdef SQL_TEST
 size_t sql_max_blobsize = 0;
 static void
-updateMaxBlobsize(struct Mem *p)
+updateMaxBlobsize(struct sql_mem *p)
 {
 	if (mem_is_bytes(p) && p->u.n > sql_max_blobsize)
 		sql_max_blobsize = p->u.n;
@@ -184,7 +184,7 @@ allocateCursor(
 	 * the top of the register space.  Cursor 1 is at Mem[p->nMem-1].
 	 * Cursor 2 is at Mem[p->nMem-2]. And so forth.
 	 */
-	struct Mem *pMem = iCur > 0 ? &p->aMem[p->nMem - iCur] : p->aMem;
+	struct sql_mem *pMem = iCur > 0 ? &p->aMem[p->nMem - iCur] : p->aMem;
 
 	VdbeCursor *pCx = 0;
 	int bt_offset = ROUND8(sizeof(VdbeCursor) + sizeof(uint32_t) * nField);
@@ -220,12 +220,12 @@ allocateCursor(
 #  define REGISTER_TRACE(P,R,M)
 #endif
 
-static struct Mem *
+static struct sql_mem *
 vdbe_prepare_null_out(struct Vdbe *v, int n)
 {
 	assert(n > 0);
 	assert(n <= (v->nMem + 1 - v->nCursor));
-	struct Mem *out = &v->aMem[n];
+	struct sql_mem *out = &v->aMem[n];
 	memAboutToChange(v, out);
 	mem_set_null(out);
 	return out;
@@ -346,7 +346,7 @@ vdbe_field_ref_fetch_data(struct vdbe_field_ref *field_ref, uint32_t fieldno)
  */
 static int
 vdbe_field_ref_fetch(struct vdbe_field_ref *field_ref, uint32_t fieldno,
-		     struct Mem *dest_mem)
+		     struct sql_mem *dest_mem)
 {
 	if (fieldno >= field_ref->field_count) {
 		UPDATE_MAX_BLOBSIZE(dest_mem);
@@ -375,11 +375,11 @@ int sqlVdbeExec(Vdbe *p)
 	/* The database */
 	struct sql *db = sql_get();
 	int iCompare = 0;          /* Result of last comparison */
-	struct Mem *aMem = p->aMem;       /* Copy of p->aMem */
-	struct Mem *pIn1 = 0;             /* 1st input operand */
-	struct Mem *pIn2 = 0;             /* 2nd input operand */
-	struct Mem *pIn3 = 0;             /* 3rd input operand */
-	struct Mem *pOut = 0;             /* Output operand */
+	struct sql_mem *aMem = p->aMem;       /* Copy of p->aMem */
+	struct sql_mem *pIn1 = 0;             /* 1st input operand */
+	struct sql_mem *pIn2 = 0;             /* 2nd input operand */
+	struct sql_mem *pIn3 = 0;             /* 3rd input operand */
+	struct sql_mem *pOut = 0;             /* Output operand */
 	int *aPermute = 0;         /* Permutation of columns for OP_Compare */
 	/*** INSERT STACK UNION HERE ***/
 
@@ -864,7 +864,7 @@ case OP_Blob: {                /* out2 */
  * The P4 value is used by sql_bind_parameter_name().
  */
 case OP_Variable: {            /* out2 */
-	struct Mem *pVar;       /* Value being transferred */
+	struct sql_mem *pVar;       /* Value being transferred */
 
 	assert(pOp->p1>0 && pOp->p1<=p->nVar);
 	assert(pOp->p4.z==0 || pOp->p4.z==sqlVListNumToName(p->pVList,pOp->p1));
@@ -958,7 +958,8 @@ case OP_SCopy: {            /* out2 */
 	assert(pOut!=pIn1);
 	mem_copy_as_ephemeral(pOut, pIn1);
 #ifdef SQL_DEBUG
-	if (pOut->pScopyFrom==0) pOut->pScopyFrom = pIn1;
+	if (pOut->copy_from == NULL)
+		pOut->copy_from = pIn1;
 #endif
 	break;
 }
@@ -983,7 +984,7 @@ case OP_ResultRow: {
 
 	p->pResultSet = &aMem[pOp->p1];
 #ifdef SQL_DEBUG
-	struct Mem *pMem = p->pResultSet;
+	struct sql_mem *pMem = p->pResultSet;
 	for (int i = 0; i < pOp->p2; i++) {
 		assert(memIsValid(&pMem[i]));
 		REGISTER_TRACE(p, pOp->p1+i, &pMem[i]);
@@ -1190,7 +1191,7 @@ case OP_FunctionByName: {
 	 */
 	enum field_type returns = func->def->returns;
 	int argc = pOp->p1;
-	struct Mem *argv = &aMem[pOp->p2];
+	struct sql_mem *argv = &aMem[pOp->p2];
 	struct port args, ret;
 
 	struct region *region = &fiber()->gc;
@@ -1201,7 +1202,7 @@ case OP_FunctionByName: {
 
 	pOut = vdbe_prepare_null_out(p, pOp->p3);
 	uint32_t size;
-	struct Mem *mem = (struct Mem *)port_get_vdbemem(&ret, &size);
+	struct sql_mem *mem = (struct sql_mem *)port_get_vdbemem(&ret, &size);
 	port_destroy(&ret);
 	if (mem == NULL) {
 		region_truncate(region, region_svp);
@@ -1411,7 +1412,7 @@ case OP_Map: {
 case OP_Getitem: {
 	int count = pOp->p1;
 	assert(count > 0);
-	struct Mem *value = &aMem[pOp->p3 + count];
+	struct sql_mem *value = &aMem[pOp->p3 + count];
 	if (mem_is_null(value)) {
 		diag_set(ClientError, ER_SQL_EXECUTE, "Selecting is not "
 			 "possible from NULL");
@@ -1424,7 +1425,7 @@ case OP_Getitem: {
 	}
 
 	pOut = &aMem[pOp->p2];
-	struct Mem *keys = &aMem[pOp->p3];
+	struct sql_mem *keys = &aMem[pOp->p3];
 	if (mem_getitem(value, keys, count, pOut) != 0)
 		goto abort_due_to_error;
 	break;
@@ -1656,8 +1657,8 @@ case OP_Compare: {
 		assert(i < (int)def->part_count);
 		struct coll *coll = def->parts[i].coll;
 		bool is_rev = def->parts[i].sort_order == SORT_ORDER_DESC;
-		struct Mem *a = &aMem[p1+idx];
-		struct Mem *b = &aMem[p2+idx];
+		struct sql_mem *a = &aMem[p1 + idx];
+		struct sql_mem *b = &aMem[p2 + idx];
 		if (!mem_is_comparable(a)) {
 			diag_set(ClientError, ER_SQL_TYPE_MISMATCH, mem_str(a),
 				 "comparable type");
@@ -1890,8 +1891,8 @@ case OP_Column: {
 	int p2;            /* column number to retrieve */
 	VdbeCursor *pC;    /* The VDBE cursor */
 	BtCursor *pCrsr = NULL; /* The BTree cursor */
-	struct Mem *pDest;        /* Where to write the extracted value */
-	struct Mem *pReg;         /* PseudoTable input register */
+	struct sql_mem *pDest;        /* Where to write the extracted value */
+	struct sql_mem *pReg;         /* PseudoTable input register */
 
 	pC = p->apCsr[pOp->p1];
 	p2 = pOp->p2;
@@ -1931,7 +1932,7 @@ case OP_Column: {
 	}
 	assert(pC->eCurType == CURTYPE_TARANTOOL ||
 	       pC->eCurType == CURTYPE_PSEUDO);
-	struct Mem *default_val_mem =
+	struct sql_mem *default_val_mem =
 		pOp->p4type == P4_MEM ? pOp->p4.pMem : NULL;
 	if (vdbe_field_ref_fetch(&pC->field_ref, p2, pDest) != 0)
 		goto abort_due_to_error;
@@ -1990,7 +1991,7 @@ case OP_FetchByName: {
 		assert(ref->field_count == 1);
 		id = 0;
 	}
-	struct Mem *res = vdbe_prepare_null_out(p, pOp->p3);
+	struct sql_mem *res = vdbe_prepare_null_out(p, pOp->p3);
 	if (vdbe_field_ref_fetch(ref, id, res) != 0)
 		goto abort_due_to_error;
 	REGISTER_TRACE(p, pOp->p3, res);
@@ -2005,7 +2006,7 @@ case OP_FetchByName: {
  */
 case OP_Fetch: {
 	struct vdbe_field_ref *ref = p->aMem[pOp->p1].u.p;
-	struct Mem *res = vdbe_prepare_null_out(p, pOp->p3);
+	struct sql_mem *res = vdbe_prepare_null_out(p, pOp->p3);
 	if (vdbe_field_ref_fetch(ref, pOp->p2, res) != 0)
 		goto abort_due_to_error;
 	REGISTER_TRACE(p, pOp->p3, res);
@@ -2050,7 +2051,7 @@ case OP_ApplyType: {
  */
 case OP_MakeRecord: {
 	/* First field to be combined into the record. */
-	struct Mem *pData0;
+	struct sql_mem *pData0;
 	int nField;            /* Number of fields in the record */
 	u8 bIsEphemeral;
 
@@ -2153,7 +2154,7 @@ case OP_Count: {         /* out2 */
  */
 case OP_CreateForeignKey: {
 	assert(pOp->p1 >= 0);
-	struct Mem *mems = &aMem[pOp->p1];
+	struct sql_mem *mems = &aMem[pOp->p1];
 	assert(mem_is_uint(&mems[0]) && mem_is_uint(&mems[1]));
 	uint32_t child_id = mems[0].u.u;
 	uint32_t parent_id = mems[1].u.u;
@@ -2584,11 +2585,11 @@ case OP_SeekGT: {       /* jump, in3 */
 	uint32_t len = pOp->p4.i;
 	assert(pOp->p4type == P4_INT32);
 	assert(len <= cur->key_def->part_count);
-	struct Mem *mems = &aMem[pOp->p3];
+	struct sql_mem *mems = &aMem[pOp->p3];
 	bool is_op_change = false;
 	for (uint32_t i = 0; i < len; ++i) {
 		enum field_type type = cur->key_def->parts[i].type;
-		struct Mem *mem = &mems[i];
+		struct sql_mem *mem = &mems[i];
 		if (mem_is_field_compatible(mem, type))
 			continue;
 		if (!sql_type_is_numeric(type) || !mem_is_num(mem)) {
@@ -2686,12 +2687,12 @@ case OP_SeekGE: {       /* jump, in3 */
 	uint32_t len = pOp->p4.i;
 	assert(pOp->p4type == P4_INT32);
 	assert(len <= cur->key_def->part_count);
-	struct Mem *mems = &aMem[pOp->p3];
+	struct sql_mem *mems = &aMem[pOp->p3];
 	bool is_op_change = false;
 	bool is_zero = false;
 	for (uint32_t i = 0; i < len; ++i) {
 		enum field_type type = cur->key_def->parts[i].type;
-		struct Mem *mem = &mems[i];
+		struct sql_mem *mem = &mems[i];
 		if (mem_is_field_compatible(mem, type))
 			continue;
 		if (!sql_type_is_numeric(type) || !mem_is_num(mem)) {
@@ -2900,7 +2901,7 @@ case OP_NextSystemSpaceId: {
 	assert(pOp->p1 >= 0 && pOp->p3 >= 0);
 	uint32_t space_id = pOp->p1;
 	assert(space_id == BOX_SEQUENCE_ID || space_id == BOX_FUNC_ID);
-	struct Mem *res = &p->aMem[pOp->p2];
+	struct sql_mem *res = &p->aMem[pOp->p2];
 	char key[1];
 	struct tuple *tuple;
 	char *key_end = mp_encode_array(key, 0);
@@ -2963,7 +2964,7 @@ case OP_NextIdEphemeral: {
  */
 case OP_FCopy: {     /* out2 */
 	VdbeFrame *pFrame;
-	struct Mem *pIn1, *pOut;
+	struct sql_mem *pIn1, *pOut;
 	if (p->pFrame && ((pOp->p3 & OPFLAG_SAME_FRAME) == 0)) {
 		for(pFrame=p->pFrame; pFrame->pParent; pFrame=pFrame->pParent);
 		pIn1 = &pFrame->aMem[pOp->p1];
@@ -3566,17 +3567,17 @@ case OP_IdxInsert: {
  *           raise an error.
  */
 case OP_Update: {
-	struct Mem *new_tuple = &aMem[pOp->p1];
+	struct sql_mem *new_tuple = &aMem[pOp->p1];
 	if (pOp->p5 & OPFLAG_NCHANGE)
 		p->nChange++;
 
 	struct space *space = aMem[pOp->p4.i].u.p;
 	assert(pOp->p4type == P4_INT32);
 
-	struct Mem *key_mem = &aMem[pOp->p2];
+	struct sql_mem *key_mem = &aMem[pOp->p2];
 	assert(mem_is_bin(key_mem));
 
-	struct Mem *upd_fields_mem = &aMem[pOp->p3];
+	struct sql_mem *upd_fields_mem = &aMem[pOp->p3];
 	assert(mem_is_bin(upd_fields_mem));
 	uint32_t *upd_fields = (uint32_t *)upd_fields_mem->u.z;
 	uint32_t upd_fields_cnt = upd_fields_mem->u.n / sizeof(uint32_t);
@@ -3962,11 +3963,11 @@ case OP_Program: {        /* jump */
 	int nMem;               /* Number of memory registers for sub-program */
 	int nByte;              /* Bytes of runtime space required for sub-program */
 	/* Register to allocate runtime space. */
-	struct Mem *pRt;
+	struct sql_mem *pRt;
 	/* Used to iterate through memory cells. */
-	struct Mem *pMem;
+	struct sql_mem *pMem;
 	/* Last memory cell in new array. */
-	struct Mem *pEnd;
+	struct sql_mem *pEnd;
 	VdbeFrame *pFrame;      /* New vdbe frame to execute in */
 	SubProgram *pProgram;   /* Sub-program to execute */
 	void *t;                /* Token identifying trigger */
@@ -4018,7 +4019,7 @@ case OP_Program: {        /* jump */
 		assert(nMem>0);
 		if (pProgram->nCsr==0) nMem++;
 		nByte = ROUND8(sizeof(VdbeFrame))
-			+ nMem * sizeof(struct Mem)
+			+ nMem * sizeof(struct sql_mem)
 			+ pProgram->nCsr * sizeof(VdbeCursor *);
 		pFrame = sql_xmalloc0(nByte);
 		mem_set_frame(pRt, pFrame);
@@ -4041,7 +4042,7 @@ case OP_Program: {        /* jump */
 			mem_set_invalid(pMem);
 		}
 	} else {
-		pFrame = pRt->u.pFrame;
+		pFrame = pRt->u.frame;
 		assert(pProgram->nMem+pProgram->nCsr==pFrame->nChildMem
 		       || (pProgram->nCsr==0 && pProgram->nMem+1==pFrame->nChildMem));
 		assert(pProgram->nCsr==pFrame->nChildCsr);
@@ -4079,7 +4080,7 @@ case OP_Program: {        /* jump */
  */
 case OP_Param: {           /* out2 */
 	VdbeFrame *pFrame;
-	struct Mem *pIn;
+	struct sql_mem *pIn;
 	pOut = vdbe_prepare_null_out(p, pOp->p2);
 	pFrame = p->pFrame;
 	pIn = &pFrame->aMem[pOp->p1 + pFrame->aOp[pFrame->pc].p1];
@@ -4196,7 +4197,7 @@ case OP_DecrJumpZero: {      /* jump, in1 */
 case OP_AggStep: {
 	int argc = pOp->p1;
 	sql_context *pCtx;
-	struct Mem *pMem;
+	struct sql_mem *pMem;
 
 	assert(pOp->p4type==P4_FUNCCTX);
 	pCtx = pOp->p4.pCtx;
@@ -4235,7 +4236,7 @@ case OP_AggStep: {
 case OP_AggFinal: {
 	assert(pOp->p1>0 && pOp->p1<=(p->nMem+1 - p->nCursor));
 	struct func_sql_builtin *func = (struct func_sql_builtin *)pOp->p4.func;
-	struct Mem *pIn1 = &aMem[pOp->p1];
+	struct sql_mem *pIn1 = &aMem[pOp->p1];
 
 	if (func->finalize != NULL && func->finalize(pIn1) != 0)
 		goto abort_due_to_error;

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -1947,12 +1947,13 @@ case OP_Column: {
 	/* Currently PSEUDO cursor does not have info about field types. */
 	if (pC->eCurType == CURTYPE_TARANTOOL)
 		field_type = pC->uc.pCursor->space->def->fields[p2].type;
+	assert(pDest->group == MEM_GROUP_DATA);
 	if (field_type == FIELD_TYPE_ANY)
-		pDest->flags |= MEM_Any;
+		pDest->group = MEM_GROUP_ANY;
 	else if (field_type == FIELD_TYPE_SCALAR)
-		pDest->flags |= MEM_Scalar;
+		pDest->group = MEM_GROUP_SCALAR;
 	else if (field_type == FIELD_TYPE_NUMBER)
-		pDest->flags |= MEM_Number;
+		pDest->group = MEM_GROUP_NUMBER;
 op_column_out:
 	REGISTER_TRACE(p, pOp->p3, pDest);
 	break;

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -3174,7 +3174,6 @@ case OP_RowData: {
 	}
 	sqlCursorPayload(pCrsr, 0, n, buf);
 	mem_set_bin(pOut, buf, n);
-	mem_set_ephemeral(pOut);
 	UPDATE_MAX_BLOBSIZE(pOut);
 	REGISTER_TRACE(p, pOp->p2, pOut);
 	break;
@@ -3491,8 +3490,6 @@ case OP_IdxInsert: {
 	struct space *space = aMem[pOp->p2].u.p;
 	assert(space != NULL);
 	if (space->def->id != 0) {
-		/* Make sure that memory has been allocated on region. */
-		assert(mem_is_ephemeral(&aMem[pOp->p1]));
 		if (pOp->opcode == OP_IdxInsert) {
 			rc = tarantoolsqlInsert(space, pIn2->z,
 						    pIn2->z + pIn2->n);

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -805,7 +805,7 @@ case OP_String: {          /* out2 */
  * is less than P2 (typically P3 is zero) then only register P2 is
  * set to NULL.
  *
- * If the P1 value is non-zero, then also set the MEM_Cleared flag so that
+ * If the P1 value is non-zero, then also set the is_cleared flag so that
  * NULL values will not compare equal even if SQL_NULLEQ is set on
  * OP_Ne or OP_Eq.
  */

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -68,10 +68,10 @@
  * copies are not misused.
  */
 static void
-sqlVdbeMemAboutToChange(Vdbe * pVdbe, Mem * pMem)
+sqlVdbeMemAboutToChange(struct Vdbe *pVdbe, struct Mem *pMem)
 {
 	int i;
-	Mem *pX;
+	struct Mem *pX;
 	for (i = 0, pX = pVdbe->aMem; i < pVdbe->nMem; i++, pX++) {
 		if (mem_is_dynamic(pX)) {
 			if (pX->pScopyFrom == pMem) {
@@ -130,7 +130,7 @@ int sql_sort_count = 0;
 #ifdef SQL_TEST
 size_t sql_max_blobsize = 0;
 static void
-updateMaxBlobsize(Mem *p)
+updateMaxBlobsize(struct Mem *p)
 {
 	if (mem_is_bytes(p) && p->u.n > sql_max_blobsize)
 		sql_max_blobsize = p->u.n;
@@ -184,7 +184,7 @@ allocateCursor(
 	 * the top of the register space.  Cursor 1 is at Mem[p->nMem-1].
 	 * Cursor 2 is at Mem[p->nMem-2]. And so forth.
 	 */
-	Mem *pMem = iCur>0 ? &p->aMem[p->nMem-iCur] : p->aMem;
+	struct Mem *pMem = iCur > 0 ? &p->aMem[p->nMem - iCur] : p->aMem;
 
 	VdbeCursor *pCx = 0;
 	int bt_offset = ROUND8(sizeof(VdbeCursor) + sizeof(uint32_t) * nField);
@@ -375,11 +375,11 @@ int sqlVdbeExec(Vdbe *p)
 	/* The database */
 	struct sql *db = sql_get();
 	int iCompare = 0;          /* Result of last comparison */
-	Mem *aMem = p->aMem;       /* Copy of p->aMem */
-	Mem *pIn1 = 0;             /* 1st input operand */
-	Mem *pIn2 = 0;             /* 2nd input operand */
-	Mem *pIn3 = 0;             /* 3rd input operand */
-	Mem *pOut = 0;             /* Output operand */
+	struct Mem *aMem = p->aMem;       /* Copy of p->aMem */
+	struct Mem *pIn1 = 0;             /* 1st input operand */
+	struct Mem *pIn2 = 0;             /* 2nd input operand */
+	struct Mem *pIn3 = 0;             /* 3rd input operand */
+	struct Mem *pOut = 0;             /* Output operand */
 	int *aPermute = 0;         /* Permutation of columns for OP_Compare */
 	/*** INSERT STACK UNION HERE ***/
 
@@ -864,7 +864,7 @@ case OP_Blob: {                /* out2 */
  * The P4 value is used by sql_bind_parameter_name().
  */
 case OP_Variable: {            /* out2 */
-	Mem *pVar;       /* Value being transferred */
+	struct Mem *pVar;       /* Value being transferred */
 
 	assert(pOp->p1>0 && pOp->p1<=p->nVar);
 	assert(pOp->p4.z==0 || pOp->p4.z==sqlVListNumToName(p->pVList,pOp->p1));
@@ -1890,8 +1890,8 @@ case OP_Column: {
 	int p2;            /* column number to retrieve */
 	VdbeCursor *pC;    /* The VDBE cursor */
 	BtCursor *pCrsr = NULL; /* The BTree cursor */
-	Mem *pDest;        /* Where to write the extracted value */
-	Mem *pReg;         /* PseudoTable input register */
+	struct Mem *pDest;        /* Where to write the extracted value */
+	struct Mem *pReg;         /* PseudoTable input register */
 
 	pC = p->apCsr[pOp->p1];
 	p2 = pOp->p2;
@@ -2049,7 +2049,8 @@ case OP_ApplyType: {
  * into ephemeral space. Thus, sort of memory optimization can be performed.
  */
 case OP_MakeRecord: {
-	Mem *pData0;           /* First field to be combined into the record */
+	/* First field to be combined into the record. */
+	struct Mem *pData0;
 	int nField;            /* Number of fields in the record */
 	u8 bIsEphemeral;
 
@@ -2962,7 +2963,7 @@ case OP_NextIdEphemeral: {
  */
 case OP_FCopy: {     /* out2 */
 	VdbeFrame *pFrame;
-	Mem *pIn1, *pOut;
+	struct Mem *pIn1, *pOut;
 	if (p->pFrame && ((pOp->p3 & OPFLAG_SAME_FRAME) == 0)) {
 		for(pFrame=p->pFrame; pFrame->pParent; pFrame=pFrame->pParent);
 		pIn1 = &pFrame->aMem[pOp->p1];
@@ -3960,9 +3961,12 @@ case OP_LoadAnalysis: {
 case OP_Program: {        /* jump */
 	int nMem;               /* Number of memory registers for sub-program */
 	int nByte;              /* Bytes of runtime space required for sub-program */
-	Mem *pRt;               /* Register to allocate runtime space */
-	Mem *pMem;              /* Used to iterate through memory cells */
-	Mem *pEnd;              /* Last memory cell in new array */
+	/* Register to allocate runtime space. */
+	struct Mem *pRt;
+	/* Used to iterate through memory cells. */
+	struct Mem *pMem;
+	/* Last memory cell in new array. */
+	struct Mem *pEnd;
 	VdbeFrame *pFrame;      /* New vdbe frame to execute in */
 	SubProgram *pProgram;   /* Sub-program to execute */
 	void *t;                /* Token identifying trigger */
@@ -4014,7 +4018,7 @@ case OP_Program: {        /* jump */
 		assert(nMem>0);
 		if (pProgram->nCsr==0) nMem++;
 		nByte = ROUND8(sizeof(VdbeFrame))
-			+ nMem * sizeof(Mem)
+			+ nMem * sizeof(struct Mem)
 			+ pProgram->nCsr * sizeof(VdbeCursor *);
 		pFrame = sql_xmalloc0(nByte);
 		mem_set_frame(pRt, pFrame);
@@ -4075,7 +4079,7 @@ case OP_Program: {        /* jump */
  */
 case OP_Param: {           /* out2 */
 	VdbeFrame *pFrame;
-	Mem *pIn;
+	struct Mem *pIn;
 	pOut = vdbe_prepare_null_out(p, pOp->p2);
 	pFrame = p->pFrame;
 	pIn = &pFrame->aMem[pOp->p1 + pFrame->aOp[pFrame->pc].p1];
@@ -4192,7 +4196,7 @@ case OP_DecrJumpZero: {      /* jump, in1 */
 case OP_AggStep: {
 	int argc = pOp->p1;
 	sql_context *pCtx;
-	Mem *pMem;
+	struct Mem *pMem;
 
 	assert(pOp->p4type==P4_FUNCCTX);
 	pCtx = pOp->p4.pCtx;

--- a/src/box/sql/vdbe.h
+++ b/src/box/sql/vdbe.h
@@ -78,7 +78,7 @@ struct VdbeOp {
 		struct func *func;
 		sql_context *pCtx;	/* Used when p4type is P4_FUNCCTX */
 		struct coll *pColl;	/* Used when p4type is P4_COLLSEQ */
-		struct Mem *pMem;	/* Used when p4type is P4_MEM */
+		struct sql_mem *pMem;	/* Used when p4type is P4_MEM */
 		bool b;         /* Used when p4type is P4_BOOL */
 		int *ai;	/* Used when p4type is P4_INTARRAY */
 		SubProgram *pProgram;	/* Used when p4type is P4_SUBPROGRAM */
@@ -249,7 +249,7 @@ vdbe_metadata_set_col_autoincrement(struct Vdbe *p, int idx);
 int
 vdbe_metadata_set_col_span(struct Vdbe *p, int idx, const char *span);
 
-const struct Mem *
+const struct sql_mem *
 vdbe_get_bound_value(struct Vdbe *vdbe, int id);
 
 void sqlVdbeCountChanges(Vdbe *);

--- a/src/box/sql/vdbe.h
+++ b/src/box/sql/vdbe.h
@@ -51,7 +51,6 @@ typedef struct Vdbe Vdbe;
  * The names of the following types declared in vdbeInt.h are required
  * for the VdbeOp definition.
  */
-typedef struct Mem Mem;
 typedef struct SubProgram SubProgram;
 
 /*
@@ -79,7 +78,7 @@ struct VdbeOp {
 		struct func *func;
 		sql_context *pCtx;	/* Used when p4type is P4_FUNCCTX */
 		struct coll *pColl;	/* Used when p4type is P4_COLLSEQ */
-		Mem *pMem;	/* Used when p4type is P4_MEM */
+		struct Mem *pMem;	/* Used when p4type is P4_MEM */
 		bool b;         /* Used when p4type is P4_BOOL */
 		int *ai;	/* Used when p4type is P4_INTARRAY */
 		SubProgram *pProgram;	/* Used when p4type is P4_SUBPROGRAM */

--- a/src/box/sql/vdbeInt.h
+++ b/src/box/sql/vdbeInt.h
@@ -378,11 +378,9 @@ int sqlVdbeSorterRewind(const VdbeCursor *, int *);
 int sqlVdbeSorterWrite(const VdbeCursor *, Mem *);
 int sqlVdbeSorterCompare(const VdbeCursor *, Mem *, int, int *);
 
-int sqlVdbeMemTranslate(Mem *, u8);
 #ifdef SQL_DEBUG
 void sqlVdbePrintSql(Vdbe *);
 #endif
-int sqlVdbeMemHandleBom(Mem * pMem);
 
 struct mpstream;
 struct region;

--- a/src/box/sql/vdbeInt.h
+++ b/src/box/sql/vdbeInt.h
@@ -143,7 +143,7 @@ struct VdbeFrame {
 	Op *aOp;		/* Program instructions for parent frame */
 	i64 *anExec;		/* Event counters from parent frame */
 	/* Array of memory cells for parent frame. */
-	struct Mem *aMem;
+	struct sql_mem *aMem;
 	VdbeCursor **apCsr;	/* Array of Vdbe cursors for parent frame */
 	void *token;		/* Copy of SubProgram.token */
 	int nCursor;		/* Number of entries in apCsr */
@@ -170,7 +170,7 @@ struct VdbeFrame {
  * (Mem) which are only defined there.
  */
 struct sql_context {
-	struct Mem *pOut;		/* The return value is stored here */
+	struct sql_mem *pOut;		/* The return value is stored here */
 	/* A pointer to function implementation. */
 	struct func *func;
 	struct coll *coll;
@@ -261,12 +261,12 @@ struct Vdbe {
 	 */
 
 	Op *aOp;		/* Space to hold the virtual machine's program */
-	struct Mem *aMem;		/* The memory locations */
+	struct sql_mem *aMem;		/* The memory locations */
 	/** SQL metadata for DML/DQL queries. */
 	struct sql_column_metadata *metadata;
-	struct Mem *pResultSet;	/* Pointer to an array of results */
+	struct sql_mem *pResultSet;	/* Pointer to an array of results */
 	VdbeCursor **apCsr;	/* One element of this array for each open cursor */
-	struct Mem *aVar;		/* Values for the OP_Variable opcode. */
+	struct sql_mem *aVar;		/* Values for the OP_Variable opcode. */
 	/**
 	 * Array which contains positions of variables to be
 	 * bound in resulting set of SELECT.
@@ -371,7 +371,7 @@ sqlVdbeSorterClose(struct VdbeCursor *pCsr);
 
 /** Copy the current sorter key into the memory cell. */
 int
-sqlVdbeSorterRowkey(const struct VdbeCursor *cur, struct Mem *res);
+sqlVdbeSorterRowkey(const struct VdbeCursor *cur, struct sql_mem *res);
 
 /** Advance to the next element in the sorter. */
 int
@@ -381,7 +381,7 @@ int sqlVdbeSorterRewind(const VdbeCursor *, int *);
 
 /** Add a record to the sorter. */
 int
-sqlVdbeSorterWrite(const struct VdbeCursor *cur, struct Mem *rec);
+sqlVdbeSorterWrite(const struct VdbeCursor *cur, struct sql_mem *rec);
 
 /**
  * Compare the value in MEM with the key that the sorter cursor passed as the
@@ -396,7 +396,7 @@ sqlVdbeSorterWrite(const struct VdbeCursor *cur, struct Mem *rec);
  * current sorter key.
  */
 int
-sqlVdbeSorterCompare(const struct VdbeCursor *cur, struct Mem *val,
+sqlVdbeSorterCompare(const struct VdbeCursor *cur, struct sql_mem *val,
 		     int column_count, int *result);
 
 #ifdef SQL_DEBUG

--- a/src/box/sql/vdbeapi.c
+++ b/src/box/sql/vdbeapi.c
@@ -247,9 +247,9 @@ sql_stmt_est_size(const struct Vdbe *v)
 	/* Opcodes */
 	size += sizeof(struct VdbeOp) * v->nOp;
 	/* Memory cells */
-	size += sizeof(struct Mem) * v->nMem;
+	size += sizeof(struct sql_mem) * v->nMem;
 	/* Bindings */
-	size += sizeof(struct Mem) * v->nVar;
+	size += sizeof(struct sql_mem) * v->nVar;
 	/* Bindings included in the result set */
 	size += sizeof(uint32_t) * v->res_var_count;
 	/* Cursors */
@@ -310,7 +310,7 @@ sql_stmt_query_str(const struct Vdbe *v)
 static int
 vdbeUnbind(struct Vdbe *p, int i)
 {
-	struct Mem *pVar;
+	struct sql_mem *pVar;
 	assert(p != NULL);
 	assert(p->magic == VDBE_MAGIC_RUN && p->pc < 0);
 	assert(i > 0);

--- a/src/box/sql/vdbeapi.c
+++ b/src/box/sql/vdbeapi.c
@@ -310,7 +310,7 @@ sql_stmt_query_str(const struct Vdbe *v)
 static int
 vdbeUnbind(struct Vdbe *p, int i)
 {
-	Mem *pVar;
+	struct Mem *pVar;
 	assert(p != NULL);
 	assert(p->magic == VDBE_MAGIC_RUN && p->pc < 0);
 	assert(i > 0);

--- a/src/box/sql/vdbeapi.c
+++ b/src/box/sql/vdbeapi.c
@@ -456,30 +456,30 @@ sql_bind_ptr(struct Vdbe *p, int i, void *ptr)
 }
 
 int
-sql_bind_str_static(struct Vdbe *vdbe, int i, const char *str, uint32_t len)
+sql_bind_str(struct Vdbe *vdbe, int i, const char *str, uint32_t len)
 {
-	mem_set_str_static(&vdbe->aVar[i - 1], (char *)str, len);
+	mem_set_str(&vdbe->aVar[i - 1], (char *)str, len);
 	return sql_bind_type(vdbe, i, "text");
 }
 
 int
-sql_bind_bin_static(struct Vdbe *vdbe, int i, const char *str, uint32_t size)
+sql_bind_bin(struct Vdbe *vdbe, int i, const char *str, uint32_t size)
 {
-	mem_set_bin_static(&vdbe->aVar[i - 1], (char *)str, size);
+	mem_set_bin(&vdbe->aVar[i - 1], (char *)str, size);
 	return sql_bind_type(vdbe, i, "text");
 }
 
 int
-sql_bind_array_static(struct Vdbe *vdbe, int i, const char *str, uint32_t size)
+sql_bind_array(struct Vdbe *vdbe, int i, const char *str, uint32_t size)
 {
-	mem_set_array_static(&vdbe->aVar[i - 1], (char *)str, size);
+	mem_set_array(&vdbe->aVar[i - 1], (char *)str, size);
 	return sql_bind_type(vdbe, i, "array");
 }
 
 int
-sql_bind_map_static(struct Vdbe *vdbe, int i, const char *str, uint32_t size)
+sql_bind_map(struct Vdbe *vdbe, int i, const char *str, uint32_t size)
 {
-	mem_set_map_static(&vdbe->aVar[i - 1], (char *)str, size);
+	mem_set_map(&vdbe->aVar[i - 1], (char *)str, size);
 	return sql_bind_type(vdbe, i, "map");
 }
 

--- a/src/box/sql/vdbeaux.c
+++ b/src/box/sql/vdbeaux.c
@@ -1199,7 +1199,7 @@ sqlVdbeList(Vdbe * p)
 			pMem++;
 
 			char *value = (char *)sqlOpcodeName(pOp->opcode);
-			mem_set_str0_static(pMem, value);
+			mem_set_str0(pMem, value);
 			pMem++;
 
 			/* When an OP_Program opcode is encounter (the only opcode that has
@@ -1240,22 +1240,26 @@ sqlVdbeList(Vdbe * p)
 		zP4 = displayP4(pOp, buf, 256);
 		if (zP4 != buf) {
 			sql_xfree(buf);
-			mem_set_str0_ephemeral(pMem, zP4);
+			mem_set_str0(pMem, zP4);
+			mem_set_ephemeral(pMem);
 		} else {
-			mem_set_str0_allocated(pMem, zP4);
+			mem_set_str0(pMem, zP4);
+			mem_set_dynamic(pMem);
 		}
 		pMem++;
 
 		if (p->explain == 1) {
 			buf = sql_xmalloc(4);
 			sql_snprintf(3, buf, "%.2x", pOp->p5);
-			mem_set_str0_allocated(pMem, buf);
+			mem_set_str0(pMem, buf);
+			mem_set_dynamic(pMem);
 			pMem++;
 
 #ifdef SQL_ENABLE_EXPLAIN_COMMENTS
 			buf = sql_xmalloc(500);
 			displayComment(pOp, zP4, buf, 500);
-			mem_set_str0_allocated(pMem, buf);
+			mem_set_str0(pMem, buf);
+			mem_set_dynamic(pMem);
 #else
 			mem_set_null(pMem);
 #endif

--- a/src/box/sql/vdbeaux.c
+++ b/src/box/sql/vdbeaux.c
@@ -1096,7 +1096,7 @@ void
 sqlVdbeFrameDelete(VdbeFrame * p)
 {
 	int i;
-	Mem *aMem = VdbeFrameMem(p);
+	struct Mem *aMem = VdbeFrameMem(p);
 	VdbeCursor **apCsr = (VdbeCursor **) & aMem[p->nChildMem];
 	for (i = 0; i < p->nChildCsr; i++)
 		sqlVdbeFreeCursor(apCsr[i]);
@@ -1125,10 +1125,10 @@ sqlVdbeList(Vdbe * p)
 	int nRow;		/* Stop when row count reaches this */
 	int nSub = 0;		/* Number of sub-vdbes seen so far */
 	SubProgram **apSub = 0;	/* Array of sub-vdbes */
-	Mem *pSub = 0;		/* Memory cell hold array of subprogs */
+	struct Mem *pSub = 0;		/* Memory cell hold array of subprogs */
 	int i;			/* Loop counter */
 	int rc = 0;	/* Return code */
-	Mem *pMem = &p->aMem[1];	/* First Mem of result set */
+	struct Mem *pMem = &p->aMem[1];	/* First Mem of result set */
 
 	assert(p->explain);
 	assert(p->magic == VDBE_MAGIC_RUN);
@@ -1440,8 +1440,8 @@ sqlVdbeMakeReady(Vdbe * p,	/* The VDBE */
 	 */
 	do {
 		x.nNeeded = 0;
-		p->aMem = allocSpace(&x, p->aMem, nMem * sizeof(Mem));
-		p->aVar = allocSpace(&x, p->aVar, nVar * sizeof(Mem));
+		p->aMem = allocSpace(&x, p->aMem, nMem * sizeof(struct Mem));
+		p->aVar = allocSpace(&x, p->aVar, nVar * sizeof(struct Mem));
 		p->apCsr =
 		    allocSpace(&x, p->apCsr, nCursor * sizeof(VdbeCursor *));
 		if (x.nNeeded == 0)
@@ -2017,11 +2017,11 @@ sqlVdbeAllocUnpackedRecord(struct key_def *key_def)
 {
 	UnpackedRecord *p;	/* Unpacked record to return */
 	int nByte;		/* Number of bytes required for *p */
-	nByte =
-	    ROUND8(sizeof(UnpackedRecord)) + sizeof(Mem) * (key_def->part_count +
-							    1);
+	nByte = ROUND8(sizeof(struct UnpackedRecord)) +
+		sizeof(struct Mem) * (key_def->part_count + 1);
 	p = sql_xmalloc(nByte);
-	p->aMem = (Mem *) & ((char *)p)[ROUND8(sizeof(UnpackedRecord))];
+	size_t idx = ROUND8(sizeof(struct UnpackedRecord));
+	p->aMem = (struct Mem *)&((char *)p)[idx];
 	for (uint32_t i = 0; i < key_def->part_count + 1; ++i)
 		mem_create(&p->aMem[i]);
 	p->key_def = key_def;
@@ -2077,7 +2077,7 @@ sqlVdbeRecordUnpackMsgpack(struct key_def *key_def,	/* Information about the rec
 {
 	uint32_t n;
 	const char *zParse = pKey;
-	Mem *pMem = p->aMem;
+	struct Mem *pMem = p->aMem;
 	n = mp_decode_array(&zParse);
 	n = p->nField = MIN(n, key_def->part_count);
 	p->default_rc = 0;

--- a/src/box/sql/vdbeaux.c
+++ b/src/box/sql/vdbeaux.c
@@ -1160,8 +1160,8 @@ sqlVdbeList(Vdbe * p)
 			/* On the first call to sql_step(), pSub will hold a NULL.  It is
 			 * initialized to a BLOB by the P4_SUBPROGRAM processing logic below
 			 */
-			nSub = pSub->n / sizeof(Vdbe *);
-			apSub = (SubProgram **) pSub->z;
+			nSub = pSub->u.n / sizeof(struct Vdbe *);
+			apSub = (struct SubProgram **)pSub->u.z;
 		}
 		for (i = 0; i < nSub; i++) {
 			nRow += apSub[i]->nOp;
@@ -2083,8 +2083,7 @@ sqlVdbeRecordUnpackMsgpack(struct key_def *key_def,	/* Information about the rec
 	p->default_rc = 0;
 	p->key_def = key_def;
 	while (n--) {
-		pMem->szMalloc = 0;
-		pMem->z = 0;
+		mem_destroy(pMem);
 		uint32_t sz = 0;
 		mem_from_mp_ephemeral(pMem, zParse, &sz);
 		assert(sz != 0);

--- a/src/box/sql/vdbeaux.c
+++ b/src/box/sql/vdbeaux.c
@@ -1238,14 +1238,11 @@ sqlVdbeList(Vdbe * p)
 
 		char *buf = sql_xmalloc(256);
 		zP4 = displayP4(pOp, buf, 256);
-		if (zP4 != buf) {
+		mem_set_str0(pMem, zP4);
+		if (zP4 != buf)
 			sql_xfree(buf);
-			mem_set_str0(pMem, zP4);
-			mem_set_ephemeral(pMem);
-		} else {
-			mem_set_str0(pMem, zP4);
+		else
 			mem_set_dynamic(pMem);
-		}
 		pMem++;
 
 		if (p->explain == 1) {

--- a/src/box/sql/vdbesort.c
+++ b/src/box/sql/vdbesort.c
@@ -1394,7 +1394,7 @@ sqlVdbeSorterWrite(const VdbeCursor * pCsr,	/* Sorter cursor */
 
 	assert(pCsr->eCurType == CURTYPE_SORTER);
 	pSorter = pCsr->uc.pSorter;
-	getVarint32((const u8 *)&pVal->z[1], t);
+	getVarint32((const u8 *)&pVal->u.z[1], t);
 	if (t > 0 && t < 10 && t != 7) {
 		pSorter->typeMask &= SORTER_TYPE_INTEGER;
 	} else if (t > 10 && (t & 0x01)) {
@@ -1418,8 +1418,8 @@ sqlVdbeSorterWrite(const VdbeCursor * pCsr,	/* Sorter cursor */
 	 *   * The total memory allocated for the in-memory list is greater
 	 *     than (page-size * cache-size), or
 	 */
-	nReq = pVal->n + sizeof(SorterRecord);
-	nPMA = pVal->n + sqlVarintLen(pVal->n);
+	nReq = pVal->u.n + sizeof(SorterRecord);
+	nPMA = pVal->u.n + sqlVarintLen(pVal->u.n);
 	if (pSorter->mxPmaSize) {
 		if (pSorter->list.aMemory) {
 			bFlush = pSorter->iMemory
@@ -1475,8 +1475,8 @@ sqlVdbeSorterWrite(const VdbeCursor * pCsr,	/* Sorter cursor */
 		pNew->u.pNext = pSorter->list.pList;
 	}
 
-	memcpy(SRVAL(pNew), pVal->z, pVal->n);
-	pNew->nVal = pVal->n;
+	memcpy(SRVAL(pNew), pVal->u.z, pVal->u.n);
+	pNew->nVal = pVal->u.n;
 	pSorter->list.pList = pNew;
 
 	return rc;
@@ -2109,11 +2109,8 @@ sqlVdbeSorterRowkey(const VdbeCursor * pCsr, Mem * pOut)
  * turn is used to verify uniqueness when constructing a UNIQUE INDEX.
  */
 int
-sqlVdbeSorterCompare(const VdbeCursor * pCsr,	/* Sorter cursor */
-			 Mem * pVal,	/* Value to compare to current sorter key */
-			 int nKeyCol,	/* Compare this many columns */
-			 int *pRes	/* OUT: Result of comparison */
-    )
+sqlVdbeSorterCompare(const struct VdbeCursor *pCsr, struct Mem *pVal,
+		     int nKeyCol, int *res)
 {
 	VdbeSorter *pSorter;
 	UnpackedRecord *r2;
@@ -2135,11 +2132,11 @@ sqlVdbeSorterCompare(const VdbeCursor * pCsr,	/* Sorter cursor */
 	sqlVdbeRecordUnpackMsgpack(pCsr->key_def, pKey, r2);
 	for (i = 0; i < nKeyCol; i++) {
 		if (mem_is_null(&r2->aMem[i])) {
-			*pRes = -1;
+			*res = -1;
 			return 0;
 		}
 	}
 
-	*pRes = sqlVdbeRecordCompareMsgpack(pVal->z, r2);
+	*res = sqlVdbeRecordCompareMsgpack(pVal->u.z, r2);
 	return 0;
 }

--- a/src/box/sql/vdbesort.c
+++ b/src/box/sql/vdbesort.c
@@ -1376,13 +1376,8 @@ vdbeSorterFlushPMA(VdbeSorter * pSorter)
 	return vdbeSorterListToPMA(&pSorter->aTask, &pSorter->list);
 }
 
-/*
- * Add a record to the sorter.
- */
 int
-sqlVdbeSorterWrite(const VdbeCursor * pCsr,	/* Sorter cursor */
-		       Mem * pVal	/* Memory cell containing record */
-    )
+sqlVdbeSorterWrite(const VdbeCursor *pCsr, struct Mem *pVal)
 {
 	VdbeSorter *pSorter;
 	int rc = 0;	/* Return Code */
@@ -2073,11 +2068,8 @@ vdbeSorterRowkey(const VdbeSorter * pSorter,	/* Sorter object */
 	return pKey;
 }
 
-/*
- * Copy the current sorter key into the memory cell pOut.
- */
 int
-sqlVdbeSorterRowkey(const VdbeCursor * pCsr, Mem * pOut)
+sqlVdbeSorterRowkey(const VdbeCursor *pCsr, struct Mem *pOut)
 {
 	VdbeSorter *pSorter;
 	void *pKey;
@@ -2092,22 +2084,6 @@ sqlVdbeSorterRowkey(const VdbeCursor * pCsr, Mem * pOut)
 	return 0;
 }
 
-/*
- * Compare the key in memory cell pVal with the key that the sorter cursor
- * passed as the first argument currently points to. For the purposes of
- * the comparison, ignore the rowid field at the end of each record.
- *
- * If the sorter cursor key contains any NULL values, consider it to be
- * less than pVal. Even if pVal also contains NULL values.
- *
- * If an error occurs, return -1.
- * Otherwise, set *pRes to a negative, zero or positive value if the
- * key in pVal is smaller than, equal to or larger than the current sorter
- * key.
- *
- * This routine forms the core of the OP_SorterCompare opcode, which in
- * turn is used to verify uniqueness when constructing a UNIQUE INDEX.
- */
 int
 sqlVdbeSorterCompare(const struct VdbeCursor *pCsr, struct Mem *pVal,
 		     int nKeyCol, int *res)

--- a/src/box/sql/vdbesort.c
+++ b/src/box/sql/vdbesort.c
@@ -1377,7 +1377,7 @@ vdbeSorterFlushPMA(VdbeSorter * pSorter)
 }
 
 int
-sqlVdbeSorterWrite(const VdbeCursor *pCsr, struct Mem *pVal)
+sqlVdbeSorterWrite(const VdbeCursor *pCsr, struct sql_mem *pVal)
 {
 	VdbeSorter *pSorter;
 	int rc = 0;	/* Return Code */
@@ -2069,7 +2069,7 @@ vdbeSorterRowkey(const VdbeSorter * pSorter,	/* Sorter object */
 }
 
 int
-sqlVdbeSorterRowkey(const VdbeCursor *pCsr, struct Mem *pOut)
+sqlVdbeSorterRowkey(const VdbeCursor *pCsr, struct sql_mem *pOut)
 {
 	VdbeSorter *pSorter;
 	void *pKey;
@@ -2085,7 +2085,7 @@ sqlVdbeSorterRowkey(const VdbeCursor *pCsr, struct Mem *pOut)
 }
 
 int
-sqlVdbeSorterCompare(const struct VdbeCursor *pCsr, struct Mem *pVal,
+sqlVdbeSorterCompare(const struct VdbeCursor *pCsr, struct sql_mem *pVal,
 		     int nKeyCol, int *res)
 {
 	VdbeSorter *pSorter;

--- a/src/box/sql/where.c
+++ b/src/box/sql/where.c
@@ -1234,11 +1234,11 @@ whereRangeSkipScanEst(Parse * pParse,		/* Parsing & code generating context */
 	enum field_type type = p->key_def->parts[nEq].type;
 
 	/* Value extracted from pLower */
-	struct Mem *p1 = NULL;
+	struct sql_mem *p1 = NULL;
 	/* Value extracted from pUpper */
-	struct Mem *p2 = NULL;
+	struct sql_mem *p2 = NULL;
 	/* Value extracted from record */
-	struct Mem *pVal = NULL;
+	struct sql_mem *pVal = NULL;
 
 	struct coll *coll = p->key_def->parts[nEq].coll;
 	if (pLower) {

--- a/src/box/sql/whereexpr.c
+++ b/src/box/sql/whereexpr.c
@@ -298,14 +298,14 @@ like_optimization_is_valid(Parse *pParse, Expr *pExpr, Expr **ppPrefix,
 		int iCol = pRight->iColumn;
 		const struct Mem *var = vdbe_get_bound_value(pReprepare, iCol);
 		if (var != NULL && mem_is_str(var)) {
-			uint32_t size = var->n + 1;
+			uint32_t size = var->u.n + 1;
 			char *str = region_alloc(region, size);
 			if (str == NULL) {
 				diag_set(OutOfMemory, size, "region", "str");
 				return -1;
 			}
-			memcpy(str, var->z, var->n);
-			str[var->n] = '\0';
+			memcpy(str, var->u.z, var->u.n);
+			str[var->u.n] = '\0';
 			z = str;
 		}
 		assert(pRight->op == TK_VARIABLE || pRight->op == TK_REGISTER);

--- a/src/box/sql/whereexpr.c
+++ b/src/box/sql/whereexpr.c
@@ -296,7 +296,8 @@ like_optimization_is_valid(Parse *pParse, Expr *pExpr, Expr **ppPrefix,
 	if (op == TK_VARIABLE) {
 		Vdbe *pReprepare = pParse->pReprepare;
 		int iCol = pRight->iColumn;
-		const struct Mem *var = vdbe_get_bound_value(pReprepare, iCol);
+		const struct sql_mem *var = vdbe_get_bound_value(pReprepare,
+								 iCol);
 		if (var != NULL && mem_is_str(var)) {
 			uint32_t size = var->u.n + 1;
 			char *str = region_alloc(region, size);

--- a/src/lib/core/port.h
+++ b/src/lib/core/port.h
@@ -39,8 +39,8 @@ extern "C" {
 
 struct obuf;
 struct lua_State;
+struct sql_mem;
 struct port;
-struct Mem;
 
 /**
  * A single port represents a destination of any output. One such
@@ -107,7 +107,7 @@ struct port_vtab {
 	 * @get_msgpack method, i.e. it depends on particular
 	 * implementation
 	 */
-	struct Mem *(*get_vdbemem)(struct port *port, uint32_t *size);
+	struct sql_mem *(*get_vdbemem)(struct port *port, uint32_t *size);
 	/** Destroy a port and release associated resources. */
 	void (*destroy)(struct port *port);
 };
@@ -162,7 +162,7 @@ port_get_msgpack(struct port *port, uint32_t *size)
 	return port->vtab->get_msgpack(port, size);
 }
 
-static inline struct Mem *
+static inline struct sql_mem *
 port_get_vdbemem(struct port *port, uint32_t *size)
 {
 	return port->vtab->get_vdbemem(port, size);


### PR DESCRIPTION
This patch-set reworks `struct Mem` and renames it to `struct sql_mem`.

Closes #6051