### PR TITLE
config: better diagnostic for a corrupted snapshot

### DIFF
--- a/changelogs/unreleased/config-better-corrupted-snap-diagnostic.md
+++ b/changelogs/unreleased/config-better-corrupted-snap-diagnostic.md
@@ -1,0 +1,4 @@
+## bugfix/config
+
+* Improved the diagnostic given for a corrupted snapshot file without an
+  instance or replica set UUID (gh-8862).


### PR DESCRIPTION
If a given snapshot has no instance or replicaset UUID, give a meaningful diagnostic and fail.

Part of #8862