### PR TITLE
Revert "ci: temporarily patch GC finalizer test"

### DIFF
--- a/.test.mk
+++ b/.test.mk
@@ -45,12 +45,6 @@ build: configure
 
 .PHONY: run-luajit-test
 run-luajit-test:
-	# Temporary hack for an unstable LuaJIT test. To be removed in
-	# the scope of gh-9145.
-	sed -i.bak -e 's/for _ = 1, 4000 do/for _ = 1, 10000 do/' \
-		third_party/luajit/test/tarantool-tests/lj-946-print-errors-from-gc-fin-custom.test.lua
-	sed -i.bak -e 's/for _ = 1, 4000 do/for _ = 1, 10000 do/' \
-		third_party/luajit/test/tarantool-tests/lj-946-print-errors-from-gc-fin-default/script.lua
 	${LUAJIT_TEST_ENV} cmake --build ${LUAJIT_TEST_BUILD_DIR} --parallel ${NPROC} --target LuaJIT-test
 
 .PHONY: install-test-deps


### PR DESCRIPTION
This reverts commit b471fc97ba0b8e0260585593044c70274a754ccb.

Tests for GC finalizers were patched in the luajit submodule. The submodule was updated in
commit 1a0bafd5250eb8103d46e3437ce3b23c9ccbbdf7.

NO_DOC=Revert CI hack
NO_TEST=Revert CI hack
NO_CHANGELOG=Revert CI hack