### PR TITLE
core: build fix for recent gcc

### DIFF
--- a/src/lib/core/coio_task.c
+++ b/src/lib/core/coio_task.c
@@ -111,9 +111,7 @@ static int
 coio_on_start(void *data)
 {
 	(void) data;
-	struct cord *cord = (struct cord *)calloc(sizeof(struct cord), 1);
-	if (!cord)
-		return -1;
+	struct cord *cord = xcalloc(1, sizeof(struct cord));
 	cord_create(cord, "coio");
 	return 0;
 }


### PR DESCRIPTION
```
/home/shiny/dev/tarantool/src/lib/core/coio_task.c:114:58:
	error: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument
	and not in the later argument [-Werror=calloc-transposed-args]
  114 |         struct cord *cord = (struct cord *)calloc(sizeof(struct cord), 1);
```