### PR TITLE
memtx: fix heap-use-after-free of tuple stories caused by space alter

### DIFF
--- a/changelogs/unreleased/gh-8781-heap-use-after-free-in-memtx-tx-delete-gap.md
+++ b/changelogs/unreleased/gh-8781-heap-use-after-free-in-memtx-tx-delete-gap.md
@@ -1,0 +1,5 @@
+## bugfix/memtx
+
+* Fixed a heap-use-after-free bug in the transaction manager, which could occur
+  when performing a DDL operation concurrently with a transaction on the same
+  space (gh-8781).


### PR DESCRIPTION
When a space is altered, we abort all in-progress transactions and delete all stories related to that space: the problem is we don't delete the stories' read gaps, which are also linked to the stories' transactions, which get cleaned up on transaction destruction — this, in turn, results in heap-use-after-free. To fix this, clean up stories' read gap in `memtx_on_space_delete` — we don't do this in `memtx_tx_story_delete` since it expects the story to not have any read gaps (see `memtx_tx_story_gc_step`).

Tested this patch manually against Nick Shirokovskiy's experimental small-ASAN integration branch.

Closes #8781

NO_DOC=bugfix
NO_TEST=<already covered by existing tests, but was not detectable by ASAN>

(cherry picked from commit e1ed31bbe450c775d48d27055434cdd527338500)