### PR TITLE
config: support master auto-discovery in vshard

### DIFF
--- a/src/box/lua/config/applier/sharding.lua
+++ b/src/box/lua/config/applier/sharding.lua
@@ -1,10 +1,7 @@
 local log = require('internal.config.utils.log')
-local fiber = require('fiber')
 _G.vshard = nil
 
-local fiber_wait_ro_rw
-
-local function vshard_cfg(config)
+local function apply(config)
     local configdata = config._configdata
     local roles = configdata:get('sharding.roles')
     if roles == nil then
@@ -13,68 +10,30 @@ local function vshard_cfg(config)
     if _G.vshard == nil then
         _G.vshard = require('vshard')
     end
+    local is_storage = false
+    local is_router = false
     for _, role in pairs(roles) do
-        local cfg = configdata:sharding()
-        --
-        -- Make vshard repeat current box.cfg options (see vshard/issues/428).
-        -- TODO: delete when box.cfg{} will not be called in vshard.
-        --
-        cfg.listen = box.cfg.listen
-        cfg.read_only = box.cfg.read_only
-        cfg.replication = box.cfg.replication
-
         if role == 'storage' then
-            local names = configdata:names()
-            local replicaset_uuid = names.replicaset_uuid
-            assert(replicaset_uuid == box.cfg.replicaset_uuid)
-            local instance_uuid = names.instance_uuid
-            assert(instance_uuid == box.cfg.instance_uuid)
-            local this_replicaset_cfg = cfg.sharding[replicaset_uuid]
-            --
-            -- Currently, the replicaset master must set itself as the master in
-            -- its own configuration.
-            -- TODO: remove when vshard introduces auto-discovery of masters.
-            --
-            if not box.info.ro then
-                this_replicaset_cfg.master = nil
-                this_replicaset_cfg.replicas[instance_uuid].master = true
-            end
-            log.info('sharding: apply sharding config')
-            _G.vshard.storage.cfg(cfg, instance_uuid)
-            --
-            -- Currently, replicaset masters may not be aware of all other
-            -- masters, so the rebalancer is disabled.
-            -- TODO: remove when vshard introduces auto-discovery of masters.
-            --
-            if _G.vshard.storage.internal.is_rebalancer_active then
-                log.info('sharding: disable rebalancer')
-                _G.vshard.storage.rebalancer_disable()
-            end
-        end
-        if role == 'router' then
-            _G.vshard.router.cfg(cfg)
+            is_storage = true
+        elseif role == 'router' then
+            is_router = true
         end
     end
-end
-
-local function wait_ro_rw(config)
-    while true do
-        if box.info.ro then
-            box.ctl.wait_rw()
-        else
-            box.ctl.wait_ro()
-        end
-        local ok, err = pcall(vshard_cfg, config)
-        if not ok then
-            log.error(err)
-        end
+    local cfg = configdata:sharding()
+    --
+    -- Make vshard repeat current box.cfg options (see vshard/issues/428).
+    -- TODO: delete when box.cfg{} will not be called in vshard.
+    --
+    cfg.listen = box.cfg.listen
+    cfg.read_only = box.cfg.read_only
+    cfg.replication = box.cfg.replication
+    if is_storage then
+        log.info('sharding: apply storage config')
+        _G.vshard.storage.cfg(cfg, box.info.uuid)
     end
-end
-
-local function apply(config)
-    vshard_cfg(config)
-    if fiber_wait_ro_rw == nil then
-        fiber_wait_ro_rw = fiber.create(wait_ro_rw, config)
+    if is_router then
+        log.info('sharding: apply router config')
+        _G.vshard.router.cfg(cfg)
     end
 end
 


### PR DESCRIPTION
This patch adds support for automatic master discovery in vshard. There is no longer a need to reapply the vshard storage configuration every time an instance becomes a master or ceases to be a master.

Automatic master discovery also solves the problem with the rebalancer. Previously, the rebalancer could not work correctly if the masters of some replicasets were unknown, and since the vshard config generated by the config module did not contain information about all the masters, the rebalancer was disabled. The rebalancer can now perform master discovery
on its own, which is why it is enabled.

Before this patch, the config module was based on the "test: use dofile() for configs instead of require" commit in vshard. At a minimum, commit "storage: fix assertion error in conn_manager" is now required.

Part of #8862