### PR TITLE
build: fix static build error when compiling with Clang

### DIFF
--- a/cmake/CheckDependencies.cmake
+++ b/cmake/CheckDependencies.cmake
@@ -28,6 +28,7 @@ elseif(UNIX)
         libgcc_s
         libpthread
         libsvace
+        libstdc++
     )
 else()
     message(FATAL_ERROR "Unknown platform")

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -155,10 +155,10 @@ endif()
 option(ENABLE_BUNDLED_LIBUNWIND "Bundled libunwind will be built"
        ${ENABLE_BUNDLED_LIBUNWIND_DEFAULT})
 
-# On macOS there is no '-static-libstdc++' flag and it's use will
-# raise following error:
-# error: argument unused during compilation: '-static-libstdc++'
-if(BUILD_STATIC AND NOT TARGET_OS_DARWIN)
+# In Clang there is no '-static-libstdc++' flag and its use will raise
+# the following error:
+#     clang: error: argument unused during compilation: '-static-libstdc++'
+if(BUILD_STATIC AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     # Static linking for c++ routines
     add_compile_flags("C;CXX" "-static-libstdc++")
 endif()


### PR DESCRIPTION
This patch fixes the following error when building tarantool statically with Clang compiler on a Linux system:

    clang: error: argument unused during compilation: '-static-libstdc++'

Fixes #9646