### PR TITLE
[2.11] box: fix schema downgrade replication

### DIFF
--- a/changelogs/unreleased/gh-9049-schema-downgrade-replication.md
+++ b/changelogs/unreleased/gh-9049-schema-downgrade-replication.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+- Fixed a bug that caused a replication error after calling
+  `box.schema.downgrade` (gh-9049).

--- a/extra/exports
+++ b/extra/exports
@@ -100,6 +100,8 @@ box_region_used
 box_replace
 box_return_mp
 box_return_tuple
+box_schema_upgrade_begin
+box_schema_upgrade_end
 box_schema_version
 box_select_ffi
 box_sequence_current

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -2454,7 +2454,8 @@ on_replace_dd_index(struct trigger * /* trigger */, void *event)
 		/*
 		 * Dropping the primary key in a system space: off limits.
 		 */
-		if (space_is_system(old_space)) {
+		if (!dd_check_is_disabled() &&
+		    space_is_system(old_space)) {
 			diag_set(ClientError, ER_LAST_DROP,
 				  space_name(old_space));
 			return -1;
@@ -3114,13 +3115,12 @@ func_def_new_from_tuple(struct tuple *tuple)
 		language = STR2ENUM(func_language, language_str);
 		/*
 		 * 'SQL_BUILTIN' was dropped in 2.9, but to support upgrade
-		 * from previous versions, we allow to create such functions
-		 * if the data dictionary version is older.
+		 * from previous versions, we allow to create such functions.
 		 */
 		if (language == func_language_MAX ||
 		    language == FUNC_LANGUAGE_SQL ||
 		    (language == FUNC_LANGUAGE_SQL_BUILTIN &&
-		     dd_version_id >= version_id(2, 9, 0))) {
+		     !dd_check_is_disabled())) {
 			diag_set(ClientError, ER_FUNCTION_LANGUAGE,
 				 language_str, tt_cstr(name, name_len));
 			return NULL;

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -324,7 +324,7 @@ struct errcode_record {
 	/*269 */_(ER_UNUSED3,			"") \
 	/*270 */_(ER_UNUSED4,			"") \
 	/*271 */_(ER_UNUSED5,			"") \
-	/*272 */_(ER_UNUSED6,			"") \
+	/*272 */_(ER_SCHEMA_UPGRADE_IN_PROGRESS, "Schema upgrade is already in progress") \
 	/*273 */_(ER_UNUSED7,			"") \
 	/*274 */_(ER_UNCONFIGURED,		"Please call box.cfg{} first") \
 

--- a/src/box/schema.h
+++ b/src/box/schema.h
@@ -52,6 +52,15 @@ extern uint32_t dd_version_id;
 /** Triggers invoked after schema initialization. */
 extern struct rlist on_schema_init;
 
+/**
+ * Returns true if data dictionary checks may be skipped by the current fiber.
+ *
+ * We disable some data dictionary checks for schema upgrade and downgrade, for
+ * example, we allow dropping a system space.
+ */
+bool
+dd_check_is_disabled(void);
+
 /** \cond public */
 
 /**

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -484,6 +484,7 @@ t;
  |   264: box.error.NIL_UUID
  |   265: box.error.WRONG_FUNCTION_OPTIONS
  |   266: box.error.MISSING_SYSTEM_SPACES
+ |   272: box.error.SCHEMA_UPGRADE_IN_PROGRESS
  |   274: box.error.UNCONFIGURED
  | ...
 

--- a/test/replication-luatest/gh_9049_schema_downgrade_test.lua
+++ b/test/replication-luatest/gh_9049_schema_downgrade_test.lua
@@ -1,0 +1,41 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_test('test_schema_downgrade', function(cg)
+    cg.master = server:new({alias = 'master'})
+    cg.replica = server:new({
+        alias = 'replica',
+        box_cfg = {
+            read_only = true,
+            replication = cg.master.net_box_uri,
+        },
+    })
+    cg.master:start()
+    cg.replica:start()
+end)
+
+g.test_schema_downgrade = function(cg)
+    local version = cg.master:exec(function()
+        box.schema.downgrade('2.8.4')
+        return box.space._schema:get('version')
+    end)
+    cg.replica:wait_for_vclock_of(cg.master)
+    cg.replica:exec(function(version)
+        t.assert(box.info.replication[1].upstream)
+        t.assert_equals(box.info.replication[1].upstream.status, 'follow')
+        t.assert_equals(box.space._schema:get('version'), version)
+    end, {version})
+    cg.replica:restart()
+    cg.replica:exec(function(version)
+        t.assert(box.info.replication[1].upstream)
+        t.assert_equals(box.info.replication[1].upstream.status, 'follow')
+        t.assert_equals(box.space._schema:get('version'), version)
+    end, {version})
+end
+
+g.after_test('test_schema_downgrade', function(cg)
+    cg.replica:drop()
+    cg.master:drop()
+end)


### PR DESCRIPTION
Backport of #9092 to Tarantool 2.11.

NOTE: We don't have the commit that disables DDL operations with an old schema in 2.11 so we have to backport bits of it from 3.0, see commit 97c2c9a4fb58b ("box: disable DDL with old schema").