### PR TITLE
box: fix unique violation in functional index with nullable parts

### DIFF
--- a/changelogs/unreleased/gh-8587-unique-violation-in-functional-index-with-nullable.md
+++ b/changelogs/unreleased/gh-8587-unique-violation-in-functional-index-with-nullable.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a bug when a tuple could be inserted even if it violates a `unique`
+  constraint of a functional index that has a nullable part (gh-8587).

--- a/test/box-luatest/gh_8587_func_index_unique_violation_test.lua
+++ b/test/box-luatest/gh_8587_func_index_unique_violation_test.lua
@@ -1,0 +1,106 @@
+local t = require('luatest')
+
+local g = t.group('gh-8587', t.helpers.matrix{
+                                is_unique = {true, false},
+                                is_nullable = {true, false}})
+g.before_all(function(cg)
+    local server = require('luatest.server')
+    cg.server = server:new{alias = 'master'}
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test then box.space.test:drop() end
+    end)
+end)
+
+-- Test a simple functional index with all combinations of
+-- unique = {true, false} and is_nullable = {true, false}.
+g.test_simple = function(cg)
+    cg.server:exec(function(is_unique, is_nullable)
+        local opts = {format = {{name = 'id', type = 'unsigned'},
+                                {name = 'f2', type = 'string',
+                                 is_nullable = is_nullable}}}
+        local s = box.schema.space.create('test', opts)
+        s:create_index('pk')
+
+        opts = {is_sandboxed = true,
+                is_deterministic = true,
+                body = "function(tuple) return {tuple[2]} end"}
+        box.schema.func.create('func_ret_f2', opts)
+
+        opts = {func = 'func_ret_f2',
+                unique = is_unique,
+                parts = {{field = 1, type = 'string',
+                          is_nullable = is_nullable}}}
+        local idx = s:create_index('idx', opts)
+
+        if is_nullable then
+            s:insert{1, box.NULL}
+            s:insert{2, box.NULL}
+            t.assert_equals(idx:select(), {{1}, {2}})
+        end
+
+        s:insert{3, 'aa'}
+        if is_unique then
+            t.assert_error_msg_content_equals(
+                'Duplicate key exists in unique index "idx" in space "test" ' ..
+                'with old tuple - [3, "aa"] and new tuple - [4, "aa"]',
+                function() s:insert{4, 'aa'} end)
+            t.assert_equals(idx:select{'aa'}, {{3, 'aa'}})
+        else
+            s:insert{4, 'aa'}
+            t.assert_equals(idx:select{'aa'}, {{3, 'aa'}, {4, 'aa'}})
+        end
+    end, {cg.params.is_unique, cg.params.is_nullable})
+end
+
+-- Test a multikey multipart functional index.
+g.test_multikey_multipart = function(cg)
+    cg.server:exec(function(is_unique, is_nullable)
+        local s = box.schema.space.create('test')
+        s:format{{name = 'name', type = 'string'},
+                 {name = 'address', type = 'string'},
+                 {name = 'address2', type = 'string'}}
+        s:create_index('name', {parts = {{field = 1, type = 'string'}}})
+        local lua_code = [[function(tuple)
+            local address = string.split(tuple[2])
+            local ret = {}
+            for _, v in pairs(address) do
+                table.insert(ret, {utf8.upper(v), tuple[3]})
+            end
+            return ret
+        end]]
+        box.schema.func.create('address', {body = lua_code,
+                                           is_sandboxed = true,
+                                           is_deterministic = true,
+                                           opts = {is_multikey = true}})
+        s:create_index('addr', {unique = is_unique,
+                                func = 'address',
+                                parts = {{field = 1, type = 'string',
+                                          is_nullable = is_nullable},
+                                         {field = 2, type = 'string',
+                                          is_nullable = is_nullable}}})
+        s:insert{'James', 'SIS Building Lambeth London UK', '1'}
+        s:insert{'Sherlock', '221B Baker St Marylebone London NW1 6XE UK', '2'}
+        if is_unique then
+            t.assert_error_msg_content_equals(
+                'Duplicate key exists in unique index "addr" in space "test"' ..
+                ' with old tuple - ["Sherlock", "221B Baker St Marylebone ' ..
+                'London NW1 6XE UK", "2"] and new tuple - ["Sherlock2", "' ..
+                '221B Baker St Marylebone London NW1 6XE UK", "2"]',
+                function()
+                    s:insert{'Sherlock2',
+                             '221B Baker St Marylebone London NW1 6XE UK', '2'}
+                end)
+        else
+            s:insert{'Sherlock2',
+                     '221B Baker St Marylebone London NW1 6XE UK', '2'}
+        end
+    end, {cg.params.is_unique, cg.params.is_nullable})
+end

--- a/test/unit/key_def.c
+++ b/test/unit/key_def.c
@@ -135,6 +135,114 @@ test_key_def_new_func(const char *format, ...)
 }
 
 /**
+ * Checks that tuple_compare() -> func_index_compare() return value equals
+ * `expected`.
+ */
+static void
+test_check_tuple_compare_func(struct key_def *cmp_def,
+			      struct tuple *tuple_a, struct tuple *func_key_a,
+			      struct tuple *tuple_b, struct tuple *func_key_b,
+			      int expected)
+{
+	int r = tuple_compare(tuple_a, (hint_t)func_key_a,
+			      tuple_b, (hint_t)func_key_b, cmp_def);
+	r = r > 0 ? 1 : r < 0 ? -1 : 0;
+	is(r, expected, "func_index_compare(%s/%s, %s/%s) = %d, expected %d",
+	   tuple_str(tuple_a), tuple_str(func_key_a),
+	   tuple_str(tuple_b), tuple_str(func_key_b), r, expected);
+}
+
+static void
+test_func_compare(void)
+{
+	plan(6);
+	header();
+
+	struct key_def *func_def = test_key_def_new_func(
+		"[{%s%u%s%s%s%b}{%s%u%s%s%s%b}]",
+		"field", 0, "type", "string", "is_nullable", 1,
+		"field", 1, "type", "string", "is_nullable", 1);
+
+	struct key_def *pk_def = test_key_def_new(
+		"[{%s%u%s%s}]",
+		"field", 1, "type", "unsigned");
+
+	struct key_def *cmp_def = key_def_merge(func_def, pk_def);
+	/* Just like when `opts->is_unique == true`, see index_def_new(). */
+	cmp_def->unique_part_count = func_def->part_count;
+
+	struct testcase {
+		int expected_result;
+		struct tuple *tuple_a;
+		struct tuple *tuple_b;
+		struct tuple *func_key_a;
+		struct tuple *func_key_b;
+	};
+
+	struct testcase testcases[] = {
+		{
+			-1, /* func_key_a < func_key_b */
+			test_tuple_new("[%s%u%s]", "--", 0, "--"),
+			test_tuple_new("[%s%u%s]", "--", 0, "--"),
+			test_tuple_new("[%sNIL]", "aa"),
+			test_tuple_new("[%s%s]", "aa", "bb"),
+		}, {
+			1, /* func_key_a > func_key_b */
+			test_tuple_new("[%s%u%s]", "--", 0, "--"),
+			test_tuple_new("[%s%u%s]", "--", 0, "--"),
+			test_tuple_new("[%s%s]", "aa", "bb"),
+			test_tuple_new("[%sNIL]", "aa"),
+		}, {
+			0, /* func_key_a == func_key_b, pk not compared */
+			test_tuple_new("[%s%u%s]", "--", 10, "--"),
+			test_tuple_new("[%s%u%s]", "--", 20, "--"),
+			test_tuple_new("[%s%s]", "aa", "bb"),
+			test_tuple_new("[%s%s]", "aa", "bb"),
+		}, {
+			-1, /* func_key_a == func_key_b, pk_a < pk_b */
+			test_tuple_new("[%s%u%s]", "--", 30, "--"),
+			test_tuple_new("[%s%u%s]", "--", 40, "--"),
+			test_tuple_new("[%sNIL]", "aa"),
+			test_tuple_new("[%sNIL]", "aa"),
+		}, {
+			1, /* func_key_a == func_key_b, pk_a > pk_b */
+			test_tuple_new("[%s%u%s]", "--", 60, "--"),
+			test_tuple_new("[%s%u%s]", "--", 50, "--"),
+			test_tuple_new("[%sNIL]", "aa"),
+			test_tuple_new("[%sNIL]", "aa"),
+		}, {
+			0, /* func_key_a == func_key_b, pk_a == pk_b */
+			test_tuple_new("[%s%u%s]", "--", 70, "--"),
+			test_tuple_new("[%s%u%s]", "--", 70, "--"),
+			test_tuple_new("[%sNIL]", "aa"),
+			test_tuple_new("[%sNIL]", "aa"),
+		}
+	};
+
+	for (size_t i = 0; i < lengthof(testcases); i++) {
+		struct testcase *t = &testcases[i];
+		test_check_tuple_compare_func(cmp_def,
+					      t->tuple_a, t->func_key_a,
+					      t->tuple_b, t->func_key_b,
+					      t->expected_result);
+	}
+
+	for (size_t i = 0; i < lengthof(testcases); i++) {
+		struct testcase *t = &testcases[i];
+		tuple_delete(t->tuple_a);
+		tuple_delete(t->tuple_b);
+		tuple_delete(t->func_key_a);
+		tuple_delete(t->func_key_b);
+	}
+	key_def_delete(func_def);
+	key_def_delete(pk_def);
+	key_def_delete(cmp_def);
+
+	footer();
+	check_plan();
+}
+
+/**
  * Checks that tuple_compare_with_key with cmp_def of functional index
  * returns the same result as comparison of concatenated func and primary keys.
  */
@@ -217,6 +325,8 @@ test_func_compare_with_key(void)
 	for (unsigned int i = 0; i < lengthof(keys); i++)
 		free(keys[i]);
 	tuple_delete(func_key);
+	tuple_delete(tuple);
+	tuple_delete(model);
 	key_def_delete(def);
 	key_def_delete(pk_def);
 	key_def_delete(cmp_def);
@@ -350,9 +460,10 @@ test_tuple_validate_key_parts_raw(void)
 static int
 test_main(void)
 {
-	plan(3);
+	plan(4);
 	header();
 
+	test_func_compare();
 	test_func_compare_with_key();
 	test_tuple_extract_key_raw_slowpath_nullable();
 	test_tuple_validate_key_parts_raw();


### PR DESCRIPTION
Currently `is_nullable` property of a functional index part disables the `unique` property of the index. The bug is in `func_index_compare()`, which compares functional keys first, and if they are equal it compares the primary keys. This behaviour is correct only when some part of the key is NULL (and for non-unique indexes), but for now the primary keys are compared unconditionally. Fix this by checking for NULL key parts.

Closes #8587