### PR TITLE
Fix crash in small when when `slab_alloc_factor` is low and memory pressure is high

### DIFF
--- a/changelogs/unreleased/gh-10148-fix-small-crash-low-alloc-factor.md
+++ b/changelogs/unreleased/gh-10148-fix-small-crash-low-alloc-factor.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+- Fixed a crash when `slab_alloc_factor` is low and memory pressure is high
+  (gh-10148).

--- a/test/box-luatest/gh_10148_fix_crash_low_slab_alloc_factor_test.lua
+++ b/test/box-luatest/gh_10148_fix_crash_low_slab_alloc_factor_test.lua
@@ -1,0 +1,41 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new({
+        box_cfg = {
+            slab_alloc_factor = 1.001,
+            memtx_memory = 64 * 1024 * 1024,
+            wal_mode = 'none',
+        }
+    })
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+g.test_low_slab_alloc_factor = function(cg)
+    cg.server:exec(function()
+        local test = box.schema.create_space('test')
+        test:create_index('pri')
+        for i=1,1000000 do
+            local ok, err = pcall(test.insert, test, {i, string.rep('x', 1000)})
+            if not ok then
+                t.assert_equals(err:unpack().type, 'OutOfMemory')
+                break
+            end
+        end
+    end)
+end


### PR DESCRIPTION
Closes #10148

Small PR https://github.com/tarantool/small/pull/94