### PR TITLE
iproto: introduce `IPROTO_INSERT_ARROW` request

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -64,3 +64,6 @@
 [submodule "third_party/metrics"]
 	path = third_party/metrics
 	url = https://github.com/tarantool/metrics.git
+[submodule "third_party/arrow/nanoarrow"]
+	path = third_party/arrow/nanoarrow
+	url = https://github.com/apache/arrow-nanoarrow.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -741,6 +741,13 @@ libccdt_build()
 add_dependencies(build_bundled_libs cdt)
 
 #
+# Nanoarrow
+#
+include(BuildNanoarrow)
+nanoarrow_build()
+add_dependencies(build_bundled_libs bundled-nanoarrow)
+
+#
 # Third-Party misc
 #
 

--- a/cmake/BuildNanoarrow.cmake
+++ b/cmake/BuildNanoarrow.cmake
@@ -1,0 +1,75 @@
+# A macro to build the bundled nanoarrow library
+macro(nanoarrow_build)
+    set(NANOARROW_SOURCE_DIR ${PROJECT_SOURCE_DIR}/third_party/arrow/nanoarrow/)
+    set(NANOARROW_INSTALL_DIR ${PROJECT_BINARY_DIR}/third_party/nanoarrow/)
+    set(NANOARROW_INCLUDE_DIR ${NANOARROW_INSTALL_DIR}/include/)
+
+    set(NANOARROW_CORE_LIBRARY ${NANOARROW_INSTALL_DIR}/lib/libnanoarrow.a)
+    set(NANOARROW_IPC_LIBRARY ${NANOARROW_INSTALL_DIR}/lib/libnanoarrow_ipc.a)
+    set(FLATCCRT_LIBRARY ${NANOARROW_INSTALL_DIR}/lib/libflatccrt.a)
+    set(NANOARROW_LIBRARIES
+        ${NANOARROW_CORE_LIBRARY} ${NANOARROW_IPC_LIBRARY} ${FLATCCRT_LIBRARY})
+
+    set(NANOARROW_CFLAGS ${DEPENDENCY_CFLAGS})
+
+    # Silence the "src/nanoarrow/ipc/decoder.c:1115:7: error: conversion from
+    # `long unsigned int' to `int32_t' {aka `int'} may change value" warning
+    # on ancient compilers, in particular GCC 4.8.5 from CentOS 7.
+    set(NANOARROW_CFLAGS "${NANOARROW_CFLAGS} -Wno-error=conversion")
+
+    list(APPEND NANOARROW_CMAKE_FLAGS "-DCMAKE_C_FLAGS=${NANOARROW_CFLAGS}")
+
+    # Build nanoarrow IPC extension.
+    list(APPEND NANOARROW_CMAKE_FLAGS "-DNANOARROW_IPC=ON")
+
+    # Switch on the static build.
+    list(APPEND NANOARROW_CMAKE_FLAGS "-DBUILD_STATIC_LIBS=ON")
+
+    # Switch off the shared build.
+    list(APPEND NANOARROW_CMAKE_FLAGS "-DBUILD_SHARED_LIBS=OFF")
+
+    # Even though we set the external project's install dir
+    # below, we still need to pass the corresponding install
+    # prefix via cmake arguments.
+    list(APPEND NANOARROW_CMAKE_FLAGS
+        "-DCMAKE_INSTALL_PREFIX=${NANOARROW_INSTALL_DIR}")
+
+    # Pass the same toolchain as is used to build tarantool itself,
+    # because they can be incompatible.
+    list(APPEND NANOARROW_CMAKE_FLAGS "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}")
+    list(APPEND NANOARROW_CMAKE_FLAGS "-DCMAKE_LINKER=${CMAKE_LINKER}")
+    list(APPEND NANOARROW_CMAKE_FLAGS "-DCMAKE_AR=${CMAKE_AR}")
+    list(APPEND NANOARROW_CMAKE_FLAGS "-DCMAKE_RANLIB=${CMAKE_RANLIB}")
+    list(APPEND NANOARROW_CMAKE_FLAGS "-DCMAKE_NM=${CMAKE_NM}")
+    list(APPEND NANOARROW_CMAKE_FLAGS "-DCMAKE_STRIP=${CMAKE_STRIP}")
+    list(APPEND NANOARROW_CMAKE_FLAGS "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
+
+    include(ExternalProject)
+    ExternalProject_Add(bundled-nanoarrow-project
+        PREFIX ${NANOARROW_INSTALL_DIR}
+        SOURCE_DIR ${NANOARROW_SOURCE_DIR}
+        CMAKE_ARGS ${NANOARROW_CMAKE_FLAGS}
+        BUILD_BYPRODUCTS ${NANOARROW_LIBRARIES}
+    )
+
+    add_library(bundled-nanoarrow-core STATIC IMPORTED GLOBAL)
+    set_target_properties(bundled-nanoarrow-core PROPERTIES IMPORTED_LOCATION
+        ${NANOARROW_CORE_LIBRARY})
+    add_dependencies(bundled-nanoarrow-core bundled-nanoarrow-project)
+
+    add_library(bundled-nanoarrow-ipc STATIC IMPORTED GLOBAL)
+    set_target_properties(bundled-nanoarrow-ipc PROPERTIES IMPORTED_LOCATION
+        ${NANOARROW_IPC_LIBRARY})
+    add_dependencies(bundled-nanoarrow-ipc bundled-nanoarrow-project)
+
+    add_library(bundled-flatccrt STATIC IMPORTED GLOBAL)
+    set_target_properties(bundled-flatccrt PROPERTIES IMPORTED_LOCATION
+        ${FLATCCRT_LIBRARY})
+    add_dependencies(bundled-flatccrt bundled-nanoarrow-project)
+
+    add_custom_target(bundled-nanoarrow
+        DEPENDS bundled-nanoarrow-core bundled-nanoarrow-ipc bundled-flatccrt)
+
+    # Setup NANOARROW_INCLUDE_DIRS for global use.
+    set(NANOARROW_INCLUDE_DIRS ${NANOARROW_INCLUDE_DIR})
+endmacro()

--- a/debian/copyright
+++ b/debian/copyright
@@ -369,6 +369,10 @@ Files: third_party/arrow/abi.h
 Copyright: 2016-2024 The Apache Software Foundation
 License: Apache-2.0
 
+Files: third_party/arrow/nanoarrow/*
+Copyright: 2023-2024 The Apache Software Foundation
+License: Apache-2.0
+
 License: BSD-2-Clause
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions

--- a/extra/exports
+++ b/extra/exports
@@ -73,6 +73,7 @@ box_index_tuple_position
 box_info_lsn
 box_init_latest_dd_version_id
 box_insert
+box_insert_arrow
 box_iproto_override
 box_iproto_send
 box_is_ro

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -306,7 +306,7 @@ endif()
 set (reexport_libraries server core misc bitset csv swim swim_udp swim_ev
      shutdown tzcode ${LUAJIT_LIBRARIES} ${MSGPUCK_LIBRARIES} ${ICU_LIBRARIES}
      ${CURL_LIBRARIES} ${XXHASH_LIBRARIES} ${LIBCDT_LIBRARIES}
-     ${EXTRA_REEXPORT_LIBRARIES})
+     ${NANOARROW_LIBRARIES} ${EXTRA_REEXPORT_LIBRARIES})
 
 set (common_libraries
     ${reexport_libraries}

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -133,6 +133,7 @@ add_custom_target(box_generate_lua_sources
 set_property(DIRECTORY PROPERTY ADDITIONAL_MAKE_CLEAN_FILES ${lua_sources})
 
 include_directories(${ZSTD_INCLUDE_DIRS})
+include_directories(${NANOARROW_INCLUDE_DIRS})
 include_directories(${PROJECT_BINARY_DIR}/src/box/sql)
 include_directories(${PROJECT_BINARY_DIR}/src/box)
 include_directories(${EXTRA_CORE_INCLUDE_DIRS})

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -282,6 +282,7 @@ set(box_sources
     decimal.c
     read_view.c
     mp_box_ctx.c
+    arrow_ipc.c
     ${sql_sources}
     ${lua_sources}
     lua/init.c

--- a/src/box/arrow_ipc.c
+++ b/src/box/arrow_ipc.c
@@ -1,0 +1,166 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2024, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include "arrow_ipc.h"
+
+#include "diag.h"
+#include "error.h"
+#include "small/region.h"
+#include "nanoarrow/nanoarrow_ipc.h"
+
+int
+arrow_ipc_encode(struct ArrowArray *array, struct ArrowSchema *schema,
+		 struct region *region, const char **ret_data,
+		 const char **ret_data_end)
+{
+	ArrowErrorCode rc;
+	struct ArrowError error;
+	struct ArrowBuffer buffer;
+	ArrowBufferInit(&buffer);
+
+	struct ArrowArrayView array_view;
+	rc = ArrowArrayViewInitFromSchema(&array_view, schema, &error);
+	if (rc != NANOARROW_OK) {
+		diag_set(ClientError, ER_ARROW_IPC_ENCODE,
+			 "ArrowArrayViewInitFromSchema", error.message);
+		return -1;
+	}
+
+	/* Set buffer sizes and data pointers from an array. */
+	rc = ArrowArrayViewSetArray(&array_view, array, &error);
+	if (rc != NANOARROW_OK) {
+		diag_set(ClientError, ER_ARROW_IPC_ENCODE,
+			 "ArrowArrayViewSetArray", error.message);
+		goto error1;
+	}
+
+	/* All bytes written to the stream will be appended to the buffer. */
+	struct ArrowIpcOutputStream stream;
+	rc = ArrowIpcOutputStreamInitBuffer(&stream, &buffer);
+	if (rc != NANOARROW_OK) {
+		diag_set(ClientError, ER_ARROW_IPC_ENCODE,
+			 "ArrowIpcOutputStreamInitBuffer", NULL);
+		goto error1;
+	}
+
+	/*
+	 * A stream writer which encodes schema and array into an IPC byte
+	 * stream. The writer takes ownership of the output byte stream.
+	 */
+	struct ArrowIpcWriter writer;
+	rc = ArrowIpcWriterInit(&writer, &stream);
+	if (rc != NANOARROW_OK) {
+		diag_set(ClientError, ER_ARROW_IPC_ENCODE, "ArrowIpcWriterInit",
+			 NULL);
+		stream.release(&stream);
+		goto error1;
+	}
+
+	rc = ArrowIpcWriterWriteSchema(&writer, schema, &error);
+	if (rc != NANOARROW_OK) {
+		diag_set(ClientError, ER_ARROW_IPC_ENCODE,
+			 "ArrowIpcWriterWriteSchema", error.message);
+		goto error2;
+	}
+
+	rc = ArrowIpcWriterWriteArrayView(&writer, &array_view, &error);
+	if (rc != NANOARROW_OK) {
+		diag_set(ClientError, ER_ARROW_IPC_ENCODE,
+			 "ArrowIpcWriterWriteArrayView", error.message);
+		goto error2;
+	}
+
+	/*
+	 * TODO: It is possible to avoid extra `memcpy()' by switching
+	 * `ArrowBuffer' to `region_realloc()'.
+	 */
+	char *data = xregion_alloc(region, buffer.size_bytes);
+	memcpy(data, buffer.data, buffer.size_bytes);
+	*ret_data = data;
+	*ret_data_end = data + buffer.size_bytes;
+
+	ArrowIpcWriterReset(&writer);
+	ArrowArrayViewReset(&array_view);
+	ArrowBufferReset(&buffer);
+	return 0;
+error2:
+	ArrowIpcWriterReset(&writer);
+error1:
+	ArrowArrayViewReset(&array_view);
+	ArrowBufferReset(&buffer);
+	return -1;
+}
+
+int
+arrow_ipc_decode(struct ArrowArray *array, struct ArrowSchema *schema,
+		 const char *data, const char *data_end)
+{
+	ssize_t size = data_end - data;
+	if (size <= 0) {
+		diag_set(ClientError, ER_ARROW_IPC_DECODE, NULL,
+			 "Unexpected data size");
+		return -1;
+	}
+
+	ArrowErrorCode rc;
+	struct ArrowError error;
+	struct ArrowBuffer buffer;
+	ArrowBufferInit(&buffer);
+
+	rc = ArrowBufferAppend(&buffer, data, size);
+	if (rc != NANOARROW_OK) {
+		diag_set(ClientError, ER_ARROW_IPC_DECODE, "ArrowBufferAppend",
+			 NULL);
+		ArrowBufferReset(&buffer);
+		return -1;
+	}
+
+	/*
+	 * Create an input stream from a buffer.
+	 * The stream takes ownership of the buffer and reads bytes from it.
+	 */
+	struct ArrowIpcInputStream input_stream;
+	rc = ArrowIpcInputStreamInitBuffer(&input_stream, &buffer);
+	if (rc != NANOARROW_OK) {
+		diag_set(ClientError, ER_ARROW_IPC_DECODE,
+			 "ArrowIpcInputStreamInitBuffer", NULL);
+		ArrowBufferReset(&buffer);
+		return -1;
+	}
+
+	/*
+	 * Initialize an array stream from an input stream of bytes.
+	 * The array_stream takes ownership of input_stream.
+	 */
+	struct ArrowArrayStream array_stream;
+	rc = ArrowIpcArrayStreamReaderInit(&array_stream, &input_stream, NULL);
+	if (rc != NANOARROW_OK) {
+		diag_set(ClientError, ER_ARROW_IPC_DECODE,
+			 "ArrowIpcArrayStreamReaderInit", NULL);
+		input_stream.release(&input_stream);
+		return -1;
+	}
+
+	rc = ArrowArrayStreamGetSchema(&array_stream, schema, &error);
+	if (rc != NANOARROW_OK) {
+		diag_set(ClientError, ER_ARROW_IPC_DECODE,
+			 "ArrowArrayStreamGetSchema", error.message);
+		goto error;
+	}
+
+	rc = ArrowArrayStreamGetNext(&array_stream, array, &error);
+	if (rc != NANOARROW_OK) {
+		diag_set(ClientError, ER_ARROW_IPC_DECODE,
+			 "ArrowArrayStreamGetNext", error.message);
+		schema->release(schema);
+		goto error;
+	}
+
+	ArrowArrayStreamRelease(&array_stream);
+	return 0;
+error:
+	ArrowArrayStreamRelease(&array_stream);
+	return -1;
+}

--- a/src/box/arrow_ipc.h
+++ b/src/box/arrow_ipc.h
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2024, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include "arrow/abi.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+struct region;
+
+/**
+ * Encodes `array' and `schema' into Arrow IPC format. The memory is allocated
+ * on `region', and the address is returned via `ret_data' and `ret_data_end'.
+ * Returns 0 on success, -1 on failure (diag is set).
+ */
+int
+arrow_ipc_encode(struct ArrowArray *array, struct ArrowSchema *schema,
+		 struct region *region, const char **ret_data,
+		 const char **ret_data_end);
+
+/**
+ * Decodes `array' and `schema' from the `data' in Arrow IPC format.
+ * Returns 0 on success, -1 on failure (diag is set).
+ */
+int
+arrow_ipc_decode(struct ArrowArray *array, struct ArrowSchema *schema,
+		 const char *data, const char *data_end);
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */

--- a/src/box/blackhole.c
+++ b/src/box/blackhole.c
@@ -113,6 +113,7 @@ static const struct space_vtab blackhole_space_vtab = {
 	/* .execute_delete = */ blackhole_space_execute_delete,
 	/* .execute_update = */ blackhole_space_execute_update,
 	/* .execute_upsert = */ blackhole_space_execute_upsert,
+	/* .execute_insert_arrow = */ generic_space_execute_insert_arrow,
 	/* .ephemeral_replace = */ generic_space_ephemeral_replace,
 	/* .ephemeral_delete = */ generic_space_ephemeral_delete,
 	/* .ephemeral_rowid_next = */ generic_space_ephemeral_rowid_next,

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -4011,6 +4011,19 @@ box_upsert(uint32_t space_id, uint32_t index_id, const char *tuple,
 	return box_process1(&request, result);
 }
 
+API_EXPORT int
+box_insert_arrow(uint32_t space_id, struct ArrowArray *array,
+		 struct ArrowSchema *schema)
+{
+	struct request request;
+	memset(&request, 0, sizeof(request));
+	request.type = IPROTO_INSERT_ARROW;
+	request.space_id = space_id;
+	request.arrow_array = array;
+	request.arrow_schema = schema;
+	return box_process1(&request, NULL);
+}
+
 /**
  * Trigger space truncation by bumping a counter
  * in _truncate space.

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -666,6 +666,31 @@ box_upsert(uint32_t space_id, uint32_t index_id, const char *tuple,
 	   const char *tuple_end, const char *ops, const char *ops_end,
 	   int index_base, box_tuple_t **result);
 
+struct ArrowArray;
+struct ArrowSchema;
+
+/**
+ * Executes a batch insert request.
+ *
+ * A record batch from the Arrow `array` is inserted into the space columns,
+ * whose names are provided by the Arrow `schema`. Column types in the schema
+ * must match the types of the corresponding fields in the space format.
+ *
+ * If a column is nullable in space format, it can be omitted. All non-nullable
+ * columns (including primary key parts) must be present in the batch.
+ *
+ * This function does not release neither `array` nor `schema`.
+ *
+ * \param space_id space identifier
+ * \param array input data in ArrowArray format
+ * \param schema definition of the input data in ArrowSchema format
+ * \retval 0 on success
+ * \retval -1 on error (check box_error_last())
+ */
+API_EXPORT int
+box_insert_arrow(uint32_t space_id, struct ArrowArray *array,
+		 struct ArrowSchema *schema);
+
 /**
  * Truncate space.
  *

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -433,6 +433,8 @@ struct errcode_record {
 	_(ER_READ_VIEW_CLOSED, 286,		"The read view is closed") \
 	_(ER_WAL_QUEUE_FULL, 287,		"The WAL queue is full") \
 	_(ER_INVALID_VCLOCK, 288,		"Invalid vclock", "value", STRING) \
+	_(ER_ARROW_IPC_ENCODE, 289,		"Failed to encode Arrow IPC data", "method", STRING, "details", STRING) \
+	_(ER_ARROW_IPC_DECODE, 290,		"Failed to decode Arrow IPC data", "method", STRING, "details", STRING) \
 	TEST_ERROR_CODES(_) /** This one should be last. */
 
 /*

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -1866,6 +1866,7 @@ iproto_msg_decode(struct iproto_msg *msg, struct cmsg_hop **route)
 	case IPROTO_UPDATE:
 	case IPROTO_DELETE:
 	case IPROTO_UPSERT:
+	case IPROTO_INSERT_ARROW:
 		assert(type < sizeof(iproto_thread->dml_route) /
 			      sizeof(*iproto_thread->dml_route));
 		*route = iproto_thread->dml_route[type];
@@ -3655,6 +3656,7 @@ iproto_thread_init_routes(struct iproto_thread *iproto_thread)
 	assert(dml_route[IPROTO_BEGIN] == NULL);
 	assert(dml_route[IPROTO_COMMIT] == NULL);
 	assert(dml_route[IPROTO_ROLLBACK] == NULL);
+	dml_route[IPROTO_INSERT_ARROW] = iproto_thread->process1_route;
 
 	iproto_thread->connect_route[0] =
 		{ tx_process_connect, &iproto_thread->net_pipe };

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -3636,34 +3636,26 @@ iproto_thread_init_routes(struct iproto_thread *iproto_thread)
 	iproto_thread->push_route[0] =
 		{ iproto_process_push, &iproto_thread->tx_pipe };
 	iproto_thread->push_route[1] = { tx_end_push, NULL };
-	/* IPROTO_OK */
-	iproto_thread->dml_route[0] = NULL;
-	/* IPROTO_SELECT */
-	iproto_thread->dml_route[1] = iproto_thread->select_route;
-	/* IPROTO_INSERT */
-	iproto_thread->dml_route[2] = iproto_thread->process1_route;
-	/* IPROTO_REPLACE */
-	iproto_thread->dml_route[3] = iproto_thread->process1_route;
-	/* IPROTO_UPDATE */
-	iproto_thread->dml_route[4] = iproto_thread->process1_route;
-	/* IPROTO_DELETE */
-	iproto_thread->dml_route[5] = iproto_thread->process1_route;
-	 /* IPROTO_CALL_16 */
-	iproto_thread->dml_route[6] =  iproto_thread->call_route;
-	/* IPROTO_AUTH */
-	iproto_thread->dml_route[7] = iproto_thread->misc_route;
-	/* IPROTO_EVAL */
-	iproto_thread->dml_route[8] = iproto_thread->call_route;
-	/* IPROTO_UPSERT */
-	iproto_thread->dml_route[9] = iproto_thread->process1_route;
-	/* IPROTO_CALL */
-	iproto_thread->dml_route[10] = iproto_thread->call_route;
-	/* IPROTO_EXECUTE */
-	iproto_thread->dml_route[11] = iproto_thread->sql_route;
-	/* IPROTO_NOP */
-	iproto_thread->dml_route[12] = NULL;
-	/* IPROTO_PREPARE */
-	iproto_thread->dml_route[13] = iproto_thread->sql_route;
+
+	struct cmsg_hop **dml_route = iproto_thread->dml_route;
+	assert(dml_route[IPROTO_OK] == NULL);
+	dml_route[IPROTO_SELECT] = iproto_thread->select_route;
+	dml_route[IPROTO_INSERT] = iproto_thread->process1_route;
+	dml_route[IPROTO_REPLACE] = iproto_thread->process1_route;
+	dml_route[IPROTO_UPDATE] = iproto_thread->process1_route;
+	dml_route[IPROTO_DELETE] = iproto_thread->process1_route;
+	dml_route[IPROTO_CALL_16] = iproto_thread->call_route;
+	dml_route[IPROTO_AUTH] = iproto_thread->misc_route;
+	dml_route[IPROTO_EVAL] = iproto_thread->call_route;
+	dml_route[IPROTO_UPSERT] = iproto_thread->process1_route;
+	dml_route[IPROTO_CALL] = iproto_thread->call_route;
+	dml_route[IPROTO_EXECUTE] = iproto_thread->sql_route;
+	assert(dml_route[IPROTO_NOP] == NULL);
+	dml_route[IPROTO_PREPARE] = iproto_thread->sql_route;
+	assert(dml_route[IPROTO_BEGIN] == NULL);
+	assert(dml_route[IPROTO_COMMIT] == NULL);
+	assert(dml_route[IPROTO_ROLLBACK] == NULL);
+
 	iproto_thread->connect_route[0] =
 		{ tx_process_connect, &iproto_thread->net_pipe };
 	iproto_thread->connect_route[1] = { net_send_greeting, NULL };

--- a/src/box/iproto_constants.c
+++ b/src/box/iproto_constants.c
@@ -32,23 +32,24 @@
 
 #define bit(c) (1ULL<<IPROTO_##c)
 const uint64_t iproto_body_key_map[IPROTO_TYPE_STAT_MAX] = {
-	0,                                                     /* unused */
-	bit(SPACE_ID) | bit(LIMIT) | bit(KEY),                 /* SELECT */
-	bit(SPACE_ID) | bit(TUPLE),                            /* INSERT */
-	bit(SPACE_ID) | bit(TUPLE),                            /* REPLACE */
-	bit(SPACE_ID) | bit(KEY) | bit(TUPLE),                 /* UPDATE */
-	bit(SPACE_ID) | bit(KEY),                              /* DELETE */
-	0,                                                     /* CALL_16 */
-	0,                                                     /* AUTH */
-	0,                                                     /* EVAL */
-	bit(SPACE_ID) | bit(OPS) | bit(TUPLE),                 /* UPSERT */
-	0,                                                     /* CALL */
-	0,                                                     /* EXECUTE */
-	0,                                                     /* NOP */
-	0,                                                     /* PREPARE */
-	0,                                                     /* BEGIN */
-	0,                                                     /* COMMIT */
-	0,                                                     /* ROLLBACK */
+	0,                                                    /* unused */
+	bit(SPACE_ID) | bit(LIMIT) | bit(KEY),                /* SELECT */
+	bit(SPACE_ID) | bit(TUPLE),                           /* INSERT */
+	bit(SPACE_ID) | bit(TUPLE),                           /* REPLACE */
+	bit(SPACE_ID) | bit(KEY) | bit(TUPLE),                /* UPDATE */
+	bit(SPACE_ID) | bit(KEY),                             /* DELETE */
+	0,                                                    /* CALL_16 */
+	0,                                                    /* AUTH */
+	0,                                                    /* EVAL */
+	bit(SPACE_ID) | bit(OPS) | bit(TUPLE),                /* UPSERT */
+	0,                                                    /* CALL */
+	0,                                                    /* EXECUTE */
+	0,                                                    /* NOP */
+	0,                                                    /* PREPARE */
+	0,                                                    /* BEGIN */
+	0,                                                    /* COMMIT */
+	0,                                                    /* ROLLBACK */
+	bit(SPACE_ID) | bit(ARROW),                           /* INSERT_ARROW */
 };
 #undef bit
 

--- a/src/box/iproto_constants.h
+++ b/src/box/iproto_constants.h
@@ -156,6 +156,10 @@ extern const char *iproto_flag_bit_strs[];
 	/** Position of last selected tuple in response. */		\
 	_(POSITION, 0x35, MP_STR)					\
 									\
+	/** Also request keys. See the comment above. */		\
+	/** The data in Arrow format. */				\
+	_(ARROW, 0x36, MP_EXT)						\
+									\
 	/* Leave a gap between response keys and SQL keys. */		\
 	_(SQL_TEXT, 0x40, MP_STR)					\
 	_(SQL_BIND, 0x41, MP_ARRAY)					\
@@ -346,6 +350,8 @@ iproto_key_bit(unsigned char key)
 	_(COMMIT, 15)							\
 	/* Rollback transaction */					\
 	_(ROLLBACK, 16)							\
+	/** INSERT Arrow request. */					\
+	_(INSERT_ARROW, 17)						\
 									\
 	_(RAFT, 30)							\
 	/** PROMOTE request. */						\
@@ -429,7 +435,7 @@ enum iproto_type {
 	IPROTO_UNKNOWN = -1,
 
 	/** The maximum typecode used for box.stat() */
-	IPROTO_TYPE_STAT_MAX = IPROTO_ROLLBACK + 1,
+	IPROTO_TYPE_STAT_MAX = IPROTO_INSERT_ARROW + 1,
 
 	/** Vinyl run info stored in .index file */
 	VY_INDEX_RUN_INFO = 100,
@@ -525,7 +531,8 @@ static inline bool
 iproto_type_is_dml(uint16_t type)
 {
 	return (type >= IPROTO_SELECT && type <= IPROTO_DELETE) ||
-		type == IPROTO_UPSERT || type == IPROTO_NOP;
+		type == IPROTO_UPSERT || type == IPROTO_NOP ||
+		type == IPROTO_INSERT_ARROW;
 }
 
 /**

--- a/src/box/iproto_features.c
+++ b/src/box/iproto_features.c
@@ -91,4 +91,6 @@ iproto_features_init(void)
 #endif /* defined(ENABLE_FETCH_SNAPSHOT_CURSOR) */
 	iproto_features_set(&IPROTO_CURRENT_FEATURES,
 			    IPROTO_FEATURE_IS_SYNC);
+	iproto_features_set(&IPROTO_CURRENT_FEATURES,
+			    IPROTO_FEATURE_INSERT_ARROW);
 }

--- a/src/box/iproto_features.h
+++ b/src/box/iproto_features.h
@@ -88,6 +88,10 @@ extern "C" {
 	 * IS_SYNC flag in IPROTO_BEGIN, IPROTO_COMMIT
 	 */								\
 	_(IS_SYNC, 11)							\
+	/**
+	 * Support of data insertion in Arrow format.
+	 */								\
+	_(INSERT_ARROW, 12)						\
 
 #define IPROTO_FEATURE_MEMBER(s, v) IPROTO_FEATURE_ ## s = v,
 
@@ -112,7 +116,7 @@ struct iproto_features {
  * `box.iproto.protocol_version` needs to be updated correspondingly.
  */
 enum {
-	IPROTO_CURRENT_VERSION = 9,
+	IPROTO_CURRENT_VERSION = 10,
 };
 
 /**

--- a/src/box/lua/net_box.c
+++ b/src/box/lua/net_box.c
@@ -82,7 +82,7 @@ enum {
 	/**
 	 * IPROTO protocol version supported by the netbox connector.
 	 */
-	NETBOX_IPROTO_VERSION = 9,
+	NETBOX_IPROTO_VERSION = 10,
 };
 
 /**

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -1463,6 +1463,7 @@ static const struct space_vtab memtx_space_vtab = {
 	/* .execute_delete = */ memtx_space_execute_delete,
 	/* .execute_update = */ memtx_space_execute_update,
 	/* .execute_upsert = */ memtx_space_execute_upsert,
+	/* .execute_insert_arrow = */ generic_space_execute_insert_arrow,
 	/* .ephemeral_replace = */ memtx_space_ephemeral_replace,
 	/* .ephemeral_delete = */ memtx_space_ephemeral_delete,
 	/* .ephemeral_rowid_next = */ memtx_space_ephemeral_rowid_next,

--- a/src/box/session_settings.c
+++ b/src/box/session_settings.c
@@ -425,6 +425,7 @@ const struct space_vtab session_settings_space_vtab = {
 	/* .execute_delete = */ session_settings_space_execute_delete,
 	/* .execute_update = */ session_settings_space_execute_update,
 	/* .execute_upsert = */ session_settings_space_execute_upsert,
+	/* .execute_insert_arrow = */ generic_space_execute_insert_arrow,
 	/* .ephemeral_replace = */ generic_space_ephemeral_replace,
 	/* .ephemeral_delete = */ generic_space_ephemeral_delete,
 	/* .ephemeral_rowid_next = */ generic_space_ephemeral_rowid_next,

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -41,6 +41,7 @@
 #include "iproto_constants.h"
 #include "core/event.h"
 #include "txn_event_trigger.h"
+#include "arrow/abi.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -70,6 +71,9 @@ struct space_vtab {
 	int (*execute_update)(struct space *, struct txn *,
 			      struct request *, struct tuple **result);
 	int (*execute_upsert)(struct space *, struct txn *, struct request *);
+	int (*execute_insert_arrow)(struct space *space, struct txn *txn,
+				    struct ArrowArray *array,
+				    struct ArrowSchema *schema);
 
 	int (*ephemeral_replace)(struct space *, const char *, const char *);
 
@@ -762,6 +766,9 @@ space_cleanup_constraints(struct space *space);
  * Virtual method stubs.
  */
 size_t generic_space_bsize(struct space *);
+int generic_space_execute_insert_arrow(struct space *space, struct txn *txn,
+				       struct ArrowArray *array,
+				       struct ArrowSchema *schema);
 int generic_space_ephemeral_replace(struct space *, const char *, const char *);
 int generic_space_ephemeral_delete(struct space *, const char *);
 int generic_space_ephemeral_rowid_next(struct space *, uint64_t *);

--- a/src/box/sysview.c
+++ b/src/box/sysview.c
@@ -487,6 +487,7 @@ static const struct space_vtab sysview_space_vtab = {
 	/* .execute_delete = */ sysview_space_execute_delete,
 	/* .execute_update = */ sysview_space_execute_update,
 	/* .execute_upsert = */ sysview_space_execute_upsert,
+	/* .execute_insert_arrow = */ generic_space_execute_insert_arrow,
 	/* .ephemeral_replace = */ generic_space_ephemeral_replace,
 	/* .ephemeral_delete = */ generic_space_ephemeral_delete,
 	/* .ephemeral_rowid_next = */ generic_space_ephemeral_rowid_next,

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -42,6 +42,7 @@
 #include "session.h"
 #include "wal_ext.h"
 #include "rmean.h"
+#include "arrow_ipc.h"
 
 double too_long_threshold;
 
@@ -277,6 +278,18 @@ txn_add_redo(struct txn *txn, struct txn_stmt *stmt, struct request *request)
 	if (space != NULL && space->wal_ext != NULL)
 		space_wal_ext_process_request(space->wal_ext, stmt, request);
 	struct region *txn_region = tx_region_acquire(txn);
+	if (request->arrow_array != NULL) {
+		assert(request->arrow_schema != NULL);
+		assert(request->arrow_ipc == NULL);
+		assert(request->arrow_ipc_end == NULL);
+		if (arrow_ipc_encode(
+				request->arrow_array, request->arrow_schema,
+				txn_region, &request->arrow_ipc,
+				&request->arrow_ipc_end) != 0) {
+			tx_region_release(txn, TX_ALLOC_SYSTEM);
+			return -1;
+		}
+	}
 	xrow_encode_dml(request, txn_region, row->body, &row->bodycnt);
 	tx_region_release(txn, TX_ALLOC_SYSTEM);
 	txn_region = NULL;

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -4685,6 +4685,7 @@ static const struct space_vtab vinyl_space_vtab = {
 	/* .execute_delete = */ vinyl_space_execute_delete,
 	/* .execute_update = */ vinyl_space_execute_update,
 	/* .execute_upsert = */ vinyl_space_execute_upsert,
+	/* .execute_insert_arrow = */ generic_space_execute_insert_arrow,
 	/* .ephemeral_replace = */ generic_space_ephemeral_replace,
 	/* .ephemeral_delete = */ generic_space_ephemeral_delete,
 	/* .ephemeral_rowid_next = */ generic_space_ephemeral_rowid_next,

--- a/src/box/xrow.h
+++ b/src/box/xrow.h
@@ -211,6 +211,14 @@ struct request {
 	/** Insert/replace/upsert tuple or proc argument or update operations. */
 	const char *tuple;
 	const char *tuple_end;
+	/** The data in in-memory Arrow format. */
+	struct ArrowArray *arrow_array;
+	/** Arrow schema for @arrow_array. */
+	struct ArrowSchema *arrow_schema;
+	/** The data in serialized Arrow format. */
+	const char *arrow_ipc;
+	/** End of @arrow_ipc. */
+	const char *arrow_ipc_end;
 	/** Upsert operations. */
 	const char *ops;
 	const char *ops_end;

--- a/src/lib/core/CMakeLists.txt
+++ b/src/lib/core/CMakeLists.txt
@@ -79,7 +79,7 @@ endif()
 add_library(core STATIC ${core_sources})
 
 target_link_libraries(core salad small uri decNumber bit tzcode misc
-                      ${LIBEV_LIBRARIES}
+                      ${LIBEV_LIBRARIES} ${NANOARROW_LIBRARIES}
                       ${LIBEIO_LIBRARIES} ${LIBCORO_LIBRARIES}
                       ${MSGPUCK_LIBRARIES} ${ICU_LIBRARIES}
                       ${LIBCDT_LIBRARIES} ${OPENSSL_LIBRARIES}
@@ -103,6 +103,8 @@ endif()
 if (ENABLE_BUNDLED_ICU)
     add_dependencies(core bundled-icu)
 endif()
+
+add_dependencies(core bundled-nanoarrow)
 
 if (ENABLE_TUPLE_COMPRESSION)
     target_link_libraries(core ${ZSTD_LIBRARIES})

--- a/src/lib/core/mp_extension_types.h
+++ b/src/lib/core/mp_extension_types.h
@@ -48,6 +48,7 @@ enum mp_extension_type {
     MP_COMPRESSION = 5,
     MP_INTERVAL = 6,
     MP_TUPLE = 7,
+    MP_ARROW = 8,
     mp_extension_type_MAX,
 };
 

--- a/test/app-tap/module_api.c
+++ b/test/app-tap/module_api.c
@@ -15,6 +15,8 @@
 #include <lua.h>
 #include <lauxlib.h>
 
+#include "arrow/abi.h"
+
 #define STR2(x) #x
 #define STR(x) STR2(x)
 
@@ -3362,6 +3364,24 @@ test_fiber_basic_api(lua_State *L)
 	return 1;
 }
 
+static int
+test_box_insert_arrow(struct lua_State *L)
+{
+	fail_unless(lua_gettop(L) == 1);
+	fail_unless(lua_isnumber(L, 1));
+	uint32_t space_id = lua_tointeger(L, 1);
+	struct ArrowSchema schema;
+	struct ArrowArray array;
+	memset(&schema, 0, sizeof(schema));
+	memset(&array, 0, sizeof(array));
+
+	int rc = box_insert_arrow(space_id, &array, &schema);
+	fail_unless(rc == -1);
+	check_diag("ClientError", "memtx does not support arrow format");
+	lua_pushboolean(L, 1);
+	return 1;
+}
+
 LUA_API int
 luaopen_module_api(lua_State *L)
 {
@@ -3420,6 +3440,7 @@ luaopen_module_api(lua_State *L)
 		{"box_iproto_send", test_box_iproto_send},
 		{"box_iproto_override_set", test_box_iproto_override_set},
 		{"box_iproto_override_reset", test_box_iproto_override_reset},
+		{"box_insert_arrow", test_box_insert_arrow},
 		{NULL, NULL}
 	};
 	luaL_register(L, "module_api", lib);

--- a/test/app-tap/module_api.test.lua
+++ b/test/app-tap/module_api.test.lua
@@ -670,8 +670,14 @@ local function test_box_ibuf(test, module)
     test:ok(module.box_ibuf(require('buffer').ibuf()), "box_ibuf API")
 end
 
+local function test_box_insert_arrow(test, module)
+    test:plan(1)
+    test:ok(module.box_insert_arrow(box.space.test.id),
+            "box_insert_arrow API")
+end
+
 require('tap').test("module_api", function(test)
-    test:plan(51)
+    test:plan(52)
     local status, module = pcall(require, 'module_api')
     test:is(status, true, "module")
     test:ok(status, "module is loaded")
@@ -709,6 +715,7 @@ require('tap').test("module_api", function(test)
     test:test("box_iproto_send", test_box_iproto_send, module)
     test:test("box_iproto_override", test_box_iproto_override, module)
     test:test("box_ibuf", test_box_ibuf, module)
+    test:test("box_insert_arrow", test_box_insert_arrow, module)
 
     space:drop()
 end)

--- a/test/box-luatest/gh_10508_iproto_insert_arrow_test.lua
+++ b/test/box-luatest/gh_10508_iproto_insert_arrow_test.lua
@@ -1,0 +1,135 @@
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+    cg.server:exec(function(net_box_uri)
+        rawset(_G, 'iproto_insert_arrow', function(hex_body)
+            local uri = require('uri')
+            local socket = require('socket')
+            -- Connect to the server.
+            local u = uri.parse(net_box_uri)
+            local s = socket.tcp_connect(u.host, u.service)
+            local greeting = s:read(box.iproto.GREETING_SIZE)
+            greeting = box.iproto.decode_greeting(greeting)
+            t.assert_covers(greeting, {protocol = 'Binary'})
+            -- Send the request.
+            local request = box.iproto.encode_packet(
+                {request_type = box.iproto.type.INSERT_ARROW, sync = 123},
+                -- Ignore whitespaces.
+                string.fromhex(hex_body:gsub("%s+", ""))
+            )
+            t.assert_equals(s:write(request), #request)
+            -- Read the response.
+            local response = ''
+            local header, body
+            repeat
+                header, body = box.iproto.decode_packet(response)
+                if header == nil then
+                    local size = body
+                    local data = s:read(size)
+                    t.assert_is_not(data)
+                    response = response .. data
+                end
+            until header ~= nil
+            s:close()
+            return body
+        end)
+    end, {cg.server.net_box_uri})
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+-- Test various invalid requests.
+g.test_iproto_insert_arrow_invalid = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('test')
+        s:create_index('pk')
+
+        -- <MP_MAP> {}
+        local r = _G.iproto_insert_arrow('80')
+        t.assert_equals(r[box.iproto.key.ERROR_24],
+                        "Missing mandatory field 'SPACE_ID' in request")
+        -- <MP_MAP> {
+        --     IPROTO_SPACE_ID: 512}
+        r = _G.iproto_insert_arrow('8110cd0200')
+        t.assert_equals(r[box.iproto.key.ERROR_24],
+                        "Missing mandatory field 'ARROW' in request")
+        -- <MP_MAP> {
+        --     IPROTO_SPACE_ID: 512,
+        --     IPROTO_ARROW: <MP_NIL> null}
+        r = _G.iproto_insert_arrow('8210cd020036c0')
+        t.assert_equals(r[box.iproto.key.ERROR_24],
+                        'Invalid MsgPack - packet body')
+        -- <MP_MAP> {
+        --     IPROTO_SPACE_ID: 512,
+        --     IPROTO_ARROW: <MP_EXT> {
+        --         type: MP_UNKNOWN_EXTENSION,
+        --         size: 0}}
+        r = _G.iproto_insert_arrow('8210cd020036c70000')
+        t.assert_equals(r[box.iproto.key.ERROR_24],
+                        'Invalid MsgPack - packet body')
+        -- <MP_MAP> {
+        --     IPROTO_SPACE_ID: 512,
+        --     IPROTO_ARROW: <MP_EXT> {
+        --         type: MP_ARROW,
+        --         size: 0}}
+        r = _G.iproto_insert_arrow('8210cd020036c70008')
+        t.assert_equals(r[box.iproto.key.ERROR_24],
+                        'Failed to decode Arrow IPC data')
+        t.assert_equals(r[box.iproto.key.ERROR][0][1][6].details,
+                        'Unexpected data size')
+        -- <MP_MAP> {
+        --     IPROTO_SPACE_ID: 512,
+        --     IPROTO_ARROW: <MP_EXT> {
+        --         type: MP_ARROW,
+        --         size: 4,
+        --         data: [0xde, 0xad, 0xbe, 0xef]}}
+        r = _G.iproto_insert_arrow('8210cd020036c70408deadbeef')
+        t.assert_equals(r[box.iproto.key.ERROR_24],
+                        'Failed to decode Arrow IPC data')
+        t.assert_equals(r[box.iproto.key.ERROR][0][1][6].method,
+                        'ArrowArrayStreamGetSchema')
+        t.assert_equals(r[box.iproto.key.ERROR][0][1][6].details,
+                        'Expected at least 8 bytes in remainder of stream')
+
+        -- Correct Schema, but Array is missing.
+        r = _G.iproto_insert_arrow([[
+            8210cd020036c8007c08ffffffff70000000040000009effffff0400010004000000
+            b6ffffff0c00000004000000000000000100000004000000daffffff140000000202
+            000004000000f0ffffff4000000001000000610000000600080004000c0010000400
+            080009000c000c000c0000000400000008000a000c00040006000800ffffffff]])
+        t.assert_equals(r[box.iproto.key.ERROR_24],
+                        'Failed to decode Arrow IPC data')
+        t.assert_equals(r[box.iproto.key.ERROR][0][1][6].method,
+                        'ArrowArrayStreamGetNext')
+        t.assert_equals(r[box.iproto.key.ERROR][0][1][6].details,
+                        'Expected at least 8 bytes in remainder of stream')
+
+        -- A valid request, but memtx does not support arrow format.
+        r = _G.iproto_insert_arrow([[
+            8210cd020036c8011008ffffffff70000000040000009effffff0400010004000000
+            b6ffffff0c00000004000000000000000100000004000000daffffff140000000202
+            000004000000f0ffffff4000000001000000610000000600080004000c0010000400
+            080009000c000c000c0000000400000008000a000c00040006000800ffffffff8800
+            0000040000008affffff0400030010000000080000000000000000000000acffffff
+            01000000000000003400000008000000000000000200000000000000000000000000
+            00000000000000000000000000000800000000000000000000000100000001000000
+            0000000000000000000000000a00140004000c0010000c0014000400060008000c00
+            00000000000000000000]])
+        t.assert_equals(r[box.iproto.key.ERROR_24],
+                        'memtx does not support arrow format')
+    end)
+end

--- a/test/box-luatest/gh_7894_export_iproto_constants_and_features_test.lua
+++ b/test/box-luatest/gh_7894_export_iproto_constants_and_features_test.lua
@@ -66,6 +66,7 @@ local reference_table = {
         BIND_METADATA = 0x33,
         BIND_COUNT = 0x34,
         POSITION = 0x35,
+        ARROW = 0x36,
         SQL_TEXT = 0x40,
         SQL_BIND = 0x41,
         SQL_INFO = 0x42,
@@ -136,6 +137,7 @@ local reference_table = {
         BEGIN = 14,
         COMMIT = 15,
         ROLLBACK = 16,
+        INSERT_ARROW = 17,
         RAFT = 30,
         RAFT_PROMOTE = 31,
         RAFT_DEMOTE = 32,
@@ -171,7 +173,7 @@ local reference_table = {
     },
 
     -- `IPROTO_CURRENT_VERSION` constant
-    protocol_version = 9,
+    protocol_version = 10,
 
     -- `feature_id` enumeration
     protocol_features = {
@@ -187,6 +189,7 @@ local reference_table = {
         call_arg_tuple_extension = true,
         fetch_snapshot_cursor = is_enterprise and true or nil,
         is_sync = true,
+        insert_arrow = true,
     },
     feature = {
         streams = 0,
@@ -201,6 +204,7 @@ local reference_table = {
         call_arg_tuple_extension = 9,
         fetch_snapshot_cursor = 10,
         is_sync = 11,
+        insert_arrow = 12,
     },
 }
 

--- a/test/box-luatest/iproto_request_handlers_overriding_test.lua
+++ b/test/box-luatest/iproto_request_handlers_overriding_test.lua
@@ -28,6 +28,7 @@ local basic_rq_types = {
     VOTE_DEPRECATED = box.iproto.type.VOTE_DEPRECATED,
     VOTE = box.iproto.type.VOTE,
     AUTH = box.iproto.type.AUTH,
+    INSERT_ARROW = box.iproto.type.INSERT_ARROW,
 }
 
 -- Grep server logs for error messages about unsupported request types.

--- a/test/box-py/iproto.result
+++ b/test/box-py/iproto.result
@@ -210,11 +210,11 @@ Invalid MsgPack - request body
 # Invalid auth_type
 Invalid MsgPack - request body
 # Empty request body
-version=9, features=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11], auth_type=chap-sha1
+version=10, features=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12], auth_type=chap-sha1
 # Unknown version and features
-version=9, features=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11], auth_type=chap-sha1
+version=10, features=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12], auth_type=chap-sha1
 # Unknown request key
-version=9, features=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11], auth_type=chap-sha1
+version=10, features=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12], auth_type=chap-sha1
 
 #
 # gh-6257 Watchers

--- a/test/box-tap/feedback_daemon.test.lua
+++ b/test/box-tap/feedback_daemon.test.lua
@@ -251,7 +251,7 @@ box.space.features_sync:drop()
 
 local function check_stats(stat)
     local sub = test:test('feedback operation stats')
-    sub:plan(27)
+    sub:plan(28)
     local box_stat = box.stat()
     local net_stat = box.stat.net()
     for op, val in pairs(box_stat) do

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -499,6 +499,8 @@ t;
  |   286: box.error.READ_VIEW_CLOSED
  |   287: box.error.WAL_QUEUE_FULL
  |   288: box.error.INVALID_VCLOCK
+ |   289: box.error.ARROW_IPC_ENCODE
+ |   290: box.error.ARROW_IPC_DECODE
  | ...
 
 test_run:cmd("setopt delimiter ''");

--- a/test/box/misc.result
+++ b/test/box/misc.result
@@ -153,6 +153,7 @@ t;
   - INSERT
   - EVAL
   - ERROR
+  - INSERT_ARROW
   - CALL
   - BEGIN
   - PREPARE

--- a/test/box/net.box_iproto_id.result
+++ b/test/box/net.box_iproto_id.result
@@ -23,7 +23,7 @@ c = net.connect(box.cfg.listen)
  | ...
 c.peer_protocol_version
  | ---
- | - 9
+ | - 10
  | ...
 print_features(c)
  | ---
@@ -32,12 +32,13 @@ print_features(c)
  |   error_extension: true
  |   call_arg_tuple_extension: true
  |   pagination: true
- |   is_sync: true
+ |   insert_arrow: true
  |   space_and_index_names: true
+ |   dml_tuple_extension: true
  |   streams: true
  |   watch_once: true
- |   dml_tuple_extension: true
  |   call_ret_tuple_extension: true
+ |   is_sync: true
  | ...
 c:close()
  | ---
@@ -66,12 +67,13 @@ print_features(c)
  |   error_extension: false
  |   call_arg_tuple_extension: false
  |   pagination: false
- |   is_sync: false
+ |   insert_arrow: false
  |   space_and_index_names: false
+ |   dml_tuple_extension: false
  |   streams: false
  |   watch_once: false
- |   dml_tuple_extension: false
  |   call_ret_tuple_extension: false
+ |   is_sync: false
  | ...
 errinj.set('ERRINJ_IPROTO_DISABLE_ID', false)
  | ---
@@ -121,12 +123,13 @@ print_features(c)
  |   error_extension: true
  |   call_arg_tuple_extension: true
  |   pagination: true
- |   is_sync: true
+ |   insert_arrow: true
  |   space_and_index_names: true
+ |   dml_tuple_extension: true
  |   streams: true
  |   watch_once: true
- |   dml_tuple_extension: true
  |   call_ret_tuple_extension: true
+ |   is_sync: true
  | ...
 c:close()
  | ---
@@ -172,7 +175,7 @@ c.error -- error
  | ...
 c.peer_protocol_version
  | ---
- | - 9
+ | - 10
  | ...
 print_features(c)
  | ---
@@ -181,12 +184,13 @@ print_features(c)
  |   error_extension: true
  |   call_arg_tuple_extension: true
  |   pagination: true
- |   is_sync: true
+ |   insert_arrow: true
  |   space_and_index_names: true
+ |   dml_tuple_extension: true
  |   streams: true
  |   watch_once: true
- |   dml_tuple_extension: true
  |   call_ret_tuple_extension: true
+ |   is_sync: true
  | ...
 c:close()
  | ---
@@ -205,7 +209,7 @@ c.error -- error
  | ...
 c.peer_protocol_version
  | ---
- | - 9
+ | - 10
  | ...
 print_features(c)
  | ---
@@ -214,12 +218,13 @@ print_features(c)
  |   error_extension: true
  |   call_arg_tuple_extension: true
  |   pagination: true
- |   is_sync: true
+ |   insert_arrow: true
  |   space_and_index_names: true
+ |   dml_tuple_extension: true
  |   streams: true
  |   watch_once: true
- |   dml_tuple_extension: true
  |   call_ret_tuple_extension: true
+ |   is_sync: true
  | ...
 c:close()
  | ---

--- a/third_party/README
+++ b/third_party/README
@@ -66,3 +66,9 @@ How to update arrow/abi.h
 
 Get the header from
 git@github.com:apache/arrow.git cpp/src/arrow/c/abi.h
+
+How to update arrow/nanoarrow
+=============================
+
+Run from project root dir:
+git submodule update --remote third_party/arrow/nanoarrow


### PR DESCRIPTION
The new request inserts into a given space the data that is encoded into Arrow IPC columnar format [^1].
At the moment the request is not supported by memtx and vinyl spaces.

[^1]: https://arrow.apache.org/docs/format/Columnar.html#serialization-and-interprocess-communication-ipc

Closes https://github.com/tarantool/tarantool/issues/10508
Needed for https://github.com/tarantool/tarantool-ee/issues/820