### PR TITLE
[2.10] sql: fix integer overflow in built-in functions

### DIFF
--- a/changelogs/unreleased/ghs-119-too-long-mem-values.md
+++ b/changelogs/unreleased/ghs-119-too-long-mem-values.md
@@ -1,0 +1,3 @@
+## bugfix/sql
+
+* Fixed integer overflow issues in built-in functions (ghs-119).

--- a/src/box/sql/func.c
+++ b/src/box/sql/func.c
@@ -280,12 +280,18 @@ func_char_length(struct sql_context *ctx, int argc, const struct Mem *argv)
 	const struct Mem *arg = &argv[0];
 	if (mem_is_null(arg))
 		return;
-	assert(mem_is_str(arg) && arg->n >= 0);
+	assert(mem_is_str(arg));
+	if (arg->n > SQL_MAX_LENGTH) {
+		ctx->is_aborted = true;
+		diag_set(ClientError, ER_SQL_EXECUTE, "string or blob too big");
+		return;
+	}
+	int32_t n = arg->n;
 	uint32_t len = 0;
-	int offset = 0;
-	while (offset < arg->n) {
+	int32_t offset = 0;
+	while (offset < n) {
 		UChar32 c;
-		U8_NEXT((uint8_t *)arg->z, offset, arg->n, c);
+		U8_NEXT((uint8_t *)arg->z, offset, n, c);
 		++len;
 	}
 	mem_set_uint(ctx->pOut, len);
@@ -300,10 +306,15 @@ func_lower_upper(struct sql_context *ctx, int argc, const struct Mem *argv)
 	const struct Mem *arg = &argv[0];
 	if (mem_is_null(arg))
 		return;
-	assert(mem_is_str(arg) && arg->n >= 0);
+	assert(mem_is_str(arg));
 	if (arg->n == 0)
 		return mem_set_str0_static(ctx->pOut, "");
 	const char *str = arg->z;
+	if (arg->n > SQL_MAX_LENGTH) {
+		diag_set(ClientError, ER_SQL_EXECUTE, "string or blob too big");
+		ctx->is_aborted = true;
+		return;
+	}
 	int32_t len = arg->n;
 	struct sql *db = sql_get();
 	char *res = sqlDbMallocRawNN(db, len);
@@ -362,17 +373,17 @@ func_nullif(struct sql_context *ctx, int argc, const struct Mem *argv)
 		ctx->is_aborted = true;
 }
 
-/** Implementation of the TRIM() function. */
-static inline int
-trim_bin_end(const char *str, int end, const char *octets, int octets_size,
-	     int flags)
+/** Return the position of the last not removed byte. */
+static inline size_t
+trim_bin_end(const char *str, size_t end, const char *octets,
+	     size_t octets_size, int flags)
 {
 	if ((flags & TRIM_TRAILING) == 0)
 		return end;
 	while (end > 0) {
 		bool is_trimmed = false;
 		char c = str[end - 1];
-		for (int i = 0; i < octets_size && !is_trimmed; ++i)
+		for (size_t i = 0; i < octets_size && !is_trimmed; ++i)
 			is_trimmed = c == octets[i];
 		if (!is_trimmed)
 			break;
@@ -381,17 +392,18 @@ trim_bin_end(const char *str, int end, const char *octets, int octets_size,
 	return end;
 }
 
-static inline int
-trim_bin_start(const char *str, int end, const char *octets, int octets_size,
-	       int flags)
+/** Return the position of the first not removed byte. */
+static inline size_t
+trim_bin_start(const char *str, size_t end, const char *octets,
+	       size_t octets_size, int flags)
 {
 	if ((flags & TRIM_LEADING) == 0)
 		return 0;
-	int start = 0;
+	size_t start = 0;
 	while (start < end) {
 		bool is_trimmed = false;
 		char c = str[start];
-		for (int i = 0; i < octets_size && !is_trimmed; ++i)
+		for (size_t i = 0; i < octets_size && !is_trimmed; ++i)
 			is_trimmed = c == octets[i];
 		if (!is_trimmed)
 			break;
@@ -400,6 +412,7 @@ trim_bin_start(const char *str, int end, const char *octets, int octets_size,
 	return start;
 }
 
+/** Implementation of the TRIM() function for VARBINARY. */
 static void
 func_trim_bin(struct sql_context *ctx, int argc, const struct Mem *argv)
 {
@@ -408,9 +421,9 @@ func_trim_bin(struct sql_context *ctx, int argc, const struct Mem *argv)
 	assert(argc == 2 || (argc == 3 && mem_is_bin(&argv[2])));
 	assert(mem_is_bin(&argv[0]) && mem_is_uint(&argv[1]));
 	const char *str = argv[0].z;
-	int size = argv[0].n;
+	size_t size = argv[0].n;
 	const char *octets;
-	int octets_size;
+	size_t octets_size;
 	if (argc == 3) {
 		octets = argv[2].z;
 		octets_size = argv[2].n;
@@ -420,8 +433,8 @@ func_trim_bin(struct sql_context *ctx, int argc, const struct Mem *argv)
 	}
 
 	int flags = argv[1].u.u;
-	int end = trim_bin_end(str, size, octets, octets_size, flags);
-	int start = trim_bin_start(str, end, octets, octets_size, flags);
+	size_t end = trim_bin_end(str, size, octets, octets_size, flags);
+	size_t start = trim_bin_start(str, end, octets, octets_size, flags);
 
 	if (start >= end)
 		return mem_set_bin_static(ctx->pOut, "", 0);
@@ -429,17 +442,18 @@ func_trim_bin(struct sql_context *ctx, int argc, const struct Mem *argv)
 		ctx->is_aborted = true;
 }
 
-static inline int
-trim_str_end(const char *str, int end, const char *chars, uint8_t *chars_len,
-	     int chars_count, int flags)
+/** Return the position of the last not removed character. */
+static inline int32_t
+trim_str_end(const char *str, int32_t end, const char *chars,
+	     uint8_t *chars_len, size_t chars_count, int flags)
 {
 	if ((flags & TRIM_TRAILING) == 0)
 		return end;
 	while (end > 0) {
 		bool is_trimmed = false;
 		const char *c = chars;
-		int len;
-		for (int i = 0; i < chars_count && !is_trimmed; ++i) {
+		int32_t len;
+		for (size_t i = 0; i < chars_count && !is_trimmed; ++i) {
 			len = chars_len[i];
 			const char *s = str + end - len;
 			is_trimmed = len <= end && memcmp(c, s, len) == 0;
@@ -453,18 +467,19 @@ trim_str_end(const char *str, int end, const char *chars, uint8_t *chars_len,
 	return end;
 }
 
-static inline int
-trim_str_start(const char *str, int end, const char *chars, uint8_t *chars_len,
-	       int chars_count, int flags)
+/** Return the position of the first not removed character. */
+static inline int32_t
+trim_str_start(const char *str, int32_t end, const char *chars,
+	       uint8_t *chars_len, size_t chars_count, int flags)
 {
 	if ((flags & TRIM_LEADING) == 0)
 		return 0;
-	int start = 0;
+	int32_t start = 0;
 	while (start < end) {
 		bool is_trimmed = false;
 		const char *c = chars;
-		int len;
-		for (int i = 0; i < chars_count && !is_trimmed; ++i) {
+		int32_t len;
+		for (size_t i = 0; i < chars_count && !is_trimmed; ++i) {
 			len = chars_len[i];
 			const char *s = str + start;
 			is_trimmed = start + len <= end &&
@@ -479,6 +494,7 @@ trim_str_start(const char *str, int end, const char *chars, uint8_t *chars_len,
 	return start;
 }
 
+/** Implementation of the TRIM() function for STRING. */
 static void
 func_trim_str(struct sql_context *ctx, int argc, const struct Mem *argv)
 {
@@ -487,10 +503,21 @@ func_trim_str(struct sql_context *ctx, int argc, const struct Mem *argv)
 	assert(argc == 2 || (argc == 3 && mem_is_str(&argv[2])));
 	assert(mem_is_str(&argv[0]) && mem_is_uint(&argv[1]));
 	const char *str = argv[0].z;
-	int size = argv[0].n;
+	if (argv[0].n > SQL_MAX_LENGTH) {
+		ctx->is_aborted = true;
+		diag_set(ClientError, ER_SQL_EXECUTE, "string or blob too big");
+		return;
+	}
+	int32_t size = argv[0].n;
 	const char *chars;
-	int chars_size;
+	int32_t chars_size;
 	if (argc == 3) {
+		if (argv[2].n > SQL_MAX_LENGTH) {
+			ctx->is_aborted = true;
+			diag_set(ClientError, ER_SQL_EXECUTE,
+				 "string or blob too big");
+			return;
+		}
 		chars = argv[2].z;
 		chars_size = argv[2].n;
 	} else {
@@ -506,20 +533,21 @@ func_trim_str(struct sql_context *ctx, int argc, const struct Mem *argv)
 		diag_set(OutOfMemory, chars_size, "region_alloc", "chars_len");
 		return;
 	}
-	int chars_count = 0;
+	size_t chars_count = 0;
 
-	int offset = 0;
+	int32_t offset = 0;
 	while (offset < chars_size) {
 		UChar32 c;
-		int prev = offset;
+		size_t prev = offset;
 		U8_NEXT((uint8_t *)chars, offset, chars_size, c);
 		chars_len[chars_count++] = offset - prev;
 	}
 
 	uint64_t flags = argv[1].u.u;
-	int end = trim_str_end(str, size, chars, chars_len, chars_count, flags);
-	int start = trim_str_start(str, end, chars, chars_len, chars_count,
+	int32_t end = trim_str_end(str, size, chars, chars_len, chars_count,
 				   flags);
+	int32_t start = trim_str_start(str, end, chars, chars_len, chars_count,
+				       flags);
 	region_truncate(region, svp);
 
 	if (start >= end)
@@ -540,8 +568,8 @@ func_position_octets(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 	const char *key = argv[0].z;
 	const char *str = argv[1].z;
-	int key_size = argv[0].n;
-	int str_size = argv[1].n;
+	size_t key_size = argv[0].n;
+	size_t str_size = argv[1].n;
 	if (key_size <= 0)
 		return mem_set_uint(ctx->pOut, 1);
 	const char *pos = memmem(str, str_size, key, key_size);
@@ -557,16 +585,21 @@ func_position_characters(struct sql_context *ctx, int argc,
 	if (mem_is_any_null(&argv[0], &argv[1]))
 		return;
 	assert(mem_is_str(&argv[0]) && mem_is_str(&argv[1]));
+	if (argv[0].n > SQL_MAX_LENGTH || argv[1].n > SQL_MAX_LENGTH) {
+		ctx->is_aborted = true;
+		diag_set(ClientError, ER_SQL_EXECUTE, "string or blob too big");
+		return;
+	}
 
 	const char *key = argv[0].z;
 	const char *str = argv[1].z;
-	int key_size = argv[0].n;
-	int str_size = argv[1].n;
+	int32_t key_size = argv[0].n;
+	int32_t str_size = argv[1].n;
 	if (key_size <= 0)
 		return mem_set_uint(ctx->pOut, 1);
 
-	int key_end = 0;
-	int str_end = 0;
+	int32_t key_end = 0;
+	int32_t str_end = 0;
 	while (key_end < key_size && str_end < str_size) {
 		UChar32 c;
 		U8_NEXT((uint8_t *)key, key_end, key_size, c);
@@ -579,8 +612,8 @@ func_position_characters(struct sql_context *ctx, int argc,
 	if (coll->cmp(key, key_size, str, str_end, coll) == 0)
 		return mem_set_uint(ctx->pOut, 1);
 
-	int i = 2;
-	int str_pos = 0;
+	int32_t i = 2;
+	int32_t str_pos = 0;
 	while (str_end < str_size) {
 		UChar32 c;
 		U8_NEXT((uint8_t *)str, str_pos, str_size, c);
@@ -694,10 +727,15 @@ func_substr_characters(struct sql_context *ctx, int argc, const
 	if (mem_is_any_null(&argv[0], &argv[1]))
 		return;
 	assert(mem_is_str(&argv[0]) && mem_is_int(&argv[1]));
+	if (argv[0].n > SQL_MAX_LENGTH) {
+		ctx->is_aborted = true;
+		diag_set(ClientError, ER_SQL_EXECUTE, "string or blob too big");
+		return;
+	}
 
 	const char *str = argv[0].z;
-	int pos = 0;
-	int end = argv[0].n;
+	int32_t pos = 0;
+	int32_t end = argv[0].n;
 	if (argc == 2) {
 		uint64_t start = mem_is_uint(&argv[1]) && argv[1].u.u > 1 ?
 				 argv[1].u.u - 1 : 0;
@@ -739,7 +777,7 @@ func_substr_characters(struct sql_context *ctx, int argc, const
 	if (pos == end)
 		return mem_set_str_static(ctx->pOut, "", 0);
 
-	int cur = pos;
+	int32_t cur = pos;
 	for (uint64_t i = 0; i < length && cur < end; ++i) {
 		UChar32 c;
 		U8_NEXT((uint8_t *)str, cur, end, c);
@@ -773,7 +811,7 @@ func_char(struct sql_context *ctx, int argc, const struct Mem *argv)
 		diag_set(OutOfMemory, size, "region_alloc_array", "buf");
 		return;
 	}
-	int len = 0;
+	size_t len = 0;
 	for (int i = 0; i < argc; ++i) {
 		if (mem_is_null(&argv[i]))
 			buf[i] = 0;
@@ -790,7 +828,7 @@ func_char(struct sql_context *ctx, int argc, const struct Mem *argv)
 		ctx->is_aborted = true;
 		return;
 	}
-	int pos = 0;
+	size_t pos = 0;
 	for (int i = 0; i < argc; ++i) {
 		UBool is_error = false;
 		U8_APPEND((uint8_t *)str, pos, len, buf[i], is_error);
@@ -819,7 +857,7 @@ func_greatest_least(struct sql_context *ctx, int argc, const struct Mem *argv)
 
 	if (mem_is_null(&argv[0]))
 		return;
-	int best = 0;
+	size_t best = 0;
 	for (int i = 1; i < argc; ++i) {
 		if (mem_is_null(&argv[i]))
 			return;
@@ -850,7 +888,7 @@ func_hex(struct sql_context *ctx, int argc, const struct Mem *argv)
 	if (mem_is_null(arg))
 		return;
 
-	assert(mem_is_bin(arg) && arg->n >= 0);
+	assert(mem_is_bin(arg));
 	if (arg->n == 0)
 		return mem_set_str0_static(ctx->pOut, "");
 
@@ -860,7 +898,7 @@ func_hex(struct sql_context *ctx, int argc, const struct Mem *argv)
 		ctx->is_aborted = true;
 		return;
 	}
-	for (int i = 0; i < arg->n; ++i) {
+	for (size_t i = 0; i < arg->n; ++i) {
 		char c = arg->z[i];
 		str[2 * i] = hexdigits[(c >> 4) & 0xf];
 		str[2 * i + 1] = hexdigits[c & 0xf];
@@ -877,7 +915,7 @@ func_octet_length(struct sql_context *ctx, int argc, const struct Mem *argv)
 	const struct Mem *arg = &argv[0];
 	if (mem_is_null(arg))
 		return;
-	assert(mem_is_bytes(arg) && arg->n >= 0);
+	assert(mem_is_bytes(arg));
 	mem_set_uint(ctx->pOut, arg->n);
 }
 
@@ -941,6 +979,11 @@ func_randomblob(struct sql_context *ctx, int argc, const struct Mem *argv)
 	if (arg->u.u == 0)
 		return mem_set_bin_static(ctx->pOut, "", 0);
 	uint64_t len = arg->u.u;
+	if (len > SQL_MAX_LENGTH) {
+		ctx->is_aborted = true;
+		diag_set(ClientError, ER_SQL_EXECUTE, "string or blob too big");
+		return;
+	}
 	char *res = sqlDbMallocRawNN(sql_get(), len);
 	if (res == NULL) {
 		ctx->is_aborted = true;
@@ -968,6 +1011,11 @@ func_zeroblob(struct sql_context *ctx, int argc, const struct Mem *argv)
 	if (arg->u.u == 0)
 		return mem_set_bin_static(ctx->pOut, "", 0);
 	uint64_t len = arg->u.u;
+	if (len > SQL_MAX_LENGTH) {
+		ctx->is_aborted = true;
+		diag_set(ClientError, ER_SQL_EXECUTE, "string or blob too big");
+		return;
+	}
 	char *res = sqlDbMallocZero(sql_get(), len);
 	if (res == NULL) {
 		ctx->is_aborted = true;
@@ -1101,9 +1149,16 @@ func_unicode(struct sql_context *ctx, int argc, const struct Mem *argv)
 	assert(mem_is_str(arg));
 	if (arg->n == 0)
 		return mem_set_uint(ctx->pOut, 0);
-	int pos = 0;
+	if (arg->n > SQL_MAX_LENGTH) {
+		ctx->is_aborted = true;
+		diag_set(ClientError, ER_SQL_EXECUTE, "string or blob too big");
+		return;
+	}
+
+	int32_t pos = 0;
+	int32_t n = arg->n;
 	UChar32 c;
-	U8_NEXT((uint8_t *)arg->z, pos, arg->n, c);
+	U8_NEXT((uint8_t *)arg->z, pos, n, c);
 	(void)pos;
 	mem_set_uint(ctx->pOut, (uint64_t)c);
 }
@@ -1402,11 +1457,15 @@ static void
 likeFunc(sql_context *context, int argc, const struct Mem *argv)
 {
 	u32 escape = SQL_END_OF_STRING;
-	int nPat;
 	assert(argc == 2 || argc == 3);
 	if (mem_is_any_null(&argv[0], &argv[1]))
 		return;
 	assert(mem_is_str(&argv[0]) && mem_is_str(&argv[1]));
+	if (argv[0].n > SQL_MAX_LENGTH || argv[1].n > SQL_MAX_LENGTH) {
+		context->is_aborted = true;
+		diag_set(ClientError, ER_SQL_EXECUTE, "string or blob too big");
+		return;
+	}
 	const char *zB = argv[0].z;
 	const char *zA = argv[1].z;
 	const char *zB_end = zB + argv[0].n;
@@ -1417,7 +1476,7 @@ likeFunc(sql_context *context, int argc, const struct Mem *argv)
 	 * of deep recursion and N*N behavior in
 	 * sql_utf8_pattern_compare().
 	 */
-	nPat = argv[0].n;
+	int32_t nPat = argv[0].n;
 	if (nPat > sql_get()->aLimit[SQL_LIMIT_LIKE_PATTERN_LENGTH]) {
 		diag_set(ClientError, ER_SQL_EXECUTE, "LIKE pattern is too "\
 			 "complex");
@@ -1428,14 +1487,21 @@ likeFunc(sql_context *context, int argc, const struct Mem *argv)
 	if (argc == 3) {
 		if (mem_is_null(&argv[2]))
 			return;
+		assert(mem_is_str(&argv[2]));
+		if (argv[2].n > SQL_MAX_LENGTH) {
+			context->is_aborted = true;
+			diag_set(ClientError, ER_SQL_EXECUTE,
+				 "string or blob too big");
+			return;
+		}
 		/*
 		 * The escape character string must consist of a
 		 * single UTF-8 character. Otherwise, return an
 		 * error.
 		 */
 		const char *str = argv[2].z;
-		int pos = 0;
-		int end = argv[2].n;
+		int32_t pos = 0;
+		int32_t end = argv[2].n;
 		U8_NEXT((uint8_t *)str, pos, end, escape);
 		if (pos != end || end == 0) {
 			diag_set(ClientError, ER_SQL_EXECUTE, "ESCAPE "\
@@ -1522,14 +1588,14 @@ quoteFunc(struct sql_context *context, int argc, const struct Mem *argv)
 	}
 	case MEM_TYPE_BIN: {
 		const char *zBlob = argv[0].z;
-		int nBlob = argv[0].n;
+		size_t nBlob = argv[0].n;
 		uint32_t size = 2 * nBlob + 3;
 		char *zText = sqlDbMallocRawNN(sql_get(), size);
 		if (zText == NULL) {
 			context->is_aborted = true;
 			return;
 		}
-		for (int i = 0; i < nBlob; i++) {
+		for (size_t i = 0; i < nBlob; i++) {
 			zText[(i * 2) + 2] = hexdigits[(zBlob[i] >> 4) & 0x0F];
 			zText[(i * 2) + 3] = hexdigits[(zBlob[i]) & 0x0F];
 		}
@@ -1589,12 +1655,18 @@ replaceFunc(struct sql_context *context, int argc, const struct Mem *argv)
 	const unsigned char *zPattern;	/* The pattern string B */
 	const unsigned char *zRep;	/* The replacement string C */
 	unsigned char *zOut;	/* The output */
-	int nStr;		/* Size of zStr */
-	int nPattern;		/* Size of zPattern */
-	int nRep;		/* Size of zRep */
-	i64 nOut;		/* Maximum size of zOut */
-	int loopLimit;		/* Last zStr[] that might match zPattern[] */
-	int i, j;		/* Loop counters */
+	/* Size of zStr. */
+	size_t nStr;
+	/* Size of zPattern. */
+	size_t nPattern;
+	/* Size of zRep. */
+	size_t nRep;
+	/* Maximum size of zOut. */
+	size_t nOut;
+	/* Last zStr[] that might match zPattern[]. */
+	size_t loopLimit;
+	/* Loop counters. */
+	size_t i, j;
 
 	assert(argc == 3);
 	(void)argc;
@@ -1628,6 +1700,13 @@ replaceFunc(struct sql_context *context, int argc, const struct Mem *argv)
 		} else {
 			u8 *zOld;
 			nOut += nRep - nPattern;
+			if (nOut > SQL_MAX_LENGTH) {
+				sqlDbFree(db, zOut);
+				context->is_aborted = true;
+				diag_set(ClientError, ER_SQL_EXECUTE,
+					 "string or blob too big");
+				return;
+			}
 			zOld = zOut;
 			zOut = sqlDbRealloc(db, zOut, nOut);
 			if (zOut == NULL) {

--- a/src/box/sql/malloc.c
+++ b/src/box/sql/malloc.c
@@ -162,7 +162,7 @@ sqlMallocSize(void *p)
 	return sql_sized_sizeof(p);
 }
 
-int
+size_t
 sqlDbMallocSize(sql * db, void *p)
 {
 	assert(p != 0);

--- a/src/box/sql/mem.h
+++ b/src/box/sql/mem.h
@@ -87,11 +87,13 @@ struct Mem {
 	/** Type of the value this MEM contains. */
 	enum mem_type type;
 	u32 flags;		/* Some combination of MEM_Null, MEM_Str, MEM_Dyn, etc. */
-	int n;			/* size (in bytes) of string value, excluding trailing '\0' */
+	/* Size of variable length value. */
+	size_t n;
 	char *z;		/* String or BLOB value */
 	/* ShallowCopy only needs to copy the information above */
 	char *zMalloc;		/* Space to hold MEM_Str or MEM_Blob if szMalloc>0 */
-	int szMalloc;		/* Size of the zMalloc allocation */
+	/* Size of the zMalloc allocation. */
+	size_t szMalloc;
 	u32 uTemp;		/* Transient storage for serial_type in OP_MakeRecord */
 	sql *db;		/* The associated database connection */
 #ifdef SQL_DEBUG
@@ -296,7 +298,7 @@ mem_is_field_compatible(const struct Mem *mem, enum field_type type);
  * value is equal to or greater than size, then the value has been truncated.
  */
 int
-mem_snprintf(char *buf, uint32_t size, const struct Mem *mem);
+mem_snprintf(char *buf, size_t size, const struct Mem *mem);
 
 /**
  * Returns a NULL-terminated string representation of a MEM. Memory for the
@@ -374,11 +376,11 @@ mem_set_interval(struct Mem *mem, const struct interval *itv);
 
 /** Clear MEM and set it to STRING. The string belongs to another object. */
 void
-mem_set_str_ephemeral(struct Mem *mem, char *value, uint32_t len);
+mem_set_str_ephemeral(struct Mem *mem, char *value, size_t len);
 
 /** Clear MEM and set it to STRING. The string is static. */
 void
-mem_set_str_static(struct Mem *mem, char *value, uint32_t len);
+mem_set_str_static(struct Mem *mem, char *value, size_t len);
 
 /**
  * Clear MEM and set it to STRING. The string was allocated by another object
@@ -387,7 +389,7 @@ mem_set_str_static(struct Mem *mem, char *value, uint32_t len);
  * different value of this allocation type.
  */
 void
-mem_set_str_allocated(struct Mem *mem, char *value, uint32_t len);
+mem_set_str_allocated(struct Mem *mem, char *value, size_t len);
 
 /**
  * Clear MEM and set it to NULL-terminated STRING. The string belongs to
@@ -411,7 +413,7 @@ mem_set_str0_allocated(struct Mem *mem, char *value);
 
 /** Copy string to a newly allocated memory. The MEM type becomes STRING. */
 int
-mem_copy_str(struct Mem *mem, const char *value, uint32_t len);
+mem_copy_str(struct Mem *mem, const char *value, size_t len);
 
 /**
  * Copy NULL-terminated string to a newly allocated memory. The MEM type becomes
@@ -425,11 +427,11 @@ mem_copy_str0(struct Mem *mem, const char *value);
  * object.
  */
 void
-mem_set_bin_ephemeral(struct Mem *mem, char *value, uint32_t size);
+mem_set_bin_ephemeral(struct Mem *mem, char *value, size_t size);
 
 /** Clear MEM and set it to VARBINARY. The binary value is static. */
 void
-mem_set_bin_static(struct Mem *mem, char *value, uint32_t size);
+mem_set_bin_static(struct Mem *mem, char *value, size_t size);
 
 /**
  * Clear MEM and set it to VARBINARY. The binary value was allocated by another
@@ -438,28 +440,28 @@ mem_set_bin_static(struct Mem *mem, char *value, uint32_t size);
  * different value of this allocation type.
  */
 void
-mem_set_bin_allocated(struct Mem *mem, char *value, uint32_t size);
+mem_set_bin_allocated(struct Mem *mem, char *value, size_t size);
 
 /**
  * Copy binary value to a newly allocated memory. The MEM type becomes
  * VARBINARY.
  */
 int
-mem_copy_bin(struct Mem *mem, const char *value, uint32_t size);
+mem_copy_bin(struct Mem *mem, const char *value, size_t size);
 
 /**
  * Clear MEM and set it to MAP. The binary value belongs to another object. The
  * binary value must be msgpack of MAP type.
  */
 void
-mem_set_map_ephemeral(struct Mem *mem, char *value, uint32_t size);
+mem_set_map_ephemeral(struct Mem *mem, char *value, size_t size);
 
 /**
  * Clear MEM and set it to MAP. The binary value is static. The binary value
  * must be msgpack of MAP type.
  */
 void
-mem_set_map_static(struct Mem *mem, char *value, uint32_t size);
+mem_set_map_static(struct Mem *mem, char *value, size_t size);
 
 /**
  * Clear MEM and set it to MAP. The binary value was allocated by another object
@@ -469,25 +471,25 @@ mem_set_map_static(struct Mem *mem, char *value, uint32_t size);
  * allocation type.
  */
 void
-mem_set_map_allocated(struct Mem *mem, char *value, uint32_t size);
+mem_set_map_allocated(struct Mem *mem, char *value, size_t size);
 
 /** Copy MAP value to a newly allocated memory. The MEM type becomes MAP. */
 int
-mem_copy_map(struct Mem *mem, const char *value, uint32_t size);
+mem_copy_map(struct Mem *mem, const char *value, size_t size);
 
 /**
  * Clear MEM and set it to ARRAY. The binary value belongs to another object.
  * The binary value must be msgpack of ARRAY type.
  */
 void
-mem_set_array_ephemeral(struct Mem *mem, char *value, uint32_t size);
+mem_set_array_ephemeral(struct Mem *mem, char *value, size_t size);
 
 /**
  * Clear MEM and set it to ARRAY. The binary value is static. The binary value
  * must be msgpack of ARRAY type.
  */
 void
-mem_set_array_static(struct Mem *mem, char *value, uint32_t size);
+mem_set_array_static(struct Mem *mem, char *value, size_t size);
 
 /**
  * Clear MEM and set it to ARRAY. The binary value was allocated by another
@@ -497,11 +499,11 @@ mem_set_array_static(struct Mem *mem, char *value, uint32_t size);
  * this allocation type.
  */
 void
-mem_set_array_allocated(struct Mem *mem, char *value, uint32_t size);
+mem_set_array_allocated(struct Mem *mem, char *value, size_t size);
 
 /** Copy ARRAY value to a newly allocated memory. The MEM type becomes ARRAY. */
 int
-mem_copy_array(struct Mem *mem, const char *value, uint32_t size);
+mem_copy_array(struct Mem *mem, const char *value, size_t size);
 
 /** Clear MEM and set it to invalid state. */
 void
@@ -554,7 +556,7 @@ mem_move(struct Mem *to, struct Mem *from);
  * memory is allocated in an attempt to reduce the total number of allocations.
  */
 int
-mem_append(struct Mem *mem, const char *value, uint32_t len);
+mem_append(struct Mem *mem, const char *value, size_t len);
 
 /**
  * Concatenate strings or binaries from the first and the second MEMs and write
@@ -811,7 +813,7 @@ mem_get_bin(const struct Mem *mem, const char **s);
  * not changed.
  */
 int
-mem_len(const struct Mem *mem, uint32_t *len);
+mem_len(const struct Mem *mem, size_t *len);
 
 /**
  * Return length of value for MEM of STRING or VARBINARY type. This function is
@@ -821,7 +823,7 @@ mem_len(const struct Mem *mem, uint32_t *len);
 static inline int
 mem_len_unsafe(const struct Mem *mem)
 {
-	uint32_t len;
+	size_t len;
 	if (mem_len(mem, &len) != 0)
 		return 0;
 	return len;
@@ -852,7 +854,15 @@ int sqlVdbeCheckMemInvariants(struct Mem *);
 #define memIsValid(M)  ((M)->type != MEM_TYPE_INVALID)
 #endif
 
-int sqlVdbeMemClearAndResize(struct Mem * pMem, int n);
+/**
+ * Change the pMem->zMalloc allocation to be at least szNew bytes. If
+ * pMem->zMalloc already meets or exceeds the requested size, this routine is a
+ * no-op. Any prior string or blob content in the pMem object will be discarded.
+ *
+ * Return 0 on success or -1 if unable to complete the resizing.
+ */
+int
+sqlVdbeMemClearAndResize(struct Mem *pMem, size_t n);
 
 void sqlValueFree(struct Mem *);
 struct Mem *sqlValueNew(struct sql *);

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2429,7 +2429,13 @@ void *sqlDbReallocOrFree(sql *, void *, u64);
 void *sqlDbRealloc(sql *, void *, u64);
 void sqlDbFree(sql *, void *);
 int sqlMallocSize(void *);
-int sqlDbMallocSize(sql *, void *);
+
+/**
+ * Return the size of a memory allocation previously obtained from
+ * sqlDbMallocRaw() or sqlDbMallocRawNN().
+ */
+size_t
+sqlDbMallocSize(sql *, void *);
 
 /*
  * On systems with ample stack space and that support alloca(), make

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -130,7 +130,7 @@ int sql_sort_count = 0;
  * help verify the correct operation of the library.
  */
 #ifdef SQL_TEST
-int sql_max_blobsize = 0;
+size_t sql_max_blobsize = 0;
 static void
 updateMaxBlobsize(Mem *p)
 {

--- a/test/sql-luatest/ghs_119_too_long_mem_values_test.lua
+++ b/test/sql-luatest/ghs_119_too_long_mem_values_test.lua
@@ -1,0 +1,73 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_zeroblob = function()
+    g.server:exec(function()
+        local ret, err = box.execute([[SELECT randomblob(0x80000010);]])
+        t.assert(ret == nil)
+        local msg = [[Failed to execute SQL statement: string or blob too big]]
+        t.assert_equals(err.message, msg)
+    end)
+end
+
+g.test_randomblob = function()
+    g.server:exec(function()
+        local ret, err = box.execute([[SELECT zeroblob(0x80000010);]])
+        t.assert(ret == nil)
+        local msg = [[Failed to execute SQL statement: string or blob too big]]
+        t.assert_equals(err.message, msg)
+    end)
+end
+
+g.test_replace = function()
+    g.server:exec(function()
+        local a = string.rep('1', 50000)
+        local b = string.rep('2', 50000)
+        local ret, err = box.execute([[SELECT replace(?, '1', ?);]], {a, b})
+        t.assert(ret == nil)
+        local msg = [[Failed to execute SQL statement: string or blob too big]]
+        t.assert_equals(err.message, msg)
+    end)
+end
+
+g.test_quote = function()
+    g.server:exec(function()
+        local ret, err = box.execute([[SELECT quote(randomblob(499999999));]])
+        t.assert(ret == nil)
+        local msg = [[Failed to execute SQL statement: string or blob too big]]
+        t.assert_equals(err.message, msg)
+    end)
+end
+
+g.test_hex = function()
+    g.server:exec(function()
+        local ret, err = box.execute([[SELECT hex(randomblob(500000001));]])
+        t.assert(ret == nil)
+        local msg = [[Failed to execute SQL statement: string or blob too big]]
+        t.assert_equals(err.message, msg)
+    end)
+end
+
+g.test_group_concat = function()
+    g.server:exec(function()
+        box.execute([[CREATE TABLE t(i INT PRIMARY KEY, s VARBINARY);]])
+        box.execute([[INSERT INTO t VALUES(1, randomblob(10000));]])
+        box.execute([[INSERT INTO t VALUES(2, randomblob(10000));]])
+        local sql = [[SELECT group_concat(s, randomblob(999999999)) FROM t;]]
+        local ret, err = box.execute(sql)
+        t.assert(ret == nil)
+        local msg = [[Failed to execute SQL statement: string or blob too big]]
+        t.assert_equals(err.message, msg)
+    end)
+end

--- a/test/sql-luatest/suite.ini
+++ b/test/sql-luatest/suite.ini
@@ -1,3 +1,4 @@
 [default]
 core = luatest
 description = SQL tests on luatest
+long_run = sql-luatest/ghs_119_too_long_mem_values_test.lua


### PR DESCRIPTION
This patch replaces the type for some int and uint32_t values with size_t to avoid problems with integer overflow.

Closes tarantool/security#119

NO_DOC=bugfix

(cherry picked from commit 60a187d7e113fb1c0768774d46215792cc0cef7e)