### PR TITLE
compat: follow-up `is_old` / `is_new`

### DIFF
--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -991,7 +991,7 @@ return schema.new('instance_config', schema.record({
         sync_timeout = schema.scalar({
             type = 'number',
             box_cfg = 'replication_sync_timeout',
-            default = compat.box_cfg_replication_sync_timeout.default == 'old'
+            default = compat.box_cfg_replication_sync_timeout:is_old()
                 and 300 or 0,
         }),
         sync_lag = schema.scalar({

--- a/src/box/lua/tuple.lua
+++ b/src/box/lua/tuple.lua
@@ -76,7 +76,7 @@ local NEW_OPTION_TYPES = {
 }
 
 local new_tuple = function(...)
-    if compat.box_tuple_new_vararg.current == 'old' then
+    if compat.box_tuple_new_vararg:is_old() then
         return internal.tuple.new{...}
     end
     local tuple, options = ...

--- a/src/lua/compat.lua
+++ b/src/lua/compat.lua
@@ -428,6 +428,37 @@ function compat_mt.__newindex(_, key, val)
     set_option(key, val)
 end
 
+local compat_option_methods = {}
+
+-- Returns the effective compat option value - 'old' or 'new'.
+local function option_value(option)
+    if option.current == 'default' then
+        return option.default
+    else
+        return option.current
+    end
+end
+
+-- Whether the effective value of the option is `new`.
+function compat_option_methods.is_new(option)
+    if type(option) ~= 'table' then
+        error('usage: compat.<option_name>:is_new()')
+    end
+    return option_value(option) == 'new'
+end
+
+-- Whether the effective value of the option is `old`.
+function compat_option_methods.is_old(option)
+    if type(option) ~= 'table' then
+        error('usage: compat.<option_name>:is_old()')
+    end
+    return option_value(option) == 'old'
+end
+
+local compat_option_mt = {
+    __index = compat_option_methods,
+}
+
 function compat_mt.__index(_, key)
     if not options[key] then
         error(('Invalid option %s'):format(key))
@@ -446,29 +477,7 @@ function compat_mt.__index(_, key)
         result.current = 'old'
     end
 
-    -- Whether the effective value of the option is `new`.
-    function result.is_new(option)
-        if type(option) ~= 'table' then
-            error(('usage: compat.%s:is_new()'):format(key))
-        end
-        if option.current == 'new' then
-            return true
-        end
-        if option.current == 'old' then
-            return false
-        end
-        return option.default == 'new'
-    end
-
-    -- Whether the effective value of the option is `old`.
-    function result.is_old(option)
-        if type(option) ~= 'table' then
-            error(('usage: compat.%s:is_old()'):format(key))
-        end
-        return not option:is_new()
-    end
-
-    return result
+    return setmetatable(result, compat_option_mt)
 end
 
 compat_mt.__serialize = serialize_compat

--- a/test/app-luatest/gh_7000_compat_module_test.lua
+++ b/test/app-luatest/gh_7000_compat_module_test.lua
@@ -234,11 +234,12 @@ g.test_is_new_is_old = function()
         t.assert_equals(compat[name]:is_new(), is_new)
         t.assert_equals(compat[name]:is_old(), not is_new)
 
-        local err_pattern = 'usage: compat.%s:%s'
-        t.assert_error_msg_contains(err_pattern:format(name, 'is_new'),
-                                    compat[name].is_new, nil)
-        t.assert_error_msg_contains(err_pattern:format(name, 'is_old'),
-                                    compat[name].is_old, nil)
+        t.assert_error_msg_content_equals(
+            'usage: compat.<option_name>:is_new()',
+            compat[name].is_new)
+        t.assert_error_msg_content_equals(
+            'usage: compat.<option_name>:is_old()',
+            compat[name].is_old)
     end
 end
 


### PR DESCRIPTION
- Move the `is_old` and `is_new` compat option methods to a metatable.
- Use them where appropriate.

Follow-up #8807