### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9145-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9145-luajit-fixes.md
@@ -1,0 +1,9 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-9145). The following issues
+were fixed as part of this activity:
+
+* Fixed dangling references to CType.
+* Ensured returned string is alive in `ffi.typeinfo()`.
+* Fixed the missing initialization of the internal structure, leading to a
+  crash when recording a trace with an allocation of cdata.


### PR DESCRIPTION
* FFI: Fix dangling reference to CType in carith_checkarg().
* FFI: Fix dangling reference to CType. Improve checks.
* FFI: Fix dangling reference to CType.
* FFI: Ensure returned string is alive in ffi.typeinfo().
* FFI: Fix missing cts->L initialization in argv2ctype().
* Abstract out on-demand loading of FFI library.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump