### PR TITLE
doc: drop 'breaking change' mark from 2.11.2 notes

### DIFF
--- a/changelogs/2.11.2.md
+++ b/changelogs/2.11.2.md
@@ -146,9 +146,9 @@ were fixed as part of this activity:
   lengthy args, such as list of audit events (ghe-523).
 * Fixed crashes if `box.info.memory()`, `box.info.gc()`, `box.info.vinyl()`,
   and `box.info.sql()` are called before `box.cfg{}` (gh-9173).
-* **[Breaking change]** Added a `c_func_iproto_multireturn` option to the
-  `compat` module. The new behavior drops an additional array that wraps
-  multiple results returned via iproto (gh-4799).
+* Added a `c_func_iproto_multireturn` option to the `compat` module. The new
+  behavior drops an additional array that wraps multiple results returned via
+  iproto (gh-4799).
 * Fixed a bug that allows downgrading from a schema version more recent than
   a Tarantool version (gh-9182).
 * Fixed a bug when `on_shutdown` triggers weren't run if `os.exit()` was


### PR DESCRIPTION
The release notes states one change as breaking, but the new behavior was enabled on 3.0 branch, see commit 6cb3911681d6 ("box: set default c_func_iproto_multireturn to new"), and not enabled on 2.11 branch.

Thanks @Mons for the notice!