### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9145-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9145-luajit-fixes.md
@@ -1,0 +1,7 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-9145). The following issues
+were fixed as part of this activity:
+
+* Fixed incorrect fold rule for `x - (-0)` on trace (for `x = -0` the result
+  should be `0`).


### PR DESCRIPTION
* Fix FOLD rule for x-0.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump