### PR TITLE
replication: improve name conflict error message

### DIFF
--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -319,10 +319,10 @@ struct errcode_record {
 	/*264 */_(ER_NIL_UUID,			"Nil UUID is reserved and can't be used in replication") \
 	/*265 */_(ER_WRONG_FUNCTION_OPTIONS,	"Wrong function options: %s") \
 	/*266 */_(ER_MISSING_SYSTEM_SPACES,	"Snapshot has no system spaces") \
-	/*267 */_(ER_CLUSTER_NAME_MISMATCH,	"Cluster name mismatch: expected %s, got %s") \
-	/*268 */_(ER_REPLICASET_NAME_MISMATCH,	"Replicaset name mismatch: expected %s, got %s") \
+	/*267 */_(ER_CLUSTER_NAME_MISMATCH,	"Cluster name mismatch: name '%s' provided in config confilcts with the instance one '%s'") \
+	/*268 */_(ER_REPLICASET_NAME_MISMATCH,	"Replicaset name mismatch: name '%s' provided in config confilcts with the instance one '%s'") \
 	/*269 */_(ER_INSTANCE_NAME_DUPLICATE,	"Duplicate replica name %s, already occupied by %s") \
-	/*270 */_(ER_INSTANCE_NAME_MISMATCH,	"Instance name mismatch: expected %s, got %s") \
+	/*270 */_(ER_INSTANCE_NAME_MISMATCH,	"Instance name mismatch: name '%s' provided in config confilcts with the instance one '%s'") \
 	/*271 */_(ER_SCHEMA_NEEDS_UPGRADE,	"Your schema version is %u.%u.%u while Tarantool %s requires a more recent schema version. Please, consider using box.schema.upgrade().") \
 	/*272 */_(ER_SCHEMA_UPGRADE_IN_PROGRESS, "Schema upgrade is already in progress") \
 	/*273 */_(ER_DEPRECATED,		"%s is deprecated") \

--- a/test/replication-luatest/cluster_name_test.lua
+++ b/test/replication-luatest/cluster_name_test.lua
@@ -238,7 +238,8 @@ g.test_cluster_name_bootstrap_mismatch = function(lg)
                                  new_replica.alias .. '.log')
     wait_for_death(new_replica)
     t.assert(new_replica:grep_log(
-        'Cluster name mismatch: expected test%-name, got <no%-name>', 1024,
+        'Cluster name mismatch: name \'test%-name\' provided in config ' ..
+        'confilcts with the instance one \'<no%-name>\'', 1024,
         {filename = logfile}))
     new_replica:drop()
     --
@@ -262,7 +263,8 @@ g.test_cluster_name_bootstrap_mismatch = function(lg)
     logfile = fio.pathjoin(new_replica.workdir, new_replica.alias .. '.log')
     wait_for_death(new_replica)
     t.assert(new_replica:grep_log(
-        'Cluster name mismatch: expected new%-name, got test%-name', 1024,
+        'Cluster name mismatch: name \'new%-name\' provided in config ' ..
+        'confilcts with the instance one \'test%-name\'', 1024,
         {filename = logfile}))
     new_replica:drop()
     lg.master:exec(function(replica_id)
@@ -291,7 +293,8 @@ g.test_cluster_name_recovery_mismatch = function(lg)
     local logfile = fio.pathjoin(lg.replica.workdir, lg.replica.alias .. '.log')
     wait_for_death(lg.replica)
     t.assert(lg.replica:grep_log(
-        'Cluster name mismatch: expected new%-name, got test%-name', 1024,
+        'Cluster name mismatch: name \'new%-name\' provided in config ' ..
+        'confilcts with the instance one \'test%-name\'', 1024,
         {filename = logfile}))
     --
     -- Has name in WAL, no name in cfg. Then the replica uses the saved name, no
@@ -329,7 +332,8 @@ g.test_cluster_name_recovery_mismatch = function(lg)
     }, {wait_until_ready = false})
     wait_for_death(lg.replica)
     t.assert(lg.replica:grep_log(
-        'Cluster name mismatch: expected new%-name, got <no%-name>', 1024,
+        'Cluster name mismatch: name \'new%-name\' provided in config ' ..
+        'confilcts with the instance one \'<no%-name>\'', 1024,
         {filename = logfile}))
     box_cfg.cluster_name = nil
     box_cfg.force_recovery = nil
@@ -360,7 +364,8 @@ g.test_cluster_name_recovery_mismatch = function(lg)
     logfile = fio.pathjoin(lg.master.workdir, lg.master.alias .. '.log')
     wait_for_death(lg.master)
     t.assert(lg.master:grep_log(
-        'Cluster name mismatch: expected new%-name, got test%-name', 1024,
+        'Cluster name mismatch: name \'new%-name\' provided in config ' ..
+        'confilcts with the instance one \'test%-name\'', 1024,
         {filename = logfile}))
     --
     -- No name in WAL, has name in cfg.
@@ -386,7 +391,8 @@ g.test_cluster_name_recovery_mismatch = function(lg)
     }, {wait_until_ready = false})
     wait_for_death(lg.master)
     t.assert(lg.master:grep_log(
-        'Cluster name mismatch: expected new%-name, got <no%-name>', 1024,
+        'Cluster name mismatch: name \'new%-name\' provided in config ' ..
+        'confilcts with the instance one \'<no%-name>\'', 1024,
         {filename = logfile}))
     box_cfg.cluster_name = nil
     box_cfg.force_recovery = nil

--- a/test/replication-luatest/instance_name_test.lua
+++ b/test/replication-luatest/instance_name_test.lua
@@ -259,7 +259,8 @@ g.test_instance_name_bootstrap_mismatch = function(lg)
                                  new_replica.alias .. '.log')
     wait_for_death(new_replica)
     t.assert(new_replica:grep_log(
-        'Instance name mismatch: expected new%-replica%-name, got other%-name',
+        'Instance name mismatch: name \'new%-replica%-name\' provided in ' ..
+        'config confilcts with the instance one \'other%-name\'',
         1024, {filename = logfile}))
     new_replica:drop()
     --
@@ -285,7 +286,8 @@ g.test_instance_name_bootstrap_mismatch = function(lg)
     logfile = fio.pathjoin(new_replica.workdir, new_replica.alias .. '.log')
     wait_for_death(new_replica)
     t.assert(new_replica:grep_log(
-        'Instance name mismatch: expected new%-replica%-name, got <no%-name>',
+        'Instance name mismatch: name \'new%-replica%-name\' provided in ' ..
+        'config confilcts with the instance one \'<no%-name>\'',
         1024, {filename = logfile}))
     new_replica:drop()
     --
@@ -320,7 +322,8 @@ g.test_instance_name_recovery_mismatch = function(lg)
                                  lg.replica.alias .. '.log')
     wait_for_death(lg.replica)
     t.assert(lg.replica:grep_log(
-        'Instance name mismatch: expected new%-name, got replica%-name', 1024,
+        'Instance name mismatch: name \'new%-name\' provided in config ' ..
+        'confilcts with the instance one \'replica%-name\'', 1024,
         {filename = logfile}))
     --
     -- Has name in WAL, no name in cfg. Then the replica uses the saved name, no
@@ -358,7 +361,8 @@ g.test_instance_name_recovery_mismatch = function(lg)
     logfile = fio.pathjoin(lg.replica.workdir, lg.replica.alias .. '.log')
     wait_for_death(lg.replica)
     t.assert(lg.replica:grep_log(
-        'Instance name mismatch: expected new%-name, got <no%-name>', 1024,
+        'Instance name mismatch: name \'new%-name\' provided in config ' ..
+        'confilcts with the instance one \'<no%-name>\'', 1024,
         {filename = logfile}))
     box_cfg.instance_name = nil
     box_cfg.force_recovery = nil
@@ -380,7 +384,8 @@ g.test_instance_name_recovery_mismatch = function(lg)
     logfile = fio.pathjoin(lg.master.workdir, lg.master.alias .. '.log')
     wait_for_death(lg.master)
     t.assert(lg.master:grep_log(
-        'Instance name mismatch: expected new%-name, got master%-name', 1024,
+        'Instance name mismatch: name \'new%-name\' provided in config ' ..
+        'confilcts with the instance one \'master%-name\'', 1024,
         {filename = logfile}))
     --
     -- No name in WAL, has name in cfg.
@@ -405,7 +410,8 @@ g.test_instance_name_recovery_mismatch = function(lg)
     logfile = fio.pathjoin(lg.master.workdir, lg.master.alias .. '.log')
     wait_for_death(lg.master)
     t.assert(lg.master:grep_log(
-        'Instance name mismatch: expected new%-name, got <no%-name>', 1024,
+        'Instance name mismatch: name \'new%-name\' provided in config ' ..
+        'confilcts with the instance one \'<no%-name>\'', 1024,
         {filename = logfile}))
     box_cfg.instance_name = nil
     box_cfg.force_recovery = nil

--- a/test/replication-luatest/replicaset_name_test.lua
+++ b/test/replication-luatest/replicaset_name_test.lua
@@ -236,7 +236,8 @@ g.test_replicaset_name_bootstrap_mismatch = function(lg)
                                  new_replica.alias .. '.log')
     wait_for_death(new_replica)
     t.assert(new_replica:grep_log(
-        'Replicaset name mismatch: expected test%-name, got <no%-name>', 1024,
+        'Replicaset name mismatch: name \'test%-name\' provided in config ' ..
+        'confilcts with the instance one \'<no%-name>\'', 1023,
         {filename = logfile}))
     new_replica:drop()
     --
@@ -260,7 +261,8 @@ g.test_replicaset_name_bootstrap_mismatch = function(lg)
     logfile = fio.pathjoin(new_replica.workdir, new_replica.alias .. '.log')
     wait_for_death(new_replica)
     t.assert(new_replica:grep_log(
-        'Replicaset name mismatch: expected new%-name, got test%-name', 1024,
+        'Replicaset name mismatch: name \'new%-name\' provided in config ' ..
+        'confilcts with the instance one \'test%-name\'', 1024,
         {filename = logfile}))
     new_replica:drop()
     lg.master:exec(function(replica_id)
@@ -289,7 +291,8 @@ g.test_replicaset_name_recovery_mismatch = function(lg)
     local logfile = fio.pathjoin(lg.replica.workdir, lg.replica.alias .. '.log')
     wait_for_death(lg.replica)
     t.assert(lg.replica:grep_log(
-        'Replicaset name mismatch: expected new%-name, got test%-name', 1024,
+        'Replicaset name mismatch: name \'new%-name\' provided in config ' ..
+        'confilcts with the instance one \'test%-name\'', 1024,
         {filename = logfile}))
     --
     -- Has name in WAL, no name in cfg. Then the replica uses the saved name, no
@@ -327,7 +330,8 @@ g.test_replicaset_name_recovery_mismatch = function(lg)
     }, {wait_until_ready = false})
     wait_for_death(lg.replica)
     t.assert(lg.replica:grep_log(
-        'Replicaset name mismatch: expected new%-name, got <no%-name>', 1024,
+        'Replicaset name mismatch: name \'new%-name\' provided in config ' ..
+        'confilcts with the instance one \'<no%-name>\'', 1024,
         {filename = logfile}))
     box_cfg.replicaset_name = nil
     box_cfg.force_recovery = nil
@@ -358,7 +362,8 @@ g.test_replicaset_name_recovery_mismatch = function(lg)
     logfile = fio.pathjoin(lg.master.workdir, lg.master.alias .. '.log')
     wait_for_death(lg.master)
     t.assert(lg.master:grep_log(
-        'Replicaset name mismatch: expected new%-name, got test%-name', 1024,
+        'Replicaset name mismatch: name \'new%-name\' provided in config ' ..
+        'confilcts with the instance one \'test%-name\'', 1024,
         {filename = logfile}))
     --
     -- No name in WAL, has name in cfg.
@@ -384,7 +389,8 @@ g.test_replicaset_name_recovery_mismatch = function(lg)
     }, {wait_until_ready = false})
     wait_for_death(lg.master)
     t.assert(lg.master:grep_log(
-        'Replicaset name mismatch: expected new%-name, got <no%-name>', 1024,
+        'Replicaset name mismatch: name \'new%-name\' provided in config ' ..
+        'confilcts with the instance one \'<no%-name>\'', 1024,
         {filename = logfile}))
     box_cfg.replicaset_name = nil
     -- Has to be forced or it won't be able to sync with the replica because of


### PR DESCRIPTION
The error message was not quite clear in case instance has any name defined and config provides a different one.

Closes #8692

NO_CHANGELOG=no previous release with this error message
NO_DOC=not needed since no changes to the public API