### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-8825-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8825-luajit-fixes.md
@@ -7,3 +7,4 @@ were fixed as part of this activity:
 * Fixed recording of `BC_VARG` with unused vararg values.
 * Initialization instructions on trace are now emitted only for the first
   member of a union.
+* Fixed various `^` operator inconsistencies.


### PR DESCRIPTION
* test: introduce `samevalues()` TAP checker
* Remove pow() splitting and cleanup backends.
* Improve assertions.
* Fix pow() optimization inconsistencies.
* Revert to trival pow() optimizations to prevent inaccuracies.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump

---
Be aware that this patch is rebased on the #8969.