### PR TITLE
[backport 3.0] config: add subj URI to config verification error

### DIFF
--- a/changelogs/unreleased/gh-9644-verbose-uri-error.md
+++ b/changelogs/unreleased/gh-9644-verbose-uri-error.md
@@ -1,0 +1,4 @@
+## bugfix/config
+
+* Added a subject URI to the error that is thrown on configuration
+  verification (gh-9644).

--- a/changelogs/unreleased/gh-9644-verbose-uri-error.md
+++ b/changelogs/unreleased/gh-9644-verbose-uri-error.md
@@ -2,3 +2,5 @@
 
 * Added a subject URI to the error that is thrown on configuration
   verification (gh-9644).
+* Added a warning with the skipped (unsuitable) URI to replicaset
+  and sharding configuration (gh-9644).

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -36,7 +36,8 @@ local function peer_uris(configdata)
         -- A user may configure a custom data flow using
         -- `replication.peers` option.
         if not is_anon then
-            local uri = instance_config:instance_uri(iconfig_def, 'peer')
+            local uri = instance_config:instance_uri(iconfig_def, 'peer',
+                {log_prefix = "replicaset dataflow configuration: "})
             if uri == nil then
                 log.info('%s: instance %q has no iproto.advertise.peer or ' ..
                     'iproto.listen URI suitable to create a client socket',

--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -84,7 +84,8 @@ local function instance_sharding(iconfig, instance_name)
         return nil
     end
     local zone = instance_config:get(iconfig, 'sharding.zone')
-    local uri = instance_config:instance_uri(iconfig, 'sharding')
+    local log_opts = {log_prefix = "sharding configuration: "}
+    local uri = instance_config:instance_uri(iconfig, 'sharding', log_opts)
     if uri == nil then
         local err = 'No suitable URI provided for instance %q'
         error(err:format(instance_name), 0)

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -212,7 +212,7 @@ local function validate_uri_field(has_login_field, used_to_connect)
         if used_to_connect then
             local ok, err = uri_is_suitable_to_connect(uri)
             if not ok then
-                w.error(err)
+                w.error("bad URI %q: %s", data, err)
             end
         end
     end

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -527,6 +527,7 @@ for case_name, case in pairs({
         advertise = {uri = '0.0.0.0:3301'},
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.%s.uri',
+            'bad URI "0.0.0.0:3301"',
             'INADDR_ANY (0.0.0.0) cannot be used to create a client socket',
         }, ': '),
     },
@@ -534,6 +535,7 @@ for case_name, case in pairs({
         advertise = {uri = '0.0.0.0:3301', login = 'user'},
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.%s.uri',
+            'bad URI "0.0.0.0:3301"',
             'INADDR_ANY (0.0.0.0) cannot be used to create a client socket',
         }, ': '),
     },
@@ -541,6 +543,7 @@ for case_name, case in pairs({
         advertise = {uri = '0.0.0.0:3301', login = 'user', password = 'pass'},
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.%s.uri',
+            'bad URI "0.0.0.0:3301"',
             'INADDR_ANY (0.0.0.0) cannot be used to create a client socket',
         }, ': '),
     },
@@ -548,6 +551,7 @@ for case_name, case in pairs({
         advertise = {uri = '[::]:3301'},
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.%s.uri',
+            'bad URI "[::]:3301"',
             'in6addr_any (::) cannot be used to create a client socket',
         }, ': '),
     },
@@ -555,6 +559,7 @@ for case_name, case in pairs({
         advertise = {uri = '[::]:3301', login = 'user'},
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.%s.uri',
+            'bad URI "[::]:3301"',
             'in6addr_any (::) cannot be used to create a client socket',
         }, ': '),
     },
@@ -562,6 +567,7 @@ for case_name, case in pairs({
         advertise = {uri = '[::]:3301', login = 'user', password = 'pass'},
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.%s.uri',
+            'bad URI "[::]:3301"',
             'in6addr_any (::) cannot be used to create a client socket',
         }, ': '),
     },
@@ -569,6 +575,7 @@ for case_name, case in pairs({
         advertise = {uri = 'localhost:0'},
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.%s.uri',
+            'bad URI "localhost:0"',
             'An URI with zero port cannot be used to create a client socket',
         }, ': '),
     },
@@ -576,6 +583,7 @@ for case_name, case in pairs({
         advertise = {uri = 'localhost:0', login = 'user'},
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.%s.uri',
+            'bad URI "localhost:0"',
             'An URI with zero port cannot be used to create a client socket',
         }, ': '),
     },
@@ -583,6 +591,7 @@ for case_name, case in pairs({
         advertise = {uri = 'localhost:0', login = 'user', password = 'pass'},
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.%s.uri',
+            'bad URI "localhost:0"',
             'An URI with zero port cannot be used to create a client socket',
         }, ': '),
     },
@@ -625,6 +634,7 @@ for case_name, case in pairs({
         advertise = '0.0.0.0:3301',
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.client',
+            'bad URI "0.0.0.0:3301"',
             'INADDR_ANY (0.0.0.0) cannot be used to create a client socket',
         }, ': '),
     },
@@ -632,6 +642,7 @@ for case_name, case in pairs({
         advertise = '[::]:3301',
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.client',
+            'bad URI "[::]:3301"',
             'in6addr_any (::) cannot be used to create a client socket',
         }, ': '),
     },
@@ -639,6 +650,7 @@ for case_name, case in pairs({
         advertise = 'localhost:0',
         exp_err_msg = table.concat({
             '[instance_config] iproto.advertise.client',
+            'bad URI "localhost:0"',
             'An URI with zero port cannot be used to create a client socket',
         }, ': '),
     },


### PR DESCRIPTION
*(This is a backport of PR #9906 to `release/3.0`, future `3.0.2` release.)*

----

Before this patch, it was quite difficult to determine, which URI in config was unsuitable.
Now the subject URI is listed in the error body.

Closes of #9644