### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-8594-sysprof-ffunc-crash.md
+++ b/changelogs/unreleased/gh-8594-sysprof-ffunc-crash.md
@@ -1,0 +1,3 @@
+## bugfix/luajit
+
+* Fixed sysprof crash during stack unwinding for FFUNC.


### PR DESCRIPTION
sysprof: fix crash during FFUNC stream

Closes #8594

NO_DOC=LuaJIT bump
NO_TEST=LuaJIT bump