### PR TITLE
misc: add missing changelogs for trigger registry

### DIFF
--- a/changelogs/unreleased/gh-8657-move-triggers-to-trigger-registry.md
+++ b/changelogs/unreleased/gh-8657-move-triggers-to-trigger-registry.md
@@ -1,0 +1,8 @@
+## feature/lua
+
+* **[Breaking change]** Triggers from `space_object` and `box.session` were
+  moved to the trigger registry (gh-8657). Now triggers set with
+  `space:on_replace()` or `space:before_replace()` are attached to the space id,
+  not the space object. So, if you delete a space with registered triggers and
+  create another space with the same id, it will use the triggers that are left
+  from the deleted space.

--- a/changelogs/unreleased/gh-8664-trigger-on-change.md
+++ b/changelogs/unreleased/gh-8664-trigger-on-change.md
@@ -1,0 +1,4 @@
+## feature/lua
+
+* Introduced a new event 'tarantool.trigger.on_change' in the trigger registry.
+  It is called when any event in the trigger registry is modified (gh-8664).


### PR DESCRIPTION
The commit adds missing changelogs for tarantool.trigger.on_change and triggers that were moved to the trigger registry. The second changelog is especially important because it describes a breaking change of space triggers behavior.

Follow-up #8664
Part of #8657