### PR TITLE
box: fix `drop_while` integration with `index:pairs`

### DIFF
--- a/changelogs/unreleased/gh-6403-index-iterator-methods.md
+++ b/changelogs/unreleased/gh-6403-index-iterator-methods.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed a bug when the `drop_while` method of index iterators (`index:pairs()`,
+  `space:pairs()`) dropped an extra element (gh-6403).

--- a/changelogs/unreleased/gh-6403-luafun-fixes.md
+++ b/changelogs/unreleased/gh-6403-luafun-fixes.md
@@ -1,0 +1,6 @@
+## bugfix/lua
+
+* Now `fun.chain` works correctly with iterators without `param`.
+* Now `fun.drop_while` supports stateful iterators.
+* Module `fun` is populated with missing `maximum_by` alias of `max_by`.
+* Now `fun.nth` and `fun.length` work correctly with other luafun iterators.

--- a/perf/lua/CMakeLists.txt
+++ b/perf/lua/CMakeLists.txt
@@ -54,6 +54,7 @@ create_perf_lua_test(NAME 1mops_write)
 create_perf_lua_test(NAME box_select)
 create_perf_lua_test(NAME gh-7089-vclock-copy)
 create_perf_lua_test(NAME uri_escape_unescape)
+create_perf_lua_test(NAME luafun)
 
 include_directories(${MSGPUCK_INCLUDE_DIRS})
 

--- a/perf/lua/luafun.lua
+++ b/perf/lua/luafun.lua
@@ -1,0 +1,77 @@
+local fun = require("fun")
+local clock = require("clock")
+local t = require("tarantool")
+local benchmark = require("benchmark")
+
+local USAGE = [[
+ This benchmark measures the performance of luafun module.
+]]
+
+local params = benchmark.argparse(arg, {}, USAGE)
+
+local bench = benchmark.new(params)
+
+local _, _, build_type = string.match(t.build.target, "^(.+)-(.+)-(.+)$")
+if build_type == "Debug" then
+    print("WARNING: tarantool has built with enabled debug mode")
+end
+
+--
+-- Data for `drop_while` benchmark.
+--
+
+local DROP_WHILE_CYCLES = 10^3
+local DROP_WHILE_N = 10^7
+
+local function DROP_WHILE_FILTER(x)
+    return x <= 50
+end
+
+local DROP_WHILE_DATA = {}
+for _ = 1, DROP_WHILE_N / 2 do
+    local value = math.random(50)
+    table.insert(DROP_WHILE_DATA, value)
+end
+for _ = 1, DROP_WHILE_N / 2 do
+    local value = math.random(51, 100)
+    table.insert(DROP_WHILE_DATA, value)
+end
+
+--
+-- Benchmarks themselves.
+--
+
+local tests = {{
+    name = "drop_while",
+    items = DROP_WHILE_N,
+    cycles = DROP_WHILE_CYCLES,
+    payload = function()
+        local acc = 0
+        for _ = 1, DROP_WHILE_CYCLES do
+            -- Random factor to disable any possible optimizations
+            local factor = math.random(10)
+            for _, i in fun.iter(t):drop_while(DROP_WHILE_FILTER) do
+                acc = acc + i * factor
+            end
+        end
+    end,
+}}
+
+local function run_test(testname, func, items, cycles)
+    local real_time = clock.time()
+    local cpu_time = clock.proc()
+    func()
+    local real_delta = clock.time() - real_time
+    local cpu_delta = clock.proc() - cpu_time
+    bench:add_result(testname, {
+        real_time = real_delta / cycles,
+        cpu_time = cpu_delta / cycles,
+        items = items,
+    })
+end
+
+for _, test in ipairs(tests) do
+    run_test(test.name, test.payload, test.items, test.cycles)
+end
+
+bench:dump_results()

--- a/test/app/luafun.result
+++ b/test/app/luafun.result
@@ -61,6 +61,7 @@ methods
   - max
   - max_by
   - maximum
+  - maximum_by
   - min
   - min_by
   - minimum

--- a/test/box-luatest/gh_6403_space_pairs_luafun_integration_test.lua
+++ b/test/box-luatest/gh_6403_space_pairs_luafun_integration_test.lua
@@ -1,0 +1,44 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+-- Both engines to check if both luac and ffi implementations work correctly
+local g = t.group(nil, {{engine = 'memtx'}, {engine = 'vinyl'}})
+
+g.before_all(function(g)
+    g.server = server:new()
+    g.server:start()
+    g.server:exec(function(engine)
+        local space = box.schema.space.create('test', {engine = engine})
+        space:create_index('primary')
+        space:insert({1})
+        space:insert({2})
+        space:insert({3})
+    end, {g.params.engine})
+end)
+
+g.after_all(function(g)
+    g.server:drop()
+end)
+
+-- Check if drop_while method works fine for space.pairs
+g.test_drop_while = function(g)
+    g.server:exec(function()
+        local fun = require('fun')
+        local select_result = box.space.test:select()
+
+        local function check_case(cond)
+            local actual = box.space.test:pairs():drop_while(cond):totable()
+            local expected = fun.iter(select_result):drop_while(cond):totable()
+            t.assert_equals(actual, expected)
+        end
+
+        check_case(function(_) return false end)
+        check_case(function(_) return true end)
+        check_case(function(t) return t[1] > 100 end)
+        check_case(function(t) return t[1] < 100 end)
+        check_case(function(t) return t[1] > 0 end)
+        check_case(function(t) return t[1] < 0 end)
+        check_case(function(t) return t[1] > 2 end)
+        check_case(function(t) return t[1] < 2 end)
+    end)
+end


### PR DESCRIPTION
Since our index iterators are stateful (can return different values with the same `state` passed), old luafun `drop_while` implementation didn't work well with them - it was skipping an extra element. The PR bumps luafun and resolves this issue.

Closes https://github.com/tarantool/tarantool/issues/6403