### PR TITLE
Silence coverity in instance names code

### DIFF
--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -4606,6 +4606,7 @@ on_replace_dd_cluster(struct trigger *trigger, void *event)
 			return on_replace_dd_cluster_update(old_def, new_def);
 		return on_replace_dd_cluster_insert(new_def);
 	}
+	assert(old_def != NULL);
 	return on_replace_dd_cluster_delete(old_def);
 }
 

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -2336,8 +2336,14 @@ box_set_instance_name(void)
 	strlcpy(old_cfg_name, cfg_instance_name, NODE_NAME_SIZE_MAX);
 	auto guard = make_scoped_guard([&]{
 		strlcpy(cfg_instance_name, old_cfg_name, NODE_NAME_SIZE_MAX);
-		box_restart_replication();
-		replicaset_follow();
+		try {
+			box_restart_replication();
+			replicaset_follow();
+		} catch (Exception *exc) {
+			exc->log();
+		} catch (...) {
+			panic("Unknown exception on instance name set failure");
+		}
 	});
 	strlcpy(cfg_instance_name, name, NODE_NAME_SIZE_MAX);
 	/* Nil means the config doesn't care, allows to use any name. */


### PR DESCRIPTION
Coverity complained about a couple of places. The patch silences them.