### PR TITLE
iproto: introduce IS_SYNC feature

### DIFF
--- a/changelogs/unreleased/gh-10173-is-sync-feature.md
+++ b/changelogs/unreleased/gh-10173-is-sync-feature.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Added the missing IPROTO_FEATURE_IS_SYNC feature, which requires
+  IPROTO_IS_SYNC in IPROTO_BEGIN/COMMIT requests on the server (gh-10173).

--- a/src/box/iproto_features.c
+++ b/src/box/iproto_features.c
@@ -89,4 +89,6 @@ iproto_features_init(void)
 	iproto_features_set(&IPROTO_CURRENT_FEATURES,
 			    IPROTO_FEATURE_FETCH_SNAPSHOT_CURSOR);
 #endif /* defined(ENABLE_FETCH_SNAPSHOT_CURSOR) */
+	iproto_features_set(&IPROTO_CURRENT_FEATURES,
+			    IPROTO_FEATURE_IS_SYNC);
 }

--- a/src/box/iproto_features.h
+++ b/src/box/iproto_features.h
@@ -82,7 +82,12 @@ extern "C" {
 	 * IPROTO_IS_CHECKPOINT_JOIN, IPROTO_CHECKPOINT_VCLOCK and
 	 * IRPOTO_CHECKPOINT_LSN.
 	 */								\
-	 _(FETCH_SNAPSHOT_CURSOR, 10)					\
+	_(FETCH_SNAPSHOT_CURSOR, 10)					\
+	/**
+	 * Synchronous transaction support:
+	 * IS_SYNC flag in IPROTO_BEGIN, IPROTO_COMMIT
+	 */								\
+	_(IS_SYNC, 11)							\
 
 #define IPROTO_FEATURE_MEMBER(s, v) IPROTO_FEATURE_ ## s = v,
 
@@ -107,7 +112,7 @@ struct iproto_features {
  * `box.iproto.protocol_version` needs to be updated correspondingly.
  */
 enum {
-	IPROTO_CURRENT_VERSION = 8,
+	IPROTO_CURRENT_VERSION = 9,
 };
 
 /**

--- a/src/box/lua/net_box.c
+++ b/src/box/lua/net_box.c
@@ -82,7 +82,7 @@ enum {
 	/**
 	 * IPROTO protocol version supported by the netbox connector.
 	 */
-	NETBOX_IPROTO_VERSION = 8,
+	NETBOX_IPROTO_VERSION = 9,
 };
 
 /**
@@ -3270,6 +3270,8 @@ luaopen_net_box(struct lua_State *L)
 			    IPROTO_FEATURE_CALL_RET_TUPLE_EXTENSION);
 	iproto_features_set(&NETBOX_IPROTO_FEATURES,
 			    IPROTO_FEATURE_CALL_ARG_TUPLE_EXTENSION);
+	iproto_features_set(&NETBOX_IPROTO_FEATURES,
+			    IPROTO_FEATURE_IS_SYNC);
 
 	lua_pushcfunction(L, luaT_netbox_request_iterator_next);
 	luaT_netbox_request_iterator_next_ref = luaL_ref(L, LUA_REGISTRYINDEX);

--- a/test/box-luatest/gh_7894_export_iproto_constants_and_features_test.lua
+++ b/test/box-luatest/gh_7894_export_iproto_constants_and_features_test.lua
@@ -171,7 +171,7 @@ local reference_table = {
     },
 
     -- `IPROTO_CURRENT_VERSION` constant
-    protocol_version = 8,
+    protocol_version = 9,
 
     -- `feature_id` enumeration
     protocol_features = {
@@ -186,6 +186,7 @@ local reference_table = {
         call_ret_tuple_extension = true,
         call_arg_tuple_extension = true,
         fetch_snapshot_cursor = is_enterprise and true or nil,
+        is_sync = true,
     },
     feature = {
         streams = 0,
@@ -199,6 +200,7 @@ local reference_table = {
         call_ret_tuple_extension = 8,
         call_arg_tuple_extension = 9,
         fetch_snapshot_cursor = 10,
+        is_sync = 11,
     },
 }
 

--- a/test/box-py/iproto.result
+++ b/test/box-py/iproto.result
@@ -210,11 +210,11 @@ Invalid MsgPack - request body
 # Invalid auth_type
 Invalid MsgPack - request body
 # Empty request body
-version=8, features=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], auth_type=chap-sha1
+version=9, features=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11], auth_type=chap-sha1
 # Unknown version and features
-version=8, features=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], auth_type=chap-sha1
+version=9, features=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11], auth_type=chap-sha1
 # Unknown request key
-version=8, features=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], auth_type=chap-sha1
+version=9, features=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11], auth_type=chap-sha1
 
 #
 # gh-6257 Watchers

--- a/test/box/net.box_iproto_id.result
+++ b/test/box/net.box_iproto_id.result
@@ -23,7 +23,7 @@ c = net.connect(box.cfg.listen)
  | ...
 c.peer_protocol_version
  | ---
- | - 8
+ | - 9
  | ...
 print_features(c)
  | ---
@@ -32,6 +32,7 @@ print_features(c)
  |   error_extension: true
  |   call_arg_tuple_extension: true
  |   pagination: true
+ |   is_sync: true
  |   space_and_index_names: true
  |   streams: true
  |   watch_once: true
@@ -65,6 +66,7 @@ print_features(c)
  |   error_extension: false
  |   call_arg_tuple_extension: false
  |   pagination: false
+ |   is_sync: false
  |   space_and_index_names: false
  |   streams: false
  |   watch_once: false
@@ -119,6 +121,7 @@ print_features(c)
  |   error_extension: true
  |   call_arg_tuple_extension: true
  |   pagination: true
+ |   is_sync: true
  |   space_and_index_names: true
  |   streams: true
  |   watch_once: true
@@ -169,7 +172,7 @@ c.error -- error
  | ...
 c.peer_protocol_version
  | ---
- | - 8
+ | - 9
  | ...
 print_features(c)
  | ---
@@ -178,6 +181,7 @@ print_features(c)
  |   error_extension: true
  |   call_arg_tuple_extension: true
  |   pagination: true
+ |   is_sync: true
  |   space_and_index_names: true
  |   streams: true
  |   watch_once: true
@@ -201,7 +205,7 @@ c.error -- error
  | ...
 c.peer_protocol_version
  | ---
- | - 8
+ | - 9
  | ...
 print_features(c)
  | ---
@@ -210,6 +214,7 @@ print_features(c)
  |   error_extension: true
  |   call_arg_tuple_extension: true
  |   pagination: true
+ |   is_sync: true
  |   space_and_index_names: true
  |   streams: true
  |   watch_once: true


### PR DESCRIPTION
`IPROTO_IS_SYNC`, which was introduced by commit c3c0d439ce8f ("box: add is_sync option") in Tarantool 3.0.0-beta1, still doesn't have a feature bit. Let's add it finally.

Closes #10173