### PR TITLE
Add variants of ALTER TABLE DROP CONSTRAINT

### DIFF
--- a/changelogs/unreleased/gh-9112-upgrade-drop-constraint.md
+++ b/changelogs/unreleased/gh-9112-upgrade-drop-constraint.md
@@ -1,0 +1,4 @@
+## feature/sql
+
+* **[Breaking change]** The `DROP CONSTRAINT` statement has been
+  improved (gh-9112).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3464,8 +3464,6 @@ boxk(int type, uint32_t space_id, const char *format, ...)
 	RegionGuard region_guard(region);
 	const char *data = mp_vformat_on_region(region, &size, format, ap);
 	va_end(ap);
-	if (data == NULL)
-		return -1;
 	const char *data_end = data + size;
 	switch (type) {
 	case IPROTO_INSERT:

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -1488,10 +1488,6 @@ sql_constraint_drop(uint32_t space_id, const char *name)
 	const char *ops = mp_format_on_region(region, &size, "[[%s%s%u]]", "#",
 					      path, 1);
 	const char *end = ops + size;
-	if (ops == NULL) {
-		region_truncate(region, used);
-		return -1;
-	}
 	int rc = box_update(BOX_SPACE_ID, 0, key, key_end, ops, end, 0, NULL);
 	region_truncate(region, used);
 	return rc;
@@ -1544,8 +1540,6 @@ sql_constraint_create(const char *name, uint32_t space_id, const char *path,
 		ops = mp_format_on_region(region, &ops_size, "[[%s%s%p]]", "!",
 					  buf, value);
 	}
-	if (ops == NULL)
-		goto error;
 	const char *end = ops + ops_size;
 	if (box_update(BOX_SPACE_ID, 0, key, key_end, ops, end, 0, NULL) != 0)
 		goto error;
@@ -1596,8 +1590,6 @@ sql_foreign_key_create(const char *name, uint32_t child_id, uint32_t parent_id,
 					    "space", parent_id, "field",
 					    mapping);
 	}
-	if (value == NULL)
-		return -1;
 	assert(mp_typeof(*value) == MP_MAP);
 	for (uint32_t i = 0; i < count; ++i) {
 		if (cdefs[i].type != CONSTR_FKEY)

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -2050,20 +2050,33 @@ sql_drop_table_constraint(struct Parse *parser, const struct Token *table_name,
 		sqlVdbeCountChanges(v);
 		sqlVdbeAddOp4(v, OP_DropTupleForeignKey, space->def->id, 0, 0,
 			      sql_xstrdup(fk->name), P4_DYNAMIC);
-		return;
 	}
 
 	const struct tuple_constraint_def *ck =
 		sql_tuple_ck_by_token(space, name);
 	if (ck != NULL) {
+		if (fk != NULL) {
+			diag_set(ClientError, ER_SQL_EXECUTE,
+				 tt_sprintf("ambiguous constraint name: '%s'",
+					    fk->name));
+			parser->is_aborted = true;
+			return;
+		}
 		sqlVdbeCountChanges(v);
 		sqlVdbeAddOp4(v, OP_DropTupleCheck, space->def->id, 0, 0,
 			      sql_xstrdup(ck->name), P4_DYNAMIC);
-		return;
 	}
 
 	uint32_t index_id = sql_index_id_by_token(space, name);
 	if (index_id != UINT32_MAX) {
+		if (fk != NULL || ck != NULL) {
+			const char *str = fk != NULL ? fk->name : ck->name;
+			diag_set(ClientError, ER_SQL_EXECUTE,
+				 tt_sprintf("ambiguous constraint name: '%s'",
+					    str));
+			parser->is_aborted = true;
+			return;
+		}
 		int regs = sqlGetTempRange(parser, 3);
 		sqlVdbeCountChanges(v);
 		sqlVdbeAddOp2(v, OP_Integer, space->def->id, regs);
@@ -2074,6 +2087,9 @@ sql_drop_table_constraint(struct Parse *parser, const struct Token *table_name,
 		sqlReleaseTempRange(parser, regs, 3);
 		return;
 	}
+
+	if (fk != NULL || ck != NULL)
+		return;
 
 	diag_set(ClientError, ER_NO_SUCH_CONSTRAINT,
 		 sql_tt_name_from_token(name), space->def->name);
@@ -2102,6 +2118,7 @@ sql_drop_field_constraint(struct Parse *parser, const struct Token *table_name,
 		return;
 	}
 	struct Vdbe *v = sqlGetVdbe(parser);
+	const char *field_name = space->def->fields[fieldno].name;
 
 	const struct tuple_constraint_def *fk =
 		sql_field_fk_by_token(space, fieldno, name);
@@ -2109,19 +2126,28 @@ sql_drop_field_constraint(struct Parse *parser, const struct Token *table_name,
 		sqlVdbeCountChanges(v);
 		sqlVdbeAddOp4(v, OP_DropFieldForeignKey, space->def->id, 0,
 			      fieldno, sql_xstrdup(fk->name), P4_DYNAMIC);
-		return;
 	}
 
 	const struct tuple_constraint_def *ck =
 		sql_field_ck_by_token(space, fieldno, name);
 	if (ck != NULL) {
+		if (fk != NULL) {
+			const char *err =
+				tt_sprintf("ambiguous constraint name: '%s.%s'",
+					   field_name, fk->name);
+			diag_set(ClientError, ER_SQL_EXECUTE, err);
+			parser->is_aborted = true;
+			return;
+		}
 		sqlVdbeCountChanges(v);
 		sqlVdbeAddOp4(v, OP_DropFieldCheck, space->def->id, 0, fieldno,
 			      sql_xstrdup(ck->name), P4_DYNAMIC);
 		return;
 	}
 
-	const char *field_name = space->def->fields[fieldno].name;
+	if (fk != NULL)
+		return;
+
 	char *name_str = sql_name_from_token(name);
 	diag_set(ClientError, ER_NO_SUCH_CONSTRAINT,
 		 tt_sprintf("%s.%s", field_name, name_str), space->def->name);

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -1722,10 +1722,14 @@ cmd ::= alter_table_start(A) RENAME TO nm(N). {
     sql_alter_table_rename(pParse);
 }
 
-cmd ::= ALTER TABLE fullname(X) DROP CONSTRAINT nm(Z). {
-  drop_constraint_def_init(&pParse->drop_constraint_def, X, &Z, false);
+cmd ::= ALTER TABLE nm(X) DROP CONSTRAINT nm(Z). {
   pParse->initiateTTrans = true;
-  sql_drop_constraint(pParse);
+  sql_drop_table_constraint(pParse, &X, &Z);
+}
+
+cmd ::= ALTER TABLE nm(X) DROP CONSTRAINT nm(F) DOT nm(Z). {
+  pParse->initiateTTrans = true;
+  sql_drop_field_constraint(pParse, &X, &F, &Z);
 }
 
 //////////////////////// COMMON TABLE EXPRESSIONS ////////////////////////////

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -1727,9 +1727,39 @@ cmd ::= ALTER TABLE nm(X) DROP CONSTRAINT nm(Z). {
   sql_drop_table_constraint(pParse, &X, &Z);
 }
 
+cmd ::= ALTER TABLE nm(X) DROP CONSTRAINT nm(Z) FOREIGN KEY. {
+  pParse->initiateTTrans = true;
+  sql_drop_tuple_foreign_key(pParse, &X, &Z);
+}
+
+cmd ::= ALTER TABLE nm(X) DROP CONSTRAINT nm(Z) PRIMARY KEY. {
+  pParse->initiateTTrans = true;
+  sql_drop_primary_key(pParse, &X, &Z);
+}
+
+cmd ::= ALTER TABLE nm(X) DROP CONSTRAINT nm(Z) UNIQUE. {
+  pParse->initiateTTrans = true;
+  sql_drop_unique(pParse, &X, &Z);
+}
+
+cmd ::= ALTER TABLE nm(X) DROP CONSTRAINT nm(Z) CHECK. {
+  pParse->initiateTTrans = true;
+  sql_drop_tuple_check(pParse, &X, &Z);
+}
+
 cmd ::= ALTER TABLE nm(X) DROP CONSTRAINT nm(F) DOT nm(Z). {
   pParse->initiateTTrans = true;
   sql_drop_field_constraint(pParse, &X, &F, &Z);
+}
+
+cmd ::= ALTER TABLE nm(X) DROP CONSTRAINT nm(F) DOT nm(Z) FOREIGN KEY. {
+  pParse->initiateTTrans = true;
+  sql_drop_field_foreign_key(pParse, &X, &F, &Z);
+}
+
+cmd ::= ALTER TABLE nm(X) DROP CONSTRAINT nm(F) DOT nm(Z) CHECK. {
+  pParse->initiateTTrans = true;
+  sql_drop_field_check(pParse, &X, &F, &Z);
 }
 
 //////////////////////// COMMON TABLE EXPRESSIONS ////////////////////////////

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -301,10 +301,6 @@ struct drop_trigger_def {
 	struct drop_entity_def base;
 };
 
-struct drop_constraint_def {
-	struct drop_entity_def base;
-};
-
 struct drop_index_def {
 	struct drop_entity_def base;
 };
@@ -434,15 +430,6 @@ drop_trigger_def_init(struct drop_trigger_def *drop_trigger_def,
 {
 	drop_entity_def_init(&drop_trigger_def->base, parent_name, name,
 			     if_exist, ENTITY_TYPE_TRIGGER);
-}
-
-static inline void
-drop_constraint_def_init(struct drop_constraint_def *drop_constraint_def,
-			 struct SrcList *parent_name, struct Token *name,
-			 bool if_exist)
-{
-	drop_entity_def_init(&drop_constraint_def->base, parent_name, name,
-			     if_exist, ENTITY_TYPE_CONSTRAINT);
 }
 
 static inline void

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -3667,11 +3667,42 @@ void
 sql_drop_table_constraint(struct Parse *parser, const struct Token *table_name,
 			  const struct Token *constraint_name);
 
+/** Emit code to drop tuple FOREIGN KEY constraint. */
+void
+sql_drop_tuple_foreign_key(struct Parse *parser, const struct Token *table_name,
+			   const struct Token *name);
+
+/** Emit code to drop tuple CHECK constraint. */
+void
+sql_drop_tuple_check(struct Parse *parser, const struct Token *table_name,
+		     const struct Token *name);
+
+/** Emit code to drop PRIMARY KEY constraint. */
+void
+sql_drop_primary_key(struct Parse *parser, const struct Token *table_name,
+		     const struct Token *name);
+
+/** Emit code to drop UNIQUE constraint. */
+void
+sql_drop_unique(struct Parse *parser, const struct Token *table_name,
+		const struct Token *name);
+
 /** Emit code to field FOREIGN KEY or field CHECK constraint. */
 void
 sql_drop_field_constraint(struct Parse *parser, const struct Token *table_name,
 			  const struct Token *column_name,
 			  const struct Token *name);
+
+/** Emit code to drop field FOREIGN KEY constraint. */
+void
+sql_drop_field_foreign_key(struct Parse *parser, const struct Token *table_name,
+			   const struct Token *column_name,
+			   const struct Token *name);
+
+/** Emit code to drop field CHECK constraint. */
+void
+sql_drop_field_check(struct Parse *parser, const struct Token *table_name,
+		     const struct Token *column_name, const struct Token *name);
 
 /**
  * Now our SQL implementation can't operate on spaces which

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2046,7 +2046,6 @@ struct Parse {
 		struct create_trigger_def create_trigger_def;
 		struct create_view_def create_view_def;
 		struct rename_entity_def rename_entity_def;
-		struct drop_constraint_def drop_constraint_def;
 		struct drop_index_def drop_index_def;
 		struct drop_table_def drop_table_def;
 		struct drop_trigger_def drop_trigger_def;

--- a/src/box/sql/tarantoolInt.h
+++ b/src/box/sql/tarantoolInt.h
@@ -179,13 +179,22 @@ sql_encode_table_opts(struct region *region, struct space_def *def,
 char *
 fk_constraint_encode_links(const struct fk_constraint_def *fk, uint32_t *size);
 
-/**
- * Drop the check constraint or foreign key. This function drops tuple and field
- * constraints. If there is more than one constraint with the given name, one of
- * them will be dropped.
- */
+/** Drop tuple FOREIGN KEY constraint with given name. */
 int
-sql_constraint_drop(uint32_t space_id, const char *name);
+sql_tuple_foreign_key_drop(uint32_t space_id, const char *name);
+
+/** Drop tuple CHECK constraint with given name. */
+int
+sql_tuple_check_drop(uint32_t space_id, const char *name);
+
+/** Drop field FOREIGN KEY constraint of given field with given name. */
+int
+sql_field_foreign_key_drop(uint32_t space_id, uint32_t fieldno,
+			   const char *name);
+
+/** Drop field CHECK constraint of given field with given name. */
+int
+sql_field_check_drop(uint32_t space_id, uint32_t fieldno, const char *name);
 
 /**
  * Create new foreign key.

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -2195,14 +2195,51 @@ case OP_CreateCheck: {
 }
 
 /**
- * Opcode: DropTupleConstraint P1 * * P4 *
- * Synopsis: Drop constraint from box.space[P1]
- *
- * Drop constraint named P4.z from space P1.
+ * Opcode: OP_DropTupleForeignKey P1 * * P4 *
+ * Synopsis: Drop FOREIGN KEY constraint from box.space[P1]
  */
-case OP_DropTupleConstraint: {
+case OP_DropTupleForeignKey: {
 	assert(pOp->p1 >= 0 && pOp->p4.z != NULL);
-	if (sql_constraint_drop(pOp->p1, pOp->p4.z) != 0)
+	if (sql_tuple_foreign_key_drop(pOp->p1, pOp->p4.z) != 0)
+		goto abort_due_to_error;
+	assert(p->nChange == 0);
+	p->nChange = 1;
+	break;
+}
+
+/**
+ * Opcode: DropTupleConstraint P1 * * P4 *
+ * Synopsis: Drop CHECK constraint from box.space[P1]
+ */
+case OP_DropTupleCheck: {
+	assert(pOp->p1 >= 0 && pOp->p4.z != NULL);
+	if (sql_tuple_check_drop(pOp->p1, pOp->p4.z) != 0)
+		goto abort_due_to_error;
+	assert(p->nChange == 0);
+	p->nChange = 1;
+	break;
+}
+
+/**
+ * Opcode: OP_DropFieldForeignKey P1 * P3 P4 *
+ * Synopsis: Drop FOREIGN KEY constraint from field P3 of box.space[P1]
+ */
+case OP_DropFieldForeignKey: {
+	assert(pOp->p1 >= 0 && pOp->p4.z != NULL);
+	if (sql_field_foreign_key_drop(pOp->p1, pOp->p3, pOp->p4.z) != 0)
+		goto abort_due_to_error;
+	assert(p->nChange == 0);
+	p->nChange = 1;
+	break;
+}
+
+/**
+ * Opcode: OP_DropFieldCheck P1 * P3 P4 *
+ * Synopsis: Drop CHECK constraint from field P3 of box.space[P1]
+ */
+case OP_DropFieldCheck: {
+	assert(pOp->p1 >= 0 && pOp->p4.z != NULL);
+	if (sql_field_check_drop(pOp->p1, pOp->p3, pOp->p4.z) != 0)
 		goto abort_due_to_error;
 	assert(p->nChange == 0);
 	p->nChange = 1;

--- a/src/lib/core/mp_util.c
+++ b/src/lib/core/mp_util.c
@@ -16,12 +16,8 @@ mp_vformat_on_region(struct region *region, size_t *size, const char *format,
 	va_list ap;
 	va_copy(ap, src);
 	size_t buf_size = mp_vformat(NULL, 0, format, ap);
-	char *buf = region_alloc(region, buf_size);
+	char *buf = xregion_alloc(region, buf_size);
 	va_end(ap);
-	if (buf == NULL) {
-		diag_set(OutOfMemory, buf_size, "region_alloc", "buf");
-		return buf;
-	}
 	va_copy(ap, src);
 	*size = mp_vformat(buf, buf_size, format, ap);
 	va_end(ap);

--- a/src/lib/core/mp_util.h
+++ b/src/lib/core/mp_util.h
@@ -25,7 +25,6 @@ struct region;
  * list.
  * @param src Variable argument list.
  *
- * @retval NULL on error.
  * @retval Address of the buffer with the encoded value.
  */
 const char *
@@ -42,7 +41,6 @@ mp_vformat_on_region(struct region *region, size_t *size, const char *format,
  * resulting msgpack and the types of the next arguments.
  * @param ... Values to encode.
  *
- * @retval NULL on error.
  * @retval Address of the buffer with the encoded value.
  */
 const char *


### PR DESCRIPTION
Since we don't have a single namespace for names of all the constraint types, we need to add `DROP CONSTRAINT` variants to be able to drop any desired constraint.

Closes #9112