### PR TITLE
[backport 2.11] key_def: ignore json path in key_def_find_by_fieldno

### DIFF
--- a/src/box/key_def.c
+++ b/src/box/key_def.c
@@ -989,10 +989,12 @@ key_def_decode_parts(struct key_part_def *parts, uint32_t part_count,
 const struct key_part *
 key_def_find_by_fieldno(const struct key_def *key_def, uint32_t fieldno)
 {
-	struct key_part part;
-	memset(&part, 0, sizeof(struct key_part));
-	part.fieldno = fieldno;
-	return key_def_find(key_def, &part);
+	const struct key_part *part = key_def->parts;
+	const struct key_part *end = part + key_def->part_count;
+	for (; part != end; part++)
+		if (part->fieldno == fieldno)
+			return part;
+	return NULL;
 }
 
 const struct key_part *

--- a/src/box/key_def.h
+++ b/src/box/key_def.h
@@ -714,7 +714,9 @@ key_def_decode_parts(struct key_part_def *parts, uint32_t part_count,
 		     uint32_t field_count, struct region *region);
 
 /**
- * Returns the part in index_def->parts for the specified fieldno.
+ * Returns the first part in index_def->parts for the specified fieldno.
+ * The part is returned regardless of whether it is indexed by JSON path or not.
+ *
  * If fieldno is not in index_def->parts returns NULL.
  */
 const struct key_part *

--- a/test/unit/key_def.c
+++ b/test/unit/key_def.c
@@ -451,16 +451,45 @@ test_tuple_validate_key_parts_raw(void)
 	check_plan();
 }
 
+static void
+test_key_def_find_by_fieldno(void)
+{
+	plan(3);
+	header();
+
+	const struct key_part *key_part;
+	struct key_def *key_def = test_key_def_new(
+		"[{%s%u%s%s}{%s%u%s%s}{%s%u%s%s%s%s}]",
+		"field", 1, "type", "unsigned",
+		"field", 2, "type", "string",
+		"field", 3, "type", "string", "path", "foo");
+
+	key_part = key_def_find_by_fieldno(key_def, 2);
+	isnt(key_part, NULL, "field 2 (no path) found");
+
+	key_part = key_def_find_by_fieldno(key_def, 3);
+	isnt(key_part, NULL, "field 3 (with path) found");
+
+	key_part = key_def_find_by_fieldno(key_def, 100);
+	is(key_part, NULL, "field 100 not found");
+
+	key_def_delete(key_def);
+
+	footer();
+	check_plan();
+}
+
 static int
 test_main(void)
 {
-	plan(4);
+	plan(5);
 	header();
 
 	test_func_compare();
 	test_func_compare_with_key();
 	test_tuple_extract_key_raw_slowpath_nullable();
 	test_tuple_validate_key_parts_raw();
+	test_key_def_find_by_fieldno();
 
 	footer();
 	return check_plan();


### PR DESCRIPTION
This function returns a key_def part by a field number. However, currently it returns NULL for parts that contain a JSON path to indexed data. Fix it.

Needed for tarantool/tarantool-ee#671

NO_DOC=bugfix
NO_CHANGELOG=not visible in CE

(cherry picked from commit cb0264c3cac00c288f9a0b4614f203d1c4b157ab)