### PR TITLE
ci: fix module API build/publish job

### DIFF
--- a/.github/workflows/publish-module-api-doc.yaml
+++ b/.github/workflows/publish-module-api-doc.yaml
@@ -52,6 +52,12 @@ jobs:
       - name: Setup Doxygen
         run: sudo apt install -y doxygen
 
+      # Not a full list of dependencies. Just ones that are
+      # required to successful configuration stage (cmake) and
+      # missed in the runner's environment.
+      - name: Setup tarantool dependencies
+        run: sudo apt install -y libreadline-dev
+
       - name: Build module API documentation using Doxygen
         run: |
             cmake .
@@ -60,7 +66,7 @@ jobs:
             doxygen Doxyfile.API
 
       - name: Publish generated API documentation to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4.4.0
+        uses: JamesIves/github-pages-deploy-action@v4.6.6
         with:
           folder: doc/
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
The `ubuntu-latest` image is now `ubuntu-24.04`, see https://github.blog/changelog/2024-09-25-actions-new-images-and-ubuntu-latest-changes/. The job fails on this image with the following error:

```
CMake Error at /usr/local/share/cmake-3.30/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find Readline (missing: READLINE_INCLUDE_DIR READLINE_LIBRARY)
```

It seems, the libreadline-dev package is missing. Let's install it.

Also, update a version of the publishing action to the latest at the moment. I didn't perform any check, but I guess that a new version of NodeJS is needed and the latest action version has better support of it.