### PR TITLE
vinyl: fix memory leak in vy_task_write_run

### DIFF
--- a/src/box/vy_run.c
+++ b/src/box/vy_run.c
@@ -2363,6 +2363,7 @@ vy_run_writer_commit(struct vy_run_writer *writer)
 			       writer->space_id, writer->iid) != 0)
 		goto out;
 
+	vy_run_writer_destroy(writer);
 	rc = 0;
 out:
 	region_truncate(&fiber()->gc, region_svp);


### PR DESCRIPTION
Looks like this is typo introduced in the commit 0704ebb778d4 ("xlog: rework writer API").

Close #9428