### PR TITLE
[backport 2.11] box: support exclude_null option in functional indexes

### DIFF
--- a/changelogs/unreleased/gh-9732-func-index-exclude-null.md
+++ b/changelogs/unreleased/gh-9732-func-index-exclude-null.md
@@ -1,0 +1,3 @@
+## bugfix/box
+
+* The `exclude_null` option is now supported by functional indexes (gh-9732).

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -1442,6 +1442,8 @@ memtx_tree_func_index_replace(struct index *base, struct tuple *old_tuple,
 		(struct memtx_tree_index<true> *)base;
 	struct index_def *index_def = index->base.def;
 	assert(index_def->key_def->for_func_index);
+	/* Make sure that key_def is not multikey - we rely on it below. */
+	assert(!index_def->key_def->is_multikey);
 
 	int rc = -1;
 	struct region *region = &fiber()->gc;
@@ -1459,8 +1461,11 @@ memtx_tree_func_index_replace(struct index *base, struct tuple *old_tuple,
 		int err = 0;
 		struct tuple *key;
 		struct func_key_undo *undo;
+		struct key_def *key_def = index_def->key_def;
 		while ((err = key_list_iterator_next(&it, &key)) == 0 &&
 			key != NULL) {
+			if (tuple_key_is_excluded(key, key_def, MULTIKEY_NONE))
+				continue;
 			/* Perform insertion, log it in list. */
 			undo = func_key_undo_new(region);
 			if (undo == NULL) {
@@ -1748,6 +1753,8 @@ memtx_tree_func_index_build_next(struct index *base, struct tuple *tuple)
 		(struct memtx_tree_index<true> *)base;
 	struct index_def *index_def = index->base.def;
 	assert(index_def->key_def->for_func_index);
+	/* Make sure that key_def is not multikey - we rely on it below. */
+	assert(!index_def->key_def->is_multikey);
 
 	struct region *region = &fiber()->gc;
 	size_t region_svp = region_used(region);
@@ -1757,9 +1764,12 @@ memtx_tree_func_index_build_next(struct index *base, struct tuple *tuple)
 				     memtx->func_key_format) != 0)
 		return -1;
 
+	struct key_def *key_def = index_def->key_def;
 	struct tuple *key;
 	uint32_t insert_idx = index->build_array_size;
 	while (key_list_iterator_next(&it, &key) == 0 && key != NULL) {
+		if (tuple_key_is_excluded(key, key_def, MULTIKEY_NONE))
+			continue;
 		if (memtx_tree_index_build_array_append(index, tuple,
 							(hint_t)key) != 0)
 			goto error;

--- a/test/box-luatest/gh_9732_func_index_exclude_null_test.lua
+++ b/test/box-luatest/gh_9732_func_index_exclude_null_test.lua
@@ -1,0 +1,209 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.space ~= nil then
+            box.space.space:drop()
+        end
+        if box.func.func ~= nil then
+            box.func.func:drop()
+        end
+        if box.func.multipart_func ~= nil then
+            box.func.multipart_func:drop()
+        end
+    end)
+end)
+
+g.test_func_index_exclude_null = function(cg)
+    cg.server:exec(function()
+        local space = box.schema.space.create("space")
+        space:format({
+            {name = "first", type = "unsigned"},
+            {name = "second", type = "unsigned", is_nullable = true},
+            {name = "third", type = "unsigned", is_nullable = true}
+        })
+        space:create_index("primary",
+            {parts = {{field = 1, type = "unsigned"}}})
+
+        box.schema.func.create("func", {
+            body = [[
+                function(tuple)
+                    return {tuple[2]}
+                end
+            ]],
+            is_deterministic = true,
+            is_sandboxed = true,
+        })
+        space:create_index("index", {
+            unique = false,
+            func = "func",
+            parts = {{field = 1, type = "unsigned",
+                      is_nullable = true, exclude_null = true}},
+        })
+
+        box.schema.func.create("multipart_func", {
+            body = [[
+                function(tuple)
+                    return {tuple[2], tuple[3]}
+                end
+            ]],
+            is_deterministic = true,
+            is_sandboxed = true,
+        })
+        space:create_index("multipart_index", {
+            unique = false,
+            func = "multipart_func",
+            parts = {
+                {field = 1, type = "unsigned",
+                 is_nullable = true, exclude_null = true},
+                {field = 2, type = "unsigned",
+                 is_nullable = true, exclude_null = true}
+            }
+        })
+
+        space:insert({1, 1, 1})
+        space:insert({2, 2, box.NULL})
+        space:insert({3, box.NULL, 3})
+        space:insert({4, box.NULL, box.NULL})
+    end)
+
+    local function check_case()
+        local index = box.space.space.index.index
+        t.assert_equals(
+            index:select({}, {fullscan = true}), {{1, 1, 1}, {2, 2}})
+        t.assert_equals(index:select({1}), {{1, 1, 1}})
+        t.assert_equals(index:select({2}), {{2, 2}})
+        t.assert_equals(index:select({3}), {})
+        t.assert_equals(index:select({4}), {})
+        t.assert_equals(index:select({box.NULL}), {})
+
+        local multipart = box.space.space.index.multipart_index
+        t.assert_equals(multipart:select({}, {fullscan = true}), {{1, 1, 1}})
+        t.assert_equals(multipart:select({1}), {{1, 1, 1}})
+        t.assert_equals(multipart:select({2}), {})
+        t.assert_equals(multipart:select({3}), {})
+        t.assert_equals(multipart:select({4}), {})
+        t.assert_equals(multipart:select({box.NULL}), {})
+    end
+
+    cg.server:exec(check_case)
+
+    -- Check after recovery
+    cg.server:restart()
+    cg.server:exec(check_case)
+end
+
+g.test_func_index_exclude_null_multikey = function(cg)
+    cg.server:exec(function()
+        local space = box.schema.space.create("space")
+        space:format({
+            {name = "first", type = "unsigned"},
+            {name = "second", type = "unsigned"}
+        })
+        space:create_index("primary",
+            {parts = {{field = 1, type = "unsigned"}}})
+
+        box.schema.func.create("func", {
+            body = [[
+                function(tuple)
+                    local box_NULL = tuple[3]
+                    assert(type(box_NULL) == 'cdata')
+                    assert(box_NULL == nil)
+
+                    local last_val = box_NULL
+                    if tuple[1] == 0 then
+                        last_val = 'abc'
+                    end
+                    return {
+                        {box_NULL}, {tuple[1]}, {box_NULL},
+                        {tuple[2]}, {last_val}
+                    }
+                end
+            ]],
+            is_deterministic = true,
+            is_sandboxed = true,
+            opts = {is_multikey = true},
+        })
+        space:create_index("index", {
+            unique = false,
+            func = "func",
+            parts = {{field = 1, type = "unsigned",
+                      is_nullable = true, exclude_null = true}}
+        })
+
+        box.schema.func.create("multipart_func", {
+            body = [[
+                function(tuple)
+                    local box_NULL = tuple[3]
+                    assert(type(box_NULL) == 'cdata')
+                    assert(box_NULL == nil)
+                    return {
+                        {tuple[1], tuple[2]}, {tuple[1], box_NULL},
+                        {box_NULL, tuple[2]}, {box_NULL, box_NULL}
+                    }
+                end
+            ]],
+            is_deterministic = true,
+            is_sandboxed = true,
+            opts = {is_multikey = true},
+        })
+        space:create_index("multipart_index", {
+            unique = false,
+            func = "multipart_func",
+            parts = {
+                {field = 1, type = "unsigned", is_nullable = true,
+                 exclude_null = true},
+                {field = 2, type = "unsigned", is_nullable = true,
+                 exclude_null = true}
+            }
+        })
+
+        -- Insert tuple with invalid last key to check if rollback of inserted
+        -- keys of functional multikey works correctly
+        local ok = pcall(function() space:insert({0, 0, box.NULL}) end)
+        t.assert(not ok)
+
+        space:insert({1, 2, box.NULL})
+        space:insert({3, 4, box.NULL})
+    end)
+
+    local function check_case()
+        local index = box.space.space.index.index
+        t.assert_equals(
+            index:select({}, {fullscan = true}),
+            {{1, 2}, {1, 2}, {3, 4}, {3, 4}}
+        )
+        t.assert_equals(index:select({1}), {{1, 2}})
+        t.assert_equals(index:select({2}), {{1, 2}})
+        t.assert_equals(index:select({3}), {{3, 4}})
+        t.assert_equals(index:select({4}), {{3, 4}})
+        t.assert_equals(index:select({box.NULL}), {})
+
+        local multipart = box.space.space.index.multipart_index
+        t.assert_equals(
+            multipart:select({}, {fullscan = true}), {{1, 2}, {3, 4}})
+        t.assert_equals(multipart:select({1}), {{1, 2}})
+        t.assert_equals(multipart:select({1, 2}), {{1, 2}})
+        t.assert_equals(multipart:select({3}), {{3, 4}})
+        t.assert_equals(multipart:select({3, 4}), {{3, 4}})
+        t.assert_equals(multipart:select({box.NULL}), {})
+    end
+
+    cg.server:exec(check_case)
+
+    -- Check after recovery
+    cg.server:restart()
+    cg.server:exec(check_case)
+end


### PR DESCRIPTION
Currently, exclude_null option doesn't affect functional indexes at all. It seems that we just forgot to check if tuple should be inserted to the index - the patch simply adds missing check in replace and build_next methods of functional memtx_tree index.

Closes #9732

NO_DOC=bugfix

(cherry picked from commit c56998fad6a7f2cda4252b5cfde1ccef5050fe19)