### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-8516-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8516-luajit-fixes.md
@@ -1,0 +1,6 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-8516). The following issues
+were fixed as part of this activity:
+
+* Fixed assembling of `IR_LREF` assembling for GC64 mode on x86_64.


### PR DESCRIPTION
* LJ_GC64: Make ASMREF_L references 64 bit.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump