### PR TITLE
iproto: don't use cord_cancel_and_join for iproto shutdown

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -5866,7 +5866,6 @@ box_storage_free(void)
 {
 	if (!is_storage_initialized)
 		return;
-	iproto_free();
 	replication_free();
 	gc_free();
 	engine_shutdown();
@@ -5922,7 +5921,7 @@ box_storage_shutdown()
 {
 	if (!is_storage_initialized)
 		return;
-	iproto_drop_connections();
+	iproto_shutdown();
 }
 
 void

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -3036,12 +3036,12 @@ net_cord_f(va_list  ap)
 	cbus_loop(&endpoint);
 
 	cpipe_destroy(&iproto_thread->tx_pipe);
-	/*
-	 * Nothing to do in the fiber so far, the service
-	 * will take care of creating events for incoming
-	 * connections.
-	 */
+	cbus_endpoint_destroy(&endpoint, cbus_process);
 	evio_service_detach(&iproto_thread->binary);
+
+	mempool_destroy(&iproto_thread->iproto_stream_pool);
+	mempool_destroy(&iproto_thread->iproto_connection_pool);
+	mempool_destroy(&iproto_thread->iproto_msg_pool);
 	return 0;
 }
 
@@ -3785,10 +3785,15 @@ iproto_req_handler_delete(struct iproto_req_handler *handler)
 }
 
 void
-iproto_free(void)
+iproto_shutdown(void)
 {
+	iproto_drop_connections();
+
 	for (int i = 0; i < iproto_threads_count; i++) {
-		cord_cancel_and_join(&iproto_threads[i].net_cord);
+		cbus_stop_loop(&iproto_threads[i].net_pipe);
+		cpipe_destroy(&iproto_threads[i].net_pipe);
+		if (cord_join(&iproto_threads[i].net_cord) != 0)
+			panic_syserror("iproto cord join failed");
 		mh_i32_delete(iproto_threads[i].req_handlers);
 		/*
 		 * Close socket descriptor to prevent hot standby instance

--- a/src/box/iproto.h
+++ b/src/box/iproto.h
@@ -178,8 +178,12 @@ iproto_session_send(struct session *session,
 		    const char *header, const char *header_end,
 		    const char *body, const char *body_end);
 
+/**
+ * Drop all current connections (see iproto_drop_connections) stop and
+ * free iproto. TX event loop running is required to work.
+ */
 void
-iproto_free(void);
+iproto_shutdown(void);
 
 /**
  * Drop all current connections. That is stop IO and cancel all inprogress


### PR DESCRIPTION
Also we now can free all resources allocated in iproto threads.

Part of #8423