### PR TITLE
config: introduce roles

### DIFF
--- a/changelogs/unreleased/gh-9078-roles.md
+++ b/changelogs/unreleased/gh-9078-roles.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* Introduced the initial support for roles - programs that run when
+  a configuration is loaded or reloaded (gh-9078).

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -44,6 +44,7 @@ lua_source(lua_sources lua/config/applier/console.lua     config_applier_console
 lua_source(lua_sources lua/config/applier/credentials.lua config_applier_credentials_lua)
 lua_source(lua_sources lua/config/applier/fiber.lua       config_applier_fiber_lua)
 lua_source(lua_sources lua/config/applier/mkdir.lua       config_applier_mkdir_lua)
+lua_source(lua_sources lua/config/applier/roles.lua       config_applier_roles_lua)
 lua_source(lua_sources lua/config/applier/sharding.lua    config_applier_sharding_lua)
 lua_source(lua_sources lua/config/cluster_config.lua      config_cluster_config_lua)
 lua_source(lua_sources lua/config/configdata.lua          config_configdata_lua)

--- a/src/box/lua/config/applier/roles.lua
+++ b/src/box/lua/config/applier/roles.lua
@@ -1,0 +1,87 @@
+local log = require('internal.config.utils.log')
+
+local last_loaded = {}
+local last_loaded_names_ordered = {}
+
+local function stop_roles(roles_to_skip)
+    for id = #last_loaded_names_ordered, 1, -1 do
+        local role_name = last_loaded_names_ordered[id]
+        if roles_to_skip == nil or roles_to_skip[role_name] == nil then
+            log.verbose('roles.apply: stop role ' .. role_name)
+            local ok, err = pcall(last_loaded[role_name].stop)
+            if not ok then
+                error(('Error stopping role %s: %s'):format(role_name, err), 0)
+            end
+        end
+    end
+end
+
+local function apply(config)
+    local configdata = config._configdata
+    local role_names = configdata:get('roles', {use_default = true})
+    if role_names == nil or next(role_names) == nil then
+        stop_roles()
+        return
+    end
+
+    -- Remove duplicates.
+    local roles = {}
+    local roles_ordered = {}
+    for _, role_name in pairs(role_names) do
+        if roles[role_name] == nil then
+            table.insert(roles_ordered, role_name)
+        end
+        roles[role_name] = true
+    end
+
+    -- Stop removed roles.
+    stop_roles(roles)
+
+    -- Run roles.
+    local roles_cfg = configdata:get('roles_cfg', {use_default = true}) or {}
+    local loaded = {}
+    local loaded_names_ordered = {}
+
+    -- Load roles.
+    for _, role_name in ipairs(roles_ordered) do
+        local role = last_loaded[role_name]
+        if not role then
+            log.verbose('roles.apply: load role ' .. role_name)
+            role = require(role_name)
+            local funcs = {'validate', 'apply', 'stop'}
+            for _, func_name in pairs(funcs) do
+                if type(role[func_name]) ~= 'function' then
+                    local err = 'Role %s does not contain function %s'
+                    error(err:format(role_name, func_name), 0)
+                end
+            end
+        end
+        loaded[role_name] = role
+        table.insert(loaded_names_ordered, role_name)
+    end
+
+    -- Validate configs for all roles.
+    for _, role_name in ipairs(roles_ordered) do
+        local ok, err = pcall(loaded[role_name].validate, roles_cfg[role_name])
+        if not ok then
+            error(('Wrong config for role %s: %s'):format(role_name, err), 0)
+        end
+    end
+
+    -- Apply configs for all roles.
+    for _, role_name in ipairs(roles_ordered) do
+        log.verbose('roles.apply: apply config for role ' .. role_name)
+        local ok, err = pcall(loaded[role_name].apply, roles_cfg[role_name])
+        if not ok then
+            error(('Error applying role %s: %s'):format(role_name, err), 0)
+        end
+    end
+
+    last_loaded = loaded
+    last_loaded_names_ordered = loaded_names_ordered
+end
+
+return {
+    name = 'roles',
+    apply = apply,
+}

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -150,6 +150,7 @@ function methods._initialize(self)
     self:_register_applier(require('internal.config.applier.console'))
     self:_register_applier(require('internal.config.applier.fiber'))
     self:_register_applier(require('internal.config.applier.sharding'))
+    self:_register_applier(require('internal.config.applier.roles'))
     self:_register_applier(require('internal.config.applier.app'))
 
     if extras ~= nil then

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1802,6 +1802,13 @@ return schema.new('instance_config', schema.record({
             "compatibility",
         }),
     })),
+    roles_cfg = schema.map({
+        key = schema.scalar({type = 'string'}),
+        value = schema.scalar({type = 'any'}),
+    }),
+    roles = schema.array({
+        items = schema.scalar({type = 'string'})
+    }),
 }, {
     -- This kind of validation cannot be implemented as the
     -- 'validate' annotation of a particular schema node. There

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -144,6 +144,7 @@ extern char session_lua[],
 	config_applier_credentials_lua[],
 	config_applier_fiber_lua[],
 	config_applier_mkdir_lua[],
+	config_applier_roles_lua[],
 	config_applier_sharding_lua[],
 	config_cluster_config_lua[],
 	config_configdata_lua[],
@@ -386,6 +387,10 @@ static const char *lua_sources[] = {
 	"config/applier/sharding",
 	"internal.config.applier.sharding",
 	config_applier_sharding_lua,
+
+	"config/applier/roles",
+	"internal.config.applier.roles",
+	config_applier_roles_lua,
 
 	"config/init",
 	"config",

--- a/test/config-luatest/roles_test.lua
+++ b/test/config-luatest/roles_test.lua
@@ -1,0 +1,355 @@
+local t = require('luatest')
+local helpers = require('test.config-luatest.helpers')
+
+local g = helpers.group()
+
+-- Make sure the role is properly loaded.
+g.test_single_role_success = function(g)
+    local one = [[
+        local function apply(cfg)
+            _G.bar = cfg
+        end
+
+        _G.foo = 42
+        _G.bar = nil
+
+        return {
+            validate = function() end,
+            apply = apply,
+            stop = function() end,
+        }
+    ]]
+    local verify = function()
+        local config = require('config')
+        t.assert_equals(_G.foo, 42)
+        local roles_cfg = config:get('roles_cfg')
+        t.assert_equals(roles_cfg['one'], 12345)
+        t.assert_equals(roles_cfg['one'], _G.bar)
+    end
+
+    helpers.success_case(g, {
+        roles = {one = one},
+        options = {
+            ['roles_cfg'] = {one = 12345},
+            ['roles'] = {'one'}
+        },
+        verify = verify,
+    })
+end
+
+-- Make sure the role is loaded only once during each run.
+g.test_role_repeat_success = function(g)
+    local one = [[
+        local function apply(cfg)
+            _G.foo = _G.foo * cfg
+        end
+
+        _G.foo = 42
+
+        return {
+            validate = function() end,
+            apply = apply,
+            stop = function() end,
+        }
+    ]]
+    local verify = function()
+        local config = require('config')
+        local roles_cfg = config:get('roles_cfg')
+        t.assert_equals(roles_cfg['one'], 3)
+        t.assert_equals(_G.foo, 42 * 3)
+    end
+
+    helpers.success_case(g, {
+        roles = {one = one},
+        options = {
+            ['roles_cfg'] = {one = 3},
+            ['roles'] = {'one', 'one', 'one', 'one', 'one', 'one', 'one'}
+        },
+        verify = verify,
+    })
+end
+
+-- Make sure all roles are loaded correctly and in correct order.
+g.test_multiple_role_success = function(g)
+    local one = [[
+        local function apply(cfg)
+            _G.foo = tonumber(cfg)
+        end
+
+        _G.foo = nil
+
+        return {
+            validate = function() end,
+            apply = apply,
+            stop = function() end,
+        }
+    ]]
+
+    local two = [[
+        local function apply(cfg)
+            _G.foo = _G.foo + tonumber(cfg)
+        end
+
+        return {
+            validate = function() end,
+            apply = apply,
+            stop = function() end,
+        }
+    ]]
+
+    local three = [[
+        local function apply(cfg)
+            _G.foo = foo / tonumber(cfg)
+        end
+
+        return {
+            validate = function() end,
+            apply = apply,
+            stop = function() end,
+        }
+    ]]
+
+    local verify = function()
+        local config = require('config')
+        t.assert_equals(config:get('roles'), {'one', 'two', 'three'})
+        local roles_cfg = config:get('roles_cfg')
+        local one = roles_cfg['one']
+        local two = roles_cfg['two']
+        local three = roles_cfg['three']
+        t.assert_equals(one, 42)
+        t.assert_equals(two, '24')
+        t.assert_equals(three, 3)
+        t.assert_equals(_G.foo, 22)
+    end
+
+    helpers.success_case(g, {
+        roles = {one = one, two = two, three = three},
+        options = {
+            ['roles_cfg'] = {one = 42, two = '24', three = 3},
+            ['roles'] = {'one', 'two', 'three'}
+        },
+        verify = verify,
+    })
+end
+
+-- Make sure the roles call apply() during a reload.
+g.test_role_reload_success = function(g)
+    local one = [[
+        local function apply(cfg)
+            _G.foo = _G.foo * cfg
+        end
+
+        _G.foo = 42
+
+        return {
+            validate = function() end,
+            apply = apply,
+            stop = function() end,
+        }
+    ]]
+
+    local verify = function()
+        local config = require('config')
+        local roles_cfg = config:get('roles_cfg')
+        t.assert_equals(roles_cfg['one'], 2)
+        t.assert_equals(_G.foo, 42 * 2)
+    end
+
+    local verify_2 = function()
+        local config = require('config')
+        local roles_cfg = config:get('roles_cfg')
+        t.assert_equals(roles_cfg['one'], 3)
+        t.assert_equals(_G.foo, 42 * 2 * 3)
+    end
+
+    helpers.reload_success_case(g, {
+        roles = {one = one},
+        roles_2 = {one = one},
+        options = {
+            ['roles_cfg'] = {one = 2},
+            ['roles'] = {'one'}
+        },
+        options_2 = {
+            ['roles_cfg'] = {one = 3},
+            ['roles'] = {'one'}
+        },
+        verify = verify,
+        verify_2 = verify_2,
+    })
+end
+
+-- Make sure the roles are stopped after reload if they were removed from the
+-- configuration.
+g.test_role_stop_success = function(g)
+    local one = [[
+        local function apply(cfg)
+            _G.foo = _G.foo * cfg
+        end
+
+        local function stop()
+            _G.foo = _G.foo - 100
+        end
+
+        _G.foo = 42
+
+        return {
+            validate = function() end,
+            apply = apply,
+            stop = stop,
+        }
+    ]]
+
+    local verify = function()
+        local config = require('config')
+        t.assert_equals(config:get('roles'), {'one'})
+        local roles_cfg = config:get('roles_cfg')
+        t.assert_equals(roles_cfg['one'], 2)
+        t.assert_equals(_G.foo, 42 * 2)
+    end
+
+    local verify_2 = function()
+        local config = require('config')
+        t.assert_equals(config:get('roles'), nil)
+        local roles_cfg = config:get('roles_cfg')
+        t.assert_equals(roles_cfg['one'], 1)
+        t.assert_equals(_G.foo, 42 * 2 - 100)
+    end
+
+    helpers.reload_success_case(g, {
+        roles = {one = one},
+        roles_2 = {one = one},
+        options = {
+            ['roles_cfg'] = {one = 2},
+            ['roles'] = {'one'}
+        },
+        options_2 = {
+            ['roles_cfg'] = {one = 1},
+        },
+        verify = verify,
+        verify_2 = verify_2,
+    })
+end
+
+-- Ensure that errors during config validation are handled correctly.
+g.test_role_validate_error = function(g)
+    local one = [[
+        local function validate(cfg)
+            error('something wrong', 0)
+        end
+
+        return {
+            validate = validate,
+            apply = function() end,
+            stop = function() end,
+        }
+    ]]
+
+    helpers.failure_case(g, {
+        roles = {one = one},
+        options = {
+            ['roles_cfg'] = {one = 1},
+            ['roles'] = {'one'}
+        },
+        exp_err = 'Wrong config for role one: something wrong'
+    })
+end
+
+-- Ensure that errors during role application are handled correctly.
+g.test_role_apply_error = function(g)
+    local one = [[
+        local function apply(cfg)
+            error('something wrong', 0)
+        end
+
+        return {
+            validate = function() end,
+            apply = apply,
+            stop = function() end,
+        }
+    ]]
+
+    helpers.failure_case(g, {
+        roles = {one = one},
+        options = {
+            ['roles_cfg'] = {one = 1},
+            ['roles'] = {'one'}
+        },
+        exp_err = 'Error applying role one: something wrong'
+    })
+end
+
+-- Make sure an error is raised if not all methods are present.
+g.test_role_no_method_error = function(g)
+    local one = [[
+        return {
+            apply = function() end,
+            stop = function() end,
+        }
+    ]]
+    helpers.failure_case(g, {
+        roles = {one = one},
+        options = {
+            ['roles_cfg'] = {one = 1},
+            ['roles'] = {'one'}
+        },
+        exp_err = 'Role one does not contain function validate'
+    })
+
+    one = [[
+        return {
+            validate = function() end,
+            stop = function() end,
+        }
+    ]]
+    helpers.failure_case(g, {
+        roles = {one = one},
+        options = {
+            ['roles_cfg'] = {one = 1},
+            ['roles'] = {'one'}
+        },
+        exp_err = 'Role one does not contain function apply'
+    })
+
+    one = [[
+        return {
+            validate = function() end,
+            apply = function() end,
+        }
+    ]]
+    helpers.failure_case(g, {
+        roles = {one = one},
+        options = {
+            ['roles_cfg'] = {one = 1},
+            ['roles'] = {'one'}
+        },
+        exp_err = 'Role one does not contain function stop'
+    })
+end
+
+-- Ensure that errors during role stopping are handled correctly.
+--
+-- Also verify that the error is raised by config:reload() and the same error
+-- appears in the alerts.
+g.test_role_reload_error = function(g)
+    local one = [[
+        return {
+            validate = function() end,
+            apply = function() end,
+            stop = function() error('Wrongly stopped', 0) end,
+        }
+    ]]
+
+    helpers.reload_failure_case(g, {
+        roles = {one = one},
+        roles_2 = {one = one},
+        options = {
+            ['roles_cfg'] = {one = 1},
+            ['roles'] = {'one'}
+        },
+        options_2 = {
+            ['roles_cfg'] = {one = 1},
+        },
+        verify = function() end,
+        exp_err = 'Error stopping role one: Wrongly stopped'
+    })
+end


### PR DESCRIPTION
This patch introduces initial support for roles. Dependencies are not
currently supported for roles.

Part of https://github.com/tarantool/tarantool/issues/9078

@TarantoolBot document
Title: Roles

Two new options have been added: "roles" and "roles_cfg". The first one
is an array and the second one is a map. Each of these can be defined
per instance, replica set, group, and globally. As with almost all other
options, with the exception of those defined as 'map', the 'roles'
option for the lower scope will replace the roles for the higher scope.
Value roles_cfg however defined as "map", so it will be merged.

The "roles" option defines the roles for each instance. A role is a
program that runs when a configuration is loaded or reloaded. If a role
is defined more than once on an instance, it will still only be run
once. Three functions must be defined in the role: validate(), apply()
and stop(). Each of these functions should throw an error if it occurs.

The "roles_cfg" option specifies the configuration for each role. In
this option, the role name is the key and the role configuration is the
value.

On each run, all roles will be loaded (if necessary) in the order in
which they were specified; the configuration for each role will then be
validated using the corresponding validate() function in the same order;
and then they will all be run with apply() function in the same order.
If some roles have been removed from the instance, they will be stopped
in reverse order using the stop() function.

Example of a role structure:
```Lua
local M = {}

-- Validates configuration of the role.
--
-- Called on initial configuration apply at startup and on
-- configuration reload if the role is enabled for the given instance.
--
-- The cfg argument may have arbitrary user provided value,
-- including nil.
--
-- Must raise an error if the validation fail.
function M.validate(cfg)
    -- <...>
end

-- Applies the given configuration of the role.
--
-- Called on initial configuration apply at startup and on
-- configuration reload if the role is enabled for the given instance.
--
-- The cfg argument may have arbitrary user provided value,
-- including nil.
--
-- Must raise an error if the given configuration can't be applied.
function M.apply(cfg)
    -- <...>
end

-- Stops the role.
--
-- Called on configuration reload if the role was enabled before
-- and removed now from the list of roles of the given instance.
--
-- Should cancel all background fibers and clean up hold
-- resources.
--
-- Must raise an error if this action can't be performed.
function M.stop()
    -- <...>
end

return M
```