### PR TITLE
[backport 2.11] memtx: re-design handling of DDL in memtx MVCC

### DIFF
--- a/changelogs/unreleased/gh-10146-mvcc-ddl-crashes-and-isolation-violation.md
+++ b/changelogs/unreleased/gh-10146-mvcc-ddl-crashes-and-isolation-violation.md
@@ -1,0 +1,4 @@
+## bugfix/memtx
+
+* Fixed several bugs when DDL with MVCC enabled could lead to a crash
+  or violate isolation of other transactions (gh-10146).

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -790,13 +790,13 @@ void
 index_delete(struct index *index)
 {
 	assert(index->refs == 0);
+	assert(rlist_empty(&index->read_gaps));
 	/*
 	 * Free index_def after destroying the index as
 	 * engine might still need it, e.g. to check if
 	 * the index is primary or secondary.
 	 */
 	struct index_def *def = index->def;
-	memtx_tx_on_index_delete(index);
 	index->vtab->destroy(index);
 	index_def_delete(def);
 }

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -1252,6 +1252,10 @@ memtx_space_build_index(struct space *src_space, struct index *new_index,
 	 */
 	bool can_yield = pk->def->type != HASH;
 
+	inj = errinj(ERRINJ_BUILD_INDEX_DISABLE_YIELD, ERRINJ_BOOL);
+	if (inj != NULL && inj->bparam == true)
+		can_yield = false;
+
 	struct memtx_engine *memtx = (struct memtx_engine *)src_space->engine;
 	struct memtx_ddl_state state;
 	struct trigger on_replace;

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -1397,6 +1397,23 @@ memtx_space_finish_alter(struct space *old_space, struct space *new_space)
 		new_memtx_space->bsize = old_memtx_space->bsize;
 }
 
+/**
+ * Invalidate the space in transaction manager.
+ */
+static void
+memtx_space_invalidate(struct space *space)
+{
+	/*
+	 * Abort all concurrent transactions and invalidate space in MVCC
+	 * only if it is enabled. Otherwise, all concurrent transactions
+	 * will be aborted when DDL will be prepared.
+	 */
+	if (memtx_tx_manager_use_mvcc_engine) {
+		memtx_tx_abort_all_for_ddl(in_txn());
+		memtx_tx_invalidate_space(space, in_txn());
+	}
+}
+
 /* }}} DDL */
 
 static const struct space_vtab memtx_space_vtab = {
@@ -1421,7 +1438,7 @@ static const struct space_vtab memtx_space_vtab = {
 	/* .prepare_alter = */ memtx_space_prepare_alter,
 	/* .finish_alter = */ memtx_space_finish_alter,
 	/* .prepare_upgrade = */ memtx_space_prepare_upgrade,
-	/* .invalidate = */ generic_space_invalidate,
+	/* .invalidate = */ memtx_space_invalidate,
 };
 
 struct space *

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -956,6 +956,7 @@ memtx_tx_story_delete(struct memtx_story *story)
 {
 	assert(story->add_stmt == NULL);
 	assert(story->del_stmt == NULL);
+	assert(rlist_empty(&story->reader_list));
 	for (uint32_t i = 0; i < story->index_count; i++) {
 		assert(story->link[i].newer_story == NULL);
 		assert(story->link[i].older_story == NULL);
@@ -2990,6 +2991,18 @@ memtx_tx_on_space_delete(struct space *space)
 							  in_read_gaps);
 				memtx_tx_delete_gap(item);
 			}
+		}
+		/*
+		 * Remove all read trackers since they point to the story that
+		 * is going to be deleted.
+		 */
+		while (!rlist_empty(&story->reader_list)) {
+			struct tx_read_tracker *tracker =
+				rlist_first_entry(&story->reader_list,
+						  struct tx_read_tracker,
+						  in_reader_list);
+			rlist_del(&tracker->in_reader_list);
+			rlist_del(&tracker->in_read_set);
 		}
 		memtx_tx_story_delete(story);
 	}

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -2761,19 +2761,6 @@ memtx_tx_delete_gap(struct gap_item_base *item)
 }
 
 void
-memtx_tx_on_index_delete(struct index *index)
-{
-	while (!rlist_empty(&index->read_gaps)) {
-		struct gap_item_base *item =
-			rlist_first_entry(&index->read_gaps,
-					  struct gap_item_base,
-					  in_read_gaps);
-		memtx_tx_delete_gap(item);
-	}
-	memtx_tx_story_gc();
-}
-
-void
 memtx_tx_invalidate_space(struct space *space, struct txn *active_txn)
 {
 	struct memtx_story *story;
@@ -2881,6 +2868,21 @@ memtx_tx_invalidate_space(struct space *space, struct txn *active_txn)
 		stailq_foreach_entry(stmt, &txn->stmts, next) {
 			if (stmt->space == space)
 				stmt->engine_savepoint = NULL;
+		}
+	}
+
+	/*
+	 * Phase four: remove all read trackers from the space indexes. Since
+	 * all concurrent transactions are aborted, we don't need them anymore.
+	 */
+	for (size_t i = 0; i < space->index_count; i++) {
+		struct index *index = space->index[i];
+		while (!rlist_empty(&index->read_gaps)) {
+			struct gap_item_base *item =
+				rlist_first_entry(&index->read_gaps,
+						  struct gap_item_base,
+						  in_read_gaps);
+			memtx_tx_delete_gap(item);
 		}
 	}
 }

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -682,6 +682,12 @@ memtx_tx_acquire_ddl(struct txn *tx)
 	(void) txn_can_yield(tx, false);
 }
 
+/**
+ * Clean and clear all read lists of @a txn.
+ */
+static void
+memtx_tx_clear_txn_read_lists(struct txn *txn);
+
 void
 memtx_tx_abort_all_for_ddl(struct txn *ddl_owner)
 {
@@ -696,7 +702,8 @@ memtx_tx_abort_all_for_ddl(struct txn *ddl_owner)
 			continue;
 		to_be_aborted->status = TXN_ABORTED;
 		txn_set_flags(to_be_aborted, TXN_IS_CONFLICTED);
-		say_warn("Transaction committing DDL (id=%lld) has aborted "
+		memtx_tx_clear_txn_read_lists(to_be_aborted);
+		say_warn("Transaction processing DDL (id=%lld) has aborted "
 			 "another TX (id=%lld)", (long long) ddl_owner->id,
 			 (long long) to_be_aborted->id);
 	}
@@ -1199,51 +1206,8 @@ static void
 memtx_tx_story_unlink_top_on_space_delete(struct memtx_story *story,
 					  uint32_t idx)
 {
-	assert(story != NULL);
-	assert(idx < story->index_count);
 	struct memtx_story_link *link = &story->link[idx];
-
-	assert(link->newer_story == NULL);
-	/*
-	 * Note that link[idx].in_index may not be the same as
-	 * story->space->index[idx] in case space is going to be deleted
-	 * in memtx_tx_on_space_delete(): during space alter operation we
-	 * swap all indexes to the new space object and instead use dummy
-	 * structs.
-	 */
-	struct index *index = story->link[idx].in_index;
-
 	struct memtx_story *old_story = link->older_story;
-	assert(old_story == NULL || old_story->link[idx].in_index == NULL);
-	struct tuple *old_tuple = old_story == NULL ? NULL : old_story->tuple;
-	struct tuple *removed, *unused;
-	if (index_replace(index, story->tuple, old_tuple,
-			  DUP_INSERT, &removed, &unused) != 0) {
-		diag_log();
-		unreachable();
-		panic("failed to rebind story in index");
-	}
-	assert(story->tuple == removed ||
-	       (removed == NULL && tuple_key_is_excluded(story->tuple,
-							 index->def->key_def,
-							 MULTIKEY_NONE)));
-	story->link[idx].in_index = NULL;
-	if (old_story != NULL)
-		old_story->link[idx].in_index = index;
-
-	/*
-	 * A space holds references to all his tuples.
-	 * All tuples that are physically in the primary index are referenced.
-	 * Thus we have to reference the tuple that was added to the primary
-	 * index and dereference the tuple that was removed from it.
-	 */
-	if (idx == 0) {
-		if (old_story != NULL)
-			memtx_tx_ref_to_primary(old_story);
-		memtx_tx_unref_from_primary(story);
-	}
-
-	/* Now simply unlink the story. */
 	if (old_story != NULL)
 		memtx_tx_story_unlink(story, old_story, idx);
 }
@@ -1279,7 +1243,6 @@ memtx_tx_story_unlink_both_on_space_delete(struct memtx_story *story,
 	assert(idx < story->index_count);
 	struct memtx_story_link *link = &story->link[idx];
 	if (link->newer_story == NULL) {
-		assert(link->in_index != NULL);
 		memtx_tx_story_unlink_top_on_space_delete(story, idx);
 	} else {
 		memtx_tx_story_unlink_both_common(story, idx);
@@ -1329,11 +1292,7 @@ memtx_tx_story_reorder(struct memtx_story *story,
 }
 
 /**
- * Unlink @a story from all chains and remove corresponding tuple from
- * indexes if necessary: used in `memtx_tx_on_space_delete` — intentionally
- * violates the top of the history chain invariant (see
- * `memtx_tx_story_full_unlink_story_gc_step`), since all stories are deleted
- * anyways.
+ * Unlink @a story from all chains, must be already removed from the index.
  */
 static void
 memtx_tx_story_full_unlink_on_space_delete(struct memtx_story *story)
@@ -1341,38 +1300,7 @@ memtx_tx_story_full_unlink_on_space_delete(struct memtx_story *story)
 	for (uint32_t i = 0; i < story->index_count; i++) {
 		struct memtx_story_link *link = &story->link[i];
 		if (link->newer_story == NULL) {
-			/*
-			 * We are at the top of the chain. That means
-			 * that story->tuple might be in index. If the story
-			 * actually deletes the tuple and is present in index,
-			 * it must be deleted from index.
-			 */
-			if (story->del_psn > 0 && link->in_index != NULL) {
-				struct index *index = link->in_index;
-				struct tuple *removed, *unused;
-				if (index_replace(index, story->tuple, NULL,
-						  DUP_INSERT,
-						  &removed, &unused) != 0) {
-					diag_log();
-					unreachable();
-					panic("failed to rollback change");
-				}
-				struct key_def *key_def = index->def->key_def;
-				assert(story->tuple == removed ||
-				       (removed == NULL &&
-					tuple_key_is_excluded(story->tuple,
-							      key_def,
-							      MULTIKEY_NONE)));
-				(void)key_def;
-				link->in_index = NULL;
-				/*
-				 * All tuples in pk are referenced.
-				 * Once removed it must be unreferenced.
-				 */
-				if (i == 0)
-					memtx_tx_unref_from_primary(story);
-			}
-
+			assert(link->in_index == NULL);
 			memtx_tx_story_unlink(story, link->older_story, i);
 		} else {
 			/* Just unlink from list */
@@ -2338,6 +2266,43 @@ memtx_tx_history_rollback_deleted_story(struct txn_stmt *stmt)
 	memtx_tx_story_unlink_deleted_by(del_story, stmt);
 }
 
+/**
+ * The helper rolls back a statements that is empty - has no stories
+ * linked. It can happen due to several reasons:
+ * 1. MVCC hasn't created stories for the stmt. It happens when space is
+ *    ephemeral or when the statement has deleted nothing. In this case
+ *    helper does nothing.
+ * 2. MVCC created stories for the statement, but they were deleted due to
+ *    DDL - here are 3 types of such transactions. First one is concurrent
+ *    with DDL. We shouldn't roll them back because we have already handled
+ *    them on DDL. Second one is DDL itself (`is_schema_changed` flag is set)
+ *    since stories of all the DML operations that happened before DDL were
+ *    deleted. We must roll its statements back because now the space contain
+ *    all its tuples. Third type is transactions prepared before DDL. We've
+ *    also removed their stories on DDL, so here we should roll them back
+ *    without stories if they have failed to commit.
+ */
+void
+memtx_tx_history_rollback_empty_stmt(struct txn_stmt *stmt)
+{
+	struct tuple *old_tuple = stmt->rollback_info.old_tuple;
+	struct tuple *new_tuple = stmt->rollback_info.new_tuple;
+	if (!stmt->txn->is_schema_changed && stmt->txn->psn == 0)
+		return;
+	if (stmt->space->def->opts.is_ephemeral ||
+	    (old_tuple == NULL && new_tuple == NULL))
+		return;
+	for (size_t i = 0; i < stmt->space->index_count; i++) {
+		struct tuple *unused;
+		if (index_replace(stmt->space->index[i], new_tuple, old_tuple,
+				  DUP_REPLACE_OR_INSERT, &unused,
+				  &unused) != 0) {
+			panic("failed to rebind story in index on "
+			      "rollback of statement without story");
+		}
+	}
+}
+
 void
 memtx_tx_history_rollback_stmt(struct txn_stmt *stmt)
 {
@@ -2362,6 +2327,8 @@ memtx_tx_history_rollback_stmt(struct txn_stmt *stmt)
 		memtx_tx_history_rollback_added_story(stmt);
 	else if (stmt->del_story != NULL)
 		memtx_tx_history_rollback_deleted_story(stmt);
+	else
+		memtx_tx_history_rollback_empty_stmt(stmt);
 	assert(stmt->add_story == NULL && stmt->del_story == NULL);
 }
 
@@ -2399,7 +2366,8 @@ memtx_tx_history_remove_stmt(struct txn_stmt *stmt)
 		memtx_tx_history_remove_added_story(stmt);
 	if (stmt->del_story != NULL)
 		memtx_tx_history_remove_deleted_story(stmt);
-	stmt->engine_savepoint = NULL;
+	if (stmt->txn->status == TXN_ABORTED)
+		stmt->engine_savepoint = NULL;
 }
 
 /**
@@ -2689,12 +2657,6 @@ memtx_tx_history_prepare_stmt(struct txn_stmt *stmt)
 	memtx_tx_story_gc();
 }
 
-/**
- * Clean and clear all read lists of @a txn.
- */
-static void
-memtx_tx_clear_txn_read_lists(struct txn *txn);
-
 void
 memtx_tx_prepare_finalize(struct txn *txn)
 {
@@ -2919,20 +2881,68 @@ memtx_tx_on_index_delete(struct index *index)
 }
 
 void
-memtx_tx_on_space_delete(struct space *space)
+memtx_tx_invalidate_space(struct space *space, struct txn *active_txn)
 {
+	struct memtx_story *story;
+	/*
+	 * Phase one: fill the indexes with actual tuples. Here we insert
+	 * all tuples visible to `active_txn`.
+	 */
+	rlist_foreach_entry(story, &space->memtx_stories, in_space_stories) {
+		assert(story->index_count == space->index_count);
+
+		for (uint32_t i = 0; i < story->index_count; i++) {
+			struct index *index = story->link[i].in_index;
+			if (index == NULL)
+				continue;
+
+			/* Mark as not in index. */
+			story->link[i].in_index = NULL;
+
+			/* Skip chains of excluded tuples. */
+			if (tuple_key_is_excluded(story->tuple,
+						  index->def->key_def,
+						  MULTIKEY_NONE))
+				continue;
+
+			struct tuple *new_tuple = NULL;
+			bool is_own_change;
+			memtx_tx_story_find_visible_tuple(story, active_txn, i,
+							  true, &new_tuple,
+							  &is_own_change);
+
+			/* Visible tuple is already in index - do nothing. */
+			if (new_tuple == story->tuple)
+				continue;
+
+			struct tuple *unused;
+			if (index_replace(index, story->tuple, new_tuple,
+					  DUP_REPLACE, &unused,
+					  &unused) != 0) {
+				diag_log();
+				unreachable();
+				panic("failed to rebind story in index on "
+				      "space invalidation");
+			}
+
+			if (i == 0) {
+				if (new_tuple != NULL) {
+					memtx_tx_ref_to_primary(
+						memtx_tx_story_get(new_tuple));
+				}
+				memtx_tx_unref_from_primary(story);
+			}
+		}
+	}
+
+	/*
+	 * Phase two: destroy all the stories. They are expected to be unlinked
+	 * from the indexes during the first phase.
+	 */
 	while (!rlist_empty(&space->memtx_stories)) {
-		struct memtx_story *story
-			= rlist_first_entry(&space->memtx_stories,
-					    struct memtx_story,
-					    in_space_stories);
-		/*
-		 * Space is to be altered (not necessarily dropped). Since
-		 * this operation is considered to be DDL, all other
-		 * transactions will be aborted anyway. We can't postpone
-		 * rollback till actual call of commit/rollback since stories
-		 * should be destroyed immediately.
-		 */
+		story = rlist_first_entry(&space->memtx_stories,
+					  struct memtx_story,
+					  in_space_stories);
 		if (story->add_stmt != NULL)
 			memtx_tx_history_remove_stmt(story->add_stmt);
 		while (story->del_stmt != NULL)

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -2232,6 +2232,11 @@ memtx_tx_history_rollback_empty_stmt(struct txn_stmt *stmt)
 			      "rollback of statement without story");
 		}
 	}
+	/* We have no stories here so reference bare tuples instead. */
+	if (new_tuple != NULL)
+		tuple_unref(new_tuple);
+	if (old_tuple != NULL)
+		tuple_ref(old_tuple);
 }
 
 void

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -2978,7 +2978,7 @@ memtx_tx_on_space_delete(struct space *space)
 		 */
 		if (story->add_stmt != NULL)
 			memtx_tx_history_remove_stmt(story->add_stmt);
-		if (story->del_stmt != NULL)
+		while (story->del_stmt != NULL)
 			memtx_tx_history_remove_stmt(story->del_stmt);
 		memtx_tx_story_full_unlink_on_space_delete(story);
 		for (uint32_t i = 0; i < story->index_count; i++) {

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1202,53 +1202,6 @@ memtx_tx_story_link_top(struct memtx_story *new_top,
 	rlist_splice(&new_link->read_gaps, &old_link->read_gaps);
 }
 
-static void
-memtx_tx_story_unlink_top_on_space_delete(struct memtx_story *story,
-					  uint32_t idx)
-{
-	struct memtx_story_link *link = &story->link[idx];
-	struct memtx_story *old_story = link->older_story;
-	if (old_story != NULL)
-		memtx_tx_story_unlink(story, old_story, idx);
-}
-
-/**
- * Unlink a @a story from history chain in @a index in both directions.
- * Handles case when the story is not on top of the history: simply remove from
- * list.
- */
-static void
-memtx_tx_story_unlink_both_common(struct memtx_story *story,
-				  uint32_t idx)
-{
-	assert(idx < story->index_count);
-	struct memtx_story_link *link = &story->link[idx];
-	struct memtx_story *newer_story = link->newer_story;
-	struct memtx_story *older_story = link->older_story;
-	memtx_tx_story_unlink(newer_story, story, idx);
-	memtx_tx_story_unlink(story, older_story, idx);
-	memtx_tx_story_link(newer_story, older_story, idx);
-}
-
-/**
- * Unlink a @a story from history chain in @a index in both directions.
- * If the story was in the top of history chain - unlink from top. Otherwise,
- * see description of `memtx_tx_story_unlink_both_common`.
- * Since the space is being deleted, we need to simply unlink the story.
- */
-static void
-memtx_tx_story_unlink_both_on_space_delete(struct memtx_story *story,
-					   uint32_t idx)
-{
-	assert(idx < story->index_count);
-	struct memtx_story_link *link = &story->link[idx];
-	if (link->newer_story == NULL) {
-		memtx_tx_story_unlink_top_on_space_delete(story, idx);
-	} else {
-		memtx_tx_story_unlink_both_common(story, idx);
-	}
-}
-
 /**
  * Change the order of stories in history chain.
  */
@@ -2077,28 +2030,6 @@ memtx_tx_history_add_stmt(struct txn_stmt *stmt, struct tuple *old_tuple,
 }
 
 /*
- * Relink those who delete this story and make them delete older story.
- */
-static void
-memtx_tx_history_remove_story_del_stmts(struct memtx_story *story)
-{
-	struct memtx_story *old_story = story->link[0].older_story;
-	while (story->del_stmt) {
-		struct txn_stmt *del_stmt = story->del_stmt;
-
-		/* Unlink from old list in any case. */
-		story->del_stmt = del_stmt->next_in_del_list;
-		del_stmt->next_in_del_list = NULL;
-		del_stmt->del_story = NULL;
-
-		/* Link to old story's list. */
-		if (old_story != NULL)
-			memtx_tx_story_link_deleted_by(old_story,
-						       del_stmt);
-	}
-}
-
-/*
  * Abort with conflict all transactions that have read @a story.
  */
 static void
@@ -2330,44 +2261,6 @@ memtx_tx_history_rollback_stmt(struct txn_stmt *stmt)
 	else
 		memtx_tx_history_rollback_empty_stmt(stmt);
 	assert(stmt->add_story == NULL && stmt->del_story == NULL);
-}
-
-/*
- * Completely remove statement that adds a story.
- */
-static void
-memtx_tx_history_remove_added_story(struct txn_stmt *stmt)
-{
-	assert(stmt->add_story != NULL);
-	assert(stmt->add_story->tuple == stmt->rollback_info.new_tuple);
-	struct memtx_story *story = stmt->add_story;
-	memtx_tx_history_remove_story_del_stmts(story);
-	for (uint32_t i = 0; i < story->index_count; i++)
-		memtx_tx_story_unlink_both_on_space_delete(story, i);
-	memtx_tx_story_unlink_added_by(story, stmt);
-}
-
-/*
- * Completely remove statement that deletes a story.
- */
-static void
-memtx_tx_history_remove_deleted_story(struct txn_stmt *stmt)
-{
-	memtx_tx_story_unlink_deleted_by(stmt->del_story, stmt);
-}
-
-/*
- * Completely (as opposed to rollback) remove statement from history.
- */
-static void
-memtx_tx_history_remove_stmt(struct txn_stmt *stmt)
-{
-	if (stmt->add_story != NULL)
-		memtx_tx_history_remove_added_story(stmt);
-	if (stmt->del_story != NULL)
-		memtx_tx_history_remove_deleted_story(stmt);
-	if (stmt->txn->status == TXN_ABORTED)
-		stmt->engine_savepoint = NULL;
 }
 
 /**
@@ -2944,9 +2837,10 @@ memtx_tx_invalidate_space(struct space *space, struct txn *active_txn)
 					  struct memtx_story,
 					  in_space_stories);
 		if (story->add_stmt != NULL)
-			memtx_tx_history_remove_stmt(story->add_stmt);
+			memtx_tx_story_unlink_added_by(story, story->add_stmt);
 		while (story->del_stmt != NULL)
-			memtx_tx_history_remove_stmt(story->del_stmt);
+			memtx_tx_story_unlink_deleted_by(story,
+							 story->del_stmt);
 		memtx_tx_story_full_unlink_on_space_delete(story);
 		for (uint32_t i = 0; i < story->index_count; i++) {
 			struct rlist *read_gaps = &story->link[i].read_gaps;
@@ -2971,6 +2865,23 @@ memtx_tx_invalidate_space(struct space *space, struct txn *active_txn)
 			rlist_del(&tracker->in_read_set);
 		}
 		memtx_tx_story_delete(story);
+	}
+
+	/*
+	 * Phase three: remove savepoints from all affected statements so that
+	 * they won't be rolled back because we already did it. Moreover, they
+	 * could access the old space that is going to be deleted leading to
+	 * use-after-free.
+	 */
+	struct txn *txn;
+	rlist_foreach_entry(txn, &txm.all_txs, in_all_txs) {
+		if (txn->status != TXN_ABORTED || txn->psn != 0)
+			continue;
+		struct txn_stmt *stmt;
+		stailq_foreach_entry(stmt, &txn->stmts, next) {
+			if (stmt->space == space)
+				stmt->engine_savepoint = NULL;
+		}
 	}
 }
 

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -2353,7 +2353,7 @@ memtx_tx_history_remove_added_story(struct txn_stmt *stmt)
 static void
 memtx_tx_history_remove_deleted_story(struct txn_stmt *stmt)
 {
-	memtx_tx_history_rollback_deleted_story(stmt);
+	memtx_tx_story_unlink_deleted_by(stmt->del_story, stmt);
 }
 
 /*

--- a/src/box/memtx_tx.h
+++ b/src/box/memtx_tx.h
@@ -413,15 +413,15 @@ void
 memtx_tx_on_index_delete(struct index *index);
 
 /**
- * Notify manager the a space is deleted.
- * It's necessary because there is a chance that garbage collector hasn't
- * deleted all stories of that space and in that case some actions of
- * story's destructor are not applicable.
+ * Invalidate space in memtx tx: remove all the objects associated with
+ * space and its schema. The helper is supposed to be called when there is
+ * only one active transaction that is passed as `active_txn`. The indexes
+ * are populated with tuples according to what `active_txn` observes.
  *
  * NB: can trigger story garbage collection.
  */
 void
-memtx_tx_on_space_delete(struct space *space);
+memtx_tx_invalidate_space(struct space *space, struct txn *active_txn);
 
 /**
  * Create a snapshot cleaner.

--- a/src/box/memtx_tx.h
+++ b/src/box/memtx_tx.h
@@ -405,14 +405,6 @@ void
 memtx_tx_clean_txn(struct txn *txn);
 
 /**
- * Notify manager tha an index is deleted and free data, save in index.
- *
- * NB: can trigger story garbage collection.
- */
-void
-memtx_tx_on_index_delete(struct index *index);
-
-/**
  * Invalidate space in memtx tx: remove all the objects associated with
  * space and its schema. The helper is supposed to be called when there is
  * only one active transaction that is passed as `active_txn`. The indexes

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -442,7 +442,7 @@ void
 space_delete(struct space *space)
 {
 	assert(rlist_empty(&space->alter_stmts));
-	memtx_tx_on_space_delete(space);
+	assert(rlist_empty(&space->memtx_stories));
 	for (uint32_t j = 0; j <= space->index_id_max; j++) {
 		struct index *index = space->index_map[j];
 		if (index != NULL)

--- a/src/lib/core/errinj.h
+++ b/src/lib/core/errinj.h
@@ -80,6 +80,7 @@ struct errinj {
 	_(ERRINJ_BUILD_INDEX, ERRINJ_INT, {.iparam = -1}) \
 	_(ERRINJ_BUILD_INDEX_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_BUILD_INDEX_ON_ROLLBACK_ALLOC, ERRINJ_BOOL, {.bparam = false}) \
+	_(ERRINJ_BUILD_INDEX_DISABLE_YIELD, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_CHECK_FORMAT_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_COIO_SENDFILE_CHUNK, ERRINJ_INT, {.iparam = -1}) \
 	_(ERRINJ_COIO_WRITE_CHUNK, ERRINJ_BOOL, {.bparam = false}) \

--- a/test/box-luatest/mvcc_ddl_stress_test.lua
+++ b/test/box-luatest/mvcc_ddl_stress_test.lua
@@ -1,0 +1,206 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group('Stress tests for MVCC DDL', t.helpers.matrix{
+    is_interactive = {true, false},
+    disable_background_index_build = {true, false},
+    errinj_wal = {true, false},
+})
+
+g.before_each(function(cg)
+    cg.server = server:new{box_cfg = {memtx_use_mvcc_engine = true}}
+    cg.server:start()
+end)
+
+g.after_each(function(cg)
+    cg.server:stop()
+end)
+
+local function stress_test_impl(seed, interactive_dml, wal_errinj)
+    math.randomseed(seed)
+    local fiber = require('fiber')
+    local log = require('log')
+    local formats = {
+        {{name = 'field1', type = 'unsigned'}},
+        {{name = 'field1', type = 'scalar'}}
+    }
+    local next_format_idx = 1
+    box.schema.space.create('test')
+    box.space.test:create_index('pk')
+
+    local MIN_INDEX = 2
+    local MAX_INDEX = 10
+    for i = 1, MAX_INDEX do
+        box.space.test:create_index('sk_' .. tostring(i))
+    end
+
+    local MAX_TUPLE = math.random(500, 2000)
+    for i = 1, MAX_TUPLE do
+        box.space.test:replace{i}
+    end
+
+    local max_ddl_ops = 3
+    local ddl_ops = {
+        'alter space',
+        'create index',
+        'alter index',
+        'drop index'
+    }
+
+    local max_dml_ops = 20
+    local dml_ops = {
+        'insert',
+        'replace',
+        'delete',
+        'get'
+    }
+
+    local successfully_completed_dml = 0
+    local successfully_completed_ddl = 0
+
+    local function do_random_ddl()
+        local idx = math.random(#ddl_ops)
+        local op = ddl_ops[idx]
+
+        if op == 'alter space' then
+            local new_format = formats[next_format_idx]
+            box.space.test:format(new_format)
+            next_format_idx = (next_format_idx + 1) % #formats + 1
+        elseif op == 'create index' then
+            box.space.test:create_index('sk_' .. tostring(MAX_INDEX))
+            MAX_INDEX = MAX_INDEX + 1
+        elseif op == 'alter index' then
+            box.space.test.index.sk_1:alter(
+                {parts = {{field = 1, type = 'unsigned'}}})
+        elseif op == 'drop index' then
+            if MIN_INDEX > MAX_INDEX then
+                -- No indexes left for drop - do another op
+                do_random_ddl()
+                return
+            end
+            box.space.test.index['sk_' .. tostring(MIN_INDEX)]:drop()
+            MIN_INDEX = MIN_INDEX + 1
+        end
+    end
+
+    local function do_random_dml()
+        local idx = math.random(#dml_ops)
+        local op = dml_ops[idx]
+        if op == 'insert' then
+            box.space.test:insert{MAX_TUPLE + 1}
+            MAX_TUPLE = MAX_TUPLE + 1
+        elseif op == 'replace' then
+            local value = math.random(MAX_TUPLE)
+            box.space.test:replace{value}
+        elseif op == 'delete' then
+            local value = math.random(MAX_TUPLE)
+            box.space.test:delete{value}
+        elseif op == 'get' then
+            local value = math.random(MAX_TUPLE)
+            box.space.test:get{value}
+        end
+    end
+
+    -- Number of iterations
+    local N = 50
+
+    local function dml_fiber_f()
+        for _ = 1, N do
+            pcall(function()
+                local ops_num = math.random(max_dml_ops)
+                box.atomic(function()
+                    for _ = 1, ops_num do
+                        do_random_dml()
+                        if interactive_dml and math.random(1, 10) == 10 then
+                            -- Yield with 10% probability
+                            fiber.sleep(0)
+                        end
+                    end
+                end)
+                successfully_completed_dml = successfully_completed_dml + 1
+            end)
+        end
+    end
+
+    local function ddl_fiber_f()
+        for _ = 1, N do
+            pcall(function()
+                local ops_num = math.random(max_ddl_ops)
+                box.atomic(function()
+                    for _ = 1, ops_num do
+                        do_random_ddl()
+                    end
+                end)
+                successfully_completed_ddl = successfully_completed_ddl + 1
+            end)
+        end
+    end
+
+    local DML_FIBERS_MAX = 100
+    local DDL_FIBERS_MAX = 3
+
+    local dml_fibers_num = math.random(DML_FIBERS_MAX)
+    local ddl_fibers_num = math.random(DDL_FIBERS_MAX)
+
+    local fibers = {}
+    for _ = 1, dml_fibers_num do
+        local f = fiber.new(dml_fiber_f)
+        f:set_joinable(true)
+        table.insert(fibers, f)
+    end
+    for _ = 1, ddl_fibers_num do
+        local f = fiber.new(ddl_fiber_f)
+        f:set_joinable(true)
+        table.insert(fibers, f)
+    end
+
+    if wal_errinj then
+        local function wal_errinj_fiber_f()
+            for _ = 1, 5 do
+                -- Inject each error with 0.8 probability so that probability
+                -- of both errors being injected is more than 0.5
+                if math.random(1, 10) < 9 then
+                    box.error.injection.set('ERRINJ_WAL_DELAY', true)
+                    fiber.sleep(0.5)
+                    box.error.injection.set('ERRINJ_WAL_DELAY', false)
+                end
+                if math.random(1, 10) < 9 then
+                    box.error.injection.set('ERRINJ_WAL_ERROR', true)
+                    fiber.sleep(0.5)
+                    box.error.injection.set('ERRINJ_WAL_ERROR', false)
+                end
+            end
+        end
+        local f = fiber.new(wal_errinj_fiber_f)
+        table.insert(fibers, f)
+    end
+
+    for _, f in pairs(fibers) do
+        local ok = f:join()
+        t.assert(ok)
+    end
+
+    -- Verbosity
+    log.info('Successfully completed DML: ' .. successfully_completed_dml)
+    log.info('Successfully completed DDL: ' .. successfully_completed_ddl)
+end
+
+g.test_stress = function(cg)
+    if cg.params.disable_background_index_build then
+        t.tarantool.skip_if_not_debug()
+        cg.server:exec(function()
+            box.error.injection.set('ERRINJ_BUILD_INDEX_DISABLE_YIELD', true)
+        end)
+    end
+
+    if cg.params.wal_errinj then
+        t.tarantool.skip_if_not_debug()
+    end
+
+    local seed = os.time()
+    -- Print the seed so that the test can be easily reproduced at least on
+    -- the same device
+    print('Running stress test with seed: ' .. seed)
+    cg.server:exec(stress_test_impl,
+        {seed, cg.params.is_interactive, cg.params.wal_errinj})
+end

--- a/test/box-luatest/mvcc_ddl_test.lua
+++ b/test/box-luatest/mvcc_ddl_test.lua
@@ -1,0 +1,45 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_each(function(cg)
+    cg.server = server:new{box_cfg = {memtx_use_mvcc_engine = true}}
+    cg.server:start()
+end)
+
+g.after_each(function(cg)
+    cg.server:stop()
+end)
+
+-- The test checks that all delete statements are handled correctly
+-- on space drop
+g.test_drop_space_many_delete_statements = function(cg)
+    cg.server:exec(function()
+        local txn_proxy = require("test.box.lua.txn_proxy")
+
+        -- Create space with tuples
+        local s = box.schema.space.create('test')
+        s:create_index('pk')
+        for i = 1, 100 do
+            s:replace{i}
+        end
+
+        -- Delete the tuples concurrently
+        local tx1 = txn_proxy:new()
+        local tx2 = txn_proxy:new()
+        tx1:begin()
+        tx2:begin()
+        for i = 1, 100 do
+            local stmt = "box.space.test:delete{" .. i .. "}"
+            tx1(stmt)
+            tx2(stmt)
+        end
+        s:drop()
+        tx1:rollback()
+        tx2:rollback()
+
+        -- Collect garbage
+        box.internal.memtx_tx_gc(1000)
+    end)
+end

--- a/test/box-luatest/mvcc_ddl_test.lua
+++ b/test/box-luatest/mvcc_ddl_test.lua
@@ -86,3 +86,54 @@ g.test_background_build = function(cg)
         box.internal.memtx_tx_gc(1000)
     end)
 end
+
+-- The test covers a crash when transaction that is being deleted removes
+-- itself from reader list of a deleted story that leads to use-after-free
+g.test_reader_list_use_after_free = function(cg)
+    cg.server:exec(function()
+        local txn_proxy = require("test.box.lua.txn_proxy")
+
+        -- Create space with tuples
+        local s = box.schema.space.create('test')
+        s:create_index('pk')
+
+        box.begin()
+        for i = 1, 10000 do
+            s:replace{i}
+        end
+        box.commit()
+
+        -- Create a transaction that reads every tuple so it's
+        -- inserted to reader list of every story
+        local tx = txn_proxy.new()
+        tx:begin()
+        for i = 1, 10000 do
+            tx('box.space.test:get{' .. i .. '}')
+        end
+
+        -- Create a new index
+        -- Firstly, we need it so that all the stories will be deleted
+        -- due to DDL
+        -- Secondly, we need to create a new index so that layout of stories
+        -- will be changed and use-after-free on rlist link will trash another
+        -- field (for example, pointer to tuple) and that's will definitely lead
+        -- to crash
+        box.space.test:create_index('sk')
+
+        -- Open a read-view so that stories for all tuples from the space
+        -- are created
+        local rv = txn_proxy.new()
+        rv:begin()
+        rv('box.space.test:select{}')
+
+        -- Rollback the first reader so that it will delete itself from reader
+        -- lists of all stories and that will lead to use-after-free
+        tx:rollback()
+
+        -- Read all the tuples, Tarantool is most likely to crash here if
+        -- use-after-free broke something
+        for i = 1, 10000 do
+            s:get{i}
+        end
+    end)
+end

--- a/test/box-luatest/mvcc_ddl_test.lua
+++ b/test/box-luatest/mvcc_ddl_test.lua
@@ -137,3 +137,282 @@ g.test_reader_list_use_after_free = function(cg)
         end
     end)
 end
+
+-- The test checks if stories associated with old schema cannot
+-- be access on index creation
+-- gh-10096
+g.test_dont_access_old_stories_on_index_create = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+
+        local s = box.schema.space.create('test')
+        s:create_index('pk', {parts = {{1}}})
+        s:create_index('sk1', {parts = {{2}}, unique = true})
+
+        s:insert{1, 1, 1, 0}
+        -- Collect stories to be independent from GC steps
+        box.internal.memtx_tx_gc(100)
+
+        -- Create index in a separate transaction
+        -- Transaction creating index will create story for our tuple
+        -- when it reads it to insert into the new index
+        -- The problem is the story is created with old index_count and
+        -- does not have links for created index
+        local created_index = false
+        local f = fiber.create(function()
+            s:create_index('sk2', {parts = {{3}}, unique = true})
+            created_index = true
+        end)
+        f:set_joinable(true)
+
+        -- Make sure txn is still in progress
+        assert(not created_index)
+        s:replace{1, 1, 1, 1}
+        local ok = f:join()
+        t.assert(ok)
+    end)
+end
+
+-- The test checks if stories associated with old schema cannot
+-- be access when index is being altered
+-- gh-10097
+g.test_dont_access_old_stories_on_index_alter = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+
+        local s = box.schema.space.create('test')
+        s:create_index('pk', {parts = {{1}}})
+        s:create_index('sk1', {parts = {{2}}, unique = true})
+
+        s:insert{1, 1, 1, 0}
+        -- Collect stories to be independent from GC steps
+        box.internal.memtx_tx_gc(100)
+
+        -- Alter index in a separate transaction
+        -- Transaction creating index will create story for our tuple
+        -- when it reads it to insert into the new index
+        -- The problem is the story link points to the old index, but
+        -- it was replaced with the new one (new index object, hence,
+        -- new address)
+        local altered_index = false
+        local f = fiber.create(function()
+            s.index.sk1:alter({parts = {{3}}, unique = true})
+            altered_index = true
+        end)
+        f:set_joinable(true)
+
+        -- Make sure txn is still in progress
+        assert(not altered_index)
+        s:replace{1, 1, 1, 1}
+        local ok = f:join()
+        t.assert(ok)
+    end)
+end
+
+-- The test covers a crash when using count after DDL because
+-- DDL has violated some MVCC invariants that are checked in count
+-- gh-10474, case 3
+g.test_count_crashes_after_ddl = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+
+        local s = box.schema.create_space('test')
+        s:create_index('pk')
+        s:create_index('sk', {parts={{2}}})
+
+        -- Do a sequence of operations under WAL delay:
+        -- Replace
+        -- DDL
+        -- Replace
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+        fiber.create(function() box.space.test:replace{1, 1, 1} end)
+        local f = fiber.create(function()
+            box.space.test:format{{name = 'field1', type = 'scalar'}}
+        end)
+        fiber.create(function() box.space.test:replace{1, 1, 1} end)
+        f:set_joinable(true)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+
+        local ok = f:join()
+        t.assert(ok)
+        t.assert_equals(box.space.test:count(), 1)
+    end)
+end
+
+-- The test checks if isolation of transactions is not broken when DDL
+-- is committed. It happened because we removed all memtx stories on commit
+-- eariler.
+g.test_txn_isolation_on_ddl_commit = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+
+        local s = box.schema.space.create('test')
+        s:create_index('pk', {parts = {{1}}})
+
+        -- Few tuples to do DDL without yields
+        for i = 1, 5 do
+            s:replace{i}
+        end
+
+        -- Collect stories to be independent from GC steps
+        box.internal.memtx_tx_gc(100)
+
+        -- Alter space in a separate transaction
+        local altered_space = false
+        local f = fiber.create(function()
+            s:format({{name = 'field1', type = 'unsigned'}})
+            altered_space = true
+        end)
+        f:set_joinable(true)
+        -- Make sure txn is still in progress
+        t.assert(not altered_space)
+
+        box.begin()
+        -- Drop all the tuples in the new transaction
+        for i = 1, 5 do
+            s:delete(i)
+        end
+        -- Check if tuples were deleted
+        t.assert_equals(s:select{}, {})
+
+        -- Wait for DDL to be committed and make sure it was successful
+        local ok = f:join()
+        t.assert(ok)
+
+        -- Check contents after yield
+        t.assert_equals(s:select{}, {})
+
+        box.commit()
+
+        -- We committed a transaction deleting all tuples just now, result
+        -- still must be empty
+        t.assert_equals(s:select{}, {})
+    end)
+end
+
+-- The test checks if DDL aborts all conflicting transactions - not preparing
+-- the DDL but the operation itself. We should check this behavior because we
+-- delete all memtx stories on DDL so we cannot support transaction isolation
+-- anymore. If we didn't abort active transactions, rollback of DDL could
+-- violate their isolation.
+g.test_abort_all_on_ddl = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        local s = box.schema.space.create('test')
+        s:create_index('pk', {parts = {{1}}})
+        local errmsg = 'Transaction has been aborted by conflict'
+
+        box.begin()
+        s:replace{1}
+        local ddl = fiber.create(function()
+            s:create_index('sk')
+        end)
+        ddl:set_joinable(true)
+        t.assert_error_msg_content_equals(errmsg, box.commit)
+        local ok = ddl:join()
+        t.assert(ok)
+    end)
+end
+
+-- The test checks if rollback of DDL aborts all conflicting transactions since
+-- they rely on new schema which is going to be rolled back. Since we already
+-- abort all transactions on DDL itself and transaction doing DDL cannot yield,
+-- the only way a concurrent transaction can appear is after DDL is prepared but
+-- before it is committed. If DDL wasn't prepared (manual rollback), there
+-- can't be concurrent transactions.
+g.test_abort_all_ddl_rollback = function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        local s = box.schema.space.create('test')
+        s:create_index('pk', {parts = {{1}}})
+        local errmsg = 'Transaction has been aborted by conflict'
+
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+
+        local ddl = fiber.create(function()
+            s:create_index('sk')
+        end)
+        ddl:set_joinable(true)
+
+        box.begin()
+        s:replace{1}
+        box.error.injection.set('ERRINJ_WAL_WRITE', true)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        local ok = ddl:join()
+        t.assert_not(ok, 'DDL must fail and rollback due to WAL error')
+        box.error.injection.set('ERRINJ_WAL_WRITE', false)
+        t.assert_error_msg_content_equals(errmsg, box.commit)
+    end)
+end
+
+g.test_rollback_mixed_ddl_and_dml = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        s:create_index('pk', {parts = {{1}}})
+        for i = 1, 10 do
+            s:replace{i}
+        end
+        local saved_select = s:select{}
+        box.begin()
+        s:replace{1, 1}
+        s:delete{1}
+        s:delete{2}
+        s:insert{11}
+        s:alter({is_sync = true})
+        s:replace{3, 1}
+        s:delete{4}
+        s:delete{5}
+        s:insert{12}
+        s:alter({is_sync = false})
+        box.rollback()
+        t.assert_equals(s:select{}, saved_select)
+    end)
+end
+
+g.test_rollback_prepared_dml_and_ddl = function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        local s = box.schema.space.create('test')
+        s:create_index('pk', {parts = {{1}}})
+        for i = 1, 10 do
+            s:replace{i}
+        end
+        local saved_select = s:select{}
+
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+        local dml1 = fiber.create(function()
+            box.begin()
+            s:replace{1, 1}
+            s:replace{2, 2}
+            s:delete{3}
+            s:delete{4}
+            s:insert{100}
+            box.commit()
+        end)
+        dml1:set_joinable(true)
+        local ddl = fiber.create(function()
+            s:create_index('sk')
+        end)
+        ddl:set_joinable(true)
+        local dml2 = fiber.create(function()
+            box.begin()
+            s:replace{4, 4}
+            s:replace{5, 5}
+            s:delete{8}
+            s:insert{200}
+            box.commit()
+        end)
+        dml2:set_joinable(true)
+        box.error.injection.set('ERRINJ_WAL_WRITE', true)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        local ok = dml1:join()
+        t.assert_not(ok)
+        ok = dml2:join()
+        t.assert_not(ok)
+        ok = ddl:join()
+        t.assert_not(ok)
+        t.assert_equals(s:select{}, saved_select)
+    end)
+end


### PR DESCRIPTION
This is a backport of #10160 and #10567 to 2.11