### PR TITLE
memtx: record getting the index size in the MVCC

### DIFF
--- a/changelogs/unreleased/gh-10149-index-len-mvcc.md
+++ b/changelogs/unreleased/gh-10149-index-len-mvcc.md
@@ -1,0 +1,5 @@
+## bugfix/memtx
+
+* Fixed a bug when the initial index size wasn't recorded in the MVCC,
+  so no transaction conflict occurred if the index size changed during
+  the transaction (gh-10149).

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -708,12 +708,11 @@ struct index {
 	uint32_t dense_id;
 	/**
 	 * List of gap_item's describing gap reads in the index with NULL
-	 * successor OR full scan gaps.
-	 * The first type happens when reading from empty index,
-	 * or when reading from rightmost part of ordered index (TREE).
-	 * The second type happens when a full scan was finished for
-	 * unordered index (HASH).
-	 * @sa struct gap_item_base.
+	 * successor, full scan and count gaps, see enum gap_item_type for
+	 * more info.
+	 *
+	 * NB: do not add items to the end of the list - it is reserved for
+	 * full count items.
 	 */
 	struct rlist read_gaps;
 };

--- a/src/box/memtx_bitset.cc
+++ b/src/box/memtx_bitset.cc
@@ -240,7 +240,7 @@ memtx_bitset_index_size(struct index *base)
 	struct space *space = space_by_id(base->def->space_id);
 	/* Substract invisible count. */
 	return tt_bitset_index_size(&index->index) -
-	       memtx_tx_index_invisible_count(in_txn(), space, base);
+	       memtx_tx_track_count(in_txn(), space, base, ITER_GE, NULL, 0);
 }
 
 static ssize_t

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -272,7 +272,7 @@ memtx_hash_index_size(struct index *base)
 	struct space *space = space_by_id(base->def->space_id);
 	/* Substract invisible count. */
 	return light_index_count(&index->hash_table) -
-	       memtx_tx_index_invisible_count(in_txn(), space, base);
+	       memtx_tx_track_count(in_txn(), space, base, ITER_GE, NULL, 0);
 }
 
 static ssize_t

--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -209,7 +209,7 @@ memtx_rtree_index_size(struct index *base)
 	struct space *space = space_by_id(base->def->space_id);
 	/* Substract invisible count. */
 	return rtree_number_of_records(&index->tree) -
-	       memtx_tx_index_invisible_count(in_txn(), space, base);
+	       memtx_tx_track_count(in_txn(), space, base, ITER_GE, NULL, 0);
 }
 
 static ssize_t

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -1082,7 +1082,7 @@ memtx_tree_index_size(struct index *base)
 	struct space *space = space_by_id(base->def->space_id);
 	/* Substract invisible count. */
 	return memtx_tree_size(&index->tree) -
-	       memtx_tx_index_invisible_count(in_txn(), space, base);
+	       memtx_tx_track_count(in_txn(), space, base, ITER_GE, NULL, 0);
 }
 
 template <bool USE_HINT>

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -3703,6 +3703,41 @@ memtx_tx_track_gap_slow(struct txn *txn, struct space *space, struct index *inde
 }
 
 /**
+ * Check if a full count had been performed by the @a txn in @a index and
+ * recorded in the MVCC already. See the @a memtx_tx_track_count_until_slow
+ * for more details on how such a gap item is inserted into the index gap list.
+ */
+static bool
+memtx_tx_index_full_count_recorded_already(struct index *index, struct txn *txn)
+{
+	struct gap_item_base *item_base;
+	rlist_foreach_entry_reverse(item_base, &index->read_gaps,
+				    in_read_gaps) {
+		/* Not a count item = no full count items expected next. */
+		if (item_base->type != GAP_COUNT)
+			break;
+
+		/* Skip if not gap item of the current transaction. */
+		if (item_base->txn != txn)
+			continue;
+
+		/* Not a full count = no full count items expected next. */
+		struct count_gap_item *item =
+			(struct count_gap_item *)item_base;
+		if (item->part_count != 0)
+			break;
+
+		/* Same if not a full count without `until` specified. */
+		if (item->until != NULL)
+			break;
+
+		/* Found a full count gap item of the txn created previously. */
+		return true;
+	}
+	return false;
+}
+
+/**
  * Record in TX manager that a transaction @a txn have counted @a index of @a
  * space by @a key and iterator @a type. This function must be used for queries
  * that count tuples in indexes (for example, index:size or index:count) or if
@@ -3730,10 +3765,29 @@ memtx_tx_track_count_until_slow(struct txn *txn, struct space *space,
 				      type == ITER_REQ ? ITER_LE :
 				      type, key, part_count));
 
+	/* Check if a full index count happened previously by the txn. */
+	if (txn != NULL && part_count == 0 && until == NULL &&
+	    memtx_tx_index_full_count_recorded_already(index, txn)) {
+		return memtx_tx_index_invisible_count_matching_until(
+			txn, space, index, type, key,
+			part_count, until, until_hint);
+	}
+
 	if (txn != NULL && txn->status == TXN_INPROGRESS) {
 		struct count_gap_item *item = memtx_tx_count_gap_item_new(
 			txn, type, key, part_count, until, until_hint);
-		rlist_add(&index->read_gaps, &item->base.in_read_gaps);
+		/*
+		 * Empty key count trackers are inserted in the end of the index
+		 * gap list, so we can search for an existing empty key gap item
+		 * without traversing the whole list and check if a new one will
+		 * be a duplicate.
+		 */
+		if (part_count == 0 && until == NULL) {
+			rlist_add_tail(&index->read_gaps,
+				       &item->base.in_read_gaps);
+		} else {
+			rlist_add(&index->read_gaps, &item->base.in_read_gaps);
+		}
 	}
 
 	/*

--- a/src/box/memtx_tx.h
+++ b/src/box/memtx_tx.h
@@ -434,7 +434,7 @@ memtx_tx_tuple_clarify(struct txn *txn, struct space *space,
 }
 
 /**
- * Helper of invisible count functions.
+ * Helper of memtx_tx_index_invisible_count_matching_until.
  */
 uint32_t
 memtx_tx_index_invisible_count_matching_until_slow(
@@ -444,30 +444,17 @@ memtx_tx_index_invisible_count_matching_until_slow(
 
 /**
  * When MVCC engine is enabled, an index can contain temporary non-committed
- * tuples that are not visible outside their transaction.
- * That's why internal index size can be greater than visible by
- * standalone observer.
- * The function calculates tje number of tuples that are physically present
- * in index, but have no visible value.
- */
-static inline uint32_t
-memtx_tx_index_invisible_count(struct txn *txn,
-			       struct space *space, struct index *index)
-{
-	if (!memtx_tx_manager_use_mvcc_engine)
-		return 0;
-	return memtx_tx_index_invisible_count_matching_until_slow(
-		txn, space, index, ITER_GE, NULL, 0, NULL, HINT_NONE);
-}
-
-/**
- * Same as memtx_tx_index_invisible_count but only counts tuples matching to
- * the given key and iterator up to the given tuple (exclusively) according to
- * the index order.
+ * tuples that are not visible outside their transaction. That's why internal
+ * index size can be greater than visible by standalone observer.
+ *
+ * The function calculates the number of tuples that are physically present
+ * in index, but have no visible value. But only tuples that match the given
+ * key and iterator type and are located strictly before the given @a until
+ * tuple according to the iterator order are counted.
  *
  * E. g. for index: [1, 2, 3, 4, 5], given all items in the index are invisible
  * to the transaction, counting matching LE 3 until 1 will give 2 (3 and 2 will
- * be counted, 1 will not since the count is exclusive).
+ * be counted, 1 will not since we count everything strictly before 1).
  */
 static inline uint32_t
 memtx_tx_index_invisible_count_matching_until(

--- a/test/box-luatest/gh_10149_index_len_mvcc_test.lua
+++ b/test/box-luatest/gh_10149_index_len_mvcc_test.lua
@@ -1,0 +1,127 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group('gh-10149-index-len-mvcc')
+
+g.before_all(function(cg)
+    cg.server = server:new{box_cfg = {memtx_use_mvcc_engine = true}}
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+-- Test if the tree index's len() method is recorded in MVCC.
+g.test_index_len_mvcc_tree = function(cg)
+    cg.server:exec(function()
+        -- Create a space with data.
+        local s = box.schema.space.create('test')
+        s:create_index('pk')
+        s:insert({1})
+
+        -- Prepare the proxies.
+        local txn_proxy = require('test.box.lua.txn_proxy')
+        local tx1 = txn_proxy.new()
+        local tx2 = txn_proxy.new()
+
+        -- TX1 open a transaction and reads the index size.
+        tx1:begin()
+        tx1('box.space.test:len()')
+
+        -- TX2 changes the index size (now TX1 must be conflicted).
+        tx2('box.space.test:insert({2})')
+
+        -- TX1 does a writing operation (must fail).
+        t.assert_equals(tx1('box.space.test:delete({1})'),
+                        {{error = "Transaction has been aborted by conflict"}})
+    end)
+end
+
+-- Test if the hash index's len() method is recorded in MVCC.
+g.test_index_len_mvcc_hash = function(cg)
+    cg.server:exec(function()
+        -- Create a space with data.
+        local s = box.schema.space.create('test')
+        s:create_index('pk', {type = 'hash'})
+        s:insert({1})
+
+        -- Prepare the proxies.
+        local txn_proxy = require('test.box.lua.txn_proxy')
+        local tx1 = txn_proxy.new()
+        local tx2 = txn_proxy.new()
+
+        -- TX1 open a transaction and reads the index size.
+        tx1:begin()
+        tx1('box.space.test:len()')
+
+        -- TX2 changes the index size (now TX1 must be conflicted).
+        tx2('box.space.test:insert({2})')
+
+        -- TX1 does a writing operation (must fail).
+        t.assert_equals(tx1('box.space.test:delete({1})'),
+                        {{error = "Transaction has been aborted by conflict"}})
+    end)
+end
+
+-- Test if the bitset index's len() method is recorded in MVCC.
+g.test_index_len_mvcc_bitset = function(cg)
+    cg.server:exec(function()
+        -- Create a space with data.
+        local s = box.schema.space.create('test')
+        s:create_index('pk')
+        s:create_index('sk', {type = 'bitset'})
+        s:insert({1, 1})
+
+        -- Prepare the proxies.
+        local txn_proxy = require('test.box.lua.txn_proxy')
+        local tx1 = txn_proxy.new()
+        local tx2 = txn_proxy.new()
+
+        -- TX1 open a transaction and reads the index size.
+        tx1:begin()
+        tx1('box.space.test.index.sk:len()')
+
+        -- TX2 changes the index size (now TX1 must be conflicted).
+        tx2('box.space.test:insert({2, 2})')
+
+        -- TX1 does a writing operation (must fail).
+        t.assert_equals(tx1('box.space.test.index.sk:delete({1})'),
+                        {{error = "Transaction has been aborted by conflict"}})
+    end)
+end
+
+-- Test if the rtree index's len() method is recorded in MVCC.
+g.test_index_len_mvcc_rtree = function(cg)
+    cg.server:exec(function()
+        -- Create a space with data.
+        local s = box.schema.space.create('test')
+        s:create_index('pk')
+        s:create_index('sk', {type = 'rtree'})
+        s:insert({1, {1, 1}})
+
+        -- Prepare the proxies.
+        local txn_proxy = require('test.box.lua.txn_proxy')
+        local tx1 = txn_proxy.new()
+        local tx2 = txn_proxy.new()
+
+        -- TX1 open a transaction and reads the index size.
+        tx1:begin()
+        tx1('box.space.test.index.sk:len()')
+
+        -- TX2 changes the index size (now TX1 must be conflicted).
+        tx2('box.space.test:insert({2, {2, 2}})')
+
+        -- TX1 does a writing operation (must fail).
+        t.assert_equals(tx1('box.space.test.index.sk:delete({{1, 1}})'),
+                        {{error = "Transaction has been aborted by conflict"}})
+    end)
+end

--- a/test/box-luatest/gh_8204_fast_offset_test.lua
+++ b/test/box-luatest/gh_8204_fast_offset_test.lua
@@ -1030,6 +1030,103 @@ g_mvcc.test_past_history = function()
     end)
 end
 
+g_mvcc.test_redundant_trackers = function()
+    g_mvcc.server:exec(function()
+        -- The test space.
+        local s = box.schema.space.create('test')
+        s:create_index('pk')
+        s:insert({1})
+        s:insert({2})
+
+        -- Prepare proxies.
+        local txn_proxy = require('test.box.lua.txn_proxy')
+        local tx1 = txn_proxy.new()
+        local tx2 = txn_proxy.new()
+        local tx3 = txn_proxy.new()
+
+        -- Create a full count gap item with `until' specified for the tx1.
+        tx1:begin()
+        local old_tracker_mem = box.stat.memtx().tx.mvcc.trackers.total
+        tx1('box.space.test:select({}, {offset = 1})')
+        local new_tracker_mem = box.stat.memtx().tx.mvcc.trackers.total
+        t.assert_gt(new_tracker_mem, old_tracker_mem)
+
+        -- Create a non-count gap item for the tx1.
+        old_tracker_mem = box.stat.memtx().tx.mvcc.trackers.total
+        tx1('box.space.test:select({1}, {iterator = "GE"})')
+        new_tracker_mem = box.stat.memtx().tx.mvcc.trackers.total
+        t.assert_gt(new_tracker_mem, old_tracker_mem)
+
+        -- Do tx1:count({}) and create a full count gap item with no `until'.
+        old_tracker_mem = box.stat.memtx().tx.mvcc.trackers.total
+        t.assert_equals(tx1('return box.space.test:count{}')[1], 2)
+        new_tracker_mem = box.stat.memtx().tx.mvcc.trackers.total
+        t.assert_gt(new_tracker_mem, old_tracker_mem)
+
+        -- Insert an item and do tx1:count({}) once again.
+        -- No new tracker must be created.
+        tx3:begin()
+        tx3('box.space.test:replace{3}')
+        old_tracker_mem = box.stat.memtx().tx.mvcc.trackers.total
+        t.assert_equals(tx1('return box.space.test:count{}')[1], 2)
+        new_tracker_mem = box.stat.memtx().tx.mvcc.trackers.total
+        t.assert_equals(new_tracker_mem, old_tracker_mem)
+
+        -- Commit and reopen the writer to make the readers different.
+        tx3:commit()
+        t.assert_equals(box.space.test:len(), 3)
+        tx3:begin()
+        tx3('box.space.test:replace{4}')
+
+        -- Create a count gap item with `until' specified for the tx2.
+        tx2:begin()
+        old_tracker_mem = box.stat.memtx().tx.mvcc.trackers.total
+        tx2('box.space.test:select({}, {offset = 1})')
+        new_tracker_mem = box.stat.memtx().tx.mvcc.trackers.total
+        t.assert_gt(new_tracker_mem, old_tracker_mem)
+
+        -- Do tx2:count({}) and create its full count gap item with no `until'.
+        old_tracker_mem = box.stat.memtx().tx.mvcc.trackers.total
+        t.assert_equals(tx2('return box.space.test:count{}')[1], 3)
+        new_tracker_mem = box.stat.memtx().tx.mvcc.trackers.total
+        t.assert_gt(new_tracker_mem, old_tracker_mem)
+
+        -- No new trackers for both tx1 and tx2 on count({}).
+        tx3('box.space.test:replace{5}')
+        old_tracker_mem = box.stat.memtx().tx.mvcc.trackers.total
+        t.assert_equals(tx1('return box.space.test:count{}')[1], 2)
+        t.assert_equals(tx2('return box.space.test:count{}')[1], 3)
+        new_tracker_mem = box.stat.memtx().tx.mvcc.trackers.total
+        t.assert_equals(new_tracker_mem, old_tracker_mem)
+
+        -- Create some other trackers in the front of the gap list.
+        tx3('box.space.test:replace{6}')
+        old_tracker_mem = box.stat.memtx().tx.mvcc.trackers.total
+        tx1('box.space.test:select({1}, {iterator = "GT"})')
+        tx2('box.space.test:select({2}, {iterator = "GE"})')
+        new_tracker_mem = box.stat.memtx().tx.mvcc.trackers.total
+        t.assert_gt(new_tracker_mem, old_tracker_mem)
+
+        -- Still no new trackers for both tx1 and tx2 on count({}).
+        tx3('box.space.test:replace{7}')
+        old_tracker_mem = box.stat.memtx().tx.mvcc.trackers.total
+        t.assert_equals(tx1('return box.space.test:count{}')[1], 2)
+        t.assert_equals(tx2('return box.space.test:count{}')[1], 3)
+        new_tracker_mem = box.stat.memtx().tx.mvcc.trackers.total
+        t.assert_equals(new_tracker_mem, old_tracker_mem)
+
+        -- Commit the writer.
+        tx3:commit()
+        t.assert_equals(box.space.test:len(), 7)
+
+        -- Check and commit the readers.
+        t.assert_equals(tx1('return box.space.test:count{}')[1], 2)
+        t.assert_equals(tx2('return box.space.test:count{}')[1], 3)
+        tx1:commit()
+        tx2:commit()
+    end)
+end
+
 g_mvcc.test_offset = function()
     g_mvcc.server:exec(function()
         -- The test space.


### PR DESCRIPTION
Currently getting the index size (aka calling the index.len() method) is not recorded in the MVCC. This has a side effect that if the size if an index is changed after the transaction first inspected it, it's not conflicted and may continue performing writing operations on the space. That's a problem since in this case the transaction can perform a set of operations assuming that at the time it commits the size of the index is the same as been checked, which may not be true.

Let's fix this by informing the MVCC system about the index size check performed by a transaction.

Closes #10149

NO_DOC=buffix