### PR TITLE
ci: fix Coverity workflow

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -3,7 +3,7 @@ name: coverity
 on:
   workflow_dispatch:
   schedule:
-    - cron:  '0 4 * * 6'
+    - cron: '0 4 * * 6'
 
 jobs:
   coverity:
@@ -13,13 +13,6 @@ jobs:
 
     timeout-minutes: 60
 
-    container:
-      image: docker.io/tarantool/testing:debian-buster
-      # Our testing expects that the init process (PID 1) will
-      # reap orphan processes. At least the following test leans
-      # on it: app-tap/gh-4983-tnt-e-assert-false-hangs.test.lua.
-      options: '--init'
-
     steps:
       - name: Prepare checkout
         uses: tarantool/actions/prepare-checkout@master
@@ -28,33 +21,29 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - uses: ./.github/actions/environment
-      - name: test
-        run: make -f .test.mk test-coverity
-        env:
-          COVERITY_TOKEN: ${{ secrets.COVERITY_TOKEN }}
+
+      - name: Determine tarantool version
+        run: printf 'version=%s\n' $(git describe --long --always HEAD) >> "${GITHUB_OUTPUT}"
+        id: version
+
+      # Not a full list of dependencies. Just ones that are
+      # required to successful configuration stage (cmake) and
+      # missed in the runner's environment.
+      - name: Setup tarantool dependencies
+        run: sudo apt install -y libreadline-dev
+
+      - name: Configure
+        run: cmake -S . -B . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_WERROR=ON -DTEST_BUILD=ON
+
+      - uses: vapier/coverity-scan-action@v1
+        with:
+          token: ${{ secrets.COVERITY_TOKEN }}
+          email: admin@tarantool.org
+          command: cmake --build . --parallel $(nproc)
+          version: ${{ steps.version.outputs.version }}
+
       - name: Send VK Teams message on failure
         if: failure()
         uses: ./.github/actions/report-job-status
         with:
           bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
-      - name: artifacts
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: debug
-          retention-days: 21
-          path: ${{ env.VARDIR }}/artifacts
-      # Find the PR associated with this push, if there is one.
-      - uses: jwalton/gh-find-current-pr@v1
-        if: success()
-        id: findPr
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create comment in PR if it exists
-        if: success() && steps.findPr.outputs.number != false
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          issue-number: ${{ steps.findPr.outputs.pr }}
-          body: |
-            Check coverity results on coverity.com site
-            [![Coverity Status](https://scan.coverity.com/projects/11609/badge.svg?flat=1)](https://scan.coverity.com/projects/tarantool-tarantool)

--- a/.test.mk
+++ b/.test.mk
@@ -19,9 +19,6 @@ MAX_FILES ?= 4096
 VARDIR ?= /tmp/t
 TEST_RUN_PARAMS = --builddir ${PWD}/${BUILD_DIR}
 
-COVERITY_DIR = cov-int
-COVERITY_URL = https://scan.coverity.com/builds?project=tarantool%2Ftarantool
-
 CMAKE = ${CMAKE_ENV} cmake -S ${SRC_DIR} -B ${BUILD_DIR}
 CMAKE_BUILD = ${CMAKE_BUILD_ENV} cmake --build ${BUILD_DIR} --parallel ${NPROC}
 
@@ -268,40 +265,6 @@ test-jepsen: CMAKE_PARAMS = -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                             -DTEST_BUILD=ON
 test-jepsen: configure prebuild-jepsen
 	${CMAKE_BUILD} --target run-jepsen
-
-##############################
-# Coverity testing           #
-##############################
-
-.PHONY: build-coverity
-build-coverity: CMAKE_PARAMS = -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-                               -DENABLE_WERROR=ON \
-                               -DTEST_BUILD=ON
-build-coverity: CMAKE_BUILD_ENV = PATH=${PATH}:/cov-analysis/bin cov-build --dir ${COVERITY_DIR}
-build-coverity: configure
-	${CMAKE_BUILD}
-
-.PHONY: test-coverity
-test-coverity: build-coverity
-	tar czvf tarantool.tgz ${COVERITY_DIR}
-	if [ -n "$${COVERITY_TOKEN}" ]; then \
-		echo "Exporting code coverity information to scan.coverity.com"; \
-		curl --location \
-		     --fail \
-		     --silent \
-		     --show-error \
-		     --retry 5 \
-		     --retry-delay 5 \
-		     --form token=$${COVERITY_TOKEN} \
-		     --form email=tarantool@tarantool.org \
-		     --form file=@tarantool.tgz \
-		     --form version=$(shell git describe HEAD) \
-		     --form description="Tarantool Coverity" \
-		     ${COVERITY_URL}; \
-	else \
-		echo "Coverity token is not provided"; \
-		exit 1; \
-	fi
 
 ##############################
 # LuaJIT integration testing #


### PR DESCRIPTION
It doesn't work since 2023-11-18. The uploading succeeds, but the website says:

> The Coverity Build tool version is no longer supported. Please
> download the latest version for your platform from
> https://scan.coverity.com/download...

It seems, some specific toolset is installed in the `tarantool/testing:debian-buster` image and it was deprecated 11 months ago.

Recently the CI workflow starts to fail due to use of the old image with an old CMake in it:

> [  2%] Performing configure step for 'bundled-nanoarrow-project'
> -- Building using CMake version: 3.13.4
> -- Configuring incomplete, errors occurred!
> CMake Error at CMakeLists.txt:19 (cmake_minimum_required):
>   CMake 3.14 or higher is required.  You are running version 3.13.4

It is likely due to commit 49c160c28c97 ("third_party: initial import of nanoarrow").

Here I refine the workflow file:

* Get rid of the custom docker image with preinstalled Coverity toolset.
* Use a nice [unofficial-coverity-scan](https://github.com/marketplace/actions/unofficial-coverity-scan) GitHub Action.
* Add the `libreadline-dev` dependency installation, because it is needed to build tarantool on Ubuntu 24.04.
* Drop related `.test.mk` rules, because it looks more readable to invoke a few commands from the workflow file directly.
* Drop testing artifacts uploading that seems a copy-paste from some workflow that runs the tests and the given directory unlikely has any file in our case.
* Drop unused step that adds a comment to the pull request.

And things seems to start working. At least, after a testing run of the workflow now I see the following status on the website:

> Last Build Status: Running. Your build is currently being analyzed

See also #10651.