### PR TITLE
ci: remove Tarantool tests from LuaJIT integration

### DIFF
--- a/.test.mk
+++ b/.test.mk
@@ -304,10 +304,10 @@ test-coverity: build-coverity
 # LuaJIT integration testing #
 ##############################
 
-test-luajit-Linux-x86_64: build run-luajit-test run-test
+test-luajit-Linux-x86_64: build run-luajit-test
 
-test-luajit-Linux-ARM64: build run-luajit-test run-test
+test-luajit-Linux-ARM64: build run-luajit-test
 
-test-luajit-macOS-x86_64: prebuild-osx build run-luajit-test pretest-osx run-test
+test-luajit-macOS-x86_64: prebuild-osx build run-luajit-test
 
-test-luajit-macOS-ARM64: prebuild-osx build run-luajit-test pretest-osx run-test
+test-luajit-macOS-ARM64: prebuild-osx build run-luajit-test


### PR DESCRIPTION
After the commit 3daf2399dd5b ('ci: fix step parameters for reusable runs') it is now possible to create Tarantool integration workflows for any repository in the Tarantool organization. Considering this, we don't need to run Tarantool tests under the old target for the LuaJIT integration in .test.mk and we can leave only LuaJIT tests in this target for the sake of exotic Tarantool builds testing.

NO_DOC=CI
NO_TEST=CI
NO_CHANGELOG=CI