### PR TITLE
lua: replace `api_check()` with `assert()`

### DIFF
--- a/src/lua/utils.c
+++ b/src/lua/utils.c
@@ -67,7 +67,7 @@ index2adr(lua_State *L, int idx)
 		TValue *o = L->base + (idx - 1);
 		return o < L->top ? o : niltv(L);
 	} else if (idx > LUA_REGISTRYINDEX) {
-		api_check(L, idx != 0 && -idx <= L->top - L->base);
+		assert(idx != 0 && -idx <= L->top - L->base);
 		return L->top + idx;
 	} else if (idx == LUA_GLOBALSINDEX) {
 		TValue *o = &G(L)->tmptv;
@@ -77,7 +77,7 @@ index2adr(lua_State *L, int idx)
 		return registry(L);
 	} else {
 		GCfunc *fn = curr_func(L);
-		api_check(L, fn->c.gct == ~LJ_TFUNC && !isluafunc(fn));
+		assert(fn->c.gct == ~LJ_TFUNC && !isluafunc(fn));
 		if (idx == LUA_ENVIRONINDEX) {
 			TValue *o = &G(L)->tmptv;
 			settabV(L, o, tabref(fn->c.env));


### PR DESCRIPTION
`api_check()` is LuaJIT internal assertion. To prevent inconsistency during internal assertion changing (for example during backporting) use glibc's `assert()` instead.

NO_DOC=internal
NO_TEST=internal
NO_CHANGELOG=internal