### PR TITLE
error: finish changes to several C modules to use box.error

### DIFF
--- a/src/box/lua/call.c
+++ b/src/box/lua/call.c
@@ -1089,8 +1089,10 @@ lbox_func_call(struct lua_State *L)
 {
 	if (box_check_configured() != 0)
 		return luaT_error(L);
-	if (lua_gettop(L) < 1 || !lua_isstring(L, 1))
-		return luaL_error(L, "Use func:call(...)");
+	if (lua_gettop(L) < 1 || !lua_isstring(L, 1)) {
+		diag_set(IllegalParams, "Use func:call(...)");
+		return luaT_error(L);
+	}
 
 	size_t name_len;
 	const char *name = lua_tolstring(L, 1, &name_len);

--- a/src/box/lua/index.c
+++ b/src/box/lua/index.c
@@ -372,7 +372,7 @@ lbox_iterator_next(lua_State *L)
 static int
 lbox_truncate(struct lua_State *L)
 {
-	uint32_t space_id = luaL_checkinteger(L, 1);
+	uint32_t space_id = luaT_checkint(L, 1);
 	if (box_truncate(space_id) != 0)
 		return luaT_error(L);
 	return 0;

--- a/test/app-tap/msgpack.test.lua
+++ b/test/app-tap/msgpack.test.lua
@@ -48,12 +48,12 @@ local function test_misc(test, s)
     test:is_deeply(result, {1}, "ibuf_decode result")
     test:ok(not st and e:match("null"), "null ibuf")
     st, e = pcall(s.decode, "\xd4\x0f\x00")
-    test:is(e, "Unsupported MsgPack extension type: 15",
-               "decode result for \\xd4\\x0f\\x00: " .. e)
+    test:is(tostring(e), "Unsupported MsgPack extension type: 15",
+            "decode result for \\xd4\\x0f\\x00: " .. e)
     test:ok(not st, "unsupported extension decode")
     st, e = pcall(s.decode, "\xd4\xfe\x00")
-    test:is(e, "Unsupported MsgPack extension type: -2",
-               "decode result for \\xd4\\xfe\\x00: " .. e)
+    test:is(tostring(e), "Unsupported MsgPack extension type: -2",
+            "decode result for \\xd4\\xfe\\x00: " .. e)
     test:ok(not st, "unsupported extension decode")
 end
 


### PR DESCRIPTION
We already do some steps to use `box.error` in these C modules. Let's finish it to make a clear distinction between C modules that are switched to `box.error` and that are not (see #10121).

Follow-up #9996