### PR TITLE
doc: proofread 2.11 changelogs

### DIFF
--- a/changelogs/unreleased/gh-8374-local-print-accepts-non-strings.md
+++ b/changelogs/unreleased/gh-8374-local-print-accepts-non-strings.md
@@ -1,6 +1,6 @@
 ## bugfix/console
 
-* Fixed `console.local_print()` accepting only string arguments. It backfired in
-  some rare cases, e.g. when connecting via tarantoolctl to cartridged tarantool
-  and using wrong credentials, a cdata error was passed through the
-  `local_print()`, that failed to interpret it (gh-8374).
+* Fixed `console.local_print()` failing on non-string arguments, which led to
+  some rare errors. For example, when connecting via tarantoolctl to cartridged
+  tarantool with incorrect credentials, a cdata error was passed through the
+  `local_print()`, which failed to interpret it (gh-8374).

--- a/changelogs/unreleased/gh-8511-pagination-validate-cmp-def.md
+++ b/changelogs/unreleased/gh-8511-pagination-validate-cmp-def.md
@@ -1,5 +1,6 @@
 ## bugfix/core
 
-* Loosen requirements for tuple which is used as position - passed to
-  `index:tuple_pos()` or to option `after` of `index:select`. Now, only
-  key parts of current and primary indexes are validated (gh-8511).
+* Relaxed the tuple format requirements on tuples passed as the page starting
+  position to `index:tuple_pos()` or to the `after` option of `index:select`.
+  Now, Tarantool validates only the key parts of the index being used and all
+  primary indexes (gh-8511).


### PR DESCRIPTION
Proofread 2.11 changelogs that were pushed before switching
to new process (reviewing changelogs in PRs).

NO_CHANGELOG=changelog
NO_DOC=changelog
NO_TEST=changelog