### PR TITLE
[backport 3.1] config: close old socket after replacing socket

### DIFF
--- a/changelogs/unreleased/gh-9535-close-listen-socket-after-replace.md
+++ b/changelogs/unreleased/gh-9535-close-listen-socket-after-replace.md
@@ -1,0 +1,4 @@
+## bugfix/config
+
+* Fixed a bug that causes Tarantool to continue listening on the previous socket
+  even after `console.socket` has changed (gh-9535).

--- a/src/box/lua/config/applier/console.lua
+++ b/src/box/lua/config/applier/console.lua
@@ -1,7 +1,11 @@
-local errno = require('errno')
 local console = require('console')
 local log = require('internal.config.utils.log')
 local instance_config = require('internal.config.instance_config')
+local fio = require('fio')
+
+-- Active socket and its location.
+local listening_socket = nil
+local listening_socket_abspath = nil
 
 local function socket_file_to_listen_uri(file)
     if file:startswith('/') or file:startswith('./') then
@@ -10,34 +14,47 @@ local function socket_file_to_listen_uri(file)
     return ('unix/:./%s'):format(file)
 end
 
+local function close_listening_socket()
+    if listening_socket ~= nil then
+        listening_socket:close()
+        listening_socket = nil
+        listening_socket_abspath = nil
+    end
+end
+
 local function apply(config)
     local configdata = config._configdata
     local enabled = configdata:get('console.enabled', {use_default = true})
     if not enabled then
         log.debug('console.apply: console is disabled by the ' ..
             'console.enabled option; skipping...')
+        -- If the console is disabled, we must close the active socket.
+        close_listening_socket()
         return
     end
 
-    local socket_file = configdata:get('console.socket', {use_default = true})
-    assert(socket_file ~= nil)
+    local new_socket_file = configdata:get('console.socket',
+        {use_default = true})
+    assert(new_socket_file ~= nil)
 
     -- The same socket file is pointed by different paths before
     -- and after first box.cfg() if the `process.work_dir` option
     -- is set.
     local iconfig_def = configdata._iconfig_def
-    socket_file = instance_config:prepare_file_path(iconfig_def, socket_file)
+    new_socket_file = instance_config:prepare_file_path(iconfig_def,
+        new_socket_file)
+    local new_socket_abspath = fio.abspath(new_socket_file)
 
-    local listen_uri = socket_file_to_listen_uri(socket_file)
-    log.debug('console.apply: %s', listen_uri)
+    -- If console.socket has changed we must close the listening socket.
+    if listening_socket_abspath ~= new_socket_abspath then
+        close_listening_socket()
+    end
 
-    -- Ignore 'Address already in use' error, because it is
-    -- natural effect of reloading the configuration. All others
-    -- errors are re-raised and lead to failure of apply of the
-    -- configuration.
-    local ok, res = pcall(console.listen, listen_uri)
-    if not ok and errno() ~= errno.EADDRINUSE then
-        error(res)
+    if listening_socket_abspath == nil then
+        local listen_uri = socket_file_to_listen_uri(new_socket_file)
+        log.debug('console.apply: %s', listen_uri)
+        listening_socket = console.listen(listen_uri)
+        listening_socket_abspath = new_socket_abspath
     end
 end
 


### PR DESCRIPTION
*(This is a backport of PR #10198 to `release/3.1`, a future `3.1.2` release.)*

----

Аfter replacing the `console.socket` in config tarantool keeps listening on the previous socket (by default `var/{{ instance_name }}/run/tarantool.control` or the previous socket set to `console.socket`). This patch closes the old listening sockets on the reconfiguration.

Closes #9535