### PR TITLE
config: give better error if a role is not a table

### DIFF
--- a/changelogs/unreleased/config-not-a-table-role-error-message.md
+++ b/changelogs/unreleased/config-not-a-table-role-error-message.md
@@ -1,0 +1,4 @@
+## bugfix/config
+
+* Improved an error message on an attempt to use a non-table module as a role
+  (gh-10049).

--- a/src/box/lua/config/applier/roles.lua
+++ b/src/box/lua/config/applier/roles.lua
@@ -138,6 +138,11 @@ local function post_apply(config)
         if not role then
             log.verbose('roles.post_apply: load role ' .. role_name)
             role = require(role_name)
+            if type(role) ~= 'table' then
+                local err = 'Unable to use module %s as a role: ' ..
+                    'expected table, got %s'
+                error(err:format(role_name, type(role)), 0)
+            end
             local funcs = {'validate', 'apply', 'stop'}
             for _, func_name in pairs(funcs) do
                 if type(role[func_name]) ~= 'function' then

--- a/test/config-luatest/roles_test.lua
+++ b/test/config-luatest/roles_test.lua
@@ -619,3 +619,20 @@ g.test_role_started_and_stopped_after_config_loaded = function(g)
         verify_2 = verify_2,
     })
 end
+
+-- Ensure that a descriptive error is raised if the given module
+-- is not a table.
+g.test_role_is_not_a_table = function(g)
+    local myrole = string.dump(function()
+        return 42
+    end)
+
+    helpers.failure_case(g, {
+        roles = {myrole = myrole},
+        options = {
+            ['roles'] = {'myrole'}
+        },
+        exp_err = 'Unable to use module myrole as a role: ' ..
+            'expected table, got number',
+    })
+end


### PR DESCRIPTION
An attempt to use a non-table module as a role now reports a more descriptive error:

> Unable to use module <...> as a role: expected table, got <...>

Fixes #10049