### PR TITLE
config: TLS options support -- follow up

### DIFF
--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -70,7 +70,7 @@ function methods.names(self)
     }
 end
 
-local function instance_sharding(iconfig)
+local function instance_sharding(iconfig, instance_name)
     local roles = instance_config:get(iconfig, 'sharding.roles')
     if roles == nil or #roles == 0 then
         return nil
@@ -86,7 +86,8 @@ local function instance_sharding(iconfig)
     local zone = instance_config:get(iconfig, 'sharding.zone')
     local uri = instance_config:instance_uri(iconfig, 'sharding')
     if uri == nil then
-        error('No suitable URI provided', 0)
+        local err = 'No suitable URI provided for instance %q'
+        error(err:format(instance_name), 0)
     end
     --
     -- Currently, vshard does not accept URI without a username. So if we got a
@@ -171,7 +172,7 @@ function methods.sharding(self)
                         table.insert(rebalancers, replicaset_name)
                     end
                 end
-                local isharding = instance_sharding(iconfig)
+                local isharding = instance_sharding(iconfig, instance_name)
                 if isharding ~= nil then
                     if replicaset_uuid == nil then
                         replicaset_uuid = instance_config:get(iconfig,

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -287,6 +287,7 @@ local function instance_uri(self, iconfig, advertise_type)
         if listen == nil then
             return nil
         end
+        uri = table.copy(uri)
         uri.uri, uri.params = find_suitable_uri_to_connect(listen)
     end
     -- No URI found for the given instance.
@@ -297,6 +298,7 @@ local function instance_uri(self, iconfig, advertise_type)
     -- If there is a login. but there are no password: lookup the
     -- credentials section.
     if uri.password == nil and uri.login ~= nil then
+        uri = table.copy(uri)
         uri.password = find_password(self, iconfig, uri.login)
     end
     return uri

--- a/test/luatest_helpers/server.lua
+++ b/test/luatest_helpers/server.lua
@@ -82,6 +82,7 @@ local function find_advertise_uri(config, instance_name, dir)
     end
 
     for _, uri in ipairs(uris or {}) do
+        uri = table.copy(uri)
         uri.uri = uri.uri:gsub('{{ *instance_name *}}', instance_name)
         uri.uri = uri.uri:gsub('unix/:%./', ('unix/:%s/'):format(dir))
         local u = urilib.parse(uri)


### PR DESCRIPTION
I accidentally discarded some changes made by @ImeevMA in PR #9385. The previous version of the patchset goes to the main branch as result. I'm very sorry.

This commit returns the code of the last version of the patchset.

The changes are described in https://github.com/tarantool/tarantool/pull/9385#discussion_r1430935585. Quoted here:

> 1. Reduce code duplication in the validation logic. It also
>    eliminates remaining (dead) code that interprets user@ and
>    user:pass@ syntax. And give better error messages in come cases
>    (comma separates URIs for example).
> 2. Forbid {} as an URI to simplify logic in instance_uri.
> 3. Refresh the comments.

Also added copying of an original URI table before a modification to prevent influence of the original URIs from config. See the second commit.

Part of #8862