### PR TITLE
ci: remove tarantoolctl from deb and rpm

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,20 +4,12 @@
 VERSION  := $(shell dpkg-parsechangelog|grep ^Version|awk '{print $$2}')
 UVERSION := $(shell echo $(VERSION)|sed 's/-[[:digit:]]\+$$//')
 
-ifneq ($(wildcard /usr/bin/dh_systemd_start),)
-WITH_SYSTEMD:=ON
-else
-WITH_SYSTEMD:=OFF
-endif
-
 DEB_CMAKE_EXTRA_FLAGS := \
 	-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 	-DCMAKE_INSTALL_LIBDIR=lib/$(DEB_HOST_MULTIARCH) \
 	-DCMAKE_INSTALL_SYSCONFDIR=/etc \
 	-DCMAKE_INSTALL_LOCALSTATEDIR=/var \
 	-DENABLE_DIST=ON \
-	-DWITH_SYSVINIT=ON \
-	-DWITH_SYSTEMD=$(WITH_SYSTEMD)
 
 # Append -DLUAJIT_ENABLE_GC64=ON flag if ${GC64} env variable is 'true'.
 ifeq ($(GC64), true)
@@ -28,12 +20,7 @@ ifneq ($(MAKE_CHECK), false)
 	DEB_MAKE_CHECK_TARGET := test-force
 endif
 
-# Install tarantool.service within tarantool-common package, but does not
-# install it within tarantool and tarantool-dev packages.
 DEB_DH_INSTALLINIT_ARGS                     := --name=tarantool
-DEB_DH_SYSTEMD_ENABLE_ARGS_tarantool        := --name=tarantool
-DEB_DH_SYSTEMD_ENABLE_ARGS_tarantool-common := --name=tarantool tarantool.service
-DEB_DH_SYSTEMD_START_ARGS_tarantool-common  := --no-restart-on-upgrade tarantool.service
 
 # Needed for proper backtraces in fiber.info()
 DEB_DH_STRIP_ARGS	        := -X/usr/bin/tarantool
@@ -42,15 +29,6 @@ DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/buildflags.mk
 include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/class/cmake.mk
-
-debian/tarantool-common.install:
-ifneq ($(wildcard /usr/bin/dh_systemd_start),)
-	cp -p debian/tarantool-common.install.systemd.in $@
-else
-	cp -p debian/tarantool-common.install.sysvinit.in $@
-endif
-
-build-indep: debian/tarantool-common.install
 
 tarball: clean
 	git describe --long --always > VERSION

--- a/debian/tarantool-common.dirs
+++ b/debian/tarantool-common.dirs
@@ -1,5 +1,0 @@
-/etc/tarantool/instances.available
-/etc/tarantool/instances.enabled
-/var/log/tarantool
-/var/lib/tarantool
-/usr/share/tarantool/luarocks

--- a/debian/tarantool-common.install.systemd.in
+++ b/debian/tarantool-common.install.systemd.in
@@ -1,9 +1,0 @@
-/etc/default/tarantool
-/usr/bin/tarantoolctl
-/etc/tarantool/instances.available/example.lua
-/etc/logrotate.d/tarantool
-/lib/systemd/system/tarantool.service
-/lib/systemd/system/tarantool@.service
-/lib/systemd/system-generators/tarantool-generator
-/usr/lib/tmpfiles.d/tarantool.conf
-/usr/share/man/man1/tarantoolctl.1

--- a/debian/tarantool-common.install.sysvinit.in
+++ b/debian/tarantool-common.install.sysvinit.in
@@ -1,5 +1,0 @@
-/etc/default/tarantool
-/usr/bin/tarantoolctl
-/etc/tarantool/instances.available/example.lua
-/etc/logrotate.d/tarantool
-/usr/share/man/man1/tarantoolctl.1

--- a/debian/tarantool-common.lintian-overrides
+++ b/debian/tarantool-common.lintian-overrides
@@ -1,1 +1,0 @@
-tarantool-common: unusual-interpreter usr/bin/tarantoolctl #!tarantool

--- a/debian/tarantool-common.tarantool.init
+++ b/debian/tarantool-common.tarantool.init
@@ -1,1 +1,0 @@
-../extra/dist/tarantool.init

--- a/debian/tarantool.service
+++ b/debian/tarantool.service
@@ -1,1 +1,0 @@
-../extra/dist/tarantool.service


### PR DESCRIPTION
tarantoolctl has been removed from packages.
Systemd, sysvinit and logrotate scripts
based on it were also removed.
All this functionality is covered by the tt utility.

Part of #9443

NO_DOC=CI
NO_TEST=CI
NO_CHANGELOG=CI