### PR TITLE
[2.10] sql: properly check result of decimal parsing

### DIFF
--- a/changelogs/unreleased/gh-9469-too-big-decimal.md
+++ b/changelogs/unreleased/gh-9469-too-big-decimal.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Fixed a crash when a decimal literal representing a decimal number greater
+  than or equal to 10^38 was parsed in SQL (gh-9469).

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -319,6 +319,7 @@ struct errcode_record {
 	/*264 */_(ER_UNUSED18,			"") \
 	/*265 */_(ER_UNUSED19,			"") \
 	/*266 */_(ER_MISSING_SYSTEM_SPACES,	"Snapshot has no system spaces") \
+	/*267 */_(ER_INVALID_DEC,		"Invalid decimal: '%s'") \
 
 /*
  * !IMPORTANT! Please follow instructions at start of the file

--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -3382,6 +3382,7 @@ expr_code_dec(struct Parse *parser, struct Expr *expr, bool is_neg, int reg)
 	return;
 error:
 	sqlDbFree(sql_get(), value);
+	diag_set(ClientError, ER_INVALID_DEC, str);
 	parser->is_aborted = true;
 }
 

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -466,6 +466,7 @@ t;
  |   245: box.error.OLD_TERM
  |   246: box.error.INTERFERING_ELECTIONS
  |   266: box.error.MISSING_SYSTEM_SPACES
+ |   267: box.error.INVALID_DEC
  | ...
 
 test_run:cmd("setopt delimiter ''");

--- a/test/sql-luatest/gh_9469_too_big_decimals_test.lua
+++ b/test/sql-luatest/gh_9469_too_big_decimals_test.lua
@@ -1,0 +1,29 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_too_big_decimal = function()
+    g.server:exec(function()
+        local dec = '111111111111111111111111111111111111111.0'
+        local sql = ([[SELECT %s;]]):format(dec)
+        local exp = ([[Invalid decimal: '%s']]):format(dec)
+        local res, err = box.execute(sql)
+        t.assert(res == nil)
+        t.assert_equals(err.message, exp)
+
+        sql = ([[SELECT -%s;]]):format(dec)
+        res, err = box.execute(sql)
+        t.assert(res == nil)
+        t.assert_equals(err.message, exp)
+    end)
+end


### PR DESCRIPTION
This patch fixes a crash that can occur when SQL parses a decimal literal that represents a number greater than or equal to 10^38.

Closes #9469

NO_DOC=bugfix

(cherry picked from commit 05551a556bbca9e4aa5fa910e1b62ea67e6177e6)