### PR TITLE
box: fix the comparison in the functions cache

### DIFF
--- a/changelogs/unreleased/gh-9426-func-cache.md
+++ b/changelogs/unreleased/gh-9426-func-cache.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed a very rare bug when a function deletion could cause an inconsistent
+  state of the database (gh-9426).

--- a/src/box/func_cache.c
+++ b/src/box/func_cache.c
@@ -66,7 +66,7 @@ func_cache_delete(uint32_t fid)
 	mh_i32ptr_del(funcs, k, NULL);
 	k = mh_strnptr_find_str(funcs_by_name, func->def->name,
 				strlen(func->def->name));
-	if (k != mh_end(funcs))
+	if (k != mh_end(funcs_by_name))
 		mh_strnptr_del(funcs_by_name, k, NULL);
 }
 

--- a/test/box-luatest/gh_9426_func_cache_test.lua
+++ b/test/box-luatest/gh_9426_func_cache_test.lua
@@ -1,0 +1,29 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_func_cache = function(cg)
+    cg.server:exec(function()
+        -- See the explanation in the #9426.
+        box.schema.func.create('tortoise')
+        box.schema.func.create('dog')
+        box.schema.func.drop('tortoise')
+        box.schema.func.create('mouse')
+        box.schema.func.create('chicken')
+        box.schema.func.create('horse')
+        box.schema.func.create('rat')
+        box.schema.func.drop('horse')
+        box.schema.func.create('horse')
+        t.assert_equals(box.schema.func.exists('horse'), true)
+    end)
+end


### PR DESCRIPTION
Before this patch it could happen that deletion of a function from the function cache didn't delete it from the funcs_by_name map. The reason is that the check if the function exists in the map performs the comparison of the search result with the `end` backet id of the wrong hash table.

The situation in which this could happen is the following:
1. Insertion of a new function into the cache triggers resize of thefuncs_by_value map, but the size of the funcs map remains the same.
2. Then user deletes a function. This removes the function from the funcs map. Then we check if the function exists in thefuncs_by_value map. The function exists there, but it so happens that it's bucket id equals to the funcs map bucket count, so the incorrect check if the function exists in the funcs_by_value map states that the function does not exist there, so it's not dropped from the map.
3. Now we have the following result: the function is referenced inthe funcs_by_value map, but not in funcs map. This triggers the assertion failure on any attempt to insert a new function with the same name.

Closes #9426

NO_DOC=bugfix