### PR TITLE
 small: bump new version with UBSan fixes 

### DIFF
--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -633,14 +633,6 @@ sql_bind_parameter_lindex(struct Vdbe *v, const char *zName, int nName);
 #endif
 
 /*
- * GCC does not define the offsetof() macro so we'll have to do it
- * ourselves.
- */
-#ifndef offsetof
-#define offsetof(STRUCTURE,FIELD) ((int)((char*)&((STRUCTURE*)0)->FIELD))
-#endif
-
-/*
  * Macros to compute minimum and maximum of two numbers.
  */
 #ifndef MIN

--- a/src/trivia/util.h
+++ b/src/trivia/util.h
@@ -270,8 +270,12 @@ alloc_failure(const char *filename, int line, size_t size)
  * including padding if any.
  */
 #ifndef offsetof
-#define offsetof(type, member) ((size_t) &((type *)0)->member)
-#endif
+#  if __has_builtin(__builtin_offsetof)
+#    define offsetof(type, member) __builtin_offsetof(type, member)
+#  else
+#    define offsetof(type, member) ((size_t)&((type *)0)->member)
+#  endif
+#endif /* offsetof */
 
 /**
  * This macro is used to retrieve an enclosing structure from a pointer to


### PR DESCRIPTION
This patch bumped small to the new version that does not trigger
UBSan with `*_entry*` macros and should support new oss-fuzz builder.

Fixes: https://github.com/tarantool/tarantool/issues/10143

NO_DOC=small submodule bump
NO_TEST=small submodule bump