### PR TITLE
config: add `--help-env-list` CLI option

### DIFF
--- a/changelogs/unreleased/config-help-env-list.md
+++ b/changelogs/unreleased/config-help-env-list.md
@@ -1,0 +1,3 @@
+## feature/config
+
+* Added `--help-env-list` CLI option (gh-8862).

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -52,6 +52,7 @@ lua_source(lua_sources lua/config/source/env.lua          config_source_env_lua)
 lua_source(lua_sources lua/config/source/file.lua         config_source_file_lua)
 lua_source(lua_sources lua/config/utils/log.lua           config_utils_log_lua)
 lua_source(lua_sources lua/config/utils/schema.lua        config_utils_schema_lua)
+lua_source(lua_sources lua/config/utils/tabulate.lua      config_utils_tabulate_lua)
 
 if (ENABLE_CONFIG_EXTRAS)
     lua_source(lua_sources ${CONFIG_EXTRAS_DIR}/source/etcd.lua config_source_etcd_lua)

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -356,6 +356,11 @@ function methods._startup(self, instance_name, config_file)
     self:_set_status_based_on_alerts()
 end
 
+function methods._print_env_list(self)
+    local env_source = require('internal.config.source.env').new()
+    io.stdout:write(env_source:_env_list())
+end
+
 function methods.get(self, path)
     selfcheck(self, 'get')
     if self._status == 'uninitialized' then

--- a/src/box/lua/config/utils/tabulate.lua
+++ b/src/box/lua/config/utils/tabulate.lua
@@ -1,0 +1,68 @@
+-- Very simple pretty-printer of tabular data.
+--
+-- Example:
+--
+-- tabulate.encode({
+--     {'a', 'b', 'c'},
+--     tabulate.SPACER,
+--     {'d', 'e', 'f'},
+--     {'g', 'h', 'i'},
+-- })
+--
+-- ->
+--
+-- | a | b | c |
+-- | - | - | - |
+-- | d | e | f |
+-- | g | h | i |
+
+local SPACER = {}
+
+-- Format data as a table.
+--
+-- Accepts an array of rows. Each row in an array of values. Each
+-- value is a string.
+local function encode(rows)
+    -- Calculate column widths and columns amount.
+    local column_widths = {}
+    for _i, row in ipairs(rows) do
+        for j, v in ipairs(row) do
+            assert(type(v) == 'string')
+            column_widths[j] = math.max(column_widths[j] or 0, #v)
+        end
+    end
+    local column_count = #column_widths
+
+    -- Use a table as a string buffer.
+    local acc = {}
+
+    -- Add all the values into the accumulator with proper spacing
+    -- around and appropriate separators.
+    for _i, row in ipairs(rows) do
+        if row == SPACER then
+            for j = 1, column_count do
+                local width = column_widths[j]
+                table.insert(acc, '| ')
+                table.insert(acc, ('-'):rep(width))
+                table.insert(acc, ' ')
+            end
+            table.insert(acc, '|\n')
+        else
+            for j = 1, column_count do
+                assert(row[j] ~= nil)
+                local width = column_widths[j]
+                table.insert(acc, '| ')
+                table.insert(acc, row[j]:ljust(width))
+                table.insert(acc, ' ')
+            end
+            table.insert(acc, '|\n')
+        end
+    end
+
+    return table.concat(acc)
+end
+
+return {
+    SPACER = SPACER,
+    encode = encode,
+}

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -150,7 +150,8 @@ extern char session_lua[],
 	config_source_env_lua[],
 	config_source_file_lua[],
 	config_utils_log_lua[],
-	config_utils_schema_lua[]
+	config_utils_schema_lua[],
+	config_utils_tabulate_lua[]
 #if ENABLE_CONFIG_EXTRAS
 	,
 	config_source_etcd_lua[],
@@ -321,6 +322,10 @@ static const char *lua_sources[] = {
 	"config/utils/schema",
 	"internal.config.utils.schema",
 	config_utils_schema_lua,
+
+	"config/utils/tabulate",
+	"internal.config.utils.tabulate",
+	config_utils_tabulate_lua,
 
 	"config/instance_config",
 	"internal.config.instance_config",

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -1042,6 +1042,7 @@ run_script_f(va_list ap)
 	bool interactive = opt_mask & O_INTERACTIVE;
 	bool bytecode = opt_mask & O_BYTECODE;
 	bool debugging = opt_mask & O_DEBUGGING;
+	bool help_env_list = opt_mask & O_HELP_ENV_LIST;
 	/*
 	 * An error is returned via an external diag. A caller
 	 * can't use fiber_join(), because the script can call
@@ -1106,6 +1107,23 @@ run_script_f(va_list ap)
 		default:
 			unreachable(); /* checked by getopt() in main() */
 		}
+	}
+
+	/*
+	 * Show a list of environment variables that are
+	 * considered by tarantool and exit.
+	 */
+	if (help_env_list) {
+		/* require('config'):_print_env_list() */
+		if (lua_require_lib(L, "config") != 0)
+			goto error;
+		lua_pushstring(L, "_print_env_list");
+		lua_gettable(L, -2);
+		lua_pushvalue(L, -2);
+		if (luaT_call(L, 1, 0) != 0)
+			goto error;
+		lua_settop(L, 0);
+		goto end;
 	}
 
 	/*

--- a/src/lua/init.h
+++ b/src/lua/init.h
@@ -55,6 +55,7 @@ struct instance_state {
 #define O_BYTECODE    0x2
 #define O_DEBUGGING   0x4
 #define O_EXECUTE     0x8
+#define O_HELP_ENV_LIST 0x10
 
 /**
  * Create tarantool_L and initialize built-in Lua modules.

--- a/test/box-py/args.result
+++ b/test/box-py/args.result
@@ -24,6 +24,7 @@ Usage:
 Options:
 
  -h, --help             display this help and exit
+ --help-env-list        display env variables taken into account
  -v, --version          print program version and exit
  -c, --config PATH      set a path to yaml config file as 'PATH'
  -n, --name INSTANCE    set an instance name as 'INSTANCE'
@@ -65,6 +66,7 @@ Usage:
 Options:
 
  -h, --help             display this help and exit
+ --help-env-list        display env variables taken into account
  -v, --version          print program version and exit
  -c, --config PATH      set a path to yaml config file as 'PATH'
  -n, --name INSTANCE    set an instance name as 'INSTANCE'

--- a/test/config-luatest/cli_test.lua
+++ b/test/config-luatest/cli_test.lua
@@ -1,0 +1,72 @@
+local t = require('luatest')
+local justrun = require('test.justrun')
+
+local g = t.group()
+
+g.test_help_env_list = function()
+    local res = justrun.tarantool('.', {}, {'--help-env-list'}, {nojson = true})
+    t.assert_equals(res.exit_code, 0)
+
+    -- Pick up several well-known env variables to verify the idea
+    -- of the listing, but at the same time, don't list all the
+    -- options in the test case.
+    local cases = {
+        -- Verify that the env variables that duplicates CLI
+        -- options are present.
+        {
+            name = 'TT_INSTANCE_NAME',
+            type = 'string',
+            default = 'N/A',
+            availability = 'Community Edition',
+        },
+        {
+            name = 'TT_CONFIG',
+            type = 'string',
+            default = 'nil',
+            availability = 'Community Edition',
+        },
+        -- An env variable that accepts a numeric value and has
+        -- explicit default value.
+        {
+            name = 'TT_MEMTX_MEMORY',
+            type = 'integer',
+            default = '268435456',
+            availability = 'Community Edition',
+        },
+        -- An env variable that has box.NULL default.
+        {
+            name = 'TT_DATABASE_MODE',
+            type = 'string',
+            default = 'box.NULL',
+            availability = 'Community Edition',
+        },
+        -- An option with a template default.
+        {
+            name = 'TT_CONSOLE_SOCKET',
+            type = 'string',
+            default = '{{ instance_name }}.control',
+            availability = 'Community Edition',
+        },
+        -- An Enterprise Edition option and, at the same time,
+        -- an option with non-string type.
+        {
+            name = 'TT_CONFIG_ETCD_ENDPOINTS',
+            type = 'array',
+            default = 'nil',
+            availability = 'Enterprise Edition',
+        },
+        -- Yet another Enterprise Edition option.
+        {
+            name = 'TT_WAL_EXT_NEW',
+            type = 'boolean',
+            default = 'nil',
+            availability = 'Enterprise Edition',
+        },
+    }
+
+    for _, case in ipairs(cases) do
+        local needle = ('%s.*%s.*%s.*%s'):format(case.name, case.type,
+            case.default, case.availability)
+        t.assert(res.stdout:find(needle), case.name)
+    end
+end

--- a/test/config-luatest/config_test.lua
+++ b/test/config-luatest/config_test.lua
@@ -99,6 +99,12 @@ g.test_configdata = function()
                 box_cfg = "sql_cache_size",
                 default = 5242880,
                 type = "integer",
+                computed = {
+                    annotations = {
+                        config_version = "dev",
+                        box_cfg = "sql_cache_size",
+                    },
+                },
             },
         },
         {
@@ -108,6 +114,12 @@ g.test_configdata = function()
                 box_cfg = "memtx_memory",
                 default = 268435456,
                 type = "integer",
+                computed = {
+                    annotations = {
+                        config_version = "dev",
+                        box_cfg = "memtx_memory",
+                    },
+                },
             },
         },
     }

--- a/test/config-luatest/tabulate_test.lua
+++ b/test/config-luatest/tabulate_test.lua
@@ -1,0 +1,44 @@
+local tabulate = require('internal.config.utils.tabulate')
+local t = require('luatest')
+
+local g = t.group()
+
+g.test_basic = function()
+    local header = {
+        'Destination',
+        'Gateway',
+        'Genmask',
+        'Flags',
+        'Metric',
+        'Ref',
+        'Use',
+        'Iface',
+    }
+    local route_1 = {
+        '0.0.0.0',  -- Destination
+        '10.0.0.1', -- Gateway
+        '0.0.0.0',  -- Genmask
+        'UG',       -- Flags
+        '3005',     -- Metric
+        '0',        -- Ref
+        '0',        -- Use
+        'wlan0',    -- Iface
+    }
+    local route_2 = {
+        '10.0.0.0',      -- Destination
+        '0.0.0.0',       -- Gateway
+        '255.255.255.0', -- Genmask
+        'U',             -- Flags
+        '3005',          -- Metric
+        '0',             -- Ref
+        '0',             -- Use
+        'wlan0',         -- Iface
+    }
+    local res = tabulate.encode({header, tabulate.SPACER, route_1, route_2})
+    t.assert_equals(res, ([[
+| Destination | Gateway  | Genmask       | Flags | Metric | Ref | Use | Iface |
+| ----------- | -------- | ------------- | ----- | ------ | --- | --- | ----- |
+| 0.0.0.0     | 10.0.0.1 | 0.0.0.0       | UG    | 3005   | 0   | 0   | wlan0 |
+| 10.0.0.0    | 0.0.0.0  | 255.255.255.0 | U     | 3005   | 0   | 0   | wlan0 |
+]]):lstrip())
+end


### PR DESCRIPTION
It lists environment variables that are taken into account by the config module.

Part of #8862

----

Current output is the following.

<details>
<summary>Click to expand.</summary>

| ENVIRONMENT VARIABLE                      | TYPE           | DEFAULT                         | AVAILABILITY       |
| ----------------------------------------- | -------------- | ------------------------------- | ------------------ |
| TT_INSTANCE_NAME                          | string         | N/A                             | Community Edition  |
| TT_CONFIG                                 | string         | nil                             | Community Edition  |
| ----------------------------------------- | -------------- | ------------------------------- | ------------------ |
| TT_APP_CFG                                | map            | nil                             | Community Edition  |
| TT_APP_FILE                               | string         | nil                             | Community Edition  |
| TT_APP_MODULE                             | string         | nil                             | Community Edition  |
| TT_CONFIG_ETCD_ENDPOINTS                  | array          | nil                             | Enterprise Edition |
| TT_CONFIG_ETCD_HTTP_REQUEST_TIMEOUT       | number         | nil                             | Enterprise Edition |
| TT_CONFIG_ETCD_HTTP_REQUEST_UNIX_SOCKET   | string         | nil                             | Enterprise Edition |
| TT_CONFIG_ETCD_PASSWORD                   | string         | nil                             | Enterprise Edition |
| TT_CONFIG_ETCD_PREFIX                     | string         | nil                             | Enterprise Edition |
| TT_CONFIG_ETCD_SSL_CA_FILE                | string         | nil                             | Enterprise Edition |
| TT_CONFIG_ETCD_SSL_CA_PATH                | string         | nil                             | Enterprise Edition |
| TT_CONFIG_ETCD_SSL_SSL_KEY                | string         | nil                             | Enterprise Edition |
| TT_CONFIG_ETCD_SSL_VERIFY_HOST            | boolean        | nil                             | Enterprise Edition |
| TT_CONFIG_ETCD_SSL_VERIFY_PEER            | boolean        | nil                             | Enterprise Edition |
| TT_CONFIG_ETCD_USERNAME                   | string         | nil                             | Enterprise Edition |
| TT_CONFIG_RELOAD                          | string         | auto                            | Community Edition  |
| TT_CONFIG_VERSION                         | string         | nil                             | Community Edition  |
| TT_CONSOLE_ENABLED                        | boolean        | true                            | Community Edition  |
| TT_CONSOLE_SOCKET                         | string         | {{ instance_name }}.control     | Community Edition  |
| TT_CREDENTIALS_ROLES                      | map            | nil                             | Community Edition  |
| TT_CREDENTIALS_USERS                      | map            | nil                             | Community Edition  |
| TT_DATABASE_HOT_STANDBY                   | boolean        | false                           | Community Edition  |
| TT_DATABASE_INSTANCE_UUID                 | string         | box.NULL                        | Community Edition  |
| TT_DATABASE_MODE                          | string         | box.NULL                        | Community Edition  |
| TT_DATABASE_REPLICASET_UUID               | string         | box.NULL                        | Community Edition  |
| TT_DATABASE_TXN_ISOLATION                 | string         | best-effort                     | Community Edition  |
| TT_DATABASE_TXN_TIMEOUT                   | number         | 3153600000                      | Community Edition  |
| TT_DATABASE_USE_MVCC_ENGINE               | boolean        | false                           | Community Edition  |
| TT_FEEDBACK_CRASHINFO                     | boolean        | true                            | Community Edition  |
| TT_FEEDBACK_ENABLED                       | boolean        | true                            | Community Edition  |
| TT_FEEDBACK_HOST                          | string         | https://feedback.tarantool.io   | Community Edition  |
| TT_FEEDBACK_INTERVAL                      | number         | 3600                            | Community Edition  |
| TT_FEEDBACK_METRICS_COLLECT_INTERVAL      | number         | 60                              | Community Edition  |
| TT_FEEDBACK_METRICS_LIMIT                 | integer        | 1048576                         | Community Edition  |
| TT_FEEDBACK_SEND_METRICS                  | boolean        | true                            | Community Edition  |
| TT_FIBER_IO_COLLECT_INTERVAL              | number         | box.NULL                        | Community Edition  |
| TT_FIBER_SLICE_ERR                        | number         | 1                               | Community Edition  |
| TT_FIBER_SLICE_WARN                       | number         | 0.5                             | Community Edition  |
| TT_FIBER_TOO_LONG_THRESHOLD               | number         | 0.5                             | Community Edition  |
| TT_FIBER_TOP_ENABLED                      | boolean        | false                           | Community Edition  |
| TT_FIBER_WORKER_POOL_THREADS              | number         | 4                               | Community Edition  |
| TT_FLIGHTREC_ENABLED                      | boolean        | false                           | Enterprise Edition |
| TT_FLIGHTREC_LOGS_LOG_LEVEL               | integer        | 6                               | Enterprise Edition |
| TT_FLIGHTREC_LOGS_MAX_MSG_SIZE            | integer        | 4096                            | Enterprise Edition |
| TT_FLIGHTREC_LOGS_SIZE                    | integer        | 10485760                        | Enterprise Edition |
| TT_FLIGHTREC_METRICS_INTERVAL             | number         | 1                               | Enterprise Edition |
| TT_FLIGHTREC_METRICS_PERIOD               | number         | 180                             | Enterprise Edition |
| TT_FLIGHTREC_REQUESTS_MAX_REQ_SIZE        | integer        | 16384                           | Enterprise Edition |
| TT_FLIGHTREC_REQUESTS_MAX_RES_SIZE        | integer        | 16384                           | Enterprise Edition |
| TT_FLIGHTREC_REQUESTS_SIZE                | integer        | 10485760                        | Enterprise Edition |
| TT_IPROTO_ADVERTISE_CLIENT                | string         | box.NULL                        | Community Edition  |
| TT_IPROTO_ADVERTISE_PEER                  | string         | box.NULL                        | Community Edition  |
| TT_IPROTO_ADVERTISE_SHARDING              | string         | box.NULL                        | Community Edition  |
| TT_IPROTO_LISTEN                          | string         | box.NULL                        | Community Edition  |
| TT_IPROTO_NET_MSG_MAX                     | integer        | 768                             | Community Edition  |
| TT_IPROTO_READAHEAD                       | integer        | 16320                           | Community Edition  |
| TT_IPROTO_THREADS                         | integer        | 1                               | Community Edition  |
| TT_LOG_FILE                               | string         | {{ instance_name }}.log         | Community Edition  |
| TT_LOG_FORMAT                             | string         | plain                           | Community Edition  |
| TT_LOG_LEVEL                              | number, string | 5                               | Community Edition  |
| TT_LOG_MODULES                            | map            | box.NULL                        | Community Edition  |
| TT_LOG_NONBLOCK                           | boolean        | false                           | Community Edition  |
| TT_LOG_PIPE                               | string         | box.NULL                        | Community Edition  |
| TT_LOG_SYSLOG_FACILITY                    | string         | local7                          | Community Edition  |
| TT_LOG_SYSLOG_IDENTITY                    | string         | tarantool                       | Community Edition  |
| TT_LOG_SYSLOG_SERVER                      | string         | box.NULL                        | Community Edition  |
| TT_LOG_TO                                 | string         | stderr                          | Community Edition  |
| TT_MEMTX_ALLOCATOR                        | string         | small                           | Community Edition  |
| TT_MEMTX_MAX_TUPLE_SIZE                   | integer        | 1048576                         | Community Edition  |
| TT_MEMTX_MEMORY                           | integer        | 268435456                       | Community Edition  |
| TT_MEMTX_MIN_TUPLE_SIZE                   | integer        | 16                              | Community Edition  |
| TT_MEMTX_SLAB_ALLOC_FACTOR                | number         | 1.05                            | Community Edition  |
| TT_MEMTX_SLAB_ALLOC_GRANULARITY           | integer        | 8                               | Community Edition  |
| TT_MEMTX_SORT_THREADS                     | integer        | box.NULL                        | Community Edition  |
| TT_METRICS_EXCLUDE                        | array          | nil                             | Community Edition  |
| TT_METRICS_INCLUDE                        | array          | nil                             | Community Edition  |
| TT_METRICS_LABELS                         | map            | nil                             | Community Edition  |
| TT_PROCESS_BACKGROUND                     | boolean        | false                           | Community Edition  |
| TT_PROCESS_COREDUMP                       | boolean        | false                           | Community Edition  |
| TT_PROCESS_PID_FILE                       | string         | {{ instance_name }}.pid         | Community Edition  |
| TT_PROCESS_STRIP_CORE                     | boolean        | true                            | Community Edition  |
| TT_PROCESS_TITLE                          | string         | tarantool - {{ instance_name }} | Community Edition  |
| TT_PROCESS_USERNAME                       | string         | box.NULL                        | Community Edition  |
| TT_PROCESS_WORK_DIR                       | string         | box.NULL                        | Community Edition  |
| TT_REPLICATION_ANON                       | boolean        | false                           | Community Edition  |
| TT_REPLICATION_BOOTSTRAP_STRATEGY         | string         | auto                            | Community Edition  |
| TT_REPLICATION_CONNECT_TIMEOUT            | number         | 30                              | Community Edition  |
| TT_REPLICATION_ELECTION_FENCING_MODE      | string         | soft                            | Community Edition  |
| TT_REPLICATION_ELECTION_MODE              | string         | box.NULL                        | Community Edition  |
| TT_REPLICATION_ELECTION_TIMEOUT           | number         | 5                               | Community Edition  |
| TT_REPLICATION_FAILOVER                   | string         | off                             | Community Edition  |
| TT_REPLICATION_PEERS                      | array          | box.NULL                        | Community Edition  |
| TT_REPLICATION_SKIP_CONFLICT              | boolean        | false                           | Community Edition  |
| TT_REPLICATION_SYNC_LAG                   | number         | 10                              | Community Edition  |
| TT_REPLICATION_SYNC_TIMEOUT               | number         | 0                               | Community Edition  |
| TT_REPLICATION_SYNCHRO_QUORUM             | string, number | N / 2 + 1                       | Community Edition  |
| TT_REPLICATION_SYNCHRO_TIMEOUT            | number         | 5                               | Community Edition  |
| TT_REPLICATION_THREADS                    | integer        | 1                               | Community Edition  |
| TT_REPLICATION_TIMEOUT                    | number         | 1                               | Community Edition  |
| TT_SECURITY_AUTH_DELAY                    | number         | 0                               | Enterprise Edition |
| TT_SECURITY_AUTH_TYPE                     | string         | chap-sha1                       | Community Edition  |
| TT_SECURITY_DISABLE_GUEST                 | boolean        | false                           | Enterprise Edition |
| TT_SECURITY_PASSWORD_ENFORCE_DIGITS       | boolean        | false                           | Enterprise Edition |
| TT_SECURITY_PASSWORD_ENFORCE_LOWERCASE    | boolean        | false                           | Enterprise Edition |
| TT_SECURITY_PASSWORD_ENFORCE_SPECIALCHARS | boolean        | false                           | Enterprise Edition |
| TT_SECURITY_PASSWORD_ENFORCE_UPPERCASE    | boolean        | false                           | Enterprise Edition |
| TT_SECURITY_PASSWORD_HISTORY_LENGTH       | integer        | 0                               | Enterprise Edition |
| TT_SECURITY_PASSWORD_LIFETIME_DAYS        | integer        | 0                               | Enterprise Edition |
| TT_SECURITY_PASSWORD_MIN_LENGTH           | integer        | 0                               | Enterprise Edition |
| TT_SNAPSHOT_BY_INTERVAL                   | number         | 3600                            | Community Edition  |
| TT_SNAPSHOT_BY_WAL_SIZE                   | integer        | 1e+18                           | Community Edition  |
| TT_SNAPSHOT_COUNT                         | integer        | 2                               | Community Edition  |
| TT_SNAPSHOT_DIR                           | string         | {{ instance_name }}             | Community Edition  |
| TT_SNAPSHOT_SNAP_IO_RATE_LIMIT            | number         | box.NULL                        | Community Edition  |
| TT_SQL_CACHE_SIZE                         | integer        | 5242880                         | Community Edition  |
| TT_VINYL_BLOOM_FPR                        | number         | 0.05                            | Community Edition  |
| TT_VINYL_CACHE                            | integer        | 134217728                       | Community Edition  |
| TT_VINYL_DEFER_DELETES                    | boolean        | false                           | Community Edition  |
| TT_VINYL_DIR                              | string         | {{ instance_name }}             | Community Edition  |
| TT_VINYL_MAX_TUPLE_SIZE                   | integer        | 1048576                         | Community Edition  |
| TT_VINYL_MEMORY                           | integer        | 134217728                       | Community Edition  |
| TT_VINYL_PAGE_SIZE                        | integer        | 8192                            | Community Edition  |
| TT_VINYL_RANGE_SIZE                       | integer        | box.NULL                        | Community Edition  |
| TT_VINYL_READ_THREADS                     | integer        | 1                               | Community Edition  |
| TT_VINYL_RUN_COUNT_PER_LEVEL              | integer        | 2                               | Community Edition  |
| TT_VINYL_RUN_SIZE_RATIO                   | number         | 3.5                             | Community Edition  |
| TT_VINYL_TIMEOUT                          | number         | 60                              | Community Edition  |
| TT_VINYL_WRITE_THREADS                    | integer        | 4                               | Community Edition  |
| TT_WAL_CLEANUP_DELAY                      | number         | 14400                           | Community Edition  |
| TT_WAL_DIR                                | string         | {{ instance_name }}             | Community Edition  |
| TT_WAL_DIR_RESCAN_DELAY                   | number         | 2                               | Community Edition  |
| TT_WAL_EXT_NEW                            | boolean        | nil                             | Enterprise Edition |
| TT_WAL_EXT_OLD                            | boolean        | nil                             | Enterprise Edition |
| TT_WAL_EXT_SPACES                         | map            | nil                             | Enterprise Edition |
| TT_WAL_MAX_SIZE                           | integer        | 268435456                       | Community Edition  |
| TT_WAL_MODE                               | string         | write                           | Community Edition  |
| TT_WAL_QUEUE_MAX_SIZE                     | integer        | 16777216                        | Community Edition  |
</details>