### PR TITLE
build: enable LTO for RedOS 7

### DIFF
--- a/rpm/tarantool.spec
+++ b/rpm/tarantool.spec
@@ -167,7 +167,7 @@ C and Lua/C modules.
          -DSYSTEMD_UNIT_DIR:PATH=%{_unitdir} \
          -DSYSTEMD_TMPFILES_DIR:PATH=%{_tmpfilesdir} \
 %endif
-%if (0%{?fedora} >= 33 || 0%{?almalinux} >= 9)
+%if (0%{?fedora} >= 33 || 0%{?almalinux} >= 9 || 0%{?redos} >= 7)
          -DENABLE_LTO=ON \
 %endif
 %if %{_gc64} == "true"

--- a/test/app-tap/iconv.skipcond
+++ b/test/app-tap/iconv.skipcond
@@ -1,0 +1,5 @@
+import os
+
+# Disabled on RED OS due to missing character encodings (UTF-16, UTF-16BE, etc).
+if os.getenv('OS') == 'redos':
+    self.skip = 1


### PR DESCRIPTION
Enable LTO in the rpm spec file for RedOS 7+. Otherwise, we are getting a compilation error.
