### PR TITLE
[2.10] ci: bump version of actions/checkout

### DIFF
--- a/.github/workflows/alpine_3_16.yml
+++ b/.github/workflows/alpine_3_16.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/alpine_3_16_aarch64.yml
+++ b/.github/workflows/alpine_3_16_aarch64.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/centos_7_aarch64.yml
+++ b/.github/workflows/centos_7_aarch64.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/centos_8_aarch64.yml
+++ b/.github/workflows/centos_8_aarch64.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
       - name: Sources checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/debian_10_aarch64.yml
+++ b/.github/workflows/debian_10_aarch64.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/debian_11_aarch64.yml
+++ b/.github/workflows/debian_11_aarch64.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
       - name: Sources checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/debug_asan_clang.yml
+++ b/.github/workflows/debug_asan_clang.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/fedora_34_aarch64.yml
+++ b/.github/workflows/fedora_34_aarch64.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/fedora_35.yml
+++ b/.github/workflows/fedora_35.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/fedora_35_aarch64.yml
+++ b/.github/workflows/fedora_35_aarch64.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/fedora_36.yml
+++ b/.github/workflows/fedora_36.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/fedora_36_aarch64.yml
+++ b/.github/workflows/fedora_36_aarch64.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -65,7 +65,7 @@ jobs:
           fuzz-seconds: 600
           dry-run: false
           sanitizer: ${{ matrix.sanitizer }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         id: checkout
         if: failure()
         with:

--- a/.github/workflows/jepsen-cluster-txm.yml
+++ b/.github/workflows/jepsen-cluster-txm.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/jepsen-cluster.yml
+++ b/.github/workflows/jepsen-cluster.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/jepsen-single-instance-txm.yml
+++ b/.github/workflows/jepsen-single-instance-txm.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/jepsen-single-instance.yml
+++ b/.github/workflows/jepsen-single-instance.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -93,7 +93,7 @@ jobs:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
       # We don't need neither deep fetch, nor submodules here.
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Don't use actions/setup-python to don't bother with proper
       # setup of our self-hosted machines, see [1].
       #
@@ -122,7 +122,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/luajit-integration.yml
+++ b/.github/workflows/luajit-integration.yml
@@ -55,7 +55,7 @@ jobs:
         uses: tarantool/actions/prepare-checkout@master
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: tarantool/tarantool
           fetch-depth: 0

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -31,7 +31,7 @@ jobs:
         uses: tarantool/actions/prepare-checkout@master
 
       - name: Sources checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ matrix.tarantool-branch }}
           fetch-depth: 0

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/perf_cbench.yml
+++ b/.github/workflows/perf_cbench.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
       - name: cleanup workspace
         run: docker run -w /source -v ${PWD}:/source -i centos:8 /bin/bash -c "chown -R $(id -u):$(id -g) * .[^.]*"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: test
         env:
           BENCH: 'cbench'

--- a/.github/workflows/perf_linkbench_ssd.yml
+++ b/.github/workflows/perf_linkbench_ssd.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
       - name: cleanup workspace
         run: docker run -w /source -v ${PWD}:/source -i centos:8 /bin/bash -c "chown -R $(id -u):$(id -g) * .[^.]*"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: test
         env:
           BENCH: 'linkbench'

--- a/.github/workflows/perf_nosqlbench_hash.yml
+++ b/.github/workflows/perf_nosqlbench_hash.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
       - name: cleanup workspace
         run: docker run -w /source -v ${PWD}:/source -i centos:8 /bin/bash -c "chown -R $(id -u):$(id -g) * .[^.]*"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: test
         env:
           BENCH: 'nosqlbench'

--- a/.github/workflows/perf_nosqlbench_tree.yml
+++ b/.github/workflows/perf_nosqlbench_tree.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
       - name: cleanup workspace
         run: docker run -w /source -v ${PWD}:/source -i centos:8 /bin/bash -c "chown -R $(id -u):$(id -g) * .[^.]*"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: test
         env:
           BENCH: 'nosqlbench'

--- a/.github/workflows/perf_sysbench.yml
+++ b/.github/workflows/perf_sysbench.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout tarantool
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ matrix.branch }}
           fetch-depth: 0
@@ -41,13 +41,13 @@ jobs:
       - uses: ./.github/actions/environment
 
       - name: Checkout bench-run
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: bench-run
           repository: tarantool/bench-run
 
       - name: Checkout sysbench
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: sysbench
           repository: tarantool/sysbench

--- a/.github/workflows/perf_tpcc.yml
+++ b/.github/workflows/perf_tpcc.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
       - name: cleanup workspace
         run: docker run -w /source -v ${PWD}:/source -i centos:8 /bin/bash -c "chown -R $(id -u):$(id -g) * .[^.]*"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: test
         env:
           BENCH: 'tpcc'

--- a/.github/workflows/perf_tpch.yml
+++ b/.github/workflows/perf_tpch.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
       - name: cleanup workspace
         run: docker run -w /source -v ${PWD}:/source -i centos:8 /bin/bash -c "chown -R $(id -u):$(id -g) * .[^.]*"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: test
         env:
           BENCH: 'tpch'

--- a/.github/workflows/perf_ycsb_hash.yml
+++ b/.github/workflows/perf_ycsb_hash.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
       - name: cleanup workspace
         run: docker run -w /source -v ${PWD}:/source -i centos:8 /bin/bash -c "chown -R $(id -u):$(id -g) * .[^.]*"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: test
         env:
           BENCH: 'ycsb'

--- a/.github/workflows/perf_ycsb_tree.yml
+++ b/.github/workflows/perf_ycsb_tree.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo "/usr/local/git/bin" | tee -a $GITHUB_PATH
       - name: cleanup workspace
         run: docker run -w /source -v ${PWD}:/source -i centos:8 /bin/bash -c "chown -R $(id -u):$(id -g) * .[^.]*"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: test
         env:
           BENCH: 'ycsb'

--- a/.github/workflows/redos_7_3.yaml
+++ b/.github/workflows/redos_7_3.yaml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/release_asan_clang.yml
+++ b/.github/workflows/release_asan_clang.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/release_lto_clang.yml
+++ b/.github/workflows/release_lto_clang.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
           # Fetch the entire history for all branches and tags.

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/ubuntu_20_04_aarch64.yml
+++ b/.github/workflows/ubuntu_20_04_aarch64.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/ubuntu_22_04_aarch64.yml
+++ b/.github/workflows/ubuntu_22_04_aarch64.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive


### PR DESCRIPTION
Just a regular backport of #9795 via a pull request to verify changes.