### PR TITLE
httpc: fix content-length with a stream

### DIFF
--- a/changelogs/unreleased/gh-8744-fix-chunked-with-content-length.md
+++ b/changelogs/unreleased/gh-8744-fix-chunked-with-content-length.md
@@ -1,0 +1,4 @@
+## bugfix/lua/http client
+
+* Fixed the `Transfer-Encoding: chunked` setting being enabled even if
+  the `Content-Length` header exists for stream requests (gh-8744).

--- a/src/httpc.h
+++ b/src/httpc.h
@@ -133,11 +133,11 @@ struct httpc_request {
 	 */
 	bool set_keep_alive_header;
 	/**
-	 * True when Transfer-Encoding: chunked must be
-	 * set before execution automatically if chunked
-	 * io enabled.
+	 * It's the number of bytes of data in the body of the
+	 * request. The value is equal to "Content-Length"
+	 * header or -1 otherwise.
 	 */
-	bool set_chunked_header;
+	long content_length;
 	/** True when chunked io is enabled. */
 	bool io;
 	/**

--- a/test/app-luatest/http_client_test.lua
+++ b/test/app-luatest/http_client_test.lua
@@ -195,6 +195,19 @@ g.test_http_client_headers_redefine = function(cg)
                     'Redefined Connection header')
 end
 
+g.test_http_client_content_length_invalid = function(cg)
+    local url = cg.url
+    local expected = "Content%-Length header " ..
+        "value must be a non%-negative integer"
+    for _, length in ipairs({"asd", "-1", "1asd"}) do
+        local opts = table.deepcopy(cg.opts)
+        opts.headers = {['Content-Length'] = length}
+        local ok, err = pcall(client.post, url, nil, opts)
+        t.assert_equals(ok, false, 'an error expected')
+        t.assert_str_contains(json.encode(err), expected, 'digit')
+    end
+end
+
 g.test_cancel_and_errinj = function(cg)
     local url, opts = cg.url, cg.opts
     local ch = fiber.channel(1)
@@ -1238,6 +1251,34 @@ g.test_http_client_io_post = function(cg)
     t.assert_equals(read, data, 'read == post')
     t.assert_equals(io.status, 200, 'io')
     t.assert_equals(io.reason, 'Ok', '200 - Ok')
+
+end
+
+g.test_http_client_io_post_encoding_chunked = function(cg)
+    local url, opts = cg.url, table.deepcopy(cg.opts)
+    local endpoint = 'encoding'
+    local data = 'any data'
+    opts.chunked = true
+
+    local io = client.post(url .. endpoint, data, opts)
+    io:finish()
+
+    local encoding = io:read(1024)
+    t.assert_equals(encoding, 'chunked', 'enconding == chunked')
+end
+
+g.test_http_client_io_post_content_length_no_encoding = function(cg)
+    local url, opts = cg.url, table.deepcopy(cg.opts)
+    local endpoint = 'encoding'
+    local data = 'any data'
+    opts.chunked = true
+    opts.headers = {['Content-Length'] = tostring(string.len(data))}
+
+    local io = client.post(url .. endpoint, data, opts)
+    io:finish()
+
+    local encoding = io:read(1024)
+    t.assert_equals(encoding, 'none', 'encoding == none')
 end
 
 g.test_http_client_io_post_more_than_content_length = function(cg)
@@ -1250,11 +1291,11 @@ g.test_http_client_io_post_more_than_content_length = function(cg)
     local written = io:write(data, 1)
     t.assert_equals(written, string.len(data), 'written')
     written = io:write(data, 1)
-    t.assert_equals(written, string.len(data), 'written')
+    t.assert_equals(written, 0, 'written')
     io:finish()
 
     local read = io:read(string.len(data) * 2)
-    t.assert_equals(read, data .. data, 'read == post')
+    t.assert_equals(read, data, 'read == post')
     t.assert_equals(io.status, 200, 'io')
     t.assert_equals(io.reason, 'Ok', '200 - Ok')
 end
@@ -1290,6 +1331,9 @@ g.test_http_client_io_post_post_read = function(cg)
     local ok, err = pcall(io.read, io, 1, 0.0001)
     t.assert_equals(ok, false, 'an error expected')
     t.assert_str_contains(json.encode(err), 'timed out', 'timeout')
+
+    local written = io:write(data)
+    t.assert_equals(written, string.len(data), "written")
     io:finish()
     t.assert_equals(io.status, 200, 'io')
     t.assert_equals(io.reason, 'Ok', '200 - Ok')

--- a/test/app-luatest/httpd.py
+++ b/test/app-luatest/httpd.py
@@ -64,7 +64,7 @@ def json_body():
     headers = [("Content-Type", "application/json; charset=utf-8")]
     return code, body, headers
 
-paths = {
+read_paths = {
         "/": hello,
         "/abc": hello1,
         "/absent": absent,
@@ -75,12 +75,25 @@ paths = {
         "/lango_body": lango_body,
         }
 
+def encoding(env):
+    code = "200 OK"
+    if "HTTP_TRANSFER_ENCODING" in env:
+        body = [str.encode(env["HTTP_TRANSFER_ENCODING"])]
+    else:
+        body = [b'none']
+    headers = []
+    return code, body, headers
+
+post_paths = {
+        "/encoding": encoding,
+        }
+
 def read_handle(env, response):
     code = "404 Not Found"
     headers = []
     body = [b'Not Found']
-    if env["PATH_INFO"] in paths:
-        code, body, headers = paths[env["PATH_INFO"]]()
+    if env["PATH_INFO"] in read_paths:
+        code, body, headers = read_paths[env["PATH_INFO"]]()
     for key,value in iter(env.items()):
         if "HTTP_" in key:
             headers.append((key[5:].lower(), value))
@@ -91,6 +104,8 @@ def post_handle(env, response):
     code = "200 OK"
     body = [env["wsgi.input"].read()]
     headers = []
+    if env["PATH_INFO"] in post_paths:
+        code, body, headers = post_paths[env["PATH_INFO"]](env)
     for key,value in iter(env.items()):
         if "HTTP_" in key:
             headers.append((key[5:].lower(), value))


### PR DESCRIPTION
The description of CURLOPT_UPLOAD [1] is confusing:

    If you use PUT to an HTTP 1.1 server, you can upload data without
    knowing the size before starting the transfer if you use chunked
    encoding. You enable this by adding a header like
    "Transfer-Encoding: chunked" with CURLOPT_HTTPHEADER.

In fact, libcurl adds this header itself. Actually we need to avoid
adding this header by libcurl with CURLOPT_INFILESIZE [2].

The CURLOPT_UPLOAD documentation has been updated [3].

1. https://github.com/curl/curl/blob/555bacd6d522bcca497573765056354f4d5d7b33/docs/libcurl/opts/CURLOPT_UPLOAD.3
2. https://curl.se/libcurl/c/httpput.html
3. https://github.com/curl/curl/pull/11300

Closes https://github.com/tarantool/tarantool/issues/8744

NO_DOC=bugfix