### PR TITLE
box: use format data instead of field def array in space read view

### DIFF
--- a/src/box/read_view.c
+++ b/src/box/read_view.c
@@ -75,8 +75,7 @@ static void
 space_read_view_delete(struct space_read_view *space_rv)
 {
 	assert(space_rv->format == NULL);
-	if (space_rv->field_count > 0)
-		field_def_array_delete(space_rv->fields, space_rv->field_count);
+	free(space_rv->format_data);
 	for (uint32_t i = 0; i <= space_rv->index_id_max; i++) {
 		struct index_read_view *index_rv = space_rv->index_map[i];
 		if (index_rv != NULL) {
@@ -108,14 +107,15 @@ space_read_view_new(struct space *space, const struct read_view_opts *opts)
 
 	space_rv->id = space_id(space);
 	space_rv->group_id = space_group_id(space);
-	if (opts->enable_field_names && space->def->field_count > 0) {
-		space_rv->fields = field_def_array_dup(space->def->fields,
-						       space->def->field_count);
-		assert(space_rv->fields != NULL);
-		space_rv->field_count = space->def->field_count;
+	if (opts->enable_field_names &&
+	    space->def->format_data != NULL) {
+		space_rv->format_data = xmalloc(space->def->format_data_len);
+		memcpy(space_rv->format_data, space->def->format_data,
+		       space->def->format_data_len);
+		space_rv->format_data_len = space->def->format_data_len;
 	} else {
-		space_rv->fields = NULL;
-		space_rv->field_count = 0;
+		space_rv->format_data = NULL;
+		space_rv->format_data_len = 0;
 	}
 	space_rv->format = NULL;
 	if (opts->enable_space_upgrade && space->upgrade != NULL) {

--- a/src/box/read_view.h
+++ b/src/box/read_view.h
@@ -35,13 +35,14 @@ struct space_read_view {
 	/** Space name. */
 	char *name;
 	/**
-	 * Tuple field definition array used by this space. Allocated only if
+	 * Tuple format data used by this space. Allocated only if
 	 * read_view_opts::enable_field_names is set, otherwise set to NULL.
-	 * Used for creation of space_read_view::format.
+	 * Used for creation of space_read_view::format and
+	 * box_raw_read_view_space::fields.
 	 */
-	struct field_def *fields;
-	/** Number of entries in the fields array. */
-	uint32_t field_count;
+	char *format_data;
+	/** Length of tuple format data. */
+	size_t format_data_len;
 	/**
 	 * Runtime tuple format needed to access tuple field names by name.
 	 * Referenced (ref counter incremented).


### PR DESCRIPTION
See also EE-part: tarantool/tarantool-ee#489.

Follows-up #4693