### PR TITLE
box: fix memory leak when dropping temporary spaces

### DIFF
--- a/changelogs/unreleased/gh-9296-fix-memory-leak-when-dropping-fully-temporary-spaces.md
+++ b/changelogs/unreleased/gh-9296-fix-memory-leak-when-dropping-fully-temporary-spaces.md
@@ -1,0 +1,3 @@
+## bugfix/box
+
+* Fixed a memory leak when dropping fully-temporary spaces (gh-9296).

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -622,6 +622,10 @@ txn_complete_fail(struct txn *txn);
 /**
  * Complete transaction processing successfully. All the changes are going to
  * become committed and visible.
+ *
+ * This function will run any on_commit triggers associated with @a txn and only
+ * them, so if any statements of this transaction have on_commit triggers,
+ * they must be moved into txn->on_commit before this function is called.
  */
 void
 txn_complete_success(struct txn *txn);


### PR DESCRIPTION
Before this fix we used to leak memory when dropping fully-temporary
spaces. The problem was that the memory is only freed in the on_commit
callback of the transaction, but dropping a temporary space is a NOP
(meta-data is not persisted), and the on_commit triggers used to not be
invoked for NOP transactions.

Closes https://github.com/tarantool/tarantool/issues/9296

NO_DOC=bug fix