### PR TITLE
relay: fix stack use after return

### DIFF
--- a/changelogs/unreleased/gh-9505-relay-stack-use-after-return.md
+++ b/changelogs/unreleased/gh-9505-relay-stack-use-after-return.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed an issue when it was possible to use the
+  `box_collect_confirmed_vclock` stack after return (gh-9505).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -2540,6 +2540,15 @@ box_wait_quorum(uint32_t lead_id, int64_t target_lsn, int quorum,
 	return 0;
 }
 
+/**
+ * The pool is used by box_cc to allocate sync_trigger_data that is used in
+ * box_collect_confirmed_vclock and relay_get_sync_on_start. We allocate
+ * sync_trigger_data dynamically because these functions are running in
+ * different fibers. The lifetime of sync_trigger_data is not limited by the
+ * execution time of box_collect_confirmed_vclock.
+ */
+static struct mempool sync_trigger_data_pool;
+
 /** A structure holding trigger data to collect syncs. */
 struct sync_trigger_data {
 	/** Syncs to wait for. */
@@ -2558,7 +2567,29 @@ struct sync_trigger_data {
 	int count;
 	/** Whether the request is timed out. */
 	bool is_timed_out;
+	/** Count of fibers that are using data. */
+	int ref_count;
 };
+
+/** Let others know we need data. */
+void
+sync_trigger_data_ref(struct sync_trigger_data *data)
+{
+	++data->ref_count;
+}
+
+/**
+ * Let others know that we no longer need the data.
+ * If no one else needs the data, free it.
+ */
+void
+sync_trigger_data_unref(struct sync_trigger_data *data)
+{
+	--data->ref_count;
+	assert(data->ref_count >= 0);
+	if (data->ref_count == 0)
+		mempool_free(&sync_trigger_data_pool, data);
+}
 
 /**
  * A trigger executed on each ack to collect up to date remote node vclocks.
@@ -2605,12 +2636,15 @@ relay_get_sync_on_start(struct trigger *trigger, void *event)
 	/* Already accounted. */
 	if (bit_test(&data->collected_vclock_map, id))
 		return 0;
+
+	sync_trigger_data_ref(data);
 	if (relay_trigger_vclock_sync(relay, &data->vclock_syncs[id],
 				      data->deadline) != 0) {
 		diag_clear(diag_get());
 		data->is_timed_out = true;
 		fiber_wakeup(data->waiter);
 	}
+	sync_trigger_data_unref(data);
 	return 0;
 }
 
@@ -2632,54 +2666,60 @@ box_collect_confirmed_vclock(struct vclock *confirmed_vclock, double deadline)
 	if (vclock_count <= 1)
 		return 0;
 
-	struct sync_trigger_data data = {
-		.vclock_syncs = {0},
-		.collected_vclock_map = 0,
-		.waiter = fiber(),
-		.vclock = confirmed_vclock,
-		.deadline = deadline,
-		.count = vclock_count,
-		.is_timed_out = false,
-	};
-	bit_set(&data.collected_vclock_map, instance_id);
+	struct sync_trigger_data *data = (sync_trigger_data *)
+		xmempool_alloc(&sync_trigger_data_pool);
+	memset(data->vclock_syncs, 0, sizeof(data->vclock_syncs));
+	data->collected_vclock_map = 0;
+	data->waiter = fiber();
+	data->vclock = confirmed_vclock;
+	data->deadline = deadline;
+	data->count = vclock_count;
+	data->is_timed_out = false;
+	data->ref_count = 0;
+
+	sync_trigger_data_ref(data);
+	bit_set(&data->collected_vclock_map, instance_id);
 	struct trigger on_relay_thread_start;
-	trigger_create(&on_relay_thread_start, relay_get_sync_on_start, &data,
+	trigger_create(&on_relay_thread_start, relay_get_sync_on_start, data,
 		       NULL);
 	trigger_add(&replicaset.on_relay_thread_start, &on_relay_thread_start);
 	struct trigger on_ack;
-	trigger_create(&on_ack, check_vclock_sync_on_ack, &data, NULL);
+	trigger_create(&on_ack, check_vclock_sync_on_ack, data, NULL);
 	trigger_add(&replicaset.on_ack, &on_ack);
+
+	auto guard = make_scoped_guard([&] {
+		trigger_clear(&on_ack);
+		trigger_clear(&on_relay_thread_start);
+		sync_trigger_data_unref(data);
+	});
+
 	replicaset_foreach(replica) {
 		if (relay_get_state(replica->relay) != RELAY_FOLLOW ||
 		    replica->anon) {
 			continue;
 		}
 		/* Might be already filled by on_relay_thread_start trigger. */
-		if (data.vclock_syncs[replica->id] != 0)
+		if (data->vclock_syncs[replica->id] != 0)
 			continue;
 		if (relay_trigger_vclock_sync(replica->relay,
-					      &data.vclock_syncs[replica->id],
+					      &data->vclock_syncs[replica->id],
 					      deadline) != 0) {
 			/* Timed out. */
-			trigger_clear(&on_ack);
-			trigger_clear(&on_relay_thread_start);
 			return -1;
 		}
 	}
 
-	while (bit_count_u32(data.collected_vclock_map) < vclock_count &&
-	       !data.is_timed_out && !fiber_is_cancelled()) {
+	while (bit_count_u32(data->collected_vclock_map) < vclock_count &&
+	       !data->is_timed_out && !fiber_is_cancelled()) {
 		if (fiber_yield_deadline(deadline))
 			break;
 	}
 
-	trigger_clear(&on_ack);
-	trigger_clear(&on_relay_thread_start);
 	if (fiber_is_cancelled()) {
 		diag_set(FiberIsCancelled);
 		return -1;
 	}
-	if (bit_count_u32(data.collected_vclock_map) < vclock_count) {
+	if (bit_count_u32(data->collected_vclock_map) < vclock_count) {
 		diag_set(TimedOut);
 		return -1;
 	}
@@ -5984,6 +6024,8 @@ box_init(void)
 	 */
 	builtin_events_init();
 	crash_callback = box_crash_callback;
+	mempool_create(&sync_trigger_data_pool, &cord()->slabc,
+		       sizeof(struct sync_trigger_data));
 }
 
 /** Shutdown box storage i.e. stop parts that need TX loop running. */
@@ -6036,6 +6078,7 @@ box_free(void)
 	txn_event_trigger_free();
 	tuple_free();
 	iproto_constants_free();
+	mempool_destroy(&sync_trigger_data_pool);
 	/* schema_module_free(); */
 	/* session_free(); */
 	/* user_cache_free(); */


### PR DESCRIPTION
Fixed a bug when it was possible to use the
box_collect_confirmed_vclock stack after return.

Closes #9505

NO_DOC=bugfix
NO_TEST=asan