### PR TITLE
Fix a crash when a collation, used by a space, is deleted

### DIFF
--- a/changelogs/unreleased/gh-4544-segfault-if-i-delete-a-collation.md
+++ b/changelogs/unreleased/gh-4544-segfault-if-i-delete-a-collation.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fixed a crash when a collation used by a space was deleted (gh-4544).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -900,6 +900,7 @@ alter_space_rollback(struct trigger *trigger, void * /* event */)
 	space_swap_triggers(alter->new_space, alter->old_space);
 	space_swap_constraint_ids(alter->new_space, alter->old_space);
 	space_reattach_constraints(alter->old_space);
+	space_pin_collations(alter->old_space);
 	space_cache_replace(alter->new_space, alter->old_space);
 	alter_space_delete(alter);
 	return 0;
@@ -1027,6 +1028,7 @@ alter_space_do(struct txn_stmt *stmt, struct alter_space *alter)
 	 */
 	space_cache_replace(alter->old_space, alter->new_space);
 	space_detach_constraints(alter->old_space);
+	space_unpin_collations(alter->old_space);
 	/*
 	 * Install transaction commit/rollback triggers to either
 	 * finish or rollback the DDL depending on the results of
@@ -1734,6 +1736,7 @@ on_drop_space_rollback(struct trigger *trigger, void *event)
 	struct space *space = (struct space *)trigger->data;
 	space_cache_replace(NULL, space);
 	space_reattach_constraints(space);
+	space_pin_collations(space);
 	return 0;
 }
 
@@ -2154,6 +2157,7 @@ on_replace_dd_space(struct trigger * /* trigger */, void *event)
 		 * on commit or reattached on rollback.
 		 */
 		space_detach_constraints(old_space);
+		space_unpin_collations(old_space);
 		/**
 		 * The space must be deleted from the space
 		 * cache right away to achieve linearisable
@@ -3531,10 +3535,6 @@ on_replace_dd_collation(struct trigger * /* trigger */, void *event)
 			txn_alter_trigger_new(on_drop_collation_rollback, NULL);
 		if (on_commit == NULL || on_rollback == NULL)
 			return -1;
-		/*
-		 * TODO: Check that no index uses the collation
-		 * identifier.
-		 */
 		uint32_t out;
 		if (tuple_field_u32(old_tuple, BOX_COLLATION_FIELD_ID, &out) != 0)
 			return -1;
@@ -3556,6 +3556,20 @@ on_replace_dd_collation(struct trigger * /* trigger */, void *event)
 				 old_coll_id->owner_id, SC_COLLATION,
 				 PRIV_D) != 0)
 			return -1;
+		/*
+		 * Don't allow user to drop a collation identifier that is
+		 * currently used.
+		 */
+		enum coll_id_holder_type pinned_type;
+		if (coll_id_is_pinned(old_coll_id, &pinned_type)) {
+			const char *type_str =
+				coll_id_holder_type_strs[pinned_type];
+			diag_set(ClientError, ER_DROP_COLLATION,
+				 old_coll_id->name,
+				 tt_sprintf("collation is referenced by %s",
+					    type_str));
+			return -1;
+		}
 		/*
 		 * Set on_commit/on_rollback triggers after
 		 * deletion from the cache to make trigger logic

--- a/src/box/coll_id.c
+++ b/src/box/coll_id.c
@@ -53,12 +53,14 @@ coll_id_new(const struct coll_id_def *def)
 	coll_id->name_len = def->name_len;
 	memcpy(coll_id->name, def->name, def->name_len);
 	coll_id->name[coll_id->name_len] = 0;
+	rlist_create(&coll_id->cache_pin_list);
 	return coll_id;
 }
 
 void
 coll_id_delete(struct coll_id *coll_id)
 {
+	assert(rlist_empty(&coll_id->cache_pin_list));
 	coll_unref(coll_id->coll);
 	free(coll_id);
 }

--- a/src/box/coll_id.h
+++ b/src/box/coll_id.h
@@ -32,6 +32,7 @@
  */
 #include <stddef.h>
 #include <stdint.h>
+#include "small/rlist.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -56,6 +57,11 @@ struct coll_id {
 	uint32_t owner_id;
 	/** Collation object. */
 	struct coll *coll;
+	/**
+	 * Holders of the same collation identifier are linked into ring list by
+	 * `coll_id_cache_holder::in_coll_id`.
+	 */
+	struct rlist cache_pin_list;
 	/** Collation name. */
 	size_t name_len;
 	char name[0];

--- a/src/box/coll_id_cache.h
+++ b/src/box/coll_id_cache.h
@@ -31,12 +31,47 @@
  * SUCH DAMAGE.
  */
 #include <stdint.h>
+#include <stdbool.h>
+#include "small/rlist.h"
 
 #if defined(__cplusplus)
 extern "C" {
 #endif /* defined(__cplusplus) */
 
 struct coll_id;
+
+/**
+ * Type of a holder that can pin coll_id. See `struct coll_id_cache_holder`.
+ */
+enum coll_id_holder_type {
+	COLL_ID_HOLDER_SPACE_FORMAT,
+	COLL_ID_HOLDER_INDEX,
+	COLL_ID_HOLDER_MAX,
+};
+
+/**
+ * Lowercase name of each type.
+ */
+extern const char *coll_id_holder_type_strs[COLL_ID_HOLDER_MAX];
+
+/**
+ * Definition of a holder that pinned some coll_id. Pinning of a coll_id is
+ * a mechanism that is designed for preventing of deletion of some coll_id from
+ * coll_id cache by storing links to holders that prevented that.
+ */
+struct coll_id_cache_holder {
+	/** Link in `space::coll_id_holders`. */
+	struct rlist in_space;
+	/** Link in `coll_id::cache_pin_list`. */
+	struct rlist in_coll_id;
+	/** Actual pointer to coll_id. */
+	struct coll_id *coll_id;
+	/**
+	 * Type of holder, mostly for better error generation, but also can be
+	 * used for proper container_of application.
+	 */
+	enum coll_id_holder_type type;
+};
 
 /**
  * Create global hash tables.
@@ -62,7 +97,7 @@ coll_id_cache_replace(struct coll_id *coll_id, struct coll_id **replaced_id);
  * @param coll_id Collation to delete.
  */
 void
-coll_id_cache_delete(const struct coll_id *coll_id);
+coll_id_cache_delete(struct coll_id *coll_id);
 
 /**
  * Find a collation object by its id.
@@ -75,6 +110,32 @@ coll_by_id(uint32_t id);
  */
 struct coll_id *
 coll_by_name(const char *name, uint32_t len);
+
+/**
+ * Register that there is a `holder` of type `type` that is dependent on
+ * coll_id. coll_id must be in cache (asserted).
+ * If coll_id has holders, it must not be deleted (asserted).
+ */
+void
+coll_id_pin(struct coll_id *coll_id, struct coll_id_cache_holder *holder,
+	    enum coll_id_holder_type type);
+
+/**
+ * Notify that `holder` does not depend anymore on coll_id.
+ * coll_id must be in cache (asserted).
+ * If coll_id has no holders, it can be deleted.
+ */
+void
+coll_id_unpin(struct coll_id_cache_holder *holder);
+
+/**
+ * Check whether coll_id has holders or not.
+ * If it has, `type` argument is set to the first holder's type.
+ * coll_id must be in cache (asserted).
+ * If coll_id has holders, it must not be deleted (asserted).
+ */
+bool
+coll_id_is_pinned(struct coll_id *coll_id, enum coll_id_holder_type *type);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -225,7 +225,7 @@ struct errcode_record {
 	/*170 */_(ER_CONSTRAINT_EXISTS,		"%s constraint '%s' already exists in space '%s'") \
 	/*171 */_(ER_SQL_TYPE_MISMATCH,		"Type mismatch: can not convert %s to %s") \
 	/*172 */_(ER_ROWID_OVERFLOW,            "Rowid is overflowed: too many entries in ephemeral space") \
-	/*173 */_(ER_DROP_COLLATION,		"Can't drop collation %s : %s") \
+	/*173 */_(ER_DROP_COLLATION,		"Can't drop collation '%s': %s") \
 	/*174 */_(ER_ILLEGAL_COLLATION_MIX,	"Illegal mix of collations") \
 	/*175 */_(ER_SQL_NO_SUCH_PRAGMA,	"Pragma '%s' does not exist") \
 	/*176 */_(ER_SQL_CANT_RESOLVE_FIELD,	"Can’t resolve field '%s'") \

--- a/src/box/index_def.c
+++ b/src/box/index_def.c
@@ -208,27 +208,20 @@ index_stat_dup(const struct index_stat *src)
 	return dup;
 }
 
-/** Free a key definition. */
 void
 index_def_delete(struct index_def *index_def)
 {
 	index_opts_destroy(&index_def->opts);
 	free(index_def->name);
 
-	if (index_def->key_def) {
-		TRASH(index_def->key_def);
-		free(index_def->key_def);
-	}
+	if (index_def->key_def)
+		key_def_delete(index_def->key_def);
 
-	if (index_def->cmp_def) {
-		TRASH(index_def->cmp_def);
-		free(index_def->cmp_def);
-	}
+	if (index_def->cmp_def)
+		key_def_delete(index_def->cmp_def);
 
-	if (index_def->pk_def) {
-		TRASH(index_def->pk_def);
-		free(index_def->pk_def);
-	}
+	if (index_def->pk_def)
+		key_def_delete(index_def->pk_def);
 
 	TRASH(index_def);
 	free(index_def);

--- a/src/box/index_def.h
+++ b/src/box/index_def.h
@@ -370,7 +370,7 @@ index_def_list_add(struct rlist *index_def_list, struct index_def *index_def)
 }
 
 /**
- * Create a new index definition definition.
+ * Create a new index definition.
  *
  * @param key_def  key definition, must be fully built
  * @param pk_def   primary key definition, pass non-NULL

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -248,6 +248,11 @@ struct space {
 	 * (i.e. if not NULL WAL entries may contain extra fields).
 	 */
 	struct space_wal_ext *wal_ext;
+	/**
+	 * List of collation identifier holders.
+	 * Linked by `coll_id_cache_holder::in_space`.
+	 */
+	struct rlist coll_id_holders;
 };
 
 /** Space alter statement. */
@@ -271,6 +276,19 @@ space_detach_constraints(struct space *space);
  */
 void
 space_reattach_constraints(struct space *space);
+
+/**
+ * Pin in cache the collation identifiers that are referenced by space format
+ * and/or indexes, so that they can't be deleted.
+ */
+void
+space_pin_collations(struct space *space);
+
+/**
+ * Unpin collation identifiers.
+ */
+void
+space_unpin_collations(struct space *space);
 
 /** Initialize a base space instance. */
 int

--- a/src/box/sql/show.c
+++ b/src/box/sql/show.c
@@ -278,14 +278,9 @@ sql_describe_field(struct sql_desc *desc, const struct field_def *field)
 
 	if (field->coll_id != 0) {
 		struct coll_id *coll_id = coll_by_id(field->coll_id);
-		if (coll_id == NULL) {
-			sql_desc_error(desc, "collation",
-				       tt_sprintf("%d", field->coll_id),
-				       "collation does not exist");
-		} else {
-			sql_desc_append(desc, " COLLATE ");
-			sql_desc_append_name(desc, coll_id->name);
-		}
+		assert(coll_id != NULL);
+		sql_desc_append(desc, " COLLATE ");
+		sql_desc_append_name(desc, coll_id->name);
 	}
 	if (!field->is_nullable)
 		sql_desc_append(desc, " NOT NULL");

--- a/test/box/net.box_is_nullable_gh-3256.result
+++ b/test/box/net.box_is_nullable_gh-3256.result
@@ -79,10 +79,10 @@ parts[1].collation == 'test'
 c:close()
 ---
 ...
-box.internal.collation.drop('test')
+space:drop()
 ---
 ...
-space:drop()
+box.internal.collation.drop('test')
 ---
 ...
 c.state

--- a/test/box/net.box_is_nullable_gh-3256.test.lua
+++ b/test/box/net.box_is_nullable_gh-3256.test.lua
@@ -26,7 +26,7 @@ parts[1].type == 'string'
 parts[1].is_nullable == false
 parts[1].collation == 'test'
 c:close()
-box.internal.collation.drop('test')
 space:drop()
+box.internal.collation.drop('test')
 c.state
 c = nil

--- a/test/engine-luatest/gh_4544_collation_drop_test.lua
+++ b/test/engine-luatest/gh_4544_collation_drop_test.lua
@@ -1,0 +1,62 @@
+local t = require('luatest')
+
+local function before_all(cg)
+    local server = require('luatest.server')
+    cg.server = server:new()
+    cg.server:start()
+end
+
+local function after_all(cg)
+    cg.server:drop()
+end
+
+local g1 = t.group('gh-4544-1')
+g1.before_all(before_all)
+g1.after_all(after_all)
+
+-- Check that key_def compare doesn't crash after collation drop.
+g1.test_keydef_crash = function(cg)
+    cg.server:exec(function()
+        local key_def = require('key_def')
+        local coll_name = 'unicode_af_s1'
+        local kd = key_def.new({{field = 1, type = 'string',
+                                 collation = coll_name}})
+        box.internal.collation.drop(coll_name)
+        kd:compare({'a'}, {'b'})
+        t.assert_equals(kd:totable()[1].collation, '<deleted>')
+    end)
+end
+
+-- Replace old collation, which is used by key_def, by the new one with the same
+-- fingerprint.
+g1.test_keydef_replace_coll_same = function(cg)
+    cg.server:exec(function()
+        local key_def = require('key_def')
+        local old_name = 'my old coll'
+        local new_name = 'my new coll'
+        box.internal.collation.create(old_name, 'ICU', '', {})
+        local kd = key_def.new({{field = 1, type = 'string',
+                                 collation = old_name}})
+        box.internal.collation.drop(old_name)
+        box.internal.collation.create(new_name, 'ICU', '', {})
+        t.assert_equals(kd:totable()[1].collation, new_name)
+        box.internal.collation.drop(new_name)
+    end)
+end
+
+-- Replace old collation, which is used by key_def, by the new one with
+-- different fingerprint.
+g1.test_keydef_replace_coll_different = function(cg)
+    cg.server:exec(function()
+        local key_def = require('key_def')
+        local old_name = 'my old coll'
+        local new_name = 'my new coll'
+        box.internal.collation.create(old_name, 'ICU', '', {})
+        local kd = key_def.new({{field = 1, type = 'string',
+                                 collation = old_name}})
+        box.internal.collation.drop(old_name)
+        box.internal.collation.create(new_name, 'ICU', 'ru-RU', {})
+        t.assert_equals(kd:totable()[1].collation, '<deleted>')
+        box.internal.collation.drop(new_name)
+    end)
+end

--- a/test/sql-luatest/show_create_table_test.lua
+++ b/test/sql-luatest/show_create_table_test.lua
@@ -412,14 +412,6 @@ g.test_wrong_collation = function()
                      "WITH ENGINE = 'memtx';"}
         _G.check('"a"', res)
 
-        -- Collations does not exists.
-        box.space._collation:delete(col.id)
-        res = {'CREATE TABLE "a"(\n"i" STRING NOT NULL,\n'..
-               'CONSTRAINT "i" PRIMARY KEY("i"))\nWITH ENGINE = \'memtx\';'}
-        local err = {"Problem with collation '277': collation does not exist."}
-        _G.check('"a"', res, err)
-
-        box.space._collation:insert(col)
         box.space.a:drop()
         box.space._collation:delete(col.id)
 

--- a/test/sql/collation.result
+++ b/test/sql/collation.result
@@ -225,7 +225,7 @@ box.space._collation:select{0}
 ...
 box.space._collation:delete{0}
 ---
-- error: 'Can''t drop collation none : system collation'
+- error: 'Can''t drop collation ''none'': system collation'
 ...
 -- gh-3185: collations of LHS and RHS must be compatible.
 --


### PR DESCRIPTION
**box: reference collation by `key_def` parts**

It was possible to delete a collation, which is in use by a `key_def`.

---

**box: pin coll_id by space format and by indexes**

Pin in cache the collation identifiers that are referenced by space format and/or indexes, so that they can't be deleted.

Closes https://github.com/tarantool/tarantool/issues/4544