### PR TITLE
ci: testing ASAN instrumentation of LuaJIT internal allocator

### DIFF
--- a/.github/workflows/debug_asan_clang.yml
+++ b/.github/workflows/debug_asan_clang.yml
@@ -71,6 +71,18 @@ jobs:
       # of the .github/actions/environment action.
       options: '--init --privileged'
 
+    strategy:
+      matrix:
+        ALLOCATOR: [sysmalloc, dlmalloc]
+        include:
+          - ALLOCATOR: sysmalloc
+            MAKE_CMD: test-debug-asan-sysmalloc
+          - ALLOCATOR: dlmalloc
+            MAKE_CMD: test-debug-asan-dlmalloc
+
+    name: >
+      debug_asan_clang_${{ matrix.ALLOCATOR }}
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
@@ -89,11 +101,18 @@ jobs:
         with:
           submodule: ${{ inputs.submodule }}
           revision: ${{ inputs.revision }}
+      - name: Switch luajit submodule branch
+        # This step is a temporary solution needed to test the ASAN
+        # instrumentation of LuaJIT allocator.
+        if: ${{ matrix.ALLOCATOR == 'dlmalloc' }}
+        run: |
+          git -C third_party/luajit fetch origin mandesero/lj-10231-ASAN-and-LJ-allocator && \
+          git -C third_party/luajit checkout mandesero/lj-10231-ASAN-and-LJ-allocator
       - name: test
         env:
           CC: clang-19
           CXX: clang++-19
-        run: make -f .test.mk test-debug-asan
+        run: make -f .test.mk ${{ matrix.MAKE_CMD }}
       - name: Send VK Teams message on failure
         if: failure()
         uses: ./.github/actions/report-job-status

--- a/.github/workflows/release_asan_clang.yml
+++ b/.github/workflows/release_asan_clang.yml
@@ -71,6 +71,18 @@ jobs:
       # of the .github/actions/environment action.
       options: '--init --privileged'
 
+    strategy:
+      matrix:
+        ALLOCATOR: [sysmalloc, dlmalloc]
+        include:
+          - ALLOCATOR: sysmalloc
+            MAKE_CMD: test-release-asan-sysmalloc
+          - ALLOCATOR: dlmalloc
+            MAKE_CMD: test-release-asan-dlmalloc
+
+    name: >
+      release_asan_clang_${{ matrix.ALLOCATOR }}
+
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
@@ -89,11 +101,18 @@ jobs:
         with:
           submodule: ${{ inputs.submodule }}
           revision: ${{ inputs.revision }}
+      - name: Switch luajit submodule branch
+        # This step is a temporary solution needed to test the ASAN
+        # instrumentation of LuaJIT allocator.
+        if: ${{ matrix.ALLOCATOR == 'dlmalloc' }}
+        run: |
+          git -C third_party/luajit fetch origin mandesero/lj-10231-ASAN-and-LJ-allocator && \
+          git -C third_party/luajit checkout mandesero/lj-10231-ASAN-and-LJ-allocator
       - name: test
         env:
           CC: clang-19
           CXX: clang++-19
-        run: make -f .test.mk test-release-asan
+        run: make -f .test.mk ${{ matrix.MAKE_CMD }}
       - name: Send VK Teams message on failure
         if: failure()
         uses: ./.github/actions/report-job-status


### PR DESCRIPTION
This patch is a pre-patch (refer to [1]) to add ASAN instrumentation to the LuaJIT memory allocator.

LuaJIT has two usage scenarios for ASAN:
- LuaJIT using sysmalloc
- LuaJIT using internal memory allocator

This patch introduces jobs that separate the testing of these scenarios into individual jobs. This is necessary because using the internal allocator with ASAN requires `-DLUAJIT_ENABLE_GC64=ON` (refer to [1]).

Note: this patch is required to test the ASAN instrumentation of LuaJIT internal memory allocator.

[1]: Issue https://github.com/tarantool/tarantool/issues/10231