### PR TITLE
test: bump test-run to version w/ updated luatest 

### DIFF
--- a/.github/workflows/osx_debug.yml
+++ b/.github/workflows/osx_debug.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ 12, 13 ]
+        version: [ 13 ]
         arch: [ x86_64, aarch64 ]
 
     steps:

--- a/.github/workflows/osx_release.yml
+++ b/.github/workflows/osx_release.yml
@@ -46,8 +46,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ 12, 13 ]
+        version: [ 13 ]
         arch: [ x86_64, aarch64 ]
+        include:
+          - version: 12
+            arch: x86_64
 
     steps:
       - name: Prepare checkout

--- a/.github/workflows/osx_static_cmake.yml
+++ b/.github/workflows/osx_static_cmake.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ 12, 13 ]
+        version: [ 13 ]
         arch: [ x86_64, aarch64 ]
 
     steps:

--- a/test/box-luatest/builtin_events_test.lua
+++ b/test/box-luatest/builtin_events_test.lua
@@ -89,8 +89,8 @@ g.test_box_status = function(cg)
             replication_connect_timeout = 0.001,
             replication_timeout = 0.001,
         }
-    end, {{server.build_listen_uri('master'),
-           server.build_listen_uri('replica')}})
+    end, {{cg.master.net_box_uri,
+           server.build_listen_uri('replica', cg.replica_set.id)}})
     -- here we have 2 notifications: entering ro when can't connect
     -- to master and the second one when going orphan
     t.helpers.retrying({}, function() t.assert_equals(result_no, 3) end)
@@ -143,9 +143,9 @@ g.before_test('test_box_election', function(cg)
 
     local box_cfg = {
         replication = {
-            server.build_listen_uri('instance_1'),
-            server.build_listen_uri('instance_2'),
-            server.build_listen_uri('instance_3'),
+            server.build_listen_uri('instance_1', cg.replica_set.id),
+            server.build_listen_uri('instance_2', cg.replica_set.id),
+            server.build_listen_uri('instance_3', cg.replica_set.id),
         },
         replication_connect_quorum = 0,
         election_mode = 'off',
@@ -339,7 +339,7 @@ g.before_test('test_internal_ballot', function(cg)
     cg.replica = cg.replica_set:build_and_add_server({
         alias = 'replica',
         box_cfg = {
-            replication = server.build_listen_uri('master'),
+            replication = cg.master.net_box_uri,
             replication_timeout = 0.1,
             replication_anon = true,
             read_only = true,

--- a/test/box-luatest/gh_6857_tuple_ext_validation_test.lua
+++ b/test/box-luatest/gh_6857_tuple_ext_validation_test.lua
@@ -1,6 +1,5 @@
 local t = require('luatest')
 local cluster = require('luatest.replica_set')
-local server = require('luatest.server')
 
 local g = t.group('gh-6857-tuple-ext-validation')
 
@@ -87,7 +86,7 @@ g.test_extension_tuple_validation = function()
         ['interval #7'] = string.fromhex('d6060100d100'), -- bad value (signed)
     }
 
-    local c = net_box.connect(server.build_listen_uri('default'))
+    local c = net_box.connect(g.cluster.servers[1].net_box_uri)
     t.assert_equals(c.state, 'active', 'Connection established')
 
     -- First check that there are no complaints on correctly-encoded ext types.

--- a/test/box-luatest/gh_7583_txn_stat_test.lua
+++ b/test/box-luatest/gh_7583_txn_stat_test.lua
@@ -66,7 +66,7 @@ g.before_test('test_replication', function(cg)
     cg.replica = server:new({
         alias = 'replica',
         box_cfg = {
-            replication = server.build_listen_uri('default'),
+            replication = cg.server.net_box_uri,
         },
     })
 end)

--- a/test/box-luatest/gh_7974_force_recovery_bugs_test.lua
+++ b/test/box-luatest/gh_7974_force_recovery_bugs_test.lua
@@ -18,7 +18,7 @@ g.test_unknown_request_type_force_recovery = function()
     local datadir = 'test/box-luatest/gh_7974_data/unknown_request_type'
     local s = server:new(
         {
-            alias = 'unknown_request_type_ok',
+            alias = 'gh_7974_urt_ok',
             box_cfg = {force_recovery = true},
             datadir = datadir,
         })
@@ -27,7 +27,7 @@ g.test_unknown_request_type_force_recovery = function()
 
     s = server:new(
         {
-            alias = 'unknown_request_type_fail',
+            alias = 'gh_7974_urt_fail',
             box_cfg = {force_recovery = false},
             datadir = datadir,
         })
@@ -55,7 +55,7 @@ g.test_invalid_non_insert_request_force_recovery = function()
     local datadir = 'test/box-luatest/gh_7974_data/invalid_non_insert_request'
     local s = server:new(
             {
-                alias = 'invalid_non_insert_request_ok',
+                alias = 'gh_7974_inir_ok',
                 box_cfg = {force_recovery = true},
                 datadir = datadir,
             })
@@ -64,7 +64,7 @@ g.test_invalid_non_insert_request_force_recovery = function()
 
     s = server:new(
         {
-            alias = 'invalid_non_insert_request_fail',
+            alias = 'gh_7974_inir_fail',
             box_cfg = {force_recovery = false},
             datadir = datadir,
         })
@@ -95,7 +95,7 @@ g.test_invalid_user_space_request_force_recovery = function()
     local datadir = 'test/box-luatest/gh_7974_data/invalid_user_space_request'
     local s = server:new(
             {
-                alias = 'invalid_user_space_request_ok',
+                alias = 'gh_7974_iusr_ok',
                 box_cfg = {force_recovery = true},
                 datadir = datadir,
             })
@@ -104,7 +104,7 @@ g.test_invalid_user_space_request_force_recovery = function()
 
     s = server:new(
         {
-            alias = 'invalid_user_space_request_fail',
+            alias = 'gh_7974_iusr_fail',
             box_cfg = {force_recovery = false},
             datadir = datadir,
         })
@@ -134,7 +134,7 @@ g.test_first_corrupted_request_force_recovery = function()
     local datadir = 'test/box-luatest/gh_7974_data/first_corrupted_request'
     local s = server:new(
             {
-                alias = 'first_corrupted_request_fail',
+                alias = 'gh_7974_fcr_fail',
                 box_cfg = {force_recovery = true},
                 datadir = datadir,
             })
@@ -165,7 +165,7 @@ g.test_second_corrupted_request_force_recovery = function()
     local datadir = 'test/box-luatest/gh_7974_data/second_corrupted_request'
     local s = server:new(
             {
-                alias = 'second_corrupted_request_ok',
+                alias = 'gh_7974_scr_ok',
                 box_cfg = {force_recovery = true},
                 datadir = datadir,
             })
@@ -174,7 +174,7 @@ g.test_second_corrupted_request_force_recovery = function()
 
     s = server:new(
         {
-            alias = 'second_corrupted_request_fail',
+            alias = 'gh_7974_scr_fail',
             box_cfg = {force_recovery = false},
             datadir = datadir,
         })
@@ -204,7 +204,7 @@ g.test_empty_snapshot_force_recovery = function()
     local datadir = 'test/box-luatest/gh_7974_data/empty_snapshot'
     local s = server:new(
             {
-                alias = 'empty_snapshot_fail',
+                alias = 'gh_7974_es_fail',
                 box_cfg = {force_recovery = true},
                 datadir = datadir,
             })
@@ -234,7 +234,7 @@ g.test_only_user_space_request_force_recovery = function()
     local datadir = 'test/box-luatest/gh_7974_data/only_user_space_request'
     local s = server:new(
             {
-                alias = 'only_user_space_request_fail',
+                alias = 'gh_7974_ousr_fail',
                 box_cfg = {force_recovery = true},
                 datadir = datadir,
             })

--- a/test/box-luatest/gh_7988_auth_type_test.lua
+++ b/test/box-luatest/gh_7988_auth_type_test.lua
@@ -68,7 +68,7 @@ g.before_test('test_replication', function(cg)
     cg.replica = server:new({
         alias = 'replica',
         box_cfg = {
-            replication = server.build_listen_uri('master'),
+            replication = cg.server.net_box_uri,
         },
     })
     cg.replica:start()
@@ -97,5 +97,5 @@ g.test_replication = function(cg)
         uri = urilib.format(parsed_uri, true)
         box.cfg({replication = uri})
         t.assert_equals(box.info.replication[1].upstream.status, 'follow')
-    end, {server.build_listen_uri('master')})
+    end, {cg.server.net_box_uri})
 end

--- a/test/box-luatest/gh_8260_system_read_view_list_test.lua
+++ b/test/box-luatest/gh_8260_system_read_view_list_test.lua
@@ -201,11 +201,11 @@ g_list.before_all(function(cg)
     end)
     cg.replica1 = server:new({
         alias = 'replica1',
-        box_cfg = {replication = server.build_listen_uri('master')},
+        box_cfg = {replication = cg.server.net_box_uri},
     })
     cg.replica2 = server:new({
         alias = 'replica2',
-        box_cfg = {replication = server.build_listen_uri('master')},
+        box_cfg = {replication = cg.server.net_box_uri},
     })
 end)
 

--- a/test/engine-luatest/gh_6436_field_constraint_test.lua
+++ b/test/engine-luatest/gh_6436_field_constraint_test.lua
@@ -574,7 +574,7 @@ g.test_constraint_replication = function(cg)
     end, {engine})
 
     local replica_cfg = {
-        replication = server.build_listen_uri('master'),
+        replication = cg.server.net_box_uri,
     }
     local replica = server:new({alias = 'replica', box_cfg = replica_cfg})
     replica:start()

--- a/test/replication-luatest/bootstrap_strategy_test.lua
+++ b/test/replication-luatest/bootstrap_strategy_test.lua
@@ -39,8 +39,8 @@ g_auto.before_test('test_auto_bootstrap_waits_for_confirmations', function(cg)
     cg.replica_set = replica_set:new{}
     cg.box_cfg = {
         replication = {
-            server.build_listen_uri('server_bs_1'),
-            server.build_listen_uri('server_bs_2'),
+            server.build_listen_uri('server1'),
+            server.build_listen_uri('server2'),
         },
         replication_connect_timeout = 1000,
         replication_timeout = 0.1,
@@ -48,18 +48,18 @@ g_auto.before_test('test_auto_bootstrap_waits_for_confirmations', function(cg)
     -- Make server1 the bootstrap leader.
     cg.box_cfg.instance_uuid = uuid1
     cg.server1 = cg.replica_set:build_and_add_server{
-        alias = 'server_bs_1',
+        alias = 'server1',
         box_cfg = cg.box_cfg,
     }
-    cg.box_cfg.replication[3] = server.build_listen_uri('server_bs_3')
+    cg.box_cfg.replication[3] = server.build_listen_uri('server3')
     cg.box_cfg.instance_uuid = uuid2
     cg.server2 = cg.replica_set:build_and_add_server{
-        alias = 'server_bs_2',
+        alias = 'server2',
         box_cfg = cg.box_cfg,
     }
     cg.box_cfg.instance_uuid = uuid3
     cg.server3 = cg.replica_set:build_and_add_server{
-        alias = 'server_bs_3',
+        alias = 'server3',
         box_cfg = cg.box_cfg,
     }
 end)
@@ -82,19 +82,19 @@ g_auto.before_test('test_join_checks_fullmesh', function(cg)
     cg.replica_set = replica_set:new{}
     cg.box_cfg = {
         replication = {
-            server.build_listen_uri('server_bs_1'),
-            server.build_listen_uri('server_bs_2'),
+            server.build_listen_uri('server1'),
+            server.build_listen_uri('server2'),
         },
         replication_timeout = 0.1,
     }
     cg.box_cfg.instance_uuid = uuid1
     cg.server1 = cg.replica_set:build_and_add_server{
-        alias = 'server_bs_1',
+        alias = 'server1',
         box_cfg = cg.box_cfg,
     }
     cg.box_cfg.instance_uuid = uuid2
     cg.server2 = cg.replica_set:build_and_add_server{
-        alias = 'server_bs_2',
+        alias = 'server2',
         box_cfg = cg.box_cfg,
     }
     cg.replica_set:start()
@@ -103,11 +103,11 @@ end)
 g_auto.test_join_checks_fullmesh = function(cg)
     cg.box_cfg.replication[2] = nil
     cg.server3 = cg.replica_set:build_server{
-        alias = 'server_bs_3',
+        alias = 'server3',
         box_cfg = cg.box_cfg,
     }
     cg.server3:start{wait_until_ready = false}
-    local logfile = fio.pathjoin(cg.server3.workdir, 'server_bs_3.log')
+    local logfile = fio.pathjoin(cg.server3.workdir, 'server3.log')
     local uuid_pattern = uuid2:gsub('%-', '%%-')
     local pattern = 'No connection to ' .. uuid_pattern
     t.helpers.retrying({}, function()
@@ -190,11 +190,11 @@ end)
 g_config.before_test('test_no_replication', function(cg)
     cg.replica_set = replica_set:new{}
     cg.server1 = cg.replica_set:build_and_add_server{
-        alias = 'server_bs_1',
+        alias = 'server1',
         box_cfg = {
             replication_timeout = 0.1,
             bootstrap_strategy = 'config',
-            bootstrap_leader = server.build_listen_uri('server_bs_1'),
+            bootstrap_leader = server.build_listen_uri('server1'),
             replication = nil
         },
     }
@@ -204,7 +204,7 @@ local no_leader_msg = 'failed to connect to the bootstrap leader'
 
 g_config.test_no_replication = function(cg)
     cg.replica_set:start{wait_until_ready = false}
-    local logfile = fio.pathjoin(cg.server1.workdir, 'server_bs_1.log')
+    local logfile = fio.pathjoin(cg.server1.workdir, 'server1.log')
     t.helpers.retrying({}, function()
         t.assert(server:grep_log(no_leader_msg, nil, {filename = logfile}))
     end)
@@ -213,7 +213,7 @@ end
 g_config.before_test('test_uuid', function(cg)
     cg.replica_set = replica_set:new{}
     cg.server1 = cg.replica_set:build_and_add_server{
-        alias = 'server_bs_1',
+        alias = 'server1',
         box_cfg = {
             bootstrap_strategy = 'config',
             bootstrap_leader = uuid1,
@@ -238,18 +238,18 @@ end)
 g_config.before_test('test_replication_without_bootstrap_leader', function(cg)
     cg.replica_set = replica_set:new{}
     cg.server1 = cg.replica_set:build_and_add_server{
-        alias = 'server_bs_1',
+        alias = 'server1',
         box_cfg = {
             replication_timeout = 0.1,
             bootstrap_strategy = 'config',
-            bootstrap_leader = server.build_listen_uri('server_bs_1'),
+            bootstrap_leader = server.build_listen_uri('server1'),
             replication = {
-                server.build_listen_uri('server_bs_2'),
+                server.build_listen_uri('server2'),
             },
         },
     }
     cg.server2 = cg.replica_set:build_and_add_server{
-        alias = 'server_bs_2',
+        alias = 'server2',
         box_cfg = {
             replication_timeout = 0.1,
         },
@@ -258,7 +258,7 @@ end)
 
 g_config.test_replication_without_bootstrap_leader = function(cg)
     cg.replica_set:start{wait_until_ready = false}
-    local logfile = fio.pathjoin(cg.server1.workdir, 'server_bs_1.log')
+    local logfile = fio.pathjoin(cg.server1.workdir, 'server1.log')
     t.helpers.retrying({}, function()
         t.assert(server:grep_log(no_leader_msg, nil, {filename = logfile}))
     end)
@@ -280,12 +280,12 @@ local set_log_before_cfg = [[
 g_config.before_test('test_no_leader', function(cg)
     cg.replica_set = replica_set:new{}
     cg.server1 = cg.replica_set:build_and_add_server{
-        alias = 'server_bs_1',
+        alias = 'server1',
         box_cfg = {
             replication_timeout = 0.1,
             bootstrap_strategy = 'config',
             bootstrap_leader = nil,
-            replication = server.build_listen_uri('server_bs_1'),
+            replication = server.build_listen_uri('server1'),
         },
         env = {
             ['TARANTOOL_RUN_BEFORE_BOX_CFG'] = set_log_before_cfg,
@@ -295,7 +295,7 @@ end)
 
 g_config.test_no_leader = function(cg)
     cg.replica_set:start{wait_until_ready = false}
-    local logfile = fio.pathjoin(cg.server1.workdir, 'server_bs_1.log')
+    local logfile = fio.pathjoin(cg.server1.workdir, 'server1.log')
     local empty_leader_msg = "the option can't be empty when bootstrap " ..
                              "strategy is 'config'"
     t.helpers.retrying({}, function()
@@ -306,12 +306,12 @@ end
 g_config.before_test('test_single_leader', function(cg)
     cg.replica_set = replica_set:new{}
     cg.server1 = cg.replica_set:build_and_add_server{
-        alias = 'server_bs_1',
+        alias = 'server1',
         box_cfg = {
             replication_timeout = 0.1,
             bootstrap_strategy = 'config',
-            bootstrap_leader = server.build_listen_uri('server_bs_1'),
-            replication = server.build_listen_uri('server_bs_1'),
+            bootstrap_leader = server.build_listen_uri('server1'),
+            replication = server.build_listen_uri('server1'),
         },
     }
 end)
@@ -329,14 +329,14 @@ g_config.after_test('test_single_leader', function(cg)
 end)
 
 local g_config_success = t.group('gh-7999-bootstrap-strategy-config-success', {
-     {leader = 'server_bs_3'},
+     {leader = 'server3'},
      {leader = uuid3},
 })
 
 g_config_success.before_each(function(cg)
     cg.leader = cg.params.leader
     -- cg.params can't have "/" for some reason, so recreate the path here.
-    if string.match(cg.leader, 'server_bs_3') then
+    if string.match(cg.leader, 'server3') then
         cg.leader = server.build_listen_uri(cg.leader)
     end
 end)
@@ -348,22 +348,22 @@ end)
 g_config_success.before_test('test_correct_bootstrap_leader', function(cg)
     cg.replica_set = replica_set:new{}
     cg.server1 = cg.replica_set:build_and_add_server{
-        alias = 'server_bs_1',
+        alias = 'server1',
         box_cfg = {
             bootstrap_strategy = 'config',
             bootstrap_leader = cg.leader,
             instance_uuid = uuid1,
             replication = {
-                server.build_listen_uri('server_bs_1'),
-                server.build_listen_uri('server_bs_2'),
-                server.build_listen_uri('server_bs_3'),
+                server.build_listen_uri('server1'),
+                server.build_listen_uri('server2'),
+                server.build_listen_uri('server3'),
             },
             replication_timeout = 0.1,
         },
     }
     cg.replica_set_a = replica_set:new{}
     cg.server2 = cg.replica_set_a:build_and_add_server{
-        alias = 'server_bs_2',
+        alias = 'server2',
         box_cfg = {
             replicaset_uuid = uuida,
             instance_uuid = uuid2,
@@ -371,12 +371,12 @@ g_config_success.before_test('test_correct_bootstrap_leader', function(cg)
     }
     cg.replica_set_b = replica_set:new{}
     cg.server3 = cg.replica_set_b:build_and_add_server{
-        alias = 'server_bs_3',
+        alias = 'server3',
         box_cfg = {
             replicaset_uuid = uuidb,
             instance_uuid = uuid3,
             listen = {
-                server.build_listen_uri('server_bs_3'),
+                server.build_listen_uri('server3'),
             },
         },
     }
@@ -401,14 +401,14 @@ end
 g_config_success.before_test('test_wait_only_for_leader', function(cg)
     cg.replica_set = replica_set:new{}
     cg.server1 = cg.replica_set:build_and_add_server{
-        alias = 'server_bs_1',
+        alias = 'server1',
         box_cfg = {
             bootstrap_strategy = 'config',
             bootstrap_leader = cg.leader,
             replication = {
-                server.build_listen_uri('server_bs_1'),
+                server.build_listen_uri('server1'),
                 server.build_listen_uri('unreachable_2'),
-                server.build_listen_uri('server_bs_3'),
+                server.build_listen_uri('server3'),
                 server.build_listen_uri('unreachable_4'),
             },
             replication_connect_timeout = 1000,
@@ -416,12 +416,12 @@ g_config_success.before_test('test_wait_only_for_leader', function(cg)
         },
     }
     cg.server3 = cg.replica_set:build_and_add_server{
-        alias = 'server_bs_3',
+        alias = 'server3',
         box_cfg = {
             replicaset_uuid = uuidb,
             instance_uuid = uuid3,
             listen = {
-                server.build_listen_uri('server_bs_3'),
+                server.build_listen_uri('server3'),
             },
         },
     }

--- a/test/replication-luatest/election_fencing_test.lua
+++ b/test/replication-luatest/election_fencing_test.lua
@@ -3,10 +3,10 @@ local cluster = require('luatest.replica_set')
 local server = require('luatest.server')
 
 local g_async = luatest.group('fencing_async', {
-    {mode = 'manual'}, {mode = 'candidate'}})
+    {election_mode = 'manual'}, {election_mode = 'candidate'}})
 local g_sync = luatest.group('fencing_sync')
 local g_mode = luatest.group('fencing_mode', {
-    {mode = 'soft'}, {mode = 'strict'}})
+    {election_fencing_mode = 'soft'}, {election_fencing_mode = 'strict'}})
 
 local SHORT_TIMEOUT = 0.1
 local LONG_TIMEOUT = 1000
@@ -61,20 +61,13 @@ local function box_cfg_update(servers, cfg)
 end
 
 local function start(g)
-    local suffix
-    if g.params then
-        suffix = g.params.mode
-    else
-        suffix = g.name
-    end
-
     g.box_cfg = {
         election_mode = 'manual',
         election_timeout = SHORT_TIMEOUT,
         replication = {
-            server.build_listen_uri('server_1_' .. suffix),
-            server.build_listen_uri('server_2_' .. suffix),
-            server.build_listen_uri('server_3_' .. suffix),
+            server.build_listen_uri('server_1'),
+            server.build_listen_uri('server_2'),
+            server.build_listen_uri('server_3'),
         },
         replication_synchro_quorum = 2,
         replication_synchro_timeout = SHORT_TIMEOUT,
@@ -83,13 +76,13 @@ local function start(g)
 
     g.cluster = cluster:new({})
     g.server_1 = g.cluster:build_and_add_server(
-        {alias = 'server_1_' .. suffix, box_cfg = g.box_cfg})
+        {alias = 'server_1', box_cfg = g.box_cfg})
 
     g.box_cfg.read_only = true
     g.server_2 = g.cluster:build_and_add_server(
-        {alias = 'server_2_' .. suffix, box_cfg = g.box_cfg})
+        {alias = 'server_2', box_cfg = g.box_cfg})
     g.server_3 = g.cluster:build_and_add_server(
-        {alias = 'server_3_' .. suffix, box_cfg = g.box_cfg})
+        {alias = 'server_3', box_cfg = g.box_cfg})
 
     g.cluster:start()
     g.cluster:wait_for_fullmesh()
@@ -116,7 +109,7 @@ g_async.after_each(function(g)
 end)
 
 g_async.test_fencing = function(g)
-    box_cfg_update({g.server_1}, {election_mode = g.params.mode})
+    box_cfg_update({g.server_1}, {election_mode = g.params.election_mode})
     g.server_1:exec(function()
         box.schema.create_space('test'):create_index('pk')
     end)
@@ -303,20 +296,19 @@ g_mode.after_all(stop)
 g_mode.test_fencing_mode = function(g)
     local timeout = 0.5
     box_cfg_update({g.server_1, g.server_2}, {
-        election_fencing_mode = g.params.mode,
+        election_fencing_mode = g.params.election_fencing_mode,
         replication_timeout = timeout,
     })
 
     local proxy = require('luatest.replica_proxy'):new({
-        client_socket_path = server.build_listen_uri(
-            g.server_1.alias .. '_proxy'),
-        server_socket_path = server.build_listen_uri(g.server_1.alias),
+        client_socket_path = server.build_listen_uri('server_1_proxy'),
+        server_socket_path = server.build_listen_uri('server_1'),
     })
     proxy:start({force = true})
 
     local proxied_replication = {
-        server.build_listen_uri(g.server_1.alias .. '_proxy'),
-        server.build_listen_uri(g.server_2.alias),
+        server.build_listen_uri('server_1_proxy'),
+        server.build_listen_uri('server_2'),
     }
 
     box_cfg_update({g.server_2}, {replication = {}})
@@ -343,7 +335,7 @@ g_mode.test_fencing_mode = function(g)
         return box.info.replication[leader_id].upstream.status
     end, {leader_id})
 
-    if g.params.mode == 'strict' then
+    if g.params.election_fencing_mode == 'strict' then
         luatest.assert_equals(follower_connection_status, 'follow',
             'Follower did not notice leader disconnection')
     else

--- a/test/replication-luatest/election_fencing_test.lua
+++ b/test/replication-luatest/election_fencing_test.lua
@@ -61,20 +61,21 @@ local function box_cfg_update(servers, cfg)
 end
 
 local function start(g)
+    g.cluster = cluster:new({})
+
     g.box_cfg = {
         election_mode = 'manual',
         election_timeout = SHORT_TIMEOUT,
         replication = {
-            server.build_listen_uri('server_1'),
-            server.build_listen_uri('server_2'),
-            server.build_listen_uri('server_3'),
+            server.build_listen_uri('server_1', g.cluster.id),
+            server.build_listen_uri('server_2', g.cluster.id),
+            server.build_listen_uri('server_3', g.cluster.id),
         },
         replication_synchro_quorum = 2,
         replication_synchro_timeout = SHORT_TIMEOUT,
         replication_timeout = SHORT_TIMEOUT,
     }
 
-    g.cluster = cluster:new({})
     g.server_1 = g.cluster:build_and_add_server(
         {alias = 'server_1', box_cfg = g.box_cfg})
 
@@ -302,13 +303,13 @@ g_mode.test_fencing_mode = function(g)
 
     local proxy = require('luatest.replica_proxy'):new({
         client_socket_path = server.build_listen_uri('server_1_proxy'),
-        server_socket_path = server.build_listen_uri('server_1'),
+        server_socket_path = server.build_listen_uri('server_1', g.cluster.id),
     })
     proxy:start({force = true})
 
     local proxied_replication = {
         server.build_listen_uri('server_1_proxy'),
-        server.build_listen_uri('server_2'),
+        server.build_listen_uri('server_2', g.cluster.id),
     }
 
     box_cfg_update({g.server_2}, {replication = {}})

--- a/test/replication-luatest/election_pre_vote_test.lua
+++ b/test/replication-luatest/election_pre_vote_test.lua
@@ -17,9 +17,9 @@ g.before_all(function()
     g.cluster = cluster:new({})
     g.cfg = {
         replication = {
-            server.build_listen_uri('node1'),
-            server.build_listen_uri('node2'),
-            server.build_listen_uri('node3'),
+            server.build_listen_uri('node1', g.cluster.id),
+            server.build_listen_uri('node2', g.cluster.id),
+            server.build_listen_uri('node3', g.cluster.id),
         },
         election_mode = 'candidate',
         replication_timeout = REPLICATION_TIMEOUT,
@@ -58,8 +58,8 @@ g.test_no_direct_connection = function(g)
     g.follower1:exec(function(cfg) box.cfg(cfg) end,
         {{
             replication = {
-               server.build_listen_uri(g.follower1.alias),
-               server.build_listen_uri(g.follower2.alias),
+               g.follower1.net_box_uri,
+               g.follower2.net_box_uri,
             }
         }})
     t.helpers.retrying({}, function()
@@ -91,8 +91,8 @@ g.test_no_quorum = function(g)
     g.follower1:exec(function(cfg) box.cfg(cfg) end,
         {{
             replication = {
-               server.build_listen_uri(g.follower1.alias),
-               server.build_listen_uri(g.follower2.alias),
+               g.follower1.net_box_uri,
+               g.follower2.net_box_uri,
             }
         }})
     t.assert_equals(g.follower1:exec(get_election_term), term,

--- a/test/replication-luatest/election_split_vote_test.lua
+++ b/test/replication-luatest/election_split_vote_test.lua
@@ -13,8 +13,8 @@ local g = t.group('split-vote')
 
 g.before_each(function()
     g.cluster = cluster:new({})
-    local node1_uri = server.build_listen_uri('node1')
-    local node2_uri = server.build_listen_uri('node2')
+    local node1_uri = server.build_listen_uri('node1', g.cluster.id)
+    local node2_uri = server.build_listen_uri('node2', g.cluster.id)
     local replication = {node1_uri, node2_uri}
     local box_cfg = {
         listen = node1_uri,

--- a/test/replication-luatest/gh_4669_applier_reconnect_test.lua
+++ b/test/replication-luatest/gh_4669_applier_reconnect_test.lua
@@ -9,7 +9,7 @@ g.before_each(function()
     g.master = g.cluster:build_server({alias = 'master'})
     local box_cfg = {
         bootstrap_strategy = 'legacy',
-        replication = server.build_listen_uri('master'),
+        replication = g.master.net_box_uri,
     }
     g.replica = g.cluster:build_server({alias = 'replica', box_cfg = box_cfg})
     g.replica2 = g.cluster:build_server({alias = 'replica2', box_cfg = box_cfg})

--- a/test/replication-luatest/gh_5158_invalid_recovery_from_xlog_test.lua
+++ b/test/replication-luatest/gh_5158_invalid_recovery_from_xlog_test.lua
@@ -1,6 +1,5 @@
 local t = require('luatest')
 local cluster = require('luatest.replica_set')
-local server = require('luatest.server')
 local fio = require('fio')
 
 local g = t.group('gh_5158')
@@ -17,7 +16,7 @@ g.before_each(function(cg)
         alias = 'replica',
         box_cfg = {
             replication = {
-                server.build_listen_uri('master'),
+                cg.master.net_box_uri,
             },
         },
     }
@@ -71,7 +70,7 @@ g.test_invalid_recovery_from_xlog = function(cg)
         box.cfg{wal_queue_max_size = 1}
         box.cfg{replication = uri, replication_sync_timeout = 0.1}
         box.error.injection.set('ERRINJ_WAL_DELAY', false)
-    end, {server.build_listen_uri('master')})
+    end, {cg.master.net_box_uri})
 
     -- Check that the master isn't dead
     t.assert_equals(cg.master:exec(function()

--- a/test/replication-luatest/gh_5295_split_brain_test.lua
+++ b/test/replication-luatest/gh_5295_split_brain_test.lua
@@ -60,8 +60,8 @@ g.before_each(function(cg)
 
     test_id = test_id + 1
     cg.box_cfg.replication = {
-            server.build_listen_uri('main'),
-            server.build_listen_uri('split_replica'..test_id),
+            cg.main.net_box_uri,
+            server.build_listen_uri('split_replica'..test_id, cg.cluster.id),
     }
     cg.split_replica = cg.cluster:build_and_add_server{
         alias = 'split_replica'..test_id,
@@ -101,8 +101,9 @@ local function partition_replica(cg)
     cg.main:exec(update_replication, {})
 end
 
-local function reconnect_and_check_split_brain(srv)
-    srv:exec(update_replication, {server.build_listen_uri('main')})
+local function reconnect_and_check_split_brain(cg)
+    local srv = cg.split_replica
+    srv:exec(update_replication, {cg.main.net_box_uri})
     t.helpers.retrying({}, srv.exec, srv, function()
         local upstream = box.info.replication[1].upstream
         t.assert_equals(upstream.status, 'stopped', 'replication is stopped')
@@ -136,7 +137,7 @@ g.test_async_old_term = function(cg)
     partition_replica(cg)
     cg.split_replica:exec(write_promote)
     cg.main:exec(function() box.space.async:replace{1} end)
-    reconnect_and_check_split_brain(cg.split_replica)
+    reconnect_and_check_split_brain(cg)
 end
 
 -- Any unseen sync transaction confirmation from an obsolete term means a
@@ -145,7 +146,7 @@ g.test_confirm_old_term = function(cg)
     partition_replica(cg)
     cg.split_replica:exec(write_promote)
     cg.main:exec(function() box.space.sync:replace{1} end)
-    reconnect_and_check_split_brain(cg.split_replica)
+    reconnect_and_check_split_brain(cg)
 end
 
 -- Any unseen sync transaction rollback from an obsolete term means a
@@ -158,7 +159,7 @@ g.test_rollback_old_term = function(cg)
         pcall(box.space.sync.replace, box.space.sync, {1})
         box.cfg{replication_synchro_quorum = 1}
     end)
-    reconnect_and_check_split_brain(cg.split_replica)
+    reconnect_and_check_split_brain(cg)
 end
 
 -- Conflicting demote for the same term is a split-brain.
@@ -166,7 +167,7 @@ g.test_demote_same_term = function(cg)
     partition_replica(cg)
     cg.split_replica:exec(write_promote)
     cg.main:exec(write_demote)
-    reconnect_and_check_split_brain(cg.split_replica)
+    reconnect_and_check_split_brain(cg)
     cg.main:exec(write_promote)
 end
 
@@ -176,7 +177,7 @@ g.test_promote_same_term = function(cg)
     partition_replica(cg)
     cg.split_replica:exec(write_promote)
     cg.main:exec(write_promote)
-    reconnect_and_check_split_brain(cg.split_replica)
+    reconnect_and_check_split_brain(cg)
 end
 
 -- Promote from a bigger term with lsn < confirmed_lsn is a split brain.
@@ -185,7 +186,7 @@ g.test_promote_new_term_small_lsn = function(cg)
     partition_replica(cg)
     cg.split_replica:exec(function() box.space.sync:replace{1} end)
     cg.main:exec(write_promote)
-    reconnect_and_check_split_brain(cg.split_replica)
+    reconnect_and_check_split_brain(cg)
 end
 
 local function fill_queue_and_write(server)
@@ -220,7 +221,7 @@ g.test_promote_new_term_big_lsn = function(cg)
     partition_replica(cg)
     perform_rollback(cg.split_replica)
     cg.main:exec(write_promote)
-    reconnect_and_check_split_brain(cg.split_replica)
+    reconnect_and_check_split_brain(cg)
 end
 
 -- Promote from a bigger term with conflicting queue contents is a split brain.
@@ -231,5 +232,5 @@ g.test_promote_new_term_conflicting_queue = function(cg)
     perform_rollback(cg.split_replica)
     cg.main:exec(write_promote)
     fill_queue_and_write(cg.split_replica)
-    reconnect_and_check_split_brain(cg.split_replica)
+    reconnect_and_check_split_brain(cg)
 end

--- a/test/replication-luatest/gh_5418_qsync_with_anon_test.lua
+++ b/test/replication-luatest/gh_5418_qsync_with_anon_test.lua
@@ -9,7 +9,7 @@ g.before_each(function(cg)
 
     local box_cfg = {
         replication         = {
-            server.build_listen_uri('master')
+            server.build_listen_uri('master', cg.cluster.id)
         },
         replication_synchro_quorum = 2,
         replication_timeout = 1
@@ -19,8 +19,8 @@ g.before_each(function(cg)
 
     local box_cfg = {
         replication         = {
-            server.build_listen_uri('master'),
-            server.build_listen_uri('replica')
+            cg.master.net_box_uri,
+            server.build_listen_uri('replica', cg.cluster.id)
         },
         replication_timeout = 1,
         replication_connect_timeout = 4,

--- a/test/replication-luatest/gh_5568_read_only_reason_test.lua
+++ b/test/replication-luatest/gh_5568_read_only_reason_test.lua
@@ -17,8 +17,8 @@ local wait_timeout = 120
 --
 local function make_create_cluster(g) return function()
     g.cluster = cluster:new({})
-    local master_uri = server.build_listen_uri('master')
-    local replica_uri = server.build_listen_uri('replica')
+    local master_uri = server.build_listen_uri('master', g.cluster.id)
+    local replica_uri = server.build_listen_uri('replica', g.cluster.id)
     local replication = {master_uri, replica_uri}
     local box_cfg = {
         listen = master_uri,
@@ -97,7 +97,7 @@ end
 -- Read-only because is an orphan.
 --
 g.test_read_only_reason_orphan = function(g)
-    local fake_uri = server.build_listen_uri('fake')
+    local fake_uri = server.build_listen_uri('fake', g.cluster.id)
     local old_timeout, ok, err = g.master:exec(function(fake_uri)
         -- Make connect-quorum impossible to satisfy using a fake instance.
         local old_timeout = box.cfg.replication_connect_timeout

--- a/test/replication-luatest/gh_6033_box_promote_demote_test.lua
+++ b/test/replication-luatest/gh_6033_box_promote_demote_test.lua
@@ -92,8 +92,8 @@ local function cluster_init(g)
         replication_synchro_timeout = 5,
         replication_synchro_quorum = 1,
         replication = {
-            server.build_listen_uri('server_1'),
-            server.build_listen_uri('server_2'),
+            server.build_listen_uri('server_1', g.cluster.id),
+            server.build_listen_uri('server_2', g.cluster.id),
         },
     }
 
@@ -387,9 +387,9 @@ g_common.test_limbo_full_interfering_promote = function(g)
     -- server_2 will interrupt server_1, while server_3 is leader
     local box_cfg = table.copy(g.box_cfg)
     box_cfg.replication = {
-        server.build_listen_uri('server_1'),
-        server.build_listen_uri('server_2'),
-        server.build_listen_uri('server_3'),
+        g.server_1.net_box_uri,
+        g.server_2.net_box_uri,
+        server.build_listen_uri('server_3', g.cluster.id),
     }
 
     local server_3 = g.cluster:build_server(

--- a/test/replication-luatest/gh_6033_box_promote_demote_test.lua
+++ b/test/replication-luatest/gh_6033_box_promote_demote_test.lua
@@ -92,15 +92,15 @@ local function cluster_init(g)
         replication_synchro_timeout = 5,
         replication_synchro_quorum = 1,
         replication = {
-            server.build_listen_uri('server_gh6033_1'),
-            server.build_listen_uri('server_gh6033_2'),
+            server.build_listen_uri('server_1'),
+            server.build_listen_uri('server_2'),
         },
     }
 
     g.server_1 = g.cluster:build_and_add_server(
-        {alias = 'server_gh6033_1', box_cfg = g.box_cfg})
+        {alias = 'server_1', box_cfg = g.box_cfg})
     g.server_2 = g.cluster:build_and_add_server(
-        {alias = 'server_gh6033_2', box_cfg = g.box_cfg})
+        {alias = 'server_2', box_cfg = g.box_cfg})
     g.cluster:start()
     g.cluster:wait_for_fullmesh()
 end
@@ -387,13 +387,13 @@ g_common.test_limbo_full_interfering_promote = function(g)
     -- server_2 will interrupt server_1, while server_3 is leader
     local box_cfg = table.copy(g.box_cfg)
     box_cfg.replication = {
-        server.build_listen_uri('server_gh6033_1'),
-        server.build_listen_uri('server_gh6033_2'),
-        server.build_listen_uri('server_gh6033_3'),
+        server.build_listen_uri('server_1'),
+        server.build_listen_uri('server_2'),
+        server.build_listen_uri('server_3'),
     }
 
     local server_3 = g.cluster:build_server(
-        {alias = 'server_gh6033_3', box_cfg = box_cfg})
+        {alias = 'server_3', box_cfg = box_cfg})
     server_3:start()
     wait_sync({g.server_1, g.server_2, server_3})
     box_cfg_update(g.cluster.servers, box_cfg)

--- a/test/replication-luatest/gh_6036_qsync_order_test.lua
+++ b/test/replication-luatest/gh_6036_qsync_order_test.lua
@@ -10,8 +10,8 @@ g.before_all(function(cg)
 
     cg.box_cfg = {
         replication = {
-            server.build_listen_uri('r1'),
-            server.build_listen_uri('r2'),
+            server.build_listen_uri('r1', cg.cluster.id),
+            server.build_listen_uri('r2', cg.cluster.id),
         },
         replication_timeout         = 0.1,
         replication_connect_quorum  = 1,
@@ -62,7 +62,7 @@ end
 --
 -- The test requires 3rd replica to graft in.
 g.before_test("test_qsync_order", function(cg)
-    cg.box_cfg.replication[3] = server.build_listen_uri("r3")
+    cg.box_cfg.replication[3] = server.build_listen_uri("r3", cg.cluster.id)
     cg.r3 = cg.cluster:build_and_add_server({
         alias = 'r3',
         box_cfg = cg.box_cfg
@@ -90,15 +90,15 @@ g.test_qsync_order = function(cg)
     --
     -- Drop connection between r3 and r2.
     cg.r3:exec(update_replication, {
-        server.build_listen_uri("r1"),
-        server.build_listen_uri("r3"),
+        cg.r1.net_box_uri,
+        cg.r3.net_box_uri,
     })
 
     --
     -- Drop connection between r2 and r3.
     cg.r2:exec(update_replication, {
-        server.build_listen_uri("r1"),
-        server.build_listen_uri("r2"),
+        cg.r1.net_box_uri,
+        cg.r2.net_box_uri,
     })
 
     --

--- a/test/replication-luatest/gh_6123_truncate_temp_space_test.lua
+++ b/test/replication-luatest/gh_6123_truncate_temp_space_test.lua
@@ -9,7 +9,7 @@ g.before_each(function(cg)
 
     local box_cfg = {
         replication         = {
-            server.build_listen_uri('master')
+            server.build_listen_uri('master', cg.cluster.id)
         },
         replication_timeout = 1,
         read_only           = false
@@ -19,8 +19,8 @@ g.before_each(function(cg)
 
     local box_cfg = {
         replication         = {
-            server.build_listen_uri('master'),
-            server.build_listen_uri('replica')
+            cg.master.net_box_uri,
+            server.build_listen_uri('replica', cg.cluster.id)
         },
         replication_timeout = 1,
         replication_connect_timeout = 4,

--- a/test/replication-luatest/gh_6126_auto_rejoin_test.lua
+++ b/test/replication-luatest/gh_6126_auto_rejoin_test.lua
@@ -10,7 +10,7 @@ g.before_each(function(cg)
 
     local box_cfg = {
         replication = {
-            server.build_listen_uri('instance_1'),
+            server.build_listen_uri('instance_1', cg.cluster.id),
         },
         instance_uuid = t.helpers.uuid('b'),
     }
@@ -19,8 +19,8 @@ g.before_each(function(cg)
 
     box_cfg = {
         replication = {
-            server.build_listen_uri('anon'),
-            server.build_listen_uri('instance_1'),
+            server.build_listen_uri('anon', cg.cluster.id),
+            cg.instance_1.net_box_uri,
         },
         instance_uuid = t.helpers.uuid('a'),
         read_only = true,
@@ -31,9 +31,9 @@ g.before_each(function(cg)
 
     box_cfg = {
         replication = {
-            server.build_listen_uri('anon'),
-            server.build_listen_uri('instance_1'),
-            server.build_listen_uri('instance_2'),
+            cg.anon.net_box_uri,
+            cg.instance_1.net_box_uri,
+            server.build_listen_uri('instance_2', cg.cluster.id),
         },
         instance_uuid = t.helpers.uuid('c'),
     }

--- a/test/replication-luatest/gh_6754_promote_before_new_term_test.lua
+++ b/test/replication-luatest/gh_6754_promote_before_new_term_test.lua
@@ -13,18 +13,18 @@ g.before_all(function(g)
         replication_synchro_quorum = 1,
         replication_timeout = 0.1,
         replication = {
-            server.build_listen_uri('server_gh6754_1'),
-            server.build_listen_uri('server_gh6754_2'),
+            server.build_listen_uri('server_1'),
+            server.build_listen_uri('server_2'),
         },
     }
 
     g.server_1 = g.cluster:build_and_add_server(
-        {alias = 'server_gh6754_1', box_cfg = g.box_cfg})
+        {alias = 'server_1', box_cfg = g.box_cfg})
 
     g.box_cfg.read_only = false
 
     g.server_2 = g.cluster:build_and_add_server(
-        {alias = 'server_gh6754_2', box_cfg = g.box_cfg})
+        {alias = 'server_2', box_cfg = g.box_cfg})
     g.cluster:start()
     g.cluster:wait_for_fullmesh()
 end)

--- a/test/replication-luatest/gh_6754_promote_before_new_term_test.lua
+++ b/test/replication-luatest/gh_6754_promote_before_new_term_test.lua
@@ -13,8 +13,8 @@ g.before_all(function(g)
         replication_synchro_quorum = 1,
         replication_timeout = 0.1,
         replication = {
-            server.build_listen_uri('server_1'),
-            server.build_listen_uri('server_2'),
+            server.build_listen_uri('server_1', g.cluster.id),
+            server.build_listen_uri('server_2', g.cluster.id),
         },
     }
 

--- a/test/replication-luatest/gh_6842_qsync_applier_order_test.lua
+++ b/test/replication-luatest/gh_6842_qsync_applier_order_test.lua
@@ -13,8 +13,8 @@ local function cluster_create(g)
         replication_synchro_quorum = 2,
         replication_synchro_timeout = 1000,
         replication = {
-            server.build_listen_uri('server1'),
-            server.build_listen_uri('server2'),
+            server.build_listen_uri('server1', g.cluster.id),
+            server.build_listen_uri('server2', g.cluster.id),
         },
     }
     g.server1 = g.cluster:build_and_add_server({

--- a/test/replication-luatest/gh_6842_qsync_applier_order_test.lua
+++ b/test/replication-luatest/gh_6842_qsync_applier_order_test.lua
@@ -13,17 +13,17 @@ local function cluster_create(g)
         replication_synchro_quorum = 2,
         replication_synchro_timeout = 1000,
         replication = {
-            server.build_listen_uri('server_gh6842_1'),
-            server.build_listen_uri('server_gh6842_2'),
+            server.build_listen_uri('server1'),
+            server.build_listen_uri('server2'),
         },
     }
     g.server1 = g.cluster:build_and_add_server({
-        alias = 'server_gh6842_1', box_cfg = box_cfg
+        alias = 'server1', box_cfg = box_cfg
     })
     -- For stability. To guarantee server1 is first, server2 is second.
     box_cfg.read_only = true
     g.server2 = g.cluster:build_and_add_server({
-        alias = 'server_gh6842_2', box_cfg = box_cfg
+        alias = 'server2', box_cfg = box_cfg
     })
     g.cluster:start()
 

--- a/test/replication-luatest/gh_6966_readonly_bootstrap_test.lua
+++ b/test/replication-luatest/gh_6966_readonly_bootstrap_test.lua
@@ -11,14 +11,14 @@ g.before_all(function(cg)
     local cfg = {
         replication_timeout = 0.1,
         replication = {
-            server.build_listen_uri('master'),
+            server.build_listen_uri('master', cg.cluster.id),
         },
     }
     cg.master = cg.cluster:build_and_add_server({
         alias = 'master',
         box_cfg = cfg
     })
-    cfg.replication[2] = server.build_listen_uri('replica')
+    cfg.replication[2] = server.build_listen_uri('replica', cg.cluster.id)
     cg.replica = cg.cluster:build_and_add_server({
         alias = 'replica',
         box_cfg = cfg

--- a/test/replication-luatest/gh_7086_box_issue_promote_assert_test.lua
+++ b/test/replication-luatest/gh_7086_box_issue_promote_assert_test.lua
@@ -25,18 +25,18 @@ local function cluster_init(g)
         replication_synchro_timeout = 5,
         replication_synchro_quorum = 1,
         replication = {
-            server.build_listen_uri('server_gh7086_1'),
-            server.build_listen_uri('server_gh7086_2'),
-            server.build_listen_uri('server_gh7086_3'),
+            server.build_listen_uri('server_1'),
+            server.build_listen_uri('server_2'),
+            server.build_listen_uri('server_3'),
         },
     }
 
     g.server_1 = g.cluster:build_and_add_server(
-        {alias = 'server_gh7086_1', box_cfg = g.box_cfg})
+        {alias = 'server_1', box_cfg = g.box_cfg})
     g.server_2 = g.cluster:build_and_add_server(
-        {alias = 'server_gh7086_2', box_cfg = g.box_cfg})
+        {alias = 'server_2', box_cfg = g.box_cfg})
     g.server_3 = g.cluster:build_and_add_server(
-        {alias = 'server_gh7086_3', box_cfg = g.box_cfg})
+        {alias = 'server_3', box_cfg = g.box_cfg})
     g.cluster:start()
     g.cluster:wait_for_fullmesh()
 end

--- a/test/replication-luatest/gh_7086_box_issue_promote_assert_test.lua
+++ b/test/replication-luatest/gh_7086_box_issue_promote_assert_test.lua
@@ -25,9 +25,9 @@ local function cluster_init(g)
         replication_synchro_timeout = 5,
         replication_synchro_quorum = 1,
         replication = {
-            server.build_listen_uri('server_1'),
-            server.build_listen_uri('server_2'),
-            server.build_listen_uri('server_3'),
+            server.build_listen_uri('server_1', g.cluster.id),
+            server.build_listen_uri('server_2', g.cluster.id),
+            server.build_listen_uri('server_3', g.cluster.id),
         },
     }
 

--- a/test/replication-luatest/gh_7204_greeting_timeout_test.lua
+++ b/test/replication-luatest/gh_7204_greeting_timeout_test.lua
@@ -21,7 +21,7 @@ g.after_all(function(g)
 end)
 
 g.test_greeting_timeout = function(g)
-    local uri = server.build_listen_uri('server')
+    local uri = server.build_listen_uri('server', g.server.id)
     local s = socket.tcp_server('unix/', uri, {
         handler = function() fiber.sleep(9000) end
     })

--- a/test/replication-luatest/gh_7253_election_long_wal_write_test.lua
+++ b/test/replication-luatest/gh_7253_election_long_wal_write_test.lua
@@ -74,22 +74,22 @@ g.before_all(function(g)
         election_timeout = 1000,
         election_fencing_enabled = false,
         replication = {
-            server.build_listen_uri('server_gh7253_1'),
-            server.build_listen_uri('server_gh7253_2'),
-            server.build_listen_uri('server_gh7253_3'),
+            server.build_listen_uri('server1'),
+            server.build_listen_uri('server2'),
+            server.build_listen_uri('server3'),
         },
         bootstrap_strategy = 'legacy',
     }
     box_cfg.election_mode = 'manual'
     g.server1 = g.cluster:build_and_add_server({
-        alias = 'server_gh7253_1', box_cfg = box_cfg
+        alias = 'server1', box_cfg = box_cfg
     })
     box_cfg.election_mode = 'voter'
     g.server2 = g.cluster:build_and_add_server({
-        alias = 'server_gh7253_2', box_cfg = box_cfg
+        alias = 'server2', box_cfg = box_cfg
     })
     g.server3 = g.cluster:build_and_add_server({
-        alias = 'server_gh7253_3', box_cfg = box_cfg
+        alias = 'server3', box_cfg = box_cfg
     })
     g.cluster:start()
 
@@ -282,8 +282,8 @@ g.test_old_leader_txn_during_promote_write = function(g)
     -- Build the topology:
     --   server1  server2 <-> server3
     --
-    local server2_uri = server.build_listen_uri('server_gh7253_2')
-    local server3_uri = server.build_listen_uri('server_gh7253_3')
+    local server2_uri = server.build_listen_uri('server2')
+    local server3_uri = server.build_listen_uri('server3')
     server_set_replication(g.server1, {})
     server_set_replication(g.server2, {server2_uri, server3_uri})
     server_set_replication(g.server3, {server2_uri, server3_uri})
@@ -371,25 +371,25 @@ end
 -- forwards the bad txn.
 --
 g.test_old_leader_txn_during_promote_write_complex = function(g)
-    local server1_uri = server.build_listen_uri('server_gh7253_1')
-    local server2_uri = server.build_listen_uri('server_gh7253_2')
-    local server3_uri = server.build_listen_uri('server_gh7253_3')
-    local server4_uri = server.build_listen_uri('server_gh7253_4')
-    local server5_uri = server.build_listen_uri('server_gh7253_5')
+    local server1_uri = server.build_listen_uri('server1')
+    local server2_uri = server.build_listen_uri('server2')
+    local server3_uri = server.build_listen_uri('server3')
+    local server4_uri = server.build_listen_uri('server4')
+    local server5_uri = server.build_listen_uri('server5')
     --
     -- Build the topology:
     --   server4 <- fullmesh(server1, server2, server3)
     --   server3 <-> server5
     --
     g.server4 = g.cluster:build_and_add_server({
-        alias = 'server_gh7253_4', box_cfg = g.server3.box_cfg
+        alias = 'server4', box_cfg = g.server3.box_cfg
     })
     g.server4:start()
     -- Server5 is needed only to make server3 able to win elections without
     -- participation of server1. Could also lower the quorum, but it wouldn't be
     -- fair. The test is too complex for these tricks.
     g.server5 = g.cluster:build_and_add_server({
-        alias = 'server_gh7253_5', box_cfg = g.server3.box_cfg
+        alias = 'server5', box_cfg = g.server3.box_cfg
     })
     g.server5:start()
     server_set_replication(g.server5, {server3_uri})

--- a/test/replication-luatest/gh_7253_election_long_wal_write_test.lua
+++ b/test/replication-luatest/gh_7253_election_long_wal_write_test.lua
@@ -74,9 +74,9 @@ g.before_all(function(g)
         election_timeout = 1000,
         election_fencing_enabled = false,
         replication = {
-            server.build_listen_uri('server1'),
-            server.build_listen_uri('server2'),
-            server.build_listen_uri('server3'),
+            server.build_listen_uri('server1', g.cluster.id),
+            server.build_listen_uri('server2', g.cluster.id),
+            server.build_listen_uri('server3', g.cluster.id),
         },
         bootstrap_strategy = 'legacy',
     }
@@ -282,8 +282,8 @@ g.test_old_leader_txn_during_promote_write = function(g)
     -- Build the topology:
     --   server1  server2 <-> server3
     --
-    local server2_uri = server.build_listen_uri('server2')
-    local server3_uri = server.build_listen_uri('server3')
+    local server2_uri = g.server2.net_box_uri
+    local server3_uri = g.server3.net_box_uri
     server_set_replication(g.server1, {})
     server_set_replication(g.server2, {server2_uri, server3_uri})
     server_set_replication(g.server3, {server2_uri, server3_uri})
@@ -371,11 +371,11 @@ end
 -- forwards the bad txn.
 --
 g.test_old_leader_txn_during_promote_write_complex = function(g)
-    local server1_uri = server.build_listen_uri('server1')
-    local server2_uri = server.build_listen_uri('server2')
-    local server3_uri = server.build_listen_uri('server3')
-    local server4_uri = server.build_listen_uri('server4')
-    local server5_uri = server.build_listen_uri('server5')
+    local server1_uri = g.server1.net_box_uri
+    local server2_uri = g.server2.net_box_uri
+    local server3_uri = g.server3.net_box_uri
+    local server4_uri = server.build_listen_uri('server4', g.cluster.id)
+    local server5_uri = server.build_listen_uri('server5', g.cluster.id)
     --
     -- Build the topology:
     --   server4 <- fullmesh(server1, server2, server3)

--- a/test/replication-luatest/gh_7286_split_brain_false_positive_test.lua
+++ b/test/replication-luatest/gh_7286_split_brain_false_positive_test.lua
@@ -14,8 +14,8 @@ g.before_all(function(cg)
         election_mode = 'off',
         replication_timeout = 0.1,
         replication = {
-            server.build_listen_uri('node1'),
-            server.build_listen_uri('node2'),
+            server.build_listen_uri('node1', cg.cluster.id),
+            server.build_listen_uri('node2', cg.cluster.id),
         },
     }
     cg.node1 = cg.cluster:build_and_add_server{

--- a/test/replication-luatest/gh_7377_bootstrap_connection_failure_test.lua
+++ b/test/replication-luatest/gh_7377_bootstrap_connection_failure_test.lua
@@ -14,9 +14,9 @@ g.before_all(function(cg)
     cg.servers = {}
     local box_cfg = {
         replication = {
-            server.build_listen_uri('server_gh7377_1'),
-            server.build_listen_uri('server_gh7377_2'),
-            server.build_listen_uri('server_gh7377_3'),
+            server.build_listen_uri('server_1'),
+            server.build_listen_uri('server_2'),
+            server.build_listen_uri('server_3'),
         },
         replication_timeout = timeout,
         bootstrap_strategy = 'legacy',
@@ -27,20 +27,19 @@ g.before_all(function(cg)
         'cccccccc-cccc-cccc-cccc-cccccccccccc',
     }
 
-    -- Connection server_gh7377_3 -> server_gh7377_1 is proxied, others are not.
+    -- Connection server_3 -> server_1 is proxied, others are not.
     cg.proxy = proxy:new{
-        client_socket_path = server.build_listen_uri('server_gh7377_1_proxy'),
-        server_socket_path = server.build_listen_uri('server_gh7377_1'),
+        client_socket_path = server.build_listen_uri('server_1_proxy'),
+        server_socket_path = server.build_listen_uri('server_1'),
     }
     t.assert(cg.proxy:start{force = true}, 'Proxy started successfully')
     for i = 1, 3 do
         box_cfg.instance_uuid = cg.uuids[i]
         if i == 3 then
-            box_cfg.replication[1] = server.build_listen_uri(
-                'server_gh7377_1_proxy')
+            box_cfg.replication[1] = server.build_listen_uri('server_1_proxy')
         end
         cg.servers[i] = cg.cluster:build_and_add_server({
-            alias = 'server_gh7377_' .. i,
+            alias = 'server_' .. i,
             box_cfg = box_cfg,
         })
     end
@@ -83,7 +82,7 @@ g.test_bootstrap_with_bad_connection = function(cg)
     cg.cluster:start{wait_until_ready = false}
     wait_bootstrapped(cg.servers[1], cg.uuids[2])
     fiber.sleep(timeout)
-    local logfile = fio.pathjoin(cg.servers[3].workdir, 'server_gh7377_3.log')
+    local logfile = fio.pathjoin(cg.servers[3].workdir, 'server_3.log')
     t.assert(not cg.servers[3]:grep_log(bootstrap_msg, nil,
                                         {filename = logfile}),
              'Server 3 waits for connection')

--- a/test/replication-luatest/gh_7377_bootstrap_connection_failure_test.lua
+++ b/test/replication-luatest/gh_7377_bootstrap_connection_failure_test.lua
@@ -14,9 +14,9 @@ g.before_all(function(cg)
     cg.servers = {}
     local box_cfg = {
         replication = {
-            server.build_listen_uri('server_1'),
-            server.build_listen_uri('server_2'),
-            server.build_listen_uri('server_3'),
+            server.build_listen_uri('server_1', cg.cluster.id),
+            server.build_listen_uri('server_2', cg.cluster.id),
+            server.build_listen_uri('server_3', cg.cluster.id),
         },
         replication_timeout = timeout,
         bootstrap_strategy = 'legacy',
@@ -30,7 +30,7 @@ g.before_all(function(cg)
     -- Connection server_3 -> server_1 is proxied, others are not.
     cg.proxy = proxy:new{
         client_socket_path = server.build_listen_uri('server_1_proxy'),
-        server_socket_path = server.build_listen_uri('server_1'),
+        server_socket_path = server.build_listen_uri('server_1', cg.cluster.id),
     }
     t.assert(cg.proxy:start{force = true}, 'Proxy started successfully')
     for i = 1, 3 do

--- a/test/replication-luatest/gh_7512_raft_leader_hang_test.lua
+++ b/test/replication-luatest/gh_7512_raft_leader_hang_test.lua
@@ -13,8 +13,8 @@ g.before_all(function(cg)
         replication_timeout = 0.1,
         replication_synchro_quorum = 1,
         replication = {
-            server.build_listen_uri('node1'),
-            server.build_listen_uri('node2'),
+            server.build_listen_uri('node1', cg.cluster.id),
+            server.build_listen_uri('node2', cg.cluster.id),
         },
     }
     cg.node1 = cg.cluster:build_and_add_server{

--- a/test/replication-luatest/gh_7515_sync_node_sees_leader_hang_test.lua
+++ b/test/replication-luatest/gh_7515_sync_node_sees_leader_hang_test.lua
@@ -11,9 +11,9 @@ g.before_each(function(cg)
     local box_cfg = {
         replication_timeout = 0.1,
         replication = {
-            server.build_listen_uri('server1'),
-            server.build_listen_uri('server2'),
-            server.build_listen_uri('server3'),
+            server.build_listen_uri('server1', cg.replica_set.id),
+            server.build_listen_uri('server2', cg.replica_set.id),
+            server.build_listen_uri('server3', cg.replica_set.id),
         },
     }
     for i = 1, 3 do

--- a/test/replication-luatest/gh_7515_sync_node_sees_leader_hang_test.lua
+++ b/test/replication-luatest/gh_7515_sync_node_sees_leader_hang_test.lua
@@ -11,19 +11,19 @@ g.before_each(function(cg)
     local box_cfg = {
         replication_timeout = 0.1,
         replication = {
-            server.build_listen_uri('server_gh7515_1'),
-            server.build_listen_uri('server_gh7515_2'),
-            server.build_listen_uri('server_gh7515_3'),
+            server.build_listen_uri('server1'),
+            server.build_listen_uri('server2'),
+            server.build_listen_uri('server3'),
         },
     }
     for i = 1, 3 do
-        local alias = 'server_gh7515_' .. i
+        local alias = 'server' .. i
         if i == 1 then
             box_cfg.election_mode = 'candidate'
         else
             box_cfg.election_mode = 'voter'
         end
-        cg['server' .. i] = cg.replica_set:build_and_add_server{
+        cg[alias] = cg.replica_set:build_and_add_server{
             alias = alias,
             box_cfg = box_cfg,
         }

--- a/test/replication-luatest/gh_7581_downstream_lag_test.lua
+++ b/test/replication-luatest/gh_7581_downstream_lag_test.lua
@@ -17,8 +17,8 @@ g.before_each(function(g)
     local box_cfg = {
         replication_timeout = POLL_TIMEOUT,
         replication = {
-            server.build_listen_uri("server1"),
-            server.build_listen_uri("server2"),
+            server.build_listen_uri("server1", g.cluster.id),
+            server.build_listen_uri("server2", g.cluster.id),
         },
     }
     g.server1 = g.cluster:build_and_add_server({

--- a/test/replication-luatest/gh_7584_missing_xlog_test.lua
+++ b/test/replication-luatest/gh_7584_missing_xlog_test.lua
@@ -1,6 +1,5 @@
 local t = require('luatest')
 local cluster = require('luatest.replica_set')
-local server = require('luatest.server')
 
 local g = t.group('gh-7584')
 
@@ -16,7 +15,7 @@ g.before_all(function(cg)
         alias = 'replica',
         box_cfg = {
             replication = {
-                server.build_listen_uri('master'),
+                cg.master.net_box_uri,
             },
         },
     }

--- a/test/replication-luatest/gh_7590_replicaset_assert_test.lua
+++ b/test/replication-luatest/gh_7590_replicaset_assert_test.lua
@@ -9,9 +9,9 @@ g.before_all(function(g)
     g.cfg = {
         replication_timeout = 0.1,
         replication = {
-            server.build_listen_uri('r1'),
-            server.build_listen_uri('r2'),
-            server.build_listen_uri('r3'),
+            server.build_listen_uri('r1', g.cluster.id),
+            server.build_listen_uri('r2', g.cluster.id),
+            server.build_listen_uri('r3', g.cluster.id),
         },
     }
 

--- a/test/replication-luatest/gh_7592_local_write_with_syncro_test.lua
+++ b/test/replication-luatest/gh_7592_local_write_with_syncro_test.lua
@@ -13,8 +13,8 @@ g.before_each(function(cg)
         replication_timeout = 0.1,
         election_mode = 'off',
         replication = {
-            server.build_listen_uri('master'),
-            server.build_listen_uri('replica'),
+            server.build_listen_uri('master', cg.cluster.id),
+            server.build_listen_uri('replica', cg.cluster.id),
         },
     }
     cg.master = cg.cluster:build_and_add_server{

--- a/test/replication-luatest/gh_8121_memtx_mvcc_replication_stream_test.lua
+++ b/test/replication-luatest/gh_8121_memtx_mvcc_replication_stream_test.lua
@@ -1,6 +1,5 @@
 local t = require('luatest')
 local replica_set = require('luatest.replica_set')
-local server = require('luatest.server')
 
 local g = t.group(nil, t.helpers.matrix({engine = {'memtx', 'vinyl'}}))
 
@@ -17,7 +16,7 @@ g.before_all(function(cg)
             {
                 alias = 'replica',
                 box_cfg = {
-                    replication = server.build_listen_uri('master'),
+                    replication = cg.master.net_box_uri,
                     replication_timeout = 0.1,
                     memtx_use_mvcc_engine = true,
                     txn_isolation = 'read-confirmed',
@@ -55,7 +54,7 @@ g.test_replication_stream_transaction_conflict_errors = function(cg)
     end)
     cg.replica:exec(function(master_uri)
         box.cfg{replication = master_uri}
-    end, {server.build_listen_uri('master')})
+    end, {cg.master.net_box_uri})
     t.helpers.retrying({}, function()
         cg.replica:assert_follows_upstream(cg.master:get_instance_id())
     end)

--- a/test/replication-luatest/gh_8168_extra_term_bump_test.lua
+++ b/test/replication-luatest/gh_8168_extra_term_bump_test.lua
@@ -8,20 +8,20 @@ g.before_each(function(cg)
     cg.replica_set = replica_set:new{}
     local box_cfg = {
         replication = {
-            server.build_listen_uri('server_gh8168_1'),
-            server.build_listen_uri('server_gh8168_2'),
+            server.build_listen_uri('server1'),
+            server.build_listen_uri('server2'),
         },
         election_mode = 'manual',
         replication_timeout = 0.1,
     }
     cg.server1 = cg.replica_set:build_and_add_server{
-        alias = 'server_gh8168_1',
+        alias = 'server1',
         box_cfg = box_cfg,
     }
     box_cfg.election_timeout = 1e-9
     box_cfg.read_only = true
     cg.server2 = cg.replica_set:build_and_add_server{
-        alias = 'server_gh8168_2',
+        alias = 'server2',
         box_cfg = box_cfg,
     }
     cg.replica_set:start()

--- a/test/replication-luatest/gh_8168_extra_term_bump_test.lua
+++ b/test/replication-luatest/gh_8168_extra_term_bump_test.lua
@@ -8,8 +8,8 @@ g.before_each(function(cg)
     cg.replica_set = replica_set:new{}
     local box_cfg = {
         replication = {
-            server.build_listen_uri('server1'),
-            server.build_listen_uri('server2'),
+            server.build_listen_uri('server1', cg.replica_set.id),
+            server.build_listen_uri('server2', cg.replica_set.id),
         },
         election_mode = 'manual',
         replication_timeout = 0.1,

--- a/test/replication-luatest/gh_8185_dont_connect_to_nil_uuid_test.lua
+++ b/test/replication-luatest/gh_8185_dont_connect_to_nil_uuid_test.lua
@@ -16,7 +16,7 @@ g.before_each(function(cg)
     })
 
     cg.proxy = proxy:new({
-        client_socket_path = server.build_listen_uri('proxy'),
+        client_socket_path = cg.server.box_cfg.replication[1],
         server_socket_path = "/dev/null",
 
         -- Proxy will send nil UUID greeting as soon as client connects.

--- a/test/replication-luatest/linearizable_test.lua
+++ b/test/replication-luatest/linearizable_test.lua
@@ -31,7 +31,8 @@ g.before_all(function(cg)
     })
     -- Servers 2 and 3 are interconnected without a proxy.
     for i = 2, num_servers do
-        cg.box_cfg.replication[i] = server.build_listen_uri('server_' .. i)
+        cg.box_cfg.replication[i] = server.build_listen_uri('server_' .. i,
+            cg.cluster.id)
     end
     for i = 2, num_servers do
         cg.servers[i] = cg.cluster:build_and_add_server({
@@ -44,7 +45,8 @@ g.before_all(function(cg)
         cg.proxies[i] = proxy:new({
             client_socket_path = server.build_listen_uri('server_' .. i ..
                 '_proxy'),
-            server_socket_path = server.build_listen_uri('server_' .. i),
+            server_socket_path = server.build_listen_uri('server_' .. i,
+                cg.cluster.id),
         })
         cg.proxies[i]:start({force = true})
     end

--- a/test/replication-luatest/linearizable_test.lua
+++ b/test/replication-luatest/linearizable_test.lua
@@ -9,7 +9,7 @@ local g = t.group('linearizable-read')
 local function build_replication(num_instances)
     local t = {}
     for i = 1, num_instances do
-        table.insert(t, server.build_listen_uri('server_lr_' .. i .. '_proxy'))
+        table.insert(t, server.build_listen_uri('server_' .. i .. '_proxy'))
     end
     return t
 end
@@ -26,25 +26,25 @@ g.before_all(function(cg)
         memtx_use_mvcc_engine = true,
     }
     cg.servers[1] = cg.cluster:build_and_add_server({
-        alias = 'server_lr_1',
+        alias = 'server_1',
         box_cfg = cg.box_cfg,
     })
     -- Servers 2 and 3 are interconnected without a proxy.
     for i = 2, num_servers do
-        cg.box_cfg.replication[i] = server.build_listen_uri('server_lr_' .. i)
+        cg.box_cfg.replication[i] = server.build_listen_uri('server_' .. i)
     end
     for i = 2, num_servers do
         cg.servers[i] = cg.cluster:build_and_add_server({
-            alias = 'server_lr_' .. i,
+            alias = 'server_' .. i,
             box_cfg = cg.box_cfg,
         })
     end
     cg.proxies = {}
     for i = 1, num_servers do
         cg.proxies[i] = proxy:new({
-            client_socket_path = server.build_listen_uri('server_lr_' .. i ..
+            client_socket_path = server.build_listen_uri('server_' .. i ..
                 '_proxy'),
-            server_socket_path = server.build_listen_uri('server_lr_' .. i),
+            server_socket_path = server.build_listen_uri('server_' .. i),
         })
         cg.proxies[i]:start({force = true})
     end

--- a/test/replication-luatest/no_quorum_test.lua
+++ b/test/replication-luatest/no_quorum_test.lua
@@ -9,8 +9,8 @@ pg.before_each(function(cg)
     cg.cluster = Cluster:new({})
     cg.master = cg.cluster:build_server({alias = 'master'})
     local box_cfg = {
-        listen = server.build_listen_uri('no_quorum'),
-        replication = server.build_listen_uri('master'),
+        listen = server.build_listen_uri('no_quorum', cg.cluster.id),
+        replication = cg.master.net_box_uri,
         memtx_memory = 107374182,
         replication_connect_quorum = 0,
         replication_timeout = 0.1,

--- a/test/replication-luatest/quorum_master_test.lua
+++ b/test/replication-luatest/quorum_master_test.lua
@@ -11,8 +11,8 @@ pg.before_each(function(cg)
 
     cg.box_cfg = {
         replication = {
-            server.build_listen_uri('master_quorum1');
-            server.build_listen_uri('master_quorum2');
+            server.build_listen_uri('master_quorum1', cg.cluster.id);
+            server.build_listen_uri('master_quorum2', cg.cluster.id);
         };
         replication_connect_quorum = 0;
         replication_timeout = 0.1;

--- a/test/replication-luatest/quorum_misc_test.lua
+++ b/test/replication-luatest/quorum_misc_test.lua
@@ -16,9 +16,9 @@ pg.before_each(function(cg)
         replication_sync_lag = 0.01;
         replication_connect_quorum = 3;
         replication = {
-            server.build_listen_uri('quorum1');
-            server.build_listen_uri('quorum2');
-            server.build_listen_uri('quorum3');
+            server.build_listen_uri('quorum1', cg.cluster.id);
+            server.build_listen_uri('quorum2', cg.cluster.id);
+            server.build_listen_uri('quorum3', cg.cluster.id);
         };
     }
     cg.quorum1 = cg.cluster:build_server({alias = 'quorum1', box_cfg = box_cfg})
@@ -29,9 +29,11 @@ pg.before_each(function(cg)
         replication_timeout = 0.05,
         replication_connect_timeout = 10,
         replication_connect_quorum = 1,
-        replication = {server.build_listen_uri('replica_quorum'),
-                       server.build_listen_uri('replica_quorum1'),
-                       server.build_listen_uri('replica_quorum2')}
+        replication = {server.build_listen_uri('replica_quorum', cg.cluster.id),
+                       server.build_listen_uri('replica_quorum1',
+                           cg.cluster.id),
+                       server.build_listen_uri('replica_quorum2',
+                           cg.cluster.id)}
     }
     cg.replica_quorum = cg.cluster:build_server({alias = 'replica_quorum',
                                                  box_cfg = box_cfg})
@@ -60,7 +62,7 @@ pg.test_quorum_during_reconfiguration = function(cg)
                     }
                 })
     end
-    local nonexistent_uri = server.build_listen_uri('replica_quorum1')
+    local nonexistent_uri = server.build_listen_uri('nonexistent_uri')
     t.helpers.retrying({timeout = 10},
         function()
             -- If replication_connect_quorum was ignored here, the instance

--- a/test/replication-luatest/quorum_orphan_test.lua
+++ b/test/replication-luatest/quorum_orphan_test.lua
@@ -14,9 +14,9 @@ pg.before_each(function(cg)
         replication_sync_lag = 0.01;
         replication_connect_quorum = 3;
         replication = {
-            server.build_listen_uri('quorum1');
-            server.build_listen_uri('quorum2');
-            server.build_listen_uri('quorum3');
+            server.build_listen_uri('quorum1', cg.cluster.id);
+            server.build_listen_uri('quorum2', cg.cluster.id);
+            server.build_listen_uri('quorum3', cg.cluster.id);
         };
     }
 

--- a/test/replication-luatest/recovery_triggers_test.lua
+++ b/test/replication-luatest/recovery_triggers_test.lua
@@ -22,7 +22,7 @@ g.before_all(function(cg)
     cg.replica = cg.cluster:build_and_add_server({
         alias = 'replica',
         box_cfg = {
-            replication = server.build_listen_uri('server'),
+            replication = cg.server.net_box_uri,
         },
         env = {
             ['TARANTOOL_RUN_BEFORE_BOX_CFG'] = run_before_cfg,
@@ -83,7 +83,7 @@ g.test_recovery_stages = function(cg)
         replication_connect_timeout = 0.1,
         replication_timeout = 0.1,
         replication = {
-            server.build_listen_uri('server'),
+            cg.server.net_box_uri,
             server.build_listen_uri('non-existent-uri'),
         },
         bootstrap_strategy = 'legacy',

--- a/test/sql-luatest/gh_5183_fix_index_field_missing_test.lua
+++ b/test/sql-luatest/gh_5183_fix_index_field_missing_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 g.before_all(function()
-    g.server = server:new({alias = 'test_index_field_missing'})
+    g.server = server:new({alias = 'gh-5183'})
     g.server:start()
 end)
 

--- a/test/sql-luatest/gh_5310_cursor_invalidation_test.lua
+++ b/test/sql-luatest/gh_5310_cursor_invalidation_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 g.before_all(function()
-    g.server = server:new({alias = 'test_cursor_invalidation'})
+    g.server = server:new({alias = 'gh-5310'})
     g.server:start()
     g.server:exec(function()
         box.execute([[SET SESSION "sql_seq_scan" = true;]])

--- a/test/sql-luatest/gh_5526_no_error_on_too_many_indexes_test.lua
+++ b/test/sql-luatest/gh_5526_no_error_on_too_many_indexes_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 g.before_all(function()
-    g.server = server:new({alias = 'test_no_error_on_too_many_indexes'})
+    g.server = server:new({alias = 'gh-5526'})
     g.server:start()
 end)
 

--- a/test/sql-luatest/gh_5678_join_with_unsupported_index_test.lua
+++ b/test/sql-luatest/gh_5678_join_with_unsupported_index_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 g.before_all(function()
-    g.server = server:new({alias = 'test_join_with_unsupported_index'})
+    g.server = server:new({alias = 'gh-5678'})
     g.server:start()
     g.server:exec(function()
         box.execute([[SET SESSION "sql_seq_scan" = true;]])

--- a/test/sql-luatest/gh_5976_indexed_by_assertion_test.lua
+++ b/test/sql-luatest/gh_5976_indexed_by_assertion_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 g.before_all(function()
-    g.server = server:new({alias = 'test_assertion_in_indexed_by'})
+    g.server = server:new({alias = 'gh-5976'})
     g.server:start()
 end)
 

--- a/test/sql-luatest/gh_6422_autoinc_ids_reset_test.lua
+++ b/test/sql-luatest/gh_6422_autoinc_ids_reset_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 g.before_all(function()
-    g.server = server:new({alias = 'test_autoinc_id_reset'})
+    g.server = server:new({alias = 'gh-6422'})
     g.server:start()
 end)
 

--- a/test/sql-luatest/gh_6572_nan_is_not_null_test.lua
+++ b/test/sql-luatest/gh_6572_nan_is_not_null_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 g.before_all(function()
-    g.server = server:new({alias = 'test_nan_null'})
+    g.server = server:new({alias = 'gh-6572'})
     g.server:start()
 end)
 

--- a/test/sql-luatest/gh_6575_assertion_in_modulo_test.lua
+++ b/test/sql-luatest/gh_6575_assertion_in_modulo_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 g.before_all(function()
-    g.server = server:new({alias = 'test_assertion_in_modulo'})
+    g.server = server:new({alias = 'gh-6575'})
     g.server:start()
 end)
 

--- a/test/sql-luatest/gh_6650_round_with_big_precision_test.lua
+++ b/test/sql-luatest/gh_6650_round_with_big_precision_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 g.before_all(function()
-    g.server = server:new({alias = 'test_round_double'})
+    g.server = server:new({alias = 'gh-6650'})
     g.server:start()
 end)
 

--- a/test/sql-luatest/gh_6668_problems_with_map_array_test.lua
+++ b/test/sql-luatest/gh_6668_problems_with_map_array_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 g.before_all(function()
-    g.server = server:new({alias = 'map_array_problems'})
+    g.server = server:new({alias = 'gh-6668'})
     g.server:start()
     g.server:exec(function()
         box.execute([[SET SESSION "sql_seq_scan" = true;]])

--- a/test/sql-luatest/gh_6773_arithmetic_operands_test.lua
+++ b/test/sql-luatest/gh_6773_arithmetic_operands_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 g.before_all(function()
-    g.server = server:new({alias = 'arithmetic_operands'})
+    g.server = server:new({alias = 'gh-6773'})
     g.server:start()
 end)
 

--- a/test/sql-luatest/gh_6988_add_round_implementations_test.lua
+++ b/test/sql-luatest/gh_6988_add_round_implementations_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 g.before_all(function()
-    g.server = server:new({alias = 'round_dec_int'})
+    g.server = server:new({alias = 'gh-6988'})
     g.server:start()
 end)
 

--- a/test/sql-luatest/gh_6989_nullif_result_type_test.lua
+++ b/test/sql-luatest/gh_6989_nullif_result_type_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 g.before_all(function()
-    g.server = server:new({alias = 'test_assertion_in_modulo'})
+    g.server = server:new({alias = 'gh-6989'})
     g.server:start()
 end)
 

--- a/test/sql-luatest/gh_6990_case_operation_type_test.lua
+++ b/test/sql-luatest/gh_6990_case_operation_type_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 g.before_all(function()
-    g.server = server:new({alias = 'test_case_operation_type'})
+    g.server = server:new({alias = 'gh-6990'})
     g.server:start()
 end)
 

--- a/test/sql-luatest/gh_7043_temp_space_format_test.lua
+++ b/test/sql-luatest/gh_7043_temp_space_format_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 g.before_all(function()
-    g.server = server:new({alias = 'test_space_format'})
+    g.server = server:new({alias = 'gh-7043'})
     g.server:start()
     g.server:exec(function()
         box.execute([[SET SESSION "sql_seq_scan" = true;]])

--- a/test/sql-luatest/gh_7132_insertion_crash_test.lua
+++ b/test/sql-luatest/gh_7132_insertion_crash_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 g.before_all(function()
-    g.server = server:new({alias = 'insertion_crash'})
+    g.server = server:new({alias = 'gh-7132'})
     g.server:start()
     g.server:exec(function()
         box.execute([[SET SESSION "sql_seq_scan" = true;]])

--- a/test/sql-luatest/gh_7295_uint_and_int_def_err_test.lua
+++ b/test/sql-luatest/gh_7295_uint_and_int_def_err_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 g.before_all(function()
-    g.server = server:new({alias = 'test_uint_int'})
+    g.server = server:new({alias = 'gh-7295'})
     g.server:start()
     g.server:exec(function()
         box.execute([[SET SESSION "sql_seq_scan" = true;]])

--- a/test/sql-luatest/gh_7345_any_in_order_by_ephem_test.lua
+++ b/test/sql-luatest/gh_7345_any_in_order_by_ephem_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 g.before_all(function()
-    g.server = server:new({alias = 'test_any_in_order_by_ephem'})
+    g.server = server:new({alias = 'gh-7345'})
     g.server:start()
     g.server:exec(function()
         box.execute([[SET SESSION "sql_seq_scan" = true;]])

--- a/test/sql-luatest/gh_7358_prepared_stmt_truncation_test.lua
+++ b/test/sql-luatest/gh_7358_prepared_stmt_truncation_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 g.before_all(function()
-    g.server = server:new({alias = 'test_prepared_stmt_truncation'})
+    g.server = server:new({alias = 'gh-7358'})
     g.server:start()
     g.server:exec(function()
         box.execute([[SET SESSION "sql_seq_scan" = true;]])

--- a/test/sql-luatest/gh_8365_no_func_in_index_def_test.lua
+++ b/test/sql-luatest/gh_8365_no_func_in_index_def_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 g.before_all(function()
-    g.server = server:new({alias = 'no_func_in_idx_def'})
+    g.server = server:new({alias = 'gh-8365'})
     g.server:start()
 end)
 


### PR DESCRIPTION
**Revert "test: dirty fix for some flaky replication-luatest tests"**

---

**test: bump test-run to version w/ updated luatest**

Bump test-run to new version with the following improvements:

- Properly ignore Unix sockets on artifact saving [1]
- Bump luatest to 0.5.7-34-g930b63b [2]

[1] https://github.com/tarantool/test-run/commit/3afaccc
[2] https://github.com/tarantool/test-run/commit/02c4828

---

**test: update tests according to luatest changes**

All tests were updated according to https://github.com/tarantool/luatest/commit/930b63b. So this
should resolve the problem with Unix socket collisions that we tried to
fix, for example, in https://github.com/tarantool/tarantool/commit/7ac2685.

---

**ci: reduce testing for macOS 12**

We have the limited hardware resources with macOS 12, and full testing
is time-consuming. So let's check only the release build on the x86_64 
platform.