### PR TITLE
box: fix typo in pagination `after` position option validation

### DIFF
--- a/changelogs/unreleased/gh-8716-pagination-invalid-after-pos-bug.md
+++ b/changelogs/unreleased/gh-8716-pagination-invalid-after-pos-bug.md
@@ -1,0 +1,5 @@
+## bugfix/box
+
+* Fixed a bug (bad error message) in pagination related to the validation of the
+  `after` position option of the `:select` and `:pairs` methods of space and
+  index objects (gh-8716).

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -1943,7 +1943,7 @@ local function check_pairs_opts(opts, key_is_nil)
             after = opts.after
             if after ~= nil and type(after) ~= "string" and type(after) ~= "table"
               and not is_tuple(after) then
-                box.error(box.error.INVALID_POSITION)
+                box.error(box.error.ITERATOR_POSITION)
             end
         end
     end
@@ -2467,7 +2467,7 @@ local function check_select_opts(opts, key_is_nil)
             after = opts.after
             if type(after) ~= "string" and type(after) ~= "table" and
                     not is_tuple(after) then
-                box.error(box.error.INVALID_POSITION)
+                box.error(box.error.ITERATOR_POSITION)
             end
         end
         if opts.fetch_pos ~= nil then

--- a/test/engine-luatest/pagination_test.lua
+++ b/test/engine-luatest/pagination_test.lua
@@ -382,6 +382,18 @@ tree_g.test_invalid_positions = function(cg)
         end)
         t.assert_equals(flag, false)
         t.assert_equals(err.code, box.error.ITERATOR_POSITION)
+
+        flag, err = pcall(function()
+            s:select(nil, {fullscan=true, limit=1, after=777})
+        end)
+        t.assert_equals(flag, false)
+        t.assert_equals(err.code, box.error.ITERATOR_POSITION)
+
+        flag, err = pcall(function()
+            s:pairs(nil, {fullscan=true, limit=1, after=777})
+        end)
+        t.assert_equals(flag, false)
+        t.assert_equals(err.code, box.error.ITERATOR_POSITION)
     end)
 end
 


### PR DESCRIPTION
Closes #8716

NO_DOC=bugfix