### PR TITLE
ci: avoid sending perf stat to Influx from forks

### DIFF
--- a/.github/workflows/perf_micro.yml
+++ b/.github/workflows/perf_micro.yml
@@ -79,6 +79,11 @@ jobs:
       - name: Aggregate benchmark results
         run: make -f .test.mk test-perf-aggregate
       - name: Send statistics to InfluxDB
+        # Run on push to the 'master' and release branches or on
+        # non-fork pull requests (secrets are unavailable in fork
+        # pull requests).
+        if: github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository
         # TODO: For now, use the debug bucket for this PoC.
         # --silent -o /dev/null: Prevent dumping any reply part
         # in the output in case of an error.


### PR DESCRIPTION
This patch is the follow-up for the commit
49946a72b72884d4f84269b90e6a61 ("ci: send perf statistics to InfluxDB"). Since secrets are unavailable for fork repositories, the sending step fails due to a missed InfluxDB URL and token. This patch allows to run this step only for on push events or PRs from the main repository itself.

NO_DOC=CI
NO_CHANGELOG=CI
NO_TEST=CI