### PR TITLE
ci: run asan workflow on 'asan-ci' label

### DIFF
--- a/.github/workflows/release_asan_clang.yml
+++ b/.github/workflows/release_asan_clang.yml
@@ -33,10 +33,11 @@ concurrency:
 jobs:
   release_asan_clang:
     # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' label is set.
+    # or on pull request if the 'full-ci' or 'asan-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
         ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+          contains(github.event.pull_request.labels.*.name, 'full-ci') ||
+          contains(github.event.pull_request.labels.*.name, 'asan-ci') )
 
     runs-on: ubuntu-20.04-self-hosted
 


### PR DESCRIPTION
It is convinient to have a label to run ASAN CI without running full CI.