### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9145-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9145-luajit-fixes.md
@@ -1,0 +1,6 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-9145). The following issues
+were fixed as part of this activity:
+
+* Fixed output for `IR_CONV` in `jit.dump()`.


### PR DESCRIPTION
* Fix jit.dump() output for IR_CONV.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump