### PR TITLE
audit/security: get rid of session triggers

### DIFF
--- a/src/box/audit.h
+++ b/src/box/audit.h
@@ -32,6 +32,24 @@ audit_log_check_filter(const char *filter)
 	return 0;
 }
 
+/**
+ * Logs disconnect event if it is enabled.
+ */
+static inline void
+audit_on_disconnect(void) {}
+
+/**
+ * Logs authenticate event if it is enabled.
+ */
+static inline void
+audit_on_auth(const char *user_name, size_t user_name_len,
+	      bool is_authenticated)
+{
+	(void)user_name;
+	(void)user_name_len;
+	(void)is_authenticated;
+}
+
 static inline void
 audit_log_init(const char *init_str, int log_nonblock, const char *format,
 	       const char *filter)

--- a/src/box/authentication.c
+++ b/src/box/authentication.c
@@ -121,9 +121,7 @@ authenticate(const char *user_name, uint32_t user_name_len,
 	if (access_check_session(user) != 0)
 		return -1;
 ok:
-	/* check and run auth triggers on success */
-	if (! rlist_empty(&session_on_auth) &&
-	    session_run_on_auth_triggers(&auth_res) != 0)
+	if (session_run_on_auth_triggers(&auth_res) != 0)
 		return -1;
 	credentials_reset(&current_session()->credentials, user);
 	return 0;

--- a/src/box/error.cc
+++ b/src/box/error.cc
@@ -31,6 +31,7 @@
 #include "error.h"
 #include <stdio.h>
 
+#include "audit.h"
 #include "fiber.h"
 #include "rmean.h"
 #include "trigger.h"

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -1777,10 +1777,8 @@ tx_process_disconnect(struct cmsg *m)
 		 * closed, its push() method is replaced with a stub.
 		 */
 		con->tx.is_push_pending = false;
-		if (! rlist_empty(&session_on_disconnect)) {
-			tx_fiber_init(con->session, 0);
-			session_run_on_disconnect_triggers(con->session);
-		}
+		tx_fiber_init(con->session, 0);
+		session_run_on_disconnect_triggers(con->session);
 	}
 }
 

--- a/src/box/security.h
+++ b/src/box/security.h
@@ -19,6 +19,19 @@ extern "C" {
 
 struct user;
 
+/**
+ * Registers an authentication delay for the given user if authentication
+ * failed and the feature is enabled.
+ */
+static inline void
+security_on_auth(const char *user_name, size_t user_name_len,
+		 bool is_authenticated)
+{
+	(void)user_name;
+	(void)user_name_len;
+	(void)is_authenticated;
+}
+
 static inline void
 security_init(void) {}
 

--- a/src/box/session.c
+++ b/src/box/session.c
@@ -43,6 +43,8 @@
 #include "on_shutdown.h"
 #include "sql.h"
 #include "tweaks.h"
+#include "audit.h"
+#include "security.h"
 
 const char *session_type_strs[] = {
 	"background",
@@ -341,6 +343,7 @@ session_run_triggers(struct session *session, struct rlist *triggers)
 void
 session_run_on_disconnect_triggers(struct session *session)
 {
+	audit_on_disconnect();
 	if (session_run_triggers(session, &session_on_disconnect) != 0)
 		diag_log();
 }
@@ -354,6 +357,10 @@ session_run_on_connect_triggers(struct session *session)
 int
 session_run_on_auth_triggers(const struct on_auth_trigger_ctx *result)
 {
+	audit_on_auth(result->user_name, result->user_name_len,
+		      result->is_authenticated);
+	security_on_auth(result->user_name, result->user_name_len,
+			 result->is_authenticated);
 	return trigger_run(&session_on_auth, (void *)result);
 }
 


### PR DESCRIPTION
Since we are going to move session triggers to the trigger registry, old session triggers will be used only for audit and security features. Also, direct function call makes code more obvious than using callback. So let's remove old session triggers form audit and security and use functions instead. The patch adss CE stubs for functions that will be used instead of session_on_auth and session_on_disconnect triggers. Also, audit uses on_access_denied trigger, which is considered as a session trigger, but it belong to internal box_error library while audit is built as a part of box library - this case is more complicated, so let's leave old on_access_denied trigger for now.

Part of #8657

DO NOT MERGED BEFORE EE PART IS APPROVED