### PR TITLE
[backport 3.1] ci: temporary disable aarch64 packaging job

### DIFF
--- a/.github/workflows/distrib.yml
+++ b/.github/workflows/distrib.yml
@@ -62,26 +62,27 @@ jobs:
       }'
     secrets: inherit
 
-  packaging-aarch64:
-    # Run on push to the 'master' and release branches of tarantool/tarantool
-    # or on pull request if the 'full-ci' or 'static-build-ci' label is set.
-    if: github.repository == 'tarantool/tarantool' &&
-        ( github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'full-ci') ||
-          contains(github.event.pull_request.labels.*.name, 'static-build-ci') )
-
-    uses: ./.github/workflows/packaging_build_test_deploy.yml
-    with:
-      arch: aarch64
-      test-matrix: '{
-        "include": [
-          {"os": "debian-buster"}, {"os": "debian-bullseye"},
-          {"os": "centos-8"},
-          {"os": "fedora-35"}, {"os": "fedora-36"},
-          {"os": "ubuntu-focal"}, {"os": "ubuntu-jammy"}
-        ]
-      }'
-    secrets: inherit
+# Uncomment this job when aarch64 runners will be up.
+#  packaging-aarch64:
+#    # Run on push to the 'master' and release branches of tarantool/tarantool
+#    # or on pull request if the 'full-ci' or 'static-build-ci' label is set.
+#    if: github.repository == 'tarantool/tarantool' &&
+#        ( github.event_name != 'pull_request' ||
+#          contains(github.event.pull_request.labels.*.name, 'full-ci') ||
+#          contains(github.event.pull_request.labels.*.name, 'static-build-ci') )
+#
+#    uses: ./.github/workflows/packaging_build_test_deploy.yml
+#    with:
+#      arch: aarch64
+#      test-matrix: '{
+#        "include": [
+#          {"os": "debian-buster"}, {"os": "debian-bullseye"},
+#          {"os": "centos-8"},
+#          {"os": "fedora-35"}, {"os": "fedora-36"},
+#          {"os": "ubuntu-focal"}, {"os": "ubuntu-jammy"}
+#        ]
+#      }'
+#    secrets: inherit
 
   docker:
     # Run on push of a tag except '*-entrypoint' to tarantool/tarantool.
@@ -89,7 +90,7 @@ jobs:
         startsWith(github.ref, 'refs/tags/') &&
         !endsWith(github.ref, '-entrypoint')
 
-    needs: [ packaging-x86_64, packaging-aarch64 ]
+    needs: [ packaging-x86_64 ] #, packaging-aarch64 ]
 
     uses: ./.github/workflows/docker_build_push.yml
     secrets: inherit


### PR DESCRIPTION
*(This is a backport of PR #10048 to `release/3.1`.)*

----

We are experiencing some issues with aarch64 runners at this moment, so we have to disable aarch64 packaging job until the issue is resolved. Other aarch64 jobs can be disabled via GitHub UI, so let's do it there.