### PR TITLE
config: directory layout enhancements

### DIFF
--- a/changelogs/unreleased/config-change-default-paths.md
+++ b/changelogs/unreleased/config-change-default-paths.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* The default directory and file paths are changed to `var/run/<...>`,
+  `var/log/<...>`, `var/lib/<...>` and so on (gh-8862).

--- a/changelogs/unreleased/config-create-parent-directories.md
+++ b/changelogs/unreleased/config-create-parent-directories.md
@@ -3,3 +3,4 @@
 * Support parent directories creation for options that accept a directory or a
   file (gh-8862).
 * Create parent directories for `console.socket` and `log.file` (gh-8862).
+* Create the `process.work_dir` directory (gh-8862).

--- a/changelogs/unreleased/config-create-parent-directories.md
+++ b/changelogs/unreleased/config-create-parent-directories.md
@@ -4,3 +4,5 @@
   file (gh-8862).
 * Create parent directories for `console.socket` and `log.file` (gh-8862).
 * Create the `process.work_dir` directory (gh-8862).
+* Consider all the paths as relative to `process.work_dir` when creating
+  necessary directories (gh-8862).

--- a/changelogs/unreleased/config-create-parent-directories.md
+++ b/changelogs/unreleased/config-create-parent-directories.md
@@ -2,4 +2,4 @@
 
 * Support parent directories creation for options that accept a directory or a
   file (gh-8862).
-* Create parent directory for `console.socket` (gh-8862).
+* Create parent directories for `console.socket` and `log.file` (gh-8862).

--- a/changelogs/unreleased/config-create-parent-directories.md
+++ b/changelogs/unreleased/config-create-parent-directories.md
@@ -2,3 +2,4 @@
 
 * Support parent directories creation for options that accept a directory or a
   file (gh-8862).
+* Create parent directory for `console.socket` (gh-8862).

--- a/changelogs/unreleased/config-lua-module-search-paths.md
+++ b/changelogs/unreleased/config-lua-module-search-paths.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* The directory that contains the configuration file is now added into the Lua
+  modules search paths (gh-8862).

--- a/src/box/lua/config/applier/mkdir.lua
+++ b/src/box/lua/config/applier/mkdir.lua
@@ -24,6 +24,18 @@ end
 
 local function apply(config)
     local configdata = config._configdata
+
+    -- Create process.work_dir directory if box.cfg() is not
+    -- called yet.
+    if type(box.cfg) == 'function' then
+        local work_dir = configdata:get('process.work_dir',
+            {use_default = true})
+        if work_dir ~= nil then
+            local prefix = ('mkdir.apply[%s]'):format('process.work_dir')
+            safe_mkdir(prefix, work_dir)
+        end
+    end
+
     configdata:filter(function(w)
         return w.schema.mkdir ~= nil
     end, {use_default = true}):each(function(w)

--- a/src/box/lua/config/applier/mkdir.lua
+++ b/src/box/lua/config/applier/mkdir.lua
@@ -49,6 +49,12 @@ local function apply(config)
         local prefix = ('mkdir.apply[%s]'):format('console.socket')
         safe_mkdir(prefix, fio.dirname(console.socket))
     end
+
+    local log = configdata:get('log', {use_default = true})
+    if log.to == 'file' then
+        local prefix = ('mkdir.apply[%s]'):format('log.file')
+        safe_mkdir(prefix, fio.dirname(log.file))
+    end
 end
 
 return {

--- a/src/box/lua/config/applier/mkdir.lua
+++ b/src/box/lua/config/applier/mkdir.lua
@@ -43,6 +43,12 @@ local function apply(config)
         local prefix = ('mkdir.apply[%s]'):format(table.concat(w.path, '.'))
         safe_mkdir(prefix, fio.dirname(w.data))
     end)
+
+    local console = configdata:get('console', {use_default = true})
+    if console.enabled then
+        local prefix = ('mkdir.apply[%s]'):format('console.socket')
+        safe_mkdir(prefix, fio.dirname(console.socket))
+    end
 end
 
 return {

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -357,6 +357,10 @@ return schema.new('instance_config', schema.record({
             type = 'string',
             box_cfg = 'work_dir',
             box_cfg_nondynamic = true,
+            -- The mkdir annotation is not present here, because
+            -- otherwise the directory would be created
+            -- unconditionally. Instead, mkdir applier creates it
+            -- only before the first box.cfg() call.
             default = box.NULL,
         }),
         pid_file = schema.scalar({

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -432,6 +432,10 @@ return schema.new('instance_config', schema.record({
         }),
         file = schema.scalar({
             type = 'string',
+            -- The mk_parent_dir annotation is not present here,
+            -- because otherwise the directory would be created
+            -- unconditionally. Instead, mkdir applier creates it
+            -- if log.to is 'file'.
             default = '{{ instance_name }}.log',
         }),
         pipe = schema.scalar({

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -368,7 +368,7 @@ return schema.new('instance_config', schema.record({
             box_cfg = 'pid_file',
             box_cfg_nondynamic = true,
             mk_parent_dir = true,
-            default = '{{ instance_name }}.pid',
+            default = 'var/run/{{ instance_name }}/tarantool.pid',
         }),
     }),
     console = schema.record({
@@ -382,7 +382,7 @@ return schema.new('instance_config', schema.record({
             -- because otherwise the directory would be created
             -- unconditionally. Instead, mkdir applier creates it
             -- if console.enabled is true.
-            default = '{{ instance_name }}.control',
+            default = 'var/run/{{ instance_name }}/tarantool.control',
         }),
     }),
     fiber = schema.record({
@@ -440,7 +440,7 @@ return schema.new('instance_config', schema.record({
             -- because otherwise the directory would be created
             -- unconditionally. Instead, mkdir applier creates it
             -- if log.to is 'file'.
-            default = '{{ instance_name }}.log',
+            default = 'var/log/{{ instance_name }}/tarantool.log',
         }),
         pipe = schema.scalar({
             type = 'string',
@@ -767,7 +767,7 @@ return schema.new('instance_config', schema.record({
             box_cfg = 'vinyl_dir',
             box_cfg_nondynamic = true,
             mkdir = true,
-            default = '{{ instance_name }}',
+            default = 'var/lib/{{ instance_name }}',
         }),
         max_tuple_size = schema.scalar({
             type = 'integer',
@@ -827,7 +827,7 @@ return schema.new('instance_config', schema.record({
             box_cfg = 'wal_dir',
             box_cfg_nondynamic = true,
             mkdir = true,
-            default = '{{ instance_name }}',
+            default = 'var/lib/{{ instance_name }}',
         }),
         mode = schema.enum({
             'none',
@@ -908,7 +908,7 @@ return schema.new('instance_config', schema.record({
             box_cfg = 'memtx_dir',
             box_cfg_nondynamic = true,
             mkdir = true,
-            default = '{{ instance_name }}',
+            default = 'var/lib/{{ instance_name }}',
         }),
         by = schema.record({
             interval = schema.scalar({

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -374,6 +374,10 @@ return schema.new('instance_config', schema.record({
         }),
         socket = schema.scalar({
             type = 'string',
+            -- The mk_parent_dir annotation is not present here,
+            -- because otherwise the directory would be created
+            -- unconditionally. Instead, mkdir applier creates it
+            -- if console.enabled is true.
             default = '{{ instance_name }}.control',
         }),
     }),

--- a/src/main.cc
+++ b/src/main.cc
@@ -885,7 +885,14 @@ main(int argc, char **argv)
 #ifndef NDEBUG
 	errinj_set_with_environment_vars();
 #endif
-	tarantool_lua_init(tarantool_bin, script, main_argc, main_argv);
+	/*
+	 * Pass either a configuration file or a script file to
+	 * configure Lua loaders paths.
+	 */
+	const char *config_or_script = instance.config != NULL ?
+		instance.config : script;
+	tarantool_lua_init(tarantool_bin, config_or_script, main_argc,
+			   main_argv);
 
 	start_time = ev_monotonic_time();
 

--- a/test/config-luatest/appliers_test.lua
+++ b/test/config-luatest/appliers_test.lua
@@ -76,8 +76,8 @@ g.test_applier_mkdir = function()
     local opts = {nojson = true, stderr = false}
     local res = justrun.tarantool(dir, env, {'main.lua'}, opts)
     t.assert_equals(res.exit_code, 0)
-    t.assert_equals(res.stdout, 'instance-001')
-    t.assert(fio.path.is_dir(fio.pathjoin(dir, 'instance-001')))
+    t.assert_equals(res.stdout, 'var/lib/instance-001')
+    t.assert(fio.path.is_dir(fio.pathjoin(dir, '/var/lib/instance-001')))
 end
 
 g.test_applier_box_cfg = function()

--- a/test/config-luatest/cli_test.lua
+++ b/test/config-luatest/cli_test.lua
@@ -44,7 +44,7 @@ g.test_help_env_list = function()
         {
             name = 'TT_CONSOLE_SOCKET',
             type = 'string',
-            default = '{{ instance_name }}.control',
+            default = 'var/run/{{ instance_name }}/tarantool.control',
             availability = 'Community Edition',
         },
         -- An Enterprise Edition option and, at the same time,

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -132,7 +132,7 @@ g.test_defaults = function()
         },
         log = {
             to = 'stderr',
-            file = '{{ instance_name }}.log',
+            file = 'var/log/{{ instance_name }}/tarantool.log',
             pipe = box.NULL,
             syslog = {
                 identity = 'tarantool',
@@ -144,7 +144,7 @@ g.test_defaults = function()
             format = 'plain',
         },
         snapshot = {
-            dir = '{{ instance_name }}',
+            dir = 'var/lib/{{ instance_name }}',
             by = {
                 interval = 3600,
                 wal_size = 1000000000000000000,
@@ -170,10 +170,10 @@ g.test_defaults = function()
             title = 'tarantool - {{ instance_name }}',
             username = box.NULL,
             work_dir = box.NULL,
-            pid_file = '{{ instance_name }}.pid',
+            pid_file = 'var/run/{{ instance_name }}/tarantool.pid',
         },
         vinyl = {
-            dir = '{{ instance_name }}',
+            dir = 'var/lib/{{ instance_name }}',
             max_tuple_size = 1048576,
             bloom_fpr = 0.05,
             page_size = 8192,
@@ -213,7 +213,7 @@ g.test_defaults = function()
             bootstrap_strategy = 'auto',
         },
         wal = {
-            dir = '{{ instance_name }}',
+            dir = 'var/lib/{{ instance_name }}',
             mode = 'write',
             max_size = 268435456,
             dir_rescan_delay = 2,
@@ -222,7 +222,7 @@ g.test_defaults = function()
         },
         console = {
             enabled = true,
-            socket = '{{ instance_name }}.control',
+            socket = 'var/run/{{ instance_name }}/tarantool.control',
         },
         memtx = {
             memory = 268435456,

--- a/test/config-luatest/helpers.lua
+++ b/test/config-luatest/helpers.lua
@@ -196,7 +196,7 @@ end
 --
 --   Verify test invariants after config:reload().
 local function reload_success_case(g, opts)
-    local script_2 = assert(opts.script_2)
+    local script_2 = opts.script_2
     local options = assert(opts.options)
     local verify_2 = assert(opts.verify_2)
 

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -156,7 +156,7 @@ g.test_process = function()
         title = 'tarantool - {{ instance_name }}',
         username = box.NULL,
         work_dir = box.NULL,
-        pid_file = '{{ instance_name }}.pid',
+        pid_file = 'var/run/{{ instance_name }}/tarantool.pid',
     }
     local res = instance_config:apply_default({}).process
     t.assert_equals(res, exp)
@@ -174,7 +174,7 @@ g.test_console = function()
 
     local exp = {
         enabled = true,
-        socket = '{{ instance_name }}.control',
+        socket = 'var/run/{{ instance_name }}/tarantool.control',
     }
     local res = instance_config:apply_default({}).console
     t.assert_equals(res, exp)
@@ -256,7 +256,7 @@ g.test_log = function()
 
     local exp = {
         to = 'stderr',
-        file = '{{ instance_name }}.log',
+        file = 'var/log/{{ instance_name }}/tarantool.log',
         pipe = box.NULL,
         syslog = {
             identity = 'tarantool',
@@ -734,7 +734,7 @@ g.test_vinyl = function()
     validate_fields(iconfig.vinyl, instance_config.schema.fields.vinyl)
 
     local exp = {
-        dir = '{{ instance_name }}',
+        dir = 'var/lib/{{ instance_name }}',
         max_tuple_size = 1048576,
         bloom_fpr = 0.05,
         page_size = 8192,
@@ -768,7 +768,7 @@ g.test_wal = function()
     validate_fields(iconfig.wal, instance_config.schema.fields.wal)
 
     local exp = {
-        dir = '{{ instance_name }}',
+        dir = 'var/lib/{{ instance_name }}',
         mode = 'write',
         max_size = 268435456,
         dir_rescan_delay = 2,
@@ -832,7 +832,7 @@ g.test_snapshot = function()
     validate_fields(iconfig.snapshot, instance_config.schema.fields.snapshot)
 
     local exp = {
-        dir = '{{ instance_name }}',
+        dir = 'var/lib/{{ instance_name }}',
         by = {
             interval = 3600,
             wal_size = 1000000000000000000,

--- a/test/config-luatest/mkdir_test.lua
+++ b/test/config-luatest/mkdir_test.lua
@@ -7,7 +7,7 @@ g.test_nested_dirs = function(g)
     local verify = function()
         local fio = require('fio')
 
-        for _, dir in ipairs({'a/b', 'd/e/f', 'g/h/i', 'j/k/l'}) do
+        for _, dir in ipairs({'a/b', 'd/e/f', 'g/h/i', 'j/k/l', 'm/n'}) do
             t.assert_equals(fio.path.is_dir(dir), true)
         end
     end
@@ -18,6 +18,7 @@ g.test_nested_dirs = function(g)
             ['vinyl.dir'] = 'd/e/f',
             ['wal.dir'] = 'g/h/i',
             ['snapshot.dir'] = 'j/k/l',
+            ['console.socket'] = 'm/n/o.socket',
         },
         verify = verify,
     })

--- a/test/config-luatest/mkdir_test.lua
+++ b/test/config-luatest/mkdir_test.lua
@@ -1,4 +1,6 @@
+local fio = require('fio')
 local t = require('luatest')
+local treegen = require('test.treegen')
 local helpers = require('test.config-luatest.helpers')
 
 local g = helpers.group()
@@ -24,5 +26,48 @@ g.test_nested_dirs = function(g)
             ['log.file'] = 'p/q/r.log',
         },
         verify = verify,
+    })
+end
+
+-- Verify that work_dir is created at startup.
+--
+-- Also verify that if the directory is set as a relative path,
+-- config:reload() doesn't attempt to create the same path inside
+-- the work_dir.
+--
+-- IOW, if the work_dir is a/b/c, we shouldn't create a/b/c/a/b/c
+-- at reload.
+g.test_work_dir = function(g)
+    local dir = treegen.prepare_directory(g, {}, {})
+
+    local verify = loadstring(([[
+        local fio = require('fio')
+
+        local work_dir = fio.pathjoin('%s', 'a/b/c')
+        assert(fio.path.is_dir(work_dir))
+        assert(not fio.path.exists(fio.pathjoin(work_dir, 'a')))
+    ]]):format(dir))
+
+    local data_dir = fio.pathjoin(dir, '{{ instance_name }}')
+    helpers.reload_success_case(g, {
+        dir = dir,
+        options = {
+            ['process.work_dir'] = 'a/b/c',
+
+            -- Place all the necessary directories and files into
+            -- a location outside of the work_dir.
+            --
+            -- It allows to test the work_dir creation logic
+            -- independently of creation of other directories.
+            ['process.pid_file'] = fio.pathjoin(dir, '{{ instance_name }}.pid'),
+            ['vinyl.dir'] = data_dir,
+            ['wal.dir'] = data_dir,
+            ['snapshot.dir'] = data_dir,
+            ['console.socket'] = fio.pathjoin(dir,
+                '{{ instance_name }}.control'),
+            ['iproto.listen'] = fio.pathjoin(dir, '{{ instance_name }}.iproto'),
+        },
+        verify = verify,
+        verify_2 = verify,
     })
 end

--- a/test/config-luatest/mkdir_test.lua
+++ b/test/config-luatest/mkdir_test.lua
@@ -7,7 +7,8 @@ g.test_nested_dirs = function(g)
     local verify = function()
         local fio = require('fio')
 
-        for _, dir in ipairs({'a/b', 'd/e/f', 'g/h/i', 'j/k/l', 'm/n'}) do
+        local dirs = {'a/b', 'd/e/f', 'g/h/i', 'j/k/l', 'm/n', 'p/q'}
+        for _, dir in ipairs(dirs) do
             t.assert_equals(fio.path.is_dir(dir), true)
         end
     end
@@ -19,6 +20,8 @@ g.test_nested_dirs = function(g)
             ['wal.dir'] = 'g/h/i',
             ['snapshot.dir'] = 'j/k/l',
             ['console.socket'] = 'm/n/o.socket',
+            ['log.to'] = 'file',
+            ['log.file'] = 'p/q/r.log',
         },
         verify = verify,
     })


### PR DESCRIPTION
This patchset accumulates a set of bug fixes and enhancements around tarantool directory layout.

* Parent directories are now created for `console.socket` and `log.file` when appropriate.
* `process.work_dir` is also created if provided.
* All the created directories are calculated relative to `process.work_dir` at startup and reload.
* The new `cartridge-cli` and `tt` inspired directory layout is in effect by default.

    ```
    + var/
      + lib/
        + instance-001/
          - *.xlog
          - *.snap
          - *.vylog
      + log/
        + instance-001/
          - tarantool.log
      + run/
        + instance-001/
          - tarantool.control
          - tarantool.pid
    ```
* Config's directory is added into Lua module search paths.

Part of #8862