### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9595-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9595-luajit-fixes.md
@@ -1,0 +1,7 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-9595). The following
+issues were fixed as part of this activity:
+
+* Fixed a crash during the restoration of the sunk `TNEW` with a huge array
+  part.


### PR DESCRIPTION
* Optimize table.new() with constant args to (sinkable) IR_TNEW.
* Only emit proper parent references in snapshot replay.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump