### PR TITLE
test: increase expected selectG execution time for debug ASAN build

### DIFF
--- a/test/sql-tap/selectG.test.lua
+++ b/test/sql-tap/selectG.test.lua
@@ -1,5 +1,6 @@
 #!/usr/bin/env tarantool
 local test = require("sqltester")
+local tarantool = require('tarantool')
 test:plan(1)
 
 --!./tcltestrunner.lua
@@ -27,9 +28,14 @@ test:plan(1)
 -- the insert run for over a minute.
 --
 local engine = test:engine()
-local time_quota =
-    engine == 'memtx' and 25 or (
-    engine == 'vinyl' and 50 or 0) -- seconds
+local time_quota
+if tarantool.build.asan then
+    time_quota = engine == 'memtx' and 80 or (
+                 engine == 'vinyl' and 140 or 0) -- seconds
+else
+    time_quota = engine == 'memtx' and 25 or (
+                 engine == 'vinyl' and 50 or 0) -- seconds
+end
 test:do_test(
     100,
     function()


### PR DESCRIPTION
The test is quite a flacky in debug ASAN CI workflow. The issue is test check upper boundary of it's execution time. I run many instances of this test on in parallel and got average time of 40s for memtex and 70s for vinyl.

The time quota is already changed by the commit 84cb1e049272 ("sql: increase time quota for selectG test on vinyl") for laptops with HDD. I did not check execution time for HDD though. I guess the bottleneck for debug ASAN is CPU.

Follow-up #7327