### PR TITLE
test/config: verify that user/role is not deleted

### DIFF
--- a/test/config-luatest/helpers.lua
+++ b/test/config-luatest/helpers.lua
@@ -196,6 +196,11 @@ end
 --   A new script to write into the main.lua file before
 --   config:reload().
 --
+-- * opts.options_2
+--
+--   A new config to use for the config:reload(). It is optional,
+--   if not provided opts.options is used instead.
+--
 -- * opts.verify_2
 --
 --   Verify test invariants after config:reload().
@@ -203,13 +208,14 @@ local function reload_success_case(g, opts)
     local script_2 = opts.script_2
     local options = assert(opts.options)
     local verify_2 = assert(opts.verify_2)
+    local options_2 = opts.options_2 or options
 
     local prepared = success_case(g, opts)
 
     prepare_case(g, {
         dir = prepared.dir,
         script = script_2,
-        options = options,
+        options = options_2,
     })
     g.server:exec(function()
         local config = require('config')

--- a/test/treegen.lua
+++ b/test/treegen.lua
@@ -79,7 +79,7 @@ end
 -- unless KEEP_DATA environment variable is set to a
 -- non-empty value.
 function treegen.clean(g)
-    local dirs = table.copy(g.tempdirs)
+    local dirs = table.copy(g.tempdirs) or {}
     g.tempdirs = nil
 
     local keep_data = (os.getenv('KEEP_DATA') or '') ~= ''


### PR DESCRIPTION
When the configuration changes and the instance is reloaded with it,
some roles or users may be removed from the config. In such case,
it would be destructive to delete/disable them on the instance, so
this test checks that all users and roles removed in config stay
on the instance.
    
Part of #8967
