### PR TITLE
box: fix `SIGSEGV` on unaligned access to a struct with extended alignment

### DIFF
--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -2143,7 +2143,7 @@ applier_init(void)
 						  sizeof(struct applier_thread *));
 	for (int i = 0; i < replication_threads; i++) {
 		struct applier_thread *thread =
-			(struct applier_thread *)xmalloc(sizeof(*thread));
+			xalloc_object(struct applier_thread);
 		applier_thread_create(thread);
 		applier_threads[i] = thread;
 	}

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -3857,8 +3857,8 @@ iproto_init(int threads_count)
 	 * we don't need any accept functions.
 	 */
 	evio_service_create(loop(), &tx_binary, "tx_binary", NULL, NULL);
-	iproto_threads = (struct iproto_thread *)
-		xcalloc(threads_count, sizeof(struct iproto_thread));
+	iproto_threads = xalloc_array(struct iproto_thread, threads_count);
+	memset(iproto_threads, 0, sizeof(struct iproto_thread) * threads_count);
 	fiber_cond_create(&drop_finished_cond);
 
 	for (int i = 0; i < threads_count; i++, iproto_threads_count++) {

--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -291,14 +291,7 @@ relay_new(struct replica *replica)
 	 * (Use clang UB Sanitizer, to make sure of this)
 	 */
 	assert((sizeof(struct relay) % alignof(struct relay)) == 0);
-	struct relay *relay = (struct relay *)
-		aligned_alloc(alignof(struct relay), sizeof(struct relay));
-	if (relay == NULL) {
-		diag_set(OutOfMemory, sizeof(struct relay), "aligned_alloc",
-			  "struct relay");
-		return NULL;
-	}
-
+	struct relay *relay = xalloc_object(struct relay);
 	memset(relay, 0, sizeof(struct relay));
 	relay->replica = replica;
 	relay->last_row_time = ev_monotonic_now(loop());
@@ -472,9 +465,6 @@ relay_initial_join(struct iostream *io, uint64_t sync, struct vclock *vclock,
 		   struct checkpoint_cursor *cursor)
 {
 	struct relay *relay = relay_new(NULL);
-	if (relay == NULL)
-		diag_raise();
-
 	relay_start(relay, io, sync, relay_send_initial_join_row, relay_yield,
 		    UINT64_MAX);
 	xrow_stream_create(&relay->xrow_stream);

--- a/src/box/replication.cc
+++ b/src/box/replication.cc
@@ -305,10 +305,6 @@ replica_new(void)
 			  "struct replica");
 	}
 	replica->relay = relay_new(replica);
-	if (replica->relay == NULL) {
-		free(replica);
-		diag_raise();
-	}
 	replica->id = 0;
 	replica->anon = false;
 	replica->uuid = uuid_nil;

--- a/src/trivia/util.h
+++ b/src/trivia/util.h
@@ -133,6 +133,12 @@ alloc_failure(const char *filename, int line, size_t size)
 #define xstrndup(s, n)		xalloc_impl((n) + 1, strndup, (s), (n))
 #define xaligned_alloc(size, align) \
 		xalloc_impl((size), aligned_alloc, (align), (size))
+#define xalloc_object(T) ({							\
+	(T *)xaligned_alloc(sizeof(T), alignof(T));				\
+})
+#define xalloc_array(T, count) ({						\
+	(T *)xaligned_alloc(sizeof(T) * (count), alignof(T));			\
+})
 #define xmempool_alloc(p)	xalloc_impl((p)->objsize, mempool_alloc, (p))
 #define xregion_alloc(p, size)	xalloc_impl((size), region_alloc, (p), (size))
 #define xregion_aligned_alloc(p, size, align) \


### PR DESCRIPTION
**Revert "hotfix: change aligned_alloc to posix_memalign"**

This reverts commit https://github.com/tarantool/tarantool/commit/3c25c667352ec4f9c733c514a1b8c15264c6ad88.

`aligned_alloc()` is supported by macOS since 10.15. I believe that we do not support older versions now.

**box: fix `SIGSEGV` on unaligned access to a struct with extended alignment**

All structures with a non-default alignment (set by `alignas()`) must be allocated by `aligned_alloc()`, otherwise an access to such a structure member fill crash, e.g. if compiled with AVX-512 support.

Closes https://github.com/tarantool/tarantool/issues/10215
Part of https://github.com/tarantool/tarantool/issues/10631