### PR TITLE
config: allow postponing object grants till creation

### DIFF
--- a/changelogs/unreleased/gh-8967-set-creds-in-lazy-way.md
+++ b/changelogs/unreleased/gh-8967-set-creds-in-lazy-way.md
@@ -1,0 +1,5 @@
+## feature/config
+
+* Now the permissions for space, function, and sequence can be granted
+  via the config. If the object has not been created yet, the grant is
+  postponed and executed after the creation of the object (gh-8967).

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1196,11 +1196,6 @@ return schema.new('instance_config', schema.record({
                         universe = schema.scalar({
                             type = 'boolean',
                         }),
-                        -- TODO: It is not possible to grant a
-                        -- permission for a non-existing object.
-                        -- It blocks ability to set it from a
-                        -- config. Disabled for now.
-                        --[[
                         spaces = schema.array({
                             items = schema.scalar({
                                 type = 'string',
@@ -1216,7 +1211,6 @@ return schema.new('instance_config', schema.record({
                                 type = 'string',
                             }),
                         }),
-                        ]]--
                     }),
                 }),
                 -- The given role has all the privileges from
@@ -1253,11 +1247,6 @@ return schema.new('instance_config', schema.record({
                         universe = schema.scalar({
                             type = 'boolean',
                         }),
-                        -- TODO: It is not possible to grant a
-                        -- permission for a non-existing object.
-                        -- It blocks ability to set it from a
-                        -- config. Disabled for now.
-                        --[[
                         spaces = schema.array({
                             items = schema.scalar({
                                 type = 'string',
@@ -1273,7 +1262,6 @@ return schema.new('instance_config', schema.record({
                                 type = 'string',
                             }),
                         }),
-                        ]]--
                     }),
                 }),
                 -- The given user has all the privileges from

--- a/test/config-luatest/helpers.lua
+++ b/test/config-luatest/helpers.lua
@@ -201,6 +201,7 @@ end
 -- * opts.script
 -- * opts.options
 -- * opts.verify
+-- * opts.verify_args
 --
 --   Same as in success_case().
 --
@@ -221,11 +222,16 @@ end
 -- * opts.verify_2
 --
 --   Verify test invariants after config:reload().
+--
+-- * opts.verify_args_2
+--
+--   Arguments for the second verify function.
 local function reload_success_case(g, opts)
     local roles_2 = opts.roles_2
     local script_2 = opts.script_2
     local options = assert(opts.options)
     local verify_2 = assert(opts.verify_2)
+    local verify_args_2 = opts.verify_args_2
     local options_2 = opts.options_2 or options
 
     local prepared = success_case(g, opts)
@@ -240,7 +246,7 @@ local function reload_success_case(g, opts)
         local config = require('config')
         config:reload()
     end)
-    g.server:exec(verify_2)
+    g.server:exec(verify_2, verify_args_2)
 end
 
 -- Start a server, write a new script/config, reload, run a

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -900,6 +900,13 @@ g.test_credentials = function()
                                 'drop',
                             },
                             universe = false,
+                            spaces = {
+                                'myspace1',
+                            },
+                            functions = {
+                                'myfunc1',
+                            },
+                            sequences = { },
                         },
                     },
                     roles = {'one', 'two'},
@@ -915,6 +922,13 @@ g.test_credentials = function()
                                 'read',
                             },
                             universe = true,
+                            spaces = { },
+                            functions = {
+                                'myfunc2',
+                            },
+                            sequences = {
+                                'myseq2'
+                            },
                         },
                     },
                     roles = {'one', 'two'},


### PR DESCRIPTION
Before this patch privileges for space, function and sequence alone
were disabled. Only permission for universe could be granted. It was
done because there wasn't a way to grant or revoke a privilege when
subjecting object hasn't been created yet.
    
This patch allows grants and revokes for objects that will be created
after the applier. These actions will be postponed and executed via
on_commit trigger after the object is registered in the according system
space of box.space._space/_func/_sequence.
    
Now permission can be granted to space/function/sequence from within the
config.
    
Part of #8967
    
NO_DOC=documentation request will be filed manually for the whole credentials
