### PR TITLE
ci: remove using Docker container in source.yml 

### DIFF
--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -13,11 +13,9 @@ jobs:
   source:
     if: github.repository == 'tarantool/tarantool'
 
-    runs-on: ubuntu-20.04-self-hosted
+    runs-on: ubuntu-22.04
 
     steps:
-      - name: Prepare checkout
-        uses: tarantool/actions/prepare-checkout@master
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -28,10 +26,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
-        run: |
-          sudo apt-get -y update
-          sudo apt-get install -y awscli
-          ${CI_MAKE} source-deploy
+        run: ${CI_MAKE} source-deploy
       - name: Send VK Teams message on failure
         if: failure()
         uses: ./.github/actions/report-job-status

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -15,9 +15,6 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
-    container:
-      image: docker.io/tarantool/testing:ubuntu-focal
-
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master


### PR DESCRIPTION
In this commit, we're fixing a problem with Docker in the workflow
`.github/workflows/source.yml`.

The mentioned workflow uses the `.github/actions/environment` action
that needs a permission to make a loopback device for [1]. We didn't
allow for that before due to missing container args, and it caused the
following error:

```
umount: /tmp/luajit-test-vardir: must be superuser to unmount.
256000+0 records in
256000+0 records out
1048576000 bytes (1.0 GB, 1000 MiB) copied, 1.36702 s, 767 MB/s
mount: /tmp/luajit-test-vardir: mount failed: Operation not permitted.
Error: Process completed with exit code 1.
```

The problem started since commit https://github.com/tarantool/tarantool/commit/af996bbb920372f0323fcb68b5a47b8727c172ee ("ci: dockerize
linux workflows"). The simplest way to fix the issue is not to run
the workflow inside a Docker container because a tarball with the
source code is created via the `./packpack/packpack tarball` command
that runs a Docker container as well.

[1] https://github.com/tarantool/tarantool/issues/7472