### PR TITLE
config: introduce sharding.weight

### DIFF
--- a/changelogs/unreleased/gh-9775-option-weight.md
+++ b/changelogs/unreleased/gh-9775-option-weight.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* Introduced the `sharding.weight` configuration option, which reflects
+  the relative amount of data that a replicaset can store (gh-9775).

--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -147,6 +147,10 @@ function methods.sharding(self)
     for group_name, group in pairs(self._cconfig.groups) do
         for replicaset_name, value in pairs(group.replicasets) do
             local lock
+            local weight
+            -- For replicaset-level options, we need to get them from the any
+            -- instance of the replicaset.
+            local is_rs_options_set = false
             local replicaset_uuid
             local replicaset_cfg = {}
             local is_rebalancer = nil
@@ -160,8 +164,10 @@ function methods.sharding(self)
                                                            instance_name)
                 iconfig = instance_config:apply_default(iconfig)
                 iconfig = instance_config:apply_vars(iconfig, vars)
-                if lock == nil then
+                if not is_rs_options_set then
+                    is_rs_options_set = true
                     lock = instance_config:get(iconfig, 'sharding.lock')
+                    weight = instance_config:get(iconfig, 'sharding.weight')
                 end
                 if is_rebalancer == nil then
                     local roles = instance_config:get(iconfig, 'sharding.roles')
@@ -188,6 +194,7 @@ function methods.sharding(self)
                     uuid = replicaset_uuid,
                     master = 'auto',
                     lock = lock,
+                    weight = weight,
                 }
             end
         end

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1902,6 +1902,20 @@ return schema.new('instance_config', schema.record({
                 end
             end,
         }),
+        weight = schema.scalar({
+            type = 'number',
+            default = 1,
+            validate = function(data, w)
+                local scope = w.schema.computed.annotations.scope
+                if data == nil or scope == nil then
+                    return
+                end
+                if scope == 'instance' then
+                    w.error('sharding.weight cannot be defined in the ' ..
+                            'instance scope')
+                end
+            end,
+        }),
         -- TODO: Add validate.
         roles = schema.set({
             'router',

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -304,6 +304,7 @@ g.test_defaults = function()
             sched_ref_quota = 300,
             shard_index = "bucket_id",
             sync_timeout = 1,
+            weight = 1,
         },
         audit_log = is_enterprise and {
             file = "var/log/{{ instance_name }}/audit.log",

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1583,6 +1583,7 @@ g.test_sharding = function()
             roles = {'router', 'storage'},
             lock = false,
             zone = 1,
+            weight = 1.5,
             sync_timeout = 2,
             connection_outdate_delay = 3,
             failover_ping_timeout = 4,
@@ -1623,6 +1624,7 @@ g.test_sharding = function()
         sched_ref_quota = 300,
         shard_index = "bucket_id",
         sync_timeout = 1,
+        weight = 1,
     }
     local res = instance_config:apply_default({}).sharding
     t.assert_equals(res, exp)

--- a/test/config-luatest/vars_test.lua
+++ b/test/config-luatest/vars_test.lua
@@ -215,6 +215,7 @@ g.test_sharding = helpers.run_as_script(function()
                     uri = exp_uri('storages', 'storages-a', 'storage-a-003'),
                 },
             },
+            weight = 1,
         },
         ['storages-b'] = {
             master = 'auto',
@@ -229,6 +230,7 @@ g.test_sharding = helpers.run_as_script(function()
                     uri = exp_uri('storages', 'storages-b', 'storage-b-003'),
                 },
             },
+            weight = 1,
         },
     })
 end)


### PR DESCRIPTION
Closes #9775

@TarantoolBot document
Title: The `sharding.weight` option

The `sharding.weight` option can be set to facilitate rebalancing. The larger the weight of a replicaset, the more data it can store. This is a relative value, so a replicaset with a value N times larger than a value of the another replicaset can store N times more data. The default value is 1.