### PR TITLE
test: re-enable linearizable test after fix

### DIFF
--- a/test/replication-luatest/linearizable_test.lua
+++ b/test/replication-luatest/linearizable_test.lua
@@ -17,7 +17,6 @@ end
 local num_servers = 3
 
 g.before_all(function(cg)
-    t.skip('Skipped until tarantool/tarantool-qa#277 is resolved')
     cg.cluster = cluster:new({})
     cg.servers = {}
     cg.box_cfg = {
@@ -193,6 +192,10 @@ g.test_leader_change = function(cg)
     end)
     cg.servers[2]:wait_for_vclock_of(cg.servers[1])
     cg.servers[3]:wait_for_vclock_of(cg.servers[1])
+    t.helpers.retrying({}, function()
+        cg.servers[2]:assert_follows_upstream(cg.servers[1]:get_instance_id())
+        cg.servers[2]:assert_follows_upstream(cg.servers[3]:get_instance_id())
+    end)
     for i = 1, num_servers do
         cg.proxies[i]:pause()
     end


### PR DESCRIPTION
The test flaked a lot on FreeBSD and Mac OS due to some proxy problems which were fixed in scope of tarantool/luatest@5b704ac.

Another possible failure looked like this:

NO_WRAP
[006] not ok 5  linearizable-read.test_leader_change
[006] #   Can't modify data on a read-only instance - it is an orphan
[006] #   stack traceback:
[006] #         ...tarantool/test/replication-luatest/linearizable_test.lua:196: in function 'linearizable-read.test_leader_change'
[006] #         ...
[006] #         [C]: in function 'xpcall'
NO_WRAP

Fix it by waiting for the server to follow its upstreams.

Closes tarantool/tarantool-qa#277

NO_DOC=test fix
NO_CHANGELOG=test fix