### PR TITLE
ci: fix module API publish job (again)

### DIFF
--- a/.github/workflows/publish-module-api-doc.yaml
+++ b/.github/workflows/publish-module-api-doc.yaml
@@ -66,7 +66,7 @@ jobs:
             doxygen Doxyfile.API
 
       - name: Publish generated API documentation to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4.6.6
+        uses: JamesIves/github-pages-deploy-action@v4.6.4
         with:
           folder: doc/
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
The new version of the publishing action leads to the following error:

```
Error: File not found: '/home/runner/work/_actions/JamesIves/github-pages-deploy-action/v4.6.6/lib/main.js'
```

Let's revert it to v4.6.4 (because v4.6.5 change was reverted in v4.6.6).

See also JamesIves/github-pages-deploy-action#1697