### PR TITLE
config: introduce vshard named identification

### DIFF
--- a/src/box/lua/config/applier/sharding.lua
+++ b/src/box/lua/config/applier/sharding.lua
@@ -22,7 +22,9 @@ local function apply(config)
     local cfg = configdata:sharding()
     if is_storage then
         log.info('sharding: apply storage config')
-        _G.vshard.storage.cfg(cfg, box.info.uuid)
+        -- Name may be not set in box.info.name, e.g. during names applying.
+        -- Configure vshard anyway, pass configuration name.
+        _G.vshard.storage.cfg(cfg, configdata:names().instance_name)
     end
     if is_router then
         log.info('sharding: apply router config')

--- a/test/config-luatest/config_test.lua
+++ b/test/config-luatest/config_test.lua
@@ -153,8 +153,6 @@ local function verify_configdata()
         replicaset_name = "replicaset-001",
     }
     local res_names = data:names()
-    res_names.instance_uuid = nil
-    res_names.replicaset_uuid = nil
     t.assert_equals(res_names, expected_names)
 
     t.assert_equals(data:peers(), {'instance-001', 'instance-002'})

--- a/test/config-luatest/vars_test.lua
+++ b/test/config-luatest/vars_test.lua
@@ -186,20 +186,9 @@ g.test_sharding = run_as_script(function()
                 },
                 replicasets = {
                     ['routers-a'] = {
-                        database = {
-                            replicaset_uuid = t.helpers.uuid('f', 0),
-                        },
                         instances = {
-                            ['router-001'] = {
-                                database = {
-                                    instance_uuid = t.helpers.uuid('f', 1),
-                                },
-                            },
-                            ['router-002'] = {
-                                database = {
-                                    instance_uuid = t.helpers.uuid('f', 2),
-                                },
-                            },
+                            ['router-001'] = {},
+                            ['router-002'] = {},
                         },
                     },
                 },
@@ -210,47 +199,17 @@ g.test_sharding = run_as_script(function()
                 },
                 replicasets = {
                     ['storages-a'] = {
-                        database = {
-                            replicaset_uuid = t.helpers.uuid('e', 'a', 0),
-                        },
                         instances = {
-                            ['storage-a-001'] = {
-                                database = {
-                                    instance_uuid = t.helpers.uuid('e', 'a', 1),
-                                },
-                            },
-                            ['storage-a-002'] = {
-                                database = {
-                                    instance_uuid = t.helpers.uuid('e', 'a', 2),
-                                },
-                            },
-                            ['storage-a-003'] = {
-                                database = {
-                                    instance_uuid = t.helpers.uuid('e', 'a', 3),
-                                },
-                            },
+                            ['storage-a-001'] = {},
+                            ['storage-a-002'] = {},
+                            ['storage-a-003'] = {},
                         },
                     },
                     ['storages-b'] = {
-                        database = {
-                            replicaset_uuid = t.helpers.uuid('e', 'b', 0),
-                        },
                         instances = {
-                            ['storage-b-001'] = {
-                                database = {
-                                    instance_uuid = t.helpers.uuid('e', 'b', 1),
-                                },
-                            },
-                            ['storage-b-002'] = {
-                                database = {
-                                    instance_uuid = t.helpers.uuid('e', 'b', 2),
-                                },
-                            },
-                            ['storage-b-003'] = {
-                                database = {
-                                    instance_uuid = t.helpers.uuid('e', 'b', 3),
-                                },
-                            },
+                            ['storage-b-001'] = {},
+                            ['storage-b-002'] = {},
+                            ['storage-b-003'] = {},
                         },
                     },
                 },
@@ -269,36 +228,30 @@ g.test_sharding = run_as_script(function()
 
     -- Verify URIs of the storages.
     t.assert_equals(res.sharding, {
-        [t.helpers.uuid('e', 'a', 0)] = {
+        ['storages-a'] = {
             master = 'auto',
             replicas = {
-                [t.helpers.uuid('e', 'a', 1)] = {
-                    name = 'storage-a-001',
+                ['storage-a-001'] = {
                     uri = exp_uri('storages', 'storages-a', 'storage-a-001'),
                 },
-                [t.helpers.uuid('e', 'a', 2)] = {
-                    name = 'storage-a-002',
+                ['storage-a-002'] = {
                     uri = exp_uri('storages', 'storages-a', 'storage-a-002'),
                 },
-                [t.helpers.uuid('e', 'a', 3)] = {
-                    name = 'storage-a-003',
+                ['storage-a-003'] = {
                     uri = exp_uri('storages', 'storages-a', 'storage-a-003'),
                 },
             },
         },
-        [t.helpers.uuid('e', 'b', 0)] = {
+        ['storages-b'] = {
             master = 'auto',
             replicas = {
-                [t.helpers.uuid('e', 'b', 1)] = {
-                    name = 'storage-b-001',
+                ['storage-b-001'] = {
                     uri = exp_uri('storages', 'storages-b', 'storage-b-001'),
                 },
-                [t.helpers.uuid('e', 'b', 2)] = {
-                    name = 'storage-b-002',
+                ['storage-b-002'] = {
                     uri = exp_uri('storages', 'storages-b', 'storage-b-002'),
                 },
-                [t.helpers.uuid('e', 'b', 3)] = {
-                    name = 'storage-b-003',
+                ['storage-b-003'] = {
                     uri = exp_uri('storages', 'storages-b', 'storage-b-003'),
                 },
             },

--- a/test/config-luatest/vshard_test.lua
+++ b/test/config-luatest/vshard_test.lua
@@ -119,6 +119,7 @@ g.test_fixed_masters = function(g)
         bucket_count = 1234,
         discovery_mode = "on",
         failover_ping_timeout = 5,
+        identification_mode = 'name_as_key',
         rebalancer_disbalance_threshold = 1,
         rebalancer_max_receiving = 100,
         rebalancer_max_sending = 1,
@@ -129,41 +130,39 @@ g.test_fixed_masters = function(g)
         shard_index = "bucket_id",
         sync_timeout = 1,
         sharding = {
-            ["11111111-1111-1111-0011-111111111111"] = {
+            ["replicaset-001"] = {
                 master = "auto",
                 replicas = {
-                    ["ef10b92d-9ae9-e7bb-004c-89d8fb468341"] = {
-                        name = "instance-002",
-                        uri = {
-                            login = "storage",
-                            password = "storage",
-                            uri = "unix/:./instance-002.iproto",
-                        },
-                    },
-                    ["ffe08155-a26d-bd7c-0024-00ee6815a41c"] = {
-                        name = "instance-001",
+                    ["instance-001"] = {
                         uri = {
                             login = "storage",
                             password = "storage",
                             uri = "unix/:./instance-001.iproto",
                         },
                     },
+                    ["instance-002"] = {
+                        uri = {
+                            login = "storage",
+                            password = "storage",
+                            uri = "unix/:./instance-002.iproto",
+                        },
+                    },
                 },
+                uuid = "11111111-1111-1111-0011-111111111111",
                 weight = 1,
             },
-            ["d1f75e70-6883-d7fe-0087-e582c9c67543"] = {
+            ["replicaset-002"] = {
                 master = "auto",
                 replicas = {
-                    ["22222222-2222-2222-0022-222222222222"] = {
-                        name = "instance-003",
+                    ["instance-003"] = {
                         uri = {
                             login = "storage",
                             password = "storage",
                             uri = "unix/:./instance-003.iproto",
                         },
+                        uuid = "22222222-2222-2222-0022-222222222222",
                     },
-                    ["50367d8e-488b-309b-001a-138a0c516772"] = {
-                        name = "instance-004",
+                    ["instance-004"] = {
                         uri = {
                             login = "storage",
                             password = "storage",
@@ -233,9 +232,9 @@ g.test_fixed_masters = function(g)
     g.server_5:eval(exec)
     t.helpers.retrying({timeout = 60}, function()
         local res = g.server_2:eval([[return box.space.a:select()]])
-        t.assert_equals(res, {{800, 800}})
-        res = g.server_4:eval([[return box.space.a:select()]])
         t.assert_equals(res, {{1, 1}})
+        res = g.server_4:eval([[return box.space.a:select()]])
+        t.assert_equals(res, {{800, 800}})
     end)
 
     -- Make sure that the new master is auto-discovered when master is changed.
@@ -252,9 +251,9 @@ g.test_fixed_masters = function(g)
     g.server_5:eval(exec)
     t.helpers.retrying({timeout = 60}, function()
         local res = g.server_1:eval([[return box.space.a:select()]])
-        t.assert_equals(res, {{799, 799}, {800, 800}})
-        res = g.server_3:eval([[return box.space.a:select()]])
         t.assert_equals(res, {{1, 1}, {2, 2}})
+        res = g.server_3:eval([[return box.space.a:select()]])
+        t.assert_equals(res, {{799, 799}, {800, 800}})
     end)
 end
 
@@ -355,42 +354,38 @@ g.test_rebalancer_role = function(g)
 
     -- Check vshard config on each instance.
     local exp = {
-        ["2ab78dc2-4652-3699-00e4-12df0ae32351"] = {
+        ["replicaset-001"] = {
             master = "auto",
             rebalancer = true,
             replicas = {
-                ["ef10b92d-9ae9-e7bb-004c-89d8fb468341"] = {
-                    name = "instance-002",
-                    uri = {
-                        login = "storage",
-                        password = "storage",
-                        uri = "unix/:./instance-002.iproto"
-                    },
-                },
-                ["ffe08155-a26d-bd7c-0024-00ee6815a41c"] = {
-                    name = "instance-001",
+                ["instance-001"] = {
                     uri = {
                         login = "storage",
                         password = "storage",
                         uri = "unix/:./instance-001.iproto"
                     },
                 },
+                ["instance-002"] = {
+                    uri = {
+                        login = "storage",
+                        password = "storage",
+                        uri = "unix/:./instance-002.iproto"
+                    },
+                },
             },
             weight = 1,
         },
-        ["d1f75e70-6883-d7fe-0087-e582c9c67543"] = {
+        ["replicaset-002"] = {
             master = "auto",
             replicas = {
-                ["f2974852-9b48-8e24-00ea-d34059bf24fd"] = {
-                    name = "instance-003",
+                ["instance-003"] = {
                     uri = {
                         login = "storage",
                         password = "storage",
                         uri = "unix/:./instance-003.iproto"
                     },
                 },
-                ["50367d8e-488b-309b-001a-138a0c516772"] = {
-                    name = "instance-004",
+                ["instance-004"] = {
                     uri = {
                         login = "storage",
                         password = "storage",


### PR DESCRIPTION
Vshard now supports names instead of UUIDs in configuration. Let's use them and finally drop generating UUIDs in config.

From now on we can recover instances without explicitly passing UUIDs to configuration.