### PR TITLE
ci: add timeout for workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -50,6 +50,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -11,6 +11,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:debian-buster
       # Our testing expects that the init process (PID 1) will

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -50,6 +50,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -50,6 +50,8 @@ jobs:
 
     runs-on: graviton
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/debug_asan_clang.yml
+++ b/.github/workflows/debug_asan_clang.yml
@@ -51,6 +51,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-jammy-clang16
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -53,6 +53,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -10,6 +10,8 @@ jobs:
   build-push:
     runs-on: [ self-hosted, Linux, x86_64, regular ]
 
+    timeout-minutes: 60
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/etcd_integration.yml
+++ b/.github/workflows/etcd_integration.yml
@@ -13,6 +13,8 @@ jobs:
   run_tests:
     runs-on: ubuntu-20.04
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -12,6 +12,8 @@ jobs:
 
     runs-on: freebsd-${{ matrix.freebsd-version }}-mcs
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -45,6 +45,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lango-stale-reviews.yml
+++ b/.github/workflows/lango-stale-reviews.yml
@@ -13,6 +13,7 @@ jobs:
       ORGANIZATION: Tarantool
       PROJECT_ID: 83
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
 
@@ -70,6 +72,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
 
@@ -99,6 +103,8 @@ jobs:
           !contains(github.event.pull_request.labels.*.name, 'notest') )
 
     runs-on: ubuntu-20.04-self-hosted
+
+    timeout-minutes: 60
 
     container:
       image: docker.io/tarantool/testing:ubuntu-jammy

--- a/.github/workflows/luajit-integration.yml
+++ b/.github/workflows/luajit-integration.yml
@@ -50,6 +50,7 @@ on:
 jobs:
   luajit-integration:
     runs-on: [self-hosted, regular, '${{ inputs.os }}', '${{ inputs.arch }}']
+    timeout-minutes: 60
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -50,6 +50,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -14,6 +14,8 @@ jobs:
       - 'macos-${{ matrix.osx-version }}-self-hosted'
       - '${{ matrix.machine-arch }}'
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -50,6 +50,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/packaging_build_test_deploy.yml
+++ b/.github/workflows/packaging_build_test_deploy.yml
@@ -18,6 +18,8 @@ jobs:
   build:
     runs-on: [ self-hosted, Linux, '${{ inputs.arch }}', regular ]
 
+    timeout-minutes: 60
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
@@ -70,6 +72,8 @@ jobs:
 
   test:
     runs-on: [ self-hosted, Linux, '${{ inputs.arch }}', regular ]
+
+    timeout-minutes: 60
 
     needs: build
 
@@ -174,6 +178,8 @@ jobs:
         !endsWith(github.ref, '-entrypoint')
 
     runs-on: [ self-hosted, Linux, lightweight ]
+
+    timeout-minutes: 60
 
     needs: test
 

--- a/.github/workflows/perf_micro.yml
+++ b/.github/workflows/perf_micro.yml
@@ -50,6 +50,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/publish-module-api-doc.yaml
+++ b/.github/workflows/publish-module-api-doc.yaml
@@ -32,6 +32,8 @@ jobs:
   build-api-doc:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 60
+
     # Run on push to the tarantool/tarantool repository or on pull request
     # if the 'notest' label is not set.
     if: github.repository == 'tarantool/tarantool' &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/release_asan_clang.yml
+++ b/.github/workflows/release_asan_clang.yml
@@ -51,6 +51,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-jammy-clang16
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -50,6 +50,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-jammy-clang16
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -50,6 +50,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/release_lto_clang.yml
+++ b/.github/workflows/release_lto_clang.yml
@@ -50,6 +50,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-jammy-clang16
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -35,6 +35,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    timeout-minutes: 60
     env:
       OS: ${{ inputs.os }}
       DIST: ${{ inputs.dist }}

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -15,6 +15,8 @@ jobs:
 
     runs-on: ubuntu-22.04
 
+    timeout-minutes: 60
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -51,6 +51,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -51,6 +51,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/submodule_update.yml
+++ b/.github/workflows/submodule_update.yml
@@ -18,6 +18,8 @@ jobs:
 
     runs-on: [ self-hosted, Linux, x86_64, flavor-1-2 ]
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
 


### PR DESCRIPTION
Add `timeout-minutes` to workflow jobs to control max duration time. By default, each job in a workflow can run for up to 6 hours of the execution time. If a job reaches this limit, the job is terminated by GitHub automatically and fails to complete. This patch sets job timeouts to 60 minutes to avoid waiting for jobs to complete for 6 hours.