### PR TITLE
config: check vshard version

### DIFF
--- a/changelogs/unreleased/gh-8862-limit-vshard-version.md
+++ b/changelogs/unreleased/gh-8862-limit-vshard-version.md
@@ -1,0 +1,3 @@
+## feature/config
+
+* The minimum supported `vshard` module version is now 0.1.25 (gh-8862).

--- a/src/box/lua/config/applier/sharding.lua
+++ b/src/box/lua/config/applier/sharding.lua
@@ -1,3 +1,4 @@
+local expression = require('internal.config.utils.expression')
 local log = require('internal.config.utils.log')
 _G.vshard = nil
 
@@ -10,9 +11,17 @@ local function apply(config)
     if roles == nil then
         return
     end
-    if _G.vshard == nil then
-        _G.vshard = require('vshard')
+    -- Make sure vshard is available and its version is not too old.
+    local ok, vshard = pcall(require, 'vshard')
+    if not ok then
+        error('The vshard module is not available', 0)
     end
+    if expression.eval('v < 0.1.25', {v = vshard.consts.VERSION}) then
+        error('The vshard module is too old: the minimum supported version ' ..
+              'is 0.1.25.', 0)
+    end
+
+    _G.vshard = vshard
     local is_storage = false
     local is_router = false
     for _, role in pairs(roles) do


### PR DESCRIPTION
This patch sets requirements for vshard version that is supported by config module.

Part of #8862

NO_TEST=internal

@TarantoolBot document
Title: config: supported vshard version

The vshard version supported by the config module cannot be less than 0.1.25. Note, that vshard will only be loaded if any of instances have sharding storage role or sharding router role.