### PR TITLE
[backport 3.1] test/interactive: a couple of enhancements

### DIFF
--- a/test/app-luatest/gh_7031_configure_eos_in_lua_console_test.lua
+++ b/test/app-luatest/gh_7031_configure_eos_in_lua_console_test.lua
@@ -1,15 +1,10 @@
 local server = require('luatest.server')
-local fio = require('fio')
 local it = require('test.interactive_tarantool')
 local t = require('luatest')
 
 local g = t.group()
 
 local child
-
-g.before_each(function()
-    child = it.new()
-end)
 
 g.after_each(function()
     if g.server ~= nil then
@@ -28,36 +23,30 @@ local function repl(command, exp_line)
 end
 
 g.test_empty_default_local_eos = function()
+    child = it.new()
+
     repl('\\set output lua', 'true')
     repl('42', '42')
 end
 
 g.test_configure_local_eos = function()
+    child = it.new()
+
     repl('\\set output lua,local_eos=/', 'true/')
     repl('42', '42/')
     repl('\\set output lua,local_eos=', 'true')
     repl('42', '42')
 end
 
-g.test_client_server_local_eos = function()
+g.test_client_server_local_eos = function(g)
     g.server = server:new({alias = 'console_server'})
     g.server:start()
 
-    local socket_path = fio.pathjoin(g.server.workdir, 'admin.socket')
-    local listen_command  = "require('console').listen('%s')"
-    local connect_command = "require('console').connect('%s')"
-
-    listen_command  = listen_command:format(socket_path)
-    connect_command = connect_command:format(socket_path)
-
     -- Listen on the server.
-    g.server:eval(listen_command)
+    g.server:eval("require('console').listen('unix/:./tarantool.control')")
 
     -- Connect the interactive client to the server's console.
-    child:execute_command(connect_command)
-    local response = child:read_response()
-    t.assert_equals(response, true)
-    child:set_prompt(('unix/:%s> '):format(socket_path))
+    child = it.connect(g.server)
 
     repl('\\set output lua,local_eos=/', 'true/')
     repl('42', '42/')

--- a/test/app-luatest/gh_8136_fix_print_wrapper_not_handling_errors_thrown_from_print_test.lua
+++ b/test/app-luatest/gh_8136_fix_print_wrapper_not_handling_errors_thrown_from_print_test.lua
@@ -5,7 +5,10 @@ local g = t.group()
 
 -- Checks that `print` throwing an error is handled correctly.
 g.test_basic_print_with_exception = function()
-    local child = it.new({args = {'-l', 'fiber'}})
+    local child = it.new({
+        args = {'-l', 'fiber'},
+        env = {TT_CONSOLE_HIDE_SHOW_PROMPT = 'true'},
+    })
 
     child:execute_command([[
         _ = fiber.create(function()

--- a/test/box-luatest/gh_8051_set_box_cfg_thru_env_test.lua
+++ b/test/box-luatest/gh_8051_set_box_cfg_thru_env_test.lua
@@ -1,4 +1,3 @@
-local fun = require('fun')
 local server = require('luatest.server')
 local treegen = require('test.treegen')
 local it = require('test.interactive_tarantool')
@@ -28,13 +27,6 @@ g.after_all(function(g)
     treegen.clean(g)
 end)
 
--- Disable hide/show prompt functionality, because it breaks a
--- command echo check. The reason is that the 'scheduled next
--- checkpoint' log message is issued from a background fiber.
-local env_default = {
-    TT_CONSOLE_HIDE_SHOW_PROMPT = 'false',
-}
-
 g.test_json_table_curly_bracket = function()
     local env = {["TT_METRICS"] = '{"labels":{"alias":"gh_8051"},' ..
                                   '"include":"all","exclude":["vinyl"]}'}
@@ -47,9 +39,9 @@ end
 
 g.test_json_table_square_bracket = function(g)
     g.child = it.new({
-        env = fun.chain(env_default, {
+        env = {
             TT_LISTEN = '["localhost:0"]',
-        }):tomap(),
+        },
     })
 
     local command = ('box.cfg({work_dir = %q})'):format(g.dir)
@@ -70,9 +62,9 @@ end
 
 g.test_format_error = function(g)
     g.child = it.new({
-        env = fun.chain(env_default, {
+        env = {
             TT_LOG_MODULES = 'aaa=info,bbb',
-        }):tomap(),
+        },
     })
 
     local command = ('box.cfg({work_dir = %q})'):format(g.dir)
@@ -82,9 +74,9 @@ end
 
 g.test_format_error_empty_key = function()
     g.child = it.new({
-        env = fun.chain(env_default, {
+        env = {
             TT_LOG_MODULES = 'aaa=info,=error',
-        }):tomap(),
+        },
     })
 
     local command = ('box.cfg({work_dir = %q})'):format(g.dir)

--- a/test/box-luatest/hide_show_prompt_test.lua
+++ b/test/box-luatest/hide_show_prompt_test.lua
@@ -8,7 +8,10 @@ local g = t.group()
 -- It does not check that tarantool preserves current input line
 -- and cursor position.
 g.test_basic_print = function()
-    local child = it.new({args = {'-l', 'fiber'}})
+    local child = it.new({
+        args = {'-l', 'fiber'},
+        env = {TT_CONSOLE_HIDE_SHOW_PROMPT = 'true'},
+    })
 
     child:execute_command([[
         _ = fiber.create(function()
@@ -35,7 +38,10 @@ end
 -- We don't check for presence of 'flood' lines in the log, but
 -- verify that prompt on stdout is shown and hid.
 g.test_basic_log = function()
-    local child = it.new({args = {'-l', 'fiber', '-l', 'log'}})
+    local child = it.new({
+        args = {'-l', 'fiber', '-l', 'log'},
+        env = {TT_CONSOLE_HIDE_SHOW_PROMPT = 'true'},
+    })
 
     child:execute_command([[
         _ = fiber.create(function()

--- a/test/config-luatest/credentials_applier_test.lua
+++ b/test/config-luatest/credentials_applier_test.lua
@@ -340,15 +340,7 @@ g.test_sync_privileges = function(g)
         },
     }
 
-    -- Disable hide/show prompt functionality, because it breaks
-    -- a command echo check. The reason is that the 'scheduled
-    -- next checkpoint' log message is issued from a background
-    -- fiber.
-    local child = it.new({
-        env = {
-            TT_CONSOLE_HIDE_SHOW_PROMPT = 'false',
-        },
-    })
+    local child = it.new()
     local dir = treegen.prepare_directory(g, {}, {})
     child:roundtrip(("box.cfg{work_dir = %q}"):format(dir))
 
@@ -395,15 +387,7 @@ g.test_set_password = function(g)
             t.tarantool.skip_if_not_enterprise()
         end
 
-        -- Disable hide/show prompt functionality, because it
-        -- breaks a command echo check. The reason is that the
-        -- 'scheduled next checkpoint' log message is issued from
-        -- a background fiber.
-        local child = it.new({
-            env = {
-                TT_CONSOLE_HIDE_SHOW_PROMPT = 'false',
-            },
-        })
+        local child = it.new()
 
         local dir = treegen.prepare_directory(g, {}, {})
         local socket = "unix/:./test_socket.iproto"

--- a/test/interactive_tarantool.lua
+++ b/test/interactive_tarantool.lua
@@ -333,6 +333,13 @@ function M._new_internal(opts)
             -- (because the command in the echo output will be
             -- trimmed).
             INPUTRC = '/dev/null',
+            -- Disable hide/show prompt functionality, because it
+            -- may break a command echo check.
+            --
+            -- For example, it occurs on the 'scheduled next
+            -- checkpoint' log message, which is issued from a
+            -- background fiber.
+            TT_CONSOLE_HIDE_SHOW_PROMPT = 'false',
         }, env):tomap(),
     })
 

--- a/test/interactive_tarantool.lua
+++ b/test/interactive_tarantool.lua
@@ -285,13 +285,17 @@ function mt.close(self)
     self.ph:close()
 end
 
--- Run a command and assert response.
-function mt.roundtrip(self, command, expected)
+-- Run a command and return its response.
+--
+-- If an expected value is provided, verify that the response
+-- equals to it.
+function mt.roundtrip(self, command, ...)
     self:execute_command(command)
     local response = self:read_response()
-    if expected ~= nil then
-        t.assert_equals(response, expected)
+    if select('#', ...) > 0 then
+        t.assert_equals(response, (...))
     end
+    return response
 end
 
 -- }}} Instance methods


### PR DESCRIPTION
*(This is a backport of PR #9999 to the `release/3.1` branch.)*

----

This patchset proposes a couple of enhancements for the `test.interactive_tarantool` testing helper.

* `:roundtrip()` now able to verify a response against `nil` and returns the response.
* The hide/show prompt feature (#7169) is now disabled by default.
* The new `connect()` function makes it easier to work with a remote console.

See the commit messages for details.

Part of #9985