### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9145-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9145-luajit-fixes.md
@@ -4,3 +4,4 @@ Backported patches from the vanilla LuaJIT trunk (gh-9145). The following issues
 were fixed as part of this activity:
 
 * Fixed error handling after return from a child coroutine.
+* Limited exponent range in number parsing by `2^20`.


### PR DESCRIPTION
* Limit exponent range in number parsing.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump