### PR TITLE
[backport 3.0] trigger: do not return handler from trigger.del

### DIFF
--- a/src/box/lua/trigger.c
+++ b/src/box/lua/trigger.c
@@ -42,7 +42,7 @@ luaT_trigger_set(struct lua_State *L)
 /**
  * Deletes a trigger with passed name from passed event.
  * The first argument is event name, the second one is trigger name.
- * Returns deleted trigger handler.
+ * Returns no values.
  */
 static int
 luaT_trigger_del(struct lua_State *L)
@@ -52,14 +52,9 @@ luaT_trigger_del(struct lua_State *L)
 	const char *event_name = luaL_checkstring(L, 1);
 	const char *trigger_name = luaL_checkstring(L, 2);
 	struct event *event = event_get(event_name, false);
-	if (event == NULL)
-		return 0;
-	struct func_adapter *old = event_find_trigger(event, trigger_name);
-	if (old == NULL)
-		return 0;
-	func_adapter_lua_get_func(old, L);
-	event_reset_trigger(event, trigger_name, NULL);
-	return 1;
+	if (event != NULL)
+		event_reset_trigger(event, trigger_name, NULL);
+	return 0;
 }
 
 /**

--- a/test/app-luatest/trigger_module_test.lua
+++ b/test/app-luatest/trigger_module_test.lua
@@ -66,16 +66,14 @@ g.test_simple = function()
 
         trigger.call(event, 42)
         t.assert_equals(state, 42)
-        ret_handler = trigger.del(event, name)
-        t.assert_equals(ret_handler, handler)
+        trigger.del(event, name)
 
         state = 0
         trigger.call(event)
         t.assert_equals(state, 0)
 
         -- Check that deletion of nothing does not throw error and returns nil
-        ret_handler = trigger.del(event, name)
-        t.assert_equals(ret_handler, nil)
+        trigger.del(event, name)
     end)
 end
 


### PR DESCRIPTION
It was mistake to return handler from trigger deletion - if the handler is not Lua object, its lifetime is independent from Lua, and we basically return object from its destructor. Let's just return nothing because checking if a trigger was actually deleted seems to be misusage of our trigger paradigm.

NO_CHANGELOG=not documented behavior
NO_DOC=bugfix

(cherry picked from commit c54adc1e1fb71dc4b5e6c1435e3a12a9537ce0e0)