### PR TITLE
lua/key_def: add key validation and comparison functions

### DIFF
--- a/changelogs/unreleased/gh-9863-new-key-def-functions.md
+++ b/changelogs/unreleased/gh-9863-new-key-def-functions.md
@@ -1,0 +1,4 @@
+## feature/lua
+
+* Added key validation and comparison functions to the `key_def` module
+  (gh-9863).

--- a/src/box/lua/key_def.h
+++ b/src/box/lua/key_def.h
@@ -73,6 +73,27 @@ int
 luaT_key_def_extract_key(struct lua_State *L, int idx);
 
 /**
+ * Check that key matches given key definition.
+ * Raise error if not.
+ */
+int
+luaT_key_def_validate_key(struct lua_State *L, int idx);
+
+/**
+ * Check that full key matches given key definition.
+ * Raise error if not.
+ */
+int
+luaT_key_def_validate_full_key(struct lua_State *L, int idx);
+
+/**
+ * Check that tuple matches given key definition.
+ * Raise error if not.
+ */
+int
+luaT_key_def_validate_tuple(struct lua_State *L, int idx);
+
+/**
  * Compare tuples using the key definition.
  * Push 0  if key_fields(tuple_a) == key_fields(tuple_b)
  *      <0 if key_fields(tuple_a) < key_fields(tuple_b)
@@ -93,6 +114,15 @@ luaT_key_def_compare(struct lua_State *L, int idx);
  */
 int
 luaT_key_def_compare_with_key(struct lua_State *L, int idx);
+
+/**
+ * Compare keys using the key definition.
+ * Push 0  if parts(key_a) == parts(key_b)
+ *      <0 if parts(key_a) < parts(key_b)
+ *      >0 if parts(key_a) > parts(key_b)
+ */
+int
+luaT_key_def_compare_keys(struct lua_State *L, int idx);
 
 /**
  * Construct and export to LUA a new key definition with a set

--- a/src/box/lua/key_def.lua
+++ b/src/box/lua/key_def.lua
@@ -4,8 +4,12 @@ local key_def_t = ffi.typeof('struct key_def')
 
 local methods = {
     ['extract_key'] = key_def.extract_key,
+    ['validate_key'] = key_def.validate_key,
+    ['validate_full_key'] = key_def.validate_full_key,
+    ['validate_tuple'] = key_def.validate_tuple,
     ['compare'] = key_def.compare,
     ['compare_with_key'] = key_def.compare_with_key,
+    ['compare_keys'] = key_def.compare_keys,
     ['merge'] = key_def.merge,
     ['totable'] = key_def.totable,
     ['__serialize'] = key_def.totable,

--- a/test/app-luatest/key_def_test.lua
+++ b/test/app-luatest/key_def_test.lua
@@ -1,0 +1,231 @@
+local json_lib = require('json')
+local key_def_lib = require('key_def')
+
+local t = require('luatest')
+
+local g = t.group()
+
+g.test_validate_key = function()
+    local key_def = key_def_lib.new({
+        {type = 'unsigned', fieldno = 4},
+        {type = 'string', fieldno = 2},
+    })
+    local errmsg
+
+    t.assert_error_msg_equals(
+        "Usage: key_def:validate_key(key)",
+        key_def.validate_key)
+    t.assert_error_msg_equals(
+        "Usage: key_def:validate_key(key)",
+        key_def.validate_key, key_def)
+    t.assert_error_msg_equals(
+        "A tuple or a table expected, got number",
+        key_def.validate_key, key_def, 0)
+
+    errmsg = "Supplied key type of part 0 does not match index part type: " ..
+             "expected unsigned"
+    t.assert_error_msg_equals(errmsg, key_def.validate_key, key_def,
+                              {'a', 'b'})
+    t.assert_error_msg_equals(errmsg, key_def.validate_key, key_def,
+                              box.tuple.new({'a', 'b'}))
+
+    errmsg = "Supplied key type of part 1 does not match index part type: " ..
+             "expected string"
+    t.assert_error_msg_equals(errmsg, key_def.validate_key, key_def,
+                              {1, 2})
+    t.assert_error_msg_equals(errmsg, key_def.validate_key, key_def,
+                              box.tuple.new({1, 2}))
+
+    errmsg = "Invalid key part count (expected [0..2], got 3)"
+    t.assert_error_msg_equals(errmsg, key_def.validate_key, key_def,
+                              {1, 'a', 1})
+    t.assert_error_msg_equals(errmsg, key_def.validate_key, key_def,
+                              box.tuple.new({1, 'a', 1}))
+
+    key_def:validate_key({})
+    key_def:validate_key({1})
+    key_def:validate_key({1, 'a'})
+    key_def:validate_key(box.tuple.new({}))
+    key_def:validate_key(box.tuple.new({1}))
+    key_def:validate_key(box.tuple.new({1, 'a'}))
+end
+
+g.test_validate_full_key = function()
+    local key_def = key_def_lib.new({
+        {type = 'unsigned', fieldno = 4},
+        {type = 'string', fieldno = 2},
+    })
+    local errmsg
+
+    t.assert_error_msg_equals(
+        "Usage: key_def:validate_full_key(key)",
+        key_def.validate_full_key)
+    t.assert_error_msg_equals(
+        "Usage: key_def:validate_full_key(key)",
+        key_def.validate_full_key, key_def)
+    t.assert_error_msg_equals(
+        "A tuple or a table expected, got number",
+        key_def.validate_full_key, key_def, 0)
+
+    errmsg = "Supplied key type of part 0 does not match index part type: " ..
+             "expected unsigned"
+    t.assert_error_msg_equals(errmsg, key_def.validate_full_key, key_def,
+                              {'a', 'b'})
+    t.assert_error_msg_equals(errmsg, key_def.validate_full_key, key_def,
+                              box.tuple.new({'a', 'b'}))
+
+    errmsg = "Supplied key type of part 1 does not match index part type: " ..
+             "expected string"
+    t.assert_error_msg_equals(errmsg, key_def.validate_full_key, key_def,
+                              {1, 2})
+    t.assert_error_msg_equals(errmsg, key_def.validate_full_key, key_def,
+                              box.tuple.new({1, 2}))
+
+    errmsg = "Invalid key part count in an exact match (expected 2, got 1)"
+    t.assert_error_msg_equals(errmsg, key_def.validate_full_key, key_def,
+                              {1})
+    t.assert_error_msg_equals(errmsg, key_def.validate_full_key, key_def,
+                              box.tuple.new({1}))
+
+    errmsg = "Invalid key part count in an exact match (expected 2, got 3)"
+    t.assert_error_msg_equals(errmsg, key_def.validate_full_key, key_def,
+                              {1, 'a', 1})
+    t.assert_error_msg_equals(errmsg, key_def.validate_full_key, key_def,
+                              box.tuple.new({1, 'a', 1}))
+
+    key_def:validate_full_key({1, 'a'})
+    key_def:validate_full_key(box.tuple.new({1, 'a'}))
+end
+
+g.test_validate_tuple = function()
+    local key_def = key_def_lib.new({
+        {type = 'unsigned', fieldno = 4},
+        {type = 'string', fieldno = 2},
+    })
+    local errmsg
+
+    t.assert_error_msg_equals(
+        "Usage: key_def:validate_tuple(tuple)",
+        key_def.validate_tuple)
+    t.assert_error_msg_equals(
+        "Usage: key_def:validate_tuple(tuple)",
+        key_def.validate_tuple, key_def)
+    t.assert_error_msg_equals(
+        "A tuple or a table expected, got number",
+        key_def.validate_tuple, key_def, 0)
+
+    errmsg = "Supplied key type of part 0 does not match index part type: " ..
+             "expected unsigned"
+    t.assert_error_msg_equals(errmsg, key_def.validate_tuple, key_def,
+                              {box.NULL, 'a', box.NULL, 'b'})
+    t.assert_error_msg_equals(errmsg, key_def.validate_tuple, key_def,
+                              box.tuple.new({box.NULL, 'a', box.NULL, 'b'}))
+
+    errmsg = "Supplied key type of part 1 does not match index part type: " ..
+             "expected string"
+    t.assert_error_msg_equals(errmsg, key_def.validate_tuple, key_def,
+                              {box.NULL, 1, box.NULL, 2})
+    t.assert_error_msg_equals(errmsg, key_def.validate_tuple, key_def,
+                              box.tuple.new({box.NULL, 1, box.NULL, 2}))
+
+    errmsg = "Tuple field [4] required by space format is missing"
+    t.assert_error_msg_equals(errmsg, key_def.validate_tuple, key_def,
+                              {1, 2})
+    t.assert_error_msg_equals(errmsg, key_def.validate_tuple, key_def,
+                              box.tuple.new({1, 2}))
+
+    key_def:validate_tuple({box.NULL, 'a', box.NULL, 1})
+    key_def:validate_tuple(box.tuple.new({box.NULL, 'a', box.NULL, 1}))
+end
+
+g.test_compare_keys = function()
+    local key_def = key_def_lib.new({
+        {type = 'unsigned', fieldno = 4},
+        {type = 'string', fieldno = 2},
+    })
+    local errmsg
+
+    t.assert_error_msg_equals(
+        "Usage: key_def:compare_keys(key_a, key_b)",
+        key_def.compare_keys)
+    t.assert_error_msg_equals(
+        "Usage: key_def:compare_keys(key_a, key_b)",
+        key_def.compare_keys, key_def)
+    t.assert_error_msg_equals(
+        "Usage: key_def:compare_keys(key_a, key_b)",
+        key_def.compare_keys, key_def, {})
+    t.assert_error_msg_equals(
+        "A tuple or a table expected, got number",
+        key_def.compare_keys, key_def, 0, {})
+    t.assert_error_msg_equals(
+        "A tuple or a table expected, got number",
+        key_def.compare_keys, key_def, {}, 0)
+
+    errmsg = "Supplied key type of part 0 does not match index part type: " ..
+             "expected unsigned"
+    t.assert_error_msg_equals(errmsg, key_def.compare_keys, key_def,
+                              {'a', 'b'}, {})
+    t.assert_error_msg_equals(errmsg, key_def.compare_keys, key_def,
+                              box.tuple.new({'a', 'b'}), {})
+    t.assert_error_msg_equals(errmsg, key_def.compare_keys, key_def,
+                              {}, {'a', 'b'})
+    t.assert_error_msg_equals(errmsg, key_def.compare_keys, key_def,
+                              {}, box.tuple.new({'a', 'b'}))
+
+    errmsg = "Supplied key type of part 1 does not match index part type: " ..
+             "expected string"
+    t.assert_error_msg_equals(errmsg, key_def.compare_keys, key_def,
+                              {1, 2}, {})
+    t.assert_error_msg_equals(errmsg, key_def.compare_keys, key_def,
+                              box.tuple.new({1, 2}), {})
+    t.assert_error_msg_equals(errmsg, key_def.compare_keys, key_def,
+                              {}, {1, 2})
+    t.assert_error_msg_equals(errmsg, key_def.compare_keys, key_def,
+                              {}, box.tuple.new({1, 2}))
+
+    errmsg = "Invalid key part count (expected [0..2], got 3)"
+    t.assert_error_msg_equals(errmsg, key_def.compare_keys, key_def,
+                              {1, 'a', 1}, {})
+    t.assert_error_msg_equals(errmsg, key_def.compare_keys, key_def,
+                              box.tuple.new({1, 'a', 1}), {})
+    t.assert_error_msg_equals(errmsg, key_def.compare_keys, key_def,
+                              {}, {1, 'a', 1})
+    t.assert_error_msg_equals(errmsg, key_def.compare_keys, key_def,
+                              {}, box.tuple.new({1, 'a', 1}))
+
+    for _, v in ipairs({
+        {{}, {}, 0},
+        {{}, {1}, 0},
+        {{}, {1, 'a'}, 0},
+        {{1}, {}, 0},
+        {{1}, {1}, 0},
+        {{1}, {1, 'a'}, 0},
+        {{1, 'a'}, {}, 0},
+        {{1, 'a'}, {1}, 0},
+        {{1, 'a'}, {1, 'a'}, 0},
+        {{2}, {1}, 1},
+        {{2}, {1, 'a'}, 1},
+        {{2}, {3}, -1},
+        {{2}, {3, 'a'}, -1},
+        {{2, 'b'}, {1}, 1},
+        {{2, 'b'}, {1, 'a'}, 1},
+        {{2, 'b'}, {2, 'a'}, 1},
+        {{2, 'b'}, {3}, -1},
+        {{2, 'b'}, {3, 'a'}, -1},
+        {{2, 'b'}, {2, 'c'}, -1},
+    }) do
+        local key_a, key_b, ret = unpack(v)
+        local msg = string.format('compare(%s, %s)',
+                                  json_lib.encode(key_a),
+                                  json_lib.encode(key_b))
+        t.assert_equals(key_def:compare_keys(key_a, key_b),
+                        ret, msg)
+        t.assert_equals(key_def:compare_keys(box.tuple.new(key_a), key_b),
+                        ret, msg)
+        t.assert_equals(key_def:compare_keys(key_a, box.tuple.new(key_b)),
+                        ret, msg)
+        t.assert_equals(key_def:compare_keys(box.tuple.new(key_a),
+                                             box.tuple.new(key_b)),
+                        ret, msg)
+    end
+end

--- a/test/box-luatest/gh_7356_index_parts_methods_test.lua
+++ b/test/box-luatest/gh_7356_index_parts_methods_test.lua
@@ -52,6 +52,146 @@ g.test_extract_key = function(cg)
     end)
 end
 
+-- Test index_object.parts:validate_key(key)
+g.test_validate_key = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        local pk = s:create_index('pk', {parts = {4, 'unsigned', 2, 'string'}})
+        local errmsg
+
+        t.assert_error_msg_content_equals(
+            'Usage: index.parts:validate_key(key)',
+            pk.parts.validate_key)
+        t.assert_error_msg_content_equals(
+            'Usage: index.parts:validate_key(key)',
+            pk.parts.validate_key, pk.parts)
+        t.assert_error_msg_content_equals(
+            'A tuple or a table expected, got number',
+            pk.parts.validate_key, pk.parts, 0)
+
+        errmsg = "Supplied key type of part 0 does not match " ..
+                 "index part type: expected unsigned"
+        t.assert_error_msg_content_equals(
+            errmsg, pk.parts.validate_key, pk.parts, {'a', 'b'})
+        t.assert_error_msg_content_equals(
+            errmsg, pk.parts.validate_key, pk.parts, box.tuple.new({'a', 'b'}))
+
+        errmsg = "Supplied key type of part 1 does not match " ..
+                 "index part type: expected string"
+        t.assert_error_msg_equals(
+            errmsg, pk.parts.validate_key, pk.parts, {1, 2})
+        t.assert_error_msg_equals(
+            errmsg, pk.parts.validate_key, pk.parts, box.tuple.new({1, 2}))
+
+        errmsg = "Invalid key part count (expected [0..2], got 3)"
+        t.assert_error_msg_equals(
+            errmsg, pk.parts.validate_key, pk.parts, {1, 'a', 1})
+        t.assert_error_msg_equals(
+            errmsg, pk.parts.validate_key, pk.parts, box.tuple.new({1, 'a', 1}))
+
+        pk.parts:validate_key({})
+        pk.parts:validate_key({1})
+        pk.parts:validate_key({1, 'a'})
+        pk.parts:validate_key(box.tuple.new({}))
+        pk.parts:validate_key(box.tuple.new({1}))
+        pk.parts:validate_key(box.tuple.new({1, 'a'}))
+    end)
+end
+
+-- Test index_object.parts:validate_full_key(key)
+g.test_validate_full_key = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        local pk = s:create_index('pk', {parts = {4, 'unsigned', 2, 'string'}})
+        local errmsg
+
+        t.assert_error_msg_content_equals(
+            'Usage: index.parts:validate_full_key(key)',
+            pk.parts.validate_full_key)
+        t.assert_error_msg_content_equals(
+            'Usage: index.parts:validate_full_key(key)',
+            pk.parts.validate_full_key, pk.parts)
+        t.assert_error_msg_content_equals(
+            'A tuple or a table expected, got number',
+            pk.parts.validate_full_key, pk.parts, 0)
+
+        errmsg = "Supplied key type of part 0 does not match " ..
+                 "index part type: expected unsigned"
+        t.assert_error_msg_content_equals(errmsg, pk.parts.validate_full_key,
+                                          pk.parts, {'a', 'b'})
+        t.assert_error_msg_content_equals(errmsg, pk.parts.validate_full_key,
+                                          pk.parts, box.tuple.new({'a', 'b'}))
+
+        errmsg = "Supplied key type of part 1 does not match " ..
+                 "index part type: expected string"
+        t.assert_error_msg_equals(
+            errmsg, pk.parts.validate_full_key, pk.parts, {1, 2})
+        t.assert_error_msg_equals(
+            errmsg, pk.parts.validate_full_key, pk.parts, box.tuple.new({1, 2}))
+
+        errmsg = "Invalid key part count in an exact match (expected 2, got 1)"
+        t.assert_error_msg_equals(
+            errmsg, pk.parts.validate_full_key, pk.parts, {1})
+        t.assert_error_msg_equals(
+            errmsg, pk.parts.validate_full_key, pk.parts, box.tuple.new({1}))
+
+        errmsg = "Invalid key part count in an exact match (expected 2, got 3)"
+        t.assert_error_msg_equals(errmsg, pk.parts.validate_full_key, pk.parts,
+                                  {1, 'a', 1})
+        t.assert_error_msg_equals(errmsg, pk.parts.validate_full_key, pk.parts,
+                                  box.tuple.new({1, 'a', 1}))
+
+        pk.parts:validate_full_key({1, 'a'})
+        pk.parts:validate_full_key(box.tuple.new({1, 'a'}))
+    end)
+end
+
+-- Test index_object.parts:validate_tuple(tuple)
+g.test_validate_tuple = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        local pk = s:create_index('pk', {parts = {4, 'unsigned', 2, 'string'}})
+        local errmsg
+
+        t.assert_error_msg_content_equals(
+            'Usage: index.parts:validate_tuple(tuple)',
+            pk.parts.validate_tuple)
+        t.assert_error_msg_content_equals(
+            'Usage: index.parts:validate_tuple(tuple)',
+            pk.parts.validate_tuple, pk.parts)
+        t.assert_error_msg_content_equals(
+            'A tuple or a table expected, got number',
+            pk.parts.validate_tuple, pk.parts, 0)
+
+        errmsg = "Supplied key type of part 0 does not match " ..
+                 "index part type: expected unsigned"
+        t.assert_error_msg_content_equals(
+            errmsg, pk.parts.validate_tuple, pk.parts,
+            {box.NULL, 'a', box.NULL, 'b'})
+        t.assert_error_msg_content_equals(
+            errmsg, pk.parts.validate_tuple, pk.parts,
+            box.tuple.new({box.NULL, 'a', box.NULL, 'b'}))
+
+        errmsg = "Supplied key type of part 1 does not match " ..
+                 "index part type: expected string"
+        t.assert_error_msg_equals(
+            errmsg, pk.parts.validate_tuple, pk.parts,
+            {box.NULL, 1, box.NULL, 2})
+        t.assert_error_msg_equals(
+            errmsg, pk.parts.validate_tuple, pk.parts,
+            box.tuple.new({box.NULL, 1, box.NULL, 2}))
+
+        errmsg = "Tuple field [4] required by space format is missing"
+        t.assert_error_msg_equals(errmsg, pk.parts.validate_tuple, pk.parts,
+                                  {1, 2})
+        t.assert_error_msg_equals(errmsg, pk.parts.validate_tuple, pk.parts,
+                                  box.tuple.new({1, 2}))
+
+        pk.parts:validate_tuple({box.NULL, 'a', box.NULL, 1})
+        pk.parts:validate_tuple(box.tuple.new({box.NULL, 'a', box.NULL, 1}))
+    end)
+end
+
 -- Test index_object.parts:compare(tuple_a, tuple_b)
 g.test_compare = function(cg)
     cg.server:exec(function()
@@ -118,6 +258,100 @@ g.test_compare_with_key = function(cg)
         t.assert_error_msg_content_equals(
             'multikey path is unsupported',
             mk.parts.compare_with_key, mk.parts, tuple, {'x', 1})
+    end)
+end
+
+-- Test index_object.parts:compare_keys(key_a, key_b)
+g.test_compare_keys = function(cg)
+    cg.server:exec(function()
+        local json = require('json')
+
+        local s = box.schema.space.create('test')
+        local pk = s:create_index('pk', {parts = {4, 'unsigned', 2, 'string'}})
+        local errmsg
+
+        t.assert_error_msg_equals(
+            "Usage: index.parts:compare_keys(key_a, key_b)",
+            pk.parts.compare_keys)
+        t.assert_error_msg_equals(
+            "Usage: index.parts:compare_keys(key_a, key_b)",
+            pk.parts.compare_keys, pk.parts)
+        t.assert_error_msg_equals(
+            "Usage: index.parts:compare_keys(key_a, key_b)",
+            pk.parts.compare_keys, pk.parts, {})
+        t.assert_error_msg_equals(
+            "A tuple or a table expected, got number",
+            pk.parts.compare_keys, pk.parts, 0, {})
+        t.assert_error_msg_equals(
+            "A tuple or a table expected, got number",
+            pk.parts.compare_keys, pk.parts, {}, 0)
+
+        errmsg = "Supplied key type of part 0 does not match " ..
+                 "index part type: expected unsigned"
+        t.assert_error_msg_equals(errmsg, pk.parts.compare_keys, pk.parts,
+                                  {'a', 'b'}, {})
+        t.assert_error_msg_equals(errmsg, pk.parts.compare_keys, pk.parts,
+                                  box.tuple.new({'a', 'b'}), {})
+        t.assert_error_msg_equals(errmsg, pk.parts.compare_keys, pk.parts,
+                                  {}, {'a', 'b'})
+        t.assert_error_msg_equals(errmsg, pk.parts.compare_keys, pk.parts,
+                                  {}, box.tuple.new({'a', 'b'}))
+
+        errmsg = "Supplied key type of part 1 does not match " ..
+                 "index part type: expected string"
+        t.assert_error_msg_equals(errmsg, pk.parts.compare_keys, pk.parts,
+                                  {1, 2}, {})
+        t.assert_error_msg_equals(errmsg, pk.parts.compare_keys, pk.parts,
+                                  box.tuple.new({1, 2}), {})
+        t.assert_error_msg_equals(errmsg, pk.parts.compare_keys, pk.parts,
+                                  {}, {1, 2})
+        t.assert_error_msg_equals(errmsg, pk.parts.compare_keys, pk.parts,
+                                  {}, box.tuple.new({1, 2}))
+
+        errmsg = "Invalid key part count (expected [0..2], got 3)"
+        t.assert_error_msg_equals(errmsg, pk.parts.compare_keys, pk.parts,
+                                  {1, 'a', 1}, {})
+        t.assert_error_msg_equals(errmsg, pk.parts.compare_keys, pk.parts,
+                                  box.tuple.new({1, 'a', 1}), {})
+        t.assert_error_msg_equals(errmsg, pk.parts.compare_keys, pk.parts,
+                                  {}, {1, 'a', 1})
+        t.assert_error_msg_equals(errmsg, pk.parts.compare_keys, pk.parts,
+                                  {}, box.tuple.new({1, 'a', 1}))
+
+        for _, v in ipairs({
+            {{}, {}, 0},
+            {{}, {1}, 0},
+            {{}, {1, 'a'}, 0},
+            {{1}, {}, 0},
+            {{1}, {1}, 0},
+            {{1}, {1, 'a'}, 0},
+            {{1, 'a'}, {}, 0},
+            {{1, 'a'}, {1}, 0},
+            {{1, 'a'}, {1, 'a'}, 0},
+            {{2}, {1}, 1},
+            {{2}, {1, 'a'}, 1},
+            {{2}, {3}, -1},
+            {{2}, {3, 'a'}, -1},
+            {{2, 'b'}, {1}, 1},
+            {{2, 'b'}, {1, 'a'}, 1},
+            {{2, 'b'}, {2, 'a'}, 1},
+            {{2, 'b'}, {3}, -1},
+            {{2, 'b'}, {3, 'a'}, -1},
+            {{2, 'b'}, {2, 'c'}, -1},
+        }) do
+            local key_a, key_b, ret = unpack(v)
+            local msg = string.format('compare(%s, %s)',
+                                      json.encode(key_a), json.encode(key_b))
+            t.assert_equals(pk.parts:compare_keys(key_a, key_b),
+                            ret, msg)
+            t.assert_equals(pk.parts:compare_keys(box.tuple.new(key_a), key_b),
+                            ret, msg)
+            t.assert_equals(pk.parts:compare_keys(key_a, box.tuple.new(key_b)),
+                            ret, msg)
+            t.assert_equals(pk.parts:compare_keys(box.tuple.new(key_a),
+                                                  box.tuple.new(key_b)),
+                            ret, msg)
+        end
     end)
 end
 


### PR DESCRIPTION
The following new functions were introduced to the `key_def` Lua module:

 - `key_def:validate_key(key)`: validates a key against a key definition object. Raises an exception if the key doesn't match. Returns nothing on success. See also `box_key_def_validate_key` C API function.

 - `key_def:validate_full_key(key)`: validates a full key against a key definition object. Raises an exception if the key doesn't match. Returns nothing on success. See also `box_key_def_validate_full_key` C API function.

 - `key_def:validate_tuple(tuple)`: validates a tuple against a key definition object. Raises an exception if the tuple doesn't match. Returns nothing on success. See also `box_key_def_validate_tuple` C API function.

 - `key_def:compare_keys(key_a, key_b)`: compares two keys according to a key definition object. Raises an exception if any of the given key doesn't match the key definition. On success, returns a value <0 if `key_a` parts are less than `key_b` parts, 0 if equal, >1 if greater.

Closes #9863