### PR TITLE
memtx: skip excluded tuples in index count with MVCC enabled

### DIFF
--- a/changelogs/unreleased/gh-10396-memtx-mvcc-exclude-null-count.md
+++ b/changelogs/unreleased/gh-10396-memtx-mvcc-exclude-null-count.md
@@ -1,0 +1,5 @@
+## bugfix/memtx
+
+* Fixed a bug when `index:count()` could return the wrong number, raise the
+  last error, or fail with the `IllegalParams` error if the index has
+  the `exclude_null` attribute and MVCC is enabled (gh-10396).

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -2876,6 +2876,17 @@ memtx_tx_index_invisible_count_slow(struct txn *txn,
 		}
 		assert(link->newer_story == NULL);
 
+		/*
+		 * Excluded tuples have their own chains consisting of the only
+		 * excluded story. Such stories must be skipped since they are
+		 * not actually inserted to index.
+		 */
+		if (tuple_key_is_excluded(story->tuple, index->def->key_def,
+					  MULTIKEY_NONE)) {
+			assert(link->older_story == NULL);
+			continue;
+		}
+
 		struct tuple *visible = NULL;
 		bool is_prepared_ok = detect_whether_prepared_ok(txn);
 		bool unused;


### PR DESCRIPTION
Excluded tuples actually have their own history chains in MVCC - such chains consist of only one `memtx_story` containing excluded tuple itself. Such chains should be skipped when counting invisible tuples because they are not inserted to the index - that's what the commit does.

Closes https://github.com/tarantool/tarantool/issues/10396