### PR TITLE
memtx: use the matras's new reservation machinery

### DIFF
--- a/perf/bps_tree.cc
+++ b/perf/bps_tree.cc
@@ -439,7 +439,7 @@ test_delete_insert(benchmark::State &state, size_t count, KeyGen kg)
 	create<tree>(t, count, allocator);
 	for (auto _ : state) {
 		typename tree::elem_t elem(kg());
-		tree::delete_(&t, elem);
+		tree::delete_(&t, elem, NULL);
 		tree::insert(&t, elem, &replaced, &successor);
 	}
 	tree::destroy(&t);
@@ -572,7 +572,7 @@ test_delete(benchmark::State &state, size_t count, KeyGen kg)
 	typename tree::Allocator allocator(count);
 	create<tree>(t, count, allocator);
 	for (auto _ : state)
-		tree::delete_(&t, kg());
+		tree::delete_(&t, kg(), NULL);
 	tree::destroy(&t);
 }
 

--- a/src/box/memtx_bitset.cc
+++ b/src/box/memtx_bitset.cc
@@ -541,8 +541,8 @@ memtx_bitset_index_new(struct memtx_engine *memtx, struct index_def *def)
 	index->id_to_tuple = (struct matras *)malloc(sizeof(*index->id_to_tuple));
 	if (index->id_to_tuple == NULL)
 		panic("failed to allocate memtx bitset index");
-	matras_create(index->id_to_tuple, MEMTX_EXTENT_SIZE, sizeof(struct tuple *),
-		      memtx_index_extent_alloc, memtx_index_extent_free, memtx,
+	matras_create(index->id_to_tuple, sizeof(struct tuple *),
+		      &memtx->index_extent_allocator,
 		      &memtx->index_extent_stats);
 
 	index->tuple_to_id = mh_bitset_index_new();

--- a/src/box/memtx_bitset.cc
+++ b/src/box/memtx_bitset.cc
@@ -85,7 +85,7 @@ enum {
 	SPARE_ID_END = 0xFFFFFFFF
 };
 
-static void
+static int
 memtx_bitset_index_register_tuple(struct memtx_bitset_index *index,
 				  struct tuple *tuple)
 {
@@ -98,6 +98,8 @@ memtx_bitset_index_register_tuple(struct memtx_bitset_index *index,
 		place = (struct tuple **)mem;
 	} else {
 		place = (struct tuple **)matras_alloc(index->id_to_tuple, &id);
+		if (place == NULL)
+			return -1;
 	}
 	*place = tuple;
 
@@ -105,6 +107,7 @@ memtx_bitset_index_register_tuple(struct memtx_bitset_index *index,
 	entry.id = id;
 	entry.tuple = tuple;
 	mh_bitset_index_put(index->tuple_to_id, &entry, 0, 0);
+	return 0;
 }
 
 static void
@@ -321,7 +324,15 @@ memtx_bitset_index_replace(struct index *base, struct tuple *old_tuple,
 		uint32_t key_len;
 		const void *key = make_key(field, &key_len);
 #ifndef OLD_GOOD_BITSET
-		memtx_bitset_index_register_tuple(index, new_tuple);
+		if (memtx_bitset_index_register_tuple(index, new_tuple) != 0) {
+			/*
+			 * We can't fail to allocate a new tuple pointer if we
+			 * have just deregistered the old one - it will be moved
+			 * to the spare list and reused.
+			 */
+			assert(*result == NULL);
+			return -1;
+		}
 		uint32_t value = memtx_bitset_index_tuple_to_value(index, new_tuple);
 #else /* #ifndef OLD_GOOD_BITSET */
 		uint32_t value = tuple_to_value(new_tuple);

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -2173,22 +2173,6 @@ memtx_index_extent_free(struct matras_allocator *matras_allocator, void *extent)
 	mempool_free(&memtx->index_extent_pool, extent);
 }
 
-/**
- * Reserve num extents in pool.
- * Ensure that next num extent_alloc will succeed w/o an error
- */
-int
-memtx_index_extent_reserve(struct memtx_engine *memtx, int num)
-{
-	ERROR_INJECT(ERRINJ_INDEX_ALLOC, {
-		/* same error as in mempool_alloc */
-		diag_set(OutOfMemory, MEMTX_EXTENT_SIZE,
-			 "mempool", "new slab");
-		return -1;
-	});
-	return matras_allocator_reserve(&memtx->index_extent_allocator, num);
-}
-
 bool
 memtx_index_def_change_requires_rebuild(struct index *index,
 					const struct index_def *new_def)

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -92,6 +92,13 @@ memtx_tuple_new_raw_impl(struct tuple_format *format, const char *data,
 static void
 memtx_engine_run_gc(struct memtx_engine *memtx, bool *stop);
 
+static void *
+memtx_index_extent_alloc(struct matras_allocator *matras_allocator);
+
+static void
+memtx_index_extent_free(struct matras_allocator *matras_allocator,
+			void *extent);
+
 template<class ALLOC>
 static void
 memtx_alloc_init(void)
@@ -220,12 +227,7 @@ memtx_engine_free(struct engine *engine)
 	mempool_destroy(&memtx->iterator_pool);
 	if (mempool_is_initialized(&memtx->rtree_iterator_pool))
 		mempool_destroy(&memtx->rtree_iterator_pool);
-	void *p = memtx->reserved_extents;
-	while (p != NULL) {
-		void *next = *(void **)p;
-		memtx_index_extent_free(memtx, p);
-		p = next;
-	}
+	matras_allocator_destroy(&memtx->index_extent_allocator);
 	mempool_destroy(&memtx->index_extent_pool);
 	slab_cache_destroy(&memtx->index_slab_cache);
 	mh_ptr_delete(memtx->malloc_extents);
@@ -1771,11 +1773,13 @@ memtx_engine_new(const char *snap_dirname, bool force_recovery,
 	slab_cache_create(&memtx->index_slab_cache, &memtx->arena);
 	mempool_create(&memtx->index_extent_pool, &memtx->index_slab_cache,
 		       MEMTX_EXTENT_SIZE);
+	matras_allocator_create(&memtx->index_extent_allocator,
+				MEMTX_EXTENT_SIZE,
+				memtx_index_extent_alloc,
+				memtx_index_extent_free);
 	matras_stats_create(&memtx->index_extent_stats);
 	mempool_create(&memtx->iterator_pool, cord_slab_cache(),
 		       MEMTX_ITERATOR_SIZE);
-	memtx->num_reserved_extents = 0;
-	memtx->reserved_extents = NULL;
 	memtx->malloc_extents = mh_ptr_new();
 
 	memtx->state = MEMTX_INITIALIZED;
@@ -2117,17 +2121,12 @@ create_memtx_tuple_format_vtab(struct tuple_format_vtab *vtab)
 /**
  * Allocate a block of size MEMTX_EXTENT_SIZE for memtx index
  */
-void *
-memtx_index_extent_alloc(void *ctx)
+static void *
+memtx_index_extent_alloc(struct matras_allocator *matras_allocator)
 {
-	struct memtx_engine *memtx = (struct memtx_engine *)ctx;
-	if (memtx->reserved_extents) {
-		assert(memtx->num_reserved_extents > 0);
-		memtx->num_reserved_extents--;
-		void *result = memtx->reserved_extents;
-		memtx->reserved_extents = *(void **)memtx->reserved_extents;
-		return result;
-	}
+	struct memtx_engine *memtx = container_of(matras_allocator,
+						  struct memtx_engine,
+						  index_extent_allocator);
 	ERROR_INJECT(ERRINJ_INDEX_ALLOC, { goto fail; });
 	void *ret;
 	while ((ret = mempool_alloc(&memtx->index_extent_pool)) == NULL) {
@@ -2159,10 +2158,12 @@ fail:
 /**
  * Free a block previously allocated by memtx_index_extent_alloc
  */
-void
-memtx_index_extent_free(void *ctx, void *extent)
+static void
+memtx_index_extent_free(struct matras_allocator *matras_allocator, void *extent)
 {
-	struct memtx_engine *memtx = (struct memtx_engine *)ctx;
+	struct memtx_engine *memtx = container_of(matras_allocator,
+						  struct memtx_engine,
+						  index_extent_allocator);
 	mh_int_t p = mh_ptr_find(memtx->malloc_extents, extent, NULL);
 	if (p != mh_end(memtx->malloc_extents)) {
 		mh_ptr_del(memtx->malloc_extents, p, NULL);
@@ -2185,25 +2186,7 @@ memtx_index_extent_reserve(struct memtx_engine *memtx, int num)
 			 "mempool", "new slab");
 		return -1;
 	});
-	struct mempool *pool = &memtx->index_extent_pool;
-	while (memtx->num_reserved_extents < num) {
-		void *ext;
-		while ((ext = mempool_alloc(pool)) == NULL) {
-			bool stop;
-			memtx_engine_run_gc(memtx, &stop);
-			if (stop)
-				break;
-		}
-		if (ext == NULL) {
-			diag_set(OutOfMemory, MEMTX_EXTENT_SIZE,
-				 "mempool", "new slab");
-			return -1;
-		}
-		*(void **)ext = memtx->reserved_extents;
-		memtx->reserved_extents = ext;
-		memtx->num_reserved_extents++;
-	}
-	return 0;
+	return matras_allocator_reserve(&memtx->index_extent_allocator, num);
 }
 
 bool

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -144,19 +144,12 @@ struct memtx_engine {
 	struct slab_cache slab_cache;
 	/** Slab cache for allocating index extents. */
 	struct slab_cache index_slab_cache;
-	/** Index extent allocator. */
+	/** Index extent source. */
 	struct mempool index_extent_pool;
+	/** Index extent allocator. */
+	struct matras_allocator index_extent_allocator;
 	/** Index extent allocator statistics. */
 	struct matras_stats index_extent_stats;
-	/**
-	 * To ensure proper statement-level rollback in case
-	 * of out of memory conditions, we maintain a number
-	 * of slack memory extents reserved before a statement
-	 * is begun. If there isn't enough slack memory,
-	 * we don't begin the statement.
-	 */
-	int num_reserved_extents;
-	void *reserved_extents;
 	/** Maximal allowed tuple size, box.cfg.memtx_max_tuple_size. */
 	size_t max_tuple_size;
 	/** Memory pool for rtree index iterator. */
@@ -260,20 +253,6 @@ enum {
 extern struct tuple *
 (*memtx_tuple_new_raw)(struct tuple_format *format, const char *data,
 		       const char *end, bool validate);
-
-/**
- * Allocate a block of size MEMTX_EXTENT_SIZE for memtx index
- * @ctx must point to memtx engine
- */
-void *
-memtx_index_extent_alloc(void *ctx);
-
-/**
- * Free a block previously allocated by memtx_index_extent_alloc
- * @ctx must point to memtx engine
- */
-void
-memtx_index_extent_free(void *ctx, void *extent);
 
 /**
  * Reserve num extents in pool.

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -91,18 +91,6 @@ enum memtx_recovery_state {
 	MEMTX_OK,
 };
 
-enum memtx_reserve_extents_num {
-	/**
-	 * This number is calculated based on the
-	 * max (realistic) number of insertions
-	 * a deletion from a B-tree or an R-tree
-	 * can lead to, and, as a result, the max
-	 * number of new block allocations.
-	 */
-	RESERVE_EXTENTS_BEFORE_DELETE = 8,
-	RESERVE_EXTENTS_BEFORE_REPLACE = 16
-};
-
 /**
  * The size of the biggest memtx iterator. Used with
  * mempool_create. This is the size of the block that will be
@@ -253,13 +241,6 @@ enum {
 extern struct tuple *
 (*memtx_tuple_new_raw)(struct tuple_format *format, const char *data,
 		       const char *end, bool validate);
-
-/**
- * Reserve num extents in pool.
- * Ensure that next num extent_alloc will succeed w/o an error
- */
-int
-memtx_index_extent_reserve(struct memtx_engine *memtx, int num);
 
 /**
  * Generic implementation of index_vtab::def_change_requires_rebuild,

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -691,8 +691,7 @@ memtx_hash_index_new(struct memtx_engine *memtx, struct index_def *def)
 		     &memtx_hash_index_vtab, def);
 
 	light_index_create(&index->hash_table, index->base.def->key_def,
-			   MEMTX_EXTENT_SIZE, memtx_index_extent_alloc,
-			   memtx_index_extent_free, memtx,
+			   &memtx->index_extent_allocator,
 			   &memtx->index_extent_stats);
 	return &index->base;
 }

--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -449,7 +449,6 @@ memtx_rtree_index_new(struct memtx_engine *memtx, struct index_def *def)
 
 	index->dimension = def->opts.dimension;
 	rtree_init(&index->tree, index->dimension, distance_type,
-		   MEMTX_EXTENT_SIZE, memtx_index_extent_alloc,
-		   memtx_index_extent_free, memtx, &memtx->index_extent_stats);
+		   &memtx->index_extent_allocator, &memtx->index_extent_stats);
 	return &index->base;
 }

--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -52,6 +52,18 @@ struct memtx_rtree_index {
 	struct rtree tree;
 };
 
+enum memtx_rtree_reserve_extents_num {
+	/**
+	 * This number is calculated based on the
+	 * max (realistic) number of insertions
+	 * a deletion from a B-tree or an R-tree
+	 * can lead to, and, as a result, the max
+	 * number of new block allocations.
+	 */
+	RESERVE_EXTENTS_BEFORE_DELETE = 8,
+	RESERVE_EXTENTS_BEFORE_REPLACE = 16
+};
+
 /* {{{ Utilities. *************************************************/
 
 static inline int
@@ -262,6 +274,17 @@ memtx_rtree_index_replace(struct index *base, struct tuple *old_tuple,
 	(void)mode;
 	struct memtx_rtree_index *index = (struct memtx_rtree_index *)base;
 
+	/*
+	 * There's no allocation failure handling in the tree, so it's required
+	 * to reserve potentially big enough space prior to the operations.
+	 */
+	struct memtx_engine *memtx = (struct memtx_engine *)base->engine;
+	if (matras_allocator_reserve(&memtx->index_extent_allocator,
+				     new_tuple != NULL ?
+				     RESERVE_EXTENTS_BEFORE_REPLACE :
+				     RESERVE_EXTENTS_BEFORE_DELETE) != 0)
+		return -1;
+
 	/* RTREE index doesn't support ordering. */
 	*successor = NULL;
 
@@ -296,7 +319,8 @@ memtx_rtree_index_reserve(struct index *base, uint32_t size_hint)
 		return -1;
 	});
 	struct memtx_engine *memtx = (struct memtx_engine *)base->engine;
-	return memtx_index_extent_reserve(memtx, RESERVE_EXTENTS_BEFORE_REPLACE);
+	return matras_allocator_reserve(&memtx->index_extent_allocator,
+					RESERVE_EXTENTS_BEFORE_REPLACE);
 }
 
 /** Implementation of create_iterator for memtx rtree index. */

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -293,16 +293,6 @@ memtx_space_replace_all_keys(struct space *space, struct tuple *old_tuple,
 			     enum dup_replace_mode mode,
 			     struct tuple **result)
 {
-	struct memtx_engine *memtx = (struct memtx_engine *)space->engine;
-	/*
-	 * Ensure we have enough slack memory to guarantee
-	 * successful statement-level rollback.
-	 */
-	if (memtx_index_extent_reserve(memtx, new_tuple != NULL ?
-				       RESERVE_EXTENTS_BEFORE_REPLACE :
-				       RESERVE_EXTENTS_BEFORE_DELETE) != 0)
-		return -1;
-
 	uint32_t i = 0;
 
 	/* Update the primary key */

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -2610,8 +2610,8 @@ memtx_tree_index_new_tpl(struct memtx_engine *memtx, struct index_def *def,
 	cmp_def = def->opts.is_unique && !def->key_def->is_nullable ?
 			index->base.def->key_def : index->base.def->cmp_def;
 
-	memtx_tree_create(&index->tree, cmp_def, memtx_index_extent_alloc,
-			  memtx_index_extent_free, memtx,
+	memtx_tree_create(&index->tree, cmp_def,
+			  &memtx->index_extent_allocator,
 			  &memtx->index_extent_stats);
 	index->is_func = def->key_def->func_index_func != NULL;
 	return &index->base;

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -1543,7 +1543,7 @@ memtx_tree_index_replace(struct index *base, struct tuple *old_tuple,
 
 		if (index_check_dup(base, old_tuple, new_tuple,
 				    dup_data.tuple, mode) != 0) {
-			memtx_tree_delete(&index->tree, new_data);
+			memtx_tree_delete(&index->tree, new_data, NULL);
 			if (dup_data.tuple != NULL)
 				memtx_tree_insert(&index->tree, dup_data, NULL, NULL);
 			return -1;
@@ -1560,7 +1560,7 @@ memtx_tree_index_replace(struct index *base, struct tuple *old_tuple,
 		old_data.tuple = old_tuple;
 		if (USE_HINT)
 			old_data.set_hint(tuple_hint(old_tuple, cmp_def));
-		memtx_tree_delete(&index->tree, old_data);
+		memtx_tree_delete(&index->tree, old_data, NULL);
 		*result = old_tuple;
 	} else {
 		*result = NULL;
@@ -1600,7 +1600,7 @@ memtx_tree_index_replace_multikey_one(struct memtx_tree_index<true> *index,
 	} else if (index_check_dup(&index->base, old_tuple, new_tuple,
 				   dup_data.tuple, mode) != 0) {
 		/* Rollback replace. */
-		memtx_tree_delete(&index->tree, new_data);
+		memtx_tree_delete(&index->tree, new_data, NULL);
 		if (dup_data.tuple != NULL)
 			memtx_tree_insert(&index->tree, dup_data, NULL, NULL);
 		return -1;

--- a/src/box/vy_cache.c
+++ b/src/box/vy_cache.c
@@ -203,7 +203,7 @@ vy_cache_gc_step(struct vy_cache_env *env)
 	}
 	cache->version++;
 	vy_stmt_counter_acct_tuple(&cache->stat.evict, node->entry.stmt);
-	vy_cache_tree_delete(&cache->cache_tree, node);
+	vy_cache_tree_delete(&cache->cache_tree, node, NULL);
 	vy_cache_node_delete(cache->env, node);
 }
 
@@ -504,7 +504,7 @@ vy_cache_on_write(struct vy_cache *cache, struct vy_entry entry,
 		}
 		vy_stmt_counter_acct_tuple(&cache->stat.invalidate,
 					   to_delete->entry.stmt);
-		vy_cache_tree_delete(&cache->cache_tree, to_delete);
+		vy_cache_tree_delete(&cache->cache_tree, to_delete, NULL);
 		vy_cache_node_delete(cache->env, to_delete);
 	}
 }

--- a/src/box/vy_cache.h
+++ b/src/box/vy_cache.h
@@ -119,6 +119,8 @@ struct vy_cache_env {
 	struct rlist cache_lru;
 	/** Common mempool for vy_cache_node struct */
 	struct mempool cache_node_mempool;
+	/** Common matras extent allocator. */
+	struct matras_allocator allocator;
 	/** Size of memory occupied by cached tuples */
 	size_t mem_used;
 	/** Max memory size that can be used for cache */

--- a/src/box/vy_mem.c
+++ b/src/box/vy_mem.c
@@ -71,9 +71,10 @@ vy_mem_env_destroy(struct vy_mem_env *env)
 /** {{{ vy_mem */
 
 static void *
-vy_mem_tree_extent_alloc(void *ctx)
+vy_mem_tree_extent_alloc(struct matras_allocator *allocator)
 {
-	struct vy_mem *mem = (struct vy_mem *) ctx;
+	struct vy_mem *mem = container_of(allocator, struct vy_mem,
+					  matras_allocator);
 	struct vy_mem_env *env = mem->env;
 	void *ret = lsregion_aligned_alloc(&env->allocator,
 					   VY_MEM_TREE_EXTENT_SIZE,
@@ -89,10 +90,10 @@ vy_mem_tree_extent_alloc(void *ctx)
 }
 
 static void
-vy_mem_tree_extent_free(void *ctx, void *p)
+vy_mem_tree_extent_free(struct matras_allocator *allocator, void *p)
 {
 	/* Can't free part of region allocated memory. */
-	(void)ctx;
+	(void)allocator;
 	(void)p;
 }
 
@@ -114,9 +115,12 @@ vy_mem_new(struct vy_mem_env *env, struct key_def *cmp_def,
 	index->space_cache_version = space_cache_version;
 	index->format = format;
 	tuple_format_ref(format);
+	matras_allocator_create(&index->matras_allocator,
+				VY_MEM_TREE_EXTENT_SIZE,
+				vy_mem_tree_extent_alloc,
+				vy_mem_tree_extent_free);
 	vy_mem_tree_create(&index->tree, cmp_def,
-			   vy_mem_tree_extent_alloc,
-			   vy_mem_tree_extent_free, index, NULL);
+			   &index->matras_allocator, NULL);
 	rlist_create(&index->in_sealed);
 	fiber_cond_create(&index->pin_cond);
 	return index;
@@ -126,6 +130,13 @@ void
 vy_mem_delete(struct vy_mem *index)
 {
 	index->env->tree_extent_size -= index->tree_extent_size;
+	/*
+	 * It would be expected to destroy the index->matras_allocator and
+	 * the index->tree here, but they simply free allocated and reserved
+	 * memory blocks, and the lsregion used for allocation of the memory
+	 * does not support freeing arbitrary blocks, so they're effectively
+	 * no-ops. Let's omit them.
+	 */
 	tuple_format_unref(index->format);
 	fiber_cond_destroy(&index->pin_cond);
 	TRASH(index);

--- a/src/box/vy_mem.c
+++ b/src/box/vy_mem.c
@@ -290,7 +290,9 @@ vy_mem_rollback_stmt(struct vy_mem *mem, struct vy_entry entry,
 	 * Either way, we don't subtract the statement size because lsregion
 	 * doesn't support freeing memory.
 	 */
-	if (vy_mem_tree_delete(&mem->tree, entry) == 0) {
+	struct vy_entry deleted = vy_entry_none();
+	VERIFY(vy_mem_tree_delete(&mem->tree, entry, &deleted) == 0);
+	if (deleted.stmt != NULL) {
 		mem->version++;
 		mem->count.rows--;
 		count->rows--;

--- a/src/box/vy_mem.h
+++ b/src/box/vy_mem.h
@@ -162,6 +162,8 @@ struct vy_mem {
 	struct rlist in_sealed;
 	/** BPS tree */
 	struct vy_mem_tree tree;
+	/* The matras allocator used by the tree. */
+	struct matras_allocator matras_allocator;
 	/** Size of memory used for storing tree extents. */
 	size_t tree_extent_size;
 	/** Number of statements. */

--- a/src/lib/salad/bps_tree.h
+++ b/src/lib/salad/bps_tree.h
@@ -697,10 +697,9 @@ struct bps_tree_iterator {
  * @param alloc_stats - optional extent allocator statistics
  */
 static inline void
-bps_tree_create(struct bps_tree *tree, bps_tree_arg_t arg,
-		matras_alloc_func extent_alloc_func,
-		matras_free_func extent_free_func,
-		void *alloc_ctx, struct matras_stats *alloc_stats);
+bps_tree_create(struct bps_tree *t, bps_tree_arg_t arg,
+		struct matras_allocator *allocator,
+		struct matras_stats *alloc_stats);
 
 /**
  * @brief Fills a new (asserted) tree with values from sorted array.
@@ -1578,9 +1577,8 @@ struct bps_leaf_path_elem {
  */
 static inline void
 bps_tree_create(struct bps_tree *t, bps_tree_arg_t arg,
-		matras_alloc_func extent_alloc_func,
-		matras_free_func extent_free_func,
-		void *alloc_ctx, struct matras_stats *alloc_stats)
+		struct matras_allocator *allocator,
+		struct matras_stats *alloc_stats)
 {
 	struct bps_tree_common *tree = &t->common;
 	tree->root_id = (bps_tree_block_id_t)(-1);
@@ -1594,10 +1592,7 @@ bps_tree_create(struct bps_tree *t, bps_tree_arg_t arg,
 	tree->garbage_head_id = (bps_tree_block_id_t)(-1);
 	tree->arg = arg;
 	memset(&tree->max_elem, 0, sizeof(tree->max_elem));
-	matras_create(&t->matras,
-		      BPS_TREE_EXTENT_SIZE, BPS_TREE_BLOCK_SIZE,
-		      extent_alloc_func, extent_free_func, alloc_ctx,
-		      alloc_stats);
+	matras_create(&t->matras, BPS_TREE_BLOCK_SIZE, allocator, alloc_stats);
 	matras_head_read_view(&t->view);
 	tree->matras = &t->matras;
 	tree->view = &t->view;

--- a/src/lib/salad/light.h
+++ b/src/lib/salad/light.h
@@ -212,8 +212,7 @@ static const uint32_t LIGHT(end) = 0xFFFFFFFF;
  */
 static inline void
 LIGHT(create)(struct LIGHT(core) *ht, LIGHT_CMP_ARG_TYPE arg,
-	      size_t extent_size, matras_alloc_func extent_alloc_func,
-	      matras_free_func extent_free_func, void *alloc_ctx,
+	      struct matras_allocator *allocator,
 	      struct matras_stats *alloc_stats);
 
 /**
@@ -440,8 +439,7 @@ LIGHT(view_iterator_get_and_next)(const struct LIGHT(view) *v,
  */
 static inline void
 LIGHT(create)(struct LIGHT(core) *htab, LIGHT_CMP_ARG_TYPE arg,
-	      size_t extent_size, matras_alloc_func extent_alloc_func,
-	      matras_free_func extent_free_func, void *alloc_ctx,
+	      struct matras_allocator *allocator,
 	      struct matras_stats *alloc_stats)
 {
 	struct LIGHT(common) *ht = &htab->common;
@@ -451,10 +449,8 @@ LIGHT(create)(struct LIGHT(core) *htab, LIGHT_CMP_ARG_TYPE arg,
 	ht->table_size = 0;
 	ht->empty_slot = LIGHT(end);
 	ht->arg = arg;
-	matras_create(&htab->mtable,
-		      extent_size, sizeof(struct LIGHT(record)),
-		      extent_alloc_func, extent_free_func, alloc_ctx,
-		      alloc_stats);
+	matras_create(&htab->mtable, sizeof(struct LIGHT(record)),
+		      allocator, alloc_stats);
 	matras_head_read_view(&htab->view);
 	ht->mtable = &htab->mtable;
 	ht->view = &htab->view;

--- a/src/lib/salad/rtree.c
+++ b/src/lib/salad/rtree.c
@@ -942,9 +942,9 @@ rtree_iterator_next(struct rtree_iterator *itr)
 
 void
 rtree_init(struct rtree *tree, unsigned dimension,
-	   enum rtree_distance_type distance_type, uint32_t extent_size,
-	   matras_alloc_func extent_alloc, matras_free_func extent_free,
-	   void *alloc_ctx, struct matras_stats *alloc_stats)
+	   enum rtree_distance_type distance_type,
+	   struct matras_allocator *allocator,
+	   struct matras_stats *alloc_stats)
 {
 	tree->n_records = 0;
 	tree->height = 0;
@@ -970,8 +970,7 @@ rtree_init(struct rtree *tree, unsigned dimension,
 	tree->neighbours_in_page = (tree->page_size - sizeof(void *))
 		/ sizeof(struct rtree_neighbor);
 
-	matras_create(&tree->mtab, extent_size, tree->page_size,
-		      extent_alloc, extent_free, alloc_ctx, alloc_stats);
+	matras_create(&tree->mtab, tree->page_size, allocator, alloc_stats);
 }
 
 void

--- a/src/lib/salad/rtree.h
+++ b/src/lib/salad/rtree.h
@@ -234,9 +234,9 @@ rtree_set2dp(struct rtree_rect *rect, coord_t x, coord_t y);
  */
 void
 rtree_init(struct rtree *tree, unsigned dimension,
-	   enum rtree_distance_type distance_type, uint32_t extent_size,
-	   matras_alloc_func extent_alloc, matras_free_func extent_free,
-	   void *alloc_ctx, struct matras_stats *alloc_stats);
+	   enum rtree_distance_type distance_type,
+	   struct matras_allocator *allocator,
+	   struct matras_stats *alloc_stats);
 
 /**
  * @brief Destroy a tree

--- a/test/box/errinj_index.result
+++ b/test/box/errinj_index.result
@@ -93,11 +93,11 @@ res
 ...
 for i = 501,2500 do s:insert{i, i} end
 ---
-- error: Failed to allocate 16384 bytes in mempool for new slab
+- error: Failed to allocate 16384 bytes in memtx_tree_index for replace
 ...
-s:delete{1}
+s:delete{1} -- still can delete, it does not require extents if no read view
 ---
-- error: Failed to allocate 16384 bytes in mempool for new slab
+- [1, 1, 'test1']
 ...
 res = {}
 ---
@@ -107,8 +107,7 @@ for i = 1,10 do table.insert(res, (s:get{i})) end
 ...
 res
 ---
-- - [1, 1, 'test1']
-  - [2, 2, 'test2']
+- - [2, 2, 'test2']
   - [3, 3, 'test3']
   - [4, 4, 'test4']
   - [5, 5, 'test5']
@@ -121,30 +120,29 @@ res
 res = {}
 ---
 ...
-for i = 501,510 do table.insert(res, (s:get{i})) end
+for i = 501,2500 do table.insert(res, (s:get{i})) end
 ---
 ...
-res
+#res -- only could insert some of entries with the extents reserved previously
 ---
-- []
+- 612
 ...
---count must be exactly 10
-function check_iter_and_size() local count = 0 for _, t in s.index[0]:pairs() do count = count + 1 end return count == 10 and "ok" or "fail" end
+function check_iter_and_size(num) local count = 0 for _, t in s.index[0]:pairs() do count = count + 1 end return count == num and "ok" or "fail" end
 ---
 ...
-check_iter_and_size()
+check_iter_and_size(621)
 ---
 - ok
 ...
 for i = 2501,3500 do s:insert{i, i} end
 ---
-- error: Failed to allocate 16384 bytes in mempool for new slab
+- error: Failed to allocate 16384 bytes in memtx_tree_index for replace
 ...
-s:delete{2}
+s:delete{2} -- still can delete, it does not require extents if no read view
 ---
-- error: Failed to allocate 16384 bytes in mempool for new slab
+- [2, 2, 'test2']
 ...
-check_iter_and_size()
+check_iter_and_size(620)
 ---
 - ok
 ...
@@ -156,9 +154,7 @@ for i = 1,10 do table.insert(res, (s:get{i})) end
 ...
 res
 ---
-- - [1, 1, 'test1']
-  - [2, 2, 'test2']
-  - [3, 3, 'test3']
+- - [3, 3, 'test3']
   - [4, 4, 'test4']
   - [5, 5, 'test5']
   - [6, 6, 'test6']
@@ -182,9 +178,7 @@ for i = 1,10 do table.insert(res, (s:get{i})) end
 ...
 res
 ---
-- - [1, 1, 'test1']
-  - [2, 2, 'test2']
-  - [3, 3, 'test3']
+- - [3, 3, 'test3']
   - [4, 4, 'test4']
   - [5, 5, 'test5']
   - [6, 6, 'test6']
@@ -205,9 +199,7 @@ for i = 1,10 do table.insert(res, (s:get{i})) end
 ...
 res
 ---
-- - [1, 1, 'test1']
-  - [2, 2, 'test2']
-  - [3, 3, 'test3']
+- - [3, 3, 'test3']
   - [4, 4, 'test4']
   - [5, 5, 'test5']
   - [6, 6, 'test6']
@@ -330,11 +322,11 @@ res
 ...
 for i = 501,2500 do s:insert{i, i} end
 ---
-- error: Failed to allocate 16384 bytes in mempool for new slab
+- error: Failed to allocate 16384 bytes in hash_table for key
 ...
-s:delete{1}
+s:delete{1} -- still can delete, it does not require extents if no read view
 ---
-- error: Failed to allocate 16384 bytes in mempool for new slab
+- [1, 1, 'test1']
 ...
 res = {}
 ---
@@ -344,8 +336,7 @@ for i = 1,10 do table.insert(res, (s:get{i})) end
 ...
 res
 ---
-- - [1, 1, 'test1']
-  - [2, 2, 'test2']
+- - [2, 2, 'test2']
   - [3, 3, 'test3']
   - [4, 4, 'test4']
   - [5, 5, 'test5']
@@ -358,36 +349,26 @@ res
 res = {}
 ---
 ...
-for i = 501,510 do table.insert(res, (s:get{i})) end
+for i = 501,2500 do table.insert(res, (s:get{i})) end
 ---
 ...
-res
+#res -- only could insert some of entries with the extents reserved previously
 ---
-- []
+- 1014
 ...
-res = {}
----
-...
-for i = 2001,2010 do table.insert(res, (s:get{i})) end
----
-...
-res
----
-- []
-...
-check_iter_and_size()
+check_iter_and_size(1023)
 ---
 - ok
 ...
 for i = 2501,3500 do s:insert{i, i} end
 ---
-- error: Failed to allocate 16384 bytes in mempool for new slab
+- error: Failed to allocate 16384 bytes in hash_table for key
 ...
-s:delete{2}
+s:delete{2} -- still can delete, it does not require extents if no read view
 ---
-- error: Failed to allocate 16384 bytes in mempool for new slab
+- [2, 2, 'test2']
 ...
-check_iter_and_size()
+check_iter_and_size(1023)
 ---
 - ok
 ...
@@ -399,9 +380,7 @@ for i = 1,10 do table.insert(res, (s:get{i})) end
 ...
 res
 ---
-- - [1, 1, 'test1']
-  - [2, 2, 'test2']
-  - [3, 3, 'test3']
+- - [3, 3, 'test3']
   - [4, 4, 'test4']
   - [5, 5, 'test5']
   - [6, 6, 'test6']
@@ -412,13 +391,13 @@ res
 ...
 for i = 3501,4500 do s:insert{i, i} end
 ---
-- error: Failed to allocate 16384 bytes in mempool for new slab
+- error: Failed to allocate 16384 bytes in hash_table for key
 ...
-s:delete{3}
+s:delete{3} -- still can delete, it does not require extents if no read view
 ---
-- error: Failed to allocate 16384 bytes in mempool for new slab
+- [3, 3, 'test3']
 ...
-check_iter_and_size()
+check_iter_and_size(1023)
 ---
 - ok
 ...
@@ -437,10 +416,7 @@ for i = 1,10 do table.insert(res, (s:get{i})) end
 ...
 res
 ---
-- - [1, 1, 'test1']
-  - [2, 2, 'test2']
-  - [3, 3, 'test3']
-  - [4, 4, 'test4']
+- - [4, 4, 'test4']
   - [5, 5, 'test5']
   - [6, 6, 'test6']
   - [7, 7, 'test7']
@@ -460,10 +436,7 @@ for i = 1,10 do table.insert(res, (s:get{i})) end
 ...
 res
 ---
-- - [1, 1, 'test1']
-  - [2, 2, 'test2']
-  - [3, 3, 'test3']
-  - [4, 4, 'test4']
+- - [4, 4, 'test4']
   - [5, 5, 'test5']
   - [6, 6, 'test6']
   - [7, 7, 'test7']

--- a/test/box/errinj_index.test.lua
+++ b/test/box/errinj_index.test.lua
@@ -23,22 +23,21 @@ for _, t in s.index[0]:pairs() do table.insert(res, t) end
 res
 
 for i = 501,2500 do s:insert{i, i} end
-s:delete{1}
+s:delete{1} -- still can delete, it does not require extents if no read view
 
 res = {}
 for i = 1,10 do table.insert(res, (s:get{i})) end
 res
 res = {}
-for i = 501,510 do table.insert(res, (s:get{i})) end
-res
+for i = 501,2500 do table.insert(res, (s:get{i})) end
+#res -- only could insert some of entries with the extents reserved previously
 
---count must be exactly 10
-function check_iter_and_size() local count = 0 for _, t in s.index[0]:pairs() do count = count + 1 end return count == 10 and "ok" or "fail" end
-check_iter_and_size()
+function check_iter_and_size(num) local count = 0 for _, t in s.index[0]:pairs() do count = count + 1 end return count == num and "ok" or "fail" end
+check_iter_and_size(621)
 
 for i = 2501,3500 do s:insert{i, i} end
-s:delete{2}
-check_iter_and_size()
+s:delete{2} -- still can delete, it does not require extents if no read view
+check_iter_and_size(620)
 res = {}
 for i = 1,10 do table.insert(res, (s:get{i})) end
 res
@@ -83,30 +82,27 @@ for _, t in s.index[0]:pairs() do table.insert(res, t) end
 res
 
 for i = 501,2500 do s:insert{i, i} end
-s:delete{1}
+s:delete{1} -- still can delete, it does not require extents if no read view
 
 res = {}
 for i = 1,10 do table.insert(res, (s:get{i})) end
 res
 res = {}
-for i = 501,510 do table.insert(res, (s:get{i})) end
-res
-res = {}
-for i = 2001,2010 do table.insert(res, (s:get{i})) end
-res
+for i = 501,2500 do table.insert(res, (s:get{i})) end
+#res -- only could insert some of entries with the extents reserved previously
 
-check_iter_and_size()
+check_iter_and_size(1023)
 
 for i = 2501,3500 do s:insert{i, i} end
-s:delete{2}
-check_iter_and_size()
+s:delete{2} -- still can delete, it does not require extents if no read view
+check_iter_and_size(1023)
 res = {}
 for i = 1,10 do table.insert(res, (s:get{i})) end
 res
 
 for i = 3501,4500 do s:insert{i, i} end
-s:delete{3}
-check_iter_and_size()
+s:delete{3} -- still can delete, it does not require extents if no read view
+check_iter_and_size(1023)
 
 errinj.set("ERRINJ_INDEX_ALLOC", false)
 

--- a/test/unit/bps_tree.cc
+++ b/test/unit/bps_tree.cc
@@ -2,6 +2,7 @@
 #include <cstdio>
 #include <cinttypes>
 #include <ctime>
+#include <climits>
 
 #include "sptree.h"
 #include "qsort_arg.h"
@@ -222,7 +223,7 @@ simple_check()
 		type_t v = i;
 		if (test_find(&tree, v) == NULL)
 			fail("element in tree (1)", "false");
-		test_delete(&tree, v);
+		test_delete(&tree, v, NULL);
 		debug_check(&tree);
 	}
 	if (test_size(&tree) != 0)
@@ -248,7 +249,7 @@ simple_check()
 		type_t v = rounds - 1 - i;
 		if (test_find(&tree, v) == NULL)
 			fail("element in tree (2)", "false");
-		test_delete(&tree, v);
+		test_delete(&tree, v, NULL);
 		debug_check(&tree);
 	}
 	if (test_size(&tree) != 0)
@@ -274,7 +275,7 @@ simple_check()
 		type_t v = i;
 		if (test_find(&tree, v) == NULL)
 			fail("element in tree (3)", "false");
-		test_delete(&tree, v);
+		test_delete(&tree, v, NULL);
 		debug_check(&tree);
 	}
 	if (test_size(&tree) != 0)
@@ -300,7 +301,7 @@ simple_check()
 		type_t v = rounds - 1 - i;
 		if (test_find(&tree, v) == NULL)
 			fail("element in tree (4)", "false");
-		test_delete(&tree, v);
+		test_delete(&tree, v, NULL);
 		debug_check(&tree);
 	}
 	if (test_size(&tree) != 0)
@@ -361,7 +362,7 @@ compare_with_sptree_check()
 			test_insert(&tree, rnd, 0, 0);
 		} else {
 			sptree_test_delete(&spt_test, &rnd);
-			test_delete(&tree, rnd);
+			test_delete(&tree, rnd, NULL);
 		}
 
 		debug_check(&tree);
@@ -418,7 +419,7 @@ compare_with_sptree_check_branches()
 			fail("trees integrity", "false");
 
 		sptree_test_delete(&spt_test, &v);
-		test_delete(&tree, v);
+		test_delete(&tree, v, NULL);
 
 		debug_check(&tree);
 
@@ -453,7 +454,7 @@ compare_with_sptree_check_branches()
 			fail("trees integrity", "false");
 
 		sptree_test_delete(&spt_test, &v);
-		test_delete(&tree, v);
+		test_delete(&tree, v, NULL);
 
 		debug_check(&tree);
 
@@ -492,7 +493,7 @@ compare_with_sptree_check_branches()
 			fail("trees integrity", "false");
 
 		sptree_test_delete(&spt_test, &v);
-		test_delete(&tree, v);
+		test_delete(&tree, v, NULL);
 
 		debug_check(&tree);
 
@@ -531,7 +532,7 @@ compare_with_sptree_check_branches()
 			fail("trees integrity", "false");
 
 		sptree_test_delete(&spt_test, &v);
-		test_delete(&tree, v);
+		test_delete(&tree, v, NULL);
 
 		debug_check(&tree);
 
@@ -574,7 +575,7 @@ compare_with_sptree_check_branches()
 			fail("trees integrity", "false");
 
 		sptree_test_delete(&spt_test, &v);
-		test_delete(&tree, v);
+		test_delete(&tree, v, NULL);
 
 		debug_check(&tree);
 
@@ -855,13 +856,18 @@ delete_value_check()
 	struct elem_t e1 = {1, 1};
 	struct_tree_insert(&tree, e1, NULL, NULL);
 	struct elem_t e2 = {1, 2};
+	struct elem_t deleted = {LONG_MAX, LONG_MAX};
 
-	fail_unless(struct_tree_delete_value(&tree, e2, NULL) == -1);
+	fail_unless(struct_tree_delete_value(&tree, e2, &deleted) == 0);
+	fail_unless(deleted.info == LONG_MAX);
+	fail_unless(deleted.marker == LONG_MAX);
 	fail_unless(struct_tree_find(&tree, 1) != NULL);
 	fail_unless(struct_tree_debug_check(&tree) == 0);
 	ok(true, "deletion of non-identical element fails");
 
-	fail_unless(struct_tree_delete_value(&tree, e1, NULL) == 0);
+	fail_unless(struct_tree_delete_value(&tree, e1, &deleted) == 0);
+	fail_unless(deleted.info == e1.info);
+	fail_unless(deleted.marker == e1.marker);
 	fail_unless(struct_tree_find(&tree, 1) == NULL);
 	fail_unless(struct_tree_debug_check(&tree) == 0);
 	ok(true, "deletion of identical element succeeds");

--- a/test/unit/bps_tree.cc
+++ b/test/unit/bps_tree.cc
@@ -931,7 +931,7 @@ main(void)
 	printing_test();
 	white_box_test();
 	approximate_count();
-	ok(extents_count == 0, "memory leak check");
+	ok(extents_count == allocator.num_reserved_extents, "leak check");
 	insert_get_iterator();
 	delete_value_check();
 	insert_successor_test();

--- a/test/unit/bps_tree_iterator.cc
+++ b/test/unit/bps_tree_iterator.cc
@@ -269,8 +269,12 @@ iterator_invalidate_check()
 			elem_t e;
 			e.first = i * test_size * 2;
 			e.second = i * test_size * 2;
-			int res = test_delete(&tree, e);
-			assert(res == 0);
+			elem_t deleted;
+			deleted.first = LONG_MAX;
+			deleted.second = LONG_MAX;
+			fail_unless(test_delete(&tree, e, &deleted) == 0);
+			fail_unless(deleted.first == e.first);
+			fail_unless(deleted.second == e.second);
 		}
 		for (long i = 0; i < test_size; i++) {
 			do {
@@ -368,8 +372,12 @@ iterator_invalidate_check()
 			elem_t e;
 			e.first = i * test_size * 2;
 			e.second = i * test_size * 2;
-			int res = test_delete(&tree, e);
-			assert(res == 0);
+			elem_t deleted;
+			deleted.first = LONG_MAX;
+			deleted.second = LONG_MAX;
+			fail_unless(test_delete(&tree, e, &deleted) == 0);
+			fail_unless(deleted.first == e.first);
+			fail_unless(deleted.second == e.second);
 		}
 		for (long i = 0; i < ins_cnt; i++) {
 			elem_t e;
@@ -468,7 +476,7 @@ iterator_freeze_check()
 			elem_t e;
 			e.first = rand() % test_data_mod;
 			e.second = 0;
-			test_delete(&tree, e);
+			test_delete(&tree, e, NULL);
 			fail_if(test_debug_check(&tree));
 			fail_if(test_view_debug_check(&view2));
 		}

--- a/test/unit/bps_tree_iterator.cc
+++ b/test/unit/bps_tree_iterator.cc
@@ -504,7 +504,8 @@ main(void)
 	iterator_check();
 	iterator_invalidate_check();
 	iterator_freeze_check();
-	ok(total_extents_allocated == 0, "memory leak check");
+	ok(total_extents_allocated == allocator.num_reserved_extents,
+	   "leak check");
 
 	matras_allocator_destroy(&allocator);
 

--- a/test/unit/bps_tree_offset_api.cc
+++ b/test/unit/bps_tree_offset_api.cc
@@ -398,45 +398,53 @@ insert_delete_get_offset()
 	for (int i = 0; i < count; i++)
 		insert_and_check(&tree, i, (size_t)i);
 	fail_unless(test_size(&tree) == (size_t)count);
-	fail_unless((int)stats.extent_count == extent_count);
+	fail_unless((int)stats.extent_count ==
+		    extent_count - allocator.num_reserved_extents);
 	for (int i = 0; i < count; i++)
 		delete_and_check(&tree, i, 0);
 	fail_unless(test_size(&tree) == 0);
-	fail_unless((int)stats.extent_count == extent_count);
+	fail_unless((int)stats.extent_count ==
+		    extent_count - allocator.num_reserved_extents);
 	ok(true, "Insert 1..X, delete 1..X");
 
 	for (int i = 0; i < count; i++)
 		insert_and_check(&tree, i, (size_t)i);
 	fail_unless(test_size(&tree) == (size_t)count);
-	fail_unless((int)stats.extent_count == extent_count);
+	fail_unless((int)stats.extent_count ==
+		    extent_count - allocator.num_reserved_extents);
 	for (int i = count - 1; i >= 0; i--)
 		delete_and_check(&tree, i, (size_t)i);
 	fail_unless(test_size(&tree) == 0);
-	fail_unless((int)stats.extent_count == extent_count);
+	fail_unless((int)stats.extent_count ==
+		    extent_count - allocator.num_reserved_extents);
 	ok(true, "Insert 1..X, delete X..1");
 
 	for (int i = count - 1; i >= 0; i--)
 		insert_and_check(&tree, i, 0);
 	fail_unless(test_size(&tree) == (size_t)count);
-	fail_unless((int)stats.extent_count == extent_count);
+	fail_unless((int)stats.extent_count ==
+		    extent_count - allocator.num_reserved_extents);
 	for (int i = 0; i < count; i++)
 		delete_and_check(&tree, i, 0);
 	fail_unless(test_size(&tree) == 0);
-	fail_unless((int)stats.extent_count == extent_count);
+	fail_unless((int)stats.extent_count ==
+		    extent_count - allocator.num_reserved_extents);
 	ok(true, "Insert X..1, delete 1..X");
 
 	for (int i = count - 1; i >= 0; i--)
 		insert_and_check(&tree, i, 0);
 	fail_unless(test_size(&tree) == (size_t)count);
-	fail_unless((int)stats.extent_count == extent_count);
+	fail_unless((int)stats.extent_count ==
+		    extent_count - allocator.num_reserved_extents);
 	for (int i = count - 1; i >= 0; i--)
 		delete_and_check(&tree, i, (size_t)i);
 	fail_unless(test_size(&tree) == 0);
-	fail_unless((int)stats.extent_count == extent_count);
+	fail_unless((int)stats.extent_count ==
+		    extent_count - allocator.num_reserved_extents);
 	ok(true, "Insert X..1, delete X..1");
 
 	test_destroy(&tree);
-	fail_unless(extent_count == 0);
+	fail_unless(extent_count == allocator.num_reserved_extents);
 
 	footer();
 	check_plan();

--- a/test/unit/bps_tree_offset_api.cc
+++ b/test/unit/bps_tree_offset_api.cc
@@ -166,22 +166,22 @@ typedef int64_t type_t;
 static int extent_count = 0;
 
 static void *
-extent_alloc(void *ctx)
+extent_alloc(struct matras_allocator *allocator)
 {
-	int *p_extent_count = (int *)ctx;
-	assert(p_extent_count == &extent_count);
-	++*p_extent_count;
+	(void)allocator;
+	++extent_count;
 	return xmalloc(BPS_TREE_EXTENT_SIZE);
 }
 
 static void
-extent_free(void *ctx, void *extent)
+extent_free(struct matras_allocator *allocator, void *extent)
 {
-	int *p_extent_count = (int *)ctx;
-	assert(p_extent_count == &extent_count);
-	--*p_extent_count;
+	(void)allocator;
+	--extent_count;
 	free(extent);
 }
+
+struct matras_allocator allocator;
 
 static uint32_t
 rng()
@@ -233,14 +233,14 @@ iterator_at()
 	struct test tree;
 	std::set<int64_t> set;
 
-	test_create(&tree, 0, extent_alloc, extent_free, &extent_count, NULL);
+	test_create(&tree, 0, &allocator, NULL);
 	test_do_iterator_at_invalid(&tree, 0);
 	test_do_iterator_at_invalid(&tree, 37);
 	test_do_iterator_at_invalid(&tree, SIZE_MAX);
 	test_destroy(&tree);
 	ok(true, "Iterator at on an empty tree");
 
-	test_create(&tree, 0, extent_alloc, extent_free, &extent_count, NULL);
+	test_create(&tree, 0, &allocator, NULL);
 	for (size_t i = 0; i < count; i++) {
 		fail_unless(test_insert(&tree, i, NULL, NULL) == 0);
 		for (size_t j = 0; j <= i; j++)
@@ -251,7 +251,7 @@ iterator_at()
 	test_destroy(&tree);
 	ok(true, "Iterator at on sequential insertion");
 
-	test_create(&tree, 0, extent_alloc, extent_free, &extent_count, NULL);
+	test_create(&tree, 0, &allocator, NULL);
 	for (size_t i = 0; i < count; i++) {
 		int64_t v = rand_i[i];
 		fail_unless(test_insert(&tree, v, NULL, NULL) == 0);
@@ -282,7 +282,7 @@ find_get_offset()
 	struct test tree;
 	std::set<int64_t> set;
 
-	test_create(&tree, 0, extent_alloc, extent_free, &extent_count, NULL);
+	test_create(&tree, 0, &allocator, NULL);
 	test_do_find_invalid(&tree, 0);
 	test_do_find_invalid(&tree, -1);
 	test_do_find_invalid(&tree, 37);
@@ -291,7 +291,7 @@ find_get_offset()
 	test_destroy(&tree);
 	ok(true, "Find in an empty tree");
 
-	test_create(&tree, 0, extent_alloc, extent_free, &extent_count, NULL);
+	test_create(&tree, 0, &allocator, NULL);
 	for (size_t i = 0; i < count; i++) {
 		test_insert(&tree, i, NULL, NULL);
 		for (size_t j = 0; j <= i; j++)
@@ -302,7 +302,7 @@ find_get_offset()
 	test_destroy(&tree);
 	ok(true, "Find on sequential insertion");
 
-	test_create(&tree, 0, extent_alloc, extent_free, &extent_count, NULL);
+	test_create(&tree, 0, &allocator, NULL);
 	for (size_t i = 0; i < count; i++) {
 		int64_t v = rand_i[i];
 		fail_unless(test_insert(&tree, v, NULL, NULL) == 0);
@@ -335,7 +335,7 @@ bounds_get_offset()
 	struct test tree;
 	std::set<int64_t> set;
 
-	test_create(&tree, 0, extent_alloc, extent_free, &extent_count, NULL);
+	test_create(&tree, 0, &allocator, NULL);
 	test_do_bounds_invalid(&tree, 0);
 	test_do_bounds_invalid(&tree, -1);
 	test_do_bounds_invalid(&tree, 37);
@@ -344,7 +344,7 @@ bounds_get_offset()
 	test_destroy(&tree);
 	ok(true, "Upper & lower bound on an empty tree");
 
-	test_create(&tree, 0, extent_alloc, extent_free, &extent_count, NULL);
+	test_create(&tree, 0, &allocator, NULL);
 	for (int i = 0; i < count; i++) {
 		fail_unless(test_insert(&tree, i, NULL, NULL) == 0);
 		for (int j = 0; j <= i; j++)
@@ -355,7 +355,7 @@ bounds_get_offset()
 	test_destroy(&tree);
 	ok(true, "Upper & lower bound on sequential insertion");
 
-	test_create(&tree, 0, extent_alloc, extent_free, &extent_count, NULL);
+	test_create(&tree, 0, &allocator, NULL);
 	for (int i = 0; i < count; i++) {
 		int64_t v = rand_i[i];
 		fail_unless(test_insert(&tree, v, NULL, NULL) == 0);
@@ -393,7 +393,7 @@ insert_delete_get_offset()
 
 	const int count = 2000;
 	struct test tree;
-	test_create(&tree, 0, extent_alloc, extent_free, &extent_count, &stats);
+	test_create(&tree, 0, &allocator, &stats);
 
 	for (int i = 0; i < count; i++)
 		insert_and_check(&tree, i, (size_t)i);
@@ -448,10 +448,15 @@ main(void)
 	plan(4);
 	header();
 
+	matras_allocator_create(&allocator, BPS_TREE_EXTENT_SIZE,
+				extent_alloc, extent_free);
+
 	iterator_at();
 	find_get_offset();
 	bounds_get_offset();
 	insert_delete_get_offset();
+
+	matras_allocator_destroy(&allocator);
 
 	footer();
 	return check_plan();

--- a/test/unit/bps_tree_offset_api.cc
+++ b/test/unit/bps_tree_offset_api.cc
@@ -146,9 +146,11 @@ typedef int64_t type_t;
 	struct test *t = (tree_arg); \
 	int64_t value = (value_arg); \
 	size_t expected_pos = (expected_pos_arg); \
+	int64_t deleted = INT64_MAX; \
 	size_t pos = SIZE_MAX; \
 	fail_unless(test_find(t, value) != NULL); \
-	fail_unless(test_delete_get_offset(t, value, &pos) == 0); \
+	fail_unless(test_delete_get_offset(t, value, &deleted, &pos) == 0); \
+	fail_unless(deleted == value); \
 	fail_unless(pos == (expected_pos)); \
 	fail_unless(test_find(t, value) == NULL); \
 	int result = test_debug_check(t); \

--- a/test/unit/bps_tree_view.c
+++ b/test/unit/bps_tree_view.c
@@ -83,7 +83,7 @@ test_size(void)
 		test_tree_do_insert(&tree, i + 1000);
 		test_tree_view_do_debug_check(&view);
 		if (i % 2 == 0) {
-			test_tree_delete(&tree, i);
+			test_tree_delete(&tree, i, NULL);
 			test_tree_view_do_debug_check(&view);
 		}
 	}
@@ -115,7 +115,7 @@ test_find(void)
 		test_tree_do_insert(&tree, i + 1000);
 		test_tree_view_do_debug_check(&view);
 		if (i % 2 == 0) {
-			test_tree_delete(&tree, i);
+			test_tree_delete(&tree, i, NULL);
 			test_tree_view_do_debug_check(&view);
 		}
 	}
@@ -172,7 +172,7 @@ test_first(void)
 	ok(p != NULL && *p == 0,
 	   "non-empty view first before tree change");
 	for (int i = 0; i < 100; i++) {
-		test_tree_delete(&tree, i);
+		test_tree_delete(&tree, i, NULL);
 		test_tree_view_do_debug_check(&view);
 	}
 	it = test_tree_view_first(&view);
@@ -216,7 +216,7 @@ test_last(void)
 	ok(p != NULL && *p == 999,
 	   "non-empty view last before tree change");
 	for (int i = 900; i < 1000; i++) {
-		test_tree_delete(&tree, i);
+		test_tree_delete(&tree, i, NULL);
 		test_tree_view_do_debug_check(&view);
 	}
 	it = test_tree_view_last(&view);
@@ -248,7 +248,7 @@ test_lower_bound(void)
 	for (int i = 0; i < 1000; i++) {
 		test_tree_do_insert(&tree, i * 10);
 		test_tree_view_do_debug_check(&view);
-		test_tree_delete(&tree, i * 2);
+		test_tree_delete(&tree, i * 2, NULL);
 		test_tree_view_do_debug_check(&view);
 	}
 
@@ -298,7 +298,7 @@ test_upper_bound(void)
 	for (int i = 0; i < 1000; i++) {
 		test_tree_do_insert(&tree, i * 10);
 		test_tree_view_do_debug_check(&view);
-		test_tree_delete(&tree, i * 2);
+		test_tree_delete(&tree, i * 2, NULL);
 		test_tree_view_do_debug_check(&view);
 	}
 
@@ -349,7 +349,7 @@ test_iterator(void)
 
 	for (int i = 0; i < 1000; i++) {
 		if (i % 6 == 0) {
-			test_tree_delete(&tree, i);
+			test_tree_delete(&tree, i, NULL);
 			test_tree_view_do_debug_check(&view);
 		}
 		if (i % 5 == 0) {

--- a/test/unit/bps_tree_view.c
+++ b/test/unit/bps_tree_view.c
@@ -31,7 +31,7 @@
 #include "salad/bps_tree.h"
 
 #define test_tree_do_create(tree) \
-	test_tree_create(tree, NULL, extent_alloc, extent_free, NULL, NULL)
+	test_tree_create(tree, NULL, &allocator, NULL)
 
 #define test_tree_do_insert(tree, val) \
 	fail_if(test_tree_insert((tree), (val), NULL, NULL) != 0)
@@ -40,18 +40,20 @@
 	fail_if(test_tree_view_debug_check((view)))
 
 static void *
-extent_alloc(void *ctx)
+extent_alloc(struct matras_allocator *allocator)
 {
-	(void)ctx;
+	(void)allocator;
 	return xmalloc(BPS_TREE_EXTENT_SIZE);
 }
 
 static void
-extent_free(void *ctx, void *extent)
+extent_free(struct matras_allocator *allocator, void *extent)
 {
-	(void)ctx;
+	(void)allocator;
 	free(extent);
 }
+
+struct matras_allocator allocator;
 
 static void
 test_size(void)
@@ -490,6 +492,9 @@ main(void)
 	plan(8);
 	header();
 
+	matras_allocator_create(&allocator, BPS_TREE_EXTENT_SIZE,
+				extent_alloc, extent_free);
+
 	test_size();
 	test_find();
 	test_first();
@@ -498,6 +503,8 @@ main(void)
 	test_upper_bound();
 	test_iterator();
 	test_iterator_is_equal();
+
+	matras_allocator_destroy(&allocator);
 
 	footer();
 	return check_plan();

--- a/test/unit/light.cc
+++ b/test/unit/light.cc
@@ -41,23 +41,20 @@ equal_key(hash_value_t v1, hash_value_t v2)
 #include "salad/light.h"
 
 inline void *
-my_light_alloc(void *ctx)
+my_light_alloc(struct matras_allocator *allocator)
 {
-	size_t *p_extents_count = (size_t *)ctx;
-	assert(p_extents_count == &extents_count);
-	++*p_extents_count;
+	++extents_count;
 	return malloc(light_extent_size);
 }
 
 inline void
-my_light_free(void *ctx, void *p)
+my_light_free(struct matras_allocator *allocator, void *p)
 {
-	size_t *p_extents_count = (size_t *)ctx;
-	assert(p_extents_count == &extents_count);
-	--*p_extents_count;
+	--extents_count;
 	free(p);
 }
 
+static struct matras_allocator allocator;
 
 static void
 simple_test()
@@ -69,8 +66,7 @@ simple_test()
 	stats.extent_count = extents_count;
 
 	struct light_core ht;
-	light_create(&ht, 0, light_extent_size, my_light_alloc, my_light_free,
-		     &extents_count, &stats);
+	light_create(&ht, 0, &allocator, &stats);
 	std::vector<bool> vect;
 	size_t count = 0;
 	const size_t rounds = 1000;
@@ -135,8 +131,7 @@ collision_test()
 	header();
 
 	struct light_core ht;
-	light_create(&ht, 0, light_extent_size, my_light_alloc, my_light_free,
-		     &extents_count, NULL);
+	light_create(&ht, 0, &allocator, NULL);
 	std::vector<bool> vect;
 	size_t count = 0;
 	const size_t rounds = 100;
@@ -199,8 +194,7 @@ iterator_test()
 	header();
 
 	struct light_core ht;
-	light_create(&ht, 0, light_extent_size, my_light_alloc, my_light_free,
-		     &extents_count, NULL);
+	light_create(&ht, 0, &allocator, NULL);
 	const size_t rounds = 1000;
 	const size_t start_limits = 20;
 
@@ -262,8 +256,7 @@ iterator_freeze_check()
 	struct light_core ht;
 
 	for (int i = 0; i < 10; i++) {
-		light_create(&ht, 0, light_extent_size, my_light_alloc,
-			     my_light_free, &extents_count, NULL);
+		light_create(&ht, 0, &allocator, NULL);
 		int comp_buf_size = 0;
 		int comp_buf_size2 = 0;
 		for (int j = 0; j < test_data_size; j++) {
@@ -337,8 +330,7 @@ slot_in_big_table_test()
 	header();
 
 	struct light_core ht;
-	light_create(&ht, 0, light_extent_size, my_light_alloc, my_light_free,
-		     &extents_count, NULL);
+	light_create(&ht, 0, &allocator, NULL);
 
 	ht.common.table_size = 4000000000;
 	ht.common.cover_mask = 0xffffffff;
@@ -368,8 +360,7 @@ max_capacity_test()
 	const size_t data_count = (size_t)UINT32_MAX + 1 - LIGHT_GROW_INCREMENT;
 
 	struct light_core ht;
-	light_create(&ht, 0, light_extent_size, my_light_alloc, my_light_free,
-		     &extents_count, NULL);
+	light_create(&ht, 0, &allocator, NULL);
 
 	uint64_t seed[4];
 	random_bytes((char *)seed, sizeof(seed));
@@ -407,6 +398,8 @@ int
 main(int, const char**)
 {
 	random_init();
+	matras_allocator_create(&allocator, light_extent_size,
+				my_light_alloc, my_light_free);
 
 	simple_test();
 	collision_test();
@@ -418,5 +411,6 @@ main(int, const char**)
 	if (extents_count != 0)
 		fail("memory leak!", "true");
 
+	matras_allocator_destroy(&allocator);
 	random_free();
 }

--- a/test/unit/light.cc
+++ b/test/unit/light.cc
@@ -408,7 +408,7 @@ main(int, const char**)
 	slot_in_big_table_test();
 	max_capacity_test();
 
-	if (extents_count != 0)
+	if ((int)extents_count != allocator.num_reserved_extents)
 		fail("memory leak!", "true");
 
 	matras_allocator_destroy(&allocator);

--- a/test/unit/light_view.c
+++ b/test/unit/light_view.c
@@ -39,24 +39,25 @@ equal_key(struct data a, int b)
 #include "salad/light.h"
 
 static void *
-alloc_extent(void *ctx)
+alloc_extent(struct matras_allocator *allocator)
 {
-	(void)ctx;
+	(void)allocator;
 	return xmalloc(extent_size);
 }
 
 static void
-free_extent(void *ctx, void *p)
+free_extent(struct matras_allocator *allocator, void *p)
 {
-	(void)ctx;
+	(void)allocator;
 	free(p);
 }
+
+static struct matras_allocator allocator;
 
 static void
 light_do_create(struct light_core *ht)
 {
-	light_create(ht, NULL, extent_size, alloc_extent, free_extent,
-		     NULL, NULL);
+	light_create(ht, NULL, &allocator, NULL);
 }
 
 static void
@@ -254,9 +255,14 @@ main(void)
 	plan(3);
 	header();
 
+	matras_allocator_create(&allocator, extent_size,
+				alloc_extent, free_extent);
+
 	test_count();
 	test_find();
 	test_iterator();
+
+	matras_allocator_destroy(&allocator);
 
 	footer();
 	return check_plan();

--- a/test/unit/rtree_iterator.cc
+++ b/test/unit/rtree_iterator.cc
@@ -10,22 +10,22 @@ static int extent_count = 0;
 const uint32_t extent_size = 1024 * 8;
 
 static void *
-extent_alloc(void *ctx)
+extent_alloc(struct matras_allocator *allocator)
 {
-	int *p_extent_count = (int *)ctx;
-	assert(p_extent_count == &extent_count);
-	++*p_extent_count;
+	(void)allocator;
+	++extent_count;
 	return malloc(extent_size);
 }
 
 static void
-extent_free(void *ctx, void *page)
+extent_free(struct matras_allocator *allocator, void *page)
 {
-	int *p_extent_count = (int *)ctx;
-	assert(p_extent_count == &extent_count);
-	--*p_extent_count;
+	(void)allocator;
+	--extent_count;
 	free(page);
 }
+
+struct matras_allocator allocator;
 
 static void
 iterator_check()
@@ -33,8 +33,7 @@ iterator_check()
 	header();
 
 	struct rtree tree;
-	rtree_init(&tree, 2, RTREE_EUCLID, extent_size,
-		   extent_alloc, extent_free, &extent_count, NULL);
+	rtree_init(&tree, 2, RTREE_EUCLID, &allocator, NULL);
 
 	/* Filling tree */
 	const size_t count1 = 10000;
@@ -215,8 +214,7 @@ iterator_invalidate_check()
 			del_cnt = test_size - del_pos;
 		}
 		struct rtree tree;
-		rtree_init(&tree, 2, RTREE_EUCLID, extent_size,
-			   extent_alloc, extent_free, &extent_count, NULL);
+		rtree_init(&tree, 2, RTREE_EUCLID, &allocator, NULL);
 		struct rtree_iterator iterators[test_size];
 		for (size_t i = 0; i < test_size; i++)
 			rtree_iterator_init(iterators + i);
@@ -260,8 +258,7 @@ iterator_invalidate_check()
 		size_t ins_cnt = rand() % max_insert_count + 1;
 
 		struct rtree tree;
-		rtree_init(&tree, 2, RTREE_EUCLID, extent_size,
-			   extent_alloc, extent_free, &extent_count, NULL);
+		rtree_init(&tree, 2, RTREE_EUCLID, &allocator, NULL);
 		struct rtree_iterator iterators[test_size];
 		for (size_t i = 0; i < test_size; i++)
 			rtree_iterator_init(iterators + i);
@@ -309,9 +306,12 @@ iterator_invalidate_check()
 int
 main(void)
 {
+	matras_allocator_create(&allocator, extent_size,
+				extent_alloc, extent_free);
 	iterator_check();
 	iterator_invalidate_check();
 	if (extent_count != 0) {
 		fail("memory leak!", "false");
 	}
+	matras_allocator_destroy(&allocator);
 }


### PR DESCRIPTION
A long time ago the it's been found that in some circumstances the
RTREE index could fail to rollback because of OOM. This is the case
because removal of a key from such an index can sometimes lead to
allocation of new blocks that could fail. So, in order to guarantee
a successful rollback of an insertion into the index, the memtx
engine extent reservation machinery had been introduced (see the
issue #727).

But some time ago it's beed found out that the reservation of memory
prior to insertion can be not enough to guarantee a successful roll
back of the statements, so it's been decided to use a regular malloc
for failed allocations performed during rollback (see #10551). This
also fixed the RTREE issue for which the extent reservation had been
introduced in the first place.

But this functionality allows to simplify code of data structures,
such as BPS tree, so that we can reserve the max amount of extents
that could be required to perform an operation and, if reservation
succeeds, be sure that we're safe from any kind of OOM up until we
have finished the operation.

But it's only known to specific data structures which amount of memory
will be required for them to perform their operations, and all current
memtx structures (BPS tree, light hash, rtree, bitset) use matras to
deal with memory allocations, so it would be nice to make them able to
reserve exactly as much extents as they need themselves instead of
reserving max sane amount of ones as it's done now (see the constants:
`RESERVE_EXTENTS_BEFORE_REPLACE` and `RESERVE_EXTENTS_BEFORE_DELETE`).

The problem is that if we reserve extents in each matras instance we
will possibly be wasting a lot of memory in each index, so it would
be much better to share the reserved extents as it's done in the memtx
engine now.

So, in order to allow indexes reserve memoy for themselves and share
the reserved memory amoug all indexes, let's introduce a new entity:
`matras_allocator`.

The entity is to be shared amoug all memtx indexes and it allows to
reserve memory for indexes for various purposes. So instead of matras
holding the reserved extents, it's the deal of the new shared entity.

And the entity is exactly what the small submodule bump introduces.

Needed for tarantool/tarantool-ee#822

NO_DOC=submodule bump
NO_TEST=submodule bump
NO_CHANGELOG=submodule bump
