### PR TITLE
config: add metrics section to schema

### DIFF
--- a/changelogs/unreleased/gh-8861-metrics-options.md
+++ b/changelogs/unreleased/gh-8861-metrics-options.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* All metrics configuration options from `box.cfg{}` are now supported
+  in the YAML config (gh-8861).

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -355,6 +355,17 @@ local function apply(config)
     -- Set bootstrap_leader option.
     box_cfg.bootstrap_leader = configdata:bootstrap_leader()
 
+    -- Set metrics option.
+    local include = configdata:get('metrics.include', {use_default = true})
+    local exclude = configdata:get('metrics.exclude', {use_default = true})
+    local labels = configdata:get('metrics.labels', {use_default = true})
+
+    box_cfg.metrics = {
+        include = include or { 'all' },
+        exclude = exclude or { },
+        labels = labels or { alias = names.instance_name },
+    }
+
     -- The startup process may need a special handling and differs
     -- from the configuration reloading process.
     local is_startup = type(box.cfg) == 'function'

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1357,6 +1357,52 @@ return schema.new('instance_config', schema.record({
             box_cfg = 'password_history_length',
         })),
     }),
+    metrics = schema.record({
+        -- Metrics doesn't have box_cfg annotation, because currently nested
+        -- options and maps/arrays defaults are not supported.
+        include = schema.set({
+            'all',
+            'network',
+            'operations',
+            'system',
+            'replicas',
+            'info',
+            'slab',
+            'runtime',
+            'memory',
+            'spaces',
+            'fibers',
+            'cpu',
+            'vinyl',
+            'memtx',
+            'luajit',
+            'clock',
+            'event_loop',
+        }),
+        exclude = schema.set({
+            'all',
+            'network',
+            'operations',
+            'system',
+            'replicas',
+            'info',
+            'slab',
+            'runtime',
+            'memory',
+            'spaces',
+            'fibers',
+            'cpu',
+            'vinyl',
+            'memtx',
+            'luajit',
+            'clock',
+            'event_loop',
+        }),
+        labels = schema.map({
+            key = schema.scalar({type = 'string'}),
+            value = schema.scalar({type = 'string'}),
+        }),
+    }),
 }, {
     -- This kind of validation cannot be implemented as the
     -- 'validate' annotation of a particular schema node. There

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1016,6 +1016,7 @@ g.test_box_cfg_coverage = function()
         replicaset_name = true,
         cluster_name = true,
         log = true,
+        metrics = true,
 
         -- Controlled by the leader and database.mode options,
         -- handled by the box_cfg applier.
@@ -1036,9 +1037,6 @@ g.test_box_cfg_coverage = function()
         audit_nonblock = true,
         audit_format = true,
         audit_filter = true,
-
-        -- TODO: Will be added in the scope of gh-8861.
-        metrics = true,
     }
 
     -- There are options, where defaults are changed deliberately.
@@ -1279,4 +1277,17 @@ g.test_security_community = function()
     }
 
     instance_config:validate(iconfig)
+end
+
+g.test_metrics = function()
+    local iconfig = {
+        metrics = {
+            include = {'network', 'info', 'cpu'},
+            exclude = {'info'},
+            labels = {foo = 'bar'},
+        }
+    }
+
+    instance_config:validate(iconfig)
+    validate_fields(iconfig.metrics, instance_config.schema.fields.metrics)
 end


### PR DESCRIPTION
This patch introduces all metrics configuration.

Part of #8861

NO_DOC=tarantool/doc#3544 links the most actual schema,
       no need to update the issue.