### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/lj-946-print-errors-from-gc-fin.md
+++ b/changelogs/unreleased/lj-946-print-errors-from-gc-fin.md
@@ -1,0 +1,3 @@
+## bugfix/luajit
+
+* Errors from gc finalizers are now printed instead of being rethrown.


### PR DESCRIPTION
Fix last commit.
Print errors from __gc finalizers instead of rethrowing them.

Part of #9145

NO_DOC=LuaJIT
NO_TEST=LuaJIT