### PR TITLE
box: fix out of bound write in `error_payload_destroy()`

### DIFF
--- a/changelogs/unreleased/gh-9098-out-of-bound-write-in-error_payload_destroy.md
+++ b/changelogs/unreleased/gh-9098-out-of-bound-write-in-error_payload_destroy.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a possible out-of-bound write in debug build on unpacking a MsgPack
+  error extension (gh-9098).

--- a/src/lib/core/error_payload.h
+++ b/src/lib/core/error_payload.h
@@ -20,7 +20,7 @@ struct error_field {
 	/** Data size. */
 	uint32_t size;
 	/** Zero terminated field name. */
-	char name[1];
+	char *name;
 };
 
 /**

--- a/src/lua/error.lua
+++ b/src/lua/error.lua
@@ -18,7 +18,7 @@ typedef void (*error_f)(struct error *e);
 struct error_field {
     char *_data;
     uint32_t _size;
-    char _name[1];
+    char *_name;
 };
 
 struct error_payload {


### PR DESCRIPTION
If `strlen(name)` is 1, `value_size` is 1, and `extra` is 0, then 15 bytes are allocated for `struct error_field` in `error_payload_prepare()`. However, the size of this structure is 16 because of the padding for the alignment. Thus `TRASH()` in `error_payload_destroy()` writes 1 byte beyond the structure.

Closes #9098