### PR TITLE
console: make __autocomplete retrival for cdata exception-safe

### DIFF
--- a/test/app-luatest/gh_6305_autocomplete_metamethod_test.lua
+++ b/test/app-luatest/gh_6305_autocomplete_metamethod_test.lua
@@ -58,6 +58,12 @@ g.test__autocomplete = function()
                                                    'table11.second',
                                                    'table11.auto',
                                                    })
+   -- __index function can throw an error - should be Ok
+   setmetatable(tab, {__index = function() error('test error') end})
+   t.assert_items_equals(tabcomplete('table11.'), {'table11.',
+                                                   'table11.first',
+                                                   'table11.second',
+                                                   })
    -- __autocomplete supercedes __index, no completions from the latter
    setmetatable(tab, {__autocomplete = function() return {auto = true} end,
                       __index = {index = true}})


### PR DESCRIPTION
Fixes a regression introduced in cf644abd, which added exception-unsafe code for retrieval of `__autocomplete` metamethod of cdata objects.

I wasn't able to test the orginal reported bug, since the luatest server starts with `box` configured.

Closes #9828