### PR TITLE
fiber: fix use-after-free on fiber destroy/recycle

### DIFF
--- a/changelogs/unreleased/gh-9020-fix-use-after-free-on-fiber-finish.md
+++ b/changelogs/unreleased/gh-9020-fix-use-after-free-on-fiber-finish.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fixed a use-after-free bug in fiber recycling code (gh-9020).


### PR DESCRIPTION
When fiber region is freed/destroyed and ENABLE_BACKTRACE is set then `fiber_on_gc_truncate` callback is called. At this time both `used` argument and `fiber->gc_initial_size` are equal to 0. Thus `fiber->first_alloc_bt` is accessed which is already freed.

With a bad luck freeing fiber region can put slab back into slab arena. So writing after free can change memory used by another thread.

Closes #9020