### PR TITLE
test: fix flaky gh_7581_downstream_lag_test

### DIFF
--- a/test/replication-luatest/gh_7581_downstream_lag_test.lua
+++ b/test/replication-luatest/gh_7581_downstream_lag_test.lua
@@ -30,6 +30,7 @@ g.before_each(function(g)
         box_cfg = box_cfg,
     })
     g.cluster:start()
+    g.cluster:wait_for_fullmesh()
     g.server1:exec(function()
         box.schema.space.create("test")
         box.space.test:create_index("pk")


### PR DESCRIPTION
The test starts the cluster and immediately tries to create a space on master. Sometimes it fails with "Can't modify data on a read-only instance - it is an orphan" error.

When the instance is not in sync with sufficient number of nodes it has orphan status, which means the instance is read-only. Sometimes, the instance doesn't have enough time to connect to all instances and get out of orphan state.

Let's add waiting until every node is connected to every other node in the replica set.

Closes tarantool/tarantool-qa#326

NO_CHANGELOG=test
NO_DOC=test