### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9145-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9145-luajit-fixes.md
@@ -1,0 +1,7 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-9145). The following issues
+were fixed as part of this activity:
+
+* Fixed `math.min()`/`math.max()` inconsistencies for x86/x86_64 architectures
+  when called with a NaN argument or `-0` and `0`.


### PR DESCRIPTION
* IR_MIN/IR_MAX is non-commutative due to underlying FPU ops.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump