### PR TITLE
ci: drop testing for FreeBSD 12, add for FreeBSD 14

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        freebsd-version: [ 12, 13 ]
+        freebsd-version: [ 13, 14 ]
         tarantool-branch:
           - 'master'
           - 'release/3.0'


### PR DESCRIPTION
- Drop testing for FreeBSD 12 since FreeBSD 14 is available
- Add testing for FreeBSD 14