### PR TITLE
box: fix `space:bsize()` handling on space alter

### DIFF
--- a/changelogs/unreleased/gh-9247-fix-space-bsize-handling-on-space-alter.md
+++ b/changelogs/unreleased/gh-9247-fix-space-bsize-handling-on-space-alter.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a bug that could result in the incorrect `space:bsize()` when altering
+  a primary index concurrently with DML operations (gh-9247).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -1063,6 +1063,7 @@ alter_space_do(struct txn_stmt *stmt, struct alter_space *alter)
 	 * The new space is ready. Time to update the space
 	 * cache with it.
 	 */
+	space_finish_alter(alter->old_space, alter->new_space);
 	space_cache_replace(alter->old_space, alter->new_space);
 	space_detach_constraints(alter->old_space);
 	space_unpin_collations(alter->old_space);

--- a/src/box/blackhole.c
+++ b/src/box/blackhole.c
@@ -126,6 +126,7 @@ static const struct space_vtab blackhole_space_vtab = {
 	/* .build_index = */ generic_space_build_index,
 	/* .swap_index = */ generic_space_swap_index,
 	/* .prepare_alter = */ generic_space_prepare_alter,
+	/* .finish_alter = */ generic_space_finish_alter,
 	/* .prepare_upgrade = */ generic_space_prepare_upgrade,
 	/* .invalidate = */ generic_space_invalidate,
 };

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -1058,7 +1058,6 @@ memtx_space_drop_primary_key(struct space *space)
 	 *   can be put back online properly.
 	 */
 	memtx_space->replace = memtx_space_replace_no_keys;
-	memtx_space->bsize = 0;
 }
 
 static void
@@ -1377,8 +1376,24 @@ memtx_space_prepare_alter(struct space *old_space, struct space *new_space)
 	}
 
 	new_memtx_space->replace = old_memtx_space->replace;
-	new_memtx_space->bsize = old_memtx_space->bsize;
 	return 0;
+}
+
+/**
+ * Copy bsize to the newly altered space from the old space.
+ * In case of DropIndex or TruncateIndex alter operations, the new space will be
+ * empty, and bsize must not be copied.
+ */
+static void
+memtx_space_finish_alter(struct space *old_space, struct space *new_space)
+{
+	struct memtx_space *old_memtx_space = (struct memtx_space *)old_space;
+	struct memtx_space *new_memtx_space = (struct memtx_space *)new_space;
+
+	bool is_empty = new_space->index_count == 0 ||
+			index_size(new_space->index[0]) == 0;
+	if (!is_empty)
+		new_memtx_space->bsize = old_memtx_space->bsize;
 }
 
 /* }}} DDL */
@@ -1403,6 +1418,7 @@ static const struct space_vtab memtx_space_vtab = {
 	/* .build_index = */ memtx_space_build_index,
 	/* .swap_index = */ generic_space_swap_index,
 	/* .prepare_alter = */ memtx_space_prepare_alter,
+	/* .finish_alter = */ memtx_space_finish_alter,
 	/* .prepare_upgrade = */ memtx_space_prepare_upgrade,
 	/* .invalidate = */ generic_space_invalidate,
 };

--- a/src/box/session_settings.c
+++ b/src/box/session_settings.c
@@ -437,6 +437,7 @@ const struct space_vtab session_settings_space_vtab = {
 	/* .build_index = */ generic_space_build_index,
 	/* .swap_index = */ generic_space_swap_index,
 	/* .prepare_alter = */ generic_space_prepare_alter,
+	/* .finish_alter = */ generic_space_finish_alter,
 	/* .prepare_upgrade = */ generic_space_prepare_upgrade,
 	/* .invalidate = */ generic_space_invalidate,
 };

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -1404,6 +1404,13 @@ generic_space_prepare_alter(struct space *old_space, struct space *new_space)
 	return 0;
 }
 
+void
+generic_space_finish_alter(struct space *old_space, struct space *new_space)
+{
+	(void)old_space;
+	(void)new_space;
+}
+
 int
 generic_space_prepare_upgrade(struct space *old_space, struct space *new_space)
 {

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -145,6 +145,12 @@ struct space_vtab {
 	 */
 	int (*prepare_alter)(struct space *old_space,
 			     struct space *new_space);
+	/**
+	 * Notify the engine after altering a space and before replacing
+	 * old_space with new_space in the space cache.
+	 */
+	void (*finish_alter)(struct space *old_space,
+			     struct space *new_space);
 	/** Prepares a space for online upgrade on alter. */
 	int (*prepare_upgrade)(struct space *old_space,
 			       struct space *new_space);
@@ -652,6 +658,13 @@ space_prepare_alter(struct space *old_space, struct space *new_space)
 	return new_space->vtab->prepare_alter(old_space, new_space);
 }
 
+static inline void
+space_finish_alter(struct space *old_space, struct space *new_space)
+{
+	assert(old_space->vtab == new_space->vtab);
+	new_space->vtab->finish_alter(old_space, new_space);
+}
+
 static inline int
 space_prepare_upgrade(struct space *old_space, struct space *new_space)
 {
@@ -765,6 +778,7 @@ int generic_space_check_format(struct space *, struct tuple_format *);
 int generic_space_build_index(struct space *, struct index *,
 			      struct tuple_format *, bool);
 int generic_space_prepare_alter(struct space *, struct space *);
+void generic_space_finish_alter(struct space *, struct space *);
 int generic_space_prepare_upgrade(struct space *old_space,
 				  struct space *new_space);
 void generic_space_invalidate(struct space *);

--- a/src/box/sysview.c
+++ b/src/box/sysview.c
@@ -505,6 +505,7 @@ static const struct space_vtab sysview_space_vtab = {
 	/* .build_index = */ generic_space_build_index,
 	/* .swap_index = */ generic_space_swap_index,
 	/* .prepare_alter = */ generic_space_prepare_alter,
+	/* .finish_alter = */ generic_space_finish_alter,
 	/* .prepare_upgrade = */ generic_space_prepare_upgrade,
 	/* .invalidate = */ generic_space_invalidate,
 };

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -4640,6 +4640,7 @@ static const struct space_vtab vinyl_space_vtab = {
 	/* .build_index = */ vinyl_space_build_index,
 	/* .swap_index = */ vinyl_space_swap_index,
 	/* .prepare_alter = */ vinyl_space_prepare_alter,
+	/* .finish_alter = */ generic_space_finish_alter,
 	/* .prepare_upgrade = */ generic_space_prepare_upgrade,
 	/* .invalidate = */ vinyl_space_invalidate,
 };

--- a/test/box-luatest/gh_9247_bsize_on_concurrent_dml_and_alter_test.lua
+++ b/test/box-luatest/gh_9247_bsize_on_concurrent_dml_and_alter_test.lua
@@ -1,0 +1,118 @@
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group('gh-9247')
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        box.space.test:drop()
+    end)
+end)
+
+-- Based on `test/box/alter-primary-index-tuple-leak-long.test.lua'.
+local function concurrent_insert_and_alter_helper(cg, rollback)
+    cg.server:exec(function(rollback)
+        local fiber = require('fiber')
+        local s = box.schema.space.create('test')
+        local idx = s:create_index('pk')
+        local alter_started = false
+        local data = string.rep('a', 66)
+
+        -- Create a table with enough tuples to make primary index alter in
+        -- background.
+        for i = 0, 7000, 100 do
+            box.begin()
+            for j = i, i + 99 do
+                s:insert{j, j, data}
+            end
+            box.commit()
+        end
+
+        -- Wait for fiber yield during altering and insert some tuples.
+        local fib_insert = fiber.new(function()
+            while not alter_started do
+                fiber.sleep(0)
+            end
+            box.begin()
+            for i = 8000, 9000 do
+                s:insert{i, i, data}
+            end
+            box.commit()
+        end)
+
+        -- Alter primary index.
+        -- If the index will not be altered in background, the test will fail
+        -- after timeout (fib_insert:join() will wait forever).
+        local fib_alter = fiber.new(function()
+            alter_started = true
+            box.begin()
+            idx:alter{parts = {{field = 2}}}
+            if rollback then
+                box.rollback()
+            else
+                box.commit()
+            end
+            alter_started = false
+        end)
+
+        fib_insert:set_joinable(true)
+        fib_alter:set_joinable(true)
+        fib_insert:join()
+        fib_alter:join()
+
+        local bsize = 0
+        for _, tuple in s:pairs() do
+            bsize = bsize + tuple:bsize()
+        end
+        t.assert_equals(s:bsize(), bsize)
+    end, {rollback})
+end
+
+-- Check that space:bsize() is correct for a built-in-background primary index
+-- with concurrent inserts.
+g.test_concurrent_insert_and_alter_commit = function(cg)
+    concurrent_insert_and_alter_helper(cg, false)
+end
+
+-- Check that space:bsize() is correct for a built-in-background primary index
+-- with concurrent inserts.
+g.test_concurrent_insert_and_alter_rollback = function(cg)
+    concurrent_insert_and_alter_helper(cg, true)
+end
+
+local function truncate_helper(cg, rollback)
+    cg.server:exec(function(rollback)
+        local s = box.schema.space.create('test')
+        s:create_index('pk')
+        s:insert{1, 2, 3}
+        local bsize_before_truncate = s:bsize()
+
+        box.begin()
+        s:truncate()
+        if rollback then
+            box.rollback()
+            t.assert_equals(s:bsize(), bsize_before_truncate)
+        else
+            box.commit()
+            t.assert_equals(s:bsize(), 0)
+        end
+    end, {rollback})
+end
+
+-- Check that space:bsize() is correct after successful space:truncate().
+g.test_truncate_commit = function(cg)
+    truncate_helper(cg, false)
+end
+
+-- Check that space:bsize() is correct after rolled back space:truncate().
+g.test_truncate_rollback = function(cg)
+    truncate_helper(cg, true)
+end


### PR DESCRIPTION
During building an index in background, some transaction can perform a dml request that affects space size (e.g. a replace), but the size will remain the same, because `bsize` is moved from the old space to the new space in `memtx_space_prepare_alter()` prior to `space_execute_dml()`. Fix this issue by calling `space_finish_alter()` in `alter_space_do()`. In fact, this patch partially reverts commit https://github.com/tarantool/tarantool/commit/9ec3b1a445a6335b0e25f9fefdaaaf7f7f17cd7d (`alter: zap space_vtab::commit_alter`).

Closes #9247