### PR TITLE
Fix inconsistent multireturn values for stored C functions

### DIFF
--- a/changelogs/unreleased/gh-4799-consistent-c-functions-calls.md
+++ b/changelogs/unreleased/gh-4799-consistent-c-functions-calls.md
@@ -1,0 +1,5 @@
+## bugfix/box
+
+* **[Breaking change]** Added a `c_func_iproto_multireturn` option to the
+  `compat` module. The new behavior drops an additional array that wraps
+  multiple results returned via iproto (gh-4799).

--- a/changelogs/unreleased/gh-8576-set-compat-options-to-new.md
+++ b/changelogs/unreleased/gh-8576-set-compat-options-to-new.md
@@ -7,5 +7,6 @@
     * `fiber_channel_close_mode`
     * `fiber_slice_default`
     * `box_cfg_replication_sync_timeout`
+    * `c_func_iproto_multireturn`
 
   More information on the new behavior can be found on the [Module compat](https://www.tarantool.io/en/doc/latest/reference/reference_lua/compat/) page.

--- a/src/box/port.c
+++ b/src/box/port.c
@@ -231,7 +231,7 @@ port_c_dump_msgpack(struct port *base, struct obuf *out)
 /**
  * If set, don't wrap results into an additional array on encode.
  */
-static bool c_func_iproto_multireturn = false;
+static bool c_func_iproto_multireturn = true;
 TWEAK_BOOL(c_func_iproto_multireturn);
 
 int

--- a/src/box/port.c
+++ b/src/box/port.c
@@ -37,6 +37,7 @@
 #include <fiber.h>
 #include "errinj.h"
 #include "mpstream/mpstream.h"
+#include "tweaks.h"
 
 /**
  * The pool is used by port_c to allocate entries and to store
@@ -204,7 +205,7 @@ port_c_add_str(struct port *base, const char *str, uint32_t len)
 }
 
 static int
-port_c_dump_msgpack_16(struct port *base, struct obuf *out)
+port_c_dump_msgpack(struct port *base, struct obuf *out)
 {
 	struct port_c *port = (struct port_c *)base;
 	struct port_c_entry *pe;
@@ -227,8 +228,14 @@ port_c_dump_msgpack_16(struct port *base, struct obuf *out)
 	return port->size;
 }
 
-static int
-port_c_dump_msgpack(struct port *base, struct obuf *out)
+/**
+ * If set, don't wrap results into an additional array on encode.
+ */
+static bool c_func_iproto_multireturn = false;
+TWEAK_BOOL(c_func_iproto_multireturn);
+
+int
+port_c_dump_msgpack_wrapped(struct port *base, struct obuf *out)
 {
 	struct port_c *port = (struct port_c *)base;
 	char *size_buf = obuf_alloc(out, mp_sizeof_array(port->size));
@@ -238,9 +245,23 @@ port_c_dump_msgpack(struct port *base, struct obuf *out)
 		return -1;
 	}
 	mp_encode_array(size_buf, port->size);
-	if (port_c_dump_msgpack_16(base, out) < 0)
+	if (port_c_dump_msgpack(base, out) < 0)
 		return -1;
 	return 1;
+}
+
+/**
+ * Encode the C port results to the msgpack.
+ * If c_func_iproto_multireturn is disabled, encode them without
+ * wrapping them in the additional msgpack array.
+ */
+static int
+port_c_dump_msgpack_compatible(struct port *base, struct obuf *out)
+{
+	if (c_func_iproto_multireturn)
+		return port_c_dump_msgpack(base, out);
+	else
+		return port_c_dump_msgpack_wrapped(base, out);
 }
 
 /** Callback to forward and error from mpstream methods. */
@@ -299,8 +320,8 @@ extern struct Mem *
 port_c_get_vdbemem(struct port *base, uint32_t *size);
 
 const struct port_vtab port_c_vtab = {
-	.dump_msgpack = port_c_dump_msgpack,
-	.dump_msgpack_16 = port_c_dump_msgpack_16,
+	.dump_msgpack = port_c_dump_msgpack_compatible,
+	.dump_msgpack_16 = port_c_dump_msgpack,
 	.dump_lua = port_c_dump_lua,
 	.dump_plain = NULL,
 	.get_msgpack = port_c_get_msgpack,

--- a/src/box/port.h
+++ b/src/box/port.h
@@ -31,6 +31,7 @@
  * SUCH DAMAGE.
  */
 #include "trivia/util.h"
+#include "small/obuf.h"
 #include <port.h>
 #include <stdbool.h>
 
@@ -172,6 +173,14 @@ port_init(void);
 
 void
 port_free(void);
+
+/**
+ * Encodes the port's content into the msgpack array.
+ * Returns 1 (amount of results) in the case of success,
+ * -1 otherwise.
+ */
+int
+port_c_dump_msgpack_wrapped(struct port *port, struct obuf *out);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/box/sql/port.c
+++ b/src/box/sql/port.c
@@ -270,7 +270,7 @@ port_sql_dump_msgpack(struct port *port, struct obuf *out)
 			return -1;
 		}
 		pos = mp_encode_uint(pos, IPROTO_DATA);
-		if (port_c_vtab.dump_msgpack(port, out) < 0)
+		if (port_c_dump_msgpack_wrapped(port, out) < 0)
 			return -1;
 		break;
 	}

--- a/src/lua/compat.lua
+++ b/src/lua/compat.lua
@@ -89,6 +89,13 @@ an error on any attempt to use it.
 https://tarantool.io/compat/box_session_push_deprecation
 ]]
 
+local C_FUNC_IPROTO_MULTIRETURN_BRIEF = [[
+Whether the results of the C stored function should be encoded with an
+additional msgpack array when returning them via iproto.
+
+https://tarantool.io/compat/c_func_iproto_multireturn
+]]
+
 -- Returns an action callback that toggles a tweak.
 local function tweak_action(tweak_name, old_tweak_value, new_tweak_value)
     return function(is_new)
@@ -167,6 +174,13 @@ local options = {
         brief = BOX_SESSION_PUSH_DEPRECATION_BRIEF,
         run_action_now = true,
         action = tweak_action('box_session_push_is_disabled', false, true),
+    },
+    c_func_iproto_multireturn = {
+        default = 'old',
+        obsolete = nil,
+        brief = C_FUNC_IPROTO_MULTIRETURN_BRIEF,
+        run_action_now = true,
+        action = tweak_action('c_func_iproto_multireturn', false, true),
     },
 }
 

--- a/src/lua/compat.lua
+++ b/src/lua/compat.lua
@@ -176,7 +176,7 @@ local options = {
         action = tweak_action('box_session_push_is_disabled', false, true),
     },
     c_func_iproto_multireturn = {
-        default = 'old',
+        default = 'new',
         obsolete = nil,
         brief = C_FUNC_IPROTO_MULTIRETURN_BRIEF,
         run_action_now = true,

--- a/test/box-luatest/CMakeLists.txt
+++ b/test/box-luatest/CMakeLists.txt
@@ -1,1 +1,4 @@
+include_directories(${MSGPUCK_INCLUDE_DIRS})
+build_module(gh_4799_lib gh_4799_fix_c_stored_functions_call.c)
+target_link_libraries(gh_4799_lib msgpuck)
 build_module(gh_6506_lib gh_6506_wakeup_writing_to_wal_fiber.c)

--- a/test/box-luatest/gh_4799_fix_c_stored_functions_call.c
+++ b/test/box-luatest/gh_4799_fix_c_stored_functions_call.c
@@ -1,0 +1,17 @@
+#include "module.h"
+#include "msgpuck.h"
+
+#define BUF_SIZE 8
+
+/** Simple function returns true and -1 as mutltiresults. */
+int
+multires(box_function_ctx_t *ctx, const char *args, const char *args_end)
+{
+	char buf[BUF_SIZE];
+	memset(buf, '\0', BUF_SIZE);
+	char *pos = mp_encode_bool(buf, true);
+	box_return_mp(ctx, buf, pos);
+	pos = mp_encode_int(buf, -1);
+	box_return_mp(ctx, buf, pos);
+	return 0;
+}

--- a/test/box-luatest/gh_4799_fix_c_stored_functions_call_test.lua
+++ b/test/box-luatest/gh_4799_fix_c_stored_functions_call_test.lua
@@ -47,6 +47,18 @@ g.test_compat_c_func_iproto_multireturn = function()
 
         -- Test the default behaviour.
         compat.c_func_iproto_multireturn = 'default'
-        t.assert_equals({connect:call(C_FUNC)}, EXPECTED_OLD)
+        t.assert_equals({connect:call(C_FUNC)}, EXPECTED_NEW)
+    end)
+end
+
+-- Test for consistent results when calling the C function locally
+-- and via iproto.
+g.test_c_func_consistent_results = function()
+    g.server:exec(function()
+        local net = require('net.box')
+        -- This function returns `true` and `-1` as the results.
+        local C_FUNC = 'gh_4799_lib.multires'
+        local connect = net:connect(box.cfg.listen)
+        t.assert_equals({connect:call(C_FUNC)}, {box.func[C_FUNC]:call()})
     end)
 end

--- a/test/box-luatest/gh_4799_fix_c_stored_functions_call_test.lua
+++ b/test/box-luatest/gh_4799_fix_c_stored_functions_call_test.lua
@@ -1,0 +1,52 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+    -- Set the CPATH for all tests. Register the test function.
+    cg.server:exec(function()
+        local build_path = os.getenv('BUILDDIR')
+        local lib_suffix = jit.os == 'OSX' and 'dylib' or 'so'
+        package.cpath = ('%s/test/box-luatest/?.%s;%s'):format(
+            build_path, lib_suffix, package.path
+        )
+
+        box.schema.func.create('gh_4799_lib.multires', {language = 'C'})
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:stop()
+end)
+
+g.test_compat_c_func_iproto_multireturn = function()
+    g.server:exec(function()
+        local net = require('net.box')
+        local compat = require('compat')
+
+        -- This function returns `true` and `-1` as the results.
+        local C_FUNC = 'gh_4799_lib.multires'
+        local EXPECTED_NEW = {true, -1}
+        local EXPECTED_OLD = {EXPECTED_NEW}
+
+        -- This compatibility option doesn't expect to be switched
+        -- on the fly. At least, there are no guarantees.
+        -- So just use one connection here.
+        local connect = net:connect(box.cfg.listen)
+
+        -- Test that the old behaviour wraps returning values.
+        compat.c_func_iproto_multireturn = 'old'
+        t.assert_equals({connect:call(C_FUNC)}, EXPECTED_OLD)
+
+        -- Test that the new behaviour returns multiresults.
+        compat.c_func_iproto_multireturn = 'new'
+        t.assert_equals({connect:call(C_FUNC)}, EXPECTED_NEW)
+
+        -- Test the default behaviour.
+        compat.c_func_iproto_multireturn = 'default'
+        t.assert_equals({connect:call(C_FUNC)}, EXPECTED_OLD)
+    end)
+end

--- a/test/box/func_reload.result
+++ b/test/box/func_reload.result
@@ -62,7 +62,6 @@ box.space.test:insert{0}
 ...
 c:call("reload.foo", {1})
 ---
-- []
 ...
 box.space.test:delete{0}
 ---
@@ -77,7 +76,6 @@ box.schema.func.reload("reload")
 ...
 c:call("reload.foo")
 ---
-- []
 ...
 box.space.test:select{}
 ---
@@ -118,7 +116,6 @@ box.schema.func.reload("reload")
 ...
 c:call("reload.foo")
 ---
-- []
 ...
 while box.space.test:count() < 2 * fibers + 1 do fiber.sleep(0.001) end
 ---
@@ -178,7 +175,7 @@ ch = fiber.channel(2)
 -- call first time to load function
 c:call("reload.test_reload")
 ---
-- [[1]]
+- [1]
 ...
 s:delete({1})
 ---
@@ -217,7 +214,7 @@ box.schema.user.grant('guest', 'execute', 'function', 'reload.test_reload_fail')
 ...
 c:call("reload.test_reload_fail")
 ---
-- [[2]]
+- [2]
 ...
 fio.copyfile(reload1_path, reload_path)
 ---
@@ -225,11 +222,11 @@ fio.copyfile(reload1_path, reload_path)
 ...
 c:call("reload.test_reload")
 ---
-- [[2]]
+- [2]
 ...
 c:call("reload.test_reload_fail")
 ---
-- [[2]]
+- [2]
 ...
 box.schema.func.reload()
 ---

--- a/test/box/function1.result
+++ b/test/box/function1.result
@@ -67,7 +67,6 @@ box.schema.user.grant('guest', 'read,write', 'space', 'test')
 ...
 c:call('function1')
 ---
-- []
 ...
 box.schema.func.drop("function1")
 ---
@@ -88,7 +87,7 @@ c:call('function1.args', { "xx" })
 ...
 c:call('function1.args', { 15 })
 ---
-- [[15, 'hello']]
+- [15, 'hello']
 ...
 box.func["function1.args"]
 ---
@@ -132,7 +131,6 @@ box.schema.user.grant('guest', 'execute', 'function', 'function1.multi_inc')
 ...
 c:call('function1.multi_inc')
 ---
-- []
 ...
 box.space.test:select{}
 ---
@@ -140,7 +138,6 @@ box.space.test:select{}
 ...
 c:call('function1.multi_inc', { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
 ---
-- []
 ...
 box.space.test:select{}
 ---
@@ -157,7 +154,6 @@ box.space.test:select{}
 ...
 c:call('function1.multi_inc', { 2, 4, 6, 8, 10 })
 ---
-- []
 ...
 box.space.test:select{}
 ---
@@ -174,7 +170,6 @@ box.space.test:select{}
 ...
 c:call('function1.multi_inc', { 0, 2, 4 })
 ---
-- []
 ...
 box.space.test:select{}
 ---
@@ -809,11 +804,13 @@ box.func[name]:call()
 box.schema.user.grant('guest', 'super')
 ---
 ...
--- Netbox:call() returns not the same as local call for C
--- functions, see #4799.
 net:connect(box.cfg.listen):call(name)
 ---
-- [1, -1, 18446744073709551615, '123456789101112131415', [2]]
+- 1
+- -1
+- 18446744073709551615
+- '123456789101112131415'
+- [2]
 ...
 box.schema.user.revoke('guest', 'super')
 ---

--- a/test/box/function1.test.lua
+++ b/test/box/function1.test.lua
@@ -276,8 +276,6 @@ box.schema.func.create(name, {language = "C", exports = {'LUA'}})
 box.func[name]:call()
 
 box.schema.user.grant('guest', 'super')
--- Netbox:call() returns not the same as local call for C
--- functions, see #4799.
 net:connect(box.cfg.listen):call(name)
 box.schema.user.revoke('guest', 'super')
 

--- a/test/box/push.result
+++ b/test/box/push.result
@@ -592,7 +592,6 @@ c:call('function1.test_push',   \
        {on_push = table.insert, \
         on_push_ctx = messages})
 ---
-- []
 ...
 messages
 ---


### PR DESCRIPTION
The first commit introduces the `c_func_iproto_multireturn` option (when set to new, the results of the stored C function aren't wrapped in an additional msgpack array, see below). By default, it is set to 'old', to avoid conflicts.  Also, this makes the first patch backportable to 2.11 as is (except conflict with compatibility options in compat.lua, see #9144). The second commit switches the behaviour to 'new' and fixes some diff tests.

As described in the commit message to the first patch, the SQL mechanism depends on the `port_dump_msgpack()` too, so just using the introduced flag in `port_c_dump_msgpack()` isn't good. As an alternative option, we can introduce 2 new fields (say `encode_call_results16`, `encode_call_results`) in `port_vtab` to call them and use the flag only there. But I'm not sure that adding 2 new fields to the structure only for this is good either.

As far as there are only two possible fields in the changelog header entry (`feature/*` or `bugfix/*`), I prefer the second one instead of `compatibility/*`.


I provide the doc-request below for your convenience in reading:

---

Title: Document `c_func_iproto_multireturn` compat option

Please create a documentation page for the new compat option:
https://tarantool.io/compat/c_func_iproto_multireturn

In the new behaviour, the multiresults returned by a stored C function
via iproto aren't wrapped in the additional msgpack array (old).

```
tarantool> compat.c_func_iproto_multireturn = 'old'
---
...

tarantool> net_box.connect(box.cfg.listen):call('myclib.cfunc')
---
- [true, -1]
...

tarantool> compat.c_func_iproto_multireturn = 'new'
---
...

tarantool> net_box.connect(box.cfg.listen):call('myclib.cfunc')
---
- true
- -1
...

```

The new behaviour is consistent with the local call of the function
via `box.func`:

```
tarantool> box.func['myclib.cfunc']:call()
---
- true
- -1
...

```

Assume you have a stored C function that returns values like the
following:

```c
char *position = mp_encode_bool(buffer, true);
box_return_mp(ctx, buffer, position);
/* ... */
position = mp_encode_int(buffer, -1);
box_return_mp(ctx, buffer, position);
```

If you want to preserve the format of the returned array for your C
functions, when the `c_func_iproto_multireturn` option is set to "new",
you should add the additional wrapping, like the following:

```c
char *position = mp_encode_array(buffer_with_results, n_results);
position = mp_encode_bool(position, true);
/* ... */
position = mp_encode_int(position, -1);
box_return_mp(ctx, buffer_with_results, position);
```

The amount of `box_return_mp()` calls indicates the number of values to
be returned.

Also, you should update its usage via `box.func` if there is any.