### PR TITLE
wal: add stubs for wal_retention_period

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -178,7 +178,12 @@ endif()
 add_library(tuple STATIC ${tuple_sources})
 target_link_libraries(tuple json box_error core ${MSGPUCK_LIBRARIES} misc bit coll)
 
-add_library(xlog STATIC xlog.c)
+set(xlog_sources xlog.c)
+if(ENABLE_RETENTION_PERIOD)
+    list(APPEND xlog_sources ${RETENTION_PERIOD_SOURCES})
+endif()
+
+add_library(xlog STATIC ${xlog_sources})
 target_link_libraries(xlog core box_error crc32 ${ZSTD_LIBRARIES})
 
 set(box_sources

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -362,6 +362,8 @@ box_init_say();
 extern "C" {
 #endif /* defined(__cplusplus) */
 
+int box_set_wal_retention_period(void);
+
 typedef struct tuple box_tuple_t;
 
 bool

--- a/src/box/gc.c
+++ b/src/box/gc.c
@@ -226,6 +226,15 @@ gc_run_cleanup(void)
 		consumer = gc_tree_next(&gc.consumers, consumer);
 	}
 
+	/*
+	 * Acquire minimum vclock of a file, which is protected from garbage
+	 * collection by wal_retention_period option.
+	 */
+	struct vclock retention_vclock;
+	wal_get_retention_vclock(&retention_vclock);
+	if (vclock_is_set(&retention_vclock))
+		vclock_min(&min_vclock, &retention_vclock);
+
 	if (vclock_sum(&min_vclock) > vclock_sum(&gc.vclock)) {
 		vclock_copy(&gc.vclock, &min_vclock);
 		run_wal_gc = true;

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1293,6 +1293,11 @@ return schema.new('instance_config', schema.record({
             box_cfg = 'wal_cleanup_delay',
             default = 4 * 3600,
         }),
+        retention_period = enterprise_edition(schema.scalar({
+            type = 'number',
+            box_cfg = 'wal_retention_period',
+            default = 0,
+        })),
         -- box.cfg({wal_ext = <...>}) replaces the previous
         -- value without any merging. See explanation why it is
         -- important in the log.modules description.

--- a/src/box/lua/info.c
+++ b/src/box/lua/info.c
@@ -522,6 +522,15 @@ lbox_info_gc_call(struct lua_State *L)
 	lua_pushboolean(L, gc.is_paused);
 	lua_settable(L, -3);
 
+	lua_pushstring(L, "wal_retention_vclock");
+	struct vclock retention_vclock;
+	wal_get_retention_vclock(&retention_vclock);
+	if (vclock_is_set(&retention_vclock))
+		luaT_pushvclock(L, &retention_vclock);
+	else
+		luaL_pushnull(L);
+	lua_settable(L, -3);
+
 	lua_pushstring(L, "checkpoints");
 	lua_newtable(L);
 

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -79,6 +79,7 @@
 #include "box/lua/security.h"
 #include "box/lua/space_upgrade.h"
 #include "box/lua/wal_ext.h"
+#include "box/lua/wal_retention_period.h"
 #include "box/lua/trigger.h"
 #include "box/lua/config/utils/expression_lexer.h"
 #include "box/lua/failover.h"
@@ -896,6 +897,7 @@ box_lua_init(struct lua_State *L)
 	box_lua_iproto_init(L);
 	box_lua_space_upgrade_init(L);
 	box_lua_audit_init(L);
+	box_lua_wal_retention_period_init(L);
 	box_lua_wal_ext_init(L);
 	box_lua_read_view_init(L);
 	box_lua_security_init(L);

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -77,6 +77,12 @@ local function ifdef_security(value)
     end
 end
 
+local function ifdef_wal_retention_period(value)
+    if private.cfg_set_wal_retention_period ~= nil then
+        return value
+    end
+end
+
 -- all available options
 local default_cfg = {
     listen              = nil,
@@ -151,6 +157,7 @@ local default_cfg = {
     wal_dir_rescan_delay= 2,
     wal_queue_max_size  = 16 * 1024 * 1024,
     wal_cleanup_delay   = 4 * 3600,
+    wal_retention_period = ifdef_wal_retention_period(0),
     wal_ext             = ifdef_wal_ext(nil),
     force_recovery      = false,
     replication         = nil,
@@ -349,6 +356,7 @@ local template_cfg = {
     wal_max_size        = 'number',
     wal_dir_rescan_delay= 'number',
     wal_cleanup_delay   = 'number',
+    wal_retention_period = ifdef_wal_retention_period('number'),
     wal_ext             = ifdef_wal_ext('table'),
     force_recovery      = 'boolean',
     replication         = 'string, number, table',
@@ -497,6 +505,7 @@ local dynamic_cfg = {
     -- do nothing, affects new replicas, which query this value on start
     wal_dir_rescan_delay    = nop,
     wal_cleanup_delay       = private.cfg_set_wal_cleanup_delay,
+    wal_retention_period    = private.cfg_set_wal_retention_period,
     custom_proc_title       = function()
         require('title').update(box.cfg.custom_proc_title)
     end,
@@ -693,6 +702,7 @@ local dynamic_cfg_skip_at_load = {
     disable_guest           = ifdef_security(true),
     secure_erasing          = ifdef_security(true),
     password_lifetime_days  = ifdef_security(true),
+    wal_retention_period    = ifdef_wal_retention_period(true),
 }
 
 -- Options that are not part of dynamic_cfg_modules and applied individually

--- a/src/box/lua/wal_retention_period.h
+++ b/src/box/lua/wal_retention_period.h
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2024, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include "trivia/config.h"
+
+#if defined(ENABLE_RETENTION_PERIOD)
+#include "lua/wal_retention_period_impl.h"
+#else /* !defined(ENABLE_RETENTION_PERIOD) */
+
+struct lua_State;
+
+static inline void
+box_lua_wal_retention_period_init(struct lua_State *L)
+{
+	(void)L;
+}
+
+#endif /* !defined(ENABLE_RETENTION_PERIOD) */

--- a/src/box/retention_period.h
+++ b/src/box/retention_period.h
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2024, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include "trivia/config.h"
+
+#if defined(ENABLE_RETENTION_PERIOD)
+#include "retention_period_impl.h"
+#else /* !defined(ENABLE_RETENTION_PERIOD) */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+#include "vclock/vclock.h"
+#include "xlog.h"
+
+/**
+ * Allocate vclock structure. In EE additional memory is allocated,
+ * where expiration time is saved.
+ */
+static inline struct vclock*
+retention_vclock_new(void)
+{
+	return (struct vclock *)xmalloc(sizeof(struct vclock));
+}
+
+/**
+ * Set expiration time of the @retention_vclock to now + @period.
+ */
+static inline void
+retention_vclock_set(struct vclock *retention_vclock, double period)
+{
+	(void)retention_vclock;
+	(void)period;
+}
+
+/**
+ * Update expiration time of all files. New period must be saved inside xdir.
+ */
+static inline void
+retention_index_update(struct xdir *xdir, double old_period)
+{
+	(void)xdir;
+	(void)old_period;
+}
+
+/**
+ * Return vclock of the oldest file, which is protected from garbage collection.
+ * Vclock is cleared, if none of the files are protected. Vclock must be
+ * non-nil.
+ */
+static inline void
+retention_index_get(vclockset_t *index, struct vclock *vclock)
+{
+	(void)index;
+	assert(vclock != NULL);
+	vclock_clear(vclock);
+}
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */
+
+#endif /* !defined(ENABLE_RETENTION_PERIOD) */

--- a/src/box/wal.h
+++ b/src/box/wal.h
@@ -107,7 +107,8 @@ typedef void (*wal_on_checkpoint_threshold_f)(void);
  */
 int
 wal_init(enum wal_mode wal_mode, const char *wal_dirname,
-	 int64_t wal_max_size, const struct tt_uuid *instance_uuid,
+	 int64_t wal_max_size, double wal_retention_period,
+	 const struct tt_uuid *instance_uuid,
 	 wal_on_garbage_collection_f on_garbage_collection,
 	 wal_on_checkpoint_threshold_f on_checkpoint_threshold);
 
@@ -265,6 +266,20 @@ wal_set_checkpoint_threshold(int64_t threshold);
  */
 void
 wal_set_queue_max_size(int64_t size);
+
+/**
+ * Set new value for wal_retention_period, update expiration time
+ * of all xlog files.
+ */
+void
+wal_set_retention_period(double period);
+
+/**
+ * Return vclock (unless @vclock is NULL) of the oldest file,
+ * which is protected from garbage collection.
+ */
+void
+wal_get_retention_vclock(struct vclock *vclock);
 
 /**
  * Remove WAL files that are not needed by consumers reading

--- a/src/box/xlog.h
+++ b/src/box/xlog.h
@@ -160,6 +160,11 @@ struct xdir {
 	 */
 	vclockset_t index;
 	/**
+	 * Number of seconds to delay garbage collection of files
+	 * after they are closed.
+	 */
+	double retention_period;
+	/**
 	 * Directory path.
 	 */
 	char dirname[PATH_MAX];
@@ -197,6 +202,27 @@ int
 xdir_check(struct xdir *dir);
 
 /**
+ * Set new value for retention_period, update expiration time
+ * of all existing files.
+ */
+void
+xdir_set_retention_period(struct xdir *xdir, double period);
+
+/**
+ * Return vclock (unless @vclock is NULL) of the oldest file,
+ * which is protected from garbage collection.
+ */
+void
+xdir_get_retention_vclock(struct xdir *xdir, struct vclock *vclock);
+
+/**
+ * Find requested @vclock in index of xdir and set its retention
+ * according to retention_period.
+ */
+void
+xdir_set_retention_vclock(struct xdir *xdir, struct vclock *vclock);
+
+/**
  * Return a file name based on directory type, vector clock
  * sum, and a suffix (.inprogress or not).
  */
@@ -215,7 +241,17 @@ static inline bool
 xdir_has_garbage(struct xdir *dir, int64_t signature)
 {
 	struct vclock *vclock = vclockset_first(&dir->index);
-	return vclock != NULL && vclock_sum(vclock) < signature;
+	if (vclock == NULL)
+		return false;
+
+	struct vclock retention;
+	xdir_get_retention_vclock(dir, &retention);
+	if (!vclock_is_set(&retention) ||
+	    vclock_compare(vclock, &retention) < 0)
+		return vclock_sum(vclock) < signature;
+
+	/** All files are protected from gc. */
+	return false;
 }
 
 /**
@@ -504,7 +540,7 @@ ssize_t
 xlog_fallocate(struct xlog *log, size_t size);
 
 /**
- * Write a row to xlog, 
+ * Write a row to xlog,
  *
  * @retval count of writen bytes
  * @retval -1 for error

--- a/src/trivia/config.h.cmake
+++ b/src/trivia/config.h.cmake
@@ -284,6 +284,7 @@
 #cmakedefine ENABLE_AUDIT_LOG 1
 #cmakedefine ENABLE_FEEDBACK_DAEMON 1
 #cmakedefine ENABLE_WAL_EXT 1
+#cmakedefine ENABLE_RETENTION_PERIOD 1
 #cmakedefine ENABLE_READ_VIEW 1
 #cmakedefine ENABLE_SECURITY 1
 #cmakedefine ENABLE_MEMCS_ENGINE 1

--- a/test/box/box.lua
+++ b/test/box/box.lua
@@ -48,6 +48,7 @@ local _enterprise_keys = {
     password_enforce_specialchars = true,
     password_history_length = true,
     wal_ext = true,
+    wal_retention_period = true,
 }
 
 function cfg_filter(data)

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -245,6 +245,7 @@ g.test_defaults = function()
             dir_rescan_delay = 2,
             queue_max_size = 16777216,
             cleanup_delay = 14400,
+            retention_period = is_enterprise and 0 or nil,
         },
         console = {
             enabled = true,

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1045,6 +1045,7 @@ g.test_wal_enterprise = function()
             dir_rescan_delay = 1,
             queue_max_size = 1,
             cleanup_delay = 1,
+            retention_period = 1,
             ext = {
                 old = true,
                 new = false,
@@ -1067,6 +1068,7 @@ g.test_wal_enterprise = function()
         dir_rescan_delay = 2,
         queue_max_size = 16777216,
         cleanup_delay = 14400,
+        retention_period = 0,
     }
     local res = instance_config:apply_default({}).wal
     t.assert_equals(res, exp)

--- a/test/unit/vclock.cc
+++ b/test/unit/vclock.cc
@@ -413,25 +413,30 @@ test_fromstring_invalid()
 	vclock_from_string(&va, (a));					\
 	vclock_from_string(&vb, (b));					\
 	vclock_from_string(&vexp, (exp));				\
-	vclock_##fun##_ignore0(&va, &vb);				\
+	vclock_##fun(&va, &vb);						\
 	is(vclock_compare(&va, &vexp), 0,				\
 	   #fun " between %s and %s is %s", a, b, exp);			\
 })
 
 int
-test_minmax_ignore0(void)
+test_minmax(void)
 {
-	plan(4);
+	plan(6);
 	header();
 
-	test(max, "{0: 1, 1: 17, 2: 3}", "{0: 10, 1: 5, 2: 7}",
+	test(max_ignore0, "{0: 1, 1: 17, 2: 3}", "{0: 10, 1: 5, 2: 7}",
 	     "{0: 1, 1: 17, 2: 7}");
-	test(min, "{0: 10, 1: 17, 2: 3}", "{0: 1, 1: 5, 2: 7}",
+	test(min_ignore0, "{0: 10, 1: 17, 2: 3}", "{0: 1, 1: 5, 2: 7}",
 	     "{0: 10, 1: 5, 2: 3}");
-	test(max, "{1: 1, 2: 1, 3: 1}", "{1: 100, 2: 100, 31: 100}",
+	test(max_ignore0, "{1: 1, 2: 1, 3: 1}", "{1: 100, 2: 100, 31: 100}",
 	     "{1: 100, 2: 100, 3: 1, 31: 100}");
-	test(min, "{1: 1, 2: 1, 3: 1}", "{1: 100, 2: 100, 31: 100}",
+	test(min_ignore0, "{1: 1, 2: 1, 3: 1}", "{1: 100, 2: 100, 31: 100}",
 	     "{1:1, 2: 1}");
+
+	test(max, "{0: 1, 1: 17, 2: 3}", "{0: 10, 1: 5, 2: 7}",
+	     "{0: 10, 1: 17, 2: 7}");
+	test(min, "{0: 10, 1: 17, 2: 3}", "{0: 1, 1: 5, 2: 7}",
+	     "{0: 1, 1: 5, 2: 3}");
 
 	footer();
 	return check_plan();
@@ -449,7 +454,7 @@ main(void)
 	test_tostring();
 	test_fromstring();
 	test_fromstring_invalid();
-	test_minmax_ignore0();
+	test_minmax();
 
 	return check_plan();
 }

--- a/test/unit/vclock.result
+++ b/test/unit/vclock.result
@@ -147,11 +147,13 @@ ok 4 - subtests
     ok 32 - fromstring "{1:20, 1:10}" => 12
 	*** test_fromstring_invalid: done ***
 ok 5 - subtests
-    1..4
-	*** test_minmax_ignore0 ***
-    ok 1 - max between {0: 1, 1: 17, 2: 3} and {0: 10, 1: 5, 2: 7} is {0: 1, 1: 17, 2: 7}
-    ok 2 - min between {0: 10, 1: 17, 2: 3} and {0: 1, 1: 5, 2: 7} is {0: 10, 1: 5, 2: 3}
-    ok 3 - max between {1: 1, 2: 1, 3: 1} and {1: 100, 2: 100, 31: 100} is {1: 100, 2: 100, 3: 1, 31: 100}
-    ok 4 - min between {1: 1, 2: 1, 3: 1} and {1: 100, 2: 100, 31: 100} is {1:1, 2: 1}
-	*** test_minmax_ignore0: done ***
+    1..6
+	*** test_minmax ***
+    ok 1 - max_ignore0 between {0: 1, 1: 17, 2: 3} and {0: 10, 1: 5, 2: 7} is {0: 1, 1: 17, 2: 7}
+    ok 2 - min_ignore0 between {0: 10, 1: 17, 2: 3} and {0: 1, 1: 5, 2: 7} is {0: 10, 1: 5, 2: 3}
+    ok 3 - max_ignore0 between {1: 1, 2: 1, 3: 1} and {1: 100, 2: 100, 31: 100} is {1: 100, 2: 100, 3: 1, 31: 100}
+    ok 4 - min_ignore0 between {1: 1, 2: 1, 3: 1} and {1: 100, 2: 100, 31: 100} is {1:1, 2: 1}
+    ok 5 - max between {0: 1, 1: 17, 2: 3} and {0: 10, 1: 5, 2: 7} is {0: 10, 1: 17, 2: 7}
+    ok 6 - min between {0: 10, 1: 17, 2: 3} and {0: 1, 1: 5, 2: 7} is {0: 1, 1: 5, 2: 3}
+	*** test_minmax: done ***
 ok 6 - subtests


### PR DESCRIPTION
This PR adds a new configuration option wal_retention_period and
function stubs for it. It's needed to avoid rebootstrap on anonymous
replicas, as Tarantool doesn't save xlog for them.

  * wal_retention_period. Type: double. Default: 0. Unit: seconds.

  Description: When xlog file is closed it won't be immediately
  deleted by garbage collector if wal_retention_period is set to
  non-zero value. wal_retention_delay determines how many seconds
  after closing this file should be saved. During instance restart
  the timeout is set to 'wal_retention_period - time' passed since
  file modification.

The option is dynamic. Its value is stored and used in C code, so we
define configuration callbacks in EE: cfg_set_wal_retention_period.

Needed for https://github.com/tarantool/tarantool-ee/issues/513

NO_DOC=EE
NO_CHANGELOG=EE