### PR TITLE
connpool: support filtering by `sharding.roles`

### DIFF
--- a/changelogs/unreleased/gh-10318-connpool-sharding-roles-filter.md
+++ b/changelogs/unreleased/gh-10318-connpool-sharding-roles-filter.md
@@ -1,0 +1,4 @@
+## feature/connpool
+
+- The `connpool.filter()` and `connpool.call()` functions now support
+  filtering by the `sharding.roles` option (gh-10318).


### PR DESCRIPTION
Support filtering replicasets by the configured sharding role by adding `sharding_roles` into the `connpool.filter()` and `connpool.call()` options.

Closes #10318