### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-8516-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8516-luajit-fixes.md
@@ -4,3 +4,4 @@ Backported patches from the vanilla LuaJIT trunk (gh-8516). The following issues
 were fixed as part of this activity:
 
 * Fixed `IR_LREF` assembling for the GC64 mode on x86_64.
+* Fixed `lua_yield()` invocation inside C hooks.


### PR DESCRIPTION
* Fix lua_yield() from C hook.
* Another fix for lua_yield() from C hook.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump