### PR TITLE
sql: fix assertion and check in PRINTF()

### DIFF
--- a/src/box/sql/func.c
+++ b/src/box/sql/func.c
@@ -943,8 +943,9 @@ func_printf(struct sql_context *ctx, int argc, const struct Mem *argv)
 	sqlStrAccumInit(&acc, db, 0, 0, db->aLimit[SQL_LIMIT_LENGTH]);
 	acc.printfFlags = SQL_PRINTF_SQLFUNC;
 	sqlXPrintf(&acc, format, &pargs);
-	assert(acc.accError == 0 || acc.accError == STRACCUM_TOOBIG);
-	if (acc.accError == STRACCUM_TOOBIG) {
+	assert(acc.accError == 0 || acc.accError == STRACCUM_TOOBIG ||
+	       acc.accError == STRACCUM_NOMEM);
+	if (acc.accError != 0) {
 		ctx->is_aborted = true;
 		diag_set(ClientError, ER_SQL_EXECUTE, "string or blob too big");
 		return;


### PR DESCRIPTION
In 2.11 and later, there is no STRACCUM_NOMEM error in printf(), however this is not the case in 2.10, resulting in an assertion or segmentation error. This patch fixes that.

Follow-up #tarantool/security#122

NO_DOC=backport fix
NO_TEST=backport fix
NO_CHANGELOG=backport fix
