### PR TITLE
unit: fix undefined behaviour in prbuf test

### DIFF
--- a/test/unit/prbuf.c
+++ b/test/unit/prbuf.c
@@ -43,7 +43,7 @@ enum test_buffer_status {
 	TEST_BUFFER_STATUS_COUNT
 };
 
-const char *info_msg = "prbuf(size=%lu, payload=%lu, iterations=%lu) %s";
+const char *info_msg = "prbuf(size=%lu, payload=%lu, iterations=%zu) %s";
 
 const char *test_buffer_status_strs[TEST_BUFFER_STATUS_COUNT] = {
 	"has been validated",
@@ -229,8 +229,9 @@ test_buffer_foreach_copy_number(uint32_t buffer_size,
 	for (size_t i = 0; i < lengthof(copy_number_arr); ++i) {
 		rc = test_buffer(buffer_size, payload, payload_size,
 				 copy_number_arr[i]);
-		is(rc, 0, info_msg, buffer_size, payload_size,
-		   copy_number_arr[i], test_buffer_status_strs[rc]);
+		is(rc, 0, info_msg, (unsigned long)buffer_size,
+		   (unsigned long)payload_size, copy_number_arr[i],
+		   test_buffer_status_strs[rc]);
 	}
 }
 


### PR DESCRIPTION
The test start to fail in CI on osx_debug (x86_64) workflow

```
[033]  	*** test_buffer_foreach_copy_number ***
[033] -ok 13 - prbuf(size=256, payload=16, iterations=16) has been validated
[033] -ok 14 - prbuf(size=256, payload=16, iterations=32) has been validated
[033] -ok 15 - prbuf(size=256, payload=16, iterations=64) has been validated
[033] +ok 13 - prbuf(size=256, payload=4294967312, iterations=16) has been validated
[033] +ok 14 - prbuf(size=256, payload=4294967312, iterations=32) has been validated
[033] +ok 15 - prbuf(size=256, payload=4294967312, iterations=64) has been validated
[033]  	*** test_buffer_foreach_copy_number: done ***
```