### PR TITLE
memtx: itroduce `exhaust_after` and `step_count` tree iterator members

### DIFF
--- a/src/box/index.h
+++ b/src/box/index.h
@@ -751,7 +751,7 @@ struct index_read_view_iterator_base {
 };
 
 /** Size of the index_read_view_iterator struct. */
-#define INDEX_READ_VIEW_ITERATOR_SIZE 80
+#define INDEX_READ_VIEW_ITERATOR_SIZE 88
 
 static_assert(sizeof(struct index_read_view_iterator_base) <=
 	      INDEX_READ_VIEW_ITERATOR_SIZE,


### PR DESCRIPTION
The EQ/REQ tree iterators in the memtx read view perform comparison of the search key with each next tuple using the `key_data` member. The thing is, since a read view of a tree is immutable, we can just perform the second lookup to find the last tuple and only compare tuple pointers on each step. This will reduce the total overhead of iteration over tuples with huge field count, because the equal key comparison is expensive for them in read views now since we can't use the tuple format.

The first step towards this is introducing a new `exhaust_after` field to be used instead of the `key_data` in case of partial key search, and `step_count` for heuristics on whether to optimize the iteration or not.

Part of tarantool/tarantool-ee#921

NO_DOC=internal
NO_TEST=internal
NO_CHANGELOG=internal