### PR TITLE
[backport 2.11] build: curl option BUILD_MISC_DOCS set OFF

### DIFF
--- a/changelogs/unreleased/libcurl-doc-option-fix.md
+++ b/changelogs/unreleased/libcurl-doc-option-fix.md
@@ -1,0 +1,3 @@
+## bugfix/build
+
+* The `BUILD_MISC_DOCS` curl option is now disabled by default (gh-10576).

--- a/cmake/BuildLibCURL.cmake
+++ b/cmake/BuildLibCURL.cmake
@@ -43,6 +43,7 @@ macro(curl_build)
 
     # Let's disable building documentation for curl to save build time.
     list(APPEND LIBCURL_CMAKE_FLAGS "-DENABLE_CURL_MANUAL=OFF")
+    list(APPEND LIBCURL_CMAKE_FLAGS "-DBUILD_MISC_DOCS=OFF")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DBUILD_LIBCURL_DOCS=OFF")
 
     # Setup use of openssl, use the same OpenSSL library


### PR DESCRIPTION
*(This is a backport of PR #10597 to `release/2.11`, a future `2.11.5` release.)*

----

Curl option BUILD_MISC_DOCS builds misc man pages and set ON by default. Other documentation building options such as ENABLE_CURL_MANUAL and BUILD_LIBCURL_DOCS was set OFF in BuildLibCurl.cmake. I suppose this option has to be added in commit 7192bf667917 ("third_party: update libcurl from 8.7.0 to 8.8.0+patches") and set OFF.

Follows up #9885