### PR TITLE
[2.10] test: disable JIT in test/app/digest.test.lua

### DIFF
--- a/test/app/digest.result
+++ b/test/app/digest.result
@@ -1,3 +1,10 @@
+-- Disable JIT due to #6097.
+jit.off()
+---
+...
+jit.flush()
+---
+...
 test_run = require('test_run').new()
 ---
 ...

--- a/test/app/digest.test.lua
+++ b/test/app/digest.test.lua
@@ -1,3 +1,7 @@
+-- Disable JIT due to #6097.
+jit.off()
+jit.flush()
+
 test_run = require('test_run').new()
 test_run:cmd("push filter ".."'\\.lua.*:[0-9]+: ' to '.lua:<line>\"]: '")
 


### PR DESCRIPTION
After we moved osx testing from the per-commit to nightly basis [1], we accidentally enabled running tarantool tests on macOS/M1 for 2.10. So we had some tests failed, and they were fixed by cherry-picking a few commits from the master branch [2]. Also, some tests were fixed by updating test-run to the new version [3] with needed fix [4]. So it's time to fix the last failed test (test/app/digest.test.lua) on macOS/M1 by disabling JIT in it due to the issue [5].

[1] https://github.com/tarantool/tarantool/pull/9571
[2] https://github.com/tarantool/tarantool/pull/9672
[3] https://github.com/tarantool/tarantool/pull/9685
[4] https://github.com/tarantool/test-run/pull/422
[5] https://github.com/tarantool/tarantool/issues/6097

---

Tested on macOS/M1 as well:
```
...
Top 10 longest tests (seconds):
*  63.54 replication-luatest/quorum_orphan_test.lua
*  57.07 sql-tap/in2.test.lua:memtx
*  30.97 replication-luatest/gh_4669_applier_reconnect_test.lua
*  22.82 replication-luatest/quorum_misc_test.lua
*  22.43 sql-tap/trigger8.test.lua:memtx
*  20.72 box/gh-5422-broken_snapshot.test.lua
*  19.87 replication-luatest/gh_7318_box_wait_limbo_acked_test.lua
*  17.62 sql-tap/trigger8.test.lua:vinyl
*  15.89 engine-luatest/gh_6436_field_foreign_key_test.lua
*  15.05 vinyl/gh-4810-dump-during-index-build.test.lua
---------------------------------------------------------------------------------
Statistics:
* disabled: 73
* pass: 1583
* skip: 6
```