### PR TITLE
vinyl: fix index build crash on invalid UPSERT

### DIFF
--- a/changelogs/unreleased/gh-10026-vy-index-build-crash-on-invalid-upsert-fix.md
+++ b/changelogs/unreleased/gh-10026-vy-index-build-crash-on-invalid-upsert-fix.md
@@ -1,0 +1,4 @@
+## bugfix/vinyl
+
+* Fixed a bug when creation of a new index crashed while trying to process
+  an invalid `UPSERT` statement (gh-10026).

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -2183,8 +2183,13 @@ vy_upsert(struct vy_env *env, struct vy_tx *tx, struct txn_stmt *stmt,
 		diag_log();
 		/*
 		 * Upsert is skipped, to match the semantics of
-		 * vy_lsm_upsert().
+		 * vy_lsm_upsert(). Clear the statement so that
+		 * vy_build_on_replace() doesn't try to apply it.
 		 */
+		tuple_unref(stmt->old_tuple);
+		tuple_unref(stmt->new_tuple);
+		stmt->old_tuple = NULL;
+		stmt->new_tuple = NULL;
 		return 0;
 	}
 	return vy_perform_update(env, tx, stmt, space, pk, column_mask);

--- a/test/engine-luatest/gh_10026_index_build_crash_on_invalid_upsert_test.lua
+++ b/test/engine-luatest/gh_10026_index_build_crash_on_invalid_upsert_test.lua
@@ -1,0 +1,47 @@
+local t = require('luatest')
+
+local server = require('luatest.server')
+
+local g = t.group(nil, t.helpers.matrix{engine = {'memtx', 'vinyl'}})
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        box.error.injection.set('ERRINJ_BUILD_INDEX_DELAY', false)
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+g.test_index_build_crash_on_invalid_upsert = function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server:exec(function(engine)
+        local fiber = require('fiber')
+        local s = box.schema.space.create('test', {engine = engine,})
+        s:create_index('primary')
+        for i = 1, 5 do
+            s:insert({i, i * 10})
+        end
+        box.error.injection.set('ERRINJ_BUILD_INDEX_DELAY', true)
+        local f = fiber.new(s.create_index, s, 'secondary',
+                            {parts = {2, 'unsigned'}})
+        f:set_joinable(true)
+        for i = 1, 5 do
+            s:upsert({i, i * 100}, {{'+', 1, 1}})
+        end
+        box.error.injection.set('ERRINJ_BUILD_INDEX_DELAY', false)
+        f:join()
+        t.assert(s.index.secondary)
+        t.assert_equals(s.index.secondary:select({}, {fullscan = true}),
+                        {{1, 10}, {2, 20}, {3, 30}, {4, 40}, {5, 50}})
+    end, {cg.params.engine})
+end

--- a/test/vinyl/on_replace.result
+++ b/test/vinyl/on_replace.result
@@ -788,8 +788,8 @@ space:upsert({1, 1, 1}, {{'+', 2, 1}}) -- must fail
 ...
 old_tuple, new_tuple
 ---
+- [1, 1, 1]
 - [1, 1, 2]
-- [1, 2, 2]
 ...
 space:upsert({4, 4, 4}, {{'!', 4, 400}})
 ---


### PR DESCRIPTION
Like `UPDATE`, `UPSERT` must not modify primary key parts. Unlike `UPDATE`, such an invalid `UPSERT` statement doesn't fail (raise an error) - we just log the error and ignore the statement. The problem is, we don't clear `txn_stmt`. As a result, if we're currently building a new index, the `on_replace` trigger installed by the build procedure will try to process this statement, triggering the assertion in the transaction manager that doesn't expect any statements in a secondary index without the corresponding statement in the primary index:

```
./src/box/vy_tx.c:728: vy_tx_prepare: Assertion `lsm->space_id == current_space_id' failed.
```

Let's fix this by clearing the `txn_stmt` corresponding to a skipped `UPSERT`.

Note, this also means that `on_replace` triggers installed by the user won't run on invalid `UPSERT` (hence `test/vinyl/on_replace.result` update), but this is consistent with the memtx engine, which doesn't run them in this case, either.

Closes #10026