### PR TITLE
perf: introduce the box benchmarks

### DIFF
--- a/perf/lua/CMakeLists.txt
+++ b/perf/lua/CMakeLists.txt
@@ -57,6 +57,12 @@ create_perf_lua_test(NAME uri_escape_unescape)
 
 include_directories(${MSGPUCK_INCLUDE_DIRS})
 
+build_module(benchmark_box_module benchmark_box_module.cc)
+target_link_libraries(benchmark_box_module msgpuck)
+create_perf_lua_test(NAME memtx_tree
+                     DEPENDS benchmark_box_module
+)
+
 build_module(column_scan_module column_scan_module.c)
 target_link_libraries(column_scan_module msgpuck)
 create_perf_lua_test(NAME column_scan

--- a/perf/lua/benchmark_box_module.cc
+++ b/perf/lua/benchmark_box_module.cc
@@ -1,0 +1,496 @@
+/*
+ * Copyright 2024, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+extern "C" {
+#include <lua.h>
+#include <lauxlib.h>
+}
+
+#include <module.h>
+#include <msgpuck.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <random>
+
+#include "trivia/config.h"
+#include "trivia/util.h"
+
+enum {
+	MAX_STRING_SIZE = 1024,
+	MAX_PAYLOAD_SIZE = 1024 * 1024,
+};
+
+enum distribution {
+	INCREMENTAL,      /* 0, 1, 2, etc. */
+	LINEAR,           /* Random, linear distribution. */
+	distribution_MAX,
+};
+
+const char *distribution_strs[] = {
+	"incremental",
+	"linear",
+};
+
+static_assert(lengthof(distribution_strs) == distribution_MAX);
+
+const char *field_type_strs[] = {
+	/* [FIELD_TYPE_ANY]      = */ "any",
+	/* [FIELD_TYPE_UNSIGNED] = */ "unsigned",
+	/* [FIELD_TYPE_STRING]   = */ "string",
+	/* [FIELD_TYPE_NUMBER]   = */ "number",
+	/* [FIELD_TYPE_DOUBLE]   = */ "double",
+	/* [FIELD_TYPE_INTEGER]  = */ "integer",
+	/* [FIELD_TYPE_BOOLEAN]  = */ "boolean",
+	/* [FIELD_TYPE_VARBINARY] = */"varbinary",
+	/* [FIELD_TYPE_SCALAR]   = */ "scalar",
+	/* [FIELD_TYPE_DECIMAL]  = */ "decimal",
+	/* [FIELD_TYPE_UUID]     = */ "uuid",
+	/* [FIELD_TYPE_DATETIME] = */ "datetime",
+	/* [FIELD_TYPE_INTERVAL] = */ "interval",
+	/* [FIELD_TYPE_ARRAY]    = */ "array",
+	/* [FIELD_TYPE_MAP]      = */ "map",
+	/* [FIELD_TYPE_INT8]     = */ "int8",
+	/* [FIELD_TYPE_UINT8]    = */ "uint8",
+	/* [FIELD_TYPE_INT16]    = */ "int16",
+	/* [FIELD_TYPE_UINT16]   = */ "uint16",
+	/* [FIELD_TYPE_INT32]    = */ "int32",
+	/* [FIELD_TYPE_UINT32]   = */ "uint32",
+	/* [FIELD_TYPE_INT64]    = */ "int64",
+	/* [FIELD_TYPE_UINT64]   = */ "uint64",
+	/* [FIELD_TYPE_FLOAT32]  = */ "float32",
+	/* [FIELD_TYPE_FLOAT64]  = */ "float64",
+};
+
+static_assert(lengthof(field_type_strs) == field_type_MAX,
+	       "Each field type must be present in field_type_strs");
+
+struct Payload {
+	enum field_type type;
+	enum distribution distribution;
+};
+
+struct Options {
+	int request_count;
+	int payload_size;
+	struct Payload *payload;
+};
+
+struct Benchmark {
+	struct Options *options;
+	union State {
+		uint64_t u64;
+		struct {
+			size_t len;
+			char *buf;
+		} str;
+	} *payload_states;
+	char *payload_buf;
+	std::minstd_rand rng; /* Generates unique and reproducible values. */
+};
+
+uint32_t
+strindex(const char *const *haystack, const char *needle, uint32_t hmax)
+{
+	for (unsigned index = 0; index != hmax && haystack[index]; index++)
+		if (strcasecmp(haystack[index], needle) == 0)
+			return index;
+	return hmax;
+}
+
+static int
+benchmark_init_payload_incremental(struct Benchmark *benchmark, int i)
+{
+	struct Options *options = benchmark->options;
+	switch (options->payload[i].type) {
+	case FIELD_TYPE_UNSIGNED:
+		benchmark->payload_states[i].u64 = 0;
+		break;
+	case FIELD_TYPE_STRING:
+		benchmark->payload_states[i].str.buf =
+			(char *)box_region_alloc(MAX_STRING_SIZE);
+		strcpy(benchmark->payload_states[i].str.buf, "0");
+		benchmark->payload_states[i].str.len = 1;
+		break;
+	default:
+		box_error_raise(ER_PROC_LUA, "unsupported type (inc.init)");
+		return -1;
+	}
+	return 0;
+}
+
+static int
+benchmark_init_payload_linear(struct Benchmark *benchmark, int i)
+{
+	struct Options *options = benchmark->options;
+	if (options->payload[i].type != FIELD_TYPE_UNSIGNED &&
+	    options->payload[i].type != FIELD_TYPE_STRING) {
+		box_error_raise(ER_PROC_LUA, "unsupported type (lin.init)");
+		return -1;
+	}
+	return 0;
+}
+
+static int
+benchmark_init(struct Benchmark *benchmark, struct Options *options)
+{
+	benchmark->options = options;
+	benchmark->payload_buf = (char *)box_region_alloc(MAX_PAYLOAD_SIZE);
+	benchmark->payload_states = (union Benchmark::State *)
+		box_region_aligned_alloc(options->payload_size,
+					 alignof(Benchmark::State));
+	int rc;
+	for (int i = 0; i < options->payload_size; i++) {
+		switch (options->payload[i].distribution) {
+		case INCREMENTAL:
+			rc = benchmark_init_payload_incremental(benchmark, i);
+			break;
+		case LINEAR:
+			rc = benchmark_init_payload_linear(benchmark, i);
+			break;
+		case distribution_MAX:
+			unreachable();
+		}
+		if (rc != 0)
+			return -1;
+	}
+	return 0;
+}
+
+static int
+benchmark_next_payload_incremental(struct Benchmark *benchmark,
+				   int i, char **data)
+{
+	struct Options *options = benchmark->options;
+	union Benchmark::State *payload_state = &benchmark->payload_states[i];
+	switch (options->payload[i].type) {
+	case FIELD_TYPE_UNSIGNED:
+		*data = mp_encode_uint(*data, payload_state->u64++);
+		break;
+	default:
+		box_error_raise(ER_PROC_LUA, "unsupported type (inc.gen)");
+		return -1;
+	}
+	return 0;
+}
+
+static int
+benchmark_next_payload_linear(struct Benchmark *benchmark, int i, char **data)
+{
+	struct Options *options = benchmark->options;
+	switch (options->payload[i].type) {
+	case FIELD_TYPE_UNSIGNED:
+		*data = mp_encode_uint(*data, benchmark->rng());
+		break;
+	default:
+		box_error_raise(ER_PROC_LUA, "unsupported type (lin.gen)");
+		return -1;
+	}
+	return 0;
+}
+
+static int
+benchmark_next_payload(struct Benchmark *benchmark, char **begin, char **end)
+{
+	struct Options *options = benchmark->options;
+	char *data = benchmark->payload_buf;
+	*begin = data;
+	data = mp_encode_array(data, options->payload_size);
+	int rc;
+	for (int i = 0; i < options->payload_size; i++) {
+		switch (options->payload[i].distribution) {
+		case INCREMENTAL:
+			rc = benchmark_next_payload_incremental(benchmark,
+								i, &data);
+			break;
+		case LINEAR:
+			rc = benchmark_next_payload_linear(benchmark, i, &data);
+			break;
+		case distribution_MAX:
+			unreachable();
+		}
+		if (rc != 0)
+			return -1;
+	}
+	*end = data;
+	return 0;
+}
+
+static int
+benchmark_parse_options(struct lua_State *L, int idx, struct Options *options)
+{
+	/* Get the request count. */
+	lua_getfield(L, idx, "request_count");
+	options->request_count =
+		lua_isnil(L, -1) ? 1000000 : lua_tonumber(L, -1);
+	lua_pop(L, 1);
+
+	/* Get the test data format. */
+	lua_getfield(L, idx, "payload");
+	if (!lua_isnil(L, -1)) {
+		options->payload_size = lua_objlen(L, -1);
+		options->payload = (struct Payload *)box_region_aligned_alloc(
+			alignof(struct Payload), options->payload_size);
+		for (int i = 0; i < options->payload_size; i++) {
+			/* payload[i] */
+			lua_rawgeti(L, -1, i + 1);
+
+			/* payload[i].type */
+			lua_getfield(L, -1, "type");
+			if (lua_isnil(L, -1)) {
+				box_error_raise(ER_PROC_LUA,
+						"field type must be specified");
+				return -1;
+			}
+			const char *str = lua_tostring(L, -1);
+			options->payload[i].type = STR2ENUM(field_type, str);
+			if (options->payload[i].type == field_type_MAX) {
+				box_error_raise(ER_PROC_LUA,
+						"unknown field type");
+				return -1;
+			}
+			lua_pop(L, 1);
+
+			/* payload[i].distribution */
+			lua_getfield(L, -1, "distribution");
+			if (!lua_isnil(L, -1)) {
+				const char *str = lua_tostring(L, -1);
+				options->payload[i].distribution =
+					STR2ENUM(distribution, str);
+				if (options->payload[i].distribution ==
+				    distribution_MAX) {
+					box_error_raise(ER_PROC_LUA, "unknown"
+							" distribution type");
+					return -1;
+				}
+			} else {
+				options->payload[i].distribution = LINEAR;
+			}
+			lua_pop(L, 1);
+
+			/* payload[i] */
+			lua_pop(L, 1);
+		}
+	}
+	lua_pop(L, 1);
+	return 0;
+}
+
+static int
+benchmark_replace_lua_func(struct lua_State *L)
+{
+	if (lua_gettop(L) != 2 || !lua_isnumber(L, 1) ||
+	    (lua_type(L, 2) != LUA_TTABLE))
+		return luaL_error(L, "Usage replace(space_id, opts)");
+
+	/* Get the space ID. */
+	uint32_t space_id = lua_tonumber(L, 1);
+
+	/* Create and fill the Options structure. */
+	size_t region_svp = box_region_used();
+	struct Options options;
+	if (benchmark_parse_options(L, 2, &options) == -1) {
+		box_region_truncate(region_svp);
+		return luaT_error(L);
+	}
+
+	/* Initialize the payload generator. */
+	struct Benchmark benchmark;
+	if (benchmark_init(&benchmark, &options) != 0) {
+		box_region_truncate(region_svp);
+		return luaT_error(L);
+	}
+
+	/* Do the benchmark. */
+	for (int i = 0; i < options.request_count; i++) {
+		struct tuple *unused;
+		char *data, *data_end;
+		if (benchmark_next_payload(&benchmark, &data, &data_end) != 0 ||
+		    box_replace(space_id, data, data_end, &unused) != 0) {
+			box_region_truncate(region_svp);
+			return luaT_error(L);
+		}
+	}
+
+	/* Clean-up. */
+	box_region_truncate(region_svp);
+	return 0;
+}
+
+static int
+benchmark_insert_lua_func(struct lua_State *L)
+{
+	if (lua_gettop(L) != 2 || !lua_isnumber(L, 1) ||
+	    (lua_type(L, 2) != LUA_TTABLE))
+		return luaL_error(L, "Usage insert(space_id, opts)");
+
+	/* Get the space ID. */
+	uint32_t space_id = lua_tonumber(L, 1);
+
+	/* Create and fill the Options structure. */
+	size_t region_svp = box_region_used();
+	struct Options options;
+	if (benchmark_parse_options(L, 2, &options) != 0) {
+		box_region_truncate(region_svp);
+		return luaT_error(L);
+	}
+
+	/* Initialize the payload generator. */
+	struct Benchmark benchmark;
+	if (benchmark_init(&benchmark, &options) != 0) {
+		box_region_truncate(region_svp);
+		return luaT_error(L);
+	}
+
+	/* Do the benchmark. */
+	for (int i = 0; i < options.request_count; i++) {
+		struct tuple *unused;
+		char *data, *data_end;
+		if (benchmark_next_payload(&benchmark, &data, &data_end) != 0 ||
+		    box_insert(space_id, data, data_end, &unused) != 0) {
+			box_region_truncate(region_svp);
+			return luaT_error(L);
+		}
+	}
+
+	/* Clean-up. */
+	box_region_truncate(region_svp);
+	return 0;
+}
+
+static int
+benchmark_delete_lua_func(struct lua_State *L)
+{
+	if (lua_gettop(L) != 3 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2) ||
+	    (lua_type(L, 3) != LUA_TTABLE))
+		return luaL_error(L, "Usage delete(space_id, index_id, opts)");
+
+	/* Get the space ID. */
+	uint32_t space_id = lua_tonumber(L, 1);
+
+	/* Get the index ID. */
+	uint32_t index_id = lua_tonumber(L, 2);
+
+	/* Create and fill the Options structure. */
+	size_t region_svp = box_region_used();
+	struct Options options;
+	if (benchmark_parse_options(L, 3, &options) == -1) {
+		box_region_truncate(region_svp);
+		return luaT_error(L);
+	}
+
+	/* Initialize the payload generator. */
+	struct Benchmark benchmark;
+	if (benchmark_init(&benchmark, &options) != 0) {
+		box_region_truncate(region_svp);
+		return luaT_error(L);
+	}
+
+	/* Do the benchmark. */
+	for (int i = 0; i < options.request_count; i++) {
+		struct tuple *unused;
+		char *data, *data_end;
+		if (benchmark_next_payload(&benchmark, &data, &data_end) != 0 ||
+		    box_delete(space_id, index_id, data,
+			       data_end, &unused) != 0) {
+			box_region_truncate(region_svp);
+			return luaT_error(L);
+		}
+	}
+
+	/* Clean-up. */
+	box_region_truncate(region_svp);
+	return 0;
+}
+
+static int
+benchmark_get_lua_func(struct lua_State *L)
+{
+	if (lua_gettop(L) != 3 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2) ||
+	    (lua_type(L, 3) != LUA_TTABLE))
+		return luaL_error(L, "Usage get(space_id, index_id, opts)");
+
+	/* Get the space ID. */
+	uint32_t space_id = lua_tonumber(L, 1);
+
+	/* Get the index ID. */
+	uint32_t index_id = lua_tonumber(L, 2);
+
+	/* Create and fill the Options structure. */
+	size_t region_svp = box_region_used();
+	struct Options options;
+	if (benchmark_parse_options(L, 3, &options) == -1) {
+		box_region_truncate(region_svp);
+		return luaT_error(L);
+	}
+
+	/* Initialize the payload generator. */
+	struct Benchmark benchmark;
+	if (benchmark_init(&benchmark, &options) != 0) {
+		box_region_truncate(region_svp);
+		return luaT_error(L);
+	}
+
+	/* Do the benchmark. */
+	for (int i = 0; i < options.request_count; i++) {
+		struct tuple *unused;
+		char *key, *key_end;
+		if (benchmark_next_payload(&benchmark, &key, &key_end) != 0) {
+			box_region_truncate(region_svp);
+			return luaT_error(L);
+		}
+		box_iterator_t *it = box_index_iterator(space_id, index_id,
+							ITER_EQ, key, key_end);
+		if (it == NULL) {
+			box_region_truncate(region_svp);
+			return luaT_error(L);
+		}
+		box_iterator_free(it);
+	}
+
+	/* Clean-up. */
+	box_region_truncate(region_svp);
+	return 0;
+}
+
+extern "C" int
+luaopen_benchmark_box_module(struct lua_State *L)
+{
+	static const struct luaL_Reg lib[] = {
+		{"replace", benchmark_replace_lua_func},
+		{"insert", benchmark_insert_lua_func},
+		{"delete", benchmark_delete_lua_func},
+		{"get", benchmark_get_lua_func},
+		{NULL, NULL}
+	};
+	luaL_register(L, "benchmark", lib);
+	return 1;
+}

--- a/perf/lua/memtx_tree.lua
+++ b/perf/lua/memtx_tree.lua
@@ -1,0 +1,115 @@
+--
+-- The test measures run time of box_replace C function.
+--
+-- Output format (console):
+-- <test-case> <rows-per-second>
+--
+-- NOTE: The test requires a C module. Set the BUILDDIR environment variable to
+-- the tarantool build directory if using out-of-source build.
+--
+
+local clock = require('clock')
+local fiber = require('fiber')
+local fio = require('fio')
+local ffi = require('ffi')
+local log = require('log')
+local tarantool = require('tarantool')
+local benchmark = require('benchmark')
+
+local USAGE = [[
+   request_count <number, 10000000> - the amount of replaces to perform
+   repetitions <number, 1>          - the number of benchmark repetitions
+
+ Being run without options, this benchmark measures the run time of a replace
+ single of a tuple with single unsigned key (random with linear distribution).
+
+]]
+
+local params = benchmark.argparse(arg, {
+    {'request_count', 'number'},
+    {'repetitions', 'number'},
+}, USAGE)
+
+local DEFAULT_COUNT = 10000000
+local DEFAULT_REPETITIONS = 1
+
+params.request_count = params.request_count or DEFAULT_COUNT
+params.repetitions = params.repetitions or DEFAULT_REPETITIONS
+
+local BUILDDIR = fio.abspath(fio.pathjoin(os.getenv('BUILDDIR') or '.'))
+local MODULEPATH = fio.pathjoin(BUILDDIR, 'perf', 'lua',
+                                '?.' .. tarantool.build.mod_format)
+
+package.cpath = MODULEPATH .. ';' .. package.cpath
+
+local benchmark_box = require('benchmark_box_module')
+
+box.cfg({
+    memtx_memory = 8 * 1024 * 1024 * 1024,
+    wal_mode = 'none',
+})
+
+local options = {request_count = params.request_count,
+                 payload = {{type = 'unsigned'}}}
+
+local bench = benchmark.new(params)
+
+box.schema.space.create('test')
+box.space.test:create_index('pk')
+
+fiber.set_max_slice(9000)
+
+TESTS = {
+    {
+        name = 'box_insert',
+        func = function(options)
+            benchmark_box.insert(box.space.test.id, options)
+        end
+    },
+    {
+        name = 'box_replace',
+        func = function(options)
+            benchmark_box.replace(box.space.test.id, options)
+        end
+    },
+    {
+        name = 'box_delete',
+        func = function(options)
+            benchmark_box.delete(box.space.test.id, 0, options)
+        end
+    },
+    {
+        name = 'box_get',
+        func = function(options)
+            benchmark_box.get(box.space.test.id, 0, options)
+        end
+    },
+}
+
+for _, distribution in pairs({'incremental', 'linear'}) do
+    options.payload[1].distribution = distribution
+    for i = 1, params.repetitions + 1 do
+        for _, test in ipairs(TESTS) do
+            box.begin()
+            local real_time_start = clock.time()
+            local cpu_time_start = clock.proc()
+            test.func(options)
+            local delta_real = clock.time() - real_time_start
+            local delta_cpu = clock.proc() - cpu_time_start
+            box.commit()
+
+            -- The first run is warm-up.
+            if i ~= 1 then
+                bench:add_result(test.name .. '_' .. distribution, {
+                    real_time = delta_real,
+                    cpu_time = delta_cpu,
+                    items = params.request_count,
+                })
+            end
+        end
+    end
+end
+
+bench:dump_results()
+
+os.exit(0)

--- a/perf/lua/memtx_tree_rv.lua
+++ b/perf/lua/memtx_tree_rv.lua
@@ -1,0 +1,109 @@
+--
+-- The test measures run time of box_replace C function.
+--
+-- Output format (console):
+-- <test-case> <rows-per-second>
+--
+-- NOTE: The test requires a C module. Set the BUILDDIR environment variable to
+-- the tarantool build directory if using out-of-source build.
+--
+
+local clock = require('clock')
+local fiber = require('fiber')
+local fio = require('fio')
+local ffi = require('ffi')
+local log = require('log')
+local tarantool = require('tarantool')
+local benchmark = require('benchmark')
+
+local USAGE = [[
+   request_count <number, 10000000> - the amount of replaces to perform
+   repetitions <number, 1>          - the number of benchmark repetitions
+
+ Being run without options, this benchmark measures the run time of a replace
+ single of a tuple with single unsigned key (random with linear distribution).
+
+]]
+
+local params = benchmark.argparse(arg, {
+    {'request_count', 'number'},
+    {'repetitions', 'number'},
+}, USAGE)
+
+local DEFAULT_COUNT = 10000000
+local DEFAULT_REPETITIONS = 1
+
+params.request_count = params.request_count or DEFAULT_COUNT
+params.repetitions = params.repetitions or DEFAULT_REPETITIONS
+
+local BUILDDIR = fio.abspath(fio.pathjoin(os.getenv('BUILDDIR') or '.'))
+local MODULEPATH = fio.pathjoin(BUILDDIR, 'perf', 'lua',
+                                '?.' .. tarantool.build.mod_format)
+
+package.cpath = MODULEPATH .. ';' .. package.cpath
+
+local benchmark_box = require('benchmark_box_module')
+
+box.cfg({
+    memtx_memory = 8 * 1024 * 1024 * 1024,
+    wal_mode = 'none',
+})
+
+local options = {request_count = params.request_count,
+                 payload = {{type = 'unsigned'}}}
+
+local bench = benchmark.new(params)
+
+box.schema.space.create('test')
+box.space.test:create_index('pk')
+
+fiber.set_max_slice(9000)
+
+TESTS = {
+    {
+        name = 'box_replace',
+        func = function(options)
+            benchmark_box.replace(box.space.test.id, options)
+        end
+    },
+    {
+        name = 'box_delete',
+        func = function(options)
+            benchmark_box.delete(box.space.test.id, 0, options)
+        end
+    },
+}
+
+for _, distribution in pairs({'incremental', 'linear'}) do
+    options.payload[1].distribution = distribution
+    for i = 1, params.repetitions + 1 do
+        for _, test in ipairs(TESTS) do
+            benchmark_box.insert(box.space.test.id, options)
+            local rv = box.read_view.open()
+
+            box.begin()
+            local real_time_start = clock.time()
+            local cpu_time_start = clock.proc()
+            test.func(options)
+            local delta_real = clock.time() - real_time_start
+            local delta_cpu = clock.proc() - cpu_time_start
+            box.commit()
+
+            rv:close()
+            box.space.test:truncate()
+
+            -- The first run is warm-up.
+            if i ~= 1 then
+                bench:add_result(test.name .. '_' .. distribution, {
+                    real_time = delta_real,
+                    cpu_time = delta_cpu,
+                    items = params.request_count,
+                })
+            end
+        end
+    end
+end
+
+bench:dump_results()
+
+os.exit(0)

--- a/perf/tools/compare_ci.py
+++ b/perf/tools/compare_ci.py
@@ -1,0 +1,172 @@
+colorize_diff = False
+
+def ratio(base, value):
+    return 100.0 / base * value
+
+def get_diff(base, value, reverse = False, orange_thr = 2):
+    result = ratio(base, value) - 100.0
+    result *= -1 if reverse else 1
+    if result == 0:
+        return '-'
+    if result < 0:
+        color = 'green'
+    elif result <= orange_thr:
+        color = 'RedOrange'
+    else:
+        color = 'red'
+    result *= -1 if reverse else 1
+    prefix = '+' if result > 0 else ''
+    if colorize_diff:
+        return f'$\\color{"{"}{color}{"}"}{prefix}{result:.02f}％$'
+    else:
+        return f'{prefix}{result:.02f}%'
+
+def print_table(rows, prefix = 0):
+    if len(rows) == 0:
+        return
+    cols = len(rows[0])
+    for row in rows:
+        assert(cols == len(row))
+    max_cell_len = [ -1 ] * cols
+    for row in rows:
+        for i in range(len(row)):
+            length = len(row[i].encode('utf-16-le')) // 2
+            max_cell_len[i] = max((max_cell_len[i], length))
+    for i in range(len(rows)):
+        print(' ' * prefix, end = '')
+        print('|', end = '')
+        for j in range(len(rows[i])):
+            print(f' {rows[i][j].ljust(max_cell_len[j])} |', end = '')
+        print('') # Newline.
+        if i == 0:
+            print(' ' * prefix, end = '')
+            print('|', end = '')
+            for j in range(len(rows[i])):
+                print(f' {"-" * (max_cell_len[j])} |', end = '')
+            print('')
+
+    print('')
+
+from statistics import mean, median, stdev, variance
+from math import sqrt
+import sys
+
+def t_test(a_count, b_count, a_mean, b_mean, a_variance, b_variance, p = 0.002):
+    # Sources of values:
+    # - https://en.wikipedia.org/wiki/Student%27s_t-distribution
+    # - https://www.itl.nist.gov/div898/handbook/eda/section3/eda3672.htm
+    distribution = {}
+    distribution[0.002] = [
+        318.309, 22.327, 10.215, 7.173, 5.893, 5.208, 4.785, 4.501, 4.297, 4.144, # df = 1..10.
+        4.025, 3.930, 3.852, 3.787, 3.733, 3.686, 3.646, 3.610, 3.579, 3.552,     # df = 11..20.
+        3.527, 3.505, 3.485, 3.467, 3.450, 3.435, 3.421, 3.408, 3.396, 3.385,     # df = 21..30.
+        3.375, 3.365, 3.356, 3.348, 3.340, 3.333, 3.326, 3.319, 3.313, 3.307,     # df = 31..40.
+        3.301, 3.296, 3.291, 3.286, 3.281, 3.277, 3.273, 3.269, 3.265, 3.261,     # df = 41..50.
+        3.258, 3.255, 3.251, 3.248, 3.245, 3.242, 3.239, 3.237, 3.234, 3.232,     # df = 51..60.
+        3.229, 3.227, 3.225, 3.223, 3.220, 3.218, 3.216, 3.214, 3.213, 3.211,     # df = 61..70.
+        3.209, 3.207, 3.206, 3.204, 3.202, 3.201, 3.199, 3.198, 3.197, 3.195,     # df = 71..80.
+        3.194, 3.193, 3.191, 3.190, 3.189, 3.188, 3.187, 3.185, 3.184, 3.183,     # df = 81..90.
+        3.182, 3.181, 3.180, 3.179, 3.178, 3.177, 3.176, 3.175, 3.175, 3.174,     # df = 91..100.
+        3.090,                                                                    # df = ∞.
+    ]
+
+    volatility_coefficient = 0.25 # Tuning for the execution environment.
+
+    mean_difference = abs(a_mean - b_mean)
+    standard_error = sqrt(a_variance / a_count + b_variance / b_count)
+    t_value = mean_difference / standard_error
+    t_value *= volatility_coefficient
+
+    assert(a_count > 1 and b_count > 1)
+    df = pow(a_variance / a_count + b_variance / b_count, 2) / (
+             (1 / (a_count - 1)) * pow(a_variance / a_count, 2) +
+             (1 / (b_count - 1)) * pow(b_variance / b_count, 2)
+         )
+    t_value_critical = distribution[p][min(int(df) - 1, len(distribution[p]) - 1)]
+
+    if t_value > t_value_critical:
+        if a_mean > b_mean:
+            result = 'Regression' if t_value > t_value_critical * 1.5 else 'Suspecious'
+        else:
+            result = 'Improvement' if t_value > t_value_critical * 1.5 else 'Uncertain'
+        return f"{result} (t-value {t_value:.2f} > {t_value_critical:.2f})"
+    else:
+        return "~"
+
+def get_stats(fname):
+    s = open(fname).read()
+
+    test_results = {}
+
+    for l in s.splitlines():
+        if len(l) == 0:
+            continue
+        name, result, _ = l.split()
+        if name not in test_results:
+            test_results[name] = []
+        test_results[name].append(float(result))
+
+    test_stats = {}
+
+    for name, results in test_results.items():
+        test_stats[name] = {}
+        test_stats[name]['count'] = len(results)
+        test_stats[name]['min'] = min(results)
+        test_stats[name]['max'] = max(results)
+        test_stats[name]['mean'] = mean(results)
+        test_stats[name]['median'] = median(results)
+        test_stats[name]['variance'] = variance(results)
+
+        sorted_data = sorted(results)
+        test_stats[name]['90%'] = sorted_data[int(len(sorted_data) * 0.90)]
+        test_stats[name]['95%'] = sorted_data[int(len(sorted_data) * 0.95)]
+        test_stats[name]['99%'] = sorted_data[int(len(sorted_data) * 0.99)]
+
+        min_ = test_stats[name]['min']
+        avg_ = test_stats[name]['mean']
+        disp_ = avg_ - min_;
+        test_stats[name]['disp%'] = 100.0 / avg_ * disp_
+        test_stats[name]['stdev%'] = 100.0 / avg_ * stdev(results)
+
+    return test_stats
+
+test_stats_old = get_stats(sys.argv[1])
+test_stats_new = get_stats(sys.argv[2]) if len(sys.argv) > 2 else test_stats_old
+
+table = [['test', '50%', 'disp', 'stdev', 't-test']]
+for name in test_stats_old:
+    assert(name in test_stats_old)
+    assert(name in test_stats_new)
+
+    stats_old = test_stats_old[name]
+    stats_new = test_stats_new[name]
+
+    def stat(name):
+        old = '{:.2f}'.format(stats_old[name])
+        new = '{:.2f}'.format(stats_new[name])
+        diff = get_diff(stats_old[name], stats_new[name], reverse = True)
+        return old, new, diff
+
+    def merge(old, new, diff):
+        return f'{old} / {new} ({diff})'
+
+    t_mean_old, t_mean_new, t_mean_diff = stat('mean')
+    t_median_old, t_median_new, t_median_diff = stat('median')
+    t_p90_old, t_p90_new, t_p90_diff = stat('90%')
+    t_p95_old, t_p95_new, t_p95_diff = stat('95%')
+    t_p99_old, t_p99_new, t_p99_diff = stat('99%')
+
+    t_disp = '{:.2f}% / {:.2f}%'.format(stats_old['disp%'], stats_new['disp%'])
+    t_stdev = '{:.2f}% / {:.2f}%'.format(stats_old['stdev%'], stats_new['stdev%'])
+
+    t_mean = merge(t_mean_old, t_mean_new, t_mean_diff)
+    t_median = merge(t_median_old, t_median_new, t_median_diff)
+
+    t_test_result = t_test(stats_old['count'], stats_new['count'],
+                           stats_old['mean'], stats_new['mean'],
+                           stats_old['variance'], stats_new['variance'])
+
+    table.append([name, t_median, t_disp, t_stdev, t_test_result])
+    name = ''
+
+print_table(table)


### PR DESCRIPTION
These are used to prevent regressions in the box and simplify its performance analysis:
- memtx_tree.lua
- memtx_tree_rv.lua

In order to check the benchmark results a new compare_ci.py tool is introduced: it uses the student's t-test in order to check if the difference between measurements is significant.

NO_DOC=perf test
NO_TEST=perf test
NO_CHANGELOG=perf test