### PR TITLE
sql: fix memory leak in SQL parser for column default

### DIFF
--- a/changelogs/unreleased/gh-9159-fix-memleak-in-sql-column-default-parser.md
+++ b/changelogs/unreleased/gh-9159-fix-memleak-in-sql-column-default-parser.md
@@ -1,0 +1,3 @@
+## bugfix/sql
+
+* Fixed a memory leak in a parser for a column's default rule (gh-9159).

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -1499,7 +1499,7 @@ cmd ::= FUNCTION_KW(T) expr(E). {
     return;
   }
   pParse->parsed_ast_type = AST_TYPE_EXPR;
-  pParse->parsed_ast.expr = sqlExprDup(E.pExpr, 0);
+  pParse->parsed_ast.expr = E.pExpr;
 }
 
 //////////////////////////// The SHOW CREATE TABLE command /////////////////////


### PR DESCRIPTION
If token is referenced in C code then destructor for token is not called. Thus we don't need to duplicate. Otherwise we got a memory leak.

See https://www.sqlite.org/cgi/src/doc/trunk/doc/lemon.html#destructor

Close #9159
