### PR TITLE
[2.10] test: don't skip gh_8445_crash_during_crash_report_test.lua on AArch64 Linux

### DIFF
--- a/test/app-luatest/gh_8445_crash_during_crash_report_test.lua
+++ b/test/app-luatest/gh_8445_crash_during_crash_report_test.lua
@@ -2,9 +2,6 @@ local t = require('luatest')
 local g = t.group('gh-8445')
 
 g.before_all(function(cg)
-    -- TODO(gh-8572)
-    t.skip_if(jit.arch == 'arm64' and jit.os == 'Linux',
-              'Disabled on AArch64 Linux due to #8572')
     local server = require('luatest.server')
     cg.server = server:new({alias = 'gh-8445'})
 end)


### PR DESCRIPTION
The test was disabled in master and 2.11 due to #8572.
That issue is not applicable to 2.10, hence `gh_8445_crash_during_crash_report_test.lua` can be enabled.