### PR TITLE
box: support varbinary in splice update operation

### DIFF
--- a/changelogs/unreleased/gh-9997-support-splice-for-varbinary.md
+++ b/changelogs/unreleased/gh-9997-support-splice-for-varbinary.md
@@ -1,0 +1,4 @@
+## feature/core
+
+* The splice operation (':') in update/upsert is now allowed for varbinary fields
+  and can take a varbinary argument for insertion (gh-9997).

--- a/src/box/xrow_update_field.h
+++ b/src/box/xrow_update_field.h
@@ -112,8 +112,19 @@ enum xrow_update_scalar_type {
 	XUPDATE_TYPE_FLOAT = 3,
 	/** struct int96_num */
 	XUPDATE_TYPE_INT = 4,
-	/** xrow_update_string */
+	/** xrow_update_string for MP_STR and MP_BIN */
 	XUPDATE_TYPE_STR = 5,
+};
+
+/**
+ * Store type of string (in terms of msgpack it would be MP_STR or MP_BIN)
+ * from which the string was read and to which it should be stored.
+ */
+enum xrow_update_str_store_type {
+	/** MP_STR */
+	XUPDATE_STORE_TYPE_STR,
+	/** MP_BIN */
+	XUPDATE_STORE_TYPE_BIN,
 };
 
 /**
@@ -146,7 +157,7 @@ struct xrow_update_string_chunk {
 };
 
 /**
- * String value.
+ * String or varbinary value.
  */
 struct xrow_update_string {
 	union {
@@ -166,6 +177,8 @@ struct xrow_update_string {
 	};
 	/** String value type. See enum definition for details. */
 	enum xrow_update_string_type type;
+	/** Store type. See enum definition for details. */
+	enum xrow_update_str_store_type store_type;
 };
 
 /**

--- a/test/box-luatest/error_subsystem_improvements_test.lua
+++ b/test/box-luatest/error_subsystem_improvements_test.lua
@@ -920,7 +920,7 @@ g.test_dml_update_error = function(cg)
             ops = {{':', 2, 2, 1, 'foo'}},
             tuple = {1, 2},
             message = "Argument type in operation ':' on field 2 does not " ..
-                      "match field type: expected a string"
+                      "match field type: expected a string or varbinary"
         }, test.update, test, {1}, {{':', 2, 2, 1, 'foo'}})
 
         local dummy = function(_, new) return new end

--- a/test/box-luatest/gh_10032_update_upsert_splice_test.lua
+++ b/test/box-luatest/gh_10032_update_upsert_splice_test.lua
@@ -1,0 +1,79 @@
+local t = require('luatest')
+local server = require('luatest.server')
+local helper = require('test.box-luatest.update_upsert_splice_helper')
+
+-- Type data stored in tuple: string or varbinary.
+local types = {{type = 'str'}, {type = 'bin'}}
+local g = t.group('gh-10032-update-upsert-splice', types)
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+   cg.server:exec(function()
+        if box.space.test then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+-- Test lots of various variants of splice (':') of tuple update.
+g.test_tuple_update_splice = function(cg)
+    local data_type = cg.params.type
+    local tmpl = helper.generate_tuple_template(data_type)
+    local test_cases = helper.generate_test_cases(tmpl)
+
+    local tuple = box.tuple.new(tmpl)
+
+    for _, test_case in ipairs(test_cases) do
+        local ok, ret = pcall(tuple.update, tuple, test_case.ops)
+        helper.check_test_case_result(test_case, ok, ret)
+    end
+end
+
+-- Test lots of various variants of splice (':') of memtx space update.
+g.test_memtx_update_splice = function(cg)
+    local data_type = cg.params.type
+    cg.server:exec(function(data_type)
+        local helper = require('test.box-luatest.update_upsert_splice_helper')
+        local tmpl = helper.generate_tuple_template(data_type)
+        local test_cases = helper.generate_test_cases(tmpl)
+
+        local s = box.schema.space.create('test', {engine = 'memtx'})
+        s:create_index('pk')
+
+        for _, test_case in ipairs(test_cases) do
+            s:replace(tmpl)
+            local ok, ret = pcall(s.update, s, tmpl[1], test_case.ops)
+            helper.check_test_case_result(test_case, ok, ret)
+        end
+    end, {data_type})
+end
+
+-- Test lots of various variants of splice (':') of memtx space upsert.
+g.test_memtx_upsert_splice = function(cg)
+    local data_type = cg.params.type
+    cg.server:exec(function(data_type)
+        local helper = require('test.box-luatest.update_upsert_splice_helper')
+        local tmpl = helper.generate_tuple_template(data_type)
+        local test_cases = helper.generate_test_cases(tmpl, true)
+
+        local s = box.schema.space.create('test', {engine = 'memtx'})
+        s:create_index('pk')
+
+        for _, test_case in ipairs(test_cases) do
+            s:replace(tmpl)
+            local ok, ret = pcall(s.upsert, s, tmpl, test_case.ops)
+            if ok then
+                ret = s:get(tmpl[1])
+            end
+            helper.check_test_case_result(test_case, ok, ret)
+        end
+    end, {data_type})
+end

--- a/test/box-luatest/gh_9997_update_splice_test.lua
+++ b/test/box-luatest/gh_9997_update_splice_test.lua
@@ -1,0 +1,35 @@
+local t = require('luatest')
+local g = t.group('gh-9997-update-splice')
+local varbinary = require('varbinary')
+
+-- Simple test that test several variants of update splice operation.
+g.test_tuple_update_splice = function()
+    local tuple
+    -- Varbinary field.
+    tuple = box.tuple.new{varbinary.new('1234567890')}
+    tuple = tuple:update{{':', 1, 4, 2, 'abc'}}
+    t.assert(varbinary.is(tuple[1]))
+    t.assert_equals(tuple[1], '123abc67890')
+
+    -- Varbinary argument.
+    tuple = box.tuple.new{'1234567890'}
+    tuple = tuple:update{{':', 1, 4, 2, varbinary.new('abc')}}
+    t.assert_type(tuple[1], 'string')
+    t.assert_equals(tuple[1], '123abc67890')
+
+    -- Varbinary field and argument.
+    tuple = box.tuple.new{varbinary.new('1234567890')}
+    tuple = tuple:update{{':', 1, 4, 2, varbinary.new('abc')}}
+    t.assert(varbinary.is(tuple[1]))
+    t.assert_equals(tuple[1], '123abc67890')
+
+    -- Other types are still forbidden.
+    local mess = "Argument type in operation ':' on field 1 does not match " ..
+                 "field type: expected a string or varbinary"
+    tuple = box.tuple.new{1234567890}
+    t.assert_error_msg_equals(mess, tuple.update, tuple,
+                              {{':', 1, 4, 2, 'abc'}})
+    tuple = box.tuple.new{'1234567890'}
+    t.assert_error_msg_equals(mess, tuple.update, tuple,
+                              {{':', 1, 4, 2, 42}})
+end

--- a/test/box-luatest/update_upsert_splice_helper.lua
+++ b/test/box-luatest/update_upsert_splice_helper.lua
@@ -1,0 +1,162 @@
+-- Helper of gh_10032_update_upsert_splice_test.lua
+local t = require('luatest')
+local varbinary = require('varbinary')
+
+local M = {}
+
+-- Reference function that applies update splice 'ops' to tuple-like 'array'.
+local function reference_splice(array, ops, is_upsert)
+    -- By design zero offset error is thrown while reading ops.
+    for _, op in ipairs(ops) do
+        local field = op[2]
+        local pos = op[3]
+        if pos == 0 then
+            error('SPLICE error on field ' .. field ..
+                  ': offset is out of bound', 0)
+        end
+    end
+    array = table.copy(array)
+    for _, op in ipairs(ops) do
+        local strop, field, pos, cut, paste = unpack(op)
+        assert(strop == ':')
+        paste = tostring(paste)
+        local value = array[field]
+        if varbinary.is(value) then
+            value = tostring(value)
+        elseif type(value) ~= 'string' then
+            if is_upsert then
+                goto continue
+            end
+            error('Argument type in operation \':\' on field ' .. field ..
+                  ' does not match field type: expected a string or varbinary',
+                  0)
+        end
+        assert(pos ~= 0) -- checked before.
+        if pos > #value + 1 then
+            pos = #value + 1
+        elseif pos < -#value - 1 then
+            if is_upsert then
+                goto continue
+            end
+            error('SPLICE error on field ' .. field ..
+                  ': offset is out of bound', 0)
+        elseif pos < 0 then
+            pos = #value + 2 + pos
+        end
+        local l = string.sub(value, 1, pos - 1)
+        local r = string.sub(value, pos + cut)
+        value = l .. paste .. r
+        if varbinary.is(array[field]) then
+            array[field] = varbinary.new(value)
+        else
+            array[field] = value
+        end
+        ::continue::
+    end
+    return array
+end
+
+-- Test update operations.
+local check_ops = {
+    -- error.
+    {':', 1, 1, 0, ''},
+    {':', 2, 0, 0, ''},
+    {':', 2, -6, 0, ''}, -- possible error.
+    -- noop.
+    {':', 2, 1, 0, ''},
+    -- delete.
+    {':', 2, 1, 1, ''},
+    {':', 2, 3, 2, varbinary.new('')},
+    {':', 2, 5, 1, ''},
+    {':', 2, -1, 1, varbinary.new('')},
+    {':', 2, -3, 2, ''},
+    {':', 2, -5, 1, varbinary.new('')},
+    -- insert.
+    {':', 2, 1, 0, 'bbbb'},
+    {':', 2, 3, 0, varbinary.new('cccc')},
+    {':', 2, 5, 0, 'dddd'},
+    {':', 2, -1, 0, varbinary.new('eeee')},
+    {':', 2, -3, 0, 'ffff'},
+    {':', 2, -5, 0, varbinary.new('gggg')},
+    -- replace.
+    {':', 2, 1, 2, varbinary.new('hhhh')},
+    {':', 2, 3, 3, 'iiii'},
+    {':', 2, 5, 1, varbinary.new('jjjj')},
+    {':', 2, -1, 2, 'kkkk'},
+    {':', 2, -3, 3, varbinary.new('llll')},
+    {':', 2, -5, 1, 'mmmm'},
+}
+
+-- Get random update operation.
+local rnd_op = function()
+    return check_ops[math.random(#check_ops)]
+end
+
+-- Generate lots of test cases: update operations and expected results.
+-- Test case result is map with two fields 'ok' and 'ret' that are expected
+-- to get from pcall with test case update.
+function M.generate_test_cases(tmpl, is_upsert)
+    local cases = {}
+
+    for _, op in ipairs(check_ops) do
+        table.insert(cases, {ops = {op}})
+    end
+    for _ = 1, 100 do
+        table.insert(cases, {ops = {rnd_op(), rnd_op()}})
+    end
+    for _ = 1, 200 do
+        table.insert(cases, {ops = {rnd_op(), rnd_op(), rnd_op()}})
+    end
+    for _ = 1, 600 do
+        table.insert(cases, {ops = {rnd_op(), rnd_op(), rnd_op(), rnd_op()}})
+    end
+
+    for _, test_case in pairs(cases) do
+        local ok, ret = pcall(reference_splice, tmpl, test_case.ops, is_upsert)
+        test_case.res = {
+            ok = ok,
+            ret = ret,
+        }
+    end
+
+    return cases
+end
+
+-- Generate array with 2nd field of given type ('str' or 'bin').
+function M.generate_tuple_template(data_type)
+    assert(data_type == 'str' or data_type == 'bin')
+    local tmpl = {100, '1234', 200}
+    if data_type == 'bin' then
+        tmpl[2] = varbinary.new(tmpl[2])
+    end
+    return tmpl
+end
+
+-- Get field type - 'bin' or 'str'.
+-- This function is required both on host and on server, and unfortunately now
+-- test engine cannot pass functions as exec arguments, so define source code.
+local function field_type(field)
+    local varbinary = require('varbinary')
+    if type(field) == 'string' then
+        return 'str'
+    elseif varbinary.is(field) then
+        return 'bin'
+    end
+end
+
+-- Check that result of update (ok, ret as return values of the corresponding
+-- pcall) comply test case's expected result.
+function M.check_test_case_result(test_case, ok, ret)
+    local ops = test_case.ops
+    local expected_ok = test_case.res.ok
+    local expected_ret = test_case.res.ret
+    t.assert_equals(ok, expected_ok, ops)
+    if ok then
+        t.assert_equals(ret, expected_ret, ops)
+        t.assert_equals(field_type(ret[2]), field_type(expected_ret[2]), ops)
+    else
+        t.assert_equals(tostring(ret), expected_ret, ops)
+    end
+end
+
+return M


### PR DESCRIPTION
Just in case splice is an update operation that can modify string
field, deleting a part of it and inserting something instead.
```
tarantool> box.tuple.new{'1234567'}:update{{':', 1, 2, 3, '!'}}
---
- ['1!567']
...
```
In the this example splice operation ':' takes field 1 of tuple,
takes position 2 in string, removes 3 symbols and inserts '!' to
that position.

Both deletion and insertion can naturally degrade to no-op.

Before this patch a splice operation required both field and
inserting argument to be strings.

This patch allows the field and the argument to be varbinary.
```
tarantool> varb = require('varbinary')
tarantool> t = box.tuple.new{varb.new('1234567')}
tarantool> t:update{{':', 1, 2, 3, varb.new('!')}}
---
- [!!binary MSE1Njc=]
...

```

That also allows to insert strings into varbinary fields and
insert varbinary data into string. The actual field type after
update such operation remains the same, so updated string will
be string, while updated varbinary will be varbinary.

Closes https://github.com/tarantool/tarantool/issues/9997