### PR TITLE
box/lua: don't crash on `box.internal.tuple_format.new()` misuse

### DIFF
--- a/test/box-luatest/gh_4693_formats_for_standalone_tuples_test.lua
+++ b/test/box-luatest/gh_4693_formats_for_standalone_tuples_test.lua
@@ -37,6 +37,21 @@ g.test_box_tuple_format_new = function()
     end)
 end
 
+-- Checks that improper use of `box.internal.tuple_format.new` doesn't crash.
+g.test_box_internal_tuple_format_new = function(cg)
+    cg.server:exec(function()
+        t.assert_error_msg_equals(
+            "Wrong space format: expected array",
+            box.internal.tuple_format.new)
+        t.assert_error_msg_equals(
+            "Wrong space format: expected array",
+            box.internal.tuple_format.new, 1984)
+        t.assert_error_msg_equals(
+            "Wrong space format: expected array",
+            box.internal.tuple_format.new, {type = 'test'})
+    end)
+end
+
 g.before_test('test_box_tuple_format_gc', function (cg)
     cg.server:exec(function()
         box.error.injection.set('ERRINJ_TUPLE_FORMAT_COUNT', 2)


### PR DESCRIPTION
Even though `box.internal.tuple_format.new()` is an internal function, it is quite easy to call it from the console using auto completion and to crash Tarantool. Let's replace the assertion with an error.

Closes #10529