### PR TITLE
[backport 2.10] test: pull treegen and justrun changes from master

### DIFF
--- a/test/justrun.lua
+++ b/test/justrun.lua
@@ -72,6 +72,10 @@ function justrun.tarantool(dir, env, args, opts)
     local opts = opts or {}
     assert(type(opts) == 'table')
 
+    -- Prevent system/user inputrc configuration file from
+    -- influencing testing code.
+    env['INPUTRC'] = '/dev/null'
+
     local tarantool_exe = arg[-1]
     -- Use popen.shell() instead of popen.new() due to lack of
     -- cwd option in popen (gh-5633).

--- a/test/justrun.lua
+++ b/test/justrun.lua
@@ -65,6 +65,11 @@ end
 --
 --   Collect stderr and place it into the `stderr` field of the
 --   return value
+--
+-- - quote_args (boolean, default: false)
+--
+--   Quote CLI arguments before concatenating them into a shell
+--   command.
 function justrun.tarantool(dir, env, args, opts)
     assert(type(dir) == 'string')
     assert(type(env) == 'table')
@@ -82,8 +87,11 @@ function justrun.tarantool(dir, env, args, opts)
     local env_str = table.concat(fun.iter(env):map(function(k, v)
         return ('%s=%q'):format(k, v)
     end):totable(), ' ')
+    local args_str = table.concat(fun.iter(args):map(function(v)
+        return opts.quote_args and ('%q'):format(v) or v
+    end):totable(), ' ')
     local command = ('cd %s && %s %s %s'):format(dir, env_str, tarantool_exe,
-                                                 table.concat(args, ' '))
+                                                 args_str)
     log.info(('Running a command: %s'):format(command))
     local mode = opts.stderr and 'rR' or 'r'
     local ph = popen.shell(command, mode)

--- a/test/treegen.lua
+++ b/test/treegen.lua
@@ -58,6 +58,7 @@ function treegen.write_script(dir, script, body)
     local fh = fio.open(script_abspath, flags, mode)
     fh:write(body)
     fh:close()
+    return script_abspath
 end
 
 -- Generate a script that follows a template and write it at the

--- a/test/treegen.lua
+++ b/test/treegen.lua
@@ -79,7 +79,7 @@ end
 -- unless KEEP_DATA environment variable is set to a
 -- non-empty value.
 function treegen.clean(g)
-    local dirs = table.copy(g.tempdirs)
+    local dirs = table.copy(g.tempdirs) or {}
     g.tempdirs = nil
 
     local keep_data = (os.getenv('KEEP_DATA') or '') ~= ''


### PR DESCRIPTION
The list of changes:

* f81b1aaca3607664c033392a66301e4746f8b3cc test: return a dir from treegen.prepare_directory()
* 8c3b4c088236161f76955e86e8ce96f24671c973 test: adjust treegen for TMPDIR ending with slash
* 028c65e04389cafd02d31fa70147b1e1b1f93217 test: reset readline configuration for justrun too
* 9b0896d9e63143ce4e894365639c431f682b2958 test: make treegen.clean more durable
* 761273f26deba5911e2e04d2c3b2c855fe864846 test: allow to quote CLI arguments in justrun