### PR TITLE
sql: remove field sql_default_value

### DIFF
--- a/src/box/field_def.c
+++ b/src/box/field_def.c
@@ -201,7 +201,6 @@ static const struct opt_def field_def_reg[] = {
 	OPT_DEF_ENUM("nullable_action", on_conflict_action, struct field_def,
 		     nullable_action, NULL),
 	OPT_DEF("collation", OPT_UINT32, struct field_def, coll_id),
-	OPT_DEF("sql_default", OPT_STRPTR, struct field_def, sql_default_value),
 	OPT_DEF_ENUM("compression", compression_type, struct field_def,
 		     compression_type, NULL),
 	OPT_DEF_CUSTOM("default", field_def_parse_default_value),
@@ -222,7 +221,6 @@ const struct field_def field_def_default = {
 	.is_nullable = false,
 	.nullable_action = ON_CONFLICT_ACTION_DEFAULT,
 	.coll_id = COLL_NONE,
-	.sql_default_value = NULL,
 	.default_value = NULL,
 	.default_value_size = 0,
 	.default_func_id = 0,
@@ -443,10 +441,6 @@ field_def_array_dup(const struct field_def *fields, uint32_t field_count)
 	grp_alloc_reserve_data(&all, sizeof(*fields) * field_count);
 	for (uint32_t i = 0; i < field_count; i++) {
 		grp_alloc_reserve_str0(&all, fields[i].name);
-		if (fields[i].sql_default_value != NULL) {
-			grp_alloc_reserve_str0(&all,
-					       fields[i].sql_default_value);
-		}
 		grp_alloc_reserve_data(&all, fields[i].default_value_size);
 	}
 	grp_alloc_use(&all, xmalloc(grp_alloc_size(&all)));
@@ -455,10 +449,6 @@ field_def_array_dup(const struct field_def *fields, uint32_t field_count)
 	for (uint32_t i = 0; i < field_count; ++i) {
 		copy[i] = fields[i];
 		copy[i].name = grp_alloc_create_str0(&all, fields[i].name);
-		if (fields[i].sql_default_value != NULL) {
-			copy[i].sql_default_value = grp_alloc_create_str0(
-				&all, fields[i].sql_default_value);
-		}
 		if (fields[i].default_value != NULL) {
 			size_t size = fields[i].default_value_size;
 			char *buf = grp_alloc_create_data(&all, size);

--- a/src/box/field_def.h
+++ b/src/box/field_def.h
@@ -149,8 +149,6 @@ struct field_def {
 	enum on_conflict_action nullable_action;
 	/** Collation ID for string comparison. */
 	uint32_t coll_id;
-	/** 0-terminated SQL expression for DEFAULT value. */
-	char *sql_default_value;
 	/** MsgPack with the default value. */
 	char *default_value;
 	/** Size of the default value. */

--- a/src/box/sql/pragma.c
+++ b/src/box/sql/pragma.c
@@ -113,10 +113,8 @@ sql_pragma_table_info(struct Parse *parse, const struct space *space)
 			k = key_def_find_by_fieldno(kdef, i) - kdef->parts + 1;
 		}
 		sqlVdbeMultiLoad(v, 1, "issisi", i, field->name,
-				     field_type_strs[field->type],
-				     !field->is_nullable,
-				     field->sql_default_value,
-				     k);
+				 field_type_strs[field->type],
+				 !field->is_nullable, NULL, k);
 		sqlVdbeAddOp2(v, OP_ResultRow, 1, 6);
 	}
 }

--- a/src/box/tuple_format.h
+++ b/src/box/tuple_format.h
@@ -68,26 +68,7 @@ enum { TUPLE_OFFSET_SLOT_NIL = INT32_MAX };
 struct tuple;
 struct tuple_format;
 struct coll;
-struct Expr;
 struct mpstream;
-
-typedef struct Expr *
-(*tuple_format_expr_compile_f)(const char *expr, int expr_len);
-
-typedef void
-(*tuple_format_expr_delete_f)(struct Expr *expr);
-
-/**
- * Callback that compiles an SQL expression.
- * Needed for avoid SQL dependency.
- */
-extern tuple_format_expr_compile_f tuple_format_expr_compile;
-
-/**
- * Callback that deletes an SQL expression.
- * Needed for avoid SQL dependency.
- */
-extern tuple_format_expr_delete_f tuple_format_expr_delete;
 
 /** Engine-specific tuple format methods. */
 struct tuple_format_vtab {
@@ -175,8 +156,6 @@ struct tuple_field {
 	struct tuple_constraint *constraint;
 	/** Number of constraints. */
 	uint32_t constraint_count;
-	/** AST for parsed SQL default value. */
-	struct Expr *sql_default_value_expr;
 	/** Tuple field default value. */
 	struct field_default_value default_value;
 };

--- a/test/unit/tuple_format.c
+++ b/test/unit/tuple_format.c
@@ -31,7 +31,7 @@ mpstream_error(void *is_err)
 static int
 test_tuple_format_cmp(void)
 {
-	plan(19);
+	plan(18);
 	header();
 
 	char buf[1024];
@@ -123,17 +123,6 @@ test_tuple_format_cmp(void)
 	coll_id_cache_delete(coll_id1);
 	coll_id_delete(coll_id2);
 	coll_id_delete(coll_id1);
-
-	size = mp_format(buf, lengthof(buf), "[{%s%s %s%s}]",
-			 "name", "f", "sql_default", "1 + 1");
-	f1 = runtime_tuple_format_new(buf, size, false);
-	size = mp_format(buf, lengthof(buf), "[{%s%s %s%s}]",
-			 "name", "f", "sql_default", "2");
-	f2 = runtime_tuple_format_new(buf, size, false);
-	ok(f1 != f2, "tuple formats with different expressions in "
-	   "'sql_default' definitions are not equal");
-	tuple_format_delete(f1);
-	tuple_format_delete(f2);
 
 	size = mp_format(buf, lengthof(buf), "[{%s%s %s{%s%d %s%d}}]",
 			 "name", "f", "constraint", "c1", 1,


### PR DESCRIPTION
This patch removes the sql_default_value field from the struct field_def and the sql_default_value_expr field from the struct tuple_field as they are no longer needed.

Follow-up #8793

NO_DOC=refactoring
NO_TEST=refactoring
NO_CHANGELOG=refactoring