### PR TITLE
sql: rework OP_SetDiag opcode

### DIFF
--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -4309,15 +4309,10 @@ sqlExprCodeTarget(Parse * pParse, Expr * pExpr, int target)
 		}
 		assert(!ExprHasProperty(pExpr, EP_IntValue));
 		if (pExpr->on_conflict_action == ON_CONFLICT_ACTION_IGNORE) {
-			sqlVdbeAddOp4(v, OP_Halt, 0,
-					  ON_CONFLICT_ACTION_IGNORE, 0,
-					  pExpr->u.zToken, 0);
+			sqlVdbeAddOp2(v, OP_Halt, 0, ON_CONFLICT_ACTION_IGNORE);
 		} else {
-			const char *err =
-				tt_sprintf(tnt_errcode_desc(ER_SQL_EXECUTE),
-					   pExpr->u.zToken);
-			sqlVdbeAddOp4(v, OP_SetDiag, ER_SQL_EXECUTE, 0, 0, err,
-				      P4_STATIC);
+			sqlVdbeAddOp4(v, OP_SetDiag, ER_SQL_EXECUTE, 0, 0,
+				      sql_xstrdup(pExpr->u.zToken), P4_DYNAMIC);
 			sqlVdbeAddOp2(v, OP_Halt, -1,
 				      pExpr->on_conflict_action);
 		}

--- a/src/box/sql/insert.c
+++ b/src/box/sql/insert.c
@@ -795,13 +795,11 @@ vdbe_emit_constraint_checks(struct Parse *parse_context, struct space *space,
 		case ON_CONFLICT_ACTION_ABORT:
 		case ON_CONFLICT_ACTION_ROLLBACK:
 		case ON_CONFLICT_ACTION_FAIL:
-			err = tt_sprintf(tnt_errcode_desc(ER_SQL_EXECUTE),
-					 tt_sprintf("NOT NULL constraint "\
-						    "failed: %s.%s", def->name,
-						    def->fields[i].name));
+			err = tt_sprintf("NOT NULL constraint failed: %s.%s",
+					 def->name, def->fields[i].name);
 			addr = sqlVdbeAddOp1(v, OP_NotNull, new_tuple_reg + i);
-			sqlVdbeAddOp4(v, OP_SetDiag, ER_SQL_EXECUTE, 0, 0, err,
-				      P4_STATIC);
+			sqlVdbeAddOp4(v, OP_SetDiag, ER_SQL_EXECUTE, 0, 0,
+				      sql_xstrdup(err), P4_DYNAMIC);
 			sqlVdbeAddOp2(v, OP_Halt, -1, on_conflict_nullable);
 			sqlVdbeJumpHere(v, addr);
 			break;

--- a/src/box/sql/select.c
+++ b/src/box/sql/select.c
@@ -2276,9 +2276,8 @@ computeLimitRegisters(Parse * pParse, Select * p, int iBreak)
 		sqlVdbeAddOp2(v, OP_Integer, 0, r1);
 		sqlVdbeAddOp3(v, OP_Ge, r1, positive_limit_label, iLimit);
 		/* Otherwise return an error and stop */
-		const char *err = tt_sprintf(tnt_errcode_desc(ER_SQL_EXECUTE),
-					     "Only positive integers are "\
-					     "allowed in the LIMIT clause");
+		const char *err = "Only positive integers are allowed in the "
+				  "LIMIT clause";
 		sqlVdbeResolveLabel(v, halt_label);
 		sqlVdbeAddOp4(v, OP_SetDiag, ER_SQL_EXECUTE, 0, 0, err,
 			      P4_STATIC);
@@ -2308,10 +2307,8 @@ computeLimitRegisters(Parse * pParse, Select * p, int iBreak)
 				sqlVdbeAddOp2(v, OP_Integer, 1, r1);
 				int no_err = sqlVdbeMakeLabel(v);
 				sqlVdbeAddOp3(v, OP_Eq, iLimit, no_err, r1);
-				err = tnt_errcode_desc(ER_SQL_EXECUTE);
-				err = tt_sprintf(err, "Expression subquery "\
-						 "could be limited only "\
-						 "with 1");
+				err = "Expression subquery could be limited "
+				      "only with 1";
 				sqlVdbeAddOp4(v, OP_SetDiag, ER_SQL_EXECUTE, 0,
 					      0, err, P4_STATIC);
 				sqlVdbeAddOp1(v, OP_Halt, -1);
@@ -2335,9 +2332,8 @@ computeLimitRegisters(Parse * pParse, Select * p, int iBreak)
 
             		sqlVdbeAddOp3(v, OP_Ge, r1, positive_offset_label, iOffset);
 			/* Otherwise return an error and stop */
-			err = tt_sprintf(tnt_errcode_desc(ER_SQL_EXECUTE),
-					 "Only positive integers are allowed "\
-					 "in the OFFSET clause");
+			err = "Only positive integers are allowed in the "
+			      "OFFSET clause";
 			sqlVdbeResolveLabel(v, offset_error_label);
 			sqlVdbeAddOp4(v, OP_SetDiag, ER_SQL_EXECUTE, 0, 0, err,
 				      P4_STATIC);
@@ -5506,9 +5502,7 @@ vdbe_code_raise_on_multiple_rows(struct Parse *parser, int limit_reg, int end_ma
 	int r1 = sqlGetTempReg(parser);
 	sqlVdbeAddOp2(v, OP_Integer, 0, r1);
 	sqlVdbeAddOp3(v, OP_Ne, r1, end_mark, limit_reg);
-	const char *error = tt_sprintf(tnt_errcode_desc(ER_SQL_EXECUTE),
-				       "Expression subquery returned more "\
-				       "than 1 row");
+	const char *error = "Expression subquery returned more than 1 row";
 	sqlVdbeAddOp4(v, OP_SetDiag, ER_SQL_EXECUTE, 0, 0, error, P4_STATIC);
 	sqlVdbeAddOp1(v, OP_Halt, -1);
 	sqlReleaseTempReg(parser, r1);

--- a/src/box/sql/trigger.c
+++ b/src/box/sql/trigger.c
@@ -95,17 +95,15 @@ sql_trigger_begin(struct Parse *parse)
 	if (!parse->parse_only) {
 		struct Vdbe *v = sqlGetVdbe(parse);
 		sqlVdbeCountChanges(v);
-		const char *error_msg =
-			tt_sprintf(tnt_errcode_desc(ER_TRIGGER_EXISTS),
-				   trigger_name);
 		int name_reg = ++parse->nMem;
 		sqlVdbeAddOp4(parse->pVdbe, OP_String8, 0, name_reg, 0,
 			      sql_xstrdup(trigger_name), P4_DYNAMIC);
 		bool no_err = create_def->if_not_exist;
 		vdbe_emit_halt_with_presence_test(parse, BOX_TRIGGER_ID, 0,
 						  name_reg, 1,
-						  ER_TRIGGER_EXISTS, error_msg,
-						  (no_err != 0), OP_NoConflict);
+						  ER_TRIGGER_EXISTS,
+						  trigger_name, (no_err != 0),
+						  OP_NoConflict);
 	}
 
 	/* Build the Trigger object. */
@@ -335,14 +333,11 @@ sql_drop_trigger(struct Parse *parser)
 
 	assert(name->nSrc == 1);
 	const char *trigger_name = name->a[0].zName;
-	const char *error_msg =
-		tt_sprintf(tnt_errcode_desc(ER_NO_SUCH_TRIGGER),
-			   trigger_name);
 	int name_reg = ++parser->nMem;
 	sqlVdbeAddOp4(v, OP_String8, 0, name_reg, 0, sql_xstrdup(trigger_name),
 		      P4_DYNAMIC);
 	vdbe_emit_halt_with_presence_test(parser, BOX_TRIGGER_ID, 0, name_reg,
-					  1, ER_NO_SUCH_TRIGGER, error_msg,
+					  1, ER_NO_SUCH_TRIGGER, trigger_name,
 					  no_err, OP_Found);
 	vdbe_code_drop_trigger(parser, trigger_name, true);
 	sqlSrcListDelete(name);

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -530,7 +530,10 @@ case OP_Goto: {             /* jump */
  * text description of the error.
  */
 case OP_SetDiag: {             /* jump */
-	box_error_set(__FILE__, __LINE__, pOp->p1, pOp->p4.z);
+	assert(pOp->p1 == ER_TRIGGER_EXISTS || pOp->p1 == ER_NO_SUCH_TRIGGER ||
+	       pOp->p1 == ER_SPACE_EXISTS || pOp->p1 == ER_FUNCTION_EXISTS ||
+	       pOp->p1 == ER_SQL_CANT_ADD_AUTOINC || pOp->p1 == ER_SQL_EXECUTE);
+	diag_set(ClientError, pOp->p1, pOp->p4.z);
 	if (pOp->p2 != 0)
 		goto jump_to_p2;
 	break;


### PR DESCRIPTION
Prior to this patch, the OP_SetDiag opcode accepted an error code and error description, which already included the description from the error code. But this makes #9108 more difficult, so now the accepted error description does not include the description from the error code.

Note that this change is possible because all accepted error codes use exactly one argument.

Additionally, this patch removes p4 from the OP_Halt opcode in one place, since OP_Halt only uses p1 and p2 and does not use p4. Moreover, the address specified in p4 may not be available by the time OP_Halt is executed.

Needed for #9108
