### PR TITLE
tuple: introduce the key_str function

### DIFF
--- a/src/box/tuple.c
+++ b/src/box/tuple.c
@@ -868,12 +868,37 @@ tuple_snprint(char *buf, int size, struct tuple *tuple)
 	return total;
 }
 
+int
+key_snprint(char *buf, int size, const char *key, uint32_t part_count)
+{
+	int total = 0;
+	const char *data = key;
+	SNPRINT(total, snprintf, buf, size, "[");
+	for (uint32_t i = 0; i < part_count; i++) {
+		SNPRINT(total, mp_snprint, buf, size, data);
+		mp_next(&data);
+		if (i != part_count - 1)
+			SNPRINT(total, snprintf, buf, size, ", ");
+	}
+	SNPRINT(total, snprintf, buf, size, "]");
+	return total;
+}
+
 const char *
 tuple_str(struct tuple *tuple)
 {
 	char *buf = tt_static_buf();
 	if (tuple_snprint(buf, TT_STATIC_BUF_LEN, tuple) < 0)
 		return "<failed to format tuple>";
+	return buf;
+}
+
+const char *
+key_str(const char *key, uint32_t part_count)
+{
+	char *buf = tt_static_buf();
+	if (key_snprint(buf, TT_STATIC_BUF_LEN, key, part_count) < 0)
+		return "<failed to format key>";
 	return buf;
 }
 

--- a/src/box/tuple.h
+++ b/src/box/tuple.h
@@ -756,6 +756,16 @@ const char *
 tuple_str(struct tuple *tuple);
 
 /**
+ * Format a key into string using a static buffer.
+ * Useful for debugger. Example: [1, 2, "string"]
+ * @param key to format (without the MP_ARRAY header)
+ * @param key part count
+ * @return formatted null-terminated string
+ */
+const char *
+key_str(const char *key, uint32_t part_count);
+
+/**
  * Format msgpack into string using a static buffer.
  * Useful for debugger. Example: [1, 2, "string"]
  * @param msgpack to format

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -599,6 +599,11 @@ create_unit_test(PREFIX iterator_position
                  LIBRARIES unit box core
 )
 
+create_unit_test(PREFIX key_str
+                 SOURCES key_str.c box_test_utils.c
+                 LIBRARIES unit box core
+)
+
 create_unit_test(PREFIX key_def
                  SOURCES key_def.cc box_test_utils.c
                  LIBRARIES unit box core

--- a/test/unit/key_str.c
+++ b/test/unit/key_str.c
@@ -1,0 +1,72 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "tuple.h"
+#include "memory.h"
+#include "msgpuck.h"
+
+#define UNIT_TAP_COMPATIBLE 1
+#include "unit.h"
+
+void
+check(const char *key, uint32_t part_count, const char *expect, const char *info)
+{
+	const char *str = key_str(key, part_count);
+	ok(strcmp(str, expect) == 0, "%s: %s == %s", info, str, expect);
+}
+
+int
+main(void)
+{
+	memory_init();
+	fiber_init(fiber_c_invoke);
+
+	plan(7);
+	header();
+
+	char data[1024] = {};
+	char *ptr = NULL;
+
+	check(NULL, 0, "[]", "Empty key");
+
+	mp_encode_uint(data, 37);
+	check(data, 1, "[37]", "Single unsigned");
+
+	mp_encode_int(data, -37);
+	check(data, 1, "[-37]", "Single integer");
+
+	mp_encode_str0(data, "37");
+	check(data, 1, "[\"37\"]", "Single string");
+
+	ptr = mp_encode_array(data, 2);
+	ptr = mp_encode_uint(ptr, 1);
+	mp_encode_str0(ptr, "2");
+	check(data, 1, "[[1, \"2\"]]", "Array");
+
+	ptr = mp_encode_map(data, 2);
+	ptr = mp_encode_str0(ptr, "key1");
+	ptr = mp_encode_uint(ptr, 1);
+	ptr = mp_encode_str0(ptr, "key2");
+	mp_encode_uint(ptr, 2);
+	check(data, 1, "[{\"key1\": 1, \"key2\": 2}]", "Map");
+
+	ptr = mp_encode_int(data, -1);
+	ptr = mp_encode_uint(ptr, 0);
+	ptr = mp_encode_str0(ptr, "1");
+	ptr = mp_encode_array(ptr, 2);
+	ptr = mp_encode_uint(ptr, 2);
+	ptr = mp_encode_map(ptr, 2);
+	ptr = mp_encode_str0(ptr, "3");
+	ptr = mp_encode_uint(ptr, 4);
+	ptr = mp_encode_uint(ptr, 5);
+	mp_encode_str0(ptr, "6");
+	check(data, 4, "[-1, 0, \"1\", [2, {\"3\": 4, 5: \"6\"}]]",
+	      "Everything at once");
+
+	footer();
+
+	fiber_free();
+	memory_free();
+	return check_plan();
+}


### PR DESCRIPTION
The function consumes the MsgPack encoded key (without the MP_ARRAY header) and part count and prints the key string representation into a static buffer, returning a pointer to it. It meant to be used for debugging purposes.

NO_DOC=internal
NO_TEST=internal
NO_CHANGELOG=internal