### PR TITLE
test: bump test-run to new version

### DIFF
--- a/test/box-tap/gh-5602-environment-vars-cfg.result
+++ b/test/box-tap/gh-5602-environment-vars-cfg.result
@@ -1,4 +1,6 @@
 TAP version 13
+1..1
+TAP version 13
 1..6
 ok - box.cfg is successful
 ok - listen
@@ -28,6 +30,4 @@ TAP version 13
 1..2
 ok - box.cfg is not successful
 ok - bad strip_core value
-TAP version 13
-1..1
 ok - exit status list


### PR DESCRIPTION
Bump test-run to new version with the following improvements:

- lint: update flake8 to 5.* [1]
- app: write test output directly to files [2]
- app: disable stdout bufferization [3]
- luatest: fix luatest command description [4]
- luatest: split stdout and stderr [5]
- luatest: write stdout to a file directly [6]
- luatest: drop a dead code [7]
- luatest: disable stdout buffering [8]
- Prettify messages about log files [9]

[1] tarantool/test-run@4916351
[2] tarantool/test-run@7b3c003
[3] tarantool/test-run@48ccad8
[4] tarantool/test-run@2756eb2
[5] tarantool/test-run@3dab8dc
[6] tarantool/test-run@0c24557
[7] tarantool/test-run@036e6b6
[8] tarantool/test-run@e65a5f8
[9] tarantool/test-run@7a1ec4f