### PR TITLE
[backport 2.11] changelog: add new topics 'tools' and 'testing'

### DIFF
--- a/tools/gen-release-notes
+++ b/tools/gen-release-notes
@@ -14,7 +14,7 @@ import subprocess
 # Ensure certain order for known sections.
 SECTIONS_TOP = ['core', 'memtx', 'vinyl', 'replication', 'swim',
                 'raft', 'luajit', 'lua', 'sql']
-SECTIONS_BOTTOM = ['build', 'testing', 'misc']
+SECTIONS_BOTTOM = ['build', 'misc']
 
 # Prettify headers, apply the ordering.
 REDEFINITIONS = {
@@ -284,9 +284,10 @@ class Parser:
         if line.startswith('## '):
             header = line.split(' ', 1)[1].strip()
             fst = header.split('/', 1)[0]
-            if fst not in ('feature', 'bugfix'):
+            if fst not in ('feature', 'bugfix', 'tools', 'testing'):
                 raise self.error("Unknown header: '{}', should be "
-                                 "'feature/<...>' or 'bugfix/<...>'"
+                                 "'feature/<...>' or 'bugfix/<...>' or"
+                                 "'tools/<...>' or 'testing/<...>'"
                                  .format(header))
             self.header = header
             self._process = self._wait_content


### PR DESCRIPTION
Some changes are not new features, rather developer tools updates and improvements. There are also number of tweaks we can introduce to improve testing and tests backporting across branches, which also are not considered neither feature nor bug fix.

NO_DOC=changelog
NO_TEST=changelog
NO_CHANGELOG=changelog

(cherry picked from commit 4d6937ef69a55b72ce1c8194cf9c42b913752a73)