### PR TITLE
sql: remove one row limit in EXISTS subquery

### DIFF
--- a/changelogs/unreleased/gh-8676-fix-exists-predicate.md
+++ b/changelogs/unreleased/gh-8676-fix-exists-predicate.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* The `EXISTS` predicate no longer requires `LIMIT 1` to work correctly if more
+  than one row is returned in the subselect (gh-8676).

--- a/test/sql-luatest/gh_8676_exists_in_multiselect_test.lua
+++ b/test/sql-luatest/gh_8676_exists_in_multiselect_test.lua
@@ -1,0 +1,20 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_exists = function()
+    g.server:exec(function()
+        local res = box.execute([[SELECT EXISTS (VALUES (1), (2));]])
+        t.assert_equals(res.rows, {{true}})
+    end)
+end

--- a/test/sql-tap/tkt1473.test.lua
+++ b/test/sql-tap/tkt1473.test.lua
@@ -199,14 +199,14 @@ test:do_execsql_test(
         -- </tkt1473-2.9>
     })
 
-test:do_catchsql_test(
+test:do_execsql_test(
     "tkt1473-3.2",
     [[
         SELECT EXISTS
           (SELECT 1 FROM t1 WHERE a=1 UNION ALL SELECT 2 FROM t1 WHERE b=0)
     ]], {
         -- <tkt1473-3.2>
-        1, "Failed to execute SQL statement: Expression subquery returned more than 1 row"
+        true
         -- </tkt1473-3.2>
     })
 
@@ -221,36 +221,36 @@ test:do_execsql_test(
         -- </tkt1473-3.3>
     })
 
-test:do_catchsql_test(
+test:do_execsql_test(
     "tkt1473-3.4",
     [[
         SELECT EXISTS
           (SELECT 1 FROM t1 WHERE a=1 UNION ALL SELECT 2 FROM t1 WHERE b=4)
     ]], {
         -- <tkt1473-3.4>
-        1, "Failed to execute SQL statement: Expression subquery returned more than 1 row"
+        true
         -- </tkt1473-3.4>
     })
 
-test:do_catchsql_test(
+test:do_execsql_test(
     "tkt1473-3.5",
     [[
         SELECT EXISTS
           (SELECT 1 FROM t1 WHERE a=1 UNION SELECT 2 FROM t1 WHERE b=4)
     ]], {
         -- <tkt1473-3.5>
-        1, "Failed to execute SQL statement: Expression subquery returned more than 1 row"
+        true
         -- </tkt1473-3.5>
     })
 
-test:do_catchsql_test(
+test:do_execsql_test(
     "tkt1473-3.6",
     [[
         SELECT EXISTS
           (SELECT 1 FROM t1 WHERE a=0 UNION ALL SELECT 2 FROM t1 WHERE b=4)
     ]], {
         -- <tkt1473-3.6>
-        1, "Failed to execute SQL statement: Expression subquery returned more than 1 row"
+        true
         -- </tkt1473-3.6>
     })
 
@@ -483,7 +483,7 @@ test:do_execsql_test(
         -- </tkt1473-4.7>
     })
 
-test:do_catchsql_test(
+test:do_execsql_test(
     "tkt1473-5.3",
     [[
         SELECT EXISTS (
@@ -509,11 +509,11 @@ test:do_catchsql_test(
         )
     ]], {
         -- <tkt1473-5.3>
-        1, "Failed to execute SQL statement: Expression subquery returned more than 1 row"
+        true
         -- </tkt1473-5.3>
     })
 
-test:do_catchsql_test(
+test:do_execsql_test(
     "tkt1473-5.4",
     [[
         SELECT EXISTS (
@@ -539,11 +539,11 @@ test:do_catchsql_test(
         )
     ]], {
         -- <tkt1473-5.4>
-        1, "Failed to execute SQL statement: Expression subquery returned more than 1 row"
+        true
         -- </tkt1473-5.4>
     })
 
-test:do_catchsql_test(
+test:do_execsql_test(
     "tkt1473-5.5",
     [[
         SELECT EXISTS (
@@ -569,11 +569,11 @@ test:do_catchsql_test(
         )
     ]], {
         -- <tkt1473-5.5>
-        1, "Failed to execute SQL statement: Expression subquery returned more than 1 row"
+        true
         -- </tkt1473-5.5>
     })
 
-test:do_catchsql_test(
+test:do_execsql_test(
     "tkt1473-5.6",
     [[
         SELECT EXISTS (
@@ -599,7 +599,7 @@ test:do_catchsql_test(
         )
     ]], {
         -- <tkt1473-5.6>
-        1, "Failed to execute SQL statement: Expression subquery returned more than 1 row"
+        true
         -- </tkt1473-5.6>
     })
 
@@ -633,7 +633,7 @@ test:do_execsql_test(
         -- </tkt1473-5.7>
     })
 
-test:do_catchsql_test(
+test:do_execsql_test(
     "tkt1473-6.3",
     [[
         SELECT EXISTS (
@@ -659,11 +659,11 @@ test:do_catchsql_test(
         )
     ]], {
         -- <tkt1473-6.3>
-        1, "Failed to execute SQL statement: Expression subquery returned more than 1 row"
+        true
         -- </tkt1473-6.3>
     })
 
-test:do_catchsql_test(
+test:do_execsql_test(
     "tkt1473-6.4",
     [[
         SELECT EXISTS (
@@ -689,7 +689,7 @@ test:do_catchsql_test(
         )
     ]], {
         -- <tkt1473-6.4>
-        1, "Failed to execute SQL statement: Expression subquery returned more than 1 row"
+        true
         -- </tkt1473-6.4>
     })
 


### PR DESCRIPTION
According to ANSI, EXISTS is a predicate that tests a given subquery and returns true if it returns more than 0 rows, false otherwise. However, before this patch, EXISTS worked correctly only if there were exactly 0 or 1 rows, and in all other cases it gave an error. This patch makes EXITS work properly.

Closes #8676

@TarantoolBot document
Title: EXISTS predicate

The EXISTS predicate in SQL is a predicate that returns true if the given SQL subquery returns at least one row, and false otherwise.

Example:
```
SELECT EXISTS(SELECT * FROM (VALUES(1), (2)));
```