### PR TITLE
Do not check permissions on functions if functions are used in a constraint or in a function index

### DIFF
--- a/changelogs/unreleased/gh-7873-func-priv-check.md
+++ b/changelogs/unreleased/gh-7873-func-priv-check.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed the privilege check when using spaces with functional indexes and
+  constraints (gh-7873).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -396,6 +396,8 @@ index_def_new_from_tuple(struct tuple *tuple, struct space *space)
 	 */
 	struct func *func = NULL;
 	if (for_func_index && (func = func_by_id(opts.func_id)) != NULL) {
+		if (func_access_check(func) != 0)
+			return NULL;
 		if (func_index_check_func(func) != 0)
 			return NULL;
 		index_def_set_func(index_def, func);
@@ -5225,6 +5227,15 @@ on_replace_dd_func_index(struct trigger *trigger, void *event)
 			diag_set(ClientError, ER_NO_SUCH_FUNCTION, int2str(fid));
 			return -1;
 		}
+		/*
+		 * These checks are duplicated from the _index's on_replace
+		 * trigger in order to perform required checks during recovery.
+		 *
+		 * See the comment above the same checks in the
+		 * index_def_new_from_tuple function.
+		 */
+		if (func_access_check(func) != 0)
+			return -1;
 		if (func_index_check_func(func) != 0)
 			return -1;
 		if (index->def->opts.func_id != func->def->fid) {

--- a/src/box/key_list.c
+++ b/src/box/key_list.c
@@ -59,7 +59,7 @@ key_list_iterator_create(struct key_list_iterator *it, struct tuple *tuple,
 	struct port out_port, in_port;
 	port_c_create(&in_port);
 	port_c_add_tuple(&in_port, tuple);
-	int rc = func_call(func, &in_port, &out_port);
+	int rc = func_call_no_access_check(func, &in_port, &out_port);
 	port_destroy(&in_port);
 	if (rc != 0) {
 		/* Can't evaluate function. */

--- a/src/box/tuple_constraint_func.c
+++ b/src/box/tuple_constraint_func.c
@@ -97,7 +97,8 @@ tuple_constraint_call_func(const struct tuple_constraint *constr,
 					constr->space->format);
 	port_c_add_str(&in_port, constr->def.name, constr->def.name_len);
 
-	int rc = func_call(constr->func_cache_holder.func, &in_port, &out_port);
+	int rc = func_call_no_access_check(constr->func_cache_holder.func,
+					   &in_port, &out_port);
 	port_destroy(&in_port);
 	if (rc == 0) {
 		uint32_t ret_size;
@@ -189,7 +190,7 @@ tuple_constraint_func_init(struct tuple_constraint *constr,
 		assert(constr->check == tuple_constraint_noop_check);
 		return 0;
 	}
-	if (func == NULL ||
+	if (func == NULL || func_access_check(func) != 0 ||
 	    tuple_constraint_func_verify(constr, func, is_field) != 0) {
 		constr->space = NULL;
 		return -1;

--- a/test/box-luatest/gh_7873_func_perm_check_test.lua
+++ b/test/box-luatest/gh_7873_func_perm_check_test.lua
@@ -1,0 +1,71 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+local function test_func_indexes()
+    local value
+    local prefix = 'test_func_indexes_'
+    local uname = prefix .. 'user'
+    local fname = prefix .. 'func'
+    local s_test = box.schema.space.create(prefix .. 's_test')
+    local err = "Execute access to function '" .. fname .. "'"
+                .. " is denied for user '" .. uname .. "'"
+
+    -- Fill spaces to invoke format/constraint check.
+    s_test:create_index('pk')
+    for i = 1, 10 do s_test:insert({i}) end
+
+    -- Create a function by 'admin'.
+    box.schema.func.create(fname, {
+        body = 'function(tuple) return { tuple[1] } end',
+        is_deterministic = true,
+        is_sandboxed = true
+    })
+
+    -- Set the function as functional index function.
+    value = {parts = {{1, 'number'}}, unique = true, func = fname}
+    s_test:create_index('fk1', value)
+
+    -- Create a restricted user.
+    box.session.su('admin')
+    box.schema.user.create(uname)
+    box.schema.user.grant(uname, 'read,write,alter,create,drop', 'universe')
+
+    -- Switch to the restricted user.
+    box.session.su(uname)
+
+    ----------------------------------------------------------------------------
+    -- The restricted user should be able to use the space with a functional
+    -- index using the function that was created by 'admin'.
+
+    s_test:insert({42})
+
+    ----------------------------------------------------------------------------
+    -- The restricted user should not be able to specify the function that was
+    -- created by 'admin' as a functional index function.
+
+    value = {parts = {{1, 'unsigned'}}, unique = true, func = fname}
+    t.assert_error_msg_equals(err, s_test.create_index, s_test, 'fk2', value)
+
+    ----------------------------------------------------------------------------
+    -- Cleanup.
+
+    box.session.su('admin')
+    s_test:drop()
+    box.schema.user.drop(uname)
+    box.schema.func.drop(fname)
+end
+
+g.test_func_indexes = function(cg)
+    cg.server:exec(test_func_indexes)
+end


### PR DESCRIPTION
Function execution permissions should only be checked on functional index creation and on functional index function set. This is also true for constraints.

Closes #7873