### PR TITLE
sql: fix integer overflow in built-in functions

### DIFF
--- a/changelogs/unreleased/ghs-119-too-long-mem-values.md
+++ b/changelogs/unreleased/ghs-119-too-long-mem-values.md
@@ -1,0 +1,3 @@
+## bugfix/sql
+
+* Fixed integer overflow issues in built-in functions (ghs-119).

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -60,7 +60,7 @@
  * in pMem->z is discarded.
  */
 static int
-sqlVdbeMemGrow(struct Mem *pMem, int n, int preserve);
+sqlVdbeMemGrow(struct Mem *pMem, size_t n, int preserve);
 
 enum {
 	BUF_SIZE = 32,
@@ -126,7 +126,7 @@ mem_is_field_compatible(const struct Mem *mem, enum field_type type)
 }
 
 int
-mem_snprintf(char *buf, uint32_t size, const struct Mem *mem)
+mem_snprintf(char *buf, size_t size, const struct Mem *mem)
 {
 	int res = -1;
 	switch (mem->type) {
@@ -134,9 +134,11 @@ mem_snprintf(char *buf, uint32_t size, const struct Mem *mem)
 		res = snprintf(buf, size, "NULL");
 		break;
 	case MEM_TYPE_STR:
-	case MEM_TYPE_BIN:
-		res = snprintf(buf, size, "%.*s", mem->n, mem->z);
+	case MEM_TYPE_BIN: {
+		int len = MIN(mem->n, INT_MAX);
+		res = snprintf(buf, size, "%.*s", len, mem->z);
 		break;
+	}
 	case MEM_TYPE_INT:
 		res = snprintf(buf, size, "%lld", mem->u.i);
 		break;
@@ -195,8 +197,10 @@ mem_str(const struct Mem *mem)
 		return "NULL";
 	const char *type = mem_type_to_str(mem);
 	if (mem->type == MEM_TYPE_STR) {
-		if (mem->n <= STR_VALUE_MAX_LEN)
-			return tt_sprintf("%s('%.*s')", type, mem->n, mem->z);
+		if (mem->n <= STR_VALUE_MAX_LEN) {
+			return tt_sprintf("%s('%.*s')", type, (int)mem->n,
+					  mem->z);
+		}
 		return tt_sprintf("%s('%.*s...)", type, STR_VALUE_MAX_LEN,
 				  mem->z);
 	}
@@ -209,7 +213,7 @@ mem_str(const struct Mem *mem)
 			n = (mem->z[i] & 0x0F);
 			buf[2 * i + 1] = n < 10 ? ('0' + n) : ('A' + n - 10);
 		}
-		if (mem->n > len)
+		if (mem->n > (size_t)len)
 			return tt_sprintf("%s(x'%.*s...)", type, len * 2, buf);
 		return tt_sprintf("%s(x'%.*s')", type, len * 2, buf);
 	}
@@ -393,7 +397,7 @@ mem_set_interval(struct Mem *mem, const struct interval *itv)
 }
 
 static inline void
-set_str_const(struct Mem *mem, char *value, uint32_t len, int alloc_type)
+set_str_const(struct Mem *mem, char *value, size_t len, int alloc_type)
 {
 	assert((alloc_type & (MEM_Static | MEM_Ephem)) != 0);
 	mem_clear(mem);
@@ -404,7 +408,7 @@ set_str_const(struct Mem *mem, char *value, uint32_t len, int alloc_type)
 }
 
 static inline void
-set_str_dynamic(struct Mem *mem, char *value, uint32_t len, int alloc_type)
+set_str_dynamic(struct Mem *mem, char *value, size_t len, int alloc_type)
 {
 	assert(mem->szMalloc == 0 || value != mem->zMalloc);
 	mem_destroy(mem);
@@ -417,19 +421,19 @@ set_str_dynamic(struct Mem *mem, char *value, uint32_t len, int alloc_type)
 }
 
 void
-mem_set_str_ephemeral(struct Mem *mem, char *value, uint32_t len)
+mem_set_str_ephemeral(struct Mem *mem, char *value, size_t len)
 {
 	set_str_const(mem, value, len, MEM_Ephem);
 }
 
 void
-mem_set_str_static(struct Mem *mem, char *value, uint32_t len)
+mem_set_str_static(struct Mem *mem, char *value, size_t len)
 {
 	set_str_const(mem, value, len, MEM_Static);
 }
 
 void
-mem_set_str_allocated(struct Mem *mem, char *value, uint32_t len)
+mem_set_str_allocated(struct Mem *mem, char *value, size_t len)
 {
 	set_str_dynamic(mem, value, len, 0);
 }
@@ -453,7 +457,7 @@ mem_set_str0_allocated(struct Mem *mem, char *value)
 }
 
 static int
-mem_copy_bytes(struct Mem *mem, const char *value, uint32_t size,
+mem_copy_bytes(struct Mem *mem, const char *value, size_t size,
 	       enum mem_type type)
 {
 	if (mem_is_bytes(mem) && mem->z == value) {
@@ -475,7 +479,7 @@ mem_copy_bytes(struct Mem *mem, const char *value, uint32_t size,
 }
 
 int
-mem_copy_str(struct Mem *mem, const char *value, uint32_t len)
+mem_copy_str(struct Mem *mem, const char *value, size_t len)
 {
 	return mem_copy_bytes(mem, value, len, MEM_TYPE_STR);
 }
@@ -483,7 +487,7 @@ mem_copy_str(struct Mem *mem, const char *value, uint32_t len)
 int
 mem_copy_str0(struct Mem *mem, const char *value)
 {
-	uint32_t len = strlen(value);
+	size_t len = strlen(value);
 	if (mem_copy_str(mem, value, len + 1) != 0)
 		return -1;
 	mem->n = len;
@@ -491,7 +495,7 @@ mem_copy_str0(struct Mem *mem, const char *value)
 }
 
 static inline void
-set_bin_const(struct Mem *mem, char *value, uint32_t size, int alloc_type)
+set_bin_const(struct Mem *mem, char *value, size_t size, int alloc_type)
 {
 	assert((alloc_type & (MEM_Static | MEM_Ephem)) != 0);
 	mem_clear(mem);
@@ -502,7 +506,7 @@ set_bin_const(struct Mem *mem, char *value, uint32_t size, int alloc_type)
 }
 
 static inline void
-set_bin_dynamic(struct Mem *mem, char *value, uint32_t size, int alloc_type)
+set_bin_dynamic(struct Mem *mem, char *value, size_t size, int alloc_type)
 {
 	assert(mem->szMalloc == 0 || value != mem->zMalloc);
 	mem_destroy(mem);
@@ -515,31 +519,31 @@ set_bin_dynamic(struct Mem *mem, char *value, uint32_t size, int alloc_type)
 }
 
 void
-mem_set_bin_ephemeral(struct Mem *mem, char *value, uint32_t size)
+mem_set_bin_ephemeral(struct Mem *mem, char *value, size_t size)
 {
 	set_bin_const(mem, value, size, MEM_Ephem);
 }
 
 void
-mem_set_bin_static(struct Mem *mem, char *value, uint32_t size)
+mem_set_bin_static(struct Mem *mem, char *value, size_t size)
 {
 	set_bin_const(mem, value, size, MEM_Static);
 }
 
 void
-mem_set_bin_allocated(struct Mem *mem, char *value, uint32_t size)
+mem_set_bin_allocated(struct Mem *mem, char *value, size_t size)
 {
 	set_bin_dynamic(mem, value, size, 0);
 }
 
 int
-mem_copy_bin(struct Mem *mem, const char *value, uint32_t size)
+mem_copy_bin(struct Mem *mem, const char *value, size_t size)
 {
 	return mem_copy_bytes(mem, value, size, MEM_TYPE_BIN);
 }
 
 static inline void
-set_msgpack_value(struct Mem *mem, char *value, uint32_t size, int alloc_type,
+set_msgpack_value(struct Mem *mem, char *value, size_t size, int alloc_type,
 		  enum mem_type type)
 {
 	if (alloc_type == MEM_Ephem || alloc_type == MEM_Static)
@@ -550,55 +554,55 @@ set_msgpack_value(struct Mem *mem, char *value, uint32_t size, int alloc_type,
 }
 
 void
-mem_set_map_ephemeral(struct Mem *mem, char *value, uint32_t size)
+mem_set_map_ephemeral(struct Mem *mem, char *value, size_t size)
 {
 	assert(mp_typeof(*value) == MP_MAP);
 	set_msgpack_value(mem, value, size, MEM_Ephem, MEM_TYPE_MAP);
 }
 
 void
-mem_set_map_static(struct Mem *mem, char *value, uint32_t size)
+mem_set_map_static(struct Mem *mem, char *value, size_t size)
 {
 	assert(mp_typeof(*value) == MP_MAP);
 	set_msgpack_value(mem, value, size, MEM_Static, MEM_TYPE_MAP);
 }
 
 void
-mem_set_map_allocated(struct Mem *mem, char *value, uint32_t size)
+mem_set_map_allocated(struct Mem *mem, char *value, size_t size)
 {
 	assert(mp_typeof(*value) == MP_MAP);
 	set_msgpack_value(mem, value, size, 0, MEM_TYPE_MAP);
 }
 
 int
-mem_copy_map(struct Mem *mem, const char *value, uint32_t size)
+mem_copy_map(struct Mem *mem, const char *value, size_t size)
 {
 	return mem_copy_bytes(mem, value, size, MEM_TYPE_MAP);
 }
 
 void
-mem_set_array_ephemeral(struct Mem *mem, char *value, uint32_t size)
+mem_set_array_ephemeral(struct Mem *mem, char *value, size_t size)
 {
 	assert(mp_typeof(*value) == MP_ARRAY);
 	set_msgpack_value(mem, value, size, MEM_Ephem, MEM_TYPE_ARRAY);
 }
 
 void
-mem_set_array_static(struct Mem *mem, char *value, uint32_t size)
+mem_set_array_static(struct Mem *mem, char *value, size_t size)
 {
 	assert(mp_typeof(*value) == MP_ARRAY);
 	set_msgpack_value(mem, value, size, MEM_Static, MEM_TYPE_ARRAY);
 }
 
 void
-mem_set_array_allocated(struct Mem *mem, char *value, uint32_t size)
+mem_set_array_allocated(struct Mem *mem, char *value, size_t size)
 {
 	assert(mp_typeof(*value) == MP_ARRAY);
 	set_msgpack_value(mem, value, size, 0, MEM_TYPE_ARRAY);
 }
 
 int
-mem_copy_array(struct Mem *mem, const char *value, uint32_t size)
+mem_copy_array(struct Mem *mem, const char *value, size_t size)
 {
 	return mem_copy_bytes(mem, value, size, MEM_TYPE_ARRAY);
 }
@@ -772,12 +776,12 @@ str_to_bool(struct Mem *mem)
 {
 	assert(mem->type == MEM_TYPE_STR);
 	char *str = mem->z;
-	uint32_t len = mem->n;
+	size_t len = mem->n;
 	bool b;
 	const char *str_true = "TRUE";
 	const char *str_false = "FALSE";
-	uint32_t len_true = strlen(str_true);
-	uint32_t len_false = strlen(str_false);
+	size_t len_true = strlen(str_true);
+	size_t len_false = strlen(str_false);
 
 	for (; isspace(str[0]); str++, len--);
 	for (; isspace(str[len - 1]); len--);
@@ -1277,8 +1281,8 @@ datetime_to_str0(struct Mem *mem)
 {
 	assert(mem->type == MEM_TYPE_DATETIME);
 	char buf[DT_TO_STRING_BUFSIZE];
-	uint32_t len = datetime_to_string(&mem->u.dt, buf,
-					  DT_TO_STRING_BUFSIZE);
+	size_t len = datetime_to_string(&mem->u.dt, buf,
+					DT_TO_STRING_BUFSIZE);
 	assert(len == strlen(buf));
 	return mem_copy_str(mem, buf, len);
 }
@@ -1289,8 +1293,8 @@ interval_to_str0(struct Mem *mem)
 {
 	assert(mem->type == MEM_TYPE_INTERVAL);
 	char buf[DT_IVAL_TO_STRING_BUFSIZE];
-	uint32_t len = interval_to_string(&mem->u.itv, buf,
-					  DT_IVAL_TO_STRING_BUFSIZE);
+	size_t len = interval_to_string(&mem->u.itv, buf,
+					DT_IVAL_TO_STRING_BUFSIZE);
 	assert(len == strlen(buf));
 	return mem_copy_str(mem, buf, len);
 }
@@ -1907,7 +1911,7 @@ mem_get_bin(const struct Mem *mem, const char **s)
 }
 
 int
-mem_len(const struct Mem *mem, uint32_t *len)
+mem_len(const struct Mem *mem, size_t *len)
 {
 	if (!mem_is_bytes(mem))
 		return -1;
@@ -1967,23 +1971,23 @@ mem_move(struct Mem *to, struct Mem *from)
 }
 
 int
-mem_append(struct Mem *mem, const char *value, uint32_t len)
+mem_append(struct Mem *mem, const char *value, size_t len)
 {
 	assert((mem->type & (MEM_TYPE_BIN | MEM_TYPE_STR)) != 0);
 	if (len == 0)
 		return 0;
-	int new_size = mem->n + len;
+	size_t n = mem->n + len;
 	if (((mem->flags & (MEM_Static | MEM_Ephem)) != 0) ||
-	    mem->szMalloc < new_size) {
+	    mem->szMalloc < n) {
 		/*
 		 * Force exponential buffer size growth to avoid having to call
 		 * this routine too often.
 		 */
-		if (sqlVdbeMemGrow(mem, new_size + mem->n, 1) != 0)
+		if (sqlVdbeMemGrow(mem, n + mem->n, 1) != 0)
 			return -1;
 	}
 	memcpy(&mem->z[mem->n], value, len);
-	mem->n = new_size;
+	mem->n = n;
 	return 0;
 }
 
@@ -2015,7 +2019,7 @@ mem_concat(const struct Mem *a, const struct Mem *b, struct Mem *result)
 		return -1;
 	}
 
-	uint32_t size = a->n + b->n;
+	size_t size = a->n + b->n;
 	if ((int)size > sql_get()->aLimit[SQL_LIMIT_LENGTH]) {
 		diag_set(ClientError, ER_SQL_EXECUTE, "string or blob too big");
 		return -1;
@@ -2497,7 +2501,11 @@ mem_cmp_bin(const struct Mem *a, const struct Mem *b)
 {
 	assert((a->type & b->type & MEM_TYPE_BIN) != 0);
 	int res = memcmp(a->z, b->z, MIN(a->n, b->n));
-	return res != 0 ? res : a->n - b->n;
+	if (res != 0 || a->n == b->n)
+		return res;
+	if (a->n > b->n)
+		return 1;
+	return -1;
 }
 
 static int
@@ -2613,7 +2621,11 @@ mem_cmp_str(const struct Mem *a, const struct Mem *b, const struct coll *coll)
 	if (coll != NULL)
 		return coll->cmp(a->z, a->n, b->z, b->n, coll);
 	int res = memcmp(a->z, b->z, MIN(a->n, b->n));
-	return res != 0 ? res : a->n - b->n;
+	if (res != 0 || a->n == b->n)
+		return res;
+	if (a->n > b->n)
+		return 1;
+	return -1;
 }
 
 static int
@@ -2910,7 +2922,7 @@ sqlVdbeCheckMemInvariants(Mem * p)
 #endif
 
 static int
-sqlVdbeMemGrow(struct Mem *pMem, int n, int bPreserve)
+sqlVdbeMemGrow(struct Mem *pMem, size_t n, int bPreserve)
 {
 	assert(sqlVdbeCheckMemInvariants(pMem));
 
@@ -2943,19 +2955,8 @@ sqlVdbeMemGrow(struct Mem *pMem, int n, int bPreserve)
 	return 0;
 }
 
-/*
- * Change the pMem->zMalloc allocation to be at least szNew bytes.
- * If pMem->zMalloc already meets or exceeds the requested size, this
- * routine is a no-op.
- *
- * Any prior string or blob content in the pMem object may be discarded.
- * The pMem->xDel destructor is called, if it exists. Though STRING, VARBINARY,
- * MAP and ARRAY values may be discarded, all other values are preserved.
- *
- * Return 0 on success or -1 if unable to complete the resizing.
- */
 int
-sqlVdbeMemClearAndResize(Mem * pMem, int szNew)
+sqlVdbeMemClearAndResize(struct Mem *pMem, size_t szNew)
 {
 	assert(szNew > 0);
 	if (pMem->szMalloc < szNew) {

--- a/src/box/sql/mem.h
+++ b/src/box/sql/mem.h
@@ -87,11 +87,13 @@ struct Mem {
 	/** Type of the value this MEM contains. */
 	enum mem_type type;
 	u32 flags;		/* Some combination of MEM_Null, MEM_Str, MEM_Dyn, etc. */
-	int n;			/* size (in bytes) of string value, excluding trailing '\0' */
+	/* Size of variable length value. */
+	size_t n;
 	char *z;		/* String or BLOB value */
 	/* ShallowCopy only needs to copy the information above */
 	char *zMalloc;		/* Space to hold MEM_Str or MEM_Blob if szMalloc>0 */
-	int szMalloc;		/* Size of the zMalloc allocation */
+	/* Size of the zMalloc allocation. */
+	size_t szMalloc;
 	u32 uTemp;		/* Transient storage for serial_type in OP_MakeRecord */
 #ifdef SQL_DEBUG
 	Mem *pScopyFrom;	/* This Mem is a shallow copy of pScopyFrom */
@@ -295,7 +297,7 @@ mem_is_field_compatible(const struct Mem *mem, enum field_type type);
  * value is equal to or greater than size, then the value has been truncated.
  */
 int
-mem_snprintf(char *buf, uint32_t size, const struct Mem *mem);
+mem_snprintf(char *buf, size_t size, const struct Mem *mem);
 
 /**
  * Returns a NULL-terminated string representation of a MEM. Memory for the
@@ -376,11 +378,11 @@ mem_set_interval(struct Mem *mem, const struct interval *itv);
 
 /** Clear MEM and set it to STRING. The string belongs to another object. */
 void
-mem_set_str_ephemeral(struct Mem *mem, char *value, uint32_t len);
+mem_set_str_ephemeral(struct Mem *mem, char *value, size_t len);
 
 /** Clear MEM and set it to STRING. The string is static. */
 void
-mem_set_str_static(struct Mem *mem, char *value, uint32_t len);
+mem_set_str_static(struct Mem *mem, char *value, size_t len);
 
 /**
  * Clear MEM and set it to STRING. The string was allocated by another object
@@ -389,7 +391,7 @@ mem_set_str_static(struct Mem *mem, char *value, uint32_t len);
  * different value of this allocation type.
  */
 void
-mem_set_str_allocated(struct Mem *mem, char *value, uint32_t len);
+mem_set_str_allocated(struct Mem *mem, char *value, size_t len);
 
 /**
  * Clear MEM and set it to NULL-terminated STRING. The string belongs to
@@ -413,7 +415,7 @@ mem_set_str0_allocated(struct Mem *mem, char *value);
 
 /** Copy string to a newly allocated memory. The MEM type becomes STRING. */
 int
-mem_copy_str(struct Mem *mem, const char *value, uint32_t len);
+mem_copy_str(struct Mem *mem, const char *value, size_t len);
 
 /**
  * Copy NULL-terminated string to a newly allocated memory. The MEM type becomes
@@ -427,11 +429,11 @@ mem_copy_str0(struct Mem *mem, const char *value);
  * object.
  */
 void
-mem_set_bin_ephemeral(struct Mem *mem, char *value, uint32_t size);
+mem_set_bin_ephemeral(struct Mem *mem, char *value, size_t size);
 
 /** Clear MEM and set it to VARBINARY. The binary value is static. */
 void
-mem_set_bin_static(struct Mem *mem, char *value, uint32_t size);
+mem_set_bin_static(struct Mem *mem, char *value, size_t size);
 
 /**
  * Clear MEM and set it to VARBINARY. The binary value was allocated by another
@@ -440,28 +442,28 @@ mem_set_bin_static(struct Mem *mem, char *value, uint32_t size);
  * different value of this allocation type.
  */
 void
-mem_set_bin_allocated(struct Mem *mem, char *value, uint32_t size);
+mem_set_bin_allocated(struct Mem *mem, char *value, size_t size);
 
 /**
  * Copy binary value to a newly allocated memory. The MEM type becomes
  * VARBINARY.
  */
 int
-mem_copy_bin(struct Mem *mem, const char *value, uint32_t size);
+mem_copy_bin(struct Mem *mem, const char *value, size_t size);
 
 /**
  * Clear MEM and set it to MAP. The binary value belongs to another object. The
  * binary value must be msgpack of MAP type.
  */
 void
-mem_set_map_ephemeral(struct Mem *mem, char *value, uint32_t size);
+mem_set_map_ephemeral(struct Mem *mem, char *value, size_t size);
 
 /**
  * Clear MEM and set it to MAP. The binary value is static. The binary value
  * must be msgpack of MAP type.
  */
 void
-mem_set_map_static(struct Mem *mem, char *value, uint32_t size);
+mem_set_map_static(struct Mem *mem, char *value, size_t size);
 
 /**
  * Clear MEM and set it to MAP. The binary value was allocated by another object
@@ -471,25 +473,25 @@ mem_set_map_static(struct Mem *mem, char *value, uint32_t size);
  * allocation type.
  */
 void
-mem_set_map_allocated(struct Mem *mem, char *value, uint32_t size);
+mem_set_map_allocated(struct Mem *mem, char *value, size_t size);
 
 /** Copy MAP value to a newly allocated memory. The MEM type becomes MAP. */
 int
-mem_copy_map(struct Mem *mem, const char *value, uint32_t size);
+mem_copy_map(struct Mem *mem, const char *value, size_t size);
 
 /**
  * Clear MEM and set it to ARRAY. The binary value belongs to another object.
  * The binary value must be msgpack of ARRAY type.
  */
 void
-mem_set_array_ephemeral(struct Mem *mem, char *value, uint32_t size);
+mem_set_array_ephemeral(struct Mem *mem, char *value, size_t size);
 
 /**
  * Clear MEM and set it to ARRAY. The binary value is static. The binary value
  * must be msgpack of ARRAY type.
  */
 void
-mem_set_array_static(struct Mem *mem, char *value, uint32_t size);
+mem_set_array_static(struct Mem *mem, char *value, size_t size);
 
 /**
  * Clear MEM and set it to ARRAY. The binary value was allocated by another
@@ -499,11 +501,11 @@ mem_set_array_static(struct Mem *mem, char *value, uint32_t size);
  * this allocation type.
  */
 void
-mem_set_array_allocated(struct Mem *mem, char *value, uint32_t size);
+mem_set_array_allocated(struct Mem *mem, char *value, size_t size);
 
 /** Copy ARRAY value to a newly allocated memory. The MEM type becomes ARRAY. */
 int
-mem_copy_array(struct Mem *mem, const char *value, uint32_t size);
+mem_copy_array(struct Mem *mem, const char *value, size_t size);
 
 /** Clear MEM and set it to invalid state. */
 void
@@ -556,7 +558,7 @@ mem_move(struct Mem *to, struct Mem *from);
  * memory is allocated in an attempt to reduce the total number of allocations.
  */
 int
-mem_append(struct Mem *mem, const char *value, uint32_t len);
+mem_append(struct Mem *mem, const char *value, size_t len);
 
 /**
  * Concatenate strings or binaries from the first and the second MEMs and write
@@ -813,7 +815,7 @@ mem_get_bin(const struct Mem *mem, const char **s);
  * not changed.
  */
 int
-mem_len(const struct Mem *mem, uint32_t *len);
+mem_len(const struct Mem *mem, size_t *len);
 
 /**
  * Return length of value for MEM of STRING or VARBINARY type. This function is
@@ -823,7 +825,7 @@ mem_len(const struct Mem *mem, uint32_t *len);
 static inline int
 mem_len_unsafe(const struct Mem *mem)
 {
-	uint32_t len;
+	size_t len;
 	if (mem_len(mem, &len) != 0)
 		return 0;
 	return len;
@@ -854,7 +856,15 @@ int sqlVdbeCheckMemInvariants(struct Mem *);
 #define memIsValid(M)  ((M)->type != MEM_TYPE_INVALID)
 #endif
 
-int sqlVdbeMemClearAndResize(struct Mem * pMem, int n);
+/**
+ * Change the pMem->zMalloc allocation to be at least szNew bytes. If
+ * pMem->zMalloc already meets or exceeds the requested size, this routine is a
+ * no-op. Any prior string or blob content in the pMem object will be discarded.
+ *
+ * Return 0 on success or -1 if unable to complete the resizing.
+ */
+int
+sqlVdbeMemClearAndResize(struct Mem *pMem, size_t n);
 
 /*
  * Release an array of N Mem elements

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -129,7 +129,7 @@ int sql_sort_count = 0;
  * help verify the correct operation of the library.
  */
 #ifdef SQL_TEST
-int sql_max_blobsize = 0;
+size_t sql_max_blobsize = 0;
 static void
 updateMaxBlobsize(Mem *p)
 {

--- a/test/sql-luatest/ghs_119_too_long_mem_values_test.lua
+++ b/test/sql-luatest/ghs_119_too_long_mem_values_test.lua
@@ -1,0 +1,73 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_zeroblob = function()
+    g.server:exec(function()
+        local ret, err = box.execute([[SELECT randomblob(0x80000010);]])
+        t.assert(ret == nil)
+        local msg = [[Failed to execute SQL statement: string or blob too big]]
+        t.assert_equals(err.message, msg)
+    end)
+end
+
+g.test_randomblob = function()
+    g.server:exec(function()
+        local ret, err = box.execute([[SELECT zeroblob(0x80000010);]])
+        t.assert(ret == nil)
+        local msg = [[Failed to execute SQL statement: string or blob too big]]
+        t.assert_equals(err.message, msg)
+    end)
+end
+
+g.test_replace = function()
+    g.server:exec(function()
+        local a = string.rep('1', 50000)
+        local b = string.rep('2', 50000)
+        local ret, err = box.execute([[SELECT replace(?, '1', ?);]], {a, b})
+        t.assert(ret == nil)
+        local msg = [[Failed to execute SQL statement: string or blob too big]]
+        t.assert_equals(err.message, msg)
+    end)
+end
+
+g.test_quote = function()
+    g.server:exec(function()
+        local ret, err = box.execute([[SELECT quote(randomblob(499999999));]])
+        t.assert(ret == nil)
+        local msg = [[Failed to execute SQL statement: string or blob too big]]
+        t.assert_equals(err.message, msg)
+    end)
+end
+
+g.test_hex = function()
+    g.server:exec(function()
+        local ret, err = box.execute([[SELECT hex(randomblob(500000001));]])
+        t.assert(ret == nil)
+        local msg = [[Failed to execute SQL statement: string or blob too big]]
+        t.assert_equals(err.message, msg)
+    end)
+end
+
+g.test_group_concat = function()
+    g.server:exec(function()
+        box.execute([[CREATE TABLE t(i INT PRIMARY KEY, s VARBINARY);]])
+        box.execute([[INSERT INTO t VALUES(1, randomblob(10000));]])
+        box.execute([[INSERT INTO t VALUES(2, randomblob(10000));]])
+        local sql = [[SELECT group_concat(s, randomblob(999999999)) FROM t;]]
+        local ret, err = box.execute(sql)
+        t.assert(ret == nil)
+        local msg = [[Failed to execute SQL statement: string or blob too big]]
+        t.assert_equals(err.message, msg)
+    end)
+end

--- a/test/sql-luatest/suite.ini
+++ b/test/sql-luatest/suite.ini
@@ -1,3 +1,4 @@
 [default]
 core = luatest
 description = SQL tests on luatest
+long_run = sql-luatest/ghs_119_too_long_mem_values_test.lua


### PR DESCRIPTION
This patch replaces the type for some int and uint32_t values with size_t to avoid problems with integer overflow.

Closes tarantool/security#119

NO_DOC=bugfix