### PR TITLE
journal: broadcast `box.wal_error` event on write error

### DIFF
--- a/changelogs/unreleased/gh-9405-wal-error-event.md
+++ b/changelogs/unreleased/gh-9405-wal-error-event.md
@@ -1,0 +1,5 @@
+## feature/core
+
+* Introduced the new built-in system event `box.wal_error` that is broadcast
+  whenever Tarantool fails to commit a transaction to the write-ahead log
+  (gh-9405).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -5634,6 +5634,7 @@ builtin_events_init(void)
 	box_broadcast_fmt("box.schema", "{}");
 	box_broadcast_fmt("box.status", "{}");
 	box_broadcast_fmt("box.election", "{}");
+	box_broadcast_fmt("box.wal_error", "{}");
 	box_broadcast_fmt(box_ballot_event_key, "{}");
 	ev_timer_init(&box_broadcast_ballot_timer,
 		      box_broadcast_ballot_on_timeout, 0, 0);

--- a/src/box/journal.c
+++ b/src/box/journal.c
@@ -32,6 +32,7 @@
 #include <small/region.h>
 #include <diag.h>
 #include "error.h"
+#include "watcher.h"
 
 struct journal *current_journal = NULL;
 
@@ -46,9 +47,13 @@ void
 diag_set_journal_res_detailed(const char *file, unsigned line, int64_t res)
 {
 	switch(res) {
-	case JOURNAL_ENTRY_ERR_IO:
+	case JOURNAL_ENTRY_ERR_IO: {
+		static uint64_t io_error_count;
+		box_broadcast_fmt("box.wal_error", "{%s%llu}",
+				  "count", ++io_error_count);
 		diag_set_detailed(file, line, ClientError, ER_WAL_IO);
 		return;
+	}
 	case JOURNAL_ENTRY_ERR_CASCADE:
 		diag_set_detailed(file, line, ClientError, ER_CASCADE_ROLLBACK);
 		return;

--- a/test/box-luatest/gh_9405_wal_error_event_test.lua
+++ b/test/box-luatest/gh_9405_wal_error_event_test.lua
@@ -1,0 +1,53 @@
+local net = require('net.box')
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug();
+    cg.server = server:new()
+    cg.server:start()
+    cg.server:exec(function()
+        local s = box.schema.create_space('test')
+        s:create_index('pk')
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+    cg.server = nil
+end)
+
+g.test_wal_error_event = function(cg)
+    local conn = net.connect(cg.server.net_box_uri);
+    local event = {}
+    conn:watch('box.wal_error', function(k, v)
+        event[k] = v
+    end)
+    t.helpers.retrying({}, function()
+        t.assert_type(event['box.wal_error'], 'table')
+    end)
+    local count = event['box.wal_error'].count
+    cg.server:exec(function()
+        local s = box.space.test
+        for i = 1, 10 do
+            s:replace({i})
+        end
+    end)
+    t.assert_equals(event['box.wal_error'], {count = count})
+    cg.server:exec(function()
+        local s = box.space.test
+        local errinj = box.error.injection
+        errinj.set('ERRINJ_WAL_FALLOCATE', 10)
+        for i = 1, 10 do
+            t.assert_error_msg_equals('Failed to write to disk',
+                                      s.replace, s, {i})
+            t.assert_equals(errinj.get('ERRINJ_WAL_FALLOCATE'), 10 - i)
+        end
+    end)
+    count = (count or 0) + 10
+    t.helpers.retrying({}, function()
+        t.assert_equals(event['box.wal_error'], {count = count})
+    end)
+end


### PR DESCRIPTION
The new event is broadcast whenever Tarantool fails to commit a transaction to the write-ahead log (WAL), which usually means there's a problem with the underlying disk storage. The new event's payload is a table that currently contains the only field `count` that stores the number of WAL errors happened so far or nil if there hasn't been any WAL errors.

Closes #9405