### PR TITLE
box: log error that caused initial checkpoint failure

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -5210,8 +5210,10 @@ bootstrap_master(void)
 		diag_raise();
 
 	/* Make the initial checkpoint */
-	if (gc_checkpoint() != 0)
-		panic("failed to create a checkpoint");
+	if (gc_checkpoint() != 0) {
+		say_error("failed to create a checkpoint");
+		diag_raise();
+	}
 
 	box_run_on_recovery_state(RECOVERY_STATE_SNAPSHOT_RECOVERED);
 	box_run_on_recovery_state(RECOVERY_STATE_WAL_RECOVERED);
@@ -5311,8 +5313,10 @@ bootstrap_from_master(struct replica *master)
 		diag_raise();
 
 	/* Make the initial checkpoint */
-	if (gc_checkpoint() != 0)
-		panic("failed to create a checkpoint");
+	if (gc_checkpoint() != 0) {
+		say_error("failed to create a checkpoint");
+		diag_raise();
+	}
 
 	box_run_on_recovery_state(RECOVERY_STATE_WAL_RECOVERED);
 


### PR DESCRIPTION
Currently, we just panic without providing any additional information if we failed to create the initial checkpoint on bootstrap. This complicates trouble shooting. Let's replace `panic()` with `say_error()` and raise the exception that caused the failure. The exception will be caught by by `box_cfg()`, which will log it and then panic.