### PR TITLE
iproto: fix assertion on dropping of a new connection

### DIFF
--- a/changelogs/unreleased/gh-9717-fix-crash-on-new-connection-drop.md
+++ b/changelogs/unreleased/gh-9717-fix-crash-on-new-connection-drop.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fixed a crash on dropping a just accepted connection (gh-9717).


### PR DESCRIPTION
We need to handle case of dropping new connection. When `net_send_greeting()` is executed the connection can be closed due to `iproto_drop_connections()` call.

Note that in the test the Tarantool crashes for another reason. Due to access after sleep to the connection that is destroyed so its memory is poisoned. Yet we visit `net_send_greeting()` too in the test with patch so original issue is verified too. We also need to test that such a connection is closed. This will be done in EE version.

Closes #9717

There is an additional test in the EE PR https://github.com/tarantool/tarantool-ee/pull/692