### PR TITLE
config: allow to call config:get() from app script

### DIFF
--- a/changelogs/unreleased/config-get-configuration-from-app.md
+++ b/changelogs/unreleased/config-get-configuration-from-app.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* It is now possible to access configuration from the application script using
+  the `config:get()` method (gh-8862).

--- a/src/box/lua/config/applier/app.lua
+++ b/src/box/lua/config/applier/app.lua
@@ -1,16 +1,20 @@
 local log = require('internal.config.utils.log')
 
-local function apply(config)
+local function apply(_config)
+    log.verbose('app.apply: do nothing')
+end
+
+local function post_apply(config)
     local configdata = config._configdata
     local file = configdata:get('app.file', {use_default = true})
     local module = configdata:get('app.module', {use_default = true})
     if file ~= nil then
         assert(module == nil)
         local fn = assert(loadfile(file))
-        log.verbose('app.apply: loading '..file)
+        log.verbose('app.post_apply: loading '..file)
         fn(file)
     elseif module ~= nil then
-        log.verbose('app.apply: loading '..module)
+        log.verbose('app.post_apply: loading '..module)
         require(module)
     end
 end
@@ -18,4 +22,5 @@ end
 return {
     name = 'app',
     apply = apply,
+    post_apply = post_apply,
 }

--- a/test/config-luatest/app_test.lua
+++ b/test/config-luatest/app_test.lua
@@ -1,0 +1,110 @@
+local t = require('luatest')
+local helpers = require('test.config-luatest.helpers')
+
+local g = helpers.group()
+
+-- Start a script that is pointed by app.file or app.module.
+--
+-- TODO: Verify that the script has access to config:get() values.
+g.test_startup_success = function(g)
+    local script = [[
+        -- TODO: Verify that the script has access to config:get()
+        -- values.
+        -- local config = require('config')
+        -- assert(config:get('app.cfg.foo') == 42)
+
+        _G.foo = 42
+    ]]
+    local verify = function()
+        local config = require('config')
+        t.assert_equals(_G.foo, 42)
+        t.assert_equals(config:get('app.cfg.foo'), 42)
+    end
+
+    helpers.success_case(g, {
+        script = script,
+        options = {
+            ['app.file'] = 'main.lua',
+            ['app.cfg'] = {foo = 42},
+        },
+        verify = verify,
+    })
+
+    helpers.success_case(g, {
+        script = script,
+        options = {
+            ['app.module'] = 'main',
+            ['app.cfg'] = {foo = 42},
+        },
+        verify = verify,
+    })
+end
+
+-- Start a script that is pointed by app.file or app.module.
+--
+-- Verify that an error in the script leads to a startup failure.
+g.test_startup_error = function(g)
+    local err_msg = 'Application is unable to start'
+    local script = ([[
+        error('%s', 0)
+    ]]):format(err_msg)
+
+    helpers.failure_case(g, {
+        script = script,
+        options = {['app.file'] = 'main.lua'},
+        exp_err = err_msg,
+    })
+
+    helpers.failure_case(g, {
+        script = script,
+        options = {['app.module'] = 'main'},
+        exp_err = err_msg,
+    })
+end
+
+-- Start a server, write a script that raises an error, reload.
+--
+-- Verify that the error is raised by config:reload() and the same
+-- error appears in the alerts.
+--
+-- The test case uses only app.file deliberately: if the
+-- application script is set as app.module, it is not re-executed
+-- on config:reload() due to caching in package.loaded.
+g.test_reload_failure = function(g)
+    local err_msg = 'Application is unable to start'
+
+    helpers.reload_failure_case(g, {
+        script = '',
+        options = {['app.file'] = 'main.lua'},
+        verify = function() end,
+        script_2 = ([[
+            error('%s', 0)
+        ]]):format(err_msg),
+        exp_err = err_msg,
+    })
+end
+
+-- Start a server, write a script that raises an error, reload.
+--
+-- Verify that the error is NOT raised when the application script
+-- is set using app.module (due to caching in package.loaded).
+--
+-- This behavior may be changed in a future.
+g.test_reload_success = function(g)
+    local err_msg = 'Application is unable to start'
+
+    helpers.reload_success_case(g, {
+        script = '',
+        options = {['app.module'] = 'main'},
+        verify = function() end,
+        script_2 = ([[
+            error('%s', 0)
+        ]]):format(err_msg),
+        verify_2 = function()
+            local config = require('config')
+            local info = config:info()
+            t.assert_equals(info.status, 'ready')
+            t.assert_equals(#info.alerts, 0)
+        end,
+    })
+end

--- a/test/config-luatest/app_test.lua
+++ b/test/config-luatest/app_test.lua
@@ -5,13 +5,14 @@ local g = helpers.group()
 
 -- Start a script that is pointed by app.file or app.module.
 --
--- TODO: Verify that the script has access to config:get() values.
+-- Verify that the script has access to config:get() values.
 g.test_startup_success = function(g)
     local script = [[
-        -- TODO: Verify that the script has access to config:get()
-        -- values.
-        -- local config = require('config')
-        -- assert(config:get('app.cfg.foo') == 42)
+        local config = require('config')
+        assert(config:get('app.cfg.foo') == 42)
+        local info = config:info()
+        assert(info.status == 'ready')
+        assert(#info.alerts == 0)
 
         _G.foo = 42
     ]]

--- a/test/config-luatest/appliers_test.lua
+++ b/test/config-luatest/appliers_test.lua
@@ -52,7 +52,7 @@ local appliers_script = [[
     local fiber = require('internal.config.applier.fiber')
     fiber.apply(config)
     local app = require('internal.config.applier.app')
-    local ok, err = pcall(app.apply, config)
+    local ok, err = pcall(app.post_apply, config)
     %s
     os.exit(0)
 ]]

--- a/test/config-luatest/basic_test.lua
+++ b/test/config-luatest/basic_test.lua
@@ -7,23 +7,7 @@ local justrun = require('test.justrun')
 local server = require('test.luatest_helpers.server')
 local helpers = require('test.config-luatest.helpers')
 
-local g = t.group()
-
-g.before_all(function(g)
-    treegen.init(g)
-end)
-
-g.after_all(function(g)
-    treegen.clean(g)
-end)
-
-g.after_each(function(g)
-    for k, v in pairs(g) do
-        if k == 'server' or k:match('^server_%d+$') then
-            v:stop()
-        end
-    end
-end)
+local g = helpers.group()
 
 local function count_lines(s)
     return #s:split('\n')

--- a/test/config-luatest/config_test.lua
+++ b/test/config-luatest/config_test.lua
@@ -237,8 +237,7 @@ g.test_config_broadcast = function()
         local fiber = require('fiber')
         local status = ''
         box.watch('config.info', function(_, v) status = v.status end)
-        while status ~= 'startup_in_progress' and
-              status ~= 'reload_in_progress' do
+        while status ~= 'ready' do
             fiber.sleep(0.1)
         end
         print(status)
@@ -249,7 +248,7 @@ g.test_config_broadcast = function()
     local args = {'main.lua'}
     local res = justrun.tarantool(dir, {}, args, opts)
     t.assert_equals(res.exit_code, 0)
-    local exp = {'startup_in_progress', 'ready', 'reload_in_progress', 'ready'}
+    local exp = {'ready', 'ready', 'ready', 'ready'}
     t.assert_equals(res.stdout, table.concat(exp, "\n"))
 end
 


### PR DESCRIPTION
It is convenient to access configuration using `config:get()` from the application script (`app.file` or `app.module`).

However, before this commit, it was not possible, because the configuration was not considered as applied before the application script is loaded.

Now, the script loading is moved into the post-apply phase.

The resulting sequence of steps on startup/reload is the following.

* collect configuration information (from all the sources)
* \<if the previous step is failed, set `check_errors` status and break>
* apply the configuration (call all the appliers)
* \<if the previous step is failed, set `check_errors` status and break>
* \<set the new successful status: `ready` or `check_warnings`>
* call post-apply hooks (including application script loading)
* \<if the previous step is failed, set `check_errors` status and break>
* \<set the new successful status: `ready` or `check_warnings`>

Part of #8862

----

See also a state diagram in https://github.com/tarantool/doc/issues/3544.