### PR TITLE
config: don't persist group name as cluster_name

### DIFF
--- a/changelogs/unreleased/config-dont-persist-group-name.md
+++ b/changelogs/unreleased/config-dont-persist-group-name.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* A group name from a topology defined by the cluster configuration doesn't
+  persisted anymore as `box.cfg.cluster_name` (gh-8862).

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -346,11 +346,16 @@ local function apply(config)
         end
     end
 
-    -- Add instance, replicaset and group (cluster) names.
+    -- Persist an instance name to protect a user from accidental
+    -- attempt to run an instance from a snapshot left by another
+    -- instance.
+    --
+    -- Persist a replicaset name to protect a user from attempt to
+    -- mix instances with data from different replicasets into one
+    -- replicaset.
     local names = configdata:names()
-    box_cfg.cluster_name = names.group_name
-    box_cfg.replicaset_name = names.replicaset_name
     box_cfg.instance_name = names.instance_name
+    box_cfg.replicaset_name = names.replicaset_name
 
     -- Set bootstrap_leader option.
     box_cfg.bootstrap_leader = configdata:bootstrap_leader()

--- a/test/config-luatest/basic_test.lua
+++ b/test/config-luatest/basic_test.lua
@@ -518,3 +518,18 @@ g.test_extras_on_community_edition = function(g)
         verify = verify,
     })
 end
+
+-- Verify that an instance name and a replicaset name are set from
+-- the cluster config topology, while a cluster name remains
+-- unset.
+g.test_persistent_names = function(g)
+    local verify = function()
+        t.assert_equals(box.info.name, 'instance-001')
+        t.assert_equals(box.info.replicaset.name, 'replicaset-001')
+        t.assert_equals(box.info.cluster.name, nil)
+    end
+
+    helpers.success_case(g, {
+        verify = verify,
+    })
+end

--- a/test/config-luatest/helpers.lua
+++ b/test/config-luatest/helpers.lua
@@ -51,17 +51,14 @@ local function start_example_replicaset(g, dir, config_file, opts)
     local info = g.server_1:eval('return box.info')
     t.assert_equals(info.name, 'instance-001')
     t.assert_equals(info.replicaset.name, 'replicaset-001')
-    t.assert_equals(info.cluster.name, 'group-001')
 
     local info = g.server_2:eval('return box.info')
     t.assert_equals(info.name, 'instance-002')
     t.assert_equals(info.replicaset.name, 'replicaset-001')
-    t.assert_equals(info.cluster.name, 'group-001')
 
     local info = g.server_3:eval('return box.info')
     t.assert_equals(info.name, 'instance-003')
     t.assert_equals(info.replicaset.name, 'replicaset-001')
-    t.assert_equals(info.cluster.name, 'group-001')
 end
 
 -- A simple single instance configuration.


### PR DESCRIPTION
We agreed that it is up to a user how to draw a line between one set of instances that is considered as a separate cluster and another set of instances that is assumed as a different cluster. This line is virtual and there is no sense to impose restrictions until we add some certain (and consistent) semantic to word 'cluster' in context of tarantool.

Part of #8862