### PR TITLE
sequence: use xmalloc where appropriate

### DIFF
--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -4888,8 +4888,6 @@ on_replace_dd_sequence(struct trigger * /* trigger */, void *event)
 		if (on_rollback == NULL)
 			return -1;
 		seq = sequence_new(new_def);
-		if (seq == NULL)
-			return -1;
 		sequence_cache_insert(seq);
 		on_rollback->data = seq;
 		txn_stmt_on_rollback(stmt, on_rollback);

--- a/src/box/sequence.c
+++ b/src/box/sequence.c
@@ -131,11 +131,7 @@ sequence_free(void)
 struct sequence *
 sequence_new(struct sequence_def *def)
 {
-	struct sequence *seq = calloc(1, sizeof(*seq));
-	if (seq == NULL) {
-		diag_set(OutOfMemory, sizeof(*seq), "malloc", "sequence");
-		return NULL;
-	}
+	struct sequence *seq = xcalloc(1, sizeof(*seq));
 	seq->def = def;
 	return seq;
 }
@@ -341,7 +337,7 @@ sequence_data_iterator_next_raw(struct index_read_view_iterator *iterator,
 
 	const size_t buf_size = mp_sizeof_array(2) +
 				2 * mp_sizeof_uint(UINT64_MAX);
-	char *buf = region_alloc(&fiber()->gc, buf_size);
+	char *buf = xregion_alloc(&fiber()->gc, buf_size);
 	char *buf_end = buf;
 	buf_end = mp_encode_array(buf_end, 2);
 	buf_end = mp_encode_uint(buf_end, sd->id);

--- a/src/box/sequence.h
+++ b/src/box/sequence.h
@@ -106,6 +106,8 @@ sequence_free(void);
  * the new sequence and will be freed automatically when
  * the sequence is destroyed so it must be allocated with
  * malloc().
+ *
+ * This function never fails (never returns NULL).
  */
 struct sequence *
 sequence_new(struct sequence_def *def);


### PR DESCRIPTION
Allocations from fiber region and heap should never fail so it's okay to use xmalloc for them.

This fixes the following coverity report complaining about unchecked region_alloc result:

https://scan7.scan.coverity.com/reports.htm#v39198/p13437/fileInstanceId=149497639&defectInstanceId=19021351&mergedDefectId=1525560