### PR TITLE
box: introduce `tuple:info()` and `space:stat()`

### DIFF
--- a/changelogs/unreleased/gh-6762-add-tuple-info-and-space-stat.md
+++ b/changelogs/unreleased/gh-6762-add-tuple-info-and-space-stat.md
@@ -1,0 +1,4 @@
+## feature/core
+
+* Introduced new methods `tuple:info()` and `space:stat()` with the detailed
+  information on memory consumed by data (gh-6762).

--- a/src/box/allocator.h
+++ b/src/box/allocator.h
@@ -129,6 +129,11 @@ public:
 	{
 		return &small_alloc;
 	}
+	static inline void
+	get_alloc_info(void *ptr, size_t size, struct small_alloc_info *info)
+	{
+		small_alloc_info(&small_alloc, ptr, size, info);
+	}
 private:
 	static struct small_alloc small_alloc;
 };

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -2709,6 +2709,7 @@ space_mt.run_triggers = function(space, yesno)
     builtin.space_run_triggers(s, yesno)
 end
 space_mt.frommap = box.internal.space.frommap
+space_mt.stat = box.internal.space.stat
 space_mt.__index = space_mt
 
 box.schema.index_mt = base_index_mt

--- a/src/box/lua/tuple.c
+++ b/src/box/lua/tuple.c
@@ -722,6 +722,41 @@ luaT_pushtuple(struct lua_State *L, box_tuple_t *tuple)
 	luaL_setcdatagc(L, -2);
 }
 
+/**
+ * Push to Lua stack a table with the information about a tuple, located on top
+ * of the stack.
+ */
+static int
+lbox_tuple_info(lua_State *L)
+{
+	int argc = lua_gettop(L);
+	if (argc != 1)
+		luaL_error(L, "Usage: tuple:info()");
+
+	struct tuple *tuple = luaT_checktuple(L, 1);
+	struct tuple_info info;
+	tuple_info(tuple, &info);
+
+	lua_newtable(L);
+
+	lua_pushnumber(L, info.data_size);
+	lua_setfield(L, -2, "data_size");
+
+	lua_pushnumber(L, info.header_size);
+	lua_setfield(L, -2, "header_size");
+
+	lua_pushnumber(L, info.field_map_size);
+	lua_setfield(L, -2, "field_map_size");
+
+	lua_pushnumber(L, info.waste_size);
+	lua_setfield(L, -2, "waste_size");
+
+	lua_pushstring(L, tuple_arena_type_strs[info.arena_type]);
+	lua_setfield(L, -2, "arena");
+
+	return 1;
+}
+
 static const struct luaL_Reg lbox_tuple_meta[] = {
 	{"__gc", lbox_tuple_gc},
 	{"tostring", lbox_tuple_to_string},
@@ -730,6 +765,7 @@ static const struct luaL_Reg lbox_tuple_meta[] = {
 	{"tuple_to_map", lbox_tuple_to_map},
 	{"tuple_field_by_path", lbox_tuple_field_by_path},
 	{"new", lbox_tuple_new},
+	{"info", lbox_tuple_info},
 	{NULL, NULL}
 };
 

--- a/src/box/lua/tuple.lua
+++ b/src/box/lua/tuple.lua
@@ -333,6 +333,7 @@ local methods = {
     ["upsert"]      = tuple_upsert;
     ["bsize"]       = tuple_bsize;
     ["tomap"]       = internal.tuple.tuple_to_map;
+    ["info"]        = internal.tuple.info;
 }
 
 -- Aliases for tuple:methods().

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -617,10 +617,7 @@ memtx_engine_commit(struct engine *engine, struct txn *txn)
 	stailq_foreach_entry(stmt, &txn->stmts, next) {
 		if (memtx_tx_manager_use_mvcc_engine) {
 			assert(stmt->space->engine == engine);
-			struct memtx_space *mspace =
-				(struct memtx_space *)stmt->space;
-			size_t *bsize = &mspace->bsize;
-			memtx_tx_history_commit_stmt(stmt, bsize);
+			memtx_tx_history_commit_stmt(stmt);
 		}
 		if (stmt->engine_savepoint != NULL) {
 			struct space *space = stmt->space;
@@ -679,7 +676,7 @@ memtx_engine_rollback_statement(struct engine *engine, struct txn *txn,
 		}
 	}
 
-	memtx_space_update_bsize(space, new_tuple, old_tuple);
+	memtx_space_update_tuple_stat(space, new_tuple, old_tuple);
 	if (old_tuple != NULL)
 		tuple_ref(old_tuple);
 	if (new_tuple != NULL)

--- a/src/box/memtx_space.h
+++ b/src/box/memtx_space.h
@@ -31,6 +31,7 @@
  * SUCH DAMAGE.
  */
 #include "space.h"
+#include "tuple.h"
 #include "memtx_engine.h"
 
 #if defined(__cplusplus)
@@ -41,8 +42,13 @@ struct memtx_engine;
 
 struct memtx_space {
 	struct space base;
-	/* Number of bytes used in memory by tuples in the space. */
-	size_t bsize;
+	/**
+	 * Cumulative statistics on the memory usage by tuples in the space,
+	 * grouped by the following arena types:
+	 *  0 - TUPLE_ARENA_MEMTX;
+	 *  1 - TUPLE_ARENA_MALLOC.
+	 */
+	struct tuple_info tuple_stat[2];
 	/**
 	 * This counter is used to generate unique ids for
 	 * ephemeral spaces. Mostly used by SQL: values of this
@@ -59,17 +65,17 @@ struct memtx_space {
 };
 
 /**
- * Change binary size of a space subtracting old tuple's size and
- * adding new tuple's size. Used also for rollback by swaping old
- * and new tuple.
+ * Update memory usage statistics of a space by subtracting old tuple's sizes
+ * and adding new tuple's sizes. Used also for rollback by swapping old and new
+ * tuples.
  *
  * @param space Instance of memtx space.
  * @param old_tuple Old tuple (replaced or deleted).
  * @param new_tuple New tuple (inserted).
  */
 void
-memtx_space_update_bsize(struct space *space, struct tuple *old_tuple,
-			 struct tuple *new_tuple);
+memtx_space_update_tuple_stat(struct space *space, struct tuple *old_tuple,
+			      struct tuple *new_tuple);
 
 int
 memtx_space_replace_no_keys(struct space *, struct tuple *, struct tuple *,

--- a/src/box/memtx_tx.h
+++ b/src/box/memtx_tx.h
@@ -251,10 +251,9 @@ memtx_tx_prepare_finalize(struct txn *txn);
  * NB: can trigger story garbage collection.
  *
  * @param stmt current statement.
- * @param bsize the space bsize.
  */
 void
-memtx_tx_history_commit_stmt(struct txn_stmt *stmt, size_t *bsize);
+memtx_tx_history_commit_stmt(struct txn_stmt *stmt);
 
 /** Helper of memtx_tx_tuple_clarify */
 struct tuple *

--- a/src/box/tuple_format.h
+++ b/src/box/tuple_format.h
@@ -66,6 +66,7 @@ enum { TUPLE_INDEX_BASE = 1 };
 enum { TUPLE_OFFSET_SLOT_NIL = INT32_MAX };
 
 struct tuple;
+struct tuple_info;
 struct tuple_format;
 struct coll;
 struct Expr;
@@ -104,6 +105,13 @@ struct tuple_format_vtab {
 	struct tuple*
 	(*tuple_new)(struct tuple_format *format, const char *data,
 	             const char *end);
+	/**
+	 * Fill `tuple_info' with the engine-specific and allocator-specific
+	 * information about the `tuple'.
+	 */
+	void
+	(*tuple_info)(struct tuple_format *format, struct tuple *tuple,
+		      struct tuple_info *tuple_info);
 };
 
 struct tuple_constraint;

--- a/src/box/vy_stmt.c
+++ b/src/box/vy_stmt.c
@@ -119,11 +119,26 @@ vy_tuple_delete(struct tuple_format *format, struct tuple *tuple)
 	free(tuple);
 }
 
+/** Fill `tuple_info'. */
+static void
+vy_tuple_info(struct tuple_format *format, struct tuple *tuple,
+	      struct tuple_info *tuple_info)
+{
+	(void)format;
+	uint16_t data_offset = tuple_data_offset(tuple);
+	tuple_info->data_size = tuple_bsize(tuple);
+	tuple_info->header_size = sizeof(struct vy_stmt);
+	tuple_info->field_map_size = data_offset - tuple_info->header_size;
+	tuple_info->waste_size = 0;
+	tuple_info->arena_type = TUPLE_ARENA_MALLOC;
+}
+
 void
 vy_stmt_env_create(struct vy_stmt_env *env)
 {
 	env->tuple_format_vtab.tuple_new = vy_tuple_new;
 	env->tuple_format_vtab.tuple_delete = vy_tuple_delete;
+	env->tuple_format_vtab.tuple_info = vy_tuple_info;
 	env->max_tuple_size = 1024 * 1024;
 	env->sum_tuple_size = 0;
 	env->key_format = vy_simple_stmt_format_new(env, NULL, 0);

--- a/test/box-luatest/gh_6762_tuple_and_space_size_test.lua
+++ b/test/box-luatest/gh_6762_tuple_and_space_size_test.lua
@@ -129,3 +129,103 @@ g1.test_errors = function()
         box.tuple.new{0}.info, 'xxx'
     )
 end
+
+local g2 = t.group('gh-6762-space-stat',
+                   {{use_mvcc = false}, {use_mvcc = true}})
+
+g2.before_all(function(cg)
+    local box_cfg = {
+        slab_alloc_factor = 1.3,
+        slab_alloc_granularity = 32,
+        memtx_max_tuple_size = 1200*1000,
+        memtx_use_mvcc_engine = cg.params.use_mvcc
+    }
+    cg.server = server:new{box_cfg = box_cfg}
+    cg.server:start()
+end)
+g2.after_all(after_all)
+g2.after_each(after_each)
+
+-- Test stat() method of a memtx space.
+g2.test_space_stat_memtx = function(cg)
+    skip_if_asan_is_enabled()
+    cg.server:exec(function(use_mvcc)
+        local s = box.schema.space.create('memtx')
+        s:create_index('pk', {parts = {2}})
+
+        s:insert{string.rep('a', 251), 0}
+        s:insert{string.rep('b', 252), 1}
+        s:insert{string.rep('c', 1100*1000), 2}
+        s:insert{string.rep('d', 1100*1000), 3}
+
+        local total_data_size = 0
+        for _, tuple in s:pairs() do
+            total_data_size = total_data_size + tuple:info().data_size
+        end
+        t.assert_equals(total_data_size, s:bsize())
+        t.assert_equals(total_data_size,
+                        s:stat().tuple.memtx.data_size +
+                        s:stat().tuple.malloc.data_size)
+
+        local old_stat = { tuple = {  memtx = { data_size = 511,
+                                                header_size = 16,
+                                                field_map_size = 8,
+                                                waste_size = 489 },
+                                     malloc = { data_size = 2200014,
+                                                header_size = 20,
+                                                field_map_size = 8,
+                                                waste_size = 0 } }
+                         }
+        local new_stat = { tuple = {  memtx = { data_size = 517,
+                                                header_size = 22,
+                                                field_map_size = 12,
+                                                waste_size = 537 },
+                                     malloc = { data_size = 1100007,
+                                                header_size = 10,
+                                                field_map_size = 4,
+                                                waste_size = 0 } }
+                         }
+        t.assert_equals(s:stat(), old_stat)
+
+        box.begin()
+        s:delete{3}
+        s:insert{'new', 3}
+        t.assert_equals(s:stat(), use_mvcc and old_stat or new_stat)
+        box.rollback()
+        t.assert_equals(s:stat(), old_stat)
+
+        box.begin()
+        s:delete{3}
+        s:insert{'new', 3}
+        t.assert_equals(s:stat(), use_mvcc and old_stat or new_stat)
+        box.commit()
+        t.assert_equals(s:stat(), new_stat)
+    end, {cg.params.use_mvcc})
+end
+
+-- Test stat() method of a vinyl space.
+g2.test_space_stat_vinyl = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('vinyl', {engine = 'vinyl'})
+        s:create_index('pk', {parts = {2}})
+        s:insert{string.rep('a', 251), 0}
+        t.assert_equals(s:stat(), {})
+    end)
+end
+
+-- Test error messages.
+g2.test_errors = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('memtx')
+        t.assert_error_msg_content_equals(
+            'Usage: space:stat()',
+            function() s.stat() end
+        )
+        t.assert_error_msg_content_equals(
+            'Usage: space:stat()',
+            function() s:stat('xxx') end
+        )
+        t.assert_equals({s.stat{id = 'xxx'}},
+                        {nil, "Space with id '0' doesn't exist"})
+    end)
+end

--- a/test/box-luatest/gh_6762_tuple_and_space_size_test.lua
+++ b/test/box-luatest/gh_6762_tuple_and_space_size_test.lua
@@ -1,0 +1,131 @@
+local t = require('luatest')
+local tarantool = require('tarantool')
+local server = require('luatest.server')
+
+-- If ASAN is enabled, the information about memory allocation is different.
+-- There is no sense in testing it.
+local function skip_if_asan_is_enabled()
+    t.skip_if(tarantool.build.asan)
+end
+
+local function after_all(cg)
+    cg.server:drop()
+end
+
+local function after_each(cg)
+    cg.server:exec(function()
+        if box.space.memtx then
+            box.space.memtx:drop()
+        end
+        if box.space.vinyl then
+            box.space.vinyl:drop()
+        end
+    end)
+end
+
+local g1 = t.group('gh-6762-tuple-info')
+
+g1.before_all(function(cg)
+    local box_cfg = {
+        slab_alloc_factor = 1.3,
+        slab_alloc_granularity = 32,
+        memtx_max_tuple_size = 1200*1000
+    }
+    cg.server = server:new{box_cfg = box_cfg}
+    cg.server:start()
+end)
+g1.after_all(after_all)
+g1.after_each(after_each)
+
+-- Test info() method of a runtime tuple.
+g1.test_tuple_info_runtime = function(cg)
+    cg.server:exec(function()
+        -- Compact form of a tuple.
+        t.assert_equals(box.tuple.new{string.rep('c', 252)}:info(),
+                        { data_size = 255,
+                          header_size = 6,
+                          field_map_size = 0,
+                          waste_size = 0,
+                          arena = "runtime" }
+        )
+        -- Bulky form of a tuple.
+        t.assert_equals(box.tuple.new{string.rep('b', 253)}:info(),
+                        { data_size = 256,
+                          header_size = 10,
+                          field_map_size = 0,
+                          waste_size = 0,
+                          arena = "runtime" }
+        )
+    end)
+end
+
+-- Test info() method of a memtx tuple.
+g1.test_tuple_info_memtx = function(cg)
+    skip_if_asan_is_enabled()
+    cg.server:exec(function()
+        local s = box.schema.space.create('memtx')
+        s:create_index('pk', {parts = {2}})
+
+        -- Compact form of a tuple.
+        t.assert_equals(s:insert{string.rep('c', 251), 0}:info(),
+                        { data_size = 255,
+                          header_size = 6,
+                          field_map_size = 4,
+                          waste_size = 247,
+                          arena = "memtx" }
+        )
+        -- Bulky form of a tuple.
+        t.assert_equals(s:insert{string.rep('b', 252), 1}:info(),
+                        { data_size = 256,
+                          header_size = 10,
+                          field_map_size = 4,
+                          waste_size = 242,
+                          arena = "memtx" }
+        )
+        -- malloc'ed tuple.
+        t.assert_equals(s:insert{string.rep('m', 1100*1000), 2}:info(),
+                        { data_size = 1100007,
+                          header_size = 10,
+                          field_map_size = 4,
+                          waste_size = 0,
+                          arena = "malloc" }
+        )
+        -- Check that info().data_size equals bsize()
+        t.assert_equals(s:get(0):info().data_size, s:get(0):bsize())
+        t.assert_equals(s:get(1):info().data_size, s:get(1):bsize())
+        t.assert_equals(s:get(2):info().data_size, s:get(2):bsize())
+    end)
+end
+
+-- Test info() method of a vinyl tuple.
+g1.test_tuple_info_vinyl = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('vinyl', {engine = 'vinyl'})
+        s:create_index('pk', {parts = {2}})
+        t.assert_equals(s:insert{'v', 0}:info(),
+                        { data_size = 4,
+                          header_size = 24,
+                          field_map_size = 4,
+                          waste_size = 0,
+                          arena = "malloc" }
+        )
+        -- Check that info().data_size equals bsize()
+        t.assert_equals(s:get(0):info().data_size, s:get(0):bsize())
+    end)
+end
+
+-- Test error messages.
+g1.test_errors = function()
+    t.assert_error_msg_content_equals(
+        'Usage: tuple:info()',
+        function() box.tuple.new{0}.info() end
+    )
+    t.assert_error_msg_content_equals(
+        'Usage: tuple:info()',
+        function() box.tuple.new{0}:info('xxx') end
+    )
+    t.assert_error_msg_equals(
+        'Invalid argument #1 (box.tuple expected, got string)',
+        box.tuple.new{0}.info, 'xxx'
+    )
+end

--- a/test/unit/memtx_allocator.cc
+++ b/test/unit/memtx_allocator.cc
@@ -48,9 +48,20 @@ test_tuple_delete(struct tuple_format *format, struct tuple *tuple)
 	MemtxAllocator<SmallAlloc>::free_tuple(tuple);
 }
 
+static void
+test_tuple_info(struct tuple_format *format, struct tuple *tuple,
+		struct tuple_info *tuple_info)
+{
+	assert(format == test_tuple_format);
+	(void)format;
+	(void)tuple;
+	(void)tuple_info;
+}
+
 static struct tuple_format_vtab test_tuple_format_vtab = {
 	.tuple_delete = test_tuple_delete,
 	.tuple_new = test_tuple_new,
+	.tuple_info = test_tuple_info,
 };
 
 static struct tuple *


### PR DESCRIPTION
#### `tuple_object:info()` - Get information about the tuple

Returns a table with the following fields:

 * `data_size` - Size of the MessagePack data in the tuple.
   This number equals to number returned by `tuple_object:bsize()`.
 * `header_size` - Size of the internal tuple header.
 * `field_map_size` - Size of the field map.
   Field map is used to speed up access to indexed fields of the tuple.
 * `waste_size` - The amount of excess memory used to store the tuple in mempool.
 * `arena` - Type of the arena where the tuple is allocated.
   Possible values are: "memtx", "malloc", "runtime".

---

#### `space_object:stat()` - Get statistics on the memory usage

Returns a table with the cumulative statistics on the memory usage by tuples in the space.
The statistics is grouped by arena types: "memtx" or "malloc".
For a detailed description of each field see `tuple_object:info()`.

Note: The statistics is collected only for memtx storage engine.
For other types of spaces, an empty table is returned.

Example:

```yaml
tarantool> box.space.test:stat()
---
- tuple:
    memtx:
      data_size: 5100699
      header_size: 96
      field_map_size: 40
      waste_size: 143093
    malloc:
      data_size: 18850077
      header_size: 70
      field_map_size: 28
      waste_size: 0
...
```

Closes https://github.com/tarantool/tarantool/issues/6762

**Do not merge until https://github.com/tarantool/small/pull/77 and #9251 are merged!**