### PR TITLE
Revert "ci: temporary disable aarch64 packaging job"

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -94,8 +94,11 @@ runs:
         git submodule foreach --recursive 'git clean -xffd'
 
         # See for details: https://github.com/tarantool/tarantool/issues/7472.
-        # Do nothing on GitHub-hosted runners.
-        if ${{ runner.os == 'Linux' &&
+        # However, this workaround doesn't work on our aarch64 runners due to
+        # the following error:
+        #     mount: /tmp/luajit-test-vardir: mount failed: Operation not permitted
+        # Looks like it happens because our aarch64 runners are LXD containers.
+        if ${{ runner.os == 'Linux' && runner.arch != 'ARM64' &&
                !contains(runner.name, 'GitHub Actions') }}; then
             LUAJIT_TEST_VARDIR=/tmp/luajit-test-vardir
             LUAJIT_TEST_VARDIR_DISK=/tmp/luajit-test-vardir-disk/disk.ext4

--- a/.github/workflows/distrib.yml
+++ b/.github/workflows/distrib.yml
@@ -62,27 +62,26 @@ jobs:
       }'
     secrets: inherit
 
-# Uncomment this job when aarch64 runners will be up.
-#  packaging-aarch64:
-#    # Run on push to the 'master' and release branches of tarantool/tarantool
-#    # or on pull request if the 'full-ci' or 'static-build-ci' label is set.
-#    if: github.repository == 'tarantool/tarantool' &&
-#        ( github.event_name != 'pull_request' ||
-#          contains(github.event.pull_request.labels.*.name, 'full-ci') ||
-#          contains(github.event.pull_request.labels.*.name, 'static-build-ci') )
-#
-#    uses: ./.github/workflows/packaging_build_test_deploy.yml
-#    with:
-#      arch: aarch64
-#      test-matrix: '{
-#        "include": [
-#          {"os": "debian-buster"}, {"os": "debian-bullseye"},
-#          {"os": "centos-8"},
-#          {"os": "fedora-35"}, {"os": "fedora-36"},
-#          {"os": "ubuntu-focal"}, {"os": "ubuntu-jammy"}
-#        ]
-#      }'
-#    secrets: inherit
+  packaging-aarch64:
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' or 'static-build-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') ||
+          contains(github.event.pull_request.labels.*.name, 'static-build-ci') )
+
+    uses: ./.github/workflows/packaging_build_test_deploy.yml
+    with:
+      arch: aarch64
+      test-matrix: '{
+        "include": [
+          {"os": "debian-buster"}, {"os": "debian-bullseye"},
+          {"os": "centos-8"},
+          {"os": "fedora-35"}, {"os": "fedora-36"},
+          {"os": "ubuntu-focal"}, {"os": "ubuntu-jammy"}
+        ]
+      }'
+    secrets: inherit
 
   docker:
     # Run on push of a tag except '*-entrypoint' to tarantool/tarantool.
@@ -90,7 +89,7 @@ jobs:
         startsWith(github.ref, 'refs/tags/') &&
         !endsWith(github.ref, '-entrypoint')
 
-    needs: [ packaging-x86_64 ] #, packaging-aarch64 ]
+    needs: [ packaging-x86_64, packaging-aarch64 ]
 
     uses: ./.github/workflows/docker_build_push.yml
     secrets: inherit


### PR DESCRIPTION
This reverts commit ef3152cdc249045be8250c65d47b1a002e49467e.

We have solved the issues with aarch64 runners, so we can enable back aarch64 jobs.