### PR TITLE
test/fuzz: get rid of custom cflags

### DIFF
--- a/test/fuzz/sql_fuzzer/CMakeLists.txt
+++ b/test/fuzz/sql_fuzzer/CMakeLists.txt
@@ -26,7 +26,4 @@ target_link_libraries(sql_fuzzer PUBLIC box
                                         ${LPM_LIBRARIES}
                                         fuzzer_config)
 
-set_property(TARGET sql-query-proto PROPERTY
-             COMPILE_FLAGS "-fsanitize=fuzzer-no-link,address -fsanitize-coverage=trace-cmp -fprofile-instr-generate")
-
 set(FUZZ_TEST_TARGETS "${FUZZ_TEST_TARGETS};sql_fuzzer" PARENT_SCOPE)


### PR DESCRIPTION
NO_CHANGELOG=internal
NO_DOC=internal
NO_TEST=internal

Depends on PR https://github.com/tarantool/tarantool/pull/8487 (fixed memleak in SQL)

Fixes #8529