### PR TITLE
memtx: fix a bug with mvcc and exclude_null option

### DIFF
--- a/changelogs/unreleased/gh-9954-mvcc-crash-with-exclude-null.md
+++ b/changelogs/unreleased/gh-9954-mvcc-crash-with-exclude-null.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fixed a bug that resulted in a crash when both MVCC and index with the `exclude_null` part were used (gh-9954).

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1227,7 +1227,10 @@ memtx_tx_story_unlink_top_common(struct memtx_story *story, uint32_t idx)
 		unreachable();
 		panic("failed to rebind story in index");
 	}
-	assert(story->tuple == removed);
+	assert(story->tuple == removed ||
+	       (removed == NULL && tuple_key_is_excluded(story->tuple,
+							 index->def->key_def,
+							 MULTIKEY_NONE)));
 	story->link[idx].in_index = NULL;
 	if (old_story != NULL)
 		old_story->link[idx].in_index = index;
@@ -1396,7 +1399,13 @@ memtx_tx_story_full_unlink_on_space_delete(struct memtx_story *story)
 					unreachable();
 					panic("failed to rollback change");
 				}
-				assert(story->tuple == removed);
+				struct key_def *key_def = index->def->key_def;
+				assert(story->tuple == removed ||
+				       (removed == NULL &&
+					tuple_key_is_excluded(story->tuple,
+							      key_def,
+							      MULTIKEY_NONE)));
+				(void)key_def;
 				link->in_index = NULL;
 				/*
 				 * All tuples in pk are referenced.
@@ -1471,7 +1480,13 @@ memtx_tx_story_full_unlink_story_gc_step(struct memtx_story *story)
 					unreachable();
 					panic("failed to rollback change");
 				}
-				assert(story->tuple == removed);
+				struct key_def *key_def = index->def->key_def;
+				assert(story->tuple == removed ||
+				       (removed == NULL &&
+					tuple_key_is_excluded(story->tuple,
+							      key_def,
+							      MULTIKEY_NONE)));
+				(void)key_def;
 				link->in_index = NULL;
 				/*
 				 * All tuples in pk are referenced.
@@ -1997,12 +2012,18 @@ memtx_tx_history_add_insert_stmt(struct txn_stmt *stmt,
 	/* Process replacement in indexes. */
 	struct tuple *directly_replaced[space->index_count];
 	struct tuple *direct_successor[space->index_count];
+	bool tuple_excluded[space->index_count];
 	uint32_t directly_replaced_count = 0;
 	for (uint32_t i = 0; i < space->index_count; i++) {
 		struct index *index = space->index[i];
 		struct tuple **replaced = &directly_replaced[i];
 		struct tuple **successor = &direct_successor[i];
-		if (index_replace(index, NULL, new_tuple,
+		*replaced = *successor = NULL;
+		tuple_excluded[i] = tuple_key_is_excluded(new_tuple,
+							  index->def->key_def,
+							  MULTIKEY_NONE);
+		if (!tuple_excluded[i] &&
+		    index_replace(index, NULL, new_tuple,
 				  DUP_REPLACE_OR_INSERT,
 				  replaced, successor) != 0)
 		{
@@ -2037,12 +2058,13 @@ memtx_tx_history_add_insert_stmt(struct txn_stmt *stmt,
 	for (uint32_t i = 0; i < space->index_count; i++) {
 		struct tuple *next = directly_replaced[i];
 		struct tuple *succ = direct_successor[i];
-		if (next == NULL) {
+		if (next == NULL && !tuple_excluded[i]) {
 			/* Collect conflicts. */
 			memtx_tx_handle_gap_write(space, add_story, succ, i);
 			memtx_tx_handle_point_hole_write(space, add_story, i);
 			memtx_tx_story_link_top(add_story, NULL, i, true);
-		} else {
+		}
+		if (next != NULL) {
 			/* Form chains. */
 			struct memtx_story *next_story = next_pk_story;
 			if (next != next_pk) {

--- a/test/box-luatest/gh_9954_mvcc_with_exclude_null_test.lua
+++ b/test/box-luatest/gh_9954_mvcc_with_exclude_null_test.lua
@@ -1,0 +1,109 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new{
+        alias   = 'default',
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:drop()
+end)
+
+g.before_each(function()
+    g.server:exec(function()
+        local space = box.schema.space.create('test', {if_not_exists = true})
+        space:format({
+             {name = 'id';    type = 'unsigned';},
+             {name = 'data';  type = 'string';},
+             {name = 'cnt';   type = 'unsigned';   is_nullable=true},
+         })
+
+        space:create_index('pk', {
+            parts = {'id'},
+            if_not_exists = true,
+        })
+
+        space:create_index('second', {
+            parts = {{'data'}, {'cnt', exclude_null=true}},
+            unique = false,
+            if_not_exists = true,
+        })
+    end)
+end)
+
+g.after_each(function()
+    g.server:exec(function()
+        if box.space.test then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+-- Test right from the issue.
+g.test_mvcc_with_exclude_null_base = function()
+    g.server:exec(function()
+        require('console').eval("box.space.test:insert({1, 'fdf'})")
+    end)
+end
+
+-- Test that excluded tuple has no side effects.
+g.test_mvcc_with_exclude_null_side_effects = function()
+    g.server:exec(function()
+        local txn_proxy = require("test.box.lua.txn_proxy")
+        local tx1 = txn_proxy.new()
+        local tx2 = txn_proxy.new()
+        tx1:begin()
+        tx2:begin()
+        -- Perform a full scan.
+        tx1("box.space.test.index.second:select{}")
+        -- Perform a range scan.
+        tx2("box.space.test.index.second:select({'a'}, {iterator = 'ge'})")
+
+        box.space.test:insert{1, 'fdf'}
+
+        -- Perform independent RW stmt.
+        tx2("box.space.test:replace{2, 'a'}")
+        t.assert_equals(tx2:commit(), '')
+        -- Perform independent RW stmt.
+        tx1("box.space.test:replace{3, 'b'}")
+        t.assert_equals(tx1:commit(), '')
+    end)
+end
+
+-- Test the rollback story.
+g.test_mvcc_with_exclude_null_rollback = function()
+    g.server:exec(function()
+        box.begin()
+        box.space.test:insert{1, 'fdf'}
+        box.rollback()
+    end)
+end
+
+-- Test the case with GC.
+g.test_mvcc_with_exclude_null_collect_garbage = function()
+    g.server:exec(function()
+        for i = 1, 100 do
+            box.space.test:insert{i, 'fdf'}
+        end
+        box.internal.memtx_tx_gc(10)
+    end)
+end
+
+-- Test space drop case.
+g.test_mvcc_with_exclude_null_space_drop = function()
+    g.server:exec(function()
+        local txn_proxy = require("test.box.lua.txn_proxy")
+        for i = 1, 100 do
+            local tx = txn_proxy.new()
+            tx:begin()
+            tx("box.space.test:insert{" .. i .. ", 'fdf'}")
+        end
+        box.space.test:drop()
+    end)
+end


### PR DESCRIPTION
Before this patch MVCC engine expected that if index_replace sets `result` to NULL then index_replace sets `successor` to something (NULL or existing tuple, depending on index type). That looked fine because by contract `successor` is set when true insertion was happened.

Unfortunately it was not considered that case of `exclude_null` part in index the insertion can be silently skipped and thus `successor` can be not set. The latter access of it led to UB.

Fix it by explicit check of tuple_key_is_excluded and work on this case correctly.

Note that logically `index_replace` should return a flag whether the new tuple was filtered (excluded) by key_def. But on the other hand this flag is required only for mvcc while the function is already has lots of agruments and it's very cheap to determine this flag right from memtx_tx, so I decided to make the most simple patch.

Closes #9954

NO_DOC=bugfix