### PR TITLE
ci: dedicated token for Lango stale PRs

### DIFF
--- a/.github/workflows/lango-stale-reviews.yml
+++ b/.github/workflows/lango-stale-reviews.yml
@@ -2,11 +2,12 @@ name: lango-stale-reviews
 on:
   schedule:
     - cron:  '* */1 * * *'    # At every hour.
+  workflow_dispatch:
 
 jobs:
   update-last-activity-dates:
     env:
-      LANGO_REVIEW_BOARD_TOKEN: ${{ github.token }}
+      LANGO_REVIEW_BOARD_TOKEN: ${{ secrets.LANGO_REVIEW_BOARD_TOKEN }}
       ORGANIZATION: Tarantool
       PROJECT_ID: 83
     runs-on: ubuntu-latest


### PR DESCRIPTION
Default token for actions provided by GitHub lacks read and write permissions for private projects. This commit changes the token used for the stale PRs workflow to the dedicated token with needed permissions.

NO_DOC=Workflow fix
NO_TEST=Workflow fix
NO_CHANGELOG=Workflow fix