### PR TITLE
perf: fix warnings in `column_scan_module.c`

### DIFF
--- a/perf/lua/column_scan_module.c
+++ b/perf/lua/column_scan_module.c
@@ -63,7 +63,7 @@ sum_iterator_rv_lua_func(struct lua_State *L)
 	if (space == NULL)
 		return luaT_error(L);
 	box_raw_read_view_index_t *index =
-		box_raw_read_view_index_by_id(space, 0);
+		box_raw_read_view_index_by_id(space, index_id);
 	if (index == NULL)
 		return luaT_error(L);
 	char key[8];
@@ -153,7 +153,7 @@ sum_scanner_rv_lua_func(struct lua_State *L)
 	if (space == NULL)
 		return luaT_error(L);
 	box_raw_read_view_index_t *index =
-		box_raw_read_view_index_by_id(space, 0);
+		box_raw_read_view_index_by_id(space, index_id);
 	if (index == NULL)
 		return luaT_error(L);
 	char key[8];


### PR DESCRIPTION
Fix the following warnings (with `ENABLE_READ_VIEW` defined):

```
./perf/lua/column_scan_module.c:59:18: error: unused variable ‘index_id’ [-Werror=unused-variable]
   59 |         uint32_t index_id = luaL_checkinteger(L, 2);
      |                  ^~~~~~~~

./perf/lua/column_scan_module.c:149:18: error: unused variable ‘index_id’ [-Werror=unused-variable]
  149 |         uint32_t index_id = luaL_checkinteger(L, 2);
      |                  ^~~~~~~~
```