### PR TITLE
ci: update paths in workflows

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -8,10 +8,12 @@ on:
     tags:
       - '**'
     paths:
-      - '.github/workflows/**'
+      - '.github/workflows/fuzzing.yml'
       - 'src/**'
       - 'test/fuzz/**'
       - 'test/static/corpus/**'
+    paths-ignore:
+      - '**.lua'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
 

--- a/.github/workflows/publish-module-api-doc.yaml
+++ b/.github/workflows/publish-module-api-doc.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - 'master'
+    paths:
+      - '.github/workflows/publish-module-api-doc.yaml'
+      - 'src/**'
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Follows up https://github.com/tarantool/tarantool/pull/8904

Author: Sergey Bronnikov <sergeyb@tarantool.org>
Date:   Wed Aug 16 11:16:55 2023 +0300

    ci: update paths in a workflows
    
    When using the push and pull_request events, one can configure a
    workflow to run based on what file paths are changed.
    
    Fuzzing is a heavyweight job, we can reduce a set of paths used for
    triggering this job. The patch replaces `.github/workflows/**` to
    `.github/workflows/fuzzing.yml` because workflows are independent and
    changes in other workflows does not affect fuzzing at all and patch adds
    Lua files (`**.lua`) to ignores because fuzzing focused on C/C++ code.
    
    Module API documentation is described in Doxygen comments in C/C++ files
    in src. The patch changes paths in workflow accordingly.
    
    See syntax of `paths` and `paths-ignore` in [1].
    
    1. https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
    
