### PR TITLE
net_box: fix a crash when a trigger deletes itself

### DIFF
--- a/changelogs/unreleased/gh-10622-net-box-trigger-crash-on-self-delete.md
+++ b/changelogs/unreleased/gh-10622-net-box-trigger-crash-on-self-delete.md
@@ -1,0 +1,3 @@
+## bugfix/lua/netbox
+
+* Fixed a crash when `net.box` triggers deleted themselves (gh-10622).

--- a/test/box-luatest/gh_10622_net_box_trigger_crash_on_self_delete_test.lua
+++ b/test/box-luatest/gh_10622_net_box_trigger_crash_on_self_delete_test.lua
@@ -1,0 +1,52 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+-- Reproducer from the issue
+g.test_net_box_trigger_crash_on_self_delete = function()
+    g.server:exec(function(uri)
+        local f = function(conn) conn:on_connect{name = 'test'} end
+        local net = require('net.box')
+        local c = net.connect(uri, {wait_connected = false})
+        c:on_connect{func = f, name = 'test'}
+        t.assert_not(c:is_connected())
+        t.assert(c:wait_connected(10))
+    end, {g.server.net_box_uri})
+end
+
+-- Check if Lua trigger list doesn't crash on self delete
+g.test_trigger_list_crash_on_self_delete = function()
+    g.server:exec(function()
+        local trigger_list = require('internal.trigger').new()
+        local function f()
+            trigger_list(nil, f)
+        end
+        trigger_list(f)
+        trigger_list:run()
+    end)
+end
+
+-- Check if Lua trigger list doesn't crash when one trigger
+-- clears the list
+g.test_trigger_list_crash_on_list_clear = function()
+    g.server:exec(function()
+        local trigger_list = require('internal.trigger').new()
+        local function f()
+            trigger_list(nil, nil, 't1')
+            trigger_list(nil, nil, 't2')
+        end
+        trigger_list(f, nil, 't1')
+        trigger_list(f, nil, 't2')
+        trigger_list:run()
+    end)
+end


### PR DESCRIPTION
In https://github.com/tarantool/tarantool/commit/6d882740f3e56b62527fb9a606b748a138090014 we rewrote Lua module `internal.trigger` that is used in
`net.box` and possibly some external modules. Old implementation held
all triggers in a Lua table, so deleting a trigger on the fly wasn't a
problem. Now we store all triggers in a list and simply iterate over it
when the triggers are fired, so the trigger list became non-resistent to
modifications on the fly. In order to fix it, let's simply use
`trigger_run` - it is resistant to the list modifications.

Closes #10622