### PR TITLE
[backport 3.0] config: set config status after "post_apply" phase

### DIFF
--- a/changelogs/unreleased/ghe-643-set-status-after-post-apply.md
+++ b/changelogs/unreleased/ghe-643-set-status-after-post-apply.md
@@ -1,0 +1,3 @@
+## bugfix/config
+
+* The config status is now set after the `post_apply` phase (ghe-643).

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -407,7 +407,6 @@ function methods._startup(self, instance_name, config_file)
     else
         self:_apply_on_startup({phase = 2})
     end
-    self:_set_status_based_on_alerts()
 
     self:_post_apply()
     self:_set_status_based_on_alerts()
@@ -449,7 +448,6 @@ function methods._reload_noexc(self, opts)
     local ok, err = pcall(function(opts)
         self:_store(self:_collect(opts))
         self:_apply()
-        self:_set_status_based_on_alerts()
         self:_post_apply()
     end, opts)
 

--- a/test/config-luatest/app_test.lua
+++ b/test/config-luatest/app_test.lua
@@ -11,7 +11,7 @@ g.test_startup_success = function(g)
         local config = require('config')
         assert(config:get('app.cfg.foo') == 42)
         local info = config:info()
-        assert(info.status == 'ready')
+        assert(info.status == 'startup_in_progress')
         assert(#info.alerts == 0)
 
         _G.foo = 42

--- a/test/config-luatest/roles_test.lua
+++ b/test/config-luatest/roles_test.lua
@@ -597,12 +597,15 @@ g.test_role_started_and_stopped_after_config_loaded = function(g)
         }
     end)
     local verify = function()
-        local exp = {{'start', 'ready', {'one'}}}
+        local exp = {{'start', 'startup_in_progress', {'one'}}}
         t.assert_equals(rawget(_G, 'state'), exp)
     end
 
     local verify_2 = function()
-        local exp = {{'start', 'ready', {'one'}}, {'stop', 'ready'}}
+        local exp = {
+            {'start', 'startup_in_progress', {'one'}},
+            {'stop', 'reload_in_progress'},
+        }
         t.assert_equals(rawget(_G, 'state'), exp)
     end
 


### PR DESCRIPTION
*(This is a backport of PR #9773 to `release/3.0`, future `3.0.2` release.)*

----

Previously, the config status was set after the "apply" phase, and then set again after the "post_apply" phase. This can lead to a situation where the status becomes "ready" after the "apply" phase and changes to "check_errors" or "check_warnings" after the "post_apply" phase. Because of this, it was possible that config:reload() may be called from a role or an app even if though the config loading is not finished.

Note that due to this change, the "startup_in_progress" and "reload_in_progress" statuses are now expanded to include the "post_apply" phase.

Also note that the status still changes before the "extras.post_apply" stage.

Needed for https://github.com/tarantool/tarantool-ee/issues/643