### PR TITLE
txn: first step towards cross-engine transactions

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -4947,9 +4947,22 @@ engine_init()
 				    cfg_geti("memtx_sort_threads"),
 				    box_on_indexes_built);
 	engine_register((struct engine *)memtx);
+	assert(memtx->base.id < MAX_TX_ENGINE_COUNT);
 	box_set_memtx_max_tuple_size();
 
 	memcs_engine_register();
+
+	struct engine *vinyl;
+	vinyl = vinyl_engine_new_xc(cfg_gets("vinyl_dir"),
+				    cfg_geti64("vinyl_memory"),
+				    cfg_geti("vinyl_read_threads"),
+				    cfg_geti("vinyl_write_threads"),
+				    box_is_force_recovery);
+	engine_register(vinyl);
+	assert(vinyl->id < MAX_TX_ENGINE_COUNT);
+	box_set_vinyl_max_tuple_size();
+	box_set_vinyl_cache();
+	box_set_vinyl_timeout();
 
 	struct sysview_engine *sysview = sysview_engine_new_xc();
 	engine_register((struct engine *)sysview);
@@ -4959,17 +4972,6 @@ engine_init()
 
 	struct engine *blackhole = blackhole_engine_new_xc();
 	engine_register(blackhole);
-
-	struct engine *vinyl;
-	vinyl = vinyl_engine_new_xc(cfg_gets("vinyl_dir"),
-				    cfg_geti64("vinyl_memory"),
-				    cfg_geti("vinyl_read_threads"),
-				    cfg_geti("vinyl_write_threads"),
-				    box_is_force_recovery);
-	engine_register((struct engine *)vinyl);
-	box_set_vinyl_max_tuple_size();
-	box_set_vinyl_cache();
-	box_set_vinyl_timeout();
 }
 
 /**

--- a/src/box/engine.c
+++ b/src/box/engine.c
@@ -42,12 +42,6 @@ RLIST_HEAD(engines);
 
 enum recovery_state recovery_state = RECOVERY_NOT_STARTED;
 
-/**
- * For simplicity, assume that the engine count can't exceed
- * the value of this constant.
- */
-enum { MAX_ENGINE_COUNT = 10 };
-
 /** Register engine instance. */
 void engine_register(struct engine *engine)
 {

--- a/src/box/engine.h
+++ b/src/box/engine.h
@@ -40,6 +40,20 @@
 extern "C" {
 #endif /* defined(__cplusplus) */
 
+enum {
+	/**
+	 * For simplicity, assume that the total engine count can't exceed
+	 * the value of this constant.
+	 */
+	MAX_ENGINE_COUNT = 10,
+	/**
+	 * Max number of engines involved in a multi-statement transaction.
+	 * This value must be greater than any `engine::id' of an engine
+	 * without `ENGINE_BYPASS_TX' flag.
+	 */
+	MAX_TX_ENGINE_COUNT = 3,
+};
+
 struct engine;
 struct engine_read_view;
 struct txn;
@@ -281,6 +295,10 @@ enum {
 	 * Engine setting this flag must support read views.
 	 */
 	ENGINE_JOIN_BY_MEMTX = 1 << 3,
+	/**
+	 * Set if the engine supports cross-engine transactions.
+	 */
+	ENGINE_SUPPORTS_CROSS_ENGINE_TX = 1 << 4,
 };
 
 struct engine {
@@ -338,7 +356,7 @@ struct engine_join_ctx {
 	void **data;
 };
 
-/** Register engine engine instance. */
+/** Register engine instance. */
 void engine_register(struct engine *engine);
 
 /** Call a visitor function on every registered engine. */

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -221,7 +221,7 @@ struct errcode_record {
 	_(ER_TIMEOUT, 78,			"Timeout exceeded") \
 	_(ER_ACTIVE_TRANSACTION, 79,		"Operation is not permitted when there is an active transaction ") \
 	_(ER_CURSOR_NO_TRANSACTION, 80,		"The transaction the cursor belongs to has ended") \
-	_(ER_CROSS_ENGINE_TRANSACTION, 81,	"A multi-statement transaction can not use multiple storage engines") \
+	_(ER_CROSS_ENGINE_TRANSACTION, 81,	"Storage engine '%s' does not support cross-engine transactions", "engine", STRING) \
 	_(ER_NO_SUCH_ROLE, 82,			"Role '%s' is not found", "role", STRING) \
 	_(ER_ROLE_EXISTS, 83,			"Role '%s' already exists", "role", STRING) \
 	_(ER_CREATE_ROLE, 84,			"Failed to create role '%s': %s", "role", STRING, "details", STRING) \

--- a/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
+++ b/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
@@ -5,7 +5,7 @@ local g = t.group()
 
 -- Sizes of objects from transaction manager.
 -- Please update them, if you changed the relevant structures.
-local SIZE_OF_STMT = 136
+local SIZE_OF_STMT = 144
 -- Size of story with one link (for spaces with 1 index).
 local SIZE_OF_STORY = 144
 -- Size of tuple with 2 number fields

--- a/test/box/transaction.result
+++ b/test/box/transaction.result
@@ -602,7 +602,7 @@ box.begin()
 box.space.test:truncate()
 box.space.vinyl:select{};
 ---
-- error: A multi-statement transaction can not use multiple storage engines
+- error: Storage engine 'vinyl' does not support cross-engine transactions
 ...
 -- A transaction is left open due to an exception in the Lua fragment
 box.rollback();
@@ -638,7 +638,7 @@ box.begin()
 box.space.test:truncate()
 box.space.vinyl:insert{2, 'truncate'};
 ---
-- error: A multi-statement transaction can not use multiple storage engines
+- error: Storage engine 'vinyl' does not support cross-engine transactions
 ...
 -- A transaction is left open due to an exception in the above fragment
 box.rollback();

--- a/test/sql/triggers.result
+++ b/test/sql/triggers.result
@@ -340,7 +340,7 @@ box.execute("INSERT INTO n VALUES (0, '',null);")
 box.execute("UPDATE m SET s1 = 'The Rain In Spain';")
 ---
 - null
-- A multi-statement transaction can not use multiple storage engines
+- Storage engine 'vinyl' does not support cross-engine transactions
 ...
 -- ANALYZE banned in gh-4069
 -- box.sql.execute("ANALYZE m;")
@@ -384,7 +384,7 @@ box.execute("INSERT INTO n VALUES (0, '',null);")
 box.execute("UPDATE m SET s1 = 'The Rain In Spain';")
 ---
 - null
-- A multi-statement transaction can not use multiple storage engines
+- Storage engine 'vinyl' does not support cross-engine transactions
 ...
 -- ANALYZE banned in gh-4069
 -- box.sql.execute("ANALYZE n;")
@@ -428,7 +428,7 @@ box.execute("INSERT INTO test2 VALUES (1)")
 box.execute("SELECT * FROM test")
 ---
 - null
-- A multi-statement transaction can not use multiple storage engines
+- Storage engine 'vinyl' does not support cross-engine transactions
 ...
 box.execute("ROLLBACK;")
 ---


### PR DESCRIPTION
This patch replaces `txn::engine` with `txn::engines[3]`, so that a multi-statement transaction can involve up to 3 storage engines. However, for now the `ENGINE_SUPPORTS_CROSS_ENGINE_TX` flag is set only for `memtx` engine (when MVCC is off), so there are no user-visible changes.

Needed for #1803
Needed for tarantool/tarantool-ee#823