### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-7745-exceptions-on-traces.md
+++ b/changelogs/unreleased/gh-7745-exceptions-on-traces.md
@@ -1,0 +1,3 @@
+## feature/luajit
+
+* Now the LuaJIT can handle exceptions on traces (gh-7745).

--- a/changelogs/unreleased/gh-8069-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8069-luajit-fixes.md
@@ -8,3 +8,5 @@ were fixed as part of this activity:
 * Fixed `pcall()` call without arguments on arm64.
 * Fixed assembling of IR_{AHUV}LOAD specialized to boolean for aarch64.
 * Fixed constant rematerialization on arm64.
+* Fixed `emit_rma()` for x64/GC64 mode for non-`mov` instructions.
+* Limited Lua C library path with the default `PATH_MAX` value of 4096 bytes.

--- a/changelogs/unreleased/gh-8516-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8516-luajit-fixes.md
@@ -1,0 +1,6 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-8516). The following issues
+were fixed as part of this activity:
+
+* Fixed assembling of `IR_LREF` assembling for GC64 mode on x86_64


### PR DESCRIPTION
* Fix IR_RENAME snapshot number. Follow-up fix for a32aeadc.
* OSX: Disable unreliable assertion for external frame unwinding.
* Disable unreliable assertion for external frame unwinding.
* Handle on-trace OOM errors from helper functions.
* LJ_GC64: Make ASMREF_L references 64 bit.
* lldb: introduce luajit-lldb
* x64/LJ_GC64: Fix emit_rma().
* Limit path length passed to C library loader.

Closes #7745
Part of #4808
Part of #8069
Part of #8516

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump
