### PR TITLE
Bump msgpuck submodule

### DIFF
--- a/changelogs/unreleased/gh-9965-wrong-uint-comparison.md
+++ b/changelogs/unreleased/gh-9965-wrong-uint-comparison.md
@@ -1,0 +1,5 @@
+## bugfix/core
+
+- Fixed a bug in the unsigned numbers comparison in tuple keys. It allowed to
+  insert the same key multiple times into a unique index, and sometimes wouldn't
+  allow to find an existing key in an index (gh-9965).


### PR DESCRIPTION
This update pulls the following commit:

* Fix mp_compare_uint()

Closes #9965

NO_DOC=bugfix
NO_TEST=tested in the submodule