### PR TITLE
Introduce `box.session.new`

### DIFF
--- a/changelogs/unreleased/gh-8801-iproto-session-from-fd.md
+++ b/changelogs/unreleased/gh-8801-iproto-session-from-fd.md
@@ -1,0 +1,4 @@
+## feature/box
+
+* Introduced the new function `box.session.new` for creating a new IPROTO
+  session from a socket file descriptor number (gh-8801).

--- a/src/box/iproto.h
+++ b/src/box/iproto.h
@@ -32,11 +32,14 @@
  */
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include "box/box.h"
 
 struct uri_set;
 struct session;
+struct user;
+struct iostream;
 
 #if defined(__cplusplus)
 extern "C" {
@@ -140,6 +143,28 @@ iproto_listen(const struct uri_set *uri_set);
 
 int
 iproto_set_msg_max(int iproto_msg_max);
+
+/**
+ * Creates a new IPROTO session over the given IO stream and returns the new
+ * session id. Never fails. Doesn't yield.
+ *
+ * The IO stream must refer to a non-blocking socket but this isn't enforced by
+ * this function. If it isn't so, the new connection may not work as expected.
+ *
+ * If the user argument isn't NULL, the new session will be authenticated as
+ * the specified user. Otherwise, it will be authenticated as guest.
+ *
+ * The function takes ownership of the passed IO stream by moving it to the
+ * new IPROTO connection (see iostream_move).
+ *
+ * Essentially, this function passes the IO stream to the callback invoked
+ * by an IPROTO thread upon accepting a new connection on a listening socket.
+ * The callback creates a new IPROTO connection, attaches it to the given
+ * session, then sends the greeting message and starts processing requests as
+ * usual. All of this is done asynchronously by an IPROTO thread.
+ */
+uint64_t
+iproto_session_new(struct iostream *io, struct user *user);
 
 /**
  * Sends a packet with the given header and body over the IPROTO session's

--- a/src/lib/core/cbus.h
+++ b/src/lib/core/cbus.h
@@ -389,6 +389,19 @@ cbus_call(struct cpipe *callee, struct cpipe *caller, struct cbus_call_msg *msg,
 }
 
 /**
+ * Execute an asynchronous call over cbus.
+ *
+ * In contrast to cbus_call_timeout, this function doesn't yield.
+ *
+ * If free_cb isn't NULL, it'll be invoked by the caller thread upon
+ * completion.
+ */
+void
+cbus_call_async(struct cpipe *callee, struct cpipe *caller,
+		struct cbus_call_msg *msg, cbus_call_f func,
+		cbus_call_f free_cb);
+
+/**
  * Block until all messages queued in a pipe have been processed.
  * Done by submitting a dummy message to the pipe and waiting
  * until it is complete.

--- a/test/box-luatest/gh_7894_export_iproto_constants_and_features_test.lua
+++ b/test/box-luatest/gh_7894_export_iproto_constants_and_features_test.lua
@@ -190,12 +190,8 @@ local reference_table = {
 -- Checks that IPROTO constants and features are exported correctly.
 g.test_iproto_constants_and_features_export = function(cg)
     cg.server:exec(function(reference_table)
-        for k, v in pairs(box.iproto) do
-            local v_type = type(v)
-            if v_type ~= 'function' and v_type ~= 'thread' and
-               v_type ~= 'userdata' then
-                t.assert_equals(v, reference_table[k])
-            end
+        for k, v in pairs(reference_table) do
+            t.assert_equals(box.iproto[k], v)
         end
     end, {reference_table})
 end

--- a/test/box-luatest/gh_8801_iproto_session_from_fd_test.lua
+++ b/test/box-luatest/gh_8801_iproto_session_from_fd_test.lua
@@ -1,0 +1,220 @@
+local fio = require('fio')
+local net = require('net.box')
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+local SOCK_PATH = fio.pathjoin(server.vardir, 'gh-8801.sock')
+
+g.before_all(function(cg)
+    cg.server = server:new({box_cfg = {iproto_threads = 4}})
+    cg.server:start()
+
+    -- Start a TCP server listening on SOCK_PATH.
+    --
+    -- The server handler will accept all incoming connections with
+    -- box.session.new(opts).
+    cg.start_listen = function(opts)
+        cg.server:exec(function(sock_path, opts)
+            local socket = require('socket')
+            t.assert_not(rawget(_G, 'listen_sock'))
+            local function handler(sock)
+                local opts2 = opts and table.copy(opts) or {}
+                opts2.fd = sock:fd()
+                box.session.new(opts2)
+                sock:detach()
+            end
+            local listen_sock = socket.tcp_server('unix/', sock_path, handler)
+            t.assert(listen_sock)
+            rawset(_G, 'listen_sock', listen_sock)
+        end, {SOCK_PATH, opts})
+    end
+
+    -- Stop the server started with start_listen.
+    cg.stop_listen = function()
+        cg.server:exec(function()
+            local listen_sock = rawget(_G, 'listen_sock')
+            if listen_sock then
+                listen_sock:close()
+                rawset(_G, 'listen_sock', nil)
+            end
+        end)
+    end
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.stop_listen()
+end)
+
+-- Checks that box.cfg() must be called.
+g.test_no_cfg = function()
+    t.assert_error_msg_equals("Please call box.cfg{} first",
+                              box.session.new, {fd = 0})
+end
+
+-- Checks errors raised on invalid arguments.
+g.test_invalid_args = function(cg)
+    cg.server:exec(function()
+        t.assert_error_msg_equals(
+            "Illegal parameters, options should be a table",
+            box.session.new, 'foo')
+        t.assert_error_msg_equals(
+            "Illegal parameters, unexpected option 'foo'",
+            box.session.new, {foo = 'bar'})
+        t.assert_error_msg_equals(
+            "Illegal parameters, " ..
+            "options parameter 'type' should be of type string",
+            box.session.new, {type = 0})
+        t.assert_error_msg_equals(
+            "Illegal parameters, invalid session type 'foo', " ..
+            "the only supported type is 'binary'",
+            box.session.new, {type = 'foo'})
+        t.assert_error_msg_equals(
+            "Illegal parameters, options parameter 'fd' is mandatory",
+            box.session.new, {})
+        t.assert_error_msg_equals(
+            "Illegal parameters, " ..
+            "options parameter 'fd' should be of type number",
+            box.session.new, {fd = 'foo'})
+        t.assert_error_msg_equals(
+            "Illegal parameters, " ..
+            "options parameter 'fd' must be nonnegative integer",
+            box.session.new, {fd = -1})
+        t.assert_error_msg_equals(
+            "Illegal parameters, " ..
+            "options parameter 'fd' must be nonnegative integer",
+            box.session.new, {fd = 2 ^ 31})
+        t.assert_error_msg_equals(
+            "Illegal parameters, " ..
+            "options parameter 'fd' must be nonnegative integer",
+            box.session.new, {fd = 1.5})
+        t.assert_error_msg_equals(
+            "Illegal parameters, " ..
+            "options parameter 'user' should be of type string",
+            box.session.new, {user = 0})
+        t.assert_error_msg_equals(
+            "User 'foo' is not found",
+            box.session.new, {fd = 0, user = 'foo'})
+        t.assert_error_msg_equals(
+            "Illegal parameters, " ..
+            "options parameter 'storage' should be of type table",
+            box.session.new, {storage = 'foo'})
+    end)
+end
+
+-- Checks default options.
+g.test_defaults = function(cg)
+    cg.start_listen()
+    local conn = net.connect(SOCK_PATH)
+    t.assert(conn.state, 'active')
+    t.assert_equals(conn:call('box.session.type'), 'binary')
+    t.assert_equals(conn:call('box.session.peer'), 'unix/:(socket)')
+    t.assert_equals(conn:call('box.session.user'), 'guest')
+    t.assert_equals(conn:eval('return box.session.storage'), {})
+    conn:close()
+end
+
+-- Checks that one may specify a custom session user.
+g.test_custom_user = function(cg)
+    cg.start_listen({user = 'admin'})
+    local conn = net.connect(SOCK_PATH)
+    t.assert(conn.state, 'active')
+    t.assert_equals(conn:call('box.session.type'), 'binary')
+    t.assert_equals(conn:call('box.session.peer'), 'unix/:(socket)')
+    t.assert_equals(conn:call('box.session.user'), 'admin')
+    t.assert_equals(conn:eval('return box.session.storage'), {})
+    conn:close()
+end
+
+-- Checks that one may override a custom session user by passing credentials.
+g.test_custom_user_override = function(cg)
+    cg.start_listen({user = 'admin'})
+    local conn = net.connect(SOCK_PATH, {user = 'guest'})
+    t.assert(conn.state, 'active')
+    t.assert_equals(conn:call('box.session.type'), 'binary')
+    t.assert_equals(conn:call('box.session.peer'), 'unix/:(socket)')
+    t.assert_equals(conn:call('box.session.user'), 'guest')
+    t.assert_equals(conn:eval('return box.session.storage'), {})
+    conn:close()
+end
+
+-- Checks that one may specify a custom session storage.
+g.test_custom_storage = function(cg)
+    local storage = {foo = 1, bar = 2}
+    cg.start_listen({storage = storage})
+    local conn = net.connect(SOCK_PATH)
+    t.assert(conn.state, 'active')
+    t.assert_equals(conn:call('box.session.type'), 'binary')
+    t.assert_equals(conn:call('box.session.peer'), 'unix/:(socket)')
+    t.assert_equals(conn:call('box.session.user'), 'guest')
+    t.assert_equals(conn:eval('return box.session.storage'), storage)
+    conn:close()
+end
+
+-- Checks that one may specify the 'binary' session type explicitly.
+g.test_session_type = function(cg)
+    cg.start_listen({type = 'binary'})
+    local conn = net.connect(SOCK_PATH)
+    t.assert(conn.state, 'active')
+    t.assert_equals(conn:call('box.session.type'), 'binary')
+    t.assert_equals(conn:call('box.session.peer'), 'unix/:(socket)')
+    t.assert_equals(conn:call('box.session.user'), 'guest')
+    t.assert_equals(conn:eval('return box.session.storage'), {})
+    conn:close()
+end
+
+-- Checks that connections are distributed evenly among all threads.
+g.test_threads = function(cg)
+    cg.start_listen()
+    local COUNT = 20
+    local conns = {}
+    for i = 1, COUNT do
+        conns[i] = net.connect(SOCK_PATH)
+        t.assert(conns[i].state, 'active')
+    end
+    cg.server:exec(function(COUNT)
+        t.assert(box.cfg.iproto_threads > 1)
+        for i = 1, box.cfg.iproto_threads do
+            t.assert_ge(box.stat.net.thread[i].CONNECTIONS.current,
+                        COUNT / box.cfg.iproto_threads)
+        end
+    end, {COUNT})
+    for i = 1, COUNT do
+        conns[i]:close()
+    end
+end
+
+g.after_test('test_invalid_fd', function(cg)
+    cg.server:exec(function()
+        for _, func in ipairs(box.session.on_connect()) do
+            box.session.on_connect(nil, func)
+        end
+        t.assert_equals(box.session.on_connect(), {})
+    end)
+end)
+
+-- Checks that the session created from an invalid fd is closed.
+g.test_invalid_fd = function(cg)
+    cg.server:exec(function()
+        local sid, fd, peer
+        box.session.on_connect(function()
+            sid = box.session.id()
+            fd = box.session.fd()
+            peer = box.session.peer()
+        end)
+        box.session.new({fd = 9000})
+        t.helpers.retrying({}, function()
+            t.assert_is_not(sid, nil)
+        end)
+        t.assert_equals(fd, 9000)
+        t.assert_is(peer, nil)
+        t.helpers.retrying({}, function()
+            t.assert_not(box.session.exists(sid))
+        end)
+    end)
+end


### PR DESCRIPTION
The new function creates a new session given a table of options:

 - `type`: string, optional. Default: "binary". [Type][session-type] of the new session. Currently, only "binary" is supported, which creates a new IPROTO session.

 - `fd`: number, mandatory. File descriptor number (fd) to be used for the new connection input-output. The fd must refer to a [socket] and be switched to the [non-blocking mode][socket-nonblock] but this isn't enforced, i.e. the user may pass an invalid fd, in which case the connection won't work as expected.

 - `user`: string, optional. Default: "guest". Name of the user to authenticate the new session as. Note, this doesn't prevent the other end to perform explicit [authentication].

 - `storage`: table, optional. Default: empty table. Initial value of the [session-local storage][session-storage].

On success, `box.session.new` takes ownership of the `fd` and returns nothing. On failure, an error is raised.

Possible errors:
 - Invalid option value type.
 - `fd` isn't specified or has an invalid value.
 - `box.cfg` wasn't called.
 - `user` doesn't exist.

Example:

The code below creates a TCP server that accepts all incoming IPROTO connections on port 3301, authenticates them as 'admin' and sets the session-local storage to `{foo = 'bar'}`.

```lua
box.cfg()
require('socket').tcp_server('localhost', 3301, function(s)
    box.session.new({
        type = 'binary',
        fd = s:fd(),
        user = 'admin',
        storage = {foo = 'bar'},
    })
    s:detach()
end)
```

Notes:
- `box.cfg` must be called before using `box.session.new` to start IPROTO threads. Setting [`box.cfg.listen`][box-cfg-listen] isn't required though.
- The socket object must be detached after passing its fd to `box.session.new`, otherwise the fd would be closed on Lua garbage collection.

Closes #8801

[authentication]: https://www.tarantool.io/en/doc/latest/dev_guide/internals/iproto/authentication/
[box-cfg-listen]: https://www.tarantool.io/en/doc/latest/reference/configuration/#cfg-basic-listen
[session-storage]: https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_session/storage/
[session-type]: https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_session/type/
[socket]: https://www.tarantool.io/en/doc/latest/reference/reference_lua/socket/
[socket-nonblock]: https://www.tarantool.io/en/doc/latest/reference/reference_lua/socket/#socket-nonblock