### PR TITLE
[backport 3.1] config: use vshard-ee if available

### DIFF
--- a/changelogs/unreleased/config-support-vshard-ee.md
+++ b/changelogs/unreleased/config-support-vshard-ee.md
@@ -1,0 +1,4 @@
+## bugfix/config
+
+* Support for `vshard-ee` in addition to `vshard` in the sharding configuration
+  logic (ghe-815).

--- a/src/box/lua/config/applier/credentials.lua
+++ b/src/box/lua/config/applier/credentials.lua
@@ -1,5 +1,6 @@
 local expression = require('internal.config.utils.expression')
 local log = require('internal.config.utils.log')
+local loaders = require('internal.loaders')
 local digest = require('digest')
 local fiber = require('fiber')
 
@@ -318,9 +319,10 @@ local function sharding_role(configdata)
     -- The error will be thrown later, in sharding.lua. Here we are simply
     -- trying to avoid the "module not found" error.
     --
-    local ok, vshard = pcall(require, 'vshard')
+    local ok, vshard = pcall(loaders.require_first, 'vshard-ee', 'vshard')
     if ok and expression.eval('v >= 0.1.25', {v = vshard.consts.VERSION}) then
-        local vexports = require('vshard.storage.exports')
+        local vexports = loaders.require_first('vshard-ee.storage.exports',
+            'vshard.storage.exports')
         local exports = vexports.compile(vexports.log[#vexports.log])
         for name in pairs(exports.funcs) do
             table.insert(funcs, name)

--- a/src/box/lua/config/applier/sharding.lua
+++ b/src/box/lua/config/applier/sharding.lua
@@ -1,5 +1,6 @@
 local expression = require('internal.config.utils.expression')
 local log = require('internal.config.utils.log')
+local loaders = require('internal.loaders')
 _G.vshard = nil
 
 -- Watcher which will create all the necessary functions.
@@ -12,9 +13,9 @@ local function apply(config)
         return
     end
     -- Make sure vshard is available and its version is not too old.
-    local ok, vshard = pcall(require, 'vshard')
+    local ok, vshard = pcall(loaders.require_first, 'vshard-ee', 'vshard')
     if not ok then
-        error('The vshard module is not available', 0)
+        error('The vshard-ee/vshard module is not available', 0)
     end
     if expression.eval('v < 0.1.25', {v = vshard.consts.VERSION}) then
         error('The vshard module is too old: the minimum supported version ' ..
@@ -36,7 +37,8 @@ local function apply(config)
         -- Start a watcher which will create all the necessary functions.
         if watcher == nil then
             local function deploy_funcs()
-                local vexports = require('vshard.storage.exports')
+                local vexports = loaders.require_first(
+                    'vshard-ee.storage.exports', 'vshard.storage.exports')
                 local exports = vexports.compile(vexports.log[#vexports.log])
                 vexports.deploy_funcs(exports)
             end

--- a/src/lua/loaders.lua
+++ b/src/lua/loaders.lua
@@ -512,6 +512,31 @@ _G.require = function(modname)
     return raw_require(modname)
 end
 
+-- Load first available module from the given ones.
+--
+-- It just calls `require()` on the provided arguments (in the
+-- given order) and once this call succeeds, the function returns
+-- its result.
+--
+-- If neither of the given modules can be `require`'d, an error is
+-- raised.
+local function require_first(...)
+    if select('#', ...) == 0 then
+        error('loaders.require_first expects at least one argument', 0)
+    end
+
+    for i = 1, select('#', ...) do
+        local module_name = select(i, ...)
+        local ok, res = pcall(require, module_name)
+        if ok then
+            return res
+        end
+    end
+
+    local modules_str = ('"%s"'):format(table.concat({...}, '", "'))
+    error(('neither of modules %s are found'):format(modules_str), 0)
+end
+
 return {
     ROCKS_LIB_PATH = ROCKS_LIB_PATH,
     ROCKS_LUA_PATH = ROCKS_LUA_PATH,
@@ -537,4 +562,5 @@ return {
     --
     -- Usage: loaders.no_package_loaded[modname] = true
     no_package_loaded = no_package_loaded,
+    require_first = require_first,
 }

--- a/test/app-luatest/require_first_test.lua
+++ b/test/app-luatest/require_first_test.lua
@@ -1,0 +1,49 @@
+local t = require('luatest')
+local treegen = require('test.treegen')
+local justrun = require('test.justrun')
+
+local g = t.group()
+
+g.before_all(treegen.init)
+g.after_all(treegen.clean)
+
+-- A few test cases for the loaders.require_first() function.
+--
+-- Note: The loaders module is internal.
+g.test_basic = function(g)
+    local dir = treegen.prepare_directory(g, {}, {})
+    treegen.write_script(dir, 'a.lua', 'return {whoami = "a"}')
+    treegen.write_script(dir, 'b.lua', 'return {whoami = "b"}')
+
+    treegen.write_script(dir, 'main.lua', string.dump(function()
+        local loaders = require('internal.loaders')
+        local t = require('luatest')
+
+        for i, case in ipairs({
+            -- Positive test cases.
+            {args = {'a', 'b'}, exp = {whoami = 'a'}},
+            {args = {'b', 'a'}, exp = {whoami = 'b'}},
+            {args = {'a', 'c'}, exp = {whoami = 'a'}},
+            {args = {'c', 'a'}, exp = {whoami = 'a'}},
+            -- Negative test cases.
+            {args = {}, err = 'loaders.require_first expects at least one ' ..
+                'argument'},
+            {args = {'c'}, err = 'neither of modules "c" are found'},
+            {args = {'c', 'd'}, err = 'neither of modules "c", "d" are found'},
+        }) do
+            if case.exp ~= nil then
+                assert(case.err == nil)
+                local res = loaders.require_first(unpack(case.args))
+                t.assert_equals(res, case.exp, ('case #%03d'):format(i))
+            else
+                assert(case.err ~= nil)
+                t.assert_error_msg_equals(case.err, loaders.require_first,
+                    unpack(case.args))
+            end
+        end
+    end))
+
+    local opts = {nojson = true, stderr = true}
+    local res = justrun.tarantool(dir, {}, {'main.lua'}, opts)
+    t.assert_equals(res.exit_code, 0, {res.stdout, res.stderr})
+end

--- a/test/box-luatest/upgrade/2.11.0/vshard/storage-gen.lua
+++ b/test/box-luatest/upgrade/2.11.0/vshard/storage-gen.lua
@@ -45,7 +45,10 @@ local names = {
 }
 
 -- Start the database with sharding
-local vshard = require('vshard')
+local ok, vshard = pcall(require, 'vshard-ee')
+if not ok then
+    vshard = require('vshard')
+end
 vshard.storage.cfg(cfg, names[NAME])
 
 box.once("testapp", function()

--- a/test/config-luatest/vshard_test.lua
+++ b/test/config-luatest/vshard_test.lua
@@ -7,10 +7,17 @@ local helpers = require('test.config-luatest.helpers')
 
 local g = helpers.group()
 
-local has_vshard = pcall(require, 'vshard')
+local has_vshard = pcall(require, 'vshard-ee')
+if not has_vshard then
+    has_vshard = pcall(require, 'vshard')
+end
+
+local function skip_if_no_vshard()
+    t.skip_if(not has_vshard, 'Module "vshard-ee/vshard" is not available')
+end
 
 g.test_fixed_masters = function(g)
-    t.skip_if(not has_vshard, 'Module "vshard" is not available')
+    skip_if_no_vshard()
     local dir = treegen.prepare_directory(g, {}, {})
     local config = [[
     credentials:
@@ -258,7 +265,7 @@ g.test_fixed_masters = function(g)
 end
 
 g.test_rebalancer_role = function(g)
-    t.skip_if(not has_vshard, 'Module "vshard" is not available')
+    skip_if_no_vshard()
     local dir = treegen.prepare_directory(g, {}, {})
     local config = [[
     credentials:
@@ -422,7 +429,7 @@ g.test_rebalancer_role = function(g)
 end
 
 g.test_too_many_rebalancers = function(g)
-    t.skip_if(not has_vshard, 'Module "vshard" is not available')
+    skip_if_no_vshard()
     local dir = treegen.prepare_directory(g, {}, {})
     local config = [[
     credentials:
@@ -470,7 +477,7 @@ end
 -- credentials sharding role.
 --
 g.test_no_sharding_credentials_role_success = function(g)
-    t.skip_if(not has_vshard, 'Module "vshard" is not available')
+    skip_if_no_vshard()
     helpers.success_case(g, {
         options = {
             ['credentials.users.storage.roles'] = {'sharding'},
@@ -494,7 +501,7 @@ g.test_no_sharding_credentials_role_success = function(g)
 end
 
 g.test_no_sharding_credentials_role_error = function(g)
-    t.skip_if(not has_vshard, 'Module "vshard" is not available')
+    skip_if_no_vshard()
     local dir = treegen.prepare_directory(g, {}, {})
     local config = [[
     credentials:
@@ -536,7 +543,7 @@ end
 -- credentials, its credential sharding role is not checked.
 --
 g.test_no_storage_user = function(g)
-    t.skip_if(not has_vshard, 'Module "vshard" is not available')
+    skip_if_no_vshard()
     helpers.success_case(g, {
         options = {
             ['sharding.roles'] = {'storage', 'router'},
@@ -551,7 +558,7 @@ end
 
 -- Make sure that the credential sharding role has all necessary credentials.
 g.test_sharding_credentials_role = function(g)
-    t.skip_if(not has_vshard, 'Module "vshard" is not available')
+    skip_if_no_vshard()
     local dir = treegen.prepare_directory(g, {}, {})
     local config = [[
     credentials:
@@ -594,7 +601,10 @@ g.test_sharding_credentials_role = function(g)
         local role = box.space._user.index.name:get('sharding')
         local repl_id = box.space._user.index.name:get('replication').id
         t.assert(role ~= nil)
-        local vexports = require('vshard.storage.exports')
+        local ok, vexports = pcall(require, 'vshard-ee.storage.exports')
+        if not ok then
+            vexports = require('vshard.storage.exports')
+        end
         local exports = vexports.compile(vexports.log[#vexports.log])
 
         -- The role should have the necessary privileges.
@@ -618,7 +628,7 @@ g.test_sharding_credentials_role = function(g)
 end
 
 g.test_no_suitable_uri = function(g)
-    t.skip_if(not has_vshard, 'Module "vshard" is not available')
+    skip_if_no_vshard()
     local dir = treegen.prepare_directory(g, {}, {})
     local config = [[
     credentials:
@@ -656,7 +666,7 @@ end
 -- Make sure that rebalancing will be disabled if rebalancer_mode == 'off', even
 -- if rebalancer sharding role is assigned.
 g.test_rebalancer_mode = function(g)
-    t.skip_if(not has_vshard, 'Module "vshard" is not available')
+    skip_if_no_vshard()
     local dir = treegen.prepare_directory(g, {}, {})
     local config = [[
     credentials:
@@ -708,7 +718,7 @@ end
 -- Make sure the shrading.weight configuration parameter is set
 -- correctly in vshard.
 g.test_weight = function(g)
-    t.skip_if(not has_vshard, 'Module "vshard" is not available')
+    skip_if_no_vshard()
     local dir = treegen.prepare_directory(g, {}, {})
     local config = [[
     credentials:

--- a/test/config-luatest/vshard_upgrade_test.lua
+++ b/test/config-luatest/vshard_upgrade_test.lua
@@ -7,7 +7,10 @@ local fio = require('fio')
 
 local g = t.group()
 
-local has_vshard = pcall(require, 'vshard')
+local has_vshard = pcall(require, 'vshard-ee')
+if not has_vshard then
+    has_vshard = pcall(require, 'vshard')
+end
 
 --
 -- Test, that Tarantool upgrade with vshard happens without downtime:
@@ -20,7 +23,7 @@ local has_vshard = pcall(require, 'vshard')
 --     6. Vshard works after all names are applied.
 --
 g.before_all(function(g)
-    t.skip_if(not has_vshard, 'Module "vshard" is not available')
+    t.skip_if(not has_vshard, 'Module "vshard-ee/vshard" is not available')
     treegen.init(g)
     local uuids = {
         ['rs-001'] = 'cbf06940-0790-498b-948d-042b62cf3d29',


### PR DESCRIPTION
*(This is a backport of PR #10129 to `release/3.1`, future `3.1.1` release.)*

----

The new closed-source `vshard-ee` module was recently introduced. It is based on the open-source `vshard` module and, as far as I know, provides the same API.

Let's configure `vshard-ee` in the same way as `vshard` if sharding is enabled in tarantool's configuration.

Prefer `vshard-ee` if both are available.

Fixes https://github.com/tarantool/tarantool-ee/issues/815