### PR TITLE
relay: batch sent rows

### DIFF
--- a/changelogs/unreleased/gh-10161-relay-speedup.md
+++ b/changelogs/unreleased/gh-10161-relay-speedup.md
@@ -1,0 +1,5 @@
+## bugfix/replication
+
+* Significantly improved replication performance by batching rows to be sent
+  before dispatch. Batch size in bytes may be controlled by a new tweak
+  `xrow_stream_flush_size` (default is 16 kb) (gh-10161).

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -1796,7 +1796,7 @@ iproto_msg_prepare(struct iproto_msg *msg, const char **pos, const char *reqend)
 	struct cmsg_hop *route;
 	int rc;
 
-	if (xrow_header_decode(&msg->header, pos, reqend, true) != 0)
+	if (xrow_decode(&msg->header, pos, reqend, true) != 0)
 		goto error;
 	assert(*pos == reqend);
 

--- a/src/box/lua/net_box.c
+++ b/src/box/lua/net_box.c
@@ -1286,9 +1286,8 @@ netbox_transport_send_and_recv(struct netbox_transport *transport,
 			required = size + len;
 			if (data_len >= required) {
 				const char *body_end = rpos + len;
-				int rc = xrow_header_decode(
-						hdr, &rpos, body_end,
-						/*end_is_exact=*/true);
+				int rc = xrow_decode(hdr, &rpos, body_end,
+						     /*end_is_exact=*/true);
 				transport->last_msg_size = body_end - bufpos;
 				return rc;
 			}

--- a/src/box/vy_run.c
+++ b/src/box/vy_run.c
@@ -758,7 +758,7 @@ vy_page_xrow(struct vy_page *page, uint32_t stmt_no,
 	const char *data_end = stmt_no + 1 < page->row_count ?
 			       page->data + page->row_index[stmt_no + 1] :
 			       page->data + page->unpacked_size;
-	return xrow_header_decode(xrow, &data, data_end, false);
+	return xrow_decode(xrow, &data, data_end, false);
 }
 
 /* {{{ vy_run_iterator vy_run_iterator support functions */
@@ -932,7 +932,7 @@ vy_page_read(struct vy_page *page, const struct vy_page_info *page_info,
 	struct xrow_header xrow;
 	data_pos = page->data + page_info->row_index_offset;
 	data_end = page->data + page_info->unpacked_size;
-	if (xrow_header_decode(&xrow, &data_pos, data_end, true) == -1)
+	if (xrow_decode(&xrow, &data_pos, data_end, true) == -1)
 		goto error;
 	if (xrow.type != VY_RUN_ROW_INDEX) {
 		diag_set(ClientError, ER_INVALID_RUN_FILE,

--- a/src/box/xlog.c
+++ b/src/box/xlog.c
@@ -1365,8 +1365,7 @@ xlog_write_row(struct xlog *log, const struct xrow_header *packet)
 	/** don't write sync to the disk */
 	size_t region_svp = region_used(&fiber()->gc);
 	int iovcnt;
-	xrow_header_encode(packet, /*sync=*/0, /*fixheader_len=*/0,
-			   iov, &iovcnt);
+	xrow_encode(packet, /*sync=*/0, /*fixheader_len=*/0, iov, &iovcnt);
 	for (int i = 0; i < iovcnt; ++i) {
 		struct errinj *inj = errinj(ERRINJ_WAL_WRITE_PARTIAL,
 					    ERRINJ_INT);
@@ -1890,9 +1889,8 @@ xlog_tx_cursor_next_row(struct xlog_tx_cursor *tx_cursor,
 	if (ibuf_used(&tx_cursor->rows) == 0)
 		return 1;
 	/* Return row from xlog tx buffer */
-	int rc = xrow_header_decode(xrow,
-				    (const char **)&tx_cursor->rows.rpos,
-				    (const char *)tx_cursor->rows.wpos, false);
+	int rc = xrow_decode(xrow, (const char **)&tx_cursor->rows.rpos,
+			     (const char *)tx_cursor->rows.wpos, false);
 	if (rc != 0) {
 		diag_set(XlogError, "can't parse row");
 		/* Discard remaining row data */

--- a/src/box/xrow.h
+++ b/src/box/xrow.h
@@ -154,8 +154,20 @@ xrow_approx_len(const struct xrow_header *row)
  * @post iovcnt <= XROW_IOVMAX
  */
 void
-xrow_header_encode(const struct xrow_header *header, uint64_t sync,
-		   size_t fixheader_len, struct iovec *out, int *iovcnt);
+xrow_encode(const struct xrow_header *header, uint64_t sync,
+	    size_t fixheader_len, struct iovec *out, int *iovcnt);
+
+/**
+ * Encode xrow header into a given buffer.
+ *
+ * @param header xrow.
+ * @param sync request sync number.
+ * @param data buffer. When set to NULL, simply count the needed data size.
+ *
+ * @return the exact space taken for encoding.
+ */
+size_t
+xrow_header_encode(const struct xrow_header *header, uint64_t sync, char *data);
 
 /**
  * Decode xrow from a binary packet
@@ -171,8 +183,8 @@ xrow_header_encode(const struct xrow_header *header, uint64_t sync,
  * @post *pos == end on success if @end_is_exact is set
  */
 int
-xrow_header_decode(struct xrow_header *header, const char **pos,
-		   const char *end, bool end_is_exact);
+xrow_decode(struct xrow_header *header, const char **pos,
+	    const char *end, bool end_is_exact);
 
 /**
  * DML request.
@@ -757,7 +769,7 @@ xrow_encode_type(struct xrow_header *row, uint16_t type);
 
 /**
  * Fast encode xrow header using the specified header fields.
- * It is faster than the xrow_header_encode, because uses
+ * It is faster than the xrow_encode, because uses
  * the predefined values for all fields of the header, defined
  * in the struct iproto_header_bin in iproto_port.cc. Because of
  * it, the implementation is placed in the same
@@ -771,7 +783,7 @@ xrow_encode_type(struct xrow_header *row, uint16_t type);
  * @param schema_version Schema version.
  * @param body_length Length of the body of the iproto message.
  *        Please, pass it without IPROTO_HEADER_LEN.
- * @see xrow_header_encode()
+ * @see xrow_encode()
  */
 void
 iproto_header_encode(char *data, uint16_t type, uint64_t sync,
@@ -1106,12 +1118,12 @@ vclock_follow_xrow(struct vclock* vclock, const struct xrow_header *row)
 #if defined(__cplusplus)
 } /* extern "C" */
 
-/** @copydoc xrow_header_decode. */
+/** @copydoc xrow_decode. */
 static inline void
-xrow_header_decode_xc(struct xrow_header *header, const char **pos,
-		      const char *end, bool end_is_exact)
+xrow_decode_xc(struct xrow_header *header, const char **pos,
+	       const char *end, bool end_is_exact)
 {
-	if (xrow_header_decode(header, pos, end, end_is_exact) < 0)
+	if (xrow_decode(header, pos, end, end_is_exact) < 0)
 		diag_raise();
 }
 

--- a/src/box/xrow_io.cc
+++ b/src/box/xrow_io.cc
@@ -57,8 +57,7 @@ coio_read_xrow(struct iostream *io, struct ibuf *in, struct xrow_header *row)
 	if (len > ibuf_used(in))
 		coio_breadn(io, in, len - ibuf_used(in));
 
-	xrow_header_decode_xc(row, (const char **) &in->rpos, in->rpos + len,
-			      true);
+	xrow_decode_xc(row, (const char **)&in->rpos, in->rpos + len, true);
 }
 
 void
@@ -88,8 +87,7 @@ coio_read_xrow_timeout_xc(struct iostream *io, struct ibuf *in,
 	if (len > ibuf_used(in))
 		coio_breadn_timeout(io, in, len - ibuf_used(in), delay);
 
-	xrow_header_decode_xc(row, (const char **) &in->rpos, in->rpos + len,
-			      true);
+	xrow_decode_xc(row, (const char **)&in->rpos, in->rpos + len, true);
 }
 
 

--- a/src/box/xrow_io.cc
+++ b/src/box/xrow_io.cc
@@ -28,12 +28,15 @@
  * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
+#include <sys/uio.h>
 #include "xrow_io.h"
 #include "xrow.h"
 #include "coio.h"
 #include "coio_buf.h"
 #include "error.h"
 #include "msgpuck/msgpuck.h"
+#include "scoped_guard.h"
+#include "tweaks.h"
 
 void
 coio_read_xrow(struct iostream *io, struct ibuf *in, struct xrow_header *row)
@@ -102,3 +105,58 @@ coio_write_xrow(struct iostream *io, const struct xrow_header *row)
 		diag_raise();
 }
 
+uint64_t xrow_stream_flush_size = 16384;
+TWEAK_UINT(xrow_stream_flush_size);
+
+void
+xrow_stream_write(struct xrow_stream *stream, const struct xrow_header *row)
+{
+	/* Fixheader - encodes length of the packet. */
+	size_t fixheader_len = 5;
+	assert(fixheader_len == mp_sizeof_uint(UINT32_MAX));
+	size_t approx_len = fixheader_len + xrow_approx_len(row);
+	/* Reserve excess space to save on exact size calculation. */
+	char *data = (char *)xlsregion_reserve(&stream->lsregion, approx_len);
+	/* Leave space for the fixheader. */
+	char *d = data + fixheader_len;
+	d += xrow_header_encode(row, row->sync, d);
+	for (int i = 0; i < row->bodycnt; i++) {
+		size_t l = row->body[i].iov_len;
+		memcpy(d, row->body[i].iov_base, l);
+		d += l;
+	}
+	size_t data_len = d - data;
+	assert(data_len <= approx_len);
+	*data = 0xce; /* MP_UINT32 */
+	store_u32(data + 1, mp_bswap_u32(data_len - fixheader_len));
+	xlsregion_alloc(&stream->lsregion, data_len, ++stream->lsr_id);
+}
+
+int
+xrow_stream_flush(struct xrow_stream *stream, struct iostream *io)
+{
+#ifndef NDEBUG
+	assert(stream->owner == NULL);
+	stream->owner = fiber();
+	auto guard = make_scoped_guard([&] {
+		stream->owner = NULL;
+	});
+#endif
+	ssize_t to_flush = lsregion_used(&stream->lsregion);
+	/*
+	 * Might flush more than requested if data is added to the buffer
+	 * during the coio_writev yield.
+	 */
+	while (to_flush > 0) {
+		struct iovec iov[IOV_MAX];
+		int iovcnt = lengthof(iov);
+		int64_t gc_id = lsregion_to_iovec(&stream->lsregion, iov,
+						  &iovcnt, &stream->flush_pos);
+		ssize_t written = coio_writev(io, iov, iovcnt, 0);
+		if (written < 0)
+			return -1;
+		to_flush -= written;
+		lsregion_gc(&stream->lsregion, gc_id);
+	}
+	return 0;
+}

--- a/src/trivia/util.h
+++ b/src/trivia/util.h
@@ -149,6 +149,8 @@ alloc_failure(const char *filename, int line, size_t size)
 #define xlsregion_alloc_object(lsregion, id, T) ({				\
 	(T *)xlsregion_aligned_alloc((lsregion), sizeof(T), alignof(T), (id));	\
 })
+#define xlsregion_reserve(p, size) \
+	xalloc_impl((size), lsregion_reserve, (p), (size))
 #define xregion_alloc_object(region, T) ({					\
 	(T *)xregion_aligned_alloc((region), sizeof(T), alignof(T));		\
 })

--- a/test/fuzz/xrow_header_decode_fuzzer.c
+++ b/test/fuzz/xrow_header_decode_fuzzer.c
@@ -28,7 +28,7 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 		return -1;
 
 	struct xrow_header header;
-	xrow_header_decode(&header, &p, pe, false);
+	xrow_decode(&header, &p, pe, false);
 
 	return 0;
 }

--- a/test/replication/sync.result
+++ b/test/replication/sync.result
@@ -7,6 +7,12 @@ test_run = require('test_run').new()
 engine = test_run:get_cfg('engine')
 ---
 ...
+tweaks = require('internal.tweaks')
+---
+...
+tweaks_xrow_stream_flush_size_default = tweaks.xrow_stream_flush_size
+---
+...
 test_run:cleanup_cluster()
 ---
 ...
@@ -47,6 +53,7 @@ function fill()
     end
     fiber.create(function()
         box.error.injection.set('ERRINJ_RELAY_TIMEOUT', 0.0025)
+        tweaks.xrow_stream_flush_size = 1
         test_run:wait_cond(function()
             local r = box.info.replication[2]
             return r ~= nil and r.downstream ~= nil and
@@ -101,7 +108,7 @@ test_run:cmd("switch replica")
 -- Since max allowed lag is small, all records should arrive
 -- by the time box.cfg() returns.
 --
-box.cfg{replication_sync_lag = 0.001}
+box.cfg{replication_sync_lag = 0.001, replication_sync_timeout = 300}
 ---
 ...
 box.cfg{replication = replication}
@@ -252,6 +259,9 @@ test_run:cmd("switch default")
 box.error.injection.set('ERRINJ_RELAY_TIMEOUT', 0)
 ---
 - ok
+...
+tweaks.xrow_stream_flush_size = tweaks_xrow_stream_flush_size_default
+---
 ...
 box.error.injection.set('ERRINJ_WAL_DELAY', true)
 ---

--- a/test/unit/xrow.cc
+++ b/test/unit/xrow.cc
@@ -205,7 +205,7 @@ test_greeting()
 }
 
 void
-test_xrow_header_encode_decode()
+test_xrow_encode_decode()
 {
 	header();
 	/* Test all possible 3-bit combinations. */
@@ -214,8 +214,8 @@ test_xrow_header_encode_decode()
 	struct xrow_header header;
 	char buffer[2048];
 	char *pos = mp_encode_uint(buffer, 300);
-	is(xrow_header_decode(&header, (const char **) &pos,
-			      buffer + 100, true), -1, "bad msgpack end");
+	is(xrow_decode(&header, (const char **)&pos, buffer + 100, true), -1,
+	   "bad msgpack end");
 
 	header.type = 100;
 	header.replica_id = 200;
@@ -232,8 +232,7 @@ test_xrow_header_encode_decode()
 		header.wait_ack = opt_idx >> 2 & 0x01;
 		int iovcnt;
 		struct iovec vec[1];
-		xrow_header_encode(&header, sync, /*fixheader_len=*/200,
-				   vec, &iovcnt);
+		xrow_encode(&header, sync, /*fixheader_len=*/200, vec, &iovcnt);
 		is(1, iovcnt, "encode");
 		int fixheader_len = 200;
 		pos = (char *)vec[0].iov_base + fixheader_len;
@@ -256,7 +255,7 @@ test_xrow_header_encode_decode()
 		const char *const begin = pos;
 		const char *end = (const char *)vec[0].iov_base;
 		end += vec[0].iov_len;
-		is(xrow_header_decode(&decoded_header, &pos, end, true), 0,
+		is(xrow_decode(&decoded_header, &pos, end, true), 0,
 		   "header decode");
 		is(header.stream_id, decoded_header.stream_id, "decoded stream_id");
 		is(header.is_commit, decoded_header.is_commit, "decoded is_commit");
@@ -451,8 +450,8 @@ test_xrow_decode_unknown_key(void)
 	const char *end = buf + mp_format(buf, sizeof(buf), "{%u%s}",
 					  0xDEAD, "foobar");
 	struct xrow_header header;
-	is(xrow_header_decode(&header, &p, end, /*end_is_exact=*/true), 0,
-	   "xrow_header_decode");
+	is(xrow_decode(&header, &p, end, /*end_is_exact=*/true), 0,
+	   "xrow_decode");
 
 	memset(&header, 0, sizeof(header));
 	header.bodycnt = 1;
@@ -804,7 +803,7 @@ main(void)
 
 	test_iproto_constants();
 	test_greeting();
-	test_xrow_header_encode_decode();
+	test_xrow_encode_decode();
 	test_request_str();
 	test_xrow_fields();
 	test_xrow_encode_dml();


### PR DESCRIPTION
relay: batch sent rows

Relay sends rows one by one, issuing one `write()` system call per each
sent row. This hurts performance quite a lot: in the 1mops_write test
[1] on my machine master node is able to reach ~ 1.9 million RPS while
replication performance peaks at ~ 0.5 million RPS.

As shown by a PoC patch, batching the rows allows to remove the
replication bottleneck almost completely. Even sending 2 rows per one
write() call already doubles the performance, and sending 64 rows per
one write() call allows the replica to catch up with master's speed [2].

This patch makes relay buffer rows until the total buffer size reaches a
certain threshold, and then flush everything with a single writev()
call.

The flush threshold is configurable via a new tweak -
xrow_buf_flush_size, which has a default value of 16 kb.

A size threshold is chosen over simple row count, because it's more
flexible for different row sizes: if the user has multi-kilobyte tuples,
batching hundreds of such tuples might overflow the socket's send buffer
size, resulting in extra wait until the send buffer becomes free again.
This extra time might've been used for enqueuing extra rows. The
problem would become even worse for hundred-kilobyte tuples and so on.

At the same time the user might have different workload types. One with
large tuples and other with relatively small ones, in which case
batching by size rather than by row count is more predictable
performance wise.

[1] https://github.com/tarantool/tarantool/blob/master/perf/lua/1mops_write.lua
[2] https://www.notion.so/tarantool/relay-248de4a9600f4c4d8d83e81cf1104926

Closes #10161

NO_DOC=not a documentable feature
NO_TEST=covered by existing tests