### PR TITLE
box: fix `NULL` pointer dereference in `on_replace_dd_space`

### DIFF
--- a/changelogs/unreleased/gh-9407-deref-of-null-old_space.md
+++ b/changelogs/unreleased/gh-9407-deref-of-null-old_space.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a possible crash on space drop that could happen if system triggers have
+  been disabled by a user (gh-9407).

--- a/test/engine-luatest/gh_9407_deref_of_null_old_space_test.lua
+++ b/test/engine-luatest/gh_9407_deref_of_null_old_space_test.lua
@@ -1,0 +1,28 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group('gh-9407', {{engine = 'memtx'}, {engine = 'vinyl'}})
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+-- Check that Tarantool doesn't crash in the following scenario:
+g.test_null_dereference = function(cg)
+    cg.server:exec(function(engine)
+        local space_id = 512
+        -- 1. Disable the `on_replace_dd_space' core trigger.
+        box.space._space:run_triggers(false)
+        -- 2. New space is inserted into `_space', but not into the space cache.
+        box.schema.create_space('test', {engine = engine, id = space_id})
+        -- 3. Enable `on_replace_dd_space' back.
+        box.space._space:run_triggers(true)
+        -- 4. Try to drop the space.
+        box.space._space:delete({space_id})
+    end, {cg.params.engine})
+end


### PR DESCRIPTION
Is it possible to get into `on_replace_dd_space` with both `new_tuple` and `old_space` equal `NULL`.
This can happen if a space is created when core triggers are turned off.

Closes #9407