### PR TITLE
[2.10] Missing backports needed for OSX testing

### DIFF
--- a/changelogs/unreleased/gh-8074-fix-backtraces-on-m1-macs.md
+++ b/changelogs/unreleased/gh-8074-fix-backtraces-on-m1-macs.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed the collection of fiber backtraces on the M1/M2 macOS platform
+  (gh-8074).

--- a/src/box/lua/console.lua
+++ b/src/box/lua/console.lua
@@ -822,11 +822,7 @@ local function connect(uri, opts)
     -- We don't know if the remote end is binary or Lua console so we first try
     -- to connect to it as binary using net.box and fall back on Lua console if
     -- it fails.
-    local remote = net_box.connect(u.host, u.service, {
-            connect_timeout = opts.timeout,
-            user = u.login,
-            password = u.password,
-    })
+    local remote = net_box.connect(uri, {connect_timeout = opts.timeout})
     if remote.state == 'error' then
         local err = remote.error
         remote = nil

--- a/src/lib/core/backtrace.c
+++ b/src/lib/core/backtrace.c
@@ -83,6 +83,13 @@ collect_current_stack(struct backtrace *bt, void *stack)
 				  "status: %d", rc);
 			return stack;
 		}
+#ifdef __aarch64__
+		/*
+		 * Apple's libunwind for AArch64 returns the IP with the Pointer
+		 * Authentication Codes (bits 47-63). Strip them out.
+		 */
+		ip &= 0x7fffffffffffull;
+#endif /* __aarch64__ */
 		append_frame(bt, (void *)ip);
 		rc = unw_step(&unw_cur);
 		if (rc <= 0) {


### PR DESCRIPTION
Just a regular backport of #8818 and #9267 via a pull request to verify changes.