### PR TITLE
ci: add workflow to check downgrade versions

### DIFF
--- a/.github/workflows/downgrade_versions.yml
+++ b/.github/workflows/downgrade_versions.yml
@@ -1,0 +1,58 @@
+name: downgrade_versions
+
+on:
+  push:
+    tags:
+      - '**'
+
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch, and
+  # tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+jobs:
+  downgrade_versions:
+    if: github.repository == 'tarantool/tarantool'
+
+    runs-on: ubuntu-20.04-self-hosted
+
+    container:
+      image: docker.io/tarantool/testing:ubuntu-jammy
+
+    steps:
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
+
+      - name: Sources checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # If workflow is triggered by pushing a tag and we checkout
+          # using github.ref then checkout action overwrite tag with tag
+          # without annotation. This breaks check-downgrade-versions.sh
+          # script as it is triggered only on annotated tags. Let's
+          # checkout by sha in this case.
+          ref: ${{ github.sha }}
+
+      - name: Check downgrade versions
+        run: ./tools/check-downgrade-versions.sh
+
+      - name: Send VK Teams message on failure
+        if: failure()
+        uses: ./.github/actions/report-job-status
+        with:
+          bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}

--- a/src/box/lua/upgrade.lua
+++ b/src/box/lua/upgrade.lua
@@ -2092,6 +2092,7 @@ end
 
 -- List of all Tarantool releases we can downgrade to.
 local downgrade_versions = {
+    -- DOWNGRADE VERSIONS BEGIN
     "2.8.2",
     "2.8.3",
     "2.8.4",
@@ -2105,6 +2106,7 @@ local downgrade_versions = {
     "2.11.1",
     "3.0.0",
     "3.1.0",
+    -- DOWNGRADE VERSIONS END
 }
 
 -- Downgrade or list downgrade issues depending of dry_run argument value.

--- a/tools/check-downgrade-versions.sh
+++ b/tools/check-downgrade-versions.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# This script checks that we can downgrade to all the released versions
+# less then being released. For example when releasing version 2.11.4
+# we check that we can downgrade to 2.11.3, 2.11.2, ..., 2.10.8, 2.10.7, ...
+# 2.8.2.
+#
+# The versions we can downgrade to are those mentioned in downgrade_versions
+# list in src/box/lua/upgrade.lua. For the sake of parsing simplicity
+# the versions should be between begin and end marks:
+# -- DOWNGRADE VERSIONS BEGIN
+# -- DOWNGRADE VERSIONS END
+#
+# The check is only done for the commit tagged as release version
+# (annotated tag with name like 2.11.4).
+
+set -eo pipefail
+
+error() {
+   echo "$@" 1>&2
+   exit 1
+}
+
+cleanup() {
+  rm -f $tag_exceptions $expected_versions $actual_versions || true
+}
+
+trap "cleanup" EXIT
+
+# Tags that should not be considered.
+tag_exceptions=`mktemp`
+echo 2.9.0 > $tag_exceptions
+
+this_tag=`git describe --exact-match 2>/dev/null || true`
+tag_pattern='^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$'
+# Make downgrade check only for the release tags.
+if [[ $this_tag =~ $tag_pattern ]]; then
+    # File with expected versions.
+    expected_versions=`mktemp`
+    # Sorted (in version order) list of release tags.
+    tags=`git tag | grep -E $tag_pattern | sort -V`
+    skip=1
+    # Cut tags below 2.8.2 and above $this_tag
+    for tag in $tags; do
+        if [[ $tag = '2.8.2' ]]; then
+            skip=0
+        fi
+        if [[ $skip -eq 0 ]]; then
+            echo $tag >> $expected_versions
+        fi
+        if [[ $tag = $this_tag ]]; then
+            skip=1
+        fi
+    done
+
+    # File of versions we can downgrade to.
+    actual_versions=`mktemp`
+    begin_mark='DOWNGRADE VERSIONS BEGIN'
+    end_mark='DOWNGRADE VERSIONS END'
+    upgrade_file='src/box/lua/upgrade.lua'
+    grep -q "$begin_mark" $upgrade_file ||
+        error "Cannot find start mark in $upgrade_file"
+    grep -q "$end_mark" $upgrade_file ||
+        error "Cannot find end mark in $upgrade_file"
+
+    # Cut part of $upgrade_file between $begin_mark and $end_mark
+    # and for every line strip everything except version.
+    awk "/$begin_mark/{flag=1; next}
+         /$end_mark/{flag=0} flag" $upgrade_file |
+         sed -E 's/.*"(.*)".*/\1/' > $actual_versions
+
+    cat $tag_exceptions >> $actual_versions
+    # Sort in usual order before using `comm`.
+    sort -o $expected_versions $expected_versions
+    sort -o $actual_versions $actual_versions
+    diff=`comm -23 $expected_versions $actual_versions`
+    if [ -n "$diff" ]; then
+        echo "Some versions are missing in downgrade list:" 1>&2
+        echo "$diff"
+        exit 1
+    fi
+fi
+
+echo OK
+exit 0


### PR DESCRIPTION
Tarantool has hardcoded list of versions it can downgrade to. This list should consist of all the released versions less than Tarantool version. This workflow helps to make sure we update the list before release.

When run on the commit with release tag it check the list and fail if it misses some released version less than current. In this case we are supposed to update downgrade list (with required downgrade code) and update the release tag.

Closes #8319