### PR TITLE
config: add ordered dictionary (internal module)

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -62,6 +62,7 @@ lua_source(lua_sources lua/config/utils/aboard.lua        config_utils_aboard_lu
 lua_source(lua_sources lua/config/utils/expression.lua    config_utils_expression_lua)
 lua_source(lua_sources lua/config/utils/file.lua          config_utils_file_lua)
 lua_source(lua_sources lua/config/utils/log.lua           config_utils_log_lua)
+lua_source(lua_sources lua/config/utils/odict.lua         config_utils_odict_lua)
 lua_source(lua_sources lua/config/utils/schema.lua        config_utils_schema_lua)
 lua_source(lua_sources lua/config/utils/snapshot.lua      config_utils_snapshot_lua)
 lua_source(lua_sources lua/config/utils/tabulate.lua      config_utils_tabulate_lua)

--- a/src/box/lua/config/utils/odict.lua
+++ b/src/box/lua/config/utils/odict.lua
@@ -1,0 +1,213 @@
+-- Ordered dictionary.
+--
+-- The collection tracks the order in which the items are added
+-- and provides odict.pairs() function to get them in this order.
+--
+-- The ordered dictionary is a usual Lua table with a specific
+-- metatable. All the table operations are applicable.
+--
+-- It is similar to Python's collections.OrderedDict.
+--
+-- Example:
+--
+--  | local od = odict.new()
+--  |
+--  | od.a = 1
+--  | od.b = 2
+--  | od.c = 3
+--  |
+--  | print('od.a', od.a) -- 1
+--  | print('od.b', od.b) -- 2
+--  | print('od.c', od.c) -- 3
+--  |
+--  | for k, v in odict.pairs(od) do
+--  |     print(k, v)
+--  | end
+--  | -- print: a, 1
+--  | -- print: b, 2
+--  | -- print: c, 3
+--
+-- If an element is deleted and added again, it is added to the
+-- end.
+--
+--  | local od = odict.new()
+--  |
+--  | od.a = 1
+--  | od.b = 2
+--  | od.c = 3
+--  |
+--  | od.b = nil
+--  | od.b = 4
+--  |
+--  | for k, v in odict.pairs(od) do
+--  |     print(k, v)
+--  | end
+--  | -- print: a, 1
+--  | -- print: c, 3
+--  | -- print: b, 4
+--
+-- If an element is changed (without prior deletion), it remains
+-- on the same position.
+--
+-- Beware: console shows the fields as unordered. The same for the
+-- serialization into JSON/YAML/MessagePack formats. It should be
+-- solved after gh-9747.
+
+local REINDEX_THRESHOLD = 1000
+
+local registry = setmetatable({}, {__mode = 'k'})
+
+-- Generator function for odict.pairs().
+--
+-- Returns (key, value).
+local function gen(od, prev_key)
+    local ctx = registry[od]
+
+    -- The previous key is nil only on the first call of the
+    -- generator function.
+    local id = prev_key == nil and 0 or ctx.key2id[prev_key]
+    -- NB: This assert doesn't catch all the kinds of changes
+    -- during an iteration. It rather verifies a precondition
+    -- for the following cycle.
+    assert(id ~= nil, 'ordered dictionary is changed during iteration')
+
+    while id <= ctx.max_id do
+        id = id + 1
+        local key = ctx.id2key[id]
+        -- id2key may have holes for IDs <= max_id in place of
+        -- deleted items.
+        --
+        -- id2key may contain a stalled entry, because __newindex
+        -- is not called on assignment of an existing field,
+        -- including assignment to nil.
+        if key ~= nil and od[key] ~= nil then
+            return key, od[key]
+        end
+    end
+end
+
+-- Returns a Lua iterator triplet (gen, param, state).
+--
+-- Usage:
+--
+--  | for k, v in odict.pairs(od) do
+--  |     <...>
+--  | end
+--
+-- The iterator stability guarantees are the same as for usual
+-- pairs().
+--
+-- Quote from the Lua 5.1 reference manual:
+--
+-- > The behavior of `next` is undefined if, during the traversal,
+-- > you assign any value to a non-existent field in the table.
+-- > You may however modify existing fields. In particular, you
+-- > may clear existing fields.
+local function _pairs(od)
+    return gen, od, nil
+end
+
+-- Delete the key from the id<->key mappings.
+local function release(ctx, key)
+    local id = ctx.key2id[key]
+    if id ~= nil then
+        ctx.key2id[key] = nil
+        ctx.id2key[id] = nil
+
+        -- No need to grow the IDs if the same key is assigned and
+        -- deleted in a loop.
+        --
+        -- for <...> do
+        --     od.x = 'x'
+        --     od.x = nil
+        -- end
+        if id == ctx.max_id then
+            ctx.max_id = ctx.max_id - 1
+        end
+    end
+end
+
+-- Track the new key in the id<->key mappings.
+local function track(ctx, key)
+    local id = ctx.max_id + 1
+    ctx.id2key[id] = key
+    ctx.key2id[key] = id
+    ctx.max_id = id
+end
+
+-- Renew the id<->key mappings to eliminate holes.
+local function reindex(od, ctx)
+    -- This cycle reassigns IDs in the following way.
+    --
+    --    1     2     3     4
+    -- | foo | nil | bar | baz |
+    --          ^    | ^    |
+    --          +----+ +----+
+    local old_max_id = ctx.max_id
+    ctx.max_id = 0
+    for id = 1, old_max_id do
+        local key = ctx.id2key[id]
+        -- Drop the given key-id pair from the key<->id mappings.
+        if key ~= nil then
+            release(ctx, key)
+        end
+        -- Add the new key-id pair into the key<->id mappings.
+        if key ~= nil and od[key] ~= nil then
+            track(ctx, key)
+        end
+    end
+end
+
+local mt = {
+    __newindex = function(self, k, v)
+        local ctx = registry[self]
+
+        -- __newindex is never called on an existing field of a
+        -- table.
+        assert(rawget(self, k) == nil)
+
+        -- If a field with this key had existed, we should update
+        -- the key<->id mappings to let gen() know the new order.
+        release(ctx, k)
+
+        -- If a non-existing field is assigned to nil, we have
+        -- nothing to do.
+        if type(v) == 'nil' then
+            return
+        end
+
+        -- Add the value.
+        track(ctx, k)
+        rawset(self, k, v)
+
+        ctx.reindex_countdown = ctx.reindex_countdown - 1
+        assert(ctx.reindex_countdown >= 0)
+
+        -- We can't track density, because __newindex is not
+        -- called on assigning an existing field to nil.
+        --
+        -- Let's reindex every N assignments of a new non-nil
+        -- field, where N is the size of the dictionary (but not
+        -- less than REINDEX_THRESHOLD).
+        if ctx.reindex_countdown == 0 then
+            reindex(self, ctx)
+            ctx.reindex_countdown = math.max(ctx.max_id, REINDEX_THRESHOLD)
+        end
+    end,
+}
+
+local function new()
+    local res = setmetatable({}, mt)
+    registry[res] = {
+        id2key = {},
+        key2id = {},
+        max_id = 0,
+        reindex_countdown = REINDEX_THRESHOLD,
+    }
+    return res
+end
+
+return {
+    new = new,
+    pairs = _pairs,
+}

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -166,6 +166,7 @@ extern char session_lua[],
 	config_utils_expression_lua[],
 	config_utils_file_lua[],
 	config_utils_log_lua[],
+	config_utils_odict_lua[],
 	config_utils_schema_lua[],
 	config_utils_snapshot_lua[],
 	config_utils_tabulate_lua[]
@@ -349,6 +350,10 @@ static const char *lua_sources[] = {
 	"config/utils/log",
 	"internal.config.utils.log",
 	config_utils_log_lua,
+
+	"config/utils/odict",
+	"internal.config.utils.odict",
+	config_utils_odict_lua,
 
 	"config/utils/aboard",
 	"internal.config.utils.aboard",

--- a/test/config-luatest/odict_test.lua
+++ b/test/config-luatest/odict_test.lua
@@ -1,0 +1,393 @@
+local fun = require('fun')
+local odict = require('internal.config.utils.odict')
+local t = require('luatest')
+
+local g = t.group()
+
+g.test_set_get = function()
+    local od = odict.new()
+
+    od.a = 1
+    od.b = 2
+    od.c = 3
+
+    t.assert_equals(od.a, 1)
+    t.assert_equals(od.b, 2)
+    t.assert_equals(od.c, 3)
+end
+
+g.test_delete_non_existing = function()
+    local od = odict.new()
+
+    od.a = nil
+
+    t.assert_equals(od.a, nil)
+end
+
+g.test_delete = function()
+    local od = odict.new()
+
+    od.a = 1
+    od.b = 2
+    od.c = 3
+
+    od.b = nil
+
+    t.assert_equals(od.a, 1)
+    t.assert_equals(od.b, nil)
+    t.assert_equals(od.c, 3)
+end
+
+g.test_pairs = function()
+    local od = odict.new()
+
+    od.a = 1
+    od.b = 2
+    od.c = 3
+
+    local res = {}
+    for k, v in odict.pairs(od) do
+        table.insert(res, {k, v})
+    end
+    t.assert_equals(res, {
+        {'a', 1},
+        {'b', 2},
+        {'c', 3},
+    })
+end
+
+g.test_pairs_set = function()
+    local od = odict.new()
+
+    od.a = 1
+    od.b = 2
+    od.c = 3
+
+    od.b = 2.1
+
+    local res = {}
+    for k, v in odict.pairs(od) do
+        table.insert(res, {k, v})
+    end
+    t.assert_equals(res, {
+        {'a', 1},
+        {'b', 2.1},
+        {'c', 3},
+    })
+end
+
+
+g.test_pairs_delete = function()
+    local od = odict.new()
+
+    od.a = 1
+    od.b = 2
+    od.c = 3
+
+    od.b = nil
+
+    local res = {}
+    for k, v in odict.pairs(od) do
+        table.insert(res, {k, v})
+    end
+    t.assert_equals(res, {
+        {'a', 1},
+        {'c', 3},
+    })
+end
+
+g.test_pairs_delete_and_set = function()
+    local od = odict.new()
+
+    od.a = 1
+    od.b = 2
+    od.c = 3
+
+    od.b = nil
+    od.b = 4
+
+    local res = {}
+    for k, v in odict.pairs(od) do
+        table.insert(res, {k, v})
+    end
+    t.assert_equals(res, {
+        {'a', 1},
+        {'c', 3},
+        {'b', 4},
+    })
+end
+
+-- {{{ Helpers for reindexing test cases
+
+-- Parse a range expressed like Python's slice operator.
+--
+-- '1:3000' -> 1, 3000
+-- '1:3000:2' -> 1, 3000, 2
+--
+-- The result is suitable to pass into fun.range().
+local function parse_range(s)
+    local start, stop, step = unpack(s:split(':', 2))
+    start = tonumber(start)
+    stop = tonumber(stop)
+    step = tonumber(step)
+    return start, stop, step
+end
+
+-- Generate a value based on the given prefix and the given key.
+local function gen_value(prefix, key)
+    return ('%s-%s'):format(prefix, key)
+end
+
+local slice_mt = {
+    __newindex = function(self, k, v)
+        fun.range(parse_range(k)):each(function(k)
+            if type(v) == 'nil' then
+                self.od[k] = nil
+            else
+                self.od[k] = gen_value(v, k)
+            end
+        end)
+    end,
+}
+
+-- Bulk assign values to a table using a slicing operator, similar
+-- to Python's one.
+local function slice(od)
+    return setmetatable({od = od}, slice_mt)
+end
+
+-- Verify that the ordered dictionary returns given values in the
+-- given order.
+--
+-- The values are described in the following way.
+--
+-- {
+--     '<range> <prefix>',
+--     ...
+-- }
+--
+-- <range> is a start:stop or a start:stop:step string, see
+-- parse_range().
+--
+-- <prefix> is a value prefix, see gen_value().
+local function check(od, values)
+    local res = {}
+    for k, v in odict.pairs(od) do
+        table.insert(res, {k, v})
+    end
+
+    local exp = {}
+    for _, v in ipairs(values) do
+        local range_str, prefix = unpack(v:split(' ', 1))
+        fun.range(parse_range(range_str)):each(function(k)
+            table.insert(exp, {k, gen_value(prefix, k)})
+        end)
+    end
+
+    t.assert_equals(res, exp)
+end
+
+-- Access the internal registry of ordered dictionaries.
+local function registry()
+    for i = 1, debug.getinfo(odict.new).nups do
+        local name, var = debug.getupvalue(odict.new, i)
+        if name == 'registry' then
+            return var
+        end
+    end
+    assert(false)
+end
+
+-- Look on the maximum ID in the internal key<->id mappings.
+--
+-- Useful to verify that the reindexing actually occurs.
+local function max_id(od)
+    return registry()[od].max_id
+end
+
+-- }}} Helpers for reindexing test cases
+
+-- {{{ Reindexing test cases
+
+-- Fill 6000 values, clear first 3000, fill 3000 more. Verify that
+-- the order is correct for all the remaining values.
+--
+-- Sketchy illustration of these assignments is below.
+--
+--         1 .. 3000 .. 6000 .. 9000
+-- step 1   aaaa
+-- step 2   aaaa    bbbb
+-- step 3           bbbb
+-- step 4           bbbb    cccc
+--
+-- The expected order is bbbb cccc.
+g.test_reindex_delete_head = function()
+    local od = odict.new()
+
+    slice(od)['1:3000'] = 'aaaa'
+    slice(od)['3001:6000'] = 'bbbb'
+    slice(od)['1:3000'] = nil
+    slice(od)['6001:9000'] = 'cccc'
+
+    check(od, {
+        '3001:6000 bbbb',
+        '6001:9000 cccc',
+    })
+    t.assert_equals(max_id(od), 6000)
+end
+
+-- Fill 6000 values, clear first 3000, fill 3000 more, reassign
+-- first 3000 ones. Verify that the order is correct for all
+-- the remaining values.
+--
+-- Sketchy illustration of these assignments is below.
+--
+--         1 .. 3000 .. 6000 .. 9000
+-- step 1   aaaa
+-- step 2   aaaa    bbbb
+-- step 3           bbbb
+-- step 4           bbbb    cccc
+-- step 5   dddd    bbbb    cccc
+--
+-- The expected order is bbbb cccc dddd.
+g.test_reindex_reassing_head = function()
+    local od = odict.new()
+
+    slice(od)['1:3000'] = 'aaaa'
+    slice(od)['3001:6000'] = 'bbbb'
+    slice(od)['1:3000'] = nil
+    slice(od)['6001:9000'] = 'cccc'
+    slice(od)['1:3000'] = 'dddd'
+
+    check(od, {
+        '3001:6000 bbbb',
+        '6001:9000 cccc',
+        '1:3000 dddd',
+    })
+    t.assert_equals(max_id(od), 9000)
+end
+
+-- Fill 6000 values, clear last 3000 ones, fill 3000 more. Verify
+-- that the order is correct for all the remaining values.
+--
+-- Sketchy illustration of these assignments is below.
+--
+--         1 .. 3000 .. 6000 .. 9000
+-- step 1   aaaa
+-- step 2   aaaa    bbbb
+-- step 3   aaaa
+-- step 4   aaaa            cccc
+--
+-- The expected order is aaaa cccc.
+g.test_reindex_delete_middle = function()
+    local od = odict.new()
+
+    slice(od)['1:3000'] = 'aaaa'
+    slice(od)['3001:6000'] = 'bbbb'
+    slice(od)['3001:6000'] = nil
+    slice(od)['6001:9000'] = 'cccc'
+
+    check(od, {
+        '1:3000 aaaa',
+        '6001:9000 cccc',
+    })
+    t.assert_equals(max_id(od), 6000)
+end
+
+-- Fill 6000 values, clear last 3000 ones, fill 3000 more,
+-- reassing the cleared values. Verify that the order is
+-- correct for all the remaining values.
+--
+-- Sketchy illustration of these assignments is below.
+--
+--         1 .. 3000 .. 6000 .. 9000
+-- step 1   aaaa
+-- step 2   aaaa    bbbb
+-- step 3   aaaa
+-- step 4   aaaa            cccc
+-- step 5   aaaa    dddd    cccc
+--
+-- The expected order is aaaa cccc dddd.
+g.test_reindex_reassign_middle = function()
+    local od = odict.new()
+
+    slice(od)['1:3000'] = 'aaaa'
+    slice(od)['3001:6000'] = 'bbbb'
+    slice(od)['3001:6000'] = nil
+    slice(od)['6001:9000'] = 'cccc'
+    slice(od)['3001:6000'] = 'dddd'
+
+    check(od, {
+        '1:3000 aaaa',
+        '6001:9000 cccc',
+        '3001:6000 dddd',
+    })
+    t.assert_equals(max_id(od), 9000)
+end
+
+-- Fill 9000 values, clear the last 3000 ones. Verify that the
+-- order is correct for all the remaining values.
+--
+-- Sketchy illustration of these assignments is below.
+--
+--         1 .. 3000 .. 6000 .. 9000
+-- step 1   aaaa
+-- step 2   aaaa    bbbb
+-- step 3           bbbb    cccc
+-- step 4           bbbb
+--
+-- The expected order is aaaa bbbb.
+g.test_reindex_delete_tail = function()
+    local od = odict.new()
+
+    slice(od)['1:3000'] = 'aaaa'
+    slice(od)['3001:6000'] = 'bbbb'
+    slice(od)['6001:9000'] = 'cccc'
+    slice(od)['6001:9000'] = nil
+
+    check(od, {
+        '1:3000 aaaa',
+        '3001:6000 bbbb',
+    })
+
+    -- This test case doesn't involve reindexing after deletion of
+    -- the 6001:9000 fields. So, we check the order of remaining
+    -- values and don't check the maximum ID in the internal
+    -- key<->id mappings.
+end
+
+-- Fill 9000 values, clear the last 3000 ones, then reassign them.
+-- Verify that the order is correct for all the remaining values.
+--
+-- Sketchy illustration of these assignments is below.
+--
+--         1 .. 3000 .. 6000 .. 9000
+-- step 1   aaaa
+-- step 2   aaaa    bbbb
+-- step 3           bbbb    cccc
+-- step 4           bbbb
+-- step 5           bbbb    dddd
+--
+-- The expected order is aaaa bbbb dddd.
+g.test_reindex_reassign_tail = function()
+    local od = odict.new()
+
+    slice(od)['1:3000'] = 'aaaa'
+    slice(od)['3001:6000'] = 'bbbb'
+    slice(od)['6001:9000'] = 'cccc'
+    slice(od)['6001:9000'] = nil
+    slice(od)['6001:9000'] = 'dddd'
+
+    check(od, {
+        '1:3000 aaaa',
+        '3001:6000 bbbb',
+        '6001:9000 dddd',
+    })
+
+    -- This test case doesn't involve reindexing after reassigning
+    -- of the 6001:9000 fields. So, we check the order of
+    -- remaining values and don't check the maximum ID in the
+    -- internal key<->id mappings.
+end
+
+-- }}} Reindexing test cases


### PR DESCRIPTION
In development of the configuration module we met several cases, when an order of appearance of some items is as important as a constant time access using a key.

This commit adds a collection that serves such a need. It is to be used internally in the src/box/lua/config code.

The module is inspired by Python's collections.OrderedDict. See the description in the module code for details.