### PR TITLE
Add more failover coordinator stubs

### DIFF
--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1095,6 +1095,24 @@ return schema.new('instance_config', schema.record({
             --
             -- No database.mode or 'leader' options should be set.
             'election',
+            -- Automatic leader appointment by an external
+            -- failover agent ('supervised').
+            --
+            -- The default database.mode is 'ro' (but there is an
+            -- exception during a replicaset bootstrapping, see
+            -- applier/box_cfg.lua).
+            --
+            -- The failover agent assigns the 'rw' mode to one
+            -- instance in the replicaset.
+            --
+            -- No database.mode or 'leader' options should be set.
+            --
+            -- TODO: Raise an error if this value is set on
+            -- Tarantool Community Edition. The instance side code
+            -- that handles failover agent commands is part of
+            -- Tarantool Enterprise Edition, so there is no much
+            -- sense to enable this mode on the Community Edition.
+            'supervised',
         }, {
             default = 'off',
         }),

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1853,6 +1853,14 @@ return schema.new('instance_config', schema.record({
             type = 'number',
             default = 1,
         }),
+        lease_interval = schema.scalar({
+            type = 'number',
+            default = 30,
+        }),
+        renew_interval = schema.scalar({
+            type = 'number',
+            default = 10,
+        }),
     }),
 }, {
     -- This kind of validation cannot be implemented as the

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -288,6 +288,8 @@ g.test_defaults = function()
             probe_interval = 10,
             connect_timeout = 1,
             call_timeout = 1,
+            lease_interval = 30,
+            renew_interval = 10,
         },
     }
     local res = cluster_config:apply_default({})

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1372,6 +1372,8 @@ g.test_failover = function()
             probe_interval = 5,
             connect_timeout = 2,
             call_timeout = 2,
+            lease_interval = 10,
+            renew_interval = 1,
         },
     }
 
@@ -1382,6 +1384,8 @@ g.test_failover = function()
         probe_interval = 10,
         connect_timeout = 1,
         call_timeout = 1,
+        lease_interval = 30,
+        renew_interval = 10,
     }
     local res = instance_config:apply_default({}).failover
     t.assert_equals(res, exp)


### PR DESCRIPTION
Implemented `"replication.failover"` = `"supervised"` mode, where instances basically starts in the read-only mode and waits for commands from an external coordinator.

Added `lease_interval` into the `failover` section to control how long a supervised master waits for a renew command from the coordinator before going to the read-only mode.

Added `renew_interval` into the `failover` section to control how often the coordinator should send the renew commands.

The failover coodrinator is to be implemented as part of Tarantool Enterprise Edition.

Part of https://github.com/tarantool/tarantool-ee/issues/564
Follows up PR #9189