### PR TITLE
box: fix invalid memory access in tuple_compare_with_key_sequential (2.10 special)

### DIFF
--- a/changelogs/unreleased/gh-8899-compare-with-key-slowpath-invalid-memory-access.md
+++ b/changelogs/unreleased/gh-8899-compare-with-key-slowpath-invalid-memory-access.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed an invalid memory access in a corner case of a specialized comparison
+  function (gh-8899).

--- a/src/box/tuple_compare.cc
+++ b/src/box/tuple_compare.cc
@@ -929,8 +929,9 @@ tuple_compare_with_key_sequential(struct tuple *tuple, hint_t tuple_hint,
 		assert(field_count >= part_count);
 		cmp_part_count = part_count;
 	}
-	rc = key_compare_parts<is_nullable>(tuple_key, key, cmp_part_count,
-					    key_def);
+	rc = key_compare_and_skip_parts<is_nullable>(&tuple_key, &key,
+						     cmp_part_count,
+						     key_def);
 	if (!has_optional_parts || rc != 0)
 		return rc;
 	/*
@@ -938,11 +939,6 @@ tuple_compare_with_key_sequential(struct tuple *tuple, hint_t tuple_hint,
 	 * corresponding key fields to be equal to NULL.
 	 */
 	if (field_count < part_count) {
-		/*
-		 * Key's and tuple's first field_count fields are
-		 * equal, and their bsize too.
-		 */
-		key += tuple_bsize(tuple) - mp_sizeof_array(field_count);
 		for (uint32_t i = field_count; i < part_count;
 		     ++i, mp_next(&key)) {
 			if (mp_typeof(*key) != MP_NIL)

--- a/test/box-luatest/gh_8899_tuple_compare_with_key_slowpath_last_loop_test.lua
+++ b/test/box-luatest/gh_8899_tuple_compare_with_key_slowpath_last_loop_test.lua
@@ -1,0 +1,41 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group('gh-8899-tuple-compare-with-key-slowpath-last-loop')
+
+g.before_all(function()
+    g.server = server:new()
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_tuple_compare_with_key_slowpath_last_loop = function()
+    g.server:exec(function()
+        local ffi = require('ffi')
+
+        local function double(n)
+            return ffi.cast('double', n)
+        end
+
+        local s = box.schema.space.create('test', {engine = 'memtx'})
+        s:create_index('pk')
+        local sk = s:create_index('sk', {parts = {
+                {1, 'unsigned'},
+                {2, 'number', is_nullable = true},
+                {3, 'number', is_nullable = true}
+        }})
+
+        -- 1-byte unsigned in DB, 8-byte double in request.
+        s:replace({1, 2})
+        t.assert_equals(sk:select({1, double(2), box.NULL}, {iterator = 'EQ'}),
+                        {{1, 2}})
+
+        -- 8-byte double in DB, 1-byte unsigned in request.
+        s:replace({1, double(3)})
+        t.assert_equals(sk:select({1, 3, box.NULL}, {iterator = 'EQ'}),
+                        {{1, 3}})
+    end)
+end


### PR DESCRIPTION
1. Since number type was introduced we can not assume if tuples are equal by comparison then their sizes are equal too. So the place the assumption is used is fixed. These changes has been taken from [#8922](https://github.com/tarantool/tarantool/pull/8922).
2. Partially applied the ca832f278855554f2741e54a997cece9bb7e2197 commit. Effectively it just introduced the `key_compare_and_skip_parts` function that is required for [#8922](https://github.com/tarantool/tarantool/pull/8922) and created the key_def test. Changes to the commit in details:
   
   src/box/tuple_compare.cc:
   - Omitted the `func_index_compare_with_key` update.

   test/unit/key_def.c:
   - Omitted four tests that checked the `func_index_compare_with_key` update.