### PR TITLE
box: loose truncate check in case of foreign key 2.10

### DIFF
--- a/changelogs/unreleased/gh-8946-foreign-key-disables-truncate.md
+++ b/changelogs/unreleased/gh-8946-foreign-key-disables-truncate.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a bug when a space that is referenced by a foreign key could not
+  be truncated even if the referring space was empty (gh-8946).

--- a/src/box/space_cache.h
+++ b/src/box/space_cache.h
@@ -179,7 +179,7 @@ space_cache_unpin(struct space_cache_holder *holder);
 /**
  * Check whether the @a space has holders or not.
  * If it has, @a type argument is set to the first holder's type.
- * The function must be in cache (asserted).
+ * The space must be in cache (asserted).
  * If a space has holders, it must not be deleted (asserted).
  */
 bool

--- a/test/engine-luatest/gh_6436_complex_foreign_key_test.lua
+++ b/test/engine-luatest/gh_6436_complex_foreign_key_test.lua
@@ -109,7 +109,7 @@ g.test_complex_foreign_key_primary = function(cg)
         t.assert_equals(country:select{}, {{1, 11, 'Russia'}, {1, 12, 'France'}})
         t.assert_error_msg_content_equals(
             "Can't modify space 'country': space is referenced by foreign key",
-            function() country:drop() end
+            box.atomic, country.drop, country
         )
         t.assert_error_msg_content_equals(
             "Foreign key 'country' integrity check failed: wrong foreign field name",
@@ -198,7 +198,7 @@ g.test_complex_foreign_key_secondary = function(cg)
                                            {101, 1, 'earth', 'rf', 'France'}})
         t.assert_error_msg_content_equals(
             "Can't modify space 'country': space is referenced by foreign key",
-            function() country:drop() end
+            box.atomic, country.drop, country
         )
         t.assert_equals(country:select{}, {{100, 1, 'earth', 'ru', 'Russia'},
                                            {101, 1, 'earth', 'rf', 'France'}})
@@ -293,7 +293,7 @@ g.test_complex_foreign_key_numeric = function(cg)
                                            {101, 1, 'earth', 'rf', 'France'}})
         t.assert_error_msg_content_equals(
             "Can't modify space 'country': space is referenced by foreign key",
-            function() country:drop() end
+            box.atomic, country.drop, country
         )
         t.assert_equals(country:select{}, {{100, 1, 'earth', 'ru', 'Russia'},
                                            {101, 1, 'earth', 'rf', 'France'}})

--- a/test/engine-luatest/gh_6436_field_foreign_key_test.lua
+++ b/test/engine-luatest/gh_6436_field_foreign_key_test.lua
@@ -137,7 +137,7 @@ g.test_foreign_key_primary = function(cg)
         t.assert_equals(country:select{}, {{1, 'ru', 'Russia'}, {2, 'fr', 'France'}})
         t.assert_error_msg_content_equals(
             "Can't modify space 'country': space is referenced by foreign key",
-            function() country:drop() end
+            box.atomic, country.drop, country
         )
         t.assert_equals(country:select{}, {{1, 'ru', 'Russia'}, {2, 'fr', 'France'}})
         t.assert_error_msg_content_equals(
@@ -215,7 +215,7 @@ g.test_foreign_key_secondary = function(cg)
         t.assert_equals(country:select{}, {{1, 'ru', 'Russia'}, {2, 'fr', 'France'}})
         t.assert_error_msg_content_equals(
             "Can't modify space 'country': space is referenced by foreign key",
-            function() country:drop() end
+            box.atomic, country.drop, country
         )
         t.assert_equals(country:select{}, {{1, 'ru', 'Russia'}, {2, 'fr', 'France'}})
         t.assert_error_msg_content_equals(
@@ -297,7 +297,7 @@ g.test_foreign_key_numeric = function(cg)
         t.assert_equals(country:select{}, {{1, 'ru', 'Russia'}, {2, 'fr', 'France'}})
         t.assert_error_msg_content_equals(
             "Can't modify space 'country': space is referenced by foreign key",
-            function() country:drop() end
+            box.atomic, country.drop, country
         )
         t.assert_equals(country:select{}, {{1, 'ru', 'Russia'}, {2, 'fr', 'France'}})
         t.assert_error_msg_content_equals(

--- a/test/engine-luatest/gh_8946_foreign_key_disables_truncate_test.lua
+++ b/test/engine-luatest/gh_8946_foreign_key_disables_truncate_test.lua
@@ -1,0 +1,131 @@
+-- https://github.com/tarantool/tarantool/issues/8946
+-- Test that a space that another empty space refers to can be truncated.
+local server = require('luatest.server')
+local t = require('luatest')
+
+local engines = {{engine = 'memtx'}, {engine = 'vinyl'}}
+local g = t.group('gh-8946-foreign-key-truncate-test', engines)
+
+g.before_all(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:stop()
+    cg.server = nil
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.client_phones then
+            box.space.client_phones:drop()
+        end
+        if box.space.client then
+            box.space.client:drop()
+        end
+    end)
+end)
+
+-- Field foreign key must not disable truncate if referring space is empty.
+g.test_field_foreign_key_truncate = function(cg)
+    local engine = cg.params.engine
+
+    cg.server:exec(function(engine)
+        box.schema.space.create('client', {engine = engine})
+        box.space.client:format({
+            {name = 'customer_id', type = 'string', is_nullable = false},
+            {name = 'esia_id', type = 'string', is_nullable = false},
+        })
+
+        box.space.client:create_index('pk_client_customer_id', {
+            parts = {{field = 'customer_id', collation = 'unicode'}},
+            type = 'tree', unique = true
+        })
+        box.space.client:create_index('idx_client_esia_id', {
+            parts = {{field = 'esia_id', collation = 'unicode'}},
+            type = 'tree', unique = false
+        })
+
+        box.schema.space.create('client_phones', {engine = engine})
+        box.space.client_phones:format({
+            {name = 'phone', type = 'string', is_nullable = false},
+            {name = 'customer_id',
+             foreign_key = {space = 'client', field = 'customer_id'}},
+        })
+
+        box.space.client_phones:create_index('idx_client_phones_phone', {
+            parts = {{field = 'phone', collation = 'unicode'}},
+            type = 'tree', unique = true
+        })
+
+        box.space.client:insert{'01','esia-01'}
+        box.space.client:insert{'02','esia-02'}
+
+        box.space.client_phones:insert{'9121234','01'}
+        box.space.client_phones:insert{'3222222','02'}
+
+        -- Now truncate is prohibited.
+        t.assert_error_msg_content_equals(
+            "Can't modify space 'client': space is referenced by foreign key",
+            box.space.client.truncate, box.space.client)
+
+        box.space.client_phones:truncate()
+
+        -- Now truncate is allowed.
+        box.space.client:truncate()
+    end, {engine})
+end
+
+-- Tuple foreign key must not disable truncate if referring space is empty.
+g.test_tuple_foreign_key_truncate = function(cg)
+    local engine = cg.params.engine
+
+    cg.server:exec(function(engine)
+        box.schema.space.create('client', {engine = engine})
+        box.space.client:format({
+            {name = 'customer_id', type = 'string', is_nullable = false},
+            {name = 'esia_id', type = 'string', is_nullable = false},
+        })
+
+        box.space.client:create_index('pk_client_customer_id', {
+            parts = {{field = 'customer_id', collation = 'unicode'}},
+            type = 'tree', unique = true
+        })
+        box.space.client:create_index('idx_client_esia_id', {
+            parts = {{field = 'esia_id', collation = 'unicode'}},
+            type = 'tree', unique = false
+        })
+
+        box.schema.space.create('client_phones', {
+            engine = engine,
+            foreign_key = {space = 'client',
+                           field = {customer_id = 'customer_id'}}
+        })
+        box.space.client_phones:format({
+            {name = 'phone', type = 'string', is_nullable = false},
+            {name = 'customer_id'},
+        })
+
+        box.space.client_phones:create_index('idx_client_phones_phone', {
+            parts = {{field = 'phone', collation = 'unicode'}},
+            type = 'tree', unique = true
+        })
+
+        box.space.client:insert{'01','esia-01'}
+        box.space.client:insert{'02','esia-02'}
+
+        box.space.client_phones:insert{'9121234','01'}
+        box.space.client_phones:insert{'3222222','02'}
+
+        -- Now truncate is prohibited.
+        t.assert_error_msg_content_equals(
+            "Can't modify space 'client': space is referenced by foreign key",
+            box.space.client.truncate, box.space.client)
+
+        box.space.client_phones:truncate()
+
+        -- Now truncate is allowed.
+        box.space.client:truncate()
+    end, {engine})
+end

--- a/test/sql/delete.result
+++ b/test/sql/delete.result
@@ -137,6 +137,10 @@ box.execute("CREATE TABLE t2(x INT PRIMARY KEY REFERENCES t1(id));")
 ---
 - row_count: 1
 ...
+box.execute("INSERT INTO t2 VALUES(1);")
+---
+- row_count: 1
+...
 box.execute("TRUNCATE TABLE t1;")
 ---
 - null

--- a/test/sql/delete.test.lua
+++ b/test/sql/delete.test.lua
@@ -59,6 +59,7 @@ box.execute("TRUNCATE TABLE v1;")
 
 -- Can't truncate table with FK.
 box.execute("CREATE TABLE t2(x INT PRIMARY KEY REFERENCES t1(id));")
+box.execute("INSERT INTO t2 VALUES(1);")
 box.execute("TRUNCATE TABLE t1;")
 
 -- Table triggers should be ignored.


### PR DESCRIPTION
In #7309 a truncation of a space that was referenced by foreign key from some other space was prohibited.

It appeared that this solution is too bothering since a user can't truncate a space even if he truncated referring space before that.

Fix it by allowing space truncate if referring spaces are empty. Also allow drop of the primary index in the same case with the same reason: logically the index along with all space data is not needed for consistency if there's no referring data.

Note that by design space truncate is implemented quite similar to space drop. Both delete all indexes, from secondary to primary. Since this patch allows deletion of the primary index (which is the action that actually deletes all data from the space), this patch changes the result of space drop too: the space remains alive with no indexes, while before this patch it remained alive with no secondary indexes but with present primary. In both cases the behaviour is quite strange and must be fixed in #4348. To make tests pass I had to perform drop in box.atomic manually.

Closes #8946

NO_DOC=bugfix

(cherry picked from commit 983a7ec215d46b6d02935d1baa8bbe07fc371795)

(backport of #8947)