### PR TITLE
config: add schema-aware data processing module

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -37,7 +37,8 @@ lua_source(lua_sources lua/key_def.lua key_def_lua)
 lua_source(lua_sources lua/merger.lua merger_lua)
 
 # {{{ config
-lua_source(lua_sources lua/config/utils/log.lua        config_utils_log_lua)
+lua_source(lua_sources lua/config/utils/log.lua           config_utils_log_lua)
+lua_source(lua_sources lua/config/utils/schema.lua        config_utils_schema_lua)
 # }}} config
 
 set(bin_sources)

--- a/src/box/lua/config/utils/schema.lua
+++ b/src/box/lua/config/utils/schema.lua
@@ -342,6 +342,23 @@ end
 
 -- }}} Schema node constructors: scalar, record, map, array
 
+-- {{{ Derived schema node type constructors: enum
+
+-- Shortcut for a string scalar with given allowed values.
+local function enum(allowed_values, annotations)
+    local scalar_def = {
+        type = 'string',
+        allowed_values = allowed_values,
+    }
+    for k, v in pairs(annotations or {}) do
+        assert(k ~= 'type' and k ~= 'allowed_values')
+        scalar_def[k] = v
+    end
+    return scalar(scalar_def)
+end
+
+-- }}} Derived schema node type constructors: enum
+
 -- {{{ <schema object>:validate()
 
 -- Verify that the given table adheres array requirements.
@@ -1550,6 +1567,13 @@ return {
     record = record,
     map = map,
     array = array,
+
+    -- Constructors for 'derived types'.
+    --
+    -- It produces a scalar, record, map or array, but annotates
+    -- it in some specific way to, say, impose extra constraint
+    -- rules at validation.
+    enum = enum,
 
     -- Schema object constructor.
     new = new,

--- a/src/box/lua/config/utils/schema.lua
+++ b/src/box/lua/config/utils/schema.lua
@@ -5,6 +5,81 @@ local schema_mt = {}
 
 local scalars = {}
 
+-- {{{ Walkthrough helpers
+
+-- Create walkthrough context.
+local function walkthrough_start(self, params)
+    local ctx = {path = {}, name = rawget(self, 'name')}
+    for k, v in pairs(params or {}) do
+        ctx[k] = v
+    end
+    return ctx
+end
+
+-- Step down to a field.
+local function walkthrough_enter(ctx, name)
+    table.insert(ctx.path, name)
+end
+
+-- Step up from the last field.
+local function walkthrough_leave(ctx)
+    table.remove(ctx.path)
+end
+
+-- Construct a string that describes the current path.
+local function walkthrough_path(ctx)
+    local res = ''
+    for _, name in ipairs(ctx.path) do
+        if type(name) == 'number' then
+            res = res .. ('[%d]'):format(name)
+        else
+            res = res .. '.' .. name
+        end
+    end
+    if res:startswith('.') then
+        res = res:sub(2)
+    end
+    return res
+end
+
+-- Generate a prefix for an error message based on the given
+-- walkthrough context.
+local function walkthrough_error_prefix(ctx)
+    if ctx.path == nil or next(ctx.path) == nil then
+        return ('[%s] '):format(ctx.name)
+    end
+    return ('[%s] %s: '):format(ctx.name, walkthrough_path(ctx))
+end
+
+-- Generate an error supplemented by details from the given
+-- walkthrough context.
+local function walkthrough_error(ctx, message, ...)
+    local error_prefix = walkthrough_error_prefix(ctx)
+    error(('%s%s'):format(error_prefix, message:format(...)), 0)
+end
+
+-- Verify that the data is a table and, if it is not so, produce a
+-- nice schema-aware error.
+--
+-- Applicable for a record, a map, an array.
+--
+-- Useful as part of validation, but also as a lightweight
+-- consistency check.
+local function walkthrough_assert_table(ctx, schema, data)
+    assert(schema.type == 'record' or schema.type == 'map' or
+        schema.type == 'array')
+
+    if type(data) == 'table' then
+        return
+    end
+
+    local article = schema.type == 'array' and 'an' or 'a'
+    walkthrough_error(ctx, 'Unexpected data type for %s %s: %q', article,
+        schema.type, type(data))
+end
+
+-- }}} Walkthrough helpers
+
 -- {{{ Scalar definitions
 
 -- A scalar definition:
@@ -12,26 +87,74 @@ local scalars = {}
 -- {
 --     -- How the scalar is named.
 --     type = <string>,
+--     -- Check given data against the type constraints.
+--
+--     -> true (means the data is valid)
+--     -> false, err (otherwise)
+--     validate_noexc = <function>,
 -- }
+
+-- Verify whether the given value (data) has expected type and
+-- produce a human readable error message otherwise.
+local function validate_type_noexc(data, exp_type)
+    -- exp_type is a Lua type like 'string'.
+    assert(type(exp_type) == 'string')
+    if type(data) ~= exp_type then
+        local err = ('Expected %q, got %q'):format(exp_type, type(data))
+        return false, err
+    end
+    return true
+end
 
 scalars.string = {
     type = 'string',
+    validate_noexc = function(data)
+        return validate_type_noexc(data, 'string')
+    end,
 }
 
 scalars.number = {
     type = 'number',
+    validate_noexc = function(data)
+        -- TODO: Should we accept cdata<int64_t> and
+        -- cdata<uint64_t> here?
+        return validate_type_noexc(data, 'number')
+    end,
 }
 
 scalars.integer = {
     type = 'integer',
+    validate_noexc = function(data)
+        -- TODO: Accept cdata<int64_t> and cdata<uint64_t>.
+        local ok, err = validate_type_noexc(data, 'number')
+        if not ok then
+            return false, err
+        end
+        if data - math.floor(data) ~= 0 then
+            -- NB: %s is chosen deliberately: it formats a
+            -- floating-point number in a more human friendly way
+            -- than %f. For example, 5.5 vs 5.500000.
+            local err = ('Expected number without a fractional part, ' ..
+                'got %s'):format(data)
+            return false, err
+        end
+        return true
+    end,
 }
 
 scalars.boolean = {
     type = 'boolean',
+    validate_noexc = function(data)
+        return validate_type_noexc(data, 'boolean')
+    end,
 }
 
 scalars.any = {
     type = 'any',
+    validate_noexc = function(_data)
+        -- No validation.
+        return true
+    end,
 }
 
 local function is_scalar(schema)
@@ -141,6 +264,130 @@ local function array(array_def)
 end
 
 -- }}} Schema node constructors: scalar, record, map, array
+
+-- {{{ <schema object>:validate()
+
+-- Verify that the given table adheres array requirements.
+--
+-- It accepts an array without holes.
+--
+-- Strictly speaking,
+--
+-- * If the table is empty it is OK.
+-- * If the table is non-empty, the constraints are the following:
+--   * all keys are numeric, without a fractional part
+--   * the lower key is 1
+--   * the higher key is equal to the number of items
+local function validate_table_is_array(data, ctx)
+    assert(type(data) == 'table')
+
+    -- Check that all the keys are numeric.
+    local key_count = 0
+    local min_key = 1/0  -- +inf
+    local max_key = -1/0 -- -inf
+    for k, _ in pairs(data) do
+        if type(k) ~= 'number' then
+            walkthrough_error(ctx, 'An array contains a non-numeric ' ..
+                'key: %q', k)
+        end
+        if k - math.floor(k) ~= 0 then
+            walkthrough_error(ctx, 'An array contains a non-integral ' ..
+                'numeric key: %s', k)
+        end
+        key_count = key_count + 1
+        min_key = math.min(min_key, k)
+        max_key = math.max(max_key, k)
+    end
+
+    -- An empty array is a valid array.
+    if key_count == 0 then
+        return
+    end
+
+    -- Check that the array starts from 1 and has no holes.
+    if min_key ~= 1 then
+        walkthrough_error(ctx, 'An array must start from index 1, ' ..
+            'got min index %d', min_key)
+    end
+
+    -- Check that the array has no holes.
+    if max_key ~= key_count then
+        walkthrough_error(ctx, 'An array must not have holes, got ' ..
+            'a table with %d integer fields with max index %d', key_count,
+            max_key)
+    end
+end
+
+local function validate_impl(schema, data, ctx)
+    if is_scalar(schema) then
+        local scalar_def = scalars[schema.type]
+        assert(scalar_def ~= nil)
+
+        local ok, err = scalar_def.validate_noexc(data)
+        if not ok then
+            walkthrough_error(ctx, 'Unexpected data for scalar %q: %s',
+                schema.type, err)
+        end
+    elseif schema.type == 'record' then
+        walkthrough_assert_table(ctx, schema, data)
+
+        for field_name, field_def in pairs(schema.fields) do
+            walkthrough_enter(ctx, field_name)
+            local field = data[field_name]
+            -- Assume fields as non-required.
+            if field ~= nil then
+                validate_impl(field_def, field, ctx)
+            end
+            walkthrough_leave(ctx)
+        end
+
+        -- Walk over the data to catch unknown fields.
+        for field_name, _ in pairs(data) do
+            local field_def = schema.fields[field_name]
+            if field_def == nil then
+                walkthrough_error(ctx, 'Unexpected field %q', field_name)
+            end
+        end
+    elseif schema.type == 'map' then
+        walkthrough_assert_table(ctx, schema, data)
+
+        for field_name, field_value in pairs(data) do
+            walkthrough_enter(ctx, field_name)
+            validate_impl(schema.key, field_name, ctx)
+            validate_impl(schema.value, field_value, ctx)
+            walkthrough_leave(ctx)
+        end
+    elseif schema.type == 'array' then
+        walkthrough_assert_table(ctx, schema, data)
+        validate_table_is_array(data, ctx)
+
+        for i, v in ipairs(data) do
+            walkthrough_enter(ctx, i)
+            validate_impl(schema.items, v, ctx)
+            walkthrough_leave(ctx)
+        end
+    else
+        assert(false)
+    end
+end
+
+-- Validate the given data against the given schema.
+--
+-- Nuances:
+--
+-- * `schema.new('<...>', schema.scalar(<...>))` doesn't accept
+--   `nil` and `box.NULL`. However,
+-- * All fields in a record are optional: they accept `nil` and
+--   `box.NULL`.
+-- * The record/map/array determination is purely schema based.
+--   mt.__serialize marks in the data are not involved anyhow.
+-- * An array shouldn't have any holes (nil values in a middle).
+function methods.validate(self, data)
+    local ctx = walkthrough_start(self)
+    validate_impl(rawget(self, 'schema'), data, ctx)
+end
+
+-- }}} <schema object>:validate()
 
 -- {{{ Schema object constructor: new
 

--- a/src/box/lua/config/utils/schema.lua
+++ b/src/box/lua/config/utils/schema.lua
@@ -1,0 +1,195 @@
+-- Schema-aware data manipulations.
+
+local methods = {}
+local schema_mt = {}
+
+local scalars = {}
+
+-- {{{ Scalar definitions
+
+-- A scalar definition:
+--
+-- {
+--     -- How the scalar is named.
+--     type = <string>,
+-- }
+
+scalars.string = {
+    type = 'string',
+}
+
+scalars.number = {
+    type = 'number',
+}
+
+scalars.integer = {
+    type = 'integer',
+}
+
+scalars.boolean = {
+    type = 'boolean',
+}
+
+scalars.any = {
+    type = 'any',
+}
+
+local function is_scalar(schema)
+    return scalars[schema.type] ~= nil
+end
+
+-- }}} Scalar definitions
+
+-- {{{ Schema node constructors: scalar, record, map, array
+
+-- A schema node:
+--
+-- {
+--     -- One of scalar types, 'record', 'map' or 'array'.
+--     type = <string>,
+--     -- For a record.
+--     fields = <table>,
+--     -- For a map.
+--     key = <table>,
+--     value = <table>,
+--     -- For an array.
+--     items = <table>,
+--     -- Arbitrary user specified annotations.
+--     <..annotations..>
+-- }
+
+-- Create a scalar.
+--
+-- Example:
+--
+-- schema.scalar({
+--     type = 'string',
+--     <..annotations..>,
+-- })
+local function scalar(scalar_def)
+    assert(scalar_def.type ~= nil)
+    assert(is_scalar(scalar_def))
+    return scalar_def
+end
+
+-- Create a record.
+--
+-- A record node describes an object with the following properties:
+--
+-- * string keys
+-- * certain keys (listed)
+-- * certain value types (listed)
+--
+-- Example:
+--
+-- schema.record({
+--     foo = <schema node>,
+--     bar = <schema node>,
+-- }, {
+--     <..annotations..>
+-- })
+local function record(fields, annotations)
+    local res = {
+        type = 'record',
+        fields = fields or {},
+    }
+    for k, v in pairs(annotations or {}) do
+        assert(k ~= 'type' and k ~= 'fields')
+        res[k] = v
+    end
+    return res
+end
+
+-- Create a map.
+--
+-- A map node describes an object with the following properties:
+--
+-- * arbitrary keys
+-- * all keys have the same certain type
+-- * all values have the same certain type
+--
+-- Example:
+--
+-- schema.map({
+--     key = <schema node>,
+--     value = <schema node>,
+--     <..annotations..>
+-- })
+local function map(map_def)
+    assert(map_def.key ~= nil)
+    assert(map_def.value ~= nil)
+    assert(map_def.type == nil)
+    local res = table.copy(map_def)
+    res.type = 'map'
+    return res
+end
+
+-- Create an array.
+--
+-- Example:
+--
+-- schema.array({
+--     items = <schema node>,
+--     <..annotations..>
+-- })
+local function array(array_def)
+    assert(array_def.items ~= nil)
+    assert(array_def.type == nil)
+    local res = table.copy(array_def)
+    res.type = 'array'
+    return res
+end
+
+-- }}} Schema node constructors: scalar, record, map, array
+
+-- {{{ Schema object constructor: new
+
+-- Define a field lookup function on a schema object.
+--
+-- `<schema object>.foo` performs the following:
+--
+-- * search for a user-provided method
+-- * search for a method defined in this module
+-- * if 'name', 'schema' or 'methods' -- return the given field
+-- * otherwise return nil
+function schema_mt.__index(self, key)
+    local instance_methods = rawget(self, 'methods')
+    if instance_methods[key] ~= nil then
+        return instance_methods[key]
+    end
+    if methods[key] ~= nil then
+        return methods[key]
+    end
+    return rawget(self, key)
+end
+
+-- Create a schema object.
+--
+-- Unlike a schema node it has a name, has methods defined in this
+-- module and user-provided methods.
+local function new(name, schema, opts)
+    local opts = opts or {}
+    local instance_methods = opts.methods or {}
+
+    assert(type(name) == 'string')
+    assert(type(schema) == 'table')
+
+    return setmetatable({
+        name = name,
+        schema = schema,
+        methods = instance_methods,
+    }, schema_mt)
+end
+
+-- }}} Schema object constructor: new
+
+return {
+    -- Schema node constructors.
+    scalar = scalar,
+    record = record,
+    map = map,
+    array = array,
+
+    -- Schema object constructor.
+    new = new,
+}

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -135,7 +135,8 @@ extern char session_lua[],
 	metrics_utils_lua[],
 	metrics_version_lua[],
 	/* {{{ config */
-	config_utils_log_lua[];
+	config_utils_log_lua[],
+	config_utils_schema_lua[];
 	/* }}} config */
 
 /**
@@ -281,6 +282,10 @@ static const char *lua_sources[] = {
 	"config/utils/log",
 	"internal.config.utils.log",
 	config_utils_log_lua,
+
+	"config/utils/schema",
+	"internal.config.utils.schema",
+	config_utils_schema_lua,
 
 	/* }}} config */
 

--- a/test/config-luatest/schema_test.lua
+++ b/test/config-luatest/schema_test.lua
@@ -2350,3 +2350,54 @@ g.test_merge_any = function()
 end
 
 -- }}} <schema object>:merge()
+
+-- {{{ <schema object>:pairs()
+
+g.test_pairs = function()
+    local str = schema.scalar({type = 'string'})
+    local map = schema.map({
+        key = schema.scalar({type = 'string'}),
+        value = schema.record({
+            foo = schema.scalar({type = 'number'}),
+        }),
+    })
+    local arr = schema.array({
+        items = schema.record({
+            foo = schema.scalar({type = 'number'}),
+        }),
+    })
+    local s = schema.new('myschema', schema.record({
+        str = str,
+        map = map,
+        arr = arr,
+        rec = schema.record({
+            str = str,
+            map = map,
+            arr = arr,
+            rec = schema.record({
+                str = str,
+                map = map,
+                arr = arr,
+            }),
+        }),
+    }))
+
+    local res = s:pairs():map(function(w)
+        return {w.schema, w.path}
+    end):totable()
+    t.assert_items_equals(res, {
+        {str, {'str'}},
+        {map, {'map'}},
+        {arr, {'arr'}},
+
+        {str, {'rec', 'str'}},
+        {map, {'rec', 'map'}},
+        {arr, {'rec', 'arr'}},
+
+        {str, {'rec', 'rec', 'str'}},
+        {map, {'rec', 'rec', 'map'}},
+        {arr, {'rec', 'rec', 'arr'}},
+    })
+end
+
+-- }}} <schema object>:pairs()

--- a/test/config-luatest/schema_test.lua
+++ b/test/config-luatest/schema_test.lua
@@ -1,0 +1,271 @@
+local schema = require('internal.config.utils.schema')
+local t = require('luatest')
+
+local g = t.group()
+
+-- {{{ Schema node constructors: scalar, record, map, array
+
+-- schema.scalar() must return a table of the following shape.
+--
+-- {
+--     type = <...>,
+--     <..annnotations..>
+-- }
+g.test_scalar_constructor = function()
+    -- Several simple good cases.
+    local types = {
+        'string',
+        'number',
+        'integer',
+        'boolean',
+        'any',
+    }
+    for _, scalar_type in ipairs(types) do
+        local def = {type = scalar_type}
+        t.assert_equals(schema.scalar(def), def)
+        local def = {type = scalar_type, my_annotation = 'info'}
+        t.assert_equals(schema.scalar(def), def)
+    end
+
+    -- Several simple bad cases.
+    --
+    -- Ignore error messages. They are just 'assertion failed at
+    -- line X', purely for the schema creator.
+    local bad_scalar_defs = {
+        5,
+        '',
+        {},
+        {type = 'unknown'},
+        {foo = 'bar'},
+        {1, 2, 3},
+    }
+    for _, def in ipairs(bad_scalar_defs) do
+        t.assert_equals((pcall(schema.scalar, def)), false)
+    end
+end
+
+-- schema.record() must return a table of the following shape.
+--
+-- {
+--     type = 'record',
+--     fields = <...>,
+--     <..annotations..>
+-- }
+g.test_record_constructor = function()
+    local scalar_1 = schema.scalar({type = 'string'})
+    local scalar_2 = schema.scalar({type = 'number'})
+
+    -- A simple good case.
+    t.assert_equals(schema.record({
+        foo = scalar_1,
+        bar = scalar_2,
+    }), {
+        type = 'record',
+        fields = {
+            foo = scalar_1,
+            bar = scalar_2,
+        },
+    })
+
+    -- A simple good case with annotations.
+    t.assert_equals(schema.record({
+        foo = scalar_1,
+        bar = scalar_2,
+    }, {
+        my_annotation = 'info',
+    }), {
+        type = 'record',
+        fields = {
+            foo = scalar_1,
+            bar = scalar_2,
+        },
+        my_annotation = 'info',
+    })
+
+    -- An empty record is allowed.
+    --
+    -- No args -- an empty record is created.
+    t.assert_equals(schema.record({}), {type = 'record', fields = {}})
+    t.assert_equals(schema.record(), {type = 'record', fields = {}})
+
+    -- Same named field and annotation are allowed.
+    t.assert_equals(schema.record({
+        foo = scalar_1,
+    }, {
+        foo = 'info',
+    }), {
+        type = 'record',
+        fields = {
+            foo = scalar_1,
+        },
+        foo = 'info',
+    })
+
+    -- Bad cases: 'type' or 'fields' annotations.
+    --
+    -- Ignore error messages. They are just 'assertion failed at
+    -- line X', purely for the schema creator.
+    local fields = {foo = scalar_1}
+    t.assert_equals((pcall(schema.record, fields, {type = 'info'})), false)
+    t.assert_equals((pcall(schema.record, fields, {fields = 'info'})), false)
+end
+
+-- schema.map() must return a table of the following shape.
+--
+-- {
+--     type = 'map',
+--     key = <...>,
+--     value = <...>,
+--     <..annotations..>
+-- }
+g.test_map_constructor = function()
+    local scalar_1 = schema.scalar({type = 'string'})
+    local scalar_2 = schema.scalar({type = 'number'})
+
+    -- A simple good case.
+    t.assert_equals(schema.map({
+        key = scalar_1,
+        value = scalar_2,
+    }), {
+        type = 'map',
+        key = scalar_1,
+        value = scalar_2,
+    })
+
+    -- A simple good case with annotations.
+    t.assert_equals(schema.map({
+        key = scalar_1,
+        value = scalar_2,
+        my_annotation = 'info',
+    }), {
+        type = 'map',
+        key = scalar_1,
+        value = scalar_2,
+        my_annotation = 'info',
+    })
+
+    -- Simple bad cases.
+    --
+    -- No args, no key, no value.
+    --
+    -- Ignore error messages. They are just 'assertion failed at
+    -- line X', purely for the schema creator.
+    t.assert_equals((pcall(schema.map)), false)
+    t.assert_equals((pcall(schema.map, {})), false)
+    t.assert_equals((pcall(schema.map, {value = scalar_1})), false)
+    t.assert_equals((pcall(schema.map, {key = scalar_1})), false)
+
+    -- Bad case: 'type' annotation is forbidden.
+    --
+    -- Even if it is 'map'.
+    local def = {key = scalar_1, value = scalar_2, type = 'info'}
+    t.assert_equals((pcall(schema.map, def)), false)
+    local def = {key = scalar_1, value = scalar_2, type = 'map'}
+    t.assert_equals((pcall(schema.map, def)), false)
+end
+
+-- schema.array() must return a table of the following shape.
+--
+-- {
+--     type = 'array',
+--     items = <...>,
+--     <..annotations..>
+-- }
+g.test_array_constructor = function()
+    local scalar = schema.scalar({type = 'string'})
+
+    -- A simple good case.
+    t.assert_equals(schema.array({
+        items = scalar,
+    }), {
+        type = 'array',
+        items = scalar,
+    })
+
+    -- A simple good case with annotations.
+    t.assert_equals(schema.array({
+        items = scalar,
+        my_annotation = 'info',
+    }), {
+        type = 'array',
+        items = scalar,
+        my_annotation = 'info',
+    })
+
+    -- Simple bad cases.
+    --
+    -- No args, no items.
+    --
+    -- Ignore error messages. They are just 'assertion failed at
+    -- line X', purely for the schema creator.
+    t.assert_equals((pcall(schema.array)), false)
+    t.assert_equals((pcall(schema.array, {})), false)
+
+    -- Bad case: 'type' annotation is forbidden.
+    --
+    -- Even if it is 'array'.
+    local def = {items = scalar, type = 'info'}
+    t.assert_equals((pcall(schema.array, def)), false)
+    local def = {items = scalar, type = 'array'}
+    t.assert_equals((pcall(schema.array, def)), false)
+end
+
+-- }}} Schema node constructors: scalar, record, map, array
+
+-- {{{ Schema object constructor: new
+
+-- schema.new() must return a table of the following shape.
+--
+-- {
+--     name = <string>,
+--     schema = <...>,
+--     methods = <...>
+-- }
+--
+-- It should have a metatable with methods provided by the
+-- schema module and methods provided in the constructor
+-- arguments.
+g.test_schema_new = function()
+    local scalar_1 = schema.scalar({type = 'string'})
+    local scalar_2 = schema.scalar({type = 'number'})
+
+    -- Several simple good cases.
+    local schema_nodes = {
+        scalar_1,
+        schema.record({foo = scalar_1}),
+        schema.map({key = scalar_1, value = scalar_2}),
+        schema.array({items = scalar_1}),
+    }
+    for _, schema_node in ipairs(schema_nodes) do
+        local name = 'myschema'
+        local s = schema.new(name, schema_node)
+        t.assert_equals(s.name, name)
+        t.assert_equals(s.schema, schema_node)
+        t.assert_equals(s.methods, {})
+        t.assert(getmetatable(s) ~= nil)
+
+        local mymethods = {
+            foo = function(self)
+                return {'foo', self}
+            end
+        }
+        local s = schema.new(name, schema_node, {methods = mymethods})
+        t.assert_equals(s.methods.foo, mymethods.foo)
+        t.assert_equals(s:foo(), {'foo', s})
+    end
+
+    -- Bad cases: no args, no name, no schema node, wrong name
+    -- type, wrong schema node type.
+    --
+    -- Ignore error messages. They are just 'assertion failed at
+    -- line X', purely for the schema creator.
+    t.assert_equals((pcall(schema.new)), false)
+    t.assert_equals((pcall(schema.new, 'myschema')), false)
+    t.assert_equals((pcall(schema.new, 'myschema', 5)), false)
+    t.assert_equals((pcall(schema.new, 'myschema', 'foo')), false)
+    t.assert_equals((pcall(schema.new, nil, scalar_1)), false)
+    t.assert_equals((pcall(schema.new, 5, scalar_1)), false)
+    t.assert_equals((pcall(schema.new, {}, scalar_1)), false)
+end
+
+-- }}} Schema object constructor: new

--- a/test/config-luatest/schema_test.lua
+++ b/test/config-luatest/schema_test.lua
@@ -515,4 +515,40 @@ g.test_validate_array = function()
     }, ': '))
 end
 
+g.test_validate_by_allowed_values = function()
+    local allowed_values = {
+        0, 'fatal',
+        1, 'syserror',
+        2, 'error',
+        3, 'crit',
+        4, 'warn',
+        5, 'info',
+        6, 'verbose',
+        7, 'debug',
+    }
+
+    local s = schema.new('log_level', schema.scalar({
+        type = 'any',
+        allowed_values = allowed_values,
+    }))
+
+    -- Good cases: all the allowed values are actually allowed.
+    for _, level in ipairs(allowed_values) do
+        s:validate(level)
+    end
+
+    -- Bad cases: other values are not allowed.
+    assert_validate_error(s, -1, ('[log_level] Got %s, but only the ' ..
+        'following values are allowed: %s'):format(-1,
+        table.concat(allowed_values, ', ')))
+
+    -- Verify that a type validation occurs before the allowed
+    -- values validation.
+    local s = schema.new('fruits', schema.scalar({
+        type = 'string',
+        allowed_values = {'orange', 'banana'},
+    }))
+    assert_validate_scalar_type_mismatch(s, 1, 'string')
+end
+
 -- }}} <schema object>:validate()


### PR DESCRIPTION
The module offers a schema definition format and provides a bunch of functions to validate and manipulate hierarchical data.

See the API description in #8725.

The module is part of the new declarative configuration initiative, see #8724.

This pull request doesn't add any public API: the module is for internal use and its API can be changed later.

Fixes #8725