### PR TITLE
box: fix `box.iproto.override` crash if used before `box.cfg`

### DIFF
--- a/changelogs/unreleased/gh-8975-box-iproto-override-without-cfg.md
+++ b/changelogs/unreleased/gh-8975-box-iproto-override-without-cfg.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed a crash when `box.iproto.override` was called with unconfigured box.
+  Now, an error is raised instead (gh-8975).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -5283,6 +5283,16 @@ box_is_configured(void)
 	return is_box_configured;
 }
 
+int
+box_check_configured(void)
+{
+	if (!is_box_configured) {
+		diag_set(ClientError, ER_UNCONFIGURED);
+		return -1;
+	}
+	return 0;
+}
+
 static void
 box_cfg_xc(void)
 {

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -128,6 +128,12 @@ box_cfg(void);
 bool
 box_is_configured(void);
 
+/**
+ * Return 0 if box has been configured, otherwise set diag and return -1.
+ */
+int
+box_check_configured(void);
+
 /** Check if the slice of main cord has expired. */
 int
 box_check_slice_slow(void);

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -326,6 +326,7 @@ struct errcode_record {
 	/*271 */_(ER_SCHEMA_NEEDS_UPGRADE,	"Your schema version is %u.%u.%u while Tarantool %s requires a more recent schema version. Please, consider using box.schema.upgrade().") \
 	/*272 */_(ER_SCHEMA_UPGRADE_IN_PROGRESS, "Schema upgrade is already in progress") \
 	/*273 */_(ER_DEPRECATED,		"%s is deprecated") \
+	/*274 */_(ER_UNCONFIGURED,		"Please call box.cfg{} first") \
 
 /*
  * !IMPORTANT! Please follow instructions at start of the file

--- a/src/box/lua/iproto.c
+++ b/src/box/lua/iproto.c
@@ -309,6 +309,8 @@ lua_req_handler_destroy(void *ctx)
 static int
 lbox_iproto_override(struct lua_State *L)
 {
+	if (box_check_configured() != 0)
+		return luaT_error(L);
 	int n_args = lua_gettop(L);
 	if (n_args != 2)
 		return luaL_error(L, "Usage: "

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -1014,9 +1014,8 @@ for k, v in pairs(box) do
 end
 
 setmetatable(box, {
-    __index = function(table, index) -- luacheck: no unused args
-        error(debug.traceback("Please call box.cfg{} first"))
-        error("Please call box.cfg{} first")
+    __index = function()
+        box.error(box.error.UNCONFIGURED)
      end
 })
 

--- a/src/box/lua/session.c
+++ b/src/box/lua/session.c
@@ -166,8 +166,8 @@ lbox_session_effective_user(struct lua_State *L)
 static int
 lbox_session_su(struct lua_State *L)
 {
-	if (!box_is_configured())
-		luaL_error(L, "Please call box.cfg{} first");
+	if (box_check_configured() != 0)
+		luaT_error(L);
 	int top = lua_gettop(L);
 	if (top < 1)
 		luaL_error(L, "session.su(): bad arguments");

--- a/test/box-luatest/iproto_request_handlers_overriding_test.lua
+++ b/test/box-luatest/iproto_request_handlers_overriding_test.lua
@@ -123,6 +123,14 @@ g.after_all(function(cg)
     cg.server:drop()
 end)
 
+-- Checks that `box.iproto.override` raises an error if called on
+-- an unconfigured instance (gh-8975).
+g.test_box_iproto_override_without_cfg = function()
+    t.assert_error_msg_equals('Please call box.cfg{} first',
+                              box.iproto.override, box.iproto.type.UNKNOWN,
+                              function() end)
+end
+
 -- Checks that `box.iproto.override` errors are handled correctly.
 g.test_box_iproto_override_errors = function(cg)
     cg.server:exec(function()

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -492,6 +492,7 @@ t;
  |   271: box.error.SCHEMA_NEEDS_UPGRADE
  |   272: box.error.SCHEMA_UPGRADE_IN_PROGRESS
  |   273: box.error.DEPRECATED
+ |   274: box.error.UNCONFIGURED
  | ...
 
 test_run:cmd("setopt delimiter ''");


### PR DESCRIPTION
The function can't be called on an unconfigured instance because it needs IPROTO threads up and running. Let's raise an error to avoid a crash.

Since we have two other places where we need to raise the same error (`box.session.su` and `box.__index`), let's introduce the new code `ER_UNCONFIGURED` for this error.

Closes #8975