### PR TITLE
sql: refactor PSEUDO and SORTER cursors

### DIFF
--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -3630,7 +3630,7 @@ sqlExprCodeTarget(Parse * pParse, Expr * pExpr, int target)
 				return pCol->iMem;
 			} else if (pAggInfo->useSortingIdx) {
 				sqlVdbeAddOp3(v, OP_Column,
-						  pAggInfo->sortingIdxPTab,
+					      pAggInfo->sortingIdx,
 						  pCol->iSorterColumn, target);
 				return target;
 			}

--- a/src/box/sql/select.c
+++ b/src/box/sql/select.c
@@ -2560,7 +2560,7 @@ generateWithRecursiveQuery(Parse * pParse,	/* Parsing context */
 
 	/* Allocate cursors for Current, Queue, and Distinct. */
 	regCurrent = ++pParse->nMem;
-	sqlVdbeAddOp3(v, OP_OpenPseudo, iCurrent, regCurrent, nCol);
+	sqlVdbeAddOp2(v, OP_OpenPseudo, iCurrent, nCol);
 	struct sql_space_info *info;
 	if (pOrderBy) {
 		VdbeComment((v, "Orderby table"));
@@ -2599,13 +2599,13 @@ generateWithRecursiveQuery(Parse * pParse,	/* Parsing context */
 	addrTop = sqlVdbeAddOp2(v, OP_Rewind, iQueue, addrBreak);
 
 	/* Transfer the next row in Queue over to Current */
-	sqlVdbeAddOp1(v, OP_NullRow, iCurrent);	/* To reset column cache */
 	if (pOrderBy) {
 		sqlVdbeAddOp3(v, OP_Column, iQueue, pOrderBy->nExpr + 1,
 				  regCurrent);
 	} else {
 		sqlVdbeAddOp2(v, OP_RowData, iQueue, regCurrent);
 	}
+	sqlVdbeAddOp2(v, OP_PseudoData, iCurrent, regCurrent);
 	sqlVdbeAddOp1(v, OP_Delete, iQueue);
 
 	/* Output the single row in Current */

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -1254,7 +1254,6 @@ struct AggInfo {
 				 * than the source table
 				 */
 	int sortingIdx;		/* Cursor number of the sorting index */
-	int sortingIdxPTab;	/* Cursor number of pseudo-table */
 	int nSortingColumn;	/* Number of columns in the sorting index */
 	int mnReg, mxReg;	/* Range of registers allocated for aCol and aFunc */
 	ExprList *pGroupBy;	/* The group by clause */

--- a/src/box/sql/vdbeInt.h
+++ b/src/box/sql/vdbeInt.h
@@ -368,7 +368,9 @@ sqlVdbeSorterReset(struct VdbeSorter *pSorter);
 void
 sqlVdbeSorterClose(struct VdbeCursor *pCsr);
 
-int sqlVdbeSorterRowkey(const VdbeCursor *, Mem *);
+/** Prepare the current sorter key. */
+void
+sqlVdbeSorterRowkey(struct VdbeCursor *pCsr);
 
 /** Advance to the next element in the sorter. */
 int

--- a/src/box/sql/vdbeInt.h
+++ b/src/box/sql/vdbeInt.h
@@ -97,7 +97,6 @@ struct VdbeCursor {
 	 */
 	union {
 		BtCursor *pCursor;	/* CURTYPE_TARANTOOL */
-		int pseudoTableReg;	/* CURTYPE_PSEUDO. Reg holding content. */
 		VdbeSorter *pSorter;	/* CURTYPE_SORTER. Sorter object */
 	} uc;
 	/** Info about keys needed by index cursors. */

--- a/src/box/sql/vdbesort.c
+++ b/src/box/sql/vdbesort.c
@@ -2073,11 +2073,8 @@ vdbeSorterRowkey(const VdbeSorter * pSorter,	/* Sorter object */
 	return pKey;
 }
 
-/*
- * Copy the current sorter key into the memory cell pOut.
- */
-int
-sqlVdbeSorterRowkey(const VdbeCursor * pCsr, Mem * pOut)
+void
+sqlVdbeSorterRowkey(struct VdbeCursor *pCsr)
 {
 	VdbeSorter *pSorter;
 	void *pKey;
@@ -2086,10 +2083,7 @@ sqlVdbeSorterRowkey(const VdbeCursor * pCsr, Mem * pOut)
 	assert(pCsr->eCurType == CURTYPE_SORTER);
 	pSorter = pCsr->uc.pSorter;
 	pKey = vdbeSorterRowkey(pSorter, &nKey);
-	if (mem_copy_bin(pOut, pKey, nKey) != 0)
-		return -1;
-
-	return 0;
+	vdbe_field_ref_prepare_data(&pCsr->field_ref, pKey, nKey);
 }
 
 /*


### PR DESCRIPTION
This patch-set refactors the PSEUDO and SORTER cursors.

The first patch make the SORTER cursor to prepare the data before passing it directly to the OP_Column, instead of passing the data to the OP_Column using the PSEUDO cursor and preparing the data in the first OP_Column for each row.

The second patch resets the nullRow field for the PSEUDO cursor and causes the PSEUDO cursor to prepare the data before passing it to the OP_Column instead of preparing the data in the first OP_Column for each row.

The logical continuation of these patches is the actual preparation of data for the TARANTOOL cursor before passing it to OP_Column and the removal of the cacheStatus field from the cursors. However, at the moment there are some problems with this. The main reasons are that a TARANTOOL cursor may not contain data and that the opcode OP_RowData can be used with a TARANTOOL cursor instead of OP_Column for optimization purposes. In case of passing to OP_RowData we do not need to prepare data.

This patch-set is a preparation for adding new cursors for new structures that will replace ephemeral tables.

Needed for #8099 