### PR TITLE
ci: bump version of upload-artifact/download-artifact action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
         submodules: recursive
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
@@ -62,6 +62,6 @@ jobs:
       run: make -f .test.mk build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -108,14 +108,14 @@ jobs:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
 
       - name: Collect coverage info
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           retention-days: 21
           path: ./coverage.info
 
       - name: Collect failure logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: failure-logs

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: debug

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -97,7 +97,7 @@ jobs:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
 
       - name: Collect artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: failure-logs

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -89,7 +89,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: failure-logs

--- a/.github/workflows/debug_asan_clang.yml
+++ b/.github/workflows/debug_asan_clang.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: debug_asan_clang

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: default_gcc_centos_7

--- a/.github/workflows/etcd_integration.yml
+++ b/.github/workflows/etcd_integration.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Check out the etcd-client module
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/etcd-client
           token: ${{ secrets.PRIVATE_REPO_ACCESS_TOKEN }}

--- a/.github/workflows/etcd_integration.yml
+++ b/.github/workflows/etcd_integration.yml
@@ -27,7 +27,7 @@ jobs:
           token: ${{ secrets.PRIVATE_REPO_ACCESS_TOKEN }}
 
       - name: Download the tarantool build artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
 

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -60,7 +60,7 @@ jobs:
           $GITHUB_ENV
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ format(

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: upload crash
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure() && steps.build.outcome == 'success'
         with:
           name: ${{ matrix.sanitizer }}-artifacts

--- a/.github/workflows/jepsen-cluster-txm.yml
+++ b/.github/workflows/jepsen-cluster-txm.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: jepsen-cluster-txm

--- a/.github/workflows/jepsen-cluster.yml
+++ b/.github/workflows/jepsen-cluster.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: jepsen-cluster

--- a/.github/workflows/jepsen-single-instance-txm.yml
+++ b/.github/workflows/jepsen-single-instance-txm.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: jepsen-single-instance-txm

--- a/.github/workflows/jepsen-single-instance.yml
+++ b/.github/workflows/jepsen-single-instance.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: jepsen-single-instance

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: memtx_allocator_based_on_malloc

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -58,7 +58,7 @@ jobs:
           $GITHUB_ENV
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ format(

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: out_of_source

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -55,7 +55,7 @@ jobs:
       test-matrix: '{
         "include": [
           {"os": "debian-buster"}, {"os": "debian-bullseye"},
-          {"os": "centos-7"}, {"os": "centos-8"},
+          {"os": "centos-8"},
           {"os": "fedora-35"}, {"os": "fedora-36"},
           {"os": "ubuntu-focal"}, {"os": "ubuntu-jammy"}
         ]
@@ -76,7 +76,7 @@ jobs:
       test-matrix: '{
         "include": [
           {"os": "debian-buster"}, {"os": "debian-bullseye"},
-          {"os": "centos-7"}, {"os": "centos-8"},
+          {"os": "centos-8"},
           {"os": "fedora-35"}, {"os": "fedora-36"},
           {"os": "ubuntu-focal"}, {"os": "ubuntu-jammy"}
         ]

--- a/.github/workflows/perf_cbench.yml
+++ b/.github/workflows/perf_cbench.yml
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/actions/send-telegram-notify
         if: failure()
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: perf_cbench

--- a/.github/workflows/perf_linkbench_ssd.yml
+++ b/.github/workflows/perf_linkbench_ssd.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/send-telegram-notify
         if: failure()
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: perf_linkbench_ssd

--- a/.github/workflows/perf_micro.yml
+++ b/.github/workflows/perf_micro.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: release

--- a/.github/workflows/perf_nosqlbench_hash.yml
+++ b/.github/workflows/perf_nosqlbench_hash.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/send-telegram-notify
         if: failure()
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: perf_nosqlbench_hash

--- a/.github/workflows/perf_nosqlbench_tree.yml
+++ b/.github/workflows/perf_nosqlbench_tree.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/send-telegram-notify
         if: failure()
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: perf_nosqlbench_tree

--- a/.github/workflows/perf_sysbench.yml
+++ b/.github/workflows/perf_sysbench.yml
@@ -147,7 +147,7 @@ jobs:
         if: failure()
 
       - name: Collect artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: perf_sysbench_${{ matrix.branch }}

--- a/.github/workflows/perf_tpcc.yml
+++ b/.github/workflows/perf_tpcc.yml
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/actions/send-telegram-notify
         if: failure()
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: perf_tpcc

--- a/.github/workflows/perf_tpch.yml
+++ b/.github/workflows/perf_tpch.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/send-telegram-notify
         if: failure()
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: perf_tpch

--- a/.github/workflows/perf_ycsb_hash.yml
+++ b/.github/workflows/perf_ycsb_hash.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/send-telegram-notify
         if: failure()
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: perf_ycsb_hash

--- a/.github/workflows/perf_ycsb_tree.yml
+++ b/.github/workflows/perf_ycsb_tree.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/send-telegram-notify
         if: failure()
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: perf_ycsb_tree

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: release

--- a/.github/workflows/release_asan_clang.yml
+++ b/.github/workflows/release_asan_clang.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: release_asan_clang

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: release_clang

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: release_lto

--- a/.github/workflows/release_lto_clang.yml
+++ b/.github/workflows/release_lto_clang.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: release_lto_clang

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -68,7 +68,7 @@ jobs:
           PRESERVE_ENVVARS: 'MAKE_CHECK,${{ env.PRESERVE_ENVVARS }}'
         run: make -f .pack.mk package
       - name: 'Upload build artifacts'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tarantool-${{ env.OS }}-${{ env.DIST }}-${{ steps.get_sha.outputs.sha }}
           retention-days: 21
@@ -78,7 +78,7 @@ jobs:
           if-no-files-found: error
       - name: 'Upload logs if the build failed'
         if: failure() && steps.run_build.conclusion == 'failure'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tarantool-build-log-${{ env.OS }}-${{ env.DIST }}-${{ steps.get_sha.outputs.sha }}
           retention-days: 21

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: static_build

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
       - name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: static_build_cmake_linux

--- a/.github/workflows/static_build_pack_test_deploy.yml
+++ b/.github/workflows/static_build_pack_test_deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -94,7 +94,7 @@ jobs:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -181,7 +181,7 @@ jobs:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/static_build_pack_test_deploy.yml
+++ b/.github/workflows/static_build_pack_test_deploy.yml
@@ -39,7 +39,7 @@ jobs:
         working-directory: static-build/tarantool-prefix/src/tarantool-build/
 
       - name: Upload deb packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tarantool-deb-${{ inputs.arch }}
           retention-days: 21
@@ -47,7 +47,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload rpm packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tarantool-rpm-${{ inputs.arch }}
           retention-days: 21
@@ -55,7 +55,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload test libraries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tarantool-test-libs-${{ inputs.arch }}
           retention-days: 21
@@ -123,14 +123,14 @@ jobs:
       - uses: ./.github/actions/environment
 
       - name: Download packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tarantool-${{
             env.PACKAGE_MANAGER == 'apt' && 'deb' || 'rpm' }}-${{ inputs.arch }}
           path: build
 
       - name: Download test libraries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tarantool-test-libs-${{ inputs.arch }}
           path: build
@@ -186,13 +186,13 @@ jobs:
           fetch-depth: 0
 
       - name: Download deb packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tarantool-deb-${{ inputs.arch }}
           path: build
 
       - name: Download rpm packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tarantool-rpm-${{ inputs.arch }}
           path: build


### PR DESCRIPTION
- bump version of `upload-artifact`/`download-artifact` action
- drop testing on CentOS 7 in packaging workflow
- follow up bump of `checkout` action (follows up #9795)
- bump version of `codeql-action` action