### PR TITLE
config: verify replicaset to contain an instance

### DIFF
--- a/changelogs/unreleased/gh-9895-forbid-empty-group-or-replicaset.md
+++ b/changelogs/unreleased/gh-9895-forbid-empty-group-or-replicaset.md
@@ -1,0 +1,5 @@
+## bugfix/config
+
+* Added additional validation to a cluster's configuration.
+  Now it is forbidden to create an empty group or
+  replicaset (gh-9895).

--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -731,11 +731,31 @@ local function validate_anon(found, peers, failover, leader)
     end
 end
 
+local function validate_misplacing(cconfig)
+    for group_name, group_cfg in pairs(cconfig.groups) do
+        if group_cfg.replicasets == nil or
+                next(group_cfg.replicasets) == nil then
+            error(('group %q should include at ' ..
+                   'least one replicaset.'):format(group_name), 0)
+        end
+
+        for replicaset_name, replicaset_cfg in pairs(group_cfg.replicasets) do
+            if replicaset_cfg.instances == nil or
+                    next(replicaset_cfg.instances) == nil then
+                error(('replicaset %q should include at ' ..
+                       'least one instance.'):format(replicaset_name), 0)
+            end
+        end
+    end
+end
+
 local function new(iconfig, cconfig, instance_name)
     -- Find myself in a cluster config, determine peers in the same
     -- replicaset.
     local found = cluster_config:find_instance(cconfig, instance_name)
     assert(found ~= nil)
+
+    validate_misplacing(cconfig)
 
     -- Precalculate configuration with applied defaults.
     local iconfig_def = instance_config:apply_default(iconfig)

--- a/test/config-luatest/cbuilder.lua
+++ b/test/config-luatest/cbuilder.lua
@@ -106,6 +106,17 @@ local function cbuilder_set_global_option(self, path, value)
     return self
 end
 
+-- Set an option for the selected group.
+local function cbuilder_set_group_option(self, path, value)
+    assert(type(path) == 'string')
+    path = fun.chain({
+        'groups', self._group,
+    }, path:split('.')):totable()
+
+    cluster_config:set(self._config, path, value)
+    return self
+end
+
 -- Set an option for the selected replicaset.
 local function cbuilder_set_replicaset_option(self, path, value)
     assert(type(path) == 'string')
@@ -169,6 +180,7 @@ local cbuilder_mt = {
     use_group = cbuilder_use_group,
     use_replicaset = cbuilder_use_replicaset,
     set_global_option = cbuilder_set_global_option,
+    set_group_option = cbuilder_set_group_option,
     set_replicaset_option = cbuilder_set_replicaset_option,
     set_instance_option = cbuilder_set_instance_option,
     add_instance = cbuilder_add_instance,

--- a/test/config-luatest/cluster.lua
+++ b/test/config-luatest/cluster.lua
@@ -54,9 +54,9 @@ end
 -- in the alphabetical order.
 local function instance_names_from_config(config)
     local instance_names = {}
-    for _, group in pairs(config.groups) do
-        for _, replicaset in pairs(group.replicasets) do
-            for name, _ in pairs(replicaset.instances) do
+    for _, group in pairs(config.groups or {}) do
+        for _, replicaset in pairs(group.replicasets or {}) do
+            for name, _ in pairs(replicaset.instances or {}) do
                 table.insert(instance_names, name)
             end
         end
@@ -206,6 +206,7 @@ local cluster_mt = {
 }
 
 local function new(g, config, server_opts)
+    assert(config._config == nil, "Please provide cbuilder.new():config()")
     assert(g.cluster == nil)
 
     -- Prepare a temporary directory and write a configuration
@@ -259,6 +260,7 @@ end
 -- ensure that all the instances fails to start and reports the
 -- given error message.
 local function startup_error(g, config, exp_err)
+    assert(config._config == nil, "Please provide cbuilder.new():config()")
     -- Prepare a temporary directory and write a configuration
     -- file.
     local dir = treegen.prepare_directory(g, {}, {})

--- a/test/config-luatest/cluster_config_test.lua
+++ b/test/config-luatest/cluster_config_test.lua
@@ -281,3 +281,33 @@ g.test_instance_uri_errors = function(g)
         end)
     end)
 end
+
+-- Attempt to pass an empty group and an empty replicaset.
+g.test_misplace_option = function(g)
+    local config = cbuilder.new()
+        :use_group('g-001')
+
+        :use_replicaset('r-001')
+        :add_instance('i-001', {})
+
+        :use_group('sharding')
+        :set_group_option('roles', {'storage'})
+        :config()
+
+    cluster.startup_error(g, config, "group \"sharding\" should " ..
+                                     "include at least one replicaset.")
+
+    local config = cbuilder.new()
+        :use_group('g-001')
+
+        :use_replicaset('r-001')
+        :add_instance('i-001', {})
+
+        :use_replicaset('sharding')
+        :set_replicaset_option('roles', {'storage'})
+
+        :config()
+
+    cluster.startup_error(g, config, "replicaset \"sharding\" should " ..
+                                     "include at least one instance.")
+end


### PR DESCRIPTION
It is very easy to misplace a config option to a different lever, for
example create an empty replicaset `sharding` with storage role, instead
of configuring sharding option to `storage`:
```yaml
groups:
  g-001:
    replicasets:
      sharding:
        roles:
        - storage
      r-001:
        instances:
          i-001: {}
```

This patch adds verification that forbids creating a replicaset without
a single instance in it.

Closes https://github.com/tarantool/tarantool/issues/9895

NO_DOC=bugfix