### PR TITLE
cmake: add libresolv to static dependency list

### DIFF
--- a/cmake/CheckDependencies.cmake
+++ b/cmake/CheckDependencies.cmake
@@ -30,6 +30,10 @@ elseif(UNIX)
         libsvace
         libstdc++
     )
+    # See for details https://github.com/tarantool/tarantool/issues/9740
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND ENABLE_ASAN)
+        set(ALLOWLIST ${ALLOWLIST} libresolv)
+    endif()
 else()
     message(FATAL_ERROR "Unknown platform")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -427,6 +427,8 @@ if(BUILD_STATIC AND OPENSSL_USE_STATIC_LIBS)
         TARGET tarantool POST_BUILD
         COMMAND ${CMAKE_COMMAND}
             -DFILE=${PROJECT_BINARY_DIR}/src/tarantool
+            -DCMAKE_CXX_COMPILER_ID=${CMAKE_CXX_COMPILER_ID}
+            -DENABLE_ASAN=${ENABLE_ASAN}
             -P ${PROJECT_SOURCE_DIR}/cmake/CheckDependencies.cmake
     )
 endif()


### PR DESCRIPTION
If we run a static build with ASAN enabled via Clang 16, the build will fail unless `libresolv` is in the white list of static dependencies. It looks like it is a peculiarity of Clang 16 and higher.

Fixes https://github.com/tarantool/tarantool/issues/9740