### PR TITLE
test: disable ASAN for `box/tx_man.test.lua`

### DIFF
--- a/test/box/tx_man.skipcond
+++ b/test/box/tx_man.skipcond
@@ -1,0 +1,7 @@
+import os
+
+# Disabled at ASAN build due to issue tarantool/tarantool-qa#324.
+if os.getenv("ASAN") == 'ON':
+    self.skip = 1
+
+# vim: set ft=python:


### PR DESCRIPTION
For some unknown reason ASAN crashes with SIGSEGV on this test during shutdown.
See tarantool/tarantool-qa#324 for details.