### PR TITLE
log: emit file name and line for all log levels

### DIFF
--- a/changelogs/unreleased/gh-9913-emit-filename-for-all-log-levels.md
+++ b/changelogs/unreleased/gh-9913-emit-filename-for-all-log-levels.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a bug when log entries did not contain the file name and line at some
+  log levels in plain format (gh-9913).

--- a/src/lib/core/say.c
+++ b/src/lib/core/say.c
@@ -857,15 +857,12 @@ say_format_plain(struct log *log, char *buf, int len, int level,
 	if (module != NULL)
 		SNPRINT(total, snprintf, buf, len, "/%s", module);
 
-	if (level == S_WARN || level == S_ERROR || level == S_SYSERROR) {
-		/* Primitive basename(filename) */
-		if (filename) {
-			for (const char *f = filename; *f; f++)
-				if (*f == '/' && *(f + 1) != '\0')
-					filename = f + 1;
-			SNPRINT(total, snprintf, buf, len, " %s:%i", filename,
-				line);
-		}
+	/* Primitive basename(filename) */
+	if (filename != NULL) {
+		for (const char *f = filename; *f; f++)
+			if (*f == '/' && *(f + 1) != '\0')
+				filename = f + 1;
+		SNPRINT(total, snprintf, buf, len, " %s:%i", filename, line);
 	}
 
 	SNPRINT(total, snprintf, buf, len, " %c> ", level_chars[level]);

--- a/test/box-luatest/gh_3211_per_module_log_level_test.lua
+++ b/test/box-luatest/gh_3211_per_module_log_level_test.lua
@@ -66,8 +66,8 @@ g1.test_log_new = function(cg)
     end)
 
     find_in_log(cg, 'info from the default log', true)
-    find_in_log(cg, 'module1 I> info from the first module', true)
-    find_in_log(cg, 'module2 I> info from the second module', true)
+    find_in_log(cg, 'module1 .+ I> info from the first module', true)
+    find_in_log(cg, 'module2 .+ I> info from the second module', true)
 end
 
 -- Test log.cfg{modules = {...}} and box.cfg{log_modules = {...}}
@@ -159,7 +159,7 @@ g1.test_modname_deduction = function(cg)
         local module = require('test.box-luatest.gh_3211_module.testmod')
         module.say_hello()
     end)
-    find_in_log(cg, 'testmod I> hello', true)
+    find_in_log(cg, 'testmod testmod.lua:4 I> hello', true)
 end
 
 -- Test log.cfg{modules = {tarantool = ...}} and

--- a/test/box-tap/gh-4785-syslog.test.lua
+++ b/test/box-tap/gh-4785-syslog.test.lua
@@ -39,7 +39,7 @@ test:plan(4)
 local ok = true
 local logs = {}
 while true do
-    local entry = unix_socket:recv(128)
+    local entry = unix_socket:recv(256)
     if entry == nil then break end
     ok = ok and entry:match(pattern)
     table.insert(logs, entry)
@@ -48,7 +48,7 @@ test:ok(ok, 'box.cfg() log entries are in syslog format', {logs = logs})
 
 -- Verify a log entry written by log.info().
 log.info('hello')
-local entry = unix_socket:recv(128)
+local entry = unix_socket:recv(256)
 test:like(entry, pattern, 'log.info() log entry is in syslog format',
           {logs = {entry}})
 
@@ -58,7 +58,7 @@ test:ok(ok, "log.log_format('plain') is ignored with syslog")
 
 -- Verify log format again after log.log_format().
 log.info('world')
-local entry = unix_socket:recv(128)
+local entry = unix_socket:recv(256)
 test:like(entry, pattern, 'log.info() log entry after log_format',
           {logs = {entry}})
 

--- a/test/config-luatest/log_test.lua
+++ b/test/config-luatest/log_test.lua
@@ -30,16 +30,17 @@ g.test_log_only_changed_options = function()
     local path = fio.pathjoin(dir, 'log.txt')
     local logs = {}
     for line in io.lines(path) do
-        local res = string.gmatch(line, 'box.load_cfg I> set .+')()
+        local res = string.gmatch(line, 'box.load_cfg .+ I> set .+')()
         if res ~= nil then
+            res = string.gsub(res, '.+ I> ', '')
             table.insert(logs, res)
         end
     end
     local exp = {
-        [[box.load_cfg I> set 'log' configuration option to "file:log.txt"]],
-        [[box.load_cfg I> set 'sql_cache_size' configuration option to 1000]],
-        [[box.load_cfg I> set 'sql_cache_size' configuration option to 2000]],
-        [[box.load_cfg I> set 'sql_cache_size' configuration option to 1000]],
+        [[set 'log' configuration option to "file:log.txt"]],
+        [[set 'sql_cache_size' configuration option to 1000]],
+        [[set 'sql_cache_size' configuration option to 2000]],
+        [[set 'sql_cache_size' configuration option to 1000]],
     }
     t.assert_equals(logs, exp)
 end


### PR DESCRIPTION
Currently in `plain` log format the file name and line are printed only for `syserror`, `error` and `warn` log levels.
Let's print them for all log levels. In `json` log format the name and line are already emitted unconditionally.

Closes #9913