### PR TITLE
Introduce `mode` option for `call()` and `filter()` from `experimental.connpool` module

### DIFF
--- a/changelogs/unreleased/gh-9930-mode-option.md
+++ b/changelogs/unreleased/gh-9930-mode-option.md
@@ -1,0 +1,4 @@
+## feature/experimental
+
+* Introduced the `mode` option for the `filter()` and `call()` functions
+  in the `experimental.connpool` module (gh-9930).

--- a/src/box/lua/experimental/connpool.lua
+++ b/src/box/lua/experimental/connpool.lua
@@ -1,6 +1,11 @@
+local fiber = require('fiber')
+local clock = require('clock')
 local config = require('config')
 local checks = require('checks')
 local netbox = require('net.box')
+
+local WATCHER_DELAY = 0.1
+local WATCHER_TIMEOUT = 10
 
 local connections = {}
 
@@ -44,6 +49,17 @@ local function connect(instance_name, opts)
         end
         conn = res
         connections[instance_name] = conn
+        local function mode(conn)
+            if conn.state == 'active' then
+                return conn._mode
+            end
+            return nil
+        end
+        conn.mode = mode
+        local function watch_status(_key, value)
+            conn._mode = value.is_ro and 'ro' or 'rw'
+        end
+        conn:watch('box.status', watch_status)
     end
 
     -- If opts.wait_connected is not false we wait until the connection is
@@ -53,6 +69,28 @@ local function connect(instance_name, opts)
         error(msg:format(instance_name, conn.error), 0)
     end
     return conn
+end
+
+local function connect_to_candidates(candidates)
+    local delay = WATCHER_DELAY
+    local conn_opts = {connect_timeout = WATCHER_TIMEOUT}
+    local connected_candidates = {}
+    for _, instance_name in pairs(candidates) do
+        local time_connect_end = clock.monotonic() + WATCHER_TIMEOUT
+        local ok, conn = pcall(connect, instance_name, conn_opts)
+        -- If state is not 'active', conn:mode() cannot become not nil.
+        if ok and conn.state == 'active' then
+            while conn:mode() == nil and clock.monotonic() < time_connect_end do
+                fiber.sleep(delay)
+            end
+            if conn:mode() ~= nil then
+                table.insert(connected_candidates, instance_name)
+            else
+                conn:close()
+            end
+        end
+    end
+    return connected_candidates
 end
 
 local function is_roles_match(expected_roles, present_roles)
@@ -91,25 +129,67 @@ local function is_labels_match(expected_labels, present_labels)
     return true
 end
 
-local function is_candidate_match(instance_name, opts)
+local function is_candidate_match_static(instance_name, opts)
     assert(opts ~= nil and type(opts) == 'table')
     local get_opts = {instance = instance_name}
     return is_roles_match(opts.roles, config:get('roles', get_opts)) and
            is_labels_match(opts.labels, config:get('labels', get_opts))
 end
 
+local function is_mode_match(mode, instance_name)
+    if mode == nil then
+        return true
+    end
+    local conn = connections[instance_name]
+    assert(conn ~= nil)
+    return conn:mode() == mode
+end
+
+local function is_candidate_match_dynamic(instance_name, opts)
+    assert(opts ~= nil and type(opts) == 'table')
+    return is_mode_match(opts.mode, instance_name)
+end
+
 local function filter(opts)
     checks({
         labels = '?table',
         roles = '?table',
+        mode = '?string',
     })
-    local candidates = {}
+    opts = opts or {}
+    if opts.mode ~= nil and opts.mode ~= 'ro' and opts.mode ~= 'rw' then
+        local msg = 'Expected nil, "ro" or "rw", got "%s"'
+        error(msg:format(opts.mode), 0)
+    end
+    local static_opts = {
+        labels = opts.labels,
+        roles = opts.roles,
+    }
+    local dynamic_opts = {
+        mode = opts.mode,
+    }
+
+    -- First, select candidates using the information from the config.
+    local static_candidates = {}
     for instance_name in pairs(config:instances()) do
-        if is_candidate_match(instance_name, opts or {}) then
-            table.insert(candidates, instance_name)
+        if is_candidate_match_static(instance_name, static_opts) then
+            table.insert(static_candidates, instance_name)
         end
     end
-    return candidates
+    -- Return if retrieving dynamic information is not required.
+    if next(static_candidates) == nil or next(dynamic_opts) == nil then
+        return static_candidates
+    end
+
+    -- Filter the remaining candidates after connecting to them.
+    local connected_candidates = connect_to_candidates(static_candidates)
+    local dynamic_candidates = {}
+    for _, instance_name in pairs(connected_candidates) do
+        if is_candidate_match_dynamic(instance_name, dynamic_opts) then
+            table.insert(dynamic_candidates, instance_name)
+        end
+    end
+    return dynamic_candidates
 end
 
 local function get_connection(all_candidates, prefer_local)


### PR DESCRIPTION
This patch adds a `mode` option to `experimental.call()` and `experimental.filter()`. This option allows to execute filter candidates for these functions depending on RO status of the instances.

Closes #9930