### PR TITLE
box: fix the `memtx.perftest` gcc regression

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -159,6 +159,13 @@ set(tuple_sources
     identifier.c
 )
 
+# The comparators extensively use inlining so we let gcc inline functions until
+# the compilation unit growth reaches 100% (the default is 30%).
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set_source_files_properties(tuple_compare.cc PROPERTIES
+                                COMPILE_FLAGS "--param inline-unit-growth=100")
+endif()
+
 if(ENABLE_TUPLE_COMPRESSION)
     list(APPEND tuple_sources ${TUPLE_COMPRESSION_BOX_SOURCES})
 endif()


### PR DESCRIPTION
The commit 9cc5a0bb1b3fdc155e6bec35e84699aff75a56f6 ("box: introduce template parameters for the sort order check") made gcc stop inlining some functions because the introduced templates increased the object file growth (briefly). In particular, the `mp_compare_uint` hadn't been inlined into the precompiled comparator anymore.

The gcc compiler has limit of 30% to grow the compilation unit by default. This commit increases the limit to 100% thus allowing more aggressive inlining.

perf/memtx.cc results (RelWithDebInfo, time in nanoseconds):

| Test | Base | After #8915 | Patched |
| - | - | - | - |
| TreeGetRandomExistingKeys | 738 | 760 ($\color{red}+3％$) | 742 ($\color{RedOrange}+0.6％$)
| TreeGet1RandomExistingKey | 350 | 400 ($\color{red}+14.3％$) | 357 ($\color{RedOrange}+2％$)

As a side effect another function call had been inlined into the comparator, so we still have a regression.

Fixes #9211

NO_DOC=no code changes
NO_TEST=no code changes
NO_CHANGELOG=no code changes
