### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-8825-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8825-luajit-fixes.md
@@ -7,3 +7,4 @@ were fixed as part of this activity:
 * Fixed recording of `BC_VARG` with unused vararg values.
 * Initialization instructions on trace are now emitted only for the first
   member of a union.
+* Prevent integer overflow while parsing long strings.


### PR DESCRIPTION
* MIPS: Use precise search for exit jump patching.
* test: introduce mcode generator for tests
* MIPS: Fix handling of spare long-range jump slots.
* MIPS64: Add soft-float support to JIT compiler backend.
* PPC: Add soft-float support to interpreter.
* PPC: Add soft-float support to JIT compiler backend.
* build: fix non-Linux/macOS builds
* Windows: Add UWP support, part 1.
* FFI: Eliminate hardcoded string hashes.
* Cleanup math function compilation and fix inconsistencies.
* Fix GCC 7 -Wimplicit-fallthrough warnings.
* DynASM: Fix warning.
* ARM: Fix GCC 7 -Wimplicit-fallthrough warnings.
* Fix debug.getinfo() argument check.
* Fix LJ_MAX_JSLOTS assertion in rec_check_slots().
* Prevent integer overflow while parsing long strings.
* MIPS64: Fix register allocation in assembly of HREF.
* DynASM/MIPS: Fix shadowed variable.
* MIPS: Add MIPS64 R6 port.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump
NO_CHANGELOG=LuaJIT submodule bump