### PR TITLE
Change cmake variable BACKUP_STORAGE to option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,7 +388,7 @@ endif(CMAKE_BUILD_TYPE STREQUAL "Debug")
 ##
 
 # URL of the backup storage to download bundled dependencies from.
-set(BACKUP_STORAGE https://distrib.hb.vkcs.cloud)
+set(BACKUP_STORAGE "https://distrib.hb.vkcloud-storage.ru" CACHE STRING "Source to download third party dependencies")
 
 set(EMBED_LUAZLIB ${BUILD_STATIC})
 


### PR DESCRIPTION
There is BACKUP_STORAGE var to use any source to download dependencies. Convert it to option to make it possible to use it from command line.

NO_DOC=build
NO_TEST=build
NO_CHANGELOG=build