### PR TITLE
cmake: introduce target checkpatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ include(CheckFunctionExists)
 include(FindOptionalPackage)
 include(FindPackageMessage)
 include(ExternalProject)
+include(CheckPatch)
 
 find_program(ECHO echo)
 find_program(CAT cat)

--- a/cmake/CheckPatch.cmake
+++ b/cmake/CheckPatch.cmake
@@ -1,0 +1,31 @@
+find_program(CHECKPATCH checkpatch.pl
+             HINTS ${PROJECT_SOURCE_DIR}/checkpatch)
+find_program(CODESPELL codespell)
+
+add_custom_target(checkpatch)
+
+set(BASE_GIT_REF "origin/master")
+if(DEFINED ENV{CHECKPATCH_GITREF})
+    set(BASE_GIT_REF "$ENV{CHECKPATCH_GITREF}")
+endif()
+
+# Description of supported checks in
+# https://github.com/tarantool/checkpatch/blob/master/doc/checkpatch.rst
+set(CHECKPATCH_OPTIONS --git ${BASE_GIT_REF}..HEAD --show-types)
+if(CODESPELL)
+    set(CHECKPATCH_OPTIONS ${CHECKPATCH_OPTIONS} --codespell)
+endif(CODESPELL)
+
+if(CHECKPATCH)
+    add_custom_command(TARGET checkpatch
+        COMMENT "Running checkpatch on a current branch against ${BASE_GIT_REF}"
+        COMMAND ${CHECKPATCH} ${CHECKPATCH_OPTIONS}
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    )
+else()
+    set(WARN_MSG "`checkpatch.pl' is not found, so checkpatch target is dummy.")
+    add_custom_command(TARGET ${PROJECT_NAME}-checkpatch
+        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --red ${WARN_MSG}
+        COMMENT ${WARN_MSG}
+    )
+endif(CHECKPATCH)


### PR DESCRIPTION
Patch introduces a new CMake target "checkpatch", that checks patches on top of the master branch using script checkpatch.pl [1]. By default CMake looking for checkpatch.pl in a directory "checkpatch" in Tarantool's repository root directory and in a directories specified in PATH.

1. https://github.com/tarantool/checkpatch

NO_CHANGELOG=internal
NO_DOC=internal
NO_TEST=internal