### PR TITLE
config: allow empty configuration file

### DIFF
--- a/changelogs/unreleased/gh-9845-nil-error-on-empty-config.md
+++ b/changelogs/unreleased/gh-9845-nil-error-on-empty-config.md
@@ -1,0 +1,5 @@
+## bugfix/config
+
+* Fixed a non-verbose error on an empty configuration file.
+  Now Tarantool can successfully start up with an empty configuration
+  file using data from other configuration sources (gh-9845).

--- a/src/box/lua/config/source/file.lua
+++ b/src/box/lua/config/source/file.lua
@@ -26,6 +26,12 @@ function methods.sync(self, config_module, _iconfig)
             config_module._config_file, res))
     end
 
+    -- YAML returns `nil` or `box.NULL` on empty file,
+    -- while config sources should be {} if empty.
+    if res == nil then
+        res = {}
+    end
+
     self._values = res
 end
 

--- a/test/config-luatest/sources_test.lua
+++ b/test/config-luatest/sources_test.lua
@@ -176,3 +176,24 @@ g.test_sources_priority = function(g)
         t.assert_equals(config:get('log.syslog.identity'), 'from env default')
     end)
 end
+
+g.test_empty_sources = function()
+    local dir = treegen.prepare_directory(g, {}, {})
+    local test_cases = {
+        "",
+        "--- null\n...\n",
+    }
+
+    for _, case in ipairs(test_cases) do
+        treegen.write_script(dir, 'single.yaml', case)
+
+        local exp = "No cluster config received from the given " ..
+                    "configuration sources."
+
+        local args = {'--name', 'instance-001', '--config', 'single.yaml'}
+        local res = justrun.tarantool(dir, {}, args, {stderr = true})
+
+        t.assert_equals(res.exit_code, 1)
+        t.assert_str_contains(res.stderr, exp)
+    end
+end


### PR DESCRIPTION
Before this patch, Tarantool, when started with empty configuration file, used to fail with a non verbose error:
```
$ ./src/tarantool -n instance-001 -c single.yaml
LuajitError: [cluster_config] Unexpected data type for a record: "nil"
fatal error, exiting the event loop
```

Now Tarantool instance can be set up with configuration from remote
configuration sources available in Tarantool Enterprise Edition and
run with empty config file. When there is no configuration provided
for the instance an according error is thrown.

Closes #9845

NO_DOC=bugfix