### PR TITLE
test: fix several more tests after the luatest bump

### DIFF
--- a/test/box-luatest/gh_6539_log_user_space_empty_or_nil_select_test.lua
+++ b/test/box-luatest/gh_6539_log_user_space_empty_or_nil_select_test.lua
@@ -115,7 +115,9 @@ for _, eng in pairs{'memtx', 'vinyl'} do
                          'set'):format(eng))
         end
 
-        local log_file = g.server:eval('return box.cfg.log')
+        local log_file = g.server:exec(function()
+            return rawget(_G, 'box_cfg_log_file') or box.cfg.log
+        end)
         for _, call_fmt in pairs(dangerous_call_fmts) do
             local call = call_fmt:format(space)
             g.server:eval(call)

--- a/test/box-luatest/gh_7231_memtx_hash_idx_gt_iter_deprecation_test.lua
+++ b/test/box-luatest/gh_7231_memtx_hash_idx_gt_iter_deprecation_test.lua
@@ -31,7 +31,9 @@ g.test_memtx_hash_idx_iter_gt_deprecation = function(cg)
                                 "not be used. It will be removed in a " ..
                                 "future Tarantool release."
     t.assert_is_not(cg.server:grep_log(deprecation_warning, 256), nil)
-    local log_file = g.server:exec(function() return box.cfg.log end)
+    local log_file = g.server:exec(function()
+        return rawget(_G, 'box_cfg_log_file') or box.cfg.log
+    end)
     fio.truncate(log_file)
     cg.server:exec(function()
         box.space.s:select({}, {iterator = 'GT'})

--- a/test/replication-luatest/gh_10088_apply_deletion_of_replica_from_cluster_on_deleted_replica_test.lua
+++ b/test/replication-luatest/gh_10088_apply_deletion_of_replica_from_cluster_on_deleted_replica_test.lua
@@ -37,7 +37,9 @@ end)
 -- Also test the behaviour of the deleted replica after recovery.
 g_two_member_cluster.test_deletion = function(cg)
     local replica_id = cg.replica:get_instance_id()
-    local log_file = cg.master:exec(function() return box.cfg.log end)
+    local log_file = cg.master:exec(function()
+        return rawget(_G, 'box_cfg_log_file') or box.cfg.log
+    end)
     fio.truncate(log_file)
     cg.master:exec(function(replica_id)
         t.assert(box.space._cluster:delete{replica_id})


### PR DESCRIPTION
The test gh_10088 was committed in parallel with the luatest bump and thus slipped from the post-bump tests fixup in commit cfd4bf4685de ("test: adapt tests to the new luatest version"). Fix it now.

NO_CHANGELOG=test
NO_TEST=test
NO_DOC=test