### PR TITLE
Enable synchronous replication for systems spaces when the synchronous queue is claimed

### DIFF
--- a/changelogs/unreleased/gh-9723-sync-system-spaces.md
+++ b/changelogs/unreleased/gh-9723-sync-system-spaces.md
@@ -1,0 +1,10 @@
+## feature/replication
+
+* Made all of the system spaces synchronous by default when the synchronous
+  queue is claimed, i.e., `box.info.synchro.queue.owner ~= 0`. Added a
+  `box_consider_system_spaces_synchronous` backward compatibility option to
+  control this behavior. Added a new read-only `state` subtable for the Lua
+  space object returned from the `box.space` registry. This subtable has an
+  `is_sync` field that reflects the effective state of replication for system
+  spaces. For user spaces, this field will always mirror the `is_sync` option
+  set for the space (gh-9723).

--- a/extra/exports
+++ b/extra/exports
@@ -324,6 +324,7 @@ swim_self
 swim_set_codec
 swim_set_payload
 swim_size
+system_spaces_update_is_sync_state_from_compat
 tarantool_exit
 tarantool_lua_slab_cache
 tarantool_uptime

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2423,6 +2423,12 @@ return schema.new('instance_config', schema.record({
         }, {
             default = 'old',
         }),
+        box_consider_system_spaces_synchronous = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'old',
+        }),
     }),
     -- Instance labels.
     labels = schema.map({

--- a/src/box/lua/space.cc
+++ b/src/box/lua/space.cc
@@ -464,11 +464,18 @@ lbox_fillspace(struct lua_State *L, struct space *space, int i)
 
 	/* space.is_sync */
 	lua_pushstring(L, "is_sync");
-	lua_pushboolean(L, space_is_sync(space));
+	lua_pushboolean(L, space->def->opts.is_sync);
 	lua_settable(L, i);
 
 	lua_pushstring(L, "enabled");
 	lua_pushboolean(L, space_index(space, 0) != 0);
+	lua_settable(L, i);
+
+	/* space.state table */
+	lua_pushstring(L, "state");
+	lua_createtable(L, 0, 1);
+	lua_pushboolean(L, space_is_sync(space));
+	lua_setfield(L, -2, "is_sync");
 	lua_settable(L, i);
 
 	/* space:on_replace */

--- a/src/box/schema_def.h
+++ b/src/box/schema_def.h
@@ -72,61 +72,64 @@ static_assert(BOX_INVALID_NAME_MAX <= BOX_NAME_MAX,
 
 /**
  * List of system space definitions in the following format:
- * (name, identifier).
+ * (name, identifier, is_sync),
+ * where is_sync determines whether synchronous replication is enabled for this
+ * system space when the synchronous queue is claimed. If is_sync is false, a
+ * reason must be supplied after the space definition comment.
  */
-#define SYSTEM_SPACES(_) /* (name, id) */ \
-	/** Space id of _vinyl_deferred_delete. */ \
-	_(VINYL_DEFERRED_DELETE, 257) \
+#define SYSTEM_SPACES(_) /* (name, id, is_sync) */ \
+	/** Space id of _vinyl_deferred_delete. Local space. */ \
+	_(VINYL_DEFERRED_DELETE, 257, false) \
 	/** Space id of _schema. */ \
-	_(SCHEMA, 272) \
+	_(SCHEMA, 272, true) \
 	/** Space id of _collation. */ \
-	_(COLLATION, 276) \
+	_(COLLATION, 276, true) \
 	/** Space id of _vcollation. */ \
-	_(VCOLLATION, 277) \
+	_(VCOLLATION, 277, true) \
 	/** Space id of _space. */ \
-	_(SPACE, 280) \
+	_(SPACE, 280, true) \
 	/** Space id of _vspace view. */ \
-	_(VSPACE, 281) \
+	_(VSPACE, 281, true) \
 	/** Space id of _sequence. */ \
-	_(SEQUENCE, 284) \
-	/** Space id of _sequence_data. */ \
-	_(SEQUENCE_DATA, 285) \
+	_(SEQUENCE, 284, true) \
+	/** Space id of _sequence_data. Synchronized by space operations. */ \
+	_(SEQUENCE_DATA, 285, false) \
 	/** Space id of _vsequence view. */ \
-	_(VSEQUENCE, 286) \
+	_(VSEQUENCE, 286, true) \
 	/** Space id of _index. */ \
-	_(INDEX, 288) \
+	_(INDEX, 288, true) \
 	/** Space id of _vindex view. */ \
-	_(VINDEX, 289) \
+	_(VINDEX, 289, true) \
 	/** Space id of _func. */ \
-	_(FUNC, 296) \
+	_(FUNC, 296, true) \
 	/** Space id of _vfunc view. */ \
-	_(VFUNC, 297) \
+	_(VFUNC, 297, true) \
 	/** Space id of _user. */ \
-	_(USER, 304) \
+	_(USER, 304, true) \
 	/** Space id of _vuser view. */ \
-	_(VUSER, 305) \
+	_(VUSER, 305, true) \
 	/** Space id of _priv. */ \
-	_(PRIV, 312) \
+	_(PRIV, 312, true) \
 	/** Space id of _vpriv view. */ \
-	_(VPRIV, 313) \
+	_(VPRIV, 313, true) \
 	/** Space id of _cluster. */ \
-	_(CLUSTER, 320) \
+	_(CLUSTER, 320, true) \
 	/** Space id of _trigger. */ \
-	_(TRIGGER, 328) \
+	_(TRIGGER, 328, true) \
 	/** Space id of _truncate. */ \
-	_(TRUNCATE, 330) \
+	_(TRUNCATE, 330, true) \
 	/** Space id of _space_sequence. */ \
-	_(SPACE_SEQUENCE, 340) \
+	_(SPACE_SEQUENCE, 340, true) \
 	/** Space id of _vspace_sequence. */ \
-	_(VSPACE_SEQUENCE, 341) \
+	_(VSPACE_SEQUENCE, 341, true) \
 	/** Space id of _fk_constraint. */ \
-	_(FK_CONSTRAINT, 356) \
+	_(FK_CONSTRAINT, 356, true) \
 	/** Space id of _ck_contraint. */ \
-	_(CK_CONSTRAINT, 364) \
+	_(CK_CONSTRAINT, 364, true) \
 	/** Space id of _func_index. */ \
-	_(FUNC_INDEX, 372) \
+	_(FUNC_INDEX, 372, true) \
 	/** Space id of _session_settings. */ \
-	_(SESSION_SETTINGS, 380) \
+	_(SESSION_SETTINGS, 380, true) \
 
 /** System space identifier definition. */
 #define SYSTEM_SPACE_MEMBER(name, id, ...) BOX_ ## name ## _ID = id,

--- a/src/box/schema_def.h
+++ b/src/box/schema_def.h
@@ -69,61 +69,72 @@ static_assert(BOX_INVALID_NAME_MAX <= BOX_NAME_MAX,
 	      "invalid name max is less than name max");
 
 /** \cond public */
+
+/**
+ * List of system space definitions in the following format:
+ * (name, identifier).
+ */
+#define SYSTEM_SPACES(_) /* (name, id) */ \
+	/** Space id of _vinyl_deferred_delete. */ \
+	_(VINYL_DEFERRED_DELETE, 257) \
+	/** Space id of _schema. */ \
+	_(SCHEMA, 272) \
+	/** Space id of _collation. */ \
+	_(COLLATION, 276) \
+	/** Space id of _vcollation. */ \
+	_(VCOLLATION, 277) \
+	/** Space id of _space. */ \
+	_(SPACE, 280) \
+	/** Space id of _vspace view. */ \
+	_(VSPACE, 281) \
+	/** Space id of _sequence. */ \
+	_(SEQUENCE, 284) \
+	/** Space id of _sequence_data. */ \
+	_(SEQUENCE_DATA, 285) \
+	/** Space id of _vsequence view. */ \
+	_(VSEQUENCE, 286) \
+	/** Space id of _index. */ \
+	_(INDEX, 288) \
+	/** Space id of _vindex view. */ \
+	_(VINDEX, 289) \
+	/** Space id of _func. */ \
+	_(FUNC, 296) \
+	/** Space id of _vfunc view. */ \
+	_(VFUNC, 297) \
+	/** Space id of _user. */ \
+	_(USER, 304) \
+	/** Space id of _vuser view. */ \
+	_(VUSER, 305) \
+	/** Space id of _priv. */ \
+	_(PRIV, 312) \
+	/** Space id of _vpriv view. */ \
+	_(VPRIV, 313) \
+	/** Space id of _cluster. */ \
+	_(CLUSTER, 320) \
+	/** Space id of _trigger. */ \
+	_(TRIGGER, 328) \
+	/** Space id of _truncate. */ \
+	_(TRUNCATE, 330) \
+	/** Space id of _space_sequence. */ \
+	_(SPACE_SEQUENCE, 340) \
+	/** Space id of _vspace_sequence. */ \
+	_(VSPACE_SEQUENCE, 341) \
+	/** Space id of _fk_constraint. */ \
+	_(FK_CONSTRAINT, 356) \
+	/** Space id of _ck_contraint. */ \
+	_(CK_CONSTRAINT, 364) \
+	/** Space id of _func_index. */ \
+	_(FUNC_INDEX, 372) \
+	/** Space id of _session_settings. */ \
+	_(SESSION_SETTINGS, 380) \
+
+/** System space identifier definition. */
+#define SYSTEM_SPACE_MEMBER(name, id, ...) BOX_ ## name ## _ID = id,
+
 enum {
 	/** Start of the reserved range of system spaces. */
 	BOX_SYSTEM_ID_MIN = 256,
-	/** Space if of _vinyl_deferred_delete. */
-	BOX_VINYL_DEFERRED_DELETE_ID = 257,
-	/** Space id of _schema. */
-	BOX_SCHEMA_ID = 272,
-	/** Space id of _collation. */
-	BOX_COLLATION_ID = 276,
-	/** Space id of _vcollation. */
-	BOX_VCOLLATION_ID = 277,
-	/** Space id of _space. */
-	BOX_SPACE_ID = 280,
-	/** Space id of _vspace view. */
-	BOX_VSPACE_ID = 281,
-	/** Space id of _sequence. */
-	BOX_SEQUENCE_ID = 284,
-	/** Space id of _sequence_data. */
-	BOX_SEQUENCE_DATA_ID = 285,
-	/** Space id of _vsequence view. */
-	BOX_VSEQUENCE_ID = 286,
-	/** Space id of _index. */
-	BOX_INDEX_ID = 288,
-	/** Space id of _vindex view. */
-	BOX_VINDEX_ID = 289,
-	/** Space id of _func. */
-	BOX_FUNC_ID = 296,
-	/** Space id of _vfunc view. */
-	BOX_VFUNC_ID = 297,
-	/** Space id of _user. */
-	BOX_USER_ID = 304,
-	/** Space id of _vuser view. */
-	BOX_VUSER_ID = 305,
-	/** Space id of _priv. */
-	BOX_PRIV_ID = 312,
-	/** Space id of _vpriv view. */
-	BOX_VPRIV_ID = 313,
-	/** Space id of _cluster. */
-	BOX_CLUSTER_ID = 320,
-	/** Space id of _trigger. */
-	BOX_TRIGGER_ID = 328,
-	/** Space id of _truncate. */
-	BOX_TRUNCATE_ID = 330,
-	/** Space id of _space_sequence. */
-	BOX_SPACE_SEQUENCE_ID = 340,
-	/** Space id of _vspace_sequence. */
-	BOX_VSPACE_SEQUENCE_ID = 341,
-	/** Space id of _fk_constraint. */
-	BOX_FK_CONSTRAINT_ID = 356,
-	/** Space id of _ck_contraint. */
-	BOX_CK_CONSTRAINT_ID = 364,
-	/** Space id of _func_index. */
-	BOX_FUNC_INDEX_ID = 372,
-	/** Space id of _session_settings. */
-	BOX_SESSION_SETTINGS_ID = 380,
+	SYSTEM_SPACES(SYSTEM_SPACE_MEMBER)
 	/** End of the reserved range of system spaces. */
 	BOX_SYSTEM_ID_MAX = 511,
 	BOX_ID_NIL = 2147483647

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -621,6 +621,7 @@ space_create(struct space *space, struct engine *engine,
 	rlist_create(&space->memtx_stories);
 	rlist_create(&space->alter_stmts);
 	space->lua_ref = LUA_NOREF;
+	space->state.is_sync = space->def->opts.is_sync;
 	return 0;
 
 fail_free_indexes:

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -731,6 +731,10 @@ space_delete(struct space *space);
 int
 space_foreach(int (*func)(struct space *sp, void *udata), void *udata);
 
+/** Update the state of synchronous replication for system spaces. */
+void
+system_spaces_update_is_sync_state(bool is_sync);
+
 /**
  * Dump space definition (key definitions, key count)
  * for ALTER.

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -284,6 +284,14 @@ struct space {
 	 * this object in sync. For more information see #9120.
 	 */
 	int lua_ref;
+	/** The effective state of this space. */
+	struct {
+		/**
+		 * The effective state of synchronous replication for this
+		 * space.
+		 */
+		bool is_sync;
+	} state;
 };
 
 /** Space alter statement. */
@@ -409,7 +417,7 @@ space_is_temporary(const struct space *space)
 static inline bool
 space_is_sync(const struct space *space)
 {
-	return space->def->opts.is_sync;
+	return space->state.is_sync;
 }
 
 /** Return replication group id of a space. */

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -33,6 +33,7 @@
 #include "vclock/vclock.h"
 #include "latch.h"
 #include "errinj.h"
+#include "replication.h"
 
 #include <stdint.h>
 
@@ -473,6 +474,13 @@ txn_limbo_fence(struct txn_limbo *limbo);
  */
 void
 txn_limbo_unfence(struct txn_limbo *limbo);
+
+/** Return whether limbo has an owner. */
+static inline bool
+txn_limbo_has_owner(struct txn_limbo *limbo)
+{
+	return limbo->owner_id != REPLICA_ID_NIL;
+}
 
 /**
  * Initialize qsync engine.

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -335,6 +335,7 @@ g.test_defaults = function()
             yaml_pretty_multiline = 'new',
             fiber_channel_close_mode = 'new',
             box_cfg_replication_sync_timeout = 'new',
+            box_consider_system_spaces_synchronous = 'old',
             box_error_serialize_verbose = 'old',
             sql_seq_scan_default = 'new',
             fiber_slice_default = 'new',

--- a/test/replication-luatest/gh_9723_sync_system_spaces_test.lua
+++ b/test/replication-luatest/gh_9723_sync_system_spaces_test.lua
@@ -1,0 +1,681 @@
+local cbuilder = require('test.config-luatest.cbuilder')
+local cluster = require('test.config-luatest.cluster')
+local compat = require('compat')
+local fio = require('fio')
+local fun = require('fun')
+local t = require('luatest')
+local treegen = require('test.treegen')
+local replica_set = require('luatest.replica_set')
+local server = require('test.luatest_helpers.server')
+local yaml = require('yaml')
+
+local g_general = t.group('general')
+local g_recovery = t.group('recovery')
+local g_schema_upgrade = t.group('schema_upgrade')
+
+local check_sync_system_spaces = [[
+    function(is_sync_state)
+        local t = require('luatest')
+
+        local sync_system_spaces = {
+            '_schema',
+            '_collation',
+            '_vcollation',
+            '_space',
+            '_vspace',
+            '_sequence',
+            '_vsequence',
+            '_index',
+            '_vindex',
+            '_func',
+            '_vfunc',
+            '_user',
+            '_vuser',
+            '_priv',
+            '_vpriv',
+            '_cluster',
+            '_trigger',
+            '_truncate',
+            '_space_sequence',
+            '_vspace_sequence',
+            '_fk_constraint',
+            '_ck_constraint',
+            '_func_index',
+            '_session_settings',
+        }
+
+        local async_system_spaces = {
+            '_vinyl_deferred_delete', -- local space
+            '_sequence_data', -- synchronized by synchronous space operations
+        }
+
+        for _, space in ipairs(sync_system_spaces) do
+            t.assert_equals(box.space[space].is_sync, false)
+            t.assert_equals(box.space[space].state.is_sync, is_sync_state)
+        end
+        for _, space in ipairs(async_system_spaces) do
+            t.assert_equals(box.space[space].is_sync, false)
+            t.assert_equals(box.space[space].state.is_sync, false)
+        end
+    end
+]]
+
+g_general.before_each(function(cg)
+    cg.replica_set = replica_set:new{}
+    local box_cfg = {
+        replication = {
+            server.build_listen_uri('server1', cg.replica_set.id),
+            server.build_listen_uri('server2', cg.replica_set.id),
+        },
+        replication_timeout = 0.1,
+        replication_synchro_timeout = 60,
+    }
+    cg.replication = box_cfg.replication
+    cg.server1 = cg.replica_set:build_and_add_server{
+        alias = 'server1',
+        box_cfg = box_cfg,
+    }
+    cg.server2 = cg.replica_set:build_and_add_server{
+        alias = 'server2',
+        box_cfg = box_cfg,
+    }
+    cg.replica_set:start()
+    cg.replica_set:wait_for_fullmesh()
+    cg.server1:exec(function(check_sync_system_spaces)
+        box.schema.func.create('check_sync_system_spaces', {
+            body = check_sync_system_spaces,
+        })
+    end, {check_sync_system_spaces})
+    cg.server1:wait_for_downstream_to(cg.server2)
+end)
+
+g_general.after_each(function(cg)
+    cg.replica_set:drop()
+end)
+
+-- Test the old behaviour: the system spaces do not become synchronous when the
+-- synchronous queue is claimed.
+g_general.test_old_behaviour = function(cg)
+    t.assert_equals(compat.box_consider_system_spaces_synchronous.default,
+                    'old')
+    cg.server1:exec(function()
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+    cg.server2:exec(function()
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+
+    cg.server1:exec(function()
+        box.space._schema:alter{is_sync = true}
+        t.assert_equals(box.space._schema.is_sync, true)
+        t.assert_equals(box.space._schema.state.is_sync, true)
+    end)
+    cg.server1:wait_for_downstream_to(cg.server2)
+    cg.server2:exec(function()
+        t.assert_equals(box.space._schema.is_sync, true)
+        t.assert_equals(box.space._schema.state.is_sync, true)
+    end)
+    cg.server1:exec(function()
+        box.space._schema:alter{is_sync = false}
+        t.assert_equals(box.space._schema.is_sync, false)
+        t.assert_equals(box.space._schema.state.is_sync, false)
+    end)
+    cg.server1:wait_for_downstream_to(cg.server2)
+    cg.server2:exec(function()
+        t.assert_equals(box.space._schema.is_sync, false)
+        t.assert_equals(box.space._schema.state.is_sync, false)
+    end)
+
+    -- Claim the synchronous queue, the system spaces must continue being
+    -- asynchronous.
+    cg.server1:exec(function()
+        box.ctl.promote()
+        t.assert_not_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+    cg.server1:wait_for_downstream_to(cg.server2)
+    cg.server2:exec(function()
+        t.assert_not_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+
+    -- Unclaim the synchronous queue, the system spaces must continue being
+    -- asynchronous.
+    cg.server1:exec(function()
+        box.ctl.demote()
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+    cg.server1:wait_for_downstream_to(cg.server2)
+    cg.server2:exec(function()
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+
+    -- Test that the state of synchronous replication for the system spaces is
+    -- enabled by the user-provided 'is_sync'.
+    cg.server1:exec(function()
+        box.space._schema:alter{is_sync = true}
+        t.assert_equals(box.space._schema.is_sync, true)
+        t.assert_equals(box.space._schema.state.is_sync, true)
+    end)
+    cg.server1:wait_for_downstream_to(cg.server2)
+
+    -- Claim the synchronous queue, the system space must continue being
+    -- synchronous.
+    cg.server1:exec(function()
+        box.ctl.promote()
+        t.assert_not_equals(box.info.synchro.queue.owner, 0)
+        t.assert_equals(box.space._schema.is_sync, true)
+        t.assert_equals(box.space._schema.state.is_sync, true)
+    end)
+    cg.server1:wait_for_downstream_to(cg.server2)
+    cg.server2:exec(function()
+        t.assert_not_equals(box.info.synchro.queue.owner, 0)
+        t.assert_equals(box.space._schema.is_sync, true)
+        t.assert_equals(box.space._schema.state.is_sync, true)
+    end)
+
+    -- Unclaim the synchronous queue, the system space must continue being
+    -- synchronous.
+    cg.server1:exec(function()
+        box.ctl.demote()
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        t.assert_equals(box.space._schema.is_sync, true)
+        t.assert_equals(box.space._schema.state.is_sync, true)
+    end)
+    cg.server1:wait_for_downstream_to(cg.server2)
+    cg.server2:exec(function()
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        t.assert_equals(box.space._schema.is_sync, true)
+        t.assert_equals(box.space._schema.state.is_sync, true)
+    end)
+end
+
+g_general.before_test('test_new_behaviour', function(cg)
+    cg.server1:exec(function()
+        require('compat').box_consider_system_spaces_synchronous = 'new'
+    end)
+    cg.server2:exec(function()
+        require('compat').box_consider_system_spaces_synchronous = 'new'
+    end)
+end)
+
+-- Test the new behaviour: the system spaces become synchronous when the
+-- synchronous queue is claimed.
+g_general.test_new_behaviour = function(cg)
+    cg.server1:exec(function()
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+    cg.server2:exec(function()
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+
+    -- Claim the synchronous queue, the system spaces must start being
+    -- synchronous.
+    cg.server1:exec(function()
+        box.ctl.promote()
+        t.assert_not_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', true)
+    end)
+    cg.server1:wait_for_downstream_to(cg.server2)
+    cg.server2:exec(function()
+        t.assert_not_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', true)
+    end)
+
+    -- Claim the synchronous queue on the other instance, the system spaces must
+    -- continue being synchronous.
+    cg.server2:exec(function()
+        box.ctl.promote()
+        t.assert_not_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', true)
+    end)
+    cg.server2:wait_for_downstream_to(cg.server1)
+    cg.server1:exec(function()
+        t.assert_not_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', true)
+    end)
+
+    -- Unclaim the synchronous queue, the system spaces must stop being
+    -- synchronous.
+    cg.server2:exec(function()
+        box.ctl.demote()
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+    cg.server2:wait_for_downstream_to(cg.server1)
+    cg.server1:exec(function()
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+
+    -- Test that the state of synchronous replication for the system spaces is
+    -- the disjunction of the user-provided 'is_sync' with the synchronous queue
+    -- state.
+    cg.server1:exec(function()
+        box.space._schema:alter{is_sync = true}
+        t.assert_equals(box.space._schema.is_sync, true)
+        t.assert_equals(box.space._schema.state.is_sync, true)
+    end)
+    cg.server1:wait_for_downstream_to(cg.server2)
+
+    -- Claim the synchronous queue, the system space must continue being
+    -- synchronous.
+    cg.server1:exec(function()
+        box.ctl.promote()
+        t.assert_not_equals(box.info.synchro.queue.owner, 0)
+        t.assert_equals(box.space._schema.is_sync, true)
+        t.assert_equals(box.space._schema.state.is_sync, true)
+    end)
+    cg.server1:wait_for_downstream_to(cg.server2)
+    cg.server2:exec(function()
+        t.assert_not_equals(box.info.synchro.queue.owner, 0)
+        t.assert_equals(box.space._schema.is_sync, true)
+        t.assert_equals(box.space._schema.state.is_sync, true)
+    end)
+
+    -- Unclaim the synchronous queue, the system space must continue being
+    -- synchronous.
+    cg.server1:exec(function()
+        box.ctl.demote()
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        t.assert_equals(box.space._schema.is_sync, true)
+        t.assert_equals(box.space._schema.state.is_sync, true)
+    end)
+    cg.server1:wait_for_downstream_to(cg.server2)
+    cg.server2:exec(function()
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        t.assert_equals(box.space._schema.is_sync, true)
+        t.assert_equals(box.space._schema.state.is_sync, true)
+    end)
+end
+
+g_general.before_test('test_new_behaviour_corner_cases', function(cg)
+    cg.server1:exec(function()
+        box.cfg{wal_queue_max_size = 1}
+        require('compat').box_consider_system_spaces_synchronous = 'new'
+    end)
+    cg.server2:exec(function()
+        box.cfg{wal_queue_max_size = 1}
+        require('compat').box_consider_system_spaces_synchronous = 'new'
+    end)
+end)
+
+-- Test the corner cases of the new behaviour.
+g_general.test_new_behaviour_corner_cases = function(cg)
+    t.tarantool.skip_if_not_debug()
+
+    cg.server1:exec(function()
+        local fiber = require('fiber')
+
+        -- Test that synchronous replication for the system spaces is enabled
+        -- once the PROMOTE request is prepared (i.e., before being written to
+        -- the WAL).
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 1)
+        local f = fiber.new(function()
+            box.ctl.promote()
+        end)
+        f:set_joinable(true)
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+        end)
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', true)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        t.assert(f:join())
+        t.assert_equals(box.info.synchro.queue.owner, box.info.id)
+        box.schema.func.call('check_sync_system_spaces', true)
+
+        -- Test that synchronous replication for the system spaces is disabled
+        -- once the DEMOTE request is prepared (i.e., before being written to
+        -- the WAL).
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 1)
+        f = fiber.new(function()
+            box.ctl.demote()
+        end)
+        f:set_joinable(true)
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+        end)
+        t.assert_not_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', false)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        t.assert(f:join())
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+    cg.server1:wait_for_downstream_to(cg.server2)
+
+    -- Test that synchronous replication for the system spaces is handled
+    -- correctly when a PROMOTE request is rolled back and the synchronous queue
+    -- is not claimed.
+    cg.server2:exec(function()
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', false)
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 1)
+    end)
+    local fid = cg.server1:exec(function()
+        box.error.injection.set('ERRINJ_RAFT_WAIT_TERM_PERSISTED_DELAY', true)
+        local f = require('fiber').create(function()
+            box.ctl.promote()
+        end)
+        f:set_joinable(true)
+        return f:id()
+    end)
+    t.helpers.retrying({timeout = 60}, function()
+        t.assert(cg.server2:grep_log('RAFT: persisted state {term: 4}'))
+    end)
+    cg.server1:exec(function(fid)
+        box.error.injection.set('ERRINJ_RAFT_WAIT_TERM_PERSISTED_DELAY', false)
+        t.assert(require('fiber').find(fid):join())
+    end, {fid})
+    cg.server2:exec(function()
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+        end)
+        t.assert(box.info.synchro.queue.busy)
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', true)
+        box.error.injection.set('ERRINJ_WAL_FALLOCATE', 1)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert_not(box.info.synchro.queue.busy)
+            t.assert_equals(box.info.synchro.queue.owner, 0)
+            box.schema.func.call('check_sync_system_spaces', false)
+        end)
+    end)
+
+    -- Restart replication.
+    cg.server2:exec(function(replication)
+        box.cfg{replication = ''}
+        box.cfg{replication = replication}
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert_not_equals(box.info.status, "orphan")
+        end)
+    end, {cg.replication})
+
+    -- Test that synchronous replication for the system spaces is handled
+    -- correctly when a PROMOTE request is rolled back and the synchronous queue
+    -- is claimed.
+    cg.server1:wait_for_downstream_to(cg.server2)
+    cg.server2:exec(function()
+        box.ctl.promote()
+        t.assert_equals(box.info.synchro.queue.owner, box.info.id)
+        box.schema.func.call('check_sync_system_spaces', true)
+    end)
+    cg.server2:wait_for_downstream_to(cg.server1)
+    cg.server1:exec(function()
+        t.assert_not_equals(box.info.synchro.queue.owner, 0)
+        t.assert_not_equals(box.info.synchro.queue.owner, box.info.id)
+        box.schema.func.call('check_sync_system_spaces', true)
+    end)
+    cg.server2:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 1)
+    end)
+    local fid = cg.server1:exec(function()
+        box.error.injection.set('ERRINJ_RAFT_WAIT_TERM_PERSISTED_DELAY', true)
+        local f = require('fiber').create(function()
+            box.ctl.promote()
+        end)
+        f:set_joinable(true)
+        return f:id()
+    end)
+    t.helpers.retrying({timeout = 60}, function()
+        t.assert(cg.server2:grep_log('RAFT: persisted state {term: 6}'))
+    end)
+    cg.server1:exec(function(fid)
+        box.error.injection.set('ERRINJ_RAFT_WAIT_TERM_PERSISTED_DELAY', false)
+        t.assert(require('fiber').find(fid):join())
+    end, {fid})
+    cg.server2:exec(function()
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+        end)
+        t.assert(box.info.synchro.queue.busy)
+        t.assert_equals(box.info.synchro.queue.owner, box.info.id)
+        box.schema.func.call('check_sync_system_spaces', true)
+        box.error.injection.set('ERRINJ_WAL_FALLOCATE', 1)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert_not(box.info.synchro.queue.busy)
+            t.assert_equals(box.info.synchro.queue.owner, box.info.id)
+            box.schema.func.call('check_sync_system_spaces', true)
+        end)
+    end)
+
+    -- Restart replication.
+    cg.server2:exec(function(replication)
+        box.cfg{replication = ''}
+        box.cfg{replication = replication}
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert_not_equals(box.info.status, "orphan")
+        end)
+    end, {cg.replication})
+
+    -- Test that synchronous replication for the system spaces is handled
+    -- correctly when a DEMOTE request is rolled back.
+    cg.server1:wait_for_downstream_to(cg.server2)
+    cg.server2:exec(function()
+        t.assert_not_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', true)
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 1)
+    end)
+    fid = cg.server1:exec(function()
+        box.error.injection.set('ERRINJ_RAFT_WAIT_TERM_PERSISTED_DELAY', true)
+        local f = require('fiber').create(function()
+            box.ctl.demote()
+        end)
+        f:set_joinable(true)
+        return f:id()
+    end)
+    t.helpers.retrying({timeout = 60}, function()
+        t.assert(cg.server2:grep_log('RAFT: persisted state {term: 7}'))
+    end)
+    cg.server1:exec(function(fid)
+        box.error.injection.set('ERRINJ_RAFT_WAIT_TERM_PERSISTED_DELAY', false)
+        require('fiber').find(fid):join()
+    end, {fid})
+    cg.server2:exec(function()
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+        end)
+        t.assert_not_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', false)
+        box.error.injection.set('ERRINJ_WAL_FALLOCATE', 1)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert_not(box.info.synchro.queue.busy)
+            t.assert_not_equals(box.info.synchro.queue.owner, 0)
+            box.schema.func.call('check_sync_system_spaces', true)
+        end)
+    end)
+end
+
+-- Test that the transition of the compat option works correctly.
+g_general.test_compat_opt_transition = function(cg)
+    cg.server1:exec(function()
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+    cg.server2:exec(function()
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+
+    cg.server1:exec(function()
+        box.ctl.promote()
+        t.assert_equals(box.info.synchro.queue.owner, box.info.id)
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+    cg.server1:wait_for_downstream_to(cg.server2)
+    cg.server2:exec(function()
+        t.assert_not_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+
+    cg.server1:exec(function()
+        require('compat').box_consider_system_spaces_synchronous = 'new'
+        box.schema.func.call('check_sync_system_spaces', true)
+    end)
+    cg.server2:exec(function()
+        require('compat').box_consider_system_spaces_synchronous = 'new'
+        box.schema.func.call('check_sync_system_spaces', true)
+    end)
+
+    cg.server1:exec(function()
+        require('compat').box_consider_system_spaces_synchronous = 'old'
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+    cg.server2:exec(function()
+        require('compat').box_consider_system_spaces_synchronous = 'old'
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+
+    cg.server1:exec(function()
+        require('compat').box_consider_system_spaces_synchronous = 'new'
+        box.schema.func.call('check_sync_system_spaces', true)
+    end)
+    cg.server2:exec(function()
+        require('compat').box_consider_system_spaces_synchronous = 'new'
+        box.schema.func.call('check_sync_system_spaces', true)
+    end)
+
+    cg.server1:exec(function()
+        box.ctl.demote()
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+    cg.server1:wait_for_downstream_to(cg.server2)
+    cg.server2:exec(function()
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+
+    cg.server1:exec(function()
+        require('compat').box_consider_system_spaces_synchronous = 'old'
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+    cg.server2:exec(function()
+        require('compat').box_consider_system_spaces_synchronous = 'old'
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+end
+
+g_recovery.before_all(cluster.init)
+g_recovery.after_all(cluster.clean)
+g_recovery.after_each(cluster.drop)
+
+g_recovery.before_each(function(cg)
+    local config = cbuilder.new()
+        :add_instance('server', {})
+        :set_instance_option('server', 'compat', {
+            box_consider_system_spaces_synchronous = 'new',
+        })
+        :config()
+    local cluster = cluster.new(cg, config)
+    cluster:start()
+    cluster.server:exec(function(check_sync_system_spaces)
+        t.assert_equals(require("compat").
+                        box_consider_system_spaces_synchronous.current, "new")
+        box.schema.func.create('check_sync_system_spaces', {
+            body = check_sync_system_spaces,
+    })
+    end, {check_sync_system_spaces})
+end)
+
+-- Test that system spaces are not synchronous after bootstrap.
+g_recovery.test_bootstrap = function(cg)
+    cg.cluster.server:exec(function()
+        box.schema.func.call('check_sync_system_spaces', false)
+    end)
+end
+
+-- Test that system spaces are synchronous after recovery from an xlog with a
+-- promote entry.
+g_recovery.test_recovery_from_xlog = function(cg)
+    cg.cluster.server:exec(function()
+        box.ctl.promote()
+        box.schema.func.call('check_sync_system_spaces', true)
+    end)
+    cg.cluster.server:restart()
+    cg.cluster.server:exec(function()
+        box.schema.func.call('check_sync_system_spaces', true)
+    end)
+end
+
+-- Test that system spaces are synchronous after recovery from a snapshot with a
+-- promote entry.
+g_recovery.test_recovery_from_snap = function(cg)
+    cg.cluster.server:exec(function()
+        box.ctl.promote()
+        box.schema.func.call('check_sync_system_spaces', true)
+        box.snapshot()
+    end)
+    cg.cluster.server:restart()
+    cg.cluster.server:exec(function()
+        box.schema.func.call('check_sync_system_spaces', true)
+    end)
+end
+
+g_schema_upgrade.before_each(function(cg)
+    treegen.init(cg)
+
+    local rs_uuid = 'd266de7d-b3fb-45d8-b644-580700550614'
+    local inst_uuid = 'bb89f474-7ed6-414c-a1d0-da7392c563d7'
+    local datadir = 'test/box-luatest/upgrade/2.10.4'
+    local dir = treegen.prepare_directory(cg, {}, {})
+    local workdir = fio.pathjoin(dir, 'server')
+    fio.mktree(workdir)
+    fio.copytree(datadir, workdir)
+
+    local config = cbuilder.new()
+        :add_instance('server', {
+            compat = {box_consider_system_spaces_synchronous = 'new'},
+            snapshot = {dir = workdir},
+            wal = {dir = workdir},
+            database = {
+                instance_uuid = inst_uuid, replicaset_uuid = rs_uuid,
+                mode = 'ro',
+            }})
+        :config()
+    local cfg = yaml.encode(config)
+    local config_file = treegen.write_script(dir, 'cfg.yaml', cfg)
+    local opts = {
+        env = {LUA_PATH = os.environ()['LUA_PATH']},
+        config_file = config_file,
+        chdir = dir,
+    }
+    cg.server = server:new(fun.chain(opts, {alias = 'server'}):tomap())
+    cg.server:start()
+    cg.server:exec(function()
+        t.assert_equals(require("compat").
+                        box_consider_system_spaces_synchronous.current, "new")
+    end)
+end)
+
+-- Test that a system space added after a schema upgrade, while the synchronous
+-- queue is claimed, is synchronous.
+g_schema_upgrade.test_upgrade_adding_new_space = function(cg)
+    cg.server:exec(function(check_sync_system_spaces)
+        t.assert_equals(box.space._schema:get{'version'}, {'version', 2, 10, 4})
+        t.assert_equals(box.space._vspace_sequence, nil)
+        box.cfg{read_only = false}
+        box.ctl.promote()
+        box.schema.upgrade()
+        t.assert_not_equals(box.space._vspace_sequence, nil)
+        box.schema.func.create('check_sync_system_spaces', {
+            body = check_sync_system_spaces,
+        })
+        box.schema.func.call('check_sync_system_spaces', true)
+    end, {check_sync_system_spaces})
+end
+
+g_schema_upgrade.after_each(function(cg)
+    cg.server:drop()
+    treegen.clean(cg)
+end)

--- a/test/replication/qsync_basic.result
+++ b/test/replication/qsync_basic.result
@@ -11,6 +11,14 @@ s1.is_sync
  | ---
  | - true
  | ...
+s1.state.is_sync
+ | ---
+ | - true
+ | ...
+s1.is_sync == s1.state.is_sync
+ | ---
+ | - true
+ | ...
 pk = s1:create_index('pk')
  | ---
  | ...
@@ -33,6 +41,14 @@ s2 = box.schema.create_space('test2')
 s2.is_sync
  | ---
  | - false
+ | ...
+s2.state.is_sync
+ | ---
+ | - false
+ | ...
+s2.is_sync == s2.state.is_sync
+ | ---
+ | - true
  | ...
 
 -- Net.box takes sync into account.

--- a/test/replication/qsync_basic.test.lua
+++ b/test/replication/qsync_basic.test.lua
@@ -5,6 +5,8 @@
 --
 s1 = box.schema.create_space('test1', {is_sync = true})
 s1.is_sync
+s1.state.is_sync
+s1.is_sync == s1.state.is_sync
 pk = s1:create_index('pk')
 box.ctl.promote()
 box.begin() s1:insert({1}) s1:insert({2}) box.commit()
@@ -13,6 +15,8 @@ s1:select{}
 -- Default is async.
 s2 = box.schema.create_space('test2')
 s2.is_sync
+s2.state.is_sync
+s2.is_sync == s2.state.is_sync
 
 -- Net.box takes sync into account.
 box.schema.user.grant('guest', 'super')

--- a/test/unit/snap_quorum_delay.cc
+++ b/test/unit/snap_quorum_delay.cc
@@ -78,7 +78,6 @@ enum process_type {
  * (to push a transaction to the limbo and simulate confirm).
  */
 const int fake_lsn = 1;
-extern "C" int instance_id;
 const int relay_id = 2;
 
 int


### PR DESCRIPTION
This patch series enables synchronous replication for systems spaces when the synchronous queue is claimed.

Closes #9723