### PR TITLE
Add the extra include directory for salad library

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -136,6 +136,7 @@ include_directories(${ZSTD_INCLUDE_DIRS})
 include_directories(${PROJECT_BINARY_DIR}/src/box/sql)
 include_directories(${PROJECT_BINARY_DIR}/src/box)
 include_directories(${EXTRA_CORE_INCLUDE_DIRS})
+include_directories(${EXTRA_SALAD_INCLUDE_DIRS})
 include_directories(${EXTRA_BOX_INCLUDE_DIRS})
 
 add_library(box_error STATIC error.cc errcode.c mp_error.cc)


### PR DESCRIPTION
It's used to introduce new data structures in the Tarantool EE.

NO_DOC=no functional changes
NO_TEST=no functional changes
NO_CHANGELOG=no functional changes