### PR TITLE
box: switch to normal streaming compression API of ZSTD

### DIFF
--- a/changelogs/unreleased/gh-8537-bump-zstd.md
+++ b/changelogs/unreleased/gh-8537-bump-zstd.md
@@ -1,0 +1,3 @@
+## feature/build
+
+* Updated `zstd` to version 1.5.5 (gh-8537).


### PR DESCRIPTION
Closes #8537
Follows up #8391

Note: tarantool/tarantool-ee does not use the streaming compression API of zstd, so we don't need to patch it.