### PR TITLE
box: allow indexing of fixed-size numeric field types

### DIFF
--- a/src/box/index_def.h
+++ b/src/box/index_def.h
@@ -302,12 +302,24 @@ index_def_cmp(const struct index_def *key1, const struct index_def *key2);
  * Check a key definition for violation of various limits.
  *
  * @param index_def index definition
- * @param old_space space definition
+ * @param space_name space name
  * @retval 0 Success.
  * @retval -1 Error. Diag is set.
  */
 int
 index_def_check(struct index_def *index_def, const char *space_name);
+
+/**
+ * Check types of tuple fields indexed by `index_def'.
+ *
+ * @param index_def index definition
+ * @param space_name space name
+ * @retval 0 Success.
+ * @retval -1 Error. Diag is set.
+ */
+int
+index_def_check_field_types(struct index_def *index_def,
+			    const char *space_name);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -868,19 +868,9 @@ memtx_space_check_index_def(struct space *space, struct index_def *index_def)
 		return -1;
 	}
 
-	/* Only HASH and TREE indexes checks parts there */
-	/* Check that there are no ANY, ARRAY, MAP parts */
-	for (uint32_t i = 0; i < key_def->part_count; i++) {
-		struct key_part *part = &key_def->parts[i];
-		if (part->type <= FIELD_TYPE_ANY ||
-		    part->type >= FIELD_TYPE_INTERVAL) {
-			diag_set(ClientError, ER_MODIFY_INDEX,
-				 index_def->name, space_name(space),
-				 tt_sprintf("field type '%s' is not supported",
-					    field_type_strs[part->type]));
-			return -1;
-		}
-	}
+	/* Only HASH and TREE indexes check parts there. */
+	if (index_def_check_field_types(index_def, space_name(space)) != 0)
+		return -1;
 	return 0;
 }
 

--- a/src/box/tuple_compare.cc
+++ b/src/box/tuple_compare.cc
@@ -131,6 +131,22 @@ mp_compare_bool(const char *field_a, const char *field_b)
 }
 
 static int
+mp_compare_float32(const char *field_a, const char *field_b)
+{
+	float a_val = mp_decode_float(&field_a);
+	float b_val = mp_decode_float(&field_b);
+	return COMPARE_RESULT(a_val, b_val);
+}
+
+static int
+mp_compare_float64(const char *field_a, const char *field_b)
+{
+	double a_val = mp_decode_double(&field_a);
+	double b_val = mp_decode_double(&field_b);
+	return COMPARE_RESULT(a_val, b_val);
+}
+
+static int
 mp_compare_as_double(const char *field_a, const char *field_b)
 {
 	double a_val = mp_read_as_double(field_a);
@@ -497,18 +513,30 @@ tuple_compare_field(const char *field_a, const char *field_b,
 {
 	switch (type) {
 	case FIELD_TYPE_UNSIGNED:
+	case FIELD_TYPE_UINT8:
+	case FIELD_TYPE_UINT16:
+	case FIELD_TYPE_UINT32:
+	case FIELD_TYPE_UINT64:
 		return mp_compare_uint(field_a, field_b);
 	case FIELD_TYPE_STRING:
 		return coll != NULL ?
 		       mp_compare_str_coll(field_a, field_b, coll) :
 		       mp_compare_str(field_a, field_b);
 	case FIELD_TYPE_INTEGER:
+	case FIELD_TYPE_INT8:
+	case FIELD_TYPE_INT16:
+	case FIELD_TYPE_INT32:
+	case FIELD_TYPE_INT64:
 		return mp_compare_integer_with_type(field_a,
 						    mp_typeof(*field_a),
 						    field_b,
 						    mp_typeof(*field_b));
 	case FIELD_TYPE_NUMBER:
 		return mp_compare_number(field_a, field_b);
+	case FIELD_TYPE_FLOAT32:
+		return mp_compare_float32(field_a, field_b);
+	case FIELD_TYPE_FLOAT64:
+		return mp_compare_float64(field_a, field_b);
 	case FIELD_TYPE_DOUBLE:
 		return mp_compare_as_double(field_a, field_b);
 	case FIELD_TYPE_BOOLEAN:
@@ -538,17 +566,29 @@ tuple_compare_field_with_type(const char *field_a, enum mp_type a_type,
 {
 	switch (type) {
 	case FIELD_TYPE_UNSIGNED:
+	case FIELD_TYPE_UINT8:
+	case FIELD_TYPE_UINT16:
+	case FIELD_TYPE_UINT32:
+	case FIELD_TYPE_UINT64:
 		return mp_compare_uint(field_a, field_b);
 	case FIELD_TYPE_STRING:
 		return coll != NULL ?
 		       mp_compare_str_coll(field_a, field_b, coll) :
 		       mp_compare_str(field_a, field_b);
 	case FIELD_TYPE_INTEGER:
+	case FIELD_TYPE_INT8:
+	case FIELD_TYPE_INT16:
+	case FIELD_TYPE_INT32:
+	case FIELD_TYPE_INT64:
 		return mp_compare_integer_with_type(field_a, a_type,
 						    field_b, b_type);
 	case FIELD_TYPE_NUMBER:
 		return mp_compare_number_with_type(field_a, a_type,
 						   field_b, b_type);
+	case FIELD_TYPE_FLOAT32:
+		return mp_compare_float32(field_a, field_b);
+	case FIELD_TYPE_FLOAT64:
+		return mp_compare_float64(field_a, field_b);
 	case FIELD_TYPE_DOUBLE:
 		return mp_compare_as_double(field_a, field_b);
 	case FIELD_TYPE_BOOLEAN:
@@ -1811,6 +1851,20 @@ field_hint_integer(const char *field)
 }
 
 static inline hint_t
+field_hint_float32(const char *field)
+{
+	assert(mp_typeof(*field) == MP_FLOAT);
+	return hint_double(mp_decode_float(&field));
+}
+
+static inline hint_t
+field_hint_float64(const char *field)
+{
+	assert(mp_typeof(*field) == MP_DOUBLE);
+	return hint_double(mp_decode_double(&field));
+}
+
+static inline hint_t
 field_hint_double(const char *field)
 {
 	return hint_double(mp_read_as_double(field));
@@ -1963,11 +2017,23 @@ field_hint(const char *field, struct coll *coll)
 	case FIELD_TYPE_BOOLEAN:
 		return field_hint_boolean(field);
 	case FIELD_TYPE_UNSIGNED:
+	case FIELD_TYPE_UINT8:
+	case FIELD_TYPE_UINT16:
+	case FIELD_TYPE_UINT32:
+	case FIELD_TYPE_UINT64:
 		return field_hint_unsigned(field);
 	case FIELD_TYPE_INTEGER:
+	case FIELD_TYPE_INT8:
+	case FIELD_TYPE_INT16:
+	case FIELD_TYPE_INT32:
+	case FIELD_TYPE_INT64:
 		return field_hint_integer(field);
 	case FIELD_TYPE_NUMBER:
 		return field_hint_number(field);
+	case FIELD_TYPE_FLOAT32:
+		return field_hint_float32(field);
+	case FIELD_TYPE_FLOAT64:
+		return field_hint_float64(field);
 	case FIELD_TYPE_DOUBLE:
 		return field_hint_double(field);
 	case FIELD_TYPE_STRING:
@@ -2109,6 +2175,36 @@ key_def_set_hint_func(struct key_def *def)
 		break;
 	case FIELD_TYPE_DATETIME:
 		key_def_set_hint_func<FIELD_TYPE_DATETIME>(def);
+		break;
+	case FIELD_TYPE_INT8:
+		key_def_set_hint_func<FIELD_TYPE_INT8>(def);
+		break;
+	case FIELD_TYPE_UINT8:
+		key_def_set_hint_func<FIELD_TYPE_UINT8>(def);
+		break;
+	case FIELD_TYPE_INT16:
+		key_def_set_hint_func<FIELD_TYPE_INT16>(def);
+		break;
+	case FIELD_TYPE_UINT16:
+		key_def_set_hint_func<FIELD_TYPE_UINT16>(def);
+		break;
+	case FIELD_TYPE_INT32:
+		key_def_set_hint_func<FIELD_TYPE_INT32>(def);
+		break;
+	case FIELD_TYPE_UINT32:
+		key_def_set_hint_func<FIELD_TYPE_UINT32>(def);
+		break;
+	case FIELD_TYPE_INT64:
+		key_def_set_hint_func<FIELD_TYPE_INT64>(def);
+		break;
+	case FIELD_TYPE_UINT64:
+		key_def_set_hint_func<FIELD_TYPE_UINT64>(def);
+		break;
+	case FIELD_TYPE_FLOAT32:
+		key_def_set_hint_func<FIELD_TYPE_FLOAT32>(def);
+		break;
+	case FIELD_TYPE_FLOAT64:
+		key_def_set_hint_func<FIELD_TYPE_FLOAT64>(def);
 		break;
 	default:
 		/* Invalid key definition. */

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -685,18 +685,10 @@ vinyl_space_check_index_def(struct space *space, struct index_def *index_def)
 		diag_set(ClientError, ER_NULLABLE_PRIMARY, space_name(space));
 		return -1;
 	}
-	/* Check that there are no ANY, ARRAY, MAP parts */
-	for (uint32_t i = 0; i < key_def->part_count; i++) {
-		struct key_part *part = &key_def->parts[i];
-		if (part->type <= FIELD_TYPE_ANY ||
-		    part->type >= FIELD_TYPE_ARRAY) {
-			diag_set(ClientError, ER_MODIFY_INDEX,
-				 index_def->name, space_name(space),
-				 tt_sprintf("field type '%s' is not supported",
-					    field_type_strs[part->type]));
-			return -1;
-		}
-	}
+
+	if (index_def_check_field_types(index_def, space_name(space)) != 0)
+		return -1;
+
 	if (key_def->for_func_index) {
 		diag_set(ClientError, ER_UNSUPPORTED, "Vinyl",
 			 "functional index");


### PR DESCRIPTION
The types added by commit 2e0f9a3c265e ("box: introduce fixed-size numeric field types") can't be indexed. Fix it.

Closes #9611