### PR TITLE
datetime: add additional tests for a strptime()

### DIFF
--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -487,7 +487,7 @@ test:test("Simple tests for parser", function(test)
 end)
 
 test:test("Multiple tests for parser (with nanoseconds)", function(test)
-    test:plan(211)
+    test:plan(273)
     -- borrowed from
     -- github.com/chansen/p5-time-moment/blob/master/t/180_from_string.t
     local tests =
@@ -559,7 +559,8 @@ test:test("Multiple tests for parser (with nanoseconds)", function(test)
     for _, value in ipairs(tests) do
         local str, epoch, nsec, tzoffset, check
         str, epoch, nsec, tzoffset, check = unpack(value)
-        local dt = date.parse(str)
+        local dt, parsed_syms = date.parse(str)
+        test:is(parsed_syms, #str, 'all characters are parsed')
         test:is(dt.epoch, epoch, ('%s: dt.epoch == %d'):format(str, epoch))
         test:is(dt.nsec, nsec, ('%s: dt.nsec == %d'):format(str, nsec))
         test:is(dt.tzoffset, tzoffset, ('%s: dt.tzoffset == %d'):format(str, tzoffset))
@@ -577,7 +578,7 @@ local function create_date_string(date)
 end
 
 test:test("Check parsing of full supported years range", function(test)
-    test:plan(63)
+    test:plan(84)
     local valid_years = {
         -5879610, -5879000, -5800000, -2e6, -1e5, -1e4, -9999, -2000, -1000,
         0, 1, 1000, 1900, 1970, 2000, 9999,
@@ -586,7 +587,8 @@ test:test("Check parsing of full supported years range", function(test)
     local fmt = '%FT%T%z'
     for _, y in ipairs(valid_years) do
         local txt = ('%04d-06-22'):format(y)
-        local dt = date.parse(txt)
+        local dt, parsed_syms = date.parse(txt)
+        test:is(parsed_syms, #txt, 'all characters are parsed')
         test:isnt(dt, nil, dt)
         local out_txt = tostring(dt)
         local out_dt = date.parse(out_txt)


### PR DESCRIPTION
The testsuite "Datetime string parsing by format (detailed)" tests parsing of a string with various conversion specifications. However, `tostring(dt)` is used as a test oracle and all these testcases does not test some conversion specifications at all, because metamethod `__tostring` for datetime object uses `:format()` with default format string.

Due to missed tests for conversion specifications behavior described in #10470 was missed:

```
tarantool> dt = date.parse('Mon', {format = '%a'})
tarantool> dt
---
- 1970-01-01T00:00:00Z
...

tarantool> dt:format('%a')
---
- Thu
...
```

The patch adds tests for `strptime` with all possible conversion specifications described in strftime(3).

Follows up #8588
Relates to #10470

NO_CHANGELOG=testing
NO_DOC=testing
NO_TEST=testing