### PR TITLE
test: increase maximum fiber slice for `wal_off` tests

### DIFF
--- a/test/wal_off/wal.lua
+++ b/test/wal_off/wal.lua
@@ -9,5 +9,5 @@ box.cfg{
 }
 
 -- Wal off tests can be running for a very long time without yields.
-require('fiber').set_max_slice(50)
+require('fiber').set_max_slice(120)
 require('console').listen(os.getenv('ADMIN'))


### PR DESCRIPTION
If a lot of tests are running in parallel, 50 sec limit may not be enough. Let's increase it to 120 sec.

Closes #7580
Closes tarantool/tarantool-qa#273