### PR TITLE
test: specify the dir in the cluster helper

### DIFF
--- a/test/config-luatest/cluster.lua
+++ b/test/config-luatest/cluster.lua
@@ -204,13 +204,13 @@ local cluster_mt = {
     end
 }
 
-local function new(g, config, server_opts)
+local function new(g, config, server_opts, opts)
     assert(config._config == nil, "Please provide cbuilder:new():config()")
     assert(g.cluster == nil)
 
     -- Prepare a temporary directory and write a configuration
     -- file.
-    local dir = treegen.prepare_directory({}, {})
+    local dir = opts and opts.dir or treegen.prepare_directory({}, {})
     local config_file_rel = 'config.yaml'
     local config_file = treegen.write_file(dir, config_file_rel,
                                            yaml.encode(config))


### PR DESCRIPTION
The cluster helper in `test/config-luatest/cluster.lua` is used to define the clusters in an easy way. Though every time the `cluster.new` is called it creates a new temporary directory, which is not good when you're writing a test setting up the directory before the cluster start.

This patch adds an `opts` object as the fourth parameter for `cluster.new` and makes the function use `opts.dir` as a key for specifying the directory to start the cluster.

Example:
```lua
    local dir = '/some/long/dir'
    local cluster_config = cbuilder:new(remote_config)
        :use_replicaset('r-001')
        :add_instance('i-001', {})
        :config()

    -- The cluster will be started in a new temp directory.
    local cluster = cluster.new(g, cluster_config)

    -- The cluster will be started in '/some/long/dir'.
    local cluster = cluster.new(g, cluster_config, nil, { dir = dir })
```

Needed for testing tarantool/tarantool-ee#870.