### PR TITLE
Gh 8654 memtx mvcc abort readers of prepared 2.11

### DIFF
--- a/changelogs/unreleased/gh-8326-mvcc-lost-gap-record.md
+++ b/changelogs/unreleased/gh-8326-mvcc-lost-gap-record.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fixed a bug when MVCC sometimes lost gap record (gh-8326).

--- a/changelogs/unreleased/gh-8648-mvcc-broken-rollback-of-prepared.md
+++ b/changelogs/unreleased/gh-8648-mvcc-broken-rollback-of-prepared.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a bug when MVCC rollback of prepared statement could break internal
+  invariants (gh-8648).

--- a/changelogs/unreleased/gh-8654-mvcc-abort-readers-of-prepared-and-rollbacked.md
+++ b/changelogs/unreleased/gh-8654-mvcc-abort-readers-of-prepared-and-rollbacked.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Now MVCC engine automatically aborts a transaction if it reads changes
+  of a prepared transaction and this transaction is aborted (gh-8654).

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -786,7 +786,7 @@ index_create(struct index *index, struct engine *engine,
 	index->unique_id = unique_id++;
 	/* Unusable until set to proper value during space creation. */
 	index->dense_id = UINT32_MAX;
-	rlist_create(&index->nearby_gaps);
+	rlist_create(&index->read_gaps);
 	rlist_create(&index->full_scans);
 	return 0;
 }

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -787,7 +787,6 @@ index_create(struct index *index, struct engine *engine,
 	/* Unusable until set to proper value during space creation. */
 	index->dense_id = UINT32_MAX;
 	rlist_create(&index->read_gaps);
-	rlist_create(&index->full_scans);
 	return 0;
 }
 

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -645,13 +645,14 @@ struct index {
 	uint32_t dense_id;
 	/**
 	 * List of gap_item's describing gap reads in the index with NULL
-	 * successor. Those gap reads happen when reading from empty index,
+	 * successor OR full scan gaps.
+	 * The first type happens when reading from empty index,
 	 * or when reading from rightmost part of ordered index (TREE).
-	 * @sa struct gap_item.
+	 * The second type happens when a full scan was finished for
+	 * unordered index (HASH).
+	 * @sa struct gap_item_base.
 	 */
 	struct rlist read_gaps;
-	/** List of full scans of the index. @sa struct full_scan_item. */
-	struct rlist full_scans;
 };
 
 /**

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -649,7 +649,7 @@ struct index {
 	 * or when reading from rightmost part of ordered index (TREE).
 	 * @sa struct gap_item.
 	 */
-	struct rlist nearby_gaps;
+	struct rlist read_gaps;
 	/** List of full scans of the index. @sa struct full_scan_item. */
 	struct rlist full_scans;
 };

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -399,9 +399,6 @@ memtx_space_execute_replace(struct space *space, struct txn *txn,
 		return -1;
 	tuple_ref(new_tuple);
 
-	if (mode == DUP_INSERT)
-		stmt->does_require_old_tuple = true;
-
 	if (memtx_space_replace_tuple(space, stmt, NULL, new_tuple,
 				      mode) != 0) {
 		tuple_unref(new_tuple);
@@ -432,12 +429,6 @@ memtx_space_execute_delete(struct space *space, struct txn *txn,
 		*result = NULL;
 		return 0;
 	}
-
-	/*
-	 * We have to delete exactly old_tuple just because we return it as
-	 * a result.
-	 */
-	stmt->does_require_old_tuple = true;
 
 	if (memtx_space_replace_tuple(space, stmt, old_tuple, NULL,
 				      DUP_REPLACE_OR_INSERT) != 0)
@@ -495,8 +486,6 @@ memtx_space_execute_update(struct space *space, struct txn *txn,
 	if (new_tuple == NULL)
 		return -1;
 	tuple_ref(new_tuple);
-
-	stmt->does_require_old_tuple = true;
 
 	if (memtx_space_replace_tuple(space, stmt, old_tuple, new_tuple,
 				      DUP_REPLACE) != 0) {
@@ -621,8 +610,6 @@ memtx_space_execute_upsert(struct space *space, struct txn *txn,
 		}
 	}
 	assert(new_tuple != NULL);
-
-	stmt->does_require_old_tuple = true;
 
 	/*
 	 * It's OK to use DUP_REPLACE_OR_INSERT: we don't risk

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1625,7 +1625,6 @@ memtx_tx_story_delete_is_visible(struct memtx_story *story, struct txn *txn,
 {
 	*is_own_change = false;
 
-	bool was_deleted_by_prepared = false;
 	struct txn_stmt *dels = story->del_stmt;
 	while (dels != NULL) {
 		if (dels->txn == txn) {
@@ -1633,8 +1632,6 @@ memtx_tx_story_delete_is_visible(struct memtx_story *story, struct txn *txn,
 			*is_own_change = true;
 			return true;
 		}
-		if (story->del_psn != 0 && dels->txn->psn == story->del_psn)
-			was_deleted_by_prepared = true;
 		dels = dels->next_in_del_list;
 	}
 
@@ -1645,7 +1642,7 @@ memtx_tx_story_delete_is_visible(struct memtx_story *story, struct txn *txn,
 	if (is_prepared_ok && story->del_psn != 0 && story->del_psn < rv_psn)
 		return true; /* Tuple is deleted by prepared TX. */
 
-	if (story->del_psn != 0 && !was_deleted_by_prepared &&
+	if (story->del_psn != 0 && story->del_stmt == NULL &&
 	    story->del_psn < rv_psn)
 		return true; /* Tuple is deleted by committed TX. */
 
@@ -2183,13 +2180,57 @@ memtx_tx_history_remove_story_del_stmts(struct memtx_story *story)
 static void
 memtx_tx_history_rollback_added_story(struct txn_stmt *stmt)
 {
-	assert(stmt->add_story != NULL);
-	assert(stmt->add_story->tuple == stmt->rollback_info.new_tuple);
-	struct memtx_story *story = stmt->add_story;
+	struct memtx_story *add_story = stmt->add_story;
+	struct memtx_story *del_story = stmt->del_story;
 
-	memtx_tx_history_remove_story_del_stmts(story);
-	story->add_stmt = NULL;
-	stmt->add_story = NULL;
+	/*
+	 * In case of rollback of prepared statement we need to rollback
+	 * preparation actions.
+	 */
+	if (stmt->txn->psn != 0) {
+		/*
+		 * During preparation of this statement there were two cases:
+		 * * del_story != NULL: all in-progress transactions that were
+		 *   to delete del_story were relinked to delete add_story.
+		 * * del_story == NULL: all in-progress transactions that were
+		 *   to delete same nothing were relinked to delete add_story.
+		 * See memtx_tx_history_prepare_insert_stmt for details.
+		 * Note that by design of rollback, all statements are rolled
+		 * back in reverse order, and thus at this point there can be no
+		 * statements of the same transaction that deletes add_story.
+		 * So we must scan delete statements and relink them to delete
+		 * del_story if it's not NULL or to delete nothing otherwise.
+		 */
+		struct txn_stmt **from = &add_story->del_stmt;
+		while (*from != NULL) {
+			struct txn_stmt *test_stmt = *from;
+			assert(test_stmt->del_story == add_story);
+			assert(test_stmt->txn != stmt->txn);
+			assert(!test_stmt->is_own_change);
+			assert(test_stmt->txn->psn == 0);
+
+			/* Unlink from add_story list. */
+			*from = test_stmt->next_in_del_list;
+			test_stmt->next_in_del_list = NULL;
+			test_stmt->del_story = NULL;
+
+			if (del_story != NULL) {
+				/* Link to del_story's list. */
+				memtx_tx_story_link_deleted_by(del_story,
+							       test_stmt);
+			}
+		}
+
+		/* Revert psn assignment. */
+		add_story->add_psn = 0;
+		if (del_story != NULL)
+			del_story->del_psn = 0;
+	}
+
+	/* Unlink stories from the statement. */
+	memtx_tx_story_unlink_added_by(add_story, stmt);
+	if (del_story != NULL)
+		memtx_tx_story_unlink_deleted_by(del_story, stmt);
 
 	/*
 	 * Sink the story to the end of chain and mark is as deleted long
@@ -2197,16 +2238,16 @@ memtx_tx_history_rollback_added_story(struct txn_stmt *stmt)
 	 * be invisible to any reader (that's what is needed) and still be
 	 * able to store read set, if necessary.
 	 */
-	for (uint32_t i = 0; i < story->index_count; ) {
-		struct memtx_story *old_story = story->link[i].older_story;
+	for (uint32_t i = 0; i < add_story->index_count; ) {
+		struct memtx_story *old_story = add_story->link[i].older_story;
 		if (old_story == NULL) {
 			/* Old story is absent. */
 			i++; /* Go to the next index. */
 			continue;
 		}
-		memtx_tx_story_reorder(story, old_story, i);
+		memtx_tx_story_reorder(add_story, old_story, i);
 	}
-	story->del_psn = MEMTX_TX_ROLLBACKED_PSN;
+	add_story->del_psn = MEMTX_TX_ROLLBACKED_PSN;
 }
 
 /*
@@ -2215,22 +2256,67 @@ memtx_tx_history_rollback_added_story(struct txn_stmt *stmt)
 static void
 memtx_tx_history_rollback_deleted_story(struct txn_stmt *stmt)
 {
-	struct memtx_story *story = stmt->del_story;
+	struct memtx_story *del_story = stmt->del_story;
+
 	/*
-	 * There can be no more than one prepared statement deleting a story at
-	 * any point in time.
+	 * In case of rollback of prepared statement we need to rollback
+	 * preparation actions.
 	 */
-	assert(story->del_psn == 0 || story->del_psn == stmt->txn->psn);
-	story->del_psn = 0;
-	memtx_tx_story_unlink_deleted_by(story, stmt);
+	if (stmt->txn->psn != 0) {
+		/*
+		 * During preparation of deletion we could unlink other
+		 * transactions that want to overwrite this story. Now we have
+		 * to restore the link. Replace-like statements can be found in
+		 * the story chain of primary index. Unfortunately DELETE
+		 * statements cannot be found since after unlink they are not
+		 * present in chains. The good news is that by design all their
+		 * transactions are surely conflicted because of read-write
+		 * conflict and thus does not matter anymore.
+		 */
+		struct memtx_story *test_story;
+		for (test_story = del_story->link[0].newer_story;
+		     test_story != NULL;
+		     test_story = test_story->link[0].newer_story) {
+			struct txn_stmt *test_stmt = test_story->add_stmt;
+			if (test_stmt->is_own_change)
+				continue;
+			assert(test_stmt->txn != stmt->txn);
+			assert(test_stmt->del_story == NULL);
+			assert(test_stmt->txn->psn == 0);
+			memtx_tx_story_link_deleted_by(del_story, test_stmt);
+		}
+
+		/* Revert psn assignment. */
+		del_story->del_psn = 0;
+	}
+
+	/* Unlink the story from the statement. */
+	memtx_tx_story_unlink_deleted_by(del_story, stmt);
 }
 
 void
 memtx_tx_history_rollback_stmt(struct txn_stmt *stmt)
 {
+	/* Consistency asserts. */
+	if (stmt->add_story != NULL) {
+		assert(stmt->add_story->tuple == stmt->rollback_info.new_tuple);
+		assert(stmt->add_story->add_psn == stmt->txn->psn);
+	}
+	if (stmt->del_story != NULL)
+		assert(stmt->del_story->del_psn == stmt->txn->psn);
+	/*
+	 * There can be no more than one prepared statement deleting a story at
+	 * any point in time.
+	 */
+	assert(stmt->txn->psn == 0 || stmt->next_in_del_list == NULL);
+
+	/*
+	 * Note that both add_story and del_story can be NULL,
+	 * see comment in memtx_tx_history_prepare_stmt.
+	 */
 	if (stmt->add_story != NULL)
 		memtx_tx_history_rollback_added_story(stmt);
-	if (stmt->del_story != NULL)
+	else if (stmt->del_story != NULL)
 		memtx_tx_history_rollback_deleted_story(stmt);
 	assert(stmt->add_story == NULL && stmt->del_story == NULL);
 }
@@ -2581,6 +2667,7 @@ memtx_tx_history_commit_stmt(struct txn_stmt *stmt, size_t *bsize)
 		memtx_tx_story_unlink_added_by(stmt->add_story, stmt);
 	}
 	if (stmt->del_story != NULL) {
+		assert(stmt->del_story->del_stmt == stmt);
 		*bsize -= tuple_bsize(stmt->del_story->tuple);
 		memtx_tx_story_unlink_deleted_by(stmt->del_story, stmt);
 	}

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -371,18 +371,20 @@ memtx_tx_mempool_destroy(struct memtx_tx_mempool *mempool)
 	mempool->alloc_type = MEMTX_TX_ALLOC_TYPE_MAX;
 }
 
-void *
-memtx_tx_mempool_alloc(struct txn *txn, struct memtx_tx_mempool *mempool)
+/**
+ * Allocate an object on given @a mempool and account allocated size in
+ * statistics of transaction @a txn.
+ */
+static void *
+memtx_tx_xmempool_alloc(struct txn *txn, struct memtx_tx_mempool *mempool)
 {
-	void *allocation = mempool_alloc(&mempool->pool);
-	if (allocation != NULL) {
-		uint32_t size = mempool->pool.objsize;
-		memtx_tx_track_allocation(txn, size, mempool->alloc_type);
-	}
+	void *allocation = xmempool_alloc(&mempool->pool);
+	uint32_t size = mempool->pool.objsize;
+	memtx_tx_track_allocation(txn, size, mempool->alloc_type);
 	return allocation;
 }
 
-void
+static void
 memtx_tx_mempool_free(struct txn *txn, struct memtx_tx_mempool *mempool, void *ptr)
 {
 	uint32_t size = mempool->pool.objsize;
@@ -414,8 +416,8 @@ memtx_tx_region_object_to_type(enum memtx_tx_alloc_object alloc_obj)
  * Use this method to track txn's allocations!
  */
 static inline void *
-memtx_tx_region_alloc_object(struct txn *txn,
-			     enum memtx_tx_alloc_object alloc_obj)
+memtx_tx_xregion_alloc_object(struct txn *txn,
+			      enum memtx_tx_alloc_object alloc_obj)
 {
 	size_t size = 0;
 	void *alloc = NULL;
@@ -423,15 +425,14 @@ memtx_tx_region_alloc_object(struct txn *txn,
 		memtx_tx_region_object_to_type(alloc_obj);
 	switch (alloc_obj) {
 	case MEMTX_TX_OBJECT_READ_TRACKER:
-		alloc = region_alloc_object(&txn->region,
-					    struct tx_read_tracker, &size);
+		alloc = xregion_alloc_object(&txn->region,
+					     struct tx_read_tracker, &size);
 		break;
 	default:
 		unreachable();
 	}
 	assert(alloc_type < MEMTX_TX_ALLOC_TYPE_MAX);
-	if (alloc != NULL)
-		memtx_tx_track_allocation(txn, size, alloc_type);
+	memtx_tx_track_allocation(txn, size, alloc_type);
 	return alloc;
 }
 
@@ -441,10 +442,10 @@ memtx_tx_region_alloc_object(struct txn *txn,
  * Use this method to track allocations!
  */
 static inline void *
-memtx_tx_region_alloc(struct txn *txn, size_t size,
-		      enum memtx_tx_alloc_type alloc_type)
+memtx_tx_xregion_alloc(struct txn *txn, size_t size,
+		       enum memtx_tx_alloc_type alloc_type)
 {
-	void *allocation = region_alloc(&txn->region, size);
+	void *allocation = xregion_alloc(&txn->region, size);
 	if (allocation != NULL)
 		memtx_tx_track_allocation(txn, size, alloc_type);
 	return allocation;
@@ -588,20 +589,17 @@ memtx_tx_statistics_collect(struct memtx_tx_statistics *stats)
 	stats->txn_count = txn_count;
 }
 
-int
+void
 memtx_tx_register_txn(struct txn *tx)
 {
-	int size = 0;
+	size_t bytes;
 	tx->memtx_tx_alloc_stats =
-		region_alloc_array(&tx->region,
-				   typeof(*tx->memtx_tx_alloc_stats),
-				   MEMTX_TX_ALLOC_TYPE_MAX, &size);
-	if (tx->memtx_tx_alloc_stats == NULL)
-		return -1;
+		xregion_alloc_array(&tx->region,
+				    typeof(*tx->memtx_tx_alloc_stats),
+				    MEMTX_TX_ALLOC_TYPE_MAX, &bytes);
 	memset(tx->memtx_tx_alloc_stats, 0,
 	       sizeof(*tx->memtx_tx_alloc_stats) * MEMTX_TX_ALLOC_TYPE_MAX);
 	rlist_add_tail(&txm.all_txs, &tx->in_all_txs);
-	return 0;
 }
 
 void
@@ -814,7 +812,6 @@ memtx_tx_unref_from_primary(struct memtx_story *story)
 
 /**
  * Create a new story and link it with the @a tuple.
- * @return story on success, NULL on error (diag is set).
  */
 static struct memtx_story *
 memtx_tx_story_new(struct space *space, struct tuple *tuple,
@@ -825,12 +822,7 @@ memtx_tx_story_new(struct space *space, struct tuple *tuple,
 	uint32_t index_count = space->index_count;
 	assert(index_count < BOX_INDEX_MAX);
 	struct mempool *pool = &txm.memtx_tx_story_pool[index_count];
-	struct memtx_story *story = (struct memtx_story *) mempool_alloc(pool);
-	size_t item_size = pool->objsize;
-	if (story == NULL) {
-		diag_set(OutOfMemory, item_size, "mempool_alloc", "story");
-		return NULL;
-	}
+	struct memtx_story *story = (struct memtx_story *)xmempool_alloc(pool);
 	story->tuple = tuple;
 
 	const struct memtx_story **put_story =
@@ -843,7 +835,7 @@ memtx_tx_story_new(struct space *space, struct tuple *tuple,
 	tuple_ref(tuple);
 	story->status = MEMTX_TX_STORY_USED;
 	struct memtx_tx_stats *stats = &txm.story_stats[story->status];
-	memtx_tx_stats_collect(stats, item_size);
+	memtx_tx_stats_collect(stats, pool->objsize);
 	story->tuple_is_retained = false;
 	if (!tuple_is_referenced_to_pk)
 		memtx_tx_story_track_retained_tuple(story);
@@ -1175,28 +1167,6 @@ memtx_tx_story_unlink_top_common_light(struct memtx_story *story, uint32_t idx)
 	struct memtx_story *old_story = link->older_story;
 	if (old_story != NULL)
 		memtx_tx_story_unlink(story, old_story, idx);
-}
-
-/**
- * See description of `memtx_tx_story_unlink_top_common_light`.
- * As opposed to `memtx_tx_story_unlink_top_on_space_delete_light`, also
- * rebinds gap records to the new top in history chain.
- */
-static void
-memtx_tx_story_unlink_top_on_rollback_light(struct memtx_story *story,
-					    uint32_t idx)
-{
-	assert(story != NULL);
-	assert(idx < story->index_count);
-	struct memtx_story_link *link = &story->link[idx];
-	assert(link->newer_story == NULL);
-	struct memtx_story *old_story = link->older_story;
-	memtx_tx_story_unlink_top_common_light(story, idx);
-	if (old_story != NULL) {
-		/* Rebind gap records to the new top of the list */
-		struct memtx_story_link *old_link = &old_story->link[idx];
-		rlist_splice(&old_link->nearby_gaps, &link->nearby_gaps);
-	}
 }
 
 /**
@@ -1663,7 +1633,7 @@ point_hole_storage_find(struct index *index, struct tuple *tuple)
  * Track the fact that transaction @a txn have read @a story in @a space.
  * This fact could lead this transaction to read view or conflict state.
  */
-static int
+static void
 memtx_tx_track_read_story(struct txn *txn, struct space *space,
 			  struct memtx_story *story, uint64_t index_mask);
 
@@ -1673,35 +1643,30 @@ memtx_tx_track_read_story(struct txn *txn, struct space *space,
  * tuple. It's the moment where we can search for stored point hole trackers
  * and find conflict causes.
  */
-static int
+static void
 check_hole(struct space *space, struct memtx_story *story,
 	   uint32_t ind)
 {
 	struct point_hole_item *list =
 		point_hole_storage_find(space->index[ind], story->tuple);
 	if (list == NULL)
-		return 0;
+		return;
 
 	struct point_hole_item *item = list;
 	uint64_t index_mask = 1ull << (ind & 63);
 	do {
-		if (memtx_tx_track_read_story(item->txn, space, story,
-					      index_mask) != 0)
-			return -1;
+		memtx_tx_track_read_story(item->txn, space, story, index_mask);
 		item = rlist_entry(item->ring.next,
 				   struct point_hole_item, ring);
 	} while (item != list);
-	return 0;
 }
 
 /**
  * Record in TX manager that a transaction @txn have read a @tuple in @space.
  *
  * NB: can trigger story garbage collection.
- *
- * @return 0 on success, -1 on memory error.
  */
-static int
+static void
 memtx_tx_track_read(struct txn *txn, struct space *space, struct tuple *tuple);
 
 /**
@@ -1784,7 +1749,7 @@ memtx_tx_gap_item_new(struct txn *txn, enum iterator_type type,
  * Handle insertion to a new place in index. There can be readers which
  * have read from this gap and thus must be sent to read view or conflicted.
  */
-static int
+static void
 memtx_tx_handle_gap_write(struct txn *txn, struct space *space,
 			  struct memtx_story *story, struct tuple *tuple,
 			  struct tuple *successor, uint32_t ind)
@@ -1794,13 +1759,12 @@ memtx_tx_handle_gap_write(struct txn *txn, struct space *space,
 	struct rlist *fsc_list = &index->full_scans;
 	uint64_t index_mask = 1ull << (ind & 63);
 	rlist_foreach_entry_safe(fsc_item, fsc_list, in_full_scans, fsc_tmp) {
-		if (fsc_item->txn != txn &&
-		    (memtx_tx_track_read_story(fsc_item->txn, space, story,
-					       index_mask) != 0))
-			return -1;
+		if (fsc_item->txn != txn)
+			memtx_tx_track_read_story(fsc_item->txn, space, story,
+						  index_mask);
 	}
 	if (successor != NULL && !tuple_has_flag(successor, TUPLE_IS_DIRTY))
-		return 0; /* no gap records */
+		return; /* no gap records */
 
 	struct rlist *list = &index->nearby_gaps;
 	if (successor != NULL) {
@@ -1841,10 +1805,9 @@ memtx_tx_handle_gap_write(struct txn *txn, struct space *space,
 		if (story->add_stmt != NULL &&
 		    story->add_stmt->txn == item->txn)
 			need_track = false;
-		if (need_track && memtx_tx_track_read_story(item->txn, space,
-							    story,
-							    index_mask) != 0)
-			return -1;
+		if (need_track)
+			memtx_tx_track_read_story(item->txn, space,
+						  story, index_mask);
 		if (need_split) {
 			/*
 			 * The insertion divided the gap into two parts.
@@ -1855,8 +1818,6 @@ memtx_tx_handle_gap_write(struct txn *txn, struct space *space,
 				memtx_tx_gap_item_new(item->txn, item->type,
 						      item->key,
 						      item->part_count);
-			if (copy == NULL)
-				return -1;
 
 			rlist_add(&story->link[ind].nearby_gaps,
 				  &copy->in_nearby_gaps);
@@ -1872,7 +1833,6 @@ memtx_tx_handle_gap_write(struct txn *txn, struct space *space,
 					     item->type == ITER_GT)));
 		}
 	}
-	return 0;
 }
 
 /**
@@ -1893,8 +1853,7 @@ memtx_tx_history_add_insert_stmt(struct txn_stmt *stmt,
 	assert(new_tuple != NULL);
 
 	struct space *space = stmt->space;
-	struct memtx_story *add_story = NULL;
-	struct memtx_story *created_story = NULL, *replaced_story = NULL;
+	struct memtx_story *add_story = NULL, *replaced_story = NULL;
 
 	struct tuple *directly_replaced[space->index_count];
 	struct tuple *direct_successor[space->index_count];
@@ -1928,8 +1887,6 @@ memtx_tx_history_add_insert_stmt(struct txn_stmt *stmt,
 	 * it is not referenced to it, so we pass false as the last argument.
 	 */
 	add_story = memtx_tx_story_new(space, new_tuple, false);
-	if (add_story == NULL)
-		goto fail;
 	memtx_tx_story_link_added_by(add_story, stmt);
 
 	if (replaced != NULL && !tuple_has_flag(replaced, TUPLE_IS_DIRTY)) {
@@ -1937,37 +1894,28 @@ memtx_tx_history_add_insert_stmt(struct txn_stmt *stmt,
 		 * Note that despite the tuple is not in pk,
 		 * it is referenced to it, so we pass true as the last argument.
 		 */
-		created_story = memtx_tx_story_new(space, replaced, true);
-		if (created_story == NULL)
-			goto fail;
-		replaced_story = created_story;
+		replaced_story = memtx_tx_story_new(space, replaced, true);
 		memtx_tx_story_link_top_light(add_story, replaced_story, 0);
 	} else if (replaced != NULL) {
 		replaced_story = memtx_tx_story_get(replaced);
 		memtx_tx_story_link_top_light(add_story, replaced_story, 0);
 	} else {
-		rc = memtx_tx_handle_gap_write(stmt->txn, space,
-					       add_story, new_tuple,
-					       direct_successor[0], 0);
-		if (rc != 0)
-			goto fail;
+		memtx_tx_handle_gap_write(stmt->txn, space,
+					  add_story, new_tuple,
+					  direct_successor[0], 0);
 	}
 
 	/* Collect point phantom read conflicts. */
-	for (uint32_t i = 0; i < space->index_count; i++) {
-		if (check_hole(space, add_story, i) != 0)
-			goto fail;
-	}
+	for (uint32_t i = 0; i < space->index_count; i++)
+		check_hole(space, add_story, i);
 
 	if (replaced_story != NULL)
 		replaced_story->link[0].in_index = NULL;
 	for (uint32_t i = 1; i < space->index_count; i++) {
 		if (directly_replaced[i] == NULL) {
-			rc = memtx_tx_handle_gap_write(stmt->txn, space,
-						       add_story, new_tuple,
-						       direct_successor[i], i);
-			if (rc != 0)
-				goto fail;
+			memtx_tx_handle_gap_write(stmt->txn, space,
+						  add_story, new_tuple,
+						  direct_successor[i], i);
 			continue;
 		}
 		assert(tuple_has_flag(directly_replaced[i], TUPLE_IS_DIRTY));
@@ -2017,18 +1965,6 @@ memtx_tx_history_add_insert_stmt(struct txn_stmt *stmt,
 	return 0;
 
 fail:
-	if (add_story != NULL) {
-		for (uint32_t i = 0; i < add_story->index_count; i++) {
-			struct memtx_story_link *link = &add_story->link[i];
-			assert(link->newer_story == NULL); (void)link;
-			memtx_tx_story_unlink_top_on_rollback_light(add_story,
-								    i);
-		}
-		memtx_tx_story_delete(add_story);
-	}
-	if (created_story)
-		memtx_tx_story_delete(created_story);
-
 	while (directly_replaced_count > 0) {
 		uint32_t i = --directly_replaced_count;
 		struct index *index = space->index[i];
@@ -2066,8 +2002,6 @@ memtx_tx_history_add_delete_stmt(struct txn_stmt *stmt,
 		 * and is referenced to it.
 		 */
 		del_story = memtx_tx_story_new(space, old_tuple, true);
-		if (del_story == NULL)
-			return -1;
 	}
 	if (!del_story->tuple_is_retained)
 		memtx_tx_story_track_retained_tuple(del_story);
@@ -2720,20 +2654,15 @@ tx_read_tracker_new(struct txn *reader, struct memtx_story *story,
 		    uint64_t index_mask)
 {
 	struct tx_read_tracker *tracker;
-	tracker = memtx_tx_region_alloc_object(reader,
-					       MEMTX_TX_OBJECT_READ_TRACKER);
-	if (tracker == NULL) {
-		diag_set(OutOfMemory, sizeof(*tracker), "tx region",
-			 "read_tracker");
-		return NULL;
-	}
+	tracker = memtx_tx_xregion_alloc_object(reader,
+						MEMTX_TX_OBJECT_READ_TRACKER);
 	tracker->reader = reader;
 	tracker->story = story;
 	tracker->index_mask = index_mask;
 	return tracker;
 }
 
-static int
+static void
 memtx_tx_track_read_story_slow(struct txn *txn, struct memtx_story *story,
 			       uint64_t index_mask)
 {
@@ -2764,49 +2693,44 @@ memtx_tx_track_read_story_slow(struct txn *txn, struct memtx_story *story,
 		tracker->index_mask |= index_mask;
 	} else {
 		tracker = tx_read_tracker_new(txn, story, index_mask);
-		if (tracker == NULL)
-			return -1;
 	}
 	rlist_add(&story->reader_list, &tracker->in_reader_list);
 	rlist_add(&txn->read_set, &tracker->in_read_set);
-	return 0;
 }
 
-static int
+static void
 memtx_tx_track_read_story(struct txn *txn, struct space *space,
 			  struct memtx_story *story, uint64_t index_mask)
 {
 	if (txn == NULL)
-		return 0;
+		return;
 	if (space == NULL)
-		return 0;
+		return;
 	if (space->def->opts.is_ephemeral)
-		return 0;
-	return memtx_tx_track_read_story_slow(txn, story, index_mask);
+		return;
+	memtx_tx_track_read_story_slow(txn, story, index_mask);
 }
 
 /**
  * Record in TX manager that a transaction @txn have read a @tuple in @space.
  *
  * NB: can trigger story garbage collection.
- *
- * @return 0 on success, -1 on memory error.
  */
-static int
+static void
 memtx_tx_track_read(struct txn *txn, struct space *space, struct tuple *tuple)
 {
 	if (tuple == NULL)
-		return 0;
+		return;
 	if (txn == NULL)
-		return 0;
+		return;
 	if (space == NULL)
-		return 0;
+		return;
 	if (space->def->opts.is_ephemeral)
-		return 0;
+		return;
 
 	if (tuple_has_flag(tuple, TUPLE_IS_DIRTY)) {
 		struct memtx_story *story = memtx_tx_story_get(tuple);
-		return memtx_tx_track_read_story(txn, space, story, UINT64_MAX);
+		memtx_tx_track_read_story(txn, space, story, UINT64_MAX);
 	} else {
 		/*
 		 * The tuple is not dirty therefore it is placed in pk
@@ -2814,34 +2738,22 @@ memtx_tx_track_read(struct txn *txn, struct space *space, struct tuple *tuple)
 		 */
 		struct memtx_story *story =
 			memtx_tx_story_new(space, tuple, true);
-		if (story == NULL)
-			return -1;
 		struct tx_read_tracker *tracker;
 		tracker = tx_read_tracker_new(txn, story, UINT64_MAX);
-		if (tracker == NULL) {
-			memtx_tx_story_delete(story);
-			return -1;
-		}
 		rlist_add(&story->reader_list, &tracker->in_reader_list);
 		rlist_add(&txn->read_set, &tracker->in_read_set);
-		return 0;
 	}
 }
 
 /**
- * Create new point_hole_item by given argumnets and put it to hash table.
+ * Create new point_hole_item by given arguments and put it to hash table.
  */
-static int
+static void
 point_hole_storage_new(struct index *index, const char *key,
 		       size_t key_len, struct txn *txn)
 {
 	struct memtx_tx_mempool *pool = &txm.point_hole_item_pool;
-	struct point_hole_item *object = memtx_tx_mempool_alloc(txn, pool);
-	if (object == NULL) {
-		diag_set(OutOfMemory, sizeof(*object),
-			 "mempool_alloc", "point_hole_item");
-		return -1;
-	}
+	struct point_hole_item *object = memtx_tx_xmempool_alloc(txn, pool);
 
 	rlist_create(&object->ring);
 	rlist_create(&object->in_point_holes_list);
@@ -2850,14 +2762,8 @@ point_hole_storage_new(struct index *index, const char *key,
 	if (key_len <= sizeof(object->short_key)) {
 		object->key = object->short_key;
 	} else {
-		object->key = memtx_tx_region_alloc(txn, key_len,
-						    MEMTX_TX_ALLOC_TRACKER);
-		if (object->key == NULL) {
-			memtx_tx_mempool_free(txn, pool, object);
-			diag_set(OutOfMemory, key_len, "tx region",
-				 "point key");
-			return -1;
-		}
+		object->key = memtx_tx_xregion_alloc(txn, key_len,
+						     MEMTX_TX_ALLOC_TRACKER);
 	}
 	memcpy((char *)object->key, key, key_len);
 	object->key_len = key_len;
@@ -2883,7 +2789,6 @@ point_hole_storage_new(struct index *index, const char *key,
 		txm.point_holes_size++;
 	}
 	rlist_add(&txn->point_holes_list, &object->in_point_holes_list);
-	return 0;
 }
 
 static void
@@ -2938,13 +2843,12 @@ point_hole_storage_delete(struct point_hole_item *object)
  * from @a space and @a index with @a key.
  * The key is expected to be full, that is has part count equal to part
  * count in unique cmp_key of the index.
- * @return 0 on success, -1 on memory error.
  */
-int
+void
 memtx_tx_track_point_slow(struct txn *txn, struct index *index, const char *key)
 {
 	if (txn->status != TXN_INPROGRESS)
-		return 0;
+		return;
 
 	struct key_def *def = index->def->key_def;
 	const char *tmp = key;
@@ -2952,7 +2856,7 @@ memtx_tx_track_point_slow(struct txn *txn, struct index *index, const char *key)
 		mp_next(&tmp);
 	size_t key_len = tmp - key;
 	memtx_tx_story_gc();
-	return point_hole_storage_new(index, key, key_len, txn);
+	point_hole_storage_new(index, key, key_len, txn);
 }
 
 static struct gap_item *
@@ -2960,11 +2864,7 @@ memtx_tx_gap_item_new(struct txn *txn, enum iterator_type type,
 		      const char *key, uint32_t part_count)
 {
 	struct gap_item *item =
-		memtx_tx_mempool_alloc(txn, &txm.gap_item_mempoool);
-	if (item == NULL) {
-		diag_set(OutOfMemory, sizeof(*item), "mempool_alloc", "gap");
-		return NULL;
-	}
+		memtx_tx_xmempool_alloc(txn, &txm.gap_item_mempoool);
 
 	item->txn = txn;
 	item->type = type;
@@ -2978,15 +2878,8 @@ memtx_tx_gap_item_new(struct txn *txn, enum iterator_type type,
 	} else if (item->key_len <= sizeof(item->short_key)) {
 		item->key = item->short_key;
 	} else {
-		item->key = memtx_tx_region_alloc(txn, item->key_len,
-						  MEMTX_TX_ALLOC_TRACKER);
-		if (item->key == NULL) {
-			memtx_tx_mempool_free(txn,
-					      &txm.gap_item_mempoool, item);
-			diag_set(OutOfMemory, item->key_len, "tx region",
-				 "point key");
-			return NULL;
-		}
+		item->key = memtx_tx_xregion_alloc(txn, item->key_len,
+						   MEMTX_TX_ALLOC_TRACKER);
 	}
 	memcpy((char *)item->key, key, item->key_len);
 	rlist_add(&txn->gap_list, &item->in_gap_list);
@@ -3000,21 +2893,17 @@ memtx_tx_gap_item_new(struct txn *txn, enum iterator_type type,
  * This function must be used for ordered indexes, such as TREE, for queries
  * when iteration type is not EQ or when the key is not full (otherwise
  * it's faster to use memtx_tx_track_point).
- *
- * @return 0 on success, -1 on memory error.
  */
-int
+void
 memtx_tx_track_gap_slow(struct txn *txn, struct space *space, struct index *index,
 			struct tuple *successor, enum iterator_type type,
 			const char *key, uint32_t part_count)
 {
 	if (txn->status != TXN_INPROGRESS)
-		return 0;
+		return;
 
 	struct gap_item *item = memtx_tx_gap_item_new(txn, type, key,
 						      part_count);
-	if (item == NULL)
-		return -1;
 
 	if (successor != NULL) {
 		struct memtx_story *story;
@@ -3026,12 +2915,6 @@ memtx_tx_track_gap_slow(struct txn *txn, struct space *space, struct index *inde
 			 * and is referenced to it.
 			 */
 			story = memtx_tx_story_new(space, successor, true);
-			if (story == NULL) {
-				memtx_tx_mempool_free(txn,
-						      &txm.gap_item_mempoool,
-						      item);
-				return -1;
-			}
 		}
 		assert(index->dense_id < story->index_count);
 		assert(story->link[index->dense_id].in_index != NULL);
@@ -3041,21 +2924,13 @@ memtx_tx_track_gap_slow(struct txn *txn, struct space *space, struct index *inde
 		rlist_add(&index->nearby_gaps, &item->in_nearby_gaps);
 	}
 	memtx_tx_story_gc();
-	return 0;
 }
 
 static struct full_scan_item *
 memtx_tx_full_scan_item_new(struct txn *txn)
 {
 	struct full_scan_item *item =
-		(struct full_scan_item *)memtx_tx_mempool_alloc(txn,
-			&txm.full_scan_item_mempool);
-	if (item == NULL) {
-		diag_set(OutOfMemory, sizeof(*item), "mempool_alloc",
-			 "full_scan_item");
-		return NULL;
-	}
-
+		memtx_tx_xmempool_alloc(txn, &txm.full_scan_item_mempool);
 	item->txn = txn;
 	rlist_add(&txn->full_scan_list, &item->in_full_scan_list);
 	return item;
@@ -3065,22 +2940,16 @@ memtx_tx_full_scan_item_new(struct txn *txn)
  * Record in TX manager that a transaction @a txn have read full @a index.
  * This function must be used for unordered indexes, such as HASH, for queries
  * when iteration type is ALL.
- *
- * @return 0 on success, -1 on memory error.
  */
-int
+void
 memtx_tx_track_full_scan_slow(struct txn *txn, struct index *index)
 {
 	if (txn->status != TXN_INPROGRESS)
-		return 0;
+		return;
 
 	struct full_scan_item *item = memtx_tx_full_scan_item_new(txn);
-	if (item == NULL)
-		return -1;
-
 	rlist_add(&index->full_scans, &item->in_full_scans);
 	memtx_tx_story_gc();
-	return 0;
 }
 
 /**

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -2012,7 +2012,7 @@ memtx_tx_history_add_stmt(struct txn_stmt *stmt, struct tuple *old_tuple,
 			  struct tuple **result)
 {
 	assert(stmt != NULL);
-	assert(stmt->space != NULL);
+	assert(stmt->space != NULL && !stmt->space->def->opts.is_ephemeral);
 	assert(new_tuple != NULL || old_tuple != NULL);
 	assert(new_tuple == NULL || !tuple_has_flag(new_tuple, TUPLE_IS_DIRTY));
 
@@ -2657,11 +2657,7 @@ static void
 memtx_tx_track_read_story(struct txn *txn, struct space *space,
 			  struct memtx_story *story, uint64_t index_mask)
 {
-	if (txn == NULL)
-		return;
-	if (space == NULL)
-		return;
-	if (space->def->opts.is_ephemeral)
+	if (txn == NULL || space == NULL || space->def->opts.is_ephemeral)
 		return;
 	(void)space;
 	assert(story != NULL);
@@ -2706,11 +2702,7 @@ memtx_tx_track_read(struct txn *txn, struct space *space, struct tuple *tuple)
 {
 	if (tuple == NULL)
 		return;
-	if (txn == NULL)
-		return;
-	if (space == NULL)
-		return;
-	if (space->def->opts.is_ephemeral)
+	if (txn == NULL || space == NULL || space->def->opts.is_ephemeral)
 		return;
 
 	if (tuple_has_flag(tuple, TUPLE_IS_DIRTY)) {

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -2649,10 +2649,21 @@ tx_read_tracker_new(struct txn *reader, struct memtx_story *story,
 	return tracker;
 }
 
+/**
+ * Track the fact that transaction @a txn have read @a story in @a space.
+ * This fact could lead this transaction to read view or conflict state.
+ */
 static void
-memtx_tx_track_read_story_slow(struct txn *txn, struct memtx_story *story,
-			       uint64_t index_mask)
+memtx_tx_track_read_story(struct txn *txn, struct space *space,
+			  struct memtx_story *story, uint64_t index_mask)
 {
+	if (txn == NULL)
+		return;
+	if (space == NULL)
+		return;
+	if (space->def->opts.is_ephemeral)
+		return;
+	(void)space;
 	assert(story != NULL);
 	struct tx_read_tracker *tracker = NULL;
 
@@ -2683,19 +2694,6 @@ memtx_tx_track_read_story_slow(struct txn *txn, struct memtx_story *story,
 	}
 	rlist_add(&story->reader_list, &tracker->in_reader_list);
 	rlist_add(&txn->read_set, &tracker->in_read_set);
-}
-
-static void
-memtx_tx_track_read_story(struct txn *txn, struct space *space,
-			  struct memtx_story *story, uint64_t index_mask)
-{
-	if (txn == NULL)
-		return;
-	if (space == NULL)
-		return;
-	if (space->def->opts.is_ephemeral)
-		return;
-	memtx_tx_track_read_story_slow(txn, story, index_mask);
 }
 
 /**

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1851,11 +1851,11 @@ memtx_tx_track_story_gap(struct txn *txn, struct memtx_story *story,
  * have read from this gap and thus must be sent to read view or conflicted.
  */
 static void
-memtx_tx_handle_gap_write(struct space *space,
-			  struct memtx_story *story, struct tuple *tuple,
+memtx_tx_handle_gap_write(struct space *space, struct memtx_story *story,
 			  struct tuple *successor, uint32_t ind)
 {
 	assert(story->link[ind].newer_story == NULL);
+	struct tuple *tuple = story->tuple;
 	struct index *index = space->index[ind];
 	struct gap_item_base *item_base, *tmp;
 	rlist_foreach_entry_safe(item_base, &index->read_gaps,
@@ -1936,6 +1936,24 @@ memtx_tx_handle_gap_write(struct space *space,
 }
 
 /**
+ * Helper of memtx_tx_history_add_stmt, that sets @a result pointer to
+ * @old_tuple and reference is if necessary.
+ */
+static void
+memtx_tx_history_add_stmt_prepare_result(struct tuple *old_tuple,
+					 struct tuple **result)
+{
+	*result = old_tuple;
+	if (*result != NULL) {
+		/*
+		 * The result must be a referenced pointer. The caller must
+		 * unreference it by itself.
+		 */
+		tuple_ref(*result);
+	}
+}
+
+/**
  * Helper of @sa memtx_tx_history_add_stmt, does actual work in case when
  * new_tuple != NULL.
  * Just for understanding, that might be:
@@ -1951,14 +1969,12 @@ memtx_tx_history_add_insert_stmt(struct txn_stmt *stmt,
 				 struct tuple **result)
 {
 	assert(new_tuple != NULL);
-
 	struct space *space = stmt->space;
-	struct memtx_story *add_story = NULL, *replaced_story = NULL;
 
+	/* Process replacement in indexes. */
 	struct tuple *directly_replaced[space->index_count];
 	struct tuple *direct_successor[space->index_count];
 	uint32_t directly_replaced_count = 0;
-
 	for (uint32_t i = 0; i < space->index_count; i++) {
 		struct index *index = space->index[i];
 		struct tuple **replaced = &directly_replaced[i];
@@ -1972,9 +1988,8 @@ memtx_tx_history_add_insert_stmt(struct txn_stmt *stmt,
 		}
 	}
 	directly_replaced_count = space->index_count;
-	struct tuple *replaced = directly_replaced[0];
 
-	/* Check overwritten tuple */
+	/* Check overwritten tuple. */
 	bool is_own_change = false;
 	int rc = check_dup(stmt, new_tuple, directly_replaced,
 			   &old_tuple, mode, &is_own_change);
@@ -1982,44 +1997,49 @@ memtx_tx_history_add_insert_stmt(struct txn_stmt *stmt,
 		goto fail;
 	stmt->is_own_change = is_own_change;
 
-	/* Create add_story and replaced_story if necessary. */
-	add_story = memtx_tx_story_new(space, new_tuple);
+	/* Create add_story. */
+	struct memtx_story *add_story = memtx_tx_story_new(space, new_tuple);
 	memtx_tx_story_link_added_by(add_story, stmt);
 
-	if (replaced != NULL && !tuple_has_flag(replaced, TUPLE_IS_DIRTY)) {
-		replaced_story = memtx_tx_story_new(space, replaced);
-		memtx_tx_story_link_top(add_story, replaced_story, 0, true);
-	} else if (replaced != NULL) {
-		replaced_story = memtx_tx_story_get(replaced);
-		memtx_tx_story_link_top(add_story, replaced_story, 0, true);
-	} else {
-		memtx_tx_story_link_top(add_story, NULL, 0, true);
-		memtx_tx_handle_gap_write(space, add_story, new_tuple,
-					  direct_successor[0], 0);
+	/* Create next story in the primary index if necessary. */
+	struct tuple *next_pk = directly_replaced[0];
+	struct memtx_story *next_pk_story = NULL;
+	if (next_pk != NULL && tuple_has_flag(next_pk, TUPLE_IS_DIRTY)) {
+		next_pk_story = memtx_tx_story_get(next_pk);
+	} else if (next_pk != NULL) {
+		next_pk_story = memtx_tx_story_new(space, next_pk);
 	}
 
-	/* Collect point phantom read conflicts. */
-	for (uint32_t i = 0; i < space->index_count; i++)
-		if (directly_replaced[i] == NULL)
+	/* Collect conflicts or form chains. */
+	for (uint32_t i = 0; i < space->index_count; i++) {
+		struct tuple *next = directly_replaced[i];
+		struct tuple *succ = direct_successor[i];
+		if (next == NULL) {
+			/* Collect conflicts. */
+			memtx_tx_handle_gap_write(space, add_story, succ, i);
 			memtx_tx_handle_point_hole_write(space, add_story, i);
-
-	for (uint32_t i = 1; i < space->index_count; i++) {
-		if (directly_replaced[i] == NULL) {
-			memtx_tx_handle_gap_write(space, add_story, new_tuple,
-						  direct_successor[i], i);
-			continue;
+			memtx_tx_story_link_top(add_story, NULL, i, true);
+		} else {
+			/* Form chains. */
+			struct memtx_story *next_story = next_pk_story;
+			if (next != next_pk) {
+				assert(tuple_has_flag(next, TUPLE_IS_DIRTY));
+				next_story = memtx_tx_story_get(next);
+			}
+			memtx_tx_story_link_top(add_story, next_story, i, true);
 		}
-		assert(tuple_has_flag(directly_replaced[i], TUPLE_IS_DIRTY));
-		struct memtx_story *secondary_replaced =
-			memtx_tx_story_get(directly_replaced[i]);
-		memtx_tx_story_link_top(add_story, secondary_replaced, i, true);
 	}
 
+	/*
+	 * Now old_tuple points to a tuple that is actually replaced by this
+	 * statement. Let's find its story and link with the statement.
+	 */
 	struct memtx_story *del_story = NULL;
 	if (old_tuple != NULL) {
+		/* Link story of old_tuple as deleted_by. */
 		assert(tuple_has_flag(old_tuple, TUPLE_IS_DIRTY));
-		if (old_tuple == replaced)
-			del_story = replaced_story;
+		if (old_tuple == next_pk)
+			del_story = next_pk_story;
 		else
 			del_story = memtx_tx_story_get(old_tuple);
 		memtx_tx_story_link_deleted_by(del_story, stmt);
@@ -2049,19 +2069,12 @@ memtx_tx_history_add_insert_stmt(struct txn_stmt *stmt,
 			memtx_tx_track_read_story(stmt->txn, space, del_story);
 	}
 
-	*result = old_tuple;
-	if (*result != NULL) {
-		/*
-		 * The result must be a referenced pointer. The caller must
-		 * unreference it by itself.
-		 */
-		tuple_ref(*result);
-	}
+	/* Finalize the result. */
+	memtx_tx_history_add_stmt_prepare_result(old_tuple, result);
 	return 0;
 
 fail:
-	while (directly_replaced_count > 0) {
-		uint32_t i = --directly_replaced_count;
+	for (uint32_t i = directly_replaced_count - 1; i + 1 > 0; i--) {
 		struct index *index = space->index[i];
 		struct tuple *unused;
 		if (index_replace(index, new_tuple, directly_replaced[i],
@@ -2085,31 +2098,29 @@ memtx_tx_history_add_delete_stmt(struct txn_stmt *stmt,
 				 struct tuple *old_tuple,
 				 struct tuple **result)
 {
-	struct space *space = stmt->space;
-	struct memtx_story *del_story;
+	/*
+	 * Find deleted story and link it with the statement.
+	 * The funny thing is that specific API of space->replace function
+	 * requires old_tuple as an argument, which can only be acquired
+	 * through mvcc clarification. That means that the story of old_tuple
+	 * must have been already created and it already contains a read
+	 * record by this transaction. That's why we expect old_tuple to
+	 * be dirty and do not set read tracker as would be logically
+	 * correct in this function, something like that:
+	 * memtx_tx_track_read_story(stmt->txn, stmt->space, del_story)
+	 */
+	assert(tuple_has_flag(old_tuple, TUPLE_IS_DIRTY));
+	struct memtx_story *del_story = memtx_tx_story_get(old_tuple);
+	if (del_story->add_stmt != NULL)
+		stmt->is_own_change = del_story->add_stmt->txn == stmt->txn;
+	memtx_tx_story_link_deleted_by(del_story, stmt);
 
-	if (tuple_has_flag(old_tuple, TUPLE_IS_DIRTY)) {
-		del_story = memtx_tx_story_get(old_tuple);
-		if (del_story->add_stmt != NULL)
-			stmt->is_own_change =
-				del_story->add_stmt->txn == stmt->txn;
-	} else {
-		assert(stmt->txn != NULL);
-		del_story = memtx_tx_story_new(space, old_tuple);
-	}
+	/* Notify statistics. */
 	if (!del_story->tuple_is_retained)
 		memtx_tx_story_track_retained_tuple(del_story);
 
-	memtx_tx_story_link_deleted_by(del_story, stmt);
-	*result = old_tuple;
-
-	if (*result != NULL) {
-		/*
-		 * The result must be a referenced pointer. The caller must
-		 * unreference it by itself.
-		 */
-		tuple_ref(*result);
-	}
+	/* Finalize the result. */
+	memtx_tx_history_add_stmt_prepare_result(old_tuple, result);
 	return 0;
 }
 

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -484,8 +484,6 @@ struct tx_manager
 	struct memtx_tx_mempool point_hole_item_pool;
 	/** Hash table that hold point selects with empty result. */
 	struct mh_point_holes_t *point_holes;
-	/** Count of elements in point_holes table. */
-	size_t point_holes_size;
 	/** Mempool for gap_item objects. */
 	struct memtx_tx_mempool gap_item_mempoool;
 	/** Mempool for full_scan_item objects. */
@@ -538,7 +536,6 @@ memtx_tx_manager_init()
 	memtx_tx_mempool_create(&txm.full_scan_item_mempool,
 				sizeof(struct full_scan_item),
 				MEMTX_TX_ALLOC_TRACKER);
-	txm.point_holes_size = 0;
 	rlist_create(&txm.all_stories);
 	rlist_create(&txm.all_txs);
 	txm.traverse_all_stories = &txm.all_stories;
@@ -1637,18 +1634,6 @@ memtx_tx_check_dup(struct tuple *new_tuple, struct tuple *old_tuple,
 	return 0;
 }
 
-static struct point_hole_item *
-point_hole_storage_find(struct index *index, struct tuple *tuple)
-{
-	struct point_hole_key key;
-	key.index = index;
-	key.tuple = tuple;
-	mh_int_t pos = mh_point_holes_find(txm.point_holes, &key, 0);
-	if (pos == mh_end(txm.point_holes))
-		return NULL;
-	return *mh_point_holes_node(txm.point_holes, pos);
-}
-
 /**
  * Track the fact that transaction @a txn have read @a story in @a space.
  * This fact could lead this transaction to read view or conflict state.
@@ -1659,26 +1644,45 @@ memtx_tx_track_read_story(struct txn *txn, struct space *space,
 
 /**
  * Check for possible conflict relations during insertion of @a new tuple,
- * and given that it was a real insertion, not the replacement of existing
- * tuple. It's the moment where we can search for stored point hole trackers
- * and find conflict causes.
+ * (with the corresponding @a story) into index @a ind. It is needed if and
+ * only if that was real insertion - there was no replaced tuple in the index.
+ * It's the moment where we can search for stored point hole trackers and find
+ * conflict causes. If some transactions have been reading the key in the
+ * index (and found nothing) - those transactions will be removed from
+ * point hole tracker and will be rebind as normal reader of given tuple.
  */
 static void
-check_hole(struct space *space, struct memtx_story *story,
-	   uint32_t ind)
+memtx_tx_handle_point_hole_write(struct space *space, struct memtx_story *story,
+				 uint32_t ind)
 {
-	struct point_hole_item *list =
-		point_hole_storage_find(space->index[ind], story->tuple);
-	if (list == NULL)
+	struct mh_point_holes_t *ht = txm.point_holes;
+	struct point_hole_key key;
+	key.index = space->index[ind];
+	key.tuple = story->tuple;
+	mh_int_t pos = mh_point_holes_find(ht, &key, 0);
+	if (pos == mh_end(ht))
 		return;
+	struct point_hole_item *item = *mh_point_holes_node(ht, pos);
 
-	struct point_hole_item *item = list;
+	struct memtx_tx_mempool *pool = &txm.point_hole_item_pool;
 	uint64_t index_mask = 1ull << (ind & 63);
+	bool has_more_items;
 	do {
 		memtx_tx_track_read_story(item->txn, space, story, index_mask);
-		item = rlist_entry(item->ring.next,
-				   struct point_hole_item, ring);
-	} while (item != list);
+
+		struct point_hole_item *next_item =
+			rlist_entry(item->ring.next,
+				    struct point_hole_item, ring);
+		has_more_items = next_item != item;
+
+		rlist_del(&item->ring);
+		rlist_del(&item->in_point_holes_list);
+		memtx_tx_mempool_free(item->txn, pool, item);
+
+		item = next_item;
+	} while (has_more_items);
+
+	mh_point_holes_del(ht, pos, 0);
 }
 
 /**
@@ -1920,7 +1924,8 @@ memtx_tx_history_add_insert_stmt(struct txn_stmt *stmt,
 
 	/* Collect point phantom read conflicts. */
 	for (uint32_t i = 0; i < space->index_count; i++)
-		check_hole(space, add_story, i);
+		if (directly_replaced[i] == NULL)
+			memtx_tx_handle_point_hole_write(space, add_story, i);
 
 	for (uint32_t i = 1; i < space->index_count; i++) {
 		if (directly_replaced[i] == NULL) {
@@ -2769,8 +2774,6 @@ point_hole_storage_new(struct index *index, const char *key,
 		rlist_add(&replaced->ring, &object->ring);
 		assert(replaced->is_head);
 		replaced->is_head = false;
-	} else {
-		txm.point_holes_size++;
 	}
 	rlist_add(&txn->point_holes_list, &object->in_point_holes_list);
 }
@@ -2815,7 +2818,6 @@ point_hole_storage_delete(struct point_hole_item *object)
 						       &exist, 0);
 		assert(exist);
 		mh_point_holes_del(txm.point_holes, pos, 0);
-		txm.point_holes_size--;
 	}
 	rlist_del(&object->in_point_holes_list);
 	struct memtx_tx_mempool *pool = &txm.point_hole_item_pool;

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -937,23 +937,18 @@ memtx_tx_story_new(struct space *space, struct tuple *tuple)
 static void
 memtx_tx_story_delete(struct memtx_story *story)
 {
+	/* Expecting to delete fully unlinked story. */
+	assert(story->add_stmt == NULL);
+	assert(story->del_stmt == NULL);
+	for (uint32_t i = 0; i < story->index_count; i++) {
+		assert(story->link[i].newer_story == NULL);
+		assert(story->link[i].older_story == NULL);
+	}
+
 	memtx_tx_stats_discard(&txm.story_stats[story->status],
 			       memtx_story_size(story));
 	if (story->tuple_is_retained)
 		memtx_tx_story_untrack_retained_tuple(story);
-
-	if (story->add_stmt != NULL) {
-		assert(story->add_stmt->add_story == story);
-		story->add_stmt->add_story = NULL;
-		story->add_stmt = NULL;
-	}
-	while (story->del_stmt != NULL) {
-		assert(story->del_stmt->del_story == story);
-		story->del_stmt->del_story = NULL;
-		struct txn_stmt *next = story->del_stmt->next_in_del_list;
-		story->del_stmt->next_in_del_list = NULL;
-		story->del_stmt = next;
-	}
 
 	if (txm.traverse_all_stories == &story->in_all_stories)
 		txm.traverse_all_stories = rlist_next(txm.traverse_all_stories);
@@ -966,14 +961,6 @@ memtx_tx_story_delete(struct memtx_story *story)
 
 	tuple_clear_flag(story->tuple, TUPLE_IS_DIRTY);
 	tuple_unref(story->tuple);
-
-#ifndef NDEBUG
-	/* Expecting to delete fully unlinked story. */
-	for (uint32_t i = 0; i < story->index_count; i++) {
-		assert(story->link[i].newer_story == NULL);
-		assert(story->link[i].older_story == NULL);
-	}
-#endif
 
 	struct mempool *pool = &txm.memtx_tx_story_pool[story->index_count];
 	mempool_free(pool, story);

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -792,9 +792,9 @@ static inline void
 memtx_tx_ref_to_primary(struct memtx_story *story)
 {
 	assert(story != NULL);
-	assert(story->tuple_is_retained);
 	tuple_ref(story->tuple);
-	memtx_tx_story_untrack_retained_tuple(story);
+	if (story->tuple_is_retained)
+		memtx_tx_story_untrack_retained_tuple(story);
 }
 
 /**
@@ -812,10 +812,18 @@ memtx_tx_unref_from_primary(struct memtx_story *story)
 
 /**
  * Create a new story and link it with the @a tuple.
+ * There are two known scenarios of using this function:
+ * * The story is created for a clean tuple that is in space (and thus in
+ *   space indexes) now. Such a story is a top of degenerate chains that
+ *   consist of this story only.
+ * * The story is created for a new tuple that is to be inserted into space.
+ *   Such a story will become the top of chains, and a special function
+ *   memtx_tx_story_link_top must be called for that.
+ * In any case this story is expected to be a top of chains, so we set
+ * in_index members in story links to appropriate values.
  */
 static struct memtx_story *
-memtx_tx_story_new(struct space *space, struct tuple *tuple,
-		   bool tuple_is_referenced_to_pk)
+memtx_tx_story_new(struct space *space, struct tuple *tuple)
 {
 	txm.must_do_gc_steps += TX_MANAGER_GC_STEPS_SIZE;
 	assert(!tuple_has_flag(tuple, TUPLE_IS_DIRTY));
@@ -837,8 +845,6 @@ memtx_tx_story_new(struct space *space, struct tuple *tuple,
 	struct memtx_tx_stats *stats = &txm.story_stats[story->status];
 	memtx_tx_stats_collect(stats, pool->objsize);
 	story->tuple_is_retained = false;
-	if (!tuple_is_referenced_to_pk)
-		memtx_tx_story_track_retained_tuple(story);
 	story->index_count = index_count;
 	story->add_stmt = NULL;
 	story->add_psn = 0;
@@ -1030,72 +1036,85 @@ memtx_tx_story_unlink(struct memtx_story *story,
 }
 
 /**
- * Link a @a story with @a old_story in @a index (in both directions),
- * where old_story was at the top of chain. This is a light version of
- * function, intended for the case when the appropriate index IS ALREADY
- * changed, and now stores story->tuple.
- * In addition to linking in list, this function also rebinds gap records
- * to the new top - story - in history chain.
- * @a old_story is allowed to be NULL.
- */
-static void
-memtx_tx_story_link_top_light(struct memtx_story *new_top,
-			      struct memtx_story *old_top,
-			      uint32_t idx)
-{
-	memtx_tx_story_link(new_top, old_top, idx);
-
-	if (old_top == NULL)
-		return;
-
-	/* Rebind gap records to the top of the list */
-	struct memtx_story_link *new_link = &new_top->link[idx];
-	struct memtx_story_link *old_link = &old_top->link[idx];
-	rlist_splice(&new_link->nearby_gaps, &old_link->nearby_gaps);
-}
-
-/**
- * Link a @a new_top with @a old_top in @a index (in both directions),
- * where old_top was at the top of chain (that means that index itself
- * stores a pointer to old_top->tuple).
- * In addition to linking in list, this function also rebinds gap records
- * to the new top - story - in history chain.
- * This function makes also changes in the index, replacing old_top->tuple
- * with new_top->tuple.
+ * Link a @a new_top with @a old_top in @a idx (in both directions), where
+ * @a old_top was at the top of chain.
+ * There are two different but close in implementation scenarios in which
+ * this function should be used:
+ * * @a is_new_tuple is true:
+ *   @a new_top is a newly created story of a new tuple, that (by design) was
+ *   just inserted into indexes. @a old_top is the story that was previously
+ *   in the top of chain or NULL if the chain was empty.
+ * * @a is_new_tuple is false:
+ *   @a old_top was in the top of chain while @a new_top was a story next to it,
+ *   and the chain must be reordered and @a new_top must become at the top of
+ *   chain and @a old_top must be linked after it. This case also requires
+ *   physical replacement in index - it will point to new_top->tuple.
  */
 static void
 memtx_tx_story_link_top(struct memtx_story *new_top,
 			struct memtx_story *old_top,
-			uint32_t idx)
+			uint32_t idx, bool is_new_tuple)
 {
-	assert(old_top != NULL);
-	memtx_tx_story_link_top_light(new_top, old_top, idx);
-
-	/* Make the change in index. */
-	struct index *index = old_top->link[idx].in_index;
-	assert(index != NULL);
-	assert(new_top->link[idx].in_index == NULL);
-	struct tuple *removed, *unused;
-	if (index_replace(index, old_top->tuple, new_top->tuple,
-			  DUP_REPLACE, &removed, &unused) != 0) {
-		diag_log();
-		unreachable();
-		panic("failed to rebind story in index");
+	assert(old_top != NULL || is_new_tuple);
+	if (is_new_tuple && old_top == NULL) {
+		if (idx == 0)
+			memtx_tx_ref_to_primary(new_top);
+		return;
 	}
-	assert(old_top->tuple == removed);
-	old_top->link[idx].in_index = NULL;
-	new_top->link[idx].in_index = index;
+	struct memtx_story_link *new_link = &new_top->link[idx];
+	struct memtx_story_link *old_link = &old_top->link[idx];
+	assert(old_link->in_index != NULL);
+	assert(old_link->newer_story == NULL);
+	if (is_new_tuple) {
+		assert(new_link->newer_story == NULL);
+		assert(new_link->older_story == NULL);
+	} else {
+		assert(new_link->newer_story == old_top);
+		assert(old_link->older_story == new_top);
+	}
+
+	if (!is_new_tuple) {
+		/* Make the change in index. */
+		struct index *index = old_link->in_index;
+		struct tuple *removed, *unused;
+		if (index_replace(index, old_top->tuple, new_top->tuple,
+				  DUP_REPLACE, &removed, &unused) != 0) {
+			diag_log();
+			unreachable();
+			panic("failed to rebind story in index");
+		}
+		assert(old_top->tuple == removed);
+	}
+
+	/* Link the list. */
+	if (is_new_tuple) {
+		memtx_tx_story_link(new_top, old_top, idx);
+		/* in_index must be set in story_new. */
+		assert(new_link->in_index == old_link->in_index);
+		old_link->in_index = NULL;
+	} else {
+		struct memtx_story *older_story = new_link->older_story;
+		memtx_tx_story_unlink(old_top, new_top, idx);
+		memtx_tx_story_unlink(new_top, older_story, idx);
+		memtx_tx_story_link(new_top, old_top, idx);
+		memtx_tx_story_link(old_top, older_story, idx);
+		new_link->in_index = old_link->in_index;
+		old_link->in_index = NULL;
+	}
 
 	/*
 	 * A space holds references to all his tuples.
 	 * All tuples that are physically in the primary index are referenced.
-	 * Thus we have to reference the tuple that was added to the primar
+	 * Thus we have to reference the tuple that was added to the primary
 	 * index and dereference the tuple that was removed from it.
 	 */
 	if (idx == 0) {
 		memtx_tx_ref_to_primary(new_top);
 		memtx_tx_unref_from_primary(old_top);
 	}
+
+	/* Rebind gap records to the top of the list */
+	rlist_splice(&new_link->nearby_gaps, &old_link->nearby_gaps);
 }
 
 /**
@@ -1255,20 +1274,21 @@ memtx_tx_story_reorder(struct memtx_story *story,
 	 *      [     old_story     ]        [       story       ]
 	 *      [    older_story    ]        [    older_story    ]
 	 */
-	memtx_tx_story_unlink(story, old_story, idx);
-	memtx_tx_story_unlink(old_story, older_story, idx);
 	if (newer_story != NULL) {
 		/* Simple relink in list. */
 		memtx_tx_story_unlink(newer_story, story, idx);
+		memtx_tx_story_unlink(story, old_story, idx);
+		memtx_tx_story_unlink(old_story, older_story, idx);
+
 		memtx_tx_story_link(newer_story, old_story, idx);
 		memtx_tx_story_link(old_story, story, idx);
+		memtx_tx_story_link(story, older_story, idx);
 	} else {
 		/*
 		 * story was in the top of history chain. In terms of reorder,
 		 * we have to make old_story the new top of chain. */
-		memtx_tx_story_link_top(old_story, story, idx);
+		memtx_tx_story_link_top(old_story, story, idx, false);
 	}
-	memtx_tx_story_link(story, older_story, idx);
 }
 
 /**
@@ -1881,25 +1901,18 @@ memtx_tx_history_add_insert_stmt(struct txn_stmt *stmt,
 	if (rc != 0)
 		goto fail;
 
-	/*
-	 * Create add_story and replaced_story if necessary.
-	 * Note that despite the tuple is already in pk,
-	 * it is not referenced to it, so we pass false as the last argument.
-	 */
-	add_story = memtx_tx_story_new(space, new_tuple, false);
+	/* Create add_story and replaced_story if necessary. */
+	add_story = memtx_tx_story_new(space, new_tuple);
 	memtx_tx_story_link_added_by(add_story, stmt);
 
 	if (replaced != NULL && !tuple_has_flag(replaced, TUPLE_IS_DIRTY)) {
-		/*
-		 * Note that despite the tuple is not in pk,
-		 * it is referenced to it, so we pass true as the last argument.
-		 */
-		replaced_story = memtx_tx_story_new(space, replaced, true);
-		memtx_tx_story_link_top_light(add_story, replaced_story, 0);
+		replaced_story = memtx_tx_story_new(space, replaced);
+		memtx_tx_story_link_top(add_story, replaced_story, 0, true);
 	} else if (replaced != NULL) {
 		replaced_story = memtx_tx_story_get(replaced);
-		memtx_tx_story_link_top_light(add_story, replaced_story, 0);
+		memtx_tx_story_link_top(add_story, replaced_story, 0, true);
 	} else {
+		memtx_tx_story_link_top(add_story, NULL, 0, true);
 		memtx_tx_handle_gap_write(stmt->txn, space,
 					  add_story, new_tuple,
 					  direct_successor[0], 0);
@@ -1909,8 +1922,6 @@ memtx_tx_history_add_insert_stmt(struct txn_stmt *stmt,
 	for (uint32_t i = 0; i < space->index_count; i++)
 		check_hole(space, add_story, i);
 
-	if (replaced_story != NULL)
-		replaced_story->link[0].in_index = NULL;
 	for (uint32_t i = 1; i < space->index_count; i++) {
 		if (directly_replaced[i] == NULL) {
 			memtx_tx_handle_gap_write(stmt->txn, space,
@@ -1921,8 +1932,7 @@ memtx_tx_history_add_insert_stmt(struct txn_stmt *stmt,
 		assert(tuple_has_flag(directly_replaced[i], TUPLE_IS_DIRTY));
 		struct memtx_story *secondary_replaced =
 			memtx_tx_story_get(directly_replaced[i]);
-		memtx_tx_story_link_top_light(add_story, secondary_replaced, i);
-		secondary_replaced->link[i].in_index = NULL;
+		memtx_tx_story_link_top(add_story, secondary_replaced, i, true);
 	}
 
 	if (old_tuple != NULL) {
@@ -1936,23 +1946,6 @@ memtx_tx_history_add_insert_stmt(struct txn_stmt *stmt,
 		memtx_tx_story_link_deleted_by(del_story, stmt);
 	} else if (is_own_change)
 		stmt->is_pure_insert = true;
-
-	if (new_tuple != NULL) {
-		/*
-		 * A space holds references to all his tuples.
-		 * It's made via primary index - all tuples that are physically
-		 * in primary index must be referenced (a replaces tuple must
-		 * be dereferenced).
-		 */
-		assert(add_story == memtx_tx_story_get(new_tuple));
-
-		memtx_tx_ref_to_primary(add_story);
-		if (directly_replaced[0] != NULL) {
-			assert(replaced_story ==
-			       memtx_tx_story_get(directly_replaced[0]));
-			memtx_tx_unref_from_primary(replaced_story);
-		}
-	}
 
 	*result = old_tuple;
 	if (*result != NULL) {
@@ -1997,11 +1990,7 @@ memtx_tx_history_add_delete_stmt(struct txn_stmt *stmt,
 		del_story = memtx_tx_story_get(old_tuple);
 	} else {
 		assert(stmt->txn != NULL);
-		/*
-		 * The tuple is not dirty therefore it is placed in pk
-		 * and is referenced to it.
-		 */
-		del_story = memtx_tx_story_new(space, old_tuple, true);
+		del_story = memtx_tx_story_new(space, old_tuple);
 	}
 	if (!del_story->tuple_is_retained)
 		memtx_tx_story_track_retained_tuple(del_story);
@@ -2732,12 +2721,7 @@ memtx_tx_track_read(struct txn *txn, struct space *space, struct tuple *tuple)
 		struct memtx_story *story = memtx_tx_story_get(tuple);
 		memtx_tx_track_read_story(txn, space, story, UINT64_MAX);
 	} else {
-		/*
-		 * The tuple is not dirty therefore it is placed in pk
-		 * and is referenced to it.
-		 */
-		struct memtx_story *story =
-			memtx_tx_story_new(space, tuple, true);
+		struct memtx_story *story = memtx_tx_story_new(space, tuple);
 		struct tx_read_tracker *tracker;
 		tracker = tx_read_tracker_new(txn, story, UINT64_MAX);
 		rlist_add(&story->reader_list, &tracker->in_reader_list);
@@ -2910,11 +2894,7 @@ memtx_tx_track_gap_slow(struct txn *txn, struct space *space, struct index *inde
 		if (tuple_has_flag(successor, TUPLE_IS_DIRTY)) {
 			story = memtx_tx_story_get(successor);
 		} else {
-			/*
-			 * The tuple is not dirty therefore it is placed in pk
-			 * and is referenced to it.
-			 */
-			story = memtx_tx_story_new(space, successor, true);
+			story = memtx_tx_story_new(space, successor);
 		}
 		assert(index->dense_id < story->index_count);
 		assert(story->link[index->dense_id].in_index != NULL);

--- a/src/box/memtx_tx.h
+++ b/src/box/memtx_tx.h
@@ -144,7 +144,7 @@ memtx_tx_statistics_collect(struct memtx_tx_statistics *stats);
  * Initialize MVCC part of a transaction.
  * Must be called even if MVCC engine is not enabled in config.
  */
-int
+void
 memtx_tx_register_txn(struct txn *txn);
 
 /**
@@ -263,7 +263,7 @@ memtx_tx_tuple_clarify_slow(struct txn *txn, struct space *space,
 			    uint32_t mk_index);
 
 /** Helper of memtx_tx_track_point */
-int
+void
 memtx_tx_track_point_slow(struct txn *txn, struct index *index,
 			  const char *key);
 
@@ -277,24 +277,24 @@ memtx_tx_track_point_slow(struct txn *txn, struct index *index,
  *
  * @return 0 on success, -1 on memory error.
  */
-static inline int
+static inline void
 memtx_tx_track_point(struct txn *txn, struct space *space,
 		     struct index *index, const char *key)
 {
 	if (!memtx_tx_manager_use_mvcc_engine)
-		return 0;
+		return;
 	if (txn == NULL)
-		return 0;
+		return;
 	/* Skip ephemeral spaces. */
 	if (space == NULL || space->def->id == 0)
-		return 0;
-	return memtx_tx_track_point_slow(txn, index, key);
+		return;
+	memtx_tx_track_point_slow(txn, index, key);
 }
 
 /**
  * Helper of memtx_tx_track_gap.
  */
-int
+void
 memtx_tx_track_gap_slow(struct txn *txn, struct space *space, struct index *index,
 			struct tuple *successor, enum iterator_type type,
 			const char *key, uint32_t part_count);
@@ -308,29 +308,27 @@ memtx_tx_track_gap_slow(struct txn *txn, struct space *space, struct index *inde
  * it's faster to use memtx_tx_track_point).
  *
  * NB: can trigger story garbage collection.
- *
- * @return 0 on success, -1 on memory error.
  */
-static inline int
+static inline void
 memtx_tx_track_gap(struct txn *txn, struct space *space, struct index *index,
 		   struct tuple *successor, enum iterator_type type,
 		   const char *key, uint32_t part_count)
 {
 	if (!memtx_tx_manager_use_mvcc_engine)
-		return 0;
+		return;
 	if (txn == NULL)
-		return 0;
+		return;
 	/* Skip ephemeral spaces. */
 	if (space == NULL || space->def->id == 0)
-		return 0;
-	return memtx_tx_track_gap_slow(txn, space, index, successor,
-				       type, key, part_count);
+		return;
+	memtx_tx_track_gap_slow(txn, space, index, successor,
+				type, key, part_count);
 }
 
 /**
  * Helper of memtx_tx_track_full_scan.
  */
-int
+void
 memtx_tx_track_full_scan_slow(struct txn *txn, struct index *index);
 
 /**
@@ -343,18 +341,18 @@ memtx_tx_track_full_scan_slow(struct txn *txn, struct index *index);
  *
  * @return 0 on success, -1 on memory error.
  */
-static inline int
+static inline void
 memtx_tx_track_full_scan(struct txn *txn, struct space *space,
 			 struct index *index)
 {
 	if (!memtx_tx_manager_use_mvcc_engine)
-		return 0;
+		return;
 	if (txn == NULL)
-		return 0;
+		return;
 	/* Skip ephemeral spaces. */
 	if (space == NULL || space->def->id == 0)
-		return 0;
-	return memtx_tx_track_full_scan_slow(txn, index);
+		return;
+	memtx_tx_track_full_scan_slow(txn, index);
 }
 
 /**

--- a/src/box/memtx_tx.h
+++ b/src/box/memtx_tx.h
@@ -62,11 +62,13 @@ enum memtx_tx_alloc_object {
 	/**
 	 * Deprecated object of type struct memtx_tx_conflict.
 	 * Left for statistics compatibility.
-	 * TODO: remove it considering monitoring module.
+	 * TODO(gh-8149): remove it considering monitoring module.
 	 */
 	MEMTX_TX_OBJECT_CONFLICT = 0,
 	/**
-	 * Object of type struct tx_conflict_tracker.
+	 * Deprecated object of type struct tx_conflict_tracker.
+	 * Left for statistics compatibility.
+	 * TODO(gh-8149): remove it considering monitoring module.
 	 */
 	MEMTX_TX_OBJECT_CONFLICT_TRACKER = 1,
 	/**

--- a/src/box/memtx_tx.h
+++ b/src/box/memtx_tx.h
@@ -283,10 +283,7 @@ memtx_tx_track_point(struct txn *txn, struct space *space,
 {
 	if (!memtx_tx_manager_use_mvcc_engine)
 		return;
-	if (txn == NULL)
-		return;
-	/* Skip ephemeral spaces. */
-	if (space == NULL || space->def->id == 0)
+	if (txn == NULL || space == NULL || space->def->opts.is_ephemeral)
 		return;
 	memtx_tx_track_point_slow(txn, index, key);
 }
@@ -316,10 +313,7 @@ memtx_tx_track_gap(struct txn *txn, struct space *space, struct index *index,
 {
 	if (!memtx_tx_manager_use_mvcc_engine)
 		return;
-	if (txn == NULL)
-		return;
-	/* Skip ephemeral spaces. */
-	if (space == NULL || space->def->id == 0)
+	if (txn == NULL || space == NULL || space->def->opts.is_ephemeral)
 		return;
 	memtx_tx_track_gap_slow(txn, space, index, successor,
 				type, key, part_count);
@@ -347,10 +341,7 @@ memtx_tx_track_full_scan(struct txn *txn, struct space *space,
 {
 	if (!memtx_tx_manager_use_mvcc_engine)
 		return;
-	if (txn == NULL)
-		return;
-	/* Skip ephemeral spaces. */
-	if (space == NULL || space->def->id == 0)
+	if (txn == NULL || space == NULL || space->def->opts.is_ephemeral)
 		return;
 	memtx_tx_track_full_scan_slow(txn, index);
 }

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -506,11 +506,7 @@ txn_begin(void)
 	 * if they are not supported.
 	 */
 	txn_set_flags(txn, TXN_CAN_YIELD);
-	int rc = memtx_tx_register_txn(txn);
-	if (rc == -1) {
-		txn_free(txn);
-		return NULL;
-	}
+	memtx_tx_register_txn(txn);
 	rmean_collect(rmean_box, IPROTO_BEGIN, 1);
 	return txn;
 }

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -413,8 +413,6 @@ txn_new(void)
 	rlist_create(&txn->point_holes_list);
 	rlist_create(&txn->gap_list);
 	rlist_create(&txn->full_scan_list);
-	rlist_create(&txn->conflict_list);
-	rlist_create(&txn->conflicted_by_list);
 	rlist_create(&txn->in_read_view_txs);
 	rlist_create(&txn->in_all_txs);
 	txn->space_on_replace_triggers_depth = 0;
@@ -476,8 +474,6 @@ txn_begin(void)
 	struct txn *txn = txn_new();
 	if (txn == NULL)
 		return NULL;
-	assert(rlist_empty(&txn->conflict_list));
-	assert(rlist_empty(&txn->conflicted_by_list));
 
 	/* Initialize members explicitly to save time on memset() */
 	stailq_create(&txn->stmts);

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -306,7 +306,7 @@ txn_stmt_new(struct txn *txn)
 	stmt->engine_savepoint = NULL;
 	stmt->row = NULL;
 	stmt->has_triggers = false;
-	stmt->is_pure_insert = false;
+	stmt->is_own_change = false;
 	return stmt;
 }
 

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -306,7 +306,6 @@ txn_stmt_new(struct txn *txn)
 	stmt->engine_savepoint = NULL;
 	stmt->row = NULL;
 	stmt->has_triggers = false;
-	stmt->does_require_old_tuple = false;
 	stmt->is_pure_insert = false;
 	return stmt;
 }
@@ -633,20 +632,7 @@ txn_commit_stmt(struct txn *txn, struct request *request)
 	 */
 	if (stmt->space != NULL && stmt->space->run_triggers &&
 	    (stmt->old_tuple || stmt->new_tuple)) {
-		if (!rlist_empty(&stmt->space->before_replace)) {
-			/*
-			 * Triggers see old_tuple and that tuple
-			 * must remain the same
-			 */
-			stmt->does_require_old_tuple = true;
-		}
 		if (!rlist_empty(&stmt->space->on_replace)) {
-			/*
-			 * Triggers see old_tuple and that tuple
-			 * must remain the same
-			 */
-			stmt->does_require_old_tuple = true;
-
 			txn->space_on_replace_triggers_depth++;
 			int rc = trigger_run(&stmt->space->on_replace, txn);
 			txn->space_on_replace_triggers_depth--;

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -412,7 +412,6 @@ txn_new(void)
 	rlist_create(&txn->read_set);
 	rlist_create(&txn->point_holes_list);
 	rlist_create(&txn->gap_list);
-	rlist_create(&txn->full_scan_list);
 	rlist_create(&txn->in_read_view_txs);
 	rlist_create(&txn->in_all_txs);
 	txn->space_on_replace_triggers_depth = 0;

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -45,8 +45,12 @@
 
 double too_long_threshold;
 
-/** Last prepare-sequence-number that was assigned to prepared TX. */
-int64_t txn_last_psn = 0;
+/**
+ * Incremental counter for psn (prepare sequence number) of a transaction.
+ * The next prepared transaction will get psn == txn_next_psn++.
+ * See also struct txn::psn.
+ */
+int64_t txn_next_psn = TXN_MIN_PSN;
 
 enum txn_isolation_level txn_default_isolation = TXN_ISOLATION_BEST_EFFORT;
 
@@ -357,50 +361,9 @@ txn_rollback_one_stmt(struct txn *txn, struct txn_stmt *stmt)
 	}
 }
 
-/**
- * Assign's a PSN to a RW transaction that wasn't yet prepared.
- */
-static void
-txn_assign_psn(struct txn *txn)
-{
-	if (txn->psn == 0) {
-		if (txn->status == TXN_IN_READ_VIEW) {
-			assert(stailq_empty(&txn->stmts));
-		} else {
-			assert(txn->status == TXN_INPROGRESS ||
-			       txn->status == TXN_ABORTED);
-			txn->psn = ++txn_last_psn;
-		}
-	} else {
-		assert(txn->status == TXN_PREPARED);
-	}
-}
-
-/*
- * Begins the rollback to savepoint process by assigning a PSN to the
- * transaction (rolled back statements require a PSN).
- */
-static void
-txn_rollback_to_svp_begin(struct txn *txn)
-{
-	txn_assign_psn(txn);
-}
-
-/*
- * Finishes the rollback to savepoint process by resetting the transaction's
- * PSN (since this not a complete transaction rollback).
- */
-static void
-txn_rollback_to_svp_finish(struct txn *txn)
-{
-	if (txn->status != TXN_PREPARED)
-		txn->psn = 0;
-}
-
 static void
 txn_rollback_to_svp(struct txn *txn, struct stailq_entry *svp)
 {
-	txn_rollback_to_svp_begin(txn);
 	struct txn_stmt *stmt;
 	struct stailq rollback;
 	stailq_cut_tail(&txn->stmts, svp, &rollback);
@@ -421,7 +384,6 @@ txn_rollback_to_svp(struct txn *txn, struct stailq_entry *svp)
 		stmt->space = NULL;
 		stmt->row = NULL;
 	}
-	txn_rollback_to_svp_finish(txn);
 }
 
 /*
@@ -747,7 +709,6 @@ txn_free_or_wakeup(struct txn *txn)
 void
 txn_complete_fail(struct txn *txn)
 {
-	assert(txn->psn != 0);
 	assert(!txn_has_flag(txn, TXN_IS_DONE));
 	assert(txn->signature < 0);
 	assert(txn->signature != TXN_SIGNATURE_UNKNOWN);
@@ -991,12 +952,14 @@ txn_prepare(struct txn *txn)
 	if (txn_check_can_continue(txn) != 0)
 		return -1;
 
-	txn_assign_psn(txn);
-
 	if (txn->rollback_timer != NULL) {
 		ev_timer_stop(loop(), txn->rollback_timer);
 		txn->rollback_timer = NULL;
 	}
+
+	assert(txn->psn == 0);
+	/* psn must be set before calling engine handlers. */
+	txn->psn = txn_next_psn++;
 
 	/*
 	 * Perform transaction conflict resolution. Engine == NULL when
@@ -1184,10 +1147,6 @@ txn_rollback(struct txn *txn)
 {
 	assert(txn == in_txn());
 	assert(txn->signature != TXN_SIGNATURE_UNKNOWN);
-	/*
-	 * Rolled back statements require a PSN.
-	 */
-	txn_assign_psn(txn);
 	txn->status = TXN_ABORTED;
 	trigger_clear(&txn->fiber_on_stop);
 	trigger_clear(&txn->fiber_on_yield);

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -504,18 +504,6 @@ struct txn {
 	/** List of savepoints to find savepoint by name. */
 	struct rlist savepoints;
 	/**
-	 * List of tx_conflict_tracker records where .breaker is the current
-	 * transaction and .victim is the transactions that must be aborted
-	 * if the current transaction is committed.
-	 */
-	struct rlist conflict_list;
-	/**
-	 * List of tx_conflict_tracker records where .victim is the current
-	 * transaction and .breaker is the transactions that, if committed,
-	 * will abort the current transaction.
-	 */
-	struct rlist conflicted_by_list;
-	/**
 	 * Link in tx_manager::read_view_txs.
 	 */
 	struct rlist in_read_view_txs;

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -302,13 +302,13 @@ struct txn_stmt {
 	/** on_commit and/or on_rollback list is not empty. */
 	bool has_triggers;
 	/*
-	 * `insert` statement is guaranteed not to delete anything
-	 * from the transaction's point of view (i.e., there was a preceding
-	 * `delete` in the scope of the same transaction): no linking to the
-	 * list of `delete` statements is required during preparation of insert
-	 * statements that add preceding stories.
+	 * Flag that shows whether this statement overwrites own transaction
+	 * statement. For example if a transaction makes two replaces of the
+	 * same key, the second statement will be with is_own_change = true.
+	 * Or if a transaction deletes some key and then inserts that key,
+	 * the insertion statement will be with is_own_change = true.
 	 */
-	bool is_pure_insert;
+	bool is_own_change;
 	/**
 	* Request type - IPROTO type code
 	*/

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -301,19 +301,6 @@ struct txn_stmt {
 	struct xrow_header *row;
 	/** on_commit and/or on_rollback list is not empty. */
 	bool has_triggers;
-	/**
-	 * Whether the stmt requires to replace exactly old_tuple (member).
-	 * That flag is needed for transactional conflict manager - if any
-	 * other transaction commits a replacement of old_tuple before current
-	 * one and the flag is set - the current transaction will be aborted.
-	 * For example REPLACE just replaces a key, no matter what tuple
-	 * lays in the index and thus does_require_old_tuple = false.
-	 * In contrast, UPDATE makes new tuple using old_tuple and thus
-	 * the statement will require old_tuple (does_require_old_tuple = true).
-	 * INSERT also does_require_old_tuple = true because it requires
-	 * old_tuple to be NULL.
-	 */
-	bool does_require_old_tuple;
 	/*
 	 * `insert` statement is guaranteed not to delete anything
 	 * from the transaction's point of view (i.e., there was a preceding

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -46,8 +46,12 @@ extern "C" {
 /** box statistics */
 extern struct rmean *rmean_box;
 
-/** Last prepare-sequence-number that was assigned to prepared TX. */
-extern int64_t txn_last_psn;
+/**
+ * Incremental counter for psn (prepare sequence number) of a transaction.
+ * The next prepared transaction will get psn == txn_next_psn++.
+ * See also struct txn::psn.
+ */
+extern int64_t txn_next_psn;
 
 struct journal_entry;
 struct engine;
@@ -109,7 +113,14 @@ enum {
 	 * Maximum recursion depth for on_replace triggers.
 	 * Large numbers may corrupt C stack.
 	 */
-	TXN_SUB_STMT_MAX = 3
+	TXN_SUB_STMT_MAX = 3,
+	/**
+	 * The minimal PSN (prepare sequence number) that can be assigned to a
+	 * prepared transaction (see struct txn::psn). All values below this
+	 * threshold can be used by a transaction manager as values with
+	 * special meaning that no real transaction can have.
+	 */
+	TXN_MIN_PSN = 2,
 };
 
 enum {

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -511,10 +511,8 @@ struct txn {
 	struct rlist read_set;
 	/** List of point hole reads. @sa struct point_hole_item. */
 	struct rlist point_holes_list;
-	/** List of gap reads. @sa struct gap_item. */
+	/** List of gap reads. @sa struct inplace_gap_item / nearby_gap_item. */
 	struct rlist gap_list;
-	/** List of full scans. @sa struct full_scan_item. */
-	struct rlist full_scan_list;
 	/** Link in tx_manager::all_txs. */
 	struct rlist in_all_txs;
 	/** True in case transaction provides any DDL change. */

--- a/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
+++ b/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
@@ -14,7 +14,6 @@ local SIZE_OF_TUPLE = 9
 local SIZE_OF_XROW = 147
 -- Tracker can allocate additional memory, be careful!
 local SIZE_OF_READ_TRACKER = 56
-local SIZE_OF_CONFLICT_TRACKER = 48
 local SIZE_OF_POINT_TRACKER = 88
 local SIZE_OF_GAP_TRACKER = 80
 
@@ -365,7 +364,7 @@ g.test_conflict = function()
     g.server:eval('tx1("s:get(1)")')
     g.server:eval('tx2("s:replace{1, 2}")')
     g.server:eval("box.internal.memtx_tx_gc(10)")
-    local trackers_used = SIZE_OF_CONFLICT_TRACKER + SIZE_OF_POINT_TRACKER
+    local trackers_used = SIZE_OF_READ_TRACKER + SIZE_OF_POINT_TRACKER
     local diff = {
         ["txn"] = {
             ["statements"] = {

--- a/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
+++ b/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
@@ -15,7 +15,8 @@ local SIZE_OF_XROW = 147
 -- Tracker can allocate additional memory, be careful!
 local SIZE_OF_READ_TRACKER = 48
 local SIZE_OF_POINT_TRACKER = 88
-local SIZE_OF_GAP_TRACKER = 80
+local SIZE_OF_INPLACE_GAP_TRACKER = 48
+local SIZE_OF_NEARBY_GAP_TRACKER = 88
 
 local current_stat = {}
 
@@ -327,7 +328,7 @@ g.test_tracker = function()
     g.server:eval('tx1 = txn_proxy.new()')
     g.server:eval('tx1:begin()')
     g.server:eval('tx1("s:select{2}")')
-    local trackers_used = 2 * SIZE_OF_GAP_TRACKER + SIZE_OF_READ_TRACKER
+    local trackers_used = 2 * SIZE_OF_NEARBY_GAP_TRACKER + SIZE_OF_READ_TRACKER
     local diff = {
         ["mvcc"] = {
             ["trackers"] = {
@@ -408,7 +409,7 @@ g.test_conflict = function()
     g.server:eval("box.internal.memtx_tx_gc(10)")
     -- Note that we have subtract the previous value of trackers_used
     -- because point trackers are freed and we need negative diff for them.
-    trackers_used = SIZE_OF_GAP_TRACKER - trackers_used
+    trackers_used = SIZE_OF_INPLACE_GAP_TRACKER - trackers_used
     local diff = {
         ["txn"] = {
             ["statements"] = {

--- a/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
+++ b/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
@@ -13,7 +13,7 @@ local SIZE_OF_TUPLE = 9
 -- Size of xrow for tuples with 2 number fields
 local SIZE_OF_XROW = 147
 -- Tracker can allocate additional memory, be careful!
-local SIZE_OF_READ_TRACKER = 56
+local SIZE_OF_READ_TRACKER = 48
 local SIZE_OF_POINT_TRACKER = 88
 local SIZE_OF_GAP_TRACKER = 80
 
@@ -403,12 +403,12 @@ g.test_conflict = function()
     }
     tx_gc(g.server, 10, diff)
 
-    -- Test that hole point tracker was replaced by normal read tracker.
+    -- Test that hole point tracker was replaced by gap read tracker.
     g.server:eval('tx2("s:replace{1, 2}")')
     g.server:eval("box.internal.memtx_tx_gc(10)")
     -- Note that we have subtract the previous value of trackers_used
     -- because point trackers are freed and we need negative diff for them.
-    trackers_used = SIZE_OF_READ_TRACKER - trackers_used
+    trackers_used = SIZE_OF_GAP_TRACKER - trackers_used
     local diff = {
         ["txn"] = {
             ["statements"] = {

--- a/test/box-luatest/gh_8326_mvcc_lost_gap_record_test.lua
+++ b/test/box-luatest/gh_8326_mvcc_lost_gap_record_test.lua
@@ -1,0 +1,72 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new{
+        alias   = 'default',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:drop()
+end)
+
+g.before_each(function()
+    g.server:exec(function()
+        local s = box.schema.space.create('s')
+        s:create_index('pk', {parts = {{1, 'uint'}, {2, 'uint'}}})
+        s:create_index('sk', {type = 'hash', parts = {{2, 'uint'}}})
+    end)
+end)
+
+g.after_each(function()
+    g.server:exec(function()
+        box.space.s:drop()
+    end)
+end)
+
+g.test_lost_gap_record = function()
+    g.server:exec(function()
+        local txn_proxy = require("test.box.lua.txn_proxy")
+
+        local tx1 = txn_proxy.new()
+        local tx2 = txn_proxy.new()
+        tx1:begin()
+        tx2:begin()
+
+        tx1('box.space.s:select{1}') -- select by partial key {1}, empty result
+        tx1('box.space.s:replace{1, 1, 1}') -- write right to selected
+
+        tx2('box.space.s:replace{1, 1, 2}') -- overwrite by the second TX
+        tx2:commit() -- ok, now tx1 must become conflicted because of select{1}
+
+        t.assert_equals(tx1:commit(),
+                        {{error = "Transaction has been aborted by conflict"}})
+        t.assert_equals(box.space.s:select{1}, {{1, 1, 2}})
+    end)
+end
+
+g.test_lost_full_scan_record = function()
+    g.server:exec(function()
+        local txn_proxy = require("test.box.lua.txn_proxy")
+
+        local tx1 = txn_proxy.new()
+        local tx2 = txn_proxy.new()
+        tx1:begin()
+        tx2:begin()
+
+        tx1('box.space.s.index.sk:select{}') -- secondary fullscan, empty result
+        tx1('box.space.s:replace{1, 1, 1}') -- write to selected
+
+        tx2('box.space.s:replace{1, 1, 2}') -- overwrite by the second TX
+        tx2:commit() -- ok, now tx1 must become conflicted because of select{1}
+
+        t.assert_equals(tx1:commit(),
+                        {{error = "Transaction has been aborted by conflict"}})
+        t.assert_equals(box.space.s:select{1}, {{1, 1, 2}})
+    end)
+end

--- a/test/box-luatest/gh_8648_memtx_mvcc_rollback_prepared_test.lua
+++ b/test/box-luatest/gh_8648_memtx_mvcc_rollback_prepared_test.lua
@@ -1,0 +1,157 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new{
+        alias   = 'default',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.before_each(function(cg)
+    cg.server:exec(function()
+        box.schema.create_space('test'):create_index('pk')
+    end)
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        box.space.test:drop()
+    end)
+end)
+
+-- Test that ensures that rollback of prepared works correctly.
+-- Case when there was a tuple before transactions.
+g.test_rollback_prepared_simple_with_tuple = function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server:exec(function()
+        box.space.test:create_index('sk', {parts={{2}}})
+        local txn_proxy = require("test.box.lua.txn_proxy")
+
+        box.space.test:replace{1, 0, 0}
+
+        local tx1 = txn_proxy.new()
+        tx1:begin()
+        tx1('box.space.test:replace{1, 1, 1}')
+        -- {1, 0, 0} is invisible since it is replaced by {1, 1, 1}
+        t.assert_equals(tx1('box.space.test.index.sk:select{0}'), {{}})
+
+        local tx2 = txn_proxy.new()
+        tx2:begin()
+        tx2('box.space.test:replace{1, 2, 2}')
+
+        -- Prepare and rollback tx2.
+        box.error.injection.set('ERRINJ_WAL_WRITE', true)
+        tx2:commit()
+        box.error.injection.set('ERRINJ_WAL_WRITE', false)
+
+        -- {1, 0, 0} must remain invisible since it is replaced by {1, 1, 1}
+        t.assert_equals(tx1('box.space.test.index.sk:select{0}'), {{}})
+        -- Must be successful
+        t.assert_equals(tx1:commit(), "")
+    end)
+end
+
+-- Test that ensures that rollback of prepared works correctly.
+-- Case when there were no tuple before transactions.
+g.test_rollback_prepared_simple_without_tuple = function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server:exec(function()
+        box.space.test:create_index('sk', {parts={{2}}})
+        local txn_proxy = require("test.box.lua.txn_proxy")
+
+        local tx1 = txn_proxy.new()
+        tx1:begin()
+        tx1('box.space.test:replace{11, 21}')
+
+        local tx2 = txn_proxy.new()
+        tx2:begin()
+        tx2('box.space.test:replace{11, 22}')
+
+        -- Prepare and rollback tx2.
+        box.error.injection.set('ERRINJ_WAL_WRITE', true)
+        tx2:commit()
+        box.error.injection.set('ERRINJ_WAL_WRITE', false)
+
+        tx1:rollback()
+
+        -- Nothing of the above must be visible since everything is rollbacked.
+        t.assert_equals(box.space.test.index.pk:select{11}, {})
+        t.assert_equals(box.space.test.index.sk:select{21}, {})
+        t.assert_equals(box.space.test.index.sk:select{22}, {})
+    end)
+end
+
+-- Test that ensures that rollback of prepared works correctly.
+-- Case with rollback of prepared DELETE statement.
+g.test_rollback_prepared_simple_delete = function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server:exec(function()
+        box.space.test:create_index('sk', {parts={{2}}})
+        local txn_proxy = require("test.box.lua.txn_proxy")
+
+        box.space.test:replace{21, 30}
+        local tx1 = txn_proxy.new()
+        tx1:begin()
+        tx1('box.space.test:replace{21, 31}')
+        -- tx1 must overwrite {21, 30}.
+        t.assert_equals(tx1('box.space.test.index.sk:select{30}'), {{}})
+
+        local tx2 = txn_proxy.new()
+        tx2:begin()
+        tx2('box.space.test:delete{21}')
+
+        -- Prepare and rollback tx2.
+        box.error.injection.set('ERRINJ_WAL_WRITE', true)
+        tx2:commit()
+        box.error.injection.set('ERRINJ_WAL_WRITE', false)
+
+        -- tx1 must continue to overwrite {21, 30}.
+        t.assert_equals(tx1('box.space.test.index.sk:select{30}'), {{}})
+
+        tx1:rollback()
+    end)
+end
+
+-- The first test from issue.
+g.test_rollback_prepared_complicated = function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server:exec(function()
+        local txn_proxy = require("test.box.lua.txn_proxy")
+
+        box.space.test:replace{1, 1, 1}
+
+        -- tx1 is made just for preventing further GC of {1, 1, 1} story.
+        local tx1 = txn_proxy.new()
+        tx1:begin()
+        tx1('box.space.test:select{1}') -- {1, 1, 1}
+
+        box.space.test:delete{1} -- tx1 goes to read view and owns {1, 1, 1}
+
+        local tx2 = txn_proxy.new()
+        tx2:begin()
+        tx2('box.space.test:replace{1, 2, 2}')
+
+        local tx3 = txn_proxy.new()
+        tx3:begin()
+        tx3('box.space.test:replace{1, 3, 3}')
+
+        -- Prepare and rollback tx2.
+        box.error.injection.set('ERRINJ_WAL_WRITE', true)
+        t.assert_equals(tx2:commit(), {{error = "Failed to write to disk"}})
+        box.error.injection.set('ERRINJ_WAL_WRITE', false)
+
+        -- Must be OK
+        t.assert_equals(tx3:rollback(), "")
+
+        -- Must return {}
+        t.assert_equals(box.space.test:select{1}, {})
+    end)
+end

--- a/test/box/tx_man.result
+++ b/test/box/tx_man.result
@@ -165,6 +165,74 @@ s:select{}
  | - - [1, 2]
  | ...
 
+-- Insert read/write conflicts.
+s:delete{1}
+ | ---
+ | - [1, 2]
+ | ...
+tx1:begin()
+ | ---
+ | - 
+ | ...
+tx2:begin()
+ | ---
+ | - 
+ | ...
+tx1('s:insert{1, 1}')
+ | ---
+ | - - [1, 1]
+ | ...
+tx2('s:insert{1, 2}')
+ | ---
+ | - - [1, 2]
+ | ...
+tx1:commit()
+ | ---
+ | - 
+ | ...
+tx2:commit()
+ | ---
+ | - - {'error': 'Transaction has been aborted by conflict'}
+ | ...
+s:select{}
+ | ---
+ | - - [1, 1]
+ | ...
+
+-- Insert read/write conflicts, different order.
+s:delete{1}
+ | ---
+ | - [1, 1]
+ | ...
+tx1:begin()
+ | ---
+ | - 
+ | ...
+tx2:begin()
+ | ---
+ | - 
+ | ...
+tx1('s:insert{1, 1}')
+ | ---
+ | - - [1, 1]
+ | ...
+tx2('s:insert{1, 2}')
+ | ---
+ | - - [1, 2]
+ | ...
+tx2:commit() -- note that tx2 commits first.
+ | ---
+ | - 
+ | ...
+tx1:commit()
+ | ---
+ | - - {'error': 'Transaction has been aborted by conflict'}
+ | ...
+s:select{}
+ | ---
+ | - - [1, 2]
+ | ...
+
 -- Implicit read/write conflicts.
 s:replace{1, 0}
  | ---

--- a/test/box/tx_man.test.lua
+++ b/test/box/tx_man.test.lua
@@ -54,6 +54,26 @@ tx2:commit() -- note that tx2 commits first.
 tx1:commit()
 s:select{}
 
+-- Insert read/write conflicts.
+s:delete{1}
+tx1:begin()
+tx2:begin()
+tx1('s:insert{1, 1}')
+tx2('s:insert{1, 2}')
+tx1:commit()
+tx2:commit()
+s:select{}
+
+-- Insert read/write conflicts, different order.
+s:delete{1}
+tx1:begin()
+tx2:begin()
+tx1('s:insert{1, 1}')
+tx2('s:insert{1, 2}')
+tx2:commit() -- note that tx2 commits first.
+tx1:commit()
+s:select{}
+
 -- Implicit read/write conflicts.
 s:replace{1, 0}
 tx1:begin()

--- a/test/engine-luatest/gh_8654_memtx_mvcc_abort_readers_of_prepared_test.lua
+++ b/test/engine-luatest/gh_8654_memtx_mvcc_abort_readers_of_prepared_test.lua
@@ -1,0 +1,86 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local pg = t.group(nil, t.helpers.matrix({engine = {'memtx', 'vinyl'},
+                                          idx = {0, 1}}))
+
+pg.before_all(function(cg)
+    cg.server = server:new{
+        alias   = 'default',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    cg.server:start()
+end)
+
+pg.after_all(function(cg)
+    cg.server:drop()
+end)
+
+pg.before_each(function(cg)
+    cg.server:exec(function(engine)
+        local s = box.schema.create_space('test', {engine = engine})
+        s:create_index('pk')
+        s:create_index('sk', {parts = {{2, 'uint'}}})
+    end, {cg.params.engine})
+end)
+
+pg.after_each(function(cg)
+    cg.server:exec(function()
+        box.space.test:drop()
+    end)
+end)
+
+-- Check that if transaction with insertion is prepared and then aborted,
+-- its readers are aborted too.
+pg.test_abort_readers_of_insertion = function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server:exec(function(idx)
+        local txn_proxy = require('test.box.lua.txn_proxy')
+        local fiber = require('fiber')
+
+        local tx1 = txn_proxy.new()
+        local tx2 = txn_proxy.new()
+        tx1:begin()
+        tx2:begin()
+        tx1('box.space.test:replace{1, 1}')
+        tx2('box.space.test:replace{2, 2}')
+        box.error.injection.set('ERRINJ_WAL_WRITE', true)
+        local fib = fiber.create(tx1.commit, tx1)
+        fib:set_joinable(true)
+        -- select by any index must read {1, 1} and lead to the same behavior.
+        t.assert_equals(tx2('box.space.test.index[' .. idx ..']:select{1}'),
+                        {{{1, 1}}})
+        fib:join()
+        box.error.injection.set('ERRINJ_WAL_WRITE', false)
+        t.assert_equals(tx2:commit(),
+                        {{error = "Transaction has been aborted by conflict"}})
+    end, {cg.params.idx})
+end
+
+-- Check that if transaction with deletion is prepared and then aborted,
+-- its readers are aborted too.
+pg.test_abort_readers_of_deletion = function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server:exec(function(idx)
+        local txn_proxy = require('test.box.lua.txn_proxy')
+        local fiber = require('fiber')
+
+        box.space.test:replace{1, 1}
+        local tx1 = txn_proxy.new()
+        local tx2 = txn_proxy.new()
+        tx1:begin()
+        tx2:begin()
+        tx1('box.space.test:delete{1}')
+        tx2('box.space.test:replace{2, 2}')
+        box.error.injection.set('ERRINJ_WAL_WRITE', true)
+        local fib = fiber.create(tx1.commit, tx1)
+        fib:set_joinable(true)
+        -- select by any index must read {} and lead to the same behavior.
+        t.assert_equals(tx2('box.space.test.index[' .. idx ..']:select{1}'),
+                        {{}})
+        fib:join()
+        box.error.injection.set('ERRINJ_WAL_WRITE', false)
+        t.assert_equals(tx2:commit(),
+                        {{error = "Transaction has been aborted by conflict"}})
+    end, {cg.params.idx})
+end


### PR DESCRIPTION
A huge refactoring of MVCC engine.

Closes https://github.com/tarantool/tarantool/issues/8654
Closes https://github.com/tarantool/tarantool/issues/8648
Closes https://github.com/tarantool/tarantool/issues/8326

(backport from master).