### PR TITLE
sql: fix improper varbinary decoding

### DIFF
--- a/changelogs/unreleased/gh-10243-sql-varbinary-from-lua.md
+++ b/changelogs/unreleased/gh-10243-sql-varbinary-from-lua.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Fixed a bug with using a Lua varbinary object as a bound variable in
+  SQL (gh-10243).

--- a/src/box/lua/execute.c
+++ b/src/box/lua/execute.c
@@ -339,6 +339,7 @@ lua_sql_bind_decode(struct lua_State *L, struct sql_bind *bind, int idx, int i)
 		bind->i64 = field.ival;
 		bind->bytes = sizeof(bind->i64);
 		break;
+	case MP_BIN:
 	case MP_STR:
 		/*
 		 * Data should be saved in allocated memory as it
@@ -360,9 +361,6 @@ lua_sql_bind_decode(struct lua_State *L, struct sql_bind *bind, int idx, int i)
 	case MP_BOOL:
 		bind->b = field.bval;
 		bind->bytes = sizeof(bind->b);
-		break;
-	case MP_BIN:
-		bind->s = mp_decode_bin(&field.sval.data, &bind->bytes);
 		break;
 	case MP_EXT:
 		if (field.ext_type == MP_UUID) {

--- a/test/sql-luatest/gh_10243_varbinary_bound_variable_test.lua
+++ b/test/sql-luatest/gh_10243_varbinary_bound_variable_test.lua
@@ -1,0 +1,25 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_exists = function()
+    g.server:exec(function()
+        local varbinary = require('varbinary')
+        local val = varbinary.new('asd')
+        t.assert_equals(box.execute([[SELECT ?;]], {val}).rows[1][1], val)
+
+        val = box.execute([[SELECT RANDOMBLOB(10);]]).rows[1][1]
+        t.assert(varbinary.is(val))
+        t.assert_equals(box.execute([[SELECT ?;]], {val}).rows[1][1], val)
+    end)
+end


### PR DESCRIPTION
Fixed a bug with decoding Lua varbinary provided as a bound variable.

NO_DOC=bugfix

Closes #10243