### PR TITLE
config: move role start and stop to _post_apply()

### DIFF
--- a/changelogs/unreleased/gh-9649-config-get-in-roles.md
+++ b/changelogs/unreleased/gh-9649-config-get-in-roles.md
@@ -1,0 +1,4 @@
+## bugfix/config
+
+* Calling `require('config'):get()` in role code now returns the configuration
+  that is currently applied (gh-9649).

--- a/src/box/lua/config/applier/roles.lua
+++ b/src/box/lua/config/applier/roles.lua
@@ -3,6 +3,10 @@ local log = require('internal.config.utils.log')
 local last_loaded = {}
 local last_roles_ordered = {}
 
+local function apply(_config)
+    log.verbose('roles.apply: do nothing')
+end
+
 local function stop_roles(roles_to_skip)
     local roles_to_stop = {}
     for id = #last_roles_ordered, 1, -1 do
@@ -44,7 +48,7 @@ local function stop_roles(roles_to_skip)
         end
     end
     for _, role_name in ipairs(roles_to_stop) do
-        log.verbose('roles.apply: stop role ' .. role_name)
+        log.verbose('roles.post_apply: stop role ' .. role_name)
         local ok, err = pcall(last_loaded[role_name].stop)
         if not ok then
             error(('Error stopping role %s: %s'):format(role_name, err), 0)
@@ -106,7 +110,7 @@ local function resort_roles(original_order, roles)
     return ordered
 end
 
-local function apply(config)
+local function post_apply(config)
     local configdata = config._configdata
     local role_names = configdata:get('roles', {use_default = true})
     if role_names == nil or next(role_names) == nil then
@@ -132,7 +136,7 @@ local function apply(config)
     for _, role_name in ipairs(roles_ordered) do
         local role = last_loaded[role_name]
         if not role then
-            log.verbose('roles.apply: load role ' .. role_name)
+            log.verbose('roles.post_apply: load role ' .. role_name)
             role = require(role_name)
             local funcs = {'validate', 'apply', 'stop'}
             for _, func_name in pairs(funcs) do
@@ -164,7 +168,7 @@ local function apply(config)
 
     -- Apply configs for all roles.
     for _, role_name in ipairs(roles_ordered) do
-        log.verbose('roles.apply: apply config for role ' .. role_name)
+        log.verbose('roles.post_apply: apply config for role ' .. role_name)
         local ok, err = pcall(loaded[role_name].apply, roles_cfg[role_name])
         if not ok then
             error(('Error applying role %s: %s'):format(role_name, err), 0)
@@ -178,4 +182,5 @@ end
 return {
     name = 'roles',
     apply = apply,
+    post_apply = post_apply,
 }


### PR DESCRIPTION
Roles are now started and stopped at the "post_apply" stage rather than at the "apply" stage. This allows require('config'):get() to correctly return the configuration that is being applied.

Closes #9649
