### PR TITLE
ci: add crud integration test run

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -129,6 +129,12 @@ jobs:
     with:
       artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
 
+  crud:
+    needs: tarantool
+    uses: tarantool/crud/.github/workflows/reusable_test.yml@master
+    with:
+      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+
   ddl:
     needs: tarantool
     uses: tarantool/ddl/.github/workflows/reusable_test.yml@master


### PR DESCRIPTION
The patch returns integration test run with `crud`. The test run was removed earlier [1] because the `crud` did not support tests with Tarantool 3.0. But now it supports [2].

1. https://github.com/tarantool/tarantool/commit/7316d8165e80b3678b45fd1b42823a8f92b734f6
2. https://github.com/tarantool/crud/pull/381

NO_DOC=ci
NO_TEST=ci
NO_CHANGELOG=ci