### PR TITLE
test: fix flaky gh_7515_sync_node_sees_leader_hang

### DIFF
--- a/test/replication-luatest/gh_7515_sync_node_sees_leader_hang_test.lua
+++ b/test/replication-luatest/gh_7515_sync_node_sees_leader_hang_test.lua
@@ -9,6 +9,7 @@ local g = t.group('gh_7515_notice_leader_hang_during_sync')
 g.before_each(function(cg)
     cg.replica_set = replica_set:new{}
     local box_cfg = {
+        election_fencing_mode = 'off',
         replication_timeout = 0.1,
         replication = {
             server.build_listen_uri('server1', cg.replica_set.id),


### PR DESCRIPTION
The test checks, whether the instance notices leader hang during sync. For that it stops server2 and generates some data on the master (server1). The problem is, when connection to server3 flakes, server1 resigns and becomes read only due to fencing enabled.

Let's disable fencing for this test, as we don't want automatic leader resigning here.

Closes tarantool/tarantool-qa#325

NO_CHANGELOG=test
NO_DOC=test