### PR TITLE
box/lua: change `space:bsize()` return type from `cdata` to `number`

### DIFF
--- a/changelogs/unreleased/gh-9735-fix-space-bsize-return-type.md
+++ b/changelogs/unreleased/gh-9735-fix-space-bsize-return-type.md
@@ -1,0 +1,4 @@
+## bugfix/lua
+
+* Changed return value type of `space:bsize()` from `cdata` to `number`
+  (gh-9735).

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -2761,7 +2761,7 @@ space_mt.bsize = function(space)
     if s == nil then
         box.error(box.error.NO_SUCH_SPACE, space.name, 2)
     end
-    return builtin.space_bsize(s)
+    return tonumber(builtin.space_bsize(s))
 end
 
 space_mt.get = function(space, key)

--- a/test/box/space_bsize.result
+++ b/test/box/space_bsize.result
@@ -98,6 +98,14 @@ utils.space_bsize(s)
 ---
 - 130
 ...
+type(s:bsize())
+---
+- number
+...
+type(utils.space_bsize(s))
+---
+- number
+...
 s:drop()
 ---
 ...

--- a/test/box/space_bsize.test.lua
+++ b/test/box/space_bsize.test.lua
@@ -46,5 +46,7 @@ for i = 1, 13 do s:insert{ i, string.rep('x', i) } end
 
 s:bsize()
 utils.space_bsize(s)
+type(s:bsize())
+type(utils.space_bsize(s))
 
 s:drop()


### PR DESCRIPTION
To be consistent with other similar methods, e.g. `index:bsize()`.

Closes #9735