### PR TITLE
trivia: rework xregion_alloc_* macros

### DIFF
--- a/src/box/lua/misc.cc
+++ b/src/box/lua/misc.cc
@@ -397,13 +397,10 @@ lbox_tuple_format_new(struct lua_State *L)
 	uint32_t count = lua_objlen(L, 1);
 	if (count == 0)
 		return lbox_push_tuple_format(L, tuple_format_runtime);
-	size_t size;
 	struct region *region = &fiber()->gc;
 	size_t region_svp = region_used(region);
-	struct field_def *fields =
-		(struct field_def *)xregion_alloc_array(region,
-							struct field_def, count,
-							&size);
+	struct field_def *fields = xregion_alloc_array(region,
+						       struct field_def, count);
 	for (uint32_t i = 0; i < count; ++i) {
 		size_t len;
 		fields[i] = field_def_default;

--- a/src/box/sql/select.c
+++ b/src/box/sql/select.c
@@ -2065,10 +2065,9 @@ sqlColumnsFromExprList(Parse * parse, ExprList * expr_list,
 	 */
 	assert(space_def->fields == NULL);
 	struct region *region = &parse->region;
-	size_t size;
 	space_def->fields =
 		xregion_alloc_array(region, typeof(space_def->fields[0]),
-				    column_count, &size);
+				    column_count);
 	for (uint32_t i = 0; i < column_count; i++) {
 		memcpy(&space_def->fields[i], &field_def_default,
 		       sizeof(field_def_default));

--- a/src/box/tuple_constraint_def.c
+++ b/src/box/tuple_constraint_def.c
@@ -103,9 +103,7 @@ tuple_constraint_def_decode(const char **data,
 	if (*count == 0)
 		return 0;
 
-	size_t bytes;
-	*def = xregion_alloc_array(region, struct tuple_constraint_def,
-				   *count, &bytes);
+	*def = xregion_alloc_array(region, struct tuple_constraint_def, *count);
 	for (uint32_t i = 0; i < old_count; i++)
 		(*def)[i] = old_def[i];
 	struct tuple_constraint_def *new_def = *def + old_count;
@@ -212,10 +210,9 @@ field_mapping_decode(const char **data,
 		return -1;
 	}
 	fkey->field_mapping_size = mapping_size;
-	size_t sz;
 	fkey->field_mapping = xregion_alloc_array(
 		region, struct tuple_constraint_fkey_field_mapping,
-		mapping_size, &sz);
+		mapping_size);
 	for (uint32_t i = 0 ; i < 2 * mapping_size; i++) {
 		struct tuple_constraint_field_id *def = i % 2 == 0 ?
 			&fkey->field_mapping[i / 2].local_field :
@@ -250,9 +247,8 @@ tuple_constraint_def_decode_fkey(const char **data,
 	if (*count == 0)
 		return 0;
 
-	size_t bytes;
 	*def = xregion_alloc_array(region, struct tuple_constraint_def,
-				   *count, &bytes);
+				   *count);
 	for (uint32_t i = 0; i < old_count; i++)
 		(*def)[i] = old_def[i];
 	struct tuple_constraint_def *new_def = *def + old_count;

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -1306,10 +1306,9 @@ fiber_gc_checker_init(struct fiber *fiber)
 		return;
 	}
 
-	size_t size;
 	fiber->first_alloc_bt =
 		xregion_alloc_object(&fiber->gc,
-				     typeof(*fiber->first_alloc_bt), &size);
+				     typeof(*fiber->first_alloc_bt));
 	fiber->gc_initial_size = region_used(&fiber->gc);
 	region_set_callbacks(&fiber->gc,
 			     fiber_on_gc_alloc, fiber_on_gc_truncate,

--- a/src/trivia/util.h
+++ b/src/trivia/util.h
@@ -128,16 +128,20 @@ strnindex(const char *const *haystack, const char *needle, uint32_t len,
 #define xstrndup(s, n)		xalloc_impl((n) + 1, strndup, (s), (n))
 #define xmempool_alloc(p)	xalloc_impl((p)->objsize, mempool_alloc, (p))
 #define xregion_alloc(p, size)	xalloc_impl((size), region_alloc, (p), (size))
-#define xregion_alloc_object(region, T, size) \
-		xalloc_impl(size, region_alloc_object, region, T, size)
-#define xregion_alloc_array(p, T, count, size)				\
-	xalloc_impl(sizeof(T) * (count), region_alloc_array, (p), T,	\
-		    (count), (size))
+#define xregion_aligned_alloc(p, size, align) \
+		xalloc_impl((size), region_aligned_alloc, (p), (size), (align))
 #define xregion_join(p, size)	xalloc_impl((size), region_join, (p), (size))
 #define xibuf_alloc(p, size)	xalloc_impl((size), ibuf_alloc, (p), (size))
 #define xibuf_reserve(p, size)	xalloc_impl((size), ibuf_reserve, (p), (size))
 #define xruntime_memory_alloc(size) \
 	xalloc_impl((size), runtime_memory_alloc, (size))
+
+#define xregion_alloc_object(region, T) ({					\
+	(T *)xregion_aligned_alloc((region), sizeof(T), alignof(T));		\
+})
+#define xregion_alloc_array(region, T, count) ({				\
+	(T *)xregion_aligned_alloc((region), sizeof(T) * (count), alignof(T));\
+})
 
 /** \cond public */
 


### PR DESCRIPTION
This patch removes the 'size' argument from macros, as it was only used to set an error on failure, which is not possible for x* versions. In addition, both macros now cast the value to the specified type, as is done in the original macros.

Closes #8522

NO_DOC=internal
NO_TEST=internal
NO_CHANGELOG=internal