### PR TITLE
fiber: phohibit fiber self join

### DIFF
--- a/changelogs/unreleased/gh-10196-fix-fiber-self-join-hang.md
+++ b/changelogs/unreleased/gh-10196-fix-fiber-self-join-hang.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fixed hang on fiber self join (gh-10196).

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -778,6 +778,9 @@ fiber_join_timeout(struct fiber *fiber, double timeout)
 	if ((fiber->flags & FIBER_JOIN_BEEN_INVOKED) != 0)
 		panic("join of a joined fiber detected");
 
+	if (fiber() == fiber)
+		panic("cannot join itself");
+
 	/* Prohibit joining the fiber and changing its joinability. */
 	fiber->flags |= FIBER_JOIN_BEEN_INVOKED;
 

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -370,6 +370,7 @@ fiber_set_joinable(struct fiber *fiber, bool yesno);
  *
  * @pre FIBER_IS_JOINABLE flag is set (panic if not).
  * @pre the fiber is not joined yet (panic if not).
+ * @pre the fiber is different from current (panic if not).
  *
  * \param f fiber to be woken up
  * \return fiber function ret code

--- a/src/lua/fiber.c
+++ b/src/lua/fiber.c
@@ -830,6 +830,10 @@ lbox_fiber_join(struct lua_State *L)
 		diag_set(IllegalParams, "the fiber is not joinable");
 		luaT_error(L);
 	}
+	if (fid == fiber()->fid) {
+		diag_set(IllegalParams, "cannot join itself");
+		luaT_error(L);
+	}
 	double timeout = TIMEOUT_INFINITY;
 	if (!lua_isnoneornil(L, 2)) {
 		if (!lua_isnumber(L, 2) ||

--- a/test/app-luatest/fiber_test.lua
+++ b/test/app-luatest/fiber_test.lua
@@ -81,3 +81,18 @@ g.test_gh_10187_no_memory_leak_on_dead_fiber_search = function()
     collectgarbage()
     t.assert_equals(weak_table.fiber, nil)
 end
+
+g.test_gh_10196_no_hang_on_self_join = function()
+    local f = fiber.new(function()
+        fiber.self():join()
+    end)
+    f:set_joinable(true)
+    f:wakeup()
+    fiber.yield()
+    local ok, res = f:join()
+    t.assert_not(ok)
+    t.assert_covers(res:unpack(), {
+        type = 'IllegalParams',
+        message = 'cannot join itself',
+    })
+end


### PR DESCRIPTION
In this case join will just hang. Instead let's raise an error in case of Lua API and panic in case of C API.

Closes #10196