### PR TITLE
datetime: introduce tz in datetime.parse()

### DIFF
--- a/changelogs/unreleased/gh-10420-introduce-tz-option-in-parse.md
+++ b/changelogs/unreleased/gh-10420-introduce-tz-option-in-parse.md
@@ -1,0 +1,3 @@
+## bugfix/datetime
+
+* Implemented the `tz` option in `datetime:parse()` (gh-10420).

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -922,6 +922,10 @@ local function datetime_parse_from(str, obj)
         check_str(tzname, 'datetime.parse()')
     end
 
+    if tzoffset and tzname then
+        error("ambiguous timezone: both tzoffset and tz are specified")
+    end
+
     local date, len
     if not fmt or fmt == '' or fmt == 'iso8601' or fmt == 'rfc3339' then
         date, len = datetime_parse_full(str)


### PR DESCRIPTION
Depends on #8412