### PR TITLE
lua: bump metrics module

### DIFF
--- a/changelogs/unreleased/bump-metrics-to-3370f85.md
+++ b/changelogs/unreleased/bump-metrics-to-3370f85.md
@@ -1,0 +1,3 @@
+## feature/lua
+
+* Added a `tnt_election_leader_idle` metric to built-in `metrics`.


### PR DESCRIPTION
Bump metrics package submodule. There are 8 new commits, but only two of them affects Tarantool:
- Add election_leader_idle metric [1];
- test: run log capture tests on a separate server [2];

the other 6 affect documentation and CI/CD scripts of the original repo. The latter one is required to bump luatest in test-run [3], since otherwise metrics log capture test fails on a new version.

1. https://github.com/tarantool/metrics/commit/ba9726d9b0cdfb22aa56d852f7fdc7b0aa22756a
2. https://github.com/tarantool/metrics/commit/3370f856efd4172bf24916e66e3846eeb01550a8
3. https://github.com/tarantool/test-run/pull/426