### PR TITLE
config: introduce config:instance_uri()

### DIFF
--- a/changelogs/unreleased/gh-9842-instance-uri.md
+++ b/changelogs/unreleased/gh-9842-instance-uri.md
@@ -1,0 +1,3 @@
+## feature/config
+
+* Introduced the `instance_uri()` method for the `config` module (gh-9842).

--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -70,6 +70,11 @@ function methods.names(self)
     }
 end
 
+function methods._instance_uri(self, uri_type, opts)
+    assert(uri_type == 'peer' or uri_type == 'sharding')
+    return instance_config:instance_uri(choose_iconfig(self, opts), uri_type)
+end
+
 -- Generate a part of a vshard configuration that relates to
 -- a particular instance.
 --
@@ -90,8 +95,7 @@ function methods._instance_sharding(self, opts)
         return nil
     end
     local zone = self:get('sharding.zone', opts)
-    local uri = instance_config:instance_uri(choose_iconfig(self, opts),
-        'sharding')
+    local uri = self:_instance_uri('sharding', opts)
     if uri == nil then
         local err = 'No suitable URI provided for instance %q'
         error(err:format(opts.instance), 0)

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -578,6 +578,28 @@ function methods.instances(self)
     return res
 end
 
+function methods.instance_uri(self, uri_type, opts)
+    selfcheck(self, 'instance_uri')
+    initcheck(self, 'instance_uri', 'cluster')
+    uri_type = uri_type == nil and 'peer' or uri_type
+    if uri_type ~= 'peer' and uri_type ~= 'sharding' then
+        error(('Expected "peer" or "sharding", got %q'):format(uri_type), 0)
+    end
+    opts = opts == nil and {} or opts
+    if type(opts) ~= 'table' then
+        error(('Expected table, got %s'):format(type(opts)), 0)
+    end
+    if opts.instance ~= nil and type(opts.instance) ~= 'string' then
+        error(('Expected string, got %s'):format(type(opts.instance)), 0)
+    end
+
+    local uri_opts = {
+        instance = opts.instance,
+        use_default = true,
+    }
+    return self._configdata_applied:_instance_uri(uri_type, uri_opts)
+end
+
 -- The object is a singleton. The constructor should be called
 -- only once.
 local function new()


### PR DESCRIPTION
This patch introduces the instance_uri() method for the config module. This method returns the URI of the specified instance from the config.

Needed for #9842

@TarantoolBot document
Title: instance_uri() method for config module

The configuration module's `instance_uri()` method returns the URI of the instance that is used to create a replicaset or sharding cluster. This method takes two arguments:
1) `peer` or null to return the URI that is used to create the
   replicaset, or `sharding` to return the URI that is used to create
   the sharding cluster;
2) `options`, which only support `options.instance`, to specify the
   instance whose URI should be returned; by default, the URI of the
   instance on which the function is executed is returned.