### PR TITLE
box: fix `SIGSEGV` on unaligned access to `struct applier`

### DIFF
--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -2767,8 +2767,8 @@ applier_kill(struct applier *applier, struct error *e)
 struct applier *
 applier_new(const struct uri *uri)
 {
-	struct applier *applier = (struct applier *)
-		xcalloc(1, sizeof(struct applier));
+	struct applier *applier = xalloc_object(struct applier);
+	memset(applier, 0, sizeof(*applier));
 	if (iostream_ctx_create(&applier->io_ctx, IOSTREAM_CLIENT, uri) != 0) {
 		free(applier);
 		diag_raise();


### PR DESCRIPTION
All structures with a non-default alignment (set by `alignas()`) must be allocated by `aligned_alloc()`, otherwise an access to such a structure member fill crash, e.g. if compiled with AVX-512 support.

See also commit a60ec82d4f07 ("box: fix SIGSEGV on unaligned access to a struct with extended alignment").

Closes #10699