### PR TITLE
Backport of "ci: add debug_asan_clang workflow" PR to 2.11

### DIFF
--- a/.github/workflows/debug_asan_clang.yml
+++ b/.github/workflows/debug_asan_clang.yml
@@ -1,0 +1,93 @@
+name: debug_asan_clang
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/**'
+    tags:
+      - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
+
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch, and
+  # tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+jobs:
+  debug_asan_clang:
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' or 'asan-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') ||
+          contains(github.event.pull_request.labels.*.name, 'asan-ci') )
+
+    runs-on: ubuntu-20.04-self-hosted
+
+    container:
+      image: docker.io/tarantool/testing:ubuntu-jammy-clang16
+      # Mount /dev to the container to be able to mount a disk image inside it
+      # for successful run of the .github/actions/environment action.
+      volumes:
+        - /dev:/dev
+      # Our testing expects that the init process (PID 1) will
+      # reap orphan processes. At least the following test leans
+      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
+      # Add extra privileges to the container for successful run
+      # of the .github/actions/environment action.
+      options: '--init --privileged'
+
+    steps:
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: Install deps
+        uses: ./.github/actions/install-deps-debian
+      - name: test
+        env:
+          CC: clang-16
+          CXX: clang++-16
+        run: make -f .test.mk test-debug-asan
+      - name: Send VK Teams message on failure
+        if: failure()
+        uses: ./.github/actions/report-job-status
+        with:
+          bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
+      - name: artifacts
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: debug_asan_clang
+          retention-days: 21
+          path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/release/') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.test.mk
+++ b/.test.mk
@@ -81,6 +81,34 @@ test-perf: CMAKE_PARAMS = -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 
 test-perf: build run-perf-test
 
+# *_ASAN variables are common part of respective variables for all ASAN builds.
+CMAKE_PARAMS_ASAN = -DENABLE_WERROR=ON \
+                    -DENABLE_ASAN=ON \
+                    -DENABLE_UB_SANITIZER=ON \
+                    -DENABLE_FUZZER=ON \
+                    -DTEST_BUILD=ON
+# Some checks are temporary suppressed in the scope of the issue
+# https://github.com/tarantool/tarantool/issues/4360:
+#   - ASAN: to suppress failures of memory error checks caught while tests run, the asan/asan.supp
+#     file is used. It is set as a value for the `-fsanitize-blacklist` option at the build time in
+#     the cmake/profile.cmake file.
+#   - LSAN: to suppress failures of memory leak checks caught while tests run, the asan/lsan.supp
+#     file is used.
+TEST_RUN_ENV_ASAN = ASAN=ON \
+                    LSAN_OPTIONS=suppressions=${PWD}/asan/lsan.supp \
+                    ASAN_OPTIONS=heap_profile=0:unmap_shadow_on_exit=1:$\
+                                 detect_invalid_pointer_pairs=1:symbolize=1:$\
+                                 detect_leaks=1:dump_instruction_bytes=1:$\
+                                 print_suppressions=0
+LUAJIT_TEST_ENV_ASAN = LSAN_OPTIONS=suppressions=${PWD}/asan/lsan.supp \
+                       ASAN_OPTIONS=detect_invalid_pointer_pairs=1:$\
+                                    detect_leaks=1:$\
+                                    dump_instruction_bytes=1:$\
+                                    heap_profile=0:$\
+                                    print_suppressions=0:$\
+                                    symbolize=1:$\
+                                    unmap_shadow_on_exit=1
+
 # Release ASAN build
 
 .PHONY: test-release-asan
@@ -92,35 +120,29 @@ test-perf: build run-perf-test
 # while running LuaJIT tests with ASan support enabled.
 # Experiments once again confirm the notorious quote that "640 Kb
 # ought to be enough for anybody".
-test-release-asan: CMAKE_PARAMS = -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-                                  -DENABLE_WERROR=ON \
-                                  -DENABLE_ASAN=ON \
-                                  -DENABLE_UB_SANITIZER=ON \
-                                  -DFIBER_STACK_SIZE=640Kb \
-                                  -DENABLE_FUZZER=ON \
-                                  -DTEST_BUILD=ON
-# Some checks are temporary suppressed in the scope of the issue
-# https://github.com/tarantool/tarantool/issues/4360:
-#   - ASAN: to suppress failures of memory error checks caught while tests run, the asan/asan.supp
-#     file is used. It is set as a value for the `-fsanitize-blacklist` option at the build time in
-#     the cmake/profile.cmake file.
-#   - LSAN: to suppress failures of memory leak checks caught while tests run, the asan/lsan.supp
-#     file is used.
-test-release-asan: TEST_RUN_ENV = ASAN=ON \
-                                  LSAN_OPTIONS=suppressions=${PWD}/asan/lsan.supp \
-                                  ASAN_OPTIONS=heap_profile=0:unmap_shadow_on_exit=1:$\
-                                               detect_invalid_pointer_pairs=1:symbolize=1:$\
-                                               detect_leaks=1:dump_instruction_bytes=1:$\
-                                               print_suppressions=0
-test-release-asan: LUAJIT_TEST_ENV = LSAN_OPTIONS=suppressions=${PWD}/asan/lsan.supp \
-                                     ASAN_OPTIONS=detect_invalid_pointer_pairs=1:$\
-                                                  detect_leaks=1:$\
-                                                  dump_instruction_bytes=1:$\
-                                                  heap_profile=0:$\
-                                                  print_suppressions=0:$\
-                                                  symbolize=1:$\
-                                                  unmap_shadow_on_exit=1
+test-release-asan: CMAKE_PARAMS = ${CMAKE_PARAMS_ASAN} \
+                                  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                                  -DFIBER_STACK_SIZE=640Kb
+test-release-asan: TEST_RUN_ENV = ${TEST_RUN_ENV_ASAN}
+test-release-asan: LUAJIT_TEST_ENV = ${LUAJIT_TEST_ENV_ASAN}
 test-release-asan: build run-luajit-test run-test
+
+# Debug ASAN build
+
+.PHONY: test-debug-asan
+# We need even larger fiber stacks in ASAN debug build for luajit tests
+# to pass. Value twice as big as in ASAN release is just a wild guess.
+test-debug-asan: CMAKE_PARAMS = ${CMAKE_PARAMS_ASAN} \
+                                -DCMAKE_BUILD_TYPE=Debug \
+                                -DFIBER_STACK_SIZE=1280Kb
+test-debug-asan: TEST_RUN_ENV = ${TEST_RUN_ENV_ASAN}
+test-debug-asan: LUAJIT_TEST_ENV = ${LUAJIT_TEST_ENV_ASAN}
+# Increase timeouts as some tests in ASAN debug build take quite a lot
+# of time to finish.
+test-debug-asan: TEST_RUN_PARAMS += --test-timeout 620 \
+                                    --no-output-timeout 630 \
+                                    --server-start-timeout 610
+test-debug-asan: build run-luajit-test run-test
 
 # Debug build
 

--- a/asan/lsan.supp
+++ b/asan/lsan.supp
@@ -78,3 +78,6 @@ leak:fiber_cxx_invoke
 # test: vinyl/recover.test.lua
 # source: src/lib/core/fiber.c
 leak:cord_costart_thread_func
+
+# TODO(gh-9213): remove when the issue is fixed
+leak:luaT_push_key_def

--- a/src/box/vy_cache.c
+++ b/src/box/vy_cache.c
@@ -62,9 +62,18 @@ vy_cache_env_create(struct vy_cache_env *e, struct slab_cache *slab_cache)
 		       sizeof(struct vy_cache_node));
 }
 
+/** Delete a node from the cache. */
+static void
+vy_cache_gc_step(struct vy_cache_env *env);
+
 void
 vy_cache_env_destroy(struct vy_cache_env *e)
 {
+#if ENABLE_ASAN
+	/* Purge cache to suppress leak detector. */
+	while (e->mem_used > 0)
+		vy_cache_gc_step(e);
+#endif
 	mempool_destroy(&e->cache_node_mempool);
 }
 

--- a/test/app-tap/gh-2717-no-quit-sigint.test.lua
+++ b/test/app-tap/gh-2717-no-quit-sigint.test.lua
@@ -36,7 +36,10 @@ local time_quota = 10.0
 local output = ''
 while output:find(prompt) == nil
         and clock.monotonic() - start_time < time_quota do
-    output = output .. ph:read({timeout = 1.0})
+    local data = ph:read({timeout = 1.0})
+    if data ~= nil then
+        output = output .. data
+    end
 end
 assert(clock.monotonic() - start_time < time_quota, 'time_quota is violated')
 ph:signal(popen.signal.SIGINT)
@@ -79,7 +82,10 @@ local prompt_name = 'tarantool'
 local expected_output = prompt
 while output:find(expected_output) == nil
         and clock.monotonic() - start_time < time_quota do
-    output = output .. ph:read({timeout = 1.0})
+    local data = ph:read({timeout = 1.0})
+    if data ~= nil then
+        output = output .. data
+    end
 end
 assert(clock.monotonic() - start_time < time_quota, 'time_quota is violated')
 


### PR DESCRIPTION
PR for master branch https://github.com/tarantool/tarantool/pull/9225

Commit https://github.com/tarantool/tarantool/commit/232c28f333ac75be26abb54dc308e2e5813b7acd is dropped because it depends on https://github.com/tarantool/tarantool/commit/230123566f5c4502cf346c75a1e941a0440e016b. Anyway we don't need it because slice check is turned off by default in 2.11.

We also need to take https://github.com/tarantool/tarantool/commit/bf62170fc03883426b156e917f606eee356c056e (PR https://github.com/tarantool/tarantool/pull/9161) to pass debug_asan_clang CI.