### PR TITLE
ci: fix an error in workflow

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -10,10 +10,9 @@ on:
     paths:
       - '.github/workflows/fuzzing.yml'
       - 'src/**'
+      - '!src/**.lua'
       - 'test/fuzz/**'
       - 'test/static/corpus/**'
-    paths-ignore:
-      - '**.lua'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
 


### PR DESCRIPTION
Commit f14cb97d ("ci: update paths in a fuzzing workflow") breaks fuzzing workflow because one may only define one of `paths` and `paths-ignore` for a single event. The patch fixes that.

NO_CHANGELOG=ci
NO_DOC=ci
NO_TEST=ci