### PR TITLE
Client fibers shutdown fixes

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -5931,6 +5931,7 @@ box_storage_shutdown()
 	if (!is_storage_initialized)
 		return;
 	iproto_shutdown();
+	box_watcher_shutdown();
 	/*
 	 * Finish client fibers after iproto_shutdown otherwise new fibers
 	 * can be started through new iproto requests. Also we should

--- a/src/box/watcher.h
+++ b/src/box/watcher.h
@@ -8,6 +8,7 @@
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "small/rlist.h"
 
@@ -153,6 +154,8 @@ struct watchable {
 	struct rlist pending_watchers;
 	/** Background fiber that runs watcher callbacks. */
 	struct fiber *worker;
+	/** Set if watchable shutdown is started. */
+	bool is_shutdown;
 };
 
 /**
@@ -280,6 +283,13 @@ box_watch_once(const char *key, size_t key_len, const char **end);
 
 void
 box_watcher_init(void);
+
+/**
+ * Shutdown watcher. After shutdown API still can be used but notifications
+ * are stopped.
+ */
+void
+box_watcher_shutdown(void);
 
 void
 box_watcher_free(void);

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -856,6 +856,9 @@ struct cord {
 	int client_fiber_count;
 	/** Fiber calling fiber_shutdown. NULL if there is no such. */
 	struct fiber *shutdown_fiber;
+	/** Whether shutdown is started. */
+	bool is_shutdown;
+
 };
 
 extern __thread struct cord *cord_ptr;


### PR DESCRIPTION
Fix an issue with client fibers shutdown and disable client code execution thru watcher callbacks during shutdown.

Part of #8423