### PR TITLE
 [Backport 2.11] datetime: use tzoffset in datetime.parse{format}

### DIFF
--- a/changelogs/unreleased/gh-8333-fix-ignoring-tzoffset-in-parse.md
+++ b/changelogs/unreleased/gh-8333-fix-ignoring-tzoffset-in-parse.md
@@ -1,0 +1,4 @@
+## bugfix/lua/datetime
+
+* Fixed a bug that caused `datetime.parse()` ignore `tzoffset`
+  option if a custom format was used (gh-8333).

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -865,7 +865,7 @@ str_to_datetime(struct Mem *mem)
 {
 	assert(mem->type == MEM_TYPE_STR);
 	struct datetime dt;
-	if (datetime_parse_full(&dt, mem->z, mem->n, NULL, 0) <= 0)
+	if (datetime_parse_full(&dt, mem->z, mem->n) <= 0)
 		return -1;
 	mem_set_datetime(mem, &dt);
 	return 0;

--- a/src/lib/core/datetime.c
+++ b/src/lib/core/datetime.c
@@ -302,8 +302,7 @@ parse_tz_suffix(const char *str, size_t len, time_t base,
 }
 
 ssize_t
-datetime_parse_full(struct datetime *date, const char *str, size_t len,
-		    const char *tzsuffix, int32_t offset)
+datetime_parse_full(struct datetime *date, const char *str, size_t len)
 {
 	size_t n;
 	dt_t dt;
@@ -311,6 +310,7 @@ datetime_parse_full(struct datetime *date, const char *str, size_t len,
 	char c;
 	int sec_of_day = 0, nanosecond = 0;
 	int16_t tzindex = 0;
+	int32_t offset = 0;
 
 	n = dt_parse_iso_date(str, len, &dt);
 	if (n == 0)
@@ -337,19 +337,6 @@ datetime_parse_full(struct datetime *date, const char *str, size_t len,
 	if (len <= 0)
 		goto exit;
 
-	/* now we have parsed enough of date literal, and we are
-	 * ready to consume timezone suffix, if overridden
-	 */
-	time_t base = dt_epoch(dt) + sec_of_day - offset * 60;
-	ssize_t l;
-	if (tzsuffix != NULL) {
-		l = parse_tz_suffix(tzsuffix, strlen(tzsuffix), base,
-				    &tzindex, &offset);
-		if (l < 0)
-			return l;
-		goto exit;
-	}
-
 	if (*str == ' ') {
 		str++;
 		len--;
@@ -357,7 +344,8 @@ datetime_parse_full(struct datetime *date, const char *str, size_t len,
 	if (len <= 0)
 		goto exit;
 
-	l = parse_tz_suffix(str, len, base, &tzindex, &offset);
+	time_t base = dt_epoch(dt) + sec_of_day;
+	ssize_t l = parse_tz_suffix(str, len, base, &tzindex, &offset);
 	if (l < 0)
 		return l;
 	str += l;

--- a/src/lib/core/datetime.h
+++ b/src/lib/core/datetime.h
@@ -192,10 +192,6 @@ datetime_isdst(const struct datetime *date);
  * @param date output datetime value
  * @param str input text in relaxed ISO-8601 format (0-terminated)
  * @param len length of str buffer
- * @param tzsuffix timezone override, if you need to interpret
- *        date/time value as local. Pass NULL if you need to interpret it
- *        as UTC, or you provide meaningful suffix in the literal to be
- *        parsed.
  * @retval Upon successful completion returns length of accepted
  *         prefix substring. It's ok if there is some unaccepted trailer.
  *         Returns 0 only if text is not recognizable as date/time string.
@@ -203,8 +199,7 @@ datetime_isdst(const struct datetime *date);
  * @sa datetime_strptime()
  */
 ssize_t
-datetime_parse_full(struct datetime *date, const char *str, size_t len,
-		    const char *tzsuffix, int32_t offset);
+datetime_parse_full(struct datetime *date, const char *str, size_t len);
 
 /** Parse timezone suffix
  * @param str input text in relaxed ISO-8601 format (0-terminated)

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -913,9 +913,8 @@ local function datetime_parse_from(str, obj)
     end
     check_str_or_nil(fmt, 'datetime.parse()')
 
-    local offset
     if tzoffset ~= nil then
-        offset = get_timezone(tzoffset, 'tzoffset')
+        local offset = get_timezone(tzoffset, 'tzoffset')
         check_range(offset, -720, 840, 'tzoffset')
     end
 
@@ -923,16 +922,20 @@ local function datetime_parse_from(str, obj)
         check_str(tzname, 'datetime.parse()')
     end
 
+    local date, len
     if not fmt or fmt == '' or fmt == 'iso8601' or fmt == 'rfc3339' then
-        local date, len = datetime_parse_full(str)
-        -- Override timezone.
-        if date.tz == '' and date.tzoffset == 0 then
-            datetime_set(date, obj or {})
-        end
-        return date, tonumber(len)
+        date, len = datetime_parse_full(str)
     else
-        return datetime_parse_format(str, fmt)
+        date, len = datetime_parse_format(str, fmt)
     end
+
+    -- Override timezone, if it was not specified in a parsed
+    -- string.
+    if date.tz == '' and date.tzoffset == 0 then
+        datetime_set(date, { tzoffset = tzoffset, tz = tzname })
+    end
+
+    return date, len
 end
 
 --[[

--- a/src/lua/tnt_datetime.c
+++ b/src/lua/tnt_datetime.c
@@ -34,10 +34,9 @@ tnt_datetime_to_string(const struct datetime *date, char *buf, ssize_t len)
 }
 
 ssize_t
-tnt_datetime_parse_full(struct datetime *date, const char *str, size_t len,
-			const char *tzsuffix, int32_t offset)
+tnt_datetime_parse_full(struct datetime *date, const char *str, size_t len)
 {
-	return datetime_parse_full(date, str, len, tzsuffix, offset);
+	return datetime_parse_full(date, str, len);
 }
 
 ssize_t

--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -424,7 +424,7 @@ test:test("Formatting limits", function(test)
 end)
 
 test:test("Simple tests for parser", function(test)
-    test:plan(12)
+    test:plan(14)
     test:ok(date.parse("1970-01-01T01:00:00Z") ==
             date.new{year=1970, mon=1, day=1, hour=1, min=0, sec=0})
     test:ok(date.parse("1970-01-01T01:00:00Z", {format = 'iso8601'}) ==
@@ -445,6 +445,10 @@ test:test("Simple tests for parser", function(test)
             date.new{year=1970, mon=1, day=1, hour=1, min=0, sec=0, tzoffset=0})
     test:ok(date.parse("1970-01-01T01:00:00+01:00", {tzoffset = '+02:00'}) ==
             date.new{year=1970, mon=1, day=1, hour=1, min=0, sec=0, tzoffset=60})
+    test:ok(date.parse('1998-11-25', { format = '%Y-%m-%d', tzoffset = 180 }) ==
+            date.new({ year = 1998, month = 11, day = 25, tzoffset = 180 }))
+    test:ok(date.parse('1998', { format = '%Y', tzoffset = '+03:00' }) ==
+            date.new({ year = 1998, tzoffset = 180 }))
 
     test:ok(date.parse("1970-01-01T02:00:00Z") <
             date.new{year=1970, mon=1, day=1, hour=2, min=0, sec=1})

--- a/test/fuzz/datetime_parse_full_fuzzer.c
+++ b/test/fuzz/datetime_parse_full_fuzzer.c
@@ -15,7 +15,7 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	memcpy(buf, data, size);
 	buf[size] = '\0';
 	struct datetime date_expected;
-	datetime_parse_full(&date_expected, buf, size, NULL, 0);
+	datetime_parse_full(&date_expected, buf, size);
 	free(buf);
 
 	return 0;

--- a/test/unit/datetime.c
+++ b/test/unit/datetime.c
@@ -106,13 +106,12 @@ datetime_test(void)
 	struct datetime date_expected;
 
 	plan(497);
-	datetime_parse_full(&date_expected, sample, sizeof(sample) - 1,
-			    NULL, 0);
+	datetime_parse_full(&date_expected, sample, sizeof(sample) - 1);
 
 	for (index = 0; index < lengthof(tests); index++) {
 		struct datetime date;
 		size_t len = datetime_parse_full(&date, tests[index].str,
-						 tests[index].len, NULL, 0);
+						 tests[index].len);
 		is(len > 0, true, "correct parse_datetime return value "
 		   "for '%s'", tests[index].str);
 		is(date.epoch, date_expected.epoch,
@@ -134,7 +133,7 @@ datetime_test(void)
 		is(date.epoch, date_strp.epoch,
 		   "reversible seconds via datetime_strptime for '%s'", buff);
 		struct datetime date_parsed;
-		len = datetime_parse_full(&date_parsed, buff, len, NULL, 0);
+		len = datetime_parse_full(&date_parsed, buff, len);
 		is(len > 0, true, "correct datetime_parse_full return value "
 		   "for '%s'", buff);
 		is(date.epoch, date_parsed.epoch,


### PR DESCRIPTION
Orig PR: https://github.com/tarantool/tarantool/pull/8412