### PR TITLE
sql: fix use-after-poison in variable binding

### DIFF
--- a/src/box/lua/execute.c
+++ b/src/box/lua/execute.c
@@ -345,8 +345,8 @@ lua_sql_bind_decode(struct lua_State *L, struct sql_bind *bind, int idx, int i)
 		 * Data should be saved in allocated memory as it
 		 * will be poped from Lua stack.
 		 */
-		buf = xregion_alloc(region, field.sval.len + 1);
-		memcpy(buf, field.sval.data, field.sval.len + 1);
+		buf = xregion_alloc(region, field.sval.len);
+		memcpy(buf, field.sval.data, field.sval.len);
 		bind->s = buf;
 		bind->bytes = field.sval.len;
 		break;


### PR DESCRIPTION
This patch fixes a bug found by the ASAN instrumentation of LuaJIT allocator [1]. The problem is using `memcpy` beyond the size of the buffer being copied.

Failing tests:
  - ./test/sql-luatest/gh_10243_varbinary_bound_variable_test.lua

[1]: Issue https://github.com/tarantool/tarantool/issues/10231

Closes https://github.com/tarantool/tarantool/issues/10398

NO_DOC=bugfix
NO_CHANGELOG=bugfix
NO_TEST=rely on existing test (run failing tests with tarantool build described in [1]).