### PR TITLE
`net.box` connection object triggers bugfixes

### DIFF
--- a/changelogs/unreleased/gh-9677-netbox-on_disconnect-error-behaviour.md
+++ b/changelogs/unreleased/gh-9677-netbox-on_disconnect-error-behaviour.md
@@ -1,0 +1,5 @@
+## bugfix/lua
+
+* Fixed an inconsistency between the documented `on_disconnect` trigger behavior
+  of `net.box` connections when an error is thrown and the actual behavior
+  (gh-9717).

--- a/changelogs/unreleased/gh-9679-on_schema_reload-error-behaviour.md
+++ b/changelogs/unreleased/gh-9679-on_schema_reload-error-behaviour.md
@@ -1,0 +1,5 @@
+## bugfix/lua
+
+* The `on_schema_reload` trigger behavior of `net.box` connections when an
+  error is thrown is now consistent with the behavior of the `on_disconnect`
+  trigger (gh-9679).

--- a/changelogs/unreleased/gh-9797-netbox-on_disconnect-error-hangs-server.md
+++ b/changelogs/unreleased/gh-9797-netbox-on_disconnect-error-hangs-server.md
@@ -1,0 +1,5 @@
+## bugfix/lua
+
+* Fixed a bug in the `on_disconnect` trigger of `net.box` connections that
+  caused Tarantool server to hang indefinitely when an error was thrown from the
+  trigger (gh-9797).

--- a/changelogs/unreleased/gh-9827-netbox-on_connect-close.md
+++ b/changelogs/unreleased/gh-9827-netbox-on_connect-close.md
@@ -1,0 +1,4 @@
+## bugfix/lua
+
+* Fixed a bug when a `net.box` connection remained active after being closed
+  from the connection's `on_connect` trigger (gh-9827).

--- a/src/box/lua/net_box.lua
+++ b/src/box/lua/net_box.lua
@@ -1165,7 +1165,11 @@ function remote_methods:_install_schema(schema_version, spaces, indices,
 
     self.schema_version = schema_version
     self.space = sl
-    self._on_schema_reload:run(self)
+    local ok, err = pcall(self._on_schema_reload.run, self._on_schema_reload,
+                          self)
+    if not ok then
+        log.error(err)
+    end
 end
 
 local function nothing_or_data(value)

--- a/src/box/lua/net_box.lua
+++ b/src/box/lua/net_box.lua
@@ -277,6 +277,7 @@ local function new_sm(uri_or_fd, opts)
         end
         if what == 'state_changed' then
             local state, err = ...
+            remote.state, remote.error = state, err
             local was_connected = remote._is_connected
             if state == 'active' then
                 if not was_connected then
@@ -301,7 +302,6 @@ local function new_sm(uri_or_fd, opts)
                 -- time we finish running on_shutdown triggers.
                 remote._shutdown_pending = nil
             end
-            remote.state, remote.error = state, err
             if state == 'error_reconnect' then
                 -- Repeat the same error in verbose log only.
                 -- Else the error clogs the log. See gh-3175.

--- a/src/box/lua/net_box.lua
+++ b/src/box/lua/net_box.lua
@@ -287,7 +287,11 @@ local function new_sm(uri_or_fd, opts)
                    state == 'closed' then
                 if was_connected then
                     remote._is_connected = false
-                    remote._on_disconnect:run(remote)
+                    local ok, trigger_err = pcall(remote._on_disconnect.run,
+                                                  remote._on_disconnect, remote)
+                    if not ok then
+                        log.error(trigger_err)
+                    end
                 end
                 -- A server may exit after initiating a graceful shutdown but
                 -- before all clients close their connections (for example, on

--- a/test/box-luatest/gh_9309_errors_in_triggers_test.lua
+++ b/test/box-luatest/gh_9309_errors_in_triggers_test.lua
@@ -195,10 +195,9 @@ g.test_net_box_triggers_error = function()
         conn = net.connect(uri, {wait_connected = false})
         t.assert_equals(conn.state, 'initial')
         errmsg = 'net.box on_schema_reload error'
+        -- Error is logged - it will be checked later
         conn:on_schema_reload(function() error(errmsg) end)
         conn:wait_connected()
-        -- Error is raised when the connection is used
-        t.assert_error_msg_content_equals(errmsg, conn.call, conn, 'abc')
 
         conn = net.connect(uri, {wait_connected = true})
         errmsg = 'net.box on_shutdown error'
@@ -208,6 +207,7 @@ g.test_net_box_triggers_error = function()
     g.server:drop()
 
     t.assert(g.client:grep_log("net.box on_disconnect error"))
+    t.assert(g.client:grep_log("net.box on_schema_reload error"))
     t.assert(g.client:grep_log("net.box on_shutdown error"))
     g.client:drop()
 end

--- a/test/box-luatest/gh_9677_netbox_on_disconnect_error_behaviour_test.lua
+++ b/test/box-luatest/gh_9677_netbox_on_disconnect_error_behaviour_test.lua
@@ -1,0 +1,31 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+-- Tests that the actual behaviour of the `on_disconnect` trigger when an error
+-- is thrown is consistent with its documented behaviour.
+g.test_on_disconnect_error_behaviour = function(cg)
+    local trigger_err = '777'
+    cg.server:exec(function(trigger_err)
+        local net_box = require('net.box')
+
+        local c = net_box.connect(box.cfg.listen)
+        c:on_disconnect(function()
+            error(trigger_err)
+        end)
+        local ok = pcall(function() c:close() end)
+        t.assert(ok)
+        t.assert(c:wait_state('closed', 10))
+    end, {trigger_err})
+    t.assert(cg.server:grep_log(trigger_err))
+end

--- a/test/box-luatest/gh_9679_netbox_on_schema_reload_error_behaviour_test.lua
+++ b/test/box-luatest/gh_9679_netbox_on_schema_reload_error_behaviour_test.lua
@@ -1,0 +1,28 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+-- Tests the behaviour of the `on_schema_reload` trigger.
+g.test_on_schema_reload_error_behaviour = function(cg)
+    local trigger_err = '777'
+    cg.server:exec(function(trigger_err)
+        local net_box = require('net.box')
+
+        local c = net_box.connect(box.cfg.listen, {wait_connected = false})
+        c:on_schema_reload(function()
+            error(trigger_err)
+        end)
+        t.assert(c:wait_state('active', 10))
+    end, {trigger_err})
+    t.assert(cg.server:grep_log(trigger_err))
+end

--- a/test/box-luatest/gh_9797_netbox_on_disconnect_error_hangs_server_test.lua
+++ b/test/box-luatest/gh_9797_netbox_on_disconnect_error_hangs_server_test.lua
@@ -1,0 +1,32 @@
+local net_box = require('net.box')
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+-- Tests that throwing an error from the `on_disconnect` trigger does not hang
+-- the server indefinitely.
+g.test_on_disconnect_error_hangs_server = function(cg)
+    local c = net_box.connect(cg.server.net_box_uri)
+    c:on_disconnect(function()
+        error(777)
+    end)
+    pcall(function() c:close() end)
+    local log_file = cg.server:exec(function()
+        box.ctl.set_on_shutdown_timeout(1)
+        -- `grep_log` will not be able to retrieve it after we drop the server.
+        return box.cfg.log
+    end)
+    cg.server:drop()
+    t.assert_not(cg.server:grep_log('on_shutdown triggers failed', 1024,
+                                    {filename = log_file}))
+end

--- a/test/box-luatest/gh_9827_netbox_on_connect_close_test.lua
+++ b/test/box-luatest/gh_9827_netbox_on_connect_close_test.lua
@@ -1,0 +1,24 @@
+local net_box = require('net.box')
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+-- Tests that closing the connection from the `on_connect` trigger works
+-- correctly.
+g.test_on_connect_close = function(cg)
+    local c = net_box.connect(cg.server.net_box_uri, {wait_connected = false})
+    c:on_connect(function()
+        pcall(function() c:close() end)
+    end)
+    t.assert(c:wait_state('closed', 10))
+end


### PR DESCRIPTION
This patch set fixes several bugs related to `net.box` connection object triggers. It also changes the behaviour of the `on_schema_reload` trigger to make it more logically consistent. Finally, it fixes UB in the connection's `transport:stop` method.

Closes #9677
Closes #9679
Closes #9797
Closes #9827