### PR TITLE
ci: fix PR update timestamp setter

### DIFF
--- a/.github/workflows/lango-stale-reviews.yml
+++ b/.github/workflows/lango-stale-reviews.yml
@@ -16,7 +16,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-          cache: pip
       - name: Install dependencies
         run: pip install requests
       - name: Update dates


### PR DESCRIPTION
The setup-python action defaults to searching for
a dependency file (requirements.txt or pyproject.toml for pip, Pipfile.lock for pipenv or poetry.lock for poetry) in the repository, and uses its hash as a
part of the cache key. We don't have one, so the
caching option is disabled.

NO_DOC=Workflow fix
NO_TEST=Workflow fix
NO_CHANGELOG=Workflow fix