### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9595-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9595-luajit-fixes.md
@@ -12,3 +12,4 @@ were fixed as part of this activity:
 * Fixed recording of `setmetatable()` with `nil` as the second argument.
 * Fixed recording of `select()` in case with negative first argument.
 * Fixed use-def analysis for child upvalues.
+* Fixed recording of the `__concat()` metamethod for vararg and `pcall` frames.


### PR DESCRIPTION
* Fix recording of __concat metamethod.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump