### PR TITLE
memtx: assert that space is not `NULL` in `index_read_view_create`

### DIFF
--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -651,7 +651,8 @@ memtx_hash_index_create_read_view(struct index *base)
 		free(rv);
 		return NULL;
 	}
-	struct space *space = space_cache_find(base->def->space_id);
+	struct space *space = space_by_id(base->def->space_id);
+	assert(space != NULL);
 	memtx_tx_snapshot_cleaner_create(&rv->cleaner, space);
 	rv->index = index;
 	index_ref(base);

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -2073,7 +2073,8 @@ memtx_tree_index_create_read_view(struct index *base)
 		free(rv);
 		return NULL;
 	}
-	struct space *space = space_cache_find(base->def->space_id);
+	struct space *space = space_by_id(base->def->space_id);
+	assert(space != NULL);
 	memtx_tx_snapshot_cleaner_create(&rv->cleaner, space);
 	rv->index = index;
 	index_ref(base);


### PR DESCRIPTION
This should suppress the following coverity issues:

- https://scan7.scan.coverity.com/reports.htm#v39198/p13437/fileInstanceId=146712118&defectInstanceId=18978766&mergedDefectId=1563095
- https://scan7.scan.coverity.com/reports.htm#v39198/p13437/fileInstanceId=146712113&defectInstanceId=18978750&mergedDefectId=1563094

While we are at it, let's use `space_by_id` instead of `space_cache_find` because read view creation is a rare operation affecting all spaces so caching the last space by id doesn't make any sense.