### PR TITLE
lyaml: fix alias serialization

### DIFF
--- a/changelogs/unreleased/fix-yaml-alias-serialization.md
+++ b/changelogs/unreleased/fix-yaml-alias-serialization.md
@@ -1,0 +1,3 @@
+## bugfix/lua
+
+* Fixed alias detection in the YAML encoder (gh-8350, gh-8310, gh-8321).

--- a/src/lua/utils.c
+++ b/src/lua/utils.c
@@ -812,6 +812,24 @@ luaL_checkconstchar(struct lua_State *L, int idx, const char **res,
 	return 0;
 }
 
+bool
+luaT_hasfield(struct lua_State *L, int obj_index, int table_index)
+{
+	/*
+	 * lua_pushvalue() changes the size of the Lua stack, so
+	 * calling lua_gettable() with a relative index would pick
+	 * up a wrong object.
+	 */
+	if (table_index < 0)
+		table_index += lua_gettop(L) + 1;
+
+	lua_pushvalue(L, obj_index);
+	lua_gettable(L, table_index);
+	bool res = !lua_isnil(L, -1);
+	lua_pop(L, 1);
+	return res;
+}
+
 lua_State *
 luaT_state(void)
 {

--- a/src/lua/utils.h
+++ b/src/lua/utils.h
@@ -530,6 +530,13 @@ int
 luaL_checkconstchar(struct lua_State *L, int idx, const char **res,
 		    uint32_t *cdata_type_p);
 
+/**
+ * Whether the object at the given valid index is in the table at
+ * the given valid index.
+ */
+bool
+luaT_hasfield(struct lua_State *L, int obj_index, int table_index);
+
 /* {{{ Helper functions to interact with a Lua iterator from C */
 
 /**

--- a/test/app-luatest/serializer_test.lua
+++ b/test/app-luatest/serializer_test.lua
@@ -1,0 +1,64 @@
+local yaml = require('yaml')
+local fiber = require('fiber')
+local t = require('luatest')
+
+local g = t.group()
+
+local strip = function(str)
+    return str:gsub('^%s*', ''):gsub('\n%s*', '\n')
+end
+
+local function serialize(o, s)
+    s = s or yaml
+    return s.decode(s.encode(o))
+end
+
+g.test_recursion = function()
+    local x = {}
+    x.x = x
+    local res = serialize(x)
+    t.assert(rawequal(res, res.x))
+end
+
+g.test_stress = function()
+    local s = yaml.new()
+    s.cfg({encode_use_tostring = true})
+
+    -- Shouldn't raise or cycle.
+    serialize(_G, s)
+end
+
+g.test_gh_8350_no_unnecessary_anchors = function()
+    local x = {{}}
+    setmetatable(x, {__serialize = function(_) return {x[1]} end})
+    local expected = [[
+        ---
+        - []
+        ...
+    ]]
+    t.assert_equals(yaml.encode(x), strip(expected))
+end
+
+g.test_gh_8310_alias_across_serialize_method = function()
+    local x = {}
+    local y = setmetatable({}, {__serialize = function() return x end})
+    local z = {x, y}
+    local expected = [[
+        ---
+        - &0 []
+        - *0
+        ...
+    ]]
+    t.assert_equals(yaml.encode(z), strip(expected))
+end
+
+g.test_gh_8321_alias_between_same_udata_objects = function()
+    local x = serialize({fiber.self(), fiber.self()})
+    t.assert(rawequal(x[1], x[2]))
+end
+
+g.test_gh_8321_alias_between_same_cdata_objects = function()
+    local tuple = box.tuple.new({})
+    local x = serialize({tuple, tuple})
+    t.assert(rawequal(x[1], x[2]))
+end

--- a/test/box/tuple.result
+++ b/test/box/tuple.result
@@ -518,8 +518,8 @@ gen, init, state = t:pairs()
 gen, init, state
 ---
 - gen: <tuple iterator>
-  param: ['a', 'b', 'c']
-- ['a', 'b', 'c']
+  param: &0 ['a', 'b', 'c']
+- *0
 - null
 ...
 state, val = gen(init, state)
@@ -625,16 +625,16 @@ r
 t:pairs(nil)
 ---
 - gen: <tuple iterator>
-  param: ['a', 'b', 'c']
-- ['a', 'b', 'c']
+  param: &0 ['a', 'b', 'c']
+- *0
 - null
 ...
 t:pairs("fdsaf")
 ---
 - state: fdsaf
   gen: <tuple iterator>
-  param: ['a', 'b', 'c']
-- ['a', 'b', 'c']
+  param: &0 ['a', 'b', 'c']
+- *0
 - fdsaf
 ...
 --------------------------------------------------------------------------------

--- a/third_party/lua-yaml/lyaml.cc
+++ b/third_party/lua-yaml/lyaml.cc
@@ -98,6 +98,7 @@ struct lua_yaml_dumper {
 
    lua_State *outputL;
    luaL_Buffer yamlbuf;
+   int reftable_index;
 };
 
 /**
@@ -630,8 +631,6 @@ static int yaml_is_flow_mode(struct lua_yaml_dumper *dumper) {
    return 0;
 }
 
-static void find_references(struct lua_yaml_dumper *dumper);
-
 static int dump_node(struct lua_yaml_dumper *dumper)
 {
    size_t len = 0;
@@ -646,14 +645,13 @@ static int dump_node(struct lua_yaml_dumper *dumper)
    bool unused;
    (void) unused;
 
+   luaT_reftable_serialize(dumper->L, dumper->reftable_index);
    yaml_char_t *anchor = get_yaml_anchor(dumper);
    if (anchor && !*anchor)
       return 1;
 
    int top = lua_gettop(dumper->L);
    luaL_checkfield(dumper->L, dumper->cfg, top, &field);
-   if (field.serialized)
-      find_references(dumper);
    switch(field.type) {
    case MP_UINT:
       snprintf(buf, sizeof(buf) - 1, "%" PRIu64, field.ival);
@@ -791,9 +789,12 @@ static int append_output(void *arg, unsigned char *buf, size_t len) {
 }
 
 static void find_references(struct lua_yaml_dumper *dumper) {
-   int newval = -1, type = lua_type(dumper->L, -1);
-   if (type != LUA_TTABLE)
-      return;
+   int newval = -1;
+
+   lua_pushvalue(dumper->L, -1); /* push copy of table */
+   luaT_reftable_serialize(dumper->L, dumper->reftable_index);
+   if (lua_type(dumper->L, -1) != LUA_TTABLE)
+      goto done;
 
    lua_pushvalue(dumper->L, -1); /* push copy of table */
    lua_rawget(dumper->L, dumper->anchortable_index);
@@ -808,7 +809,7 @@ static void find_references(struct lua_yaml_dumper *dumper) {
       lua_rawset(dumper->L, dumper->anchortable_index);
    }
    if (newval)
-      return;
+      goto done;
 
    /* recursively process other table values */
    lua_pushnil(dumper->L);
@@ -817,6 +818,17 @@ static void find_references(struct lua_yaml_dumper *dumper) {
       lua_pop(dumper->L, 1);
       find_references(dumper); /* find references on key */
    }
+
+done:
+   /*
+    * Pop the serialized object, leave the original object on top
+    * of the Lua stack.
+    *
+    * NB: It is important for the cycle above: it assumes that
+    * table keys are not changed in the recursive call. Otherwise
+    * it would feed an incorrect key to lua_next().
+    */
+   lua_pop(dumper->L, 1);
 }
 
 int
@@ -863,12 +875,16 @@ lua_yaml_encode(lua_State *L, struct luaL_serializer *serializer,
    lua_newtable(L);
    dumper.anchortable_index = lua_gettop(L);
    dumper.anchor_number = 0;
+
+   luaT_reftable_new(L, dumper.cfg, 1);
+   dumper.reftable_index = lua_gettop(L);
+
    lua_pushvalue(L, 1); /* push copy of arg we're processing */
    find_references(&dumper);
    dump_document(&dumper);
    if (dumper.error)
       goto error;
-   lua_pop(L, 2); /* pop copied arg and anchor table */
+   lua_pop(L, 3); /* pop copied arg and anchor/ref tables */
 
    if (!yaml_stream_end_event_initialize(&ev) ||
        !yaml_emitter_emit(&dumper.emitter, &ev) ||


### PR DESCRIPTION
The #8350 was introduced by the commit b42302f52ada ("lua-yaml: enable aliasing for objects returned by __serialize") so the patch is effectively reversed.

The idea is to call all object __serialize methods recursively before finding references. The new serialization pass stores the mapping from the original object to the serialized representation.

After this, the reference analysis pass and the encoding pass use this mapping to replace original objects with the serialized representation.

As result, the reference analysis has a complete information about objects and no references are missed.

Closes #8350
Closes #8310
Closes #8321

----

*(This is an alternative implementation of PR #9736.)*