### PR TITLE
sio: use `kern.ipc.somaxconn` for `listen()` on Mac

### DIFF
--- a/changelogs/unreleased/gh-8130-enable-somaxconn-on-mac.md
+++ b/changelogs/unreleased/gh-8130-enable-somaxconn-on-mac.md
@@ -1,0 +1,5 @@
+## bugfix/core
+
+* Fixed the bug that on Mac the system setting `kern.ipc.somaxconn` was ignored
+  for listening sockets. Now it is used, but capped at 32367 due to how
+  `listen()` works on Mac (gh-8130).


### PR DESCRIPTION
listen() on Mac used to take SOMAXCONN as the backlog size. It is just 128, which is too small when connections are incoming too fast. They get rejected.

Increase of the queue size wasn't possible, because the limit was hardcoded. But now sio takes the runtime limit from kern.ipc.somaxconn sysctl setting.

One weird thing is that when set too high, it seems to have no effect, like if nothing was changed. Specifically, values above 32767 are not doing anything, even though stay visible in kern.ipc.somaxconn.

It seems listen() on Mac internally might be using 'short' or int16_t to store the queue size and it gets broken when anything above INT16_MAX is used. The code truncates the queue size to this value if the given one is too high.

Closes #8130

NO_DOC=bugfix
NO_TEST=requires root privileges for testing