### PR TITLE
iproto: don't use cord_cancel_and_join for iproto shutdown V2

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -5925,7 +5925,7 @@ box_storage_shutdown()
 {
 	if (!is_storage_initialized)
 		return;
-	iproto_drop_connections();
+	iproto_shutdown();
 }
 
 void

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -331,6 +331,7 @@ struct errcode_record {
 	/*276 */_(ER_DEFAULT_FUNC_FAILED,	"Error calling field default function '%s': %s") \
 	/*277 */_(ER_INVALID_DEC,		"Invalid decimal: '%s'") \
 	/*278 */_(ER_IN_ANOTHER_PROMOTE,	"box.ctl.promote() is already running") \
+	/*279 */_(ER_SHUTDOWN,			"Server is shutting down") \
 
 /*
  * !IMPORTANT! Please follow instructions at start of the file

--- a/src/box/iproto.h
+++ b/src/box/iproto.h
@@ -191,6 +191,13 @@ iproto_free(void);
 void
 iproto_drop_connections(void);
 
+/**
+ * Prepare for freeing resources in iproto_free while TX event loop is still
+ * running.
+ */
+void
+iproto_shutdown(void);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/iproto.h
+++ b/src/box/iproto.h
@@ -145,8 +145,8 @@ int
 iproto_set_msg_max(int iproto_msg_max);
 
 /**
- * Creates a new IPROTO session over the given IO stream and returns the new
- * session id. Never fails. Doesn't yield.
+ * Creates a new IPROTO session over the given IO stream. Doesn't yield.
+ * Set the output parameter sid to the sid of newly created session.
  *
  * The IO stream must refer to a non-blocking socket but this isn't enforced by
  * this function. If it isn't so, the new connection may not work as expected.
@@ -155,16 +155,18 @@ iproto_set_msg_max(int iproto_msg_max);
  * the specified user. Otherwise, it will be authenticated as guest.
  *
  * The function takes ownership of the passed IO stream by moving it to the
- * new IPROTO connection (see iostream_move).
+ * new IPROTO connection (see iostream_move) except for error case.
  *
  * Essentially, this function passes the IO stream to the callback invoked
  * by an IPROTO thread upon accepting a new connection on a listening socket.
  * The callback creates a new IPROTO connection, attaches it to the given
  * session, then sends the greeting message and starts processing requests as
  * usual. All of this is done asynchronously by an IPROTO thread.
+ *
+ * Returns 0 on success, and -1 otherwise (diagnostic is set).
  */
-uint64_t
-iproto_session_new(struct iostream *io, struct user *user);
+int
+iproto_session_new(struct iostream *io, struct user *user, uint64_t *sid);
 
 /**
  * Sends a packet with the given header and body over the IPROTO session's

--- a/src/box/lua/iproto.c
+++ b/src/box/lua/iproto.c
@@ -227,7 +227,9 @@ lbox_iproto_session_new(struct lua_State *L)
 	}
 	struct iostream io;
 	plain_iostream_create(&io, fd);
-	uint64_t sid = iproto_session_new(&io, user);
+	uint64_t sid;
+	if (iproto_session_new(&io, user, &sid) != 0)
+		return luaT_error(L);
 	luaL_pushuint64(L, sid);
 	return 1;
 }

--- a/test/app-luatest/shutdown_test.lua
+++ b/test/app-luatest/shutdown_test.lua
@@ -1,0 +1,120 @@
+local server = require('luatest.server')
+local fiber = require('fiber')
+local t = require('luatest')
+
+local g = t.group()
+
+local delay_shutdown
+local delay_shutdown_cond = fiber.cond()
+
+g.before_each(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        local socket = require('socket')
+        rawset(_G, 'delay_shutdown', true)
+        rawset(_G, 'delay_shutdown_cond', fiber.cond())
+        rawset(_G, 'delay_shutdown', function()
+            while _G.delay_shutdown do
+                _G.delay_shutdown_cond:wait()
+            end
+        end)
+        -- Wait until we refuse to connect which means iproto shutdown trigger
+        -- is finished and new connections should not be possible.
+        rawset(_G, 'wait_iproto_shutdown', function()
+            t.helpers.retrying({}, function()
+                local sock, err = socket.tcp_connect(box.cfg.listen)
+                if err == nil then
+                    sock:close()
+                    error('still ok')
+                end
+            end)
+        end)
+    end)
+end)
+
+g.after_each(function(cg)
+    if cg.server ~= nil then
+        cg.server:exec(function()
+            _G.delay_shutdown = false
+            _G.delay_shutdown_cond:signal()
+        end)
+        delay_shutdown = false
+        delay_shutdown_cond:signal()
+        cg.server:drop()
+    end
+end)
+
+-- Delay shutdown of connection to server so that we can continue to send
+-- commands to server after server shutdown started.
+local function delay_server_connection_shutdown(server)
+    delay_shutdown = true
+    server.net_box:on_shutdown(function()
+        while delay_shutdown do
+            delay_shutdown_cond:wait()
+        end
+    end)
+end
+
+-- Test changing iproto listen after iproto shutdown is started.
+g.test_iproto_listen_after_shutdown_started = function(cg)
+    delay_server_connection_shutdown(cg.server)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        local net = require('net.box')
+        local fio = require('fio')
+        box.ctl.set_on_shutdown_timeout(10000)
+        box.ctl.on_shutdown(_G.delay_shutdown)
+        fiber.new(function()
+            os.exit()
+        end)
+        _G.wait_iproto_shutdown()
+        local path = fio.pathjoin(fio.cwd(), 'another.sock')
+        box.cfg{listen = path}
+        -- Server will listen on given URL but will not accept new connection
+        -- and will not send greeting etc.
+        local conn = net.connect(box.cfg.listen, {connect_timeout = 3})
+        t.assert_equals(conn.state, 'error')
+        t.assert_str_contains(conn.error, 'timed out')
+        conn:close()
+    end)
+end
+
+-- Test creating new session after iproto shutdown is started.
+g.test_box_session_new_after_shutdown_started = function(cg)
+    delay_server_connection_shutdown(cg.server)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        local net = require('net.box')
+        local fio = require('fio')
+        local socket = require('socket')
+        box.ctl.set_on_shutdown_timeout(10000)
+        box.ctl.on_shutdown(_G.delay_shutdown)
+        fiber.new(function()
+            os.exit()
+        end)
+        _G.wait_iproto_shutdown()
+        local path = fio.pathjoin(fio.cwd(), 'some.sock')
+        local session_ret, session_err
+        local function handler(sock)
+            session_ret, session_err = pcall(box.session.new, {fd = sock:fd()})
+            if session_ret then
+                sock:detach()
+            else
+                sock:close()
+            end
+        end
+        local server = socket.tcp_server('unix/', path, handler)
+        local conn = net.connect(path)
+        t.assert_equals(conn.state, 'error')
+        t.assert_str_contains(conn.error,
+                              'unexpected EOF when reading from socket')
+        t.assert_equals(session_ret, false)
+        t.assert_str_contains(session_err:unpack().type, 'ClientError')
+        t.assert_str_contains(session_err:unpack().message,
+                              'Server is shutting down')
+        conn:close()
+        server:close()
+    end)
+end

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -497,6 +497,7 @@ t;
  |   276: box.error.DEFAULT_FUNC_FAILED
  |   277: box.error.INVALID_DEC
  |   278: box.error.IN_ANOTHER_PROMOTE
+ |   279: box.error.SHUTDOWN
  | ...
 
 test_run:cmd("setopt delimiter ''");


### PR DESCRIPTION
Also we now can free all resources allocated in iproto threads.

Part of #8423