### PR TITLE
build: call abort instead of _exit if ASAN found an error

### DIFF
--- a/.test.mk
+++ b/.test.mk
@@ -99,7 +99,8 @@ TEST_RUN_ENV_ASAN = ASAN=ON \
                     ASAN_OPTIONS=heap_profile=0:unmap_shadow_on_exit=1:$\
                                  detect_invalid_pointer_pairs=1:symbolize=1:$\
                                  detect_leaks=1:dump_instruction_bytes=1:$\
-                                 print_suppressions=0
+                                 print_suppressions=0:$\
+                                 abort_on_error=true
 LUAJIT_TEST_ENV_ASAN = LSAN_OPTIONS=suppressions=${PWD}/asan/lsan.supp \
                        ASAN_OPTIONS=detect_invalid_pointer_pairs=1:$\
                                     detect_leaks=1:$\
@@ -107,7 +108,8 @@ LUAJIT_TEST_ENV_ASAN = LSAN_OPTIONS=suppressions=${PWD}/asan/lsan.supp \
                                     heap_profile=0:$\
                                     print_suppressions=0:$\
                                     symbolize=1:$\
-                                    unmap_shadow_on_exit=1
+                                    unmap_shadow_on_exit=1:$\
+                                    abort_on_error=true
 
 # Release ASAN build
 

--- a/test/app-luatest/gh_9411_fix_graceful_shutdown_break_on_script_exit_test.lua
+++ b/test/app-luatest/gh_9411_fix_graceful_shutdown_break_on_script_exit_test.lua
@@ -30,7 +30,8 @@ g.test = function()
     local handle, err = popen.new({tarantool_bin, '-e', script},
                                   {stdout = popen.opts.PIPE,
                                    stdin = popen.opts.DEVNULL,
-                                   stderr = popen.opts.DEVNULL})
+                                   stderr = popen.opts.DEVNULL,
+                                   env = os.environ()})
     assert(handle, err)
     g.handle = handle
     -- NB: Don't guess a good timeout, just use 60 seconds as

--- a/test/box-luatest/gh_9266_fix_on_shutdown_and_osexit_from_cmd_expr_test.lua
+++ b/test/box-luatest/gh_9266_fix_on_shutdown_and_osexit_from_cmd_expr_test.lua
@@ -22,7 +22,8 @@ g.test = function()
     local handle, err = popen.new({tarantool, '-e', code},
                                   {stdout = popen.opts.PIPE,
                                    stdin = popen.opts.DEVNULL,
-                                   stderr = popen.opts.DEVNULL})
+                                   stderr = popen.opts.DEVNULL,
+                                   env = os.environ() })
     assert(handle, err)
     g.handle = handle
     -- NB: Don't guess a good timeout, just use 60 seconds as

--- a/test/config-luatest/log_wrapper_test.lua
+++ b/test/config-luatest/log_wrapper_test.lua
@@ -26,6 +26,7 @@ g.test_jsonify_table = function(g)
         exit_code = 0,
         stdout = '',
         stderr = 'foo: {"bar":"baz"}',
+        env = os.environ(),
     })
 end
 

--- a/test/justrun.lua
+++ b/test/justrun.lua
@@ -94,6 +94,7 @@ function justrun.tarantool(dir, env, args, opts)
                                                  args_str)
     log.info(('Running a command: %s'):format(command))
     local mode = opts.stderr and 'rR' or 'r'
+    mode.env = os.environ()
     local ph = popen.shell(command, mode)
 
     local stderr_fiber


### PR DESCRIPTION
Now LeakSanitizer silently prints a report about found error and testing is continue. Due to this found errors could be ignored in CI. The patch enables option `abort_on_error` in `ASAN_OPTIONS` [1] and after that Address Sanitizer and LeakSanitizer will call `abort()` instead of `_exit()` after printing the error report.

1. https://github.com/google/sanitizers/wiki/SanitizerCommonFlags

NO_CHANGELOG=build
NO_DOC=build
NO_TEST=build