### PR TITLE
git: add diff=cpp attribute for C/C++ source files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,10 @@
 *.snap binary
 *.xlog binary
+*.c diff=cpp
+*.h diff=cpp
+*.cc diff=cpp
+*.hh diff=cpp
+*.cpp diff=cpp
+*.hpp diff=cpp
+*.c++ diff=cpp
+*.h++ diff=cpp


### PR DESCRIPTION
This improves diff hunk name detection. Needed for checkpatch to correctly detect if patched code belongs to a function.