### PR TITLE
[3.0] httpc: use http 1.1 by default

### DIFF
--- a/src/httpc.c
+++ b/src/httpc.c
@@ -214,6 +214,8 @@ httpc_request_new(struct httpc_env *env, const char *method,
 			 curl_easy_header_cb);
 	curl_easy_setopt(req->curl_request.easy, CURLOPT_NOPROGRESS, 1L);
 	curl_easy_setopt(req->curl_request.easy, CURLOPT_NOSIGNAL, 1L);
+	curl_easy_setopt(req->curl_request.easy, CURLOPT_HTTP_VERSION,
+			 CURL_HTTP_VERSION_1_1);
 
 	ibuf_create(&req->send, &cord()->slabc, 1);
 


### PR DESCRIPTION
Commit 0ea1ba877b8e ("third_party: update libcurl from 8.3.0 to 8.4.0") bumps libcurl version and bringed a regression: http client returns nothing using connection with HTTP/2 protocol. The problem could be reproduced by etcd-client, see description in issue [1]. The problem in http client is due to commit "h2: testcase and fix for pausing h2 streams" [2] in libcurl. With reverted commit in libcurl the problem is gone.

To work around the issue, commit sets HTTP 1.1 as default protocol in http client.

Needed for #9547

1. https://github.com/tarantool/tarantool/issues/9547
2. https://github.com/curl/curl/commit/6b9a591bf7d82031f463373706d7de1cba0adee6

NO_CHANGELOG=workaround
NO_DOC=workaround
NO_TEST=etcd client's tests in Tarantool EE