### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9145-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9145-luajit-fixes.md
@@ -1,0 +1,6 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-9145). The following issues
+were fixed as part of this activity:
+
+* Improved error reporting on stack overflow.


### PR DESCRIPTION
Follow-up fix for stack overflow handling cleanup. Cleanup stack overflow handling.
Improve error reporting on stack overflow.

Part of #9145

NO_DOC=LuaJIT bump
NO_TEST=LuaJIT bump