### PR TITLE
test: allow to omit message in ok/is/isnt unit test helpers

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -82,7 +82,7 @@ create_unit_test(PREFIX rope_avl
 )
 create_unit_test(PREFIX rope_stress
                  SOURCES rope_stress.c
-                 LIBRARIES salad
+                 LIBRARIES salad unit
 )
 create_unit_test(PREFIX rope
                  SOURCES rope.c

--- a/test/unit/bps_tree_view.c
+++ b/test/unit/bps_tree_view.c
@@ -139,20 +139,20 @@ test_first(void)
 		test_tree_do_insert(&tree, i);
 	it = test_tree_view_first(&view);
 	p = test_tree_view_iterator_get_elem(&view, &it);
-	is(p, NULL, "empty view first after tree change")
+	is(p, NULL, "empty view first after tree change");
 	test_tree_view_destroy(&view);
 
 	test_tree_view_create(&view, &tree);
 	it = test_tree_view_first(&view);
 	p = test_tree_view_iterator_get_elem(&view, &it);
 	ok(p != NULL && *p == 0,
-	   "non-empty view first before tree change")
+	   "non-empty view first before tree change");
 	for (int i = 0; i < 100; i++)
 		test_tree_delete(&tree, i);
 	it = test_tree_view_first(&view);
 	p = test_tree_view_iterator_get_elem(&view, &it);
 	ok(p != NULL && *p == 0,
-	   "non-empty view first after tree change")
+	   "non-empty view first after tree change");
 	test_tree_view_destroy(&view);
 
 	test_tree_destroy(&tree);
@@ -179,20 +179,20 @@ test_last(void)
 		test_tree_do_insert(&tree, i);
 	it = test_tree_view_last(&view);
 	p = test_tree_view_iterator_get_elem(&view, &it);
-	is(p, NULL, "empty view last after tree change")
+	is(p, NULL, "empty view last after tree change");
 	test_tree_view_destroy(&view);
 
 	test_tree_view_create(&view, &tree);
 	it = test_tree_view_last(&view);
 	p = test_tree_view_iterator_get_elem(&view, &it);
 	ok(p != NULL && *p == 999,
-	   "non-empty view last before tree change")
+	   "non-empty view last before tree change");
 	for (int i = 900; i < 1000; i++)
 		test_tree_delete(&tree, i);
 	it = test_tree_view_last(&view);
 	p = test_tree_view_iterator_get_elem(&view, &it);
 	ok(p != NULL && *p == 999,
-	   "non-empty view last after tree change")
+	   "non-empty view last after tree change");
 	test_tree_view_destroy(&view);
 
 	test_tree_destroy(&tree);

--- a/test/unit/crypto.c
+++ b/test/unit/crypto.c
@@ -105,7 +105,7 @@ test_aes128_codec(void)
 	rc = crypto_codec_encrypt(c, iv2, plain, plain_size,
 				  buffer2, buffer_size);
 	is(rc, 16, "encrypt with different IV and the same number of written "\
-	   "bytes returned")
+	   "bytes returned");
 	isnt(memcmp(buffer2, buffer1, rc), 0,
 	     "the encrypted data looks different");
 	rc = crypto_codec_decrypt(c, iv2, buffer2, 16, buffer1, buffer_size);

--- a/test/unit/event.c
+++ b/test/unit/event.c
@@ -63,9 +63,9 @@ test_basic(void)
 		old = event_find_trigger(event, trg_name);
 		is(old, &func, "New trigger must be found");
 		ok(event_has_triggers(event), "Event must not be empty");
-		is(func_destroy_count, 0, "Func must not be destroyed yet")
+		is(func_destroy_count, 0, "Func must not be destroyed yet");
 		event_reset_trigger(event, trg_name, NULL);
-		is(func_destroy_count, 1, "Func must be destroyed")
+		is(func_destroy_count, 1, "Func must be destroyed");
 		old = event_find_trigger(event, trg_name);
 		is(old, NULL, "Deleted trigger must not be found");
 		ok(!event_has_triggers(event), "Event must be empty");
@@ -248,7 +248,7 @@ test_event_iterator_stability_del_step(int breakpoint, const char *del_mask,
 	const char *name = NULL;
 	for (int i = 0; i <= breakpoint; i++) {
 		bool ok = event_trigger_iterator_next(&it, &trg, &name);
-		ok(ok, "Iterator must not be exhausted yet")
+		ok(ok, "Iterator must not be exhausted yet");
 		const char *trg_name = tt_sprintf("%d", i);
 		is(strcmp(name, trg_name), 0,
 		   "Triggers must be traversed in reversed order");
@@ -314,7 +314,7 @@ test_event_iterator_stability_replace_step(int breakpoint,
 	const char *name = NULL;
 	for (int i = 0; i <= breakpoint; i++) {
 		bool ok = event_trigger_iterator_next(&it, &trg, &name);
-		ok(ok, "Iterator must not be exhausted yet")
+		ok(ok, "Iterator must not be exhausted yet");
 		const char *trg_name = tt_sprintf("%d", i);
 		is(strcmp(name, trg_name), 0,
 		   "Triggers must be traversed in reversed order");
@@ -328,7 +328,7 @@ test_event_iterator_stability_replace_step(int breakpoint,
 	ok(event_has_triggers(event), "Event must not be empty");
 	for (int i = breakpoint + 1; i < trigger_num; ++i) {
 		bool ok = event_trigger_iterator_next(&it, &trg, &name);
-		ok(ok, "Traversal must continue")
+		ok(ok, "Traversal must continue");
 		const char *trg_name = tt_sprintf("%d", i);
 		is(strcmp(name, trg_name), 0,
 		   "Triggers must be traversed in reversed order");

--- a/test/unit/json.c
+++ b/test/unit/json.c
@@ -42,7 +42,7 @@ test_basic()
 	is_next_key("field3");
 	is_next_index(3, 4);
 
-	reset_to_new_path("[3].field[2].field")
+	reset_to_new_path("[3].field[2].field");
 	is_next_index(3, 2);
 	is_next_key("field");
 	is_next_index(3, 1);
@@ -141,25 +141,26 @@ test_errors()
 		   "error on position %d for <%s>", errpos, path);
 	}
 
-	reset_to_new_path("f.[2]")
+	reset_to_new_path("f.[2]");
 	struct json_token token;
 	json_lexer_next_token(&lexer, &token);
-	is(json_lexer_next_token(&lexer, &token), 3, "can not write <field.[index]>")
+	is(json_lexer_next_token(&lexer, &token), 3,
+	   "can not write <field.[index]>");
 
-	reset_to_new_path("[1]key")
+	reset_to_new_path("[1]key");
 	json_lexer_next_token(&lexer, &token);
 	is(json_lexer_next_token(&lexer, &token), 4, "can not omit '.' before "\
 	   "not a first key out of []");
 
-	reset_to_new_path("f.")
+	reset_to_new_path("f.");
 	json_lexer_next_token(&lexer, &token);
 	is(json_lexer_next_token(&lexer, &token), 3, "error in leading <.>");
 
-	reset_to_new_path("fiel d1")
+	reset_to_new_path("feel d1");
 	json_lexer_next_token(&lexer, &token);
 	is(json_lexer_next_token(&lexer, &token), 5, "space inside identifier");
 
-	reset_to_new_path("field\t1")
+	reset_to_new_path("field\t1");
 	json_lexer_next_token(&lexer, &token);
 	is(json_lexer_next_token(&lexer, &token), 6, "tab inside identifier");
 

--- a/test/unit/lua_func_adapter.c
+++ b/test/unit/lua_func_adapter.c
@@ -104,7 +104,7 @@ test_tuple(void)
 		func_adapter_pop_tuple(func, &ctx, tuples + i);
 		isnt(tuples[i], NULL, "Returned tuple must not be NULL");
 	}
-	ok(func_adapter_is_null(func, &ctx), "Expected null - no values left")
+	ok(func_adapter_is_null(func, &ctx), "Expected null - no values left");
 	func_adapter_end(func, &ctx);
 	func_adapter_destroy(func);
 	lua_settop(tarantool_L, 0);
@@ -158,7 +158,7 @@ test_string(void)
 	strncpy(buf, s1, s1_len);
 	strcpy(buf + s1_len, s2);
 	is(strcmp(retval, buf), 0, "Expected %s", buf);
-	ok(func_adapter_is_null(func, &ctx), "Expected null - no values left")
+	ok(func_adapter_is_null(func, &ctx), "Expected null - no values left");
 	func_adapter_end(func, &ctx);
 	func_adapter_destroy(func);
 	lua_settop(tarantool_L, 0);
@@ -185,13 +185,13 @@ test_null(void)
 	int rc = func_adapter_call(func, &ctx);
 	fail_if(rc != 0);
 	for (size_t i = 0; i < null_count; ++i) {
-		ok(func_adapter_is_null(func, &ctx), "Expected null")
+		ok(func_adapter_is_null(func, &ctx), "Expected null");
 		func_adapter_pop_null(func, &ctx);
 	}
 	ok(func_adapter_is_double(func, &ctx), "Expected double");
 	double double_retval = 0;
 	func_adapter_pop_double(func, &ctx, &double_retval);
-	ok(func_adapter_is_null(func, &ctx), "Expected null - no values left")
+	ok(func_adapter_is_null(func, &ctx), "Expected null - no values left");
 	func_adapter_end(func, &ctx);
 	func_adapter_destroy(func);
 	lua_settop(tarantool_L, 0);

--- a/test/unit/lua_utils.c
+++ b/test/unit/lua_utils.c
@@ -131,7 +131,7 @@ test_tolstring_strict(lua_State *L)
 	lua_pop(L, 1);
 
 	lua_pushnumber(L, 42);
-	is(luaL_tolstring_strict(L, -1, &len), NULL, "number")
+	is(luaL_tolstring_strict(L, -1, &len), NULL, "number");
 	lua_pop(L, 1);
 
 	footer();

--- a/test/unit/prbuf.c
+++ b/test/unit/prbuf.c
@@ -468,7 +468,7 @@ test_buffer_prepared_large(void)
 	fill_buffer(&buf, payload_small, payload_size, entry_count);
 	int entry_count_after = count_records(mem, buffer_size);
 	ok(entry_count_after == entry_count, "entry count after is %d",
-	   entry_count_after)
+	   entry_count_after);
 
 	footer();
 	check_plan();

--- a/test/unit/raft.c
+++ b/test/unit/raft.c
@@ -2267,7 +2267,7 @@ raft_test_pre_vote(void)
 
 	raft_run_for(node.cfg_death_timeout / 2);
 	is(raft_leader_idle(&node.raft), node.cfg_death_timeout / 2,
-	   "leader_idle counts from 0 on a previous leader")
+	   "leader_idle counts from 0 on a previous leader");
 
 	raft_node_cfg_is_enabled(&node, false);
 

--- a/test/unit/swim.c
+++ b/test/unit/swim.c
@@ -358,7 +358,7 @@ swim_test_probe(void)
 	is(swim_probe_member(s1, NULL), -1, "probe validates URI");
 	is(swim_probe_member(s1, s2_uri), 0, "send probe");
 	is(swim_cluster_wait_fullmesh(cluster, 0.1), 0,
-	   "receive ACK on probe and get fullmesh")
+	   "receive ACK on probe and get fullmesh");
 
 	swim_cluster_delete(cluster);
 	swim_finish_test();
@@ -514,7 +514,7 @@ swim_test_quit(void)
 	swim_member_unref(s0_self);
 	is(swim_cluster_wait_status_everywhere(cluster, 0, MEMBER_LEFT, 0),
 	   0, "'quit' is sent to all the members without delays between "\
-	   "dispatches")
+	   "dispatches");
 	/*
 	 * Return the instance back and check that it refutes the
 	 * old LEFT status.
@@ -557,7 +557,7 @@ swim_test_quit(void)
 	swim_cluster_unblock_io(cluster, 1);
 	is(swim_cluster_wait_incarnation(cluster, 1, 1, 1, 1, 0), 0,
 	   "S2 finally got 'quit' message from S1, but with its 'own' UUID - "\
-	   "refute it")
+	   "refute it");
 	swim_cluster_delete(cluster);
 
 	/**
@@ -1081,7 +1081,7 @@ swim_test_member_by_uuid(void)
 	struct swim *s1 = swim_cluster_member(cluster, 0);
 	const struct swim_member *s1_self = swim_self(s1);
 	is(swim_member_by_uuid(s1, swim_member_uuid(s1_self)), s1_self,
-	   "found by UUID")
+	   "found by UUID");
 
 	struct tt_uuid uuid = uuid_nil;
 	uuid.time_low = 1000;

--- a/test/unit/swim_errinj.c
+++ b/test/unit/swim_errinj.c
@@ -165,7 +165,7 @@ swim_test_payload_refutation(void)
 	swim_cluster_set_drop_out(cluster, 2, 100);
 	is(swim_cluster_wait_payload_everywhere(cluster, 0, s0_new_payload,
 						s0_new_payload_size, 3), 0,
-	  "S3 learns S1's payload from S2")
+	  "S3 learns S1's payload from S2");
 
 	swim_cluster_delete(cluster);
 	swim_finish_test();

--- a/test/unit/tuple_bigref.c
+++ b/test/unit/tuple_bigref.c
@@ -104,12 +104,12 @@ test_one()
 	tuple = create_tuple();
 
 	is(tuple_count, 1, "allocated");
-	is(tuple_bigref_tuple_count(), 0, "no bigrefs")
+	is(tuple_bigref_tuple_count(), 0, "no bigrefs");
 
 	tuple_unref(tuple);
 
 	is(tuple_count, 0, "deallocated");
-	is(tuple_bigref_tuple_count(), 0, "no bigrefs")
+	is(tuple_bigref_tuple_count(), 0, "no bigrefs");
 
 	/* few refs */
 	tuple = create_tuple();
@@ -117,13 +117,13 @@ test_one()
 		tuple_ref(tuple);
 
 	is(tuple_count, 1, "allocated");
-	is(tuple_bigref_tuple_count(), 0, "no bigrefs")
+	is(tuple_bigref_tuple_count(), 0, "no bigrefs");
 
 	for (size_t j = 0; j < FEW_REFS; j++)
 		tuple_unref(tuple);
 
 	is(tuple_count, 0, "deallocated");
-	is(tuple_bigref_tuple_count(), 0, "no bigrefs")
+	is(tuple_bigref_tuple_count(), 0, "no bigrefs");
 
 	/* many refs */
 	tuple = create_tuple();
@@ -131,13 +131,13 @@ test_one()
 		tuple_ref(tuple);
 
 	is(tuple_count, 1, "allocated");
-	is(tuple_bigref_tuple_count(), 1, "bigrefs")
+	is(tuple_bigref_tuple_count(), 1, "bigrefs");
 
 	for (size_t j = 0; j < MANY_REFS; j++)
 		tuple_unref(tuple);
 
 	is(tuple_count, 0, "all deallocated");
-	is(tuple_bigref_tuple_count(), 0, "no bigrefs")
+	is(tuple_bigref_tuple_count(), 0, "no bigrefs");
 
 	footer();
 	check_plan();
@@ -160,13 +160,13 @@ test_batch()
 		tuples[i] = create_tuple();
 
 	is(tuple_count, TEST_MAX_TUPLE_COUNT, "all allocated");
-	is(tuple_bigref_tuple_count(), 0, "no bigrefs")
+	is(tuple_bigref_tuple_count(), 0, "no bigrefs");
 
 	for (size_t i = 0; i < TEST_MAX_TUPLE_COUNT; i++)
 		tuple_unref(tuples[i]);
 
 	is(tuple_count, 0, "all deallocated");
-	is(tuple_bigref_tuple_count(), 0, "no bigrefs")
+	is(tuple_bigref_tuple_count(), 0, "no bigrefs");
 
 	/* few refs */
 	for (size_t i = 0; i < TEST_MAX_TUPLE_COUNT; i++)
@@ -176,14 +176,14 @@ test_batch()
 			tuple_ref(tuples[i]);
 
 	is(tuple_count, TEST_MAX_TUPLE_COUNT, "all allocated");
-	is(tuple_bigref_tuple_count(), 0, "no bigrefs")
+	is(tuple_bigref_tuple_count(), 0, "no bigrefs");
 
 	for (size_t i = 0; i < TEST_MAX_TUPLE_COUNT; i++)
 		for (size_t j = 0; j < FEW_REFS; j++)
 			tuple_unref(tuples[i]);
 
 	is(tuple_count, 0, "all deallocated");
-	is(tuple_bigref_tuple_count(), 0, "no bigrefs")
+	is(tuple_bigref_tuple_count(), 0, "no bigrefs");
 
 	/* many refs */
 	for (size_t i = 0; i < TEST_MAX_TUPLE_COUNT; i++)
@@ -194,7 +194,7 @@ test_batch()
 	}
 
 	is(tuple_count, TEST_MAX_TUPLE_COUNT, "all allocated");
-	is(tuple_bigref_tuple_count(), TEST_MAX_TUPLE_COUNT, "all bigrefs")
+	is(tuple_bigref_tuple_count(), TEST_MAX_TUPLE_COUNT, "all bigrefs");
 
 	for (size_t i = 0; i < TEST_MAX_TUPLE_COUNT; i++) {
 		for (size_t j = 0; j < MANY_REFS; j++)
@@ -202,7 +202,7 @@ test_batch()
 	}
 
 	is(tuple_count, 0, "all deallocated");
-	is(tuple_bigref_tuple_count(), 0, "no bigrefs")
+	is(tuple_bigref_tuple_count(), 0, "no bigrefs");
 
 	footer();
 	check_plan();
@@ -251,7 +251,7 @@ test_random()
 		tuple_unref(allocated_tuples[0]);
 
 	ok(no_erros, "no errors");
-	is(tuple_bigref_tuple_count(), 0, "no bigrefs")
+	is(tuple_bigref_tuple_count(), 0, "no bigrefs");
 
 	footer();
 	check_plan();

--- a/test/unit/tweaks.c
+++ b/test/unit/tweaks.c
@@ -139,7 +139,7 @@ test_bool_var(void)
 	v.type = TWEAK_VALUE_BOOL;
 	v.bval = false;
 	is(tweak_set(t, &v), 0, "set tweak value");
-	is(bool_var, false, "var value after set")
+	is(bool_var, false, "var value after set");
 	tweak_get(t, &v);
 	is(v.type, TWEAK_VALUE_BOOL, "tweak value type after set");
 	is(v.bval, false, "tweak value after set");
@@ -178,7 +178,7 @@ test_int_var(void)
 	v.type = TWEAK_VALUE_INT;
 	v.ival = 11;
 	is(tweak_set(t, &v), 0, "set tweak value");
-	is(int_var, 11, "var value after set")
+	is(int_var, 11, "var value after set");
 	tweak_get(t, &v);
 	is(v.type, TWEAK_VALUE_INT, "tweak value type after set");
 	is(v.ival, 11, "tweak value after set");
@@ -217,14 +217,14 @@ test_double_var(void)
 	v.type = TWEAK_VALUE_INT;
 	v.ival = 11;
 	is(tweak_set(t, &v), 0, "set tweak value to int");
-	is(double_var, 11, "var value after set to int")
+	is(double_var, 11, "var value after set to int");
 	tweak_get(t, &v);
 	is(v.type, TWEAK_VALUE_DOUBLE, "tweak value type after set to int");
 	is(v.dval, 11, "tweak value after set to int");
 	v.type = TWEAK_VALUE_DOUBLE;
 	v.dval = 0.5;
 	is(tweak_set(t, &v), 0, "set tweak value to double");
-	is(double_var, 0.5, "var value after set to double")
+	is(double_var, 0.5, "var value after set to double");
 	tweak_get(t, &v);
 	is(v.type, TWEAK_VALUE_DOUBLE, "tweak value type after set to double");
 	is(v.dval, 0.5, "tweak value after set to double");

--- a/test/unit/unit.c
+++ b/test/unit/unit.c
@@ -1,5 +1,6 @@
 #include "unit.h"
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdarg.h>
 
@@ -19,12 +20,15 @@ _space(FILE *stream)
 }
 
 void
-plan(int count)
+_plan(int count, bool tap)
 {
 	++level;
 	plan_test[level] = count;
 	tests_done[level] = 0;
 	tests_failed[level] = 0;
+
+	if (tap && level == 0)
+		printf("TAP version 13\n");
 
 	_space(stdout);
 	printf("%d..%d\n", 1, plan_test[level]);

--- a/test/unit/unit.c
+++ b/test/unit/unit.c
@@ -60,19 +60,24 @@ check_plan(void)
 	return r;
 }
 
-int
-_ok(int condition, const char *fmt, ...)
+void
+_ok(int condition, const char *expr, const char *file, int line,
+    const char *fmt, ...)
 {
 	va_list ap;
 
 	_space(stdout);
 	printf("%s %d - ", condition ? "ok" : "not ok", ++tests_done[level]);
-	if (!condition)
-		tests_failed[level]++;
 	va_start(ap, fmt);
 	vprintf(fmt, ap);
 	printf("\n");
 	va_end(ap);
-	return condition;
+	if (!condition) {
+		tests_failed[level]++;
+		_space(stderr);
+		fprintf(stderr, "#   Failed test `%s'\n", expr);
+		_space(stderr);
+		fprintf(stderr, "#   in %s at line %d\n", file, line);
+	}
 }
 

--- a/test/unit/vclock.cc
+++ b/test/unit/vclock.cc
@@ -346,7 +346,8 @@ test_fromstring()
 	struct vclock tmp;						\
 	vclock_create(&tmp);						\
 	is(vclock_from_string(&tmp, str), offset,			\
-		"fromstring \"%s\" => %u", str, offset)})
+		"fromstring \"%s\" => %u", str, offset);		\
+})
 
 int
 test_fromstring_invalid()

--- a/test/unit/vy_mem.c
+++ b/test/unit/vy_mem.c
@@ -48,9 +48,9 @@ test_basic(void)
 
 	/* Check version  */
 	entry = vy_mem_insert_template(mem, &stmts[4]);
-	is(mem->version, 8, "vy_mem->version")
+	is(mem->version, 8, "vy_mem->version");
 	vy_mem_commit_stmt(mem, entry);
-	is(mem->version, 9, "vy_mem->version")
+	is(mem->version, 9, "vy_mem->version");
 
 	/* Clean up */
 	vy_mem_delete(mem);

--- a/test/unit/vy_point_lookup.c
+++ b/test/unit/vy_point_lookup.c
@@ -96,19 +96,19 @@ test_basic()
 
 	struct vy_lsm *pk = vy_lsm_new(&lsm_env, &cache_env, &mem_env,
 				       index_def, format, NULL, 0);
-	isnt(pk, NULL, "lsm is not NULL")
+	isnt(pk, NULL, "lsm is not NULL");
 
 	struct vy_range *range = vy_range_new(1, vy_entry_none(),
 					      vy_entry_none(), pk->cmp_def);
 
-	isnt(pk, NULL, "range is not NULL")
+	isnt(pk, NULL, "range is not NULL");
 	vy_lsm_add_range(pk, range);
 
 	struct rlist read_views = RLIST_HEAD_INITIALIZER(read_views);
 
 	char dir_tmpl[] = "./vy_point_test.XXXXXX";
 	char *dir_name = mkdtemp(dir_tmpl);
-	isnt(dir_name, NULL, "temp dir name is not NULL")
+	isnt(dir_name, NULL, "temp dir name is not NULL");
 	char path[PATH_MAX];
 	strcpy(path, dir_name);
 	strcat(path, "/512");

--- a/test/unit/xmalloc.c
+++ b/test/unit/xmalloc.c
@@ -12,7 +12,7 @@ test_xmalloc(void)
 	plan(1);
 	const int size = 9000;
 	char *p = xmalloc(size);
-	isnt(p, NULL, "p != NULL");
+	isnt(p, NULL);
 	if (p != NULL) {
 		memset(p, 'x', size);
 		free(p);
@@ -29,14 +29,14 @@ test_xcalloc(void)
 	const int nmemb = 42;
 	const int size = 9000;
 	char *p = xcalloc(nmemb, size);
-	isnt(p, NULL, "p != NULL");
+	isnt(p, NULL);
 	if (p != NULL) {
 		bool is_zeroed = true;
 		for (int i = 0; i < nmemb * size && is_zeroed; i++) {
 			if (p[i] != 0)
 				is_zeroed = false;
 		}
-		ok(is_zeroed, "p is zeroed");
+		ok(is_zeroed);
 		free(p);
 	}
 	check_plan();
@@ -50,18 +50,18 @@ test_xrealloc(void)
 	plan(3);
 	const int size = 9000;
 	char *p = xrealloc(NULL, size);
-	isnt(p, NULL, "p != NULL on alloc");
+	isnt(p, NULL);
 	if (p != NULL)
 		memset(p, 'x', size);
 	p = xrealloc(p, size * 2);
-	isnt(p, NULL, "p != NULL on realloc");
+	isnt(p, NULL);
 	if (p != NULL) {
 		bool is_same = true;
 		for (int i = 0; i < size && is_same; i++) {
 			if (p[i] != 'x')
 				is_same = false;
 		}
-		ok(is_same, "p is same after realloc");
+		ok(is_same);
 		memset(p, 'x', size * 2);
 		free(p);
 	}
@@ -76,14 +76,14 @@ test_xstrdup(void)
 	plan(3);
 	const int size = 9000;
 	char *s = xmalloc(size);
-	isnt(s, NULL, "s != NULL");
+	isnt(s, NULL);
 	if (s != NULL) {
 		memset(s, 'x', size);
 		s[size - 1] = 0;
 		char *copy = xstrdup(s);
-		isnt(copy, NULL, "copy != NULL");
+		isnt(copy, NULL);
 		if (copy != NULL) {
-			is(strcmp(s, copy), 0, "strcmp(s, copy) == 0");
+			is(strcmp(s, copy), 0);
 			free(copy);
 		}
 		free(s);
@@ -100,18 +100,17 @@ test_xstrndup(void)
 	const int size = 9000;
 	const int n = size / 2;
 	char *s = xmalloc(size);
-	isnt(s, NULL, "s != NULL");
+	isnt(s, NULL);
 	if (s != NULL) {
 		memset(s, 'x', size);
 		s[size - 1] = 0;
 		char *copy = xstrndup(s, n);
-		isnt(copy, NULL, "copy != NULL");
+		isnt(copy, NULL);
 		if (copy != NULL) {
-			is(strlen(copy), (size_t)n, "strlen(copy) == n");
-			is(strncmp(s, copy, n), 0, "strncmp(s, copy, n) == 0");
-			ok(strncmp(s, copy, n + 1) > 0,
-			   "strncmp(s, copy, n + 1) > 0");
-			ok(strcmp(s, copy) > 0, "strcmp(s, copy) > 0");
+			is(strlen(copy), (size_t)n);
+			is(strncmp(s, copy, n), 0);
+			ok(strncmp(s, copy, n + 1) > 0);
+			ok(strcmp(s, copy) > 0);
 			free(copy);
 		}
 		free(s);

--- a/test/unit/xmalloc.c
+++ b/test/unit/xmalloc.c
@@ -36,7 +36,7 @@ test_xcalloc(void)
 			if (p[i] != 0)
 				is_zeroed = false;
 		}
-		ok(is_zeroed, "p is zeroed")
+		ok(is_zeroed, "p is zeroed");
 		free(p);
 	}
 	check_plan();

--- a/test/unit/xrow.cc
+++ b/test/unit/xrow.cc
@@ -407,16 +407,16 @@ test_xrow_encode_dml(void)
 	is(memcmp(data, r.key, strlen(r.key)), 0, "decoded key");
 	data += strlen(r.key);
 
-	is(mp_decode_uint(&data), IPROTO_OPS, "decoded ops key")
+	is(mp_decode_uint(&data), IPROTO_OPS, "decoded ops key");
 	is(memcmp(data, r.ops, strlen(r.ops)), 0, "decoded ops");
 	data += strlen(r.ops);
 
-	is(mp_decode_uint(&data), IPROTO_TUPLE_META, "decoded meta key")
+	is(mp_decode_uint(&data), IPROTO_TUPLE_META, "decoded meta key");
 	is(memcmp(data, r.tuple_meta, strlen(r.tuple_meta)), 0,
 	   "decoded meta");
 	data += strlen(r.tuple_meta);
 
-	is(mp_decode_uint(&data), IPROTO_TUPLE, "decoded tuple key")
+	is(mp_decode_uint(&data), IPROTO_TUPLE, "decoded tuple key");
 	is(memcmp(data, r.tuple, strlen(r.tuple)), 0, "decoded tuple");
 	data += strlen(r.tuple);
 


### PR DESCRIPTION
The main goal of this PR is to make the message argument of ok/is/isnt unit test helpers optional because it's really annoying to specify it after each check.

Along the way, it also does some cleanup:
 - Removes duplicated code from `unit.h`.
 - Adds missing trailing semicolons after ok/is/isnt.