### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-5994-memprof-human-readable.md
+++ b/changelogs/unreleased/gh-5994-memprof-human-readable.md
@@ -1,0 +1,4 @@
+## feature/tools
+
+Added the `--human-readable` option for the `misc.memprof` parser to print
+sizes like 1KiB, 234MiB, 2GiB, etc.

--- a/changelogs/unreleased/gh-9595-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9595-luajit-fixes.md
@@ -12,3 +12,9 @@ were fixed as part of this activity:
 * Fixed recording of `setmetatable()` with `nil` as the second argument.
 * Fixed recording of `select()` in case with negative first argument.
 * Fixed use-def analysis for child upvalues.
+* Added the `cc` file type for saving bytecode.
+* Fixed C file generation in `jit.bcsave`.
+* Fixed trace error handling during trace stitching.
+* Fixed recording of the `__concat` metamethod for vararg or protected frames.
+* Fixed recording of a side trace returning to a lower frame with a maximum
+  possible frame size.


### PR DESCRIPTION
* test: set dependencies in BuildTestCLib macro
* Add 'cc' file type for saving bytecode.
* Fix C file generation in jit.bcsave.
* Throw any errors before stack changes in trace stitching.
* Fix recording of __concat metamethod.
* Check frame size limit before returning to a lower frame.
* build: purge sysprof.collapse module
* build: fix tool components handling
* memprof: refactor `heap_chunk` data structure
* memprof: remove unused arguments
* memprof: introduce the `--human-readable` option
* profilers: introduce event reader module
* ci: extend tarantool integration testing

Part of #9595
Part of #5994
Follows up #8700
Needed for #9217

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump