### PR TITLE
lua: add RSA-PSS verify OSSL wrapper

### DIFF
--- a/extra/exports
+++ b/extra/exports
@@ -193,6 +193,7 @@ crypto_stream_delete
 crypto_stream_new
 crypto_X509_get_default_cert_dir_env
 crypto_X509_get_default_cert_file_env
+crypto_RSA_PSS_verify
 csv_create
 csv_destroy
 csv_escape_field

--- a/src/lua/crypto.lua
+++ b/src/lua/crypto.lua
@@ -73,6 +73,11 @@ ffi.cdef[[
 
     void
     crypto_stream_delete(struct crypto_stream *s);
+
+    int
+    crypto_RSA_PSS_verify(const unsigned char *text, size_t text_len,
+                          const unsigned char *pub_key, size_t key_len,
+                          const unsigned char *sig, size_t sig_len);
 ]]
 
 local function openssl_err_str()
@@ -435,10 +440,17 @@ for algo_name, algo_value in pairs(crypto_algos) do
     end
 end
 
+local function rsa_pss_verify(text, public_key, signature)
+    return ffi.C.crypto_RSA_PSS_verify(text, text:len(),
+                                       public_key, public_key:len(),
+                                       signature, signature:len())
+end
+
 local public_methods = {
     digest = digest_api,
     hmac   = hmac_api,
     cipher = crypto_api,
+    rsa_pss_verify = rsa_pss_verify,
 }
 
 local module_mt = {

--- a/test/app-luatest/crypto_add_rsa_pss_test.lua
+++ b/test/app-luatest/crypto_add_rsa_pss_test.lua
@@ -1,0 +1,35 @@
+local t = require('luatest')
+local g = t.group()
+
+local crypto = require('crypto')
+
+g.test_rsa_sig_verify = function()
+
+    local pub_key = [=[
+    -----BEGIN PUBLIC KEY-----
+    MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxTZHa+OdyXZiqLQkrWo4
+    6ulcBAx0pmHdxFVXEcwbyQ/uh38bXiWviDwczQyw7Mh9n7r45NYeuiyjJsl9fUzg
+    ZJ71alU8ah1mJWE4nMarHdAtr1EmRGXqtU+hzWYDCx9x/LOvhjojCFsQIMGgGe6a
+    Ze6ix9Yl4tcZor2WeY1xEuNriaJ9vPPvxjVbP+cOKruK0RYe7sDzTiVrgaIB2Ww3
+    8wee2VAqpno+3SNONYzos89kZxBJxdHeWbIyIYPsgbernrRTA+JzimXzfjdI55qG
+    50GbyEMaPdlp9uLggUCw0phGQsyxhRHB5WzcSn1IIlc/XBD3/uiulQvkXWDV6gZW
+    qQIDAQAB
+    -----END PUBLIC KEY-----
+    ]=]
+
+    local message = "This is the message to be checked by Tarantool!\n"
+
+    local signature =
+            '1648457f63127320826e5e84cdf0a9efa7b1956bc732c80471d8c281856ab4' ..
+            '8ad399e071034792f318ea850e0900a4c5941283448210341d283223112f47' ..
+            '65b52189acb53a36f4a9bc648c8267056311fdfc7444757780e748df4ddb7e' ..
+            'edd9f670e261051660c3a89d34ea280c3e0095adb9752828d2fef19e6089dc' ..
+            '465e13d666487cd3795872f51e420febcb7162b2bed62ec60aeb8cb6caa24a' ..
+            '729edc7bd3ef4f7eb7c160a9898bdccbbd2b459ab865c26a623ee917c03c40' ..
+            '78a8f37d3c43827c017246f2bdc96cc4d196521fccace47059973af258e9f1' ..
+            'a14795611d64270f8ef4ea905fb8237bfcf615f932a3abaf4389b119334283' ..
+            '81a1e2346e741858'
+    signature = string.fromhex(signature)
+
+    t.assert(crypto.rsa_pss_verify(message, pub_key, signature))
+end


### PR DESCRIPTION
This patch adds Lua wrapper for OpenSSL RSA-PSS signature verification. It is required by integrity module to validate hashes.json file.

Part of tarantool/tarantool-ee#679

NO_DOC=yet
NO_CHANGELOG=yet
NO_TEST=yet