### PR TITLE
relay: check return value of xrow_decode_synchro

### DIFF
--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -1280,7 +1280,8 @@ relay_filter_row(struct relay *relay, struct xrow_header *packet)
 	 */
 	if (iproto_type_is_promote_request(packet->type)) {
 		struct synchro_request req;
-		xrow_decode_synchro(packet, &req, NULL);
+		if (xrow_decode_synchro(packet, &req, NULL) != 0)
+			diag_raise();
 		while (relay->sent_raft_term < req.term) {
 			if (fiber_is_cancelled()) {
 				diag_set(FiberIsCancelled);


### PR DESCRIPTION
Relay sometimes decodes the PROMOTE packets to be sent in order to conditionally delay their despatch. It was believed that own WALs can't be corrupted and hence there is no point in checking that decoding succeeds.

Let's be more strict here and check the decoding result before proceeding.

Closes #9265

NO_DOC=bugfix
NO_TEST=hard to test
NO_CHANGELOG=not user-visible