### PR TITLE
box: do not log option value if it not changed

### DIFF
--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -934,7 +934,11 @@ local function reconfig_modules(module_keys, oldcfg, newcfg, log_basecfg)
             error(err)
         end
 
-        log_changed_options(oldcfg, keys, log_basecfg)
+        if log_basecfg ~= nil then
+            log_changed_options(oldcfg, keys, log_basecfg)
+        else
+            log_changed_options(oldcfg, keys, oldvals)
+        end
     end
 end
 

--- a/test/config-luatest/log_test.lua
+++ b/test/config-luatest/log_test.lua
@@ -1,0 +1,53 @@
+local t = require('luatest')
+local fio = require('fio')
+local justrun = require('test.justrun')
+local treegen = require('test.treegen')
+
+local g = t.group()
+
+g.before_all(function()
+    treegen.init(g)
+end)
+
+g.after_all(function()
+    treegen.clean(g)
+end)
+
+g.test_log_only_changed_options = function()
+    local dir = treegen.prepare_directory(g, {}, {})
+    local script = [[
+        box.cfg{log_level = 5, log = 'file:log.txt'}
+        box.cfg{sql_cache_size = 1000}
+        box.cfg{sql_cache_size = 1000}
+        box.cfg{sql_cache_size = 1000}
+        box.cfg{sql_cache_size = 2000}
+        box.cfg{sql_cache_size = 2000}
+        box.cfg{sql_cache_size = 1000}
+        box.cfg{sql_cache_size = 1000}
+        box.cfg{sql_cache_size = 1000}
+        os.exit(0)
+    ]]
+    treegen.write_script(dir, 'main.lua', script)
+
+    local env = {}
+    local opts = {nojson = true, stderr = false}
+    local args = {'main.lua'}
+    local res = justrun.tarantool(dir, env, args, opts)
+    t.assert_equals(res.exit_code, 0)
+
+    local path = fio.pathjoin(dir, 'log.txt')
+    local logs = {}
+    for line in io.lines(path) do
+        local res = string.gmatch(line, 'box.load_cfg I> set .+')()
+        if res ~= nil then
+            table.insert(logs, res)
+        end
+    end
+    local exp = {
+        [[box.load_cfg I> set 'log' configuration option to "file:log.txt"]],
+        [[box.load_cfg I> set 'sql_cache_size' configuration option to 1000]],
+        [[box.load_cfg I> set 'sql_cache_size' configuration option to 2000]],
+        [[box.load_cfg I> set 'sql_cache_size' configuration option to 1000]],
+    }
+    t.assert_equals(logs, exp)
+end


### PR DESCRIPTION
After commit 9b2b3e58792fb1 ("box: apply dynamic cfg even if option value is unchanged"), running box.cfg{} with any parameters logs the values of those options, even if the option value has not changed. This is quite awkward for config as it gives a lot of options to box.cfg{}, although many of them may have the old value. This patch causes box.cfg{} to log only those options whose values have changed.

Closes #9195