### PR TITLE
[Backport 2.11]  Forbid non-integers in datetime.new, :set() and parse()

### DIFF
--- a/changelogs/unreleased/gh-10391-forbid-non-integers-datetime-new.md
+++ b/changelogs/unreleased/gh-10391-forbid-non-integers-datetime-new.md
@@ -1,0 +1,3 @@
+## bugfix/datetime
+
+- Forbid non-integers in `datetime.new()` (gh-10391).

--- a/changelogs/unreleased/gh-10391-forbid-non-integers-datetime-set.md
+++ b/changelogs/unreleased/gh-10391-forbid-non-integers-datetime-set.md
@@ -1,0 +1,3 @@
+## bugfix/datetime
+
+- Forbid non-integers in `:set()` and `datetime.parse()` (gh-10391).

--- a/changelogs/unreleased/gh-10391-forbid-non-integers-sql-datetime.md
+++ b/changelogs/unreleased/gh-10391-forbid-non-integers-sql-datetime.md
@@ -1,0 +1,3 @@
+## bugfix/datetime
+
+- Forbid non-integers in SQL's `CAST({}) AS datetime` (gh-10391).

--- a/src/lib/core/datetime.c
+++ b/src/lib/core/datetime.c
@@ -47,6 +47,12 @@ local_secs(const struct datetime *date)
 	return (int64_t)date->epoch + date->tzoffset * 60;
 }
 
+static int
+is_integer(double num)
+{
+	return roundf(num) == num;
+}
+
 /**
  * Resolve tzindex encoded timezone from @sa date using Olson facilities.
  * @param[in] epoch decode input epoch time (in seconds).
@@ -1052,6 +1058,18 @@ map_field_to_dt_field(struct dt_fields *fields, const char **data)
 static int
 datetime_from_fields(struct datetime *dt, const struct dt_fields *fields)
 {
+	if (!is_integer(fields->year) ||
+	    !is_integer(fields->month) ||
+	    !is_integer(fields->day) ||
+	    !is_integer(fields->hour) ||
+	    !is_integer(fields->min) ||
+	    !is_integer(fields->sec) ||
+	    !is_integer(fields->msec) ||
+	    !is_integer(fields->usec) ||
+	    !is_integer(fields->nsec) ||
+	    !is_integer(fields->tzoffset))
+		return -1;
+
 	if (fields->count_usec > 1)
 		return -1;
 	double nsec = fields->msec * 1000000 + fields->usec * 1000 +

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -1031,16 +1031,19 @@ local function datetime_set(self, obj)
     local y = obj.year
     if y ~= nil then
         check_range(y, MIN_DATE_YEAR, MAX_DATE_YEAR, 'year')
+        check_integer(y, 'year')
         ymd = true
     end
     local M = obj.month
     if M ~= nil then
         check_range(M, 1, 12, 'month')
+        check_integer(M, 'month')
         ymd = true
     end
     local d = obj.day
     if d ~= nil then
         check_range(d, 1, 31, 'day', -1)
+        check_integer(d, 'day')
         ymd = true
     end
 
@@ -1052,16 +1055,19 @@ local function datetime_set(self, obj)
     local h = obj.hour
     if h ~= nil then
         check_range(h, 0, 23, 'hour')
+        check_integer(h, 'hour')
         hms = true
     end
     local m = obj.min
     if m ~= nil then
         check_range(m, 0, 59, 'min')
+        check_integer(m, 'min')
         hms = true
     end
     local sec = obj.sec
     if sec ~= nil then
         check_range(sec, 0, 60, 'sec')
+        check_integer(sec, 'sec')
         hms = true
     end
 
@@ -1075,12 +1081,15 @@ local function datetime_set(self, obj)
         end
         if usec ~= nil then
             check_range(usec, 0, 1e6, 'usec')
+            check_integer(usec, 'usec')
             self.nsec = usec * 1e3
         elseif msec ~= nil then
             check_range(msec, 0, 1e3, 'msec')
+            check_integer(msec, 'msec')
             self.nsec = msec * 1e6
         elseif nsec ~= nil then
             check_range(nsec, 0, 1e9, 'nsec')
+            check_integer(nsec, 'nsec')
             self.nsec = nsec
         end
     end

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -504,6 +504,7 @@ end
 
 local function get_timezone(offset, msg)
     if type(offset) == 'number' then
+        check_integer(offset, 'tzoffset')
         return offset
     elseif type(offset) == 'string' then
         return parse_tzoffset(offset)
@@ -527,31 +528,37 @@ local function datetime_new(obj)
     local y = obj.year
     if y ~= nil then
         check_range(y, MIN_DATE_YEAR, MAX_DATE_YEAR, 'year')
+        check_integer(y, 'year')
         ymd = true
     end
     local M = obj.month
     if M ~= nil then
         check_range(M, 1, 12, 'month')
+        check_integer(M, 'month')
         ymd = true
     end
     local d = obj.day
     if d ~= nil then
         check_range(d, 1, 31, 'day', -1)
+        check_integer(d, 'day')
         ymd = true
     end
     local h = obj.hour
     if h ~= nil then
         check_range(h, 0, 23, 'hour')
+        check_integer(h, 'hour')
         hms = true
     end
     local m = obj.min
     if m ~= nil then
         check_range(m, 0, 59, 'min')
+        check_integer(m, 'min')
         hms = true
     end
     local s = obj.sec
     if s ~= nil then
         check_range(s, 0, 60, 'sec')
+        check_integer(s, 'sec')
         hms = true
     end
 
@@ -565,12 +572,15 @@ local function datetime_new(obj)
         end
         if usec ~= nil then
             check_range(usec, 0, 1e6, 'usec')
+            check_integer(usec, 'usec')
             nsec = usec * 1e3
         elseif msec ~= nil then
             check_range(msec, 0, 1e3, 'msec')
+            check_integer(msec, 'msec')
             nsec = msec * 1e6
         else
             check_range(nsec, 0, 1e9, 'nsec')
+            check_integer(nsec, 'nsec')
         end
     else
         nsec = 0

--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -34,9 +34,11 @@ local MAX_MSEC_RANGE = math.floor(MAX_NSEC_RANGE / 1e6)
 local incompat_types = 'incompatible types for datetime comparison'
 local only_integer_ts = 'only integer values allowed in timestamp'..
                         ' if nsec, usec, or msecs provided'
+local only_integer_msg = function(key)
+    return key .. ': integer value expected, but received number'
+end
 local only_one_of = 'only one of nsec, usec or msecs may be defined'..
                     ' simultaneously'
-local int_ival_exp = 'sec: integer value expected, but received number'
 local timestamp_and_ymd = 'timestamp is not allowed if year/month/day provided'
 local timestamp_and_hms = 'timestamp is not allowed if hour/min/sec provided'
 local str_or_num_exp = 'tzoffset: string or number expected, but received'
@@ -271,7 +273,7 @@ test:test("Simple date creation by attributes", function(test)
 end)
 
 test:test("Simple date creation by attributes - check failed", function(test)
-    test:plan(83)
+    test:plan(93)
 
     local boundary_checks = {
         {'year', {MIN_DATE_YEAR, MAX_DATE_YEAR}},
@@ -339,6 +341,16 @@ test:test("Simple date creation by attributes - check failed", function(test)
         {only_one_of, { nsec = 123456, msec = 123}},
         {only_one_of, { usec = 123, msec = 123}},
         {only_one_of, { nsec = 123456, usec = 123, msec = 123}},
+        {only_integer_msg('nsec'), { nsec = 1.1 }},
+        {only_integer_msg('msec'), { msec = 1.1 }},
+        {only_integer_msg('usec'), { usec = 1.1 }},
+        {only_integer_msg('tzoffset'), { tzoffset = 1.1 }},
+        {only_integer_msg('year'), { year = 1.1 }},
+        {only_integer_msg('month'), { month = 1.1 }},
+        {only_integer_msg('day'), { day = 1.1 }},
+        {only_integer_msg('hour'), { hour = 1.1 }},
+        {only_integer_msg('min'), { min = 1.1 }},
+        {only_integer_msg('sec'), { sec = 1.1 }},
         {only_integer_ts, { timestamp = 12345.125, usec = 123}},
         {only_integer_ts, { timestamp = 12345.125, msec = 123}},
         {only_integer_ts, { timestamp = 12345.125, nsec = 123}},
@@ -1169,9 +1181,9 @@ test:test("Time interval operations", function(test)
         {only_one_of, { nsec = 123456, msec = 123}},
         {only_one_of, { usec = 123, msec = 123}},
         {only_one_of, { nsec = 123456, usec = 123, msec = 123}},
-        {int_ival_exp, { sec = 12345.125, usec = 123}},
-        {int_ival_exp, { sec = 12345.125, msec = 123}},
-        {int_ival_exp, { sec = 12345.125, nsec = 123}},
+        {only_integer_msg('sec'), { sec = 12345.125, usec = 123}},
+        {only_integer_msg('sec'), { sec = 12345.125, msec = 123}},
+        {only_integer_msg('sec'), { sec = 12345.125, nsec = 123}},
     }
     for _, row in pairs(specific_errors) do
         local err_msg, obj = unpack(row)
@@ -1322,9 +1334,9 @@ test:test("Time intervals creation - range checks", function(test)
         {only_one_of, { nsec = 123456, msec = 123}},
         {only_one_of, { usec = 123, msec = 123}},
         {only_one_of, { nsec = 123456, usec = 123, msec = 123}},
-        {int_ival_exp, { sec = 12345.125, usec = 123}},
-        {int_ival_exp, { sec = 12345.125, msec = 123}},
-        {int_ival_exp, { sec = 12345.125, nsec = 123}},
+        {only_integer_msg('sec'), { sec = 12345.125, usec = 123}},
+        {only_integer_msg('sec'), { sec = 12345.125, msec = 123}},
+        {only_integer_msg('sec'), { sec = 12345.125, nsec = 123}},
         {table_expected('interval.new()', '2001-01-01'), '2001-01-01'},
         {table_expected('interval.new()', 20010101), 20010101},
         {range_check_error('year', 1e21, {-MAX_YEAR_RANGE, MAX_YEAR_RANGE}),

--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -569,7 +569,7 @@ local function couldnt_parse(txt)
 end
 
 test:test("Check parsing of dates with invalid attributes", function(test)
-    test:plan(32)
+    test:plan(33)
 
     local boundary_checks = {
         {'month', {1, 12}},
@@ -601,6 +601,17 @@ test:test("Check parsing of dates with invalid attributes", function(test)
         txt = create_date_string{[attr_name] = right + 50}
         assert_raises(test, couldnt_parse(txt),
                       function() dt, len = date.parse(txt) end)
+    end
+
+    local specific_errors = {
+        {
+            only_integer_msg('tzoffset'),
+            { '1998-11-25', { format = '%Y-%m-%d', tzoffset = 1.1 } }
+        },
+    }
+    for _, row in pairs(specific_errors) do
+        local err_msg, attribs = unpack(row)
+        assert_raises(test, err_msg, function() date.parse(unpack(attribs)) end)
     end
 end)
 
@@ -2009,7 +2020,7 @@ end)
 
 
 test:test("Time invalid :set{} operations", function(test)
-    test:plan(84)
+    test:plan(94)
 
     local boundary_checks = {
         {'year', {MIN_DATE_YEAR, MAX_DATE_YEAR}},
@@ -2078,6 +2089,16 @@ test:test("Time invalid :set{} operations", function(test)
         {only_one_of, { nsec = 123456, msec = 123}},
         {only_one_of, { usec = 123, msec = 123}},
         {only_one_of, { nsec = 123456, usec = 123, msec = 123}},
+        {only_integer_msg('nsec'), { nsec = 1.1 }},
+        {only_integer_msg('msec'), { msec = 1.1 }},
+        {only_integer_msg('usec'), { usec = 1.1 }},
+        {only_integer_msg('tzoffset'), { tzoffset = 1.1 }},
+        {only_integer_msg('year'), { year = 1.1 }},
+        {only_integer_msg('month'), { month = 1.1 }},
+        {only_integer_msg('day'), { day = 1.1 }},
+        {only_integer_msg('hour'), { hour = 1.1 }},
+        {only_integer_msg('min'), { min = 1.1 }},
+        {only_integer_msg('sec'), { sec = 1.1 }},
         {only_integer_ts, { timestamp = 12345.125, usec = 123}},
         {only_integer_ts, { timestamp = 12345.125, msec = 123}},
         {only_integer_ts, { timestamp = 12345.125, nsec = 123}},

--- a/test/sql-luatest/datetime_test.lua
+++ b/test/sql-luatest/datetime_test.lua
@@ -2514,10 +2514,41 @@ g.test_datetime_33_3 = function()
         local dt = require('datetime')
         local dt1 = dt.new({year = 1})
         local sql = [[SELECT CAST({'year': 1.1} AS DATETIME);]]
-        t.assert_equals(box.execute(sql).rows, {{dt1}})
+        local _, err, res
+        _, err = box.execute(sql)
+        res = [[Type mismatch: can not convert ]]..
+              [[map({"year": 1.1}) to datetime]]
+        t.assert_equals(err.message, res)
 
         sql = [[SELECT CAST({'year': 1.1e0} AS DATETIME);]]
-        t.assert_equals(box.execute(sql).rows, {{dt1}})
+        _, err = box.execute(sql)
+        res = [[Type mismatch: can not convert ]]..
+              [[map({"year": 1.1}) to datetime]]
+        t.assert_equals(err.message, res)
+
+        -- The timestamp value should be integer if the fractional
+        -- part for the last second is set via the nsec.
+        sql = [[SELECT CAST({'timestamp': 1.1, 'nsec': 1} AS DATETIME);]]
+        _, err = box.execute(sql)
+        res = [[Type mismatch: can not convert ]]..
+              [[map({"timestamp": 1.1, "nsec": 1}) to datetime]]
+        t.assert_equals(err.message, res)
+
+        -- The timestamp value should be integer if the fractional
+        -- part for the last second is set via the usec.
+        sql = [[SELECT CAST({'timestamp': 1.1, 'usec': 1} AS DATETIME);]]
+        _, err = box.execute(sql)
+        res = [[Type mismatch: can not convert ]]..
+              [[map({"timestamp": 1.1, "usec": 1}) to datetime]]
+        t.assert_equals(err.message, res)
+
+        -- The timestamp value should be integer if the fractional
+        -- part for the last second is set via the msec.
+        sql = [[SELECT CAST({'timestamp': 1.1, 'msec': 1} AS DATETIME);]]
+        _, err = box.execute(sql)
+        res = [[Type mismatch: can not convert ]]..
+              [[map({"timestamp": 1.1, "msec": 1}) to datetime]]
+        t.assert_equals(err.message, res)
 
         sql = [[SELECT CAST({'year': 1} AS DATETIME);]]
         t.assert_equals(box.execute(sql).rows, {{dt1}})


### PR DESCRIPTION
Orig PR: https://github.com/tarantool/tarantool/pull/10488