### PR TITLE
lua: introduce is_interval for datetime.interval

### DIFF
--- a/changelogs/unreleased/gh-10269-is_interval-for-module-interval.md
+++ b/changelogs/unreleased/gh-10269-is_interval-for-module-interval.md
@@ -1,0 +1,4 @@
+## feature/box
+
+* Added the `is_interval` function to check that the provided value is
+  `interval` (gh-10269).

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -1303,6 +1303,7 @@ ffi.metatype(interval_t, {
 
 local interval_mt = {
     new     = interval_new,
+    is_interval = is_interval,
 }
 
 return setmetatable(

--- a/test/app-luatest/interval_test.lua
+++ b/test/app-luatest/interval_test.lua
@@ -34,3 +34,8 @@ end
 g.test_check_interval_encode_ffi = function()
     t.assert_equals(bin, msgpackffi.encode(val))
 end
+
+g.test_is_interval = function()
+    t.assert(itv.is_interval(val))
+    t.assert_not(itv.is_interval({}))
+end


### PR DESCRIPTION
This patch introduces is_interval() function for
require('datetime').interval.

Closes #10269

@TarantoolBot document
Title: Function require('datetime').interval.is_interval()

All modules representing field types, with the exception of `interval` (i.e. `varbinary`, `uuid`, `decimal`, `datetime`), have an `is_<type_name>` function. Now such a function is provided for the `interval` module.