### PR TITLE
downgrade: fix test to downgrade on available version

### DIFF
--- a/test/box-luatest/downgrade_test.lua
+++ b/test/box-luatest/downgrade_test.lua
@@ -92,7 +92,8 @@ g.test_downgrade_from_more_recent_version = function(cg)
         local err = 'Cannot downgrade as current schema version %s is newer' ..
                     ' than Tarantool version %s'
         t.assert_error_msg_contains(err:format(new_version, app_version),
-                                    box.schema.downgrade, app_version)
+                                    box.schema.downgrade,
+                                    box.schema.downgrade_versions()[1])
         t.assert_equals(schema_version(), new_version)
     end)
 end


### PR DESCRIPTION
It is not convenient that `test_downgrade_from_more_recent_version` breaks if we create tag for new version and do not add next version to the downgrade versions list. If the version is released we should add it to the list anyway but it is not matter of this test.

Follow up #9182