### PR TITLE
[backport 3.1] test: bump test-run to new version

### DIFF
--- a/test/box-luatest/box_cfg_env_test.lua
+++ b/test/box-luatest/box_cfg_env_test.lua
@@ -166,11 +166,7 @@ g.test_uri_list = function(g)
 
     local opts = {nojson = true, stderr = true}
     local res = justrun.tarantool(dir, {}, {'main.lua'}, opts)
-    t.assert_equals(res, {
-        exit_code = 0,
-        stdout = '',
-        stderr = '',
-    })
+    t.assert_equals(res.exit_code, 0, {res.stdout, res.stderr})
 end
 
 -- These test cases use a real box.cfg() call inside a child

--- a/test/box-luatest/box_schema_before_box_cfg_test.lua
+++ b/test/box-luatest/box_schema_before_box_cfg_test.lua
@@ -67,6 +67,5 @@ g.test_box_schema_before_box_cfg = function()
 
     local opts = {nojson = true, stderr = true}
     local res = justrun.tarantool(dir, {}, {'main.lua'}, opts)
-    t.assert_equals(res.stderr, "")
-    t.assert_equals(res.exit_code, 0)
+    t.assert_equals(res.exit_code, 0, {res.stdout, res.stderr})
 end

--- a/test/box-luatest/gh_6819_iproto_watch_not_implemented_test.lua
+++ b/test/box-luatest/gh_6819_iproto_watch_not_implemented_test.lua
@@ -71,7 +71,7 @@ g.test_iproto_watch_reported_but_not_implemented = function()
     g.server:exec(function(err_count_1)
         t.helpers.retrying({}, function()
             local err_count_2 = box.stat.ERROR.total
-            t.assert_equals(err_count_2 - err_count_1, 3)
+            t.assert_equals(err_count_2 - err_count_1, 4)
         end)
     end, {err_count_1})
     conn:close()

--- a/test/config-luatest/config_test.lua
+++ b/test/config-luatest/config_test.lua
@@ -165,11 +165,7 @@ g.test_configdata = function()
 
     local opts = {nojson = true, stderr = true}
     local res = justrun.tarantool(dir, {}, {'main.lua'}, opts)
-    t.assert_equals(res, {
-        exit_code = 0,
-        stdout = '',
-        stderr = '',
-    })
+    t.assert_equals(res.exit_code, 0, {res.stdout, res.stderr})
 end
 
 g.test_config_general = function()

--- a/test/config-luatest/helpers.lua
+++ b/test/config-luatest/helpers.lua
@@ -64,11 +64,7 @@ local function run_as_script(f)
 
         local opts = {nojson = true, stderr = true}
         local res = justrun.tarantool(dir, {}, {'main.lua'}, opts)
-        t.assert_equals(res, {
-            exit_code = 0,
-            stdout = '',
-            stderr = '',
-        })
+        t.assert_equals(res.exit_code, 0, {res.stdout, res.stderr})
     end
 end
 

--- a/test/replication-luatest/gh_8433_raft_is_candidate_test.lua
+++ b/test/replication-luatest/gh_8433_raft_is_candidate_test.lua
@@ -75,7 +75,8 @@ g.test_prevote_fail = function(g)
     --        the corresponding bit in leader_witness_map is cleared.
     --     3. Break last applier and make sure, that election isn't started.
     --
-    luatest.assert_equals(g.replica_set:get_leader(), g.server1)
+    luatest.assert_equals(g.replica_set:get_leader():get_instance_id(),
+                          g.server1:get_instance_id())
     local old_term = g.server1:get_election_term()
     g.server3:exec(function()
         box.cfg({election_mode = 'candidate'})


### PR DESCRIPTION
Backport of 97a801e190e94ae804acc5075ba1f7bfaf7553cc