### PR TITLE
config: add `lua.memory` option

### DIFF
--- a/changelogs/unreleased/gh-9849-lua-memory-limit-config.md
+++ b/changelogs/unreleased/gh-9849-lua-memory-limit-config.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* Added the `lua.memory` parameter to set up the maximum available RAM for
+  Lua scripts (gh-9849).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -187,6 +187,7 @@ set (server_sources
      ssl_cert_paths_discover.c
      systemd.c
      version.c
+     lua/alloc.c
      lua/digest.c
      lua/init.c
      lua/fiber.c

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -51,6 +51,7 @@ lua_source(lua_sources lua/config/applier/compat.lua       config_applier_compat
 lua_source(lua_sources lua/config/applier/console.lua      config_applier_console_lua)
 lua_source(lua_sources lua/config/applier/credentials.lua  config_applier_credentials_lua)
 lua_source(lua_sources lua/config/applier/fiber.lua        config_applier_fiber_lua)
+lua_source(lua_sources lua/config/applier/lua.lua          config_applier_lua_lua)
 lua_source(lua_sources lua/config/applier/mkdir.lua        config_applier_mkdir_lua)
 lua_source(lua_sources lua/config/applier/roles.lua        config_applier_roles_lua)
 lua_source(lua_sources lua/config/applier/sharding.lua     config_applier_sharding_lua)

--- a/src/box/lua/config/applier/lua.lua
+++ b/src/box/lua/config/applier/lua.lua
@@ -1,0 +1,51 @@
+local alloc = require('internal.alloc')
+local log = require('internal.config.utils.log')
+
+-- After limiting the memory to some value we want to be sure
+-- there is unused memory not to fail right after setting the
+-- new limit.
+--
+-- This value represents the required amount of unused memory
+-- after applying the lua.memory parameter.
+--
+-- The value is equal to 16MB. It has been chosen arbitrarily
+-- as 1/16 of the minimum Lua memory limit.
+local REQUIRED_UNUSED_MEMORY_AFTER_APPLICATION = 16 * 1024 * 1024
+
+local function apply(config)
+    local configdata = config._configdata
+    local memory_limit = configdata:get('lua.memory', {use_default = true})
+    local old_memory_limit = alloc.getlimit()
+    local used_memory = alloc.used()
+
+    -- Nothing to do if the limit is unchanged.
+    if memory_limit == old_memory_limit then
+        return
+    end
+
+    -- Check there is enough unused space after applying
+    -- the new Lua memory limit.
+    --
+    -- Otherwise, the alert is set.
+    if memory_limit <
+       used_memory + REQUIRED_UNUSED_MEMORY_AFTER_APPLICATION then
+        local name = 'lua_memory_limit_too_small'
+        local warning = 'lua.apply: lua.memory will be applied ' ..
+                        'after restarting the instance since the ' ..
+                        'new limit is too close to the currently ' ..
+                        'allocated amount of memory'
+        config._aboard:set({type = 'warn', message = warning}, {key = name})
+        return
+    end
+
+    -- The call throws an error if the user tries to limit the
+    -- memory with values < 256MB.
+    alloc.setlimit(memory_limit)
+
+    log.verbose(('lua.apply: set memory limit to %d'):format(memory_limit))
+end
+
+return {
+    name = 'lua',
+    apply = apply,
+}

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -143,6 +143,7 @@ function methods._initialize(self)
         self:_register_source(require('internal.config.source.file').new())
     end
 
+    self:_register_applier(require('internal.config.applier.lua'))
     self:_register_applier(require('internal.config.applier.compat'))
     self:_register_applier(require('internal.config.applier.mkdir'))
     self:_register_applier(require('internal.config.applier.console'))
@@ -315,10 +316,11 @@ function methods._store(self, iconfig, cconfig, source_info)
     self._configdata = configdata.new(iconfig, cconfig, self._instance_name)
 end
 
--- Invoke compat, mkdir, console and box_cfg appliers at the first
--- phase. Invoke all the other ones at the second phase.
+-- Invoke lua, compat, mkdir, console and box_cfg appliers at the
+-- first phase. Invoke all the other ones at the second phase.
 function methods._apply_on_startup(self, opts)
     local first_phase_appliers = {
+        lua = true,
         compat = true,
         mkdir = true,
         console = true,

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -742,6 +742,21 @@ return schema.new('instance_config', schema.record({
             default = 'var/run/{{ instance_name }}/tarantool.pid',
         }),
     }),
+    lua = schema.record({
+        -- Maximum allowed memory allocated by Lua.
+        -- The value can't be less than 256MB and can't be
+        -- changed without restarting the Tarantool instance.
+        memory = schema.scalar({
+            type = 'integer',
+            -- Default value: 2GB.
+            default = 2 * 1024 * 1024 * 1024,
+            validate = function(data, w)
+                if data < 256 * 1024 * 1024 then
+                    w.error('Memory limit should be >= 256MB')
+                end
+            end,
+        }),
+    }),
     console = schema.record({
         enabled = schema.scalar({
             type = 'boolean',

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -156,6 +156,7 @@ extern char session_lua[],
 	config_applier_console_lua[],
 	config_applier_credentials_lua[],
 	config_applier_fiber_lua[],
+	config_applier_lua_lua[],
 	config_applier_mkdir_lua[],
 	config_applier_roles_lua[],
 	config_applier_sharding_lua[],
@@ -438,6 +439,10 @@ static const char *lua_sources[] = {
 	"config/applier/fiber",
 	"internal.config.applier.fiber",
 	config_applier_fiber_lua,
+
+	"config/applier/lua",
+	"internal.config.applier.lua",
+	config_applier_lua_lua,
 
 	"config/applier/mkdir",
 	"internal.config.applier.mkdir",

--- a/src/lua/alloc.c
+++ b/src/lua/alloc.c
@@ -1,0 +1,153 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2024, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include "lua/utils.h"
+
+#include <lauxlib.h> /* luaL_error */
+
+#define LUA_MEMORY_LIMIT_DEFAULT (2ULL * 1024 * 1024 * 1024)
+
+/**
+ * Default allocator function which is wrapped into a new one
+ * with the Lua memory limit checker.
+ */
+static lua_Alloc orig_alloc;
+/**
+ * Memory limit for LuaJIT.
+ */
+static size_t memory_limit = LUA_MEMORY_LIMIT_DEFAULT;
+/**
+ * Amount of memory used by LuaJIT.
+ */
+static size_t used;
+
+/**
+ * Lua custom memory allocation function. It extends the original
+ * one with a memory counter and a limit check.
+ */
+static void *
+alloc_with_limit(void *ud, void *ptr, size_t osize, size_t nsize)
+{
+	size_t new_used = used + nsize - osize;
+	if (new_used > memory_limit) {
+		/*
+		 * Returning NULL results in the "not enough
+		 * memory" error.
+		 */
+		return NULL;
+	}
+
+	void *result = orig_alloc(ud, ptr, osize, nsize);
+
+	if (result != NULL || nsize == 0)
+		used = new_used;
+
+	/*
+	 * Result may be NULL, in this case "not enough memory"
+	 * is raised.
+	 */
+	return result;
+}
+
+static int
+set_alloc_limit(size_t new_memory_limit)
+{
+	if (new_memory_limit < used) {
+		diag_set(LuajitError, "Cannot limit the Lua memory with values "
+			 "less than the currently allocated amount");
+		return -1;
+	}
+	memory_limit = new_memory_limit;
+	return 0;
+}
+
+void
+luaT_initalloc(struct lua_State *L)
+{
+	assert(L != NULL);
+
+	used = luaL_getgctotal(L);
+
+	void *orig_ud;
+	orig_alloc = lua_getallocf(L, &orig_ud);
+
+	assert(orig_alloc != NULL);
+
+	lua_setallocf(L, alloc_with_limit, orig_ud);
+}
+
+/**
+ * alloc.getlimit() -- get the allocator memory limit.
+ */
+static int
+lbox_alloc_getlimit(struct lua_State *L)
+{
+	lua_pushinteger(L, memory_limit);
+	return 1;
+}
+
+/**
+ * alloc.setlimit() -- set the allocator memory limit.
+ * Returns old memory limit.
+ */
+static int
+lbox_alloc_setlimit(struct lua_State *L)
+{
+	if (lua_gettop(L) < 1) {
+		diag_set(IllegalParams, "Usage: alloc.setlimit(amount)");
+		return luaT_error(L);
+	}
+
+	ssize_t amount = luaL_checkinteger(L, 1);
+
+	if (amount < 0) {
+		diag_set(IllegalParams, "Invalid memory limit: "
+			 "the value must be >= 0");
+		return luaT_error(L);
+	}
+
+	size_t old_memory_limit = memory_limit;
+
+	if (set_alloc_limit(amount) < 0)
+		return luaT_error(L);
+
+	lua_pushinteger(L, old_memory_limit);
+	return 1;
+}
+
+/**
+ * alloc.used() -- get the amount of the allocated memory.
+ */
+static int
+lbox_alloc_used(struct lua_State *L)
+{
+	lua_pushinteger(L, used);
+	return 1;
+}
+
+/**
+ * alloc.unused() -- get the amount of the unused memory.
+ */
+static int
+lbox_alloc_unused(struct lua_State *L)
+{
+	lua_pushinteger(L, memory_limit - used);
+	return 1;
+}
+
+void
+tarantool_lua_alloc_init(struct lua_State *L)
+{
+	static const struct luaL_Reg alloc_methods[] = {
+		{"setlimit", lbox_alloc_setlimit},
+		{"getlimit", lbox_alloc_getlimit},
+		{"used",     lbox_alloc_used},
+		{"unused",   lbox_alloc_unused},
+		{NULL, NULL}
+	};
+
+	luaT_newmodule(L, "internal.alloc", alloc_methods);
+	lua_pop(L, 1);
+}

--- a/src/lua/alloc.h
+++ b/src/lua/alloc.h
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2024, Tarantool AUTHORS, please see AUTHORS file.
+ */
+
+#pragma once
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+#include <stddef.h>
+
+#include <lua.h>
+
+/**
+ * Initializes custom allocator for the LuaJIT VM.
+ * The allocator supports memory limitation.
+ */
+void
+luaT_initalloc(struct lua_State *L);
+
+void
+tarantool_lua_alloc_init(struct lua_State *L);
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -49,6 +49,7 @@
 #include "coio.h"
 #include "core/backtrace.h"
 #include "core/tt_static.h"
+#include "lua/alloc.h"
 #include "lua/backtrace.h"
 #include "lua/fiber.h"
 #include "lua/fiber_cond.h"
@@ -733,10 +734,7 @@ void
 tarantool_lua_init(const char *tarantool_bin, const char *script, int argc,
 		   char **argv)
 {
-	lua_State *L = luaL_newstate();
-	if (L == NULL) {
-		panic("failed to initialize Lua");
-	}
+	lua_State *L = luaT_newstate();
 	luaL_openlibs(L);
 #ifndef LUAJIT_JIT_STATUS
 	(void)luaJIT_setmode(L, 0, LUAJIT_MODE_ENGINE | LUAJIT_MODE_OFF);
@@ -784,6 +782,7 @@ tarantool_lua_init(const char *tarantool_bin, const char *script, int argc,
 	lua_call(L, 0, 0);
 	lua_register(L, "tonumber64", lbox_tonumber64);
 
+	tarantool_lua_alloc_init(L);
 	tarantool_lua_tweaks_init(L);
 	tarantool_lua_uri_init(L);
 	tarantool_lua_utf8_init(L);

--- a/src/lua/utils.c
+++ b/src/lua/utils.c
@@ -42,6 +42,7 @@
 #include "core/say.h"
 #include "core/tt_uuid.h"
 #include "lj_trace.h"
+#include "lua/alloc.h"
 #include "lua/serializer.h"
 #include "trivia/util.h"
 #include "vclock/vclock.h"
@@ -58,6 +59,18 @@ uint32_t CTID_VARBINARY;
 uint32_t CTID_UUID;
 uint32_t CTID_DATETIME = 0;
 uint32_t CTID_INTERVAL = 0;
+
+struct lua_State *
+luaT_newstate(void)
+{
+	struct lua_State *L = luaL_newstate();
+	if (L == NULL)
+		panic("failed to initialize Lua");
+
+	luaT_initalloc(L);
+
+	return L;
+}
 
 /** A copy of index2adr() from luajit/src/lj_api.c. */
 static TValue *

--- a/src/lua/utils.h
+++ b/src/lua/utils.h
@@ -82,6 +82,14 @@ extern uint32_t CTID_DATETIME;
 extern uint32_t CTID_INTERVAL;
 
 /**
+ * Creates a new Lua state with a custom allocator function.
+ * Guarantees the state is not NULL. It panics if lua_State can't
+ * be allocated.
+ */
+struct lua_State *
+luaT_newstate(void);
+
+/**
  * Pushes a new varbinary object with the given content to the Lua stack.
  */
 void

--- a/test/app-luatest/alloc_test.lua
+++ b/test/app-luatest/alloc_test.lua
@@ -1,0 +1,55 @@
+local alloc = require('internal.alloc')
+
+local t = require('luatest')
+local g = t.group()
+
+g.test_invalid_arg = function()
+    local errmsg
+    local function test(...)
+        t.assert_error_msg_equals(errmsg, alloc.setlimit, ...)
+    end
+
+    errmsg = 'Usage: alloc.setlimit(amount)'
+    test()
+
+    errmsg = 'bad argument #1 to \'?\' (number expected, got ' ..
+             'string)'
+    test('foo')
+
+    errmsg = 'Invalid memory limit: the value must be >= 0'
+    test(-1024)
+
+    errmsg = 'Cannot limit the Lua memory with values less ' ..
+             'than the currently allocated amount'
+    test(16)
+end
+
+g.test_basic = function()
+    local function test(amount)
+        local old_memory_limit = alloc.getlimit()
+        t.assert_equals(alloc.setlimit(amount), old_memory_limit)
+        t.assert_equals(alloc.getlimit(), amount)
+    end
+
+    test(256 * 1024 * 1024)
+    test(1024 * 1024 * 1024)
+    test(2 * 1024 * 1024 * 1024)
+    test(4 * 1024 * 1024 * 1024)
+    test(8 * 1024 * 1024 * 1024)
+end
+
+g.test_used_and_unused = function()
+    local function test(amount)
+        alloc.setlimit(amount)
+        t.assert_equals(collectgarbage('count'), alloc.used() / 1024)
+        t.assert_equals(amount / 1024 - collectgarbage('count'),
+                        alloc.unused() / 1024)
+        t.assert_equals(alloc.used() + alloc.unused(), alloc.getlimit())
+    end
+
+    test(256 * 1024 * 1024)
+    test(1024 * 1024 * 1024)
+    test(2 * 1024 * 1024 * 1024)
+    test(4 * 1024 * 1024 * 1024)
+    test(8 * 1024 * 1024 * 1024)
+end

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -69,6 +69,7 @@ end
 local instance_config_fields = {
     'config',
     'process',
+    'lua',
     'console',
     'fiber',
     'log',
@@ -328,6 +329,7 @@ g.test_defaults = function()
             enabled = true,
             socket = 'var/run/{{ instance_name }}/tarantool.control',
         },
+        lua = {memory = 2147483648},
         memtx = {
             memory = 268435456,
             allocator = 'small',

--- a/test/config-luatest/lua_memory_test.lua
+++ b/test/config-luatest/lua_memory_test.lua
@@ -1,0 +1,204 @@
+local t = require('luatest')
+local cbuilder = require('luatest.cbuilder')
+local cluster = require('test.config-luatest.cluster')
+
+local g = t.group()
+
+g.before_all(cluster.init)
+g.after_each(cluster.drop)
+g.after_all(cluster.clean)
+
+g.test_basic = function(g)
+    -- Configuration limiting memory available to Lua with 256MB.
+    local lua_memory = 256 * 1024 * 1024
+    local config = cbuilder:new()
+        :set_global_option('lua.memory', lua_memory)
+        :add_instance('i-001', {})
+        :config()
+
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    -- Check lua.memory has been successfully applied.
+    cluster['i-001']:exec(function(lua_memory)
+        local alloc = require('internal.alloc')
+        local config = require('config')
+
+        t.assert_equals(config:get('lua.memory'), lua_memory)
+        t.assert_equals(alloc.getlimit(), lua_memory)
+    end, {lua_memory})
+
+    -- Check there is a "not enough memory" error when Lua
+    -- tries to allocate more than configured.
+    cluster['i-001']:exec(function()
+        local alloc = require('internal.alloc')
+        local digest = require('digest')
+
+        local function overflow()
+            -- Try to allocate all of the Lua available memory
+            -- plus 1MB.
+            local size = alloc.unused() + 1024 * 1024
+            local _ = digest.urandom(size)
+        end
+
+        t.assert_error_msg_equals('not enough memory', overflow, {})
+    end)
+
+    -- Check it's still possible to allocate almost all of the
+    -- memory up to the limit.
+    cluster['i-001']:exec(function()
+        local alloc = require('internal.alloc')
+        local digest = require('digest')
+
+        -- Try to allocate all of the Lua available memory
+        -- minus 1MB.
+        local size = alloc.unused() - 1 * 1024 * 1024
+        local _ = digest.urandom(size)
+
+        -- Check there is <= 2MB left. 2MB is used instead
+        -- of 1MB to ensure the implementation details of Lua
+        -- memory management won't affect the comparison.
+        t.assert_le(alloc.unused(), 2 * 1024 * 1024)
+    end)
+end
+
+g.test_update = function(g)
+    -- Config with 512MB memory limit.
+    local lua_memory_0 = 512 * 1024 * 1024
+    local config_0 = cbuilder:new()
+        :set_global_option('lua.memory', lua_memory_0)
+        :add_instance('i-001', {})
+        :config()
+
+    local cluster = cluster.new(g, config_0)
+    cluster:start()
+
+    -- Config with 256MB memory limit.
+    local lua_memory_1 = 256 * 1024 * 1024
+    local config_1 = cbuilder:new(config_0)
+        :set_global_option('lua.memory', lua_memory_1)
+        :add_instance('i-001', {})
+        :config()
+
+    -- Load a config with a new lua.memory value.
+    cluster:reload(config_1)
+
+    -- lua.memory could be decreased dynamically if
+    -- the limit is not too close to the currently used
+    -- amount of memory.
+    -- Check there is no alerts and it's performed successfully.
+    cluster['i-001']:exec(function(lua_memory)
+        local alloc = require('internal.alloc')
+        local config = require('config')
+
+        t.assert_equals(config:get('lua.memory'), lua_memory)
+        t.assert_equals(alloc.getlimit(), lua_memory)
+
+        local alerts = config:info().alerts
+        t.assert_equals(alerts, {})
+    end, {lua_memory_1})
+
+    -- Config with 1GB Lua memory limit.
+    local lua_memory_2 = 1024 * 1024 * 1024
+    local config_2 = cbuilder:new(config_1)
+        :set_global_option('lua.memory', lua_memory_2)
+        :config()
+
+    -- Load a config with a new lua.memory value.
+    cluster:reload(config_2)
+
+    -- lua.memory could be increased dynamically.
+    -- Check there is no alerts and it's performed successfully.
+    cluster['i-001']:exec(function(lua_memory)
+        local alloc = require('internal.alloc')
+        local config = require('config')
+
+        t.assert_equals(config:get('lua.memory'), lua_memory)
+        t.assert_equals(alloc.getlimit(), lua_memory)
+
+        local alerts = config:info().alerts
+        t.assert_equals(alerts, {})
+    end, {lua_memory_2})
+
+    -- Allocate a huge chunk of memory and fetch the used
+    -- value (1/4 of the current memory limit).
+    local used = cluster['i-001']:exec(function(lua_memory)
+        local alloc = require('internal.alloc')
+        local digest = require('digest')
+
+        rawset(_G, 'stub', digest.urandom(lua_memory / 4))
+        return alloc.used()
+    end, {lua_memory_2})
+
+    local lua_memory_3 = used + 1024 * 1024
+    -- Config with currently used + 1MB memory limit.
+    local config_3 = cbuilder:new(config_2)
+        :set_global_option('lua.memory', lua_memory_3)
+        :config()
+    cluster:reload(config_3)
+
+    -- The lua.memory option can't be applied if after applying
+    -- there won't be enough unused space (currently it's 16MB).
+    --
+    -- Check applying doesn't change anything and creates an
+    -- alert on restart is needed to apply changes.
+    cluster['i-001']:exec(function(new_lua_memory, old_lua_memory)
+        local alloc = require('internal.alloc')
+        local config = require('config')
+
+        t.assert_equals(config:get('lua.memory'), new_lua_memory)
+        t.assert_equals(alloc.getlimit(), old_lua_memory)
+
+        local alerts = config:info().alerts
+        t.assert_equals(#alerts, 1)
+        t.assert_equals(alerts[1].type, 'warn')
+        local exp = 'lua.apply: lua.memory will be applied after ' ..
+                    'restarting the instance since the new limit is too ' ..
+                    'close to the currently allocated amount of memory'
+        t.assert_equals(alerts[1].message, exp)
+    end, {lua_memory_3, lua_memory_2})
+
+    -- Restart the cluster. Check the option has been
+    -- applied and there is no alerts.
+    cluster:stop()
+    cluster:start()
+
+    cluster['i-001']:exec(function(lua_memory)
+        local alloc = require('internal.alloc')
+        local config = require('config')
+
+        t.assert_equals(config:get('lua.memory'), lua_memory)
+        t.assert_equals(alloc.getlimit(), lua_memory)
+
+        local alerts = config:info().alerts
+        t.assert_equals(alerts, {})
+    end, {lua_memory_3})
+
+    cluster:reload(config_3)
+
+    -- Make sure loading configuration with the same lua.memory
+    -- value don't issue an alert.
+    cluster['i-001']:exec(function(lua_memory)
+        local alloc = require('internal.alloc')
+        local config = require('config')
+
+        t.assert_equals(config:get('lua.memory'), lua_memory)
+        t.assert_equals(alloc.getlimit(), lua_memory)
+
+        local alerts = config:info().alerts
+        t.assert_equals(alerts, {})
+    end, {lua_memory_3})
+
+end
+
+g.test_wrong_value = function(g)
+    local config = cbuilder:new()
+        :add_instance('i-001', {})
+        :config()
+
+    -- cbuilder automatically validates config.
+    -- Rewrite lua.memory option externally.
+    config.lua = {memory = 1024}
+
+    cluster.startup_error(g, config, 'Memory limit should be >= 256MB')
+end


### PR DESCRIPTION
Sometimes we need to limit Lua maximum available memory. Add the config property `lua.memory` to specify the maximum byte amount used for lua allocations.

The limit is implemented with a custom allocation function. It's passed into a Lua state during instantiation. The function itself counts memory used by LuaJIT and prevents allocating more than specified in the config file.

If new memory limit is applied at runtime Tarantool waits for instance reload before applying a new option. 

Closes #8881 