### PR TITLE
[backport] box: export box_slab_info via C API

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -35,6 +35,7 @@
 #include <sys/utsname.h>
 #include <spawn.h>
 
+#include "box/allocator.h"
 #include "lua/utils.h" /* lua_hash() */
 #include "fiber_pool.h"
 #include <say.h>
@@ -4229,6 +4230,49 @@ box_info_lsn(void)
 	} else {
 		return -1;
 	}
+}
+
+/**
+ * Get memtx status information for box.slab.info
+ */
+uint64_t
+box_slab_info(enum box_slab_info_type type)
+{
+	struct memtx_engine *memtx;
+	memtx = (struct memtx_engine *)engine_by_name("memtx");
+
+	struct allocator_stats stats;
+	memset(&stats, 0, sizeof(stats));
+
+	allocators_stats(&stats);
+	struct mempool_stats index_stats;
+	mempool_stats(&memtx->index_extent_pool, &index_stats);
+
+	switch (type) {
+	case BOX_SLAB_INFO_ITEMS_SIZE:
+		return stats.small.total + stats.sys.total;
+	case BOX_SLAB_INFO_ITEMS_USED:
+		return stats.small.used + stats.sys.used;
+	case BOX_SLAB_INFO_ARENA_SIZE:
+		/*
+		 * We could use stats.small.used + index_stats.total.used
+		 * here, but this would not account for slabs which are
+		 * sitting in slab cache or in the arena, available for reuse.
+		 * Make sure a simple formula: items_used_ratio > 0.9 &&
+		 * arena_used_ratio > 0.9 && quota_used_ratio > 0.9 work as
+		 * an indicator for reaching Tarantool memory limit.
+		 */
+		return memtx->arena.used;
+	case BOX_SLAB_INFO_ARENA_USED:
+		/** System allocator does not use arena. */
+		return stats.small.used + index_stats.totals.used;
+	case BOX_SLAB_INFO_QUOTA_SIZE:
+		return quota_total(&memtx->quota);
+	case BOX_SLAB_INFO_QUOTA_USED:
+		return quota_used(&memtx->quota);
+	default:
+		return 0;
+	};
 }
 
 /**

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -873,6 +873,22 @@ box_read_ffi_disable(void);
 void
 box_read_ffi_enable(void);
 
+/*! Codes for request memtx status information for box.slab.info. */
+enum box_slab_info_type {
+	BOX_SLAB_INFO_ITEMS_SIZE = 0, /*!< Allocated only for tuples. */
+	BOX_SLAB_INFO_ITEMS_USED = 1, /*!< Used only for tuples. */
+	BOX_SLAB_INFO_ARENA_SIZE = 2, /*!< Allocated for  tuples and indexes. */
+	BOX_SLAB_INFO_ARENA_USED = 3, /*!< Used for both tuples and indexes. */
+	BOX_SLAB_INFO_QUOTA_SIZE = 4, /*!< Memory limit for slab allocator. */
+	BOX_SLAB_INFO_QUOTA_USED = 5, /*!< Used by slab allocator. */
+};
+
+/**
+ * Get memtx status information for box.slab.info.
+ */
+uint64_t
+box_slab_info(enum box_slab_info_type type);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -22,6 +22,10 @@
  * fiber.h. See gh-8025.
  *
  * [2]: test/box-tap/check_merge_source.c
+ *
+ * box_slab_info() is used in TCS to get information about the memory
+ * state during automatic selection of the columns to delete when
+ * tarantool's memory runs out.
  */
 
 extern void
@@ -52,6 +56,8 @@ extern void
 ipc_value_new(void);
 extern void
 fiber_lua_state(void);
+extern void
+box_slab_info(void);
 
 /** Symbol definition. */
 struct symbol_def {
@@ -76,6 +82,7 @@ static struct symbol_def symbols[] = {
 	{"ipc_value_delete", ipc_value_delete},
 	{"ipc_value_new", ipc_value_new},
 	{"fiber_lua_state", fiber_lua_state},
+	{"box_slab_info", box_slab_info},
 	{NULL, NULL}
 };
 

--- a/test/app-luatest/tnt_internal_symbol_test.lua
+++ b/test/app-luatest/tnt_internal_symbol_test.lua
@@ -26,6 +26,7 @@ g.test_fiber_channel = function()
         'ipc_value_delete',
         'ipc_value_new',
         'fiber_lua_state',
+        'box_slab_info',
     }
     -- Verify only that we can get the address. The functions are
     -- provided 'as is' and we don't guarantee anything regarding


### PR DESCRIPTION
Added the new C function `box_slab_info` that returns information about the memory state depending on the passed argument `box_slab_info_type`. The same information is available in Lua via `box.slab.info()`.

Backported to 3.2.1 in the sake of TCS, which uses that function to get information about the memory state during automatic selection of the columns to delete when tarantool's memory runs out.

Co-authored-by: SEChudinov <s.chudinov@vkteam.ru>

NO_DOC=internal
NO_CHANGELOG=internal