### PR TITLE
box: fix crashes if some box.info functions called before box.cfg

### DIFF
--- a/changelogs/unreleased/gh-9173-box-info-crash.md
+++ b/changelogs/unreleased/gh-9173-box-info-crash.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed crashes if `box.info.memory()`, `box.info.gc()`, `box.info.vinyl()`,
+  and `box.info.sql()` are called before `box.cfg{}` (gh-9173).

--- a/src/box/lua/info.c
+++ b/src/box/lua/info.c
@@ -444,6 +444,9 @@ lbox_info_cluster(struct lua_State *L)
 static int
 lbox_info_memory_call(struct lua_State *L)
 {
+	if (box_check_configured() != 0)
+		return luaT_error(L);
+
 	struct engine_memory_stat stat;
 	engine_memory_stat(&stat);
 
@@ -496,6 +499,9 @@ lbox_info_memory(struct lua_State *L)
 static int
 lbox_info_gc_call(struct lua_State *L)
 {
+	if (box_check_configured() != 0)
+		return luaT_error(L);
+
 	int count;
 
 	lua_newtable(L);
@@ -594,6 +600,9 @@ lbox_info_gc(struct lua_State *L)
 static int
 lbox_info_vinyl_call(struct lua_State *L)
 {
+	if (box_check_configured() != 0)
+		return luaT_error(L);
+
 	struct info_handler h;
 	luaT_info_handler_create(&h, L);
 	struct engine *vinyl = engine_by_name("vinyl");
@@ -621,6 +630,9 @@ lbox_info_vinyl(struct lua_State *L)
 static int
 lbox_info_sql_call(struct lua_State *L)
 {
+	if (box_check_configured() != 0)
+		return luaT_error(L);
+
 	struct info_handler h;
 	luaT_info_handler_create(&h, L);
 	sql_stmt_cache_stat(&h);

--- a/test/box-luatest/gh_9173_box_info_before_box_cfg_test.lua
+++ b/test/box-luatest/gh_9173_box_info_before_box_cfg_test.lua
@@ -1,0 +1,23 @@
+local t = require('luatest')
+
+local g = t.group()
+
+g.test_all_box_info = function()
+    -- Check that application won't be crashed
+    for _, func in pairs(box.info()) do
+        pcall(func)
+    end
+end
+
+g.test_box_info_errors = function()
+    t.assert_error_msg_equals('Please call box.cfg{} first',
+                              box.info.memory)
+    t.assert_error_msg_equals('Please call box.cfg{} first',
+                              box.info.sql)
+    t.assert_error_msg_equals('Please call box.cfg{} first',
+                              box.info.vinyl)
+    t.assert_error_msg_equals('Please call box.cfg{} first',
+                              box.info.gc)
+    t.assert_equals(box.info.replication_anon(), {},
+                    'Works ok without box.cfg{}')
+end


### PR DESCRIPTION
Before this patch if one called `vinyl`, `sql`, `gc` and `memory` functions from box.info() instance crashed. It's interesting that `replication_anon` functions worked ok.
This patch fixes that crashes.

Closes #9173

NO_DOC=bugfix