### PR TITLE
lua: introduce protobuf decoder module

### DIFF
--- a/changelogs/unreleased/protobuf_decoder_module.md
+++ b/changelogs/unreleased/protobuf_decoder_module.md
@@ -1,0 +1,3 @@
+## feature/lua
+
+* Introduced a Lua implementation of the protobuf decoder (gh-9844).

--- a/src/lua/protobuf_wireformat.lua
+++ b/src/lua/protobuf_wireformat.lua
@@ -2,15 +2,37 @@ local ffi = require('ffi')
 local int64_t = ffi.typeof('int64_t')
 local uint64_t = ffi.typeof('uint64_t')
 
-local WIRE_TYPE_VARINT = 0
-local WIRE_TYPE_I64 = 1
-local WIRE_TYPE_LEN = 2
--- SGROUP (3) and EGROUP (4) are deprecated in proto3.
-local WIRE_TYPE_I32 = 5
-
 local NUMERIC_DEFAULT = 0
 local STRING_DEFAULT = ''
 local BOOL_DEFAULT = false
+
+-- Maximum length of encoded varint is ten bytes
+local MAX_VARINT_LEN = 10
+
+-- Maximum value for cast decoded varint to number
+local DBL_INT_MAX = 1e14 - 1
+
+local VARINT = {
+    id = 0,
+    name = 'varint',
+}
+
+local I64 = {
+    id = 1,
+    name = 'I64',
+}
+
+local LEN = {
+    id = 2,
+    name = 'len',
+}
+
+local I32 = {
+    id = 5,
+    name = 'I32',
+}
+
+local types = {[0] = VARINT, [1] = I64, [2] = LEN, [5] = I32}
 
 -- {{{ Helpers
 
@@ -21,11 +43,21 @@ local function as_float(value)
     return ffi.string(ffi.cast('char *', p), 4)
 end
 
+-- Number representation of IEEE 754 32-bit value.
+local function from_float(value)
+    return ffi.cast('float *', value)[0]
+end
+
 -- 64-bit IEEE 754 representation of the given number.
 local function as_double(value)
     local p = ffi.new('double[1]')
     p[0] = value
     return ffi.string(ffi.cast('char *', p), 8)
+end
+
+-- Number representation of IEEE 754 64-bit value.
+local function from_double(value)
+    return ffi.cast('double *', value)[0]
 end
 
 -- 32-bit two's complement representation of the given integral number.
@@ -46,6 +78,15 @@ local function as_int32(value)
     return ffi.string(ffi.cast('char *', p), 4)
 end
 
+-- Number representation of 32-bit two's complement value.
+local function extract_uint32(value)
+    return ffi.cast('uint32_t *', value)[0]
+end
+
+local function extract_int32(value)
+    return ffi.cast('int32_t *', value)[0]
+end
+
 -- 64-bit two's complement representation of the given integral number.
 local function as_int64(value)
     local ctype
@@ -62,6 +103,32 @@ local function as_int64(value)
     local p = ffi.new(ctype)
     p[0] = value
     return ffi.string(ffi.cast('char *', p), 8)
+end
+
+-- Number representation of 64-bit two's complement value.
+local function from_int64(value)
+    return ffi.cast('uint64_t *', value)[0]
+end
+
+-- Converts input unsigned cdata into signed cdata or lua number if
+-- it fits lua number integer representation without rounding range.
+local function cast_signed_type(value)
+    assert(type(value) == 'cdata')
+    value = ffi.cast('int64_t', value)
+    if value < DBL_INT_MAX and value > -DBL_INT_MAX then
+        value = tonumber(value)
+    end
+    return value
+end
+
+-- Converts input unsigned cdata into lua number if it fits lua
+-- number integer representation without rounding range.
+local function cast_unsigned_type(value)
+    assert(type(value) == 'cdata')
+    if value < DBL_INT_MAX then
+        value = tonumber(value)
+    end
+    return value
 end
 
 -- Encode an integral value as VARINT without a tag.
@@ -97,6 +164,41 @@ local function encode_varint(value)
     return ffi.string(buf, size)
 end
 
+-- Reads a defined amount of bytes from decode context
+--
+-- This function makes boundary check when called.
+local function read_bytes(ctx, amount, bound)
+    if ctx.pos + amount - 1 > bound then
+        ctx.pos = bound
+        ctx:error('Reached end of message while decoding')
+    end
+    local res = string.sub(ctx.val, ctx.pos, ctx.pos + amount - 1)
+    ctx.pos = ctx.pos + amount
+    return res
+end
+
+-- Decode input value as VARINT without a tag.
+--
+-- Input value type: decode context.
+--
+-- This is a function to decode tag or integer data values.
+local function decode_varint(ctx, bound)
+    local msb
+    local res = 0
+    local len = 0
+    repeat
+        local payload = ffi.cast('uint64_t', read_bytes(ctx, 1, bound):byte())
+        if len >= MAX_VARINT_LEN then
+            ctx:error('Incorrect msb for varint to decode')
+        end
+        msb = bit.band(payload, 0x80)
+        payload = bit.band(payload, 0x7f)
+        res = bit.bor(res, bit.lshift(payload, 7 * len))
+        len = len + 1
+    until msb == 0
+    return res
+end
+
 -- Encode a tag byte.
 --
 -- Tag byte consists of the given field_id and the given Protocol Buffers
@@ -123,7 +225,37 @@ local function encode_int(field_id, value)
     if type(value) == 'boolean' then
         value = value and 1 or 0
     end
-    return encode_tag(field_id, WIRE_TYPE_VARINT) .. encode_varint(value)
+    return encode_tag(field_id, VARINT.id) .. encode_varint(value)
+end
+
+-- Decode an integral value encoded as VARINT using two complement encoding.
+--
+-- Input value types: decode context.
+--
+-- Used for Protocol Buffers types: int32, int64.
+local function decode_int(ctx, bound)
+    local res = decode_varint(ctx, bound)
+    return cast_signed_type(res)
+end
+
+-- Decode a tag byte.
+--
+-- Returns wire type as the first value and field_id as the second value.
+local function decode_tag(ctx, bound)
+    local tag = decode_int(ctx, bound)
+    return bit.band(tag, 0x7), bit.rshift(tag, 3)
+end
+
+-- Return default value for input type.
+local function get_default(type)
+    assert(type ~= 'message')
+    if type == 'bool' then
+        return BOOL_DEFAULT
+    elseif type == 'string' or type == 'bytes' then
+        return STRING_DEFAULT
+    else
+        return NUMERIC_DEFAULT
+    end
 end
 
 -- Encode an integral value as VARINT using the "ZigZag" encoding.
@@ -140,6 +272,44 @@ local function encode_sint(field_id, value)
     end
 end
 
+-- Decode an integral value encoded as VARINT using the "ZigZag" encoding.
+--
+-- Input value types: decode context.
+--
+-- Used for Protocol Buffers types: sint32, sint64.
+local function decode_sint(ctx, bound)
+    local res = decode_varint(ctx, bound)
+    if res % 2 == 0 then
+        res = res / 2
+    else
+        res = -(res / 2) - 1
+    end
+    return cast_signed_type(res)
+end
+
+-- Decode an integral value encoded as VARINT using two complement encoding.
+--
+-- Input value types: decode context.
+--
+-- Used for Protocol Buffers types: uint32, uint64.
+local function decode_uint(ctx, bound)
+    local res = decode_varint(ctx, bound)
+    return cast_unsigned_type(res)
+end
+
+-- Decode an boolean value encoded as VARINT using two complement encoding.
+--
+-- Input value type: decode context.
+--
+-- Used for Protocol Buffers types: bool.
+local function decode_bool(ctx, bound)
+    local payload = decode_varint(ctx, bound)
+    if payload == 1 then
+        return true
+    end
+    return false
+end
+
 -- Encode an integral value as I32.
 --
 -- Input value types: number (integral), cdata<int64_t>, cdata<uint64_t>.
@@ -149,7 +319,27 @@ local function encode_fixed32(field_id, value)
     if value == NUMERIC_DEFAULT then
         return ''
     end
-    return encode_tag(field_id, WIRE_TYPE_I32) .. as_int32(value)
+    return encode_tag(field_id, I32.id) .. as_int32(value)
+end
+
+-- Decode an unsigned integral value encoded as I32.
+--
+-- Input value type: decode context.
+--
+-- Used for Protocol Buffers types: fixed32.
+local function decode_fixed32(ctx, bound)
+    local res = read_bytes(ctx, 4, bound)
+    return tonumber(extract_uint32(res))
+end
+
+-- Decode a signed integral value encoded as I32.
+--
+-- Input value type: decode context.
+--
+-- Used for Protocol Buffers types: sfixed32.
+local function decode_sfixed32(ctx, bound)
+    local res = read_bytes(ctx, 4, bound)
+    return tonumber(extract_int32(res))
 end
 
 -- Encode a floating point value as I32.
@@ -161,7 +351,17 @@ local function encode_float(field_id, value)
     if value == NUMERIC_DEFAULT then
         return ''
     end
-    return encode_tag(field_id, WIRE_TYPE_I32) .. as_float(value)
+    return encode_tag(field_id, I32.id) .. as_float(value)
+end
+
+-- Decode a floating point value encoded as I32.
+--
+-- Input value type: decode context.
+--
+-- Used for Protocol Buffers type: float.
+local function decode_float(ctx, bound)
+    local res = read_bytes(ctx, 4, bound)
+    return from_float(res)
 end
 
 -- Encode an integral value as I64.
@@ -173,7 +373,27 @@ local function encode_fixed64(field_id, value)
     if value == NUMERIC_DEFAULT then
         return ''
     end
-    return encode_tag(field_id, WIRE_TYPE_I64) .. as_int64(value)
+    return encode_tag(field_id, I64.id) .. as_int64(value)
+end
+
+-- Decode an unsigned integral value encoded as I64.
+--
+-- Input value type: decode context.
+--
+-- Used for Protocol Buffers types: fixed64.
+local function decode_fixed64(ctx, bound)
+    local res = read_bytes(ctx, 8, bound)
+    return cast_unsigned_type(from_int64(res))
+end
+
+-- Decode a signed integral value encoded as I64.
+--
+-- Input value type: decode context.
+--
+-- Used for Protocol Buffers types: sfixed64.
+local function decode_sfixed64(ctx, bound)
+    local res = read_bytes(ctx, 8, bound)
+    return cast_signed_type(from_int64(res))
 end
 
 -- Encode a floating point value as I64.
@@ -185,7 +405,17 @@ local function encode_double(field_id, value)
     if value == NUMERIC_DEFAULT then
         return ''
     end
-    return encode_tag(field_id, WIRE_TYPE_I64) .. as_double(value)
+    return encode_tag(field_id, I64.id) .. as_double(value)
+end
+
+-- Decode a floating point value encoded as I64.
+--
+-- Input value type: decode context.
+--
+-- Used for Protocol Buffers type: float.
+local function decode_double(ctx, bound)
+    local res = read_bytes(ctx, 8, bound)
+    return from_double(res)
 end
 
 -- Encode a string value as LEN.
@@ -199,9 +429,21 @@ local function encode_len(field_id, value, ex_presence)
         return ''
     end
     return string.format('%s%s%s',
-        encode_tag(field_id, WIRE_TYPE_LEN),
+        encode_tag(field_id, LEN.id),
         encode_varint(string.len(value)),
         value)
+end
+
+-- Decode a string value encoded as LEN.
+--
+-- Input value type: decode context.
+--
+-- Used for Protocol Buffers types: string, bytes, embedded message, packed
+-- repeated fields.
+local function decode_len(ctx, bound)
+    local len = decode_int(ctx, bound)
+    local res = read_bytes(ctx, len, bound)
+    return res
 end
 
 -- }}} API functions
@@ -214,4 +456,22 @@ return{
     encode_double = encode_double,
     encode_fixed64 = encode_fixed64,
     encode_len = encode_len,
+    get_default = get_default,
+    decode_tag = decode_tag,
+    decode_int = decode_int,
+    decode_sint = decode_sint,
+    decode_uint = decode_uint,
+    decode_bool = decode_bool,
+    decode_float = decode_float,
+    decode_double = decode_double,
+    decode_fixed32 = decode_fixed32,
+    decode_sfixed32 = decode_sfixed32,
+    decode_fixed64 = decode_fixed64,
+    decode_sfixed64 = decode_sfixed64,
+    decode_len = decode_len,
+    VARINT = VARINT,
+    LEN = LEN,
+    I32 = I32,
+    I64 = I64,
+    types = types,
 }

--- a/test/app-luatest/protobuf_decoder_test.lua
+++ b/test/app-luatest/protobuf_decoder_test.lua
@@ -1,0 +1,517 @@
+local ffi = require('ffi')
+local t = require('luatest')
+local protobuf = require('protobuf')
+local g = t.group()
+
+local p = t.group('numeric_type_decoding', {
+    {type = 'int32', value = '\b\n', res = {val = 10}},
+    {type = 'sint32', value = '\b\x14', res = {val = 10}},
+    {type = 'uint32', value = '\b\n', res = {val = 10}},
+    {type = 'int64', value = '\b\n', res = {val = 10}},
+    {type = 'sint64', value = '\b\x14', res = {val = 10}},
+    {type = 'uint64', value = '\b\n', res = {val = 10}},
+    {type = 'bool', value = '\b\x01', res = {val = true}},
+    {type = 'float', value = '\r\0\0\0?', res = {val = 0.5}},
+    {type = 'double', value = '\t333333ӿ', res = {val = -0.3}},
+    {type = 'fixed32', value = '\r\n\0\0\0', res = {val = 10}},
+    {type = 'sfixed32', value = '\r\n\0\0\0', res = {val = 10}},
+    {type = 'fixed64', value = '\t\n\0\0\0\0\0\0\0', res = {val = 10}},
+    {type = 'sfixed64', value = '\t\n\0\0\0\0\0\0\0', res = {val = 10}},
+    {type = 'string', value = '\n\x04abcd', res = {val = 'abcd'}},
+    {type = 'bytes', value = '\n\x04abcd', res = {val = 'abcd'}},
+})
+
+p.test_numeric_type_decoding = function(cg)
+    local protocol = protobuf.protocol({
+        protobuf.message('test', {val = {cg.params.type, 1}})
+    })
+    local result = protocol:decode('test', cg.params.value)
+    t.assert_equals(result, cg.params.res)
+    t.assert_equals(type(result.val), type(cg.params.res.val))
+end
+
+g.test_minimum_value_decoding = function()
+    local testcases = {
+        {type = 'int32', value = '\b\x80\x80\x80\x80\xF8\xFF\xFF\xFF\xFF\x01',
+            res = {val = -2^31}},
+        {type = 'sint32', value = '\b\xFF\xFF\xFF\xFF\x0F',
+            res = {val = -2^31}},
+        {type = 'uint32', value = '\b\1', res = {val = 1}},
+        {type = 'int64', value = '\b\x80\x80\x80\x80\x80\x80\x80\x80\x80\x01',
+            res = {val = -2LL^63}},
+        {type = 'sint64', value = '\b\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01',
+            res = {val = -2LL^63}},
+        {type = 'uint64', value = '\b\1', res = {val = 1}},
+        {type = 'float', value = '\r\xFF\xFF\x7F\xFF',
+            res = {val = -0x1.fffffep+127}},
+        {type = 'double', value = '\t\xFF\xFF\xFF\xFF\xFF\xFF\xEF\xFF',
+            res = {val = -0x1.fffffffffffffp+1023}},
+        {type = 'fixed32', value = '\r\x01\0\0\0', res = {val = 1}},
+        {type = 'sfixed32', value = '\r\0\0\0\x80', res = {val = -2^31}},
+        {type = 'fixed64', value = '\t\x01\0\0\0\0\0\0\0', res = {val = 1}},
+        {type = 'sfixed64', value = '\t\0\0\0\0\0\0\0\x80',
+            res = {val = -2LL^63}},
+    }
+    for _, test in pairs(testcases) do
+        local protocol = protobuf.protocol({
+            protobuf.message('test', {val = {test.type, 1}})
+        })
+        local result = protocol:decode('test', test.value)
+        t.assert_equals(result, test.res)
+        t.assert_equals(type(result.val), type(test.res.val))
+        if type(test.res.val) == 'cdata' then
+            t.assert_equals(ffi.typeof(result.val), ffi.typeof(test.res.val))
+        end
+    end
+end
+
+g.test_maximum_value_decoding = function()
+    local testcases = {
+        {type = 'int32', value = '\b\xFF\xFF\xFF\xFF\a',
+            res = {val = 2^31 - 1}},
+        {type = 'sint32', value = '\b\xFE\xFF\xFF\xFF\x0F',
+            res = {val = 2^31 - 1}},
+        {type = 'uint32', value = '\b\xFF\xFF\xFF\xFF\x0F',
+            res = {val = 2^32 - 1}},
+        {type = 'int64', value = '\b\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F',
+            res = {val = 2LL^63 - 1}},
+        {type = 'sint64', value = '\b\xFE\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01',
+            res = {val = 2LL^63 - 1}},
+        {type = 'uint64', value = '\b\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01',
+            res = {val = 2ULL^64 - 1}},
+        {type = 'bool', value = '\b\x01', res = {val = true}},
+        {type = 'float', value = '\r\xFF\xFF\x7F\x7F',
+            res = {val = 0x1.fffffep+127}},
+        {type = 'double', value = '\t\xFF\xFF\xFF\xFF\xFF\xFF\xEF\x7F',
+            res = {val = 0x1.fffffffffffffp+1023}},
+        {type = 'fixed32', value = '\r\xFF\xFF\xFF\xFF',
+            res = {val = 2^32 - 1}},
+        {type = 'sfixed32', value = '\r\xFF\xFF\xFF\x7F',
+            res = {val = 2^31 - 1}},
+        {type = 'fixed64', value = '\t\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF',
+            res = {val = 2ULL^64 - 1}},
+        {type = 'sfixed64', value = '\t\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F',
+            res = {val = 2LL^63 - 1}},
+    }
+    for _, test in pairs(testcases) do
+        local protocol = protobuf.protocol({
+            protobuf.message('test', {val = {test.type, 1}})
+        })
+        local result = protocol:decode('test', test.value)
+        t.assert_equals(result, test.res)
+        t.assert_equals(type(result.val), type(test.res.val))
+        if type(test.res.val) == 'cdata' then
+            t.assert_equals(ffi.typeof(result.val), ffi.typeof(test.res.val))
+        end
+    end
+end
+
+g.test_repeated_field_decoding = function()
+    local testcases = {
+        {type = 'int32', value = '\n\x03\n\v\f', res = {val = {10, 11, 12}}},
+        {type = 'sint32', value = '\n\x03\x14\x16\x18',
+            res = {val = {10, 11, 12}}},
+        {type = 'uint32', value = '\n\x03\n\v\f', res = {val = {10, 11, 12}}},
+        {type = 'int64', value = '\n\x03\n\v\f', res = {val = {10, 11, 12}}},
+        {type = 'sint64', value = '\n\x03\x14\x16\x18',
+            res = {val = {10, 11, 12}}},
+        {type = 'uint64', value = '\n\x03\n\v\f', res = {val = {10, 11, 12}}},
+        {type = 'fixed32', value = '\n\f\n\0\0\0\v\0\0\0\f\0\0\0',
+            res = {val = {10, 11, 12}}},
+        {type = 'sfixed32', value = '\n\f\n\0\0\0\v\0\0\0\f\0\0\0',
+            res = {val = {10, 11, 12}}},
+        {type = 'fixed64', value = '\n\x10\n\0\0\0\0\0\0\0\v\0\0\0\0\0\0\0',
+            res = {val = {10, 11}}},
+        {type = 'sfixed64', value = '\n\x10\n\0\0\0\0\0\0\0\v\0\0\0\0\0\0\0',
+            res = {val = {10, 11}}},
+        {type = 'bool', value = '\n\x03\x01\x01\x01',
+            res = {val = {true, true, true}}},
+        {type = 'string', value = '\n\x03fuz\n\x03buz',
+            res = {val = {'fuz', 'buz'}}},
+        {type = 'bytes', value = '\n\x03fuz\n\x03buz',
+            res = {val = {'fuz', 'buz'}}},
+        {type = 'float', value = '\n\b\0\0\xC0?\0\0 @',
+            res = {val = {1.5, 2.5}}},
+        {type = 'double', value = '\n\x10\0\0\0\0\0\0\xF8?\0\0\0\0\0\0\x04@',
+            res = {val = {1.5, 2.5}}},
+    }
+    for _, test in pairs(testcases) do
+        local protocol = protobuf.protocol({
+            protobuf.message('test', {val = {'repeated ' .. test.type, 1}})
+        })
+        local result = protocol:decode('test', test.value)
+        t.assert_equals(result, test.res)
+    end
+end
+
+g.test_repeated_field_decoding_from_unpacked = function()
+    local testcases = {
+        {type = 'repeated int32', value = '\b\x01\b\x02\b\x03',
+            res = {val1 = {1, 2, 3}}},
+        {type = 'repeated bool', value = '\b\x01\b\x01',
+            res = {val1 = {true, true}}},
+        {type = 'repeated int64', value = '\b\n\b\v\b\f',
+            res = {val1 = {10, 11, 12}}}
+    }
+    for _, test in pairs(testcases) do
+        local protocol = protobuf.protocol({
+            protobuf.message('test', {val1 = {test.type, 1}})
+        })
+        local result = protocol:decode('test', test.value)
+        t.assert_equals(result, test.res)
+    end
+end
+
+g.test_decode_unpacked_repeated_field_out_of_order = function()
+    local protocol = protobuf.protocol({
+        protobuf.message('test_message', {
+            val1 = {'int32', 1},
+            val2 = {'repeated int32', 2},
+        })
+    })
+    local encoded_msg = '\x10\v\b\n\x10\f\x10\r'
+    local expected_res = {val1 = 10, val2 = {11, 12, 13}}
+    local result = protocol:decode('test_message', encoded_msg)
+    t.assert_equals(result, expected_res)
+end
+
+g.test_repeated_enum_decoding = function()
+    local protocol = protobuf.protocol({
+        protobuf.message('test_message', {
+            val1 = {'repeated test_enum', 1},
+        }),
+        protobuf.enum('test_enum', {
+            ok = 0,
+            err1 = 1,
+            err2 = 2,
+        })
+    })
+    local encoded_msg = '\b\x01\b\x02\b\x03'
+    local expected_res = {val1 = {'err1', 'err2', 3}}
+    local result = protocol:decode('test_message', encoded_msg)
+    t.assert_equals(result, expected_res)
+end
+
+g.test_repeated_message_decoding = function()
+    local protocol = protobuf.protocol({
+        protobuf.message('first_message', {
+            val1 = {'repeated second_message', 1},
+        }),
+        protobuf.message('second_message', {
+            val1 = {'int32', 1},
+            val2 = {'repeated string', 2},
+        })
+    })
+    local encoded_msg = '\n\f\x12\x03fuz\x12\x03buz\b\x01\n\f\x12\x03buz' ..
+        '\x12\x03fuz\b\x02'
+    local expected_res = {val1 = {{val1 = 1, val2 = {"fuz", "buz"}},
+        {val1 = 2, val2 = {"buz", "fuz"}}}}
+    local result = protocol:decode('first_message', encoded_msg)
+    t.assert_equals(result, expected_res)
+end
+
+local p = t.group('default value encoding', t.helpers.matrix({
+    value = {''},
+    arg = {
+        {type = 'int32', res = {val = 0}},
+        {type = 'sint32', res = {val = 0}},
+        {type = 'uint32', res = {val = 0}},
+        {type = 'int64', res = {val = 0}},
+        {type = 'sint64', res = {val = 0}},
+        {type = 'uint64', res = {val = 0}},
+        {type = 'bool', res = {val = false}},
+        {type = 'float', res = {val = 0}},
+        {type = 'double', res = {val = 0}},
+    }
+}))
+
+p.test_default_value_encoding = function(cg)
+    local protocol = protobuf.protocol({
+        protobuf.message('test', {val = {cg.params.arg.type, 1}})
+    })
+    local result = protocol:decode('test', cg.params.value,
+        {set_default = true})
+    t.assert_equals(result, cg.params.arg.res)
+end
+
+g.test_empty_input_set_default_false = function()
+    local protocol = protobuf.protocol({
+        protobuf.message('test', {val = {'int32', 1}})
+    })
+    local result = protocol:decode('test', '')
+    t.assert_equals(result, {})
+end
+
+g.test_decode_embedded_message = function()
+    local protocol = protobuf.protocol({
+        protobuf.message('first_message', {
+            val1 = {'int32', 1},
+            val2 = {'second_message', 2},
+        }),
+        protobuf.message('second_message', {
+            val1 = {'int32', 1},
+            val2 = {'string', 2},
+            val3 = {'fixed64', 3},
+        })
+    })
+    local encoded_msg = '\x12\x13\x19\x05\0\0\0\0\0\0\0\b\f\x12\x06fuzbuz' ..
+        '\b\xF6\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01'
+    local expected_res = {val1 = -10,
+        val2 = {val1 = 12, val2 = 'fuzbuz', val3 = 5}}
+    local result = protocol:decode('first_message', encoded_msg)
+    t.assert_equals(result, expected_res)
+end
+
+g.test_decode_embedded_message_with_set_default = function()
+    local protocol = protobuf.protocol({
+        protobuf.message('first_message', {
+            val1 = {'int32', 1},
+            val2 = {'second_message', 2},
+        }),
+        protobuf.message('second_message', {
+            val1 = {'int32', 1},
+            val2 = {'string', 2},
+            val3 = {'fixed64', 3},
+        })
+    })
+    local encoded_msg = '\x12\a\x12\x03xyz\b\n'
+    local expected_res = {val1 = 0,
+        val2 = {val1 = 10, val2 = 'xyz', val3 = 0}}
+    local result = protocol:decode('first_message', encoded_msg,
+        {set_default = true})
+    t.assert_equals(result, expected_res)
+end
+
+g.test_decode_embedded_resursive_message_with_set_default = function()
+    local protocol = protobuf.protocol({
+        protobuf.message('first_message', {
+            val1 = {'int32', 1},
+            val2 = {'first_message', 2},
+            val3 = {'int32', 3},
+        })
+    })
+    local encoded_msg = '\x12\x04\x18\f\b\v\b\n'
+    local expected_res = {val1 = 10, val2 = {val1 = 11, val3 = 12}, val3 = 0}
+    local result = protocol:decode('first_message', encoded_msg,
+        {set_default = true})
+    t.assert_equals(result, expected_res)
+end
+
+g.test_decode_enum_with_set_default = function()
+    local protocol = protobuf.protocol({
+        protobuf.message('test_message', {
+            val1 = {'int32', 1},
+            val2 = {'test_enum', 2},
+        }),
+        protobuf.enum('test_enum', {
+            ok = 0,
+            err1 = 1,
+        })
+    })
+    local encoded_msg = '\b\n'
+    local expected_res = {val1 = 10, val2 = 'ok'}
+    local result = protocol:decode('test_message', encoded_msg,
+        {set_default = true})
+    t.assert_equals(result, expected_res)
+end
+
+g.test_decode_enum = function()
+    local protocol = protobuf.protocol({
+        protobuf.message('test_message', {
+            val1 = {'int32', 1},
+            val2 = {'test_enum', 2},
+        }),
+        protobuf.enum('test_enum', {
+            ok = 0,
+            err = 1,
+        })
+    })
+    local encoded_msg = '\x10\x01\b\n'
+    local expected_res = {val1 = 10, val2 = 'err'}
+    local result = protocol:decode('test_message', encoded_msg)
+    t.assert_equals(result, expected_res)
+end
+
+g.test_decode_unknown_field_varint_and_len = function()
+    local protocol = protobuf.protocol({
+        protobuf.message('test', {
+            val3 = {'fixed32', 3},
+            val4 = {'fixed64', 4},
+        })
+    })
+    local encoded_msg = '\x1D\n\0\x01\0\n\x03xyz!\x80\xF4\x01\0\0\0\0\0\x10\n'
+    local expected_res = {_unknown_fields = {'\n\x03xyz', '\x10\n'},
+        val3 = 65546, val4 = 128128}
+    local result = protocol:decode('test', encoded_msg)
+    t.assert_equals(result, expected_res)
+end
+
+g.test_decode_unknown_field_fixed32_and_fixed64 = function()
+    local protocol = protobuf.protocol({
+        protobuf.message('test', {
+            val1 = {'bytes', 1},
+            val2 = {'int64', 2},
+        })
+    })
+    local encoded_msg = '\x1D\n\0\x01\0\n\x03xyz!\x80\xF4\x01\0\0\0\0\0\x10\n'
+    local expected_res = {_unknown_fields = {'\x1D\n\0\x01\0',
+        '!\x80\xF4\x01\0\0\0\0\0'}, val1 = "xyz", val2 = 10}
+    local result = protocol:decode('test', encoded_msg)
+    t.assert_equals(result, expected_res)
+end
+
+g.test_exception_decoded_varint_data_out_of_range = function()
+    local testcases = {
+        {type = 'int32', data = '\b\x80\x80\x80\x80\b', res = 2^31},
+        {type = 'int32', data = '\b\xFF\xFF\xFF\xFF\xF7\xFF\xFF\xFF\xFF\x01',
+            res = -2^31 - 1},
+        {type = 'uint32', data = '\b\x80\x80\x80\x80\x10', res = 2^32},
+        {type = 'sint32', data = '\b\x80\x80\x80\x80\x10', res = 2^31},
+        {type = 'sint32', data = '\b\x81\x80\x80\x80\x10', res = -2^31 - 1},
+    }
+    for _, test in pairs(testcases) do
+        local protocol = protobuf.protocol({
+            protobuf.message('test', {val = {test.type, 1}})
+        })
+        local msg = 'Input data for "val" field is "' .. test.res ..
+            '" and do not fit in "' .. test.type .. '"'
+        t.assert_error_msg_contains(msg, protocol.decode, protocol,
+            'test', test.data)
+    end
+end
+
+g.test_exception_decoding_data_with_wrong_wire_type = function()
+    local testcases = {
+        {type = 'fixed32', encoded_wire_type = 'varint',
+            expected_wire_type = 'I32', data = '\b\n'},
+        {type = 'fixed32', encoded_wire_type = 'I64',
+            expected_wire_type = 'I32', data = '\t\n\0\0\0\0\0\0\0'},
+        {type = 'fixed32', encoded_wire_type = 'len',
+            expected_wire_type = 'I32', data = '\n\x03fuz'},
+        {type = 'string', encoded_wire_type = 'varint',
+            expected_wire_type = 'len', data = '\b\n'},
+        {type = 'string', encoded_wire_type = 'I64',
+            expected_wire_type = 'len', data = '\t\n\0\0\0\0\0\0\0'},
+        {type = 'string', encoded_wire_type = 'I32',
+            expected_wire_type = 'len', data = '\r\n\0\0\0'},
+        {type = 'fixed64', encoded_wire_type = 'varint',
+            expected_wire_type = 'I64', data = '\b\n'},
+        {type = 'fixed64', encoded_wire_type = 'I32',
+            expected_wire_type = 'I64', data = '\r\n\0\0\0'},
+        {type = 'fixed64', encoded_wire_type = 'len',
+            expected_wire_type = 'I64', data = '\n\x03fuz'},
+    }
+    for _, test in pairs(testcases) do
+        local protocol = protobuf.protocol({
+            protobuf.message('test', {val = {test.type, 1}})
+        })
+        local msg = '[test.val] decoding error on position 2: Value for ' ..
+            'field was encoded as "' .. test.encoded_wire_type .. '" and ' ..
+            'can`t be decoded as "' .. test.expected_wire_type .. '"'
+        t.assert_error_msg_contains(msg, protocol.decode, protocol,
+            'test', test.data)
+    end
+end
+
+g.test_exception_wrong_protobuf_type = function()
+    local protocol = protobuf.protocol({
+        protobuf.message('test', {val = {'int32', 1}})
+    })
+    local msg = '[test.val] decoding error on position 2: ' ..
+        'Decoding data contains incorrect protobuf type: 4'
+    local data = '\f\x01'
+    t.assert_error_msg_contains(msg, protocol.decode, protocol, 'test', data)
+end
+
+g.test_exception_wrong_protocol_name = function()
+    local protocol = protobuf.protocol({
+        protobuf.message('test', {val = {'int32', 1}})
+    })
+    local msg = 'There is no message or enum named "xtest"' ..
+        ' in the given protocol'
+    local data = '\b\n'
+    t.assert_error_msg_contains(msg, protocol.decode, protocol, 'xtest', data)
+end
+
+g.test_exception_attempt_to_decode_enum = function()
+    local protocol = protobuf.protocol({
+        protobuf.message('test', {val = {'int32', 1}}),
+        protobuf.enum('xtest', {ok = 0,
+            error1 = 1,})
+    })
+    local msg = 'Attempt to decode enum "xtest" as a top level message'
+    local data = '\b\n'
+    t.assert_error_msg_contains(msg, protocol.decode, protocol, 'xtest', data)
+end
+
+g.test_exception_reserved_id = function()
+    local protocol = protobuf.protocol({
+        protobuf.message('test', {val = {'int32', 1}})
+    })
+    local msg = 'Id 19015 in \"test.<field>\" field ' ..
+        'is in reserved id range [19000, 19999]'
+    local data = '\xB8\xA4\t\n'
+    t.assert_error_msg_contains(msg, protocol.decode, protocol, 'test', data)
+end
+
+g.test_exception_not_valid_id = function()
+    local protocol = protobuf.protocol({
+        protobuf.message('test', {val = {'int32', 1}})
+    })
+    local msg = 'Id 0 in \"test.<field>\" field is out of range [1; 536870911]'
+    local data = '\0\n'
+    t.assert_error_msg_contains(msg, protocol.decode, protocol, 'test', data)
+end
+
+g.test_exception_incorrect_msb = function()
+    local protocol = protobuf.protocol({
+        protobuf.message('test', {val = {'int32', 1}})
+    })
+    local msg = '[test.val] decoding error on position 13: ' ..
+        'Incorrect msb for varint to decode'
+    local data = '\b\x80\xF0\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01'
+    t.assert_error_msg_contains(msg, protocol.decode, protocol, 'test', data)
+end
+
+g.test_exception_interrupted_message = function()
+    local testcases = {
+        {type = 'int32', data = '\b\xC0\xB5', num = 3},
+        {type = 'int64', data = '\b\x80\xEB', num = 3},
+        {type = 'float', data = '\rI \xF1', num = 4},
+        {type = 'double', data = '\t/\xDD$\x06\x81', num = 6},
+        {type = 'fixed32', data = '\r\x01\0\0', num = 4},
+        {type = 'sfixed32', data = '\r\x01\0\0', num = 4},
+        {type = 'fixed64', data = '\t\x0F\0\0\0\0\0\0', num = 8},
+        {type = 'sfixed64', data = '\t\x0F\0\0\0\0\0\0', num = 8},
+        {type = 'string', data = '\n\x03fu', num = 4}
+    }
+    for _, test in pairs(testcases) do
+        local protocol = protobuf.protocol({
+            protobuf.message('test', {val = {test.type, 1}})
+        })
+        local msg = ('[test.val] decoding error on position %d: ')
+            :format(test.num) .. 'Reached end of message while decoding'
+        t.assert_error_msg_contains(msg, protocol.decode, protocol, 'test',
+            test.data)
+    end
+end
+
+-- In this test embedded message is encoded between two varint fields.
+-- Last byte in embedded message contains msb for varint field.
+-- This byte was intentionally deleted. This leads to an error
+-- when decoder runs out of embedded message boundary while trying to
+-- decode varint without msb.
+g.test_exception_damaged_embedded_message = function()
+    local protocol = protobuf.protocol({
+        protobuf.message('test_message', {
+            val1 = {'int32', 1},
+            val2 = {'test_message', 2},
+            val3 = {'int32', 20000},
+        })
+    })
+    local data = '\b\f\x12\a\x80\xE2\t\x01\b\xF4\x80\xE2\t\x19'
+    local msg = '[test_message.val2.val1] decoding error on position 12: ' ..
+        'Reached end of message while decoding'
+    t.assert_error_msg_contains(msg, protocol.decode, protocol,
+        'test_message', data)
+end

--- a/test/app-luatest/protobuf_utils.lua
+++ b/test/app-luatest/protobuf_utils.lua
@@ -1,0 +1,23 @@
+local function strings_deepequal(str1, str2)
+    if string.len(str1) ~= string.len(str2) then
+        error(string.format('Expected and result strings are not ' ..
+            'equal by length: %s, %s', str1:hex(), str2:hex()))
+    end
+    local charCount = {}
+    for i = 1, #str1 do
+        local char = str1:sub(i, i)
+        charCount[char] = (charCount[char] or 0) + 1
+    end
+    for i = 1, #str2 do
+        local char = str2:sub(i, i)
+        if not charCount[char] or charCount[char] == 0 then
+            error(string.format('Expected and result strings are not ' ..
+                'equal: %s, %s', str1:hex(), str2:hex()))
+        end
+        charCount[char] = charCount[char] - 1
+    end
+end
+
+return{
+    strings_deepequal = strings_deepequal
+}


### PR DESCRIPTION
Decoder can decode data according to existing protocol.
As a result a lua table with decoded values is returned.
This table can be used for encode method as an input
value.

Part of https://github.com/tarantool/tarantool/issues/9844

@TarantoolBot document
Title: Protobuf module decoder
Product: Tarantool
Root document: -

Protobuf decoder API

Introducing protobuf decoder. All the Protocol Buffers wire
types are supported except group start/end, which are
deprecated in proto3. To decode data you need to select a
protocol according to which data will be decoded.

Decoder takes a byte string which contains encoded protobuf
data and returns a lua table, which contains all existing in
binary values. Default values or not assigned field will be
absent in result table.

Here is an example of use:

```lua
result = protocol:decode('MessageName', binary_string)
```

If you need not assigned fields to have a value you can set
'set_default' flag in options, according to example:

```lua
result = protocol:decode('MessageName', binary_string,
    {set_default = true})
```

With `set_default` flag set the result table will have default
values for all fields. Scalar type fields or enums are assigned
with default values described here:
https://protobuf.dev/programming-guides/proto3/#default.
Default value for repeated field is an empty table and default
value for message is nil.