### PR TITLE
[backport 3.0] config: fix leader failing to start when uuids are set

### DIFF
--- a/changelogs/unreleased/gh_9572_config_with_uuids.md
+++ b/changelogs/unreleased/gh_9572_config_with_uuids.md
@@ -1,0 +1,5 @@
+## bugfix/config
+
+* Fixed an issue when a leader fails to start with the `attempt to index a nil
+  value` error if a config with all UUIDs set is used during a cluster's
+  bootstrap (gh-9572).

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -188,8 +188,12 @@ local function names_try_set_missing()
     -- Set names for all instances in the replicaset.
     for name, uuid in pairs(missing_names._peers) do
         if uuid ~= 'unknown' then
-            local tuple = box.space._cluster.index.uuid:select(uuid)
-            box.space._cluster:update(tuple[1][1], {{'=', 3, name}})
+            local tuple = box.space._cluster.index.uuid:get(uuid)
+            -- Tuple may be nil, when instance has not joined yet. Alert
+            -- will be dropped, when instance is joined, nothing to do.
+            if tuple ~= nil then
+                box.space._cluster:update(tuple[1], {{'=', 3, name}})
+            end
         end
     end
     box.commit()

--- a/test/config-luatest/gh_9572_config_with_uuids_test.lua
+++ b/test/config-luatest/gh_9572_config_with_uuids_test.lua
@@ -1,0 +1,39 @@
+local uuid = require('uuid')
+local t = require('luatest')
+local cbuilder = require('test.config-luatest.cbuilder')
+local replicaset = require('test.config-luatest.replicaset')
+
+local g = t.group()
+
+g.before_all(replicaset.init)
+g.after_each(replicaset.drop)
+g.after_all(replicaset.clean)
+
+g.test_basic = function(g)
+    local config = cbuilder.new()
+        :set_replicaset_option('replication.failover', 'manual')
+        :set_replicaset_option('leader', 'i-001')
+        :add_instance('i-001', {
+            database = {
+                instance_uuid = uuid.str()
+            }
+        })
+        :add_instance('i-002', {
+            database = {
+                instance_uuid = uuid.str()
+            }
+        })
+        :config()
+    local rs = replicaset.new(g, config)
+    rs:start()
+
+    rs['i-001']:exec(function()
+        t.assert_equals(box.info.name, 'i-001')
+        t.assert_equals(require('config')._alerts, {})
+    end)
+
+    rs['i-002']:exec(function()
+        t.assert_equals(box.info.name, 'i-002')
+        t.assert_equals(require('config')._alerts, {})
+    end)
+end


### PR DESCRIPTION
**This is backport of PR #9573 to the `release/3.0` branch.**

---

Currently a leader fails to start with `attempt to index a nil value` error, when all UUIDs are specified in config. This is caused by the fact, that we try to apply names to the instance, which have not joined yet, _cluster record doesn't exist.

We must skip such names. Alert will be dropeed automatically as soon as the instance is joined.

Closes #9572