### PR TITLE
applier: fix use after free

### DIFF
--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -2023,7 +2023,7 @@ applier_thread_reader_f(va_list ap)
 				 TIMEOUT_INFINITY :
 				 replication_disconnect_timeout();
 		struct applier_tx *tx;
-		tx = lsregion_alloc_object(lsr, applier->thread.lsr_id++,
+		tx = lsregion_alloc_object(lsr, ++applier->thread.lsr_id,
 					   struct applier_tx);
 		if (tx == NULL) {
 			diag_set(OutOfMemory, sizeof(*tx),


### PR DESCRIPTION
Applier thread uses lsregion to allocate the messages for tx thread. The
messages are freed upon return to the applier thread using a
corresponding lsr_id.

Due to a typo, one of the lsregion allocations was made with a postfix
increment of lsr_id instead of the prefix one. Essentially, part of a
new message was allocated with an old lsr_id, and might be freed early
by a return of a previous message.

Fix this.

Closes https://github.com/tarantool/tarantool/issues/8848

NO_DOC=bugfix
NO_TEST=covered by asan in https://github.com/tarantool/tarantool/pull/8901
NO_CHANGELOG=bugfix