### PR TITLE
build/lua: add TEST_BUILD define/tarantool.build flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -818,7 +818,7 @@ elseif(IS_DIRECTORY .git AND GIT)
     )
 endif()
 
-option(TEST_BUILD "Abort if memory leak is found." OFF)
+option(TEST_BUILD "Use defaults suited for tests" OFF)
 set(ABORT_ON_LEAK_DEFAULT ${TEST_BUILD})
 option(ABORT_ON_LEAK "Abort if memory leak is found." ${ABORT_ON_LEAK_DEFAULT})
 

--- a/changelogs/unreleased/add-test-build-flag-to-tarantool-build.md
+++ b/changelogs/unreleased/add-test-build-flag-to-tarantool-build.md
@@ -1,0 +1,4 @@
+## feature/box
+
+* Added a new flag `tarantool.build.test_build` that shows whether a build
+  flag `TEST_BUILD` is set.

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -658,6 +658,15 @@ luaopen_tarantool(lua_State *L)
 #endif
 	lua_settable(L, -3);
 
+	/* build.test_build */
+	lua_pushstring(L, "test_build");
+#ifdef TEST_BUILD
+	lua_pushboolean(L, true);
+#else
+	lua_pushboolean(L, false);
+#endif
+	lua_settable(L, -3);
+
 	lua_settable(L, -3);    /* box.info.build */
 
 	/* debug */

--- a/src/trivia/config.h.cmake
+++ b/src/trivia/config.h.cmake
@@ -299,6 +299,7 @@
 #cmakedefine BUILD_STATIC 1
 #cmakedefine EMBED_LUAZLIB 1
 #cmakedefine EMBED_LUAZIP 1
+#cmakedefine TEST_BUILD 1
 
 /*
  * vim: syntax=c

--- a/test/app-luatest/tarantool_package_test.lua
+++ b/test/app-luatest/tarantool_package_test.lua
@@ -8,3 +8,8 @@ g.test_build_asan = function()
     local asan = b.flags:match('-fsanitize=[%a,]*address') ~= nil
     t.assert_equals(b.asan, asan)
 end
+
+g.test_build_test_build = function()
+    local b = tarantool.build
+    t.assert_equals(type(b.test_build), 'boolean')
+end


### PR DESCRIPTION
In the commit 22d507d5e968 ("iproto: don't hang on uncancellable iproto request") we used `TEST_BUILD` define which is absent, we only have a CMake build option with such name. Let's add a define too.

While at it let's also show this flag in the `tarantool.build` table.

Follow-up #8423