### PR TITLE
test: disable Lua JIT in `app-luatest/http_client_test`

### DIFF
--- a/test/app-luatest/http_client_test.lua
+++ b/test/app-luatest/http_client_test.lua
@@ -5,6 +5,10 @@ local uri = require('uri')
 local os = require('os')
 local t = require('luatest')
 
+-- FIXME(gh-8718): The test fails if Lua JIT is enabled.
+jit.off()
+jit.flush()
+
 local g = t.group('http_client', {
     {sock_family = 'AF_INET'},
     {sock_family = 'AF_UNIX'},


### PR DESCRIPTION
We'll enable it when #8718 is fixed.