### PR TITLE
misc: use ibuf API to discard/allocate/consume.

### DIFF
--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -945,7 +945,7 @@ iproto_connection_close(struct iproto_connection *con)
 		 * parsed data is processed.  It's important this
 		 * is done only once.
 		 */
-		con->p_ibuf->wpos -= con->parse_size;
+		ibuf_discard(con->p_ibuf, con->parse_size);
 		mh_int_t node;
 		mh_foreach(con->streams, node) {
 			struct iproto_stream *stream = (struct iproto_stream *)
@@ -1052,15 +1052,15 @@ iproto_connection_input_buffer(struct iproto_connection *con)
 	}
 
 	xibuf_reserve(new_ibuf, to_read + con->parse_size);
-	/*
-	 * Discard unparsed data in the old buffer, otherwise it
-	 * won't be recycled when all parsed requests are processed.
-	 */
-	old_ibuf->wpos -= con->parse_size;
 	if (con->parse_size != 0) {
 		/* Move the cached request prefix to the new buffer. */
-		memcpy(new_ibuf->rpos, old_ibuf->wpos, con->parse_size);
-		new_ibuf->wpos += con->parse_size;
+		void *wpos = ibuf_alloc(new_ibuf, con->parse_size);
+		memcpy(wpos, old_ibuf->wpos - con->parse_size, con->parse_size);
+		/*
+		 * Discard unparsed data in the old buffer, otherwise it
+		 * won't be recycled when all parsed requests are processed.
+		 */
+		ibuf_discard(old_ibuf, con->parse_size);
 		/*
 		 * We made ibuf idle. If obuf was already idle it
 		 * makes the both ibuf and obuf idle, time to trim

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -589,6 +589,11 @@ struct iproto_connection
 	/** Pointer to the current buffer. */
 	struct ibuf *p_ibuf;
 	/**
+	 * Number of not yet processed messages in the corresponding
+	 * input buffer.
+	 */
+	size_t input_msg_count[2];
+	/**
 	 * Two rotating buffers for output. The tx thread switches to
 	 * another buffer if it finds it to be empty (flushed out).
 	 * This guarantees that memory gets recycled as soon as output
@@ -946,6 +951,7 @@ iproto_connection_close(struct iproto_connection *con)
 		 * is done only once.
 		 */
 		ibuf_discard(con->p_ibuf, con->parse_size);
+		con->parse_size = 0;
 		mh_int_t node;
 		mh_foreach(con->streams, node) {
 			struct iproto_stream *stream = (struct iproto_stream *)
@@ -1168,8 +1174,8 @@ err_msgpack:
 		msg->p_ibuf = con->p_ibuf;
 		msg->reqstart = reqstart;
 		msg->wpos = con->wpos;
-
 		msg->len = reqend - reqstart; /* total request length */
+		con->input_msg_count[msg->p_ibuf == &con->ibuf[1]]++;
 
 		iproto_msg_prepare(msg, &pos, reqend, &stop_input);
 		if (iproto_msg_start_processing_in_stream(msg)) {
@@ -1444,6 +1450,8 @@ iproto_connection_new(struct iproto_thread *iproto_thread)
 	ev_io_init(&con->output, iproto_connection_on_output, -1, EV_NONE);
 	ibuf_create(&con->ibuf[0], cord_slab_cache(), iproto_readahead);
 	ibuf_create(&con->ibuf[1], cord_slab_cache(), iproto_readahead);
+	con->input_msg_count[0] = 0;
+	con->input_msg_count[1] = 0;
 	obuf_create(&con->obuf[0], &con->iproto_thread->net_slabc,
 		    iproto_readahead);
 	obuf_create(&con->obuf[1], &con->iproto_thread->net_slabc,
@@ -1825,6 +1833,28 @@ net_finish_destroy(struct cmsg *m)
 	iproto_connection_delete(con);
 }
 
+/** Account msg data in connection input buffer as processed. */
+static void
+iproto_msg_finish_input(iproto_msg *msg)
+{
+	struct iproto_connection *con = msg->connection;
+	struct ibuf *ibuf = msg->p_ibuf;
+	size_t *count = &con->input_msg_count[msg->p_ibuf == &con->ibuf[1]];
+	/*
+	 * Consume data from input buffer only when data of all messages
+	 * is processed because messages process order and order of messages
+	 * in the buffer may differ.
+	 */
+	assert(*count != 0);
+	if (--(*count) == 0) {
+		size_t processed = ibuf_used(ibuf);
+		if (ibuf == con->p_ibuf) {
+			assert(processed >= con->parse_size);
+			processed -= con->parse_size;
+		}
+		ibuf_consume(ibuf, processed);
+	}
+}
 
 static void
 net_discard_input(struct cmsg *m)
@@ -1832,7 +1862,7 @@ net_discard_input(struct cmsg *m)
 	struct iproto_msg *msg = container_of(m, struct iproto_msg,
 					      discard_input);
 	struct iproto_connection *con = msg->connection;
-	msg->p_ibuf->rpos += msg->len;
+	iproto_msg_finish_input(msg);
 	msg->len = 0;
 	con->long_poll_count++;
 	if (con->state == IPROTO_CONNECTION_ALIVE)
@@ -2633,7 +2663,7 @@ net_send_msg(struct cmsg *m)
 	iproto_msg_finish_processing_in_stream(msg);
 	if (msg->len != 0) {
 		/* Discard request (see iproto_enqueue_batch()). */
-		msg->p_ibuf->rpos += msg->len;
+		iproto_msg_finish_input(msg);
 	} else {
 		/* Already discarded by net_discard_input(). */
 		assert(con->long_poll_count > 0);
@@ -2669,7 +2699,7 @@ net_end_join(struct cmsg *m)
 	struct iproto_connection *con = msg->connection;
 	struct ibuf *ibuf = msg->p_ibuf;
 
-	ibuf->rpos += msg->len;
+	iproto_msg_finish_input(msg);
 	iproto_msg_delete(msg);
 
 	assert(! ev_is_active(&con->input));
@@ -2687,7 +2717,7 @@ net_end_subscribe(struct cmsg *m)
 	struct iproto_msg *msg = (struct iproto_msg *) m;
 	struct iproto_connection *con = msg->connection;
 
-	msg->p_ibuf->rpos += msg->len;
+	iproto_msg_finish_input(msg);
 	iproto_msg_delete(msg);
 
 	assert(! ev_is_active(&con->input));

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -1941,7 +1941,7 @@ local function iterator_pos_set(index, pos, ibuf)
         iterator_pos_end[0] = iterator_pos[0] + #pos
         return true
     else
-        ibuf.rpos = ibuf.wpos
+        ibuf:consume(ibuf.wpos - ibuf.rpos)
         local tuple, tuple_end = tuple_encode(ibuf, pos)
         return builtin.box_index_tuple_position(
                 index.space_id, index.id, tuple, tuple_end,

--- a/src/box/lua/tuple.lua
+++ b/src/box/lua/tuple.lua
@@ -304,9 +304,7 @@ end
 local function tuple_to_msgpack(buf, tuple)
     assert(ffi.istype(tuple_t, tuple))
     local bsize = builtin.box_tuple_bsize(tuple)
-    buf:reserve(bsize)
-    builtin.box_tuple_to_buf(tuple, buf.wpos, bsize)
-    buf.wpos = buf.wpos + bsize
+    builtin.box_tuple_to_buf(tuple, buf:alloc(bsize), bsize)
 end
 
 local function tuple_bsize(tuple)

--- a/src/httpc.c
+++ b/src/httpc.c
@@ -68,7 +68,7 @@ curl_easy_io_read_cb(char *buffer, size_t size, size_t nitems, void *ctx)
 
 	size_t read_len = ibuf_len < buffer_size ? ibuf_len : buffer_size;
 	memcpy(buffer, req->send.rpos, read_len);
-	req->send.rpos += read_len;
+	ibuf_consume(&req->send, read_len);
 
 	fiber_cond_broadcast(&req->io_send_cond);
 	return read_len;
@@ -541,7 +541,7 @@ httpc_request_io_read(struct httpc_request *req, char *buf, size_t len,
 		if (copied == ibuf_len)
 			ibuf_reset(&req->io_recv);
 		else
-			req->io_recv.rpos += copied;
+			ibuf_consume(&req->io_recv, copied);
 	}
 
 	if (copied < len && recv_len > 0) {

--- a/src/lib/core/coio_buf.h
+++ b/src/lib/core/coio_buf.h
@@ -50,7 +50,7 @@ coio_bread(struct iostream *io, struct ibuf *buf, size_t sz)
 	ssize_t n = coio_read_ahead(io, buf->wpos, sz, ibuf_unused(buf));
 	if (n < 0)
 		diag_raise();
-	buf->wpos += n;
+	VERIFY(ibuf_alloc(buf, n) != NULL);
 	return n;
 }
 
@@ -68,7 +68,7 @@ coio_bread_timeout(struct iostream *io, struct ibuf *buf, size_t sz,
 			                    timeout);
 	if (n < 0)
 		diag_raise();
-	buf->wpos += n;
+	VERIFY(ibuf_alloc(buf, n) != NULL);
 	return n;
 }
 
@@ -80,7 +80,7 @@ coio_breadn(struct iostream *io, struct ibuf *buf, size_t sz)
 	ssize_t n = coio_readn_ahead(io, buf->wpos, sz, ibuf_unused(buf));
 	if (n < 0)
 		diag_raise();
-	buf->wpos += n;
+	VERIFY(ibuf_alloc(buf, n) != NULL);
 	return n;
 }
 
@@ -99,7 +99,7 @@ coio_breadn_timeout(struct iostream *io, struct ibuf *buf, size_t sz,
 			                     timeout);
 	if (n < 0)
 		diag_raise();
-	buf->wpos += n;
+	VERIFY(ibuf_alloc(buf, n) != NULL);
 	return n;
 }
 

--- a/src/lib/core/prbuf.h
+++ b/src/lib/core/prbuf.h
@@ -95,6 +95,10 @@ struct prbuf_reader {
 	 */
 	size_t unread_size;
 	/**
+	 * Number of bytes in the last record read by client.
+	 */
+	size_t last_read_size;
+	/**
 	 * File offset of the beginning of the data area.
 	 * Data area is the area after header till the end of the buffer.
 	 */
@@ -121,6 +125,9 @@ prbuf_reader_create(struct prbuf_reader *reader, int fd, off_t offset);
 /**
  * Read the next record into entry argument. If there are no more records
  * then returned record will be a terminator (EOF, ptr == NULL && size == 0).
+ *
+ * Pointer to data on successful read is valid until next call to this
+ * function.
  *
  * After EOF the function can be called again and will return EOF.
  *

--- a/src/lua/buffer.lua
+++ b/src/lua/buffer.lua
@@ -154,6 +154,13 @@ local function ibuf_read(buf, size)
     return rpos
 end
 
+local function ibuf_consume(buf, size)
+    checkibuf(buf, 'consume')
+    checksize(buf, size)
+    utils.poison_memory_region(buf.rpos, size);
+    buf.rpos = buf.rpos + size
+end
+
 local function ibuf_serialize(buf)
     local properties = { rpos = buf.rpos, wpos = buf.wpos }
     return { ibuf = properties }
@@ -168,6 +175,7 @@ local ibuf_methods = {
 
     checksize = ibuf_checksize;
     read = ibuf_read;
+    consume = ibuf_consume;
     __serialize = ibuf_serialize;
 
     size = ibuf_used;

--- a/src/lua/httpc.lua
+++ b/src/lua/httpc.lua
@@ -424,7 +424,7 @@ local function io_read(self, opts, timeout)
     local len = check(self, chunk, delimiter)
     if len ~= nil then
         local data = ffi.string(rbuf.rpos, len)
-        rbuf.rpos = rbuf.rpos + len
+        rbuf:consume(len)
         return data
     end
 
@@ -438,15 +438,15 @@ local function io_read(self, opts, timeout)
             self._errno = nil
             local len = rbuf:size()
             local data = ffi.string(rbuf.rpos, len)
-            rbuf.rpos = rbuf.rpos + len
+            rbuf:consume(len)
             return data
         else
-            rbuf.wpos = rbuf.wpos + res
+            rbuf:alloc(res)
             local len = check(self, chunk, delimiter)
             if len ~= nil then
                 self._errno = nil
                 local data = ffi.string(rbuf.rpos, len)
-                rbuf.rpos = rbuf.rpos + len
+                rbuf:consume(len)
                 return data
             end
         end

--- a/src/lua/socket.lua
+++ b/src/lua/socket.lua
@@ -705,7 +705,7 @@ local function read(self, limit, timeout, check, ...)
     if len ~= nil then
         self._errno = nil
         local data = ffi.string(rbuf.rpos, len)
-        rbuf.rpos = rbuf.rpos + len
+        rbuf:consume(len)
         return data
     end
 
@@ -720,15 +720,15 @@ local function read(self, limit, timeout, check, ...)
             self._errno = nil
             local len = rbuf:size()
             local data = ffi.string(rbuf.rpos, len)
-            rbuf.rpos = rbuf.rpos + len
+            rbuf:consume(len)
             return data
         elseif res ~= nil then
-            rbuf.wpos = rbuf.wpos + res
+            rbuf:alloc(res)
             local len = check(self, limit, ...)
             if len ~= nil then
                 self._errno = nil
                 local data = ffi.string(rbuf.rpos, len)
-                rbuf.rpos = rbuf.rpos + len
+                rbuf:consume(len)
                 return data
             end
         elseif not errno_is_transient[self._errno] then


### PR DESCRIPTION
We have several places where we move ibuf.wpos pointer directly without using ibuf API. As a result we don't poison the area that is known to be unallocated.

Let's introduce `ibuf_discard` to discard given number of bytes from write end of the buffer.

Follow-up #7327