### PR TITLE
config: postpone creds applier when in RO till RW

### DIFF
--- a/changelogs/unreleased/gh-8967-creds-postope-sync-when-RO-till-RW.md
+++ b/changelogs/unreleased/gh-8967-creds-postope-sync-when-RO-till-RW.md
@@ -1,0 +1,5 @@
+## feature/config
+
+* On read-only instances, Tarantool now synchronizes credentials
+  in the background when switching to read-write mode instead of
+  skipping the synchronization (gh-8967).


### PR DESCRIPTION
Before this patch credentials applier used to just skip if Tarantool was in Read Only mode. Now it starts a fiber that waits for instance to be switched to Read Write mode and then applies in the background.

Part of #8967

NO_DOC=documentation request will be filed manually for the whole
       credentials