### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9595-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9595-luajit-fixes.md
@@ -12,3 +12,4 @@ were fixed as part of this activity:
 * Fixed recording of `setmetatable()` with `nil` as the second argument.
 * Fixed recording of `select()` in case with negative first argument.
 * Fixed use-def analysis for child upvalues.
+* Fixed broken Lua stack on trace abort during NYI stitch recording.


### PR DESCRIPTION
Throw any errors before stack changes in trace stitching.

Part of #9595

NO_DOC=LJ
NO_TEST=LJ