### PR TITLE
[backport 2.11] Add stubs for file FETCH_SNAPSHOT

### DIFF
--- a/changelogs/unreleased/gh-9401-anon-replica-synchro.md
+++ b/changelogs/unreleased/gh-9401-anon-replica-synchro.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed anonymous replicas not receiving the synchronous transaction queue state
+  during join (gh-9401).

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -870,8 +870,11 @@ applier_fetch_snapshot(struct applier *applier)
 	struct iostream *io = &applier->io;
 	struct xrow_header row;
 
-	memset(&row, 0, sizeof(row));
-	row.type = IPROTO_FETCH_SNAPSHOT;
+	struct fetch_snapshot_request req = {
+		.version_id = tarantool_version_id(),
+	};
+	RegionGuard region_guard(&fiber()->gc);
+	xrow_encode_fetch_snapshot(&row, &req);
 	coio_write_xrow(io, &row);
 
 	applier_set_state(applier, APPLIER_WAIT_SNAPSHOT);

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -789,7 +789,7 @@ applier_wait_snapshot(struct applier *applier)
 		 * vclock in bootstrap_from_master()
 		 */
 		struct vclock vclock;
-		xrow_decode_vclock_xc(&row, &vclock);
+		xrow_decode_vclock_ignore0_xc(&row, &vclock);
 		box_init_instance_vclock(&vclock);
 	}
 
@@ -847,7 +847,7 @@ applier_wait_snapshot(struct applier *applier)
 				 * this vclock is not used.
 				 */
 				struct vclock vclock;
-				xrow_decode_vclock_xc(&row, &vclock);
+				xrow_decode_vclock_ignore0_xc(&row, &vclock);
 				box_init_instance_vclock(&vclock);
 			}
 			break; /* end of stream */

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -870,8 +870,14 @@ applier_fetch_snapshot(struct applier *applier)
 	struct iostream *io = &applier->io;
 	struct xrow_header row;
 
+	struct vclock vclock;
+	vclock_create(&vclock);
 	struct fetch_snapshot_request req = {
 		.version_id = tarantool_version_id(),
+		/* Applier doesn't support checkpoint join. */
+		.is_checkpoint_join = false,
+		.checkpoint_vclock = vclock,
+		.checkpoint_lsn = 0,
 	};
 	RegionGuard region_guard(&fiber()->gc);
 	xrow_encode_fetch_snapshot(&row, &req);

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3940,7 +3940,7 @@ box_process_fetch_snapshot(struct iostream *io,
 	/* Send end of snapshot data marker */
 	struct xrow_header row;
 	RegionGuard region_guard(&fiber()->gc);
-	xrow_encode_vclock(&row, &stop_vclock);
+	xrow_encode_vclock_ignore0(&row, &stop_vclock);
 	row.sync = header->sync;
 	coio_write_xrow(io, &row);
 }
@@ -4046,7 +4046,7 @@ box_process_register(struct iostream *io, const struct xrow_header *header)
 	RegionGuard region_guard(&fiber()->gc);
 	struct xrow_header row;
 	/* Send end of WAL stream marker */
-	xrow_encode_vclock(&row, instance_vclock);
+	xrow_encode_vclock_ignore0(&row, instance_vclock);
 	row.sync = header->sync;
 	coio_write_xrow(io, &row);
 
@@ -4187,7 +4187,7 @@ box_process_join(struct iostream *io, const struct xrow_header *header)
 	/* Send end of initial stage data marker */
 	struct xrow_header row;
 	RegionGuard region_guard(&fiber()->gc);
-	xrow_encode_vclock(&row, &stop_vclock);
+	xrow_encode_vclock_ignore0(&row, &stop_vclock);
 	row.sync = header->sync;
 	coio_write_xrow(io, &row);
 
@@ -4200,7 +4200,7 @@ box_process_join(struct iostream *io, const struct xrow_header *header)
 	say_info("final data sent.");
 
 	/* Send end of WAL stream marker */
-	xrow_encode_vclock(&row, instance_vclock);
+	xrow_encode_vclock_ignore0(&row, instance_vclock);
 	row.sync = header->sync;
 	coio_write_xrow(io, &row);
 

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3910,6 +3910,9 @@ box_process_fetch_snapshot(struct iostream *io,
 {
 	assert(header->type == IPROTO_FETCH_SNAPSHOT);
 
+	struct fetch_snapshot_request req;
+	xrow_decode_fetch_snapshot_xc(header, &req);
+
 	/* Check that bootstrap has been finished */
 	if (!is_box_configured)
 		tnt_raise(ClientError, ER_LOADING);
@@ -3927,7 +3930,7 @@ box_process_fetch_snapshot(struct iostream *io,
 
 	/* Send the snapshot data to the instance. */
 	struct vclock start_vclock;
-	relay_initial_join(io, header->sync, &start_vclock, 0);
+	relay_initial_join(io, header->sync, &start_vclock, req.version_id);
 	say_info("read-view sent.");
 
 	/* Remember master's vclock after the last request */

--- a/src/box/engine.c
+++ b/src/box/engine.c
@@ -205,19 +205,11 @@ engine_backup(const struct vclock *vclock, engine_backup_cb cb, void *cb_arg)
 int
 engine_prepare_join(struct engine_join_ctx *ctx)
 {
-	ctx->array = calloc(MAX_ENGINE_COUNT, sizeof(void *));
-	if (ctx->array == NULL) {
-		diag_set(OutOfMemory, MAX_ENGINE_COUNT * sizeof(void *),
-			 "malloc", "engine join context");
-		return -1;
-	}
-	int i = 0;
+	ctx->data = xcalloc(MAX_ENGINE_COUNT, sizeof(void *));
 	struct engine *engine;
 	engine_foreach(engine) {
-		assert(i < MAX_ENGINE_COUNT);
-		if (engine->vtab->prepare_join(engine, &ctx->array[i]) != 0)
+		if (engine->vtab->prepare_join(engine, ctx) != 0)
 			goto fail;
-		i++;
 	}
 	return 0;
 fail:
@@ -230,12 +222,10 @@ engine_join(struct engine_join_ctx *ctx, struct xstream *stream)
 {
 	ERROR_INJECT_YIELD(ERRINJ_ENGINE_JOIN_DELAY);
 
-	int i = 0;
 	struct engine *engine;
 	engine_foreach(engine) {
-		if (engine->vtab->join(engine, ctx->array[i], stream) != 0)
+		if (engine->vtab->join(engine, ctx, stream) != 0)
 			return -1;
-		i++;
 	}
 	return 0;
 }
@@ -243,14 +233,11 @@ engine_join(struct engine_join_ctx *ctx, struct xstream *stream)
 void
 engine_complete_join(struct engine_join_ctx *ctx)
 {
-	int i = 0;
 	struct engine *engine;
 	engine_foreach(engine) {
-		if (ctx->array[i] != NULL)
-			engine->vtab->complete_join(engine, ctx->array[i]);
-		i++;
+		engine->vtab->complete_join(engine, ctx);
 	}
-	free(ctx->array);
+	free(ctx->data);
 }
 
 void
@@ -283,15 +270,15 @@ generic_engine_create_read_view(struct engine *engine,
 }
 
 int
-generic_engine_prepare_join(struct engine *engine, void **ctx)
+generic_engine_prepare_join(struct engine *engine, struct engine_join_ctx *ctx)
 {
-	(void)engine;
-	*ctx = NULL;
+	ctx->data[engine->id] = NULL;
 	return 0;
 }
 
 int
-generic_engine_join(struct engine *engine, void *ctx, struct xstream *stream)
+generic_engine_join(struct engine *engine, struct engine_join_ctx *ctx,
+		    struct xstream *stream)
 {
 	(void)engine;
 	(void)ctx;
@@ -300,7 +287,7 @@ generic_engine_join(struct engine *engine, void *ctx, struct xstream *stream)
 }
 
 void
-generic_engine_complete_join(struct engine *engine, void *ctx)
+generic_engine_complete_join(struct engine *engine, struct engine_join_ctx *ctx)
 {
 	(void)engine;
 	(void)ctx;

--- a/src/box/engine.h
+++ b/src/box/engine.h
@@ -300,11 +300,25 @@ struct engine_read_view {
 	struct rlist link;
 };
 
+/**
+ * Cursor used during checkpoint initial join. Shared between engines.
+ */
+struct checkpoint_cursor {
+	/** Signature of the checkpoint to take data from. */
+	struct vclock *vclock;
+	/** Checkpoint lsn to start from. */
+	int64_t start_lsn;
+	/** Counter, shared between engines */
+	int64_t lsn_counter;
+};
+
 struct engine_join_ctx {
 	/** Vclock to respond with. */
 	struct vclock *vclock;
 	/** Whether sending JOIN_META stage is required. */
 	bool send_meta;
+	/** Checkpoint join cursor. */
+	struct checkpoint_cursor *cursor;
 	/** Array of engine join contexts, one per each engine. */
 	void **data;
 };

--- a/src/box/engine.h
+++ b/src/box/engine.h
@@ -49,6 +49,7 @@ struct space;
 struct space_def;
 struct vclock;
 struct xstream;
+struct engine_join_ctx;
 
 extern struct rlist engines;
 
@@ -116,17 +117,19 @@ struct engine_vtab {
 	 * Setup and return a context that will be used
 	 * on further steps.
 	 */
-	int (*prepare_join)(struct engine *engine, void **ctx);
+	int (*prepare_join)(struct engine *engine, struct engine_join_ctx *ctx);
 	/**
 	 * Feed the read view frozen on the previous step to
 	 * the given stream.
 	 */
-	int (*join)(struct engine *engine, void *ctx, struct xstream *stream);
+	int (*join)(struct engine *engine, struct engine_join_ctx *ctx,
+		    struct xstream *stream);
 	/**
 	 * Release the read view and free the context prepared
 	 * on the first step.
 	 */
-	void (*complete_join)(struct engine *engine, void *ctx);
+	void (*complete_join)(struct engine *engine,
+			      struct engine_join_ctx *ctx);
 	/**
 	 * Begin a new single or multi-statement transaction.
 	 * Called on first statement in a transaction, not when
@@ -298,8 +301,12 @@ struct engine_read_view {
 };
 
 struct engine_join_ctx {
+	/** Vclock to respond with. */
+	struct vclock *vclock;
+	/** Whether sending JOIN_META stage is required. */
+	bool send_meta;
 	/** Array of engine join contexts, one per each engine. */
-	void **array;
+	void **data;
 };
 
 /** Register engine engine instance. */
@@ -467,9 +474,10 @@ engine_reset_stat(void);
 struct engine_read_view *
 generic_engine_create_read_view(struct engine *engine,
 				const struct read_view_opts *opts);
-int generic_engine_prepare_join(struct engine *, void **);
-int generic_engine_join(struct engine *, void *, struct xstream *);
-void generic_engine_complete_join(struct engine *, void *);
+int generic_engine_prepare_join(struct engine *, struct engine_join_ctx *);
+int generic_engine_join(struct engine *, struct engine_join_ctx *,
+			struct xstream *);
+void generic_engine_complete_join(struct engine *, struct engine_join_ctx *);
 int generic_engine_begin(struct engine *, struct txn *);
 int generic_engine_begin_statement(struct engine *, struct txn *);
 int generic_engine_prepare(struct engine *, struct txn *);

--- a/src/box/iproto_constants.h
+++ b/src/box/iproto_constants.h
@@ -194,6 +194,21 @@ extern const char *iproto_flag_bit_strs[];
 	 * authentication method.
 	 */								\
 	_(AUTH_TYPE, 0x5b, MP_STR)					\
+	 /**
+	  * Flag indicating whether checkpoint join should be done.
+	  */								\
+	 _(IS_CHECKPOINT_JOIN, 0x62, MP_BOOL)				\
+	 /**
+	  * Shows the signature of the checkpoint to read from.
+	  * Requires CHECKPOINT_JOIN to be true.
+	  */								\
+	 _(CHECKPOINT_VCLOCK, 0x63, MP_MAP)				\
+	 /**
+	  * Shows the lsn to start sending from. Server sends all rows
+	  * >= IPROTO_CHECKPOINT_LSN. Requires CHECKPOINT_JOIN to be
+	  * true and CHECKPOINT_VCLOCK to be set.
+	  */								\
+	 _(CHECKPOINT_LSN, 0x64, MP_UINT)				\
 
 #define IPROTO_KEY_MEMBER(s, v, ...) IPROTO_ ## s = v,
 

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -57,6 +57,7 @@
 #include "memtx_tuple_compression.h"
 #include "memtx_space.h"
 #include "memtx_space_upgrade.h"
+#include "wal.h"
 
 #include <type_traits>
 
@@ -1208,6 +1209,38 @@ struct memtx_join_ctx {
 	struct xstream *stream;
 };
 
+/** Respond to the JOIN request with the current vclock. */
+static void
+send_join_header(struct xstream *stream, const struct vclock *vclock)
+{
+	struct xrow_header row;
+	/* Encoding replication request uses fiber()->gc region. */
+	RegionGuard region_guard(&fiber()->gc);
+	xrow_encode_vclock(&row, vclock);
+	xstream_write(stream, &row);
+}
+
+static void
+send_join_meta(struct xstream *stream, const struct raft_request *raft_req,
+	       const struct synchro_request *synchro_req)
+{
+	struct xrow_header row;
+	/* Encoding raft request uses fiber()->gc region. */
+	RegionGuard region_guard(&fiber()->gc);
+
+	/* Mark the beginning of the metadata stream. */
+	xrow_encode_type(&row, IPROTO_JOIN_META);
+	xstream_write(stream, &row);
+
+	xrow_encode_raft(&row, &fiber()->gc, raft_req);
+	xstream_write(stream, &row);
+
+	char body[XROW_BODY_LEN_MAX];
+	xrow_encode_synchro(&row, body, synchro_req);
+	row.replica_id = synchro_req->replica_id;
+	xstream_write(stream, &row);
+}
+
 /** Space filter for replica join. */
 static bool
 memtx_join_space_filter(struct space *space, void *arg)
@@ -1219,9 +1252,8 @@ memtx_join_space_filter(struct space *space, void *arg)
 }
 
 static int
-memtx_engine_prepare_join(struct engine *engine, void **arg)
+memtx_engine_prepare_join(struct engine *engine, struct engine_join_ctx *arg)
 {
-	(void)engine;
 	struct memtx_join_ctx *ctx =
 		(struct memtx_join_ctx *)malloc(sizeof(*ctx));
 	if (ctx == NULL) {
@@ -1239,7 +1271,7 @@ memtx_engine_prepare_join(struct engine *engine, void **arg)
 		free(ctx);
 		return -1;
 	}
-	*arg = ctx;
+	arg->data[engine->id] = ctx;
 	return 0;
 }
 
@@ -1299,11 +1331,48 @@ memtx_join_f(va_list ap)
 }
 
 static int
-memtx_engine_join(struct engine *engine, void *arg, struct xstream *stream)
+memtx_engine_join(struct engine *engine, struct engine_join_ctx *arg,
+		  struct xstream *stream)
 {
-	(void)engine;
-	struct memtx_join_ctx *ctx = (struct memtx_join_ctx *)arg;
+	struct memtx_join_ctx *ctx =
+		(struct memtx_join_ctx *)arg->data[engine->id];
 	ctx->stream = stream;
+
+	struct vclock limbo_vclock;
+	struct raft_request raft_req;
+	struct synchro_request synchro_req;
+	/*
+	 * Sync WAL to make sure that all changes visible from
+	 * the frozen read view are successfully committed and
+	 * obtain corresponding vclock.
+	 *
+	 * This cannot be done in prepare_join, as we should not
+	 * yield between read-view creation. Moreover, wal syncing
+	 * should happen after creation of all engine's read-views.
+	 */
+	if (wal_sync(arg->vclock) != 0)
+		return -1;
+
+	/*
+	 * Start sending data only when the latest sync
+	 * transaction is confirmed.
+	 */
+	if (txn_limbo_wait_confirm(&txn_limbo) != 0)
+		return -1;
+
+	txn_limbo_checkpoint(&txn_limbo, &synchro_req, &limbo_vclock);
+	box_raft_checkpoint_local(&raft_req);
+
+	/* Respond with vclock and JOIN_META. */
+	send_join_header(stream, arg->vclock);
+	if (arg->send_meta) {
+		send_join_meta(stream, &raft_req, &synchro_req);
+		struct xrow_header row;
+		/* Mark the beginning of the data stream. */
+		xrow_encode_type(&row, IPROTO_JOIN_SNAPSHOT);
+		xstream_write(stream, &row);
+	}
+
 	/*
 	 * Memtx snapshot iterators are safe to use from another
 	 * thread and so we do so as not to consume too much of
@@ -1321,10 +1390,10 @@ memtx_engine_join(struct engine *engine, void *arg, struct xstream *stream)
 }
 
 static void
-memtx_engine_complete_join(struct engine *engine, void *arg)
+memtx_engine_complete_join(struct engine *engine, struct engine_join_ctx *arg)
 {
-	(void)engine;
-	struct memtx_join_ctx *ctx = (struct memtx_join_ctx *)arg;
+	struct memtx_join_ctx *ctx =
+		(struct memtx_join_ctx *)arg->data[engine->id];
 	read_view_close(&ctx->rv);
 	free(ctx);
 }

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -1216,7 +1216,14 @@ send_join_header(struct xstream *stream, const struct vclock *vclock)
 	struct xrow_header row;
 	/* Encoding replication request uses fiber()->gc region. */
 	RegionGuard region_guard(&fiber()->gc);
-	xrow_encode_vclock_ignore0(&row, vclock);
+	/*
+	 * Vclock is encoded with 0th component, as in case of checkpoint
+	 * join it corresponds to the vclock of the checkpoint, where 0th
+	 * component is essential, as otherwise signature won't be correct.
+	 * Client sends this vclock in IPROTO_CURSOR, when he wants to
+	 * continue fetching from the same checkpoint.
+	 */
+	xrow_encode_vclock(&row, vclock);
 	xstream_write(stream, &row);
 }
 

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -885,6 +885,17 @@ checkpoint_write_synchro(struct xlog *l, const struct synchro_request *req)
 	return checkpoint_write_row(l, &row);
 }
 
+static int
+checkpoint_write_system_data(struct xlog *l, const struct raft_request *raft,
+			     const struct synchro_request *synchro)
+{
+	if (checkpoint_write_raft(l, raft) != 0)
+		return -1;
+	if (checkpoint_write_synchro(l, synchro) != 0)
+		return -1;
+	return 0;
+}
+
 #ifndef NDEBUG
 /*
  * The functions defined below are used in tests to write a corrupted
@@ -972,6 +983,7 @@ checkpoint_f(va_list ap)
 	if (xdir_create_xlog(&ckpt->dir, &snap, &ckpt->vclock) != 0)
 		return -1;
 
+	bool is_synchro_written = false;
 	say_info("saving snapshot `%s'", snap.filename);
 	ERROR_INJECT_SLEEP(ERRINJ_SNAP_WRITE_DELAY);
 	ERROR_INJECT(ERRINJ_SNAP_SKIP_ALL_ROWS, goto done);
@@ -984,6 +996,19 @@ checkpoint_f(va_list ap)
 		});
 		if (skip)
 			continue;
+		/*
+		 * Raft and limbo states are written right after system spaces
+		 * but before user ones. This is needed to reduce the time,
+		 * needed to acquire states from the checkpoint, which is used
+		 * during checkpoint join.
+		 */
+		if (!is_synchro_written && !space_id_is_system(space_rv->id)) {
+			rc = checkpoint_write_system_data(&snap, &ckpt->raft,
+							  &ckpt->synchro_state);
+			if (rc != 0)
+				break;
+			is_synchro_written = true;
+		}
 		struct index_read_view *index_rv =
 			space_read_view_index(space_rv, 0);
 		assert(index_rv != NULL);
@@ -1027,9 +1052,14 @@ checkpoint_f(va_list ap)
 		if (checkpoint_write_invalid_system_row(&snap) != 0)
 			goto fail;
 	});
-	if (checkpoint_write_raft(&snap, &ckpt->raft) != 0)
-		goto fail;
-	if (checkpoint_write_synchro(&snap, &ckpt->synchro_state) != 0)
+	/*
+	 * There may be no user data (e.g. when only RAFT_PROMOTE is written),
+	 * write limbo and raft states right after system spaces, at the end
+	 * of the checkpoint.
+	 */
+	if (!is_synchro_written &&
+	    checkpoint_write_system_data(&snap, &ckpt->raft,
+					 &ckpt->synchro_state) != 0)
 		goto fail;
 	goto done;
 done:

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -1216,7 +1216,7 @@ send_join_header(struct xstream *stream, const struct vclock *vclock)
 	struct xrow_header row;
 	/* Encoding replication request uses fiber()->gc region. */
 	RegionGuard region_guard(&fiber()->gc);
-	xrow_encode_vclock(&row, vclock);
+	xrow_encode_vclock_ignore0(&row, vclock);
 	xstream_write(stream, &row);
 }
 

--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -458,7 +458,8 @@ relay_cord_init(struct relay *relay)
 
 void
 relay_initial_join(struct iostream *io, uint64_t sync, struct vclock *vclock,
-		   uint32_t replica_version_id)
+		   uint32_t replica_version_id,
+		   struct checkpoint_cursor *cursor)
 {
 	struct relay *relay = relay_new(NULL);
 	if (relay == NULL)
@@ -480,6 +481,7 @@ relay_initial_join(struct iostream *io, uint64_t sync, struct vclock *vclock,
 	 */
 	ctx.send_meta = replica_version_id > 0;
 	ctx.vclock = vclock;
+	ctx.cursor = cursor;
 	engine_prepare_join_xc(&ctx);
 	auto join_guard = make_scoped_guard([&] {
 		engine_complete_join(&ctx);

--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -473,60 +473,17 @@ relay_initial_join(struct iostream *io, uint64_t sync, struct vclock *vclock,
 
 	/* Freeze a read view in engines. */
 	struct engine_join_ctx ctx;
-	engine_prepare_join_xc(&ctx);
-	auto join_guard = make_scoped_guard([&] {
-		engine_complete_join(&ctx);
-	});
-
-	/*
-	 * Sync WAL to make sure that all changes visible from
-	 * the frozen read view are successfully committed and
-	 * obtain corresponding vclock.
-	 */
-	if (wal_sync(vclock) != 0)
-		diag_raise();
-
-	/*
-	 * Start sending data only when the latest sync
-	 * transaction is confirmed.
-	 */
-	if (txn_limbo_wait_confirm(&txn_limbo) != 0)
-		diag_raise();
-
-	struct synchro_request req;
-	struct raft_request raft_req;
-	struct vclock limbo_vclock;
-	txn_limbo_checkpoint(&txn_limbo, &req, &limbo_vclock);
-	box_raft_checkpoint_local(&raft_req);
-
-	/* Respond to the JOIN request with the current vclock. */
-	struct xrow_header row;
-	RegionGuard region_guard(&fiber()->gc);
-	xrow_encode_vclock(&row, vclock);
-	row.sync = sync;
-	coio_write_xrow(relay->io, &row);
-
+	memset(&ctx, 0, sizeof(ctx));
 	/*
 	 * Version is present starting with 2.7.3, 2.8.2, 2.9.1
 	 * All these versions know of additional META stage of initial join.
 	 */
-	if (replica_version_id > 0) {
-		/* Mark the beginning of the metadata stream. */
-		xrow_encode_type(&row, IPROTO_JOIN_META);
-		xstream_write(&relay->stream, &row);
-
-		xrow_encode_raft(&row, &fiber()->gc, &raft_req);
-		xstream_write(&relay->stream, &row);
-
-		char body[XROW_BODY_LEN_MAX];
-		xrow_encode_synchro(&row, body, &req);
-		row.replica_id = req.replica_id;
-		xstream_write(&relay->stream, &row);
-
-		/* Mark the end of the metadata stream. */
-		xrow_encode_type(&row, IPROTO_JOIN_SNAPSHOT);
-		xstream_write(&relay->stream, &row);
-	}
+	ctx.send_meta = replica_version_id > 0;
+	ctx.vclock = vclock;
+	engine_prepare_join_xc(&ctx);
+	auto join_guard = make_scoped_guard([&] {
+		engine_complete_join(&ctx);
+	});
 
 	/* Send read view to the replica. */
 	engine_join_xc(&ctx, &relay->stream);

--- a/src/box/relay.h
+++ b/src/box/relay.h
@@ -42,6 +42,7 @@ struct relay;
 struct replica;
 struct tt_uuid;
 struct vclock;
+struct checkpoint_cursor;
 
 enum relay_state {
 	/**
@@ -126,10 +127,12 @@ relay_push_raft(struct relay *relay, const struct raft_request *req);
  * @param sync      sync from incoming JOIN request
  * @param vclock[out] vclock of the read view sent to the replica
  * @param replica_version_id peer's version
+ * @param cursor    cursor for checkpoint join, if NULL - read-view join.
  */
 void
 relay_initial_join(struct iostream *io, uint64_t sync, struct vclock *vclock,
-		   uint32_t replica_version_id);
+		   uint32_t replica_version_id,
+		   struct checkpoint_cursor *cursor);
 
 /**
  * Send final JOIN rows to the replica.

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -3030,6 +3030,41 @@ struct vy_join_ctx {
 	struct vy_read_view *rv;
 };
 
+#if defined(ENABLE_FETCH_SNAPSHOT_CURSOR)
+#include "vinyl_checkpoint_join.c"
+#else /* !defined(ENABLE_FETCH_SNAPSHOT_CURSOR) */
+
+static int
+vinyl_engine_prepare_checkpoint_join(struct engine *engine,
+				     struct engine_join_ctx *ctx)
+{
+	(void)engine;
+	(void)ctx;
+	unreachable();
+	return -1;
+}
+
+static int
+vinyl_engine_checkpoint_join(struct engine *engine, struct engine_join_ctx *ctx,
+			     struct xstream *stream)
+{
+	(void)engine;
+	(void)ctx;
+	(void)stream;
+	unreachable();
+	return -1;
+}
+
+static void
+vinyl_engine_complete_checkpoint_join(struct engine *engine,
+				      struct engine_join_ctx *ctx)
+{
+	(void)engine;
+	(void)ctx;
+}
+
+#endif /* !defined(ENABLE_FETCH_SNAPSHOT_CURSOR) */
+
 static int
 vy_join_add_space(struct space *space, void *arg)
 {
@@ -3064,6 +3099,9 @@ vy_join_add_space(struct space *space, void *arg)
 static int
 vinyl_engine_prepare_join(struct engine *engine, struct engine_join_ctx *arg)
 {
+	if (arg->cursor != NULL)
+		return vinyl_engine_prepare_checkpoint_join(engine, arg);
+
 	struct vy_env *env = vy_env(engine);
 	struct vy_join_ctx *ctx = malloc(sizeof(*ctx));
 	if (ctx == NULL) {
@@ -3105,6 +3143,9 @@ static int
 vinyl_engine_join(struct engine *engine, struct engine_join_ctx *arg,
 		  struct xstream *stream)
 {
+	if (arg->cursor != NULL)
+		return vinyl_engine_checkpoint_join(engine, arg, stream);
+
 	int loops = 0;
 	struct vy_join_ctx *ctx = arg->data[engine->id];
 	struct vy_join_entry *join_entry;
@@ -3130,6 +3171,9 @@ vinyl_engine_join(struct engine *engine, struct engine_join_ctx *arg,
 static void
 vinyl_engine_complete_join(struct engine *engine, struct engine_join_ctx *arg)
 {
+	if (arg->cursor != NULL)
+		return vinyl_engine_complete_checkpoint_join(engine, arg);
+
 	struct vy_env *env = vy_env(engine);
 	struct vy_join_ctx *ctx = arg->data[engine->id];
 	struct vy_join_entry *entry, *next;

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -3062,7 +3062,7 @@ vy_join_add_space(struct space *space, void *arg)
 }
 
 static int
-vinyl_engine_prepare_join(struct engine *engine, void **arg)
+vinyl_engine_prepare_join(struct engine *engine, struct engine_join_ctx *arg)
 {
 	struct vy_env *env = vy_env(engine);
 	struct vy_join_ctx *ctx = malloc(sizeof(*ctx));
@@ -3077,7 +3077,7 @@ vinyl_engine_prepare_join(struct engine *engine, void **arg)
 		free(ctx);
 		return -1;
 	}
-	*arg = ctx;
+	arg->data[engine->id] = ctx;
 	return space_foreach(vy_join_add_space, ctx);
 }
 
@@ -3102,11 +3102,11 @@ vy_join_send_tuple(struct xstream *stream, uint32_t space_id,
 }
 
 static int
-vinyl_engine_join(struct engine *engine, void *arg, struct xstream *stream)
+vinyl_engine_join(struct engine *engine, struct engine_join_ctx *arg,
+		  struct xstream *stream)
 {
-	(void)engine;
 	int loops = 0;
-	struct vy_join_ctx *ctx = arg;
+	struct vy_join_ctx *ctx = arg->data[engine->id];
 	struct vy_join_entry *join_entry;
 	rlist_foreach_entry(join_entry, &ctx->entries, in_ctx) {
 		struct vy_read_iterator *it = &join_entry->iterator;
@@ -3128,10 +3128,10 @@ vinyl_engine_join(struct engine *engine, void *arg, struct xstream *stream)
 }
 
 static void
-vinyl_engine_complete_join(struct engine *engine, void *arg)
+vinyl_engine_complete_join(struct engine *engine, struct engine_join_ctx *arg)
 {
 	struct vy_env *env = vy_env(engine);
-	struct vy_join_ctx *ctx = arg;
+	struct vy_join_ctx *ctx = arg->data[engine->id];
 	struct vy_join_entry *entry, *next;
 	rlist_foreach_entry_safe(entry, &ctx->entries, in_ctx, next) {
 		struct vy_lsm *lsm = entry->iterator.lsm;

--- a/src/box/xrow.c
+++ b/src/box/xrow.c
@@ -64,15 +64,22 @@ mp_sizeof_vclock_ignore0(const struct vclock *vclock)
 					     mp_sizeof_uint(UINT64_MAX));
 }
 
-static inline char *
-mp_encode_vclock_ignore0(char *data, const struct vclock *vclock)
+static inline uint32_t
+mp_sizeof_vclock(const struct vclock *vclock)
 {
-	data = mp_encode_map(data, vclock_size_ignore0(vclock));
+	uint32_t size = vclock_size(vclock);
+	return mp_sizeof_map(size) + size * (mp_sizeof_uint(UINT32_MAX) +
+					     mp_sizeof_uint(UINT64_MAX));
+}
+
+static inline char *
+mp_encode_vclock_impl(char *data, const struct vclock *vclock, bool ignore0)
+{
 	struct vclock_iterator it;
 	vclock_iterator_init(&it, vclock);
 	struct vclock_c replica;
 	replica = vclock_iterator_next(&it);
-	if (replica.id == 0)
+	if (replica.id == 0 && ignore0)
 		replica = vclock_iterator_next(&it);
 	for ( ; replica.id < VCLOCK_MAX; replica = vclock_iterator_next(&it)) {
 		data = mp_encode_uint(data, replica.id);
@@ -81,8 +88,22 @@ mp_encode_vclock_ignore0(char *data, const struct vclock *vclock)
 	return data;
 }
 
+static inline char *
+mp_encode_vclock_ignore0(char *data, const struct vclock *vclock)
+{
+	data = mp_encode_map(data, vclock_size_ignore0(vclock));
+	return mp_encode_vclock_impl(data, vclock, true);
+}
+
+static inline char *
+mp_encode_vclock(char *data, const struct vclock *vclock)
+{
+	data = mp_encode_map(data, vclock_size(vclock));
+	return mp_encode_vclock_impl(data, vclock, false);
+}
+
 static int
-mp_decode_vclock_ignore0(const char **data, struct vclock *vclock)
+mp_decode_vclock(const char **data, struct vclock *vclock)
 {
 	vclock_create(vclock);
 	if (mp_typeof(**data) != MP_MAP)
@@ -95,13 +116,18 @@ mp_decode_vclock_ignore0(const char **data, struct vclock *vclock)
 		if (mp_typeof(**data) != MP_UINT)
 			return -1;
 		int64_t lsn = mp_decode_uint(data);
-		/*
-		 * Skip vclock[0] coming from the remote
-		 * instances.
-		 */
-		if (lsn > 0 && id != 0)
+		if (lsn > 0)
 			vclock_follow(vclock, id, lsn);
 	}
+	return 0;
+}
+
+static int
+mp_decode_vclock_ignore0(const char **data, struct vclock *vclock)
+{
+	if (mp_decode_vclock(data, vclock) != 0)
+		return -1;
+	vclock_reset(vclock, 0, 0);
 	return 0;
 }
 
@@ -1991,6 +2017,8 @@ struct replication_request {
 	struct tt_uuid *instance_uuid;
 	/** IPROTO_VCLOCK. */
 	struct vclock *vclock_ignore0;
+	/** IPROTO_VCLOCK. */
+	struct vclock *vclock;
 	/** IPROTO_ID_FILTER. */
 	uint32_t *id_filter;
 	/** IPROTO_SERVER_VERSION. */
@@ -2007,8 +2035,14 @@ xrow_encode_replication_request(struct xrow_header *row,
 {
 	memset(row, 0, sizeof(*row));
 	size_t size = XROW_BODY_LEN_MAX;
-	if (req->vclock_ignore0 != NULL)
+	if (req->vclock_ignore0 != NULL) {
 		size += mp_sizeof_vclock_ignore0(req->vclock_ignore0);
+		assert(req->vclock == NULL);
+	}
+	if (req->vclock != NULL) {
+		size += mp_sizeof_vclock(req->vclock);
+		assert(req->vclock_ignore0 == NULL);
+	}
 	char *buf = xregion_alloc(&fiber()->gc, size);
 	/* Skip one byte for future map header. */
 	char *data = buf + 1;
@@ -2027,6 +2061,11 @@ xrow_encode_replication_request(struct xrow_header *row,
 		++map_size;
 		data = mp_encode_uint(data, IPROTO_VCLOCK);
 		data = mp_encode_vclock_ignore0(data, req->vclock_ignore0);
+	}
+	if (req->vclock != NULL) {
+		++map_size;
+		data = mp_encode_uint(data, IPROTO_VCLOCK);
+		data = mp_encode_vclock(data, req->vclock);
 	}
 	if (req->version_id != NULL) {
 		++map_size;
@@ -2432,6 +2471,15 @@ xrow_encode_vclock_ignore0(struct xrow_header *row, const struct vclock *vclock)
 {
 	const struct replication_request base_req = {
 		.vclock_ignore0 = (struct vclock *)vclock,
+	};
+	xrow_encode_replication_request(row, &base_req, IPROTO_OK);
+}
+
+void
+xrow_encode_vclock(struct xrow_header *row, const struct vclock *vclock)
+{
+	const struct replication_request base_req = {
+		.vclock = (struct vclock *)vclock,
 	};
 	xrow_encode_replication_request(row, &base_req, IPROTO_OK);
 }

--- a/src/box/xrow.c
+++ b/src/box/xrow.c
@@ -2236,6 +2236,29 @@ xrow_decode_join(const struct xrow_header *row, struct join_request *req)
 }
 
 void
+xrow_encode_fetch_snapshot(struct xrow_header *row,
+			   const struct fetch_snapshot_request *req)
+{
+	struct fetch_snapshot_request *cast =
+		(struct fetch_snapshot_request *)req;
+	const struct replication_request base_req = {
+		.version_id = &cast->version_id,
+	};
+	xrow_encode_replication_request(row, &base_req, IPROTO_FETCH_SNAPSHOT);
+}
+
+int
+xrow_decode_fetch_snapshot(const struct xrow_header *row,
+			   struct fetch_snapshot_request *req)
+{
+	memset(req, 0, sizeof(*req));
+	struct replication_request base_req = {
+		.version_id = &req->version_id,
+	};
+	return xrow_decode_replication_request(row, &base_req);
+}
+
+void
 xrow_encode_relay_heartbeat(struct xrow_header *row,
 			    const struct relay_heartbeat *req)
 {

--- a/src/box/xrow.h
+++ b/src/box/xrow.h
@@ -671,13 +671,15 @@ int
 xrow_decode_applier_heartbeat(const struct xrow_header *row,
 			      struct applier_heartbeat *req);
 
-/** Encode vclock. */
+/** Encode vclock ignoring 0th component. */
 void
-xrow_encode_vclock(struct xrow_header *row, const struct vclock *vclock);
+xrow_encode_vclock_ignore0(struct xrow_header *row,
+			   const struct vclock *vclock);
 
-/** Decode vclock. */
+/** Decode vclock ignoring 0th component. */
 int
-xrow_decode_vclock(const struct xrow_header *row, struct vclock *vclock);
+xrow_decode_vclock_ignore0(const struct xrow_header *row,
+			   struct vclock *vclock);
 
 /**
  * Encode any bodyless message.
@@ -1164,11 +1166,12 @@ xrow_decode_relay_heartbeat_xc(const struct xrow_header *row,
 		diag_raise();
 }
 
-/** @copydoc xrow_decode_vclock. */
+/** @copydoc xrow_decode_vclock_ignore0. */
 static inline void
-xrow_decode_vclock_xc(const struct xrow_header *row, struct vclock *vclock)
+xrow_decode_vclock_ignore0_xc(const struct xrow_header *row,
+			      struct vclock *vclock)
 {
-	if (xrow_decode_vclock(row, vclock) != 0)
+	if (xrow_decode_vclock_ignore0(row, vclock) != 0)
 		diag_raise();
 }
 

--- a/src/box/xrow.h
+++ b/src/box/xrow.h
@@ -614,6 +614,12 @@ xrow_decode_join(const struct xrow_header *row, struct join_request *req);
 struct fetch_snapshot_request {
 	/** Replica's version. */
 	uint32_t version_id;
+	/** Flag indicating whether checkpoint join should be done. */
+	bool is_checkpoint_join;
+	/** Checkpoint's vclock, signature of the snapshot. */
+	struct vclock checkpoint_vclock;
+	/** Checkpoint's lsn, the row number to start from. */
+	uint64_t checkpoint_lsn;
 };
 
 /** Encode FETCH_SNAPSHOT request. */

--- a/src/box/xrow.h
+++ b/src/box/xrow.h
@@ -676,6 +676,10 @@ void
 xrow_encode_vclock_ignore0(struct xrow_header *row,
 			   const struct vclock *vclock);
 
+/** Encode vclock including 0th component. */
+void
+xrow_encode_vclock(struct xrow_header *row, const struct vclock *vclock);
+
 /** Decode vclock ignoring 0th component. */
 int
 xrow_decode_vclock_ignore0(const struct xrow_header *row,

--- a/src/box/xrow.h
+++ b/src/box/xrow.h
@@ -611,6 +611,21 @@ xrow_encode_join(struct xrow_header *row, const struct join_request *req);
 int
 xrow_decode_join(const struct xrow_header *row, struct join_request *req);
 
+struct fetch_snapshot_request {
+	/** Replica's version. */
+	uint32_t version_id;
+};
+
+/** Encode FETCH_SNAPSHOT request. */
+void
+xrow_encode_fetch_snapshot(struct xrow_header *row,
+			   const struct fetch_snapshot_request *req);
+
+/** Decode FETCH_SNAPSHOT request. */
+int
+xrow_decode_fetch_snapshot(const struct xrow_header *row,
+			   struct fetch_snapshot_request *req);
+
 /**
  * Heartbeat from relay to applier. Follows the replication stream. Same
  * direction.
@@ -1110,6 +1125,15 @@ static inline void
 xrow_decode_join_xc(const struct xrow_header *row, struct join_request *req)
 {
 	if (xrow_decode_join(row, req) != 0)
+		diag_raise();
+}
+
+/** @copydoc xrow_decode_fetch_snapshot. */
+static inline void
+xrow_decode_fetch_snapshot_xc(const struct xrow_header *row,
+			      struct fetch_snapshot_request *req)
+{
+	if (xrow_decode_fetch_snapshot(row, req) != 0)
 		diag_raise();
 }
 

--- a/src/trivia/config.h.cmake
+++ b/src/trivia/config.h.cmake
@@ -288,6 +288,7 @@
 #cmakedefine ENABLE_READ_VIEW 1
 #cmakedefine ENABLE_SECURITY 1
 #cmakedefine ENABLE_COMPRESS_MODULE 1
+#cmakedefine ENABLE_FETCH_SNAPSHOT_CURSOR 1
 
 #cmakedefine EXPORT_LIBCURL_SYMBOLS 1
 

--- a/test/box-luatest/gh_7894_export_iproto_constants_and_features_test.lua
+++ b/test/box-luatest/gh_7894_export_iproto_constants_and_features_test.lua
@@ -80,6 +80,9 @@ local reference_table = {
         TXN_ISOLATION = 0x59,
         VCLOCK_SYNC = 0x5a,
         AUTH_TYPE = 0x5b,
+        IS_CHECKPOINT_JOIN = 0x62,
+        CHECKPOINT_VCLOCK = 0x63,
+        CHECKPOINT_LSN = 0x64,
     },
 
     -- `iproto_metadata_key` enumeration.

--- a/test/engine-luatest/checkpoint_test.lua
+++ b/test/engine-luatest/checkpoint_test.lua
@@ -1,0 +1,53 @@
+local t = require('luatest')
+local server = require('luatest.server')
+local xlog = require('xlog')
+
+local g = t.group()
+
+g.before_all(function(g)
+    g.server = server:new()
+    g.server:start()
+    g.server:exec(function()
+        box.schema.space.create('test'):create_index('pk')
+    end)
+end)
+
+g.after_all(function(g)
+    g.server:drop()
+end)
+
+--
+-- Test, that the limbo and raft states are saved after
+-- system spaces but before user data.
+--
+g.test_synchro_states_checkpoint = function(g)
+    local lsn = g.server:exec(function()
+        box.space.test:insert{1, 'data'}
+        box.snapshot()
+        return box.info.vclock[1]
+    end)
+
+    -- Read the whole snap in memory, as otherwise
+    -- it's impossible to access data by index.
+    local data = {}
+    local snap_template = '%020d.snap'
+    local snap = g.server.workdir .. '/' .. string.format(snap_template, lsn)
+    for _, v in xlog.pairs(snap) do
+        table.insert(data, v)
+    end
+
+    -- Skip data from the system spaces.
+    local state_idx = 0
+    for i, row in ipairs(data) do
+        if row.HEADER.type ~= 'INSERT' then
+            state_idx = i
+            break
+        end
+    end
+    -- The next rows are raft and limbo states.
+    t.assert_equals(data[state_idx].HEADER.type, 'RAFT')
+    t.assert_equals(data[state_idx + 1].HEADER.type, 'RAFT_PROMOTE')
+    -- And after states there's some user data.
+    t.assert_equals(data[state_idx + 2].HEADER.type, 'INSERT')
+    t.assert_ge(data[state_idx + 2].BODY.space_id, 512)
+end

--- a/test/replication-luatest/gh_9401_anon_replica_synchro_queue_state_test.lua
+++ b/test/replication-luatest/gh_9401_anon_replica_synchro_queue_state_test.lua
@@ -1,0 +1,68 @@
+local t = require('luatest')
+local replica_set = require('luatest.replica_set')
+local server = require('luatest.server')
+
+local g = t.group('gh-9401-anon-replica-synchro')
+
+--
+-- gh-9401: Anonymous replica didn't receive a synchronous queue snapshot during
+-- join, and treated every synchronous request as erroneous.
+--
+g.before_each(function(cg)
+    cg.replica_set = replica_set:new{}
+    cg.master = cg.replica_set:build_and_add_server{
+        alias = 'master',
+        box_cfg = {
+            replication_timeout = 0.1,
+        },
+    }
+    cg.replica = cg.replica_set:build_and_add_server{
+        alias = 'replica',
+        box_cfg = {
+            replication = server.build_listen_uri('master', cg.replica_set.id),
+            replication_anon = true,
+            replication_timeout = 0.1,
+            read_only = true,
+        },
+    }
+    cg.master:start()
+    cg.master:exec(function()
+        box.ctl.promote()
+    end)
+    cg.replica:start()
+    cg.replica:assert_follows_upstream(cg.master:get_instance_id())
+end)
+
+g.after_each(function(cg)
+    cg.replica_set:drop()
+end)
+
+g.test_anon_replica_synchro_queue = function(cg)
+    local old_term = cg.replica:exec(function(id)
+        t.assert_equals(box.info.synchro.queue.owner, id)
+        t.assert(box.info.synchro.queue.term > 1)
+        return box.info.synchro.queue.term
+    end, {cg.master:get_instance_id()})
+    cg.master:exec(function()
+        box.ctl.demote()
+    end)
+    cg.replica:wait_for_vclock_of(cg.master)
+    cg.replica:assert_follows_upstream(cg.master:get_instance_id())
+    cg.replica:exec(function(term)
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        t.assert(box.info.synchro.queue.term > term)
+    end, {old_term})
+end
+
+g.test_anon_replica_synchro_write = function(cg)
+    cg.master:exec(function()
+        box.schema.space.create('test', {is_sync = true})
+        box.space.test:create_index('pk')
+        box.space.test:insert{1}
+    end)
+    cg.replica:wait_for_vclock_of(cg.master)
+    cg.replica:assert_follows_upstream(cg.master:get_instance_id())
+    cg.replica:exec(function()
+        t.assert_equals(box.space.test:get{1}, {1})
+    end)
+end


### PR DESCRIPTION
The last commit https://github.com/tarantool/tarantool/commit/62c49367a2eab6d8008da2d7201ffa03e002c31e will not be backported since it adds a feature with index 10, in 2.11 we have only 4 of them. Moreover, it bumps iproto version to 8, but all previous feature will not be supported.

It's not crucial, server just won't reply, that it has such feature.

Changelogs added in this backport must be marked experimental!!!  But only if they're features