### PR TITLE
memtx: allow to abort checkpoint if it wasn't started

### DIFF
--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -1254,8 +1254,9 @@ static void
 memtx_engine_abort_checkpoint(struct engine *engine)
 {
 	struct memtx_engine *memtx = (struct memtx_engine *)engine;
+	if (memtx->checkpoint == NULL)
+		return;
 
-	assert(memtx->checkpoint != NULL);
 	assert(!xlog_is_open(&memtx->checkpoint->snap));
 
 	coio_call(memtx_engine_abort_checkpoint_f, &memtx->checkpoint->snap);

--- a/test/box-luatest/gh_10265_memtx_checkpoint_fail_assertion_test.lua
+++ b/test/box-luatest/gh_10265_memtx_checkpoint_fail_assertion_test.lua
@@ -1,0 +1,28 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_memtx_checkpoint_fail_assertion = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        s:create_index('pk')
+        s:replace{0, 0}
+        -- Set error injection to iterator creation to fail
+        -- memtx checkpoint right from the start.
+        box.error.injection.set('ERRINJ_INDEX_ITERATOR_NEW', true)
+        local ok = pcall(box.snapshot)
+        box.error.injection.set('ERRINJ_INDEX_ITERATOR_NEW', false)
+        t.assert_equals(ok, false, "Snapshot must fail")
+    end)
+end


### PR DESCRIPTION
When checkpoint fails, we abort it in all engines even if it wasn't started succesfully. If it fails right from the start so that checkpoint in memtx wasn't started, assertion in `memtx_engine_abort_checkpoint` fails - memtx doesn't expect that checkpoint will be aborted if it failed to start. Let's do the same thing as vinyl does - no-op if there is no checkpoint in progress.

Closes #10265
