### PR TITLE
[backport/release/2.11] luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-8825-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8825-luajit-fixes.md
@@ -1,0 +1,12 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-8825). The following issues
+were fixed as part of this activity:
+
+* Prevent integer overflow while parsing long strings.
+* Fixed various `^` operator and `math.pow()` function inconsistencies.
+* Fixed parsing with predicting `next()` and `pairs()`.
+* Fixed binary number literal parsing. Parsing of binary number with a zero
+  fractional part raises error too now.
+* Fixed load forwarding optimization applied after table rehashing.
+* Fixed recording of the `BC_TSETM`.


### PR DESCRIPTION
* Fix maxslots when recording BC_TSETM.
* Fix TDUP load forwarding after table rehash.
* Fix binary number literal parsing.
* Fix maxslots when recording BC_VARG, part 3.
* test: fix flaky <unit-jit-parse.test.lua> again
* Fix predict_next() in parser.
* Revert to trival pow() optimizations to prevent inaccuracies.
* Fix pow() optimization inconsistencies.
* Improve assertions.
* Remove pow() splitting and cleanup backends.
* test: introduce `samevalues()` TAP checker
* MIPS: Add MIPS64 R6 port.
* DynASM/MIPS: Fix shadowed variable.
* MIPS64: Fix register allocation in assembly of HREF.
* Prevent integer overflow while parsing long strings.
* Fix LJ_MAX_JSLOTS assertion in rec_check_slots().
* Fix debug.getinfo() argument check.
* ARM: Fix GCC 7 -Wimplicit-fallthrough warnings.
* DynASM: Fix warning.
* Fix GCC 7 -Wimplicit-fallthrough warnings.
* Cleanup math function compilation and fix inconsistencies.
* FFI: Eliminate hardcoded string hashes.
* Windows: Add UWP support, part 1.
* build: fix non-Linux/macOS builds
* PPC: Add soft-float support to JIT compiler backend.
* PPC: Add soft-float support to interpreter.
* MIPS64: Add soft-float support to JIT compiler backend.
* MIPS: Fix handling of spare long-range jump slots.
* test: introduce mcode generator for tests
* MIPS: Use precise search for exit jump patching.
* sysprof: improve parser's memory footprint
* tools: add execution permission to sysprof parser
* sysprof: remove `split by vmstate` option

Part of #8825 

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump