### PR TITLE
doc: squash declarative configuration changes

### DIFF
--- a/changelogs/unreleased/config-anonymous-replica.md
+++ b/changelogs/unreleased/config-anonymous-replica.md
@@ -1,4 +1,0 @@
-## bugfix/config
-
-* Effectively supported `replication.anon` option, which was broken in several
-  ways before (gh-9432).

--- a/changelogs/unreleased/config-better-corrupted-snap-diagnostic.md
+++ b/changelogs/unreleased/config-better-corrupted-snap-diagnostic.md
@@ -1,4 +1,0 @@
-## bugfix/config
-
-* Improved the diagnostic given for a corrupted snapshot file without an
-  instance or replica set UUID (gh-8862).

--- a/changelogs/unreleased/config-change-default-paths.md
+++ b/changelogs/unreleased/config-change-default-paths.md
@@ -1,4 +1,0 @@
-## feature/config
-
-* The default directory and file paths are changed to `var/run/<...>`,
-  `var/log/<...>`, `var/lib/<...>` and so on (gh-8862).

--- a/changelogs/unreleased/config-compat-options.md
+++ b/changelogs/unreleased/config-compat-options.md
@@ -1,3 +1,0 @@
-## feature/config
-
-* Added compatibility options from the `compat` module (gh-9497).

--- a/changelogs/unreleased/config-conditional-sections.md
+++ b/changelogs/unreleased/config-conditional-sections.md
@@ -1,3 +1,0 @@
-## feature/config
-
-* For upgrading purposes, conditional sections are now supported (gh-9452).

--- a/changelogs/unreleased/config-create-parent-directories.md
+++ b/changelogs/unreleased/config-create-parent-directories.md
@@ -1,8 +1,0 @@
-## bugfix/config
-
-* Support parent directories creation for options that accept a directory or a
-  file (gh-8862).
-* Create parent directories for `console.socket` and `log.file` (gh-8862).
-* Create the `process.work_dir` directory (gh-8862).
-* Consider all the paths as relative to `process.work_dir` when creating
-  necessary directories (gh-8862).

--- a/changelogs/unreleased/config-credentials-and-ro-alert.md
+++ b/changelogs/unreleased/config-credentials-and-ro-alert.md
@@ -1,5 +1,0 @@
-## bugfix/config
-
-* Removed a warning in `config:info().alerts` that appears on startup on a
-  replica if there are configured credentials to be written on the master
-  (gh-8862).

--- a/changelogs/unreleased/config-dont-persist-group-name.md
+++ b/changelogs/unreleased/config-dont-persist-group-name.md
@@ -1,4 +1,0 @@
-## feature/config
-
-* A group name from a topology defined by the cluster configuration doesn't
-  persisted anymore as `box.cfg.cluster_name` (gh-8862).

--- a/changelogs/unreleased/config-drop-config-version.md
+++ b/changelogs/unreleased/config-drop-config-version.md
@@ -1,4 +1,0 @@
-## feature/config
-
-* Removed the `config.version` option because a different schema evolution
-  mechanism was implemented (gh-9452).

--- a/changelogs/unreleased/config-extras.md
+++ b/changelogs/unreleased/config-extras.md
@@ -1,4 +1,0 @@
-## feature/config
-
-* Introduced a non-public API for extending the declarative config
-  functionality in Tarantool Community Edition (gh-8862).

--- a/changelogs/unreleased/config-fix-etcd-prefix-validation.md
+++ b/changelogs/unreleased/config-fix-etcd-prefix-validation.md
@@ -1,4 +1,0 @@
-## bugfix/config
-
-* Fixed a bug when Tarantool didn't validate the presence of
-  `config.etcd.prefix` (gh-8862).

--- a/changelogs/unreleased/config-get-configuration-from-app.md
+++ b/changelogs/unreleased/config-get-configuration-from-app.md
@@ -1,4 +1,0 @@
-## feature/config
-
-* It is now possible to access configuration from the application script using
-  the `config:get()` method (gh-8862).

--- a/changelogs/unreleased/config-handle-old-box-cfg-env-variables.md
+++ b/changelogs/unreleased/config-handle-old-box-cfg-env-variables.md
@@ -1,4 +1,0 @@
-## bugfix/config
-
-* Now most of the old `TT_*` environment variables are supported in the new
-  declarative configuration flow (gh-9485).

--- a/changelogs/unreleased/config-help-env-list.md
+++ b/changelogs/unreleased/config-help-env-list.md
@@ -1,3 +1,0 @@
-## feature/config
-
-* Added `--help-env-list` CLI option (gh-8862).

--- a/changelogs/unreleased/config-low-priority-env-source.md
+++ b/changelogs/unreleased/config-low-priority-env-source.md
@@ -1,4 +1,0 @@
-## feature/config
-
-* Added a low priority environment configuration source, which looks into
-  `TT_*_DEFAULT` variables. It is useful to declare defaults (gh-8862).

--- a/changelogs/unreleased/config-lua-module-search-paths.md
+++ b/changelogs/unreleased/config-lua-module-search-paths.md
@@ -1,4 +1,0 @@
-## feature/config
-
-* The directory that contains the configuration file is now added into the Lua
-  modules search paths (gh-8862).

--- a/changelogs/unreleased/config-read-values-from-env-file.md
+++ b/changelogs/unreleased/config-read-values-from-env-file.md
@@ -1,4 +1,0 @@
-## feature/config
-
-* Added the ability to read a cluster config value from an environment variable
-  or a file (gh-9506).

--- a/changelogs/unreleased/config-relative-config-path.md
+++ b/changelogs/unreleased/config-relative-config-path.md
@@ -1,5 +1,0 @@
-## bugfix/config
-
-* Added support for the relative path in the `--config <...>` option. Before
-  this change, `config:reload()` failed if the `process.work_dir` option was
-  set to a non-null value (gh-8862).

--- a/changelogs/unreleased/config-replicaset-group-name-templates.md
+++ b/changelogs/unreleased/config-replicaset-group-name-templates.md
@@ -1,4 +1,0 @@
-## feature/config
-
-* Added support for the `{{ replicaset_name }}` and `{{ group_name }}`
-  templates in addition to the existing `{{ instance_name }}` (gh-8862).

--- a/changelogs/unreleased/config-set-names-on-reload.md
+++ b/changelogs/unreleased/config-set-names-on-reload.md
@@ -1,3 +1,0 @@
-## bugfix/config
-
-* Increased stability and speed of automatic names applying after config reload.

--- a/changelogs/unreleased/config-start-console-before-box-cfg.md
+++ b/changelogs/unreleased/config-start-console-before-box-cfg.md
@@ -1,5 +1,0 @@
-## bugfix/config
-
-* Start the interactive console before the first `box.cfg()` call. This allows
-  you to issue the `box.ctl.make_bootstrap_leader()` command to a replica set
-  that uses the `supervised` bootstrap strategy (gh-8862).

--- a/changelogs/unreleased/config-validate-identifiers.md
+++ b/changelogs/unreleased/config-validate-identifiers.md
@@ -1,5 +1,0 @@
-## feature/config
-
-* Introduced validation for replicaset_name/uuid and instance_name/uuid
-  mismatches before the recovery process when Tarantool is configured via
-  a YAML file or etcd.

--- a/changelogs/unreleased/config-validate-names.md
+++ b/changelogs/unreleased/config-validate-names.md
@@ -1,5 +1,0 @@
-## bugfix/config
-
-* Added the validation of instance, replica set, and group names in the
-  configuration, `--name` CLI option, and `TT_INSTANCE_NAME` environment
-  variable (gh-8862).

--- a/changelogs/unreleased/config-verify-failover-and-election-mode.md
+++ b/changelogs/unreleased/config-verify-failover-and-election-mode.md
@@ -1,4 +1,0 @@
-## bugfix/config
-
-* Now `replication.election_mode` values other than `off` are possible only if
-  `replication.failover` value is `election` (gh-9431).

--- a/changelogs/unreleased/config.md
+++ b/changelogs/unreleased/config.md
@@ -1,4 +1,5 @@
-## feature/config
+## feature/box
 
-* Initial version of the declarative server and cluster configuration
-  (gh-8724).
+* Introduced a declarative server and cluster configuration (gh-8724, gh-8861,
+  gh-8862, gh-8967, gh-8978, gh-9007, gh-9078, gh-9431, gh-9432, gh-9452,
+  gh-9485, gh-9497, gh-9506).

--- a/changelogs/unreleased/gh-8861-audit-options.md
+++ b/changelogs/unreleased/gh-8861-audit-options.md
@@ -1,3 +1,0 @@
-## feature/config
-
-* All audit options are now supported (gh-8861).

--- a/changelogs/unreleased/gh-8861-bootstrap_leader-option.md
+++ b/changelogs/unreleased/gh-8861-bootstrap_leader-option.md
@@ -1,3 +1,0 @@
-## feature/config
-
-* The `bootstrap_leader` option is now supported (gh-8861).

--- a/changelogs/unreleased/gh-8861-cluster-config-error-message.md
+++ b/changelogs/unreleased/gh-8861-cluster-config-error-message.md
@@ -1,4 +1,0 @@
-## bugfix/config
-
-* Fixed an error message if the cluster configuration was not provided or the
-  instance was not found in the cluster configuration during reload (gh-8862).

--- a/changelogs/unreleased/gh-8861-config-privilege-sync.md
+++ b/changelogs/unreleased/gh-8861-config-privilege-sync.md
@@ -1,4 +1,0 @@
-## feature/config
-
-* Improved the credentials applier: now it supports two-way synchronization
-  of roles and privileges for both users and roles (gh-8861).

--- a/changelogs/unreleased/gh-8861-feedback-options.md
+++ b/changelogs/unreleased/gh-8861-feedback-options.md
@@ -1,3 +1,0 @@
-## feature/config
-
-* All feedback options are now supported (gh-8861).

--- a/changelogs/unreleased/gh-8861-flightrec-options.md
+++ b/changelogs/unreleased/gh-8861-flightrec-options.md
@@ -1,3 +1,0 @@
-## feature/config
-
-* All flight recorder options are now supported (gh-8861).

--- a/changelogs/unreleased/gh-8861-memtx.sort_threads-option.md
+++ b/changelogs/unreleased/gh-8861-memtx.sort_threads-option.md
@@ -1,3 +1,0 @@
-## feature/config
-
-* The `memtx.sort_threads` option is now supported (gh-8861).

--- a/changelogs/unreleased/gh-8861-metrics-options.md
+++ b/changelogs/unreleased/gh-8861-metrics-options.md
@@ -1,4 +1,0 @@
-## feature/config
-
-* All metrics configuration options from `box.cfg{}` are now supported
-  in the YAML config (gh-8861).

--- a/changelogs/unreleased/gh-8861-security-options.md
+++ b/changelogs/unreleased/gh-8861-security-options.md
@@ -1,4 +1,0 @@
-## feature/config
-
-* All security hardening `box.cfg{}` options are now supported by
-  config (gh-8861).

--- a/changelogs/unreleased/gh-8861-vinyl-options.md
+++ b/changelogs/unreleased/gh-8861-vinyl-options.md
@@ -1,3 +1,0 @@
-## feature/config
-
-* All vinyl options are now supported (gh-8861).

--- a/changelogs/unreleased/gh-8861-vshard-options.md
+++ b/changelogs/unreleased/gh-8861-vshard-options.md
@@ -1,4 +1,0 @@
-## feature/config
-
-* Most of vshard options are now added in the config (gh-9007).
-* Added initial support of vshard (gh-9007).

--- a/changelogs/unreleased/gh-8862-cred-sharding-role.md
+++ b/changelogs/unreleased/gh-8862-cred-sharding-role.md
@@ -1,3 +1,0 @@
-## feature/config
-
-* Introduced the credential `sharding` role (gh-8862).

--- a/changelogs/unreleased/gh-8862-limit-vshard-version.md
+++ b/changelogs/unreleased/gh-8862-limit-vshard-version.md
@@ -1,3 +1,0 @@
-## feature/config
-
-* The minimum supported `vshard` module version is now 0.1.25 (gh-8862).

--- a/changelogs/unreleased/gh-8862-rework-iproto-listen.md
+++ b/changelogs/unreleased/gh-8862-rework-iproto-listen.md
@@ -1,3 +1,0 @@
-## feature/config
-
-* The `iproto.listen` configuration option has been reworked (gh-8862).

--- a/changelogs/unreleased/gh-8862-sharding-role-rebalancer.md
+++ b/changelogs/unreleased/gh-8862-sharding-role-rebalancer.md
@@ -1,4 +1,0 @@
-## feature/config
-
-* Disabled the `sharding.role` option in the instance scope (gh-8862).
-* Introduced the `rebalancer` sharding role (gh-8862).

--- a/changelogs/unreleased/gh-8862-tls-options-for-iproto.md
+++ b/changelogs/unreleased/gh-8862-tls-options-for-iproto.md
@@ -1,3 +1,0 @@
-## feature/config
-
-* TLS options for iproto.advertise were introduced (gh-8862).

--- a/changelogs/unreleased/gh-8967-add-lua_eval-lua_call-sql.md
+++ b/changelogs/unreleased/gh-8967-add-lua_eval-lua_call-sql.md
@@ -1,4 +1,0 @@
-## feature/config
-
-* Now the brand-new `lua_eval`, `lua_call`, and `sql` object types are
-  supported by credentials (gh-8967).

--- a/changelogs/unreleased/gh-8967-creds-consider-auth-type.md
+++ b/changelogs/unreleased/gh-8967-creds-consider-auth-type.md
@@ -1,5 +1,0 @@
-## feature/config
-
-* Now a password hash (and salt) will be regenerated for users managed
-  in the configuration file if `security.auth_type` differs from a user's
-  `auth_type` (gh-8967).

--- a/changelogs/unreleased/gh-8967-creds-postope-sync-when-RO-till-RW.md
+++ b/changelogs/unreleased/gh-8967-creds-postope-sync-when-RO-till-RW.md
@@ -1,5 +1,0 @@
-## feature/config
-
-* On read-only instances, Tarantool now synchronizes credentials
-  in the background when switching to read-write mode instead of
-  skipping the synchronization (gh-8967).

--- a/changelogs/unreleased/gh-8967-creds-restore-defaults-for-default-user.md
+++ b/changelogs/unreleased/gh-8967-creds-restore-defaults-for-default-user.md
@@ -1,4 +1,0 @@
-## feature/config
-
-* Non-default privileges are now revoked from default users and roles
-  when they are removed from the config (gh-8967).

--- a/changelogs/unreleased/gh-8967-remove-hashes-from-creds.md
+++ b/changelogs/unreleased/gh-8967-remove-hashes-from-creds.md
@@ -1,4 +1,0 @@
-## feature/config
-
-* Removed the sha1 and sha256 hash entries from the config credentials
-  schema as not planned for development (gh-8967).

--- a/changelogs/unreleased/gh-8967-set-creds-in-lazy-way.md
+++ b/changelogs/unreleased/gh-8967-set-creds-in-lazy-way.md
@@ -1,5 +1,0 @@
-## feature/config
-
-* Now the permissions for space, function, and sequence can be granted
-  via the config. If the object has not been created yet, the grant is
-  postponed and executed after the creation of the object (gh-8967).

--- a/changelogs/unreleased/gh-8967-upgrade-password-sync.md
+++ b/changelogs/unreleased/gh-8967-upgrade-password-sync.md
@@ -1,7 +1,0 @@
-## feature/config
-
-* Implemented a full password support in the `config.credentials` schema,
-  including a password setting, updating and removal for the `chap-sha1`
-  auth type (supported by both Tarantool Community Edition and Tarantool
-  Enterprise Edition) and the `pap-sha256` (just for Enterprise Edition
-  where it is available) (gh-8967).

--- a/changelogs/unreleased/gh-8978-config-set-names-automatically.md
+++ b/changelogs/unreleased/gh-8978-config-set-names-automatically.md
@@ -1,4 +1,0 @@
-## feature/config
-
-* If Tarantool is configured via a YAML file or etcd, then instance and replica
-  set names are automatically set when possible (gh-8978).

--- a/changelogs/unreleased/gh-9078-role-dependencies.md
+++ b/changelogs/unreleased/gh-9078-role-dependencies.md
@@ -1,3 +1,0 @@
-## feature/config
-
-* Introduced dependencies for roles (gh-9078).

--- a/changelogs/unreleased/gh-9078-roles.md
+++ b/changelogs/unreleased/gh-9078-roles.md
@@ -1,4 +1,0 @@
-## feature/config
-
-* Introduced the initial support for roles - programs that run when
-  a configuration is loaded or reloaded (gh-9078).


### PR DESCRIPTION
A user is unlikely interesting in intermediate changes. Let's just say that the new declarative configuration is supported now.