### PR TITLE
log: make `log.cfg{modules=...}` work as `box.cfg{log_modules=...}`

### DIFF
--- a/changelogs/unreleased/gh-7962-log-cfg-modules-fix.md
+++ b/changelogs/unreleased/gh-7962-log-cfg-modules-fix.md
@@ -1,0 +1,6 @@
+## bugfix/core
+
+* Fixed the behavior of `log.cfg{modules = ...}`. Now, instead of merging the
+  new log modules configuration with the old one, it completely overwrites the
+  current configuration, which is consistent with `box.cfg{log_modules = ...}`
+  (gh-7962).

--- a/src/lua/log.lua
+++ b/src/lua/log.lua
@@ -445,8 +445,7 @@ local function log_configure(self, cfg, box_api)
             local env_cfg = box.internal.env_cfg(box2log_keys)
             box.internal.apply_env_cfg(cfg, box_to_log_cfg(env_cfg))
         end
-        cfg = box.internal.prepare_cfg(cfg, default_cfg, option_types)
-        box.internal.merge_cfg(cfg, log_cfg);
+        cfg = box.internal.prepare_cfg(cfg, log_cfg, default_cfg, option_types)
     end
 
     log_check_cfg(cfg)


### PR DESCRIPTION
Configuring log modules work differently with `log.cfg` and `box.cfg`: `box.cfg{log_modules=...}` overwrites the current config completely while `log.cfg{modules=...}` overwrites the currently config only for the specified modules. Let's fix this inconsistency by making `log.cfg` behave exactly as `box.cfg`.

Closes #7962