### PR TITLE
config: start console before first box.cfg() call

### DIFF
--- a/changelogs/unreleased/config-start-console-before-box-cfg.md
+++ b/changelogs/unreleased/config-start-console-before-box-cfg.md
@@ -1,0 +1,5 @@
+## bugfix/config
+
+* Start the interactive console before the first `box.cfg()` call. This allows
+  you to issue the `box.ctl.make_bootstrap_leader()` command to a replica set
+  that uses the `supervised` bootstrap strategy (gh-8862).

--- a/src/box/lua/config/applier/console.lua
+++ b/src/box/lua/config/applier/console.lua
@@ -1,6 +1,7 @@
 local errno = require('errno')
 local console = require('console')
 local log = require('internal.config.utils.log')
+local instance_config = require('internal.config.instance_config')
 
 local function socket_file_to_listen_uri(file)
     if file:startswith('/') or file:startswith('./') then
@@ -20,6 +21,12 @@ local function apply(config)
 
     local socket_file = configdata:get('console.socket', {use_default = true})
     assert(socket_file ~= nil)
+
+    -- The same socket file is pointed by different paths before
+    -- and after first box.cfg() if the `process.work_dir` option
+    -- is set.
+    local iconfig_def = configdata._iconfig_def
+    socket_file = instance_config:prepare_file_path(iconfig_def, socket_file)
 
     local listen_uri = socket_file_to_listen_uri(socket_file)
     log.debug('console.apply: %s', listen_uri)

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -154,9 +154,9 @@ function methods._initialize(self)
 
     self:_register_applier(require('internal.config.applier.compat'))
     self:_register_applier(require('internal.config.applier.mkdir'))
+    self:_register_applier(require('internal.config.applier.console'))
     self:_register_applier(require('internal.config.applier.box_cfg'))
     self:_register_applier(require('internal.config.applier.credentials'))
-    self:_register_applier(require('internal.config.applier.console'))
     self:_register_applier(require('internal.config.applier.fiber'))
     self:_register_applier(require('internal.config.applier.sharding'))
     self:_register_applier(require('internal.config.applier.roles'))
@@ -323,12 +323,13 @@ function methods._store(self, iconfig, cconfig, source_info)
     self._configdata = configdata.new(iconfig, cconfig, self._instance_name)
 end
 
--- Invoke compat, mkdir and box_cfg appliers at the first phase.
--- Invoke all the other ones at the second phase.
+-- Invoke compat, mkdir, console and box_cfg appliers at the first
+-- phase. Invoke all the other ones at the second phase.
 function methods._apply_on_startup(self, opts)
     local first_phase_appliers = {
         compat = true,
         mkdir = true,
+        console = true,
         box_cfg = true,
     }
 
@@ -418,8 +419,8 @@ function methods._startup(self, instance_name, config_file)
 
     -- Startup phase 1/2.
     --
-    -- Start compat, mkdir and box_cfg appliers. The latter may
-    -- force the read-only mode on this phase.
+    -- Start compat, mkdir, console and box_cfg appliers. The
+    -- latter may force the read-only mode on this phase.
     --
     -- This phase may take a long time.
     self:_store(self:_collect({sync_source = 'all'}))

--- a/test/config-luatest/cbuilder.lua
+++ b/test/config-luatest/cbuilder.lua
@@ -93,6 +93,12 @@ local base_config = {
     },
 }
 
+local function cbuilder_set_global_option(self, path, value)
+    assert(type(path) == 'string')
+    cluster_config:set(self._config, path, value)
+    return self
+end
+
 -- Set an option for replicaset-001.
 local function cbuilder_set_replicaset_option(self, path, value)
     assert(type(path) == 'string')
@@ -156,6 +162,7 @@ local function cbuilder_config(self)
 end
 
 local cbuilder_mt = {
+    set_global_option = cbuilder_set_global_option,
     set_replicaset_option = cbuilder_set_replicaset_option,
     set_instance_option = cbuilder_set_instance_option,
     add_instance = cbuilder_add_instance,

--- a/test/config-luatest/console_test.lua
+++ b/test/config-luatest/console_test.lua
@@ -1,0 +1,136 @@
+local yaml = require('yaml')
+local fio = require('fio')
+local socket = require('socket')
+local t = require('luatest')
+local cbuilder = require('test.config-luatest.cbuilder')
+local replicaset = require('test.config-luatest.replicaset')
+
+local g = t.group()
+
+g.before_all(replicaset.init)
+g.after_each(replicaset.drop)
+g.after_all(replicaset.clean)
+
+-- Connect to a text console.
+local function connect(replicaset, instance_name, config, timeout)
+    -- Determine a path.
+    --
+    -- NB: Here we read only global scope values. No group,
+    -- replicaset, instance ones.
+    local control_path = fio.pathjoin('var/run', instance_name,
+        'tarantool.control')
+    if config ~= nil and config.console ~= nil and
+       config.console.socket ~= nil then
+        control_path = config.console.socket:gsub('{{ instance_name }}',
+            instance_name)
+    end
+    if config ~= nil and config.process ~= nil and
+       config.process.work_dir ~= nil then
+        control_path = fio.pathjoin(config.process.work_dir, control_path)
+    end
+
+    -- Connect.
+    local control_path = fio.pathjoin(replicaset._dir, control_path)
+    local s = t.helpers.retrying({timeout = timeout or 60}, function()
+        local s, err = socket.tcp_connect('unix/', control_path)
+        if s == nil then
+            error(err)
+        end
+        return s
+    end)
+
+    -- Read the greeting.
+    t.assert_str_matches(s:read('\n'), 'Tarantool .+ %(Lua console%).*')
+    t.assert_str_matches(s:read('\n'), "type 'help' for interactive help.*")
+    return s
+end
+
+-- Write the given command, read the answer.
+local function eval(s, command)
+    s:write(command .. '\n')
+    local raw_reply = s:read('...\n')
+    local reply = yaml.decode(raw_reply)
+    return unpack(reply, 1, table.maxn(reply))
+end
+
+local function assert_console_works(replicaset, config)
+    local s = connect(replicaset, 'i-001', config)
+    t.assert_equals(eval(s, 'return 123'), 123)
+end
+
+local function assert_console_closed(_replicaset, _config)
+    -- TODO (gh-9535): Enable it after a fix in the console
+    -- applier. Now it doesn't stop old console sockets.
+    --
+    -- t.assert_error(connect, replicaset, 'instance-001', config, 0.1)
+end
+
+-- Start, reload, change, return back, disable.
+g.test_basic = function(g)
+    -- Start an instance and verify that the console works.
+    local config = cbuilder.new()
+        :add_instance('i-001', {})
+        :config()
+    local replicaset = replicaset.new(g, config)
+    replicaset:start()
+    assert_console_works(replicaset, config)
+
+    -- Reload and check.
+    replicaset:reload(config)
+    assert_console_works(replicaset, config)
+
+    -- Change the socket and verify that the new one appears.
+    local new_config = cbuilder.new(config)
+        :set_global_option('console.socket', 'foo.control')
+        :config()
+    replicaset:reload(new_config)
+    assert_console_works(replicaset, new_config)
+
+    -- Verify that the old console socket is gone.
+    assert_console_closed(replicaset, config)
+
+    -- Remove the new socket path.
+    replicaset:reload(config)
+    assert_console_works(replicaset, config)
+    assert_console_closed(replicaset, new_config)
+
+    -- Disable the console.
+    local new_config_2 = cbuilder.new(config)
+        :set_global_option('console.enabled', false)
+        :config()
+    replicaset:reload(new_config_2)
+    assert_console_closed(replicaset, config)
+    assert_console_closed(replicaset, new_config)
+    assert_console_closed(replicaset, new_config_2)
+end
+
+-- Start with some custom workinf directory and reload.
+g.test_custom_work_dir = function(g)
+    local config = cbuilder.new()
+        :set_global_option('process.work_dir', 'w')
+        :add_instance('i-001', {})
+        :config()
+
+    local replicaset = replicaset.new(g, config)
+    replicaset:start()
+    assert_console_works(replicaset, config)
+
+    replicaset:reload(config)
+    assert_console_works(replicaset, config)
+end
+
+-- As previous, but with `../` in the socket path.
+g.test_parent_dir_in_socket_path = function(g)
+    local config = cbuilder.new()
+        :set_global_option('process.work_dir', 'w')
+        :set_global_option('console.socket', '../foo.control')
+        :add_instance('i-001', {})
+        :config()
+
+    local replicaset = replicaset.new(g, config)
+    replicaset:start()
+    assert_console_works(replicaset, config)
+
+    replicaset:reload(config)
+    assert_console_works(replicaset, config)
+end

--- a/test/config-luatest/replicaset.lua
+++ b/test/config-luatest/replicaset.lua
@@ -78,10 +78,14 @@ local function replicaset_size(self)
 end
 
 -- Start all the instances of replicaset-001 (from group-001).
-local function replicaset_start(self)
+local function replicaset_start(self, opts)
     self:each(function(server)
         server:start({wait_until_ready = false})
     end)
+
+    if opts ~= nil and not opts.wait_until_ready then
+        return
+    end
 
     self:each(function(server)
         server:wait_until_ready()

--- a/test/config-luatest/supervised_bootstrap_test.lua
+++ b/test/config-luatest/supervised_bootstrap_test.lua
@@ -1,0 +1,75 @@
+local yaml = require('yaml')
+local fio = require('fio')
+local socket = require('socket')
+local t = require('luatest')
+local cbuilder = require('test.config-luatest.cbuilder')
+local replicaset = require('test.config-luatest.replicaset')
+
+local g = t.group()
+
+g.before_all(replicaset.init)
+g.after_each(replicaset.drop)
+g.after_all(replicaset.clean)
+
+g.test_basic = function(g)
+    local config = cbuilder.new()
+        :set_replicaset_option('replication.failover', 'election')
+        :set_replicaset_option('replication.bootstrap_strategy', 'supervised')
+        :add_instance('i-001', {})
+        :add_instance('i-002', {})
+        :add_instance('i-003', {})
+        :config()
+
+    local replicaset = replicaset.new(g, config)
+    replicaset:start({wait_until_ready = false})
+
+    -- Connect to a text console.
+    local control_path = fio.pathjoin(replicaset._dir,
+        'var/run/i-002/tarantool.control')
+    local s = t.helpers.retrying({timeout = 60}, function()
+        local s, err = socket.tcp_connect('unix/', control_path)
+        if s == nil then
+            error(err)
+        end
+        -- Skip the greeting.
+        s:read('\n')
+        s:read('\n')
+        return s
+    end)
+
+    -- Issue box.ctl.make_bootstrap_leader() command on i-002.
+    --
+    -- We should perform the retrying, because we can reach the
+    -- instance with the command before it calls the first
+    -- box.cfg(). In this case the command raises the following
+    -- error.
+    --
+    -- > box.ctl.make_bootstrap_leader() does not support
+    -- > promoting this instance before box.cfg() is called
+    t.helpers.retrying({timeout = 60}, function()
+        s:write('do box.ctl.make_bootstrap_leader() return "done" end\n')
+        local reply = yaml.decode(s:read('...\n'))
+        t.assert_equals(reply, {'done'})
+    end)
+    s:close()
+
+    -- Wait till all the servers will finish the bootstrap.
+    replicaset:each(function(server)
+        server:wait_until_ready()
+    end)
+
+    -- Verify that all the instances are healthy.
+    replicaset:each(function(server)
+        t.helpers.retrying({timeout = 60}, function()
+            server:exec(function()
+                t.assert_equals(box.info.status, 'running')
+            end)
+        end)
+    end)
+
+    -- Verify that the given instance was acted as a bootstrap
+    -- leader.
+    replicaset['i-002']:exec(function()
+        t.assert_equals(box.info.id, 1)
+    end)
+end


### PR DESCRIPTION
This commit changes the order of configuration appliers and move `console` before `box_cfg`. The `console` applier is adjusted to correctly interpret the configured socket file path before the first box.cfg().
    
The main reason to change the order is to allow a user to call `box.ctl.make_bootstrap_leader()` for a replicaset that starts in the `replication.boostrap_strategy: supervised` mode.

Part of #8862