### PR TITLE
box: apply dynamic cfg even if option value is unchanged

### DIFF
--- a/changelogs/unreleased/gh-8551-box-cfg-reload-fix.md
+++ b/changelogs/unreleased/gh-8551-box-cfg-reload-fix.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+ * `box.cfg.listen` and `box.cfg.replication` can now be reconfigured even if
+   the URI is unchanged (gh-8551).

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -910,11 +910,12 @@ local function reload_cfg(oldcfg, cfg)
     local module_keys = {}
     -- iterate over original table because prepare_cfg() may store NILs
     for key in pairs(cfg) do
-        if not compare_cfg(oldcfg[key], newcfg[key]) then
-            local name = option2module_name[key]
-            if name == nil then
+        local name = option2module_name[key]
+        if name == nil then
+            if not compare_cfg(oldcfg[key], newcfg[key]) then
                 box.error(box.error.RELOAD_CFG, key);
             end
+        else
             if module_keys[name] == nil then
                 module_keys[name] = {}
             end

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -1557,7 +1557,8 @@ memtx_engine_set_snap_io_rate_limit(struct memtx_engine *memtx, double limit)
 int
 memtx_engine_set_memory(struct memtx_engine *memtx, size_t size)
 {
-	if (size < quota_total(&memtx->quota)) {
+	if (DIV_ROUND_UP(size, QUOTA_UNIT_SIZE) <
+	    quota_total(&memtx->quota) / QUOTA_UNIT_SIZE) {
 		diag_set(ClientError, ER_CFG, "memtx_memory",
 			 "cannot decrease memory size at runtime");
 		return -1;

--- a/test/box-luatest/gh_8551_box_cfg_reload_test.lua
+++ b/test/box-luatest/gh_8551_box_cfg_reload_test.lua
@@ -1,0 +1,71 @@
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.master = server:new({alias = 'gh_8551_master'})
+    cg.master:start()
+    cg.master:exec(function()
+        box.schema.create_space('test')
+        box.space.test:create_index('primary')
+    end)
+    cg.replica = server:new({
+        alias = 'gh_8551_replica',
+        box_cfg = {
+            replication = server.build_listen_uri('gh_8551_master')
+        },
+    })
+    cg.replica:start()
+end)
+
+g.after_all(function(cg)
+    cg.master:drop()
+end)
+
+g.test_listen = function(cg)
+    cg.master:exec(function()
+        local fio = require('fio')
+        local old_listen = box.cfg.listen
+        local sock_path = fio.pathjoin(fio.cwd(), 'gh_8551_test.sock')
+        t.assert_not(fio.path.exists(sock_path))
+        box.cfg({listen = sock_path})
+        -- Delete the socket file and reconfigure box.cfg.listen.
+        -- The socket file must be recreated.
+        t.assert(fio.path.exists(sock_path))
+        t.assert(fio.unlink(sock_path))
+        t.assert_not(fio.path.exists(sock_path))
+        box.cfg({listen = sock_path})
+        t.assert(fio.path.exists(sock_path))
+        t.assert(fio.unlink(sock_path))
+        t.assert_not(fio.path.exists(sock_path))
+        -- Reset to the default box.cfg.listen.
+        box.cfg({listen = old_listen})
+        t.assert_not(fio.path.exists(sock_path))
+    end)
+end
+
+g.test_replication = function(cg)
+    cg.replica:exec(function()
+        -- Insert a conflicting record.
+        box.space.test:insert({1})
+    end)
+    cg.master:exec(function()
+        box.space.test:insert({1})
+    end)
+    cg.replica:exec(function()
+        -- Wait for replication to stop on conflict.
+        t.helpers.retrying({}, function()
+            t.assert(box.info.replication[1])
+            t.assert(box.info.replication[1].upstream)
+            t.assert_equals(box.info.replication[1].upstream.status, 'stopped')
+        end)
+        -- Delete the conflicting record and restart replication.
+        box.space.test:delete({1})
+        box.cfg({replication = box.cfg.replication})
+        t.helpers.retrying({}, function()
+            t.assert(box.info.replication[1])
+            t.assert(box.info.replication[1].upstream)
+            t.assert_equals(box.info.replication[1].upstream.status, 'follow')
+        end)
+    end)
+end


### PR DESCRIPTION
If a configuration option value passed to `box.cfg` is the same as the old one, the option handler isn't called. As a result, one can't restart the server IPROTO connection or replication by passing the same URI to `box.cfg`. This is inconvenient, for example:
 - To update an SSL key file without renaming it, one has to first pass an empty URI to `box.cfg.listen` and then reset it back.
 - To restart broken replication after fixing it manually (e.g. deleting a conflicting record on the replica), one has to first set `box.cfg.replication` to `{}` and then set it back instead of just calling `box.cfg{replication = box.cfg.replication}`.

There's no reason to skip an option update if the value is unchanged. It should be up to the option configuration callback.

The only callback that may actually fail on an attempt to set the same value is `box.cfg.memtx_memory`. This happens because the value is rounded up to a multiple of the quota unit size so we just need to fix the check accordingly.

Note that the `box.cfg.replication` configuration callback won't restart replication if it's up and running even if the URI list is rearranged thanks to commit 5994892c2f2c ("replication: fix replica disconnect upon reconfiguration"). This commit doesn't break this behavior - it just removes the `load_cfg.lua` code that would skip option update if the old and new option values are equal in Lua.

Needed for tarantool/tarantool-ee#432
Closes #8551