### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/fix-bit-shift-generation.md
+++ b/changelogs/unreleased/fix-bit-shift-generation.md
@@ -1,0 +1,3 @@
+## bugfix/luajit
+
+* Fixed result truncation for `bit.rol` on x86_64 platforms.


### PR DESCRIPTION
x64: Fix 64 bit shift code generation.

Part of #8516

NO_DOC=LuaJIT bump
NO_TEST=LuaJIT bump