### PR TITLE
config: add per instance failover priority

### DIFF
--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2310,7 +2310,24 @@ return schema.new('instance_config', schema.record({
                 type = 'number',
                 default = 10,
             }),
-        })
+        }),
+        replicasets = schema.map({
+            -- Name of the replica.
+            key = schema.scalar({
+                type = 'string',
+            }),
+            value = schema.record({
+                -- Priorities for the supervised failover mode.
+                priority = schema.map({
+                    key = schema.scalar({
+                        type = 'string',
+                    }),
+                    value = schema.scalar({
+                        type = 'number',
+                    }),
+                }),
+            }),
+        }),
     }),
     -- Compatibility options.
     compat = schema.record({

--- a/test/config-luatest/config_test.lua
+++ b/test/config-luatest/config_test.lua
@@ -922,6 +922,125 @@ g.test_failover_supervised_constrainsts = function()
     })
 end
 
+g.test_failover_config = function()
+    local dir = treegen.prepare_directory({}, {})
+    local config = [[
+        credentials:
+          users:
+            guest:
+              roles:
+              - super
+
+        iproto:
+          listen:
+            - uri: unix/:./{{ instance_name }}.iproto
+
+        failover:
+          replicasets:
+            replicaset-002: []
+
+        groups:
+          group-001:
+            replicasets:
+              replicaset-001:
+                instances:
+                  instance-001: {}
+                  instance-002: {}
+                  instance-003: {}
+    ]]
+    local config_file = treegen.write_file(dir, 'config.yaml', config)
+    local env = {TT_LOG_LEVEL = 0}
+    local args = {'--name', 'instance-001', '--config', config_file}
+    local opts = {nojson = true, stderr = true}
+    local res = justrun.tarantool(dir, env, args, opts)
+    local exp = 'LuajitError: replicaset replicaset-002 specified in the ' ..
+                'failover configuration doesn\'t exist\nfatal error, ' ..
+                'exiting the event loop'
+
+    t.assert_equals(res.exit_code, 1)
+    t.assert_equals(res.stderr, exp)
+
+    local config = [[
+        credentials:
+          users:
+            guest:
+              roles:
+              - super
+
+        iproto:
+          listen:
+            - uri: unix/:./{{ instance_name }}.iproto
+
+        failover:
+          replicasets:
+            replicaset-001:
+              priority:
+                instance-004: 1
+
+        groups:
+          group-001:
+            replicasets:
+              replicaset-001:
+                instances:
+                  instance-001: {}
+                  instance-002: {}
+                  instance-003: {}
+    ]]
+    local config_file = treegen.write_file(dir, 'config.yaml', config)
+    local env = {TT_LOG_LEVEL = 0}
+    local args = {'--name', 'instance-001', '--config', config_file}
+    local opts = {nojson = true, stderr = true}
+    local res = justrun.tarantool(dir, env, args, opts)
+    local exp = 'LuajitError: instance instance-004 from replicaset ' ..
+                'replicaset-001 specified in the failover configuration ' ..
+                'doesn\'t exist\nfatal error, exiting the event loop'
+
+    t.assert_equals(res.exit_code, 1)
+    t.assert_equals(res.stderr, exp)
+
+    local config = [[
+        credentials:
+          users:
+            guest:
+              roles:
+              - super
+
+        iproto:
+          listen:
+            - uri: unix/:./{{ instance_name }}.iproto
+
+        failover:
+          replicasets:
+            replicaset-001:
+              priority:
+                instance-003: 1
+
+        groups:
+          group-001:
+            replicasets:
+              replicaset-001:
+                instances:
+                  instance-001: {}
+                  instance-002: {}
+              replicaset-002:
+                instances:
+                  instance-003: {}
+    ]]
+    local config_file = treegen.write_file(dir, 'config.yaml', config)
+    local env = {TT_LOG_LEVEL = 0}
+    local args = {'--name', 'instance-001', '--config', config_file}
+    local opts = {nojson = true, stderr = true}
+    local res = justrun.tarantool(dir, env, args, opts)
+    local exp = 'LuajitError: instance instance-003 from replicaset ' ..
+                'replicaset-002 is specified in the wrong replicaset ' ..
+                'replicaset-001 in the failover configuration section\n' ..
+                'fatal error, exiting the event loop'
+
+    t.assert_equals(res.exit_code, 1)
+    t.assert_equals(res.stderr, exp)
+
+end
+
 g.test_advertise_from_env = function(g)
     local dir = treegen.prepare_directory({}, {})
     local config = [[

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1722,7 +1722,14 @@ g.test_failover = function()
                 renew_interval = 1,
                 keepalive_interval = 5,
             },
-        },
+            replicasets = {
+                replicaset001 = {
+                    priority = {
+                        instance001 = 1
+                    }
+                }
+            }
+        }
     }
 
     instance_config:validate(iconfig)


### PR DESCRIPTION
Added the support for the failover per repliaset `failover.replicasets` configuration. Existance of the specified replicasets are checked when the config is loaded.

Added the `failover.replicasets.<replicaset_name>.priority` section for specifying the priorities for the supervised failover per each instance. Made the config applier check if all of the specified instances exist.

EE Issue: [tarantool/taranool-ee#846](https://github.com/tarantool/tarantool-ee/issues/846)
EE PR: [tarantool/tarantool-ee#845](https://github.com/tarantool/tarantool-ee/pull/845)