### PR TITLE
replication: fix waiting for remote ballot updates during bootstrap

### DIFF
--- a/changelogs/unreleased/gh-8757-crash-on-bootstrap.md
+++ b/changelogs/unreleased/gh-8757-crash-on-bootstrap.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed a possible crash on bootstrap with `box.cfg.bootstrap_strategy = 'auto'`
+  when some of the bootstrapping nodes were stopped (gh-8757).

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -592,29 +592,28 @@ applier_on_bootstrap_leader_uuid_set_f(struct trigger *trigger, void *event)
 	struct applier *applier = (struct applier *)event;
 	struct applier_ballot_data *data =
 		(struct applier_ballot_data *)trigger->data;
+	fiber_wakeup(data->fiber);
 	if (!diag_is_empty(diag_get()))
 		diag_move(diag_get(), &data->diag);
 	else if (tt_uuid_is_nil(&applier->ballot.bootstrap_leader_uuid))
 		return 0;
 	data->done = true;
-	fiber_wakeup(data->fiber);
 	return 0;
 }
 
 void
 applier_wait_bootstrap_leader_uuid_is_set(struct applier *applier)
 {
-	/* The ballot watcher is dead and we aren't going to revive it. */
-	if (applier->ballot_watcher == NULL)
-		goto err;
 	struct trigger trigger;
 	struct applier_ballot_data data;
 	applier_ballot_data_create(&data);
 	trigger_create(&trigger, applier_on_bootstrap_leader_uuid_set_f,
 		       &data, NULL);
 	trigger_add(&applier->on_state, &trigger);
-	while (!data.done && !fiber_is_cancelled())
+	while (!data.done && !fiber_is_cancelled() &&
+	       applier->ballot_watcher != NULL) {
 		fiber_yield();
+	}
 	trigger_clear(&trigger);
 	if (fiber_is_cancelled()) {
 		diag_set(FiberIsCancelled);
@@ -622,6 +621,11 @@ applier_wait_bootstrap_leader_uuid_is_set(struct applier *applier)
 	}
 	if (!diag_is_empty(&data.diag)) {
 		diag_move(&data.diag, diag_get());
+		goto err;
+	}
+	/* The ballot watcher is dead and we aren't going to revive it. */
+	if (!data.done) {
+		diag_set(ClientError, ER_UNKNOWN);
 		goto err;
 	}
 	return;

--- a/test/replication-luatest/gh_8757_bootstrap_crash_test.lua
+++ b/test/replication-luatest/gh_8757_bootstrap_crash_test.lua
@@ -1,0 +1,65 @@
+local t = require('luatest')
+local server = require('luatest.server')
+local replica_set = require('luatest.replica_set')
+
+local g = t.group('gh-8757-bootstrap-crash')
+
+local fio = require('fio')
+local fiber = require('fiber')
+
+local function make_uuid(char)
+    local format_string = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+    return string.gsub(format_string, 'x', char)
+end
+
+g.before_each(function(cg)
+    cg.replica_set = replica_set:new{}
+end)
+
+g.after_each(function(cg)
+    cg.replica_set:drop()
+end)
+
+g.before_test('test_bootstrap_crash', function(cg)
+    cg.box_cfg = {
+        replication = {
+            server.build_listen_uri('leader', cg.replica_set.id),
+            server.build_listen_uri('replica1', cg.replica_set.id),
+            server.build_listen_uri('replica2', cg.replica_set.id),
+        },
+        replication_timeout = 0.1,
+        instance_uuid = make_uuid('1'),
+    }
+    cg.leader = cg.replica_set:build_and_add_server{
+        alias = 'leader',
+        box_cfg = cg.box_cfg,
+    }
+    for i = 1, 2 do
+        cg.box_cfg.instance_uuid = make_uuid(1 + i)
+        cg['replica' .. i] = cg.replica_set:build_and_add_server{
+            alias = 'replica' .. i,
+            box_cfg = cg.box_cfg,
+        }
+    end
+end)
+
+g.test_bootstrap_crash = function(cg)
+    cg.leader:start{wait_until_ready = false}
+    cg.replica1:start{wait_until_ready = false}
+    local logfile = fio.pathjoin(cg.leader.workdir, 'leader.log')
+    local uuid_pattern = string.gsub(make_uuid(2), '%-', '%%-')
+    local query = 'remote master ' .. uuid_pattern
+    t.helpers.retrying({}, function()
+        t.assert(cg.leader:grep_log(query, nil, {filename = logfile}),
+                 'Leader sees replica1')
+    end)
+    fiber.sleep(0.1)
+    cg.replica1:stop()
+    cg.replica2:start{wait_until_ready = false}
+    query = "Can't check who replica " .. uuid_pattern ..
+            " at .* chose its bootstrap leader"
+    t.helpers.retrying({}, function()
+        t.assert(cg.leader:grep_log(query, nil, {filename = logfile}),
+                 'Leader exits with an error')
+    end)
+end


### PR DESCRIPTION
There was a problem in applier_wait_bootstrap_leader_uuid_is_set():
 * it didn't set an error cause when the ballot watcher was dead, leading to a segfault when trying to diag_add() to the cause.
 * it didn't expect the ballot watcher to exit without an error before the bootstrap leader uuid is known, hanging forever.

The first issue could be reproduced by trying to bootstrap a replicaset consisting of both "old" (Tarantool 2.10 or less) and "new" instances. Or by user intervetion, when the user manually broadcasts the "internal.ballot" event with no data during bootstrap.

The second issue could be reproduced only by manually broadcasting an empty "internal.ballot" event.

Fix both issues. The first one by setting an ER_UNKNOWN error when the ballot watcher fiber is dead. And the second one by checking if the ballot watcher has died during waiting for the ballot update.

The test only covers the first issue: the second one can only happen with manual intervention and is hard to test: it involves broadcasting an empty "internal.ballot" from the replica while it's still connecting to remote nodes during an initial `box.cfg{}` call.

Closes #8757

NO_DOC=bugfix