### PR TITLE
index: introduce weak reference

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -189,6 +189,7 @@ set(box_sources
     tuple_convert.c
     index.cc
     index_def.c
+    index_weak_ref.c
     iterator_type.c
     memtx_hash.cc
     memtx_tree.cc

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3776,7 +3776,7 @@ box_select(uint32_t space_id, uint32_t index_id,
 		 * Refresh the pointer to the space, because the space struct
 		 * could be freed if the iterator yielded.
 		 */
-		space = iterator_space(it);
+		space = index_weak_ref_get_space(&it->index_ref);
 	}
 
 	txn_end_ro_stmt(txn, &svp);

--- a/src/box/index_weak_ref.c
+++ b/src/box/index_weak_ref.c
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2024, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include "index_weak_ref.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+
+#include "space.h"
+#include "space_cache.h"
+#include "index.h"
+
+void
+index_weak_ref_create(struct index_weak_ref *ref, struct index *index)
+{
+	ref->space_id = index->def->space_id;
+	ref->index_id = index->def->iid;
+	ref->space_cache_version = space_cache_version;
+	if (ref->space_id == 0) {
+		/* Ephemeral space. Not present in the space cache. */
+		ref->space = NULL;
+	} else {
+		ref->space = space_cache_find(ref->space_id);
+		assert(ref->space != NULL);
+	}
+	ref->index = index;
+	assert(index_weak_ref_is_checked(ref));
+}
+
+bool
+index_weak_ref_check_slow(struct index_weak_ref *ref)
+{
+	assert(!index_weak_ref_is_checked(ref));
+	assert(ref->space_id != 0);
+	struct space *space = space_by_id(ref->space_id);
+	if (space == NULL) {
+		/* Space was dropped. */
+		return false;
+	}
+	struct index *index = space_index(space, ref->index_id);
+	if (index != ref->index ||
+	    index->space_cache_version > ref->space_cache_version) {
+		/* Index was altered. */
+		return false;
+	}
+	ref->space_cache_version = space_cache_version;
+	ref->space = space;
+	assert(index_weak_ref_is_checked(ref));
+	return true;
+}

--- a/src/box/index_weak_ref.h
+++ b/src/box/index_weak_ref.h
@@ -1,0 +1,180 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2024, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+
+#include "trivia/util.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+struct space;
+struct index;
+
+/**
+ * Weak index reference.
+ *
+ * In contrast to a strong reference, it doesn't prevent the index from being
+ * destroyed. This is achieved by checking if the index can be found in the
+ * space cache by id every time the reference is accessed.
+ *
+ * Since ephemeral spaces aren't added to the space cache, the check is skipped
+ * for them. The user may still use a weak reference to an ephemeral index but
+ * it will work exactly like a plain pointer.
+ */
+struct index_weak_ref {
+	/** Referenced space id. 0 iff the space is ephemeral. */
+	uint32_t space_id;
+	/** Referenced index id. */
+	uint32_t index_id;
+	/** Space cache version after the last successful dereference. */
+	uint32_t space_cache_version;
+	/**
+	 * Pointer to the referenced space. May be stale.
+	 * NULL iff this is a reference to an ephemeral index.
+	 *
+	 * Do not access directly, use index_weak_ref_get_space() or
+	 * index_weak_ref_get_space_checked().
+	 */
+	struct space *space;
+	/**
+	 * Pointer to the referenced index. May be stale.
+	 *
+	 * Do not access directly, use index_weak_ref_get_index() or
+	 * index_weak_ref_get_index_checked().
+	 */
+	struct index *index;
+};
+
+/**
+ * Creates a weak reference to the given index.
+ *
+ * A newly created reference is guaranteed to be valid
+ * (index_weak_ref_is_checked() returns true).
+ */
+void
+index_weak_ref_create(struct index_weak_ref *ref, struct index *index);
+
+/**
+ * Returns true if the pointers to the space and index stored in the given weak
+ * reference are guaranteed to be valid.
+ */
+static inline bool
+index_weak_ref_is_checked(struct index_weak_ref *ref)
+{
+	if (ref->space_id == 0) {
+		/*
+		 * This is a reference to an ephemeral index. Since ephemeral
+		 * spaces aren't stored in the space cache, we can't possibly
+		 * check it so we assume it's always valid.
+		 */
+		return true;
+	}
+	/*
+	 * If the space cache hasn't been updated since the last check,
+	 * the reference must be valid, otherwise we need to recheck it.
+	 */
+	extern uint32_t space_cache_version;
+	return ref->space_cache_version == space_cache_version;
+}
+
+/** Slow path of index_weak_ref_check(). */
+bool
+index_weak_ref_check_slow(struct index_weak_ref *ref);
+
+/**
+ * Checks a weak reference, updating the pointer to the space if necessary.
+ * Returns false if the reference is invalid.
+ */
+static inline bool
+index_weak_ref_check(struct index_weak_ref *ref)
+{
+	if (likely(index_weak_ref_is_checked(ref)))
+		return true;
+	return index_weak_ref_check_slow(ref);
+}
+
+/**
+ * Gets pointers to the space and index from a weak reference, assuming that
+ * it was checked with index_weak_ref_check().
+ */
+static inline void
+index_weak_ref_get_checked(struct index_weak_ref *ref,
+			   struct space **space, struct index **index)
+{
+	assert(index_weak_ref_is_checked(ref));
+	*space = ref->space;
+	*index = ref->index;
+}
+
+/**
+ * Gets a pointer to the space from a weak reference, assuming that it was
+ * checked with index_weak_ref_check(). Returns NULL if the space is ephemeral.
+ */
+static inline struct space *
+index_weak_ref_get_space_checked(struct index_weak_ref *ref)
+{
+	assert(index_weak_ref_is_checked(ref));
+	return ref->space;
+}
+
+/**
+ * Gets a pointer to the index from a weak reference, assuming that it was
+ * checked with index_weak_ref_check().
+ */
+static inline struct index *
+index_weak_ref_get_index_checked(struct index_weak_ref *ref)
+{
+	assert(index_weak_ref_is_checked(ref));
+	return ref->index;
+}
+
+/**
+ * Gets pointers to the space and index from a weak reference if it's valid.
+ * Returns false if the reference is invalid.
+ */
+static inline bool
+index_weak_ref_get(struct index_weak_ref *ref,
+		   struct space **space, struct index **index)
+{
+	if (!index_weak_ref_check(ref))
+		return false;
+	index_weak_ref_get_checked(ref, space, index);
+	return true;
+}
+
+/**
+ * Gets a pointer to the space from a weak reference if it's valid.
+ * Returns NULL if the reference is invalid or the space is ephemeral.
+ */
+static inline struct space *
+index_weak_ref_get_space(struct index_weak_ref *ref)
+{
+	if (!index_weak_ref_check(ref))
+		return NULL;
+	return index_weak_ref_get_space_checked(ref);
+}
+
+/**
+ * Gets a pointer to the index from a weak reference if it's valid.
+ * Returns NULL if the reference is invalid.
+ */
+static inline struct index *
+index_weak_ref_get_index(struct index_weak_ref *ref)
+{
+	if (!index_weak_ref_check(ref))
+		return NULL;
+	return index_weak_ref_get_index_checked(ref);
+}
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -109,7 +109,7 @@ enum memtx_reserve_extents_num {
  * allocated for each iterator (except rtree index iterator that
  * is significantly bigger so has own pool).
  */
-#define MEMTX_ITERATOR_SIZE (176)
+#define MEMTX_ITERATOR_SIZE (184)
 
 typedef void
 (*memtx_on_indexes_built_cb)(void);

--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -152,14 +152,15 @@ static int
 index_rtree_iterator_next(struct iterator *i, struct tuple **ret)
 {
 	struct index_rtree_iterator *itr = (struct index_rtree_iterator *)i;
+	struct space *space;
+	struct index *index;
+	index_weak_ref_get_checked(&i->index_ref, &space, &index);
 	do {
 		*ret = (struct tuple *) rtree_iterator_next(&itr->impl);
 		if (*ret == NULL)
 			break;
-		struct index *idx = i->index;
 		struct txn *txn = in_txn();
-		struct space *space = space_by_id(i->space_id);
-		*ret = memtx_tx_tuple_clarify(txn, space, *ret, idx, 0);
+		*ret = memtx_tx_tuple_clarify(txn, space, *ret, index, 0);
 /********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND START*********/
 		memtx_tx_story_gc();
 /*********MVCC TRANSACTION MANAGER STORY GARBAGE COLLECTION BOUND END**********/

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -471,8 +471,7 @@ int tarantoolsqlEphemeralDelete(BtCursor *pCur)
 	char *key;
 	uint32_t key_size;
 	size_t region_svp = region_used(&fiber()->gc);
-	key = tuple_extract_key(pCur->last_tuple,
-				pCur->iter->index->def->key_def,
+	key = tuple_extract_key(pCur->last_tuple, pCur->index->def->key_def,
 				MULTIKEY_NONE, &key_size);
 	if (key == NULL)
 		return -1;
@@ -498,7 +497,7 @@ tarantoolsqlDelete(struct BtCursor *pCur)
 
 	size_t region_svp = region_used(&fiber()->gc);
 	key = tuple_extract_key(pCur->last_tuple,
-				pCur->iter->index->def->key_def,
+				pCur->index->def->key_def,
 				MULTIKEY_NONE, &key_size);
 	if (key == NULL)
 		return -1;
@@ -552,7 +551,7 @@ int tarantoolsqlEphemeralClearTable(BtCursor *pCur)
 
 	while (iterator_next(it, &tuple) == 0 && tuple != NULL) {
 		size_t region_svp = region_used(&fiber()->gc);
-		key = tuple_extract_key(tuple, it->index->def->key_def,
+		key = tuple_extract_key(tuple, pCur->index->def->key_def,
 					MULTIKEY_NONE, &key_size);
 		int rc = space_ephemeral_delete(pCur->space, key);
 		region_truncate(&fiber()->gc, region_svp);
@@ -719,7 +718,7 @@ tarantoolsqlIdxKeyCompare(struct BtCursor *cursor,
 	uint32_t key_size;
 #endif
 
-	key_def = cursor->iter->index->def->key_def;
+	key_def = cursor->index->def->key_def;
 	n = MIN(unpacked->nField, key_def->part_count);
 	tuple = cursor->last_tuple;
 	base = tuple_data(tuple);

--- a/src/box/sysview.c
+++ b/src/box/sysview.c
@@ -91,9 +91,8 @@ sysview_iterator_next(struct iterator *iterator, struct tuple **ret)
 	assert(iterator->free == sysview_iterator_free);
 	struct sysview_iterator *it = sysview_iterator(iterator);
 	*ret = NULL;
-	if (it->source->space_cache_version != space_cache_version)
-		return 0; /* invalidate iterator */
-	struct sysview_index *index = (struct sysview_index *)iterator->index;
+	struct sysview_index *index = (struct sysview_index *)
+		index_weak_ref_get_index_checked(&iterator->index_ref);
 	int rc;
 	while ((rc = iterator_next(it->source, ret)) == 0 && *ret != NULL) {
 		if (index->filter(it->space, *ret))

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -3735,7 +3735,8 @@ vinyl_iterator_position(struct iterator *base, const char **pos, uint32_t *size)
 {
 	struct vinyl_iterator *it = (struct vinyl_iterator *)base;
 	/* Sic: can't use it->lsm here, because the iterator may be closed. */
-	struct vy_lsm *lsm = vy_lsm(base->index);
+	struct vy_lsm *lsm = vy_lsm(index_weak_ref_get_index_checked(
+			&base->index_ref));
 	struct key_def *cmp_def = lsm->cmp_def;
 	struct vy_entry entry = it->pos;
 	if (entry.stmt == NULL) {


### PR DESCRIPTION
An iterator doesn't pin the index it was created for. Instead, it holds a 'weak' reference to it, which is invalidated if the index is dropped. This is achieved by checking if the index can be found in the space cache by id every time the reference is accessed. Let's factor out this weak reference concept into a separate class so that we can reuse it because we'll also need it to implement the index scanner API.

Needed for #9568