### PR TITLE
[backport 2.10] test: enable JIT again for flaky tests on arm64

### DIFF
--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -8,15 +8,6 @@ local json = require('json')
 local msgpack = require('msgpack')
 local TZ = date.TZ
 
---[[
-    Workaround for #6599 where we may randomly fail on AWS Graviton machines,
-    while it's working properly when jit disabled.
---]]
-if jit.arch == 'arm64' then
-    jit.off()
-    jit.flush()
-end
-
 test:plan(39)
 
 local INT_MAX = 2147483647

--- a/test/box-luatest/gh_6539_log_user_space_empty_or_nil_select_test.lua
+++ b/test/box-luatest/gh_6539_log_user_space_empty_or_nil_select_test.lua
@@ -9,11 +9,6 @@ g.before_all(function()
     g.server:start()
     g.server:exec(function()
         require("log").internal.ratelimit.disable()
-        -- Workaround for #8011
-        if jit.arch == 'arm64' then
-            jit.off()
-            jit.flush()
-        end
     end)
 end)
 


### PR DESCRIPTION
JIT has been disabled for these 2 tests on arm64 to avoid failing due to side-effects of constant rematerialization:
* <app-tap/datetime.test.lua>
* <box-luatest/gh_6539_log_user_space_empty_or_nil_select_test.lua>

The problem was solved via the commit
c4ec0c7b7a32273b194709934247e81c61b55f06 ("luajit: bump new version"). So, enable JIT compilation for these tests back.

Closes #6599
Closes #8011

NO_CHANGELOG=tests
NO_DOC=tests

(cherry picked from commit 915e0b3a4475b12ec49320421569524dc8488aed)

---
#8446 wasn't backported to the 2.10 branch due to the conflict of pagination tests. So create a separate PR.