### PR TITLE
ci: fix job name in freebsd failure report

### DIFF
--- a/.github/actions/report-job-status/action.yml
+++ b/.github/actions/report-job-status/action.yml
@@ -9,6 +9,10 @@ inputs:
     required: false
     default: tt_cicd_reports
     description: VK Teams chat ID
+  job-name:
+    required: false
+    default: ''
+    description: Workflow job name
 
 runs:
   using: composite
@@ -34,4 +38,9 @@ runs:
       with:
         bot-token: ${{ inputs.bot-token }}
         chat-id: ${{ env.CHAT_ID }}
-        job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+        # Unfortunately, the ChristopherHX/github-act-runner agent evaluates
+        # `join(matrix.*, ', ')` to `Object` instead of `a, b, c`. So let's
+        # have the facility to specify the job name manually to avoid the issue.
+        job-name: ${{
+          inputs.job-name ||
+          format('{0} ({1})', github.job, join(matrix.*, ', ')) }}

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -46,6 +46,12 @@ jobs:
         uses: ./.github/actions/report-job-status
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
+          # Specify the job name manually to avoid the issue with evaluating
+          # `join(matrix.*, ', ')` in ./.github/actions/report-job-status.
+          job-name: ${{ format(
+            'freebsd ({0}, {1})',
+            matrix.freebsd-version,
+            matrix.tarantool-branch) }}
 
       - name: Calculate short name for Tarantool branch
         if: failure()


### PR DESCRIPTION
The ChristopherHX/github-act-runner agent evaluates expression `join(matrix.*, ', ')` to `Object` instead of `a, b, c`. So let's have the facility to specify the job name manually to avoid the issue.