### PR TITLE
sql: assert in xferOptimization()

### DIFF
--- a/changelogs/unreleased/gh-8661-assertion-in-xferOptimization.md
+++ b/changelogs/unreleased/gh-8661-assertion-in-xferOptimization.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Fixed a possible assertion or segmentation fault when optimizing
+  `INSERT INTO ... SELECT FROM` (gh-8661).

--- a/test/sql-luatest/gh_8661_assertion_in_xfer_optimization_test.lua
+++ b/test/sql-luatest/gh_8661_assertion_in_xfer_optimization_test.lua
@@ -1,0 +1,23 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_index_field_missing = function()
+    g.server:exec(function()
+        box.execute([[CREATE TABLE t(i INT PRIMARY KEY);]])
+        box.schema.space.create('A', {format = {{'i', 'integer'}}})
+        local _, ret = box.execute([[INSERT INTO t SELECT * FROM a;]])
+        local err = 'SQL does not support spaces without primary key'
+        t.assert_equals(ret.message, err)
+    end)
+end


### PR DESCRIPTION
This patch fixes problems with INSERT INTO ... SELECT FROM optimization. These problems appeared after 6b8acd8, where the check became redundant, but was not updated. Two problems arose:
1) an assertion or segmentation fault when optimization was used and the source space does not have an index;
2) optimization can be used even if the indexes are incompatible.

The second problem does not result in changes that are noticeable to the user, so there is no test.

Closes #8661

NO_DOC=bugfix