### PR TITLE
lua/msgpack: add details to msgpack.decode error

### DIFF
--- a/changelogs/unreleased/gh-7968-mp-check-diag.md
+++ b/changelogs/unreleased/gh-7968-mp-check-diag.md
@@ -1,0 +1,7 @@
+## feature/lua/msgpack
+
+* Improved error reporting for `msgpack.decode`. Now, an error raised by
+  `mgpack.decode` has a detailed error message and the offset in the input
+  data. If `msgpack.decode` failed to unpack a MsgPack extension, it also
+  includes the error cause pointing to the error in the extension data
+  (gh-7986).

--- a/src/box/mp_error.cc
+++ b/src/box/mp_error.cc
@@ -204,14 +204,8 @@ mp_encode_error_one(char *data, const struct error *error)
 }
 
 static struct error *
-error_build_xc(struct mp_error *mp_error)
+error_build(struct mp_error *mp_error)
 {
-	/*
-	 * To create an error the "raw" constructor is used
-	 * because OOM error must be thrown in OOM case.
-	 * Builders returns a pointer to the static OOM error
-	 * in OOM case.
-	 */
 	struct error *err = NULL;
 	if (mp_error->type == NULL || mp_error->message == NULL ||
 	    mp_error->file == NULL) {
@@ -373,11 +367,7 @@ mp_decode_error_one(const char **data)
 		}
 	}
 
-	try {
-		err = error_build_xc(&mp_err);
-	} catch (OutOfMemory *e) {
-		assert(err == NULL && !diag_is_empty(diag_get()));
-	}
+	err = error_build(&mp_err);
 finish:
 	region_truncate(region, region_svp);
 	mp_error_destroy(&mp_err);

--- a/src/box/msgpack.c
+++ b/src/box/msgpack.c
@@ -39,6 +39,11 @@
 #include "mp_interval.h"
 #include "mp_compression.h"
 
+#include "diag.h"
+#include "error.h"
+#include "errcode.h"
+#include "trivia/util.h"
+
 static int
 msgpack_fprint_ext(FILE *file, const char **data, int depth)
 {
@@ -95,19 +100,77 @@ msgpack_check_ext_data(int8_t type, const char *data, uint32_t len)
 {
 	switch (type) {
 	case MP_DECIMAL:
-		return mp_validate_decimal(data, len);
+		if (mp_validate_decimal(data, len) != 0) {
+			diag_set(ClientError, ER_INVALID_MSGPACK,
+				 "cannot unpack decimal");
+			return -1;
+		}
+		return 0;
 	case MP_UUID:
-		return mp_validate_uuid(data, len);
+		if (mp_validate_uuid(data, len) != 0) {
+			diag_set(ClientError, ER_INVALID_MSGPACK,
+				 "cannot unpack uuid");
+			return -1;
+		}
+		return 0;
 	case MP_DATETIME:
-		return mp_validate_datetime(data, len);
+		if (mp_validate_datetime(data, len) != 0) {
+			diag_set(ClientError, ER_INVALID_MSGPACK,
+				 "cannot unpack datetime");
+			return -1;
+		}
+		return 0;
 	case MP_ERROR:
-		return mp_validate_error(data, len);
+		if (mp_validate_error(data, len) != 0) {
+			/* The error is set by error_unpack(). */
+			diag_add(ClientError, ER_INVALID_MSGPACK,
+				 "cannot unpack error");
+			return -1;
+		}
+		return 0;
 	case MP_INTERVAL:
-		return mp_validate_interval(data, len);
+		if (mp_validate_interval(data, len) != 0) {
+			diag_set(ClientError, ER_INVALID_MSGPACK,
+				 "cannot unpack interval");
+			return -1;
+		}
+		return 0;
 	case MP_COMPRESSION:
 	default:
 		return mp_check_ext_data_default(type, data, len);
 	}
+}
+
+/** Our handler invoked on mp_check() error. */
+static void
+msgpack_check_on_error(const struct mp_check_error *mperr)
+{
+	struct error *err;
+	switch (mperr->type) {
+	case MP_CHECK_ERROR_TRUNC:
+		err = diag_set(ClientError, ER_INVALID_MSGPACK,
+			       "truncated input");
+		error_set_int(err, "trunc_count", mperr->trunc_count);
+		break;
+	case MP_CHECK_ERROR_ILL:
+		err = diag_set(ClientError, ER_INVALID_MSGPACK,
+			       "illegal code");
+		break;
+	case MP_CHECK_ERROR_EXT:
+		/* The error is set by msgpack_check_ext_data(). */
+		err = diag_add(ClientError, ER_INVALID_MSGPACK,
+			       "invalid extension");
+		error_set_int(err, "ext_type", mperr->ext_type);
+		error_set_uint(err, "ext_len", mperr->ext_len);
+		break;
+	case MP_CHECK_ERROR_JUNK:
+		err = diag_set(ClientError, ER_INVALID_MSGPACK,
+			       "junk after input");
+		break;
+	default:
+		unreachable();
+	}
+	error_set_uint(err, "offset", mperr->pos - mperr->data);
 }
 
 void
@@ -116,4 +179,5 @@ msgpack_init(void)
 	mp_fprint_ext = msgpack_fprint_ext;
 	mp_snprint_ext = msgpack_snprint_ext;
 	mp_check_ext_data = msgpack_check_ext_data;
+	mp_check_on_error = msgpack_check_on_error;
 }

--- a/src/lib/core/exception.h
+++ b/src/lib/core/exception.h
@@ -271,12 +271,6 @@ public:
 	virtual void raise() { throw this; }
 };
 
-/**
- * Initialize the exception subsystem.
- */
-void
-exception_init();
-
 #define tnt_error(class, ...) ({					\
 	say_debug("%s at %s:%i", #class, __FILE__, __LINE__);		\
 	class *e = new class(__FILE__, __LINE__, ##__VA_ARGS__);	\

--- a/src/lua/msgpack.c
+++ b/src/lua/msgpack.c
@@ -581,7 +581,7 @@ lua_msgpack_decode_cdata(lua_State *L, bool check)
 		}
 		const char *p = data;
 		if (mp_check(&p, data + data_len) != 0)
-			return luaL_error(L, "msgpack.decode: invalid MsgPack");
+			return luaT_error(L);
 	}
 	struct luaL_serializer *cfg = luaL_checkserializer(L);
 	luamp_decode(L, cfg, &data);
@@ -604,7 +604,7 @@ lua_msgpack_decode_string(lua_State *L, bool check)
 	if (check) {
 		const char *p = data + offset;
 		if (mp_check(&p, data + data_len) != 0)
-			return luaL_error(L, "msgpack.decode: invalid MsgPack");
+			return luaT_error(L);
 	}
 	struct luaL_serializer *cfg = luaL_checkserializer(L);
 	const char *p = data + offset;
@@ -772,7 +772,7 @@ luamp_push_with_translation(struct lua_State *L, const char *data,
 	size_t data_len = data_end - data;
 	struct luamp_object *obj = luamp_new_object(L, data_len);
 	memcpy((char *)obj->data, data, data_len);
-	assert(mp_check(&data, data_end) == 0 && data == data_end);
+	assert(mp_check_exact(&data, data_end) == 0);
 	obj->translation = translation;
 }
 
@@ -828,10 +828,8 @@ lua_msgpack_object_from_raw(struct lua_State *L)
 	}
 	const char *p = data;
 	const char *data_end = data + data_len;
-	if (mp_check(&p, data_end) != 0 || p != data_end) {
-		return luaL_error(L, "msgpack.object_from_raw: "
-				  "invalid MsgPack");
-	}
+	if (mp_check_exact(&p, data_end) != 0)
+		return luaT_error(L);
 	struct luamp_object *obj = luamp_new_object(L, data_len);
 	memcpy((char *)obj->data, data, data_len);
 	obj->cfg = luaL_checkserializer(L);

--- a/src/main.cc
+++ b/src/main.cc
@@ -865,8 +865,6 @@ main(int argc, char **argv)
 	main_argc = argc;
 	main_argv = argv;
 
-	exception_init();
-
 	fiber_init(fiber_cxx_invoke);
 	popen_init();
 	coio_init();


### PR DESCRIPTION
With this patch, `mp_check` sets diag with detailed information about the MsgPack decoding error. The diag includes the error reason, which is appended to the error message, and the data offset, which is stored in an error payload field. Possible error reasons are: truncated input, junk after input, illegal code, invalid extension. In case of truncated input, the error also includes the `trunc_count` payload field, which is set to the number of missing MsgPack values. Failing to decode a MsgPack
extension adds two payload fields, `ext_type` and `ext_len`, and also an error cause, which is set by the extension decoder. For all extensions except the error extension, the error cause is just "cannot unpack FOO". For the error extension, it includes a detailed cause pointing to the error in the MsgPack data stored in the extension.

Currently, the `mp_check` error is reported only by the Lua msgapck decoder while other mp_check users (e.g. xrow decoder) override it. We may improve on this in future.

Examples:

```
tarantool> require('msgpack').decode('\x94\xc0')
---
- error: Invalid MsgPack - truncated input
...

tarantool> box.error.last():unpack()
---
- offset: 2
  code: 20
  base_type: ClientError
  type: ClientError
  trunc_count: 3
  message: Invalid MsgPack - truncated input
  trace:
  - file: ./src/box/msgpack.c
    line: 151
...

tarantool> require('msgpack').decode(string.char(
         >   130,  39, 170, 114, 101, 116, 117, 114, 110,  32,  46,
         >    46,  46,  33, 145, 199,  74,   3, 129,   0, 145, 134,
         >     0, 171,  67, 108, 105, 101, 110, 116,  69, 114, 114,
         >   111, 114,   1, 170,  99, 111, 110, 102, 105, 103,  46,
         >   108, 117,  97,   2, 211,   0,   0,   0,   0,   0,   0,
         >     0, 201,   3, 173,  85, 110, 107, 110, 111, 119, 110,
         >    32, 101, 114, 114, 111, 114,   4, 211,   0,   0,   0,
         >     0,   0,   0,   0,   0,   5, 211,   0,   0,   0,   0,
         >     0,   0,   0,   0))
---
- error: Invalid MsgPack - invalid extension
...

tarantool> box.error.last():unpack()
---
- code: 20
  base_type: ClientError
  prev: Invalid MsgPack - cannot unpack error
  message: Invalid MsgPack - invalid extension
  ext_len: 74
  ext_type: 3
  trace:
  - file: ./src/box/msgpack.c
    line: 161
  type: ClientError
  offset: 18
...

tarantool> box.error.last().prev:unpack()
---
- code: 20
  base_type: ClientError
  type: ClientError
  prev: Invalid MsgPack - MP_ERROR_LINE value must be MP_UINT
  message: Invalid MsgPack - cannot unpack error
  trace:
  - file: ./src/box/msgpack.c
    line: 126
...

tarantool> box.error.last().prev.prev:unpack()
---
- offset: 30
  code: 20
  base_type: ClientError
  type: ClientError
  message: Invalid MsgPack - MP_ERROR_LINE value must be MP_UINT
  trace:
  - file: ./src/box/mp_error.cc
    line: 350
...
```

Closes #7968