### PR TITLE
fio: fix default mode for files created by open()

### DIFF
--- a/changelogs/unreleased/gh-7981-fio-read-write-permissions.md
+++ b/changelogs/unreleased/gh-7981-fio-read-write-permissions.md
@@ -1,0 +1,4 @@
+## bugfix/lua/fio
+
+* The default permission mode for `fio.open()` was changed for newly
+  created files to 0666 (before umask) (gh-7981).

--- a/src/lua/fio.lua
+++ b/src/lua/fio.lua
@@ -200,7 +200,7 @@ fio.open = function(path, flags, mode)
         flags = { flags }
     end
     if type(mode) ~= 'table' then
-        mode = { mode or (bit.band(0x1FF, fio.umask())) }
+        mode = { mode or tonumber('666', 8) }
     end
 
 

--- a/test/app/fio.result
+++ b/test/app/fio.result
@@ -457,11 +457,12 @@ fio.unlink(nil)
 ---
 - error: 'Usage: fio.unlink(pathname)'
 ...
--- gh-1211 use 0777 if mode omitted in open
+-- gh-7981 use 0666 if mode omitted in open with O_CREAT
 fh4 = fio.open('newfile', {'O_RDWR','O_CREAT','O_EXCL'})
 ---
 ...
-bit.band(fh4:stat().mode, 0x1FF) == bit.band(fio.umask(), 0x1ff)
+bit.band(fh4:stat().mode, tonumber('7777', 8)) == \
+    bit.band(tonumber('666', 8), bit.bnot(fio.umask()))
 ---
 - true
 ...

--- a/test/app/fio.test.lua
+++ b/test/app/fio.test.lua
@@ -147,9 +147,10 @@ fio.rmdir(tmpdir)
 fio.unlink()
 fio.unlink(nil)
 
--- gh-1211 use 0777 if mode omitted in open
+-- gh-7981 use 0666 if mode omitted in open with O_CREAT
 fh4 = fio.open('newfile', {'O_RDWR','O_CREAT','O_EXCL'})
-bit.band(fh4:stat().mode, 0x1FF) == bit.band(fio.umask(), 0x1ff)
+bit.band(fh4:stat().mode, tonumber('7777', 8)) == \
+    bit.band(tonumber('666', 8), bit.bnot(fio.umask()))
 fh4:close()
 fio.unlink('newfile')
 


### PR DESCRIPTION
For an unknown reason default fio.open() mode used to be set as 0777 & umask that basicly equals to 18, meaning no read/write/execute rights for anyone.

Now the default is 0666 before umask, meaning read and write access.

Closes #7981

NO_DOC=bugfix