### PR TITLE
box: move space triggers to trigger module

### DIFF
--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -105,7 +105,7 @@ struct errcode_record {
 	/* 50 */_(ER_CREATE_FUNCTION,		"Failed to create function '%s': %s") \
 	/* 51 */_(ER_NO_SUCH_FUNCTION,		"Function '%s' does not exist") \
 	/* 52 */_(ER_FUNCTION_EXISTS,		"Function '%s' already exists") \
-	/* 53 */_(ER_BEFORE_REPLACE_RET,	"Invalid return value of space:before_replace trigger: expected tuple or nil, got %s") \
+	/* 53 */_(ER_BEFORE_REPLACE_RET,	"Invalid return value of space:before_replace trigger: expected tuple or nil") \
 	/* 54 */_(ER_MULTISTATEMENT_TRANSACTION,"Can not perform %s in a multi-statement transaction") \
 	/* 55 */_(ER_TRIGGER_EXISTS,		"Trigger '%s' already exists") \
 	/* 56 */_(ER_USER_MAX,			"A limit on the total number of users has been reached: %u") \

--- a/src/box/lua/func_adapter.c
+++ b/src/box/lua/func_adapter.c
@@ -7,6 +7,7 @@
 #include "box/lua/tuple.h"
 #include "box/tuple.h"
 #include "core/func_adapter.h"
+#include "lua/msgpack.h"
 #include "lua/utils.h"
 
 /**
@@ -136,6 +137,14 @@ func_adapter_lua_push_null(struct func_adapter_ctx *base)
 {
 	struct func_adapter_lua_ctx *ctx = (struct func_adapter_lua_ctx *)base;
 	lua_pushnil(ctx->L);
+}
+
+static void
+func_adapter_lua_push_msgpack(struct func_adapter_ctx *base, const char *data,
+			      const char *data_end)
+{
+	struct func_adapter_lua_ctx *ctx = (struct func_adapter_lua_ctx *)base;
+	luamp_push(ctx->L, data, data_end);
 }
 
 /**
@@ -273,6 +282,7 @@ func_adapter_lua_create(lua_State *L, int idx)
 		.push_tuple = func_adapter_lua_push_tuple,
 		.push_bool = func_adapter_lua_push_bool,
 		.push_null = func_adapter_lua_push_null,
+		.push_msgpack = func_adapter_lua_push_msgpack,
 
 		.is_double = func_adapter_lua_is_double,
 		.pop_double = func_adapter_lua_pop_double,

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -704,6 +704,13 @@ memtx_engine_bootstrap(struct engine *engine)
 	if (rc < 0)
 		return -1;
 	memtx->on_indexes_built_cb();
+
+	/* Complete space initialization. */
+	rc = space_foreach(space_on_bootstrap_complete, NULL);
+	if (rc != 0) {
+		diag_log();
+		panic("Failed to complete bootstrap!");
+	}
 	return 0;
 }
 

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -121,7 +121,13 @@ memtx_space_replace_build_next(struct space *space, struct tuple *old_tuple,
 			       enum dup_replace_mode mode,
 			       struct tuple **result)
 {
-	assert(old_tuple == NULL && mode == DUP_INSERT);
+	assert(old_tuple == NULL);
+	/*
+	 * If before_replace trigger changes tuple, the request is updated
+	 * and request type is changed to REPLACE, so we can meet
+	 * DUP_REPLACE_OR_INSERT here.
+	 */
+	assert(mode == DUP_INSERT || mode == DUP_REPLACE_OR_INSERT);
 	(void)mode;
 	*result = NULL;
 	if (old_tuple) {

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -2083,8 +2083,8 @@ memtx_tx_history_add_insert_stmt(struct txn_stmt *stmt,
 	 */
 	if (!is_own_change &&
 	    (mode == DUP_INSERT ||
-	     !rlist_empty(&stmt->space->before_replace) ||
-	     !rlist_empty(&stmt->space->on_replace))) {
+	     space_has_before_replace_triggers(stmt->space) ||
+	     space_has_on_replace_triggers(stmt->space))) {
 		assert(mode != DUP_INSERT || del_story == NULL);
 		if (del_story == NULL)
 			memtx_tx_track_story_gap(stmt->txn, add_story, 0);

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -639,9 +639,9 @@ txn_commit_stmt(struct txn *txn, struct request *request)
 	 */
 	if (stmt->space != NULL && stmt->space->run_triggers &&
 	    (stmt->old_tuple || stmt->new_tuple)) {
-		if (!rlist_empty(&stmt->space->on_replace)) {
+		if (space_has_on_replace_triggers(stmt->space)) {
 			txn->space_on_replace_triggers_depth++;
-			int rc = trigger_run(&stmt->space->on_replace, txn);
+			int rc = space_on_replace(stmt->space, txn);
 			txn->space_on_replace_triggers_depth--;
 			if (rc != 0)
 				goto fail;

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -262,6 +262,8 @@ txn_add_redo(struct txn *txn, struct txn_stmt *stmt, struct request *request)
 		row->tm = 0;
 		row->flags = 0;
 		row->stream_id = 0;
+		row->header = NULL;
+		row->header_end = NULL;
 	}
 	/*
 	 * Group ID should be set both for requests not having a

--- a/src/box/xrow.c
+++ b/src/box/xrow.c
@@ -156,6 +156,8 @@ xrow_header_decode(struct xrow_header *header, const char **pos,
 		goto bad_header;
 	if (mp_typeof(**pos) != MP_MAP)
 		goto bad_header;
+	header->header = start;
+	header->header_end = tmp;
 	bool has_tsn = false;
 	uint32_t flags = 0;
 

--- a/src/box/xrow.h
+++ b/src/box/xrow.h
@@ -117,6 +117,16 @@ struct xrow_header {
 	/* See `IPROTO_SCHEMA_VERSION`. */
 	uint64_t schema_version;
 	struct iovec body[XROW_BODY_IOVMAX];
+	/**
+	 * A pointer to the beginning of xrow header, is set on decoding.
+	 * Is NULL by default.
+	 */
+	const char *header;
+	/**
+	 * A pointer to the end of xrow header, is set on decoding.
+	 * Is NULL by default.
+	 */
+	const char *header_end;
 };
 
 /**

--- a/src/lib/core/func_adapter.h
+++ b/src/lib/core/func_adapter.h
@@ -78,6 +78,11 @@ struct func_adapter_vtab {
 	 */
 	void (*push_null)(struct func_adapter_ctx *ctx);
 	/**
+	 * Pushes MsgPack argument.
+	 */
+	void (*push_msgpack)(struct func_adapter_ctx *ctx, const char *data,
+			     const char *data_end);
+	/**
 	 * Checks if the next returned value is a tuple.
 	 */
 	bool (*is_tuple)(struct func_adapter_ctx *ctx);
@@ -212,6 +217,14 @@ static inline void
 func_adapter_push_null(struct func_adapter *func, struct func_adapter_ctx *ctx)
 {
 	func->vtab->push_null(ctx);
+}
+
+static inline void
+func_adapter_push_msgpack(struct func_adapter *func,
+			  struct func_adapter_ctx *ctx,
+			  const char *data, const char *data_end)
+{
+	func->vtab->push_msgpack(ctx, data, data_end);
 }
 
 static inline bool

--- a/src/lib/core/func_adapter.h
+++ b/src/lib/core/func_adapter.h
@@ -119,13 +119,17 @@ struct func_adapter_vtab {
 	 */
 	void (*pop_bool)(struct func_adapter_ctx *ctx, bool *val);
 	/**
-	 * Checks if the next returned value is null or nothing.
+	 * Checks if the next returned value is null.
 	 */
 	bool (*is_null)(struct func_adapter_ctx *ctx);
 	/**
 	 * Pops null.
 	 */
 	void (*pop_null)(struct func_adapter_ctx *ctx);
+	/**
+	 * Checks if there are no more returned values.
+	 */
+	bool (*is_empty)(struct func_adapter_ctx *ctx);
 	/**
 	 * Virtual destructor of the class.
 	 */
@@ -294,6 +298,12 @@ func_adapter_pop_null(struct func_adapter *func, struct func_adapter_ctx *ctx)
 {
 	assert(func_adapter_is_null(func, ctx));
 	func->vtab->pop_null(ctx);
+}
+
+static inline bool
+func_adapter_is_empty(struct func_adapter *func, struct func_adapter_ctx *ctx)
+{
+	return func->vtab->is_empty(ctx);
 }
 
 static inline void

--- a/test/box-luatest/gh_4264_recursive_trigger_test.lua
+++ b/test/box-luatest/gh_4264_recursive_trigger_test.lua
@@ -37,6 +37,8 @@ g.test_recursive_trigger_invocation = function(cg)
         s:on_replace(f2)
         s:on_replace(f1)
         s:replace{1}
+        s:on_replace(nil, f2)
+        s:on_replace(nil, f1)
         return order
     end)
     t.assert_equals(order, {11, 21, 31, 32, 22, 12},

--- a/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
+++ b/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
@@ -11,7 +11,7 @@ local SIZE_OF_STORY = 144
 -- Size of tuple with 2 number fields
 local SIZE_OF_TUPLE = 9
 -- Size of xrow for tuples with 2 number fields
-local SIZE_OF_XROW = 147
+local SIZE_OF_XROW = 163
 -- Tracker can allocate additional memory, be careful!
 local SIZE_OF_READ_TRACKER = 48
 local SIZE_OF_POINT_TRACKER = 88

--- a/test/box-luatest/gh_8027_txn_handle_abort_in_trigger_test.lua
+++ b/test/box-luatest/gh_8027_txn_handle_abort_in_trigger_test.lua
@@ -17,9 +17,13 @@ end)
 
 g.after_each(function(cg)
     cg.server:exec(function()
-        if box.space.test ~= nil then
-            box.space.test:drop()
-        end
+        local s = box.space.test
+        t.assert_not_equals(s, nil)
+        s:before_replace(nil, nil, 't1')
+        s:before_replace(nil, nil, 't2')
+        s:on_replace(nil, nil, 't1')
+        s:on_replace(nil, nil, 't2')
+        s:drop()
     end)
 end)
 
@@ -33,13 +37,13 @@ g.test_yield_before_replace = function(cg)
                 fiber.yield()
             end
             return new
-        end)
+        end, nil, 't1')
         s:before_replace(function(_, new)
             if new[2] == 10 then
                 fiber.yield()
             end
             return new
-        end)
+        end, nil, 't2')
         local errmsg = 'Transaction has been aborted by a fiber yield'
         t.assert_error_msg_equals(errmsg, s.insert, s, {10, 1})
         t.assert_error_msg_equals(errmsg, s.insert, s, {1, 10})

--- a/test/box-luatest/triggers_old_api_test.lua
+++ b/test/box-luatest/triggers_old_api_test.lua
@@ -7,6 +7,13 @@ g.before_all(function()
     g.server = server:new({alias = 'master'})
     g.server:start()
     g.server:exec(function()
+        box.schema.space.create('test', {id = 512})
+        local function space_on_replace(...)
+            return box.space.test:on_replace(...)
+        end
+        local function space_before_replace(...)
+            return box.space.test:before_replace(...)
+        end
         -- Every element of this table is an array of 2 elements. The first
         -- one is a function that sets triggers, and the second one is the name
         -- of the associated event in the trigger registry. The second element
@@ -15,6 +22,8 @@ g.before_all(function()
             {box.session.on_connect, 'box.session.on_connect'},
             {box.session.on_disconnect, 'box.session.on_disconnect'},
             {box.session.on_auth, 'box.session.on_auth'},
+            {space_on_replace, 'box.space[512].on_replace'},
+            {space_before_replace, 'box.space[512].before_replace'},
         })
 
         rawset(_G, 'ffi_monotonic_id', 0)

--- a/test/box/before_replace.result
+++ b/test/box/before_replace.result
@@ -305,7 +305,7 @@ s:before_replace(ret_invalid) == ret_invalid
 s:insert{1, 1}
 ---
 - error: 'Invalid return value of space:before_replace trigger: expected tuple or
-    nil, got string'
+    nil'
 ...
 s:select()
 ---
@@ -359,6 +359,9 @@ s2.index.sk:update(1, {{'+', 4, 1}})
 s2:select()
 ---
 - - [1, 1, 2, 2]
+...
+s2:before_replace(nil, ret_update)
+---
 ...
 s2:drop()
 ---
@@ -830,6 +833,9 @@ save_type
 ---
 - UPSERT
 ...
+s:before_replace(nil, find_type)
+---
+...
 s:drop()
 ---
 ...
@@ -845,7 +851,7 @@ _ = s:create_index('pk')
 save_type = ''
 ---
 ...
-_ = s:before_replace(function(old,new, name, type) save_type = type return new end)
+tid = s:before_replace(function(old,new, name, type) save_type = type return new end)
 ---
 ...
 _ = s:insert{1}
@@ -854,6 +860,9 @@ _ = s:insert{1}
 save_type
 ---
 - INSERT
+...
+s:before_replace(nil, tid)
+---
 ...
 s:drop()
 ---

--- a/test/box/before_replace.test.lua
+++ b/test/box/before_replace.test.lua
@@ -116,6 +116,7 @@ s2:insert{1, 1, 1, 1}
 s2:before_replace(ret_update) == ret_update
 s2.index.sk:update(1, {{'+', 4, 1}})
 s2:select()
+s2:before_replace(nil, ret_update)
 s2:drop()
 
 -- Stacking triggers.
@@ -290,6 +291,7 @@ save_type
 _ = s:upsert({3,4,5}, {{'+', 2, 1}})
 save_type
 
+s:before_replace(nil, find_type)
 s:drop()
 
 --
@@ -301,10 +303,11 @@ _ = s:create_index('pk')
 
 save_type = ''
 
-_ = s:before_replace(function(old,new, name, type) save_type = type return new end)
+tid = s:before_replace(function(old,new, name, type) save_type = type return new end)
 _ = s:insert{1}
 save_type
 
+s:before_replace(nil, tid)
 s:drop()
 
 --

--- a/test/box/on_replace.result
+++ b/test/box/on_replace.result
@@ -29,7 +29,7 @@ type(ts.on_replace)
 ...
 ts.on_replace()
 ---
-- error: 'usage: space:on_replace(function | nil, [function | nil])'
+- error: 'usage: space:on_replace(function | nil, [function | nil], [string])'
 ...
 ts:on_replace()
 ---
@@ -115,13 +115,22 @@ n
 ---
 - [2, 'd', 'e', 'f']
 ...
-type(ts:on_replace(function() test = 1 end))
+trigger_id = ts:on_replace(function() test = 1 end)
+---
+...
+type(trigger_id)
 ---
 - function
 ...
 #ts:on_replace()
 ---
 - 2
+...
+ts:on_replace(nil, trigger_id)
+---
+...
+ts:on_replace(nil, save_out)
+---
 ...
 ts:drop()
 ---
@@ -536,6 +545,9 @@ s:select()
 ---
 - []
 ...
+s:on_replace(nil, t)
+---
+...
 s:drop() -- test_on_repl_ddl
 ---
 ...
@@ -570,7 +582,7 @@ x1 = 1;
 x2 = 1;
 ---
 ...
-_ = s1:on_replace(function(old, new)
+s1_t = s1:on_replace(function(old, new)
     for i = 1, 3 do
         s2:insert{x1}
         x1 = x1 + 1
@@ -582,7 +594,7 @@ _ = s1:on_replace(function(old, new)
 end);
 ---
 ...
-_ = s2:on_replace(function(old, new)
+s2_t = s2:on_replace(function(old, new)
     for i = 1, 3 do
         s3:insert{x2}
         x2 = x2 + 1
@@ -625,7 +637,13 @@ s3:select()
   - [8]
   - [9]
 ...
+s1:on_replace(nil, s1_t)
+---
+...
 s1:drop()
+---
+...
+s2:on_replace(nil, s2_t)
 ---
 ...
 s2:drop()
@@ -658,10 +676,10 @@ _ = s3:create_index('pk')
 x = 1
 ---
 ...
-_ = s1:on_replace(function(old, new) s2:insert(new:update{{'!', 2, x}}) x = x + 1 end)
+t1 = s1:on_replace(function(old, new) s2:insert(new:update{{'!', 2, x}}) x = x + 1 end)
 ---
 ...
-_ = s1:on_replace(function(old, new) s3:insert(new:update{{'!', 2, x}}) x = x + 1 end)
+t2 = s1:on_replace(function(old, new) s3:insert(new:update{{'!', 2, x}}) x = x + 1 end)
 ---
 ...
 box.begin() s1:insert{1} s1:insert{2} s1:insert{3} box.commit()
@@ -684,6 +702,12 @@ s3:select()
 - - [1, 1]
   - [2, 3]
   - [3, 5]
+...
+s1:on_replace(nil, t1)
+---
+...
+s1:on_replace(nil, t2)
+---
 ...
 s1:drop()
 ---

--- a/test/box/on_replace.test.lua
+++ b/test/box/on_replace.test.lua
@@ -42,8 +42,11 @@ ts:replace{2, 'd', 'e', 'f'}
 o
 n
 
-type(ts:on_replace(function() test = 1 end))
+trigger_id = ts:on_replace(function() test = 1 end)
+type(trigger_id)
 #ts:on_replace()
+ts:on_replace(nil, trigger_id)
+ts:on_replace(nil, save_out)
 ts:drop()
 
 -- test garbage in lua stack
@@ -201,6 +204,7 @@ s:replace({8, 9})
 t = s:on_replace(function () s.index.pk:rename('newname') end, t)
 s:replace({9, 10})
 s:select()
+s:on_replace(nil, t)
 s:drop() -- test_on_repl_ddl
 
 --
@@ -218,7 +222,7 @@ test_run:cmd("setopt delimiter ';'");
 x1 = 1;
 x2 = 1;
 
-_ = s1:on_replace(function(old, new)
+s1_t = s1:on_replace(function(old, new)
     for i = 1, 3 do
         s2:insert{x1}
         x1 = x1 + 1
@@ -229,7 +233,7 @@ _ = s1:on_replace(function(old, new)
     pcall(s2.insert, s2, {123, 'fail'})
 end);
 
-_ = s2:on_replace(function(old, new)
+s2_t = s2:on_replace(function(old, new)
     for i = 1, 3 do
         s3:insert{x2}
         x2 = x2 + 1
@@ -250,7 +254,9 @@ s1:select()
 s2:select()
 s3:select()
 
+s1:on_replace(nil, s1_t)
 s1:drop()
+s2:on_replace(nil, s2_t)
 s2:drop()
 s3:drop()
 
@@ -266,8 +272,8 @@ _ = s3:create_index('pk')
 
 x = 1
 
-_ = s1:on_replace(function(old, new) s2:insert(new:update{{'!', 2, x}}) x = x + 1 end)
-_ = s1:on_replace(function(old, new) s3:insert(new:update{{'!', 2, x}}) x = x + 1 end)
+t1 = s1:on_replace(function(old, new) s2:insert(new:update{{'!', 2, x}}) x = x + 1 end)
+t2 = s1:on_replace(function(old, new) s3:insert(new:update{{'!', 2, x}}) x = x + 1 end)
 
 box.begin() s1:insert{1} s1:insert{2} s1:insert{3} box.commit()
 
@@ -275,6 +281,8 @@ s1:select()
 s2:select()
 s3:select()
 
+s1:on_replace(nil, t1)
+s1:on_replace(nil, t2)
 s1:drop()
 s2:drop()
 s3:drop()

--- a/test/box/push.result
+++ b/test/box/push.result
@@ -321,7 +321,10 @@ box.schema.func.drop('do_push')
 s:truncate()
 ---
 ...
-_ = s:on_replace(function() box.session.push('replace') end)
+function on_replace() box.session.push('replace') end
+---
+...
+_ = s:on_replace(on_replace)
 ---
 ...
 c:reload_schema()
@@ -340,6 +343,9 @@ s:select{}
 - - [200]
 ...
 c:close()
+---
+...
+_ = s:on_replace(nil, on_replace)
 ---
 ...
 s:drop()

--- a/test/box/push.test.lua
+++ b/test/box/push.test.lua
@@ -167,13 +167,15 @@ box.schema.func.drop('do_push')
 -- Test push from a non-call request.
 --
 s:truncate()
-_ = s:on_replace(function() box.session.push('replace') end)
+function on_replace() box.session.push('replace') end
+_ = s:on_replace(on_replace)
 c:reload_schema()
 c.space.test:replace({200}, {on_push = table.insert, on_push_ctx = messages})
 messages
 s:select{}
 
 c:close()
+_ = s:on_replace(nil, on_replace)
 s:drop()
 
 --

--- a/test/engine-luatest/space_triggers_test.lua
+++ b/test/engine-luatest/space_triggers_test.lua
@@ -1,0 +1,283 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+-- Since event name depends on space name, test with small and huge names
+-- Large name size is chosen to be larger than static buf size
+local g = t.group('Basic triggers', t.helpers.matrix{
+    engine = {'vinyl', 'memtx'},
+    space_name = {'a', string.rep('a', 20000)}
+})
+
+g.before_all(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:stop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function(space_name)
+        local trigger = require('trigger')
+        if box.space[space_name] then box.space[space_name]:drop() end
+        -- Delete all registered triggers
+        local trigger_info = trigger.info()
+        for event, trigger_list in pairs(trigger_info) do
+            for _, trigger_descr in pairs(trigger_list) do
+                local trigger_name = trigger_descr[1]
+                trigger.del(event, trigger_name)
+            end
+        end
+    end, {cg.params.space_name})
+end)
+
+g.test_on_replace = function(cg)
+    cg.server:exec(function(engine, space_name)
+        local trigger = require('trigger')
+        local old_state = {}
+        local new_state = {}
+        local handlers = {}
+        for i = 1, 4 do
+            table.insert(handlers, function(old_tuple, new_tuple, space, req)
+                if old_tuple ~= nil then
+                    table.insert(old_state, old_tuple[i])
+                end
+                table.insert(new_state, new_tuple[i])
+                t.assert_equals(space, space_name)
+                t.assert_equals(req, "REPLACE")
+            end)
+        end
+        local space_id = 743
+        local event_by_id = string.format('box.space[%d].on_replace', space_id)
+        local event_by_name = string.format('box.space.%s.on_replace',
+            space_name)
+        trigger.set(event_by_id, tostring(2), handlers[2])
+        trigger.set(event_by_name, tostring(4), handlers[4])
+        local s = box.schema.create_space(space_name,
+            {id = space_id, engine = engine})
+        s:create_index('pk')
+        t.assert_equals(old_state, {})
+        t.assert_equals(new_state, {})
+        s:replace{0, 5, 10, 15}
+        t.assert_equals(old_state, {})
+        t.assert_equals(new_state, {5, 15})
+        new_state = {}
+
+        trigger.set(event_by_id, tostring(1), handlers[1])
+        trigger.set(event_by_name, tostring(3), handlers[3])
+        s:replace{1, 2, 3, 4}
+        t.assert_equals(old_state, {})
+        t.assert_equals(new_state, {1, 2, 3, 4})
+        new_state = {}
+
+        s:replace{1, 3, 5, 7}
+        t.assert_equals(old_state, {1, 2, 3, 4})
+        t.assert_equals(new_state, {1, 3, 5, 7})
+        old_state = {}
+        new_state = {}
+
+        local new_tuple = {11, 12, 13, 14}
+        trigger.call(event_by_id, nil, new_tuple, space_name, "REPLACE")
+        trigger.call(event_by_name, nil, new_tuple, space_name, "REPLACE")
+        t.assert_equals(new_state, new_tuple)
+        new_state = {}
+    end, {cg.params.engine, cg.params.space_name})
+end
+
+g.test_before_replace = function(cg)
+    cg.server:exec(function(engine, space_name)
+        local trigger = require('trigger')
+        local handlers = {}
+        local old_state = {}
+        for i = 1, 4 do
+            table.insert(handlers, function(old_tuple, new_tuple, space, req)
+                if old_tuple ~= nil then
+                    table.insert(old_state, old_tuple[i])
+                end
+                local prev_field = new_tuple[i]
+                t.assert_equals(space, space_name)
+                t.assert_equals(req, "REPLACE")
+                return new_tuple:update{{'+', i + 1, prev_field}}
+            end)
+        end
+        local space_id = 743
+        local event_by_id = string.format('box.space[%d].before_replace',
+            space_id)
+        local event_by_name = string.format('box.space.%s.before_replace',
+            space_name)
+        trigger.set(event_by_id, tostring(2), handlers[2])
+        trigger.set(event_by_name, tostring(4), handlers[4])
+        local s = box.schema.create_space(space_name,
+            {id = space_id, engine = engine})
+        s:create_index('pk')
+
+        s:replace{1, 3, 7, 19, 289}
+        t.assert_equals(old_state, {})
+        t.assert_equals(s:get(1), {1, 3, 3 + 7, 19, 289 + 19})
+
+        trigger.set(event_by_id, tostring(1), handlers[1])
+        trigger.set(event_by_name, tostring(3), handlers[3])
+
+        s:replace{2, 15, 30, 70, 193}
+        t.assert_equals(old_state, {})
+        t.assert_equals(s:get(2), {2, 17, 47, 117, 310})
+
+        s:replace{1, 2, 3, 4, 5}
+        t.assert_equals(old_state, {1, 3, 10, 19})
+        t.assert_equals(s:get(1), {1, 3, 6, 10, 15})
+        old_state = {}
+    end, {cg.params.engine, cg.params.space_name})
+end
+
+-- Checks if returned nil and none works correctly
+g.test_before_replace_return_nil_or_none = function(cg)
+    cg.server:exec(function(engine, space_name)
+        local trigger = require('trigger')
+        t.assert_equals(trigger.info(), {})
+        local space_id = 743
+        local event_by_id = string.format('box.space[%d].before_replace',
+            space_id)
+        trigger.set(event_by_id, 'my_trg', function() return nil end)
+        local s = box.schema.create_space(space_name,
+            {id = space_id, engine = engine})
+        s:create_index('pk')
+
+        s:replace{1, 1}
+        t.assert_equals(s:get(1), nil)
+
+        trigger.set(event_by_id, 'my_trg', function() return end)
+        s:replace{1, 1}
+        t.assert_equals(s:get(1), {1, 1})
+    end, {cg.params.engine, cg.params.space_name})
+end
+
+g = t.group('Recovery triggers', {
+    -- Vinyl does not recover from snapshot.
+    {engine = 'vinyl', snapshot = false},
+    {engine = 'memtx', snapshot = true},
+    {engine = 'memtx', snapshot = false},
+})
+
+g.before_each(function(cg)
+    -- Do not create snapshots automatically
+    cg.server = server:new({box_cfg = {checkpoint_interval = 0}})
+    cg.server:start()
+end)
+
+g.after_each(function(cg)
+    cg.server:stop()
+end)
+
+g.test_recovery_replace = function(cg)
+    cg.server:exec(function(engine, snapshot)
+        local s = box.schema.create_space('test', {engine = engine})
+        s:create_index('pk')
+        for i = 1, 10 do
+            s:insert{i, i - 2}
+        end
+        if snapshot then
+            box.snapshot()
+        end
+    end, {cg.params.engine, cg.params.snapshot})
+    local run_before_cfg = [[
+        local trigger = require('trigger')
+        local msgpack = require('msgpack')
+        local regular_events = {
+            'box.space[512].before_replace',
+            'box.space.test.before_replace',
+            'box.space[512].on_replace',
+            'box.space.test.on_replace'
+        }
+        -- Ckeck that regular triggers does not work on recovery
+        rawset(_G, 'regular_fired', false)
+        for i = 1, 4 do
+            trigger.set(regular_events[i], 'regular_check',
+                        function() rawset(_G, 'regular_fired', true) end)
+        end
+
+        local recovery_events = {
+            'box.space[512].before_recovery_replace',
+            'box.space.test.before_recovery_replace',
+            'box.space[512].on_recovery_replace',
+            'box.space.test.on_recovery_replace'
+        }
+
+        rawset(_G, 'test_states', {})
+        for i = 1, 4 do
+            trigger.set(recovery_events[i], 'test_trigger',
+                        function(old, new, space, req, header, body)
+                local states = rawget(_G, 'test_states')
+                assert(msgpack.is_object(header))
+                assert(msgpack.is_object(body))
+                table.insert(states, {i,
+                    {old, new, space, req, header:decode(), body:decode()}
+                })
+                new = new:update{{"+", 2, 1}}
+                return new
+            end)
+        end
+    ]]
+    cg.server:restart({
+        env = {
+            ['TARANTOOL_RUN_BEFORE_BOX_CFG'] = run_before_cfg,
+        }
+    })
+    cg.server:exec(function(recover_from_snapshot)
+        t.assert_equals(rawget(_G, 'regular_fired'), false)
+        local states = rawget(_G, 'test_states')
+        t.assert_equals(#states, 40)
+        -- Check that tuples were updated
+        for i = 1, 10 do
+            t.assert_equals(box.space.test:get(i), {i, i})
+        end
+        for i = 1, 10 do
+            -- Check order of triggers execution
+            t.assert_equals(states[4 * i - 3][1], 1)
+            t.assert_equals(states[4 * i - 2][1], 2)
+            t.assert_equals(states[4 * i - 1][1], 3)
+            t.assert_equals(states[4 * i][1], 4)
+
+            -- Check passed arguments
+            local first = 4 * i - 3
+            local last = 4 * i
+            for j = first, last do
+                local tuple = {i, i}
+                local req_tuple = tuple
+                if j == first then
+                    tuple = {i, i - 2}
+                    req_tuple = tuple
+                elseif j == first + 1 then
+                    tuple = {i, i - 1}
+                    req_tuple = {i, i - 2}
+                end
+                t.assert_equals(states[j][2][2], tuple)
+                t.assert_equals(states[j][2][6][box.iproto.key.TUPLE],
+                    req_tuple)
+                states[j][2][2] = nil
+                states[j][2][6][box.iproto.key.TUPLE] = nil
+            end
+            -- All arguments instead of new_tuple and tuple in request must be
+            -- the same for the same request
+            for j = 1, 3 do
+                t.assert_equals(states[j][2], states[j + 1][2])
+            end
+
+            -- Inspect xrow
+            local header = states[4 * i][2][5]
+            t.assert_not_equals(header, nil)
+            t.assert_not_equals(header[box.iproto.key.TIMESTAMP], nil)
+            t.assert_equals(header[box.iproto.key.REQUEST_TYPE],
+                box.iproto.type.INSERT)
+            t.assert_not_equals(header[box.iproto.key.LSN], nil)
+            if not recover_from_snapshot then
+                t.assert_not_equals(header[box.iproto.key.REPLICA_ID], nil)
+            end
+            local body = states[4 * i][2][6]
+            t.assert_equals(body[box.iproto.key.SPACE_ID], 512)
+        end
+        -- Check that recovery triggers are not fired after recovery
+        box.space.test:replace{0, 0}
+        t.assert_equals(#states, 40)
+    end, {cg.params.snapshot})
+end

--- a/test/engine/savepoint.result
+++ b/test/engine/savepoint.result
@@ -221,6 +221,9 @@ s:select{}
 - - [1]
   - [2]
 ...
+s:on_replace(nil, on_replace)
+---
+...
 s:drop()
 ---
 ...
@@ -295,6 +298,9 @@ ok1
 errmsg1
 ---
 - 'Can not rollback to savepoint: the savepoint does not exist'
+...
+s:on_replace(nil, on_replace2)
+---
 ...
 s:drop()
 ---
@@ -501,6 +507,9 @@ s:select{}
 ---
 - - [1, 'create savepoint']
   - [5]
+...
+s:on_replace(nil, on_replace3)
+---
 ...
 s:truncate()
 ---

--- a/test/engine/savepoint.test.lua
+++ b/test/engine/savepoint.test.lua
@@ -110,6 +110,7 @@ select3
 select2
 select1
 s:select{}
+s:on_replace(nil, on_replace)
 s:drop()
 
 -- Test rollback to savepoint, created in trigger,
@@ -142,6 +143,7 @@ select3
 select4
 ok1
 errmsg1
+s:on_replace(nil, on_replace2)
 s:drop()
 
 -- Test incorrect savepoints usage inside a transaction.
@@ -246,6 +248,7 @@ s:replace{5}
 box.commit()
 test_run:cmd("setopt delimiter ''");
 s:select{}
+s:on_replace(nil, on_replace3)
 s:truncate()
 
 -- Several savepoints on a same statement.

--- a/test/sql/iproto.result
+++ b/test/sql/iproto.result
@@ -574,6 +574,9 @@ cn:execute('insert into TEST3 values (null), (null), (null), (null)')
   - -29
   row_count: 4
 ...
+_ = box.space.TEST:on_replace(nil, push_id)
+---
+...
 box.execute('drop table test')
 ---
 - row_count: 1

--- a/test/sql/iproto.test.lua
+++ b/test/sql/iproto.test.lua
@@ -169,6 +169,7 @@ box.execute('create table test3 (id int primary key autoincrement)')
 box.schema.sequence.alter('TEST3', {min=-10000, step=-10})
 cn:execute('insert into TEST3 values (null), (null), (null), (null)')
 
+_ = box.space.TEST:on_replace(nil, push_id)
 box.execute('drop table test')
 s:drop()
 sq:drop()

--- a/test/unit/lua_func_adapter.c
+++ b/test/unit/lua_func_adapter.c
@@ -42,7 +42,7 @@ generate_function(const char *function)
 static void
 test_numeric(void)
 {
-	plan(5);
+	plan(6);
 	header();
 
 	int idx = generate_function(
@@ -67,7 +67,8 @@ test_numeric(void)
 		   "Returned value must be as expected");
 	}
 
-	ok(func_adapter_is_null(func, &ctx), "Expected null - no values left");
+	ok(func_adapter_is_empty(func, &ctx), "No values left");
+	ok(!func_adapter_is_null(func, &ctx), "NULL is not absence");
 	func_adapter_end(func, &ctx);
 	func_adapter_destroy(func);
 	lua_settop(tarantool_L, 0);
@@ -105,7 +106,7 @@ test_tuple(void)
 		func_adapter_pop_tuple(func, &ctx, tuples + i);
 		isnt(tuples[i], NULL, "Returned tuple must not be NULL");
 	}
-	ok(func_adapter_is_null(func, &ctx), "Expected null - no values left");
+	ok(func_adapter_is_empty(func, &ctx), "No values left");
 	func_adapter_end(func, &ctx);
 	func_adapter_destroy(func);
 	lua_settop(tarantool_L, 0);
@@ -159,7 +160,7 @@ test_string(void)
 	strncpy(buf, s1, s1_len);
 	strcpy(buf + s1_len, s2);
 	is(strcmp(retval, buf), 0, "Expected %s", buf);
-	ok(func_adapter_is_null(func, &ctx), "Expected null - no values left");
+	ok(func_adapter_is_empty(func, &ctx), "No values left");
 	func_adapter_end(func, &ctx);
 	func_adapter_destroy(func);
 	lua_settop(tarantool_L, 0);
@@ -198,7 +199,7 @@ test_bool(void)
 	}
 
 	ok(!func_adapter_is_bool(func, &ctx), "No values left - no bool");
-	ok(func_adapter_is_null(func, &ctx), "No values left");
+	ok(func_adapter_is_empty(func, &ctx), "No values left");
 	func_adapter_end(func, &ctx);
 	func_adapter_destroy(func);
 	lua_settop(tarantool_L, 0);
@@ -231,7 +232,7 @@ test_null(void)
 	ok(func_adapter_is_double(func, &ctx), "Expected double");
 	double double_retval = 0;
 	func_adapter_pop_double(func, &ctx, &double_retval);
-	ok(func_adapter_is_null(func, &ctx), "Expected null - no values left");
+	ok(func_adapter_is_empty(func, &ctx), "No values left");
 	func_adapter_end(func, &ctx);
 	func_adapter_destroy(func);
 	lua_settop(tarantool_L, 0);

--- a/test/unit/xrow.cc
+++ b/test/unit/xrow.cc
@@ -210,7 +210,7 @@ test_xrow_header_encode_decode()
 	header();
 	/* Test all possible 3-bit combinations. */
 	const int bit_comb_count = 1 << 3;
-	plan(1 + bit_comb_count * 13);
+	plan(1 + bit_comb_count * 15);
 	struct xrow_header header;
 	char buffer[2048];
 	char *pos = mp_encode_uint(buffer, 300);
@@ -251,11 +251,12 @@ test_xrow_header_encode_decode()
 		is(size, exp_map_size, "header map size");
 
 		struct xrow_header decoded_header;
-		const char *begin = (const char *)vec[0].iov_base;
-		begin += fixheader_len;
+		const char *pos = (const char *)vec[0].iov_base;
+		pos += fixheader_len;
+		const char *const begin = pos;
 		const char *end = (const char *)vec[0].iov_base;
 		end += vec[0].iov_len;
-		is(xrow_header_decode(&decoded_header, &begin, end, true), 0,
+		is(xrow_header_decode(&decoded_header, &pos, end, true), 0,
 		   "header decode");
 		is(header.stream_id, decoded_header.stream_id, "decoded stream_id");
 		is(header.is_commit, decoded_header.is_commit, "decoded is_commit");
@@ -267,6 +268,8 @@ test_xrow_header_encode_decode()
 		is(header.tm, decoded_header.tm, "decoded tm");
 		is(decoded_header.sync, sync, "decoded sync");
 		is(decoded_header.bodycnt, 0, "decoded bodycnt");
+		is(decoded_header.header, begin);
+		is(decoded_header.header_end, end);
 	}
 
 	check_plan();

--- a/test/vinyl/on_replace.result
+++ b/test/vinyl/on_replace.result
@@ -55,6 +55,9 @@ index:select{}
 ---
 - - [6, 'f']
 ...
+space:on_replace(nil, on_replace)
+---
+...
 space:drop()
 ---
 ...
@@ -110,6 +113,9 @@ index:select{}
 index2:select{}
 ---
 - - [1, 2]
+...
+space:on_replace(nil, on_replace)
+---
 ...
 space:drop()
 ---
@@ -178,6 +184,9 @@ space:select{}
 fail = false
 ---
 ...
+space:on_replace(nil, on_replace)
+---
+...
 space:drop()
 ---
 ...
@@ -241,6 +250,9 @@ index2:select{}
   - [2, 'b']
 ...
 fail = false
+---
+...
+space:on_replace(nil, on_replace)
 ---
 ...
 space:drop()
@@ -342,6 +354,9 @@ index2:select{}
 fail = false
 ---
 ...
+space:on_replace(nil, on_replace)
+---
+...
 space:drop()
 ---
 ...
@@ -405,6 +420,9 @@ index:select{}
   - [2, 3, 4]
 ...
 fail = false
+---
+...
+space:on_replace(nil, on_replace)
 ---
 ...
 space:drop()
@@ -478,6 +496,9 @@ index2:select{}
   - [2, 2, 'b']
 ...
 fail = false
+---
+...
+space:on_replace(nil, on_replace)
 ---
 ...
 space:drop()
@@ -564,6 +585,9 @@ index:select{}
   - [4]
 ...
 fail = false
+---
+...
+space:on_replace(nil, on_replace)
 ---
 ...
 space:drop()
@@ -672,6 +696,9 @@ index2:select{}
 fail = false
 ---
 ...
+space:on_replace(nil, on_replace)
+---
+...
 space:drop()
 ---
 ...
@@ -742,6 +769,9 @@ index:select{}
   - [4, 4, 4, 4]
 ...
 fail = false
+---
+...
+space:on_replace(nil, on_replace)
 ---
 ...
 space:drop()
@@ -842,6 +872,9 @@ old_tuple, new_tuple
 - null
 ...
 fail = false
+---
+...
+space:on_replace(nil, on_replace)
 ---
 ...
 space:drop()

--- a/test/vinyl/on_replace.test.lua
+++ b/test/vinyl/on_replace.test.lua
@@ -18,6 +18,7 @@ fail = true
 space:insert({7, 'g'})
 old_tuple, new_tuple
 index:select{}
+space:on_replace(nil, on_replace)
 space:drop()
 fail = false
 
@@ -35,6 +36,7 @@ space:insert({2, 3})
 old_tuple, new_tuple
 index:select{}
 index2:select{}
+space:on_replace(nil, on_replace)
 space:drop()
 fail = false
 
@@ -54,6 +56,7 @@ space:replace({2, 100})
 old_tuple, new_tuple
 space:select{}
 fail = false
+space:on_replace(nil, on_replace)
 space:drop()
 
 -- ensure trigger error causes rollback of only one statement
@@ -73,6 +76,7 @@ box.commit()
 index:select{}
 index2:select{}
 fail = false
+space:on_replace(nil, on_replace)
 space:drop()
 
 -- on replace in multiple indexes
@@ -98,6 +102,7 @@ old_tuple, new_tuple
 index:select{}
 index2:select{}
 fail = false
+space:on_replace(nil, on_replace)
 space:drop()
 
 -- on delete from one index
@@ -117,6 +122,7 @@ index:delete({1})
 old_tuple, new_tuple
 index:select{}
 fail = false
+space:on_replace(nil, on_replace)
 space:drop()
 
 -- on delete from multiple indexes
@@ -138,6 +144,7 @@ old_tuple, new_tuple
 index:select{}
 index2:select{}
 fail = false
+space:on_replace(nil, on_replace)
 space:drop()
 
 -- on update one index
@@ -161,6 +168,7 @@ index:update({1}, {{'=', 2, 'one'}})
 old_tuple, new_tuple
 index:select{}
 fail = false
+space:on_replace(nil, on_replace)
 space:drop()
 
 -- on update multiple indexes
@@ -188,6 +196,7 @@ old_tuple, new_tuple
 index:select{}
 index2:select{}
 fail = false
+space:on_replace(nil, on_replace)
 space:drop()
 
 -- on upsert one index
@@ -210,6 +219,7 @@ old_tuple, new_tuple
 index:select{}
 
 fail = false
+space:on_replace(nil, on_replace)
 space:drop()
 
 -- on upsert multiple indexes
@@ -236,4 +246,5 @@ old_tuple, new_tuple
 space:upsert({5, 5, 5}, {{'!', 4, 500}})
 old_tuple, new_tuple
 fail = false
+space:on_replace(nil, on_replace)
 space:drop()


### PR DESCRIPTION
The patch moves space triggers to trigger registry and adds required types to `func_adapter`. Also, an assertion fail on recovery from snapshot with before_replace triggers is fixed along the way.

Part of https://github.com/tarantool/tarantool/issues/8657
Closes https://github.com/tarantool/tarantool/issues/8859
Closes #9127