### PR TITLE
test/fuzz: fix socket path in an engine test

### DIFF
--- a/test/fuzz/lua/test_engine.lua
+++ b/test/fuzz/lua/test_engine.lua
@@ -1391,7 +1391,7 @@ end
 local function run_test(num_workers, test_duration, test_dir,
                         engine_name, verbose_mode)
 
-    local socket_path = ('unix/:/%s/console.sock'):format(fio.abspath(test_dir))
+    local socket_path = fio.pathjoin(fio.abspath(test_dir), 'console.sock')
     console.listen(socket_path)
     log.info(('console listen on %s'):format(socket_path))
 


### PR DESCRIPTION
The function `console.listen` does not accept a path with duplicate slashes, so absolute pathes were rejected. The patch fixes that by building a path to Unix socket using `fio.pathjoin` that avoid double slashes. Follows up the commit 5d18b84e1e76 ("test: enable remote console for debug").

NO_CHANGELOG=testing
NO_DOC=testing
NO_TEST=testing