### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9145-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9145-luajit-fixes.md
@@ -4,3 +4,6 @@ Backported patches from the vanilla LuaJIT trunk (gh-9145). The following issues
 were fixed as part of this activity:
 
 * Fixed error handling after return from a child coroutine.
+* Fixed buffer overflow in parsing the `#pragma` directive via FFI (gh-9339).
+  Now the error is thrown when more than 6 alignment settings are pushed on the
+  internal stack.


### PR DESCRIPTION
* FFI: Fix pragma push stack limit check and throw on overflow.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump