### PR TITLE
[2.11] ci: add AlmaLinux 8, 9

### DIFF
--- a/.github/workflows/almalinux_8.yml
+++ b/.github/workflows/almalinux_8.yml
@@ -1,0 +1,84 @@
+name: almalinux_8
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/**'
+    tags:
+      - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
+
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch, and
+  # tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+jobs:
+  almalinux_8:
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+
+    runs-on: ubuntu-20.04-self-hosted
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build-type: [ '', 'gc64' ]
+
+    steps:
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: packaging
+        env:
+          RWS_AUTH: ${{ secrets.RWS_AUTH }}
+          OS: 'almalinux'
+          DIST: '8'
+          GC64: ${{ matrix.build-type == 'gc64' }}
+        uses: ./.github/actions/pack-and-deploy
+      - name: Send VK Teams message on failure
+        if: failure()
+        uses: ./.github/actions/report-job-status
+        with:
+          bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
+      - name: artifacts
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: almalinux-8${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
+          retention-days: 21
+          path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/release/') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/almalinux_8_aarch64.yml
+++ b/.github/workflows/almalinux_8_aarch64.yml
@@ -1,0 +1,78 @@
+name: almalinux_8_aarch64
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/**'
+    tags:
+      - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
+
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch, and
+  # tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+jobs:
+  almalinux_8_aarch64:
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+
+    runs-on: graviton
+
+    steps:
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: packaging
+        env:
+          RWS_AUTH: ${{ secrets.RWS_AUTH }}
+          OS: 'almalinux'
+          DIST: '8'
+        uses: ./.github/actions/pack-and-deploy
+      - name: Send VK Teams message on failure
+        if: failure()
+        uses: ./.github/actions/report-job-status
+        with:
+          bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
+      - name: artifacts
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: almalinux-8
+          retention-days: 21
+          path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/release/') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/almalinux_9.yml
+++ b/.github/workflows/almalinux_9.yml
@@ -1,0 +1,84 @@
+name: almalinux_9
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/**'
+    tags:
+      - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
+
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch, and
+  # tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+jobs:
+  almalinux_9:
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+
+    runs-on: ubuntu-20.04-self-hosted
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build-type: [ '', 'gc64' ]
+
+    steps:
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: packaging
+        env:
+          RWS_AUTH: ${{ secrets.RWS_AUTH }}
+          OS: 'almalinux'
+          DIST: '9'
+          GC64: ${{ matrix.build-type == 'gc64' }}
+        uses: ./.github/actions/pack-and-deploy
+      - name: Send VK Teams message on failure
+        if: failure()
+        uses: ./.github/actions/report-job-status
+        with:
+          bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
+      - name: artifacts
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: almalinux-9${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
+          retention-days: 21
+          path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/release/') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/almalinux_9_aarch64.yml
+++ b/.github/workflows/almalinux_9_aarch64.yml
@@ -1,0 +1,78 @@
+name: almalinux_9_aarch64
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/**'
+    tags:
+      - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
+
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch, and
+  # tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+jobs:
+  almalinux_9_aarch64:
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+
+    runs-on: graviton
+
+    steps:
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: packaging
+        env:
+          RWS_AUTH: ${{ secrets.RWS_AUTH }}
+          OS: 'almalinux'
+          DIST: '9'
+        uses: ./.github/actions/pack-and-deploy
+      - name: Send VK Teams message on failure
+        if: failure()
+        uses: ./.github/actions/report-job-status
+        with:
+          bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
+      - name: artifacts
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: almalinux-9
+          retention-days: 21
+          path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/release/') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/rpm/tarantool.spec
+++ b/rpm/tarantool.spec
@@ -167,7 +167,7 @@ C and Lua/C modules.
          -DSYSTEMD_UNIT_DIR:PATH=%{_unitdir} \
          -DSYSTEMD_TMPFILES_DIR:PATH=%{_tmpfilesdir} \
 %endif
-%if 0%{?fedora} >= 33
+%if (0%{?fedora} >= 33 || 0%{?almalinux} >= 9)
          -DENABLE_LTO=ON \
 %endif
 %if %{_gc64} == "true"


### PR DESCRIPTION
Add the `almalinux_8.yml / almalinux_9.yml` and `almalinux_8_aarch64.yml / almalinux_9_aarch64.yml` workflow files to build Tarantool packages for x86_64 and aarch64 platforms.

Closes #9706
Closes #9434