### PR TITLE
[alternative] txn: run statement `on_rollback` triggers before rolling back statement

### DIFF
--- a/changelogs/unreleased/gh-9893-rollback-ddl-on-_space-space.md
+++ b/changelogs/unreleased/gh-9893-rollback-ddl-on-_space-space.md
@@ -1,0 +1,3 @@
+## bugfix/box
+
+* Fixed rollback of DDL statements on the `_space` space (gh-9893).

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -341,11 +341,15 @@ txn_stmt_prepare_rollback_info(struct txn_stmt *stmt, struct tuple *old_tuple,
 }
 
 /*
- * Undo changes done by a statement and run the corresponding
- * rollback triggers.
+ * Run the statement's rollback triggers and undo changes done by the statement.
+ *
+ * Logically, we call triggers after running statements. These triggers can
+ * make significant changes (for instance, DDL triggers), so, for consistency,
+ * we should call the statement's `on_rollback` triggers before rolling back
+ * the corresponding statement.
  *
  * Note, a trigger set by a particular statement must be run right
- * after the statement is rolled back, because rollback triggers
+ * before the statement is rolled back, because rollback triggers
  * installed by DDL statements restore the schema cache, which is
  * necessary to roll back previous statements. For example, to roll
  * back a DML statement applied to a space whose index is dropped
@@ -355,12 +359,12 @@ txn_stmt_prepare_rollback_info(struct txn_stmt *stmt, struct tuple *old_tuple,
 static void
 txn_rollback_one_stmt(struct txn *txn, struct txn_stmt *stmt)
 {
-	if (txn->engine != NULL && stmt->space != NULL)
-		engine_rollback_statement(txn->engine, txn, stmt);
 	if (stmt->has_triggers && trigger_run(&stmt->on_rollback, stmt) != 0) {
 		diag_log();
 		panic("statement rollback trigger failed");
 	}
+	if (txn->engine != NULL && stmt->space != NULL)
+		engine_rollback_statement(txn->engine, txn, stmt);
 }
 
 /*

--- a/test/box-luatest/gh_9893_rollback_ddl_on__space_space_test.lua
+++ b/test/box-luatest/gh_9893_rollback_ddl_on__space_space_test.lua
@@ -1,0 +1,32 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+-- Test that rollback of DDL statements on the `_space` space works correctly.
+g.test_rollback_ddl_on__space_space = function(cg)
+    cg.server:exec(function()
+        local _space = box.space._space:get{box.space._space.id}:totable()
+
+        box.begin()
+        box.space._space:alter{is_sync = false, defer_deletes = true}
+        box.rollback()
+
+        -- Test that the server does not crash because of heap-use-after-free.
+        collectgarbage()
+        box.space._space:select{}
+        collectgarbage()
+
+        t.assert_equals(box.space._space:get{box.space._space.id}:totable(),
+                        _space)
+    end)
+end

--- a/test/box-luatest/rollback_ddl_on__priv_space_test.lua
+++ b/test/box-luatest/rollback_ddl_on__priv_space_test.lua
@@ -1,0 +1,51 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+-- Test that rollback of DDL statements on the `_priv` space works correctly.
+g.test_rollback_ddl_on__priv_space = function(cg)
+    cg.server:exec(function()
+        box.schema.user.create('grant')
+        box.schema.user.create('revoke')
+        box.schema.user.create('modify')
+
+        box.session.su('grant')
+        local grant_user = box.session.uid()
+        box.session.su('revoke')
+        local revoke_user = box.session.uid()
+        box.session.su('modify')
+        local modify_user = box.session.uid()
+
+        box.session.su('admin')
+
+        local grant_privs = box.space._priv:select{grant_user}
+        box.begin()
+        box.schema.user.grant('grant', 'execute', 'universe')
+        box.rollback()
+        t.assert_equals(box.space._priv:select{grant_user}, grant_privs)
+
+        box.schema.user.grant('revoke', 'execute', 'universe')
+        local revoke_privs = box.space._priv:select{revoke_user}
+        box.begin()
+        box.schema.user.revoke('revoke', 'execute', 'universe')
+        box.rollback()
+        t.assert_equals(box.space._priv:select{revoke_user}, revoke_privs)
+
+        box.schema.user.grant('modify', 'read,write,execute', 'universe')
+        local modify_privs = box.space._priv:select{modify_user}
+        box.begin()
+        box.schema.user.revoke('modify', 'execute', 'universe')
+        box.rollback()
+        t.assert_equals(box.space._priv:select{modify_user}, modify_privs)
+    end)
+end


### PR DESCRIPTION
This patch fixes the order of running a transaction statement's on_rollback triggers and rolling back the statement itself.

This patch was suggested by @drewdzzz as an alternative to the solution presented in #9936.

Closes #9893