### PR TITLE
ci: bump version of actions/checkout

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,7 +52,7 @@ jobs:
       uses: tarantool/actions/prepare-checkout@master
 
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: recursive

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
       - name: Sources checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
       - name: Sources checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/debug_asan_clang.yml
+++ b/.github/workflows/debug_asan_clang.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -65,7 +65,7 @@ jobs:
           fuzz-seconds: 600
           dry-run: false
           sanitizer: ${{ matrix.sanitizer }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         id: checkout
         if: failure()
         with:

--- a/.github/workflows/jepsen-cluster-txm.yml
+++ b/.github/workflows/jepsen-cluster-txm.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/jepsen-cluster.yml
+++ b/.github/workflows/jepsen-cluster.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/jepsen-single-instance-txm.yml
+++ b/.github/workflows/jepsen-single-instance-txm.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/jepsen-single-instance.yml
+++ b/.github/workflows/jepsen-single-instance.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/lango-stale-reviews.yml
+++ b/.github/workflows/lango-stale-reviews.yml
@@ -14,7 +14,7 @@ jobs:
       PROJECT_ID: 83
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python3
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -93,7 +93,7 @@ jobs:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
       # We don't need neither deep fetch, nor submodules here.
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Don't use actions/setup-python to don't bother with proper
       # setup of our self-hosted machines, see [1].
       #
@@ -122,7 +122,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/luajit-integration.yml
+++ b/.github/workflows/luajit-integration.yml
@@ -55,7 +55,7 @@ jobs:
         uses: tarantool/actions/prepare-checkout@master
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: tarantool/tarantool
           fetch-depth: 0

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -31,7 +31,7 @@ jobs:
         uses: tarantool/actions/prepare-checkout@master
 
       - name: Sources checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ matrix.tarantool-branch }}
           fetch-depth: 0

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/perf_cbench.yml
+++ b/.github/workflows/perf_cbench.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
       - name: cleanup workspace
         run: docker run -w /source -v ${PWD}:/source -i centos:8 /bin/bash -c "chown -R $(id -u):$(id -g) * .[^.]*"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: test
         env:
           BENCH: 'cbench'

--- a/.github/workflows/perf_linkbench_ssd.yml
+++ b/.github/workflows/perf_linkbench_ssd.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
       - name: cleanup workspace
         run: docker run -w /source -v ${PWD}:/source -i centos:8 /bin/bash -c "chown -R $(id -u):$(id -g) * .[^.]*"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: test
         env:
           BENCH: 'linkbench'

--- a/.github/workflows/perf_micro.yml
+++ b/.github/workflows/perf_micro.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/perf_nosqlbench_hash.yml
+++ b/.github/workflows/perf_nosqlbench_hash.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
       - name: cleanup workspace
         run: docker run -w /source -v ${PWD}:/source -i centos:8 /bin/bash -c "chown -R $(id -u):$(id -g) * .[^.]*"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: test
         env:
           BENCH: 'nosqlbench'

--- a/.github/workflows/perf_nosqlbench_tree.yml
+++ b/.github/workflows/perf_nosqlbench_tree.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
       - name: cleanup workspace
         run: docker run -w /source -v ${PWD}:/source -i centos:8 /bin/bash -c "chown -R $(id -u):$(id -g) * .[^.]*"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: test
         env:
           BENCH: 'nosqlbench'

--- a/.github/workflows/perf_sysbench.yml
+++ b/.github/workflows/perf_sysbench.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout tarantool
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ matrix.branch }}
           fetch-depth: 0
@@ -41,13 +41,13 @@ jobs:
       - uses: ./.github/actions/environment
 
       - name: Checkout bench-run
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: bench-run
           repository: tarantool/bench-run
 
       - name: Checkout sysbench
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: sysbench
           repository: tarantool/sysbench

--- a/.github/workflows/perf_tpcc.yml
+++ b/.github/workflows/perf_tpcc.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
       - name: cleanup workspace
         run: docker run -w /source -v ${PWD}:/source -i centos:8 /bin/bash -c "chown -R $(id -u):$(id -g) * .[^.]*"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: test
         env:
           BENCH: 'tpcc'

--- a/.github/workflows/perf_tpch.yml
+++ b/.github/workflows/perf_tpch.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
       - name: cleanup workspace
         run: docker run -w /source -v ${PWD}:/source -i centos:8 /bin/bash -c "chown -R $(id -u):$(id -g) * .[^.]*"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: test
         env:
           BENCH: 'tpch'

--- a/.github/workflows/perf_ycsb_hash.yml
+++ b/.github/workflows/perf_ycsb_hash.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
       - name: cleanup workspace
         run: docker run -w /source -v ${PWD}:/source -i centos:8 /bin/bash -c "chown -R $(id -u):$(id -g) * .[^.]*"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: test
         env:
           BENCH: 'ycsb'

--- a/.github/workflows/perf_ycsb_tree.yml
+++ b/.github/workflows/perf_ycsb_tree.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
       - name: cleanup workspace
         run: docker run -w /source -v ${PWD}:/source -i centos:8 /bin/bash -c "chown -R $(id -u):$(id -g) * .[^.]*"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: test
         env:
           BENCH: 'ycsb'

--- a/.github/workflows/publish-module-api-doc.yaml
+++ b/.github/workflows/publish-module-api-doc.yaml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/release_asan_clang.yml
+++ b/.github/workflows/release_asan_clang.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/release_lto_clang.yml
+++ b/.github/workflows/release_lto_clang.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
           # Fetch the entire history for all branches and tags.

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive


### PR DESCRIPTION
Bump version of actions/checkout to v4.
Bump fixes an annoying warning that appears in Github WebUI:

Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

NO_CHANGELOG=ci
NO_DOC=ci
NO_TEST=ci

-----

Example of GH run with annoying  warnings: https://github.com/tarantool/luajit/actions/runs/8249042242