### PR TITLE
app: start init script event loop explicitly

### DIFF
--- a/changelogs/unreleased/gh-9266-fix-on-shutdown-and-osexit-from-cmd-expr.md
+++ b/changelogs/unreleased/gh-9266-fix-on-shutdown-and-osexit-from-cmd-expr.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed a bug when `on_shutdown` triggers weren't run if `os.exit()` was
+  called from `-e` command-line option (gh-9266).

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -1112,7 +1112,16 @@ run_script_f(va_list ap)
 	 * never really dead. It never returns from its function.
 	 */
 	struct diag *diag = va_arg(ap, struct diag *);
-	bool aux_loop_is_run = false;
+
+	/*
+	 * Return control to tarantool_lua_run_script.
+	 * tarantool_lua_run_script then will start an auxiliary event
+	 * loop and re-schedule this fiber.
+	 *
+	 * This also update time in ev after Tarantool startup which
+	 * reduce time slip in timers (see #9261).
+	 */
+	fiber_sleep(0.0);
 
 	/*
 	 * Execute scripts or modules pointed by TT_PRELOAD
@@ -1229,14 +1238,6 @@ run_script_f(va_list ap)
 		goto end;
 	}
 
-	/*
-	 * Return control to tarantool_lua_run_script.
-	 * tarantool_lua_run_script then will start an auxiliary event
-	 * loop and re-schedule this fiber.
-	 */
-	fiber_sleep(0.0);
-	aux_loop_is_run = true;
-
 	int is_a_tty = isatty(STDIN_FILENO);
 
 	if (bytecode) {
@@ -1298,13 +1299,6 @@ run_script_f(va_list ap)
 	 * return control back to tarantool_lua_run_script.
 	 */
 end:
-	/*
-	 * Auxiliary loop in tarantool_lua_run_script
-	 * should start (ev_run()) before this fiber
-	 * invokes ev_break().
-	 */
-	if (!aux_loop_is_run)
-		fiber_sleep(0.0);
 	ev_break(loop(), EVBREAK_ALL);
 	return 0;
 
@@ -1348,8 +1342,7 @@ tarantool_lua_run_script(char *path, struct instance_state *instance,
 	 * Run an auxiliary event loop to re-schedule run_script fiber.
 	 * When this fiber finishes, it will call ev_break to stop the loop.
 	 */
-	if (start_loop)
-		ev_run(loop(), 0);
+	ev_run(loop(), 0);
 	/* The fiber running the startup script has ended. */
 	script_fiber = NULL;
 	diag_move(&script_diag, diag_get());

--- a/test/box-luatest/gh_9266_fix_on_shutdown_and_osexit_from_cmd_expr_test.lua
+++ b/test/box-luatest/gh_9266_fix_on_shutdown_and_osexit_from_cmd_expr_test.lua
@@ -1,0 +1,34 @@
+local t = require('luatest')
+local popen = require('popen')
+
+local g = t.group()
+
+local tarantool = arg[-1]
+
+g.after_each(function()
+    if g.handle ~= nil then
+        g.handle:close()
+    end
+    g.handle = nil
+end)
+
+g.test = function()
+    local code = [[
+        box.ctl.on_shutdown(function()
+            print('hello')
+        end)
+        os.exit()
+    ]]
+    local handle, err = popen.new({tarantool, '-e', code},
+                                  {stdout = popen.opts.PIPE,
+                                   stdin = popen.opts.DEVNULL,
+                                   stderr = popen.opts.DEVNULL})
+    assert(handle, err)
+    g.handle = handle
+    local output, err = handle:read({timeout = 3})
+    assert(output, err)
+    t.assert_equals(output, "hello\n")
+    local status = handle:wait()
+    t.assert_equals(status.state, 'exited')
+    t.assert_equals(status.exit_code, 0)
+end


### PR DESCRIPTION
The motivation is to reduce time slip on Tarantool startup before running init scripts. Internal ev time is set in `fiber_init`/`ev_default_loop` and is not get updated until starting event loop. This causes timeouts slip up to 0.3 in debug ASAN build in init script (see #9261).

Let's run event loop right at the beginning of the `run_script_f` before executing any script. This way besides updating internal ev time we make an explicit place of starting script event loop. Currently it is started lazily when config script yields.

This will fix CI for PR https://github.com/tarantool/tarantool-ee/pull/572 for debug ASAN workflow.

We can also remove `start_loop condition`. It does not make sense now. It was added in the commit 3a851430a19c ("Fix tarantool -e "os.exit()" hang") but since then we start to stop event loop after handling `os.exit()`.

Also this fixes #9266. The issue is we don't have an event loop to run on shutdown triggers if `-e` command line expression add such a trigger and then call `os.exit()`.

Follow-up #7327
Closes #9266