### PR TITLE
sql: rework parsing of RENAME and DROP statements

### DIFF
--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -2095,34 +2095,26 @@ tnt_error:
  * _fk_constraint space corresponding with the constraint type.
  */
 void
-sql_drop_constraint(struct Parse *parse_context)
+sql_drop_constraint(struct Parse *parse_context, struct Token *table_name,
+		    struct Token *name)
 {
-	struct drop_entity_def *drop_def =
-		&parse_context->drop_constraint_def.base;
-	assert(drop_def->base.entity_type == ENTITY_TYPE_CONSTRAINT);
-	assert(drop_def->base.alter_action == ALTER_ACTION_DROP);
-	const char *table_name = drop_def->base.entity_name->a[0].zName;
-	assert(table_name != NULL);
-	struct space *space = space_by_name(table_name);
+	char *table_name_str = sql_name_from_token(table_name);
+	struct space *space = space_by_name(table_name_str);
 	if (space == NULL) {
-		diag_set(ClientError, ER_NO_SUCH_SPACE, table_name);
+		sql_xfree(table_name_str);
+		diag_set(ClientError, ER_NO_SUCH_SPACE, table_name_str);
 		parse_context->is_aborted = true;
 		return;
 	}
-	char *name = sql_normalized_name_region_new(&parse_context->region,
-						    drop_def->name.z,
-						    drop_def->name.n);
-	if (name == NULL) {
-		parse_context->is_aborted = true;
-		return;
-	}
+	sql_xfree(table_name_str);
+	char *name_str = sql_name_from_token(name);
 	struct Vdbe *v = sqlGetVdbe(parse_context);
 	assert(v != NULL);
-	struct constraint_id *id = space_find_constraint_id(space, name);
+	struct constraint_id *id = space_find_constraint_id(space, name_str);
 	if (id == NULL) {
 		sqlVdbeCountChanges(v);
 		sqlVdbeAddOp4(v, OP_DropTupleConstraint, space->def->id, 0, 0,
-			      sql_xstrdup(name), P4_DYNAMIC);
+			      name_str, P4_DYNAMIC);
 		return;
 	}
 	/*
@@ -2133,8 +2125,9 @@ sql_drop_constraint(struct Parse *parse_context)
 	 */
 	assert(id->type == CONSTRAINT_TYPE_PK ||
 	       id->type == CONSTRAINT_TYPE_UNIQUE);
-	vdbe_emit_index_drop(parse_context, name, space->def,
+	vdbe_emit_index_drop(parse_context, name_str, space->def,
 			     ER_NO_SUCH_CONSTRAINT, false);
+	sql_xfree(name_str);
 	sqlVdbeCountChanges(v);
 	sqlVdbeChangeP5(v, OPFLAG_NCHANGE);
 }

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -1648,11 +1648,8 @@ raisetype(A) ::= FAIL.      {A = ON_CONFLICT_ACTION_FAIL;}
 
 
 ////////////////////////  DROP TRIGGER statement //////////////////////////////
-cmd ::= DROP TRIGGER ifexists(NOERR) fullname(X). {
-  struct Token t = Token_nil;
-  drop_trigger_def_init(&pParse->drop_trigger_def, X, &t, NOERR);
-  pParse->initiateTTrans = true;
-  sql_drop_trigger(pParse);
+cmd ::= DROP TRIGGER ifexists(NOERR) nm(X). {
+  sql_ast_init_trigger_drop(pParse, &X, NOERR);
 }
 
 //////////////////////// ALTER TABLE table ... ////////////////////////////////

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -377,11 +377,8 @@ resolvetype(A) ::= REPLACE.                  {A = ON_CONFLICT_ACTION_REPLACE;}
 ////////////////////////// The DROP TABLE /////////////////////////////////////
 //
 
-cmd ::= DROP TABLE ifexists(E) fullname(X) . {
-  struct Token t = Token_nil;
-  drop_table_def_init(&pParse->drop_table_def, X, &t, E);
-  pParse->initiateTTrans = true;
-  sql_drop_table(pParse);
+cmd ::= DROP TABLE ifexists(E) nm(X) . {
+  sql_ast_init_table_drop(pParse, &X, E);
 }
 
 cmd ::= DROP VIEW ifexists(E) nm(X) . {

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -1468,10 +1468,8 @@ eidlist(A) ::= nm(Y). {
 
 ///////////////////////////// The DROP INDEX command /////////////////////////
 //
-cmd ::= DROP INDEX ifexists(E) nm(X) ON fullname(Y).   {
-  drop_index_def_init(&pParse->drop_index_def, Y, &X, E);
-  pParse->initiateTTrans = true;
-  sql_drop_index(pParse);
+cmd ::= DROP INDEX ifexists(E) nm(X) ON nm(Y).   {
+  sql_ast_init_index_drop(pParse, &Y, &X, E);
 }
 
 ///////////////////////////// The SET SESSION command ////////////////////////

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -1716,10 +1716,8 @@ cmd ::= alter_add_constraint(N) unique_spec(U) LP sortlist(X) RP. {
 unique_spec(U) ::= UNIQUE.      { U = SQL_INDEX_TYPE_CONSTRAINT_UNIQUE; }
 unique_spec(U) ::= PRIMARY KEY. { U = SQL_INDEX_TYPE_CONSTRAINT_PK; }
 
-cmd ::= alter_table_start(A) RENAME TO nm(N). {
-    rename_entity_def_init(&pParse->rename_entity_def, A, &N);
-    pParse->initiateTTrans = true;
-    sql_alter_table_rename(pParse);
+cmd ::= ALTER TABLE nm(A) RENAME TO nm(N). {
+  sql_ast_init_table_rename(pParse, &A, &N);
 }
 
 cmd ::= ALTER TABLE fullname(X) DROP CONSTRAINT nm(Z). {

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -384,11 +384,8 @@ cmd ::= DROP TABLE ifexists(E) fullname(X) . {
   sql_drop_table(pParse);
 }
 
-cmd ::= DROP VIEW ifexists(E) fullname(X) . {
-  struct Token t = Token_nil;
-  drop_view_def_init(&pParse->drop_view_def, X, &t, E);
-  pParse->initiateTTrans = true;
-  sql_drop_table(pParse);
+cmd ::= DROP VIEW ifexists(E) nm(X) . {
+  sql_ast_init_view_drop(pParse, &X, E);
 }
 
 %type ifexists {int}

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -1720,10 +1720,8 @@ cmd ::= ALTER TABLE nm(A) RENAME TO nm(N). {
   sql_ast_init_table_rename(pParse, &A, &N);
 }
 
-cmd ::= ALTER TABLE fullname(X) DROP CONSTRAINT nm(Z). {
-  drop_constraint_def_init(&pParse->drop_constraint_def, X, &Z, false);
-  pParse->initiateTTrans = true;
-  sql_drop_constraint(pParse);
+cmd ::= ALTER TABLE nm(X) DROP CONSTRAINT nm(Z). {
+  sql_ast_init_constraint_drop(pParse, &X, &Z);
 }
 
 //////////////////////// COMMON TABLE EXPRESSIONS ////////////////////////////

--- a/src/box/sql/parse_def.c
+++ b/src/box/sql/parse_def.c
@@ -101,3 +101,14 @@ sql_ast_init_table_rename(struct Parse *parse, const struct Token *old_name,
 	parse->ast.rename.old_name = *old_name;
 	parse->ast.rename.new_name = *new_name;
 }
+
+void
+sql_ast_init_constraint_drop(struct Parse *parse,
+			     const struct Token *table_name,
+			     const struct Token *name)
+{
+	assert(parse->ast.type == SQL_AST_TYPE_UNKNOWN);
+	parse->ast.type = SQL_AST_TYPE_DROP_CONSTRAINT;
+	parse->ast.drop_constraint.table_name = *table_name;
+	parse->ast.drop_constraint.name = *name;
+}

--- a/src/box/sql/parse_def.c
+++ b/src/box/sql/parse_def.c
@@ -112,3 +112,14 @@ sql_ast_init_constraint_drop(struct Parse *parse,
 	parse->ast.drop_constraint.table_name = *table_name;
 	parse->ast.drop_constraint.name = *name;
 }
+
+void
+sql_ast_init_index_drop(struct Parse *parse, const struct Token *table_name,
+			const struct Token *index_name, bool if_exists)
+{
+	assert(parse->ast.type == SQL_AST_TYPE_UNKNOWN);
+	parse->ast.type = SQL_AST_TYPE_DROP_INDEX;
+	parse->ast.drop_index.table_name = *table_name;
+	parse->ast.drop_index.index_name = *index_name;
+	parse->ast.drop_index.if_exists = if_exists;
+}

--- a/src/box/sql/parse_def.c
+++ b/src/box/sql/parse_def.c
@@ -123,3 +123,13 @@ sql_ast_init_index_drop(struct Parse *parse, const struct Token *table_name,
 	parse->ast.drop_index.index_name = *index_name;
 	parse->ast.drop_index.if_exists = if_exists;
 }
+
+void
+sql_ast_init_trigger_drop(struct Parse *parse, const struct Token *name,
+			  bool if_exists)
+{
+	assert(parse->ast.type == SQL_AST_TYPE_UNKNOWN);
+	parse->ast.type = SQL_AST_TYPE_DROP_TRIGGER;
+	parse->ast.drop_trigger.name = *name;
+	parse->ast.drop_trigger.if_exists = if_exists;
+}

--- a/src/box/sql/parse_def.c
+++ b/src/box/sql/parse_def.c
@@ -91,3 +91,13 @@ sql_ast_init_rollback_to_savepoint(struct Parse *parse,
 	parse->ast.type = SQL_AST_TYPE_ROLLBACK_TO_SAVEPOINT;
 	parse->ast.savepoint.name = *name;
 }
+
+void
+sql_ast_init_table_rename(struct Parse *parse, const struct Token *old_name,
+			  const struct Token *new_name)
+{
+	assert(parse->ast.type == SQL_AST_TYPE_UNKNOWN);
+	parse->ast.type = SQL_AST_TYPE_TABLE_RENAME;
+	parse->ast.rename.old_name = *old_name;
+	parse->ast.rename.new_name = *new_name;
+}

--- a/src/box/sql/parse_def.c
+++ b/src/box/sql/parse_def.c
@@ -143,3 +143,13 @@ sql_ast_init_view_drop(struct Parse *parse, const struct Token *name,
 	parse->ast.drop_view.name = *name;
 	parse->ast.drop_view.if_exists = if_exists;
 }
+
+void
+sql_ast_init_table_drop(struct Parse *parse, const struct Token *name,
+			bool if_exists)
+{
+	assert(parse->ast.type == SQL_AST_TYPE_UNKNOWN);
+	parse->ast.type = SQL_AST_TYPE_DROP_TABLE;
+	parse->ast.drop_table.name = *name;
+	parse->ast.drop_table.if_exists = if_exists;
+}

--- a/src/box/sql/parse_def.c
+++ b/src/box/sql/parse_def.c
@@ -133,3 +133,13 @@ sql_ast_init_trigger_drop(struct Parse *parse, const struct Token *name,
 	parse->ast.drop_trigger.name = *name;
 	parse->ast.drop_trigger.if_exists = if_exists;
 }
+
+void
+sql_ast_init_view_drop(struct Parse *parse, const struct Token *name,
+		       bool if_exists)
+{
+	assert(parse->ast.type == SQL_AST_TYPE_UNKNOWN);
+	parse->ast.type = SQL_AST_TYPE_DROP_VIEW;
+	parse->ast.drop_view.name = *name;
+	parse->ast.drop_view.if_exists = if_exists;
+}

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -94,6 +94,8 @@ enum sql_ast_type {
 	SQL_AST_TYPE_TABLE_RENAME,
 	/** ALTER TABLE DROP CONSTRAINT statement. */
 	SQL_AST_TYPE_DROP_CONSTRAINT,
+	/** DROP INDEX statement. */
+	SQL_AST_TYPE_DROP_INDEX,
 };
 
 /**
@@ -130,6 +132,16 @@ struct sql_ast_drop_constraint {
 	struct Token name;
 };
 
+/** Description of DROP INDEX statement. */
+struct sql_ast_drop_index {
+	/** The name of the table which index will be dropped. */
+	struct Token table_name;
+	/** Name of the index to drop. */
+	struct Token index_name;
+	/** IF EXISTS flag. */
+	bool if_exists;
+};
+
 /** A structure describing the AST of the parsed SQL statement. */
 struct sql_ast {
 	/** Parsed statement type. */
@@ -141,6 +153,8 @@ struct sql_ast {
 		struct sql_ast_table_rename rename;
 		/** Description of ALTER TABLE DROP CONSTRAINT statement. */
 		struct sql_ast_drop_constraint drop_constraint;
+		/** Description of DROP INDEX statement. */
+		struct sql_ast_drop_index drop_index;
 	};
 };
 
@@ -322,10 +336,6 @@ struct drop_trigger_def {
 	struct drop_entity_def base;
 };
 
-struct drop_index_def {
-	struct drop_entity_def base;
-};
-
 struct create_trigger_def {
 	struct create_entity_def base;
 	/** One of TK_BEFORE, TK_AFTER, TK_INSTEAD. */
@@ -442,15 +452,6 @@ drop_trigger_def_init(struct drop_trigger_def *drop_trigger_def,
 {
 	drop_entity_def_init(&drop_trigger_def->base, parent_name, name,
 			     if_exist, ENTITY_TYPE_TRIGGER);
-}
-
-static inline void
-drop_index_def_init(struct drop_index_def *drop_index_def,
-		    struct SrcList *parent_name, struct Token *name,
-		    bool if_exist)
-{
-	drop_entity_def_init(&drop_index_def->base, parent_name, name, if_exist,
-			     ENTITY_TYPE_INDEX);
 }
 
 static inline void
@@ -589,5 +590,10 @@ void
 sql_ast_init_constraint_drop(struct Parse *parse,
 			     const struct Token *table_name,
 			     const struct Token *name);
+
+/** Save parsed DROP INDEX statement. */
+void
+sql_ast_init_index_drop(struct Parse *parse, const struct Token *table_name,
+			const struct Token *index_name, bool if_exists);
 
 #endif /* TARANTOOL_BOX_SQL_PARSE_DEF_H_INCLUDED */

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -98,6 +98,8 @@ enum sql_ast_type {
 	SQL_AST_TYPE_DROP_INDEX,
 	/** DROP TRIGGER statement. */
 	SQL_AST_TYPE_DROP_TRIGGER,
+	/** DROP VIEW statement. */
+	SQL_AST_TYPE_DROP_VIEW,
 };
 
 /**
@@ -152,6 +154,14 @@ struct sql_ast_drop_trigger {
 	bool if_exists;
 };
 
+/** Description of DROP VIEW statement. */
+struct sql_ast_drop_view {
+	/** Name of the VIEW to drop. */
+	struct Token name;
+	/** IF EXISTS flag. */
+	bool if_exists;
+};
+
 /** A structure describing the AST of the parsed SQL statement. */
 struct sql_ast {
 	/** Parsed statement type. */
@@ -167,6 +177,8 @@ struct sql_ast {
 		struct sql_ast_drop_index drop_index;
 		/** Description of DROP TRIGGER statement. */
 		struct sql_ast_drop_trigger drop_trigger;
+		/** Description of DROP VIEW statement. */
+		struct sql_ast_drop_view drop_view;
 	};
 };
 
@@ -340,10 +352,6 @@ struct drop_table_def {
 	struct drop_entity_def base;
 };
 
-struct drop_view_def {
-	struct drop_entity_def base;
-};
-
 struct create_trigger_def {
 	struct create_entity_def base;
 	/** One of TK_BEFORE, TK_AFTER, TK_INSTEAD. */
@@ -442,15 +450,6 @@ drop_table_def_init(struct drop_table_def *drop_table_def,
 {
 	drop_entity_def_init(&drop_table_def->base, parent_name, name, if_exist,
 			     ENTITY_TYPE_TABLE);
-}
-
-static inline void
-drop_view_def_init(struct drop_view_def *drop_view_def,
-		   struct SrcList *parent_name, struct Token *name,
-		   bool if_exist)
-{
-	drop_entity_def_init(&drop_view_def->base, parent_name, name, if_exist,
-			     ENTITY_TYPE_VIEW);
 }
 
 static inline void
@@ -599,5 +598,10 @@ sql_ast_init_index_drop(struct Parse *parse, const struct Token *table_name,
 void
 sql_ast_init_trigger_drop(struct Parse *parse, const struct Token *name,
 			  bool if_exists);
+
+/** Save parsed DROP VIEW statement. */
+void
+sql_ast_init_view_drop(struct Parse *parse, const struct Token *name,
+		       bool if_exists);
 
 #endif /* TARANTOOL_BOX_SQL_PARSE_DEF_H_INCLUDED */

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -96,6 +96,8 @@ enum sql_ast_type {
 	SQL_AST_TYPE_DROP_CONSTRAINT,
 	/** DROP INDEX statement. */
 	SQL_AST_TYPE_DROP_INDEX,
+	/** DROP TRIGGER statement. */
+	SQL_AST_TYPE_DROP_TRIGGER,
 };
 
 /**
@@ -142,6 +144,14 @@ struct sql_ast_drop_index {
 	bool if_exists;
 };
 
+/** Description of DROP TRIGGER statement. */
+struct sql_ast_drop_trigger {
+	/** Name of the trigger to drop. */
+	struct Token name;
+	/** IF EXISTS flag. */
+	bool if_exists;
+};
+
 /** A structure describing the AST of the parsed SQL statement. */
 struct sql_ast {
 	/** Parsed statement type. */
@@ -155,6 +165,8 @@ struct sql_ast {
 		struct sql_ast_drop_constraint drop_constraint;
 		/** Description of DROP INDEX statement. */
 		struct sql_ast_drop_index drop_index;
+		/** Description of DROP TRIGGER statement. */
+		struct sql_ast_drop_trigger drop_trigger;
 	};
 };
 
@@ -332,10 +344,6 @@ struct drop_view_def {
 	struct drop_entity_def base;
 };
 
-struct drop_trigger_def {
-	struct drop_entity_def base;
-};
-
 struct create_trigger_def {
 	struct create_entity_def base;
 	/** One of TK_BEFORE, TK_AFTER, TK_INSTEAD. */
@@ -443,15 +451,6 @@ drop_view_def_init(struct drop_view_def *drop_view_def,
 {
 	drop_entity_def_init(&drop_view_def->base, parent_name, name, if_exist,
 			     ENTITY_TYPE_VIEW);
-}
-
-static inline void
-drop_trigger_def_init(struct drop_trigger_def *drop_trigger_def,
-		      struct SrcList *parent_name, struct Token *name,
-		      bool if_exist)
-{
-	drop_entity_def_init(&drop_trigger_def->base, parent_name, name,
-			     if_exist, ENTITY_TYPE_TRIGGER);
 }
 
 static inline void
@@ -595,5 +594,10 @@ sql_ast_init_constraint_drop(struct Parse *parse,
 void
 sql_ast_init_index_drop(struct Parse *parse, const struct Token *table_name,
 			const struct Token *index_name, bool if_exists);
+
+/** Save parsed DROP TRIGGER statement. */
+void
+sql_ast_init_trigger_drop(struct Parse *parse, const struct Token *name,
+			  bool if_exists);
 
 #endif /* TARANTOOL_BOX_SQL_PARSE_DEF_H_INCLUDED */

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -92,6 +92,8 @@ enum sql_ast_type {
 	SQL_AST_TYPE_ROLLBACK_TO_SAVEPOINT,
 	/** ALTER TABLE RENAME statement. */
 	SQL_AST_TYPE_TABLE_RENAME,
+	/** ALTER TABLE DROP CONSTRAINT statement. */
+	SQL_AST_TYPE_DROP_CONSTRAINT,
 };
 
 /**
@@ -120,6 +122,14 @@ struct sql_ast_table_rename {
 	struct Token new_name;
 };
 
+/** Description of ALTER TABLE DROP CONSTRAINT statement. */
+struct sql_ast_drop_constraint {
+	/** The name of the table which constraint will be dropped. */
+	struct Token table_name;
+	/** Name of the constraint to drop. */
+	struct Token name;
+};
+
 /** A structure describing the AST of the parsed SQL statement. */
 struct sql_ast {
 	/** Parsed statement type. */
@@ -129,6 +139,8 @@ struct sql_ast {
 		struct sql_ast_savepoint savepoint;
 		/** Description of ALTER TABLE RENAME statement. */
 		struct sql_ast_table_rename rename;
+		/** Description of ALTER TABLE DROP CONSTRAINT statement. */
+		struct sql_ast_drop_constraint drop_constraint;
 	};
 };
 
@@ -310,10 +322,6 @@ struct drop_trigger_def {
 	struct drop_entity_def base;
 };
 
-struct drop_constraint_def {
-	struct drop_entity_def base;
-};
-
 struct drop_index_def {
 	struct drop_entity_def base;
 };
@@ -434,15 +442,6 @@ drop_trigger_def_init(struct drop_trigger_def *drop_trigger_def,
 {
 	drop_entity_def_init(&drop_trigger_def->base, parent_name, name,
 			     if_exist, ENTITY_TYPE_TRIGGER);
-}
-
-static inline void
-drop_constraint_def_init(struct drop_constraint_def *drop_constraint_def,
-			 struct SrcList *parent_name, struct Token *name,
-			 bool if_exist)
-{
-	drop_entity_def_init(&drop_constraint_def->base, parent_name, name,
-			     if_exist, ENTITY_TYPE_CONSTRAINT);
 }
 
 static inline void
@@ -584,5 +583,11 @@ sql_ast_init_rollback_to_savepoint(struct Parse *parse,
 void
 sql_ast_init_table_rename(struct Parse *parse, const struct Token *old_name,
 			  const struct Token *new_name);
+
+/** Save parsed ALTER TABLE DROP CONSTRAINT statement. */
+void
+sql_ast_init_constraint_drop(struct Parse *parse,
+			     const struct Token *table_name,
+			     const struct Token *name);
 
 #endif /* TARANTOOL_BOX_SQL_PARSE_DEF_H_INCLUDED */

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2046,7 +2046,6 @@ struct Parse {
 		struct create_trigger_def create_trigger_def;
 		struct create_view_def create_view_def;
 		struct drop_table_def drop_table_def;
-		struct drop_trigger_def drop_trigger_def;
 		struct drop_view_def drop_view_def;
 		struct enable_entity_def enable_entity_def;
 	};
@@ -3362,11 +3361,9 @@ sql_trigger_finish(struct Parse *parse, struct TriggerStep *step_list,
 /**
  * This function is called from parser to generate drop trigger
  * VDBE code.
- *
- * @param parser Parser context.
  */
 void
-sql_drop_trigger(struct Parse *parser);
+sql_drop_trigger(struct Parse *parser, struct Token *name, bool is_exists);
 
 /**
  * Drop a trigger given a pointer to that trigger.

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2045,7 +2045,6 @@ struct Parse {
 		struct create_index_def create_index_def;
 		struct create_trigger_def create_trigger_def;
 		struct create_view_def create_view_def;
-		struct drop_index_def drop_index_def;
 		struct drop_table_def drop_table_def;
 		struct drop_trigger_def drop_trigger_def;
 		struct drop_view_def drop_view_def;
@@ -2950,11 +2949,10 @@ sql_create_index(struct Parse *parse);
 /**
  * This routine will drop an existing named index.  This routine
  * implements the DROP INDEX statement.
- *
- * @param parse_context Current parsing context.
  */
 void
-sql_drop_index(struct Parse *parse_context);
+sql_drop_index(struct Parse *parse_context, struct Token *table_name,
+	       struct Token *index_name, bool if_exists);
 
 int sqlSelect(Parse *, Select *, SelectDest *);
 Select *sqlSelectNew(Parse *, ExprList *, SrcList *, Expr *, ExprList *,

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2045,7 +2045,6 @@ struct Parse {
 		struct create_index_def create_index_def;
 		struct create_trigger_def create_trigger_def;
 		struct create_view_def create_view_def;
-		struct drop_table_def drop_table_def;
 		struct enable_entity_def enable_entity_def;
 	};
 	/**
@@ -2810,8 +2809,10 @@ sql_store_select(struct Parse *parse_context, struct Select *select);
 void
 sql_drop_view(struct Parse *parse, struct Token *name, bool is_exists);
 
+/** Code DROP TABLE statement. */
 void
-sql_drop_table(struct Parse *);
+sql_drop_table(struct Parse *parse, struct Token *name, bool is_exists);
+
 void sqlInsert(Parse *, SrcList *, Select *, IdList *,
 	       enum on_conflict_action);
 

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2045,7 +2045,6 @@ struct Parse {
 		struct create_index_def create_index_def;
 		struct create_trigger_def create_trigger_def;
 		struct create_view_def create_view_def;
-		struct rename_entity_def rename_entity_def;
 		struct drop_constraint_def drop_constraint_def;
 		struct drop_index_def drop_index_def;
 		struct drop_table_def drop_table_def;
@@ -3910,14 +3909,10 @@ extern const Token sqlIntTokens[];
 extern SQL_WSD struct sqlConfig sqlConfig;
 extern int sqlPendingByte;
 
-/**
- * Generate code to implement the "ALTER TABLE xxx RENAME TO yyy"
- * command.
- *
- * @param parse Current parsing context.
- */
+/** Generate code to implement the "ALTER TABLE xxx RENAME TO yyy" command. */
 void
-sql_alter_table_rename(struct Parse *parse);
+sql_alter_table_rename(struct Parse *parse, struct Token *old_name,
+		       struct Token *new_name);
 
 /**
  * Return the length (in bytes) of the token that begins at z[0].

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2045,7 +2045,6 @@ struct Parse {
 		struct create_index_def create_index_def;
 		struct create_trigger_def create_trigger_def;
 		struct create_view_def create_view_def;
-		struct drop_constraint_def drop_constraint_def;
 		struct drop_index_def drop_index_def;
 		struct drop_table_def drop_table_def;
 		struct drop_trigger_def drop_trigger_def;
@@ -3601,16 +3600,15 @@ void
 sql_create_foreign_key(struct Parse *parse_context);
 
 /**
- * Emit code to drop the entry from _index or _ck_contstraint or
- * _fk_constraint space corresponding with the constraint type.
+ * Emit code to drop the entry from _index or drop FOREIGN KEY or CHECK
+ * constraint.
  *
  * Function called from parser to handle
  * <ALTER TABLE table DROP CONSTRAINT constraint> SQL statement.
- *
- * @param parse_context Parsing context.
  */
 void
-sql_drop_constraint(struct Parse *parse_context);
+sql_drop_constraint(struct Parse *parse_context, struct Token *table_name,
+		    struct Token *name);
 
 /**
  * Now our SQL implementation can't operate on spaces which

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2046,7 +2046,6 @@ struct Parse {
 		struct create_trigger_def create_trigger_def;
 		struct create_view_def create_view_def;
 		struct drop_table_def drop_table_def;
-		struct drop_view_def drop_view_def;
 		struct enable_entity_def enable_entity_def;
 	};
 	/**
@@ -2806,6 +2805,10 @@ sql_view_assign_cursors(struct Parse *parse, const char *view_stmt);
  */
 void
 sql_store_select(struct Parse *parse_context, struct Select *select);
+
+/** Code DROP VIEW statement. */
+void
+sql_drop_view(struct Parse *parse, struct Token *name, bool is_exists);
 
 void
 sql_drop_table(struct Parse *);

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -507,6 +507,14 @@ sql_code_ast(struct Parse *parse, struct sql_ast *ast)
 			return;
 		break;
 	}
+	case SQL_AST_TYPE_DROP_CONSTRAINT: {
+		parse->initiateTTrans = true;
+		struct sql_ast_drop_constraint *stmt = &ast->drop_constraint;
+		sql_drop_constraint(parse, &stmt->table_name, &stmt->name);
+		if (parse->is_aborted)
+			return;
+		break;
+	}
 	default:
 		assert(parse->ast.type == SQL_AST_TYPE_UNKNOWN);
 	}

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -515,6 +515,15 @@ sql_code_ast(struct Parse *parse, struct sql_ast *ast)
 			return;
 		break;
 	}
+	case SQL_AST_TYPE_DROP_INDEX: {
+		parse->initiateTTrans = true;
+		struct sql_ast_drop_index *stmt = &ast->drop_index;
+		sql_drop_index(parse, &stmt->table_name, &stmt->index_name,
+			       stmt->if_exists);
+		if (parse->is_aborted)
+			return;
+		break;
+	}
 	default:
 		assert(parse->ast.type == SQL_AST_TYPE_UNKNOWN);
 	}

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -499,6 +499,14 @@ sql_code_ast(struct Parse *parse, struct sql_ast *ast)
 	case SQL_AST_TYPE_ROLLBACK_TO_SAVEPOINT:
 		sqlSavepoint(parse, SAVEPOINT_ROLLBACK, &ast->savepoint.name);
 		break;
+	case SQL_AST_TYPE_TABLE_RENAME: {
+		parse->initiateTTrans = true;
+		struct sql_ast_table_rename *stmt = &ast->rename;
+		sql_alter_table_rename(parse, &stmt->old_name, &stmt->new_name);
+		if (parse->is_aborted)
+			return;
+		break;
+	}
 	default:
 		assert(parse->ast.type == SQL_AST_TYPE_UNKNOWN);
 	}

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -540,6 +540,14 @@ sql_code_ast(struct Parse *parse, struct sql_ast *ast)
 			return;
 		break;
 	}
+	case SQL_AST_TYPE_DROP_TABLE: {
+		parse->initiateTTrans = true;
+		struct sql_ast_drop_table *stmt = &ast->drop_table;
+		sql_drop_table(parse, &stmt->name, stmt->if_exists);
+		if (parse->is_aborted)
+			return;
+		break;
+	}
 	default:
 		assert(parse->ast.type == SQL_AST_TYPE_UNKNOWN);
 	}

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -532,6 +532,14 @@ sql_code_ast(struct Parse *parse, struct sql_ast *ast)
 			return;
 		break;
 	}
+	case SQL_AST_TYPE_DROP_VIEW: {
+		parse->initiateTTrans = true;
+		struct sql_ast_drop_view *stmt = &ast->drop_view;
+		sql_drop_view(parse, &stmt->name, stmt->if_exists);
+		if (parse->is_aborted)
+			return;
+		break;
+	}
 	default:
 		assert(parse->ast.type == SQL_AST_TYPE_UNKNOWN);
 	}

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -524,6 +524,14 @@ sql_code_ast(struct Parse *parse, struct sql_ast *ast)
 			return;
 		break;
 	}
+	case SQL_AST_TYPE_DROP_TRIGGER: {
+		parse->initiateTTrans = true;
+		struct sql_ast_drop_trigger *stmt = &ast->drop_trigger;
+		sql_drop_trigger(parse, &stmt->name, stmt->if_exists);
+		if (parse->is_aborted)
+			return;
+		break;
+	}
 	default:
 		assert(parse->ast.type == SQL_AST_TYPE_UNKNOWN);
 	}

--- a/test/sql-luatest/parser_separation_test.lua
+++ b/test/sql-luatest/parser_separation_test.lua
@@ -44,3 +44,14 @@ g.test_drop_index_parsing = function()
         t.assert_equals(err.message, "Syntax error at line 1 near '1'")
     end)
 end
+
+--
+-- Make sure that the DROP VIEW statement is processed only after successful
+-- parsing.
+--
+g.test_drop_view_parsing = function()
+    g.server:exec(function()
+        local _, err = box.execute([[DROP VIEW v 1;]])
+        t.assert_equals(err.message, "Syntax error at line 1 near '1'")
+    end)
+end

--- a/test/sql-luatest/parser_separation_test.lua
+++ b/test/sql-luatest/parser_separation_test.lua
@@ -55,3 +55,14 @@ g.test_drop_view_parsing = function()
         t.assert_equals(err.message, "Syntax error at line 1 near '1'")
     end)
 end
+
+--
+-- Make sure that the DROP TABLE statement is processed only after successful
+-- parsing.
+--
+g.test_drop_table_parsing = function()
+    g.server:exec(function()
+        local _, err = box.execute([[DROP TABLE t 1;]])
+        t.assert_equals(err.message, "Syntax error at line 1 near '1'")
+    end)
+end

--- a/test/sql-luatest/parser_separation_test.lua
+++ b/test/sql-luatest/parser_separation_test.lua
@@ -22,3 +22,14 @@ g.test_table_rename_parsing = function()
         t.assert_equals(err.message, "Syntax error at line 1 near '1'")
     end)
 end
+
+--
+-- Make sure that the ALTER TABLE DROP CONSTRAINT statement is processed only
+-- after successful parsing.
+--
+g.test_drop_constraint_parsing = function()
+    g.server:exec(function()
+        local _, err = box.execute([[ALTER TABLE t DROP CONSTRAINT t1 1;]])
+        t.assert_equals(err.message, "Syntax error at line 1 near '1'")
+    end)
+end

--- a/test/sql-luatest/parser_separation_test.lua
+++ b/test/sql-luatest/parser_separation_test.lua
@@ -1,0 +1,24 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+--
+-- Make sure that the ALTER TABLE RENAME statement is processed only after
+-- successful parsing.
+--
+g.test_table_rename_parsing = function()
+    g.server:exec(function()
+        local _, err = box.execute([[ALTER TABLE t RENAME TO t1 1;]])
+        t.assert_equals(err.message, "Syntax error at line 1 near '1'")
+    end)
+end

--- a/test/sql-luatest/parser_separation_test.lua
+++ b/test/sql-luatest/parser_separation_test.lua
@@ -33,3 +33,14 @@ g.test_drop_constraint_parsing = function()
         t.assert_equals(err.message, "Syntax error at line 1 near '1'")
     end)
 end
+
+--
+-- Make sure that the DROP INDEX statement is processed only after successful
+-- parsing.
+--
+g.test_drop_index_parsing = function()
+    g.server:exec(function()
+        local _, err = box.execute([[DROP INDEX i1 on t1 1;]])
+        t.assert_equals(err.message, "Syntax error at line 1 near '1'")
+    end)
+end

--- a/test/sql-tap/view.test.lua
+++ b/test/sql-tap/view.test.lua
@@ -925,7 +925,7 @@ test:do_catchsql_test(
         DROP VIEW main.nosuchview
     ]], {
         -- <view-17.2>
-        1, "Space 'MAIN' does not exist"
+        1, "Syntax error at line 1 near '.'"
         -- </view-17.2>
     })
 


### PR DESCRIPTION
This patch-set reworks RENAME and DROP statements. There are six of them:
```
ALTER TABLE table_name RENAME TO table_new_name;
ALTER TABLE table_name DROP CONSTRAINT constraint_name;
DROP INDEX index_name ON table_name;
DROP TRIGGER trigger_name;
DROP VIEW view_name;
DROP TABLE table_name;
```

Prior to this patch, VDBE for these statements were generated while the statement was in the process of being parsed. After this patch, VDBE for all these statements will be generated only after the parsing has successfully completed.

Part of https://github.com/tarantool/tarantool/issues/5485