### PR TITLE
index_def: make index_def_new non-failing

### DIFF
--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -394,8 +394,6 @@ index_def_new_from_tuple(struct tuple *tuple, struct space *space)
 		index_def_new(id, index_id, name, name_len, space->def->name,
 			      space->def->engine_name, type, &opts, key_def,
 			      space_index_key_def(space, 0));
-	if (index_def == NULL)
-		return NULL;
 	auto index_def_guard = make_scoped_guard([=] { index_def_delete(index_def); });
 	if (index_def_check(index_def, space_name(space)) != 0)
 		return NULL;

--- a/src/box/index_def.c
+++ b/src/box/index_def.c
@@ -103,10 +103,6 @@ index_def_new(uint32_t space_id, uint32_t iid, const char *name,
 	/* Use calloc to make index_def_delete() safe at all times. */
 	struct index_def *def = xcalloc(1, sizeof(*def));
 	def->name = xstrndup(name, name_len);
-	if (identifier_check(def->name, name_len)) {
-		index_def_delete(def);
-		return NULL;
-	}
 	if (space_name != NULL)
 		def->space_name = xstrdup(space_name);
 	memset(def->engine_name, 0, sizeof(def->engine_name));
@@ -120,10 +116,6 @@ index_def_new(uint32_t space_id, uint32_t iid, const char *name,
 		if (opts->is_unique)
 			def->cmp_def->unique_part_count =
 				def->key_def->part_count;
-		if (def->cmp_def == NULL) {
-			index_def_delete(def);
-			return NULL;
-		}
 	} else {
 		def->cmp_def = key_def_dup(key_def);
 		def->pk_def = key_def_dup(key_def);

--- a/src/box/index_def.h
+++ b/src/box/index_def.h
@@ -270,13 +270,13 @@ index_def_list_add(struct rlist *index_def_list, struct index_def *index_def)
 
 /**
  * Create a new index definition.
+ * Does not validate identifier - caller must do it manually.
  *
  * @param key_def  key definition, must be fully built
  * @param pk_def   primary key definition, pass non-NULL
  *                 for secondary keys to construct
  *                 index_def::cmp_def
- * @retval not NULL Success.
- * @retval NULL     Memory error.
+ * Never fails, always returns non-NULL value.
  */
 struct index_def *
 index_def_new(uint32_t space_id, uint32_t iid, const char *name,

--- a/src/box/key_def.c
+++ b/src/box/key_def.c
@@ -1101,12 +1101,7 @@ key_def_merge(const struct key_def *first, const struct key_def *second)
 	}
 
 	sz = key_def_sizeof(new_part_count, sz);
-	struct key_def *new_def;
-	new_def = (struct key_def *)calloc(1, sz);
-	if (new_def == NULL) {
-		diag_set(OutOfMemory, sz, "malloc", "new_def");
-		return NULL;
-	}
+	struct key_def *new_def = xcalloc(1, sz);
 	new_def->part_count = new_part_count;
 	new_def->unique_part_count = new_part_count;
 	new_def->is_nullable = first->is_nullable || second->is_nullable;

--- a/src/box/schema.cc
+++ b/src/box/schema.cc
@@ -230,8 +230,6 @@ sc_space_new(uint32_t id, const char *name,
 						    TREE /* index type */,
 						    &index_opts_default,
 						    key_def, NULL);
-	if (index_def == NULL)
-		diag_raise();
 	auto index_def_guard =
 		make_scoped_guard([=] { index_def_delete(index_def); });
 	struct rlist key_list;

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -396,10 +396,6 @@ sql_ephemeral_space_new(const struct sql_space_info *info)
 						    TREE, &index_opts_default,
 						    key_def, NULL);
 	key_def_delete(key_def);
-	if (index_def == NULL) {
-		space_def_delete(space_def);
-		return NULL;
-	}
 
 	struct rlist key_list;
 	rlist_create(&key_list);

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -2657,8 +2657,6 @@ index_fill_def(struct Parse *parse, struct index *index,
 	index->def = index_def_new(space_def->id, 0, name, name_len,
 				   space_def->name, space_def->engine_name,
 				   TREE, &opts, key_def, NULL);
-	if (index->def == NULL)
-		goto tnt_error;
 	index->def->iid = iid;
 	rc = 0;
 cleanup:

--- a/src/box/sql/where.c
+++ b/src/box/sql/where.c
@@ -900,10 +900,6 @@ constructAutomaticIndex(Parse * pParse,			/* The parsing context */
 						  space->def->engine_name,
 						  TREE, &opts, key_def, NULL);
 	key_def_delete(key_def);
-	if (idx_def == NULL) {
-		pParse->is_aborted = true;
-		return;
-	}
 	pLoop->index_def = idx_def;
 
 	/* Create the automatic index */
@@ -2128,7 +2124,6 @@ whereLoopAddBtree(WhereLoopBuilder * pBuilder,	/* WHERE clause information */
 
 		struct key_def *key_def = key_def_new(&part, 1, 0);
 		if (key_def == NULL) {
-tnt_error:
 			pWInfo->pParse->is_aborted = true;
 			return -1;
 		}
@@ -2141,8 +2136,6 @@ tnt_error:
 					   space->def->engine_name,
 					   TREE, &opts, key_def, NULL);
 		key_def_delete(key_def);
-		if (fake_index == NULL)
-			goto tnt_error;
 		/* Special marker for  non-existent index. */
 		fake_index->iid = UINT32_MAX;
 		probe = fake_index;


### PR DESCRIPTION

Function `index_def_new` can fail only due to failure of identifier
validation and due to failure of `key_def_merge` helper. The helper
`key_def_merge` can fail only because of OOM or if multikey validation
has failed.

Firstly, we never need to check identifier in `index_def_new` because we
always do it earlier actually (except for cases we use string literals
for internal indexes, but we don't need to check them anyway), so let's
remove this check. Secondly, `key_def_merge` cannot fail because of
multikey validation in `index_def_new` because the secondary index is
already validated and primary index cannot have multikey path at all.
So here it can fail only because of allocation failure - let's simply
make `key_def_merge` panic on OOM so that `index_def_new` will become
non-failing.

Closes tarantool/security#130