### PR TITLE
test: ban direct calling of box.cfg()

### DIFF
--- a/test/helper.lua
+++ b/test/helper.lua
@@ -1,0 +1,20 @@
+-- There are situations when the Tarantool instance is configured
+-- for testing. For example:
+--
+--     g.test_foo = function()
+--         box.cfg{params}
+--         ...
+--         t.assert_equals(foo, bar)
+--
+--     g.test_bar = function()
+--         t.assert_equals(foo, bar)
+--
+-- We expect that the test environment will not be configured
+-- in the `test_bar` test, but this will not always be the case
+-- (depends on the order of execution of tests).
+-- We prohibit a direct call to `box.cfg` by overriding the
+-- `__call` meta method. Motivating issue tarantool/luatest#245.
+box.cfg = setmetatable({}, {__call = function()
+    error('A direct call to `box.cfg` is forbidden' ..
+          ' (you are changing the test runner instance)', 0)
+end})

--- a/test/metrics-luatest/helper.lua
+++ b/test/metrics-luatest/helper.lua
@@ -109,4 +109,12 @@ local function workaround_requires(path)
 end
 
 workaround_requires('test.utils')
-workaround_requires('test.psutils_linux_test_payload')
+
+require('test.utils')
+local test_root = fio.dirname(
+    fio.dirname(fio.abspath(
+        package.search('third_party.metrics.test.utils')))) -- luacheck: ignore
+
+package.loaded['test.utils'].LUA_PATH = os.getenv('LUA_PATH') ..
+    test_root .. '/?.lua;' ..
+    test_root .. '/?/init.lua;'


### PR DESCRIPTION
Direct call and configuration of the runner instance is prohibited. Now if you need to test something with specific configuration use a server instance please (see luatest.Server module).

In-scope-of tarantool/luatest#245

NO_DOC=ban calling box.cfg
NO_TEST=ban calling box.cfg
NO_CHANGELOG=ban calling box.cfg