### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/oom-error-frame.md
+++ b/changelogs/unreleased/oom-error-frame.md
@@ -1,0 +1,3 @@
+## bugfix/luajit
+
+* Fixed frame for on-trace OOM handling (lj-1004).


### PR DESCRIPTION
Fix frame for on-trace out-of-memory error.

Part of #8825

NO_DOC=LuaJIT bump
NO_TEST=LuaJIT bump