### PR TITLE
Add changelog for gh-9218

### DIFF
--- a/changelogs/unreleased/gh-9218-net-box-crash-fix.md
+++ b/changelogs/unreleased/gh-9218-net-box-crash-fix.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a bug in the network buffer that could result in a crash when there are
+  a lot of pending requests (gh-9218)


### PR DESCRIPTION
The bug was fixed in the small library:
 - slab: fix NULL ptr deref in assertion in slab_get https://github.com/tarantool/small/commit/ef77efacd452cb90caea2caf22d266f791c95ec3
 - slab: fix uint32_t overflow in slab_capacity https://github.com/tarantool/small/commit/77203600a7c645d97bce56f901eec25de0b29d6e

The small library submodule was updated in commit ebafd68409ef ("small: bump version").

Closes #9218