### PR TITLE
ci: fix action for submodule bump

### DIFF
--- a/.github/actions/bump-submodule/action.yml
+++ b/.github/actions/bump-submodule/action.yml
@@ -1,5 +1,5 @@
 name: 'Bump submodule'
-description: 'Bump specified submodule from third_party'
+description: 'Bump specified third-party submodule for integration testing'
 
 inputs:
   submodule:
@@ -13,24 +13,25 @@ inputs:
 
 runs:
   using: 'composite'
-  # XXX: Environment variables to suppress git config warning.
-  # The commit is required to avoid resetting dirty
-  # changes in submodule.
-  env:
-    GIT_COMMITTER_NAME: "integration testing workflow"
-    GIT_COMMITTER_EMAIL: "noreply@tarantool.org"
-    GIT_AUTHOR_NAME: "integration testing workflow"
-    GIT_AUTHOR_EMAIL: "noreply@tarantool.org"
   steps:
-    run: |
-      pushd third_party/${{ inputs.submodule }}
-      git fetch origin
-      git checkout ${{ inputs.revision }}
-      popd
-      # XXX: --allow-empty is required to rerun flaky tests
-      # for HEAD when it is already bumped
-      # in tarantool/tarantool repo to the same revision.
-      # Otherwise the command below fails with "nothing to
-      # commit" reason.
-      git commit --allow-empty -m ${{ inputs.submodule }}": integration testing bump" \
-        third_party/${{ inputs.submodule }}
+    - name: Bump ${{ inputs.submodule }} submodule
+      shell: bash
+      run: |
+        pushd third_party/${{ inputs.submodule }}
+        git fetch origin
+        git checkout ${{ inputs.revision }}
+        popd
+        # XXX: export the following environment variables to
+        # suppress git config warning. The commit is required to
+        # avoid resetting dirty changes in the submodule.
+        export GIT_COMMITTER_NAME="Integration tester"
+        export GIT_COMMITTER_EMAIL="noreply@tarantool.org"
+        export GIT_AUTHOR_NAME="Integration tester"
+        export GIT_AUTHOR_EMAIL="noreply@tarantool.org"
+        # XXX: --allow-empty is required to rerun flaky tests
+        # for HEAD when it is already bumped
+        # in tarantool/tarantool repo to the same revision.
+        # Otherwise the command below fails with "nothing to
+        # commit" reason.
+        git commit --allow-empty -m ${{ inputs.submodule }}": integration testing bump" \
+          third_party/${{ inputs.submodule }}


### PR DESCRIPTION
It turns out, GitHub actions don't allow `env` usage in their definition. This patch fixes this issue in submodule bump action by moving the environment definition into the executed shell script.

NO_DOC=CI
NO_TEST=CI
NO_CHANGELOG=CI