### PR TITLE
test: fix server start if multiple replicasets

### DIFF
--- a/test/config-luatest/server_helper_test.lua
+++ b/test/config-luatest/server_helper_test.lua
@@ -1,0 +1,93 @@
+local fun = require('fun')
+local yaml = require('yaml')
+local t = require('luatest')
+local treegen = require('test.treegen')
+local server = require('test.luatest_helpers.server')
+local helpers = require('test.config-luatest.helpers')
+
+local g = helpers.group()
+
+g.test_multiple_groups_and_replicasets_cluster_bootstrap = function(g)
+    local dir = treegen.prepare_directory(g, {}, {})
+    local config = {
+        credentials = {
+            users = {
+                guest = {
+                    roles = {'super'},
+                },
+            },
+        },
+        iproto = {
+            listen = {{uri = 'unix/:./{{ instance_name }}.iproto'}},
+        },
+        groups = {
+            ['group-a'] = {
+                replicasets = {
+                    ['replicaset-a-01'] = {
+                        leader = 'instance-a-01-001',
+                        instances = {
+                            ['instance-a-01-001'] = {},
+                            ['instance-a-01-002'] = {},
+                        },
+                    },
+                    ['replicaset-a-02'] = {
+                        leader = 'instance-a-02-001',
+                        instances = {
+                            ['instance-a-02-001'] = {},
+                            ['instance-a-02-002'] = {},
+                        },
+                    },
+                },
+            },
+            ['group-b'] = {
+                replicasets = {
+                    ['replicaset-b-01'] = {
+                        leader = 'instance-b-01-001',
+                        instances = {
+                            ['instance-b-01-001'] = {},
+                            ['instance-b-01-002'] = {},
+                        },
+                    },
+                    ['replicaset-b-02'] = {
+                        leader = 'instance-b-02-001',
+                        instances = {
+                            ['instance-b-02-001'] = {},
+                            ['instance-b-02-002'] = {},
+                        },
+                    },
+                },
+            },
+        },
+        replication = {
+            failover = 'manual',
+        },
+    }
+    local config_file = treegen.write_script(dir, 'config.yaml',
+                                             yaml.encode(config))
+    local opts = {config_file = config_file, chdir = dir}
+
+    local servers = {}
+    for _, group in pairs(config.groups) do
+        for _, replicaset in pairs(group.replicasets) do
+            for alias, _ in pairs(replicaset.instances) do
+                local server_opts = fun.chain(opts, {alias = alias}):tomap()
+                local server = server:new(server_opts)
+
+                servers[alias] = server
+                g['server_' .. alias] = server -- For autocleanup.
+            end
+        end
+    end
+
+    for _, server in pairs(servers) do
+        server:start({wait_until_ready = false})
+    end
+
+    for _, server in pairs(servers) do
+        server:wait_until_ready()
+    end
+
+    for _, server in pairs(servers) do
+        t.assert_equals(server:eval('return box.info.name'), server.alias)
+    end
+end

--- a/test/luatest_helpers/server.lua
+++ b/test/luatest_helpers/server.lua
@@ -28,21 +28,6 @@ local function pathjoin(a, b)
     return fio.pathjoin(a, b)
 end
 
--- Find corresponding group, replicaset and instance configuration by name.
-local function find_instance_config(groups, instance_name)
-    for _, group in pairs(groups or {}) do
-        for _, replicaset in pairs(group.replicasets or {}) do
-            local instance = (replicaset.instances or {})[instance_name]
-
-            if instance ~= nil then
-                return group, replicaset, instance
-            end
-        end
-    end
-
-    return nil, nil, nil
-end
-
 -- Determine advertise URI for given instance from a cluster
 -- configuration.
 local function find_advertise_uri(config, instance_name, dir)
@@ -52,30 +37,33 @@ local function find_advertise_uri(config, instance_name, dir)
 
     -- Determine listen and advertise options that are in effect
     -- for the given instance.
-    local advertise = nil
-    local listen = nil
+    local advertise
+    local listen
 
-    local group, replicaset, instance = find_instance_config(config.groups,
-        instance_name)
-
-    if instance ~= nil then
-        if instance.iproto ~= nil then
-            if instance.iproto.advertise ~= nil then
-                advertise = advertise or instance.iproto.advertise.client
+    for _, group in pairs(config.groups or {}) do
+        for _, replicaset in pairs(group.replicasets or {}) do
+            local instance = (replicaset.instances or {})[instance_name]
+            if instance == nil then
+                break
             end
-            listen = listen or instance.iproto.listen
-        end
-        if replicaset.iproto ~= nil then
-            if replicaset.iproto.advertise ~= nil then
-                advertise = advertise or replicaset.iproto.advertise.client
+            if instance.iproto ~= nil then
+                if instance.iproto.advertise ~= nil then
+                    advertise = advertise or instance.iproto.advertise.client
+                end
+                listen = listen or instance.iproto.listen
             end
-            listen = listen or replicaset.iproto.listen
-        end
-        if group.iproto ~= nil then
-            if group.iproto.advertise ~= nil then
-                advertise = advertise or group.iproto.advertise.client
+            if replicaset.iproto ~= nil then
+                if replicaset.iproto.advertise ~= nil then
+                    advertise = advertise or replicaset.iproto.advertise.client
+                end
+                listen = listen or replicaset.iproto.listen
             end
-            listen = listen or group.iproto.listen
+            if group.iproto ~= nil then
+                if group.iproto.advertise ~= nil then
+                    advertise = advertise or group.iproto.advertise.client
+                end
+                listen = listen or group.iproto.listen
+            end
         end
     end
 


### PR DESCRIPTION
Before this patch, test server bootstrap with helper had failed with `"No suitable URI to connect is found"` error in case server wasn't found in first replicaset of the group. The reason was the following snippet of code:
```lua
if instance == nil then
    break
end
```

NO_DOC=fix test helper
NO_CHANGELOG=fix test helper