### PR TITLE
config: allow to set non-existent credential role

### DIFF
--- a/changelogs/unreleased/gh-9643-credentials-from-app-roles.md
+++ b/changelogs/unreleased/gh-9643-credentials-from-app-roles.md
@@ -1,0 +1,4 @@
+## bugfix/config
+
+* A non-existent role can now be assigned in the `credential` section of
+  the configuration.

--- a/test/config-luatest/credentials_applier_test.lua
+++ b/test/config-luatest/credentials_applier_test.lua
@@ -1766,3 +1766,92 @@ g.test_fix_status_change_with_pending_warnings = function(g)
         t.assert_equals(require('config'):info().status, 'ready')
     end)
 end
+
+-- Verify that it is possible to assign a credential role that does not exist.
+-- And that this role will be correctly assigned when it is created.
+g.test_set_nonexistent_role = function(g)
+    local config = cbuilder.new()
+        :add_instance('i-001', {})
+        :set_global_option('credentials.roles.role_one', {
+            roles = {'role_two'},
+        })
+        :config()
+
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    -- Verify that an alert is set for delayed privilege grants
+    -- for the given role.
+    cluster['i-001']:exec(function()
+        local info = require('config'):info()
+        local exp = 'box.schema.role.grant("role_one", "execute", "role", ' ..
+            '"role_two") has failed because either the object has not been ' ..
+            'created yet, or the privilege write has failed (separate alert ' ..
+            'reported)'
+        t.assert_equals(info.status, 'check_warnings')
+        t.assert_equals(#info.alerts, 1)
+        t.assert_equals(info.alerts[1].type, 'warn')
+        t.assert_equals(tostring(info.alerts[1].message), exp)
+    end)
+
+    -- Verify that the alert is dropped after `role_two` is created.
+    cluster['i-001']:exec(function()
+        box.schema.role.create('role_two')
+        local info = require('config'):info()
+        local exp = {{"execute", "role", "role_two"}}
+        t.assert_equals(info.status, 'ready')
+        t.assert_equals(#info.alerts, 0)
+        t.assert_equals(box.schema.role.info('role_one'), exp)
+    end)
+end
+
+-- Verify that alert does not go away if the user is created with a given name
+-- instead of a role.
+g.test_set_user_instead_of_role = function(g)
+    local config = cbuilder.new()
+        :add_instance('i-001', {})
+        :set_global_option('credentials.users.user_one', {
+            roles = {'role_two'},
+        })
+        :config()
+
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    -- Verify that the alert is set.
+    cluster['i-001']:exec(function()
+        local info = require('config'):info()
+        local exp = 'box.schema.user.grant("user_one", "execute", "role", ' ..
+            '"role_two") has failed because either the object has not been ' ..
+            'created yet, or the privilege write has failed (separate alert ' ..
+            'reported)'
+        t.assert_equals(info.status, 'check_warnings')
+        t.assert_equals(#info.alerts, 1)
+        t.assert_equals(info.alerts[1].type, 'warn')
+        t.assert_equals(tostring(info.alerts[1].message), exp)
+    end)
+
+    -- Verify that the alert is still present after creating user 'role_two'
+    -- instead of role 'role_two'.
+    cluster['i-001']:exec(function()
+        box.schema.user.create('role_two')
+        local info = require('config'):info()
+        local exp = 'box.schema.user.grant("user_one", "execute", "role", ' ..
+            '"role_two") has failed because either the object has not been ' ..
+            'created yet, or the privilege write has failed (separate alert ' ..
+            'reported)'
+        t.assert_equals(info.status, 'check_warnings')
+        t.assert_equals(#info.alerts, 1)
+        t.assert_equals(info.alerts[1].type, 'warn')
+        t.assert_equals(tostring(info.alerts[1].message), exp)
+    end)
+
+    -- Verify that the alert is dropped after 'role_two' is created.
+    cluster['i-001']:exec(function()
+        box.schema.user.drop('role_two')
+        box.schema.role.create('role_two')
+        local info = require('config'):info()
+        t.assert_equals(info.status, 'ready')
+        t.assert_equals(#info.alerts, 0)
+    end)
+end


### PR DESCRIPTION
Part of #9643

@TarantoolBot document
Title: Assign a non-existent credential role

A non-existent credential role can be assigned to a user or role in `credential` section of the config. The actual assignment will occur when the assigned credential role is created.