### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-8516-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8516-luajit-fixes.md
@@ -1,0 +1,6 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-8516). The following issues
+were fixed as part of this activity:
+
+* Fix TNEW load forwarding with instable types.


### PR DESCRIPTION
* Fix TNEW load forwarding with instable types.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump