### PR TITLE
tuple_extract: correctly extract key from tuples without trailing nils

### DIFF
--- a/src/box/tuple_extract_key.cc
+++ b/src/box/tuple_extract_key.cc
@@ -307,7 +307,7 @@ tuple_extract_key_slowpath_raw(const char *data, const char *data_end,
 		 */
 		if (has_optional_parts && fieldno >= field_count) {
 			/* Nullify entire columns range. */
-			null_count = fieldno - end_fieldno + 1;
+			null_count = end_fieldno - fieldno + 1;
 			memset(key_buf, MSGPACK_NULL, null_count);
 			key_buf += null_count * mp_sizeof_nil();
 			continue;


### PR DESCRIPTION
Function tuple_extract_key_raw for nullable partially sequential key_def can extract wrong key from tuples without trailing nils. Fortunately, it does not affect tarantool - tuple_extract_key_raw is used only with cmp_def, which ends with non-nullable primary key definition, hence contains no trailing nils.

Closes #8504