### PR TITLE
[2.11] ci: add `Fedora 39`

### DIFF
--- a/.github/workflows/fedora_39.yml
+++ b/.github/workflows/fedora_39.yml
@@ -1,0 +1,84 @@
+name: fedora_39
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/**'
+    tags:
+      - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
+
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch, and
+  # tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+jobs:
+  fedora_39:
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+
+    runs-on: ubuntu-20.04-self-hosted
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build-type: [ '', 'gc64' ]
+
+    steps:
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: packaging
+        env:
+          RWS_AUTH: ${{ secrets.RWS_AUTH }}
+          OS: 'fedora'
+          DIST: '39'
+          GC64: ${{ matrix.build-type == 'gc64' }}
+        uses: ./.github/actions/pack-and-deploy
+      - name: Send VK Teams message on failure
+        if: failure()
+        uses: ./.github/actions/report-job-status
+        with:
+          bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
+      - name: artifacts
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: fedora-39${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
+          retention-days: 21
+          path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/release/') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/fedora_39_aarch64.yml
+++ b/.github/workflows/fedora_39_aarch64.yml
@@ -1,0 +1,78 @@
+name: fedora_39_aarch64
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/**'
+    tags:
+      - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
+
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch, and
+  # tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+jobs:
+  fedora_39_aarch64:
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+
+    runs-on: graviton
+
+    steps:
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: packaging
+        env:
+          RWS_AUTH: ${{ secrets.RWS_AUTH }}
+          OS: 'fedora'
+          DIST: '39'
+        uses: ./.github/actions/pack-and-deploy
+      - name: Send VK Teams message on failure
+        if: failure()
+        uses: ./.github/actions/report-job-status
+        with:
+          bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
+      - name: artifacts
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: fedora-39
+          retention-days: 21
+          path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/release/') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts


### PR DESCRIPTION
Add the fedora_39.yml and fedora_39_aarch64.yml workflow files to build Tarantool packages for x86_64 and aarch64 platforms.
    
Closes #9705