### PR TITLE
config: support TLS in iproto.listen and iproto.advertise.{peer, sharding}

### DIFF
--- a/.test.mk
+++ b/.test.mk
@@ -45,6 +45,12 @@ build: configure
 
 .PHONY: run-luajit-test
 run-luajit-test:
+	# Temporary hack for an unstable LuaJIT test. To be removed in
+	# the scope of gh-9145.
+	sed -i.bak -e 's/for _ = 1, 4000 do/for _ = 1, 10000 do/' \
+		third_party/luajit/test/tarantool-tests/lj-946-print-errors-from-gc-fin-custom.test.lua
+	sed -i.bak -e 's/for _ = 1, 4000 do/for _ = 1, 10000 do/' \
+		third_party/luajit/test/tarantool-tests/lj-946-print-errors-from-gc-fin-default/script.lua
 	${LUAJIT_TEST_ENV} cmake --build ${LUAJIT_TEST_BUILD_DIR} --parallel ${NPROC} --target LuaJIT-test
 
 .PHONY: install-test-deps

--- a/changelogs/unreleased/gh-8862-rework-iproto-listen.md
+++ b/changelogs/unreleased/gh-8862-rework-iproto-listen.md
@@ -1,0 +1,3 @@
+## feature/config
+
+* The `iproto.listen` configuration option has been reworked (gh-8862).

--- a/changelogs/unreleased/gh-8862-tls-options-for-iproto.md
+++ b/changelogs/unreleased/gh-8862-tls-options-for-iproto.md
@@ -1,0 +1,3 @@
+## feature/config
+
+* TLS options for iproto.advertise were introduced (gh-8862).

--- a/doc/examples/config/replicaset.yaml
+++ b/doc/examples/config/replicaset.yaml
@@ -8,7 +8,8 @@ credentials:
       roles: [super]
 
 iproto:
-  listen: 'unix/:./{{ instance_name }}.iproto'
+  listen:
+  - uri: 'unix/:./{{ instance_name }}.iproto'
   advertise:
     peer:
       login: 'replicator'

--- a/doc/examples/config/replicaset.yaml
+++ b/doc/examples/config/replicaset.yaml
@@ -10,7 +10,8 @@ credentials:
 iproto:
   listen: 'unix/:./{{ instance_name }}.iproto'
   advertise:
-    peer: replicator@
+    peer:
+      login: 'replicator'
 
 log:
  to: file

--- a/doc/examples/config/replicaset_election_failover.yaml
+++ b/doc/examples/config/replicaset_election_failover.yaml
@@ -8,7 +8,8 @@ credentials:
       roles: [super]
 
 iproto:
-  listen: 'unix/:./{{ instance_name }}.iproto'
+  listen:
+  - uri: 'unix/:./{{ instance_name }}.iproto'
   advertise:
     peer:
       login: 'replicator'

--- a/doc/examples/config/replicaset_election_failover.yaml
+++ b/doc/examples/config/replicaset_election_failover.yaml
@@ -10,7 +10,8 @@ credentials:
 iproto:
   listen: 'unix/:./{{ instance_name }}.iproto'
   advertise:
-    peer: replicator@
+    peer:
+      login: 'replicator'
 
 log:
   to: file

--- a/doc/examples/config/replicaset_manual_failover.yaml
+++ b/doc/examples/config/replicaset_manual_failover.yaml
@@ -8,7 +8,8 @@ credentials:
       roles: [super]
 
 iproto:
-  listen: 'unix/:./{{ instance_name }}.iproto'
+  listen:
+  - uri: 'unix/:./{{ instance_name }}.iproto'
   advertise:
     peer:
       login: 'replicator'

--- a/doc/examples/config/replicaset_manual_failover.yaml
+++ b/doc/examples/config/replicaset_manual_failover.yaml
@@ -10,7 +10,8 @@ credentials:
 iproto:
   listen: 'unix/:./{{ instance_name }}.iproto'
   advertise:
-    peer: replicator@
+    peer:
+      login: 'replicator'
 
 log:
   to: file

--- a/doc/examples/config/sharding.yaml
+++ b/doc/examples/config/sharding.yaml
@@ -44,8 +44,10 @@ iproto:
   # We currently need to manually define the user for vshard. If the user is not
   # defined, the guest is used.
   advertise:
-    peer: replicator@
-    sharding: storage@
+    peer:
+      login: 'replicator'
+    sharding:
+      login: 'storage'
 
 sharding:
   bucket_count: 10000

--- a/doc/examples/config/sharding.yaml
+++ b/doc/examples/config/sharding.yaml
@@ -40,7 +40,8 @@ credentials:
       roles: [super]
 
 iproto:
-  listen: 'unix/:./{{ instance_name }}.iproto'
+  listen:
+  - uri: 'unix/:./{{ instance_name }}.iproto'
   # We currently need to manually define the user for vshard. If the user is not
   # defined, the guest is used.
   advertise:

--- a/doc/examples/config/single.yaml
+++ b/doc/examples/config/single.yaml
@@ -4,7 +4,8 @@ credentials:
       roles: [super]
 
 iproto:
-  listen: 'unix/:./{{ instance_name }}.iproto'
+  listen:
+  - uri: 'unix/:./{{ instance_name }}.iproto'
 
 groups:
   group-001:

--- a/doc/examples/config/upgrade.yaml
+++ b/doc/examples/config/upgrade.yaml
@@ -14,7 +14,8 @@ credentials:
       roles: [super]
 
 iproto:
-  listen: 'unix/:./{{ instance_name }}.iproto'
+  listen:
+  - uri: 'unix/:./{{ instance_name }}.iproto'
 
 groups:
   group-001:

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -325,6 +325,13 @@ local function apply(config)
         return w.schema.box_cfg, w.data
     end):tomap()
 
+    -- Explicitly set box_cfg.listen to box.NULL if iproto.listen is not
+    -- provided.
+    -- TODO: drop this when default for array value will be supported.
+    if configdata:get('iproto.listen') == nil then
+        box_cfg.listen = box.NULL
+    end
+
     -- Construct box_cfg.replication.
     if box_cfg.replication == nil then
         box_cfg.replication = peer_uris(configdata)

--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -92,6 +92,9 @@ local function instance_sharding(iconfig, instance_name)
     end
     local zone = instance_config:get(iconfig, 'sharding.zone')
     local uri = instance_config:instance_uri(iconfig, 'sharding')
+    if uri == nil then
+        error('No suitable URI provided', 0)
+    end
     --
     -- Currently, vshard does not accept URI without a username. So if we got a
     -- URI without a username, use "guest" as the username without a password.

--- a/test/config-luatest/anonymous_replica_test.lua
+++ b/test/config-luatest/anonymous_replica_test.lua
@@ -111,9 +111,21 @@ g.test_no_anonymous_upstream = function(g)
     replicaset:each(function(server)
         server:exec(function()
             t.assert_equals(box.cfg.replication, {
-                'replicator:secret@unix/:./instance-001.iproto',
-                'replicator:secret@unix/:./instance-002.iproto',
-                'replicator:secret@unix/:./instance-003.iproto',
+                {
+                    login = 'replicator',
+                    password = 'secret',
+                    uri = 'unix/:./instance-001.iproto',
+                },
+                {
+                    login = 'replicator',
+                    password = 'secret',
+                    uri = 'unix/:./instance-002.iproto',
+                },
+                {
+                    login = 'replicator',
+                    password = 'secret',
+                    uri = 'unix/:./instance-003.iproto',
+                },
                 -- No instance-{004,005}, because they're
                 -- anonymous replicas.
             })

--- a/test/config-luatest/basic_test.lua
+++ b/test/config-luatest/basic_test.lua
@@ -120,12 +120,17 @@ local err_msg_no_suitable_uris = 'replication.peers construction for ' ..
 for case_name, case in pairs({
     advertise_unknown_user = {
         listen_2 = 'unix/:./{{ instance_name }}.iproto',
-        advertise_2 = 'unknown@',
+        advertise_2 = {
+            login = 'unknown',
+        },
         exp_err = err_msg_cannot_find_user,
     },
     advertise_unknown_user_uri = {
         listen_2 = 'unix/:./{{ instance_name }}.iproto',
-        advertise_2 = 'unknown@unix/:./{{ instance_name }}.iproto',
+        advertise_2 = {
+            uri = 'unix/:./{{ instance_name }}.iproto',
+            login = 'unknown',
+        },
         exp_err = err_msg_cannot_find_user,
     },
     no_advertise_no_listen = {
@@ -145,15 +150,25 @@ for case_name, case in pairs({
     advertise_user_no_suitable_listen = {
         listen_2 = 'localhost:0,0.0.0.0:3301,[::]:3301',
         listen_3 = 'localhost:0,0.0.0.0:3301,[::]:3301',
-        advertise_2 = 'replicator@',
-        advertise_3 = 'replicator@',
+        advertise_2 = {
+            login = 'replicator',
+        },
+        advertise_3 = {
+            login = 'replicator',
+        },
         exp_err = err_msg_no_suitable_uris,
     },
     advertise_user_pass_no_suitable_listen = {
         listen_2 = 'localhost:0,0.0.0.0:3301,[::]:3301',
         listen_3 = 'localhost:0,0.0.0.0:3301,[::]:3301',
-        advertise_2 = 'replicator:topsecret@',
-        advertise_3 = 'replicator:topsecret@',
+        advertise_2 = {
+            login = 'replicator',
+            password = 'topsecret',
+        },
+        advertise_3 = {
+            login = 'replicator',
+            password = 'topsecret',
+        },
         exp_err = err_msg_no_suitable_uris,
     },
     all_ro = {
@@ -217,7 +232,9 @@ for case_name, case in pairs({
         local dir = treegen.prepare_directory(g, {}, {})
 
         local good_listen = 'unix/:./{{ instance_name }}.iproto'
-        local good_advertise = 'replicator@'
+        local good_advertise = {
+            login = 'replicator',
+        }
 
         local instance_001 = {
             database = {
@@ -304,51 +321,78 @@ end
 for case_name, case in pairs({
     advertise_user_pass_uri = {
         listen = 'unix/:./{{ instance_name }}.iproto',
-        advertise = 'replicator:topsecret@unix/:./{{ instance_name }}.iproto',
+        advertise = {
+            uri = 'unix/:./{{ instance_name }}.iproto',
+            login = 'replicator',
+            password = 'topsecret',
+        },
     },
     advertise_user_uri = {
         listen = 'unix/:./{{ instance_name }}.iproto',
-        advertise = 'replicator@unix/:./{{ instance_name }}.iproto',
+        advertise = {
+            uri = 'unix/:./{{ instance_name }}.iproto',
+            login = 'replicator',
+        },
     },
     advertise_uri = {
         listen = 'unix/:./{{ instance_name }}.iproto',
-        advertise = 'unix/:./{{ instance_name }}.iproto',
+        advertise = {
+            uri = 'unix/:./{{ instance_name }}.iproto',
+        },
     },
     advertise_user_pass = {
         listen = 'unix/:./{{ instance_name }}.iproto',
-        advertise = 'replicator:topsecret@',
+        advertise = {
+            login = 'replicator',
+            password = 'topsecret',
+        },
     },
     advertise_user = {
         listen = 'unix/:./{{ instance_name }}.iproto',
-        advertise = 'replicator@',
+        advertise = {
+            login = 'replicator',
+        },
     },
     advertise_user_first_listen_suitable = {
         listen = 'unix/:./{{ instance_name }}.iproto,localhost:0',
-        advertise = 'replicator@',
+        advertise = {
+            login = 'replicator',
+        },
     },
     advertise_user_second_listen_suitable = {
         listen = 'localhost:0,unix/:./{{ instance_name }}.iproto',
-        advertise = 'replicator@',
+        advertise = {
+            login = 'replicator',
+        },
     },
     advertise_guest = {
         listen = 'unix/:./{{ instance_name }}.iproto',
-        advertise = 'guest@',
+        advertise = {
+            login = 'guest',
+        },
     },
     advertise_guest_uri = {
         listen = 'unix/:./{{ instance_name }}.iproto',
-        advertise = 'guest@unix/:./{{ instance_name }}.iproto',
+        advertise = {
+            uri = 'unix/:./{{ instance_name }}.iproto',
+            login = 'guest',
+        },
     },
     some_peers_have_no_suitable_uri = {
         -- It is OK to have a peer with iproto.listen unsuitable
         -- to connect if there is at least one suitable to
         -- replicate from.
         listen = 'unix/:./{{ instance_name }}.iproto',
-        advertise = 'replicator@',
+        advertise = {
+            login = 'replicator',
+        },
         listen_4 = 'localhost:0',
     },
     election_mode = {
         listen = 'unix/:./{{ instance_name }}.iproto',
-        advertise = 'replicator@',
+        advertise = {
+            login = 'replicator',
+        },
         failover = 'election',
         database_mode = {box.NULL, box.NULL, box.NULL},
         election_mode = {'off', 'voter', 'candidate'},

--- a/test/config-luatest/basic_test.lua
+++ b/test/config-luatest/basic_test.lua
@@ -33,7 +33,7 @@ g.test_basic = function(g)
             },
         },
         iproto = {
-            listen = 'unix/:./{{ instance_name }}.iproto',
+            listen = {{uri = 'unix/:./{{ instance_name }}.iproto'}},
         },
         groups = {
             ['group-001'] = {
@@ -119,14 +119,18 @@ local err_msg_no_suitable_uris = 'replication.peers construction for ' ..
 -- Bad cases for building replicaset.
 for case_name, case in pairs({
     advertise_unknown_user = {
-        listen_2 = 'unix/:./{{ instance_name }}.iproto',
+        listen_2 = {{
+            uri = 'unix/:./{{ instance_name }}.iproto'
+        }},
         advertise_2 = {
             login = 'unknown',
         },
         exp_err = err_msg_cannot_find_user,
     },
     advertise_unknown_user_uri = {
-        listen_2 = 'unix/:./{{ instance_name }}.iproto',
+        listen_2 = {{
+            uri = 'unix/:./{{ instance_name }}.iproto'
+        }},
         advertise_2 = {
             uri = 'unix/:./{{ instance_name }}.iproto',
             login = 'unknown',
@@ -134,22 +138,38 @@ for case_name, case in pairs({
         exp_err = err_msg_cannot_find_user,
     },
     no_advertise_no_listen = {
-        listen_2 = box.NULL,
-        listen_3 = box.NULL,
+        listen_2 = {},
+        listen_3 = {},
         advertise_2 = box.NULL,
         advertise_3 = box.NULL,
         exp_err = err_msg_no_suitable_uris,
     },
     no_advertise_no_suitable_listen = {
-        listen_2 = 'localhost:0,0.0.0.0:3301,[::]:3301',
-        listen_3 = 'localhost:0,0.0.0.0:3301,[::]:3301',
+        listen_2 = {
+            {uri = 'localhost:0'},
+            {uri = '0.0.0.0:3301'},
+            {uri = '[::]:3301'}
+        },
+        listen_3 = {
+            {uri = 'localhost:0'},
+            {uri = '0.0.0.0:3301'},
+            {uri = '[::]:3301'}
+        },
         advertise_2 = box.NULL,
         advertise_3 = box.NULL,
         exp_err = err_msg_no_suitable_uris,
     },
     advertise_user_no_suitable_listen = {
-        listen_2 = 'localhost:0,0.0.0.0:3301,[::]:3301',
-        listen_3 = 'localhost:0,0.0.0.0:3301,[::]:3301',
+        listen_2 = {
+            {uri = 'localhost:0'},
+            {uri = '0.0.0.0:3301'},
+            {uri = '[::]:3301'}
+        },
+        listen_3 = {
+            {uri = 'localhost:0'},
+            {uri = '0.0.0.0:3301'},
+            {uri = '[::]:3301'}
+        },
         advertise_2 = {
             login = 'replicator',
         },
@@ -159,8 +179,16 @@ for case_name, case in pairs({
         exp_err = err_msg_no_suitable_uris,
     },
     advertise_user_pass_no_suitable_listen = {
-        listen_2 = 'localhost:0,0.0.0.0:3301,[::]:3301',
-        listen_3 = 'localhost:0,0.0.0.0:3301,[::]:3301',
+        listen_2 = {
+            {uri = 'localhost:0'},
+            {uri = '0.0.0.0:3301'},
+            {uri = '[::]:3301'}
+        },
+        listen_3 = {
+            {uri = 'localhost:0'},
+            {uri = '0.0.0.0:3301'},
+            {uri = '[::]:3301'}
+        },
         advertise_2 = {
             login = 'replicator',
             password = 'topsecret',
@@ -231,7 +259,9 @@ for case_name, case in pairs({
     g[('test_bad_replicaset_build_%s'):format(case_name)] = function(g)
         local dir = treegen.prepare_directory(g, {}, {})
 
-        local good_listen = 'unix/:./{{ instance_name }}.iproto'
+        local good_listen = {{
+            uri = 'unix/:./{{ instance_name }}.iproto'
+        }}
         local good_advertise = {
             login = 'replicator',
         }
@@ -320,7 +350,9 @@ end
 -- Successful cases for building replicaset.
 for case_name, case in pairs({
     advertise_user_pass_uri = {
-        listen = 'unix/:./{{ instance_name }}.iproto',
+        listen = {{
+            uri = 'unix/:./{{ instance_name }}.iproto',
+        }},
         advertise = {
             uri = 'unix/:./{{ instance_name }}.iproto',
             login = 'replicator',
@@ -328,51 +360,69 @@ for case_name, case in pairs({
         },
     },
     advertise_user_uri = {
-        listen = 'unix/:./{{ instance_name }}.iproto',
+        listen = {{
+            uri = 'unix/:./{{ instance_name }}.iproto',
+        }},
         advertise = {
             uri = 'unix/:./{{ instance_name }}.iproto',
             login = 'replicator',
         },
     },
     advertise_uri = {
-        listen = 'unix/:./{{ instance_name }}.iproto',
+        listen = {{
+            uri = 'unix/:./{{ instance_name }}.iproto',
+        }},
         advertise = {
             uri = 'unix/:./{{ instance_name }}.iproto',
         },
     },
     advertise_user_pass = {
-        listen = 'unix/:./{{ instance_name }}.iproto',
+        listen = {{
+            uri = 'unix/:./{{ instance_name }}.iproto',
+        }},
         advertise = {
             login = 'replicator',
             password = 'topsecret',
         },
     },
     advertise_user = {
-        listen = 'unix/:./{{ instance_name }}.iproto',
+        listen = {{
+            uri = 'unix/:./{{ instance_name }}.iproto',
+        }},
         advertise = {
             login = 'replicator',
         },
     },
     advertise_user_first_listen_suitable = {
-        listen = 'unix/:./{{ instance_name }}.iproto,localhost:0',
+        listen = {
+            {uri = 'unix/:./{{ instance_name }}.iproto'},
+            {uri = 'localhost:0'},
+        },
         advertise = {
             login = 'replicator',
         },
     },
     advertise_user_second_listen_suitable = {
-        listen = 'localhost:0,unix/:./{{ instance_name }}.iproto',
+        listen = {
+            {uri = 'localhost:0'},
+            {uri = 'unix/:./{{ instance_name }}.iproto'},
+        },
         advertise = {
             login = 'replicator',
         },
     },
     advertise_guest = {
-        listen = 'unix/:./{{ instance_name }}.iproto',
+        listen = {{
+            uri = 'unix/:./{{ instance_name }}.iproto',
+        }},
         advertise = {
             login = 'guest',
         },
     },
     advertise_guest_uri = {
-        listen = 'unix/:./{{ instance_name }}.iproto',
+        listen = {{
+            uri = 'unix/:./{{ instance_name }}.iproto',
+        }},
         advertise = {
             uri = 'unix/:./{{ instance_name }}.iproto',
             login = 'guest',
@@ -382,14 +432,20 @@ for case_name, case in pairs({
         -- It is OK to have a peer with iproto.listen unsuitable
         -- to connect if there is at least one suitable to
         -- replicate from.
-        listen = 'unix/:./{{ instance_name }}.iproto',
+        listen = {{
+            uri = 'unix/:./{{ instance_name }}.iproto',
+        }},
         advertise = {
             login = 'replicator',
         },
-        listen_4 = 'localhost:0',
+        listen_4 = {{
+            uri = 'localhost:0',
+        }},
     },
     election_mode = {
-        listen = 'unix/:./{{ instance_name }}.iproto',
+        listen = {{
+            uri = 'unix/:./{{ instance_name }}.iproto'
+        }},
         advertise = {
             login = 'replicator',
         },
@@ -585,7 +641,7 @@ g.test_loader_paths = function(g)
             },
         },
         iproto = {
-            listen = 'unix/:./{{ instance_name }}.iproto',
+            listen = {{uri = 'unix/:./{{ instance_name }}.iproto'}},
         },
         groups = {
             ['group-001'] = {

--- a/test/config-luatest/cbuilder.lua
+++ b/test/config-luatest/cbuilder.lua
@@ -66,7 +66,9 @@ local base_config = {
     iproto = {
         listen = 'unix/:./{{ instance_name }}.iproto',
         advertise = {
-            peer = 'replicator@',
+            peer = {
+                login = 'replicator',
+            }
         },
     },
     replication = {

--- a/test/config-luatest/cbuilder.lua
+++ b/test/config-luatest/cbuilder.lua
@@ -64,7 +64,9 @@ local base_config = {
         },
     },
     iproto = {
-        listen = 'unix/:./{{ instance_name }}.iproto',
+        listen = {{
+            uri = 'unix/:./{{ instance_name }}.iproto'
+        }},
         advertise = {
             peer = {
                 login = 'replicator',

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -185,8 +185,6 @@ g.test_defaults = function()
             listen = box.NULL,
             advertise = {
                 client = box.NULL,
-                peer = box.NULL,
-                sharding = box.NULL,
             },
             threads = 1,
             net_msg_max = 768,

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -46,7 +46,7 @@ g.test_cluster_config = function()
             },
         },
         iproto = {
-            listen = 'unix/:./{{ instance_name }}.iproto',
+            listen = {{uri = 'unix/:./{{ instance_name }}.iproto'}},
         },
         groups = {
             ['group-001'] = {
@@ -92,7 +92,7 @@ g.test_cluster_config = function()
             mode = 'rw',
         },
         iproto = {
-            listen = 'unix/:./{{ instance_name }}.iproto',
+            listen = {{uri = 'unix/:./{{ instance_name }}.iproto'}},
         },
     }
     t.assert_equals(instance_config, expected_config)
@@ -182,7 +182,6 @@ g.test_defaults = function()
             snap_io_rate_limit = box.NULL,
         },
         iproto = {
-            listen = box.NULL,
             advertise = {
                 client = box.NULL,
             },

--- a/test/config-luatest/credentials_applier_test.lua
+++ b/test/config-luatest/credentials_applier_test.lua
@@ -1246,7 +1246,7 @@ g.test_lua_eval_lua_call_sql = function()
                 },
             },
             iproto = {
-                listen = 'unix/:./test.iproto',
+                listen = {{uri = 'unix/:./test.iproto'}},
             },
         },
         verify = function()
@@ -1276,7 +1276,7 @@ g.test_lua_eval_lua_call_sql = function()
                 },
             },
             iproto = {
-                listen = 'unix/:./test.iproto',
+                listen = {{uri = 'unix/:./test.iproto'}},
             },
         },
         verify_2 = function()

--- a/test/config-luatest/helpers.lua
+++ b/test/config-luatest/helpers.lua
@@ -71,7 +71,7 @@ local simple_config = {
         },
     },
     iproto = {
-        listen = 'unix/:./{{ instance_name }}.iproto',
+        listen = {{uri = 'unix/:./{{ instance_name }}.iproto'}}
     },
     groups = {
         ['group-001'] = {

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -356,13 +356,46 @@ local function check_validate_iproto()
     t.assert_error_msg_equals(err, function()
         instance_config:validate(iconfig)
     end)
+
+    iconfig = {
+        iproto = {
+            listen = {{
+                params = {
+                    transport = 'plain',
+                },
+            }},
+        },
+    }
+    err = '[instance_config] iproto.listen[1]: The URI is required '..
+          'for iproto.listen'
+    t.assert_error_msg_equals(err, function()
+        instance_config:validate(iconfig)
+    end)
+
+    iconfig = {
+        iproto = {
+            listen = {{
+                uri = 'localhost:3301?transport=plain',
+            }},
+        },
+    }
+    err = "[instance_config] iproto.listen[1].uri: URI parameters should be " ..
+          "described in the 'params' field, not as the part of URI"
+    t.assert_error_msg_equals(err, function()
+        instance_config:validate(iconfig)
+    end)
 end
 
 g.test_iproto = function()
     t.tarantool.skip_if_enterprise()
     local iconfig = {
         iproto = {
-            listen = 'one',
+            listen = {{
+                uri = 'one',
+                params = {
+                    transport = 'ssl',
+                },
+            }},
             advertise = {
                 client = 'two',
                 peer = {
@@ -391,7 +424,6 @@ g.test_iproto = function()
     validate_fields(iconfig.iproto, instance_config.schema.fields.iproto)
     check_validate_iproto()
     local exp = {
-        listen = box.NULL,
         advertise = {
             client = box.NULL,
         },
@@ -407,7 +439,18 @@ g.test_iproto_enterprise = function()
     t.tarantool.skip_if_not_enterprise()
     local iconfig = {
         iproto = {
-            listen = 'one',
+            listen = {{
+                uri = 'one',
+                params = {
+                    transport = 'ssl',
+                    ssl_password = 'twenty-three',
+                    ssl_cert_file = 'twenty-four',
+                    ssl_key_file = 'twenty-five',
+                    ssl_password_file = 'twenty-six',
+                    ssl_ciphers = 'twenty-seven',
+                    ssl_ca_file = 'twenty-eight',
+                },
+            }},
             advertise = {
                 client = 'two',
                 peer = {
@@ -448,7 +491,6 @@ g.test_iproto_enterprise = function()
     validate_fields(iconfig.iproto, instance_config.schema.fields.iproto)
     check_validate_iproto()
     local exp = {
-        listen = box.NULL,
         advertise = {
             client = box.NULL,
         },
@@ -777,10 +819,12 @@ end
 -- Verify iproto.listen validation, bad cases.
 for case_name, case in pairs({
     incorrect_uri = {
-        listen = ':3301',
+        listen = {{
+            uri = ':3301',
+        }},
         exp_err_msg = table.concat({
-            '[instance_config] iproto.listen',
-            'Unable to parse an URI/a list of URIs',
+            '[instance_config] iproto.listen[1].uri',
+            'Unable to parse an URI',
             'Incorrect URI',
             'expected host:service or /unix.socket'
         }, ': '),
@@ -800,61 +844,35 @@ end
 -- Successful cases for iproto.listen.
 for case_name, case in pairs({
     inet_socket = {
-        listen = 'localhost:3301',
-    },
-    -- A username and a password have no sense in the listen URI,
-    -- but it is accepted by box.cfg() for some reason and
-    -- accepted by the instance config validation. Let's test
-    -- the existing behavior and adopt the test if it'll be
-    -- changed later.
-    inet_socket_user = {
-        listen = 'user@localhost:3301',
-    },
-    inet_socket_user_pass = {
-        listen = 'user:pass@localhost:3301',
+        listen = {{
+            uri = 'localhost:3301',
+        }},
     },
     unix_socket = {
-        listen = 'unix/:/foo/bar.iproto',
-    },
-    -- See the comment above re user@<...> and user:pass@<...>.
-    unix_socket_user = {
-        listen = 'user@unix/:/foo/bar.iproto',
-    },
-    unix_socket_user_pass = {
-        listen = 'user:pass@unix/:/foo/bar.iproto',
+        listen = {{
+            uri = 'unix/:/foo/bar.iproto',
+        }},
     },
     multiple_uris = {
-        listen = 'localhost:3301,localhost:3302',
+        listen = {
+            {uri = 'localhost:3301',},
+            {uri = 'localhost:3302',},
+        },
     },
     inaddr_any_ipv4 = {
-        listen = '0.0.0.0:3301',
-    },
-    -- See the comment above re user@<...> and user:pass@<...>.
-    inaddr_any_ipv4_user = {
-        listen = 'user@0.0.0.0:3301',
-    },
-    inaddr_any_ipv4_user_pass = {
-        listen = 'user:pass@0.0.0.0:3301',
+        listen = {{
+            uri = '0.0.0.0:3301',
+        }},
     },
     inaddr_any_ipv6 = {
-        listen = '[::]:3301',
-    },
-    -- See the comment above re user@<...> and user:pass@<...>.
-    inaddr_any_ipv6_user = {
-        listen = 'user@[::]:3301',
-    },
-    inaddr_any_ipv6_user_pass = {
-        listen = 'user:pass@[::]:3301',
+        listen = {{
+            uri = '[::]:3301',
+        }},
     },
     zero_port = {
-        listen = 'localhost:0',
-    },
-    -- See the comment above re user@<...> and user:pass@<...>.
-    zero_port_user = {
-        listen = 'user@localhost:0',
-    },
-    zero_port_user_pass = {
-        listen = 'user:pass@localhost:0',
+        listen = {{
+            uri = 'localhost:0',
+        }},
     },
 }) do
     g[('test_good_iproto_listen_%s'):format(case_name)] = function()

--- a/test/config-luatest/mkdir_test.lua
+++ b/test/config-luatest/mkdir_test.lua
@@ -65,7 +65,8 @@ g.test_work_dir = function(g)
             ['snapshot.dir'] = data_dir,
             ['console.socket'] = fio.pathjoin(dir,
                 '{{ instance_name }}.control'),
-            ['iproto.listen'] = fio.pathjoin(dir, '{{ instance_name }}.iproto'),
+            ['iproto.listen'] =
+                {{uri = fio.pathjoin(dir, '{{ instance_name }}.iproto')}},
         },
         verify = verify,
         verify_2 = verify,
@@ -122,7 +123,8 @@ g.test_dirs_are_relative_to_work_dir = function(g)
             -- to don't confuse the testing helpers and allows
             -- them to connect to the instance and execute
             -- necessary commands (such as `config:reload()`).
-            ['iproto.listen'] = fio.pathjoin(dir, '{{ instance_name }}.iproto'),
+            ['iproto.listen'] =
+                {{uri = fio.pathjoin(dir, '{{ instance_name }}.iproto')}},
         },
         verify = verify,
         verify_2 = verify,

--- a/test/config-luatest/names_upgrade_test.lua
+++ b/test/config-luatest/names_upgrade_test.lua
@@ -40,7 +40,7 @@ g.before_all(function(g)
         },
 
         iproto = {
-            listen = 'unix/:./{{ instance_name }}.iproto',
+            listen = {{uri = 'unix/:./{{ instance_name }}.iproto'}},
         },
 
         groups = {

--- a/test/config-luatest/reload_test.lua
+++ b/test/config-luatest/reload_test.lua
@@ -27,7 +27,8 @@ g.test_no_cluster_config_failure = function(g)
               roles:
               - super
         iproto:
-          listen: unix/:./{{ instance_name }}.iproto
+          listen:
+            - uri: unix/:./{{ instance_name }}.iproto
         groups:
           group-001:
             replicasets:
@@ -68,7 +69,8 @@ g.test_no_cluster_config_failure = function(g)
               roles:
               - super
         iproto:
-          listen: unix/:./{{ instance_name }}.iproto
+          listen:
+            - uri: unix/:./{{ instance_name }}.iproto
     ]]
     treegen.write_script(dir, 'config.yaml', config)
     g.server:exec(function()

--- a/test/config-luatest/set_names_reload_test.lua
+++ b/test/config-luatest/set_names_reload_test.lua
@@ -68,7 +68,7 @@ g.before_all(function(g)
         },
 
         iproto = {
-            listen = 'unix/:./{{ instance_name }}.iproto',
+            listen = {{uri = 'unix/:./{{ instance_name }}.iproto'}},
         },
 
         replication = {

--- a/test/config-luatest/set_names_test.lua
+++ b/test/config-luatest/set_names_test.lua
@@ -57,7 +57,7 @@ g.before_all(function(g)
         },
 
         iproto = {
-            listen = 'unix/:./{{ instance_name }}.iproto',
+            listen = {{uri = 'unix/:./{{ instance_name }}.iproto'}},
         },
 
         groups = {

--- a/test/config-luatest/sources_test.lua
+++ b/test/config-luatest/sources_test.lua
@@ -37,7 +37,7 @@ g.test_source_file = function()
             },
         },
         iproto = {
-            listen = 'unix/:./{{ instance_name }}.iproto',
+            listen = {{uri = 'unix/:./{{ instance_name }}.iproto'}},
         },
         groups = {
             ['group-001'] = {
@@ -133,7 +133,7 @@ g.test_sources_priority = function(g)
             },
         },
         iproto = {
-            listen = 'unix/:./{{ instance_name }}.iproto',
+            listen = {{uri = 'unix/:./{{ instance_name }}.iproto'}},
         },
         process = {
             title = 'from file',

--- a/test/config-luatest/validate_names_test.lua
+++ b/test/config-luatest/validate_names_test.lua
@@ -57,7 +57,7 @@ local function cluster_initialize(g, with_names)
         },
 
         iproto = {
-            listen = 'unix/:./{{ instance_name }}.iproto',
+            listen = {{uri = 'unix/:./{{ instance_name }}.iproto'}},
         },
 
         groups = {

--- a/test/config-luatest/vars_test.lua
+++ b/test/config-luatest/vars_test.lua
@@ -133,7 +133,7 @@ g.test_peer = run_as_script(function()
     local instance_name = 'instance-001'
     local cconfig = {
         iproto = {
-            listen = listen_template,
+            listen = {{uri = listen_template}},
         },
         groups = {
             ['group-001'] = {
@@ -156,7 +156,7 @@ g.test_peer = run_as_script(function()
             instance_name, 'tarantool.iproto'}, '/')
     end
 
-    local res = configdata:get('iproto.listen', {peer = 'instance-002'})
+    local res = configdata:get('iproto.listen', {peer = 'instance-002'})[1].uri
     t.assert_equals(res, exp_uri('group-001', 'replicaset-001', 'instance-002'))
 end)
 
@@ -177,7 +177,7 @@ g.test_sharding = run_as_script(function()
     local instance_name = 'router-001'
     local cconfig = {
         iproto = {
-            listen = listen_template,
+            listen = {{uri = listen_template}},
         },
         groups = {
             ['routers'] = {

--- a/test/config-luatest/vshard_test.lua
+++ b/test/config-luatest/vshard_test.lua
@@ -22,7 +22,8 @@ g.test_fixed_masters = function(g)
           password: "storage"
 
     iproto:
-      listen: 'unix/:./{{ instance_name }}.iproto'
+      listen:
+        - uri: 'unix/:./{{ instance_name }}.iproto'
       advertise:
         sharding:
           login: 'storage'
@@ -270,7 +271,8 @@ g.test_rebalancer_role = function(g)
           password: "storage"
 
     iproto:
-      listen: 'unix/:./{{ instance_name }}.iproto'
+      listen:
+        - uri: 'unix/:./{{ instance_name }}.iproto'
       advertise:
         sharding:
           login: 'storage'
@@ -437,7 +439,8 @@ g.test_too_many_rebalancers = function(g)
           password: "storage"
 
     iproto:
-      listen: 'unix/:./{{ instance_name }}.iproto'
+      listen:
+        - uri: 'unix/:./{{ instance_name }}.iproto'
       advertise:
         sharding:
           login: 'storage'

--- a/test/config-luatest/vshard_test.lua
+++ b/test/config-luatest/vshard_test.lua
@@ -24,7 +24,8 @@ g.test_fixed_masters = function(g)
     iproto:
       listen: 'unix/:./{{ instance_name }}.iproto'
       advertise:
-        sharding: 'storage@'
+        sharding:
+          login: 'storage'
 
     sharding:
       bucket_count: 1234
@@ -132,11 +133,19 @@ g.test_fixed_masters = function(g)
                 replicas = {
                     ["ef10b92d-9ae9-e7bb-004c-89d8fb468341"] = {
                         name = "instance-002",
-                        uri = "storage:storage@unix/:./instance-002.iproto",
+                        uri = {
+                            login = "storage",
+                            password = "storage",
+                            uri = "unix/:./instance-002.iproto",
+                        },
                     },
                     ["ffe08155-a26d-bd7c-0024-00ee6815a41c"] = {
                         name = "instance-001",
-                        uri = "storage:storage@unix/:./instance-001.iproto",
+                        uri = {
+                            login = "storage",
+                            password = "storage",
+                            uri = "unix/:./instance-001.iproto",
+                        },
                     },
                 },
                 weight = 1,
@@ -146,11 +155,19 @@ g.test_fixed_masters = function(g)
                 replicas = {
                     ["22222222-2222-2222-0022-222222222222"] = {
                         name = "instance-003",
-                        uri = "storage:storage@unix/:./instance-003.iproto",
+                        uri = {
+                            login = "storage",
+                            password = "storage",
+                            uri = "unix/:./instance-003.iproto",
+                        },
                     },
                     ["50367d8e-488b-309b-001a-138a0c516772"] = {
                         name = "instance-004",
-                        uri = "storage:storage@unix/:./instance-004.iproto"
+                        uri = {
+                            login = "storage",
+                            password = "storage",
+                            uri = "unix/:./instance-004.iproto",
+                        },
                     },
                 },
                 weight = 1,
@@ -255,7 +272,8 @@ g.test_rebalancer_role = function(g)
     iproto:
       listen: 'unix/:./{{ instance_name }}.iproto'
       advertise:
-        sharding: 'storage@'
+        sharding:
+          login: 'storage'
 
     groups:
       group-001:
@@ -341,11 +359,19 @@ g.test_rebalancer_role = function(g)
             replicas = {
                 ["ef10b92d-9ae9-e7bb-004c-89d8fb468341"] = {
                     name = "instance-002",
-                    uri = "storage:storage@unix/:./instance-002.iproto",
+                    uri = {
+                        login = "storage",
+                        password = "storage",
+                        uri = "unix/:./instance-002.iproto"
+                    },
                 },
                 ["ffe08155-a26d-bd7c-0024-00ee6815a41c"] = {
                     name = "instance-001",
-                    uri = "storage:storage@unix/:./instance-001.iproto",
+                    uri = {
+                        login = "storage",
+                        password = "storage",
+                        uri = "unix/:./instance-001.iproto"
+                    },
                 },
             },
             weight = 1,
@@ -355,11 +381,19 @@ g.test_rebalancer_role = function(g)
             replicas = {
                 ["f2974852-9b48-8e24-00ea-d34059bf24fd"] = {
                     name = "instance-003",
-                    uri = "storage:storage@unix/:./instance-003.iproto",
+                    uri = {
+                        login = "storage",
+                        password = "storage",
+                        uri = "unix/:./instance-003.iproto"
+                    },
                 },
                 ["50367d8e-488b-309b-001a-138a0c516772"] = {
                     name = "instance-004",
-                    uri = "storage:storage@unix/:./instance-004.iproto"
+                    uri = {
+                        login = "storage",
+                        password = "storage",
+                        uri = "unix/:./instance-004.iproto"
+                    },
                 },
             },
             weight = 1,
@@ -405,7 +439,8 @@ g.test_too_many_rebalancers = function(g)
     iproto:
       listen: 'unix/:./{{ instance_name }}.iproto'
       advertise:
-        sharding: 'storage@'
+        sharding:
+          login: 'storage'
 
     groups:
       group-001:


### PR DESCRIPTION
This patch-set introduces new format for `iproto.listen` and `iproto.advertise.{peer, sharding}` and introduces support for TLS in these options.

Part of #8862
