### PR TITLE
box: move all box.ctl triggers to the trigger registry

### DIFF
--- a/changelogs/unreleased/gh-8657-move-triggers-to-trigger-registry.md
+++ b/changelogs/unreleased/gh-8657-move-triggers-to-trigger-registry.md
@@ -1,8 +1,8 @@
 ## feature/lua
 
-* **[Breaking change]** Triggers from `space_object` and `box.session` were
-  moved to the trigger registry (gh-8657). Now triggers set with
-  `space:on_replace()` or `space:before_replace()` are attached to the space id,
-  not the space object. So, if you delete a space with registered triggers and
-  create another space with the same id, it will use the triggers that are left
-  from the deleted space.
+* **[Breaking change]** Triggers from `space_object`, `box.session`, and
+  `box.ctl` were moved to the trigger registry (gh-8657). Now triggers set with
+  `space_object:on_replace()` or `space_object:before_replace()` are attached to
+  the space id, not to `space_object`. So, if you delete a space with registered
+  triggers and create another space with the same id, it will use the remaining
+  triggers.

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -113,6 +113,8 @@ double txn_timeout_default;
 struct rlist box_on_shutdown_trigger_list =
 	RLIST_HEAD_INITIALIZER(box_on_shutdown_trigger_list);
 
+struct event *box_on_shutdown_event = NULL;
+
 const struct vclock *box_vclock = &replicaset.vclock;
 
 const char *box_auth_type;
@@ -5884,6 +5886,8 @@ box_init(void)
 	box_on_recovery_state_event =
 		event_get("box.ctl.on_recovery_state", true);
 	event_ref(box_on_recovery_state_event);
+	box_on_shutdown_event = event_get("box.ctl.on_shutdown", true);
+	event_ref(box_on_shutdown_event);
 	msgpack_init();
 	fiber_cond_create(&ro_cond);
 	auth_init();

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -81,7 +81,7 @@ extern struct rlist box_on_shutdown_trigger_list;
 /**
  * Triggers invoked during initial `box.cfg` call on various recovery stages.
  */
-extern struct rlist box_on_recovery_state;
+extern struct event *box_on_recovery_state_event;
 
 /**
  * Timeout during which the transaction must complete,

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -75,8 +75,11 @@ extern const char *box_auth_type;
 /** Time to wait for shutdown triggers finished */
 extern double on_shutdown_trigger_timeout;
 
-/** Invoked on box shutdown. */
+/** Internal and set by C API on_shutdown triggers. */
 extern struct rlist box_on_shutdown_trigger_list;
+
+/** User-defined on_shutdown triggers set from Lua. */
+extern struct event *box_on_shutdown_event;
 
 /**
  * Triggers invoked during initial `box.cfg` call on various recovery stages.

--- a/src/box/lua/ctl.c
+++ b/src/box/lua/ctl.c
@@ -75,8 +75,7 @@ lbox_ctl_wait_rw(struct lua_State *L)
 static int
 lbox_ctl_on_shutdown(struct lua_State *L)
 {
-	return lbox_trigger_reset(L, 2, &box_on_shutdown_trigger_list,
-				  NULL, NULL);
+	return luaT_event_reset_trigger(L, 1, box_on_shutdown_event);
 }
 
 static int

--- a/src/box/raft.h
+++ b/src/box/raft.h
@@ -40,7 +40,7 @@ extern "C" {
  * A public trigger fired on Raft state change, i.e. on a broadcast.
  * It's allowed to yield inside it, and it's run asynchronously.
  */
-extern struct rlist box_raft_on_broadcast;
+extern struct event *box_raft_on_election_event;
 
 enum election_mode {
 	ELECTION_MODE_INVALID = -1,

--- a/src/main.cc
+++ b/src/main.cc
@@ -89,6 +89,7 @@
 #include "core/clock_lowres.h"
 #include "lua/utils.h"
 #include "core/event.h"
+#include "on_shutdown.h"
 
 static pid_t master_pid = getpid();
 static struct pidfh *pid_file_handle;
@@ -163,8 +164,7 @@ on_shutdown_f(va_list ap)
 	while (!is_shutting_down)
 		fiber_yield();
 
-	if (trigger_fiber_run(&box_on_shutdown_trigger_list, NULL,
-			      on_shutdown_trigger_timeout) != 0) {
+	if (on_shutdown_run_triggers() != 0) {
 		say_error("on_shutdown triggers failed");
 		diag_log();
 		diag_clear(diag_get());

--- a/src/on_shutdown.h
+++ b/src/on_shutdown.h
@@ -60,6 +60,16 @@ box_on_shutdown(void *arg, int (*new_handler)(void *),
 
 /** \endcond public */
 
+/**
+ * Runs triggers from box_on_shutdown_trigger_list in separate fibers.
+ * Waits for their completion for on_shutdown_trigger_timeout seconds.
+ * When time is over, the function immediately stops without waiting
+ * for other triggers completion and returns a TimedOut error.
+ * NB: the function removes all elements from box_on_shutdown_trigger_list.
+ */
+int
+on_shutdown_run_triggers(void);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/on_shutdown.h
+++ b/src/on_shutdown.h
@@ -61,9 +61,9 @@ box_on_shutdown(void *arg, int (*new_handler)(void *),
 /** \endcond public */
 
 /**
- * Runs triggers from box_on_shutdown_trigger_list in separate fibers.
- * Waits for their completion for on_shutdown_trigger_timeout seconds.
- * When time is over, the function immediately stops without waiting
+ * Runs triggers from box_on_shutdown_trigger_list and on_shutdown event in
+ * separate fibers. Waits for their completion for on_shutdown_trigger_timeout
+ * seconds. When time is over, the function immediately stops without waiting
  * for other triggers completion and returns a TimedOut error.
  * NB: the function removes all elements from box_on_shutdown_trigger_list.
  */

--- a/test/box-luatest/triggers_old_api_test.lua
+++ b/test/box-luatest/triggers_old_api_test.lua
@@ -24,6 +24,9 @@ g.before_all(function()
             {box.session.on_auth, 'box.session.on_auth'},
             {space_on_replace, 'box.space[512].on_replace'},
             {space_before_replace, 'box.space[512].before_replace'},
+            {box.ctl.on_election, 'box.ctl.on_election'},
+            {box.ctl.on_recovery_state, 'box.ctl.on_recovery_state'},
+            {box.ctl.on_schema_init, 'box.ctl.on_schema_init'},
         })
 
         rawset(_G, 'ffi_monotonic_id', 0)

--- a/test/box-luatest/triggers_old_api_test.lua
+++ b/test/box-luatest/triggers_old_api_test.lua
@@ -27,6 +27,7 @@ g.before_all(function()
             {box.ctl.on_election, 'box.ctl.on_election'},
             {box.ctl.on_recovery_state, 'box.ctl.on_recovery_state'},
             {box.ctl.on_schema_init, 'box.ctl.on_schema_init'},
+            {box.ctl.on_shutdown, 'box.ctl.on_shutdown'},
         })
 
         rawset(_G, 'ffi_monotonic_id', 0)


### PR DESCRIPTION
The patch moves all triggers from `box.ctl` to the trigger registry.

Closes https://github.com/tarantool/tarantool/issues/8657