### PR TITLE
[backport 3.0] config: fix wrong status after setting permissions

### DIFF
--- a/src/box/lua/config/utils/aboard.lua
+++ b/src/box/lua/config/utils/aboard.lua
@@ -92,6 +92,13 @@ local function aboard_drop_if(self, filter_f)
     end
 end
 
+-- Traverse all alerts and apply the provided callback function to each of them.
+local function aboard_each(self, callback)
+    for key, alert in pairs(self._alerts) do
+        callback(key, alert)
+    end
+end
+
 -- Drop all the alerts.
 --
 -- The `on_drop` callback is NOT called.
@@ -156,6 +163,7 @@ local mt = {
     __index = {
         set = aboard_set,
         get = aboard_get,
+        each = aboard_each,
         drop = aboard_drop,
         drop_if = aboard_drop_if,
         clean = aboard_clean,


### PR DESCRIPTION
*(This is backport of PR #9691 to the `release/3.0` branch -- future `3.0.2` release.)*

----

Before this patch, it was possible that the config status could change to 'ready' even if there were pending alerts. This could happen if there were 'missed_privilege' warnings. Before this patch, warnings were cleared and then refilled if necessary. However, after clearing all these warnings, if there were no other warnings, the status was set to 'ready'. And if new warnings were added during the 'refilling' stage, the status did not change from 'ready' to 'check_warnings' or 'check_errors'.

Part of #9689