### PR TITLE
relay: fix unterminated final_join thread

### DIFF
--- a/src/box/relay.h
+++ b/src/box/relay.h
@@ -138,7 +138,7 @@ relay_initial_join(struct iostream *io, uint64_t sync, struct vclock *vclock,
  * @param sync      sync from incoming JOIN request
  */
 void
-relay_final_join(struct iostream *io, uint64_t sync,
+relay_final_join(struct replica *replica, struct iostream *io, uint64_t sync,
 		 struct vclock *start_vclock, struct vclock *stop_vclock);
 
 /**

--- a/test/replication/anon_register_gap.result
+++ b/test/replication/anon_register_gap.result
@@ -85,9 +85,9 @@ test_run:switch('replica')
 test_run:wait_lsn('replica', 'default')
  | ---
  | ...
-f:status()
+test_run:wait_cond(function() return f:status() == 'dead' end)
  | ---
- | - dead
+ | - true
  | ...
 box.space.test:select{}
  | ---

--- a/test/replication/anon_register_gap.test.lua
+++ b/test/replication/anon_register_gap.test.lua
@@ -32,7 +32,7 @@ box.space.test:insert{2}
 
 test_run:switch('replica')
 test_run:wait_lsn('replica', 'default')
-f:status()
+test_run:wait_cond(function() return f:status() == 'dead' end)
 box.space.test:select{}
 
 -- Cleanup


### PR DESCRIPTION
Currently if tarantool exits during relay's final join stage,
corresponding thread isn't terminated. This cause the flakiness
of the replicaset_ro_mostly.test.lua.

Let's make a pointer to a relay, which is started during final join
stage, in the replica structure and cancel it, if it exists, via
replication_free() alongside with the subscribe thread.

Closes https://github.com/tarantool/tarantool/issues/8082
Closes https://github.com/tarantool/tarantool-qa/issues/272

NO_DOC=not user-visible
NO_TEST=fix flaky test
NO_CHANGELOG=not user-visible