### PR TITLE
config/schema: support field deletion using :set()

### DIFF
--- a/changelogs/unreleased/config-schema-set-to-null-or-nil.md
+++ b/changelogs/unreleased/config-schema-set-to-null-or-nil.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* Allow to delete a field or set it to `box.NULL` using the `<schema
+  object>:set()` method (gh-10190, gh-10193, gh-10194).

--- a/test/config-luatest/cbuilder.lua
+++ b/test/config-luatest/cbuilder.lua
@@ -125,24 +125,6 @@ local function cbuilder_set_replicaset_option(self, path, value)
         'replicasets', self._replicaset,
     }, path:split('.')):totable()
 
-    -- <schema object>:set() validation is too tight. Workaround
-    -- it. Maybe we should reconsider this :set() behavior in a
-    -- future.
-    if value == nil then
-        local cur = self._config
-        for i = 1, #path - 1 do
-            -- Create missed fields.
-            local component = path[i]
-            if cur[component] == nil then
-                cur[component] = {}
-            end
-
-            cur = cur[component]
-        end
-        cur[path[#path]] = value
-        return self
-    end
-
     cluster_config:set(self._config, path, value)
     return self
 end


### PR DESCRIPTION
This commit implements the `<schema object>:set()` algorithm in a more accurate way and it solves several drawbacks of the previous implementation.

* It was impossible to set a field that is nested to a record or a map that has the box.NULL value (#10190).
* It was impossible to set a field to the box.NULL value (#10193).
* It was impossible to delete a field, now `nil` RHS value means the deletion (#10194).

See `<schema object>:set()` section in https://github.com/tarantool/doc/issues/4279 for the documentation.

Fixes #10190
Fixes #10193
Fixes #10194