### PR TITLE
box: fix UBSan error regarding misaligned store in `field_map.c`

### DIFF
--- a/src/box/field_map.c
+++ b/src/box/field_map.c
@@ -106,10 +106,10 @@ field_map_build(struct field_map_builder *builder, char *buffer)
 		/** Retrive memory for the extent. */
 		store_u32(&field_map[i], extent_wptr - (char *)field_map);
 		store_u32(extent_wptr, extent->size);
+		extent_wptr += sizeof(uint32_t);
 		uint32_t extent_offset_sz = extent->size * sizeof(uint32_t);
-		memcpy(&((uint32_t *) extent_wptr)[1], extent->offset,
-			extent_offset_sz);
-		extent_wptr += sizeof(uint32_t) + extent_offset_sz;
+		memcpy(extent_wptr, extent->offset, extent_offset_sz);
+		extent_wptr += extent_offset_sz;
 	}
 	assert(extent_wptr == buffer + builder->extents_size);
 }


### PR DESCRIPTION
The type cast is unnecessary and causes false-positive errors:

```
./src/box/field_map.c:110:10: runtime error: store to misaligned address 0x507000071082 for type 'uint32_t *' (aka 'unsigned int *'), which requires 4 byte alignment
0x507000071082: note: pointer points here
 01 00  00 00 be be be be f0 ff  ff ff 02 00 00 00 be be  be be be be be be 00 00  00 00 00 00 00 00
              ^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ./src/box/field_map.c:110:10
```

Closes https://github.com/tarantool/tarantool/issues/10631