### PR TITLE
ci: restrict Lango stale PRs workflow

### DIFF
--- a/.github/workflows/lango-stale-reviews.yml
+++ b/.github/workflows/lango-stale-reviews.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   update-last-activity-dates:
+    # Do this activity only for main repo.
+    if: github.repository == 'tarantool/tarantool'
     env:
       LANGO_REVIEW_BOARD_TOKEN: ${{ secrets.LANGO_REVIEW_BOARD_TOKEN }}
       ORGANIZATION: Tarantool


### PR DESCRIPTION
If one uses mail notifications about failed ci workflows, he can see tons of the following notifications for his fork of Tarantool: 
`[Buristan/tarantool] Run failed: lango-stale-reviews - master`
This job failed due to unknown credentials.

This patch adds the condition to run this workflow only for main Tarantool repo.

NO_DOC=Workflow fix
NO_TEST=Workflow fix
NO_CHANGELOG=Workflow fix