### PR TITLE
vinyl: fix crash on extending secondary key parts with  primary

### DIFF
--- a/changelogs/unreleased/gh-10095-vy-index-update-def-fix.md
+++ b/changelogs/unreleased/gh-10095-vy-index-update-def-fix.md
@@ -1,0 +1,4 @@
+## bugfix/vinyl
+
+* Fixed a bug when a DDL operation crashed in case of extending the key parts
+  of a secondary index with the primary index key parts (gh-10095).

--- a/test/vinyl-luatest/gh_10095_update_index_def_test.lua
+++ b/test/vinyl-luatest/gh_10095_update_index_def_test.lua
@@ -1,0 +1,35 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+g.test_update_index_def = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('test', {engine = 'vinyl'})
+        s:create_index('pk')
+        s:create_index('sk', {parts = {{2, 'unsigned'}}})
+        s:insert({1, 10, 100})
+        t.assert_equals(s.index.sk:get({10}), {1, 10, 100})
+        s.index.sk:alter({parts = {{2, 'unsigned'}, {1, 'unsigned'}}})
+        t.assert_equals(s.index.sk:get({10, 1}), {1, 10, 100})
+        s.index.sk:alter({parts = {{2, 'unsigned'}, {3, 'unsigned'}}})
+        t.assert_equals(s.index.sk:get({10, 100}), {1, 10, 100})
+    end)
+end


### PR DESCRIPTION
If a secondary index is altered in such a way that its key parts are extended with the primary key parts, rebuild isn't required because `cmp_def` doesn't change, see `vinyl_index_def_change_requires_rebuild`. In this case `vinyl_index_update_def` will try to update `key_def` and `cmp_def` in-place with `key_def_copy`. This will lead to a crash because the number of parts in the new `key_def` is greater.

We can't use `key_def_dup` instead of `key_def_copy` there because there may be read iterators using the old `key_def` by pointer so there's no other option but to force rebuild in this case.

The bug was introduced in commit 64817066ff60.

Closes #10095