### PR TITLE
console: autorequire frequently used modules

### DIFF
--- a/changelogs/unreleased/console-autorequire.md
+++ b/changelogs/unreleased/console-autorequire.md
@@ -1,0 +1,5 @@
+## feature/console
+
+* Interactive console now automatically adds frequently used built-in modules
+  into the initial environment if the `console_session_scope_vars` compat
+  option is set to `new` (gh-9986).

--- a/src/box/lua/console.lua
+++ b/src/box/lua/console.lua
@@ -52,6 +52,8 @@ compat.add_option({
     action = function() end,
 })
 
+local M = {}
+
 --
 -- Default output handler set to YAML for backward
 -- compatibility reason.
@@ -174,7 +176,7 @@ local function parse_output(value)
     return nil, fmt, opts, local_eos
 end
 
-local function set_default_output(value)
+function M.set_default_output(value)
     if value == nil then
         error("Nil output value passed")
     end
@@ -186,7 +188,7 @@ local function set_default_output(value)
     default_output_format["opts"] = opts
 end
 
-local function get_default_output(...)
+function M.get_default_output(...)
     local args = ...
     if args ~= nil then
         error("Arguments provided while prohibited")
@@ -236,7 +238,7 @@ end
 --
 -- Set/get current console EOS value from
 -- currently active output format.
-local function console_eos(eos_value)
+function M.eos(eos_value)
     if not eos_value then
         return tostring(current_eos())
     end
@@ -268,7 +270,7 @@ end
 --
 -- Set delimiter
 --
-local function delimiter(delim)
+function M.delimiter(delim)
     local self = fiber.self().storage.console
     if self == nil then
         error("console.delimiter(): need existing console")
@@ -288,7 +290,7 @@ local function set_delimiter(_storage, value)
         return error('Can not install delimiter for net box sessions')
     end
     value = value or ''
-    return delimiter(value)
+    return M.delimiter(value)
 end
 
 local function set_language(storage, value)
@@ -475,7 +477,7 @@ local function local_eval(storage, line)
     return format(unpack(res, 1, res.n))
 end
 
-local function eval(line)
+function M.eval(line)
     return local_eval(box.session.storage, line)
 end
 
@@ -859,7 +861,7 @@ local function repl(self)
     fiber.self().storage.console = nil
 end
 
-local function on_start(foo)
+function M.on_start(foo)
     if foo == nil or type(foo) == 'function' then
         repl_mt.__index.on_start = foo
         return
@@ -867,7 +869,7 @@ local function on_start(foo)
     error('Wrong type of on_start hook: ' .. type(foo))
 end
 
-local function on_client_disconnect(foo)
+function M.on_client_disconnect(foo)
     if foo == nil or type(foo) == 'function' then
         repl_mt.__index.on_client_disconnect = foo
         return
@@ -878,7 +880,7 @@ end
 --
 --
 --
-local function ac(yes_no)
+function M.ac(yes_no)
     local self = fiber.self().storage.console
     if self == nil then
         error("console.ac(): need existing console")
@@ -890,7 +892,7 @@ end
 -- Start REPL on stdin
 --
 local started = false
-local function start()
+function M.start()
     if started then
         error("console is already started")
     end
@@ -935,7 +937,7 @@ end
 --
 -- Connect to remote instance
 --
-local function connect(uri, opts)
+function M.connect(uri, opts)
     opts = opts or {}
 
     local self = fiber.self().storage.console
@@ -1035,7 +1037,7 @@ end
 --
 -- Start admin console
 --
-local function listen(uri)
+function M.listen(uri)
     local host, port
     if uri == nil then
         host = 'unix/'
@@ -1057,17 +1059,6 @@ local function listen(uri)
     return s
 end
 
-return {
-    start = start;
-    eval = eval;
-    delimiter = delimiter;
-    set_default_output = set_default_output;
-    get_default_output = get_default_output;
-    eos = console_eos;
-    ac = ac;
-    connect = connect;
-    listen = listen;
-    on_start = on_start;
-    on_client_disconnect = on_client_disconnect;
-    completion_handler = internal.completion_handler;
-}
+M.completion_handler = internal.completion_handler
+
+return M

--- a/test/app-luatest/console_autorequire_test.lua
+++ b/test/app-luatest/console_autorequire_test.lua
@@ -1,0 +1,172 @@
+local t = require('luatest')
+local it = require('test.interactive_tarantool')
+local cbuilder = require('test.config-luatest.cbuilder')
+local cluster = require('test.config-luatest.cluster')
+
+local g = t.group()
+
+local autorequire_list = {
+    'clock',
+    'compat',
+    'config',
+    'datetime',
+    'decimal',
+    'ffi',
+    'fiber',
+    'fio',
+    'fun',
+    'json',
+    'log',
+    'msgpack',
+    'popen',
+    'uuid',
+    'varbinary',
+    'yaml',
+}
+
+local function assert_no_autorequire(it)
+    it:roundtrip("require('strict').off()")
+
+    for _, m in ipairs(autorequire_list) do
+        it:roundtrip(m, nil)
+    end
+
+    it:roundtrip("require('strict').on()")
+end
+
+local function assert_autorequire(it)
+    for _, m in ipairs(autorequire_list) do
+        it:roundtrip(('type(%s)'):format(m), 'table')
+    end
+end
+
+g.before_all(cluster.init)
+g.after_each(cluster.drop)
+g.after_all(cluster.clean)
+
+g.after_each(function(g)
+    if g.it ~= nil then
+        g.it:close()
+        g.it = nil
+    end
+end)
+
+g.test_local_old_no_autorequire = function(g)
+    g.it = it.new()
+
+    g.it:roundtrip("require('compat').console_session_scope_vars = 'old'")
+    assert_no_autorequire(g.it)
+end
+
+g.test_local_new_autorequire = function(g)
+    g.it = it.new()
+
+    g.it:roundtrip("require('compat').console_session_scope_vars = 'new'")
+    assert_autorequire(g.it)
+end
+
+g.test_remote_old_no_autorequire = function(g)
+    local config = cbuilder.new()
+        :set_global_option('compat.console_session_scope_vars', 'old')
+        :add_instance('i-001', {})
+        :config()
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    g.it = it.connect(cluster['i-001'])
+    assert_no_autorequire(g.it)
+end
+
+g.test_remote_new_autorequire = function(g)
+    local config = cbuilder.new()
+        :set_global_option('compat.console_session_scope_vars', 'new')
+        :add_instance('i-001', {})
+        :config()
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    g.it = it.connect(cluster['i-001'])
+    assert_autorequire(g.it)
+end
+
+-- Add a variable into the initial console environment.
+g.test_remote_new_extend_env = function(g)
+    local config = cbuilder.new()
+        :set_global_option('compat.console_session_scope_vars', 'new')
+        :add_instance('i-001', {})
+        :config()
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    cluster['i-001']:exec(function()
+        local console = require('console')
+        local initial_env = console.initial_env()
+        initial_env.foo = 42
+    end)
+
+    g.it = it.connect(cluster['i-001'])
+    g.it:roundtrip('foo', 42)
+
+    -- All the autorequired modules are kept.
+    assert_autorequire(g.it)
+end
+
+g.test_remote_new_set_env_illegal_param = function(g)
+    local config = cbuilder.new()
+        :set_global_option('compat.console_session_scope_vars', 'new')
+        :add_instance('i-001', {})
+        :config()
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    cluster['i-001']:exec(function()
+        local console = require('console')
+
+        local exp_err = 'console.set_initial_env: expected table or nil, ' ..
+            'got number'
+        t.assert_error_msg_content_equals(exp_err, console.set_initial_env, 42)
+    end)
+end
+
+-- Set a user defined initial console environment.
+g.test_remote_new_set_env = function(g)
+    local config = cbuilder.new()
+        :set_global_option('compat.console_session_scope_vars', 'new')
+        :add_instance('i-001', {})
+        :config()
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    -- Replace the initial environment.
+    cluster['i-001']:exec(function()
+        local console = require('console')
+        console.set_initial_env({foo = 42})
+    end)
+
+    -- Verify that console.initial_env() reflects the change.
+    cluster['i-001']:exec(function()
+        local console = require('console')
+        t.assert_equals(console.initial_env(), {foo = 42})
+    end)
+
+    -- Verify that the new environment is in effect.
+    g.it = it.connect(cluster['i-001'])
+    g.it:roundtrip('foo', 42)
+
+    -- Verify that a console environment has no autorequired
+    -- modules anymore.
+    assert_no_autorequire(g.it)
+
+    g.it:close()
+    g.it = nil
+
+    -- Drop the initial environment to default.
+    cluster['i-001']:exec(function()
+        local console = require('console')
+        console.set_initial_env(nil)
+    end)
+
+    -- Verify that all the autorequired modules are there.
+    g.it = it.connect(cluster['i-001'])
+    assert_autorequire(g.it)
+end


### PR DESCRIPTION
There are built-in modules that are frequently used for administration or debugging purposes. It is convenient to have them accessible in the interactive console without extra actions.

They're accessible now without a manual `require` call if the `console_session_scope_vars` compat option is set to `new` (see also tarantool/doc#4191).

The list of the autorequired modules is below.

* clock
* compat
* config
* datetime
* decimal
* ffi
* fiber
* fio
* fun
* json
* log
* msgpack
* popen
* uuid
* varbinary
* yaml

See tarantool/tarantool#9986 for motivation behind this feature.

This list forms so called initial environment for an interactive console session. The default initial environment may be adjusted by an application, for example, to include application specific administrator functions.

Two public functions are added for this purpose: `console.initial_env()` and `console.set_initial_env(env)`.

Example 1 (keep autorequired modules, but add one more variable):

```lua
local console = require('console')

-- Add myapp_info function.
local initial_env = console.initial_env()
initial_env.myapp_info = function()
    <...>
end
```

Example 2 (replace the whole initial environment):

```lua
local console = require('console')

-- Add myapp_info function, discard the autorequired modules.
console.set_initial_env({
    myapp_info = function()
        <...>
    end,
})
```

The `console.set_initial_env()` call without an argument or with a `nil` argument drops the initial environment to its default.

A modification of the initial environment doesn't affect existing console sessions. It affects console sessions that are created after the modification.

Fixes #9986