### PR TITLE
[backport 3.1] box: grant/revoke user rights after upgrade

### DIFF
--- a/changelogs/unreleased/gh-9849-grant-revoke-user-right-after-upgrade.md
+++ b/changelogs/unreleased/gh-9849-grant-revoke-user-right-after-upgrade.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* User rights are now automatically granted/revoked after upgrading
+  without restarting (gh-9849).


### PR DESCRIPTION
*(This is a backport of PR #10248 to `release/3.1`, a future `3.1.2` release.)*

----

This PR:
- Uses `box.space._schema:on_replace()` for automatically granting/revoking user rights after upgrading the scheme without restarting.
- Adds error messages in case granting/revoking credentials broke.

Closes #9849