### PR TITLE
[backport 3.0] test: fix peculiar behavior of cluster:start()

### DIFF
--- a/test/config-luatest/cluster.lua
+++ b/test/config-luatest/cluster.lua
@@ -96,6 +96,22 @@ local function cluster_start(self, opts)
             server:wait_until_ready()
         end)
     end
+
+    -- wait_until_running is equal to wait_until_ready by default.
+    local wait_until_running = wait_until_ready
+    if opts ~= nil and opts.wait_until_running ~= nil then
+        wait_until_running = opts.wait_until_running
+    end
+
+    if wait_until_running then
+        self:each(function(server)
+            server:exec(function()
+                t.helpers.retrying({timeout = 60}, function()
+                    t.assert_equals(box.info.status, 'running')
+                end)
+            end)
+        end)
+    end
 end
 
 -- Start the given instance.

--- a/test/config-luatest/cluster.lua
+++ b/test/config-luatest/cluster.lua
@@ -85,13 +85,17 @@ local function cluster_start(self, opts)
         server:start({wait_until_ready = false})
     end)
 
-    if opts ~= nil and not opts.wait_until_ready then
-        return
+    -- wait_until_ready is true by default.
+    local wait_until_ready = true
+    if opts ~= nil and opts.wait_until_ready ~= nil then
+        wait_until_ready = opts.wait_until_ready
     end
 
-    self:each(function(server)
-        server:wait_until_ready()
-    end)
+    if wait_until_ready then
+        self:each(function(server)
+            server:wait_until_ready()
+        end)
+    end
 end
 
 -- Start the given instance.


### PR DESCRIPTION
*(This is a backport of PR #9877 to `release/3.0`, future `3.0.2` release.)*

----

Unlike `cluster:start()` without the options argument, the `cluster:start({})` call has been interpreted as `cluster:start({wait_until_ready = false})`. Now it is equivalent to `cluster:start({wait_until_ready = true})`.

`cluster:start()` has not been waiting for leaving the `'orphan'` status. Now it does this for all the instances of the cluster. The new `wait_until_running` option was added to opt out from this behavior.

The first change doesn't affect existing tests. The second one improves stability of `config-luatest/anonymous_replica_test.lua`.