### PR TITLE
[backport 3.0] lua: fix memory leak in `error_object:set_prev()`

### DIFF
--- a/changelogs/unreleased/gh-9694-memory-leak-in-error_object-set_prev.md
+++ b/changelogs/unreleased/gh-9694-memory-leak-in-error_object-set_prev.md
@@ -1,0 +1,3 @@
+## bugfix/lua
+
+* Fixed a memory leak in `error_object:set_prev()` (gh-9694).

--- a/src/lua/error.lua
+++ b/src/lua/error.lua
@@ -114,12 +114,10 @@ local function error_set_prev(err, prev)
     if not ffi.istype('struct error', prev) and prev ~= nil then
         error("Usage: error1:set_prev(error2)")
     end
-    ffi.C.error_ref(err)
     local ok = ffi.C.error_set_prev(err, prev);
     if ok ~= 0 then
         error("Cycles are not allowed")
     end
-
 end
 
 local error_fields = {


### PR DESCRIPTION
By design, the error references its cause, see error_set_prev() in diag.c. Referencing the error from error_set_prev() in error.lua is wrong. Introduced by commit 2e3c81deea50 ("error: use int64_t as reference counter").

Closes #9694

NO_DOC=bugfix
NO_TEST=memory leak

(cherry picked from commit d08dbcbf09842a0223887364f2b80caf3c23f129)