### PR TITLE
test: increase timeouts in on_shutdown tests

### DIFF
--- a/test/app-luatest/gh_9411_fix_graceful_shutdown_break_on_script_exit_test.lua
+++ b/test/app-luatest/gh_9411_fix_graceful_shutdown_break_on_script_exit_test.lua
@@ -33,7 +33,16 @@ g.test = function()
                                    stderr = popen.opts.DEVNULL})
     assert(handle, err)
     g.handle = handle
-    local output, err = handle:read({timeout = 3})
+    -- NB: Don't guess a good timeout, just use 60 seconds as
+    -- something that is definitely less than default test timeout
+    -- (110 seconds), but large enough to perform an action that
+    -- usually takes a fraction of a second.
+    --
+    -- The bad case doesn't stuck the test case anyway: if the
+    -- child process doesn't call an on_shutdown trigger, the
+    -- process exits without output and we get EOF (an empty
+    -- string) here.
+    local output, err = handle:read({timeout = 60})
     assert(output, err)
     t.assert_equals(output, 'shutdown callback finished\n')
     local status = handle:wait()

--- a/test/box-luatest/gh_9266_fix_on_shutdown_and_osexit_from_cmd_expr_test.lua
+++ b/test/box-luatest/gh_9266_fix_on_shutdown_and_osexit_from_cmd_expr_test.lua
@@ -25,7 +25,16 @@ g.test = function()
                                    stderr = popen.opts.DEVNULL})
     assert(handle, err)
     g.handle = handle
-    local output, err = handle:read({timeout = 3})
+    -- NB: Don't guess a good timeout, just use 60 seconds as
+    -- something that is definitely less than default test timeout
+    -- (110 seconds), but large enough to perform an action that
+    -- usually takes a fraction of a second.
+    --
+    -- The bad case doesn't stuck the test case anyway: if the
+    -- child process doesn't call an on_shutdown trigger, the
+    -- process exits without output and we get EOF (an empty
+    -- string) here.
+    local output, err = handle:read({timeout = 60})
     assert(output, err)
     t.assert_equals(output, "hello\n")
     local status = handle:wait()


### PR DESCRIPTION
I got four fails on the given tests in a row on debug-asan job in CI for tarantool-ee.

It seems, tarantool-ee is more sensitive to small timeouts, when the address sanitizer slows down the execution. Or I'm just lucky.

Anyway, the given tests don't really need small timeouts: increasing it doesn't break any test logic, doesn't increase duration of the test in a successful case and doesn't increase it in case of a failure.

The tests are more stable after the change: I verified it locally by running each of the tests in parallel many times on tarantool built with enabled address sanitizer.

See the following commits for details about the given test cases and the problems behind.

* commit 1fcfb8c2bc8f ("app: start init script event loop explicitly")
* commit 786eb2acdd0a ("main: don't break graceful shutdown on init script exit")

Follows up #9266
Follows up #9411