### PR TITLE
box: fix crash when on_shutdown trigger is removed

### DIFF
--- a/src/lib/core/event.c
+++ b/src/lib/core/event.c
@@ -266,6 +266,16 @@ event_remove_temporary_triggers(struct event *event)
 }
 
 void
+event_ref_all_triggers(struct event *event)
+{
+	struct event_trigger *curr = NULL;
+	rlist_foreach_entry(curr, &event->triggers, link) {
+		if (!curr->is_deleted)
+			event_trigger_ref(curr);
+	}
+}
+
+void
 event_trigger_iterator_create(struct event_trigger_iterator *it,
 			      struct event *event)
 {

--- a/src/lib/core/event.h
+++ b/src/lib/core/event.h
@@ -116,6 +116,13 @@ void
 event_remove_temporary_triggers(struct event *event);
 
 /**
+ * Reference all non-deleted triggers to prevent their deletion.
+ * They will be freed only with the event subsystem.
+ */
+void
+event_ref_all_triggers(struct event *event);
+
+/**
  * Iterator over triggers from event. Never invalidates.
  */
 struct event_trigger_iterator {

--- a/src/on_shutdown.c
+++ b/src/on_shutdown.c
@@ -228,6 +228,12 @@ on_shutdown_run_triggers(void)
 		}
 	}
 
+	/*
+	 * Since we run the triggers asynchronously, we need to reference them
+	 * to prevent use-after-free, because a trigger can delete another one
+	 * or even itself, and nothing would reference it anymore.
+	 */
+	event_ref_all_triggers(event);
 	const char *trigger_name = NULL;
 	struct func_adapter *func = NULL;
 	struct event_trigger_iterator it;

--- a/test/box-luatest/gh_9275_remove_on_shutdown_trigger_while_run_test.lua
+++ b/test/box-luatest/gh_9275_remove_on_shutdown_trigger_while_run_test.lua
@@ -1,0 +1,31 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.test_remove_on_shutdown_trigger_while_run = function()
+    local server = server:new()
+    server:start()
+    server:exec(function()
+        local fiber = require('fiber')
+
+        -- Yield at the end of each handler so that underlyig
+        -- trigger iterator makes a step and unreferences the trigger.
+        local function h1()
+            box.ctl.on_shutdown(nil, h1)
+            fiber.sleep(0)
+        end
+        local function h2()
+            box.ctl.on_shutdown(nil, nil, 'h3')
+            fiber.sleep(0)
+        end
+        local function h3()
+            box.ctl.on_shutdown(nil, nil, 'h2')
+            fiber.sleep(0)
+        end
+        box.ctl.on_shutdown(h1)
+        box.ctl.on_shutdown(h2, nil, 'h2')
+        box.ctl.on_shutdown(h3, nil, 'h3')
+    end)
+    server:drop()
+end


### PR DESCRIPTION
Since on_shutdown triggers are fired asynchronously in their own fibers, they are not referenced by `event_trigger_iterator`. That's why, if on_shutdown trigger is deleted while it is running (or is scheduled to run), it will be instantly removed, and when it is finished, segmentation fault will happen on its finalizer (`func_adapter_end`). Let's reference all on_shutdown triggers to prevent such situation - they will be deleted soon along with the whole event subsystem.
    
Closes #9275