### PR TITLE
Add failover coordinator stubs

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -62,6 +62,10 @@ if (ENABLE_CONFIG_EXTRAS)
 endif()
 # }}} config
 
+if (ENABLE_FAILOVER)
+    lua_multi_source(lua_sources ${FAILOVER_LUA_SOURCES})
+endif()
+
 set(bin_sources)
 bin_source(bin_sources bootstrap.snap bootstrap.h bootstrap_bin)
 

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1831,6 +1831,23 @@ return schema.new('instance_config', schema.record({
     roles = schema.array({
         items = schema.scalar({type = 'string'})
     }),
+    -- Options of the failover coordinator service.
+    --
+    -- TODO: Allow only in the global scope.
+    failover = schema.record({
+        probe_interval = schema.scalar({
+            type = 'number',
+            default = 10,
+        }),
+        connect_timeout = schema.scalar({
+            type = 'number',
+            default = 1,
+        }),
+        call_timeout = schema.scalar({
+            type = 'number',
+            default = 1,
+        }),
+    }),
 }, {
     -- This kind of validation cannot be implemented as the
     -- 'validate' annotation of a particular schema node. There

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -347,6 +347,23 @@ local function instance_uri(self, iconfig, advertise_type)
     return nil
 end
 
+local function apply_vars_f(data, w, vars)
+    if w.schema.type == 'string' and data ~= nil then
+        assert(type(data) == 'string')
+        return (data:gsub('{{ *(.-) *}}', function(var_name)
+            if vars[var_name] ~= nil then
+                return vars[var_name]
+            end
+            w.error(('Unknown variable %q'):format(var_name))
+        end))
+    end
+    return data
+end
+
+local function apply_vars(self, iconfig, vars)
+    return self:map(iconfig, apply_vars_f, vars)
+end
+
 local function feedback_apply_default_if(_data, _w)
     return box.internal.feedback_daemon ~= nil
 end
@@ -1833,5 +1850,6 @@ return schema.new('instance_config', schema.record({
 }), {
     methods = {
         instance_uri = instance_uri,
+        apply_vars = apply_vars,
     },
 })

--- a/src/box/lua/failover.h
+++ b/src/box/lua/failover.h
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include "trivia/config.h"
+
+#if defined(ENABLE_FAILOVER)
+#include "lua/failover_impl.h"
+#else /* !defined(ENABLE_FAILOVER) */
+
+#define FAILOVER_LUA_MODULES
+
+#endif /* !defined(ENABLE_FAILOVER) */

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -77,6 +77,7 @@
 #include "box/lua/space_upgrade.h"
 #include "box/lua/wal_ext.h"
 #include "box/lua/trigger.h"
+#include "box/lua/failover.h"
 
 #include "mpstream/mpstream.h"
 
@@ -397,6 +398,8 @@ static const char *lua_sources[] = {
 	config_init_lua,
 
 	/* }}} config */
+
+	FAILOVER_LUA_MODULES
 
 	NULL
 };

--- a/src/lua/init.h
+++ b/src/lua/init.h
@@ -56,6 +56,7 @@ struct instance_state {
 #define O_DEBUGGING   0x4
 #define O_EXECUTE     0x8
 #define O_HELP_ENV_LIST 0x10
+#define O_FAILOVER      0x20
 
 /** Returns true if the name refers to a built-in global Lua object. */
 bool

--- a/src/trivia/config.h.cmake
+++ b/src/trivia/config.h.cmake
@@ -289,6 +289,7 @@
 #cmakedefine ENABLE_COMPRESS_MODULE 1
 #cmakedefine ENABLE_ETCD_CLIENT 1
 #cmakedefine ENABLE_CONFIG_EXTRAS 1
+#cmakedefine ENABLE_FAILOVER 1
 
 #cmakedefine EXPORT_LIBCURL_SYMBOLS 1
 

--- a/test/app-luatest/gh_8613_new_cli_behaviour_test.lua
+++ b/test/app-luatest/gh_8613_new_cli_behaviour_test.lua
@@ -8,7 +8,8 @@ local misuse = {
     output = table.concat({
         'Invalid usage: please either provide a Lua script name',
         'or specify an instance name to be started',
-        'or set -i CLI flag to spawn Lua REPL.',
+        'or set -i CLI flag to spawn Lua REPL or run a',
+        'failover coordinator using --failover CLI option.'
     }, '\n'),
     pattern = false,
 }

--- a/test/box-py/args.result
+++ b/test/box-py/args.result
@@ -35,6 +35,7 @@ Options:
  -j cmd                 perform LuaJIT control command
  -b ...                 save or list bytecode
  -d                     activate debugging session for script
+ --failover             run a failover coordinator (Enterprise Edition)
  --                     stop handling options
  -                      execute stdin and stop handling options
 
@@ -78,6 +79,7 @@ Options:
  -j cmd                 perform LuaJIT control command
  -b ...                 save or list bytecode
  -d                     activate debugging session for script
+ --failover             run a failover coordinator (Enterprise Edition)
  --                     stop handling options
  -                      execute stdin and stop handling options
 

--- a/test/config-luatest/cli_test.lua
+++ b/test/config-luatest/cli_test.lua
@@ -131,3 +131,12 @@ g.test_force_recovery = function()
     t.assert_equals(res.exit_code, 0)
     t.assert_equals(res.stdout, 'false')
 end
+
+g.test_failover = function()
+    t.tarantool.skip_if_enterprise()
+    local opts = {nojson = true, stderr = true}
+    local res = justrun.tarantool('.', {}, {'--failover'}, opts)
+    t.assert_not_equals(res.exit_code, 0)
+    t.assert_equals(res.stderr, '--failover CLI option is available only in ' ..
+        'Tarantool Enterprise Edition')
+end

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -284,6 +284,11 @@ g.test_defaults = function()
             },
             to = "devnull",
         } or nil,
+        failover = {
+            probe_interval = 10,
+            connect_timeout = 1,
+            call_timeout = 1,
+        },
     }
     local res = cluster_config:apply_default({})
     t.assert_equals(res, exp)

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1351,3 +1351,24 @@ g.test_audit_available = function()
     local res = instance_config:apply_default({}).audit_log
     t.assert_equals(res, exp)
 end
+
+g.test_failover = function()
+    local iconfig = {
+        failover = {
+            probe_interval = 5,
+            connect_timeout = 2,
+            call_timeout = 2,
+        },
+    }
+
+    instance_config:validate(iconfig)
+    validate_fields(iconfig.failover, instance_config.schema.fields.failover)
+
+    local exp = {
+        probe_interval = 10,
+        connect_timeout = 1,
+        call_timeout = 1,
+    }
+    local res = instance_config:apply_default({}).failover
+    t.assert_equals(res, exp)
+end


### PR DESCRIPTION
This patchset prepares declarative configuration collecting code to be used in the failover coordinator service, adds `--failover` option, adds failover module stubs.

The failover agent is to be implemented as part of Tarantool Enterprise Edition.

Part of https://github.com/tarantool/tarantool-ee/issues/564