### PR TITLE
box: add check against setting `box.cfg` options to `inf` and `nan`

### DIFF
--- a/changelogs/unreleased/gh-4962-box-cfg-forbid-infinite-numbers.md
+++ b/changelogs/unreleased/gh-4962-box-cfg-forbid-infinite-numbers.md
@@ -1,0 +1,5 @@
+## bugfix/box
+
+* Added a check that disables setting `box.cfg` and `log.cfg` options to
+  infinite numbers (NaN, Inf). Setting a `box.cfg` or `log.cfg` option to
+  an infinite number could result in a crash or invalid behavior (gh-4962).

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -810,6 +810,14 @@ local function check_cfg_option_type(template, name, value)
                       template)
         end
     end
+    -- It makes no sense to set any configuration option value to an infinite
+    -- number (nan, inf, -inf). To prevent such numbers from slipping through
+    -- configuration option sanity checks and breaking the application logic,
+    -- we forbid them explicitly at the top level.
+    if type(value) == 'number' and not
+            (value == value and value > -math.huge and value < math.huge) then
+        box.error(box.error.CFG, name, "should be a finite number")
+    end
 end
 
 local function prepare_cfg(cfg, old_cfg, default_cfg, template_cfg, modify_cfg)

--- a/test/box-luatest/gh_4962_cfg_infinite_numbers_test.lua
+++ b/test/box-luatest/gh_4962_cfg_infinite_numbers_test.lua
@@ -1,0 +1,28 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_cfg_infinite_numbers = function(cg)
+    cg.server:exec(function()
+        for _, val in ipairs({1 / 0, -1 / 0, 0 / 0}) do
+            for opt, opt_type in pairs(box.internal.template_cfg) do
+                if opt_type:find('number') then
+                    t.assert_error_msg_equals(
+                        "Incorrect value for option '" .. opt .. "': " ..
+                        "should be a finite number",
+                        box.cfg, {[opt] = val})
+                end
+            end
+        end
+    end)
+end


### PR DESCRIPTION
Setting a `box.cfg` option to `inf` or `nan` can result in a crash or invalid behavior. For example, setting `box.cfg.checkpoint_interval` to `0/0` triggers an assertion failure. Let's add a check against `inf` and `nan` for all options. These special numbers don't make any sense as configuration option values anyway.

Closes #4962