### PR TITLE
[backport 2.11] lua: bump metrics module

### DIFF
--- a/changelogs/unreleased/bump-metrics-to-3370f85.md
+++ b/changelogs/unreleased/bump-metrics-to-3370f85.md
@@ -1,0 +1,4 @@
+## testing
+
+* Bumped `metrics` submodule to commit `3370f85` to fix compatibility with
+  `luatest` commit `d985997`.


### PR DESCRIPTION
(This is a backport of PR https://github.com/tarantool/tarantool/pull/9901 to release/2.11, future 2.11.3 release.)

----

Bump metrics package submodule. There are 8 new commits, but only two of them affects Tarantool:
- Add election_leader_idle metric [1];
- test: run log capture tests on a separate server [2]; the other 6 affect documentation and CI/CD scripts of the original repo. The latter one is required to bump luatest in test-run [3], since otherwise metrics log capture test fails on a new version.

1. https://github.com/tarantool/metrics/commit/ba9726d9b0cdfb22aa56d852f7fdc7b0aa22756a
2. https://github.com/tarantool/metrics/commit/3370f856efd4172bf24916e66e3846eeb01550a8
3. https://github.com/tarantool/test-run/pull/426

NO_DOC=doc is a part of submodule
NO_TEST=repo runs submodule tests, no new test files are added

(cherry picked from commit 50f74250e2423223352ed2dd1907789629b4bfad)