### PR TITLE
test: fix flaky tests when JIT is enabled

### DIFF
--- a/test/box/lua/utils.lua
+++ b/test/box/lua/utils.lua
@@ -188,6 +188,13 @@ local function create_iterator(obj, key, opts)
         local _, tp = iter.gen(key, state)
         return tp
     end
+    -- Disable JIT to avoid test failures when the iterator object
+    -- is referenced at the trace as the function's upvalue.
+    -- For more information, see
+    -- https://github.com/tarantool/tarantool/wiki/LuaJIT-function-inlining.
+    -- It helps to avoid side effects like those mentioned in the
+    -- tarantool/tarantool-qa#233.
+    jit.off(res.next)
     res.iterate_over = function()
         local ret = {}
         local i = 0

--- a/test/box/net.box_reconnect_after_gh-3164.result
+++ b/test/box/net.box_reconnect_after_gh-3164.result
@@ -10,6 +10,14 @@ test_run = require('test_run').new()
 net = require('net.box')
 ---
 ...
+-- Disable JIT to avoid the test failure when the connection
+-- object is referenced at the trace as the function's upvalue.
+-- For more information, see
+-- https://github.com/tarantool/tarantool/wiki/LuaJIT-function-inlining.
+-- Resolves tarantool/tarantool-qa#276.
+jit.off()
+---
+...
 test_run:cmd("push filter 'peer_uuid: .*' to 'peer_uuid: <UUID>'")
 ---
 - true

--- a/test/box/net.box_reconnect_after_gh-3164.test.lua
+++ b/test/box/net.box_reconnect_after_gh-3164.test.lua
@@ -3,6 +3,13 @@ log = require 'log'
 test_run = require('test_run').new()
 net = require('net.box')
 
+-- Disable JIT to avoid the test failure when the connection
+-- object is referenced at the trace as the function's upvalue.
+-- For more information, see
+-- https://github.com/tarantool/tarantool/wiki/LuaJIT-function-inlining.
+-- Resolves tarantool/tarantool-qa#276.
+jit.off()
+
 test_run:cmd("push filter 'peer_uuid: .*' to 'peer_uuid: <UUID>'")
 test_run:cmd("push filter 'reconnect_after: .*' to 'reconnect_after: <NUM>'")
 test_run:cmd("push filter 'schema_version: .*' to 'schema_version: <NUM>'")


### PR DESCRIPTION
test: fix flaky tests when JIT is enabled

<box/net.box_reconnect_after_gh-3164.test.lua> and <vinyl/tx_gap_lock.test.lua> checking some objects that should be collected may fail because these objects are referenced as the upvalues for a function inlined on some JIT trace. The objects aren't leaked; tests don't consider the JIT semantics. See more details in [1].

This patch disables JIT for the first test.

The second test itself isn't affected since the commit tarantool/test-run@33fbace8307e64e66b0b2178ac952b2697673917 ("Add default server restart to each test run"). Because of this commit, the `tx.gap_locks` can't be affected by the use of the `create_iterator()` function in other tests.
But to avoid similar situations in the future, the JIT is disabled for the `res.next()` function in test utils.

[1]: https://github.com/tarantool/tarantool/wiki/LuaJIT-function-inlining

Closes tarantool/tarantool-qa#233
Closes tarantool/tarantool-qa#276

NO_DOC=fix flaky test
NO_CHANGELOG=see NO_DOC