### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9595-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9595-luajit-fixes.md
@@ -1,0 +1,7 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-9595). The following
+issues were fixed as part of this activity:
+
+* Fixed stack-buffer-overflow for `string.format()` with `%g` modifier and
+  length modifier.


### PR DESCRIPTION
* Fix zero stripping in %g number formatting.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump