### PR TITLE
net.replicaset: fix a flaky test

### DIFF
--- a/test/box-luatest/gh_9823_net_replicaset_test.lua
+++ b/test/box-luatest/gh_9823_net_replicaset_test.lua
@@ -180,8 +180,8 @@ g.test_net_replicaset_basics = function(cg)
     t.helpers.retrying({timeout = 10, delay = 0.1}, function()
         info = rs:call_leader('box.info')
         t.assert_equals(info.ro, false)
-    end)
         t.assert_equals(info.name, new_leader_name)
+    end)
 end
 
 -- Test that replicaset is deleted successfully by GC.


### PR DESCRIPTION
The test checks that net.replicaset connection switches to the new leader when the new leader is elected. Unfortunately the test expects that after successful call of box.ctl.promote() the old leader is guaranteed to be in RO state. Actually this is incorrect: the new leader can legally rely on the quorum with the third instance without even notifying the original leader about new election term started, so the old leader may remain in RW state. Since the replicaset connection updates states of instances asynchronously it also may think (for some time) that the old leader is the only RW instance in replicaset.

Fix it by including check of the new leader into retrying block of the test.

Hotfix #9823

NO_CHANGELOG=fix flaky test
NO_DOC=fix flaky test