### PR TITLE
bps: fix the OS X build

### DIFF
--- a/src/lib/salad/bps_tree.h
+++ b/src/lib/salad/bps_tree.h
@@ -6470,7 +6470,7 @@ bps_tree_print_inner(const struct bps_tree_common *tree,
 							block->child_ids[0]);
 #ifdef BPS_INNER_CARD
 	bps_tree_print_indent(indent);
-	printf("Cardinality: %lu\n", block->card);
+	printf("Cardinality: %lld\n", (long long)block->card);
 #endif
 	bps_tree_print_block(tree, next, indent + 1, elem_fmt);
 	for (bps_tree_pos_t i = 0; i < block->header.size - 1; i++) {


### PR DESCRIPTION
Fix the clang warning in the BPS tree with logarithmic offset support.

Closes #9987

NO_DOC=no functional changes
NO_TEST=no functional changes
NO_CHANGELOG=no functional changes