### PR TITLE
main: fix typo in the help message

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -729,7 +729,7 @@ print_help(FILE *stream)
 		"to see online documentation.\n"
 		"\n"
 		"Visit https://github.com/tarantool/tarantool to submit bugs\n"
-		"contribute a patch.\n";
+		"or contribute a patch.\n";
 	fprintf(stream, help_msg, tarantool_version());
 }
 

--- a/test/box-py/args.result
+++ b/test/box-py/args.result
@@ -106,7 +106,7 @@ Please visit project home page at https://tarantool.io
 to see online documentation.
 
 Visit https://github.com/tarantool/tarantool to submit bugs
-contribute a patch.
+or contribute a patch.
 
 tarantool -h
 Tarantool 3.<minor>.<patch>-<suffix>
@@ -216,7 +216,7 @@ Please visit project home page at https://tarantool.io
 to see online documentation.
 
 Visit https://github.com/tarantool/tarantool to submit bugs
-contribute a patch.
+or contribute a patch.
 
 tarantool -Z
 tarantool: invalid option


### PR DESCRIPTION
Follows up commit d5c874e1bd82 ("main: rewrite help message").

Thanks to Mergen Imeev (@ImeevMA) for pointing it out!

Part of #8862