### PR TITLE
config: introduce audit options

### DIFF
--- a/changelogs/unreleased/gh-8861-audit-options.md
+++ b/changelogs/unreleased/gh-8861-audit-options.md
@@ -1,0 +1,3 @@
+## feature/config
+
+* All audit options are now supported (gh-8861).

--- a/src/box/lua/config/applier/mkdir.lua
+++ b/src/box/lua/config/applier/mkdir.lua
@@ -78,6 +78,12 @@ local function apply(config)
         local prefix = ('mkdir.apply[%s]'):format('log.file')
         safe_mkdir(prefix, fio.dirname(log.file), work_dir)
     end
+
+    local audit_log = configdata:get('audit_log', {use_default = true})
+    if audit_log ~= nil and audit_log.to == 'file' then
+        local prefix = ('mkdir.apply[%s]'):format('audit_log.file')
+        safe_mkdir(prefix, fio.dirname(audit_log.file), work_dir)
+    end
 end
 
 return {

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -270,7 +270,19 @@ g.test_defaults = function()
             sched_ref_quota = 300,
             shard_index = "bucket_id",
             sync_timeout = 1,
-        }
+        },
+        audit_log = is_enterprise and {
+            file = "var/log/{{ instance_name }}/audit.log",
+            format = "json",
+            nonblock = false,
+            pipe = box.NULL,
+            syslog = {
+                facility = "local7",
+                identity = "tarantool",
+                server = box.NULL
+            },
+            to = "devnull",
+        } or nil,
     }
     local res = cluster_config:apply_default({})
     t.assert_equals(res, exp)

--- a/test/config-luatest/helpers.lua
+++ b/test/config-luatest/helpers.lua
@@ -148,12 +148,16 @@ end
 --
 --   Function to run on the started server to verify some
 --   invariants.
+--
+-- * opts.verify_args
+--
+--  Arguments for the verify function.
 local function success_case(g, opts)
     local verify = assert(opts.verify)
     local prepared = prepare_case(g, opts)
     g.server = server:new(prepared.server)
     g.server:start()
-    g.server:exec(verify)
+    g.server:exec(verify, opts.verify_args)
     return prepared
 end
 


### PR DESCRIPTION
This patch introduces all audit options.

Part of #8861

NO_DOC=Was already described before.