### PR TITLE
[backport 2.10] test: bump test-run to new version

### DIFF
--- a/test/box-luatest/box_cfg_env_test.lua
+++ b/test/box-luatest/box_cfg_env_test.lua
@@ -97,11 +97,7 @@ g.test_uri_list = function(g)
 
     local opts = {nojson = true, stderr = true}
     local res = justrun.tarantool(dir, {}, {'main.lua'}, opts)
-    t.assert_equals(res, {
-        exit_code = 0,
-        stdout = '',
-        stderr = '',
-    })
+    t.assert_equals(res.exit_code, 0, {res.stdout, res.stderr})
 end
 
 -- These test cases use a real box.cfg() call inside a child

--- a/test/replication-luatest/gh_8433_raft_is_candidate_test.lua
+++ b/test/replication-luatest/gh_8433_raft_is_candidate_test.lua
@@ -75,7 +75,8 @@ g.test_prevote_fail = function(g)
     --        the corresponding bit in leader_witness_map is cleared.
     --     3. Break last applier and make sure, that election isn't started.
     --
-    luatest.assert_equals(g.replica_set:get_leader(), g.server1)
+    luatest.assert_equals(g.replica_set:get_leader():get_instance_id(),
+                          g.server1:get_instance_id())
     local old_term = g.server1:get_election_term()
     g.server3:exec(function()
         box.cfg({election_mode = 'candidate'})


### PR DESCRIPTION
Backport of https://github.com/tarantool/tarantool/commit/4466deafee4eb424a098653bf1d6b905eeb8163f and https://github.com/tarantool/tarantool/commit/97a801e190e94ae804acc5075ba1f7bfaf7553cc