### PR TITLE
box: fix schema downgrade replication

### DIFF
--- a/changelogs/unreleased/gh-9049-schema-downgrade-replication.md
+++ b/changelogs/unreleased/gh-9049-schema-downgrade-replication.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+- Fixed a bug that caused a replication error after calling
+  `box.schema.downgrade` (gh-9049).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -2295,7 +2295,8 @@ on_replace_dd_space(struct trigger * /* trigger */, void *event)
 		if (space_check_pinned(old_space) != 0)
 			return -1;
 		/* One can't just remove a system space. */
-		if (space_is_system(old_space)) {
+		if (!dd_check_is_disabled() &&
+		    space_is_system(old_space)) {
 			diag_set(ClientError, ER_DROP_SPACE,
 				 space_name(old_space),
 				 "the space is a system space");
@@ -2547,7 +2548,8 @@ on_replace_dd_index(struct trigger * /* trigger */, void *event)
 		/*
 		 * Dropping the primary key in a system space: off limits.
 		 */
-		if (space_is_system(old_space)) {
+		if (!dd_check_is_disabled() &&
+		    space_is_system(old_space)) {
 			diag_set(ClientError, ER_LAST_DROP,
 				  space_name(old_space));
 			return -1;
@@ -3216,13 +3218,12 @@ func_def_new_from_tuple(struct tuple *tuple)
 		language = STR2ENUM(func_language, language_str);
 		/*
 		 * 'SQL_BUILTIN' was dropped in 2.9, but to support upgrade
-		 * from previous versions, we allow to create such functions
-		 * if the data dictionary version is older.
+		 * from previous versions, we allow to create such functions.
 		 */
 		if (language == func_language_MAX ||
 		    language == FUNC_LANGUAGE_SQL ||
 		    (language == FUNC_LANGUAGE_SQL_BUILTIN &&
-		     dd_version_id >= version_id(2, 9, 0))) {
+		     !dd_check_is_disabled())) {
 			diag_set(ClientError, ER_FUNCTION_LANGUAGE,
 				 language_str, tt_cstr(name, name_len));
 			return NULL;

--- a/src/box/schema.h
+++ b/src/box/schema.h
@@ -52,6 +52,15 @@ extern uint32_t dd_version_id;
 /** Triggers invoked after schema initialization. */
 extern struct rlist on_schema_init;
 
+/**
+ * Returns true if data dictionary checks may be skipped by the current fiber.
+ *
+ * We disable some data dictionary checks for schema upgrade and downgrade, for
+ * example, we allow dropping a system space.
+ */
+bool
+dd_check_is_disabled(void);
+
 /** \cond public */
 
 /**

--- a/test/replication-luatest/gh_9049_schema_downgrade_test.lua
+++ b/test/replication-luatest/gh_9049_schema_downgrade_test.lua
@@ -1,0 +1,41 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_test('test_schema_downgrade', function(cg)
+    cg.master = server:new({alias = 'master'})
+    cg.replica = server:new({
+        alias = 'replica',
+        box_cfg = {
+            read_only = true,
+            replication = cg.master.net_box_uri,
+        },
+    })
+    cg.master:start()
+    cg.replica:start()
+end)
+
+g.test_schema_downgrade = function(cg)
+    local version = cg.master:exec(function()
+        box.schema.downgrade('2.8.4')
+        return box.space._schema:get('version')
+    end)
+    cg.replica:wait_for_vclock_of(cg.master)
+    cg.replica:exec(function(version)
+        t.assert(box.info.replication[1].upstream)
+        t.assert_equals(box.info.replication[1].upstream.status, 'follow')
+        t.assert_equals(box.space._schema:get('version'), version)
+    end, {version})
+    cg.replica:restart()
+    cg.replica:exec(function(version)
+        t.assert(box.info.replication[1].upstream)
+        t.assert_equals(box.info.replication[1].upstream.status, 'follow')
+        t.assert_equals(box.space._schema:get('version'), version)
+    end, {version})
+end
+
+g.after_test('test_schema_downgrade', function(cg)
+    cg.replica:drop()
+    cg.master:drop()
+end)


### PR DESCRIPTION
Some downgrade operations are performed with disabled system space triggers because they were prohibited recently (creation of SQL built-in functions) or never allowed (dropping a system space). This works fine on the instance running downgrade but apparently fails on replicas.

To fix this issue, let's disable the checks the operations that prevent downgrade in the following scenarios:
 - in the fiber that is currently running a schema upgrade or downgrade;
 - in the applier fiber so that it can replicate changes done by upgrade or downgrade on the master;
 - during recovery so that DDL records written to the WAL can be replayed.

We already have all the necessary infrastructure in-place - we use it for allowing DDL operations with an old schema for upgrade.

Closes #9049