### PR TITLE
test: do not produce coredumps in tests

### DIFF
--- a/src/lib/core/crash.c
+++ b/src/lib/core/crash.c
@@ -15,9 +15,13 @@
 #include "core/backtrace.h"
 #include "crash.h"
 #include "say.h"
+#include "tweaks.h"
 
 /** Storage for crash_collect function return value. */
 static struct crash_info crash_info;
+
+bool crash_produce_coredump = true;
+TWEAK_BOOL(crash_produce_coredump);
 
 /**
  * The routine is called inside crash signal handler so
@@ -186,6 +190,9 @@ crash_signal_cb(int signo, siginfo_t *siginfo, void *context)
 		/* Got a signal while running the handler. */
 		fprintf(stderr, "Fatal %d while backtracing\n", signo);
 	}
+
+	if (!crash_produce_coredump)
+		exit(EXIT_FAILURE);
 
 	/* Try to dump a core */
 	struct sigaction sa = {

--- a/src/lib/core/crash.h
+++ b/src/lib/core/crash.h
@@ -13,6 +13,9 @@
 extern "C" {
 #endif /* defined(__cplusplus) */
 
+/** If reset, do not produce coredump on crash. */
+extern bool crash_produce_coredump;
+
 #if TARGET_OS_LINUX && defined(__x86_64__)
 # define HAS_GREG
 #endif

--- a/src/lib/core/errinj.h
+++ b/src/lib/core/errinj.h
@@ -33,6 +33,7 @@
 #include <limits.h>
 #include <stddef.h>
 #include "trivia/util.h"
+#include "crash.h"
 #if defined(__cplusplus)
 extern "C" {
 #endif /* defined(__cplusplus) */
@@ -261,8 +262,9 @@ void errinj_set_with_environment_vars(void);
 #define ERROR_INJECT_RETURN(ID) ERROR_INJECT(ID, return -1)
 #define ERROR_INJECT_SLEEP(ID) ERROR_INJECT_WHILE(ID, usleep(1000))
 #define ERROR_INJECT_YIELD(ID) ERROR_INJECT_WHILE(ID, fiber_sleep(0.001))
-#define ERROR_INJECT_TERMINATE(ID) ERROR_INJECT(ID, assert(0))
-#define ERROR_INJECT_SIGILL(ID) ERROR_INJECT(ID, illegal_instruction())
+#define ERROR_INJECT_TERMINATE(ID) ERROR_INJECT(ID, exit(EXIT_FAILURE))
+#define ERROR_INJECT_SIGILL(ID) ERROR_INJECT(ID, \
+		{ crash_produce_coredump = false; illegal_instruction(); })
 #define ERROR_INJECT_INT(ID, COND, CODE) ERROR_INJECT_COND(ID, ERRINJ_INT, COND, CODE)
 #define ERROR_INJECT_DOUBLE(ID, COND, CODE) ERROR_INJECT_COND(ID, ERRINJ_DOUBLE, COND, CODE)
 

--- a/test/app-luatest/gh_8445_crash_during_crash_report_test.lua
+++ b/test/app-luatest/gh_8445_crash_during_crash_report_test.lua
@@ -18,10 +18,15 @@ g.test_crash_during_crash_report = function(cg)
     -- Use `cd' and `shell = true' due to lack of cwd option in popen (gh-5633).
     local exe = arg[-1]
     local dir = cg.tempdir
-    local cmd = [[
-        cd %s && %s -e "box.cfg{} require('log').info('pid = ' .. box.info.pid)"
+    local script = [[
+        local tweaks = require('internal.tweaks')
+        local log = require('log')
+        box.cfg{}
+        tweaks.crash_produce_coredump = false
+        log.info('pid = ' .. box.info.pid)
     ]]
-    local ph = popen.new({string.format(cmd, dir, exe)},
+    local ph = popen.new({string.format('cd %s && %s -e "%s"',
+                                         dir, exe, script)},
                          {stdout = popen.opts.DEVNULL,
                           stderr = popen.opts.PIPE, shell = true})
     t.assert(ph)


### PR DESCRIPTION
Test suite run can produce coredumps in case of bugs. Unfortunately coredumps related to bugs are mixed with coredumps produced related to special test conditions, like when we test Tarantool response to deadly signal. Avoid producing coredumps in correct test suite run.