### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/lj-690-concat-tail-call.md
+++ b/changelogs/unreleased/lj-690-concat-tail-call.md
@@ -1,0 +1,4 @@
+## bugfix/luajit
+
+* Prevented compilation of `__concat` methametod with
+  tailcall to fast function (lj-690)


### PR DESCRIPTION
Prevent compile of __concat with tailcall to fast function.

Part of #9145

NO_DOC=LuaJIT bump
NO_TEST=LuaJIT bump