### PR TITLE
console: forward original URI to net.box when connecting over IPROTO

### DIFF
--- a/src/box/lua/console.lua
+++ b/src/box/lua/console.lua
@@ -919,11 +919,7 @@ local function connect(uri, opts)
     -- We don't know if the remote end is binary or Lua console so we first try
     -- to connect to it as binary using net.box and fall back on Lua console if
     -- it fails.
-    local remote = net_box.connect(u.host, u.service, {
-            connect_timeout = opts.timeout,
-            user = u.login,
-            password = u.password,
-    })
+    local remote = net_box.connect(uri, {connect_timeout = opts.timeout})
     if remote.state == 'error' then
         local err = remote.error
         remote = nil


### PR DESCRIPTION
Tarantool supports two console protocols: text and binary. The binary protocol is implemented with IPROTO EVAL request so the console module reuses the net.box module to establish and maintain a binary connection. Currently, instead of passing the original URI specified by the user to net.box.connect as is, the console module parses the URI and passes the host and port. As a result, extra information that may be specified in URI parameters is lost. This prevents the user from connecting to the binary console using the SSL transport because to use the SSL transport the user must specify transport=ssl URI parameter.

Needed for tarantool/tarantool-ee#567