### PR TITLE
test/fuzz: fix xrow_header_decode_fuzzer

### DIFF
--- a/test/fuzz/xrow_header_decode_fuzzer.c
+++ b/test/fuzz/xrow_header_decode_fuzzer.c
@@ -1,6 +1,7 @@
 #include "box/iproto_constants.h"
 #include "box/xrow.h"
 #include "memory.h"
+#include "fiber.h"
 
 void
 cord_on_yield(void) {}
@@ -10,12 +11,14 @@ static void
 setup(void)
 {
 	memory_init();
+	fiber_init(fiber_c_invoke);
 }
 
 __attribute__((destructor))
 static void
 teardown(void)
 {
+	fiber_free();
 	memory_free();
 }
 


### PR DESCRIPTION
On 2.10 branch xrow_header_decode_fuzzer fails with segmentation fault [^1] in diag.c:diag_get() due to a missed fiber structure. This happens in 2.10 only because commit 508138b79472 ("fiber: initialize thread-local cord on demand") was not backported to 2.10.

The patch adds initialization of fiber like we do in unit tests and thus fixes segmentation fault.

NO_CHANGELOG=testing
NO_DOC=testing

[^1]: https://github.com/tarantool/tarantool/actions/runs/6123773569/job/16623579367