### PR TITLE
bps: improve tree view tests

### DIFF
--- a/test/unit/bps_tree_iterator.cc
+++ b/test/unit/bps_tree_iterator.cc
@@ -26,8 +26,14 @@ static int compare(const elem_t &a, const elem_t &b);
 static int compare_key(const elem_t &a, long b);
 
 #define BPS_TREE_NAME test
-#define BPS_TREE_BLOCK_SIZE 256 /* small value for tests */
-#define BPS_TREE_EXTENT_SIZE 1024 /* value is to low specially for tests */
+/**
+ * On COW matras make a copy of extent while API requires only copy a block.
+ * So bps tree may miss COW requests for its block but the block is copied
+ * accidentally and the test passes. To avoid this issue let's make extent and
+ * block the same size.
+ */
+#define BPS_TREE_BLOCK_SIZE 256
+#define BPS_TREE_EXTENT_SIZE 256
 #define BPS_TREE_IS_IDENTICAL(a, b) equal(a, b)
 #define BPS_TREE_COMPARE(a, b, arg) compare(a, b)
 #define BPS_TREE_COMPARE_KEY(a, b, arg) compare_key(a, b)
@@ -93,7 +99,7 @@ iterator_check()
 		   "invalid iterators are equal");
 	}
 
-	const long count1 = 10000;
+	const long count1 = 2000;
 	const long count2 = 5;
 	for (long i = 0; i < count1; i++) {
 		struct elem_t e;

--- a/test/unit/bps_tree_view.c
+++ b/test/unit/bps_tree_view.c
@@ -14,8 +14,14 @@
 #include "unit.h"
 
 #define BPS_TREE_NAME test_tree
+/**
+ * On COW matras make a copy of extent while API requires only copy a block.
+ * So bps tree may miss COW requests for its block but the block is copied
+ * accidentally and the test passes. To avoid this issue let's make extent and
+ * block the same size.
+ */
 #define BPS_TREE_BLOCK_SIZE 256
-#define BPS_TREE_EXTENT_SIZE 1024
+#define BPS_TREE_EXTENT_SIZE 256
 #define BPS_TREE_IS_IDENTICAL(a, b) ((a) == (b))
 #define BPS_TREE_COMPARE(a, b, arg) ((a) < (b) ? -1 : ((a) > (b) ? 1 : 0))
 #define BPS_TREE_COMPARE_KEY(a, b, arg) BPS_TREE_COMPARE(a, b, arg)


### PR DESCRIPTION
On COW matras make a copy of extent while API requires only copy a block. So bps tree may miss COW requests for its block but the block is copied accidentally and the test passes. To avoid this issue let's make extent and block the same size.

The same improvement we done for bps vector in https://github.com/tarantool/tarantool-ee/pull/932.