### PR TITLE
connpool: make `call()` execution faster

### DIFF
--- a/changelogs/unreleased/gh-10596-connpool-filter-support-alive-filtering.md
+++ b/changelogs/unreleased/gh-10596-connpool-filter-support-alive-filtering.md
@@ -1,0 +1,5 @@
+## feature/connpool
+
+* Now `connpool.filter()` returns only alive instances by default.
+  To use the old behaviour and acquire all instances the new option
+  `skip_connection_check` can be used (gh-10596).

--- a/changelogs/unreleased/gh-10598-make-connpool-call-faster.md
+++ b/changelogs/unreleased/gh-10598-make-connpool-call-faster.md
@@ -1,0 +1,4 @@
+## feature/connpool
+
+* `connpool.call()` method now works faster in general when it works in
+  modes different from `prefer_ro`/`prefer_rw` (gh-10598).


### PR DESCRIPTION
This patch consist of two changes in the connection pool. For sure, they should be two different PRs, but I've accidentally made one of them as a minor change in terms of the other not knowing there is an issue on it.

### Add support for filtering available instances using `connpool.filter()`.

The `connpool.filter()` now by default returns only available instances. This check can be skipped using a new `connpool.filter()` boolean option `skip_connection_check` (by default it equals `false`).

Filtering by `ro`/`rw` mode requires the connection check to be enabled.

Examples:
```lua
-- 'instance-001', 'instance-002' are available, 'instance-003' is down.

-- The table will contain 'instance-001' and 'instance-002'.
let alive = connpool.filter()

-- The table will contain 'instance-001', 'instance-002' and
-- 'instance-003'.
let all = connpool.filter({ skip_connection_check = true })
```

Closes #10596
Jira task: [TNTP-223](https://jira.vk.team/browse/TNTP-223)

### Speed up the execution of the `connpool.call()` method in default and `ro`, `rw` modes.
The connection pool `call()` function used to connect to all of the instances matching some specified static requirements and synchronously select one of the active. It was slower a lot times slower than its possible because the connpool only actually needs one active connection to perform the call.

This patch makes the connection pool `call()` function work a bit smarter. Now if the priorities (`prefer_ro`/`prefer_rw` call modes) aren't used within the `connpool.call()` the pool will wait for any connection matching the requirements as a candidate to perform the call.

Closes #10598
Jira task: [TNTP-399](https://jira.vk.team/browse/TNTP-399) 

Requires #10287 to be merged.