### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-8516-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8516-luajit-fixes.md
@@ -4,3 +4,10 @@ Backported patches from the vanilla LuaJIT trunk (gh-8516). The following issues
 were fixed as part of this activity:
 
 * Fixed `IR_LREF` assembling for the GC64 mode on x86_64.
+* Fixed canonicalization of +-0.0 keys for `IR_NEWREF`.
+* Fixed result truncation for `bit.rol` on x86_64 platforms.
+* Fixed saved bytecode encapsulated in ELF objects.
+* Fixed `lua_yield()` invocation inside C hooks.
+* Fixed memory chunk allocation beyond the memory limit.
+* Fixed TNEW load forwarding with instable types.
+* Fixed use-def analysis for `BC_VARG`, `BC_FUNCV`.


### PR DESCRIPTION
* test: fix flaky <unit-jit-parse.test.lua>
* Fix use-def analysis for vararg functions.
* Fix use-def analysis for BC_VARG.
* Fix TNEW load forwarding with instable types.
* Fix memory probing allocator to check for valid end address, too.
* Another fix for lua_yield() from C hook.
* Fix lua_yield() from C hook.
* Fix saved bytecode encapsulated in ELF objects.
* x64: Fix 64 bit shift code generation.
* Fix canonicalization of +-0.0 keys for IR_NEWREF.
* test: add utility for parsing `jit.dump`
* test: split utils.lua into several modules
* test: rewrite lj-49-bad-lightuserdata test in C
* test: rewrite misclib-sysprof-capi test in C
* test: rewrite misclib-getmetrics-capi test in C
* test: introduce utils.h helper for C tests
* test: introduce module for C tests
* test: fix setting of {DY}LD_LIBRARY_PATH variables
* build: fix build with LUAJIT_USE_GDBJIT enabled

Closes #8718
Part of #7900
Part of #8516

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump
