### PR TITLE
box: improve error message for constraint violation

### DIFF
--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -288,7 +288,7 @@ struct errcode_record {
 	/*233 */_(ER_TUPLE_FIELD_COUNT_LIMIT,	"Tuple field count limit reached: see box.schema.FIELD_MAX") \
 	/*234 */_(ER_CREATE_CONSTRAINT,		"Failed to create constraint '%s' in space '%s': %s") \
 	/*235 */_(ER_FIELD_CONSTRAINT_FAILED,	"Check constraint '%s' failed for field '%s'") \
-	/*236 */_(ER_TUPLE_CONSTRAINT_FAILED,	"Check constraint '%s' failed for tuple") \
+	/*236 */_(ER_TUPLE_CONSTRAINT_FAILED,	"Check constraint '%s' failed for a tuple") \
 	/*237 */_(ER_CREATE_FOREIGN_KEY,	"Failed to create foreign key '%s' in space '%s': %s") \
 	/*238 */_(ER_FOREIGN_KEY_INTEGRITY,	"Foreign key '%s' integrity check failed: %s") \
 	/*239 */_(ER_FIELD_FOREIGN_KEY_FAILED,	"Foreign key constraint '%s' failed for field '%s': %s") \

--- a/test/box/net.box_iproto_transactions_over_streams.result
+++ b/test/box/net.box_iproto_transactions_over_streams.result
@@ -1541,10 +1541,10 @@ true_check_res = monster_ddl_check()
 true_check_res
 ---
 - - 'Finished ok, errors and trigger catcher content: '
-  - Check constraint 'CK1' failed for tuple
+  - Check constraint 'CK1' failed for a tuple
   - Duplicate key exists in unique index "unique_unnamed_T2_2" in space "T2" with
     old tuple - [1, 1, 1] and new tuple - [2, 2, 1]
-  - Check constraint 'CK2' failed for tuple
+  - Check constraint 'CK2' failed for a tuple
   - metadata:
     - name: ID
       type: integer

--- a/test/engine-luatest/gh_6436_tuple_constraint_test.lua
+++ b/test/engine-luatest/gh_6436_tuple_constraint_test.lua
@@ -64,11 +64,11 @@ g.test_tuple_constraint_basics = function(cg)
 
             t.assert_equals(s:replace{1, 2, 3, field4}, {1, 2, 3, field4})
             t.assert_error_msg_content_equals(
-                "Check constraint 'tuple_constr1' failed for tuple",
+                "Check constraint 'tuple_constr1' failed for a tuple",
                 function() s:replace{100, 2, 3, field4} end
             )
             t.assert_error_msg_content_equals(
-                "Check constraint 'tuple_constr1' failed for tuple",
+                "Check constraint 'tuple_constr1' failed for a tuple",
                 function() s:replace{1, 200, 3, field4} end
             )
             t.assert_equals(s:select{}, {{1, 2, 3, field4}})
@@ -81,10 +81,10 @@ g.test_tuple_constraint_basics = function(cg)
         local s = c.space.test
         t.assert_equals(s:replace{1, 2, 3, field4}, {1, 2, 3, field4})
         t.assert_error_msg_content_equals(
-            "Check constraint 'tuple_constr1' failed for tuple",
+            "Check constraint 'tuple_constr1' failed for a tuple",
             function() s:replace{100, 2, 3, field4} end)
         t.assert_error_msg_content_equals(
-            "Check constraint 'tuple_constr1' failed for tuple",
+            "Check constraint 'tuple_constr1' failed for a tuple",
             function() s:replace{1, 200, 3, field4} end)
         t.assert_equals(s:select{}, {{1, 2, 3, field4}})
      end
@@ -321,15 +321,15 @@ g.test_several_tuple_constraints = function(cg)
 
             t.assert_equals(s:replace{1, 2, 3, field4}, {1, 2, 3, field4})
             t.assert_error_msg_content_equals(
-                "Check constraint 'check1' failed for tuple",
+                "Check constraint 'check1' failed for a tuple",
                 function() s:replace{100, 2, 3, field4} end
             )
             t.assert_error_msg_content_equals(
-                "Check constraint 'check2' failed for tuple",
+                "Check constraint 'check2' failed for a tuple",
                 function() s:replace{1, 200, 3, field4} end
             )
             t.assert_error_msg_content_equals(
-                "Check constraint 'check2' failed for tuple",
+                "Check constraint 'check2' failed for a tuple",
                 function() s:replace{1, 2, 300, field4} end
             )
             t.assert_equals(s:select{}, {{1, 2, 3, field4}})
@@ -342,13 +342,13 @@ g.test_several_tuple_constraints = function(cg)
         local s = c.space.test
         t.assert_equals(s:replace{1, 2, 3, field4}, {1, 2, 3, field4})
         t.assert_error_msg_content_equals(
-            "Check constraint 'check1' failed for tuple",
+            "Check constraint 'check1' failed for a tuple",
             function() s:replace{100, 2, 3, field4} end)
         t.assert_error_msg_content_equals(
-            "Check constraint 'check2' failed for tuple",
+            "Check constraint 'check2' failed for a tuple",
             function() s:replace{1, 200, 3, field4} end)
         t.assert_error_msg_content_equals(
-            "Check constraint 'check2' failed for tuple",
+            "Check constraint 'check2' failed for a tuple",
             function() s:replace{1, 2, 300, field4} end)
         t.assert_equals(s:select{}, {{1, 2, 3, field4}})
      end
@@ -437,7 +437,7 @@ g.test_tuple_constraint_integrity = function(cg)
         t.assert_equals(s.constraint, {tuple_constr1 = box.func.tuple_constr1.id})
         t.assert_equals(s:replace{1, 2, 3}, {1, 2, 3})
         t.assert_error_msg_content_equals(
-            "Check constraint 'tuple_constr1' failed for tuple",
+            "Check constraint 'tuple_constr1' failed for a tuple",
             function() s:replace{100, 2, 3} end
         )
     end, {engine})
@@ -476,18 +476,18 @@ g.test_tuple_constraint_integrity = function(cg)
 
         t.assert_equals(s:replace{100, 2, 3}, {100, 2, 3})
         t.assert_error_msg_content_equals(
-            "Check constraint 'check2' failed for tuple",
+            "Check constraint 'check2' failed for a tuple",
             function() s:replace{1, 200, 3} end
         )
         t.assert_equals(s:replace{1, 2, 300}, {1, 2, 300})
 
         t.assert_error_msg_content_equals(
-            "Check constraint 'check3' failed for tuple",
+            "Check constraint 'check3' failed for a tuple",
             function() s:alter{constraint = {check2='tuple_constr2',
                                              check3='tuple_constr3'}} end
         )
         t.assert_error_msg_content_equals(
-            "Check constraint 'check2' failed for tuple",
+            "Check constraint 'check2' failed for a tuple",
             function() s:replace{1, 200, 3} end
         )
 

--- a/test/engine-luatest/gh_6986_c_constraint_test.lua
+++ b/test/engine-luatest/gh_6986_c_constraint_test.lua
@@ -26,7 +26,7 @@ g.test_c_constraint = function(cg)
         s:alter{constraint='gh_6986.get_check'}
         t.assert_equals(s:insert{1}, {1})
         t.assert_error_msg_content_equals(
-            "Check constraint 'gh_6986.get_check' failed for tuple",
+            "Check constraint 'gh_6986.get_check' failed for a tuple",
             function() s:insert{2} end
         )
         s:drop()

--- a/test/engine-luatest/gh_7339_drop_fk_in_same_txn_test.lua
+++ b/test/engine-luatest/gh_7339_drop_fk_in_same_txn_test.lua
@@ -94,7 +94,7 @@ g.test_constraints_alter_in_txn = function(cg)
         a:replace{10, 10}
         b:replace{10, 10}
         a:insert{0, 0}
-        msg = "Check constraint 'ck1' failed for tuple"
+        msg = "Check constraint 'ck1' failed for a tuple"
         t.assert_error_msg_content_equals(msg, b.insert, b, {0, 0})
         a:insert{30, 30}
         msg = "Check constraint 'ck2' failed for field '1 (i)'"

--- a/test/engine-luatest/gh_7645_ck_fk_constraints_test.lua
+++ b/test/engine-luatest/gh_7645_ck_fk_constraints_test.lua
@@ -93,7 +93,7 @@ g.test_tuple_ck_fk_constraints = function(cg)
             function() user:replace({2, 99, 'Bob'}) end
         )
         t.assert_error_msg_content_equals(
-            "Check constraint 'check' failed for tuple",
+            "Check constraint 'check' failed for a tuple",
             function() user:replace{2, 100, 'Bob'} end
         )
     end, {engine})

--- a/test/sql-luatest/constraint_test.lua
+++ b/test/sql-luatest/constraint_test.lua
@@ -534,15 +534,18 @@ g.test_constraints_11 = function()
         box.execute([[CREATE TABLE t(i INT PRIMARY KEY,
                                      CONSTRAINT one CHECK (i > 10));]])
         local _, err = box.execute([[INSERT INTO t VALUES (1);]])
-        t.assert_equals(err.message, "Check constraint 'ONE' failed for tuple")
+        t.assert_equals(err.message,
+                        "Check constraint 'ONE' failed for a tuple")
         _, err = box.execute([[ALTER TABLE t DISABLE CHECK CONSTRAINT one;]])
         t.assert_equals(err.message, "Syntax error at line 1 near 'DISABLE'")
         _, err = box.execute([[INSERT INTO t VALUES (1);]])
-        t.assert_equals(err.message, "Check constraint 'ONE' failed for tuple")
+        t.assert_equals(err.message,
+                        "Check constraint 'ONE' failed for a tuple")
         _, err = box.execute([[ALTER TABLE t ENABLE CHECK CONSTRAINT one;]])
         t.assert_equals(err.message, "Syntax error at line 1 near 'ENABLE'")
         _, err = box.execute([[INSERT INTO t VALUES (1);]])
-        t.assert_equals(err.message, "Check constraint 'ONE' failed for tuple")
+        t.assert_equals(err.message,
+                        "Check constraint 'ONE' failed for a tuple")
 
         box.execute([[DROP TABLE t;]])
     end)

--- a/test/sql-luatest/datetime_test.lua
+++ b/test/sql-luatest/datetime_test.lua
@@ -263,7 +263,7 @@ g.test_datetime_12 = function()
                       CAST(dt as STRING) != '2001-01-01T01:00:00Z'));]])
 
         local sql = [[INSERT INTO t SELECT * from t1 LIMIT 1;]]
-        local res = [[Check constraint 'CK' failed for tuple]]
+        local res = [[Check constraint 'CK' failed for a tuple]]
         local _, err = box.execute(sql)
         box.execute([[DROP TABLE t;]])
 

--- a/test/sql-luatest/interval_test.lua
+++ b/test/sql-luatest/interval_test.lua
@@ -143,7 +143,7 @@ g.test_interval_10 = function()
                       '+1 years, 2 months, 3 days, 4 hours'));]])
 
         local sql = [[INSERT INTO t SELECT * from t0 LIMIT 1;]]
-        local res = [[Check constraint 'CK' failed for tuple]]
+        local res = [[Check constraint 'CK' failed for a tuple]]
         local _, err = box.execute(sql)
         box.execute([[DROP TABLE t;]])
 

--- a/test/sql-luatest/sql_func_expr_test.lua
+++ b/test/sql-luatest/sql_func_expr_test.lua
@@ -24,11 +24,11 @@ g.test_sql_func_expr_1 = function()
         s:alter{constraint='abc'}
         t.assert_equals(s:insert{3, 4}, {3, 4})
         t.assert_error_msg_content_equals(
-            "Check constraint 'abc' failed for tuple",
+            "Check constraint 'abc' failed for a tuple",
             function() s:insert{1, 2} end
         )
         t.assert_error_msg_content_equals(
-            "Check constraint 'abc' failed for tuple",
+            "Check constraint 'abc' failed for a tuple",
             function() s:insert{true, 2} end
         )
         box.space.test:drop()
@@ -101,7 +101,7 @@ g.test_sql_func_expr_3 = function()
         s:create_index('i')
         s:alter{constraint='abc'}
         t.assert_error_msg_content_equals(
-            "Check constraint 'abc' failed for tuple",
+            "Check constraint 'abc' failed for a tuple",
             function() s:insert{1, 1} end
         )
     end)
@@ -109,7 +109,7 @@ g.test_sql_func_expr_3 = function()
     g.server:exec(function()
         t.assert_equals(box.func.abc.language, 'SQL_EXPR')
         t.assert_error_msg_content_equals(
-            "Check constraint 'abc' failed for tuple",
+            "Check constraint 'abc' failed for a tuple",
             function() box.space.test:insert{2, 2} end
         )
         t.assert_equals(box.space.test:insert{7, 7}, {7, 7})
@@ -130,7 +130,7 @@ g.test_sql_func_expr_4 = function()
         s:alter{constraint='abc'}
         t.assert_equals(s:insert{3, 4}, {3, 4})
         t.assert_error_msg_content_equals(
-            "Check constraint 'abc' failed for tuple",
+            "Check constraint 'abc' failed for a tuple",
             function() s:insert{1, 2} end
         )
         box.space.test:drop()
@@ -150,7 +150,7 @@ g.test_sql_func_expr_4 = function()
         s:alter{constraint='abc'}
         t.assert_equals(s:insert{3, 4}, {3, 4})
         t.assert_error_msg_content_equals(
-            "Check constraint 'abc' failed for tuple",
+            "Check constraint 'abc' failed for a tuple",
             function() s:insert{1, 2} end
         )
         box.space.test:drop()

--- a/test/sql-tap/alter2.test.lua
+++ b/test/sql-tap/alter2.test.lua
@@ -224,7 +224,7 @@ test:do_catchsql_test(
         CREATE TABLE t1 (id INT PRIMARY KEY);
         ALTER TABLE t1 ADD CONSTRAINT ck CHECK(id > 0);
         INSERT INTO t1 VALUES (-1);
-    ]], { 1, "Check constraint 'CK' failed for tuple" })
+    ]], { 1, "Check constraint 'CK' failed for a tuple" })
 
 -- Make sure that one can't create constraint with the same name twice.
 --

--- a/test/sql-tap/check.test.lua
+++ b/test/sql-tap/check.test.lua
@@ -55,7 +55,7 @@ test:do_catchsql_test(
         INSERT INTO t1 VALUES(6,7, 2);
     ]], {
         -- <check-1.3>
-        1, "Check constraint 'ck_unnamed_T1_1' failed for tuple"
+        1, "Check constraint 'ck_unnamed_T1_1' failed for a tuple"
         -- </check-1.3>
     })
 
@@ -75,7 +75,7 @@ test:do_catchsql_test(
         INSERT INTO t1 VALUES(4,3, 2);
     ]], {
         -- <check-1.5>
-        1, "Check constraint 'ck_unnamed_T1_2' failed for tuple"
+        1, "Check constraint 'ck_unnamed_T1_2' failed for a tuple"
         -- </check-1.5>
     })
 
@@ -95,7 +95,7 @@ test:do_catchsql_test(
         INSERT INTO t1 VALUES(NULL,6, 4);
     ]], {
         -- <check-1.7>
-        1, "Check constraint 'ck_unnamed_T1_1' failed for tuple"
+        1, "Check constraint 'ck_unnamed_T1_1' failed for a tuple"
         -- </check-1.7>
     })
 
@@ -115,7 +115,7 @@ test:do_catchsql_test(
         INSERT INTO t1 VALUES(2,NULL, 5);
     ]], {
         -- <check-1.9>
-        1, "Check constraint 'ck_unnamed_T1_2' failed for tuple"
+        1, "Check constraint 'ck_unnamed_T1_2' failed for a tuple"
         -- </check-1.9>
     })
 
@@ -147,7 +147,7 @@ test:do_catchsql_test(
         UPDATE t1 SET x=7 WHERE x==2
     ]], {
         -- <check-1.12>
-        1, "Check constraint 'ck_unnamed_T1_1' failed for tuple"
+        1, "Check constraint 'ck_unnamed_T1_1' failed for a tuple"
         -- </check-1.12>
     })
 
@@ -167,7 +167,7 @@ test:do_catchsql_test(
         UPDATE t1 SET x=5 WHERE x==2
     ]], {
         -- <check-1.14>
-        1, "Check constraint 'ck_unnamed_T1_1' failed for tuple"
+        1, "Check constraint 'ck_unnamed_T1_1' failed for a tuple"
         -- </check-1.14>
     })
 
@@ -349,7 +349,7 @@ test:do_catchsql_test(
         INSERT INTO t3 VALUES(111,222,333);
     ]], {
         -- <check-3.9>
-        1, "Check constraint 'ck_unnamed_T3_1' failed for tuple"
+        1, "Check constraint 'ck_unnamed_T3_1' failed for a tuple"
         -- </check-3.9>
     })
 
@@ -420,7 +420,7 @@ test:do_catchsql_test(
         UPDATE t4 SET x=0, y=1;
     ]], {
         -- <check-4.6>
-        1, "Check constraint 'ck_unnamed_T4_1' failed for tuple"
+        1, "Check constraint 'ck_unnamed_T4_1' failed for a tuple"
         -- </check-4.6>
     })
 
@@ -440,7 +440,7 @@ test:do_catchsql_test(
         UPDATE t4 SET x=0, y=2;
     ]], {
         -- <check-4.9>
-        1, "Check constraint 'ck_unnamed_T4_1' failed for tuple"
+        1, "Check constraint 'ck_unnamed_T4_1' failed for a tuple"
         -- </check-4.9>
     })
 
@@ -517,7 +517,7 @@ test:do_catchsql_test(
         UPDATE OR FAIL t1 SET x=7-x, y=y+1;
     ]], {
         -- <check-6.5>
-        1, "Check constraint 'ck_unnamed_T1_1' failed for tuple"
+        1, "Check constraint 'ck_unnamed_T1_1' failed for a tuple"
         -- </check-6.5>
     })
 
@@ -539,7 +539,7 @@ test:do_catchsql_test(
         INSERT OR ROLLBACK INTO t1 VALUES(8,40.0, 10);
     ]], {
         -- <check-6.7>
-        1, "Check constraint 'ck_unnamed_T1_1' failed for tuple"
+        1, "Check constraint 'ck_unnamed_T1_1' failed for a tuple"
         -- </check-6.7>
     })
 
@@ -572,7 +572,7 @@ test:do_catchsql_test(
         REPLACE INTO t1 VALUES(6,7, 11);
     ]], {
         -- <check-6.12>
-        1, "Check constraint 'ck_unnamed_T1_1' failed for tuple"
+        1, "Check constraint 'ck_unnamed_T1_1' failed for a tuple"
         -- </check-6.12>
     })
 

--- a/test/sql-tap/decimal.test.lua
+++ b/test/sql-tap/decimal.test.lua
@@ -199,7 +199,7 @@ test:do_catchsql_test(
     [[
         INSERT INTO t5c SELECT 1, u FROM t2 LIMIT 1;
     ]], {
-        1, "Check constraint 'CK' failed for tuple"
+        1, "Check constraint 'CK' failed for a tuple"
     })
 
 test:do_execsql_test(

--- a/test/sql-tap/table.test.lua
+++ b/test/sql-tap/table.test.lua
@@ -1176,7 +1176,7 @@ test:do_catchsql_test(
         INSERT INTO T21 VALUES(2, -1, 1);
     ]], {
         -- <table-21.3>
-        1, "Check constraint 'ck_unnamed_T21_1' failed for tuple"
+        1, "Check constraint 'ck_unnamed_T21_1' failed for a tuple"
         -- </table-21.3>
     })
 
@@ -1327,7 +1327,7 @@ test:do_catchsql_test(
         INSERT INTO T28 VALUES(0);
     ]], {
         -- <table-22.10>
-        1, "Check constraint 'CHECK1' failed for tuple"
+        1, "Check constraint 'CHECK1' failed for a tuple"
         -- </table-22.10>
     })
 
@@ -1337,7 +1337,7 @@ test:do_catchsql_test(
         INSERT INTO T28 VALUES(9);
     ]], {
         -- <table-22.11>
-        1, "Check constraint 'CHECK2' failed for tuple"
+        1, "Check constraint 'CHECK2' failed for a tuple"
         -- </table-22.11>
     })
 

--- a/test/sql-tap/uuid.test.lua
+++ b/test/sql-tap/uuid.test.lua
@@ -192,7 +192,7 @@ test:do_catchsql_test(
     [[
         INSERT INTO t5c SELECT 1, u FROM t2 LIMIT 1;
     ]], {
-        1, "Check constraint 'CK' failed for tuple"
+        1, "Check constraint 'CK' failed for a tuple"
     })
 
 test:do_execsql_test(

--- a/test/sql/boolean.result
+++ b/test/sql/boolean.result
@@ -436,7 +436,7 @@ INSERT INTO t1 VALUES (1, false);
 INSERT INTO t1 VALUES (2, true);
  | ---
  | - null
- | - Check constraint 'CK' failed for tuple
+ | - Check constraint 'CK' failed for a tuple
  | ...
 
 -- Check interactions with FOREIGN KEY constraint.

--- a/test/sql/gh-2981-check-autoinc.result
+++ b/test/sql/gh-2981-check-autoinc.result
@@ -29,7 +29,7 @@ box.execute("insert into t1 values (18, null);")
 box.execute("insert into t1(s2) values (null);")
 ---
 - null
-- Check constraint 'ck_unnamed_T1_1' failed for tuple
+- Check constraint 'ck_unnamed_T1_1' failed for a tuple
 ...
 box.execute("insert into t2 values (18, null);")
 ---
@@ -38,7 +38,7 @@ box.execute("insert into t2 values (18, null);")
 box.execute("insert into t2(s2) values (null);")
 ---
 - null
-- Check constraint 'ck_unnamed_T2_1' failed for tuple
+- Check constraint 'ck_unnamed_T2_1' failed for a tuple
 ...
 box.execute("insert into t2 values (24, null);")
 ---
@@ -47,7 +47,7 @@ box.execute("insert into t2 values (24, null);")
 box.execute("insert into t2(s2) values (null);")
 ---
 - null
-- Check constraint 'ck_unnamed_T2_1' failed for tuple
+- Check constraint 'ck_unnamed_T2_1' failed for a tuple
 ...
 box.execute("insert into t3 values (9, null)")
 ---
@@ -56,7 +56,7 @@ box.execute("insert into t3 values (9, null)")
 box.execute("insert into t3(s2) values (null)")
 ---
 - null
-- Check constraint 'ck_unnamed_T3_1' failed for tuple
+- Check constraint 'ck_unnamed_T3_1' failed for a tuple
 ...
 box.execute("DROP TABLE t1")
 ---


### PR DESCRIPTION
The wording "Check constraint 'constr_name' failed for tuple" implies that the tuple should follow. This patch adds the missed "a" article.

Closes #9045