### PR TITLE
xlog: rework writer API

### DIFF
--- a/test/unit/xlog.c
+++ b/test/unit/xlog.c
@@ -137,7 +137,7 @@ test_dynamic_sized_ibuf(void)
 	ok(ibuf_capacity(&cursor.rbuf) == 0, "ibuf capacity decreased to 0");
 
 	xlog_cursor_close(&cursor, false);
-	fail_if(xlog_close(&xlog, false) < 0);
+	fail_if(xlog_close(&xlog) != 0);
 	unlink(filename);
 	rmdir(dirname);
 


### PR DESCRIPTION
The goal of this patch is to make the xlog writer API less confusing. It does the following changes:

 - Rename `xlog_rename` to `xlog_materialize`. The function strips the .inprogress suffix from an xlog file name. Usually it's called after the xlog was sealed (by writing the EOF marker) and closed but it may also be called before `xlog_close` in case the xlog file is going to be appended to (used in WAL).

 - Make `xlog_sync` private. It's called by `xlog_close` so there's no point in calling it manually. Make `xlog_close` fail if it fails to sync the file.

 - Make `xlog_close` flush the buffer so that the caller doesn't need to call `xlog_flush` manually before closing an xlog file.

 - Drop the `reuse_fd` argument of `xlog_close`. Instead, introduce a new function `xlog_close_reuse_fd` that works exactly like `xlog_close` except it doesn't close the fd and returns it in the out argument.

 - Introduce `xlog_discard`. It's supposed to be called on an incomplete xlog file to close its fd and unlink it.

Rework all the places where we write xlog files in accordance with the new API. Note about memtx snapshot writer: use `xlog_materialize` and `xlog_discard` instead of `coio_rename` and `coio_unlink`.

The new API (especially the `xlog_discard` helper) facilitates introduction of thorough (secure) file deletion because it significantly reduces the number of places in the code where xlog files are deleted.

Needed for tarantool/tarantool-ee#540