### PR TITLE
config: add `security.auth_retries` option

### DIFF
--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1428,6 +1428,11 @@ return schema.new('instance_config', schema.record({
             default = 0,
             box_cfg = 'auth_delay',
         })),
+        auth_retries = enterprise_edition(schema.scalar({
+            type = 'integer',
+            default = 0,
+            box_cfg = 'auth_retries',
+        })),
         disable_guest = enterprise_edition(schema.scalar({
             type = 'boolean',
             default = false,

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -119,6 +119,7 @@ local default_cfg = {
 
     auth_type           = 'chap-sha1',
     auth_delay          = ifdef_security(0),
+    auth_retries        = ifdef_security(0),
     disable_guest       = ifdef_security(false),
     password_lifetime_days = ifdef_security(0),
     password_min_length = ifdef_security(0),
@@ -314,6 +315,7 @@ local template_cfg = {
 
     auth_type           = 'string',
     auth_delay          = ifdef_security('number'),
+    auth_retries        = ifdef_security('number'),
     disable_guest       = ifdef_security('boolean'),
     password_lifetime_days = ifdef_security('number'),
     password_min_length = ifdef_security('number'),
@@ -517,6 +519,7 @@ local dynamic_cfg = {
     txn_isolation           = private.cfg_set_txn_isolation,
     auth_type               = private.cfg_set_auth_type,
     auth_delay              = private.cfg_set_security,
+    auth_retries            = private.cfg_set_security,
     disable_guest           = private.cfg_set_security,
     password_lifetime_days  = private.cfg_set_security,
     password_min_length     = ifdef_security(nop),
@@ -679,6 +682,7 @@ local dynamic_cfg_skip_at_load = {
     readahead               = true,
     auth_type               = true,
     auth_delay              = ifdef_security(true),
+    auth_retries            = ifdef_security(true),
     disable_guest           = ifdef_security(true),
     password_lifetime_days  = ifdef_security(true),
 }

--- a/test/box/box.lua
+++ b/test/box/box.lua
@@ -35,6 +35,7 @@ local _enterprise_keys = {
     flightrec_requests_max_req_size = true,
     flightrec_requests_max_res_size = true,
     auth_delay = true,
+    auth_retries = true,
     disable_guest = true,
     password_lifetime_days = true,
     password_min_length = true,

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -247,6 +247,7 @@ g.test_defaults = function()
         } or nil,
         security = is_enterprise and {
             auth_delay = 0,
+            auth_retries = 0,
             auth_type = "chap-sha1",
             disable_guest = false,
             password_enforce_digits = false,

--- a/test/config-luatest/config_test.lua
+++ b/test/config-luatest/config_test.lua
@@ -666,6 +666,7 @@ g.test_security_options = function()
         security:
             auth_type: pap-sha256
             auth_delay: 5
+            auth_retries: 3
             disable_guest: false
             password_lifetime_days: 90
             password_min_length: 14
@@ -693,6 +694,7 @@ g.test_security_options = function()
     g.server:exec(function()
         t.assert_equals(box.cfg.auth_type, 'pap-sha256')
         t.assert_equals(box.cfg.auth_delay, 5)
+        t.assert_equals(box.cfg.auth_retries, 3)
         t.assert_equals(box.cfg.disable_guest, false)
         t.assert_equals(box.cfg.password_lifetime_days, 90)
         t.assert_equals(box.cfg.password_min_length, 14)

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1187,6 +1187,7 @@ g.test_security_enterprise = function()
         security = {
             auth_type = 'pap-sha256',
             auth_delay = 5,
+            auth_retries = 3,
             disable_guest = true,
             password_lifetime_days = 90,
             password_min_length = 10,


### PR DESCRIPTION
The new option is backed by `box.cfg.auth_retries`. It is available only in Enterprise Edition builds.
For the implementation see https://github.com/tarantool/tarantool-ee/pull/560.

Needed for tarantool/tarantool-ee#541