### PR TITLE
netbox: close transport after stopping worker loop and wait for the stop

### DIFF
--- a/changelogs/unreleased/gh-9621-netbox-worker-crash.md
+++ b/changelogs/unreleased/gh-9621-netbox-worker-crash.md
@@ -1,0 +1,4 @@
+## bugfix/lua
+
+* Fixed a corner case when the netbox connection's worker fiber case could crash
+  (gh-9621).

--- a/changelogs/unreleased/gh-9826-netbox-on_schema_reload-close.md
+++ b/changelogs/unreleased/gh-9826-netbox-on_schema_reload-close.md
@@ -1,0 +1,4 @@
+## bugfix/lua
+
+* Fixed a bug that caused a `net.box` connection to crash after being closed
+  from the connection's `on_schema_reload` trigger (gh-9621).

--- a/test/app-luatest/gh_9621_netbox_worker_crash_test.lua
+++ b/test/app-luatest/gh_9621_netbox_worker_crash_test.lua
@@ -1,0 +1,79 @@
+local fiber = require('fiber')
+local net = require('net.box')
+local socket = require('socket')
+
+local t = require('luatest')
+local g = t.group()
+
+local cond_send_leftover_packet = fiber.cond()
+local handler = function(fd)
+    -- Greeting.
+    fd:write(box.iproto.encode_greeting())
+    -- Wait for identification request to be sent from the client, so its
+    -- send buffer gets empty.
+    fd:read(1)
+    -- Identification response.
+    local error_type = bit.bor(box.iproto.type.TYPE_ERROR,
+                               box.error.UNKNOWN_REQUEST_TYPE)
+    local id_response = box.iproto.encode_packet({request_type = error_type})
+    -- ce 00 00 00 03 81 00 00
+    local packet = box.iproto.encode_packet({request_type = box.iproto.type.OK})
+    -- ce 00 00 00 03
+    local partial_packet = packet:sub(1, 5)
+    -- 81 00 00 ce 00 00 00 03 81 00 00
+    local leftover_packet = packet:sub(6) .. packet
+    fd:write(id_response .. partial_packet)
+    cond_send_leftover_packet:wait()
+    fd:write(leftover_packet)
+end
+
+-- Test that the connection's worker fiber correctly handles scenario when
+-- connection is closed concurrently to the `coio_wait` call.
+g.test_worker_yield_from_coio_wait = function()
+    local srv = socket.tcp_server('localhost', 0, handler)
+    local c = net.new(srv:name().port, {fetch_schema = false})
+    c:on_disconnect(function()
+        fiber.yield()
+    end)
+
+    fiber.create(function()
+        c:close()
+    end)
+
+    cond_send_leftover_packet:signal()
+
+    fiber.yield()
+
+    srv:close()
+end
+
+-- Test that the connection's worker fiber correctly handles scenario when
+-- connection is closed concurrently to the `on_connect` trigger call.
+g.test_worker_yield_from_on_connect_trigger = function()
+    local cond_entered_on_connect_trigger = fiber.cond()
+    local cond_return_from_on_connect_trigger = fiber.cond()
+
+    local srv = socket.tcp_server('localhost', 0, handler)
+    local c = net.new(srv:name().port, {wait_connected = false,
+                                       fetch_schema = false})
+    c:on_connect(function()
+        cond_entered_on_connect_trigger:signal()
+        cond_return_from_on_connect_trigger:wait()
+    end)
+    c:on_disconnect(function()
+        fiber.yield()
+    end)
+
+    cond_entered_on_connect_trigger:wait()
+
+    fiber.create(function()
+        c:close()
+    end)
+
+    cond_send_leftover_packet:signal()
+    cond_return_from_on_connect_trigger:signal()
+
+    fiber.yield()
+
+    srv:close()
+end

--- a/test/box-luatest/gh_9826_netbox_on_schema_reload_close_test.lua
+++ b/test/box-luatest/gh_9826_netbox_on_schema_reload_close_test.lua
@@ -1,0 +1,25 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+-- Tests that closing the connection from the `on_schema_reload` trigger works
+-- correctly.
+g.test_on_schema_reload_close = function(cg)
+    local net_box = require('net.box')
+
+    local c = net_box.connect(cg.server.net_box_uri, {wait_connected = false})
+    c:on_schema_reload(function()
+        pcall(function() c:close() end)
+    end)
+    t.assert(c:wait_state('closed', 0.1))
+end


### PR DESCRIPTION
This patch fixes a bugs in `net.box` related to the connection being closed unexpectedly to the connection's worker fiber.

Closes #9621
Closes #9826