### PR TITLE
[DRAFT]: Collect, aggregate and send perf statistics to InfluxDB

### DIFF
--- a/.github/workflows/perf_micro.yml
+++ b/.github/workflows/perf_micro.yml
@@ -72,6 +72,19 @@ jobs:
           revision: ${{ inputs.revision }}
       - name: test
         run: make -f .test.mk test-perf
+      - name: Send statistics to InfluxDB
+        # TODO: For now, use the debug bucket for this PoC.
+        # --silent -o /dev/null: Prevent dumping any reply part
+        # in the output in case of an error.
+        # --fail: Exit with the 22 error code is status >= 400.
+        # -w: See the reason for the failure, if any.
+        run: |
+          curl --request POST \
+          "${{ secrets.INFLUXDB_URL }}/api/v2/write?org=tarantool&bucket=perf-debug&precision=s" \
+          --fail --silent -o /dev/null \
+          -w "%{http_code}" \
+          --header "Authorization: Token ${{ secrets.INFLUXDB_TOKEN_DEBUG }}" \
+          --data-binary ./perf_output/perf_summary.txt
       - name: Send VK Teams message on failure
         if: failure()
         uses: ./.github/actions/report-job-status

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ doc/*/Makefile
 extra/Makefile
 extra/*/Makefile
 perf/Makefile
+perf/lua/Makefile
 test/Makefile
 test/*/Makefile
 test/*/*/Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ extra/Makefile
 extra/*/Makefile
 perf/Makefile
 perf/lua/Makefile
+perf_output/
 test/Makefile
 test/*/Makefile
 test/*/*/Makefile

--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -5,6 +5,16 @@ file(MAKE_DIRECTORY ${PERF_OUTPUT_DIR})
 
 add_subdirectory(lua)
 
+set(TARANTOOL_BIN $<TARGET_FILE:tarantool>)
+add_custom_target(test-perf-aggregate
+                  DEPENDS test-c-perf test-lua-perf
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                  COMMAND ${TARANTOOL_BIN} ${CMAKE_CURRENT_SOURCE_DIR}/tools/aggregate.lua
+                    --output=${PERF_OUTPUT_DIR}/perf_summary.txt
+                    --input_dir=${PERF_OUTPUT_DIR}
+                  COMMENT "Aggregate performance test results"
+)
+
 find_package(benchmark QUIET)
 if (NOT ${benchmark_FOUND})
     message(AUTHOR_WARNING "Google Benchmark library was not found")
@@ -14,7 +24,7 @@ if (NOT ${benchmark_FOUND})
                       COMMENT ${MSG}
     )
     add_custom_target(test-perf
-                      DEPENDS test-c-perf test-lua-perf
+                      DEPENDS test-perf-aggregate
                       COMMENT "Running performance tests"
     )
     return()
@@ -100,6 +110,6 @@ add_custom_target(test-c-perf
 )
 
 add_custom_target(test-perf
-                  DEPENDS test-c-perf test-lua-perf
+                  DEPENDS test-perf-aggregate
                   COMMENT "Running performance tests"
 )

--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -1,5 +1,8 @@
 set(CMAKE_CXX_STANDARD 14)
 
+set(PERF_OUTPUT_DIR ${PROJECT_BINARY_DIR}/perf_output)
+file(MAKE_DIRECTORY ${PERF_OUTPUT_DIR})
+
 add_subdirectory(lua)
 
 find_package(benchmark QUIET)
@@ -40,6 +43,8 @@ function(create_perf_test_target)
   message(STATUS "Creating C performance test ${PERF_TARGET}_perftest")
   add_custom_target(${PERF_TARGET}_perftest
                     COMMAND "$<TARGET_FILE:${PERF_TARGET}.perftest>"
+                            "--benchmark_out_format=json"
+                            "--benchmark_out=${PERF_OUTPUT_DIR}/${PERF_TARGET}.json"
                     DEPENDS ${PERF_TARGET}.perftest
                     COMMENT Running ${PERF_TARGET}_perftest
   )

--- a/perf/bps_tree.cc
+++ b/perf/bps_tree.cc
@@ -120,6 +120,7 @@
 	type##_##func##_size_##size(benchmark::State &state) \
 	{ \
 		test_##func<type>(state, size); \
+		state.SetItemsProcessed(size); \
 	} \
 	BENCHMARK(type##_##func##_size_##size)
 
@@ -128,6 +129,7 @@
 	type##_##func##_height_##height(benchmark::State &state) \
 	{ \
 		test_##func<type>(state, type::height_##height##_max_size); \
+		state.SetItemsProcessed(type::height_##height##_max_size); \
 	} \
 	BENCHMARK(type##_##func##_height_##height)
 

--- a/perf/lua/CMakeLists.txt
+++ b/perf/lua/CMakeLists.txt
@@ -23,6 +23,8 @@ function(create_perf_lua_test)
                     COMMAND env
                       LUA_PATH="${LUA_PATH}"
                       ${TARANTOOL_BIN} ${TEST_PATH}
+                        --output="${PERF_OUTPUT_DIR}/${PERF_NAME}.json"
+                        --output_format=json
                     COMMENT Running ${PERF_NAME}_perftest
                     DEPENDS tarantool ${TEST_PATH}
                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/perf/lua/CMakeLists.txt
+++ b/perf/lua/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(TARANTOOL_BIN $<TARGET_FILE:tarantool>)
 set(RUN_PERF_LUA_TESTS_LIST "")
 
+set(LUA_PATH "${CMAKE_CURRENT_SOURCE_DIR}/?.lua\;\;")
+
 function(create_perf_lua_test)
   set(prefix PERF)
   set(noValues)
@@ -18,7 +20,9 @@ function(create_perf_lua_test)
   message(STATUS "Creating Lua performance test ${PERF_NAME}_perftest")
   set(TEST_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${PERF_NAME}.lua)
   add_custom_target(${PERF_NAME}_perftest
-                    COMMAND ${TARANTOOL_BIN} ${TEST_PATH}
+                    COMMAND env
+                      LUA_PATH="${LUA_PATH}"
+                      ${TARANTOOL_BIN} ${TEST_PATH}
                     COMMENT Running ${PERF_NAME}_perftest
                     DEPENDS tarantool ${TEST_PATH}
                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/perf/lua/benchmark.lua
+++ b/perf/lua/benchmark.lua
@@ -1,0 +1,63 @@
+local json = require('json')
+
+local M = {}
+
+local function format_report(bench)
+    local output_format = bench.output_format
+    local results = bench.results
+    local report = ''
+    if output_format == 'json' then
+        -- The output should have the same format as the Google
+        -- Benchmark.
+        report = json.encode({benchmarks = results})
+    else
+        assert(output_format == 'console', 'unkonwn output format')
+        for _, res in ipairs(results) do
+            report = report .. ('%s %d rps\n'):format(res.name,
+                                                      res.items_per_second)
+        end
+    end
+    return report
+end
+
+local function dump_report(bench, text)
+    local output = bench.output
+    if output then
+        local fh = assert(io.open(output, 'w'))
+        fh:write(text)
+        fh:close()
+    else
+        io.stdout:write(text)
+    end
+end
+
+local function add_result(bench, name, real_time, cpu_time, items)
+    local items_per_second = math.floor(items / real_time)
+    local result = {
+        name = name,
+        real_time = real_time,
+        cpu_time = cpu_time,
+        iterations = items,
+        items_per_second = items_per_second,
+    }
+    table.insert(bench.results, result)
+    return result
+end
+
+local function dump_results(bench)
+    dump_report(bench, format_report(bench))
+end
+
+function M.init(opts)
+    assert(type(opts) == 'table', 'given argument should be a table')
+    return setmetatable({
+        output = opts.output,
+        output_format = opts.output_format or 'console',
+        results = {},
+    }, {__index = {
+        add_result = add_result,
+        dump_results = dump_results,
+    }})
+end
+
+return M

--- a/perf/lua/column_scan.lua
+++ b/perf/lua/column_scan.lua
@@ -132,7 +132,7 @@ end
 
 local TESTS = {
     {
-        name = 'sum,first',
+        name = 'sum_first',
         func = function()
             local result = test_funcs.sum(box.space.test.id, 0, 0)
             local row_count = ffi.cast('uint64_t', params.row_count)
@@ -140,7 +140,7 @@ local TESTS = {
         end,
     },
     {
-        name = 'sum,last',
+        name = 'sum_last',
         func = function()
             local result = test_funcs.sum(box.space.test.id, 0,
                                            params.column_count - 1)

--- a/perf/tools/aggregate.lua
+++ b/perf/tools/aggregate.lua
@@ -1,0 +1,92 @@
+-- File to aggregate the benchmark results from JSON files to the
+-- format parsable by the InfluxDB line protocol [1]:
+-- <measurement>,<tag_set> <field_set> <timestamp>
+--
+-- <tag_set> and <field_set> have the following format:
+-- <key1>=<value1>,<key2>=<value2>
+--
+-- The reported tag set is a set of values that can be used for
+-- filtering data (i.e., branch or benchmark name).
+--
+-- The script accepts the following parameters:
+--
+-- <input_dir> -- the directory from which the .json files are
+--                taken.
+-- <output>    -- the filename where the results are saved.
+--
+-- [1]: https://docs.influxdata.com/influxdb/v1/write_protocols/line_protocol_tutorial/
+
+local json = require('json')
+local fio = require('fio')
+
+local params = require('internal.argparse').parse(arg, {
+    {'input_dir', 'string'},
+    {'output', 'string'},
+})
+
+local input_dir = params.input_dir
+assert(input_dir and fio.path.is_dir(input_dir),
+       'given input_dir is not a directory')
+
+local output = params.output
+local out_fh = assert(io.open(output, 'w'))
+
+local function exec(cmd)
+    return io.popen(cmd):read('*all'):gsub('^%s+', ''):gsub('%s+$', '')
+end
+
+local commit = exec('git rev-parse --short HEAD')
+assert(commit, 'can not determine the commit')
+
+local branch = exec('git rev-parse --abbrev-ref HEAD')
+assert(branch, 'can not determine the branch')
+
+local tag_set = ('branch=%s'):format(branch)
+
+local function read_all(file)
+    local fh = assert(io.open(file, 'rb'))
+    local content = fh:read('*all')
+    fh:close()
+    return content
+end
+
+local REPORTED_FIELDS = {
+    'cpu_time',
+    'items_per_second',
+    'iterations',
+    'real_time',
+}
+
+local time = os.time()
+
+for _, file in pairs(fio.listdir(input_dir)) do
+    -- Skip files in which we are not interested.
+    if not file:match('%.json$') then goto continue end
+
+    local data = read_all(('%s/%s'):format(input_dir, file))
+    local bench_name = fio.basename(file, '.json')
+    local benchmarks = json.decode(data).benchmarks
+
+    for _, bench in ipairs(benchmarks) do
+        local full_tag_set = tag_set .. (',name=%s'):format(bench.name)
+
+        -- Save commit as a field, since we don't want to filter
+        -- benchmarks by the commit (one point of data).
+        local field_set = {('commit="%s"'):format(commit)}
+
+        for _, field in ipairs(REPORTED_FIELDS) do
+            -- XXX: The stub for the `small` benchmark.
+            if bench[field] then
+                table.insert(field_set, ('%s=%s'):format(field, bench[field]))
+            end
+        end
+
+        local line = ('%s,%s %s %d\n'):format(
+            bench_name, full_tag_set, table.concat(field_set, ','), time
+        )
+        out_fh:write(line)
+    end
+    ::continue::
+end
+
+out_fh:close()


### PR DESCRIPTION
This patchset standardizes the output of all benchmarks in the perf directory to have similar output to [the Google Benchmark](https://github.com/google/benchmark). It aggregates all results in the <perf_output/perf_summary.txt> file in [InfluxDB line protocol](https://docs.influxdata.com/influxdb/v1/write_protocols/line_protocol_tutorial/) format and sends this file in a separate step to the corresponding InfluxDB bucket.
