### PR TITLE
lua: increase error serialization verbosity

### DIFF
--- a/changelogs/unreleased/gh-9105-increase-error-serialization-verbosity.md
+++ b/changelogs/unreleased/gh-9105-increase-error-serialization-verbosity.md
@@ -1,0 +1,5 @@
+## feature/lua
+
+* Increased the verbosity of `box.error`s serialization and added a new
+  `box_error_serialize_verbose` option to `compat` to retain old behaviour
+  (gh-9105).

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2357,6 +2357,12 @@ return schema.new('instance_config', schema.record({
         }, {
             default = 'old',
         }),
+        box_error_serialize_verbose = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'old',
+        }),
     }),
 }, {
     -- This kind of validation cannot be implemented as the

--- a/src/lua/compat.lua
+++ b/src/lua/compat.lua
@@ -119,6 +119,14 @@ shown if it is 0. Note that 'base_type' is still accessible for error object.
 https://tarantool.io/compat/box_error_unpack_type_and_code
 ]]
 
+local BOX_ERROR_SERIALIZE_VERBOSE = [[
+Controls the verbosity of box.error's serialization. Before, only the error
+message was serialized, omitting all other potentially useful fields. Now, a
+more verbose representation is used.
+
+https://tarantool.io/compat/box_error_serialize_verbose
+]]
+
 -- Returns an action callback that toggles a tweak.
 local function tweak_action(tweak_name, old_tweak_value, new_tweak_value)
     return function(is_new)
@@ -224,6 +232,12 @@ local options = {
         brief = BOX_ERROR_UNPACK_TYPE_AND_CODE_BRIEF,
         action = function() end
     },
+    box_error_serialize_verbose = {
+        default = 'old',
+        obsolete = nil,
+        brief = BOX_ERROR_SERIALIZE_VERBOSE,
+        action = function() end,
+    }
 }
 
 -- Array with option names in order of addition.

--- a/src/lua/msgpack.c
+++ b/src/lua/msgpack.c
@@ -342,8 +342,9 @@ restart: /* used by MP_EXT of unidentified subtype */
 			break;
 		case MP_ERROR:
 			if (!cfg->encode_error_as_ext) {
-				field->ext_type = MP_UNKNOWN_EXTENSION;
-				goto convert;
+				mpstream_encode_str(stream,
+						    field->errorval->errmsg);
+				break;
 			}
 			bool is_encoded = luamp_encode_extension(L, top, stream,
 								 ctx, &type);
@@ -370,7 +371,6 @@ restart: /* used by MP_EXT of unidentified subtype */
 				/* Value has been packed by the trigger */
 				break;
 			}
-convert:
 			/* Try to convert value to serializable type */
 			if (luaL_convertfield(L, cfg, top, field) != 0)
 				goto error;

--- a/src/lua/serializer.c
+++ b/src/lua/serializer.c
@@ -611,7 +611,7 @@ luaL_convertfield(struct lua_State *L, struct luaL_serializer *cfg, int idx,
 {
 	if (idx < 0)
 		idx = lua_gettop(L) + idx + 1;
-	assert(field->type == MP_EXT && field->ext_type == MP_UNKNOWN_EXTENSION); /* must be called after tofield() */
+	assert(field->type == MP_EXT); /* must be called after tofield() */
 
 	if (cfg->encode_load_metatables) {
 		int type = lua_type(L, idx);

--- a/src/lua/serializer.h
+++ b/src/lua/serializer.h
@@ -330,7 +330,7 @@ luaL_checkfield(struct lua_State *L, struct luaL_serializer *cfg, int idx,
 {
 	if (luaL_tofield(L, cfg, idx, field) < 0)
 		luaT_error(L);
-	if (field->type != MP_EXT || field->ext_type != MP_UNKNOWN_EXTENSION)
+	if (field->type != MP_EXT)
 		return;
 	if (luaL_convertfield(L, cfg, idx, field) != 0)
 		luaT_error(L);

--- a/test/box/net.box_error_extension_feature.result
+++ b/test/box/net.box_error_extension_feature.result
@@ -49,26 +49,22 @@ type(c:eval('return box.error.new(box.error.UNKNOWN)')) -- string
 ---
 - string
 ...
--- msgpack.cfg options are applied to CALL result
-encode_load_metatables = msgpack.cfg.encode_load_metatables
----
-...
-encode_use_tostring = msgpack.cfg.encode_use_tostring
+-- msgpack.cfg options are applied to CALL result (i.e., msgpack.cfg options are
+-- propagated to the `call_serializer_no_error_ext` serializer).
+encode_invalid_numbers = msgpack.cfg.encode_invalid_numbers
 ---
 ...
 msgpack.cfg{                                                                \
-    encode_load_metatables = false,                                         \
-    encode_use_tostring = false,                                            \
+    encode_invalid_numbers = false,                                         \
 }
 ---
 ...
-type(c:eval('return box.error.new(box.error.UNKNOWN)')) -- error
+type(c:eval('return 0/0')) -- error
 ---
-- error: unsupported Lua type 'cdata'
+- error: number must not be NaN or Inf
 ...
 msgpack.cfg{                                                                \
-    encode_load_metatables = encode_load_metatables,                        \
-    encode_use_tostring = encode_use_tostring,                              \
+    encode_invalid_numbers = encode_invalid_numbers,                        \
 }
 ---
 ...

--- a/test/box/net.box_error_extension_feature.test.lua
+++ b/test/box/net.box_error_extension_feature.test.lua
@@ -17,17 +17,15 @@ errinj.set('ERRINJ_NETBOX_DISABLE_ID', false)
 errinj.set('ERRINJ_NETBOX_FLIP_FEATURE', 2) -- clear error_extension feature
 c = net.connect(box.cfg.listen)
 type(c:eval('return box.error.new(box.error.UNKNOWN)')) -- string
--- msgpack.cfg options are applied to CALL result
-encode_load_metatables = msgpack.cfg.encode_load_metatables
-encode_use_tostring = msgpack.cfg.encode_use_tostring
+-- msgpack.cfg options are applied to CALL result (i.e., msgpack.cfg options are
+-- propagated to the `call_serializer_no_error_ext` serializer).
+encode_invalid_numbers = msgpack.cfg.encode_invalid_numbers
 msgpack.cfg{                                                                \
-    encode_load_metatables = false,                                         \
-    encode_use_tostring = false,                                            \
+    encode_invalid_numbers = false,                                         \
 }
-type(c:eval('return box.error.new(box.error.UNKNOWN)')) -- error
+type(c:eval('return 0/0')) -- error
 msgpack.cfg{                                                                \
-    encode_load_metatables = encode_load_metatables,                        \
-    encode_use_tostring = encode_use_tostring,                              \
+    encode_invalid_numbers = encode_invalid_numbers,                        \
 }
 c:close()
 errinj.set('ERRINJ_NETBOX_FLIP_FEATURE', -1)

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -330,6 +330,7 @@ g.test_defaults = function()
             yaml_pretty_multiline = 'new',
             fiber_channel_close_mode = 'new',
             box_cfg_replication_sync_timeout = 'new',
+            box_error_serialize_verbose = 'old',
             sql_seq_scan_default = 'new',
             fiber_slice_default = 'new',
             box_info_cluster_meaning = 'new',


### PR DESCRIPTION
This patch increases error serialization verbosity.

Closes #9105