### PR TITLE
replication: make yield more often when recovering from long WAL

### DIFF
--- a/changelogs/unreleased/gh-9094-recovery-from-long-WAL.md
+++ b/changelogs/unreleased/gh-9094-recovery-from-long-WAL.md
@@ -1,0 +1,5 @@
+# bugfix/replication
+
+* Now at replication no stop sending heartbeats during WAL scan. This prevents
+  relay from timing out when a freshly subscribed replica needs rows from the
+  end of a long `.xlog` (gh-9094).

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -218,6 +218,7 @@ applier_thread_writer_f(va_list ap)
 			ERROR_INJECT(ERRINJ_APPLIER_SLOW_ACK, {
 				fiber_sleep(0.01);
 			});
+			//say_info("Sent ACK");
 			/*
 			 * Even if new ACK is requested during the
 			 * write, don't send it again right away.

--- a/src/box/recovery.cc
+++ b/src/box/recovery.cc
@@ -142,7 +142,8 @@ recovery_scan(struct recovery *r, struct vclock *end_vclock,
 	struct xrow_header row;
 	while (xlog_cursor_next(&cursor, &row, true) == 0) {
 		vclock_follow_xrow(end_vclock, &row);
-		if (++stream->row_count % WAL_ROWS_PER_YIELD == 0)
+		//if (++stream->row_count % WAL_ROWS_PER_YIELD == 0)
+		if (++stream->row_count % 1 == 0)
 			xstream_yield(stream);
 	}
 	xlog_cursor_close(&cursor, false);
@@ -250,7 +251,8 @@ recover_xlog(struct recovery *r, struct xstream *stream,
 	struct xrow_header row;
 	while (xlog_cursor_next_xc(&r->cursor, &row,
 				   r->wal_dir.force_recovery) == 0) {
-		if (++stream->row_count % WAL_ROWS_PER_YIELD == 0) {
+		//if (++stream->row_count % WAL_ROWS_PER_YIELD == 0) {
+		if (++stream->row_count % 1 == 0) {
 			xstream_yield(stream);
 		}
 		if (stream->row_count % 100000 == 0) {

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -1486,7 +1486,7 @@ wal_watcher_detach(void *arg)
 	assert(!rlist_empty(&watcher->next));
 	rlist_del_entry(watcher, next);
 }
-
+//-->
 void
 wal_set_watcher(struct wal_watcher *watcher, const char *name,
 		void (*watcher_cb)(struct wal_watcher *, unsigned events),

--- a/src/box/wal.h
+++ b/src/box/wal.h
@@ -68,7 +68,7 @@ enum {
 	 * applied from WAL. It allows not to block the event
 	 * loop for the whole recovery stage.
 	 */
-	WAL_ROWS_PER_YIELD = 1 << 15,
+	WAL_ROWS_PER_YIELD = 1 << 0,
 };
 
 /** String constants for the supported modes. */

--- a/src/box/wal.h
+++ b/src/box/wal.h
@@ -62,14 +62,14 @@ enum wal_mode {
 	WAL_MODE_MAX
 };
 
-enum {
-	/**
-	 * Recovery yields once per that number of rows read and
-	 * applied from WAL. It allows not to block the event
-	 * loop for the whole recovery stage.
-	 */
-	WAL_ROWS_PER_YIELD = 1 << 0,
-};
+// enum {
+// 	/**
+// 	 * Recovery yields once per that number of rows read and
+// 	 * applied from WAL. It allows not to block the event
+// 	 * loop for the whole recovery stage.
+// 	 */
+// 	WAL_ROWS_PER_YIELD = 1 << 0,
+// };
 
 /** String constants for the supported modes. */
 extern const char *wal_mode_STRS[];

--- a/test/replication-luatest/gh_9094_recovery_from_long_wal_test.lua
+++ b/test/replication-luatest/gh_9094_recovery_from_long_wal_test.lua
@@ -1,0 +1,59 @@
+local t = require('luatest')
+local cluster = require('luatest.replica_set')
+local server = require('luatest.server')
+local fiber = require('fiber')
+
+local g = t.group('gh_9094')
+
+g.before_all(function(cg)
+    cg.cluster = cluster:new({})
+    cg.master = cg.cluster:build_and_add_server{
+        alias = 'master',
+        box_cfg = {
+            replication_timeout = 0.01,
+        },
+    }
+    cg.replica = cg.cluster:build_and_add_server{
+        alias = 'replica',
+        box_cfg = {
+            replication = {
+                cg.master.net_box_uri,
+            },
+            replication_timeout = 0.01,
+            read_only = true,
+        },
+    }
+    cg.cluster:start()
+end)
+
+g.after_all(function(cg)
+    cg.cluster:drop()
+end)
+
+g.test_recovery = function(cg)
+    cg.master:exec(function()
+        box.schema.space.create('test')
+        box.space.test:create_index('pk')
+        for i = 1, 1000000 do
+            box.space.test:insert{i}
+        end
+
+    end)
+
+    cg.replica:stop()
+
+    cg.master:exec(function()
+        box.space.test:insert{1000001}
+        box.space.test:insert{1000002}
+        box.space.test:insert{1000003}
+        box.space.test:insert{1000004}
+    end)
+
+    cg.master:restart()
+    cg.replica:start()
+
+    t.helpers.retrying({}, function()
+        cg.replica:assert_follows_upstream(1)
+    end)
+
+end

--- a/test/small
+++ b/test/small
@@ -1,1 +1,1 @@
-../src/lib/small/test/
+/home/yan/Projects/Mail/Tarantool/tarantool/test/../src/lib/small/test/


### PR DESCRIPTION
As soon as replica subscribes, relay starts scanning the first requested WAL file to find the position from which to start replication. If a replica connects and needs data from the end of a really long WAL, recovery will read up to the needed position without yields, making relay disconnect by replication_disconnect_timeout. This issue was already found and fixed before: ee6de02. To fix this problem, make sure that when recovering, a yield occurs after each WAL row. In this case, the recovery time from WAL will increase by approximately 50 percent.

Closes #9094

NO_DOC=bugfix