### PR TITLE
[release/3.1] Generate changelog for 3.1.2

### DIFF
--- a/changelogs/3.1.2.md
+++ b/changelogs/3.1.2.md
@@ -1,0 +1,84 @@
+# 3.1.2
+
+Date: 2024-08-26
+Tag: 3.1.2
+
+## Overview
+
+3.1.2 is the 3rd [stable][release_policy] version of the 3.1 release
+series. It resolves 14 bugs since 3.1.1.
+
+The "stable" label means that we have all planned features implemented and we
+see no high-impact issues. However, if you encounter an issue, feel free to
+[report it][issues] on GitHub.
+
+[release_policy]: https://www.tarantool.io/en/doc/latest/release/policy/
+[issues]: https://github.com/tarantool/tarantool/issues
+
+## Compatibility
+
+Tarantool 3.x is backward compatible with Tarantool 2.11.x in the binary data
+layout, client-server protocol, and replication protocol.
+
+Please [upgrade][upgrade] using the `box.schema.upgrade()` procedure to unlock
+all the new features of the 3.x series.
+
+[upgrade]: https://www.tarantool.io/en/doc/latest/book/admin/upgrades/
+
+## Bugs fixed
+
+### Memtx
+
+* Fixed a crash when using pagination over a non-unique index with range
+  requests and MVCC enabled (gh-10448).
+* Fixed a bug when `index:count()` could return a wrong number, raise the
+  last error, or fail with the `IllegalParams` error if the index has
+  the `exclude_null` attribute and MVCC is enabled (gh-10396).
+
+### Vinyl
+
+* Fixed a bug when any DDL operation aborted unrelated transactions (gh-10375).
+* Eliminated an unnecessary disk read when a key that was recently updated or
+  deleted was accessed via a unique secondary index (gh-10442).
+* Fixed a bug when recovery could fail with the error "Invalid VYLOG file:
+  Run XXXX deleted but not registered" or "Invalid VYLOG file: Run XXX deleted
+  twice" in case a dump or compaction completed with a disk write error after
+  the target index was dropped (gh-10452).
+
+### LuaJIT
+
+Backported patches from the vanilla LuaJIT trunk (gh-10199). The following
+issues were fixed as part of this activity:
+
+* Fixed GC marking of the cdata finalizer table.
+
+### Lua
+
+#### YAML
+
+* Strings with large exponential values equal to infinity are now encoded as
+  strings instead of numbers (gh-10164).
+
+### Core
+
+* Fixed a bug that caused synchronous transactions (created with
+  `box.begin{is_sync = true}`) on asynchronous spaces to get committed
+  asynchronously during recovery (gh-10412).
+
+### Config
+
+* User rights are now automatically granted/revoked after upgrading
+  without restarting (gh-9849).
+* Fixed a bug that causes Tarantool to continue listening on the previous socket
+  even after `console.socket` has changed (gh-9535).
+* Fixed a bug where the default value for `box.replication_sync_timeout` was
+  not set correctly (gh-10280).
+
+### Datetime
+
+* Fixed a bug with setting unspecified fields to undefined values
+  (gh-8588).
+* Added the `tz` field to a table produced by `:totable()`
+  (gh-10331).
+* Added the `timestamp` field to a table produced by `:totable()`
+  (gh-10374).

--- a/changelogs/unreleased/gh-10164-yaml-encoding-large-exps.md
+++ b/changelogs/unreleased/gh-10164-yaml-encoding-large-exps.md
@@ -1,4 +1,0 @@
-## bugfix/lua/yaml
-
-* Strings with large exponential values equal to infinity are now encoded as
-  strings instead of numbers (gh-10164).

--- a/changelogs/unreleased/gh-10199-luajit-fixes.md
+++ b/changelogs/unreleased/gh-10199-luajit-fixes.md
@@ -1,6 +1,0 @@
-## bugfix/luajit
-
-Backported patches from the vanilla LuaJIT trunk (gh-10199). The following
-issues were fixed as part of this activity:
-
-* Fixed GC marking of the cdata finalizer table.

--- a/changelogs/unreleased/gh-10280-fix-replication-sync-timeout-default-value.md
+++ b/changelogs/unreleased/gh-10280-fix-replication-sync-timeout-default-value.md
@@ -1,4 +1,0 @@
-## bugfix/config
-
-* Fixed a bug where the default value for `box.replication_sync_timeout` was
-  not set correctly (gh-10280).

--- a/changelogs/unreleased/gh-10331-tz-in-totable.md
+++ b/changelogs/unreleased/gh-10331-tz-in-totable.md
@@ -1,4 +1,0 @@
-## bugfix/datetime
-
-* Added the `tz` field to a table produced by `:totable()`
-  (gh-10331).

--- a/changelogs/unreleased/gh-10374-timestamp-in-totable.md
+++ b/changelogs/unreleased/gh-10374-timestamp-in-totable.md
@@ -1,4 +1,0 @@
-## bugfix/datetime
-
-* Added the `timestamp` field to a table produced by `:totable()`
-  (gh-10374).

--- a/changelogs/unreleased/gh-10375-vy-do-not-abort-unrelated-tx-on-ddl.md
+++ b/changelogs/unreleased/gh-10375-vy-do-not-abort-unrelated-tx-on-ddl.md
@@ -1,3 +1,0 @@
-## bugfix/vinyl
-
-* Fixed a bug when any DDL operation aborted unrelated transactions (gh-10375).

--- a/changelogs/unreleased/gh-10396-memtx-mvcc-exclude-null-count.md
+++ b/changelogs/unreleased/gh-10396-memtx-mvcc-exclude-null-count.md
@@ -1,5 +1,0 @@
-## bugfix/memtx
-
-* Fixed a bug when `index:count()` could return a wrong number, raise the
-  last error, or fail with the `IllegalParams` error if the index has
-  the `exclude_null` attribute and MVCC is enabled (gh-10396).

--- a/changelogs/unreleased/gh-10412-box-begin-is-sync-async-commit-after-recovery.md
+++ b/changelogs/unreleased/gh-10412-box-begin-is-sync-async-commit-after-recovery.md
@@ -1,5 +1,0 @@
-## bugfix/box
-
-* Fixed a bug that caused synchronous transactions (created with
-  `box.begin{is_sync = true}`) on asynchronous spaces to get committed
-  asynchronously during recovery (gh-10412).

--- a/changelogs/unreleased/gh-10442-vy-exact-match-optimization.md
+++ b/changelogs/unreleased/gh-10442-vy-exact-match-optimization.md
@@ -1,4 +1,0 @@
-## bugfix/vinyl
-
-* Eliminated an unnecessary disk read when a key that was recently updated or
-  deleted was accessed via a unique secondary index (gh-10442).

--- a/changelogs/unreleased/gh-10452-vy-log-discard-run-after-index-drop-fix.md
+++ b/changelogs/unreleased/gh-10452-vy-log-discard-run-after-index-drop-fix.md
@@ -1,6 +1,0 @@
-## bugfix/vinyl
-
-* Fixed a bug when recovery could fail with the error "Invalid VYLOG file:
-  Run XXXX deleted but not registered" or "Invalid VYLOG file: Run XXX deleted
-  twice" in case a dump or compaction completed with a disk write error after
-  the target index was dropped (gh-10452).

--- a/changelogs/unreleased/gh-10488-pagination-mvcc-non-unique-index.md
+++ b/changelogs/unreleased/gh-10488-pagination-mvcc-non-unique-index.md
@@ -1,4 +1,0 @@
-## bugfix/memtx
-
-* Fixed a crash when using pagination over a non-unique index with range
-  requests and MVCC enabled (gh-10448).

--- a/changelogs/unreleased/gh-8588-setting-unspecified-fields-fix.md
+++ b/changelogs/unreleased/gh-8588-setting-unspecified-fields-fix.md
@@ -1,4 +1,0 @@
-## bugfix/datetime
-
-* Fixed a bug with setting unspecified fields to undefined values
-  (gh-8588).

--- a/changelogs/unreleased/gh-9535-close-listen-socket-after-replace.md
+++ b/changelogs/unreleased/gh-9535-close-listen-socket-after-replace.md
@@ -1,4 +1,0 @@
-## bugfix/config
-
-* Fixed a bug that causes Tarantool to continue listening on the previous socket
-  even after `console.socket` has changed (gh-9535).

--- a/changelogs/unreleased/gh-9849-grant-revoke-user-right-after-upgrade.md
+++ b/changelogs/unreleased/gh-9849-grant-revoke-user-right-after-upgrade.md
@@ -1,4 +1,0 @@
-## bugfix/box
-
-* User rights are now automatically granted/revoked after upgrading
-  without restarting (gh-9849).

--- a/src/box/lua/upgrade.lua
+++ b/src/box/lua/upgrade.lua
@@ -2115,6 +2115,7 @@ local downgrade_versions = {
     "3.0.2",
     "3.1.0",
     "3.1.1",
+    "3.1.2",
     -- DOWNGRADE VERSIONS END
 }
 


### PR DESCRIPTION
Also, remote unreleased/ entries and add a new downgrade version to downgrade versions list.

NO_DOC=changelog
NO_TEST=changelog
NO_CHANGELOG=changelog

@Totktonada, I see some entries which duplicate the ones fixed in 2.11.4 (https://github.com/tarantool/tarantool/releases/tag/2.11.4). I'm not sure if we should remove or keep them in this changelog.