### PR TITLE
fiber: make cord_cojoin cancellable

### DIFF
--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -589,6 +589,7 @@ wal_free(void)
 	struct wal_writer *writer = &wal_writer_singleton;
 
 	cbus_stop_loop(&writer->wal_pipe);
+	cpipe_destroy(&writer->wal_pipe);
 
 	if (cord_join(&writer->cord)) {
 		/* We can't recover from this in any reasonable way. */
@@ -1233,6 +1234,7 @@ wal_writer_f(va_list ap)
 		wal_xlog_close(&vy_log_writer.xlog);
 
 	cpipe_destroy(&writer->tx_prio_pipe);
+	cbus_endpoint_destroy(&endpoint, cbus_process);
 	return 0;
 }
 

--- a/test/unit/fiber.result
+++ b/test/unit/fiber.result
@@ -30,6 +30,8 @@ OutOfMemory: Failed to allocate 42 bytes in allocator for exception
 	*** fiber_wait_on_deadline_test: done ***
 	*** cord_cojoin_test ***
 	*** cord_cojoin_test: done ***
+	*** cord_cojoin_cancel_test ***
+	*** cord_cojoin_cancel_test: done ***
 	*** cord_cancel_and_join_test ***
 	*** cord_cancel_and_join_test: done ***
 	*** fiber_test_defaults ***


### PR DESCRIPTION
We may need to cancel fiber that waits for cord to finish. For this purpose let's cancel fiber started by `cord_costart` inside the cord.

Note that there is a race between stopping `cancel_event` in cord and triggering it using `ev_async_send` in joining thread. AFAIU it is safe.

We also need to fix stopping wal cord to address stack-use-after-return issue shown below. Is arises because we did not stop async which resides in wal endpoint and endpoint resides on stack. Later when we stop the introduced `cancel_event` we access not stopped async which at this moment gone out of scope.

```
==3224698==ERROR: AddressSanitizer: stack-use-after-return on address 0x7f654b3b0170 at pc 0x555a2817c282 bp 0x7f654ca55b30 sp 0x7f654ca55b28
WRITE of size 4 at 0x7f654b3b0170 thread T3
    #0 0x555a2817c281 in ev_async_stop /home/shiny/dev/tarantool/third_party/libev/ev.c:5492:37
    #1 0x555a27827738 in cord_thread_func /home/shiny/dev/tarantool/src/lib/core/fiber.c:1990:2
    #2 0x7f65574aa9ea in start_thread /usr/src/debug/glibc/glibc/nptl/pthread_create.c:444:8
    #3 0x7f655752e7cb in clone3 /usr/src/debug/glibc/glibc/misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:78
```

Part of #8423