### PR TITLE
replication: reload URIs of anon replicas on reconfiguration

### DIFF
--- a/src/box/replication.cc
+++ b/src/box/replication.cc
@@ -1107,6 +1107,9 @@ replicaset_reload_uris(void)
 		if (applier != NULL)
 			applier_reload_uri(applier);
 	}
+	struct replica *replica;
+	rlist_foreach_entry(replica, &replicaset.anon, in_anon)
+		applier_reload_uri(replica->applier);
 }
 
 bool


### PR DESCRIPTION
In case `box.cfg.replication` isn't update by `box.cfg`, we don't try to reestablish replication connections, but we still need to reload URIs (recreate IO stream contexts created from URIs) because a URI parameter may store a path to an SSL certificate file, which could change. This was done in commit 655290aa7a8b3 ("replication: always reload URIs on reconfiguration").

There's a bug in the commit: it works as expected for appliers that already connected in the past and received UUID but it ignores anonymous appliers, i.e. appliers that never connected, as a result the following code fails:

```Lua
-- Configure replication using a wrong SSL certificate.
-- This leaves anonymous appliers reconnecting in the background.
box.cfg{replication = {...}}
-- Update the SSL certificate file and reload replication URIs.
-- At this point, the anonymous applier should finally connect.
box.cfg{replication = box.cfg.replication}
```

Needed for tarantool/tarantool-ee#432
A test can be found in https://github.com/tarantool/tarantool-ee/pull/451