### PR TITLE
[backport 3.2] test: add test_ prefix to a function name 

### DIFF
--- a/test/app-luatest/gh_8252_jit_off_on_macOS_by_default_test.lua
+++ b/test/app-luatest/gh_8252_jit_off_on_macOS_by_default_test.lua
@@ -2,7 +2,7 @@ local t = require('luatest')
 
 local g = t.group()
 
-g.jit_off_on_macOS_by_default = function()
+g.test_jit_off_on_macOS_by_default = function()
     t.assert_equals(jit.os == 'OSX', not jit.status(),
                     'JIT is disabled by default on macOS')
 end


### PR DESCRIPTION
*(This is a backport of PR #10408 to release/3.2)*

--------------

The test function `g.jit_off_on_macOS_by_default` in `gh_8252` was silently ignored by the luatest due to its lack of the required `test_` prefix. This commit renames the function to `test_jit_off_on_macOS_by_default`, ensuring that it is recognized and executed by the luatest.

Closes #10210

NO_DOC=codehealth
NO_CHANGELOG=codehealth