### PR TITLE
ci: use workaround for LuaJIT profiling tests in all workflows

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -86,10 +86,10 @@ runs:
         git clean -xffd
         git submodule foreach --recursive 'git clean -xffd'
 
-        # A temporary workaround that should be removed after the corresponding
-        # issue is fixed. See for details:
-        #   https://github.com/tarantool/tarantool/issues/7472.
-        if ${{ runner.os == 'Linux' && github.workflow == 'coverage' }}; then
+        # See for details: https://github.com/tarantool/tarantool/issues/7472.
+        # Do nothing on GitHub-hosted runners.
+        if ${{ runner.os == 'Linux' &&
+               !contains(runner.name, 'GitHub Actions') }}; then
             LUAJIT_TEST_VARDIR=/tmp/luajit-test-vardir
             LUAJIT_TEST_VARDIR_DISK=/tmp/luajit-test-vardir-disk/disk.ext4
 

--- a/.github/workflows/publish-module-api-doc.yaml
+++ b/.github/workflows/publish-module-api-doc.yaml
@@ -1,10 +1,10 @@
-name: Build and publish module API documentation
+name: publish-module-api-doc
 
 on:
   push:
-    branches: [master]
+    branches:
+      - 'master'
   pull_request:
-    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 concurrency:
@@ -30,6 +30,14 @@ concurrency:
 jobs:
   build-api-doc:
     runs-on: ubuntu-latest
+
+    # Run on push to the tarantool/tarantool repository or on pull request
+    # if the 'notest' label is not set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          ( github.event_name == 'pull_request' &&
+            !contains(github.event.pull_request.labels.*.name, 'notest') ) )
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
@@ -52,9 +60,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4.4.0
         with:
           folder: doc/
-        if: github.repository == 'tarantool/tarantool' &&
-            github.ref == 'refs/heads/master' &&
-            github.event_name != 'pull_request'
+        if: github.ref == 'refs/heads/master'
 
       - name: Send VK Teams message on failure
         if: failure()


### PR DESCRIPTION
After this patch, the workaround for LuaJIT profiling tests to avoid runner's shutdown due to no space left on the disk is going to be used in all relevant workflows. Previously, we applied it only for the coverage test, but we noticed that other jobs may be affected as well after tarantool/tarantool#8737 is merged.

Follows up tarantool/tarantool#7472