### PR TITLE
Modify CI/CD for static packages

### DIFF
--- a/.github/actions/pack-and-deploy/action.yml
+++ b/.github/actions/pack-and-deploy/action.yml
@@ -10,7 +10,16 @@ runs:
         export PACKPACK_EXTRA_DOCKER_RUN_PARAMS='--init'
 
         # Create packages.
-        make -f .pack.mk package
+        PACKAGE_TARGET=package-static
+        DEPLOY_TARGET=deploy-static
+        if ${{ startsWith(github.base_ref, 'release/2.') ||
+               startsWith(github.ref, 'refs/heads/release/2.') ||
+               startsWith(github.ref, 'refs/tags/2.') }}; then
+          PACKAGE_TARGET=${PACKAGE_TARGET%-static}
+          DEPLOY_TARGET=${DEPLOY_TARGET%-static}
+        fi
+
+        make -f .pack.mk ${PACKAGE_TARGET}
 
         # Deploy pre-release (since 2.10) and release packages. It's expected
         # that no one will push tags are used for pre-releases and releases.
@@ -20,10 +29,10 @@ runs:
           case ${{ github.ref }} in
             # It's relevant since 2.10 only.
             refs/tags/*-alpha*|refs/tags/*-beta*|refs/tags/*-rc*)
-              REPO_TYPE=pre-release make -f .pack.mk deploy
+              REPO_TYPE=pre-release make -f .pack.mk ${DEPLOY_TARGET}
               ;;
             refs/tags/*)
-              REPO_TYPE=release make -f .pack.mk deploy
+              REPO_TYPE=release make -f .pack.mk ${DEPLOY_TARGET}
               ;;
           esac
         fi

--- a/.github/workflows/static_build_packaging.yml
+++ b/.github/workflows/static_build_packaging.yml
@@ -63,7 +63,9 @@ jobs:
       - name: Install deps
         uses: ./.github/actions/install-deps-debian
       - name: Build static packages
-        run: make -f .pack.mk package-static
+        uses: ./.github/actions/pack-and-deploy
+        env:
+          RWS_AUTH: ${{ secrets.RWS_AUTH }}
       - name: Upload build artifacts
         if: github.ref == 'refs/heads/master' ||
             startsWith(github.ref, 'refs/heads/release/') ||

--- a/.github/workflows/static_build_packaging.yml
+++ b/.github/workflows/static_build_packaging.yml
@@ -73,8 +73,8 @@ jobs:
           name: tarantool-deb-rpm-x86_64-aarch64
           retention-days: 21
           path: |
-            static-build/build/tarantool*.deb
-            static-build/build/tarantool*.rpm
+            build/tarantool*.deb
+            build/tarantool*.rpm
           if-no-files-found: error
       - name: Send VK Teams message on failure
         if: failure()

--- a/static-build/make_packages.sh
+++ b/static-build/make_packages.sh
@@ -16,7 +16,7 @@
 # Set default values for variables for successful run on the local machine.
 CMAKE_TARANTOOL_ARGS="${CMAKE_TARANTOOL_ARGS:--DLUAJIT_ENABLE_GC64=ON;-DCMAKE_BUILD_TYPE=RelWithDebInfo}"
 VERSION="${VERSION:-0.0.1}"
-OUTPUT_DIR="${OUTPUT_DIR:-build}"
+OUTPUT_DIR="${OUTPUT_DIR:-$(pwd)/build}"
 
 USER_ID=$(id -u)
 
@@ -25,6 +25,8 @@ echo "CMake args: ${CMAKE_TARANTOOL_ARGS}"
 echo "Package version: ${VERSION}"
 echo "Output dir: ${OUTPUT_DIR}"
 
+mkdir -p ${OUTPUT_DIR}
+
 # Run building in a Docker container with the proper user to get artifacts
 # with the correct permissions. If USER_ID is 0, then run as root. If USER_ID
 # is not 0, then create the 'tarantool' user with the same user's ID as on the
@@ -32,8 +34,9 @@ echo "Output dir: ${OUTPUT_DIR}"
 if [ "${USER_ID}" = "0" ]; then
     docker run --rm --pull=always \
         --env VERSION=${VERSION} \
-        --env OUTPUT_DIR=${OUTPUT_DIR} \
+        --env OUTPUT_DIR=/tarantool/build \
         --volume $(pwd):/tarantool \
+        --volume ${OUTPUT_DIR}:/tarantool/build \
         --workdir /tarantool/static-build/ \
         packpack/packpack:centos-7 sh -c "
             cmake3 -DCMAKE_TARANTOOL_ARGS=\"${CMAKE_TARANTOOL_ARGS}\" &&
@@ -42,8 +45,9 @@ if [ "${USER_ID}" = "0" ]; then
 else
     docker run --rm --pull=always \
         --env VERSION=${VERSION} \
-        --env OUTPUT_DIR=${OUTPUT_DIR} \
+        --env OUTPUT_DIR=/tarantool/build \
         --volume $(pwd):/tarantool \
+        --volume ${OUTPUT_DIR}:/tarantool/build \
         --workdir /tarantool/static-build/ \
         packpack/packpack:centos-7 sh -c "
             useradd -u ${USER_ID} tarantool;


### PR DESCRIPTION
Modify .pack.mk for deploying static packages. Change the CI/CD process for creating and publishing packages to the repository. 

This PR connected with https://github.com/tarantool/rws/pull/79. It is needed to support static packages by RWS.