### PR TITLE
box: forbid same names for check constraints and foreign keys

### DIFF
--- a/changelogs/unreleased/gh-7650-forbid-same-names-for-constraints-and-fkeys.md
+++ b/changelogs/unreleased/gh-7650-forbid-same-names-for-constraints-and-fkeys.md
@@ -1,0 +1,4 @@
+## feature/core
+
+* It is now forbidden for a check constraint and a foreign key of each field
+  (or entire tuple) to have the same name (gh-7650).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -428,6 +428,12 @@ space_opts_decode(struct space_opts *opts, const char *map,
 			 diag_last_error(diag_get())->errmsg);
 		return -1;
 	}
+	if (tuple_constraint_def_array_check(opts->constraint_def,
+					     opts->constraint_count) != 0) {
+		diag_set(ClientError, ER_WRONG_SPACE_OPTIONS,
+			 diag_last_error(diag_get())->errmsg);
+		return -1;
+	}
 	return 0;
 }
 

--- a/src/box/field_def.c
+++ b/src/box/field_def.c
@@ -399,6 +399,11 @@ field_def_decode(struct field_def *field, const char **data,
 		field_def_error(fieldno, "unknown compression type");
 		return -1;
 	}
+	if (tuple_constraint_def_array_check(field->constraint_def,
+					     field->constraint_count) != 0) {
+		field_def_error(fieldno, diag_last_error(diag_get())->errmsg);
+		return -1;
+	}
 	return 0;
 }
 

--- a/src/box/tuple_constraint_def.c
+++ b/src/box/tuple_constraint_def.c
@@ -13,6 +13,7 @@
 #include "salad/grp_alloc.h"
 #include "small/region.h"
 #include "msgpuck.h"
+#include "tt_static.h"
 
 #include <PMurHash.h>
 
@@ -563,4 +564,23 @@ tuple_constraint_def_array_dup_raw(const struct tuple_constraint_def *defs,
 	/* If we did it correctly then there is no more space for strings. */
 	assert(grp_alloc_size(&all) == 0);
 	return res;
+}
+
+int
+tuple_constraint_def_array_check(const struct tuple_constraint_def *defs,
+				 size_t count)
+{
+	for (uint32_t i = 0; i < count; i++) {
+		const struct tuple_constraint_def *c1 = &defs[i];
+		for (uint32_t j = i + 1; j < count; j++) {
+			const struct tuple_constraint_def *c2 = &defs[j];
+			if (strcmp(c1->name, c2->name) == 0) {
+				diag_set(IllegalParams, tt_sprintf(
+					"duplicate constraint name '%s'",
+					c1->name));
+				return -1;
+			}
+		}
+	}
+	return 0;
 }

--- a/src/box/tuple_constraint_def.h
+++ b/src/box/tuple_constraint_def.h
@@ -185,6 +185,17 @@ tuple_constraint_def_array_dup_raw(const struct tuple_constraint_def *defs,
 				   size_t count, size_t object_size,
 				   size_t additional_size);
 
+/**
+ * Check that all constraints in the `defs` array have unique names.
+ *
+ * Return:
+ *   0 - success.
+ *  -1 - failure, diag is set (IllegalParams).
+ */
+int
+tuple_constraint_def_array_check(const struct tuple_constraint_def *defs,
+				 size_t count);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/test/engine-luatest/gh_7650_constraint_unique_names_test.lua
+++ b/test/engine-luatest/gh_7650_constraint_unique_names_test.lua
@@ -1,0 +1,73 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group('gh-7650', {{engine = 'memtx'}, {engine = 'vinyl'}})
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.city then box.space.city:drop() end
+        if box.space.country then box.space.country:drop() end
+        if box.func.check_code then box.func.check_code:drop() end
+    end)
+end)
+
+-- Check that it's not possible to create for a field a check constraint and
+-- a foreign key with the same name.
+g.test_field_constr = function(cg)
+    cg.server:exec(function(engine)
+        local func_body = "function(field) return field ~= '' end"
+        local func_opts = {language = 'Lua', body = func_body,
+                           is_deterministic = true}
+        box.schema.func.create('check_code', func_opts)
+
+        local format = {{name = 'code', type = 'string'},
+                        {name = 'name', type = 'string'}}
+        box.schema.create_space('country', {engine = engine, format = format})
+
+        format = {{name = 'name', type = 'string'},
+                  {name = 'country_code', type = 'string',
+                   constraint = {some_name = 'check_code'},
+                   foreign_key = {some_name = {space = 'country',
+                                               field = 'code'}}}}
+        local space_opts = {engine = engine, format = format}
+
+        t.assert_error_msg_equals(
+            "Wrong space format field 2: duplicate constraint name 'some_name'",
+            function() box.schema.create_space('city', space_opts) end)
+    end, {cg.params.engine})
+end
+
+-- Check that it's not possible to create a tuple check constraint and a foreign
+-- key with the same name.
+g.test_tuple_constr = function(cg)
+    cg.server:exec(function(engine)
+        local func_body = "function(tuple) return tuple[1] ~= '' end"
+        local func_opts = {language = 'Lua', body = func_body,
+                           is_deterministic = true}
+        box.schema.func.create('check_code', func_opts)
+
+        local format = {{name = 'code', type = 'string'},
+                        {name = 'name', type = 'string'}}
+        box.schema.create_space('country', {engine = engine, format = format})
+
+        format = {{name = 'name', type = 'string'},
+                  {name = 'country_code', type = 'string'}}
+        local space_opts = {engine = engine, format = format,
+                            constraint = {some_name = 'check_code'},
+                            foreign_key = {some_name = {space = 'country',
+                                                        field = {country_code =
+                                                                 'code'}}}}
+        t.assert_error_msg_equals(
+            "Wrong space options: duplicate constraint name 'some_name'",
+            function() box.schema.create_space('city', space_opts) end)
+    end, {cg.params.engine})
+end


### PR DESCRIPTION
It is possible to create a set of check constraints and foreign keys for each field and for entire tuple. By design for each field/tuple the check constraints must have unique names, the same is true for foreign keys. But it is possible to create a check constraint and a foreign key with the same name. This introduces difficulties in SQL implementation. On the other hand in real life it is hard to imagine a user that wants to create both check and foreign constraints for a field, especially with the same names. As for entire tuple it seems less obvious, but still it seems that there will be no harm if we forbid same names.

Closes #7650