### PR TITLE
config: add failover stateboard options

### DIFF
--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2272,6 +2272,33 @@ return schema.new('instance_config', schema.record({
             type = 'number',
             default = 10,
         }),
+        -- Configure how to work with a remote storage, where
+        -- failover coordinators leave its state information.
+        --
+        -- Currently, the state storage is the same as a remote
+        -- configuration storage. The URIs and connection options
+        -- are configured in the `config.etcd` or the
+        -- `config.storage` section.
+        stateboard = schema.record({
+            -- How often information in the stateboard is updated.
+            renew_interval = schema.scalar({
+                type = 'number',
+                default = 2,
+            }),
+            -- How long a transient state information is stored.
+            --
+            -- Beware: it affects how fast a coordinator assumes
+            -- that the previous active coordinator is gone.
+            --
+            -- The option should be smaller than
+            -- failover.lease_interval. Otherwise the coordinator
+            -- switching causes replicaset leaders to go to the
+            -- read-only mode for some time interval.
+            keepalive_interval = schema.scalar({
+                type = 'number',
+                default = 10,
+            }),
+        })
     }),
     -- Compatibility options.
     compat = schema.record({

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -325,6 +325,10 @@ g.test_defaults = function()
             call_timeout = 1,
             lease_interval = 30,
             renew_interval = 10,
+            stateboard = {
+                renew_interval = 2,
+                keepalive_interval = 10,
+            },
         },
         compat = {
             json_escape_forward_slash = 'new',

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1702,6 +1702,10 @@ g.test_failover = function()
             call_timeout = 2,
             lease_interval = 10,
             renew_interval = 1,
+            stateboard = {
+                renew_interval = 1,
+                keepalive_interval = 5,
+            },
         },
     }
 
@@ -1714,6 +1718,10 @@ g.test_failover = function()
         call_timeout = 1,
         lease_interval = 30,
         renew_interval = 10,
+        stateboard = {
+            renew_interval = 2,
+            keepalive_interval = 10,
+        },
     }
     local res = instance_config:apply_default({}).failover
     t.assert_equals(res, exp)


### PR DESCRIPTION
These options configure how often a state information is updated by the failover coordinator in a remote state storage and how fast a transient state is expired.

The new options are named as follows.

* `failover.stateboard.renew_interval`
* `failover.stateboard.keepalive_interval`

Part of https://github.com/tarantool/tarantool-ee/issues/564