### PR TITLE
change BACKUP_STORAGE URL for static build

### DIFF
--- a/static-build/cmake/AddDependencyProjects.cmake
+++ b/static-build/cmake/AddDependencyProjects.cmake
@@ -20,7 +20,7 @@ set(NCURSES_VERSION 6.3-20220716)
 set(NCURSES_HASH 2b7a0e31ebbd8144680f985d61f5bbd5)
 set(READLINE_VERSION 8.0)
 set(READLINE_HASH 7e6c1f16aee3244a69aba6e438295ca3)
-set(BACKUP_STORAGE https://distrib.hb.bizmrg.com)
+set(BACKUP_STORAGE https://distrib.hb.vkcs.cloud)
 
 # Pass -isysroot=<SDK_PATH> option on Mac OS to a preprocessor and a C
 # compiler to find header files installed with an SDK.


### PR DESCRIPTION
Change BACKUP_STORAGE URL for static build in static-build/cmake/AddDependencyProjects.cmake. Change URL from hb.bizmrg.com to hb.vkcs.cloud. 