### PR TITLE
popen: fix memcpy(dst, NULL, 0)

### DIFF
--- a/src/lib/core/popen.c
+++ b/src/lib/core/popen.c
@@ -1215,7 +1215,9 @@ popen_new(struct popen_opts *opts)
 	int *skip_fds = xregion_alloc_array(region, typeof(skip_fds[0]),
 					    nr_skip_fds_max);
 	size_t nr_skip_fds = opts->nr_inherit_fds;
-	memcpy(skip_fds, opts->inherit_fds, nr_skip_fds * sizeof(*skip_fds));
+	if (nr_skip_fds > 0)
+		memcpy(skip_fds, opts->inherit_fds,
+		       nr_skip_fds * sizeof(*skip_fds));
 
 	if (log_fd >= 0)
 		skip_fds[nr_skip_fds++] = log_fd;


### PR DESCRIPTION
The `popen_new()` function may be called with inherit_fds = NULL, nr_inherit_fds = 0. The lua/popen.c code actually does this.

It leads to the following memcpy() call.

```c
memcpy(dst, NULL, 0);
```

According to the C11 standard (n1256, 7.21.1), the pointer argument should have a valid value, which means pointing to some area in the program's address space, not NULL. The standard doesn't make an exception for a zero size array.

Personally I doubt that any memcpy() implementation attempts to dereference the source pointer in case of a zero size, but it is my assumption, while the standard is the standard.

The problem is found by Coverity.

Follows up #8926