### PR TITLE
box: add runtime lua_call privileges

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -6290,6 +6290,7 @@ box_free(void)
 	port_free();
 	iproto_constants_free();
 	mempool_destroy(&sync_trigger_data_pool);
+	box_lua_call_runtime_priv_reset();
 	/* schema_module_free(); */
 	/* session_free(); */
 }

--- a/src/box/call.h
+++ b/src/box/call.h
@@ -80,6 +80,23 @@ box_process_eval(struct call_request *request, struct port *port);
 int
 access_check_lua_call(const char *name, uint32_t name_len);
 
+/**
+ * Reset the user runtime privileges.
+ */
+void
+box_lua_call_runtime_priv_reset(void);
+
+/**
+ * Grant a access to lua_call function for a user.
+ * @param uname Name of the user.
+ * @param uname_len Length of the user name.
+ * @param fname Name of the function.
+ * @param fname_len Length of the function name.
+ */
+void
+box_lua_call_runtime_priv_grant(const char *uname, uint32_t uname_len,
+				const char *fname, uint32_t fname_len);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/lua/call.c
+++ b/src/box/lua/call.c
@@ -1268,6 +1268,41 @@ lbox_func_new_or_delete(struct trigger *trigger, void *event)
 	return 0;
 }
 
+static int
+lbox_box_lua_call_runtime_priv_reset(struct lua_State *L)
+{
+	if (lua_gettop(L) != 0) {
+		diag_set(IllegalParams,
+			 "Usage: box.internal.lua_call_runtime_priv_reset()");
+		return luaT_error(L);
+	}
+
+	box_lua_call_runtime_priv_reset();
+	return 0;
+}
+
+static int
+lbox_box_lua_call_runtime_priv_grant(struct lua_State *L)
+{
+	if (lua_gettop(L) != 2 || lua_type(L, 1) != LUA_TSTRING ||
+	    lua_type(L, 2) != LUA_TSTRING) {
+		diag_set(IllegalParams,
+			 "Usage: box.internal.lua_call_runtime_priv_grant(user, func)");
+		return luaT_error(L);
+	}
+
+	size_t grantee_name_len;
+	const char *grantee_name = luaL_checklstring(L, 1, &grantee_name_len);
+
+	size_t func_name_len;
+	const char *func_name = luaL_checklstring(L, 2, &func_name_len);
+
+	box_lua_call_runtime_priv_grant(grantee_name,
+					(uint32_t)grantee_name_len,
+					func_name, (uint32_t)func_name_len);
+	return 0;
+}
+
 static void
 call_serializer_update_options(void)
 {
@@ -1291,6 +1326,8 @@ static const struct luaL_Reg boxlib_internal[] = {
 	{"call_loadproc",  lbox_call_loadproc},
 	{"module_reload", lbox_module_reload},
 	{"func_call", lbox_func_call},
+	{"lua_call_runtime_priv_grant", lbox_box_lua_call_runtime_priv_grant},
+	{"lua_call_runtime_priv_reset", lbox_box_lua_call_runtime_priv_reset},
 	{NULL, NULL}
 };
 

--- a/src/lib/core/assoc.h
+++ b/src/lib/core/assoc.h
@@ -209,6 +209,69 @@ mh_strnu32_find_str(struct mh_strnu32_t *h, const char *str, uint32_t len)
 	return mh_strnu32_find(h, &key, NULL);
 }
 
+/*
+ * Map: (const char *, uint32_t, const char *, uint32_t) => (void *)
+ */
+
+#define mh_name _strnstrnptr
+/**
+ * Key of `mh_strnstrnptr_node_t` hash table.
+ */
+struct mh_strnstrnptr_key_t {
+	/* First string. */
+	const char *s1;
+	/* First string length. */
+	uint32_t s1_len;
+	/* Second string. */
+	const char *s2;
+	/* Second string length. */
+	uint32_t s2_len;
+	/* Key hash calculated using `mh_strnstrnptr_hash`. */
+	uint32_t hash;
+};
+
+/**
+ * Node of `mh_strnstrnptr_node_t` hash table.
+ */
+struct mh_strnstrnptr_node_t {
+	/* First string. */
+	const char *s1;
+	/* First string length. */
+	uint32_t s1_len;
+	/* Second string. */
+	const char *s2;
+	/* Second string length. */
+	uint32_t s2_len;
+	/* Key hash calculated using `mh_strnstrnptr_hash`. */
+	uint32_t hash;
+	/* Mapped value. */
+	void *val;
+};
+
+#define mh_key_t struct mh_strnstrnptr_key_t *
+#define mh_node_t struct mh_strnstrnptr_node_t
+
+#define mh_arg_t void *
+#define mh_hash(a, arg) ((a)->hash)
+#define mh_hash_key(a, arg) ((a)->hash)
+#define mh_cmp(a, b, arg) ((a)->s1_len != (b)->s1_len || \
+			   (a)->s2_len != (b)->s2_len || \
+			   memcmp((a)->s1, (b)->s1, (a)->s1_len) || \
+			   memcmp((a)->s2, (b)->s2, (a)->s2_len))
+#define mh_cmp_key(a, b, arg) mh_cmp(a, b, arg)
+#include "salad/mhash.h"
+
+static inline uint32_t
+mh_strnstrnptr_hash(const char *s1, uint32_t s1_len,
+		    const char *s2, uint32_t s2_len)
+{
+	uint32_t h = MH_STRN_HASH_SEED;
+	uint32_t carry = 0;
+	PMurHash32_Process(&h, &carry, s1, s1_len);
+	PMurHash32_Process(&h, &carry, s2, s2_len);
+	return PMurHash32_Result(h, carry, s1_len + s2_len);
+};
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/test/box-luatest/gh_10306_lua_call_runtime_access_test.lua
+++ b/test/box-luatest/gh_10306_lua_call_runtime_access_test.lua
@@ -1,0 +1,152 @@
+local t = require('luatest')
+local cbuilder = require('luatest.cbuilder')
+local cluster = require('test.config-luatest.cluster')
+
+local g = t.group()
+
+local config = cbuilder:new()
+    :add_instance('i-001', {})
+    :set_global_option('credentials.users.alice')
+    :set_global_option('credentials.users.alice.password', 'ALICE')
+    :config()
+
+g.before_all(cluster.init)
+g.after_each(cluster.drop)
+g.after_all(cluster.clean)
+
+local function access_error_msg(user, func)
+    local templ = 'Execute access to function \'%s\' is denied for user \'%s\''
+    return string.format(templ, func, user)
+end
+
+local function define_access_error_msg_function(server)
+    server:exec(function(access_error_msg)
+        rawset(_G, 'access_error_msg', loadstring(access_error_msg))
+    end, {string.dump(access_error_msg)})
+end
+
+g.test_lua_call_runtime_priv_grant = function(g)
+    local cluster = cluster.new(g, config)
+    cluster:start()
+    define_access_error_msg_function(cluster['i-001'])
+    cluster['i-001']:exec(function()
+        local netbox = require('net.box')
+        local config = require('config')
+        local uri = config:instance_uri().uri
+        local con = netbox.connect(uri, {user='alice', password='ALICE'})
+
+        rawset(_G, 'foo', function() return true end)
+        rawset(_G, 'bar', function() return true end)
+
+        -- Try to call 'foo' for user `alice`. Check that user `alice` does not
+        -- have privileges to call `foo`.
+        t.assert_error_msg_equals(_G.access_error_msg('alice', 'foo'),
+                                  function() con:call('foo') end)
+
+        -- Grant access to call function `foo` for user `alice`.
+        box.internal.lua_call_runtime_priv_grant('alice', 'foo')
+        t.assert(con:call('foo'))
+
+        -- Check that user `alice` does not have permission to call functions
+        -- other than `foo`.
+        t.assert_error_msg_equals(_G.access_error_msg('alice', 'bar'),
+                                  function() con:call('bar') end)
+    end)
+end
+
+g.test_lua_call_runtime_priv_reset = function(g)
+    local cluster = cluster.new(g, config)
+    cluster:start()
+    define_access_error_msg_function(cluster['i-001'])
+    cluster['i-001']:exec(function()
+        local netbox = require('net.box')
+        local config = require('config')
+        local uri = config:instance_uri().uri
+        local con = netbox.connect(uri, {user='alice', password='ALICE'})
+
+        rawset(_G, 'foo', function() return true end)
+        rawset(_G, 'bar', function() return true end)
+
+        -- Grant access to call functions `foo` and `bar` for user `alice`.
+        box.internal.lua_call_runtime_priv_grant('alice', 'foo')
+        box.internal.lua_call_runtime_priv_grant('alice', 'bar')
+
+        t.assert(con:call('foo'))
+        t.assert(con:call('bar'))
+
+        -- Reset access to call lua functions. Verify that user `alice` does not
+        -- have privileges to call any functions.
+        box.internal.lua_call_runtime_priv_reset()
+        t.assert_error_msg_equals(_G.access_error_msg('alice', 'foo'),
+                                  function() con:call('foo') end)
+        t.assert_error_msg_equals(_G.access_error_msg('alice', 'bar'),
+                                  function() con:call('bar') end)
+        t.assert_error_msg_equals(_G.access_error_msg('alice', 'baz'),
+                                  function() con:call('baz') end)
+    end)
+end
+
+g.test_grant_universe_lua_call = function(g)
+    local cluster = cluster.new(g, config)
+    cluster:start()
+    define_access_error_msg_function(cluster['i-001'])
+    cluster['i-001']:exec(function()
+        local netbox = require('net.box')
+        local config = require('config')
+        local uri = config:instance_uri().uri
+        local con = netbox.connect(uri, {user='alice', password='ALICE'})
+
+        rawset(_G, 'foo', function() return true end)
+        rawset(_G, 'bar', function() return true end)
+
+        -- Grant universe access to user `alice`.
+        box.internal.lua_call_runtime_priv_grant('alice', '')
+
+        -- Universe access gives privileges to call any non-builtins functions.
+        t.assert(con:call('foo'))
+        t.assert(con:call('bar'))
+
+        -- Universe access does not allow calling built-in functions.
+        t.assert_error_msg_equals(_G.access_error_msg('alice', 'box.info'),
+                                  function() con:call('box.info') end)
+    end)
+end
+
+g.test_grant_builtins_lua_call = function(g)
+    local cluster = cluster.new(g, config)
+    cluster:start()
+    define_access_error_msg_function(cluster['i-001'])
+    cluster['i-001']:exec(function()
+        local netbox = require('net.box')
+        local config = require('config')
+        local uri = config:instance_uri().uri
+        local con = netbox.connect(uri, {user='alice', password='ALICE'})
+
+        t.assert_error_msg_equals(_G.access_error_msg('alice', 'box.info'),
+                                  function() con:call('box.info') end)
+
+        -- Grant access to call builtins for user `alice`.
+        box.internal.lua_call_runtime_priv_grant('alice', 'box.info')
+
+        -- Check that user `alice` can call built-in functions.
+        t.assert_equals(con:call('box.info'), box.info())
+    end)
+end
+
+g.test_lua_call_runtime_priv_invalid_usage = function(g)
+    local cluster = cluster.new(g, config)
+    cluster:start()
+    define_access_error_msg_function(cluster['i-001'])
+    cluster['i-001']:exec(function()
+        local msg
+        msg = 'Usage: box.internal.lua_call_runtime_priv_grant(user, func)'
+        t.assert_error_msg_equals(msg, box.internal.lua_call_runtime_priv_grant)
+        t.assert_error_msg_equals(msg, box.internal.lua_call_runtime_priv_grant,
+                                  'alice')
+        t.assert_error_msg_equals(msg, box.internal.lua_call_runtime_priv_grant,
+                                  5, 'foo')
+        msg = 'Usage: box.internal.lua_call_runtime_priv_reset()'
+        t.assert_error_msg_equals(msg, box.internal.lua_call_runtime_priv_reset,
+                                  'alice')
+    end)
+end


### PR DESCRIPTION
This patch adds internal API methods for granting and revoking Lua function access.

New internal API methods:

-  `box.internal.lua_call_runtime_priv_grant(<user-name>, <function-name>)` grants access to the specified function for the specified user.
-  `box.internal.lua_call_runtime_priv_grant(<user-name>, '')` grants universal access (excluding built-in functions) for the specified user.
- `box.internal.lua_call_runtime_priv_reset()` revokes all previously granted function execution permissions for all users.

Closes https://github.com/tarantool/tarantool/issues/10306
Part of https://github.com/tarantool/tarantool/issues/10310