### PR TITLE
Implement key part sort order.

### DIFF
--- a/changelogs/unreleased/gh-5529-key-part-sort-order.md
+++ b/changelogs/unreleased/gh-5529-key-part-sort-order.md
@@ -1,0 +1,4 @@
+## feature/box
+
+* Now it is possible to specify the sort order for each part of an index
+  (gh-5529).

--- a/perf/tuple.cc
+++ b/perf/tuple.cc
@@ -53,7 +53,7 @@ private:
 		struct key_part_def kdp{0};
 		kdp.fieldno = 4;
 		kdp.type = FIELD_TYPE_UNSIGNED;
-		kd = key_def_new(&kdp, 1, false);
+		kd = key_def_new(&kdp, 1, 0);
 		fmt = simple_tuple_format_new(&memtx_tuple_format_vtab,
 					      &memtx, &kd, 1);
 		tuple_format_ref(fmt);

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -381,7 +381,9 @@ index_def_new_from_tuple(struct tuple *tuple, struct space *space)
 				 space->def->field_count, &fiber()->gc) != 0)
 		return NULL;
 	bool for_func_index = opts.func_id > 0;
-	key_def = key_def_new(part_def, part_count, for_func_index);
+	key_def = key_def_new(part_def, part_count,
+			      (type != TREE ? KEY_DEF_UNORDERED : 0) |
+			      (for_func_index ? KEY_DEF_FOR_FUNC_INDEX : 0));
 	if (key_def == NULL)
 		return NULL;
 	struct index_def *index_def =

--- a/src/box/key_def.c
+++ b/src/box/key_def.c
@@ -400,6 +400,10 @@ key_def_set_internal_part(struct key_part_def *internal_part,
 	internal_part->exclude_null =
 		(part->flags & BOX_KEY_PART_DEF_EXCLUDE_NULL)
 		== BOX_KEY_PART_DEF_EXCLUDE_NULL;
+	internal_part->sort_order =
+		(part->flags & BOX_KEY_PART_DEF_SORT_ORDER_DESC) ==
+		BOX_KEY_PART_DEF_SORT_ORDER_DESC ?
+		SORT_ORDER_DESC : SORT_ORDER_ASC;
 
 	/* Set internal_part->coll_id. */
 	if (part->collation != NULL) {
@@ -570,6 +574,8 @@ box_key_def_dump_parts(const box_key_def_t *key_def, uint32_t *part_count_ptr)
 			part_def->flags |= BOX_KEY_PART_DEF_IS_NULLABLE;
 		if (part->exclude_null)
 			part_def->flags |= BOX_KEY_PART_DEF_EXCLUDE_NULL;
+		if (part->sort_order == SORT_ORDER_DESC)
+			part_def->flags |= BOX_KEY_PART_DEF_SORT_ORDER_DESC;
 		assert(part->type >= 0 && part->type < field_type_MAX);
 		part_def->field_type = field_type_strs[part->type];
 

--- a/src/box/key_def.h
+++ b/src/box/key_def.h
@@ -314,6 +314,7 @@ typedef struct key_def box_key_def_t;
 enum {
 	BOX_KEY_PART_DEF_IS_NULLABLE = 1 << 0,
 	BOX_KEY_PART_DEF_EXCLUDE_NULL = 1 << 1,
+	BOX_KEY_PART_DEF_SORT_ORDER_DESC = 1 << 2,
 };
 
 /**
@@ -437,10 +438,11 @@ box_key_def_new(uint32_t *fields, uint32_t *types, uint32_t part_count);
  *
  * Default flag values are the following:
  *
- *  | Flag                          | Default value |
- *  | ----------------------------- | ------------- |
- *  | BOX_KEY_PART_DEF_IS_NULLABLE  | 0 (unset)     |
- *  | BOX_KEY_PART_DEF_EXCLUDE_NULL | 0 (unset)     |
+ *  | Flag                             | Default value |
+ *  | -------------------------------- | ------------- |
+ *  | BOX_KEY_PART_DEF_IS_NULLABLE     | 0 (unset)     |
+ *  | BOX_KEY_PART_DEF_EXCLUDE_NULL    | 0 (unset)     |
+ *  | BOX_KEY_PART_DEF_SORT_ORDER_DESC | 0 (unset)     |
  *
  * Default values of fields and flags are permitted to be changed
  * in future tarantool versions. However we should be VERY

--- a/src/box/lua/key_def.c
+++ b/src/box/lua/key_def.c
@@ -517,7 +517,7 @@ lbox_key_def_new(struct lua_State *L)
 		lua_pop(L, 1);
 	}
 
-	struct key_def *key_def = key_def_new(parts, part_count, false);
+	struct key_def *key_def = key_def_new(parts, part_count, 0);
 	region_truncate(region, region_svp);
 	if (key_def == NULL)
 		return luaT_error(L);

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -3848,3 +3848,7 @@ function box.read_view.list()
 end
 
 box.NULL = msgpack.NULL
+box.index.FORWARD_INCLUSIVE = box.index.GE
+box.index.FORWARD_EXCLUSIVE = box.index.GT
+box.index.REVERSE_INCLUSIVE = box.index.LE
+box.index.REVERSE_EXCLUSIVE = box.index.LT

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -1989,6 +1989,8 @@ memtx_index_def_change_requires_rebuild(struct index *index,
 			return true;
 		if (old_part->exclude_null != new_part->exclude_null)
 			return true;
+		if (old_part->sort_order != new_part->sort_order)
+			return true;
 	}
 	assert(old_cmp_def->is_multikey == new_cmp_def->is_multikey);
 	return false;

--- a/src/box/schema.cc
+++ b/src/box/schema.cc
@@ -198,7 +198,7 @@ sc_space_new(uint32_t id, const char *name,
 	     uint32_t key_part_count,
 	     struct trigger *replace_trigger)
 {
-	struct key_def *key_def = key_def_new(key_parts, key_part_count, false);
+	struct key_def *key_def = key_def_new(key_parts, key_part_count, 0);
 	if (key_def == NULL)
 		diag_raise();
 	auto key_def_guard =

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -393,7 +393,7 @@ sql_ephemeral_space_new(const struct sql_space_info *info)
 		parts[i].coll_id = info->coll_ids[j];
 	}
 
-	struct key_def *key_def = key_def_new(parts, part_count, false);
+	struct key_def *key_def = key_def_new(parts, part_count, 0);
 	if (key_def == NULL)
 		return NULL;
 

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -2263,7 +2263,7 @@ index_fill_def(struct Parse *parse, struct index *index,
 		part->coll_id = coll_id;
 		part->path = NULL;
 	}
-	key_def = key_def_new(key_parts, expr_list->nExpr, false);
+	key_def = key_def_new(key_parts, expr_list->nExpr, 0);
 	if (key_def == NULL)
 		goto tnt_error;
 	/*

--- a/src/box/sql/select.c
+++ b/src/box/sql/select.c
@@ -1649,7 +1649,7 @@ sql_key_info_to_key_def(struct sql_key_info *key_info)
 {
 	if (key_info->key_def == NULL) {
 		key_info->key_def = key_def_new(key_info->parts,
-						key_info->part_count, false);
+						key_info->part_count, 0);
 	}
 	return key_info->key_def;
 }

--- a/src/box/sql/where.c
+++ b/src/box/sql/where.c
@@ -884,7 +884,7 @@ constructAutomaticIndex(Parse * pParse,			/* The parsing context */
 	}
 	assert(n == nKeyCol);
 
-	struct key_def *key_def = key_def_new(parts, nKeyCol, false);
+	struct key_def *key_def = key_def_new(parts, nKeyCol, 0);
 	if (key_def == NULL) {
 		pParse->is_aborted = true;
 		return;
@@ -2775,7 +2775,7 @@ whereLoopAddBtree(WhereLoopBuilder * pBuilder,	/* WHERE clause information */
 		part.path = NULL;
 		part.exclude_null = false;
 
-		struct key_def *key_def = key_def_new(&part, 1, false);
+		struct key_def *key_def = key_def_new(&part, 1, 0);
 		if (key_def == NULL) {
 tnt_error:
 			pWInfo->pParse->is_aborted = true;

--- a/src/box/tuple_compare.cc
+++ b/src/box/tuple_compare.cc
@@ -575,20 +575,24 @@ tuple_compare_field_with_type(const char *field_a, enum mp_type a_type,
 /*
  * Reverse the compare result if the key part sort order is descending.
  */
+template<bool has_desc_parts>
 static inline int
 key_part_compare_result(struct key_part *part, int result)
 {
-	return result * (part->sort_order != SORT_ORDER_DESC ? 1 : -1);
+	bool is_asc = !has_desc_parts || part->sort_order != SORT_ORDER_DESC;
+	return result * (is_asc ? 1 : -1);
 }
 
 /*
  * Reverse the hint if the key part sort order is descending.
  */
+template<bool has_desc_parts>
 static hint_t
 key_part_hint(struct key_part *part, hint_t hint)
 {
+	bool is_asc = !has_desc_parts || part->sort_order != SORT_ORDER_DESC;
 	/* HINT_MAX - HINT_NONE underflows to HINT_NONE. */
-	return part->sort_order != SORT_ORDER_DESC ? hint : HINT_MAX - hint;
+	return is_asc ? hint : HINT_MAX - hint;
 }
 
 /*
@@ -616,7 +620,8 @@ key_part_hint(struct key_part *part, hint_t hint)
  * @retval <0 if field_a < field_b
  * @retval >0 if field_a > field_b
  */
-template<bool is_nullable, bool a_is_optional, bool b_is_optional>
+template<bool is_nullable, bool a_is_optional, bool b_is_optional,
+	 bool has_desc_parts>
 static int
 key_part_compare_fields(struct key_part *part, const char *field_a,
 			const char *field_b, bool *was_null_met = NULL)
@@ -625,7 +630,7 @@ key_part_compare_fields(struct key_part *part, const char *field_a,
 	if (!is_nullable) {
 		rc = tuple_compare_field(field_a, field_b,
 					 part->type, part->coll);
-		return key_part_compare_result(part, rc);
+		return key_part_compare_result<has_desc_parts>(part, rc);
 	}
 	enum mp_type a_type = (a_is_optional && field_a == NULL) ?
 			      MP_NIL : mp_typeof(*field_a);
@@ -642,11 +647,11 @@ key_part_compare_fields(struct key_part *part, const char *field_a,
 						   field_b, b_type,
 						   part->type, part->coll);
 	}
-	return key_part_compare_result(part, rc);
+	return key_part_compare_result<has_desc_parts>(part, rc);
 }
 
 template<bool is_nullable, bool has_optional_parts, bool has_json_paths,
-	 bool is_multikey>
+	 bool is_multikey, bool has_desc_parts>
 static inline int
 tuple_compare_slowpath(struct tuple *tuple_a, hint_t tuple_a_hint,
 		       struct tuple *tuple_b, hint_t tuple_b_hint,
@@ -701,7 +706,8 @@ tuple_compare_slowpath(struct tuple *tuple_a, hint_t tuple_a_hint,
 		assert(has_optional_parts ||
 		       (field_a != NULL && field_b != NULL));
 		rc = key_part_compare_fields<is_nullable, has_optional_parts,
-					     has_optional_parts>(
+					     has_optional_parts,
+					     has_desc_parts>(
 			part, field_a, field_b, &was_null_met);
 		if (rc != 0)
 			return rc;
@@ -745,7 +751,8 @@ tuple_compare_slowpath(struct tuple *tuple_a, hint_t tuple_a_hint,
 		 * be absent or be NULLs.
 		 */
 		assert(field_a != NULL && field_b != NULL);
-		rc = key_part_compare_fields<false, false, false>(
+		rc = key_part_compare_fields<false, false, false,
+					     has_desc_parts>(
 			part, field_a, field_b);
 		if (rc != 0)
 			return rc;
@@ -754,7 +761,7 @@ tuple_compare_slowpath(struct tuple *tuple_a, hint_t tuple_a_hint,
 }
 
 template<bool is_nullable, bool has_optional_parts, bool has_json_paths,
-	 bool is_multikey>
+	 bool is_multikey, bool has_desc_parts>
 static inline int
 tuple_compare_with_key_slowpath(struct tuple *tuple, hint_t tuple_hint,
 				const char *key, uint32_t part_count,
@@ -791,7 +798,8 @@ tuple_compare_with_key_slowpath(struct tuple *tuple, hint_t tuple_hint,
 						part->fieldno);
 		}
 		return key_part_compare_fields<is_nullable, has_optional_parts,
-					       false>(part, field, key);
+					       false, has_desc_parts>(
+			part, field, key);
 	}
 
 	struct key_part *end = part + part_count;
@@ -810,7 +818,8 @@ tuple_compare_with_key_slowpath(struct tuple *tuple, hint_t tuple_hint,
 						part->fieldno);
 		}
 		rc = key_part_compare_fields<is_nullable, has_optional_parts,
-					     false>(part, field, key);
+					     false, has_desc_parts>(
+			part, field, key);
 		if (rc != 0)
 			return rc;
 	}
@@ -824,7 +833,7 @@ tuple_compare_with_key_slowpath(struct tuple *tuple, hint_t tuple_hint,
  * Key arguments must not be NULL, allowed to be NULL if dereferenced.
  * Set was_null_met to true if at least one part is NULL, to false otherwise.
  */
-template<bool is_nullable>
+template<bool is_nullable, bool has_desc_parts>
 static inline int
 key_compare_and_skip_parts(const char **key_a, const char **key_b,
 			   uint32_t part_count, struct key_def *key_def,
@@ -838,7 +847,8 @@ key_compare_and_skip_parts(const char **key_a, const char **key_b,
 	*was_null_met = false;
 
 	if (likely(part_count == 1)) {
-		rc = key_part_compare_fields<is_nullable, false, false>(
+		rc = key_part_compare_fields<is_nullable, false, false,
+					     has_desc_parts>(
 			part, *key_a, *key_b, was_null_met);
 		/* If key parts are equals, we must skip them. */
 		if (rc == 0) {
@@ -850,7 +860,8 @@ key_compare_and_skip_parts(const char **key_a, const char **key_b,
 
 	struct key_part *end = part + part_count;
 	for (; part < end; ++part, mp_next(key_a), mp_next(key_b)) {
-		rc = key_part_compare_fields<is_nullable, false, false>(
+		rc = key_part_compare_fields<is_nullable, false, false,
+					     has_desc_parts>(
 			part, *key_a, *key_b, was_null_met);
 		if (rc != 0)
 			return rc;
@@ -858,17 +869,16 @@ key_compare_and_skip_parts(const char **key_a, const char **key_b,
 	return 0;
 }
 
-template<bool is_nullable>
+template<bool is_nullable, bool has_desc_parts>
 static inline int
 key_compare_parts(const char *key_a, const char *key_b, uint32_t part_count,
 		  struct key_def *key_def, bool *was_null_met)
 {
-	return key_compare_and_skip_parts<is_nullable>(&key_a, &key_b,
-						       part_count, key_def,
-						       was_null_met);
+	return key_compare_and_skip_parts<is_nullable, has_desc_parts>(
+		&key_a, &key_b, part_count, key_def, was_null_met);
 }
 
-template<bool is_nullable, bool has_optional_parts>
+template<bool is_nullable, bool has_optional_parts, bool has_desc_parts>
 static inline int
 tuple_compare_with_key_sequential(struct tuple *tuple, hint_t tuple_hint,
 				  const char *key, uint32_t part_count,
@@ -891,9 +901,8 @@ tuple_compare_with_key_sequential(struct tuple *tuple, hint_t tuple_hint,
 		cmp_part_count = part_count;
 	}
 	bool unused;
-	rc = key_compare_and_skip_parts<is_nullable>(&tuple_key, &key,
-						     cmp_part_count,
-						     key_def, &unused);
+	rc = key_compare_and_skip_parts<is_nullable, has_desc_parts>(
+		&tuple_key, &key, cmp_part_count, key_def, &unused);
 	if (!has_optional_parts || rc != 0)
 		return rc;
 	/*
@@ -903,7 +912,8 @@ tuple_compare_with_key_sequential(struct tuple *tuple, hint_t tuple_hint,
 	if (field_count < part_count) {
 		for (uint32_t i = field_count; i < part_count;
 		     ++i, mp_next(&key)) {
-			rc = key_part_compare_fields<true, true, false>(
+			rc = key_part_compare_fields<true, true, false,
+						     has_desc_parts>(
 				&key_def->parts[i], NULL, key);
 			if (rc != 0)
 				return rc;
@@ -926,15 +936,25 @@ key_compare(const char *key_a, uint32_t part_count_a, hint_t key_a_hint,
 	assert(part_count <= key_def->part_count);
 	bool unused;
 	if (! key_def->is_nullable) {
-		return key_compare_parts<false>(key_a, key_b, part_count,
-						key_def, &unused);
+		if (key_def_has_desc_parts(key_def)) {
+			return key_compare_parts<false, true>(
+				key_a, key_b, part_count, key_def, &unused);
+		} else {
+			return key_compare_parts<false, false>(
+				key_a, key_b, part_count, key_def, &unused);
+		}
 	} else {
-		return key_compare_parts<true>(key_a, key_b, part_count,
-					       key_def, &unused);
+		if (key_def_has_desc_parts(key_def)) {
+			return key_compare_parts<true, true>(
+				key_a, key_b, part_count, key_def, &unused);
+		} else {
+			return key_compare_parts<true, false>(
+				key_a, key_b, part_count, key_def, &unused);
+		}
 	}
 }
 
-template <bool is_nullable, bool has_optional_parts>
+template<bool is_nullable, bool has_optional_parts, bool has_desc_parts>
 static int
 tuple_compare_sequential(struct tuple *tuple_a, hint_t tuple_a_hint,
 			 struct tuple *tuple_b, hint_t tuple_b_hint,
@@ -955,9 +975,8 @@ tuple_compare_sequential(struct tuple *tuple_a, hint_t tuple_a_hint,
 		assert(fc_a >= key_def->part_count);
 		assert(fc_b >= key_def->part_count);
 		bool unused;
-		return key_compare_parts<false>(key_a, key_b,
-						key_def->part_count, key_def,
-						&unused);
+		return key_compare_parts<false, has_desc_parts>(
+			key_a, key_b, key_def->part_count, key_def, &unused);
 	}
 	bool was_null_met = false;
 	struct key_part *part = key_def->parts;
@@ -967,7 +986,8 @@ tuple_compare_sequential(struct tuple *tuple_a, hint_t tuple_a_hint,
 		field_a = (has_optional_parts && i >= fc_a) ? NULL : key_a;
 		field_b = (has_optional_parts && i >= fc_b) ? NULL : key_b;
 		rc = key_part_compare_fields<true, has_optional_parts,
-					     has_optional_parts>(
+					     has_optional_parts,
+					     has_desc_parts>(
 			part, field_a, field_b, &was_null_met);
 		if (rc != 0)
 			return rc;
@@ -986,7 +1006,8 @@ tuple_compare_sequential(struct tuple *tuple_a, hint_t tuple_a_hint,
 		 * not be absent or be null.
 		 */
 		assert(i < fc_a && i < fc_b);
-		rc = key_part_compare_fields<false, false, false>(
+		rc = key_part_compare_fields<false, false, false,
+					     has_desc_parts>(
 			part, key_a, key_b);
 		if (rc != 0)
 			return rc;
@@ -1378,7 +1399,7 @@ static const comparator_with_key_signature cmp_wk_arr[] = {
  * of the functional key part and the primary key. So its tail parts are taken
  * from primary index key definition.
  */
-template<bool is_nullable>
+template<bool is_nullable, bool has_desc_parts>
 static inline int
 func_index_compare(struct tuple *tuple_a, hint_t tuple_a_hint,
 		   struct tuple *tuple_b, hint_t tuple_b_hint,
@@ -1398,8 +1419,8 @@ func_index_compare(struct tuple *tuple_a, hint_t tuple_a_hint,
 	(void)part_count_b;
 
 	bool was_null_met;
-	int rc = key_compare_parts<is_nullable>(key_a, key_b, key_part_count,
-						cmp_def, &was_null_met);
+	int rc = key_compare_parts<is_nullable, has_desc_parts>(
+		key_a, key_b, key_part_count, cmp_def, &was_null_met);
 	if (rc != 0)
 		return rc;
 	/*
@@ -1432,7 +1453,8 @@ func_index_compare(struct tuple *tuple_a, hint_t tuple_a_hint,
 						  field_map_b, part,
 						  MULTIKEY_NONE);
 		assert(field_a != NULL && field_b != NULL);
-		rc = key_part_compare_fields<false, false, false>(
+		rc = key_part_compare_fields<false, false, false,
+					     has_desc_parts>(
 			part, field_a, field_b);
 		if (rc != 0)
 			return rc;
@@ -1446,7 +1468,7 @@ func_index_compare(struct tuple *tuple_a, hint_t tuple_a_hint,
  * functional key memory and is compared with the given key by
  * using the functional index key definition.
  */
-template<bool is_nullable>
+template<bool is_nullable, bool has_desc_parts>
 static inline int
 func_index_compare_with_key(struct tuple *tuple, hint_t tuple_hint,
 			    const char *key, uint32_t part_count,
@@ -1462,9 +1484,8 @@ func_index_compare_with_key(struct tuple *tuple, hint_t tuple_hint,
 	uint32_t cmp_part_count = MIN(part_count, tuple_key_count);
 	cmp_part_count = MIN(cmp_part_count, key_def->part_count);
 	bool unused;
-	int rc = key_compare_and_skip_parts<is_nullable>(&tuple_key, &key,
-							 cmp_part_count,
-							 key_def, &unused);
+	int rc = key_compare_and_skip_parts<is_nullable, has_desc_parts>(
+		&tuple_key, &key, cmp_part_count, key_def, &unused);
 	if (rc != 0)
 		return rc;
 	/* Equals if nothing to compare. */
@@ -1489,7 +1510,8 @@ func_index_compare_with_key(struct tuple *tuple, hint_t tuple_hint,
 		field = tuple_field_raw_by_part(format, tuple_raw, field_map,
 						part, MULTIKEY_NONE);
 		assert(field != NULL);
-		rc = key_part_compare_fields<false, false, false>(
+		rc = key_part_compare_fields<false, false, false,
+					     has_desc_parts>(
 			part, field, key);
 		mp_next(&key);
 		if (rc != 0)
@@ -1962,7 +1984,7 @@ field_hint(const char *field, struct coll *coll)
 	return HINT_NONE;
 }
 
-template<enum field_type type, bool is_nullable>
+template<enum field_type type, bool is_nullable, bool has_desc_parts>
 static hint_t
 key_hint(const char *key, uint32_t part_count, struct key_def *key_def)
 {
@@ -1970,10 +1992,10 @@ key_hint(const char *key, uint32_t part_count, struct key_def *key_def)
 	if (part_count == 0)
 		return HINT_NONE;
 	hint_t h = field_hint<type, is_nullable>(key, key_def->parts->coll);
-	return key_part_hint(key_def->parts, h);
+	return key_part_hint<has_desc_parts>(key_def->parts, h);
 }
 
-template<enum field_type type, bool is_nullable>
+template<enum field_type type, bool is_nullable, bool has_desc_parts>
 static hint_t
 tuple_hint(struct tuple *tuple, struct key_def *key_def)
 {
@@ -1982,7 +2004,7 @@ tuple_hint(struct tuple *tuple, struct key_def *key_def)
 						MULTIKEY_NONE);
 	hint_t h = is_nullable && field == NULL ? hint_nil() :
 		   field_hint<type, is_nullable>(field, key_def->parts->coll);
-	return key_part_hint(key_def->parts, h);
+	return key_part_hint<has_desc_parts>(key_def->parts, h);
 }
 
 static hint_t
@@ -2014,12 +2036,22 @@ tuple_hint_stub(struct tuple *tuple, struct key_def *key_def)
 	return HINT_NONE;
 }
 
+template<enum field_type type, bool is_nullable, bool has_desc_parts>
+static void
+key_def_set_hint_func(struct key_def *def)
+{
+	def->key_hint = key_hint<type, is_nullable, has_desc_parts>;
+	def->tuple_hint = tuple_hint<type, is_nullable, has_desc_parts>;
+}
+
 template<enum field_type type, bool is_nullable>
 static void
 key_def_set_hint_func(struct key_def *def)
 {
-	def->key_hint = key_hint<type, is_nullable>;
-	def->tuple_hint = tuple_hint<type, is_nullable>;
+	if (key_def_has_desc_parts(def))
+		key_def_set_hint_func<type, is_nullable, true>(def);
+	else
+		key_def_set_hint_func<type, is_nullable, false>(def);
 }
 
 template<enum field_type type>
@@ -2126,13 +2158,14 @@ key_def_set_compare_func_fast(struct key_def *def)
 	}
 	if (cmp == NULL) {
 		cmp = is_sequential ?
-			tuple_compare_sequential<false, false> :
-			tuple_compare_slowpath<false, false, false, false>;
+			tuple_compare_sequential<false, false, false> :
+			tuple_compare_slowpath<false, false, false,
+					       false, false>;
 	}
 	if (cmp_wk == NULL) {
 		cmp_wk = is_sequential ?
-			tuple_compare_with_key_sequential<false, false> :
-			tuple_compare_with_key_slowpath<false, false,
+			tuple_compare_with_key_sequential<false, false, false> :
+			tuple_compare_with_key_slowpath<false, false, false,
 							false, false>;
 	}
 
@@ -2140,49 +2173,96 @@ key_def_set_compare_func_fast(struct key_def *def)
 	def->tuple_compare_with_key = cmp_wk;
 }
 
-template<bool is_nullable, bool has_optional_parts>
+template<bool is_nullable, bool has_optional_parts, bool has_desc_parts>
 static void
 key_def_set_compare_func_plain(struct key_def *def)
 {
 	assert(!def->has_json_paths);
 	if (key_def_is_sequential(def)) {
 		def->tuple_compare = tuple_compare_sequential
-					<is_nullable, has_optional_parts>;
+			<is_nullable, has_optional_parts, has_desc_parts>;
 		def->tuple_compare_with_key = tuple_compare_with_key_sequential
-					<is_nullable, has_optional_parts>;
+			<is_nullable, has_optional_parts, has_desc_parts>;
 	} else {
 		def->tuple_compare = tuple_compare_slowpath
-				<is_nullable, has_optional_parts, false, false>;
+				    <is_nullable, has_optional_parts,
+				     false, false, has_desc_parts>;
 		def->tuple_compare_with_key = tuple_compare_with_key_slowpath
-				<is_nullable, has_optional_parts, false, false>;
+					     <is_nullable, has_optional_parts,
+					      false, false, has_desc_parts>;
 	}
 }
 
+/* Proxy-template. */
+template<bool is_nullable, bool has_optional_parts>
+static void
+key_def_set_compare_func_plain(struct key_def *def)
+{
+	assert(!def->has_json_paths);
+	if (key_def_has_desc_parts(def))
+		key_def_set_compare_func_plain
+			<is_nullable, has_optional_parts, true>(def);
+	else
+		key_def_set_compare_func_plain
+			<is_nullable, has_optional_parts, false>(def);
+}
+
+template<bool is_nullable, bool has_optional_parts, bool has_desc_parts>
+static void
+key_def_set_compare_func_json(struct key_def *def)
+{
+	if (def->is_multikey) {
+		def->tuple_compare = tuple_compare_slowpath
+				    <is_nullable, has_optional_parts,
+				     true, true, has_desc_parts>;
+		def->tuple_compare_with_key = tuple_compare_with_key_slowpath
+					     <is_nullable, has_optional_parts,
+					      true, true, has_desc_parts>;
+	} else {
+		def->tuple_compare = tuple_compare_slowpath
+				    <is_nullable, has_optional_parts,
+				     true, false, has_desc_parts>;
+		def->tuple_compare_with_key = tuple_compare_with_key_slowpath
+					     <is_nullable, has_optional_parts,
+					      true, false, has_desc_parts>;
+	}
+}
+
+/* Proxy-template. */
 template<bool is_nullable, bool has_optional_parts>
 static void
 key_def_set_compare_func_json(struct key_def *def)
 {
 	assert(def->has_json_paths);
-	if (def->is_multikey) {
-		def->tuple_compare = tuple_compare_slowpath
-				<is_nullable, has_optional_parts, true, true>;
-		def->tuple_compare_with_key = tuple_compare_with_key_slowpath
-				<is_nullable, has_optional_parts, true, true>;
-	} else {
-		def->tuple_compare = tuple_compare_slowpath
-				<is_nullable, has_optional_parts, true, false>;
-		def->tuple_compare_with_key = tuple_compare_with_key_slowpath
-				<is_nullable, has_optional_parts, true, false>;
-	}
+	if (key_def_has_desc_parts(def))
+		key_def_set_compare_func_json
+			<is_nullable, has_optional_parts, true>(def);
+	else
+		key_def_set_compare_func_json
+			<is_nullable, has_optional_parts, false>(def);
 }
 
-template<bool is_nullable>
+/* Forced non-required comment. */
+template<bool is_nullable, bool has_desc_parts>
 static void
-key_def_set_compare_func_for_func_index(struct key_def *def)
+key_def_set_compare_func_of_func_index(struct key_def *def)
 {
 	assert(def->for_func_index);
-	def->tuple_compare = func_index_compare<is_nullable>;
-	def->tuple_compare_with_key = func_index_compare_with_key<is_nullable>;
+	def->tuple_compare = func_index_compare<is_nullable, has_desc_parts>;
+	def->tuple_compare_with_key = func_index_compare_with_key
+				     <is_nullable, has_desc_parts>;
+}
+
+/* Proxy-template. */
+template<bool is_nullable>
+static void
+key_def_set_compare_func_of_func_index(struct key_def *def)
+{
+	assert(def->for_func_index);
+	if (key_def_has_desc_parts(def))
+		key_def_set_compare_func_of_func_index<is_nullable, true>(def);
+	else
+		key_def_set_compare_func_of_func_index<is_nullable, false>(def);
 }
 
 void
@@ -2190,9 +2270,9 @@ key_def_set_compare_func(struct key_def *def)
 {
 	if (def->for_func_index) {
 		if (def->is_nullable)
-			key_def_set_compare_func_for_func_index<true>(def);
+			key_def_set_compare_func_of_func_index<true>(def);
 		else
-			key_def_set_compare_func_for_func_index<false>(def);
+			key_def_set_compare_func_of_func_index<false>(def);
 	} else if (!def->is_nullable && !def->has_json_paths &&
 	    !key_def_has_collation(def) && !key_def_has_desc_parts(def)) {
 		key_def_set_compare_func_fast(def);

--- a/src/box/tuple_compare.h
+++ b/src/box/tuple_compare.h
@@ -67,7 +67,8 @@ typedef uint64_t hint_t;
 /**
  * Reserved value to use when comparison hint is undefined.
  */
-#define HINT_NONE ((hint_t)UINT64_MAX)
+#define HINT_NONE ((hint_t)(UINT64_MAX))
+#define HINT_MAX  ((hint_t)(UINT64_MAX - 1))
 
 /**
  * Compare two tuple hints.

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -999,6 +999,8 @@ vinyl_index_def_change_requires_rebuild(struct index *index,
 			return true;
 		if (old_part->exclude_null != new_part->exclude_null)
 			return true;
+		if (old_part->sort_order != new_part->sort_order)
+			return true;
 	}
 	assert(old_cmp_def->is_multikey == new_cmp_def->is_multikey);
 	return false;

--- a/test/app-tap/module_api.test.lua
+++ b/test/app-tap/module_api.test.lua
@@ -671,7 +671,7 @@ local function test_box_ibuf(test, module)
 end
 
 require('tap').test("module_api", function(test)
-    test:plan(48)
+    test:plan(49)
     local status, module = pcall(require, 'module_api')
     test:is(status, true, "module")
     test:ok(status, "module is loaded")

--- a/test/box-luatest/gh_7356_index_parts_methods_test.lua
+++ b/test/box-luatest/gh_7356_index_parts_methods_test.lua
@@ -130,11 +130,11 @@ g.test_merge = function(cg)
         local j = s:create_index('j', {parts = {{type = 'unsigned', field = 1},
                                                 {type = 'string', field = 3}}})
         local exp = {{fieldno = 3, type = 'string', is_nullable = false,
-                      exclude_null = false},
+                      exclude_null = false, sort_order = 'asc'},
                      {fieldno = 2, type = 'scalar', is_nullable = false,
-                      exclude_null = false},
+                      exclude_null = false, sort_order = 'asc'},
                      {fieldno = 1, type = 'unsigned', is_nullable = false,
-                      exclude_null = false}}
+                      exclude_null = false, sort_order = 'asc'}}
         t.assert_equals(i.parts:merge(j.parts):totable(), exp)
 
         t.assert_error_msg_content_equals(

--- a/test/box-tap/key_def.test.lua
+++ b/test/box-tap/key_def.test.lua
@@ -11,6 +11,7 @@ local usage_error = 'Bad params, use: key_def.new({' ..
                     '{fieldno = fieldno, type = type' ..
                     '[, is_nullable = <boolean>]' ..
                     '[, exclude_null = <boolean>]' ..
+                    '[, sort_order = <string>]' ..
                     '[, path = <string>]' ..
                     '[, collation_id = <number>]' ..
                     '[, collation = <string>]}, ...}'
@@ -32,6 +33,9 @@ local function set_key_part_defaults(parts)
         end
         if res[i].exclude_null == nil then
             res[i].exclude_null = false
+        end
+        if res[i].sort_order == nil then
+            res[i].sort_order = 'asc'
         end
     end
     return res
@@ -122,6 +126,15 @@ local key_def_new_cases = {
         'Two parameters',
         params = {{}, {}},
         exp_err = usage_error,
+    },
+    {
+        'Unknown sort order',
+        parts = {{
+            fieldno = 1,
+            type = 'string',
+            sort_order = 'invalid',
+        }},
+        exp_err = 'Unknown sort order: "invalid"',
     },
     {
         'Invalid JSON path',
@@ -522,7 +535,7 @@ test:test('merge()', function(test)
     local key_def_cb = key_def_c:merge(key_def_b)
     local exp_parts = key_def_c:totable()
     exp_parts[#exp_parts + 1] = {type = 'number', fieldno = 3,
-        is_nullable = false, exclude_null = false}
+        is_nullable = false, exclude_null = false, sort_order = 'asc'}
     test:is_deeply(key_def_cb:totable(), exp_parts,
         'case 3: verify with :totable()')
     test:is_deeply(key_def_cb:extract_key(tuple_a):totable(),
@@ -530,7 +543,7 @@ test:test('merge()', function(test)
 
     local parts_unsigned = {
         {type = 'unsigned', fieldno = 1, is_nullable = false,
-         exclude_null = false},
+         exclude_null = false, sort_order = 'asc'},
     }
     local key_def_unsigned = key_def_lib.new(parts_unsigned)
     local key_def_string = key_def_lib.new({
@@ -554,11 +567,11 @@ test:test('merge()', function(test)
     local key_def_array_map = key_def_array:merge(key_def_map)
     local exp_parts = {
         {type = 'array', fieldno = 1, is_nullable = false,
-         exclude_null = false},
+         exclude_null = false, sort_order = 'asc'},
         {type = 'unsigned', fieldno = 2, is_nullable = false,
-         exclude_null = false},
+         exclude_null = false, sort_order = 'asc'},
         {type = 'map', fieldno = 3, is_nullable = true,
-         exclude_null = false},
+         exclude_null = false, sort_order = 'asc'},
     }
     test:is_deeply(key_def_array_map:totable(), exp_parts,
         'composite case')

--- a/test/box/alter.result
+++ b/test/box/alter.result
@@ -704,14 +704,16 @@ s.index.pk
 ---
 - unique: true
   parts:
-  - type: unsigned
+  - fieldno: 1
+    sort_order: asc
+    type: unsigned
     exclude_null: false
     is_nullable: false
-    fieldno: 1
-  - type: unsigned
+  - fieldno: 2
+    sort_order: asc
+    type: unsigned
     exclude_null: false
     is_nullable: false
-    fieldno: 2
   hint: true
   id: 0
   type: TREE
@@ -740,10 +742,11 @@ s.index.pk
 ---
 - unique: true
   parts:
-  - type: unsigned
+  - fieldno: 1
+    sort_order: asc
+    type: unsigned
     exclude_null: false
     is_nullable: false
-    fieldno: 1
   hint: true
   id: 0
   type: TREE
@@ -754,10 +757,11 @@ s.index.secondary
 ---
 - unique: true
   parts:
-  - type: unsigned
+  - fieldno: 2
+    sort_order: asc
+    type: unsigned
     exclude_null: false
     is_nullable: false
-    fieldno: 2
   hint: true
   id: 1
   type: TREE

--- a/test/box/errinj.result
+++ b/test/box/errinj.result
@@ -1730,10 +1730,11 @@ rtreespace:create_index('pk', {if_not_exists = true})
 ---
 - unique: true
   parts:
-  - type: unsigned
+  - fieldno: 1
+    sort_order: asc
+    type: unsigned
     exclude_null: false
     is_nullable: false
-    fieldno: 1
   hint: true
   id: 0
   type: TREE

--- a/test/box/gh-5998-one-tx-for-ddl.result
+++ b/test/box/gh-5998-one-tx-for-ddl.result
@@ -39,10 +39,11 @@ s1:create_index('pk')
  | ---
  | - unique: true
  |   parts:
- |   - type: unsigned
+ |   - fieldno: 1
+ |     sort_order: asc
+ |     type: unsigned
  |     exclude_null: false
  |     is_nullable: false
- |     fieldno: 1
  |   hint: true
  |   id: 0
  |   type: TREE

--- a/test/box/lua.result
+++ b/test/box/lua.result
@@ -713,14 +713,16 @@ tmp = space:create_index('primary', { type = 'tree', parts = {3, 'unsigned', 2, 
 -- Print key fields in pk
 space.index['primary'].parts
 ---
-- - type: unsigned
+- - fieldno: 3
+    sort_order: asc
+    type: unsigned
     exclude_null: false
     is_nullable: false
-    fieldno: 3
-  - type: unsigned
+  - fieldno: 2
+    sort_order: asc
+    type: unsigned
     exclude_null: false
     is_nullable: false
-    fieldno: 2
 ...
 space:insert{1, 2, 3, 4}
 ---

--- a/test/box/misc.result
+++ b/test/box/misc.result
@@ -849,14 +849,16 @@ not not s:create_index('test3', {parts = {{3, 'string', collation = 'UnIcOdE'}}}
 ...
 s:create_index('test4', {parts = {{4, 'string'}}}).parts
 ---
-- - type: string
+- - fieldno: 4
+    sort_order: asc
+    type: string
     exclude_null: false
     is_nullable: false
-    fieldno: 4
 ...
 s:create_index('test5', {parts = {{5, 'string', collation = 'Unicode'}}}).parts
 ---
 - - fieldno: 5
+    sort_order: asc
     type: string
     exclude_null: false
     collation: unicode
@@ -1051,6 +1053,7 @@ i = s:create_index('test2', {parts = {{2, 'string', is_nullable = true, collatio
 i.parts
 ---
 - - fieldno: 2
+    sort_order: asc
     type: string
     exclude_null: false
     collation: unicode
@@ -1061,10 +1064,11 @@ i = s:create_index('test4', {parts = {3, 'string', is_nullable = true}})
 ...
 i.parts
 ---
-- - type: string
+- - fieldno: 3
+    sort_order: asc
+    type: string
     exclude_null: false
     is_nullable: true
-    fieldno: 3
 ...
 i = s:create_index('test5', {parts = {3, 'string', collation = 'unicode'}})
 ---
@@ -1072,6 +1076,7 @@ i = s:create_index('test5', {parts = {3, 'string', collation = 'unicode'}})
 i.parts
 ---
 - - fieldno: 3
+    sort_order: asc
     type: string
     exclude_null: false
     collation: unicode
@@ -1082,10 +1087,11 @@ i = s:create_index('test6', {parts = {4, 'string'}})
 ...
 i.parts
 ---
-- - type: string
+- - fieldno: 4
+    sort_order: asc
+    type: string
     exclude_null: false
     is_nullable: false
-    fieldno: 4
 ...
 s:drop()
 ---

--- a/test/box/tx_man.result
+++ b/test/box/tx_man.result
@@ -3882,10 +3882,11 @@ s:create_index('sk', {parts = {{2, 'unsigned'}}})
  | ---
  | - unique: true
  |   parts:
- |   - type: unsigned
+ |   - fieldno: 2
+ |     sort_order: asc
+ |     type: unsigned
  |     exclude_null: false
  |     is_nullable: false
- |     fieldno: 2
  |   hint: true
  |   id: 1
  |   type: TREE

--- a/test/engine-luatest/gh_5529_sort_order_test.lua
+++ b/test/engine-luatest/gh_5529_sort_order_test.lua
@@ -1,0 +1,342 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g_local = t.group('sort_order_test:local')
+
+local g_each_engine = t.group('sort_order_test:each_engine',
+    t.helpers.matrix({engine = {'memtx', 'vinyl'}}))
+
+local g_sequential = t.group('sort_order_test:sequential', t.helpers.matrix({
+    engine = {'memtx', 'vinyl'},
+    is_unique = {true, false}
+}))
+
+local g_func_index = t.group('sort_order_test:func_index', t.helpers.matrix({
+    engine = {'memtx'},
+    is_nullable = {true, false},
+    is_unique = {true, false}
+}))
+
+for _, g in pairs({g_local, g_sequential, g_func_index, g_each_engine}) do
+    g.before_all(function(cg)
+        cg.server = server:new({alias = 'default'})
+        cg.server:start()
+    end)
+
+    g.after_all(function(cg)
+        cg.server:drop()
+    end)
+end
+
+g_func_index.before_test('test_regular', function(cg)
+    cg.server:exec(function(engine)
+        local s = box.schema.space.create('s', {engine = engine})
+        s:create_index('pk', {parts = {
+            {1, 'unsigned'},
+            {2, 'unsigned'},
+            {3, 'unsigned'},
+            {4, 'unsigned'}
+        }})
+        for i = 1, 2 do
+            for j = 1, 2 do
+                for k = 1, 2 do
+                    for l = 1, 2 do
+                        s:insert({i, j, k, l})
+                    end
+                end
+            end
+        end
+    end, {cg.params.engine})
+end)
+
+g_func_index.after_test('test_regular', function(cg)
+    cg.server:exec(function()
+        if box.space.s ~= nil then
+            box.space.s:drop()
+        end
+        if box.func.f ~= nil then
+            box.func.f:drop()
+        end
+    end)
+end)
+
+g_func_index.test_regular = function(cg)
+    local expect = {
+        {2, 1, 2, 1},
+        {2, 1, 2, 2},
+        {2, 1, 1, 1},
+        {2, 1, 1, 2},
+        {2, 2, 2, 1},
+        {2, 2, 2, 2},
+        {2, 2, 1, 1},
+        {2, 2, 1, 2},
+        {1, 1, 2, 1},
+        {1, 1, 2, 2},
+        {1, 1, 1, 1},
+        {1, 1, 1, 2},
+        {1, 2, 2, 1},
+        {1, 2, 2, 2},
+        {1, 2, 1, 1},
+        {1, 2, 1, 2}
+    }
+
+    cg.server:exec(function(engine, is_nullable, is_unique, expect)
+        t.assert(engine ~= nil)
+        t.assert(is_nullable ~= nil)
+        t.assert(is_unique ~= nil)
+        local s = box.space.s
+        local lua_code
+        if is_nullable then
+            lua_code = 'function(t) return {t[1], t[2],'
+                       .. ' t[3] == 2 and t[3] or nil, t[4]} end'
+        else
+            lua_code = 'function(t) return {t[1], t[2], t[3], t[4]} end'
+        end
+        box.schema.func.create('f', {
+            body = lua_code,
+            is_deterministic = true,
+            is_sandboxed = true
+        })
+        local idx = s:create_index('f', {parts = {
+            {1, 'unsigned', sort_order = 'desc'},
+            {2, 'unsigned', sort_order = 'asc'},
+            {3, 'unsigned', sort_order = 'desc', is_nullable = is_nullable},
+            {4, 'unsigned', sort_order = 'asc'}
+        }, func = 'f', unique = is_unique})
+        t.assert_equals(idx:select(), expect)
+    end, {cg.params.engine, cg.params.is_nullable, cg.params.is_unique, expect})
+
+    -- Assure the index is built the right way on the WAL recovery.
+    cg.server:restart()
+    cg.server:exec(function(expect)
+        t.assert_equals(box.space.s.index.f:select(), expect)
+    end, {expect})
+
+    -- Assure the index is built the right way on the snapshot recovery.
+    cg.server:eval('box.snapshot()')
+    cg.server:restart()
+    cg.server:exec(function(expect)
+        t.assert_equals(box.space.s.index.f:select(), expect)
+    end, {expect})
+end
+
+g_func_index.before_test('test_singlepart', function(cg)
+    cg.server:exec(function(engine)
+        local s = box.schema.space.create('s', {engine = engine})
+        s:create_index('pk', {parts = {{1, 'unsigned'}}})
+        for i = 1, 16 do
+            s:insert({i})
+        end
+    end, {cg.params.engine})
+end)
+
+g_func_index.after_test('test_singlepart', function(cg)
+    cg.server:exec(function()
+        if box.space.s ~= nil then
+            box.space.s:drop()
+        end
+        if box.func.f ~= nil then
+            box.func.f:drop()
+        end
+    end)
+end)
+
+g_func_index.test_singlepart = function(cg)
+    cg.server:exec(function(engine, is_nullable, is_unique)
+        t.assert(engine ~= nil)
+        t.assert(is_nullable ~= nil)
+        t.assert(is_unique ~= nil)
+        local s = box.space.s
+        local lua_code = 'function(tuple) return {tuple[1]} end'
+        box.schema.func.create('f', {
+            body = lua_code,
+            is_deterministic = true,
+            is_sandboxed = true
+        })
+        local idx = s:create_index('f', {parts = {
+            {1, 'unsigned', sort_order = 'desc', is_nullable = is_nullable},
+        }, func = 'f', unique = is_unique})
+        local expect = {{16}, {15}, {14}, {13}, {12}, {11}, {10}, {9},
+                        {8},  {7},  {6},  {5},  {4},  {3},  {2},  {1}}
+        t.assert_equals(idx:select(), expect)
+        expect = {{8},  {7},  {6},  {5},  {4},  {3},  {2},  {1}}
+        t.assert_equals(idx:select(9, {iterator = 'GT'}), expect)
+        expect = {{9}, {10}, {11}, {12}, {13}, {14}, {15}, {16}}
+        t.assert_equals(idx:select(8, {iterator = 'LT'}), expect)
+        expect = {{9}, {8},  {7},  {6},  {5},  {4},  {3},  {2},  {1}}
+        t.assert_equals(idx:select(9, {iterator = 'GE'}), expect)
+        expect = {{8}, {9}, {10}, {11}, {12}, {13}, {14}, {15}, {16}}
+        t.assert_equals(idx:select(8, {iterator = 'LE'}), expect)
+    end, {cg.params.engine, cg.params.is_nullable, cg.params.is_unique})
+
+    -- Assure the index is built the right way on the WAL recovery.
+    cg.server:restart()
+    cg.server:exec(function()
+        local expect = {{16}, {15}, {14}, {13}, {12}, {11}, {10}, {9},
+                        {8},  {7},  {6},  {5},  {4},  {3},  {2},  {1}}
+        t.assert_equals(box.space.s.index.f:select(), expect)
+        -- Add some data for the next test.
+        box.space.s:insert({17})
+        box.space.s:insert({18})
+    end)
+
+    -- Assure the index is built the right way on the snapshot recovery.
+    cg.server:eval('box.snapshot()')
+    cg.server:restart()
+    cg.server:exec(function()
+        local expect = {{18}, {17}, {16}, {15}, {14}, {13}, {12}, {11}, {10},
+                        {9},  {8},  {7},  {6},  {5},  {4},  {3},  {2},  {1}}
+        t.assert_equals(box.space.s.index.f:select(), expect)
+    end)
+end
+
+g_sequential.before_test('test_sequential', function(cg)
+    cg.server:exec(function(engine)
+        local s = box.schema.space.create('s', {engine = engine})
+        s:create_index('pk', {parts = {{4, 'unsigned'}}})
+        local id = 1
+        for i = 1, 2 do
+            for j = 1, 2 do
+                for k = 1, 2 do
+                    s:insert({i, j, k, id})
+                    id = id + 1
+                end
+            end
+        end
+    end, {cg.params.engine})
+end)
+
+g_sequential.after_test('test_sequential', function(cg)
+    cg.server:exec(function()
+        if box.space.s ~= nil then
+            box.space.s:drop()
+        end
+    end)
+end)
+
+g_sequential.test_sequential = function(cg)
+    cg.server:exec(function(engine, is_unique)
+        t.assert(engine ~= nil)
+        t.assert(is_unique ~= nil)
+        local s = box.space.s
+        local idx = s:create_index('sk', {parts = {
+            {1, 'unsigned', sort_order = 'desc'},
+            {2, 'unsigned', sort_order = 'asc'},
+            {3, 'unsigned', sort_order = 'desc'},
+        }, unique = is_unique})
+        local expect = {
+            {2, 1, 2, 6},
+            {2, 1, 1, 5},
+            {2, 2, 2, 8},
+            {2, 2, 1, 7},
+            {1, 1, 2, 2},
+            {1, 1, 1, 1},
+            {1, 2, 2, 4},
+            {1, 2, 1, 3}
+        }
+        t.assert_equals(idx:select(), expect)
+    end, {cg.params.engine, cg.params.is_unique})
+end
+
+g_each_engine.before_test('test_alter_sort_order', function(cg)
+    cg.server:exec(function(engine)
+        local s = box.schema.space.create('s', {engine = engine})
+        s:create_index('pk', {parts = {{1, 'unsigned'}}})
+        s:create_index('i', {parts = {{1, 'unsigned'}}})
+        for i = 1, 10 do
+            s:insert({i})
+        end
+    end, {cg.params.engine})
+end)
+
+g_each_engine.after_test('test_alter_sort_order', function(cg)
+    cg.server:exec(function()
+        if box.space.s ~= nil then
+            box.space.s:drop()
+        end
+    end)
+end)
+
+g_each_engine.test_alter_sort_order = function(cg)
+    cg.server:exec(function(engine)
+        local data_asc = {}
+        local data_desc = {}
+        for i = 1, 10 do
+            data_asc[i] = {i}
+            data_desc[11 - i] = {i}
+        end
+        local s = box.space.s
+
+        local i = s.index.i
+        t.assert_equals(i:select(), data_asc)
+        i:alter({parts = {{1, 'unsigned', sort_order = 'desc'}}})
+        t.assert_equals(i:select(), data_desc)
+        i:alter({parts = {{1, 'unsigned', sort_order = 'asc'}}})
+        t.assert_equals(i:select(), data_asc)
+
+        -- Vynil does not support the primary index rebuild.
+        if engine ~= 'vinyl' then
+            i = s.index.pk
+            t.assert_equals(i:select(), data_asc)
+            i:alter({parts = {{1, 'unsigned', sort_order = 'desc'}}})
+            t.assert_equals(i:select(), data_desc)
+            i:alter({parts = {{1, 'unsigned', sort_order = 'asc'}}})
+            t.assert_equals(i:select(), data_asc)
+        end
+    end, {cg.params.engine})
+end
+
+g_local.after_test('test_box_api', function(cg)
+    cg.server:exec(function()
+        if box.space.s ~= nil then
+            box.space.s:drop()
+        end
+    end)
+end)
+
+g_local.test_box_api = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('s', {engine = 'memtx'})
+        local msg = 'Wrong index part 1: unknown sort order'
+        t.assert_error_msg_contains(msg, s.create_index, s, 'i', {parts = {
+            {1, 'unsigned', sort_order = 'invalid'},
+        }})
+        msg = 'Wrong index part 1: unordered indexes do not support sort_order'
+        t.assert_error_msg_contains(msg, s.create_index, s, 'i', {
+            type = 'HASH',
+            parts = {{1, 'unsigned', sort_order = 'asc'}},
+        })
+        t.assert_error_msg_contains(msg, s.create_index, s, 'i', {
+            type = 'RTREE',
+            parts = {{1, 'unsigned', sort_order = 'asc'}},
+        })
+        t.assert_error_msg_contains(msg, s.create_index, s, 'i', {
+            type = 'BITSET',
+            parts = {{1, 'unsigned', sort_order = 'asc'}},
+        })
+    end)
+end
+
+g_local.after_test('test_infinities_sort_order', function(cg)
+    cg.server:exec(function()
+        if box.space.s ~= nil then
+            box.space.s:drop()
+        end
+    end)
+end)
+
+g_local.test_infinities_sort_order = function(cg)
+    cg.server:exec(function()
+        -- Test that hints don't violate the correct order of
+        -- infinite values if the part is descending.
+        local s = box.schema.space.create('s', {engine = 'memtx'})
+        local desc = s:create_index('desc', {parts = {
+            {1, 'number', sort_order = 'desc'}
+        }})
+        s:insert{math.huge}
+        s:insert{-math.huge}
+        s:insert{1e100}
+        local expect = {{math.huge}, {1e100}, {-math.huge}}
+        t.assert_equals(desc:select(), expect)
+    end)
+end

--- a/test/engine/ddl.result
+++ b/test/engine/ddl.result
@@ -310,10 +310,11 @@ pk = space:create_index('pk', {parts={{field = 1, type = 'unsigned'}}})
 ...
 pk.parts
 ---
-- - type: unsigned
+- - fieldno: 1
+    sort_order: asc
+    type: unsigned
     exclude_null: false
     is_nullable: false
-    fieldno: 1
 ...
 pk:drop()
 ---
@@ -323,10 +324,11 @@ pk = space:create_index('pk', {parts={{1, 'unsigned'}}})
 ...
 pk.parts
 ---
-- - type: unsigned
+- - fieldno: 1
+    sort_order: asc
+    type: unsigned
     exclude_null: false
     is_nullable: false
-    fieldno: 1
 ...
 pk:drop()
 ---
@@ -336,10 +338,11 @@ pk = space:create_index('pk', {parts={{1, type='unsigned'}}})
 ...
 pk.parts
 ---
-- - type: unsigned
+- - fieldno: 1
+    sort_order: asc
+    type: unsigned
     exclude_null: false
     is_nullable: false
-    fieldno: 1
 ...
 space:insert{1, 2, 3}
 ---
@@ -728,10 +731,11 @@ s:format()
 ...
 s.index.sk3.parts
 ---
-- - type: string
+- - fieldno: 2
+    sort_order: asc
+    type: string
     exclude_null: false
     is_nullable: false
-    fieldno: 2
 ...
 -- Space format can be updated, if conflicted index is deleted.
 sk3:drop()
@@ -956,10 +960,11 @@ s:create_index('test', {parts = {{field = 'test'}}})
 ...
 s:create_index('test', {parts = {1}}).parts
 ---
-- - type: scalar
+- - fieldno: 1
+    sort_order: asc
+    type: scalar
     exclude_null: false
     is_nullable: false
-    fieldno: 1
 ...
 s:drop()
 ---
@@ -984,10 +989,11 @@ s:create_index('test', {parts = {{field = 'test'}}})
 ...
 s:create_index('test1', {parts = {'test1'}}).parts
 ---
-- - type: integer
+- - fieldno: 1
+    sort_order: asc
+    type: integer
     exclude_null: false
     is_nullable: false
-    fieldno: 1
 ...
 s:create_index('test2', {parts = {'test2'}}).parts
 ---
@@ -996,57 +1002,66 @@ s:create_index('test2', {parts = {'test2'}}).parts
 ...
 s:create_index('test3', {parts = {{'test1', 'integer'}}}).parts
 ---
-- - type: integer
+- - fieldno: 1
+    sort_order: asc
+    type: integer
     exclude_null: false
     is_nullable: false
-    fieldno: 1
 ...
 s:create_index('test4', {parts = {{'test2', 'integer'}}}).parts
 ---
-- - type: integer
+- - fieldno: 2
+    sort_order: asc
+    type: integer
     exclude_null: false
     is_nullable: false
-    fieldno: 2
 ...
 s:create_index('test5', {parts = {{'test2', 'integer'}}}).parts
 ---
-- - type: integer
+- - fieldno: 2
+    sort_order: asc
+    type: integer
     exclude_null: false
     is_nullable: false
-    fieldno: 2
 ...
 s:create_index('test6', {parts = {1, 3}}).parts
 ---
-- - type: integer
+- - fieldno: 1
+    sort_order: asc
+    type: integer
     exclude_null: false
     is_nullable: false
-    fieldno: 1
-  - type: integer
+  - fieldno: 3
+    sort_order: asc
+    type: integer
     exclude_null: false
     is_nullable: false
-    fieldno: 3
 ...
 s:create_index('test7', {parts = {'test1', 4}}).parts
 ---
-- - type: integer
+- - fieldno: 1
+    sort_order: asc
+    type: integer
     exclude_null: false
     is_nullable: false
-    fieldno: 1
-  - type: scalar
+  - fieldno: 4
+    sort_order: asc
+    type: scalar
     exclude_null: false
     is_nullable: false
-    fieldno: 4
 ...
 s:create_index('test8', {parts = {{1, 'integer'}, {'test4', 'scalar'}}}).parts
 ---
-- - type: integer
+- - fieldno: 1
+    sort_order: asc
+    type: integer
     exclude_null: false
     is_nullable: false
-    fieldno: 1
-  - type: scalar
+  - fieldno: 4
+    sort_order: asc
+    type: scalar
     exclude_null: false
     is_nullable: false
-    fieldno: 4
 ...
 s:drop()
 ---
@@ -1682,10 +1697,11 @@ i = s:create_index('primary', { parts = {'field1'} })
 ...
 i.parts
 ---
-- - type: unsigned
+- - fieldno: 1
+    sort_order: asc
+    type: unsigned
     exclude_null: false
     is_nullable: false
-    fieldno: 1
 ...
 -- Check that is_nullable can't be set to false on non-empty space
 s:insert({1, NULL})
@@ -1757,10 +1773,11 @@ i = s:create_index('secondary', { parts = {{2, 'string', is_nullable = true}} })
 ...
 i.parts
 ---
-- - type: string
+- - fieldno: 2
+    sort_order: asc
+    type: string
     exclude_null: false
     is_nullable: true
-    fieldno: 2
 ...
 s:insert({1, NULL})
 ---

--- a/test/engine/null.result
+++ b/test/engine/null.result
@@ -1948,20 +1948,22 @@ sk1 = s:create_index('sk1', {parts={{2, 'number', is_nullable=true, exclude_null
 ...
 sk1.parts
 ---
-- - type: number
+- - fieldno: 2
+    sort_order: asc
+    type: number
     exclude_null: true
     is_nullable: true
-    fieldno: 2
 ...
 sk2 = s:create_index('sk2', {parts={{2, 'number', is_nullable=true, exclude_null=false}}})
 ---
 ...
 sk2.parts
 ---
-- - type: number
+- - fieldno: 2
+    sort_order: asc
+    type: number
     exclude_null: false
     is_nullable: true
-    fieldno: 2
 ...
 s:insert{1, 1}
 ---
@@ -2101,10 +2103,11 @@ sk1 = s:create_index('sk1', {parts={{2, 'number', exclude_null=true}}})
 ...
 sk1.parts
 ---
-- - type: number
+- - fieldno: 2
+    sort_order: asc
+    type: number
     exclude_null: true
     is_nullable: true
-    fieldno: 2
 ...
 s:select{}
 ---
@@ -2124,10 +2127,11 @@ sk1:alter({parts={{2, 'number', is_nullable=true, exclude_null=false}}})
 ...
 sk1.parts
 ---
-- - type: number
+- - fieldno: 2
+    sort_order: asc
+    type: number
     exclude_null: false
     is_nullable: true
-    fieldno: 2
 ...
 sk1:select{}
 ---
@@ -2142,10 +2146,11 @@ sk1:alter({parts={{2, 'number', exclude_null=true}}})
 ...
 sk1.parts
 ---
-- - type: number
+- - fieldno: 2
+    sort_order: asc
+    type: number
     exclude_null: true
     is_nullable: true
-    fieldno: 2
 ...
 sk1:select{}
 ---
@@ -2160,10 +2165,11 @@ sk1:alter({parts={{2, 'number', is_nullable=false, exclude_null=true}}})
 ...
 sk1.parts
 ---
-- - type: number
+- - fieldno: 2
+    sort_order: asc
+    type: number
     exclude_null: true
     is_nullable: true
-    fieldno: 2
 ...
 -- Check that delete doesn't crash on sk1
 s:insert{5, box.NULL}
@@ -2456,10 +2462,11 @@ sk = s:create_index('sk', {parts = {2, is_nullable=true}})
 ...
 sk.parts
 ---
-- - type: scalar
+- - fieldno: 2
+    sort_order: asc
+    type: scalar
     exclude_null: false
     is_nullable: true
-    fieldno: 2
 ...
 sk:drop()
 ---
@@ -2470,6 +2477,7 @@ sk = s:create_index('sk', {parts = {2, is_nullable=true, collation='unicode'}})
 sk.parts
 ---
 - - fieldno: 2
+    sort_order: asc
     type: scalar
     exclude_null: false
     collation: unicode
@@ -2484,6 +2492,7 @@ sk = s:create_index('sk', {parts = {2, type='string', is_nullable=true, collatio
 sk.parts
 ---
 - - fieldno: 2
+    sort_order: asc
     type: string
     exclude_null: false
     collation: unicode
@@ -2499,6 +2508,7 @@ sk = s:create_index('sk', {parts = {2, is_nullable=true, 3}})
 sk.parts
 ---
 - - fieldno: 2
+    sort_order: asc
     type: string
     exclude_null: false
     collation: unicode
@@ -2512,14 +2522,16 @@ sk = s:create_index('sk', {parts = {2, 3}})
 ...
 sk.parts
 ---
-- - type: scalar
+- - fieldno: 2
+    sort_order: asc
+    type: scalar
     exclude_null: false
     is_nullable: false
-    fieldno: 2
-  - type: scalar
+  - fieldno: 3
+    sort_order: asc
+    type: scalar
     exclude_null: false
     is_nullable: false
-    fieldno: 3
 ...
 sk:drop()
 ---
@@ -2529,18 +2541,21 @@ sk = s:create_index('sk', {parts = {2, 3, 4}})
 ...
 sk.parts
 ---
-- - type: scalar
+- - fieldno: 2
+    sort_order: asc
+    type: scalar
     exclude_null: false
     is_nullable: false
-    fieldno: 2
-  - type: scalar
+  - fieldno: 3
+    sort_order: asc
+    type: scalar
     exclude_null: false
     is_nullable: false
-    fieldno: 3
-  - type: scalar
+  - fieldno: 4
+    sort_order: asc
+    type: scalar
     exclude_null: false
     is_nullable: false
-    fieldno: 4
 ...
 sk:drop()
 ---
@@ -2550,14 +2565,16 @@ sk = s:create_index('sk', {parts = {{2, 'int'}, {3, 'string'}}})
 ...
 sk.parts
 ---
-- - type: integer
+- - fieldno: 2
+    sort_order: asc
+    type: integer
     exclude_null: false
     is_nullable: false
-    fieldno: 2
-  - type: string
+  - fieldno: 3
+    sort_order: asc
+    type: string
     exclude_null: false
     is_nullable: false
-    fieldno: 3
 ...
 sk:drop()
 ---
@@ -2567,11 +2584,13 @@ sk = s:create_index('sk', {parts = {{2, is_nullable=true}, {3, collation='unicod
 ...
 sk.parts
 ---
-- - type: scalar
+- - fieldno: 2
+    sort_order: asc
+    type: scalar
     exclude_null: false
     is_nullable: true
-    fieldno: 2
   - fieldno: 3
+    sort_order: asc
     type: scalar
     exclude_null: false
     collation: unicode

--- a/test/sql/types.result
+++ b/test/sql/types.result
@@ -81,47 +81,55 @@ box.execute("CREATE INDEX i4 ON t1 (id, c, b, a, d);")
 ...
 box.space.T1.index.I1.parts
 ---
-- - type: number
+- - fieldno: 2
+    sort_order: asc
+    type: number
     exclude_null: false
     is_nullable: true
-    fieldno: 2
 ...
 box.space.T1.index.I2.parts
 ---
-- - type: integer
+- - fieldno: 3
+    sort_order: asc
+    type: integer
     exclude_null: false
     is_nullable: true
-    fieldno: 3
 ...
 box.space.T1.index.I3.parts
 ---
-- - type: string
+- - fieldno: 4
+    sort_order: asc
+    type: string
     exclude_null: false
     is_nullable: true
-    fieldno: 4
 ...
 box.space.T1.index.I4.parts
 ---
-- - type: string
+- - fieldno: 1
+    sort_order: asc
+    type: string
     exclude_null: false
     is_nullable: false
-    fieldno: 1
-  - type: string
+  - fieldno: 4
+    sort_order: asc
+    type: string
     exclude_null: false
     is_nullable: true
-    fieldno: 4
-  - type: integer
+  - fieldno: 3
+    sort_order: asc
+    type: integer
     exclude_null: false
     is_nullable: true
-    fieldno: 3
-  - type: number
+  - fieldno: 2
+    sort_order: asc
+    type: number
     exclude_null: false
     is_nullable: true
-    fieldno: 2
-  - type: scalar
+  - fieldno: 5
+    sort_order: asc
+    type: scalar
     exclude_null: false
     is_nullable: true
-    fieldno: 5
 ...
 box.execute("DROP VIEW v1;")
 ---

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -565,7 +565,7 @@ create_unit_test(PREFIX iterator_position
 )
 
 create_unit_test(PREFIX key_def
-                 SOURCES key_def.c box_test_utils.c
+                 SOURCES key_def.cc box_test_utils.c
                  LIBRARIES unit box core
 )
 

--- a/test/unit/key_def.cc
+++ b/test/unit/key_def.cc
@@ -21,13 +21,13 @@ test_key_new_va(const char *format, va_list ap)
 
 	/* Format the MsgPack key definition. */
 	const size_t mp_buf_size = 1024;
-	char *mp_buf = region_alloc(region, mp_buf_size);
+	char *mp_buf = (char *)region_alloc(region, mp_buf_size);
 	fail_if(mp_buf == NULL);
 	size_t mp_size = mp_vformat(mp_buf, mp_buf_size, format, ap);
 	fail_if(mp_size > mp_buf_size);
 
 	/* Create a key. */
-	char *key = xmalloc(mp_size);
+	char *key = (char *)xmalloc(mp_size);
 	memcpy(key, mp_buf, mp_size);
 
 	region_truncate(region, region_svp);
@@ -54,7 +54,7 @@ test_tuple_new_va(const char *format, va_list ap)
 
 	/* Format the MsgPack key definition. */
 	const size_t mp_buf_size = 1024;
-	char *mp_buf = region_alloc(region, mp_buf_size);
+	char *mp_buf = (char *)region_alloc(region, mp_buf_size);
 	fail_if(mp_buf == NULL);
 	size_t mp_size = mp_vformat(mp_buf, mp_buf_size, format, ap);
 	fail_if(mp_size > mp_buf_size);
@@ -87,14 +87,14 @@ test_key_def_new_va(const char *format, va_list ap, bool for_func_index)
 
 	/* Format the MsgPack key definition. */
 	const size_t mp_buf_size = 1024;
-	char *mp_buf = region_alloc(region, mp_buf_size);
+	char *mp_buf = (char *)region_alloc(region, mp_buf_size);
 	fail_if(mp_buf == NULL);
 	fail_if(mp_vformat(mp_buf, mp_buf_size, format, ap) > mp_buf_size);
 
 	/* Decode the key parts. */
 	const char *parts = mp_buf;
 	uint32_t part_count = mp_decode_array(&parts);
-	struct key_part_def *part_def = region_alloc(
+	struct key_part_def *part_def = (struct key_part_def *)region_alloc(
 		region, sizeof(*part_def) * part_count);
 	fail_if(part_def == NULL);
 	fail_if(key_def_decode_parts(part_def, part_count, &parts,

--- a/test/unit/luaT_tuple_new.c
+++ b/test/unit/luaT_tuple_new.c
@@ -125,7 +125,7 @@ test_basic(struct lua_State *L)
 	part.exclude_null = false;
 	part.sort_order = SORT_ORDER_ASC;
 	part.path = NULL;
-	struct key_def *key_def = key_def_new(&part, 1, false);
+	struct key_def *key_def = key_def_new(&part, 1, 0);
 	box_tuple_format_t *another_format = box_tuple_format_new(&key_def, 1);
 	key_def_delete(key_def);
 

--- a/test/unit/merger.test.c
+++ b/test/unit/merger.test.c
@@ -214,7 +214,7 @@ test_merger(struct tuple_format *format)
 		merge_source_array_new(true),
 	};
 
-	struct key_def *key_def = key_def_new(&key_part_unsigned, 1, false);
+	struct key_def *key_def = key_def_new(&key_part_unsigned, 1, 0);
 	struct merge_source *merger = merger_new(key_def, sources, source_count,
 						 false);
 	key_def_delete(key_def);
@@ -252,7 +252,7 @@ test_basic()
 	plan(4);
 	header();
 
-	struct key_def *key_def = key_def_new(&key_part_integer, 1, false);
+	struct key_def *key_def = key_def_new(&key_part_integer, 1, 0);
 	struct tuple_format *format = box_tuple_format_new(&key_def, 1);
 	assert(format != NULL);
 

--- a/test/vinyl/ddl.result
+++ b/test/vinyl/ddl.result
@@ -570,10 +570,11 @@ box.space.test.index.pk
 ---
 - unique: true
   parts:
-  - type: unsigned
+  - fieldno: 1
+    sort_order: asc
+    type: unsigned
     exclude_null: false
     is_nullable: false
-    fieldno: 1
   options:
     page_size: 8192
     run_count_per_level: 2

--- a/test/vinyl/layout.result
+++ b/test/vinyl/layout.result
@@ -138,8 +138,8 @@ result
     - - HEADER:
           type: INSERT
         BODY:
-          tuple: [0, {6: 512, 7: [{'field': 0, 'collation': 1, 'type': 'string'}],
-              9: 19, 12: 2, 13: 6}]
+          tuple: [0, {6: 512, 7: [{'field': 0, 'sort_order': 'asc', 'collation': 1,
+                  'type': 'string'}], 9: 19, 12: 2, 13: 6}]
       - HEADER:
           type: INSERT
         BODY:
@@ -163,8 +163,8 @@ result
       - HEADER:
           type: INSERT
         BODY:
-          tuple: [0, {0: 2, 5: 1, 6: 512, 7: [{'field': 1, 'is_nullable': true, 'type': 'unsigned'}],
-              9: 19, 12: 3, 13: 6}]
+          tuple: [0, {0: 2, 5: 1, 6: 512, 7: [{'field': 1, 'sort_order': 'asc', 'is_nullable': true,
+                  'type': 'unsigned'}], 9: 19, 12: 3, 13: 6}]
       - HEADER:
           type: INSERT
         BODY:


### PR DESCRIPTION
## Overview

This patch implements the previously introduced (but non-functional) `sort_order` key part parameter and exposes corresponding API to Lua's `key_def` API and C API.

The `key_def` is made aware if its index is unordered (the new `is_unordered` field is introduced), the `key_def_new` function signature has been modified: new `flags` parameter has been introduced, the `for_func_index` flag has been moved to it. Also `is_unordered` flag has been introduced.

Added semantically correct iterators for indexes with descending parts (these are aliases actually):
```lua
box.index.FORWARD_INCLUSIVE = box.index.GE
box.index.FORWARD_EXCLUSIVE = box.index.GT
box.index.REVERSE_INCLUSIVE = box.index.LE
box.index.REVERSE_EXCLUSIVE = box.index.LT
```

In order to prevent code duplciation tuple_compare.cc was refactored: field comparsion code, which was highly copy-pasted around the file is moved to a separated templated function.

In order to assure the changes didn't break anything, new tests has been introduced. The tests cover all branches of all currently existing comparators. To simplify the tests the key_def.c test was switched to C++.

Closes #5529.

## Documentation

Sort order specifies the way indexes iterate over tuples with different fields in the same part. It can be either ascending (which is the case by default) and descending.

Tuples with different ascending parts are sorted in indexes from lesser to greater, whereas tuples with different descending parts are sorted in the opposte order: from greater to lesser.

Given example:

```lua
box.cfg{}

s = box.schema.create_space('tester')
pk = s:create_index('pk', {parts = {
  {1, 'unsigned', sort_order = 'desc'},
  {2, 'unsigned', sort_order = 'asc'},
  {3, 'unsigned', sort_order = 'desc'},
}})

s:insert({1, 1, 1})
s:insert({1, 1, 2})
s:insert({1, 2, 1})
s:insert({1, 2, 2})
s:insert({2, 1, 1})
s:insert({2, 1, 2})
s:insert({2, 2, 1})
s:insert({2, 2, 2})
s:insert({3, 1, 1})
s:insert({3, 1, 2})
s:insert({3, 2, 1})
s:insert({3, 2, 2})
```

In this case field 1 and 3 are descending, whereas field 2 is ascending. So `s:select()` will return this result:

```yaml
---
- [3, 1, 2]
- [3, 1, 1]
- [3, 2, 2]
- [3, 2, 1]
- [2, 1, 2]
- [2, 1, 1]
- [2, 2, 2]
- [2, 2, 1]
- [1, 1, 2]
- [1, 1, 1]
- [1, 2, 2]
- [1, 2, 1]
...
```

Beware, that when using other sort order than 'asc' for any field 'LE', 'LT', 'GE' and 'GT' iterator lose their meaning and specify 'opposite including', 'opposite excluding', 'direct including' and 'direct excluding' iteration direction respectively. Given example above, `s:select({2}, {iterator = 'GT'})` will return this:

```yaml
---
- [1, 1, 2]
- [1, 1, 1]
- [1, 2, 2]
- [1, 2, 1]
...
```

And `s:select({1}, {iterator = 'LT'})` will give us:

```yaml
---
- [2, 2, 1]
- [2, 2, 2]
- [2, 1, 1]
- [2, 1, 2]
- [3, 2, 1]
- [3, 2, 2]
- [3, 1, 1]
- [3, 1, 2]
...
```

In order to be more clear alternative iterator aliases can be used: `FORWARD_INCLUSIVE`, `FORWARD_EXCLUSIVE`, `REVERSE_INCLUSIVE`, `REVERSE_EXCLUSIVE`:

```
> s:select({1}, {iterator = 'REVERSE_EXCLUSIVE'})
---
- [2, 2, 1]
- [2, 2, 2]
- [2, 1, 1]
- [2, 1, 2]
- [3, 2, 1]
- [3, 2, 2]
- [3, 1, 1]
- [3, 1, 2]
...
```