### PR TITLE
vinyl: fix bugs in read iterator

### DIFF
--- a/changelogs/unreleased/gh-10109-vy-read-iterator-fix.md
+++ b/changelogs/unreleased/gh-10109-vy-read-iterator-fix.md
@@ -1,0 +1,4 @@
+## bugfix/vinyl
+
+* Fixed a bug when a tuple was not returned by range `select`. The bug could
+  also trigger a crash in the read iterator (gh-10109).

--- a/src/box/vy_cache.c
+++ b/src/box/vy_cache.c
@@ -826,10 +826,13 @@ vy_cache_iterator_restore(struct vy_cache_iterator *itr, struct vy_entry last,
 			struct vy_cache_node *node =
 				*vy_cache_tree_iterator_get_elem(tree, &pos);
 			int cmp = dir * vy_entry_compare(node->entry, key, def);
+			bool is_visible = vy_cache_iterator_stmt_is_visible(
+							itr, node->entry.stmt);
+			if (!is_visible)
+				*stop = false;
 			if (cmp < 0 || (cmp == 0 && !key_belongs))
 				break;
-			if (vy_cache_iterator_stmt_is_visible(
-					itr, node->entry.stmt)) {
+			if (is_visible) {
 				itr->curr_pos = pos;
 				if (itr->curr.stmt != NULL)
 					tuple_unref(itr->curr.stmt);

--- a/src/box/vy_run.c
+++ b/src/box/vy_run.c
@@ -1557,10 +1557,8 @@ vy_run_iterator_next_lsn(struct vy_run_iterator *itr, struct vy_entry *ret)
 
 	struct vy_run_iterator_pos next_pos;
 next:
-	if (vy_run_iterator_next_pos(itr, ITER_GE, &next_pos) != 0) {
-		vy_run_iterator_stop(itr);
+	if (vy_run_iterator_next_pos(itr, ITER_GE, &next_pos) != 0)
 		return 0;
-	}
 
 	struct vy_entry next;
 	if (vy_run_iterator_read(itr, next_pos, &next) != 0)

--- a/test/vinyl-luatest/gh_10109_read_iterator_test.lua
+++ b/test/vinyl-luatest/gh_10109_read_iterator_test.lua
@@ -1,0 +1,39 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+        box.error.injection.set('ERRINJ_VY_COMPACTION_DELAY', false)
+    end)
+end)
+
+g.test_read_upsert = function(cg)
+    cg.server:exec(function()
+        box.error.injection.set('ERRINJ_VY_COMPACTION_DELAY', true)
+        local s = box.schema.create_space('test', {engine = 'vinyl'})
+        s:create_index('pk')
+        s:insert({100})
+        box.snapshot()
+        s:upsert({200}, {})
+        s:upsert({300}, {})
+        s:upsert({400}, {})
+        box.snapshot()
+        t.assert_equals(s:select({500}, {iterator = 'lt', fullscan = true}),
+                        {{400}, {300}, {200}, {100}})
+    end)
+end


### PR DESCRIPTION
The PR fixes a couple of bugs in the read iterator because of which tuples written to the database could be skipped by a range `select`.

Closes #10109