### PR TITLE
box/lua: allow to set error cause via `prev` argument

### DIFF
--- a/changelogs/unreleased/gh-9103-error-new-prev-arg.md
+++ b/changelogs/unreleased/gh-9103-error-new-prev-arg.md
@@ -1,0 +1,3 @@
+## feature/lua
+
+* Added a `prev` argument to the table constructor of `box.error.new` (gh-9103).


### PR DESCRIPTION
Currently, it's only possible to set an error cause with the set_prev method. This isn't very convenient, because one has to construct a new error without raising it, then set its cause, and only then raise it. To simplify this, a new argument `prev` is added to the error constructor.

Closes #9103

[Link to the design document](https://www.notion.so/tarantool/Error-subsystem-improvements-90faa0a4714b4143abaf8bed2c10b2fc?pvs=4#c72c870f24734020aae1fbf34e2b8569)