### PR TITLE
Disable runtime tweaks if integrity checks is enabled

### DIFF
--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -1165,6 +1165,19 @@ run_script_f(va_list ap)
 			break;
 		case 'e':
 			/*
+			 * Do not run the chunk given via -e
+			 * option if the integrity check is enabled.
+			 * XXX: Fortunately, -e and its argument
+			 * are stripped from the Lua <arg> table,
+			 * so this is "The Last Homely House"
+			 * where one can obtain this Lua chunk.
+			 * TODO: inform the user that -e Lua chunk
+			 * was not executed during the startup.
+			 */
+			if (integrity)
+				break;
+
+			/*
 			 * Execute chunk
 			 */
 			if (luaL_loadbuffer(L, optv[i + 1], strlen(optv[i + 1]),

--- a/src/main.cc
+++ b/src/main.cc
@@ -821,6 +821,19 @@ main(int argc, char **argv)
 		case 'I':
 #if ENABLE_INTEGRITY
 			opt_mask |= O_INTEGRITY;
+
+			/*
+			 * Reset all environment variables.
+			 * XXX: This is the most early spot to
+			 * reset the environment; if the error
+			 * occurs, execution cannot be proceed.
+			 */
+			if (clearenv() != 0) {
+				fprintf(stderr, "Environment is not reset, but "
+					"integrity check is enabled.\n");
+				return 1;
+			}
+
 			instance.hashes = optarg;
 			break;
 #else

--- a/src/proc_title.c
+++ b/src/proc_title.c
@@ -211,7 +211,11 @@ proc_title_init(int argc, char **argv)
 	char *mem;
 	size_t argv_copy_size, clobber_size;
 	int envc = 0;
-	while (environ[envc]) {
+	/*
+	 * XXX: The whole environment might be reset and environ
+	 * might be NULL as a result of <clearenv>.
+	 */
+	while (environ && environ[envc]) {
 		envc++;
 	}
 	argv_copy_size = sizeof(argv[0]) * (argc + 1);


### PR DESCRIPTION
This patchset implements two features related to integrity protection:
* reset environment if integrity check is on
* do not run -e chunk if integrity check is on

See more info in the corresponding commit messages.

Part of tarantool/tarantool-ee#585