### PR TITLE
test: fix flaky gh_8121_memtx_mvcc_stream_test

### DIFF
--- a/test/replication-luatest/gh_8121_memtx_mvcc_replication_stream_test.lua
+++ b/test/replication-luatest/gh_8121_memtx_mvcc_replication_stream_test.lua
@@ -29,10 +29,7 @@ g.before_all(function(cg)
         s:create_index('pk')
         s:insert{0}
     end, {cg.params.engine})
-    t.helpers.retrying({}, function()
-        cg.replica:assert_follows_upstream(cg.master:get_instance_id())
-    end)
-    cg.master:wait_for_downstream_to(cg.replica)
+    cg.replica:wait_for_vclock_of(cg.master)
     cg.replica:exec(function()
         box.cfg{replication = ""}
     end)


### PR DESCRIPTION
The test checks that replication stream doesn't get transaction conflict errors. However, currently it fails with the following error: "attempt to index field 's' (a nil value)", where 's' is a space, created at master during before_all phase.

The problem is the fact, that the test doesn't wait for replica to be synchronized with master before dropping the replication source. So, sometimes replica doesn't have any space 's' at the beginning of the test body exection.

Let's add waiting for vclocks synchronization before reconfiguring box.cfg.replication on replica.

Closes tarantool/tarantool-qa#311

NO_CHANGELOG=test
NO_DOC=test