### PR TITLE
Add `encode_key_order` option to json encoder

### DIFF
--- a/changelogs/unreleased/gh-10606-json-encode-key-order.md
+++ b/changelogs/unreleased/gh-10606-json-encode-key-order.md
@@ -1,0 +1,4 @@
+## feature/lua
+
+* Introduced a new `encode_key_order` option for the JSON encoder. It allows
+  you to pass the order of keys in the resulting JSON string (gh-10606).

--- a/src/lua/serializer.h
+++ b/src/lua/serializer.h
@@ -136,6 +136,8 @@ struct luaL_serializer {
 	int encode_invalid_as_nil;
 	/** Encode error object as MP_ERROR extension (MsgPack only). */
 	int encode_error_as_ext;
+	/** Array of keys to sort map serialization. */
+	char **encode_key_order;
 
 	/** Enables decoding NaN and Inf numbers */
 	int decode_invalid_numbers;
@@ -166,6 +168,14 @@ struct luaL_serializer {
 };
 
 /**
+ * @brief Create a new serializer configuration and push it onto the Lua stack.
+ * @param Lua stack.
+ * @return New serializer configuration.
+ */
+struct luaL_serializer *
+luaL_newserializer_config(struct lua_State *L);
+
+/**
  * @brief serializer.new() Lua binding.
  * @param L stack
  * @param reg methods to register
@@ -177,12 +187,34 @@ luaL_newserializer(struct lua_State *L, const char *modname,
 		   const luaL_Reg *reg);
 
 /**
- * Copy all option fields of @a src into @a dst. Other fields,
- * such as triggers, are not touched.
+ * @brief Copy all option fields of @a src into @a dst.
+ * Other fields, such as triggers, are not touched.
+ *
+ * This will try to free memory allocated for the options in @a dst. If @a dst
+ * has been just allocated, it should be initialized with 0s.
+ *
+ * This may allocate memory on heap for some of the options, your @a dst
+ * is created in C code, don't forget to call luaL_serializer_options_delete
+ * when the serializer object is not needed anymore to prevent memory leaks.
+ * Or you can use luaL_newserializer_config function to create a new serializer
+ * configuration on Lua stack. It will be garbage collected automatically.
+ *
+ * If the serializer object was created in lua, this will be done during garbage
+ * collection automatically.
+ *
+ * @param dst Destination serializer to copy options into.
+ * @param src Source serializer to copy options from.
  */
 void
 luaL_serializer_copy_options(struct luaL_serializer *dst,
 			     const struct luaL_serializer *src);
+
+/**
+ * Delete the serializer options and free the memory allocated for them.
+ * @param cfg Serializer.
+ */
+void
+luaL_serializer_options_delete(struct luaL_serializer *cfg);
 
 static inline struct luaL_serializer *
 luaL_checkserializer(struct lua_State *L)
@@ -242,6 +274,45 @@ struct luaL_field {
 	enum mp_extension_type ext_type;
 	bool compact;                /* a flag used by YAML serializer */
 };
+
+/**
+ * @brief Get the next field from the table in sorted order.
+ *
+ * Pops a key and a 'key index' from the stack, and pushes a key, 'key-index',
+ * value for the next element in a table provided as a third argument on stack.
+ *
+ * If cfg->encode_key_order is set, this function iterates over the table in the
+ * order defined by this array. During this process the 'key-index' is the
+ * index of the current key in cfg->encode_key_order array. If there are no more
+ * elements in the cfg->encode_key_order array this function iterates over the
+ * unvisited elements of the table in an arbitrary order.
+ *
+ * During the iterating this function may push a copy (which may be modified by
+ * the iterator) of the provided table on the stack which will be popped when
+ * there are no more elements left in the table.
+ *
+ * When the iterator reaches the last element of the table this function returns
+ * 0 and doesn't push anything on the stack, leaving the original table.
+ *
+ * A typical traversal looks like this:
+ *
+ * // cfg->encode_key_order is an array with the order of the keys
+ * // table is on the top of the stack
+ * lua_pushnil(L);  // first key index
+ * lua_pushnil(L);  // first key
+ * while (luaL_next_field(l, cfg) != 0) {
+ *     printf("%s - %s\n",
+ *            lua_typename(L, lua_type(L, -2)),  // key
+ *            lua_typename(L, lua_type(L, -1))); // value
+ *     lua_pop(L, 1); // remove value, keep key and key index for next iteration
+ * }
+ *
+ * @param L Lua stack.
+ * @param cfg Serializer configuration.
+ * @retval 0 if there are no more fields in the table.
+ */
+int
+luaL_next_field(struct lua_State *L, struct luaL_serializer *cfg);
 
 /**
  * @brief Convert a value from the Lua stack to a lua_field structure.


### PR DESCRIPTION
This option allows to pass an array of keys that will be used to sort keys in maps during serialization to json. The order of the provided keys in the resulting string will be the same as in the `encode_key_order` array. Keys, present in maps and not included in `encode_key_order` will be serialized after the sorted ones in arbitrary order.

Closes #10606