### PR TITLE
box: check fiber slice in generic implementation of index count

### DIFF
--- a/changelogs/unreleased/gh-10553-check-fiber-slice-in-vinyl-index-count.md
+++ b/changelogs/unreleased/gh-10553-check-fiber-slice-in-vinyl-index-count.md
@@ -1,0 +1,4 @@
+## bugfix/vinyl
+
+* Added a fiber slice check to `index.count()` to prevent it from blocking
+  for too long while counting tuples in a space stored in memory (gh-10553).

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -924,8 +924,12 @@ generic_index_count(struct index *index, enum iterator_type type,
 	int rc = 0;
 	size_t count = 0;
 	struct tuple *tuple = NULL;
-	while ((rc = iterator_next(it, &tuple)) == 0 && tuple != NULL)
+	while ((rc = iterator_next(it, &tuple)) == 0 && tuple != NULL) {
+		rc = box_check_slice();
+		if (rc != 0)
+			break;
 		++count;
+	}
 	iterator_delete(it);
 	if (rc < 0)
 		return rc;

--- a/test/vinyl-luatest/gh_10553_index_count_fiber_slice_test.lua
+++ b/test/vinyl-luatest/gh_10553_index_count_fiber_slice_test.lua
@@ -1,0 +1,46 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+        box.snapshot()
+    end)
+end)
+
+g.test_index_count_fiber_slice = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+
+        local s = box.schema.space.create('test', {engine = 'vinyl'})
+        s:create_index('pk')
+        s:create_index('sk', {unique = false, parts = {2, 'unsigned'}})
+
+        box.begin()
+        for i = 1, 100 * 1000 do
+            s:replace({i, i * 2})
+            if i % 1000 == 0 then
+                box.commit()
+                box.begin()
+            end
+        end
+        box.commit()
+
+        fiber.self():set_max_slice(0.01)
+        t.assert_error_covers({type = 'FiberSliceIsExceeded'},
+                              s.index.sk.count, s.index.sk)
+    end)
+end


### PR DESCRIPTION
`index.count()` may hang for too long in Vinyl if a substantial consecutive hunk of the space is stored in memory. Let's add a fiber slice check to it to prevent it from blocking the TX thread for too long.

Closes #10553