### PR TITLE
vinyl: use VERBOSE level for logging ranges

### DIFF
--- a/changelogs/unreleased/gh-10524-use-verbose-level-for-logging-vinyl-ranges.md
+++ b/changelogs/unreleased/gh-10524-use-verbose-level-for-logging-vinyl-ranges.md
@@ -1,0 +1,4 @@
+## bugfix/vinyl
+
+* Lowered the level used for logging range dump, compaction, split, and
+  coalesce events from `INFO` to `VERBOSE` (gh-10524).

--- a/src/box/vy_lsm.c
+++ b/src/box/vy_lsm.c
@@ -1154,8 +1154,8 @@ vy_lsm_split_range(struct vy_lsm *lsm, struct vy_range *range)
 	}
 	lsm->range_tree_version++;
 
-	say_info("%s: split range %s by key %s", vy_lsm_name(lsm),
-		 vy_range_str(range), tuple_str(split_key.stmt));
+	say_verbose("%s: split range %s by key %s", vy_lsm_name(lsm),
+		    vy_range_str(range), tuple_str(split_key.stmt));
 
 	rlist_foreach_entry(slice, &range->slices, in_range)
 		vy_slice_wait_pinned(slice);
@@ -1242,8 +1242,8 @@ vy_lsm_coalesce_range(struct vy_lsm *lsm, struct vy_range *range)
 	vy_lsm_add_range(lsm, result);
 	lsm->range_tree_version++;
 
-	say_info("%s: coalesced ranges %s",
-		 vy_lsm_name(lsm), vy_range_str(result));
+	say_verbose("%s: coalesced ranges %s",
+		    vy_lsm_name(lsm), vy_range_str(result));
 	return true;
 
 fail_commit:

--- a/src/box/vy_scheduler.c
+++ b/src/box/vy_scheduler.c
@@ -1321,7 +1321,7 @@ delete_mems:
 	assert(scheduler->dump_task_count > 0);
 	scheduler->dump_task_count--;
 
-	say_info("%s: dump completed", vy_lsm_name(lsm));
+	say_verbose("%s: dump completed", vy_lsm_name(lsm));
 
 	vy_scheduler_complete_dump(scheduler);
 	return 0;
@@ -1484,7 +1484,7 @@ vy_task_dump_new(struct vy_scheduler *scheduler, struct vy_worker *worker,
 
 	scheduler->dump_task_count++;
 
-	say_info("%s: dump started", vy_lsm_name(lsm));
+	say_verbose("%s: dump started", vy_lsm_name(lsm));
 	*p_task = task;
 	return 0;
 
@@ -1669,8 +1669,8 @@ out:
 	vy_range_heap_insert(&lsm->range_heap, range);
 	vy_scheduler_update_lsm(scheduler, lsm);
 
-	say_info("%s: completed compacting range %s",
-		 vy_lsm_name(lsm), vy_range_str(range));
+	say_verbose("%s: completed compacting range %s",
+		    vy_lsm_name(lsm), vy_range_str(range));
 	return 0;
 }
 
@@ -1790,9 +1790,9 @@ vy_task_compaction_new(struct vy_scheduler *scheduler, struct vy_worker *worker,
 	vy_range_heap_delete(&lsm->range_heap, range);
 	vy_scheduler_update_lsm(scheduler, lsm);
 
-	say_info("%s: started compacting range %s, runs %d/%d",
-		 vy_lsm_name(lsm), vy_range_str(range),
-                 range->compaction_priority, range->slice_count);
+	say_verbose("%s: started compacting range %s, runs %d/%d",
+		    vy_lsm_name(lsm), vy_range_str(range),
+		    range->compaction_priority, range->slice_count);
 	*p_task = task;
 	return 0;
 

--- a/test/vinyl-luatest/shutdown_test.lua
+++ b/test/vinyl-luatest/shutdown_test.lua
@@ -5,7 +5,9 @@ local t = require('luatest')
 local g = t.group()
 
 g.before_each(function(cg)
-    cg.server = server:new()
+    cg.server = server:new({
+        box_cfg = {log_level = 'verbose'},
+    })
     cg.server:start()
 end)
 
@@ -91,6 +93,7 @@ local g_cbus = t.group('cbus')
 
 g_cbus.before_each(function(cg)
     cg.server = server:new({
+        box_cfg = {log_level = 'verbose'},
         env = {
             TARANTOOL_RUN_BEFORE_BOX_CFG = [[
                 local tweaks = require('internal.tweaks')


### PR DESCRIPTION
Whenever a range is compacted, split, or coalesced, we log the range boundaries. This gets really annoying if there's an index that has a lot of key parts or contains binary strings. Let's lower the level used for logging these events down to VERBOSE so that they are not shown by default but can be enabled if needed.

Closes #10524