### PR TITLE
[backport/release/2.11] luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-8825-luajit-fixes.md
+++ b/changelogs/unreleased/gh-8825-luajit-fixes.md
@@ -10,3 +10,6 @@ were fixed as part of this activity:
   fractional part raises error too now.
 * Fixed load forwarding optimization applied after table rehashing.
 * Fixed recording of the `BC_TSETM`.
+* Fixed the panic routine when `mprotect` fails to change flags for mcode area.
+* Fixed handling of instable types in TNEW/TDUP load forwarding.
+* Handled table unsinking in the presence of `IRFL_TAB_NOMM`.


### PR DESCRIPTION
* test: fix fix-mips64-spare-side-exit-patching
* test: fix `fillmcode()` generator helper
* MIPS: Fix "bad FP FLOAD" assertion.
* Handle table unsinking in the presence of IRFL_TAB_NOMM.
* Fix handling of instable types in TNEW/TDUP load forwarding.
* Fix predict_next() in parser (again).
* Always exit after machine code page protection change fails.

Part of #8825

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump
