### PR TITLE
console: create per-session variables scope

### DIFF
--- a/changelogs/unreleased/console-session-scope-vars.md
+++ b/changelogs/unreleased/console-session-scope-vars.md
@@ -1,0 +1,5 @@
+## feature/console
+
+* Interactive console now performs non-local assignments to a per-session
+  variable scope if the `console_session_scope_vars` compat option is set to
+  `new` (gh-9985).

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2414,6 +2414,12 @@ return schema.new('instance_config', schema.record({
         }, {
             default = 'old',
         }),
+        console_session_scope_vars = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'old',
+        }),
     }),
     -- Instance labels.
     labels = schema.map({

--- a/test/app-luatest/console_session_scope_vars_test.lua
+++ b/test/app-luatest/console_session_scope_vars_test.lua
@@ -1,0 +1,136 @@
+local t = require('luatest')
+local it = require('test.interactive_tarantool')
+local cbuilder = require('test.config-luatest.cbuilder')
+local cluster = require('test.config-luatest.cluster')
+
+local g = t.group()
+
+g.before_all(cluster.init)
+g.after_each(cluster.drop)
+g.after_all(cluster.clean)
+
+local function close_on_demand(g, name)
+    if g[name] ~= nil then
+        g[name]:close()
+        g[name] = nil
+    end
+end
+
+g.after_each(function(g)
+    close_on_demand(g, 'it')
+    close_on_demand(g, 'it_1')
+    close_on_demand(g, 'it_2')
+end)
+
+g.test_compat_default = function(g)
+    local config = cbuilder.new()
+        :add_instance('i-001', {})
+        :config()
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    cluster['i-001']:exec(function()
+        local compat = require('compat')
+
+        assert(compat.console_session_scope_vars:is_old())
+    end)
+end
+
+g.test_local_old = function(g)
+    g.it = it.new()
+
+    g.it:roundtrip("require('compat').console_session_scope_vars = 'old'")
+
+    -- Non-local assignment is written to globals.
+    g.it:roundtrip('x = 5')
+    g.it:roundtrip('x', 5)
+    g.it:roundtrip("rawget(_G, 'x')", 5)
+
+    -- A global is readable without explicit _G.
+    g.it:roundtrip('_G.y = 6')
+    g.it:roundtrip('_G.y', 6)
+    g.it:roundtrip('y', 6)
+
+    -- A last write wins.
+    g.it:roundtrip('x = 5')
+    g.it:roundtrip('_G.x = 7')
+    g.it:roundtrip('x', 7)
+    g.it:roundtrip('x = 8')
+    g.it:roundtrip('x', 8)
+    g.it:roundtrip('_G.x = 9')
+    g.it:roundtrip('x', 9)
+    g.it:roundtrip('_G.x', 9)
+end
+
+g.test_local_new = function(g)
+    g.it = it.new()
+
+    g.it:roundtrip("require('compat').console_session_scope_vars = 'new'")
+
+    -- Non-local assignment doesn't affect globals.
+    g.it:roundtrip('x = 5')
+    g.it:roundtrip('x', 5)
+    g.it:roundtrip("rawget(_G, 'x')", nil)
+
+    -- A global is readable without explicit _G.
+    g.it:roundtrip('_G.y = 6')
+    g.it:roundtrip('_G.y', 6)
+    g.it:roundtrip('y', 6)
+
+    -- A session scope variable is preferred.
+    g.it:roundtrip('x = 5')
+    g.it:roundtrip('_G.x = 7')
+    g.it:roundtrip('x', 5)
+    g.it:roundtrip('x = 8')
+    g.it:roundtrip('x', 8)
+    g.it:roundtrip('_G.x = 9')
+    g.it:roundtrip('x', 8)
+    g.it:roundtrip('_G.x', 9)
+end
+
+g.test_remote_old = function(g)
+    local config = cbuilder.new()
+        :set_global_option('compat.console_session_scope_vars', 'old')
+        :add_instance('i-001', {})
+        :config()
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    g.it_1 = it.connect(cluster['i-001'])
+    g.it_2 = it.connect(cluster['i-001'])
+
+    -- Write the same named variables.
+    g.it_1:roundtrip('x = 1')
+    g.it_2:roundtrip('x = 2')
+
+    -- The variable is shared.
+    g.it_1:roundtrip('x', 2)
+    g.it_2:roundtrip('x', 2)
+
+    -- And it is written to globals.
+    g.it_1:roundtrip("rawget(_G, 'x')", 2)
+end
+
+g.test_remote_new = function(g)
+    local config = cbuilder.new()
+        :set_global_option('compat.console_session_scope_vars', 'new')
+        :add_instance('i-001', {})
+        :config()
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    g.it_1 = it.connect(cluster['i-001'])
+    g.it_2 = it.connect(cluster['i-001'])
+
+    -- Write the same named variables.
+    g.it_1:roundtrip('x = 1')
+    g.it_2:roundtrip('x = 2')
+
+    -- Each console session has its own variable with this name.
+    g.it_1:roundtrip('x', 1)
+    g.it_2:roundtrip('x', 2)
+
+    -- There is no global variable with such a name.
+    g.it_1:roundtrip("rawget(_G, 'x')", nil)
+    g.it_2:roundtrip("rawget(_G, 'x')", nil)
+end

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -348,6 +348,7 @@ g.test_defaults = function()
             box_tuple_extension = 'new',
             box_space_max = 'new',
             box_error_unpack_type_and_code = 'old',
+            console_session_scope_vars = 'old',
         },
     }
     local res = cluster_config:apply_default({})


### PR DESCRIPTION
It is counter-intuitive that all the non-local assignments in the console affect globals and may interfere with application's logic.

It is also counter-intuitive that the non-local assignments are shared between different console sessions.

Now, each console session has its own variables scope and the non-local assignments use it instead of globals.

Let's consider examples of the new behavior.

Example 1. A console session has a variable scope that is separate from globals.

```lua
console_1> _G.x = 1
console_1> x = 2

console_1> _G.x
---
- 1
...
console_1> x
---
- 2
...
```

Note: A global variable is still accessible using `_G` even if the same named session scope variable exists.

Example 2. A global variable is read if there is no session local variable.

```lua
console_1> _G.x = 1
console_1> x
---
- 1
...
```

Example 3. Different console sessions have separate variable scopes.

```lua
console_1> x = 1
console_2> x = 2

console_1> x
---
- 1
...
console_2> x
---
- 2
...
```

The new behavior is enabled using the `console_session_scope_vars` compat option. The option is `old` by default in Tarantool 3.X, `new` by default in 4.X. The `old` behavior is to be removed in 5.X.

Fixes #9985