### PR TITLE
Lua fuzzer fixes (return and break statements)

### DIFF
--- a/test/fuzz/luaL_loadbuffer/serializer.cc
+++ b/test/fuzz/luaL_loadbuffer/serializer.cc
@@ -611,7 +611,7 @@ PROTO_TOSTRING(IfStatement, statement)
 
 NESTED_PROTO_TOSTRING(ElseIfBlock, elseifblock, IfStatement)
 {
-	std::string elseifblock_str = "else if ";
+	std::string elseifblock_str = "elseif ";
 	elseifblock_str += ExpressionToString(elseifblock.condition());
 	elseifblock_str += " then\n\t";
 	elseifblock_str += BlockToString(elseifblock.block());

--- a/test/fuzz/luaL_loadbuffer/serializer.cc
+++ b/test/fuzz/luaL_loadbuffer/serializer.cc
@@ -392,7 +392,9 @@ PROTO_TOSTRING(LastStatement, laststat)
 			laststat.explist());
 		break;
 	case LastStatType::kBreak:
-		laststat_str = "break";
+		if (GetContext().break_is_possible()) {
+			laststat_str = "break";
+		}
 		break;
 	default:
 		/* Chosen as default in order to decrease number of 'break's. */
@@ -401,7 +403,7 @@ PROTO_TOSTRING(LastStatement, laststat)
 		break;
 	}
 
-	if (laststat.has_semicolon())
+	if (!laststat_str.empty() && laststat.has_semicolon())
 		laststat_str += "; ";
 
 	return laststat_str;
@@ -409,6 +411,10 @@ PROTO_TOSTRING(LastStatement, laststat)
 
 NESTED_PROTO_TOSTRING(ReturnOptionalExpressionList, explist, LastStatement)
 {
+	if (!GetContext().return_is_possible()) {
+		return "";
+	}
+
 	std::string explist_str = "return";
 	if (explist.has_explist()) {
 		explist_str += " " + ExpressionListToString(explist.explist());


### PR DESCRIPTION

Revised:

1. The serializer no longer generates `return` and `break` statements without a corresponding function or loop, so they are now skipped.
2. The serializer was generating `else if` instead of `elseif`. Due to this typo, several errors occurred as a result of unclosed `if` statements.

I generated a set of 50,000 protobuf struct samples and tested the fuzzer on this set. Here are my results:
  | Before | After | Diff (% of errors of the kind)
-- | -- | -- | --
TOTAL | 27775 | 18294 | -34.14%
attempt to call | 5897 | 6963 | 18.08%
attempt to index | 4735 | 5790 | 22.28%
'for' initial value must be a | 1825 | 2820 | 54.52%
attempt to perform arithmetic on | 1636 | 1214 | -25.79%
attempt to compare | 524 | 502 | -4.20%
cannot use '...' outside a vararg function near '...' | 311 | 272 | -12.54%
attempt to get length of | 273 | 236 | -13.55%
table index is | 146 | 145 | -0.68%
attempt to concatenate | 177 | 109 | -38.42%
ambiguous syntax | 99 | 100 | 1.01%
'for' limit must be a | 68 | 82 | 20.59%
unexpected symbol near | 67 | 57 | -14.93%
'for' step must be a | 4 | 4 | 0.00%
no loop to break | 11150 | 0 | -100.00%
'end' expected | 863 | 0 | -100.00%

I got these results:
1. Due to the skipped `break` statements, 11,150 errors (40% of all errors) disappeared.
2. Due to the skipped `return` statements, 599 errors (2% of all errors) disappeared. However, it's worth noting that these 599 errors were not caused by the absence of the `return` statement itself, but rather by errors in the return expressions.
3. Due to fixed `elseif` statements 863 errors (3% of all errors) disappeared.
4. New errors appeared in 3131 samples (11% of all errors, 25% of disappeared errors).
