### PR TITLE
vinyl: fix use-after-free in `vy_read_iterator_next`

### DIFF
--- a/changelogs/unreleased/gh-8852-vy-read-iterator-use-after-free-fix.md
+++ b/changelogs/unreleased/gh-8852-vy-read-iterator-use-after-free-fix.md
@@ -1,0 +1,5 @@
+## bugfix/vinyl
+
+* Fixed a heap-use-after-free bug in the Vinyl read iterator caused by a race
+  between a disk read and a memory dump task. The bug could lead to a crash or
+  an invalid query result (gh-8852).

--- a/src/box/vy_history.h
+++ b/src/box/vy_history.h
@@ -59,22 +59,8 @@ struct vy_history {
 struct vy_history_node {
 	/** Link in a history list. */
 	struct rlist link;
-	/** History statement. Referenced if @is_refable is set. */
+	/** History statement. Always referenced. */
 	struct vy_entry entry;
-	/**
-	 * Set if the statement stored in this node is refable,
-	 * i.e. has a reference counter that can be incremented
-	 * to pin the statement in memory. Refable statements are
-	 * referenced by the history. It is a responsibility of
-	 * the user of the history to track lifetime of unrefable
-	 * statements.
-	 *
-	 * Note, we need to store this flag here, because by the
-	 * time we clean up a history list, unrefable statements
-	 * stored in it might have been deleted, thus making
-	 * vy_stmt_is_refable() unusable.
-	 */
-	bool is_refable;
 };
 
 /**


### PR DESCRIPTION
A read source iterator stores statements in a `vy_history object` using `vy_history_append_stmt()`. If a statement can be referenced, it's reference counter is incremented. If it can't, i.e. it belongs to a memory source, it's stored in a `vy_history` object without referencing.

This works fine because memory sources are append-only. A problem arises only when we get to scanning disk sources. Since we yield while reading disk, a dump task may complete concurrently dropping the memory sources and possibly invalidating statements stored in the iterator history. Although we drop the history accumulated so far and restart the iteration from scratch in this case, there's still an issue that can result in a use-after-free bug in `vy_read_iterator_next()`.

The problem is that we access the current candidate for the next statement while evaluating a disk source after a disk read. If 'next' refers to a referenced statement, it's fine, but if it refers to a statement from a memory source, it may cause use-after-free because the memory source may be dropped during a disk read.

To fix this issue, let's make `vy_history_append_stmt()` copy statements coming from memory sources. This should be fine performance-wise because we copied memory statements eventually in `vy_history_apply()` anyway, before returning them to the user.

Note that we also have to update `vy_read_iterator_restore_mem()` because it implicitly relied on the fact that 'next' coming from a memory source can't be freed by `vy_mem_iterator_restore()`, which cleans up the memory source history. Now, it isn't true anymore so we have to temporarily take a reference to 'next' explicitly.

Closes #8852