### PR TITLE
[backport 3.1] serializer: remove duplicate of lua serializer

### DIFF
--- a/src/box/lua/console.c
+++ b/src/box/lua/console.c
@@ -969,9 +969,6 @@ tarantool_lua_console_init(struct lua_State *L)
 	 */
 	lua_setfield(L, -2, "formatter_lua");
 
-	/* Output formatter in Lua mode */
-	lua_serializer_init(L);
-
 	struct session_vtab console_session_vtab = {
 		.push	= console_session_push,
 		.fd	= console_session_fd,

--- a/src/box/lua/serialize_lua.c
+++ b/src/box/lua/serialize_lua.c
@@ -52,9 +52,6 @@ static_assert(DT_IVAL_TO_STRING_BUFSIZE > FPCONV_G_FMT_BUFSIZE,
 static_assert(DT_IVAL_TO_STRING_BUFSIZE > DT_TO_STRING_BUFSIZE,
 	      "Buffer is too small");
 
-/* Serializer for Lua output mode */
-static struct luaL_serializer *serializer_lua;
-
 enum {
 	NODE_NONE_BIT		= 0,
 	NODE_ROOT_BIT		= 1,
@@ -1035,35 +1032,4 @@ lua_parse_opts(lua_State *L, lua_dumper_opts_t *opts)
 	if (lua_isnumber(L, -1))
 		opts->indent_lvl = (int)lua_tonumber(L, -1);
 	lua_pop(L, 1);
-}
-
-/**
- * Initialize Lua serializer.
- */
-void
-lua_serializer_init(struct lua_State *L)
-{
-	/*
-	 * We don't export it as a module
-	 * for a while, so the library
-	 * is kept empty.
-	 */
-	static const luaL_Reg lualib[] = {
-		{
-			.name = NULL,
-		},
-	};
-
-	serializer_lua = luaL_newserializer(L, NULL, lualib);
-	serializer_lua->has_compact		= 1;
-	serializer_lua->encode_invalid_numbers	= 1;
-	serializer_lua->encode_load_metatables	= 1;
-	serializer_lua->encode_use_tostring	= 1;
-	serializer_lua->encode_invalid_as_nil	= 1;
-
-	/*
-	 * Keep a reference to this module so it
-	 * won't be unloaded.
-	 */
-	lua_setfield(L, -2, "formatter_lua");
 }

--- a/src/box/lua/serialize_lua.h
+++ b/src/box/lua/serialize_lua.h
@@ -50,9 +50,6 @@ typedef struct {
 	bool block_mode;
 } lua_dumper_opts_t;
 
-void
-lua_serializer_init(struct lua_State *L);
-
 int
 lua_encode(lua_State *L, struct luaL_serializer *serializer,
 	   lua_dumper_opts_t *opts);


### PR DESCRIPTION
*(This is a backport of PR #10227 to `release/3.1`, a future `3.1.2` release.)*

----

This patch fixes a bug found by the ASAN instrumentation of LuaJIT allocator [1]. The problem is using a Lua serializer object that has been cleaned up by GC.

The crash occurs when executing `tarantool> \set output lua`.

Failing tests:
 - ./test/app-luatest/gh_7031_configure_eos_in_lua_console_test.lua
 - ./test/app-tap/console.test.lua
 - ./test/box/push.test.lua
 - ./app-tap/console_lua.test.lua
 - ./app-luatest/varbinary_test.lua

The `serializer_lua` static member is removed from `src/box/lua/serialize_lua.c` along with `serializer_lua_init`, because it is not used by any function other than `serializer_lua_init`, which is not needed now too.

[1]: Issue #10231

Closes #10177 (this issue is a duplicate of #7404)