### PR TITLE
[backport 2.11] box: introduce c_func_iproto_multireturn in compat

### DIFF
--- a/changelogs/unreleased/gh-4799-consistent-c-functions-calls.md
+++ b/changelogs/unreleased/gh-4799-consistent-c-functions-calls.md
@@ -1,0 +1,5 @@
+## bugfix/box
+
+* **[Breaking change]** Added a `c_func_iproto_multireturn` option to the
+  `compat` module. The new behavior drops an additional array that wraps
+  multiple results returned via iproto (gh-4799).

--- a/src/box/port.h
+++ b/src/box/port.h
@@ -31,6 +31,7 @@
  * SUCH DAMAGE.
  */
 #include "trivia/util.h"
+#include "small/obuf.h"
 #include <port.h>
 #include <stdbool.h>
 
@@ -174,6 +175,14 @@ port_init(void);
 
 void
 port_free(void);
+
+/**
+ * Encodes the port's content into the msgpack array.
+ * Returns 1 (amount of results) in the case of success,
+ * -1 otherwise.
+ */
+int
+port_c_dump_msgpack_wrapped(struct port *port, struct obuf *out);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/box/sql/port.c
+++ b/src/box/sql/port.c
@@ -270,7 +270,7 @@ port_sql_dump_msgpack(struct port *port, struct obuf *out)
 			return -1;
 		}
 		pos = mp_encode_uint(pos, IPROTO_DATA);
-		if (port_c_vtab.dump_msgpack(port, out) < 0)
+		if (port_c_dump_msgpack_wrapped(port, out) < 0)
 			return -1;
 		break;
 	}

--- a/src/lua/compat.lua
+++ b/src/lua/compat.lua
@@ -51,6 +51,13 @@ initialization or new session creation.
 https://tarantool.io/compat/sql_seq_scan_default
 ]]
 
+local C_FUNC_IPROTO_MULTIRETURN_BRIEF = [[
+Whether the results of the C stored function should be encoded with an
+additional msgpack array when returning them via iproto.
+
+https://tarantool.io/compat/c_func_iproto_multireturn
+]]
+
 -- Returns an action callback that toggles a tweak.
 local function tweak_action(tweak_name, old_tweak_value, new_tweak_value)
     return function(is_new)
@@ -95,6 +102,13 @@ local options = {
         obsolete = nil,
         brief = SQL_SEQ_SCAN_DEFAULT_BRIEF,
         action = tweak_action('sql_seq_scan_default', true, false),
+    },
+    c_func_iproto_multireturn = {
+        default = 'old',
+        obsolete = nil,
+        brief = C_FUNC_IPROTO_MULTIRETURN_BRIEF,
+        run_action_now = true,
+        action = tweak_action('c_func_iproto_multireturn', false, true),
     },
 }
 

--- a/test/box-luatest/CMakeLists.txt
+++ b/test/box-luatest/CMakeLists.txt
@@ -1,1 +1,4 @@
+include_directories(${MSGPUCK_INCLUDE_DIRS})
+build_module(gh_4799_lib gh_4799_fix_c_stored_functions_call.c)
+target_link_libraries(gh_4799_lib msgpuck)
 build_module(gh_6506_lib gh_6506_wakeup_writing_to_wal_fiber.c)

--- a/test/box-luatest/gh_4799_fix_c_stored_functions_call.c
+++ b/test/box-luatest/gh_4799_fix_c_stored_functions_call.c
@@ -1,0 +1,17 @@
+#include "module.h"
+#include "msgpuck.h"
+
+#define BUF_SIZE 8
+
+/** Simple function returns true and -1 as mutltiresults. */
+int
+multires(box_function_ctx_t *ctx, const char *args, const char *args_end)
+{
+	char buf[BUF_SIZE];
+	memset(buf, '\0', BUF_SIZE);
+	char *pos = mp_encode_bool(buf, true);
+	box_return_mp(ctx, buf, pos);
+	pos = mp_encode_int(buf, -1);
+	box_return_mp(ctx, buf, pos);
+	return 0;
+}

--- a/test/box-luatest/gh_4799_fix_c_stored_functions_call_test.lua
+++ b/test/box-luatest/gh_4799_fix_c_stored_functions_call_test.lua
@@ -1,0 +1,52 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+    -- Set the CPATH for all tests. Register the test function.
+    cg.server:exec(function()
+        local build_path = os.getenv('BUILDDIR')
+        local lib_suffix = jit.os == 'OSX' and 'dylib' or 'so'
+        package.cpath = ('%s/test/box-luatest/?.%s;%s'):format(
+            build_path, lib_suffix, package.path
+        )
+
+        box.schema.func.create('gh_4799_lib.multires', {language = 'C'})
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:stop()
+end)
+
+g.test_compat_c_func_iproto_multireturn = function()
+    g.server:exec(function()
+        local net = require('net.box')
+        local compat = require('compat')
+
+        -- This function returns `true` and `-1` as the results.
+        local C_FUNC = 'gh_4799_lib.multires'
+        local EXPECTED_NEW = {true, -1}
+        local EXPECTED_OLD = {EXPECTED_NEW}
+
+        -- This compatibility option doesn't expect to be switched
+        -- on the fly. At least, there are no guarantees.
+        -- So just use one connection here.
+        local connect = net:connect(box.cfg.listen)
+
+        -- Test that the old behaviour wraps returning values.
+        compat.c_func_iproto_multireturn = 'old'
+        t.assert_equals({connect:call(C_FUNC)}, EXPECTED_OLD)
+
+        -- Test that the new behaviour returns multiresults.
+        compat.c_func_iproto_multireturn = 'new'
+        t.assert_equals({connect:call(C_FUNC)}, EXPECTED_NEW)
+
+        -- Test the default behaviour.
+        compat.c_func_iproto_multireturn = 'default'
+        t.assert_equals({connect:call(C_FUNC)}, EXPECTED_OLD)
+    end)
+end


### PR DESCRIPTION
This patch backports the first commit from #9143 for backward compatibility. See the description there.

I've avoided the note in the commit message about cherry-pick:
```
(cherry picked from commit f70fde8f483ded8a0345ff9b91e53a55951aa428)
```
due to the lack of a commit hash in the main repository.