### PR TITLE
config/schema: improve unexpected array error

### DIFF
--- a/changelogs/unreleased/config-schema-improve-unexpected-array-message.md
+++ b/changelogs/unreleased/config-schema-improve-unexpected-array-message.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* Improved the error message about array data when a record or a map is
+  expected (gh-10241, gh-10242).


### PR DESCRIPTION
How it looks for a map:

```lua
local schema = require('experimental.config.utils.schema')

local s = schema.new('foo', schema.map({
    key = schema.scalar({type = 'string'}),
    value = schema.scalar({type = 'string'}),
}))

s:validate({'a', 'b', 'c'})

-- Before the patch:
-- [foo] [1]: Unexpected data for scalar "string": Expected "string", got "number"

-- Now:
-- [foo] Expected a map, got an array: ["a","b","c"]
```

How it looks for a record:

```lua
local schema = require('experimental.config.utils.schema')

local s = schema.new('foo', schema.record({
    foo = schema.scalar({type = 'string'}),
}))

s:validate({'a', 'b', 'c'})

-- Before the patch:
-- [foo] Unexpected field "1"

-- Now:
-- [foo] Expected a record, got an array: ["a","b","c"]
```

The tricky part of the patch is to determine that the given record/map schema node never accepts a non-empty array, so we can report the error message that is shown above.

For example, the following record/map schema nodes accept some array values:

```lua
local schema = require('experimental.config.utils.schema')

local s = schema.new('foo', schema.record({
    [1] = schema.scalar({type = 'string'}),
    [2] = schema.scalar({type = 'string'}),
    [3] = schema.scalar({type = 'string'}),
}))

s:validate({'a', 'b', 'c'}) -- OK
```

```lua
local schema = require('experimental.config.utils.schema')

local s = schema.new('foo', schema.map({
    key = schema.scalar({type = 'integer'}),
    value = schema.scalar({type = 'string'}),
}))

s:validate({'a', 'b', 'c'}) -- OK
```

The patch implements the following criteria, when the friendly error can be issued:

* a record has no numeric field 1
* a map has a key type that can't accept a number

The criteria covers the most typical scenarios: for example, when a record/a map has string keys.

This change also improves error reporting of the validation step in the declarative configuration applying.

Fixes #10241
Fixes #10242