### PR TITLE
box: speed up select/pairs with pagination by reusing ibuf

### DIFF
--- a/changelogs/unreleased/box-speed-up-select-with-pagination.md
+++ b/changelogs/unreleased/box-speed-up-select-with-pagination.md
@@ -1,0 +1,4 @@
+## feature/box
+
+* Sped up `index.select` and `index.pairs` with the `after` option by up to 30%
+  in a synthetic test by eliminating an extra buffer allocation.

--- a/perf/lua/box_select.lua
+++ b/perf/lua/box_select.lua
@@ -1,0 +1,271 @@
+--
+-- The test measures run time of various space select operations.
+--
+-- Output format:
+-- <test-case> <run-time-nanoseconds>
+--
+-- Options:
+-- --pattern <string>  run only tests matching the pattern; it's possible
+--                     to specify more than one pattern separated by '|',
+--                     for example, 'get|select'
+-- --read_view         use a read view
+--
+
+local clock = require('clock')
+local fiber = require('fiber')
+
+local params = require('internal.argparse').parse(arg, {
+    {'pattern', 'string'},
+    {'read_view', 'boolean'},
+})
+if params.pattern then
+    params.pattern = string.split(params.pattern, '|')
+end
+
+box.cfg({log_level = 'error'})
+box.once('perf_select_init', function()
+    local s = box.schema.space.create('perf_select_space')
+    s:create_index('primary')
+    for i = 1, 1e3 do
+        s:insert({i, 'data' .. i})
+    end
+    box.snapshot()
+end)
+
+local rv
+local space
+if params.read_view then
+    rv = box.read_view.open()
+    space = rv.space.perf_select_space
+else
+    space = box.space.perf_select_space
+end
+
+--
+-- Array of test cases.
+--
+-- A test case is represented by a table with the following mandatory fields:
+--
+-- * name: test case name
+-- * func: test function
+--
+local TESTS = {
+    {
+        name = 'get_0',
+        func = function()
+            space:get({1e6})
+        end,
+    },
+    {
+        name = 'get_1',
+        func = function()
+            space:get({10})
+        end,
+    },
+    {
+        name = 'select_0',
+        func = function()
+            space:select({1e6}, {iterator = 'ge', limit = 1})
+        end,
+    },
+    {
+        name = 'select_1',
+        func = function()
+            space:select({10}, {iterator = 'ge', limit = 1})
+        end,
+    },
+    {
+        name = 'select_5',
+        func = function()
+            space:select({10}, {iterator = 'ge', limit = 5})
+        end,
+    },
+    {
+        name = 'select_10',
+        func = function()
+            space:select({10}, {iterator = 'ge', limit = 10})
+        end,
+    },
+    {
+        name = 'select_after_0',
+        func = function()
+            space:select({10}, {iterator = 'ge', after = {1e6}, limit = 1})
+        end,
+    },
+    {
+        name = 'select_after_1',
+        func = function()
+            space:select({10}, {iterator = 'ge', after = {10}, limit = 1})
+        end,
+    },
+    {
+        name = 'select_after_5',
+        func = function()
+            space:select({10}, {iterator = 'ge', after = {10}, limit = 5})
+        end,
+    },
+    {
+        name = 'select_after_10',
+        func = function()
+            space:select({10}, {iterator = 'ge', after = {10}, limit = 10})
+        end,
+    },
+    {
+        name = 'select_fetch_pos_0',
+        func = function()
+            space:select({1e6}, {iterator = 'ge', fetch_pos = true, limit = 1})
+        end,
+    },
+    {
+        name = 'select_fetch_pos_1',
+        func = function()
+            space:select({10}, {iterator = 'ge', fetch_pos = true, limit = 1})
+        end,
+    },
+    {
+        name = 'select_fetch_pos_5',
+        func = function()
+            space:select({10}, {iterator = 'ge', fetch_pos = true, limit = 5})
+        end,
+    },
+    {
+        name = 'select_fetch_pos_10',
+        func = function()
+            space:select({10}, {iterator = 'ge', fetch_pos = true, limit = 10})
+        end,
+    },
+    {
+        name = 'pairs_0',
+        func = function()
+            for _, _ in space:pairs({1e6}, {iterator = 'ge'}) do
+            end
+        end,
+    },
+    {
+        name = 'pairs_1',
+        func = function()
+            -- luacheck: ignore
+            for _, _ in space:pairs({10}, {iterator = 'ge'}) do
+                break
+            end
+        end,
+    },
+    {
+        name = 'pairs_5',
+        func = function()
+            local c = 0
+            for _, _ in space:pairs({10}, {iterator = 'ge'}) do
+                c = c + 1
+                if c == 5 then
+                    break
+                end
+            end
+        end,
+    },
+    {
+        name = 'pairs_10',
+        func = function()
+            local c = 0
+            for _, _ in space:pairs({10}, {iterator = 'ge'}) do
+                c = c + 1
+                if c == 10 then
+                    break
+                end
+            end
+        end,
+    },
+    {
+        name = 'pairs_after_0',
+        func = function()
+            for _, _ in space:pairs({10}, {iterator = 'ge', after = {1e6}}) do
+            end
+        end,
+    },
+    {
+        name = 'pairs_after_1',
+        func = function()
+            -- luacheck: ignore
+            for _, _ in space:pairs({10}, {iterator = 'ge', after = {10}}) do
+                break
+            end
+        end,
+    },
+    {
+        name = 'pairs_after_5',
+        func = function()
+            local c = 0
+            for _, _ in space:pairs({10}, {iterator = 'ge', after = {10}}) do
+                c = c + 1
+                if c == 5 then
+                    break
+                end
+            end
+        end,
+    },
+    {
+        name = 'pairs_after_10',
+        func = function()
+            local c = 0
+            for _, _ in space:pairs({10}, {iterator = 'ge', after = {10}}) do
+                c = c + 1
+                if c == 10 then
+                    break
+                end
+            end
+        end,
+    },
+    {
+        name = 'tuple_pos',
+        func = function()
+            space.index.primary:tuple_pos({10})
+        end
+    },
+}
+
+--
+-- Runs the given test case function in a loop.
+-- Returns the average time it takes to run the function once.
+--
+local function bench(test)
+    local warmup_runs = 1e2 / 4
+    local test_runs = 1e2
+    local iters_per_run = 1e4
+    local func = test.func
+    local run = function()
+        for _ = 1, iters_per_run do
+            func()
+        end
+    end
+    local test_time = 0
+    for i = 1, warmup_runs + test_runs do
+        for _ = 1, 5 do
+            collectgarbage('collect')
+            jit.flush()
+            fiber.yield()
+        end
+        local t = clock.bench(run)[1]
+        if i > warmup_runs then
+            test_time = test_time + t
+        end
+    end
+    return test_time / test_runs / iters_per_run
+end
+
+for _, test in ipairs(TESTS) do
+    local skip = false
+    if params.pattern then
+        skip = true
+        for _, pattern in ipairs(params.pattern) do
+            if string.match(test.name, pattern) then
+                skip = false
+                break
+            end
+        end
+    end
+    if not skip then
+        local t = bench(test)
+        print(string.format('%s %d', test.name, t * 1e9))
+    end
+end
+
+os.exit(0)

--- a/perf/lua/compare.lua
+++ b/perf/lua/compare.lua
@@ -1,0 +1,88 @@
+--
+-- Usage: <script> file1 file2 ...
+--
+-- An input file is supposed to contain test results in the following format:
+--
+-- <test1> <result1>
+-- <test2> <result1>
+-- ...
+--
+-- Here <testN> is the name of a test case (string, no spaces) and <resultN>
+-- is the test case result (number).
+--
+-- The script reads the result files and outputs the results in a convenient
+-- for comparison form:
+--
+--                  <file1>                  <file2>
+-- <test1>  <file1-result1>  <file2-result2> (+NNN%)
+-- <test2>  <file1-result2>  <file2-result2> (+NNN%)
+-- ...
+--
+
+-- Set of test names: <test-name> -> true.
+local test_names = {}
+
+-- Test names in the order of appearance.
+local test_names_ordered = {}
+
+-- Array of result columns.
+local columns = {}
+
+-- Width reserved for the first column (the one with the test names).
+local column0_width = 0
+
+-- Read the results from the input files.
+for i, file_name in ipairs(arg) do
+    local column = {
+        name = file_name,
+        values = {},
+    }
+    local width_extra = 2 -- space between columns
+    if i > 1 then
+        -- Reserve space for diff percentage: ' (+NNN%)'
+        width_extra = width_extra + 8
+    end
+    column.width = string.len(column.name) + width_extra
+    table.insert(columns, column)
+    for line in io.lines(file_name) do
+        local test_name, value = unpack(string.split(line))
+        if not test_names[test_name] then
+            table.insert(test_names_ordered, test_name)
+            test_names[test_name] = true
+        end
+        column0_width = math.max(column0_width, string.len(test_name))
+        column.values[test_name] = value
+        column.width = math.max(column.width, string.len(value) + width_extra)
+    end
+end
+
+-- Print the header row.
+local line = string.rjust('', column0_width)
+for _, column in ipairs(columns) do
+    line = line .. string.rjust(column.name, column.width)
+end
+print(line)
+
+-- Print the result rows.
+for _, test_name in ipairs(test_names_ordered) do
+    local line = string.rjust(test_name, column0_width)
+    for i, column in ipairs(columns) do
+        local value = column.values[test_name]
+        if not value then
+            value = 'NA'
+        end
+        if i > 1 then
+            local diff = ' (+ NA%)'
+            local curr = tonumber(value)
+            local base = tonumber(columns[1].values[test_name])
+            if base and curr then
+                diff = 100 * (curr - base) / base
+                diff = string.format(' (%s%3d%%)', diff >= 0 and '+' or '-',
+                                     math.abs(diff))
+            end
+            value = value .. diff
+        end
+        line = line .. string.rjust(value, column.width)
+    end
+    print(line)
+end


### PR DESCRIPTION
The `normalize_position()` internal function is called by select/pairs to prepare a position specified by the caller in the `options.after` argument to be passed to C over FFI. The function encodes the position passed as a table or a tuple in a temporary buffer obtained with `cord_ibuf_take()`. The problem is the cord buffer is already taken by the calling function (select/pairs) to encode the search key. As a result, `cord_ibuf_take()` allocates a new temporary buffer with malloc.

Let's avoid this extra buffer allocation by passing the taken buffer to `normalize_position()`. Let's also remove the out arguments because they are always set to `iterator_pos` and `iterator_pos_end` and instead set `iterator_pos` and `iterator_pos_end` directly. To make this behavior clear, we rename `normalize_position()` to `iterator_pos_set()`. We also remove `box.error()` from this function and instead make it return true/false so that the caller can release the buffer on failure.

To demonstrate the improvement, this PR also adds a synthetic performance test that measures execution time (in nanoseconds) of get/select/pairs with various arguments. Here are the results:

```
                      base          patched
              get_0    159      153 (-  3%)
              get_1    243      243 (+  0%)
           select_0    227      227 (+  0%)
           select_1    343      336 (-  2%)
           select_5   2323     2305 (-  0%)
          select_10   6832     6866 (+  0%)
     select_after_0    687      558 (- 18%)
     select_after_1    746      524 (- 29%)
     select_after_5   2917     2704 (-  7%)
    select_after_10   5033     4979 (-  1%)
 select_fetch_pos_0    239      233 (-  2%)
 select_fetch_pos_1    418      413 (-  1%)
 select_fetch_pos_5   2492     2496 (+  0%)
select_fetch_pos_10   5121     5179 (+  1%)
            pairs_0    320      314 (-  1%)
            pairs_1   1060     1054 (-  0%)
            pairs_5   1466     1459 (-  0%)
           pairs_10   3749     3913 (+  4%)
      pairs_after_0    788      670 (- 14%)
      pairs_after_1   1813     1611 (- 11%)
      pairs_after_5   2764     2638 (-  4%)
     pairs_after_10   4150     4098 (-  1%)
          tuple_pos    116      117 (+  0%)
```

The test will also be useful for investigating https://github.com/tarantool/tarantool-ee/issues/477. 