### PR TITLE
alter: move format compatibility check to `space_check_format`

### DIFF
--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -1120,9 +1120,7 @@ CheckSpaceFormat::prepare(struct alter_space *alter)
 								     key_def))
 				diag_raise();
 		}
-		if (!tuple_format1_can_store_format2_tuples(new_format,
-							    old_format))
-			space_check_format_with_yield(old_space, new_format);
+		space_check_format_with_yield(old_space, new_format);
 	}
 }
 

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -1008,6 +1008,8 @@ memtx_space_check_format(struct space *space, struct tuple_format *format)
 {
 	struct txn *txn = in_txn();
 
+	if (tuple_format1_can_store_format2_tuples(format, space->format))
+		return 0;
 	if (space->index_count == 0)
 		return 0;
 	struct index *pk = space->index[0];

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -1066,6 +1066,8 @@ vinyl_space_check_format(struct space *space, struct tuple_format *format)
 	struct vy_env *env = vy_env(space->engine);
 	struct txn *txn = in_txn();
 
+	if (tuple_format1_can_store_format2_tuples(format, space->format))
+		return 0;
 	/*
 	 * If this is local recovery, the space was checked before
 	 * restart so there's nothing we need to do.


### PR DESCRIPTION
We assume that if the new format can store tuples matching the old format, we can update the space format without calling the engine `check_format` callback. This is true for both memtx and vinyl but not for memcs (EE), which doesn't support extending field types (e.g. changing int16 to int32).

Let's call the engine check_format callback unconditionally and let it decide whether tuple format checking can be skipped.

Needed for tarantool/tarantool-ee#694