### PR TITLE
httpc: fix reading data in a chunked request

### DIFF
--- a/changelogs/unreleased/gh-9547-fix-reading-data-in-chunked-request.md
+++ b/changelogs/unreleased/gh-9547-fix-reading-data-in-chunked-request.md
@@ -1,0 +1,4 @@
+## bugfix/httpc
+
+* Fixed a bug when read from a chunked request returns
+  nothing (gh-9547).

--- a/src/httpc.c
+++ b/src/httpc.c
@@ -214,8 +214,6 @@ httpc_request_new(struct httpc_env *env, const char *method,
 			 curl_easy_header_cb);
 	curl_easy_setopt(req->curl_request.easy, CURLOPT_NOPROGRESS, 1L);
 	curl_easy_setopt(req->curl_request.easy, CURLOPT_NOSIGNAL, 1L);
-	curl_easy_setopt(req->curl_request.easy, CURLOPT_HTTP_VERSION,
-			 CURL_HTTP_VERSION_1_1);
 
 	ibuf_create(&req->send, &cord()->slabc, 1);
 


### PR DESCRIPTION
There was a problem: chunked request to etcd via TLS using builtin http client returns nothing. The problem was reproduced quite often by a test `integration.general.tls` in etcd-client Lua module. The patch updates curl submodule to a version based on 8.5.0 release with applied patch with fix [1].

The patch also removes workaround for aforementioned problem made in commit aa58c21206f0 ("httpc: use http 1.1 by default").

1. https://github.com/curl/curl/commit/cdd905a9854305657ebbe645095e1189dcda28c7

Fixes #9547

NO_TEST=etcd-client tests
NO_DOC=bugfix

(cherry picked from commit 9bdf2bab97d47603607455c61e91dae4b5d3ca5a)