### PR TITLE
test/fuzz: disable error injections on teardown

### DIFF
--- a/test/fuzz/lua/test_engine.lua
+++ b/test/fuzz/lua/test_engine.lua
@@ -1024,6 +1024,21 @@ local function worker_func(id, space, test_gen, test_duration)
     return errors
 end
 
+-- Disabled all enabled error injections.
+local function disable_all_errinj(errinj, space)
+    local enabled_errinj = fun.iter(errinj):
+                           filter(function(i, x)
+                               if x.is_enabled then
+                                   return i
+                               end
+                           end):totable()
+    for _, errinj_name in pairs(enabled_errinj) do
+        local errinj_val = errinj[errinj_name].disable(space)
+        errinj[errinj_name].is_enabled = false
+        pcall(box.error.injection.set, errinj_name, errinj_val)
+    end
+end
+
 local function toggle_random_errinj(errinj, max_enabled, space)
     local enabled_errinj = fun.iter(errinj):
                            filter(function(i, x)
@@ -1444,6 +1459,7 @@ local function run_test(num_workers, test_duration, test_dir,
             end
         end
     end
+    disable_all_errinj(errinj_set, space)
 
     teardown(space)
 


### PR DESCRIPTION
`test_engine.lua` actively uses error injections. Sometimes error injections remain enabled and triggered on test teardown. This leads to false positive test fails like below:

NOWRAP
```
2024-09-10 12:38:42.317 [1305] main/3502/WRK #3387/..test.fuzz.lua.test_engine I> Worker #3387 has finished.
2024-09-10 12:38:47.167 [1305] main/104/test_engine.lua/..test.fuzz.lua.test_engine I> TEARDOWN
2024-09-10 12:38:47.171 [1305] main/104/test_engine.lua wal.c:1327 E> ER_WAL_IO: Failed to write to disk
2024-09-10 12:38:47.174 [1305] main test_engine.lua:564 E> ER_WAL_IO: Failed to write to disk
2024-09-10 12:38:47.174 [1305] main F> fatal error, exiting the event loop
```
NOWRAP

The patch disables error injection at the beginning of teardown.

NO_CHANGELOG=testing
NO_DOC=testing