### PR TITLE
box: speed up `tuple_new()` for large sparse tuples by 3.5x

### DIFF
--- a/changelogs/unreleased/box-speed-up-tuple_new.md
+++ b/changelogs/unreleased/box-speed-up-tuple_new.md
@@ -1,0 +1,3 @@
+## feature/box
+
+* Sped up the creation of large sparse tuples by up to 3.5x in a synthetic test.

--- a/test/box/alter.result
+++ b/test/box/alter.result
@@ -1307,6 +1307,20 @@ s:alter({field_count = 'string'})
 ---
 - error: Illegal parameters, options parameter 'field_count' should be of type number
 ...
+-- exact_field_count is less than index_field_count.
+s:alter({field_count = 1})
+---
+...
+sk = s:create_index('sk', {parts = {2, 'unsigned'}})
+---
+...
+s:replace{1}
+---
+- error: Tuple field 2 required by space format is missing
+...
+sk:drop()
+---
+...
 -- Alter owner.
 owner1 = box.space._space:get{s.id}.owner
 ---

--- a/test/box/alter.test.lua
+++ b/test/box/alter.test.lua
@@ -522,6 +522,11 @@ s:delete{1}
 -- Invalid values.
 s:alter({field_count = box.NULL})
 s:alter({field_count = 'string'})
+-- exact_field_count is less than index_field_count.
+s:alter({field_count = 1})
+sk = s:create_index('sk', {parts = {2, 'unsigned'}})
+s:replace{1}
+sk:drop()
 
 -- Alter owner.
 owner1 = box.space._space:get{s.id}.owner

--- a/test/box/ddl_collation.result
+++ b/test/box/ddl_collation.result
@@ -141,22 +141,22 @@ box.space._collation:auto_increment{'test', 0, 'ICU'}
  | ---
  | - error: Tuple field 5 (locale) required by space format is missing
  | ...
-box.space._collation:auto_increment{'test', 'ADMIN', 'ICU', 'ru_RU'}
+box.space._collation:auto_increment{'test', 'ADMIN', 'ICU', 'ru_RU', setmap{}}
  | ---
  | - error: 'Tuple field 3 (owner) type does not match one required by operation: expected
  |     unsigned, got string'
  | ...
-box.space._collation:auto_increment{42, 0, 'ICU', 'ru_RU'}
+box.space._collation:auto_increment{42, 0, 'ICU', 'ru_RU', setmap{}}
  | ---
  | - error: 'Tuple field 2 (name) type does not match one required by operation: expected
  |     string, got unsigned'
  | ...
-box.space._collation:auto_increment{'test', 0, 42, 'ru_RU'}
+box.space._collation:auto_increment{'test', 0, 42, 'ru_RU', setmap{}}
  | ---
  | - error: 'Tuple field 4 (type) type does not match one required by operation: expected
  |     string, got unsigned'
  | ...
-box.space._collation:auto_increment{'test', 0, 'ICU', 42}
+box.space._collation:auto_increment{'test', 0, 'ICU', 42, setmap{}}
  | ---
  | - error: 'Tuple field 5 (locale) type does not match one required by operation: expected
  |     string, got unsigned'

--- a/test/box/ddl_collation.test.lua
+++ b/test/box/ddl_collation.test.lua
@@ -44,10 +44,10 @@ box.internal.collation.drop('test')
 
 box.space._collation:auto_increment{'test'}
 box.space._collation:auto_increment{'test', 0, 'ICU'}
-box.space._collation:auto_increment{'test', 'ADMIN', 'ICU', 'ru_RU'}
-box.space._collation:auto_increment{42, 0, 'ICU', 'ru_RU'}
-box.space._collation:auto_increment{'test', 0, 42, 'ru_RU'}
-box.space._collation:auto_increment{'test', 0, 'ICU', 42}
+box.space._collation:auto_increment{'test', 'ADMIN', 'ICU', 'ru_RU', setmap{}}
+box.space._collation:auto_increment{42, 0, 'ICU', 'ru_RU', setmap{}}
+box.space._collation:auto_increment{'test', 0, 42, 'ru_RU', setmap{}}
+box.space._collation:auto_increment{'test', 0, 'ICU', 42, setmap{}}
 box.space._collation:auto_increment{'test', 0, 'ICU', 'ru_RU', setmap{}} --ok
 err, res = pcall(function() return box.space._collation:auto_increment{'test', 0, 'ICU', 'ru_RU', setmap{}} end)
 assert(res.code == box.error.TUPLE_FOUND)


### PR DESCRIPTION
The first 2 patches add the `bench_tuple_new<FORMAT_SPARSE>` benchmark, that creates sparse tuples (1K fields each, 990 of which are nils).

The next 2 patches speed up the benchmark from 7 μs to 2 μs per iteration.

Needed for tarantool/tarantool-ee#711