### PR TITLE
core: fix a wrong assertion on decimal comparison with double

### DIFF
--- a/changelogs/unreleased/gh-8472-decimal-compare-float-assertion.md
+++ b/changelogs/unreleased/gh-8472-decimal-compare-float-assertion.md
@@ -1,0 +1,6 @@
+## bugfix/core
+
+* Fixed a wrong assertion in index comparators when comparing decimals with
+  floats greater than `1e38`. The error was present only in the debug build.
+  Despite the failing assertion, the behavior after the assertion was correct
+  (gh-8472).

--- a/src/box/tuple_compare.cc
+++ b/src/box/tuple_compare.cc
@@ -238,16 +238,17 @@ mp_compare_decimal(const char *lhs, const char *rhs)
 }
 
 /**
- * Compare decimal to 'not a number' which is either NaN or inf. Decimal value
- * does not matter then. It is always a valid number.
+ * Compare a decimal to something not representable as decimal. Like NaN, Inf or
+ * just a value outside the (-1e38, 1e38) range. In all these cases the decimal
+ * value doesn't matter.
  */
 static inline int
-decimal_compare_nan(double rhs)
+decimal_compare_nan_or_huge(double rhs)
 {
 	/* We assume NaN is less than everything else. */
 	if (isnan(rhs))
 		return 1;
-	assert(isinf(rhs));
+	assert(fabs(rhs) >= 1e38);
 	return (rhs < 0) - (rhs > 0);
 }
 
@@ -263,7 +264,7 @@ mp_compare_decimal_any_number(decimal_t *lhs, const char *rhs,
 		double d = mp_decode_float(&rhs);
 		rc = decimal_from_double(&rhs_dec, d);
 		if (rc == NULL)
-			return decimal_compare_nan(d) * k;
+			return decimal_compare_nan_or_huge(d) * k;
 		break;
 	}
 	case MP_DOUBLE:
@@ -271,7 +272,7 @@ mp_compare_decimal_any_number(decimal_t *lhs, const char *rhs,
 		double d = mp_decode_double(&rhs);
 		rc = decimal_from_double(&rhs_dec, d);
 		if (rc == NULL)
-			return decimal_compare_nan(d) * k;
+			return decimal_compare_nan_or_huge(d) * k;
 		break;
 	}
 	case MP_INT:


### PR DESCRIPTION
mp_compare_decimal_any_number erroneously assumed that any float or double from which a decimal can't be created is either infinite or NaN. This is not true. Any float greater than 1e38 can't fit into our decimal representation. When such a float got compared to a decimal, an assertion fired, which was wrong. Luckily, on release build the comparison was correct. Only the assertion is wrong. Fix it.

Closes #8472

NO_DOC=bugfix