### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-10199-luajit-fixes.md
+++ b/changelogs/unreleased/gh-10199-luajit-fixes.md
@@ -1,0 +1,17 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-10199). The following
+issues were fixed as part of this activity:
+
+* Now 64-bit non-FAT Mach-O object files are generated via `-b -o osx`.
+* Fixed `string.format()` compilation with many elements.
+* Fixed `dlerror()` in FFI call returning `NULL`.
+* Fixed `__tostring` metamethod access to enum cdata value.
+* Fixed limit check in narrowing optimization.
+* Dropped finalizer table rehashing after GC cycle (gh-10290).
+* Fixed recording of `select(string, ...)`.
+* Fixed stack allocation after on-trace stack check.
+* Fixed recording of `__concat` metamethod that throws an error.
+* Fixed bit op coercion in `DUALNUM` builds.
+* Fixed 64-bit shift fold rules.
+* Fixed loop optimizations for cdata arguments of vararg FFI functions.


### PR DESCRIPTION
* Fix typo.
* OSX/iOS: Always generate 64 bit non-FAT Mach-O object files.
* test: don't run JIT-based LuaJIT tests without JIT
* test: actualize <LuaJIT-tests/README.md>
* test: enable <misc/alias_alloc.lua> LuaJIT test
* test: refactor <alias_alloc.lua> LuaJIT test
* test: refactor <lang/coroutine.lua> LuaJIT test
* test: remove <misc/coro_yield.lua> LuaJIT test
* test: enable <misc/debug_gc.lua> LuaJIT test
* test: enable <misc/dualnum.lua> LuaJIT test
* test: refactor <lang/dualnum.lua> LuaJIT test
* test: remove <misc/fori_coerce.lua> LuaJIT test
* test: remove <misc/fori_dir.lua> LuaJIT test
* test: remove <misc/gc_rechain.lua> LuaJIT test
* test: enable <misc/gc_trace.lua> LuaJIT test
* test: refactor <trace/gc.lua> LuaJIT test
* test: enable <misc/gcstep.lua> LuaJIT test
* test: enable <misc/hook_active.lua> LuaJIT test
* test: enable <misc/hook_line.lua> LuaJIT test
* test: enable <misc/hook_norecord.lua> LuaJIT test
* test: enable <misc/hook_record.lua> LuaJIT test
* test: enable <misc/hook_top.lua> LuaJIT test
* test: enable <misc/jit_flush.lua> LuaJIT test
* test: remove <misc/loop_unroll.lua> LuaJIT test
* test: enable <misc/parse_comp.lua> LuaJIT test
* test: enable <misc/parse_esc.lua> LuaJIT test
* test: enable <misc/parse_misc.lua> LuaJIT test
* test: enable <misc/phi_conv.lua> LuaJIT test
* test: refactor <trace/phi/conv.lua> LuaJIT test
* test: enable <misc/recurse_deep.lua> LuaJIT test
* test: remove <misc/recurse_tail.lua> LuaJIT test
* test: enable <misc/stack_gc.lua> LuaJIT test
* test: refactor <lang/gc_stack.lua> LuaJIT test
* test: enable <misc/stack_purge.lua> LuaJIT test
* test: refactor <trace/stack_purge.lua> LuaJIT test
* test: enable <misc/stackov.lua> LuaJIT test
* test: enable <misc/stackovc.lua> LuaJIT test
* test: enable <misc/tcall_base.lua> LuaJIT test
* test: refactor <trace/tcall_base.lua> LuaJIT test
* test: enable <misc/tcall_loop.lua> LuaJIT test
* test: enable <misc/tonumber_scan.lua> LuaJIT test
* test: remove <misc/uclo.lua> LuaJIT test
* test: enable <misc/unordered_jit.lua> LuaJIT test
* test: enable <misc/wbarrier.lua> LuaJIT test
* test: enable <misc/wbarrier_jit.lua> LuaJIT test
* test: enable <misc/wbarrier_obar.lua> LuaJIT test
* test: update <LuaJIT-tests/README.md>
* test: off JIT for routines in <lang/stackov.lua>
* Limit number of string format elements to compile.
* Clear stack after print_jit_status() in CLI.
* FFI: Workaround for platform dlerror() returning NULL.
* test: move profilers tests to subdirectory
* test: rename <arm64-ccall-fp-convention.test.lua>
* cmake: introduce AppendTestEnvVar macro
* test: shrink LUA_PATH environment variable
* test: shrink LUA_CPATH and {DY}LD_LIBRARY_PATH
* test: skip flaky tests with enabled table bump
* test: set LD_PRELOAD only when necessary
* test: fix misclib-getmetrics-lapi.test.lua
* FFI: Fix __tostring metamethod access to enum cdata value.
* Fix limit check in narrow_conv_backprop().
* FFI: Drop finalizer table rehash after GC cycle.
* Drop unused function wrapper.
* FFI: Fix various issues in recff_cdata_arith.
* Add missing coercion when recording select(string, ...)
* Fix stack allocation after on-trace stack check.
* Restore state when recording __concat metamethod throws an error.
* Fix bit op coercion in DUALNUM builds.
* FFI: Fix 64 bit shift fold rules.
* Limit CSE for IR_CARG to fix loop optimizations.

Closes #10290
Closes #10199
Closes #9898
Part of #9398

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump