### PR TITLE
config: add lua_eval, lua_call and sql support to creds

### DIFF
--- a/changelogs/unreleased/gh-8967-add-lua_eval-lua_call-sql.md
+++ b/changelogs/unreleased/gh-8967-add-lua_eval-lua_call-sql.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* Now the brand-new `lua_eval`, `lua_call`, and `sql` object types are
+  supported by credentials (gh-8967).

--- a/src/box/lua/config/applier/credentials.lua
+++ b/src/box/lua/config/applier/credentials.lua
@@ -29,6 +29,12 @@ obj_types:
  - 'function'
  - 'sequence'
  - 'universe'
+ - 'lua_eval'
+ - 'lua_call'
+ - 'sql'
+
+Note that 'lua_eval', 'lua_call', 'sql' and 'universe' are special,
+they don't allow obj_name specialisation.
 
 obj_names:
  - mostly user defined strings, provided by config or box
@@ -40,9 +46,6 @@ privs:
  - read
  - write
  - execute
-   - lua_eval
-   - lua_call
-   - sql
  - session
  - usage
  - create
@@ -84,6 +87,9 @@ local function privileges_from_box(privileges)
         ['function'] = {},
         ['sequence'] = {},
         ['universe'] = {},
+        ['lua_eval'] = {},
+        ['lua_call'] = {},
+        ['sql'] = {},
     }
 
     for _, priv in ipairs(privileges) do
@@ -136,6 +142,9 @@ local function privileges_from_config(config_data)
         ['function'] = {},
         ['sequence'] = {},
         ['universe'] = {},
+        ['lua_eval'] = {},
+        ['lua_call'] = {},
+        ['sql'] = {},
     }
 
     for _, priv in ipairs(privileges) do
@@ -143,9 +152,14 @@ local function privileges_from_config(config_data)
             if priv.universe then
                 privileges_add_perm('universe', 'all', perm, intermediate)
             end
+            if priv.lua_eval then
+                privileges_add_perm('lua_eval', 'all', perm, intermediate)
+            end
             privileges_add_perm('space', priv.spaces, perm, intermediate)
             privileges_add_perm('function', priv.functions, perm, intermediate)
             privileges_add_perm('sequence', priv.sequences, perm, intermediate)
+            privileges_add_perm('lua_call', priv.lua_call, perm, intermediate)
+            privileges_add_perm('sql', priv.sql, perm, intermediate)
         end
     end
 

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1246,6 +1246,21 @@ return schema.new('instance_config', schema.record({
                                 type = 'string',
                             }),
                         }),
+                        lua_eval = schema.scalar({
+                            type = 'boolean',
+                        }),
+                        lua_call = schema.array({
+                            items = schema.scalar({
+                                type = 'string',
+                                allowed_values = {'all'},
+                            }),
+                        }),
+                        sql = schema.array({
+                            items = schema.scalar({
+                                type = 'string',
+                                allowed_values = {'all'},
+                            }),
+                        }),
                     }),
                 }),
                 -- The given role has all the privileges from
@@ -1295,6 +1310,21 @@ return schema.new('instance_config', schema.record({
                         sequences = schema.array({
                             items = schema.scalar({
                                 type = 'string',
+                            }),
+                        }),
+                        lua_eval = schema.scalar({
+                            type = 'boolean',
+                        }),
+                        lua_call = schema.array({
+                            items = schema.scalar({
+                                type = 'string',
+                                allowed_values = {'all'},
+                            }),
+                        }),
+                        sql = schema.array({
+                            items = schema.scalar({
+                                type = 'string',
+                                allowed_values = {'all'},
                             }),
                         }),
                     }),

--- a/test/config-luatest/credentials_applier_test.lua
+++ b/test/config-luatest/credentials_applier_test.lua
@@ -25,7 +25,13 @@ g.test_converters = function()
         }, {
             'session,usage',
             'universe',
-        },
+        }, {
+            'execute',
+            'lua_call',
+        }, {
+            'execute',
+            'lua_eval',
+        }
     }
 
     -- Guest privileges in format provided by config schema
@@ -36,6 +42,14 @@ g.test_converters = function()
                     'usage'
                 },
                 universe = true,
+            }, {
+                permissions = {
+                    'execute',
+                },
+                lua_eval = true,
+                lua_call = {
+                    'all'
+                },
             }
         },
         roles = {
@@ -60,6 +74,17 @@ g.test_converters = function()
                 ['usage'] = true,
             }
         },
+        ['lua_eval'] = {
+            [''] = {
+                ['execute'] = true,
+            },
+        },
+        ['lua_call'] = {
+            [''] = {
+                ['execute'] = true,
+            },
+        },
+        ['sql'] = {},
     }
 
     t.assert_equals(internal.privileges_from_box(box_guest_privileges),
@@ -121,6 +146,9 @@ g.test_converters = function()
                 ['delete'] = true,
             }
         },
+        ['lua_eval'] = {},
+        ['lua_call'] = {},
+        ['sql'] = {},
     }
 
     t.assert_equals(internal.privileges_from_box(box_admin_privileges),
@@ -171,6 +199,9 @@ g.test_converters = function()
                 ['read'] = true,
             },
         },
+        ['lua_eval'] = {},
+        ['lua_call'] = {},
+        ['sql'] = {},
     }
 
     t.assert_equals(internal.privileges_from_box(box_replication_privileges),
@@ -214,6 +245,9 @@ g.test_converters = function()
             'execute',
             'role',
             'public',
+        }, {
+            'execute',
+            'lua_call',
         },
     }
 
@@ -243,6 +277,13 @@ g.test_converters = function()
                     'read',
                 },
                 universe = true,
+            }, {
+                permissions = {
+                    'execute',
+                },
+                lua_call = {
+                    'all'
+                },
             },
         },
         roles = {
@@ -294,6 +335,13 @@ g.test_converters = function()
                 ['read'] = true,
             },
         },
+        ['lua_eval'] = {},
+        ['lua_call'] = {
+            [''] = {
+                ['execute'] = true,
+            },
+        },
+        ['sql'] = {},
     }
 
     t.assert_equals(internal.privileges_from_box(box_custom_privileges),
@@ -415,6 +463,9 @@ g.test_privileges_add_defaults = function(g)
             ['function'] = {},
             ['sequence'] = {},
             ['universe'] = {},
+            ['lua_eval'] = {},
+            ['lua_call'] = {},
+            ['sql'] = {},
         }
         defaults = internal.privileges_add_defaults(name, role_or_user,
                                                     defaults)
@@ -1164,5 +1215,84 @@ g.test_postpone_grants_till_rename = function(g)
             check_sync()
         end,
         verify_args = {iconfig},
+    })
+end
+
+g.test_lua_eval_lua_call_sql = function()
+    helpers.reload_success_case(g, {
+        options = {
+            credentials = {
+                users = {
+                    guest = {
+                        roles = { 'super' }
+                    },
+                    myuser = {
+                        password = 'secret',
+                        privileges = {
+                            {
+                                permissions = {
+                                    'execute',
+                                },
+                                lua_eval = true,
+                                lua_call = {
+                                    'all',
+                                },
+                                sql = {
+                                    'all',
+                                },
+                            }
+                        },
+                    }
+                },
+            },
+            iproto = {
+                listen = 'unix/:./test.iproto',
+            },
+        },
+        verify = function()
+            local conn = require('net.box').connect(
+                'unix/:./test.iproto',
+                {
+                    user = 'myuser',
+                    password = 'secret',
+                }
+            )
+            t.assert(conn:eval('return true'))
+
+            conn:eval([[function myfunc() return true end]])
+            t.assert(conn:call('myfunc'))
+
+            t.assert(conn:execute('SELECT 1'))
+        end,
+        options_2 = {
+            credentials = {
+                users = {
+                    guest = {
+                        roles = { 'super' }
+                    },
+                    myuser = {
+                        password = 'secret',
+                    },
+                },
+            },
+            iproto = {
+                listen = 'unix/:./test.iproto',
+            },
+        },
+        verify_2 = function()
+            local conn = require('net.box').connect(
+                'unix/:./test.iproto',
+                {
+                    user = 'myuser',
+                    password = 'secret',
+                }
+            )
+            t.assert_error(conn.eval, conn, 'return true')
+
+            -- `myfunc` already exists.
+            t.assert_error(conn.call, conn, 'myfunc')
+
+            t.assert_error(conn.execute, conn, 'SELECT 1')
+        end
     })
 end

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -907,6 +907,9 @@ g.test_credentials = function()
                                 'myfunc1',
                             },
                             sequences = { },
+                            lua_eval = false,
+                            lua_call = { 'all' },
+                            sql = { 'all' },
                         },
                     },
                     roles = {'one', 'two'},
@@ -929,6 +932,9 @@ g.test_credentials = function()
                             sequences = {
                                 'myseq2'
                             },
+                            lua_eval = true,
+                            lua_call = { },
+                            sql = { },
                         },
                     },
                     roles = {'one', 'two'},
@@ -942,6 +948,51 @@ g.test_credentials = function()
 
     local res = instance_config:apply_default({}).credentials
     t.assert_equals(res, nil)
+
+    iconfig = {
+        credentials = {
+            roles = {
+                myrole = {
+                    privileges = {
+                        {
+                            permissions = {
+                                'execute',
+                            },
+                            lua_call = { 'myfunc' },
+                        },
+                    },
+                },
+            },
+        },
+    }
+    local err = '[instance_config] credentials.roles.myrole.privileges[1].' ..
+                'lua_call[1]: Got myfunc, but only the following values are ' ..
+                'allowed: all'
+    t.assert_error_msg_equals(err, function()
+        instance_config:validate(iconfig)
+    end)
+
+    iconfig = {
+        credentials = {
+            users = {
+                myuser = {
+                    privileges = {
+                        {
+                            permissions = {
+                                'execute',
+                            },
+                            sql = { 'myfunc' },
+                        },
+                    },
+                },
+            },
+        },
+    }
+    err = '[instance_config] credentials.users.myuser.privileges[1].sql[1]: ' ..
+          'Got myfunc, but only the following values are allowed: all'
+    t.assert_error_msg_equals(err, function()
+        instance_config:validate(iconfig)
+    end)
 end
 
 g.test_app = function()


### PR DESCRIPTION
With #8906 the object types mentioned above were introduced. They control access to code execution over IPROTO.
This patch adds such object types support to credentials applier. Now 'execute' can be granted to a user or role for 'lua_eval', 'lua_call' and 'sql'. Note that similar to 'universe', objects can't be specified in the config, only 'all' is allowed.

Part of #8967

NO_DOC=documentation request will be filed manually for the whole
       credentials