### PR TITLE
config: add subj URI to config verification error

### DIFF
--- a/changelogs/unreleased/gh-9644-verbose-uri-error.md
+++ b/changelogs/unreleased/gh-9644-verbose-uri-error.md
@@ -1,0 +1,4 @@
+## bugfix/config
+
+* Added a subject URI to the error that is thrown on configuration
+  verification (gh-9644).

--- a/changelogs/unreleased/gh-9644-verbose-uri-error.md
+++ b/changelogs/unreleased/gh-9644-verbose-uri-error.md
@@ -2,3 +2,5 @@
 
 * Added a subject URI to the error that is thrown on configuration
   verification (gh-9644).
+* Added a warning with the skipped (unsuitable) URI to replicaset
+  and sharding configuration (gh-9644).

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -36,7 +36,8 @@ local function peer_uris(configdata)
         -- A user may configure a custom data flow using
         -- `replication.peers` option.
         if not is_anon then
-            local uri = instance_config:instance_uri(iconfig_def, 'peer')
+            local uri = instance_config:instance_uri(iconfig_def, 'peer',
+                {log_prefix = "replicaset dataflow configuration: "})
             if uri == nil then
                 log.info('%s: instance %q has no iproto.advertise.peer or ' ..
                     'iproto.listen URI suitable to create a client socket',

--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -70,9 +70,10 @@ function methods.names(self)
     }
 end
 
-function methods._instance_uri(self, uri_type, opts)
+function methods._instance_uri(self, uri_type, opts, log_opts)
     assert(uri_type == 'peer' or uri_type == 'sharding')
-    return instance_config:instance_uri(choose_iconfig(self, opts), uri_type)
+    return instance_config:instance_uri(choose_iconfig(self, opts), uri_type,
+                                        log_opts)
 end
 
 -- Generate a part of a vshard configuration that relates to
@@ -95,7 +96,8 @@ function methods._instance_sharding(self, opts)
         return nil
     end
     local zone = self:get('sharding.zone', opts)
-    local uri = self:_instance_uri('sharding', opts)
+    local uri = self:_instance_uri('sharding', opts,
+                                   {log_prefix = "sharding configuration: "})
     if uri == nil then
         local err = 'No suitable URI provided for instance %q'
         error(err:format(opts.instance), 0)

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -212,7 +212,7 @@ local function validate_uri_field(has_login_field, used_to_connect)
         if used_to_connect then
             local ok, err = uri_is_suitable_to_connect(uri)
             if not ok then
-                w.error(err)
+                w.error("bad URI %q: %s", data, err)
             end
         end
     end

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -531,6 +531,7 @@ for case_name, case in pairs({
         advertise = {uri = '0.0.0.0:3301'},
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.%s.uri',
+            'bad URI "0.0.0.0:3301"',
             'INADDR_ANY (0.0.0.0) cannot be used to create a client socket',
         }, ': '),
     },
@@ -538,6 +539,7 @@ for case_name, case in pairs({
         advertise = {uri = '0.0.0.0:3301', login = 'user'},
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.%s.uri',
+            'bad URI "0.0.0.0:3301"',
             'INADDR_ANY (0.0.0.0) cannot be used to create a client socket',
         }, ': '),
     },
@@ -545,6 +547,7 @@ for case_name, case in pairs({
         advertise = {uri = '0.0.0.0:3301', login = 'user', password = 'pass'},
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.%s.uri',
+            'bad URI "0.0.0.0:3301"',
             'INADDR_ANY (0.0.0.0) cannot be used to create a client socket',
         }, ': '),
     },
@@ -552,6 +555,7 @@ for case_name, case in pairs({
         advertise = {uri = '[::]:3301'},
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.%s.uri',
+            'bad URI "[::]:3301"',
             'in6addr_any (::) cannot be used to create a client socket',
         }, ': '),
     },
@@ -559,6 +563,7 @@ for case_name, case in pairs({
         advertise = {uri = '[::]:3301', login = 'user'},
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.%s.uri',
+            'bad URI "[::]:3301"',
             'in6addr_any (::) cannot be used to create a client socket',
         }, ': '),
     },
@@ -566,6 +571,7 @@ for case_name, case in pairs({
         advertise = {uri = '[::]:3301', login = 'user', password = 'pass'},
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.%s.uri',
+            'bad URI "[::]:3301"',
             'in6addr_any (::) cannot be used to create a client socket',
         }, ': '),
     },
@@ -573,6 +579,7 @@ for case_name, case in pairs({
         advertise = {uri = 'localhost:0'},
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.%s.uri',
+            'bad URI "localhost:0"',
             'An URI with zero port cannot be used to create a client socket',
         }, ': '),
     },
@@ -580,6 +587,7 @@ for case_name, case in pairs({
         advertise = {uri = 'localhost:0', login = 'user'},
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.%s.uri',
+            'bad URI "localhost:0"',
             'An URI with zero port cannot be used to create a client socket',
         }, ': '),
     },
@@ -587,6 +595,7 @@ for case_name, case in pairs({
         advertise = {uri = 'localhost:0', login = 'user', password = 'pass'},
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.%s.uri',
+            'bad URI "localhost:0"',
             'An URI with zero port cannot be used to create a client socket',
         }, ': '),
     },
@@ -629,6 +638,7 @@ for case_name, case in pairs({
         advertise = '0.0.0.0:3301',
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.client',
+            'bad URI "0.0.0.0:3301"',
             'INADDR_ANY (0.0.0.0) cannot be used to create a client socket',
         }, ': '),
     },
@@ -636,6 +646,7 @@ for case_name, case in pairs({
         advertise = '[::]:3301',
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.client',
+            'bad URI "[::]:3301"',
             'in6addr_any (::) cannot be used to create a client socket',
         }, ': '),
     },
@@ -643,6 +654,7 @@ for case_name, case in pairs({
         advertise = 'localhost:0',
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.client',
+            'bad URI "localhost:0"',
             'An URI with zero port cannot be used to create a client socket',
         }, ': '),
     },


### PR DESCRIPTION
Before this patch, it was quite difficult to determine, which URI in config was unsuitable.
Now the subject URI is listed in the error body.

NO_DOC: bugfix

Closes #9644