### PR TITLE
config: add logger wrapper with JSON encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,8 +87,8 @@ src/trivia/config.h
 install_manifest.txt
 lcov
 src/box/bootstrap.h
-src/lua/*.lua.c
-src/box/lua/*.lua.c
+src/lua/**/*.lua.c
+src/box/lua/**/*.lua.c
 third_party/lua/*.lua.c
 src/tarantool
 src/module.h

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -35,6 +35,11 @@ lua_source(lua_sources lua/console.lua console_lua)
 lua_source(lua_sources lua/xlog.lua xlog_lua)
 lua_source(lua_sources lua/key_def.lua key_def_lua)
 lua_source(lua_sources lua/merger.lua merger_lua)
+
+# {{{ config
+lua_source(lua_sources lua/config/utils/log.lua        config_utils_log_lua)
+# }}} config
+
 set(bin_sources)
 bin_source(bin_sources bootstrap.snap bootstrap.h bootstrap_bin)
 

--- a/src/box/lua/config/utils/log.lua
+++ b/src/box/lua/config/utils/log.lua
@@ -1,0 +1,156 @@
+-- Logger wrapper with a few enhancements.
+--
+-- 1. Encode tables into JSON.
+-- 2. Enable all the messages on TT_CONFIG_DEBUG=1.
+--
+-- Hopefully, the wrapper can be dropped when the following logger
+-- problems will be solved.
+--
+-- * JSONify tables at logging (gh-8611)
+-- * Follow TT_LOG_LEVEL before log.cfg()/box.cfg() (gh-8092)
+--
+-- A solution of the following problems may simplify the code of
+-- this wrapper.
+--
+-- * mylog.cfg() configures the main logger (gh-8610)
+-- * No easy way to determine if a message should go to the log
+--   (gh-8730)
+
+local json_noexc = require('json').new()
+json_noexc.cfg({encode_use_tostring = true})
+
+local logger_name = 'tarantool.config'
+local log = require('log').new(logger_name)
+
+local func2level = {
+    [log.error] = 2,
+    [log.warn] = 3,
+    [log.info] = 5,
+    [log.verbose] = 6,
+    [log.debug] = 7,
+}
+
+local func2prefix = {
+    [log.error] = 'E> ',
+    [log.warn] = 'W> ',
+    [log.info] = 'I> ',
+    [log.verbose] = 'V> ',
+    [log.debug] = 'D> ',
+}
+
+local str2level = {
+    ['fatal'] = 0,
+    ['syserror'] = 1,
+    ['error'] = 2,
+    ['warn'] = 3,
+    ['crit'] = 4,
+    ['info'] = 5,
+    ['verbose'] = 6,
+    ['debug'] = 7,
+}
+
+-- Accept false/true case insensitively.
+--
+-- Accept 0/1 as boolean values.
+--
+-- If anything else is given, just return the default.
+local function boolean_fromenv(raw_value, default)
+    if raw_value == nil or raw_value == '' then
+        return default
+    end
+    if raw_value:lower() == 'false' or raw_value == '0' then
+        return false
+    end
+    if raw_value:lower() == 'true' or raw_value == '1' then
+        return true
+    end
+    return default
+end
+
+local function say_closure(log_f)
+    local prefix = ''
+
+    -- Enable logging of everything if an environment variable is
+    -- set.
+    --
+    -- Useful for debugging.
+    --
+    -- Just setting of...
+    --
+    -- ```
+    -- TT_LOG_MODULES='{"tarantool.config": "debug"}'
+    -- ```
+    --
+    -- ...is not suitable due to gh-8092: messages before first
+    -- box.cfg() are not shown.
+    --
+    -- Explicit calling of...
+    --
+    -- ```
+    -- log.cfg({modules = {['tarantool.config'] = 'debug'}})
+    -- ```
+    --
+    -- is not suitable as well, because it makes the logger
+    -- already configured and non-dynamic options like
+    -- `box_cfg.log_nonblock` can't be applied at first box.cfg()
+    -- invocation.
+    --
+    -- So just prefix our log messages and use log.info().
+    --
+    -- The prefix represents the original log level of the
+    -- message.
+    if boolean_fromenv(os.getenv('TT_CONFIG_DEBUG'), false) then
+        prefix = func2prefix[log_f]
+        log_f = log.info
+    end
+
+    return function(fmt, ...)
+        -- Skip logging based on the log level before performing
+        -- the encoding into JSON.
+        --
+        -- log.new(<...>).cfg is the main logger configuration,
+        -- the same as log.cfg. Extract the current log level from
+        -- log.cfg.modules if it is set specifically for the config
+        -- module. See gh-8610.
+        local level = log.cfg.modules and
+            log.cfg.modules[logger_name] or
+            log.cfg.level
+        -- The level is either a string or a number. Transform it
+        -- to a number. See gh-8730.
+        level = str2level[level] or level
+        assert(type(level) == 'number')
+        if func2level[log_f] > level then
+            return
+        end
+
+        -- Micro-optimization: don't create a temporary table if
+        -- it is not needed.
+        local argc = select('#', ...)
+        if argc == 0 then
+            log_f(prefix .. fmt)
+            return
+        end
+
+        -- Encode tables into JSON.
+        --
+        -- Ignores presence of __serialize and __tostring in the
+        -- metatatable. It is suitable for the config module needs.
+        local args = {...}
+        for i = 1, argc do
+            if type(args[i]) == 'table' then
+                args[i] = json_noexc.encode(args[i])
+            end
+        end
+
+        -- Pass the result to the logger function.
+        log_f(prefix .. fmt, unpack(args, 1, argc))
+    end
+end
+
+return {
+    error = say_closure(log.error),
+    warn = say_closure(log.warn),
+    info = say_closure(log.info),
+    verbose = say_closure(log.verbose),
+    debug = say_closure(log.debug),
+}

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -133,7 +133,10 @@ extern char session_lua[],
 	metrics_tarantool_vinyl_lua[],
 	metrics_tarantool_lua[],
 	metrics_utils_lua[],
-	metrics_version_lua[];
+	metrics_version_lua[],
+	/* {{{ config */
+	config_utils_log_lua[];
+	/* }}} config */
 
 /**
  * List of box's built-in modules written using Lua.
@@ -272,6 +275,15 @@ static const char *lua_sources[] = {
 	"metrics.plugins.prometheus", metrics_plugins_prometheus_lua,
 	"third_party/metrics/metrics/plugins/json",
 	"metrics.plugins.json", metrics_plugins_json_lua,
+
+	/* {{{ config */
+
+	"config/utils/log",
+	"internal.config.utils.log",
+	config_utils_log_lua,
+
+	/* }}} config */
+
 	NULL
 };
 

--- a/test/config-luatest/log_wrapper_test.lua
+++ b/test/config-luatest/log_wrapper_test.lua
@@ -1,0 +1,160 @@
+local t = require('luatest')
+local treegen = require('test.treegen')
+local justrun = require('test.justrun')
+
+local g = t.group()
+
+g.before_all(function(g)
+    treegen.init(g)
+end)
+
+g.after_all(function(g)
+    treegen.clean(g)
+end)
+
+g.test_jsonify_table = function(g)
+    local dir = treegen.prepare_directory(g, {}, {})
+    treegen.write_script(dir, 'main.lua', [[
+        local log = require('internal.config.utils.log')
+
+        log.info('foo: %s', {bar = 'baz'})
+    ]])
+    local env = {}
+    local opts = {nojson = true, stderr = true}
+    local res = justrun.tarantool(dir, env, {'main.lua'}, opts)
+    t.assert_equals(res, {
+        exit_code = 0,
+        stdout = '',
+        stderr = 'foo: {"bar":"baz"}',
+    })
+end
+
+-- {{{ Follow log level
+
+local log_levels = {
+    'default',
+    0, 'fatal',
+    1, 'syserror',
+    2, 'error',
+    3, 'crit',
+    4, 'warn',
+    5, 'info',
+    6, 'verbose',
+    7, 'debug',
+}
+
+local logger_funcs = {
+    'error',
+    'warn',
+    'info',
+    'verbose',
+    'debug',
+}
+
+local str2level = setmetatable({
+    ['default']  = 5,
+    ['fatal']    = 0,
+    ['syserror'] = 1,
+    ['error']    = 2,
+    ['crit']     = 3,
+    ['warn']     = 4,
+    ['info']     = 5,
+    ['verbose']  = 6,
+    ['debug']    = 7,
+}, {
+    __call = function(self, x)
+        x = self[x] or x
+        assert(type(x) == 'number')
+        return x
+    end,
+})
+
+local script = [[
+    local main_log = require('log')
+    local log = require('internal.config.utils.log')
+
+    local current_level = tonumber(arg[1]) or arg[1]
+    local msg_level = arg[2]
+    local set_module_logger_level = arg[3] == 'true'
+
+    if current_level ~= 'default' then
+        if set_module_logger_level then
+            main_log.cfg({
+                modules = {
+                    ['tarantool.config'] = current_level,
+                },
+            })
+        else
+            main_log.cfg({level = current_level})
+        end
+    end
+
+    log[msg_level]('foo')
+]]
+
+for _, current_level in ipairs(log_levels) do
+    for _, msg_level in ipairs(logger_funcs) do
+        for _, set_module_logger_level in pairs({false, true}) do
+            local case_name = ('test_follow_log_level_%s_%s_%s'):format(
+                current_level, msg_level, set_module_logger_level)
+            g[case_name] = function(g)
+                local dir = treegen.prepare_directory(g, {}, {})
+                treegen.write_script(dir, 'main.lua', script)
+                local opts = {nojson = true, stderr = true}
+
+                local args = {'main.lua', tostring(current_level), msg_level,
+                    tostring(set_module_logger_level)}
+                local res = justrun.tarantool(dir, {}, args, opts)
+                t.assert_equals(res.exit_code, 0, res)
+
+                if str2level(msg_level) <= str2level(current_level) then
+                    t.assert(res.stderr:find('foo') ~= nil)
+                else
+                    t.assert(res.stderr:find('foo') == nil)
+                end
+            end
+        end
+    end
+end
+
+-- }}} Follow log level
+
+g.test_enable_debug = function(g)
+    local dir = treegen.prepare_directory(g, {}, {})
+    treegen.write_script(dir, 'main.lua', [[
+        local log = require('internal.config.utils.log')
+
+        -- A single string argument.
+        log.debug('debug')
+        log.verbose('verbose')
+        log.info('info')
+        log.warn('warn')
+        log.error('error')
+
+        -- A format string plus arguments.
+        log.debug('debug %s', {1})
+        log.verbose('verbose %s', {1})
+        log.info('info %s', {1})
+        log.warn('warn %s', {1})
+        log.error('error %s', {1})
+    ]])
+    local env = {['TT_CONFIG_DEBUG'] = '1'}
+    local opts = {nojson = true, stderr = true}
+    local res = justrun.tarantool(dir, env, {'main.lua'}, opts)
+    t.assert_equals(res, {
+        exit_code = 0,
+        stdout = '',
+        stderr = table.concat({
+            'D> debug',
+            'V> verbose',
+            'I> info',
+            'W> warn',
+            'E> error',
+            'D> debug [1]',
+            'V> verbose [1]',
+            'I> info [1]',
+            'W> warn [1]',
+            'E> error [1]',
+        }, '\n'),
+    })
+end

--- a/test/config-luatest/suite.ini
+++ b/test/config-luatest/suite.ini
@@ -1,0 +1,3 @@
+[default]
+core = luatest
+description = declarative configuration tests


### PR DESCRIPTION
The future config module works with hierarchical data a lot and needs a way to show a table as a part a log message. The config module issues log messages at different log levels and it is undesirable to perform JSON encoding for messages that will be filtered out by the current log level.

It is complicated to achieve the goal using the `log` module. Let's add a wrapper as the temporary solution. The wrapper can be eliminated after solving the problems in the `log` module that are linked in the wrapper's code.

The wrapper also simplifies debugging of the config module itself.