### PR TITLE
LuaJIT: bump new version

### DIFF
--- a/changelogs/unreleased/mark-conv-non-weak.md
+++ b/changelogs/unreleased/mark-conv-non-weak.md
@@ -1,0 +1,4 @@
+## bugfix/luajit
+
+* Marked `CONV` as non-weak, to prevent invalid control flow
+  path choice.


### PR DESCRIPTION
Mark CONV as non-weak, to prevent elimination of its side-effect.

Part of #8825

NO_DOC=LuaJIT bump
NO_TEST=LuaJIT bump