### PR TITLE
config: validate instance/replicaset/group names

### DIFF
--- a/changelogs/unreleased/config-validate-names.md
+++ b/changelogs/unreleased/config-validate-names.md
@@ -1,0 +1,5 @@
+## bugfix/config
+
+* Added the validation of instance, replica set, and group names in the
+  configuration, `--name` CLI option, and `TT_INSTANCE_NAME` environment
+  variable (gh-8862).

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -366,6 +366,12 @@ end
 
 function methods._startup(self, instance_name, config_file)
     assert(self._status == 'uninitialized')
+
+    local ok, err = cluster_config:validate_name(instance_name)
+    if not ok then
+        error(('[--name] %s'):format(err), 0)
+    end
+
     self._status = 'startup_in_progress'
     self._instance_name = instance_name
     self._config_file = config_file

--- a/test/justrun.lua
+++ b/test/justrun.lua
@@ -65,6 +65,11 @@ end
 --
 --   Collect stderr and place it into the `stderr` field of the
 --   return value
+--
+-- - quote_args (boolean, default: false)
+--
+--   Quote CLI arguments before concatenating them into a shell
+--   command.
 function justrun.tarantool(dir, env, args, opts)
     assert(type(dir) == 'string')
     assert(type(env) == 'table')
@@ -82,8 +87,11 @@ function justrun.tarantool(dir, env, args, opts)
     local env_str = table.concat(fun.iter(env):map(function(k, v)
         return ('%s=%q'):format(k, v)
     end):totable(), ' ')
+    local args_str = table.concat(fun.iter(args):map(function(v)
+        return opts.quote_args and ('%q'):format(v) or v
+    end):totable(), ' ')
     local command = ('cd %s && %s %s %s'):format(dir, env_str, tarantool_exe,
-                                                 table.concat(args, ' '))
+                                                 args_str)
     log.info(('Running a command: %s'):format(command))
     local mode = opts.stderr and 'rR' or 'r'
     local ph = popen.shell(command, mode)


### PR DESCRIPTION
Recently added persistent instance/replicaset/cluster names have certain validation rules (see #5029 and #9148). An instance name and a replicaset name that are provided in a declarative configuration are stored in the database, so they should follow the same rules.

This patch implements the validation for instance/replicaset/group names, for `--name` CLI option and `TT_INSTANCE_NAME` environment variable.

The validation rules are described in https://github.com/tarantool/doc/issues/3466, https://github.com/tarantool/doc/issues/3467 and https://github.com/tarantool/doc/issues/3468.

Part of #8862
Related to #9148