### PR TITLE
config: add `config.storage` role file to the build

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -60,6 +60,7 @@ lua_source(lua_sources lua/config/utils/tabulate.lua      config_utils_tabulate_
 
 if (ENABLE_CONFIG_EXTRAS)
     lua_source(lua_sources ${CONFIG_EXTRAS_DIR}/source/etcd.lua config_source_etcd_lua)
+    lua_source(lua_sources ${CONFIG_EXTRAS_DIR}/storage/init.lua config_storage_init_lua)
     lua_source(lua_sources ${CONFIG_EXTRAS_DIR}/extras.lua config_extras_lua)
 endif()
 # }}} config

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -164,6 +164,7 @@ extern char session_lua[],
 #if ENABLE_CONFIG_EXTRAS
 	,
 	config_source_etcd_lua[],
+	config_storage_init_lua[],
 	config_extras_lua[]
 #endif
 	;
@@ -323,6 +324,7 @@ static const char *lua_sources[] = {
 	 * - configuration sources
 	 * - configuration appliers
 	 * - the entrypoint
+	 * - config.storage role
 	 */
 
 	"config/utils/log",
@@ -406,6 +408,12 @@ static const char *lua_sources[] = {
 	"config/init",
 	"config",
 	config_init_lua,
+
+#if ENABLE_CONFIG_EXTRAS
+	"config/storage/init",
+	"config.storage",
+	config_storage_init_lua,
+#endif
 
 	/* }}} config */
 


### PR DESCRIPTION
This patch adds the `config.storage` role file to the build.

Part of https://github.com/tarantool/tarantool-ee/issues/593

NO_DOC=supplement change
NO_TEST=supplement change
NO_CHANGELOG=supplement change