### PR TITLE
[backport/release/2.10] luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-8594-sysprof-ffunc-crash.md
+++ b/changelogs/unreleased/gh-8594-sysprof-ffunc-crash.md
@@ -1,0 +1,3 @@
+## bugfix/luajit
+
+* Fixed sysprof crash during stack unwinding for FFUNC (gh-8594).

--- a/changelogs/unreleased/gh-9145-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9145-luajit-fixes.md
@@ -4,3 +4,21 @@ Backported patches from the vanilla LuaJIT trunk (gh-9145). The following issues
 were fixed as part of this activity:
 
 * Fixed error handling after return from a child coroutine.
+* Fixed clashing of addresses in the `__call` metamethod return dispatch (again).
+* Fixed the assembling for the head of the side trace (gh-8767).
+* Prevented compilation of `__concat` methamethod with tailcall to fast
+  function.
+* Fixed buffer overflow in parsing the `#pragma` directive via FFI (gh-9339).
+  Now the error is thrown when more than 6 alignment settings are pushed on the
+  internal stack.
+* Fixed incorrect fold rule for `x - (-0)` on trace (for `x = -0` the result
+  should be `0`).
+* Fixed output for `IR_CONV` in `jit.dump()`.
+* Fixed `math.min()`/`math.max()` inconsistencies for x86/x86_64 architectures
+  when called with a NaN argument or `-0` and `0`.
+* Fixed `math.ceil(x)` result sign for -1 < x < 0.5.
+* Errors from gc finalizers are now printed instead of being rethrown.
+* Fixed `lua_concat()`.
+* Fixed possible storing of NaN keys to table on trace.
+* Fixed ABC FOLD optimization with constants.
+* Marked `CONV` as non-weak, to prevent invalid control flow path choice.


### PR DESCRIPTION
* Mark CONV as non-weak, to prevent elimination of its side-effect.
* Fix ABC FOLD rule with constants.
* test: add test for conversions folding
* Add NaN check to IR_NEWREF.
* LJ_GC64: Fix lua_concat().
* test: introduce asserts assert_str{_not}_equal
* ci: enable codespell
* cmake: introduce target with codespell
* codehealth: fix typos
* tools: add cli flag to run profile dump parsers
* profilers: purge generation mechanism
* memprof: refactor symbol resolution
* sysprof: fix crash during FFUNC stream
* Fix last commit.
* Print errors from __gc finalizers instead of rethrowing them.
* x86/x64: Fix math.ceil(-0.9) result sign.
* test: fix flaky fix-jit-dump-ir-conv.test.lua
* IR_MIN/IR_MAX is non-commutative due to underlying FPU ops.
* Fix jit.dump() output for IR_CONV.
* Fix FOLD rule for x-0.
* FFI: Fix pragma push stack limit check and throw on overflow.
* Prevent compile of __concat with tailcall to fast function.
* Fix base register coalescing in side trace.
* Fix register mask for stack check in head of side trace.
* x64: Properly fix __call metamethod return dispatch.

Closes #8594
Closes #8767
Closes #9339
Part of #9145

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump
