### PR TITLE
box: disallow granting execute privilege on space

### DIFF
--- a/changelogs/unreleased/gh-9277-space-execute-priv.md
+++ b/changelogs/unreleased/gh-9277-space-execute-priv.md
@@ -1,0 +1,7 @@
+## bugfix/box
+
+* **[Breaking change]** `box.schema.user.grant()` now raises an error on
+  an attempt to grant the `execute` privilege on a space.  Historically,
+  this action was allowed although it had no effect. It's still possible
+  to revert to the old behavior with the new compatibility option
+  `box_space_execute_priv` (gh-9277).

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -1010,6 +1010,7 @@ local box_cfg_guard_whitelist = {
     NULL = true;
     info = true;
     iproto = true;
+    priv = true;
 };
 
 -- List of box members that requires full box loading.

--- a/test/box-luatest/gh_9277_space_execute_priv_test.lua
+++ b/test/box-luatest/gh_9277_space_execute_priv_test.lua
@@ -1,0 +1,37 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_test('test_space_execute_priv', function(cg)
+    cg.server:exec(function()
+        local compat = require('compat')
+        box.schema.user.drop('test', {if_exists = true})
+        compat.box_space_execute_priv = 'default'
+    end)
+end)
+
+g.test_space_execute_priv = function(cg)
+    cg.server:exec(function()
+        local compat = require('compat')
+        t.assert_equals(compat.box_space_execute_priv.current, 'default')
+        t.assert_equals(compat.box_space_execute_priv.default, 'new')
+        box.schema.user.create('test')
+        t.assert_error_msg_equals(
+            "Unsupported space privilege 'execute'",
+            box.session.su, 'admin',
+            box.schema.user.grant, 'test', 'execute', 'space')
+        compat.box_space_execute_priv = 'old'
+        box.session.su('admin', box.schema.user.grant,
+                       'test', 'execute', 'space')
+    end)
+end

--- a/test/box-py/iproto.result
+++ b/test/box-py/iproto.result
@@ -55,7 +55,7 @@ space = box.schema.space.create('test', { id = 567 })
 index = space:create_index('primary', { type = 'hash' })
 ---
 ...
-box.schema.user.grant('guest', 'read,write,execute', 'space', 'test')
+box.schema.user.grant('guest', 'read,write', 'space', 'test')
 ---
 ...
 - [1, 'baobab']
@@ -178,7 +178,7 @@ space = box.schema.space.create('test_index_base', { id = 568 })
 index = space:create_index('primary', { type = 'hash' })
 ---
 ...
-box.schema.user.grant('guest', 'read,write,execute', 'space', 'test_index_base')
+box.schema.user.grant('guest', 'read,write', 'space', 'test_index_base')
 ---
 ...
 - [1, 0, 0, 0]
@@ -302,7 +302,7 @@ space = box.schema.space.create('test', { id = 567 })
 index = space:create_index('primary', { type = 'tree' })
 ---
 ...
-box.schema.user.grant('guest', 'read,write,execute', 'space', 'test')
+box.schema.user.grant('guest', 'read,write', 'space', 'test')
 ---
 ...
 Simple pagination with after_pos

--- a/test/box-py/iproto.test.py
+++ b/test/box-py/iproto.test.py
@@ -125,7 +125,7 @@ print("\n")
 admin("box.cfg.wal_mode")
 admin("space = box.schema.space.create('test', { id = 567 })")
 admin("index = space:create_index('primary', { type = 'hash' })")
-admin("box.schema.user.grant('guest', 'read,write,execute', 'space', 'test')")
+admin("box.schema.user.grant('guest', 'read,write', 'space', 'test')")
 
 c = Connection(None, server.iproto.port)
 c.connect()
@@ -419,7 +419,7 @@ c.close()
 
 admin("space = box.schema.space.create('test_index_base', { id = 568 })")
 admin("index = space:create_index('primary', { type = 'hash' })")
-admin("box.schema.user.grant('guest', 'read,write,execute', 'space', 'test_index_base')")
+admin("box.schema.user.grant('guest', 'read,write', 'space', 'test_index_base')")
 
 c = Connection(None, server.iproto.port)
 c.connect()
@@ -678,7 +678,7 @@ print("""
 """)
 admin("space = box.schema.space.create('test', { id = 567 })")
 admin("index = space:create_index('primary', { type = 'tree' })")
-admin("box.schema.user.grant('guest', 'read,write,execute', 'space', 'test')")
+admin("box.schema.user.grant('guest', 'read,write', 'space', 'test')")
 
 c = Connection(None, server.iproto.port)
 c.connect()

--- a/test/box/access.result
+++ b/test/box/access.result
@@ -2192,18 +2192,18 @@ box.schema.user.grant('guest', 'read,write,execute', 'universe')
 sp = box.schema.create_space('not_universe')
 ---
 ...
-box.schema.user.grant('guest', 'read,write,execute', 'space', 'not_universe')
+box.schema.user.grant('guest', 'read,write', 'space', 'not_universe')
 ---
 ...
-box.schema.user.grant('guest', 'read,write,execute', 'space', 'not_universe')
+box.schema.user.grant('guest', 'read,write', 'space', 'not_universe')
 ---
-- error: User 'guest' already has read,write,execute access on space 'not_universe'
+- error: User 'guest' already has read,write access on space 'not_universe'
 ...
 -- Clean up.
 box.schema.user.revoke('guest', 'read,write,execute', 'universe')
 ---
 ...
-box.schema.user.revoke('guest', 'read,write,execute', 'space', 'not_universe')
+box.schema.user.revoke('guest', 'read,write', 'space', 'not_universe')
 ---
 ...
 sp:drop()

--- a/test/box/access.test.lua
+++ b/test/box/access.test.lua
@@ -865,12 +865,12 @@ box.schema.user.grant('guest', 'read,write,execute', 'universe')
 
 -- Expected behavior of grant() error shouldn't change otherwise.
 sp = box.schema.create_space('not_universe')
-box.schema.user.grant('guest', 'read,write,execute', 'space', 'not_universe')
-box.schema.user.grant('guest', 'read,write,execute', 'space', 'not_universe')
+box.schema.user.grant('guest', 'read,write', 'space', 'not_universe')
+box.schema.user.grant('guest', 'read,write', 'space', 'not_universe')
 
 -- Clean up.
 box.schema.user.revoke('guest', 'read,write,execute', 'universe')
-box.schema.user.revoke('guest', 'read,write,execute', 'space', 'not_universe')
+box.schema.user.revoke('guest', 'read,write', 'space', 'not_universe')
 sp:drop()
 
 --

--- a/test/box/access_misc.result
+++ b/test/box/access_misc.result
@@ -537,7 +537,7 @@ t = {}
 session.su('admin')
 ---
 ...
-box.schema.user.grant('testuser', 'read, write, execute', 'space', 'glade')
+box.schema.user.grant('testuser', 'read, write', 'space', 'glade')
 ---
 ...
 session.su('testuser')

--- a/test/box/access_misc.test.lua
+++ b/test/box/access_misc.test.lua
@@ -213,7 +213,7 @@ for key, v in s.index.primary:pairs(1, {iterator = 'GE'}) do table.insert (t, v)
 t
 t = {}
 session.su('admin')
-box.schema.user.grant('testuser', 'read, write, execute', 'space', 'glade')
+box.schema.user.grant('testuser', 'read, write', 'space', 'glade')
 session.su('testuser')
 s:select()
 for key, v in s.index.primary:pairs(3, {iterator = 'GE'}) do table.insert (t, v) end

--- a/test/box/access_sysview.result
+++ b/test/box/access_sysview.result
@@ -667,7 +667,7 @@ box.internal.collation.create('test', 'ICU', 'ru-RU')
 coll_cnt = #box.space._collation:select{}
 ---
 ...
-box.schema.user.grant("guest", "read, write, alter, execute", "space", "_collation")
+box.schema.user.grant("guest", "read, write, alter", "space", "_collation")
 ---
 ...
 box.session.su("guest")
@@ -689,7 +689,7 @@ box.session.su('admin')
 ---
 ...
 -- _vcollation is readable anyway.
-box.schema.user.revoke("guest", "read, write, alter, execute", "space", "_collation")
+box.schema.user.revoke("guest", "read, write, alter", "space", "_collation")
 ---
 ...
 box.session.su("guest")

--- a/test/box/access_sysview.test.lua
+++ b/test/box/access_sysview.test.lua
@@ -279,7 +279,7 @@ box.internal.collation.create('test', 'ICU', 'ru-RU')
 
 -- Only admin can create collation.
 coll_cnt = #box.space._collation:select{}
-box.schema.user.grant("guest", "read, write, alter, execute", "space", "_collation")
+box.schema.user.grant("guest", "read, write, alter", "space", "_collation")
 box.session.su("guest")
 box.internal.collation.create('guest0', 'ICU', 'ru-RU')
 box.space._vcollation:select{0}
@@ -287,7 +287,7 @@ box.space._vcollation:select{0}
 box.session.su('admin')
 
 -- _vcollation is readable anyway.
-box.schema.user.revoke("guest", "read, write, alter, execute", "space", "_collation")
+box.schema.user.revoke("guest", "read, write, alter", "space", "_collation")
 box.session.su("guest")
 #box.space._vcollation:select{}
 session.su('admin')

--- a/test/box/net.box_field_names_gh-2978.result
+++ b/test/box/net.box_field_names_gh-2978.result
@@ -14,7 +14,7 @@ box.space.named:insert({1, 1})
 ---
 - [1, 1]
 ...
-box.schema.user.grant('guest', 'read, write, execute', 'space')
+box.schema.user.grant('guest', 'read, write', 'space')
 ---
 ...
 cn = net.connect(box.cfg.listen)
@@ -96,6 +96,6 @@ cn:close()
 box.space.named:drop()
 ---
 ...
-box.schema.user.revoke('guest', 'read, write, execute', 'space')
+box.schema.user.revoke('guest', 'read, write', 'space')
 ---
 ...

--- a/test/box/net.box_field_names_gh-2978.test.lua
+++ b/test/box/net.box_field_names_gh-2978.test.lua
@@ -6,7 +6,7 @@ net = require('net.box')
 _ = box.schema.create_space("named", {format = {{name = "id"}, {name="abc"}}})
 _ = box.space.named:create_index('id', {parts = {{1, 'unsigned'}}})
 box.space.named:insert({1, 1})
-box.schema.user.grant('guest', 'read, write, execute', 'space')
+box.schema.user.grant('guest', 'read, write', 'space')
 cn = net.connect(box.cfg.listen)
 
 s = cn.space.named
@@ -26,4 +26,4 @@ s:select()[1]:tomap()
 
 cn:close()
 box.space.named:drop()
-box.schema.user.revoke('guest', 'read, write, execute', 'space')
+box.schema.user.revoke('guest', 'read, write', 'space')

--- a/test/box/net.box_get_connection_object.result
+++ b/test/box/net.box_get_connection_object.result
@@ -14,7 +14,7 @@ space ~= nil
 _ = box.space.test:create_index('primary')
 ---
 ...
-box.schema.user.grant('guest','read,write,execute','space', 'test')
+box.schema.user.grant('guest','read,write','space', 'test')
 ---
 ...
 c = net.connect(box.cfg.listen)
@@ -32,7 +32,7 @@ c.space.test.connection == c
 ---
 - true
 ...
-box.schema.user.revoke('guest','read,write,execute','space', 'test')
+box.schema.user.revoke('guest','read,write','space', 'test')
 ---
 ...
 c:close()

--- a/test/box/net.box_get_connection_object.test.lua
+++ b/test/box/net.box_get_connection_object.test.lua
@@ -7,7 +7,7 @@ net = require('net.box')
 space = box.schema.space.create('test', {format={{name="id", type="unsigned"}}})
 space ~= nil
 _ = box.space.test:create_index('primary')
-box.schema.user.grant('guest','read,write,execute','space', 'test')
+box.schema.user.grant('guest','read,write','space', 'test')
 
 c = net.connect(box.cfg.listen)
 
@@ -15,5 +15,5 @@ c:ping()
 c.space.test ~= nil
 
 c.space.test.connection == c
-box.schema.user.revoke('guest','read,write,execute','space', 'test')
+box.schema.user.revoke('guest','read,write','space', 'test')
 c:close()

--- a/test/sql/triggers.result
+++ b/test/sql/triggers.result
@@ -530,7 +530,7 @@ box.execute("DROP TABLE t1;")
 box.schema.user.create('tester')
 ---
 ...
-box.schema.user.grant('tester','read,write,create,execute', 'space', '_trigger')
+box.schema.user.grant('tester','read,write,create', 'space', '_trigger')
 ---
 ...
 box.execute("CREATE TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT);")

--- a/test/sql/triggers.test.lua
+++ b/test/sql/triggers.test.lua
@@ -180,7 +180,7 @@ box.execute("DROP TABLE t1;")
 -- in SQL
 --
 box.schema.user.create('tester')
-box.schema.user.grant('tester','read,write,create,execute', 'space', '_trigger')
+box.schema.user.grant('tester','read,write,create', 'space', '_trigger')
 box.execute("CREATE TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT);")
 box.session.su('tester')
 --


### PR DESCRIPTION
Historically, it was possible to grant the `execte` privilege on a space although this action had no effect. Since Tarantool 3.0 it isn't allowed anymore. The new `compat` module option `box_space_execute_priv` was added to revert to the old behavior.

Example:

```
tarantool> box.cfg{log_level = 'error'}
---
...

tarantool> box.schema.user.create('alice')
---
...

tarantool> box.schema.user.grant('alice', 'execute', 'space')
---
- error: Unsupported space privilege 'execute'
...

tarantool> require('compat').box_space_execute_priv = 'old'
---
...

tarantool> box.schema.user.grant('alice', 'execute', 'space')
---
...
```

Closes #9277