### PR TITLE
build: bump zstd submodule

### DIFF
--- a/changelogs/unreleased/gh-8537-bump-zstd.md
+++ b/changelogs/unreleased/gh-8537-bump-zstd.md
@@ -1,0 +1,3 @@
+## feature/build
+
+*  The `zstd` version was updated to 1.5.5 (gh-8537).


### PR DESCRIPTION
Updated third_party/zstd submodule from pre-v1.5.5 to v1.5.5 version. The new version fixes a rare corruption bug in high compression mode. While the probability might be very small, corruption issues are nonetheless very serious, so an update to this version is highly recommended, especially if you employ high compression modes (levels 16+). See full changelog in [1].

1. https://github.com/facebook/zstd/releases/tag/v1.5.5

Fixes #8537
Follows up #8391

NO_DOC=build
NO_TEST=build