### PR TITLE
[backport 3.1] refactor: use Lua C API instead of G(L)

### DIFF
--- a/src/box/lua/info.c
+++ b/src/box/lua/info.c
@@ -475,7 +475,7 @@ lbox_info_memory_call(struct lua_State *L)
 	lua_settable(L, -3);
 
 	lua_pushstring(L, "lua");
-	lua_pushinteger(L, G(L)->gc.total);
+	lua_pushinteger(L, luaL_getgctotal(L));
 	lua_settable(L, -3);
 
 	return 1;

--- a/src/box/lua/slab.cc
+++ b/src/box/lua/slab.cc
@@ -259,7 +259,7 @@ lbox_runtime_info(struct lua_State *L)
 	 * Lua GC heap size
 	 */
 	lua_pushstring(L, "lua");
-	lua_pushinteger(L, G(L)->gc.total);
+	lua_pushinteger(L, luaL_getgctotal(L));
 	lua_settable(L, -3);
 
 	luaL_pushuint64(L, tuple_runtime_memory_used());

--- a/src/lua/utils.c
+++ b/src/lua/utils.c
@@ -380,6 +380,12 @@ luaL_setcdatagc(struct lua_State *L, int idx)
 	lua_pop(L, 1);
 }
 
+size_t
+luaL_getgctotal(struct lua_State *L)
+{
+	return (lua_getgccount(L) * 1024ULL) + lua_gc(L, LUA_GCCOUNTB, 0);
+}
+
 /**
  * A helper to register a single type metatable.
  */

--- a/src/lua/utils.h
+++ b/src/lua/utils.h
@@ -217,6 +217,13 @@ LUA_API void
 luaL_setcdatagc(struct lua_State *L, int idx);
 
 /**
+ * @brief Return size of currently allocated memory.
+ * @param L Lua State
+ */
+size_t
+luaL_getgctotal(struct lua_State *L);
+
+/**
 * @brief Return CTypeID (FFI) of given СDATA type
 * @param L Lua State
 * @param ctypename С type name as string (e.g. "struct request" or "uint32_t")


### PR DESCRIPTION
(This is a backport of PR #10297 to release/3.1, future 3.1.1 release.)

----

To ensure better encapsulation, maintainability, and portability of the code, it is necessary to replace direct access to the fields of global structures with calls using the Lua C API.

Closes #10284

NO_DOC=refactoring
NO_TEST=refactoring
NO_CHANGELOG=refactoring

(cherry picked from commit f7bb3fc7a1222107753dc420675ecda043b0a5d2)