### PR TITLE
vinyl: fix `ERRINJ_VY_DELAY_PK_LOOKUP`

### DIFF
--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -3773,7 +3773,6 @@ next:
 		*ret = NULL;
 		goto out;
 	}
-	ERROR_INJECT_YIELD(ERRINJ_VY_DELAY_PK_LOOKUP);
 	/* Get the full tuple from the primary index. */
 	if (vy_get_by_secondary_tuple(lsm, it->tx, vy_tx_read_view(it->tx),
 				      partial, &entry) != 0)

--- a/src/lib/core/errinj.h
+++ b/src/lib/core/errinj.h
@@ -151,7 +151,6 @@ struct errinj {
 	_(ERRINJ_TXN_LIMBO_BEGIN_DELAY, ERRINJ_BOOL, {.bparam = false})\
 	_(ERRINJ_VYRUN_DATA_READ, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_VY_COMPACTION_DELAY, ERRINJ_BOOL, {.bparam = false}) \
-	_(ERRINJ_VY_DELAY_PK_LOOKUP, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_VY_DUMP_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_VY_GC, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_VY_INDEX_DUMP, ERRINJ_INT, {.iparam = -1}) \
@@ -159,7 +158,7 @@ struct errinj {
 	_(ERRINJ_VY_LOG_FILE_RENAME, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_VY_LOG_FLUSH, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_VY_LOG_WRITE_BAD_RECORDS, ERRINJ_BOOL, {.bparam = false}) \
-	_(ERRINJ_VY_POINT_ITER_WAIT, ERRINJ_BOOL, {.bparam = false}) \
+	_(ERRINJ_VY_POINT_LOOKUP_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_VY_QUOTA_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_VY_READ_PAGE, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_VY_READ_PAGE_DELAY, ERRINJ_BOOL, {.bparam = false}) \

--- a/test/fuzz/lua/test_engine.lua
+++ b/test/fuzz/lua/test_engine.lua
@@ -1161,9 +1161,8 @@ local errinj_set = {
         enable = enable_errinj_boolean,
         disable = disable_errinj_boolean,
     },
-    -- Set to true to delay lookup of tuple in primary index by
-    -- secondary key.
-    ERRINJ_VY_DELAY_PK_LOOKUP = {
+    -- Set to true to delay lookup of tuple by full key.
+    ERRINJ_VY_POINT_LOOKUP_DELAY = {
         enable = enable_errinj_boolean,
         disable = disable_errinj_boolean,
     },

--- a/test/vinyl/errinj.result
+++ b/test/vinyl/errinj.result
@@ -698,28 +698,38 @@ test_run:cmd("setopt delimiter ';'")
 ---
 - true
 ...
-function worker()
+f = fiber.new(function()
     for i = 11,20,2 do
         s:upsert({i, i}, {{'=', 3, 1}})
-        errinj.set("ERRINJ_VY_POINT_ITER_WAIT", true)
+        errinj.set("ERRINJ_VY_POINT_LOOKUP_DELAY", true)
         i1:select{i}
         s:upsert({i + 1 ,i + 1}, {{'=', 3, 1}})
-        errinj.set("ERRINJ_VY_POINT_ITER_WAIT", true)
+        errinj.set("ERRINJ_VY_POINT_LOOKUP_DELAY", true)
         i2:select{i + 1}
     end
-end
+end);
+---
+...
+f:set_joinable(true);
+---
+...
+ok, err = nil;
+---
+...
+repeat
+    box.snapshot()
+    errinj.set("ERRINJ_VY_POINT_LOOKUP_DELAY", false)
+    ok, err = f:join(0.01)
+until ok;
+---
+...
 test_run:cmd("setopt delimiter ''");
 ---
+- true
 ...
-f = fiber.create(worker)
+err -- nil
 ---
-...
-while f:status() ~= 'dead' do box.snapshot() fiber.sleep(0.01) end
----
-...
-errinj.set("ERRINJ_VY_POINT_ITER_WAIT", false)
----
-- ok
+- null
 ...
 s:drop()
 ---
@@ -804,13 +814,13 @@ s:drop()
 -- after the secondary index scan, but before a primary index
 -- lookup. It is ok, and the test checks this.
 --
-s = box.schema.create_space('test', {engine = 'vinyl'})
+s = box.schema.create_space('test', {engine = 'vinyl', defer_deletes = true})
 ---
 ...
 pk = s:create_index('pk')
 ---
 ...
-sk = s:create_index('sk', {parts = {{2, 'unsigned'}}})
+sk = s:create_index('sk', {unique = false, parts = {{2, 'unsigned'}}})
 ---
 ...
 s:replace{1, 1}
@@ -831,7 +841,7 @@ ret = nil
 function do_read() ret = sk:select({2}, {iterator = 'GE'}) end
 ---
 ...
-errinj.set("ERRINJ_VY_DELAY_PK_LOOKUP", true)
+errinj.set("ERRINJ_VY_POINT_LOOKUP_DELAY", true)
 ---
 - ok
 ...
@@ -854,7 +864,7 @@ s:replace{2, 2}
 ---
 - [2, 2]
 ...
-errinj.set("ERRINJ_VY_DELAY_PK_LOOKUP", false)
+errinj.set("ERRINJ_VY_POINT_LOOKUP_DELAY", false)
 ---
 - ok
 ...


### PR DESCRIPTION
Enabling `ERRINJ_VY_DELAY_PK_LOOKUP` makes Vinyl yield in a place where it wouldn't normally do. If the transaction is aborted in the meantime, we'll get the assertion failure:

```
./src/box/vy_point_lookup.c:219: vy_point_lookup: Assertion 'tx == NULL || tx->state == VINYL_TX_READY' failed.
```

To prevent this from happening, let's replace this invalid error injection with the new one `ERRINJ_VY_POINT_LOOKUP_DELAY` that injects a delay to `vy_point_lookup()` before reading disk. This doesn't have exactly the same effect as the old error injection because it also delays direct lookups in the primary index. Fortunately, the old error injection is used in the only test, where the new one works as expected if we make the secondary index created in the test non-unique and enable deferred writes (this makes the `s:replace{2, 2}` statement bypass a lookup in the primary index).

Also, let's replace `VY_POINT_ITER_WAIT` with the new error injection because they have very a similar meaning and `VY_POINT_LOOKUP_DELAY` works in the test using it with a very small adjustment (we need to clear it explicitly after `box.snapshot()`).

Closes #10517