### PR TITLE
box: call `tuple_free` from `box_free`

### DIFF
--- a/perf/memtx.cc
+++ b/perf/memtx.cc
@@ -187,6 +187,9 @@ private:
 		::user_cache_free();
 		::space_cache_destroy();
 
+		memtx->base.vtab->shutdown(&memtx->base);
+		::tuple_free();
+
 		::fiber_free();
 		::memory_free();
 	}

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -5911,7 +5911,7 @@ box_free(void)
 	sequence_free();
 	event_unref(box_on_recovery_state_event);
 	box_on_recovery_state_event = NULL;
-	/* tuple_free(); */
+	tuple_free();
 	/* schema_module_free(); */
 	/* session_free(); */
 	/* user_cache_free(); */

--- a/src/box/field_default_func.c
+++ b/src/box/field_default_func.c
@@ -72,6 +72,16 @@ field_default_func_call_impl(struct field_default_func *default_func,
 	return 0;
 }
 
+/**
+ * Implementation of field_default_func_destroy().
+ * Called by pointer to avoid linking dependencies.
+ */
+static void
+field_default_func_destroy_impl(struct field_default_func *default_func)
+{
+	field_default_func_unpin(default_func);
+}
+
 void
 field_default_func_unpin(struct field_default_func *default_func)
 {
@@ -109,5 +119,6 @@ field_default_func_init(struct field_default_func *default_func)
 	}
 	func_pin(func, &default_func->holder, FUNC_HOLDER_FIELD_DEFAULT);
 	default_func->call = field_default_func_call_impl;
+	default_func->destroy = field_default_func_destroy_impl;
 	return 0;
 }

--- a/src/box/field_default_func.h
+++ b/src/box/field_default_func.h
@@ -23,6 +23,8 @@ struct field_default_func {
 	int (*call)(struct field_default_func *default_func,
 		    const char *arg_data, uint32_t arg_size,
 		    const char **ret_data, uint32_t *ret_size);
+	/** Destructor. */
+	void (*destroy)(struct field_default_func *func);
 };
 
 /**
@@ -40,6 +42,13 @@ field_default_func_call(struct field_default_func *default_func,
 {
 	return default_func->call(default_func, arg_data, arg_size, ret_data,
 				  ret_size);
+}
+
+static inline void
+field_default_func_destroy(struct field_default_func *default_func)
+{
+	if (default_func->destroy != NULL)
+		default_func->destroy(default_func);
 }
 
 /**

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -208,6 +208,15 @@ memtx_engine_shutdown(struct engine *engine)
 	mempool_destroy(&memtx->index_extent_pool);
 	slab_cache_destroy(&memtx->index_slab_cache);
 	/*
+	 * The last blessed tuple may refer to a memtx tuple, which would
+	 * become inaccessible once we destroyed the arena, so we need to
+	 * clear it first.
+	 */
+	if (box_tuple_last != NULL) {
+		tuple_unref(box_tuple_last);
+		box_tuple_last = NULL;
+	}
+	/*
 	 * The order is vital: allocator destroy should take place before
 	 * slab cache destroy!
 	 */

--- a/test/unit/tuple_format.c
+++ b/test/unit/tuple_format.c
@@ -230,7 +230,6 @@ main(void)
 	memory_init();
 	fiber_init(fiber_c_invoke);
 	coll_init();
-	tuple_init(test_field_name_hash);
 	event_init();
 	box_init();
 	sql_init();
@@ -239,7 +238,6 @@ main(void)
 
 	box_free();
 	event_free();
-	tuple_free();
 	coll_free();
 	fiber_free();
 	memory_free();


### PR DESCRIPTION
There are four problems we have to address to make this possible:

 1. `memtx_engine_shutdown` may delete the tuple referenced by `box_tuple_last` so that `tuple_free`, which is called later by `box_free`, will crash trying to free it. Fix this by clearing `box_tuple_last` in `memtx_engine_shutdown`.

 2. `tuple_format_destroy` and `tuple_field_delete`, called by it, expect all constraints to be detached. Let's destroy the constraints if this isn't the case. This effectively reverts commit 7a87b9a594ee5.

 3. `tuple_field_delete`, called by `tuple_format_destroy`, expects the default value function to be unpinned. Let's unpin it if this isn't the case. To avoid linking dependencies between the tuple and box libraries, we have to introduce a virtual destructor for `field_default_func`.

 4. The `tuple_format` unit test calls `tuple_free` after `box_free`. If `box_free` calls `tuple_free` by itself, this leads to a crash. Fix this by removing `tuple_free` and `tuple_init` calls from the test.

Closes #9174