### PR TITLE
lua: provide whether ASAN build in tarantool.build.asan

### DIFF
--- a/changelogs/unreleased/add-asan-flag-to-tarantool-build.md
+++ b/changelogs/unreleased/add-asan-flag-to-tarantool-build.md
@@ -1,0 +1,4 @@
+## feature/box
+
+* Added a new flag `tarantool.build.asan` that shows whether build
+  flag `ENABLE_ASAN` is set.

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -795,15 +795,7 @@ luaopen_tarantool(lua_State *L)
 	lua_pushstring(L, tarantool_version());
 	lua_setfield(L, LUA_GLOBALSINDEX, "_TARANTOOL");
 
-	/*
-	 * Get tarantool module.
-	 *
-	 * src/lua/init.lua is already registered as tarantool
-	 * module, so we `require` it here, not create.
-	 */
-	lua_getfield(L, LUA_GLOBALSINDEX, "require");
-	lua_pushstring(L, "tarantool");
-	lua_call(L, 1, 1);
+	luaT_newmodule(L, "tarantool", NULL);
 
 	/* package */
 	lua_pushstring(L, tarantool_package());
@@ -998,6 +990,7 @@ tarantool_lua_init(const char *tarantool_bin, const char *script, int argc,
 #if defined(ENABLE_BACKTRACE)
 	backtrace_lua_init();
 #endif /* defined(ENABLE_BACKTRACE) */
+	luaopen_tarantool(L);
 	for (const char **s = lua_modules; *s; s += 2) {
 		const char *modname = *s;
 		const char *modsrc = *(s + 1);
@@ -1018,9 +1011,6 @@ tarantool_lua_init(const char *tarantool_bin, const char *script, int argc,
 		builtin_modcache_put(modname, modsrc);
 	}
 	lua_pop(L, 1); /* _PRELOAD */
-
-	luaopen_tarantool(L);
-
 #ifdef NDEBUG
 	/* Unload strict after boot in release mode */
 	if (luaL_dostring(L, "require('strict').off()") != 0)

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -851,6 +851,15 @@ luaopen_tarantool(lua_State *L)
 #endif
 	lua_settable(L, -3);
 
+	/* build.asan */
+	lua_pushstring(L, "asan");
+#ifdef ENABLE_ASAN
+	lua_pushboolean(L, true);
+#else
+	lua_pushboolean(L, false);
+#endif
+	lua_settable(L, -3);
+
 	lua_settable(L, -3);    /* box.info.build */
 
 	/* debug */

--- a/src/lua/init.lua
+++ b/src/lua/init.lua
@@ -1,8 +1,8 @@
-
 -- init.lua -- internal file
 
 local ffi = require('ffi')
 local loaders = require('internal.loaders')
+local tarantool = require('tarantool')
 
 ffi.cdef[[
 struct method_info;
@@ -211,7 +211,7 @@ local mt = {
     __serialize = filter_out_private_fields,
 }
 
-return setmetatable({
+local tarantool_lua = {
     uptime = uptime,
     pid = pid,
     _internal = {
@@ -219,4 +219,9 @@ return setmetatable({
         module_name_from_filename = module_name_from_filename,
         run_preload = run_preload,
     },
-}, mt)
+}
+-- tarantool module is already registered by src/lua/init.c
+for k, v in pairs(tarantool_lua) do
+    tarantool[k] = v
+end
+return setmetatable(tarantool, mt)

--- a/src/lua/utils.c
+++ b/src/lua/utils.c
@@ -406,7 +406,7 @@ luaT_newmodule(struct lua_State *L, const char *modname,
 	       const struct luaL_Reg *funcs)
 {
 	say_debug("%s(%s)", __func__, modname);
-	assert(modname != NULL && funcs != NULL);
+	assert(modname != NULL);
 
 	/* Get loaders.builtin. */
 	lua_getfield(L, LUA_REGISTRYINDEX, "_TARANTOOL_BUILTIN");
@@ -422,7 +422,8 @@ luaT_newmodule(struct lua_State *L, const char *modname,
 	lua_newtable(L);
 
 	/* Fill the module table with functions. */
-	luaL_setfuncs(L, funcs, 0);
+	if (funcs != NULL)
+		luaL_setfuncs(L, funcs, 0);
 
 	/* Copy the module table. */
 	lua_pushvalue(L, -1);

--- a/test/app-luatest/gh_7311_malloc_info_test.lua
+++ b/test/app-luatest/gh_7311_malloc_info_test.lua
@@ -21,7 +21,7 @@ local function is_supported()
     end
     -- If ASAN is enabled, malloc_info() exists but it is not implemented
     -- (all counters in the returned document are set to zeros).
-    if tarantool.build.flags:match('-fsanitize=[%a,]*address') then
+    if tarantool.build.asan then
         return false
     end
     return true

--- a/test/app-luatest/tarantool_package_test.lua
+++ b/test/app-luatest/tarantool_package_test.lua
@@ -1,0 +1,10 @@
+local t = require('luatest')
+local tarantool = require('tarantool')
+
+local g = t.group()
+
+g.test_build_asan = function()
+    local b = tarantool.build
+    local asan = b.flags:match('-fsanitize=[%a,]*address') ~= nil
+    t.assert_equals(b.asan, asan)
+end


### PR DESCRIPTION
We already use this info in one of the test and going to use it more.

Let's also move initializing tarantool package before initializing other packages implemented in Lua. This way we will have access to build info in those packages. In particularly build.asan flag is going to be used in buffer.lua in scope of #7327.

Part of #7327
