### PR TITLE
test/config: test suite fixes for Tarantool Enterprise Edition

### DIFF
--- a/doc/examples/config/etcd/remote.yaml
+++ b/doc/examples/config/etcd/remote.yaml
@@ -1,12 +1,10 @@
 credentials:
   users:
     replicator:
-      password:
-        plain: 'topsecret'
+      password: 'topsecret'
       roles: [replication]
     client:
-      password:
-        plain: 'secret'
+      password: 'secret'
       roles: [super]
 
 groups:

--- a/test/config-luatest/credentials_applier_test.lua
+++ b/test/config-luatest/credentials_applier_test.lua
@@ -382,7 +382,16 @@ g.test_privileges_add_defaults = function(g)
     for _, case in ipairs(cases) do
         local role_or_user, name = unpack(case)
 
-        local child = it.new()
+        -- Disable hide/show prompt functionality, because it
+        -- breaks a command echo check. The reason is that the
+        -- 'scheduled next checkpoint' log message is issued from
+        -- a background fiber.
+        local child = it.new({
+            env = {
+                TT_CONSOLE_HIDE_SHOW_PROMPT = 'false',
+            },
+        })
+
         local dir = treegen.prepare_directory(g, {}, {})
 
         child:execute_command(("box.cfg{work_dir = %q}"):format(dir))
@@ -445,7 +454,15 @@ g.test_sync_privileges = function(g)
         },
     }
 
-    local child = it.new()
+    -- Disable hide/show prompt functionality, because it breaks
+    -- a command echo check. The reason is that the 'scheduled
+    -- next checkpoint' log message is issued from a background
+    -- fiber.
+    local child = it.new({
+        env = {
+            TT_CONSOLE_HIDE_SHOW_PROMPT = 'false',
+        },
+    })
     local dir = treegen.prepare_directory(g, {}, {})
     child:roundtrip(("box.cfg{work_dir = %q}"):format(dir))
 
@@ -490,7 +507,17 @@ g.test_set_password = function(g)
         if auth_type == 'pap-sha256' then
             t.tarantool.skip_if_not_enterprise()
         end
-        local child = it.new()
+
+        -- Disable hide/show prompt functionality, because it
+        -- breaks a command echo check. The reason is that the
+        -- 'scheduled next checkpoint' log message is issued from
+        -- a background fiber.
+        local child = it.new({
+            env = {
+                TT_CONSOLE_HIDE_SHOW_PROMPT = 'false',
+            },
+        })
+
         local dir = treegen.prepare_directory(g, {}, {})
         local socket = "unix/:./test_socket.iproto"
 

--- a/test/config-luatest/credentials_applier_test.lua
+++ b/test/config-luatest/credentials_applier_test.lua
@@ -500,7 +500,11 @@ g.test_set_password = function(g)
 
     local auth_types = {
         'chap-sha1',
-        'pap-sha256',
+        -- TODO: The pap-sha256 authentication method requires
+        -- an encrypted connection, so it is left untested for
+        -- now.
+        --
+        -- 'pap-sha256',
     }
 
     for _, auth_type in ipairs(auth_types) do

--- a/test/config-luatest/credentials_applier_test.lua
+++ b/test/config-luatest/credentials_applier_test.lua
@@ -430,7 +430,7 @@ g.test_sync_privileges = function(g)
         }, {
             "revoke", "session,usage", "universe", ""
         }, {
-            "grant", "execute", "functions", ""
+            "grant", "execute", "function", ""
         },
     }
 

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -805,7 +805,7 @@ g.test_wal_enterprise = function()
     validate_fields(iconfig.wal, instance_config.schema.fields.wal)
 
     local exp = {
-        dir = '{{ instance_name }}',
+        dir = 'var/lib/{{ instance_name }}',
         mode = 'write',
         max_size = 268435456,
         dir_rescan_delay = 2,

--- a/test/interactive_tarantool.lua
+++ b/test/interactive_tarantool.lua
@@ -294,6 +294,7 @@ end
 function M._new_internal(opts)
     local opts = opts or {}
     local args = opts.args or {}
+    local env = opts.env or {}
     local prompt = opts.prompt
 
     local tarantool_exe = arg[-1]
@@ -301,7 +302,7 @@ function M._new_internal(opts)
         stdin = popen.opts.PIPE,
         stdout = popen.opts.PIPE,
         stderr = popen.opts.PIPE,
-        env = {
+        env = fun.chain({
             -- Don't know why, but without defined TERM environment
             -- variable readline doesn't accept INPUTRC environment
             -- variable.
@@ -313,7 +314,7 @@ function M._new_internal(opts)
             -- (because the command in the echo output will be
             -- trimmed).
             INPUTRC = '/dev/null',
-        },
+        }, env):tomap(),
     })
 
     local res = setmetatable({


### PR DESCRIPTION
The patches mostly add something that was forgotten in previous commits in regard to test cases that are run as part of Tarantool EE test suite.

See details in the commit messages.

Part of #8862
Part of #8967