### PR TITLE
[backport 2.11] test: update interactive_tarantool helper

### DIFF
--- a/test/interactive_tarantool.lua
+++ b/test/interactive_tarantool.lua
@@ -7,6 +7,7 @@ local log = require('log')
 local yaml = require('yaml')
 local popen = require('popen')
 local tnt = require('tarantool')
+local t = require('luatest')
 
 -- Default timeout for expecting an input on child's stdout.
 --
@@ -267,6 +268,15 @@ end
 function mt.close(self)
     self:_stop_stderr_logger()
     self.ph:close()
+end
+
+-- Run a command and assert response.
+function mt.roundtrip(self, command, expected)
+    self:execute_command(command)
+    local response = self:read_response()
+    if expected ~= nil then
+        t.assert_equals(response, expected)
+    end
 end
 
 -- }}} Instance methods

--- a/test/interactive_tarantool.lua
+++ b/test/interactive_tarantool.lua
@@ -294,6 +294,7 @@ end
 function M._new_internal(opts)
     local opts = opts or {}
     local args = opts.args or {}
+    local env = opts.env or {}
     local prompt = opts.prompt
 
     local tarantool_exe = arg[-1]
@@ -301,7 +302,7 @@ function M._new_internal(opts)
         stdin = popen.opts.PIPE,
         stdout = popen.opts.PIPE,
         stderr = popen.opts.PIPE,
-        env = {
+        env = fun.chain({
             -- Don't know why, but without defined TERM environment
             -- variable readline doesn't accept INPUTRC environment
             -- variable.
@@ -313,7 +314,7 @@ function M._new_internal(opts)
             -- (because the command in the echo output will be
             -- trimmed).
             INPUTRC = '/dev/null',
-        },
+        }, env):tomap(),
     })
 
     local res = setmetatable({


### PR DESCRIPTION
Cherry-picked the following changes from the master branch.

* 5053f286f8c5fca49a5e3428df3cfbc570e448d2 ("test: add roundtrip() to interactive_tarantool")
* 130335e43e95403d92edbb840bbcedc8e031fe23 ("test: accept env in interactive_tarantool.new()")
* 793713e655ddc9f952e819009ea79efe4eed2e74 ("test: add error rethrow to :read_response() in `it`")

It simplifies future backports of updates of the helpers and backports of updates of the tests that are using the helpers.