### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-8140-crash-in-allocator.md
+++ b/changelogs/unreleased/gh-8140-crash-in-allocator.md
@@ -1,0 +1,3 @@
+## bugfix/luajit
+
+* Fixed a crash in the allocator during sysprof profiling (gh-8140).

--- a/changelogs/unreleased/gh-9145-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9145-luajit-fixes.md
@@ -1,0 +1,15 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-9145). The following issues
+were fixed as part of this activity:
+
+* Limited exponent range in number parsing by `2^20`.
+* Fixed build with internal unwinding.
+* Fixed double-emitting of `IR_NEWREF` when restoring sunk values for side
+  trace (gh-7937).
+* Fixed the `IR_HREFK` optimization for huge tables.
+* Fixed recording of the `__concat` metamethod.
+* Fixed the embedded bytecode loader.
+* Improved error reporting on stack overflow.
+* Fixed assertion on the Lua stack overflow for a stitched trace.
+* Fixed snapshoting of functions for non-base frames.

--- a/changelogs/unreleased/gh-9595-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9595-luajit-fixes.md
@@ -1,0 +1,14 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-9595). The following issues
+were fixed as part of this activity:
+
+* No side traces are recorded now after disabling the JIT via `jit.off()`.
+* Fixed handling of instable boolean types in TDUP load forwarding.
+* Fixed a crash during the restoration of the sunk `TNEW` with a huge array
+  part.
+* Fixed stack-buffer-overflow for `string.format()` with `%g` modifier and
+  length modifier.
+* Fixed recording of `setmetatable()` with `nil` as the second argument.
+* Fixed recording of `select()` in case with negative first argument.
+* Fixed use-def analysis for child upvalues.


### PR DESCRIPTION
* test: fix initialization in lj-549-lua-load.test.c
* codehealth: add `nd` to the codespell ignore list
* LJ_GC64: Always snapshot functions for non-base frames.
* Avoid assertion in case of stack overflow from stitched trace.
* Fix recording of __concat metamethod.
* Avoid out-of-range number of results when compiling select(k, ...).
* Consider slots used by upvalues in use-def analysis.
* Only emit proper parent references in snapshot replay.
* Optimize table.new() with constant args to (sinkable) IR_TNEW.
* Followup fix for embedded bytecode loader.
* Fix embedded bytecode loader.
* LJ_GC64: Fix HREFK optimization.
* Fix unsinking of IR_FSTORE for NULL metatable.
* Fix zero stripping in %g number formatting.
* Follow-up fix for stack overflow handling cleanup.
* Cleanup stack overflow handling.
* Improve error reporting on stack overflow.
* sysprof: disable runtime host symtab updates
* codehealth: fix the typo
* Simplify handling of instable types in TNEW/TDUP load forwarding.
* Respect jit.off() on pending trace exit.
* Limit exponent range in number parsing.
* ARM64: Allow building with unwinding disabled.
* Emit sunk IR_NEWREF only once per key on snapshot replay.

Closes #7937
Closes #8140
Part of #9145
Part of #9595