### PR TITLE
build: use VK S3 for icu4c and zziplib archives

### DIFF
--- a/cmake/BuildICU.cmake
+++ b/cmake/BuildICU.cmake
@@ -1,4 +1,4 @@
-set(ICU_VERSION release-71-1/icu4c-71_1)
+set(ICU_VERSION 71_1)
 set(ICU_HASH e06ffc96f59762bd3c929b217445aaec)
 set(ICU_PATCHES_DIR ${PROJECT_SOURCE_DIR}/patches)
 set(ICU_INSTALL_DIR ${BUNDLED_LIBS_INSTALL_DIR}/icu-prefix)
@@ -22,7 +22,7 @@ ExternalProject_Add(bundled-icu-project
     SOURCE_DIR ${ICU_INSTALL_DIR}/src/icu
     BINARY_DIR ${ICU_INSTALL_DIR}/src/icu-build
     STAMP_DIR ${ICU_INSTALL_DIR}/src/icu-stamp
-    URL https://github.com/unicode-org/icu/releases/download/${ICU_VERSION}-src.tgz
+    URL ${BACKUP_STORAGE}/icu/icu4c-${ICU_VERSION}-src.tgz
     URL_MD5 ${ICU_HASH}
     CONFIGURE_COMMAND <SOURCE_DIR>/source/configure
         CC=${CMAKE_C_COMPILER}

--- a/cmake/BuildZZIP.cmake
+++ b/cmake/BuildZZIP.cmake
@@ -1,4 +1,4 @@
-set(ZZIP_VERSION v0.13.71)
+set(ZZIP_VERSION 0.13.71)
 set(ZZIP_HASH 1aa094186cf2222e4cda1b91b8fb8f60)
 set(ZZIP_INSTALL_DIR ${BUNDLED_LIBS_INSTALL_DIR}/zzip-prefix)
 set(ZZIP_INCLUDE_DIR ${ZZIP_INSTALL_DIR}/include)
@@ -36,7 +36,7 @@ ExternalProject_Add(bundled-zzip-project
     SOURCE_DIR ${ZZIP_INSTALL_DIR}/src/zzip
     BINARY_DIR ${ZZIP_INSTALL_DIR}/src/zzip-build
     STAMP_DIR ${ZZIP_INSTALL_DIR}/src/zzip-stamp
-    URL https://github.com/gdraheim/zziplib/archive/${ZZIP_VERSION}.tar.gz
+    URL ${BACKUP_STORAGE}/zziplib/zziplib-${ZZIP_VERSION}.tar.gz
     URL_MD5 ${ZZIP_HASH}
     CMAKE_ARGS ${ZZIP_CMAKE_FLAGS}
     BUILD_BYPRODUCTS ${ZZIP_LIBRARY}


### PR DESCRIPTION
The CI/CD builds are performed on VK Cloud virtual machines, so the access to VK S3 is more reliable than to GitHub archives.

In fact, we experience periodical download problems with source archives on GitHub in Tarantool Enterprise Edition builds in CI/CD and it is the motivation to backup the archives on our side. The problems appear quite frequently last few days.

The download problems are not on VK Cloud side and not on GitHub side. The packet loss is somewhere in the middle. I don't know an exact reason for now.