### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9145-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9145-luajit-fixes.md
@@ -22,3 +22,4 @@ were fixed as part of this activity:
 * Fixed possible storing of NaN keys to table on trace.
 * Fixed ABC FOLD optimization with constants.
 * Marked `CONV` as non-weak, to prevent invalid control flow path choice.
+* Fixed CSE of a `REF_BASE` operand across `IR_RETF`.


### PR DESCRIPTION
* Prevent CSE of a REF_BASE operand across IR_RETF.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump