### PR TITLE
box: fix DDL check for recovery

### DIFF
--- a/src/box/schema.cc
+++ b/src/box/schema.cc
@@ -32,6 +32,7 @@
 #include "sequence.h"
 #include "assoc.h"
 #include "alter.h"
+#include "box.h"
 #include "scoped_guard.h"
 #include "user.h"
 #include "vclock/vclock.h"
@@ -171,12 +172,14 @@ dd_check_is_disabled(void)
 	 *    modify the schema, in particular drop a system space;
 	 *  - in the applier fiber so that it can replicate changes done by
 	 *    a schema upgrade on the master;
+	 *  - during bootstrap so that DDL operations can be performed when
+	 *    generating new bootstrap snapshot;
 	 *  - during recovery so that DDL records written to the WAL can be
 	 *    replayed.
 	 */
 	return fiber() == schema_upgrade_fiber ||
 	       current_session()->type == SESSION_TYPE_APPLIER ||
-	       recovery_state != FINISHED_RECOVERY;
+	       !box_is_configured() || recovery_state != FINISHED_RECOVERY;
 }
 
 static int


### PR DESCRIPTION
Commit https://github.com/tarantool/tarantool/commit/71de4b2c921777a4150bac36c8d9dea8bbb082c9 ("box: fix schema downgrade replication") introduces check that decides when DDL is disabled if current schema is not equal to required schema. This patch adds a condition for DDL operations to be enabled during recovery, so new bootstrap snapshot can be properly generated.

Follow-up https://github.com/tarantool/tarantool/issues/9049

Co-authored-by: Vladimir Davydov <vdavydov@tarantool.org>