### PR TITLE
make: fix hard-coded compiler version in .test.mk

### DIFF
--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Install deps
         uses: ./.github/actions/install-deps-debian
       - name: test
+        env:
+          CC: clang-11
+          CXX: clang++-11
         run: make -f .test.mk test-release-asan
       - name: Send VK Teams message on failure
         if: failure()

--- a/.test.mk
+++ b/.test.mk
@@ -72,7 +72,6 @@ test-release: build run-luajit-test run-test
 # Release ASAN build
 
 .PHONY: test-release-asan
-test-release-asan: CMAKE_ENV = CC=clang-11 CXX=clang++-11
 # FIBER_STACK_SIZE=640Kb: The default value of fiber stack size
 # is 512Kb, but several tests in test/PUC-Rio-Lua-5.1-test suite
 # in the LuaJIT repo (e.g. some cases with deep recursion in


### PR DESCRIPTION
Remove hard-coded compiler version for the `test-release-asan` target in the .test.mk file.