### PR TITLE
error: allow to specify where to get error location

### DIFF
--- a/changelogs/unreleased/gh-9792-error-level.md
+++ b/changelogs/unreleased/gh-9792-error-level.md
@@ -1,0 +1,4 @@
+## feature/lua
+
+* Added the `level` argument to `box.error` and `box.error.new` to specify
+  the stack frame used for setting the error location (gh-9792).

--- a/test/app-luatest/gh_9792_error_level_test.lua
+++ b/test/app-luatest/gh_9792_error_level_test.lua
@@ -1,0 +1,186 @@
+local t = require('luatest')
+
+local g = t.group()
+
+local TEST_FILE = debug.getinfo(1, 'S').short_src
+
+g.test_invalid_args = function()
+    local arg, errmsg
+
+    arg = {type = 'foo', message = 'bar'}
+
+    -- Raising a new error with a bad level argument.
+    errmsg = 'box.error(): bad arguments'
+    t.assert_error_msg_equals(errmsg, box.error, arg, {})
+    t.assert_error_msg_equals(errmsg, box.error, arg, 'x')
+    t.assert_error_msg_equals(errmsg, box.error, arg, '1')
+    t.assert_error_msg_equals(errmsg, box.error, arg, 1, 2)
+
+    -- Creating a new error with a bad level argument.
+    errmsg = 'box.error.new(): bad arguments'
+    t.assert_error_msg_equals(errmsg, box.error.new, arg, {})
+    t.assert_error_msg_equals(errmsg, box.error.new, arg, 'x')
+    t.assert_error_msg_equals(errmsg, box.error.new, arg, '1')
+    t.assert_error_msg_equals(errmsg, box.error.new, arg, 1, 2)
+
+    arg = box.error.new(arg)
+
+    -- Raising an existing error with a bad level argument.
+    errmsg = 'box.error(): bad arguments'
+    t.assert_error_msg_equals(errmsg, box.error, arg, {})
+    t.assert_error_msg_equals(errmsg, box.error, arg, 'x')
+    t.assert_error_msg_equals(errmsg, box.error, arg, '1')
+    t.assert_error_msg_equals(errmsg, box.error, arg, 1, 2)
+
+    -- Sic: box.error.new() doesn't take an error object.
+    errmsg = 'box.error.new(): bad arguments'
+    t.assert_error_msg_equals(errmsg, box.error.new, arg)
+    t.assert_error_msg_equals(errmsg, box.error.new, arg, 1)
+    t.assert_error_msg_equals(errmsg, box.error.new, arg, {})
+    t.assert_error_msg_equals(errmsg, box.error.new, arg, 'x')
+    t.assert_error_msg_equals(errmsg, box.error.new, arg, '1')
+    t.assert_error_msg_equals(errmsg, box.error.new, arg, 1, 2)
+end
+
+g.test_raise = function()
+    local line1 = debug.getinfo(1, 'l').currentline + 3
+    t.assert_gt(line1, 0)
+    local function func1(...)
+        box.error(...)
+    end
+
+    local line2 = debug.getinfo(1, 'l').currentline + 3
+    t.assert_gt(line2, line1)
+    local function func2(...)
+        func1(...)
+    end
+
+    local line3 = debug.getinfo(1, 'l').currentline + 3
+    t.assert_gt(line3, line2)
+    local function func3(...)
+        func2(...)
+    end
+
+    local function check_trace(func, line, ...)
+        local ok, err = pcall(func, ...)
+        t.assert_not(ok)
+        t.assert_type(err, 'cdata')
+        t.assert_is_not(err.trace[1], nil)
+        t.assert_str_contains(err.trace[1].file, TEST_FILE)
+        t.assert_equals(err.trace[1].line, line)
+    end
+
+    local function check_no_trace(func, ...)
+        local ok, err = pcall(func, ...)
+        t.assert_not(ok)
+        t.assert_type(err, 'cdata')
+        t.assert_equals(err.trace, {})
+    end
+
+    -- Raising a new error.
+    local err = {type = 'TestError', message = 'Test'}
+
+    check_trace(func1, line1, err)
+    check_trace(func1, line1, err, nil)
+    check_trace(func2, line1, err)
+    check_trace(func2, line1, err, nil)
+    check_trace(func3, line1, err)
+    check_trace(func3, line1, err, nil)
+
+    check_no_trace(func1, err, 0)
+    check_no_trace(func2, err, 0)
+    check_no_trace(func3, err, 0)
+
+    check_trace(func1, line1, err, 1)
+    check_trace(func2, line1, err, 1)
+    check_trace(func3, line1, err, 1)
+
+    check_trace(func2, line2, err, 2)
+    check_trace(func3, line2, err, 2)
+
+    check_trace(func3, line3, err, 3)
+
+    -- Raising an existing error.
+    local line = debug.getinfo(1, 'l').currentline + 2
+    t.assert_gt(line, line3)
+    err = box.error.new{type = 'TestError', message = 'Test'}
+
+    check_trace(func1, line, err)
+    check_trace(func1, line, err, nil)
+    check_trace(func2, line, err)
+    check_trace(func2, line, err, nil)
+    check_trace(func3, line, err)
+    check_trace(func3, line, err, nil)
+
+    check_no_trace(func1, err, 0)
+    check_no_trace(func2, err, 0)
+    check_no_trace(func3, err, 0)
+
+    check_trace(func1, line1, err, 1)
+    check_trace(func2, line1, err, 1)
+    check_trace(func3, line1, err, 1)
+
+    check_trace(func2, line2, err, 2)
+    check_trace(func3, line2, err, 2)
+
+    check_trace(func3, line3, err, 3)
+end
+
+g.test_new = function()
+    local line1 = debug.getinfo(1, 'l').currentline + 3
+    t.assert_gt(line1, 0)
+    local function func1(...)
+        local err = box.error.new(...)
+        return err
+    end
+
+    local line2 = debug.getinfo(1, 'l').currentline + 3
+    t.assert_gt(line2, line1)
+    local function func2(...)
+        local err = func1(...)
+        return err
+    end
+
+    local line3 = debug.getinfo(1, 'l').currentline + 3
+    t.assert_gt(line3, line2)
+    local function func3(...)
+        local err = func2(...)
+        return err
+    end
+
+    local function check_trace(func, line, ...)
+        local err = func(...)
+        t.assert_type(err, 'cdata')
+        t.assert_is_not(err.trace[1], nil)
+        t.assert_str_contains(err.trace[1].file, TEST_FILE)
+        t.assert_equals(err.trace[1].line, line)
+    end
+
+    local function check_no_trace(func, ...)
+        local err = func(...)
+        t.assert_type(err, 'cdata')
+        t.assert_equals(err.trace, {})
+    end
+
+    local err = {type = 'TestError', message = 'Test'}
+
+    check_trace(func1, line1, err)
+    check_trace(func1, line1, err, nil)
+    check_trace(func2, line1, err)
+    check_trace(func2, line1, err, nil)
+    check_trace(func3, line1, err)
+    check_trace(func3, line1, err, nil)
+
+    check_no_trace(func1, err, 0)
+    check_no_trace(func2, err, 0)
+    check_no_trace(func3, err, 0)
+
+    check_trace(func1, line1, err, 1)
+    check_trace(func2, line1, err, 1)
+    check_trace(func3, line1, err, 1)
+
+    check_trace(func2, line2, err, 2)
+    check_trace(func3, line2, err, 2)
+
+    check_trace(func3, line3, err, 3)
+end

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -106,7 +106,7 @@ e
  | ...
 box.error.new()
  | ---
- | - error: 'Usage: box.error.new(code, args) or box.error.new(type, args)'
+ | - error: 'box.error.new(): bad arguments'
  | ...
 
 --
@@ -559,7 +559,7 @@ assert(box.error.last() == nil)
 --
 box.error.new(err)
  | ---
- | - error: 'Usage: box.error.new(code, args) or box.error.new(type, args)'
+ | - error: 'box.error.new(): bad arguments'
  | ...
 
 -- box.error() is supposed to re-throw last diagnostic error.


### PR DESCRIPTION
Now, when used with a table argument, `box.error` and `box.error.new` also accept an optional second argument called `level`. It has the same meaning as the `level` argument of the built-in Lua function `error`: it specifies how to get the error location. With level 1 (the default), the error location is where `box.error` / `box.error.new` was called. Level 2 points the error to where the function that called `box.error` / `box.error.new` was called; and so on. Passing level 0 avoids addition of location information to the error.

Example of using `level` with `box.error`:

```lua
local json = require('json')

local function inner(level)
    box.error({message = 'test'}, level)    -- line:4
end

local function outer(level)
    inner(level)                            -- line:8
end

local ok, err
ok, err = pcall(outer)
print(json.encode(err.trace))               -- prints line:4
ok, err = pcall(outer, 1)
print(json.encode(err.trace))               -- prints line:4
ok, err = pcall(outer, 2)
print(json.encode(err.trace))               -- prints line:8
ok, err = pcall(outer, 0)
print(json.encode(err.trace))               -- prints empty table
```

Example of using `level` with `box.error.new`:

```lua
local json = require('json')

local function inner(level)
    local err = box.error.new({message = 'test'}, level)    -- line:4
    return err
end

local function outer(level)
    local err = inner(level)                                -- line:9
    return err
end

local err
err = outer()
print(json.encode(err.trace))               -- prints line:4
err = outer(1)
print(json.encode(err.trace))               -- prints line:4
err = outer(2)
print(json.encode(err.trace))               -- prints line:9
ok, err = pcall(outer, 0)
print(json.encode(err.trace))               -- prints empty table
```

It is also possible to specify `level` when using `box.error` to re-raise an error created earlier with `box.error.new`, for example:

```lua
local json = require('json')

local err0 = box.error.new{message = 'test'}    -- line:3

local function raise(err, level)
    box.error(err, level)                       -- line:6
end

ok, err = pcall(raise, err0)
print(json.encode(err.trace))               -- prints line:3

ok, err = pcall(raise, err0, 1)
print(json.encode(err.trace))               -- prints line:6

ok, err = pcall(raise, err0, 0)
print(json.encode(err.trace))               -- prints empty table
```

Closes #9792