### PR TITLE
compat: fix err msg in compat.<option>:is_new()

### DIFF
--- a/src/lua/compat.lua
+++ b/src/lua/compat.lua
@@ -449,7 +449,7 @@ function compat_mt.__index(_, key)
     -- Whether the effective value of the option is `new`.
     function result.is_new(option)
         if type(option) ~= 'table' then
-            error('usage: compat.<option_name>:is_new()')
+            error(('usage: compat.%s:is_new()'):format(key))
         end
         if option.current == 'new' then
             return true

--- a/test/app-luatest/gh_7000_compat_module_test.lua
+++ b/test/app-luatest/gh_7000_compat_module_test.lua
@@ -233,6 +233,12 @@ g.test_is_new_is_old = function()
         local is_new = option_def.default == 'new'
         t.assert_equals(compat[name]:is_new(), is_new)
         t.assert_equals(compat[name]:is_old(), not is_new)
+
+        local err_pattern = 'usage: compat.%s:%s'
+        t.assert_error_msg_contains(err_pattern:format(name, 'is_new'),
+                                    compat[name].is_new, nil)
+        t.assert_error_msg_contains(err_pattern:format(name, 'is_old'),
+                                    compat[name].is_old, nil)
     end
 end
 


### PR DESCRIPTION
In the original patch https://github.com/tarantool/tarantool/commit/5f6d367c51f7545a940119e7a393baf982b80f3f ("compat: add is_new and
is_old to options") `compat.<option_name>:is_new()` and `:is_old()`
were introduced, but by mistake they contained different usage
messages. This patch updates `:is_new()` usage msg to more
informative one from `:is_old()`.

Follows up https://github.com/tarantool/tarantool/issues/8807

NO_CHANGELOG=changelog from 5f6d367 is valid
NO_DOC=doc from 5f6d367 is valid