### PR TITLE
test: bump test-run to new version

### DIFF
--- a/test/app-luatest/gh_8445_crash_during_crash_report_test.lua
+++ b/test/app-luatest/gh_8445_crash_during_crash_report_test.lua
@@ -1,13 +1,13 @@
+local fio = require('fio')
 local t = require('luatest')
 local g = t.group('gh-8445')
 
-g.before_all(function(cg)
-    local server = require('luatest.server')
-    cg.server = server:new({alias = 'gh-8445'})
+g.before_each(function(cg)
+    cg.tempdir = fio.tempdir()
 end)
 
-g.after_all(function(cg)
-    cg.server:drop()
+g.after_each(function(cg)
+    fio.rmtree(cg.tempdir)
 end)
 
 -- Check that forked Tarantool doesn't crash when preparing a crash report.
@@ -17,7 +17,7 @@ g.test_crash_during_crash_report = function(cg)
 
     -- Use `cd' and `shell = true' due to lack of cwd option in popen (gh-5633).
     local exe = arg[-1]
-    local dir = cg.server.workdir
+    local dir = cg.tempdir
     local cmd = [[
         cd %s && %s -e "box.cfg{} require('log').info('pid = ' .. box.info.pid)"
     ]]

--- a/test/box-luatest/gh_7434_yield_in_on_shutdown_trigger_test.lua
+++ b/test/box-luatest/gh_7434_yield_in_on_shutdown_trigger_test.lua
@@ -10,13 +10,16 @@ local script = os.getenv('SOURCEDIR') .. '/test/box-luatest/gh_7434_child.lua'
 local output_file
 
 g.before_all(function(cg)
-    local server = require('luatest.server')
-    cg.server = server:new({alias = 'master'})
-    output_file = cg.server.workdir .. '/on_shutdown_completed.txt'
+    cg.tempdir = fio.tempdir()
+    output_file = cg.tempdir .. '/on_shutdown_completed.txt'
 end)
 
 g.after_each(function()
     os.remove(output_file)
+end)
+
+g.after_all(function(cg)
+    fio.rmtree(cg.tempdir)
 end)
 
 -- Shutdown by reaching the end of the script


### PR DESCRIPTION
Bump test-run to new version with the following improvements:

- luatest: bump luatest to 0.5.7-48-g18859f6 [1]
- Adapt use luatest with new --no-clean option [2]
- luatest: bump luatest to 0.5.7-49-g9c7710e [3]

[1] tarantool/test-run@aa3b34d
[2] tarantool/test-run@8ebb3aa
[3] tarantool/test-run@82542d3

NO_DOC=test
NO_TEST=test
NO_CHANGELOG=test