### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-10199-luajit-fixes.md
+++ b/changelogs/unreleased/gh-10199-luajit-fixes.md
@@ -1,0 +1,6 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-10199). The following
+issues were fixed as part of this activity:
+
+* Fixed GC marking of the cdata finalizer table.

--- a/src/lua/utils.c
+++ b/src/lua/utils.c
@@ -129,7 +129,7 @@ luaL_pushcdata(struct lua_State *L, uint32_t ctypeid)
 		/* Handle ctype __gc metamethod. Use the fast lookup here. */
 		cTValue *tv = lj_tab_getinth(cts->miscmap, -(int32_t)ctypeid);
 		if (tv && tvistab(tv) && (tv = lj_meta_fast(L, tabV(tv), MM_gc))) {
-			GCtab *t = cts->finalizer;
+			GCtab *t = tabref(G(L)->gcroot[GCROOT_FFI_FIN]);
 			if (gcref(t->metatable)) {
 				/* Add to finalizer table, if still enabled. */
 				copyTV(L, lj_tab_set(L, t, o), tv);


### PR DESCRIPTION
* FFI: Treat cdata finalizer table as a GC root.
* FFI: Turn FFI finalizer table into a proper GC root.

Part of #10199

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump