### PR TITLE
[Backport 2.11] datetime: support tz field in :totable()

### DIFF
--- a/changelogs/unreleased/gh-10331-tz-in-totable.md
+++ b/changelogs/unreleased/gh-10331-tz-in-totable.md
@@ -1,0 +1,4 @@
+## bugfix/datetime
+
+* Added the `tz` field to a table produced by `:totable()`
+  (gh-10331).

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -973,6 +973,7 @@ local function datetime_totable(self)
         isdst = datetime_isdst(self),
         nsec = self.nsec,
         tzoffset = self.tzoffset,
+        tz = self.tz,
     }
 end
 

--- a/test/sql-luatest/datetime_test.lua
+++ b/test/sql-luatest/datetime_test.lua
@@ -864,7 +864,8 @@ end
 g.test_datetime_18_3 = function()
     g.server:exec(function()
         local dt = require('datetime')
-        local dt1 = dt.new({year = 2001, month = 1, day = 1, hour = 1})
+        local dt1 = dt.new(
+            {year = 2001, month = 1, day = 1, hour = 1, tz = 'Z'})
         local sql = [[SELECT CAST('2001-01-01T01:00:00Z' AS DATETIME);]]
         local res = {{dt1}}
         local rows = box.execute(sql).rows
@@ -2218,7 +2219,8 @@ end
 g.test_datetime_32_1 = function()
     g.server:exec(function()
         local dt = require('datetime')
-        local dt1 = dt.new({year = 2000, month = 2, day = 29, hour = 1})
+        local dt1 = dt.new(
+            {year = 2000, month = 2, day = 29, hour = 1, tz = 'Z'})
         local sql = [[SELECT CAST('2000-02-29T01:00:00Z' AS DATETIME);]]
         local res = {{dt1}}
         local rows = box.execute(sql).rows


### PR DESCRIPTION
`datetime` module has a function `:totable()` that converts the information from a datetime object into the table format. The commit 43e10ed34949 ("build, lua: built-in module datetime") added `tzoffset` field to the datetime object and to table produced by `:totable()`. The commit 9ee45289e012
("datetime: datetime.TZ array") added fields `tz` and `tzindex` to the datetime object, but not to the table produced by `:totable()`. The patch fixes that. Note, `tzindex` is not added, because it is an internal field.

```
tarantool> datetime.parse('2004-12-01T00:00 Europe/Moscow'):totable()
---
- tz: Europe/Moscow
  sec: 0
  min: 0
  yday: 336
  day: 1
  nsec: 0
  isdst: false
  wday: 4
  tzoffset: 180
  month: 12
  year: 2004
  hour: 0
...
```

Fixes #10331
Follows up #6751

@TarantoolBot document
Title: Support of tz field in :totable()

In addition to the `tzoffset` in a table produced by `:totable` we added `tz` field.

```
tarantool> datetime.parse('2004-12-01T00:00 Europe/Moscow'):totable()
---
- tz: Europe/Moscow
  sec: 0
  min: 0
  yday: 336
  day: 1
  nsec: 0
  isdst: false
  wday: 4
  tzoffset: 180
  month: 12
  year: 2004
  hour: 0
...
```

(cherry picked from commit 90552e55e0921405c43ea086ae418a72c9f000e4)