### PR TITLE
config: revoke privs for default users and roles

### DIFF
--- a/changelogs/unreleased/gh-8967-creds-restore-defaults-for-default-user.md
+++ b/changelogs/unreleased/gh-8967-creds-restore-defaults-for-default-user.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* Non-default privileges are now revoked from default users and roles
+  when they are removed from the config (gh-8967).

--- a/src/box/lua/config/applier/credentials.lua
+++ b/src/box/lua/config/applier/credentials.lua
@@ -493,6 +493,35 @@ local function apply(config)
         return
     end
 
+    -- Tarantool has the following roles and users present by default on every
+    -- instance:
+    --
+    -- Default roles:
+    -- * super
+    -- * public
+    -- * replication
+    --
+    -- Default users:
+    -- * guest
+    -- * admin
+    --
+    -- These roles and users have according privileges pre-granted by design.
+    -- Credentials applier adds such privileges with `priviliges_add_default()`
+    -- when syncing. So, for the excessive (non-default) privs to be removed,
+    -- these roles and users must be present inside configuration at least in a
+    -- form of an empty table. Otherwise, the privileges will be left unchanged,
+    -- similar to all used-defined roles and users.
+
+    credentials.roles = credentials.roles or {}
+    credentials.roles['super'] = credentials.roles['super'] or {}
+    credentials.roles['public'] = credentials.roles['public'] or {}
+    credentials.roles['replication'] = credentials.roles['replication'] or {}
+
+    credentials.users = credentials.users or {}
+    credentials.users['guest'] = credentials.users['guest'] or {}
+    credentials.users['admin'] = credentials.users['admin'] or {}
+
+    -- Create roles and users and synchronise privileges for them.
     create_roles(credentials.roles)
     create_users(credentials.users)
 end


### PR DESCRIPTION
All user-defined users and roles are not being removed and their privileges are not being revoked when this user or role is removed from config. This is done to prevent extreme repercussions of misconfiguration, e.g. empty config is provided to cluster and it breaks up.

Default users and roles are not supposed to be changed, so this rule does not apply to them. Now all of non-default privileges will be revoked if such user or role is removed from config.

Default users:
* guest
* admin

Default roles:
* super
* public
* replication

Part of #8967