### PR TITLE
test: run tests in config test suite in parallel

### DIFF
--- a/test/config-luatest/suite.ini
+++ b/test/config-luatest/suite.ini
@@ -1,3 +1,4 @@
 [default]
 core = luatest
 description = declarative configuration tests
+is_parallel = True


### PR DESCRIPTION
All the tests are independent and nothing prevents running them in parallel. The option to enable the parallel running was just forgotten.

Part of #8862