### PR TITLE
key_def: Introduce `__len` metamethod

### DIFF
--- a/changelogs/unreleased/gh-10111-provide-key_def-length.md
+++ b/changelogs/unreleased/gh-10111-provide-key_def-length.md
@@ -1,0 +1,3 @@
+## feature/lua
+
+* Introduced a standard Lua way to get the length of `key_def` (gh-10111).

--- a/src/box/lua/key_def.c
+++ b/src/box/lua/key_def.c
@@ -633,6 +633,19 @@ lbox_key_def_to_table(struct lua_State *L)
 	return 1;
 }
 
+/**
+ * Return partitions count for key_def
+ */
+static int
+lbox_key_def_part_count(struct lua_State *L)
+{
+	struct key_def *key_def = luaT_is_key_def(L, 1);
+	if (key_def == NULL)
+		return luaL_error(L, "Usage: key_def:part_count()");
+	lua_pushinteger(L, key_def->part_count);
+	return 1;
+}
+
 int
 lbox_key_def_new(struct lua_State *L)
 {
@@ -704,6 +717,7 @@ luaopen_key_def(struct lua_State *L)
 		{"compare_keys", lbox_key_def_compare_keys},
 		{"merge", lbox_key_def_merge},
 		{"totable", lbox_key_def_to_table},
+		{"part_count", lbox_key_def_part_count},
 		{NULL, NULL}
 	};
 	luaT_newmodule(L, "key_def", meta);

--- a/src/box/lua/key_def.lua
+++ b/src/box/lua/key_def.lua
@@ -20,4 +20,5 @@ ffi.metatype(key_def_t, {
         return methods[key]
     end,
     __tostring = function(self) return "<struct key_def &>" end,
+    __len = key_def.part_count,
 })

--- a/test/box-tap/key_def.test.lua
+++ b/test/box-tap/key_def.test.lua
@@ -198,7 +198,7 @@ local key_def_new_cases = {
 
 local test = tap.test('key_def')
 
-test:plan(#key_def_new_cases - 1 + 8)
+test:plan(#key_def_new_cases - 1 + 9)
 for _, case in ipairs(key_def_new_cases) do
     if type(case) == 'function' then
         case()
@@ -596,6 +596,22 @@ test:test('Usage errors', function(test)
     test:is_deeply({pcall(key_def_lib.totable)},
                    {false, 'Usage: key_def:totable()'},
                    'totable()')
+end)
+
+-- Check key_def:part_count
+test:test('Key_def part_count', function(test)
+    test:plan(4)
+    local kd = key_def_lib.new({
+        {fieldno = 2, type = 'unsigned'}, {fieldno = 4, type = 'string'}
+    })
+    test:ok(kd, 'instance created')
+    test:is(#kd, 2, 'part_count')
+
+    local kd = key_def_lib.new({
+        {fieldno = 22, type = 'string'},
+    })
+    test:ok(kd, 'instance created')
+    test:is(#kd, 1, 'part_count')
 end)
 
 os.exit(test:check() and 0 or 1)


### PR DESCRIPTION
The metamethod is a way to key_def length introspection.

Closes #10111

@TarantoolBot document
Title: key_def length introspection

To check key_def length (parts count) there is a standard lua operator `#` (`__len` metamethod).

Example:
```lua
	function is_full_pkey(space, key)
		return #space.key_def == #key
	end
```