### PR TITLE
box: make asynchronous transactions bump the limbo's confirmed LSN

### DIFF
--- a/changelogs/unreleased/gh-10528-async-tx-bump-confirmation-boundary.md
+++ b/changelogs/unreleased/gh-10528-async-tx-bump-confirmation-boundary.md
@@ -1,0 +1,6 @@
+## feature/replication
+
+* Made asynchronous transactions bump the confirmation boundary of the
+  synchronous queue allowing to detect a split-brain situation on an old
+  synchronous queue owner when he receives a PROMOTE request that does not
+  confirm the asynchronous transactions he has committed (gh-10528).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -2896,8 +2896,7 @@ box_wait_limbo_acked(double timeout)
 	if (last_entry->lsn < 0) {
 		int64_t tid = last_entry->txn->id;
 
-		journal_queue_flush();
-		if (wal_sync(NULL) != 0)
+		if (wal_flush_journal_queue_and_sync() != 0)
 			return -1;
 
 		if (box_check_promote_term_intact(promote_term) != 0)

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -1008,12 +1008,14 @@ txn_journal_entry_new(struct txn *txn)
 
 		req->approx_len += xrow_approx_len(stmt->row);
 	}
+	if (is_fully_nop)
+		txn_set_flags(txn, TXN_FORCE_ASYNC);
 	/*
 	 * There is no a check for all-local rows, because a local
 	 * space can't be synchronous. So if there is at least one
 	 * synchronous space, the transaction is not local.
 	 */
-	if (!txn_has_flag(txn, TXN_FORCE_ASYNC) && !is_fully_nop) {
+	if (!txn_has_flag(txn, TXN_FORCE_ASYNC)) {
 		if (is_sync) {
 			/*
 			 * Can't commit a fully local transaction synchronously.

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -340,6 +340,13 @@ txn_limbo_assign_lsn(struct txn_limbo *limbo, struct txn_limbo_entry *entry,
 		     int64_t lsn);
 
 /**
+ * Track the confirmation boundary on the replica in order to detect split-brain
+ * by comparing the existing LSN with the one arriving from a remote instance.
+ */
+void
+txn_limbo_confirm_lsn(struct txn_limbo *limbo, int64_t lsn);
+
+/**
  * Ack all transactions up to the given LSN on behalf of the
  * replica with the specified ID.
  */

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -649,6 +649,11 @@ wal_sync(struct vclock *vclock)
 			   wal_sync_f);
 	if (vclock != NULL)
 		vclock_copy(vclock, &msg.vclock);
+	ERROR_INJECT_COUNTDOWN(ERRINJ_WAL_SYNC_DELAY_COUNTDOWN, {
+		struct errinj *e =
+			errinj(ERRINJ_WAL_SYNC_DELAY, ERRINJ_BOOL);
+		e->bparam = true;
+	});
 	ERROR_INJECT_YIELD(ERRINJ_WAL_SYNC_DELAY);
 	return rc;
 }

--- a/src/box/wal.h
+++ b/src/box/wal.h
@@ -219,6 +219,16 @@ wal_mode(void);
 int
 wal_sync(struct vclock *vclock);
 
+/**
+ * A wrapper around `wal_sync` that ensures the journal queue is flushed.
+ */
+static inline int
+wal_flush_journal_queue_and_sync(void)
+{
+	journal_queue_flush();
+	return wal_sync(NULL);
+}
+
 struct wal_checkpoint {
 	struct cbus_call_msg base;
 	/**

--- a/src/lib/core/errinj.h
+++ b/src/lib/core/errinj.h
@@ -186,6 +186,7 @@ struct errinj {
 	_(ERRINJ_WAL_ROTATE, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_WAL_SYNC, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_WAL_SYNC_DELAY, ERRINJ_BOOL, {.bparam = false}) \
+	_(ERRINJ_WAL_SYNC_DELAY_COUNTDOWN, ERRINJ_INT, {.iparam = -1}) \
 	_(ERRINJ_WAL_WRITE, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_WAL_WRITE_COUNT, ERRINJ_INT, {.iparam = 0}) \
 	_(ERRINJ_WAL_WRITE_DISK, ERRINJ_BOOL, {.bparam = false}) \

--- a/test/replication-luatest/gh_10528_async_tx_bump_confirmation_boundary_test.lua
+++ b/test/replication-luatest/gh_10528_async_tx_bump_confirmation_boundary_test.lua
@@ -1,0 +1,233 @@
+local t = require('luatest')
+local server = require('luatest.server')
+local replica_set = require('luatest.replica_set')
+
+local g = t.group(nil, t.helpers.matrix{is_local = {false, true}})
+
+g.before_each(function(cg)
+    cg.replica_set = replica_set:new{}
+    cg.replication = {
+        server.build_listen_uri('master', cg.replica_set.id),
+        server.build_listen_uri('replica', cg.replica_set.id),
+    }
+    local box_cfg = {
+        wal_cleanup_delay = 0,
+        replication = cg.replication,
+        replication_timeout = 0.1,
+        replication_synchro_timeout = 120,
+    }
+    cg.master = cg.replica_set:build_and_add_server{
+        alias = 'master',
+        box_cfg = box_cfg,
+    }
+    cg.replica = cg.replica_set:build_and_add_server{
+        alias = 'replica',
+        box_cfg = box_cfg,
+    }
+    cg.replica_set:start()
+    cg.replica_set:wait_for_fullmesh()
+    cg.master:exec(function(is_local)
+        box.schema.space.create('a', {is_sync = false,
+                                      is_local = is_local}):create_index('p')
+        box.schema.space.create('s', {is_sync = true}):create_index('p')
+        box.ctl.promote()
+    end, {cg.params.is_local})
+    cg.master:wait_for_downstream_to(cg.replica)
+end)
+
+g.after_each(function(cg)
+    cg.replica_set:drop()
+end)
+
+-- Setup a trivial split-brain situation.
+local function setup_trivial_split_brain(cg)
+    cg.replica:update_box_cfg{replication = ''}
+
+    cg.master:exec(function()
+        box.space.a:replace{0}
+    end)
+end
+
+-- Trigger the split-brain situation by promoting a node that did not receive
+-- the preceding asynchronous transactions.
+local function trigger_split_brain(cg)
+    cg.replica:exec(function()
+        box.ctl.promote()
+        t.assert_equals(box.space.a:get{0}, nil)
+    end)
+end
+
+-- Check that the new leader did not trigger a split-brain on the old leader.
+local function check_there_is_no_split_brain(old_leader, new_leader)
+    old_leader:exec(function(replica_id)
+        t.assert_equals(box.info.replication[replica_id].upstream.status,
+                            'follow')
+    end, {new_leader:get_instance_id()})
+end
+
+-- Check whether the new leader caused a split-brain on the old leader
+local function check_for_split_brain(cg)
+    if cg.params.is_local then
+        cg.master:exec(function()
+            t.assert(box.space.a.is_local)
+        end)
+        cg.replica:wait_for_downstream_to(cg.master)
+        check_there_is_no_split_brain(cg.master, cg.replica)
+        return
+    end
+    cg.master:exec(function(replica_id)
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.replication[replica_id].upstream.status,
+                            'stopped')
+            local msg = "Split-Brain discovered: got a request with lsn " ..
+                        "from an already processed range"
+            t.assert_equals(box.info.replication[replica_id].upstream.message,
+                            msg)
+        end)
+    end, {cg.replica:get_instance_id()})
+end
+
+g.test_basic_async = function(cg)
+    setup_trivial_split_brain(cg)
+    trigger_split_brain(cg)
+    check_for_split_brain(cg)
+end
+
+-- Test that asynchronous transactions blocked by synchronous transactions bump
+-- the confirmation boundary when the synchronous transactions get confirmed.
+g.test_async_after_sync = function(cg)
+    t.tarantool.skip_if_not_debug()
+
+    cg.master:exec(function()
+        -- Block the WAL on the CONFIRM write.
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 1)
+
+        require('fiber').create(function()
+            box.space.s:replace{0}
+        end)
+
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.error.injection.get('ERRINJ_WAL_DELAY'), true)
+        end)
+    end)
+
+    cg.replica:exec(function()
+        t.assert_equals(box.info.synchro.queue.len, 1)
+        t.assert_equals(box.space.s:get{0}, {0})
+    end)
+
+    local f_a_id = cg.master:exec(function()
+        local f_a = require('fiber').create(function()
+            box.space.a:replace{0}
+        end)
+        f_a:set_joinable(true)
+        t.assert_equals(box.info.synchro.queue.len, 2)
+
+        -- Block the WAL on the asynchronous transaction write.
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.error.injection.get('ERRINJ_WAL_DELAY'), true)
+        end)
+        t.assert_equals(box.info.synchro.queue.len, 0)
+
+        return f_a:id()
+    end)
+
+    cg.replica:exec(function()
+        t.assert_equals(box.info.synchro.queue.len, 0)
+        box.cfg{replication = ''}
+    end)
+
+    cg.master:exec(function(f_a_id)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        t.assert(require('fiber').find(f_a_id):join())
+    end, {f_a_id})
+
+    trigger_split_brain(cg)
+    check_for_split_brain(cg)
+end
+
+-- Test that the confirmation boundary bumped by asynchronous transactions is
+-- correctly restored after snapshot recovery.
+g.test_snapshot_recovery = function(cg)
+    setup_trivial_split_brain(cg)
+
+    cg.master:exec(function()
+        box.snapshot()
+    end)
+
+    cg.master:restart()
+    t.helpers.retrying({timeout = 120}, function()
+        cg.master:assert_follows_upstream(cg.replica:get_instance_id())
+    end)
+
+    trigger_split_brain(cg)
+    check_for_split_brain(cg)
+end
+
+-- Test that if a new leader receives an old term synchronous transaction and
+-- nops it, the synchronous transaction does not bump the confirmation boundary
+-- — otherwise it would cause a split-brain on the new leader later on.
+g.nopped_sync_tx_does_not_cause_split_brain = function(cg)
+    cg.replica:update_box_cfg{replication = ''}
+
+    local f_id = cg.master:exec(function()
+        box.cfg{replication_synchro_quorum = 2}
+
+        local f = require('fiber').create(function()
+            box.space.s:replace{0}
+        end)
+        f:set_joinable(true)
+        return f:id()
+    end)
+
+    trigger_split_brain(cg)
+    cg.replica:update_box_cfg{replication = cg.replication}
+    cg.replica_set:wait_for_fullmesh()
+    cg.replica:wait_for_downstream_to(cg.master)
+    cg.master:exec(function(f_id)
+        t.assert_not(require('fiber').find(f_id):join())
+    end, {f_id})
+    cg.master:exec(function()
+        box.ctl.promote()
+    end)
+    cg.master:wait_for_downstream_to(cg.replica)
+    check_there_is_no_split_brain(cg.replica, cg.master)
+end
+
+g.before_test('test_async_long_wal_no_split_brain', function(cg)
+    cg.master:exec(function()
+        box.ctl.demote()
+    end)
+    cg.master:wait_for_downstream_to(cg.replica)
+end)
+
+g.test_async_long_wal_no_split_brain = function(cg)
+    t.tarantool.skip_if_not_debug()
+    t.skip_if(cg.params.is_local)
+
+    cg.replica:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+    end)
+    cg.master:exec(function()
+        box.space.a:replace{0}
+    end)
+    cg.replica:exec(function()
+        t.helpers.retrying({timeout = 5}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+        end)
+    end)
+    cg.master:exec(function()
+        box.ctl.promote()
+    end)
+    cg.replica:exec(function()
+        t.helpers.retrying({timeout = 5}, function()
+            t.assert(box.info.synchro.queue.busy)
+        end)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+    end)
+    cg.master:wait_for_downstream_to(cg.replica)
+    check_there_is_no_split_brain(cg.replica, cg.master)
+end

--- a/test/replication-luatest/gh_7318_box_wait_limbo_acked_test.lua
+++ b/test/replication-luatest/gh_7318_box_wait_limbo_acked_test.lua
@@ -196,10 +196,10 @@ g.test_update_greatest_term_while_wal_sync = function(cg)
     -- The purpose of the test is to cover
     -- 'if (box_check_promote_term_intact(promote_term) != 0)' in
     -- 'box_wait_limbo_acked()' located immediately after 'wal_sync()' call.
-    -- For this we use a special injection - 'ERRINJ_WAL_SYNC_DELAY'.
+    -- For this we use a special injection - 'ERRINJ_WAL_SYNC_DELAY_COUNTDOWN'.
     local term = cg.replica:get_election_term()
     local f = cg.replica:exec(function()
-        box.error.injection.set('ERRINJ_WAL_SYNC_DELAY', true)
+        box.error.injection.set('ERRINJ_WAL_SYNC_DELAY_COUNTDOWN', 1)
         box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
         local f = require('fiber').create(function()
             return pcall(box.ctl.promote)
@@ -245,7 +245,7 @@ g.test_txn_limbo_is_empty_while_wal_sync = function(cg)
     -- The purpose of the test is to cover
     -- 'if (txn_limbo_is_empty(&txn_limbo))' in
     -- 'box_wait_limbo_acked()' located immediately after 'wal_sync()' call.
-    -- For this we use a special injection - 'ERRINJ_WAL_SYNC_DELAY'.
+    -- For this we use a special injection - 'ERRINJ_WAL_SYNC_DELAY_COUNTDOWN'.
 
     -- If the master becomes a leader again, we will cover the condition
     -- from the previous test, and not what we want.
@@ -256,7 +256,7 @@ g.test_txn_limbo_is_empty_while_wal_sync = function(cg)
         }
     end)
     local f = cg.replica:exec(function()
-        box.error.injection.set('ERRINJ_WAL_SYNC_DELAY', true)
+        box.error.injection.set('ERRINJ_WAL_SYNC_DELAY_COUNTDOWN', 1)
         box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
         local f = require('fiber').create(function()
             return pcall(box.ctl.promote)

--- a/test/replication/gh-5167-qsync-rollback-snap.result
+++ b/test/replication/gh-5167-qsync-rollback-snap.result
@@ -133,7 +133,7 @@ test_run:switch('replica')
 -- Because ideally ROLLBACK should not be applied before written to WAL. That
 -- means count() will be > 0 until WAL write succeeds.
 test_run:wait_cond(function()                                                   \
-    return box.error.injection.get("ERRINJ_WAL_WRITE_COUNT") > wal_write_count  \
+    return box.info.synchro.queue.busy                                          \
 end)
  | ---
  | - true

--- a/test/replication/gh-5167-qsync-rollback-snap.test.lua
+++ b/test/replication/gh-5167-qsync-rollback-snap.test.lua
@@ -55,7 +55,7 @@ test_run:switch('replica')
 -- Because ideally ROLLBACK should not be applied before written to WAL. That
 -- means count() will be > 0 until WAL write succeeds.
 test_run:wait_cond(function()                                                   \
-    return box.error.injection.get("ERRINJ_WAL_WRITE_COUNT") > wal_write_count  \
+    return box.info.synchro.queue.busy                                          \
 end)
 -- Now WAL rotation is done. Snapshot will fail, because will see that a
 -- rollback happened during that. Meaning that the rotated WAL contains


### PR DESCRIPTION
This patch set makes asynchronous transactions bump the synchronous queue's confirmed LSN.

Closes #10528
Needed for #10459