### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-8825-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8825-luajit-fixes.md
@@ -1,0 +1,6 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-8825). The following issues
+were fixed as part of this activity:
+
+* Fix recording of `BC_VARG` with unused vararg values.


### PR DESCRIPTION
* Fix maxslots when recording BC_VARG.
* Fix maxslots when recording BC_VARG, part 2.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump