### PR TITLE
[backport 3.2] doc: fix tt start command in --help

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -620,7 +620,7 @@ print_help(FILE *stream)
 		"\n"
 		"Run a Tarantool instance:\n"
 		"\n"
-		"$ tt start --name <instance name>\n"
+		"$ tt start <app name>:<instance name>\n"
 		"\n"
 		"Connect to an instance:\n"
 		"\n"

--- a/test/box-py/args.result
+++ b/test/box-py/args.result
@@ -8,7 +8,7 @@ tool.
 
 Run a Tarantool instance:
 
-$ tt start --name <instance name>
+$ tt start <app name>:<instance name>
 
 Connect to an instance:
 
@@ -125,7 +125,7 @@ tool.
 
 Run a Tarantool instance:
 
-$ tt start --name <instance name>
+$ tt start <app name>:<instance name>
 
 Connect to an instance:
 


### PR DESCRIPTION
*(This is a backport of PR #10568 to `release/3.2`, a future `3.2.1` release.)*

----

Changes `tt start --name <instance name>` to `tt start <app name>:<instance name>`.

Fixes #10563