### PR TITLE
datetime: fix values of unspecified fields in dt.parse()

### DIFF
--- a/changelogs/unreleased/gh-8588-setting-unspecified-fields-fix.md
+++ b/changelogs/unreleased/gh-8588-setting-unspecified-fields-fix.md
@@ -1,0 +1,4 @@
+## bugfix/datetime
+
+* Fixed a bug with setting unspecified fields to undefined values
+  (gh-8588).

--- a/src/lib/core/datetime.c
+++ b/src/lib/core/datetime.c
@@ -166,7 +166,15 @@ datetime_strptime(struct datetime *date, const char *buf, const char *fmt)
 	assert(date != NULL);
 	assert(fmt != NULL);
 	assert(buf != NULL);
-	struct tnt_tm t = { .tm_epoch = 0 };
+	struct tnt_tm t;
+	/* Set to Unix time. */
+	struct datetime dt = {
+		.epoch = 0,
+		.nsec = 0,
+		.tzindex = 0,
+		.tzoffset = 0,
+	};
+	datetime_to_tm(&dt, &t);
 	char *ret = tnt_strptime(buf, fmt, &t);
 	if (ret == NULL)
 		return 0;

--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -8,7 +8,7 @@ local json = require('json')
 local msgpack = require('msgpack')
 local TZ = date.TZ
 
-test:plan(39)
+test:plan(41)
 
 local INT_MAX = 2147483647
 
@@ -2102,6 +2102,30 @@ test:test("Time :set{day = -1} operations", function(test)
     test:is(tostring(ts:set{month = 3, day = 2}), '1904-03-02T00:00:00Z',
             '2 March')
     test:is(tostring(ts:set{day = -1}), '1904-03-31T00:00:00Z', '31 March')
+end)
+
+test:test("Parse datetime with specified seconds", function(test)
+    test:plan(12)
+    local dt = date.parse('01', {format = '%S'})
+    test:is(dt.isdst, false, 'unspecified isdst')
+    test:is(dt.nsec, 0, 'unspecified nsec')
+    test:is(dt.sec, 1, 'specified seconds')
+    test:is(dt.min, 0, 'unspecified minutes')
+    test:is(dt.yday, 1, 'unspecified yday')
+    test:is(dt.day, 1, 'unspecified day')
+    test:is(dt.wday, 5, 'unspecified wday')
+    test:is(dt.tzoffset, 0, 'unspecified tzoffset')
+    test:is(dt.month, 1, 'unspecified month')
+    test:is(dt.year, 1970, 'unspecified year')
+    test:is(dt.hour, 0, 'unspecified hours')
+    test:is(dt.timestamp, 1, 'timestamp')
+end)
+
+test:test("Parse datetime with unspecified seconds", function(test)
+    test:plan(2)
+    local dt = date.parse('01', {format = '%H'})
+    test:is(dt.sec, 0, 'uspecified sec')
+    test:is(dt.timestamp, 3600, 'timestamp')
 end)
 
 os.exit(test:check() and 0 or 1)


### PR DESCRIPTION
datetime object can be created using `datetime.new()` and `datetime.parse()`. `datetime.new()` sets values of unspecified fields to appropriate values of fields in a Unix time (00:00:00 UTC on 1 January 1971, Thursday), see commit 43e10ed34949 ("build, lua: built-in module datetime"):

```lua
tarantool> datetime.new()
---
- 1970-01-01T00:00:00Z
...

tarantool> datetime.new():totable()
---
- sec: 0
  min: 0
  yday: 1
  day: 1
  nsec: 0
  isdst: false
  wday: 5
  tzoffset: 0
  month: 1
  year: 1970
  hour: 0
```

The function `datetime.parse` converts an input string with the date and time information into a datetime object. When fields are not specified in a input string their values becomes undefined:

```
tarantool> dt.parse('01:01:01', {format ='%H:%M:%S'}):totable()
---
- sec: -59
  min: -58
  yday: 366
  day: 31
  nsec: 0
  isdst: false
  wday: 1
  tzoffset: 0
  month: 12
  year: 0
  hour: -22
...

tarantool>
```

The commit fixes aforementioned behaviour of `datetime.parse()` by setting values for fields not specified by user to values of appropriate fields of Unix time.

NO_DOC=bugfix

Fixes #8588