### PR TITLE
salad: make rope_erase erase more then a single element

### DIFF
--- a/src/box/xrow_update_array.c
+++ b/src/box/xrow_update_array.c
@@ -454,8 +454,7 @@ xrow_update_op_do_array_delete(struct xrow_update_op *op,
 	if ((uint64_t) op->field_no + delete_count > size)
 		delete_count = size - op->field_no;
 	assert(delete_count > 0);
-	for (uint32_t u = delete_count; u != 0; --u)
-		xrow_update_rope_erase(rope, op->field_no);
+	xrow_update_rope_erase(rope, op->field_no, delete_count);
 	return 0;
 }
 

--- a/test/unit/rope.c
+++ b/test/unit/rope.c
@@ -15,8 +15,7 @@ static inline void
 test_rope_cut(struct rope *rope, rope_size_t offset, rope_size_t size)
 {
 	printf("erase offset = %zu, size = %zu \n", (size_t) offset, (size_t) size);
-	while (size-- > 0)
-		rope_erase(rope, offset);
+	rope_erase(rope, offset, size);
 	rope_pretty_print(rope, str_print);
 	rope_check(rope);
 }

--- a/test/unit/rope.result
+++ b/test/unit/rope.result
@@ -178,9 +178,9 @@ string = 'You got four of guys all five fighting over who's gonna be<Mr.X>, Mr. 
    └──{ len = 30, height = 4, data = 'special> don't know each other'}
       │  ┌──{ len = 25, height = 1, data = ', so nobody wants to back'}
       └──{ len = 5, height = 3, data = ' down'}
-         │  ┌──{ len = 1, height = 1, data = '.'}
-         └──{ len = 6, height = 2, data = '<point'}
-            └──nil
+         │  ┌──nil
+         └──{ len = 1, height = 2, data = '.'}
+            └──{ len = 6, height = 1, data = '<point'}
 
 erase offset = 173, size = 1 
 size = 178
@@ -197,9 +197,9 @@ string = 'You got four of guys all five fighting over who's gonna be<Mr.X>, Mr. 
    └──{ len = 30, height = 4, data = 'special> don't know each other'}
       │  ┌──{ len = 25, height = 1, data = ', so nobody wants to back'}
       └──{ len = 5, height = 3, data = ' down'}
-         │  ┌──{ len = 1, height = 1, data = '.'}
-         └──{ len = 5, height = 2, data = 'point'}
-            └──nil
+         │  ┌──nil
+         └──{ len = 1, height = 2, data = '.'}
+            └──{ len = 5, height = 1, data = 'point'}
 
 erase offset = 58, size = 7 
 size = 171
@@ -214,9 +214,9 @@ string = 'You got four of guys all five fighting over who's gonna be Mr. <black!
    │  ┌──{ len = 30, height = 2, data = 'special> don't know each other'}
    │  │  └──{ len = 25, height = 1, data = ', so nobody wants to back'}
    └──{ len = 5, height = 3, data = ' down'}
-      │  ┌──{ len = 1, height = 1, data = '.'}
-      └──{ len = 5, height = 2, data = 'point'}
-         └──nil
+      │  ┌──nil
+      └──{ len = 1, height = 2, data = '.'}
+         └──{ len = 5, height = 1, data = 'point'}
 
 erase offset = 63, size = 10 
 size = 161
@@ -233,9 +233,9 @@ string = 'You got four of guys all five fighting over who's gonna be Mr. Black, 
    │  ┌──{ len = 30, height = 3, data = 'special> don't know each other'}
    │  │  └──{ len = 25, height = 1, data = ', so nobody wants to back'}
    └──{ len = 5, height = 4, data = ' down'}
-      │  ┌──{ len = 1, height = 1, data = '.'}
-      └──{ len = 5, height = 2, data = 'point'}
-         └──nil
+      │  ┌──nil
+      └──{ len = 1, height = 2, data = '.'}
+         └──{ len = 5, height = 1, data = 'point'}
 
 erase offset = 79, size = 25 
 size = 136
@@ -252,9 +252,9 @@ string = 'You got four of guys all five fighting over who's gonna be Mr. Black, 
    │  ┌──{ len = 21, height = 3, data = 'don't know each other'}
    │  │  └──{ len = 25, height = 1, data = ', so nobody wants to back'}
    └──{ len = 5, height = 4, data = ' down'}
-      │  ┌──{ len = 1, height = 1, data = '.'}
-      └──{ len = 5, height = 2, data = 'point'}
-         └──nil
+      │  ┌──nil
+      └──{ len = 1, height = 2, data = '.'}
+         └──{ len = 5, height = 1, data = 'point'}
 
 erase offset = 25, size = 5 
 size = 131
@@ -271,9 +271,9 @@ string = 'You got four of guys all fighting over who's gonna be Mr. Black, but t
    │  ┌──{ len = 21, height = 3, data = 'don't know each other'}
    │  │  └──{ len = 25, height = 1, data = ', so nobody wants to back'}
    └──{ len = 5, height = 4, data = ' down'}
-      │  ┌──{ len = 1, height = 1, data = '.'}
-      └──{ len = 5, height = 2, data = 'point'}
-         └──nil
+      │  ┌──nil
+      └──{ len = 1, height = 2, data = '.'}
+         └──{ len = 5, height = 1, data = 'point'}
 
 erase offset = 126, size = 5 
 size = 126

--- a/test/unit/rope_basic.c
+++ b/test/unit/rope_basic.c
@@ -83,11 +83,16 @@ test_erase()
 	header();
 
 	struct rope *rope = test_rope_new();
-	rope_insert(rope, rope_size(rope), "a", 1);
-	test_rope_erase(rope, 0);
-	rope_insert(rope, rope_size(rope), "a", 1);
-	rope_insert(rope, rope_size(rope), "b", 1);
-	test_rope_erase(rope, 0);
+	rope_insert(rope, rope_size(rope), "abcdefjhij", 10);
+	test_rope_erase(rope, 4, 1);
+	/* Rope nodes are "abcd" "fjhij". */
+	test_rope_erase(rope, 3, 2);
+	/* Rope nodes are "abc" "jhij". */
+	test_rope_erase(rope, 4, 1);
+	/* Rope nodes are "abc" "j" "ij". */
+	test_rope_erase(rope, 2, 4);
+	/* Rope nodes are "ab". */
+	test_rope_erase(rope, 0, 2);
 
 	rope_delete(rope);
 

--- a/test/unit/rope_basic.result
+++ b/test/unit/rope_basic.result
@@ -126,14 +126,35 @@ string = '    *abc*    '
 
 	*** test_insert: done ***
 	*** test_erase ***
-erase offset = 0
+erase offset = 4, size = 1
+size = 9
+string = 'abcdfjhij'
+│  ┌──nil
+└──{ len = 4, height = 2, data = 'abcd'}
+   └──{ len = 5, height = 1, data = 'fjhij'}
+
+erase offset = 3, size = 2
+size = 7
+string = 'abcjhij'
+│  ┌──nil
+└──{ len = 3, height = 2, data = 'abc'}
+   └──{ len = 4, height = 1, data = 'jhij'}
+
+erase offset = 4, size = 1
+size = 6
+string = 'abcjij'
+│  ┌──{ len = 3, height = 1, data = 'abc'}
+└──{ len = 1, height = 2, data = 'j'}
+   └──{ len = 2, height = 1, data = 'ij'}
+
+erase offset = 2, size = 4
+size = 2
+string = 'ab'
+└──{ len = 2, height = 1, data = 'ab'}
+
+erase offset = 0, size = 2
 size = 0
 string = ''
 └──nil
-
-erase offset = 0
-size = 1
-string = 'b'
-└──{ len = 1, height = 1, data = 'b'}
 
 	*** test_erase: done ***

--- a/test/unit/rope_common.h
+++ b/test/unit/rope_common.h
@@ -75,10 +75,10 @@ test_rope_insert(struct rope *rope, rope_size_t offset, char *str)
 }
 
 static inline void
-test_rope_erase(struct rope *rope, rope_size_t offset)
+test_rope_erase(struct rope *rope, rope_size_t offset, rope_size_t size)
 {
-	printf("erase offset = %zu\n", (size_t) offset);
-	rope_erase(rope, offset);
+	printf("erase offset = %u, size = %u\n", offset, size);
+	rope_erase(rope, offset, size);
 	rope_pretty_print(rope, str_print);
 	rope_check(rope);
 }

--- a/test/unit/rope_stress.c
+++ b/test/unit/rope_stress.c
@@ -1,6 +1,10 @@
 #include <time.h>
-#include "unit.h"
+
 #include "rope_common.h"
+#include "trivia/util.h"
+
+#define UNIT_TAP_COMPATIBLE 1
+#include "unit.h"
 
 static char *data[] = {"a", "bc", "def", "ghij", "klmno"};
 
@@ -22,10 +26,10 @@ test_rope_stress_small()
 		rope_check(rope);
 		size = rope_size(rope);
 		offset = ((rope_size_t) rand()) % size;
-		if (offset == size)
-			offset--;
-		rope_erase(rope, offset);
-		fail_unless(size == rope_size(rope) + 1);
+		rope_size_t del_size = (rope_size_t)1 + rand() % 4;
+		del_size = MIN(del_size, size - offset);
+		rope_erase(rope, offset, del_size);
+		fail_unless(size == rope_size(rope) + del_size);
 		rope_check(rope);
 	}
 	rope_delete(rope);
@@ -50,10 +54,10 @@ test_rope_stress_large()
 		fail_unless(size + len == rope_size(rope));
 		size = rope_size(rope);
 		offset = ((rope_size_t) rand()) % size;
-		if (offset == size)
-			offset--;
-		rope_erase(rope, offset);
-		fail_unless(size == rope_size(rope) + 1);
+		rope_size_t del_size = (rope_size_t)1 + rand() % 4;
+		del_size = MIN(del_size, size - offset);
+		rope_erase(rope, offset, del_size);
+		fail_unless(size == rope_size(rope) + del_size);
 		if (i % 1000 == 0)
 			rope_check(rope);
 	}
@@ -64,8 +68,12 @@ test_rope_stress_large()
 int
 main()
 {
+	plan(0);
+
 	srand(time(NULL));
 	test_rope_stress_small();
 	test_rope_stress_large();
-	return 0;
+
+	footer();
+	return check_plan();
 }

--- a/test/unit/rope_stress.result
+++ b/test/unit/rope_stress.result
@@ -1,4 +1,0 @@
-	*** test_rope_stress_small ***
-	*** test_rope_stress_small: done ***
-	*** test_rope_stress_large ***
-	*** test_rope_stress_large: done ***


### PR DESCRIPTION
We are going to use rope for representation of string field on tuple update. It will help to handle multiple updates of the same string field in the single update operation.

Currently rope erase operation can only remove single element at a time which make erase complexity `S*log2(N)`. Here `S` is number or deleted elements and `N` is number of nodes in the rope. This patch changes rope API to delete given number of elements at a time. Now complexity is `K*log2(N)` when `K` is number of nodes where deleted elements resides.

Note that implementation is still suboptimal for the case when deleted elements reside in more then a single node. First the implementation searches every next node from the root of the tree. Second the balancing rotations are performed on every node deletion.

As for the first issue it can be fixed merely by traversing to the next node instead. Unfortunately the traversing code works with single level of indirection while erasion works with two levels of indirection. We can duplicate the code/use macros/copy to handle the difference but all the possibilities are rather ugly so traversal on erasion is not done. Anyway looks like sane update usage will erase from a single node every time.

Part of #8226 

NO_DOC=internal
NO_CHANGELOG=internal