### PR TITLE
[backport 2.11] relay: fix stack use after return

### DIFF
--- a/changelogs/unreleased/gh-9505-relay-stack-use-after-return.md
+++ b/changelogs/unreleased/gh-9505-relay-stack-use-after-return.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed an issue when it was possible to use the
+  `box_collect_confirmed_vclock` stack after return (gh-9505).


### PR DESCRIPTION
Fixed a bug when it was possible that the `on_relay_thread_start` trigger handler would continue to use `data` allocated on the stack of `box_collect_confirmed_vclock` after returning from it.

Closes #9505

NO_DOC=bugfix
NO_TEST=asan

(cherry picked from commit 40bd0eb1af0f9429bea0086feb7ceaf8c636f57e)