### PR TITLE
app: fix possible integer overflow in net_box.c

### DIFF
--- a/changelogs/unreleased/ghs-121-too-big-buffer-size.md
+++ b/changelogs/unreleased/ghs-121-too-big-buffer-size.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fixed an integer overflow issue in `net.box` (ghs-121).

--- a/src/box/lua/net_box.c
+++ b/src/box/lua/net_box.c
@@ -1161,8 +1161,14 @@ netbox_transport_send_and_recv(struct netbox_transport *transport,
 		} else {
 			const char *bufpos = transport->recv_buf.rpos;
 			const char *rpos = bufpos;
-			size_t len = mp_decode_uint(&rpos);
-			required = (rpos - bufpos) + len;
+			uint64_t len = mp_decode_uint(&rpos);
+			size_t size = rpos - bufpos;
+			if (len > SIZE_MAX - size) {
+				box_error_raise(ER_NO_CONNECTION,
+						"Response size too large");
+				return -1;
+			}
+			required = size + len;
 			if (data_len >= required) {
 				const char *body_end = rpos + len;
 				transport->recv_buf.rpos = (char *)body_end;

--- a/test/app-luatest/ghs_121_too_large_response_size_test.lua
+++ b/test/app-luatest/ghs_121_too_large_response_size_test.lua
@@ -1,0 +1,16 @@
+local t = require('luatest')
+local g = t.group('ghs-121')
+
+g.test_too_large_response_size = function()
+    local net = require('net.box')
+    local socket = require('socket')
+    local msgpack = require('msgpack')
+    local greeting =
+        'Tarantool 3.0.0 (Binary) b1a9c3e1-2ecd-4939-b114-3965986738ca  \n'..
+        'GuAaXfJM0doawXKUqNCptueVDEQoEY1ZQ3vQkvj6/o4=                   \n'
+    local data = msgpack.encode(18446744073709551614ULL)..msgpack.encode(1)
+    local handler = function(fd) fd:write(greeting) fd:write(data) end
+    local srv = socket.tcp_server('localhost', 0, {handler = handler})
+    local res = net.new('localhost:' .. srv:name().port)
+    t.assert_equals(res.error, "Response size too large")
+end


### PR DESCRIPTION
The netbox_transport_send_and_recv() function takes a part of the data buffer size as a parameter, and it is possible that the resulting buffer size could become larger than SIZE_MAX, resulting in an integer overflow and a segmentation fault.

Closes #tarantool/security#121

NO_DOC=bugfix