### PR TITLE
Add helpers for checking whether a transaction must be added to the limbo and whether a transaction needs to be acked

### DIFF
--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -732,7 +732,7 @@ txn_complete_fail(struct txn *txn)
 	assert(txn->signature != TXN_SIGNATURE_UNKNOWN);
 	assert(in_txn() == txn);
 	if (txn->limbo_entry != NULL) {
-		assert(txn_has_flag(txn, TXN_WAIT_SYNC));
+		assert(txn_must_be_in_limbo(txn));
 		txn_limbo_abort(&txn_limbo, txn->limbo_entry);
 		txn->limbo_entry = NULL;
 	}
@@ -764,7 +764,7 @@ void
 txn_complete_success(struct txn *txn)
 {
 	assert(!txn_has_flag(txn, TXN_IS_DONE));
-	assert(!txn_has_flag(txn, TXN_WAIT_SYNC));
+	assert(!txn_must_be_in_limbo(txn));
 	assert(txn->signature >= 0);
 	assert(in_txn() == txn);
 #ifndef NDEBUG
@@ -840,7 +840,7 @@ txn_on_journal_write(struct journal_entry *entry)
 	}
 	if (txn_has_flag(txn, TXN_HAS_TRIGGERS))
 		txn_run_wal_write_triggers(txn);
-	if (!txn_has_flag(txn, TXN_WAIT_SYNC)) {
+	if (!txn_must_be_in_limbo(txn)) {
 		txn_complete_success(txn);
 	} else {
 		int64_t lsn;
@@ -1092,7 +1092,7 @@ txn_commit_try_async(struct txn *txn)
 	if (req == NULL)
 		goto rollback;
 
-	if (txn_has_flag(txn, TXN_WAIT_SYNC) &&
+	if (txn_must_be_in_limbo(txn) &&
 	    txn_add_limbo_entry(txn, req) != 0) {
 		goto rollback;
 	}
@@ -1137,7 +1137,7 @@ txn_commit(struct txn *txn)
 	 * confirmed. Then they turn the async transaction into just a plain
 	 * txn not waiting for anything.
 	 */
-	if (txn_has_flag(txn, TXN_WAIT_SYNC) &&
+	if (txn_must_be_in_limbo(txn) &&
 	    txn_add_limbo_entry(txn, req) != 0) {
 		goto rollback_abort;
 	}
@@ -1149,7 +1149,7 @@ txn_commit(struct txn *txn)
 		diag_set_journal_res(req->res);
 		goto rollback_io;
 	}
-	if (txn_has_flag(txn, TXN_WAIT_SYNC)) {
+	if (txn_must_be_in_limbo(txn)) {
 		struct txn_limbo_entry *limbo_entry = txn->limbo_entry;
 		assert(limbo_entry->lsn > 0);
 		/*

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -534,6 +534,12 @@ txn_has_flag(const struct txn *txn, enum txn_flag flag)
 	return (txn->flags & flag) != 0;
 }
 
+static inline bool
+txn_needs_ack(const struct txn *txn)
+{
+	return (txn->flags & TXN_WAIT_ACK) != 0;
+}
+
 static inline void
 txn_set_flags(struct txn *txn, unsigned int flags)
 {

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -535,6 +535,12 @@ txn_has_flag(const struct txn *txn, enum txn_flag flag)
 }
 
 static inline bool
+txn_must_be_in_limbo(const struct txn *txn)
+{
+	return (txn->flags & TXN_WAIT_SYNC) != 0;
+}
+
+static inline bool
 txn_needs_ack(const struct txn *txn)
 {
 	return (txn->flags & TXN_WAIT_ACK) != 0;

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -123,7 +123,7 @@ txn_limbo_last_synchro_entry(struct txn_limbo *limbo)
 struct txn_limbo_entry *
 txn_limbo_append(struct txn_limbo *limbo, uint32_t id, struct txn *txn)
 {
-	assert(txn_has_flag(txn, TXN_WAIT_SYNC));
+	assert(txn_must_be_in_limbo(txn));
 	assert(limbo == &txn_limbo);
 	/*
 	 * Transactions should be added to the limbo before WAL write. Limbo
@@ -277,7 +277,7 @@ txn_limbo_wait_complete(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
 		goto complete;
 
 	assert(!txn_has_flag(entry->txn, TXN_IS_DONE));
-	assert(txn_has_flag(entry->txn, TXN_WAIT_SYNC));
+	assert(txn_must_be_in_limbo(entry->txn));
 	double start_time = fiber_clock();
 	while (true) {
 		double deadline = start_time + replication_synchro_timeout;


### PR DESCRIPTION
This patch series adds helpers for checking whether a transaction must be added to the limbo and whether a transaction needs to be acked.

Needed for tarantool/tarantool-ee#752
Needed for tarantool/tarantool-ee#755