### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9145-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9145-luajit-fixes.md
@@ -13,3 +13,6 @@ were fixed as part of this activity:
 * Improved error reporting on stack overflow.
 * Fixed assertion on the Lua stack overflow for a stitched trace.
 * Fixed snapshoting of functions for non-base frames.
+* Fixed error handling after return from a child coroutine.
+* Fix C file generation in `jit.bcsave`.
+* Add 'cc' file type for saving bytecode.


### PR DESCRIPTION
* Fix C file generation in `jit.bcsave`.

Part of #9145

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump
NO_CHANGELOG=LuaJIT submodule bump