### PR TITLE
third_party: update libcurl from 8.3.0 to 8.4.0

### DIFF
--- a/changelogs/unreleased/bump-libcurl-to-8.4.0.md
+++ b/changelogs/unreleased/bump-libcurl-to-8.4.0.md
@@ -1,0 +1,3 @@
+## feature/build
+
+* Updated libcurl to version 8.4.0.


### PR DESCRIPTION
The patch updates curl module to the version 8.4.0 [1] that brings a number of functional fixes and security fix of SOCKS5 heap buffer overflow (CVE-2023-38545), see description in [2] and commit fb4415d8aee6 ("socks: return error if hostname too long for remote resolve") in [3].

1. https://curl.se/changes.html#8_4_0
2. https://curl.se/docs/CVE-2023-38545.html
3. https://github.com/curl/curl/commit/fb4415d8aee6c1045be932a34fe6107c2f5ed147

NO_DOC=libcurl submodule bump
NO_TEST=libcurl submodule bump