### PR TITLE
Backport "wal: add stubs for wal_retention_period" to 2.11

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -131,7 +131,12 @@ endif()
 add_library(tuple STATIC ${tuple_sources})
 target_link_libraries(tuple json box_error core ${MSGPUCK_LIBRARIES} misc bit coll)
 
-add_library(xlog STATIC xlog.c)
+set(xlog_sources xlog.c)
+if(ENABLE_RETENTION_PERIOD)
+    list(APPEND xlog_sources ${RETENTION_PERIOD_SOURCES})
+endif()
+
+add_library(xlog STATIC ${xlog_sources})
 target_link_libraries(xlog core box_error crc32 ${ZSTD_LIBRARIES})
 
 set(box_sources

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -1528,6 +1528,30 @@ box_check_wal_max_size(int64_t wal_max_size)
 	return wal_max_size;
 }
 
+/** Validate that wal_retention_period is >= 0. */
+static double
+box_check_wal_retention_period()
+{
+	double value = cfg_getd("experimental_wal_retention_period");
+	if (value < 0) {
+		diag_set(ClientError, ER_CFG,
+			 "experimental_wal_retention_period",
+			 "the value must be >= 0");
+		return -1;
+	}
+	return value;
+}
+
+/** Validate wal_retention_period and raise error, if needed. */
+static double
+box_check_wal_retention_period_xc()
+{
+	double value = box_check_wal_retention_period();
+	if (value < 0)
+		diag_raise();
+	return value;
+}
+
 static ssize_t
 box_check_memory_quota(const char *quota_name)
 {
@@ -1757,6 +1781,8 @@ box_check_config(void)
 	if (box_check_wal_queue_max_size() < 0)
 		diag_raise();
 	if (box_check_wal_cleanup_delay() < 0)
+		diag_raise();
+	if (box_check_wal_retention_period() < 0)
 		diag_raise();
 	if (box_check_memory_quota("memtx_memory") < 0)
 		diag_raise();
@@ -2819,6 +2845,16 @@ box_set_wal_cleanup_delay(void)
 	if (replication_anon)
 		delay = 0;
 	gc_set_wal_cleanup_delay(delay);
+	return 0;
+}
+
+int
+box_set_wal_retention_period(void)
+{
+	double delay = box_check_wal_retention_period();
+	if (delay < 0)
+		return -1;
+	wal_set_retention_period(delay);
 	return 0;
 }
 
@@ -5323,8 +5359,10 @@ box_storage_init(void)
 	int64_t wal_max_size = box_check_wal_max_size(
 		cfg_geti64("wal_max_size"));
 	enum wal_mode wal_mode = box_check_wal_mode(cfg_gets("wal_mode"));
+	double wal_retention_period = box_check_wal_retention_period_xc();
 	if (wal_init(wal_mode, cfg_gets("wal_dir"), wal_max_size,
-		     &INSTANCE_UUID, on_wal_garbage_collection,
+		     wal_retention_period, &INSTANCE_UUID,
+		     on_wal_garbage_collection,
 		     on_wal_checkpoint_threshold) != 0) {
 		diag_raise();
 	}

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -338,6 +338,8 @@ box_init_say();
 extern "C" {
 #endif /* defined(__cplusplus) */
 
+int box_set_wal_retention_period(void);
+
 typedef struct tuple box_tuple_t;
 
 bool

--- a/src/box/gc.c
+++ b/src/box/gc.c
@@ -213,6 +213,15 @@ gc_run_cleanup(void)
 		consumer = gc_tree_next(&gc.consumers, consumer);
 	}
 
+	/*
+	 * Acquire minimum vclock of a file, which is protected from garbage
+	 * collection by wal_retention_period option.
+	 */
+	struct vclock retention_vclock;
+	wal_get_retention_vclock(&retention_vclock);
+	if (vclock_is_set(&retention_vclock))
+		vclock_min(&min_vclock, &retention_vclock);
+
 	if (vclock_sum(&min_vclock) > vclock_sum(&gc.vclock)) {
 		vclock_copy(&gc.vclock, &min_vclock);
 		run_wal_gc = true;

--- a/src/box/lua/info.c
+++ b/src/box/lua/info.c
@@ -458,6 +458,15 @@ lbox_info_gc_call(struct lua_State *L)
 	lua_pushboolean(L, gc.is_paused);
 	lua_settable(L, -3);
 
+	lua_pushstring(L, "wal_retention_vclock");
+	struct vclock retention_vclock;
+	wal_get_retention_vclock(&retention_vclock);
+	if (vclock_is_set(&retention_vclock))
+		luaT_pushvclock(L, &retention_vclock);
+	else
+		luaL_pushnull(L);
+	lua_settable(L, -3);
+
 	lua_pushstring(L, "checkpoints");
 	lua_newtable(L);
 

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -69,6 +69,7 @@
 #include "box/lua/merger.h"
 #include "box/lua/watcher.h"
 #include "box/lua/iproto.h"
+#include "box/lua/wal_retention_period.h"
 
 #include "mpstream/mpstream.h"
 
@@ -702,6 +703,9 @@ box_lua_init(struct lua_State *L)
 #endif
 #ifdef ENABLE_AUDIT_LOG
 	box_lua_audit_init(L);
+#endif
+#ifdef ENABLE_RETENTION_PERIOD
+	box_lua_wal_retention_period_init(L);
 #endif
 #ifdef ENABLE_WAL_EXT
 	box_lua_wal_ext_init(L);

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -81,6 +81,12 @@ local function ifdef_security(value)
     end
 end
 
+local function ifdef_wal_retention_period(value)
+    if private.cfg_set_wal_retention_period ~= nil then
+        return value
+    end
+end
+
 -- all available options
 local default_cfg = {
     listen              = nil,
@@ -151,6 +157,7 @@ local default_cfg = {
     wal_dir_rescan_delay= 2,
     wal_queue_max_size  = 16 * 1024 * 1024,
     wal_cleanup_delay   = 4 * 3600,
+    experimental_wal_retention_period = ifdef_wal_retention_period(0),
     wal_ext             = ifdef_wal_ext(nil),
     force_recovery      = false,
     replication         = nil,
@@ -340,6 +347,7 @@ local template_cfg = {
     wal_max_size        = 'number',
     wal_dir_rescan_delay= 'number',
     wal_cleanup_delay   = 'number',
+    experimental_wal_retention_period = ifdef_wal_retention_period('number'),
     wal_ext             = ifdef_wal_ext('table'),
     force_recovery      = 'boolean',
     replication         = 'string, number, table',
@@ -467,6 +475,7 @@ local dynamic_cfg = {
     -- do nothing, affects new replicas, which query this value on start
     wal_dir_rescan_delay    = nop,
     wal_cleanup_delay       = private.cfg_set_wal_cleanup_delay,
+    experimental_wal_retention_period = private.cfg_set_wal_retention_period,
     custom_proc_title       = function()
         require('title').update(box.cfg.custom_proc_title)
     end,
@@ -652,6 +661,7 @@ local dynamic_cfg_skip_at_load = {
     auth_delay              = ifdef_security(true),
     disable_guest           = ifdef_security(true),
     password_lifetime_days  = ifdef_security(true),
+    experimental_wal_retention_period = ifdef_wal_retention_period(true),
 }
 
 -- Options that are not part of dynamic_cfg_modules and applied individually

--- a/src/box/lua/wal_retention_period.h
+++ b/src/box/lua/wal_retention_period.h
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2024, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include "trivia/config.h"
+
+#if defined(ENABLE_RETENTION_PERIOD)
+#include "lua/wal_retention_period_impl.h"
+#else /* !defined(ENABLE_RETENTION_PERIOD) */
+
+struct lua_State;
+
+static inline void
+box_lua_wal_retention_period_init(struct lua_State *L)
+{
+	(void)L;
+}
+
+#endif /* !defined(ENABLE_RETENTION_PERIOD) */

--- a/src/box/retention_period.h
+++ b/src/box/retention_period.h
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2024, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include "trivia/config.h"
+
+#if defined(ENABLE_RETENTION_PERIOD)
+#include "retention_period_impl.h"
+#else /* !defined(ENABLE_RETENTION_PERIOD) */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+#include "vclock/vclock.h"
+#include "xlog.h"
+
+/**
+ * Allocate vclock structure. In EE additional memory is allocated,
+ * where expiration time is saved.
+ */
+static inline struct vclock*
+retention_vclock_new(void)
+{
+	return (struct vclock *)xmalloc(sizeof(struct vclock));
+}
+
+/**
+ * Set expiration time of the @retention_vclock to now + @period.
+ */
+static inline void
+retention_vclock_set(struct vclock *retention_vclock, double period)
+{
+	(void)retention_vclock;
+	(void)period;
+}
+
+/**
+ * Update expiration time of all files. New period must be saved inside xdir.
+ */
+static inline void
+retention_index_update(struct xdir *xdir, double old_period)
+{
+	(void)xdir;
+	(void)old_period;
+}
+
+/**
+ * Return vclock of the oldest file, which is protected from garbage collection.
+ * Vclock is cleared, if none of the files are protected. Vclock must be
+ * non-nil.
+ */
+static inline void
+retention_index_get(vclockset_t *index, struct vclock *vclock)
+{
+	(void)index;
+	assert(vclock != NULL);
+	vclock_clear(vclock);
+}
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */
+
+#endif /* !defined(ENABLE_RETENTION_PERIOD) */

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -418,6 +418,7 @@ tx_notify_checkpoint(struct cmsg *msg)
 static void
 wal_writer_create(struct wal_writer *writer, enum wal_mode wal_mode,
 		  const char *wal_dirname, int64_t wal_max_size,
+		  double wal_retention_period,
 		  const struct tt_uuid *instance_uuid,
 		  wal_on_garbage_collection_f on_garbage_collection,
 		  wal_on_checkpoint_threshold_f on_checkpoint_threshold)
@@ -434,6 +435,11 @@ wal_writer_create(struct wal_writer *writer, enum wal_mode wal_mode,
 	struct xlog_opts opts = xlog_opts_default;
 	opts.sync_is_async = true;
 	xdir_create(&writer->wal_dir, wal_dirname, XLOG, instance_uuid, &opts);
+	/*
+	 * wal_retention_period must be set before gc is woken up.
+	 * Otherwise files which must be preserved can be deleted.
+	 */
+	xdir_set_retention_period(&writer->wal_dir, wal_retention_period);
 	xlog_clear(&writer->current_wal);
 	if (wal_mode == WAL_FSYNC)
 		writer->wal_dir.open_wflags |= O_SYNC;
@@ -538,15 +544,16 @@ wal_open(struct wal_writer *writer)
 
 int
 wal_init(enum wal_mode wal_mode, const char *wal_dirname,
-	 int64_t wal_max_size, const struct tt_uuid *instance_uuid,
+	 int64_t wal_max_size, double wal_retention_period,
+	 const struct tt_uuid *instance_uuid,
 	 wal_on_garbage_collection_f on_garbage_collection,
 	 wal_on_checkpoint_threshold_f on_checkpoint_threshold)
 {
 	/* Initialize the state. */
 	struct wal_writer *writer = &wal_writer_singleton;
 	wal_writer_create(writer, wal_mode, wal_dirname, wal_max_size,
-			  instance_uuid, on_garbage_collection,
-			  on_checkpoint_threshold);
+			  wal_retention_period, instance_uuid,
+			  on_garbage_collection, on_checkpoint_threshold);
 
 	/* Start WAL thread. */
 	if (cord_costart(&writer->cord, "wal", wal_writer_f, NULL) != 0)
@@ -667,7 +674,8 @@ wal_begin_checkpoint_f(struct cbus_call_msg *data)
 	if (xlog_is_open(&writer->current_wal) &&
 	    vclock_sum(&writer->current_wal.meta.vclock) !=
 	    vclock_sum(&writer->vclock)) {
-
+		xdir_set_retention_vclock(
+			&writer->wal_dir, &writer->current_wal.meta.vclock);
 		xlog_close(&writer->current_wal, false);
 		/*
 		 * The next WAL will be created on the first write.
@@ -770,6 +778,59 @@ wal_set_queue_max_size(int64_t size)
 	journal_queue_set_max_size(size);
 }
 
+/** Retention delay configuration message. */
+struct wal_set_retention_period_msg {
+	/* The state of a synchronous cross-thread call. */
+	struct cbus_call_msg base;
+	/* New retention_period value. */
+	double retention_period;
+};
+
+static int
+wal_set_retention_period_f(struct cbus_call_msg *data)
+{
+	struct wal_writer *writer = &wal_writer_singleton;
+	struct wal_set_retention_period_msg *msg;
+	msg = (struct wal_set_retention_period_msg *)data;
+	xdir_set_retention_period(&writer->wal_dir, msg->retention_period);
+	return 0;
+}
+
+void
+wal_set_retention_period(double period)
+{
+	struct wal_writer *writer = &wal_writer_singleton;
+	struct wal_set_retention_period_msg msg;
+	msg.retention_period = period;
+	cbus_call(&writer->wal_pipe, &writer->tx_prio_pipe,
+		  &msg.base, wal_set_retention_period_f);
+}
+
+static int
+wal_get_retention_vclock_f(struct cbus_call_msg *data)
+{
+	struct wal_writer *writer = &wal_writer_singleton;
+	struct wal_vclock_msg *msg = (struct wal_vclock_msg *)data;
+	xdir_get_retention_vclock(&writer->wal_dir, &msg->vclock);
+	return 0;
+}
+
+void
+wal_get_retention_vclock(struct vclock *vclock)
+{
+	struct wal_writer *writer = &wal_writer_singleton;
+	if (vclock == NULL)
+		return;
+	if (writer->wal_dir.retention_period == 0) {
+		vclock_clear(vclock);
+		return;
+	}
+	struct wal_vclock_msg msg;
+	cbus_call(&writer->wal_pipe, &writer->tx_prio_pipe,
+		  &msg.base, wal_get_retention_vclock_f);
+	vclock_copy(vclock, &msg.vclock);
+}
+
 struct wal_gc_msg
 {
 	struct cbus_call_msg base;
@@ -842,6 +903,8 @@ wal_opt_rotate(struct wal_writer *writer)
 	 */
 	if (xlog_is_open(&writer->current_wal) &&
 	    writer->current_wal.offset >= writer->wal_max_size) {
+		xdir_set_retention_vclock(
+			&writer->wal_dir, &writer->current_wal.meta.vclock);
 		/*
 		 * We can not handle xlog_close()
 		 * failure in any reasonable way.
@@ -886,6 +949,14 @@ wal_fallocate(struct wal_writer *writer, size_t len)
 	 * we must not delete WALs necessary for recovery.
 	 */
 	int64_t gc_lsn = vclock_sum(&writer->checkpoint_vclock);
+
+	struct vclock retention_vclock;
+	xdir_get_retention_vclock(&writer->wal_dir, &retention_vclock);
+	if (vclock_is_set(&retention_vclock)) {
+		int64_t retention_lsn = vclock_sum(&retention_vclock);
+		if (retention_lsn < gc_lsn)
+			gc_lsn = retention_lsn;
+	}
 
 	/*
 	 * The actual write size can be greater than the sum size

--- a/src/box/wal.h
+++ b/src/box/wal.h
@@ -107,7 +107,8 @@ typedef void (*wal_on_checkpoint_threshold_f)(void);
  */
 int
 wal_init(enum wal_mode wal_mode, const char *wal_dirname,
-	 int64_t wal_max_size, const struct tt_uuid *instance_uuid,
+	 int64_t wal_max_size, double wal_retention_period,
+	 const struct tt_uuid *instance_uuid,
 	 wal_on_garbage_collection_f on_garbage_collection,
 	 wal_on_checkpoint_threshold_f on_checkpoint_threshold);
 
@@ -265,6 +266,20 @@ wal_set_checkpoint_threshold(int64_t threshold);
  */
 void
 wal_set_queue_max_size(int64_t size);
+
+/**
+ * Set new value for wal_retention_period, update expiration time
+ * of all xlog files.
+ */
+void
+wal_set_retention_period(double period);
+
+/**
+ * Return vclock (unless @vclock is NULL) of the oldest file,
+ * which is protected from garbage collection.
+ */
+void
+wal_get_retention_vclock(struct vclock *vclock);
 
 /**
  * Remove WAL files that are not needed by consumers reading

--- a/src/box/xlog.c
+++ b/src/box/xlog.c
@@ -47,6 +47,7 @@
 #include "iproto_constants.h"
 #include "errinj.h"
 #include "trivia/util.h"
+#include "retention_period.h"
 
 /*
  * FALLOC_FL_KEEP_SIZE flag has existed since fallocate() was
@@ -359,6 +360,7 @@ xdir_create(struct xdir *dir, const char *dirname, enum xdir_type type,
 		unreachable();
 	}
 	dir->type = type;
+	dir->retention_period = 0;
 }
 
 /**
@@ -419,16 +421,11 @@ xdir_index_file(struct xdir *dir, int64_t signature)
 	}
 
 	/*
-	 * Append the clock describing the file to the
-	 * directory index.
+	 * Append the clock describing the file to the directory index.
+	 * If retention feature is available (EE), then additional memory is
+	 * allocated. Time, when xlog protection should stop is saved there.
 	 */
-	struct vclock *vclock = (struct vclock *) malloc(sizeof(*vclock));
-	if (vclock == NULL) {
-		diag_set(OutOfMemory, sizeof(*vclock), "malloc", "vclock");
-		xlog_cursor_close(&cursor, false);
-		return -1;
-	}
-
+	struct vclock *vclock = retention_vclock_new();
 	vclock_copy(vclock, &meta->vclock);
 	xlog_cursor_close(&cursor, false);
 	vclockset_insert(&dir->index, vclock);
@@ -627,6 +624,8 @@ xdir_scan(struct xdir *dir, bool is_dir_required)
 			i++;
 		}
 	}
+	/* Initialize expiration time of all files, saved inside index. */
+	retention_index_update(dir, 0);
 	rc = 0;
 
 exit:
@@ -646,6 +645,31 @@ xdir_check(struct xdir *dir)
 	}
 	closedir(dh);
 	return 0;
+}
+
+void
+xdir_set_retention_period(struct xdir *xdir, double period)
+{
+	double old_period = xdir->retention_period;
+	xdir->retention_period = period;
+	retention_index_update(xdir, old_period);
+}
+
+void
+xdir_get_retention_vclock(struct xdir *xdir, struct vclock *vclock)
+{
+	retention_index_get(&xdir->index, vclock);
+}
+
+void
+xdir_set_retention_vclock(struct xdir *xdir, struct vclock *vclock)
+{
+	if (xdir->retention_period == 0)
+		return;
+
+	struct vclock *find = vclockset_match(&xdir->index, vclock);
+	assert(vclock_compare(find, vclock) == 0);
+	retention_vclock_set(find, xdir->retention_period);
 }
 
 const char *
@@ -679,6 +703,23 @@ xdir_complete_gc(eio_req *req)
 void
 xdir_collect_garbage(struct xdir *dir, int64_t signature, unsigned flags)
 {
+	struct vclock retention_vclock;
+	retention_index_get(&dir->index, &retention_vclock);
+	if (vclock_is_set(&retention_vclock) &&
+	    signature > vclock_sum(&retention_vclock)) {
+		/*
+		 * This should not normally happen and can be a reason of
+		 * xdir_retention misusage: retention_vclock must be always
+		 * checked before invoking garbage collection. As we cannot
+		 * return error code from this function (gc already updated
+		 * its vclock), the best we can do is warning.
+		 */
+		assert(false);
+		say_warn("Requested xdir gc vclock is greater than "
+			 "retention vclock. Using retention vclock instead");
+		signature = vclock_sum(&retention_vclock);
+	}
+
 	struct vclock *vclock;
 	while ((vclock = vclockset_first(&dir->index)) != NULL &&
 	       vclock_sum(vclock) < signature) {
@@ -761,9 +802,7 @@ xdir_collect_inprogress(struct xdir *xdir)
 void
 xdir_add_vclock(struct xdir *xdir, const struct vclock *vclock)
 {
-	struct vclock *copy = malloc(sizeof(*vclock));
-	if (copy == NULL)
-		panic("failed to allocate vclock");
+	struct vclock *copy = retention_vclock_new();
 	vclock_copy(copy, vclock);
 	vclockset_insert(&xdir->index, copy);
 }

--- a/src/box/xlog.h
+++ b/src/box/xlog.h
@@ -160,6 +160,11 @@ struct xdir {
 	 */
 	vclockset_t index;
 	/**
+	 * Number of seconds to delay garbage collection of files
+	 * after they are closed.
+	 */
+	double retention_period;
+	/**
 	 * Directory path.
 	 */
 	char dirname[PATH_MAX];
@@ -197,6 +202,27 @@ int
 xdir_check(struct xdir *dir);
 
 /**
+ * Set new value for retention_period, update expiration time
+ * of all existing files.
+ */
+void
+xdir_set_retention_period(struct xdir *xdir, double period);
+
+/**
+ * Return vclock (unless @vclock is NULL) of the oldest file,
+ * which is protected from garbage collection.
+ */
+void
+xdir_get_retention_vclock(struct xdir *xdir, struct vclock *vclock);
+
+/**
+ * Find requested @vclock in index of xdir and set its retention
+ * according to retention_period.
+ */
+void
+xdir_set_retention_vclock(struct xdir *xdir, struct vclock *vclock);
+
+/**
  * Return a file name based on directory type, vector clock
  * sum, and a suffix (.inprogress or not).
  */
@@ -215,7 +241,17 @@ static inline bool
 xdir_has_garbage(struct xdir *dir, int64_t signature)
 {
 	struct vclock *vclock = vclockset_first(&dir->index);
-	return vclock != NULL && vclock_sum(vclock) < signature;
+	if (vclock == NULL)
+		return false;
+
+	struct vclock retention;
+	xdir_get_retention_vclock(dir, &retention);
+	if (!vclock_is_set(&retention) ||
+	    vclock_compare(vclock, &retention) < 0)
+		return vclock_sum(vclock) < signature;
+
+	/** All files are protected from gc. */
+	return false;
 }
 
 /**
@@ -501,7 +537,7 @@ ssize_t
 xlog_fallocate(struct xlog *log, size_t size);
 
 /**
- * Write a row to xlog, 
+ * Write a row to xlog,
  *
  * @retval count of writen bytes
  * @retval -1 for error

--- a/src/trivia/config.h.cmake
+++ b/src/trivia/config.h.cmake
@@ -284,6 +284,7 @@
 #cmakedefine ENABLE_AUDIT_LOG 1
 #cmakedefine ENABLE_FEEDBACK_DAEMON 1
 #cmakedefine ENABLE_WAL_EXT 1
+#cmakedefine ENABLE_RETENTION_PERIOD 1
 #cmakedefine ENABLE_READ_VIEW 1
 #cmakedefine ENABLE_SECURITY 1
 #cmakedefine ENABLE_COMPRESS_MODULE 1

--- a/test/box/box.lua
+++ b/test/box/box.lua
@@ -44,6 +44,7 @@ local _enterprise_keys = {
     password_enforce_specialchars = true,
     password_history_length = true,
     wal_ext = true,
+    experimental_wal_retention_period = true,
 }
 
 function cfg_filter(data)

--- a/test/unit/vclock.cc
+++ b/test/unit/vclock.cc
@@ -413,25 +413,30 @@ test_fromstring_invalid()
 	vclock_from_string(&va, (a));					\
 	vclock_from_string(&vb, (b));					\
 	vclock_from_string(&vexp, (exp));				\
-	vclock_##fun##_ignore0(&va, &vb);				\
+	vclock_##fun(&va, &vb);						\
 	is(vclock_compare(&va, &vexp), 0,				\
 	   #fun " between %s and %s is %s", a, b, exp);			\
 })
 
 int
-test_minmax_ignore0(void)
+test_minmax(void)
 {
-	plan(4);
+	plan(6);
 	header();
 
-	test(max, "{0: 1, 1: 17, 2: 3}", "{0: 10, 1: 5, 2: 7}",
+	test(max_ignore0, "{0: 1, 1: 17, 2: 3}", "{0: 10, 1: 5, 2: 7}",
 	     "{0: 1, 1: 17, 2: 7}");
-	test(min, "{0: 10, 1: 17, 2: 3}", "{0: 1, 1: 5, 2: 7}",
+	test(min_ignore0, "{0: 10, 1: 17, 2: 3}", "{0: 1, 1: 5, 2: 7}",
 	     "{0: 10, 1: 5, 2: 3}");
-	test(max, "{1: 1, 2: 1, 3: 1}", "{1: 100, 2: 100, 31: 100}",
+	test(max_ignore0, "{1: 1, 2: 1, 3: 1}", "{1: 100, 2: 100, 31: 100}",
 	     "{1: 100, 2: 100, 3: 1, 31: 100}");
-	test(min, "{1: 1, 2: 1, 3: 1}", "{1: 100, 2: 100, 31: 100}",
+	test(min_ignore0, "{1: 1, 2: 1, 3: 1}", "{1: 100, 2: 100, 31: 100}",
 	     "{1:1, 2: 1}");
+
+	test(max, "{0: 1, 1: 17, 2: 3}", "{0: 10, 1: 5, 2: 7}",
+	     "{0: 10, 1: 17, 2: 7}");
+	test(min, "{0: 10, 1: 17, 2: 3}", "{0: 1, 1: 5, 2: 7}",
+	     "{0: 1, 1: 5, 2: 3}");
 
 	footer();
 	return check_plan();
@@ -449,7 +454,7 @@ main(void)
 	test_tostring();
 	test_fromstring();
 	test_fromstring_invalid();
-	test_minmax_ignore0();
+	test_minmax();
 
 	return check_plan();
 }

--- a/test/unit/vclock.result
+++ b/test/unit/vclock.result
@@ -147,11 +147,13 @@ ok 4 - subtests
     ok 32 - fromstring "{1:20, 1:10}" => 12
 	*** test_fromstring_invalid: done ***
 ok 5 - subtests
-    1..4
-	*** test_minmax_ignore0 ***
-    ok 1 - max between {0: 1, 1: 17, 2: 3} and {0: 10, 1: 5, 2: 7} is {0: 1, 1: 17, 2: 7}
-    ok 2 - min between {0: 10, 1: 17, 2: 3} and {0: 1, 1: 5, 2: 7} is {0: 10, 1: 5, 2: 3}
-    ok 3 - max between {1: 1, 2: 1, 3: 1} and {1: 100, 2: 100, 31: 100} is {1: 100, 2: 100, 3: 1, 31: 100}
-    ok 4 - min between {1: 1, 2: 1, 3: 1} and {1: 100, 2: 100, 31: 100} is {1:1, 2: 1}
-	*** test_minmax_ignore0: done ***
+    1..6
+	*** test_minmax ***
+    ok 1 - max_ignore0 between {0: 1, 1: 17, 2: 3} and {0: 10, 1: 5, 2: 7} is {0: 1, 1: 17, 2: 7}
+    ok 2 - min_ignore0 between {0: 10, 1: 17, 2: 3} and {0: 1, 1: 5, 2: 7} is {0: 10, 1: 5, 2: 3}
+    ok 3 - max_ignore0 between {1: 1, 2: 1, 3: 1} and {1: 100, 2: 100, 31: 100} is {1: 100, 2: 100, 3: 1, 31: 100}
+    ok 4 - min_ignore0 between {1: 1, 2: 1, 3: 1} and {1: 100, 2: 100, 31: 100} is {1:1, 2: 1}
+    ok 5 - max between {0: 1, 1: 17, 2: 3} and {0: 10, 1: 5, 2: 7} is {0: 10, 1: 17, 2: 7}
+    ok 6 - min between {0: 10, 1: 17, 2: 3} and {0: 1, 1: 5, 2: 7} is {0: 1, 1: 5, 2: 3}
+	*** test_minmax: done ***
 ok 6 - subtests


### PR DESCRIPTION
Renamed to `experimental_wal_retention_period`