### PR TITLE
box: compare and hash msgpack value of double key field as double

### DIFF
--- a/changelogs/unreleased/gh-7483-ignore-mpack-types.md
+++ b/changelogs/unreleased/gh-7483-ignore-mpack-types.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed the inability to insert an integral number into a double-formatted
+  field (gh-7483).

--- a/src/box/field_def.c
+++ b/src/box/field_def.c
@@ -69,7 +69,8 @@ const uint32_t field_mp_type[] = {
 	/* [FIELD_TYPE_STRING]   =  */ 1U << MP_STR,
 	/* [FIELD_TYPE_NUMBER]   =  */ (1U << MP_UINT) | (1U << MP_INT) |
 		(1U << MP_FLOAT) | (1U << MP_DOUBLE),
-	/* [FIELD_TYPE_DOUBLE]   =  */ 1U << MP_DOUBLE,
+	/* [FIELD_TYPE_DOUBLE]   =  */ (1U << MP_UINT) | (1U << MP_INT) |
+		(1U << MP_FLOAT) | (1U << MP_DOUBLE),
 	/* [FIELD_TYPE_INTEGER]  =  */ (1U << MP_UINT) | (1U << MP_INT),
 	/* [FIELD_TYPE_BOOLEAN]  =  */ 1U << MP_BOOL,
 	/* [FIELD_TYPE_VARBINARY] =  */ 1U << MP_BIN,

--- a/src/box/key_def.h
+++ b/src/box/key_def.h
@@ -1071,6 +1071,7 @@ tuple_compare_with_key(struct tuple *tuple, hint_t tuple_hint,
 
 /**
  * Compute hash of a tuple field.
+ * @param type - type of the field key part
  * @param ph1 - pointer to running hash
  * @param pcarry - pointer to carry
  * @param field - pointer to field data
@@ -1082,7 +1083,7 @@ tuple_compare_with_key(struct tuple *tuple, hint_t tuple_hint,
  */
 uint32_t
 tuple_hash_field(uint32_t *ph1, uint32_t *pcarry, const char **field,
-		 struct coll *coll);
+		 enum field_type type, struct coll *coll);
 
 /**
  * Compute hash of a key part.

--- a/src/box/tuple_bloom.c
+++ b/src/box/tuple_bloom.c
@@ -141,6 +141,7 @@ tuple_bloom_builder_add_key(struct tuple_bloom_builder *builder,
 
 	for (uint32_t i = 0; i < key_def->part_count; i++) {
 		total_size += tuple_hash_field(&h, &carry, &key,
+					       key_def->parts[i].type,
 					       key_def->parts[i].coll);
 		uint32_t hash = PMurHash32_Result(h, carry, total_size);
 		if (tuple_hash_array_add(&builder->parts[i], hash) != 0)
@@ -249,6 +250,7 @@ tuple_bloom_maybe_has_key(const struct tuple_bloom *bloom,
 
 	for (uint32_t i = 0; i < part_count; i++) {
 		total_size += tuple_hash_field(&h, &carry, &key,
+					       key_def->parts[i].type,
 					       key_def->parts[i].coll);
 		uint32_t hash = PMurHash32_Result(h, carry, total_size);
 		if (!bloom_maybe_has(&bloom->parts[i], hash))

--- a/test/engine-luatest/gh_7483_insert_int_into_double_field_test.lua
+++ b/test/engine-luatest/gh_7483_insert_int_into_double_field_test.lua
@@ -1,0 +1,67 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group('gh-7483-insert-int-into-double-field-test', {
+    {engine = 'memtx', index_type = 'tree'},
+    {engine = 'memtx', index_type = 'hash'},
+    {engine = 'vinyl', index_type = 'tree'},
+})
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.s ~= nil then
+            box.space.s:drop()
+        end
+    end)
+end)
+
+g.test_insert_int_into_double_field = function(cg)
+    cg.server:exec(function (engine, index_type)
+        local ffi = require('ffi')
+
+        local s = box.schema.space.create('s', { engine = engine })
+        s:create_index('s_idx', {type = index_type, parts = {1, 'double'}})
+
+        -- For double-typed key we cast it to double before hashing.
+        -- So 1 and 1.0 are interpret as the same value.
+        local int_1 = 1
+        local double_1 = ffi.new('double', 1.0)
+        local errdup = 'Duplicate key exists in unique index "s_idx" in space '
+                       ..'"s" with old tuple - '
+
+        -- Ok, new integer (1).
+        s:insert({int_1})
+
+        -- Fail, duplicate of 1.
+        t.assert_error_msg_contains(errdup, s.insert, s, {double_1})
+
+        -- Select the integer.
+        t.assert_equals(s:select({double_1}), {{int_1}});
+
+        -- 2 ** 63 - 1 can't be directly converted to double,
+        -- it becomes 2 ** 63 on cast.
+        local int_2e63_minus_1 = 0x7fffffffffffffffULL
+        local double_2e63 = ffi.new('double', int_2e63_minus_1)
+
+        -- Successfully insert the integer into the double field.
+        s:insert({int_2e63_minus_1})
+
+        -- Insert of double-casted integer should fail since it's recognized as
+        -- a duplicate of the integer inserted above (despite the fact that
+        -- integer is not exactly equal to the resulting double, it becomes
+        -- equal on cast to double in index).
+        t.assert_error_msg_contains(errdup, s.insert, s, {double_2e63})
+
+        -- Select of the double should retrieve the inserted integer.
+        t.assert_equals(s:select({double_2e63}), {{int_2e63_minus_1}})
+    end, {cg.params.engine, cg.params.index_type})
+end

--- a/test/engine/insert.result
+++ b/test/engine/insert.result
@@ -746,8 +746,7 @@ _ = s:create_index('ii')
 ---
 ...
 --
--- If number of Lua type NUMBER is not integer, than it could be
--- inserted in DOUBLE field.
+-- A number of Lua type NUMBER can be inserted in DOUBLE field.
 --
 s:insert({1, 1.1})
 ---
@@ -762,33 +761,31 @@ s:insert({3, -3.0009})
 - [3, -3.0009]
 ...
 --
--- Integers of Lua type NUMBER and CDATA of type int64 or uint64
--- cannot be inserted into this field.
+-- Integers of Lua type NUMBER and CDATA of type int64 or uint64 can
+-- also be inserted even if they can't be loselessly converted to
+-- double. They're stored in the space "as is".
 --
 s:insert({4, 1})
 ---
-- error: 'Tuple field 2 (d) type does not match one required by operation: expected
-    double, got unsigned'
+- [4, 1]
 ...
-s:insert({5, -9223372036854775800ULL})
+s:insert({5, 9223372036854775800ULL})
 ---
-- error: 'Tuple field 2 (d) type does not match one required by operation: expected
-    double, got unsigned'
+- [5, 9223372036854775800]
 ...
 s:insert({6, 18000000000000000000ULL})
 ---
-- error: 'Tuple field 2 (d) type does not match one required by operation: expected
-    double, got unsigned'
+- [6, 18000000000000000000]
 ...
 --
--- To insert an integer, we must cast it to a CDATA of type DOUBLE
--- using ffi.cast(). Non-integers can also be inserted this way.
+-- One can also cast a value to CDATA of type DOUBLE using ffi.cast().
+-- Non-integers can also be inserted this way.
 --
 s:insert({7, ffi.cast('double', 1)})
 ---
 - [7, 1]
 ...
-s:insert({8, ffi.cast('double', -9223372036854775808)})
+s:insert({8, ffi.cast('double', -9223372036854775800LL)})
 ---
 - [8, -9223372036854775808]
 ...
@@ -813,6 +810,9 @@ s:select()
 - - [1, 1.1]
   - [2, 2.5]
   - [3, -3.0009]
+  - [4, 1]
+  - [5, 9223372036854775800]
+  - [6, 18000000000000000000]
   - [7, 1]
   - [8, -9223372036854775808]
   - [9, 123]
@@ -829,13 +829,13 @@ dd:select(1.1)
 - - [1, 1.1]
   - [11, 1.1]
 ...
-dd:select(1)
+dd:select(-9223372036854775800LL)
 ---
-- error: 'Supplied key type of part 0 does not match index part type: expected double'
+- - [8, -9223372036854775808]
 ...
-dd:select(ffi.cast('double', 1))
+dd:select(ffi.cast('double', -9223372036854775800LL))
 ---
-- - [7, 1]
+- - [8, -9223372036854775808]
 ...
 -- Make sure the comparisons work correctly.
 dd:select(1.1, {iterator = 'ge'})
@@ -844,6 +844,8 @@ dd:select(1.1, {iterator = 'ge'})
   - [11, 1.1]
   - [2, 2.5]
   - [9, 123]
+  - [5, 9223372036854775800]
+  - [6, 18000000000000000000]
   - [10, 18000000000000000000]
 ...
 dd:select(1.1, {iterator = 'le'})
@@ -851,6 +853,7 @@ dd:select(1.1, {iterator = 'le'})
 - - [11, 1.1]
   - [1, 1.1]
   - [7, 1]
+  - [4, 1]
   - [12, -3.0009]
   - [3, -3.0009]
   - [8, -9223372036854775808]
@@ -859,11 +862,14 @@ dd:select(ffi.cast('double', 1.1), {iterator = 'gt'})
 ---
 - - [2, 2.5]
   - [9, 123]
+  - [5, 9223372036854775800]
+  - [6, 18000000000000000000]
   - [10, 18000000000000000000]
 ...
 dd:select(ffi.cast('double', 1.1), {iterator = 'lt'})
 ---
 - - [7, 1]
+  - [4, 1]
   - [12, -3.0009]
   - [3, -3.0009]
   - [8, -9223372036854775808]
@@ -874,6 +880,8 @@ dd:select(1.1, {iterator = 'all'})
   - [11, 1.1]
   - [2, 2.5]
   - [9, 123]
+  - [5, 9223372036854775800]
+  - [6, 18000000000000000000]
   - [10, 18000000000000000000]
 ...
 dd:select(1.1, {iterator = 'eq'})
@@ -885,6 +893,14 @@ dd:select(1.1, {iterator = 'req'})
 ---
 - - [11, 1.1]
   - [1, 1.1]
+...
+s:delete(4)
+---
+- [4, 1]
+...
+s:delete(6)
+---
+- [6, 18000000000000000000]
 ...
 s:delete(11)
 ---
@@ -900,31 +916,27 @@ ddd = s:create_index('ddd', {parts = {{2, 'double'}}})
 ...
 s:update(1, {{'=', 2, 2}})
 ---
-- error: 'Tuple field 2 (d) type does not match one required by operation: expected
-    double, got unsigned'
+- [1, 2]
 ...
 s:insert({22, 22})
 ---
-- error: 'Tuple field 2 (d) type does not match one required by operation: expected
-    double, got unsigned'
+- [22, 22]
 ...
 s:upsert({10, 100}, {{'=', 2, 2}})
 ---
-- error: 'Tuple field 2 (d) type does not match one required by operation: expected
-    double, got unsigned'
+- error: Duplicate key exists in unique index "ddd" in space "s" with old tuple -
+    [1, 2] and new tuple - [10, 2]
 ...
-s:upsert({100, 100}, {{'=', 2, 2}})
+s:upsert({101, 100}, {{'=', 2, 11}})
 ---
-- error: 'Tuple field 2 (d) type does not match one required by operation: expected
-    double, got unsigned'
 ...
 ddd:update(1, {{'=', 1, 70}})
 ---
-- error: 'Supplied key type of part 0 does not match index part type: expected double'
+- error: Attempt to modify a tuple field which is part of primary index in space 's'
 ...
 ddd:delete(1)
 ---
-- error: 'Supplied key type of part 0 does not match index part type: expected double'
+- [7, 1]
 ...
 s:update(2, {{'=', 2, 2.55}})
 ---
@@ -948,13 +960,13 @@ s:get(10)
 ---
 - [10, 2.2]
 ...
-ddd:update(1.1, {{'=', 3, 111}})
+ddd:update(2, {{'=', 3, 111}})
 ---
-- [1, 1.1, 111]
+- [1, 2, 111]
 ...
-ddd:delete(1.1)
+ddd:delete(2)
 ---
-- [1, 1.1, 111]
+- [1, 2, 111]
 ...
 s:update(2, {{'=', 2, ffi.cast('double', 255)}})
 ---
@@ -978,9 +990,9 @@ s:get(200)
 ---
 - [200, 222]
 ...
-ddd:update(ffi.cast('double', 1), {{'=', 3, 7}})
+ddd:update(22, {{'=', 3, 7}})
 ---
-- [7, 1, 7]
+- [22, 22, 7]
 ...
 ddd:delete(ffi.cast('double', 123))
 ---
@@ -990,11 +1002,12 @@ s:select()
 ---
 - - [2, 255]
   - [3, -3.0009]
-  - [7, 1, 7]
+  - [5, 9223372036854775800]
   - [8, -9223372036854775808]
   - [10, 2.2]
-  - [22, 22]
+  - [22, 22, 7]
   - [100, 100.5]
+  - [101, 100]
   - [200, 222]
 ...
 s:drop()

--- a/test/sql-tap/cast.test.lua
+++ b/test/sql-tap/cast.test.lua
@@ -1145,12 +1145,15 @@ test:do_catchsql_test(
     })
 
 -- Make sure that search using index in field type number work right.
+-- NOTE: Both 9999999999999999 and 10000000000000001 become the same value
+-- in index comparison because of double-cast, so we use -or-equal variants
+-- of iterators. Don't expect to have precise comparisons in double indexes.
 test:do_execsql_test(
     "cast-11",
     [[
         CREATE TABLE t6(d DOUBLE PRIMARY KEY);
         INSERT INTO t6 VALUES(10000000000000000);
-        SELECT d FROM t6 WHERE d < 10000000000000001 and d > 9999999999999999;
+        SELECT d FROM t6 WHERE d <= 10000000000000001 and d >= 9999999999999999;
         DROP TABLE t6;
     ]], {
         10000000000000000

--- a/test/unit/msgpack.result
+++ b/test/unit/msgpack.result
@@ -2375,7 +2375,7 @@ ok 22 - subtests
     ok 24 - valid fixext128
     # *** test_mp_check_ext_data: done ***
 ok 23 - subtests
-    1..96
+    1..134
     # *** test_numbers ***
     ok 1 - mp_read_int32(mp_encode_uint(123)) check success
     ok 2 - mp_read_int32(mp_encode_uint(123)) check pos advanced
@@ -2473,6 +2473,44 @@ ok 23 - subtests
     ok 94 - mp_read_double(mp_encode_double(-5.555)) check result
     ok 95 - mp_read_double(mp_encode_strl(100)) check fail
     ok 96 - mp_read_double(mp_encode_strl(100)) check pos unchanged
+    ok 97 - mp_read_double_lossy(mp_encode_uint(123)) check success
+    ok 98 - mp_read_double_lossy(mp_encode_uint(123)) check pos advanced
+    ok 99 - mp_read_double_lossy(mp_encode_uint(123)) check result
+    ok 100 - mp_read_double_lossy(mp_encode_uint(12345)) check success
+    ok 101 - mp_read_double_lossy(mp_encode_uint(12345)) check pos advanced
+    ok 102 - mp_read_double_lossy(mp_encode_uint(12345)) check result
+    ok 103 - mp_read_double_lossy(mp_encode_uint(123456789)) check success
+    ok 104 - mp_read_double_lossy(mp_encode_uint(123456789)) check pos advanced
+    ok 105 - mp_read_double_lossy(mp_encode_uint(123456789)) check result
+    ok 106 - mp_read_double_lossy(mp_encode_uint(1234567890000ULL)) check success
+    ok 107 - mp_read_double_lossy(mp_encode_uint(1234567890000ULL)) check pos advanced
+    ok 108 - mp_read_double_lossy(mp_encode_uint(1234567890000ULL)) check result
+    ok 109 - mp_read_double_lossy(mp_encode_uint(123456789123456789ULL)) check success
+    ok 110 - mp_read_double_lossy(mp_encode_uint(123456789123456789ULL)) check pos advanced
+    ok 111 - mp_read_double_lossy(mp_encode_uint(123456789123456789ULL)) check result
+    ok 112 - mp_read_double_lossy(mp_encode_int(-123)) check success
+    ok 113 - mp_read_double_lossy(mp_encode_int(-123)) check pos advanced
+    ok 114 - mp_read_double_lossy(mp_encode_int(-123)) check result
+    ok 115 - mp_read_double_lossy(mp_encode_int(-12345)) check success
+    ok 116 - mp_read_double_lossy(mp_encode_int(-12345)) check pos advanced
+    ok 117 - mp_read_double_lossy(mp_encode_int(-12345)) check result
+    ok 118 - mp_read_double_lossy(mp_encode_int(-123456789)) check success
+    ok 119 - mp_read_double_lossy(mp_encode_int(-123456789)) check pos advanced
+    ok 120 - mp_read_double_lossy(mp_encode_int(-123456789)) check result
+    ok 121 - mp_read_double_lossy(mp_encode_int(-1234567890000LL)) check success
+    ok 122 - mp_read_double_lossy(mp_encode_int(-1234567890000LL)) check pos advanced
+    ok 123 - mp_read_double_lossy(mp_encode_int(-1234567890000LL)) check result
+    ok 124 - mp_read_double_lossy(mp_encode_int(-123456789123456789LL)) check success
+    ok 125 - mp_read_double_lossy(mp_encode_int(-123456789123456789LL)) check pos advanced
+    ok 126 - mp_read_double_lossy(mp_encode_int(-123456789123456789LL)) check result
+    ok 127 - mp_read_double_lossy(mp_encode_float(6.565e6)) check success
+    ok 128 - mp_read_double_lossy(mp_encode_float(6.565e6)) check pos advanced
+    ok 129 - mp_read_double_lossy(mp_encode_float(6.565e6)) check result
+    ok 130 - mp_read_double_lossy(mp_encode_double(-5.555)) check success
+    ok 131 - mp_read_double_lossy(mp_encode_double(-5.555)) check pos advanced
+    ok 132 - mp_read_double_lossy(mp_encode_double(-5.555)) check result
+    ok 133 - mp_read_double_lossy(mp_encode_strl(100)) check fail
+    ok 134 - mp_read_double_lossy(mp_encode_strl(100)) check pos unchanged
     # *** test_numbers: done ***
 ok 24 - subtests
     1..5

--- a/test/vinyl/upsert.result
+++ b/test/vinyl/upsert.result
@@ -1187,12 +1187,12 @@ box.snapshot()
 ---
 - ok
 ...
--- Can't assign integer to float field. First operation is still applied.
+-- Can assign integer to float field.
 --
-s:upsert({1, 1, 1, 2.5, decimal.new(1.1)}, {{'+', 4, 4}})
+s:upsert({1, 1, 1, 2.5, decimal.new(1.1)}, {{'=', 4, 4}})
 ---
 ...
-s:upsert({1, 1, 1, 2.5, decimal.new(1.1)}, {{'=', 4, 4}})
+s:upsert({1, 1, 1, 2.5, decimal.new(1.1)}, {{'+', 4, 4}})
 ---
 ...
 -- Can't add floating point to integer (result is floating point).
@@ -1209,7 +1209,7 @@ box.snapshot()
 ...
 s:select()
 ---
-- - [1, 1, 1, 5.1, 1.1]
+- - [1, 1, 1, 8, 1.1]
   - [2, 6, 1, 1.1, 1.1]
 ...
 -- Integer overflow check.
@@ -1234,7 +1234,7 @@ box.snapshot()
 ...
 s:select()
 ---
-- - [1, 1, 9223372036854775809, 5.1, 1.1]
+- - [1, 1, 9223372036854775809, 8, 1.1]
   - [2, 8, 1, 1.1, 1.1]
 ...
 -- Decimals do not fit into numerics and vice versa.
@@ -1257,7 +1257,7 @@ box.snapshot()
 ...
 s:select()
 ---
-- - [1, 1, 9223372036854775809, 5.1, 2.1]
+- - [1, 1, 9223372036854775809, 8, 2.1]
   - [2, 8, 1, 1.1, 1.1]
 ...
 s:drop()

--- a/test/vinyl/upsert.test.lua
+++ b/test/vinyl/upsert.test.lua
@@ -495,10 +495,10 @@ pk = s:create_index('pk')
 s:replace{1, 1, 1, 1.1, decimal.new(1.1) }
 s:replace{2, 1, 1, 1.1, decimal.new(1.1)}
 box.snapshot()
--- Can't assign integer to float field. First operation is still applied.
+-- Can assign integer to float field.
 --
-s:upsert({1, 1, 1, 2.5, decimal.new(1.1)}, {{'+', 4, 4}})
 s:upsert({1, 1, 1, 2.5, decimal.new(1.1)}, {{'=', 4, 4}})
+s:upsert({1, 1, 1, 2.5, decimal.new(1.1)}, {{'+', 4, 4}})
 -- Can't add floating point to integer (result is floating point).
 --
 s:upsert({2, 1, 1, 2.5, decimal.new(1.1)}, {{'+', 2, 5}})


### PR DESCRIPTION
**Overview**

Make double-formatted fields accept all integer and float values.
Make indices compare double key fields (being int, uint, float or double) as doubles.
Make indices hash double key fields (being int, uint, float or double) as doubles.

So we are able to insert any number into a double-formatted field and it's interpret by indices appropriately.

Closes https://github.com/tarantool/tarantool/issues/7483
Closes https://github.com/tarantool/tarantool/issues/5933
Unblocks https://github.com/tarantool/crud/issues/298

**Changes in tuple_compare.cc:**

Comparators cast any value placed in double key field to double and compare them as doubles.

Since now `mp_compare_double` casts any value placed in field to double it was renamed to `mp_compare_as_double` to not semantically conflict with existing `mp_compare_double_*` functions.

**Changes in tuple_hash.cc:**

Hashers cast any value placed in double key field to double, encode it in double msgpack and hash it. The msgpack encoding is made for backward compatibility.

Since now the field hashing function (`tuple_hash_field`) requires field type to hash the field correctly, a new parameter has been introduced.

By the way added assertions to `field_hash` and made `key_hash_slowpath` static cause it's only used in this file.

**Changes in msgpuck:**

Added `mp_read_double_lossy` method similar to `mp_read_double` but without value checks.

**Performance effect:**

Typical slowdown for tree index with single unique double key is ~2.5% (for in-tarantool C++ benchmark, with TX thread pinned to an isolated CPU core in NOHZ mode).

__TBD__

1. Calculate non-unique index lookup slowdown.