### PR TITLE
lua: set error trace to the caller place

### DIFF
--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -429,6 +429,8 @@ struct errcode_record {
 	 * XXX: Formatted strings above are for compatibility. Use only \
 	 * error message without formatters for newly added error codes. \
 	 */ \
+	_(ER_READ_VIEW_BUSY, 285,		"The read view is busy") \
+	_(ER_READ_VIEW_CLOSED, 286,		"The read view is closed") \
 	TEST_ERROR_CODES(_) /** This one should be last. */
 
 /*

--- a/src/box/lua/call.c
+++ b/src/box/lua/call.c
@@ -447,7 +447,7 @@ execute_lua_eval(lua_State *L)
 	uint32_t expr_len = ctx->name_len;
 	if (luaL_loadbuffer(L, expr, expr_len, "=eval")) {
 		diag_set(LuajitError, lua_tostring(L, -1));
-		luaT_error(L);
+		luaT_error_at(L, 0);
 	}
 
 	/* Unpack arguments */

--- a/src/box/lua/call.c
+++ b/src/box/lua/call.c
@@ -1078,7 +1078,7 @@ lbox_module_reload(lua_State *L)
 {
 	if (box_check_configured() != 0)
 		return luaT_error(L);
-	const char *name = luaL_checkstring(L, 1);
+	const char *name = luaT_checkstring(L, 1);
 	if (box_module_reload(name) != 0)
 		return luaT_error(L);
 	return 0;

--- a/src/box/lua/console.lua
+++ b/src/box/lua/console.lua
@@ -28,6 +28,7 @@ local urilib = require('uri')
 local yaml = require('yaml')
 local net_box = require('net.box')
 local help = require('help').help
+local utils = require('internal.utils')
 
 local DEFAULT_CONNECT_TIMEOUT = 10
 local PUSH_TAG_HANDLE = '!push!'
@@ -413,13 +414,6 @@ local function get_command(line)
     return nil
 end
 
---
--- return args as table with 'n' set to args number
---
-local function table_pack(...)
-    return {n = select('#', ...), ...}
-end
-
 local initial_env
 
 -- Get initial console environment.
@@ -519,7 +513,7 @@ local function local_eval(storage, line)
     end
     -- box.is_in_txn() is stubbed to throw a error before call to box.cfg{}
     local in_txn_before = ffi.C.box_txn()
-    local res = table_pack(pcall(fun))
+    local res = utils.table_pack(pcall(fun))
     --
     -- Rollback if transaction was began in the failed expression.
     --

--- a/src/box/lua/ctl.c
+++ b/src/box/lua/ctl.c
@@ -55,7 +55,7 @@ lbox_ctl_wait_ro(struct lua_State *L)
 	int index = lua_gettop(L);
 	double timeout = TIMEOUT_INFINITY;
 	if (index > 0)
-		timeout = luaL_checknumber(L, 1);
+		timeout = luaT_checknumber(L, 1);
 	if (box_wait_ro(true, timeout) != 0)
 		return luaT_error(L);
 	return 0;
@@ -67,7 +67,7 @@ lbox_ctl_wait_rw(struct lua_State *L)
 	int index = lua_gettop(L);
 	double timeout = TIMEOUT_INFINITY;
 	if (index > 0)
-		timeout = luaL_checknumber(L, 1);
+		timeout = luaT_checknumber(L, 1);
 	if (box_wait_ro(false, timeout) != 0)
 		return luaT_error(L);
 	return 0;
@@ -136,15 +136,15 @@ lbox_ctl_set_on_shutdown_timeout(struct lua_State *L)
 {
 	int index = lua_gettop(L);
 	if (index != 1) {
-		lua_pushstring(L, "function expected one argument");
-		lua_error(L);
+		diag_set(IllegalParams, "function expected one argument");
+		luaT_error(L);
 	}
 
-	double wait_time = luaL_checknumber(L, 1);
+	double wait_time = luaT_checknumber(L, 1);
 	if (wait_time <= 0) {
-		lua_pushstring(L, "on_shutdown timeout must be greater "
-			       "then zero");
-		lua_error(L);
+		diag_set(IllegalParams,
+			 "on_shutdown timeout must be greater then zero");
+		luaT_error(L);
 	}
 
 	on_shutdown_trigger_timeout = wait_time;
@@ -160,16 +160,18 @@ lbox_ctl_set_iproto_lockdown(struct lua_State *L)
 #if defined(ENABLE_SECURITY)
 	int index = lua_gettop(L);
 	if (index != 1 || !lua_isboolean(L, 1)) {
-		lua_pushstring(L, "function expected one boolean argument");
-		lua_error(L);
+		diag_set(IllegalParams,
+			 "function expected one boolean argument");
+		luaT_error(L);
 	}
 	bool new_val = lua_toboolean(L, 1);
 	if (security_set_iproto_lockdown(new_val) != 0)
 		return luaT_error(L);
 #else
-	lua_pushstring(L, "box.ctl.iproto_lockdown() is available only in "
-		       "Enterprise Edition builds.");
-	lua_error(L);
+	diag_set(IllegalParams,
+		 "box.ctl.iproto_lockdown() is available only in "
+		 "Enterprise Edition builds.");
+	luaT_error(L);
 #endif
 	return 0;
 }

--- a/src/box/lua/index.c
+++ b/src/box/lua/index.c
@@ -47,8 +47,10 @@ static uint32_t CTID_STRUCT_ITERATOR_PTR = 0;
 static int
 lbox_insert(lua_State *L)
 {
-	if (lua_gettop(L) != 2 || !lua_isnumber(L, 1))
-		return luaL_error(L, "Usage space:insert(tuple)");
+	if (lua_gettop(L) != 2 || !lua_isnumber(L, 1)) {
+		diag_set(IllegalParams, "Usage: space:insert(tuple)");
+		return luaT_error(L);
+	}
 
 	uint32_t space_id = lua_tonumber(L, 1);
 	size_t tuple_len;
@@ -66,8 +68,10 @@ lbox_insert(lua_State *L)
 static int
 lbox_replace(lua_State *L)
 {
-	if (lua_gettop(L) != 2 || !lua_isnumber(L, 1))
-		return luaL_error(L, "Usage space:replace(tuple)");
+	if (lua_gettop(L) != 2 || !lua_isnumber(L, 1)) {
+		diag_set(IllegalParams, "Usage: space:replace(tuple)");
+		return luaT_error(L);
+	}
 
 	uint32_t space_id = lua_tonumber(L, 1);
 	size_t tuple_len;
@@ -87,8 +91,10 @@ lbox_index_update(lua_State *L)
 {
 	if (lua_gettop(L) != 4 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2) ||
 	    (lua_type(L, 3) != LUA_TTABLE && luaT_istuple(L, 3) == NULL) ||
-	    (lua_type(L, 4) != LUA_TTABLE && luaT_istuple(L, 4) == NULL))
-		return luaL_error(L, "Usage index:update(key, ops)");
+	    (lua_type(L, 4) != LUA_TTABLE && luaT_istuple(L, 4) == NULL)) {
+		diag_set(IllegalParams, "Usage: index:update(key, ops)");
+		return luaT_error(L);
+	}
 
 	int rc = -1;
 	uint32_t space_id = lua_tonumber(L, 1);
@@ -116,8 +122,10 @@ lbox_upsert(lua_State *L)
 {
 	if (lua_gettop(L) != 3 || !lua_isnumber(L, 1) ||
 	    (lua_type(L, 2) != LUA_TTABLE && luaT_istuple(L, 2) == NULL) ||
-	    (lua_type(L, 3) != LUA_TTABLE && luaT_istuple(L, 3) == NULL))
-		return luaL_error(L, "Usage space:upsert(tuple_key, ops)");
+	    (lua_type(L, 3) != LUA_TTABLE && luaT_istuple(L, 3) == NULL)) {
+		diag_set(IllegalParams, "Usage: space:upsert(tuple_key, ops)");
+		return luaT_error(L);
+	}
 
 	int rc = -1;
 	uint32_t space_id = lua_tonumber(L, 1);
@@ -143,8 +151,10 @@ static int
 lbox_index_delete(lua_State *L)
 {
 	if (lua_gettop(L) != 3 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2) ||
-	    (lua_type(L, 3) != LUA_TTABLE && luaT_istuple(L, 3) == NULL))
-		return luaL_error(L, "Usage space:delete(key)");
+	    (lua_type(L, 3) != LUA_TTABLE && luaT_istuple(L, 3) == NULL)) {
+		diag_set(IllegalParams, "Usage: space:delete(key)");
+		return luaT_error(L);
+	}
 
 	uint32_t space_id = lua_tonumber(L, 1);
 	uint32_t index_id = lua_tonumber(L, 2);
@@ -164,8 +174,11 @@ static int
 lbox_index_random(lua_State *L)
 {
 	if (lua_gettop(L) != 3 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2) ||
-	    !lua_isnumber(L, 3))
-		return luaL_error(L, "Usage index.random(space_id, index_id, rnd)");
+	    !lua_isnumber(L, 3)) {
+		diag_set(IllegalParams,
+			 "Usage: index.random(space_id, index_id, rnd)");
+		return luaT_error(L);
+	}
 
 	uint32_t space_id = lua_tonumber(L, 1);
 	uint32_t index_id = lua_tonumber(L, 2);
@@ -180,8 +193,11 @@ lbox_index_random(lua_State *L)
 static int
 lbox_index_get(lua_State *L)
 {
-	if (lua_gettop(L) != 3 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2))
-		return luaL_error(L, "Usage index.get(space_id, index_id, key)");
+	if (lua_gettop(L) != 3 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2)) {
+		diag_set(IllegalParams,
+			 "Usage: index.get(space_id, index_id, key)");
+		return luaT_error(L);
+	}
 
 	uint32_t space_id = lua_tonumber(L, 1);
 	uint32_t index_id = lua_tonumber(L, 2);
@@ -200,8 +216,11 @@ lbox_index_get(lua_State *L)
 static int
 lbox_index_min(lua_State *L)
 {
-	if (lua_gettop(L) != 3 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2))
-		return luaL_error(L, "usage index.min(space_id, index_id, key)");
+	if (lua_gettop(L) != 3 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2)) {
+		diag_set(IllegalParams,
+			 "Usage: index.min(space_id, index_id, key)");
+		return luaT_error(L);
+	}
 
 	uint32_t space_id = lua_tonumber(L, 1);
 	uint32_t index_id = lua_tonumber(L, 2);
@@ -220,8 +239,11 @@ lbox_index_min(lua_State *L)
 static int
 lbox_index_max(lua_State *L)
 {
-	if (lua_gettop(L) != 3 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2))
-		return luaL_error(L, "usage index.max(space_id, index_id, key)");
+	if (lua_gettop(L) != 3 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2)) {
+		diag_set(IllegalParams,
+			 "Usage: index.max(space_id, index_id, key)");
+		return luaT_error(L);
+	}
 
 	uint32_t space_id = lua_tonumber(L, 1);
 	uint32_t index_id = lua_tonumber(L, 2);
@@ -242,8 +264,10 @@ lbox_index_count(lua_State *L)
 {
 	if (lua_gettop(L) != 4 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2) ||
 	    !lua_isnumber(L, 3)) {
-		return luaL_error(L, "usage index.count(space_id, index_id, "
-		       "iterator, key)");
+		diag_set(IllegalParams,
+			 "Usage: index.count(space_id, index_id, "
+			 "iterator, key)");
+		return luaT_error(L);
 	}
 
 	uint32_t space_id = lua_tonumber(L, 1);
@@ -280,15 +304,19 @@ box_index_init_iterator_types(struct lua_State *L, int idx)
 static int
 lbox_index_iterator(lua_State *L)
 {
-	if (lua_gettop(L) != 5 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2) ||
-	    !lua_isnumber(L, 3))
-		return luaL_error(L, "usage index.iterator(space_id, index_id, "
-				     "type, key, after)");
+	if (lua_gettop(L) != 6 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2) ||
+	    !lua_isnumber(L, 3)) {
+		diag_set(IllegalParams,
+			 "Usage: index.iterator(space_id, index_id, "
+			 "type, key, after, level)");
+		return luaT_error(L);
+	}
 
 	uint32_t svp = region_used(&fiber()->gc);
 	uint32_t space_id = lua_tonumber(L, 1);
 	uint32_t index_id = lua_tonumber(L, 2);
 	uint32_t iterator = lua_tonumber(L, 3);
+	int level = lua_tonumber(L, 6);
 	size_t mpkey_len;
 	const char *mpkey = lua_tolstring(L, 4, &mpkey_len); /* Key encoded by Lua */
 	struct iterator *it = NULL;
@@ -311,26 +339,32 @@ lbox_index_iterator(lua_State *L)
 	return 1;
 error:
 	region_truncate(&fiber()->gc, svp);
-	return luaT_error(L);
+	return luaT_error_at(L, level);
 }
 
 static int
 lbox_iterator_next(lua_State *L)
 {
 	/* first argument is key buffer */
-	if (lua_gettop(L) < 1 || lua_type(L, 1) != LUA_TCDATA)
-		return luaL_error(L, "usage: next(param, state)");
+	if (lua_gettop(L) < 1 || lua_type(L, 1) != LUA_TCDATA) {
+		diag_set(IllegalParams, "Usage: next(param, state)");
+		return luaT_error(L);
+	}
 
 	assert(CTID_STRUCT_ITERATOR_PTR != 0);
 	uint32_t ctypeid;
 	void *data = luaL_checkcdata(L, 1, &ctypeid);
-	if (ctypeid != CTID_STRUCT_ITERATOR_PTR)
-		return luaL_error(L, "usage: next(param, state)");
+	if (ctypeid != CTID_STRUCT_ITERATOR_PTR) {
+		diag_set(IllegalParams, "Usage: next(param, state)");
+		return luaT_error(L);
+	}
+	int level = lua_tonumber(L, 2);
+	assert(level > 0);
 
 	struct iterator *itr = *(struct iterator **) data;
 	struct tuple *tuple;
 	if (box_iterator_next(itr, &tuple) != 0)
-		return luaT_error(L);
+		return luaT_error_at(L, level);
 	return luaT_pushtupleornil(L, tuple);
 }
 
@@ -351,8 +385,11 @@ lbox_truncate(struct lua_State *L)
 static int
 lbox_index_stat(lua_State *L)
 {
-	if (lua_gettop(L) != 2 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2))
-		return luaL_error(L, "usage index.info(space_id, index_id)");
+	if (lua_gettop(L) != 2 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2)) {
+		diag_set(IllegalParams,
+			 "Usage: index.info(space_id, index_id)");
+		return luaT_error(L);
+	}
 
 	uint32_t space_id = lua_tonumber(L, 1);
 	uint32_t index_id = lua_tonumber(L, 2);
@@ -367,8 +404,11 @@ lbox_index_stat(lua_State *L)
 static int
 lbox_index_compact(lua_State *L)
 {
-	if (lua_gettop(L) != 2 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2))
-		return luaL_error(L, "usage index.compact(space_id, index_id)");
+	if (lua_gettop(L) != 2 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2)) {
+		diag_set(IllegalParams,
+			 "Usage: index.compact(space_id, index_id)");
+		return luaT_error(L);
+	}
 
 	uint32_t space_id = lua_tonumber(L, 1);
 	uint32_t index_id = lua_tonumber(L, 2);

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -755,9 +755,11 @@ lbox_backup_start(struct lua_State *L)
 {
 	int checkpoint_idx = 0;
 	if (lua_gettop(L) > 0) {
-		checkpoint_idx = luaL_checkint(L, 1);
-		if (checkpoint_idx < 0)
-			return luaL_error(L, "invalid checkpoint index");
+		checkpoint_idx = luaT_checkint(L, 1);
+		if (checkpoint_idx < 0) {
+			diag_set(IllegalParams, "invalid checkpoint index");
+			return luaT_error(L);
+		}
 	}
 	lua_newtable(L);
 	struct lbox_backup_arg arg = {

--- a/src/box/lua/session.c
+++ b/src/box/lua/session.c
@@ -171,11 +171,15 @@ lbox_session_su(struct lua_State *L)
 	if (box_check_configured() != 0)
 		luaT_error(L);
 	int top = lua_gettop(L);
-	if (top < 1)
-		luaL_error(L, "session.su(): bad arguments");
+	if (top < 1) {
+		diag_set(IllegalParams, "session.su(): bad arguments");
+		luaT_error(L);
+	}
 	struct session *session = current_session();
-	if (session == NULL)
-		luaL_error(L, "session.su(): session does not exist");
+	if (session == NULL) {
+		diag_set(IllegalParams, "session.su(): session does not exist");
+		luaT_error(L);
+	}
 	struct user *user;
 	if (lua_type(L, 1) == LUA_TSTRING) {
 		size_t len;
@@ -194,7 +198,7 @@ lbox_session_su(struct lua_State *L)
 		fiber_set_user(fiber(), &session->credentials);
 		return 0; /* su */
 	}
-	luaL_checktype(L, 2, LUA_TFUNCTION);
+	luaT_checktype(L, 2, LUA_TFUNCTION);
 
 	struct credentials su_credentials;
 	struct credentials *old_credentials = fiber()->storage.credentials;
@@ -218,12 +222,14 @@ lbox_session_su(struct lua_State *L)
 static int
 lbox_session_exists(struct lua_State *L)
 {
-	if (lua_gettop(L) > 1)
-		luaL_error(L, "session.exists(sid): bad arguments");
+	if (lua_gettop(L) > 1) {
+		diag_set(IllegalParams, "session.exists(sid): bad arguments");
+		luaT_error(L);
+	}
 
 	struct session *session;
 	if (lua_gettop(L) == 1)
-		session = session_find(luaL_checkint64(L, -1));
+		session = session_find(luaT_checkint64(L, -1));
 	else
 		session = current_session();
 	lua_pushboolean(L, session != NULL);
@@ -236,16 +242,20 @@ lbox_session_exists(struct lua_State *L)
 static int
 lbox_session_fd(struct lua_State *L)
 {
-	if (lua_gettop(L) > 1)
-		luaL_error(L, "session.fd(sid): bad arguments");
+	if (lua_gettop(L) > 1) {
+		diag_set(IllegalParams, "session.fd(sid): bad arguments");
+		luaT_error(L);
+	}
 
 	struct session *session;
 	if (lua_gettop(L) == 1)
-		session = session_find(luaL_checkint64(L, -1));
+		session = session_find(luaT_checkint64(L, -1));
 	else
 		session = current_session();
-	if (session == NULL)
-		luaL_error(L, "session.fd(): session does not exist");
+	if (session == NULL) {
+		diag_set(IllegalParams, "session.fd(): session does not exist");
+		luaT_error(L);
+	}
 	lua_pushinteger(L, session_fd(session));
 	return 1;
 }
@@ -257,16 +267,21 @@ lbox_session_fd(struct lua_State *L)
 static int
 lbox_session_peer(struct lua_State *L)
 {
-	if (lua_gettop(L) > 1)
-		luaL_error(L, "session.peer(sid): bad arguments");
+	if (lua_gettop(L) > 1) {
+		diag_set(IllegalParams, "session.peer(sid): bad arguments");
+		luaT_error(L);
+	}
 
 	struct session *session;
 	if (lua_gettop(L) == 1)
-		session = session_find(luaL_checkint(L, 1));
+		session = session_find(luaT_checkint(L, 1));
 	else
 		session = current_session();
-	if (session == NULL)
-		luaL_error(L, "session.peer(): session does not exist");
+	if (session == NULL) {
+		diag_set(IllegalParams,
+			 "session.peer(): session does not exist");
+		luaT_error(L);
+	}
 	const char *peer = session_peer(session);
 	if (peer == NULL) {
 		lua_pushnil(L); /* no associated peer */
@@ -341,8 +356,10 @@ static int
 lbox_session_push(struct lua_State *L)
 {
 	struct session *session = current_session();
-	if (lua_gettop(L) != 1)
-		return luaL_error(L, "Usage: box.session.push(data)");
+	if (lua_gettop(L) != 1) {
+		diag_set(IllegalParams, "Usage: box.session.push(data)");
+		luaT_error(L);
+	}
 	if (session_push_check_deprecation() != 0)
 		return luaT_error(L);
 	struct port port;

--- a/src/box/lua/session.lua
+++ b/src/box/lua/session.lua
@@ -33,13 +33,14 @@ local SESSION_NEW_OPTS = {
 
 session.new = function(opts)
     opts = opts or {}
-    utils.check_param_table(opts, SESSION_NEW_OPTS)
+    utils.check_param_table(opts, SESSION_NEW_OPTS, 2)
     if opts.type ~= nil and opts.type ~= 'binary' then
         box.error(box.error.ILLEGAL_PARAMS,
                   "invalid session type '" .. opts.type .. "', " ..
-                  "the only supported type is 'binary'")
+                  "the only supported type is 'binary'", 2)
     end
-    local sid = box.iproto.internal.session_new(opts.fd, opts.user)
+    local sid = utils.call_at(2, box.iproto.internal.session_new, opts.fd,
+                              opts.user)
     -- It's okay to set the session storage after creating the session
     -- because session_new doesn't yield so no one could possibly access
     -- the uninitialized storage yet.

--- a/src/box/lua/tuple.lua
+++ b/src/box/lua/tuple.lua
@@ -107,24 +107,24 @@ local encode_fix = msgpackffi.internal.encode_fix
 local encode_array = msgpackffi.internal.encode_array
 local encode_r = msgpackffi.internal.encode_r
 
-local tuple_encode = function(tmpbuf, obj)
+local tuple_encode = function(tmpbuf, obj, level)
     if obj == nil then
         encode_fix(tmpbuf, 0x90, 0)  -- empty array
     elseif is_tuple(obj) then
-        encode_r(tmpbuf, obj, 1)
+        encode_r(tmpbuf, obj, 1, level and level + 1)
     elseif type(obj) == "table" then
         local obj_size = #obj
         if obj_size == 0 and not rawequal(next(obj), nil) then
             -- dictionary cannot represent a tuple
-            return box.error(box.error.TUPLE_NOT_ARRAY)
+            box.error(box.error.TUPLE_NOT_ARRAY, level and level + 1)
         end
         encode_array(tmpbuf, obj_size)
         for i = 1, obj_size, 1 do
-            encode_r(tmpbuf, obj[i], 1)
+            encode_r(tmpbuf, obj[i], 1, level and level + 1)
         end
     else
         encode_fix(tmpbuf, 0x90, 1)  -- array of one element
-        encode_r(tmpbuf, obj, 1)
+        encode_r(tmpbuf, obj, 1, level and level + 1)
     end
     return tmpbuf.rpos, tmpbuf.wpos
 end

--- a/src/box/lua/tuple_format.lua
+++ b/src/box/lua/tuple_format.lua
@@ -4,6 +4,6 @@ local utils = require('internal.utils')
 -- in Lua.
 box.tuple.format.new = function(format)
     utils.check_param(format, 'format', 'table')
-    format = box.internal.space.normalize_format(nil, nil, format)
+    format = box.internal.space.normalize_format(nil, nil, format, 2)
     return box.internal.tuple_format.new(format)
 end

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -545,12 +545,6 @@ fiber_start(struct fiber *callee, ...)
 	va_end(callee->f_data);
 }
 
-bool
-fiber_checkstack(void)
-{
-	return false;
-}
-
 static void
 fiber_make_ready(struct fiber *f)
 {

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -1132,9 +1132,6 @@ fiber_check_slice(void)
 	return 0;
 }
 
-bool
-fiber_checkstack(void);
-
 /**
  * @brief yield & check for timeout
  * @return true if timeout exceeded

--- a/src/lua/digest.c
+++ b/src/lua/digest.c
@@ -84,8 +84,10 @@ crc32_methods_update(lua_State *L)
 	size_t strl;
 	/* Get <string>. */
 	const char *str = lua_tolstring(L, 2, &strl);
-	if (str == NULL)
-		luaL_error(L, "Usage crc32:update(string)");
+	if (str == NULL) {
+		diag_set(IllegalParams, "Usage: crc32:update(string)");
+		luaT_error(L);
+	}
 	/* Get <self.value>. */
 	lua_getfield(L, 1, "value");
 	uint32_t crc32_begin = lua_tointeger(L, -1);
@@ -104,8 +106,10 @@ crc32___call(lua_State *L)
 	size_t strl;
 	/* Get <string>. */
 	const char *str = lua_tolstring(L, 2, &strl);
-	if (str == NULL)
-		luaL_error(L, "Usage digest.crc32(string)");
+	if (str == NULL) {
+		diag_set(IllegalParams, "Usage: digest.crc32(string)");
+		luaT_error(L);
+	}
 	/* Get <CRC32> upvalue. */
 	lua_pushvalue(L, lua_upvalueindex(1));
 	/* Get <CRC32.crc_begin>. */

--- a/src/lua/error.c
+++ b/src/lua/error.c
@@ -54,12 +54,14 @@ luaL_iserror(struct lua_State *L, int narg)
 }
 
 struct error *
-luaL_checkerror(struct lua_State *L, int narg)
+luaT_checkerror(struct lua_State *L, int narg)
 {
 	struct error *error = luaL_iserror(L, narg);
 	if (error == NULL)  {
-		luaL_error(L, "Invalid argument #%d (error expected, got %s)",
-			   narg, lua_typename(L, lua_type(L, narg)));
+		diag_set(IllegalParams,
+			 "Invalid argument #%d (error expected, got %s)",
+			 narg, lua_typename(L, lua_type(L, narg)));
+		luaT_error(L);
 	}
 	return error;
 }
@@ -67,7 +69,7 @@ luaL_checkerror(struct lua_State *L, int narg)
 static int
 luaL_error_gc(struct lua_State *L)
 {
-	struct error *error = luaL_checkerror(L, 1);
+	struct error *error = luaT_checkerror(L, 1);
 	error_unref(error);
 	return 0;
 }

--- a/src/lua/error.h
+++ b/src/lua/error.h
@@ -82,8 +82,15 @@ luaT_pusherror(struct lua_State *L, struct error *e);
 struct error *
 luaL_iserror(struct lua_State *L, int narg);
 
+/**
+ * Return argument on stack converted to struct error if it is box error.
+ * Otherwise raise error.
+ *
+ * @param narg argument position on stack
+ * @return argument converted
+ */
 struct error *
-luaL_checkerror(struct lua_State *L, int narg);
+luaT_checkerror(struct lua_State *L, int narg);
 
 void
 tarantool_lua_error_init(struct lua_State *L);

--- a/src/lua/error.h
+++ b/src/lua/error.h
@@ -43,12 +43,22 @@ extern uint32_t CTID_CONST_STRUCT_ERROR_REF;
 struct error;
 
 /**
- * Re-throws the last Tarantool error as a Lua object.
+ * Re-throws the last Tarantool error as a Lua object. Set trace frame
+ * of to the caller of Lua C API.
+ *
  * \sa lua_error()
  * \sa box_error_last()
  */
 LUA_API int
 luaT_error(lua_State *L);
+
+/**
+ * Same as luaT_error but set error trace frame according to given level.
+ * luaT_error same as this function with level equal to 1. If level is 0
+ * then error trace is unchanged.
+ */
+int
+luaT_error_at(lua_State *L, int level);
 
 /**
  * Return nil as the first return value and an error as the
@@ -77,6 +87,15 @@ luaL_checkerror(struct lua_State *L, int narg);
 
 void
 tarantool_lua_error_init(struct lua_State *L);
+
+/**
+ * Set the error location information (file, line) to Lua stack frame at
+ * the given level. Level 1 is the Lua function that called this function.
+ * If level is <= 0 or the function failed to get the location information,
+ * the location is cleared.
+ */
+void
+luaT_error_set_trace(lua_State *L, int level, struct error *error);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/lua/error.lua
+++ b/src/lua/error.lua
@@ -114,15 +114,15 @@ end
 local function error_set_prev(err, prev)
     -- First argument must be error.
     if not ffi.istype('struct error', err) then
-        error("Usage: error1:set_prev(error2)")
+        box.error(box.error.ILLEGAL_PARAMS,"Usage: error1:set_prev(error2)", 2)
     end
     -- Second argument must be error or nil.
     if not ffi.istype('struct error', prev) and prev ~= nil then
-        error("Usage: error1:set_prev(error2)")
+        box.error(box.error.ILLEGAL_PARAMS, "Usage: error1:set_prev(error2)", 2)
     end
     local ok = ffi.C.error_set_prev(err, prev);
     if ok ~= 0 then
-        error("Cycles are not allowed")
+        box.error(box.error.ILLEGAL_PARAMS, "Cycles are not allowed", 2)
     end
 end
 
@@ -137,7 +137,7 @@ local error_fields = {
 
 local function error_unpack(err)
     if not ffi.istype('struct error', err) then
-        error("Usage: error:unpack()")
+        box.error(box.error.ILLEGAL_PARAMS, "Usage: error:unpack()", 2)
     end
     local result = {code = err.code}
     for key, getter in pairs(error_fields)  do
@@ -162,14 +162,14 @@ end
 
 local function error_raise(err)
     if not ffi.istype('struct error', err) then
-        error("Usage: error:raise()")
+        box.error(box.error.ILLEGAL_PARAMS, "Usage: error:raise()", 2)
     end
     error(err)
 end
 
 local function error_match(err, ...)
     if not ffi.istype('struct error', err) then
-        error("Usage: error:match()")
+        box.error(box.error.ILLEGAL_PARAMS, "Usage: error:match()", 2)
     end
     return string.match(error_message(err), ...)
 end
@@ -251,7 +251,8 @@ local function error_concat(lhs, rhs)
     elseif ffi.istype('struct error', rhs) then
         return lhs .. tostring(rhs)
     else
-       error('error_mt.__concat(): neither of args is an error')
+       box.error(box.error.ILLEGAL_PARAMS,
+                 'error_mt.__concat(): neither of args is an error', 2)
     end
 end
 

--- a/src/lua/init.lua
+++ b/src/lua/init.lua
@@ -144,7 +144,7 @@ end
 dostring = function(s, ...)
     local chunk, message = loadstring(s)
     if chunk == nil then
-        error(message, 2)
+        box.error(box.error.PROC_LUA, message, 2)
     end
     return chunk(...)
 end

--- a/src/lua/init.lua
+++ b/src/lua/init.lua
@@ -194,6 +194,43 @@ local function run_preload()
     end
 end
 
+--
+-- List of modules (by path) which are required to use box.error and
+-- set trace properly.
+--
+local trace_check_required_modules = {
+    ['builtin/box/schema.lua'] = true,
+    ['builtin/box/session.lua'] = true,
+    ['builtin/digest.lua'] = true,
+    ['builtin/error.lua'] = true,
+    ['builtin/tarantool.lua']= true,
+}
+
+--
+-- Return true if module with given `path` is required to use box.error
+-- to indicate error and error trace should be set the module function
+-- invocation place.
+--
+local function trace_check_is_required(path)
+    return trace_check_required_modules[path] ~= nil
+end
+
+--
+-- Raise box error with trace not pointing to the place of this function
+-- invocation.
+--
+local function raise_incorrect_trace()
+    box.error(box.error.UNKNOWN, 1)
+end
+
+--
+-- This module is expected to raise box errors only. Raise non box error
+-- for testing purpuses.
+--
+local function raise_non_box_error()
+    error('foo bar')
+end
+
 -- Extract all fields from a table except ones that start from
 -- the underscore.
 --
@@ -219,6 +256,9 @@ local tarantool_lua = {
         strip_cwd_from_path = strip_cwd_from_path,
         module_name_from_filename = module_name_from_filename,
         run_preload = run_preload,
+        trace_check_is_required = trace_check_is_required,
+        raise_incorrect_trace = raise_incorrect_trace,
+        raise_non_box_error = raise_non_box_error,
     },
 }
 -- tarantool module is already registered by src/lua/init.c

--- a/src/lua/loaders.lua
+++ b/src/lua/loaders.lua
@@ -235,7 +235,15 @@ local function gen_legacy_loader(searchers, index)
         local loaded, err = loader(data, name)
         local message = ("error loading module '%s' from file '%s':\n\t%s")
                         :format(name, data, err)
-        return assert(loaded, message)
+        if loaded then
+            return loaded
+        else
+            if _G.box and _G.box.error then
+                box.error(box.error.PROC_LUA, message, 3)
+            else
+                error(message, 3)
+            end
+        end
     end
 end
 

--- a/src/lua/utils.c
+++ b/src/lua/utils.c
@@ -278,8 +278,10 @@ void *
 luaL_checkcdata(struct lua_State *L, int idx, uint32_t *ctypeid)
 {
 	void *cdata = luaL_tocpointer(L, idx, ctypeid);
-	if (cdata == NULL)
-		luaL_error(L, "expected cdata as %d argument", idx);
+	if (cdata == NULL) {
+		diag_set(IllegalParams, "expected cdata as %d argument", idx);
+		luaT_error(L);
+	}
 	return cdata;
 }
 

--- a/src/lua/utils.c
+++ b/src/lua/utils.c
@@ -1135,3 +1135,95 @@ void cord_on_yield(void)
 		exit(EXIT_FAILURE);
 	}
 }
+
+const char *
+luaT_checkstring(struct lua_State *L, int index)
+{
+	const char *name = lua_tostring(L, index);
+	if (name == NULL) {
+		diag_set(IllegalParams, "expected string as %d argument",
+			 index);
+		luaT_error(L);
+	}
+	return name;
+}
+
+const char *
+luaT_checklstring(struct lua_State *L, int index, size_t *len)
+{
+	const char *name = lua_tolstring(L, index, len);
+	if (name == NULL) {
+		diag_set(IllegalParams, "expected string as %d argument",
+			 index);
+		luaT_error(L);
+	}
+	return name;
+}
+
+int
+luaT_checkint(struct lua_State *L, int index)
+{
+	int ok;
+	int i = lua_tointegerx(L, index, &ok);
+	if (!ok) {
+		diag_set(IllegalParams, "expected integer as %d argument",
+			 index);
+		luaT_error(L);
+	}
+	return i;
+}
+
+double
+luaT_checknumber(struct lua_State *L, int index)
+{
+	int ok;
+	double d = lua_tonumberx(L, index, &ok);
+	if (!ok) {
+		diag_set(IllegalParams, "expected number as %d argument",
+			 index);
+		luaT_error(L);
+	}
+	return d;
+}
+
+void *
+luaT_checkudata(struct lua_State *L, int index, const char *name)
+{
+	void *udata = luaL_testudata(L, index, name);
+	if (udata == NULL) {
+		diag_set(IllegalParams, "expected %s as %d argument",
+			 name, index);
+		luaT_error(L);
+	}
+	return udata;
+}
+
+void
+luaT_checktype(struct lua_State *L, int index, int expected)
+{
+	int actual = lua_type(L, index);
+	if (actual != expected) {
+		diag_set(IllegalParams, "expected %s as %d argument",
+			 lua_typename(L, expected), index);
+		luaT_error(L);
+	}
+}
+
+int64_t
+luaT_checkint64(struct lua_State *L, int idx)
+{
+	int64_t result;
+	if (luaL_convertint64(L, idx, false, &result) != 0) {
+		diag_set(IllegalParams, "expected int64_t as %d argument", idx);
+		luaT_error(L);
+	}
+	return result;
+}
+
+int
+luaT_optint(struct lua_State *L, int index, int deflt)
+{
+	if (lua_isnoneornil(L, index))
+		return deflt;
+	return luaT_checkint(L, index);
+}

--- a/src/lua/utils.h
+++ b/src/lua/utils.h
@@ -54,6 +54,8 @@ extern "C" {
 #include <lj_meta.h>
 
 #include "lua/error.h"
+#include "error.h"
+#include "diag.h"
 
 struct lua_State;
 struct ibuf;
@@ -576,6 +578,38 @@ void luaL_iterator_delete(struct luaL_iterator *it);
 
 int
 tarantool_lua_utils_init(struct lua_State *L);
+
+/** Same as luaL_checkstring but raises box error. **/
+const char *
+luaT_checkstring(struct lua_State *L, int index);
+
+/** Same as luaL_checklstring but raises box error. **/
+const char *
+luaT_checklstring(struct lua_State *L, int index, size_t *len);
+
+/** Same as luaL_checkint but raises box error. **/
+int
+luaT_checkint(struct lua_State *L, int index);
+
+/** Same as luaL_checknumber but raises box error. **/
+double
+luaT_checknumber(struct lua_State *L, int index);
+
+/** Same as luaL_checkudata but raises box error. **/
+void *
+luaT_checkudata(struct lua_State *L, int index, const char *name);
+
+/** Same as luaL_checktype but raises box error. **/
+void
+luaT_checktype(struct lua_State *L, int index, int expected);
+
+/** Same as luaL_checkint64 but raises box error. **/
+int64_t
+luaT_checkint64(struct lua_State *L, int idx);
+
+/** Same as luaL_optint but raises box error. **/
+int
+luaT_optint(struct lua_State *L, int index, int deflt);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/lua/utils.lua
+++ b/src/lua/utils.lua
@@ -18,10 +18,11 @@ end
  Calls box.error(box.error.ILLEGAL_PARAMS, ) on error
  @example: check_param(user, 'user', 'string')
 --]]
-function utils.check_param(param, name, should_be_type)
+function utils.check_param(param, name, should_be_type, level)
     if param_type(param) ~= should_be_type then
         box.error(box.error.ILLEGAL_PARAMS,
-                  name .. " should be a " .. should_be_type)
+                  name .. " should be a " .. should_be_type,
+                  level and level + 1)
     end
 end
 
@@ -49,24 +50,25 @@ end
                                 return true
                               end} )
 --]]
-function utils.check_param_table(table, template)
+function utils.check_param_table(table, template, level)
     if table == nil then
         return
     end
     if type(table) ~= 'table' then
         box.error(box.error.ILLEGAL_PARAMS,
-                  "options should be a table")
+                  "options should be a table", level and level + 1)
     end
     for k,v in pairs(table) do
         if template[k] == nil then
             box.error(box.error.ILLEGAL_PARAMS,
-                      "unexpected option '" .. k .. "'")
+                      "unexpected option '" .. k .. "'", level and level + 1)
         elseif type(template[k]) == 'function' then
-            local res, expected_type = template[k](v)
+            local res, expected_type = template[k](v, level and level + 1)
             if not res then
                 box.error(box.error.ILLEGAL_PARAMS,
                           "options parameter '" .. k ..
-                          "' should be of type " .. expected_type)
+                          "' should be of type " .. expected_type,
+                          level and level + 1)
             end
         elseif template[k] == 'any' then -- luacheck: ignore
             -- any type is ok
@@ -75,7 +77,8 @@ function utils.check_param_table(table, template)
             if param_type(v) ~= template[k] then
                 box.error(box.error.ILLEGAL_PARAMS,
                           "options parameter '" .. k ..
-                          "' should be of type " .. template[k])
+                          "' should be of type " .. template[k],
+                          level and level + 1)
             end
         else
             local good_types = string.gsub(template[k], ' ', '')
@@ -84,7 +87,8 @@ function utils.check_param_table(table, template)
             if (string.find(haystack, needle) == nil) then
                 box.error(box.error.ILLEGAL_PARAMS,
                           "options parameter '" .. k ..
-                          "' should be one of types: " .. template[k])
+                          "' should be one of types: " .. template[k],
+                          level and level + 1)
             end
         end
     end
@@ -145,9 +149,9 @@ else
 end
 
 --[[ Throw an error, if box is unconfigured. --]]
-function utils.box_check_configured()
+function utils.box_check_configured(level)
     if type(box.cfg) == 'function' then
-        box.error(box.error.UNCONFIGURED)
+        box.error(box.error.UNCONFIGURED, level and level + 1)
     end
 end
 

--- a/test/app-luatest/console_check_trace_test.lua
+++ b/test/app-luatest/console_check_trace_test.lua
@@ -1,0 +1,36 @@
+local console = require('console')
+local yaml = require('yaml')
+local tarantool = require('tarantool')
+
+local t = require('luatest')
+
+local g = t.group()
+
+g.test_error_check_trace = function()
+    t.skip_if(not tarantool.build.test_build, 'requires test build')
+    local err = yaml.decode(console.eval([[
+        require('tarantool')._internal.raise_incorrect_trace()
+    ]]))
+    t.assert_type(err, 'table')
+    t.assert_type(err[1], 'table')
+    t.assert_type(err[1].error, 'table')
+    err = err[1].error
+    t.assert_type(err[3], 'table')
+    t.assert_type(err[3].line, 'number')
+    err[3].line = nil
+    t.assert_equals(err, {
+        'Unknown error',
+        'Warning, unexpected trace',
+        {file = 'builtin/tarantool.lua'},
+    })
+
+    local err = yaml.decode(console.eval([[
+        require('tarantool')._internal.raise_non_box_error()
+    ]]))
+    t.assert_type(err, 'table')
+    t.assert_type(err[1], 'table')
+    t.assert_type(err[1].error, 'table')
+    err = err[1].error
+    t.assert_str_matches(err[1], 'builtin/tarantool.lua:%d+: foo bar')
+    t.assert_equals(err[2], 'Warning, box error expected')
+end

--- a/test/app-luatest/gh_7489_concurrent_fiber_join_test.lua
+++ b/test/app-luatest/gh_7489_concurrent_fiber_join_test.lua
@@ -61,7 +61,7 @@ g2.test_concurrent_fiber_join = function()
        -- 6. This join should raise an error, because f1 should be already
        -- joined by the first joiner.
        -- In case of a bug, it may hang trying to join f2 instead of f1
-       return not st and err == error_message
+       return not st and tostring(err) == error_message
     end
     -- 1. Create two joiners and one joinee fibers, but do not start them
     local j1 = fiber.new(joiner_f1)

--- a/test/app-luatest/utils_test.lua
+++ b/test/app-luatest/utils_test.lua
@@ -65,3 +65,67 @@ g.test_update_param_table = function()
         c = 'y',
     })
 end
+
+g.test_is_callable = function()
+    t.assert(utils.is_callable(function() end))
+    local functor = setmetatable({}, {
+        __call = function() end
+    })
+    t.assert(utils.is_callable(functor))
+    t.assert_not(utils.is_callable(1))
+    t.assert_not(utils.is_callable("foo"))
+end
+
+g.test_table_pack = function()
+    t.assert_equals(utils.table_pack(), {n = 0})
+    t.assert_equals(utils.table_pack(1), {n = 1, 1})
+    t.assert_equals(utils.table_pack(1, 2), {n = 2, 1, 2})
+    t.assert_equals(utils.table_pack(1, 2, nil), {n = 3, 1, 2})
+    t.assert_equals(utils.table_pack(1, 2, nil, 3), {n = 4, 1, 2, nil, 3})
+end
+
+g.test_call_at = function()
+    local f = function(...) return ... end
+    t.assert_equals(utils.call_at(1, f, nil))
+    t.assert_equals(utils.call_at(1, f, 1), 1)
+    t.assert_equals(utils.table_pack(utils.call_at(1, f, 1, 2)),
+                    utils.table_pack(1, 2))
+    t.assert_equals(utils.table_pack(utils.call_at(1, f, 1, 2, nil)),
+                    utils.table_pack(1, 2, nil))
+    t.assert_equals(utils.table_pack(utils.call_at(1, f, 1, 2, nil, 3)),
+                    utils.table_pack(1, 2, nil, 3))
+
+    local this_file = debug.getinfo(1, 'S').short_src
+    local line1 = debug.getinfo(1, 'l').currentline + 1
+    local f1 = function() box.error(box.error.UNKNOWN, 1) end
+    local line2 = debug.getinfo(1, 'l').currentline + 1
+    local f2 = function(level, ...) utils.call_at(level, f1, ...) end
+    local line3 = debug.getinfo(1, 'l').currentline + 1
+    local f3 = function(...) f2(...) end
+
+    local check_box_error = function(level, line)
+        local ok, err = pcall(f3, level)
+        t.assert_not(ok)
+        t.assert(box.error.is(err))
+        t.assert_equals(err.trace[1].file, this_file)
+        t.assert_equals(err.trace[1].line, line)
+    end
+
+    check_box_error(nil, line1)
+    check_box_error(1, line2)
+    check_box_error(2, line3)
+
+    line1 = debug.getinfo(1, 'l').currentline + 1
+    f1 = function() error('foo', 1) end
+
+    local check_box_error = function(level, line_src, line_level)
+        local ok, err = pcall(f3, level)
+        t.assert_not(ok)
+        t.assert_equals(tostring(err),
+                        string.format('%s:%s: %s:%s: foo',
+                        this_file, line_level, this_file, line_src))
+    end
+
+    check_box_error(1, line1, line2)
+    check_box_error(2, line1, line3)
+end

--- a/test/app/digest.result
+++ b/test/app/digest.result
@@ -48,31 +48,31 @@ digest.sha512()
 ...
 digest.md4_hex()
 ---
-- error: 'builtin/digest.lua:<line>"]: Usage: digest.md4_hex(string)'
+- error: 'Usage: digest.md4_hex(string)'
 ...
 digest.md5_hex()
 ---
-- error: 'builtin/digest.lua:<line>"]: Usage: digest.md5_hex(string)'
+- error: 'Usage: digest.md5_hex(string)'
 ...
 digest.sha1_hex()
 ---
-- error: 'builtin/digest.lua:<line>"]: Usage: digest.sha1_hex(string)'
+- error: 'Usage: digest.sha1_hex(string)'
 ...
 digest.sha224_hex()
 ---
-- error: 'builtin/digest.lua:<line>"]: Usage: digest.sha224_hex(string)'
+- error: 'Usage: digest.sha224_hex(string)'
 ...
 digest.sha256_hex()
 ---
-- error: 'builtin/digest.lua:<line>"]: Usage: digest.sha256_hex(string)'
+- error: 'Usage: digest.sha256_hex(string)'
 ...
 digest.sha384_hex()
 ---
-- error: 'builtin/digest.lua:<line>"]: Usage: digest.sha384_hex(string)'
+- error: 'Usage: digest.sha384_hex(string)'
 ...
 digest.sha512_hex()
 ---
-- error: 'builtin/digest.lua:<line>"]: Usage: digest.sha512_hex(string)'
+- error: 'Usage: digest.sha512_hex(string)'
 ...
 --
 -- gh-1561: Bad checksum on non-string types
@@ -225,7 +225,7 @@ digest.sha512_hex('tarantool')
 ...
 digest.md5_hex(123)
 ---
-- error: 'builtin/digest.lua:<line>"]: Usage: digest.md5_hex(string)'
+- error: 'Usage: digest.md5_hex(string)'
 ...
 digest.md5_hex('123')
 ---
@@ -233,7 +233,7 @@ digest.md5_hex('123')
 ...
 digest.md5_hex(true)
 ---
-- error: 'builtin/digest.lua:<line>"]: Usage: digest.md5_hex(string)'
+- error: 'Usage: digest.md5_hex(string)'
 ...
 digest.md5_hex('true')
 ---
@@ -241,15 +241,15 @@ digest.md5_hex('true')
 ...
 digest.md5_hex(nil)
 ---
-- error: 'builtin/digest.lua:<line>"]: Usage: digest.md5_hex(string)'
+- error: 'Usage: digest.md5_hex(string)'
 ...
 digest.md5_hex()
 ---
-- error: 'builtin/digest.lua:<line>"]: Usage: digest.md5_hex(string)'
+- error: 'Usage: digest.md5_hex(string)'
 ...
 digest.crc32()
 ---
-- error: Usage digest.crc32(string)
+- error: 'Usage: digest.crc32(string)'
 ...
 digest.crc32_update(4294967295, '')
 ---
@@ -339,27 +339,27 @@ digest.base64_decode(b) == s
 ...
 digest.base64_decode(nil)
 ---
-- error: 'builtin/digest.lua:<line>"]: Usage: digest.base64_decode(string)'
+- error: 'Usage: digest.base64_decode(string)'
 ...
 digest.base64_encode(nil)
 ---
-- error: 'builtin/digest.lua:<line>"]: Usage: digest.base64_encode(string[, table])'
+- error: 'Usage: digest.base64_encode(string[, table])'
 ...
 digest.base64_encode(123)
 ---
-- error: 'builtin/digest.lua:<line>"]: Usage: digest.base64_encode(string[, table])'
+- error: 'Usage: digest.base64_encode(string[, table])'
 ...
 digest.base64_decode(123)
 ---
-- error: 'builtin/digest.lua:<line>"]: Usage: digest.base64_decode(string)'
+- error: 'Usage: digest.base64_decode(string)'
 ...
 digest.guava('hello', 0)
 ---
-- error: 'bad argument #1 to ''?'' (cannot convert ''string'' to ''uint64_t'')'
+- error: state should be a number
 ...
 digest.guava(1, 'nope_')
 ---
-- error: 'bad argument #2 to ''?'' (cannot convert ''string'' to ''int'')'
+- error: buckets should be a number
 ...
 digest.guava(10863919174838991, 11)
 ---
@@ -375,7 +375,7 @@ digest.guava(1673758223894951030, 11)
 ...
 digest.urandom()
 ---
-- error: 'builtin/digest.lua:<line>"]: Usage: digest.urandom(len)'
+- error: 'Usage: digest.urandom(len)'
 ...
 #digest.urandom(0)
 ---
@@ -655,19 +655,19 @@ digest.xxhash64.new(1):result()
 -- String is expected as input value.
 digest.xxhash32(1)
 ---
-- error: Usage digest.xxhash32(string[, unsigned number])
+- error: 'Usage: digest.xxhash32(string[, unsigned number])'
 ...
 digest.xxhash64(1)
 ---
-- error: Usage digest.xxhash64(string[, unsigned number])
+- error: 'Usage: digest.xxhash64(string[, unsigned number])'
 ...
 digest.xxhash32.new():update(1)
 ---
-- error: Usage xxhash32:update(string)
+- error: 'Usage: xxhash32:update(string)'
 ...
 digest.xxhash64.new():update(1)
 ---
-- error: Usage xxhash64:update(string)
+- error: 'Usage: xxhash64:update(string)'
 ...
 -- Seed is an optional second argument (default = 0).
 digest.xxhash32('12345')

--- a/test/app/fiber.result
+++ b/test/app/fiber.result
@@ -288,7 +288,7 @@ fiber.find(920)
 ...
 fiber.find()
 ---
-- error: 'fiber.find(id): bad arguments'
+- error: 'Usage: fiber.find(id)'
 ...
 fiber.find('test')
 ---
@@ -417,11 +417,11 @@ fiber.sleep(0.0001)
 ...
 fiber.sleep('hello')
 ---
-- error: 'fiber.sleep(delay): bad arguments'
+- error: 'Usage: fiber.sleep(delay)'
 ...
 fiber.sleep(box, 0.001)
 ---
-- error: 'fiber.sleep(delay): bad arguments'
+- error: 'Usage: fiber.sleep(delay)'
 ...
 -- test fiber.self()
 f = fiber.self()
@@ -448,8 +448,7 @@ f==g
 -- arguments to fiber.create
 f = fiber.create(print('hello'))
 ---
-- error: '[string "f = fiber.create(print(''hello'')) "]:1: fiber.create(function,
-    ...): bad arguments'
+- error: 'fiber.create(function, ...): bad arguments'
 ...
 -- test passing arguments in and out created fiber
 res = {}
@@ -502,15 +501,15 @@ res
 --  test fiber.status functions: invalid arguments
 fiber.status(1)
 ---
-- error: 'bad argument #1 to ''?'' (fiber expected, got number)'
+- error: expected fiber as 1 argument
 ...
 fiber.status('fafa-gaga')
 ---
-- error: 'bad argument #1 to ''?'' (fiber expected, got string)'
+- error: expected fiber as 1 argument
 ...
 fiber.status(nil)
 ---
-- error: 'bad argument #1 to ''?'' (fiber expected, got nil)'
+- error: expected fiber as 1 argument
 ...
 -- test fiber.cancel
 function r() fiber.sleep(1000) end
@@ -678,7 +677,7 @@ fiber.self().storage.key -- our local storage is not affected by f
 pcall(function(f) return f.storage end, f)
 ---
 - false
-- '[string "return pcall(function(f) return f.storage end..."]:1: the fiber is dead'
+- the fiber is dead
 ...
 --
 -- Test that local storage is garbage collected when fiber is died

--- a/test/app/fiber_cond.result
+++ b/test/app/fiber_cond.result
@@ -12,11 +12,11 @@ tostring(c)
 -- args validation
 c.wait()
 ---
-- error: 'usage: cond:wait([timeout])'
+- error: 'Usage: cond:wait([timeout])'
 ...
 c.wait('1')
 ---
-- error: 'bad argument #1 to ''?'' (fiber.cond expected, got string)'
+- error: 'Usage: cond:wait([timeout])'
 ...
 c:wait('1')
 ---
@@ -24,7 +24,7 @@ c:wait('1')
 ...
 c:wait(-1)
 ---
-- error: 'usage: cond:wait([timeout])'
+- error: 'Usage: cond:wait([timeout])'
 ...
 -- timeout
 c:wait(0.1)

--- a/test/app/pack.result
+++ b/test/app/pack.result
@@ -4,7 +4,7 @@ pickle = require('pickle')
 ...
 pickle.pack()
 ---
-- error: 'bad argument #1 to ''?'' (string expected, got no value)'
+- error: expected string as 1 argument
 ...
 pickle.pack(1)
 ---

--- a/test/box-luatest/box_cfg_env_test.lua
+++ b/test/box-luatest/box_cfg_env_test.lua
@@ -166,11 +166,7 @@ g.test_uri_list = function(g)
 
     local opts = {nojson = true, stderr = true}
     local res = justrun.tarantool(dir, {}, {'main.lua'}, opts)
-    t.assert_equals(res, {
-        exit_code = 0,
-        stdout = '',
-        stderr = '',
-    })
+    t.assert_equals(res.exit_code, 0, {res.stdout, res.stderr})
 end
 
 -- These test cases use a real box.cfg() call inside a child

--- a/test/box-luatest/box_read_ffi_disable_test.lua
+++ b/test/box-luatest/box_read_ffi_disable_test.lua
@@ -29,7 +29,7 @@ end)
 g.test_min = function(cg)
     cg.server:exec(function()
         local s = box.space.test
-        t.assert_error_msg_content_equals(
+        t.assert_error_msg_equals(
             "Use index:min(...) instead of index.min(...)",
             s.index.primary.min)
         t.assert_equals(s.index.primary:min(), {1, 1})
@@ -42,7 +42,7 @@ end
 g.test_max = function(cg)
     cg.server:exec(function()
         local s = box.space.test
-        t.assert_error_msg_content_equals(
+        t.assert_error_msg_equals(
             "Use index:max(...) instead of index.max(...)",
             s.index.primary.max)
         t.assert_equals(s.index.primary:max(), {10, 1})
@@ -55,7 +55,7 @@ end
 g.test_random = function(cg)
     cg.server:exec(function()
         local s = box.space.test
-        t.assert_error_msg_content_equals(
+        t.assert_error_msg_equals(
             "Use index:random(...) instead of index.random(...)",
             s.index.primary.random)
         t.assert_equals(s.index.primary:random(1), {2, 5})
@@ -68,13 +68,13 @@ end
 g.test_get = function(cg)
     cg.server:exec(function()
         local s = box.space.test
-        t.assert_error_msg_content_equals(
+        t.assert_error_msg_equals(
             "Use index:get(...) instead of index.get(...)",
             s.index.primary.get)
-        t.assert_error_msg_content_equals(
+        t.assert_error_msg_equals(
             "Invalid key part count in an exact match (expected 1, got 0)",
             s.index.primary.get, s.index.primary)
-        t.assert_error_msg_content_equals(
+        t.assert_error_msg_equals(
             "Get() doesn't support partial keys and non-unique indexes",
             s.index.secondary.get, s.index.secondary, 1)
         t.assert_equals(s:get(1), {1, 1})
@@ -85,10 +85,10 @@ end
 g.test_select = function(cg)
     cg.server:exec(function()
         local s = box.space.test
-        t.assert_error_msg_content_equals(
+        t.assert_error_msg_equals(
             "Use index:select(...) instead of index.select(...)",
             s.index.primary.select)
-        t.assert_error_msg_content_equals(
+        t.assert_error_msg_equals(
             "Unknown iterator type 'foo'",
             s.index.primary.select, s.index.primary,  {}, {iterator = 'foo'})
         t.assert_equals(s:select(2, {iterator = 'lt'}), {{1, 1}})
@@ -101,14 +101,15 @@ g.test_pairs = function(cg)
     cg.server:exec(function()
         local fun = require('fun')
         local s = box.space.test
-        t.assert_error_msg_content_equals(
+        t.assert_error_msg_equals(
             "Use index:pairs(...) instead of index.pairs(...)",
             s.index.primary.pairs)
-        t.assert_error_msg_content_equals(
+        t.assert_error_msg_equals(
             "Unknown iterator type 'foo'",
             s.index.primary.pairs, s.index.primary,  {}, {iterator = 'foo'})
         local gen = s.index.secondary:pairs(2)
-        t.assert_error_msg_content_equals("usage: next(param, state)", gen)
+        t.assert_error_msg_equals(
+            "Usage: next(param, state)", gen)
         t.assert_equals(fun.totable(s:pairs(2, {iterator = 'lt'})), {{1, 1}})
         t.assert_equals(fun.totable(s.index.primary:pairs(1)), {{1, 1}})
         t.assert_equals(fun.totable(s.index.secondary:pairs(1)),

--- a/test/box-luatest/box_schema_before_box_cfg_test.lua
+++ b/test/box-luatest/box_schema_before_box_cfg_test.lua
@@ -67,6 +67,5 @@ g.test_box_schema_before_box_cfg = function()
 
     local opts = {nojson = true, stderr = true}
     local res = justrun.tarantool(dir, {}, {'main.lua'}, opts)
-    t.assert_equals(res.stderr, "")
-    t.assert_equals(res.exit_code, 0)
+    t.assert_equals(res.exit_code, 0, {res.stdout, res.stderr})
 end

--- a/test/box-luatest/error_subsystem_improvements_test.lua
+++ b/test/box-luatest/error_subsystem_improvements_test.lua
@@ -1084,3 +1084,10 @@ g.after_test('test_netbox_call_trace', function(cg)
         end
     end)
 end)
+
+g.test_trace_checked = function()
+   local st, res = pcall(t.assert_error,
+                         tarantool._internal.raise_incorrect_trace)
+   t.assert(not st)
+   t.assert_str_contains(res.message, 'Unexpected error trace');
+end

--- a/test/box-luatest/gh_6819_iproto_watch_not_implemented_test.lua
+++ b/test/box-luatest/gh_6819_iproto_watch_not_implemented_test.lua
@@ -71,7 +71,7 @@ g.test_iproto_watch_reported_but_not_implemented = function()
     g.server:exec(function(err_count_1)
         t.helpers.retrying({}, function()
             local err_count_2 = box.stat.ERROR.total
-            t.assert_equals(err_count_2 - err_count_1, 3)
+            t.assert_equals(err_count_2 - err_count_1, 4)
         end)
     end, {err_count_1})
     conn:close()

--- a/test/box-luatest/gh_7202_options_in_atomic_test.lua
+++ b/test/box-luatest/gh_7202_options_in_atomic_test.lua
@@ -58,17 +58,17 @@ g.test_atomic_options = function()
             "(keys or values)",
             box.atomic, {txn_isolation = 'wtf'}, f)
 
-        t.assert_error_msg_contains(
-            "attempt to call a nil value",
+        t.assert_error_msg_equals(
+            "Usage: box.atomic([opts, ]tx-function[, function-arguments]",
             box.atomic, {})
 
         -- Different invalid function objects
-        t.assert_error_msg_contains(
-            "attempt to call a table value",
+        t.assert_error_msg_equals(
+            "Usage: box.atomic([opts, ]tx-function[, function-arguments]",
             box.atomic, {}, {})
 
-        t.assert_error_msg_contains(
-            "attempt to call a nil value",
-            box.atomic, {})
+        t.assert_error_msg_equals(
+            "Usage: box.atomic([opts, ]tx-function[, function-arguments]",
+            box.atomic, {}, 7)
     end)
 end

--- a/test/box-luatest/gh_8260_system_read_view_list_test.lua
+++ b/test/box-luatest/gh_8260_system_read_view_list_test.lua
@@ -29,8 +29,7 @@ g_object.test_usage = function(cg)
     cg.server:exec(function()
         local rv = rawget(_G, 'test_rv')
         t.assert_error_msg_equals(
-            'Use read_view:info(...) instead of read_view.info(...)',
-            rv.info)
+            'Use read_view:info(...) instead of read_view.info(...)', rv.info)
         t.assert_error_msg_equals(
             'Use read_view:close(...) instead of read_view.close(...)',
             rv.close)
@@ -161,10 +160,10 @@ g_status.test_close = function(cg)
         local l = box.read_view.list()
         t.assert_equals(#l, 1)
         local rv = l[1]
-        t.assert_error_msg_equals('read view is busy', rv.close, rv)
+        t.assert_error_msg_equals('The read view is busy', rv.close, rv)
         box.error.injection.set('ERRINJ_SNAP_WRITE_DELAY', false)
         t.assert(f:join())
-        t.assert_error_msg_equals('read view is closed', rv.close, rv)
+        t.assert_error_msg_equals('The read view is closed', rv.close, rv)
     end)
 end
 

--- a/test/box-tap/session.test.lua
+++ b/test/box-tap/session.test.lua
@@ -24,7 +24,7 @@ test:ok(session.exists(session.id()), "session is created")
 test:isnil(session.peer(session.id()), "session.peer")
 test:ok(session.exists(), "session.exists")
 local _, err = pcall(session.exists, 1, 2, 3)
-test:is(err, "session.exists(sid): bad arguments", "exists bad args #2")
+test:is(tostring(err), "session.exists(sid): bad arguments", "exists bad args #2")
 test:ok(not session.exists(1234567890), "session doesn't exist")
 
 -- check session.id()

--- a/test/box/access_bin.result
+++ b/test/box/access_bin.result
@@ -341,7 +341,7 @@ box.session.su('admin', box.session.user)
 ...
 box.session.su('admin', box.session.user())
 ---
-- error: 'bad argument #2 to ''?'' (function expected, got string)'
+- error: expected function as 2 argument
 ...
 -- cleanup
 box.session.su('admin')

--- a/test/box/alter_limits.result
+++ b/test/box/alter_limits.result
@@ -689,7 +689,7 @@ index = s:create_index('primary', { type = 'hash' })
 -- correct error on misuse of alter
 s.index.primary.alter({unique=false})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use index:alter(...) instead of index.alter(...)'
+- error: Use index:alter(...) instead of index.alter(...)
 ...
 s.index.primary:alter({unique=false})
 ---

--- a/test/box/backup.result
+++ b/test/box/backup.result
@@ -13,7 +13,7 @@ test_run:cleanup_cluster()
 -- Basic argument check.
 box.backup.start('test')
 ---
-- error: 'bad argument #1 to ''?'' (number expected, got string)'
+- error: expected integer as 1 argument
 ...
 box.backup.start(-1)
 ---

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -490,6 +490,8 @@ t;
  |   282: box.error.REPLICASET_NO_WRITABLE
  |   283: box.error.REPLICASET_MORE_THAN_ONE_WRITABLE
  |   284: box.error.TXN_COMMIT
+ |   285: box.error.READ_VIEW_BUSY
+ |   286: box.error.READ_VIEW_CLOSED
  | ...
 
 test_run:cmd("setopt delimiter ''");
@@ -523,13 +525,6 @@ box.error.set(1)
 box.error.set(nil)
  | ---
  | - error: 'Invalid argument #1 (error expected, got nil)'
- | ...
-box.error.set(box.error.last())
- | ---
- | ...
-assert(box.error.last() == err)
- | ---
- | - true
  | ...
 -- Check that box.error.new() does not set error to diag.
 --
@@ -578,7 +573,7 @@ assert(e1.prev == nil)
  | ...
 e1:set_prev(e1)
  | ---
- | - error: 'builtin/error.lua: Cycles are not allowed'
+ | - error: Cycles are not allowed
  | ...
 assert(e1.prev == nil)
  | ---
@@ -596,7 +591,7 @@ assert(e1.prev == e2)
  | ...
 e2:set_prev(e1)
  | ---
- | - error: 'builtin/error.lua: Cycles are not allowed'
+ | - error: Cycles are not allowed
  | ...
 assert(e2.prev == nil)
  | ---
@@ -725,7 +720,7 @@ assert(e3.prev == nil)
 --
 e3:set_prev(e1)
  | ---
- | - error: 'builtin/error.lua: Cycles are not allowed'
+ | - error: Cycles are not allowed
  | ...
 assert(e3.prev == nil)
  | ---
@@ -733,7 +728,7 @@ assert(e3.prev == nil)
  | ...
 e3:set_prev(e2)
  | ---
- | - error: 'builtin/error.lua: Cycles are not allowed'
+ | - error: Cycles are not allowed
  | ...
 assert(e3.prev == nil)
  | ---

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -32,7 +32,13 @@ e
  | ---
  | - foo
  | ...
-e:unpack()
+u = e:unpack()
+ | ---
+ | ...
+u.trace[1].line = nil
+ | ---
+ | ...
+u
  | ---
  | - name: ILLEGAL_PARAMS
  |   code: 0
@@ -40,8 +46,7 @@ e:unpack()
  |   type: IllegalParams
  |   message: foo
  |   trace:
- |   - file: '[C]'
- |     line: 4294967295
+ |   - file: builtin/box/console.lua
  | ...
 e.type
  | ---

--- a/test/box/error.test.lua
+++ b/test/box/error.test.lua
@@ -89,8 +89,6 @@ assert(box.error.last() == err)
 --
 box.error.set(1)
 box.error.set(nil)
-box.error.set(box.error.last())
-assert(box.error.last() == err)
 -- Check that box.error.new() does not set error to diag.
 --
 box.error.clear()

--- a/test/box/error.test.lua
+++ b/test/box/error.test.lua
@@ -9,7 +9,9 @@ box.error(box.error.ILLEGAL_PARAMS, "foo")
 box.error()
 e = box.error.last()
 e
-e:unpack()
+u = e:unpack()
+u.trace[1].line = nil
+u
 e.type
 e.code
 e.message

--- a/test/box/func_reload.result
+++ b/test/box/func_reload.result
@@ -230,7 +230,7 @@ c:call("reload.test_reload_fail")
 ...
 box.schema.func.reload()
 ---
-- error: 'bad argument #1 to ''?'' (string expected, got no value)'
+- error: expected string as 1 argument
 ...
 box.schema.func.reload("non-existing")
 ---

--- a/test/box/function1.result
+++ b/test/box/function1.result
@@ -545,11 +545,11 @@ func = box.func.divide
 ...
 func.call({4, 2})
 ---
-- error: 'builtin/box/schema.lua: Use func:call(...) instead of func.call(...)'
+- error: Use func:call(...) instead of func.call(...)
 ...
 func:call(4, 2)
 ---
-- error: 'builtin/box/schema.lua: Use func:call(table)'
+- error: 'Usage: func:call(table)'
 ...
 func:call()
 ---
@@ -595,7 +595,7 @@ func
 ...
 func.drop()
 ---
-- error: 'builtin/box/schema.lua: Use func:drop(...) instead of func.drop(...)'
+- error: Use func:drop(...) instead of func.drop(...)
 ...
 box.func.divide
 ---
@@ -621,7 +621,7 @@ func = box.func["function1.divide"]
 ...
 func:call(4, 2)
 ---
-- error: 'builtin/box/schema.lua: Use func:call(table)'
+- error: 'Usage: func:call(table)'
 ...
 func:call()
 ---

--- a/test/box/info.result
+++ b/test/box/info.result
@@ -143,11 +143,11 @@ box.info().ro == box.info.server.ro
 --
 box.ctl.wait_ro("abc") -- invalid argument
 ---
-- error: 'bad argument #1 to ''?'' (number expected, got string)'
+- error: expected number as 1 argument
 ...
 box.ctl.wait_rw("def") -- invalid argument
 ---
-- error: 'bad argument #1 to ''?'' (number expected, got string)'
+- error: expected number as 1 argument
 ...
 box.info.ro -- false
 ---

--- a/test/box/lua.result
+++ b/test/box/lua.result
@@ -429,7 +429,7 @@ space.index['i1']:count()
 -- Test cases for #123: box.index.count does not check arguments properly
 space.index['i1']:count(function() end)
 ---
-- error: 'builtin/msgpackffi.lua..."]:<line>: can not encode Lua type: ''function'''
+- error: 'can not encode Lua type: ''function'''
 ...
 space:drop()
 ---
@@ -854,143 +854,143 @@ pk = space:create_index('primary')
 ...
 space.len()
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use space:len(...) instead of space.len(...)'
+- error: Use space:len(...) instead of space.len(...)
 ...
 space.count({}, {iterator = 'EQ'})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use space:count(...) instead of space.count(...)'
+- error: Use space:count(...) instead of space.count(...)
 ...
 space.bsize()
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use space:bsize(...) instead of space.bsize(...)'
+- error: Use space:bsize(...) instead of space.bsize(...)
 ...
 space.get({1})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use space:get(...) instead of space.get(...)'
+- error: Use space:get(...) instead of space.get(...)
 ...
 space.select({}, {iterator = 'GE'})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use space:select(...) instead of space.select(...)'
+- error: Use space:select(...) instead of space.select(...)
 ...
 space.insert({1, 2, 3})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use space:insert(...) instead of space.insert(...)'
+- error: Use space:insert(...) instead of space.insert(...)
 ...
 space.replace({1, 2, 3})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use space:replace(...) instead of space.replace(...)'
+- error: Use space:replace(...) instead of space.replace(...)
 ...
 space.put({1, 2, 3})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use space:replace(...) instead of space.replace(...)'
+- error: Use space:replace(...) instead of space.replace(...)
 ...
 space.update({1}, {})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use space:update(...) instead of space.update(...)'
+- error: Use space:update(...) instead of space.update(...)
 ...
 space.upsert({1, 2, 3}, {})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use space:upsert(...) instead of space.upsert(...)'
+- error: Use space:upsert(...) instead of space.upsert(...)
 ...
 space.delete({1})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use space:delete(...) instead of space.delete(...)'
+- error: Use space:delete(...) instead of space.delete(...)
 ...
 space.auto_increment({'hello'})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use space:auto_increment(...) instead of space.auto_increment(...)'
+- error: Use space:auto_increment(...) instead of space.auto_increment(...)
 ...
 space.pairs({}, {iterator = 'EQ'})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use space:pairs(...) instead of space.pairs(...)'
+- error: Use space:pairs(...) instead of space.pairs(...)
 ...
 space.truncate()
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use space:truncate(...) instead of space.truncate(...)'
+- error: Use space:truncate(...) instead of space.truncate(...)
 ...
 space.format({})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use space:format(...) instead of space.format(...)'
+- error: Use space:format(...) instead of space.format(...)
 ...
 space.drop()
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use space:drop(...) instead of space.drop(...)'
+- error: Use space:drop(...) instead of space.drop(...)
 ...
 space.rename()
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use space:rename(...) instead of space.rename(...)'
+- error: Use space:rename(...) instead of space.rename(...)
 ...
 space.create_index('secondary')
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use space:create_index(...) instead of space.create_index(...)'
+- error: Use space:create_index(...) instead of space.create_index(...)
 ...
 space.run_triggers(false)
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use space:run_triggers(...) instead of space.run_triggers(...)'
+- error: Use space:run_triggers(...) instead of space.run_triggers(...)
 ...
 pk.len()
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use index:len(...) instead of index.len(...)'
+- error: Use index:len(...) instead of index.len(...)
 ...
 pk.bsize()
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use index:bsize(...) instead of index.bsize(...)'
+- error: Use index:bsize(...) instead of index.bsize(...)
 ...
 pk.min()
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use index:min(...) instead of index.min(...)'
+- error: Use index:min(...) instead of index.min(...)
 ...
 pk.min({})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use index:min(...) instead of index.min(...)'
+- error: Use index:min(...) instead of index.min(...)
 ...
 pk.max()
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use index:max(...) instead of index.max(...)'
+- error: Use index:max(...) instead of index.max(...)
 ...
 pk.max({})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use index:max(...) instead of index.max(...)'
+- error: Use index:max(...) instead of index.max(...)
 ...
 pk.random(42)
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use index:random(...) instead of index.random(...)'
+- error: Use index:random(...) instead of index.random(...)
 ...
 pk.pairs({}, {iterator = 'EQ'})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use index:pairs(...) instead of index.pairs(...)'
+- error: Use index:pairs(...) instead of index.pairs(...)
 ...
 pk.count({}, {iterator = 'EQ'})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use index:count(...) instead of index.count(...)'
+- error: Use index:count(...) instead of index.count(...)
 ...
 pk.get({1})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use index:get(...) instead of index.get(...)'
+- error: Use index:get(...) instead of index.get(...)
 ...
 pk.select({}, {iterator = 'GE'})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use index:select(...) instead of index.select(...)'
+- error: Use index:select(...) instead of index.select(...)
 ...
 pk.update({1}, {})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use index:update(...) instead of index.update(...)'
+- error: Use index:update(...) instead of index.update(...)
 ...
 pk.delete({1})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use index:delete(...) instead of index.delete(...)'
+- error: Use index:delete(...) instead of index.delete(...)
 ...
 pk.drop()
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use index:drop(...) instead of index.drop(...)'
+- error: Use index:drop(...) instead of index.drop(...)
 ...
 pk.rename("newname")
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use index:rename(...) instead of index.rename(...)'
+- error: Use index:rename(...) instead of index.rename(...)
 ...
 pk.alter({})
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use index:alter(...) instead of index.alter(...)'
+- error: Use index:alter(...) instead of index.alter(...)
 ...
 space:drop()
 ---

--- a/test/box/misc.result
+++ b/test/box/misc.result
@@ -293,7 +293,7 @@ tonumber64(1), 1
 -- Testing 64bit
 tonumber64()
 ---
-- error: 'bad argument #1 to ''?'' (value expected)'
+- error: 'Usage: tonumber64(arg)'
 ...
 tonumber64('invalid number')
 ---
@@ -473,15 +473,15 @@ tonumber64('  0b1  ') == 1
 ...
 tonumber64('  0b1  ', 'badbase')
 ---
-- error: 'bad argument #2 to ''?'' (number expected, got string)'
+- error: expected integer as 2 argument
 ...
 tonumber64('  0b1  ', 123) -- big base
 ---
-- error: 'bad argument #2 to ''?'' (base out of range)'
+- error: invalid argument 2, base out of range
 ...
 tonumber64('12345', 123) -- big base
 ---
-- error: 'bad argument #2 to ''?'' (base out of range)'
+- error: invalid argument 2, base out of range
 ...
 tonumber64('0xfffff') == 1048575
 ---
@@ -619,87 +619,87 @@ tonumber64(ffi.new('double', 10))
 -- number/cdata with custom `base` - is not supported
 tonumber64(100, 2)
 ---
-- error: 'bad argument #1 to ''?'' (string expected)'
+- error: argument 1 is not a string
 ...
 tonumber64(100LL, 2)
 ---
-- error: 'bad argument #1 to ''?'' (string expected)'
+- error: argument 1 is not a string
 ...
 tonumber64(-100LL, 2)
 ---
-- error: 'bad argument #1 to ''?'' (string expected)'
+- error: argument 1 is not a string
 ...
 tonumber64(100ULL, 2)
 ---
-- error: 'bad argument #1 to ''?'' (string expected)'
+- error: argument 1 is not a string
 ...
 tonumber64(ffi.new('char', 10), 2)
 ---
-- error: 'bad argument #1 to ''?'' (string expected)'
+- error: argument 1 is not a string
 ...
 tonumber64(ffi.new('short', 10), 2)
 ---
-- error: 'bad argument #1 to ''?'' (string expected)'
+- error: argument 1 is not a string
 ...
 tonumber64(ffi.new('int', 10), 2)
 ---
-- error: 'bad argument #1 to ''?'' (string expected)'
+- error: argument 1 is not a string
 ...
 tonumber64(ffi.new('int8_t', 10), 2)
 ---
-- error: 'bad argument #1 to ''?'' (string expected)'
+- error: argument 1 is not a string
 ...
 tonumber64(ffi.new('int16_t', 10), 2)
 ---
-- error: 'bad argument #1 to ''?'' (string expected)'
+- error: argument 1 is not a string
 ...
 tonumber64(ffi.new('int32_t', 10), 2)
 ---
-- error: 'bad argument #1 to ''?'' (string expected)'
+- error: argument 1 is not a string
 ...
 tonumber64(ffi.new('int64_t', 10), 2)
 ---
-- error: 'bad argument #1 to ''?'' (string expected)'
+- error: argument 1 is not a string
 ...
 tonumber64(ffi.new('unsigned char', 10), 2)
 ---
-- error: 'bad argument #1 to ''?'' (string expected)'
+- error: argument 1 is not a string
 ...
 tonumber64(ffi.new('unsigned short', 10), 2)
 ---
-- error: 'bad argument #1 to ''?'' (string expected)'
+- error: argument 1 is not a string
 ...
 tonumber64(ffi.new('unsigned int', 10), 2)
 ---
-- error: 'bad argument #1 to ''?'' (string expected)'
+- error: argument 1 is not a string
 ...
 tonumber64(ffi.new('unsigned int', 10), 2)
 ---
-- error: 'bad argument #1 to ''?'' (string expected)'
+- error: argument 1 is not a string
 ...
 tonumber64(ffi.new('uint8_t', 10), 2)
 ---
-- error: 'bad argument #1 to ''?'' (string expected)'
+- error: argument 1 is not a string
 ...
 tonumber64(ffi.new('uint16_t', 10), 2)
 ---
-- error: 'bad argument #1 to ''?'' (string expected)'
+- error: argument 1 is not a string
 ...
 tonumber64(ffi.new('uint32_t', 10), 2)
 ---
-- error: 'bad argument #1 to ''?'' (string expected)'
+- error: argument 1 is not a string
 ...
 tonumber64(ffi.new('uint64_t', 10), 2)
 ---
-- error: 'bad argument #1 to ''?'' (string expected)'
+- error: argument 1 is not a string
 ...
 tonumber64(ffi.new('float', 10), 2)
 ---
-- error: 'bad argument #1 to ''?'' (string expected)'
+- error: argument 1 is not a string
 ...
 tonumber64(ffi.new('double', 10), 2)
 ---
-- error: 'bad argument #1 to ''?'' (string expected)'
+- error: argument 1 is not a string
 ...
 -- invalid types - return nil
 ffi.cdef("struct __tonumber64_test {};")

--- a/test/box/net.box_incorrect_iterator_gh-841.result
+++ b/test/box/net.box_incorrect_iterator_gh-841.result
@@ -114,7 +114,7 @@ cn.space.net_box_test_space:insert{234, 1,2,3}
 ...
 cn.space.net_box_test_space.insert{234, 1,2,3}
 ---
-- error: 'builtin/box/schema.lua..."]:<line>: Use space:insert(...) instead of space.insert(...)'
+- error: Use space:insert(...) instead of space.insert(...)
 ...
 cn.space.net_box_test_space:replace{354, 1,2,3}
 ---

--- a/test/box/transaction.result
+++ b/test/box/transaction.result
@@ -452,13 +452,13 @@ box.atomic(tx);
 function tx_error(space)
     space:auto_increment{'third'}
     space:auto_increment{'fourth'}
-    error("some error")
+    box.error(box.error.ILLEGAL_PARAMS, "some error")
 end;
 ---
 ...
 box.atomic(tx_error, space);
 ---
-- error: '[string "function tx_error(space)     space:auto_incre..."]:1: some error'
+- error: some error
 ...
 function nested(space)
     box.begin()

--- a/test/box/transaction.test.lua
+++ b/test/box/transaction.test.lua
@@ -217,7 +217,7 @@ box.atomic(tx);
 function tx_error(space)
     space:auto_increment{'third'}
     space:auto_increment{'fourth'}
-    error("some error")
+    box.error(box.error.ILLEGAL_PARAMS, "some error")
 end;
 box.atomic(tx_error, space);
 

--- a/test/box/update.result
+++ b/test/box/update.result
@@ -464,7 +464,7 @@ s:insert{1, 2, 3}
 ...
 s:update({1})
 ---
-- error: Usage index:update(key, ops)
+- error: 'Usage: index:update(key, ops)'
 ...
 s:update({1}, {'=', 1, 1})
 ---
@@ -813,7 +813,7 @@ s:update({0}, {{'+', 2, -0x4000000000000001ll}})  -- overflow
 -- some wrong updates --
 s:update({0}, 0)
 ---
-- error: Usage index:update(key, ops)
+- error: 'Usage: index:update(key, ops)'
 ...
 s:update({0}, {'+', 2, 2})
 ---

--- a/test/config-luatest/config_test.lua
+++ b/test/config-luatest/config_test.lua
@@ -165,11 +165,7 @@ g.test_configdata = function()
 
     local opts = {nojson = true, stderr = true}
     local res = justrun.tarantool(dir, {}, {'main.lua'}, opts)
-    t.assert_equals(res, {
-        exit_code = 0,
-        stdout = '',
-        stderr = '',
-    })
+    t.assert_equals(res.exit_code, 0, {res.stdout, res.stderr})
 end
 
 g.test_config_general = function()

--- a/test/config-luatest/helpers.lua
+++ b/test/config-luatest/helpers.lua
@@ -64,11 +64,7 @@ local function run_as_script(f)
 
         local opts = {nojson = true, stderr = true}
         local res = justrun.tarantool(dir, {}, {'main.lua'}, opts)
-        t.assert_equals(res, {
-            exit_code = 0,
-            stdout = '',
-            stderr = '',
-        })
+        t.assert_equals(res.exit_code, 0, {res.stdout, res.stderr})
     end
 end
 

--- a/test/engine/iterator.result
+++ b/test/engine/iterator.result
@@ -4947,9 +4947,9 @@ f = function() return gen(param, state) end
 _, errmsg = pcall(f)
 ---
 ...
-errmsg:match('usage: next%(param, state%)')
+errmsg:match('Usage: next%(param, state%)')
 ---
-- 'usage: next(param, state)'
+- 'Usage: next(param, state)'
 ...
 value
 ---

--- a/test/engine/iterator.test.lua
+++ b/test/engine/iterator.test.lua
@@ -424,7 +424,7 @@ value
 s:replace{35}
 f = function() return gen(param, state) end
 _, errmsg = pcall(f)
-errmsg:match('usage: next%(param, state%)')
+errmsg:match('Usage: next%(param, state%)')
 value
 
 s:drop()

--- a/test/replication-luatest/gh_8433_raft_is_candidate_test.lua
+++ b/test/replication-luatest/gh_8433_raft_is_candidate_test.lua
@@ -75,7 +75,8 @@ g.test_prevote_fail = function(g)
     --        the corresponding bit in leader_witness_map is cleared.
     --     3. Break last applier and make sure, that election isn't started.
     --
-    luatest.assert_equals(g.replica_set:get_leader(), g.server1)
+    luatest.assert_equals(g.replica_set:get_leader():get_instance_id(),
+                          g.server1:get_instance_id())
     local old_term = g.server1:get_election_term()
     g.server3:exec(function()
         box.cfg({election_mode = 'candidate'})

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -638,6 +638,15 @@ create_unit_test(PREFIX lua_utils
                            ${READLINE_LIBRARIES}
 )
 
+create_unit_test(PREFIX lua_error
+                 SOURCES lua_error.c
+                 LIBRARIES unit core server
+                           ${LUAJIT_LIBRARIES}
+                           ${CURL_LIBRARIES}
+                           ${LIBYAML_LIBRARIES}
+                           ${READLINE_LIBRARIES}
+)
+
 create_unit_test(PREFIX lua_msgpack
                  SOURCES lua_msgpack.c
                  LIBRARIES unit core server

--- a/test/unit/lua_error.c
+++ b/test/unit/lua_error.c
@@ -29,7 +29,7 @@ raise_error_at(lua_State *L)
 static int
 error_trace(lua_State *L)
 {
-	struct error *e = luaL_checkerror(L, 1);
+	struct error *e = luaT_checkerror(L, 1);
 
 	lua_createtable(L, 0, 2);
 	lua_pushstring(L, "file");

--- a/test/unit/lua_error.c
+++ b/test/unit/lua_error.c
@@ -1,0 +1,116 @@
+#include <stdio.h>
+
+#include "diag.h"
+#include "fiber.h"
+#include "lualib.h"
+#include "memory.h"
+
+#include "lua/error.h"
+#include "lua/utils.h"
+
+#define UNIT_TAP_COMPATIBLE 1
+#include "unit.h"
+
+static int
+raise_error(lua_State *L)
+{
+	diag_set(IllegalParams, "foo");
+	return luaT_error(L);
+}
+
+static int
+raise_error_at(lua_State *L)
+{
+	int level = lua_tointeger(L, 1);
+	diag_set(IllegalParams, "bar");
+	return luaT_error_at(L, level);
+}
+
+static int
+error_trace(lua_State *L)
+{
+	struct error *e = luaL_checkerror(L, 1);
+
+	lua_createtable(L, 0, 2);
+	lua_pushstring(L, "file");
+	lua_pushstring(L, e->file);
+	lua_settable(L, -3);
+	lua_pushstring(L, "line");
+	lua_pushinteger(L, e->line);
+	lua_settable(L, -3);
+	return 1;
+}
+
+const char *test_error_lua =
+"local this_file = debug.getinfo(1, 'S').short_src\n"
+"local line1 = debug.getinfo(1, 'l').currentline + 1\n"
+"local f1 = function(fn, ...) fn(...) end\n"
+"local line2 = debug.getinfo(1, 'l').currentline + 1\n"
+"local f2 = function(fn, ...) f1(fn, ...) end\n"
+"local line3 = debug.getinfo(1, 'l').currentline + 1\n"
+"local f3 = function(fn, ...) f2(fn, ...) end\n"
+"\n"
+"local function check(line, fn, ...)\n"
+"    local ok, err = pcall(f3, fn, ...)\n"
+"\n"
+"    assert(not ok, string.format('got %s', err))\n"
+"    local trace = test_error_trace(err)\n"
+"    assert(trace.file == this_file, string.format('got \"%s\"', trace.file))\n"
+"    assert(trace.line == line,\n"
+"           string.format('expected %d, got %d', line, trace.line))\n"
+"end\n"
+"\n"
+"assert(test_raise_error ~= nil)"
+"check(line1, test_raise_error)\n"
+"check(line1, test_raise_error_at, 1)\n"
+"check(line2, test_raise_error_at, 2)\n"
+"check(line3, test_raise_error_at, 3)\n"
+"\n"
+"local ok, err = pcall(f3, test_raise_error_at, 0)\n"
+"assert(not ok, string.format('got %s', err))\n"
+"local trace = test_error_trace(err)\n"
+"assert(string.find(trace.file, 'lua_error%.c') ~= nil,\n"
+"       string.format('got %s', trace.file))\n";
+
+static void
+test_error(lua_State *L)
+{
+	plan(1);
+	header();
+
+	int rc;
+
+	lua_pushcfunction(L, raise_error);
+	lua_setglobal(L, "test_raise_error");
+	lua_pushcfunction(L, raise_error_at);
+	lua_setglobal(L, "test_raise_error_at");
+	lua_pushcfunction(L, error_trace);
+	lua_setglobal(L, "test_error_trace");
+
+	rc = luaT_dostring(L, test_error_lua);
+	ok(rc == 0, rc == 0 ? "OK" : "got %s",
+	   diag_last_error(diag_get())->errmsg);
+
+	footer();
+	check_plan();
+}
+
+int
+main(void)
+{
+	plan(1);
+	header();
+
+	struct lua_State *L = luaL_newstate();
+	luaL_openlibs(L);
+	memory_init();
+	tarantool_lua_error_init(L);
+
+	test_error(L);
+
+	memory_free();
+	lua_close(L);
+
+	footer();
+	return check_plan();
+}


### PR DESCRIPTION
Currently trace points to the C code where diag is set or Lua code where error is thrown. So it points to internal code which is not particularly useful for the user. Let's make trace point the place where API is called. This patch do it for API residing in several modules only though (schema.lua is one of them).

Closes #9914

**DO NOT MERGE** Depends on PR https://github.com/tarantool/test-run/pull/428

See EE PR https://github.com/tarantool/tarantool-ee/pull/791