### PR TITLE
memtx: reference tuples when rolling back statements without story

### DIFF
--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -2338,6 +2338,11 @@ memtx_tx_history_rollback_empty_stmt(struct txn_stmt *stmt)
 			      "rollback of statement without story");
 		}
 	}
+	/* We have no stories here so reference bare tuples instead. */
+	if (new_tuple != NULL)
+		tuple_unref(new_tuple);
+	if (old_tuple != NULL)
+		tuple_ref(old_tuple);
 }
 
 void


### PR DESCRIPTION
During the latest rework of DDL in MVCC, the new helper `memtx_tx_history_rollback_empty_stmt` was introduced - it is used for statements without stories (such statements can appear, for example, when DDL removes all stories). By mistake, we forgot to unreference the new tuple and reference the old one there - the commit fixes this embarassing mistake.

Follow-up #10146
