### PR TITLE
fiber: allow creating system fibers during shutdown

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -263,6 +263,10 @@ static bool box_feedback_crash_enabled;
 static double box_shutdown_timeout = BOX_SHUTDOWN_TIMEOUT_DEFAULT;
 TWEAK_DOUBLE(box_shutdown_timeout);
 
+/** Idle timeout for box fiber pool. */
+static double box_fiber_pool_idle_timeout = FIBER_POOL_IDLE_TIMEOUT;
+TWEAK_DOUBLE(box_fiber_pool_idle_timeout);
+
 static int
 box_run_on_recovery_state(enum box_recovery_state state)
 {
@@ -5898,7 +5902,7 @@ box_storage_init(void)
 	/* Join the cord interconnect as "tx" endpoint. */
 	fiber_pool_create(&tx_fiber_pool, "tx",
 			  IPROTO_MSG_MAX_MIN * IPROTO_FIBER_POOL_SIZE_FACTOR,
-			  FIBER_POOL_IDLE_TIMEOUT);
+			  box_fiber_pool_idle_timeout);
 	/* Add an extra endpoint for WAL wake up/rollback messages. */
 	cbus_endpoint_create(&tx_prio_endpoint, "tx_prio", tx_prio_cb,
 			     &tx_prio_endpoint);

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -1552,7 +1552,7 @@ fiber_new_ex(const char *name, const struct fiber_attr *fiber_attr,
 	assert(fiber_attr != NULL);
 	cord_collect_garbage(cord);
 
-	if (cord->is_shutdown) {
+	if (cord->is_shutdown && !(fiber_attr->flags & FIBER_IS_SYSTEM)) {
 		diag_set(FiberIsCancelled);
 		return NULL;
 	}

--- a/test/unit/fiber.cc
+++ b/test/unit/fiber.cc
@@ -703,6 +703,12 @@ new_fiber_on_shudown_f(va_list ap)
 	fail_unless(!diag_is_empty(diag_get()));
 	fail_unless(strcmp(diag_last_error(diag_get())->errmsg,
 			   "fiber is cancelled") == 0);
+	struct fiber *system_fiber =
+			fiber_new_system("system_fiber_on_shutdown", noop_f);
+	fail_unless(system_fiber != NULL);
+	fiber_set_joinable(system_fiber, true);
+	fiber_start(system_fiber);
+	fiber_join(system_fiber);
 	return 0;
 }
 


### PR DESCRIPTION
In the commit d40ce0fa028a ("core: disable fibers creation after shutdown started") we disable creation of new fibers in the process of shutdown. This may cause subsystem shutdown hanging.

The thing is we need fiber pool working during shutdown. For example vinyl engine uses it through "tx" endpoint. Fibers in the pool are finished after idle timeout. So we may have a situation when there is no idle fibers in the pool and we cannot create a new one.

Part of #8423