### PR TITLE
box: support default field values in the space format

### DIFF
--- a/changelogs/unreleased/gh-8157-default-field-value.md
+++ b/changelogs/unreleased/gh-8157-default-field-value.md
@@ -1,0 +1,3 @@
+## feature/core
+
+* Introduced the default field values in the space format (gh-8157).

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -107,6 +107,7 @@ set(tuple_sources
     tuple_format.c
     tuple_constraint_def.c
     tuple_constraint.c
+    tuple_builder.c
     xrow_update.c
     xrow_update_field.c
     xrow_update_array.c

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -300,7 +300,7 @@ struct errcode_record {
 	/*245 */_(ER_OLD_TERM,			"The term is outdated: old - %llu, new - %llu") \
 	/*246 */_(ER_INTERFERING_ELECTIONS,	"Interfering elections started")\
 	/*247 */_(ER_ITERATOR_POSITION,		"Iterator position is invalid") \
-	/*248 */_(ER_UNUSED,			"") \
+	/*248 */_(ER_DEFAULT_VALUE_TYPE,	"Type of the default value does not match tuple field %s type: expected %s, got %s") \
 	/*249 */_(ER_UNKNOWN_AUTH_METHOD,	"Unknown authentication method '%s'") \
 	/*250 */_(ER_INVALID_AUTH_DATA,		"Invalid '%s' data: %s") \
 	/*251 */_(ER_INVALID_AUTH_REQUEST,	"Invalid '%s' request: %s") \

--- a/src/box/field_def.c
+++ b/src/box/field_def.c
@@ -191,7 +191,7 @@ static const struct opt_def field_def_reg[] = {
 	OPT_DEF_ENUM("nullable_action", on_conflict_action, struct field_def,
 		     nullable_action, NULL),
 	OPT_DEF("collation", OPT_UINT32, struct field_def, coll_id),
-	OPT_DEF("default", OPT_STRPTR, struct field_def, default_value),
+	OPT_DEF("sql_default", OPT_STRPTR, struct field_def, sql_default_value),
 	OPT_DEF_ENUM("compression", compression_type, struct field_def,
 		     compression_type, NULL),
 	OPT_DEF_CUSTOM("constraint", field_def_parse_constraint),
@@ -205,7 +205,7 @@ const struct field_def field_def_default = {
 	.is_nullable = false,
 	.nullable_action = ON_CONFLICT_ACTION_DEFAULT,
 	.coll_id = COLL_NONE,
-	.default_value = NULL,
+	.sql_default_value = NULL,
 	.constraint_count = 0,
 	.constraint_def = NULL,
 };
@@ -394,8 +394,10 @@ field_def_array_dup(const struct field_def *fields, uint32_t field_count)
 	grp_alloc_reserve_data(&all, sizeof(*fields) * field_count);
 	for (uint32_t i = 0; i < field_count; i++) {
 		grp_alloc_reserve_str0(&all, fields[i].name);
-		if (fields[i].default_value != NULL)
-			grp_alloc_reserve_str0(&all, fields[i].default_value);
+		if (fields[i].sql_default_value != NULL) {
+			grp_alloc_reserve_str0(&all,
+					       fields[i].sql_default_value);
+		}
 	}
 	grp_alloc_use(&all, xmalloc(grp_alloc_size(&all)));
 	struct field_def *copy = grp_alloc_create_data(
@@ -403,9 +405,9 @@ field_def_array_dup(const struct field_def *fields, uint32_t field_count)
 	for (uint32_t i = 0; i < field_count; ++i) {
 		copy[i] = fields[i];
 		copy[i].name = grp_alloc_create_str0(&all, fields[i].name);
-		if (fields[i].default_value != NULL) {
-			copy[i].default_value = grp_alloc_create_str0(
-				&all, fields[i].default_value);
+		if (fields[i].sql_default_value != NULL) {
+			copy[i].sql_default_value = grp_alloc_create_str0(
+				&all, fields[i].sql_default_value);
 		}
 		copy[i].constraint_def = tuple_constraint_def_array_dup(
 			fields[i].constraint_def, fields[i].constraint_count);

--- a/src/box/field_def.h
+++ b/src/box/field_def.h
@@ -150,8 +150,8 @@ struct field_def {
 	/** Collation ID for string comparison. */
 	uint32_t coll_id;
 	/** 0-terminated SQL expression for DEFAULT value. */
-	char *default_value;
-	/** Type of comression to this field */
+	char *sql_default_value;
+	/** Compression type for this field. */
 	enum compression_type compression_type;
 	/** Array of constraints. Can be NULL if constraints_count == 0. */
 	struct tuple_constraint_def *constraint_def;

--- a/src/box/field_def.h
+++ b/src/box/field_def.h
@@ -151,6 +151,10 @@ struct field_def {
 	uint32_t coll_id;
 	/** 0-terminated SQL expression for DEFAULT value. */
 	char *sql_default_value;
+	/** MsgPack with the default value. */
+	char *default_value;
+	/** Size of the default value. */
+	size_t default_value_size;
 	/** Compression type for this field. */
 	enum compression_type compression_type;
 	/** Array of constraints. Can be NULL if constraints_count == 0. */

--- a/src/box/request.h
+++ b/src/box/request.h
@@ -30,6 +30,8 @@
  * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
+#include <stdbool.h>
+#include <stdint.h>
 
 #if defined(__cplusplus)
 extern "C" {
@@ -46,18 +48,24 @@ struct region;
  *
  * @param request - request to fix
  * @param space - space corresponding to request
- * @param old_tuple - the old tuple
- * @param new_tuple - the new tuple
+ * @param old_data - the old tuple data
+ * @param old_size - size of the old data
+ * @param new_data - the new tuple data
+ * @param new_size - size of the new data
  * @param region - region where request parts will be allocated
+ * @param preserve_insert_type - do not turn INSERT requests into REPLACE
  *
- * If old_tuple and new_tuple are the same, the request is turned into NOP.
- * If new_tuple is NULL, the request is turned into DELETE(old_tuple).
- * If new_tuple is not NULL, the request is turned into REPLACE(new_tuple).
+ * If old_data and new_data are the same, the request is turned into NOP.
+ * If new_data is NULL, the request is turned into DELETE(old_data).
+ * If new_data is not NULL, the request is turned into REPLACE(new_data),
+ * or into INSERT(new_data)/UPSERT(new_data) when preserve_request_type is true
+ * and the original request was INSERT or UPSERT.
  */
 int
 request_create_from_tuple(struct request *request, struct space *space,
-			  struct tuple *old_tuple, struct tuple *new_tuple,
-			  struct region *region);
+			  const char *old_data, uint32_t old_size,
+			  const char *new_data, uint32_t new_size,
+			  struct region *region, bool preserve_request_type);
 
 /**
  * Convert a request accessing a secondary key to a primary

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -368,7 +368,7 @@ sql_ephemeral_space_new(const struct sql_space_info *info)
 		names += strlen(fields[i].name) + 1;
 		fields[i].is_nullable = true;
 		fields[i].nullable_action = ON_CONFLICT_ACTION_NONE;
-		fields[i].default_value = NULL;
+		fields[i].sql_default_value = NULL;
 		fields[i].type = info->types[i];
 		fields[i].coll_id = info->coll_ids[i];
 		fields[i].compression_type = COMPRESSION_TYPE_NONE;
@@ -1030,7 +1030,7 @@ sql_encode_table(struct region *region, struct space_def *def, uint32_t *size)
 	for (uint32_t i = 0; i < field_count && !is_error; i++) {
 		uint32_t cid = def->fields[i].coll_id;
 		struct field_def *field = &def->fields[i];
-		const char *default_str = field->default_value;
+		const char *default_str = field->sql_default_value;
 		int base_len = 4;
 		if (cid != COLL_NONE)
 			base_len += 1;
@@ -1071,7 +1071,7 @@ sql_encode_table(struct region *region, struct space_def *def, uint32_t *size)
 			mpstream_encode_uint(&stream, cid);
 		}
 		if (default_str != NULL) {
-			mpstream_encode_str(&stream, "default");
+			mpstream_encode_str(&stream, "sql_default");
 			mpstream_encode_str(&stream, default_str);
 		}
 		sql_mpstream_encode_constraints(&stream, cdefs, ck_count,
@@ -1265,7 +1265,7 @@ space_column_default_expr(uint32_t space_id, uint32_t fieldno)
 		return NULL;
 	assert(space->def->field_count > fieldno);
 	struct tuple_field *field = tuple_format_field(space->format, fieldno);
-	return field->default_value_expr;
+	return field->sql_default_value_expr;
 }
 
 /**

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -369,6 +369,8 @@ sql_ephemeral_space_new(const struct sql_space_info *info)
 		fields[i].is_nullable = true;
 		fields[i].nullable_action = ON_CONFLICT_ACTION_NONE;
 		fields[i].sql_default_value = NULL;
+		fields[i].default_value = NULL;
+		fields[i].default_value_size = 0;
 		fields[i].type = info->types[i];
 		fields[i].coll_id = info->coll_ids[i];
 		fields[i].compression_type = COMPRESSION_TYPE_NONE;

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -513,17 +513,18 @@ sqlAddDefaultValue(Parse * pParse, ExprSpan * pSpan)
 			struct field_def *field =
 				&def->fields[def->field_count - 1];
 			struct region *region = &pParse->region;
-			uint32_t default_length = (int)(pSpan->zEnd - pSpan->zStart);
-			field->default_value = region_alloc(region,
-							    default_length + 1);
-			if (field->default_value == NULL) {
+			uint32_t default_length = (int)(pSpan->zEnd -
+							pSpan->zStart);
+			field->sql_default_value =
+				region_alloc(region, default_length + 1);
+			if (field->sql_default_value == NULL) {
 				diag_set(OutOfMemory, default_length + 1,
 					 "region_alloc",
-					 "field->default_value");
+					 "field->sql_default_value");
 				pParse->is_aborted = true;
 				return;
 			}
-			strlcpy(field->default_value, pSpan->zStart,
+			strlcpy(field->sql_default_value, pSpan->zStart,
 				default_length + 1);
 		}
 	}

--- a/src/box/sql/insert.c
+++ b/src/box/sql/insert.c
@@ -573,7 +573,7 @@ sqlInsert(Parse * pParse,	/* Parser context */
 						tuple_format_field(
 							space->format, i);
 					struct Expr *dflt =
-						field->default_value_expr;
+						field->sql_default_value_expr;
 					sqlExprCode(pParse,
 							dflt,
 							regCols + i + 1);
@@ -635,7 +635,8 @@ sqlInsert(Parse * pParse,	/* Parser context */
 				}
 				struct tuple_field *field =
 					tuple_format_field(space->format, i);
-				struct Expr *dflt = field->default_value_expr;
+				struct Expr *dflt =
+					field->sql_default_value_expr;
 				sqlExprCodeFactorable(pParse,
 							  dflt,
 							  iRegStore);
@@ -1102,9 +1103,10 @@ xferOptimization(Parse * pParse,	/* Parser context */
 			return 0;
 		/* Default values for second and subsequent columns need to match. */
 		if (i > 0) {
-			char *src_expr_str = src->def->fields[i].default_value;
+			char *src_expr_str =
+				src->def->fields[i].sql_default_value;
 			char *dest_expr_str =
-				dest->def->fields[i].default_value;
+				dest->def->fields[i].sql_default_value;
 			if ((dest_expr_str == NULL) != (src_expr_str == NULL) ||
 			    (dest_expr_str &&
 			     strcmp(src_expr_str, dest_expr_str) != 0)

--- a/src/box/sql/pragma.c
+++ b/src/box/sql/pragma.c
@@ -120,7 +120,8 @@ sql_pragma_table_info(struct Parse *parse, const char *tbl_name)
 		}
 		sqlVdbeMultiLoad(v, 1, "issisi", i, field->name,
 				     field_type_strs[field->type],
-				     !field->is_nullable, field->default_value,
+				     !field->is_nullable,
+				     field->sql_default_value,
 				     k);
 		sqlVdbeAddOp2(v, OP_ResultRow, 1, 6);
 	}

--- a/src/box/sql/show.c
+++ b/src/box/sql/show.c
@@ -289,8 +289,8 @@ sql_describe_field(struct sql_desc *desc, const struct field_def *field)
 	}
 	if (!field->is_nullable)
 		sql_desc_append(desc, " NOT NULL");
-	if (field->default_value != NULL)
-		sql_desc_append(desc, " DEFAULT(%s)", field->default_value);
+	if (field->sql_default_value != NULL)
+		sql_desc_append(desc, " DEFAULT(%s)", field->sql_default_value);
 	for (uint32_t i = 0; i < field->constraint_count; ++i) {
 		struct tuple_constraint_def *cdef = &field->constraint_def[i];
 		assert(cdef->type == CONSTR_FKEY || cdef->type == CONSTR_FUNC);

--- a/src/box/tuple_builder.c
+++ b/src/box/tuple_builder.c
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include <stddef.h>
+#include <stdint.h>
+#include "tuple.h"
+#include "msgpuck.h"
+#include "small/region.h"
+#include "salad/stailq.h"
+#include "tuple_builder.h"
+
+/**
+ * A chunk of data with tuple fields.
+ */
+struct tuple_chunk {
+	/** Start of the data. */
+	const char *data;
+	/** End of the data. */
+	const char *data_end;
+	/** Number of NULL fields. If > 0 then data/data_end are not used. */
+	uint32_t null_count;
+	/** Link in `tuple_builder::chunks`. */
+	struct stailq_entry in_builder;
+};
+
+void
+tuple_builder_new(struct tuple_builder *builder, struct region *region)
+{
+	stailq_create(&builder->chunks);
+	builder->field_count = 0;
+	builder->size = 0;
+	builder->region = region;
+}
+
+void
+tuple_builder_add_nil(struct tuple_builder *builder)
+{
+	builder->field_count++;
+	builder->size += mp_sizeof_nil();
+
+	struct tuple_chunk *chunk;
+	if (!stailq_empty(&builder->chunks)) {
+		chunk = stailq_last_entry(&builder->chunks, struct tuple_chunk,
+					  in_builder);
+		/* Avoid unnecessary allocation. */
+		if (chunk->null_count > 0) {
+			chunk->null_count++;
+			return;
+		}
+	}
+	chunk = xregion_alloc_object(builder->region, typeof(*chunk));
+	chunk->data = NULL;
+	chunk->data_end = NULL;
+	chunk->null_count = 1;
+	stailq_add_tail_entry(&builder->chunks, chunk, in_builder);
+}
+
+void
+tuple_builder_add(struct tuple_builder *builder, const char *data,
+		  size_t data_size, uint32_t field_count)
+{
+	const char *data_end = data + data_size;
+	builder->field_count += field_count;
+	builder->size += data_size;
+
+	struct tuple_chunk *chunk;
+	if (!stailq_empty(&builder->chunks)) {
+		chunk = stailq_last_entry(&builder->chunks, struct tuple_chunk,
+					  in_builder);
+		/* Avoid unnecessary allocation. */
+		if (chunk->data_end == data) {
+			chunk->data_end = data_end;
+			return;
+		}
+	}
+	chunk = xregion_alloc_object(builder->region, typeof(*chunk));
+	chunk->data = data;
+	chunk->data_end = data_end;
+	chunk->null_count = 0;
+	stailq_add_tail_entry(&builder->chunks, chunk, in_builder);
+}
+
+void
+tuple_builder_finalize(struct tuple_builder *builder, const char **data,
+		       const char **data_end)
+{
+	size_t data_size = builder->size +
+			   mp_sizeof_array(builder->field_count);
+	char *buf = xregion_alloc(builder->region, data_size);
+	*data = buf;
+	*data_end = buf + data_size;
+	buf = mp_encode_array(buf, builder->field_count);
+
+	struct tuple_chunk *chunk;
+	stailq_foreach_entry(chunk, &builder->chunks, in_builder) {
+		if (chunk->null_count == 0) {
+			uint32_t size = chunk->data_end - chunk->data;
+			memcpy(buf, chunk->data, size);
+			buf += size;
+		} else {
+			for (uint32_t i = 0; i < chunk->null_count; i++)
+				buf = mp_encode_nil(buf);
+		}
+	}
+	assert(buf == *data_end);
+	mp_tuple_assert(*data, *data_end);
+}

--- a/src/box/tuple_builder.h
+++ b/src/box/tuple_builder.h
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include "salad/stailq.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+struct region;
+
+/**
+ * A builder that helps to construct a tuple by concatenating chunks of data.
+ * A chunk represents one or more tuple fields (MsgPack objects).
+ *
+ * First, chunks are added to a builder object. The builder doesn't allocate
+ * any memory for the MsgPack, and doesn't copy it, only pointers to the start
+ * and to the end of the data are preserved.
+ *
+ * Once all chunks have been added, the builder can be used to encode them into
+ * the final MsgPack array.
+ */
+struct tuple_builder {
+	/** List of chunks, linked by `tuple_chunk::in_builder`. */
+	struct stailq chunks;
+	/**
+	 * Number of tuple fields. It can be greater than the number of
+	 * elements in the list of chunks.
+	 */
+	uint32_t field_count;
+	/** Total size of memory required to encode chunks from the list. */
+	size_t size;
+	/** The region used to perform memory allocation. */
+	struct region *region;
+};
+
+/**
+ * Initialize the builder. The region argument is saved to perform memory
+ * allocation for internal structures and for the resulting MsgPack array.
+ */
+void
+tuple_builder_new(struct tuple_builder *builder, struct region *region);
+
+/**
+ * Add a NULL tuple field to the builder.
+ */
+void
+tuple_builder_add_nil(struct tuple_builder *builder);
+
+/**
+ * Add a chunk of data with `field_count` tuple fields to the builder.
+ * If the chunk is adjacent to the previous one, only single pointer is updated,
+ * otherwise a new list element is allocated on builder->region and added to
+ * builder->chunks.
+ */
+void
+tuple_builder_add(struct tuple_builder *builder, const char *data,
+		  size_t data_size, uint32_t field_count);
+
+/**
+ * Encode tuple fields added to the builder into the new MsgPack array.
+ * The buffer is allocated on builder->region, and the address is returned
+ * in data and data_end.
+ */
+void
+tuple_builder_finalize(struct tuple_builder *builder, const char **data,
+		       const char **data_end);
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */

--- a/src/box/tuple_format.c
+++ b/src/box/tuple_format.c
@@ -191,8 +191,8 @@ tuple_field_delete(struct tuple_field *field)
 	for (uint32_t i = 0; i < field->constraint_count; i++)
 		field->constraint[i].destroy(&field->constraint[i]);
 	free(field->constraint);
-	if (field->default_value_expr != NULL)
-		tuple_format_expr_delete(field->default_value_expr);
+	if (field->sql_default_value_expr != NULL)
+		tuple_format_expr_delete(field->sql_default_value_expr);
 	free(field);
 }
 
@@ -503,11 +503,11 @@ tuple_format_create(struct tuple_format *format, struct key_def *const *keys,
 			tuple_constraint_array_new(fields[i].constraint_def,
 						   fields[i].constraint_count);
 		field->constraint_count = fields[i].constraint_count;
-		const char *expr = fields[i].default_value;
+		const char *expr = fields[i].sql_default_value;
 		if (expr != NULL) {
-			field->default_value_expr =
+			field->sql_default_value_expr =
 				tuple_format_expr_compile(expr, strlen(expr));
-			if (field->default_value_expr == NULL)
+			if (field->sql_default_value_expr == NULL)
 				return -1;
 		}
 	}

--- a/src/box/tuple_format.h
+++ b/src/box/tuple_format.h
@@ -65,7 +65,6 @@ enum { TUPLE_INDEX_BASE = 1 };
 enum { TUPLE_OFFSET_SLOT_NIL = INT32_MAX };
 
 struct tuple;
-struct tuple_chunk;
 struct tuple_format;
 struct coll;
 struct Expr;
@@ -163,6 +162,10 @@ struct tuple_field {
 	uint32_t constraint_count;
 	/** AST for parsed SQL default value. */
 	struct Expr *sql_default_value_expr;
+	/** MsgPack with the default value. */
+	char *default_value;
+	/** Size of the default value. */
+	size_t default_value_size;
 };
 
 /**
@@ -175,6 +178,15 @@ static inline bool
 tuple_field_is_nullable(const struct tuple_field *tuple_field)
 {
 	return tuple_field->nullable_action == ON_CONFLICT_ACTION_NONE;
+}
+
+/**
+ * Return true if tuple_field has a default value.
+ */
+static inline bool
+tuple_field_has_default(const struct tuple_field *tuple_field)
+{
+	return tuple_field->default_value != NULL;
 }
 
 /**
@@ -252,6 +264,11 @@ struct tuple_format {
 	 * path fields. See also tuple_format::fields.
 	 */
 	uint32_t total_field_count;
+	/**
+	 * An upper bound for the number of fields with a default value.
+	 * In other words, max fieldno with a default value + 1.
+	 */
+	uint32_t default_field_count;
 	/**
 	 * Bitmap of fields that must be present in a tuple
 	 * conforming to the format. Indexed by tuple_field::id.
@@ -437,6 +454,15 @@ uint32_t
 tuple_format_min_field_count(struct key_def * const *keys, uint16_t key_count,
 			     const struct field_def *space_fields,
 			     uint32_t space_field_count);
+
+/**
+ * Return true if format has at least one field with a default value.
+ */
+static inline bool
+tuple_format_has_defaults(const struct tuple_format *format)
+{
+	return format->default_field_count > 0;
+}
 
 typedef struct tuple_format box_tuple_format_t;
 
@@ -640,6 +666,17 @@ tuple_format_iterator_create(struct tuple_format_iterator *it,
 int
 tuple_format_iterator_next(struct tuple_format_iterator *it,
 			   struct tuple_format_iterator_entry *entry);
+
+/**
+ * Replace null (or absent) fields of msgpack with the default values from the
+ * format. The input msgpack is located at [*data .. *data_end).
+ * Return true if at least one field is changed, in that case data and data_end
+ * are updated to point to the new buffer with the modified msgpack. The buffer
+ * is allocated on current fiber's region.
+ */
+bool
+tuple_format_apply_defaults(struct tuple_format *format, const char **data,
+			    const char **data_end);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/box/tuple_format.h
+++ b/src/box/tuple_format.h
@@ -161,8 +161,8 @@ struct tuple_field {
 	struct tuple_constraint *constraint;
 	/** Number of constraints. */
 	uint32_t constraint_count;
-	/** AST for parsed default value. */
-	struct Expr *default_value_expr;
+	/** AST for parsed SQL default value. */
+	struct Expr *sql_default_value_expr;
 };
 
 /**

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -466,6 +466,7 @@ t;
  |   245: box.error.OLD_TERM
  |   246: box.error.INTERFERING_ELECTIONS
  |   247: box.error.ITERATOR_POSITION
+ |   248: box.error.DEFAULT_VALUE_TYPE
  |   249: box.error.UNKNOWN_AUTH_METHOD
  |   250: box.error.INVALID_AUTH_DATA
  |   251: box.error.INVALID_AUTH_REQUEST

--- a/test/engine-luatest/gh_8157_default_field_value_test.lua
+++ b/test/engine-luatest/gh_8157_default_field_value_test.lua
@@ -1,0 +1,283 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local function before_all(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end
+
+local function after_all(cg)
+    cg.server:drop()
+end
+
+local function after_each(cg)
+    cg.server:exec(function()
+        if box.space.test then box.space.test:drop() end
+    end)
+end
+
+local g = t.group('gh-8157-1', {{engine = 'memtx'}, {engine = 'vinyl'}})
+g.before_all(before_all)
+g.after_all(after_all)
+g.after_each(after_each)
+
+-- Test default field values.
+g.test_basics = function(cg)
+    cg.server:exec(function(engine)
+        local format = {
+            {name='c1', type='any'},
+            {name='c2', type='any', default={key='val'}},
+            {name='id', type='unsigned', default=0},
+            {name='c4', type='integer', is_nullable=true, default=-100500},
+            {name='c5', type='unsigned', is_nullable=false, default=0},
+            {name='c6', type='string', is_nullable=true, default='hello'}
+        }
+        local opts = {engine = engine, format = format}
+        local s = box.schema.space.create('test', opts)
+        s:create_index('pk', {parts={'id'}})
+        local sk1 = s:create_index('sk1', {parts={'c4'}})
+        local sk2 = s:create_index('sk2', {parts={{'c5'}, {'c6'}},
+                                           unique=false})
+        -- c5 and c6 are null
+        s:insert{11, 12, 13, 14}
+        t.assert_equals(sk1:select{14}, {{11, 12, 13, 14, 0, 'hello'}})
+
+        -- c4 is null
+        s:insert{21, 22, 23, nil, 25, '26'}
+        t.assert_equals(sk2:select{25}, {{21, 22, 23, -100500, 25, '26'}})
+
+        -- c2, c5, c6 are null
+        s:insert{nil, nil, 33, 34, box.NULL}
+        t.assert_equals(s:select{33}, {{nil, {key='val'}, 33, 34, 0, 'hello'}})
+
+        -- c6 is null + more fields
+        s:insert{41, 42, 43, 44, 45, nil, ',', 'world', '!'}
+        t.assert_equals(s:select{43}, {{41, 42, 43, 44, 45, 'hello',
+                                        ',', 'world', '!'}})
+
+        -- Primary indexed field id is null
+        s:insert{51, 52, nil, 54, 55, ''}
+        t.assert_equals(s:select{0}, {{51, 52, 0, 54, 55, ''}})
+    end, {cg.params.engine})
+end
+
+-- Test default field values with UPDATE and UPSERT operations.
+g.test_update_upsert = function(cg)
+    cg.server:exec(function(engine)
+        local s = box.schema.space.create('test', {engine=engine})
+        s:create_index('pk')
+        s:insert{1000, nil, 'qwerty'}
+
+        -- Check that s:format(format) is successful although the space contains
+        -- a tuple with non-nullable field `name', which is null.
+        local format = {{name='id', type='unsigned'},
+                        {name='name', type='string', default='Noname'},
+                        {name='pass', type='string'},
+                        {name='shell', type='string', default='/bin/sh',
+                         is_nullable=true}}
+        t.assert_equals(s:format(format), nil)
+
+        -- Note that existing tuples are not updated automatically by s:format()
+        t.assert_equals(s:select{1000}, {{1000, nil, 'qwerty'}})
+
+        -- Check that UPDATE does not change the `name' field, which is null.
+        s:update({1000}, {{'=', 'pass', 'secret'}})
+        t.assert_equals(s:select{1000}, {{1000, nil, 'secret'}})
+
+        -- Test UPSERT (acts as UPDATE)
+        s:upsert({1000, nil, 'love'}, {{'=', 'pass', '123456'}})
+        t.assert_equals(s:select{1000}, {{1000, nil, '123456'}})
+
+        -- Test UPSERT (acts as INSERT)
+        s:upsert({1001, nil, 'god'}, {})
+        t.assert_equals(s:select{1001}, {{1001, 'Noname', 'god', '/bin/sh'}})
+    end, {cg.params.engine})
+end
+
+-- Test default field values in a space with the field_count option set.
+g.test_exact_field_count = function(cg)
+    cg.server:exec(function(engine)
+        local format = {{name='id', type='integer'},
+                        {name='id1', type='integer'},
+                        {name='id2', type='integer', default=0}}
+        local opts = {engine = engine, format = format, field_count = 3}
+        local s = box.schema.space.create('test', opts)
+        s:create_index('pk')
+
+        -- Default value is applied to field 3 (id2), but field 2 is null.
+        t.assert_error_msg_content_equals('Tuple field 2 (id1) type does ' ..
+            'not match one required by operation: expected integer, got nil',
+            s.insert, s, {1})
+
+        t.assert_equals(s:insert{2, 2}, {2, 2, 0})
+        t.assert_equals(s:insert{3, 3, 3}, {3, 3, 3})
+
+        t.assert_error_msg_content_equals(
+            'Tuple field count 4 does not match space field count 3',
+            s.insert, s, {4, 4, nil, 4})
+    end, {cg.params.engine})
+end
+
+-- Test error messages.
+g.test_errors = function(cg)
+    cg.server:exec(function(engine)
+        -- Bad type of the default value.
+        local format = {{name='id', type='integer'},
+                        {name='c2', type='integer', default='not_integer'}}
+        local opts = {engine = engine, format = format}
+        t.assert_error_msg_content_equals('Type of the default value does ' ..
+            'not match tuple field 2 (c2) type: expected integer, got string',
+            box.schema.space.create, 'test', opts)
+
+        format = {{name='id', type='integer'},
+                  {name='c2', type='integer', default=-1}}
+        opts = {engine = engine, format = format}
+        local s = box.schema.space.create('test', opts)
+
+        -- Check upsert into a space without the primary index.
+        t.assert_error_msg_content_equals(
+            "No index #0 is defined in space 'test'",
+            s.upsert, s, {1}, {})
+
+        -- Check upsert with a wrong key type.
+        s:create_index('pk')
+        s:create_index('sk', {parts={'c2'}})
+        t.assert_error_msg_content_equals('Tuple field 1 (id) type does not ' ..
+            'match one required by operation: expected integer, got string',
+            s.upsert, s, {'bad'}, {})
+
+        -- Check upsert with a wrong update operation.
+        t.assert_error_msg_content_equals(
+            'Illegal parameters, update operation must be an array {op,..}',
+            s.upsert, s, {0}, {'bad'})
+        s:insert{0}
+        t.assert_error_msg_content_equals(
+            'Illegal parameters, update operation must be an array {op,..}',
+            s.upsert, s, {0}, {'bad'})
+
+        -- Check "duplicate key exists" error messages.
+        t.assert_error_msg_content_equals('Duplicate key exists in unique ' ..
+            'index "pk" in space "test" with old tuple - [0, -1] and new ' ..
+            'tuple - [0, -1]', s.insert, s, {0})
+        t.assert_error_msg_content_equals('Duplicate key exists in unique ' ..
+            'index "sk" in space "test" with old tuple - [0, -1] and new ' ..
+            'tuple - [1, -1]', s.insert, s, {1})
+        s:truncate()
+
+        -- Space format has more fields than the inserted tuple.
+        -- Check that the error message complains only about c3.
+        s:format{{name='id', type='integer', default=0},
+                 {name='c2', type='integer', default=-1},
+                 {name='c3', type='integer'}}
+        t.assert_error_msg_content_equals(
+            'Tuple field 3 (c3) required by space format is missing',
+            s.insert, s, {0})
+    end, {cg.params.engine})
+end
+
+-- Test default field values in conjunction with before_replace triggers.
+g.test_triggers = function(cg)
+    cg.server:exec(function(engine)
+        local format = {{name='id', type='unsigned'},
+                        {name='name', type='string', default='Noname'},
+                        {name='pass', type='string'},
+                        {name='shell', type='string', default='/bin/sh'}}
+        local s = box.schema.space.create('test', {engine = engine})
+        s:create_index('pk')
+        s:insert{1000, nil, '0000', '/bin/nologin'}
+        s:format(format)
+
+        local trigger1 = function(_, new)
+            return box.tuple.update(new, {{'=', 3, 'hacked'}})
+        end
+        s:before_replace(trigger1)
+
+        -- Check that UPSERT (acts as INSERT) applies default values.
+        t.assert_equals(s:upsert({1001, nil, 'xxxxxxxxx'}, {}),
+                        {1001, 'Noname', 'hacked', '/bin/sh'})
+
+        -- Check that UPSERT (acts as UPDATE) doesn't apply the default.
+        t.assert_equals(s:upsert({1000, nil, '0000', '/bin/zsh'},
+                                 {{'=', 'shell', '/bin/zsh'}}),
+                        {1000, nil, 'hacked', '/bin/zsh'})
+
+        -- Check that REPLACE applies default values.
+        t.assert_equals(s:replace{1000, nil, '123'},
+                        {1000, 'Noname', 'hacked', '/bin/sh'})
+
+        -- Check that defaults can be applied inside a trigger.
+        local trigger2 = function(_, new)
+            box.space.test:run_triggers(false)
+            box.space.test:insert{9000, nil, new[3]}
+        end
+        s:before_replace(trigger2, trigger1)
+        s:insert{1002, 'user', 'secret'}
+        t.assert_equals(s:select{9000}, {{9000, 'Noname', 'secret', '/bin/sh'}})
+    end, {cg.params.engine})
+end
+
+-- Test default field values with access via net.box.
+g.test_netbox = function(cg)
+    cg.server:exec(function(engine)
+        local format = {{name='id1', type='integer', default=1000},
+                        {name='id2', type='integer', default=2000},
+                        {name='id3', type='integer', default=3000}}
+        local opts = {engine = engine, format = format}
+        local s = box.schema.space.create('test', opts)
+        s:create_index('pk')
+    end, {cg.params.engine})
+
+    local netbox = require('net.box')
+    local c = netbox.connect(cg.server.net_box_uri)
+    local s = c.space.test
+
+    t.assert_equals(s:insert{1, nil, 1}, {1, 2000, 1})
+    t.assert_equals(s:insert{2}, {2, 2000, 3000})
+    t.assert_equals(s:insert{}, {1000, 2000, 3000})
+end
+
+local g2 = t.group('gh-8157-2')
+g2.before_all(before_all)
+g2.after_all(after_all)
+g2.after_each(after_each)
+
+-- Test default field values after recovery from xlog and snap.
+g2.test_recovery = function(cg)
+    cg.server:exec(function()
+        local format = {{name='id', type='integer'},
+                        {name='name', type='string', default='guest'}}
+        local opts = {format = format, id = 666}
+        local s = box.schema.space.create('test', opts)
+        s:create_index('pk')
+        s:insert{-1}
+        s:upsert({-2}, {})
+    end)
+
+    -- Check recovery from xlog.
+    cg.server:restart()
+    cg.server:exec(function()
+        t.assert_equals(box.space.test:select{-1}, {{-1, 'guest'}})
+        t.assert_equals(box.space.test:select{-2}, {{-2, 'guest'}})
+    end)
+
+    -- Check that xlog contains the actual default values.
+    local fio = require('fio')
+    local xlog = require('xlog')
+    local xlog_tuples = {}
+    local xlog_path = fio.pathjoin(cg.server.workdir,
+                                   string.format("%020d.xlog", 0))
+    for _, row in xlog.pairs(xlog_path) do
+        if row.BODY.space_id == 666 then
+            table.insert(xlog_tuples, row.BODY.tuple)
+        end
+    end
+    t.assert_equals(xlog_tuples, {{-1, 'guest'}, {-2, 'guest'}})
+
+    --- Check recovery from snap.
+    cg.server:eval('box.snapshot()')
+    cg.server:restart()
+    cg.server:exec(function()
+        t.assert_equals(box.space.test:select{-1}, {{-1, 'guest'}})
+        t.assert_equals(box.space.test:select{-2}, {{-2, 'guest'}})
+    end)
+end

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -564,6 +564,11 @@ create_unit_test(PREFIX key_def
                  LIBRARIES unit box core
 )
 
+create_unit_test(PREFIX tuple_builder
+                 SOURCES tuple_builder.c box_test_utils.c
+                 LIBRARIES unit box core
+)
+
 create_unit_test(PREFIX getenv_safe
                  SOURCES getenv_safe.c core_test_utils.c
                  LIBRARIES unit core

--- a/test/unit/tuple_builder.c
+++ b/test/unit/tuple_builder.c
@@ -1,0 +1,172 @@
+#include "fiber.h"
+#include "memory.h"
+#include "msgpuck.h"
+#include "tuple.h"
+#include "tuple_builder.h"
+
+#define UNIT_TAP_COMPATIBLE 1
+#include "unit.h"
+
+static void
+test_tuple_builder_empty(void)
+{
+	plan(2);
+	header();
+
+	const char *data, *data_end;
+	struct region *region = &fiber()->gc;
+	size_t region_svp = region_used(region);
+
+	struct tuple_builder builder;
+	tuple_builder_new(&builder, region);
+	tuple_builder_finalize(&builder, &data, &data_end);
+
+	is(mp_typeof(*data), MP_ARRAY, "type is MP_ARRAY");
+	is(mp_decode_array(&data), 0, "array is empty");
+	region_truncate(region, region_svp);
+
+	footer();
+	check_plan();
+}
+
+static void
+test_tuple_builder_nulls(void)
+{
+	plan(4);
+	header();
+
+	const char *data, *data_end;
+	struct region *region = &fiber()->gc;
+	size_t region_svp = region_used(region);
+
+	struct tuple_builder builder;
+	tuple_builder_new(&builder, region);
+	tuple_builder_add_nil(&builder);
+	tuple_builder_add_nil(&builder);
+	tuple_builder_add_nil(&builder);
+	tuple_builder_finalize(&builder, &data, &data_end);
+
+	is(mp_decode_array(&data), 3, "array contains 3 elements");
+	is(mp_typeof(*data), MP_NIL, "[0] MP_NIL");
+	mp_decode_nil(&data);
+	is(mp_typeof(*data), MP_NIL, "[1] MP_NIL");
+	mp_decode_nil(&data);
+	is(mp_typeof(*data), MP_NIL, "[2] MP_NIL");
+	region_truncate(region, region_svp);
+
+	footer();
+	check_plan();
+}
+
+static struct tuple *
+create_tuple1(void)
+{
+	char data[16];
+	char *end = data;
+	end = mp_encode_array(end, 5);
+	end = mp_encode_uint(end, 0);
+	end = mp_encode_uint(end, 111);
+	end = mp_encode_uint(end, 222);
+	end = mp_encode_uint(end, 333);
+	end = mp_encode_uint(end, 444);
+
+	struct tuple *tuple = tuple_new(tuple_format_runtime, data, end);
+	tuple_ref(tuple);
+	return tuple;
+}
+
+static struct tuple *
+create_tuple2(void)
+{
+	char data[16];
+	char *end = data;
+	end = mp_encode_array(end, 3);
+	end = mp_encode_str0(end, "xxx");
+	end = mp_encode_str0(end, "yyy");
+	end = mp_encode_str0(end, "zzz");
+
+	struct tuple *tuple = tuple_new(tuple_format_runtime, data, end);
+	tuple_ref(tuple);
+	return tuple;
+}
+
+static void
+test_tuple_builder_merge(void)
+{
+	plan(9);
+	header();
+
+	uint32_t len;
+	const char *str, *data, *data_end;
+	struct region *region = &fiber()->gc;
+	size_t region_svp = region_used(region);
+
+	struct tuple *tuple1 = create_tuple1();
+	struct tuple *tuple2 = create_tuple2();
+	const char *t1f2 = tuple_field(tuple1, 2);
+	const char *t1f3 = tuple_field(tuple1, 3);
+	const char *t1f4 = tuple_field(tuple1, 4);
+	const char *t2f0 = tuple_field(tuple2, 0);
+	const char *t2f1 = tuple_field(tuple2, 1);
+	const char *t2f2 = tuple_field(tuple2, 2);
+
+	struct tuple_builder builder;
+	tuple_builder_new(&builder, region);
+	tuple_builder_add(&builder, t1f2, t1f4 - t1f2, 2);
+	tuple_builder_add(&builder, t2f0, t2f2 - t2f0, 2);
+	tuple_builder_add_nil(&builder);
+	tuple_builder_add(&builder, t2f1, t2f2 - t2f1, 1);
+	tuple_builder_add(&builder, t1f2, t1f3 - t1f2, 1);
+	tuple_builder_add_nil(&builder);
+	tuple_builder_finalize(&builder, &data, &data_end);
+
+	tuple_unref(tuple1);
+	tuple_unref(tuple2);
+
+	is(mp_decode_array(&data), 8, "array contains 8 elements");
+	is(mp_decode_uint(&data), 222, "[0] MP_UINT is 222");
+	is(mp_decode_uint(&data), 333, "[1] MP_UINT is 333");
+	str = mp_decode_str(&data, &len);
+	is(strncmp(str, "xxx", 3), 0, "[2] MP_STR is xxx");
+	str = mp_decode_str(&data, &len);
+	is(strncmp(str, "yyy", 3), 0, "[3] MP_STR is yyy");
+	is(mp_typeof(*data), MP_NIL, "[4] MP_NIL");
+	mp_decode_nil(&data);
+	str = mp_decode_str(&data, &len);
+	is(strncmp(str, "yyy", 3), 0, "[5] MP_STR is yyy");
+	is(mp_decode_uint(&data), 222, "[6] MP_UINT is 222");
+	is(mp_typeof(*data), MP_NIL, "[7] MP_NIL");
+	region_truncate(region, region_svp);
+
+	footer();
+	check_plan();
+}
+
+static int
+test_tuple_builder(void)
+{
+	plan(3);
+	header();
+
+	test_tuple_builder_empty();
+	test_tuple_builder_nulls();
+	test_tuple_builder_merge();
+
+	footer();
+	return check_plan();
+}
+
+int
+main(void)
+{
+	memory_init();
+	fiber_init(fiber_c_invoke);
+	tuple_init(NULL);
+
+	int rc = test_tuple_builder();
+
+	tuple_free();
+	fiber_free();
+	memory_free();
+	return rc;
+}


### PR DESCRIPTION
Now a field can be assigned a default value in the space format. When a new tuple is inserted into a space, and some of the fields contain null values, those fields will be filled with their respective default values.

Closes https://github.com/tarantool/tarantool/issues/8157

@TarantoolBot document
Title: Document default field values
Root document: https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_space/format/

The format clause contains, for each field, a definition within braces: `{name='...',type='...'[,is_nullable=...][,default=...]}`, where:

* the optional `default` value contains a default value for the field. Its type must be compatible with the field type. If default value is set, it is applied regardless of whether `is_nullable` is true or false.

Example:
```lua
tarantool> box.space.tester:format{
         > {name = 'id', type = 'unsigned'},
         > {name = 'name', type = 'string', default = 'Noname'},
         > {name = 'pass', type = 'string'},
         > {name = 'shell', type = 'string', default = '/bin/sh'}}
---
...

tarantool> box.space.tester:insert{1000, nil, 'qwerty'}
---
- [1000, 'Noname', 'qwerty', '/bin/sh']
...
```