### PR TITLE
build: show tzdata version in tarantool module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -818,6 +818,23 @@ elseif(IS_DIRECTORY .git AND GIT)
     )
 endif()
 
+set(TZDATA_VERSION "")
+set(TZCODE_SOURCE_DIR ${PROJECT_SOURCE_DIR}/third_party/tz)
+if (EXISTS "${TZCODE_SOURCE_DIR}/.git" AND GIT)
+    execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --dirty
+                    WORKING_DIRECTORY ${TZCODE_SOURCE_DIR}
+                    OUTPUT_VARIABLE TZDATA_VERSION
+                    RESULT_VARIABLE TZDATA_ERROR_CODE
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
+if(TZDATA_VERSION STREQUAL "")
+    # The current version of tzdata, must be update on bump.
+    set(TZDATA_VERSION 2022a)
+    message(WARNING "Failed to determine tzdata version from Git tags. \
+                     Using default version \"${TZDATA_VERSION}\".")
+endif()
+
 option(TEST_BUILD "Use defaults suited for tests" OFF)
 set(ABORT_ON_LEAK_DEFAULT ${TEST_BUILD})
 option(ABORT_ON_LEAK "Abort if memory leak is found." ${ABORT_ON_LEAK_DEFAULT})

--- a/changelogs/unreleased/show-tzdata-version.md
+++ b/changelogs/unreleased/show-tzdata-version.md
@@ -1,0 +1,4 @@
+## feature/lua
+
+* Introduced the `tarantool.build.tzdata_version` option to get
+  the `tzdata` version.

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -634,6 +634,10 @@ luaopen_tarantool(lua_State *L)
 	lua_pushstring(L, "build");
 	lua_newtable(L);
 
+	/* tzdata version */
+	lua_pushstring(L, tzdata_version());
+	lua_setfield(L, -2, "tzdata_version");
+
 	/* build.target */
 	lua_pushstring(L, "target");
 	lua_pushstring(L, BUILD_INFO);

--- a/src/trivia/config.h.cmake
+++ b/src/trivia/config.h.cmake
@@ -23,6 +23,11 @@
  * release, e.g. 1.6.6-113-g8399d0e.
  */
 #define PACKAGE_VERSION "@TARANTOOL_VERSION@"
+/**
+ * A string with tag identifier of the tzdata release,
+ * e.g. 2024a.
+ */
+#define TZDATA_VERSION "@TZDATA_VERSION@"
 
 /** \endcond public */
 

--- a/src/version.c
+++ b/src/version.c
@@ -49,3 +49,9 @@ tarantool_version_id(void)
 	return version_id(PACKAGE_VERSION_MAJOR, PACKAGE_VERSION_MINOR,
 			  PACKAGE_VERSION_PATCH);
 }
+
+const char *
+tzdata_version(void)
+{
+	return TZDATA_VERSION;
+}

--- a/src/version.h
+++ b/src/version.h
@@ -86,6 +86,12 @@ tarantool_version(void);
 uint32_t
 tarantool_version_id(void);
 
+/**
+ * Return tzdata version as string
+ */
+const char *
+tzdata_version(void);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/test/app-tap/info.test.lua
+++ b/test/app-tap/info.test.lua
@@ -6,7 +6,7 @@ local test = require('tap').test("info")
 test:plan(1)
 
 test:test("info", function(test)
-    test:plan(10)
+    test:plan(11)
     test:like(tarantool.version, '^[1-9]', "version")
     test:isstring(tarantool.package, "package")
     test:ok(_TARANTOOL == tarantool.version, "version")
@@ -19,6 +19,10 @@ test:test("info", function(test)
             "build.linking")
     test:ok(tarantool.uptime() > 0, "uptime")
     test:ok(tarantool.pid() > 0, "pid")
+
+    local tzdata_version = "2022a"
+    test:is(tarantool.build.tzdata_version, tzdata_version,
+            "build.tzdata_version")
 end)
 
 os.exit(test:check() and 0 or 1)


### PR DESCRIPTION
Show tzdata version in `tarantool.build.tzdata_version`.

NO_TEST=internal

@TarantoolBot document
Title: Document `tarantool.build.tzdata_version`

The option shows a version of tzdata module:

```
tarantool> require('tarantool').build.tzdata_version
---
- 2024a
...
```

Please update the tarantool module documentation:

https://www.tarantool.io/en/doc/latest/reference/reference_lua/tarantool/