### PR TITLE
config: rework the way the meta is populated

### DIFF
--- a/src/box/lua/config/source/env.lua
+++ b/src/box/lua/config/source/env.lua
@@ -26,10 +26,6 @@ local function get()
     return values
 end
 
-local function meta()
-    return nil
-end
-
 return {
     name = 'env',
     -- The type is either 'instance' or 'cluster'.
@@ -40,6 +36,4 @@ return {
     --
     -- source.get()
     get = get,
-    -- Metadata of the current configuration from the source.
-    meta = meta,
 }

--- a/src/box/lua/config/source/file.lua
+++ b/src/box/lua/config/source/file.lua
@@ -75,10 +75,6 @@ local function get()
     return values
 end
 
-local function meta()
-    return nil
-end
-
 return {
     name = 'file',
     -- The type is either 'instance' or 'cluster'.
@@ -89,6 +85,4 @@ return {
     --
     -- source.get()
     get = get,
-    -- Metadata of the current configuration from the source.
-    meta = meta,
 }


### PR DESCRIPTION
This patch reworks the way the meta is populated. This is done to incrementally populate the metadata, instead of set the metadata at the end of reading data from the source. This allows to get the correct meta in cases where getting data from the source failed.

Follow-up #8789