### PR TITLE
tools: add a tool to check downgrade versions list

### DIFF
--- a/src/box/lua/upgrade.lua
+++ b/src/box/lua/upgrade.lua
@@ -2095,6 +2095,7 @@ end
 
 -- List of all Tarantool releases we can downgrade to.
 local downgrade_versions = {
+    -- DOWNGRADE VERSIONS START
     "2.8.2",
     "2.8.3",
     "2.8.4",
@@ -2107,6 +2108,7 @@ local downgrade_versions = {
     "2.11.0",
     "2.11.1",
     "3.0.0",
+    -- DOWNGRADE VERSIONS END
 }
 
 -- Downgrade or list downgrade issues depending of dry_run argument value.

--- a/tools/check-downgrade-versions.sh
+++ b/tools/check-downgrade-versions.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# vim: set ts=4 sts=4 sw=4 et:
+
+set -eo pipefail
+
+upgrade_lua=src/box/lua/upgrade.lua
+# Get checkouted tag.
+current_tag=`git describe --exact-match HEAD`
+
+# List of versions supported by downgrade.
+# awk cuts versions from sources using markers. sed filters versions only
+# (symbols between "").
+versions=`mktemp`
+awk '/DOWNGRADE VERSIONS START/{flag=1; next}
+     /DOWNGRADE VERSIONS END/{flag=0} flag' $upgrade_lua |
+     sed -E 's/.*"(.*)".*/\1/' > $versions
+
+last=`tail -n1 $versions`
+first=`head -n1 $versions`
+
+if [[ $last != $current_tag ]]; then
+    echo "Last downgrade version should be the tag being released."
+    exit 1
+fi
+
+# Sorted list of tags from git starting from $first and ending at $last
+# (inclusively).
+# Last awk do the cut [$first, $last].
+tags=`mktemp`
+git tag -l -n1 | grep stable | sort -V | awk '{print $1}' |
+    awk "/$first/{flag=1} flag; /$last/{flag=0}" > $tags
+
+
+# Use || or 'set -e' mode will exit here.
+result=0
+diff=`mktemp`
+diff -u $versions $tags >$diff || result=1
+
+if [[ $result -ne 0 ]]; then
+    echo 'Downgrade version list is not correct:'
+    echo '  + marks missing versions'
+    echo '  - marks non-existing versions'
+    sed '/^\(---\|+++\) /d' $diff
+fi
+
+rm -rf $versions $tags $diff
+exit $result


### PR DESCRIPTION
We need to make sure the downgrade versions list in `src/box/lua/upgrade.lua` has all the released versions in downstream branches. As well as the version being released itself. Here we add a tool to make this check.

Usage:

- checkout the tag being released (should be annotated tag)
- run ./tools/check-downgrade-versions.sh

If the downgrade versions list is not correct then the difference between the current list and correct one will be printed.

Close #8319