### PR TITLE
sql: rework parsing of transaction statements

### DIFF
--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -108,10 +108,7 @@ static void disableLookaside(Parse *pParse){
 
 // Input is a single SQL command
 input ::= ecmd.
-ecmd ::= explain cmdx SEMI. {
-	if (!pParse->parse_only)
-		sql_finish_coding(pParse);
-}
+ecmd ::= explain cmdx SEMI.
 ecmd ::= SEMI. {
   diag_set(ClientError, ER_SQL_STATEMENT_EMPTY);
   pParse->is_aborted = true;
@@ -149,20 +146,26 @@ cmdx ::= cmd.
 ///////////////////// Begin and end transactions. ////////////////////////////
 //
 
-cmd ::= START TRANSACTION.  {sql_transaction_begin(pParse);}
-cmd ::= COMMIT.      {sql_transaction_commit(pParse);}
-cmd ::= ROLLBACK.    {sql_transaction_rollback(pParse);}
+cmd ::= START TRANSACTION. {
+  sql_ast_init_start_transaction(pParse);
+}
+cmd ::= COMMIT. {
+  sql_ast_init_commit(pParse);
+}
+cmd ::= ROLLBACK. {
+  sql_ast_init_rollback(pParse);
+}
 
 savepoint_opt ::= SAVEPOINT.
 savepoint_opt ::= .
 cmd ::= SAVEPOINT nm(X). {
-  sqlSavepoint(pParse, SAVEPOINT_BEGIN, &X);
+  sql_ast_init_savepoint(pParse, &X);
 }
 cmd ::= RELEASE savepoint_opt nm(X). {
-  sqlSavepoint(pParse, SAVEPOINT_RELEASE, &X);
+  sql_ast_init_release_savepoint(pParse, &X);
 }
 cmd ::= ROLLBACK TO savepoint_opt nm(X). {
-  sqlSavepoint(pParse, SAVEPOINT_ROLLBACK, &X);
+  sql_ast_init_rollback_to_savepoint(pParse, &X);
 }
 
 ///////////////////// The CREATE TABLE statement ////////////////////////////

--- a/src/box/sql/parse_def.c
+++ b/src/box/sql/parse_def.c
@@ -30,7 +30,7 @@
  */
 #include <string.h>
 
-#include "parse_def.h"
+#include "sqlInt.h"
 
 const struct Token sqlIntTokens[] = {
 	{"0", 1, false},
@@ -44,4 +44,50 @@ sqlTokenInit(struct Token *p, char *z)
 {
 	p->z = z;
 	p->n = z == NULL ? 0 : strlen(z);
+}
+
+void
+sql_ast_init_start_transaction(struct Parse *parse)
+{
+	assert(parse->ast.type == SQL_AST_TYPE_UNKNOWN);
+	parse->ast.type = SQL_AST_TYPE_START_TRANSACTION;
+}
+
+void
+sql_ast_init_commit(struct Parse *parse)
+{
+	assert(parse->ast.type == SQL_AST_TYPE_UNKNOWN);
+	parse->ast.type = SQL_AST_TYPE_COMMIT;
+}
+
+void
+sql_ast_init_rollback(struct Parse *parse)
+{
+	assert(parse->ast.type == SQL_AST_TYPE_UNKNOWN);
+	parse->ast.type = SQL_AST_TYPE_ROLLBACK;
+}
+
+void
+sql_ast_init_savepoint(struct Parse *parse, const struct Token *name)
+{
+	assert(parse->ast.type == SQL_AST_TYPE_UNKNOWN);
+	parse->ast.type = SQL_AST_TYPE_SAVEPOINT;
+	parse->ast.savepoint.name = *name;
+}
+
+void
+sql_ast_init_release_savepoint(struct Parse *parse, const struct Token *name)
+{
+	assert(parse->ast.type == SQL_AST_TYPE_UNKNOWN);
+	parse->ast.type = SQL_AST_TYPE_RELEASE_SAVEPOINT;
+	parse->ast.savepoint.name = *name;
+}
+
+void
+sql_ast_init_rollback_to_savepoint(struct Parse *parse,
+				   const struct Token *name)
+{
+	assert(parse->ast.type == SQL_AST_TYPE_UNKNOWN);
+	parse->ast.type = SQL_AST_TYPE_ROLLBACK_TO_SAVEPOINT;
+	parse->ast.savepoint.name = *name;
 }

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -74,6 +74,24 @@
  * parsing context (struct Parse).
  */
 
+/** Type of parsed statement. */
+enum sql_ast_type {
+	/** Type of the statement is unknown. */
+	SQL_AST_TYPE_UNKNOWN = 0,
+	/** START TRANSACTION statement. */
+	SQL_AST_TYPE_START_TRANSACTION,
+	/** COMMIT statement. */
+	SQL_AST_TYPE_COMMIT,
+	/** ROLLBACK statement. */
+	SQL_AST_TYPE_ROLLBACK,
+	/** SAVEPOINT statement. */
+	SQL_AST_TYPE_SAVEPOINT,
+	/** RELEASE SAVEPOINT statement. */
+	SQL_AST_TYPE_RELEASE_SAVEPOINT,
+	/** ROLLBACK TO SAVEPOINT statement. */
+	SQL_AST_TYPE_ROLLBACK_TO_SAVEPOINT,
+};
+
 /**
  * Each token coming out of the lexer is an instance of
  * this structure. Tokens are also used as part of an expression.
@@ -84,6 +102,20 @@ struct Token {
 	/** Number of characters in this token. */
 	unsigned int n;
 	bool isReserved;
+};
+
+/** Description of a SAVEPOINT. */
+struct sql_ast_savepoint {
+	/** Name of the SAVEPOINT. */
+	struct Token name;
+};
+
+/** A structure describing the AST of the parsed SQL statement. */
+struct sql_ast {
+	/** Parsed statement type. */
+	enum sql_ast_type type;
+	/** Savepoint description for savepoint-related statements. */
+	struct sql_ast_savepoint savepoint;
 };
 
 /** Constant tokens for integer values. */
@@ -522,5 +554,30 @@ create_fk_constraint_parse_def_destroy(struct create_fk_constraint_parse_def *d)
 	rlist_foreach_entry(fk, &d->fkeys, link)
 		sql_expr_list_delete(fk->selfref_cols);
 }
+
+/** Save parsed START TRANSACTION statement. */
+void
+sql_ast_init_start_transaction(struct Parse *parse);
+
+/** Save parsed COMMIT statement. */
+void
+sql_ast_init_commit(struct Parse *parse);
+
+/** Save parsed ROLLBACK statement. */
+void
+sql_ast_init_rollback(struct Parse *parse);
+
+/** Save parsed SAVEPOINT statement. */
+void
+sql_ast_init_savepoint(struct Parse *parse, const struct Token *name);
+
+/** Save parsed RELEASE SAVEPOINT statement. */
+void
+sql_ast_init_release_savepoint(struct Parse *parse, const struct Token *name);
+
+/** Save parsed ROLLBACK TO SAVEPOINT statement. */
+void
+sql_ast_init_rollback_to_savepoint(struct Parse *parse,
+				   const struct Token *name);
 
 #endif /* TARANTOOL_BOX_SQL_PARSE_DEF_H_INCLUDED */

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2062,6 +2062,8 @@ struct Parse {
 	 */
 	struct create_table_def create_table_def;
 	struct create_column_def create_column_def;
+	/** AST of parsed SQL statement. */
+	struct sql_ast ast;
 	/*
 	 * FK and CK constraints appeared in a <CREATE TABLE> or
 	 * an <ALTER TABLE ADD COLUMN> statement.


### PR DESCRIPTION
This patch reworks the parsing of statements associated with transactions. There are six of them:
START TRANSACTION;
COMMIT;
ROLLBACK;
SAVEPOINT savepoint_name;
RELEASE [SAVEPOINT] savepoint_name;
ROLLBACK TO savepoint_name;

Prior to this patch, VDBE for these statements were generated while the statement was in the process of being parsed. After this patch, VDBE for all these statements will be generated only after the parsing has successfully completed.

Part of #5485

NO_DOC=Will be added later
NO_TEST=No user-visible changes are made
NO_CHANGELOG=Will be added later