### PR TITLE
config: support relative path in --config

### DIFF
--- a/changelogs/unreleased/config-relative-config-path.md
+++ b/changelogs/unreleased/config-relative-config-path.md
@@ -1,0 +1,5 @@
+## bugfix/config
+
+* Added support for the relative path in the `--config <...>` option. Before
+  this change, `config:reload()` failed if the `process.work_dir` option was
+  set to a non-null value (gh-8862).

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -1,3 +1,4 @@
+local fio = require('fio')
 local instance_config = require('internal.config.instance_config')
 local cluster_config = require('internal.config.cluster_config')
 local configdata = require('internal.config.configdata')
@@ -381,7 +382,14 @@ function methods._startup(self, instance_name, config_file)
 
     self._status = 'startup_in_progress'
     self._instance_name = instance_name
-    self._config_file = config_file
+    -- box.cfg() changes a current working directory that
+    -- invalidates relative paths.
+    --
+    -- Let's calculate an absolute path to access the file later
+    -- on :reload().
+    if config_file ~= nil then
+        self._config_file = fio.abspath(config_file)
+    end
     broadcast(self)
 
     self:_initialize()

--- a/test/config-luatest/work_dir_test.lua
+++ b/test/config-luatest/work_dir_test.lua
@@ -1,0 +1,51 @@
+local fun = require('fun')
+local yaml = require('yaml')
+local t = require('luatest')
+local treegen = require('test.treegen')
+local server = require('test.luatest_helpers.server')
+local helpers = require('test.config-luatest.helpers')
+
+local g = helpers.group()
+
+-- Verify that `--config <...>` with a relative path to the config
+-- works good with `process.work_dir` option, which changes CWD of
+-- the instance.
+g.test_relative_config_path = function(g)
+    local dir = treegen.prepare_directory(g, {}, {})
+    local config = table.copy(helpers.simple_config)
+    config.process = {
+        work_dir = 'x',
+    }
+    local config_file = 'config.yaml'
+    treegen.write_script(dir, config_file, yaml.encode(config))
+
+    -- Important: `--config <...>` is passed with a relative path.
+    local opts = {config_file = config_file, chdir = dir}
+    g.server = server:new(fun.chain(opts, {alias = 'instance-001'}):tomap())
+    g.server:start()
+
+    local function server_is_ok(server)
+        server:exec(function()
+            local config = require('config')
+
+            local info = config:info()
+            t.assert_equals({
+                status = info.status,
+                alerts = info.alerts,
+            }, {
+                status = 'ready',
+                alerts = {},
+            })
+        end)
+    end
+
+    -- Verify that the instance is started successfully. Reload
+    -- the configuration. Verify that the reload is successful.
+    server_is_ok(g.server)
+    g.server:exec(function()
+        local config = require('config')
+
+        config:reload()
+    end)
+    server_is_ok(g.server)
+end

--- a/test/luatest_helpers/server.lua
+++ b/test/luatest_helpers/server.lua
@@ -154,8 +154,16 @@ function Server:initialize()
 
         if self.net_box_uri == nil then
             local config = self.config or self.remote_config
-            self.net_box_uri = find_advertise_uri(config, self.alias,
-                self.chdir)
+
+            -- NB: listen and advertise URIs are relative to
+            -- process.work_dir, which, in turn, is relative to
+            -- self.chdir.
+            local work_dir
+            if config.process ~= nil and config.process.work_dir ~= nil then
+                work_dir = config.process.work_dir
+            end
+            local dir = pathjoin(self.chdir, work_dir)
+            self.net_box_uri = find_advertise_uri(config, self.alias, dir)
         end
     end
     getmetatable(getmetatable(self)).initialize(self)


### PR DESCRIPTION
Before this change the following conditions lead to an error on `config:reload()`.
    
* `--config <...>` CLI option is passed with a relative config path
* `process.work_dir` config option is set to a non-null value

It is fixed by calculating of an absolute config path on startup.

Part of #8862
