### PR TITLE
Hide redundant fields of box.error.unpack()

### DIFF
--- a/changelogs/unreleased/gh-9101-hide-error-unpack-redundant-fields.md
+++ b/changelogs/unreleased/gh-9101-hide-error-unpack-redundant-fields.md
@@ -1,0 +1,5 @@
+## feature/box
+
+* Hide redundant fields from `box.error.unpack()` if
+  the `box_error_unpack_type_and_code` compat option is set to 'new'.
+  The default behaviour is 'old' (gh-9101).

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2351,6 +2351,12 @@ return schema.new('instance_config', schema.record({
         }, {
             default = 'new',
         }),
+        box_error_unpack_type_and_code = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'old',
+        }),
     }),
 }, {
     -- This kind of validation cannot be implemented as the

--- a/src/lua/compat.lua
+++ b/src/lua/compat.lua
@@ -111,6 +111,14 @@ used as an error indicator in the box C API.
 https://tarantool.io/compat/box_space_max
 ]]
 
+local BOX_ERROR_UNPACK_TYPE_AND_CODE_BRIEF = [[
+Whether to show redundant fields in box.error.unpack(). The new behaviour
+is not to show 'base_type' and 'custom_type' fields. 'code' field is also not
+shown if it is 0. Note that 'base_type' is still accessible for error object.
+
+https://tarantool.io/compat/box_error_unpack_type_and_code
+]]
+
 -- Returns an action callback that toggles a tweak.
 local function tweak_action(tweak_name, old_tweak_value, new_tweak_value)
     return function(is_new)
@@ -209,6 +217,12 @@ local options = {
         obsolete = nil,
         brief = BOX_SPACE_MAX_BRIEF,
         action = tweak_action('BOX_SPACE_MAX', 2147483647, 2147483646)
+    },
+    box_error_unpack_type_and_code = {
+        default = 'old',
+        obsolete = nil,
+        brief = BOX_ERROR_UNPACK_TYPE_AND_CODE_BRIEF,
+        action = function() end
     },
 }
 

--- a/src/lua/error.lua
+++ b/src/lua/error.lua
@@ -2,6 +2,7 @@
 
 local ffi = require('ffi')
 local msgpack = require('msgpack')
+local compat = require('compat')
 
 local mp_decode = msgpack.decode_unchecked
 
@@ -142,6 +143,14 @@ local function error_unpack(err)
     for i = 0, payload._count - 1 do
         local f = fields[i]
         result[ffi.string(f._name)] = mp_decode(f._data)
+    end
+    -- Hide redundant fields from unpack output (gh-9101).
+    if compat.box_error_unpack_type_and_code:is_new() then
+        result.custom_type = nil
+        result.base_type = nil
+        if result.code == 0 then
+            result.code = nil
+        end
     end
     return result
 end

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -341,6 +341,7 @@ g.test_defaults = function()
             box_space_execute_priv = 'new',
             box_tuple_extension = 'new',
             box_space_max = 'new',
+            box_error_unpack_type_and_code = 'old',
         },
     }
     local res = cluster_config:apply_default({})


### PR DESCRIPTION
Closes #9101