### PR TITLE
lsan: add another FP leak suppression

### DIFF
--- a/asan/lsan.supp
+++ b/asan/lsan.supp
@@ -77,3 +77,4 @@ leak:box_tuple_update
 leak:box_tuple_iterator
 leak:box_index_iterator_after
 leak:ibuf_reserve_slow
+leak:box_check_slice


### PR DESCRIPTION
Another occurrence similar to  #8890  (CI of release/2.11 of EE version):

```
[007] default | Direct leak of 872 byte(s) in 1 object(s) allocated from:
[007] default |     #0 0x561e52c10a1e in malloc (/__w/tarantool-ee/tarantool-ee/tarantool/src/tarantool+0x121ba1e) (BuildId: 7e480e11e82733cb4922ef2b33f5f463ed9a620f)
[007] default |     #1 0x561e54016026 in BuildFiberSliceIsExceeded /__w/tarantool-ee/tarantool-ee/tarantool/src/lib/core/exception.cc:335:2
[007] default |     #2 0x561e5352a363 in fiber_check_slice() /__w/tarantool-ee/tarantool-ee/tarantool/src/lib/core/fiber.h:1062:3
[007] default |     #3 0x561e5352999c in box_check_slice_slow /__w/tarantool-ee/tarantool-ee/tarantool/src/box/box.cc:350:9
[007] default |     #4 0x561e52cf293b in box_check_slice() /__w/tarantool-ee/tarantool-ee/tarantool/src/box/box.h:141:10
[007] default |     #5 0x561e52cfb2af in box_iterator_next /__w/tarantool-ee/tarantool-ee/tarantool/src/box/index.cc:518:6
[007] default |     #6 0x561e7e297220  (<unknown module>)
[007] default | 
[007] default | Direct leak of 872 byte(s) in 1 object(s) allocated from:
[007] default |     #0 0x561e52c10a1e in malloc (/__w/tarantool-ee/tarantool-ee/tarantool/src/tarantool+0x121ba1e) (BuildId: 7e480e11e82733cb4922ef2b33f5f463ed9a620f)
[007] default |     #1 0x561e54016026 in BuildFiberSliceIsExceeded /__w/tarantool-ee/tarantool-ee/tarantool/src/lib/core/exception.cc:335:2
[007] default |     #2 0x561e5352a363 in fiber_check_slice() /__w/tarantool-ee/tarantool-ee/tarantool/src/lib/core/fiber.h:1062:3
[007] default |     #3 0x561e5352999c in box_check_slice_slow /__w/tarantool-ee/tarantool-ee/tarantool/src/box/box.cc:350:9
[007] default |     #4 0x561e52cf293b in box_check_slice() /__w/tarantool-ee/tarantool-ee/tarantool/src/box/box.h:141:10
[007] default |     #5 0x561e52cf17c2 in box_index_get /__w/tarantool-ee/tarantool-ee/tarantool/src/box/index.cc:293:6
[007] default |     #6 0x561e7e298148  (<unknown module>)
[007] default | 
[007] default | SUMMARY: AddressSanitizer: 1744 byte(s) leaked in 2 allocation(s).
```

