### PR TITLE
replication: send anonymous replica version id

### DIFF
--- a/changelogs/unreleased/gh-9401-anon-replica-synchro.md
+++ b/changelogs/unreleased/gh-9401-anon-replica-synchro.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed anonymous replicas not receiving the synchronous transaction queue state
+  during join (gh-9401).

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -858,8 +858,11 @@ applier_fetch_snapshot(struct applier *applier)
 	struct iostream *io = &applier->io;
 	struct xrow_header row;
 
-	memset(&row, 0, sizeof(row));
-	row.type = IPROTO_FETCH_SNAPSHOT;
+	struct fetch_snapshot_request req = {
+		.version_id = tarantool_version_id(),
+	};
+	RegionGuard region_guard(&fiber()->gc);
+	xrow_encode_fetch_snapshot(&row, &req);
 	coio_write_xrow(io, &row);
 
 	applier_set_state(applier, APPLIER_WAIT_SNAPSHOT);

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -4205,6 +4205,9 @@ box_process_fetch_snapshot(struct iostream *io,
 {
 	assert(header->type == IPROTO_FETCH_SNAPSHOT);
 
+	struct fetch_snapshot_request req;
+	xrow_decode_fetch_snapshot_xc(header, &req);
+
 	/* Check that bootstrap has been finished */
 	if (!is_box_configured)
 		tnt_raise(ClientError, ER_LOADING);
@@ -4222,7 +4225,7 @@ box_process_fetch_snapshot(struct iostream *io,
 
 	/* Send the snapshot data to the instance. */
 	struct vclock start_vclock;
-	relay_initial_join(io, header->sync, &start_vclock, 0);
+	relay_initial_join(io, header->sync, &start_vclock, req.version_id);
 	say_info("read-view sent.");
 
 	/* Remember master's vclock after the last request */

--- a/src/box/xrow.c
+++ b/src/box/xrow.c
@@ -2261,6 +2261,29 @@ xrow_decode_join(const struct xrow_header *row, struct join_request *req)
 }
 
 void
+xrow_encode_fetch_snapshot(struct xrow_header *row,
+			   const struct fetch_snapshot_request *req)
+{
+	struct fetch_snapshot_request *cast =
+		(struct fetch_snapshot_request *)req;
+	const struct replication_request base_req = {
+		.version_id = &cast->version_id,
+	};
+	xrow_encode_replication_request(row, &base_req, IPROTO_FETCH_SNAPSHOT);
+}
+
+int
+xrow_decode_fetch_snapshot(const struct xrow_header *row,
+			   struct fetch_snapshot_request *req)
+{
+	memset(req, 0, sizeof(*req));
+	struct replication_request base_req = {
+		.version_id = &req->version_id,
+	};
+	return xrow_decode_replication_request(row, &base_req);
+}
+
+void
 xrow_encode_relay_heartbeat(struct xrow_header *row,
 			    const struct relay_heartbeat *req)
 {

--- a/src/box/xrow.h
+++ b/src/box/xrow.h
@@ -661,6 +661,21 @@ xrow_encode_join(struct xrow_header *row, const struct join_request *req);
 int
 xrow_decode_join(const struct xrow_header *row, struct join_request *req);
 
+struct fetch_snapshot_request {
+	/** Replica's version. */
+	uint32_t version_id;
+};
+
+/** Encode FETCH_SNAPSHOT request. */
+void
+xrow_encode_fetch_snapshot(struct xrow_header *row,
+			   const struct fetch_snapshot_request *req);
+
+/** Decode FETCH_SNAPSHOT request. */
+int
+xrow_decode_fetch_snapshot(const struct xrow_header *row,
+			   struct fetch_snapshot_request *req);
+
 /**
  * Heartbeat from relay to applier. Follows the replication stream. Same
  * direction.
@@ -1139,6 +1154,15 @@ static inline void
 xrow_decode_join_xc(const struct xrow_header *row, struct join_request *req)
 {
 	if (xrow_decode_join(row, req) != 0)
+		diag_raise();
+}
+
+/** @copydoc xrow_decode_fetch_snapshot. */
+static inline void
+xrow_decode_fetch_snapshot_xc(const struct xrow_header *row,
+			      struct fetch_snapshot_request *req)
+{
+	if (xrow_decode_fetch_snapshot(row, req) != 0)
 		diag_raise();
 }
 

--- a/test/replication-luatest/gh_9401_anon_replica_synchro_queue_state_test.lua
+++ b/test/replication-luatest/gh_9401_anon_replica_synchro_queue_state_test.lua
@@ -1,0 +1,68 @@
+local t = require('luatest')
+local replica_set = require('luatest.replica_set')
+local server = require('luatest.server')
+
+local g = t.group('gh-9401-anon-replica-synchro')
+
+--
+-- gh-9401: Anonymous replica didn't receive a synchronous queue snapshot during
+-- join, and treated every synchronous request as erroneous.
+--
+g.before_each(function(cg)
+    cg.replica_set = replica_set:new{}
+    cg.master = cg.replica_set:build_and_add_server{
+        alias = 'master',
+        box_cfg = {
+            replication_timeout = 0.1,
+        },
+    }
+    cg.replica = cg.replica_set:build_and_add_server{
+        alias = 'replica',
+        box_cfg = {
+            replication = server.build_listen_uri('master', cg.replica_set.id),
+            replication_anon = true,
+            replication_timeout = 0.1,
+            read_only = true,
+        },
+    }
+    cg.master:start()
+    cg.master:exec(function()
+        box.ctl.promote()
+    end)
+    cg.replica:start()
+    cg.replica:assert_follows_upstream(cg.master:get_instance_id())
+end)
+
+g.after_each(function(cg)
+    cg.replica_set:drop()
+end)
+
+g.test_anon_replica_synchro_queue = function(cg)
+    local old_term = cg.replica:exec(function(id)
+        t.assert_equals(box.info.synchro.queue.owner, id)
+        t.assert(box.info.synchro.queue.term > 1)
+        return box.info.synchro.queue.term
+    end, {cg.master:get_instance_id()})
+    cg.master:exec(function()
+        box.ctl.demote()
+    end)
+    cg.replica:wait_for_vclock_of(cg.master)
+    cg.replica:assert_follows_upstream(cg.master:get_instance_id())
+    cg.replica:exec(function(term)
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        t.assert(box.info.synchro.queue.term > term)
+    end, {old_term})
+end
+
+g.test_anon_replica_synchro_write = function(cg)
+    cg.master:exec(function()
+        box.schema.space.create('test', {is_sync = true})
+        box.space.test:create_index('pk')
+        box.space.test:insert{1}
+    end)
+    cg.replica:wait_for_vclock_of(cg.master)
+    cg.replica:assert_follows_upstream(cg.master:get_instance_id())
+    cg.replica:exec(function()
+        t.assert_equals(box.space.test:get{1}, {1})
+    end)
+end


### PR DESCRIPTION
Starting with commit f1c2127d4367 ("replication: add META stage to JOIN") replication master appends a special section, called IPROTO_JOIN_META to the initial snapshot sent to the replica. This section contains the latest raft term and synchronous transaction queue owner and term.

The section is only sent to nodes, which have a non-zero version_id. For some reason, version_id encoding for FETCH_SNAPSHOT (analog of JOIN for anonymous replicas) wasn't added in that commit, so anonymous replicas do not receive synchronous queue state.

This leads to them raising ER_SPLIT_BRAIN errors later after join, when the first synchronous row arrives.

In order to fix this, start encoding version_id in FETCH_SNAPSHOT requests.

Closes #9401

@TarantoolBot document
Title: new field in `IPROTO_FETCH_SNAPSHOT` request

`IPROTO_FETCH_SNAPSHOT` request was bodyless (only contained a header) until now, but now it receives a body with a single field: `IPROTO_SERVER_VERSION` : MP_UINT -- an encoded representation of the server version of a replica issuing the request.