### PR TITLE
iproto: fix use-after-free in net_end_join

### DIFF
--- a/changelogs/unreleased/gh-9037-fix-heap-use-after-free.md
+++ b/changelogs/unreleased/gh-9037-fix-heap-use-after-free.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fixed a use-after-free bug in iproto server code (gh-9037).

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -2669,8 +2669,9 @@ net_end_join(struct cmsg *m)
 {
 	struct iproto_msg *msg = (struct iproto_msg *) m;
 	struct iproto_connection *con = msg->connection;
+	struct ibuf *ibuf = msg->p_ibuf;
 
-	msg->p_ibuf->rpos += msg->len;
+	ibuf->rpos += msg->len;
 	iproto_msg_delete(msg);
 
 	assert(! ev_is_active(&con->input));
@@ -2678,7 +2679,7 @@ net_end_join(struct cmsg *m)
 	 * Enqueue any messages if they are in the readahead
 	 * queue. Will simply start input otherwise.
 	 */
-	if (iproto_enqueue_batch(con, msg->p_ibuf) != 0)
+	if (iproto_enqueue_batch(con, ibuf) != 0)
 		iproto_connection_close(con);
 }
 


### PR DESCRIPTION
`msg` is used after it is freed in `iproto_msg_delete`.

Close #9037