### PR TITLE
box: fix drop_while integration with index:pairs

### DIFF
--- a/changelogs/unreleased/gh-6403-index-iterator-methods.md
+++ b/changelogs/unreleased/gh-6403-index-iterator-methods.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed a bug when the `drop_while` method of index iterators (`index:pairs()`,
+  `space:pairs()`) dropped an extra element (gh-6403).

--- a/changelogs/unreleased/gh-6403-luafun-fixes.md
+++ b/changelogs/unreleased/gh-6403-luafun-fixes.md
@@ -1,0 +1,7 @@
+## bugfix/lua
+
+* Now `fun.chain` works correctly with iterators without `param`.
+* Now `fun.drop_while` supports stateful iterators.
+* Populated the `fun` module with the missing `maximum_by` alias
+  of `max_by`.
+* Now `fun.nth` and `fun.length` work correctly with Luafun iterators.

--- a/perf/lua/CMakeLists.txt
+++ b/perf/lua/CMakeLists.txt
@@ -53,6 +53,7 @@ create_perf_lua_test(NAME 1mops_write)
 create_perf_lua_test(NAME box_select)
 create_perf_lua_test(NAME gh-7089-vclock-copy)
 create_perf_lua_test(NAME uri_escape_unescape)
+create_perf_lua_test(NAME luafun)
 
 include_directories(${MSGPUCK_INCLUDE_DIRS})
 

--- a/perf/lua/luafun.lua
+++ b/perf/lua/luafun.lua
@@ -1,0 +1,117 @@
+local fun = require("fun")
+local clock = require("clock")
+local tarantool = require("tarantool")
+local benchmark = require("benchmark")
+
+local USAGE = [[
+ This benchmark measures the performance of luafun module.
+]]
+
+local params = benchmark.argparse(arg, {}, USAGE)
+
+local bench = benchmark.new(params)
+
+local _, _, build_type =
+    string.match(tarantool.build.target, "^(.+)-(.+)-(.+)$")
+if build_type == "Debug" then
+    print("WARNING: tarantool has built with enabled debug mode")
+end
+-- Fix the seed to stabilise the results.
+math.randomseed(42)
+
+--
+-- Data for `drop_while` benchmark.
+--
+
+local DROP_WHILE_CYCLES = 10^3
+local DROP_WHILE_N = 10^7
+
+local function DROP_WHILE_FILTER(x)
+    return x <= 50
+end
+
+-- A case when half of a table is dropped.
+local DROP_WHILE_DATA = {}
+for _ = 1, DROP_WHILE_N / 2 do
+    local value = math.random(50)
+    table.insert(DROP_WHILE_DATA, value)
+end
+for _ = 1, DROP_WHILE_N / 2 do
+    local value = math.random(51, 100)
+    table.insert(DROP_WHILE_DATA, value)
+end
+
+-- A case when the whole table is dropped.
+local DROP_WHILE_DROP_ALL_DATA = {}
+for _ = 1, DROP_WHILE_N do
+    local value = math.random(50)
+    table.insert(DROP_WHILE_DROP_ALL_DATA, value)
+end
+
+-- A case when no values are dropped.
+local DROP_WHILE_DROP_NONE_DATA = {}
+for _ = 1, DROP_WHILE_N do
+    local value = math.random(51, 100)
+    table.insert(DROP_WHILE_DROP_NONE_DATA, value)
+end
+
+-- Parametrised drop_while benchmark function:
+-- 1. `test.cycles` - how many times to repeat the iteration;
+-- 2. `test.data` - dataset to iterate over.
+-- Pre-defined filter function is used.
+local function DROP_WHILE_BENCHMARK(test)
+    local acc = 0
+    for _ = 1, test.cycles do
+        for _, i in fun.iter(test.data):drop_while(DROP_WHILE_FILTER) do
+            acc = acc + i
+        end
+    end
+end
+
+--
+-- Benchmarks themselves.
+-- Each benchmark must have `cycles` and `items` fields meaning
+-- how many iterations are made and how many items are processed
+-- by one iteration.
+--
+
+local tests = {
+    {
+        name = "drop_while",
+        items = DROP_WHILE_N,
+        cycles = DROP_WHILE_CYCLES,
+        data = DROP_WHILE_DATA,
+        payload = DROP_WHILE_BENCHMARK,
+    }, {
+        name = "drop_while.drop_all",
+        items = DROP_WHILE_N,
+        cycles = DROP_WHILE_CYCLES,
+        data = DROP_WHILE_DROP_ALL_DATA,
+        payload = DROP_WHILE_BENCHMARK,
+    }, {
+        name = "drop_while.drop_none",
+        items = DROP_WHILE_N,
+        cycles = DROP_WHILE_CYCLES,
+        data = DROP_WHILE_DROP_NONE_DATA,
+        payload = DROP_WHILE_BENCHMARK,
+    }
+}
+
+local function run_test(test)
+    local real_time = clock.time()
+    local cpu_time = clock.proc()
+    test.payload(test)
+    local real_delta = clock.time() - real_time
+    local cpu_delta = clock.proc() - cpu_time
+    bench:add_result(test.name, {
+        real_time = real_delta / test.cycles,
+        cpu_time = cpu_delta / test.cycles,
+        items = test.items,
+    })
+end
+
+for _, test in ipairs(tests) do
+    run_test(test)
+end
+
+bench:dump_results()

--- a/test/app/luafun.result
+++ b/test/app/luafun.result
@@ -61,6 +61,7 @@ methods
   - max
   - max_by
   - maximum
+  - maximum_by
   - min
   - min_by
   - minimum

--- a/test/box-luatest/gh_6403_space_pairs_luafun_integration_test.lua
+++ b/test/box-luatest/gh_6403_space_pairs_luafun_integration_test.lua
@@ -1,0 +1,45 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+-- Both engines to check if both LuaC and FFI implementations
+-- work correctly.
+local g = t.group(nil, {{engine = 'memtx'}, {engine = 'vinyl'}})
+
+g.before_all(function(g)
+    g.server = server:new()
+    g.server:start()
+    g.server:exec(function(engine)
+        local space = box.schema.space.create('test', {engine = engine})
+        space:create_index('primary')
+        space:insert({1})
+        space:insert({2})
+        space:insert({3})
+    end, {g.params.engine})
+end)
+
+g.after_all(function(g)
+    g.server:drop()
+end)
+
+-- Check if drop_while method works fine for space.pairs.
+g.test_drop_while = function(g)
+    g.server:exec(function()
+        local fun = require('fun')
+        local select_result = box.space.test:select()
+
+        local function check_case(cond)
+            local actual = box.space.test:pairs():drop_while(cond):totable()
+            local expected = fun.iter(select_result):drop_while(cond):totable()
+            t.assert_equals(actual, expected)
+        end
+
+        check_case(function(_) return false end)
+        check_case(function(_) return true end)
+        check_case(function(t) return t[1] > 100 end)
+        check_case(function(t) return t[1] < 100 end)
+        check_case(function(t) return t[1] > 0 end)
+        check_case(function(t) return t[1] < 0 end)
+        check_case(function(t) return t[1] > 2 end)
+        check_case(function(t) return t[1] < 2 end)
+    end)
+end


### PR DESCRIPTION
Since our index iterators are stateful (can return different values with the same state passed), old luafun drop_while implementation didn't work well with them - it was skipping an extra element. The PR bumps luafun and resolves this issue.

Closes https://github.com/tarantool/tarantool/issues/6403