### PR TITLE
Backport of "ci: add debug_asan_clang workflow" PR to 2.10

### DIFF
--- a/.github/workflows/debug_asan_clang.yml
+++ b/.github/workflows/debug_asan_clang.yml
@@ -1,0 +1,93 @@
+name: debug_asan_clang
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/**'
+    tags:
+      - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
+
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch, and
+  # tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+jobs:
+  debug_asan_clang:
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' or 'asan-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') ||
+          contains(github.event.pull_request.labels.*.name, 'asan-ci') )
+
+    runs-on: ubuntu-20.04-self-hosted
+
+    container:
+      image: docker.io/tarantool/testing:ubuntu-jammy-clang16
+      # Mount /dev to the container to be able to mount a disk image inside it
+      # for successful run of the .github/actions/environment action.
+      volumes:
+        - /dev:/dev
+      # Our testing expects that the init process (PID 1) will
+      # reap orphan processes. At least the following test leans
+      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
+      # Add extra privileges to the container for successful run
+      # of the .github/actions/environment action.
+      options: '--init --privileged'
+
+    steps:
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: Install deps
+        uses: ./.github/actions/install-deps-debian
+      - name: test
+        env:
+          CC: clang-16
+          CXX: clang++-16
+        run: make -f .test.mk test-debug-asan
+      - name: Send VK Teams message on failure
+        if: failure()
+        uses: ./.github/actions/report-job-status
+        with:
+          bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
+      - name: artifacts
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: debug_asan_clang
+          retention-days: 21
+          path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/release/') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/asan/lsan.supp
+++ b/asan/lsan.supp
@@ -78,3 +78,6 @@ leak:fiber_cxx_invoke
 # test: vinyl/recover.test.lua
 # source: src/lib/core/fiber.c
 leak:cord_costart_thread_func
+
+# TODO(gh-9213): remove when the issue is fixed
+leak:luaT_push_key_def

--- a/src/box/sql/select.c
+++ b/src/box/sql/select.c
@@ -2198,7 +2198,7 @@ sqlColumnsFromExprList(Parse * parse, ExprList * expr_list,
 		nName = sqlStrlen30(zName);
 		void *field = &space_def->fields[i];
 		if (sqlHashInsert(&ht, zName, field) == field) {
-			sql_free(zName);
+			sqlDbFree(db, zName);
 			sqlOomFault(db);
 			goto cleanup;
 		}
@@ -2209,6 +2209,7 @@ sqlColumnsFromExprList(Parse * parse, ExprList * expr_list,
 		}
 		memcpy(space_def->fields[i].name, zName, nName);
 		space_def->fields[i].name[nName] = '\0';
+		sqlDbFree(db, zName);
 	}
 cleanup:
 	sqlHashClear(&ht);

--- a/src/box/vy_cache.c
+++ b/src/box/vy_cache.c
@@ -62,9 +62,18 @@ vy_cache_env_create(struct vy_cache_env *e, struct slab_cache *slab_cache)
 		       sizeof(struct vy_cache_node));
 }
 
+/** Delete a node from the cache. */
+static void
+vy_cache_gc_step(struct vy_cache_env *env);
+
 void
 vy_cache_env_destroy(struct vy_cache_env *e)
 {
+#if ENABLE_ASAN
+	/* Purge cache to suppress leak detector. */
+	while (e->mem_used > 0)
+		vy_cache_gc_step(e);
+#endif
 	mempool_destroy(&e->cache_node_mempool);
 }
 

--- a/test/app-tap/gh-2717-no-quit-sigint.test.lua
+++ b/test/app-tap/gh-2717-no-quit-sigint.test.lua
@@ -36,7 +36,10 @@ local time_quota = 10.0
 local output = ''
 while output:find(prompt) == nil
         and clock.monotonic() - start_time < time_quota do
-    output = output .. ph:read({timeout = 1.0})
+    local data = ph:read({timeout = 1.0})
+    if data ~= nil then
+        output = output .. data
+    end
 end
 assert(clock.monotonic() - start_time < time_quota, 'time_quota is violated')
 ph:signal(popen.signal.SIGINT)
@@ -79,7 +82,10 @@ local prompt_name = 'tarantool'
 local expected_output = prompt
 while output:find(expected_output) == nil
         and clock.monotonic() - start_time < time_quota do
-    output = output .. ph:read({timeout = 1.0})
+    local data = ph:read({timeout = 1.0})
+    if data ~= nil then
+        output = output .. data
+    end
 end
 assert(clock.monotonic() - start_time < time_quota, 'time_quota is violated')
 


### PR DESCRIPTION
This is basically port of PR https://github.com/tarantool/tarantool/pull/9241 (`Backport of "ci: add debug_asan_clang workflow" PR to 2.11`).

Yet we have to add `"sql: fix memory leak in sqlColumnsFromExprList"` to pass debug asan workflow.