### PR TITLE
Increase max number of tuples in hash index to `2^32 - 8`

### DIFF
--- a/changelogs/unreleased/gh-9864-allow-up-to-2-32-tuples-in-hash-index.md
+++ b/changelogs/unreleased/gh-9864-allow-up-to-2-32-tuples-in-hash-index.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Increased the maximum number of tuples in a hash index from 2147483648 (2^31)
+  to 4294967288 (2^32 - 8) (gh-9864).

--- a/src/lib/core/random.c
+++ b/src/lib/core/random.c
@@ -148,6 +148,15 @@ xoshiro_random(void)
 	return result;
 }
 
+void
+xoshiro_srand(uint64_t *seed)
+{
+	state[0] = seed[0];
+	state[1] = seed[1];
+	state[2] = seed[2];
+	state[3] = seed[3];
+}
+
 const char *
 xoshiro_state_str(void)
 {

--- a/src/lib/core/random.h
+++ b/src/lib/core/random.h
@@ -60,6 +60,14 @@ real_random(void);
 uint64_t
 xoshiro_random(void);
 
+/**
+ * Sets the `seed` for a new sequence of pseudo-random integers to be returned
+ * by xoshiro_random(). These sequences are repeatable by calling xoshiro_srand
+ * with the same seed value.
+ */
+void
+xoshiro_srand(uint64_t *seed);
+
 const char *
 xoshiro_state_str(void);
 

--- a/src/lib/salad/light.h
+++ b/src/lib/salad/light.h
@@ -526,11 +526,14 @@ LIGHT(slot)(const struct LIGHT(common) *ht, uint32_t hash)
 {
 	uint32_t cover_mask = ht->cover_mask;
 	uint32_t res = hash & cover_mask;
-	uint32_t probe = (ht->table_size - res - 1) >> 31;
+	/*
+	 * Calculate the following expression without branch instructions:
+	 * probe = res >= ht->table_size;
+	 */
+	uint32_t probe = ((size_t)ht->table_size - res - 1) >> 63;
 	uint32_t shift = __builtin_ctz(~(cover_mask >> 1));
 	res ^= (probe << shift);
 	return res;
-
 }
 
 /**

--- a/src/lib/salad/light.h
+++ b/src/lib/salad/light.h
@@ -845,6 +845,15 @@ LIGHT(grow)(struct LIGHT(common) *ht)
 {
 	assert(!matras_is_read_view_created(ht->view));
 	assert(ht->empty_slot == LIGHT(end));
+	/*
+	 * The number UINT32_MAX has a special meaning (see LIGHT(end)), hence
+	 * it can not be used as a record identifier. Given that the table is
+	 * enlarged by 8 records (see LIGHT_GROW_INCREMENT), the maximum table
+	 * size is limited by (2^32)-8 records.
+	 */
+	if ((size_t)ht->table_size + LIGHT_GROW_INCREMENT >= UINT32_MAX)
+		return -1;
+
 	uint32_t new_slot;
 	struct LIGHT(record) *new_record = (struct LIGHT(record) *)
 		matras_alloc_range(ht->mtable, &new_slot, LIGHT_GROW_INCREMENT);

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -161,8 +161,8 @@ create_unit_test(PREFIX rtree_multidim
                  LIBRARIES salad small
 )
 create_unit_test(PREFIX light
-                 SOURCES light.cc
-                 LIBRARIES small
+                 SOURCES light.cc core_test_utils.c
+                 LIBRARIES core small
 )
 create_unit_test(PREFIX light_view
                  SOURCES light_view.c

--- a/test/unit/light.cc
+++ b/test/unit/light.cc
@@ -4,6 +4,7 @@
 #include <inttypes.h>
 #include <vector>
 #include <time.h>
+#include <core/random.h>
 
 #include "unit.h"
 
@@ -350,16 +351,72 @@ slot_in_big_table_test()
 	footer();
 }
 
+/**
+ * Insert nearly 2^32 records into the hash table.
+ */
+static void
+max_capacity_test()
+{
+	/*
+	 * XXX: The test is disabled, because it requires 64 GB of RAM.
+	 */
+	return;
+
+	header();
+
+	/* The maximum number of records that can be stored in the table. */
+	const size_t data_count = (size_t)UINT32_MAX + 1 - LIGHT_GROW_INCREMENT;
+
+	struct light_core ht;
+	light_create(&ht, 0, light_extent_size, my_light_alloc, my_light_free,
+		     &extents_count, NULL);
+
+	uint64_t seed[4];
+	random_bytes((char *)seed, sizeof(seed));
+
+	/* Test light_insert(). */
+	xoshiro_srand(seed);
+	for (size_t i = 0; i < data_count; i++) {
+		hash_value_t val = xoshiro_random();
+		hash_t id = light_insert(&ht, hash(val), val);
+		fail_if(id == light_end);
+		if ((i & 0xfffff) == 0)
+			printf("%f%%\n", i * 100.0 / data_count);
+	}
+	/* Try to exceed the maximum capacity. */
+	hash_value_t val = xoshiro_random();
+	hash_t id = light_insert(&ht, hash(val), val);
+	fail_if(id != light_end);
+
+	/* Test light_find(). */
+	xoshiro_srand(seed);
+	for (size_t i = 0; i < data_count; i++) {
+		hash_value_t val = xoshiro_random();
+		hash_t id = light_find(&ht, hash(val), val);
+		fail_if(id == light_end);
+		if ((i & 0xfffff) == 0)
+			printf("%f%%\n", i * 100.0 / data_count);
+	}
+
+	light_destroy(&ht);
+
+	footer();
+}
+
 int
 main(int, const char**)
 {
-	srand(time(0));
+	random_init();
+
 	simple_test();
 	collision_test();
 	iterator_test();
 	iterator_freeze_check();
 	slot_in_big_table_test();
+	max_capacity_test();
 
 	if (extents_count != 0)
 		fail("memory leak!", "true");
+
+	random_free();
 }

--- a/test/unit/light.cc
+++ b/test/unit/light.cc
@@ -327,6 +327,29 @@ iterator_freeze_check()
 	footer();
 }
 
+/**
+ * Check that LIGHT(slot)() is correctly calculated for table sizes > 2^31.
+ */
+static void
+slot_in_big_table_test()
+{
+	header();
+
+	struct light_core ht;
+	light_create(&ht, 0, light_extent_size, my_light_alloc, my_light_free,
+		     &extents_count, NULL);
+
+	ht.common.table_size = 4000000000;
+	ht.common.cover_mask = 0xffffffff;
+	uint32_t hash = 0x00031337;
+	uint32_t slot = light_slot(&ht.common, hash);
+	fail_if(slot != 0x00031337);
+
+	light_destroy(&ht);
+
+	footer();
+}
+
 int
 main(int, const char**)
 {
@@ -335,6 +358,8 @@ main(int, const char**)
 	collision_test();
 	iterator_test();
 	iterator_freeze_check();
+	slot_in_big_table_test();
+
 	if (extents_count != 0)
 		fail("memory leak!", "true");
 }

--- a/test/unit/light.result
+++ b/test/unit/light.result
@@ -6,3 +6,5 @@
 	*** iterator_test: done ***
 	*** iterator_freeze_check ***
 	*** iterator_freeze_check: done ***
+	*** slot_in_big_table_test ***
+	*** slot_in_big_table_test: done ***


### PR DESCRIPTION
This PR increases max capacity of the `light` hash table from 2<sup>31</sup> to 2<sup>32</sup>-8 records.

Closes #9864

<s>Do not merge until https://github.com/tarantool/small/pull/85 is merged!</s>