### PR TITLE
space: drop space with its triggers set with old API

### DIFF
--- a/changelogs/unreleased/gh-8657-move-triggers-to-trigger-registry.md
+++ b/changelogs/unreleased/gh-8657-move-triggers-to-trigger-registry.md
@@ -1,8 +1,4 @@
 ## feature/lua
 
-* **[Breaking change]** Triggers from `space_object`, `box.session`, and
-  `box.ctl` were moved to the trigger registry (gh-8657). Now triggers set with
-  `space_object:on_replace()` or `space_object:before_replace()` are attached to
-  the space id, not to `space_object`. So, if you delete a space with registered
-  triggers and create another space with the same id, it will use the remaining
-  triggers.
+* Triggers from `space_object`, `box.session`, and `box.ctl` were moved to
+  the trigger registry (gh-8657).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -1793,6 +1793,7 @@ on_drop_space_commit(struct trigger *trigger, void *event)
 {
 	(void) event;
 	struct space *space = (struct space *)trigger->data;
+	space_remove_temporary_triggers(space);
 	space_delete(space);
 	return 0;
 }

--- a/src/box/lua/space.cc
+++ b/src/box/lua/space.cc
@@ -59,9 +59,9 @@ extern "C" {
 #include "vclock/vclock.h"
 
 /**
- * Set/Reset/Get a trigger to an event associated with space by id. Argument
- * event_fmt is a format string for the event name - it must expect one uint32_t
- * value as an argument.
+ * Set/Reset/Get a temporary trigger to an event associated with space by id.
+ * Argument event_fmt is a format string for the event name - it must expect
+ * one uint32_t value as an argument.
  */
 static int
 lbox_space_reset_trigger(struct lua_State *L, uint32_t space_id,
@@ -70,7 +70,8 @@ lbox_space_reset_trigger(struct lua_State *L, uint32_t space_id,
 	const char *event_name = tt_sprintf(event_fmt, space_id);
 	struct event *event = event_get(event_name, true);
 	assert(event != NULL);
-	return luaT_event_reset_trigger(L, 2, event);
+	return luaT_event_reset_trigger_with_flags(
+		L, 2, event, EVENT_TRIGGER_IS_TEMPORARY);
 }
 
 /**

--- a/src/box/lua/trigger.h
+++ b/src/box/lua/trigger.h
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include <stdint.h>
+
 #if defined(__cplusplus)
 extern "C" {
 #endif /* defined(__cplusplus) */
@@ -56,7 +58,14 @@ box_lua_trigger_init(struct lua_State *L);
  * of the trigger list otherwise. The new trigger is returned.
  */
 int
-luaT_event_reset_trigger(struct lua_State *L, int bottom, struct event *event);
+luaT_event_reset_trigger_with_flags(struct lua_State *L, int bottom,
+				    struct event *event, uint8_t flags);
+
+static inline int
+luaT_event_reset_trigger(struct lua_State *L, int bottom, struct event *event)
+{
+	return luaT_event_reset_trigger_with_flags(L, bottom, event, 0);
+}
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -423,6 +423,19 @@ space_reset_events(struct space *space)
 	space->run_recovery_triggers = false;
 }
 
+void
+space_remove_temporary_triggers(struct space *space)
+{
+	struct space_event *space_events[] = {
+		&space->on_replace_event,
+		&space->before_replace_event,
+	};
+	for (size_t i = 0; i < lengthof(space_events); ++i) {
+		event_remove_temporary_triggers(space_events[i]->by_id);
+		event_remove_temporary_triggers(space_events[i]->by_name);
+	}
+}
+
 int
 space_create(struct space *space, struct engine *engine,
 	     const struct space_vtab *vtab, struct space_def *def,

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -287,6 +287,12 @@ struct space_alter_stmt {
 };
 
 /**
+ * Remove all temporary triggers from all associated events.
+ */
+void
+space_remove_temporary_triggers(struct space *space);
+
+/**
  * Detach constraints from space. They can be reattached or deleted then.
  */
 void

--- a/src/lib/core/event.h
+++ b/src/lib/core/event.h
@@ -79,15 +79,41 @@ struct func_adapter *
 event_find_trigger(struct event *event, const char *name);
 
 /**
+ * Flags for event triggers.
+ * Must be power of two - 1 bit in binary representation.
+ */
+enum event_trigger_flag {
+	/**
+	 * The trigger is temporary - all such triggers can be dropped with
+	 * special method.
+	 */
+	EVENT_TRIGGER_IS_TEMPORARY = 1,
+};
+
+/**
  * Resets trigger by name in an event.
  * Arguments event and name must not be NULL.
  * If new_trigger is NULL, the function removes a trigger by name from the
  * event. Otherwise, it replaces trigger by name or inserts it in the beginning
- * of the underlying list of event.
+ * of the underlying list of event. The new trigger is created with passed
+ * flags.
  */
 void
+event_reset_trigger_with_flags(struct event *event, const char *name,
+			       struct func_adapter *new_trigger, uint8_t flags);
+
+static inline void
 event_reset_trigger(struct event *event, const char *name,
-		    struct func_adapter *new_trigger);
+		    struct func_adapter *new_trigger)
+{
+	event_reset_trigger_with_flags(event, name, new_trigger, 0);
+}
+
+/**
+ * Remove all the triggers marked as temporary from the event.
+ */
+void
+event_remove_temporary_triggers(struct event *event);
 
 /**
  * Iterator over triggers from event. Never invalidates.

--- a/test/box-luatest/gh_4264_recursive_trigger_test.lua
+++ b/test/box-luatest/gh_4264_recursive_trigger_test.lua
@@ -37,8 +37,6 @@ g.test_recursive_trigger_invocation = function(cg)
         s:on_replace(f2)
         s:on_replace(f1)
         s:replace{1}
-        s:on_replace(nil, f2)
-        s:on_replace(nil, f1)
         return order
     end)
     t.assert_equals(order, {11, 21, 31, 32, 22, 12},

--- a/test/box-luatest/gh_8027_txn_handle_abort_in_trigger_test.lua
+++ b/test/box-luatest/gh_8027_txn_handle_abort_in_trigger_test.lua
@@ -17,13 +17,9 @@ end)
 
 g.after_each(function(cg)
     cg.server:exec(function()
-        local s = box.space.test
-        t.assert_not_equals(s, nil)
-        s:before_replace(nil, nil, 't1')
-        s:before_replace(nil, nil, 't2')
-        s:on_replace(nil, nil, 't1')
-        s:on_replace(nil, nil, 't2')
-        s:drop()
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
     end)
 end)
 
@@ -37,13 +33,13 @@ g.test_yield_before_replace = function(cg)
                 fiber.yield()
             end
             return new
-        end, nil, 't1')
+        end)
         s:before_replace(function(_, new)
             if new[2] == 10 then
                 fiber.yield()
             end
             return new
-        end, nil, 't2')
+        end)
         local errmsg = 'Transaction has been aborted by a fiber yield'
         t.assert_error_msg_equals(errmsg, s.insert, s, {10, 1})
         t.assert_error_msg_equals(errmsg, s.insert, s, {1, 10})

--- a/test/box/before_replace.result
+++ b/test/box/before_replace.result
@@ -360,9 +360,6 @@ s2:select()
 ---
 - - [1, 1, 2, 2]
 ...
-s2:before_replace(nil, ret_update)
----
-...
 s2:drop()
 ---
 ...
@@ -833,9 +830,6 @@ save_type
 ---
 - UPSERT
 ...
-s:before_replace(nil, find_type)
----
-...
 s:drop()
 ---
 ...
@@ -851,7 +845,7 @@ _ = s:create_index('pk')
 save_type = ''
 ---
 ...
-tid = s:before_replace(function(old,new, name, type) save_type = type return new end)
+_ = s:before_replace(function(old,new, name, type) save_type = type return new end)
 ---
 ...
 _ = s:insert{1}
@@ -860,9 +854,6 @@ _ = s:insert{1}
 save_type
 ---
 - INSERT
-...
-s:before_replace(nil, tid)
----
 ...
 s:drop()
 ---
@@ -883,7 +874,7 @@ test_run:cmd('switch test')
 ---
 - true
 ...
-require('fiber').set_max_slice(100500)
+require('fiber').set_max_slice(15)
 ---
 ...
 s = box.schema.space.create('test_on_schema_init')

--- a/test/box/before_replace.test.lua
+++ b/test/box/before_replace.test.lua
@@ -116,7 +116,6 @@ s2:insert{1, 1, 1, 1}
 s2:before_replace(ret_update) == ret_update
 s2.index.sk:update(1, {{'+', 4, 1}})
 s2:select()
-s2:before_replace(nil, ret_update)
 s2:drop()
 
 -- Stacking triggers.
@@ -291,7 +290,6 @@ save_type
 _ = s:upsert({3,4,5}, {{'+', 2, 1}})
 save_type
 
-s:before_replace(nil, find_type)
 s:drop()
 
 --
@@ -303,11 +301,10 @@ _ = s:create_index('pk')
 
 save_type = ''
 
-tid = s:before_replace(function(old,new, name, type) save_type = type return new end)
+_ = s:before_replace(function(old,new, name, type) save_type = type return new end)
 _ = s:insert{1}
 save_type
 
-s:before_replace(nil, tid)
 s:drop()
 
 --
@@ -317,7 +314,7 @@ s:drop()
 test_run:cmd('create server test with script="box/on_schema_init.lua"')
 test_run:cmd('start server test')
 test_run:cmd('switch test')
-require('fiber').set_max_slice(100500)
+require('fiber').set_max_slice(15)
 s = box.schema.space.create('test_on_schema_init')
 _ = s:create_index('pk')
 test_run:cmd('setopt delimiter ";"')

--- a/test/box/on_replace.result
+++ b/test/box/on_replace.result
@@ -115,22 +115,13 @@ n
 ---
 - [2, 'd', 'e', 'f']
 ...
-trigger_id = ts:on_replace(function() test = 1 end)
----
-...
-type(trigger_id)
+type(ts:on_replace(function() test = 1 end))
 ---
 - function
 ...
 #ts:on_replace()
 ---
 - 2
-...
-ts:on_replace(nil, trigger_id)
----
-...
-ts:on_replace(nil, save_out)
----
 ...
 ts:drop()
 ---
@@ -545,9 +536,6 @@ s:select()
 ---
 - []
 ...
-s:on_replace(nil, t)
----
-...
 s:drop() -- test_on_repl_ddl
 ---
 ...
@@ -582,7 +570,7 @@ x1 = 1;
 x2 = 1;
 ---
 ...
-s1_t = s1:on_replace(function(old, new)
+_ = s1:on_replace(function(old, new)
     for i = 1, 3 do
         s2:insert{x1}
         x1 = x1 + 1
@@ -594,7 +582,7 @@ s1_t = s1:on_replace(function(old, new)
 end);
 ---
 ...
-s2_t = s2:on_replace(function(old, new)
+_ = s2:on_replace(function(old, new)
     for i = 1, 3 do
         s3:insert{x2}
         x2 = x2 + 1
@@ -637,13 +625,7 @@ s3:select()
   - [8]
   - [9]
 ...
-s1:on_replace(nil, s1_t)
----
-...
 s1:drop()
----
-...
-s2:on_replace(nil, s2_t)
 ---
 ...
 s2:drop()
@@ -676,10 +658,10 @@ _ = s3:create_index('pk')
 x = 1
 ---
 ...
-t1 = s1:on_replace(function(old, new) s2:insert(new:update{{'!', 2, x}}) x = x + 1 end)
+_ = s1:on_replace(function(old, new) s2:insert(new:update{{'!', 2, x}}) x = x + 1 end)
 ---
 ...
-t2 = s1:on_replace(function(old, new) s3:insert(new:update{{'!', 2, x}}) x = x + 1 end)
+_ = s1:on_replace(function(old, new) s3:insert(new:update{{'!', 2, x}}) x = x + 1 end)
 ---
 ...
 box.begin() s1:insert{1} s1:insert{2} s1:insert{3} box.commit()
@@ -702,12 +684,6 @@ s3:select()
 - - [1, 1]
   - [2, 3]
   - [3, 5]
-...
-s1:on_replace(nil, t1)
----
-...
-s1:on_replace(nil, t2)
----
 ...
 s1:drop()
 ---

--- a/test/box/on_replace.test.lua
+++ b/test/box/on_replace.test.lua
@@ -42,11 +42,8 @@ ts:replace{2, 'd', 'e', 'f'}
 o
 n
 
-trigger_id = ts:on_replace(function() test = 1 end)
-type(trigger_id)
+type(ts:on_replace(function() test = 1 end))
 #ts:on_replace()
-ts:on_replace(nil, trigger_id)
-ts:on_replace(nil, save_out)
 ts:drop()
 
 -- test garbage in lua stack
@@ -204,7 +201,6 @@ s:replace({8, 9})
 t = s:on_replace(function () s.index.pk:rename('newname') end, t)
 s:replace({9, 10})
 s:select()
-s:on_replace(nil, t)
 s:drop() -- test_on_repl_ddl
 
 --
@@ -222,7 +218,7 @@ test_run:cmd("setopt delimiter ';'");
 x1 = 1;
 x2 = 1;
 
-s1_t = s1:on_replace(function(old, new)
+_ = s1:on_replace(function(old, new)
     for i = 1, 3 do
         s2:insert{x1}
         x1 = x1 + 1
@@ -233,7 +229,7 @@ s1_t = s1:on_replace(function(old, new)
     pcall(s2.insert, s2, {123, 'fail'})
 end);
 
-s2_t = s2:on_replace(function(old, new)
+_ = s2:on_replace(function(old, new)
     for i = 1, 3 do
         s3:insert{x2}
         x2 = x2 + 1
@@ -254,9 +250,7 @@ s1:select()
 s2:select()
 s3:select()
 
-s1:on_replace(nil, s1_t)
 s1:drop()
-s2:on_replace(nil, s2_t)
 s2:drop()
 s3:drop()
 
@@ -272,8 +266,8 @@ _ = s3:create_index('pk')
 
 x = 1
 
-t1 = s1:on_replace(function(old, new) s2:insert(new:update{{'!', 2, x}}) x = x + 1 end)
-t2 = s1:on_replace(function(old, new) s3:insert(new:update{{'!', 2, x}}) x = x + 1 end)
+_ = s1:on_replace(function(old, new) s2:insert(new:update{{'!', 2, x}}) x = x + 1 end)
+_ = s1:on_replace(function(old, new) s3:insert(new:update{{'!', 2, x}}) x = x + 1 end)
 
 box.begin() s1:insert{1} s1:insert{2} s1:insert{3} box.commit()
 
@@ -281,8 +275,6 @@ s1:select()
 s2:select()
 s3:select()
 
-s1:on_replace(nil, t1)
-s1:on_replace(nil, t2)
 s1:drop()
 s2:drop()
 s3:drop()

--- a/test/box/push.result
+++ b/test/box/push.result
@@ -321,10 +321,7 @@ box.schema.func.drop('do_push')
 s:truncate()
 ---
 ...
-function on_replace() box.session.push('replace') end
----
-...
-_ = s:on_replace(on_replace)
+_ = s:on_replace(function() box.session.push('replace') end)
 ---
 ...
 c:reload_schema()
@@ -343,9 +340,6 @@ s:select{}
 - - [200]
 ...
 c:close()
----
-...
-_ = s:on_replace(nil, on_replace)
 ---
 ...
 s:drop()

--- a/test/box/push.test.lua
+++ b/test/box/push.test.lua
@@ -167,15 +167,13 @@ box.schema.func.drop('do_push')
 -- Test push from a non-call request.
 --
 s:truncate()
-function on_replace() box.session.push('replace') end
-_ = s:on_replace(on_replace)
+_ = s:on_replace(function() box.session.push('replace') end)
 c:reload_schema()
 c.space.test:replace({200}, {on_push = table.insert, on_push_ctx = messages})
 messages
 s:select{}
 
 c:close()
-_ = s:on_replace(nil, on_replace)
 s:drop()
 
 --

--- a/test/engine/savepoint.result
+++ b/test/engine/savepoint.result
@@ -221,9 +221,6 @@ s:select{}
 - - [1]
   - [2]
 ...
-s:on_replace(nil, on_replace)
----
-...
 s:drop()
 ---
 ...
@@ -298,9 +295,6 @@ ok1
 errmsg1
 ---
 - 'Can not rollback to savepoint: the savepoint does not exist'
-...
-s:on_replace(nil, on_replace2)
----
 ...
 s:drop()
 ---
@@ -507,9 +501,6 @@ s:select{}
 ---
 - - [1, 'create savepoint']
   - [5]
-...
-s:on_replace(nil, on_replace3)
----
 ...
 s:truncate()
 ---

--- a/test/engine/savepoint.test.lua
+++ b/test/engine/savepoint.test.lua
@@ -110,7 +110,6 @@ select3
 select2
 select1
 s:select{}
-s:on_replace(nil, on_replace)
 s:drop()
 
 -- Test rollback to savepoint, created in trigger,
@@ -143,7 +142,6 @@ select3
 select4
 ok1
 errmsg1
-s:on_replace(nil, on_replace2)
 s:drop()
 
 -- Test incorrect savepoints usage inside a transaction.
@@ -248,7 +246,6 @@ s:replace{5}
 box.commit()
 test_run:cmd("setopt delimiter ''");
 s:select{}
-s:on_replace(nil, on_replace3)
 s:truncate()
 
 -- Several savepoints on a same statement.

--- a/test/sql/iproto.result
+++ b/test/sql/iproto.result
@@ -574,9 +574,6 @@ cn:execute('insert into TEST3 values (null), (null), (null), (null)')
   - -29
   row_count: 4
 ...
-_ = box.space.TEST:on_replace(nil, push_id)
----
-...
 box.execute('drop table test')
 ---
 - row_count: 1

--- a/test/sql/iproto.test.lua
+++ b/test/sql/iproto.test.lua
@@ -169,7 +169,6 @@ box.execute('create table test3 (id int primary key autoincrement)')
 box.schema.sequence.alter('TEST3', {min=-10000, step=-10})
 cn:execute('insert into TEST3 values (null), (null), (null), (null)')
 
-_ = box.space.TEST:on_replace(nil, push_id)
 box.execute('drop table test')
 s:drop()
 sq:drop()

--- a/test/vinyl/on_replace.result
+++ b/test/vinyl/on_replace.result
@@ -55,9 +55,6 @@ index:select{}
 ---
 - - [6, 'f']
 ...
-space:on_replace(nil, on_replace)
----
-...
 space:drop()
 ---
 ...
@@ -113,9 +110,6 @@ index:select{}
 index2:select{}
 ---
 - - [1, 2]
-...
-space:on_replace(nil, on_replace)
----
 ...
 space:drop()
 ---
@@ -184,9 +178,6 @@ space:select{}
 fail = false
 ---
 ...
-space:on_replace(nil, on_replace)
----
-...
 space:drop()
 ---
 ...
@@ -250,9 +241,6 @@ index2:select{}
   - [2, 'b']
 ...
 fail = false
----
-...
-space:on_replace(nil, on_replace)
 ---
 ...
 space:drop()
@@ -354,9 +342,6 @@ index2:select{}
 fail = false
 ---
 ...
-space:on_replace(nil, on_replace)
----
-...
 space:drop()
 ---
 ...
@@ -420,9 +405,6 @@ index:select{}
   - [2, 3, 4]
 ...
 fail = false
----
-...
-space:on_replace(nil, on_replace)
 ---
 ...
 space:drop()
@@ -496,9 +478,6 @@ index2:select{}
   - [2, 2, 'b']
 ...
 fail = false
----
-...
-space:on_replace(nil, on_replace)
 ---
 ...
 space:drop()
@@ -585,9 +564,6 @@ index:select{}
   - [4]
 ...
 fail = false
----
-...
-space:on_replace(nil, on_replace)
 ---
 ...
 space:drop()
@@ -696,9 +672,6 @@ index2:select{}
 fail = false
 ---
 ...
-space:on_replace(nil, on_replace)
----
-...
 space:drop()
 ---
 ...
@@ -769,9 +742,6 @@ index:select{}
   - [4, 4, 4, 4]
 ...
 fail = false
----
-...
-space:on_replace(nil, on_replace)
 ---
 ...
 space:drop()
@@ -872,9 +842,6 @@ old_tuple, new_tuple
 - null
 ...
 fail = false
----
-...
-space:on_replace(nil, on_replace)
 ---
 ...
 space:drop()

--- a/test/vinyl/on_replace.test.lua
+++ b/test/vinyl/on_replace.test.lua
@@ -18,7 +18,6 @@ fail = true
 space:insert({7, 'g'})
 old_tuple, new_tuple
 index:select{}
-space:on_replace(nil, on_replace)
 space:drop()
 fail = false
 
@@ -36,7 +35,6 @@ space:insert({2, 3})
 old_tuple, new_tuple
 index:select{}
 index2:select{}
-space:on_replace(nil, on_replace)
 space:drop()
 fail = false
 
@@ -56,7 +54,6 @@ space:replace({2, 100})
 old_tuple, new_tuple
 space:select{}
 fail = false
-space:on_replace(nil, on_replace)
 space:drop()
 
 -- ensure trigger error causes rollback of only one statement
@@ -76,7 +73,6 @@ box.commit()
 index:select{}
 index2:select{}
 fail = false
-space:on_replace(nil, on_replace)
 space:drop()
 
 -- on replace in multiple indexes
@@ -102,7 +98,6 @@ old_tuple, new_tuple
 index:select{}
 index2:select{}
 fail = false
-space:on_replace(nil, on_replace)
 space:drop()
 
 -- on delete from one index
@@ -122,7 +117,6 @@ index:delete({1})
 old_tuple, new_tuple
 index:select{}
 fail = false
-space:on_replace(nil, on_replace)
 space:drop()
 
 -- on delete from multiple indexes
@@ -144,7 +138,6 @@ old_tuple, new_tuple
 index:select{}
 index2:select{}
 fail = false
-space:on_replace(nil, on_replace)
 space:drop()
 
 -- on update one index
@@ -168,7 +161,6 @@ index:update({1}, {{'=', 2, 'one'}})
 old_tuple, new_tuple
 index:select{}
 fail = false
-space:on_replace(nil, on_replace)
 space:drop()
 
 -- on update multiple indexes
@@ -196,7 +188,6 @@ old_tuple, new_tuple
 index:select{}
 index2:select{}
 fail = false
-space:on_replace(nil, on_replace)
 space:drop()
 
 -- on upsert one index
@@ -219,7 +210,6 @@ old_tuple, new_tuple
 index:select{}
 
 fail = false
-space:on_replace(nil, on_replace)
 space:drop()
 
 -- on upsert multiple indexes
@@ -246,5 +236,4 @@ old_tuple, new_tuple
 space:upsert({5, 5, 5}, {{'!', 4, 500}})
 old_tuple, new_tuple
 fail = false
-space:on_replace(nil, on_replace)
 space:drop()


### PR DESCRIPTION
Attaching triggers to space id instead of space object is a significant pitfall. The users who haven't discovered new triggers may not expect the triggers of a dropped space will be fired by a new one. So let's drop triggers that were set with old API along with the space.

Closes #9223