### PR TITLE
sql: refactor update_view_references a bit

### DIFF
--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -1865,8 +1865,6 @@ update_view_references(struct Select *select, int update_value,
 {
 	assert(update_value == 1 || update_value == -1);
 	struct SrcList *list = sql_select_expand_from_tables(select);
-	if (list == NULL)
-		return -1;
 	int from_tables_count = sql_src_list_entry_count(list);
 	for (int i = 0; i < from_tables_count; ++i) {
 		const char *space_name = sql_src_list_entry_name(list, i);

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -1868,8 +1868,7 @@ update_view_references(struct Select *select, int update_value,
 	int from_tables_count = sql_src_list_entry_count(list);
 	for (int i = 0; i < from_tables_count; ++i) {
 		const char *space_name = sql_src_list_entry_name(list, i);
-		if (space_name == NULL)
-			continue;
+		assert(space_name != NULL);
 		/*
 		 * Views are allowed to contain CTEs. CTE is a
 		 * temporary object, created and destroyed at SQL

--- a/src/box/sql.h
+++ b/src/box/sql.h
@@ -285,7 +285,6 @@ sql_select_delete(struct Select *select);
  *
  * @param select Select to be investigated.
  * @retval List containing all involved table names.
- *         NULL in case of OOM.
  */
 struct SrcList *
 sql_select_expand_from_tables(struct Select *select);

--- a/src/box/sql/select.c
+++ b/src/box/sql/select.c
@@ -483,9 +483,7 @@ src_list_append_unique(struct SrcList *list, const char *new_name)
 		if (name != NULL && strcmp(new_name, name) == 0)
 			return list;
 	}
-	struct SrcList *new_list =
-		sql_src_list_enlarge(list, 1, list->nSrc);
-	list = new_list;
+	list = sql_src_list_enlarge(list, 1, list->nSrc);
 	struct SrcList_item *pItem = &list->a[list->nSrc - 1];
 	pItem->zName = sql_xstrdup(new_name);
 	return list;
@@ -502,8 +500,7 @@ select_collect_table_names(struct Walker *walker, struct Select *select)
 		walker->u.pSrcList =
 			src_list_append_unique(walker->u.pSrcList,
 					       select->pSrc->a[i].zName);
-		if (walker->u.pSrcList == NULL)
-			return WRC_Abort;
+		assert(walker->u.pSrcList != NULL);
 	}
 	return WRC_Continue;
 }
@@ -518,10 +515,8 @@ sql_select_expand_from_tables(struct Select *select)
 	walker.xExprCallback = sqlExprWalkNoop;
 	walker.xSelectCallback = select_collect_table_names;
 	walker.u.pSrcList = table_names;
-	if (sqlWalkSelect(&walker, select) != 0) {
-		sqlSrcListDelete(walker.u.pSrcList);
-		return NULL;
-	}
+	int rc = sqlWalkSelect(&walker, select);
+	assert(rc == WRC_Continue); (void)rc;
 	return walker.u.pSrcList;
 }
 

--- a/src/box/sql/select.c
+++ b/src/box/sql/select.c
@@ -480,7 +480,7 @@ src_list_append_unique(struct SrcList *list, const char *new_name)
 
 	for (int i = 0; i < list->nSrc; ++i) {
 		const char *name = list->a[i].zName;
-		if (name != NULL && strcmp(new_name, name) == 0)
+		if (strcmp(new_name, name) == 0)
 			return list;
 	}
 	list = sql_src_list_enlarge(list, 1, list->nSrc);
@@ -511,6 +511,7 @@ sql_select_expand_from_tables(struct Select *select)
 	assert(select != NULL);
 	struct Walker walker;
 	struct SrcList *table_names = sql_src_list_new();
+	table_names->nSrc = 0;
 	memset(&walker, 0, sizeof(walker));
 	walker.xExprCallback = sqlExprWalkNoop;
 	walker.xSelectCallback = select_collect_table_names;

--- a/test/sql/view.result
+++ b/test/sql/view.result
@@ -271,6 +271,23 @@ box.execute("DROP TABLE c;")
 - null
 - 'Can''t drop space ''C'': other views depend on this space'
 ...
+-- Try to create invalid view using direct insert to space _space.
+space_tuple = box.space._space.index[0]:max():totable()
+---
+...
+space_tuple[1] = space_tuple[1] + 1 -- id
+---
+...
+space_tuple[3] = space_tuple[3] .. '1' -- name
+---
+...
+space_tuple[6].sql = string.gsub(space_tuple[6].sql, 'FROM c', 'FROM ccc')
+---
+...
+box.space._space:insert(space_tuple)
+---
+- error: Space 'CCC' does not exist
+...
 box.space.BCV:drop()
 ---
 ...

--- a/test/sql/view.test.lua
+++ b/test/sql/view.test.lua
@@ -101,6 +101,14 @@ box.execute("DROP TABLE c;")
 box.execute("CREATE TABLE c (s1 INT PRIMARY KEY);")
 box.execute("CREATE VIEW bcv(x, y) AS VALUES((SELECT 'k' FROM b), (VALUES((SELECT 1 FROM b WHERE s1 IN (VALUES((SELECT 1 + c.s1 FROM c)))))))")
 box.execute("DROP TABLE c;")
+
+-- Try to create invalid view using direct insert to space _space.
+space_tuple = box.space._space.index[0]:max():totable()
+space_tuple[1] = space_tuple[1] + 1 -- id
+space_tuple[3] = space_tuple[3] .. '1' -- name
+space_tuple[6].sql = string.gsub(space_tuple[6].sql, 'FROM c', 'FROM ccc')
+box.space._space:insert(space_tuple)
+
 box.space.BCV:drop()
 box.execute("DROP TABLE c;")
 box.execute("DROP TABLE b;")


### PR DESCRIPTION
The function update_view_references is called when an SQL view
is created or dropped. The goal of this function is to modify
(increment or decrement) view_ref_count member of spaces that
the view references.

There were a several issues that deserves to be refactored:
* By design in case of error it left the job partially done, so
  some space references were modified while some other - not.
  Although there was no bug since special steps were made in case
  of error, this pattern is inconvenient and should be avoided.
* In case of error the failing space name was returned via special
  argument which is not flexible and even requires allocation.
* Another argument - suppress_error - has actually never
  suppressed any error because the only case when an error could
  occur is creation of a view, which used suppress_error = false.
* Fail of that function was not actually covered with tests.

So the last commit:
* Makes the function to do all or nothing.
* Forces the function to set diag by itself in case of error.
* Removes suppress_error argument while adding several asserts.\
* Adds a small test that fulfills coverage.

On a way to success this patch also refactors SrcList structure for SQL.