### PR TITLE
config: drop alert about credentials and RO mode

### DIFF
--- a/changelogs/unreleased/config-credentials-and-ro-alert.md
+++ b/changelogs/unreleased/config-credentials-and-ro-alert.md
@@ -1,0 +1,5 @@
+## bugfix/config
+
+* Removed a warning in `config:info().alerts` that appears on startup on a
+  replica if there are configured credentials to be written on the master
+  (gh-8862).

--- a/src/box/lua/config/applier/credentials.lua
+++ b/src/box/lua/config/applier/credentials.lua
@@ -795,11 +795,12 @@ local function sync_credentials_worker()
                 obj_to_sync.type == 'BACKGROUND_FULL_SYNC' then
 
             if box.info.ro then
-                local msg = 'credentials.apply: Tarantool is in Read Only ' ..
-                            'mode, so credentials will be set up in the ' ..
-                            'background when it is switched to Read Write mode'
-                config:_alert('credentials_apply_ro',
-                              {type = 'warn', message = msg})
+                log.verbose('credentials: the database is in the read-only ' ..
+                    'mode. Waiting for the read-write mode to set up the ' ..
+                    'credentials given in the configuration. If another ' ..
+                    'instance in the replicaset will write these new ' ..
+                    'credentials, this instance will receive them and will ' ..
+                    'skip further actions.')
                 box.ctl.wait_rw()
             end
 

--- a/test/config-luatest/basic_test.lua
+++ b/test/config-luatest/basic_test.lua
@@ -23,6 +23,18 @@ local function last_n_lines(s, n)
     return table.concat(res, '\n')
 end
 
+local function replicaset_has_no_alerts(g)
+    local function no_alerts()
+        local config = require('config')
+
+        local info = config:info()
+        t.assert_equals(info.alerts, {})
+    end
+    g.server_1:exec(no_alerts)
+    g.server_2:exec(no_alerts)
+    g.server_3:exec(no_alerts)
+end
+
 g.test_basic = function(g)
     local dir = treegen.prepare_directory(g, {}, {})
     local config = {
@@ -81,6 +93,9 @@ g.test_example_replicaset = function(g)
     t.assert_equals(g.server_1:eval('return box.info.ro'), false)
     t.assert_equals(g.server_2:eval('return box.info.ro'), true)
     t.assert_equals(g.server_3:eval('return box.info.ro'), true)
+
+    -- Verify that this basic scenario starts without any alerts.
+    replicaset_has_no_alerts(g)
 end
 
 g.test_example_replicaset_manual_failover = function(g)
@@ -96,6 +111,9 @@ g.test_example_replicaset_manual_failover = function(g)
     t.assert_equals(g.server_1:eval('return box.info.ro'), false)
     t.assert_equals(g.server_2:eval('return box.info.ro'), true)
     t.assert_equals(g.server_3:eval('return box.info.ro'), true)
+
+    -- Verify that this basic scenario starts without any alerts.
+    replicaset_has_no_alerts(g)
 end
 
 g.test_example_replicaset_election_failover = function(g)
@@ -115,6 +133,9 @@ g.test_example_replicaset_election_failover = function(g)
         return not ro
     end):length()
     t.assert_equals(rw_count, 1)
+
+    -- Verify that this basic scenario starts without any alerts.
+    replicaset_has_no_alerts(g)
 end
 
 local err_msg_cannot_find_user = 'Cannot find user unknown ' ..


### PR DESCRIPTION
Before this patch a replica adds an alert regarding inability to write new credentials from config on startup. In most cases these new credentials are applied on a master and the warning becomes obsolete. The problem is that it is not removed at this point. A manual `config:reload()` is needed to flush it.

It makes the warning more confusing than helpful. Let's remove it for now.

We can return the alert back in a future, but we should do it together with a logic that drops the alert if the needed data is received from a master.

Part of #8862