### PR TITLE
fiber: fix use-after-free on shutdown with lingering fiber join

### DIFF
--- a/changelogs/unreleased/gh-9406-fix-use-after-free-on-shutdown.md
+++ b/changelogs/unreleased/gh-9406-fix-use-after-free-on-shutdown.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed potential use-after-free on Tarantool shutdown with lingering
+  fiber join (gh-9406).

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -1576,6 +1576,7 @@ fiber_destroy(struct cord *cord, struct fiber *f)
 	trigger_destroy(&f->on_stop);
 	rlist_del(&f->state);
 	rlist_del(&f->link);
+	rlist_del(&f->wake);
 #ifdef ENABLE_BACKTRACE
 	region_set_callbacks(&f->gc, NULL, NULL, NULL);
 #endif
@@ -1764,6 +1765,7 @@ cord_create(struct cord *cord, const char *name)
 	/* sched fiber is not present in alive/ready/dead list. */
 	rlist_create(&cord->sched.state);
 	rlist_create(&cord->sched.link);
+	rlist_create(&cord->sched.wake);
 	cord->sched.fid = FIBER_ID_SCHED;
 	fiber_reset(&cord->sched);
 	diag_create(&cord->sched.diag);


### PR DESCRIPTION
On Tarantool shutdown we destroy all the fibers in some sequence. We don't require that all the fibers are finished before shutdown. So it may turn out that we first destroy some alive fiber and then destroy another alive fiber which joins the first one. Currently we have use-after-free issue in this case because clearing `link` field of the second fiber changes `wake` field of the first fiber.

Close #9406