### PR TITLE
test: reset readline configuration for justrun too

### DIFF
--- a/test/justrun.lua
+++ b/test/justrun.lua
@@ -72,6 +72,10 @@ function justrun.tarantool(dir, env, args, opts)
     local opts = opts or {}
     assert(type(opts) == 'table')
 
+    -- Prevent system/user inputrc configuration file from
+    -- influencing testing code.
+    env['INPUTRC'] = '/dev/null'
+
     local tarantool_exe = arg[-1]
     -- Use popen.shell() instead of popen.new() due to lack of
     -- cwd option in popen (gh-5633).


### PR DESCRIPTION
This fixes gh_8613_new_cli_behaviour_test run with my custom .inputrc
(I use vi-cmd-mode-string/vi-ins-mode-string).

We already reset readline configuration in interactive_tarantool.lua.

Follows up ground works done for #7774