### PR TITLE
config: introduce config.etcd.watchers options

### DIFF
--- a/changelogs/unreleased/ghe-647-config-etcd-watchers-options.md
+++ b/changelogs/unreleased/ghe-647-config-etcd-watchers-options.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* Added new `config.etcd` options `watchers.reconnect_timeout` and
+  `watchers.reconnect_max_attempts` (ghe-647).

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -493,6 +493,20 @@ return schema.new('instance_config', schema.record({
                     }),
                 }),
             }),
+            watchers = schema.record({
+                reconnect_timeout = schema.scalar({
+                    type = 'number',
+                    -- default = 1.0 is applied right in the
+                    -- etcd source. See a comment above
+                    -- regarding defaults in config.etcd.
+                }),
+                reconnect_max_attempts = schema.scalar({
+                    type = 'integer',
+                    -- default = 10 is applied right in the
+                    -- etcd source. See a comment above
+                    -- regarding defaults in config.etcd.
+                }),
+            }),
             ssl = schema.record({
                 ssl_key = schema.scalar({
                     type = 'string',

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -94,6 +94,10 @@ g.test_config_enterprise = function()
                         unix_socket = 'six',
                     }
                 },
+                watchers = {
+                    reconnect_timeout = 2,
+                    reconnect_max_attempts = 3,
+                },
                 ssl = {
                     ssl_key = 'seven',
                     ca_path = 'eight',


### PR DESCRIPTION
These options are needed to properly set up reconnection of etcd watchers.

Needed for https://github.com/tarantool/tarantool-ee/issues/647
