### PR TITLE
lua: add malloc info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,8 @@ check_function_exists(setproctitle HAVE_SETPROCTITLE)
 check_function_exists(setprogname HAVE_SETPROGNAME)
 check_function_exists(getprogname HAVE_GETPROGNAME)
 
+check_symbol_exists(malloc_info malloc.h HAVE_MALLOC_INFO)
+
 #
 # Enable 'make tags' target.
 #

--- a/changelogs/unreleased/gh-7311-malloc-info.md
+++ b/changelogs/unreleased/gh-7311-malloc-info.md
@@ -1,0 +1,5 @@
+## feature/core
+
+* Added the new function `box.malloc.info()` for reporting memory usage of
+  Tarantool internal data structures allocated with `malloc()`. The function
+  is available only on Linux (gh-7311).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -217,6 +217,7 @@ set (server_sources
      lua/backtrace.c
      lua/builtin_modcache.c
      lua/tweaks.c
+     lua/xml.c
      ${lua_sources}
      ${PROJECT_SOURCE_DIR}/third_party/lua-yaml/lyaml.cc
      ${PROJECT_SOURCE_DIR}/third_party/lua-yaml/b64.c

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -955,6 +955,7 @@ local box_cfg_guard_whitelist = {
     session = true;
     tuple = true;
     runtime = true;
+    malloc = true;
     ctl = true;
     watch = true;
     broadcast = true;

--- a/src/box/lua/slab.cc
+++ b/src/box/lua/slab.cc
@@ -32,12 +32,22 @@
 
 #include "box/lua/slab.h"
 #include "lua/utils.h"
+#include "lua/xml.h"
 #include "lua/serializer.h" /* luaL_setmaphint */
 
 #include <lua.h>
 #include <lauxlib.h>
 #include <lualib.h>
 #include <lj_obj.h> /* internals: lua in box.runtime.info() */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#if defined(HAVE_MALLOC_INFO)
+# include <malloc.h>
+#endif /* defined(HAVE_MALLOC_INFO) */
 
 #include "small/small.h"
 #include "small/quota.h"
@@ -265,6 +275,144 @@ lbox_slab_check(MAYBE_UNUSED struct lua_State *L)
 	return 0;
 }
 
+/*
+ * Decodes and returns the XML document returned by malloc_info() as is.
+ *
+ * This is an internal function that isn't supposed to be called by users,
+ * but it may be useful for developers.
+ *
+ * Returns an empty table if malloc_info() isn't supported by the system.
+ * Raises a Lua error if it fails to retrieve or parse malloc_info() output.
+ */
+static int
+lbox_malloc_internal_info(struct lua_State *L)
+{
+#if defined(HAVE_MALLOC_INFO)
+	char *buf = NULL;
+	size_t buf_size = 0;
+	FILE *fp = open_memstream(&buf, &buf_size);
+	if (fp == NULL) {
+		diag_set(SystemError, "failed to open memory stream");
+		return luaT_error(L);
+	}
+	if (malloc_info(0, fp) != 0) {
+		diag_set(SystemError, "failed to get malloc info");
+		fclose(fp);
+		free(buf);
+		return luaT_error(L);
+	}
+	fclose(fp);
+	lua_pushlstring(L, buf, buf_size);
+	free(buf);
+	return luaT_xml_decode(L);
+#else /* !defined(HAVE_MALLOC_INFO) */
+	lua_newtable(L);
+	return 1;
+#endif /* defined(HAVE_MALLOC_INFO) */
+}
+
+/*
+ * Returns the malloc memory usage information in a table
+ *
+ *   {
+ *     size = <total allocated>,
+ *     used = <actually used>,
+ *   }
+ *
+ * (all numbers are in bytes).
+ *
+ * The information is retrieved with malloc_info(). If it isn't supported by
+ * the system or its format is unknown, {size = 0, used = 0} is returned.
+ *
+ * This function never raises.
+ */
+static int
+lbox_malloc_info(struct lua_State *L)
+{
+	int version = 0;
+	uint64_t total = 0;
+	uint64_t available = 0;
+	lua_pushcfunction(L, lbox_malloc_internal_info);
+	if (luaT_call(L, 0, 1) != 0)
+		goto out;
+	/*
+	 * The XML document name returned by malloc_info is expected to be
+	 * "malloc" so the document content should be in malloc[1].
+	 */
+	assert(lua_istable(L, -1));
+	lua_getfield(L, -1, "malloc");
+	if (!lua_istable(L, -1))
+		goto out;
+	lua_rawgeti(L, -1, 1);
+	if (!lua_istable(L, -1))
+		goto out;
+	/*
+	 * First, check the malloc_info version. The only known version is 1.
+	 * It's pointless to proceed if the version is different.
+	 */
+	lua_getfield(L, -1, "version");
+	version = lua_tonumber(L, -1);
+	lua_pop(L, 1);
+	if (version != 1)
+		goto out;
+	/*
+	 * Extract the size of used memory. Even though the document version is
+	 * valid, we still need to be careful accessing it.
+	 */
+	assert(lua_istable(L, -1));
+	lua_getfield(L, -1, "system");
+	if (lua_istable(L, -1)) {
+		lua_pushnil(L);
+		for (; lua_next(L, -2) != 0; lua_pop(L, 1)) {
+			if (!lua_istable(L, -1))
+				continue; /* skip XML attributes */
+			lua_getfield(L, -1, "type");
+			const char *key = lua_tostring(L, -1);
+			lua_pop(L, 1);
+			lua_getfield(L, -1, "size");
+			uint64_t size = luaL_touint64(L, -1);
+			lua_pop(L, 1);
+			if (key == NULL) {
+				continue;
+			} else if (strcmp(key, "current") == 0) {
+				total += size;
+			}
+		}
+	}
+	lua_pop(L, 1);
+	lua_getfield(L, -1, "total");
+	if (lua_istable(L, -1)) {
+		lua_pushnil(L);
+		for (; lua_next(L, -2) != 0; lua_pop(L, 1)) {
+			if (!lua_istable(L, -1))
+				continue; /* skip XML attributes */
+			lua_getfield(L, -1, "type");
+			const char *key = lua_tostring(L, -1);
+			lua_pop(L, 1);
+			lua_getfield(L, -1, "size");
+			uint64_t size = luaL_touint64(L, -1);
+			lua_pop(L, 1);
+			if (key == NULL) {
+				continue;
+			} else if (strcmp(key, "mmap") == 0) {
+				total += size;
+			} else if (strcmp(key, "fast") == 0 ||
+				   strcmp(key, "rest") == 0) {
+				available += size;
+			}
+		}
+	}
+	lua_pop(L, 1);
+out:
+	/* Return memory usage information. */
+	lua_newtable(L);
+	luaL_pushuint64(L, total);
+	lua_setfield(L, -2, "size");
+	luaL_pushuint64(L, total - available);
+	lua_setfield(L, -2, "used");
+	return 1;
+}
+
 /** Initialize box.slab package. */
 void
 box_lua_slab_init(struct lua_State *L)
@@ -295,6 +443,23 @@ box_lua_slab_init(struct lua_State *L)
 	lua_settable(L, -3);
 
 	lua_settable(L, -3); /* box.runtime */
+
+	lua_pushstring(L, "malloc");
+	lua_newtable(L);
+
+	lua_pushstring(L, "info");
+	lua_pushcfunction(L, lbox_malloc_info);
+	lua_settable(L, -3);
+
+	lua_pushstring(L, "internal");
+	lua_newtable(L);
+
+	lua_pushstring(L, "info");
+	lua_pushcfunction(L, lbox_malloc_internal_info);
+	lua_settable(L, -3);
+
+	lua_settable(L, -3); /* box.malloc.internal */
+	lua_settable(L, -3); /* box.malloc */
 
 	lua_pop(L, 1); /* box. */
 }

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -70,6 +70,7 @@
 #include "lua/uri.h"
 #include "lua/builtin_modcache.h"
 #include "lua/tweaks.h"
+#include "lua/xml.h"
 #include "digest.h"
 #include "errinj.h"
 
@@ -889,6 +890,7 @@ tarantool_lua_init(const char *tarantool_bin, const char *script, int argc,
 	tarantool_lua_uri_init(L);
 	tarantool_lua_utf8_init(L);
 	tarantool_lua_utils_init(L);
+	tarantool_lua_xml_init(L);
 	tarantool_lua_fiber_init(L);
 	tarantool_lua_fiber_cond_init(L);
 	tarantool_lua_fiber_channel_init(L);

--- a/src/lua/xml.c
+++ b/src/lua/xml.c
@@ -1,0 +1,324 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include "lua/xml.h"
+
+#include <assert.h>
+#include <ctype.h>
+#include <lua.h>
+#include <lauxlib.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "lua/utils.h"
+
+int
+luaT_xml_decode(struct lua_State *L)
+{
+	/* The input string must be at the top of the stack. */
+	int top = lua_gettop(L);
+	if (top < 1 || lua_type(L, top) != LUA_TSTRING)
+		return luaL_error(L, "expected string");
+	const char *s = lua_tostring(L, top);
+	assert(s != NULL);
+	/* Push the document table. */
+	lua_newtable(L);
+	enum {
+		ELEM,
+		TAG,
+		START_TAG,
+		END_TAG,
+		SPACE_AFTER_END_TAG,
+		ATTR,
+		ATTR_NAME,
+		ATTR_VALUE_SEP,
+		ATTR_VALUE_BEGIN,
+		ATTR_VALUE,
+		ATTR_VALUE_END,
+		ELEM_END,
+		DOC_END,
+	} state = ELEM;
+	const char *tag_name = NULL;
+	const char *attr_name = NULL;
+	const char *attr_value = NULL;
+	/*
+	 * Position of the current character in the input string recorded
+	 * as line and column numbers. Used for error reporting.
+	 */
+	int line = 1;
+	int column = 1;
+#define ERROR(msg) \
+	luaL_error(L, "XML decode error at line %d, column %d: %s", \
+		   line, column, (msg))
+	while (*s != '\0') {
+		/*
+		 * State machine:
+		 *  - 'break' skips the current character by leaving
+		 *    the switch-case.
+		 *  - 'continue' rechecks the state without skipping
+		 *    the current character.
+		 */
+		switch (state) {
+		/*
+		 * Expected an element. Currently, only tags are supported
+		 * (<section> or </section>) while values enclosed in tags are
+		 * considered invalid. Skip optional spaces and '<', then
+		 * transition to TAG.
+		 *
+		 * TODO: Handle values, such as <section>value</section>.
+		 */
+		case ELEM:
+			if (isspace(*s))
+				break; /* skip spaces */
+			if (*s != '<')
+				return ERROR("invalid token");
+			state = TAG;
+			break; /* skip '<' */
+		/*
+		 * If the current character is '/', skip it and transition to
+		 * END_TAG, otherwise transition to START_TAG.
+		 */
+		case TAG:
+			if (*s != '/') {
+				tag_name = s;
+				state = START_TAG;
+				continue;
+			}
+			if (lua_gettop(L) == top + 1) {
+				/*
+				 * The stack only contains the resulting
+				 * document table, which means there's no
+				 * start tag matching this end tag.
+				 */
+				return ERROR("invalid token");
+			}
+			tag_name = s + 1;
+			state = END_TAG;
+			break; /* skip '/' */
+		/*
+		 * Skip the start tag name, create a table for the tag
+		 * attributes and child elements, then transition to ATTR.
+		 */
+		case START_TAG: {
+			assert(tag_name != NULL);
+			/* TODO: Check names according to XML standard. */
+			if (isalnum(*s))
+				break; /* skip the tag name */
+			if ((!isspace(*s) && *s != '/' && *s != '>') ||
+			    s == tag_name)
+				return ERROR("invalid token");
+			/* Stack: parent table, ... */
+			assert(lua_gettop(L) >= top + 1);
+			assert(lua_istable(L, -1));
+			lua_pushlstring(L, tag_name, s - tag_name);
+			/*
+			 * Check that there's no attributes with the same name
+			 * in the parent table. A table is accepted because
+			 * there may be more than one element with the same
+			 * name (elements are stored in an array).
+			 */
+			lua_pushvalue(L, -1); /* tag name */
+			lua_rawget(L, -3);
+			int type = lua_type(L, -1);
+			if (type != LUA_TNIL && type != LUA_TTABLE)
+				return ERROR("duplicate name");
+			/*
+			 * Create an array entry in the parent table under this
+			 * name if it doesn't exist.
+			 */
+			if (type == LUA_TNIL) {
+				lua_pop(L, 1);
+				lua_newtable(L);
+				lua_pushvalue(L, -2); /* tag name */
+				lua_pushvalue(L, -2); /* new array */
+				lua_rawset(L, -5);
+			}
+			assert(lua_istable(L, -1));
+			int len = lua_objlen(L, -1);
+			/*
+			 * Create a new attribute table for this element and
+			 * append it to the array. Then pop the array leaving
+			 * the attribute table and the new tag name at the top
+			 * of the stack.
+			 */
+			lua_newtable(L);
+			lua_pushvalue(L, -1); /* attribute table */
+			lua_rawseti(L, -3, len + 1);
+			lua_replace(L, -2);
+			state = ATTR;
+			continue;
+		}
+		/*
+		 * Skip the end tag name, check it against the corresponding
+		 * start tag name, and transition to SPACE_AFTER_END_TAG.
+		 */
+		case END_TAG: {
+			assert(tag_name != NULL);
+			if (isalnum(*s))
+				break; /* skip the tag name */
+			if ((!isspace(*s) && *s != '>') ||
+			    s == tag_name)
+				return ERROR("invalid token");
+			/* Stack: attr table, tag name, parent table, ... */
+			assert(lua_gettop(L) >= top + 3);
+			/* Check that the start and end tag names match. */
+			size_t len;
+			const char *expected = lua_tolstring(L, -2, &len);
+			assert(expected != NULL);
+			if ((size_t)(s - tag_name) != len ||
+			    strncmp(tag_name, expected, len) != 0)
+				return ERROR("mismatched tag");
+			state = SPACE_AFTER_END_TAG;
+			continue;
+		}
+		/*
+		 * Skip optional spaces after the end tag name and transition
+		 * to ELEM_END.
+		 */
+		case SPACE_AFTER_END_TAG:
+			if (isspace(*s))
+				break; /* skip spaces */
+			state = ELEM_END;
+			continue;
+		/*
+		 * Skip optional spaces then transition to ELEM, ELEM_END, or
+		 * ATTR_NAME, depending on the current character.
+		 */
+		case ATTR:
+			if (isspace(*s))
+				break; /* skip spaces */
+			if (*s == '/') {
+				state = ELEM_END;
+				break; /* skip '/' */
+			} else if (*s == '>') {
+				state = ELEM;
+				break; /* skip '>' */
+			}
+			attr_name = s;
+			state = ATTR_NAME;
+			continue;
+		/*
+		 * Skip the attribute name and transition to ATTR_VALUE_SEP.
+		 */
+		case ATTR_NAME:
+			assert(attr_name != NULL);
+			/* TODO: Check names according to XML standard. */
+			if (isalnum(*s))
+				break; /* skip the attribute name */
+			if ((!isspace(*s) && *s != '=') ||
+			    s == attr_name)
+				return ERROR("invalid token");
+			/* Stack: attr table, tag name, parent table, ... */
+			assert(lua_gettop(L) >= top + 3);
+			lua_pushlstring(L, attr_name, s - attr_name);
+			/* Check that there's no duplicate attributes. */
+			lua_pushvalue(L, -1); /* attribute name */
+			lua_rawget(L, -3);
+			if (!lua_isnil(L, -1))
+				return ERROR("duplicate name");
+			lua_pop(L, 1);
+			state = ATTR_VALUE_SEP;
+			continue;
+		/*
+		 * Skip optional spaces and '=' separating the attribute value
+		 * from the name, then transition to ATTR_VALUE_BEGIN.
+		 */
+		case ATTR_VALUE_SEP:
+			if (isspace(*s))
+				break; /* skip spaces */
+			if (*s != '=')
+				return ERROR("invalid token");
+			state = ATTR_VALUE_BEGIN;
+			break; /* skip '=' */
+		/*
+		 * Skip optional spaces and '"' preceding the attribute value,
+		 * then transition to ATTR_VALUE.
+		 */
+		case ATTR_VALUE_BEGIN:
+			if (isspace(*s))
+				break; /* skip spaces */
+			if (*s != '"')
+				return ERROR("invalid token");
+			attr_value = s + 1;
+			state = ATTR_VALUE;
+			break; /* skip '"' */
+		/*
+		 * Skip until and including '"' following the attribute value,
+		 * insert the new attribute to the attribute table, then
+		 * transition to ATTR_VALUE_END.
+		 */
+		case ATTR_VALUE:
+			assert(attr_value != NULL);
+			/* TODO: Handle escaped quotation marks. */
+			if (*s != '"')
+				break; /* skip until '"' */
+			/*
+			 * Stack: attr name, attr table, tag name,
+			 *        parent table, ...
+			 */
+			assert(lua_gettop(L) >= top + 4);
+			/* Insert the new attribute into the table. */
+			lua_pushlstring(L, attr_value, s - attr_value);
+			lua_rawset(L, -3);
+			state = ATTR_VALUE_END;
+			break; /* skip '"' */
+		/*
+		 * Check that the attribute value is followed by a valid token,
+		 * then transition to ATTR.
+		 */
+		case ATTR_VALUE_END:
+			if (!isspace(*s) && *s != '/' && *s != '>')
+				return ERROR("invalid token");
+			state = ATTR;
+			continue;
+		/*
+		 * Skip '>' terminating the current element, pop the attribute
+		 * table and the tag name created for the element from the
+		 * stack, then transition to ELEM or DOC_END, depending on
+		 * whether we expect more elements.
+		 */
+		case ELEM_END:
+			if (*s != '>')
+				return ERROR("invalid token");
+			/* Stack: attr table, tag name, parent table, ... */
+			assert(lua_gettop(L) >= top + 3);
+			lua_pop(L, 2);
+			state = lua_gettop(L) == top + 1 ? DOC_END : ELEM;
+			break; /* skip '>' */
+		/*
+		 * End of document. No input except for spaces is expected in
+		 * this state.
+		 */
+		case DOC_END:
+			if (isspace(*s))
+				break; /* skip spaces */
+			return ERROR("junk after document");
+		}
+		if (*s == '\n') {
+			line++;
+			column = 1;
+		} else {
+			column++;
+		}
+		s++;
+	}
+	if (state != DOC_END)
+		return ERROR("truncated document");
+#undef ERROR
+	/* Replace the input string with the document table. */
+	lua_replace(L, -2);
+	return 1;
+}
+
+void
+tarantool_lua_xml_init(struct lua_State *L)
+{
+	const struct luaL_Reg module_funcs[] = {
+		{"decode", luaT_xml_decode},
+		{NULL, NULL},
+	};
+	luaT_newmodule(L, "internal.xml", module_funcs);
+	lua_pop(L, 1);
+}

--- a/src/lua/xml.h
+++ b/src/lua/xml.h
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+struct lua_State;
+
+/**
+ * Takes a string that is supposed to contain a valid XML document, decodes it,
+ * and replaces the string with a Lua table representation of the XML document.
+ * Raises a Lua error on failure. On success returns 1.
+ *
+ * Each XML element (including an input document) is represented by a Lua table.
+ * An attribute is stored in the table as a string keyed by the attribute name
+ * while a sub-element is stored in an array keyed by the sub-element tag.
+ *
+ * For example, the following document
+ *
+ *   <section version="1">
+ *     <element value="foo"/>
+ *     <element value="bar"/>
+ *   </section>
+ *
+ * will be transformed to
+ *
+ *   {
+ *     section = {
+ *       [1] = {
+ *         version = '1',
+ *         element = {
+ *           [1] = {value = 'foo'},
+ *           [2] = {value = 'bar'},
+ *         }
+ *       }
+ *     }
+ *   }
+ *
+ * Spaces and new lines in the input string are ignored.
+ *
+ * Limitations:
+ *  - Element values, such as <section>value</section>, aren't supported.
+ *  - Escape sequences in attribute values aren't supported.
+ *  - Tag and attribute names aren't checked according to the XML standard.
+ *    The parser allows only digits and letters while in XML a name may also
+ *    contain dots, dashes, and underscores, and must start with a letter or
+ *    an underscore.
+ */
+int
+luaT_xml_decode(struct lua_State *L);
+
+void
+tarantool_lua_xml_init(struct lua_State *L);
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */

--- a/src/trivia/config.h.cmake
+++ b/src/trivia/config.h.cmake
@@ -227,6 +227,8 @@
 #cmakedefine HAVE_SETPROGNAME 1
 #cmakedefine HAVE_GETPROGNAME 1
 
+#cmakedefine HAVE_MALLOC_INFO 1
+
 /*
  * Defined if ICU library has ucol_strcollUTF8 method.
  */

--- a/test/app-luatest/gh_7311_malloc_info_test.lua
+++ b/test/app-luatest/gh_7311_malloc_info_test.lua
@@ -1,0 +1,115 @@
+local tarantool = require('tarantool')
+
+local ffi = require('ffi')
+ffi.cdef([[
+    void *malloc(size_t size);
+    void free(void *p);
+]])
+local malloc = ffi.C.malloc
+local free = ffi.C.free
+
+local t = require('luatest')
+local g = t.group()
+
+local ALLOC_SIZE = 10 * 1000 * 1000
+local MARGIN = ALLOC_SIZE * 0.05
+
+local function is_supported()
+    -- malloc_info() is a GNU extension available only on Linux.
+    if jit.os ~= 'Linux' then
+        return false
+    end
+    -- If ASAN is enabled, malloc_info() exists but it is not implemented
+    -- (all counters in the returned document are set to zeros).
+    if tarantool.build.flags:match('-fsanitize=[%a,]*address') then
+        return false
+    end
+    return true
+end
+
+local function skip_if_supported()
+    t.skip_if(is_supported(), 'malloc info is supported')
+end
+
+local function skip_if_unsupported()
+    t.skip_if(not is_supported(), 'malloc info is not supported')
+end
+
+local function check_malloc_info(info)
+    t.assert_ge(info.used, 0)
+    t.assert_ge(info.size, info.used)
+    -- It's totally up to the malloc implementation whether to release memory
+    -- to the system on free() immediately or keep it for future allocations.
+    -- Still, it's reasonable to assume that a repetitive allocation and
+    -- freeing of an object of the same size won't result in growing total
+    -- memory usage infinitely. So we check that the system memory usage never
+    -- exceeds the allocated memory usage by more than the test allocation size
+    -- plus 10% overhead for internal housekeeping and fragmentation.
+    t.assert_le(info.size, info.used + 1.1 * ALLOC_SIZE)
+end
+
+g.test_malloc_info = function()
+    t.assert_type(box.malloc, 'table')
+    t.assert_type(box.malloc.info, 'function')
+    t.assert_type(box.malloc.info(), 'table')
+    t.assert_type(box.malloc.internal, 'table')
+    t.assert_type(box.malloc.internal.info, 'function')
+    t.assert_type(box.malloc.internal.info(), 'table')
+end
+
+g.test_unsupported = function()
+    skip_if_supported()
+
+    t.assert_equals(box.malloc.info(), {size = 0, used = 0})
+end
+
+g.test_malloc_small = function()
+    skip_if_unsupported()
+
+    local p = {}
+    local count = 10000
+    local size = ALLOC_SIZE / count
+    t.assert_ge(size, 100)
+
+    local info1 = box.malloc.info()
+    for i = 1, count do
+        p[i] = malloc(size)
+        t.assert_not_equals(p[i], nil)
+    end
+    local info2 = box.malloc.info()
+    for i = 1, count, 2 do
+        free(p[i])
+    end
+    local info3 = box.malloc.info()
+    for i = 2, count, 2 do
+        free(p[i])
+    end
+    local info4 = box.malloc.info()
+
+    check_malloc_info(info1)
+    check_malloc_info(info2)
+    check_malloc_info(info3)
+    check_malloc_info(info4)
+
+    t.assert_almost_equals(info2.used - info1.used, ALLOC_SIZE, MARGIN)
+    t.assert_almost_equals(info2.used - info3.used, ALLOC_SIZE / 2, MARGIN)
+    t.assert_almost_equals(info4.used, info1.used, MARGIN)
+end
+
+g.test_malloc_huge = function()
+    skip_if_unsupported()
+
+    local info1 = box.malloc.info()
+    local p = malloc(ALLOC_SIZE)
+    t.assert_not_equals(p, nil)
+    local info2 = box.malloc.info()
+    free(p)
+    local info3 = box.malloc.info()
+
+    check_malloc_info(info1)
+    check_malloc_info(info2)
+    check_malloc_info(info3)
+
+    t.assert_almost_equals(info2.used - info1.used, ALLOC_SIZE, MARGIN)
+    t.assert_almost_equals(info3.used, info1.used, MARGIN)
+end

--- a/test/app-luatest/xml_test.lua
+++ b/test/app-luatest/xml_test.lua
@@ -1,0 +1,144 @@
+local xml = require('internal.xml')
+
+local t = require('luatest')
+local g = t.group()
+
+g.test_invalid_arg = function()
+    local errmsg
+    local function test(...)
+        t.assert_error_msg_equals(errmsg, xml.decode, ...)
+    end
+
+    errmsg = 'expected string'
+    test()
+    test(123)
+    test(false)
+end
+
+g.test_invalid_input = function()
+    local errmsg
+    local function test(input, line, column)
+        t.assert_error_msg_equals(
+            string.format('XML decode error at line %d, column %d: %s',
+                          line, column, errmsg),
+            xml.decode, input)
+    end
+
+    errmsg = 'truncated document'
+    test('', 1, 1)
+    test('<', 1, 2)
+    test('<foo', 1, 5)
+    test('<foo/', 1, 6)
+    test('<foo>', 1, 6)
+    test('<foo><', 1, 7)
+    test('<foo></', 1, 8)
+    test('<foo bar', 1, 9)
+    test('<foo bar ', 1, 10)
+    test('<foo bar=', 1, 10)
+    test('<foo bar="', 1, 11)
+    test('<foo bar=""', 1, 12)
+    test('<foo bar=""/', 1, 13)
+    test('<foo bar=""/', 1, 13)
+    test('<foo><bar/>', 1, 12)
+    test('<foo><bar></bar>', 1, 17)
+    test('<foo>\n<bar>\n</bar>', 3, 7)
+
+    errmsg = 'junk after document'
+    test('<foo></foo><bar/>', 1, 12)
+    test('<foo></foo>\n<bar></bar>', 2, 1)
+
+    errmsg = 'invalid token'
+    test('foo', 1, 1)
+    test('"foo"', 1, 1)
+    test('>foo', 1, 1)
+    test('/foo', 1, 1)
+    test('=foo', 1, 1)
+    test('<>', 1, 2)
+    test('<=>', 1, 2)
+    test('</foo>', 1, 2)
+    test('<"foo"/>', 1, 2)
+    test('< foo/>', 1, 2)
+    test('<foo=/>', 1, 5)
+    test('<foo"bar"/>', 1, 5)
+    test('<foo bar/>', 1, 9)
+    test('<foo bar />', 1, 10)
+    test('<foo bar=/>', 1, 10)
+    test('<foo bar=1/>', 1, 10)
+    test('<foo bar="1""2"/>', 1, 13)
+    test('<foo bar="1"<"2"/>', 1, 13)
+    test('<foo bar="1"baz="2"/>', 1, 13)
+    test('<foo bar="1" baz="2"/ >', 1, 22)
+    test('<foo bar="1" baz="2"/=>', 1, 22)
+    test('<foo bar="1" baz="2"/<>', 1, 22)
+    test('<foo bar="1" baz="2"/foo>', 1, 22)
+    test('<foo>bar</foo>', 1, 6)
+    test('<foo></foo="1">', 1, 11)
+    test('<foo></foo bar="1">', 1, 12)
+    test('<foo\nbar="1"\nbaz=2/>', 3, 5)
+
+    errmsg = 'mismatched tag'
+    test('<foo></bar>', 1, 11)
+    test('<foo>\n<bar/>\n</bar>', 3, 6)
+    test('<foo><bar>\n</foo></bar>', 2, 6)
+
+    errmsg = 'duplicate name'
+    test('<foo bar="1" bar="2"/>', 1, 17)
+    test('<foo bar="1">\n<bar/>\n</foo>', 2, 5)
+    test('<foo bar="1">\n<foo/>\n<bar/>\n</foo>', 3, 5)
+end
+
+g.test_decode = function()
+    local expected
+    local function test(input)
+        t.assert_equals(xml.decode(input), expected)
+    end
+
+    expected = {foo = {{}}}
+    test('<foo/>')
+    test(' <foo /> ')
+    test('\n<foo\n/> ')
+    test('<foo></foo>')
+    test('<foo > </foo >')
+    test('<foo\n>\n</foo\n>')
+
+    expected = {foo = {{bar = "123"}}}
+    test('<foo bar="123"/>')
+    test('<foo bar = "123"/>')
+    test('<foo bar\n=\n"123"/>')
+    test('<foo bar="123"></foo>')
+
+    expected = {foo = {{bar = "123", baz = "xyz"}}}
+    test('<foo bar="123" baz="xyz"/>')
+    test('<foo bar="123" baz="xyz"></foo>')
+
+    expected = {foo = {{bar = {{}}}}}
+    test('<foo><bar/></foo>')
+    test('<foo> <bar/> </foo>')
+    test('<foo>\n<bar/>\n</foo>')
+    test('<foo><bar></bar></foo>')
+    test('<foo> <bar> </bar> </foo>')
+    test('<foo>\n<bar>\n</bar>\n</foo>')
+
+    expected = {foo = {{bar = {{}, {}}}}}
+    test('<foo><bar/><bar/></foo>')
+    test('<foo><bar/><bar></bar></foo>')
+    test('<foo><bar></bar><bar></bar></foo>')
+
+    expected = {foo = {{bar = {{buz = "1"}, {buz = "2"}}}}}
+    test('<foo><bar buz="1"/><bar buz="2"/></foo>')
+    test('<foo><bar buz="1"/><bar buz="2"></bar></foo>')
+    test('<foo><bar buz="1"></bar><bar buz="2"></bar></foo>')
+
+    expected = {foo = {{bar = {{}}, baz = {{}}}}}
+    test('<foo><bar/><baz/></foo>')
+    test('<foo><bar/><baz></baz></foo>')
+    test('<foo><bar></bar><baz></baz></foo>')
+
+    expected = {foo = {{bar = {{baz = {{}}}}}}}
+    test('<foo><bar><baz/></bar></foo>')
+    test('<foo><bar><baz></baz></bar></foo>')
+
+    expected = {foo = {{bar = "xyz", baz = {{}}}}}
+    test('<foo bar="xyz"><baz/></foo>')
+    test('<foo bar="xyz"><baz></baz></foo>')
+end

--- a/test/box/misc.result
+++ b/test/box/misc.result
@@ -88,6 +88,7 @@ t
   - iproto
   - is_in_txn
   - lib
+  - malloc
   - on_commit
   - on_rollback
   - once


### PR DESCRIPTION
This commit adds two new Lua functions:
 - `box.malloc.info()` is a public function that returns the total memory usage of internal data structures allocated with [`malloc()`][1]. This information is extracted from the [`malloc_info()`][2] output.
 - `box.malloc.internal.info()` is an internal function that returns a parsed XML document returned by `malloc_info()` as is. It isn't documented. We may need it to get the detailed information about the system memory allocator.

Both functions are available only on Linux and only if ASAN is disabled because otherwise `malloc_info()` is unavailable. On other platforms `box.malloc.info()` reports zero memory usage while `internal.info()` returns an empty table.

Both functions may be used before `box.cfg()` is called.

`box.malloc.info()` returns a table with two fields:

```
tarantool> box.malloc.info()
---
- size: 2498560
  used: 1835726
...
```

The `used` value is the total amount of memory in bytes allocated by Tarantool for internal data structures with `malloc()`.

The `size` value is the total amount of memory in bytes allocated from the system by the `malloc()` allocator. It may not be less than `used`.

Since `malloc_info()` returns an XML document, we also have to add an internal XML parser.

Closes #7311

[1]: https://man7.org/linux/man-pages/man3/malloc.3.html
[2]: https://man7.org/linux/man-pages/man3/malloc_info.3.html