### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9145-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9145-luajit-fixes.md
@@ -22,3 +22,5 @@ were fixed as part of this activity:
 * Fixed possible storing of NaN keys to table on trace.
 * Fixed ABC FOLD optimization with constants.
 * Marked `CONV` as non-weak, to prevent invalid control flow path choice.
+* Fixed double-emitting of `IR_NEWREF` when restoring sunk values for side
+  trace (gh-7937).


### PR DESCRIPTION
* Emit sunk IR_NEWREF only once per key on snapshot replay.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump