### PR TITLE
Avoid assertion in case of stack overflow from stitched trace

### DIFF
--- a/changelogs/unreleased/gh-9145-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9145-luajit-fixes.md
@@ -1,0 +1,6 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-9145). The following issues
+were fixed as part of this activity:
+
+* Fixed assertion on stackoverflow for stitched trace.


### PR DESCRIPTION
Avoid assertion in case of stack overflow from stitched trace.

Part of #9145

NO_DOC=LJ
NO_TEST=LJ