### PR TITLE
[Backport 2.11] test/fuzz: update compiler and library flags

### DIFF
--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -21,6 +21,10 @@ target_compile_options(
         ${CXXFLAGS}
         >
 )
+
+# `-stdlib=libstdc++` is required by ICU on OSS Fuzz.
+# `-lc++` is used by Centipede, so `-lc++` needs to come after
+# centipede's lib.
 target_link_libraries(
     fuzzer_config
     INTERFACE
@@ -30,9 +34,12 @@ target_link_libraries(
         -fprofile-instr-generate
         -fcoverage-mapping
         -g
+        -stdlib=libstdc++
         >
         $<$<BOOL:${OSS_FUZZ}>:
         $ENV{LIB_FUZZING_ENGINE}
+        -lc++
+        -stdlib=libstdc++
         >
 )
 


### PR DESCRIPTION
Orig PR: https://github.com/tarantool/tarantool/pull/10431
----

Clang compiler is linking by default against libc++ rather than libstdc++, which the code seems to be built against.

The patch adds "-stdlib=libstdc++" that is required by build on OSS Fuzz and also removes dirty hacks in a build script [2][3] and allows to switch to a static build in OSS Fuzz.

1. https://libcxx.llvm.org/docs/UsingLibcxx.html
2. https://github.com/google/oss-fuzz/commit/92d4e951c3a10b8b3d67ccd061ddaba71f01a328
3. https://github.com/google/oss-fuzz/commit/7a6315db98f574cc8beb4de7f9d2e71c6c589a34
4. https://github.com/google/oss-fuzz/pull/12322

NO_CHANGELOG=testing
NO_DOC=testing

(cherry picked from commit 79737d9d13d9e473687192be76fe055658b6e0b8)