### PR TITLE
[backport 2.11] net.box: do not start worker fiber synchronously

### DIFF
--- a/changelogs/unreleased/gh-9489-netbox-wait-connected.md
+++ b/changelogs/unreleased/gh-9489-netbox-wait-connected.md
@@ -1,0 +1,5 @@
+## bugfix/lua
+
+* Fixed a regression that caused the `wait_connected = false` option of
+  `net_box.connect` to yield, despite being required to be fully asynchronous
+  (gh-9489).

--- a/src/box/lua/net_box.c
+++ b/src/box/lua/net_box.c
@@ -2891,18 +2891,12 @@ netbox_connection_handler_f(struct lua_State *L)
 static int
 netbox_worker_f(va_list ap)
 {
-	struct netbox_transport *transport;
-	transport = va_arg(ap, struct netbox_transport *);
-	struct lua_State *L = va_arg(ap, struct lua_State *);
+	(void)ap;
+	struct netbox_transport *transport = fiber()->f_arg;
+	struct lua_State *L = fiber()->storage.lua.stack;
 	assert(transport->worker == fiber());
 	assert(transport->coro_ref != LUA_NOREF);
 	assert(transport->self_ref != LUA_NOREF);
-	/*
-	 * Code that needs a temporary fiber-local Lua state may save some time
-	 * and resources for creating a new state and use this one.
-	 */
-	assert(fiber()->storage.lua.stack == NULL);
-	fiber()->storage.lua.stack = L;
 	const double reconnect_after = transport->opts.reconnect_after;
 	while (!fiber_is_cancelled()) {
 		if (netbox_transport_connect(transport) == 0) {
@@ -2960,7 +2954,14 @@ luaT_netbox_transport_start(struct lua_State *L)
 		transport->self_ref = LUA_NOREF;
 		return luaT_error(L);
 	}
-	fiber_start(transport->worker, transport, fiber_L);
+	transport->worker->f_arg = transport;
+	/*
+	 * Code that needs a temporary fiber-local Lua state may save some time
+	 * and resources for creating a new state and use this one.
+	 */
+	assert(transport->worker->storage.lua.stack == NULL);
+	transport->worker->storage.lua.stack = fiber_L;
+	fiber_wakeup(transport->worker);
 	return 0;
 }
 

--- a/test/box-luatest/gh_9489_netbox_wait_connected_test.lua
+++ b/test/box-luatest/gh_9489_netbox_wait_connected_test.lua
@@ -1,0 +1,23 @@
+local fiber = require('fiber')
+local net_box = require('net.box')
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+-- Tests that the `wait_connected = false` option of `connect` guarantees that
+-- the a yield does not happen, i.e., that `connect` is fully asynchronous.
+g.test_wait_connected_fully_async = function(cg)
+    local csw_before = fiber.self().csw()
+    net_box.connect(cg.server.net_box_uri, {wait_connected = false})
+    t.assert_equals(fiber.self().csw(), csw_before)
+end


### PR DESCRIPTION
Due to a regression introduced in c13b3a31, the worker fiber is started synchronously, while it should be started asynchronously, in order for the `wait_connected = false` option of `connect` to work correctly. We already explicitly wait from Lua for the connection to become active via `wait_state` when `wait_connected = true`.

Closes #9489

NO_DOC=<bugfix>

(cherry picked from commit 0502a1f5249e4f1d14ef6e24628071fc712b7f14)