### PR TITLE
[backport 3.0] build: include header "unit.h" after c++ headers

### DIFF
--- a/test/unit/rtree_multidim.cc
+++ b/test/unit/rtree_multidim.cc
@@ -2,12 +2,14 @@
 #include <time.h>
 #include <algorithm>
 
-#include "unit.h"
 #include "salad/rtree.h"
 #include "../../src/lib/salad/rtree.h"
 
 #include <vector>
 #include <set>
+
+#include "unit.h"
+
 using namespace std;
 
 const uint32_t extent_size = 1024 * 16;


### PR DESCRIPTION
Header "unit.h" contains `ok` and `is` macros used to check test cases. The problem is such simple names can be used in C++ STL library headers (it's OK because such short names can be hidden in a namespace), so when including, for example, header "vector" after "unit.h", build can fail because function declaration or definition in the C++ header will turn into a macro invocation. I faced this problem building Tarantool on MacOS with SDK of 14.4 version.

NO_TEST=fix build
NO_CHANGELOG=fix build
NO_DOC=fix build

(cherry picked from commit 025ba32f842619b5d2ceb0569b4581396e75550d)