### PR TITLE
Remove broken symlink debian/tarantool.service

### DIFF
--- a/debian/tarantool.service
+++ b/debian/tarantool.service
@@ -1,1 +1,0 @@
-../extra/dist/tarantool.service


### PR DESCRIPTION
Leads nowhere after commit 216b6243bba1 ("tools: remove tarantoolctl utility").