### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-8825-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8825-luajit-fixes.md
@@ -1,0 +1,9 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-8825). The following issues
+were fixed as part of this activity:
+
+* Fixed `BC_UCLO` insertion for returns.
+* Fixed recording of `BC_VARG` with unused vararg values.
+* Initialization instructions on trace are now emitted only for the first
+  member of a union.


### PR DESCRIPTION
* FFI: Fix recording of union initialization.
* Fix maxslots when recording BC_VARG, part 2.
* Fix maxslots when recording BC_VARG.
* Fix BC_UCLO insertion for returns.
* ci: update job concurrency group definition

Part of #8825

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump
