### PR TITLE
docker: change localhost:3301 to 0.0.0.0:3301

### DIFF
--- a/docker/config/default-config.yaml
+++ b/docker/config/default-config.yaml
@@ -5,7 +5,7 @@ credentials:
 
 iproto:
   listen:
-    - uri: localhost:3301
+    - uri: 0.0.0.0:3301
 
 groups:
   group-001:


### PR DESCRIPTION
This patch changes iproto listen URI setting in default-config.yaml from `localhost:3301` to `0.0.0.0:3301`. Without this change, it's impossible to start container and use a popular way for port publishing:

    $ docker run -p 3301:3301 --rm -d tarantool/tarantool
    $ tt connect 127.0.0.1:3301
        Connecting to the instance...
        failed to run interactive console: failed to create new console:
        failed to connect: failed to get protocol:failed to read
        Tarantool greeting: EOF