### PR TITLE
box: do not allow to drop system spaces

### DIFF
--- a/changelogs/unreleased/gh-5279-system-space-removal.md
+++ b/changelogs/unreleased/gh-5279-system-space-removal.md
@@ -1,0 +1,3 @@
+## bugfix/box
+
+- Fixed the ability to drop `_vinyl_deferred_delete` system space (gh-5279).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -2099,6 +2099,13 @@ on_replace_dd_space(struct trigger * /* trigger */, void *event)
 		/* Check whether old_space is used somewhere. */
 		if (space_check_pinned(old_space) != 0)
 			return -1;
+		/* One can't just remove a system space. */
+		if (space_is_system(old_space)) {
+			diag_set(ClientError, ER_DROP_SPACE,
+				 space_name(old_space),
+				 "the space is a system space");
+			return -1;
+		}
 		/**
 		 * We need to unpin spaces that are referenced by deleted one.
 		 * Let's detach space constraints - they will be deleted

--- a/test/box/alter.result
+++ b/test/box/alter.result
@@ -71,7 +71,7 @@ _space:insert{_index.id, ADMIN, '_index', 'memtx', 0, EMPTY_MAP, {}}
     "type": "array"}]] and new tuple - [288, 1, "_index", "memtx", 0, {}, []]'
 ...
 --
--- Can't drop a system space
+-- Can't drop a space with an index
 --
 _space:delete{_space.id}
 ---
@@ -80,6 +80,13 @@ _space:delete{_space.id}
 _space:delete{_index.id}
 ---
 - error: 'Can''t drop space ''_index'': the space has indexes'
+...
+--
+-- Can't drop a system space
+--
+_space:delete{box.schema.VINYL_DEFERRED_DELETE_ID}
+---
+- error: 'Can''t drop space ''_vinyl_deferred_delete'': the space is a system space'
 ...
 --
 -- Can't change properties of a space
@@ -95,7 +102,7 @@ _space:update({_space.id}, {{'-', 1, 2}})
 --
 -- Create a space
 --
-t = _space:auto_increment{ADMIN, 'hello', 'memtx', 0, EMPTY_MAP, {}}
+t = _space:insert{box.internal.generate_space_id(), ADMIN, 'hello', 'memtx', 0, EMPTY_MAP, {}}
 ---
 ...
 -- Check that a space exists
@@ -104,7 +111,7 @@ space = box.space[t[1]]
 ...
 space.id
 ---
-- 381
+- 512
 ...
 space.field_count
 ---
@@ -149,7 +156,7 @@ space_deleted
 ...
 space:replace{0}
 ---
-- error: Space '381' does not exist
+- error: Space '512' does not exist
 ...
 err, res = pcall(function() return _index:insert{_space.id, 0, 'primary', 'tree', {unique=true}, {{0, 'unsigned'}}} end)
 ---

--- a/test/box/alter.test.lua
+++ b/test/box/alter.test.lua
@@ -29,10 +29,14 @@ err, res = pcall(function() return _space:insert{_space.id, ADMIN, '_space', 'me
 assert(res.code == box.error.TUPLE_FOUND)
 _space:insert{_index.id, ADMIN, '_index', 'memtx', 0, EMPTY_MAP, {}}
 --
--- Can't drop a system space
+-- Can't drop a space with an index
 --
 _space:delete{_space.id}
 _space:delete{_index.id}
+--
+-- Can't drop a system space
+--
+_space:delete{box.schema.VINYL_DEFERRED_DELETE_ID}
 --
 -- Can't change properties of a space
 --
@@ -41,7 +45,7 @@ _space:update({_space.id}, {{'-', 1, 2}})
 --
 -- Create a space
 --
-t = _space:auto_increment{ADMIN, 'hello', 'memtx', 0, EMPTY_MAP, {}}
+t = _space:insert{box.internal.generate_space_id(), ADMIN, 'hello', 'memtx', 0, EMPTY_MAP, {}}
 -- Check that a space exists
 space = box.space[t[1]]
 space.id


### PR DESCRIPTION
The patch adds a new check to the _space on_replace trigger failing on attempt to drop a system table.

Closes #5279

NO_DOC=bugfix

**PROBLEMS**
1. The check duplicates the one in the _index on_replace trigger: [src/box/alter.cc](https://github.com/tarantool/tarantool/blob/93b3bba9bf907f9199f31d4071b0e3a5616a243a/src/box/alter.cc#L2335). But if we remove it then we gonna have to fix a lot of tests checking system space drop, because removal of an entry from the _space space happens only after index drop: [src/box/lua/schema.lua](https://github.com/tarantool/tarantool/blob/1e02e0506f89f01d386fdaaed01ca04c54943de5/src/box/lua/schema.lua#L911), so the removal of the check invalidates the system space we attempted to drop making the lua code remove indexes of the space.

**OTHER POSSIBLE SOLUTIONS**
1. Add a dummy index to blackhole spaces so their primary index drop will trigger the existing check.