### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-5994-memprof-human-readable.md
+++ b/changelogs/unreleased/gh-5994-memprof-human-readable.md
@@ -2,3 +2,5 @@
 
 Added the `--human-readable` option for the `misc.memprof` parser to print
 sizes like 1KiB, 234MiB, 2GiB, etc.
+
+Made the errors from the profilers more user-friendly (gh-9217).

--- a/changelogs/unreleased/gh-9595-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9595-luajit-fixes.md
@@ -18,3 +18,6 @@ were fixed as part of this activity:
 * Fixed recording of the `__concat` metamethod for vararg or protected frames.
 * Fixed recording of a side trace returning to a lower frame with a maximum
   possible frame size.
+* Fixed `debug.setmetatable()` and `lua_setmetatable()` with enabled
+  `jit.dump()`.
+* Fixed recording of side traces with a down-recursion.


### PR DESCRIPTION
* ci: bump version of actions/checkout
* test: fix typo in the link to the issue
* test: refactor CMake macro LibRealPath
* test: move LibRealPath to the separate module
* test: more cautious usage of LD_PRELOAD for ASan
* test: fix lj-802-panic-at-mcode-protfail GCC+ASan
* ci: execute LuaJIT tests with GCC 10 and ASAN
* cmake: replace prove with CTest
* Prevent down-recursion for side traces.
* Handle stack reallocation in debug.setmetatable() and lua_setmetatable().
* profilers: print user-friendly errors

Closes #5994
Closes #9595
Closes #9217
Closes #9656

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump