### PR TITLE
config: add compat options

### DIFF
--- a/changelogs/unreleased/config-compat-options.md
+++ b/changelogs/unreleased/config-compat-options.md
@@ -1,0 +1,3 @@
+## feature/config
+
+* Added compatibility options from the `compat` module (gh-9497).

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -44,6 +44,7 @@ lua_source(lua_sources lua/mkversion.lua mkversion_lua)
 # {{{ config
 lua_source(lua_sources lua/config/applier/app.lua         config_applier_app_lua)
 lua_source(lua_sources lua/config/applier/box_cfg.lua     config_applier_box_cfg_lua)
+lua_source(lua_sources lua/config/applier/compat.lua      config_applier_compat_lua)
 lua_source(lua_sources lua/config/applier/console.lua     config_applier_console_lua)
 lua_source(lua_sources lua/config/applier/credentials.lua config_applier_credentials_lua)
 lua_source(lua_sources lua/config/applier/fiber.lua       config_applier_fiber_lua)

--- a/src/box/lua/config/applier/compat.lua
+++ b/src/box/lua/config/applier/compat.lua
@@ -1,0 +1,23 @@
+local compat = require('compat')
+local log = require('internal.config.utils.log')
+
+local function apply(config)
+    local configdata = config._configdata
+    local compat_options = compat._options()
+
+    for k, v in pairs(configdata:get('compat', {use_default = true})) do
+        local effective_value = compat[k]:is_new() and 'new' or 'old'
+        local is_changed = effective_value ~= v
+        if is_changed then
+            local def = compat_options[k].default == v and '(default)' or
+                '(NOT default)'
+            log.info(('Set compat option %q to %q %s'):format(k, v, def))
+            compat[k] = v
+        end
+    end
+end
+
+return {
+    name = 'compat',
+    apply = apply,
+}

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -151,6 +151,7 @@ function methods._initialize(self)
         self:_register_source(require('internal.config.source.file').new())
     end
 
+    self:_register_applier(require('internal.config.applier.compat'))
     self:_register_applier(require('internal.config.applier.mkdir'))
     self:_register_applier(require('internal.config.applier.box_cfg'))
     self:_register_applier(require('internal.config.applier.credentials'))
@@ -301,10 +302,11 @@ function methods._store(self, iconfig, cconfig, source_info)
     self._configdata = configdata.new(iconfig, cconfig, self._instance_name)
 end
 
--- Invoke mkdir and box_cfg appliers at the first phase. Invoke
--- all the other ones at the second phase.
+-- Invoke compat, mkdir and box_cfg appliers at the first phase.
+-- Invoke all the other ones at the second phase.
 function methods._apply_on_startup(self, opts)
     local first_phase_appliers = {
+        compat = true,
         mkdir = true,
         box_cfg = true,
     }
@@ -388,8 +390,8 @@ function methods._startup(self, instance_name, config_file)
 
     -- Startup phase 1/2.
     --
-    -- Start mkdir and box_cfg appliers. The latter may force the
-    -- read-only mode on this phase.
+    -- Start compat, mkdir and box_cfg appliers. The latter may
+    -- force the read-only mode on this phase.
     --
     -- This phase may take a long time.
     self:_store(self:_collect({sync_source = 'all'}))

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2018,6 +2018,99 @@ return schema.new('instance_config', schema.record({
             default = 10,
         }),
     }),
+    -- Compatibility options.
+    compat = schema.record({
+        json_escape_forward_slash = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'new',
+        }),
+        yaml_pretty_multiline = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'new',
+        }),
+        fiber_channel_close_mode = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'new',
+        }),
+        box_cfg_replication_sync_timeout = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'new',
+        }),
+        sql_seq_scan_default = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'new',
+        }),
+        fiber_slice_default = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'new',
+        }),
+        box_info_cluster_meaning = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'new',
+        }),
+        binary_data_decoding = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'new',
+        }),
+        box_tuple_new_vararg = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'new',
+        }),
+        box_session_push_deprecation = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'old',
+        }),
+        sql_priv = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'new',
+        }),
+        c_func_iproto_multireturn = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'new',
+        }),
+        box_space_execute_priv = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'new',
+        }),
+        box_tuple_extension = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'new',
+        }),
+        box_space_max = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'new',
+        }),
+    }),
 }, {
     -- This kind of validation cannot be implemented as the
     -- 'validate' annotation of a particular schema node. There

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -146,6 +146,7 @@ extern char session_lua[],
 	/* {{{ config */
 	config_applier_app_lua[],
 	config_applier_box_cfg_lua[],
+	config_applier_compat_lua[],
 	config_applier_console_lua[],
 	config_applier_credentials_lua[],
 	config_applier_fiber_lua[],
@@ -387,6 +388,10 @@ static const char *lua_sources[] = {
 	"config/applier/box_cfg",
 	"internal.config.applier.box_cfg",
 	config_applier_box_cfg_lua,
+
+	"config/applier/compat",
+	"internal.config.applier.compat",
+	config_applier_compat_lua,
 
 	"config/applier/console",
 	"internal.config.applier.console",

--- a/src/lua/compat.lua
+++ b/src/lua/compat.lua
@@ -335,6 +335,12 @@ end
 
 local compat = { }
 
+-- src/box/lua/config/applier/compat.lua needs information about
+-- default values.
+function compat._options()
+    return options
+end
+
 function compat.dump(mode)
     -- dump() works in one of the following modes:
     -- dump compat configuration as is with `default` if any

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -326,6 +326,23 @@ g.test_defaults = function()
             lease_interval = 30,
             renew_interval = 10,
         },
+        compat = {
+            json_escape_forward_slash = 'new',
+            yaml_pretty_multiline = 'new',
+            fiber_channel_close_mode = 'new',
+            box_cfg_replication_sync_timeout = 'new',
+            sql_seq_scan_default = 'new',
+            fiber_slice_default = 'new',
+            box_info_cluster_meaning = 'new',
+            binary_data_decoding = 'new',
+            box_tuple_new_vararg = 'new',
+            box_session_push_deprecation = 'old',
+            sql_priv = 'new',
+            c_func_iproto_multireturn = 'new',
+            box_space_execute_priv = 'new',
+            box_tuple_extension = 'new',
+            box_space_max = 'new',
+        },
     }
     local res = cluster_config:apply_default({})
     t.assert_equals(res, exp)

--- a/test/config-luatest/compat_test.lua
+++ b/test/config-luatest/compat_test.lua
@@ -1,0 +1,255 @@
+local fun = require('fun')
+local compat = require('compat')
+local instance_config = require('internal.config.instance_config')
+local t = require('luatest')
+local cbuilder = require('test.config-luatest.cbuilder')
+local replicaset = require('test.config-luatest.replicaset')
+
+local g = t.group()
+
+g.before_all(replicaset.init)
+g.after_each(replicaset.drop)
+g.after_all(replicaset.clean)
+
+-- These options can't be changed on reload.
+local non_dynamic = {
+    box_cfg_replication_sync_timeout = {
+        error = "The compat  option 'box_cfg_replication_sync_timeout' " ..
+            "takes effect only before the initial box.cfg() call",
+    },
+}
+
+-- Ensure that all the options from the compat module are present
+-- in the compat sections of the instance config and vice versa.
+--
+-- Also verify that the defaults are the same.
+g.test_parity = function()
+    -- Mapping option name -> default value.
+    local config_options = instance_config:pairs():filter(function(w)
+        return w.path[1] == 'compat'
+    end):map(function(w)
+        assert(#w.path == 2)
+        return w.path[2], w.schema.default
+    end):tomap()
+
+    -- Mapping option name -> default value.
+    local compat_options = fun.iter(compat._options()):map(function(k, v)
+        return k, v.default
+    end):tomap()
+
+    t.assert_equals(config_options, compat_options)
+end
+
+-- Verify that the given compat option has the given effective
+-- value.
+local function verify(replicaset, option_name, exp)
+    if exp == 'default' then
+        exp = compat._options()[option_name].default
+    end
+
+    replicaset['instance-001']:exec(function(option_name, exp)
+        local compat = require('compat')
+
+        local res = compat[option_name]:is_new() and 'new' or 'old'
+        t.assert_equals(res, exp)
+    end, {option_name, exp})
+end
+
+-- Write a new config file with the given compat option and reload
+-- the configuration.
+local function switch(replicaset, option_name, startup_config, v)
+    local config = cbuilder.new(startup_config)
+        :set_instance_option('instance-001', 'compat', {
+            [option_name] = v ~= 'default' and v or box.NULL,
+        })
+        :config()
+    replicaset:reload(config)
+end
+
+-- Start an instance with the given compat option value and verify
+-- that it is actually set.
+local function gen_startup_case(option_name, v)
+    return function(g)
+        local startup_config = cbuilder.new()
+            :add_instance('instance-001', {
+                compat = {
+                    [option_name] = v ~= 'default' and v or nil,
+                },
+            })
+            :config()
+
+        local replicaset = replicaset.new(g, startup_config)
+        replicaset:start()
+
+        verify(replicaset, option_name, v)
+    end
+end
+
+-- Start an instance and try to switch the given compat option
+-- with a reload and a verification of the effect.
+local function gen_reload_case(option_name)
+    return function(g)
+        local startup_config = cbuilder.new()
+            :add_instance('instance-001', {})
+            :config()
+
+        local replicaset = replicaset.new(g, startup_config)
+        replicaset:start()
+
+        verify(replicaset, option_name, 'default')
+
+        switch(replicaset, option_name, startup_config, 'old')
+        verify(replicaset, option_name, 'old')
+
+        switch(replicaset, option_name, startup_config, 'new')
+        verify(replicaset, option_name, 'new')
+
+        switch(replicaset, option_name, startup_config, 'default')
+        verify(replicaset, option_name, 'default')
+    end
+end
+
+-- Verify that an attempt to change the option on reload leads to
+-- an error.
+local function gen_reload_failure_case(option_name, startup_value, reload_value)
+    return function(g)
+        local startup_config = cbuilder.new()
+            :add_instance('instance-001', {
+                compat = {
+                    [option_name] = startup_value ~= 'default' and
+                        startup_value or nil,
+                },
+            })
+            :config()
+
+        local replicaset = replicaset.new(g, startup_config)
+        replicaset:start()
+
+        -- Attempt to switch the option to another value.
+        local exp_err = non_dynamic[option_name].error
+        t.assert_error_msg_content_equals(exp_err, switch, replicaset,
+            option_name, startup_config, reload_value)
+
+        -- Verify that the value remains the same.
+        verify(replicaset, option_name, startup_value)
+
+        -- Verify that config module reports an error.
+        replicaset['instance-001']:exec(function(exp_err)
+            local config = require('config')
+
+            local info = config:info()
+            t.assert_equals({
+                status = info.status,
+                alert_count = #info.alerts,
+                alert_1 = {
+                    type = 'error',
+                    message = info.alerts[1].message:gsub('^.-:[0-9]+: ', ''),
+                },
+            }, {
+                status = 'check_errors',
+                alert_count = 1,
+                alert_1 = {
+                    type = 'error',
+                    message = exp_err,
+                },
+            })
+        end, {exp_err})
+
+        -- Verify that things can be repaired using config:reload()
+        switch(replicaset, option_name, startup_config, startup_value)
+        replicaset['instance-001']:exec(function()
+            local config = require('config')
+
+            local info = config:info()
+            t.assert_equals({
+                status = info.status,
+                alerts = info.alerts,
+            }, {
+                status = 'ready',
+                alerts = {},
+            })
+        end)
+    end
+end
+
+-- Verify that start with the given compat option value and reload
+-- it to the second given value is successful.
+local function gen_reload_success_case(option_name, startup_value, reload_value)
+    return function(g)
+        local startup_config = cbuilder.new()
+            :add_instance('instance-001', {
+                compat = {
+                    [option_name] = startup_value ~= 'default' and
+                        startup_value or nil,
+                },
+            })
+            :config()
+
+        local replicaset = replicaset.new(g, startup_config)
+        replicaset:start()
+
+        -- Verify that the option is switched successfully.
+        switch(replicaset, option_name, startup_config, reload_value)
+        verify(replicaset, option_name, reload_value)
+
+        -- Verify that config module doesn't report an error.
+        replicaset['instance-001']:exec(function()
+            local config = require('config')
+
+            local info = config:info()
+            t.assert_equals({
+                status = info.status,
+                alerts = info.alerts,
+            }, {
+                status = 'ready',
+                alerts = {},
+            })
+        end)
+    end
+end
+
+-- Walk over the compat options and generate test cases for them.
+for option_name, _ in pairs(compat._options()) do
+    -- Start with the given option value.
+    local case_name_prefix = ('test_startup_%s_'):format(option_name)
+    for _, v in ipairs({'default', 'old', 'new'}) do
+        g[case_name_prefix .. v] = gen_startup_case(option_name, v)
+    end
+
+    if non_dynamic[option_name] == nil then
+        -- Start without compat option and set it on reload.
+        g['test_reload_' .. option_name] = gen_reload_case(option_name)
+    else
+        -- Start with one option name and set another on reload (expect an
+        -- error).
+        --
+        -- Also verify that null and an effective default may be
+        -- used interchangeably and switching from one to another
+        -- on reload doesn't trigger any error.
+        local case_name_prefix = ('test_reload_%s_'):format(option_name)
+        g[case_name_prefix .. 'failure_old_to_new'] = gen_reload_failure_case(
+            option_name, 'old', 'new')
+        g[case_name_prefix .. 'failure_new_to_old'] = gen_reload_failure_case(
+            option_name, 'new', 'old')
+        local def = compat._options()[option_name].default
+        if def == 'old' then
+            g[case_name_prefix .. 'failure_default_to_new'] =
+                gen_reload_failure_case(option_name, 'default', 'new')
+            g[case_name_prefix .. 'failure_new_to_default'] =
+                gen_reload_failure_case(option_name, 'new', 'default')
+            g[case_name_prefix .. 'success_default_to_old'] =
+                gen_reload_success_case(option_name, 'default', 'old')
+            g[case_name_prefix .. 'success_old_to_default'] =
+                gen_reload_success_case(option_name, 'old', 'default')
+        else
+            g[case_name_prefix .. 'success_default_to_new'] =
+                gen_reload_success_case(option_name, 'default', 'new')
+            g[case_name_prefix .. 'success_new_to_default'] =
+                gen_reload_success_case(option_name, 'new', 'default')
+            g[case_name_prefix .. 'failure_default_to_old'] =
+                gen_reload_failure_case(option_name, 'default', 'old')
+            g[case_name_prefix .. 'failure_old_to_default'] =
+                gen_reload_failure_case(option_name, 'old', 'default')
+        end
+    end
+end


### PR DESCRIPTION
The new section `compat` is added to the declarative configuration.

The options are the same as ones provided by the `compat` module. Each can be set to `old` or `new`.

Example:

```yaml
compat:
  json_escape_forward_slash: old
```

The list of currently supported options with their defaults:

```yaml
compat:
  json_escape_forward_slash: new
  yaml_pretty_multiline: new
  fiber_channel_close_mode: new
  box_cfg_replication_sync_timeout: new
  sql_seq_scan_default: new
  fiber_slice_default: new
  box_info_cluster_meaning: new
  binary_data_decoding: new
  box_tuple_new_vararg: new
  box_session_push_deprecation: old
  sql_priv: new
  c_func_iproto_multireturn: new
  box_space_execute_priv: new
  box_tuple_extension: new
  box_space_max: new
...
```

The `box_cfg_replication_sync_timeout` option is non-dynamic and it can't be changed after a startup.

Technically, all the other options could be changed in runtime (by changing the configuration file and calling `config:reload()`), but I would not generally recommend it.

At least code that handles `fiber_channel_close_mode` option has the following comment, see commit de9b93081873 ("fiber: add channel close mode option to compat").

> The behavior is unspecified for already created channels.
> Choose the mode at an early stage of application's
> initialization.

Fixes #9497