### PR TITLE
ci: fix lango stale PRs workflow

### DIFF
--- a/.github/workflows/lango-stale-reviews.yml
+++ b/.github/workflows/lango-stale-reviews.yml
@@ -1,7 +1,7 @@
 name: lango-stale-reviews
 on:
   schedule:
-    - cron:  '* */1 * * *'    # At every hour.
+    - cron:  '0 */1 * * *'    # At every hour.
   workflow_dispatch:
 
 jobs:
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python3
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Install dependencies
         run: pip install requests
       - name: Update dates


### PR DESCRIPTION
This patch fixes the crontab expression in the
Lango team stale PRs workflow, so it runs not every minute, but every hour.

Also, python version is updated to 3.11, since the script is reliant onto `datetime.fromisoformat' changes, that were introduced in that version.

NO_DOC=Workflow fix
NO_TEST=Workflow fix
NO_CHANGELOG=Workflow fix