### PR TITLE
iproto: send `IPROTO_WATCH` sync number in `IPROTO_EVENT` packet

### DIFF
--- a/changelogs/unreleased/gh-8393-iproto-watch-sync.md
+++ b/changelogs/unreleased/gh-8393-iproto-watch-sync.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* An `IPROTO_EVENT` packet now has the same sync number as the last
+  corresponding `IPROTO_WATCH` request (gh-8393).

--- a/src/box/iproto_constants.h
+++ b/src/box/iproto_constants.h
@@ -314,8 +314,9 @@ enum iproto_type {
 	 *     it unsubscribes by sending an IPROTO_UNWATCH packet.
 	 *
 	 * All the three request types are fully asynchronous - a receiving end
-	 * doesn't send a packet in reply to any of them (therefore neither of
-	 * them has a sync number).
+	 * doesn't send a packet in reply to any of them. Still, the server
+	 * sends the same sync number in an IPROTO_EVENT packet as the one sent
+	 * by the client in the last corresponding IPROTO_WATCH request.
 	 */
 	IPROTO_WATCH = 74,
 	IPROTO_UNWATCH = 75,

--- a/src/box/session.c
+++ b/src/box/session.c
@@ -106,8 +106,13 @@ session_on_stop(struct trigger *trigger, void *event)
  * Watcher registered for a session. Unregistered when the session is closed.
  */
 struct session_watcher {
+	/** Base class. */
 	struct watcher base;
+	/** Session that registered this watcher. */
 	struct session *session;
+	/** Request sync number used on watch. */
+	uint64_t sync;
+	/** Watcher callback. */
 	session_notify_f cb;
 };
 
@@ -119,12 +124,13 @@ session_watcher_run_f(struct watcher *base)
 	const char *key = watcher_key(base, &key_len);
 	const char *data_end;
 	const char *data = watcher_data(base, &data_end);
-	watcher->cb(watcher->session, key, key_len, data, data_end);
+	watcher->cb(watcher->session, watcher->sync, key, key_len,
+		    data, data_end);
 }
 
 void
-session_watch(struct session *session, const char *key,
-	      size_t key_len, session_notify_f cb)
+session_watch(struct session *session, uint64_t sync,
+	      const char *key, size_t key_len, session_notify_f cb)
 {
 	/* Look up a watcher for the specified key in this session. */
 	struct mh_strnptr_t *h = session->watchers;
@@ -137,6 +143,7 @@ session_watch(struct session *session, const char *key,
 	if (i != mh_end(h)) {
 		struct session_watcher *watcher =
 			(struct session_watcher *)mh_strnptr_node(h, i)->val;
+		watcher->sync = sync;
 		watcher_ack(&watcher->base);
 		return;
 	}
@@ -144,6 +151,7 @@ session_watch(struct session *session, const char *key,
 	struct session_watcher *watcher =
 		(struct session_watcher *)xmalloc(sizeof(*watcher));
 	watcher->session = session;
+	watcher->sync = sync;
 	watcher->cb = cb;
 	box_register_watcher(key, key_len, session_watcher_run_f,
 			     (watcher_destroy_f)free, WATCHER_EXPLICIT_ACK,

--- a/src/box/session.h
+++ b/src/box/session.h
@@ -355,7 +355,8 @@ int
 session_run_on_auth_triggers(const struct on_auth_trigger_ctx *result);
 
 typedef void
-(*session_notify_f)(struct session *session, const char *key, size_t key_len,
+(*session_notify_f)(struct session *session, uint64_t sync,
+		    const char *key, size_t key_len,
 		    const char *data, const char *data_end);
 
 /**
@@ -365,10 +366,12 @@ typedef void
  * The callback will be called unconditionally right after registration and
  * then every time the key is updated provided the last notification was
  * acknowledged.
+ *
+ * The given sync number will be passed to the callback on each invocation.
  */
 void
-session_watch(struct session *session, const char *key, size_t key_len,
-	      session_notify_f cb);
+session_watch(struct session *session, uint64_t sync,
+	      const char *key, size_t key_len, session_notify_f cb);
 
 /**
  * Unregisters a watcher registered for the given session and notification key.

--- a/src/box/xrow.c
+++ b/src/box/xrow.c
@@ -826,15 +826,18 @@ iproto_reply_chunk(struct obuf *buf, struct obuf_svp *svp, uint64_t sync,
 }
 
 int
-iproto_send_event(struct obuf *out, const char *key, size_t key_len,
+iproto_send_event(struct obuf *out, uint64_t sync,
+		  const char *key, size_t key_len,
 		  const char *data, const char *data_end)
 {
 	/* Calculate the packet size. */
 	size_t size = 5;
-	/* Packet header. Note: no sync and schema version. */
-	size += mp_sizeof_map(1);
+	/* Packet header. Note: no schema version. */
+	size += mp_sizeof_map(2);
 	size += mp_sizeof_uint(IPROTO_REQUEST_TYPE);
 	size += mp_sizeof_uint(IPROTO_EVENT);
+	size += mp_sizeof_uint(IPROTO_SYNC);
+	size += mp_sizeof_uint(sync);
 	/* Packet body. */
 	size += mp_sizeof_map(data != NULL ? 2 : 1);
 	size += mp_sizeof_uint(IPROTO_EVENT_KEY);
@@ -855,9 +858,11 @@ iproto_send_event(struct obuf *out, const char *key, size_t key_len,
 	mp_store_u32(p, size - 5);
 	p += 4;
 	/* Packet header. */
-	p = mp_encode_map(p, 1);
+	p = mp_encode_map(p, 2);
 	p = mp_encode_uint(p, IPROTO_REQUEST_TYPE);
 	p = mp_encode_uint(p, IPROTO_EVENT);
+	p = mp_encode_uint(p, IPROTO_SYNC);
+	p = mp_encode_uint(p, sync);
 	/* Packet body. */
 	p = mp_encode_map(p, data != NULL ? 2 : 1);
 	p = mp_encode_uint(p, IPROTO_EVENT_KEY);

--- a/src/box/xrow.h
+++ b/src/box/xrow.h
@@ -856,6 +856,7 @@ iproto_reply_chunk(struct obuf *buf, struct obuf_svp *svp, uint64_t sync,
 /**
  * Encode IPROTO_EVENT packet.
  * @param out Encode to.
+ * @param sync Sync number.
  * @param key Notification key name.
  * @param key_len Length of the notification key name.
  * @param data Notification data (MsgPack).
@@ -865,7 +866,8 @@ iproto_reply_chunk(struct obuf *buf, struct obuf_svp *svp, uint64_t sync,
  * @retval -1 Memory error.
  */
 int
-iproto_send_event(struct obuf *out, const char *key, size_t key_len,
+iproto_send_event(struct obuf *out, uint64_t sync,
+		  const char *key, size_t key_len,
 		  const char *data, const char *data_end);
 
 /** Write error directly to a socket. */

--- a/test/box-py/iproto.result
+++ b/test/box-py/iproto.result
@@ -222,36 +222,36 @@ version=4, features=[0, 1, 2, 3, 4], auth_type=chap-sha1
 error: Missing mandatory field 'event key' in request
 # Invalid key type
 error: Invalid MsgPack - packet body
-# Watch key 'foo'
-# Recieve event
-key='foo', value=None
-# Watch key 'bar'
-# Recieve event
-key='bar', value=None
+# Watch key 'foo', sync=1
+# Receive event
+key='foo', value=None, sync=1
+# Watch key 'bar', sync=2
+# Receive event
+key='bar', value=None, sync=2
 # Unwatch key 'bar'
-# Watch key 'bar'
-# Recieve event
-key='bar', value=None
+# Watch key 'bar', sync=3
+# Receive event
+key='bar', value=None, sync=3
 box.broadcast('foo', {1, 2, 3})
 ---
 ...
-# Recieve event
+# Receive event
    =>  Failed to recv response
 <no event received>
-# Watch key 'foo'
-# Recieve event
-key='foo', value=[1, 2, 3]
-# Watch key 'bar'
+# Watch key 'foo', sync=4
+# Receive event
+key='foo', value=[1, 2, 3], sync=4
+# Watch key 'bar', sync=5
 box.broadcast('bar', 123)
 ---
 ...
-# Recieve event
-key='bar', value=123
+# Receive event
+key='bar', value=123, sync=5
 box.broadcast('bar', 456)
 ---
 ...
 # Unwatch key 'bar'
-# Recieve event
+# Receive event
    =>  Failed to recv response
 <no event received>
 box.broadcast('foo', nil)

--- a/test/box-py/iproto.test.py
+++ b/test/box-py/iproto.test.py
@@ -516,25 +516,27 @@ print("""
 # gh-6257 Watchers
 #
 """)
-def watch(key):
-    print("# Watch key '{}'".format(key))
-    send_request({IPROTO_CODE: REQUEST_TYPE_WATCH}, {IPROTO_EVENT_KEY: key})
+def watch(key, sync):
+    print("# Watch key '{}', sync={}".format(key, sync))
+    send_request({IPROTO_CODE: REQUEST_TYPE_WATCH, IPROTO_SYNC: sync},
+                 {IPROTO_EVENT_KEY: key})
 
 def unwatch(key):
     print("# Unwatch key '{}'".format(key))
     send_request({IPROTO_CODE: REQUEST_TYPE_UNWATCH}, {IPROTO_EVENT_KEY: key})
 
 def receive_event():
-    print("# Recieve event")
+    print("# Receive event")
     resp = receive_response()
     code = resp["header"].get(IPROTO_CODE)
     if code is None:
         print("<no event received>")
         return
     if code == REQUEST_TYPE_EVENT:
-        print("key='{}', value={}".format(
+        print("key='{}', value={}, sync={}".format(
             resp["body"].get(IPROTO_EVENT_KEY, '').decode('utf-8'),
-            resp["body"].get(IPROTO_EVENT_DATA)))
+            resp["body"].get(IPROTO_EVENT_DATA),
+            resp["header"].get(IPROTO_SYNC)))
     else:
         print("Unexpected packet: {}".format(resp))
 
@@ -557,16 +559,16 @@ resp = test_request({IPROTO_CODE: REQUEST_TYPE_WATCH},
 print(resp_status(resp))
 
 # Register a watcher
-watch("foo")
+watch("foo", 1)
 receive_event()
 
 # Register a watcher for another key
-watch("bar")
+watch("bar", 2)
 receive_event()
 
 # Unregister and register watcher
 unwatch("bar")
-watch("bar")
+watch("bar", 3)
 receive_event()
 
 # No notification without ack
@@ -574,9 +576,9 @@ admin("box.broadcast('foo', {1, 2, 3})")
 check_no_event()
 
 # Notification after ack
-watch("foo")
+watch("foo", 4)
 receive_event()
-watch("bar")
+watch("bar", 5)
 admin("box.broadcast('bar', 123)")
 receive_event()
 


### PR DESCRIPTION
Initially the sync number sent by a client in an `IPROTO_WATCH` request was ignored and `IPROTO_EVENT` packet didn't have a sync number. There were complaints about it from users so we consider this to be a bug. Now the server sends the same sync number in an `IPROTO_EVENT` packet as the one sent by the client in the last corresponding `IPROTO_WATCH` request.

We don't use this functionality in net.box (sync number is always 0 for all watch/event packets), but other clients may actually use it.

Closes #8393
