### PR TITLE
iproto: don't account message twice in case of override fallback

### DIFF
--- a/changelogs/unreleased/gh-9345-fix-iproto-override-double-request-account.md
+++ b/changelogs/unreleased/gh-9345-fix-iproto-override-double-request-account.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed incorrect calculation of requests in progress in case of iproto
+  override fallback (gh-9345).

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -437,6 +437,12 @@ struct iproto_msg
 	struct stailq_entry in_stream;
 	/** Stream that owns this message, or NULL. */
 	struct iproto_stream *stream;
+	/**
+	 * True if message processing in tx thread is started. The flag is
+	 * used to prevent double accounting of message in case of iproto
+	 * override fallback to original handler.
+	 */
+	bool accepted;
 };
 
 /**
@@ -811,6 +817,7 @@ iproto_msg_new(struct iproto_connection *con)
 	msg->close_connection = false;
 	msg->connection = con;
 	msg->stream = NULL;
+	msg->accepted = false;
 	rmean_collect(con->iproto_thread->rmean, IPROTO_REQUESTS, 1);
 	return msg;
 }
@@ -1946,6 +1953,9 @@ static inline struct iproto_msg *
 tx_accept_msg(struct cmsg *m)
 {
 	struct iproto_msg *msg = (struct iproto_msg *) m;
+	if (msg->accepted)
+		return msg;
+	msg->accepted = true;
 	tx_accept_wpos(msg->connection, &msg->wpos);
 	tx_fiber_init(msg->connection->session, msg->header.sync);
 	tx_prepare_transaction_for_request(msg);


### PR DESCRIPTION
We need to call `tx_accept_msg` in `tx_process_override` before we pass message to the override handler. Unfortunately if handler response with `IPROTO_HANDLER_FALLBACK` we call the builtin handler for message that calls `tx_accept_msg` again which is not expected. Some actions of this function are idempotent and some are not.

Let's make the function NOP if it called once again.

Closes #9345
