### PR TITLE
cmake: fix warning in `FindLibUnwind.cmake`

### DIFF
--- a/cmake/FindLibUnwind.cmake
+++ b/cmake/FindLibUnwind.cmake
@@ -79,7 +79,7 @@ else()
     GetLibUnwindVersion(LIBUNWIND_VERSION)
 endif()
 
-find_package_handle_standard_args(GetLIBUNWINDVersion.cmake
+find_package_handle_standard_args(LibUnwind
       VERSION_VAR LIBUNWIND_VERSION
       REQUIRED_VARS LIBUNWIND_INCLUDE_DIR LIBUNWIND_LIBRARIES)
 


### PR DESCRIPTION
This patch fixes the following warning:

```
  CMake Warning (dev) at cmake-3.25/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
    The package name passed to `find_package_handle_standard_args`
    (GetLIBUNWINDVersion.cmake) does not match the name of the calling package
    (LibUnwind).  This can lead to problems in calling code that expects
    `find_package` result variables (e.g., `_FOUND`) to follow a certain
    pattern.
  Call Stack (most recent call first):
    cmake/FindLibUnwind.cmake:82 (find_package_handle_standard_args)
    CMakeLists.txt:552 (find_package)
```

Closes #6998