### PR TITLE
[backport 2.11] net.box: reference the connection object from asynchronous requests

### DIFF
--- a/changelogs/unreleased/gh-9629-netbox-async-request-connection-gc.md
+++ b/changelogs/unreleased/gh-9629-netbox-async-request-connection-gc.md
@@ -1,0 +1,4 @@
+## bugfix/lua
+
+* Fixed a bug in `net.box` when a connection with asynchronous requests could
+  get garbage collected (gh-9629).

--- a/src/box/lua/net_box.lua
+++ b/src/box/lua/net_box.lua
@@ -775,7 +775,7 @@ function remote_methods:_request_impl(method, opts, format, stream_id, ...)
             if opts.on_push or opts.on_push_ctx then
                 error('To handle pushes in an async request use future:pairs()')
             end
-            return transport:perform_async_request(buffer, skip_header,
+            return transport:perform_async_request(self, buffer, skip_header,
                                                    return_raw, table.insert,
                                                    {}, format, stream_id,
                                                    method, ...)

--- a/test/box-luatest/gh_9629_netbox_async_request_connection_gc_test.lua
+++ b/test/box-luatest/gh_9629_netbox_async_request_connection_gc_test.lua
@@ -1,0 +1,26 @@
+local net_box = require('net.box')
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+-- Tests that a connection with asynchronous requests does not get garbage
+-- collected.
+g.test_async_request_connection_gc = function(cg)
+    local c = net_box.connect(cg.server.net_box_uri)
+    local f = c:eval('return 777', {}, {is_async = true})
+    c = nil -- luacheck: no unused
+    collectgarbage()
+    local res, err = f:wait_result(10)
+    t.assert_equals(err, nil)
+    t.assert_equals(res[1], 777)
+end


### PR DESCRIPTION
In order to prevent the garbage collection of the discarded connection, asynchronous requests must reference the connection object. We must reference the connection object rather than the transport object, because our garbage collection hook is attached to the former.

Closes #9629

NO_DOC=<bugfix>

(cherry picked from commit fb5bf51ce53eab49c57e5da02c53098fa05afec0)