### PR TITLE
test: fix flaky #10148 test

### DIFF
--- a/test/box-luatest/gh_10148_fix_crash_low_slab_alloc_factor_test.lua
+++ b/test/box-luatest/gh_10148_fix_crash_low_slab_alloc_factor_test.lua
@@ -28,6 +28,8 @@ end)
 
 g.test_low_slab_alloc_factor = function(cg)
     cg.server:exec(function()
+        local fiber = require('fiber')
+        fiber.set_max_slice(30)
         local test = box.schema.create_space('test')
         test:create_index('pri')
         for i=1,1000000 do


### PR DESCRIPTION
The test may exceed the default fiber slice (1 second):

```
[060] server | 2024-09-09 09:16:16.329 [33093] main/111/main fiber.h:1132 W> fiber has not yielded for more than 0.500 seconds
[060] server | 2024-09-09 09:16:16.825 [33093] main/111/main/test-run.lib.luatest.luatest.log I> Assert "FiberSliceIsExceeded" equals to "OutOfMemory"
[060] not ok 1	box-luatest.gh_10148_fix_crash_low_slab_alloc_factor.test_low_slab_alloc_factor
[060] #   ...uatest/gh_10148_fix_crash_low_slab_alloc_factor_test.lua:36: expected: "OutOfMemory"
[060] #   actual: "FiberSliceIsExceeded"
[060] #   stack traceback:
[060] #   	...uatest/gh_10148_fix_crash_low_slab_alloc_factor_test.lua:30: in function 'box-luatest.gh_10148_fix_crash_low_slab_alloc_factor.test_low_slab_alloc_factor'
[060] #   	...
[060] #   	[C]: in function 'xpcall'
[060] #   artifacts:
[060] #   	server -> /tmp/t/060_box-luatest/artifacts/server-RulP4Fj6qEoI
[060] luatest | 2024-09-09 09:16:16.839 [32904] main/104/luatest/test-run.lib.luatest.luatest.log I> End test "box-luatest.gh_10148_fix_crash_low_slab_alloc_factor.test_low_slab_alloc_factor"
[060] server | 2024-09-09 09:16:16.849 [33093] main/116/iproto.shutdown I> tx_binary: stopped
[060] # Ran 1 tests in 2.388 seconds, 0 succeeded, 1 failed
```

[Link to CI failure](https://github.com/tarantool/tarantool/actions/runs/10769092675/job/29859568025?pr=10534).

Let's set the fiber slice to a sufficiently big value.

Fixes commit e4ce9e111483 ("test: add test for #10148").