### PR TITLE
config: Enhance TTY Output with Color-Coded Logs

### DIFF
--- a/changelogs/unreleased/gh-10250-color-logs-to-tty.md
+++ b/changelogs/unreleased/gh-10250-color-logs-to-tty.md
@@ -1,0 +1,4 @@
+## feature/log
+
+* Enhanced TTY output with color-coded logs. Set the `NO_COLOR`
+  option to `1` to disable color output (gh-10250).

--- a/src/lib/core/say.h
+++ b/src/lib/core/say.h
@@ -163,6 +163,18 @@ typedef int (*log_format_func_t)(struct log *log, char *buf, int len, int level,
 struct log {
 	/** The current file descriptor. */
 	int fd;
+	/**
+	 * Indicates whether the current file is a terminal (tty).
+	 * This field is non-zero if the file descriptor refers to a terminal.
+	 */
+	int isatty;
+	/** This field is non-zero if STDERR_FILENO is a terminal (tty)*/
+	int isatty_stdin;
+	/**
+	 * Enable color output to tty.
+	 * To disable ANSI color support set the `NO_COLOR=1`.
+	 */
+	int color;
 	/** The current log level. */
 	int level;
 	enum say_logger_type type;


### PR DESCRIPTION
Enhance TTY Output with Color-Coded Logs

This update introduces color-coded logging to the TTY, enhancing the visual perception of different error levels. The color scheme is as follows:

- Errors: Red
- Warnings: Yellow
- Info and Others: White

These visual cues help quickly identify the severity of messages.

Color output can be disabled by setting `NO_COLOR=1`.

Note:
    If you run tarantool in interactive mode, the welcome message
    will be colored red because the message level is "CRITICAL".

Closes #10250