### PR TITLE
Fix transaction boundaries in WAL and replication

### DIFF
--- a/changelogs/unreleased/gh-8958-remove-transaction-nop.md
+++ b/changelogs/unreleased/gh-8958-remove-transaction-nop.md
@@ -1,0 +1,6 @@
+## bugfix/replication
+
+* Fixed replicas writing corrupted xlogs when appending data to a local space
+  from an `on_replace` or `before_replace` trigger on a global replicated space.
+  Such xlogs were unrecoverable and caused other nodes to break replication with
+  the replica (gh-8746, gh-8958).

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -800,13 +800,28 @@ txn_on_journal_write(struct journal_entry *entry)
 	} else {
 		int64_t lsn;
 		/*
-		 * XXX: that is quite ugly. Need a more reliable way to get the
-		 * synchro LSN.
+		 * Synchro lsn is taken from the last global row of a
+		 * transaction. When this is a remote transaction
+		 * (n_applier_rows > 0) we know for sure the last applier row is
+		 * the last global row. Otherwise we need to find the last
+		 * global row.
 		 */
-		if (txn->n_applier_rows > 0)
+		if (txn->n_applier_rows > 0) {
 			lsn = entry->rows[txn->n_applier_rows - 1]->lsn;
-		else
-			lsn = entry->rows[entry->n_rows - 1]->lsn;
+		} else {
+			int i = entry->n_rows - 1;
+			struct xrow_header **rows = entry->rows;
+			/*
+			 * We don't care which lsn to choose for a fully local
+			 * transaction.
+			 */
+			if (!txn_is_fully_local(txn)) {
+				while (rows[i]->group_id == GROUP_LOCAL)
+					i--;
+				assert(i >= 0);
+			}
+			lsn = rows[i]->lsn;
+		}
 		txn_limbo_assign_lsn(&txn_limbo, txn->limbo_entry, lsn);
 		if (txn->fiber != NULL)
 			fiber_wakeup(txn->fiber);
@@ -825,9 +840,8 @@ txn_journal_entry_new(struct txn *txn)
 
 	assert(txn->n_new_rows + txn->n_applier_rows > 0);
 
-	/* Save space for an additional NOP row just in case. */
 	struct region *txn_region = tx_region_acquire(txn);
-	req = journal_entry_new(txn->n_new_rows + txn->n_applier_rows + 1,
+	req = journal_entry_new(txn->n_new_rows + txn->n_applier_rows,
 				txn_region, txn_on_journal_write, txn);
 	tx_region_release(txn, TX_ALLOC_SYSTEM);
 	txn_region = NULL;
@@ -893,30 +907,6 @@ txn_journal_entry_new(struct txn *txn)
 
 	assert(remote_row == req->rows + txn->n_applier_rows);
 	assert(local_row == remote_row + txn->n_new_rows);
-
-	/*
-	 * Append a dummy NOP statement to preserve replication tx
-	 * boundaries when the last tx row is a local one, and the
-	 * transaction has at least one global row.
-	 */
-	if (txn->n_local_rows > 0 &&
-	    (txn->n_local_rows != txn->n_new_rows || txn->n_applier_rows > 0) &&
-	    (*(local_row - 1))->group_id == GROUP_LOCAL) {
-		size_t size;
-		*local_row =
-			tx_region_alloc_object(txn, TX_OBJECT_XROW_HEADER,
-					       &size);
-		if (*local_row == NULL) {
-			diag_set(OutOfMemory, size, "tx_region_alloc_object",
-				 "row");
-			return NULL;
-		}
-		memset(*local_row, 0, sizeof(**local_row));
-		(*local_row)->type = IPROTO_NOP;
-		(*local_row)->group_id = GROUP_DEFAULT;
-	} else {
-		--req->n_rows;
-	}
 
 	static const uint8_t flags_map[] = {
 		[TXN_WAIT_SYNC] = IPROTO_FLAG_WAIT_SYNC,

--- a/test/replication-luatest/gh_8746_replica_transaction_boundary_test.lua
+++ b/test/replication-luatest/gh_8746_replica_transaction_boundary_test.lua
@@ -1,0 +1,56 @@
+local t = require('luatest')
+local server = require('luatest.server')
+local replica_set = require('luatest.replica_set')
+
+local g = t.group('gh-8746-transaction-boundaries')
+
+g.before_each(function(cg)
+    cg.replica_set = replica_set:new{}
+end)
+
+g.after_each(function(cg)
+    cg.replica_set:drop()
+end)
+
+local function prepare(cg)
+    cg.replica_set:start()
+    cg.master:exec(function()
+        box.schema.space.create('test')
+        box.space.test:create_index('pk')
+        box.schema.space.create('loc', {is_local = true})
+        box.space.loc:create_index('pk')
+    end)
+    cg.replica:wait_for_vclock_of(cg.master)
+    cg.replica:exec(function()
+        box.space.test:on_replace(function(_, new)
+            box.space.loc:replace(new)
+        end)
+    end)
+    cg.master:exec(function()
+        box.space.test:replace{1}
+    end)
+    cg.replica:wait_for_vclock_of(cg.master)
+end
+
+g.before_test('test_replica_recovery', function(cg)
+    cg.master = cg.replica_set:build_and_add_server{
+        alias = 'master',
+        box_cfg = {
+            replication_timeout = 0.1,
+        },
+    }
+    cg.replica = cg.replica_set:build_and_add_server{
+        alias = 'replica',
+        box_cfg = {
+            read_only = true,
+            replication = server.build_listen_uri('master', cg.replica_set.id),
+            replication_timeout = 0.1,
+        },
+    }
+end)
+
+g.test_replica_recovery = function(cg)
+    prepare(cg)
+    cg.replica:restart()
+    cg.replica:wait_for_vclock_of(cg.master)
+end

--- a/test/replication-luatest/gh_8746_replica_transaction_boundary_test.lua
+++ b/test/replication-luatest/gh_8746_replica_transaction_boundary_test.lua
@@ -54,3 +54,29 @@ g.test_replica_recovery = function(cg)
     cg.replica:restart()
     cg.replica:wait_for_vclock_of(cg.master)
 end
+
+g.before_test('test_replication_to_master', function(cg)
+    cg.box_cfg = {
+        replication = {
+            server.build_listen_uri('master', cg.replica_set.id),
+            server.build_listen_uri('replica', cg.replica_set.id),
+        },
+        replication_timeout = 0.1,
+    }
+    cg.master = cg.replica_set:build_and_add_server{
+        alias = 'master',
+        box_cfg = cg.box_cfg,
+    }
+    cg.replica = cg.replica_set:build_and_add_server{
+        alias = 'replica',
+        box_cfg = cg.box_cfg,
+    }
+end)
+
+g.test_replication_to_master = function(cg)
+    prepare(cg)
+    cg.master:wait_for_vclock_of(cg.replica)
+    t.helpers.retrying({}, function()
+        cg.master:assert_follows_upstream(cg.replica:get_instance_id())
+    end)
+end


### PR DESCRIPTION
commit 04aef9a9e0b9e6e3550e9413a0022cf3956f48d6
Author: Serge Petrenko <sergepetrenko@tarantool.org>
Date:   Thu Aug 24 11:28:39 2023 +0300

    box: fix force recovery for transactions with local rows
    
    Force recovery first tries to collect all rows of a transaction into a
    single list, and only then applies those rows.
    
    The problem was that it collected rows based on the row replica_id. For
    local rows replica_id is set to 0, but actually such rows can be part
    of a transaction coming from any instance.
    
    Fix recovery of such rows
    
    Follow-up #8746
    Follow-up #7932
    
    NO_DOC=bugfix
    NO_CHANGELOG=the broken behaviour couldn't be seen due to bug #8746

commit ce9444bfee4ccc08c6629d064a9a28393cccfaf5
Author: Serge Petrenko <sergepetrenko@tarantool.org>
Date:   Wed Aug 23 14:10:59 2023 +0300

    box: get rid of dummy NOPs after transactions ending with local rows
    
    In order to preserve transaction boundaries over replication, Tarantool
    writes a global NOP row after the last transaction row, if this row
    happens to be local. This is done to make sure that the is_commit flag,
    which is set only in the last transaction row, reaches the replica. This
    wouldn't happen if the last row was local.
    
    This workaround works fine for transactions completely authored by one
    instance: when both global and local rows come from operations of a
    single master.
    
    However, it's possible to append local rows to a remote master's
    transaction on a replica. For example, one can use on_replace triggers
    to write to replica's local space on each new transaction coming from
    master.
    
    In this case essentially a global NOP entry is added at the end of a
    remote master's transaction. This leads to several problems.
    
    First of all, this bumps replica's LSN, which is counter-intuitive,
    given that the replica might even be read-only. Besides, in a star
    topology this leads to master being unable to connect to the replica
    later on due to their vclocks becoming incompatible.
    
    Secondly, even if replication channel between master and replica is
    bidirectional, it creates a new row which should be replicated from
    replica to master, but at the same time is the last row of the master's
    transaction. Once master receives this row, it breaks its connection to
    replica due to transaction boundary violation (the last row of the
    transaction is received without its beginning).
    
    Adding a NOP row became extraneous since the previous commit, which made
    relay find transaction boundaries by itself.
    
    Closes #8958
    
    NO_DOC=bugfix

commit 4f16ab8f080ebe827f6eabbff37d026403e47203
Author: Serge Petrenko <sergepetrenko@tarantool.org>
Date:   Thu Sep 7 17:47:44 2023 +0300

    relay: send rows transactionally
    
    Some time ago we started writing transaction boundaries to WAL and
    respecting them in the replication stream: replicas wait for a full
    transaction receipt before applying it.
    
    However, during all these changes relay remained transaction-agnostic:
    it simply read single rows from WAL and sent them over to the receiver.
    
    This lead to a handful of ugly crutches: for example, tsn is not always
    equal to the lsn of the first global row of the transaction: if the
    first low is local, tsn is deduced from the first global row of the
    transaction.
    
    Also a dummy NOP was appended to the end of a transaction ending by a
    local row, so that is_commit flag wasn't lost by the replication.
    
    Let's make relay read a full transaction, filter out all the unnecessary
    rows, set the transaction boundaries accordingly and then send the
    transaction at once.
    
    Since in relay a single fiber sends data to the remote peer, there is no
    chance for a heartbeat to get in between rows of a single transaction:
    they're all sent at once. Hence the deletion of a corresponding guard
    `relay->is_sending_tx`.
    
    Prerequisite #8958
    
    NO_DOC=internal change
    NO_CHANGELOG=internal change
    NO_TEST=covered by existing tests

commit 5756f956bcda75b561ca5897d0c1f65a398527c5
Author: Serge Petrenko <sergepetrenko@tarantool.org>
Date:   Thu Jul 27 14:36:56 2023 +0300

    wal: fix transaction boundaries for replicated transactions
    
    Transaction boundaries were not updated correctly for transactions in
    which local space writes were made from a replication trigger. Existing
    transaction boundaries and row flags from the master were written as is
    on the replica. Actually, the replica should recalculate transaction
    boundaries and even WAIT_SYNC/WAIT_ACK flags.
    
    Transaction boundaries should be recalculated when a replica appends a
    local write at the end of the master's transaction, and
    WAIT_SYNC/WAIT_ACK should be overwritten when nopifying synchronous
    transactions coming from an old term.
    
    The latter fix has uncovered the bug in skipping outdated synchronous
    transactions: if one replica replaces a transaction from an old term
    with NOPs and then passes that transaction to the other replica, the
    other replica raises a split brain error. It believes the NOPs are an
    async transaction form an old term. This worked before the fix, because
    the rows were written with the original WAIT_ACK = true bit. Now this
    is fixed properly: we allow fully NOP async tranasctions from the old
    term.
    
    Closes #8746
    
    NO_DOC=bugfix
    NO_CHANGELOG=covered by the next commit

Closes #8746
Closes #8958