### PR TITLE
vinyl: fix cache corruption on skipping unconfirmed tuple

### DIFF
--- a/changelogs/unreleased/gh-10558-fix-vinyl-cache-corruption-on-skipping-unconfirmed-tuple.md
+++ b/changelogs/unreleased/gh-10558-fix-vinyl-cache-corruption-on-skipping-unconfirmed-tuple.md
@@ -1,0 +1,6 @@
+## bugfix/vinyl
+
+* Fixed a bug when `index.select()` executed in the `read-confirmed`
+  transaction isolation mode (default for read-only transactions) could corrupt
+  the tuple cache by creating a chain bypassing an unconfirmed tuple. The bug
+  could lead to a crash or invalid query results (gh-10558).

--- a/src/box/vy_point_lookup.c
+++ b/src/box/vy_point_lookup.c
@@ -134,6 +134,9 @@ vy_point_lookup_scan_mems(struct vy_lsm *lsm, struct vy_tx *tx,
 					     &min_skipped_plsn) != 0)
 			return -1;
 	}
+	/*
+	 * Switch to read view if we skipped a prepared statement.
+	 */
 	if (tx != NULL && min_skipped_plsn != INT64_MAX) {
 		if (vy_tx_send_to_read_view(tx, min_skipped_plsn) != 0)
 			return -1;

--- a/test/vinyl-luatest/gh_10558_iterator_restore_after_unconfirmed_tuple_test.lua
+++ b/test/vinyl-luatest/gh_10558_iterator_restore_after_unconfirmed_tuple_test.lua
@@ -1,0 +1,88 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        box.error.injection.set('ERRINJ_VY_READ_PAGE_DELAY', false)
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+g.test_iterator_restore_after_unconfirmed_tuple = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+
+        local s = box.schema.space.create('test', {engine = 'vinyl'})
+        s:create_index('pk')
+        s:insert({1})
+        s:insert({10})
+        box.snapshot()
+
+        -- Add chain [-inf, 1] to the cache.
+        t.assert_equals(s:select({}, {limit = 1}), {{1}})
+
+        -- Make index.select() block on disk read after fetching [1]
+        -- from the cache.
+        box.error.injection.set('ERRINJ_VY_READ_PAGE_DELAY', true)
+
+        local f1 = fiber.new(box.atomic, {txn_isolation = 'read-committed'},
+                             s.select, s, {}, {fullscan = true})
+        f1:set_joinable(true)
+        fiber.yield()
+
+        local f2 = fiber.new(box.atomic, {txn_isolation = 'read-confirmed'},
+                             s.select, s, {}, {fullscan = true})
+        f2:set_joinable(true)
+        fiber.yield()
+
+        -- Insert a new unconfirmed tuple into the memory level to make
+        -- index.select() restore the memory iterator after disk read.
+        -- The firber reading committed tuples should restore at [5].
+        -- The fiber reading confirmed tuples should skip [5] and not
+        -- add chain [1, 10] to the cache because of it.
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+        local f3 = fiber.new(s.replace, s, {5})
+        f3:set_joinable(true)
+        fiber.yield()
+
+        -- Resume iteration and check the results.
+        box.error.injection.set('ERRINJ_VY_READ_PAGE_DELAY', false)
+        local committed = {{1}, {5}, {10}}
+        local confirmed = {{1}, {10}}
+        t.assert_equals({f1:join(10)}, {true, committed})
+        t.assert_equals({f2:join(10)}, {true, confirmed})
+
+        t.assert_equals(box.atomic({txn_isolation = 'read-committed'},
+                                   s.select, s, {}, {fullscan = true}),
+                        committed)
+        t.assert_equals(box.atomic({txn_isolation = 'read-confirmed'},
+                                   s.select, s, {}, {fullscan = true}),
+                        confirmed)
+
+        -- Confirm the pending tuple and check the results.
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        f3:join()
+
+        t.assert_equals(box.atomic({txn_isolation = 'read-committed'},
+                                   s.select, s, {}, {fullscan = true}),
+                        committed)
+        t.assert_equals(box.atomic({txn_isolation = 'read-confirmed'},
+                                   s.select, s, {}, {fullscan = true}),
+                        committed)
+    end)
+end


### PR DESCRIPTION
The tuple cache doesn't store historical data. It stores only the newest tuple versions, including prepared but not yet confirmed (committed but not written to WAL) tuples. This means that transactions sent to a read view shouldn't add any new chains to the cache because such a chain may bypass a tuple invisible from the read view.

A transaction may be sent to a read view in two cases:

 1. If some other transactions updates data read by it.
 2. If the transaction is operating in the 'read-confirmed' isolation mode and skips an unconfirmed tuple while scanning the memory level. This was added in commit 588170a77c9a ("vinyl: implement transaction isolation levels").

The second point should be checked by the read iterator itself, and it is indeed for the standard case when we scan the memory level before reading the disk. However, there's the second case: if some other tuples are inserted into the memory level while the read iterator was waiting for a disk read to complete, it rescans the memory level and may skip a new unconfirmed tuple that wasn't there the first time we scanned the memory level. Currently, if this happens, it won't send itself to a read view and may corrupt the cache by inserting a chain that skips over the unconfirmed tuple. Fix this by adding the missing check.

While we are at it, let's simplify the code a bit by moving the check inside `vy_read_iterator_scan_mem()`. It's okay because sending to a read view a transaction that's already in the read view is handled correctly by `vy_tx_send_to_read_view()`.

Closes #10558