### PR TITLE
txn: run statement `on_rollback` triggers before rolling back statement

### DIFF
--- a/changelogs/unreleased/gh-9893-rollback-ddl-on-_space-space.md
+++ b/changelogs/unreleased/gh-9893-rollback-ddl-on-_space-space.md
@@ -1,0 +1,3 @@
+## bugfix/box
+
+* Fixed rollback of DDL statements on the `_space` space (gh-9893).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -3890,10 +3890,11 @@ priv_def_check(struct priv_def *priv, enum priv_type priv_type)
 
 /**
  * Update a metadata cache object with the new access
- * data.
+ * data. For the purpose of the rolled back statement, please refer to
+ * `user_reload_privs`.
  */
 static int
-grant_or_revoke(struct priv_def *priv)
+grant_or_revoke(struct priv_def *priv, struct txn_stmt *rolled_back_stmt)
 {
 	struct user *grantee = user_by_id(priv->grantee_id);
 	if (grantee == NULL)
@@ -3914,7 +3915,7 @@ grant_or_revoke(struct priv_def *priv)
 				return -1;
 		}
 	} else {
-		if (priv_grant(grantee, priv) != 0)
+		if (priv_grant(grantee, priv, rolled_back_stmt) != 0)
 			return -1;
 	}
 	return 0;
@@ -3924,13 +3925,12 @@ grant_or_revoke(struct priv_def *priv)
 static int
 revoke_priv(struct trigger *trigger, void *event)
 {
-	(void) event;
 	struct tuple *tuple = (struct tuple *)trigger->data;
 	struct priv_def priv;
 	if (priv_def_create_from_tuple(&priv, tuple) != 0)
 		return -1;
 	priv.access = 0;
-	if (grant_or_revoke(&priv) != 0)
+	if (grant_or_revoke(&priv, (struct txn_stmt *)event) != 0)
 		return -1;
 	return 0;
 }
@@ -3939,11 +3939,10 @@ revoke_priv(struct trigger *trigger, void *event)
 static int
 modify_priv(struct trigger *trigger, void *event)
 {
-	(void) event;
 	struct tuple *tuple = (struct tuple *)trigger->data;
 	struct priv_def priv;
 	if (priv_def_create_from_tuple(&priv, tuple) != 0 ||
-	    grant_or_revoke(&priv) != 0)
+	    grant_or_revoke(&priv, (struct txn_stmt *)event) != 0)
 		return -1;
 	return 0;
 }
@@ -3964,7 +3963,7 @@ on_replace_dd_priv(struct trigger * /* trigger */, void *event)
 	if (new_tuple != NULL && old_tuple == NULL) {	/* grant */
 		if (priv_def_create_from_tuple(&priv, new_tuple) != 0 ||
 		    priv_def_check(&priv, PRIV_GRANT) != 0 ||
-		    grant_or_revoke(&priv) != 0)
+		    grant_or_revoke(&priv, NULL) != 0)
 			return -1;
 		struct trigger *on_rollback =
 			txn_alter_trigger_new(revoke_priv, new_tuple);
@@ -3977,7 +3976,7 @@ on_replace_dd_priv(struct trigger * /* trigger */, void *event)
 		    priv_def_check(&priv, PRIV_REVOKE) != 0)
 			return -1;
 		priv.access = 0;
-		if (grant_or_revoke(&priv) != 0)
+		if (grant_or_revoke(&priv, NULL) != 0)
 			return -1;
 		struct trigger *on_rollback =
 			txn_alter_trigger_new(modify_priv, old_tuple);
@@ -3987,7 +3986,7 @@ on_replace_dd_priv(struct trigger * /* trigger */, void *event)
 	} else {                                       /* modify */
 		if (priv_def_create_from_tuple(&priv, new_tuple) != 0 ||
 		    priv_def_check(&priv, PRIV_GRANT) != 0 ||
-		    grant_or_revoke(&priv) != 0)
+		    grant_or_revoke(&priv, NULL) != 0)
 			return -1;
 		struct trigger *on_rollback =
 			txn_alter_trigger_new(modify_priv, old_tuple);

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -341,11 +341,15 @@ txn_stmt_prepare_rollback_info(struct txn_stmt *stmt, struct tuple *old_tuple,
 }
 
 /*
- * Undo changes done by a statement and run the corresponding
- * rollback triggers.
+ * Run the statement's rollback triggers and undo changes done by the statement.
+ *
+ * Logically, we call triggers after running statements. These triggers can
+ * make significant changes (for instance, DDL triggers), so, for consistency,
+ * we should call the statement's `on_rollback` triggers before rolling back
+ * the corresponding statement.
  *
  * Note, a trigger set by a particular statement must be run right
- * after the statement is rolled back, because rollback triggers
+ * before the statement is rolled back, because rollback triggers
  * installed by DDL statements restore the schema cache, which is
  * necessary to roll back previous statements. For example, to roll
  * back a DML statement applied to a space whose index is dropped
@@ -355,12 +359,12 @@ txn_stmt_prepare_rollback_info(struct txn_stmt *stmt, struct tuple *old_tuple,
 static void
 txn_rollback_one_stmt(struct txn *txn, struct txn_stmt *stmt)
 {
-	if (txn->engine != NULL && stmt->space != NULL)
-		engine_rollback_statement(txn->engine, txn, stmt);
 	if (stmt->has_triggers && trigger_run(&stmt->on_rollback, stmt) != 0) {
 		diag_log();
 		panic("statement rollback trigger failed");
 	}
+	if (txn->engine != NULL && stmt->space != NULL)
+		engine_rollback_statement(txn->engine, txn, stmt);
 }
 
 /*

--- a/src/box/user.h
+++ b/src/box/user.h
@@ -232,12 +232,13 @@ int
 role_revoke(struct user *grantee, struct user *role);
 
 /**
- * Grant or revoke a single privilege to a user or role
- * and re-evaluate effective access of all users of this
- * role if this role.
+ * Grant or revoke a single privilege to a user or role and re-evaluate
+ * effective access of all users of this role if this role. For the purpose of
+ * the rolled back statement, please refer to `user_reload_privs`.
  */
 int
-priv_grant(struct user *grantee, struct priv_def *priv);
+priv_grant(struct user *grantee, struct priv_def *priv,
+	   struct txn_stmt *rolled_back_stmt);
 
 int
 priv_def_create_from_tuple(struct priv_def *priv, struct tuple *tuple);

--- a/test/box-luatest/gh_9893_rollback_ddl_on__space_space_test.lua
+++ b/test/box-luatest/gh_9893_rollback_ddl_on__space_space_test.lua
@@ -1,0 +1,32 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+-- Test that rollback of DDL statements on the `_space` space works correctly.
+g.test_rollback_ddl_on__space_space = function(cg)
+    cg.server:exec(function()
+        local _space = box.space._space:get{box.space._space.id}:totable()
+
+        box.begin()
+        box.space._space:alter{is_sync = false, defer_deletes = true}
+        box.rollback()
+
+        -- Test that the server does not crash because of heap-use-after-free.
+        collectgarbage()
+        box.space._space:select{}
+        collectgarbage()
+
+        t.assert_equals(box.space._space:get{box.space._space.id}:totable(),
+                        _space)
+    end)
+end

--- a/test/box-luatest/rollback_ddl_on__priv_space_test.lua
+++ b/test/box-luatest/rollback_ddl_on__priv_space_test.lua
@@ -1,0 +1,79 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+    cg.server:exec(function()
+        local t = box.schema.space.create('test')
+        t:create_index('pk')
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+-- Test that rollback of privilege grant works correctly.
+g.test_rollback_grant = function(cg)
+    cg.server:exec(function()
+        box.schema.user.create('grant')
+        local msg = "Read access to space 'test' is denied for user 'grant'"
+        box.session.su('grant', function()
+            t.assert_error_msg_content_equals(msg, function()
+                box.space.test:select{}
+            end)
+        end)
+        box.begin()
+        box.schema.user.grant('grant', 'read', 'space', 'test')
+        box.rollback()
+        box.session.su('grant', function()
+            t.assert_error_msg_content_equals(msg, function()
+                box.space.test:select{}
+            end)
+        end)
+    end)
+end
+
+-- Test that rollback of privilege revoke works correctly.
+g.test_rollback_revoke = function(cg)
+    cg.server:exec(function()
+        box.schema.user.create('revoke')
+        box.schema.user.grant('revoke', 'read', 'space', 'test')
+        box.session.su('revoke', function()
+            t.assert_equals({}, box.space.test:select{})
+        end)
+        box.begin()
+        box.schema.user.revoke('revoke', 'read', 'space', 'test')
+        box.rollback()
+        box.session.su('revoke', function()
+            t.assert_equals({}, box.space.test:select{})
+        end)
+    end)
+end
+
+-- Test that rollback of privilege modification works correctly.
+g.test_rollback_modify = function(cg)
+    cg.server:exec(function()
+        box.schema.user.create('modify')
+        box.schema.user.grant('modify', 'read', 'space', 'test')
+        local msg = "Write access to space 'test' is denied for user 'modify'"
+        box.session.su('modify', function()
+            t.assert_equals({}, box.space.test:select{})
+            t.assert_error_msg_content_equals(msg, function()
+                box.space.test:delete{0}
+            end)
+        end)
+        box.begin()
+        box.schema.user.grant('modify', 'write', 'space', 'test')
+        box.rollback()
+        box.session.su('modify', function()
+            t.assert_equals({}, box.space.test:select{})
+            t.assert_error_msg_content_equals(msg, function()
+                box.space.test:delete{0}
+            end)
+        end)
+    end)
+end


### PR DESCRIPTION
This patch fixes the order of running a transaction statement's `on_rollback` triggers and rolling back the statement itself.

Closes #9893