### PR TITLE
core: add TWEAK_DOUBLE

### DIFF
--- a/src/lib/core/tweaks.c
+++ b/src/lib/core/tweaks.c
@@ -126,6 +126,29 @@ tweak_set_int(struct tweak *tweak, const struct tweak_value *val)
 	return 0;
 }
 
+void
+tweak_get_double(struct tweak *tweak, struct tweak_value *val)
+{
+	assert(tweak->get == tweak_get_double);
+	val->type = TWEAK_VALUE_DOUBLE;
+	val->dval = *(double *)tweak->data;
+}
+
+int
+tweak_set_double(struct tweak *tweak, const struct tweak_value *val)
+{
+	assert(tweak->set == tweak_set_double);
+	if (val->type == TWEAK_VALUE_INT) {
+		*(double *)tweak->data = val->ival;
+	} else if (val->type == TWEAK_VALUE_DOUBLE) {
+		*(double *)tweak->data = val->dval;
+	} else {
+		diag_set(IllegalParams, "Invalid value, expected number");
+		return -1;
+	}
+	return 0;
+}
+
 /**
  * snprintf(buf, size, "Invalid value, expected one of: '%s', '%s', ...",
  *          enum_strs[0], enum_strs[1], ...);

--- a/src/lib/core/tweaks.h
+++ b/src/lib/core/tweaks.h
@@ -35,6 +35,7 @@ extern "C" {
 enum tweak_value_type {
 	TWEAK_VALUE_BOOL,
 	TWEAK_VALUE_INT,
+	TWEAK_VALUE_DOUBLE,
 	TWEAK_VALUE_STR,
 };
 
@@ -47,6 +48,8 @@ struct tweak_value {
 		bool bval;
 		/** TWEAK_VALUE_INT */
 		int ival;
+		/** TWEAK_VALUE_DOUBLE */
+		double dval;
 		/** TWEAK_VALUE_STR */
 		const char *sval;
 	};
@@ -165,6 +168,19 @@ tweak_set_int(struct tweak *tweak, const struct tweak_value *val);
 #define TWEAK_INT(var)							\
 STATIC_ASSERT_VAR_TYPE(var, int)					\
 TWEAK(var, tweak_get_int, tweak_set_int)
+
+/** Double tweak value getter. */
+void
+tweak_get_double(struct tweak *tweak, struct tweak_value *val);
+
+/** Double tweak value setter. */
+int
+tweak_set_double(struct tweak *tweak, const struct tweak_value *val);
+
+/** Registers a tweak for a double variable. */
+#define TWEAK_DOUBLE(var)						\
+STATIC_ASSERT_VAR_TYPE(var, double)					\
+TWEAK(var, tweak_get_double, tweak_set_double)
 
 /**
  * Internal function that converts a tweak value to a enumeration.


### PR DESCRIPTION
Allow to register tweaks for variables of type double. Such tweak can be set to any integer or double value.

We need it to add the error factor tweak for the new tuple sorting algorithm (#3389).

Follow-up #7883