### PR TITLE
sql: update parser to exclude out of bounds access

### DIFF
--- a/extra/lempar.c
+++ b/extra/lempar.c
@@ -451,8 +451,8 @@ static unsigned int yy_find_shift_action(
   int i;
   int stateno = pParser->yytos->stateno;
  
-  if( stateno>=YY_MIN_REDUCE ) return stateno;
-  assert( stateno <= YY_SHIFT_COUNT );
+  assert(stateno>=YY_MIN_REDUCE || stateno<=YY_SHIFT_COUNT);
+  if( stateno>YY_SHIFT_COUNT ) return stateno;
   do{
     i = yy_shift_ofst[stateno];
     assert( iLookAhead!=YYNOCODE );


### PR DESCRIPTION
SVACE found a problem in parser that can cause an out of bounds access. The test is made via assert() and works for debug build. Fixed with early exit for the same condition as assert.

NO_DOC=no user-visible change
NO_CHANGELOG=code quality
NO_TEST=no change to actual behavior