### PR TITLE
box: don't require functional index function to be sandboxed

### DIFF
--- a/changelogs/unreleased/gh-10349-func-index-without-sandbox.md
+++ b/changelogs/unreleased/gh-10349-func-index-without-sandbox.md
@@ -1,0 +1,4 @@
+## feature/box
+
+* A functional index can now use a function that does not have the flag
+  `is_sandboxed` (gh-10349).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -293,11 +293,12 @@ static int
 func_index_check_func(struct func *func) {
 	assert(func != NULL);
 	if (func->def->language != FUNC_LANGUAGE_LUA ||
-	    func->def->body == NULL || !func->def->is_deterministic ||
-	    !func->def->is_sandboxed) {
-		diag_set(ClientError, ER_WRONG_INDEX_OPTIONS,
-			 "referenced function doesn't satisfy "
-			 "functional index function constraints");
+	    func->def->body == NULL || !func->def->is_deterministic) {
+		const char *errmsg = tt_sprintf(
+			"function '%s' doesn't meet functional index "
+			"function criteria (stored, deterministic, written in Lua)",
+			func->def->name);
+		diag_set(ClientError, ER_WRONG_INDEX_OPTIONS, errmsg);
 		return -1;
 	}
 	return 0;

--- a/test/box-luatest/gh_10349_functional_index_without_sandbox_test.lua
+++ b/test/box-luatest/gh_10349_functional_index_without_sandbox_test.lua
@@ -1,0 +1,57 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+        box.schema.func.drop('test', {if_exists = true})
+    end)
+end)
+
+g.test_func_index_without_sandbox = function(cg)
+    cg.server:exec(function()
+        local msgpack = require('msgpack')
+        local varbinary = require('varbinary')
+        box.schema.func.create('test', {
+            is_deterministic = true,
+            body = [[function(tuple)
+                local msgpack = require('msgpack')
+                local varbinary = require('varbinary')
+                return {varbinary.new(msgpack.encode(tuple.value))}
+            end]]
+        })
+        local s = box.schema.space.create('test', {
+            format = {
+                {'key', 'unsigned'},
+                {'value', 'any'},
+            },
+        })
+        s:create_index('primary')
+        s:create_index('value', {
+            func = 'test',
+            parts = {{1, 'varbinary'}},
+        })
+        s:insert({1, {foo = 'bar'}})
+        s:insert({2, {fuzz = 'buzz'}})
+        local function get(value)
+            local v = varbinary.new(msgpack.encode(value))
+            return box.space.test.index.value:get(v)
+        end
+        t.assert_equals(get({foo = 'bar'}), {1, {foo = 'bar'}})
+        t.assert_equals(get({fuzz = 'buzz'}), {2, {fuzz = 'buzz'}})
+        t.assert_equals(get({1, 2, 3}), nil)
+    end)
+end

--- a/test/engine/func_index.result
+++ b/test/engine/func_index.result
@@ -29,10 +29,7 @@ lua_code2 = [[function(tuple) return {tuple[1] + tuple[2], 2 * tuple[1] + tuple[
 box.schema.func.create('s_nonpersistent')
  | ---
  | ...
-box.schema.func.create('s_ivaliddef1', {body = lua_code, is_deterministic = false, is_sandboxed = true})
- | ---
- | ...
-box.schema.func.create('s_ivaliddef2', {body = lua_code, is_deterministic = true, is_sandboxed = false})
+box.schema.func.create('s_nondeterministic', {body = lua_code, is_deterministic = false, is_sandboxed = true})
  | ---
  | ...
 
@@ -60,20 +57,14 @@ _ = s:create_index('idx', {func = 6666, parts = {{1, 'unsigned'}}})
 -- Can't use non-persistent function in functional index.
 _ = s:create_index('idx', {func = box.func.s_nonpersistent.id, parts = {{1, 'unsigned'}}})
  | ---
- | - error: 'Wrong index options: referenced function doesn''t satisfy functional index
- |     function constraints'
+ | - error: 'Wrong index options: function ''s_nonpersistent'' doesn''t meet functional
+ |     index function criteria (stored, deterministic, written in Lua)'
  | ...
 -- Can't use non-deterministic function in functional index.
-_ = s:create_index('idx', {func = box.func.s_ivaliddef1.id, parts = {{1, 'unsigned'}}})
+_ = s:create_index('idx', {func = box.func.s_nondeterministic.id, parts = {{1, 'unsigned'}}})
  | ---
- | - error: 'Wrong index options: referenced function doesn''t satisfy functional index
- |     function constraints'
- | ...
--- Can't use non-sandboxed function in functional index.
-_ = s:create_index('idx', {func = box.func.s_ivaliddef2.id, parts = {{1, 'unsigned'}}})
- | ---
- | - error: 'Wrong index options: referenced function doesn''t satisfy functional index
- |     function constraints'
+ | - error: 'Wrong index options: function ''s_nondeterministic'' doesn''t meet functional
+ |     index function criteria (stored, deterministic, written in Lua)'
  | ...
 -- Can't use non-sequential parts in returned key definition.
 _ = s:create_index('idx', {func = box.func.ss.id, parts = {{1, 'unsigned'}, {3, 'unsigned'}}})
@@ -99,7 +90,7 @@ idx = s:create_index('idx', {unique = true, func = box.func.s.id, parts = {{1, '
  | ...
 box.schema.func.drop('s')
  | ---
- | - error: 'Can''t drop function 69: function has references'
+ | - error: 'Can''t drop function 68: function has references'
  | ...
 box.snapshot()
  | ---
@@ -109,7 +100,7 @@ test_run:cmd("restart server default")
  | 
 box.schema.func.drop('s')
  | ---
- | - error: 'Can''t drop function 69: function has references'
+ | - error: 'Can''t drop function 68: function has references'
  | ...
 s = box.space.withdata
  | ---

--- a/test/engine/func_index.test.lua
+++ b/test/engine/func_index.test.lua
@@ -10,8 +10,7 @@ s = box.schema.space.create('withdata', {engine = engine})
 lua_code = [[function(tuple) return {tuple[1] + tuple[2]} end]]
 lua_code2 = [[function(tuple) return {tuple[1] + tuple[2], 2 * tuple[1] + tuple[2]} end]]
 box.schema.func.create('s_nonpersistent')
-box.schema.func.create('s_ivaliddef1', {body = lua_code, is_deterministic = false, is_sandboxed = true})
-box.schema.func.create('s_ivaliddef2', {body = lua_code, is_deterministic = true, is_sandboxed = false})
+box.schema.func.create('s_nondeterministic', {body = lua_code, is_deterministic = false, is_sandboxed = true})
 
 box.schema.func.create('s', {body = lua_code, is_deterministic = true, is_sandboxed = true})
 box.schema.func.create('ss', {body = lua_code2, is_deterministic = true, is_sandboxed = true})
@@ -24,9 +23,7 @@ _ = s:create_index('idx', {func = 6666, parts = {{1, 'unsigned'}}})
 -- Can't use non-persistent function in functional index.
 _ = s:create_index('idx', {func = box.func.s_nonpersistent.id, parts = {{1, 'unsigned'}}})
 -- Can't use non-deterministic function in functional index.
-_ = s:create_index('idx', {func = box.func.s_ivaliddef1.id, parts = {{1, 'unsigned'}}})
--- Can't use non-sandboxed function in functional index.
-_ = s:create_index('idx', {func = box.func.s_ivaliddef2.id, parts = {{1, 'unsigned'}}})
+_ = s:create_index('idx', {func = box.func.s_nondeterministic.id, parts = {{1, 'unsigned'}}})
 -- Can't use non-sequential parts in returned key definition.
 _ = s:create_index('idx', {func = box.func.ss.id, parts = {{1, 'unsigned'}, {3, 'unsigned'}}})
 -- Can't use parts started not by 1 field.


### PR DESCRIPTION
The requirement for a function used in a functional index to be sandboxed is way too strict because a sandbox environment includes only a handful of Lua built-ins, like `math` or `table`. This makes it impossible for a functional index function to call built-in deterministic functions defined in modules (like `msgpack.encode` or `json.encode`) while this could be useful in certain scenarios (see #10349 for an example). Let's allow users to create functional indexes using non-sandboxed functions at their own risk.

Closes #4765
Closes #10349