### PR TITLE
[backport 2.11] box: export more symbols

### DIFF
--- a/extra/exports
+++ b/extra/exports
@@ -69,9 +69,11 @@ box_index_max
 box_index_min
 box_index_random
 box_index_tuple_position
+box_info_lsn
 box_insert
 box_iproto_override
 box_iproto_send
+box_is_ro
 box_iterator_free
 box_iterator_next
 box_key_def_delete
@@ -100,6 +102,7 @@ box_region_used
 box_replace
 box_return_mp
 box_return_tuple
+box_ro_reason
 box_schema_upgrade_begin
 box_schema_upgrade_end
 box_schema_version
@@ -150,6 +153,7 @@ box_txn_set_isolation
 box_txn_set_timeout
 box_update
 box_upsert
+box_wait_ro
 clock_monotonic
 clock_monotonic64
 clock_process

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -340,7 +340,7 @@ box_update_ro_summary(void)
 	box_broadcast_ballot();
 }
 
-const char *
+API_EXPORT const char *
 box_ro_reason(void)
 {
 	if (raft_is_ro(box_raft()))
@@ -514,7 +514,7 @@ box_set_ro(void)
 	box_update_ro_summary();
 }
 
-bool
+API_EXPORT bool
 box_is_ro(void)
 {
 	return is_ro_summary;
@@ -526,7 +526,7 @@ box_is_orphan(void)
 	return is_orphan;
 }
 
-int
+API_EXPORT int
 box_wait_ro(bool ro, double timeout)
 {
 	double deadline = ev_monotonic_now(loop()) + timeout;
@@ -3851,6 +3851,24 @@ box_iproto_override(uint32_t req_type, iproto_handler_t handler,
 		    iproto_handler_destroy_t destroy, void *ctx)
 {
 	return iproto_override(req_type, handler, destroy, ctx);
+}
+
+API_EXPORT int64_t
+box_info_lsn(void)
+{
+	/*
+	 * Self can be NULL during bootstrap: entire box.info
+	 * bundle becomes available soon after entering box.cfg{}
+	 * and replication bootstrap relies on this as it looks
+	 * at box.info.status.
+	 */
+	struct replica *self = replica_by_uuid(&INSTANCE_UUID);
+	if (self != NULL &&
+	    (self->id != REPLICA_ID_NIL || replication_anon)) {
+		return vclock_get(box_vclock, self->id);
+	} else {
+		return -1;
+	}
 }
 
 static inline void

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -172,11 +172,17 @@ box_check_writable(void);
 void
 box_set_ro(void);
 
-bool
+/** \cond public */
+
+API_EXPORT bool
 box_is_ro(void);
+
+/** \endcond public */
 
 bool
 box_is_orphan(void);
+
+/** \cond public */
 
 /**
  * Wait until the instance switches to a desired mode.
@@ -185,8 +191,10 @@ box_is_orphan(void);
  * \retval -1 timeout or fiber is cancelled
  * \retval 0 success
  */
-int
+API_EXPORT int
 box_wait_ro(bool ro, double timeout);
+
+/** \endcond public */
 
 /**
  * Switch this instance from 'orphan' to 'running' state or
@@ -213,12 +221,16 @@ box_do_set_orphan(bool orphan);
 void
 box_update_ro_summary(void);
 
+/** \cond public */
+
 /**
  * Get the reason why the instance is read only if it is. Can't be called on a
  * writable instance.
  */
-const char *
+API_EXPORT const char *
 box_ro_reason(void);
+
+/** \endcond public */
 
 /**
  * Iterate over all spaces and save them to the
@@ -707,6 +719,13 @@ box_iproto_send(uint64_t sid,
 API_EXPORT int
 box_iproto_override(uint32_t req_type, iproto_handler_t handler,
 		    iproto_handler_destroy_t destroy, void *ctx);
+
+/**
+ * Get self LSN component of box vclock, -1 if no one or bootstrap haven't
+ * succeeded.
+ */
+API_EXPORT int64_t
+box_info_lsn(void);
 
 /** \endcond public */
 

--- a/src/box/lua/info.c
+++ b/src/box/lua/info.c
@@ -285,13 +285,7 @@ lbox_info_uuid(struct lua_State *L)
 static int
 lbox_info_lsn(struct lua_State *L)
 {
-	/* See comments in lbox_info_id */
-	struct replica *self = replica_by_uuid(&INSTANCE_UUID);
-	if (self != NULL && (self->id != REPLICA_ID_NIL || replication_anon)) {
-		luaL_pushint64(L, vclock_get(box_vclock, self->id));
-	} else {
-		luaL_pushint64(L, -1);
-	}
+	luaL_pushint64(L, box_info_lsn());
 	return 1;
 }
 

--- a/test/box-luatest/gh_10378_export_symbols_test.lua
+++ b/test/box-luatest/gh_10378_export_symbols_test.lua
@@ -1,0 +1,53 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group('gh-10378')
+
+g.before_all(function()
+    g.server = server:new{alias = 'default'}
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:drop()
+end)
+
+-- Test 4 more symbols
+g.test_new_symbols = function()
+    g.server:exec(function()
+        local ffi = require('ffi');
+        local fiber = require('fiber');
+        ffi.cdef([[
+            int64_t
+            box_info_lsn(void);
+
+            bool
+            box_is_ro(void);
+
+            const char*
+            box_ro_reason(void);
+
+            int
+            box_wait_ro(bool ro, double timeout);
+        ]])
+
+        t.assert_equals(box.info.lsn, ffi.C.box_info_lsn())
+        t.assert_equals(box.info.ro, ffi.C.box_is_ro())
+        box.cfg{read_only = true}
+        t.assert_equals(box.info.ro, ffi.C.box_is_ro())
+        t.assert_equals(box.info.ro_reason, ffi.string(ffi.C.box_ro_reason()))
+
+        local state = ''
+        local f = fiber.create(function()
+            fiber.self():set_joinable(true)
+            state = 'wait started'
+            ffi.C.box_wait_ro(false, 100500)
+            state = 'wait finished'
+        end)
+
+        t.assert_equals(state, 'wait started')
+        box.cfg{read_only = false}
+        f:join()
+        t.assert_equals(state, 'wait finished')
+    end)
+end


### PR DESCRIPTION
box_info_lsn
box_is_ro
box_ro_reason
box_wait_ro

Closes #10378

NO_CHANGELOG=minor change

@TarantoolBot document
Title: document 4 more symbols in public C API

box_info_lsn
box_is_ro
box_ro_reason
box_wait_ro

Their meaning is identical to lua methods:

box.info.lsn
box.info.ro
box.info.ro_reason
box.wait_ro

(cherry picked from commit f1c76b976077e8078c42990546d9dbbdea315425)