### PR TITLE
lua: introduce module triggers

### DIFF
--- a/changelogs/unreleased/gh-8656-trigger-registry.md
+++ b/changelogs/unreleased/gh-8656-trigger-registry.md
@@ -1,0 +1,4 @@
+## feature/lua
+
+* Introduced the new Lua module `trigger`. This module enables managing and
+  calling triggers stored in trigger registry (gh-8656).

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -278,6 +278,7 @@ set(box_sources
     lua/iproto.c
     lua/func_adapter.c
     lua/tuple_format.c
+    lua/trigger.c
     ${bin_sources})
 
 if(ENABLE_AUDIT_LOG)

--- a/src/box/lua/func_adapter.c
+++ b/src/box/lua/func_adapter.c
@@ -224,6 +224,16 @@ func_adapter_lua_destroy(struct func_adapter *func_base)
 	free(func);
 }
 
+void
+func_adapter_lua_get_func(struct func_adapter *func, lua_State *L)
+{
+	assert(func != NULL);
+	assert(func->vtab->destroy == func_adapter_lua_destroy);
+	struct func_adapter_lua *lua_func =
+		(struct func_adapter_lua *)func;
+	lua_rawgeti(L, LUA_REGISTRYINDEX, lua_func->func_ref);
+}
+
 struct func_adapter *
 func_adapter_lua_create(lua_State *L, int idx)
 {

--- a/src/box/lua/func_adapter.h
+++ b/src/box/lua/func_adapter.h
@@ -18,6 +18,12 @@ struct func_adapter;
 struct func_adapter *
 func_adapter_lua_create(struct lua_State *L, int idx);
 
+/**
+ * Pushes actual Lua function onto the stack.
+ */
+void
+func_adapter_lua_get_func(struct func_adapter *func, struct lua_State *L);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -76,6 +76,7 @@
 #include "box/lua/security.h"
 #include "box/lua/space_upgrade.h"
 #include "box/lua/wal_ext.h"
+#include "box/lua/trigger.h"
 
 #include "mpstream/mpstream.h"
 
@@ -775,6 +776,7 @@ box_lua_init(struct lua_State *L)
 	box_lua_read_view_init(L);
 	box_lua_security_init(L);
 	box_lua_flightrec_init(L);
+	box_lua_trigger_init(L);
 	luaopen_net_box(L);
 	lua_pop(L, 1);
 	tarantool_lua_console_init(L);

--- a/src/box/lua/trigger.c
+++ b/src/box/lua/trigger.c
@@ -1,0 +1,255 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
+ */
+
+#include "box/lua/func_adapter.h"
+#include "core/event.h"
+#include <diag.h>
+#include <fiber.h>
+#include "lua/utils.h"
+
+/**
+ * Sets a trigger with passed name to the passed event.
+ * The first argument is event name, the second one is trigger name, the third
+ * one is new trigger handler - it can be a Lua function or another callable
+ * object. If there is an already registered trigger with such name in the
+ * event, it is replaced with new trigger.
+ * Returns new trigger handler (which was passed as the third argument).
+ */
+static int
+luaT_trigger_set(struct lua_State *L)
+{
+	if (lua_gettop(L) != 3)
+		luaL_error(L, "Usage: trigger.set(event, trigger, function)");
+	const char *event_name = luaL_checkstring(L, 1);
+	const char *trigger_name = luaL_checkstring(L, 2);
+	if (!luaL_iscallable(L, 3))
+		luaL_typerror(L, 3, "callable");
+	/*
+	 * The following code is written in assumption no error will be thrown.
+	 */
+	struct event *event = event_get(event_name, true);
+	assert(event != NULL);
+	struct func_adapter *func = func_adapter_lua_create(L, 3);
+	event_reset_trigger(event, trigger_name, func);
+	/* The new handler is still at the top of the stack. */
+	return 1;
+}
+
+/**
+ * Deletes a trigger with passed name from passed event.
+ * The first argument is event name, the second one is trigger name.
+ * Returns deleted trigger handler.
+ */
+static int
+luaT_trigger_del(struct lua_State *L)
+{
+	if (lua_gettop(L) != 2)
+		luaL_error(L, "Usage: trigger.del(event, trigger)");
+	const char *event_name = luaL_checkstring(L, 1);
+	const char *trigger_name = luaL_checkstring(L, 2);
+	struct event *event = event_get(event_name, false);
+	if (event == NULL)
+		return 0;
+	struct func_adapter *old = event_find_trigger(event, trigger_name);
+	if (old == NULL)
+		return 0;
+	func_adapter_lua_get_func(old, L);
+	event_reset_trigger(event, trigger_name, NULL);
+	return 1;
+}
+
+/**
+ * Calls all the triggers registered on passed event with variable number of
+ * arguments. Execution is stopped by a first exception.
+ * First argument must be a string - all the other arguments will be passed
+ * to the triggers without any processing or copying.
+ * Returns no values on success. If one of the triggers threw an error, it is
+ * raised again.
+ */
+static int
+luaT_trigger_call(struct lua_State *L)
+{
+	if (lua_gettop(L) < 1)
+		luaL_error(L, "Usage: trigger.call(event, [args...])");
+	const char *event_name = luaL_checkstring(L, 1);
+	struct event *event = event_get(event_name, false);
+	if (event == NULL)
+		return 0;
+	int top = lua_gettop(L);
+	int narg = top - 1;
+	struct event_trigger_iterator it;
+	event_trigger_iterator_create(&it, event);
+	struct func_adapter *trigger = NULL;
+	const char *name = NULL;
+	int rc = 0;
+	while (rc == 0 && event_trigger_iterator_next(&it, &trigger, &name)) {
+		func_adapter_lua_get_func(trigger, L);
+		for (int i = top - narg + 1; i <= top; ++i)
+			lua_pushvalue(L, i);
+		rc = luaT_call(L, narg, 0);
+	}
+	event_trigger_iterator_destroy(&it);
+	if (rc != 0)
+		return luaT_error(L);
+	return 0;
+}
+
+/**
+ * Sets an array of arrays [trigger_name, trigger_handler] by event->name key
+ * in a pre-created table. Never sets an empty array.
+ */
+static bool
+trigger_info_push_event(struct event *event, void *arg)
+{
+	lua_State *L = (lua_State *)arg;
+	struct event_trigger_iterator it;
+	struct func_adapter *trigger = NULL;
+	const char *name = NULL;
+	int idx = 0;
+	lua_createtable(L, 0, 0);
+	event_trigger_iterator_create(&it, event);
+	while (event_trigger_iterator_next(&it, &trigger, &name)) {
+		idx++;
+		lua_createtable(L, 2, 0);
+		lua_pushstring(L, name);
+		lua_rawseti(L, -2, 1);
+		func_adapter_lua_get_func(trigger, L);
+		lua_rawseti(L, -2, 2);
+		lua_rawseti(L, -2, idx);
+	}
+	event_trigger_iterator_destroy(&it);
+	lua_setfield(L, -2, event->name);
+	return true;
+}
+
+/**
+ * Pushes a key-value table, where the key is the event name and value is an
+ * array of triggers, represented by two-element [trigger_name, trigger_handler]
+ * arrays, registered on this event, in the order in which they will be called.
+ * If an event name is passed, a table contains only one key which is passed
+ * argument, if there is an event with such a name, or returned table is empty,
+ * if the event does not exist.
+ */
+static int
+luaT_trigger_info(struct lua_State *L)
+{
+	if (lua_gettop(L) > 1)
+		luaL_error(L, "Usage: trigger.info([event])");
+	if (lua_gettop(L) == 0) {
+		lua_createtable(L, 0, 0);
+		bool ok = event_foreach(trigger_info_push_event, L);
+		assert(ok);
+		(void)ok;
+	} else {
+		const char *event_name = luaL_checkstring(L, 1);
+		struct event *event = event_get(event_name, false);
+		if (event == NULL || !event_has_triggers(event)) {
+			lua_createtable(L, 0, 0);
+			return 1;
+		}
+		lua_createtable(L, 0, 1);
+		trigger_info_push_event(event, L);
+	}
+	return 1;
+}
+
+static const char *event_trigger_iterator_typename =
+	"trigger.event_trigger_iterator";
+
+/**
+ * Gets event_trigger_iterator from Lua stack with type check.
+ */
+static inline struct event_trigger_iterator *
+luaT_check_event_trigger_iterator(struct lua_State *L, int idx)
+{
+	return luaL_checkudata(L, idx, event_trigger_iterator_typename);
+}
+
+/**
+ * Takes an iterator step.
+ */
+static int
+luaT_trigger_iterator_next(struct lua_State *L)
+{
+	struct event_trigger_iterator *it =
+		luaT_check_event_trigger_iterator(L, 1);
+	struct func_adapter *trigger = NULL;
+	const char *name = NULL;
+	if (event_trigger_iterator_next(it, &trigger, &name)) {
+		lua_pushstring(L, name);
+		func_adapter_lua_get_func(trigger, L);
+		return 2;
+	}
+	return 0;
+}
+
+/**
+ * Takes an iterator step of exhausted iterator.
+ */
+static int
+luaT_trigger_iterator_next_exhausted(struct lua_State *L)
+{
+	(void)L;
+	return 0;
+}
+
+/**
+ * Destroys an iterator.
+ */
+static int
+luaT_trigger_iterator_gc(struct lua_State *L)
+{
+	struct event_trigger_iterator *it =
+		luaT_check_event_trigger_iterator(L, 1);
+	event_trigger_iterator_destroy(it);
+	TRASH(it);
+	return 0;
+}
+
+/**
+ * Creates iterator over triggers of event with passed name.
+ * The iterator yields a pair [trigger_name, trigger_handler].
+ * Return next method of iterator and iterator itself.
+ */
+static int
+luaT_trigger_pairs(struct lua_State *L)
+{
+	if (lua_gettop(L) != 1)
+		luaL_error(L, "Usage: trigger.pairs(event)");
+	const char *event_name = luaL_checkstring(L, 1);
+	struct event *event = event_get(event_name, false);
+	if (event == NULL) {
+		lua_pushcfunction(L, luaT_trigger_iterator_next_exhausted);
+		return 1;
+	}
+	lua_pushcfunction(L, luaT_trigger_iterator_next);
+	struct event_trigger_iterator *it = lua_newuserdata(L, sizeof(*it));
+	event_trigger_iterator_create(it, event);
+	luaL_getmetatable(L, event_trigger_iterator_typename);
+	lua_setmetatable(L, -2);
+	return 2;
+}
+
+void
+box_lua_trigger_init(struct lua_State *L)
+{
+	const struct luaL_Reg module_funcs[] = {
+		{"set", luaT_trigger_set},
+		{"del", luaT_trigger_del},
+		{"call", luaT_trigger_call},
+		{"info", luaT_trigger_info},
+		{"pairs", luaT_trigger_pairs},
+		{NULL, NULL}
+	};
+	luaT_newmodule(L, "trigger", module_funcs);
+	lua_pop(L, 1);
+	const struct luaL_Reg trigger_iterator_methods[] = {
+		{"__gc", luaT_trigger_iterator_gc},
+		{NULL, NULL}
+	};
+	luaL_register_type(L, event_trigger_iterator_typename,
+			   trigger_iterator_methods);
+}

--- a/src/box/lua/trigger.h
+++ b/src/box/lua/trigger.h
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+/**
+ * Initializes module trigger.
+ */
+void
+box_lua_trigger_init(struct lua_State *L);
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */

--- a/src/lib/core/CMakeLists.txt
+++ b/src/lib/core/CMakeLists.txt
@@ -46,6 +46,7 @@ set(core_sources
     cord_on_demand.cc
     tweaks.c
     tt_sort.c
+    event.c
 )
 
 if (ENABLE_BACKTRACE)

--- a/src/lib/core/event.c
+++ b/src/lib/core/event.c
@@ -1,0 +1,337 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include "event.h"
+
+#include <assert.h>
+
+#include "assoc.h"
+#include "diag.h"
+#include "trivia/util.h"
+#include "func_adapter.h"
+
+/** Registry of all events: name -> event. */
+static struct mh_strnptr_t *event_registry;
+
+/**
+ * A named node of the list, containing func_adapter. Every event_trigger is
+ * associated with an event. Since event_triggers have completely different
+ * call interface, they are not inherited from core triggers.
+ */
+struct event_trigger {
+	/** A link in a list of all registered event triggers. */
+	struct rlist link;
+	/** Trigger function. */
+	struct func_adapter *func;
+	/** Backlink to event. Needed for reference count of event. */
+	struct event *event;
+	/** Unique name of the trigger. */
+	char *name;
+	/** Trigger reference counter. */
+	uint32_t ref_count;
+	/** This flag is set when the trigger is deleted. */
+	bool is_deleted;
+};
+
+/**
+ * Creates event_trigger from func_adapter and name and binds it to passed
+ * event. Created trigger owns the adapter and will destroy it in its
+ * destructor. Passed name must be zero terminated and will be copied.
+ * Passed event must not be NULL and will be referenced by created trigger.
+ * Note that the function does not increment trigger_count field of the event.
+ */
+static struct event_trigger *
+event_trigger_new(struct func_adapter *func, struct event *event,
+		  const char *name)
+{
+	assert(name != NULL);
+	assert(event != NULL);
+	size_t name_len = strlen(name);
+	struct event_trigger *trigger =
+		xmalloc(sizeof(*trigger) + name_len + 1);
+	trigger->func = func;
+	trigger->name = (char *)(trigger + 1);
+	strlcpy(trigger->name, name, name_len + 1);
+	trigger->ref_count = 0;
+	trigger->is_deleted = false;
+	trigger->event = event;
+	event_ref(event);
+	rlist_create(&trigger->link);
+	return trigger;
+}
+
+/**
+ * Destroys an event_trigger. Underlying func_adapter is destroyed,
+ * event_trigger is deallocated.
+ */
+static void
+event_trigger_delete(struct event_trigger *trigger)
+{
+	assert(trigger->func != NULL);
+	assert(trigger->event != NULL);
+	rlist_del(&trigger->link);
+	event_unref(trigger->event);
+	func_adapter_destroy(trigger->func);
+	TRASH(trigger);
+	free(trigger);
+}
+
+/**
+ * Increments event_trigger reference counter.
+ */
+static void
+event_trigger_ref(struct event_trigger *trigger)
+{
+	trigger->ref_count++;
+}
+
+/**
+ * Decrements event_trigger reference counter. The event_trigger is destroyed
+ * if the counter reaches zero.
+ */
+static void
+event_trigger_unref(struct event_trigger *trigger)
+{
+	assert(trigger != NULL);
+	assert(trigger->ref_count > 0);
+	trigger->ref_count--;
+	assert(trigger->ref_count > 0 || trigger->is_deleted);
+	if (trigger->ref_count == 0)
+		event_trigger_delete(trigger);
+}
+
+/**
+ * Allocates, initializes a new event and inserts it to event registry.
+ * Passed name will be copied.
+ */
+static struct event *
+event_new(const char *name, size_t name_len)
+{
+	assert(name != NULL);
+	assert(name_len > 0);
+	struct event *event = xmalloc(sizeof(*event) + name_len + 1);
+	rlist_create(&event->triggers);
+	event->ref_count = 0;
+	event->trigger_count = 0;
+	event->name = (char *)(event + 1);
+	strlcpy(event->name, name, name_len + 1);
+
+	struct mh_strnptr_t *h = event_registry;
+	name = event->name;
+	uint32_t name_hash = mh_strn_hash(name, name_len);
+	struct mh_strnptr_node_t node = {name, name_len, name_hash, event};
+	struct mh_strnptr_node_t prev;
+	struct mh_strnptr_node_t *prev_ptr = &prev;
+	mh_int_t pos = mh_strnptr_put(h, &node, &prev_ptr, NULL);
+	(void)pos;
+	assert(pos != mh_end(h));
+	assert(prev_ptr == NULL);
+
+	return event;
+}
+
+/**
+ * Destroys an event and removes it from event registry.
+ * Underlying trigger list is destroyed.
+ */
+void
+event_delete(struct event *event)
+{
+	assert(event != NULL);
+
+	struct mh_strnptr_t *h = event_registry;
+	const char *name = event->name;
+	size_t name_len = strlen(name);
+	mh_int_t i = mh_strnptr_find_str(h, name, name_len);
+	assert(i != mh_end(h));
+	assert(mh_strnptr_node(h, i)->val == event);
+	mh_strnptr_del(h, i, 0);
+	TRASH(event);
+	free(event);
+}
+
+/**
+ * Finds internal event_trigger entity by name in the event.
+ * All arguments must not be NULL.
+ */
+static struct event_trigger *
+event_find_trigger_internal(struct event *event, const char *name)
+{
+	struct event_trigger *curr = NULL;
+	rlist_foreach_entry(curr, &event->triggers, link) {
+		if (!curr->is_deleted && strcmp(curr->name, name) == 0)
+			return curr;
+	}
+	return NULL;
+}
+
+struct func_adapter *
+event_find_trigger(struct event *event, const char *name)
+{
+	struct event_trigger *trigger =
+		event_find_trigger_internal(event, name);
+	return trigger != NULL ? trigger->func : NULL;
+}
+
+void
+event_reset_trigger(struct event *event, const char *name,
+		    struct func_adapter *new_trigger)
+{
+	assert(event != NULL);
+	assert(name != NULL);
+	struct event_trigger *found_trigger =
+		event_find_trigger_internal(event, name);
+	if (new_trigger != NULL) {
+		event->trigger_count++;
+		struct event_trigger *trigger =
+			event_trigger_new(new_trigger, event, name);
+		event_trigger_ref(trigger);
+		if (found_trigger == NULL) {
+			rlist_add_entry(&event->triggers, trigger, link);
+		} else {
+			/*
+			 * Insert new trigger before the replaced one not to
+			 * iterate over both of them in the case when an
+			 * iterator points to a replaced trigger.
+			 */
+			rlist_add_tail_entry(&found_trigger->link,
+					     trigger, link);
+		}
+	}
+	if (found_trigger != NULL) {
+		assert(event->trigger_count > 0);
+		event->trigger_count--;
+		found_trigger->is_deleted = true;
+		event_trigger_unref(found_trigger);
+	}
+}
+
+void
+event_trigger_iterator_create(struct event_trigger_iterator *it,
+			      struct event *event)
+{
+	event_ref(event);
+	it->event = event;
+	it->curr = &event->triggers;
+}
+
+bool
+event_trigger_iterator_next(struct event_trigger_iterator *it,
+			    struct func_adapter **func, const char **name)
+{
+	assert(func != NULL);
+	assert(name != NULL);
+
+	*func = NULL;
+	*name = NULL;
+	/* Iterator is exhausted - return. */
+	if (it->curr == NULL)
+		return false;
+	struct event_trigger *trigger;
+	struct rlist *old = it->curr;
+	/* We need to skip all the deleted triggers. */
+	do {
+		it->curr = rlist_next(it->curr);
+		trigger = rlist_entry(it->curr, struct event_trigger, link);
+		/* We have traversed the whole list. */
+		if (it->curr == &it->event->triggers) {
+			it->curr = NULL;
+			trigger = NULL;
+			goto release;
+		}
+	} while (trigger->is_deleted);
+	assert(trigger != NULL);
+	event_trigger_ref(trigger);
+release:
+	if (old != NULL && old != &it->event->triggers) {
+		struct event_trigger *old_trigger =
+			rlist_entry(old, struct event_trigger, link);
+		assert(old_trigger != trigger);
+		event_trigger_unref(old_trigger);
+	}
+	if (trigger != NULL) {
+		*func = trigger->func;
+		*name = trigger->name;
+		return true;
+	}
+	return false;
+}
+
+void
+event_trigger_iterator_destroy(struct event_trigger_iterator *it)
+{
+	if (it->curr != NULL && it->curr != &it->event->triggers) {
+		struct event_trigger *curr_trigger =
+			rlist_entry(it->curr, struct event_trigger, link);
+		event_trigger_unref(curr_trigger);
+	}
+	event_unref(it->event);
+	it->event = NULL;
+	it->curr = NULL;
+}
+
+struct event *
+event_get(const char *name, bool create_if_not_exist)
+{
+	assert(event_registry != NULL);
+	assert(name != NULL);
+	struct mh_strnptr_t *h = event_registry;
+	uint32_t name_len = strlen(name);
+	mh_int_t i = mh_strnptr_find_str(h, name, name_len);
+	if (i != mh_end(h))
+		return mh_strnptr_node(h, i)->val;
+	else if (!create_if_not_exist)
+		return NULL;
+
+	struct event *event = event_new(name, name_len);
+	return event;
+}
+
+bool
+event_foreach(event_foreach_f cb, void *arg)
+{
+	struct mh_strnptr_t *h = event_registry;
+	mh_int_t i;
+	mh_foreach(h, i) {
+		struct mh_strnptr_node_t *node = mh_strnptr_node(h, i);
+		struct event *event = node->val;
+		if (!event_has_triggers(event))
+			continue;
+		if (!cb(event, arg))
+			return false;
+	}
+	return true;
+}
+
+void
+event_init(void)
+{
+	event_registry = mh_strnptr_new();
+}
+
+void
+event_free(void)
+{
+	assert(event_registry != NULL);
+	struct mh_strnptr_t *h = event_registry;
+	mh_int_t i;
+	mh_foreach(h, i) {
+		struct event *event = mh_strnptr_node(h, i)->val;
+		/*
+		 * If the only thing that holds the event is its trigger list,
+		 * the reference counter will reach zero when the list will be
+		 * cleared and the destructor will be called. Since we will
+		 * call destructor manually, let's reference the event in order
+		 * to prevent such situation.
+		 */
+		event_ref(event);
+		struct event_trigger *trigger, *tmp;
+		rlist_foreach_entry_safe(trigger, &event->triggers, link, tmp)
+			event_trigger_delete(trigger);
+		event_delete(event);
+	}
+	mh_strnptr_delete(h);
+	event_registry = NULL;
+}

--- a/src/lib/core/event.h
+++ b/src/lib/core/event.h
@@ -1,0 +1,162 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "small/rlist.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+struct func_adapter;
+
+/**
+ * List of triggers registered on event identified by name.
+ */
+struct event {
+	/** List of triggers. */
+	struct rlist triggers;
+	/** Name of event. */
+	char *name;
+	/** Reference count. */
+	uint32_t ref_count;
+	/** Number of triggers. */
+	uint32_t trigger_count;
+};
+
+/**
+ * Destroys an event and removes it from event registry.
+ * NB: The method is private and must not be called manually.
+ */
+void
+event_delete(struct event *event);
+
+/**
+ * Increments event reference counter.
+ */
+static inline void
+event_ref(struct event *event)
+{
+	event->ref_count++;
+}
+
+/**
+ * Decrements event reference counter. The event is destroyed if the counter
+ * reaches zero.
+ */
+static inline void
+event_unref(struct event *event)
+{
+	assert(event->ref_count > 0);
+	event->ref_count--;
+	if (event->ref_count == 0) {
+		assert(rlist_empty(&event->triggers));
+		assert(event->trigger_count == 0);
+		event_delete(event);
+	}
+}
+
+/**
+ * Checks if the event has no triggers.
+ */
+static inline bool
+event_has_triggers(struct event *event)
+{
+	return event->trigger_count > 0;
+}
+
+/**
+ * Finds a trigger by name in an event. All the arguments must not be NULL.
+ */
+struct func_adapter *
+event_find_trigger(struct event *event, const char *name);
+
+/**
+ * Resets trigger by name in an event.
+ * Arguments event and name must not be NULL.
+ * If new_trigger is NULL, the function removes a trigger by name from the
+ * event. Otherwise, it replaces trigger by name or inserts it in the beginning
+ * of the underlying list of event.
+ */
+void
+event_reset_trigger(struct event *event, const char *name,
+		    struct func_adapter *new_trigger);
+
+/**
+ * Iterator over triggers from event. Never invalidates.
+ */
+struct event_trigger_iterator {
+	/**
+	 * Current element in the list of triggers.
+	 * Becomes NULL when the iterator is exhausted.
+	 */
+	struct rlist *curr;
+	/** Underlying event. */
+	struct event *event;
+};
+
+/**
+ * Initializes iterator.
+ */
+void
+event_trigger_iterator_create(struct event_trigger_iterator *it,
+			      struct event *event);
+
+/**
+ * Advances iterator. Output arguments trigger and name must not be NULL.
+ */
+bool
+event_trigger_iterator_next(struct event_trigger_iterator *it,
+			    struct func_adapter **trigger, const char **name);
+
+/**
+ * Deinitializes iterator. Does not free memory.
+ */
+void
+event_trigger_iterator_destroy(struct event_trigger_iterator *it);
+
+/**
+ * Finds an event by its name. Name must be a zero-terminated string.
+ * Creates new event and inserts it to registry if there is no event with such
+ * name when flag create_if_not_exist is true.
+ */
+struct event *
+event_get(const char *name, bool create_if_not_exist);
+
+typedef bool
+event_foreach_f(struct event *event, void *arg);
+
+/**
+ * Invokes a callback for each registered event with no particular order.
+ *
+ * The callback is passed an event object and the given argument.
+ * If it returns true, iteration continues. Otherwise, iteration breaks, and
+ * the function returns false.
+ *
+ * Empty events are guaranteed to be skipped.
+ */
+bool
+event_foreach(event_foreach_f cb, void *arg);
+
+/**
+ * Initializes event submodule.
+ */
+void
+event_init(void);
+
+/**
+ * Frees event submodule.
+ */
+void
+event_free(void);
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */

--- a/src/lib/core/func_adapter.h
+++ b/src/lib/core/func_adapter.h
@@ -5,9 +5,12 @@
  */
 #pragma once
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
+
+#include "trivia/util.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/main.cc
+++ b/src/main.cc
@@ -88,6 +88,7 @@
 #include "core/errinj.h"
 #include "core/clock_lowres.h"
 #include "lua/utils.h"
+#include "core/event.h"
 
 static pid_t master_pid = getpid();
 static struct pidfh *pid_file_handle;
@@ -592,6 +593,7 @@ tarantool_free(void)
 	session_free();
 	user_cache_free();
 #endif
+	event_free();
 	ssl_free();
 	memtx_tx_manager_free();
 	coll_free();
@@ -875,6 +877,7 @@ main(int argc, char **argv)
 	memtx_tx_manager_init();
 	module_init();
 	ssl_init();
+	event_init();
 	systemd_init();
 
 	const int override_cert_paths_env_vars = 0;

--- a/test/app-luatest/trigger_module_test.lua
+++ b/test/app-luatest/trigger_module_test.lua
@@ -1,0 +1,513 @@
+local t = require('luatest')
+
+local g = t.group()
+
+local ffi_monotonic_id = 0
+
+-- Helper that generates callable table, userdata and cdata
+local function generate_callable_objects(handler)
+    local ffi = require('ffi')
+    local a = {}
+    local mt = {__call = handler}
+    setmetatable(a, mt)
+
+    local b = newproxy(true)
+    mt = getmetatable(b)
+    mt.__call = handler
+
+    ffi_monotonic_id = ffi_monotonic_id + 1
+    local struct_name = string.format('foo%d', ffi_monotonic_id)
+    ffi.cdef(string.format('struct %s { int x; }', struct_name))
+    mt = {__call = handler}
+    ffi.metatype(string.format('struct %s', struct_name), mt)
+    local c = ffi.new(string.format('struct %s', struct_name), {x = 42})
+    return a, b, c
+end
+
+-- Basic functionality - set, delete and call with function handler
+g.test_simple = function()
+    local trigger = require('trigger')
+
+    local event = "my_events[15].subevent.event"
+    local name = "my_triggers[4352].subtriggers.trigger"
+    local state = 0
+    local function handler(new_state)
+        if new_state == nil then new_state = 1 end
+        state = new_state
+    end
+    local ret_handler = trigger.set(event, name, handler)
+    t.assert_equals(ret_handler, handler)
+    trigger.call(event)
+    t.assert_equals(state, 1)
+
+    trigger.call(event, 42)
+    t.assert_equals(state, 42)
+    ret_handler = trigger.del(event, name)
+    t.assert_equals(ret_handler, handler)
+
+    state = 0
+    trigger.call(event)
+    t.assert_equals(state, 0)
+
+    -- Check that deletion of nothing does not throw an error and returns nil
+    ret_handler = trigger.del(event, name)
+    t.assert_equals(ret_handler, nil)
+end
+
+-- Check that all the triggers are called in the reverse order
+-- of their installation and share the object as argument
+g.test_order_and_shared_argument = function()
+    local trigger = require('trigger')
+
+    local event = "my_event"
+    local name_prefix = "my_triggers."
+    local function h1(arg)
+        t.assert_equals(arg, {})
+        arg[1] = 1
+    end
+    local function h2(arg)
+        t.assert_equals(arg, {1})
+        arg[2] = 2
+    end
+    local function h3(arg)
+        t.assert_equals(arg, {1, 2})
+        arg[3] = 3
+    end
+    trigger.set(event, name_prefix .. '3', h3)
+    trigger.set(event, name_prefix .. '2', h2)
+    trigger.set(event, name_prefix .. '1', h1)
+    local arg = {}
+    trigger.call(event, arg)
+    t.assert_equals(arg, {1, 2, 3})
+    for i = 1, 3 do
+        trigger.del(event, name_prefix .. tostring(i))
+    end
+end
+
+-- Check that handler is not copied
+g.test_shared_handler = function()
+    local trigger = require('trigger')
+
+    local event = "my_event"
+    local name = "my_triggers"
+    local state = 0
+    local function handler(self)
+        state = self.value
+    end
+    local a = {}
+    local mt = {__call = handler}
+    setmetatable(a, mt)
+    trigger.set(event, name, a)
+    for i = 1, 20 do
+        a.value = i
+        trigger.call(event)
+        t.assert_equals(state, i)
+    end
+
+    trigger.del(event, name)
+end
+
+-- Check that both Lua and Tarantool exceptions are supported and
+-- trigger.call method stops the execution after the first exception.
+g.test_exceptions = function()
+    local trigger = require('trigger')
+
+    local event = "my_event"
+    local name_prefix = "my_triggers."
+    local lua_err = 'Just a Lua error'
+    local tnt_err = 'Just a Tarantool error'
+    local state = 0
+    local function h1()
+        state = state + 1
+    end
+    local function h2(cmd)
+        if cmd == 'throw lua' or cmd == 'throw' then
+            error(lua_err)
+        end
+    end
+    local function h3(cmd)
+        if cmd == 'throw tnt' or cmd == 'throw' then
+            box.error{reason = tnt_err, errcode = 42}
+        end
+    end
+    trigger.set(event, name_prefix .. '1', h1)
+    trigger.call(event)
+    t.assert_equals(state, 1)
+    state = 0
+    trigger.set(event, name_prefix .. '2', h2)
+    local success = pcall(trigger.call, event)
+    t.assert(success)
+    t.assert_equals(state, 1)
+    state = 0
+    t.assert_error_msg_content_equals(lua_err, trigger.call, event, 'throw')
+    t.assert_equals(state, 0)
+
+    trigger.set(event, name_prefix .. '3', h3)
+    success = pcall(trigger.call, event)
+    t.assert(success)
+    t.assert_equals(state, 1)
+    state = 0
+    t.assert_error_msg_content_equals(tnt_err, trigger.call, event, 'throw')
+    t.assert_equals(state, 0)
+
+    t.assert_error_msg_content_equals(lua_err, trigger.call, event, 'throw lua')
+    t.assert_equals(state, 0)
+    t.assert_error_msg_content_equals(tnt_err, trigger.call, event, 'throw tnt')
+    t.assert_equals(state, 0)
+
+    for i = 1, 3 do
+        trigger.del(event, name_prefix .. tostring(i))
+    end
+end
+
+-- Check that any callable object can be registered as a trigger
+g.test_any_callable_trigger = function()
+    local trigger = require('trigger')
+
+    local event = "my_event"
+    local name = "my_trigger"
+    local state = 0
+    local function handler(self, inc)
+        if inc == nil then inc = 1 end
+        state = state + inc
+    end
+
+    local function check_object(obj)
+        local ret_handler = trigger.set(event, name, obj)
+        t.assert_equals(ret_handler, obj)
+        state = 0
+        local new_state = math.random(1, 100)
+        trigger.call(event, new_state)
+        t.assert_equals(state, new_state)
+        trigger.del(event, name)
+    end
+
+    local a, b, c = generate_callable_objects(handler)
+
+    -- Callable table
+    check_object(a)
+    local mt = getmetatable(a)
+    mt.__metatable = "Private"
+    check_object(a)
+
+    -- Callable userdata
+    check_object(b)
+    mt = getmetatable(b)
+    mt.__metatable = "Private"
+    check_object(a)
+
+    -- Callable cdata
+    check_object(c)
+    -- Cdata metatable is already protected so a special check is not required
+end
+
+g.test_trigger_clear_from_trigger = function()
+    local trigger = require('trigger')
+    local event = "test_trigger_clear_event"
+    local order = {}
+    local f2 = function()
+        table.insert(order, 2)
+    end
+    local f1 = function()
+        table.insert(order, 1)
+        trigger.del(event, 'f2')
+        trigger.del(event, 'f1')
+    end
+    trigger.set(event, 'f2', f2)
+    trigger.set(event, 'f1', f1)
+    trigger.call(event)
+    t.assert_equals(order, {1}, "Correct trigger invocation when 1st trigger \
+                                 clears 2nd")
+end
+
+g.test_pairs = function()
+    local trigger = require('trigger')
+
+    local state = 0
+    local function handler(inc)
+        state = state + inc
+    end
+    local function handler_method(self, inc)
+        state = state + inc
+    end
+    local a, b, c = generate_callable_objects(handler_method)
+    local handlers = {handler, c, b, a, handler, c, a, handler, b, handler}
+    local event = 'event_name'
+    local trigger_prefix = 'trigger_name.'
+
+    -- Event is empty so no triggers must be traversed.
+    for _, _ in trigger.pairs(event) do
+        t.assert(false)
+    end
+
+    for i = #handlers, 1, -1 do
+        trigger.set(event, trigger_prefix..tostring(i),  handlers[i])
+    end
+
+    local idx = 0
+    local sum = 0
+    for name, h in trigger.pairs(event) do
+        idx = idx + 1
+        sum = sum + idx
+        t.assert_equals(name, trigger_prefix .. tostring(idx))
+        t.assert_equals(h, handlers[idx])
+        h(idx)
+    end
+    t.assert_equals(idx, #handlers)
+    t.assert_equals(state, sum)
+    for i = 1, #handlers do
+        trigger.del(event, trigger_prefix .. tostring(i))
+    end
+end
+
+-- Check that a trigger deleted during pairs does not break anything and
+-- isn't yielded by pairs after its deletion.
+g.test_del_during_pairs = function()
+    local trigger = require('trigger')
+
+    local event = 'del_during_pairs_event'
+    local trigger_num = 10
+    local break_point = math.random(2, trigger_num - 1)
+    local history = {}
+    local function handler_method(self)
+        table.insert(history, self.id)
+    end
+    local mt = {__call = handler_method}
+    for i = trigger_num, 1, -1 do
+        local a = {id = i}
+        setmetatable(a, mt)
+        trigger.set(event, tostring(i), a)
+    end
+
+    local idx = 0
+    local iter = {trigger.pairs(event)}
+    for _, handler in unpack(iter) do
+        idx = idx + 1
+        handler()
+        if idx == break_point then
+            break
+        end
+    end
+    trigger.del(event, tostring(math.random(1, break_point)))
+    trigger.del(event, tostring(break_point))
+    local deleted_id = math.random(break_point + 1, trigger_num)
+    trigger.del(event, tostring(deleted_id))
+
+    for _, handler in unpack(iter) do
+        handler()
+    end
+
+    t.assert_equals(#history, trigger_num - 1)
+    local history_idx = 0
+    for i = 1, trigger_num do
+        if i ~= deleted_id then
+            history_idx = history_idx + 1
+            t.assert_equals(history[history_idx], i)
+            trigger.del(event, tostring(i))
+        end
+    end
+end
+
+-- Check that pairs is successfully stopped after all triggers registered
+-- on the event are dropped
+g.test_clear_event_during_pairs = function()
+    local trigger = require('trigger')
+
+    local event = 'clear_during_pairs_event'
+    local trigger_num = 10
+    local break_point = math.random(2, trigger_num - 1)
+
+    local history = {}
+    local function handler_method(self)
+        table.insert(history, self.id)
+    end
+    local mt = {__call = handler_method}
+    for i = trigger_num, 1, -1 do
+        local a = {id = i}
+        setmetatable(a, mt)
+        trigger.set(event, tostring(i), a)
+    end
+
+    local idx = 0
+    local iter = {trigger.pairs(event)}
+    for _, handler in unpack(iter) do
+        idx = idx + 1
+        handler()
+        if idx == break_point then
+            break
+        end
+    end
+
+    for i = 1, trigger_num do
+        trigger.del(event, tostring(i))
+    end
+
+    for _, handler in unpack(iter) do
+        handler()
+    end
+
+    t.assert_equals(#history, break_point)
+    for i = 1, break_point do
+        t.assert_equals(history[i], i)
+    end
+end
+
+g.test_invalid_args = function()
+    local trigger = require('trigger')
+
+    local valid_name = "name"
+
+    local invalid_handlers = {nil, 42, 'abc', {}, {1, 2}, {k = 'v'}, box.NULL}
+    for _, h in pairs(invalid_handlers) do
+        local errmsg = string.format(
+            "bad argument #3 to '?' (callable expected, got %s)", type(h))
+        t.assert_error_msg_content_equals(errmsg, trigger.set, valid_name,
+            valid_name, h)
+    end
+
+    local handler = function() return true end
+    local invalid_names = {nil, {}, {1, 2}, {k = 'v'}, box.NULL, handler}
+    for _, invalid_name in pairs(invalid_names) do
+        local errmsg = string.format(
+            "bad argument #2 to '?' (string expected, got %s)",
+            type(invalid_name))
+        t.assert_error_msg_content_equals(
+            errmsg, trigger.set, valid_name, invalid_name, handler)
+        t.assert_error_msg_content_equals(
+            errmsg, trigger.del, valid_name, invalid_name)
+        errmsg = string.format(
+            "bad argument #1 to '?' (string expected, got %s)",
+            type(invalid_name))
+        t.assert_error_msg_content_equals(
+            errmsg, trigger.set, invalid_name, valid_name, handler)
+        t.assert_error_msg_content_equals(
+            errmsg, trigger.del, invalid_name, valid_name)
+        t.assert_error_msg_content_equals(errmsg, trigger.call, invalid_name)
+        t.assert_error_msg_content_equals(errmsg, trigger.pairs, invalid_name)
+        t.assert_error_msg_content_equals(errmsg, trigger.info, invalid_name)
+    end
+    local errmsg = "Usage: trigger.set(event, trigger, function)"
+    t.assert_error_msg_content_equals(errmsg, trigger.set, 'event', 'trigger',
+        handler, 'redundant')
+    t.assert_error_msg_content_equals(errmsg, trigger.set, 'event', 'trigger')
+    errmsg = "Usage: trigger.del(event, trigger)"
+    t.assert_error_msg_content_equals(errmsg, trigger.del, 'event', 'trigger',
+        'redundant')
+    t.assert_error_msg_content_equals(errmsg, trigger.del, 'event')
+    errmsg = "Usage: trigger.pairs(event)"
+    t.assert_error_msg_content_equals(errmsg, trigger.pairs, 'event',
+        'redundant')
+    t.assert_error_msg_content_equals(errmsg, trigger.pairs)
+    errmsg = "Usage: trigger.info([event])"
+    t.assert_error_msg_content_equals(errmsg, trigger.info, 'event',
+        'redundant')
+    errmsg = "Usage: trigger.call(event, [args...])"
+    t.assert_error_msg_content_equals(errmsg, trigger.call)
+end
+
+g.test_nil_args = function()
+    local trigger = require('trigger')
+
+    local event = "my_event"
+    local name = "my_trigger"
+
+    local state = {}
+    local function handler(a1, a2, a3, a4)
+        state = {a1, a2, a3, a4}
+    end
+    trigger.set(event, name, handler)
+    trigger.call(event, 1, 2, nil)
+    t.assert_equals(state, {1, 2})
+    state = {}
+
+    trigger.call(event, 1, nil, 3)
+    t.assert_equals(state, {1, nil, 3})
+    state = {}
+
+    trigger.call(event, nil, 2, 3)
+    t.assert_equals(state, {nil, 2, 3})
+    state = {}
+
+    trigger.call(event, nil, nil, 3)
+    t.assert_equals(state, {nil, nil, 3})
+    state = {}
+
+    trigger.call(event, 1, nil, nil, 4)
+    t.assert_equals(state, {1, nil, nil, 4})
+
+    trigger.del(event, name)
+end
+
+g.test_info = function()
+    local trigger = require('trigger')
+    local state = 0
+    local function handler(inc)
+        state = state + inc
+    end
+    local function handler_method(self, inc)
+        state = state + inc
+    end
+    local a, b, c = generate_callable_objects(handler_method)
+    local trigger_info = {
+        ["test_events[1].event"] = {
+            {"my_triggers.trig1", a},
+            {"my_triggers.trig2", b},
+            {"trig1", c},
+            {"trig2", handler},
+
+        },
+        ["test_event[2].EVENT"] = {
+            {'a', a},
+            {'b', b},
+        },
+        ["test_event[4].dsffsd"] = {
+            {'c', c},
+            {'h', handler},
+        },
+        ["AnUsualEventName"] = {
+            {'triggers.1', a},
+            {'triggers[1]', b},
+        }
+    }
+    t.assert_equals(trigger.info(), {})
+    for event_name, trigger_list in pairs(trigger_info) do
+        for i = #trigger_list, 1, -1 do
+            local trigger_data = trigger_list[i]
+            local trigger_name = trigger_data[1]
+            local trigger_handler = trigger_data[2]
+            trigger.set(event_name, trigger_name, trigger_handler)
+        end
+    end
+    for event_name, trigger_list in pairs(trigger_info) do
+        local event_info = {[event_name] = trigger_list}
+        t.assert_equals(trigger.info(event_name), event_info)
+    end
+    t.assert_equals(trigger.info(), trigger_info)
+    for event_name, trigger_list in pairs(trigger_info) do
+        for _, trigger_data in ipairs(trigger_list) do
+            local trigger_name = trigger_data[1]
+            trigger.del(event_name, trigger_name)
+        end
+    end
+    t.assert_equals(trigger.info(), {})
+end
+
+-- Checks if empty events are never shown in info, even if its triggers
+-- are not deleted yet (for example, when they are pinned by iterator).
+g.test_info_no_empty_events = function()
+    local trigger = require('trigger')
+    local function handler() end
+    local event_name = "test.event"
+    local trigger_name = "test.trigger"
+    t.assert_equals(trigger.info(), {})
+    trigger.set(event_name, trigger_name, handler)
+
+    local gen, state = trigger.pairs(event_name)
+    local n, h = gen(state)
+    t.assert_equals(n, trigger_name)
+    t.assert_equals(h, handler)
+
+    trigger.del(event_name, trigger_name)
+    t.assert_equals(trigger.info(event_name), {})
+    t.assert_equals(trigger.info(), {})
+end

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -630,3 +630,8 @@ create_unit_test(PREFIX lua_func_adapter
                            ${ICU_LIBRARIES}
                            ${LUAJIT_LIBRARIES}
 )
+
+create_unit_test(PREFIX event
+                 SOURCES event.c core_test_utils.c
+                 LIBRARIES core unit
+)

--- a/test/unit/event.c
+++ b/test/unit/event.c
@@ -1,0 +1,445 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "diag.h"
+#include "error.h"
+#include "errcode.h"
+#include "fiber.h"
+#include "func_adapter.h"
+#include "memory.h"
+#include "trivia/util.h"
+#include "event.h"
+#include "tt_static.h"
+
+#define UNIT_TAP_COMPATIBLE 1
+#include "unit.h"
+
+static int func_destroy_count;
+
+/**
+ * Virtual destructor for func_adapter for the test purposes.
+ */
+void
+func_destroy(struct func_adapter *func)
+{
+	func_destroy_count++;
+}
+
+/**
+ * The test creates event with different names and check if all the basic
+ * operations works correctly.
+ */
+static void
+test_basic(void)
+{
+	plan(4 * 14);
+
+	struct func_adapter_vtab vtab = {.destroy = func_destroy};
+	struct func_adapter func = {.vtab = &vtab};
+	const char *trg_name = "my_triggers.trg[1]";
+	const char *names[] = {
+		"name",
+		"name with spaces",
+		"namespace.name",
+		"NAMESPACE[123].name"
+	};
+	for (size_t i = 0; i < lengthof(names); ++i) {
+		const char *name = names[i];
+		struct event *event = event_get(name, false);
+		is(event, NULL, "No such event - NULL must be returned");
+		event = event_get(name, true);
+		isnt(event, NULL, "Event must be created");
+		/* Reference event to prevent deletion when it'll be empty. */
+		event_ref(event);
+		struct event *found_event = event_get(name, false);
+		is(found_event, event, "Existing event must be found");
+		struct func_adapter *old = event_find_trigger(event, trg_name);
+		is(old, NULL, "No such trigger - NULL must be returned");
+		ok(!event_has_triggers(event), "Created event must be empty");
+		event_reset_trigger(event, trg_name, &func);
+		found_event = event_get(name, false);
+		is(found_event, event, "Event must still exist");
+		old = event_find_trigger(event, trg_name);
+		is(old, &func, "New trigger must be found");
+		ok(event_has_triggers(event), "Event must not be empty");
+		is(func_destroy_count, 0, "Func must not be destroyed yet")
+		event_reset_trigger(event, trg_name, NULL);
+		is(func_destroy_count, 1, "Func must be destroyed")
+		old = event_find_trigger(event, trg_name);
+		is(old, NULL, "Deleted trigger must not be found");
+		ok(!event_has_triggers(event), "Event must be empty");
+		found_event = event_get(name, false);
+		is(found_event, event, "Referenced event must not be deleted");
+		event_unref(event);
+		found_event = event_get(name, false);
+		is(found_event, NULL, "Empty unused event must be deleted");
+		func_destroy_count = 0;
+	}
+	check_plan();
+}
+
+/**
+ * A test argument for event_foreach function.
+ */
+struct test_event_foreach_arg {
+	int names_len;
+	const char **names;
+	int traversed;
+};
+
+static bool
+test_event_foreach_f(struct event *event, void *arg)
+{
+	struct test_event_foreach_arg *data =
+		(struct test_event_foreach_arg *)arg;
+	data->traversed++;
+	bool name_found = false;
+	for (int i = 0; i < data->names_len && !name_found; ++i) {
+		name_found = strcmp(event->name, data->names[i]) == 0;
+	}
+	ok(name_found, "Traversed event must really exist");
+	return true;
+}
+
+static bool
+test_event_foreach_return_false_f(struct event *event, void *arg)
+{
+	(void)event;
+	struct test_event_foreach_arg *data =
+		(struct test_event_foreach_arg *)arg;
+	data->traversed++;
+	return false;
+}
+
+static void
+test_event_foreach(void)
+{
+	plan(10);
+	const char *names[] = {
+		"event",
+		"my_events.event1",
+		"my_events.event3",
+		"my_events[15].event"
+	};
+	struct func_adapter_vtab vtab = {.destroy = func_destroy};
+	struct func_adapter func = {.vtab = &vtab};
+	for (size_t i = 0; i < lengthof(names); ++i) {
+		struct event *event = event_get(names[i], true);
+		event_ref(event);
+		const char *trg_name = tt_sprintf("%zu", i);
+		event_reset_trigger(event, trg_name, &func);
+	}
+
+	struct test_event_foreach_arg arg = {
+		.names_len = lengthof(names),
+		.names = names,
+		.traversed = 0,
+	};
+
+	bool ok = event_foreach(test_event_foreach_f, &arg);
+	ok(ok, "Traversal must return true");
+	is(arg.traversed, lengthof(names), "All the events must be traversed");
+
+	arg.traversed = 0;
+	ok = event_foreach(test_event_foreach_return_false_f, &arg);
+	ok(!ok, "Failed traversal must return false");
+	is(arg.traversed, 1, "Only one event must be traversed");
+
+	for (size_t i = 0; i < lengthof(names); ++i) {
+		struct event *event = event_get(names[i], false);
+		const char *trg_name = tt_sprintf("%zu", i);
+		event_reset_trigger(event, trg_name, NULL);
+	}
+
+	arg.traversed = 0;
+	ok = event_foreach(test_event_foreach_f, &arg);
+	ok(ok, "Traversal of empty registry must return true");
+	is(arg.traversed, 0, "All the events are empty - nothing to traverse");
+
+	/* Unreference all the events. */
+	for (size_t i = 0; i < lengthof(names); ++i) {
+		struct event *event = event_get(names[i], false);
+		fail_if(event == NULL);
+		event_unref(event);
+	}
+
+	check_plan();
+}
+
+static void
+test_event_trigger_iterator(void)
+{
+	plan(14);
+	const char *event_name = "test_event";
+	const char *trigger_names[] = {
+		"0", "1", "2", "3", "4", "5", "6", "7"
+	};
+	struct func_adapter_vtab vtab = {.destroy = func_destroy};
+	struct func_adapter func = {.vtab = &vtab};
+
+	struct event *event = event_get(event_name, true);
+	for (int i = lengthof(trigger_names) - 1; i >= 0; --i)
+		event_reset_trigger(event, trigger_names[i], &func);
+
+	struct event_trigger_iterator it;
+	event_trigger_iterator_create(&it, event);
+	size_t idx = 0;
+	struct func_adapter *curr_trg = NULL;
+	const char *curr_name = NULL;
+	while (event_trigger_iterator_next(&it, &curr_trg, &curr_name)) {
+		is(strcmp(curr_name, trigger_names[idx]), 0,
+		   "Triggers must be traversed in reversed order");
+		idx++;
+	}
+	is(idx, lengthof(trigger_names), "All the triggers must be traversed");
+	is(curr_trg, NULL, "Exhausted iterator must return NULL trigger");
+	is(curr_name, NULL, "Exhausted iterator must return NULL name");
+
+	curr_trg = &func;
+	curr_name = "garbage";
+	bool has_elems =
+		event_trigger_iterator_next(&it, &curr_trg, &curr_name);
+	ok(!has_elems, "Iterator must stay exhausted");
+	is(curr_trg, NULL, "Exhausted iterator must return NULL trigger");
+	is(curr_name, NULL, "Exhausted iterator must return NULL name");
+
+	for (size_t i = 0; i < lengthof(trigger_names); ++i)
+		event_reset_trigger(event, trigger_names[i], NULL);
+
+	event_trigger_iterator_destroy(&it);
+
+	check_plan();
+}
+
+/**
+ * Stops at breakpoint and deletes triggers which are set in del mask.
+ */
+static void
+test_event_iterator_stability_del_step(int breakpoint, const char *del_mask,
+				       int trigger_num)
+{
+	fail_unless(breakpoint < trigger_num);
+	size_t left_after_br = 0;
+	for (int i = breakpoint + 1; i < trigger_num; ++i) {
+		if (del_mask[i] == 0)
+			left_after_br++;
+	}
+	plan((breakpoint + 1) * 2 + left_after_br + 3);
+
+	const char *event_name = "test_event";
+	struct func_adapter_vtab vtab = {.destroy = func_destroy};
+	struct func_adapter func = {.vtab = &vtab};
+
+	struct event *event = event_get(event_name, true);
+	/*
+	 * Reference the event to prevent deletion for the test cases that
+	 * delete all the triggers from the event.
+	 */
+	event_ref(event);
+	for (int i = trigger_num - 1; i >= 0; --i) {
+		const char *trg_name = tt_sprintf("%d", i);
+		event_reset_trigger(event, trg_name, &func);
+	}
+
+	struct event_trigger_iterator it;
+	event_trigger_iterator_create(&it, event);
+	struct func_adapter *trg = NULL;
+	const char *name = NULL;
+	for (int i = 0; i <= breakpoint; i++) {
+		bool ok = event_trigger_iterator_next(&it, &trg, &name);
+		ok(ok, "Iterator must not be exhausted yet")
+		const char *trg_name = tt_sprintf("%d", i);
+		is(strcmp(name, trg_name), 0,
+		   "Triggers must be traversed in reversed order");
+	}
+	bool delete_all_triggers = true;
+	for (int i = 0; i < trigger_num; ++i) {
+		if (del_mask[i] != 0) {
+			const char *trg_name = tt_sprintf("%d", i);
+			event_reset_trigger(event, trg_name, NULL);
+		} else {
+			delete_all_triggers = false;
+		}
+	}
+	is(event_has_triggers(event), !delete_all_triggers,
+	   "Function event_has_triggers must work correctly");
+	for (size_t i = 0; i < left_after_br; ++i) {
+		bool ok = event_trigger_iterator_next(&it, &trg, &name);
+		ok(ok, "Traversal must continue");
+	}
+
+	bool ok = event_trigger_iterator_next(&it, &trg, &name);
+	ok(!ok, "Iterator must be exhausted");
+	event_trigger_iterator_destroy(&it);
+	is(event_has_triggers(event), !delete_all_triggers,
+	   "Function event_has_triggers must work correctly");
+
+	for (int i = 0; i < trigger_num; ++i) {
+		if (del_mask[i] != 0)
+			continue;
+		const char *trg_name = tt_sprintf("%d", i);
+		event_reset_trigger(event, trg_name, NULL);
+	}
+	event_unref(event);
+
+	check_plan();
+}
+
+/**
+ * Stops at breakpoint and replaces triggers which are set in replace mask.
+ */
+static void
+test_event_iterator_stability_replace_step(int breakpoint,
+					   const char *replace_mask,
+					   int trigger_num)
+{
+	fail_unless(breakpoint < trigger_num);
+	plan((breakpoint + 1) * 2 + 3 * (trigger_num - breakpoint - 1) + 3);
+
+	const char *event_name = "test_event";
+	struct func_adapter_vtab vtab = {.destroy = func_destroy};
+	struct func_adapter func = {.vtab = &vtab};
+	struct func_adapter new_func = {.vtab = &vtab};
+
+	struct event *event = event_get(event_name, true);
+	for (int i = trigger_num - 1; i >= 0; --i) {
+		const char *trg_name = tt_sprintf("%d", i);
+		event_reset_trigger(event, trg_name, &func);
+	}
+
+	struct event_trigger_iterator it;
+	event_trigger_iterator_create(&it, event);
+	struct func_adapter *trg = NULL;
+	const char *name = NULL;
+	for (int i = 0; i <= breakpoint; i++) {
+		bool ok = event_trigger_iterator_next(&it, &trg, &name);
+		ok(ok, "Iterator must not be exhausted yet")
+		const char *trg_name = tt_sprintf("%d", i);
+		is(strcmp(name, trg_name), 0,
+		   "Triggers must be traversed in reversed order");
+	}
+	for (int i = 0; i < trigger_num; ++i) {
+		if (replace_mask[i] != 0) {
+			const char *trg_name = tt_sprintf("%d", i);
+			event_reset_trigger(event, trg_name, &new_func);
+		}
+	}
+	ok(event_has_triggers(event), "Event must not be empty");
+	for (int i = breakpoint + 1; i < trigger_num; ++i) {
+		bool ok = event_trigger_iterator_next(&it, &trg, &name);
+		ok(ok, "Traversal must continue")
+		const char *trg_name = tt_sprintf("%d", i);
+		is(strcmp(name, trg_name), 0,
+		   "Triggers must be traversed in reversed order");
+		if (replace_mask[i] != 0) {
+			is(trg, &new_func, "Trigger must be replaced");
+		} else {
+			is(trg, &func, "Trigger must be old");
+		}
+	}
+	bool ok = event_trigger_iterator_next(&it, &trg, &name);
+	ok(!ok, "Iterator must be exhausted");
+	event_trigger_iterator_destroy(&it);
+	ok(event_has_triggers(event), "Event must not be empty");
+
+	for (int i = 0; i < trigger_num; ++i) {
+		const char *trg_name = tt_sprintf("%d", i);
+		event_reset_trigger(event, trg_name, NULL);
+	}
+
+	check_plan();
+}
+
+/**
+ * Checks if iteration is stable in the cases of deletions and replaces.
+ */
+static void
+test_event_trigger_iterator_stability(void)
+{
+	plan(6);
+	char mask[8];
+	const size_t trigger_num = lengthof(mask);
+	memset(mask, 0, trigger_num);
+	size_t br = trigger_num / 2;
+	/**
+	 * Delete or replace current trigger.
+	 */
+	mask[br] = 1;
+	test_event_iterator_stability_del_step(br, mask, trigger_num);
+	test_event_iterator_stability_replace_step(br, mask, trigger_num);
+	memset(mask, 0, trigger_num);
+	/**
+	 * Delete or replace current, previous and next triggers.
+	 */
+	mask[br - 1] = 1;
+	mask[br] = 1;
+	mask[br + 1] = 1;
+	test_event_iterator_stability_del_step(br, mask, trigger_num);
+	test_event_iterator_stability_replace_step(br, mask, trigger_num);
+	memset(mask, 0, trigger_num);
+	/**
+	 * Delete or replace all the triggers in the middle of iteration.
+	 */
+	memset(mask, 1, trigger_num);
+	test_event_iterator_stability_del_step(br, mask, trigger_num);
+	test_event_iterator_stability_replace_step(br, mask, trigger_num);
+	memset(mask, 0, trigger_num);
+
+	check_plan();
+}
+
+static void
+test_event_free(void)
+{
+	plan(1);
+
+	struct func_adapter_vtab vtab = {.destroy = func_destroy};
+	struct func_adapter func = {.vtab = &vtab};
+	const char *trigger_names[] = {
+		"trigger[1]",
+		"trigger.second",
+		"another_trigger"
+	};
+	const char *event_names[] = {
+		"name",
+		"name with spaces",
+		"namespace.name",
+		"NAMESPACE[123].name"
+	};
+	func_destroy_count = 0;
+	for (size_t i = 0; i < lengthof(event_names); ++i) {
+		const char *name = event_names[i];
+		struct event *event = event_get(name, true);
+		for (size_t j = 0; j < lengthof(trigger_names); ++j)
+			event_reset_trigger(event, trigger_names[j], &func);
+	}
+	event_free();
+	is(func_destroy_count, lengthof(event_names) * lengthof(trigger_names),
+	   "All triggers must be destroyed");
+	/* Initialize event back. */
+	event_init();
+
+	check_plan();
+}
+
+static int
+test_main(void)
+{
+	plan(5);
+	test_basic();
+	test_event_foreach();
+	test_event_trigger_iterator();
+	test_event_trigger_iterator_stability();
+	test_event_free();
+	return check_plan();
+}
+
+int
+main(void)
+{
+	event_init();
+	int rc = test_main();
+	event_free();
+	return rc;
+}


### PR DESCRIPTION
New module allows users to set arbitrary handlers on arbitrary events.
All the existing tarantool triggers will be moved to this module later.

**NB**: despite the fact that it was written that `set` method returns old trigger in the design document, I decided to do another way - `set` returns new trigger. Rationale: firstly, for the sake of consistency with `space:insert` which returns new tuple. Secondly, only with such API user can check if the trigger was set (we will introduce `trigger.on_change` trigger which will be able to throw an error to disallow to set the trigger, and ability of such check will be helpful then).

Closes https://github.com/tarantool/tarantool/issues/8656