### PR TITLE
fiber: basic api exports

### DIFF
--- a/changelogs/unreleased/fiber-basic-api.md
+++ b/changelogs/unreleased/fiber-basic-api.md
@@ -1,0 +1,6 @@
+## feature/fiber
+
+* Exported `fiber_set_name_n`, `fiber_name`, `fiber_id`, `fiber_csw` and
+  `fiber_find` into the public C API and usable via FFI as well.
+* Make `fiber_set_joinable`, `fiber_set_ctx` and `fiber_get_ctx`
+  treat the NULL argument as the current fiber.

--- a/extra/exports
+++ b/extra/exports
@@ -218,10 +218,14 @@ fiber_cond_new
 fiber_cond_signal
 fiber_cond_wait
 fiber_cond_wait_timeout
+fiber_csw
+fiber_find
 fiber_get_ctx
+fiber_id
 fiber_is_cancelled
 fiber_join
 fiber_join_timeout
+fiber_name
 fiber_new
 fiber_new_ex
 fiber_reschedule
@@ -229,6 +233,7 @@ fiber_self
 fiber_set_cancellable
 fiber_set_ctx
 fiber_set_joinable
+fiber_set_name_n
 fiber_sleep
 fiber_start
 fiber_time

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -530,12 +530,16 @@ fiber_make_ready(struct fiber *f)
 void
 fiber_set_ctx(struct fiber *f, void *f_arg)
 {
+	if (f == NULL)
+		f = fiber();
 	f->f_arg = f_arg;
 }
 
 void *
 fiber_get_ctx(struct fiber *f)
 {
+	if (f == NULL)
+		f = fiber();
 	return f->f_arg;
 }
 
@@ -593,6 +597,8 @@ fiber_is_cancelled(void)
 void
 fiber_set_joinable(struct fiber *fiber, bool yesno)
 {
+	if (fiber == NULL)
+		fiber = fiber();
 	if (yesno == true)
 		fiber->flags |= FIBER_IS_JOINABLE;
 	else
@@ -1077,9 +1083,11 @@ fiber_loop(MAYBE_UNUSED void *data)
 }
 
 void
-fiber_set_name(struct fiber *fiber, const char *name)
+fiber_set_name_n(struct fiber *fiber, const char *name, uint32_t len)
 {
-	size_t size = strlen(name) + 1;
+	if (fiber == NULL)
+		fiber = fiber();
+	size_t size = len + 1;
 	if (size <= FIBER_NAME_INLINE) {
 		if (fiber->name != fiber->inline_name) {
 			free(fiber->name);
@@ -1100,6 +1108,30 @@ fiber_set_name(struct fiber *fiber, const char *name)
 	--size;
 	memcpy(fiber->name, name, size);
 	fiber->name[size] = 0;
+}
+
+const char *
+fiber_name(const struct fiber *fiber)
+{
+	if (fiber == NULL)
+		fiber = fiber();
+	return fiber->name;
+}
+
+uint64_t
+fiber_id(const struct fiber *fiber)
+{
+	if (fiber == NULL)
+		fiber = fiber();
+	return fiber->fid;
+}
+
+uint64_t
+fiber_csw(const struct fiber *fiber)
+{
+	if (fiber == NULL)
+		fiber = fiber();
+	return fiber->csw;
 }
 
 static inline void *

--- a/test/app-tap/module_api.c
+++ b/test/app-tap/module_api.c
@@ -326,6 +326,12 @@ fiber_set_ctx_test_func(va_list va)
 static int
 test_fiber_set_ctx(lua_State *L)
 {
+	/* Set context for the current fiber. */
+	fiber_set_ctx(NULL, (void *)0xCAFEBABEDEADF00D);
+	uint64_t ctx = (uint64_t)fiber_get_ctx(NULL);
+	fail_unless(ctx == 0xCAFEBABEDEADF00D);
+
+	/* Set context for a child fiber. */
 	struct fiber *fiber = fiber_new("test fiber", fiber_set_ctx_test_func);
 	fiber_set_joinable(fiber, true);
 	char data[3] = { '?', '!', '\0' };
@@ -3296,6 +3302,57 @@ test_box_iproto_override_reset(struct lua_State *L)
 
 /* }}} Helpers for `box_iproto_override` Lua/C API test cases */
 
+static int
+fiber_basic_api_func(va_list va)
+{
+	(void)va;
+	const char *name = "oppenheimer";
+	/* fiber_set_joinable now works with NULL. (Consistency!) */
+	fiber_set_joinable(NULL, true);
+	fiber_set_name_n(fiber_self(), name, strlen(name));
+	return 0;
+}
+
+static int
+test_fiber_basic_api(lua_State *L)
+{
+	uint64_t self_id = fiber_id(NULL);
+	struct fiber *t = fiber_find(self_id);
+	fail_unless(fiber_self() == t);
+
+	/* Set/get name of self works. */
+	const char *name = "parent";
+	fiber_set_name_n(NULL, name, strlen(name));
+	string_check_equal(fiber_name(NULL), name);
+
+	/* No such fiber. */
+	t = fiber_find((uint64_t)-1);
+	fail_unless(t == NULL);
+
+	/* Fiber is created and is immediately accessible via fiber_find. */
+	struct fiber *fiber = fiber_new("barbie", fiber_basic_api_func);
+	string_check_equal(fiber_name(fiber), "barbie");
+	uint64_t f_id = fiber_id(fiber);
+	t = fiber_find(f_id);
+	fail_unless(fiber == t);
+
+	/* Check that csw is increased because fiber_start yields. */
+	uint64_t csw0_parent = fiber_csw(NULL);
+	uint64_t csw0_child = fiber_csw(fiber);
+	fiber_start(fiber);
+	uint64_t csw1_parent = fiber_csw(NULL);
+	uint64_t csw1_child = fiber_csw(fiber);
+	fail_unless(csw1_parent == csw0_parent + 1);
+	fail_unless(csw1_child == csw0_child + 1);
+
+	string_check_equal(fiber_name(fiber), "oppenheimer");
+	/* At this point fiber is recycled. */
+	fiber_join(fiber);
+
+	lua_pushboolean(L, 1);
+	return 1;
+}
+
 LUA_API int
 luaopen_module_api(lua_State *L)
 {
@@ -3314,6 +3371,7 @@ luaopen_module_api(lua_State *L)
 		{"test_toint64", test_toint64 },
 		{"test_fiber", test_fiber },
 		{"test_fiber_set_ctx", test_fiber_set_ctx },
+		{"test_fiber_basic_api", test_fiber_basic_api },
 		{"pushcdata", test_pushcdata },
 		{"checkcdata", test_checkcdata },
 		{"test_clock", test_clock },

--- a/test/app-tap/module_api.test.lua
+++ b/test/app-tap/module_api.test.lua
@@ -671,7 +671,7 @@ local function test_box_ibuf(test, module)
 end
 
 require('tap').test("module_api", function(test)
-    test:plan(49)
+    test:plan(50)
     local status, module = pcall(require, 'module_api')
     test:is(status, true, "module")
     test:ok(status, "module is loaded")


### PR DESCRIPTION
Closes #9237

Add exports for fiber_set_name_n, fiber_get_name, fiber_get_id, fiber_get_csw & fiber_find.

@TarantoolBot document
Title: add basic fiber api to ffi exports.

5 basic functions can now be used via ffi api, which were previously only accessible via lua api: fiber_set_name_n, fiber_get_name, fiber_get_id, fiber_get_csw & fiber_find.