### PR TITLE
config: introduce remaining vinyl options

### DIFF
--- a/changelogs/unreleased/gh-8861-vinyl-options.md
+++ b/changelogs/unreleased/gh-8861-vinyl-options.md
@@ -1,0 +1,3 @@
+## feature/config
+
+* All vinyl options are now supported (gh-8861).

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -717,7 +717,22 @@ return schema.new('instance_config', schema.record({
         }),
     }),
     vinyl = schema.record({
-        -- TODO: vinyl options.
+        bloom_fpr = schema.scalar({
+            type = 'number',
+            box_cfg = 'vinyl_bloom_fpr',
+            box_cfg_nondynamic = true,
+            default = 0.05,
+        }),
+        cache = schema.scalar({
+            type = 'integer',
+            box_cfg = 'vinyl_cache',
+            default = 128 * 1024 * 1024,
+        }),
+        defer_deletes = schema.scalar({
+            type = 'boolean',
+            box_cfg = 'vinyl_defer_deletes',
+            default = false,
+        }),
         dir = schema.scalar({
             type = 'string',
             box_cfg = 'vinyl_dir',
@@ -729,6 +744,52 @@ return schema.new('instance_config', schema.record({
             type = 'integer',
             box_cfg = 'vinyl_max_tuple_size',
             default = 1024 * 1024,
+        }),
+        memory = schema.scalar({
+            type = 'integer',
+            box_cfg = 'vinyl_memory',
+            default = 128 * 1024 * 1024,
+        }),
+        page_size = schema.scalar({
+            type = 'integer',
+            box_cfg = 'vinyl_page_size',
+            box_cfg_nondynamic = true,
+            default = 8 * 1024,
+        }),
+        range_size = schema.scalar({
+            type = 'integer',
+            box_cfg = 'vinyl_range_size',
+            box_cfg_nondynamic = true,
+            default = box.NULL,
+        }),
+        read_threads = schema.scalar({
+            type = 'integer',
+            box_cfg = 'vinyl_read_threads',
+            box_cfg_nondynamic = true,
+            default = 1,
+        }),
+        run_count_per_level = schema.scalar({
+            type = 'integer',
+            box_cfg = 'vinyl_run_count_per_level',
+            box_cfg_nondynamic = true,
+            default = 2,
+        }),
+        run_size_ratio = schema.scalar({
+            type = 'number',
+            box_cfg = 'vinyl_run_size_ratio',
+            box_cfg_nondynamic = true,
+            default = 3.5,
+        }),
+        timeout = schema.scalar({
+            type = 'number',
+            box_cfg = 'vinyl_timeout',
+            default = 60,
+        }),
+        write_threads = schema.scalar({
+            type = 'integer',
+            box_cfg = 'vinyl_write_threads',
+            box_cfg_nondynamic = true,
+            default = 2,
         }),
     }),
     wal = schema.record({

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -162,6 +162,17 @@ g.test_defaults = function()
         vinyl = {
             dir = '{{ instance_name }}',
             max_tuple_size = 1048576,
+            bloom_fpr = 0.05,
+            page_size = 8192,
+            range_size = box.NULL,
+            run_count_per_level = 2,
+            run_size_ratio = 3.5,
+            read_threads = 1,
+            write_threads = 2,
+            cache = 134217728,
+            defer_deletes = false,
+            memory = 134217728,
+            timeout = 60,
         },
         database = {
             instance_uuid = box.NULL,

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -730,6 +730,17 @@ g.test_vinyl = function()
         vinyl = {
             dir = 'one',
             max_tuple_size = 1,
+            bloom_fpr = 0.1,
+            page_size = 123,
+            range_size = 321,
+            run_count_per_level = 11,
+            run_size_ratio = 1.15,
+            read_threads = 7,
+            write_threads = 9,
+            cache = 10,
+            defer_deletes = true,
+            memory = 11,
+            timeout = 5.5,
         },
     }
     instance_config:validate(iconfig)
@@ -738,6 +749,17 @@ g.test_vinyl = function()
     local exp = {
         dir = '{{ instance_name }}',
         max_tuple_size = 1048576,
+        bloom_fpr = 0.05,
+        page_size = 8192,
+        range_size = box.NULL,
+        run_count_per_level = 2,
+        run_size_ratio = 3.5,
+        read_threads = 1,
+        write_threads = 2,
+        cache = 134217728,
+        defer_deletes = false,
+        memory = 134217728,
+        timeout = 60,
     }
     local res = instance_config:apply_default({}).vinyl
     t.assert_equals(res, exp)


### PR DESCRIPTION
This patch introduces all remaining vinyl options that have not been introduced before.

Part of https://github.com/tarantool/tarantool/issues/8861