### PR TITLE
test: fix 4317_console_backslash_test to use defaut .inputrc

### DIFF
--- a/test/app-luatest/gh_4317_console_backslash_test.lua
+++ b/test/app-luatest/gh_4317_console_backslash_test.lua
@@ -38,7 +38,7 @@ g.test_using_backslash_on_local_console = function()
                               [[bbb\n]] ..
                               [=[]])]=]
 
-    local cmd = "printf '%s' | %s -i 2>/dev/null"
+    local cmd = "printf '%s' | INPUTRC=/dev/null %s -i 2>/dev/null"
     cmd = (cmd):format(tarantool_command, TARANTOOL_PATH)
     local fh = io.popen(cmd, 'r')
 


### PR DESCRIPTION
Currently test can fail if in developer environment .inputrc is custom.

Follow-up #4317

NO_TEST=test fix
NO_DOC=test fix
NO_CHANGELOG=test fix