### PR TITLE
In-memory column storage engine stub

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -331,6 +331,10 @@ if(ENABLE_INTEGRITY)
     list(APPEND box_sources ${INTEGRITY_SOURCE})
 endif()
 
+if(ENABLE_MEMCS_ENGINE)
+    list(APPEND box_sources ${MEMCS_ENGINE_SOURCES})
+endif()
+
 add_library(box STATIC ${box_sources})
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -55,6 +55,7 @@
 #include "engine.h"
 #include "memtx_engine.h"
 #include "memtx_space.h"
+#include "memcs_engine.h"
 #include "sysview.h"
 #include "blackhole.h"
 #include "service_engine.h"
@@ -4776,6 +4777,8 @@ engine_init()
 				    box_on_indexes_built);
 	engine_register((struct engine *)memtx);
 	box_set_memtx_max_tuple_size();
+
+	memcs_engine_register();
 
 	struct sysview_engine *sysview = sysview_engine_new_xc();
 	engine_register((struct engine *)sysview);

--- a/src/box/engine.h
+++ b/src/box/engine.h
@@ -263,6 +263,16 @@ enum {
 	 * Set if the engine supports creation of a read view.
 	 */
 	ENGINE_SUPPORTS_READ_VIEW = 1 << 1,
+	/**
+	 * Set if checkpointing is implemented by the memtx engine.
+	 * Engine setting this flag must support read views.
+	 */
+	ENGINE_CHECKPOINT_BY_MEMTX = 1 << 2,
+	/**
+	 * Set if replica join is implemented by the memtx engine.
+	 * Engine setting this flag must support read views.
+	 */
+	ENGINE_JOIN_BY_MEMTX = 1 << 3,
 };
 
 struct engine {

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -1049,4 +1049,10 @@ generic_index_read_view_iterator_position(struct index_read_view_iterator *it,
 	return -1;
 }
 
+void
+generic_index_read_view_iterator_destroy(struct index_read_view_iterator *it)
+{
+	TRASH(it);
+}
+
 /* }}} */

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -718,6 +718,9 @@ struct index_read_view {
 struct index_read_view_iterator_base {
 	/** Pointer to the index read view. */
 	struct index_read_view *index;
+	/** Destroy a read view iterator. */
+	void
+	(*destroy)(struct index_read_view_iterator *iterator);
 	/**
 	 * Iterate to the next tuple in the read view.
 	 *
@@ -747,7 +750,7 @@ struct index_read_view_iterator_base {
 };
 
 /** Size of the index_read_view_iterator struct. */
-#define INDEX_READ_VIEW_ITERATOR_SIZE 64
+#define INDEX_READ_VIEW_ITERATOR_SIZE 72
 
 static_assert(sizeof(struct index_read_view_iterator_base) <=
 	      INDEX_READ_VIEW_ITERATOR_SIZE,
@@ -1049,7 +1052,7 @@ index_read_view_create_iterator(struct index_read_view *rv,
 static inline void
 index_read_view_iterator_destroy(struct index_read_view_iterator *iterator)
 {
-	TRASH(iterator);
+	iterator->base.destroy(iterator);
 }
 
 static inline int
@@ -1123,6 +1126,8 @@ generic_iterator_position(struct iterator *it, const char **pos,
 int
 generic_index_read_view_iterator_position(struct index_read_view_iterator *it,
 					  const char **pos, uint32_t *size);
+void
+generic_index_read_view_iterator_destroy(struct index_read_view_iterator *it);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/box/memcs_engine.h
+++ b/src/box/memcs_engine.h
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include "trivia/config.h"
+
+#if defined(ENABLE_MEMCS_ENGINE)
+# include "memcs_engine_impl.h"
+#else /* !defined(ENABLE_MEMCS_ENGINE) */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+static inline void
+memcs_engine_register(void) {}
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */
+
+#endif /* !defined(ENABLE_MEMCS_ENGINE) */

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -628,6 +628,7 @@ hash_read_view_create_iterator(struct index_read_view *base,
 	struct hash_read_view_iterator *it =
 		(struct hash_read_view_iterator *)iterator;
 	it->base.index = base;
+	it->base.destroy = generic_index_read_view_iterator_destroy;
 	it->base.next_raw = exhausted_index_read_view_iterator_next_raw;
 	it->base.position = generic_index_read_view_iterator_position;
 	light_index_view_iterator_begin(&rv->view, &it->iterator);

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -2047,6 +2047,7 @@ tree_read_view_create_iterator(struct index_read_view *base,
 	struct tree_read_view_iterator<USE_HINT> *it =
 		(struct tree_read_view_iterator<USE_HINT> *)iterator;
 	it->base.index = base;
+	it->base.destroy = generic_index_read_view_iterator_destroy;
 	it->base.next_raw = exhausted_index_read_view_iterator_next_raw;
 	if (it->base.index->def->key_def->for_func_index)
 		it->base.position =

--- a/src/box/sequence.c
+++ b/src/box/sequence.c
@@ -388,7 +388,9 @@ sequence_data_iterator_create(struct index_read_view *base,
 	struct sequence_data_iterator *iter =
 		(struct sequence_data_iterator *)iterator;
 	iter->base.index = base;
+	iter->base.destroy = generic_index_read_view_iterator_destroy;
 	iter->base.next_raw = sequence_data_iterator_next_raw;
+	iter->base.position = generic_index_read_view_iterator_position;
 	light_sequence_view_iterator_begin(&rv->view, &iter->iter);
 	return 0;
 }

--- a/src/trivia/config.h.cmake
+++ b/src/trivia/config.h.cmake
@@ -286,6 +286,7 @@
 #cmakedefine ENABLE_WAL_EXT 1
 #cmakedefine ENABLE_READ_VIEW 1
 #cmakedefine ENABLE_SECURITY 1
+#cmakedefine ENABLE_MEMCS_ENGINE 1
 #cmakedefine ENABLE_COMPRESS_MODULE 1
 #cmakedefine ENABLE_ETCD_CLIENT 1
 #cmakedefine ENABLE_CONFIG_EXTRAS 1

--- a/test/wal_off/alter.result
+++ b/test/wal_off/alter.result
@@ -26,9 +26,9 @@ end;
 ---
 - error: 'Tuple format limit reached: 65536'
 ...
-#spaces;
+#spaces > 65000;
 ---
-- 65499
+- true
 ...
 -- cleanup
 for k, v in pairs(spaces) do

--- a/test/wal_off/alter.test.lua
+++ b/test/wal_off/alter.test.lua
@@ -11,7 +11,7 @@ for k = 1, box.schema.FORMAT_ID_MAX, 1 do
     local s = box.schema.space.create('space'..k)
     table.insert(spaces, s)
 end;
-#spaces;
+#spaces > 65000;
 -- cleanup
 for k, v in pairs(spaces) do
     v:drop()


### PR DESCRIPTION
This PR makes a few changes required to implement the new in-memory column storage engine in Tarantool Enterprise Edition:
- Ability to reuse the memtx checkpoint and join machinery in other engines. The new engine will implement a read view so we'll get checkpoint and join for free because the memtx implementation is effectively generic and depends only on the read view feature.
- Read view iterator destructor. Memtx doesn't need one so it uses the generic implementation, but the new engine will need to some deallocations when a read view iterator is destroyed.
- Memcs engine stubs. The stubs will be implemented in the tarantool-ee repository.

Needed for tarantool/tarantool-ee#617

**EE PART** https://github.com/tarantool/tarantool-ee/pull/626