### PR TITLE
[backport/release/2.10] ci: fix step parameters for reusable runs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,14 +36,14 @@ concurrency:
     startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
-    format('{0}-{1}', github.workflow, github.ref) }}
+    format('{0}-{1}-coverage', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:
   coverage:
     # Run on push to the 'master' and release branches of tarantool/tarantool
     # or on pull request if the 'notest' label is not set.
-    if: github.repository == 'tarantool/tarantool' &&
+    if: github.repository_owner == 'tarantool' &&
         ( github.event_name != 'pull_request' ||
           ( github.event_name == 'pull_request' &&
             !contains(github.event.pull_request.labels.*.name, 'notest') ) )
@@ -71,6 +71,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          repository: tarantool/tarantool
+          ref: ${{ inputs.submodule && 'release/2.10' || github.ref }}
 
       - name: Set environment
         uses: ./.github/actions/environment

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -36,14 +36,14 @@ concurrency:
     startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
-    format('{0}-{1}', github.workflow, github.ref) }}
+    format('{0}-{1}-debug', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:
   debug:
     # Run on push to the 'master' and release branches of tarantool/tarantool
     # or on pull request if the 'notest' label is not set.
-    if: github.repository == 'tarantool/tarantool' &&
+    if: github.repository_owner == 'tarantool' &&
         ( github.event_name != 'pull_request' ||
           ( github.event_name == 'pull_request' &&
             !contains(github.event.pull_request.labels.*.name, 'notest') ) )
@@ -71,6 +71,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          repository: tarantool/tarantool
+          ref: ${{ inputs.submodule && 'release/2.10' || github.ref }}
 
       - name: Set environment
         uses: ./.github/actions/environment

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -37,14 +37,14 @@ concurrency:
     startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
-    format('{0}-{1}', github.workflow, github.ref) }}
+    format('{0}-{1}-debug-aarch64', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:
   debug_aarch64:
     # Run on push to the 'master' and release branches of tarantool/tarantool
     # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
+    if: github.repository_owner == 'tarantool' &&
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
@@ -70,6 +70,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          repository: tarantool/tarantool
+          ref: ${{ inputs.submodule && 'release/2.10' || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian

--- a/.github/workflows/debug_asan_clang.yml
+++ b/.github/workflows/debug_asan_clang.yml
@@ -37,14 +37,14 @@ concurrency:
     startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
-    format('{0}-{1}', github.workflow, github.ref) }}
+    format('{0}-{1}-debug-asan-clang', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:
   debug_asan_clang:
     # Run on push to the 'master' and release branches of tarantool/tarantool
     # or on pull request if the 'full-ci' or 'asan-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
+    if: github.repository_owner == 'tarantool' &&
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'full-ci') ||
           contains(github.event.pull_request.labels.*.name, 'asan-ci') )
@@ -71,6 +71,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          repository: tarantool/tarantool
+          ref: ${{ inputs.submodule && 'release/2.10' || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -37,7 +37,7 @@ concurrency:
     startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
-    format('{0}-{1}', github.workflow, github.ref) }}
+    format('{0}-{1}-default-gcc-centos-7', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 env:
@@ -47,7 +47,7 @@ jobs:
   default_gcc_centos_7:
     # Run on push to the 'master' and release branches of tarantool/tarantool
     # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
+    if: github.repository_owner == 'tarantool' &&
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
@@ -60,6 +60,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          repository: tarantool/tarantool
+          ref: ${{ inputs.submodule && 'release/2.10' || github.ref }}
       - uses: ./.github/actions/environment
       - name: Optional submodule bump
         if: ${{ inputs.submodule }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,14 +44,14 @@ jobs:
   tarantool:
     # Run on push to the 'master' and release branches of tarantool/tarantool
     # or on pull request if the 'full-ci' or 'integration-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
+    if: github.repository_owner == 'tarantool' &&
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'full-ci') ||
           contains(github.event.pull_request.labels.*.name, 'integration-ci') )
 
     uses: tarantool/tarantool/.github/workflows/reusable_build.yml@master
     with:
-      ref: ${{ github.sha }}
+      ref: ${{ inputs.submodule && 'release/2.10' || github.ref }}
       os: ubuntu
       dist: focal
       submodule: ${{ inputs.submodule }}
@@ -61,100 +61,99 @@ jobs:
     needs: tarantool
     uses: tarantool/vshard/.github/workflows/reusable_testing.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
 
   cartridge:
     needs: tarantool
     uses: tarantool/cartridge/.github/workflows/reusable-backend-test.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
 
   expirationd:
     needs: tarantool
     uses: tarantool/expirationd/.github/workflows/reusable_testing.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
-
+      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
   smtp:
     needs: tarantool
     uses: tarantool/smtp/.github/workflows/reusable_testing.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
 
   memcached:
     needs: tarantool
     uses: tarantool/memcached/.github/workflows/reusable_testing.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
 
   metrics:
     needs: tarantool
     uses: tarantool/metrics/.github/workflows/reusable-test.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
 
   avro-schema:
     needs: tarantool
     uses: tarantool/avro-schema/.github/workflows/reusable_testing.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
 
   queue:
     needs: tarantool
     uses: tarantool/queue/.github/workflows/reusable_testing.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
 
   checks:
     needs: tarantool
     uses: tarantool/checks/.github/workflows/reusable_testing.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
 
   mysql:
     needs: tarantool
     uses: tarantool/mysql/.github/workflows/reusable_testing.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
 
   tarantool-c:
     needs: tarantool
     uses: tarantool/tarantool-c/.github/workflows/reusable_testing.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
 
   tarantool-python:
     needs: tarantool
     uses: tarantool/tarantool-python/.github/workflows/reusable_testing.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
 
   php-client:
     needs: tarantool
     uses: tarantool-php/client/.github/workflows/reusable_qa.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
 
   php-queue:
     needs: tarantool
     uses: tarantool-php/queue/.github/workflows/reusable_qa.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
 
   go-tarantool:
     needs: tarantool
     uses: tarantool/go-tarantool/.github/workflows/reusable_testing.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
 
   crud:
     needs: tarantool
     uses: tarantool/crud/.github/workflows/reusable_test.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
 
   ddl:
     needs: tarantool
     uses: tarantool/ddl/.github/workflows/reusable_test.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ github.sha }}
+      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -37,14 +37,14 @@ concurrency:
     startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
-    format('{0}-{1}', github.workflow, github.ref) }}
+    format('{0}-{1}-memtx-allocator-based-on-malloc', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:
   memtx_allocator_based_on_malloc:
     # Run on push to the 'master' and release branches of tarantool/tarantool
     # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
+    if: github.repository_owner == 'tarantool' &&
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
@@ -70,6 +70,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          repository: tarantool/tarantool
+          ref: ${{ inputs.submodule && 'release/2.10' || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -37,14 +37,14 @@ concurrency:
     startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
-    format('{0}-{1}', github.workflow, github.ref) }}
+    format('{0}-{1}-out-of-source', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:
   out_of_source:
     # Run on push to the 'master' and release branches of tarantool/tarantool
     # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
+    if: github.repository_owner == 'tarantool' &&
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
@@ -70,6 +70,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          repository: tarantool/tarantool
+          ref: ${{ inputs.submodule && 'release/2.10' || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,14 +36,14 @@ concurrency:
     startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
-    format('{0}-{1}', github.workflow, github.ref) }}
+    format('{0}-{1}-release', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:
   release:
     # Run on push to the 'master' and release branches of tarantool/tarantool
     # or on pull request if the 'notest' label is not set.
-    if: github.repository == 'tarantool/tarantool' &&
+    if: github.repository_owner == 'tarantool' &&
         ( github.event_name != 'pull_request' ||
           ( github.event_name == 'pull_request' &&
             !contains(github.event.pull_request.labels.*.name, 'notest') ) )
@@ -70,6 +70,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          repository: tarantool/tarantool
+          ref: ${{ inputs.submodule && 'release/2.10' || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian

--- a/.github/workflows/release_asan_clang.yml
+++ b/.github/workflows/release_asan_clang.yml
@@ -37,14 +37,14 @@ concurrency:
     startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
-    format('{0}-{1}', github.workflow, github.ref) }}
+    format('{0}-{1}-release-asan-clang', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:
   release_asan_clang:
     # Run on push to the 'master' and release branches of tarantool/tarantool
     # or on pull request if the 'full-ci' or 'asan-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
+    if: github.repository_owner == 'tarantool' &&
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'full-ci') ||
           contains(github.event.pull_request.labels.*.name, 'asan-ci') )
@@ -71,6 +71,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          repository: tarantool/tarantool
+          ref: ${{ inputs.submodule && 'release/2.10' || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -37,14 +37,14 @@ concurrency:
     startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
-    format('{0}-{1}', github.workflow, github.ref) }}
+    format('{0}-{1}-release-clang', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:
   release_clang:
     # Run on push to the 'master' and release branches of tarantool/tarantool
     # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
+    if: github.repository_owner == 'tarantool' &&
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
@@ -70,6 +70,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          repository: tarantool/tarantool
+          ref: ${{ inputs.submodule && 'release/2.10' || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -37,14 +37,14 @@ concurrency:
     startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
-    format('{0}-{1}', github.workflow, github.ref) }}
+    format('{0}-{1}-release-lto', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:
   release_lto:
     # Run on push to the 'master' and release branches of tarantool/tarantool
     # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
+    if: github.repository_owner == 'tarantool' &&
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
@@ -70,6 +70,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          repository: tarantool/tarantool
+          ref: ${{ inputs.submodule && 'release/2.10' || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian

--- a/.github/workflows/release_lto_clang.yml
+++ b/.github/workflows/release_lto_clang.yml
@@ -37,14 +37,14 @@ concurrency:
     startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
-    format('{0}-{1}', github.workflow, github.ref) }}
+    format('{0}-{1}-release-lto-clang', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:
   release_lto_clang:
     # Run on push to the 'master' and release branches of tarantool/tarantool
     # or on pull request if the 'full-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
+    if: github.repository_owner == 'tarantool' &&
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'full-ci') )
 
@@ -70,6 +70,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          repository: tarantool/tarantool
+          ref: ${{ inputs.submodule && 'release/2.10' || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -27,6 +27,10 @@ on:
         description: Git revision from submodule repository
         required: false
         type: string
+    outputs:
+      sha:
+        description: Tarantool commit SHA for the uploaded artifact
+        value: ${{ jobs.build.outputs.sha }}
 
 jobs:
   build:
@@ -34,6 +38,8 @@ jobs:
     env:
       OS: ${{ inputs.os }}
       DIST: ${{ inputs.dist }}
+    outputs:
+      sha: ${{ steps.get_sha.outputs.sha }}
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
@@ -44,6 +50,7 @@ jobs:
           fetch-depth: 0
           # Enable recursive submodules checkout.
           submodules: recursive
+          repository: tarantool/tarantool
       - name: 'Get the commit SHA'
         id: get_sha
         run: echo "sha=$(git log -1 --format='%H')" >> $GITHUB_OUTPUT

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -37,14 +37,14 @@ concurrency:
     startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
-    format('{0}-{1}', github.workflow, github.ref) }}
+    format('{0}-{1}-static-build', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:
   static_build:
     # Run on push to the 'master' and release branches of tarantool/tarantool
     # or on pull request if the 'full-ci' or 'static-build-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
+    if: github.repository_owner == 'tarantool' &&
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'full-ci') ||
           contains(github.event.pull_request.labels.*.name, 'static-build-ci') )
@@ -71,6 +71,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          repository: tarantool/tarantool
+          ref: ${{ inputs.submodule && 'release/2.10' || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -37,14 +37,14 @@ concurrency:
     startsWith(github.ref, 'refs/heads/release/') ||
     startsWith(github.ref, 'refs/tags/')) &&
     format('{0}-{1}', github.run_id, github.run_attempt) ||
-    format('{0}-{1}', github.workflow, github.ref) }}
+    format('{0}-{1}-static-build-cmake-linux', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:
   static_build_cmake_linux:
     # Run on push to the 'master' and release branches of tarantool/tarantool
     # or on pull request if the 'full-ci' or 'static-build-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
+    if: github.repository_owner == 'tarantool' &&
         ( github.event_name != 'pull_request' ||
           contains(github.event.pull_request.labels.*.name, 'full-ci') ||
           contains(github.event.pull_request.labels.*.name, 'static-build-ci') )
@@ -71,6 +71,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          repository: tarantool/tarantool
+          ref: ${{ inputs.submodule && 'release/2.10' || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian


### PR DESCRIPTION
This patch fixes three issues:
1. It changes the condition for workflows so they can be run not only from the Tarantool repository but from any repository in the Tarantool organization.

2. Reusable workflows substitute the `${{ github.workflow }}` context variable with the name of their top-level workflow. This behavior causes concurrency group clashes when several reusable workflows are called from a single top-level workflow. This patch adds an additional constant part to the concurrency group pattern to solve the issue.

3. The checkout actions use the reference from the repository in which the top-level workflow is located instead of the one where the reusable workflow is located. This patch solves the issue by passing the reference explicitly.

NO_DOC=CI
NO_TEST=CI
NO_CHANGELOG=CI