### PR TITLE
Fix access to uninitialized cpipe between tx and relay

### DIFF
--- a/changelogs/unreleased/gh-7991-relay-crash.md
+++ b/changelogs/unreleased/gh-7991-relay-crash.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed a crash when using transactions with the linearizable isolation level during
+  a replica reconnect (gh-7991).

--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -902,6 +902,8 @@ int
 relay_trigger_vclock_sync(struct relay *relay, uint64_t *vclock_sync,
 			  double deadline)
 {
+	if (!relay->tx.is_paired)
+		return 0;
 	struct relay_trigger_vclock_sync_msg *msg =
 		(struct relay_trigger_vclock_sync_msg *)xmalloc(sizeof(*msg));
 	msg->relay = relay;


### PR DESCRIPTION
All the code outside of relay.cc judges about relay's liveliness looking
only at relay state. When relay->state is RELAY_FOLLOW, the relay is
considered operational.

This is not always true: for example, both relay_push_raft() and
relay_trigger_vclock_sync() are only possible after relay thread pairs
with tx via the cbus. This happens **after** the relay enters
RELAY_FOLLOW state.

Fix the possible access to uninitialized cpipe by
relay_trigger_vclock_sync(): make it a nop until the relay is paired
with tx.

Closes #7991