### PR TITLE
config: update password hashes after auth_type change

### DIFF
--- a/changelogs/unreleased/gh-8967-creds-consider-auth-type.md
+++ b/changelogs/unreleased/gh-8967-creds-consider-auth-type.md
@@ -1,0 +1,5 @@
+## feature/config
+
+* Now a password hash (and salt) will be regenerated for users managed
+  in the configuration file if `security.auth_type` differs from a user's
+  `auth_type` (gh-8967).


### PR DESCRIPTION
User password is stored in a system space is a form of hash when 'chap-sha1' auth type is set, and in a form of hash with salt when 'pap-sha256' is set.

Now, if a user is set inside config, and the current auth type is different from the type the users password is stored in, the password hash will be regenerated.

Part of #8967

NO_DOC=documentation request will be filed manually for the whole
       credentials