### PR TITLE
box: fix crash on rollback on memtx memory OOM and massive index change

### DIFF
--- a/changelogs/unreleased/gh-10551-fix-index-crash-on-OOM-on-rollback.md
+++ b/changelogs/unreleased/gh-10551-fix-index-crash-on-OOM-on-rollback.md
@@ -1,0 +1,4 @@
+## bugfix/memtx
+
+- Fixed a crash on transaction rollback if memory usage is close to the limit
+  (gh-10551).

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -223,11 +223,12 @@ memtx_engine_free(struct engine *engine)
 	void *p = memtx->reserved_extents;
 	while (p != NULL) {
 		void *next = *(void **)p;
-		mempool_free(&memtx->index_extent_pool, p);
+		memtx_index_extent_free(memtx, p);
 		p = next;
 	}
 	mempool_destroy(&memtx->index_extent_pool);
 	slab_cache_destroy(&memtx->index_slab_cache);
+	mh_ptr_delete(memtx->malloc_extents);
 	/*
 	 * The last blessed tuple may refer to a memtx tuple, which would
 	 * become inaccessible once we destroyed the arena, so we need to
@@ -1772,6 +1773,7 @@ memtx_engine_new(const char *snap_dirname, bool force_recovery,
 		       MEMTX_ITERATOR_SIZE);
 	memtx->num_reserved_extents = 0;
 	memtx->reserved_extents = NULL;
+	memtx->malloc_extents = mh_ptr_new();
 
 	memtx->state = MEMTX_INITIALIZED;
 	memtx->max_tuple_size = MAX_TUPLE_SIZE;
@@ -2123,12 +2125,7 @@ memtx_index_extent_alloc(void *ctx)
 		memtx->reserved_extents = *(void **)memtx->reserved_extents;
 		return result;
 	}
-	ERROR_INJECT(ERRINJ_INDEX_ALLOC, {
-		/* same error as in mempool_alloc */
-		diag_set(OutOfMemory, MEMTX_EXTENT_SIZE,
-			 "mempool", "new slab");
-		return NULL;
-	});
+	ERROR_INJECT(ERRINJ_INDEX_ALLOC, { goto fail; });
 	void *ret;
 	while ((ret = mempool_alloc(&memtx->index_extent_pool)) == NULL) {
 		bool stop;
@@ -2137,9 +2134,23 @@ memtx_index_extent_alloc(void *ctx)
 			break;
 	}
 	if (ret == NULL)
-		diag_set(OutOfMemory, MEMTX_EXTENT_SIZE,
-			 "mempool", "new slab");
+		goto fail;
 	return ret;
+fail:
+	if (in_txn() != NULL && in_txn()->status == TXN_ABORTED) {
+		/*
+		 * We cannot sanely reserve blocks for rollback because strictly
+		 * speaking the whole index can change. We cannot tolerate
+		 * allocation failure also. So just allocate outside of the
+		 * memtx arena quota.
+		 */
+		ret = xmalloc(MEMTX_EXTENT_SIZE);
+		mh_ptr_put(memtx->malloc_extents, (const void **)&ret,
+			   NULL, NULL);
+		return ret;
+	}
+	diag_set(OutOfMemory, MEMTX_EXTENT_SIZE, "mempool", "new slab");
+	return NULL;
 }
 
 /**
@@ -2149,7 +2160,13 @@ void
 memtx_index_extent_free(void *ctx, void *extent)
 {
 	struct memtx_engine *memtx = (struct memtx_engine *)ctx;
-	return mempool_free(&memtx->index_extent_pool, extent);
+	mh_int_t p = mh_ptr_find(memtx->malloc_extents, extent, NULL);
+	if (p != mh_end(memtx->malloc_extents)) {
+		mh_ptr_del(memtx->malloc_extents, p, NULL);
+		free(extent);
+		return;
+	}
+	mempool_free(&memtx->index_extent_pool, extent);
 }
 
 /**

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -186,6 +186,8 @@ struct memtx_engine {
 	 * start.
 	 */
 	int sort_threads;
+	/** Set of extents allocated using malloc. */
+	struct mh_ptr_t *malloc_extents;
 };
 
 struct memtx_gc_task;

--- a/src/lib/core/assoc.h
+++ b/src/lib/core/assoc.h
@@ -52,6 +52,26 @@ extern "C" {
 #define mh_cmp_key(a, b, arg) ((a) != *(b))
 #include "salad/mhash.h"
 
+static inline uint32_t
+mh_ptr_hash(const void *ptr)
+{
+	uintptr_t u = (uintptr_t)ptr;
+	return u ^ (u >> 32);
+}
+
+/**
+ * Set: (void *)
+ */
+#define mh_name _ptr
+#define mh_key_t void *
+#define mh_node_t void *
+#define mh_arg_t void *
+#define mh_hash(a, arg) (mh_ptr_hash(*(a)))
+#define mh_hash_key(a, arg) (mh_ptr_hash(a))
+#define mh_cmp(a, b, arg) (*(a) != *(b))
+#define mh_cmp_key(a, b, arg) ((a) != *(b))
+#include "salad/mhash.h"
+
 /*
  * Map: (i32) => (void *)
  */

--- a/test/box-luatest/gh_10551_massive_index_change_on_rollback_test.lua
+++ b/test/box-luatest/gh_10551_massive_index_change_on_rollback_test.lua
@@ -1,0 +1,80 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.before_test('test_massive_index_change_on_rollback', function(cg)
+    cg.server:exec(function()
+        for i = 1,10 do
+            local s = box.schema.create_space('test' .. i)
+            s:create_index('pk')
+            s:insert({1})
+        end
+    end)
+end)
+
+g.after_test('test_massive_index_change_on_rollback', function(cg)
+    cg.server:exec(function()
+        for i = 1,10 do
+            local s = box.space['test' .. i]
+            if s ~= nil then
+                s:drop()
+            end
+        end
+    end)
+end)
+
+g.test_massive_index_change_on_rollback = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        local errinj = box.error.injection
+        local fibers = {}
+        errinj.set('ERRINJ_WAL_DELAY', true)
+        for i = 1,10 do
+            local f = fiber.new(function()
+                local s = box.space['test' .. i]
+                s:insert({2})
+            end)
+            fibers[i] = f
+            f:set_joinable(true)
+            f:wakeup()
+            fiber.yield()
+        end
+        fiber.create(function()
+            box.snapshot()
+        end)
+        errinj.set('ERRINJ_INDEX_ALLOC', true)
+        errinj.set('ERRINJ_WAL_WRITE_DISK', true)
+        errinj.set('ERRINJ_WAL_DELAY', false)
+        -- Test rollback is correct.
+        for i = 1,10 do
+            fibers[i]:join()
+            local s = box.space['test' .. i]
+            t.assert_equals(s:count(), 1)
+        end
+        errinj.set('ERRINJ_INDEX_ALLOC', false)
+        errinj.set('ERRINJ_WAL_WRITE_DISK', false)
+        -- Now index memory is allocated using malloc. Do insertions
+        -- to allocate index blocks as usual and thus mix malloc and default
+        -- blocks. Check index works in this case.
+        for i = 1,10 do
+            local s = box.space['test' .. i]
+            for j = 2, 1000 do
+                s:insert({j})
+            end
+            for j = 1, 1000 do
+                s:delete({j})
+            end
+        end
+    end)
+end


### PR DESCRIPTION
We cannot tolerate index extent memory allocation failure on rollback. At the same time it is not practical to reserve memory because a whole index can easily be changed on rollback if read view is created before rollback.

So in case of rollback and memtx memory OOM let's allocate outside the memtx arena limited by quota.

Now part of the index can reside outside memtx arena. But regularly the index changes will move this part back to the memtx arena. Until next such situation of course.

Closes #10551