### PR TITLE
[3.0] Don't re-review backports with doc and infra teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,21 +1,4 @@
-# Documentation team is in charge of changelogs.
-# No changes should go w/o approval by doc team
-/changelogs/ @tarantool/doc
-/.github/    @tarantool/devx
-/test/       @tarantool/devx
-/.test.mk    @tarantool/devx
-/test-run/   @tarantool/devx
 # Alexander Turenko wants to track all the activities around the
 # declarative configuration.
-#
-# NB: GitHub's code owners documentation states the following.
-#
-# > If you want to match two or more code owners with the same
-# > pattern, all the code owners must be on the same line. If the
-# > code owners are not on the same line, the pattern matches only
-# > the last mentioned code owner.
-#
-# As result @tarantool/devx should to be added explicitly here for
-# testing directories if there are other code owners.
 /src/box/lua/config/  @Totktonada
-/test/config-luatest/ @Totktonada @tarantool/devx
+/test/config-luatest/ @Totktonada


### PR DESCRIPTION
These changes are anyway approved by these teams before pushing to `master`.

In rare cases we need to adjust something in a changelog entry or a test as part of a backport. These changes will require a manual review request from a backport author.

Kept myself as a reviewer of backports related to the config's code. I need it to track what is delivered in a feature release and in a bugfix release.