### PR TITLE
config: fix automatic names apply before schema upgrade

### DIFF
--- a/extra/exports
+++ b/extra/exports
@@ -92,6 +92,7 @@ box_latch_lock
 box_latch_new
 box_latch_trylock
 box_latch_unlock
+box_latest_dd_version_id
 box_on_shutdown
 box_read_ffi_disable
 box_read_ffi_is_disabled

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -283,7 +283,9 @@ local function names_apply(config, missing_names, schema_version)
     names_alert_missing(config, missing_names)
     -- Don't wait for box.status to change, we may be already rw, set names
     -- on reload, if it's possible and needed.
-    names_try_set_missing()
+    if schema_version and schema_version >= mkversion.get_latest() then
+        names_try_set_missing()
+    end
 
     if names_state.is_configured then
         -- All triggers are already configured, nothing to do, but wait.

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -210,10 +210,10 @@ local function names_schema_upgrade_on_replace(old, new)
         return
     end
 
-    local version_3 = mkversion(3, 0, 0)
+    local latest_version = mkversion.get_latest()
     local old_version = mkversion.from_tuple(old)
     local new_version = mkversion.from_tuple(new)
-    if old_version < version_3 and new_version >= version_3 then
+    if old_version < latest_version and new_version >= latest_version then
         -- We cannot do it inside on_replace trigger, as the version
         -- is not considered set yet and we may try to set names, when
         -- schema is not yet updated, which will fail as DDL is
@@ -295,7 +295,7 @@ local function names_apply(config, missing_names, schema_version)
 
     -- Wait for rw state. If schema version is nil, bootstrap is
     -- going to be done.
-    if schema_version and schema_version < mkversion(3, 0, 0) then
+    if schema_version and schema_version < mkversion.get_latest() then
         box.space._schema:on_replace(names_schema_upgrade_on_replace)
         names_state.is_upgrade_wait = true
     else

--- a/src/box/lua/mkversion.lua
+++ b/src/box/lua/mkversion.lua
@@ -1,7 +1,11 @@
 local bit = require('bit')
 local ffi = require('ffi')
 
-ffi.cdef([[ uint32_t box_dd_version_id(void); ]])
+ffi.cdef([[
+    uint32_t box_dd_version_id(void);
+    uint32_t box_latest_dd_version_id(void);
+]])
+
 local builtin = ffi.C
 
 local mkversion_mt = {
@@ -48,6 +52,12 @@ local function mkversion_get()
     return mkversion_from_id(version)
 end
 
+-- Latest schema version this instance recognizes.
+local function mkversion_get_latest()
+    local version = builtin.box_latest_dd_version_id()
+    return mkversion_from_id(version)
+end
+
 local function mkversion_from_tuple(tuple)
     local major, minor, patch = tuple:unpack(2, 4)
     patch = patch or 0
@@ -61,6 +71,7 @@ end
 return setmetatable({
     new = mkversion_new,
     get = mkversion_get,
+    get_latest = mkversion_get_latest,
     from_id = mkversion_from_id,
     from_tuple = mkversion_from_tuple,
     from_string = mkversion_from_string,

--- a/src/box/schema.cc
+++ b/src/box/schema.cc
@@ -92,6 +92,13 @@ box_dd_version_id(void)
 	return dd_version_id;
 }
 
+/** Called from Lua via FFI to get latest_dd_version_id. */
+extern "C" uint32_t
+box_latest_dd_version_id(void)
+{
+	return latest_dd_version_id;
+}
+
 /** Called from Lua via FFI to init latest_dd_version_id. */
 extern "C" void
 box_init_latest_dd_version_id(uint32_t version_id)

--- a/test/config-luatest/names_upgrade_test.lua
+++ b/test/config-luatest/names_upgrade_test.lua
@@ -96,6 +96,12 @@ local function assert_before_upgrade()
     local info = box.info
     t.assert_equals(info.name, nil)
     t.assert_equals(info.replicaset.name, nil)
+    -- Check that config:reload() respects old schema version.
+    local config = require('config')
+    config:reload()
+    info = box.info
+    t.assert_equals(info.name, nil)
+    t.assert_equals(info.replicaset.name, nil)
 end
 
 local function assert_after_upgrade(instance_name, replicaset_name, names)


### PR DESCRIPTION
Each config reload on a node with old schema (less than 3.0.0) lead to the error ER_SCHEMA_NEEDS_UPGRADE. This happened because the relevant code didn't check for schema version before trying to apply the names.

Fix this.

Closes #9502

NO_DOC=bugfix
NO_CHANGELOG=fix in a not yet released behavior