### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-9924-luajit-fixes.md
+++ b/changelogs/unreleased/gh-9924-luajit-fixes.md
@@ -1,0 +1,17 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-9924). The following issues
+were fixed as part of this activity:
+
+* Fixed `BC_VARG` recording.
+* Fixed `ffi.alignof()` for reference types.
+* Fixed `sizeof()` expression in C parser for reference types.
+* Fixed `ffi.metatype()` for typedefs with attributes.
+* Fixed `ffi.metatype()` for non-raw types.
+* Fixed IR chain invariant in DCE.
+* Fixed OOM errors handling during trace stitching.
+* Fixed `IR_HREF` vs. `IR_HREFK` aliasing in non-`nil` store check.
+* Fixed generation of Mach-O object files.
+* Fixed undefined behavior when negating `INT_MIN` integers.
+* Replaced the numeric values of NYI bytecodes that can't be compiled, with
+  their names in the `jit.dump()`.


### PR DESCRIPTION
* Correct fix for stack check when recording BC_VARG.
* test: remove inline suppressions of _TARANTOOL
* FFI: Fix ffi.alignof() for reference types.
* FFI: Fix sizeof expression in C parser for reference types.
* FFI: Allow ffi.metatype() for typedefs with attributes.
* FFI: Fix ffi.metatype() for non-raw types.
* Maintain chain invariant in DCE.
* build: introduce option LUAJIT_ENABLE_TABLE_BUMP
* ci: add tablebump flavor for exotic builds
* test: allow `jit.parse` to return aborted traces
* Handle all types of errors during trace stitching.
* Use generic trace error for OOM during trace stitching.
* Check for IR_HREF vs. IR_HREFK aliasing in non-nil store check.
* cmake: set cmake_minimum_required only once
* cmake: fix warning about minimum required version
* ci: add a workflow for testing with AVX512 enabled
* test: introduce a helper read_file
* OSX/iOS/ARM64: Fix generation of Mach-O object files.
* OSX/iOS/ARM64: Fix bytecode embedding in Mach-O object file.
* build: introduce LUAJIT_USE_UBSAN option
* ci: enable UBSan for sanitizers testing workflow
* cmake: add the build directory to the .gitignore
* Prevent sanitizer warning in snap_restoredata().
* Avoid negation of signed integers in C that may hold INT*_MIN.
* Show name of NYI bytecode in -jv and -jdump.

Closes #9924
Closes #8473

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump