### PR TITLE
vinyl: enable exact match optimization for unique secondary indexes

### DIFF
--- a/changelogs/unreleased/gh-10442-vy-exact-match-optimization.md
+++ b/changelogs/unreleased/gh-10442-vy-exact-match-optimization.md
@@ -1,0 +1,4 @@
+## bugfix/vinyl
+
+* Eliminated an unnecessary disk read when a key that was recently updated or
+  deleted was accessed via a unique secondary index (gh-10442).

--- a/src/box/vy_read_iterator.h
+++ b/src/box/vy_read_iterator.h
@@ -63,6 +63,14 @@ struct vy_read_iterator {
 	 * checked to match the search key.
 	 */
 	bool need_check_eq;
+	/**
+	 * Set if (a) the iterator hasn't returned anything yet and (b) there
+	 * may be at most one tuple equal to the search key and the iterator
+	 * will return it if it exists (i.e. it's GE/LE/EQ/REQ). This flag
+	 * enables the optimization that skips deeper read sources if a tuple
+	 * exactly matching the search key is found.
+	 */
+	bool check_exact_match;
 	/** Set to true on the first iteration. */
 	bool is_started;
 	/**

--- a/src/box/vy_stmt.h
+++ b/src/box/vy_stmt.h
@@ -321,6 +321,14 @@ vy_stmt_is_empty_key(struct tuple *stmt)
 }
 
 /**
+ * Return true if there cannot be more than one tuple equal to
+ * the given vinyl statement in an index.
+ */
+bool
+vy_stmt_is_exact_key(struct tuple *stmt, struct key_def *cmp_def,
+		     struct key_def *key_def, bool is_unique);
+
+/**
  * Duplicate the statememnt.
  *
  * @param stmt statement

--- a/test/vinyl-luatest/gh_10442_exact_match_optimization_test.lua
+++ b/test/vinyl-luatest/gh_10442_exact_match_optimization_test.lua
@@ -1,0 +1,100 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new({
+        box_cfg = {
+            -- Disable the tuple cache and bloom filters.
+            vinyl_cache = 0,
+            vinyl_bloom_fpr = 1,
+        },
+    })
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+g.test_exact_match_optimization = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('test', {engine = 'vinyl'})
+        s:create_index('i1')
+        s:create_index('i2', {
+            unique = true,
+            parts = {{2, 'unsigned'}},
+        })
+        s:create_index('i3', {
+            unique = true,
+            parts = {{3, 'unsigned', is_nullable = true}},
+        })
+        s:replace({10, 10, 10})
+        s:replace({20, 20, 20})
+        s:replace({30, 30, 30})
+        s:replace({40, 40, 40})
+        box.snapshot()
+        s:delete({10})
+        s:delete({20})
+        s:replace({20, 20, 20})
+        s:delete({30})
+        s:replace({31, 30, 30})
+        s:delete({40})
+        s:replace({39, 40, 40})
+
+        box.stat.reset()
+
+        local function check(index, op, ret)
+            local json = require('json')
+            local msg = string.format("%s %s", index.name, json.encode(op))
+            t.assert_equals(index[op[1]](index, unpack(op, 2)), ret, msg)
+            t.assert_equals(index:stat().disk.iterator.lookup, 0, msg)
+        end
+
+        for i = 0, 2 do
+            local index = s.index[i]
+
+            check(index, {'get', {10}}, nil)
+            check(index, {'select', {10}}, {})
+            check(index, {'select', {10}, {iterator = 'req'}}, {})
+
+            local tuple = {20, 20, 20}
+            check(index, {'get', {20}}, tuple)
+            check(index, {'select', {20}}, {tuple})
+            check(index, {'select', {20}, {iterator = 'req'}}, {tuple})
+            check(index, {'select', {20},
+                  {iterator = 'ge', limit = 1}}, {tuple})
+            check(index, {'select', {20},
+                  {iterator = 'le', limit = 1}}, {tuple})
+
+            if i > 0 then
+                tuple = {31, 30, 30}
+                check(index, {'get', {30}}, tuple)
+                check(index, {'select', {30}}, {tuple})
+                check(index, {'select', {30}, {iterator = 'req'}}, {tuple})
+                check(index, {'select', {30},
+                      {iterator = 'ge', limit = 1}}, {tuple})
+                check(index, {'select', {30},
+                      {iterator = 'le', limit = 1}}, {tuple})
+
+                tuple = {39, 40, 40}
+                check(index, {'get', {40}}, tuple)
+                check(index, {'select', {40}}, {tuple})
+                check(index, {'select', {40}, {iterator = 'req'}}, {tuple})
+                check(index, {'select', {40},
+                      {iterator = 'ge', limit = 1}}, {tuple})
+                check(index, {'select', {40},
+                      {iterator = 'le', limit = 1}}, {tuple})
+            end
+        end
+    end)
+end


### PR DESCRIPTION
If the iterator type is EQ/REQ/LE/GE and the search key is exact (that is, there may be at most one tuple matching the key in the index), there's no need to scan disk levels if we found a statement for this key in the memory level. We've had this optimization for ages but it worked only for full keys in terms `cmp_def` (key definition extended with primary key parts). Apparently, a lookup in a secondary index performed by the user wouldn't match these criteria unless the secondary index explicitly included all primary key parts.

This commit improves on that. Now, we enable the optimization if the search key is **exact**. We consider a key **exact** if either of the following conditions is true:

 - The key statement is a tuple (tuple has all key parts).
 - The key statement is a full key in terms of `cmp_def`.
 - The key statement is a full key in terms of `key_def`, it doesn't contain nulls, and the index is unique. The check for nulls is necessary because even a unique nullable index may contain more than one equal key with nulls.

Note, this patch slightly refactors the optimization, adding a few comments and hopefully making it more understandable. In particular, we remove the one-result-tuple optimization for exact EQ/REQ from `vy_read_iterator_advance` and put it in `vy_read_iterator_evaluate_src` instead. This way the whole optimization resides in one place.

Closes #10442