### PR TITLE
config: introduce options for storage, add source file to the build

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -64,6 +64,7 @@ lua_source(lua_sources lua/config/utils/tabulate.lua      config_utils_tabulate_
 if (ENABLE_CONFIG_EXTRAS)
     lua_source(lua_sources ${CONFIG_EXTRAS_DIR}/source/etcd.lua config_source_etcd_lua)
     lua_source(lua_sources ${CONFIG_EXTRAS_DIR}/storage/init.lua config_storage_init_lua)
+    lua_source(lua_sources ${CONFIG_EXTRAS_DIR}/source/storage.lua config_source_storage_lua)
     lua_source(lua_sources ${CONFIG_EXTRAS_DIR}/extras.lua config_extras_lua)
 endif()
 # }}} config

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -484,6 +484,83 @@ return schema.new('instance_config', schema.record({
                 end
             end,
         })),
+        storage = enterprise_edition(schema.record({
+            prefix = schema.scalar({
+                type = 'string',
+                validate = function(data, w)
+                    if not data:startswith('/') then
+                        w.error(('config.storage.prefix should be ' ..
+                            'a path alike value, got %q'):format(data))
+                    end
+                end,
+            }),
+            endpoints = schema.array({
+                items = schema.record({
+                    uri = schema.scalar({
+                        type = 'string',
+                    }),
+                    login = schema.scalar({
+                        type = 'string',
+                    }),
+                    password = schema.scalar({
+                        type = 'string',
+                    }),
+                    params = schema.record({
+                        transport = schema.enum({
+                            'plain',
+                            'ssl',
+                        }),
+                        ssl_key_file = enterprise_edition(schema.scalar({
+                            type = 'string',
+                        })),
+                        ssl_cert_file = enterprise_edition(schema.scalar({
+                            type = 'string',
+                        })),
+                        ssl_ca_file = enterprise_edition(schema.scalar({
+                            type = 'string',
+                        })),
+                        ssl_ciphers = enterprise_edition(schema.scalar({
+                            type = 'string',
+                        })),
+                        ssl_password = enterprise_edition(schema.scalar({
+                            type = 'string',
+                        })),
+                        ssl_password_file = enterprise_edition(schema.scalar({
+                            type = 'string',
+                        })),
+                    }),
+                }),
+                validate = function(data, w)
+                    if #data == 0 then
+                        w.error('At least one endpoint must be' ..
+                            'specified in config.storage.endpoints')
+                    end
+                end,
+            }),
+            timeout = schema.scalar({
+                type = 'number',
+                default = 3,
+            }),
+            reconnect_after = schema.scalar({
+                type = 'number',
+                default = 3,
+            })
+        }, {
+            validate = function(data, w)
+                if data == nil or next(data) == nil then
+                    return
+                end
+                if data.prefix == nil and data.endpoints == nil then
+                    return
+                end
+                if data.prefix == nil then
+                    w.error('No config.storage.prefix provided')
+                end
+                if data.endpoints == nil then
+                    w.error('No config.storage.endpoints provided')
+                end
+            end
+        })),
     }),
     process = schema.record({
         strip_core = schema.scalar({

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -166,6 +166,7 @@ extern char session_lua[],
 	,
 	config_source_etcd_lua[],
 	config_storage_init_lua[],
+	config_source_storage_lua[],
 	config_extras_lua[]
 #endif
 	;
@@ -373,6 +374,10 @@ static const char *lua_sources[] = {
 	"config/source/etcd",
 	"internal.config.source.etcd",
 	config_source_etcd_lua,
+
+	"config/source/storage",
+	"internal.config.source.storage",
+	config_source_storage_lua,
 
 	"config/extras",
 	"internal.config.extras",

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -264,6 +264,10 @@ g.test_defaults = function()
         },
         config = {
             reload = 'auto',
+            storage = {
+                timeout = 3,
+                reconnect_after = 3,
+            },
         },
         feedback = box.internal.feedback_daemon ~= nil and {
             crashinfo = true,

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -80,6 +80,10 @@ g.test_config = function()
 
     local exp = {
         reload = 'auto',
+        storage = {
+            timeout = 3,
+            reconnect_after = 3,
+        }
     }
     local res = instance_config:apply_default({}).config
     t.assert_equals(res, exp)
@@ -109,7 +113,26 @@ g.test_config_enterprise = function()
                     verify_peer = true,
                     verify_host = false,
                 },
-            }
+            },
+            storage = {
+                prefix = '/one',
+                endpoints = {{
+                    uri = 'two',
+                    login = 'three',
+                    password = 'four',
+                    params = {
+                        transport = 'ssl',
+                        ssl_key_file = 'five',
+                        ssl_cert_file = 'six',
+                        ssl_ca_file = 'seven',
+                        ssl_ciphers = 'eight',
+                        ssl_password = 'nine',
+                        ssl_password_file = 'ten',
+                    },
+                }},
+                timeout = 1.1,
+                reconnect_after = 1.2,
+            },
         },
     }
     instance_config:validate(iconfig)
@@ -129,6 +152,10 @@ g.test_config_enterprise = function()
 
     local exp = {
         reload = 'auto',
+        storage = {
+            timeout = 3,
+            reconnect_after = 3,
+        }
     }
     local res = instance_config:apply_default({}).config
     t.assert_equals(res, exp)


### PR DESCRIPTION
This patchs adds config options for tarantool config storage, as fhis feature will be implemented in EE.
Also, adds the source file to the build.

Part of https://github.com/tarantool/tarantool-ee/issues/593