### PR TITLE
box: increase INDEX_READ_VIEW_ITERATOR_SIZE

### DIFF
--- a/src/box/index.h
+++ b/src/box/index.h
@@ -751,7 +751,7 @@ struct index_read_view_iterator_base {
 };
 
 /** Size of the index_read_view_iterator struct. */
-#define INDEX_READ_VIEW_ITERATOR_SIZE 72
+#define INDEX_READ_VIEW_ITERATOR_SIZE 80
 
 static_assert(sizeof(struct index_read_view_iterator_base) <=
 	      INDEX_READ_VIEW_ITERATOR_SIZE,


### PR DESCRIPTION
As we are going to add more members to `struct memcs_index_read_view_iterator` in EE.

Required for EE PR https://github.com/tarantool/tarantool-ee/pull/917