### PR TITLE
lua-yaml: wrap large doubles in quotes

### DIFF
--- a/changelogs/unreleased/gh-10164-yaml-encoding-large-exps.md
+++ b/changelogs/unreleased/gh-10164-yaml-encoding-large-exps.md
@@ -1,0 +1,4 @@
+## bugfix/lua/yaml
+
+* Strings with large exponential values equal to infinity are now encoded as
+  strings instead of numbers (gh-10164).

--- a/test/app-tap/lua/serializer_test.lua
+++ b/test/app-tap/lua/serializer_test.lua
@@ -236,7 +236,7 @@ local function test_boolean(test, s)
 end
 
 local function test_string(test, s)
-    test:plan(8)
+    test:plan(11)
     rt(test, s, "")
     rt(test, s, "abcde")
     rt(test, s, "Кудыкины горы") -- utf-8
@@ -245,6 +245,9 @@ local function test_string(test, s)
     rt(test, s, '$a\t $')
     rt(test, s, [[$a\t $]])
     rt(test, s, [[$a\\t $]])
+    rt(test, s, '9e123456789')
+    rt(test, s, 'infinity')
+    rt(test, s, 'NaN')
 end
 
 local function test_nil(test, s)


### PR DESCRIPTION
Since tarantool/luajit@a16313f large exponent double strings are not considered convertable to number. It broke encoding lua objects to YAML because single quotes weren't considered neccessary for decoding.

This fix adds wrapping of every string containing double values equal to infinity into a single quotes.

Closes #10164