### PR TITLE
sql: fix assertion in case FK or CK declared first

### DIFF
--- a/changelogs/unreleased/gh-8392-segfault-on-first-constraint.md
+++ b/changelogs/unreleased/gh-8392-segfault-on-first-constraint.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Fixed a segmentation fault if a FOREIGN KEY or CHECK constraint was declared
+  before the first column during `CREATE TABLE` (gh-8392).

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -705,6 +705,8 @@ static char *
 sql_ck_unique_name_new(struct Parse *parse, bool is_field_ck)
 {
 	struct space *space = parse->create_column_def.space;
+	if (space == NULL)
+		space = parse->create_table_def.new_space;
 	assert(space != NULL);
 	const char *space_name = space->def->name;
 	struct ck_constraint_parse *ck;
@@ -1858,6 +1860,8 @@ static char *
 sql_fk_unique_name_new(struct Parse *parse)
 {
 	struct space *space = parse->create_column_def.space;
+	if (space == NULL)
+		space = parse->create_table_def.new_space;
 	assert(space != NULL);
 	const char *space_name = space->def->name;
 	struct fk_constraint_parse *fk;


### PR DESCRIPTION
This patch fixes an assertion or segmentation error if a FOREIGN KEY or CHECK constraint is declared before the first column.

Closes #8392
