### PR TITLE
[backport 3.0] ci: use Ubuntu Jammy for checkpatch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-20.04-self-hosted
 
     container:
-      image: docker.io/tarantool/testing:ubuntu-focal
+      image: docker.io/tarantool/testing:ubuntu-jammy
 
     steps:
       - name: Prepare checkout


### PR DESCRIPTION
*(Backport of PR #9752 to `release/3.0`.)*

----

It brings newer codespell version: 2.1.0. Ubuntu Focal offers 1.16.0.

Fixes tarantool/checkpatch#70