### PR TITLE
sql: fix memleak in sqlSelect

### DIFF
--- a/changelogs/unreleased/gh-8535-memleak-in-sqlSelect.md
+++ b/changelogs/unreleased/gh-8535-memleak-in-sqlSelect.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Fixed a memory leak when an error occurred in `SELECT` with a `GROUP BY`
+  expression (gh-8535, ghs-125).

--- a/src/box/sql/select.c
+++ b/src/box/sql/select.c
@@ -6277,8 +6277,6 @@ sqlSelect(Parse * pParse,		/* The parser context */
 			 */
 			sqlVdbeJumpHere(v, addr1);
 			updateAccumulator(pParse, &sAggInfo);
-			if (pParse->is_aborted)
-				goto select_end;
 			sqlVdbeAddOp2(v, OP_Integer, 1, iUseFlag);
 			VdbeComment((v, "indicate data in accumulator"));
 
@@ -6292,6 +6290,8 @@ sqlSelect(Parse * pParse,		/* The parser context */
 				sqlWhereEnd(pWInfo);
 				sqlVdbeChangeToNoop(v, addrSortingIdx);
 			}
+			if (pParse->is_aborted)
+				goto select_end;
 
 			/* Output the final row of result
 			 */


### PR DESCRIPTION
This patch fixes a memory leak in sqlSelect that was caused by pWInfo not being removed if an error occurred while encoding a GROUP BY expression.

Closes #8535
Closes https://github.com/tarantool/security/issues/125