### PR TITLE
box: fix memory leak in `lbox_key_def_new` and `luaT_key_def_merge`

### DIFF
--- a/src/box/lua/key_def.c
+++ b/src/box/lua/key_def.c
@@ -397,7 +397,7 @@ luaT_key_def_merge(struct lua_State *L, int idx_a, int idx_b)
 	if (new_key_def == NULL)
 		return luaT_error(L);
 
-	luaT_push_key_def(L, new_key_def);
+	luaT_push_key_def_nodup(L, new_key_def);
 	return 1;
 }
 
@@ -522,7 +522,7 @@ lbox_key_def_new(struct lua_State *L)
 	 */
 	key_def_update_optionality(key_def, 0);
 
-	luaT_push_key_def(L, key_def);
+	luaT_push_key_def_nodup(L, key_def);
 	return 1;
 }
 


### PR DESCRIPTION
There was a typo in the commit 55295f5f1be7 ("box: populate index_object.parts with key_def module methods"):
the function `luaT_push_key_def()` was erroneously used instead of `luaT_push_key_def_nodup()`.