### PR TITLE
[backport 3.1] box: export more symbols

### DIFF
--- a/extra/exports
+++ b/extra/exports
@@ -70,10 +70,12 @@ box_index_max
 box_index_min
 box_index_random
 box_index_tuple_position
+box_info_lsn
 box_init_latest_dd_version_id
 box_insert
 box_iproto_override
 box_iproto_send
+box_is_ro
 box_iterator_free
 box_iterator_next
 box_key_def_delete
@@ -103,6 +105,7 @@ box_region_used
 box_replace
 box_return_mp
 box_return_tuple
+box_ro_reason
 box_schema_needs_upgrade
 box_schema_upgrade_begin
 box_schema_upgrade_end
@@ -155,6 +158,7 @@ box_txn_set_isolation
 box_txn_set_timeout
 box_update
 box_upsert
+box_wait_ro
 clock_monotonic
 clock_monotonic64
 clock_process

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -371,7 +371,7 @@ box_update_ro_summary(void)
 	box_broadcast_ballot();
 }
 
-const char *
+API_EXPORT const char *
 box_ro_reason(void)
 {
 	if (raft_is_ro(box_raft()))
@@ -545,7 +545,7 @@ box_set_ro(void)
 	box_update_ro_summary();
 }
 
-bool
+API_EXPORT bool
 box_is_ro(void)
 {
 	return is_ro_summary;
@@ -563,7 +563,7 @@ box_is_anon(void)
 	return instance_id == REPLICA_ID_NIL;
 }
 
-int
+API_EXPORT int
 box_wait_ro(bool ro, double timeout)
 {
 	double deadline = ev_monotonic_now(loop()) + timeout;
@@ -4211,6 +4211,24 @@ box_iproto_override(uint32_t req_type, iproto_handler_t handler,
 		    iproto_handler_destroy_t destroy, void *ctx)
 {
 	return iproto_override(req_type, handler, destroy, ctx);
+}
+
+API_EXPORT int64_t
+box_info_lsn(void)
+{
+	/*
+	 * Self can be NULL during bootstrap: entire box.info
+	 * bundle becomes available soon after entering box.cfg{}
+	 * and replication bootstrap relies on this as it looks
+	 * at box.info.status.
+	 */
+	struct replica *self = replica_by_uuid(&INSTANCE_UUID);
+	if (self != NULL &&
+	    (self->id != REPLICA_ID_NIL || cfg_replication_anon)) {
+		return vclock_get(box_vclock, self->id);
+	} else {
+		return -1;
+	}
 }
 
 /**

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -188,8 +188,12 @@ box_check_writable(void);
 void
 box_set_ro(void);
 
-bool
+/** \cond public */
+
+API_EXPORT bool
 box_is_ro(void);
+
+/** \endcond public */
 
 bool
 box_is_orphan(void);
@@ -198,6 +202,8 @@ box_is_orphan(void);
 bool
 box_is_anon(void);
 
+/** \cond public */
+
 /**
  * Wait until the instance switches to a desired mode.
  * \param ro wait read-only if set or read-write if unset
@@ -205,8 +211,10 @@ box_is_anon(void);
  * \retval -1 timeout or fiber is cancelled
  * \retval 0 success
  */
-int
+API_EXPORT int
 box_wait_ro(bool ro, double timeout);
+
+/** \endcond public */
 
 /**
  * Switch this instance from 'orphan' to 'running' state or
@@ -233,12 +241,16 @@ box_do_set_orphan(bool orphan);
 void
 box_update_ro_summary(void);
 
+/** \cond public */
+
 /**
  * Get the reason why the instance is read only if it is. Can't be called on a
  * writable instance.
  */
-const char *
+API_EXPORT const char *
 box_ro_reason(void);
+
+/** \endcond public */
 
 /**
  * Iterate over all spaces and save them to the
@@ -768,6 +780,13 @@ box_iproto_send(uint64_t sid,
 API_EXPORT int
 box_iproto_override(uint32_t req_type, iproto_handler_t handler,
 		    iproto_handler_destroy_t destroy, void *ctx);
+
+/**
+ * Get self LSN component of box vclock, -1 if no one or bootstrap haven't
+ * succeeded.
+ */
+API_EXPORT int64_t
+box_info_lsn(void);
 
 /** \endcond public */
 

--- a/src/box/lua/info.c
+++ b/src/box/lua/info.c
@@ -327,14 +327,7 @@ lbox_info_name(struct lua_State *L)
 static int
 lbox_info_lsn(struct lua_State *L)
 {
-	/* See comments in lbox_info_id */
-	struct replica *self = replica_by_uuid(&INSTANCE_UUID);
-	if (self != NULL &&
-	    (self->id != REPLICA_ID_NIL || cfg_replication_anon)) {
-		luaL_pushint64(L, vclock_get(box_vclock, self->id));
-	} else {
-		luaL_pushint64(L, -1);
-	}
+	luaL_pushint64(L, box_info_lsn());
 	return 1;
 }
 

--- a/test/box-luatest/gh_10378_export_symbols_test.lua
+++ b/test/box-luatest/gh_10378_export_symbols_test.lua
@@ -1,0 +1,53 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group('gh-10378')
+
+g.before_all(function()
+    g.server = server:new{alias = 'default'}
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:drop()
+end)
+
+-- Test 4 more symbols
+g.test_new_symbols = function()
+    g.server:exec(function()
+        local ffi = require('ffi');
+        local fiber = require('fiber');
+        ffi.cdef([[
+            int64_t
+            box_info_lsn(void);
+
+            bool
+            box_is_ro(void);
+
+            const char*
+            box_ro_reason(void);
+
+            int
+            box_wait_ro(bool ro, double timeout);
+        ]])
+
+        t.assert_equals(box.info.lsn, ffi.C.box_info_lsn())
+        t.assert_equals(box.info.ro, ffi.C.box_is_ro())
+        box.cfg{read_only = true}
+        t.assert_equals(box.info.ro, ffi.C.box_is_ro())
+        t.assert_equals(box.info.ro_reason, ffi.string(ffi.C.box_ro_reason()))
+
+        local state = ''
+        local f = fiber.create(function()
+            fiber.self():set_joinable(true)
+            state = 'wait started'
+            ffi.C.box_wait_ro(false, 100500)
+            state = 'wait finished'
+        end)
+
+        t.assert_equals(state, 'wait started')
+        box.cfg{read_only = false}
+        f:join()
+        t.assert_equals(state, 'wait finished')
+    end)
+end


### PR DESCRIPTION
box_info_lsn
box_is_ro
box_ro_reason
box_wait_ro

Closes #10378

NO_CHANGELOG=minor change

@TarantoolBot document
Title: document 4 more symbols in public C API

box_info_lsn
box_is_ro
box_ro_reason
box_wait_ro

Their meaning is identical to lua methods:

box.info.lsn
box.info.ro
box.info.ro_reason
box.wait_ro

(cherry picked from commit f1c76b976077e8078c42990546d9dbbdea315425)