### PR TITLE
config: introduce labels to schema

### DIFF
--- a/changelogs/unreleased/gh-9809-config-add-labels.md
+++ b/changelogs/unreleased/gh-9809-config-add-labels.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* Introduced the `labels` configuration option. The labels are maps with
+  string keys that are merged to instance level (gh-9809).

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2378,6 +2378,15 @@ return schema.new('instance_config', schema.record({
             default = 'old',
         }),
     }),
+    -- Instance labels.
+    labels = schema.map({
+        key = schema.scalar({
+            type = 'string',
+        }),
+        value = schema.scalar({
+            type = 'string',
+        }),
+    }),
 }, {
     -- This kind of validation cannot be implemented as the
     -- 'validate' annotation of a particular schema node. There

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1718,3 +1718,16 @@ g.test_failover = function()
     local res = instance_config:apply_default({}).failover
     t.assert_equals(res, exp)
 end
+
+g.test_labels = function()
+    local iconfig = {
+        labels = {
+            foo = 'true',
+            bar = 'false',
+        },
+    }
+
+    instance_config:validate(iconfig)
+
+    t.assert_equals(instance_config:apply_default({}).labels, nil)
+end

--- a/test/config-luatest/labels_test.lua
+++ b/test/config-luatest/labels_test.lua
@@ -1,0 +1,38 @@
+local t = require('luatest')
+local cbuilder = require('test.config-luatest.cbuilder')
+local cluster = require('test.config-luatest.cluster')
+
+local g = t.group()
+
+g.before_all(cluster.init)
+g.after_each(cluster.drop)
+g.after_all(cluster.clean)
+
+-- Verify that instance labels are merged correctly.
+g.test_labels = function(g)
+    local config = cbuilder.new()
+        :set_replicaset_option('labels', {
+            foo = 'true',
+            bar = 'true',
+        })
+        :add_instance('instance-001', {
+            labels = {
+                baz = 'true',
+                foo = 'false',
+            },
+        })
+        :config()
+
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    cluster['instance-001']:exec(function()
+        local config = require('config')
+
+        t.assert_equals(config:get('labels'), {
+            foo = 'false',
+            bar = 'true',
+            baz = 'true',
+        })
+    end)
+end


### PR DESCRIPTION
Closes #9809

@TarantoolBot document
Title: New labels in config schema

The new labels are basically maps with string keys and values, that are merged down to instance level. It means that if a replicaset and an instance inside it have label with same key and different value, the actual value is the one instance provided, e.g.

```yaml
groups:
  group-001:
    replicasets:
      replicaset-001:
        labels:
          foo: 'true'
          bar: 'true'
        instances:
          instance-001:
            labels:
              baz: 'true'
              foo: 'false'
```

Results in:

```
./instance-001.iproto> require('config'):get('labels')
---
- baz: 'true'
  foo: 'false'
  bar: 'true'
...
```