### PR TITLE
box: store space name and engine name in `index_def` for error reporting

### DIFF
--- a/perf/memtx.cc
+++ b/perf/memtx.cc
@@ -160,8 +160,10 @@ private:
 		if (key_def == nullptr)
 			panic("failed to create new key definition");
 		tree_idx_def = ::index_def_new(sid, tree_index_id, "pk",
-					       std::strlen("pk"), TREE,
-					       &idx_opts, key_def,
+					       std::strlen("pk"),
+					       space_def->name,
+					       space_def->engine_name,
+					       TREE, &idx_opts, key_def,
 					       /*pk_def=*/nullptr);
 		if (tree_idx_def == nullptr)
 			panic("failed to create new index definition");

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -390,8 +390,9 @@ index_def_new_from_tuple(struct tuple *tuple, struct space *space)
 	if (key_def == NULL)
 		return NULL;
 	struct index_def *index_def =
-		index_def_new(id, index_id, name, name_len, type,
-			      &opts, key_def, space_index_key_def(space, 0));
+		index_def_new(id, index_id, name, name_len, space->def->name,
+			      space->def->engine_name, type, &opts, key_def,
+			      space_index_key_def(space, 0));
 	if (index_def == NULL)
 		return NULL;
 	auto index_def_guard = make_scoped_guard([=] { index_def_delete(index_def); });
@@ -1770,6 +1771,8 @@ alter_space_move_indexes(struct alter_space *alter, uint32_t begin,
 		 */
 		new_def = index_def_new(old_def->space_id, old_def->iid,
 					old_def->name, strlen(old_def->name),
+					old_def->space_name,
+					old_def->engine_name,
 					old_def->type, &old_def->opts,
 					old_def->key_def, alter->pk_def);
 		index_def_update_optionality(new_def, min_field_count);

--- a/src/box/index_def.h
+++ b/src/box/index_def.h
@@ -33,6 +33,7 @@
 
 #include "key_def.h"
 #include "opt_def.h"
+#include "schema_def.h"
 #include "small/rlist.h"
 
 #if defined(__cplusplus)
@@ -160,19 +161,23 @@ index_opts_cmp(const struct index_opts *o1, const struct index_opts *o2)
 
 /* Definition of an index. */
 struct index_def {
-	/* A link in key list. */
+	/** A link in key list. */
 	struct rlist link;
 	/** Ordinal index number in the index array. */
 	uint32_t iid;
-	/* Space id. */
+	/** Space id. */
 	uint32_t space_id;
+	/** Space name. */
+	char *space_name;
+	/** Engine name. */
+	char engine_name[ENGINE_NAME_MAX + 1];
 	/** Index name. */
 	char *name;
 	/** Index type. */
 	enum index_type type;
 	struct index_opts opts;
 
-	/* Index key definition. */
+	/** Index key definition. */
 	struct key_def *key_def;
 	/**
 	 * User-defined key definition, merged with the primary
@@ -275,7 +280,8 @@ index_def_list_add(struct rlist *index_def_list, struct index_def *index_def)
  */
 struct index_def *
 index_def_new(uint32_t space_id, uint32_t iid, const char *name,
-	      uint32_t name_len, enum index_type type,
+	      uint32_t name_len, const char *space_name,
+	      const char *engine_name, enum index_type type,
 	      const struct index_opts *opts,
 	      struct key_def *key_def, struct key_def *pk_def);
 

--- a/src/box/schema.cc
+++ b/src/box/schema.cc
@@ -211,6 +211,11 @@ sc_space_new(uint32_t id, const char *name,
 	     uint32_t key_part_count,
 	     struct trigger *replace_trigger)
 {
+	struct space_def *def =
+		space_def_new_xc(id, ADMIN, 0, name, strlen(name), "memtx",
+				 strlen("memtx"), &space_opts_default, NULL, 0,
+				 NULL, 0);
+	auto def_guard = make_scoped_guard([=] { space_def_delete(def); });
 	struct key_def *key_def = key_def_new(key_parts, key_part_count, 0);
 	if (key_def == NULL)
 		diag_raise();
@@ -220,6 +225,8 @@ sc_space_new(uint32_t id, const char *name,
 						    0 /* index id */,
 						    "primary", /* name */
 						    strlen("primary"),
+						    def->name, /* space name */
+						    def->engine_name,
 						    TREE /* index type */,
 						    &index_opts_default,
 						    key_def, NULL);
@@ -227,11 +234,6 @@ sc_space_new(uint32_t id, const char *name,
 		diag_raise();
 	auto index_def_guard =
 		make_scoped_guard([=] { index_def_delete(index_def); });
-	struct space_def *def =
-		space_def_new_xc(id, ADMIN, 0, name, strlen(name), "memtx",
-				 strlen("memtx"), &space_opts_default, NULL, 0,
-				 NULL, 0);
-	auto def_guard = make_scoped_guard([=] { space_def_delete(def); });
 	struct rlist key_list;
 	rlist_create(&key_list);
 	rlist_add_entry(&key_list, index_def, link);

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -2654,8 +2654,9 @@ index_fill_def(struct Parse *parse, struct index *index,
 	 * only for comparison routine. Meanwhile on front-end
 	 * side only definition is used.
 	 */
-	index->def = index_def_new(space_def->id, 0, name, name_len, TREE,
-				   &opts, key_def, NULL);
+	index->def = index_def_new(space_def->id, 0, name, name_len,
+				   space_def->name, space_def->engine_name,
+				   TREE, &opts, key_def, NULL);
 	if (index->def == NULL)
 		goto tnt_error;
 	index->def->iid = iid;

--- a/src/box/sql/where.c
+++ b/src/box/sql/where.c
@@ -895,8 +895,10 @@ constructAutomaticIndex(Parse * pParse,			/* The parsing context */
 	index_opts_create(&opts);
 	const char *idx_name = "ephemeral index";
 	struct index_def *idx_def = index_def_new(space->def->id, 0, idx_name,
-						  strlen(idx_name), TREE, &opts,
-						  key_def, NULL);
+						  strlen(idx_name),
+						  space->def->name,
+						  space->def->engine_name,
+						  TREE, &opts, key_def, NULL);
 	key_def_delete(key_def);
 	if (idx_def == NULL) {
 		pParse->is_aborted = true;
@@ -2133,8 +2135,10 @@ tnt_error:
 
 		struct index_opts opts;
 		index_opts_create(&opts);
-		fake_index = index_def_new(space->def->id, 0,"fake_autoindex",
+		fake_index = index_def_new(space->def->id, 0, "fake_autoindex",
 					   sizeof("fake_autoindex") - 1,
+					   space->def->name,
+					   space->def->engine_name,
 					   TREE, &opts, key_def, NULL);
 		key_def_delete(key_def);
 		if (fake_index == NULL)

--- a/test/unit/vy_point_lookup.c
+++ b/test/unit/vy_point_lookup.c
@@ -94,7 +94,8 @@ test_basic()
 
 	struct index_opts index_opts = index_opts_default;
 	struct index_def *index_def =
-		index_def_new(512, 0, "primary", sizeof("primary") - 1, TREE,
+		index_def_new(512, 0, "primary", sizeof("primary") - 1,
+			      NULL, NULL, TREE,
 			      &index_opts, key_def, NULL);
 
 	struct vy_lsm *pk = vy_lsm_new(&lsm_env, &cache_env, &mem_env,


### PR DESCRIPTION
This patch fixes a bug that was introduced by commit https://github.com/tarantool/tarantool/commit/8fc59b101c10cf71fbb157b6f98b64eb8155ae63 that adds helper functions for initializing payloads of DML errors related to key validation.

The problem was that after the space was deleted, a situation could occur that the `space.def->name` was still needed to generate an error message if the key format was incorrect in the `get()` call from `read_view`.

This is exactly what happened sometimes in the function `error_set_index`. One of the bug reproducers was to try to `get()` with an incorrect key format (`ER_EXACT_MATCH`) in `read_view` from deleted space.

The problem has been fixed: space name as well as engine name are also `index_def` fields now. There is no need to search for space and get these fields from it.

Also some other places where space name and engine name could be taken from `index_def` has been fixed.

Needed for tarantool/tarantool-ee#787

NO_DOC=bugfix
NO_TEST=ee
NO_CHANGELOG=bug not released