### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-8825-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8825-luajit-fixes.md
@@ -18,3 +18,4 @@ were fixed as part of this activity:
 * Fixed frame for on-trace OOM handling.
 * Fixed handling of instable types in TNEW/TDUP load forwarding.
 * Handled table unsinking in the presence of `IRFL_TAB_NOMM`.
+* Fixed snapshot PC when linking to BC_JLOOP that was a BC_RET*.


### PR DESCRIPTION
Fix snapshot PC when linking to BC_JLOOP that was a BC_RET*.

Part of #8825

NO_DOC=LuaJIT bump
NO_TEST=LuaJIT bump