### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9145-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9145-luajit-fixes.md
@@ -4,3 +4,4 @@ Backported patches from the vanilla LuaJIT trunk (gh-9145). The following issues
 were fixed as part of this activity:
 
 * Fixed error handling after return from a child coroutine.
+* Fixed clashing of addresses in the `__call` metamethod return dispatch.


### PR DESCRIPTION
* x64: Properly fix __call metamethod return dispatch.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump