### PR TITLE
integration testing

### DIFF
--- a/.github/actions/bump-submodule/action.yml
+++ b/.github/actions/bump-submodule/action.yml
@@ -1,0 +1,36 @@
+name: 'Bump submodule'
+description: 'Bump specified submodule from third_party'
+
+inputs:
+  submodule:
+    description: Name of submodule to bump.
+    required: true
+    type: string
+  revision:
+    description: Git revision from submodule repository
+    required: true
+    type: string
+
+runs:
+  using: 'composite'
+  # XXX: Environment variables to suppress git config warning.
+  # The commit is required to avoid resetting dirty
+  # changes in submodule.
+  env:
+    GIT_COMMITTER_NAME: "integration testing workflow"
+    GIT_COMMITTER_EMAIL: "noreply@tarantool.org"
+    GIT_AUTHOR_NAME: "integration testing workflow"
+    GIT_AUTHOR_EMAIL: "noreply@tarantool.org"
+  steps:
+    run: |
+      pushd third_party/${{ inputs.submodule }}
+      git fetch origin
+      git checkout ${{ inputs.revision }}
+      popd
+      # XXX: --allow-empty is required to rerun flaky tests
+      # for HEAD when it is already bumped
+      # in tarantool/tarantool repo to the same revision.
+      # Otherwise the command below fails with "nothing to
+      # commit" reason.
+      git commit --allow-empty -m ${{ inputs.submodule }}": integration testing bump" \
+        third_party/${{ inputs.submodule }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,16 @@ on:
     branches: [ "master" ]
   workflow_dispatch:
     branches: [ "master" ]
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 jobs:
   analyze:
@@ -57,6 +67,13 @@ jobs:
 
     - name: Install deps
       uses: ./.github/actions/install-deps-debian
+
+    - name: Optional submodule bump
+      if: ${{ inputs.submodule }}
+      uses: ./.github/actions/bump-submodule
+      with:
+        submodule: ${{ inputs.submodule }}
+        revision: ${{ inputs.revision }}
 
     - name: Build
       run: make -f .test.mk build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,16 @@ on:
       - '**'
   pull_request:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -67,6 +77,13 @@ jobs:
 
       - name: Install deps
         uses: ./.github/actions/install-deps-debian
+
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
 
       - name: Run testing with coverage enabled
         run: make -f .test.mk test-coverage

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -9,6 +9,16 @@ on:
       - '**'
   pull_request:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -67,6 +77,13 @@ jobs:
 
       - name: Install deps
         uses: ./.github/actions/install-deps-debian
+
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
 
       - name: Run testing
         run: make -f .test.mk test-debug

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -63,6 +73,12 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
       - name: test
         run: make -f .test.mk test-debug
       - name: Send VK Teams message on failure

--- a/.github/workflows/debug_asan_clang.yml
+++ b/.github/workflows/debug_asan_clang.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -64,6 +74,12 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
       - name: test
         env:
           CC: clang-16

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -51,6 +61,12 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - uses: ./.github/actions/environment
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
       - name: test
         env:
           # Our testing expects that the init process (PID 1) will

--- a/.github/workflows/freebsd-12.yml
+++ b/.github/workflows/freebsd-12.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -50,6 +60,12 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-freebsd
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
       - name: test
         run: gmake -f .test.mk test-freebsd-release
       - name: Send VK Teams message on failure

--- a/.github/workflows/freebsd-13.yml
+++ b/.github/workflows/freebsd-13.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -50,6 +60,12 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-freebsd
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
       - name: test
         run: gmake -f .test.mk test-freebsd-release
       - name: Send VK Teams message on failure

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize, labeled ]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -44,6 +54,8 @@ jobs:
       ref: ${{ github.sha }}
       os: ubuntu
       dist: focal
+      submodule: ${{ inputs.submodule }}
+      revision: ${{ inputs.revision }}
 
   vshard:
     needs: tarantool

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,16 @@ on:
       - '**'
   pull_request:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -52,6 +62,12 @@ jobs:
           submodules: recursive
       - name: Install deps
         uses: ./.github/actions/install-deps-debian
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
       - name: test
         run: make -f .test.mk luacheck
       - name: Send VK Teams message on failure

--- a/.github/workflows/luajit-integration.yml
+++ b/.github/workflows/luajit-integration.yml
@@ -63,25 +63,10 @@ jobs:
           ref: ${{ inputs.release }}
 
       - name: LuaJIT bump
-        run: |
-          pushd third_party/luajit
-          git fetch origin
-          git checkout ${{ inputs.revision }}
-          popd
-          # XXX: export the following environment variables to
-          # suppress git config warning. The commit is required to
-          # avoid resetting dirty changes in LuaJIT submodule.
-          export GIT_COMMITTER_NAME="LuaJIT integration testing workflow"
-          export GIT_COMMITTER_EMAIL="noreply@tarantool.org"
-          export GIT_AUTHOR_NAME="LuaJIT integration testing workflow"
-          export GIT_AUTHOR_EMAIL="noreply@tarantool.org"
-          # XXX: --allow-empty is required to rerun flaky tests
-          # for tarantool/luajit HEAD when it is already bumped
-          # in tarantool/tarantool repo to the same revision.
-          # Otherwise the command below fails with "nothing to
-          # commit" reason.
-          git commit --allow-empty -m "luajit: integration testing bump" \
-            third_party/luajit
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: luajit
+          revision: ${{ inputs.revision }}
 
       - name: Set environment
         uses: ./.github/actions/environment

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -63,6 +73,12 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
       - name: test
         env:
           TEST_RUN_EXTRA_PARAMS: --memtx-allocator=system

--- a/.github/workflows/osx_debug.yml
+++ b/.github/workflows/osx_debug.yml
@@ -9,6 +9,16 @@ on:
       - '**'
   pull_request:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -56,6 +66,12 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-osx
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
       - name: test
         run: make -f .test.mk test-osx-debug
       - name: Send VK Teams message on failure

--- a/.github/workflows/osx_release.yml
+++ b/.github/workflows/osx_release.yml
@@ -9,6 +9,16 @@ on:
       - '**'
   pull_request:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -59,6 +69,12 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-osx
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
       - name: test
         run: make -f .test.mk test-osx-release
       - name: Send VK Teams message on failure

--- a/.github/workflows/osx_release_lto.yml
+++ b/.github/workflows/osx_release_lto.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -56,6 +66,12 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-osx
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
       - name: test
         env:
           CMAKE_EXTRA_PARAMS: -DENABLE_LTO=ON

--- a/.github/workflows/osx_static_cmake.yml
+++ b/.github/workflows/osx_static_cmake.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -57,6 +67,12 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-osx
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
       - name: test
         run: make -f .test.mk test-osx-static-cmake
       - name: Send VK Teams message on failure

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -63,6 +73,12 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
       - name: test
         env:
           BUILD_DIR: build

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize, labeled ]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -50,6 +60,8 @@ jobs:
           {"os": "ubuntu-focal"}, {"os": "ubuntu-jammy"}
         ]
       }'
+      submodule: ${{ inputs.submodule }}
+      revision: ${{ inputs.revision }}
     secrets: inherit
 
   packaging-aarch64:

--- a/.github/workflows/perf_micro.yml
+++ b/.github/workflows/perf_micro.yml
@@ -9,6 +9,16 @@ on:
       - '**'
   pull_request:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -50,6 +60,12 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
       - name: test
         run: make -f .test.mk test-perf
       - name: Send VK Teams message on failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,16 @@ on:
       - '**'
   pull_request:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -63,6 +73,12 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
       - name: test
         run: make -f .test.mk test-release
       - name: Send VK Teams message on failure

--- a/.github/workflows/release_asan_clang.yml
+++ b/.github/workflows/release_asan_clang.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -64,6 +74,12 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
       - name: test
         env:
           CC: clang-16

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -63,6 +73,12 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
       - name: test
         env:
           CC: clang-16

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -63,6 +73,12 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
       - name: test
         env:
           CMAKE_EXTRA_PARAMS: -DENABLE_LTO=ON

--- a/.github/workflows/release_lto_clang.yml
+++ b/.github/workflows/release_lto_clang.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -63,6 +73,12 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
       - name: test
         env:
           CC: clang-16

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -19,6 +19,14 @@ on:
         default: focal
         required: false
         type: string
+      submodule:
+        description: Name of submodule to bump.
+        required: false
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: false
+        type: string
 
 jobs:
   build:
@@ -40,6 +48,12 @@ jobs:
         id: get_sha
         run: echo "sha=$(git log -1 --format='%H')" >> $GITHUB_OUTPUT
       - uses: ./.github/actions/environment
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
       - name: 'Build tarantool packages for ${{ env.OS }}(${{ env.DIST }})'
         id: run_build
         env:

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -64,6 +74,12 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
       - name: test
         run: make -f .test.mk test-static
       - name: Send VK Teams message on failure

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      submodule:
+        description: Name of submodule to bump.
+        required: true
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: true
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -64,6 +74,12 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
       - name: test
         run: make -f .test.mk test-static-cmake
       - name: Send VK Teams message on failure

--- a/.github/workflows/static_build_pack_test_deploy.yml
+++ b/.github/workflows/static_build_pack_test_deploy.yml
@@ -13,6 +13,14 @@ on:
         default: '{"include": [{"os": "ubuntu-focal"}, {"os": "ubuntu-jammy"}]}'
         required: false
         type: string
+      submodule:
+        description: Name of submodule to bump.
+        required: false
+        type: string
+      revision:
+        description: Git revision from submodule repository
+        required: false
+        type: string
 
 jobs:
   build:
@@ -28,6 +36,13 @@ jobs:
           submodules: recursive
 
       - uses: ./.github/actions/environment
+
+      - name: Optional submodule bump
+        if: ${{ inputs.submodule }}
+        uses: ./.github/actions/bump-submodule
+        with:
+          submodule: ${{ inputs.submodule }}
+          revision: ${{ inputs.revision }}
 
       - name: Make static build packages
         run: make -f .pack.mk package-static


### PR DESCRIPTION
Currently, if there is a need to test submodule integration with Tarantool and its integration, it is required to create a PR. That is inconvenient, so this patch introduces the option to run the same jobs that are triggered by the `full-ci` label as reusable workflows with the desired submodule revision. This allows for integration testing of submodules within their designated repositories.