### PR TITLE
datetime: fix error when timestamp is set with nsec/usec/msec

### DIFF
--- a/changelogs/unreleased/gh-8583-fix-datetime-set-with-nsec.md
+++ b/changelogs/unreleased/gh-8583-fix-datetime-set-with-nsec.md
@@ -1,0 +1,4 @@
+## bugfix/datetime
+
+* Fixed an error in `datetime.set` when `timestamp` is passed along with `nsec`,
+`usec`, or `msec` (gh-8583).

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -1090,11 +1090,17 @@ local function datetime_set(self, obj)
         -- otherwise - use nsec, usec, or msec
         if count_usec == 0 then
             nsec = fraction * 1e9
-        else
+        elseif fraction ~= 0 then
             error('only integer values allowed in timestamp '..
                   'if nsec, usec, or msecs provided', 2)
         end
 
+        if msec ~= nil then
+            nsec = msec * 1e6
+        end
+        if usec ~= nil then
+            nsec = usec * 1e3
+        end
         if tzname ~= nil then
             offset, self.tzindex = parse_tzname(sec_int, tzname)
         end

--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -1773,7 +1773,7 @@ test:test("totable{}", function(test)
 end)
 
 test:test("Time :set{} operations", function(test)
-    test:plan(12)
+    test:plan(15)
 
     local ts = date.new{ year = 2021, month = 8, day = 31,
                   hour = 0, min = 31, sec = 11, tzoffset = '+0300'}
@@ -1801,6 +1801,12 @@ test:test("Time :set{} operations", function(test)
             'usec = 123')
     test:is(tostring(ts:set{ nsec = 123}), '2021-08-30T21:31:11.000000123+0800',
             'nsec = 123')
+    test:is(tostring(ts:set{timestamp = 1630359071, msec = 123}),
+            '2021-08-30T21:31:11.123+0800', 'timestamp + msec')
+    test:is(tostring(ts:set{timestamp = 1630359071, usec = 123}),
+            '2021-08-30T21:31:11.000123+0800', 'timestamp + usec')
+    test:is(tostring(ts:set{timestamp = 1630359071, nsec = 123}),
+            '2021-08-30T21:31:11.000000123+0800', 'timestamp + nsec')
 end)
 
 test:test("Check :set{} and .new{} equal for all attributes", function(test)


### PR DESCRIPTION
This patch fixes a case when timestamp is passed to datetime.set function at the same time with nsec, usec or msec. It works fine for datetime.new but some logic was missed for set function. Here we fix that and introduce a test.

Closes #8583