### PR TITLE
config: add dependencies for roles

### DIFF
--- a/changelogs/unreleased/gh-9078-role-dependencies.md
+++ b/changelogs/unreleased/gh-9078-role-dependencies.md
@@ -1,0 +1,3 @@
+## feature/config
+
+* Introduced dependencies for roles (gh-9078).

--- a/src/box/lua/config/applier/roles.lua
+++ b/src/box/lua/config/applier/roles.lua
@@ -1,19 +1,109 @@
 local log = require('internal.config.utils.log')
 
 local last_loaded = {}
-local last_loaded_names_ordered = {}
+local last_roles_ordered = {}
 
 local function stop_roles(roles_to_skip)
-    for id = #last_loaded_names_ordered, 1, -1 do
-        local role_name = last_loaded_names_ordered[id]
+    local roles_to_stop = {}
+    for id = #last_roles_ordered, 1, -1 do
+        local role_name = last_roles_ordered[id]
         if roles_to_skip == nil or roles_to_skip[role_name] == nil then
-            log.verbose('roles.apply: stop role ' .. role_name)
-            local ok, err = pcall(last_loaded[role_name].stop)
-            if not ok then
-                error(('Error stopping role %s: %s'):format(role_name, err), 0)
-            end
+            table.insert(roles_to_stop, role_name)
         end
     end
+    if #roles_to_stop == 0 then
+        return
+    end
+    local deps = {}
+    for role_name in pairs(roles_to_skip or {}) do
+        local role = last_loaded[role_name] or {}
+        -- There is no need to check transitive dependencies for roles_to_skip,
+        -- because they were already checked when roles were started, i.e. if
+        -- role A depends on role B, which depends on role C, and we stop
+        -- role C, then we will get the error that role B depends on role C.
+        for _, dep in pairs(role.dependencies or {}) do
+            deps[dep] = deps[dep] or {}
+            table.insert(deps[dep], role_name)
+        end
+    end
+    for _, role_name in ipairs(roles_to_stop) do
+        if deps[role_name] ~= nil then
+            local err
+            if #deps[role_name] == 1 then
+                err =('role %q depends on it'):format(deps[role_name][1])
+            else
+                local names = {}
+                for _, v in ipairs(deps[role_name]) do
+                    table.insert(names, ("%q"):format(v))
+                end
+                local names_str = table.concat(names, ', ')
+                err = ('roles %s depend on it'):format(names_str)
+            end
+            error(('Role %q cannot be stopped because %s'):format(role_name,
+                                                                  err), 0)
+        end
+    end
+    for _, role_name in ipairs(roles_to_stop) do
+        log.verbose('roles.apply: stop role ' .. role_name)
+        local ok, err = pcall(last_loaded[role_name].stop)
+        if not ok then
+            error(('Error stopping role %s: %s'):format(role_name, err), 0)
+        end
+    end
+end
+
+local function resort_roles(original_order, roles)
+    local ordered = {}
+
+    -- Needed to detect circular dependencies.
+    local to_add = {}
+
+    -- To skip already added roles.
+    local added = {}
+
+    local function add_role(role_name)
+        if added[role_name] then
+            return
+        end
+
+        to_add[role_name] = true
+
+        for _, dep in ipairs(roles[role_name].dependencies or {}) do
+            -- Detect a role that is not in the list of instance's roles.
+            if not roles[dep] then
+                local err = 'Role %q requires role %q, but the latter is ' ..
+                            'not in the list of roles of the instance'
+                error(err:format(role_name, dep), 0)
+            end
+
+            -- Detect a circular dependency.
+            if to_add[dep] and role_name == dep then
+                local err = 'Circular dependency: role %q depends on itself'
+                error(err:format(role_name), 0)
+            end
+            if to_add[dep] and role_name ~= dep then
+                local err = 'Circular dependency: roles %q and %q depend on ' ..
+                            'each other'
+                error(err:format(role_name, dep), 0)
+            end
+
+            -- Go into the recursion: add the dependency.
+            add_role(dep)
+        end
+
+        to_add[role_name] = nil
+        added[role_name] = true
+        table.insert(ordered, role_name)
+    end
+
+    -- Keep the order, where the dependency tree doesn't obligate
+    -- us to change it.
+    for _, role_name in ipairs(original_order) do
+        assert(roles[role_name] ~= nil)
+        add_role(role_name)
+    end
+
+    return ordered
 end
 
 local function apply(config)
@@ -37,12 +127,8 @@ local function apply(config)
     -- Stop removed roles.
     stop_roles(roles)
 
-    -- Run roles.
-    local roles_cfg = configdata:get('roles_cfg', {use_default = true}) or {}
-    local loaded = {}
-    local loaded_names_ordered = {}
-
     -- Load roles.
+    local loaded = {}
     for _, role_name in ipairs(roles_ordered) do
         local role = last_loaded[role_name]
         if not role then
@@ -57,10 +143,18 @@ local function apply(config)
             end
         end
         loaded[role_name] = role
-        table.insert(loaded_names_ordered, role_name)
+        if role.dependencies ~= nil and type(role.dependencies) ~= 'table' then
+            local err = 'Role %q has field "dependencies" of type %s, '..
+                        'array-like table or nil expected'
+            error(err:format(role_name, type(role.dependencies)), 0)
+        end
     end
 
+    -- Re-sorting of roles taking into account dependencies between them.
+    roles_ordered = resort_roles(roles_ordered, loaded)
+
     -- Validate configs for all roles.
+    local roles_cfg = configdata:get('roles_cfg', {use_default = true}) or {}
     for _, role_name in ipairs(roles_ordered) do
         local ok, err = pcall(loaded[role_name].validate, roles_cfg[role_name])
         if not ok then
@@ -78,7 +172,7 @@ local function apply(config)
     end
 
     last_loaded = loaded
-    last_loaded_names_ordered = loaded_names_ordered
+    last_roles_ordered = roles_ordered
 end
 
 return {


### PR DESCRIPTION
This patch adds dependencies support for roles.

Part of #9078

@TarantoolBot document
Title: dependencies for roles

Roles can now have dependencies. This means that the verify() and apply() methods will be executed for these roles, taking into account the dependencies. Dependencies should be written in the "dependencies" field of the array type. Note, the roles will be loaded (not applied!) in the same order in which they were specified, i.e. not taking dependencies into account.

Example:

Dependencies of role A: B, C
Dependencies of role B: D
No other role has dependencies.

Order in which roles were given: [E, C, A, B, D, G]
They will be loaded in the same order: [E, C, A, B, D, G]
The order, in which functions verify() and apply() will be executed: [E, C, D, B, A, G].