### PR TITLE
box: add error details for main box operations

### DIFF
--- a/changelogs/unreleased/gh-7223-add-more-error-details.md
+++ b/changelogs/unreleased/gh-7223-add-more-error-details.md
@@ -1,0 +1,3 @@
+## bugfix/box
+
+* Added more error details for basic box operations (gh-7223).

--- a/changelogs/unreleased/gh-9111-add-more-error-details.md
+++ b/changelogs/unreleased/gh-9111-add-more-error-details.md
@@ -1,0 +1,3 @@
+## feature/box
+
+* Added more error details for basic box operations (gh-9111).

--- a/test/box-luatest/extra_assertions.lua
+++ b/test/box-luatest/extra_assertions.lua
@@ -1,0 +1,11 @@
+local t = require('luatest')
+
+-- XXX: This is temporary. The assertion is present in latest Luatest and
+-- is making its way into Tarantool currently.
+t.assert_error_covers = function(expected, fn, ...)
+    local ok, actual = pcall(fn, ...)
+    t.assert_not(ok)
+    actual = actual:unpack()
+    t.assert_equals(type(actual), 'table')
+    t.assert_covers(actual, expected)
+end

--- a/test/engine/func_index.result
+++ b/test/engine/func_index.result
@@ -273,16 +273,19 @@ e = box.error.last()
  | ...
 e:unpack()
  | ---
- | - code: 198
+ | - operation: insert
+ |   code: 198
  |   base_type: ClientError
- |   type: ClientError
  |   prev: '[string "return function(tuple)                 local ..."]:1: attempt to
  |     call global ''require'' (a nil value)'
  |   message: 'Failed to build a key for functional index ''idx'' of space ''withdata'':
  |     can''t evaluate function'
+ |   tuple: [1]
  |   trace:
  |   - file: <filename>
  |     line: <line>
+ |   type: ClientError
+ |   space: withdata
  | ...
 e = e.prev
  | ---


### PR DESCRIPTION
Add error details for basic box operations like insert, replace, select etc.

**DO NOT MERGE** until `luatest.assert_error_covers` make it into Tarantool (job in progress).  

Closes #9111
Closes #7223

@TarantoolBot document
Title: Provide more error details for basic box operations Product: Tarantool
Since: 3.1

For example for this setup:

```lua
  local test = box.schema.create_space('test')
  test:create_index('primary')
  test:create_index('second', {parts = {2, 'unsigned', 1, 'unsigned'}})
```

Before we get (note that compat option `box_error_serialize_verbose` is set to 'new' to show error details in console. It does not affect whether details are added or not):

```
tarantool> test.index.second:get{1}
---
- error:
    code: 19
    base_type: ClientError
    type: ClientError
    message: Invalid key part count in an exact match (expected 2, got 1)
    trace:
    - file: ./src/box/index.cc
      line: 149
...
```

And now we get (see 'operation', 'space', 'index' and 'key' fields):

```
tarantool> test.index.second:get{1}
---
- error:
    operation: get
    code: 19
    base_type: ClientError
    message: Invalid key part count in an exact match (expected 2, got 1)
    trace:
    - file: ./src/box/index.cc
      line: 149
    type: ClientError
    index: second
    space: test
    key: [1]
...
```