### PR TITLE
space: optimize lookup by id

### DIFF
--- a/src/box/space_cache.c
+++ b/src/box/space_cache.c
@@ -22,6 +22,15 @@ static struct mh_strnptr_t *spaces_by_name;
  */
 uint32_t space_cache_version;
 
+/**
+ * Value of space_cache_version at the time of the last space lookup,
+ * see space_by_id_fast().
+ */
+uint32_t prev_space_cache_version;
+
+/** Last looked up space, see space_by_id_fast(). */
+struct space *prev_space;
+
 const char *space_cache_holder_type_strs[SPACE_HOLDER_MAX] = {
 	"foreign key",
 };
@@ -48,9 +57,8 @@ space_cache_destroy(void)
 	mh_strnptr_delete(spaces_by_name);
 }
 
-/** Return space by its number */
 struct space *
-space_by_id(uint32_t id)
+space_by_id_slow(uint32_t id)
 {
 	mh_int_t space = mh_i32ptr_find(spaces, id, NULL);
 	if (space == mh_end(spaces))
@@ -249,4 +257,13 @@ space_cache_is_pinned(struct space *space, enum space_cache_holder_type *type)
 		}
 	}
 	return false;
+}
+
+#undef space_by_id
+
+/** Define the space_by_id() symbol for FFI. */
+struct space *
+space_by_id(uint32_t id)
+{
+	return space_by_id_fast(id);
 }

--- a/test/unit/vy_point_lookup.c
+++ b/test/unit/vy_point_lookup.c
@@ -12,7 +12,10 @@
 
 uint64_t schema_version;
 uint32_t space_cache_version;
-struct space *space_by_id(uint32_t id) { return NULL; }
+uint32_t prev_space_cache_version;
+struct space *prev_space;
+struct space *
+space_by_id_slow(uint32_t id) { return NULL; }
 struct vy_lsm *vy_lsm(struct index *index) { return NULL; }
 void index_delete(struct index *index) { unreachable(); }
 


### PR DESCRIPTION
In contrast to `space_cache_find()`, `space_by_id()` doesn't cache the last looked up space to speed up following lookups. This is confusing, because one would expect the only difference between `space_cache_find()` and `space_by_id()` functions to be that the former sets diag while the latter doesn't. Let's move the `prev_space` cache to `space_by_id()` to fix this issue.

To achieve that we need to make `space_by_id()` inline, which is tricky because it's called via FFI. We work around that by defining a macro `space_by_id()` which expands to `space_by_id_fast()` while still keeping the `space_by_id()` symbol for FFI.

Last but not least, we make the last cached space global (currently it's instantiated once per each `space_cache_find()` call site). This is a good thing because we often call `space_by_id()` a few times while processing the *same* DML request (e.g. in memtx mvcc).