### PR TITLE
uri: add login and password fields

### DIFF
--- a/changelogs/unreleased/gh-9435-login-password-fields-in-uri.md
+++ b/changelogs/unreleased/gh-9435-login-password-fields-in-uri.md
@@ -1,0 +1,3 @@
+## feature/uri
+
+* Introduced the `login` and `password` fields in `uri.parse()` (gh-9435).

--- a/src/lib/uri/uri.c
+++ b/src/lib/uri/uri.c
@@ -198,6 +198,17 @@ uri_create_params(struct uri *uri, const char *query)
 }
 
 void
+uri_set_credentials(struct uri *uri, const char *login, const char *password)
+{
+	assert(login != NULL);
+	free(uri->login);
+	uri->login = xstrdup(login);
+
+	free(uri->password);
+	uri->password = password == NULL ? NULL : xstrdup(password);
+}
+
+void
 uri_copy(struct uri *dst, const struct uri *src)
 {
 	dst->scheme = XSTRDUP(src->scheme);

--- a/src/lib/uri/uri.h
+++ b/src/lib/uri/uri.h
@@ -64,6 +64,10 @@ uri_add_param(struct uri *uri, const char *name, const char *value);
 void
 uri_remove_param(struct uri *uri, const char *name);
 
+/** Set @a login and @a password in the @a uri. */
+void
+uri_set_credentials(struct uri *uri, const char *login, const char *password);
+
 /**
  * Copy constructor for @a dst URI. Copies all fiels from
  * @a src URI to @dst URI.

--- a/test/app-luatest/uri_unit_test.lua
+++ b/test/app-luatest/uri_unit_test.lua
@@ -32,6 +32,51 @@ uri_params_g.test_params = function(cg)
     t.assert_equals(uri_params(cg.params.params), cg.params.query_string)
 end
 
+local uri_creds_g = t.group("uri_creds", {
+    {tab = {uri = 'localhost:3301', login = 'one', password = 'two'},
+     res = {login = 'one', password = 'two'}},
+    {tab = {uri = 'localhost:3301', login = 'one'},
+     res = {login = 'one'}},
+    {tab = {uri = 'alpha:qwe@localhost:3301', login = 'one', password = 'two'},
+     res = {login = 'one', password = 'two'}},
+    {tab = {uri = 'alpha:qwe@localhost:3301', login = 'one'},
+     res = {login = 'one'}},
+})
+
+uri_creds_g.test_creads = function(cg)
+    local res = uri.parse(cg.params.tab)
+    t.assert_equals(res.login, cg.params.res.login)
+    t.assert_equals(res.password, cg.params.res.password)
+end
+
+local uri_creds_errors_g = t.group("uri_creds_errors", {
+    {tab = {uri = 'localhost:3301', login = 1, password = 'two'},
+     err = 'Invalid URI table: expected type for login is string'},
+    {tab = {uri = 'localhost:3301', login = 'one', password = 2},
+     err = 'Invalid URI table: expected type for password is string'},
+    {tab = {uri = 'alpha:qwe@localhost:3301', password = 'two'},
+     err = 'Invalid URI table: login required if password is set'},
+})
+
+uri_creds_errors_g.test_creads_errors = function(cg)
+    local res, err = uri.parse(cg.params.tab)
+    t.assert(res == nil)
+    t.assert_equals(err.message, cg.params.err)
+end
+
+local uri_set_creds_errors_g = t.group("uri_set_creds_errors", {
+    {tab = {'localhost:3301', 'localhost:3302', login = 'one'},
+     err = 'URI login is not allowed for multiple URIs'},
+    {tab = {'localhost:3301', 'localhost:3302', password = 'two'},
+     err = 'URI password is not allowed for multiple URIs'},
+})
+
+uri_set_creds_errors_g.test_set_creds_errors = function(cg)
+    local res, err = uri.parse_many(cg.params.tab)
+    t.assert(res == nil)
+    t.assert_equals(err.message, cg.params.err)
+end
+
 g.test_params_escaping = function(_)
     local uri_params = uri._internal.params
     local params = {


### PR DESCRIPTION
Closes #9435

@TarantoolBot document
Title: `login` and `password` fields in URI table

Now `uri.parse()` can parse a table containing the `login` and `password` fields. Values from these fields take precedence over values obtained from the string URI. For example, login and password of `{uri = 'one:two:localhost:3301, login = 'alpha', password = 'omega'}` will be `alpha` and `omega` respectively. If the `login` field is set and the `password` field is not set, the password is set to `nil`. If the "password" field is set, the "login" field must be present.