### PR TITLE
config: rework replication.peers

### DIFF
--- a/changelogs/unreleased/gh-9541-change-replication-peers.md
+++ b/changelogs/unreleased/gh-9541-change-replication-peers.md
@@ -1,0 +1,3 @@
+## feature/config
+
+* The `replication.peers` option now accepts a list of instance names (gh-9541).

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1404,13 +1404,24 @@ return schema.new('instance_config', schema.record({
         }, {
             default = 'off',
         }),
-        -- XXX: needs more validation
         peers = schema.array({
             items = schema.scalar({
                 type = 'string',
             }),
-            box_cfg = 'replication',
             default = box.NULL,
+            validate = function(data, w)
+                if #data == 0 then
+                    w.error('replication.peers can only be nil or non-empty')
+                end
+                local upstreams = {}
+                for _, peer_name in ipairs(data) do
+                    if upstreams[peer_name] then
+                        w.error(('instance %q specified more than ' ..
+                                 'once'):format(peer_name))
+                    end
+                    upstreams[peer_name] = true
+                end
+            end,
         }),
         anon = schema.scalar({
             type = 'boolean',

--- a/test/config-luatest/anonymous_replica_test.lua
+++ b/test/config-luatest/anonymous_replica_test.lua
@@ -23,9 +23,9 @@ g.test_basic = function(g)
     -- One master, two replicas, two anonymous replicas.
     local config = cbuilder.new()
         :set_replicaset_option('replication.peers', {
-            'replicator:secret@unix/:./instance-001.iproto',
-            'replicator:secret@unix/:./instance-002.iproto',
-            'replicator:secret@unix/:./instance-003.iproto',
+            'instance-001',
+            'instance-002',
+            'instance-003',
         })
         :add_instance('instance-001', {
             database = {

--- a/test/config-luatest/basic_test.lua
+++ b/test/config-luatest/basic_test.lua
@@ -166,13 +166,20 @@ for case_name, case in pairs({
         exp_err = err_msg_cannot_find_user,
     },
     no_advertise_no_listen = {
+        listen_1 = {},
         listen_2 = {},
         listen_3 = {},
+        advertise_1 = box.NULL,
         advertise_2 = box.NULL,
         advertise_3 = box.NULL,
         exp_err = err_msg_no_suitable_uris,
     },
     no_advertise_no_suitable_listen = {
+        listen_1 = {
+            {uri = 'localhost:0'},
+            {uri = '0.0.0.0:3301'},
+            {uri = '[::]:3301'}
+        },
         listen_2 = {
             {uri = 'localhost:0'},
             {uri = '0.0.0.0:3301'},
@@ -183,11 +190,17 @@ for case_name, case in pairs({
             {uri = '0.0.0.0:3301'},
             {uri = '[::]:3301'}
         },
+        advertise_1 = box.NULL,
         advertise_2 = box.NULL,
         advertise_3 = box.NULL,
         exp_err = err_msg_no_suitable_uris,
     },
     advertise_user_no_suitable_listen = {
+        listen_1 = {
+            {uri = 'localhost:0'},
+            {uri = '0.0.0.0:3301'},
+            {uri = '[::]:3301'}
+        },
         listen_2 = {
             {uri = 'localhost:0'},
             {uri = '0.0.0.0:3301'},
@@ -197,6 +210,9 @@ for case_name, case in pairs({
             {uri = 'localhost:0'},
             {uri = '0.0.0.0:3301'},
             {uri = '[::]:3301'}
+        },
+        advertise_1 = {
+            login = 'replicator',
         },
         advertise_2 = {
             login = 'replicator',
@@ -207,6 +223,11 @@ for case_name, case in pairs({
         exp_err = err_msg_no_suitable_uris,
     },
     advertise_user_pass_no_suitable_listen = {
+        listen_1 = {
+            {uri = 'localhost:0'},
+            {uri = '0.0.0.0:3301'},
+            {uri = '[::]:3301'}
+        },
         listen_2 = {
             {uri = 'localhost:0'},
             {uri = '0.0.0.0:3301'},
@@ -216,6 +237,10 @@ for case_name, case in pairs({
             {uri = 'localhost:0'},
             {uri = '0.0.0.0:3301'},
             {uri = '[::]:3301'}
+        },
+        advertise_1 = {
+            login = 'replicator',
+            password = 'topsecret',
         },
         advertise_2 = {
             login = 'replicator',

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1120,6 +1120,28 @@ g.test_replication = function()
     validate_fields(iconfig.replication,
                     instance_config.schema.fields.replication)
 
+    iconfig = {
+        replication = {
+            peers = {},
+        },
+    }
+    local err = '[instance_config] replication.peers: replication.peers can ' ..
+                'only be nil or non-empty'
+    t.assert_error_msg_content_equals(err, function()
+        instance_config:validate(iconfig)
+    end)
+
+    iconfig = {
+        replication = {
+            peers = {'one', 'two', 'one'},
+        },
+    }
+    err = '[instance_config] replication.peers: instance "one" specified ' ..
+          'more than once'
+    t.assert_error_msg_content_equals(err, function()
+        instance_config:validate(iconfig)
+    end)
+
     local exp = {
         failover = 'off',
         anon = false,
@@ -1299,6 +1321,7 @@ g.test_box_cfg_coverage = function()
         metrics = true,
         audit_log = true,
         audit_filter = true,
+        replication = true,
 
         -- Controlled by the leader and database.mode options,
         -- handled by the box_cfg applier.


### PR DESCRIPTION
After this patch, replication.peers will accept a list of instance names instead of a list of URIs.

Closes #9541

@TarantoolBot document
Title: replication.peers config option

The replication.peers option accepts a list of instance names that will be set as upstreams. If the option is not nil, it cannot be empty. For an instance, the option can only contain the names of the instances of the replicaset to which the instance belongs.

Currently, if the option does not contain all instances of a replicaset, except maybe one instance, the instance `bootstrap_strategy` option must be set to `config` and the instance replicaset `bootstrap_leader` option must be one of the instances from the `replication.peers`.
