### PR TITLE
httpc: HTTP version option for HTTP client

### DIFF
--- a/changelogs/unreleased/gh-9806-http-set-version.md
+++ b/changelogs/unreleased/gh-9806-http-set-version.md
@@ -1,0 +1,4 @@
+## feature/lua/http client
+
+* Added the `http_version` option to the `request()`, `post()`,
+  `get()` and other request functions from the `http.client` module (gh-9806).

--- a/src/httpc.c
+++ b/src/httpc.c
@@ -464,6 +464,29 @@ httpc_set_accept_encoding(struct httpc_request *req, const char *encoding)
 #endif
 }
 
+int
+httpc_set_http_version(struct httpc_request *req, const char *version)
+{
+	if (strcmp(version, "1.1") == 0) {
+		curl_easy_setopt(req->curl_request.easy, CURLOPT_HTTP_VERSION,
+				 (long)CURL_HTTP_VERSION_1_1);
+	} else if (strcmp(version, "2") == 0) {
+		curl_easy_setopt(req->curl_request.easy, CURLOPT_HTTP_VERSION,
+				 (long)CURL_HTTP_VERSION_2);
+	} else if (strcmp(version, "2-tls") == 0) {
+		curl_easy_setopt(req->curl_request.easy, CURLOPT_HTTP_VERSION,
+				 (long)CURL_HTTP_VERSION_2TLS);
+	} else if (strcmp(version, "2-prior-knowledge") == 0) {
+		curl_easy_setopt(req->curl_request.easy, CURLOPT_HTTP_VERSION,
+				 (long)CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE);
+	} else {
+		diag_set(IllegalParams, "Not a supported http version: %s",
+			 version);
+		return -1;
+	}
+	return 0;
+}
+
 /**
  * The callback to call after a CURL request is completed.
  */

--- a/src/httpc.h
+++ b/src/httpc.h
@@ -440,6 +440,16 @@ void
 httpc_set_accept_encoding(struct httpc_request *req, const char *encoding);
 
 /**
+ * Specify http protocol version for request
+ * @param req request
+ * @param version - http version to use for this request
+ * Version can be 1.1, 2, 2-tls or 2-prior-knowledge
+ * @see https://curl.se/libcurl/c/CURLOPT_HTTP_VERSION.html
+ */
+int
+httpc_set_http_version(struct httpc_request *req, const char *version);
+
+/**
  * Enable a chunked io interface for the request. It allows to
  * send and receive data via chunks.
  *

--- a/src/lua/httpc.c
+++ b/src/lua/httpc.c
@@ -364,6 +364,15 @@ luaT_httpc_request(lua_State *L)
 		httpc_set_accept_encoding(req, lua_tostring(L, -1));
 	lua_pop(L, 1);
 
+	lua_getfield(L, 5, "http_version");
+	if (!lua_isnil(L, -1)) {
+		if (httpc_set_http_version(req, lua_tostring(L, -1))) {
+			httpc_request_delete(req);
+			return luaT_error(L);
+		}
+	}
+	lua_pop(L, 1);
+
 	bool chunked = false;
 	lua_getfield(L, 5, "chunked");
 	if (!lua_isnil(L, -1) && lua_isboolean(L, -1))

--- a/src/lua/httpc.lua
+++ b/src/lua/httpc.lua
@@ -525,6 +525,8 @@ end
 --
 --      accept_encoding - enables automatic decompression of HTTP responses;
 --
+--      http_version - describes an http version;
+--
 --      chunked - enables chunked io interface;
 --
 --      params - a table with query parameters;

--- a/test/app-luatest/http_client_http_version_test.lua
+++ b/test/app-luatest/http_client_http_version_test.lua
@@ -1,0 +1,94 @@
+-- This tests are using treegen to catch information about protocol version
+-- by catching stderr. Treegen creates and tracks temporary directories, where
+-- scripts with testing workloads reside.
+
+local t = require('luatest')
+local treegen = require('test.treegen')
+local justrun = require('test.justrun')
+local socket = require('socket')
+
+local wrong_version_group = t.group()
+
+local http_version_group = t.group('versions', {
+    { proto = 'http', version = nil },
+    { proto = 'http', version = '1.1' },
+    { proto = 'http', version = '2' },
+    { proto = 'http', version = '2-tls' },
+    { proto = 'http', version = '2-prior-knowledge' },
+    { proto = 'https', version = nil },
+    { proto = 'https', version = '1.1' },
+    { proto = 'https', version = '2' },
+    { proto = 'https', version = '2-tls' },
+    { proto = 'https', version = '2-prior-knowledge' },
+})
+
+local expected = {
+    ['nil'] = {
+        http = 'GET / HTTP/1.1',
+        https = 'ALPN: curl offers h2,http/1.1',
+    },
+    ['1.1'] = {
+        http = 'GET / HTTP/1.1',
+        https = 'ALPN: curl offers http/1.1',
+    },
+    ['2'] = {
+        http = 'Connection: Upgrade, HTTP2-Settings',
+        https = 'ALPN: curl offers h2,http/1.1',
+    },
+    ['2-tls'] = {
+        http = 'GET / HTTP/1.1',
+        https = 'ALPN: curl offers h2,http/1.1',
+    },
+    ['2-prior-knowledge'] = {
+        http = '[HTTP/2] [1] OPENED stream',
+        https = 'ALPN: curl offers h2,http/1.1',
+    },
+}
+
+http_version_group.before_all(treegen.init)
+http_version_group.after_all(treegen.clean)
+
+http_version_group.before_each(function(g)
+    g.server = socket.tcp_server('127.0.0.1', 0, function(_s) end)
+end)
+
+http_version_group.after_each(function(g)
+    g.server:close()
+end)
+
+local http_request_script = string.dump(function()
+    local http_client = require('http.client').new()
+    local proto = os.getenv('PROTO')
+    local port = os.getenv('HTTP_SERVER_PORT')
+    local uri = proto .. '://127.0.0.1:' .. port
+    local ok = pcall(http_client.get, http_client, uri, {
+        verbose = true,
+        http_version = os.getenv('HTTP_VERSION'),
+    })
+    -- The server accepts the connection and closes it immediately so
+    -- the http request is expected to fail.
+    assert(not ok)
+end)
+
+http_version_group.test_http_version = function(g)
+    local dir = treegen.prepare_directory(g, {}, {})
+    local script_name = 'http_request.lua'
+    treegen.write_script(dir, script_name, http_request_script)
+    local args = {script_name}
+    local opts = {nojson = true, stderr = true}
+    local env = {HTTP_SERVER_PORT = g.server:name().port}
+    env.PROTO = g.params.proto
+    env.HTTP_VERSION = g.params.version
+    local res = justrun.tarantool(dir, env, args, opts)
+    local exp = expected[tostring(g.params.version)][g.params.proto]
+    t.assert_str_contains(res.stderr, exp)
+end
+
+wrong_version_group.test_request_wrong_http_version = function()
+    local http_client = require('http.client').new()
+    local exp_err = 'Not a supported http version: Not an http version'
+    local uri = 'http://127.0.0.1:8080'
+    t.assert_error_msg_equals(exp_err, function()
+        http_client:get(uri, {http_version = 'Not an http version'})
+    end)
+end


### PR DESCRIPTION
The `http_version` option allows to set version of http in functions like
`request()`, `post()`, `get()` and etc using this curl option:
https://curl.se/libcurl/c/CURLOPT_HTTP_VERSION.html
The http_version takes one of the strings listed below or a nil value
and sets the appropriate protocol version.

List of supported values:
1) nil - works as '2-tls' by default.
2) '1.1' - sets HTTP/1.1 version.
3) '2' - sets HTTP/2 version that falls back to HTTP/1.1 if cannot be
   negotiated with the server.
4) '2-tls' - works as '2' for HTTPS and as '1.1' for plain text HTTP.
5) '2-prior-knowledge' sets HTTP/2 version without HTTP/1.1 at back.
   It requires prior knowledge that the server supports HTTP/2.

Closes #9806