### PR TITLE
iproto: fix use-after-free on using iproto API after shutdown

### DIFF
--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -330,6 +330,7 @@ struct errcode_record {
 	/*275 */_(ER_CREATE_DEFAULT_FUNC,	"Failed to create field default function '%s': %s") \
 	/*276 */_(ER_DEFAULT_FUNC_FAILED,	"Error calling field default function '%s': %s") \
 	/*277 */_(ER_INVALID_DEC,		"Invalid decimal: '%s'") \
+	/*278 */_(ER_SERVER_SHUTDOWN,		"Server is shutting down") \
 
 /*
  * !IMPORTANT! Please follow instructions at start of the file

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -496,6 +496,7 @@ t;
  |   275: box.error.CREATE_DEFAULT_FUNC
  |   276: box.error.DEFAULT_FUNC_FAILED
  |   277: box.error.INVALID_DEC
+ |   278: box.error.SERVER_SHUTDOWN
  | ...
 
 test_run:cmd("setopt delimiter ''");


### PR DESCRIPTION
In the commit 26acba832c4e ("iproto: don't use cord_cancel_and_join for iproto shutdown") we free iproto while TX event loop is still running. So TX fiber that try to use iproto API after that will cause UB. In particular this was reported by ASAN run of
`enterprise-luatest/flightrec_test`.

Let's make API work even after shutdown. Also there is another issue with shutdown. We stop accepting new connections during client graceful shutdown but we may start to accept them again if it requested thru iproto API. For this reason in particular we may leave some connections running on freeing iproto which is UB. Let's fix it here too.

Also while we at it let's change to `cord_cojoin` in `iproto_shutdown` so that event loop is not blocked.

Closes #9507