### PR TITLE
test: enable JIT back in app-luatest/http_client_test

### DIFF
--- a/test/app-luatest/http_client_test.lua
+++ b/test/app-luatest/http_client_test.lua
@@ -5,10 +5,6 @@ local uri = require('uri')
 local os = require('os')
 local t = require('luatest')
 
--- FIXME(gh-8718): The test fails if Lua JIT is enabled.
-jit.off()
-jit.flush()
-
 local g = t.group('http_client', {
     {sock_family = 'AF_INET'},
     {sock_family = 'AF_UNIX'},


### PR DESCRIPTION
This patch reverts the temporary fix introduced in commit 53c94bc79ecfc0451bc3ffa57ffb88e3217671ff ("test: disable Lua JIT in app-luatest/http_client_test") since the issues with invalid traces generation for vararg functions are resolved, so JIT machinery can be enabled back then.

Follows up #8718
Relates to #8516

NO_DOC=test
NO_CHANGELOG=test