### PR TITLE
box: introduce transactional event triggers

### DIFF
--- a/changelogs/unreleased/gh-5717-transactional-event-triggers.md
+++ b/changelogs/unreleased/gh-5717-transactional-event-triggers.md
@@ -1,0 +1,6 @@
+## feature/core
+
+* Introduced transaction-related events `box.before_commit`, `box.on_commit`,
+  and `box.on_rollback` for the new trigger registry. One of the main advantages
+  of the new triggers is that they can be set for all transactions rather than
+  setting them within each transaction (gh-5717, gh-8656).

--- a/perf/memtx.cc
+++ b/perf/memtx.cc
@@ -94,6 +94,7 @@ private:
 		::memtx_tx_manager_init();
 		::event_init();
 
+		::txn_event_trigger_init();
 		::space_cache_init();
 		::user_cache_init();
 		::session_init();
@@ -189,6 +190,7 @@ private:
 
 		memtx->base.vtab->shutdown(&memtx->base);
 		::tuple_free();
+		::txn_event_trigger_free();
 
 		::fiber_free();
 		::memory_free();

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -234,6 +234,7 @@ set(box_sources
     port.c
     txn.c
     txn_limbo.c
+    txn_event_trigger.c
     raft.c
     box.cc
     gc.c

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -5887,6 +5887,7 @@ box_init(void)
 	event_ref(box_on_recovery_state_event);
 	box_on_shutdown_event = event_get("box.ctl.on_shutdown", true);
 	event_ref(box_on_shutdown_event);
+	txn_event_trigger_init();
 	msgpack_init();
 	fiber_cond_create(&ro_cond);
 	auth_init();
@@ -5928,6 +5929,7 @@ box_free(void)
 	sequence_free();
 	event_unref(box_on_recovery_state_event);
 	box_on_recovery_state_event = NULL;
+	txn_event_trigger_free();
 	tuple_free();
 	/* schema_module_free(); */
 	/* session_free(); */

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -328,12 +328,51 @@ space_unpin_defaults(struct space *space)
 }
 
 /**
- * Set all the events associated with space: on_replace and before_replace,
+ * Setup each event in `events', associated with the `space' by id and by name.
+ */
+static void
+space_set_events_impl(struct space *space, struct space_event *events[],
+		      size_t event_count, const char *const by_id_fmt[],
+		      const char *const by_name_fmt[])
+{
+	size_t space_id_len = snprintf(NULL, 0, "%u", space_id(space));
+	size_t space_name_len = strlen(space_name(space));
+
+	for (size_t i = 0; i < event_count; ++i) {
+		size_t region_svp = region_used(&fiber()->gc);
+
+		/* Set event by id. */
+		size_t buf_size = strlen(by_id_fmt[i]) + space_id_len
+				  - strlen("%u") + 1;
+		char *event_name = xregion_alloc(&fiber()->gc, buf_size);
+		snprintf(event_name, buf_size, by_id_fmt[i], space_id(space));
+		struct event **event = &events[i]->by_id;
+		assert(*event == NULL);
+		*event = event_get(event_name, true);
+		event_ref(*event);
+
+		/* Set event by name. */
+		buf_size = strlen(by_name_fmt[i]) + space_name_len
+			   - strlen("%s") + 1;
+		event_name = xregion_alloc(&fiber()->gc, buf_size);
+		snprintf(event_name, buf_size, by_name_fmt[i],
+			 space_name(space));
+		event = &events[i]->by_name;
+		assert(*event == NULL);
+		*event = event_get(event_name, true);
+		event_ref(*event);
+
+		region_truncate(&fiber()->gc, region_svp);
+	}
+}
+
+/**
+ * Set DML events associated with the space: on_replace and before_replace,
  * bound by name and by id. If argument is_on_recovery is true, recovery events
  * are set instead of regular ones.
  */
 static void
-space_set_events(struct space *space, bool is_on_recovery)
+space_set_dml_events(struct space *space, bool is_on_recovery)
 {
 	assert(space->def != NULL);
 	/*
@@ -347,62 +386,99 @@ space_set_events(struct space *space, bool is_on_recovery)
 	};
 	/*
 	 * Format strings for names of events associated with the space by id
-	 * and by name. Since space has several versions of each replace trigger
+	 * and by name. The space has several versions of each replace trigger
 	 * (for example, on_recovery_replace which is fired only on recovery and
-	 * on_replace which is fired after recovery), name of replace operation
-	 * is an argument for format string.
+	 * on_replace which is fired after recovery).
 	 */
-	static const char * const event_by_id_fmt[] = {
-		"box.space[%u].on_%s",
-		"box.space[%u].before_%s",
+	static const char *const event_by_id_recovery_fmt[] = {
+		"box.space[%u].on_recovery_replace",
+		"box.space[%u].before_recovery_replace",
 	};
-	static const char * const event_by_name_fmt[] = {
-		"box.space.%s.on_%s",
-		"box.space.%s.before_%s",
+	static const char *const event_by_id_fmt[] = {
+		"box.space[%u].on_replace",
+		"box.space[%u].before_replace",
 	};
+	static const char *const event_by_name_recovery_fmt[] = {
+		"box.space.%s.on_recovery_replace",
+		"box.space.%s.before_recovery_replace",
+	};
+	static const char *const event_by_name_fmt[] = {
+		"box.space.%s.on_replace",
+		"box.space.%s.before_replace",
+	};
+	static_assert(lengthof(space_events) ==
+		      lengthof(event_by_id_recovery_fmt),
+		      "Every space event must be covered with name");
 	static_assert(lengthof(space_events) == lengthof(event_by_id_fmt),
+		      "Every space event must be covered with name");
+	static_assert(lengthof(space_events) ==
+		      lengthof(event_by_name_recovery_fmt),
 		      "Every space event must be covered with name");
 	static_assert(lengthof(space_events) == lengthof(event_by_name_fmt),
 		      "Every space event must be covered with name");
 
-	const char *replace_name =
-		is_on_recovery ? "recovery_replace" : "replace";
+	const char *const *by_id_fmt =
+		is_on_recovery ? event_by_id_recovery_fmt : event_by_id_fmt;
+	const char *const *by_name_fmt =
+		is_on_recovery ? event_by_name_recovery_fmt : event_by_name_fmt;
+
 	space->run_recovery_triggers = is_on_recovery;
+
+	space_set_events_impl(space, space_events, lengthof(space_events),
+			      by_id_fmt, by_name_fmt);
+}
+
+/**
+ * Set transactional events associated with the space, bound by space name and
+ * by space id.
+ */
+static void
+space_set_txn_events(struct space *space)
+{
+	assert(space->def != NULL);
 	/*
-	 * Allocate buffer for event names. We make an assumption that all
-	 * format strings for event names are limited by the constant below.
-	 * This assumption is tested in the loop at the end of the function.
-	 * Another assumption is that string representation of space id is
-	 * limited by another constant below.
+	 * Transactional events associated with the space by id and by name. All
+	 * format strings for event names must be declared in the same order.
 	 */
-	const size_t event_fmt_max_len = 30;
-	const size_t space_id_max_len = 10;
-	const size_t buf_size = event_fmt_max_len + strlen(replace_name) + 1 +
-		MAX(space_id_max_len, strlen(space->def->name)) + 1;
-	size_t region_svp = region_used(&fiber()->gc);
-	char *event_name = xregion_alloc(&fiber()->gc, buf_size);
-	for (size_t i = 0; i < lengthof(space_events); ++i) {
-		/* Test our assumption made during buf_size calculation. */
-		assert(strlen(event_by_name_fmt[i]) <= event_fmt_max_len);
-		assert(strlen(event_by_id_fmt[i]) <= event_fmt_max_len);
+	struct space_event *txn_events[] = {
+		&space->txn_events[TXN_EVENT_BEFORE_COMMIT],
+		&space->txn_events[TXN_EVENT_ON_COMMIT],
+		&space->txn_events[TXN_EVENT_ON_ROLLBACK],
+	};
+	static_assert(lengthof(space->txn_events) == lengthof(txn_events),
+		      "Every txn event must be present in txn_events");
+	/*
+	 * Format strings for event names.
+	 */
+	static const char *const event_by_id_fmt[] = {
+		"box.before_commit.space[%u]",
+		"box.on_commit.space[%u]",
+		"box.on_rollback.space[%u]",
+	};
+	static const char *const event_by_name_fmt[] = {
+		"box.before_commit.space.%s",
+		"box.on_commit.space.%s",
+		"box.on_rollback.space.%s",
+	};
+	static_assert(lengthof(event_by_id_fmt) == lengthof(txn_events),
+		      "Every txn event must be covered with name");
+	static_assert(lengthof(event_by_name_fmt) == lengthof(txn_events),
+		      "Every txn event must be covered with name");
 
-		/* Set event by id. */
-		snprintf(event_name, buf_size, event_by_id_fmt[i],
-			 space->def->id, replace_name);
-		struct event **event = &space_events[i]->by_id;
-		assert(*event == NULL);
-		*event = event_get(event_name, true);
-		event_ref(*event);
+	space_set_events_impl(space, txn_events, lengthof(txn_events),
+			      event_by_id_fmt, event_by_name_fmt);
+}
 
-		/* Set event by name. */
-		snprintf(event_name, buf_size, event_by_name_fmt[i],
-			 space->def->name, replace_name);
-		event = &space_events[i]->by_name;
-		assert(*event == NULL);
-		*event = event_get(event_name, true);
-		event_ref(*event);
-	}
-	region_truncate(&fiber()->gc, region_svp);
+/**
+ * Set all events (DML and transactional) associated with the space, bound by
+ * name and by id. If argument is_on_recovery is true, recovery events are set
+ * instead of regular ones (applicable only to DML events).
+ */
+static void
+space_set_events(struct space *space, bool is_on_recovery)
+{
+	space_set_dml_events(space, is_on_recovery);
+	space_set_txn_events(space);
 }
 
 /**
@@ -411,15 +487,21 @@ space_set_events(struct space *space, bool is_on_recovery)
 static void
 space_reset_events(struct space *space)
 {
-	struct space_event *space_events[] = {
+	struct space_event *space_dml_events[] = {
 		&space->on_replace_event,
 		&space->before_replace_event,
 	};
-	for (size_t i = 0; i < lengthof(space_events); ++i) {
-		event_unref(space_events[i]->by_id);
-		space_events[i]->by_id = NULL;
-		event_unref(space_events[i]->by_name);
-		space_events[i]->by_name = NULL;
+	for (size_t i = 0; i < lengthof(space_dml_events); ++i) {
+		event_unref(space_dml_events[i]->by_id);
+		space_dml_events[i]->by_id = NULL;
+		event_unref(space_dml_events[i]->by_name);
+		space_dml_events[i]->by_name = NULL;
+	}
+	for (size_t i = 0; i < lengthof(space->txn_events); ++i) {
+		event_unref(space->txn_events[i].by_id);
+		space->txn_events[i].by_id = NULL;
+		event_unref(space->txn_events[i].by_name);
+		space->txn_events[i].by_name = NULL;
 	}
 	space->run_recovery_triggers = false;
 }
@@ -804,7 +886,7 @@ space_run_replace_triggers(struct event *event, struct txn *txn,
 		else
 			func_adapter_push_null(trigger, &ctx);
 		/* TODO: maybe the space object has to be here */
-		func_adapter_push_str0(trigger, &ctx, stmt->space->def->name);
+		func_adapter_push_str0(trigger, &ctx, space_name(stmt->space));
 		/* Operation type: INSERT/UPDATE/UPSERT/REPLACE/DELETE */
 		func_adapter_push_str0(trigger, &ctx,
 				       iproto_type_name(stmt->type));

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -40,6 +40,7 @@
 #include "diag.h"
 #include "iproto_constants.h"
 #include "core/event.h"
+#include "txn_event_trigger.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -190,6 +191,8 @@ struct space {
 	struct space_event before_replace_event;
 	/** User-defined on_replace triggers. */
 	struct space_event on_replace_event;
+	/** User-defined transactional event triggers. */
+	struct space_event txn_events[txn_event_id_MAX];
 	/** SQL Trigger list. */
 	struct sql_trigger *sql_triggers;
 	/**
@@ -553,14 +556,23 @@ int
 access_check_space(struct space *space, user_access_t access);
 
 /**
+ * Check if the `space_event' has registered triggers.
+ */
+static inline bool
+space_event_has_triggers(struct space_event *space_event)
+{
+	return event_has_triggers(space_event->by_id) ||
+	       event_has_triggers(space_event->by_name);
+}
+
+/**
  * Check if the space has registered on_replace triggers.
  */
 static inline bool
 space_has_on_replace_triggers(struct space *space)
 {
 	return !rlist_empty(&space->on_replace) ||
-	       event_has_triggers(space->on_replace_event.by_id) ||
-	       event_has_triggers(space->on_replace_event.by_name);
+	       space_event_has_triggers(&space->on_replace_event);
 }
 
 /**
@@ -570,8 +582,7 @@ static inline bool
 space_has_before_replace_triggers(struct space *space)
 {
 	return !rlist_empty(&space->before_replace) ||
-	       event_has_triggers(space->before_replace_event.by_id) ||
-	       event_has_triggers(space->before_replace_event.by_name);
+	       space_event_has_triggers(&space->before_replace_event);
 }
 
 /**

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -488,6 +488,8 @@ struct txn {
 	struct trigger fiber_on_stop;
 	/** Commit and rollback triggers. */
 	struct rlist on_commit, on_rollback, on_wal_write;
+	/** User-defined event triggers, bounded by space ID or space name. */
+	struct txn_event txn_events[txn_event_id_MAX];
 	/** List of savepoints to find savepoint by name. */
 	struct rlist savepoints;
 	/**

--- a/src/box/txn_event_trigger.c
+++ b/src/box/txn_event_trigger.c
@@ -1,0 +1,340 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include "core/assoc.h"
+#include "func_adapter.h"
+#include "txn.h"
+
+/** Global events, i.e. triggered by all transactions. */
+struct event *txn_global_events[txn_event_id_MAX];
+
+void
+txn_event_trigger_init(void)
+{
+	/* Initialize global events. */
+	static const char * const event_names[] = {
+		"box.before_commit",
+		"box.on_commit",
+		"box.on_rollback",
+	};
+	static_assert(lengthof(txn_global_events) == lengthof(event_names),
+		      "Every event must be covered with name");
+
+	for (size_t i = 0; i < lengthof(txn_global_events); i++) {
+		txn_global_events[i] = event_get(event_names[i], true);
+		event_ref(txn_global_events[i]);
+	}
+}
+
+void
+txn_event_trigger_free(void)
+{
+	/* Destroy global events. */
+	for (size_t i = 0; i < lengthof(txn_global_events); i++) {
+		event_unref(txn_global_events[i]);
+		txn_global_events[i] = NULL;
+	}
+}
+
+void
+txn_event_init(struct txn_event *txn_event)
+{
+	txn_event->mode = TXN_EVENT_NO_TRIGGERS;
+	txn_event->space_id = 0;
+	txn_event->space_event = NULL;
+}
+
+void
+txn_event_add_space(struct txn *txn, struct space *space, int event_id)
+{
+	assert(space != NULL);
+	assert(event_id >= 0 && event_id < txn_event_id_MAX);
+	struct space_event *space_event = &space->txn_events[event_id];
+	if (likely(!space_event_has_triggers(space_event)))
+		return;
+
+	struct txn_event *txn_event = &txn->txn_events[event_id];
+	switch (txn_event->mode) {
+	case TXN_EVENT_NO_TRIGGERS:
+		txn_event->mode = TXN_EVENT_ONE_SPACE;
+		txn_event->space_id = space_id(space);
+		txn_event->space_event = space_event;
+		break;
+	case TXN_EVENT_ONE_SPACE:
+		if (txn_event->space_id != space_id(space)) {
+			txn_event->mode = TXN_EVENT_MULTIPLE_SPACES;
+			txn_event->space_id = 0;
+			txn_event->space_event = NULL;
+		}
+		break;
+	case TXN_EVENT_MULTIPLE_SPACES:
+		break;
+	default:
+		unreachable();
+	}
+}
+
+enum { SPACE_ID_FILTER_ALL_SPACES = -1 };
+
+/**
+ * State of the iterator, which is passed to txn_iterator_next().
+ */
+struct txn_iterator_state {
+	/** Request number, starting from 1. */
+	uint32_t req_num;
+	/** Current statement of the transaction. */
+	struct txn_stmt *stmt;
+	/**
+	 * Iterate only over statements with the given space id.
+	 * Or set to SPACE_ID_FILTER_ALL_SPACES for all spaces.
+	 */
+	int64_t space_id_filter;
+};
+
+/**
+ * The iterator goes through every statement of the transaction.
+ */
+static int
+txn_iterator_next(struct func_adapter *func, struct func_adapter_ctx *ctx,
+		  void *state)
+{
+	struct txn_iterator_state *txn_state =
+		(struct txn_iterator_state *)state;
+	struct txn_stmt *stmt = txn_state->stmt;
+
+	/* Skip unwanted spaces if space id filter is set. */
+	if (txn_state->space_id_filter != SPACE_ID_FILTER_ALL_SPACES) {
+		while (stmt != NULL &&
+		       space_id(stmt->space) != txn_state->space_id_filter) {
+			stmt = stailq_next_entry(stmt, next);
+		}
+	}
+
+	if (stmt == NULL)
+		return 0;
+	/*
+	 * The iterator returns 4 values:
+	 *  1. An ordinal request number;
+	 *  2. The old value of the tuple;
+	 *  3. The new value of the tuple;
+	 *  4. The ID of the space.
+	 */
+	func_adapter_push_double(func, ctx, txn_state->req_num++);
+	if (stmt->old_tuple != NULL)
+		func_adapter_push_tuple(func, ctx, stmt->old_tuple);
+	else
+		func_adapter_push_null(func, ctx);
+	if (stmt->new_tuple != NULL)
+		func_adapter_push_tuple(func, ctx, stmt->new_tuple);
+	else
+		func_adapter_push_null(func, ctx);
+	func_adapter_push_double(func, ctx, space_id(stmt->space));
+
+	txn_state->stmt = stailq_next_entry(stmt, next);
+	return 0;
+}
+
+/**
+ * Run triggers registered in `txn' for the `event'.
+ * `stmt' points to the first statement of a transaction or a savepoint.
+ * `can_abort' is set to true if the trigger can abort the transaction.
+ * `space_id' is passed to the iterator to filter spaces by the ID.
+ */
+static int
+run_triggers_general(struct txn *txn, struct txn_stmt *stmt,
+		     struct event *event, bool can_abort, int64_t space_id)
+{
+	int rc = 0;
+	const char *name = NULL;
+	struct func_adapter *trigger = NULL;
+	struct func_adapter_ctx ctx;
+	struct event_trigger_iterator it;
+	event_trigger_iterator_create(&it, event);
+
+	while (rc == 0 && event_trigger_iterator_next(&it, &trigger, &name)) {
+		if (can_abort) {
+			/*
+			 * The transaction could be aborted while the previous
+			 * trigger was running (e.g. if the trigger-function
+			 * yielded or failed).
+			 */
+			rc = txn_check_can_continue(txn);
+			if (rc != 0)
+				break;
+		}
+		/*
+		 * The trigger-function has one parameter - an iterator over the
+		 * statements of the transaction. The return value is ignored.
+		 */
+		struct txn_iterator_state state;
+		state.req_num = 1;
+		state.stmt = stmt;
+		state.space_id_filter = space_id;
+		func_adapter_begin(trigger, &ctx);
+		func_adapter_push_iterator(trigger, &ctx, &state,
+					   txn_iterator_next);
+		rc = func_adapter_call(trigger, &ctx);
+		func_adapter_end(trigger, &ctx);
+	}
+	event_trigger_iterator_destroy(&it);
+	return rc;
+}
+
+/**
+ * Run triggers registered in `txn' for the `space_event'.
+ * Each space event includes 2 lists of triggers: bound by id, bound by name.
+ * `stmt' points to the first statement of a transaction or a savepoint.
+ * `can_abort' is set to true if the trigger can abort the transaction.
+ * `space_id' is passed to the iterator to filter spaces by the ID.
+ */
+static int
+run_triggers_of_single_space(struct txn *txn, struct txn_stmt *stmt,
+			     struct space_event *space_event, bool can_abort,
+			     int64_t space_id)
+{
+	struct event *events[] = {
+		space_event->by_id,
+		space_event->by_name,
+	};
+	/*
+	 * Since the triggers can yield (even if it is not allowed), a space
+	 * can be dropped while executing one of the trigger lists and all the
+	 * events will be deleted - reference them to prevent use-after-free.
+	 */
+	for (size_t i = 0; i < lengthof(events); i++)
+		event_ref(events[i]);
+	int rc = 0;
+	for (size_t i = 0; i < lengthof(events) && rc == 0; i++) {
+		rc = run_triggers_general(txn, stmt, events[i], can_abort,
+					  space_id);
+	}
+	for (size_t i = 0; i < lengthof(events); i++)
+		event_unref(events[i]);
+	return rc;
+}
+
+/**
+ * Run triggers registered in `txn' for the `event_id'.
+ * Used in the case when there is more than one space touched by `txn', which
+ * have triggers for the `event_id' event.
+ * `stmt' points to the first statement of a transaction or a savepoint.
+ * `can_abort' is set to true if the trigger can abort the transaction.
+ */
+static int
+run_triggers_of_multi_spaces(struct txn *txn, struct txn_stmt *stmt,
+			     int event_id, bool can_abort)
+{
+	/*
+	 * Collect all spaces with triggers into the map.
+	 */
+	struct txn_stmt *first_stmt = stmt;
+	struct mh_i32ptr_t *spaces = mh_i32ptr_new();
+	while (stmt != NULL) {
+		struct space_event *e = &stmt->space->txn_events[event_id];
+		if (space_event_has_triggers(e)) {
+			struct mh_i32ptr_node_t node = {
+				space_id(stmt->space),
+				stmt->space
+			};
+			mh_i32ptr_put(spaces, &node, NULL, NULL);
+		}
+		stmt = stailq_next_entry(stmt, next);
+	}
+	/*
+	 * Run triggers for spaces from the map.
+	 */
+	int rc = 0;
+	mh_int_t i;
+	mh_foreach(spaces, i) {
+		uint32_t space_id = mh_i32ptr_node(spaces, i)->key;
+		struct space *space = mh_i32ptr_node(spaces, i)->val;
+		struct space_event *event = &space->txn_events[event_id];
+		rc = run_triggers_of_single_space(txn, first_stmt, event,
+						  can_abort, space_id);
+		if (rc != 0)
+			goto out;
+	}
+out:
+	mh_i32ptr_delete(spaces);
+	return rc;
+}
+
+/**
+ * Run triggers, set for the `event_id' on spaces that are modified by the
+ * transaction `txn'.
+ * `stmt' points to the first statement of a transaction or a savepoint.
+ * `can_abort' is set to true if the trigger can abort the transaction.
+ */
+static int
+run_triggers_of_spaces(struct txn *txn, struct txn_stmt *stmt, int event_id,
+		       bool can_abort)
+{
+	assert(event_id >= 0 && event_id < txn_event_id_MAX);
+	struct txn_event *txn_event = &txn->txn_events[event_id];
+
+	if (txn_event->mode == TXN_EVENT_ONE_SPACE) {
+		if (run_triggers_of_single_space(
+				txn, stmt, txn_event->space_event, can_abort,
+				txn_event->space_id) != 0)
+			return -1;
+	} else if (txn_event->mode == TXN_EVENT_MULTIPLE_SPACES) {
+		if (run_triggers_of_multi_spaces(
+				txn, stmt, event_id, can_abort) != 0)
+			return -1;
+	}
+	return 0;
+}
+
+/**
+ * Run all `event_id' triggers: global and registered in the `txn'.
+ * `stmt' points to the first statement of a transaction or a savepoint.
+ * `can_abort' is set to true if the trigger can abort the transaction.
+ */
+static int
+run_triggers(struct txn *txn, struct txn_stmt *stmt, int event_id,
+	     bool can_abort)
+{
+	/*
+	 * Run triggers, set on spaces that are modified by the transaction.
+	 */
+	if (run_triggers_of_spaces(txn, stmt, event_id, can_abort) != 0)
+		return -1;
+	/*
+	 * Run global triggers.
+	 */
+	struct event *event = txn_global_events[event_id];
+	return run_triggers_general(txn, stmt, event, can_abort,
+				    SPACE_ID_FILTER_ALL_SPACES);
+}
+
+int
+txn_event_before_commit_run_triggers(struct txn *txn)
+{
+	struct txn_stmt *stmt = txn_first_stmt(txn);
+	return run_triggers(txn, stmt, TXN_EVENT_BEFORE_COMMIT, true);
+}
+
+int
+txn_event_on_commit_run_triggers(struct txn *txn)
+{
+	struct txn_stmt *stmt = txn_first_stmt(txn);
+	return run_triggers(txn, stmt, TXN_EVENT_ON_COMMIT, false);
+}
+
+int
+txn_event_on_rollback_run_triggers(struct txn *txn)
+{
+	struct txn_stmt *stmt = txn_first_stmt(txn);
+	return run_triggers(txn, stmt, TXN_EVENT_ON_ROLLBACK, false);
+}
+
+int
+txn_event_on_rollback_to_svp_run_triggers(struct txn *txn,
+					  struct stailq *stmts)
+{
+	struct txn_stmt *stmt;
+	stmt = stailq_first_entry(stmts, struct txn_stmt, next);
+	return run_triggers(txn, stmt, TXN_EVENT_ON_ROLLBACK, false);
+}

--- a/src/box/txn_event_trigger.h
+++ b/src/box/txn_event_trigger.h
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include <stdint.h>
+#include "salad/stailq.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** ID of a transactional event. */
+enum txn_event_id {
+	TXN_EVENT_BEFORE_COMMIT = 0,
+	TXN_EVENT_ON_COMMIT = 1,
+	TXN_EVENT_ON_ROLLBACK = 2,
+	txn_event_id_MAX
+};
+
+/**
+ * How many spaces modified by the transaction have registered triggers for the
+ * given event.
+ */
+enum txn_event_mode {
+	/** There are no spaces with triggers. */
+	TXN_EVENT_NO_TRIGGERS,
+	/** One space has triggers. */
+	TXN_EVENT_ONE_SPACE,
+	/** Several spaces with triggers. */
+	TXN_EVENT_MULTIPLE_SPACES
+};
+
+/**
+ * Event triggers, registered for the spaces that are modified by the given
+ * transaction. This structure is used to optimize the case when there is only
+ * one space in the transaction, which has triggers registered for this event.
+ * If there are more such spaces, a loop over all txn statements is required to
+ * run the triggers (see run_triggers_for_txn_event()).
+ */
+struct txn_event {
+	/** How many spaces have registered triggers. */
+	enum txn_event_mode mode;
+	/** ID of the space for TXN_EVENT_ONE_SPACE mode. */
+	uint32_t space_id;
+	/** Cached space event for TXN_EVENT_ONE_SPACE mode. */
+	struct space_event *space_event;
+};
+
+struct space;
+struct txn;
+struct txn_savepoint;
+
+/** Initialize the "txn event trigger" subsystem. */
+void
+txn_event_trigger_init(void);
+
+/** Destroy the "txn event trigger" subsystem. */
+void
+txn_event_trigger_free(void);
+
+/** Initialize the `txn_event' structure. */
+void
+txn_event_init(struct txn_event *txn_event);
+
+/**
+ * Save event `txn_event_id' from the `space' in `txn' events.
+ * For details see the description of the `txn_event' structure.
+ */
+void
+txn_event_add_space(struct txn *txn, struct space *space, int txn_event_id);
+
+/** Run `box.before_commit' event triggers. */
+int
+txn_event_before_commit_run_triggers(struct txn *txn);
+
+/** Run `box.on_commit' event triggers. */
+int
+txn_event_on_commit_run_triggers(struct txn *txn);
+
+/**
+ * Run `box.on_rollback' event triggers on transaction rollback.
+ * The list of statements in `txn' is expected to be reversed.
+ */
+int
+txn_event_on_rollback_run_triggers(struct txn *txn);
+
+/**
+ * Run `box.on_rollback' event triggers on rollback to savepoint.
+ * The list of statements `stmts' is expected to be reversed.
+ */
+int
+txn_event_on_rollback_to_svp_run_triggers(struct txn *txn,
+					  struct stailq *stmts);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif

--- a/src/lib/core/func_adapter.h
+++ b/src/lib/core/func_adapter.h
@@ -35,6 +35,16 @@ struct func_adapter_ctx {
 struct func_adapter;
 
 /**
+ * Type of function that can be used as an iterator_next method.
+ * Function must return 0 in the case of success. In the case of error,
+ * diag must be set and -1 must be returned.
+ * The state of an iterator is passed as the third argument.
+ */
+typedef int
+(*func_adapter_iterator_next_f)(struct func_adapter *,
+				struct func_adapter_ctx *, void *);
+
+/**
  * Virtual table for func_adapter class.
  * Usage of these methods is in the description of func_adapter class.
  */
@@ -82,6 +92,15 @@ struct func_adapter_vtab {
 	 */
 	void (*push_msgpack)(struct func_adapter_ctx *ctx, const char *data,
 			     const char *data_end);
+	/**
+	 * Pushes an iterator as argument. The third argument is a pointer that
+	 * will be passed to iterator next. The fourth one is a function which
+	 * will be called to advance the iterator. See type declaration
+	 * description for details.
+	 */
+	void (*push_iterator)(struct func_adapter *func,
+			      struct func_adapter_ctx *ctx, void *state,
+			      func_adapter_iterator_next_f iterator_next);
 	/**
 	 * Checks if the next returned value is a tuple.
 	 */
@@ -229,6 +248,14 @@ func_adapter_push_msgpack(struct func_adapter *func,
 			  const char *data, const char *data_end)
 {
 	func->vtab->push_msgpack(ctx, data, data_end);
+}
+
+static inline void
+func_adapter_push_iterator(struct func_adapter *func,
+			   struct func_adapter_ctx *ctx, void *state,
+			   func_adapter_iterator_next_f iterator_next)
+{
+	func->vtab->push_iterator(func, ctx, state, iterator_next);
 }
 
 static inline bool

--- a/test/engine-luatest/gh_5717_txn_event_triggers_test.lua
+++ b/test/engine-luatest/gh_5717_txn_event_triggers_test.lua
@@ -1,0 +1,549 @@
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group('gh-5717', {{engine = 'memtx'}, {engine = 'vinyl'}})
+
+g.before_all(function(cg)
+    -- Force disable MVCC to abort the transaction by fiber yield.
+    local box_cfg = {memtx_use_mvcc_engine = false}
+    cg.server = server:new{box_cfg = box_cfg}
+    cg.server:start()
+    cg.server:exec(function()
+        -- Allows to inject an error into the trigger.
+        rawset(_G, 'errinj_trigger_name', '')
+        -- Set a trigger that will save all passed information into `_G.result'.
+        local function trigger_set(event, event_full, type, name)
+            local trigger = require('trigger')
+            trigger.set(event_full, name, function(iterator)
+                if name == _G.errinj_trigger_name then
+                    error('errinj in ' .. name)
+                end
+                local tuples = {}
+                for num, old_tuple, new_tuple, space_id in iterator() do
+                    table.insert(tuples, {
+                        num = num, old_tuple = old_tuple,
+                        new_tuple = new_tuple, space_id = space_id
+                    })
+                end
+                table.insert(_G.result, {event = event, type = type,
+                                         name = name, tuples = tuples})
+            end)
+        end
+        -- Set a global trigger on `event'.
+        rawset(_G, 'trigger_set_global', function(event, name)
+            trigger_set(event, event, 'global', name)
+        end)
+        -- Set a trigger on `event', filtered by `space_id'.
+        rawset(_G, 'trigger_set_by_id', function(event, name, space_id)
+            local event_full = string.format('%s.space[%d]', event, space_id)
+            trigger_set(event, event_full, 'by_id', name)
+        end)
+        -- Set a trigger on `event', filtered by `space_name'.
+        rawset(_G, 'trigger_set_by_name', function(event, name, space_name)
+            local event_full = string.format('%s.space.%s', event, space_name)
+            trigger_set(event, event_full, 'by_name', name)
+        end)
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        -- Delete all registered triggers.
+        local trigger = require('trigger')
+        local trigger_info = trigger.info()
+        for event, trigger_list in pairs(trigger_info) do
+            for _, trigger_descr in pairs(trigger_list) do
+                local trigger_name = trigger_descr[1]
+                trigger.del(event, trigger_name)
+            end
+        end
+        if box.space.bands then box.space.bands:drop() end
+        if box.space.albums then box.space.albums:drop() end
+    end)
+end)
+
+-- Test basic functionality of `before_commit', `on_commit' and `on_rollback'
+-- triggers.
+g.test_triggers_basic = function(cg)
+    cg.server:exec(function(engine)
+        local trigger = require('trigger')
+
+        local opts = {engine = engine, id = 743}
+        local s = box.schema.space.create('bands', opts)
+        s:create_index('pk')
+        _G.trigger_set_global('box.before_commit', 't1')
+        _G.trigger_set_by_id('box.on_commit', 't2', s.id)
+        _G.trigger_set_by_name('box.on_rollback', 't3', s.name)
+
+        -- Check that triggers are called for a single-statement transaction.
+        rawset(_G, 'result', {})
+        s:auto_increment{'The Beatles', 1960}
+        t.assert_equals(_G.result, {
+            {event = 'box.before_commit', type = 'global', name = 't1',
+             tuples = {
+                {num = 1, space_id = 743, old_tuple = nil,
+                 new_tuple = {1, 'The Beatles', 1960}},
+            }},
+            {event = 'box.on_commit', type = 'by_id', name = 't2',
+             tuples = {
+                {num = 1, space_id = 743, old_tuple = nil,
+                 new_tuple = {1, 'The Beatles', 1960}},
+            }},
+        })
+
+        -- Check that triggers are called for a multi-statement transaction.
+        _G.result = {}
+        box.begin()
+        s:auto_increment{'The Rolling Stones', 1962}
+        s:auto_increment{'Pink Floyd', 1965}
+        s:delete{100500}
+        box.commit()
+        t.assert_equals(_G.result, {
+            {event = 'box.before_commit', type = 'global', name = 't1',
+             tuples = {
+                {num = 1, space_id = 743, old_tuple = nil,
+                 new_tuple = {2, 'The Rolling Stones', 1962}},
+                {num = 2, space_id = 743, old_tuple = nil,
+                 new_tuple = {3, 'Pink Floyd', 1965}},
+                {num = 3, space_id = 743, old_tuple = nil, new_tuple = nil},
+            }},
+            {event = 'box.on_commit', type = 'by_id', name = 't2',
+             tuples = {
+                {num = 1, space_id = 743, old_tuple = nil,
+                 new_tuple = {2, 'The Rolling Stones', 1962}},
+                {num = 2, space_id = 743, old_tuple = nil,
+                 new_tuple = {3, 'Pink Floyd', 1965}},
+                {num = 3, space_id = 743, old_tuple = nil, new_tuple = nil},
+            }},
+        })
+
+        -- Check `on_rollback' trigger. Note that `before_commit' is not called
+        -- for explicit rollback.
+        _G.result = {}
+        box.begin()
+        s:auto_increment{'The Stooges', 1967}
+        s:auto_increment{'Black Sabbath', 1968}
+        s:delete{100500}
+        box.rollback()
+        t.assert_equals(_G.result, {
+            {event = 'box.on_rollback', type = 'by_name', name = 't3',
+             tuples = {
+                {num = 1, space_id = 743, old_tuple = nil, new_tuple = nil},
+                {num = 2, space_id = 743, old_tuple = nil,
+                 new_tuple = {5, 'Black Sabbath', 1968}},
+                {num = 3, space_id = 743, old_tuple = nil,
+                 new_tuple = {4, 'The Stooges', 1967}},
+            }},
+        })
+
+        -- Check triggers on rollback to a savepoint.
+        _G.result = {}
+        box.begin()
+        s:auto_increment{'Queen', 1970}
+        local svp = box.savepoint()
+        s:auto_increment{'The Dictators', 1973}
+        s:auto_increment{'Automobil', 1974}
+        box.rollback_to_savepoint(svp)
+        s:auto_increment{'Ramones', 1974}
+        box.commit()
+        t.assert_equals(_G.result, {
+            {event = 'box.on_rollback', type = 'by_name', name = 't3',
+             tuples = {
+                {num = 1, space_id = 743, old_tuple = nil,
+                 new_tuple = {6, 'Automobil', 1974}},
+                {num = 2, space_id = 743, old_tuple = nil,
+                 new_tuple = {5, 'The Dictators', 1973}},
+            }},
+            {event = 'box.before_commit', type = 'global', name = 't1',
+             tuples = {
+                {num = 1, space_id = 743, old_tuple = nil,
+                 new_tuple = {4, 'Queen', 1970}},
+                {num = 2, space_id = 743, old_tuple = nil,
+                 new_tuple = {5, 'Ramones', 1974}},
+            }},
+            {event = 'box.on_commit', type = 'by_id', name = 't2',
+             tuples = {
+                {num = 1, space_id = 743, old_tuple = nil,
+                 new_tuple = {4, 'Queen', 1970}},
+                {num = 2, space_id = 743, old_tuple = nil,
+                 new_tuple = {5, 'Ramones', 1974}},
+            }},
+        })
+
+        -- Check that only `before_commit' is called for an empty committed txn.
+        _G.result = {}
+        box.begin()
+        box.commit()
+        t.assert_equals(_G.result, {
+            {event = 'box.before_commit', type = 'global', name = 't1',
+             tuples = {}},
+        })
+
+        -- Check that no triggers are called for an empty rolled back txn.
+        _G.result = {}
+        box.begin()
+        box.rollback()
+        t.assert_equals(_G.result, {})
+
+        -- Check that it is possible to delete triggers within an active
+        -- transaction.
+        _G.result = {}
+        box.begin()
+        s:auto_increment{'Smokie', 1964}
+        trigger.del('box.before_commit', 't1')
+        trigger.del('box.on_commit.space[743]', 't2')
+        box.commit()
+        t.assert_equals(_G.result, {})
+    end, {cg.params.engine})
+end
+
+-- Tests with error injection to force rollback due to WAL failure.
+g.test_triggers_debug = function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server:exec(function(engine)
+        local s = box.schema.space.create('bands', {engine = engine})
+        s:create_index('pk')
+        _G.trigger_set_global('box.before_commit', 'before')
+        _G.trigger_set_global('box.on_commit', 'commit')
+        _G.trigger_set_global('box.on_rollback', 'rollback')
+
+        -- Check triggers on rollback by a WAL I/O error.
+        -- Note the reverse order of tuples in `on_rollback' vs `before_commit'.
+        rawset(_G, 'result', {})
+        box.begin()
+        s:auto_increment{'Король и Шут', 1988}
+        s:auto_increment{'Б.А.У.', 2011}
+        box.error.injection.set("ERRINJ_WAL_IO", true)
+        t.assert_error_msg_equals('Failed to write to disk', box.commit)
+        box.error.injection.set("ERRINJ_WAL_IO", false)
+        t.assert_equals(_G.result, {
+            {event = 'box.before_commit', type = 'global', name = 'before',
+             tuples = {
+                {num = 1, space_id = 512, old_tuple = nil,
+                 new_tuple = {1, 'Король и Шут', 1988}},
+                {num = 2, space_id = 512, old_tuple = nil,
+                 new_tuple = {2, 'Б.А.У.', 2011}},
+            }},
+            {event = 'box.on_rollback', type = 'global', name = 'rollback',
+             tuples = {
+                {num = 1, space_id = 512, old_tuple = nil,
+                 new_tuple = {2, 'Б.А.У.', 2011}},
+                {num = 2, space_id = 512, old_tuple = nil,
+                 new_tuple = {1, 'Король и Шут', 1988}},
+            }},
+        })
+    end, {cg.params.engine})
+end
+
+-- Test the order of multiple triggers for one event.
+g.test_triggers_order = function(cg)
+    cg.server:exec(function(engine)
+        local trigger = require('trigger')
+        local opts = {engine = engine, id = 666}
+        local s = box.schema.space.create('test', opts)
+        s:create_index('pk')
+
+        -- Set two triggers of each type in random order, however trigger #2
+        -- always follows trigger #1 of the same type.
+        _G.trigger_set_global('box.before_commit', 'global 1')
+        _G.trigger_set_by_id('box.on_commit', 'by_id 1', s.id)
+        _G.trigger_set_by_name('box.on_commit', 'by_name 1', 'bands')
+        _G.trigger_set_global('box.on_rollback', 'global 1')
+        _G.trigger_set_by_name('box.before_commit', 'by_name 1', 'bands')
+        _G.trigger_set_global('box.on_rollback', 'global 2')
+        _G.trigger_set_by_id('box.before_commit', 'by_id 1', s.id)
+        _G.trigger_set_global('box.before_commit', 'global 2')
+        _G.trigger_set_by_id('box.on_rollback', 'by_id 1', s.id)
+        _G.trigger_set_global('box.on_commit', 'global 1')
+        _G.trigger_set_by_id('box.on_commit', 'by_id 2', s.id)
+        _G.trigger_set_by_id('box.before_commit', 'by_id 2', s.id)
+        _G.trigger_set_by_name('box.before_commit', 'by_name 2', 'bands')
+        _G.trigger_set_by_id('box.on_rollback', 'by_id 2', s.id)
+        _G.trigger_set_by_name('box.on_commit', 'by_name 2', 'bands')
+        _G.trigger_set_global('box.on_commit', 'global 2')
+        _G.trigger_set_by_name('box.on_rollback', 'by_name 1', 'bands')
+        _G.trigger_set_by_name('box.on_rollback', 'by_name 2', 'bands')
+
+        -- Check that `before_commit' and `on_commit' triggers of one type are
+        -- executed in reverse order of their installation.
+        -- Global triggers are always executed after space-specific triggers.
+        rawset(_G, 'result', {})
+        local tuple = s:auto_increment{'Skepticism', 1991}
+        local tuples = {{num = 1, space_id = s.id, old_tuple = nil,
+                         new_tuple = tuple}}
+        t.assert_equals(_G.result, {
+            {event = 'box.before_commit', type = 'by_id', name = 'by_id 2',
+             tuples = tuples},
+            {event = 'box.before_commit', type = 'by_id', name = 'by_id 1',
+             tuples = tuples},
+            {event = 'box.before_commit', type = 'global', name = 'global 2',
+             tuples = tuples},
+            {event = 'box.before_commit', type = 'global', name = 'global 1',
+             tuples = tuples},
+            {event = 'box.on_commit', type = 'by_id', name = 'by_id 2',
+             tuples = tuples},
+            {event = 'box.on_commit', type = 'by_id', name = 'by_id 1',
+             tuples = tuples},
+            {event = 'box.on_commit', type = 'global', name = 'global 2',
+             tuples = tuples},
+            {event = 'box.on_commit', type = 'global', name = 'global 1',
+             tuples = tuples},
+        })
+
+        -- Note that there were no "by_name" events, because the triggers were
+        -- set to the "bands" name, but the space is called "test".
+        s:rename('bands')
+
+        -- Check that `on_rollback' triggers are executed in reverse order of
+        -- their installation.
+        -- Global triggers are always executed after space-specific triggers.
+        _G.result = {}
+        box.begin()
+        local tuple = s:auto_increment{'Apocalyptica', 1993}
+        box.rollback()
+        local tuples = {{num = 1, space_id = s.id, old_tuple = nil,
+                         new_tuple = tuple}}
+        t.assert_equals(_G.result, {
+            {event = 'box.on_rollback', type = 'by_id', name = 'by_id 2',
+             tuples = tuples},
+            {event = 'box.on_rollback', type = 'by_id', name = 'by_id 1',
+             tuples = tuples},
+            {event = 'box.on_rollback', type = 'by_name', name = 'by_name 2',
+             tuples = tuples},
+            {event = 'box.on_rollback', type = 'by_name', name = 'by_name 1',
+             tuples = tuples},
+            {event = 'box.on_rollback', type = 'global', name = 'global 2',
+             tuples = tuples},
+            {event = 'box.on_rollback', type = 'global', name = 'global 1',
+             tuples = tuples},
+        })
+
+        -- Delete all `before_commit' triggers.
+        for event, trigger_list in pairs(trigger.info()) do
+            if event:startswith('box.before_commit') then
+                for _, trigger_descr in pairs(trigger_list) do
+                    trigger.del(event, trigger_descr[1])
+                end
+            end
+        end
+
+        -- Check that if a trigger fails, the remaining triggers for this event
+        -- (including global ones) are not called.
+        _G.result = {}
+        _G.errinj_trigger_name = 'by_name 2'
+        local tuple = s:auto_increment{'U2', 1976}
+        _G.errinj_trigger_name = ''
+        local tuples = {{num = 1, space_id = s.id, old_tuple = nil,
+                         new_tuple = tuple}}
+        t.assert_equals(_G.result, {
+            {event = 'box.on_commit', type = 'by_id', name = 'by_id 2',
+             tuples = tuples},
+            {event = 'box.on_commit', type = 'by_id', name = 'by_id 1',
+             tuples = tuples},
+        })
+    end, {cg.params.engine})
+end
+
+-- Test cases with multiple spaces with triggers.
+g.test_triggers_multi_space = function(cg)
+    cg.server:exec(function(engine)
+        local trigger = require('trigger')
+
+        local bands = box.schema.space.create('bands', {engine = engine})
+        bands:format({{name='id', type='unsigned'}})
+        bands:create_index('pk')
+        _G.trigger_set_by_name('box.on_commit', 'bands_commit', bands.name)
+        _G.trigger_set_by_name('box.on_rollback', 'bands_rollb', bands.name)
+
+        local albums = box.schema.space.create('albums', {engine = engine})
+        albums:create_index('pk')
+        _G.trigger_set_by_id('box.on_commit', 'albums_commit', albums.id)
+        _G.trigger_set_by_id('box.on_rollback', 'albums_rollb', albums.id)
+
+        -- Check that the trigger-function argument iterates only over the
+        -- statements with given space name/id.
+        rawset(_G, 'result', {})
+        box.begin()
+        local kraftwerk = bands:auto_increment{'Kraftwerk', 1970}
+        albums:auto_increment{kraftwerk.id, 'Autobahn', 1974}
+        albums:auto_increment{kraftwerk.id, 'Computerwelt', 1981}
+        local rammstein = bands:auto_increment{'Rammstein', 1994}
+        albums:auto_increment{rammstein.id, 'Herzeleid', 1995}
+        albums:auto_increment{rammstein.id, 'Sehnsucht', 1997}
+        box.commit()
+        t.assert_equals(_G.result, {
+            {event = 'box.on_commit', type = 'by_name', name = 'bands_commit',
+             tuples = {
+                {num = 1, space_id = 512, old_tuple = nil,
+                 new_tuple = {1, 'Kraftwerk', 1970}},
+                {num = 2, space_id = 512, old_tuple = nil,
+                 new_tuple = {2, 'Rammstein', 1994}},
+            }},
+            {event = 'box.on_commit', type = 'by_id', name = 'albums_commit',
+             tuples = {
+                {num = 1, space_id = 513, old_tuple = nil,
+                 new_tuple = {1, 1, 'Autobahn', 1974}},
+                {num = 2, space_id = 513, old_tuple = nil,
+                 new_tuple = {2, 1, 'Computerwelt', 1981}},
+                {num = 3, space_id = 513, old_tuple = nil,
+                 new_tuple = {3, 2, 'Herzeleid', 1995}},
+                {num = 4, space_id = 513, old_tuple = nil,
+                 new_tuple = {4, 2, 'Sehnsucht', 1997}},
+            }},
+        })
+
+        -- Check triggers on rollback to a savepoint.
+        _G.result = {}
+        box.begin()
+        local scorpions = bands:auto_increment{'Scorpions', 1965}
+        albums:auto_increment{scorpions.id, 'Love at First Sting', 1984}
+        local svp = box.savepoint()
+        albums:auto_increment{scorpions.id, 'Crazy World', 1990}
+        box.rollback_to_savepoint(svp)
+        box.commit()
+        t.assert_equals(_G.result, {
+            {event = 'box.on_rollback', type = 'by_id', name = 'albums_rollb',
+             tuples = {
+                {num = 1, space_id = 513, old_tuple = nil,
+                 new_tuple = {6, 3, 'Crazy World', 1990}},
+            }},
+            {event = 'box.on_commit', type = 'by_id', name = 'albums_commit',
+             tuples = {
+                {num = 1, space_id = 513, old_tuple = nil,
+                 new_tuple = {5, 3, 'Love at First Sting', 1984}},
+            }},
+            {event = 'box.on_commit', type = 'by_name', name = 'bands_commit',
+             tuples = {
+                {num = 1, space_id = 512, old_tuple = nil,
+                 new_tuple = {3, 'Scorpions', 1965}},
+            }},
+        })
+
+        -- Check that it is possible to delete a trigger within an active
+        -- transaction.
+        _G.result = {}
+        box.begin()
+        local madsin = bands:auto_increment{'Mad Sin', 1987}
+        albums:auto_increment{madsin.id, 'Break the Rules', 1992}
+        trigger.del('box.on_commit.space.bands', 'bands_commit')
+        box.commit()
+        t.assert_equals(_G.result, {
+            {event = 'box.on_commit', type = 'by_id', name = 'albums_commit',
+             tuples = {
+                {num = 1, space_id = 513, old_tuple = nil,
+                 new_tuple = {6, 4, 'Break the Rules', 1992}},
+            }},
+        })
+    end, {cg.params.engine})
+end
+
+-- Various `before_commit'-specific tests.
+g.test_before_commit = function(cg)
+    cg.server:exec(function(engine)
+        local trigger = require('trigger')
+        local bands = box.schema.space.create('bands', {engine = engine})
+        local albums = box.schema.space.create('albums', {engine = engine})
+        bands:format({{name='id', type='unsigned'},
+                      {name='name', type='string'},
+                      {name='year', type='unsigned'}})
+        bands:create_index('pk')
+        albums:create_index('pk')
+        _G.trigger_set_global('box.on_commit', 'commit')
+
+        trigger.set('box.before_commit.space.bands', 't', function(iterator)
+            for _, _, band in iterator() do
+                albums:auto_increment{band.id, 'The First Album', band.year}
+            end
+            return 'ignored'
+        end)
+
+        -- Check that it is possible to write into spaces from `before_commit'.
+        rawset(_G, 'result', {})
+        bands:auto_increment{'Motörhead', 1975}
+        t.assert_equals(_G.result, {
+            {event = 'box.on_commit', type = 'global', name = 'commit',
+             tuples = {
+                {num = 1, space_id = 512, old_tuple = nil,
+                 new_tuple = {1, 'Motörhead', 1975}},
+                {num = 2, space_id = 513, old_tuple = nil,
+                 new_tuple = {1, 1, 'The First Album', 1975}},
+            }},
+        })
+
+        -- Check that new entries do not survive the rollback.
+        _G.result = {}
+        box.begin()
+        bands:auto_increment{'Madness', 1976}
+        box.rollback()
+        t.assert_equals(_G.result, {})
+        trigger.del('box.before_commit.space.bands', 't')
+
+        -- Check that if `before_commit' trigger yields on memtx without MVCC,
+        -- the transaction is aborted.
+        trigger.set('box.before_commit.space.bands', 't', function()
+            require('fiber').yield()
+        end)
+        _G.result = {}
+        box.begin()
+        bands:auto_increment{'The Clash', 1976}
+        pcall(box.commit)
+        if engine == 'memtx' then
+            t.assert_equals(_G.result, {})
+        elseif engine == 'vinyl' then
+            t.assert_equals(_G.result, {
+                {event = 'box.on_commit', type = 'global', name = 'commit',
+                 tuples = {
+                    {num = 1, space_id = 512, old_tuple = nil,
+                     new_tuple = {2, 'The Clash', 1976}},
+                }},
+            })
+        end
+        trigger.del('box.before_commit.space.bands', 't')
+
+        -- Check that if a trigger raises an error, the transaction is aborted.
+        trigger.set('box.before_commit.space.bands', 't', function()
+            error('error in before_commit')
+        end)
+        _G.result = {}
+        box.begin()
+        local band = bands:auto_increment{'The Misfits', 1977}
+        albums:auto_increment{band.id, 'Walk Among Us', 1982}
+        t.assert_error_msg_content_equals('error in before_commit', box.commit)
+        t.assert_equals(_G.result, {})
+        trigger.del('box.before_commit.space.bands', 't')
+    end, {cg.params.engine})
+end
+
+-- Various `on_commit' and `on_rollback'-specific tests.
+g.test_commit_rollback = function(cg)
+    cg.server:exec(function(engine)
+        local trigger = require('trigger')
+        local s = box.schema.space.create('bands', {engine = engine})
+        s:create_index('pk')
+
+        trigger.set('box.on_commit', 't', function()
+            error('error in on_commit')
+        end)
+        trigger.set('box.on_rollback.space.bands', 't', function()
+            box.error({reason = 'error in on_rollback', errcode = 42})
+        end)
+
+        -- Check that the error in the `on_commit' trigger is simply logged
+        -- without raising.
+        s:auto_increment{'Nena', 1981}
+
+        -- Check that the error in the `on_rollback' trigger is simply logged
+        -- without raising.
+        box.begin()
+        s:auto_increment{'The Cranberries', 1989}
+        box.rollback()
+    end, {cg.params.engine})
+
+    t.helpers.retrying({}, function()
+        t.assert_is_not(cg.server:grep_log('error in on_commit'), nil)
+        t.assert_is_not(cg.server:grep_log('error in on_rollback'), nil)
+    end)
+end


### PR DESCRIPTION
This patch introduces 3 new transaction-related events, that can be used for setting user-defined triggers:

 * `box.before_commit` - triggered when a transaction is ready to commit;
 * `box.on_commit` - triggered when a transaction is committed;
 * `box.on_rollback` - triggered when a transaction is rolled back.

Each of them have 3 versions, e.g. `box.on_commit` event has:

 * `box.on_commit` - global version, called for all transactions;
 * `box.on_commit.space.test` - called for transactions that write to space "test";
 * `box.on_commit.space[512]` - called for transactions that write to space with id 512.

These triggers are implemented via the [new trigger registry](https://github.com/tarantool/tarantool/pull/8622) and work independently from the core `on_commit` and `on_rollback` triggers. One of the main advantages of the new triggers is that they can be set for all transactions, rather than setting them within each transaction.

Space-specific triggers are called prior to global ones. If a trigger-function fails, the remaining triggers for this event (including global) are not executed.

The trigger-function for each event may take an iterator parameter. Similar to core triggers, the iterator goes through the effects of every request that changed a space during the transaction.

`box.before_commit` trigger-function restrictions:

 * Yield is allowed;
 * Allowed to write into database spaces;
 * If the function raises an error, the transaction is rolled back.

`box.on_commit` and `box.on_rollback` trigger-function restrictions:

 * Yield is forbidden (it will crash Tarantool);
 * The function should not access any database spaces;
 * If the function raises an error, the error is simply logged.

Closes https://github.com/tarantool/tarantool/issues/5717