### PR TITLE
[2.11] core: fix wal saving an empty xlog during startup failure

### DIFF
--- a/changelogs/unreleased/gh-8704-wal-exit-empty-xlog.md
+++ b/changelogs/unreleased/gh-8704-wal-exit-empty-xlog.md
@@ -1,0 +1,5 @@
+## bugfix/core
+
+* Fixed the node writing an empty `00000000000000000000.xlog` file regardless of
+  the actual vclock when interrupted during the initial `box.cfg()` call
+  (gh-8704).

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -1206,7 +1206,7 @@ wal_writer_f(va_list ap)
 	 * have to rescan the last WAL to find the instance vclock.
 	 * Don't create a WAL if the last one is empty.
 	 */
-	if (writer->wal_mode != WAL_NONE &&
+	if (writer->wal_mode != WAL_NONE && vclock_sum(&writer->vclock) > 0 &&
 	    (!xlog_is_open(&writer->current_wal) ||
 	     vclock_compare(&writer->vclock,
 			    &writer->current_wal.meta.vclock) > 0)) {

--- a/test/box-luatest/gh_8704_extra_empty_xlog_on_exit_test.lua
+++ b/test/box-luatest/gh_8704_extra_empty_xlog_on_exit_test.lua
@@ -1,0 +1,38 @@
+local t = require('luatest')
+local server = require('luatest.server')
+local replica_set = require('luatest.replica_set')
+
+local g = t.group('gh-8704-empty-xlog-on-exit')
+
+local fio = require('fio')
+
+g.before_each(function(cg)
+    cg.rs = replica_set:new{}
+    cg.server = cg.rs:build_and_add_server{
+        alias = 'server',
+        box_cfg = {
+            replication = server.build_listen_uri('nonexistent_uri', cg.rs.id),
+        },
+    }
+end)
+
+g.after_each(function(cg)
+    cg.rs:drop()
+end)
+
+g.test_no_empty_xlog_on_startup_failure = function(cg)
+    cg.server:start{wait_until_ready = false}
+    local logfile = fio.pathjoin(cg.server.workdir, 'server.log')
+    t.helpers.retrying({}, function()
+        t.assert(cg.server:grep_log('connecting to 1 replicas', nil,
+                                    {filename = logfile}),
+                 'Server is started')
+    end)
+    cg.server:stop()
+    local xlog_pattern = fio.pathjoin(cg.server.workdir, '*.xlog')
+    t.assert_equals(#fio.glob(xlog_pattern), 0,
+                    'No xlogs left after a failed startup')
+    local snap_pattern = fio.pathjoin(cg.server.workdir, '*.snap')
+    t.assert_equals(#fio.glob(snap_pattern), 0,
+                    'No snapshots left after a failed startup')
+end


### PR DESCRIPTION
After the commit a392eb765c12 ("box: destroy its modules even if box.cfg not done") wal_free() on exit is called even if box.cfg() isn't finished yet, and thus wal isn't yet enabled. This leads to a bug when wal would unconditionally write a 00...0.xlog regardless of the actual xlog directory contents or the actual vclock.

Let's fix this by not writing an empty xlog on exit if wal writer's vclock is zero. It means the writer either wasn't enabled yet, or was enabled, but hasn't written anything. In both cases writing the empty xlog is extraneous.

Closes #8704

NO_DOC=bugfix

(cherry picked from commit f78908c98c67d01440a76176f7faa24cc17735f6)