### PR TITLE
ci: dockerize linux workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,16 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    container:
+      image: docker.io/tarantool/testing:ubuntu-focal
+      # Mount /dev to the container to be able to mount a disk image inside it
+      # for successful run of the .github/actions/environment action.
+      volumes:
+        - /dev:/dev
+      # Add extra privileges to the container for successful run
+      # of the .github/actions/environment action.
+      options: '--privileged'
+
     steps:
     - name: Prepare checkout
       uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,6 +40,19 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    container:
+      image: docker.io/tarantool/testing:ubuntu-focal
+      # Mount /dev to the container to be able to mount a disk image inside it
+      # for successful run of the .github/actions/environment action.
+      volumes:
+        - /dev:/dev
+      # Our testing expects that the init process (PID 1) will
+      # reap orphan processes. At least the following test leans
+      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
+      # Add extra privileges to the container for successful run
+      # of the .github/actions/environment action.
+      options: '--init --privileged'
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -40,6 +40,19 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    container:
+      image: docker.io/tarantool/testing:ubuntu-focal
+      # Mount /dev to the container to be able to mount a disk image inside it
+      # for successful run of the .github/actions/environment action.
+      volumes:
+        - /dev:/dev
+      # Our testing expects that the init process (PID 1) will
+      # reap orphan processes. At least the following test leans
+      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
+      # Add extra privileges to the container for successful run
+      # of the .github/actions/environment action.
+      options: '--init --privileged'
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -40,6 +40,19 @@ jobs:
 
     runs-on: graviton
 
+    container:
+      image: docker.io/tarantool/testing:ubuntu-focal
+      # Mount /dev to the container to be able to mount a disk image inside it
+      # for successful run of the .github/actions/environment action.
+      volumes:
+        - /dev:/dev
+      # Our testing expects that the init process (PID 1) will
+      # reap orphan processes. At least the following test leans
+      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
+      # Add extra privileges to the container for successful run
+      # of the .github/actions/environment action.
+      options: '--init --privileged'
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,6 +40,9 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    container:
+      image: docker.io/tarantool/testing:ubuntu-focal
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
@@ -67,6 +70,9 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    container:
+      image: docker.io/tarantool/testing:ubuntu-focal
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
@@ -93,6 +99,9 @@ jobs:
           !contains(github.event.pull_request.labels.*.name, 'notest') )
 
     runs-on: ubuntu-20.04-self-hosted
+
+    container:
+      image: docker.io/tarantool/testing:ubuntu-focal
 
     steps:
       - name: Prepare checkout

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -40,6 +40,19 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    container:
+      image: docker.io/tarantool/testing:ubuntu-focal
+      # Mount /dev to the container to be able to mount a disk image inside it
+      # for successful run of the .github/actions/environment action.
+      volumes:
+        - /dev:/dev
+      # Our testing expects that the init process (PID 1) will
+      # reap orphan processes. At least the following test leans
+      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
+      # Add extra privileges to the container for successful run
+      # of the .github/actions/environment action.
+      options: '--init --privileged'
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -40,6 +40,19 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    container:
+      image: docker.io/tarantool/testing:ubuntu-focal
+      # Mount /dev to the container to be able to mount a disk image inside it
+      # for successful run of the .github/actions/environment action.
+      volumes:
+        - /dev:/dev
+      # Our testing expects that the init process (PID 1) will
+      # reap orphan processes. At least the following test leans
+      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
+      # Add extra privileges to the container for successful run
+      # of the .github/actions/environment action.
+      options: '--init --privileged'
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,19 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    container:
+      image: docker.io/tarantool/testing:ubuntu-focal
+      # Mount /dev to the container to be able to mount a disk image inside it
+      # for successful run of the .github/actions/environment action.
+      volumes:
+        - /dev:/dev
+      # Our testing expects that the init process (PID 1) will
+      # reap orphan processes. At least the following test leans
+      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
+      # Add extra privileges to the container for successful run
+      # of the .github/actions/environment action.
+      options: '--init --privileged'
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -40,6 +40,19 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    container:
+      image: docker.io/tarantool/testing:ubuntu-focal
+      # Mount /dev to the container to be able to mount a disk image inside it
+      # for successful run of the .github/actions/environment action.
+      volumes:
+        - /dev:/dev
+      # Our testing expects that the init process (PID 1) will
+      # reap orphan processes. At least the following test leans
+      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
+      # Add extra privileges to the container for successful run
+      # of the .github/actions/environment action.
+      options: '--init --privileged'
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -15,6 +15,9 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    container:
+      image: docker.io/tarantool/testing:ubuntu-focal
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -41,6 +41,19 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    container:
+      image: docker.io/tarantool/testing:ubuntu-focal
+      # Mount /dev to the container to be able to mount a disk image inside it
+      # for successful run of the .github/actions/environment action.
+      volumes:
+        - /dev:/dev
+      # Our testing expects that the init process (PID 1) will
+      # reap orphan processes. At least the following test leans
+      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
+      # Add extra privileges to the container for successful run
+      # of the .github/actions/environment action.
+      options: '--init --privileged'
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -41,6 +41,19 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    container:
+      image: docker.io/tarantool/testing:ubuntu-focal
+      # Mount /dev to the container to be able to mount a disk image inside it
+      # for successful run of the .github/actions/environment action.
+      volumes:
+        - /dev:/dev
+      # Our testing expects that the init process (PID 1) will
+      # reap orphan processes. At least the following test leans
+      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
+      # Add extra privileges to the container for successful run
+      # of the .github/actions/environment action.
+      options: '--init --privileged'
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/submodule_update.yml
+++ b/.github/workflows/submodule_update.yml
@@ -18,6 +18,9 @@ jobs:
 
     runs-on: [ self-hosted, Linux, x86_64, flavor-1-2 ]
 
+    container:
+      image: docker.io/tarantool/testing:ubuntu-focal
+
     outputs:
       commit-sha: ${{ steps.update-ee.outputs.sha }}
 


### PR DESCRIPTION
Modify Linux workflows for running jobs inside Docker containers. It helps isolate the building and testing environment from the runner's system and other workflows.

Closes tarantool/tarantool-qa#327
