### PR TITLE
box: build fix

### DIFF
--- a/src/box/tuple_hash.cc
+++ b/src/box/tuple_hash.cc
@@ -308,13 +308,12 @@ tuple_hash_field(uint32_t *ph1, uint32_t *pcarry, const char **field,
 	 * double and decimal have the same hash.
 	 */
 	if (type == FIELD_TYPE_DOUBLE) {
-		double value;
+		double value = 0;
 		/*
 		 * This will only fail if the mp_type is not numeric, which is
 		 * impossible here (see field_mp_plain_type_is_compatible).
 		 */
-		if (mp_read_double_lossy(field, &value) == -1)
-			unreachable();
+		VERIFY(mp_read_double_lossy(field, &value) == 0);
 		char *double_msgpack_end = mp_encode_double(buf, value);
 		size = double_msgpack_end - buf;
 		assert(size <= sizeof(buf));


### PR DESCRIPTION
I got compile error for release build on gcc 14.2.1 20240910 version.

```
In function ‘char* mp_store_double(char*, double)’,
    inlined from ‘char* mp_encode_double(char*, double)’ at /home/shiny/dev/tarantool-ee/tarantool/src/lib/msgpuck/msgpuck.h:2409:24,
    inlined from ‘uint32_t tuple_hash_field(uint32_t*, uint32_t*, const char**, field_type, coll*)’ at /home/shiny/dev/tarantool-ee/tarantool/src/box/tuple_hash.cc:317:46:
/home/shiny/dev/tarantool-ee/tarantool/src/lib/msgpuck/msgpuck.h:340:16: error: ‘value’ may be used uninitialized [-Werror=maybe-uninitialized]
  340 |         cast.d = val;
      |         ~~~~~~~^~~~~
/home/shiny/dev/tarantool-ee/tarantool/src/box/tuple_hash.cc: In function ‘uint32_t tuple_hash_field(uint32_t*, uint32_t*, const char**, field_type, coll*)’:
/home/shiny/dev/tarantool-ee/tarantool/src/box/tuple_hash.cc:311:24: note: ‘value’ was declared here
  311 |                 double value;
      |
```