### PR TITLE
downgrade: fail if schema version is more recent than application

### DIFF
--- a/changelogs/unreleased/gh-9182-disable-downgrade-more-recent-schema.md
+++ b/changelogs/unreleased/gh-9182-disable-downgrade-more-recent-schema.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed a bug that allows downgrading from a schema version more recent than
+  a Tarantool version (gh-9182).

--- a/src/box/lua/upgrade.lua
+++ b/src/box/lua/upgrade.lua
@@ -6,6 +6,7 @@ local xlog = require('xlog')
 local ffi = require('ffi')
 local fun = require('fun')
 local utils = require('internal.utils')
+local tarantool = require('tarantool')
 
 ffi.cdef([[
     uint32_t box_dd_version_id(void);
@@ -2125,6 +2126,12 @@ local function downgrade_impl(version_str, dry_run)
     end
 
     local schema_version_cur = get_version()
+    local app_version = tarantool.version:match('^%d+%.%d+%.%d+')
+    if schema_version_cur > mkversion.parse(app_version) then
+        local err = "Cannot downgrade as current schema version %s is newer" ..
+                    " than Tarantool version %s"
+        error(err:format(schema_version_cur, app_version))
+    end
     local schema_version_dst = app2schema_version(version)
     if schema_version_cur < schema_version_dst then
         local err = "Cannot downgrade as current schema version %s is older" ..

--- a/test/box-luatest/downgrade_test.lua
+++ b/test/box-luatest/downgrade_test.lua
@@ -76,6 +76,27 @@ g.test_downgrade_sanity_checks = function(cg)
     end)
 end
 
+g.test_downgrade_from_more_recent_version = function(cg)
+    cg.server:exec(function()
+        local tarantool = require('tarantool')
+        local function schema_version()
+            local t = box.space._schema:get{'version'}
+            return string.format('%d.%d.%d', t[2], t[3], t[4])
+        end
+
+        local app_version = tarantool.version:match('^%d+%.%d+%.%d+')
+        local major, minor, patch = app_version:match('(%d+)%.(%d+)%.(%d+)')
+        box.space._schema:replace({'version', tonumber(major), tonumber(minor),
+                                   tonumber(patch) + 1})
+        local new_version = schema_version()
+        local err = 'Cannot downgrade as current schema version %s is newer' ..
+                    ' than Tarantool version %s'
+        t.assert_error_msg_contains(err:format(new_version, app_version),
+                                    box.schema.downgrade, app_version)
+        t.assert_equals(schema_version(), new_version)
+    end)
+end
+
 g.test_downgrade_and_upgrade = function(cg)
     cg.server:exec(function()
         box.schema.downgrade("2.8.2")


### PR DESCRIPTION
In this case we don't have knowledge how to downgrade correctly.

Close #9182