### PR TITLE
test: disable fiber slice check in replica_apply_order test

### DIFF
--- a/test/replication/replica_apply_order.result
+++ b/test/replication/replica_apply_order.result
@@ -75,6 +75,10 @@ test_run:cmd("switch replica1")
  | ---
  | - true
  | ...
+-- index.count() checks fiber slice (gh-10553)
+require('fiber').set_max_slice(9000)
+ | ---
+ | ...
 test_run:cmd("setopt delimiter ';'")
  | ---
  | - true

--- a/test/replication/replica_apply_order.test.lua
+++ b/test/replication/replica_apply_order.test.lua
@@ -26,6 +26,8 @@ ch:get()
 
 errinj.set("ERRINJ_RELAY_FINAL_SLEEP", false)
 test_run:cmd("switch replica1")
+-- index.count() checks fiber slice (gh-10553)
+require('fiber').set_max_slice(9000)
 test_run:cmd("setopt delimiter ';'")
 function get_max_index_and_count()
     return box.space.test.index.primary:max()[1], box.space.test.index.primary:count()


### PR DESCRIPTION
Since commit e19bca5a74e8 ("box: check fiber slice in generic implementation of index count"), Vinyl's version of `index.count()` checks the fiber slice. As a result, the test may fail if it runs under a heavy load:

```
| @@ -94,6 +94,7 @@
|      end
|  end;
|   | ---
| + | - error: fiber slice is exceeded
|   | ...
|  -- Verify that at any moment max index is corresponding to amount of tuples,
|  -- which means that changes apply order is correct
```

Let's set the max fiber slice to a big value to avoid that.