### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-6323-fix-cur_L-on-error.md
+++ b/changelogs/unreleased/gh-6323-fix-cur_L-on-error.md
@@ -1,0 +1,4 @@
+## bugfix/luajit
+
+* Fixed a bug when an error could be raised on the non-currently executed
+  coroutine (gh-6323).

--- a/changelogs/unreleased/gh-9145-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9145-luajit-fixes.md
@@ -1,0 +1,6 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-9145). The following issues
+were fixed as part of this activity:
+
+* Fixed error handling after return from a child coroutine.


### PR DESCRIPTION
* Revert "Update cur_L on exceptional path (arm)"
* Revert "arm64: fix cur_L restoration on error throw"
* Revert "Update cur_L on exceptional path"
* Revert "Fix cur_L tracking on exceptional path"
* Restore cur_L for specific Lua/C API use case.
* Fix Clang build.

Closes #6323
Part of #9145

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump