### PR TITLE
ci: fix CMake options in a build with enabled ASAN

### DIFF
--- a/.test.mk
+++ b/.test.mk
@@ -81,6 +81,8 @@ test-release: build run-luajit-test run-test
 # Experiments once again confirm the notorious quote that "640 Kb
 # ought to be enough for anybody".
 test-release-asan: CMAKE_PARAMS = -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                                  -DLUAJIT_USE_SYSMALLOC=ON \
+                                  -DLUAJIT_ENABLE_GC64=ON \
                                   -DENABLE_WERROR=ON \
                                   -DENABLE_ASAN=ON \
                                   -DENABLE_UB_SANITIZER=ON \


### PR DESCRIPTION
**Blocked by** https://github.com/tarantool/tarantool/issues/3071

As a result of the commit in LuaJIT submodule tarantool/luajit@a86e376 ("build: introduce LUAJIT_USE_ASAN option") ASan and LSan support has been finally added to LuaJIT runtime.

Furthermore, the internal LuaJIT memory allocator is not instrumented yet, so to find any memory faults it's worth building LuaJIT with system provided memory allocator (i.e. enable LUAJIT_USE_SYSMALLOC option). Using LUAJIT_USE_SYSMALLOC requires enabling LUAJIT_ENABLE_GC64.

The patch enables both CMake options in a build with enabled ASAN. Without path the following message is appears:

CMake Warning at third_party/luajit/CMakeLists.txt:278 (message):
  Unfortunately, internal LuaJIT memory allocator is not instrumented yet, so
  to find any memory errors it's better to build LuaJIT with system provided
  memory allocator (i.e.  run CMake configuration phase with
  -DLUAJIT_USE_SYSMALLOC=ON).

Follows up #5878

NO_CHANGELOG=ci
NO_DOC=ci
NO_TEST=ci