### PR TITLE
say: replace panic macro with a function

### DIFF
--- a/src/lib/core/say.c
+++ b/src/lib/core/say.c
@@ -73,6 +73,19 @@ void
 enum say_format log_format = SF_PLAIN;
 enum { SAY_SYSLOG_DEFAULT_PORT = 512 };
 
+NORETURN void
+panic(const char *format, ...)
+{
+	char buf[1024];
+	va_list args;
+
+	va_start(args, format);
+	vsnprintf(buf, sizeof(buf), format, args);
+	va_end(args);
+
+	panic_status(EXIT_FAILURE, "%s", buf);
+}
+
 /** List of logs to rotate */
 static RLIST_HEAD(log_rotate_list);
 

--- a/src/lib/core/say.h
+++ b/src/lib/core/say.h
@@ -418,11 +418,13 @@ _say_strerror(int errnum);
 	lsan_turn_off(); \
 	exit(status); \
 })
-#define panic(...)			panic_status(EXIT_FAILURE, __VA_ARGS__)
 #define panic_syserror(...)		({ \
 	say(S_FATAL, tt_strerror(errno), __VA_ARGS__); \
 	exit(EXIT_FAILURE); \
 })
+
+NORETURN void
+panic(const char *format, ...);
 
 /**
  * Log a message once.

--- a/src/lua/utils.c
+++ b/src/lua/utils.c
@@ -1097,15 +1097,6 @@ tarantool_lua_utils_init(struct lua_State *L)
 	return 0;
 }
 
-/*
- * XXX: There is already defined <panic> macro in say.h header
- * (included in diag.h). As a result the call below is misexpanded
- * and compilation fails with the corresponding error. To avoid
- * this error the macro is undefined since it's not used anymore
- * in scope of this translation unit.
- */
-#undef panic
-
 /**
  * This routine encloses the checks and actions to be done when
  * the running fiber yields the execution.


### PR DESCRIPTION
This patch refactors the panic macro into a function to prevent preprocessor conflicts. Previously, the panic macro in `src/lib/core/say.h` could clash with LuaJIT's internal panic routine, causing macro expansion issues and compilation failures. By using a function instead, the patch resolves these conflicts and ensures correct handling of panic calls.

Closes #5365

NO_DOC=refactoring
NO_TEST=refactoring
NO_CHANGELOG=refactoring