### PR TITLE
build: fix package.cpath for debian based distros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,19 +354,15 @@ endforeach()
 set(_libdirs)
 list(APPEND _libdirs "/usr/local/${MULTILIB}") # LuaRocks
 list(APPEND _libdirs "${CMAKE_INSTALL_FULL_LIBDIR}") # Install prefix
-if(NOT CMAKE_CROSSCOMPILING AND EXISTS "/etc/debian_version")
-    # gh-1085: LuaRocks on Debian uses lib instead of lib/x86_64-linux-gnu/
-    list(APPEND _libdirs "/usr/local/lib") # LuaRocks on Debian
-endif()
-if(NOT CMAKE_CROSSCOMPILING AND EXISTS "/etc/gentoo-release")
-    # LuaRocks on Gentoo
-    list(APPEND _libdirs "/usr/${MULTILIB}/lua/luarocks/lib")
-endif()
-if(NOT CMAKE_CROSSCOMPILING AND EXISTS "/etc/alpine-release")
-    # LuaRocks on Alpine
-    list(APPEND _libdirs "/usr/local/lib")
-endif()
-list(APPEND _libdirs "/usr/${MULTILIB}") # System packages
+# gh-1085: LuaRocks on Debian and Alpine uses lib instead
+# of lib/${ARCH}-linux-gnu/
+list(APPEND _libdirs "/usr/local/lib")
+# LuaRocks on Gentoo
+list(APPEND _libdirs "/usr/${MULTILIB}/lua/luarocks/lib")
+# System packages
+list(APPEND _libdirs "/usr/${MULTILIB}")
+# Add CPATH on Debian based systems depending on architecture
+list(APPEND _libdirs "/usr/lib/${CMAKE_HOST_SYSTEM_PROCESSOR}-linux-gnu")
 list(REMOVE_DUPLICATES _libdirs)
 set(MODULE_LIBPATH)
 foreach(dir

--- a/changelogs/unreleased/gh-9580-fix-cpath-for-external-libs.md
+++ b/changelogs/unreleased/gh-9580-fix-cpath-for-external-libs.md
@@ -1,0 +1,3 @@
+## bugfix/build
+
+* Fixed `package.cpath` for Debian based distros (gh-9580).


### PR DESCRIPTION
In Linux systems based on Debian, libraries are installed in paths depending on the architecture. For example, /usr/lib/x86_64-linux-gnu/, /usr/lib/aarch64-linux-gnu/. Some packages may be installed in these paths, but Tarantool does not look for libraries installed in these paths. This patch solves the problem.

Also remove redundant OS depended `if` branches.

Fix #9580