### PR TITLE
Rework Lua module searchers and loaders

### DIFF
--- a/changelogs/unreleased/fix-lua-loader-error-handling.md
+++ b/changelogs/unreleased/fix-lua-loader-error-handling.md
@@ -1,0 +1,4 @@
+## bugfix/lua
+
+* Fixed the incorrect propagation of Lua errors raised while loading
+  the module via the Tarantool-specific loaders.

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -913,6 +913,10 @@ tarantool_lua_init(const char *tarantool_bin, const char *script, int argc,
 	}
 	lua_setfield(L, LUA_GLOBALSINDEX, "arg");
 
+	/* Create a table for "package.searchers" analogue. */
+	lua_newtable(L);
+	lua_setfield(L, LUA_REGISTRYINDEX, "_TARANTOOL_PACKAGE_SEARCHERS");
+
 	/*
 	 * Create a table for storing loaded built-in modules.
 	 * Similar to _LOADED (package.loaded).

--- a/src/lua/loaders.lua
+++ b/src/lua/loaders.lua
@@ -247,15 +247,15 @@ local function prefix_searcher(prefix, subsearcher)
     end
 end
 
--- Accept a loader and return the same loader, but enabled only
--- when given condition (a function return value) is true.
-local function conditional_loader(subloader, onoff)
+-- Accept a searcher and return the same searcher, but enabled
+-- only when given condition (a function return value) is true.
+local function conditional_searcher(subsearcher, onoff)
     assert(type(onoff) == 'function')
     return function(name)
         if onoff(name) then
-            return subloader(name)
+            return subsearcher(name)
         end
-        -- It is okay to return nothing, require() ignores it.
+        -- It is okay to return nothing, <require> ignores it.
     end
 end
 
@@ -431,14 +431,14 @@ local function override_searcher_onoff(_name)
     return getenv_boolean('TT_OVERRIDE_BUILTIN', true)
 end
 
-local override_loader = conditional_loader(gen_file_loader(chain_searchers({
+local override_loader = gen_file_loader(conditional_searcher(chain_searchers({
     prefix_searcher('override', searchers[2]),
     prefix_searcher('override', searchers[3]),
     prefix_searcher('override', searchers[4]),
     prefix_searcher('override', searchers[5]),
     prefix_searcher('override', searchers[6]),
     prefix_searcher('override', searchers[7]),
-})), override_searcher_onoff)
+}), override_searcher_onoff))
 
 
 local function dummy_loader(searcher, sentinel)

--- a/src/lua/loaders.lua
+++ b/src/lua/loaders.lua
@@ -140,11 +140,9 @@ local function gen_loader_func(search_fn, load_fn)
             return err
         end
         local loaded, err = load_fn(file, name)
-        if err == nil then
-            return loaded
-        else
-            return err
-        end
+        local message = ("error loading module '%s' from file '%s':\n\t%s")
+                        :format(name, file, err)
+        return assert(loaded, message)
     end
 end
 

--- a/test/app-luatest/fix_lua_loader_error_handling_test.lua
+++ b/test/app-luatest/fix_lua_loader_error_handling_test.lua
@@ -1,0 +1,44 @@
+local t = require('luatest')
+local treegen = require('test.treegen')
+local fio = require('fio')
+
+local g = t.group()
+
+-- XXX: I would rather tweak <package.path>, since it's the
+-- recommended way to manage the hints for the loaders. However,
+-- the loader provided by LuaJIT that uses <package.path> works
+-- fine (i.e. throws the expected error), unlike the ones added
+-- for Tarantool. Hence, the easiest way to check Tarantool
+-- loaders is switching the current working directory for the
+-- test. Preserve the original working directory to restore it at
+-- the end of the test.
+local cwd = fio.cwd()
+
+local luadir
+local name = 'syntax'
+
+-- XXX: Unfortunately, multiline literals do not interpolate
+-- escape sequences, so just concatenate two lines of the error
+-- message to build the final template.
+local errlike = table.concat({
+    "error loading module '<NAME>' from file '<DIR>/<NAME>.lua':",
+    "<DIR>/<NAME>.lua:1: unexpected symbol near '?'",
+}, "\n\t")
+
+
+g.before_all(function()
+    treegen.init(g)
+    treegen.add_template(g, ('^%s%%.lua$'):format(name), [[?syntax error?]])
+    luadir = treegen.prepare_directory(g, {('%s.lua'):format(name)})
+    fio.chdir(luadir)
+end)
+
+g.after_all(function(g)
+    treegen.clean(g)
+    fio.chdir(cwd)
+end)
+
+g.test_loader_error_handling = function()
+    local errmsg = errlike:gsub('%<(%w+)>', { DIR = luadir, NAME = name })
+    t.assert_error_msg_equals(errmsg, require, name)
+end


### PR DESCRIPTION
This patchset implements the refactoring of Tarantool `package.loaders` required for Tarantool integrity protection (needed for tarantool/tarantool-ee#585).

**Per-patch review is highly recommended (though GitHub works badly in this mode).**

Since Tarantool follows [Lua 5.1 semantics](https://www.lua.org/manual/5.1/manual.html), the set of routines in package.loaders is used to tweak Lua modules loading. E.g. overriding
machinery has been implemented on top of the `package.loaders`. Unfortunately, `package.loaders` are not such flexible as it's needed and this mechanism is redesigned in [Lua 5.2](https://www.lua.org/manual/5.2/manual.html).

Starting from Lua 5.2 package.loaders has been superseded by `package.searchers`. This is quite natural change, since nobody wants to tweak the "loading" rules, but rather the "searching" process. As a result of this redesign evolution up to the [Lua 5.4](https://www.lua.org/manual/5.4/manual.html), users are able to obtain the "source" of the module being loaded (i.e. file name or specific sentinel for preload packages).

---

This first patch introduces Tarantool internal table with package.searchers and reimplements package.preload and tarantool.builtin loaders using the machinery described above:
* The new searcher function, respecting Lua 5.4 semantics, is implemented for each loader.
* Each searcher is wrapped with the function to implement "dummy" loader respecting Lua 5.1 semantics.

---

Originally, Lua uses only constant path patterns in `package.path` and `package.cpath`. Tarantool enhances user experience here and provides more relaxed rules for module searching: some paths are calculated at the moment the module is being searched and are relative to the current working directory. Unfortunately it makes "searchers" more complex, since all the paths can't be calculated when Tarantool starts up.

Furthermore, there is the particular priority while loading Lua modules in Tarantool. Originally, Lua tries to load the particular Lua script using the hints from `package.path` and *only if* no Lua module is found, Lua tries to load the corresponding Lua C library using the hints from `package.cpath`. Tarantool loaders are prioritized by the locations at first and only then by the module implementation. This also makes "searchers" structure more complex than it could be.

Anyway, "file" loaders are split into the three layers:
1. "Pathogen": the function generated by `<gen_path_builder>`, building the hints for searchers.
2. "Searcher": the function generated by `<gen_file_searcher>` helper, using the particular file loading method (`<load_lua>` or `<load_lib>`) and the given pathogen to obtain the hints with path patterns to be used in `<package.searchpath>` routine.
3. "Loader": the function generated by `<gen_file_loader>` helper, following Lua 5.1 loaders semantics and using the particular searcher.

All the generated searchers are stored in the <package.searchers> analogue introduced in the first patch of this refactoring series.

---

Considering the way "app" paths injection is implemented in Tarantool loaders to save the loading priority, the chained loaders machinery introduced in the commit 7e9051c44905dbe5c2396568ee252e09bf1963da ("lua: don't set built-in modules to package.loaded") is also implemented for the new searching mechanism. The approach is the same as the one used for chaining loaders. As a result, "app" paths searchers are injected into the "cwd" paths searchers the same way it has been done in the original loaders context.

The third patch also introduces numerical indices into <package.searchers> analogue to provide the convenient searchers <-> loaders mapping used in the final patch of this series.

--- 

Within the fourth patch the overriding mechanism introduced in the commit ec47c389fd5e5e64a1a8d1d33dac108c19b325c0 ("lua: allow to override a built-in module") is moved to the "searching" phase of the new loading machinery. Furthermore, `package.path`/`package.cpath` searchers are also added to the indexed list made for the mapping.

---

Within the fifth patch the mechanism for enabling/disabling loaders introduced in the commit 87b4da31e1ac2c14e9779054b28601862652d706 ("lua: enable/disable override loader") is moved to the "searching" phase of the new loading machinery.

---

Though croot loader is not the popular way to work with Lua C libraries, some modules are organised using this mechanism, so they have to be verified via Tarantool integrity protection system, hence croot loader has to be reimplemented to the new searching machinery.
    
The corresponding croot searcher is implemented in this patch and added to the indexed part of the <package.searchers> table. 
    
It's worth to mention two peculiarities related to the croot loader and searcher:
* Since Tarantool uses original croot loader from LuaJIT, it ignores all paths except ones specified in `<package.cpath>`. However, there might be some croot-like modules in the Tarantool-specific cpaths (cwd or application root). It looks like croot machinery is not widely used, if this bug bothers nobody, but it's still need to be fixed.
* Similar situation relates to the overriding mechanism, that was recently introduced: there is no "prefixed" croot loader and all libraries using croot loading machinery are ignored for the overridden paths as a result.

---

Though all Lua 5.1 loaders machinery will be superseded by Lua 5.4 searchers machinery, Tarantool still should follow Lua 5.1 semantics, so the "legacy" loader is required. This patch implements the common helper `<gen_legacy_loader>` to wrap all loaders and make the new machinery conform the Lua 5.1 semantics.
    
Moreover, some since all tweaks and helpers are implemented for searching machinery, `<chain_loaders>` is not required anymore.

---

Finally, to make it possible to instrument the searchers with Tarantool integrity protection, two steps are left.
* Implement mapping from searchers table to `<package.loaders>` using `<gen_legacy_loader>` helper.
* Obtain the searcher from the table directly, so the runtime instrumentation take the effect.

As a result `<gen_legacy_loader>` is reimplemented to use the table with searchers as an upvalue instead of the particular searcher routiine, and `<package.loaders>` table is filled by the function generated with the updated helper.

---
---

The first patch of the series fixes error handling between module "searching" and "loading" processes. Originally, if module is not found, the error message is returned to <require> and is accumulated to the "not found" message. If no suitable module is found, the error is raised by `<require>`. In case, when the desired module is found, <require> tries to load it. If any error occurs while loading the module, the "loader" yields the corresponding error. The latter part was broken since the commit 4e27b0e61747c5c6a8e7b9e53b18fa78f24ae61a ("app: let user define search root for packages"), so if the error occurs while loading the module, Tarantool proceed with searching the module in other locations.
    
This bug was found via [lua-Harness suite](https://fperrad.frama.io/lua-Harness/) used in tarantool/luajit testing routine, so the test added in the patch partially duplicates the particular test case in lua-Harness.