### PR TITLE
test: bump test-run to version w/ updated luatest and fix tests

### DIFF
--- a/test/box-luatest/gh_4264_recursive_trigger_test.lua
+++ b/test/box-luatest/gh_4264_recursive_trigger_test.lua
@@ -73,7 +73,7 @@ g2.before_test('test_on_shutdown_trigger_clear', function(cg)
 end)
 
 g2.after_test('test_on_shutdown_trigger_clear', function(cg)
-    cg.server:clean()
+    cg.server:drop()
 end)
 
 g2.test_on_shutdown_trigger_clear = function(cg)

--- a/test/box-luatest/gh_6794_recover_nonmatching_xlogs_test.lua
+++ b/test/box-luatest/gh_6794_recover_nonmatching_xlogs_test.lua
@@ -11,7 +11,7 @@ g.before_test('test_panic_without_force_recovery', function()
 end)
 
 g.after_test("test_panic_without_force_recovery", function()
-    g.server:clean()
+    g.server:drop()
 end)
 
 g.before_test('test_ignore_with_force_recovery', function()

--- a/test/box-luatest/gh_7800_recover_snap_without_spaces_test.lua
+++ b/test/box-luatest/gh_7800_recover_snap_without_spaces_test.lua
@@ -10,7 +10,7 @@ g.before_all(function()
 end)
 
 g.after_all(function()
-    g.server:clean()
+    g.server:drop()
 end)
 
 g.test_recovery = function()

--- a/test/box-luatest/gh_7846_crash_on_replica_id_alter_test.lua
+++ b/test/box-luatest/gh_7846_crash_on_replica_id_alter_test.lua
@@ -46,11 +46,6 @@ g.test_before_replace_alter_replica_id = function(cg)
         end)
     end
 
-    if ret_nil == false then
-        server2:drop()
-    else
-        -- Cannot drop server because it was not started.
-        server2:clean()
-    end
+    server2:drop()
     server1:drop()
 end

--- a/test/box-luatest/gh_7917_log_row_on_recovery_error_test.lua
+++ b/test/box-luatest/gh_7917_log_row_on_recovery_error_test.lua
@@ -24,5 +24,5 @@ g.test_log_row_on_recovery_error = function(cg)
 end
 
 g.after_each(function(cg)
-    cg.server:clean()
+    cg.server:drop()
 end)

--- a/test/box-luatest/gh_7974_force_recovery_bugs_test.lua
+++ b/test/box-luatest/gh_7974_force_recovery_bugs_test.lua
@@ -38,7 +38,7 @@ g.test_unknown_request_type_force_recovery = function()
                                        "Unknown request type 777", nil,
                                        {filename = log}), nil)
     end)
-    s:clean()
+    s:drop()
 end
 
 -- Checks that force recovery works with snapshot containing no user
@@ -75,7 +75,7 @@ g.test_invalid_non_insert_request_force_recovery = function()
                                        "Invalid MsgPack %- raft body", nil,
                                        {filename = log}), nil)
     end)
-    s:clean()
+    s:drop()
 end
 
 -- Checks that force recovery works with snapshot containing an invalid user
@@ -115,7 +115,7 @@ g.test_invalid_user_space_request_force_recovery = function()
                                        "Space '777' does not exist", nil,
                                        {filename = log}), nil)
     end)
-    s:clean()
+    s:drop()
 end
 
 -- Checks that force recovery does not work with snapshot containing one
@@ -145,7 +145,7 @@ g.test_first_corrupted_request_force_recovery = function()
                                        "can't parse row", nil,
                                        {filename = log}), nil)
     end)
-    s:clean()
+    s:drop()
 end
 
 -- Checks that force recovery works with snapshot containing one valid
@@ -185,7 +185,7 @@ g.test_second_corrupted_request_force_recovery = function()
                                        "can't parse row", nil,
                                        {filename = log}), nil)
     end)
-    s:clean()
+    s:drop()
 end
 
 -- Checks that force recovery does not work with empty snapshot.
@@ -215,7 +215,7 @@ g.test_empty_snapshot_force_recovery = function()
                                        "Snapshot has no system spaces", nil,
                                        {filename = log}), nil)
     end)
-    s:clean()
+    s:drop()
 end
 
 -- Checks that force recovery does not work with snapshot containing no system
@@ -245,5 +245,5 @@ g.test_only_user_space_request_force_recovery = function()
                                        "Snapshot has no system spaces", nil,
                                        {filename = log}), nil)
     end)
-    s:clean()
+    s:drop()
 end

--- a/test/replication-luatest/bootstrap_strategy_test.lua
+++ b/test/replication-luatest/bootstrap_strategy_test.lua
@@ -115,8 +115,7 @@ g_auto.test_join_checks_fullmesh = function(cg)
                     'Server3 detected a missing connection to ' .. uuid2)
     end)
     t.assert(not server_is_ready(cg.server3), 'Server3 is dead')
-    -- Server is dead, stopping it will fail.
-    cg.server3:clean()
+    cg.server3:drop()
 end
 
 g_auto.before_test('test_sync_waits_for_all_connected', function(cg)
@@ -185,7 +184,7 @@ end
 local g_config = t.group('gh-7999-bootstrap-strategy-config')
 
 g_config.after_each(function(cg)
-    cg.replica_set:clean()
+    cg.replica_set:drop()
 end)
 
 g_config.before_test('test_no_replication', function(cg)

--- a/test/replication-luatest/election_fencing_test.lua
+++ b/test/replication-luatest/election_fencing_test.lua
@@ -3,10 +3,10 @@ local cluster = require('luatest.replica_set')
 local server = require('luatest.server')
 
 local g_async = luatest.group('fencing_async', {
-    {election_mode = 'manual'}, {election_mode = 'candidate'}})
+    {mode = 'manual'}, {mode = 'candidate'}})
 local g_sync = luatest.group('fencing_sync')
 local g_mode = luatest.group('fencing_mode', {
-    {election_fencing_mode = 'soft'}, {election_fencing_mode = 'strict'}})
+    {mode = 'soft'}, {mode = 'strict'}})
 
 local SHORT_TIMEOUT = 0.1
 local LONG_TIMEOUT = 1000
@@ -61,13 +61,20 @@ local function box_cfg_update(servers, cfg)
 end
 
 local function start(g)
+    local suffix
+    if g.params then
+        suffix = g.params.mode
+    else
+        suffix = g.name
+    end
+
     g.box_cfg = {
         election_mode = 'manual',
         election_timeout = SHORT_TIMEOUT,
         replication = {
-            server.build_listen_uri('server_1'),
-            server.build_listen_uri('server_2'),
-            server.build_listen_uri('server_3'),
+            server.build_listen_uri('server_1_' .. suffix),
+            server.build_listen_uri('server_2_' .. suffix),
+            server.build_listen_uri('server_3_' .. suffix),
         },
         replication_synchro_quorum = 2,
         replication_synchro_timeout = SHORT_TIMEOUT,
@@ -76,13 +83,13 @@ local function start(g)
 
     g.cluster = cluster:new({})
     g.server_1 = g.cluster:build_and_add_server(
-        {alias = 'server_1', box_cfg = g.box_cfg})
+        {alias = 'server_1_' .. suffix, box_cfg = g.box_cfg})
 
     g.box_cfg.read_only = true
     g.server_2 = g.cluster:build_and_add_server(
-        {alias = 'server_2', box_cfg = g.box_cfg})
+        {alias = 'server_2_' .. suffix, box_cfg = g.box_cfg})
     g.server_3 = g.cluster:build_and_add_server(
-        {alias = 'server_3', box_cfg = g.box_cfg})
+        {alias = 'server_3_' .. suffix, box_cfg = g.box_cfg})
 
     g.cluster:start()
     g.cluster:wait_for_fullmesh()
@@ -109,7 +116,7 @@ g_async.after_each(function(g)
 end)
 
 g_async.test_fencing = function(g)
-    box_cfg_update({g.server_1}, {election_mode = g.params.election_mode})
+    box_cfg_update({g.server_1}, {election_mode = g.params.mode})
     g.server_1:exec(function()
         box.schema.create_space('test'):create_index('pk')
     end)
@@ -296,19 +303,20 @@ g_mode.after_all(stop)
 g_mode.test_fencing_mode = function(g)
     local timeout = 0.5
     box_cfg_update({g.server_1, g.server_2}, {
-        election_fencing_mode = g.params.election_fencing_mode,
+        election_fencing_mode = g.params.mode,
         replication_timeout = timeout,
     })
 
     local proxy = require('luatest.replica_proxy'):new({
-        client_socket_path = server.build_listen_uri('server_1_proxy'),
-        server_socket_path = server.build_listen_uri('server_1'),
+        client_socket_path = server.build_listen_uri(
+            g.server_1.alias .. '_proxy'),
+        server_socket_path = server.build_listen_uri(g.server_1.alias),
     })
     proxy:start({force = true})
 
     local proxied_replication = {
-        server.build_listen_uri('server_1_proxy'),
-        server.build_listen_uri('server_2'),
+        server.build_listen_uri(g.server_1.alias .. '_proxy'),
+        server.build_listen_uri(g.server_2.alias),
     }
 
     box_cfg_update({g.server_2}, {replication = {}})
@@ -335,7 +343,7 @@ g_mode.test_fencing_mode = function(g)
         return box.info.replication[leader_id].upstream.status
     end, {leader_id})
 
-    if g.params.election_fencing_mode == 'strict' then
+    if g.params.mode == 'strict' then
         luatest.assert_equals(follower_connection_status, 'follow',
             'Follower did not notice leader disconnection')
     else

--- a/test/replication-luatest/gh_5295_split_brain_test.lua
+++ b/test/replication-luatest/gh_5295_split_brain_test.lua
@@ -80,8 +80,7 @@ end)
 
 -- Drop the partitioned server after each case of split-brain.
 g.after_each(function(cg)
-    cg.split_replica:stop()
-    cg.split_replica:clean()
+    cg.split_replica:drop()
     -- Drop the replica's cluster entry, so that next one receives same id.
     cg.main:exec(function()
         box.ctl.promote()

--- a/test/replication-luatest/gh_6033_box_promote_demote_test.lua
+++ b/test/replication-luatest/gh_6033_box_promote_demote_test.lua
@@ -92,15 +92,15 @@ local function cluster_init(g)
         replication_synchro_timeout = 5,
         replication_synchro_quorum = 1,
         replication = {
-            server.build_listen_uri('server_1'),
-            server.build_listen_uri('server_2'),
+            server.build_listen_uri('server_gh6033_1'),
+            server.build_listen_uri('server_gh6033_2'),
         },
     }
 
     g.server_1 = g.cluster:build_and_add_server(
-        {alias = 'server_1', box_cfg = g.box_cfg})
+        {alias = 'server_gh6033_1', box_cfg = g.box_cfg})
     g.server_2 = g.cluster:build_and_add_server(
-        {alias = 'server_2', box_cfg = g.box_cfg})
+        {alias = 'server_gh6033_2', box_cfg = g.box_cfg})
     g.cluster:start()
     g.cluster:wait_for_fullmesh()
 end
@@ -387,13 +387,13 @@ g_common.test_limbo_full_interfering_promote = function(g)
     -- server_2 will interrupt server_1, while server_3 is leader
     local box_cfg = table.copy(g.box_cfg)
     box_cfg.replication = {
-        server.build_listen_uri('server_1'),
-        server.build_listen_uri('server_2'),
-        server.build_listen_uri('server_3'),
+        server.build_listen_uri('server_gh6033_1'),
+        server.build_listen_uri('server_gh6033_2'),
+        server.build_listen_uri('server_gh6033_3'),
     }
 
     local server_3 = g.cluster:build_server(
-        {alias = 'server_3', box_cfg = box_cfg})
+        {alias = 'server_gh6033_3', box_cfg = box_cfg})
     server_3:start()
     wait_sync({g.server_1, g.server_2, server_3})
     box_cfg_update(g.cluster.servers, box_cfg)

--- a/test/replication-luatest/gh_6036_qsync_order_test.lua
+++ b/test/replication-luatest/gh_6036_qsync_order_test.lua
@@ -163,8 +163,7 @@ g.after_test("test_qsync_order", function(cg)
     cg.box_cfg.replication[3] = nil
     cg.r1:exec(update_replication, cg.box_cfg.replication)
     cg.r2:exec(update_replication, cg.box_cfg.replication)
-    cg.r3:stop()
-    cg.r3:clean()
+    cg.r3:drop()
     cg.r3 = nil
 end)
 

--- a/test/replication-luatest/gh_6754_promote_before_new_term_test.lua
+++ b/test/replication-luatest/gh_6754_promote_before_new_term_test.lua
@@ -13,18 +13,18 @@ g.before_all(function(g)
         replication_synchro_quorum = 1,
         replication_timeout = 0.1,
         replication = {
-            server.build_listen_uri('server_1'),
-            server.build_listen_uri('server_2'),
+            server.build_listen_uri('server_gh6754_1'),
+            server.build_listen_uri('server_gh6754_2'),
         },
     }
 
     g.server_1 = g.cluster:build_and_add_server(
-        {alias = 'server_1', box_cfg = g.box_cfg})
+        {alias = 'server_gh6754_1', box_cfg = g.box_cfg})
 
     g.box_cfg.read_only = false
 
     g.server_2 = g.cluster:build_and_add_server(
-        {alias = 'server_2', box_cfg = g.box_cfg})
+        {alias = 'server_gh6754_2', box_cfg = g.box_cfg})
     g.cluster:start()
     g.cluster:wait_for_fullmesh()
 end)

--- a/test/replication-luatest/gh_6842_qsync_applier_order_test.lua
+++ b/test/replication-luatest/gh_6842_qsync_applier_order_test.lua
@@ -13,17 +13,17 @@ local function cluster_create(g)
         replication_synchro_quorum = 2,
         replication_synchro_timeout = 1000,
         replication = {
-            server.build_listen_uri('server1'),
-            server.build_listen_uri('server2'),
+            server.build_listen_uri('server_gh6842_1'),
+            server.build_listen_uri('server_gh6842_2'),
         },
     }
     g.server1 = g.cluster:build_and_add_server({
-        alias = 'server1', box_cfg = box_cfg
+        alias = 'server_gh6842_1', box_cfg = box_cfg
     })
     -- For stability. To guarantee server1 is first, server2 is second.
     box_cfg.read_only = true
     g.server2 = g.cluster:build_and_add_server({
-        alias = 'server2', box_cfg = box_cfg
+        alias = 'server_gh6842_2', box_cfg = box_cfg
     })
     g.cluster:start()
 

--- a/test/replication-luatest/gh_7086_box_issue_promote_assert_test.lua
+++ b/test/replication-luatest/gh_7086_box_issue_promote_assert_test.lua
@@ -25,18 +25,18 @@ local function cluster_init(g)
         replication_synchro_timeout = 5,
         replication_synchro_quorum = 1,
         replication = {
-            server.build_listen_uri('server_1'),
-            server.build_listen_uri('server_2'),
-            server.build_listen_uri('server_3'),
+            server.build_listen_uri('server_gh7086_1'),
+            server.build_listen_uri('server_gh7086_2'),
+            server.build_listen_uri('server_gh7086_3'),
         },
     }
 
     g.server_1 = g.cluster:build_and_add_server(
-        {alias = 'server_1', box_cfg = g.box_cfg})
+        {alias = 'server_gh7086_1', box_cfg = g.box_cfg})
     g.server_2 = g.cluster:build_and_add_server(
-        {alias = 'server_2', box_cfg = g.box_cfg})
+        {alias = 'server_gh7086_2', box_cfg = g.box_cfg})
     g.server_3 = g.cluster:build_and_add_server(
-        {alias = 'server_3', box_cfg = g.box_cfg})
+        {alias = 'server_gh7086_3', box_cfg = g.box_cfg})
     g.cluster:start()
     g.cluster:wait_for_fullmesh()
 end

--- a/test/replication-luatest/gh_7253_election_long_wal_write_test.lua
+++ b/test/replication-luatest/gh_7253_election_long_wal_write_test.lua
@@ -74,22 +74,22 @@ g.before_all(function(g)
         election_timeout = 1000,
         election_fencing_enabled = false,
         replication = {
-            server.build_listen_uri('server1'),
-            server.build_listen_uri('server2'),
-            server.build_listen_uri('server3'),
+            server.build_listen_uri('server_gh7253_1'),
+            server.build_listen_uri('server_gh7253_2'),
+            server.build_listen_uri('server_gh7253_3'),
         },
         bootstrap_strategy = 'legacy',
     }
     box_cfg.election_mode = 'manual'
     g.server1 = g.cluster:build_and_add_server({
-        alias = 'server1', box_cfg = box_cfg
+        alias = 'server_gh7253_1', box_cfg = box_cfg
     })
     box_cfg.election_mode = 'voter'
     g.server2 = g.cluster:build_and_add_server({
-        alias = 'server2', box_cfg = box_cfg
+        alias = 'server_gh7253_2', box_cfg = box_cfg
     })
     g.server3 = g.cluster:build_and_add_server({
-        alias = 'server3', box_cfg = box_cfg
+        alias = 'server_gh7253_3', box_cfg = box_cfg
     })
     g.cluster:start()
 
@@ -282,8 +282,8 @@ g.test_old_leader_txn_during_promote_write = function(g)
     -- Build the topology:
     --   server1  server2 <-> server3
     --
-    local server2_uri = server.build_listen_uri('server2')
-    local server3_uri = server.build_listen_uri('server3')
+    local server2_uri = server.build_listen_uri('server_gh7253_2')
+    local server3_uri = server.build_listen_uri('server_gh7253_3')
     server_set_replication(g.server1, {})
     server_set_replication(g.server2, {server2_uri, server3_uri})
     server_set_replication(g.server3, {server2_uri, server3_uri})
@@ -371,25 +371,25 @@ end
 -- forwards the bad txn.
 --
 g.test_old_leader_txn_during_promote_write_complex = function(g)
-    local server1_uri = server.build_listen_uri('server1')
-    local server2_uri = server.build_listen_uri('server2')
-    local server3_uri = server.build_listen_uri('server3')
-    local server4_uri = server.build_listen_uri('server4')
-    local server5_uri = server.build_listen_uri('server5')
+    local server1_uri = server.build_listen_uri('server_gh7253_1')
+    local server2_uri = server.build_listen_uri('server_gh7253_2')
+    local server3_uri = server.build_listen_uri('server_gh7253_3')
+    local server4_uri = server.build_listen_uri('server_gh7253_4')
+    local server5_uri = server.build_listen_uri('server_gh7253_5')
     --
     -- Build the topology:
     --   server4 <- fullmesh(server1, server2, server3)
     --   server3 <-> server5
     --
     g.server4 = g.cluster:build_and_add_server({
-        alias = 'server4', box_cfg = g.server3.box_cfg
+        alias = 'server_gh7253_4', box_cfg = g.server3.box_cfg
     })
     g.server4:start()
     -- Server5 is needed only to make server3 able to win elections without
     -- participation of server1. Could also lower the quorum, but it wouldn't be
     -- fair. The test is too complex for these tricks.
     g.server5 = g.cluster:build_and_add_server({
-        alias = 'server5', box_cfg = g.server3.box_cfg
+        alias = 'server_gh7253_5', box_cfg = g.server3.box_cfg
     })
     g.server5:start()
     server_set_replication(g.server5, {server3_uri})

--- a/test/replication-luatest/gh_7253_election_long_wal_write_test.lua
+++ b/test/replication-luatest/gh_7253_election_long_wal_write_test.lua
@@ -501,8 +501,7 @@ g.test_old_leader_txn_during_promote_write_complex = function(g)
     local server4_id = g.server4:get_instance_id()
     local server5_id = g.server5:get_instance_id()
     for _, s in pairs({g.server4, g.server5}) do
-        s:stop()
-        s:clean()
+        s:drop()
         g.cluster:delete_server(s.alias)
         g[s.alias] = nil
     end

--- a/test/replication-luatest/gh_7377_bootstrap_connection_failure_test.lua
+++ b/test/replication-luatest/gh_7377_bootstrap_connection_failure_test.lua
@@ -14,9 +14,9 @@ g.before_all(function(cg)
     cg.servers = {}
     local box_cfg = {
         replication = {
-            server.build_listen_uri('server_1'),
-            server.build_listen_uri('server_2'),
-            server.build_listen_uri('server_3'),
+            server.build_listen_uri('server_gh7377_1'),
+            server.build_listen_uri('server_gh7377_2'),
+            server.build_listen_uri('server_gh7377_3'),
         },
         replication_timeout = timeout,
         bootstrap_strategy = 'legacy',
@@ -27,19 +27,20 @@ g.before_all(function(cg)
         'cccccccc-cccc-cccc-cccc-cccccccccccc',
     }
 
-    -- Connection server_3 -> server_1 is proxied, others are not.
+    -- Connection server_gh7377_3 -> server_gh7377_1 is proxied, others are not.
     cg.proxy = proxy:new{
-        client_socket_path = server.build_listen_uri('server_1_proxy'),
-        server_socket_path = server.build_listen_uri('server_1'),
+        client_socket_path = server.build_listen_uri('server_gh7377_1_proxy'),
+        server_socket_path = server.build_listen_uri('server_gh7377_1'),
     }
     t.assert(cg.proxy:start{force = true}, 'Proxy started successfully')
     for i = 1, 3 do
         box_cfg.instance_uuid = cg.uuids[i]
         if i == 3 then
-            box_cfg.replication[1] = server.build_listen_uri('server_1_proxy')
+            box_cfg.replication[1] = server.build_listen_uri(
+                'server_gh7377_1_proxy')
         end
         cg.servers[i] = cg.cluster:build_and_add_server({
-            alias = 'server_' .. i,
+            alias = 'server_gh7377_' .. i,
             box_cfg = box_cfg,
         })
     end
@@ -82,7 +83,7 @@ g.test_bootstrap_with_bad_connection = function(cg)
     cg.cluster:start{wait_until_ready = false}
     wait_bootstrapped(cg.servers[1], cg.uuids[2])
     fiber.sleep(timeout)
-    local logfile = fio.pathjoin(cg.servers[3].workdir, 'server_3.log')
+    local logfile = fio.pathjoin(cg.servers[3].workdir, 'server_gh7377_3.log')
     t.assert(not cg.servers[3]:grep_log(bootstrap_msg, nil,
                                         {filename = logfile}),
              'Server 3 waits for connection')

--- a/test/replication-luatest/gh_7515_sync_node_sees_leader_hang_test.lua
+++ b/test/replication-luatest/gh_7515_sync_node_sees_leader_hang_test.lua
@@ -11,19 +11,19 @@ g.before_each(function(cg)
     local box_cfg = {
         replication_timeout = 0.1,
         replication = {
-            server.build_listen_uri('server1'),
-            server.build_listen_uri('server2'),
-            server.build_listen_uri('server3'),
+            server.build_listen_uri('server_gh7515_1'),
+            server.build_listen_uri('server_gh7515_2'),
+            server.build_listen_uri('server_gh7515_3'),
         },
     }
     for i = 1, 3 do
-        local alias = 'server' .. i
+        local alias = 'server_gh7515_' .. i
         if i == 1 then
             box_cfg.election_mode = 'candidate'
         else
             box_cfg.election_mode = 'voter'
         end
-        cg[alias] = cg.replica_set:build_and_add_server{
+        cg['server' .. i] = cg.replica_set:build_and_add_server{
             alias = alias,
             box_cfg = box_cfg,
         }

--- a/test/replication-luatest/gh_8168_extra_term_bump_test.lua
+++ b/test/replication-luatest/gh_8168_extra_term_bump_test.lua
@@ -8,20 +8,20 @@ g.before_each(function(cg)
     cg.replica_set = replica_set:new{}
     local box_cfg = {
         replication = {
-            server.build_listen_uri('server1'),
-            server.build_listen_uri('server2'),
+            server.build_listen_uri('server_gh8168_1'),
+            server.build_listen_uri('server_gh8168_2'),
         },
         election_mode = 'manual',
         replication_timeout = 0.1,
     }
     cg.server1 = cg.replica_set:build_and_add_server{
-        alias = 'server1',
+        alias = 'server_gh8168_1',
         box_cfg = box_cfg,
     }
     box_cfg.election_timeout = 1e-9
     box_cfg.read_only = true
     cg.server2 = cg.replica_set:build_and_add_server{
-        alias = 'server2',
+        alias = 'server_gh8168_2',
         box_cfg = box_cfg,
     }
     cg.replica_set:start()

--- a/test/replication-luatest/linearizable_test.lua
+++ b/test/replication-luatest/linearizable_test.lua
@@ -9,7 +9,7 @@ local g = t.group('linearizable-read')
 local function build_replication(num_instances)
     local t = {}
     for i = 1, num_instances do
-        table.insert(t, server.build_listen_uri('server_' .. i .. '_proxy'))
+        table.insert(t, server.build_listen_uri('server_lr_' .. i .. '_proxy'))
     end
     return t
 end
@@ -25,25 +25,25 @@ g.before_all(function(cg)
         memtx_use_mvcc_engine = true,
     }
     cg.servers[1] = cg.cluster:build_and_add_server({
-        alias = 'server_1',
+        alias = 'server_lr_1',
         box_cfg = cg.box_cfg,
     })
     -- Servers 2 and 3 are interconnected without a proxy.
     for i = 2, num_servers do
-        cg.box_cfg.replication[i] = server.build_listen_uri('server_' .. i)
+        cg.box_cfg.replication[i] = server.build_listen_uri('server_lr_' .. i)
     end
     for i = 2, num_servers do
         cg.servers[i] = cg.cluster:build_and_add_server({
-            alias = 'server_' .. i,
+            alias = 'server_lr_' .. i,
             box_cfg = cg.box_cfg,
         })
     end
     cg.proxies = {}
     for i = 1, num_servers do
         cg.proxies[i] = proxy:new({
-            client_socket_path = server.build_listen_uri('server_' .. i ..
+            client_socket_path = server.build_listen_uri('server_lr_' .. i ..
                 '_proxy'),
-            server_socket_path = server.build_listen_uri('server_' .. i),
+            server_socket_path = server.build_listen_uri('server_lr_' .. i),
         })
         cg.proxies[i]:start({force = true})
     end

--- a/test/replication-luatest/linearizable_test.lua
+++ b/test/replication-luatest/linearizable_test.lua
@@ -17,6 +17,7 @@ end
 local num_servers = 3
 
 g.before_all(function(cg)
+    t.skip('Skipped until tarantool/tarantool-qa#277 is resolved')
     cg.cluster = cluster:new({})
     cg.servers = {}
     cg.box_cfg = {


### PR DESCRIPTION
### 1. Bump test-run
Bump test-run to new version with the following improvements:

- Bump luatest to 0.5.7-33-g8523e5c [1]

[1] tarantool/test-run@7db594d

### 2. replace `clean()` method with `drop()` of server

Server API from the luatest has been changed: `server:clean()` method has been removed. Use `server:drop()` instead.

Follows up tarantool/luatest#296