### PR TITLE
Always reload URIs when listen/replication is reconfigured

### DIFF
--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -2695,6 +2695,16 @@ applier_delete(struct applier *applier)
 }
 
 void
+applier_reload_uri(struct applier *applier)
+{
+	struct iostream_ctx io_ctx;
+	if (iostream_ctx_create(&io_ctx, IOSTREAM_CLIENT, &applier->uri) != 0)
+		diag_raise();
+	iostream_ctx_destroy(&applier->io_ctx);
+	iostream_ctx_move(&applier->io_ctx, &io_ctx);
+}
+
+void
 applier_resume(struct applier *applier)
 {
 	assert(!fiber_is_dead(applier->fiber));

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -454,17 +454,12 @@ applier_watch_ballot(struct applier *applier)
 {
 	struct xrow_header row;
 	struct iostream io;
-	struct iostream_ctx io_ctx;
 	struct ibuf ibuf;
-	iostream_ctx_clear(&io_ctx);
-	if (iostream_ctx_create(&io_ctx, IOSTREAM_CLIENT, &applier->uri) != 0)
-		diag_raise();
 	iostream_clear(&io);
 	ibuf_create(&ibuf, &cord()->slabc, 1024);
 	auto guard = make_scoped_guard([&] {
 		if (iostream_is_initialized(&io))
 			iostream_close(&io);
-		iostream_ctx_destroy(&io_ctx);
 		ibuf_destroy(&ibuf);
 	});
 
@@ -472,7 +467,8 @@ applier_watch_ballot(struct applier *applier)
 
 	applier->addr_len = sizeof(applier->addrstorage);
 	applier_connection_init(&io, &applier->uri, &applier->addr,
-				&applier->addr_len, &io_ctx, &greeting);
+				&applier->addr_len, &applier->io_ctx,
+				&greeting);
 	if (!iproto_features_test(&applier->features,
 				  IPROTO_FEATURE_WATCHERS)) {
 		goto try_vote;

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -2659,7 +2659,7 @@ applier_stop(struct applier *applier)
 }
 
 struct applier *
-applier_new(struct uri *uri)
+applier_new(const struct uri *uri)
 {
 	struct applier *applier = (struct applier *)
 		xcalloc(1, sizeof(struct applier));
@@ -2670,7 +2670,7 @@ applier_new(struct uri *uri)
 	iostream_clear(&applier->io);
 	ibuf_create(&applier->ibuf, &cord()->slabc, 1024);
 
-	uri_move(&applier->uri, uri);
+	uri_copy(&applier->uri, uri);
 	applier->last_row_time = ev_monotonic_now(loop());
 	rlist_create(&applier->on_state);
 	rlist_create(&applier->on_ballot_update);

--- a/src/box/applier.h
+++ b/src/box/applier.h
@@ -308,7 +308,7 @@ applier_stop(struct applier *applier);
  * @error   throws exception
  */
 struct applier *
-applier_new(struct uri *uri);
+applier_new(const struct uri *uri);
 
 /**
  * Destroy and delete a applier.

--- a/src/box/applier.h
+++ b/src/box/applier.h
@@ -316,6 +316,14 @@ applier_new(const struct uri *uri);
 void
 applier_delete(struct applier *applier);
 
+/**
+ * Recreates the IO stream context from the applier's URI.
+ *
+ * Throws an exception on failure.
+ */
+void
+applier_reload_uri(struct applier *applier);
+
 /*
  * Resume execution of applier until \a state.
  */

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -1775,7 +1775,15 @@ box_set_replication(void)
 	struct uri_set uri_set;
 	if (box_check_replication(&uri_set) != 0)
 		diag_raise();
+	bool unchanged = uri_set_is_equal(&uri_set, &replication_uris);
 	uri_set_destroy(&uri_set);
+	if (unchanged) {
+		/*
+		 * No need to reconnect or sync in case the configuration is
+		 * the same.
+		 */
+		return;
+	}
 	/*
 	 * Try to connect to all replicas within the timeout period.
 	 * Stay in orphan mode in case we fail to connect to at least

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -1780,8 +1780,11 @@ box_set_replication(void)
 	if (unchanged) {
 		/*
 		 * No need to reconnect or sync in case the configuration is
-		 * the same.
+		 * the same. However, we should still reload the URIs because
+		 * a URI parameter may store a path to a file (for example,
+		 * an SSL certificate), which could change.
 		 */
+		replicaset_reload_uris();
 		return;
 	}
 	/*

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -1734,7 +1734,7 @@ box_sync_replication(bool do_quorum, bool do_reuse)
 	}
 	int count = 0;
 	struct applier *appliers[VCLOCK_MAX] = {};
-	auto appliers_guard = make_scoped_guard([=]{
+	auto appliers_guard = make_scoped_guard([&]{
 		for (int i = 0; i < count; i++)
 			applier_delete(appliers[i]); /* doesn't affect diag */
 	});

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -1728,21 +1728,7 @@ box_sync_replication(bool do_quorum, bool do_reuse)
 	auto uri_set_guard = make_scoped_guard([&]{
 		uri_set_destroy(&uri_set);
 	});
-	if (uri_set.uri_count >= VCLOCK_MAX) {
-		tnt_raise(ClientError, ER_CFG, "replication",
-			  "too many replicas");
-	}
-	int count = 0;
-	struct applier *appliers[VCLOCK_MAX] = {};
-	auto appliers_guard = make_scoped_guard([&]{
-		for (int i = 0; i < count; i++)
-			applier_delete(appliers[i]); /* doesn't affect diag */
-	});
-	for (; count < uri_set.uri_count; count++) {
-		appliers[count] = applier_new(&uri_set.uris[count]);
-	}
-	replicaset_connect(appliers, count, do_quorum, do_reuse);
-	appliers_guard.is_active = false;
+	replicaset_connect(&uri_set, do_quorum, do_reuse);
 }
 
 static inline void

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -910,11 +910,12 @@ local function reload_cfg(oldcfg, cfg)
     local module_keys = {}
     -- iterate over original table because prepare_cfg() may store NILs
     for key in pairs(cfg) do
-        if not compare_cfg(oldcfg[key], newcfg[key]) then
-            local name = option2module_name[key]
-            if name == nil then
+        local name = option2module_name[key]
+        if name == nil then
+            if not compare_cfg(oldcfg[key], newcfg[key]) then
                 box.error(box.error.RELOAD_CFG, key);
             end
+        else
             if module_keys[name] == nil then
                 module_keys[name] = {}
             end

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -1557,7 +1557,8 @@ memtx_engine_set_snap_io_rate_limit(struct memtx_engine *memtx, double limit)
 int
 memtx_engine_set_memory(struct memtx_engine *memtx, size_t size)
 {
-	if (size < quota_total(&memtx->quota)) {
+	if (DIV_ROUND_UP(size, QUOTA_UNIT_SIZE) <
+	    quota_total(&memtx->quota) / QUOTA_UNIT_SIZE) {
 		diag_set(ClientError, ER_CFG, "memtx_memory",
 			 "cannot decrease memory size at runtime");
 		return -1;

--- a/src/box/replication.cc
+++ b/src/box/replication.cc
@@ -450,7 +450,7 @@ replicaset_on_health_change(void)
 		trigger_run(&replicaset_on_quorum_loss, NULL);
 }
 
-void
+static void
 replica_set_applier(struct replica *replica, struct applier *applier)
 {
 	assert(replica->applier == NULL);
@@ -482,7 +482,7 @@ replica_update_applier_health(struct replica *replica)
 	replicaset_on_health_change();
 }
 
-void
+static void
 replica_clear_applier(struct replica *replica)
 {
 	assert(replica->applier != NULL);
@@ -973,14 +973,29 @@ replicaset_is_connected(struct replicaset_connect_state *state,
 }
 
 void
-replicaset_connect(struct applier **appliers, int count,
+replicaset_connect(const struct uri_set *uris,
 		   bool connect_quorum, bool keep_connect)
 {
-	if (count == 0) {
+	if (uris->uri_count == 0) {
 		/* Cleanup the replica set. */
-		replicaset_update(appliers, 0, false);
+		replicaset_update(NULL, 0, false);
 		return;
 	}
+	if (uris->uri_count >= VCLOCK_MAX) {
+		tnt_raise(ClientError, ER_CFG, "replication",
+			  "too many replicas");
+	}
+	int count = 0;
+	struct applier *appliers[VCLOCK_MAX] = {};
+	auto appliers_guard = make_scoped_guard([&]{
+		for (int i = 0; i < count; i++) {
+			struct applier *applier = appliers[i];
+			applier_stop(applier);
+			applier_delete(applier);
+		}
+	});
+	for (; count < uris->uri_count; count++)
+		appliers[count] = applier_new(&uris->uris[count]);
 
 	say_info("connecting to %d replicas", count);
 
@@ -1045,9 +1060,8 @@ replicaset_connect(struct applier **appliers, int count,
 		/* Timeout or connection failure. */
 		if (state.connected < replicaset_connect_quorum(count) &&
 		    connect_quorum) {
-			diag_set(ClientError, ER_CFG, "replication",
-				 "failed to connect to one or more replicas");
-			goto error;
+			tnt_raise(ClientError, ER_CFG, "replication",
+				  "failed to connect to one or more replicas");
 		}
 	} else {
 		say_info("connected to %d replicas", state.connected);
@@ -1067,19 +1081,8 @@ replicaset_connect(struct applier **appliers, int count,
 	}
 
 	/* Now all the appliers are connected, update the replica set. */
-	try {
-		replicaset_update(appliers, count, keep_connect);
-	} catch (Exception *e) {
-		goto error;
-	}
-	return;
-error:
-	/* Destroy appliers */
-	for (int i = 0; i < count; i++) {
-		trigger_clear(&triggers[i].base);
-		applier_stop(appliers[i]);
-	}
-	diag_raise();
+	replicaset_update(appliers, count, keep_connect);
+	appliers_guard.is_active = false;
 }
 
 bool

--- a/src/box/replication.cc
+++ b/src/box/replication.cc
@@ -47,6 +47,7 @@ uint32_t instance_id = REPLICA_ID_NIL;
 struct tt_uuid INSTANCE_UUID;
 struct tt_uuid REPLICASET_UUID;
 
+struct uri_set replication_uris;
 double replication_timeout = 1.0; /* seconds */
 double replication_connect_timeout = 30.0; /* seconds */
 int replication_connect_quorum = REPLICATION_CONNECT_QUORUM_ALL;
@@ -979,6 +980,9 @@ replicaset_connect(const struct uri_set *uris,
 	if (uris->uri_count == 0) {
 		/* Cleanup the replica set. */
 		replicaset_update(NULL, 0, false);
+		uri_set_destroy(&replication_uris);
+		if (uri_set_create(&replication_uris, NULL) != 0)
+			unreachable();
 		return;
 	}
 	if (uris->uri_count >= VCLOCK_MAX) {
@@ -1083,6 +1087,8 @@ replicaset_connect(const struct uri_set *uris,
 	/* Now all the appliers are connected, update the replica set. */
 	replicaset_update(appliers, count, keep_connect);
 	appliers_guard.is_active = false;
+	uri_set_destroy(&replication_uris);
+	uri_set_copy(&replication_uris, uris);
 }
 
 bool

--- a/src/box/replication.cc
+++ b/src/box/replication.cc
@@ -1091,6 +1091,16 @@ replicaset_connect(const struct uri_set *uris,
 	uri_set_copy(&replication_uris, uris);
 }
 
+void
+replicaset_reload_uris(void)
+{
+	replicaset_foreach(replica) {
+		struct applier *applier = replica->applier;
+		if (applier != NULL)
+			applier_reload_uri(applier);
+	}
+}
+
 bool
 replicaset_needs_rejoin(struct replica **master)
 {

--- a/src/box/replication.h
+++ b/src/box/replication.h
@@ -586,6 +586,19 @@ replicaset_connect(const struct uri_set *uris,
 		   bool connect_quorum, bool keep_connect);
 
 /**
+ * Reload replica URIs.
+ *
+ * Called on reconfiguration in case the remote peer URIs are the same.
+ * A URI parameter may store a path to a file (for example, an SSL
+ * certificate), which could change, so we need to recreate appliers'
+ * IO stream contexts in this case.
+ *
+ * Throws an exception on failure.
+ */
+void
+replicaset_reload_uris(void);
+
+/**
  * Check if the current instance fell too much behind its
  * peers in the replica set and needs to be rebootstrapped.
  * If it does, return true and set @master to the instance

--- a/src/box/replication.h
+++ b/src/box/replication.h
@@ -133,6 +133,11 @@ extern struct uri cfg_bootstrap_leader_uri;
 extern enum replicaset_state replicaset_state;
 
 /**
+ * Remote peer URIs. Set by box.cfg.replication_uris.
+ */
+extern struct uri_set replication_uris;
+
+/**
  * Network timeout. Determines how often master and slave exchange
  * heartbeat messages. Set by box.cfg.replication_timeout.
  */

--- a/src/box/replication.h
+++ b/src/box/replication.h
@@ -457,12 +457,6 @@ replica_set_id(struct replica *replica, uint32_t id);
 void
 replica_clear_id(struct replica *replica);
 
-void
-replica_clear_applier(struct replica *replica);
-
-void
-replica_set_applier(struct replica * replica, struct applier * applier);
-
 /**
  * Check if there are enough "healthy" connections, and fire the appropriate
  * triggers. A replica connection is considered "healthy", when:
@@ -574,9 +568,8 @@ replicaset_add_anon(const struct tt_uuid *replica_uuid);
  * \post appliers are connected to remote hosts and paused.
  * Use replicaset_follow() to resume appliers.
  *
- * \param appliers the array of appliers
- * \param count size of appliers array
- * \param timeout connection timeout
+ * \param uris           remote peer URIs
+ * \param timeout        connection timeout
  * \param connect_quorum if this flag is set, fail unless at
  *                       least replication_connect_quorum
  *                       appliers have successfully connected.
@@ -584,7 +577,7 @@ replicaset_add_anon(const struct tt_uuid *replica_uuid);
  *                       old connection to the replica is fine.
  */
 void
-replicaset_connect(struct applier **appliers, int count,
+replicaset_connect(const struct uri_set *uris,
 		   bool connect_quorum, bool keep_connect);
 
 /**

--- a/src/lib/core/evio.h
+++ b/src/lib/core/evio.h
@@ -109,17 +109,9 @@ evio_service_create(struct ev_loop *loop, struct evio_service *service,
                     const char *name, evio_accept_f on_accept,
                     void *on_accept_param);
 
-/** Bind service to specified uri */
+/** Bind service to specified URI and start listening on it. */
 int
-evio_service_bind(struct evio_service *service, const struct uri_set *uri_set);
-
-/**
- * Listen on bounded socket
- *
- * @retval 0 for success
- */
-int
-evio_service_listen(struct evio_service *service);
+evio_service_start(struct evio_service *service, const struct uri_set *uri_set);
 
 /** If started, stop event flow, without closing the acceptor socket. */
 void
@@ -134,9 +126,6 @@ evio_service_stop(struct evio_service *service);
  */
 void
 evio_service_attach(struct evio_service *dst, const struct evio_service *src);
-
-bool
-evio_service_is_active(const struct evio_service *service);
 
 static inline void
 evio_timeout_init(ev_loop *loop, ev_tstamp *start, ev_tstamp *delay,

--- a/src/lib/core/evio.h
+++ b/src/lib/core/evio.h
@@ -127,6 +127,19 @@ evio_service_stop(struct evio_service *service);
 void
 evio_service_attach(struct evio_service *dst, const struct evio_service *src);
 
+/**
+ * Reload service URIs.
+ *
+ * Called on reconfiguration in case the new listen URIs are the same.
+ * A URI parameter may store a path to a file (for example, an SSL
+ * certificate), which could change, so we need to recreate service entries'
+ * IO stream contexts in this case.
+ *
+ * Returns -1 on failure.
+ */
+int
+evio_service_reload_uris(struct evio_service *service);
+
 static inline void
 evio_timeout_init(ev_loop *loop, ev_tstamp *start, ev_tstamp *delay,
 		  ev_tstamp timeout)

--- a/src/lib/core/iostream.c
+++ b/src/lib/core/iostream.c
@@ -98,15 +98,14 @@ iostream_ctx_create(struct iostream_ctx *ctx, enum iostream_mode mode,
 {
 	assert(mode == IOSTREAM_SERVER || mode == IOSTREAM_CLIENT);
 	ctx->mode = mode;
+	ctx->ssl = NULL;
 	const char *transport = uri_param(uri, "transport", 0);
 	if (transport != NULL) {
 		if (strcmp(transport, "ssl") == 0) {
 			ctx->ssl = ssl_iostream_ctx_new(mode, uri);
 			if (ctx->ssl == NULL)
 				goto err;
-		} else if (strcmp(transport, "plain") == 0) {
-			ctx->ssl = NULL;
-		} else {
+		} else if (strcmp(transport, "plain") != 0) {
 			diag_set(IllegalParams, "Invalid transport: %s",
 				 transport);
 			goto err;

--- a/src/lib/core/iostream.c
+++ b/src/lib/core/iostream.c
@@ -125,6 +125,14 @@ iostream_ctx_destroy(struct iostream_ctx *ctx)
 	iostream_ctx_clear(ctx);
 }
 
+void
+iostream_ctx_copy(struct iostream_ctx *dst, const struct iostream_ctx *src)
+{
+	assert(src->mode == IOSTREAM_CLIENT || src->mode == IOSTREAM_SERVER);
+	dst->mode = src->mode;
+	dst->ssl = ssl_iostream_ctx_dup(src->ssl);
+}
+
 int
 iostream_create(struct iostream *io, int fd, const struct iostream_ctx *ctx)
 {

--- a/src/lib/core/iostream.h
+++ b/src/lib/core/iostream.h
@@ -266,6 +266,17 @@ iostream_ctx_clear(struct iostream_ctx *ctx)
 }
 
 /**
+ * Move constructor: copies src to dst and clears src.
+ */
+static inline void
+iostream_ctx_move(struct iostream_ctx *dst, struct iostream_ctx *src)
+{
+	assert(src->mode == IOSTREAM_CLIENT || src->mode == IOSTREAM_SERVER);
+	*dst = *src;
+	iostream_ctx_clear(src);
+}
+
+/**
  * Creates an IO stream context for the given mode and URI.
  * On success returns 0. On failure returns -1, sets diag,
  * and clears the context struct (see iostream_ctx_clear).

--- a/src/lib/core/iostream.h
+++ b/src/lib/core/iostream.h
@@ -266,6 +266,12 @@ iostream_ctx_clear(struct iostream_ctx *ctx)
 }
 
 /**
+ * Copy constructor: copies src to dst.
+ */
+void
+iostream_ctx_copy(struct iostream_ctx *dst, const struct iostream_ctx *src);
+
+/**
  * Move constructor: copies src to dst and clears src.
  */
 static inline void

--- a/src/lib/core/ssl.h
+++ b/src/lib/core/ssl.h
@@ -11,6 +11,8 @@
 # include "ssl_impl.h"
 #else /* !defined(ENABLE_SSL) */
 
+#include <assert.h>
+
 #include "iostream.h"
 #include "trivia/util.h"
 
@@ -29,6 +31,13 @@ ssl_free(void);
 
 struct ssl_iostream_ctx *
 ssl_iostream_ctx_new(enum iostream_mode mode, const struct uri *uri);
+
+static inline struct ssl_iostream_ctx *
+ssl_iostream_ctx_dup(struct ssl_iostream_ctx *ctx)
+{
+	assert(ctx == NULL);
+	return ctx;
+}
 
 static inline void
 ssl_iostream_ctx_delete(struct ssl_iostream_ctx *ctx)

--- a/src/lib/uri/uri.h
+++ b/src/lib/uri/uri.h
@@ -123,6 +123,18 @@ uri_set_destroy(struct uri_set *uri_set);
 void
 uri_set_add(struct uri_set *uri_set, struct uri *uri);
 
+/**
+ * Copies all URIs from @a src to @dst.
+ */
+void
+uri_set_copy(struct uri_set *dst, const struct uri_set *src);
+
+/**
+ * Return true if the two sets contain the same URIs in the same order.
+ */
+bool
+uri_set_is_equal(const struct uri_set *a, const struct uri_set *b);
+
 int
 uri_format(char *str, int len, const struct uri *uri, bool write_password);
 
@@ -157,6 +169,15 @@ uri_unescape(const char *src, size_t src_size, char *dst, bool decode_plus);
 /** Determine if uris refer to the same host:service or unix socket path. */
 bool
 uri_addr_is_equal(const struct uri *a, const struct uri *b);
+
+/**
+ * Return true if the two uris are equivalent, i.e. they have the same scheme,
+ * credentials, address, query parameters, and fragment.
+ *
+ * Note, query strings are not compared. We compare query parameters instead.
+ */
+bool
+uri_is_equal(const struct uri *a, const struct uri *b);
 
 /** Check if a uri is empty. */
 bool

--- a/test/unit/uri.c
+++ b/test/unit/uri.c
@@ -167,7 +167,7 @@ test_addr_is_equal(void)
 		{"unix/:/path/to/file", "/path/to/file", true},
 	};
 	header();
-	plan(3 * lengthof(test_pairs));
+	plan(4 * lengthof(test_pairs));
 	for (unsigned i = 0; i < lengthof(test_pairs); i++) {
 		struct uri uri_a, uri_b;
 		const char *src_a = test_pairs[i].src_a;
@@ -180,7 +180,137 @@ test_addr_is_equal(void)
 		is(uri_addr_is_equal(&uri_a, &uri_b), is_equal,
 		   "%s %s equal to %s", src_a ? src_a : "NULL",
 		   is_equal ? "is" : "isn't", src_b ? src_b : "NULL");
+		is(uri_addr_is_equal(&uri_b, &uri_a), is_equal,
+		   "%s %s equal to %s", src_b ? src_b : "NULL",
+		   is_equal ? "is" : "isn't", src_a ? src_a : "NULL");
+		uri_destroy(&uri_a);
+		uri_destroy(&uri_b);
 	}
+	check_plan();
+	footer();
+}
+
+static void
+test_uri_is_equal(void)
+{
+	struct uri_equal_expected test_pairs[] = {
+		{NULL, NULL, true},
+		{"localhost", "localhost", true},
+		{"user@localhost", "localhost", false},
+		{"user@localhost", "user@localhost", true},
+		{"user:pass@localhost", "user@localhost", false},
+		{"user:pass@localhost", "user:pass@localhost", true},
+		{"localhost:3301", "localhost:3302", false},
+		{"localhost:3301", "localhost:3301", true},
+		{"host_a", "host_b", false},
+		{"scheme://localhost", "localhost", false},
+		{"scheme://localhost", "scheme://localhost", true},
+		{"scheme1://host:port", "scheme2://host:port", false},
+		{"localhost/path/to/file", "localhost", false},
+		{"/path/to/file", "/path/to/file", true},
+		{"/path/to/file", "localhost/path/to/file", false},
+		{"unix/path/to/file", "/path/to/file", false},
+		{"unix/:/path/to/file", "/path/to/file", true},
+		{"localhost#foo", "localhost#bar", false},
+		{"localhost#foo", "localhost#foo", true},
+		{"localhost?foo", "localhost", false},
+		{"localhost?foo", "localhost?foo", true},
+		{"localhost?foo=1", "localhost?foo", false},
+		{"localhost?foo=1", "localhost?foo&foo=1", true},
+		{"localhost?foo&bar", "localhost?foo", false},
+		{"localhost?foo&bar", "localhost?foo&bar", true},
+		{"localhost?foo&bar", "localhost?bar&foo", true},
+		{"localhost?foo=1", "localhost", false},
+		{"localhost?foo=1", "localhost?bar=1", false},
+		{"localhost?foo=1", "localhost?foo=2", false},
+		{"localhost?foo=1", "localhost?foo=1", true},
+		{"localhost?foo=1", "localhost?foo=1&foo=2", false},
+		{"localhost?foo=1&foo=2", "localhost?foo=2&foo=1", false},
+		{"localhost?foo=1&bar=1", "localhost?foo=1&bar=2", false},
+		{"localhost?foo=1&bar=3&foo=2",
+		 "localhost?foo=1&foo=2&bar=3", true},
+		{"localhost?foo=1&bar=3&foo=2",
+		 "localhost?bar=3&foo=1&foo=2", true},
+	};
+	header();
+	plan(4 * lengthof(test_pairs));
+	for (unsigned i = 0; i < lengthof(test_pairs); i++) {
+		struct uri uri_a, uri_b;
+		const char *src_a = test_pairs[i].src_a;
+		const char *src_b = test_pairs[i].src_b;
+		bool is_equal = test_pairs[i].is_equal;
+		ok(uri_create(&uri_a, src_a) == 0, "uri_create(%s)",
+		   src_a ? src_a : "NULL");
+		ok(uri_create(&uri_b, src_b) == 0, "uri_create(%s)",
+		   src_b ? src_b : "NULL");
+		is(uri_is_equal(&uri_a, &uri_b), is_equal,
+		   "%s %s equal to %s", src_a ? src_a : "NULL",
+		   is_equal ? "is" : "isn't", src_b ? src_b : "NULL");
+		is(uri_is_equal(&uri_b, &uri_a), is_equal,
+		   "%s %s equal to %s", src_b ? src_b : "NULL",
+		   is_equal ? "is" : "isn't", src_a ? src_a : "NULL");
+		uri_destroy(&uri_a);
+		uri_destroy(&uri_b);
+	}
+	check_plan();
+	footer();
+}
+
+static void
+test_uri_set_is_equal(void)
+{
+	struct uri_equal_expected test_pairs[] = {
+		{NULL, NULL, true},
+		{NULL, "localhost", false},
+		{NULL, "", true},
+		{"", "", true},
+		{"", "localhost", false},
+		{"localhost", "localhost", true},
+		{"host1,host2", "host1", false},
+		{"host1,host2", "host2", false},
+		{"host1,host2", "host2,host1", false},
+		{"host1,host2", "host1,host2", true},
+	};
+	header();
+	plan(4 * lengthof(test_pairs));
+	for (unsigned i = 0; i < lengthof(test_pairs); i++) {
+		struct uri_set uri_a, uri_b;
+		const char *src_a = test_pairs[i].src_a;
+		const char *src_b = test_pairs[i].src_b;
+		bool is_equal = test_pairs[i].is_equal;
+		ok(uri_set_create(&uri_a, src_a) == 0, "uri_create(%s)",
+		   src_a ? src_a : "NULL");
+		ok(uri_set_create(&uri_b, src_b) == 0, "uri_create(%s)",
+		   src_b ? src_b : "NULL");
+		is(uri_set_is_equal(&uri_a, &uri_b), is_equal,
+		   "%s %s equal to %s", src_a ? src_a : "NULL",
+		   is_equal ? "is" : "isn't", src_b ? src_b : "NULL");
+		is(uri_set_is_equal(&uri_b, &uri_a), is_equal,
+		   "%s %s equal to %s", src_b ? src_b : "NULL",
+		   is_equal ? "is" : "isn't", src_a ? src_a : "NULL");
+		uri_set_destroy(&uri_a);
+		uri_set_destroy(&uri_b);
+	}
+	check_plan();
+	footer();
+}
+
+static void
+test_uri_set_copy(void)
+{
+	header();
+	plan(2);
+	struct uri_set src, dst;
+	uri_set_create(&src, NULL);
+	uri_set_copy(&dst, &src);
+	ok(uri_set_is_equal(&src, &dst), "empty");
+	uri_set_destroy(&src);
+	uri_set_destroy(&dst);
+	uri_set_create(&src, "host1,host2");
+	uri_set_copy(&dst, &src);
+	ok(uri_set_is_equal(&src, &dst), "non-empty");
+	uri_set_destroy(&src);
+	uri_set_destroy(&dst);
 	check_plan();
 	footer();
 }
@@ -828,12 +958,15 @@ test_unescape_special_cases(void)
 int
 main(void)
 {
-	plan(11);
+	plan(14);
 	test_copy_sample();
 	test_copy_empty();
 	test_move_sample();
 	test_move_empty();
 	test_addr_is_equal();
+	test_uri_is_equal();
+	test_uri_set_is_equal();
+	test_uri_set_copy();
 	test_string_uri_with_query_params_parse();
 	test_string_uri_set_with_query_params_parse();
 	test_invalid_string_uri_set();


### PR DESCRIPTION
Currently, `box.cfg` doesn't call an option handler if the option value is unchanged (in Lua). This means that

```Lua
box.cfg{listen = box.cfg.listen}
box.cfg{replication = box.cfg.replication}
```

are no-ops. Since paths to SSL certificate files are stored in URI parameters, this means that one can't reload SSL certificate files by resetting the configuration to the same values, which is inconvenient.

We tried to unconditionally call the option handler even if the old and new option values are the same, see #8552, but this broke some integration tests. In particular, it broke vshard tests, as explained in https://github.com/tarantool/tarantool/issues/8551#issuecomment-1505503984, so we refused from this approach.

In this PR, apart from removing the Lua `box.cfg` check, we also patch the `box.cfg.replication` and `box.cfg.listen` option handlers to safely reload URI parameters by recreating IO stream contexts without disrupting existing connections or establishing new ones in case the URIs are the same.

Needed for tarantool/tarantool-ee#432