### PR TITLE
memtx: fix integer overflow in memtx index statistics

### DIFF
--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -1523,9 +1523,10 @@ memtx_engine_stat_index(struct memtx_engine *memtx, struct info_handler *h)
 {
 	struct matras_stats *stats = &memtx->index_extent_stats;
 	info_table_begin(h, "index");
-	info_append_int(h, "total", stats->extent_count * MEMTX_EXTENT_SIZE);
-	info_append_int(h, "read_view",
-			stats->read_view_extent_count * MEMTX_EXTENT_SIZE);
+	info_append_int(h, "total", (size_t)stats->extent_count *
+			MEMTX_EXTENT_SIZE);
+	info_append_int(h, "read_view", (size_t)stats->read_view_extent_count *
+			MEMTX_EXTENT_SIZE);
 	info_table_end(h); /* index */
 }
 


### PR DESCRIPTION
This may result in invalid statistics if there's more than 4 GB allocated for index extents.

Fixes commit a75f4b7eee823 ("memtx: introduce read view statistics")
Follow-up #8501
Coverity report [1537026](https://scan7.scan.coverity.com/reports.htm#v41662/p13437/fileInstanceId=138568189&defectInstanceId=18798966&mergedDefectId=1537026), [1537027](https://scan7.scan.coverity.com/reports.htm#v41662/p13437/fileInstanceId=138568189&defectInstanceId=18798985&mergedDefectId=1537027).