### PR TITLE
config: fix 'instance not found' failure message

### DIFF
--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -236,9 +236,7 @@ function methods._collect(self, opts)
                 replicasets:
                   replicaset-001:
                     instances:
-                      instance-001:
-                        database:
-                          rw: true
+                      instance-001: {}
         ]]):format(action, self._instance_name, source_info_str), 0)
     end
 


### PR DESCRIPTION
The instance config schema was modified in commit 8ee2b0d8c9a44 ("config: start singleton instance in RW by default"): the `database.rw` (boolean) parameter was replaced by the `database.mode` parameter (enum of `ro` and `rw`).

However, in the same commit, the default mode of an instance that is the only one in its replicaset was modified: it starts in the read-write mode by default. As result, the parameter is actually unneeded in the minimal configuration example.

These changes were not reflected in the 'instance not found' error message, which contains the minimal configuration example. It is fixed here.

Part of #8862
Follows up #8810