### PR TITLE
fiber: use alternative signal stack

### DIFF
--- a/changelogs/unreleased/gh-9222-sigaltstack.md
+++ b/changelogs/unreleased/gh-9222-sigaltstack.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a crash that happened while printing the stack trace on a stack
+  overflow bug (gh-9222).

--- a/src/lib/core/crash.c
+++ b/src/lib/core/crash.c
@@ -225,9 +225,12 @@ crash_signal_init(void)
 	 *
 	 * SA_NODEFER allows receiving the same signal
 	 * during handler.
+	 *
+	 * SA_ONSTACK is required to handle stack overflow, which
+	 * makes the current stack unusable.
 	 */
 	struct sigaction sa = {
-		.sa_flags = SA_RESETHAND | SA_NODEFER | SA_SIGINFO,
+		.sa_flags = SA_RESETHAND | SA_NODEFER | SA_SIGINFO | SA_ONSTACK,
 		.sa_sigaction = crash_signal_cb,
 	};
 	sigemptyset(&sa.sa_mask);


### PR DESCRIPTION
We install a signal handler that prints the stack trace on SIGSEGV, SIGBUS, SIGILL, SIGFPE. The signal handler uses the current stack. This works fine for most issues, but not for stack overflow, because the latter makes the current stack unusable, leading to a crash in the signal handler. Let's install an alternative signal stack in each thread so that we can print the stack trace on stack overflow.

Closes #9222