### PR TITLE
box: prevent demoted leader from being a candidate in the next elections

### DIFF
--- a/changelogs/unreleased/gh-9855-box-ctl-demote-guarantee-demoting.md
+++ b/changelogs/unreleased/gh-9855-box-ctl-demote-guarantee-demoting.md
@@ -1,0 +1,5 @@
+## bugfix/replication
+
+* Fixed a bug that allowed the old leader in
+  `box.cfg{election_mode = 'candidate'` mode to get re-elected after resigning
+  himself through `box.ctl.demote` (gh-9855).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3086,9 +3086,8 @@ box_demote(void)
 			return 0;
 		if (txn_limbo.owner_id != instance_id)
 			return 0;
-		if (raft->state != RAFT_STATE_LEADER)
-			return 0;
-		return box_trigger_elections();
+		box_raft_leader_step_off();
+		return 0;
 	}
 
 	assert(raft->state == RAFT_STATE_FOLLOWER);

--- a/src/box/raft.c
+++ b/src/box/raft.c
@@ -302,13 +302,7 @@ box_raft_fence(void)
 	raft_resign(raft);
 }
 
-/**
- * Resign RAFT leadership and freeze limbo regardless of
- * box_election_fencing_mode. It waits until the elections
- * begin. After the death-timeout expires, it starts a new
- * round of elections.
- */
-static void
+void
 box_raft_leader_step_off(void)
 {
 	struct raft *raft = box_raft();

--- a/src/box/raft.h
+++ b/src/box/raft.h
@@ -152,6 +152,15 @@ box_raft_set_election_fencing_mode(enum election_fencing_mode mode);
 void
 box_raft_election_fencing_pause(void);
 
+/**
+ * Resign RAFT leadership and freeze limbo regardless of
+ * box_election_fencing_mode. It waits until the elections
+ * begin. After the death-timeout expires, it starts a new
+ * round of elections.
+ */
+void
+box_raft_leader_step_off(void);
+
 void
 box_raft_init(void);
 

--- a/test/replication-luatest/gh_6033_box_promote_demote_test.lua
+++ b/test/replication-luatest/gh_6033_box_promote_demote_test.lua
@@ -108,6 +108,11 @@ end
 local function cluster_reinit(g)
     box_cfg_update(g.cluster.servers, g.box_cfg)
     wait_sync(g.cluster.servers)
+    for _, server in ipairs(g.cluster.servers) do
+        server:exec(function()
+            box.ctl.demote()
+        end)
+    end
 end
 
 local function cluster_stop(g)

--- a/test/replication-luatest/gh_9855_box_ctl_demote_guarantee_demoting_test.lua
+++ b/test/replication-luatest/gh_9855_box_ctl_demote_guarantee_demoting_test.lua
@@ -1,0 +1,77 @@
+local t = require('luatest')
+local replica_set = require('luatest.replica_set')
+local server = require('luatest.server')
+
+local g = t.group()
+
+g.before_each(function(cg)
+    cg.replica_set = replica_set:new{}
+    local box_cfg = {
+        replication = {
+            server.build_listen_uri('server1', cg.replica_set.id),
+            server.build_listen_uri('server2', cg.replica_set.id),
+        },
+        election_mode = 'candidate',
+        replication_timeout = 0.1,
+        election_timeout = 0.5,
+    }
+    cg.server1 = cg.replica_set:build_and_add_server{
+        alias = 'server1',
+        box_cfg = box_cfg,
+    }
+    box_cfg.election_mode = 'voter'
+    cg.server2 = cg.replica_set:build_and_add_server{
+        alias = 'server2',
+        box_cfg = box_cfg,
+    }
+    cg.replica_set:start()
+    cg.replica_set:wait_for_fullmesh()
+end)
+
+g.after_each(function(cg)
+    cg.replica_set:drop()
+end)
+
+-- Test that the demoted leader can still win in subsequent elections.
+local function test_subsequent_elections(demoted_leader, current_leader)
+    current_leader:exec(function()
+        box.ctl.demote()
+    end)
+    demoted_leader:wait_for_election_leader();
+    demoted_leader:exec(function()
+        t.assert_equals(box.info.election.vote, box.info.election.leader)
+    end)
+    current_leader:exec(function()
+        t.assert_equals(box.info.election.vote, box.info.election.leader)
+    end)
+end
+
+-- Test that the demoted leader cannot get elected after resigning himself
+-- through `box.ctl.demote`.
+g.test_demote_guarantee = function(cg)
+    cg.server1:wait_for_election_leader()
+    cg.server2:update_box_cfg({election_mode = 'candidate'})
+    cg.server1:exec(function()
+        box.ctl.demote()
+    end)
+    cg.server2:wait_for_election_leader();
+    cg.server1:exec(function()
+        t.assert_equals(box.info.election.vote, box.info.election.leader)
+    end)
+    test_subsequent_elections(cg.server1, cg.server2)
+end
+
+-- Test that the demoted leader waits for leader death timeout after resigning
+-- himself through `box.ctl.demote` and starts subsequent elections.
+g.test_demoted_leader_election_in_subsequent_elections = function(cg)
+    cg.server1:wait_for_election_leader()
+    local demoted_term = cg.server1:get_election_term()
+    cg.server1:exec(function()
+        box.ctl.demote()
+    end)
+    cg.server1:wait_for_election_leader()
+    cg.server1:exec(function(demoted_term)
+        t.assert_equals(box.info.election.term, demoted_term + 1)
+        t.assert_equals(box.info.election.vote, box.info.election.leader)
+    end, {demoted_term})
+end


### PR DESCRIPTION
This patch prevents the demoted leader from being a candidate in the next elections.

Closes #9855