### PR TITLE
config: expand config:info()

### DIFF
--- a/changelogs/unreleased/gh-9780-show-active-meta.md
+++ b/changelogs/unreleased/gh-9780-show-active-meta.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* `config:info()` can now display source metadata from the last successful
+  load along with source metadata from the very last load attempt (gh-9780).


### PR DESCRIPTION
Closes #9780

@TarantoolBot document
Title: Expansion of `config:info()`

Before this patch, the `meta` field of the `config:info()` function contained the meta data of the last load, even if it was unsuccessful reload. This can be inconvenient because if the reload fails, we expect that the last configuration that was successfully applied is used, but its metadata was lost.

Now `config:info()` can take one argument — the version of the information that should be returned by the function. If no arguments are specified or the argument is the string `v1`, the return value has the same structure as before. If the argument is the string `v2`, the `meta` field in the return value has fields - `active` (meta for the last successfully applied configuration) and `last` (meta of the last loaded configuration). Currently only these values are accepted.