### PR TITLE
ci: disable UBsan in a fuzzing workflow

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sanitizer: [address, undefined]
+        sanitizer: [address]
 
     steps:
       - name: build fuzzers (${{ matrix.sanitizer }})


### PR DESCRIPTION
Docker image has been updated on OSS Fuzz in scope of ticket [1]. UBSan in updated image revealed a member access within null pointer of type `'typeof (*trigger)' (aka 'struct trigger')`, see [2]. The patch disables temporarily UBsan in a fuzzing workflow until the fix of aforemenetioned problem.

1. https://github.com/google/oss-fuzz/pull/12085
2. https://github.com/tarantool/tarantool/issues/10143

Related to #10143

NO_CHANGELOG=ci
NO_DOC=ci
NO_TEST=ci


// CC: @LevKats 