### PR TITLE
[2.10] ci: bump Clang version to 16 in release build ASAN testing

### DIFF
--- a/.github/workflows/release_asan_clang.yml
+++ b/.github/workflows/release_asan_clang.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: release_asan_clang11
+          name: release_asan_clang
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
       - name: Upload artifacts to S3

--- a/.github/workflows/release_asan_clang.yml
+++ b/.github/workflows/release_asan_clang.yml
@@ -1,4 +1,4 @@
-name: release_asan_clang11
+name: release_asan_clang
 
 on:
   push:
@@ -31,7 +31,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  release_asan_clang11:
+  release_asan_clang:
     # Run on push to the 'master' and release branches of tarantool/tarantool
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
@@ -39,6 +39,19 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
+
+    container:
+      image: docker.io/tarantool/testing:ubuntu-jammy-clang16
+      # Mount /dev to the container to be able to mount a disk image inside it
+      # for successful run of the .github/actions/environment action.
+      volumes:
+        - /dev:/dev
+      # Our testing expects that the init process (PID 1) will
+      # reap orphan processes. At least the following test leans
+      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
+      # Add extra privileges to the container for successful run
+      # of the .github/actions/environment action.
+      options: '--init --privileged'
 
     steps:
       - name: Prepare checkout
@@ -52,8 +65,8 @@ jobs:
         uses: ./.github/actions/install-deps-debian
       - name: test
         env:
-          CC: clang-11
-          CXX: clang++-11
+          CC: clang-16
+          CXX: clang++-16
         run: make -f .test.mk test-release-asan
       - name: Send VK Teams message on failure
         if: failure()

--- a/.github/workflows/release_asan_clang11.yml
+++ b/.github/workflows/release_asan_clang11.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Install deps
         uses: ./.github/actions/install-deps-debian
       - name: test
+        env:
+          CC: clang-11
+          CXX: clang++-11
         run: make -f .test.mk test-release-asan
       - name: Send VK Teams message on failure
         if: failure()

--- a/.github/workflows/release_lto_clang.yml
+++ b/.github/workflows/release_lto_clang.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: release_lto_clang11
+          name: release_lto_clang
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
       - name: Upload artifacts to S3

--- a/.test.mk
+++ b/.test.mk
@@ -69,7 +69,6 @@ test-release: build run-luajit-test run-test
 # Release ASAN build
 
 .PHONY: test-release-asan
-test-release-asan: CMAKE_ENV = CC=clang-11 CXX=clang++-11
 # FIBER_STACK_SIZE=640Kb: The default value of fiber stack size
 # is 512Kb, but several tests in test/PUC-Rio-Lua-5.1-test suite
 # in the LuaJIT repo (e.g. some cases with deep recursion in

--- a/test/box/tx_man.skipcond
+++ b/test/box/tx_man.skipcond
@@ -1,0 +1,7 @@
+import os
+
+# Disabled at ASAN build due to issue tarantool/tarantool-qa#324.
+if os.getenv("ASAN") == 'ON':
+    self.skip = 1
+
+# vim: set ft=python:


### PR DESCRIPTION
Just a regular cherry-pick of test/infra changes via a pull request to verify changes.