### PR TITLE
[backport 2.11] build: update libcurl to curl-8_10_1-241-g461ce6c61

### DIFF
--- a/changelogs/unreleased/bump-libcurl-to-8.10.1.md
+++ b/changelogs/unreleased/bump-libcurl-to-8.10.1.md
@@ -1,3 +1,3 @@
 ## bugfix/build
 
-* Updated libcurl to version 8.10.1 (gh-10576).
+* Updated libcurl to version `curl-8_10_1-241-g461ce6c61` (gh-10576).

--- a/cmake/BuildLibCURL.cmake
+++ b/cmake/BuildLibCURL.cmake
@@ -45,6 +45,7 @@ macro(curl_build)
 
     # Let's disable testing for curl to save build time.
     list(APPEND LIBCURL_CMAKE_FLAGS "-DBUILD_TESTING=OFF")
+    list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_TEST_BUNDLES=OFF")
 
     # Let's disable building documentation for curl to save build time.
     list(APPEND LIBCURL_CMAKE_FLAGS "-DENABLE_CURL_MANUAL=OFF")
@@ -176,6 +177,7 @@ macro(curl_build)
     list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_DISABLE_POP3=ON")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_DISABLE_IMAP=ON")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_DISABLE_MQTT=ON")
+    list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_DISABLE_IPFS=ON")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_DISABLE_SMTP=OFF")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_DISABLE_ALTSVC=ON")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_DISABLE_SRP=OFF")
@@ -211,7 +213,7 @@ macro(curl_build)
     list(APPEND LIBCURL_CMAKE_FLAGS "-DENABLE_CURLDEBUG=${TARANTOOL_DEBUG}")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DENABLE_DEBUG=${TARANTOOL_DEBUG}")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DUSE_MSH3=OFF")
-    list(APPEND LIBCURL_CMAKE_FLAGS "-DENABLE_WEBSOCKETS=OFF")
+    list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_DISABLE_WEBSOCKETS=ON")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DCMAKE_UNITY_BUILD=OFF")
     # Note that CMake build does not allow build curl and libcurl debug
     # enabled, see https://github.com/curl/curl/blob/master/docs/INSTALL.cmake


### PR DESCRIPTION
*(This is a backport of PR #10681 to `release/2.11`.)*

----

The reason is that the previous libcurl submodule update in commit 0919f390802f146852b462215327ef03e2730cfc ("third_party: update libcurl from 8.8.0 to 8.10.1") reveals the following regression:

```c
$ tarantool -e "require('http.client').new():get('https://google.com')"
tarantool: ./third_party/curl/lib/multi.c:3691: curl_multi_assign: Assertion `!(multi)' failed.
Aborted (core dumped)
```

The stacktrace is the following:

```c
<...>
#4  __assert_fail
#5  curl_multi_assign            // <- called by us
#6  curl_multi_sock_cb           // <- this is our callback
#7  Curl_multi_pollset_ev
#8  cpool_update_shutdown_ev
#9  cpool_discard_conn
#10 cpool_close_and_destroy_all
#11 Curl_cpool_destroy
#12 curl_multi_cleanup
#13 curl_env_finish              // <- destroy the multi handle
#14 httpc_env_finish
#15 luaT_httpc_cleanup
#16 lj_BC_FUNCC
#17 gc_call_finalizer
#18 gc_finalize
#19 gc_onestep
#20 lj_gc_fullgc
#21 lua_gc
#22 lj_cf_collectgarbage
#23 lj_BC_FUNCC
#24 lua_pcall
#25 luaT_call
#26 lua_main
#27 run_script_f
#28 fiber_cxx_invoke
#29 fiber_loop
#30 coro_init
```

The multi handle is during the destroy, but our `CURLMOPT_SOCKETFUNCTION` callback is invoked and the `curl_multi_assign()` call (invoked to associate a libev watcher to the given file descriptor) fails on the assertion. Everything is as described in https://github.com/curl/curl/issues/15201.

The first bad libcurl's commit is [curl-8_10_0-4-g48f61e781][1], but later it was fixed in [curl-8_10_1-241-g461ce6c61][2]. This commit updates libcurl to this revision to fix the regression.

Adjusted build options in our build script:

* Added `CURL_DISABLE_IPFS=ON`: [curl-8_10_1-57-gce7d0d413][3]
* Added `CURL_TEST_BUNDLES=OFF`: [curl-8_10_1-67-g71cf0d1fc][4]
* Changed `ENABLE_WEBSOCKETS=OFF` to `CURL_DISABLE_WEBSOCKETS=ON`: [curl-8_10_1-130-gd78e129d5][5]

[1]: https://github.com/curl/curl/commit/48f61e781a01e6a8dbc4a347e280644b1c68ab6a
[2]: https://github.com/curl/curl/commit/461ce6c6160b86439ddd74c59541231ec9e8558e
[3]: https://github.com/curl/curl/commit/ce7d0d41378007eda676c83ad6b86c59870cc9f1
[4]: https://github.com/curl/curl/commit/71cf0d1fca9e1f53524e1545ef0c08d174458d80
[5]: https://github.com/curl/curl/commit/d78e129d50b2d190f1c1bde2ad1f62f02f152db0