### PR TITLE
lua: fix uninitialized var usage in `luamp_encode_with_translation`

### DIFF
--- a/src/lua/msgpack.c
+++ b/src/lua/msgpack.c
@@ -324,6 +324,7 @@ restart: /* used by MP_EXT of unidentified subtype */
 		type = MP_ARRAY;
 		break;
 	case MP_EXT:
+		type = MP_EXT;
 		switch (field->ext_type) {
 		case MP_DECIMAL:
 			mpstream_encode_decimal(stream, field->decval);


### PR DESCRIPTION
`*type_out` was set to uninitialized value for `field->type == MP_EXT`.
This was introduced by commit 9f9142d64289 ("box: cleanup on tuple encoding failure")

Closes #9023