### PR TITLE
config: fix error message during reload

### DIFF
--- a/changelogs/unreleased/gh-8861-cluster-config-error-message.md
+++ b/changelogs/unreleased/gh-8861-cluster-config-error-message.md
@@ -1,0 +1,4 @@
+## bugfix/config
+
+* Fixed an error message if the cluster configuration was not provided or the
+  instance was not found in the cluster configuration during reload (gh-8862).

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -192,8 +192,11 @@ function methods._collect(self, opts)
     end
 
     if next(cconfig) == nil then
+        local is_reload = self._status == 'reload_in_progress'
+        local action = is_reload and 'Reload' or 'Startup'
+        local source_info_str = table.concat(source_info, '\n')
         error(dedent([[
-            Startup failure.
+            %s failure.
 
             No cluster config received from the given configuration sources.
 
@@ -208,12 +211,15 @@ function methods._collect(self, opts)
             * Use --config <file> command line option.
             * Use TT_CONFIG_ETCD_* environment variables (available on Tarantool
               Enterprise Edition).
-        ]]):format(table.concat(source_info, '\n'), self._instance_name), 0)
+        ]]):format(action, source_info_str, self._instance_name), 0)
     end
 
     if cluster_config:find_instance(cconfig, self._instance_name) == nil then
+        local is_reload = self._status == 'reload_in_progress'
+        local action = is_reload and 'Reload' or 'Startup'
+        local source_info_str = table.concat(source_info, '\n')
         error(dedent([[
-            Startup failure.
+            %s failure.
 
             Unable to find instance %q in the group/replicaset/instance
             topology provided by the given cluster configuration sources.
@@ -233,7 +239,7 @@ function methods._collect(self, opts)
                       instance-001:
                         database:
                           rw: true
-        ]]):format(self._instance_name, table.concat(source_info, '\n')), 0)
+        ]]):format(action, self._instance_name, source_info_str), 0)
     end
 
     self._configdata = configdata.new(iconfig, cconfig, self._instance_name)

--- a/test/config-luatest/reload_test.lua
+++ b/test/config-luatest/reload_test.lua
@@ -1,0 +1,80 @@
+local t = require('luatest')
+local treegen = require('test.treegen')
+local server = require('test.luatest_helpers.server')
+
+local g = t.group()
+
+g.before_all(function(g)
+    treegen.init(g)
+end)
+
+g.after_all(function(g)
+    treegen.clean(g)
+end)
+
+g.after_each(function()
+    if g.server ~= nil then
+        g.server:stop()
+    end
+end)
+
+g.test_no_cluster_config_failure = function(g)
+    local dir = treegen.prepare_directory(g, {}, {})
+    local config = [[
+        credentials:
+          users:
+            guest:
+              roles:
+              - super
+        iproto:
+          listen: unix/:./{{ instance_name }}.iproto
+        groups:
+          group-001:
+            replicasets:
+              replicaset-001:
+                instances:
+                  instance-001: {}
+    ]]
+    local config_file = treegen.write_script(dir, 'config.yaml', config)
+    local opts = {
+        config_file = config_file,
+        alias = 'instance-001',
+        chdir = dir,
+    }
+    g.server = server:new(opts)
+    g.server:start()
+
+    --
+    -- Make sure that the error starts with "Reload" if the configuration did
+    -- not contain a cluster configuration at the time of the reload.
+    --
+    config = [[{}]]
+    treegen.write_script(dir, 'config.yaml', config)
+    g.server:exec(function()
+        local config = require('config')
+        local ok, err = pcall(config.reload, config)
+        t.assert(not ok)
+        t.assert(string.startswith(err, 'Reload failure.\n\nNo cluster config'))
+    end)
+
+    --
+    -- Make sure that the error starts with "Reload" if the instance was not
+    -- found in the cluster configuration at the time of the reload.
+    --
+    config = [[
+        credentials:
+          users:
+            guest:
+              roles:
+              - super
+        iproto:
+          listen: unix/:./{{ instance_name }}.iproto
+    ]]
+    treegen.write_script(dir, 'config.yaml', config)
+    g.server:exec(function()
+        local config = require('config')
+        local ok, err = pcall(config.reload, config)
+        t.assert(not ok)
+        t.assert(string.startswith(err, 'Reload failure.\n\nUnable to find'))
+    end)
+end


### PR DESCRIPTION
Prior to this patch, if a cluster configuration was not present or an instance was not found in the configuration during a reload, the error would begin with 'Startup failure'. Now it starts with 'Reload failure' in these cases.

Part of https://github.com/tarantool/tarantool/issues/8862