### PR TITLE
Errcode payload extensions

### DIFF
--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -105,19 +105,39 @@ struct errcode_record {
 	_(ER_TEST_5_ARGS, 10033,		"Test error", "f1", INT, "f2", INT, "f3", INT, "f4", INT, "f5", INT) \
 	_(ER_TEST_FORMAT_MSG, 10050,		"Test error %i %s", "f1", INT, "f2", STRING) \
 	_(ER_TEST_FORMAT_MSG_LESS, 10051,	"Test error %i %s", "f1", INT, "f2", STRING, "f3", INT) \
+	_(ER_TEST_OMIT_TYPE_CHAR, 10060,	"Test error %c", NULL, CHAR) \
+	_(ER_TEST_OMIT_TYPE_INT, 10061,		"Test error %i", NULL, INT) \
+	_(ER_TEST_OMIT_TYPE_UINT, 10062,	"Test error %u", NULL, UINT) \
+	_(ER_TEST_OMIT_TYPE_LONG, 10063,	"Test error %li", NULL, LONG) \
+	_(ER_TEST_OMIT_TYPE_ULONG, 10064,	"Test error %lu", NULL, ULONG) \
+	_(ER_TEST_OMIT_TYPE_LLONG, 10065,	"Test error %lli", NULL, LLONG) \
+	_(ER_TEST_OMIT_TYPE_ULLONG, 10066,	"Test error %llu", NULL, ULLONG) \
+	_(ER_TEST_OMIT_TYPE_STRING, 10067,	"Test error %s", NULL, STRING) \
 
 #else
 #define TEST_ERROR_CODES(_)
 #endif
 
-/*
- * To add a new error code to Tarantool, extend this array.
+/**
+ * Tarantool error codes.
  *
- * !IMPORTANT! Currently you need to manually update the user
- * guide (doc/user/errcode.xml) with each added error code.
- * Please don't forget to do it!
+ * Error description is:
+ *   _(<token>, <error_code>, <format_string>,  <payload_fields>)
+ * where:
+ *   token		- the enum constant name for <error_code>
+ *   error_code		- error code value
+ *   format_string	- format string used for error creation, varargs will
+ *			  be used with this format string
+ *   payload fields	- variable number of <NAME>, <TYPE> pairs describing
+ *			  how varargs passed on error creation will be
+ *			  added as error payload
+ *
+ * In payload fields <NAME> is a string literal and <TYPE> is from
+ * enum errcode_field_type. Yet to be consise use short defines like
+ * CHAR etc instead of enum. If <NAME> is NULL then the that positional
+ * argument will be passed to formatted string but will not be added as
+ * error payload.
  */
-
 #define ERROR_CODES(_) \
 	_(ER_UNKNOWN, 0,			"Unknown error") \
 	_(ER_ILLEGAL_PARAMS, 1,			"Illegal parameters, %s") \

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -99,10 +99,12 @@ struct errcode_record {
 	_(ER_TEST_TYPE_STRING, 10008,		"Test error", "field", STRING) \
 	_(ER_TEST_TYPE_MSGPACK, 10009,		"Test error", "field", MSGPACK) \
 	_(ER_TEST_TYPE_TUPLE, 10010,		"Test error", "field", TUPLE) \
-	_(ER_TEST_2_ARGS, 10011,		"Test error", "f1", INT, "f2", INT) \
-	_(ER_TEST_3_ARGS, 10012,		"Test error", "f1", INT, "f2", INT, "f3", INT) \
-	_(ER_TEST_4_ARGS, 10013,		"Test error", "f1", INT, "f2", INT, "f3", INT, "f4", INT) \
-	_(ER_TEST_5_ARGS, 10014,		"Test error", "f1", INT, "f2", INT, "f3", INT, "f4", INT, "f5", INT) \
+	_(ER_TEST_2_ARGS, 10030,		"Test error", "f1", INT, "f2", INT) \
+	_(ER_TEST_3_ARGS, 10031,		"Test error", "f1", INT, "f2", INT, "f3", INT) \
+	_(ER_TEST_4_ARGS, 10032,		"Test error", "f1", INT, "f2", INT, "f3", INT, "f4", INT) \
+	_(ER_TEST_5_ARGS, 10033,		"Test error", "f1", INT, "f2", INT, "f3", INT, "f4", INT, "f5", INT) \
+	_(ER_TEST_FORMAT_MSG, 10050,		"Test error %i %s", "f1", INT, "f2", STRING) \
+	_(ER_TEST_FORMAT_MSG_LESS, 10051,	"Test error %i %s", "f1", INT, "f2", STRING, "f3", INT) \
 
 #else
 #define TEST_ERROR_CODES(_)

--- a/src/box/error.cc
+++ b/src/box/error.cc
@@ -167,7 +167,10 @@ static void
 client_error_create(struct error *e, va_list ap)
 {
 	const struct errcode_record *r = tnt_errcode_record(e->code);
-	error_vformat_msg(e, r->errdesc, ap);
+	va_list ap_copy;
+	va_copy(ap_copy, ap);
+	error_vformat_msg(e, r->errdesc, ap_copy);
+	va_end(ap_copy);
 	for (int i = 0; i < r->errfields_count; i++) {
 		switch (r->errfields[i].type) {
 		case ERRCODE_FIELD_TYPE_CHAR: {

--- a/src/box/error.cc
+++ b/src/box/error.cc
@@ -172,50 +172,66 @@ client_error_create(struct error *e, va_list ap)
 	error_vformat_msg(e, r->errdesc, ap_copy);
 	va_end(ap_copy);
 	for (int i = 0; i < r->errfields_count; i++) {
+		const char *name = r->errfields[i].name;
 		switch (r->errfields[i].type) {
 		case ERRCODE_FIELD_TYPE_CHAR: {
 			char buf[2] = {(char)va_arg(ap, int), '\0'};
-			error_set_str(e, r->errfields[i].name, buf);
+			if (name != NULL)
+				error_set_str(e, name, buf);
 			break;
 		}
-		case ERRCODE_FIELD_TYPE_INT:
-			error_set_int(e, r->errfields[i].name,
-				      va_arg(ap, int));
+		case ERRCODE_FIELD_TYPE_INT: {
+			int v = va_arg(ap, int);
+			if (name != NULL)
+				error_set_int(e, name, v);
 			break;
-		case ERRCODE_FIELD_TYPE_UINT:
-			error_set_uint(e, r->errfields[i].name,
-				       va_arg(ap, unsigned));
+		}
+		case ERRCODE_FIELD_TYPE_UINT: {
+			unsigned v = va_arg(ap, unsigned);
+			if (name != NULL)
+				error_set_uint(e, name, v);
 			break;
-		case ERRCODE_FIELD_TYPE_LONG:
-			error_set_int(e, r->errfields[i].name,
-				      va_arg(ap, long));
+		}
+		case ERRCODE_FIELD_TYPE_LONG: {
+			long v = va_arg(ap, long);
+			if (name != NULL)
+				error_set_int(e, name, v);
 			break;
-		case ERRCODE_FIELD_TYPE_ULONG:
-			error_set_uint(e, r->errfields[i].name,
-				       va_arg(ap, unsigned long));
+		}
+		case ERRCODE_FIELD_TYPE_ULONG: {
+			unsigned long v = va_arg(ap, unsigned long);
+			if (name != NULL)
+				error_set_uint(e, name, v);
 			break;
-		case ERRCODE_FIELD_TYPE_LLONG:
-			error_set_int(e, r->errfields[i].name,
-				      va_arg(ap, long long));
+		}
+		case ERRCODE_FIELD_TYPE_LLONG: {
+			long long v = va_arg(ap, long long);
+			if (name != NULL)
+				error_set_int(e, name, v);
 			break;
-		case ERRCODE_FIELD_TYPE_ULLONG:
-			error_set_uint(e, r->errfields[i].name,
-				       va_arg(ap, unsigned long long));
+		}
+		case ERRCODE_FIELD_TYPE_ULLONG: {
+			unsigned long long v = va_arg(ap, unsigned long long);
+			if (name != NULL)
+				error_set_uint(e, name, v);
 			break;
-		case ERRCODE_FIELD_TYPE_STRING:
-			error_set_str(e, r->errfields[i].name,
-				      va_arg(ap, const char *));
+		}
+		case ERRCODE_FIELD_TYPE_STRING: {
+			const char *s = va_arg(ap, const char *);
+			if (name != NULL)
+				error_set_str(e, name, s);
 			break;
+		}
 		case ERRCODE_FIELD_TYPE_MSGPACK: {
 			const char *mp = va_arg(ap, const char *);
 			const char *mp_end = mp;
 			mp_next(&mp_end);
-			error_set_mp(e, r->errfields[i].name, mp, mp_end - mp);
+			error_set_mp(e, name, mp, mp_end - mp);
 			break;
 		}
 		case ERRCODE_FIELD_TYPE_TUPLE: {
 			struct tuple *tuple = va_arg(ap, struct tuple *);
-			error_set_mp(e, r->errfields[i].name, tuple_data(tuple),
+			error_set_mp(e, name, tuple_data(tuple),
 				     tuple_bsize(tuple));
 			break;
 		}

--- a/src/box/lua/error.cc
+++ b/src/box/lua/error.cc
@@ -148,8 +148,6 @@ luaT_error_create(lua_State *L, int top_base)
 			code = lua_tonumber(L, top_base);
 			record = tnt_errcode_record(code);
 			reason = record->errdesc;
-			if (record->errfields_count > 0)
-				goto raise;
 		} else {
 			custom_type = lua_tostring(L, top_base);
 			/*

--- a/src/box/lua/error.cc
+++ b/src/box/lua/error.cc
@@ -247,9 +247,9 @@ raise:
 		for (int i = top_base + 1;
 		     i <= top && argidx < record->errfields_count;
 		     i++, argidx++) {
-			luaT_error_payload_set(L, error,
-					       record->errfields[argidx].name,
-					       i);
+			const char *name = record->errfields[argidx].name;
+			if (name != NULL)
+				luaT_error_payload_set(L, error, name, i);
 		}
 	}
 	return error;

--- a/test/box-luatest/error_subsystem_improvements_test.lua
+++ b/test/box-luatest/error_subsystem_improvements_test.lua
@@ -284,6 +284,29 @@ g.test_client_error_creation = function()
     t.assert_equals(e.f1, 1)
     t.assert_equals(e.f2, 'five')
     t.assert_equals(e.f3, 3)
+
+    -- Test if field name is NULL then respective positional argument
+    -- is printed in formatted string message but not become payload.
+    --
+    -- We don't support creation of errors with 'l' modifiers in format string.
+    local fields_count = function(e)
+        local c = 0
+        for _, _ in pairs(e:unpack()) do c = c + 1 end
+        return c
+    end
+    local ref = box.error.new(box.error.TEST_FIRST)
+    local e = box.error.new(box.error.TEST_OMIT_TYPE_CHAR, string.byte('x'))
+    t.assert_equals(e.message, 'Test error x')
+    t.assert_equals(fields_count(e), fields_count(ref))
+    local e = box.error.new(box.error.TEST_OMIT_TYPE_INT, 1)
+    t.assert_equals(e.message, 'Test error 1')
+    t.assert_equals(fields_count(e), fields_count(ref))
+    local e = box.error.new(box.error.TEST_OMIT_TYPE_UINT, 2)
+    t.assert_equals(e.message, 'Test error 2')
+    t.assert_equals(fields_count(e), fields_count(ref))
+    local e = box.error.new(box.error.TEST_OMIT_TYPE_STRING, 'str')
+    t.assert_equals(e.message, 'Test error str')
+    t.assert_equals(fields_count(e), fields_count(ref))
 end
 
 --

--- a/test/box-luatest/error_subsystem_improvements_test.lua
+++ b/test/box-luatest/error_subsystem_improvements_test.lua
@@ -270,6 +270,20 @@ g.test_client_error_creation = function()
     -- Test passing excess payload fields works too.
     local e = box.error.new(box.error.TEST_TYPE_INT, 1, 2, 3, 4, 5)
     t.assert_equals(e.field, 1)
+
+    -- Test format string is supported in message.
+    local e = box.error.new(box.error.TEST_FORMAT_MSG, 1, 'two')
+    t.assert_equals(e.message, 'Test error 1 two')
+    t.assert_equals(e.f1, 1)
+    t.assert_equals(e.f2, 'two')
+
+    -- Test number of arguments of format string may be less
+    -- then number of payload arguments.
+    local e = box.error.new(box.error.TEST_FORMAT_MSG_LESS, 1, 'five', 3)
+    t.assert_equals(e.message, 'Test error 1 five')
+    t.assert_equals(e.f1, 1)
+    t.assert_equals(e.f2, 'five')
+    t.assert_equals(e.f3, 3)
 end
 
 --

--- a/test/unit/error.c
+++ b/test/unit/error.c
@@ -644,7 +644,7 @@ static void
 test_client_error_creation(void)
 {
 	header();
-	plan(42);
+	plan(58);
 
 	/* Test CHAR argument type */
 	const char *s;
@@ -676,7 +676,7 @@ test_client_error_creation(void)
 	ok(error_get_uint(e, "field", &u) && u == UINT_MAX);
 
 	/* Test LONG argument type */
-	diag_set(ClientError, ER_TEST_TYPE_LONG, 1);
+	diag_set(ClientError, ER_TEST_TYPE_LONG, 1L);
 	e = diag_last_error(diag_get());
 	ok(error_get_int(e, "field", &i) && i == 1);
 	diag_set(ClientError, ER_TEST_TYPE_LONG, LONG_MAX);
@@ -687,7 +687,7 @@ test_client_error_creation(void)
 	ok(error_get_int(e, "field", &i) && i == LONG_MIN);
 
 	/* Test ULONG argument type */
-	diag_set(ClientError, ER_TEST_TYPE_ULONG, 1);
+	diag_set(ClientError, ER_TEST_TYPE_ULONG, 1UL);
 	e = diag_last_error(diag_get());
 	ok(error_get_uint(e, "field", &u) && u == 1);
 	diag_set(ClientError, ER_TEST_TYPE_ULONG, ULONG_MAX);
@@ -695,7 +695,7 @@ test_client_error_creation(void)
 	ok(error_get_uint(e, "field", &u) && u == ULONG_MAX);
 
 	/* Test LLONG argument type */
-	diag_set(ClientError, ER_TEST_TYPE_LLONG, 1);
+	diag_set(ClientError, ER_TEST_TYPE_LLONG, 1LL);
 	e = diag_last_error(diag_get());
 	ok(error_get_int(e, "field", &i) && i == 1);
 	diag_set(ClientError, ER_TEST_TYPE_LLONG, LLONG_MAX);
@@ -706,7 +706,7 @@ test_client_error_creation(void)
 	ok(error_get_int(e, "field", &i) && i == LLONG_MIN);
 
 	/* Test ULLONG argument type */
-	diag_set(ClientError, ER_TEST_TYPE_ULLONG, 1);
+	diag_set(ClientError, ER_TEST_TYPE_ULLONG, 1ULL);
 	e = diag_last_error(diag_get());
 	ok(error_get_uint(e, "field", &u) && u == 1);
 	diag_set(ClientError, ER_TEST_TYPE_ULLONG, ULLONG_MAX);
@@ -786,6 +786,43 @@ test_client_error_creation(void)
 	ok(s != NULL && strcmp(s, "seven") == 0);
 	ok(error_get_int(e, "f3", &i) && i == 3);
 	ok(e->errmsg != NULL && strcmp(e->errmsg, "Test error 1 seven") == 0);
+
+	/*
+	 * Test if field name is NULL then respective positional argument
+	 * is printed in formatted string message but not become payload.
+	 */
+	diag_set(ClientError, ER_TEST_OMIT_TYPE_CHAR, 'x');
+	e = diag_last_error(diag_get());
+	ok(e->errmsg != NULL && strcmp(e->errmsg, "Test error x") == 0);
+	ok(e->payload.count == 0);
+	diag_set(ClientError, ER_TEST_OMIT_TYPE_INT, 1);
+	e = diag_last_error(diag_get());
+	ok(e->errmsg != NULL && strcmp(e->errmsg, "Test error 1") == 0);
+	ok(e->payload.count == 0);
+	diag_set(ClientError, ER_TEST_OMIT_TYPE_UINT, 2);
+	e = diag_last_error(diag_get());
+	ok(e->errmsg != NULL && strcmp(e->errmsg, "Test error 2") == 0);
+	ok(e->payload.count == 0);
+	diag_set(ClientError, ER_TEST_OMIT_TYPE_LONG, 3L);
+	e = diag_last_error(diag_get());
+	ok(e->errmsg != NULL && strcmp(e->errmsg, "Test error 3") == 0);
+	ok(e->payload.count == 0);
+	diag_set(ClientError, ER_TEST_OMIT_TYPE_ULONG, 4UL);
+	e = diag_last_error(diag_get());
+	ok(e->errmsg != NULL && strcmp(e->errmsg, "Test error 4") == 0);
+	ok(e->payload.count == 0);
+	diag_set(ClientError, ER_TEST_OMIT_TYPE_LLONG, 5LL);
+	e = diag_last_error(diag_get());
+	ok(e->errmsg != NULL && strcmp(e->errmsg, "Test error 5") == 0);
+	ok(e->payload.count == 0);
+	diag_set(ClientError, ER_TEST_OMIT_TYPE_ULLONG, 6ULL);
+	e = diag_last_error(diag_get());
+	ok(e->errmsg != NULL && strcmp(e->errmsg, "Test error 6") == 0);
+	ok(e->payload.count == 0);
+	diag_set(ClientError, ER_TEST_OMIT_TYPE_STRING, "str");
+	e = diag_last_error(diag_get());
+	ok(e->errmsg != NULL && strcmp(e->errmsg, "Test error str") == 0);
+	ok(e->payload.count == 0);
 
 	check_plan();
 	footer();

--- a/test/unit/error.c
+++ b/test/unit/error.c
@@ -644,7 +644,7 @@ static void
 test_client_error_creation(void)
 {
 	header();
-	plan(35);
+	plan(42);
 
 	/* Test CHAR argument type */
 	const char *s;
@@ -766,6 +766,26 @@ test_client_error_creation(void)
 	ok(error_get_int(e, "f3", &i) && i == 3);
 	ok(error_get_int(e, "f4", &i) && i == 4);
 	ok(error_get_int(e, "f5", &i) && i == 5);
+
+	/* Test format string is supported in message. */
+	diag_set(ClientError, ER_TEST_FORMAT_MSG, 1, "two");
+	e = diag_last_error(diag_get());
+	ok(error_get_int(e, "f1", &i) && i == 1);
+	s = error_get_str(e, "f2");
+	ok(s != NULL && strcmp(s, "two") == 0);
+	ok(e->errmsg != NULL && strcmp(e->errmsg, "Test error 1 two") == 0);
+
+	/*
+	 * Test number of arguments of format string may be less
+	 * then number of payload arguments.
+	 */
+	diag_set(ClientError, ER_TEST_FORMAT_MSG_LESS, 1, "seven", 3);
+	e = diag_last_error(diag_get());
+	ok(error_get_int(e, "f1", &i) && i == 1);
+	s = error_get_str(e, "f2");
+	ok(s != NULL && strcmp(s, "seven") == 0);
+	ok(error_get_int(e, "f3", &i) && i == 3);
+	ok(e->errmsg != NULL && strcmp(e->errmsg, "Test error 1 seven") == 0);
 
 	check_plan();
 	footer();


### PR DESCRIPTION
1. Support both format string and payload for errors.
2.  Support omitting arguments on error creation.

See commits for details.

Follow up #9109