### PR TITLE
box: add hostname to box.info

### DIFF
--- a/changelogs/unreleased/gh-8605-add-gethostname.md
+++ b/changelogs/unreleased/gh-8605-add-gethostname.md
@@ -1,0 +1,3 @@
+## feature/box
+
+* Added a new `box.info` parameter `hostname` (gh-8605).

--- a/test/box-luatest/gh_8605_add_box_info_hostname_test.lua
+++ b/test/box-luatest/gh_8605_add_box_info_hostname_test.lua
@@ -1,0 +1,21 @@
+local popen = require('popen')
+local t = require('luatest')
+
+local g = t.group()
+
+g.test_hostname_result = function()
+    local ph = popen.shell("hostname", 'r')
+
+    local exp_status = {
+        state = popen.state.EXITED,
+        exit_code = 0,
+    }
+    local status = ph:wait()
+    t.skip_if(status.exit_code == 127, "no hostname on host")
+    t.assert_equals(status, exp_status, 'verify process status')
+
+    local hostname = ph:read():rstrip()
+    t.assert_equals(hostname, box.info.hostname, 'verify hostname')
+
+    ph:close()
+end

--- a/test/box/info.result
+++ b/test/box/info.result
@@ -63,6 +63,10 @@ box.info.replicaset.uuid == box.space._schema:get{'replicaset_uuid'}[2]
 ---
 - true
 ...
+type(box.info.hostname) == 'string'
+---
+- true
+...
 t = {}
 ---
 ...
@@ -77,6 +81,7 @@ t
 - - cluster
   - election
   - gc
+  - hostname
   - id
   - listen
   - lsn

--- a/test/box/info.test.lua
+++ b/test/box/info.test.lua
@@ -17,6 +17,7 @@ box.info.status
 string.len(box.info.uptime) > 0
 string.match(box.info.uptime, '^[1-9][0-9]*$') ~= nil
 box.info.replicaset.uuid == box.space._schema:get{'replicaset_uuid'}[2]
+type(box.info.hostname) == 'string'
 t = {}
 for k, _ in pairs(box.info()) do table.insert(t, k) end
 table.sort(t)


### PR DESCRIPTION
Hostname is a useful piece of information in state reports. So it was decided to add it to box.info.

Hostname is obtained on requested and is not cached.

Closes #8605

@TarantoolBot document
Title: Add hostname to box.info

This patch adds hostname to box.info, it can be useful e.g. to supplement various instance state reports. It is not cached and is requested on each call.