### PR TITLE
core/lua: introduce func_adapter for Lua

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -249,6 +249,7 @@ set(box_sources
     lua/merger.c
     lua/watcher.c
     lua/iproto.c
+    lua/func_adapter.c
     ${bin_sources})
 
 if(ENABLE_AUDIT_LOG)

--- a/src/box/lua/func_adapter.c
+++ b/src/box/lua/func_adapter.c
@@ -1,0 +1,257 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include "box/lua/func_adapter.h"
+#include "box/lua/tuple.h"
+#include "box/tuple.h"
+#include "core/func_adapter.h"
+#include "lua/utils.h"
+
+/**
+ * Context for func_adapter_lua.
+ */
+struct func_adapter_lua_ctx {
+	/**
+	 * Lua state which stores arguments and is used to call Lua function.
+	 */
+	struct lua_State *L;
+	/**
+	 * A reference to Lua state in Lua registry.
+	 */
+	int coro_ref;
+	/**
+	 * Saved top of L.
+	 */
+	int top_svp;
+	/**
+	 * Index of an element that will be popped next. It is used not to
+	 * remove elements from the middle of the Lua stack.
+	 */
+	int idx;
+};
+
+static_assert(sizeof(struct func_adapter_lua_ctx) <= sizeof(struct func_adapter_ctx),
+	      "sizeof(func_adapter_lua_ctx) must be <= "
+	      "sizeof(func_adapter_ctx)");
+
+/**
+ * Specialization of func_adapter for Lua functions and other callable objects.
+ */
+struct func_adapter_lua {
+	/**
+	 * Virtual table.
+	 */
+	const struct func_adapter_vtab *vtab;
+	/**
+	 * Reference to the function in Lua registry.
+	 */
+	int func_ref;
+};
+
+/**
+ * Creates (or gets cached in fiber) Lua state and saves its top.
+ */
+static void
+func_adapter_lua_begin(struct func_adapter *base,
+		       struct func_adapter_ctx *base_ctx)
+{
+	struct func_adapter_lua *func = (struct func_adapter_lua *)base;
+	struct func_adapter_lua_ctx *ctx =
+		(struct func_adapter_lua_ctx *)base_ctx;
+	if (fiber()->storage.lua.stack == NULL) {
+		ctx->L = luaT_newthread(tarantool_L);
+		if (ctx->L == NULL)
+			panic("Cannot create Lua thread");
+		ctx->coro_ref = luaL_ref(tarantool_L, LUA_REGISTRYINDEX);
+	} else {
+		ctx->L = fiber()->storage.lua.stack;
+		ctx->coro_ref = LUA_REFNIL;
+	}
+	ctx->idx = 0;
+	ctx->top_svp = lua_gettop(ctx->L);
+	lua_rawgeti(ctx->L, LUA_REGISTRYINDEX, func->func_ref);
+}
+
+/**
+ * Releases Lua state.
+ */
+static void
+func_adapter_lua_end(struct func_adapter_ctx *base)
+{
+	struct func_adapter_lua_ctx *ctx = (struct func_adapter_lua_ctx *)base;
+	lua_settop(ctx->L, ctx->top_svp);
+	luaL_unref(tarantool_L, LUA_REGISTRYINDEX, ctx->coro_ref);
+	ctx->coro_ref = LUA_REFNIL;
+	ctx->L = NULL;
+}
+
+/**
+ * Call the function with arguments that were passed before.
+ */
+static int
+func_adapter_lua_call(struct func_adapter_ctx *base_ctx)
+{
+	struct func_adapter_lua_ctx *ctx =
+		(struct func_adapter_lua_ctx *)base_ctx;
+	int nargs = lua_gettop(ctx->L) - ctx->top_svp - 1;
+	if (luaT_call(ctx->L, nargs, LUA_MULTRET) != 0)
+		return -1;
+	ctx->idx = ctx->top_svp + 1;
+	return 0;
+}
+
+static void
+func_adapter_lua_push_double(struct func_adapter_ctx *base, double val)
+{
+	struct func_adapter_lua_ctx *ctx = (struct func_adapter_lua_ctx *)base;
+	lua_pushnumber(ctx->L, val);
+}
+
+static void
+func_adapter_lua_push_str(struct func_adapter_ctx *base,
+			  const char *str, size_t len)
+{
+	struct func_adapter_lua_ctx *ctx = (struct func_adapter_lua_ctx *)base;
+	lua_pushlstring(ctx->L, str, len);
+}
+
+static void
+func_adapter_lua_push_tuple(struct func_adapter_ctx *base, struct tuple *tuple)
+{
+	struct func_adapter_lua_ctx *ctx = (struct func_adapter_lua_ctx *)base;
+	luaT_pushtuple(ctx->L, tuple);
+}
+
+static void
+func_adapter_lua_push_null(struct func_adapter_ctx *base)
+{
+	struct func_adapter_lua_ctx *ctx = (struct func_adapter_lua_ctx *)base;
+	lua_pushnil(ctx->L);
+}
+
+/**
+ * Checks if the next value is a Lua number. Cdata numeric types and decimal are
+ * not supported.
+ */
+static bool
+func_adapter_lua_is_double(struct func_adapter_ctx *base)
+{
+	struct func_adapter_lua_ctx *ctx = (struct func_adapter_lua_ctx *)base;
+	return lua_gettop(ctx->L) >= ctx->idx &&
+	       lua_type(ctx->L, ctx->idx) == LUA_TNUMBER;
+}
+
+static void
+func_adapter_lua_pop_double(struct func_adapter_ctx *base, double *out)
+{
+	struct func_adapter_lua_ctx *ctx = (struct func_adapter_lua_ctx *)base;
+	*out = lua_tonumber(ctx->L, ctx->idx++);
+}
+
+static bool
+func_adapter_lua_is_str(struct func_adapter_ctx *base)
+{
+	struct func_adapter_lua_ctx *ctx = (struct func_adapter_lua_ctx *)base;
+	return lua_gettop(ctx->L) >= ctx->idx &&
+	       lua_type(ctx->L, ctx->idx) == LUA_TSTRING;
+}
+
+static void
+func_adapter_lua_pop_str(struct func_adapter_ctx *base, const char **str,
+			 size_t *len)
+{
+	struct func_adapter_lua_ctx *ctx = (struct func_adapter_lua_ctx *)base;
+	*str = lua_tolstring(ctx->L, ctx->idx++, len);
+}
+
+/**
+ * Check if the next value is a cdata tuple.
+ */
+static bool
+func_adapter_lua_is_tuple(struct func_adapter_ctx *base)
+{
+	struct func_adapter_lua_ctx *ctx = (struct func_adapter_lua_ctx *)base;
+	int idx = ctx->idx;
+	return lua_gettop(ctx->L) >= idx && luaT_istuple(ctx->L, idx) != NULL;
+}
+
+/**
+ * Pops cdata tuple. Does not cast Lua tables to tuples.
+ */
+static void
+func_adapter_lua_pop_tuple(struct func_adapter_ctx *base, struct tuple **out)
+{
+	struct func_adapter_lua_ctx *ctx = (struct func_adapter_lua_ctx *)base;
+	*out = luaT_istuple(ctx->L, ctx->idx++);
+	assert(*out != NULL);
+	tuple_ref(*out);
+}
+
+/**
+ * Null in Lua can be represented in three ways: nil, box.NULL or just absence
+ * of an object. The function checks all the cases.
+ */
+static bool
+func_adapter_lua_is_null(struct func_adapter_ctx *base)
+{
+	struct func_adapter_lua_ctx *ctx = (struct func_adapter_lua_ctx *)base;
+	return lua_gettop(ctx->L) < ctx->idx || lua_isnil(ctx->L, ctx->idx) ||
+	       luaL_isnull(ctx->L, ctx->idx);
+}
+
+/**
+ * Pops null value. Since it can be used when all the values were popped, index
+ * is advanced only when we are in the scope of the Lua stack.
+ */
+static void
+func_adapter_lua_pop_null(struct func_adapter_ctx *base)
+{
+	struct func_adapter_lua_ctx *ctx = (struct func_adapter_lua_ctx *)base;
+	if (lua_gettop(ctx->L) >= ctx->idx)
+		ctx->idx++;
+}
+
+/**
+ * Virtual destructor.
+ */
+static void
+func_adapter_lua_destroy(struct func_adapter *func_base)
+{
+	struct func_adapter_lua *func = (struct func_adapter_lua *)func_base;
+	luaL_unref(tarantool_L, LUA_REGISTRYINDEX, func->func_ref);
+	free(func);
+}
+
+struct func_adapter *
+func_adapter_lua_create(lua_State *L, int idx)
+{
+	static const struct func_adapter_vtab vtab = {
+		.begin = func_adapter_lua_begin,
+		.end = func_adapter_lua_end,
+		.call = func_adapter_lua_call,
+
+		.push_double = func_adapter_lua_push_double,
+		.push_str = func_adapter_lua_push_str,
+		.push_tuple = func_adapter_lua_push_tuple,
+		.push_null = func_adapter_lua_push_null,
+
+		.is_double = func_adapter_lua_is_double,
+		.pop_double = func_adapter_lua_pop_double,
+		.is_str = func_adapter_lua_is_str,
+		.pop_str = func_adapter_lua_pop_str,
+		.is_tuple = func_adapter_lua_is_tuple,
+		.pop_tuple = func_adapter_lua_pop_tuple,
+		.is_null = func_adapter_lua_is_null,
+		.pop_null = func_adapter_lua_pop_null,
+
+		.destroy = func_adapter_lua_destroy,
+	};
+	struct func_adapter_lua *func = xmalloc(sizeof(*func));
+	assert(luaL_iscallable(L, idx));
+	lua_pushvalue(L, idx);
+	func->func_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+	func->vtab = &vtab;
+	return (struct func_adapter *)func;
+}

--- a/src/box/lua/func_adapter.h
+++ b/src/box/lua/func_adapter.h
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+struct lua_State;
+struct func_adapter;
+
+/**
+ * Creates func_adapter_lua from Lua callable object. Never returns NULL.
+ */
+struct func_adapter *
+func_adapter_lua_create(struct lua_State *L, int idx);
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */

--- a/src/lib/core/func_adapter.h
+++ b/src/lib/core/func_adapter.h
@@ -1,0 +1,258 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct tuple;
+
+#define FUNC_ADAPTER_CTX_SIZE 24
+
+/**
+ * Abstract func_adapter_ctx instance. It is supposed to be converted
+ * to a concrete realization, which must not occupy more memory than this
+ * instance.
+ */
+struct func_adapter_ctx {
+	/**
+	 * Padding to achieve required size.
+	 */
+	char pad[FUNC_ADAPTER_CTX_SIZE];
+};
+
+struct func_adapter;
+
+/**
+ * Virtual table for func_adapter class.
+ * Usage of these methods is in the description of func_adapter class.
+ */
+struct func_adapter_vtab {
+	/**
+	 * Prepares for call of the function. One must allocate func_adapter_ctx
+	 * (using stack or heap) and pass it to this function to initialize it.
+	 * After this call, all the arguments must be pushed in direct order.
+	 */
+	void (*begin)(struct func_adapter *func, struct func_adapter_ctx *ctx);
+	/**
+	 * Calls the function. All the arguments must be pushed before.
+	 */
+	int (*call)(struct func_adapter_ctx *ctx);
+	/**
+	 * Releases all the resources occupied by context. It must not be used
+	 * after this method was called, so all required arguments must be
+	 * popped before.
+	 * Must be called even in the case of fail.
+	 */
+	void (*end)(struct func_adapter_ctx *ctx);
+	/**
+	 * Pushes tuple argument.
+	 */
+	void (*push_tuple)(struct func_adapter_ctx *ctx, struct tuple *tuple);
+	/**
+	 * Pushes double argument.
+	 */
+	void (*push_double)(struct func_adapter_ctx *ctx, double value);
+	/**
+	 * Pushes string argument.
+	 */
+	void (*push_str)(struct func_adapter_ctx *ctx, const char *str,
+			 size_t len);
+	/**
+	 * Pushes null argument.
+	 */
+	void (*push_null)(struct func_adapter_ctx *ctx);
+	/**
+	 * Checks if the next returned value is a tuple.
+	 */
+	bool (*is_tuple)(struct func_adapter_ctx *ctx);
+	/**
+	 * Pops tuple. Returned tuple is referenced by the function and caller
+	 * must unreference it. Never returns NULL.
+	 */
+	void (*pop_tuple)(struct func_adapter_ctx *ctx, struct tuple **tuple);
+	/**
+	 * Checks if the next returned value is a number that can be represented
+	 * by double without loss of precision.
+	 */
+	bool (*is_double)(struct func_adapter_ctx *ctx);
+	/**
+	 * Pops double value.
+	 */
+	void (*pop_double)(struct func_adapter_ctx *ctx, double *number);
+	/**
+	 * Checks if the next returned value is a string.
+	 */
+	bool (*is_str)(struct func_adapter_ctx *ctx);
+	/**
+	 * Pops string value. Argument len is allowed to be NULL.
+	 * Never return NULL.
+	 */
+	void (*pop_str)(struct func_adapter_ctx *ctx, const char **str,
+			size_t *len);
+	/**
+	 * Checks if the next returned value is null or nothing.
+	 */
+	bool (*is_null)(struct func_adapter_ctx *ctx);
+	/**
+	 * Pops null.
+	 */
+	void (*pop_null)(struct func_adapter_ctx *ctx);
+	/**
+	 * Virtual destructor of the class.
+	 */
+	void (*destroy)(struct func_adapter *func);
+};
+
+/**
+ * Base class for all function adapters. Instance of this class should not
+ * be created.
+ * Function is called in several stages:
+ * 1. Preparation - func_adapter_ctx instance is allocated and initialized by
+ *    begin method. Then, all the arguments are pushed in direct order (the
+ *    first argument is pushed first). Pop methods must not be called at this
+ *    stage.
+ * 2. Call - the actual function call. If the call was not successful, it sets
+ *    diag and returns -1. In the case of error, one must stop the calling
+ *    process and call method end to release occupied resources.
+ * 3. Finalization - returned values are popped in direct order (first returned
+ *    value will be popped first). When popping a value of a particular type,
+ *    one must be sure that the next value has this type. It is not necessary to
+ *    pop all the returned values. When all the returned values are popped, all
+ *    the next values will be nulls. After all, method end must be called.
+ */
+struct func_adapter {
+	/**
+	 * Virtual table.
+	 */
+	const struct func_adapter_vtab *vtab;
+};
+
+static inline void
+func_adapter_begin(struct func_adapter *func, struct func_adapter_ctx *ctx)
+{
+	func->vtab->begin(func, ctx);
+}
+
+static inline void
+func_adapter_end(struct func_adapter *func, struct func_adapter_ctx *ctx)
+{
+	func->vtab->end(ctx);
+	TRASH(ctx);
+}
+
+static inline int
+func_adapter_call(struct func_adapter *func, struct func_adapter_ctx *ctx)
+{
+	return func->vtab->call(ctx);
+}
+
+static inline void
+func_adapter_push_double(struct func_adapter *func,
+			 struct func_adapter_ctx *ctx, double val)
+{
+	func->vtab->push_double(ctx, val);
+}
+
+static inline void
+func_adapter_push_str(struct func_adapter *func, struct func_adapter_ctx *ctx,
+		      const char *str, size_t len)
+{
+	func->vtab->push_str(ctx, str, len);
+}
+
+/**
+ * Pushes zero-terimnated string.
+ */
+static inline void
+func_adapter_push_str0(struct func_adapter *func, struct func_adapter_ctx *ctx,
+		       const char *str)
+{
+	func->vtab->push_str(ctx, str, strlen(str));
+}
+
+static inline void
+func_adapter_push_tuple(struct func_adapter *func,
+			struct func_adapter_ctx *ctx, struct tuple *tuple)
+{
+	func->vtab->push_tuple(ctx, tuple);
+}
+
+static inline void
+func_adapter_push_null(struct func_adapter *func, struct func_adapter_ctx *ctx)
+{
+	func->vtab->push_null(ctx);
+}
+
+static inline bool
+func_adapter_is_double(struct func_adapter *func, struct func_adapter_ctx *ctx)
+{
+	return func->vtab->is_double(ctx);
+}
+
+static inline void
+func_adapter_pop_double(struct func_adapter *func,
+			struct func_adapter_ctx *ctx, double *out)
+{
+	assert(func_adapter_is_double(func, ctx));
+	func->vtab->pop_double(ctx, out);
+}
+
+static inline bool
+func_adapter_is_str(struct func_adapter *func, struct func_adapter_ctx *ctx)
+{
+	return func->vtab->is_str(ctx);
+}
+
+static inline void
+func_adapter_pop_str(struct func_adapter *func, struct func_adapter_ctx *ctx,
+		     const char **str, size_t *len)
+{
+	assert(func_adapter_is_str(func, ctx));
+	func->vtab->pop_str(ctx, str, len);
+}
+
+static inline bool
+func_adapter_is_tuple(struct func_adapter *func, struct func_adapter_ctx *ctx)
+{
+	return func->vtab->is_tuple(ctx);
+}
+
+static inline void
+func_adapter_pop_tuple(struct func_adapter *func,
+		       struct func_adapter_ctx *ctx, struct tuple **tuple)
+{
+	assert(func_adapter_is_tuple(func, ctx));
+	func->vtab->pop_tuple(ctx, tuple);
+}
+
+static inline bool
+func_adapter_is_null(struct func_adapter *func, struct func_adapter_ctx *ctx)
+{
+	return func->vtab->is_null(ctx);
+}
+
+static inline void
+func_adapter_pop_null(struct func_adapter *func, struct func_adapter_ctx *ctx)
+{
+	assert(func_adapter_is_null(func, ctx));
+	func->vtab->pop_null(ctx);
+}
+
+static inline void
+func_adapter_destroy(struct func_adapter *func)
+{
+	func->vtab->destroy(func);
+}
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -610,3 +610,13 @@ create_unit_test(PREFIX node_name
                  SOURCES node_name.c core_test_utils.c
                  LIBRARIES core unit node_name
 )
+
+create_unit_test(PREFIX lua_func_adapter
+                 SOURCES lua_func_adapter.c box_test_utils.c
+                 LIBRARIES unit box server core misc
+                           ${CURL_LIBRARIES}
+                           ${LIBYAML_LIBRARIES}
+                           ${READLINE_LIBRARIES}
+                           ${ICU_LIBRARIES}
+                           ${LUAJIT_LIBRARIES}
+)

--- a/test/unit/lua_func_adapter.c
+++ b/test/unit/lua_func_adapter.c
@@ -1,0 +1,308 @@
+#include "diag.h"
+#include "fiber.h"
+#include "memory.h"
+#include "lua/init.h"
+#include "lua/error.h"
+#include "lua/utils.h"
+#include "lua/msgpack.h"
+#include "box/tuple.h"
+#include "box/lua/func_adapter.h"
+#include "box/lua/tuple.h"
+#include "core/func_adapter.h"
+
+#define UNIT_TAP_COMPATIBLE 1
+#include "unit.h"
+#include "lua_test_utils.h"
+
+#define EPS 0.0001
+
+/**
+ * Check if two floating point numbers are equal.
+ */
+static bool
+number_eq(double a, double b)
+{
+	return fabs(a - b) < EPS;
+}
+
+#undef EPS
+
+/**
+ * Generates Lua function from string and returns its index in tarantool_L.
+ */
+static int
+generate_function(const char *function)
+{
+	int rc = luaT_dostring(tarantool_L, tt_sprintf("return %s", function));
+	fail_if(rc != 0);
+	return lua_gettop(tarantool_L);
+}
+
+static void
+test_numeric(void)
+{
+	plan(5);
+	header();
+
+	int idx = generate_function(
+		"function(a, b, c, d) "
+		"return a * b * c * d, a + b + c + d end");
+	const double expected[] = { 3 * 5 * 7 * 11, 3 + 5 + 7 + 11};
+	struct func_adapter *func = func_adapter_lua_create(tarantool_L, idx);
+	struct func_adapter_ctx ctx;
+	func_adapter_begin(func, &ctx);
+	func_adapter_push_double(func, &ctx, 3);
+	func_adapter_push_double(func, &ctx, 5);
+	func_adapter_push_double(func, &ctx, 7);
+	func_adapter_push_double(func, &ctx, 11);
+	int rc = func_adapter_call(func, &ctx);
+	fail_if(rc != 0);
+
+	for (size_t i = 0; i < lengthof(expected); ++i) {
+		ok(func_adapter_is_double(func, &ctx), "Expected double");
+		double retval = 0;
+		func_adapter_pop_double(func, &ctx, &retval);
+		ok(number_eq(expected[i], retval),
+		   "Returned value must be as expected");
+	}
+
+	ok(func_adapter_is_null(func, &ctx), "Expected null - no values left");
+	func_adapter_end(func, &ctx);
+	func_adapter_destroy(func);
+	lua_settop(tarantool_L, 0);
+
+	footer();
+	check_plan();
+}
+
+static void
+test_tuple(void)
+{
+	plan(17);
+	header();
+
+	int idx = generate_function(
+		"function(a, b, tuple) "
+		"return box.tuple.new{a, b}, tuple, box.tuple.new{b, a}, "
+		"box.tuple.new{a + b, a - b} end");
+	struct func_adapter *func = func_adapter_lua_create(tarantool_L, idx);
+	struct func_adapter_ctx ctx;
+	func_adapter_begin(func, &ctx);
+	func_adapter_push_double(func, &ctx, 42);
+	func_adapter_push_double(func, &ctx, 43);
+	static const char *tuple_data = "\x92\x06\x03";
+	struct tuple *tuple = tuple_new(tuple_format_runtime, tuple_data,
+					tuple_data + strlen(tuple_data));
+	tuple_ref(tuple);
+	func_adapter_push_tuple(func, &ctx, tuple);
+	int rc = func_adapter_call(func, &ctx);
+	fail_if(rc != 0);
+	struct tuple *tuples[4];
+	for (size_t i = 0; i < lengthof(tuples); ++i) {
+		ok(func_adapter_is_tuple(func, &ctx), "Expected tuple");
+		func_adapter_pop_tuple(func, &ctx, tuples + i);
+		isnt(tuples[i], NULL, "Returned tuple must not be NULL");
+	}
+	ok(func_adapter_is_null(func, &ctx), "Expected null - no values left")
+	func_adapter_end(func, &ctx);
+	func_adapter_destroy(func);
+	lua_settop(tarantool_L, 0);
+
+	const char *expected_tuples[] = {
+		"[42, 43]", "[6, 3]", "[43, 42]", "[85, -1]"};
+	for (size_t i = 0; i < lengthof(tuples); ++i) {
+		ok(!tuple_is_unreferenced(tuples[i]),
+		   "Returned tuple must be referenced");
+		const char *str = tuple_str(tuples[i]);
+		is(strcmp(expected_tuples[i], str), 0, "Expected %s, got %s",
+		   expected_tuples[i], str);
+		tuple_unref(tuples[i]);
+	}
+	tuple_unref(tuple);
+
+	footer();
+	check_plan();
+}
+
+static void
+test_string(void)
+{
+	plan(6);
+	header();
+
+	int idx = generate_function(
+		"function(s1, s2) "
+		"return s1, s1 .. s2 end");
+	struct func_adapter *func = func_adapter_lua_create(tarantool_L, idx);
+	struct func_adapter_ctx ctx;
+	func_adapter_begin(func, &ctx);
+	/* Not zero-terminated string. */
+	const char s1[] = {'a', 'b', 'c'};
+	size_t s1_len = lengthof(s1);
+	const char *s2 = "42strstr";
+	size_t s2_len = strlen(s2);
+	func_adapter_push_str(func, &ctx, s1, s1_len);
+	func_adapter_push_str0(func, &ctx, s2);
+	int rc = func_adapter_call(func, &ctx);
+	fail_if(rc != 0);
+	ok(func_adapter_is_str(func, &ctx), "Expected string");
+	const char *retval = NULL;
+	func_adapter_pop_str(func, &ctx, &retval, NULL);
+	is(strncmp(retval, s1, s1_len), 0, "Popped string must match");
+	size_t len = 0;
+	ok(func_adapter_is_str(func, &ctx), "Expected string");
+	func_adapter_pop_str(func, &ctx, &retval, &len);
+	is(len, s1_len + s2_len, "Len does not match");
+	char *buf = tt_static_buf();
+	strncpy(buf, s1, s1_len);
+	strcpy(buf + s1_len, s2);
+	is(strcmp(retval, buf), 0, "Expected %s", buf);
+	ok(func_adapter_is_null(func, &ctx), "Expected null - no values left")
+	func_adapter_end(func, &ctx);
+	func_adapter_destroy(func);
+	lua_settop(tarantool_L, 0);
+
+	footer();
+	check_plan();
+}
+
+static void
+test_null(void)
+{
+	plan(7);
+	header();
+
+	int idx = generate_function(
+		"function(a, b, c) return a, box.NULL, nil, c, b end");
+	const size_t null_count = 4;
+	const double double_val = 42;
+	struct func_adapter *func = func_adapter_lua_create(tarantool_L, idx);
+	struct func_adapter_ctx ctx;
+	func_adapter_begin(func, &ctx);
+	func_adapter_push_null(func, &ctx);
+	func_adapter_push_double(func, &ctx, double_val);
+	int rc = func_adapter_call(func, &ctx);
+	fail_if(rc != 0);
+	for (size_t i = 0; i < null_count; ++i) {
+		ok(func_adapter_is_null(func, &ctx), "Expected null")
+		func_adapter_pop_null(func, &ctx);
+	}
+	ok(func_adapter_is_double(func, &ctx), "Expected double");
+	double double_retval = 0;
+	func_adapter_pop_double(func, &ctx, &double_retval);
+	ok(func_adapter_is_null(func, &ctx), "Expected null - no values left")
+	func_adapter_end(func, &ctx);
+	func_adapter_destroy(func);
+	lua_settop(tarantool_L, 0);
+
+	is(double_retval, double_val, "Returned value must be as expected");
+
+	footer();
+	check_plan();
+}
+
+static void
+test_error(void)
+{
+	plan(2);
+	header();
+
+	const char *functions[] = {
+		"function() error('lua error') end",
+		"function() box.error('tnt error') end"
+	};
+
+	for (size_t i = 0; i < lengthof(functions); ++i) {
+		int idx = generate_function(functions[i]);
+		struct func_adapter *func = func_adapter_lua_create(tarantool_L,
+								    idx);
+		struct func_adapter_ctx ctx;
+		func_adapter_begin(func, &ctx);
+		int rc = func_adapter_call(func, &ctx);
+		is(rc, -1, "Call must fail");
+		func_adapter_end(func, &ctx);
+		func_adapter_destroy(func);
+		lua_settop(tarantool_L, 0);
+	}
+
+	footer();
+	check_plan();
+}
+
+static void
+test_callable(void)
+{
+	plan(3);
+	header();
+
+	const int table_value = 42;
+	const int argument = 19;
+	struct lua_State *L = tarantool_L;
+	lua_createtable(L, 1, 0);
+	lua_pushinteger(L, table_value);
+	lua_rawseti(L, -2, 1);
+	lua_createtable(L, 0, 1);
+	generate_function("function(self, a) return self[1] - a end");
+	lua_setfield(L, -2, "__call");
+	lua_setmetatable(L, -2);
+
+	struct func_adapter *func = func_adapter_lua_create(L, lua_gettop(L));
+	struct func_adapter_ctx ctx;
+	func_adapter_begin(func, &ctx);
+	func_adapter_push_double(func, &ctx, argument);
+	int rc = func_adapter_call(func, &ctx);
+	ok(rc == 0, "Callable table must be called successfully");
+	ok(func_adapter_is_double(func, &ctx), "Expected double");
+	double retval = 0;
+	func_adapter_pop_double(func, &ctx, &retval);
+	ok(number_eq(retval, table_value - argument),
+	   "Returned value must be as expected");
+	func_adapter_end(func, &ctx);
+	func_adapter_destroy(func);
+	lua_settop(L, 0);
+
+	footer();
+	check_plan();
+}
+
+static int
+test_lua_func_adapter(void)
+{
+	plan(6);
+	header();
+
+	test_numeric();
+	test_tuple();
+	test_string();
+	test_null();
+	test_error();
+	test_callable();
+
+	footer();
+	return check_plan();
+}
+
+int
+main(void)
+{
+	memory_init();
+	fiber_init(fiber_c_invoke);
+	tuple_init(NULL);
+
+	lua_State *L = luaT_newteststate();
+	tarantool_L = L;
+
+	tarantool_lua_error_init(L);
+	tarantool_lua_utils_init(L);
+	luaopen_msgpack(L);
+	box_lua_tuple_init(L);
+
+	int rc = test_lua_func_adapter();
+
+	lua_close(L);
+	tarantool_L = NULL;
+	tuple_free();
+	fiber_free();
+	memory_free();
+	return rc;
+}


### PR DESCRIPTION
We are going to introduce universal triggers registry and use it for
tarantool triggers (e.g. space.on_replace). However, when trigger is set
to the registry, we do not know which arguments will be passed there
from C. That is why current implementation of triggers in tarantool is not
suitable for use in universal registry.

We decided to introduce func_adapter interface which allows to call
functions from any programming language. Now we support only one
language, which is Lua, so for the most part this interface is needed
to invert dependencies.

The patch introduces func_adapter interface and its implementation for
Lua functions.

Part of https://github.com/tarantool/tarantool/issues/8657