### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9595-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9595-luajit-fixes.md
@@ -1,0 +1,6 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-9595). The following
+issues were fixed as part of this activity:
+
+* No side traces are recorded now after disabling the JIT via `jit.off()`.


### PR DESCRIPTION
* Respect jit.off() on pending trace exit.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump