### PR TITLE
lua/fiber: do not raise on printing a dead fiber

### DIFF
--- a/changelogs/unreleased/gh-4265-printing-a-finished-fiber-stops-the-program.md
+++ b/changelogs/unreleased/gh-4265-printing-a-finished-fiber-stops-the-program.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* An error is no longer raised on an attempt to print a dead fiber (gh-4265).

--- a/test/app-luatest/fiber_test.lua
+++ b/test/app-luatest/fiber_test.lua
@@ -1,0 +1,36 @@
+local fiber = require('fiber')
+local t = require('luatest')
+local g = t.group('fiber')
+
+-- Test __serialize metamethod of the fiber.
+g.test_serialize = function()
+    local f = fiber.new(function() end)
+    local fid = f:id()
+    f:name('test fiber')
+
+    -- Serialize a ready fiber.
+    t.assert_equals(f:__serialize(),
+                    { id = fid, name = 'test fiber', status = 'suspended' })
+
+    -- gh-4265: Serializing a finished fiber should not raise an error.
+    fiber.yield()
+    t.assert_equals(f:__serialize(), { id = fid, status = 'dead' })
+
+    -- Serialize a running fiber.
+    t.assert_equals(fiber.self():__serialize(),
+                    { id = fiber.self():id(),
+                      name = 'luatest',
+                      status = 'running' })
+end
+
+-- Test __tostring metamethod of the fiber.
+g.test_tostring = function()
+    local f = fiber.new(function() end)
+    local fid = f:id()
+
+    t.assert_equals(tostring(f), "fiber: " .. fid)
+
+    -- gh-4265: Printing a finished fiber should not raise an error.
+    fiber.yield()
+    t.assert_equals(tostring(f), "fiber: " .. fid .. " (dead)")
+end

--- a/test/app/fiber.result
+++ b/test/app/fiber.result
@@ -961,9 +961,8 @@ fiber.create(function()end):name()
 --
 -- gh-1926
 --
-fiber.create(function() fiber.wakeup(fiber.self()) end)
+_ = fiber.create(function() fiber.wakeup(fiber.self()) end)
 ---
-- the fiber is dead
 ...
 --
 -- gh-2066 test for fiber wakeup

--- a/test/app/fiber.test.lua
+++ b/test/app/fiber.test.lua
@@ -387,7 +387,7 @@ fiber.create(function()end):name()
 --
 -- gh-1926
 --
-fiber.create(function() fiber.wakeup(fiber.self()) end)
+_ = fiber.create(function() fiber.wakeup(fiber.self()) end)
 
 --
 -- gh-2066 test for fiber wakeup


### PR DESCRIPTION
An attempt to print a dead fiber raised a fatal error, which is quite unexpected.
This patch updates `__tostring` metamethod of `fiber_object` so that it pushes the `fiber: <fid> (dead)` string instead of the error. The `__serialize` metamethod is patched similarly.

Closes #4265