### PR TITLE
Remove LuaJIT-related CLI tests

### DIFF
--- a/test/box-py/args.result
+++ b/test/box-py/args.result
@@ -338,28 +338,3 @@ arg[2] => 2
 arg[3] => 3
 arg[4] => --help
 
--b
-Save LuaJIT bytecode: luajit -b[options] input output
-  -l        Only list bytecode.
-  -s        Strip debug info (default).
-  -g        Keep debug info.
-  -n name   Set module name (default: auto-detect from input name).
-  -t type   Set output file type (default: auto-detect from output name).
-  -a arch   Override architecture for object files (default: native).
-  -o os     Override OS for object files (default: native).
-  -e chunk  Use chunk string as input.
-  --        Stop handling options.
-  -         Use stdin as input and/or stdout as output.
-
-File types: c h obj o raw (default)
--bl -e ''
--- BYTECODE -- "":0-1
-0001    RET0     0   1
-
--b -l -e ''
--- BYTECODE -- "":0-1
-0001    RET0     0   1
-
--b -e '' output
--jon -e ''
--j on -e ''

--- a/test/box-py/args.test.py
+++ b/test/box-py/args.test.py
@@ -61,16 +61,4 @@ server.test_option("-e \"print(rawget(_G, 'log') == nil)\" " + \
                    script + \
                    " 1 2 3 --help")
 
-b_cmds = ["-b", "-bl -e ''", "-b -l -e ''", "-b -e '' output"]
-for cmd in b_cmds:
-    res = server.test_option_get(cmd, silent=True)
-    print(cmd)
-    print(res, end='')
-
-j_cmds = ["-jon -e ''", "-j on -e ''"]
-for cmd in j_cmds:
-    res = server.test_option_get(cmd, silent=True)
-    assert res == ""
-    print(cmd)
-
 sys.stdout.clear_all_filters()


### PR DESCRIPTION
There are two reasons for this changeset:

* The positive one: Tarantool supports -b and -j options to use LuaJIT modules since the commit bf8b76a4dfc9dd62d4131e90e2ae5d83843b6630 ("lua: proxy -j and -b flags"), so the related tests from lua-Harness suite can be partially (since -O option is still not implemented in Tarantool) enabled.

* The negative one: Tarantool diff-based tests for CLI interfaces are hard to maintain, if any change occurs in LuaJIT modules, since the aforementioned tests implement dumb comparison of the output, produced by the current CLI version against the expected one, provided by the .result file. Hence, to rule the tests related to LuaJIT CLI interface in a more convenient way, the corresponding tests should be moved from the tests in Tarantool repository to the tests in LuaJIT repository.

The recent LuaJIT bump landed to the master in scope of the commit 0dcf675952fbb76d8cfb6de30b680451d56cdf43 ("luajit: bump new version") enables the nice checks implemented in the lua-Harness suite; this patch removes the barely maintainable diff-based tests from Tarantool repo.

NO_DOC=test
NO_CHANGELOG=test