### PR TITLE
box: apply deletion of replica from `_cluster` on the deleted replica

### DIFF
--- a/changelogs/unreleased/gh-10088-apply-deletion-of-replica-from_cluster-on-deleted-replica.md
+++ b/changelogs/unreleased/gh-10088-apply-deletion-of-replica-from_cluster-on-deleted-replica.md
@@ -1,0 +1,4 @@
+## feature/replication
+
+* A replica deleted from the `_cluster` space now applies its own deletion and
+  does not try to rejoin (gh-10088).

--- a/changelogs/unreleased/gh-10266-async-tx-from-deleted-replica-arrive-on-remaining-cluster.md
+++ b/changelogs/unreleased/gh-10266-async-tx-from-deleted-replica-arrive-on-remaining-cluster.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed a bug that allowed asynchronous transactions from a replica deleted from
+  the cluster to arrive on the remaining cluster members (gh-10266).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -61,6 +61,7 @@
 #include "authentication.h"
 #include "node_name.h"
 #include "core/func_adapter.h"
+#include "relay.h"
 
 /* {{{ Auxiliary functions and methods. */
 
@@ -4434,6 +4435,8 @@ on_replace_cluster_clear_id(struct trigger *trigger, void *event)
 				if (replica->applier != NULL)
 					applier_kill(replica->applier,
 						     diag_last_error(diag));
+				if (replica->relay != NULL)
+					relay_cancel(replica->relay);
 			}
 			diag_clear(diag);
 		}

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -1652,6 +1652,10 @@ applier_apply_tx(struct applier *applier, struct stailq *rows)
 	struct latch *latch = (replica ? &replica->order_latch :
 			       &replicaset.applier.order_latch);
 	latch_lock(latch);
+	if (fiber_is_cancelled()) {
+		rc = -1;
+		goto finish;
+	}
 	if (vclock_get(&replicaset.applier.vclock,
 		       last_row->replica_id) >= last_row->lsn) {
 		goto finish;

--- a/src/box/applier.h
+++ b/src/box/applier.h
@@ -302,6 +302,13 @@ void
 applier_stop(struct applier *applier);
 
 /**
+ * Kill a client and optionally set an error for it (can be NULL). The client is
+ * expected to be alive.
+ */
+void
+applier_kill(struct applier *applier, struct error *error);
+
+/**
  * Allocate an instance of applier object, create applier and initialize
  * remote uri (copied to struct applier).
  *

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -4701,6 +4701,10 @@ box_process_subscribe(struct iostream *io, const struct xrow_header *header)
 		if (replica->id != REPLICA_ID_NIL)
 			tnt_raise(ClientError, ER_PROTOCOL, "Can't subscribe "
 				  "an anonymous replica having an ID assigned");
+		if (!replica->anon)
+			tnt_raise(ClientError, ER_PROTOCOL, "Can't subscribe "
+				  "a previously deleted non-anonymous replica "
+				  "as an anonymous replica");
 	} else if (!req.is_anon &&
 		   (replica == NULL || replica->id == REPLICA_ID_NIL)) {
 		/*

--- a/src/box/relay.h
+++ b/src/box/relay.h
@@ -112,6 +112,12 @@ relay_trigger_vclock_sync(struct relay *relay, uint64_t *vclock_sync,
 void
 relay_push_raft(struct relay *relay, const struct raft_request *req);
 
+/**
+ * Cancel the relay.
+ */
+void
+relay_cancel(struct relay *relay);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/replication.cc
+++ b/src/box/replication.cc
@@ -416,7 +416,6 @@ replica_clear_id(struct replica *replica)
 	--replicaset.registered_count;
 	gc_delay_unref();
 	if (replica->id == instance_id) {
-		assert(replicaset.is_joining);
 		instance_id = REPLICA_ID_NIL;
 		box_broadcast_id();
 	} else {

--- a/src/box/replication.cc
+++ b/src/box/replication.cc
@@ -665,12 +665,6 @@ replica_on_applier_state_f(struct trigger *trigger, void *event)
 			struct replica, on_applier_state);
 	replica_update_applier_health(replica);
 	switch (replica->applier->state) {
-	case APPLIER_WAIT_SNAPSHOT:
-		replicaset.is_joining = true;
-		break;
-	case APPLIER_JOINED:
-		replicaset.is_joining = false;
-		break;
 	case APPLIER_CONNECTED:
 		try {
 			if (tt_uuid_is_nil(&replica->uuid))

--- a/src/box/replication.h
+++ b/src/box/replication.h
@@ -294,11 +294,6 @@ struct replicaset {
 	 * to connect and those that failed to connect.
 	 */
 	struct rlist anon;
-	/**
-	 * This flag is set while the instance is bootstrapping
-	 * from a remote master.
-	 */
-	bool is_joining;
 	/* A number of anonymous replicas following this instance. */
 	int anon_count;
 	/**

--- a/test/replication-luatest/gh_10088_apply_deletion_of_replica_from_cluster_on_deleted_replica_test.lua
+++ b/test/replication-luatest/gh_10088_apply_deletion_of_replica_from_cluster_on_deleted_replica_test.lua
@@ -1,0 +1,174 @@
+local fio = require('fio')
+local t = require('luatest')
+local replica_set = require('luatest.replica_set')
+local server = require('luatest.server')
+
+local g_two_member_cluster = t.group('two_member_cluster')
+local g_three_member_cluster = t.group('three_member_cluster')
+
+g_two_member_cluster.before_each(function(cg)
+    cg.master = server:new{alias = 'master', box_cfg = {
+        replication_synchro_timeout = 120,
+    }}
+    cg.master:start()
+    cg.replica = server:new{alias = 'replica', box_cfg = {
+        replication = cg.master.net_box_uri,
+        replication_synchro_timeout = 120,
+    }}
+    cg.replica:start()
+    -- Add the replica to the master's replicaset table: needed for testing
+    -- the behaviour of the deleted replica after recovery.
+    cg.master:update_box_cfg{replication = cg.replica.net_box_uri}
+    cg.master:exec(function()
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_not_equals(box.info.status, "orphan")
+        end)
+    end)
+    -- Make `_cluster` space synchronous.
+    cg.master:exec(function()
+        box.ctl.promote()
+        box.space._cluster:alter{is_sync = true}
+        box.schema.space.create('sync', {is_sync = true}):create_index('pk')
+    end)
+    cg.master:wait_for_downstream_to(cg.replica)
+end)
+
+-- Test that synchronous deletion from 2-member cluster works properly.
+-- Also test the behaviour of the deleted replica after recovery.
+g_two_member_cluster.test_deletion = function(cg)
+    local replica_id = cg.replica:get_instance_id()
+    local log_file = cg.master:exec(function() return box.cfg.log end)
+    fio.truncate(log_file)
+    cg.master:exec(function(replica_id)
+        t.assert(box.space._cluster:delete{replica_id})
+    end, {replica_id})
+    cg.replica:wait_for_vclock_of(cg.master)
+    cg.replica:exec(function()
+        t.assert_equals(box.info.id, nil)
+    end)
+    t.assert_equals(cg.master:grep_log('joining replica'), nil)
+    -- Test the behaviour of the deleted replica after recovery.
+    cg.replica:restart(nil, {wait_until_ready = false})
+    local panic_msg = "'replication_anon' cfg didn't work"
+    local log = fio.pathjoin(cg.replica.workdir, cg.replica.alias..'.log')
+    -- By default, the deleted replica must panic after recovery, because it is
+    -- bootstrapped, it does not have an instance ID, and it is not configured
+    -- as anonymous.
+    t.helpers.retrying({timeout = 120}, function()
+        t.assert(cg.replica:grep_log(panic_msg, nil, {filename = log}))
+    end)
+    cg.replica:restart({box_cfg = {
+        replication = cg.master.net_box_uri,
+        replication_anon = true,
+        read_only = true,
+    }}, {wait_until_ready = false})
+    local err_msg = "Can't subscribe a previously deleted non%-anonymous " ..
+                    "replica as an anonymous replica"
+    -- If the deleted replica is configured as anonymous during recovery, the
+    -- master sees it as a non-anonymous replica in his replicaset table, and
+    -- rejects the subscription request.
+    t.helpers.retrying({timeout = 120}, function()
+        t.assert(cg.replica:grep_log(err_msg, nil, {filename = log}))
+    end)
+end
+
+g_two_member_cluster.after_each(function(cg)
+    cg.master:drop()
+    cg.replica:drop()
+end)
+
+g_three_member_cluster.before_each(function(cg)
+    cg.replica_set = replica_set:new{}
+    cg.master = cg.replica_set:build_and_add_server{alias = 'master',
+                                                    box_cfg = {
+        replication_synchro_timeout = 120,
+    }}
+    cg.master:start()
+    cg.replica =
+        cg.replica_set:build_and_add_server{alias = 'replica',
+                                            box_cfg = {
+        replication = {
+            cg.master.net_box_uri,
+            server.build_listen_uri('to_be_deleted', cg.replica_set.id),
+        },
+    }}
+    cg.replica_to_be_deleted =
+        cg.replica_set:build_and_add_server{alias = 'to_be_deleted',
+                                            box_cfg = {
+        replication = {
+            cg.master.net_box_uri,
+            server.build_listen_uri('replica', cg.replica_set.id),
+        },
+    }}
+    cg.replica_set:start()
+    cg.master:exec(function()
+        box.ctl.promote()
+        box.space._cluster:alter{is_sync = true}
+        box.schema.space.create('sync', {is_sync = true}):create_index('pk')
+    end)
+    cg.master:wait_for_downstream_to(cg.replica)
+    cg.master:wait_for_downstream_to(cg.replica_to_be_deleted)
+end)
+
+-- Test that synchronous deletion from 3-member cluster with 1 disabled node and
+-- the deleted node alive works properly.
+g_three_member_cluster.test_deletion = function(cg)
+    cg.replica:exec(function()
+        box.cfg{replication = ''}
+    end)
+    local to_be_deleted_id = cg.replica_to_be_deleted:get_instance_id()
+    cg.master:exec(function(to_be_deleted_id)
+        t.assert(box.space._cluster:delete{to_be_deleted_id})
+    end, {to_be_deleted_id})
+    cg.replica_to_be_deleted:wait_for_vclock_of(cg.master)
+    cg.replica_to_be_deleted:exec(function()
+        t.assert_equals(box.info.id, nil)
+    end)
+end
+
+-- Test that the deleted replica stops all appliers, effectively stopping
+-- replication, and cannot ack synchronous transactions.
+g_three_member_cluster.test_behaviour_of_deleted_replica = function(cg)
+    local to_be_deleted_id = cg.replica_to_be_deleted:get_instance_id()
+    cg.master:exec(function(to_be_deleted_id)
+        t.assert(box.space._cluster:delete{to_be_deleted_id})
+    end, {to_be_deleted_id})
+    cg.replica_to_be_deleted:wait_for_vclock_of(cg.master)
+    local master_id = cg.master:get_instance_id()
+    local replica_id = cg.replica:get_instance_id()
+    cg.replica_to_be_deleted:exec(function(deleted_id, master_id, replica_id)
+        t.assert_equals(box.info.id, nil)
+        local msg = "The local instance id " .. deleted_id .. " is read-only"
+        -- Test that the deleted node stopped replication with the master
+        -- from which it received the delete.
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.replication[master_id].upstream.status,
+                            'stopped')
+            t.assert_equals(box.info.replication[master_id].upstream.message,
+                            msg)
+        end)
+        -- Test that the deleted node stopped replication with the other replica
+        -- from which it did not receive the delete.
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.replication[replica_id].upstream.status,
+                            'stopped')
+            t.assert_equals(box.info.replication[replica_id].upstream.message,
+                            msg)
+        end)
+    end, {to_be_deleted_id, master_id, replica_id})
+
+    -- Test that the deleted node cannot ack a synchronous transaction.
+    cg.master:exec(function()
+        box.cfg{replication_synchro_quorum = 3, replication_synchro_timeout = 1}
+
+        local msg = 'Quorum collection for a synchronous transaction is ' ..
+                    'timed out'
+        t.assert_error_msg_content_equals(msg, function()
+            box.space.sync:replace{0}
+        end)
+    end)
+end
+
+g_three_member_cluster.after_each(function(cg)
+    cg.replica_set:drop()
+end)

--- a/test/replication-luatest/gh_10266_async_tx_from_deleted_replica_arrive_on_remaining_cluster_test.lua
+++ b/test/replication-luatest/gh_10266_async_tx_from_deleted_replica_arrive_on_remaining_cluster_test.lua
@@ -1,0 +1,58 @@
+local t = require('luatest')
+local replica_set = require('luatest.replica_set')
+local server = require('luatest.server')
+
+local g = t.group()
+
+g.before_each(function(cg)
+    cg.replica_set = replica_set:new{}
+    local box_cfg = {
+        replication = {
+            server.build_listen_uri('remaining', cg.replica_set.id),
+            server.build_listen_uri('deleted', cg.replica_set.id),
+        },
+        replication_timeout = 0.1,
+    }
+    cg.remaining = cg.replica_set:build_and_add_server{
+        alias = 'remaining',
+        box_cfg = box_cfg,
+    }
+    box_cfg.read_only = true
+    cg.deleted = cg.replica_set:build_and_add_server{
+        alias = 'deleted',
+        box_cfg = box_cfg,
+    }
+    cg.replica_set:start()
+    cg.remaining:exec(function()
+        box.schema.space.create('s'):create_index('p')
+    end)
+    cg.deleted:exec(function()
+        box.cfg{read_only = false}
+    end)
+    cg.replica_set:wait_for_fullmesh()
+    cg.remaining:wait_for_downstream_to(cg.deleted)
+end)
+
+g.after_each(function(cg)
+    cg.replica_set:drop()
+end)
+
+-- Test that asynchronous transactions from a deleted replica do not arrive on
+-- the remaining replica.
+g.test_async_tx_on_deleted_replica_do_not_arrive_on_remaining_replica =
+function(cg)
+    cg.remaining:exec(function()
+        t.assert_equals(box.info.id, 1)
+        box.space._cluster:delete{2}
+    end)
+    cg.deleted:wait_for_vclock_of(cg.remaining)
+    cg.deleted:exec(function()
+        t.assert_equals(box.info.id, nil)
+        box.space.s:replace{0}
+    end)
+    t.assert_not_equals(cg.deleted:grep_log('exiting the relay loop'), nil)
+    cg.remaining:exec(function(timeout)
+        require('fiber').sleep(timeout)
+        t.assert_equals(box.space.s:get{0}, nil)
+    end, {1})
+end

--- a/test/replication/prune.result
+++ b/test/replication/prune.result
@@ -132,39 +132,6 @@ test_run:cmd('eval replica1 "box.info.replication[1].upstream.message"')
 ---
 - ['The local instance id 2 is read-only']
 ...
--- restart replica and check that replica isn't able to join to cluster
-test_run:cmd('stop server replica1')
----
-- true
-...
-test_run:cmd('start server replica1 with args="true", wait=False, crash_expected=True')
----
-- true
-...
-test_run:cmd('switch replica1')
----
-- true
-...
-test_run:wait_upstream(1, {message_re = "Can't subscribe non%-anonymous replica"})
----
-- true
-...
-test_run:cmd('switch default')
----
-- true
-...
-box.space._cluster:len() == 1
----
-- true
-...
-test_run:cmd('eval replica1 "box.info.replication[1].upstream.status"')
----
-- ['loading']
-...
-test_run:cmd('eval replica1 "box.info.replication[1].upstream.message"')[1]:match("Can't subscribe non%-anonymous replica") ~= nil
----
-- true
-...
 replica_set.delete(test_run, 2)
 ---
 ...

--- a/test/replication/prune.test.lua
+++ b/test/replication/prune.test.lua
@@ -63,16 +63,6 @@ replica_set.unregister(test_run, 2)
 
 while test_run:cmd('eval replica1 "box.info.replication[1].upstream.status"')[1] ~= 'stopped' do fiber.sleep(0.001) end
 test_run:cmd('eval replica1 "box.info.replication[1].upstream.message"')
-
--- restart replica and check that replica isn't able to join to cluster
-test_run:cmd('stop server replica1')
-test_run:cmd('start server replica1 with args="true", wait=False, crash_expected=True')
-test_run:cmd('switch replica1')
-test_run:wait_upstream(1, {message_re = "Can't subscribe non%-anonymous replica"})
-test_run:cmd('switch default')
-box.space._cluster:len() == 1
-test_run:cmd('eval replica1 "box.info.replication[1].upstream.status"')
-test_run:cmd('eval replica1 "box.info.replication[1].upstream.message"')[1]:match("Can't subscribe non%-anonymous replica") ~= nil
 replica_set.delete(test_run, 2)
 
 box.space.test:drop()


### PR DESCRIPTION
This patch series applies deletion of replica from `_cluster` on the deleted replica.

Closes #10088
Closes #10266