### PR TITLE
[backport/release/2.10] luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9145-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9145-luajit-fixes.md
@@ -22,3 +22,11 @@ were fixed as part of this activity:
 * Fixed possible storing of NaN keys to table on trace.
 * Fixed ABC FOLD optimization with constants.
 * Marked `CONV` as non-weak, to prevent invalid control flow path choice.
+* Fixed CSE of a `REF_BASE` operand across `IR_RETF`.
+* Fixed the fold rule for `BUFHDR APPEND`.
+* Fixed HREFK, ALOAD, HLOAD, forwarding vs. `table.clear()`.
+* Fixed snapshot PC when linking to `BC_JLOOP` that was a `BC_RET*`.
+* Fixed dangling references to CType.
+* Ensured returned string is alive in `ffi.typeinfo()`.
+* Fixed the missing initialization of the internal structure, leading to a
+  crash when recording a trace with an allocation of cdata.


### PR DESCRIPTION
* FFI: Fix dangling reference to CType in carith_checkarg().
* FFI: Fix dangling reference to CType. Improve checks.
* FFI: Fix dangling reference to CType.
* FFI: Ensure returned string is alive in ffi.typeinfo().
* FFI: Fix missing cts->L initialization in argv2ctype().
* Abstract out on-demand loading of FFI library.
* test: fix flaky finalizer error handler tests
* test: adjust lua-Harness test error assertion
* Fix snapshot PC when linking to BC_JLOOP that was a BC_RET*.
* snap: check J->pc is within its proto bytecode
* Fix HREFK forwarding vs. table.clear().
* Fix FOLD rule for BUFHDR append.
* Prevent CSE of a REF_BASE operand across IR_RETF.
* test: rewrite sysprof test using managed execution
* test: disable buffering for the C test engine

Part of #9145

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump
