### PR TITLE
lua/popen: introduce `inherit_fds` option for `popen.new`

### DIFF
--- a/changelogs/unreleased/gh-8926-popen-inherit-fds.md
+++ b/changelogs/unreleased/gh-8926-popen-inherit-fds.md
@@ -1,0 +1,5 @@
+## feature/lua/popen
+
+* Introduced new option `inherit_fds` for `popen.new`. The option takes
+  an array of file descriptor numbers that should be left open in the child
+  process (gh-8926).

--- a/src/lib/core/popen.c
+++ b/src/lib/core/popen.c
@@ -199,12 +199,7 @@ handle_new(struct popen_opts *opts)
 		size += strlen(opts->argv[i]) + 3;
 	}
 
-	handle = malloc(sizeof(*handle) + size);
-	if (!handle) {
-		diag_set(OutOfMemory, sizeof(*handle) + size,
-			 "malloc", "popen_handle");
-		return NULL;
-	}
+	handle = xmalloc(sizeof(*handle) + size);
 
 	pos = handle->command = (void *)handle + sizeof(*handle);
 	pos_max = pos + size;
@@ -1134,7 +1129,6 @@ popen_wait_group_leadership(pid_t pid)
  *   getpgid() fails in the parent process.
  * - SystemError: (temporary restriction) one of std{in,out,err}
  *   is closed in the parent process.
- * - OutOfMemory: unable to allocate handle.
  */
 struct popen_handle *
 popen_new(struct popen_opts *opts)

--- a/src/lib/core/popen.h
+++ b/src/lib/core/popen.h
@@ -145,6 +145,10 @@ struct popen_opts {
 	size_t			nr_argv;
 	char			**env;
 	unsigned int		flags;
+	/** File descriptors that should be left open in the child. */
+	int *inherit_fds;
+	/** Size of the inherit_fds array. */
+	size_t nr_inherit_fds;
 };
 
 /**

--- a/test/app-luatest/popen_test.lua
+++ b/test/app-luatest/popen_test.lua
@@ -1,0 +1,60 @@
+local buffer = require('buffer')
+local ffi = require('ffi')
+local popen = require('popen')
+local t = require('luatest')
+
+local g = t.group()
+
+local TARANTOOL_PATH = arg[-1]
+
+ffi.cdef([[
+    int pipe(int pipefd[2]);
+]])
+
+g.test_inherit_fds = function()
+    t.assert_error_msg_equals(
+        'popen.new: wrong parameter "opts.inherit_fds": ' ..
+        'expected table or nil, got number',
+        popen.new, {TARANTOOL_PATH}, {inherit_fds = 0})
+    t.assert_error_msg_equals(
+        'popen.new: wrong parameter "opts.inherit_fds": ' ..
+        'expected table or nil, got string',
+        popen.new, {TARANTOOL_PATH}, {inherit_fds = 'foo'})
+    t.assert_error_msg_equals(
+        'popen.new: wrong parameter "opts.inherit_fds[1]": ' ..
+        'expected nonnegative integer, got string',
+        popen.new, {TARANTOOL_PATH}, {inherit_fds = {'foo'}})
+    t.assert_error_msg_equals(
+        'popen.new: wrong parameter "opts.inherit_fds[2]": ' ..
+        'expected nonnegative integer, got number',
+        popen.new, {TARANTOOL_PATH}, {inherit_fds = {0, 1.5}})
+    t.assert_error_msg_equals(
+        'popen.new: wrong parameter "opts.inherit_fds[3]": ' ..
+        'expected nonnegative integer, got number',
+        popen.new, {TARANTOOL_PATH}, {inherit_fds = {0, 1, 1e100}})
+    t.assert_error_msg_equals(
+        'popen.new: wrong parameter "opts.inherit_fds[3]": ' ..
+        'expected nonnegative integer, got number',
+        popen.new, {TARANTOOL_PATH}, {inherit_fds = {0, 1, -1e100}})
+    t.assert_error_msg_equals(
+        'popen.new: wrong parameter "opts.inherit_fds[4]": ' ..
+        'expected nonnegative integer, got number',
+        popen.new, {TARANTOOL_PATH}, {inherit_fds = {0, 1, 2, -1}})
+
+    local fds = ffi.new('int[2]')
+    t.assert_equals(ffi.C.pipe(fds), 0)
+
+    local msg = 'foobar'
+    local script = string.format([[require('ffi').C.write(%d, '%s', %d)]],
+                                 fds[1], msg, #msg)
+    local ph = popen.new({TARANTOOL_PATH, '-e', script},
+                         {close_fds = true, inherit_fds = {fds[1]}})
+    t.assert_equals(ffi.C.close(fds[1]), 0)
+    t.assert_covers(ph:wait(), {exit_code = 0})
+
+    local ibuf = buffer.ibuf()
+    t.assert_equals(ffi.C.read(fds[0], ibuf:reserve(#msg), #msg), #msg)
+    t.assert_equals(ffi.C.close(fds[0]), 0)
+    t.assert_equals(ffi.string(ibuf.rpos, #msg), msg)
+    ibuf:recycle()
+end


### PR DESCRIPTION
The new option takes an array of file descriptor numbers that should be left open in the child process if the `close_fds` flag is set. If the `close_fds` flag isn't set, the option has no effect because in this case none of the parent's file descriptors are closed anyway.

The option may be useful for establishing a communication channel between a Tarantool instance and a process spawned by it with `popen.new`, for example, using `socket.socketpair`.

Closes #8926