### PR TITLE
config: add missing ssl.ssl_cert for etcd

### DIFF
--- a/changelogs/unreleased/ghe-827-etcd-ssl-cert.md
+++ b/changelogs/unreleased/ghe-827-etcd-ssl-cert.md
@@ -1,0 +1,4 @@
+## bugfix/config
+
+* Added the `ssl.ssl_cert` configuration option for `etcd` configuration
+  storage (ghe-827).

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -521,6 +521,9 @@ return schema.new('instance_config', schema.record({
                 ssl_key = schema.scalar({
                     type = 'string',
                 }),
+                ssl_cert = schema.scalar({
+                    type = 'string',
+                }),
                 ca_path = schema.scalar({
                     type = 'string',
                 }),

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -100,8 +100,9 @@ g.test_config_enterprise = function()
                 },
                 ssl = {
                     ssl_key = 'seven',
-                    ca_path = 'eight',
-                    ca_file = 'nine',
+                    ssl_cert = 'eight',
+                    ca_path = 'nine',
+                    ca_file = 'ten',
                     verify_peer = true,
                     verify_host = false,
                 },


### PR DESCRIPTION
etcd configuration section allows to connect to TLS-encrypted etcd cluster, providing a way to pass `ssl.ssl_key`. But it is not enough when etcd server have client cert auth enabled and has a CA file, since it requires a ssl_cert as well. Actually, propagating ssl_cert is already a part of the EE connect code [1], we just missing the top-level config option.

Fixes https://github.com/tarantool/tarantool-ee/issues/827

1. https://github.com/tarantool/tarantool-ee/blame/1138443c46e7a6e1bb855277bc6cb3333240131c/src/box/lua/config/source/etcd.lua#L103

@TarantoolBot document
Title: config: add missing ssl.ssl_cert for etcd

etcd configuration section already allows to set `ssl.ssl_key`. Now it also allows to pass `ssl.ssl_cert`.