### PR TITLE
[2.10] box: disable split-brain detection until schema is upgraded

### DIFF
--- a/changelogs/unreleased/gh-8996-spurious-spit-brain-detected.md
+++ b/changelogs/unreleased/gh-8996-spurious-spit-brain-detected.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed a false-positive split-brain in a replica set on the first
+  promotion after an upgrade from versions before 2.10.1 (gh-8996).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -41,6 +41,7 @@
 #include "coll_id_cache.h"
 #include "coll_id_def.h"
 #include "txn.h"
+#include "txn_limbo.h"
 #include "tuple.h"
 #include "tuple_constraint.h"
 #include "fiber.h" /* for gc_pool */
@@ -4168,6 +4169,20 @@ on_replace_dd_priv(struct trigger * /* trigger */, void *event)
 
 /* {{{ cluster configuration */
 
+static int
+start_synchro_filtering(va_list /* ap */)
+{
+	txn_limbo_filter_enable(&txn_limbo);
+	return 0;
+}
+
+static int
+stop_synchro_filtering(va_list /* ap */)
+{
+	txn_limbo_filter_disable(&txn_limbo);
+	return 0;
+}
+
 /**
  * This trigger is invoked only upon initial recovery, when
  * reading contents of the system spaces from the snapshot.
@@ -4218,6 +4233,25 @@ on_replace_dd_schema(struct trigger * /* trigger */, void *event)
 			 * example, for box.internal.bootstrap().
 			 */
 			dd_version_id = tarantool_version_id();
+		}
+		if (recovery_state != FINISHED_RECOVERY) {
+			return 0;
+		}
+		struct fiber *fiber = NULL;
+		if (dd_version_id > version_id(2, 10, 1) &&
+		    recovery_state == FINISHED_RECOVERY) {
+			fiber = fiber_new_system("synchro_filter_enabler",
+						 start_synchro_filtering);
+			if (fiber == NULL)
+				return -1;
+			fiber_wakeup(fiber);
+		} else if (dd_version_id <= version_id(2, 10, 1) &&
+			   recovery_state == FINISHED_RECOVERY) {
+			fiber = fiber_new_system("synchro_filter_disabler",
+						 stop_synchro_filtering);
+			if (fiber == NULL)
+				return -1;
+			fiber_wakeup(fiber);
 		}
 	}
 	return 0;

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -4247,9 +4247,12 @@ box_cfg_xc(void)
 	/*
 	 * Enable split brain detection once node is fully recovered or
 	 * bootstrapped. No split brain could happen during bootstrap or local
-	 * recovery.
+	 * recovery. Only do so in an upgraded cluster. Unfortunately, schema
+	 * version 2.10.1 was used in 2.10.0 release, while split-brain
+	 * detection appeared in 2.10.1. So use the schema version after 2.10.1.
 	 */
-	txn_limbo_filter_enable(&txn_limbo);
+	if (dd_version_id > version_id(2, 10, 1))
+		txn_limbo_filter_enable(&txn_limbo);
 
 	title("running");
 	say_info("ready to accept requests");

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -1282,6 +1282,14 @@ txn_limbo_filter_enable(struct txn_limbo *limbo)
 }
 
 void
+txn_limbo_filter_disable(struct txn_limbo *limbo)
+{
+	latch_lock(&limbo->promote_latch);
+	limbo->do_validate = false;
+	latch_unlock(&limbo->promote_latch);
+}
+
+void
 txn_limbo_init(void)
 {
 	txn_limbo_create(&txn_limbo);

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -428,6 +428,10 @@ txn_limbo_on_parameters_change(struct txn_limbo *limbo);
 void
 txn_limbo_filter_enable(struct txn_limbo *limbo);
 
+/** Stop filtering incoming synchro requests. */
+void
+txn_limbo_filter_disable(struct txn_limbo *limbo);
+
 /**
  * Freeze limbo. Prevent CONFIRMs and ROLLBACKs until limbo is unfrozen.
  */


### PR DESCRIPTION
Our split-brain detection machinery relies among other things on all nodes tracking the synchro queue confirmed lsn. This tracking was only added together with the split-brain detection. Only the synchro queue owner tracked the confirmed lsn before.

This means that after an upgrade all the replicas remember the latest confirmed lsn as 0, and any PROMOTE/DEMOTE request from the queue owner is treated as a split brain.

Let's fix this and only enable split-brain detection on the replica set once the schema version is updated. Thanks to the synchro queue freeze on restart, this can only happen after a new PROMOTE or DEMOTE entry is written by one of the nodes, and thus the correct confirmed lsn is propagated with this PROMOTE/DEMOTE to all the cluster members.

Closes #8996

NO_DOC=bugfix
NO_TEST=2.10 lacks box.schema.downgrade(), which's used in the test

(cherry picked from commit a844bd37ac9b523165ce709d1f70a68dce0eb308)