### PR TITLE
backport of PR #9264 "app: start init script event loop explicitly" to 2.11

### DIFF
--- a/changelogs/unreleased/gh-9266-fix-on-shutdown-and-osexit-from-cmd-expr.md
+++ b/changelogs/unreleased/gh-9266-fix-on-shutdown-and-osexit-from-cmd-expr.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed a bug when `on_shutdown` triggers weren't run if `os.exit()` was
+  called from `-e` command-line option (gh-9266).

--- a/test/box-luatest/gh_9266_fix_on_shutdown_and_osexit_from_cmd_expr_test.lua
+++ b/test/box-luatest/gh_9266_fix_on_shutdown_and_osexit_from_cmd_expr_test.lua
@@ -1,0 +1,34 @@
+local t = require('luatest')
+local popen = require('popen')
+
+local g = t.group()
+
+local tarantool = arg[-1]
+
+g.after_each(function()
+    if g.handle ~= nil then
+        g.handle:close()
+    end
+    g.handle = nil
+end)
+
+g.test = function()
+    local code = [[
+        box.ctl.on_shutdown(function()
+            print('hello')
+        end)
+        os.exit()
+    ]]
+    local handle, err = popen.new({tarantool, '-e', code},
+                                  {stdout = popen.opts.PIPE,
+                                   stdin = popen.opts.DEVNULL,
+                                   stderr = popen.opts.DEVNULL})
+    assert(handle, err)
+    g.handle = handle
+    local output, err = handle:read({timeout = 3})
+    assert(output, err)
+    t.assert_equals(output, "hello\n")
+    local status = handle:wait()
+    t.assert_equals(status.state, 'exited')
+    t.assert_equals(status.exit_code, 0)
+end


### PR DESCRIPTION
Original PR is https://github.com/tarantool/tarantool/pull/9264. Nothing is changed except for context changes.