### PR TITLE
vinyl: do not abort unrelated transactions on DDL

### DIFF
--- a/changelogs/unreleased/gh-10375-vy-do-not-abort-unrelated-tx-on-ddl.md
+++ b/changelogs/unreleased/gh-10375-vy-do-not-abort-unrelated-tx-on-ddl.md
@@ -1,0 +1,3 @@
+## bugfix/vinyl
+
+* Fixed a bug when any DDL operation aborted unrelated transactions (gh-10375).

--- a/src/box/engine.h
+++ b/src/box/engine.h
@@ -299,6 +299,12 @@ enum {
 	 * Set if the engine supports cross-engine transactions.
 	 */
 	ENGINE_SUPPORTS_CROSS_ENGINE_TX = 1 << 4,
+	/**
+	 * Set if the engine's transaction manager properly handles
+	 * concurrent DDL operations. A DDL operation will abort all
+	 * transactions for engines that don't have this flag set.
+	 */
+	ENGINE_TXM_HANDLES_DDL = 1 << 5,
 };
 
 struct engine {

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -690,6 +690,8 @@ memtx_tx_abort_all_for_ddl(struct txn *ddl_owner)
 	rlist_foreach_entry(to_be_aborted, &txm.all_txs, in_all_txs) {
 		if (to_be_aborted == ddl_owner)
 			continue;
+		if (txn_has_flag(to_be_aborted, TXN_HANDLES_DDL))
+			continue;
 		if (to_be_aborted->status != TXN_INPROGRESS &&
 		    to_be_aborted->status != TXN_IN_READ_VIEW)
 			continue;

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -114,6 +114,12 @@ enum txn_flag {
 	TXN_IS_STARTED_IN_ENGINE = 0x400,
 	/** Transaction supports multiple engines. */
 	TXN_SUPPORTS_MULTI_ENGINE = 0x800,
+	/**
+	 * Transaction properly handles concurrent DDL operations.
+	 * If a transaction doesn't have this flag, it'll be aborted
+	 * by any DDL operation.
+	 */
+	TXN_HANDLES_DDL = 0x1000,
 };
 
 enum {

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -2712,6 +2712,7 @@ vinyl_engine_new(const char *dir, size_t memory,
 
 	env->base.vtab = &vinyl_engine_vtab;
 	env->base.name = "vinyl";
+	env->base.flags = ENGINE_TXM_HANDLES_DDL;
 	return &env->base;
 }
 

--- a/test/engine-luatest/gh_10375_ddl_does_not_abort_unrelated_transactions_test.lua
+++ b/test/engine-luatest/gh_10375_ddl_does_not_abort_unrelated_transactions_test.lua
@@ -1,0 +1,65 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group(nil, t.helpers.matrix{engine = {'memtx', 'vinyl'}})
+
+g.before_all(function(cg)
+    cg.server = server:new({
+        box_cfg = {memtx_use_mvcc_engine = true},
+    })
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test1 ~= nil then
+            box.space.test1:drop()
+        end
+        if box.space.test2 ~= nil then
+            box.space.test2:drop()
+        end
+    end)
+end)
+
+g.test_ddl_does_not_abort_unrelated_transactions = function(cg)
+    t.skip_if(cg.params.engine == 'memtx', 'gh-10377')
+    cg.server:exec(function(engine)
+        local fiber = require('fiber')
+        box.schema.create_space('test1', {engine = engine})
+        box.space.test1:create_index('primary')
+        box.begin()
+        box.space.test1:insert({1, 10})
+        local f = fiber.new(function()
+            box.schema.create_space('test2', {engine = engine})
+            box.space.test2:create_index('primary')
+        end)
+        f:set_joinable(true)
+        t.assert_equals({f:join()}, {true})
+        t.assert_equals({pcall(box.commit)}, {true})
+        t.assert_equals(box.space.test1:select(), {{1, 10}})
+    end, {cg.params.engine})
+end
+
+g.test_ddl_aborts_related_transactions = function(cg)
+    cg.server:exec(function(engine)
+        local fiber = require('fiber')
+        box.schema.create_space('test1', {engine = engine})
+        box.space.test1:create_index('primary')
+        box.begin()
+        box.space.test1:insert({1, 10})
+        local f = fiber.new(function()
+            box.space.test1:create_index('secondary', {parts = {2, 'unsigned'}})
+        end)
+        f:set_joinable(true)
+        t.assert_equals({f:join()}, {true})
+        t.assert_error_covers({
+            type = 'ClientError',
+            code = box.error.TRANSACTION_CONFLICT,
+        }, box.commit)
+        t.assert_equals(box.space.test1:select(), {})
+    end, {cg.params.engine})
+end


### PR DESCRIPTION
Since commit 8f4be3227635 ("txm: disallow yields after DDL operation in TX"), any DDL operation aborts **all** active transactions, even those that wouldn't be affected by it anyway, see `memtx_engine_prepare()`, `memtx_tx_abort_all_for_ddl()`. Actually, there's no need to do that in Vinyl because it properly handles concurrent DDL operations, see commit d3e123695651 ("vinyl: abort affected transactions when space is removed from cache"). Let's skip Vinyl transactions from consideration by marking the Vinyl engine with a special flag.

Closes #10375