### PR TITLE
ci: fix fail on artifact upload to S3 for freebsd

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -70,7 +70,14 @@ jobs:
           startsWith(github.ref, 'refs/heads/release/') ||
           startsWith(github.ref, 'refs/tags/') )
         with:
-          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          # Unfortunately, `${{ github.job }} (${{ join(matrix.*, ', ') }})` is
+          # evaluated to `freebsd (Object)` and that's why the job name is made
+          # manually. Looks like the ChristopherHX/github-act-runner agent has
+          # a bug somewhere.
+          job-name: ${{ format(
+            'freebsd ({0}, {1})',
+            matrix.freebsd-version,
+            matrix.tarantool-branch) }}
           access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
           secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
           source: ${{ env.VARDIR }}/artifacts


### PR DESCRIPTION
This patch fixes the following issue:

    Error: Unable to retrieve job ID by provided job name

The `${{ github.job }} (${{ join(matrix.*, ', ') }})` expression was evaluated to `freebsd (Object)` instead of proper job name. It looks like the ChristopherHX/github-act-runner agent has a bug somewhere. Now the job name is made manually to bypass the issue.