### PR TITLE
datetime: fix cases when datetime nanoseconds could be represented incorrectly

### DIFF
--- a/changelogs/unreleased/gh-8570-fix-datetime-str-negative-nsec.md
+++ b/changelogs/unreleased/gh-8570-fix-datetime-str-negative-nsec.md
@@ -1,0 +1,4 @@
+## bugfix/datetime
+
+* Fixed errors when the string representation of a datetime object had
+a negative nanosecond part (gh-8570).

--- a/src/lib/core/datetime.c
+++ b/src/lib/core/datetime.c
@@ -647,6 +647,10 @@ normalize_nsec(int64_t *psecs, int *pnsec)
 	if (nsec < 0 || nsec >= NANOS_PER_SEC) {
 		secs += nsec / NANOS_PER_SEC;
 		nsec %= NANOS_PER_SEC;
+		if (nsec < 0) {
+			secs -= 1;
+			nsec += NANOS_PER_SEC;
+		}
 	}
 	*psecs = secs;
 	*pnsec = nsec;

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -588,6 +588,13 @@ local function datetime_new(obj)
         end
         local fraction
         s, fraction = math_modf(ts)
+        -- In case of negative fraction part we should
+        -- make it positive at the expense of the integer part.
+        -- Code below expects that "nsec" value is always positive.
+        if fraction < 0 then
+            s = s - 1
+            fraction = fraction + 1
+        end
         -- if there are separate nsec, usec, or msec provided then
         -- timestamp should be integer
         if count_usec == 0 then
@@ -1085,6 +1092,13 @@ local function datetime_set(self, obj)
         end
         local sec_int, fraction
         sec_int, fraction = math_modf(ts)
+        -- In case of negative fraction part we should
+        -- make it positive at the expense of the integer part.
+        -- Code below expects that "nsec" value is always positive.
+        if fraction < 0 then
+            sec_int = sec_int - 1
+            fraction = fraction + 1
+        end
         -- if there is one of nsec, usec, msec provided
         -- then ignore fraction in timestamp
         -- otherwise - use nsec, usec, or msec

--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -192,7 +192,7 @@ test:test("Default date creation and comparison", function(test)
 end)
 
 test:test("Simple date creation by attributes", function(test)
-    test:plan(14)
+    test:plan(15)
     local ts
     local obj = {}
     local attribs = {
@@ -222,6 +222,8 @@ test:test("Simple date creation by attributes", function(test)
             '2021-08-30T21:31:11.000123Z', '{timestamp.usec}')
     test:is(tostring(date.new{timestamp = 1630359071, nsec = 123}),
             '2021-08-30T21:31:11.000000123Z', '{timestamp.nsec}')
+    test:is(tostring(date.new{timestamp = -0.1}),
+            '1969-12-31T23:59:59.900Z', '{negative timestamp}')
 end)
 
 test:test("Simple date creation by attributes - check failed", function(test)
@@ -1779,7 +1781,7 @@ test:test("totable{}", function(test)
 end)
 
 test:test("Time :set{} operations", function(test)
-    test:plan(15)
+    test:plan(16)
 
     local ts = date.new{ year = 2021, month = 8, day = 31,
                   hour = 0, min = 31, sec = 11, tzoffset = '+0300'}
@@ -1813,10 +1815,12 @@ test:test("Time :set{} operations", function(test)
             '2021-08-30T21:31:11.000123+0800', 'timestamp + usec')
     test:is(tostring(ts:set{timestamp = 1630359071, nsec = 123}),
             '2021-08-30T21:31:11.000000123+0800', 'timestamp + nsec')
+    test:is(tostring(ts:set{timestamp = -0.1}),
+            '1969-12-31T23:59:59.900+0800', 'negative timestamp')
 end)
 
 test:test("Check :set{} and .new{} equal for all attributes", function(test)
-    test:plan(11)
+    test:plan(12)
     local ts, ts2
     local obj = {}
     local attribs = {
@@ -1844,6 +1848,12 @@ test:test("Check :set{} and .new{} equal for all attributes", function(test)
     ts = date.new(obj)
     ts2 = date.new():set(obj)
     test:is(ts, ts2, ('timestamp+tzoffset (%s = %s)'):
+            format(tostring(ts), tostring(ts2)))
+
+    obj = {timestamp = -0.1, tzoffset = '+0800'}
+    ts = date.new(obj)
+    ts2 = date.new():set(obj)
+    test:is(ts, ts2, ('negative timestamp+tzoffset (%s = %s)'):
             format(tostring(ts), tostring(ts2)))
 end)
 

--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -1551,16 +1551,18 @@ Matrix of subtraction operands eligibility and their result type
 | table           |          |          |          |
 ]]
 test:test("Matrix of allowed time and interval subtractions", function(test)
-    test:plan(29)
+    test:plan(31)
 
     -- check arithmetic with leap dates
     local T1970 = date.new{year = 1970, month = 1, day = 1}
     local T2000 = date.new{year = 2000, month = 1, day = 1}
+    local T1970S1 = date.new{year = 1970, month = 1, day = 1, sec = 1}
     local I1 = date.interval.new{day = 1}
     local M2 = date.interval.new{month = 2}
     local M10 = date.interval.new{month = 10}
     local Y1 = date.interval.new{year = 1}
     local Y5 = date.interval.new{year = 5}
+    local NS1000 = date.interval.new{nsec = 1000}
 
     test:is(catchsub_status(T1970, I1), true, "status: T - I")
     test:is(catchsub_status(T1970, M2), true, "status: T - M")
@@ -1579,6 +1581,10 @@ test:test("Matrix of allowed time and interval subtractions", function(test)
     test:is(tostring(T1970 - I1), "1969-12-31T00:00:00Z", "value: T - I")
     test:is(tostring(T1970 - M2), "1969-11-01T00:00:00Z", "value: T - M")
     test:is(tostring(T1970 - Y1), "1969-01-01T00:00:00Z", "value: T - Y")
+    test:is(tostring(T1970 - NS1000), "1969-12-31T23:59:59.999999Z",
+        "value: T - NS1000")
+    test:is(tostring(T1970S1 - NS1000), "1970-01-01T00:00:00.999999Z",
+        "value: T1970S1 - NS1000")
     test:is(tostring(T1970 - T2000), "-30 years", "value: T - T")
     test:is(tostring(Y5 - Y1), "+4 years", "value: Y - Y")
 


### PR DESCRIPTION
Closes #8570
