### PR TITLE
schema: broadcast persistent schema version in box.status

### DIFF
--- a/changelogs/unreleased/gh-10546-schema-version-broadcast.md
+++ b/changelogs/unreleased/gh-10546-schema-version-broadcast.md
@@ -1,0 +1,3 @@
+## feature/core
+
+* Added the `dd_version` field to the `box.status` system event (gh-10546).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -4152,6 +4152,7 @@ on_commit_dd_version(struct trigger *trigger, void * /* event */)
 	struct fiber *fiber = data->fiber;
 	if (fiber != NULL)
 		fiber_wakeup(fiber);
+	box_broadcast_status();
 	return 0;
 }
 

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -297,12 +297,6 @@ static void
 box_storage_init(void);
 
 /**
- * Broadcast the current instance status
- */
-static void
-box_broadcast_status(void);
-
-/**
  * A timer to broadcast the updated vclock. Doing this on each vclock update
  * would be too expensive.
  */
@@ -6022,18 +6016,20 @@ box_broadcast_id(void)
 	assert((size_t)(w - buf) < sizeof(buf));
 }
 
-static void
+void
 box_broadcast_status(void)
 {
 	char buf[1024];
 	char *w = buf;
-	w = mp_encode_map(w, 3);
+	w = mp_encode_map(w, 4);
 	w = mp_encode_str0(w, "is_ro");
 	w = mp_encode_bool(w, box_is_ro());
 	w = mp_encode_str0(w, "is_ro_cfg");
 	w = mp_encode_bool(w, cfg_geti("read_only"));
 	w = mp_encode_str0(w, "status");
 	w = mp_encode_str0(w, box_status());
+	w = mp_encode_str0(w, "dd_version");
+	w = mp_encode_str0(w, version_id_to_string(dd_version_id));
 
 	box_broadcast("box.status", strlen("box.status"), buf, w);
 

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -870,6 +870,12 @@ void
 box_broadcast_id(void);
 
 /**
+ * Broadcast the status of the instance.
+ */
+void
+box_broadcast_status(void);
+
+/**
  * Broadcast the current election state of RAFT machinery
  */
 void

--- a/test/box-luatest/builtin_events_test.lua
+++ b/test/box-luatest/builtin_events_test.lua
@@ -72,6 +72,8 @@ g.test_box_status = function(cg)
     local watcher = c:watch('box.status',
                             function(name, state)
                                 t.assert_equals(name, 'box.status')
+                                -- Tested in the box-luatest/upgrade_to_3_0_0.
+                                state.dd_version = nil
                                 result = state
                                 result_no = result_no + 1
                             end)

--- a/test/box-luatest/upgrade_to_3_0_0_test.lua
+++ b/test/box-luatest/upgrade_to_3_0_0_test.lua
@@ -1,30 +1,46 @@
 local server = require('luatest.server')
+local replica_set = require('luatest.replica_set')
 local t = require('luatest')
 
 local g = t.group("Upgrade from 2.11.0")
 
 g.before_all(function(cg)
-    cg.server = server:new({
-        datadir = 'test/box-luatest/upgrade/2.11.0',
+    cg.replica_set = replica_set:new{}
+    cg.master = cg.replica_set:build_and_add_server({
+        alias = 'master',
+        datadir = 'test/box-luatest/upgrade/2.11.0/replicaset/instance-001'
     })
-    cg.server:start()
+    cg.replica = cg.replica_set:build_and_add_server({
+        alias = 'replica',
+        datadir = 'test/box-luatest/upgrade/2.11.0/replicaset/instance-002',
+        box_cfg = {
+            read_only = true,
+            replication = cg.master.net_box_uri,
+        },
+    })
+    cg.replica_set:start()
 end)
 
 g.after_all(function(cg)
-    cg.server:drop()
+    cg.replica_set:drop()
 end)
 
 g.after_each(function(cg)
-    cg.server:exec(function()
+    cg.master:exec(function()
         box.schema.downgrade('2.11.0')
+        box.snapshot()
+    end)
+    cg.replica:wait_for_vclock_of(cg.master)
+    cg.replica:exec(function()
         box.snapshot()
     end)
 end)
 
 g.test_new_replicaset_uuid_key = function(cg)
-    cg.server:exec(function()
+    cg.master:exec(function()
         t.assert_equals(box.space._schema:get{'version'}, {'version', 2, 11, 0})
         box.schema.upgrade()
+
         local _schema = box.space._schema
         t.assert_equals(_schema:get{'cluster'}, nil)
         t.assert_equals(_schema:get{'replicaset_uuid'}.value,
@@ -33,7 +49,7 @@ g.test_new_replicaset_uuid_key = function(cg)
 end
 
 g.test_ddl_is_forbidden = function(cg)
-    cg.server:exec(function()
+    cg.master:exec(function()
         t.assert_equals(box.space._schema:get{'version'}, {'version', 2, 11, 0})
         -- DDL is prohibited before 2.11.1.
         local msg = "DDL_BEFORE_UPGRADE requires schema version 2.11.1"
@@ -43,6 +59,49 @@ g.test_ddl_is_forbidden = function(cg)
 
         box.schema.upgrade()
     end)
+end
+
+--
+-- gh-10546: check, that dd_version is properly broadcasted, when
+-- schema version is changed.
+--
+g.test_dd_version_broadcast = function(cg)
+    local function set_dd_version_watcher()
+        local mkversion = require('internal.mkversion')
+        rawset(_G, 'watcher_counter', 0)
+        rawset(_G, 'watcher_version', {})
+        rawset(_G, 'watcher', box.watch('box.status', function(_, status)
+            t.assert_not_equals(status.dd_version, nil)
+            _G.watcher_version = mkversion.from_string(status.dd_version)
+            _G.watcher_counter = _G.watcher_counter + 1
+        end))
+    end
+
+    local function clear_dd_version_watcher()
+        _G.watcher:unregister()
+    end
+
+    cg.master:exec(set_dd_version_watcher)
+    cg.replica:exec(set_dd_version_watcher)
+
+    cg.master:exec(function()
+        local mkversion = require('internal.mkversion')
+        local old_counter = _G.watcher_counter
+        box.schema.upgrade()
+        t.helpers.retrying({}, function()
+            t.assert_gt(_G.watcher_counter, old_counter)
+        end)
+        t.assert_equals(_G.watcher_version, mkversion.get_latest())
+    end)
+
+    cg.replica:wait_for_vclock_of(g.master)
+    cg.replica:exec(function()
+        local mkversion = require('internal.mkversion')
+        t.assert_equals(_G.watcher_version, mkversion.get_latest())
+    end)
+
+    cg.master:exec(clear_dd_version_watcher)
+    cg.replica:exec(clear_dd_version_watcher)
 end
 
 local g_2_11_1 = t.group("Upgrade from 2.11.1")


### PR DESCRIPTION
https://github.com/tarantool/tarantool/issues/10520 will allow DDL before schema is upgraded
in order to simplify the upgrade process. However, some DDL will
remain forbidden until box.schema.upgrade is called, e.g. creating
persistent triggers when upgrading to 3.0.0.

In order to make writing upgrade triggers easier this commit adds
new field to the box.status system event: dd_version. This should
not be confused with schema.version value, as the latter shows, whether
the database schema (e.g. creating space) was updated.
box.status.dd_version on the other side is the value of the
persistent schema from box.space._schema['version'].

Without box.status.dd_version user has to set on_replace trigger for
box.space._schema, which will check version and rw state, after which
trigger will send it further. The problem with this approach is the fact,
that it requires synchronization of two changing states: dd schema
version and rw state, which is difficult to achieve.

With box.status.dd_version user has to just set watcher, which
checks !status.is_ro and status.dd_version >= needed one.

Closes https://github.com/tarantool/tarantool/issues/10546