### PR TITLE
memtx: do not pass NULL to memcpy when creating gap item in MVCC

### DIFF
--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -3220,7 +3220,8 @@ memtx_tx_nearby_gap_item_new(struct txn *txn, enum iterator_type type,
 		item->key = memtx_tx_xregion_alloc(txn, item->key_len,
 						   MEMTX_TX_ALLOC_TRACKER);
 	}
-	memcpy((char *)item->key, key, item->key_len);
+	if (item->key != NULL)
+		memcpy((char *)item->key, key, item->key_len);
 	return item;
 }
 


### PR DESCRIPTION
According to the C standard, passing `NULL` to `memcpy` is UB, even if it copies nothing (number of bytes to copy is 0). The commit fixes such situation in memtx MVCC.

**NB**: This problem is [already fixed](https://github.com/tarantool/tarantool/blob/37bf64b7d7f76ea3330909655da90d64d0add558/src/box/memtx_tx.c#L3343) in `master`, so the PR is going to be merged into `release/3.2`. Also, it should be cherry-picked to `2.11`.

Closes tarantool/security#129