### PR TITLE
fiber: make the concurrent fiber_join safer

### DIFF
--- a/changelogs/unreleased/gh-7562-fiber_join.md
+++ b/changelogs/unreleased/gh-7562-fiber_join.md
@@ -1,0 +1,6 @@
+## bugfix/core
+
+* Fixed a possible inconsistent state entering if fibers are joined incorrectly.
+  Now the `fiber_set_joinable` function panics if the fiber is dead or joined
+  already. The `fiber_join` and `fiber_join_timeout` functions now panic on a
+  double join if it is possible to detect it (gh-7562).

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -170,6 +170,11 @@ enum {
 	 * This flag idicates, if the fiber can be killed from the Lua world.
 	 */
 	FIBER_IS_SYSTEM         = 1 << 8,
+	/**
+	 * Someone has joined the fiber already. So this fiber can't be joined
+	 * once again nor can its joinability be changed.
+	 */
+	FIBER_JOIN_BEEN_INVOKED = 1 << 9,
 	FIBER_DEFAULT_FLAGS	= 0
 };
 
@@ -346,6 +351,11 @@ fiber_set_cancellable(bool yesno);
 
 /**
  * Set fiber to be joinable (false by default).
+ * The fiber must not be joined already nor dead.
+ *
+ * @pre the fiber is not dead (panic if not).
+ * @pre the fiber is not joined yet (panic if not).
+ *
  * \param fiber to (un)set the joinable property.
  *              If set to NULL, the current fiber is used.
  * \param yesno status to set
@@ -357,7 +367,9 @@ fiber_set_joinable(struct fiber *fiber, bool yesno);
  * Wait until the fiber is dead and then move its execution
  * status to the caller.
  * The fiber must not be detached (@sa fiber_set_joinable()).
- * @pre FIBER_IS_JOINABLE flag is set.
+ *
+ * @pre FIBER_IS_JOINABLE flag is set (panic if not).
+ * @pre the fiber is not joined yet (panic if not).
  *
  * \param f fiber to be woken up
  * \return fiber function ret code
@@ -372,7 +384,9 @@ fiber_join(struct fiber *f);
  * Return fiber execution status to the caller or -1
  * if timeout exceeded and set diag.
  * The fiber must not be detached @sa fiber_set_joinable()
+ *
  * @pre FIBER_IS_JOINABLE flag is set.
+ * @pre the fiber is not joined yet (panic if not).
  *
  * \param f fiber to be woken up
  * \param timeout time during which we wait for the fiber completion

--- a/test/unit/fiber.cc
+++ b/test/unit/fiber.cc
@@ -191,6 +191,20 @@ fiber_join_test()
 	fiber_cancel(fiber);
 	fiber_join(fiber);
 
+	note("Can change the joinability in safe cases.");
+	fiber = fiber_new_xc("alive_not_joinable", noop_f);
+	/* Non-joinable not dead fiber.  */
+	fiber_set_joinable(fiber, true);
+	fail_unless((fiber->flags & FIBER_IS_JOINABLE) != 0);
+	/* Joinable not dead and not joined fiber. */
+	fiber_set_joinable(fiber, false);
+	fail_unless((fiber->flags & FIBER_IS_JOINABLE) == 0);
+	/* The same as the first case , just to be sure. */
+	fiber_set_joinable(fiber, true);
+	fail_unless((fiber->flags & FIBER_IS_JOINABLE) != 0);
+	fiber_wakeup(fiber);
+	fiber_join(fiber);
+
 	footer();
 }
 

--- a/test/unit/fiber.result
+++ b/test/unit/fiber.result
@@ -12,6 +12,7 @@ OutOfMemory: Failed to allocate 42 bytes in allocator for exception
 # exception propagated
 # cancel dead has started
 # by this time the fiber should be dead already
+# Can change the joinability in safe cases.
 	*** fiber_join_test: done ***
 	*** fiber_stack_test ***
 # normal-stack fiber not crashed


### PR DESCRIPTION
Prior to this patch a bunch of illegal conditions were possible:
1. The joinability of a fiber could be changed while the fiber is being joined by someone. This could lead to double recycling: the first one happened on the fiber finish, and the second one in the fiber join.
2. The joinability of a dead joinable fiber could be altered, this led to inability jo join the dead fiber and free its resources.
3. A running fiber could be joined concurrently by two or more fibers, so the fiber could be recycled more than once (once per each concurrent join).
4. A dead joined fiber could be made joinable and joined once more leading to a double recycle.

Fixed these issues by adding a new FIBER_IS_JOINED flag and using it where appropriate: now the `fiber_join` detects the double join and joinability change requests are ignored in some cases.

It's still possible that a fiber join is performed on a struct which has been recycled and, if the new fiber is joinable too, this can't be detected. The current fiber API does not allow to fix this, so this is to be the user's responsibility, they should be warned about the fact the double join to the same fiber is illegal.

Closes #7562

@TarantoolBot document
Title: `fiber_join` and `fiber_set_joinable` behave differently now.

`fiber_join` now detects a join of a joined fiber in case if the fiber struct wasn't reused. If the double join is detected the function raises an error.

`fiber_set_joinable` only changes the fiber joinability if it's alive and is not yet joined, othervice it does nothing. This prevents some amount of error conditions that could happen when using the API in an unexpected way:
- Making a dead joinable fiber non-joinable could lead to a memory leak: one can't join the fiber anymore.
- Making an alive joined fiber non-joinable would lead to the double free: once on the fiber function finish, and secondly in the active fiber join finish.
- Making a dead joined fiber joinable allowed to join the fiber once again leading to a double free.

Any given by the API `struct fiber` should only be joined once. If a fiber is joined after the first join on it has finished the behavior is undefined: it can either be a runtime error or an incidental join to a totally foreign fiber.