### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-8825-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8825-luajit-fixes.md
@@ -7,3 +7,4 @@ were fixed as part of this activity:
 * Fixed recording of `BC_VARG` with unused vararg values.
 * Initialization instructions on trace are now emitted only for the first
   member of a union.
+* Handle table unsinking in the presence of `IRFL_TAB_NOMM`.


### PR DESCRIPTION
* Handle table unsinking in the presence of IRFL_TAB_NOMM.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump