### PR TITLE
Finish the CE part of the logarithmic offset RFC

### DIFF
--- a/changelogs/unreleased/gh-8204-offset_of.md
+++ b/changelogs/unreleased/gh-8204-offset_of.md
@@ -1,0 +1,5 @@
+## feature/lua
+
+* Introduced a new `index:offset_of` method. It allows to get the position in
+  the index relative to the iterator direction of a tuple matching the given
+  key and iterator (gh-8204).

--- a/changelogs/unreleased/gh-8204-pairs-offset.md
+++ b/changelogs/unreleased/gh-8204-pairs-offset.md
@@ -1,0 +1,4 @@
+## feature/lua
+
+* Introduced a new `offset` parameter in the `index:pairs` method. It allows to
+  skip the first tuples of the iterator (gh-8204).

--- a/changelogs/unreleased/gh-8204-select-offset-count-perf.md
+++ b/changelogs/unreleased/gh-8204-select-offset-count-perf.md
@@ -1,0 +1,10 @@
+## feature/memtx
+
+* Improved performance of tree index methods: `select()` with the `offset`
+  specified and `count()` method. The underlying algorithm for these methods is
+  changed: the old one's time complexity was `O(n)`, where `n` is the value of
+  `offset` or the amount of counted tuples. The new algorithm's complexity is
+  `O(log(size))`, where `size` is the number of tuples stored in the index. Now
+  it does not depend on the `offset` value or the amount of tuples to count. It
+  is safe to use these functions with arbitrary big offset values and tuple
+  count (gh-8204).

--- a/extra/exports
+++ b/extra/exports
@@ -64,7 +64,7 @@ box_index_count
 box_index_get
 box_index_id_by_name
 box_index_iterator
-box_index_iterator_after
+box_index_iterator_with_offset
 box_index_len
 box_index_max
 box_index_min

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3857,8 +3857,8 @@ box_select(uint32_t space_id, uint32_t index_id,
 	if (txn_begin_ro_stmt(space, &txn, &svp) != 0)
 		return -1;
 
-	struct iterator *it = index_create_iterator_after(index, type, key,
-							  part_count, pos);
+	struct iterator *it = index_create_iterator_with_offset(
+		index, type, key, part_count, pos, offset);
 	if (it == NULL) {
 		txn_end_ro_stmt(txn, &svp);
 		return -1;
@@ -3875,10 +3875,6 @@ box_select(uint32_t space_id, uint32_t index_id,
 		rc = iterator_next(it, &tuple);
 		if (rc != 0 || tuple == NULL)
 			break;
-		if (offset > 0) {
-			offset--;
-			continue;
-		}
 		port_c_add_tuple(port, tuple);
 		found++;
 		/*

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -495,9 +495,10 @@ box_index_count(uint32_t space_id, uint32_t index_id, int type,
 /* {{{ Iterators ************************************************/
 
 box_iterator_t *
-box_index_iterator_after(uint32_t space_id, uint32_t index_id, int type,
-			 const char *key, const char *key_end,
-			 const char *packed_pos, const char *packed_pos_end)
+box_index_iterator_with_offset(uint32_t space_id, uint32_t index_id, int type,
+			       const char *key, const char *key_end,
+			       const char *packed_pos,
+			       const char *packed_pos_end, uint32_t offset)
 {
 	assert(key != NULL && key_end != NULL);
 	mp_tuple_assert(key, key_end);
@@ -541,8 +542,8 @@ box_index_iterator_after(uint32_t space_id, uint32_t index_id, int type,
 	struct txn_ro_savepoint svp;
 	if (txn_begin_ro_stmt(space, &txn, &svp) != 0)
 		return NULL;
-	struct iterator *it = index_create_iterator_after(index, itype, key,
-							  part_count, pos);
+	struct iterator *it = index_create_iterator_with_offset(
+		index, itype, key, part_count, pos, offset);
 	txn_end_ro_stmt(txn, &svp);
 	if (it == NULL)
 		return NULL;
@@ -558,8 +559,8 @@ box_iterator_t *
 box_index_iterator(uint32_t space_id, uint32_t index_id, int type,
 		   const char *key, const char *key_end)
 {
-	return box_index_iterator_after(space_id, index_id, type, key, key_end,
-					NULL, NULL);
+	return box_index_iterator_with_offset(space_id, index_id, type, key,
+					      key_end, NULL, NULL, 0);
 }
 
 int

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -981,6 +981,34 @@ generic_index_create_iterator(struct index *base, enum iterator_type type,
 }
 
 
+struct iterator *
+generic_index_create_iterator_with_offset(struct index *base,
+					  enum iterator_type type,
+					  const char *key, uint32_t part_count,
+					  const char *pos, uint32_t offset)
+{
+	/* Create a reguar iterator. */
+	struct iterator *it = index_create_iterator_after(
+		base, type, key, part_count, pos);
+	if (it == NULL)
+		return NULL;
+
+	/* Skip the required amount of tuples. */
+	for (size_t i = 0; i < offset; i++) {
+		if (box_check_slice() != 0)
+			goto fail;
+		struct tuple *skipped_tuple;
+		if (iterator_next(it, &skipped_tuple) != 0)
+			goto fail;
+		if (skipped_tuple == NULL)
+			return it;
+	}
+	return it;
+fail:
+	iterator_delete(it);
+	return NULL;
+}
+
 struct index_read_view *
 generic_index_create_read_view(struct index *index)
 {

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -575,6 +575,13 @@ struct index_vtab {
 					    const char *key,
 					    uint32_t part_count,
 					    const char *pos);
+	/** The same as create_iterator but skip first @offset tuples. */
+	struct iterator *(*create_iterator_with_offset)(struct index *index,
+							enum iterator_type type,
+							const char *key,
+							uint32_t part_count,
+							const char *pos,
+							uint32_t offset);
 	/** Create an index read view. */
 	struct index_read_view *(*create_read_view)(struct index *index);
 	/** Introspection (index:stat()) */
@@ -919,6 +926,15 @@ index_replace(struct index *index, struct tuple *old_tuple,
 }
 
 static inline struct iterator *
+index_create_iterator_with_offset(struct index *index, enum iterator_type type,
+				  const char *key, uint32_t part_count,
+				  const char *pos, uint32_t offset)
+{
+	return index->vtab->create_iterator_with_offset(
+		index, type, key, part_count, pos, offset);
+}
+
+static inline struct iterator *
 index_create_iterator_after(struct index *index, enum iterator_type type,
 			    const char *key, uint32_t part_count,
 			    const char *pos)
@@ -1079,6 +1095,11 @@ struct iterator *
 generic_index_create_iterator(struct index *base, enum iterator_type type,
 			      const char *key, uint32_t part_count,
 			      const char *pos);
+struct iterator *
+generic_index_create_iterator_with_offset(struct index *base,
+					  enum iterator_type type,
+					  const char *key, uint32_t part_count,
+					  const char *pos, uint32_t offset);
 int generic_index_build_next(struct index *, struct tuple *);
 void generic_index_end_build(struct index *);
 int

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -256,14 +256,16 @@ box_tuple_extract_key(box_tuple_t *tuple, uint32_t space_id,
 /** \endcond public */
 
 /**
- * Allocate and initialize iterator for space_id, index_id. If packed_pos is
- * not NULL, iterator will start right after tuple with position, described by
- * this argument. A returned iterator must be destroyed by box_iterator_free().
+ * Allocate and initialize iterator for space_id, index_id and then skip @a
+ * offset tuples. If packed_pos is not NULL, iterator will start right after
+ * tuple with position, described by this argument. A returned iterator must
+ * be destroyed by box_iterator_free().
  */
 box_iterator_t *
-box_index_iterator_after(uint32_t space_id, uint32_t index_id, int type,
-			 const char *key, const char *key_end,
-			 const char *packed_pos, const char *packed_pos_end);
+box_index_iterator_with_offset(uint32_t space_id, uint32_t index_id, int type,
+			       const char *key, const char *key_end,
+			       const char *packed_pos,
+			       const char *packed_pos_end, uint32_t offset);
 
 /**
  * A helper for position extractors. Get packed position of tuple in
@@ -342,7 +344,7 @@ struct iterator {
 	/**
 	 * Pointer to a buffer which was allocated for start position with
 	 * runtime_alloc. Will be freed on iterator_delete.
-	 * Needed for box_index_iterator_after.
+	 * Needed for box_index_iterator_with_offset.
 	 */
 	char *pos_buf;
 };

--- a/src/box/lua/index.c
+++ b/src/box/lua/index.c
@@ -304,11 +304,11 @@ box_index_init_iterator_types(struct lua_State *L, int idx)
 static int
 lbox_index_iterator(lua_State *L)
 {
-	if (lua_gettop(L) != 6 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2) ||
-	    !lua_isnumber(L, 3)) {
+	if (lua_gettop(L) != 7 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2) ||
+	    !lua_isnumber(L, 3) || !lua_isnumber(L, 6)) {
 		diag_set(IllegalParams,
 			 "Usage: index.iterator(space_id, index_id, "
-			 "type, key, after, level)");
+			 "type, key, after, offset, level)");
 		return luaT_error(L);
 	}
 
@@ -316,7 +316,8 @@ lbox_index_iterator(lua_State *L)
 	uint32_t space_id = lua_tonumber(L, 1);
 	uint32_t index_id = lua_tonumber(L, 2);
 	uint32_t iterator = lua_tonumber(L, 3);
-	int level = lua_tonumber(L, 6);
+	uint32_t offset = lua_tonumber(L, 6);
+	int level = lua_tonumber(L, 7);
 	size_t mpkey_len;
 	const char *mpkey = lua_tolstring(L, 4, &mpkey_len); /* Key encoded by Lua */
 	struct iterator *it = NULL;
@@ -325,9 +326,9 @@ lbox_index_iterator(lua_State *L)
 	if (lbox_index_normalize_position(L, 5, space_id, index_id,
 					  &packed_pos, &packed_pos_end) != 0)
 		goto error;
-	it = box_index_iterator_after(space_id, index_id, iterator, mpkey,
-				      mpkey + mpkey_len, packed_pos,
-				      packed_pos_end);
+	it = box_index_iterator_with_offset(space_id, index_id, iterator, mpkey,
+					    mpkey + mpkey_len, packed_pos,
+					    packed_pos_end, offset);
 
 	if (it == NULL)
 		goto error;

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -49,10 +49,12 @@ ffi.cdef[[
     typedef struct iterator box_iterator_t;
 
     box_iterator_t *
-    box_index_iterator_after(uint32_t space_id, uint32_t index_id, int type,
-                             const char *key, const char *key_end,
-                             const char *packed_pos,
-                             const char *packed_pos_end);
+    box_index_iterator_with_offset(uint32_t space_id, uint32_t index_id,
+                                   int type, const char *key,
+                                   const char *key_end,
+                                   const char *packed_pos,
+                                   const char *packed_pos_end,
+                                   uint32_t offset);
     int
     box_iterator_next(box_iterator_t *itr, box_tuple_t **result);
     void
@@ -2037,8 +2039,12 @@ end
 
 local function check_pairs_opts(opts, key_is_nil, level)
     local iterator = check_iterator_type(opts, key_is_nil, level and level + 1)
+    local offset = 0
     local after = nil
     if opts ~= nil and type(opts) == "table" then
+        if opts.offset ~= nil then
+            offset = opts.offset
+        end
         if opts.after ~= nil then
             after = opts.after
             if after ~= nil and type(after) ~= "string" and type(after) ~= "table"
@@ -2047,7 +2053,7 @@ local function check_pairs_opts(opts, key_is_nil, level)
             end
         end
     end
-    return iterator, after
+    return iterator, after, offset
 end
 
 box.internal.check_pairs_opts = check_pairs_opts
@@ -2458,16 +2464,16 @@ base_index_mt.pairs_ffi = function(index, key, opts)
     local ibuf = cord_ibuf_take()
     local pkey, pkey_end = tuple_encode(ibuf, key, 2)
     local svp = builtin.box_region_used()
-    local itype, after = check_pairs_opts(opts, pkey + 1 >= pkey_end, 2)
+    local itype, after, offset = check_pairs_opts(opts, pkey + 1 >= pkey_end, 2)
     local ok = iterator_pos_set(index, after, ibuf, 2)
     local keybuf = ffi.string(pkey, pkey_end - pkey)
     cord_ibuf_put(ibuf)
     local cdata
     if ok then
         local pkeybuf = ffi.cast('const char *', keybuf)
-        cdata = builtin.box_index_iterator_after(
+        cdata = builtin.box_index_iterator_with_offset(
                 index.space_id, index.id, itype, pkeybuf, pkeybuf + #keybuf,
-                iterator_pos[0], iterator_pos_end[0])
+                iterator_pos[0], iterator_pos_end[0], offset)
     end
     builtin.box_region_truncate(svp)
     if cdata == nil then
@@ -2479,11 +2485,11 @@ end
 base_index_mt.pairs_luac = function(index, key, opts)
     check_index_arg(index, 'pairs', 2)
     key = keify(key)
-    local itype, after = check_pairs_opts(opts, #key == 0, 2)
+    local itype, after, offset = check_pairs_opts(opts, #key == 0, 2)
     local keymp = msgpack.encode(key)
     local keybuf = ffi.string(keymp, #keymp)
     local cdata = internal.iterator(index.space_id, index.id, itype, keymp,
-        after, 2);
+        after, offset, 2);
     return fun.wrap(iterator_gen_luac, keybuf,
         ffi.gc(cdata, builtin.box_iterator_free))
 end

--- a/src/box/memtx_bitset.cc
+++ b/src/box/memtx_bitset.cc
@@ -238,6 +238,7 @@ memtx_bitset_index_size(struct index *base)
 {
 	struct memtx_bitset_index *index = (struct memtx_bitset_index *)base;
 	struct space *space = space_by_id(base->def->space_id);
+	memtx_tx_story_gc();
 	/* Substract invisible count. */
 	return tt_bitset_index_size(&index->index) -
 	       memtx_tx_index_invisible_count(in_txn(), space, base);

--- a/src/box/memtx_bitset.cc
+++ b/src/box/memtx_bitset.cc
@@ -512,6 +512,8 @@ static const struct index_vtab memtx_bitset_index_vtab = {
 	/* .get = */ generic_index_get,
 	/* .replace = */ memtx_bitset_index_replace,
 	/* .create_iterator = */ memtx_bitset_index_create_iterator,
+	/* .create_iterator_with_offset = */
+	generic_index_create_iterator_with_offset,
 	/* .create_read_view = */ generic_index_create_read_view,
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -276,6 +276,7 @@ memtx_hash_index_size(struct index *base)
 {
 	struct memtx_hash_index *index = (struct memtx_hash_index *)base;
 	struct space *space = space_by_id(base->def->space_id);
+	memtx_tx_story_gc();
 	/* Substract invisible count. */
 	return light_index_count(&index->hash_table) -
 	       memtx_tx_index_invisible_count(in_txn(), space, base);

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -666,6 +666,8 @@ static const struct index_vtab memtx_hash_index_vtab = {
 	/* .get = */ memtx_index_get,
 	/* .replace = */ memtx_hash_index_replace,
 	/* .create_iterator = */ memtx_hash_index_create_iterator,
+	/* .create_iterator_with_offset = */
+	generic_index_create_iterator_with_offset,
 	/* .create_read_view = */ memtx_hash_index_create_read_view,
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,

--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -198,6 +198,7 @@ memtx_rtree_index_size(struct index *base)
 {
 	struct memtx_rtree_index *index = (struct memtx_rtree_index *)base;
 	struct space *space = space_by_id(base->def->space_id);
+	memtx_tx_story_gc();
 	/* Substract invisible count. */
 	return rtree_number_of_records(&index->tree) -
 	       memtx_tx_index_invisible_count(in_txn(), space, base);

--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -401,6 +401,8 @@ static const struct index_vtab memtx_rtree_index_vtab = {
 	/* .get = */ memtx_index_get,
 	/* .replace = */ memtx_rtree_index_replace,
 	/* .create_iterator = */ memtx_rtree_index_create_iterator,
+	/* .create_iterator_with_offset = */
+	generic_index_create_iterator_with_offset,
 	/* .create_read_view = */ generic_index_create_read_view,
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -2392,6 +2392,8 @@ static const struct index_vtab memtx_tree_disabled_index_vtab = {
 	/* .get = */ generic_index_get,
 	/* .replace = */ disabled_index_replace,
 	/* .create_iterator = */ generic_index_create_iterator,
+	/* .create_iterator_with_offset = */
+	generic_index_create_iterator_with_offset,
 	/* .create_read_view = */ generic_index_create_read_view,
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,
@@ -2455,6 +2457,8 @@ get_memtx_tree_index_vtab(void)
 				 memtx_tree_index_replace<USE_HINT>,
 		/* .create_iterator = */
 			memtx_tree_index_create_iterator<USE_HINT>,
+		/* .create_iterator_with_offset = */
+		generic_index_create_iterator_with_offset,
 		/* .create_read_view = */
 			memtx_tree_index_create_read_view<USE_HINT>,
 		/* .stat = */ generic_index_stat,

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -277,7 +277,24 @@ struct full_scan_gap_item {
 /**
  * Derived class for count gap, @sa GAP_COUNT.
  */
-#define count_gap_item nearby_gap_item
+struct count_gap_item {
+	/** Base class. */
+	struct gap_item_base base;
+	/** The key. Can be NULL. */
+	const char *key;
+	/* Length of the key. */
+	uint32_t key_len;
+	/* Part count of the key. */
+	uint32_t part_count;
+	/** Search mode. */
+	enum iterator_type type;
+	/** Storage for short key. @key may point here. */
+	char short_key[16];
+	/** The bound tuple. */
+	struct tuple *until;
+	/** The bound tuple hint. */
+	hint_t until_hint;
+};
 
 /**
  * Initialize common part of gap item, except for in_read_gaps member,
@@ -320,7 +337,8 @@ memtx_tx_full_scan_gap_item_new(struct txn *txn);
  */
 static struct count_gap_item *
 memtx_tx_count_gap_item_new(struct txn *txn, enum iterator_type type,
-			    const char *key, uint32_t part_count);
+			    const char *key, uint32_t part_count,
+			    struct tuple *until, hint_t until_hint);
 
 /**
  * Helper structure for searching for point_hole_item in the hash table,
@@ -580,6 +598,8 @@ struct tx_manager
 	struct memtx_tx_mempool inplace_gap_item_mempoool;
 	/** Mempool for nearby_gap_item objects. */
 	struct memtx_tx_mempool nearby_gap_item_mempoool;
+	/** Mempool for count_gap_item objects. */
+	struct memtx_tx_mempool count_gap_item_mempool;
 	/** Mempool for full_scan_gap_item objects. */
 	struct memtx_tx_mempool full_scan_gap_item_mempool;
 	/** List of all memtx_story objects. */
@@ -630,6 +650,9 @@ memtx_tx_manager_init()
 	memtx_tx_mempool_create(&txm.nearby_gap_item_mempoool,
 				sizeof(struct nearby_gap_item),
 				MEMTX_TX_ALLOC_TRACKER);
+	memtx_tx_mempool_create(&txm.count_gap_item_mempool,
+				sizeof(struct count_gap_item),
+				MEMTX_TX_ALLOC_TRACKER);
 	memtx_tx_mempool_create(&txm.full_scan_gap_item_mempool,
 				sizeof(struct full_scan_gap_item),
 				MEMTX_TX_ALLOC_TRACKER);
@@ -650,6 +673,7 @@ memtx_tx_manager_free()
 	mh_point_holes_delete(txm.point_holes);
 	memtx_tx_mempool_destroy(&txm.inplace_gap_item_mempoool);
 	memtx_tx_mempool_destroy(&txm.nearby_gap_item_mempoool);
+	memtx_tx_mempool_destroy(&txm.count_gap_item_mempool);
 	memtx_tx_mempool_destroy(&txm.full_scan_gap_item_mempool);
 }
 
@@ -1672,6 +1696,43 @@ memtx_tx_tuple_matches(struct key_def *def, struct tuple *tuple,
 }
 
 /**
+ * Check if @a tuple is positioned prior to @a until in @a index according
+ * to the iterator @a type direction and the given @a cmp_def.
+ */
+static bool
+memtx_tx_tuple_is_before(struct key_def *cmp_def, struct tuple *tuple,
+			 struct tuple *until, hint_t until_hint,
+			 enum iterator_type type)
+{
+	int dir = iterator_direction(type);
+	hint_t th = tuple_hint(tuple, cmp_def);
+	int until_cmp = tuple_compare(until, until_hint,
+				      tuple, th, cmp_def);
+	return dir * until_cmp > 0;
+}
+
+/**
+ * Check if @a tuple matches the given @a key and iterator @a type by the
+ * given @a key_def and is positioned prior to @a until in index according
+ * to the iterator @a type direction and the given @a cmp_def.
+ *
+ * The @a until parameter is optional (can be NULL).
+ */
+static bool
+memtx_tx_tuple_matches_until(struct key_def *key_def, struct tuple *tuple,
+			     enum iterator_type type, const char *key,
+			     uint32_t part_count, struct key_def *cmp_def,
+			     struct tuple *until, hint_t until_hint)
+{
+	/* Check the border (if any) using the cmp_def. */
+	if (until != NULL && !memtx_tx_tuple_is_before(cmp_def, tuple, until,
+						       until_hint, type))
+		return false;
+
+	return memtx_tx_tuple_matches(key_def, tuple, type, key, part_count);
+}
+
+/**
  * Check for possible conflict relations with GAP_COUNT entries during insertion
  * or deletion of tuple (with the corresponding @a story) in index @a ind. It is
  * needed if and only if there was no replaced tuple in the index for insertion
@@ -1695,12 +1756,14 @@ memtx_tx_handle_counted_write(struct space *space, struct memtx_story *story,
 				 in_read_gaps, tmp) {
 		if (item_base->type != GAP_COUNT)
 			continue;
+
 		struct count_gap_item *item =
 			(struct count_gap_item *)item_base;
 
-		bool tuple_matches = memtx_tx_tuple_matches(
-			index->def->key_def, story->tuple,
-			item->type, item->key, item->part_count);
+		bool tuple_matches = memtx_tx_tuple_matches_until(
+			index->def->key_def, story->tuple, item->type,
+			item->key, item->part_count, index->def->cmp_def,
+			item->until, item->until_hint);
 
 		/*
 		 * Someone has counted tuples in the index by a key and iterator
@@ -2839,12 +2902,32 @@ memtx_tx_tuple_clarify_slow(struct txn *txn, struct space *space,
 } while (0)
 
 uint32_t
-memtx_tx_index_invisible_count_slow(struct txn *txn,
-				    struct space *space, struct index *index)
+memtx_tx_index_invisible_count_matching_until_slow(
+	struct txn *txn, struct space *space, struct index *index,
+	enum iterator_type type, const char *key, uint32_t part_count,
+	struct tuple *until, hint_t until_hint)
 {
+	struct key_def *key_def = index->def->key_def;
+	struct key_def *cmp_def = index->def->cmp_def;
+
+	/*
+	 * The border is only valid if it's located at or after the first
+	 * tuple in the index according to the iterator direction and key.
+	 */
+	assert(until == NULL ||
+	       memtx_tx_tuple_matches(key_def, until, type == ITER_EQ ?
+				      ITER_GE : type == ITER_REQ ? ITER_LE :
+				      type, key, part_count));
+
 	uint32_t res = 0;
 	struct memtx_story *story;
 	memtx_tx_foreach_in_index_tuple_story(space, index, story, {
+		/* All tuples in the story chain share the same key. */
+		if (!memtx_tx_tuple_matches_until(key_def, story->tuple, type,
+						  key, part_count, cmp_def,
+						  until, until_hint))
+			continue;
+
 		struct tuple *visible = NULL;
 		bool is_prepared_ok = detect_whether_prepared_ok(txn);
 		bool unused;
@@ -2854,8 +2937,27 @@ memtx_tx_index_invisible_count_slow(struct txn *txn,
 		if (visible == NULL)
 			res++;
 	});
-	memtx_tx_story_gc();
 	return res;
+}
+
+/**
+ * Detect whether key of @a tuple from @a index is visible to @a txn.
+ */
+bool
+memtx_tx_tuple_key_is_visible_slow(struct txn *txn, struct index *index,
+				   struct tuple *tuple)
+{
+	if (!tuple_has_flag(tuple, TUPLE_IS_DIRTY))
+		return true;
+
+	struct memtx_story *story = memtx_tx_story_get(tuple);
+	struct tuple *visible = NULL;
+	bool is_prepared_ok = detect_whether_prepared_ok(txn);
+	bool unused;
+	memtx_tx_story_find_visible_tuple(story, txn, index->dense_id,
+					  is_prepared_ok, &visible,
+					  &unused);
+	return visible != NULL;
 }
 
 /**
@@ -2872,8 +2974,10 @@ memtx_tx_delete_gap(struct gap_item_base *item)
 		pool = &txm.inplace_gap_item_mempoool;
 		break;
 	case GAP_NEARBY:
-	case GAP_COUNT:
 		pool = &txm.nearby_gap_item_mempoool;
+		break;
+	case GAP_COUNT:
+		pool = &txm.count_gap_item_mempool;
 		break;
 	case GAP_FULL_SCAN:
 		pool = &txm.full_scan_gap_item_mempool;
@@ -3217,6 +3321,30 @@ memtx_tx_inplace_gap_item_new(struct txn *txn)
 	return item;
 }
 
+/*
+ * Saves the given @a key in the @a short_key buffer of size @a short_key_size
+ * if it fits or allocates a new one on the @a txn's region. Returns the key
+ * length in the @a key_len output parameter.
+ */
+static char *
+memtx_tx_save_key(struct txn *txn, const char *key, uint32_t part_count,
+		  char *short_key, size_t short_key_size, uint32_t *key_len)
+{
+	const char *tmp = key;
+	for (uint32_t i = 0; i < part_count; i++)
+		mp_next(&tmp);
+	*key_len = tmp - key;
+	if (part_count == 0)
+		return NULL;
+	char *result = short_key;
+	if (*key_len > short_key_size) {
+		result = memtx_tx_xregion_alloc(txn, *key_len,
+						MEMTX_TX_ALLOC_TRACKER);
+	}
+	memcpy(result, key, *key_len);
+	return result;
+}
+
 /**
  * Allocate and create nearby gap item.
  * Note that in_read_gaps base member must be initialized later.
@@ -3231,33 +3359,37 @@ memtx_tx_nearby_gap_item_new(struct txn *txn, enum iterator_type type,
 
 	item->type = type;
 	item->part_count = part_count;
-	const char *tmp = key;
-	for (uint32_t i = 0; i < part_count; i++)
-		mp_next(&tmp);
-	item->key_len = tmp - key;
-	if (part_count == 0) {
-		item->key = NULL;
-	} else if (item->key_len <= sizeof(item->short_key)) {
-		item->key = item->short_key;
-	} else {
-		item->key = memtx_tx_xregion_alloc(txn, item->key_len,
-						   MEMTX_TX_ALLOC_TRACKER);
-	}
-	memcpy((char *)item->key, key, item->key_len);
+	item->key = memtx_tx_save_key(txn, key, part_count, item->short_key,
+				      sizeof(item->short_key), &item->key_len);
 	return item;
 }
 
 /**
- * Allocate and create count gap item.
+ * Allocate and create count gap item. The @a until tuple's story must have
+ * a gap item from the @a txn transaction or be tracked by it, so the story
+ * is not deleted by the garbage collector and the tuple is not deleted (if
+ * it's not NULL).
+ *
  * Note that in_read_gaps base member must be initialized later.
  */
 static struct count_gap_item *
 memtx_tx_count_gap_item_new(struct txn *txn, enum iterator_type type,
-			    const char *key, uint32_t part_count)
+			    const char *key, uint32_t part_count,
+			    struct tuple *until, hint_t until_hint)
 {
-	struct count_gap_item *item =
-		memtx_tx_nearby_gap_item_new(txn, type, key, part_count);
-	item->base.type = GAP_COUNT;
+	assert(until == NULL || tuple_has_flag(until, TUPLE_IS_DIRTY));
+
+	struct memtx_tx_mempool *pool = &txm.count_gap_item_mempool;
+	struct count_gap_item *item = memtx_tx_xmempool_alloc(txn, pool);
+	gap_item_base_create(&item->base, GAP_COUNT, txn);
+
+	item->type = type;
+	item->part_count = part_count;
+	item->key = memtx_tx_save_key(txn, key, part_count, item->short_key,
+				      sizeof(item->short_key), &item->key_len);
+	item->until = until;
+	item->until_hint = until_hint;
+
 	return item;
 }
 
@@ -3313,18 +3445,34 @@ memtx_tx_track_gap_slow(struct txn *txn, struct space *space, struct index *inde
 /**
  * Record in TX manager that a transaction @a txn have counted @a index of @a
  * space by @a key and iterator @a type. This function must be used for queries
- * that count tuples in indexes (for example, index:size or index:count).
+ * that count tuples in indexes (for example, index:size or index:count) or if
+ * tuples are skipped by a transaction without reading.
  *
  * @return the amount of invisible tuples counted.
+ *
+ * @pre The @a until tuple (if not NULL) must be clarified by @a txn.
  */
 uint32_t
-memtx_tx_track_count_slow(struct txn *txn, struct space *space,
-			  struct index *index, enum iterator_type type,
-			  const char *key, uint32_t part_count)
+memtx_tx_track_count_until_slow(struct txn *txn, struct space *space,
+				struct index *index, enum iterator_type type,
+				const char *key, uint32_t part_count,
+				struct tuple *until, hint_t until_hint)
 {
+	struct key_def *key_def = index->def->key_def;
+	struct key_def *cmp_def = index->def->cmp_def;
+
+	/*
+	 * The border is only valid if it's located at or after the first
+	 * tuple in the index according to the iterator direction and key.
+	 */
+	assert(until == NULL ||
+	       memtx_tx_tuple_matches(key_def, until, type == ITER_EQ ?
+				      ITER_GE : type == ITER_REQ ? ITER_LE :
+				      type, key, part_count));
+
 	if (txn != NULL && txn->status == TXN_INPROGRESS) {
-		struct count_gap_item *item =
-			memtx_tx_count_gap_item_new(txn, type, key, part_count);
+		struct count_gap_item *item = memtx_tx_count_gap_item_new(
+			txn, type, key, part_count, until, until_hint);
 		rlist_add(&index->read_gaps, &item->base.in_read_gaps);
 	}
 
@@ -3345,8 +3493,9 @@ memtx_tx_track_count_slow(struct txn *txn, struct space *space,
 	struct memtx_story *story;
 	memtx_tx_foreach_in_index_tuple_story(space, index, story, {
 		/* All tuples in the story chain share the same key. */
-		if (!memtx_tx_tuple_matches(index->def->key_def, story->tuple,
-					    type, key, part_count))
+		if (!memtx_tx_tuple_matches_until(key_def, story->tuple, type,
+						  key, part_count, cmp_def,
+						  until, until_hint))
 			continue;
 
 		/*

--- a/src/box/memtx_tx.h
+++ b/src/box/memtx_tx.h
@@ -322,9 +322,10 @@ memtx_tx_track_gap(struct txn *txn, struct space *space, struct index *index,
  * Helper of memtx_tx_track_count.
  */
 uint32_t
-memtx_tx_track_count_slow(struct txn *txn, struct space *space,
-			  struct index *index, enum iterator_type type,
-			  const char *key, uint32_t part_count);
+memtx_tx_track_count_until_slow(struct txn *txn, struct space *space,
+				struct index *index, enum iterator_type type,
+				const char *key, uint32_t part_count,
+				struct tuple *until, hint_t until_hint);
 
 /**
  * Record in TX manager that a transaction @a txn have counted @a index from @a
@@ -342,8 +343,32 @@ memtx_tx_track_count(struct txn *txn, struct space *space,
 {
 	if (!memtx_tx_manager_use_mvcc_engine)
 		return 0;
-	return memtx_tx_track_count_slow(txn, space, index,
-					 type, key, part_count);
+	return memtx_tx_track_count_until_slow(txn, space, index, type, key,
+					       part_count, NULL, HINT_NONE);
+}
+
+/**
+ * Record in TX manager that a transaction @a txn have counted @a index from @a
+ * space by @a key and iterator @a type @a until a tuple. This function must be
+ * used when all tuples matching the key and iterator until the given one are
+ * skipped by a transaction without reading (e. g. select with offset).
+ *
+ * NB: can trigger story garbage collection.
+ *
+ * @return the amount of invisible tuples counted.
+ *
+ * @pre The @a until tuple (if not NULL) must be clarified by @a txn.
+ */
+static inline uint32_t
+memtx_tx_track_count_until(struct txn *txn, struct space *space,
+			   struct index *index, enum iterator_type type,
+			   const char *key, uint32_t part_count,
+			   struct tuple *until, hint_t until_hint)
+{
+	if (!memtx_tx_manager_use_mvcc_engine)
+		return 0;
+	return memtx_tx_track_count_until_slow(txn, space, index, type, key,
+					       part_count, until, until_hint);
 }
 
 /**
@@ -400,9 +425,14 @@ memtx_tx_tuple_clarify(struct txn *txn, struct space *space,
 	return memtx_tx_tuple_clarify_slow(txn, space, tuple, index, mk_index);
 }
 
+/**
+ * Helper of invisible count functions.
+ */
 uint32_t
-memtx_tx_index_invisible_count_slow(struct txn *txn,
-				    struct space *space, struct index *index);
+memtx_tx_index_invisible_count_matching_until_slow(
+	struct txn *txn, struct space *space, struct index *index,
+	enum iterator_type type, const char *key, uint32_t part_count,
+	struct tuple *until, hint_t until_hint);
 
 /**
  * When MVCC engine is enabled, an index can contain temporary non-committed
@@ -411,8 +441,6 @@ memtx_tx_index_invisible_count_slow(struct txn *txn,
  * standalone observer.
  * The function calculates tje number of tuples that are physically present
  * in index, but have no visible value.
- *
- * NB: can trigger story garbage collection.
  */
 static inline uint32_t
 memtx_tx_index_invisible_count(struct txn *txn,
@@ -420,7 +448,46 @@ memtx_tx_index_invisible_count(struct txn *txn,
 {
 	if (!memtx_tx_manager_use_mvcc_engine)
 		return 0;
-	return memtx_tx_index_invisible_count_slow(txn, space, index);
+	return memtx_tx_index_invisible_count_matching_until_slow(
+		txn, space, index, ITER_GE, NULL, 0, NULL, HINT_NONE);
+}
+
+/**
+ * Same as memtx_tx_index_invisible_count but only counts tuples matching to
+ * the given key and iterator up to the given tuple (exclusively) according to
+ * the index order.
+ *
+ * E. g. for index: [1, 2, 3, 4, 5], given all items in the index are invisible
+ * to the transaction, counting matching LE 3 until 1 will give 2 (3 and 2 will
+ * be counted, 1 will not since the count is exclusive).
+ */
+static inline uint32_t
+memtx_tx_index_invisible_count_matching_until(
+	struct txn *txn, struct space *space, struct index *index,
+	enum iterator_type type, const char *key, uint32_t part_count,
+	struct tuple *until, hint_t until_hint)
+{
+	if (!memtx_tx_manager_use_mvcc_engine)
+		return 0;
+	return memtx_tx_index_invisible_count_matching_until_slow(
+		txn, space, index, type, key, part_count, until, until_hint);
+}
+
+/** Helper of memtx_tx_tuple_is_visible. */
+bool
+memtx_tx_tuple_key_is_visible_slow(struct txn *txn, struct index *index,
+				   struct tuple *tuple);
+
+/**
+ * Detect whether key of @a tuple from @a index is visible to @a txn.
+ */
+static inline bool
+memtx_tx_tuple_key_is_visible(struct txn *txn, struct index *index,
+			      struct tuple *tuple)
+{
+	if (!memtx_tx_manager_use_mvcc_engine)
+		return true;
+	return memtx_tx_tuple_key_is_visible_slow(txn, index, tuple);
 }
 
 /**

--- a/src/box/session_settings.c
+++ b/src/box/session_settings.c
@@ -282,6 +282,8 @@ static const struct index_vtab session_settings_index_vtab = {
 	/* .get = */ session_settings_index_get,
 	/* .replace = */ generic_index_replace,
 	/* .create_iterator = */ session_settings_index_create_iterator,
+	/* .create_iterator_with_offset = */
+	generic_index_create_iterator_with_offset,
 	/* .create_read_view = */ generic_index_create_read_view,
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,

--- a/src/box/sysview.c
+++ b/src/box/sysview.c
@@ -193,6 +193,8 @@ static const struct index_vtab sysview_index_vtab = {
 	/* .get = */ sysview_index_get,
 	/* .replace = */ generic_index_replace,
 	/* .create_iterator = */ sysview_index_create_iterator,
+	/* .create_iterator_with_offset = */
+	generic_index_create_iterator_with_offset,
 	/* .create_read_view = */ generic_index_create_read_view,
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -4723,6 +4723,8 @@ static const struct index_vtab vinyl_index_vtab = {
 	/* .get = */ vinyl_index_get,
 	/* .replace = */ generic_index_replace,
 	/* .create_iterator = */ vinyl_index_create_iterator,
+	/* .create_iterator_with_offset = */
+	generic_index_create_iterator_with_offset,
 	/* .create_read_view = */ generic_index_create_read_view,
 	/* .stat = */ vinyl_index_stat,
 	/* .compact = */ vinyl_index_compact,

--- a/test/box-luatest/gh_8204_fast_offset_test.lua
+++ b/test/box-luatest/gh_8204_fast_offset_test.lua
@@ -256,6 +256,126 @@ g_generic.test_offset = function()
     end)
 end
 
+g_generic.test_offset_of = function()
+    g_generic.server:exec(function()
+        -- Create and fill the space.
+        local s = box.schema.space.create('test')
+
+        -- A test wrapper to fit cases in single lines.
+        local function check(key, it, expect)
+            local pp = require('luatest.pp')
+
+            -- The location of the callee.
+            local file = debug.getinfo(2, 'S').source
+            local line = debug.getinfo(2, 'l').currentline
+
+            -- The stringified key.
+            local key_str = pp.tostring(key)
+
+            t.assert_equals(s:offset_of(key, {iterator = it}), expect,
+                            string.format('\nkey: %s,\niterator: %s,' ..
+                                          '\nfile: %s,\nline: %d,',
+                                          key_str, it, file, line))
+        end
+
+        -- Test a space without indexes. This is not right since we have no
+        -- indexes and thus no way to check if the given key is valid, but
+        -- that's the way it works, so it has to be tested.
+        for _, it in pairs({'lt', 'le', 'req', 'eq', 'ge', 'gt', 'np', 'pp'}) do
+            check({}, it, 0)
+            check({37}, it, 0)
+            check({"string"}, it, 0)
+            check({"multi", "part"}, it, 0)
+        end
+
+        -- Create and fill an index of unsigned integers.
+        s:create_index('pk')
+        s:insert({1})
+        s:insert({3})
+
+        -- iterator = GE
+        check({0}, 'ge', 0) -- [<1>, 3]
+        check({1}, 'ge', 0) -- [<1>, 3]
+        check({2}, 'ge', 1) -- [1, <3>]
+        check({3}, 'ge', 1) -- [1, <3>]
+        check({4}, 'ge', 2) -- [1, 3, <...>]
+
+        -- iterator = GT
+        check({0}, 'gt', 0) -- [<1>, 3]
+        check({1}, 'gt', 1) -- [1, <3>]
+        check({2}, 'gt', 1) -- [1, <3>]
+        check({3}, 'gt', 2) -- [1, 3, <...>]
+        check({4}, 'gt', 2) -- [1, 3, <...>]
+
+        -- iterator = LE
+        check({0}, 'le', 2) -- [3, 1, <...>]
+        check({1}, 'le', 1) -- [3, <1>]
+        check({2}, 'le', 1) -- [3, <1>]
+        check({3}, 'le', 0) -- [<3>, 1]
+        check({4}, 'le', 0) -- [<3>, 1]
+
+        -- iterator = LT
+        check({0}, 'lt', 2) -- [3, 1, <...>]
+        check({1}, 'lt', 2) -- [3, 1, <...>]
+        check({2}, 'lt', 1) -- [3, <1>]
+        check({3}, 'lt', 1) -- [3, <1>]
+        check({4}, 'lt', 0) -- [<3>, 1]
+
+        -- iterator = EQ
+        check({0}, 'eq', 0) -- [<0>, 1, 3]
+        check({1}, 'eq', 0) -- [<1>, 3]
+        check({2}, 'eq', 1) -- [1, <2>, 3]
+        check({3}, 'eq', 1) -- [1, <3>]
+        check({4}, 'eq', 2) -- [1, 3, <4>]
+
+        -- iterator = REQ
+        check({0}, 'req', 2) -- [3, 1, <0>]
+        check({1}, 'req', 1) -- [3, <1>]
+        check({2}, 'req', 1) -- [3, <2>, 1]
+        check({3}, 'req', 0) -- [<3>, 1]
+        check({4}, 'req', 0) -- [<4>, 3, 1]
+
+        -- Create and fill an index of strings.
+        s.index.pk:drop()
+        s:create_index('pk', {parts = {1, 'string'}})
+        s:insert({'b'})
+        s:insert({'bb'})
+        s:insert({'bc'})
+        s:insert({'c'})
+        s:insert({'cc'})
+
+        -- iterator = NP
+        check({'a'},  'np', 0) -- [<b>, bb, bc, c, cc]
+        check({'ba'}, 'np', 1) -- [b, <bb>, bc, c, cc]
+        check({'bb'}, 'np', 2) -- [b, bb, <bc>, c, cc]
+        check({'b'},  'np', 3) -- [b, bb, bc, <c>, cc]
+        check({'ca'}, 'np', 4) -- [b, bb, bc, c, <cc>]
+        check({'c'},  'np', 5) -- [b, bb, bc, c, cc, <...>]
+
+        -- iterator = PP
+        check({'b'},  'pp', 5) -- [cc, c, bc, bb, b, <...>]
+        check({'bb'}, 'pp', 4) -- [cc, c, bc, bb, <b>]
+        check({'bc'}, 'pp', 3) -- [cc, c, bc, <bb>, b]
+        check({'bd'}, 'pp', 2) -- [cc, c, <bc>, bb, b]
+        check({'cc'}, 'pp', 1) -- [cc, <c>, bc, bb, b]
+        check({'cd'}, 'pp', 0) -- [<cc>, c, bc, bb, b]
+
+        -- Create and fill a multipart index.
+        s.index.pk:drop()
+        s:create_index('pk', {parts = {{1, 'unsigned'}, {2, 'unsigned'}}})
+        s:insert({1, 1})
+        s:insert({1, 2})
+        s:insert({2, 1})
+
+        check({1}, 'eq',  0) -- [<{1, 1}>, {1, 2}, {2, 1}]
+        check({1}, 'gt',  2) -- [{1, 1}, {1, 2}, <{2, 1}>]
+        check({1}, 'ge',  0) -- [<{1, 1}>, {1, 2}, {2, 1}]
+        check({1}, 'req', 1) -- [{2, 1}, <{1, 2}>, {1, 1}]
+        check({1}, 'lt',  3) -- [{2, 1}, {1, 2}, {1, 1}, <...>]
+        check({1}, 'le',  1) -- [{2, 1}, <{1, 2}>, {1, 1}]
+    end)
+end
+
 g_mvcc.test_count = function()
     g_mvcc.server:exec(function()
         -- The test space with fast offset PK.

--- a/test/box-luatest/gh_8204_fast_offset_test.lua
+++ b/test/box-luatest/gh_8204_fast_offset_test.lua
@@ -163,6 +163,91 @@ g_generic.test_count = function()
     end)
 end
 
+g_generic.test_offset = function()
+    g_generic.server:exec(function()
+        -- A space with a secondary key (so we can check nulls).
+        local s = box.schema.space.create('test')
+        s:create_index('pk')
+
+        -- The tested index.
+        local sk = s:create_index('sk',
+                                  {parts = {{2, 'uint64', is_nullable = true},
+                                            {3, 'uint64', is_nullable = true}}})
+
+        -- The test data.
+
+        local existing_tuples = {
+            {1, 1, 1},
+            {2, 1, 3},
+            {3, 3, 1},
+            {4, 3, 2},
+            {5, 5, 1},
+            {6, 5, 3},
+        }
+
+        local test_keys = {
+            {},
+            {box.NULL}, {box.NULL, box.NULL}, {box.NULL, 0},
+            {box.NULL, 1}, {box.NULL, 2}, {box.NULL, 3}, {box.NULL, 4},
+            {0}, {0, box.NULL}, {0, 0}, {0, 1}, {0, 2}, {0, 3}, {0, 4},
+            {1}, {1, box.NULL}, {1, 0}, {1, 1}, {1, 2}, {1, 3}, {1, 4},
+            {2}, {2, box.NULL}, {2, 0}, {2, 1}, {2, 2}, {2, 3}, {2, 4},
+            {3}, {3, box.NULL}, {3, 0}, {3, 1}, {3, 2}, {3, 3}, {3, 4},
+            {4}, {4, box.NULL}, {4, 0}, {4, 1}, {4, 2}, {4, 3}, {4, 4},
+            {5}, {5, box.NULL}, {5, 0}, {5, 1}, {5, 2}, {5, 3}, {5, 4},
+            {6}, {6, box.NULL}, {6, 0}, {6, 1}, {6, 2}, {6, 3}, {6, 4},
+        }
+
+        local test_offsets = {0, 3, 10}
+
+        local all_iterators = {'lt', 'le', 'eq', 'req', 'ge', 'gt', 'all'}
+
+        -- A helper function for verbose assertion using pretty printer.
+        local function check(it, key, offset, expect)
+            local pp = require('luatest.pp')
+
+            -- The location of the callee.
+            local file = debug.getinfo(2, 'S').source
+            local line = debug.getinfo(2, 'l').currentline
+
+            -- The stringified key.
+            local key_str = pp.tostring(key)
+
+            local opts = {iterator = it, offset = offset}
+            local result = sk:select(key, opts)
+
+            t.assert_equals(result, expect, string.format('\nkey: %s,' ..
+                            '\noffset = %d,\niterator: %s,\nfile: %s,' ..
+                            '\nline: %d,', key_str, offset, it, file, line))
+        end
+
+        -- Test the empty space.
+        for _, it in pairs(all_iterators) do
+            for _, key in pairs(test_keys) do
+                for _, offset in pairs(test_offsets) do
+                    check(it, key, offset, {})
+                end
+            end
+        end
+
+        -- Fill the space.
+        for _, tuple in pairs(existing_tuples) do
+            s:insert(tuple)
+        end
+
+        -- Test the non-empty space.
+        for _, it in pairs(all_iterators) do
+            for _, key in pairs(test_keys) do
+                local selected = sk:select(key, {iterator = it})
+                for _, offset in pairs(test_offsets) do
+                    local expect = {unpack(selected, offset + 1, #selected)}
+                    check(it, key, offset, expect)
+                end
+            end
+        end
+    end)
+end
+
 g_mvcc.test_count = function()
     g_mvcc.server:exec(function()
         -- The test space with fast offset PK.
@@ -508,5 +593,390 @@ g_mvcc.test_past_history = function()
 
         -- Check if insert actually happened.
         t.assert_equals(box.space.test:select{}, {{1, 0}})
+    end)
+end
+
+g_mvcc.test_offset = function()
+    g_mvcc.server:exec(function()
+        -- The test space.
+        local s = box.schema.space.create('test')
+        s:create_index('pk', {parts = {{1, 'unsigned'}, {2, 'unsigned'}}})
+
+        -- Create a space to make tested transactions writing - only writing
+        -- transactions can cause conflicts with aborts.
+        box.schema.space.create('make_conflicting_writer')
+        box.space.make_conflicting_writer:create_index('pk', {sequence = true})
+
+        local kd = require('key_def').new(s.index.pk.parts)
+
+        local all_iterators = {'lt', 'le', 'req', 'eq', 'ge', 'gt'}
+        local iterator_is_reverse = {lt = true, le = true, req = true}
+        local existing_keys = {}
+        local unexisting_keys = {}
+        local all_keys = {}
+        local test_keys = {}
+        local test_offsets = {0, 3, 100}
+
+        -- Prepare proxies.
+        local txn_proxy = require('test.box.lua.txn_proxy')
+        local tx = txn_proxy.new()
+        local tx1 = txn_proxy.new()
+        local tx2 = txn_proxy.new()
+
+        -- Proxy helpers.
+        local conflict = {{error = "Transaction has been aborted by conflict"}}
+        local success = ''
+
+        -- Stringify a table (key or tuple) to use in lua code string.
+        -- E. g. array of 2 elements is transformed into "{1, 2}" string.
+        local function to_lua_code(table)
+            -- Create a raw table without metatables.
+            local raw_table = {}
+            for k, v in pairs(table) do
+                raw_table[k] = v
+            end
+            return require('luatest.pp').tostring(raw_table)
+        end
+
+        -- Some keys are defined to exist in the space, others - aren't. This
+        -- is useful for testing (one knows what can be inserted or deleted).
+        local function to_exist(i)
+            return i % 2 == 1 -- 1, 3, 5 exist, 0, 2, 4, 6 - don't.
+        end
+
+        -- Check if the local tables are consistent with space contents.
+        local function check_spaces()
+            t.assert_equals(s:len(), #existing_keys)
+            t.assert_equals(s:select(), existing_keys)
+        end
+
+        -- Generate key lists.
+        for i = 0, 6 do
+            for j = 0, 6 do
+                if to_exist(i) or j == i then
+                    if not to_exist(i) or not to_exist(j) then
+                        table.insert(unexisting_keys, {i, j})
+                    else
+                        table.insert(existing_keys, {i, j})
+                    end
+                    table.insert(all_keys, {i, j})
+                    table.insert(test_keys, {i, j})
+                end
+            end
+            table.insert(test_keys, {i})
+        end
+        table.insert(test_keys, {})
+
+        -- Insert the keys to exist.
+        for _, key in pairs(existing_keys) do
+            s:insert(key)
+        end
+        check_spaces()
+
+        -- Check if select in the test space with given key and iterator gives
+        -- the expected result.
+        local function check(tx, it, key, offset, expect, file, line)
+            -- The location of the callee.
+            local file = file or debug.getinfo(2, 'S').source
+            local line = line or debug.getinfo(2, 'l').currentline
+
+            -- The stringified key.
+            local key_str = to_lua_code(key)
+
+            local code = string.format('box.space.test:select(%s, ' ..
+                                       '{iterator = "%s", offset = %d})',
+                                       key_str, it, offset)
+
+            local comment = string.format(
+                '\nkey: %s,\niterator: %s,\noffset = %d\nfile: %s,' ..
+                '\nline: %d,', key_str, it, offset, file, line)
+
+            box.space.test.index.pk:len()
+            local ok, res = pcall(tx, code)
+            box.space.test.index.pk:bsize()
+            t.assert(ok, comment)
+            t.assert_equals(res, {expect}, comment)
+        end
+
+        -- Make the tx1 open a transaction and select with iter, key and offset.
+        -- then make the tx2 insert/replace/delete (op) the given tuple,
+        -- then make the tx1 writing to make it abort on conflict,
+        -- then make the tx1 commit its transaction and expect tx1_result.
+        --
+        -- The tuple inserted/deleted by tx2 is cleaned up.
+        -- The make_conflicting_writer space is updated but not restored.
+        local function select_do(it, key, offset, expect, op, tuple, tx1_result)
+            assert(op == 'insert' or op == 'replace' or op == 'delete')
+
+            local old_len = s:len()
+            local tuple_existed = s:count(tuple) ~= 0
+
+            -- The location of the callee.
+            local file = debug.getinfo(2, 'S').source
+            local line = debug.getinfo(2, 'l').currentline
+
+            local key_str = to_lua_code(key)
+            local tuple_str = to_lua_code(tuple)
+
+            local tx2_command = string.format('return box.space.test:%s(%s)',
+                                              op, tuple_str)
+
+            local comment = string.format('\nkey: %s\niterator: %s\noffset: ' ..
+                                          '%d\noperation: %s\ntuple: %s\n' ..
+                                          'file: %s,\nline: %s', key_str, it,
+                                          offset, op, tuple_str, file, line)
+
+            -- Remove past stories cause they cause unconditional conflicts,
+            -- whereas future statements only conflict with count if they
+            -- insert a new matching tuple or delete a counted one.
+            box.internal.memtx_tx_gc(100)
+
+            -- Make the tx1 start a transaction and count.
+            tx1:begin()
+            check(tx1, it, key, offset, expect, file, line);
+
+            -- Make the tx2 perform the op.
+            t.assert_equals(tx2(tx2_command), {tuple}, comment)
+
+            -- Make the tx1 writing to abort on conflict.
+            tx1('box.space.make_conflicting_writer:insert({nil})')
+
+            -- Try to commit the tx1.
+            t.assert_equals(tx1:commit(), tx1_result, comment)
+
+            -- Cleanup.
+            local tuple_exists = s:count(tuple) ~= 0
+            if op == 'insert' and not tuple_existed and tuple_exists then
+                s:delete(tuple)
+            elseif op == 'delete' and tuple_existed and not tuple_exists then
+                s:insert(tuple)
+            end
+            t.assert_equals(s:len(), old_len, comment)
+        end
+
+        -- Check if a tuple matches to the given iterator type and key.
+        local function tuple_matches(tuple, it, key)
+            -- An empty key matches to anything.
+            if #key == 0 then
+                return true
+            end
+
+            local lt_matches = it == 'lt' or it == 'le'
+            local eq_matches = it == 'le' or it == 'ge' or
+                               it == 'eq' or it == 'req'
+            local gt_matches = it == 'ge' or it == 'gt'
+
+            local cmp = kd:compare_with_key(tuple, key)
+            return (cmp == 0 and eq_matches) or
+                   (cmp < 0 and lt_matches) or
+                   (cmp > 0 and gt_matches)
+        end
+
+        -- Check for consistency of select with key, iterator and offset in the
+        -- given transaction: first performs a select, and then performs various
+        -- inserts, replaces and deletes of keys and checks if the select result
+        -- remains the same.
+        --
+        -- If the transaction is nil, starts and commits a new one.
+        local function check_consistency(tx_arg, it, key, offset, expect)
+            -- The location of the callee.
+            local file = debug.getinfo(2, 'S').source
+            local line = debug.getinfo(2, 'l').currentline
+
+            local existing_keys = s:select()
+            local old_len = #existing_keys
+            local tx = tx_arg or txn_proxy.new()
+
+            -- Start a transaction manually if no passed.
+            if tx_arg == nil then
+                tx:begin()
+            end
+
+            check(tx, it, key, offset, expect, file, line)
+            for _, new_key in pairs(unexisting_keys) do
+                s:insert(new_key)
+                check(tx, it, key, offset, expect, file, line)
+            end
+            for _, old_key in pairs(existing_keys) do
+                s:delete(old_key)
+                check(tx, it, key, offset, expect, file, line)
+            end
+            for _, old_key in pairs(unexisting_keys) do
+                s:delete(old_key)
+                check(tx, it, key, offset, expect, file, line)
+            end
+            for _, new_key in pairs(existing_keys) do
+                s:insert(new_key)
+                check(tx, it, key, offset, expect, file, line)
+            end
+
+            -- Autocommit if no transaction passed.
+            if tx_arg == nil then
+                t.assert_equals(tx:commit(), success)
+            end
+
+            t.assert_equals(s:len(), old_len)
+            t.assert_equals(s:select(), existing_keys)
+        end
+
+        -- Conflict (select & replace first).
+        for _, it in pairs(all_iterators) do
+            for _, key in pairs(test_keys) do
+                local selected = s:select(key, {iterator = it})
+                for _, offset in pairs(test_offsets) do
+                    local expect = {unpack(selected, offset + 1, #selected)}
+                    local first = selected[offset + 1]
+                    if first ~= nil then
+                        select_do(it, key, offset, expect,
+                                  'replace', first, conflict)
+                    end
+                end
+            end
+        end
+
+        -- Conflict (select & delete first).
+        for _, it in pairs(all_iterators) do
+            for _, key in pairs(test_keys) do
+                local selected = s:select(key, {iterator = it})
+                for _, offset in pairs(test_offsets) do
+                    local expect = {unpack(selected, offset + 1, #selected)}
+                    local first = selected[offset + 1]
+                    if first ~= nil then
+                        select_do(it, key, offset, expect,
+                                  'delete', first, conflict)
+                    end
+                end
+            end
+        end
+
+        -- No conflict (select & replace skipped).
+        for _, it in pairs(all_iterators) do
+            for _, key in pairs(test_keys) do
+                local selected = s:select(key, {iterator = it})
+                for _, offset in pairs(test_offsets) do
+                    local expect = {unpack(selected, offset + 1, #selected)}
+                    local skipped = {unpack(selected, 1, offset)}
+                    for _, tuple in pairs(skipped) do
+                        select_do(it, key, offset, expect,
+                                  'replace', tuple, success)
+                    end
+                end
+            end
+        end
+        check_spaces()
+
+        -- Conflict (select & delete skipped).
+        for _, it in pairs(all_iterators) do
+            for _, key in pairs(test_keys) do
+                local selected = s:select(key, {iterator = it})
+                for _, offset in pairs(test_offsets) do
+                    local expect = {unpack(selected, offset + 1, #selected)}
+                    local skipped = {unpack(selected, 1, offset)}
+                    for _, tuple in pairs(skipped) do
+                        select_do(it, key, offset, expect,
+                                  'delete', tuple, conflict)
+                    end
+                end
+            end
+        end
+        check_spaces()
+
+        -- Conflict (select & insert potentially skipped).
+        for _, it in pairs(all_iterators) do
+            local dir = iterator_is_reverse[it] and -1 or 1
+            for _, key in pairs(test_keys) do
+                local selected = s:select(key, {iterator = it})
+                for _, offset in pairs(test_offsets) do
+                    local expect = {unpack(selected, offset + 1, #selected)}
+                    local first = selected[offset + 1]
+                    for _, tuple in pairs(unexisting_keys) do
+                        local matches = tuple_matches(tuple, it, key)
+                        local is_before_first = first == nil or
+                            kd:compare(tuple, first) * dir >= 0
+                        if matches and is_before_first then
+                            select_do(it, key, offset, expect,
+                                      'insert', tuple, conflict)
+                        end
+                    end
+                end
+            end
+        end
+
+        -- No conflict (select & replace not matching).
+        for _, it in pairs(all_iterators) do
+            for _, key in pairs(test_keys) do
+                local selected = s:select(key, {iterator = it})
+                for _, offset in pairs(test_offsets) do
+                    local expect = {unpack(selected, offset + 1, #selected)}
+                    for _, tuple in pairs(existing_keys) do
+                        if not tuple_matches(tuple, it, key) then
+                            select_do(it, key, offset, expect,
+                                      'replace', tuple, success)
+                        end
+                    end
+                end
+            end
+        end
+        check_spaces()
+
+        -- No conflict (select & delete not matching).
+        for _, it in pairs(all_iterators) do
+            for _, key in pairs(test_keys) do
+                local selected = s:select(key, {iterator = it})
+                for _, offset in pairs(test_offsets) do
+                    local expect = {unpack(selected, offset + 1, #selected)}
+                    for _, tuple in pairs(existing_keys) do
+                        if not tuple_matches(tuple, it, key) then
+                            select_do(it, key, offset, expect,
+                                      'delete', tuple, success)
+                        end
+                    end
+                end
+            end
+        end
+        check_spaces()
+
+        -- No conflict (select & insert not matching).
+        for _, it in pairs(all_iterators) do
+            for _, key in pairs(test_keys) do
+                local selected = s:select(key, {iterator = it})
+                for _, offset in pairs(test_offsets) do
+                    local expect = {unpack(selected, offset + 1, #selected)}
+                    for _, tuple in pairs(unexisting_keys) do
+                        if not tuple_matches(tuple, it, key) then
+                            select_do(it, key, offset, expect,
+                                      'insert', tuple, success)
+                        end
+                    end
+                end
+            end
+        end
+        check_spaces()
+
+        -- Consistency in the read view.
+        for _, it in pairs(all_iterators) do
+            for _, key in pairs(test_keys) do
+                local selected = s:select(key, {iterator = it})
+                for _, offset in pairs(test_offsets) do
+                    local expect = {unpack(selected, offset + 1, #selected)}
+                    check_consistency(nil, it, key, offset, expect)
+                end
+            end
+        end
+        check_spaces()
+
+        -- Consistency in the read view (in a single transaction).
+        tx:begin()
+        for _, it in pairs(all_iterators) do
+            for _, key in pairs(test_keys) do
+                local selected = s:select(key, {iterator = it})
+                for _, offset in pairs(test_offsets) do
+                    local expect = {unpack(selected, offset + 1, #selected)}
+                    check_consistency(tx, it, key, offset, expect)
+                end
+            end
+        end
+        t.assert_equals(tx:commit(), success)
+        check_spaces()
     end)
 end

--- a/test/box-luatest/gh_8204_fast_offset_test.lua
+++ b/test/box-luatest/gh_8204_fast_offset_test.lua
@@ -213,12 +213,20 @@ g_generic.test_offset = function()
             -- The stringified key.
             local key_str = pp.tostring(key)
 
-            local opts = {iterator = it, offset = offset}
-            local result = sk:select(key, opts)
+            local comment = string.format(
+                '\nkey: %s,\noffset = %d,\niterator: %s,\nfile: %s,' ..
+                '\nline: %d,', key_str, offset, it, file, line)
 
-            t.assert_equals(result, expect, string.format('\nkey: %s,' ..
-                            '\noffset = %d,\niterator: %s,\nfile: %s,' ..
-                            '\nline: %d,', key_str, offset, it, file, line))
+            local opts = {iterator = it, offset = offset}
+
+            local result = sk:select(key, opts)
+            t.assert_equals(result, expect, comment)
+
+            local pairs_result = {}
+            for _, tuple in sk:pairs(key, opts) do
+                table.insert(pairs_result, tuple)
+            end
+            t.assert_equals(pairs_result, expect, comment)
         end
 
         -- Test the empty space.


### PR DESCRIPTION
This patchset completes the CE part of the logarithmic offset RFC:
1. accelerate the `select` with `offset` in memtx;
2. introduce the `offset` parameter of `index:pairs` method;
3. introduce the `index:offset_of` method.

Closes #8204