### PR TITLE
iproto: make iproto resistant to misusage

### DIFF
--- a/changelogs/unreleased/gh_10155_make_iproto_resistant_to_misusage.md
+++ b/changelogs/unreleased/gh_10155_make_iproto_resistant_to_misusage.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a bug when a server could crash if a client sent an IPROTO replication
+  request without waiting for pending requests to complete (gh-10155).

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -920,6 +920,8 @@ struct iproto_connection
 	struct cmsg cancel_msg;
 	/** Set if connection is accepted in TX. */
 	bool is_established;
+	/** Number of iproto requests in flight. */
+	size_t request_count;
 };
 
 /** Returns a string suitable for logging. */
@@ -984,6 +986,8 @@ iproto_check_msg_max(struct iproto_thread *iproto_thread)
 static inline void
 iproto_msg_delete(struct iproto_msg *msg)
 {
+	assert(msg->connection->request_count > 0);
+	msg->connection->request_count--;
 	struct iproto_thread *iproto_thread = msg->connection->iproto_thread;
 	mempool_free(&msg->connection->iproto_thread->iproto_msg_pool, msg);
 	iproto_resume(iproto_thread);
@@ -1009,6 +1013,7 @@ iproto_msg_new(struct iproto_connection *con)
 	msg->stream = NULL;
 	msg->fiber = NULL;
 	rmean_collect(con->iproto_thread->rmean, IPROTO_REQUESTS, 1);
+	con->request_count++;
 	return msg;
 }
 
@@ -1019,6 +1024,7 @@ static inline void
 iproto_connection_feed_input(struct iproto_connection *con)
 {
 	assert(con->state == IPROTO_CONNECTION_ALIVE);
+	assert(!con->is_in_replication);
 	if (!ev_is_active(&con->input) && rlist_empty(&con->in_stop_list))
 		ev_feed_event(con->loop, &con->input, EV_CUSTOM);
 }
@@ -1030,6 +1036,7 @@ static inline void
 iproto_connection_feed_output(struct iproto_connection *con)
 {
 	assert(con->state == IPROTO_CONNECTION_ALIVE);
+	assert(!con->is_in_replication);
 	if (!ev_is_active(&con->output))
 		ev_feed_event(con->loop, &con->output, EV_CUSTOM);
 }
@@ -1283,6 +1290,13 @@ iproto_connection_input_buffer(struct iproto_connection *con)
 	return new_ibuf;
 }
 
+static inline bool
+iproto_is_flushed(struct iproto_connection *con)
+{
+	return con->wpos.obuf == con->wend.obuf &&
+		   con->wpos.svp.used == con->wend.svp.used;
+}
+
 /**
  * Check if message belongs to stream (stream_id != 0), and if it
  * is so create new stream or get stream from connection streams
@@ -1479,6 +1493,7 @@ iproto_connection_on_input(ev_loop *loop, struct ev_io *watcher,
 	assert(con->state == IPROTO_CONNECTION_ALIVE);
 	assert(rlist_empty(&con->in_stop_list));
 	assert(loop == con->loop);
+	assert(!con->is_in_replication);
 	/*
 	 * Throttle if there are too many pending requests,
 	 * otherwise we might deplete the fiber pool in tx
@@ -1562,6 +1577,11 @@ iproto_flush(struct iproto_connection *con)
 		return 0;
 	}
 	assert(begin->used < end->used);
+
+	ERROR_INJECT(ERRINJ_IPROTO_FLUSH_DELAY, {
+		return IOSTREAM_WANT_WRITE;
+	});
+
 	struct iovec iov[SMALL_OBUF_IOV_MAX+1];
 	struct iovec *src = obuf->iov;
 	int iovcnt = end->pos - begin->pos + 1;
@@ -1611,6 +1631,7 @@ iproto_connection_on_output(ev_loop *loop, struct ev_io *watcher,
 {
 	struct iproto_connection *con = (struct iproto_connection *) watcher->data;
 	assert(con->state == IPROTO_CONNECTION_ALIVE);
+	assert(!con->is_in_replication);
 	int rc;
 	while ((rc = iproto_flush(con)) <= 0) {
 		if (rc != 0) {
@@ -1675,6 +1696,7 @@ iproto_connection_new(struct iproto_thread *iproto_thread)
 	con->tx.is_push_pending = false;
 	con->tx.is_push_sent = false;
 	rmean_collect(iproto_thread->rmean, IPROTO_CONNECTIONS, 1);
+	con->request_count = 0;
 	return con;
 }
 
@@ -1787,9 +1809,11 @@ iproto_msg_prepare(struct iproto_msg *msg, const char **pos, const char *reqend)
 {
 	uint64_t stream_id;
 	uint32_t type;
+	bool is_replication_request;
 	bool request_is_not_for_stream;
 	bool request_is_only_for_stream;
-	struct iproto_thread *iproto_thread = msg->connection->iproto_thread;
+	struct iproto_connection *con = msg->connection;
+	struct iproto_thread *iproto_thread = con->iproto_thread;
 	mh_i32_t *handlers = iproto_thread->req_handlers;
 	mh_int_t handler;
 	struct cmsg_hop *route;
@@ -1819,14 +1843,27 @@ iproto_msg_prepare(struct iproto_msg *msg, const char **pos, const char *reqend)
 		goto error;
 	}
 
-	msg->connection->is_in_replication = type == IPROTO_JOIN ||
-					     type == IPROTO_FETCH_SNAPSHOT ||
-					     type == IPROTO_REGISTER ||
-					     type == IPROTO_SUBSCRIBE;
+	is_replication_request = msg->header.type == IPROTO_JOIN ||
+				 msg->header.type == IPROTO_FETCH_SNAPSHOT ||
+				 msg->header.type == IPROTO_REGISTER ||
+				 msg->header.type == IPROTO_SUBSCRIBE;
+
+	if (is_replication_request) {
+		/**
+		 * Before processing a replication request, ensure that all
+		 * writing requests have been completely flushed to obuf.
+		 */
+		if (con->request_count > 1 || !iproto_is_flushed(con)) {
+			diag_set(ClientError, ER_PROTOCOL, "Can't process "
+				 "join/subscribe while there are pending requests");
+			goto error;
+		}
+		con->is_in_replication = true;
+	}
 
 	handler = mh_i32_find(handlers, type, NULL);
 	if (handler != mh_end(handlers)) {
-		assert(!msg->connection->is_in_replication);
+		assert(!con->is_in_replication);
 		cmsg_init(&msg->base, iproto_thread->override_route);
 		return;
 	}

--- a/src/lib/core/errinj.h
+++ b/src/lib/core/errinj.h
@@ -103,6 +103,7 @@ struct errinj {
 	_(ERRINJ_IPROTO_DISABLE_ID, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_IPROTO_DISABLE_WATCH, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_IPROTO_FLIP_FEATURE, ERRINJ_INT, {.iparam = -1}) \
+	_(ERRINJ_IPROTO_FLUSH_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_IPROTO_PROCESS_REPLICATION_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_IPROTO_SET_VERSION, ERRINJ_INT, {.iparam = -1}) \
 	_(ERRINJ_IPROTO_TX_DELAY, ERRINJ_BOOL, {.bparam = false}) \

--- a/test/box-luatest/gh_10155_make_iproto_resistant_to_misusage_test.lua
+++ b/test/box-luatest/gh_10155_make_iproto_resistant_to_misusage_test.lua
@@ -1,0 +1,241 @@
+local lsocket = require('socket')
+local msgpack = require('msgpack')
+local server = require('luatest.server')
+local t = require('luatest')
+local uri = require('uri')
+
+local key = box.iproto.key
+local type = box.iproto.type
+
+local g = t.group('make-iproto-resistant-to-misusage')
+--
+-- gh-10155: make iproto resistant to misusage.
+--
+local wait_timeout = 60
+
+local function iproto_error_type(error_type)
+    return bit.bor(box.iproto.type.TYPE_ERROR, error_type)
+end
+
+local function socket_connect(server)
+    local u = uri.parse(server.net_box_uri)
+    local s = lsocket.tcp_connect(u.host, u.service)
+    t.assert_not_equals(s, nil)
+    -- Skip the greeting
+    s:read(box.iproto.GREETING_SIZE, wait_timeout)
+    return s
+end
+
+local function encode_map(map)
+    return msgpack.object(setmetatable(map, {__serialize = 'map'}))
+end
+
+local function setmap(map)
+    return setmetatable(map, {__serialize = 'map'})
+end
+
+local function socket_write(s, header, body)
+    return s:write(box.iproto.encode_packet(header, body))
+end
+
+local function write_ok(s, body)
+    local header = {
+        [key.REQUEST_TYPE] = box.iproto.type.OK,
+        [key.SYNC] = 1,
+    }
+    if body == nil then
+        body = {}
+    end
+    return socket_write(s, header, body)
+end
+
+local function write_eval(s, expr)
+    local key = box.iproto.key
+    local header = {
+        [key.REQUEST_TYPE] = box.iproto.type.EVAL,
+        [key.SYNC] = 1,
+    }
+    local body = {
+        [key.EXPR] = expr,
+        [key.TUPLE] = {},
+    }
+    return s:write(box.iproto.encode_packet(header, body))
+end
+
+local function write_fetch_snapshot(s)
+    local header = {
+        [key.REQUEST_TYPE] = box.iproto.type.FETCH_SNAPSHOT,
+        [key.SYNC] = 1,
+    }
+    local body = setmap({})
+    return socket_write(s, header, body)
+end
+
+local function write_subscribe(s, uuid, replicaset_uuid, is_anon)
+    local header = {
+        [key.REQUEST_TYPE] = box.iproto.type.SUBSCRIBE,
+        [key.SYNC] = 1,
+    }
+    local body = {
+        [key.REPLICASET_UUID] = replicaset_uuid,
+        [key.INSTANCE_UUID] = uuid,
+        [key.VCLOCK] = encode_map({}),
+        [key.REPLICA_ANON] = is_anon,
+    }
+    return socket_write(s, header, body)
+end
+
+local function socket_read(s)
+    local size_mp = s:read(5, wait_timeout)
+    t.assert_equals(#size_mp, 5)
+    local size = msgpack.decode(size_mp)
+    local response = s:read(size, wait_timeout)
+    t.assert_equals(#response, size)
+    return box.iproto.decode_packet(size_mp .. response)
+end
+
+-- Read all data sent in FETCH_SNAPSHOT response
+local function read_snapshot(s)
+    local h, _ = socket_read(s)
+    local request_type = h[key.REQUEST_TYPE]
+    while request_type == type.INSERT or request_type == type.RAFT_PROMOTE do
+        h, _ = socket_read(s)
+        request_type = h[key.REQUEST_TYPE]
+    end
+    t.assert_equals(h.REQUEST_TYPE, type.OK)
+end
+
+g.before_each(function(g)
+    g.server = server:new()
+    g.server:start()
+    g.server:exec(function()
+        box.schema.space.create('test')
+        box.space.test:create_index('pk')
+        for i = 1, 100 do
+            box.space.test:replace{i}
+        end
+    end)
+    g.s = socket_connect(g.server)
+end)
+
+g.after_each(function(g)
+    g.s:close()
+    g.server:stop()
+end)
+
+-- The case sends a dummy OK before subscribe
+g.test_iproto_crash_on_subscribe = function(g)
+    local uuid = require('uuid').str()
+    local replicaset_uuid = g.server:eval('return box.info.replicaset.uuid')
+    -- Write OK but do not read response before writing subscribe
+    write_ok(g.s)
+    write_subscribe(g.s, uuid, replicaset_uuid, true)
+    local request_type = socket_read(g.s)[key.REQUEST_TYPE]
+    t.assert_equals(request_type,
+        iproto_error_type(box.error.UNKNOWN_REQUEST_TYPE))
+    request_type = socket_read(g.s)[key.REQUEST_TYPE]
+    t.assert(request_type == type.OK or request_type ==
+        iproto_error_type(box.error.PROTOCOL))
+end
+
+-- The test is designed to check the behavior when, at the time of receiving a
+-- replication request, the responses to all previous requests are written to
+-- obuf but not flushed to the socket
+g.test_iproto_crash_on_subscribe_flush_delay = function(g)
+    t.tarantool.skip_if_not_debug()
+    local uuid = require('uuid').str()
+    local replicaset_uuid = g.server:eval('return box.info.replicaset.uuid')
+    -- You can't use lustest.server:exec here because it will block
+    write_eval(g.s, "box.error.injection.set(" ..
+        "'ERRINJ_IPROTO_FLUSH_DELAY', true)")
+    -- Several requests in a row to pretend to be a non-blocking client and
+    -- provoke iproto_connection_feed_input, so that subscribe is immediately
+    -- read
+    for _ = 1, 3 do
+        write_ok(g.s)
+    end
+    -- A short pause so that the packages do not end up in one batch and all
+    -- responses have time to be written in obuf
+    require('fiber').sleep(0.1)
+    write_subscribe(g.s, uuid, replicaset_uuid, true)
+    -- A short pause so that the tx thread has time to write the response to
+    -- the subscribe request to the socket
+    require('fiber').sleep(0.1)
+    g.server:exec(function()
+        box.error.injection.set('ERRINJ_IPROTO_FLUSH_DELAY', false)
+    end)
+    -- Read IPROTO_EVAL response
+    local request_type = socket_read(g.s)[key.REQUEST_TYPE]
+    t.assert(request_type == type.OK)
+    for _ = 1, 3 do
+        request_type = socket_read(g.s)[key.REQUEST_TYPE]
+        t.assert_equals(request_type,
+            iproto_error_type(box.error.UNKNOWN_REQUEST_TYPE))
+    end
+    request_type = socket_read(g.s)[key.REQUEST_TYPE]
+    t.assert(request_type == type.OK or request_type ==
+        iproto_error_type(box.error.PROTOCOL))
+end
+
+-- The case sends dummy OKs before subscribe
+g.test_iproto_crash_on_subscribe_spam_ok = function(g)
+    local uuid = require('uuid').str()
+    local replicaset_uuid = g.server:eval('return box.info.replicaset.uuid')
+    -- Write OKs but do not read responses before writing subscribe
+    for _ = 1, 100 do
+        write_ok(g.s)
+    end
+    write_subscribe(g.s, uuid, replicaset_uuid, true)
+    local request_type
+    for _ = 1, 100 do
+        request_type = socket_read(g.s)[key.REQUEST_TYPE]
+        t.assert_equals(request_type,
+            iproto_error_type(box.error.UNKNOWN_REQUEST_TYPE))
+    end
+    request_type = socket_read(g.s)[key.REQUEST_TYPE]
+    t.assert(request_type == type.OK or request_type ==
+        iproto_error_type(box.error.PROTOCOL))
+end
+
+-- The case simulates a situation where the user of anonymous replication
+-- simply sent IPROTO_OK back after FETCH_SNAPSHOT by mistake (did not know
+-- that Tarantool doesn't expect a reply on FETCH_SNAPSHOT)
+g.test_iproto_crash_fetch_snapshot_subscribe = function(g)
+    local uuid = require('uuid').str()
+    local replicaset_uuid = g.server:eval('return box.info.replicaset.uuid')
+    write_fetch_snapshot(g.s)
+    local request_type = socket_read(g.s)[key.REQUEST_TYPE]
+    t.assert_equals(request_type, type.OK)
+    read_snapshot(g.s)
+    -- Write OK but do not read response before writing subscribe
+    write_ok(g.s)
+    write_subscribe(g.s, uuid, replicaset_uuid, true)
+    request_type = socket_read(g.s)[key.REQUEST_TYPE]
+    t.assert_equals(request_type,
+        iproto_error_type(box.error.UNKNOWN_REQUEST_TYPE))
+    request_type = socket_read(g.s)[key.REQUEST_TYPE]
+    t.assert(request_type == type.OK or request_type ==
+        iproto_error_type(box.error.PROTOCOL))
+end
+
+-- The same as above, but additionally forgot to pass is_anon option to
+-- subscribe
+g.test_iproto_crash_fetch_snapshot_subscribe_not_anon = function(g)
+    local uuid = require('uuid').str()
+    local replicaset_uuid = g.server:eval('return box.info.replicaset.uuid')
+    write_fetch_snapshot(g.s)
+    local request_type = socket_read(g.s)[key.REQUEST_TYPE]
+    t.assert_equals(request_type, type.OK)
+    read_snapshot(g.s)
+    -- Write OK but do not read response before writing subscribe
+    write_ok(g.s)
+    -- Subscribe as not anon replica
+    write_subscribe(g.s, uuid, replicaset_uuid)
+    request_type = socket_read(g.s)[key.REQUEST_TYPE]
+    t.assert_equals(request_type,
+        iproto_error_type(box.error.UNKNOWN_REQUEST_TYPE))
+    request_type = socket_read(g.s)[key.REQUEST_TYPE]
+    t.assert(request_type ==
+        iproto_error_type(box.error.TOO_EARLY_SUBSCRIBE) or request_type ==
+        iproto_error_type(box.error.PROTOCOL))
+end


### PR DESCRIPTION
Fixed an issue when the tarantool could be easily crashed using iproto incorrectly, not according to the protocol.

The problem seems to be unsynchronized multi-threaded communication with the socket. Hence the large number of different backtraces and assertions. To reproduce this, instead of `IPROTO_OK` you can use anything whose route looks like ->main->iproto (looks like all messages are going this way now), for example, I checked this with `IPROTO_PING`. A bad execution scenario is shown in the picture:
![iproto_misusage_championship](https://github.com/user-attachments/assets/ee6c3338-5999-4dd3-b7ba-5a69bfe0e659)
More specifically, the problem is that when `tx_process_replication` is executed in `main`, it does not know anything about the c-messages that are queued at the "net_x" endpoint in `iproto`. In `iproto_enqueue_batch` we call `ev_io_stop` on both `input`/`output` watchers, which prevents the `EV_READ`/`EV_WRITE` events from firing (and also clears pending events), but this does not help against `ev_feed_event`, which is called in the cmsg callback queued in the `iproto` thread.

Closes #10155

NO_DOC=bugfix