### PR TITLE
sql: decrease number of tests in in2.test.lua

### DIFF
--- a/test/sql-tap/in2.test.lua
+++ b/test/sql-tap/in2.test.lua
@@ -1,6 +1,6 @@
 #!/usr/bin/env tarantool
 local test = require("sqltester")
-test:plan(1999)
+test:plan(999)
 
 --!./tcltestrunner.lua
 -- 2007 May 12
@@ -29,7 +29,7 @@ test:do_execsql_test(
         -- </in2-1>
     })
 
-local N = 2000
+local N = 1000
 -- MUST_WORK_TEST
 test:do_test(
     "in2-2",


### PR DESCRIPTION
This patch reduces the number of tests in the in2.test.lua test file. This patch also reduces the number of inserted values. This shouldn't affect the test since it's not really an original Tarantool test, but it will reduce the execution time of this test. Currently this test often fails due to a timeout.
