### PR TITLE
config: introduce --force-recovery CLI option

### DIFF
--- a/changelogs/unreleased/gh-8876-force-recovery-cli-option.md
+++ b/changelogs/unreleased/gh-8876-force-recovery-cli-option.md
@@ -1,0 +1,3 @@
+## feature/app
+
+* Added the new `--force-recovery` CLI option (gh-8876).

--- a/src/box/lua/cfg.cc
+++ b/src/box/lua/cfg.cc
@@ -480,6 +480,13 @@ lbox_cfg_set_auth_type(struct lua_State *L)
 	return 0;
 }
 
+static int
+lbox_cfg_get_force_recovery(struct lua_State *L)
+{
+	lua_pushboolean(L, box_is_force_recovery);
+	return 1;
+}
+
 void
 box_lua_cfg_init(struct lua_State *L)
 {
@@ -528,6 +535,7 @@ box_lua_cfg_init(struct lua_State *L)
 		{"cfg_set_txn_timeout", lbox_cfg_set_txn_timeout},
 		{"cfg_set_txn_isolation", lbox_cfg_set_txn_isolation},
 		{"cfg_set_auth_type", lbox_cfg_set_auth_type},
+		{"cfg_get_force_recovery", lbox_cfg_get_force_recovery},
 		{NULL, NULL}
 	};
 

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -1036,6 +1036,12 @@ local function load_cfg(cfg)
 
     cfg = upgrade_cfg(cfg, translate_cfg)
 
+    -- Forced recovery can be envoked by CLI options. Set the appropriate
+    -- box_cfg option in this case.
+    if cfg.force_recovery == nil and private.cfg_get_force_recovery() then
+        cfg.force_recovery = true;
+    end
+
     -- Set options passed through environment variables.
     apply_env_cfg(cfg, box.internal.cfg.env, pre_load_cfg_is_set)
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -635,6 +635,7 @@ print_help(FILE *stream, const char *program)
 		"Options:\n\n"
 		" -h, --help             display this help and exit\n"
 		" --help-env-list        display env variables taken into account\n"
+		" --force-recovery       enable force-recovery\n"
 		" -v, --version          print program version and exit\n"
 		" -c, --config PATH      set a path to yaml config file as 'PATH'\n"
 		" -n, --name INSTANCE    set an instance name as 'INSTANCE'\n"
@@ -692,6 +693,7 @@ main(int argc, char **argv)
 		 * change it if -E short option should be added.
 		 */
 		{"help-env-list", no_argument, 0, 'E'},
+		{"force-recovery", no_argument, 0, 'F'},
 		{NULL, 0, 0, 0},
 	};
 	static const char *opts = "+hVvb::ij:e:l:dc:n:";
@@ -723,6 +725,9 @@ main(int argc, char **argv)
 			return 0;
 		case 'E':
 			opt_mask |= O_HELP_ENV_LIST;
+			break;
+		case 'F':
+			box_is_force_recovery = true;
 			break;
 		case 'i':
 			/* Force interactive mode */

--- a/test/box-py/args.result
+++ b/test/box-py/args.result
@@ -25,6 +25,7 @@ Options:
 
  -h, --help             display this help and exit
  --help-env-list        display env variables taken into account
+ --force-recovery       enable force-recovery
  -v, --version          print program version and exit
  -c, --config PATH      set a path to yaml config file as 'PATH'
  -n, --name INSTANCE    set an instance name as 'INSTANCE'
@@ -67,6 +68,7 @@ Options:
 
  -h, --help             display this help and exit
  --help-env-list        display env variables taken into account
+ --force-recovery       enable force-recovery
  -v, --version          print program version and exit
  -c, --config PATH      set a path to yaml config file as 'PATH'
  -n, --name INSTANCE    set an instance name as 'INSTANCE'


### PR DESCRIPTION
This patch introduces a new CLI option: --force-recovery.

Closes #8876