### PR TITLE
box: introduce `tuple_field_validate()`

### DIFF
--- a/src/box/tuple_format.h
+++ b/src/box/tuple_format.h
@@ -719,6 +719,17 @@ tuple_format_apply_defaults(struct tuple_format *format, const char **data,
 void
 tuple_format_to_mpstream(struct tuple_format *format, struct mpstream *stream);
 
+/**
+ * Checks that `mp_data' is compatible with the `field' type defined in format,
+ * checks that integer value is within an allowed range, also checks field
+ * constraints, etc.
+ *
+ * Returns 0 on success. On error, sets diag and returns -1.
+ */
+int
+tuple_field_validate(struct tuple_format *format, struct tuple_field *field,
+		     const char *mp_data, const char *mp_data_end);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/xrow_update.c
+++ b/src/box/xrow_update.c
@@ -101,52 +101,7 @@
  * deleted one.
  */
 
-/** Update internal state */
-struct xrow_update
-{
-	/** Operations array. */
-	struct xrow_update_op *ops;
-	/** Length of ops. */
-	uint32_t op_count;
-	/**
-	 * Index base for MessagePack update operations. If update
-	 * is from Lua, then the base is 1. Otherwise 0. That
-	 * field exists because Lua uses 1-based array indexing,
-	 * and Lua-to-MessagePack encoder keeps this indexing when
-	 * encodes operations array. Index base allows not to
-	 * re-encode each Lua update with 0-based indexes.
-	 */
-	int index_base;
-	/**
-	 * A bitmask of all columns modified by this update. Only
-	 * the first level of a tuple is accounted here. I.e. if
-	 * a field [1][2][3] was updated, then only [1] is
-	 * reflected.
-	 */
-	uint64_t column_mask;
-	/** First level of update tree. It is always array. */
-	struct xrow_update_field root;
-};
-
-/**
- * Read and check update operations and fill column mask.
- *
- * @param[out] update Update meta.
- * @param expr MessagePack array of operations.
- * @param expr_end End of the @a expr.
- * @param dict Dictionary to lookup field number by a name.
- * @param field_count_hint Field count in the updated tuple. If
- *        there is no tuple at hand (for example, when we are
- *        reading UPSERT operations), then 0 for field count will
- *        do as a hint: the only effect of a wrong hint is
- *        a possibly incorrect column_mask.
- *        A correct field count results in an accurate
- *        column mask calculation.
- *
- * @retval  0 Success.
- * @retval -1 Error.
- */
-static int
+int
 xrow_update_read_ops(struct xrow_update *update, const char *expr,
 		     const char *expr_end, struct tuple_dictionary *dict,
 		     int32_t field_count_hint)
@@ -334,7 +289,7 @@ xrow_upsert_do_ops(struct xrow_update *update, const char *header,
 	return 0;
 }
 
-static void
+void
 xrow_update_init(struct xrow_update *update, int index_base)
 {
 	memset(update, 0, sizeof(*update));

--- a/src/lib/salad/rope.h
+++ b/src/lib/salad/rope.h
@@ -50,6 +50,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <assert.h>
+#include "trivia/util.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -704,7 +705,7 @@ rope_node_print(const struct rope_node *node, rope_visit_f print, void *cb_arg,
 	const char *padding[] = { "│   ", "   " };
 
 	rope_size_t child_prefix_len = strlen(prefix) + strlen(padding[0]) + 1;
-	char *child_prefix = malloc(child_prefix_len);
+	char *child_prefix = (char *)xmalloc(child_prefix_len);
 
 	if (node && (node->link[0] || node->link[1])) {
 		snprintf(child_prefix, child_prefix_len - 1,


### PR DESCRIPTION
`tuple_field_validate()`, `xrow_update_init()` and `xrow_update_read_ops()` will be used by the `memcs` engine, which is part of Tarantool Enterprise Edition.

Needed for tarantool/tarantool-ee#628