### PR TITLE
vinyl: handle error loading statement from disk during key lookup

### DIFF
--- a/changelogs/unreleased/gh-10512-fix-vinyl-page-load-error-handling.md
+++ b/changelogs/unreleased/gh-10512-fix-vinyl-page-load-error-handling.md
@@ -1,0 +1,4 @@
+## bugfix/vinyl
+
+* Fixed a bug when `index.select()` could silently skip a tuple if it failed to
+  load a row from a run file (gh-10512).

--- a/test/vinyl-luatest/gh_10512_page_load_error_test.lua
+++ b/test/vinyl-luatest/gh_10512_page_load_error_test.lua
@@ -1,0 +1,59 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new({
+        box_cfg = {
+            -- Disable cache to force reads from disk.
+            vinyl_cache = 0,
+            vinyl_max_tuple_size = 1024 * 1024,
+        },
+    })
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+        box.cfg{vinyl_max_tuple_size = 1024 * 1024}
+    end)
+end)
+
+g.test_page_load_error = function(cg)
+    cg.server:exec(function()
+        local digest = require('digest')
+        local s = box.schema.space.create('test', {engine = 'vinyl'})
+        s:create_index('pk', {page_size = 1024})
+        for i = 1, 50 do
+            -- Use random padding to make compression ineffective.
+            -- With constant padding, all the tuple could end up
+            -- in a single page.
+            s:insert({i, digest.urandom(128)})
+        end
+        -- Dumps tuples to disk.
+        box.snapshot()
+        box.cfg{vinyl_max_tuple_size = 128}
+        for _, iterator in ipairs({'ge', 'gt', 'le', 'lt', 'eq', 'req'}) do
+            for key = 1, 50 do
+                -- With key = 1 and iterator = 'lt', the read iterator will
+                -- figure out that no page can store requested tuples by
+                -- looking at the first page's min key and won't load any
+                -- pages.
+                if key > 1 or iterator ~= 'lt' then
+                    t.assert_error_covers({
+                        type = 'ClientError',
+                        code = box.error.VINYL_MAX_TUPLE_SIZE,
+                    }, s.count, s, key, {iterator = iterator})
+                end
+            end
+        end
+    end)
+end


### PR DESCRIPTION
`vy_page_stmt()` may fail (return NULL) if:
 - the statement is corrupted;
 - memory allocation for the statement fails;
 - the statement size exceeds `box.cfg.vinyl_max_tuple_size`.

If this happens `vy_page_find_key()` won't return an error. Instead, it'll either point the caller to a wrong statement or claim that there's no statement matching the key in this page. This may result in invalid index selection results and, later on, a crash caused by inconsistencies in the tuple cache. The issue was introduced by commit ac8ce0233a00.

All of the three cases are actually very unlikely to happen in production:
 - If a statement stored in a run file is corrupted, we'll probably fail to load the whole page due to failed checksums and never even get to `vy_page_stmt()`.
 - Statements are allocated with `malloc()`, which doesn't normally fail (instead the whole process would be terminated by OOM) .
 - Users don't tend to lower the tuple size limit after restart.

Still, let's fix the issue by implementing proper error handling for `vy_page_find_key()`.

Closes #10512