### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9145-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9145-luajit-fixes.md
@@ -1,0 +1,6 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-9145). The following issues
+were fixed as part of this activity:
+
+* Fixed `math.ceil(x)` result sign for -1 < x < 0.5.


### PR DESCRIPTION
* x86/x64: Fix math.ceil(-0.9) result sign.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump