### PR TITLE
[2.10] ci: add timeouts for workflow jobs

### DIFF
--- a/.github/workflows/alpine_3_16.yml
+++ b/.github/workflows/alpine_3_16.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/alpine_3_16_aarch64.yml
+++ b/.github/workflows/alpine_3_16_aarch64.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: graviton
 
+    timeout-minutes: 60
+
     env:
       OS: 'alpine'
       DIST: '3.16'

--- a/.github/workflows/centos_7.yml
+++ b/.github/workflows/centos_7.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/centos_7_aarch64.yml
+++ b/.github/workflows/centos_7_aarch64.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: graviton
 
+    timeout-minutes: 60
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/centos_8.yml
+++ b/.github/workflows/centos_8.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/centos_8_aarch64.yml
+++ b/.github/workflows/centos_8_aarch64.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: graviton
 
+    timeout-minutes: 60
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -50,6 +50,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -11,6 +11,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:debian-buster
       # Our testing expects that the init process (PID 1) will

--- a/.github/workflows/debian_10.yml
+++ b/.github/workflows/debian_10.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/debian_10_aarch64.yml
+++ b/.github/workflows/debian_10_aarch64.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: graviton
 
+    timeout-minutes: 60
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/debian_11.yml
+++ b/.github/workflows/debian_11.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/debian_11_aarch64.yml
+++ b/.github/workflows/debian_11_aarch64.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: graviton
 
+    timeout-minutes: 60
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/debian_9.yml
+++ b/.github/workflows/debian_9.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -50,6 +50,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -50,6 +50,8 @@ jobs:
 
     runs-on: graviton
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/debug_asan_clang.yml
+++ b/.github/workflows/debug_asan_clang.yml
@@ -51,6 +51,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-jammy-clang16
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -53,6 +53,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/fedora_34.yml
+++ b/.github/workflows/fedora_34.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/fedora_34_aarch64.yml
+++ b/.github/workflows/fedora_34_aarch64.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: graviton
 
+    timeout-minutes: 60
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/fedora_35.yml
+++ b/.github/workflows/fedora_35.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/fedora_35_aarch64.yml
+++ b/.github/workflows/fedora_35_aarch64.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: graviton
 
+    timeout-minutes: 60
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/fedora_36.yml
+++ b/.github/workflows/fedora_36.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/fedora_36_aarch64.yml
+++ b/.github/workflows/fedora_36_aarch64.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: graviton
 
+    timeout-minutes: 60
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -12,6 +12,8 @@ jobs:
 
     runs-on: freebsd-${{ matrix.freebsd-version }}-mcs
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -45,6 +45,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,6 +50,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
 
@@ -86,6 +88,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
 
@@ -115,6 +119,8 @@ jobs:
           !contains(github.event.pull_request.labels.*.name, 'notest') )
 
     runs-on: ubuntu-20.04-self-hosted
+
+    timeout-minutes: 60
 
     container:
       image: docker.io/tarantool/testing:ubuntu-jammy

--- a/.github/workflows/luajit-integration.yml
+++ b/.github/workflows/luajit-integration.yml
@@ -50,6 +50,7 @@ on:
 jobs:
   luajit-integration:
     runs-on: [self-hosted, regular, '${{ inputs.os }}', '${{ inputs.arch }}']
+    timeout-minutes: 60
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -50,6 +50,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -14,6 +14,8 @@ jobs:
       - 'macos-${{ matrix.osx-version }}-self-hosted'
       - '${{ matrix.machine-arch }}'
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -50,6 +50,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/redos_7_3.yaml
+++ b/.github/workflows/redos_7_3.yaml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/release_asan_clang.yml
+++ b/.github/workflows/release_asan_clang.yml
@@ -51,6 +51,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-jammy-clang16
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -50,6 +50,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-jammy-clang16
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -50,6 +50,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/release_lto_clang.yml
+++ b/.github/workflows/release_lto_clang.yml
@@ -50,6 +50,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-jammy-clang16
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -35,6 +35,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    timeout-minutes: 60
     env:
       OS: ${{ inputs.os }}
       DIST: ${{ inputs.dist }}

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -15,6 +15,8 @@ jobs:
 
     runs-on: ubuntu-22.04
 
+    timeout-minutes: 60
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -51,6 +51,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -51,6 +51,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
       # Mount /dev to the container to be able to mount a disk image inside it

--- a/.github/workflows/submodule_update.yml
+++ b/.github/workflows/submodule_update.yml
@@ -18,6 +18,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     container:
       image: docker.io/tarantool/testing:ubuntu-focal
 
@@ -65,6 +67,8 @@ jobs:
     if: github.repository == 'tarantool/tarantool'
 
     runs-on: [ self-hosted, Linux, x86_64, flavor-1-2 ]
+
+    timeout-minutes: 60
 
     needs: update-ee
 

--- a/.github/workflows/ubuntu_16_04.yml
+++ b/.github/workflows/ubuntu_16_04.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ubuntu_20_04_aarch64.yml
+++ b/.github/workflows/ubuntu_20_04_aarch64.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: graviton
 
+    timeout-minutes: 60
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: ubuntu-20.04-self-hosted
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ubuntu_22_04_aarch64.yml
+++ b/.github/workflows/ubuntu_22_04_aarch64.yml
@@ -40,6 +40,8 @@ jobs:
 
     runs-on: graviton
 
+    timeout-minutes: 60
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master


### PR DESCRIPTION
By default, each job in a workflow can run for up to 6 hours of the execution time. If a job reaches this limit, the job is terminated by GitHub automatically and fails to complete. This patch sets job timeouts to 60 minutes to avoid waiting for jobs to complete for 6 hours.
