### PR TITLE
misc: fix compilation errors under clang 18

### DIFF
--- a/src/trivia/util.h
+++ b/src/trivia/util.h
@@ -40,6 +40,7 @@
 #include <inttypes.h>
 #include <assert.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 #if defined(__cplusplus)
 extern "C" {

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -142,6 +142,12 @@ create_unit_test(PREFIX bps_tree
                  LIBRARIES unit small misc
                  COMPILE_DEFINITIONS TEST_DEFAULT
 )
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set_source_files_properties(
+        bps_tree.cc
+        PROPERTIES COMPILE_FLAGS
+            "-Wno-vla-cxx-extension -Wno-unknown-warning-option")
+endif()
 create_unit_test(PREFIX bps_tree_inner_card
                  SOURCES bps_tree.cc
                  LIBRARIES unit small misc


### PR DESCRIPTION
This PR aims to fix a couple of clang's new pedantic warnings which break the project build.