### PR TITLE
box: add details to DML specific errors

### DIFF
--- a/changelogs/unreleased/gh-7223-add-more-error-details.md
+++ b/changelogs/unreleased/gh-7223-add-more-error-details.md
@@ -1,0 +1,3 @@
+## bugfix/box
+
+* Added details for DML specific errors (gh-7223).

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -234,7 +234,7 @@ struct errcode_record {
 	_(ER_PRIV_NOT_GRANTED, 91,		"User '%s' does not have %s access on %s '%s'", "user", STRING, "privilege", STRING, "object_type", STRING, "object", STRING) \
 	_(ER_ROLE_NOT_GRANTED, 92,		"User '%s' does not have role '%s'", "user", STRING, "role", STRING) \
 	_(ER_MISSING_SNAPSHOT, 93,		"Can't find snapshot") \
-	_(ER_CANT_UPDATE_PRIMARY_KEY, 94,	"Attempt to modify a tuple field which is part of primary index in space '%s'", "space", STRING) \
+	_(ER_CANT_UPDATE_PRIMARY_KEY, 94,	"Attempt to modify a tuple field which is part of primary index in space '%s'", "space", STRING, "space_id", UINT, "old_tuple", TUPLE, "new_tuple", TUPLE, "ops", MSGPACK) \
 	_(ER_UPDATE_INTEGER_OVERFLOW, 95,	"Integer overflow when performing '%c' operation on field %s", "operation", CHAR, "field", STRING) \
 	_(ER_GUEST_USER_PASSWORD, 96,		"Setting password for guest user has no effect") \
 	_(ER_TRANSACTION_CONFLICT, 97,		"Transaction has been aborted by conflict") \

--- a/src/box/error.cc
+++ b/src/box/error.cc
@@ -219,7 +219,7 @@ client_error_create(struct error *e, va_list ap)
 		}
 		case ERRCODE_FIELD_TYPE_STRING: {
 			const char *s = va_arg(ap, const char *);
-			if (set_payload)
+			if (set_payload && s != NULL)
 				error_set_str(e, name, s);
 			break;
 		}
@@ -227,15 +227,18 @@ client_error_create(struct error *e, va_list ap)
 			const char *mp = va_arg(ap, const char *);
 			const char *mp_end = mp;
 			assert(set_payload);
-			mp_next(&mp_end);
-			error_set_mp(e, name, mp, mp_end - mp);
+			if (mp != NULL) {
+				mp_next(&mp_end);
+				error_set_mp(e, name, mp, mp_end - mp);
+			}
 			break;
 		}
 		case ERRCODE_FIELD_TYPE_TUPLE: {
 			struct tuple *tuple = va_arg(ap, struct tuple *);
 			assert(set_payload);
-			error_set_mp(e, name, tuple_data(tuple),
-				     tuple_bsize(tuple));
+			if (tuple != NULL)
+				error_set_mp(e, name, tuple_data(tuple),
+					     tuple_bsize(tuple));
 			break;
 		}
 		default:

--- a/src/box/field_map.h
+++ b/src/box/field_map.h
@@ -184,11 +184,8 @@ field_map_get_offset(const uint32_t *field_map, int32_t offset_slot,
  *
  * Routine uses region to perform memory allocation for internal
  * structures.
- *
- * Returns 0 on success. In case of memory allocation error sets
- * diag message and returns -1.
  */
-int
+void
 field_map_builder_create(struct field_map_builder *builder,
 			 uint32_t minimal_field_map_size,
 			 struct region *region);
@@ -213,7 +210,7 @@ field_map_builder_slot_extent_new(struct field_map_builder *builder,
  * The offset_slot argument must be negative and offset must be
  * positive (by definition).
  */
-static inline int
+static inline void
 field_map_builder_set_slot(struct field_map_builder *builder,
 			   int32_t offset_slot, uint32_t offset,
 			   int32_t multikey_idx, uint32_t multikey_count,
@@ -235,12 +232,9 @@ field_map_builder_set_slot(struct field_map_builder *builder,
 		} else {
 			extent = field_map_builder_slot_extent_new(builder,
 					offset_slot, multikey_count, region);
-			if (extent == NULL)
-				return -1;
 		}
 		extent->offset[multikey_idx] = offset;
 	}
-	return 0;
 }
 
 /**

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -221,7 +221,8 @@ index_check_dup(struct index *index, struct tuple *old_tuple,
 			struct space *space = space_by_id(index->def->space_id);
 			assert(space != NULL);
 			diag_set(ClientError, ER_CANT_UPDATE_PRIMARY_KEY,
-				 space->def->name);
+				 space->def->name, space->def->id,
+				 old_tuple, new_tuple, NULL);
 			return -1;
 		}
 	} else { /* dup_tuple != NULL */

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -796,6 +796,10 @@ replace_check_dup(struct tuple *old_tuple, struct tuple *dup_tuple,
 	return 0;
 }
 
+/** Add payload fields with index details to the error. */
+void
+error_set_index(struct error *error, const struct index_def *index_def);
+
 /**
  * Initialize an index instance.
  * Note, this function copies the given index definition.

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -765,36 +765,13 @@ struct index_read_view_iterator {
 };
 
 /**
- * Check if replacement of an old tuple with a new one is
- * allowed.
+ * Check if replacement of an old tuple with a new one is allowed.
+ * Return 0 on success, -1 on error (diag is set).
  */
-static inline uint32_t
-replace_check_dup(struct tuple *old_tuple, struct tuple *dup_tuple,
-		  enum dup_replace_mode mode)
-{
-	if (dup_tuple == NULL) {
-		if (mode == DUP_REPLACE) {
-			assert(old_tuple != NULL);
-			/*
-			 * dup_replace_mode is DUP_REPLACE, and
-			 * a tuple with the same key is not found.
-			 */
-			return ER_CANT_UPDATE_PRIMARY_KEY;
-		}
-	} else { /* dup_tuple != NULL */
-		if (dup_tuple != old_tuple &&
-		    (old_tuple != NULL || mode == DUP_INSERT)) {
-			/*
-			 * There is a duplicate of new_tuple,
-			 * and it's not old_tuple: we can't
-			 * possibly delete more than one tuple
-			 * at once.
-			 */
-			return ER_TUPLE_FOUND;
-		}
-	}
-	return 0;
-}
+int
+index_check_dup(struct index *index, struct tuple *old_tuple,
+		struct tuple *new_tuple, struct tuple *dup_tuple,
+		enum dup_replace_mode mode);
 
 /** Add payload fields with index details to the error. */
 void

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -450,23 +450,15 @@ key_validate(const struct index_def *index_def, enum iterator_type type,
 
 /**
  * Check that the supplied key is valid for a search in a unique
- * index (i.e. the key must be fully specified).
+ * index (i.e. the key must be fully specified). Also check that
+ * index is unique.
+ *
  * @retval 0  The key is valid.
  * @retval -1 The key is invalid.
  */
 int
-exact_key_validate(struct key_def *key_def, const char *key,
+exact_key_validate(struct index_def *index_def, const char *key,
 		   uint32_t part_count);
-
-/**
- * Check that the supplied key is valid for representing iterator
- * position (i.e. the key must be fully specified, but nulls are allowed).
- * @retval 0  The key is valid.
- * @retval -1 The key is invalid.
- */
-int
-exact_key_validate_nullable(struct key_def *key_def, const char *key,
-			    uint32_t part_count);
 
 /**
  * The manner in which replace in a unique index must treat

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -386,29 +386,14 @@ memtx_hash_index_replace(struct index *base, struct tuple *old_tuple,
 				 "hash_table", "key");
 			return -1;
 		}
-		uint32_t errcode = replace_check_dup(old_tuple,
-						     dup_tuple, mode);
-		if (errcode) {
+		if (index_check_dup(base, old_tuple, new_tuple,
+				    dup_tuple, mode) != 0) {
 			light_index_delete(hash_table, pos);
 			if (dup_tuple) {
 				uint32_t pos = light_index_insert(hash_table, h, dup_tuple);
 				if (pos == light_index_end) {
 					panic("Failed to allocate memory in "
 					      "recover of int hash_table");
-				}
-			}
-			struct space *sp = space_cache_find(base->def->space_id);
-			if (sp != NULL) {
-				if (errcode == ER_TUPLE_FOUND){
-					diag_set(ClientError, errcode,
-						 base->def->name,
-						 space_name(sp),
-						 tuple_str(dup_tuple),
-						 tuple_str(new_tuple),
-						 dup_tuple, new_tuple);
-				} else {
-					diag_set(ClientError, errcode,
-						 space_name(sp));
 				}
 			}
 			return -1;

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -649,7 +649,8 @@ memtx_space_execute_upsert(struct space *space, struct txn *txn,
 				  HINT_NONE, pk->def->key_def) != 0) {
 			/* Primary key is changed: log error and do nothing. */
 			diag_set(ClientError, ER_CANT_UPDATE_PRIMARY_KEY,
-				 space_name(space));
+				 space_name(space), space_id(space),
+				 old_tuple, new_tuple, NULL);
 			diag_log();
 			tuple_unref(new_tuple);
 			return 0;

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -455,12 +455,12 @@ memtx_space_execute_delete(struct space *space, struct txn *txn,
 {
 	struct txn_stmt *stmt = txn_current_stmt(txn);
 	/* Try to find the tuple by unique key. */
-	struct index *pk = index_find_unique(space, request->index_id);
+	struct index *pk = index_find(space, request->index_id);
 	if (pk == NULL)
 		return -1;
 	const char *key = request->key;
 	uint32_t part_count = mp_decode_array(&key);
-	if (exact_key_validate(pk->def->key_def, key, part_count) != 0)
+	if (exact_key_validate(pk->def, key, part_count) != 0)
 		return -1;
 	struct tuple *old_tuple;
 	if (index_get_internal(pk, key, part_count, &old_tuple) != 0)
@@ -490,12 +490,12 @@ memtx_space_execute_update(struct space *space, struct txn *txn,
 {
 	struct txn_stmt *stmt = txn_current_stmt(txn);
 	/* Try to find the tuple by unique key. */
-	struct index *pk = index_find_unique(space, request->index_id);
+	struct index *pk = index_find(space, request->index_id);
 	if (pk == NULL)
 		return -1;
 	const char *key = request->key;
 	uint32_t part_count = mp_decode_array(&key);
-	if (exact_key_validate(pk->def->key_def, key, part_count) != 0)
+	if (exact_key_validate(pk->def, key, part_count) != 0)
 		return -1;
 	struct tuple *old_tuple;
 	if (index_get_internal(pk, key, part_count, &old_tuple) != 0)
@@ -550,7 +550,7 @@ memtx_space_execute_upsert(struct space *space, struct txn *txn,
 	if (tuple_validate_raw(space->format, request->tuple))
 		return -1;
 
-	struct index *index = index_find_unique(space, 0);
+	struct index *index = index_find(space, 0);
 	if (index == NULL)
 		return -1;
 

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1696,31 +1696,6 @@ memtx_tx_story_find_visible_tuple(struct memtx_story *story, struct txn *tnx,
 }
 
 /**
- * replace_check_dup wrapper, that follows usual return code convention and
- * sets diag in case of error.
- */
-static int
-memtx_tx_check_dup(struct tuple *new_tuple, struct tuple *old_tuple,
-		   struct tuple *dup_tuple, enum dup_replace_mode mode,
-		   struct index *index, struct space *space)
-{
-	uint32_t errcode;
-	errcode = replace_check_dup(old_tuple, dup_tuple, mode);
-	if (errcode != 0) {
-		if (errcode == ER_TUPLE_FOUND) {
-			diag_set(ClientError, errcode,
-				 index->def->name, space_name(space),
-				 tuple_str(dup_tuple), tuple_str(new_tuple),
-				 dup_tuple, new_tuple);
-		} else {
-			diag_set(ClientError, errcode, space_name(space));
-		}
-		return -1;
-	}
-	return 0;
-}
-
-/**
  * Track the fact that transaction @a txn have read @a story in @a space.
  * This fact could lead this transaction to read view or conflict state.
  */
@@ -1816,8 +1791,8 @@ check_dup(struct txn_stmt *stmt, struct tuple *new_tuple,
 						  is_own_change);
 	}
 
-	if (memtx_tx_check_dup(new_tuple, *old_tuple, visible_replaced,
-			       mode, space->index[0], space) != 0) {
+	if (index_check_dup(space->index[0], *old_tuple, new_tuple,
+			    visible_replaced, mode) != 0) {
 		memtx_tx_track_read(txn, space, visible_replaced);
 		return -1;
 	}
@@ -1847,9 +1822,8 @@ check_dup(struct txn_stmt *stmt, struct tuple *new_tuple,
 							  &unused);
 		}
 
-		if (memtx_tx_check_dup(new_tuple, visible_replaced, visible,
-				       DUP_INSERT, space->index[i],
-				       space) != 0) {
+		if (index_check_dup(space->index[i], visible_replaced,
+				    new_tuple, visible, DUP_INSERT) != 0) {
 			memtx_tx_track_read(txn, space, visible);
 			return -1;
 		}

--- a/src/box/session_settings.c
+++ b/src/box/session_settings.c
@@ -356,8 +356,10 @@ session_settings_space_execute_update(struct space *space, struct txn *txn,
 				       old_data, old_data_end, format,
 				       &new_size, request->index_base,
 				       &column_mask);
-	if (new_data == NULL)
+	if (new_data == NULL) {
+		error_set_index(diag_last_error(diag_get()), pk_def);
 		goto finish;
+	}
 	*result = box_tuple_new(format, new_data, new_data + new_size);
 	if (*result == NULL)
 		goto finish;

--- a/src/box/session_settings.c
+++ b/src/box/session_settings.c
@@ -368,8 +368,13 @@ session_settings_space_execute_update(struct space *space, struct txn *txn,
 				       column_mask)) {
 		if (key_len != new_key_len ||
 		    memcmp(key, new_key, key_len) != 0) {
+			struct tuple *old_tuple =
+				tuple_new(format, old_data, old_data_end);
 			diag_set(ClientError, ER_CANT_UPDATE_PRIMARY_KEY,
-				 space_name(space));
+				 space_name(space), space_id(space),
+				 old_tuple, *result,
+				 NULL);
+			tuple_delete(old_tuple);
 			goto finish;
 		}
 	}

--- a/src/box/session_settings.c
+++ b/src/box/session_settings.c
@@ -342,14 +342,8 @@ session_settings_space_execute_update(struct space *space, struct txn *txn,
 
 	const char *new_key, *key = request->key;
 	uint32_t new_size, new_key_len, key_len = mp_decode_array(&key);
-	if (key_len == 0) {
-		diag_set(ClientError, ER_EXACT_MATCH, 1, 0);
+	if (exact_key_validate(pk_def, key, key_len) != 0)
 		return -1;
-	}
-	if (key_len > 1 || mp_typeof(*key) != MP_STR) {
-		diag_set(ClientError, ER_KEY_PART_TYPE, 0, "string");
-		return -1;
-	}
 	key = mp_decode_str(&key, &key_len);
 	key = tt_cstr(key, key_len);
 	sid = session_setting_find(key);

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -1071,7 +1071,7 @@ space_before_replace(struct space *space, struct txn *txn,
 	switch (type) {
 	case IPROTO_UPDATE:
 	case IPROTO_DELETE:
-		index = index_find_unique(space, request->index_id);
+		index = index_find(space, request->index_id);
 		if (index == NULL)
 			return -1;
 		key = request->key;
@@ -1103,7 +1103,7 @@ space_before_replace(struct space *space, struct txn *txn,
 		return 0;
 	}
 
-	if (exact_key_validate(index->def->key_def, key, part_count) != 0 ||
+	if (exact_key_validate(index->def, key, part_count) != 0 ||
 	    index_get(index, key, part_count, &old_tuple) != 0) {
 		region_truncate(&fiber()->gc, region_svp);
 		return -1;

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -1142,8 +1142,11 @@ after_old_tuple_lookup:;
 					       old_data_end,
 					       space->format, &new_size,
 					       request->index_base, NULL);
-		if (new_data == NULL)
+		if (new_data == NULL) {
+			error_set_index(diag_last_error(diag_get()),
+					index->def);
 			return -1;
+		}
 		new_data_end = new_data + new_size;
 		break;
 	case IPROTO_DELETE:
@@ -1165,8 +1168,11 @@ after_old_tuple_lookup:;
 			if (xrow_update_check_ops(request->ops,
 						  request->ops_end,
 						  space->format,
-						  request->index_base) != 0)
+						  request->index_base) != 0) {
+				error_set_space(diag_last_error(diag_get()),
+						space->def);
 				return -1;
+			}
 			break;
 		}
 		old_data = tuple_data_range(old_tuple, &old_size);
@@ -1176,6 +1182,11 @@ after_old_tuple_lookup:;
 					       space->format, &new_size,
 					       request->index_base, false,
 					       NULL);
+		if (new_data == NULL) {
+			error_set_space(diag_last_error(diag_get()),
+					space->def);
+			return -1;
+		}
 		new_data_end = new_data + new_size;
 		break;
 	default:

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -1273,7 +1273,8 @@ after_old_tuple_lookup:;
 	    tuple_compare(old_tuple, HINT_NONE, new_tuple, HINT_NONE,
 			  pk->def->key_def) != 0) {
 		diag_set(ClientError, ER_CANT_UPDATE_PRIMARY_KEY,
-			 space->def->name);
+			 space->def->name, space->def->id, old_tuple, new_tuple,
+			 NULL);
 		rc = -1;
 		goto out;
 	}

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -507,21 +507,6 @@ index_find(struct space *space, uint32_t index_id)
 }
 
 /**
- * Wrapper around index_find() which checks that
- * the found index is unique.
- */
-static inline struct index *
-index_find_unique(struct space *space, uint32_t index_id)
-{
-	struct index *index = index_find(space, index_id);
-	if (index != NULL && !index->def->opts.is_unique) {
-		diag_set(ClientError, ER_MORE_THAN_ONE_TUPLE);
-		return NULL;
-	}
-	return index;
-}
-
-/**
  * Returns number of bytes used in memory by tuples in the space.
  */
 size_t
@@ -799,42 +784,6 @@ access_check_space_xc(struct space *space, user_access_t access)
 {
 	if (access_check_space(space, access) != 0)
 		diag_raise();
-}
-
-/**
- * Look up the index by id, and throw an exception if not found.
- */
-static inline struct index *
-index_find_xc(struct space *space, uint32_t index_id)
-{
-	struct index *index = index_find(space, index_id);
-	if (index == NULL)
-		diag_raise();
-	return index;
-}
-
-static inline struct index *
-index_find_unique_xc(struct space *space, uint32_t index_id)
-{
-	struct index *index = index_find_unique(space, index_id);
-	if (index == NULL)
-		diag_raise();
-	return index;
-}
-
-/**
- * Find an index in a system space. Throw an error
- * if we somehow deal with a non-memtx space (it can't
- * be used for system spaces.
- */
-static inline struct index *
-index_find_system_xc(struct space *space, uint32_t index_id)
-{
-	if (! space_is_memtx(space)) {
-		tnt_raise(ClientError, ER_UNSUPPORTED,
-			  space->engine->name, "system data");
-	}
-	return index_find_xc(space, index_id);
 }
 
 static inline void

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -746,6 +746,14 @@ space_dump_def(const struct space *space, struct rlist *key_list);
 void
 space_fill_index_map(struct space *space);
 
+/** Add info about space to the error. */
+static inline void
+error_set_space(struct error *error, struct space_def *def)
+{
+	error_set_str(error, "space", def->name);
+	error_set_uint(error, "space_id", def->id);
+}
+
 /*
  * Virtual method stubs.
  */

--- a/src/box/sysview.c
+++ b/src/box/sysview.c
@@ -161,11 +161,7 @@ sysview_index_get(struct index *base, const char *key,
 	struct index *pk = index_find(source, index->source_index_id);
 	if (pk == NULL)
 		return -1;
-	if (!pk->def->opts.is_unique) {
-		diag_set(ClientError, ER_MORE_THAN_ONE_TUPLE);
-		return -1;
-	}
-	if (exact_key_validate(pk->def->key_def, key, part_count) != 0)
+	if (exact_key_validate(pk->def, key, part_count) != 0)
 		return -1;
 	struct tuple *tuple;
 	if (index_get(pk, key, part_count, &tuple) != 0)

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -1798,7 +1798,8 @@ vy_check_update(struct space *space, const struct vy_lsm *pk,
 	    vy_stmt_compare(old_tuple, HINT_NONE, new_tuple,
 			    HINT_NONE, pk->key_def) != 0) {
 		diag_set(ClientError, ER_CANT_UPDATE_PRIMARY_KEY,
-			 space_name(space));
+			 space_name(space), space_id(space), old_tuple,
+			 new_tuple, NULL);
 		return -1;
 	}
 	return 0;

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -1684,44 +1684,6 @@ vy_check_is_unique(struct vy_env *env, struct vy_tx *tx,
 }
 
 /**
- * Check that the key can be used for search in a unique index
- * LSM tree.
- * @param  lsm        LSM tree for checking.
- * @param  key        MessagePack'ed data, the array without a
- *                    header.
- * @param  part_count Part count of the key.
- *
- * @retval  0 The key is valid.
- * @retval -1 The key is not valid, the appropriate error is set
- *            in the diagnostics area.
- */
-static inline int
-vy_unique_key_validate(struct vy_lsm *lsm, const char *key,
-		       uint32_t part_count)
-{
-	assert(lsm->opts.is_unique);
-	assert(key != NULL || part_count == 0);
-	/*
-	 * The LSM tree contains tuples with concatenation of
-	 * secondary and primary key fields, while the key
-	 * supplied by the user only contains the secondary key
-	 * fields. Use the correct key def to validate the key.
-	 * The key can be used to look up in the LSM tree since
-	 * the supplied key parts uniquely identify the tuple,
-	 * as long as the index is unique.
-	 */
-	uint32_t original_part_count = lsm->key_def->part_count;
-	if (original_part_count != part_count) {
-		diag_set(ClientError, ER_EXACT_MATCH,
-			 original_part_count, part_count);
-		return -1;
-	}
-	const char *key_end;
-	return key_validate_parts(lsm->cmp_def, key, part_count, false,
-				  &key_end);
-}
-
-/**
  * Returns true if the deferred DELETE optimization should be enabled for the
  * given space. It is regulated by a per-space knob, but we also disable it if
  * the space has UPSERT statements, because the deferred DELETE optimization
@@ -1761,7 +1723,7 @@ vy_delete(struct vy_env *env, struct vy_tx *tx, struct txn_stmt *stmt,
 		return -1;
 	const char *key = request->key;
 	uint32_t part_count = mp_decode_array(&key);
-	if (vy_unique_key_validate(lsm, key, part_count))
+	if (exact_key_validate(lsm->base.def, key, part_count))
 		return -1;
 	/*
 	 * There are four cases when we need to get the full tuple
@@ -1916,7 +1878,7 @@ vy_update(struct vy_env *env, struct vy_tx *tx, struct txn_stmt *stmt,
 		return -1;
 	const char *key = request->key;
 	uint32_t part_count = mp_decode_array(&key);
-	if (vy_unique_key_validate(lsm, key, part_count))
+	if (exact_key_validate(lsm->base.def, key, part_count))
 		return -1;
 
 	if (vy_get_by_raw_key(lsm, tx, vy_tx_read_view(tx),

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -1900,8 +1900,10 @@ vy_update(struct vy_env *env, struct vy_tx *tx, struct txn_stmt *stmt,
 					old_tuple, old_tuple_end,
 					pk->mem_format, &new_size,
 					request->index_base, &column_mask);
-	if (new_tuple == NULL)
+	if (new_tuple == NULL) {
+		error_set_index(diag_last_error(diag_get()), pk->base.def);
 		return -1;
+	}
 	new_tuple_end = new_tuple + new_size;
 	/*
 	 * Check that the new tuple matches the space format and
@@ -2098,6 +2100,7 @@ vy_upsert(struct vy_env *env, struct vy_tx *tx, struct txn_stmt *stmt,
 	/* Check update operations. */
 	if (xrow_update_check_ops(request->ops, request->ops_end,
 				  pk->mem_format, request->index_base) != 0) {
+		error_set_space(diag_last_error(diag_get()), space->def);
 		return -1;
 	}
 	if (request->index_base != 0) {

--- a/src/box/vy_stmt.c
+++ b/src/box/vy_stmt.c
@@ -452,9 +452,7 @@ vy_stmt_new_surrogate_delete_raw(struct tuple_format *format,
 		return NULL;
 	}
 	struct field_map_builder builder;
-	if (field_map_builder_create(&builder, format->field_map_size,
-				     region) != 0)
-		goto out;
+	field_map_builder_create(&builder, format->field_map_size, region);
 	/*
 	 * Perform simultaneous parsing of the tuple and
 	 * format::fields tree traversal to copy indexed field
@@ -488,11 +486,12 @@ vy_stmt_new_surrogate_delete_raw(struct tuple_format *format,
 		}
 		/* Initialize field_map with data offset. */
 		uint32_t offset_slot = entry.field->offset_slot;
-		if (offset_slot != TUPLE_OFFSET_SLOT_NIL &&
-		    field_map_builder_set_slot(&builder, offset_slot,
-					pos - data, entry.multikey_idx,
-					entry.multikey_count, region) != 0)
-			goto out;
+		if (offset_slot != TUPLE_OFFSET_SLOT_NIL)
+			field_map_builder_set_slot(&builder, offset_slot,
+						   pos - data,
+						   entry.multikey_idx,
+						   entry.multikey_count,
+						   region);
 		/* Copy field data. */
 		if (entry.field->type == FIELD_TYPE_ARRAY) {
 			pos = mp_encode_array(pos, entry.count);

--- a/test/unit/error.c
+++ b/test/unit/error.c
@@ -659,7 +659,7 @@ static void
 test_client_error_creation(void)
 {
 	header();
-	plan(64);
+	plan(67);
 
 	/* Test CHAR argument type */
 	const char *s;
@@ -850,6 +850,23 @@ test_client_error_creation(void)
 	e = diag_last_error(diag_get());
 	ok(e->errmsg != NULL && strcmp(e->errmsg, "Test error str") == 0);
 	ok(e->payload.count == ref_payload_count);
+
+	/*
+	 * Test if argument for payload-only field is NULL then it is
+	 * not added.
+	 */
+	diag_set(ClientError, ER_TEST_TYPE_STRING, NULL);
+	e = diag_last_error(diag_get());
+	s = error_get_str(e, "field");
+	ok(s == NULL);
+	diag_set(ClientError, ER_TEST_TYPE_MSGPACK, NULL);
+	e = diag_last_error(diag_get());
+	mp = error_get_mp(e, "field", &mp_size);
+	ok(mp == NULL);
+	diag_set(ClientError, ER_TEST_TYPE_TUPLE, NULL);
+	e = diag_last_error(diag_get());
+	mp = error_get_mp(e, "field", &mp_size);
+	ok(mp == NULL);
 
 	check_plan();
 	footer();


### PR DESCRIPTION
Closes #7223

EE part is https://github.com/tarantool/tarantool-ee/pull/776

For example for this setup:

```lua
local test = box.schema.create_space('test')
test:create_index('primary')
test:create_index('second', {parts = {2, 'unsigned', 1, 'unsigned'}})
```

Before we get (note that compat option `box_error_serialize_verbose` is set
to 'new' to show error details in console. It does not affect whether
details are added or not):

```
tarantool> test.index.second:get{1}
---
- error:
code: 19
base_type: ClientError
type: ClientError
message: Invalid key part count in an exact match (expected 2, got 1)
trace:
- file: ./src/box/index.cc
  line: 149
...
```

And now we get (see 'space', 'space_id', 'index', 'index_id' and 'key' fields):

```
tarantool> test.index.second:get{1}
---
- error:
code: 19
base_type: ClientError
message: Invalid key part count in an exact match (expected 2, got 1)
trace:
- file: ./src/box/index.cc
  line: 149
type: ClientError
index: second
space: test
index_id: 2
space_id: 512
key: [1]
...
```
