### PR TITLE
misc: get rid of small _xc functions

### DIFF
--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -655,8 +655,10 @@ public:
 
 	void *operator new(size_t size)
 	{
-		return region_aligned_calloc_xc(&in_txn()->region, size,
-						alignof(uint64_t));
+		void *ptr = xregion_aligned_alloc(&in_txn()->region, size,
+						  alignof(uint64_t));
+		memset(ptr, 0, size);
+		return ptr;
 	}
 	void operator delete(void * /* ptr */) {}
 };

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3841,7 +3841,7 @@ space_truncate(struct space *space)
 	size_t buf_size = 3 * mp_sizeof_array(UINT32_MAX) +
 			  4 * mp_sizeof_uint(UINT64_MAX) + mp_sizeof_str(1);
 	RegionGuard region_guard(&fiber()->gc);
-	char *buf = (char *)region_alloc_xc(&fiber()->gc, buf_size);
+	char *buf = (char *)xregion_alloc(&fiber()->gc, buf_size);
 
 	char *tuple_buf = buf;
 	char *tuple_buf_end = tuple_buf;

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -1043,7 +1043,7 @@ iproto_connection_input_buffer(struct iproto_connection *con)
 	 * (in only has unparsed content).
 	 */
 	if (ibuf_used(old_ibuf) == con->parse_size) {
-		ibuf_reserve_xc(old_ibuf, to_read);
+		xibuf_reserve(old_ibuf, to_read);
 		return old_ibuf;
 	}
 
@@ -1061,7 +1061,7 @@ iproto_connection_input_buffer(struct iproto_connection *con)
 		ibuf_create(new_ibuf, cord_slab_cache(), iproto_readahead);
 	}
 
-	ibuf_reserve_xc(new_ibuf, to_read + con->parse_size);
+	xibuf_reserve(new_ibuf, to_read + con->parse_size);
 	/*
 	 * Discard unparsed data in the old buffer, otherwise it
 	 * won't be recycled when all parsed requests are processed.
@@ -2465,7 +2465,7 @@ tx_process_misc(struct cmsg *m)
 					      msg->watch.key_len, &data_end);
 			if (iproto_prepare_select(out, &header) != 0)
 				diag_raise();
-			obuf_dup_xc(out, data, data_end - data);
+			xobuf_dup(out, data, data_end - data);
 			iproto_reply_select(out, &header, msg->header.sync,
 					    ::schema_version,
 					    data != NULL ? 1 : 0);
@@ -2845,7 +2845,7 @@ tx_process_connect(struct cmsg *m)
 		random_bytes(con->salt, IPROTO_SALT_SIZE);
 		greeting_encode(greeting, tarantool_version_id(), &uuid,
 				con->salt, IPROTO_SALT_SIZE);
-		obuf_dup_xc(out, greeting, IPROTO_GREETING_SIZE);
+		xobuf_dup(out, greeting, IPROTO_GREETING_SIZE);
 		if (! rlist_empty(&session_on_connect)) {
 			if (session_run_on_connect_triggers(con->session) != 0)
 				diag_raise();

--- a/src/box/user.h
+++ b/src/box/user.h
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include "user_def.h"
 #include "small/region.h"
+#include "diag.h"
 
 #if defined(__cplusplus)
 extern "C" {

--- a/src/lib/core/coio_buf.h
+++ b/src/lib/core/coio_buf.h
@@ -46,7 +46,7 @@ struct iostream;
 static inline ssize_t
 coio_bread(struct iostream *io, struct ibuf *buf, size_t sz)
 {
-	ibuf_reserve_xc(buf, sz);
+	xibuf_reserve(buf, sz);
 	ssize_t n = coio_read_ahead(io, buf->wpos, sz, ibuf_unused(buf));
 	if (n < 0)
 		diag_raise();
@@ -63,7 +63,7 @@ static inline ssize_t
 coio_bread_timeout(struct iostream *io, struct ibuf *buf, size_t sz,
 		   ev_tstamp timeout)
 {
-	ibuf_reserve_xc(buf, sz);
+	xibuf_reserve(buf, sz);
 	ssize_t n = coio_read_ahead_timeout(io, buf->wpos, sz, ibuf_unused(buf),
 			                    timeout);
 	if (n < 0)
@@ -76,7 +76,7 @@ coio_bread_timeout(struct iostream *io, struct ibuf *buf, size_t sz,
 static inline ssize_t
 coio_breadn(struct iostream *io, struct ibuf *buf, size_t sz)
 {
-	ibuf_reserve_xc(buf, sz);
+	xibuf_reserve(buf, sz);
 	ssize_t n = coio_readn_ahead(io, buf->wpos, sz, ibuf_unused(buf));
 	if (n < 0)
 		diag_raise();
@@ -94,7 +94,7 @@ static inline ssize_t
 coio_breadn_timeout(struct iostream *io, struct ibuf *buf, size_t sz,
 		    ev_tstamp timeout)
 {
-	ibuf_reserve_xc(buf, sz);
+	xibuf_reserve(buf, sz);
 	ssize_t n = coio_readn_ahead_timeout(io, buf->wpos, sz, ibuf_unused(buf),
 			                     timeout);
 	if (n < 0)

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -45,6 +45,7 @@
 #include "salad/stailq.h"
 #include "clock_lowres.h"
 #include "backtrace.h"
+#include "exception.h"
 
 #include <coro/coro.h>
 


### PR DESCRIPTION
Small library currently depends on Tarantool core thru 'exception.h'. This is not the way to go. Let's drop this dependency and instead of moving _xc functions to Tarantool repo we can just stop using them. Our current policy is to panic on OOM in case of runtime allocation.

Part of #7327