### PR TITLE
box: allow `lua_call` priv owners to call registered Lua functions

### DIFF
--- a/src/box/call.c
+++ b/src/box/call.c
@@ -160,9 +160,8 @@ box_run_on_call(enum iproto_type type, const char *expr, int expr_len,
 	trigger_run(&box_on_call, &ctx);
 }
 
-/** Checks if the current user may execute any global Lua function. */
-static int
-access_check_call(const char *name, uint32_t name_len)
+int
+access_check_lua_call(const char *name, uint32_t name_len)
 {
 	struct credentials *cr = effective_user();
 	user_access_t access = PRIV_X | PRIV_U;
@@ -182,7 +181,7 @@ access_check_call(const char *name, uint32_t name_len)
 
 /** Checks if the current user may execute an arbitrary Lua expression. */
 static int
-access_check_eval(void)
+access_check_lua_eval(void)
 {
 	struct credentials *cr = effective_user();
 	user_access_t access = PRIV_X | PRIV_U;
@@ -229,7 +228,7 @@ box_process_call(struct call_request *request, struct port *port)
 			goto cleanup;
 		}
 	} else {
-		if (access_check_call(name, name_len) != 0) {
+		if (access_check_lua_call(name, name_len) != 0) {
 			rc = -1;
 			goto cleanup;
 		}
@@ -249,7 +248,7 @@ box_process_eval(struct call_request *request, struct port *port)
 {
 	rmean_collect(rmean_box, IPROTO_EVAL, 1);
 	/* Check permissions */
-	if (access_check_eval() != 0)
+	if (access_check_lua_eval() != 0)
 		return -1;
 	struct mp_box_ctx ctx;
 	if (mp_box_ctx_create(&ctx, NULL, request->tuple_formats) != 0)

--- a/src/box/call.h
+++ b/src/box/call.h
@@ -76,6 +76,10 @@ box_process_call(struct call_request *request, struct port *port);
 int
 box_process_eval(struct call_request *request, struct port *port);
 
+/** Checks if the current user may execute a global Lua function. */
+int
+access_check_lua_call(const char *name, uint32_t name_len);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/func.c
+++ b/src/box/func.c
@@ -31,6 +31,7 @@
 #include "func.h"
 #include "fiber.h"
 #include "assoc.h"
+#include "call.h"
 #include "lua/call.h"
 #include "diag.h"
 #include "port.h"
@@ -567,6 +568,10 @@ func_access_check(struct func *func)
 	if ((func_access & PRIV_U) != 0 ||
 	    (func->def->uid != credentials->uid &&
 	     func_access & ~func->access[credentials->auth_token].effective)) {
+		if (func->def->language == FUNC_LANGUAGE_LUA &&
+		    func->def->body == NULL)
+			return access_check_lua_call(func->def->name,
+						     func->def->name_len);
 		/* Access violation, report error. */
 		struct user *user = user_find(credentials->uid);
 		if (user != NULL) {


### PR DESCRIPTION
Currently, the `lua_call` privilege simply doesn't work for registered functions. This patch fixes this issue: now, it grants access to any registered function that is written in Lua unless it's a built-in function, such as `dostring`, or a persistent function.

Note, this patch renames `access_check_call` to `access_check_lua_call` to avoid confusion because this function is now global. It also renames `access_check_eval` to `access_check_lua_eval` for consistency.

Closes #9363