### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9595-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9595-luajit-fixes.md
@@ -12,3 +12,5 @@ were fixed as part of this activity:
 * Fixed recording of `setmetatable()` with `nil` as the second argument.
 * Fixed recording of `select()` in case with negative first argument.
 * Fixed use-def analysis for child upvalues.
+* Fixed recording of a return to a lower frame with the maximum possible frame
+  size.


### PR DESCRIPTION
* Check frame size limit before returning to a lower frame.

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump