### PR TITLE
[backport 2.11] ci: fix module API build/publish job

### DIFF
--- a/.github/workflows/publish-module-api-doc.yaml
+++ b/.github/workflows/publish-module-api-doc.yaml
@@ -66,7 +66,7 @@ jobs:
             doxygen Doxyfile.API
 
       - name: Publish generated API documentation to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4.6.6
+        uses: JamesIves/github-pages-deploy-action@v4.6.4
         with:
           folder: doc/
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/publish-module-api-doc.yaml
+++ b/.github/workflows/publish-module-api-doc.yaml
@@ -52,6 +52,12 @@ jobs:
       - name: Setup Doxygen
         run: sudo apt install -y doxygen
 
+      # Not a full list of dependencies. Just ones that are
+      # required to successful configuration stage (cmake) and
+      # missed in the runner's environment.
+      - name: Setup tarantool dependencies
+        run: sudo apt install -y libreadline-dev
+
       - name: Build module API documentation using Doxygen
         run: |
             cmake .
@@ -60,7 +66,7 @@ jobs:
             doxygen Doxyfile.API
 
       - name: Publish generated API documentation to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4.4.0
+        uses: JamesIves/github-pages-deploy-action@v4.6.6
         with:
           folder: doc/
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
*(This is a backport of PR #10624 and PR #10625 to `release/2.11`.)*

The second commit fixes the publication step, which is performed only on the `master` branch. In fact, it is not necessary, but left here to minimize a difference in workflows with `master`.

----

The `ubuntu-latest` image is now `ubuntu-24.04`, see https://github.blog/changelog/2024-09-25-actions-new-images-and-ubuntu-latest-changes/. The job fails on this image with the following error:

```
CMake Error at /usr/local/share/cmake-3.30/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find Readline (missing: READLINE_INCLUDE_DIR READLINE_LIBRARY)
```

It seems, the libreadline-dev package is missing. Let's install it.

Also, update a version of the publishing action to `v4.6.4`. I guess that a new version of NodeJS is needed and the newer action version has better support of it.