### PR TITLE
test: fix flakiness in gh_5568_read_only_reason

### DIFF
--- a/test/replication-luatest/gh_5568_read_only_reason_test.lua
+++ b/test/replication-luatest/gh_5568_read_only_reason_test.lua
@@ -35,6 +35,7 @@ local function make_create_cluster(g) return function()
     g.cluster:add_server(g.master)
     g.cluster:add_server(g.replica)
     g.cluster:start()
+    g.cluster:wait_for_fullmesh()
 end end
 
 local function make_destroy_cluster(g) return function()


### PR DESCRIPTION
The test has two groups, in front of each of which, a cluster is created. Sometimes, it fails on the first test in every group: either ro_reason is explicitly checked and it equals to `orphan`, not nil, or we try to write to a still read-only instance and get the error, that it's orphan.

The problem is the fact, that we don't wait until the connections are established in a cluster. Let's add waiting for full mesh in cluster creation.

Closes tarantool/tarantool-qa#320

NO_CHANGELOG=test fix
NO_DOC=test fix