### PR TITLE
vinyl: fix bug when tuple not committed to unique nullable index

### DIFF
--- a/changelogs/unreleased/gh-9769-vy-unique-nullable-index-fix.md
+++ b/changelogs/unreleased/gh-9769-vy-unique-nullable-index-fix.md
@@ -1,0 +1,4 @@
+## bugfix/vinyl
+
+* Fixed a bug in the transaction manager when a tuple was not committed to
+  a unique nullable secondary index (gh-9769).

--- a/test/engine-luatest/gh_9769_tuple_lost_in_unique_nullable_index_test.lua
+++ b/test/engine-luatest/gh_9769_tuple_lost_in_unique_nullable_index_test.lua
@@ -1,0 +1,45 @@
+local t = require('luatest')
+
+local server = require('luatest.server')
+
+local g = t.group(nil, t.helpers.matrix{engine = {'memtx', 'vinyl'}})
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+g.test_tuple_lost_in_unique_nullable_index = function(cg)
+    cg.server:exec(function(engine)
+        local s = box.schema.space.create('test', {
+            engine = engine,
+            format = {
+                {name = 'a', type = 'unsigned'},
+                {name = 'b', type = 'unsigned', is_nullable = true},
+            },
+        })
+        s:create_index('primary', {parts = {'a'}})
+        s:create_index('secondary', {parts = {'b'}, unique = true})
+        s:insert({1, 10})
+        box.atomic(function()
+            s:replace({1, 20})
+            s:insert({2, 10})
+        end)
+        t.assert_equals(s.index.primary:select({}, {fullscan = true}),
+                        {{1, 20}, {2, 10}})
+        t.assert_equals(s.index.secondary:select({}, {fullscan = true}),
+                        {{2, 10}, {1, 20}})
+    end, {cg.params.engine})
+end


### PR DESCRIPTION
A unique nullable key definition extended with primary key parts (`cmp_def`) assumes that two tuples are equal *without* comparing primary key fields if all secondary key fields are equal and not nulls, see `tuple_compare_slowpath()`. This is a hack required to ignore the uniqueness constraint for nulls in memtx. The memtx engine can't use the secondary key definition as is (`key_def`) for comparing tuples in the index tree, as it does for a non-nullable unique index, because this wouldn't allow insertion of any duplicates, including nulls. It couldn't use `cmp_def` without this hack, either, because then conflicting tuples with the same secondary key fields would always compare as not equal due to different primary key parts.

For Vinyl, this hack isn't required because it explicitly skips the uniqueness check if any of the indexed fields are nulls, see `vy_check_is_unique_secondary()`. Furthermore, this hack is harmful because Vinyl relies on the fact that two tuples compare as equal by `cmp_def` if and only if *all* key fields (both secondary and primary) are equal. For example, this is used in the transaction manager, which overwrites statements equal by `cmp_def`, see `vy_tx_set_entry()`.

Let's disable this hack by resetting `unique_part_count` in `cmp_def`.

Closes #9769