### PR TITLE
box: fix memory leaks on `ER_MULTISTATEMENT_TRANSACTION` in DDL

### DIFF
--- a/changelogs/unreleased/gh-8733-ddl-memory-leaks.md
+++ b/changelogs/unreleased/gh-8733-ddl-memory-leaks.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed the memory leaks caused by the multi-statement transaction errors in the
+  space index building and the space format checking operations (gh-8773).


### PR DESCRIPTION
Closes #8773