### PR TITLE
txn: fix `on_rollback` trigger arguments for transactions aborted by yield or timeout

### DIFF
--- a/changelogs/unreleased/gh-7810-run-triggers-on-rollback-to-savepoint.md
+++ b/changelogs/unreleased/gh-7810-run-triggers-on-rollback-to-savepoint.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a bug when `on_rollback` triggers were not invoked during a rollback
+  to a savepoint (gh-7810).

--- a/changelogs/unreleased/gh-9340-fix-on_rollback-function-args.md
+++ b/changelogs/unreleased/gh-9340-fix-on_rollback-function-args.md
@@ -1,0 +1,5 @@
+## bugfix/core
+
+* Fixed a bug when `on_rollback` trigger functions were invoked with an empty
+  iterator argument if a transaction was aborted by a fiber yield or by a
+  timeout (gh-9340).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -868,7 +868,8 @@ struct mh_i32_t *AlterSpaceLock::registry;
 static int
 alter_space_commit(struct trigger *trigger, void *event)
 {
-	struct txn *txn = (struct txn *) event;
+	(void)event;
+	struct txn *txn = in_txn();
 	struct alter_space *alter = (struct alter_space *) trigger->data;
 	/*
 	 * The engine (vinyl) expects us to pass the signature of

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -1219,8 +1219,9 @@ applier_rollback_by_wal_io(int64_t signature)
 static int
 applier_txn_rollback_cb(struct trigger *trigger, void *event)
 {
-	(void) trigger;
-	struct txn *txn = (struct txn *) event;
+	(void)trigger;
+	(void)event;
+	struct txn *txn = in_txn();
 	/*
 	 * Synchronous transaction rollback due to receiving a
 	 * ROLLBACK entry is a normal event and requires no

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -1437,7 +1437,7 @@ box_txn_rollback_to_savepoint(box_txn_savepoint_t *svp)
 		diag_set(ClientError, ER_NO_SUCH_SAVEPOINT);
 		return -1;
 	}
-	txn_rollback_to_svp(txn, svp->stmt, false);
+	txn_rollback_to_svp(txn, svp->stmt, true);
 	/* Discard from list all newer savepoints. */
 	RLIST_HEAD(discard);
 	rlist_cut_before(&discard, &txn->savepoints, &svp->link);

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -909,6 +909,13 @@ txn_is_first_statement(struct txn *txn)
 	return stailq_last(&txn->stmts) == stailq_first(&txn->stmts);
 }
 
+/** The first statement of the transaction. */
+static inline struct txn_stmt *
+txn_first_stmt(struct txn *txn)
+{
+	return stailq_first_entry(&txn->stmts, struct txn_stmt, next);
+}
+
 /** The current statement of the transaction. */
 static inline struct txn_stmt *
 txn_current_stmt(struct txn *txn)

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -4395,7 +4395,8 @@ out:
 static int
 vy_deferred_delete_on_commit(struct trigger *trigger, void *event)
 {
-	struct txn *txn = event;
+	(void)event;
+	struct txn *txn = in_txn();
 	struct vy_mem *mem = trigger->data;
 	/*
 	 * Update dump_lsn so that we can skip dumped deferred

--- a/test/engine-luatest/gh_9340_on_rollback_trigger_args_test.lua
+++ b/test/engine-luatest/gh_9340_on_rollback_trigger_args_test.lua
@@ -1,0 +1,173 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local function before_all(cg, box_cfg)
+    cg.server = server:new({box_cfg = box_cfg})
+    cg.server:start()
+    cg.server:exec(function()
+        -- A trigger that saves everything from `iterator' into `_G.result'.
+        rawset(_G, 'on_rollback_trigger', function(iterator)
+            local result = {}
+            for num, old_tuple, new_tuple, space_id in iterator() do
+                table.insert(result, {
+                    num = num, space_id = space_id,
+                    old_tuple = old_tuple, new_tuple = new_tuple
+                })
+            end
+            rawset(_G, 'result', result)
+        end)
+    end)
+end
+
+local function after_all(cg)
+    cg.server:drop()
+end
+
+local function after_each(cg)
+    cg.server:exec(function()
+        box.space.test1:drop()
+        box.space.test2:drop()
+    end)
+end
+
+-- Enable MVCC to abort transactions by a timeout or by a conflict.
+local g_mvcc_on = t.group('gh-9340-mvcc-on', {{engine = 'memtx'},
+                                              {engine = 'vinyl'}})
+g_mvcc_on.before_all(function(cg)
+    before_all(cg, {memtx_use_mvcc_engine = true})
+end)
+g_mvcc_on.after_all(after_all)
+g_mvcc_on.after_each(after_each)
+
+-- Check arguments of the `on_rollback' triggers.
+g_mvcc_on.test_trigger_args = function(cg)
+    cg.server:exec(function(engine)
+        local fiber = require('fiber')
+        local s1 = box.schema.space.create('test1', {engine = engine})
+        local s2 = box.schema.space.create('test2', {engine = engine})
+        s1:create_index('pk')
+        s2:create_index('pk')
+        s1:on_replace(function() box.on_rollback(_G.on_rollback_trigger) end)
+
+        -- Check rollback by `box.rollback()'.
+        box.begin()
+        s1:insert{1}
+        s2:insert{2}
+        box.rollback()
+        t.assert_equals(_G.result, {
+            {num = 1, space_id = 513, old_tuple = nil, new_tuple = {2}},
+            {num = 2, space_id = 512, old_tuple = nil, new_tuple = {1}},
+        })
+
+        -- Check rollback by a conflict.
+        box.begin()
+        s1:insert{3}
+        s2:insert{4}
+        local f = fiber.new(s1.insert, s1, {3, 3})
+        f:set_joinable(true)
+        t.assert_equals({f:join()}, {true, {3, 3}})
+        local errmsg = 'Transaction has been aborted by conflict'
+        t.assert_error_msg_equals(errmsg, s1.insert, s1, {33})
+        t.assert_error_msg_equals(errmsg, s2.insert, s2, {44})
+        t.assert_error_msg_equals(errmsg, box.commit)
+        t.assert_equals(_G.result, {
+            {num = 1, space_id = 513, old_tuple = nil, new_tuple = {4}},
+            {num = 2, space_id = 512, old_tuple = nil, new_tuple = {3}},
+        })
+
+        -- Check rollback by a timeout.
+        box.begin({timeout = 0.01})
+        s1:insert{5}
+        s2:insert{6}
+        fiber.sleep(0.1)
+        local errmsg = 'Transaction has been aborted by timeout'
+        t.assert_error_msg_equals(errmsg, s1.insert, s1, {55})
+        t.assert_error_msg_equals(errmsg, s2.insert, s2, {66})
+        t.assert_error_msg_equals(errmsg, box.commit)
+        t.assert_equals(_G.result, {
+            {num = 1, space_id = 513, old_tuple = nil, new_tuple = {6}},
+            {num = 2, space_id = 512, old_tuple = nil, new_tuple = {5}},
+        })
+
+        -- Check that rollback of a single statement (without full transaction
+        -- rollback) doesn't invoke `on_rollback' triggers.
+        local function error_in_on_replace()
+            error('err')
+        end
+        s2:on_replace(error_in_on_replace)
+        _G.result = {}
+        box.begin()
+        s1:insert{7}
+        t.assert_error_msg_content_equals('err', s2.insert, s2, {77})
+        box.commit()
+        s2:on_replace(nil, error_in_on_replace)
+        t.assert_equals(_G.result, {})
+    end, {cg.params.engine})
+end
+
+-- Tests with error injection to force rollback due to WAL failure.
+g_mvcc_on.test_trigger_args_debug = function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server:exec(function(engine)
+        local s1 = box.schema.space.create('test1', {engine = engine})
+        local s2 = box.schema.space.create('test2', {engine = engine})
+        s1:create_index('pk')
+        s2:create_index('pk')
+        s1:on_replace(function() box.on_rollback(_G.on_rollback_trigger) end)
+
+        -- Check rollback by a WAL I/O error.
+        box.begin()
+        s1:insert{1}
+        s2:insert{2}
+        box.error.injection.set("ERRINJ_WAL_IO", true)
+        t.assert_error_msg_equals('Failed to write to disk', box.commit)
+        box.error.injection.set("ERRINJ_WAL_IO", false)
+        t.assert_equals(_G.result, {
+            {num = 1, space_id = 513, old_tuple = nil, new_tuple = {2}},
+            {num = 2, space_id = 512, old_tuple = nil, new_tuple = {1}},
+        })
+
+        -- Check that `on_rollback' triggers are called with correct arguments
+        -- for single-statement transactions as well.
+        box.error.injection.set("ERRINJ_WAL_IO", true)
+        t.assert_error_msg_equals('Failed to write to disk', s1.insert, s1, {3})
+        box.error.injection.set("ERRINJ_WAL_IO", false)
+        t.assert_equals(_G.result, {
+            {num = 1, space_id = 512, old_tuple = nil, new_tuple = {3}},
+        })
+    end, {cg.params.engine})
+end
+
+-- Force disable MVCC to abort the transaction by fiber yield.
+local g_mvcc_off = t.group('gh-9340-mvcc-off-memtx')
+g_mvcc_off.before_all(function(cg)
+    before_all(cg, {memtx_use_mvcc_engine = false})
+end)
+g_mvcc_off.after_all(after_all)
+g_mvcc_off.after_each(after_each)
+
+-- Check arguments of the `on_rollback' triggers.
+g_mvcc_off.test_trigger_args = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        local s1 = box.schema.space.create('test1', {engine = 'memtx'})
+        local s2 = box.schema.space.create('test2', {engine = 'memtx'})
+        s1:create_index('pk')
+        s2:create_index('pk')
+
+        -- Check rollback by `fiber.yield()'.
+        box.begin()
+        box.on_rollback(_G.on_rollback_trigger)
+        s1:insert{1}
+        s2:insert{2}
+        fiber.yield()
+        local errmsg = 'Transaction has been aborted by a fiber yield'
+        t.assert_error_msg_equals(errmsg, s1.insert, s1, {11})
+        t.assert_error_msg_equals(errmsg, s2.insert, s2, {22})
+        t.assert_error_msg_equals(errmsg, box.commit)
+        t.assert_equals(_G.result, {
+            {num = 1, space_id = 513, old_tuple = nil, new_tuple = {2}},
+            {num = 2, space_id = 512, old_tuple = nil, new_tuple = {1}},
+        })
+    end)
+end

--- a/test/engine/savepoint.result
+++ b/test/engine/savepoint.result
@@ -560,12 +560,12 @@ did_rollback = false
 box.begin()                                                                     \
 svp = box.savepoint()                                                           \
 s:replace{4}                                                                    \
-box.on_rollback(function() did_rollback = true assert(false) end)               \
+box.on_rollback(function() did_rollback = true end)                             \
 box.rollback_to_savepoint(svp)                                                  \
 box.commit()
 ---
 ...
-assert(not did_rollback)
+assert(did_rollback)
 ---
 - true
 ...
@@ -574,12 +574,12 @@ assert(not did_rollback)
 box.begin()                                                                     \
 svp = box.savepoint()                                                           \
 box.schema.create_space('test2', {engine = engine})                             \
-box.on_rollback(function() did_rollback = true assert(false) end)               \
+box.on_rollback(function() did_rollback = true end)                             \
 box.rollback_to_savepoint(svp)                                                  \
 box.commit()
 ---
 ...
-assert(not did_rollback)
+assert(did_rollback)
 ---
 - true
 ...

--- a/test/engine/savepoint.test.lua
+++ b/test/engine/savepoint.test.lua
@@ -285,20 +285,20 @@ did_rollback = false
 box.begin()                                                                     \
 svp = box.savepoint()                                                           \
 s:replace{4}                                                                    \
-box.on_rollback(function() did_rollback = true assert(false) end)               \
+box.on_rollback(function() did_rollback = true end)                             \
 box.rollback_to_savepoint(svp)                                                  \
 box.commit()
-assert(not did_rollback)
+assert(did_rollback)
 
 -- Try DDL too. It installs the flag in the statement that it has triggers.
 -- This should not change the behaviour.
 box.begin()                                                                     \
 svp = box.savepoint()                                                           \
 box.schema.create_space('test2', {engine = engine})                             \
-box.on_rollback(function() did_rollback = true assert(false) end)               \
+box.on_rollback(function() did_rollback = true end)                             \
 box.rollback_to_savepoint(svp)                                                  \
 box.commit()
-assert(not did_rollback)
+assert(did_rollback)
 assert(not box.schema.space.test2)
 
 s:drop()


### PR DESCRIPTION
#### txn: pass `txn_stmt` instead of `txn` to `on_commit`/`on_rollback`

Currently `on_rollback` triggers are called on rollback of the whole transaction. To make it possible to invoke them on rollback to a savepoint, we need to pass a statement at which the savepoint was created.

#### txn: fix `on_rollback` trigger args for txns aborted by yield/timeout

Currently, if a transaction is aborted by a fiber yield or by a timeout, `txn_rollback_to_svp()` is called to rollback all statements of the txn. After that the transaction is completely aborted on attempt to commit it. If an `on_rollback` trigger is set, it is called from `txn_complete_fail()`, however it receives an empty iterator, because at this point the statements are already destroyed. This patch invokes `on_rollback` triggers directly from `txn_rollback_to_svp()` for abort-by-yield, and postpones the rollback for abort-by-timeout.

#### txn: run `on_rollback` triggers on rollback to savepoint

Currently, if a statement is rolled back during rollback to a savepoint, it does not appear in neither `on_commit` nor `on_rollback` triggers. Fix this by running `on_rollback` triggers during the rollback to the savepoint.

Closes https://github.com/tarantool/tarantool/issues/7810
Closes https://github.com/tarantool/tarantool/issues/9340