### PR TITLE
sql: fix wrong argument order in sqlMatchSpanName

### DIFF
--- a/changelogs/unreleased/gh-9445-wrong-argument-order.md
+++ b/changelogs/unreleased/gh-9445-wrong-argument-order.md
@@ -1,0 +1,5 @@
+## bugfix/sql
+
+* Fixed a bug when an incorrect query result could be returned if tables
+  participated in a join and their names met certain conditions. The bug was
+  added in version `3.0.0-beta1` in issue gh-4467 (gh-9445).

--- a/src/box/sql/resolve.c
+++ b/src/box/sql/resolve.c
@@ -189,7 +189,7 @@ sql_find_column_expr(const struct ExprList *list, const char *tab_name,
 {
 	for (int j = 0; j < list->nExpr; j++) {
 		if (sqlMatchSpanName(list->a[j].zSpan, col_name, tab_name,
-				     old_tab, old_col))
+				     old_col, old_tab))
 			return j;
 	}
 	return -1;

--- a/test/sql-luatest/gh_9445_wrong_arguments_order_test.lua
+++ b/test/sql-luatest/gh_9445_wrong_arguments_order_test.lua
@@ -1,0 +1,28 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_exists = function()
+    g.server:exec(function()
+        box.execute([[CREATE TABLE A(I1 INT PRIMARY KEY, B INT);]])
+        box.execute([[CREATE TABLE B(I2 INT PRIMARY KEY, A INT);]])
+        box.execute([[INSERT INTO A VALUES(1, 2);]])
+        box.execute([[INSERT INTO B VALUES(1, 3);]])
+        local sql = [[SELECT a.b FROM (SEQSCAN a INNER JOIN b ON i1=i2) AS c;]]
+        local res = box.execute(sql).rows
+        t.assert_equals(res, {{2}})
+        sql = [[SELECT A.B FROM (SEQSCAN A INNER JOIN B ON I1=I2) AS C;]]
+        res = box.execute(sql).rows
+        t.assert_equals(res, {{2}})
+    end)
+end


### PR DESCRIPTION
Fixed incorrect argument order in sqlMatchSpanName(), which could lead to incorrect query results.

Closes #9445
