### PR TITLE
lua: add `message` argument to table constructor of `box.error.new`

### DIFF
--- a/changelogs/unreleased/gh-9102-error-new-message-arg.md
+++ b/changelogs/unreleased/gh-9102-error-new-message-arg.md
@@ -1,0 +1,4 @@
+## feature/lua
+
+* Added a `message` argument to the table constructor of `box.error.new`
+  (gh-9102).

--- a/test/box-luatest/error_subsystem_improvements_test.lua
+++ b/test/box-luatest/error_subsystem_improvements_test.lua
@@ -79,3 +79,15 @@ g.test_custom_payload = function()
         custom_type = "MyAppError",
     })
 end
+
+-- Test the `message` argument to the table constructor of `box.error.new`
+-- (gh-9102).
+g.test_error_new_message_arg = function()
+    local msg = 'message'
+    t.assert_equals(box.error.new{msg}.message, msg)
+    t.assert_equals(box.error.new{message = msg}.message, msg)
+    t.assert_equals(box.error.new{reason = msg}.message, msg)
+    t.assert_equals(box.error.new{msg, message = 'other'}.message, msg)
+    t.assert_equals(box.error.new{message = msg, reason = 'other'}.message, msg)
+    t.assert_equals(box.error.new{msg, reason = 'other'}.message, msg)
+end


### PR DESCRIPTION
This patch add a `message` option to the table constructor of `box.error.new`.

Closes #9102