### PR TITLE
sql: fix invalid negation.

### DIFF
--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -3198,7 +3198,12 @@ expr_code_int(struct Parse *parse, struct Expr *expr, bool is_neg,
 			return;
 		}
 	}
-	if (is_neg)
+
+	/*
+	 * We don't need to negate INT64_MIN value because it's negation is
+	 * equal to it.
+	 */
+	if (is_neg && value != INT64_MIN)
 		value = -value;
 	sqlVdbeAddOp4Dup8(v, OP_Int64, 0, mem, 0, (u8 *) &value,
 			  is_neg ? P4_INT64 : P4_UINT64);


### PR DESCRIPTION
This patch fixes the check for invalid negation, which was found by [sydr-fuzz](https://github.com/ispras/oss-sydr-fuzz) in `box/sql/expr.c:3202`.

The error occurred because the value of `value` var can be equal to `INT64_MIN` (which is equal to `(uint64_t) INT64_MAX + 1`), and it won't be handled by corresponding check. To fix this it is enough just to change the check to `>=` instead of `>` to parse this value as well.

How to reproduce:

1. Build and run docker container from [here](https://github.com/ispras/oss-sydr-fuzz/tree/master/projects/tarantool):
 
        sudo docker build -t oss-sydr-fuzz-tarantool
        sudo docker run --rm --privileged -v `pwd`:/fuzz -it oss-sydr-fuzz-tarantool /bin/bash

2. Run target `/sql_fuzzer` on this input
[tarantool-neg.txt](https://github.com/tarantool/tarantool/files/11444190/tarantool-neg.txt)

        /sql_fuzzer tarantool-neg.txt

3. You will see the following output:

        tarantool/src/box/sql/expr.c:3202:11: runtime error: negation of -9223372036854775808 cannot be represented in type 'int64_t' (aka 'long'); cast to an unsigned type to negate this value to itself
        SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /tarantool/src/box/sql/expr.c:3202:11 in

NO_DOC=refactoring
NO_CHANGELOG=refactoring
NO_TEST=refactoring