### PR TITLE
third_party: fix `nanoarrow` install directory

### DIFF
--- a/cmake/BuildNanoarrow.cmake
+++ b/cmake/BuildNanoarrow.cmake
@@ -1,7 +1,7 @@
 # A macro to build the bundled nanoarrow library
 macro(nanoarrow_build)
     set(NANOARROW_SOURCE_DIR ${PROJECT_SOURCE_DIR}/third_party/arrow/nanoarrow/)
-    set(NANOARROW_INSTALL_DIR ${PROJECT_BINARY_DIR}/third_party/nanoarrow/)
+    set(NANOARROW_INSTALL_DIR ${PROJECT_BINARY_DIR}/build/nanoarrow/)
     set(NANOARROW_INCLUDE_DIR ${NANOARROW_INSTALL_DIR}/include/)
 
     set(NANOARROW_CORE_LIBRARY ${NANOARROW_INSTALL_DIR}/lib/libnanoarrow.a)


### PR DESCRIPTION
Currently, in case of in-source build, the nanoarrow library is compiled in `<tarantool_git>/third_party/nanoarrow/`, although it is better to compile it in `<tarantool_git>/build/nanoarrow/`, because the `build` directory is ignored by `.gitignore`.

Follow-up #10508