### PR TITLE
box: pass source tuple to `default_func` field option of `space:format`

### DIFF
--- a/changelogs/unreleased/gh-9825-space-format-default-func-tuple-arg.md
+++ b/changelogs/unreleased/gh-9825-space-format-default-func-tuple-arg.md
@@ -1,0 +1,4 @@
+## feature/box
+
+* Added the source tuple as a second argument for the functional variant of the
+  default field values (gh-9825).

--- a/src/box/field_default_func.c
+++ b/src/box/field_default_func.c
@@ -43,12 +43,17 @@ field_default_func_verify(struct func *func)
 static int
 field_default_func_call_impl(struct field_default_func *default_func,
 			     const char *arg_data, uint32_t arg_size,
-			     const char **ret_data, uint32_t *ret_size)
+			     struct tuple *source, const char **ret_data,
+			     uint32_t *ret_size)
 {
 	struct port out_port, in_port;
 	port_c_create(&in_port);
-	if (arg_data != NULL)
+	if (arg_data != NULL) {
 		port_c_add_mp(&in_port, arg_data, arg_data + arg_size);
+	} else {
+		port_c_add_null(&in_port);
+	}
+	port_c_add_tuple(&in_port, source);
 
 	int rc = func_call_no_access_check(default_func->holder.func,
 					   &in_port, &out_port);

--- a/src/box/field_default_func.h
+++ b/src/box/field_default_func.h
@@ -22,7 +22,8 @@ struct field_default_func {
 	/** Call function with given argument. */
 	int (*call)(struct field_default_func *default_func,
 		    const char *arg_data, uint32_t arg_size,
-		    const char **ret_data, uint32_t *ret_size);
+		    struct tuple *source, const char **ret_data,
+		    uint32_t *ret_size);
 	/** Destructor. */
 	void (*destroy)(struct field_default_func *func);
 };
@@ -38,10 +39,11 @@ struct field_default_func {
 static inline int
 field_default_func_call(struct field_default_func *default_func,
 			const char *arg_data, uint32_t arg_size,
-			const char **ret_data, uint32_t *ret_size)
+			struct tuple *source, const char **ret_data,
+			uint32_t *ret_size)
 {
-	return default_func->call(default_func, arg_data, arg_size, ret_data,
-				  ret_size);
+	return default_func->call(default_func, arg_data, arg_size, source,
+				  ret_data, ret_size);
 }
 
 static inline void

--- a/src/box/sql/func.c
+++ b/src/box/sql/func.c
@@ -2467,8 +2467,8 @@ func_sql_expr_call(struct func *func, struct port *args, struct port *ret)
 	const char *data;
 	uint32_t mp_size;
 	struct tuple_format *format;
-	if (port->size > 0) {
-		struct port_c_entry *pe = port->first;
+	struct port_c_entry *pe = port->first;
+	if (pe->type != PORT_C_ENTRY_NULL) {
 		assert(pe->type == PORT_C_ENTRY_MP);
 		data = pe->mp.data;
 		mp_size = pe->mp.size;

--- a/src/box/tuple_format.c
+++ b/src/box/tuple_format.c
@@ -34,6 +34,7 @@
 #include "json/json.h"
 #include "coll_id_cache.h"
 #include "trivia/util.h"
+#include "tuple.h"
 #include "tuple_builder.h"
 #include "tuple_constraint.h"
 #include "field_default_func.h"
@@ -1556,6 +1557,11 @@ tuple_format_apply_defaults(struct tuple_format *format, const char **data,
 	tuple_builder_new(&builder, &fiber()->gc);
 	size_t region_svp = region_used(&fiber()->gc);
 	bool is_tuple_changed = false;
+	struct tuple *source = NULL;
+	if (tuple_format_has_default_funcs(format)) {
+		source = tuple_new(tuple_format_runtime, *data, *data_end);
+		tuple_ref(source);
+	}
 	/*
 	 * Process fields that are present in both the format and the tuple.
 	 * Break prematurely when all defaults are applied.
@@ -1578,9 +1584,10 @@ tuple_format_apply_defaults(struct tuple_format *format, const char **data,
 			const char *ret_data;
 			uint32_t ret_size;
 			if (field_default_func_call(&d->func, d->data,
-						    d->size, &ret_data,
+						    d->size, source, &ret_data,
 						    &ret_size) != 0) {
 				region_truncate(&fiber()->gc, region_svp);
+				tuple_unref(source);
 				return -1;
 			}
 			tuple_builder_add(&builder, ret_data, ret_size, 1);
@@ -1605,9 +1612,10 @@ tuple_format_apply_defaults(struct tuple_format *format, const char **data,
 			const char *ret_data;
 			uint32_t ret_size;
 			if (field_default_func_call(&d->func, d->data,
-						    d->size, &ret_data,
+						    d->size, source, &ret_data,
 						    &ret_size) != 0) {
 				region_truncate(&fiber()->gc, region_svp);
+				tuple_unref(source);
 				return -1;
 			}
 			tuple_builder_add(&builder, ret_data, ret_size, 1);
@@ -1620,6 +1628,8 @@ tuple_format_apply_defaults(struct tuple_format *format, const char **data,
 			tuple_builder_add_nil(&builder);
 		}
 	}
+	if (source != NULL)
+		tuple_unref(source);
 	/*
 	 * Return if no fields were changed.
 	 */

--- a/src/box/tuple_format.h
+++ b/src/box/tuple_format.h
@@ -497,6 +497,19 @@ tuple_format_has_defaults(const struct tuple_format *format)
 	return format->default_field_count > 0;
 }
 
+/**
+ * Return true if format has at least one field with a functional default value.
+ */
+static inline bool
+tuple_format_has_default_funcs(struct tuple_format *format)
+{
+	for (size_t i = 0; i < format->default_field_count; ++i) {
+		if (tuple_field_has_default_func(tuple_format_field(format, i)))
+			return true;
+	}
+	return false;
+}
+
 typedef struct tuple_format box_tuple_format_t;
 
 /** \cond public */

--- a/test/engine-luatest/gh_9825_space_format_default_func_tuple_arg_test.lua
+++ b/test/engine-luatest/gh_9825_space_format_default_func_tuple_arg_test.lua
@@ -1,0 +1,68 @@
+local t = require('luatest')
+local g = t.group(nil, t.helpers.matrix{engine = {'memtx', 'vinyl'}})
+
+g.before_all(function(cg)
+    local server = require('luatest.server')
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+-- Test that the tuple argument passed to the `default_func` field option of
+-- `space:format` works correctly.
+g.test_space_format_default_func_tuple_arg = function(cg)
+    cg.server:exec(function(engine)
+        rawset(_G, 'test_data', {})
+
+        local nil_arg_body = [[
+            function(arg, t)
+                _G.test_data.nil_arg = arg
+                _G.test_data.nil_arg_tuple = t
+                return 5
+            end
+        ]]
+        box.schema.func.create('nil_arg',
+                               {language = 'Lua', body = nil_arg_body})
+        local test_body = [[
+            function(arg, t)
+                _G.test_data.arg = arg;
+                _G.test_data.arg_tuple = t;
+                return t[1] + t[4] + t[7]
+            end
+        ]]
+        box.schema.func.create('test', {language = 'Lua', body = test_body})
+
+        local format = {
+            {name='f1'},
+            {name='f2', type = 'string'},
+            {name='f3', default = 3},
+            {name='f4', default = 44},
+            {name='f5', default_func = 'nil_arg'},
+            {name='f6', default = 6, default_func = 'test'},
+        }
+        local opts = {engine = engine, format = format}
+        local s = box.schema.space.create('test', opts)
+        s:create_index('pk')
+
+        local source = box.tuple.new{1, 666, box.NULL, 4, box.NULL, box.NULL, 7}
+        local err_msg = "Tuple field 2 (f2) type does not match one " ..
+                        "required by operation: expected string, got unsigned"
+        t.assert_error_msg_content_equals(err_msg,
+                                          function() s:insert(source) end)
+        t.assert_equals(_G.test_data.nil_arg, nil)
+        t.assert_equals(_G.test_data.arg, 6)
+        t.assert_equals(_G.test_data.nil_arg_tuple, _G.test_data.arg_tuple)
+        -- The tuple argument is exactly the same as the source tuple.
+        t.assert_equals(_G.test_data.arg_tuple, source)
+        -- The tuple argument does not have the format dictionary.
+        t.assert_equals(_G.test_data.arg_tuple:totable(),
+                        _G.test_data.arg_tuple:tomap())
+        -- The tuple argument may not comply to the space format.
+        t.assert_not_equals(type(_G.test_data.arg_tuple[2]), 'string')
+        t.assert_equals(s:insert{1, 's', box.NULL, 4, box.NULL,  box.NULL, 7},
+                                {1, 's',        3, 4,        5, 1 + 4 + 7, 7})
+    end, {cg.params.engine})
+end


### PR DESCRIPTION
This patch adds a source tuple as a second argument to the `default_func` field option to `space:format`.

Closes #9825