### PR TITLE
[backport 3.2]  config: refactor to reuse already calculated values in configdata

### DIFF
--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -329,18 +329,6 @@ local function build_peers(instances, replicaset_name)
     return res
 end
 
--- Returns instance_uuid and replicaset_uuid, saved in config.
-local function find_uuids_by_name(peers, instance_name)
-    for name, peer in pairs(peers) do
-        if name == instance_name then
-            local iconfig = peer.iconfig_def
-            return instance_config:get(iconfig, 'database.instance_uuid'),
-                   instance_config:get(iconfig, 'database.replicaset_uuid')
-        end
-    end
-    return nil
-end
-
 local function find_peer_name_by_uuid(peers, instance_uuid)
     for name, peer in pairs(peers) do
         local uuid = instance_config:get(peer.iconfig_def,
@@ -874,14 +862,12 @@ local function new(iconfig, cconfig, instance_name)
     -- and during config reload.
     local saved_names = find_saved_names(iconfig_def)
     if saved_names ~= nil then
-        local config_instance_uuid, config_replicaset_uuid =
-            find_uuids_by_name(peers, instance_name)
         validate_names(saved_names, {
             replicaset_name = found.replicaset_name,
             instance_name = instance_name,
             -- UUIDs from config, generated one should not be used here.
-            replicaset_uuid = config_replicaset_uuid,
-            instance_uuid = config_instance_uuid,
+            replicaset_uuid = replicaset_uuid,
+            instance_uuid = instance_uuid,
             peers = peers,
         }, iconfig_def)
     end

--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -486,7 +486,6 @@ local function validate_names(saved_names, config_names, iconfig)
     -- Fail early, if current UUID is not set, but no name is found
     -- inside the snapshot file. Ignore this failure, if replica is
     -- configured as anonymous, anon replicas cannot have names.
-    local iconfig = config_names.peers[config_names.instance_name].iconfig_def
     if not instance_config:get(iconfig, 'replication.anon') then
         if saved_names.instance_name == nil and
            config_names.instance_uuid == nil then
@@ -868,7 +867,6 @@ local function new(iconfig, cconfig, instance_name)
             -- UUIDs from config, generated one should not be used here.
             replicaset_uuid = replicaset_uuid,
             instance_uuid = instance_uuid,
-            peers = peers,
         }, iconfig_def)
     end
 


### PR DESCRIPTION
*(This is a backport of PR #10683 to `release/3.2`.)*

----

No functional changes, just a little refactoring.

These two commits adjust the configdata code to reuse a few values, which are already calculated, instead of acquiring them once again.