### PR TITLE
box: add is_sync option

### DIFF
--- a/changelogs/unreleased/gh-8650-add-is_sync-option.md
+++ b/changelogs/unreleased/gh-8650-add-is_sync-option.md
@@ -1,0 +1,6 @@
+## feature/box
+
+* Added a new `is_sync` parameter to `box.atomic()`. To make the transaction
+synchronous, set the `is_sync` option to `true`. Setting `is_sync = false` is
+prohibited. If any value other than true/nil is set, for example
+`is_sync = "some string"`, then an error will be thrown (gh-8650).

--- a/extra/exports
+++ b/extra/exports
@@ -146,6 +146,7 @@ box_txn_begin
 box_txn_commit
 box_txn_id
 box_txn_isolation
+box_txn_make_sync
 box_txn_rollback
 box_txn_rollback_to_savepoint
 box_txn_savepoint

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -1432,6 +1432,19 @@ apply_plain_tx(uint32_t replica_id, struct stailq *rows,
 		goto fail;
 	}
 
+	item = stailq_last_entry(rows, struct applier_tx_row, next);
+
+	/*
+	 * Look at the flags item->row->flags. If the transaction
+	 * is synchronous, then set is_sync = true (txn.c). This
+	 * should only be done on replicas. The master sets these
+	 * flags and independently decides whether the transaction
+	 * is synchronous or not. All txn meta flags are set only
+	 * for the last txn row.
+	 */
+	if ((item->row.flags & IPROTO_FLAG_WAIT_ACK) != 0)
+		box_txn_make_sync();
+
 	if (use_triggers) {
 		/* We are ready to submit txn to wal. */
 		struct trigger *on_rollback, *on_wal_write;
@@ -1463,7 +1476,6 @@ apply_plain_tx(uint32_t replica_id, struct stailq *rows,
 		 * transaction traversed network + remote WAL bundle before
 		 * ack get received.
 		 */
-		item = stailq_last_entry(rows, struct applier_tx_row, next);
 		rcb->replica_id = replica_id;
 		rcb->txn_last_tm = item->row.tm;
 

--- a/src/box/iproto_constants.h
+++ b/src/box/iproto_constants.h
@@ -214,7 +214,11 @@ extern const char *iproto_flag_bit_strs[];
 	 * Mapping of format identifier to format clause consisting of field
 	 * names and field types.
 	 */								\
-	_(TUPLE_FORMATS, 0x60, MP_MAP)
+	_(TUPLE_FORMATS, 0x60, MP_MAP)					\
+	/**
+	 * Flag indicating whether the transaction is synchronous.
+	 */								\
+	 _(IS_SYNC, 0x61, MP_BOOL)
 
 #define IPROTO_KEY_MEMBER(s, v, ...) IPROTO_ ## s = v,
 

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -417,6 +417,40 @@ static const char *lua_sources[] = {
 static int
 lbox_commit(lua_State *L)
 {
+	int top = lua_gettop(L);
+	if (top >= 1) {
+		/* box.commit(nil) */
+		if (lua_isnil(L, 1))
+			goto box_commit;
+
+		if (lua_type(L, 1) != LUA_TTABLE) {
+			diag_set(IllegalParams, "Illegal parameters, options "
+				 "should be a table");
+			return luaT_error(L);
+		}
+		/* Get is_sync */
+		lua_getfield(L, 1, "is_sync");
+		/* box.commit({is_sync = nil}) */
+		if (lua_isnil(L, -1))
+			goto box_commit;
+
+		if (!lua_isboolean(L, -1)) {
+			diag_set(IllegalParams, "Illegal parameters, is_sync "
+				 "must be a boolean");
+			return luaT_error(L);
+		}
+		bool is_sync = lua_toboolean(L, lua_gettop(L));
+		lua_pop(L, 1);
+
+		if (!is_sync) {
+			diag_set(IllegalParams, "Illegal parameters, is_sync "
+				 "can only be true");
+			return luaT_error(L);
+		}
+		box_txn_make_sync();
+	}
+
+box_commit:
 	if (box_txn_commit() != 0)
 		return luaT_error(L);
 	return 0;

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -850,7 +850,8 @@ txn_journal_entry_new(struct txn *txn)
 
 	struct xrow_header **remote_row = req->rows;
 	struct xrow_header **local_row = req->rows + txn->n_applier_rows;
-	bool is_sync = false;
+	bool is_sync = txn_has_flag(txn, TXN_WAIT_ACK);
+
 	/*
 	 * A transaction which consists of NOPs solely should pass through the
 	 * limbo without waiting. Even when the limbo is not empty. This is
@@ -892,6 +893,15 @@ txn_journal_entry_new(struct txn *txn)
 	 */
 	if (!txn_has_flag(txn, TXN_FORCE_ASYNC) && !is_fully_nop) {
 		if (is_sync) {
+			/*
+			 * Can't commit a fully local transaction synchronously.
+			 */
+			if (txn_is_fully_local(txn)) {
+				diag_set(IllegalParams,
+					 "An attempt to commit a fully local "
+					 "transaction synchronously");
+				return NULL;
+			}
 			txn_set_flags(txn, TXN_WAIT_SYNC | TXN_WAIT_ACK);
 		} else if (!txn_limbo_is_empty(&txn_limbo)) {
 			/*
@@ -1273,6 +1283,20 @@ box_txn_set_timeout(double timeout)
 	}
 	txn_set_timeout(txn, timeout);
 	return 0;
+}
+
+void
+box_txn_make_sync(void)
+{
+	struct txn *txn = in_txn();
+	/*
+	 * Do nothing if transaction is not started,
+	 * it's the same as BEGIN + COMMIT.
+	 */
+	if (!txn)
+		return;
+
+	txn_set_flags(txn, TXN_WAIT_ACK);
 }
 
 /** Wait for a linearization point for a transaction. */

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -1042,6 +1042,11 @@ box_txn_set_timeout(double timeout);
 API_EXPORT int
 box_txn_set_isolation(uint32_t level);
 
+/**
+ * Make the transaction synchronous.
+ */
+API_EXPORT void
+box_txn_make_sync(void);
 /** \endcond public */
 
 typedef struct txn_savepoint box_txn_savepoint_t;

--- a/src/box/xrow.h
+++ b/src/box/xrow.h
@@ -862,7 +862,7 @@ struct sql_request {
  * @param row Encoded data.
  * @param[out] request Request to decode to.
  *
- * @retval  0 Sucess.
+ * @retval  0 Success.
  * @retval -1 Format or memory error.
  */
 int
@@ -1000,6 +1000,10 @@ struct begin_request {
 	 * Must be ono of enum txn_isolation_level values.
 	 */
 	uint32_t txn_isolation;
+	/**
+	 * is_sync that determines the synchronism of transactions.
+	 */
+	bool is_sync;
 };
 
 /**
@@ -1007,11 +1011,33 @@ struct begin_request {
  * @param row Encoded data.
  * @param[out] request Request to decode to.
  *
- * @retval  0 Sucess.
+ * @retval  0 Success.
  * @retval -1 Format error.
  */
 int
 xrow_decode_begin(const struct xrow_header *row, struct begin_request *request);
+
+/**
+ * COMMIT request.
+ */
+struct commit_request {
+	/**
+	 * is_sync that determines the synchronism of transactions.
+	 */
+	bool is_sync;
+};
+
+/**
+ * Parse the COMMIT request.
+ * @param row Encoded data.
+ * @param[out] request Request to decode to.
+ *
+ * @retval  0 Success.
+ * @retval -1 Format error.
+ */
+int
+xrow_decode_commit(const struct xrow_header *row,
+		   struct commit_request *request);
 
 /**
  * Update vclock with the next LSN value for given replica id.

--- a/test/box-luatest/gh_7894_export_iproto_constants_and_features_test.lua
+++ b/test/box-luatest/gh_7894_export_iproto_constants_and_features_test.lua
@@ -85,6 +85,7 @@ local reference_table = {
         SPACE_NAME = 0x5e,
         INDEX_NAME = 0x5f,
         TUPLE_FORMATS = 0x60,
+        IS_SYNC = 0x61,
     },
 
     -- `iproto_metadata_key` enumeration.

--- a/test/box-luatest/gh_8650_add_is_sync_option_test.lua
+++ b/test/box-luatest/gh_8650_add_is_sync_option_test.lua
@@ -1,0 +1,394 @@
+local t = require('luatest')
+local cluster = require('luatest.replica_set')
+local server = require('luatest.server')
+local net = require('net.box')
+local msgpack = require('msgpack')
+
+local g = t.group('gh_8650')
+
+g.before_each(function(cg)
+    cg.cluster = cluster:new({})
+    local box_cfg = {
+        memtx_use_mvcc_engine = true,
+        replication = {
+            server.build_listen_uri('master', cg.cluster.id),
+            server.build_listen_uri('replica', cg.cluster.id)
+        },
+        replication_synchro_quorum = 2
+    }
+
+    cg.master = cg.cluster:build_and_add_server({alias = 'master',
+                                                 box_cfg = box_cfg})
+    box_cfg.read_only = true
+    cg.replica = cg.cluster:build_and_add_server({alias = 'replica',
+                                                  box_cfg = box_cfg})
+    cg.cluster:start()
+end)
+
+g.after_each(function(cg)
+    cg.cluster:drop()
+end)
+
+g.test_box_begin_commit_is_sync = function(cg)
+    cg.master:exec(function()
+        box.schema.space.create('test')
+        box.space.test:create_index('pk')
+        box.ctl.promote()
+
+        box.begin()
+            box.space.test:insert{1, 'is_sync = false'}
+        box.commit()
+        box.begin({is_sync = true})
+            box.space.test:insert{2, 'is_sync = true'}
+        box.commit()
+        box.begin()
+            box.space.test:insert{3, 'is_sync = true'}
+        box.commit({is_sync = true})
+        box.begin({is_sync = true})
+            box.space.test:insert{4, 'is_sync = true'}
+        box.commit({is_sync = true})
+    end)
+
+    local err_msg = "Illegal parameters, is_sync can only be true"
+    t.assert_error_msg_content_equals(err_msg, function()
+        cg.master:exec(function()
+            box.begin({is_sync = false})
+                box.space.test:insert{5, 'is_sync = error'}
+            box.commit()
+        end)
+    end)
+
+    t.assert_error_msg_content_equals(err_msg, function()
+        cg.master:exec(function()
+            box.begin()
+                box.space.test:insert{6, 'is_sync = error'}
+            box.commit({is_sync = false})
+        end)
+    end)
+
+    err_msg = "Illegal parameters, is_sync must be a boolean"
+    t.assert_error_msg_content_equals(err_msg, function()
+        cg.master:exec(function()
+            box.begin({is_sync = "foo"})
+                box.space.test:insert{7, 'is_sync = error'}
+            box.commit()
+        end)
+    end)
+
+    t.assert_error_msg_content_equals(err_msg, function()
+        cg.master:exec(function()
+            box.begin()
+                box.space.test:insert{8, 'is_sync = error'}
+            box.commit({is_sync = "foo"})
+        end)
+    end)
+
+    t.assert_equals(cg.master:exec(function()
+        return box.space.test:select()
+    end), {{1, 'is_sync = false'}, {2, 'is_sync = true'},
+           {3, 'is_sync = true'}, {4, 'is_sync = true'}})
+
+    t.assert_equals(cg.replica:exec(function()
+        return box.space.test:select()
+    end), {{1, 'is_sync = false'}, {2, 'is_sync = true'},
+           {3, 'is_sync = true'}, {4, 'is_sync = true'}})
+
+
+    cg.replica:stop()
+
+    -- Async transaction
+    cg.master:exec(function()
+        box.begin()
+            box.space.test:insert{9, 'is_sync = false'}
+        box.commit()
+    end)
+
+    -- Sync transaction
+    err_msg = "Quorum collection for a synchronous transaction is timed out"
+    t.assert_error_msg_content_equals(err_msg, function()
+        cg.master:exec(function()
+            box.cfg{replication_synchro_timeout = 0.01}
+            box.begin({is_sync = true})
+                box.space.test:insert{10, 'is_sync = true'}
+            box.commit()
+        end)
+    end)
+
+    t.assert_equals(cg.master:exec(function()
+        return box.space.test:select()
+    end), {{1, 'is_sync = false'}, {2, 'is_sync = true'},
+           {3, 'is_sync = true'}, {4, 'is_sync = true'},
+           {9, 'is_sync = false'}})
+end
+
+g.test_box_atomic_is_sync = function(cg)
+    cg.master:exec(function()
+        box.schema.space.create('test')
+        box.space.test:create_index('pk')
+        box.ctl.promote()
+
+        box.atomic(function()
+            box.space.test:insert{1, 'is_sync = false'}
+            box.space.test:insert{2, 'is_sync = false'}
+        end)
+        box.atomic({is_sync = true}, function()
+            box.space.test:insert{3, 'is_sync = true'}
+            box.space.test:insert{4, 'is_sync = true'}
+        end)
+    end)
+
+    local err_msg = "Illegal parameters, is_sync can only be true"
+    t.assert_error_msg_content_equals(err_msg, function()
+        cg.master:exec(function()
+            box.atomic({is_sync = false}, function()
+                box.space.test:insert{5, 'is_sync = error'}
+                box.space.test:insert{6, 'is_sync = error'}
+            end)
+        end)
+    end)
+
+    err_msg = "Illegal parameters, is_sync must be a boolean"
+    t.assert_error_msg_content_equals(err_msg, function()
+        cg.master:exec(function()
+            box.atomic({is_sync = "foo"}, function()
+                box.space.test:insert{7, 'is_sync = error'}
+                box.space.test:insert{8, 'is_sync = error'}
+            end)
+        end)
+    end)
+
+    t.assert_equals(cg.master:exec(function()
+        return box.space.test:select()
+    end), {{1, 'is_sync = false'}, {2, 'is_sync = false'},
+           {3, 'is_sync = true'}, {4, 'is_sync = true'}})
+
+    t.assert_equals(cg.replica:exec(function()
+        return box.space.test:select()
+    end), {{1, 'is_sync = false'}, {2, 'is_sync = false'},
+           {3, 'is_sync = true'}, {4, 'is_sync = true'}})
+
+    cg.replica:stop()
+
+    -- Async transaction
+    cg.master:exec(function()
+        box.atomic(function()
+            box.space.test:insert{9, 'is_sync = false'}
+        end)
+    end)
+
+    -- Sync transaction
+    err_msg = "Quorum collection for a synchronous transaction is timed out"
+    t.assert_error_msg_content_equals(err_msg, function()
+        cg.master:exec(function()
+            box.cfg{replication_synchro_timeout = 0.01}
+            box.atomic({is_sync = true}, function()
+                box.space.test:insert{10, 'is_sync = true'}
+            end)
+        end)
+    end)
+
+    t.assert_equals(cg.master:exec(function()
+        return box.space.test:select()
+    end), {{1, 'is_sync = false'}, {2, 'is_sync = false'},
+           {3, 'is_sync = true'}, {4, 'is_sync = true'},
+           {9, "is_sync = false"}})
+end
+
+local function inject_iproto_begin_or_commit(c, request, is_sync)
+    local header = msgpack.encode({
+        [box.iproto.key.REQUEST_TYPE] = box.iproto.type[request],
+        [box.iproto.key.SYNC] = c:_next_sync(),
+        [box.iproto.key.STREAM_ID] = c._stream_id or 0,
+    })
+    local body = msgpack.encode({
+        [box.iproto.key.IS_SYNC] = is_sync,
+    })
+    local size = msgpack.encode(#header + #body)
+    local request = size .. header .. body
+    return c:_inject(request)
+end
+
+g.test_iproto_is_sync = function(cg)
+    local c = net.connect(cg.master.net_box_uri)
+    local s = c:new_stream()
+
+    cg.master:exec(function()
+        box.schema.space.create('test')
+        box.space.test:create_index('pk')
+        box.ctl.promote()
+    end)
+
+    -- Throwing iproto errors if is_sync is set incorrectly
+    local err_msg = "Illegal parameters, is_sync can only be true"
+    t.assert_error_msg_content_equals(err_msg, function()
+        inject_iproto_begin_or_commit(s, 'BEGIN', false)
+    end)
+
+    err_msg = "Invalid MsgPack - request body"
+    t.assert_error_msg_content_equals(err_msg, function()
+        inject_iproto_begin_or_commit(s, 'BEGIN', 'foo')
+    end)
+
+    err_msg = "Illegal parameters, is_sync can only be true"
+    t.assert_error_msg_content_equals(err_msg, function()
+        inject_iproto_begin_or_commit(s, 'COMMIT', false)
+    end)
+
+    err_msg = "Invalid MsgPack - request body"
+    t.assert_error_msg_content_equals(err_msg, function()
+        inject_iproto_begin_or_commit(s, 'COMMIT', 'foo')
+    end)
+
+    -- is_sync is set correctly
+    s:begin()
+    s.space.test:insert({1, 'is_sync = false'})
+    s:commit()
+
+    s:begin({is_sync = true})
+    s.space.test:insert({2, 'is_sync = true'})
+    s:commit()
+
+    s:begin()
+    s.space.test:insert({3, 'is_sync = true'})
+    s:commit({is_sync = true})
+
+    cg.replica:stop()
+
+    -- Async transaction
+    s:begin()
+    s.space.test:insert({4, 'is_sync = false'})
+    s:commit()
+
+    -- Sync transaction
+    cg.master:exec(function()
+        box.cfg{replication_synchro_timeout = 0.01}
+    end)
+
+    err_msg = "Quorum collection for a synchronous transaction is timed out"
+    t.assert_error_msg_content_equals(err_msg, function()
+        s:begin({is_sync = true})
+        s.space.test:insert({5, 'is_sync = true'})
+        s:commit()
+    end)
+
+    t.assert_error_msg_content_equals(err_msg, function()
+        s:begin()
+        s.space.test:insert({6, 'is_sync = true'})
+        s:commit({is_sync = true})
+    end)
+
+    t.assert_equals(cg.master:exec(function()
+        return box.space.test:select()
+    end), {{1, 'is_sync = false'}, {2, 'is_sync = true'},
+           {3, 'is_sync = true'}, {4, 'is_sync = false'}})
+
+    c:close()
+end
+
+g.test_commit_opts = function(cg)
+    local c = net.connect(cg.master.net_box_uri)
+    local s = c:new_stream()
+
+    cg.master:exec(function()
+        box.schema.space.create('test')
+        box.space.test:create_index('pk')
+        box.ctl.promote()
+    end)
+
+    -- Commit options are set correctly
+    s:begin()
+    s.space.test:insert({1, 'good'})
+    s:commit({is_async = false})
+
+    s:begin()
+    s.space.test:insert({2, 'good'})
+    s:commit()
+
+    s:begin()
+    s.space.test:insert({3, 'good'})
+    s:commit({is_sync = true})
+
+    s:begin()
+    s.space.test:insert({4, 'good'})
+    s:commit({is_sync = true}, {is_async = false})
+
+    s:begin()
+    s.space.test:insert({5, 'good'})
+    s:commit(nil, {is_async = false})
+
+    t.assert_equals(cg.master:exec(function()
+        return box.space.test:select()
+    end), {{1, 'good'}, {2, 'good'}, {3, 'good'}, {4, 'good'}, {5, 'good'}})
+
+    -- Commit options are set incorrectly
+    s:begin()
+    local err_msg = "Illegal parameters, unexpected option 'is_sync'"
+    t.assert_error_msg_content_equals(err_msg, function()
+        s:commit({is_sync = true, is_async = false})
+    end)
+    t.assert_error_msg_content_equals(err_msg, function()
+        s:commit({is_async = false, is_sync = false})
+    end)
+
+    err_msg = "Illegal parameters, options are either in the wrong order or " ..
+              "mixed up"
+    t.assert_error_msg_content_equals(err_msg, function()
+        s:commit({is_async = false}, {is_sync = false})
+    end)
+
+    err_msg = "Illegal parameters, options should be a table"
+    t.assert_error_msg_content_equals(err_msg, function()
+        s:commit({}, 123)
+    end)
+    t.assert_error_msg_content_equals(err_msg, function()
+        s:commit(123, {})
+    end)
+
+    c:close()
+end
+
+g.test_commit_local_space = function(cg)
+    cg.master:exec(function()
+        box.schema.space.create('test')
+        box.space.test:create_index('pk')
+        box.schema.space.create('loc', {is_local = true})
+        box.space.loc:create_index('pk')
+        box.ctl.promote()
+        box.begin() box.space.loc:insert{1} box.commit()
+    end)
+
+
+    local err_msg = "An attempt to commit a fully local transaction " ..
+                    "synchronously"
+    t.assert_error_msg_content_equals(err_msg, function()
+        cg.master:exec(function()
+            box.begin({is_sync = true}) box.space.loc:insert{2} box.commit()
+        end)
+    end)
+
+    t.assert_error_msg_content_equals(err_msg, function()
+        cg.master:exec(function()
+            box.begin() box.space.loc:insert{3} box.commit({is_sync = true})
+        end)
+    end)
+
+    t.assert_error_msg_content_equals(err_msg, function()
+        cg.master:exec(function()
+            box.begin({is_sync = true})
+                box.space.loc:insert{4}
+            box.commit({is_sync = true})
+        end)
+    end)
+
+    t.assert_error_msg_content_equals(err_msg, function()
+        cg.master:exec(function()
+            box.atomic({is_sync = true}, function()
+                box.space.loc:insert{5}
+            end)
+        end)
+    end)
+
+    t.assert_equals(cg.master:exec(function()
+        return box.space.loc:select()
+    end), {{1}})
+end


### PR DESCRIPTION
Added the new is_sync parameter to `box.begin()`, `box.commit()`, and `box.atomic()`. To make the transaction synchronous, set the `is_sync` option to `true`. If to set any value other than `true/nil`, for example `is_sync = "some string"`, then an error will be thrown. Examples:
```Lua
-- Sync transactions
box.atomic({is_sync = true}, function() ... end)

box.begin({is_sync = true}) ... box.commit({is_sync = true})

box.begin({is_sync = true}) ... box.commit()

box.begin() ... box.commit({is_sync = true})

-- Async transactions
box.atomic(function() ... end)

box.begin() ... box.commit()

```

Closes https://github.com/tarantool/tarantool/issues/8650

NO_DOC=internal