### PR TITLE
config: add security section to schema

### DIFF
--- a/changelogs/unreleased/gh-8861-security-options.md
+++ b/changelogs/unreleased/gh-8861-security-options.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* All security hardening `box.cfg{}` options are now supported by
+  config (gh-8861).

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1295,6 +1295,68 @@ return schema.new('instance_config', schema.record({
             default = 16384,
         })),
     }),
+    security = schema.record({
+        auth_type = schema.enum({
+            'chap-sha1',
+            'pap-sha256',
+        }, {
+            box_cfg = 'auth_type',
+            default = 'chap-sha1',
+            validate = function(auth_type, w)
+                if auth_type ~= 'chap-sha1' and
+                        tarantool.package ~= 'Tarantool Enterprise' then
+                    w.error('"chap-sha1" is the only authentication method ' ..
+                            '(auth_type) available in Tarantool Community ' ..
+                            'Edition (%q requested)', auth_type)
+                end
+            end,
+        }),
+        auth_delay = enterprise_edition(schema.scalar({
+            type = 'number',
+            default = 0,
+            box_cfg = 'auth_delay',
+        })),
+        disable_guest = enterprise_edition(schema.scalar({
+            type = 'boolean',
+            default = false,
+            box_cfg = 'disable_guest',
+        })),
+        password_lifetime_days = enterprise_edition(schema.scalar({
+            type = 'integer',
+            default = 0,
+            box_cfg = 'password_lifetime_days',
+        })),
+        password_min_length = enterprise_edition(schema.scalar({
+            type = 'integer',
+            default = 0,
+            box_cfg = 'password_min_length',
+        })),
+        password_enforce_uppercase = enterprise_edition(schema.scalar({
+            type = 'boolean',
+            default = false,
+            box_cfg = 'password_enforce_uppercase',
+        })),
+        password_enforce_lowercase = enterprise_edition(schema.scalar({
+            type = 'boolean',
+            default = false,
+            box_cfg = 'password_enforce_lowercase',
+        })),
+        password_enforce_digits = enterprise_edition(schema.scalar({
+            type = 'boolean',
+            default = false,
+            box_cfg = 'password_enforce_digits',
+        })),
+        password_enforce_specialchars = enterprise_edition(schema.scalar({
+            type = 'boolean',
+            default = false,
+            box_cfg = 'password_enforce_specialchars',
+        })),
+        password_history_length = enterprise_edition(schema.scalar({
+            type = 'integer',
+            default = 0,
+            box_cfg = 'password_history_length',
+        })),
+    }),
 }, {
     -- This kind of validation cannot be implemented as the
     -- 'validate' annotation of a particular schema node. There

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -245,6 +245,20 @@ g.test_defaults = function()
             interval = 3600,
             metrics_limit = 1024*1024,
         } or nil,
+        security = is_enterprise and {
+            auth_delay = 0,
+            auth_type = "chap-sha1",
+            disable_guest = false,
+            password_enforce_digits = false,
+            password_enforce_lowercase = false,
+            password_enforce_specialchars = false,
+            password_enforce_uppercase = false,
+            password_history_length = 0,
+            password_lifetime_days = 0,
+            password_min_length = 0,
+        } or {
+            auth_type = "chap-sha1"
+        },
     }
     local res = cluster_config:apply_default({})
     t.assert_equals(res, exp)


### PR DESCRIPTION
The following box.cfg options were described in instance_config with defaults similar to ones in box.cfg:
* auth_type
* auth_delay
* disable_guest
* password_lifetime_days
* password_min_length
* password_enforce_uppercase
* password_enforce_lowercase
* password_enforce_digits
* password_enforce_specialchars
* password_history_length

Part of #8861