### PR TITLE
perf: speed up column scan test initialization

### DIFF
--- a/perf/lua/column_scan.lua
+++ b/perf/lua/column_scan.lua
@@ -104,7 +104,7 @@ box.once('init', function()
             end
         end
         s:insert(tuple)
-        if i % 1000 then
+        if i % 1000 == 0 then
             box.commit()
             local pct = math.floor(100 * i / params.row_count)
             if pct ~= pct_complete then


### PR DESCRIPTION
It was intended to do 1000 inserts per transaction, but by mistake `box.commit()` was called after each insertion.