### PR TITLE
ci: fix integration concurrency group

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,7 +37,7 @@ concurrency:
     startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
-    format('{0}-{1}', github.workflow, github.ref) }}
+    format('{0}-{1}-integration', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
In commit 3daf2399dd5b ("ci: fix step parameters for reusable runs") the integration workflow was made reusable, but concurrency group pattern modification that was done for other workflows made reusable in the same patch was forgotten. This patch fixes the mentioned issue.

NO_DOC=CI
NO_TEST=CI
NO_CHANGELOG=CI