### PR TITLE
box: fix memleak on functional index drop

### DIFF
--- a/changelogs/unreleased/gh-10163-fix-functional-index-drop-memleak.md
+++ b/changelogs/unreleased/gh-10163-fix-functional-index-drop-memleak.md
@@ -1,0 +1,3 @@
+## bugfix/box
+
+* Fixed memory leak on functional index drop (gh-10163).

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -214,6 +214,8 @@ struct memtx_tree_index {
 	size_t build_array_size, build_array_alloc_size;
 	struct memtx_gc_task gc_task;
 	memtx_tree_iterator_t<USE_HINT> gc_iterator;
+	/** Whether index is functional. */
+	bool is_func;
 };
 
 /* {{{ Utilities. *************************************************/
@@ -910,12 +912,16 @@ memtx_tree_index_gc_run(struct memtx_gc_task *task, bool *done)
 	memtx_tree_t<USE_HINT> *tree = &index->tree;
 	memtx_tree_iterator_t<USE_HINT> *itr = &index->gc_iterator;
 
+	const bool is_func = index->is_func;
 	unsigned int loops = 0;
 	while (!memtx_tree_iterator_is_invalid(itr)) {
 		struct memtx_tree_data<USE_HINT> *res =
 			memtx_tree_iterator_get_elem(tree, itr);
 		memtx_tree_iterator_next(tree, itr);
-		tuple_unref(res->tuple);
+		if (is_func)
+			tuple_unref((struct tuple *)res->hint);
+		else
+			tuple_unref(res->tuple);
 		if (++loops >= YIELD_LOOPS) {
 			*done = false;
 			return;
@@ -951,11 +957,15 @@ memtx_tree_index_destroy(struct index *base)
 	struct memtx_tree_index<USE_HINT> *index =
 		(struct memtx_tree_index<USE_HINT> *)base;
 	struct memtx_engine *memtx = (struct memtx_engine *)base->engine;
-	if (base->def->iid == 0) {
+	if (base->def->iid == 0 || index->is_func) {
 		/*
 		 * Primary index. We need to free all tuples stored
 		 * in the index, which may take a while. Schedule a
 		 * background task in order not to block tx thread.
+		 *
+		 * Functional index. For every tuple we need to
+		 * free all functional keys associated with this tuple.
+		 * Let's do it in background also.
 		 */
 		index->gc_task.vtab = get_memtx_tree_index_gc_vtab<USE_HINT>();
 		index->gc_iterator = memtx_tree_first(&index->tree);
@@ -2280,6 +2290,7 @@ memtx_tree_index_new_tpl(struct memtx_engine *memtx, struct index_def *def,
 	memtx_tree_create(&index->tree, cmp_def, memtx_index_extent_alloc,
 			  memtx_index_extent_free, memtx,
 			  &memtx->index_extent_stats);
+	index->is_func = def->key_def->func_index_func != NULL;
 	return &index->base;
 }
 
@@ -2292,11 +2303,11 @@ memtx_tree_index_new(struct memtx_engine *memtx, struct index_def *def)
 		if (def->key_def->func_index_func != NULL) {
 			vtab = get_memtx_tree_index_vtab
 				<MEMTX_TREE_VTAB_FUNC>();
-			use_hint = true;
 		} else {
 			vtab = get_memtx_tree_index_vtab
 				<MEMTX_TREE_VTAB_DISABLED>();
 		}
+		use_hint = true;
 	} else if (def->key_def->is_multikey) {
 		vtab = get_memtx_tree_index_vtab<MEMTX_TREE_VTAB_MULTIKEY>();
 		use_hint = true;

--- a/test/box-luatest/gh_10163_fix_functional_index_drop_memleak_test.lua
+++ b/test/box-luatest/gh_10163_fix_functional_index_drop_memleak_test.lua
@@ -1,0 +1,53 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new({box_cfg = {
+        memtx_memory = 128 * 1024 * 1024
+    }})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    if cg.server ~= nil then
+        cg.server:drop()
+    end
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+-- Test memory allocated for functional index key is freed.
+-- Otherwise we should fail to insert tuple.
+g.test_functional_index_drop_memory = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+
+        local func_code = [[
+        function(tuple)
+            return {string.rep('a', 512 * 1024)}
+        end]]
+        box.schema.func.create('func', {
+            body = func_code, is_deterministic = true, is_sandboxed = true})
+
+        for c = 1,10 do -- luacheck: no unused
+            local test = box.schema.space.create('test')
+            test:create_index('pk')
+            test:create_index('fk', {
+                unique = false, func = 'func', parts = {{1, 'string'}}})
+            for i = 1,64 do
+                test:replace({i})
+            end
+            test:drop()
+            fiber.yield()
+            collectgarbage()
+        end
+    end)
+end


### PR DESCRIPTION
We just don't free functional index keys on functional index drop now. Let's approach keys deletion as in the case of primary index drop ie let's drop these keys in background.

Closes #10163
