### PR TITLE
[backport 3.0] config: call extras.post_apply() if reload failed

### DIFF
--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -355,10 +355,6 @@ function methods._post_apply(self)
             applier.post_apply(self)
         end
     end
-
-    if extras ~= nil then
-        extras.post_apply(self)
-    end
 end
 
 -- Set proper status depending on received alerts.
@@ -415,6 +411,9 @@ function methods._startup(self, instance_name, config_file)
 
     self:_post_apply()
     self:_set_status_based_on_alerts()
+    if extras ~= nil then
+        extras.post_apply(self)
+    end
 end
 
 function methods._print_env_list(self)
@@ -460,6 +459,9 @@ function methods._reload_noexc(self, opts)
     end
 
     self:_set_status_based_on_alerts()
+    if extras ~= nil then
+        extras.post_apply(self)
+    end
 
     return ok, err
 end


### PR DESCRIPTION
*(This is backport of PR #9623 to the `release/3.0` branch, future 3.0.2 release.)*

----

This patch changes when extras.post_apply() is executed. Previously, it would only run if a _post_apply() was successful and all previous reload steps completed properly. It will now be executed, even if some reload steps failed.

Note that if an error appears during startup, Tarantool will stop and extras.post_apply() will not be executed.

Also note that if the startup or restart is successful, there will be no change in behavior due to this patch.

Needed for https://github.com/tarantool/tarantool-ee/issues/643