### PR TITLE
build: allow to build debug packages

### DIFF
--- a/.pack.mk
+++ b/.pack.mk
@@ -45,7 +45,7 @@ package: prepare
 	echo VERSION=$${VERSION}; \
 	PACKPACK_EXTRA_DOCKER_RUN_PARAMS="--network=host --volume ${VARDIR}:${VARDIR} ${PACKPACK_EXTRA_DOCKER_RUN_PARAMS}" \
 	TARBALL_EXTRA_ARGS="--exclude=*.exe --exclude=*.dll" \
-	PRESERVE_ENVVARS="TARBALL_EXTRA_ARGS,${PRESERVE_ENVVARS}" \
+	PRESERVE_ENVVARS="CMAKE_BUILD_TYPE,TARBALL_EXTRA_ARGS,${PRESERVE_ENVVARS}" \
 	./packpack/packpack
 
 package-static:

--- a/apk/APKBUILD
+++ b/apk/APKBUILD
@@ -26,7 +26,7 @@ build() {
         GC64=ON
     fi
 
-    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-RelWithDebInfo} \
           -DENABLE_DIST:BOOL=ON \
           -DLUAJIT_DISABLE_SYSPROF:BOOL=ON \
           -DLUAJIT_ENABLE_GC64:BOOL=${GC64:-OFF} \

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -183,8 +183,10 @@ endif()
 
 add_compile_flags("C;CXX" "-fno-common")
 
-if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-# Remove VALGRIND code and assertions in *any* type of release build.
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_definitions("-Wp,-U_FORTIFY_SOURCE")
+else()
+    # Remove VALGRIND code and assertions in *any* type of release build.
     add_definitions("-DNDEBUG" "-DNVALGRIND")
 endif()
 

--- a/debian/rules
+++ b/debian/rules
@@ -3,9 +3,10 @@
 
 VERSION  := $(shell dpkg-parsechangelog|grep ^Version|awk '{print $$2}')
 UVERSION := $(shell echo $(VERSION)|sed 's/-[[:digit:]]\+$$//')
+CMAKE_BUILD_TYPE := $(shell echo $${CMAKE_BUILD_TYPE:-RelWithDebInfo})
 
 DEB_CMAKE_EXTRA_FLAGS := \
-	-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+	-DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
 	-DCMAKE_INSTALL_LIBDIR=lib/$(DEB_HOST_MULTIARCH) \
 	-DCMAKE_INSTALL_SYSCONFDIR=/etc \
 	-DCMAKE_INSTALL_LOCALSTATEDIR=/var \

--- a/rpm/tarantool.spec
+++ b/rpm/tarantool.spec
@@ -4,6 +4,11 @@
 # need to use cmake3 package to build Tarantool on old systems.
 %define use_cmake3 0%{?rhel} == 7
 
+%define _cmake_build_type "%{getenv:CMAKE_BUILD_TYPE}"
+%if %{_cmake_build_type} == ""
+%define _cmake_build_type RelWithDebInfo
+%endif
+
 # Get ${GC64} env variable which can keep the value of 'true' or 'false' to
 # enable or disable luajit gc64.
 %define _gc64 "%{getenv:GC64}"
@@ -140,7 +145,7 @@ C and Lua/C modules.
 %cmake \
 %endif
        -B . \
-         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+         -DCMAKE_BUILD_TYPE=%{_cmake_build_type} \
          -DCMAKE_INSTALL_LOCALSTATEDIR:PATH=%{_localstatedir} \
          -DCMAKE_INSTALL_SYSCONFDIR:PATH=%{_sysconfdir} \
 %if 0%{?fedora} >= 33

--- a/rump/Makefile
+++ b/rump/Makefile
@@ -3,7 +3,7 @@ CBUILDROOT ?= /usr/rumprun-x86_64
 
 all:
 	cd .. && ${CHOST}-cmake . \
-		-DCMAKE_BUILD_TYPE=Debug \
+		-DCMAKE_BUILD_TYPE=$${CMAKE_BUILD_TYPE:-RelWithDebInfo} \
 		-DENABLE_BUNDLED_LIBYAML=ON \
 		-DENABLE_DIST=OFF
 	$(MAKE) -C .. $(MAKEOPTS) tarantool


### PR DESCRIPTION
`CMAKE_BUILD_TYPE` environment is now considered in all Tarantool packages specs. The behavior is the same as before if omitted (build RelWithDebInfo). Command to build debug tarantool package:

`CMAKE_BUILD_TYPE=Debug OS=ubuntu DIST=jammy make -f .pack.mk package`

Part of #5416

NO_TEST=make
NO_CHANGELOG=make
NO_DOC=make