### PR TITLE
box: fix memory leak on `error_unpack_unsafe()` failure

### DIFF
--- a/changelogs/unreleased/gh-8921-memory-leak-in-xrow_decode_error.md
+++ b/changelogs/unreleased/gh-8921-memory-leak-in-xrow_decode_error.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed the memory leak on unpacking an invalid MsgPack error extension
+  (gh-8921).

--- a/src/box/mp_error.cc
+++ b/src/box/mp_error.cc
@@ -482,7 +482,7 @@ error_unpack_unsafe(const char **data)
 		if (mp_typeof(**data) != MP_UINT) {
 			diag_set(ClientError, ER_INVALID_MSGPACK,
 				 "Invalid MP_ERROR MsgPack format");
-			return NULL;
+			goto error;
 		}
 		uint64_t key = mp_decode_uint(data);
 		switch(key) {
@@ -490,14 +490,14 @@ error_unpack_unsafe(const char **data)
 			if (mp_typeof(**data) != MP_ARRAY) {
 				diag_set(ClientError, ER_INVALID_MSGPACK,
 					 "Invalid MP_ERROR MsgPack format");
-				return NULL;
+				goto error;
 			}
 			uint32_t stack_sz = mp_decode_array(data);
 			struct error *effect = NULL;
 			for (uint32_t i = 0; i < stack_sz; i++) {
 				struct error *cur = mp_decode_error_one(data);
 				if (cur == NULL)
-					return NULL;
+					goto error;
 				if (err == NULL) {
 					err = cur;
 					effect = cur;
@@ -514,6 +514,14 @@ error_unpack_unsafe(const char **data)
 		}
 	}
 	return err;
+
+error:
+	if (err != NULL) {
+		/* A hack to delete the error. */
+		error_ref(err);
+		error_unref(err);
+	}
+	return NULL;
 }
 
 struct error *


### PR DESCRIPTION
Memory is leaked in the following scenario:
- `MP_ERROR_STACK` with 2 errors is passed to `error_unpack_unsafe()`:
  1. A correct `MP_MAP` with `MP_ERROR_*` fields;
  2. Something unexpected, e.g. `MP_INT`;
- This first call to `mp_decode_error_one()` allocates memory for the first error in `error_build_xc()` -> `new ClientError()`;
- The second call to `mp_decode_error_one()` returns `NULL`, and `error_unpack_unsafe()` returns `NULL` too. Memory from the previous step is leaked.

Closes #8921