### PR TITLE
test: add WA for #3807 to wal_off/oom.test

### DIFF
--- a/test/wal_off/oom.result
+++ b/test/wal_off/oom.result
@@ -162,6 +162,10 @@ t
   - [48, 'testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest']
   - [49, 'testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest']
 ...
+-- TODO(gh-3807) - may fail to truncate due to memory limit is reached
+box.cfg{memtx_memory = box.cfg.memtx_memory + 1024}
+---
+...
 space:truncate()
 ---
 ...

--- a/test/wal_off/oom.test.lua
+++ b/test/wal_off/oom.test.lua
@@ -43,6 +43,9 @@ for state, v in space:pairs() do
 end;
 test_run:cmd("setopt delimiter ''");
 t
+
+-- TODO(gh-3807) - may fail to truncate due to memory limit is reached
+box.cfg{memtx_memory = box.cfg.memtx_memory + 1024}
 space:truncate()
 space:insert{0, 'test'}
 space.index['primary']:get{0}


### PR DESCRIPTION
We hit #3807 in release/2.11 for release ASAN build with ASAN-friendly small allocators.

Follow-up #7327