### PR TITLE
[Backport 2.11] datetime: introduce tz in datetime.parse()

### DIFF
--- a/changelogs/unreleased/gh-10420-introduce-tz-option-in-parse.md
+++ b/changelogs/unreleased/gh-10420-introduce-tz-option-in-parse.md
@@ -1,0 +1,3 @@
+## bugfix/datetime
+
+* Implemented the `tz` option in `datetime:parse()` (gh-10420).

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -922,6 +922,10 @@ local function datetime_parse_from(str, obj)
         check_str(tzname, 'datetime.parse()')
     end
 
+    if tzoffset and tzname then
+        error("ambiguous timezone: both tzoffset and tz are specified")
+    end
+
     local date, len
     if not fmt or fmt == '' or fmt == 'iso8601' or fmt == 'rfc3339' then
         date, len = datetime_parse_full(str)


### PR DESCRIPTION
Orig PR: https://github.com/tarantool/tarantool/pull/10526

----

There is an option tz in `datetime.parse()`, it was added in commit 3c40366172e3 ("datetime, lua: date parsing functions"). The option is not documented, and the commit message says that option `tz` is "Not yet implemented in this commit.".

The patch added tests and a doc request for this option. The behaviour of the option `tz` is the same as with option `tzoffset`:
- if timezone was not set in a parsed string then it is set to a value specified by `tz`
- if timezone was set in a parsed string then option `tz` is ignored

```
tarantool> date.parse("1970-01-01T01:00:00 MSK", { tz = 'Europe/Paris' })
---
- 1970-01-01T01:00:00 MSK
- 23
...

tarantool> date.parse("1970-01-01T01:00:00", { tz = 'Europe/Paris' })
---
- 1970-01-01T01:00:00 Europe/Paris
- 19
...
```

Follows up #6731
Fixes #10420

@TarantoolBot document
Title: Introduce option `tz` in `datetime.parse()`

The option `tz` is added in a function `datetime.parse()`. The option set timezone to a passed value if it was not set in a parsed string.

(cherry picked from commit c6bab23a6dc4f819167cbc78eb93859847a389ea)