### PR TITLE
replication: allow to pass instance name as bootstrap_leader

### DIFF
--- a/changelogs/unreleased/gh-8539-bootstrap-leader-name.md
+++ b/changelogs/unreleased/gh-8539-bootstrap-leader-name.md
@@ -1,0 +1,15 @@
+## feature/replication
+
+* Added the ability to set the `bootstrap_leader` configuration option to the
+  instance name of the desired bootstrap leader:
+  ```lua
+    box.cfg{
+        bootstrap_strategy = 'config',
+        bootstrap_leader = 'leader-name',
+        replication = {
+            ...
+        },
+        ...
+    }
+  ```
+  (gh-7999, gh-8539).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -4426,6 +4426,15 @@ box_process_vote(struct ballot *ballot)
 	vclock_copy(&ballot->vclock, &replicaset.vclock);
 	vclock_copy(&ballot->gc_vclock, &gc.vclock);
 	ballot->bootstrap_leader_uuid = bootstrap_leader_uuid;
+	if (*INSTANCE_NAME != '\0') {
+		strlcpy(ballot->instance_name, INSTANCE_NAME,
+			NODE_NAME_SIZE_MAX);
+	} else if (*cfg_instance_name != '\0') {
+		strlcpy(ballot->instance_name, cfg_instance_name,
+			NODE_NAME_SIZE_MAX);
+	} else {
+		*ballot->instance_name = '\0';
+	}
 	int i = 0;
 	replicaset_foreach(replica) {
 		if (replica->id != 0)

--- a/src/box/iproto_constants.h
+++ b/src/box/iproto_constants.h
@@ -263,6 +263,7 @@ extern const char *iproto_metadata_key_strs[];
 	_(CAN_LEAD, 0x07)						\
 	_(BOOTSTRAP_LEADER_UUID, 0x08)					\
 	_(REGISTERED_REPLICA_UUIDS, 0x09)				\
+	_(INSTANCE_NAME, 0x0a)						\
 
 #define IPROTO_BALLOT_KEY_MEMBER(s, v) IPROTO_BALLOT_ ## s = v,
 

--- a/src/box/replication.cc
+++ b/src/box/replication.cc
@@ -65,6 +65,7 @@ int replication_threads = 1;
 bool cfg_replication_anon = true;
 struct tt_uuid cfg_bootstrap_leader_uuid;
 struct uri cfg_bootstrap_leader_uri;
+char cfg_bootstrap_leader_name[NODE_NAME_SIZE_MAX];
 char cfg_instance_name[NODE_NAME_SIZE_MAX];
 
 struct replicaset replicaset;
@@ -948,6 +949,10 @@ applier_is_bootstrap_leader(const struct applier *applier)
 {
 	assert(!tt_uuid_is_nil(&applier->uuid));
 	if (bootstrap_strategy == BOOTSTRAP_STRATEGY_CONFIG) {
+		if (*cfg_bootstrap_leader_name != '\0') {
+			return strcmp(applier->ballot.instance_name,
+				      cfg_bootstrap_leader_name) == 0;
+		}
 		if (!tt_uuid_is_nil(&cfg_bootstrap_leader_uuid)) {
 			return tt_uuid_is_equal(&applier->uuid,
 						&cfg_bootstrap_leader_uuid);
@@ -1448,8 +1453,10 @@ replicaset_find_join_master_cfg(void)
 		if (applier_is_bootstrap_leader(applier))
 			leader = replica;
 	}
-	if (leader == NULL && !tt_uuid_is_equal(&cfg_bootstrap_leader_uuid,
-						&INSTANCE_UUID)) {
+	if (leader == NULL &&
+	    !tt_uuid_is_equal(&cfg_bootstrap_leader_uuid, &INSTANCE_UUID) &&
+	    (strcmp(cfg_bootstrap_leader_name, cfg_instance_name) != 0 ||
+	     *cfg_bootstrap_leader_name == '\0')) {
 		tnt_raise(ClientError, ER_CFG, "bootstrap_leader",
 			  "failed to connect to the bootstrap leader");
 	}

--- a/src/box/replication.h
+++ b/src/box/replication.h
@@ -138,6 +138,12 @@ extern struct tt_uuid cfg_bootstrap_leader_uuid;
 extern struct uri cfg_bootstrap_leader_uri;
 
 /**
+ * The name of the bootstrap leader configured via the bootstrap_leader
+ * configuration option.
+ */
+extern char cfg_bootstrap_leader_name[];
+
+/**
  * Configured name of this instance. Might be different from the actual name if
  * the configuration is not fully applied yet.
  */

--- a/src/box/xrow.h
+++ b/src/box/xrow.h
@@ -509,6 +509,8 @@ struct ballot {
 	struct vclock gc_vclock;
 	/** The uuid of the instance this node considers a bootstrap leader. */
 	struct tt_uuid bootstrap_leader_uuid;
+	/** The name of this node. */
+	char instance_name[NODE_NAME_SIZE_MAX];
 	/** Replica uuids registered in the replica set. */
 	struct tt_uuid registered_replica_uuids[VCLOCK_MAX];
 	/** Number of replicas registered in the replica set. */

--- a/test/box-luatest/builtin_events_test.lua
+++ b/test/box-luatest/builtin_events_test.lua
@@ -414,4 +414,8 @@ g.test_internal_ballot = function(cg)
     expected[ballot_key.CAN_LEAD] = true
     expected[ballot_key.IS_RO] = true
     cg.replica:exec(wait_ballot_updated_to, {expected})
+    cg.replica:update_box_cfg{instance_name='replica-name'}
+    expected[ballot_key.INSTANCE_NAME] = 'replica-name'
+    expected[ballot_key.VCLOCK] = cg.master:get_vclock()
+    cg.replica:exec(wait_ballot_updated_to, {expected})
 end

--- a/test/box-luatest/gh_7894_export_iproto_constants_and_features_test.lua
+++ b/test/box-luatest/gh_7894_export_iproto_constants_and_features_test.lua
@@ -107,6 +107,7 @@ local reference_table = {
         CAN_LEAD = 0x07,
         BOOTSTRAP_LEADER_UUID = 0x08,
         REGISTERED_REPLICA_UUIDS = 0x09,
+        INSTANCE_NAME = 0x0a,
     },
 
     -- `iproto_type` enumeration.


### PR DESCRIPTION
Make it possible to specify the bootstrap leader via an instance name in addition to its URI and UUID.

Closes #8539

@TarantoolBot document
Title: `box.cfg.bootstrap_leader` accepts instance names now

The option `box.cfg.bootstrap_leader`, which specifies the desired bootstrap leader when bootstrap_strategy is "config" now accepts instance names.

For example, this is a valid config without replication:
```lua
box.cfg{
    instance_name = 'main-server',
    bootstrap_strategy = 'config',
    bootstrap_leader = 'main-server'
}
```

When `box.cfg` contains some entries in `replication`, the node will bootstrap from whatever node which has its `box.cfg.instance_name` set to the same value as specified in `box.cfg.bootstrap_leader`.

This is an addition to tarantool/doc#3432