### PR TITLE
sql: assign collation to indexes in CREATE TABLE

### DIFF
--- a/changelogs/unreleased/gh-9229-no-collation-for-indexes.md
+++ b/changelogs/unreleased/gh-9229-no-collation-for-indexes.md
@@ -1,0 +1,6 @@
+## bugfix/sql
+
+* Fixed assertion in a debug build when a collation was added after an index
+  with more than one field (gh-9229).
+* Fixed a bug that in some cases would not assign collations to an index created
+  during `CREATE TABLE` (gh-9229).

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -737,26 +737,32 @@ sql_create_check_contraint(struct Parse *parser, bool is_field_ck)
 void
 sqlAddCollateType(Parse * pParse, Token * pToken)
 {
+	char *coll_name = sql_name_from_token(pToken);
+	uint32_t coll_id;
+	struct coll *coll = sql_get_coll_seq(pParse, coll_name, &coll_id);
+	sql_xfree(coll_name);
+	if (coll == NULL)
+		return;
+
 	struct space *space = pParse->create_column_def.space;
 	assert(space != NULL);
-	uint32_t i = space->def->field_count - 1;
-	char *coll_name = sql_name_from_token(pToken);
-	uint32_t *coll_id = &space->def->fields[i].coll_id;
-	if (sql_get_coll_seq(pParse, coll_name, coll_id) != NULL) {
-		/* If the column is declared as "<name> PRIMARY KEY COLLATE <type>",
-		 * then an index may have been created on this column before the
-		 * collation type was added. Correct this if it is the case.
-		 */
-		for (uint32_t i = 0; i < space->index_count; ++i) {
-			struct index *idx = space->index[i];
-			assert(idx->def->key_def->part_count == 1);
-			if (idx->def->key_def->parts[0].fieldno == i) {
-				coll_id = &idx->def->key_def->parts[0].coll_id;
-				(void)sql_column_collation(space->def, i, coll_id);
-			}
-		}
+	uint32_t fieldno = space->def->field_count - 1;
+	space->def->fields[fieldno].coll_id = coll_id;
+
+	/*
+	 * Indexes that include the current field may have already been created
+	 * before the collation was added. These indexes can be created using
+	 * ... field_name STRING PRIMARY KEY COLLATE ...
+	 * or
+	 * ... field_name STRING UNIQUE COLLATE ...
+	 * In this case, we should add a collation to them.
+	 */
+	for (uint32_t iid = 0; iid < space->index_count; ++iid) {
+		struct index *idx = space->index[iid];
+		if (idx->def->key_def->part_count == 1 &&
+		    idx->def->key_def->parts[0].fieldno == fieldno)
+			idx->def->key_def->parts[0].coll_id = coll_id;
 	}
-	sql_xfree(coll_name);
 }
 
 struct coll *

--- a/test/sql-luatest/collation_test.lua
+++ b/test/sql-luatest/collation_test.lua
@@ -19,3 +19,13 @@ g.test_ghs_80 = function()
         t.assert_equals(err.message, "Collation 'A' does not exist")
     end)
 end
+
+g.test_gh_9229 = function()
+    g.server:exec(function()
+        local sql = [[CREATE TABLE t(i INT, a INT, PRIMARY KEY(i, a),
+                      b STRING UNIQUE COLLATE "unicode_ci");]]
+        box.execute(sql)
+        t.assert_equals(box.space.T.index[1].parts[1].collation, "unicode_ci")
+        box.execute([[DROP TABLE t;]])
+    end)
+end


### PR DESCRIPTION
Before this patch, if an index was created due to a column's UNIQUE constraint or a column's PRIMARY KEY constraint before adding a collation, and if the column's fieldno was not equal to the index's position in space->index, the collation would not be assigned to the index.

Also, this patch fixes an assertion in debug build for the case when an index with more that one field was created befo a collation was added.

Closes #9229
