### PR TITLE
perf: add column scan test

### DIFF
--- a/perf/lua/CMakeLists.txt
+++ b/perf/lua/CMakeLists.txt
@@ -28,7 +28,14 @@ endfunction()
 
 create_perf_lua_test(NAME 1mops_write)
 create_perf_lua_test(NAME box_select)
+create_perf_lua_test(NAME column_scan)
 create_perf_lua_test(NAME uri_escape_unescape)
+
+include_directories(${MSGPUCK_INCLUDE_DIRS})
+
+build_module(column_scan_module column_scan_module.c)
+target_link_libraries(column_scan_module msgpuck)
+add_dependencies(column_scan_perftest column_scan_module)
 
 add_custom_target(test-lua-perf
                   DEPENDS "${RUN_PERF_LUA_TESTS_LIST}"

--- a/perf/lua/column_scan.lua
+++ b/perf/lua/column_scan.lua
@@ -1,0 +1,156 @@
+--
+-- The test measures run time of space full scan.
+--
+-- Output format:
+-- <test-case> <run-time-seconds>
+--
+-- Options:
+-- --engine <string>         space engine to use for the test
+-- --column_count <number>   number of columns in the test space
+-- --row_count <number>      number of rows in the test space
+-- --use_read_view           use a read view
+-- --use_scanner_api         use the column scanner API
+--
+-- NOTE: The test requires a C module. Set the BUILDDIR environment variable to
+-- the tarantool build directory if using out-of-source build.
+--
+
+local clock = require('clock')
+local fiber = require('fiber')
+local fio = require('fio')
+local ffi = require('ffi')
+local log = require('log')
+local tarantool = require('tarantool')
+
+local params = require('internal.argparse').parse(arg, {
+    {'engine', 'string'},
+    {'column_count', 'number'},
+    {'row_count', 'number'},
+    {'use_read_view', 'boolean'},
+    {'use_scanner_api', 'boolean'},
+})
+
+local DEFAULT_ENGINE = 'memtx'
+local DEFAULT_COLUMN_COUNT = 100
+local DEFAULT_ROW_COUNT = 1000 * 1000
+
+params.engine = params.engine or DEFAULT_ENGINE
+params.column_count = params.column_count or DEFAULT_COLUMN_COUNT
+params.row_count = params.row_count or DEFAULT_ROW_COUNT
+params.use_read_view = params.use_read_view or false
+params.use_scanner_api = params.use_scanner_api or false
+
+local BUILDDIR = fio.abspath(fio.pathjoin(os.getenv('BUILDDIR') or '.'))
+local MODULEPATH = fio.pathjoin(BUILDDIR, 'perf', 'lua',
+                                '?.' .. tarantool.build.mod_format)
+
+package.cpath = MODULEPATH .. ';' .. package.cpath
+
+local test_module = require('column_scan_module')
+local test_funcs = {}
+
+for _, func_name in ipairs({'sum'}) do
+    local full_func_name
+    if params.use_scanner_api then
+        full_func_name = func_name .. '_scanner'
+    else
+        full_func_name = func_name .. '_iterator'
+    end
+    if params.use_read_view then
+        full_func_name = full_func_name .. '_rv'
+    end
+    local f = test_module[full_func_name]
+    if f == nil then
+        error('The specified test mode is not supported by this build')
+    end
+    test_funcs[func_name] = f
+end
+
+local WORK_DIR = string.format(
+    'column_scan,engine=%s,column_count=%d,row_count=%d',
+    params.engine, params.column_count, params.row_count)
+
+fio.mkdir(WORK_DIR)
+
+box.cfg({
+    work_dir = WORK_DIR,
+    log = 'tarantool.log',
+    memtx_memory = 4 * 1024 * 1024 * 1024,
+    checkpoint_count = 1,
+})
+
+box.once('init', function()
+    log.info('Creating the test space...')
+    local format = {}
+    for i = 1, params.column_count do
+        table.insert(format, {'field_' .. i, 'unsigned'})
+    end
+    local s = box.schema.space.create('test', {
+        engine = params.engine,
+        field_count = #format,
+        format = format,
+    })
+    s:create_index('pk')
+    log.info('Generating the test data set...')
+    local tuple = {}
+    local pct_complete = 0
+    box.begin()
+    for i = 1, params.row_count do
+        for j = 1, params.column_count do
+            if j % 2 == 1 then
+                tuple[j] = i
+            else
+                tuple[j] = params.row_count - i + 1
+            end
+        end
+        s:insert(tuple)
+        if i % 1000 then
+            box.commit()
+            local pct = math.floor(100 * i / params.row_count)
+            if pct ~= pct_complete then
+                log.info('%d%% complete', pct)
+                pct_complete = pct
+            end
+            box.begin()
+        end
+    end
+    box.commit()
+    log.info('Writing a snapshot...')
+    box.snapshot()
+end)
+
+local function check_result(result, expected)
+    log.info('expected %s, got %s', expected, result)
+    assert(result == expected)
+end
+
+local TESTS = {
+    {
+        name = 'sum,first',
+        func = function()
+            local result = test_funcs.sum(box.space.test.id, 0, 0)
+            local row_count = ffi.cast('uint64_t', params.row_count)
+            check_result(result, row_count * (row_count + 1) / 2)
+        end,
+    },
+    {
+        name = 'sum,last',
+        func = function()
+            local result = test_funcs.sum(box.space.test.id, 0,
+                                           params.column_count - 1)
+            local row_count = ffi.cast('uint64_t', params.row_count)
+            check_result(result, row_count * (row_count + 1) / 2)
+        end,
+    },
+}
+
+test_module.init()
+fiber.set_max_slice(9000)
+
+for _, test in ipairs(TESTS) do
+    log.info('Running test %s...', test.name)
+    test.func() -- warmup
+    print(string.format('%s %.3f', test.name, clock.bench(test.func)[1]))
+end
+
+os.exit(0)

--- a/perf/lua/column_scan_module.c
+++ b/perf/lua/column_scan_module.c
@@ -1,0 +1,224 @@
+#include <lua.h>
+#include <lauxlib.h>
+#include <module.h>
+#include <msgpuck.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "trivia/config.h"
+#include "trivia/util.h"
+
+#if defined(ENABLE_MEMCS_ENGINE)
+# define ENABLE_SCANNER 1
+#endif /* ENABLE_MEMCS_ENGINE */
+
+#if defined(ENABLE_READ_VIEW)
+static box_raw_read_view_t *rv;
+#endif /* ENABLE_READ_VIEW */
+
+static int
+sum_iterator_lua_func(struct lua_State *L)
+{
+	uint32_t space_id = luaL_checkinteger(L, 1);
+	uint32_t index_id = luaL_checkinteger(L, 2);
+	uint32_t field_no = luaL_checkinteger(L, 3);
+	char key[8];
+	char *key_end = mp_encode_array(key, 0);
+	box_iterator_t *iter = box_index_iterator(space_id, index_id, ITER_ALL,
+						  key, key_end);
+	if (iter == NULL)
+		return luaT_error(L);
+	int rc = 0;
+	uint64_t sum = 0;
+	box_tuple_t *tuple;
+	while (true) {
+		rc = box_iterator_next(iter, &tuple);
+		if (rc != 0 || tuple == NULL)
+			break;
+		const char *data = box_tuple_field(tuple, field_no);
+		if (unlikely(data == NULL || mp_typeof(*data) != MP_UINT)) {
+			rc = box_error_raise(ER_PROC_LUA, "unexpected result");
+			break;
+		}
+		sum += mp_decode_uint(&data);
+	}
+	box_iterator_free(iter);
+	if (rc != 0)
+		return luaT_error(L);
+	luaL_pushuint64(L, sum);
+	return 1;
+}
+
+#if defined(ENABLE_READ_VIEW)
+static int
+sum_iterator_rv_lua_func(struct lua_State *L)
+{
+	if (rv == NULL)
+		return luaL_error(L, "run init() first");
+	uint32_t space_id = luaL_checkinteger(L, 1);
+	uint32_t index_id = luaL_checkinteger(L, 2);
+	uint32_t field_no = luaL_checkinteger(L, 3);
+	box_raw_read_view_space_t *space =
+		box_raw_read_view_space_by_id(rv, space_id);
+	if (space == NULL)
+		return luaT_error(L);
+	box_raw_read_view_index_t *index =
+		box_raw_read_view_index_by_id(space, 0);
+	if (index == NULL)
+		return luaT_error(L);
+	char key[8];
+	char *key_end = mp_encode_array(key, 0);
+	box_raw_read_view_iterator_t iter;
+	if (box_raw_read_view_iterator_create(&iter, index, ITER_ALL,
+					      key, key_end) != 0)
+		return luaT_error(L);
+	int rc = 0;
+	uint64_t sum = 0;
+	while (true) {
+		uint32_t size;
+		const char *data;
+		rc = box_raw_read_view_iterator_next(&iter, &data, &size);
+		if (rc != 0 || data == NULL)
+			break;
+		if (unlikely(mp_typeof(*data) != MP_ARRAY ||
+			     mp_decode_array(&data) <= field_no)) {
+			rc = box_error_raise(ER_PROC_LUA, "unexpected result");
+			break;
+		}
+		for (int i = 0; i < (int)field_no; i++)
+			mp_next(&data);
+		sum += mp_decode_uint(&data);
+	}
+	box_raw_read_view_iterator_destroy(&iter);
+	if (rc != 0)
+		return luaT_error(L);
+	luaL_pushuint64(L, sum);
+	return 1;
+}
+#endif /* defined(ENABLE_READ_VIEW) */
+
+#if defined(ENABLE_SCANNER)
+static int
+sum_scanner_lua_func(struct lua_State *L)
+{
+	uint32_t space_id = luaL_checkinteger(L, 1);
+	uint32_t index_id = luaL_checkinteger(L, 2);
+	uint32_t field_no = luaL_checkinteger(L, 3);
+	char key[8];
+	char *key_end = mp_encode_array(key, 0);
+	uint32_t fields[] = {field_no};
+	uint32_t field_count = lengthof(fields);
+	box_scanner_t *scanner = box_index_scanner(space_id, index_id,
+						   field_count, fields,
+						   key, key_end, NULL);
+	if (scanner == NULL)
+		return luaT_error(L);
+	int rc = 0;
+	uint64_t sum = 0;
+	size_t region_svp = box_region_used();
+	while (true) {
+		box_scanner_result_t result;
+		rc = box_scanner_next(scanner, 4096, &result);
+		if (rc != 0 || result.row_count == 0)
+			break;
+		if (unlikely(result.columns[0].type != SCANNER_COLUMN_UINT64)) {
+			rc = box_error_raise(ER_PROC_LUA, "unexpected result");
+			break;
+		}
+		uint64_t *values = result.columns[0].data;
+		for (int i = 0; i < (int)result.row_count; i++)
+			sum += values[i];
+		box_region_truncate(region_svp);
+	}
+	box_region_truncate(region_svp);
+	box_scanner_free(scanner);
+	if (rc != 0)
+		return luaT_error(L);
+	luaL_pushuint64(L, sum);
+	return 1;
+}
+#endif /* defined(ENABLE_SCANNER) */
+
+#if defined(ENABLE_SCANNER) && defined(ENABLE_READ_VIEW)
+static int
+sum_scanner_rv_lua_func(struct lua_State *L)
+{
+	if (rv == NULL)
+		return luaL_error(L, "run init() first");
+	uint32_t space_id = luaL_checkinteger(L, 1);
+	uint32_t index_id = luaL_checkinteger(L, 2);
+	uint32_t field_no = luaL_checkinteger(L, 3);
+	box_raw_read_view_space_t *space =
+		box_raw_read_view_space_by_id(rv, space_id);
+	if (space == NULL)
+		return luaT_error(L);
+	box_raw_read_view_index_t *index =
+		box_raw_read_view_index_by_id(space, 0);
+	if (index == NULL)
+		return luaT_error(L);
+	char key[8];
+	char *key_end = mp_encode_array(key, 0);
+	uint32_t fields[] = {field_no};
+	uint32_t field_count = lengthof(fields);
+	box_raw_read_view_scanner_t *scanner = box_raw_read_view_scanner_new(
+		index, field_count, fields, key, key_end, NULL);
+	if (scanner == NULL)
+		return luaT_error(L);
+	int rc = 0;
+	uint64_t sum = 0;
+	size_t region_svp = box_region_used();
+	while (true) {
+		box_scanner_result_t result;
+		rc = box_raw_read_view_scanner_next(scanner, 4096, &result);
+		if (rc != 0 || result.row_count == 0)
+			break;
+		if (unlikely(result.columns[0].type != SCANNER_COLUMN_UINT64)) {
+			rc = box_error_raise(ER_PROC_LUA, "unexpected result");
+			break;
+		}
+		uint64_t *values = result.columns[0].data;
+		for (int i = 0; i < (int)result.row_count; i++)
+			sum += values[i];
+		box_region_truncate(region_svp);
+	}
+	box_region_truncate(region_svp);
+	box_raw_read_view_scanner_delete(scanner);
+	if (rc != 0)
+		return luaT_error(L);
+	luaL_pushuint64(L, sum);
+	return 1;
+}
+#endif /* defined(ENABLE_SCANNER) && defined(ENABLE_READ_VIEW) */
+
+static int
+init_lua_func(struct lua_State *L)
+{
+#if defined(ENABLE_READ_VIEW)
+	rv = box_raw_read_view_new("test");
+	if (rv == NULL)
+		return luaT_error(L);
+#endif /* defined(ENABLE_READ_VIEW) */
+	(void)L;
+	return 0;
+}
+
+LUA_API int
+luaopen_column_scan_module(struct lua_State *L)
+{
+	static const struct luaL_Reg lib[] = {
+		{"init", init_lua_func},
+		{"sum_iterator", sum_iterator_lua_func},
+#if defined(ENABLE_READ_VIEW)
+		{"sum_iterator_rv", sum_iterator_rv_lua_func},
+#endif /* defined(ENABLE_READ_VIEW) */
+#if defined(ENABLE_SCANNER)
+		{"sum_scanner", sum_scanner_lua_func},
+#endif /* defined(ENABLE_SCANNER) */
+#if defined(ENABLE_SCANNER) && defined(ENABLE_READ_VIEW)
+		{"sum_scanner_rv", sum_scanner_rv_lua_func},
+#endif /* defined(ENABLE_SCANNER) && defined(ENABLE_READ_VIEW) */
+		{NULL, NULL},
+	};
+	luaL_register(L, "column_scan_module", lib);
+	return 1;
+}


### PR DESCRIPTION
The test creates a space with 1 million rows and 100 columns storing unsigned integer values (both row and column count are configurable) and sums values over the first and the last columns.

By default the test uses the iterator C API but one may switch to the column scanner C API and/or raw read view C API (both features are exclusive to the Enterprise Edition).

It's also possible to specify the engine to use (default is memtx).

Closes tarantool/tarantool-ee#659