### PR TITLE
box: validate `key_def->part_count` prior to memory allocation

### DIFF
--- a/changelogs/unreleased/gh-8688-zero-part_count-crash.md
+++ b/changelogs/unreleased/gh-8688-zero-part_count-crash.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a crash that could happen when inserting an index definition with an
+  empty parts list directly into `box.space._index` (gh-8688).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -341,8 +341,6 @@ index_def_new_from_tuple(struct tuple *tuple, struct space *space)
 		return NULL;
 	if (index_opts_decode(&opts, opts_field, &fiber()->gc) != 0)
 		return NULL;
-	const char *parts = tuple_field(tuple, BOX_INDEX_FIELD_PARTS);
-	uint32_t part_count = mp_decode_array(&parts);
 	if (name_len > BOX_NAME_MAX) {
 		diag_set(ClientError, ER_MODIFY_INDEX,
 			  tt_cstr(name, BOX_INVALID_NAME_MAX),
@@ -351,6 +349,19 @@ index_def_new_from_tuple(struct tuple *tuple, struct space *space)
 	}
 	if (identifier_check(name, name_len) != 0)
 		return NULL;
+
+	const char *parts = tuple_field(tuple, BOX_INDEX_FIELD_PARTS);
+	uint32_t part_count = mp_decode_array(&parts);
+	if (part_count == 0) {
+		diag_set(ClientError, ER_MODIFY_INDEX, tt_cstr(name, name_len),
+			 space_name(space), "part count must be positive");
+		return NULL;
+	}
+	if (part_count > BOX_INDEX_PART_MAX) {
+		diag_set(ClientError, ER_MODIFY_INDEX, tt_cstr(name, name_len),
+			 space_name(space), "too many key parts");
+		return NULL;
+	}
 	struct key_def *key_def = NULL;
 	struct key_part_def *part_def = (struct key_part_def *)
 		malloc(sizeof(*part_def) * part_count);

--- a/src/box/index_def.c
+++ b/src/box/index_def.c
@@ -280,16 +280,6 @@ index_def_check(struct index_def *index_def, const char *space_name)
 			 space_name, "primary key must be unique");
 		return -1;
 	}
-	if (index_def->key_def->part_count == 0) {
-		diag_set(ClientError, ER_MODIFY_INDEX, index_def->name,
-			 space_name, "part count must be positive");
-		return -1;
-	}
-	if (index_def->key_def->part_count > BOX_INDEX_PART_MAX) {
-		diag_set(ClientError, ER_MODIFY_INDEX, index_def->name,
-			 space_name, "too many key parts");
-		return -1;
-	}
 	if (index_def->iid == 0 && index_def->key_def->is_multikey) {
 		diag_set(ClientError, ER_MODIFY_INDEX, index_def->name,
 			 space_name, "primary key cannot be multikey");

--- a/src/box/key_def.c
+++ b/src/box/key_def.c
@@ -268,6 +268,7 @@ struct key_def *
 key_def_new(const struct key_part_def *parts, uint32_t part_count,
 	    bool for_func_index)
 {
+	assert(part_count > 0);
 	size_t sz = 0;
 	for (uint32_t i = 0; i < part_count; i++)
 		sz += parts[i].path != NULL ? strlen(parts[i].path) : 0;

--- a/test/engine-luatest/gh_8688_wrong_index_parts_test.lua
+++ b/test/engine-luatest/gh_8688_wrong_index_parts_test.lua
@@ -1,0 +1,43 @@
+local t = require('luatest')
+local g = t.group('gh-8688', {{engine = 'memtx'}, {engine = 'vinyl'}})
+local server = require('luatest.server')
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+-- Check that it is not possible to insert an index definition with bad list
+-- of the parts directly into `box.space._index`.
+g.test_wrong_index_parts = function(cg)
+    cg.server:exec(function(engine)
+        local s = box.schema.space.create('test', {engine = engine})
+
+        local parts = {}
+        t.assert_error_msg_equals(
+            "Can't create or modify index 'pk' in space 'test': " ..
+            "part count must be positive",
+            function()
+                box.space._index:insert{s.id, 0, 'pk', 'tree',
+                                        {unique = true}, parts}
+            end
+        )
+
+        for k = 1, box.schema.INDEX_PART_MAX + 1, 1 do
+            table.insert(parts, k)
+            table.insert(parts, 'unsigned')
+        end
+        t.assert_error_msg_equals(
+            "Can't create or modify index 'pk' in space 'test': " ..
+            "too many key parts",
+            function()
+                box.space._index:insert{s.id, 0, 'pk', 'tree',
+                                        {unique = true}, parts}
+            end
+        )
+    end, {cg.params.engine})
+end


### PR DESCRIPTION
`part_count` was checked in `index_def_check()`, which was called too late.
Before that check:
1. `malloc(sizeof(*part_def) * part_count)` can fail for huge `part_count`;
2. `key_def_new()` can crash for zero `part_count` because of out of bound access in:
```
- #1 key_def_contains_sequential_parts (def=0x5555561a2ef0) at src/box/tuple_extract_key.cc:26
- #2 key_def_set_extract_func (key_def=0x5555561a2ef0) at src/box/tuple_extract_key.cc:442
- #3 key_def_set_func (def=0x5555561a2ef0) at src/box/key_def.c:162
- #4 key_def_new (parts=0x7fffc4001350, part_count=0, for_func_index=false) at src/box/key_def.c:320
```

Closes #8688