### PR TITLE
[backport 2.11] sio: fix error message displaying bind address

### DIFF
--- a/src/lib/core/sio.h
+++ b/src/lib/core/sio.h
@@ -236,6 +236,16 @@ ssize_t sio_recvfrom(int fd, void *buf, size_t len, int flags,
 int
 sio_uri_to_addr(const char *uri, struct sockaddr *addr, bool *is_host_empty);
 
+/* internals, for unit testing */
+
+/**
+ * Return a string containing fd, base address and peer from arguments.
+ * Used mostly in error messages.
+ */
+const char *
+sio_socketname_addr(int fd, const struct sockaddr *base_addr,
+		    socklen_t addrlen);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/test/unit/sio.c
+++ b/test/unit/sio.c
@@ -90,6 +90,32 @@ check_uri_to_addr(void)
 }
 
 static void
+check_sio_socketname_addr(void)
+{
+	header();
+	plan(2);
+	struct sockaddr_storage base_storage;
+	struct sockaddr *base_addr = (struct sockaddr *)&base_storage;
+	socklen_t addrlen = sizeof(base_storage);
+
+	bool is_host_empty;
+	char base_addr_str[] = "192.0.2.255:1";
+	sio_uri_to_addr(base_addr_str, base_addr, &is_host_empty);
+
+	const char *name = sio_socketname_addr(-3,
+					       base_addr, addrlen);
+
+	is_str(name, "fd -3", "works for invalid fd");
+
+	name = sio_socketname_addr(3, base_addr, addrlen);
+	char expectedbase[] = "fd 3, aka 192.0.2.255:1";
+	is_str(name, expectedbase, "works for fd and base_addr only");
+
+	check_plan();
+	footer();
+}
+
+static void
 check_auto_bind(void)
 {
 	header();
@@ -118,9 +144,10 @@ main(void)
 	fiber_init(fiber_c_invoke);
 
 	header();
-	plan(2);
+	plan(3);
 	check_uri_to_addr();
 	check_auto_bind();
+	check_sio_socketname_addr();
 	int rc = check_plan();
 	footer();
 

--- a/test/unit/unit.h
+++ b/test/unit/unit.h
@@ -118,6 +118,8 @@ int check_plan(void);
 #define is(a, b, ...)		_ok0((a) == (b), #a " == " #b, ##__VA_ARGS__)
 #define isnt(a, b, ...)		_ok0((a) != (b), #a " != " #b, ##__VA_ARGS__)
 
+#define is_str(a, b, fmt, args...) ok(strcmp(a, b) == 0, fmt, ##args)
+
 #if UNIT_TAP_COMPATIBLE
 
 #define header()					\

--- a/test/unit/uri.c
+++ b/test/unit/uri.c
@@ -10,8 +10,6 @@
 #define URI_PARAM_MAX 10
 #define URI_PARAM_VALUE_MAX 10
 
-#define is_str(a, b, fmt, args...) ok(strcmp(a, b) == 0, fmt, ##args)
-
 static void
 sample_uri_create(struct uri *uri)
 {


### PR DESCRIPTION
Now `sio_bind` function prints address into error message directly instead of relying on `fd` used in `bind` that failed to execute.

`sio_bind` used `sio_socketname_to_buffer` for error message effectively attempting printing address bound to `fd` while there actually was an error in binding that address to that socket in the first place.

Fixes #5925

NO_DOC=bugfix
NO_CHANGELOG=minor

(cherry picked from commit a5214bfcfefc9c14ff8b0a076afbb05cc01db767)