### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-8825-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8825-luajit-fixes.md
@@ -7,3 +7,5 @@ were fixed as part of this activity:
 * Fixed recording of `BC_VARG` with unused vararg values.
 * Initialization instructions on trace are now emitted only for the first
   member of a union.
+* Fix binary number literal parsing. Parsing of binary number with a zero
+  fractional part raises error too now.


### PR DESCRIPTION
* Fix binary number literal parsing.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump