### PR TITLE
uri: mark the parser source file as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@
 *.hpp diff=cpp
 *.c++ diff=cpp
 *.h++ diff=cpp
+src/lib/uri/uri_parser.c linguist-generated=true


### PR DESCRIPTION
The motivation is to exclude the file from diffs on GitHub's web interface (https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github) and to exclude it from checkpatch checks (https://github.com/tarantool/checkpatch/pull/75).