### PR TITLE
fiber: fix crashes by aligning fiber stack on a 16-byte boundary

### DIFF
--- a/test/unit/guard.cc
+++ b/test/unit/guard.cc
@@ -34,7 +34,7 @@ stack_break_f(char *frame_zero)
 	sum += block[(unsigned char) block[4]];
 
 	ptrdiff_t stack_diff = frame_curr - frame_zero;
-	if ((size_t)abs(stack_diff) < default_attr.stack_size)
+	if ((size_t)abs(stack_diff) < fiber_self()->stack_size)
 		sum += stack_break_f(frame_zero);
 	return sum;
 }


### PR DESCRIPTION
    Modern 64-bit architectures such as x86_64 and aarch64 require[1] that
    the stack be properly aligned on a 16-byte boundary; this ABI property
    lets any function use sse2/neon/simd instructions without having to take
    extra steps to align the stack.
    
    Obviously, tarantool seems to work fine by default. However, I was able
    to make it crash just by building it with ASAN enabled using clang 18.
    This has to do with the change to `sizeof(struct slab)` that happens
    in this build mode.
    
    Thus, the patch aims to add extra alignment steps, even for architectures
    which don't have such a requirement. This way we'll make it easier to
    test and maintain, not to mention that 32-bit machines are unlikely
    to be of interest for any production workload.
    
    [1]: This may depend on certain arch/os settings, but it's definitely
    reasonable to take extra precautions in case the alignment mode is active.

---

CMake options:

```
$ CC=clang CXX=clang++ cmake .. \
  -DENABLE_BUNDLED_{OPENSSL,LIBCURL,LIBUNWIND}=OFF \
  -DENABLE_{ASAN,UB_SANITIZER}=ON
...
-- [SetFiberStackSize] Default fiber stack size:  524288 (adjusted to 528384 bytes)
...
```

Crash info:

```
Segmentation fault
  code: 128
  addr: (nil)
  context: 0x7cad3c05cac0
  siginfo: 0x7cad3c05cbf0
  rax      0x0                0
  rbx      0x0                0
  rcx      0x7cad38f1dd1c     137083426561308
  rdx      0x0                0
  rsi      0x5401             21505
  rdi      0x0                0
  rsp      0x7cad375fdc28     137083400215592
  rbp      0x7cad375fdc58     137083400215640
  r8       0x7cad375fdc68     137083400215656
  r9       0x8835cac8         2285226696
  r10      0x40de496f         1088309615
  r11      0x206              518
  r12      0x0                0
  r13      0x0                0
  r14      0x0                0
  r15      0x0                0
  rip      0x7cad38f1dd2a     137083426561322
  eflags   0x10246            66118
  cs       0x33               51
  gs       0x0                0
  fs       0x0                0
  cr2      0x0                0
  err      0x0                0
  oldmask  0x0                0
  trapno   0xd                13
Current time: 1720474757
Please file a bug at https://github.com/tarantool/tarantool/issues
Attempting backtrace... Note: since the server has already crashed, 
this may fail as well
#1  0x5912ef99f661 in crash_collect+1945
#2  0x5912ef99ed5f in crash_signal_cb+279
#3  0x7cad38e50ae0 in ??+0
#4  0x7cad38f1dd2a in tcgetattr+58
#5  0x7cad38f1bca2 in isatty+34
#6  0x5912ef8fe314 in run_script_f+7404
#7  0x5912eed765ad in fiber_cxx_invoke(int (*)(__va_list_tag*), __va_list_tag*)+85
#8  0x5912ef9c6e11 in fiber_loop+1113
#9  0x5912f04dfa4a in coro_init+298
Aborted (core dumped)
```

GDB debug session with proofs:

<details>
  <summary>Expand</summary>

```gdb
Reading symbols from src/tarantool...
(gdb) b fiber_stack_create 
Breakpoint 1 at 0x177be5f: file tarantool/src/lib/core/fiber.c, line 1475.
Breakpoint 1, fiber_stack_create (fiber=0x515000032318, fiber_attr=0x555557b917a0 <fiber_attr_default>, slabc=0x555558e04f00 <main_cord+320>) at tarantool/src/lib/core/fiber.c:1475
1475		size_t stack_size = fiber_attr->stack_size - slab_sizeof();
(gdb) n
1476		fiber->stack_slab = slab_get(slabc, stack_size);
(gdb) 
1478		if (fiber->stack_slab == NULL) {
(gdb) 
1485		if (stack_direction < 0) {
(gdb) 
1492			guard = page_align_up(slab_data(fiber->stack_slab));
(gdb) 
1493			fiber->stack = guard + page_size;
(gdb) 
1494			fiber->stack_size = slab_data(fiber->stack_slab) + stack_size -
(gdb) 
1495					    fiber->stack;
(gdb) 
1494			fiber->stack_size = slab_data(fiber->stack_slab) + stack_size -
(gdb) 
1496		} else {
(gdb) p/x fiber->stack_size
$3 = 0x7f828
(gdb) p/x fiber->stack
$4 = 0x7ffff417f000
(gdb) b coro_create
Breakpoint 2 at 0x5555577e955a: file tarantool/third_party/coro/coro.c, line 387.
(gdb) c
Continuing.

Breakpoint 2, coro_create (ctx=0x515000032318, coro=0x555556cd09b8 <fiber_loop>, arg=0x0, sptr=0x7ffff417f000, ssize=522280) at tarantool/third_party/coro/coro.c:387
387	  coro_context nctx;
(gdb) n
395	  if (!coro)
(gdb) 
399	  coro_init_func = coro;
(gdb) 
400	  coro_init_arg  = arg;
(gdb) 
402	  new_coro    = ctx;
(gdb) 
403	  create_coro = &nctx;
(gdb) 
508	  ctx->sp = (void **)(ssize + (char *)sptr);
(gdb) 
510	  *--ctx->sp = (void *)0;
(gdb) 
511	  *--ctx->sp = (void *)coro_init;
(gdb) 
524	  ctx->sp -= NUM_SAVED;
(gdb) 
525	  memset (ctx->sp, 0, sizeof (*ctx->sp) * NUM_SAVED);
(gdb) 
555	  coro_transfer (create_coro, new_coro);
(gdb) p ctx->sp
$5 = (void **) 0x7ffff41fe7e8
(gdb) c
Continuing.

...
...
...

Program received signal SIGSEGV, Segmentation fault.
0x00007ffff4f1dd2a in tcgetattr () from /usr/lib/libc.so.6
(gdb) display/i $pc
1: x/i $pc
=> 0x7ffff4f1dd2a <tcgetattr+58>:	movdqa xmm0,XMMWORD PTR [rbp-0x30]
(gdb) p $rbp - 0x30
$1 = (void *) 0x7ffff33fdc28
```

This trapped `movdqa` is a dead giveaway that the fiber's stack is misaligned.

</details>