### PR TITLE
box: fix NULL pointer dereference in error_unpack_unsafe

### DIFF
--- a/changelogs/unreleased/gh-9136-null-dereference-in-error_set_prev.md
+++ b/changelogs/unreleased/gh-9136-null-dereference-in-error_set_prev.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a possible crash when unpacking an invalid MsgPack error extension
+  (gh-9136).

--- a/src/box/mp_error.cc
+++ b/src/box/mp_error.cc
@@ -480,6 +480,11 @@ error_unpack_unsafe(const char **data)
 		uint64_t key = mp_decode_uint(data);
 		switch(key) {
 		case MP_ERROR_STACK: {
+			if (err != NULL) {
+				diag_set(ClientError, ER_INVALID_MSGPACK,
+					 "duplicate MP_ERROR_STACK key");
+				goto error;
+			}
 			if (CHECK_MP_TYPE(data, MP_ARRAY,
 					  "MP_ERROR_STACK value") != 0)
 				goto error;

--- a/test/app-luatest/msgpack_test.lua
+++ b/test/app-luatest/msgpack_test.lua
@@ -678,6 +678,14 @@ g_error_details.test_error_details = function(cg)
             prev = {message = 'MP_ERROR_STACK is missing', offset = 1},
         },
     })
+    check_error('\xc7\x10\x03\x82\x00\x91\x83\x00\xa1\x00\x01\xa1\x00\x03' ..
+                '\xa1\x00\x00\x91\x00', {
+        message = 'invalid extension', offset = 3, ext_len = 16, ext_type = 3,
+        prev = {
+            message = 'cannot unpack error',
+            prev = {message = 'duplicate MP_ERROR_STACK key', offset = 14},
+        },
+    })
     check_error('\xc7\x04\x03\x81\x00\x91\x80', {
         message = 'invalid extension', offset = 3, ext_len = 4, ext_type = 3,
         prev = {

--- a/test/unit/xrow.cc
+++ b/test/unit/xrow.cc
@@ -720,13 +720,56 @@ test_xrow_decode_error_gh_9098(void)
 	footer();
 }
 
+static void
+test_xrow_decode_error_gh_9136(void)
+{
+	header();
+	plan(1);
+
+	uint8_t data[] = {
+		0x81, /* MP_MAP of 1 element */
+		0x52, /* IPROTO_ERROR: */
+		0x82, /* MP_MAP of 2 elements */
+		0x00, /* MP_ERROR_STACK: */
+		0x91, /* MP_ARRAY of 1 element */
+		0x83, /* MP_MAP of 3 elements */
+		0x00, 0xa1, 0x00, /* MP_ERROR_TYPE: "" */
+		0x01, 0xa1, 0x00, /* MP_ERROR_FILE: "" */
+		0x03, 0xa1, 0x00, /* MP_ERROR_MESSAGE: "" */
+		0x00, /* MP_ERROR_STACK: */
+		0x91, /* MP_ARRAY of 1 element */
+		0x83, /* MP_MAP of 3 elements */
+		0x00, 0xa1, 0x00, /* MP_ERROR_TYPE: "" */
+		0x01, 0xa1, 0x00, /* MP_ERROR_FILE: "" */
+		0x03, 0xa1, 0x00, /* MP_ERROR_MESSAGE: "" */
+	};
+
+	struct iovec body;
+	body.iov_base = (void *)data;
+	body.iov_len = sizeof(data);
+
+	struct xrow_header row;
+	row.type = IPROTO_TYPE_ERROR | 9136;
+	row.body[0] = body;
+	row.bodycnt = 1;
+
+	xrow_decode_error(&row);
+
+	struct error *e = diag_last_error(diag_get());
+	is(e->code, 9136, "xrow_decode_error");
+	diag_destroy(diag_get());
+
+	check_plan();
+	footer();
+}
+
 int
 main(void)
 {
 	memory_init();
 	fiber_init(fiber_c_invoke);
 	header();
-	plan(11);
+	plan(12);
 
 	random_init();
 
@@ -742,6 +785,7 @@ main(void)
 	test_xrow_decode_error_3();
 	test_xrow_decode_error_4();
 	test_xrow_decode_error_gh_9098();
+	test_xrow_decode_error_gh_9136();
 
 	random_free();
 	fiber_free();


### PR DESCRIPTION
If `MP_ERROR` map contains two `MP_ERROR_STACK` keys, then the second to call to `error_set_prev(effect, cur)` will crash, because `effect` is NULL, but `err == NULL` is false, because it is assigned on the first iteration. This patch raises an error if more than one `MP_ERROR_STACK` key is present.

Closes #9136