### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9145-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9145-luajit-fixes.md
@@ -1,0 +1,4 @@
+## bugfix/luajit
+Backported patches from the vanilla LuaJIT trunk (gh-9145). The following issues
+were fixed as part of this activity:
+* Fixed recording of __concat metamethod.


### PR DESCRIPTION
Fix recording of __concat metamethod.

Part of #9145

NO_DOC=LJ
NO_TEST=LJ