### PR TITLE
config: add missing field in test

### DIFF
--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -82,6 +82,7 @@ g.test_config_enterprise = function()
     local iconfig = {
         config = {
             reload = 'auto',
+            context = {},
             etcd = {
                 prefix = '/one',
                 endpoints = {'two', 'three'},


### PR DESCRIPTION
This patch adds missing field in instance_config_schema_test.lua.

Follow-up #9506

NO_DOC=fix for test
NO_CHANGELOG=fix for test