### PR TITLE
test: fix fiber stack overflow test not overflowing

### DIFF
--- a/src/trivia/util.h
+++ b/src/trivia/util.h
@@ -477,6 +477,17 @@ alloc_failure(const char *filename, int line, size_t size)
 #  define PACKED
 #endif
 
+/**
+ * NO_SANITIZE_ADDRESS attribute disables AddressSanitizer for a given function.
+ * The attribute may not be supported by old compilers, but they do not support
+ * ASAN as well, so it's safe to define the attribute only if ASAN is enabled.
+ */
+#if __has_feature(address_sanitizer)
+#  define NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
+#else
+#  define NO_SANITIZE_ADDRESS
+#endif
+
 /** Function Attributes }}} */
 
 /** {{{ Statement Attributes */


### PR DESCRIPTION
`test/unit/guard.cc` calls `stack_break_f()` recursively until the stack overflows and a signal is fired, however it relies on undefined behavior when compares pointers to local variables. Fixed by comparing `__builtin_frame_address()` instead.

One of the examples of this UB is when ASAN allocates local variables on fake stacks, in that case the test completes without the stack overflow.

Also this patch disables ASAN for `stack_break_f()` to keep the array on the fiber stack (see the corresponding comment) and marks it as volatile to avoid optimizing it away by the compiler.

Closes tarantool/tarantool-qa#323