### PR TITLE
vinyl: add statistic for total size of memory occupied by tuples

### DIFF
--- a/changelogs/unreleased/gh-8485-vy-tuple-stat.md
+++ b/changelogs/unreleased/gh-8485-vy-tuple-stat.md
@@ -1,0 +1,5 @@
+## feature/vinyl
+
+* Introduced the `memory.tuple` statistic for `box.stat.vinyl()` that shows
+  the total size of memory occupied by all tuples allocated by the Vinyl engine
+  (gh-8485).

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -296,6 +296,7 @@ vy_info_append_memory(struct vy_env *env, struct info_handler *h)
 	info_table_begin(h, "memory");
 	info_append_int(h, "tx", vy_tx_manager_mem_used(env->xm));
 	info_append_int(h, "level0", lsregion_used(&env->mem_env.allocator));
+	info_append_int(h, "tuple", env->stmt_env.sum_tuple_size);
 	info_append_int(h, "tuple_cache", env->cache_env.mem_used);
 	info_append_int(h, "page_index", env->lsm_env.page_index_size);
 	info_append_int(h, "bloom_filter", env->lsm_env.bloom_size);

--- a/src/box/vy_stmt.h
+++ b/src/box/vy_stmt.h
@@ -75,6 +75,13 @@ struct vy_stmt_env {
 	 */
 	size_t max_tuple_size;
 	/**
+	 * Size of memory occupied by all vinyl tuples allocated
+	 * in the main thread. Note, this doesn't include keys,
+	 * which should be fine because keys shouldn't stay in
+	 * memory for long.
+	 */
+	size_t sum_tuple_size;
+	/**
 	 * Tuple format used for creating key statements (e.g.
 	 * statements read from secondary index runs). It doesn't
 	 * impose any restrictions on tuple fields, neither does

--- a/test/vinyl-luatest/gh_8485_tuple_stat_test.lua
+++ b/test/vinyl-luatest/gh_8485_tuple_stat_test.lua
@@ -1,0 +1,61 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+    cg.server:exec(function()
+        box.schema.create_space('test', {engine = 'vinyl'})
+        box.space.test:create_index('primary', {
+            parts = {1, 'unsigned'},
+        })
+        box.space.test:create_index('secondary', {
+            parts = {2, 'string'}, unique = false,
+        })
+        for i = 1, 10 do
+            box.space.test:insert({i, string.rep('x', 1000)})
+            if i == 5 then
+                box.snapshot()
+            end
+        end
+        collectgarbage()
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_tuple_stat = function(cg)
+    cg.server:exec(function()
+        local function gc()
+            box.tuple.new() -- drop blessed tuple ref
+            collectgarbage()
+        end
+        -- Initial value is 0.
+        gc()
+        t.assert_equals(box.stat.vinyl().memory.tuple, 0)
+
+        -- Tuples pinned by Lua.
+        box.cfg({vinyl_cache = 0})
+        local ret = box.space.test:select()
+        t.assert_equals(#ret, 10)
+        t.assert_almost_equals(box.stat.vinyl().memory.tuple, 10 * 1000, 1000)
+        ret = nil -- luacheck: ignore
+        gc()
+        t.assert_equals(box.stat.vinyl().memory.tuple, 0)
+
+        -- Tuples pinned by cache.
+        box.cfg({vinyl_cache = 100 * 1000})
+        ret = box.space.test:select()
+        t.assert_equals(#ret, 10)
+        t.assert_almost_equals(box.stat.vinyl().memory.tuple, 10 * 1000, 1000)
+        ret = nil -- luacheck: ignore
+        gc()
+        t.assert_almost_equals(box.stat.vinyl().memory.tuple, 10 * 1000, 1000)
+        box.cfg({vinyl_cache = 0})
+        t.assert_equals(box.stat.vinyl().memory.tuple, 0)
+    end)
+end

--- a/test/vinyl/stat.result
+++ b/test/vinyl/stat.result
@@ -256,8 +256,9 @@ gstat()
     tuple_cache: 0
     tx: 0
     level0: 0
-    page_index: 0
     bloom_filter: 0
+    page_index: 0
+    tuple: 0
   disk:
     data_compacted: 0
     data: 0
@@ -1007,6 +1008,13 @@ stat_diff(gstat(), st, 'tx')
 ---
 - commit: 1
 ...
+-- free tuples pinned by Lua
+_ = nil
+---
+...
+_ = collectgarbage()
+---
+...
 -- box.stat.reset
 box.stat.reset()
 ---
@@ -1140,8 +1148,9 @@ gstat()
     tuple_cache: 14313
     tx: 0
     level0: 261562
-    page_index: 1250
     bloom_filter: 140
+    page_index: 1250
+    tuple: 13689
   disk:
     data_compacted: 104299
     data: 104299

--- a/test/vinyl/stat.test.lua
+++ b/test/vinyl/stat.test.lua
@@ -323,6 +323,10 @@ stat_diff(gstat(), st, 'tx')
 box.commit()
 stat_diff(gstat(), st, 'tx')
 
+-- free tuples pinned by Lua
+_ = nil
+_ = collectgarbage()
+
 -- box.stat.reset
 box.stat.reset()
 istat()


### PR DESCRIPTION
Vinyl tuples returned to the user are allocated with `malloc`. They may be pinned by Lua indefinitely. Currently, there's no way to figure out how much memory is occupied by these tuples. This commit adds a statistic to `box.stat.vinyl()` that accounts them.

The new statistic is named `memory.tuple` and shows the total size of memory in bytes occupied by Vinyl tuples. It includes cached tuples and tuples pinned by the Lua world.

Closes #8485