### PR TITLE
net.box: do not start worker fiber synchronously

### DIFF
--- a/changelogs/unreleased/gh-9489-netbox-wait-connected.md
+++ b/changelogs/unreleased/gh-9489-netbox-wait-connected.md
@@ -1,0 +1,5 @@
+## bugfix/lua
+
+* Fixed a regression that caused the `wait_connected = false` option of
+  `net_box.connect` to yield, despite being required to be fully asynchronous
+  (gh-9489).

--- a/test/box-luatest/gh_9489_netbox_wait_connected_test.lua
+++ b/test/box-luatest/gh_9489_netbox_wait_connected_test.lua
@@ -1,0 +1,23 @@
+local fiber = require('fiber')
+local net_box = require('net.box')
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+-- Tests that the `wait_connected = false` option of `connect` guarantees that
+-- the a yield does not happen, i.e., that `connect` is fully asynchronous.
+g.test_wait_connected_fully_async = function(cg)
+    local csw_before = fiber.self().csw()
+    net_box.connect(cg.server.net_box_uri, {wait_connected = false})
+    t.assert_equals(fiber.self().csw(), csw_before)
+end


### PR DESCRIPTION
This patch fixes a regression introduced in c13b3a31, which caused the worker fiber to start synchronously, while it should be started asynchronously.

Closes #9489