### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9145-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9145-luajit-fixes.md
@@ -1,0 +1,6 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-9145). The following issues
+were fixed as part of this activity:
+
+* Fixed the assembling for the head of the side trace (gh-8767).


### PR DESCRIPTION
* Fix base register coalescing in side trace.
* Fix register mask for stack check in head of side trace.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump