### PR TITLE
config: allow to configure an anonymous replica

### DIFF
--- a/changelogs/unreleased/config-anonymous-replica.md
+++ b/changelogs/unreleased/config-anonymous-replica.md
@@ -5,9 +5,6 @@
 
   There are caveats that are not resolved yet:
 
-  * An attempt to configure a replicaset where all instances are anonymous
-    replicas should lead to an error on config validation, before configuration
-    applying.
   * An attempt to configure an anonymous replica in read-write mode (using
     `database.mode` or `<replicaset>.leader`) should lead to an error on config
     validation, before configuration applying.

--- a/changelogs/unreleased/config-anonymous-replica.md
+++ b/changelogs/unreleased/config-anonymous-replica.md
@@ -5,8 +5,6 @@
 
   There are caveats that are not resolved yet:
 
-  * An anonymous replica shouldn't be chosen as a bootstrap leader in
-    `replication.failover: supervised` mode.
   * An attempt to configure a replicaset where all instances are anonymous
     replicas should lead to an error on config validation, before configuration
     applying.

--- a/changelogs/unreleased/config-anonymous-replica.md
+++ b/changelogs/unreleased/config-anonymous-replica.md
@@ -1,0 +1,25 @@
+## bugfix/config
+
+* Effectively supported `replication.anon` option, which was broken in several
+  ways before (gh-9432).
+
+  There are caveats that are not resolved yet:
+
+  * An anonymous replica shouldn't be used as an upstream for non-anonymous
+    replica.
+  * An anonymous replica possibly shouldn't be used as an upstream for other
+    anonymous replicas by default.
+  * An anonymous replica shouldn't be chosen as a bootstrap leader in
+    `replication.failover: supervised` mode.
+  * An attempt to configure a replicaset where all instances are anonymous
+    replicas should lead to an error on config validation, before configuration
+    applying.
+  * An attempt to configure an anonymous replica in read-write mode (using
+    `database.mode` or `<replicaset>.leader`) should lead to an error on config
+    validation, before configuration applying.
+  * An attempt to configure an anonymous replica with
+    `replication.election_mode` != `off` should lead to an error on config
+    validation, before configuration applying.
+  * An anonymous replica can't be bootstrapped from a replicaset, where all the
+    instance are in read-only mode, however there are no technical problems
+    there (just too tight validation).

--- a/changelogs/unreleased/config-anonymous-replica.md
+++ b/changelogs/unreleased/config-anonymous-replica.md
@@ -2,9 +2,3 @@
 
 * Effectively supported `replication.anon` option, which was broken in several
   ways before (gh-9432).
-
-  There are caveats that are not resolved yet:
-
-  * An anonymous replica can't be bootstrapped from a replicaset, where all the
-    instance are in read-only mode, however there are no technical problems
-    there (just too tight validation).

--- a/changelogs/unreleased/config-anonymous-replica.md
+++ b/changelogs/unreleased/config-anonymous-replica.md
@@ -5,10 +5,6 @@
 
   There are caveats that are not resolved yet:
 
-  * An anonymous replica shouldn't be used as an upstream for non-anonymous
-    replica.
-  * An anonymous replica possibly shouldn't be used as an upstream for other
-    anonymous replicas by default.
   * An anonymous replica shouldn't be chosen as a bootstrap leader in
     `replication.failover: supervised` mode.
   * An attempt to configure a replicaset where all instances are anonymous

--- a/changelogs/unreleased/config-anonymous-replica.md
+++ b/changelogs/unreleased/config-anonymous-replica.md
@@ -5,12 +5,6 @@
 
   There are caveats that are not resolved yet:
 
-  * An attempt to configure an anonymous replica in read-write mode (using
-    `database.mode` or `<replicaset>.leader`) should lead to an error on config
-    validation, before configuration applying.
-  * An attempt to configure an anonymous replica with
-    `replication.election_mode` != `off` should lead to an error on config
-    validation, before configuration applying.
   * An anonymous replica can't be bootstrapped from a replicaset, where all the
     instance are in read-only mode, however there are no technical problems
     there (just too tight validation).

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -369,6 +369,10 @@ local function apply(config)
         --
         -- * 1 instance: read-write.
         -- * >1 instances: read-only.
+        --
+        -- NB: configdata.lua verifies that there is at least one
+        -- non-anonymous instance. So, an anonymous replica is
+        -- read-only by default.
         local mode = configdata:get('database.mode', {use_default = true})
         if mode == 'ro' then
             box_cfg.read_only = true

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -436,7 +436,8 @@ local function apply(config)
         -- the following.
         --
         -- * Look over the peer names of the replicaset and choose
-        --   the minimal name (compare them lexicographically).
+        --   the minimal name across all non-anonymous instances
+        --   (compare them lexicographically).
         -- * The instance with the minimal name starts in the RW
         --   mode to be able to bootstrap the replicaset if there
         --   is no local snapshot. Otherwise, it starts as usual,

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -348,6 +348,7 @@ local function apply(config)
 
     local failover = configdata:get('replication.failover',
         {use_default = true})
+    local is_anon = configdata:get('replication.anon', {use_default = true})
 
     -- Read-only or read-write?
     if failover == 'off' then
@@ -525,8 +526,12 @@ local function apply(config)
 
     -- Names are applied only if they're already in snap file.
     -- Otherwise, master must apply names after box.cfg asynchronously.
+    --
+    -- Note: an anonymous replica has no an entry in the _cluster
+    -- system space, so it can't have a persistent instance name.
+    -- It is never returned by :missing_names().
     local missing_names = configdata:missing_names()
-    if not missing_names._peers[names.instance_name] then
+    if not is_anon and not missing_names._peers[names.instance_name] then
         box_cfg.instance_name = names.instance_name
     end
     if not missing_names[names.replicaset_name] then

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -646,10 +646,9 @@ local function apply(config)
         -- already registered. We should decide what to do in the
         -- case.
         --
-        -- TODO: An anonymous replica is not to be registered in
+        -- Note: an anonymous replica is not to be registered in
         -- _cluster. So, it can subscribe to such a replicaset.
-        -- We should decide what to do in the case.
-        if in_replicaset and not has_snap then
+        if in_replicaset and not has_snap and not is_anon then
             local has_rw = false
             if failover == 'off' then
                 for _, peer_name in ipairs(configdata:peers()) do

--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -568,7 +568,18 @@ local function new(iconfig, cconfig, instance_name)
                 found.replicaset_name), 0)
         end
         assert(bootstrap_leader == nil)
-        bootstrap_leader_name = peer_names[1]
+
+        -- Choose first non-anonymous instance.
+        for _, peer_name in ipairs(peer_names) do
+            assert(peers[peer_name] ~= nil)
+            local iconfig_def = peers[peer_name].iconfig_def
+            local is_anon = instance_config:get(iconfig_def, 'replication.anon')
+            if not is_anon then
+                bootstrap_leader_name = peer_name
+                break
+            end
+        end
+        assert(bootstrap_leader_name ~= nil)
     end
 
     -- Names and UUIDs are always validated: during instance start

--- a/test/config-luatest/anonymous_replica_test.lua
+++ b/test/config-luatest/anonymous_replica_test.lua
@@ -1,0 +1,61 @@
+local t = require('luatest')
+local cbuilder = require('test.config-luatest.cbuilder')
+local replicaset = require('test.config-luatest.replicaset')
+
+local g = t.group()
+
+g.before_all(replicaset.init)
+g.after_each(replicaset.drop)
+g.after_all(replicaset.clean)
+
+-- Verify that an anonymous replica can be started and joined to
+-- a replicaset.
+--
+-- This test excludes the `replication.peers` autoconstruction
+-- logic by defining the option on its own. This automatic
+-- construction is verified in a separate test case (TODO).
+g.test_basic = function(g)
+    -- One master, two replicas, two anonymous replicas.
+    local config = cbuilder.new()
+        :set_replicaset_option('replication.peers', {
+            'replicator:secret@unix/:./instance-001.iproto',
+            'replicator:secret@unix/:./instance-002.iproto',
+            'replicator:secret@unix/:./instance-003.iproto',
+        })
+        :add_instance('instance-001', {
+            database = {
+                mode = 'rw',
+            },
+        })
+        :add_instance('instance-002', {})
+        :add_instance('instance-003', {})
+        :add_instance('instance-004', {
+            replication = {
+                anon = true,
+            },
+        })
+        :add_instance('instance-005', {
+            replication = {
+                anon = true,
+            },
+        })
+        :config()
+
+    local replicaset = replicaset.new(g, config)
+    replicaset:start()
+
+    -- Verify that all the instances are healthy.
+    replicaset:each(function(server)
+        server:exec(function()
+            t.assert_equals(box.info.status, 'running')
+        end)
+    end)
+
+    -- Verify that the anonymous replicas are actually anonymous.
+    replicaset['instance-004']:exec(function()
+        t.assert_equals(box.info.id, 0)
+    end)
+    replicaset['instance-005']:exec(function()
+        t.assert_equals(box.info.id, 0)
+    end)
+end

--- a/test/config-luatest/anonymous_replica_test.lua
+++ b/test/config-luatest/anonymous_replica_test.lua
@@ -13,7 +13,7 @@ g.after_all(replicaset.clean)
 --
 -- This test excludes the `replication.peers` autoconstruction
 -- logic by defining the option on its own. This automatic
--- construction is verified in a separate test case (TODO).
+-- construction is verified in a separate test case.
 g.test_basic = function(g)
     -- One master, two replicas, two anonymous replicas.
     local config = cbuilder.new()
@@ -57,5 +57,61 @@ g.test_basic = function(g)
     end)
     replicaset['instance-005']:exec(function()
         t.assert_equals(box.info.id, 0)
+    end)
+end
+
+-- Verify that an anonymous replica is not used as an upstream for
+-- other instances of the same replicaset.
+g.test_no_anonymous_upstream = function(g)
+    -- One master, two replicas, two anonymous replicas.
+    --
+    -- NB: It is the same as config in `test_basic`, but has no
+    -- `replication.peers` option.
+    local config = cbuilder.new()
+        :add_instance('instance-001', {
+            database = {
+                mode = 'rw',
+            },
+        })
+        :add_instance('instance-002', {})
+        :add_instance('instance-003', {})
+        :add_instance('instance-004', {
+            replication = {
+                anon = true,
+            },
+        })
+        :add_instance('instance-005', {
+            replication = {
+                anon = true,
+            },
+        })
+        :config()
+
+    local replicaset = replicaset.new(g, config)
+    replicaset:start()
+
+     -- Verify that the anonymous replicas are actually anonymous.
+    replicaset['instance-004']:exec(function()
+        t.assert_equals(box.info.id, 0)
+    end)
+    replicaset['instance-005']:exec(function()
+        t.assert_equals(box.info.id, 0)
+    end)
+
+    -- Verify box.cfg.replication on all instances.
+    --
+    -- NB: We can check box.info.replication as well, but it just
+    -- adds extra code and doesn't improve coverage of upstream
+    -- list construction logic.
+    replicaset:each(function(server)
+        server:exec(function()
+            t.assert_equals(box.cfg.replication, {
+                'replicator:secret@unix/:./instance-001.iproto',
+                'replicator:secret@unix/:./instance-002.iproto',
+                'replicator:secret@unix/:./instance-003.iproto',
+                -- No instance-{004,005}, because they're
+                -- anonymous replicas.
+            })
+        end)
     end)
 end


### PR DESCRIPTION
`replication.anon: true` option is now working.

Mostly, it is the only thing that a user needs to know about this changeset.

However, technically speaking, several related configuration checks are introduced here and dependent defaults were adjusted to make usage of anonymous replicas smoother.

The new configuration constrainsts are the following.
    
* A replicaset must contain at least one non-anonymous instance.
* An anonymous replica can't be configured as writable instance using `database.mode` or `<replicaset>.leader` options.
* An anonymous replica can't be configured with `replication.election_mode` equals to `candidate`, `voter` or `manual` (only `off` is allowed).

A few more nuances about anonymous replicas:

* Anonymous replicas are filtered out from default upstream list.
* A `replication.failover: election` replicaset can contain anonymous replicas, but `replication.election_mode` defaults to `off` for them (unlike non-anonymous instances, where the default is `candidate`).
* `replication.failover: supervised` skips anonymous replicas, when choosing a bootstrap leader.
* A anonymous replica can joined a replicaset, which has all the instances in read-only mode (unlike a non-anonymous instance).

Please, check out commits of the patchset for more detailed description of the constrains and nuances.

Fixes #9432