### PR TITLE
docker/cd: build and push Docker image on release tag

### DIFF
--- a/.github/workflows/distrib.yml
+++ b/.github/workflows/distrib.yml
@@ -1,4 +1,4 @@
-name: packaging
+name: distrib
 
 on:
   push:
@@ -49,7 +49,7 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'full-ci') ||
           contains(github.event.pull_request.labels.*.name, 'static-build-ci') )
 
-    uses: ./.github/workflows/static_build_pack_test_deploy.yml
+    uses: ./.github/workflows/packaging_build_test_deploy.yml
     with:
       arch: x86_64
       test-matrix: '{
@@ -70,7 +70,7 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'full-ci') ||
           contains(github.event.pull_request.labels.*.name, 'static-build-ci') )
 
-    uses: ./.github/workflows/static_build_pack_test_deploy.yml
+    uses: ./.github/workflows/packaging_build_test_deploy.yml
     with:
       arch: aarch64
       test-matrix: '{
@@ -81,4 +81,15 @@ jobs:
           {"os": "ubuntu-focal"}, {"os": "ubuntu-jammy"}
         ]
       }'
+    secrets: inherit
+
+  docker:
+    # Run on push of a tag except '*-entrypoint' to tarantool/tarantool.
+    if: github.repository == 'tarantool/tarantool' &&
+        startsWith(github.ref, 'refs/tags/') &&
+        !endsWith(github.ref, '-entrypoint')
+
+    needs: [ packaging-x86_64, packaging-aarch64 ]
+
+    uses: ./.github/workflows/docker_build_push.yml
     secrets: inherit

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -1,0 +1,89 @@
+name: docker-build-push
+
+on:
+  workflow_call:
+
+env:
+  DOCKERHUB_API: https://hub.docker.com/v2
+
+jobs:
+  build-push:
+    runs-on: [ self-hosted, Linux, x86_64, regular ]
+
+    steps:
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
+
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/environment
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compose image tags
+        run: |
+          REPO=tarantool/tarantool
+          case ${{ github.ref }} in
+            refs/tags/*-alpha*|refs/tags/*-beta*|refs/tags/*-rc*)
+              echo "TAGS=${REPO}:${{ github.ref_name }}" >> $GITHUB_ENV
+              ;;
+            refs/tags/*)
+              MAJOR=$(echo ${{ github.ref_name }} | cut -f1 -d.)
+              MINOR=$(echo ${{ github.ref_name }} | cut -f2 -d.)
+              MAJOR_MINOR=${MAJOR}.${MINOR}
+              TAGS=${REPO}:${{ github.ref_name }},${REPO}:${MAJOR_MINOR}
+              echo "TAGS=${TAGS}" >> $GITHUB_ENV
+
+              # Add the major version tag (3, 4, 5, etc.) to the image if tag
+              # {major_version}.{minor_version + 1} does not exist.
+              # Let's say we have 3.1.0 release, and it is the latest release of
+              # Tarantool. According to this fact, we have the existing image on
+              # Docker Hub with three tags: 3.1.0, 3.1, 3.
+              # If 3.0.2 release is created, the corresponding image will be
+              # pushed to Docker Hub with tags 3.0.2, 3.0, and tag 3 will not
+              # be pushed since tag 3.1 exists and tag 3 should point to the
+              # same image which tag 3.1 points to.
+              MAJOR_MINOR_UP=${MAJOR}.$((MINOR + 1))
+              if curl \
+                  --location \
+                  --silent \
+                  --show-error \
+                  --retry 5 \
+                  --retry-delay 5 \
+                  --request GET \
+                  ${DOCKERHUB_API}/repositories/${REPO}/tags/${MAJOR_MINOR_UP} \
+                  | grep -o "tag '${MAJOR_MINOR_UP}' not found"; then
+                echo "adding tag '${REPO}:${MAJOR}'"
+                echo "adding tag '${REPO}:latest'"
+                TAGS=${TAGS},${REPO}:${MAJOR},${REPO}:latest
+                echo "TAGS=${TAGS}" >> $GITHUB_ENV
+              fi
+              ;;
+          esac
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker
+          file: ./docker/Dockerfile
+          build-args: TARANTOOL_VERSION=${{ github.ref_name }}
+          platforms: linux/amd64,linux/arm64
+          no-cache: true
+          push: true
+          tags: ${{ env.TAGS }}
+
+      - name: Send VK Teams message on failure
+        if: failure()
+        uses: ./.github/actions/report-job-status
+        with:
+          bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}

--- a/.github/workflows/packaging_build_test_deploy.yml
+++ b/.github/workflows/packaging_build_test_deploy.yml
@@ -1,4 +1,4 @@
-name: static_build_pack_test_deploy
+name: packaging-build-test-deploy
 
 on:
   workflow_call:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,78 @@
+FROM ubuntu:22.04
+
+ARG TARANTOOL_VERSION
+ARG TARANTOOL_VERSION_REGEX="^([0-9]+\.[0-9]+\.[0-9]+)($|-(alpha|beta|rc)[1-9]$)"
+ARG TARANTOOL_DOWNLOAD_BASE_URL="https://download.tarantool.org/tarantool"
+ARG TARANTOOL_APT_SOURCES_FILE="/etc/apt/sources.list.d/tarantool.list"
+
+ENV TT_APP_NAME="default"
+ENV TT_INSTANCE_NAME="master"
+
+RUN if [ -z "${TARANTOOL_VERSION}" ]; then \
+        echo "ERROR: TARANTOOL_VERSION is not defined"; \
+        echo "ERROR: Please provide, for example, --build-arg TARANTOOL_VERSION=3.1.0"; \
+        exit 1; \
+    elif [ ! $(echo "${TARANTOOL_VERSION}" | grep -E "${TARANTOOL_VERSION_REGEX}") ]; then \
+        echo "ERROR: TARANTOOL_VERSION is not valid"; \
+        echo "ERROR: Please provide, for example, 3.1.0 or 3.1.0-(alpha|beta|rc)(1-9)"; \
+        exit 1; \
+    else \
+        echo "TARANTOOL_VERSION is defined and valid"; \
+    fi
+
+RUN useradd --system --user-group --shell /bin/sh tarantool
+
+RUN apt-get update && \
+    apt-get -y --no-install-recommends install \
+        gosu \
+        curl \
+        gnupg2 \
+        ca-certificates && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN case "${TARANTOOL_VERSION}" in \
+        *-alpha*|*-beta*|*-rc*) \
+            REPO_TYPE="pre-release" \
+            TARANTOOL_VERSION="$(echo "${TARANTOOL_VERSION}" | sed 's/-/~/')" \
+            ;; \
+        *) \
+            REPO_TYPE="release" \
+            ;; \
+    esac && \
+    TARANTOOL_SERIES="series-$(echo "${TARANTOOL_VERSION}" | cut -d . -f 1)" && \
+    UBUNTU_CODENAME="$(. /etc/os-release && echo "${UBUNTU_CODENAME}")" && \
+    curl -L ${TARANTOOL_DOWNLOAD_BASE_URL}/${REPO_TYPE}/${TARANTOOL_SERIES}/gpgkey | apt-key add - && \
+    curl -L ${TARANTOOL_DOWNLOAD_BASE_URL}/modules/gpgkey | apt-key add - && \
+    echo "deb ${TARANTOOL_DOWNLOAD_BASE_URL}/${REPO_TYPE}/${TARANTOOL_SERIES}/linux-deb/ static main" >> ${TARANTOOL_APT_SOURCES_FILE} && \
+    echo "deb ${TARANTOOL_DOWNLOAD_BASE_URL}/release/modules/linux-deb/ static main" >> ${TARANTOOL_APT_SOURCES_FILE} && \
+    echo "deb ${TARANTOOL_DOWNLOAD_BASE_URL}/release/modules/ubuntu/ ${UBUNTU_CODENAME} main" >> ${TARANTOOL_APT_SOURCES_FILE} && \
+    apt-get update && \
+    apt-get -y --no-install-recommends install \
+        tarantool="${TARANTOOL_VERSION}-1" \
+        tarantool-dev="${TARANTOOL_VERSION}-1" \
+        tt && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/tarantool && \
+    mkdir -p /var/lib/tarantool && \
+    mkdir -p /var/log/tarantool && \
+    mkdir -p /var/run/tarantool && \
+    chown -R tarantool:tarantool /opt/tarantool && \
+    chown -R tarantool:tarantool /var/lib/tarantool && \
+    chown -R tarantool:tarantool /var/log/tarantool && \
+    chown -R tarantool:tarantool /var/run/tarantool
+
+WORKDIR /opt/tarantool
+VOLUME /var/lib/tarantool
+
+COPY config/default-config.yaml /
+COPY entrypoint/docker-entrypoint.sh /
+COPY tools/console /usr/local/bin/
+COPY tools/status /usr/local/bin/
+
+EXPOSE 3301
+
+HEALTHCHECK CMD status
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["tarantool"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,159 @@
+# Tarantool Docker Image (version 3.0+)
+
+- [What is Tarantool](#what-is-tarantool)
+- [Quick start](#quick-start)
+- [What's on board](#whats-on-board)
+  - [Data directories](#data-directories)
+  - [Convenience tools](#convenience-tools)
+- [How to use image](#how-to-use-image)
+  - [Start a Tarantool instance](#start-a-tarantool-instance)
+  - [Connect to a running Tarantool instance](#connect-to-a-running-tarantool-instance)
+  - [Add application code with a volume mount](#add-application-code-with-a-volume-mount)
+  - [Build your own image](#build-your-own-image)
+- [Release policy](#release-policy)
+- [Reporting problems and getting help](#reporting-problems-and-getting-help)
+
+## What is Tarantool
+
+Tarantool is an in-memory computing platform that combines a Lua application
+server and a database management system. Read more about Tarantool at
+[tarantool.io](https://www.tarantool.io/en/developers/).
+
+## Quick start
+
+To try out Tarantool, run this command:
+
+```console
+$ docker run --rm -t -i tarantool/tarantool -i
+```
+
+It will create a one-off Tarantool instance and open an interactive console.
+From there, you can either type `tutorial()` in the console or follow the
+[documentation](https://www.tarantool.io/en/doc/latest/getting_started/getting_started_db/).
+
+## What's on board
+
+The `tarantool/tarantool` image contains the `tarantool` and `tt` executables.
+
+There are also a few [convenience tools](#convenience-tools) that make use of
+the fact that there is only one Tarantool instance running in the container.
+
+The Docker image come in one flavor, based on the `ubuntu:22.04` image.
+The image is built and published on Docker Hub for each Tarantool release as
+well as for alpha, beta and release candidate versions.
+
+### Data directories
+
+Mount these directories as volumes:
+
+- `/var/lib/tarantool` contains operational data (snapshots, xlogs, etc.).
+
+- `/opt/tarantool` is the directory for Lua application code.
+
+### Convenience tools
+
+- `console` -- opens an administrative console to a running Tarantool instance.
+
+- `status` -- returns `running` output and zero status code if Tarantool has
+  been initialized and is operating normally. Otherwise, returns `not running`
+  output and non-zero status code.
+
+## How to use image
+
+### Start a Tarantool instance
+
+```console
+$ docker run \
+  --name mytarantool \
+  -p 3301:3301 -d \
+  tarantool/tarantool
+```
+
+This will start an instance of Tarantool and expose it on port 3301. Note that
+by default there is no password protection, so don't expose this instance to the
+outside world.
+
+### Connect to a running Tarantool instance
+
+```console
+$ docker exec -t -i mytarantool console
+```
+
+This will open an interactive admin console on the running instance named
+`mytarantool`. You can safely detach from it anytime, the server will continue
+running.
+
+This `console` doesn't require authentication, because it uses a local UNIX
+domain socket in the container to connect to Tarantool. However, it requires
+you to have direct access to the container.
+
+If you need to access a remote console via TCP/IP, use the `tt` utility as
+explained [here](https://www.tarantool.io/en/doc/latest/reference/tooling/tt_cli/).
+
+### Add application code with a volume mount
+
+The simplest way to provide application code is to mount your code directory to
+`/opt/tarantool`:
+
+```console
+$ docker run \
+  --name mytarantool \
+  -p 3301:3301 -d \
+  -v /path/to/my/app:/opt/tarantool \
+  tarantool/tarantool \
+  tarantool /opt/tarantool/app.lua
+```
+
+Here, `/path/to/my/app` is the host directory containing Lua code and `app.lua`
+is the entry point of your application. Note that for your code to run, you must
+execute the main script explicitly, which is done in the last line.
+
+### Build your own image
+
+To pack and distribute an image with your code, create your own `Dockerfile`:
+
+```dockerfile
+FROM tarantool/tarantool:3.1.0
+COPY app.lua /opt/tarantool
+CMD ["tarantool", "/opt/tarantool/app.lua"]
+```
+
+Then build it with:
+
+```console
+$ docker build -t company/appname:tag .
+```
+
+We recommend building from an image with a precise tag, for example, `3.1.0`,
+not `3.1` or `latest`. This way you will have more control over the updates of
+Tarantool and other dependencies of your application.
+
+## Release policy
+
+All images are pushed to [Docker Hub](https://hub.docker.com/).
+
+Patch-version tags (`x.y.z`) are always frozen and never updated.
+Minor-version tags (`x.y`) are re-pushed if a new patch-version release has been
+created.
+Major-version tags (`x`) are re-pushed if a new patch-version or minor-version
+release has been created.
+
+### Example
+
+Let's say we have `3.1.0` release, and it is the latest release of Tarantool.
+According to this fact, we have the image on Docker Hub with three tags:
+`3.1.0`, `3.1`, `3`.
+
+If `3.1.1` release is created, the corresponding image will be pushed to Docker
+Hub with tags `3.1.1`, `3.1`, `3`, i.e, tags `3.1` and `3` will be re-pushed.
+
+If `3.2.0` release is created, the corresponding image will be pushed to Docker
+Hub with tags `3.2.0`, `3.2`, `3`, i.e, tag `3` will be re-pushed.
+
+## Reporting problems and getting help
+
+You can report problems and request features
+[on our GitHub](https://github.com/tarantool/tarantool).
+
+Alternatively, you may get help on our
+[Telegram channel](https://t.me/tarantool).

--- a/docker/config/default-config.yaml
+++ b/docker/config/default-config.yaml
@@ -1,0 +1,15 @@
+credentials:
+  users:
+    guest:
+      roles: [ super ]
+
+iproto:
+  listen:
+    - uri: localhost:3301
+
+groups:
+  group-001:
+    replicasets:
+      replicaset-001:
+        instances:
+          master: { }

--- a/docker/entrypoint/docker-entrypoint.sh
+++ b/docker/entrypoint/docker-entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+set -e
+
+APP_DIR="/opt/tarantool"
+DATA_DIR="/var/lib/tarantool/sys_env"
+LOG_DIR="/var/log/tarantool/sys_env"
+RUN_DIR="/var/run/tarantool/sys_env"
+
+DEFAULT_CONFIG="/default-config.yaml"
+CUSTOM_CONFIG="${APP_DIR}/${TT_APP_NAME}/config.yaml"
+
+if [ -f "${CUSTOM_CONFIG}" ] && [ -z "${TT_CONFIG}" ]; then
+    export TT_CONFIG="${CUSTOM_CONFIG}"
+else
+    export TT_CONFIG="${TT_CONFIG:-${DEFAULT_CONFIG}}"
+fi
+
+export TT_SNAPSHOT_DIR_DEFAULT="${DATA_DIR}/${TT_APP_NAME}/${TT_INSTANCE_NAME}"
+export TT_VINYL_DIR_DEFAULT="${DATA_DIR}/${TT_APP_NAME}/${TT_INSTANCE_NAME}"
+export TT_WAL_DIR_DEFAULT="${DATA_DIR}/${TT_APP_NAME}/${TT_INSTANCE_NAME}"
+export TT_LOG_FILE_DEFAULT="${LOG_DIR}/${TT_APP_NAME}/${TT_INSTANCE_NAME}/tarantool.log"
+export TT_CONSOLE_SOCKET_DEFAULT="${RUN_DIR}/${TT_APP_NAME}/${TT_INSTANCE_NAME}/tarantool.control"
+export TT_PROCESS_PID_FILE_DEFAULT="${RUN_DIR}/${TT_APP_NAME}/${TT_INSTANCE_NAME}/tarantool.pid"
+
+# Handle args such as `-v` or `--help`.
+if [ " -${1#?}" = " $1" ]; then
+    set -- tarantool "$@"
+fi
+
+# Allow the container to be started without `--user tarantool`.
+if [ "$1" = "tarantool" ] && [ "$(id -u)" = "0" ]; then
+    exec gosu tarantool "$0" "$@"
+fi
+
+if [ "$1" = "tarantool" ]; then
+    shift
+    exec tarantool "$@"
+fi
+
+exec "$@"

--- a/docker/example/app/config.yaml
+++ b/docker/example/app/config.yaml
@@ -1,0 +1,26 @@
+credentials:
+  users:
+    guest:
+      roles: [ super ]
+
+replication:
+  failover: manual
+
+groups:
+  group-001:
+    replicasets:
+      replicaset-001:
+        leader: instance-001
+        instances:
+          instance-001:
+            iproto:
+              listen:
+                - uri: instance-001:3301
+          instance-002:
+            iproto:
+              listen:
+                - uri: instance-002:3302
+          instance-003:
+            iproto:
+              listen:
+                - uri: instance-003:3303

--- a/docker/example/docker-compose.yaml
+++ b/docker/example/docker-compose.yaml
@@ -1,0 +1,46 @@
+services:
+  instance-001:
+    image: tarantool/tarantool:3.0.1
+    container_name: tarantool-instance-001
+    volumes:
+      - ./app:/opt/tarantool/app
+      - ./data:/var/lib/tarantool
+    environment:
+      - TT_APP_NAME=app
+      - TT_INSTANCE_NAME=instance-001
+    networks:
+      - tarantool
+    ports:
+      - "3301:3301"
+
+  instance-002:
+    image: tarantool/tarantool:3.0.1
+    container_name: tarantool-instance-002
+    volumes:
+      - ./app:/opt/tarantool/app
+      - ./data:/var/lib/tarantool
+    environment:
+      - TT_APP_NAME=app
+      - TT_INSTANCE_NAME=instance-002
+    networks:
+      - tarantool
+    ports:
+      - "3302:3301"
+
+  instance-003:
+    image: tarantool/tarantool:3.0.1
+    container_name: tarantool-instance-003
+    volumes:
+      - ./app:/opt/tarantool/app
+      - ./data:/var/lib/tarantool
+    environment:
+      - TT_APP_NAME=app
+      - TT_INSTANCE_NAME=instance-003
+    networks:
+      - tarantool
+    ports:
+      - "3303:3301"
+
+networks:
+  tarantool:
+    driver: bridge

--- a/docker/tools/console
+++ b/docker/tools/console
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+RUN_DIR="/var/run/tarantool/sys_env"
+TT_CONSOLE_SOCKET_DEFAULT="${RUN_DIR}/${TT_APP_NAME}/${TT_INSTANCE_NAME}/tarantool.control"
+tt connect "${TT_CONSOLE_SOCKET:-${TT_CONSOLE_SOCKET_DEFAULT}}"

--- a/docker/tools/status
+++ b/docker/tools/status
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+RUN_DIR="/var/run/tarantool/sys_env"
+TT_CONSOLE_SOCKET_DEFAULT="${RUN_DIR}/${TT_APP_NAME}/${TT_INSTANCE_NAME}/tarantool.control"
+STATUS_CODE=$(
+    tt connect "${TT_CONSOLE_SOCKET:-${TT_CONSOLE_SOCKET_DEFAULT}}" -f- 1>/dev/null <<EOF
+\q
+EOF
+    echo $?
+)
+
+if [ "${STATUS_CODE}" = "0" ]; then
+    echo "running"
+    exit 0
+else
+    echo "not running"
+    exit "${STATUS_CODE}"
+fi


### PR DESCRIPTION
Bring a base toolset for building official Docker images for
Tarantool 3.0+ version.

Toolset components:

1. Dockerfile for building Docker images (based on Ubuntu 22.04)
2. Docker entrypoint script (docker-entrypoint.sh)
3. Default Tarantool config (default-config.yaml)
4. Auxiliary tools for checking Tarantool instance status and connecting
   to admin console
5. Example of a basic Tarantool cluster that can be started via Docker
   Compose (a tool for running multi-container applications)

---

Add the Docker image build routine as a part of the release
pipeline.

A word about image tags.

For example, if a release tag is 3.1.0, the resulting Docker image will
be pushed to Docker Hub with the following tags: 3.1.0, 3.1, 3.
If a release tag is 3.1.0-alpha1, the resulting Docker image will be
pushed to Docker Hub with one tag: 3.1.0-alpha1.
Same for 3.1.0-beta1 or 3.1.0-rc1 tag.

---

Closes #9596 