### PR TITLE
config: add low priority env source

### DIFF
--- a/changelogs/unreleased/config-low-priority-env-source.md
+++ b/changelogs/unreleased/config-low-priority-env-source.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* Added a low priority environment configuration source, which looks into
+  `TT_*_DEFAULT` variables. It is useful to declare defaults (gh-8862).

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -110,10 +110,10 @@ function methods._initialize(self)
     -- priority. The menthal rule here is the following: values
     -- closer to the process are preferred: env first, then file,
     -- then etcd (if available).
-    self:_register_source(require('internal.config.source.env'))
+    self:_register_source(require('internal.config.source.env').new())
 
     if self._config_file ~= nil then
-        self:_register_source(require('internal.config.source.file'))
+        self:_register_source(require('internal.config.source.file').new())
     end
 
     self:_register_applier(require('internal.config.applier.mkdir'))
@@ -148,14 +148,14 @@ function methods._collect(self, opts)
         -- argument. The 'config' section of the config may
         -- contain a configuration needed for a source.
         if sync_source == source.name or sync_source == 'all' then
-            source.sync(self, iconfig)
+            source:sync(self, iconfig)
         end
 
         -- Validate configurations gathered from the sources.
         if source.type == 'instance' then
-            instance_config:validate(source.get())
+            instance_config:validate(source:get())
         elseif source.type == 'cluster' then
-            cluster_config:validate(source.get())
+            cluster_config:validate(source:get())
         else
             assert(false)
         end
@@ -173,12 +173,12 @@ function methods._collect(self, opts)
         -- accumulator is passed as the second.
         local source_iconfig
         if source.type == 'cluster' then
-            local source_cconfig = source.get()
+            local source_cconfig = source:get()
             cconfig = cluster_config:merge(source_cconfig, cconfig)
             source_iconfig = cluster_config:instantiate(cconfig,
                 self._instance_name)
         elseif source.type == 'instance' then
-            source_iconfig = source.get()
+            source_iconfig = source:get()
         else
             assert(false)
         end
@@ -186,7 +186,7 @@ function methods._collect(self, opts)
 
         -- If a source returns an empty table, mark it as ones
         -- that provide no data.
-        local has_data = next(source.get()) ~= nil
+        local has_data = next(source:get()) ~= nil
         table.insert(source_info, ('* %q [type: %s]%s'):format(source.name,
             source.type, has_data and '' or ' (no data)'))
     end

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -104,12 +104,14 @@ end
 
 function methods._initialize(self)
     -- The sources are synchronized in the order of registration:
-    -- env, file, etcd (the latter is present in Tarantool EE).
+    -- env, file, etcd (present in Tarantool EE), env for
+    -- defaults.
     --
     -- The configuration values from the first source has highest
     -- priority. The menthal rule here is the following: values
     -- closer to the process are preferred: env first, then file,
-    -- then etcd (if available).
+    -- then etcd (if available). And only then the env source with
+    -- defaults.
     self:_register_source(require('internal.config.source.env').new())
 
     if self._config_file ~= nil then
@@ -128,6 +130,10 @@ function methods._initialize(self)
     if extras ~= nil then
         extras.initialize(self)
     end
+
+    self:_register_source(require('internal.config.source.env').new({
+        env_var_suffix = 'default',
+    }))
 end
 
 function methods._collect(self, opts)

--- a/src/box/lua/config/source/file.lua
+++ b/src/box/lua/config/source/file.lua
@@ -3,7 +3,12 @@ local buffer = require('buffer')
 local fio = require('fio')
 local yaml = require('yaml')
 
-local values = {}
+local methods = {}
+local mt = {
+    __index = methods,
+}
+
+-- {{{ Helpers
 
 -- Read the file block by block till EOF.
 local function stream_read(fh)
@@ -58,7 +63,9 @@ local function universal_read(file_name, file_kind)
     return data
 end
 
-local function sync(config_module, _iconfig)
+-- }}} Helpers
+
+function methods.sync(self, config_module, _iconfig)
     assert(config_module._config_file ~= nil)
 
     local data = universal_read(config_module._config_file, 'config file')
@@ -68,21 +75,21 @@ local function sync(config_module, _iconfig)
             config_module._config_file, res))
     end
 
-    values = res
+    self._values = res
 end
 
-local function get()
-    return values
+function methods.get(self)
+    return self._values
+end
+
+local function new()
+    return setmetatable({
+        name = 'file',
+        type = 'cluster',
+        _values = {},
+    }, mt)
 end
 
 return {
-    name = 'file',
-    -- The type is either 'instance' or 'cluster'.
-    type = 'cluster',
-    -- Gather most actual config values.
-    sync = sync,
-    -- Access the configuration after source.sync().
-    --
-    -- source.get()
-    get = get,
+    new = new,
 }

--- a/test/config-luatest/sources_test.lua
+++ b/test/config-luatest/sources_test.lua
@@ -1,8 +1,11 @@
 local t = require('luatest')
+local fun = require('fun')
 local json = require('json')
+local yaml = require('yaml')
 local treegen = require('test.treegen')
 local justrun = require('test.justrun')
 local source_file = require('internal.config.source.file').new()
+local server = require('test.luatest_helpers.server')
 
 local g = t.group()
 
@@ -12,6 +15,13 @@ end)
 
 g.after_all(function()
     treegen.clean(g)
+end)
+
+g.after_each(function(g)
+    if g.server ~= nil then
+        g.server:stop()
+        g.server = nil
+    end
 end)
 
 g.test_source_file = function()
@@ -49,15 +59,14 @@ g.test_source_env = function()
     local dir = treegen.prepare_directory(g, {}, {})
     local script = [[
         local json = require('json')
-        local source_env = require('internal.config.source.env').new()
+        local source_env = require('internal.config.source.env').new({
+            env_var_suffix = arg[1],
+        })
         source_env:sync({}, {})
         print(json.encode(source_env:get()))
     ]]
     treegen.write_script(dir, 'main.lua', script)
 
-    local env = {TT_LOG_LEVEL = 'info', TT_MEMTX_MEMORY = 1000000}
-    local opts = {nojson = true, stderr = false}
-    local res = justrun.tarantool(dir, env, {'main.lua'}, opts)
     local exp = {
         config = {
             version = 'dev',
@@ -69,6 +78,104 @@ g.test_source_env = function()
             memory = 1000000
         },
     }
-    t.assert_equals(res.exit_code, 0)
-    t.assert_equals(json.decode(res.stdout), exp)
+
+    local cases = {
+        {
+            name = 'env',
+            env_var_suffix = nil,
+            env = {
+                TT_LOG_LEVEL = 'info',
+                TT_MEMTX_MEMORY = 1000000,
+            },
+        },
+        {
+            name = 'env default',
+            env_var_suffix = 'default',
+            env = {
+                TT_LOG_LEVEL_DEFAULT = 'info',
+                TT_MEMTX_MEMORY_DEFAULT = 1000000,
+            },
+        },
+    }
+    local opts = {nojson = true, stderr = false}
+    for _, case in ipairs(cases) do
+        local comment = ('case: %s'):format(case.name)
+        local args = {'main.lua', case.env_var_suffix}
+        local res = justrun.tarantool(dir, case.env, args, opts)
+        t.assert_equals(res.exit_code, 0, comment)
+        t.assert_equals(json.decode(res.stdout), exp, comment)
+    end
+end
+
+-- Verify priority of configuration sources.
+--
+-- 1. env (TT_*)
+-- 2. file
+-- 3. env default (TT_*_DEFAULT)
+--
+-- Several string options from the instance config are chosen for
+-- testing purposes, their meaning is irrelevant for the test.
+--
+-- The table below shows where the given option is set (which
+-- source defines it) and what we expect as a result.
+--
+-- | option              | env | file | env default | result      |
+-- | ------------------- | --- | ---- | ----------- | ----------- |
+-- | process.title       |     |  +   |      +      | file        |
+-- | log.file            |  +  |  +   |             | env         |
+-- | log.pipe            |  +  |      |      +      | env         |
+-- | log.syslog.identity |     |      |      +      | env default |
+g.test_sources_priority = function(g)
+    local dir = treegen.prepare_directory(g, {}, {})
+    local config = {
+        credentials = {
+            users = {
+                guest = {
+                    roles = {'super'},
+                },
+            },
+        },
+        iproto = {
+            listen = 'unix/:./{{ instance_name }}.iproto',
+        },
+        process = {
+            title = 'from file',
+        },
+        log = {
+            file = 'from file',
+        },
+        groups = {
+            ['group-001'] = {
+                replicasets = {
+                    ['replicaset-001'] = {
+                        instances = {
+                            ['instance-001'] = {},
+                        },
+                    },
+                },
+            },
+        },
+    }
+    local config_file = treegen.write_script(dir, 'config.yaml',
+                                             yaml.encode(config))
+    local opts = {
+        config_file = config_file,
+        chdir = dir,
+        env = {
+            TT_PROCESS_TITLE_DEFAULT = 'from env default',
+            TT_LOG_FILE = 'from env',
+            TT_LOG_PIPE = 'from env',
+            TT_LOG_PIPE_DEFAULT = 'from env default',
+            TT_LOG_SYSLOG_IDENTITY_DEFAULT = 'from env default',
+        },
+    }
+    g.server = server:new(fun.chain(opts, {alias = 'instance-001'}):tomap())
+    g.server:start()
+    g.server:exec(function()
+        local config = require('config')
+        t.assert_equals(config:get('process.title'), 'from file')
+        t.assert_equals(config:get('log.file'), 'from env')
+        t.assert_equals(config:get('log.pipe'), 'from env')
+        t.assert_equals(config:get('log.syslog.identity'), 'from env default')
+    end)
 end

--- a/test/config-luatest/sources_test.lua
+++ b/test/config-luatest/sources_test.lua
@@ -2,7 +2,7 @@ local t = require('luatest')
 local json = require('json')
 local treegen = require('test.treegen')
 local justrun = require('test.justrun')
-local source_file = require('internal.config.source.file')
+local source_file = require('internal.config.source.file').new()
 
 local g = t.group()
 
@@ -16,8 +16,8 @@ end)
 
 g.test_source_file = function()
     local config = {_config_file = 'doc/examples/config/single.yaml'}
-    source_file.sync(config, {})
-    local res = source_file.get()
+    source_file:sync(config, {})
+    local res = source_file:get()
     local exp = {
         credentials = {
             users = {
@@ -49,9 +49,9 @@ g.test_source_env = function()
     local dir = treegen.prepare_directory(g, {}, {})
     local script = [[
         local json = require('json')
-        local source_env = require('internal.config.source.env')
-        source_env.sync({}, {})
-        print(json.encode(source_env.get()))
+        local source_env = require('internal.config.source.env').new()
+        source_env:sync({}, {})
+        print(json.encode(source_env:get()))
     ]]
     treegen.write_script(dir, 'main.lua', script)
 


### PR DESCRIPTION
The usual environment configuration source is useful for parametrized run:

```sh
TT_MEMTX_MEMORY=<...> tarantool --name <...> --config <...>
```

However, sometimes a user may need to set a default value, which doesn't rewrite one that is provided in the configuration. Now, it is possible to do using the environment variables with the `_DEFAULT` suffix.

```sh
TT_MEMTX_MEMORY_DEFAULT=<...> tarantool --name <...> --config <...>
```

This feature may be especially useful for wrappers that run tarantool internally with some default paths for data directories, socket files, pid file. We likely will use it in the `tt` tool.

Part of #8862

----

Tarantool EE part: https://github.com/tarantool/tarantool-ee/pull/504