### PR TITLE
 config: rework privilege revocation

### DIFF
--- a/changelogs/unreleased/gh-9643-credentials-from-app-roles.md
+++ b/changelogs/unreleased/gh-9643-credentials-from-app-roles.md
@@ -1,4 +1,6 @@
 ## bugfix/config
 
 * A non-existent role can now be assigned in the `credential` section of
-  the configuration.
+  the configuration (gh-9643).
+* Privileges that were not granted by the config module are no longer
+  revoked by the config module (gh-9643).

--- a/src/box/lua/config/applier/credentials.lua
+++ b/src/box/lua/config/applier/credentials.lua
@@ -546,7 +546,8 @@ local privileges_action_f = function(grant_or_revoke, role_or_user, name, privs,
     if err.code ~= box.error.NO_SUCH_SPACE and
             err.code ~= box.error.NO_SUCH_ROLE and
             err.code ~= box.error.NO_SUCH_FUNCTION and
-            err.code ~= box.error.NO_SUCH_SEQUENCE then
+            err.code ~= box.error.NO_SUCH_SEQUENCE and
+            err.code ~= box.error.SCHEMA_NEEDS_UPGRADE then
         err = ('credentials.apply: box.schema.%s.%s(%q, %q, %q, %q) failed: %s')
               :format(role_or_user, grant_or_revoke, name, privs, obj_type,
                       obj_name, err)
@@ -667,6 +668,7 @@ local function sync_privileges(credentials, obj_to_sync)
             }
             local msg = 'box.schema.%s.%s(%q, %q, %q, %q) has failed ' ..
                 'because either the object has not been created yet, ' ..
+                'a database schema upgrade has not been performed, ' ..
                 'or the privilege write has failed (separate alert reported)'
             local privs = table.concat(grant.privs, ',')
             alert.message = msg:format(role_or_user, 'grant', name, privs,

--- a/test/config-luatest/credentials_applier_test.lua
+++ b/test/config-luatest/credentials_applier_test.lua
@@ -1786,8 +1786,8 @@ g.test_set_nonexistent_role = function(g)
         local info = require('config'):info()
         local exp = 'box.schema.role.grant("role_one", "execute", "role", ' ..
             '"role_two") has failed because either the object has not been ' ..
-            'created yet, or the privilege write has failed (separate alert ' ..
-            'reported)'
+            'created yet, a database schema upgrade has not been performed, ' ..
+            'or the privilege write has failed (separate alert reported)'
         t.assert_equals(info.status, 'check_warnings')
         t.assert_equals(#info.alerts, 1)
         t.assert_equals(info.alerts[1].type, 'warn')
@@ -1823,8 +1823,8 @@ g.test_set_user_instead_of_role = function(g)
         local info = require('config'):info()
         local exp = 'box.schema.user.grant("user_one", "execute", "role", ' ..
             '"role_two") has failed because either the object has not been ' ..
-            'created yet, or the privilege write has failed (separate alert ' ..
-            'reported)'
+            'created yet, a database schema upgrade has not been performed, ' ..
+            'or the privilege write has failed (separate alert reported)'
         t.assert_equals(info.status, 'check_warnings')
         t.assert_equals(#info.alerts, 1)
         t.assert_equals(info.alerts[1].type, 'warn')
@@ -1838,8 +1838,8 @@ g.test_set_user_instead_of_role = function(g)
         local info = require('config'):info()
         local exp = 'box.schema.user.grant("user_one", "execute", "role", ' ..
             '"role_two") has failed because either the object has not been ' ..
-            'created yet, or the privilege write has failed (separate alert ' ..
-            'reported)'
+            'created yet, a database schema upgrade has not been performed, ' ..
+            'or the privilege write has failed (separate alert reported)'
         t.assert_equals(info.status, 'check_warnings')
         t.assert_equals(#info.alerts, 1)
         t.assert_equals(info.alerts[1].type, 'warn')

--- a/test/config-luatest/upgrade_test.lua
+++ b/test/config-luatest/upgrade_test.lua
@@ -1,0 +1,84 @@
+local t = require('luatest')
+local treegen = require('test.treegen')
+local server = require('test.luatest_helpers.server')
+local yaml = require('yaml')
+local fio = require('fio')
+
+local g = t.group()
+
+g.before_all(function(g)
+    treegen.init(g)
+
+    local dir = treegen.prepare_directory(g, {}, {})
+    local data = 'test/box-luatest/upgrade/2.11.0/00000000000000000003.snap'
+    fio.copyfile(data, dir)
+
+    local config = {
+        credentials = {
+            users = {
+                guest = {
+                    privileges = {{
+                        permissions = {'read'},
+                        spaces = {'_space'},
+                    }},
+                },
+            },
+        },
+
+        iproto = {
+            listen = {{uri = 'unix/:./{{ instance_name }}.iproto'}},
+        },
+
+        database = {
+            replicaset_uuid = '9f62fe8b-7e70-474d-b051-d6af635f3cae',
+            instance_uuid = '2ea3f41a-aae0-4652-8a51-69f8ca303c21',
+        },
+
+        snapshot = {
+            dir = dir,
+        },
+
+        wal = {
+            dir = dir,
+        },
+
+        groups = {
+            ['group-001'] = {
+                replicasets = {
+                    ['replicaset-001'] = {
+                        instances = {
+                            ['instance-001'] = {},
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    local cfg = yaml.encode(config)
+    treegen.write_script(dir, 'cfg.yaml', cfg)
+    local opts = {config_file = 'cfg.yaml', chdir = dir, alias = 'instance-001'}
+    g.server = server:new(opts)
+
+    g.server:start()
+end)
+
+g.after_all(function(g)
+    g.server:drop()
+    treegen.clean(g)
+end)
+
+g.test_upgrade = function()
+    g.server:exec(function()
+        t.assert_equals(box.space._schema:get("version"), {'version', 2, 11, 0})
+        local messages = {}
+        for _, alert in pairs(require("config"):info().alerts) do
+            table.insert(messages, alert.message)
+        end
+        local exp = 'box.schema.user.grant("guest", "read", "space", ' ..
+            '"_space") has failed because either the object has not been ' ..
+            'created yet, a database schema upgrade has not been performed, ' ..
+            'or the privilege write has failed (separate alert reported)'
+        t.assert_items_include(messages, {exp})
+    end)
+end


### PR DESCRIPTION
Closes https://github.com/tarantool/tarantool/issues/9643

@TarantoolBot document
Title: config: changes in `credentials` section

Now the privileges that were not granted by the configuration, as well as privileges that were not granted solely by the configuration, are not revoked on reload. Privileges only granted by the config module will still be revoked if they are removed from the `credentials` section on reload.