### PR TITLE
Improve election stability and reproducibility

### DIFF
--- a/changelogs/unreleased/gh-8497-promote-atomic.md
+++ b/changelogs/unreleased/gh-8497-promote-atomic.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed a possible failure to promote the desired node by `box.ctl.promote()` on
+  a cluster with nodes configured with `election_mode = "candidate"` (gh-8497).

--- a/changelogs/unreleased/gh-8698-spurious-split-vote.md
+++ b/changelogs/unreleased/gh-8698-spurious-split-vote.md
@@ -1,0 +1,5 @@
+## bugfix/replication
+
+* Fixed nodes configured with `election_mode = 'candidate'` spuriously detecting
+  a split-vote when another candidate should win with exactly a quorum of votes
+  for it (gh-8698).

--- a/src/lib/raft/raft.c
+++ b/src/lib/raft/raft.c
@@ -1211,6 +1211,7 @@ raft_promote(struct raft *raft)
 		return;
 	raft_sm_schedule_new_term(raft, raft->volatile_term + 1);
 	raft_start_candidate(raft);
+	raft_sm_schedule_new_vote(raft, raft->self, raft->vclock);
 }
 
 void

--- a/src/lib/raft/raft.c
+++ b/src/lib/raft/raft.c
@@ -935,7 +935,7 @@ raft_sm_schedule_new_vote(struct raft *raft, uint32_t candidate_id,
 	assert(!raft->votes[raft->self].did_vote);
 	raft->volatile_vote = candidate_id;
 	vclock_copy(&raft->candidate_vclock, candidate_vclock);
-	raft_add_vote(raft, raft->self, raft->self);
+	raft_add_vote(raft, raft->self, candidate_id);
 	raft_sm_pause_and_dump(raft);
 	/* Nothing visible is changed - no broadcast. */
 }

--- a/src/lib/raft/raft.c
+++ b/src/lib/raft/raft.c
@@ -741,6 +741,15 @@ end_dump:
 		if (raft->volatile_vote == 0)
 			goto do_dump;
 		/*
+		 * Skip self. When vote is issued, own vclock can be smaller,
+		 * but that doesn't matter. Can always vote for self. Not having
+		 * this special case still works if the node is configured as a
+		 * candidate, but the node might log that it canceled a vote for
+		 * self, which is confusing.
+		 */
+		if (raft->volatile_vote == raft->self)
+			goto do_dump_with_vote;
+		/*
 		 * Vote and term bumps are persisted separately. This serves as
 		 * a flush of all transactions going to WAL right now so as the
 		 * current node could correctly compare its own vclock vs
@@ -750,15 +759,6 @@ end_dump:
 		 */
 		if (raft->volatile_term > raft->term)
 			goto do_dump;
-		/*
-		 * Skip self. When vote was issued, own vclock could be smaller,
-		 * but that doesn't matter. Can always vote for self. Not having
-		 * this special case still works if the node is configured as a
-		 * candidate, but the node might log that it canceled a vote for
-		 * self, which is confusing.
-		 */
-		if (raft->volatile_vote == raft->self)
-			goto do_dump_with_vote;
 		if (!raft_can_vote_for(raft, &raft->candidate_vclock)) {
 			say_info("RAFT: vote request for %u is canceled - the "
 				 "vclock is not acceptable anymore",

--- a/test/replication-luatest/gh_6036_qsync_order_test.lua
+++ b/test/replication-luatest/gh_6036_qsync_order_test.lua
@@ -187,7 +187,7 @@ g.test_promote_order = function(cg)
     cg.r1:exec(function() box.cfg{replication=""} end)
     cg.r2:exec(function()
         box.cfg{replication = {}}
-        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 2)
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 1)
         require('fiber').create(function() box.ctl.promote() end)
     end)
     t.helpers.retrying({}, function()

--- a/test/replication-luatest/gh_8497_atomic_promote_test.lua
+++ b/test/replication-luatest/gh_8497_atomic_promote_test.lua
@@ -1,0 +1,56 @@
+local t = require('luatest')
+local server = require('luatest.server')
+local replica_set = require('luatest.replica_set')
+
+local g = t.group('gh-8497-atomic-promote')
+
+g.before_each(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.replica_set = replica_set:new({})
+    cg.box_cfg = {
+        replication_timeout = 0.1,
+        replication = {
+            server.build_listen_uri('server1', cg.replica_set.id),
+            server.build_listen_uri('server2', cg.replica_set.id),
+        },
+    }
+    cg.box_cfg.election_mode = 'candidate'
+    cg.server1 = cg.replica_set:build_and_add_server{
+        alias = 'server1',
+        box_cfg = cg.box_cfg,
+    }
+    cg.box_cfg.election_mode = 'voter'
+    cg.server2 = cg.replica_set:build_and_add_server{
+        alias = 'server2',
+        box_cfg = cg.box_cfg,
+    }
+    cg.replica_set:start()
+    cg.replica_set:wait_for_fullmesh()
+    cg.server1:wait_for_election_leader()
+end)
+
+g.after_each(function(cg)
+    cg.replica_set:drop()
+end)
+
+g.test_election_promote_finishes_in_one_term = function(cg)
+    cg.server2:update_box_cfg{election_mode = 'candidate'}
+    local term = cg.server1:get_election_term()
+    t.assert_equals(term, cg.server2:get_election_term(),
+                    'The cluster is stable')
+    local ok, err = cg.server2:exec(function()
+        local fiber = require('fiber')
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 1)
+        local fib = fiber.new(box.ctl.promote)
+        fib:set_joinable(true)
+        fiber.sleep(2 * box.cfg.replication_timeout)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        return fib:join()
+    end)
+    t.assert_equals({ok, err}, {true, nil}, 'No error in promote')
+    cg.server2:wait_for_election_leader()
+    t.assert_equals(term + 1, cg.server1:get_election_term(),
+                    'The term is bumped once')
+    t.assert_equals(term + 1, cg.server2:get_election_term(),
+                    'The term is bumped once')
+end

--- a/test/replication/election_basic.result
+++ b/test/replication/election_basic.result
@@ -403,11 +403,11 @@ box.ctl.promote()
  | ---
  | ...
 
-test_run:wait_cond(function() return #election_tbl == 9 end)
+test_run:wait_cond(function() return #election_tbl == 8 end)
  | ---
  | - true
  | ...
-assert(election_tbl[7].state == 'follower')
+assert(election_tbl[7].state == 'candidate')
  | ---
  | - true
  | ...
@@ -415,20 +415,11 @@ assert(election_tbl[7].term == election_tbl[6].term + 1)
  | ---
  | - true
  | ...
--- Vote is visible here already, but it is volatile.
 assert(election_tbl[7].vote == 1)
  | ---
  | - true
  | ...
-assert(election_tbl[8].state == 'candidate')
- | ---
- | - true
- | ...
-assert(election_tbl[8].vote == 1)
- | ---
- | - true
- | ...
-assert(election_tbl[9].state == 'leader')
+assert(election_tbl[8].state == 'leader')
  | ---
  | - true
  | ...

--- a/test/replication/election_basic.result
+++ b/test/replication/election_basic.result
@@ -338,7 +338,7 @@ box.cfg{election_mode='candidate'}
  | ---
  | ...
 
-test_run:wait_cond(function() return #election_tbl == 4 end)
+test_run:wait_cond(function() return #election_tbl == 3 end)
  | ---
  | - true
  | ...
@@ -346,28 +346,23 @@ assert(election_tbl[1].state == 'follower')
  | ---
  | - true
  | ...
-assert(election_tbl[2].state == 'follower')
- | ---
- | - true
- | ...
 assert(election_tbl[2].term > election_tbl[1].term)
  | ---
  | - true
  | ...
--- Vote is visible here already, but it is volatile.
 assert(election_tbl[2].vote == 1)
  | ---
  | - true
  | ...
-assert(election_tbl[3].state == 'candidate')
+assert(election_tbl[2].state == 'candidate')
  | ---
  | - true
  | ...
-assert(election_tbl[3].vote == 1)
+assert(election_tbl[2].vote == 1)
  | ---
  | - true
  | ...
-assert(election_tbl[4].state == 'leader')
+assert(election_tbl[3].state == 'leader')
  | ---
  | - true
  | ...
@@ -375,11 +370,11 @@ assert(election_tbl[4].state == 'leader')
 box.cfg{election_mode='voter'}
  | ---
  | ...
-test_run:wait_cond(function() return #election_tbl == 5 end)
+test_run:wait_cond(function() return #election_tbl == 4 end)
  | ---
  | - true
  | ...
-assert(election_tbl[5].state == 'follower')
+assert(election_tbl[4].state == 'follower')
  | ---
  | - true
  | ...
@@ -387,7 +382,7 @@ assert(election_tbl[5].state == 'follower')
 box.cfg{election_mode='off'}
  | ---
  | ...
-test_run:wait_cond(function() return #election_tbl == 6 end)
+test_run:wait_cond(function() return #election_tbl == 5 end)
  | ---
  | - true
  | ...
@@ -395,11 +390,11 @@ test_run:wait_cond(function() return #election_tbl == 6 end)
 box.cfg{election_mode='manual'}
  | ---
  | ...
-test_run:wait_cond(function() return #election_tbl == 7 end)
+test_run:wait_cond(function() return #election_tbl == 6 end)
  | ---
  | - true
  | ...
-assert(election_tbl[7].state == 'follower')
+assert(election_tbl[6].state == 'follower')
  | ---
  | - true
  | ...
@@ -408,32 +403,32 @@ box.ctl.promote()
  | ---
  | ...
 
-test_run:wait_cond(function() return #election_tbl == 10 end)
+test_run:wait_cond(function() return #election_tbl == 9 end)
  | ---
  | - true
  | ...
-assert(election_tbl[8].state == 'follower')
+assert(election_tbl[7].state == 'follower')
  | ---
  | - true
  | ...
-assert(election_tbl[8].term == election_tbl[7].term + 1)
+assert(election_tbl[7].term == election_tbl[6].term + 1)
  | ---
  | - true
  | ...
 -- Vote is visible here already, but it is volatile.
+assert(election_tbl[7].vote == 1)
+ | ---
+ | - true
+ | ...
+assert(election_tbl[8].state == 'candidate')
+ | ---
+ | - true
+ | ...
 assert(election_tbl[8].vote == 1)
  | ---
  | - true
  | ...
-assert(election_tbl[9].state == 'candidate')
- | ---
- | - true
- | ...
-assert(election_tbl[9].vote == 1)
- | ---
- | - true
- | ...
-assert(election_tbl[10].state == 'leader')
+assert(election_tbl[9].state == 'leader')
  | ---
  | - true
  | ...

--- a/test/replication/election_basic.test.lua
+++ b/test/replication/election_basic.test.lua
@@ -165,14 +165,11 @@ assert(election_tbl[6].state == 'follower')
 
 box.ctl.promote()
 
-test_run:wait_cond(function() return #election_tbl == 9 end)
-assert(election_tbl[7].state == 'follower')
+test_run:wait_cond(function() return #election_tbl == 8 end)
+assert(election_tbl[7].state == 'candidate')
 assert(election_tbl[7].term == election_tbl[6].term + 1)
--- Vote is visible here already, but it is volatile.
 assert(election_tbl[7].vote == 1)
-assert(election_tbl[8].state == 'candidate')
-assert(election_tbl[8].vote == 1)
-assert(election_tbl[9].state == 'leader')
+assert(election_tbl[8].state == 'leader')
 
 test_run:cmd('stop server replica')
 test_run:cmd('delete server replica')

--- a/test/replication/election_basic.test.lua
+++ b/test/replication/election_basic.test.lua
@@ -144,37 +144,35 @@ _ = box.ctl.on_election(trig)
 box.cfg{replication_synchro_quorum=2}
 box.cfg{election_mode='candidate'}
 
-test_run:wait_cond(function() return #election_tbl == 4 end)
+test_run:wait_cond(function() return #election_tbl == 3 end)
 assert(election_tbl[1].state == 'follower')
-assert(election_tbl[2].state == 'follower')
 assert(election_tbl[2].term > election_tbl[1].term)
--- Vote is visible here already, but it is volatile.
 assert(election_tbl[2].vote == 1)
-assert(election_tbl[3].state == 'candidate')
-assert(election_tbl[3].vote == 1)
-assert(election_tbl[4].state == 'leader')
+assert(election_tbl[2].state == 'candidate')
+assert(election_tbl[2].vote == 1)
+assert(election_tbl[3].state == 'leader')
 
 box.cfg{election_mode='voter'}
-test_run:wait_cond(function() return #election_tbl == 5 end)
-assert(election_tbl[5].state == 'follower')
+test_run:wait_cond(function() return #election_tbl == 4 end)
+assert(election_tbl[4].state == 'follower')
 
 box.cfg{election_mode='off'}
-test_run:wait_cond(function() return #election_tbl == 6 end)
+test_run:wait_cond(function() return #election_tbl == 5 end)
 
 box.cfg{election_mode='manual'}
-test_run:wait_cond(function() return #election_tbl == 7 end)
-assert(election_tbl[7].state == 'follower')
+test_run:wait_cond(function() return #election_tbl == 6 end)
+assert(election_tbl[6].state == 'follower')
 
 box.ctl.promote()
 
-test_run:wait_cond(function() return #election_tbl == 10 end)
-assert(election_tbl[8].state == 'follower')
-assert(election_tbl[8].term == election_tbl[7].term + 1)
+test_run:wait_cond(function() return #election_tbl == 9 end)
+assert(election_tbl[7].state == 'follower')
+assert(election_tbl[7].term == election_tbl[6].term + 1)
 -- Vote is visible here already, but it is volatile.
+assert(election_tbl[7].vote == 1)
+assert(election_tbl[8].state == 'candidate')
 assert(election_tbl[8].vote == 1)
-assert(election_tbl[9].state == 'candidate')
-assert(election_tbl[9].vote == 1)
-assert(election_tbl[10].state == 'leader')
+assert(election_tbl[9].state == 'leader')
 
 test_run:cmd('stop server replica')
 test_run:cmd('delete server replica')

--- a/test/unit/raft.c
+++ b/test/unit/raft.c
@@ -2348,7 +2348,7 @@ raft_test_resign(void)
 		1 /* Vote. */,
 		2 /* Volatile term. */,
 		1 /* Volatile vote. */,
-		"{0: 2}" /* Vclock. */
+		"{0: 1}" /* Vclock. */
 	), "became leader");
 
 	raft_node_resign(&node);
@@ -2361,7 +2361,7 @@ raft_test_resign(void)
 		1 /* Vote. */,
 		2 /* Volatile term. */,
 		1 /* Volatile vote. */,
-		"{0: 2}" /* Vclock. */
+		"{0: 1}" /* Vclock. */
 	), "resigned from leader state");
 
 	raft_node_destroy(&node);


### PR DESCRIPTION
Fix a couple of bugs regarding election stability:
1. Make candidates write and broadcast term and vote for self atomically. This reduces possible split-vote scenarios where other candidates vote for themselves unnecessarily.
2. Do the same for `box.ctl.promote()`
3. Fix a bug in split-vote detector.

Closes #8497
Closes #8698