### PR TITLE
sql: limit memory allocation in REPLACE()

### DIFF
--- a/src/box/sql/func.c
+++ b/src/box/sql/func.c
@@ -1661,6 +1661,13 @@ replaceFunc(struct sql_context *context, int argc, const struct Mem *argv)
 			zOut[j++] = zStr[i];
 		} else {
 			nOut += nRep - nPattern;
+			if (nOut > SQL_MAX_LENGTH) {
+				sql_xfree(zOut);
+				context->is_aborted = true;
+				diag_set(ClientError, ER_SQL_EXECUTE,
+					 "string or blob too big");
+				return;
+			}
 			zOut = sql_xrealloc(zOut, nOut);
 			memcpy(&zOut[j], zRep, nRep);
 			j += nRep;

--- a/test/sql-luatest/ghs_119_too_long_mem_values_test.lua
+++ b/test/sql-luatest/ghs_119_too_long_mem_values_test.lua
@@ -38,6 +38,10 @@ g.test_replace = function()
         t.assert(ret == nil)
         local msg = [[Failed to execute SQL statement: string or blob too big]]
         t.assert_equals(err.message, msg)
+        ret, err = box.execute([[SELECT replace(zeroblob(0x1000), zeroblob(1),
+                                                randomblob(0x10000000))]])
+        t.assert(ret == nil)
+        t.assert_equals(err.message, msg)
     end)
 end
 


### PR DESCRIPTION
This patch limits the amount of allocated memory in the built-in REPLACE() function.

Follow-up tarantool/security#119

For master and 2.11 only. In 2.10 the issue is already fixed.