### PR TITLE
Generate changelog for 2.10.7

### DIFF
--- a/changelogs/2.10.7.md
+++ b/changelogs/2.10.7.md
@@ -1,0 +1,87 @@
+Date: 2023-05-24
+Tag: 2.10.7
+
+## Overview
+
+2.10.7 is the 8th [stable][release_policy] version of the 2.10 release
+series. It resolves 17 bugs since 2.10.6.
+
+The "stable" label means that we have all planned features implemented and we
+see no high-impact issues. However, if you encounter an issue, feel free to
+[report it][issues] on GitHub.
+
+[release_policy]: https://www.tarantool.io/en/doc/latest/dev_guide/release_management/#release-policy
+[issues]: https://github.com/tarantool/tarantool/issues
+
+## Compatibility
+
+Tarantool 2.x is backward compatible with Tarantool 1.10.x in the binary data
+layout, client-server protocol, and replication protocol.
+
+Please [upgrade][upgrade] using the `box.schema.upgrade()` procedure to unlock
+all the new features of the 2.x series.
+
+[upgrade]: https://www.tarantool.io/en/doc/latest/book/admin/upgrades/
+
+## Bugs fixed
+
+### Core
+
+* Fixed a crash that could happen when preparing a crash report on macOS
+  (gh-8445).
+* Fixed an integer overflow issue in `net.box` (ghs-121).
+* An `IPROTO_EVENT` packet now has the same sync number as the last
+  corresponding `IPROTO_WATCH` request (gh-8393).
+* Fixed a bug because of which a dirty (not committed to WAL) DDL record could
+  be written to a snapshot and cause a recovery failure (gh-8530).
+
+### Replication
+
+* Fixed a bug that occurred on applier failure: a node could start an election
+  without having a quorum to do this (gh-8433).
+* Now if a join fails with some non-critical error, such as `ER_READONLY`,
+  `ER_ACCESS_DENIED`, or something network-related, the instance tries
+  to find a new master to join off and tries again (gh-6126, gh-8681).
+
+* States when joining a replica are renamed. Now the value of
+  `box.info.replication[id].upstream.status` during join can be either
+ `wait_snapshot` or `fetch_snapshot` instead of `initial_join` (gh-6126).
+* Fixed replicaset bootstrap getting stuck on some nodes with `ER_READONLY` when
+  there are connectivity problems (gh-7737, gh-8681).
+* Fixed a bug when a replicaset state machine that is tracking the number
+  of appliers according to their states could become inconsistent during
+  reconfiguration (gh-7590).
+
+### LuaJIT
+
+Backported patches from vanilla LuaJIT trunk (gh-8069). In the scope of this
+activity, the following issues have been resolved:
+
+* Fixed `emit_rma()` for x64/GC64 mode for non-`mov` instructions.
+* Limited Lua C library path with the default `PATH_MAX` value of 4096 bytes.
+  Backported patches from the vanilla LuaJIT trunk (gh-8516). The following issues
+  were fixed as part of this activity:
+
+* Fixed assembling of `IR_LREF` assembling for GC64 mode on x86_64.
+
+### SQL
+
+* Fixed an assertion when selecting tuples with incomplete internal
+  format (gh-8418).
+* Fixed integer overflow issues in built-in functions (ghs-119).
+* Fixed a possible assertion or segmentation fault when optimizing
+  `INSERT INTO ... SELECT FROM` (gh-8661).
+* Fixed an integer overflow issue and added check for the `printf()` failure due
+  to too large size (ghs-122).
+
+### Datetime
+
+* Fixed an error in `datetime.set` when `timestamp` is passed along with `nsec`,
+ `usec`, or `msec` (gh-8583).
+* Fixed errors when the string representation of a datetime object had
+ a negative nanosecond part (gh-8570).
+
+### Build
+
+* Enabled compiler optimizations for static build dependencies, which were
+  erroneously disabled in version 2.10.3 (gh-8606).

--- a/changelogs/unreleased/fix-bootstrap-with-er-readonly.md
+++ b/changelogs/unreleased/fix-bootstrap-with-er-readonly.md
@@ -1,4 +1,0 @@
-## bugfix/replication
-
-* Fixed replicaset bootstrap getting stuck on some nodes with `ER_READONLY` when
-  there are connectivity problems (gh-7737, gh-8681).

--- a/changelogs/unreleased/gh-6126-retry-join-automatically.md
+++ b/changelogs/unreleased/gh-6126-retry-join-automatically.md
@@ -1,9 +1,0 @@
-## bugfix/replication
-
-* Now if a join fails with some non-critical error, such as `ER_READONLY`,
-  `ER_ACCESS_DENIED`, or something network-related, the instance tries
-  to find a new master to join off and tries again (gh-6126, gh-8681).
-
-* States when joining a replica are renamed. Now the value of
-  `box.info.replication[id].upstream.status` during join can be either
- `wait_snapshot` or `fetch_snapshot` instead of `initial_join` (gh-6126).

--- a/changelogs/unreleased/gh-7590-replicaset-assert.md
+++ b/changelogs/unreleased/gh-7590-replicaset-assert.md
@@ -1,5 +1,0 @@
-## bugfix/replication
-
-* Fixed a bug when a replicaset state machine that is tracking the number
-  of appliers according to their states could become inconsistent during
-  reconfiguration (gh-7590).

--- a/changelogs/unreleased/gh-8069-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8069-luajit-fixes.md
@@ -1,7 +1,0 @@
-## bugfix/luajit
-
-Backported patches from vanilla LuaJIT trunk (gh-8069). In the scope of this
-activity, the following issues have been resolved:
-
-* Fixed `emit_rma()` for x64/GC64 mode for non-`mov` instructions.
-* Limited Lua C library path with the default `PATH_MAX` value of 4096 bytes.

--- a/changelogs/unreleased/gh-8393-iproto-watch-sync.md
+++ b/changelogs/unreleased/gh-8393-iproto-watch-sync.md
@@ -1,4 +1,0 @@
-## bugfix/core
-
-* An `IPROTO_EVENT` packet now has the same sync number as the last
-  corresponding `IPROTO_WATCH` request (gh-8393).

--- a/changelogs/unreleased/gh-8418-asserton-on-select-from-_space.md
+++ b/changelogs/unreleased/gh-8418-asserton-on-select-from-_space.md
@@ -1,4 +1,0 @@
-## bugfix/sql
-
-* Fixed an assertion when selecting tuples with incomplete internal
-  format (gh-8418).

--- a/changelogs/unreleased/gh-8433-raft-is-candidate.md
+++ b/changelogs/unreleased/gh-8433-raft-is-candidate.md
@@ -1,4 +1,0 @@
-## bugfix/replication
-
-* Fixed a bug that occurred on applier failure: a node could start an election
-  without having a quorum to do this (gh-8433).

--- a/changelogs/unreleased/gh-8445-crash-during-crash-report.md
+++ b/changelogs/unreleased/gh-8445-crash-during-crash-report.md
@@ -1,4 +1,0 @@
-## bugfix/core
-
-* Fixed a crash that could happen when preparing a crash report on macOS
-  (gh-8445).

--- a/changelogs/unreleased/gh-8516-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8516-luajit-fixes.md
@@ -1,6 +1,0 @@
-## bugfix/luajit
-
-Backported patches from the vanilla LuaJIT trunk (gh-8516). The following issues
-were fixed as part of this activity:
-
-* Fixed assembling of `IR_LREF` assembling for GC64 mode on x86_64.

--- a/changelogs/unreleased/gh-8530-alter-space-snapshot-fix.md
+++ b/changelogs/unreleased/gh-8530-alter-space-snapshot-fix.md
@@ -1,4 +1,0 @@
-## bugfix/core
-
-* Fixed a bug because of which a dirty (not committed to WAL) DDL record could
-  be written to a snapshot and cause a recovery failure (gh-8530).

--- a/changelogs/unreleased/gh-8570-fix-datetime-str-negative-nsec.md
+++ b/changelogs/unreleased/gh-8570-fix-datetime-str-negative-nsec.md
@@ -1,4 +1,0 @@
-## bugfix/datetime
-
-* Fixed errors when the string representation of a datetime object had
-a negative nanosecond part (gh-8570).

--- a/changelogs/unreleased/gh-8583-fix-datetime-set-with-nsec.md
+++ b/changelogs/unreleased/gh-8583-fix-datetime-set-with-nsec.md
@@ -1,4 +1,0 @@
-## bugfix/datetime
-
-* Fixed an error in `datetime.set` when `timestamp` is passed along with `nsec`,
-`usec`, or `msec` (gh-8583).

--- a/changelogs/unreleased/gh-8606-static-build-enable-optimization.md
+++ b/changelogs/unreleased/gh-8606-static-build-enable-optimization.md
@@ -1,4 +1,0 @@
-## bugfix/build
-
-* Enabled compiler optimizations for static build dependencies, which were
-  erroneously disabled in version 2.10.3 (gh-8606).

--- a/changelogs/unreleased/gh-8661-assertion-in-xferOptimization.md
+++ b/changelogs/unreleased/gh-8661-assertion-in-xferOptimization.md
@@ -1,4 +1,0 @@
-## bugfix/sql
-
-* Fixed a possible assertion or segmentation fault when optimizing
-  `INSERT INTO ... SELECT FROM` (gh-8661).

--- a/changelogs/unreleased/ghs-119-too-long-mem-values.md
+++ b/changelogs/unreleased/ghs-119-too-long-mem-values.md
@@ -1,3 +1,0 @@
-## bugfix/sql
-
-* Fixed integer overflow issues in built-in functions (ghs-119).

--- a/changelogs/unreleased/ghs-121-too-big-buffer-size.md
+++ b/changelogs/unreleased/ghs-121-too-big-buffer-size.md
@@ -1,3 +1,0 @@
-## bugfix/core
-
-* Fixed an integer overflow issue in `net.box` (ghs-121).

--- a/changelogs/unreleased/ghs-122-allocations-in-printf.md
+++ b/changelogs/unreleased/ghs-122-allocations-in-printf.md
@@ -1,4 +1,0 @@
-## bugfix/sql
-
-* Fixed an integer overflow issue and added check for the `printf()` failure due
-  to too large size (ghs-122).


### PR DESCRIPTION
Generate changelog for 2.10.7 release.
Also, clean changelogs/unreleased folder.

NO_DOC=no code changes
NO_TEST=no code changes
NO_CHANGELOG=no code changes