### PR TITLE
replication: add bootstrap_strategy "supervised"

### DIFF
--- a/changelogs/unreleased/gh-8509-bootstrap-strategy-supervised.md
+++ b/changelogs/unreleased/gh-8509-bootstrap-strategy-supervised.md
@@ -1,0 +1,18 @@
+## feature/replication
+
+* You may now control which node new replicas choose as a bootstrap leader
+  without touching node config. To do so, set `box.cfg.bootstrap_strategy` to
+  `'supervised'`, and the nodes will only bootstrap off the node on which you
+  called `box.ctl.make_bootstrap_leader()` last.
+  This works on an empty replica set bootstrap as well: start the admin console
+  before configuring the nodes. Then configure the nodes:
+  ```lua
+  box.cfg{
+      bootstrap_strategy = 'supervised',
+      replication = ...,
+      listen = ...,
+  }
+  ```
+  Finally, call `box.ctl.make_bootstrap_leader()` through the admin console
+  on the node you want to promote. All the nodes will bootstrap off that node
+  (gh-8509).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -3897,7 +3897,7 @@ on_replace_dd_schema(struct trigger * /* trigger */, void *event)
 			return -1;
 		}
 		tt_uuid uu;
-		if (tuple_field_uuid(new_tuple, BOX_CLUSTER_FIELD_UUID, &uu) != 0)
+		if (tuple_field_uuid(new_tuple, BOX_SCHEMA_FIELD_VALUE, &uu) != 0)
 			return -1;
 		REPLICASET_UUID = uu;
 		box_broadcast_id();

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -3872,6 +3872,78 @@ on_replace_dd_priv(struct trigger * /* trigger */, void *event)
 /* {{{ cluster configuration */
 
 /**
+ * This trigger implements the "last write wins" strategy for
+ * "bootstrap_leader_uuid" tuple of space _schema. Comparison is performed by
+ * a timestamp and replica_id of the node which authored the change.
+ */
+static int
+before_replace_dd_schema(struct trigger * /* trigger */, void *event)
+{
+	struct txn *txn = (struct txn *)event;
+	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct tuple *old_tuple = stmt->old_tuple;
+	struct tuple *new_tuple = stmt->new_tuple;
+	const char *key = tuple_field_cstr(new_tuple != NULL ?
+					   new_tuple : old_tuple,
+					   BOX_SCHEMA_FIELD_KEY);
+	if (key == NULL)
+		return -1;
+	if (strcmp(key, "bootstrap_leader_uuid") == 0) {
+		uint64_t old_ts = 0;
+		uint32_t old_id = 0;
+		uint64_t new_ts = UINT64_MAX;
+		uint32_t new_id = UINT32_MAX;
+		int ts_field = BOX_SCHEMA_FIELD_VALUE + 1;
+		int id_field = BOX_SCHEMA_FIELD_VALUE + 2;
+		/*
+		 * Assume anything can be stored in old_tuple, so do not require
+		 * it to have a timestamp or replica_id. In contrary to that,
+		 * always require new tuple to have a valid timestamp and
+		 * replica_id.
+		 */
+		if (old_tuple != NULL) {
+			const char *field = tuple_field(old_tuple, ts_field);
+			if (field != NULL && mp_typeof(*field) == MP_UINT)
+				old_ts = mp_decode_uint(&field);
+			field = tuple_field(old_tuple, id_field);
+			if (field != NULL && mp_typeof(*field) == MP_UINT)
+				old_id = mp_decode_uint(&field);
+		}
+		if (new_tuple != NULL &&
+		    (tuple_field_u64(new_tuple, ts_field, &new_ts) != 0 ||
+		     tuple_field_u32(new_tuple, id_field, &new_id) != 0)) {
+			return -1;
+		}
+		if (new_ts < old_ts || (new_ts == old_ts && new_id < old_id)) {
+			say_info("Ignore the replace of tuple %s with %s in "
+				 "space _schema: the former has a newer "
+				 "timestamp", tuple_str(old_tuple),
+				 tuple_str(new_tuple));
+			goto return_old;
+		}
+	}
+	return 0;
+return_old:
+	if (new_tuple != NULL)
+		tuple_unref(new_tuple);
+	if (old_tuple != NULL)
+		tuple_ref(old_tuple);
+	stmt->new_tuple = old_tuple;
+	return 0;
+}
+
+/** An on_commit trigger to update bootstrap leader uuid. */
+static int
+on_commit_schema_set_bootstrap_leader_uuid(struct trigger *trigger, void *event)
+{
+	(void)event;
+	struct tt_uuid *uuid = (struct tt_uuid *)trigger->data;
+	bootstrap_leader_uuid = *uuid;
+	box_broadcast_ballot();
+	return 0;
+}
+
+/**
  * This trigger is invoked only upon initial recovery, when
  * reading contents of the system spaces from the snapshot.
  *
@@ -3888,7 +3960,7 @@ on_replace_dd_schema(struct trigger * /* trigger */, void *event)
 	struct tuple *old_tuple = stmt->old_tuple;
 	struct tuple *new_tuple = stmt->new_tuple;
 	const char *key = tuple_field_cstr(new_tuple ? new_tuple : old_tuple,
-					      BOX_SCHEMA_FIELD_KEY);
+					   BOX_SCHEMA_FIELD_KEY);
 	if (key == NULL)
 		return -1;
 	if (strcmp(key, "cluster") == 0) {
@@ -3922,6 +3994,20 @@ on_replace_dd_schema(struct trigger * /* trigger */, void *event)
 			 */
 			dd_version_id = tarantool_version_id();
 		}
+	} else if (strcmp(key, "bootstrap_leader_uuid") == 0) {
+		struct tt_uuid *uuid = xregion_alloc_object(&txn->region,
+							    typeof(*uuid));
+		if (!new_tuple) {
+			*uuid = uuid_nil;
+		} else if (tuple_field_uuid(new_tuple, BOX_SCHEMA_FIELD_VALUE,
+					    uuid) != 0) {
+			return -1;
+		}
+		struct trigger *on_commit = txn_alter_trigger_new(
+			on_commit_schema_set_bootstrap_leader_uuid, uuid);
+		if (on_commit == NULL)
+			return -1;
+		txn_on_commit(txn, on_commit);
 	}
 	return 0;
 }
@@ -4856,6 +4942,7 @@ TRIGGER(alter_space_on_replace_space, on_replace_dd_space);
 TRIGGER(alter_space_on_replace_index, on_replace_dd_index);
 TRIGGER(on_replace_truncate, on_replace_dd_truncate);
 TRIGGER(on_replace_schema, on_replace_dd_schema);
+TRIGGER(before_replace_schema, before_replace_dd_schema);
 TRIGGER(on_replace_user, on_replace_dd_user);
 TRIGGER(on_replace_func, on_replace_dd_func);
 TRIGGER(on_replace_collation, on_replace_dd_collation);

--- a/src/box/alter.h
+++ b/src/box/alter.h
@@ -32,6 +32,8 @@
  */
 #include "trigger.h"
 
+extern struct trigger before_replace_schema;
+
 extern struct trigger alter_space_on_replace_space;
 extern struct trigger alter_space_on_replace_index;
 extern struct trigger on_replace_truncate;

--- a/src/box/applier.h
+++ b/src/box/applier.h
@@ -182,10 +182,8 @@ struct applier {
 	struct iostream io;
 	/** Input buffer */
 	struct ibuf ibuf;
-	/** Triggers invoked on state change */
+	/** Triggers invoked on state change or ballot update. */
 	struct rlist on_state;
-	/** Triggers invoked on ballot update. */
-	struct rlist on_ballot_update;
 	/**
 	 * Set if the applier was paused (see applier_pause()) and is now
 	 * waiting on resume_cond to be resumed (see applier_resume()).

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -91,6 +91,13 @@ extern double txn_timeout_default;
 /** "internal.ballot" built-in event key. */
 extern const char *box_ballot_event_key;
 
+/**
+ * UUID of the node this instance considers the bootstrap leader. Is broadcast
+ * to replicas via the ballot and influences the replica's choice of the
+ * bootstrap leader.
+ */
+extern struct tt_uuid bootstrap_leader_uuid;
+
 /*
  * Initialize box library
  * @throws C++ exception
@@ -367,6 +374,12 @@ box_iterator_position_unpack(const char *packed_pos,
 			     struct key_def *cmp_def, const char *key,
 			     uint32_t key_part_count, int iterator,
 			     const char **pos, const char **pos_end);
+
+/**
+ * For bootstrap_strategy = "supervised", set this node as the bootstrap leader.
+ */
+int
+box_make_bootstrap_leader(void);
 
 /**
  * Select data, satisfying filters (key and iterator), and dump it to port.

--- a/src/box/lua/ctl.c
+++ b/src/box/lua/ctl.c
@@ -118,6 +118,14 @@ lbox_ctl_demote(struct lua_State *L)
 }
 
 static int
+lbox_ctl_make_bootstrap_leader(struct lua_State *L)
+{
+	if (box_make_bootstrap_leader() != 0)
+		return luaT_error(L);
+	return 0;
+}
+
+static int
 lbox_ctl_is_recovery_finished(struct lua_State *L)
 {
 	struct memtx_engine *memtx;
@@ -158,6 +166,7 @@ static const struct luaL_Reg lbox_ctl_lib[] = {
 	/* An old alias. */
 	{"clear_synchro_queue", lbox_ctl_promote},
 	{"demote", lbox_ctl_demote},
+	{"make_bootstrap_leader", lbox_ctl_make_bootstrap_leader},
 	{"is_recovery_finished", lbox_ctl_is_recovery_finished},
 	{"set_on_shutdown_timeout", lbox_ctl_set_on_shutdown_timeout},
 	{NULL, NULL}

--- a/src/box/replication.h
+++ b/src/box/replication.h
@@ -105,6 +105,7 @@ enum bootstrap_strategy {
 	BOOTSTRAP_STRATEGY_AUTO,
 	BOOTSTRAP_STRATEGY_LEGACY,
 	BOOTSTRAP_STRATEGY_CONFIG,
+	BOOTSTRAP_STRATEGY_SUPERVISED,
 };
 
 /** Instance's bootstrap strategy. Controls replication reconfiguration. */

--- a/src/box/schema.cc
+++ b/src/box/schema.cc
@@ -222,6 +222,9 @@ schema_init(void)
 	key_parts[0].type = FIELD_TYPE_STRING;
 	sc_space_new(BOX_SCHEMA_ID, "_schema", key_parts, 1,
 		     &on_replace_schema);
+	struct space *schema = space_by_id(BOX_SCHEMA_ID);
+	assert(schema != NULL);
+	trigger_add(&schema->before_replace, &before_replace_schema);
 
 	/* _collation - collation description. */
 	key_parts[0].fieldno = 0;

--- a/src/box/schema_def.h
+++ b/src/box/schema_def.h
@@ -206,6 +206,7 @@ enum {
 /** _schema fields. */
 enum {
 	BOX_SCHEMA_FIELD_KEY = 0,
+	BOX_SCHEMA_FIELD_VALUE = 1,
 };
 
 /** _cluster fields. */


### PR DESCRIPTION
This commit adds another possible bootstrap_strategy to accompany "auto" and "config": "supervised".

Such a strategy may be useful to pin the desired bootstrap leader on an active cluster (so that the user may join the replicas from the desired node without changing their box.cfg) or to manually set the bootstrap leader among the nodes that managed to start without issues.

More details are in the docbot request.

Closes #8509

@TarantoolBot document
Title: new bootstrap strategy - "supervised"

The `bootstrap_strategy` configuration option may now be set to "supervised".

This strategy works as follows:
When bootstrapping a new replicaset, the nodes do not choose a bootstrap leader and wait for it to be appointed by the user: the user may appoint a bootstrap leader by calling `box.ctl.make_bootstrap_leader()` on the desired node. In order to do so the user has to start an admin console before the initial `box.cfg` call. The console may then be used to issue the `box.ctl.make_bootstrap_leader()` call.

When joining a new replica with `bootstrap_strategy` = "supervised", the replica will not choose the bootstrap_leader automatically, but will instead join to the node on which `box.ctl.make_bootstrap_leader()` was issued last.