### PR TITLE
box: forbid DDL, DML, DQL, DCL and TCL in transactional triggers

### DIFF
--- a/changelogs/unreleased/gh-9186-7331-forbid-db-access-and-txn-control-in-txn-triggers.md
+++ b/changelogs/unreleased/gh-9186-7331-forbid-db-access-and-txn-control-in-txn-triggers.md
@@ -1,0 +1,5 @@
+## bugfix/box
+
+* An attempt to execute a DDL, DML, DQL, DCL or TCL query within
+  a transactional trigger (`on_commit` or `on_rollback`) now fails
+  with a specific error (gh-9186, gh-7331).

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -424,6 +424,7 @@ struct errcode_record {
 	_(ER_REPLICASET_NOT_FOUND, 281,		"The replicaset was not found by its name") \
 	_(ER_REPLICASET_NO_WRITABLE, 282,	"Writable instance was not found in replicaset") \
 	_(ER_REPLICASET_MORE_THAN_ONE_WRITABLE, 283, "More than one writable was found in replicaset") \
+	_(ER_TXN_COMMIT, 284,			"Transaction was committed") \
 	/** \
 	 * XXX: Formatted strings above are for compatibility. Use only \
 	 * error message without formatters for newly added error codes. \

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -733,6 +733,7 @@ txn_complete_fail(struct txn *txn)
 		txn->limbo_entry = NULL;
 	}
 	txn->status = TXN_ABORTED;
+	txn_set_flags(txn, TXN_IS_ROLLED_BACK);
 	struct txn_stmt *stmt;
 	stailq_reverse(&txn->stmts);
 	stailq_foreach_entry(stmt, &txn->stmts, next)

--- a/test/box-luatest/gh_9186_7331_forbid_database_access_in_txn_triggers_test.lua
+++ b/test/box-luatest/gh_9186_7331_forbid_database_access_in_txn_triggers_test.lua
@@ -1,0 +1,99 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_each(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_each(function(cg)
+    cg.server:drop()
+end)
+
+g.test_database_access_in_txn_triggers = function(cg)
+    cg.server:exec(function()
+        local trigger = require('trigger')
+
+        -- Create spaces of all types (ordinary, temporary, data-temporary)
+        local s = box.schema.create_space('s')
+        s:create_index('pk')
+        local ts = box.schema.create_space('ts', {type = 'temporary'})
+        ts:create_index('pk')
+        local dts = box.schema.create_space('dts', {type = 'data-temporary'})
+        dts:create_index('pk')
+
+        -- Create user to check DCL
+        box.schema.user.create('test_user')
+
+        -- Checker for old triggers (box.on_commit and box.on_rollback)
+        local function check_case_old(trigger, action, finalizer, expected_err)
+            box.begin()
+            s:replace{0, 0}
+            local err = nil
+            local function trigger_f()
+                local _, errmsg = pcall(action)
+                err = errmsg
+            end
+            trigger(trigger_f)
+            finalizer()
+            t.assert_equals(err.message, expected_err)
+        end
+
+        -- Checker for new triggers (using module trigger)
+        local function check_case_new(event, action, finalizer, expected_err)
+            local err = nil
+            local function trigger_f()
+                local _, errmsg = pcall(action)
+                err = errmsg
+            end
+            trigger.set(event, "test_trigger", trigger_f)
+
+            box.begin()
+            s:replace{0, 0}
+            finalizer()
+
+            trigger.del(event, "test_trigger")
+            t.assert_equals(err.message, expected_err)
+        end
+
+        -- Cases that should fail in transactional triggers
+        local cases = {
+            -- DML
+            function() s:replace{1, 1} end,
+            function() ts:replace{1, 1} end,
+            function() dts:replace{1, 1} end,
+
+            -- DQL
+            function() s:select{} end,
+            function() s:get{0} end,
+            function() ts:select{} end,
+            function() ts:get{0} end,
+            function() dts:select{} end,
+            function() dts:get{0} end,
+
+            -- DDL
+            function() box.schema.create_space('new_space') end,
+            function() s:create_index('sk') end,
+            function() box.schema.func.create('new_func') end,
+            function() box.schema.user.create('new_user') end,
+
+            -- DCL
+            function()
+                box.schema.user.grant('test_user', 'read,write', 'space', 's')
+            end,
+            function()
+                box.schema.user.revoke('test_user', 'read,write', 'space', 's')
+            end
+        }
+
+        for _, case in pairs(cases) do
+            check_case_old(box.on_commit, case, box.commit, 'Transaction was committed')
+            check_case_old(box.on_rollback, case, box.rollback, 'Transaction was rolled back')
+
+            check_case_new('box.on_commit', case, box.commit, 'Transaction was committed')
+            check_case_new('box.on_rollback', case, box.rollback, 'Transaction was rolled back')
+        end
+    end)
+end

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -489,6 +489,7 @@ t;
  |   281: box.error.REPLICASET_NOT_FOUND
  |   282: box.error.REPLICASET_NO_WRITABLE
  |   283: box.error.REPLICASET_MORE_THAN_ONE_WRITABLE
+ |   284: box.error.TXN_COMMIT
  | ...
 
 test_run:cmd("setopt delimiter ''");


### PR DESCRIPTION
When we are going to start a new statement in transaction, we check if current transaction can continue with a special helper. This helper fails only when the transaction is aborted, but if transaction is committed, it actually cannot be continued as well because it is over. So let's consider committed transactions as non-continuable.

Along the way, let's fix an error thrown when someone tries to access database within on_rollback trigger - now it is reported as "Unknown error", let's use "Transaction was rolled back" instead.

Also, user is not allowed to execute TCL statements in on_commit and on_rollback triggers - it is documented UB. However, this prohibition can be easily overseen: one could, for example, try to rollback current transaction if something is not OK in on_commit trigger. So let's check if TCL statements are not executed in transactional triggers.

Closes #9186
Closes #7331 