### PR TITLE
test: fix null pointer dereference in `coio::test_getaddrinfo`

### DIFF
--- a/test/unit/coio.cc
+++ b/test/unit/coio.cc
@@ -95,7 +95,8 @@ test_getaddrinfo(void)
 	rc = coio_getaddrinfo("non_exists_hostname", port, NULL, &i,
 			      15768000000);
 	isnt(rc, 0, "getaddrinfo retval");
-	const char *errmsg = diag_get()->last->errmsg;
+	const error *last_err = diag_get()->last;
+	const char *errmsg = last_err == NULL ? "" : last_err->errmsg;
 	bool is_match_with_exp = strstr(errmsg, "getaddrinfo") == errmsg;
 	is(is_match_with_exp, true, "getaddrinfo error message");
 


### PR DESCRIPTION
in test/unit/coio.cc if rc at coio.cc:95 equals to 0 (no errors occured) then test crashes with SIGSEGV at this line:
```c
const char *errmsg = diag_get()->last->errmsg;
```

I ran into this by accident while running tests on a machine with an unusual network setup. I understand that this is not the expected branch code execution, but i think it good to fix it anyway. 