### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/lj-595-fix-clang-build.md
+++ b/changelogs/unreleased/lj-595-fix-clang-build.md
@@ -1,0 +1,3 @@
+## bugfix/luajit
+
+* Fixed build for clang versions that don't define `__GNUC__`.


### PR DESCRIPTION
Fix Clang build.

Part of #9145

NO_DOC=LuaJIT submodule
NO_TEST=LuaJIT submodule