### PR TITLE
vinyl: fix crash in index drop if there is DML request reading from it

### DIFF
--- a/changelogs/unreleased/gh-10094-vy-index-drop-crash-fix.md
+++ b/changelogs/unreleased/gh-10094-vy-index-drop-crash-fix.md
@@ -1,0 +1,4 @@
+## bugfix/vinyl
+
+* Fixed a bug when a DDL operation dropping a unique index could crash
+  if performed concurrently with DML requests (gh-10094).

--- a/src/box/vy_lsm.c
+++ b/src/box/vy_lsm.c
@@ -256,7 +256,7 @@ vy_range_tree_free_cb(vy_range_tree_t *t, struct vy_range *range, void *arg)
 	(void)arg;
 	struct vy_slice *slice;
 	rlist_foreach_entry(slice, &range->slices, in_range)
-		vy_slice_wait_pinned(slice);
+		assert(slice->pin_count == 0);
 	vy_range_delete(range);
 	return NULL;
 }

--- a/test/vinyl-luatest/gh_10094_index_drop_test.lua
+++ b/test/vinyl-luatest/gh_10094_index_drop_test.lua
@@ -1,0 +1,44 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new()
+    cg.server:start()
+    cg.server:exec(function()
+        box.cfg{vinyl_cache = 0}
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+        box.error.injection.set('ERRINJ_VY_READ_PAGE_DELAY', false)
+    end)
+end)
+
+g.test_index_drop = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        local s = box.schema.create_space('test', {engine = 'vinyl'})
+        s:create_index('pk')
+        s:create_index('sk', {parts = {{2, 'unsigned'}}})
+        s:insert{1, 10}
+        box.snapshot()
+        box.error.injection.set('ERRINJ_VY_READ_PAGE_DELAY', true)
+        fiber.create(function()
+            s:insert{2, 10}
+        end)
+        s.index.sk:drop()
+        box.error.injection.set('ERRINJ_VY_READ_PAGE_DELAY', false)
+        t.assert_equals(s:select({}, {fullscan = true}), {{1, 10}})
+    end)
+end


### PR DESCRIPTION
A DML request (insert, replace, update) can yield while reading from the disk in order to check unique constraints. In the meantime the index can be dropped. The DML request can't crash in this case thanks to commit d3e1236956515, but the DDL operation can because:
 - It unreferences the index in `alter_space_commit`, which may result in dropping the LSM tree with `vy_lsm_delete`.
 - `vy_lsm_delete` may yield in `vy_range_tree_free_cb` while waiting for disk readers to complete.
 - Yielding in commit triggers isn't allowed (crashes).

We already fixed a similar issue when `index.get` crashed if raced with index drop, see commit 75f03a50df4a. Let's fix this issue in the same way - by taking a reference to the LSM tree while checking unique constraints. To do that it's enough to move `vy_lsm_ref` from `vinyl_index_get` to `vy_get`.

Also, let's replace `vy_slice_wait_pinned` with an assertion checking that the slice pin count is 0 in `vy_range_tree_free_cb` because `vy_lsm_delete` must not yield.

Closes #10094