### PR TITLE
lua: prevent serialization of error for ucdata

### DIFF
--- a/changelogs/unreleased/gh-9396-ucdata-serialize-error.md
+++ b/changelogs/unreleased/gh-9396-ucdata-serialize-error.md
@@ -1,0 +1,4 @@
+## bugfix/lua
+
+* An error from a serializer function for cdata and userdata is not ignored now
+  (gh-9396).

--- a/src/lua/serializer.c
+++ b/src/lua/serializer.c
@@ -274,7 +274,10 @@ lua_field_inspect_ucdata(struct lua_State *L, struct luaL_serializer *cfg,
 		}
 		/* copy object itself */
 		lua_pushvalue(L, idx);
-		lua_pcall(L, 1, 1, 0);
+		if (lua_pcall(L, 1, 1, 0) != LUA_OK) {
+			diag_set(LuajitError, lua_tostring(L, -1));
+			return -1;
+		}
 		/* replace obj with the unpacked value */
 		lua_replace(L, idx);
 		if (luaL_tofield(L, cfg, idx, field) < 0)

--- a/test/app-luatest/gh_9396_ucdata_serialize_error_test.lua
+++ b/test/app-luatest/gh_9396_ucdata_serialize_error_test.lua
@@ -1,0 +1,18 @@
+local t = require('luatest')
+local g = t.group()
+
+-- XXX: Use `yaml.encode()` to trigger a serialization error.
+local yaml = require('yaml')
+
+local ERRMSG = 'error in serializer'
+
+g.test_error_in_ucdata_serializer = function()
+    local ud_mt = {__serialize = function()
+        error(ERRMSG)
+    end}
+    ud_mt.__index = ud_mt
+    local ud = newproxy(true)
+    debug.setmetatable(ud, ud_mt)
+    -- XXX: This helper fails if there is no error raised.
+    t.assert_error_msg_matches('.*' .. ERRMSG, yaml.encode, ud)
+end


### PR DESCRIPTION
The alternative solution is to use just `lua_call()` instead, since the error should be caught somewhere in the upper frames.
```diff
diff --git a/src/lua/serializer.c b/src/lua/serializer.c
index 1018f9572..56400e7f3 100644
--- a/src/lua/serializer.c
+++ b/src/lua/serializer.c
@@ -274,7 +274,11 @@ lua_field_inspect_ucdata(struct lua_State *L, struct luaL_serializer *cfg,
                 }
                 /* copy object itself */
                 lua_pushvalue(L, idx);
-                lua_pcall(L, 1, 1, 0);
+                /*
+                 * The possible error should be catched in some
+                 * upper frame.
+                 */
+                lua_call(L, 1, 1);
                 /* replace obj with the unpacked value */
                 lua_replace(L, idx);
                 if (luaL_tofield(L, cfg, idx, field) < 0)
```

The results of the benchmark below for both ways are quite similar, so I prefer the most common way (the one in the patch):
```sh
time src/tarantool -e "                                                                
local yml = require'yaml'
local ud_mt = {__serialize = function()
  return ''
end}
ud_mt.__index = ud_mt
local ud = newproxy(true)
debug.setmetatable(ud, ud_mt)
collectgarbage('stop')
for _ = 1, 3e6 do
    yml.encode(ud)
end
"  
```

|`lua_pcall()` | `lua_call()` |
|--|--|
| $4.896s\ (\sigma=0.037$) | $4.879s\ (\sigma=0.034$) |