### PR TITLE
test: bump test-run to new version

### DIFF
--- a/test/box-luatest/gh_7904_export_box_schema_version_to_public_api_test.lua
+++ b/test/box-luatest/gh_7904_export_box_schema_version_to_public_api_test.lua
@@ -23,7 +23,9 @@ g.test_box_internal_schema_version_deprecation = function(cg)
     local deprecation_warning =
         'box.internal.schema_version will be removed, please use box.info.schema_version instead'
     t.assert_is_not(cg.server:grep_log(deprecation_warning, 256), nil)
-    local log_file = g.server:exec(function() return box.cfg.log end)
+    local log_file = g.server:exec(function()
+        return rawget(_G, 'box_cfg_log_file') or box.cfg.log
+    end)
     fio.truncate(log_file)
     cg.server:exec(function()
         box.internal.schema_version()

--- a/test/box-luatest/gh_9309_errors_in_triggers_test.lua
+++ b/test/box-luatest/gh_9309_errors_in_triggers_test.lua
@@ -95,7 +95,9 @@ g.test_ctl_triggers_error = function()
         box.ctl.on_shutdown(function() error("on_shutdown error") end, nil)
     end)
 
-    local server_log_path = g.server:exec(function() return box.cfg.log end)
+    local server_log_path = g.server:exec(function()
+        return rawget(_G, 'box_cfg_log_file') or box.cfg.log
+    end)
     g.server:drop()
     t.assert(g.server:grep_log("on_shutdown error", nil,
         {filename = server_log_path}))

--- a/test/box-luatest/gh_9797_netbox_on_disconnect_error_hangs_server_test.lua
+++ b/test/box-luatest/gh_9797_netbox_on_disconnect_error_hangs_server_test.lua
@@ -24,7 +24,7 @@ g.test_on_disconnect_error_hangs_server = function(cg)
     local log_file = cg.server:exec(function()
         box.ctl.set_on_shutdown_timeout(1)
         -- `grep_log` will not be able to retrieve it after we drop the server.
-        return box.cfg.log
+        return rawget(_G, 'box_cfg_log_file') or box.cfg.log
     end)
     cg.server:drop()
     t.assert_not(cg.server:grep_log('on_shutdown triggers failed', 1024,


### PR DESCRIPTION
Bump test-run to new version with the following improvements:

- luatest: fix ability to run a test several times [1]
- Enable luatest logging [2]
- tap13: fix parsing non-utf8 chars [3]

[1] tarantool/test-run@240cdea
[2] tarantool/test-run@b8b60b4
[3] tarantool/test-run@7290540

NO_DOC=test
NO_TEST=test
NO_CHANGELOG=test