### PR TITLE
config: expose experimental.config.utils.schema

### DIFF
--- a/changelogs/unreleased/config-expose-config-utils-schema.md
+++ b/changelogs/unreleased/config-expose-config-utils-schema.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* Expose the `experimental.config.utils.schema` built-in module to the public
+  API (gh-10117).

--- a/src/box/lua/config/cluster_config.lua
+++ b/src/box/lua/config/cluster_config.lua
@@ -1,4 +1,4 @@
-local schema = require('internal.config.utils.schema')
+local schema = require('experimental.config.utils.schema')
 local instance_config = require('internal.config.instance_config')
 local expression = require('internal.config.utils.expression')
 

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1,4 +1,4 @@
-local schema = require('internal.config.utils.schema')
+local schema = require('experimental.config.utils.schema')
 local tarantool = require('tarantool')
 local compat = require('compat')
 local uuid = require('uuid')

--- a/src/box/lua/config/source/env.lua
+++ b/src/box/lua/config/source/env.lua
@@ -1,6 +1,6 @@
 local uri = require('uri')
 local fun = require('fun')
-local schema = require('internal.config.utils.schema')
+local schema = require('experimental.config.utils.schema')
 local tabulate = require('internal.config.utils.tabulate')
 local instance_config = require('internal.config.instance_config')
 

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -362,7 +362,7 @@ static const char *lua_sources[] = {
 	config_utils_aboard_lua,
 
 	"config/utils/schema",
-	"internal.config.utils.schema",
+	"experimental.config.utils.schema",
 	config_utils_schema_lua,
 
 	"config/utils/tabulate",

--- a/test/config-luatest/schema_test.lua
+++ b/test/config-luatest/schema_test.lua
@@ -1,6 +1,6 @@
 local ffi = require('ffi')
 local fun = require('fun')
-local schema = require('internal.config.utils.schema')
+local schema = require('experimental.config.utils.schema')
 local t = require('luatest')
 
 local g = t.group()


### PR DESCRIPTION
The module is renamed from `internal.config.utils.schema` to `experimental.config.utils.schema` without changes.

It is useful for validation of configuration data in roles and applications.

Also, it provides a couple of methods that aim to simplify usual tasks around processing of hierarchical configuration data. For example,

* get/set a nested value
* apply defaults from the schema
* filter data based on annotations from the schema
* transform a hierarchical data using a function
* merge two hierarchical values
* parse environment variable according to its type in the schema

See https://github.com/tarantool/doc/issues/4279 for an in-depth description.

Fixes #10117