### PR TITLE
[backport 3.2] test: fix flaky gh_9918_synchro_queue_additional_info_test.lua

### DIFF
--- a/test/replication-luatest/gh_9918_synchro_queue_additional_info_test.lua
+++ b/test/replication-luatest/gh_9918_synchro_queue_additional_info_test.lua
@@ -24,6 +24,7 @@ g.before_each(function(cg)
         box_cfg = box_cfg,
     }
     cg.replica_set:start()
+    cg.replica_set:wait_for_fullmesh()
     cg.leader:exec(function()
         box.ctl.promote()
         local s = box.schema.space.create('s', {is_sync = true})
@@ -31,7 +32,6 @@ g.before_each(function(cg)
         local as = box.schema.space.create('as', {is_sync = false})
         as:create_index('pk')
     end)
-    cg.replica_set:wait_for_fullmesh()
     cg.leader:wait_for_downstream_to(cg.replica)
 end)
 


### PR DESCRIPTION
This patch eliminates flaking in the
`gh_9918_synchro_queue_additional_info_test.lua` test. The problem was that the test did not wait for the connection between master and replica to be established, and therefore master node was in the "orphan" state at the time `box.ctl.promote()` was called. Thus, it turned out that the master node became the owner of the limbo, but was still read only.

To fix this, this patch simply calls `cg.replica_set:wait_for_fullmesh()` on the previous line before `box.ctl.promote()`.

Closes #10463

NO_DOC=test fix
NO_CHANGELOG=test fix

(cherry picked from commit 37bf64b7d7f76ea3330909655da90d64d0add558)