### PR TITLE
box: remove static_assert() from field_def.h

### DIFF
--- a/src/box/field_def.h
+++ b/src/box/field_def.h
@@ -89,22 +89,6 @@ enum on_conflict_action {
 
 /** \endcond public */
 
-enum {
-	/**
-	 * This mask allows to store in VdbeOp.p5 operand of
-	 * OP_Eq, OP_Lt etc opcodes field type alongside with
-	 * flags.
-	 */
-	FIELD_TYPE_MASK = 15
-};
-
-/**
- * For detailed explanation see context of OP_Eq, OP_Lt etc
- * opcodes in vdbe.c.
- */
-static_assert((int) field_type_MAX <= (int) FIELD_TYPE_MASK,
-	      "values of enum field_type should fit into 4 bits of VdbeOp.p5");
-
 extern const char *field_type_strs[];
 
 extern const char *on_conflict_action_strs[];


### PR DESCRIPTION
This patch removes the static_assert(). This static_assert was necessary because after commit 037e2e449be8 ("sql: clean-up affinity from SQL source code") and before commit 078bcf00437f ("sql: remove implicit cast from comparison opcodes"), 4 bits of the p5 field of the struct VdbeOp were used to store the field type in VDBE comparison opcodes. After the commit 078bcf00437f ("sql: remove implicit cast from comparison opcodes"), these opcodes no longer need the field type, so this static_assert() is now unneeded.
