### PR TITLE
util: introduce the ALWAYS_INLINE macro

### DIFF
--- a/src/box/tuple_compare.cc
+++ b/src/box/tuple_compare.cc
@@ -48,7 +48,7 @@
  * in it can have dramatic impact on the overall
  * performance.
  */
-inline __attribute__((always_inline)) int
+ALWAYS_INLINE int
 mp_compare_uint(const char **data_a, const char **data_b);
 
 enum mp_class {
@@ -626,7 +626,7 @@ key_part_hint(struct key_part *part, hint_t hint)
  */
 template<bool is_nullable, bool a_is_optional, bool b_is_optional,
 	 bool has_desc_parts>
-static inline __attribute__((always_inline)) int
+static ALWAYS_INLINE int
 key_part_compare_fields(struct key_part *part, const char *field_a,
 			const char *field_b, bool *was_null_met = NULL)
 {

--- a/src/trivia/util.h
+++ b/src/trivia/util.h
@@ -399,6 +399,23 @@ alloc_failure(const char *filename, int line, size_t size)
 #endif
 
 /**
+ * Adds the 'always_inline' attribute to the function if it's supported. This
+ * attribute forces the function to be inlined if it's possible. If it's not,
+ * this results in a diagnostic.
+ *
+ * Example:
+ *
+ * \code
+ * ALWAYS_INLINE int function() { return 0; }
+ * \endcode
+ */
+#if __has_attribute(always_inline) || defined(__GNUC__)
+#  define ALWAYS_INLINE inline __attribute__((always_inline))
+#else
+#  define ALWAYS_INLINE inline
+#endif
+
+/**
  * A function declared as NORETURN shall not return to its caller.
  * The compiler will generate a diagnostic for a function declared as
  * NORETURN that appears to be capable of returning to its caller.


### PR DESCRIPTION
The macro expands to inline keyword and always_inline attribute if it's supported. This attribute forces the compiler to inline the function if it's possible and raise a diagnostic if it's not.

Needed for https://github.com/tarantool/tarantool-ee/issues/580

NO_DOC=internal
NO_TEST=internal
NO_CHANGELOG=internal