### PR TITLE
[backport 3.1] box: account for `wait_ack` flag of the tx's last row during recovery

### DIFF
--- a/changelogs/unreleased/gh-10412-box-begin-is-sync-async-commit-after-recovery.md
+++ b/changelogs/unreleased/gh-10412-box-begin-is-sync-async-commit-after-recovery.md
@@ -1,0 +1,5 @@
+## bugfix/box
+
+* Fixed a bug that caused synchronous transactions (created with
+  `box.begin{is_sync = true}`) on asynchronous spaces to get committed
+  asynchronously during recovery (gh-10412).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -841,6 +841,8 @@ wal_stream_apply_dml_row(struct wal_stream *stream, struct xrow_header *row)
 	assert(txn != NULL);
 	if (!row->is_commit)
 		return 0;
+	if (row->wait_ack)
+		box_txn_make_sync();
 	/*
 	 * For fully local transactions the TSN check won't work like for global
 	 * transactions, because it is not known if there are global rows until

--- a/test/box-luatest/gh_10412_box_begin_is_sync_async_commit_after_recovery_test.lua
+++ b/test/box-luatest/gh_10412_box_begin_is_sync_async_commit_after_recovery_test.lua
@@ -1,0 +1,50 @@
+local nb = require('net.box')
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group()
+
+g.before_each(function(cg)
+    cg.server = server:new{box_cfg = {
+        memtx_use_mvcc_engine = true,
+        replication_synchro_timeout = 120,
+        replication_synchro_quorum = 2,
+    }}
+    cg.server:start()
+    cg.server:exec(function()
+        box.schema.create_space('async', {is_sync = false}):create_index('pk')
+        box.ctl.promote()
+    end)
+end)
+
+g.test_box_begin_is_sync_sync_commit_after_recovery = function(cg)
+    local c = nb.connect(cg.server.net_box_uri)
+    local s = c:new_stream()
+    s:begin{is_sync = true}
+    -- The transaction meta flags are only assigned to the last transaction
+    -- statement, so let's test that this is accounted for by adding 2
+    -- statements rather than 1.
+    s.space.async:replace{0}
+    s.space.async:replace{1}
+    s:commit({is_async = true})
+
+    cg.server:exec(function()
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.synchro.queue.len, 1)
+        end)
+    end)
+
+    c:close()
+
+    cg.server:restart()
+
+    cg.server:exec(function()
+        t.assert_equals(box.info.synchro.queue.len, 1)
+        t.assert_equals(box.space.async:get{0}, nil)
+        t.assert_equals(box.space.async:get{1}, nil)
+    end)
+end
+
+g.after_each(function(cg)
+    cg.server:drop()
+end)


### PR DESCRIPTION
Currently, we do not account for the `wait_ack` flag of the transaction's last row during recovery, instead relying on the fact the transaction will be made synchronous when applying operations on a synchronous space.

However, this logic is at odds with explicitly created synchronous transactions (created with box.begin{is_sync = true}), which may not have operations on synchronous spaces. As a result, during recovery we do not treat these transactions as synchronous.

Let's fix this by mirroring the applier logic to the recovery.

Closes #10412

NO_DOC=<bugfix>

(cherry picked from commit c3ed71f37ca1c08ac1134da267866cc5cbaebe60)