### PR TITLE
lua/socket: introduce `socket.from_fd`, `socket:detach`, `socket.socketpair`

### DIFF
--- a/changelogs/unreleased/gh-8927-socketpair.md
+++ b/changelogs/unreleased/gh-8927-socketpair.md
@@ -1,0 +1,4 @@
+## feature/lua/socket
+
+* Introduced new socket functions `socket.socketpair`, `socket.from_fd`, and
+  `socket:detach` (gh-8927).

--- a/test/app-luatest/socket_test.lua
+++ b/test/app-luatest/socket_test.lua
@@ -35,3 +35,26 @@ g.test_from_fd = function()
     t.assert(s.itype, 0)
     t.assert_not(s:close())
 end
+
+g.test_detach = function()
+    local s1 = socket('AF_INET', 'SOCK_STREAM', 'tcp')
+    t.assert(s1)
+    local s2 = socket.from_fd(s1:fd())
+    t.assert(s2)
+    t.assert_error_msg_content_equals('Usage: socket:method()', s1.detach)
+    t.assert_is(s1:detach(), nil)
+    local errmsg = 'attempt to use closed socket'
+    t.assert_error_msg_content_equals(errmsg, s1.detach, s1)
+    t.assert_error_msg_content_equals(errmsg, s1.close, s1)
+    t.assert(s2:close())
+
+    s1 = socket('AF_UNIX', 'SOCK_STREAM', 0)
+    t.assert(s1)
+    s2 = socket.from_fd(s1:fd())
+    t.assert(s2)
+    t.assert_is(s1:detach())
+    s1 = nil -- luacheck: ignore
+    collectgarbage('collect')
+    t.assert_is_not(s2:name(), nil)
+    t.assert(s2:close())
+end

--- a/test/app-luatest/socket_test.lua
+++ b/test/app-luatest/socket_test.lua
@@ -1,0 +1,37 @@
+local socket = require('socket')
+local t = require('luatest')
+
+local g = t.group()
+
+g.test_from_fd = function()
+    local errmsg = 'fd must be a number'
+    t.assert_error_msg_content_equals(errmsg, socket.from_fd)
+    t.assert_error_msg_content_equals(errmsg, socket.from_fd, 'foo')
+
+    local s1 = socket('AF_INET', 'SOCK_STREAM', 'tcp')
+    t.assert(s1)
+    local s2 = socket.from_fd(s1:fd())
+    t.assert(s2)
+    t.assert_equals(s2:fd(), s1:fd())
+    t.assert_equals(s2.itype, socket.internal.SO_TYPE.SOCK_STREAM)
+
+    t.assert(s1:close())
+    t.assert_not(s2:close())
+
+    s1 = socket('AF_INET', 'SOCK_DGRAM', 'udp')
+    t.assert(s1)
+    s2 = socket.from_fd(s1:fd())
+    t.assert(s2)
+    t.assert_equals(s2:fd(), s1:fd())
+    t.assert_equals(s2.itype, socket.internal.SO_TYPE.SOCK_DGRAM)
+
+    t.assert(s1:close())
+    t.assert_not(s2:close())
+
+    local invalid_fd = 100500
+    local s = socket.from_fd(invalid_fd)
+    t.assert(s)
+    t.assert(s:fd(), invalid_fd)
+    t.assert(s.itype, 0)
+    t.assert_not(s:close())
+end


### PR DESCRIPTION
This PR adds two socket module functions and one socket object method:

- `socket.from_fd(fd)`: constructs a socket object from the file descriptor number. Returns the new socket object on success. Never fails. Note, the function doesn't perform any checks on the given file descriptor so technically it's possible to pass a closed file descriptor or a file descriptor that refers to a file, in which case the new socket object methods may not work as expected.

- `socket:detach()`: like `socket:close()` but doesn't close the socket file descriptor, only switches the socket object to the closed state. Returns nothing. If the socket was already detached or closed, raises an exception.

  Along with `socket.from_fd`, this method may be used for transferring file descriptor ownership from one socket to another:

  ```Lua
  local socket = require('socket')
  local s1 = socket('AF_INET', 'SOCK_STREAM', 'tcp')
  local s2 = socket.from_fd(s1:fd())
  s1:detach()
  ```

- `socket.socketpair(domain, type, proto)`: a wrapper around the [`socketpair`][1] system call. Returns two socket objects representing the two ends of the new socket pair on success. On failure, returns nil and sets [`errno`][2].

  Example:

  ```Lua
  local errno = require('errno')
  local socket = require('socket')
  local s1, s1 = socketpair('AF_UNIX', 'SOCK_STREAM', 0)
  if not s1 then
      error('socketpair: ' .. errno.strerror())
  end
  s1:send('foo')
  assert(s2:recv() == 'foo')
  s1:close()
  s2:close()
  ```

Closes #8927

[1]: https://man7.org/linux/man-pages/man2/socketpair.2.html
[2]: https://www.tarantool.io/en/doc/latest/reference/reference_lua/errno/