### PR TITLE
box: deprecate box.session.push

### DIFF
--- a/changelogs/unreleased/gh-8802-box-session-push-deprecation.md
+++ b/changelogs/unreleased/gh-8802-box-session-push-deprecation.md
@@ -1,0 +1,4 @@
+## feature/box
+
+* The function `box.session.push` is now deprecated. Consider using
+  `box.broadcast` instead (gh-8802).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -4000,6 +4000,8 @@ box_session_push(const char *data, const char *data_end)
 	struct session *session = current_session();
 	if (session == NULL)
 		return -1;
+	if (session_push_check_deprecation() != 0)
+		return -1;
 	struct port_msgpack port;
 	struct port *base = (struct port *)&port;
 	port_msgpack_create(base, data, data_end - data);

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -325,6 +325,7 @@ struct errcode_record {
 	/*270 */_(ER_INSTANCE_NAME_MISMATCH,	"Instance name mismatch: expected %s, got %s") \
 	/*271 */_(ER_SCHEMA_NEEDS_UPGRADE,	"Your schema version is %u.%u.%u while Tarantool %s requires a more recent schema version. Please, consider using box.schema.upgrade().") \
 	/*272 */_(ER_SCHEMA_UPGRADE_IN_PROGRESS, "Schema upgrade is already in progress") \
+	/*273 */_(ER_DEPRECATED,		"%s is deprecated") \
 
 /*
  * !IMPORTANT! Please follow instructions at start of the file

--- a/src/box/lua/session.c
+++ b/src/box/lua/session.c
@@ -374,6 +374,8 @@ lbox_session_push(struct lua_State *L)
 	struct session *session = current_session();
 	if (lua_gettop(L) != 1)
 		return luaL_error(L, "Usage: box.session.push(data)");
+	if (session_push_check_deprecation() != 0)
+		return luaT_error(L);
 	struct port port;
 	port_lua_create(&port, L);
 	if (session_push(session, &port) != 0)

--- a/src/box/session.c
+++ b/src/box/session.c
@@ -42,6 +42,7 @@
 #include "watcher.h"
 #include "on_shutdown.h"
 #include "sql.h"
+#include "tweaks.h"
 
 const char *session_type_strs[] = {
 	"background",
@@ -491,6 +492,24 @@ int
 access_check_universe(user_access_t access)
 {
 	return access_check_universe_object(access, SC_UNIVERSE, "");
+}
+
+/**
+ * If set, raise an error on any attempt to use box.session.push.
+ */
+static bool box_session_push_is_disabled = true;
+TWEAK_BOOL(box_session_push_is_disabled);
+
+int
+session_push_check_deprecation(void)
+{
+	say_warn_once("box.session.push is deprecated. "
+		      "Consider using box.broadcast instead.");
+	if (box_session_push_is_disabled) {
+		diag_set(ClientError, ER_DEPRECATED, "box.session.push");
+		return -1;
+	}
+	return 0;
 }
 
 int

--- a/src/box/session.h
+++ b/src/box/session.h
@@ -403,6 +403,14 @@ access_check_universe_object(user_access_t access,
 			     enum schema_object_type object_type,
 			     const char *object_name);
 
+/**
+ * This function is called by public API wrappers around session push.
+ * It logs a deprecation warning. If session push is disabled, it also
+ * sets diag and returns -1.
+ */
+int
+session_push_check_deprecation(void);
+
 static inline int
 session_push(struct session *session, struct port *port)
 {

--- a/src/lib/core/say.h
+++ b/src/lib/core/say.h
@@ -420,6 +420,20 @@ _say_strerror(int errnum);
 	exit(EXIT_FAILURE); \
 })
 
+/**
+ * Log a message once.
+ */
+#define say_once(level, error, format, ...) ({				\
+	static bool done = false;					\
+	if (!done) {							\
+		say(level, error, format, ##__VA_ARGS__);		\
+		done = true;						\
+	}								\
+})
+
+#define say_warn_once(format, ...) \
+	say_once(S_WARN, NULL, format, ##__VA_ARGS__)
+
 enum {
 	/* 10 messages per 5 seconds. */
 	SAY_RATELIMIT_INTERVAL = 5,

--- a/src/lua/compat.lua
+++ b/src/lua/compat.lua
@@ -73,6 +73,13 @@ argument.
 https://tarantool.io/compat/box_tuple_new_vararg
 ]]
 
+local BOX_SESSION_PUSH_DEPRECATION_BRIEF = [[
+Function `box.session.push` is deprecated. The new behavior is to raise
+an error on any attempt to use it.
+
+https://tarantool.io/compat/box_session_push_deprecation
+]]
+
 -- Returns an action callback that toggles a tweak.
 local function tweak_action(tweak_name, old_tweak_value, new_tweak_value)
     return function(is_new)
@@ -138,6 +145,13 @@ local options = {
         obsolete = nil,
         brief = BOX_TUPLE_NEW_VARARG_BRIEF,
         action = function() end,
+    },
+    box_session_push_deprecation = {
+        default = 'old',
+        obsolete = nil,
+        brief = BOX_SESSION_PUSH_DEPRECATION_BRIEF,
+        run_action_now = true,
+        action = tweak_action('box_session_push_is_disabled', false, true),
     },
 }
 

--- a/test/box-luatest/gh_8802_box_session_push_deprecation_test.lua
+++ b/test/box-luatest/gh_8802_box_session_push_deprecation_test.lua
@@ -1,0 +1,93 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local WARNING_PATTERN = 'W> box%.session%.push is deprecated. ' ..
+                        'Consider using box%.broadcast instead%.$'
+
+local g = t.group('box_session_push_deprecation', t.helpers.matrix({
+    api = {'lua', 'c'},
+    compat = {'old', 'new'},
+}))
+
+g.before_all(function(cg)
+    cg.server = server:new()
+end)
+
+g.before_each(function(cg)
+    cg.server:start()
+    cg.server:exec(function(params)
+        local func
+        if params.api == 'lua' then
+            func = box.session.push
+        elseif params.api == 'c' then
+            local ffi = require('ffi')
+            local msgpack = require('msgpack')
+            ffi.cdef([[
+                int box_session_push(const char *data, const char *data_end);
+            ]])
+            func = function(value)
+                local data = msgpack.encode(value)
+                if ffi.C.box_session_push(
+                        ffi.cast('const char *', data),
+                        ffi.cast('const char *', data) + #data) ~= 0 then
+                    box.error()
+                end
+            end
+        end
+        t.assert(func)
+        rawset(_G, 'box_session_push', func)
+    end, {cg.params})
+end)
+
+g.after_each(function(cg)
+    cg.server:stop()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test = function(cg)
+    cg.server:exec(function(params)
+        local compat = require('compat')
+        compat.box_session_push_deprecation = params.compat
+    end, {cg.params})
+
+    t.assert_not(cg.server:grep_log(WARNING_PATTERN),
+                 'No deprecation warning in the log initially')
+
+    -- Test box.session.push. It shouldn't work with the new behavior.
+    -- The warning should be logged in any case.
+    cg.server:exec(function()
+        local compat = require('compat')
+        local box_session_push = rawget(_G, 'box_session_push')
+        local ok, err = pcall(box_session_push, 'foo')
+        t.assert_equals(ok, compat.box_session_push_deprecation:is_old(),
+                        'box.session.push status')
+        if not ok then
+            t.assert_equals(tostring(err), 'box.session.push is deprecated',
+                            'box.session.push error')
+        end
+    end)
+    t.assert(cg.server:grep_log(WARNING_PATTERN),
+             'Deprecation warning is logged')
+
+    -- Check that the warning is logged only once.
+    cg.server:exec(function()
+        local log = require('log')
+        for _ = 1, 10 do
+            log.warn(string.rep('x', 1000))
+        end
+        local compat = require('compat')
+        local box_session_push = rawget(_G, 'box_session_push')
+        local ok, err = pcall(box_session_push, 'foo')
+        t.assert_equals(ok, compat.box_session_push_deprecation:is_old(),
+                        'box.session.push status')
+        if not ok then
+            t.assert_equals(tostring(err), 'box.session.push is deprecated',
+                            'box.session.push error')
+        end
+    end)
+    t.assert_not(cg.server:grep_log(WARNING_PATTERN, 5000),
+                 'Deprecation warning is logged only once')
+end

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -491,6 +491,7 @@ t;
  |   270: box.error.INSTANCE_NAME_MISMATCH
  |   271: box.error.SCHEMA_NEEDS_UPGRADE
  |   272: box.error.SCHEMA_UPGRADE_IN_PROGRESS
+ |   273: box.error.DEPRECATED
  | ...
 
 test_run:cmd("setopt delimiter ''");


### PR DESCRIPTION
The `box.session.push` Lua function and `box_session_push` C API function are deprecated starting from Tarantool 3.0. Calling any of these functions for the first time results in printing a warning message to the log.

The new compat module option `box_session_push_deprecation` was introduced to control whether the functions are still available. With the old behavior, which is the default in Tarantool 3.0, `box.session.push` is still available. With the new behavior, any attempt to use it raises an exception.

We are planning to switch the compat option to the new behavior starting from Tarantool 4.0 with the ability to revert to the old behavior. Starting from Tarantool 5.0 we are planning to drop `box.session.push` completely.

Closes #8802