### PR TITLE
box: allow to access to the granted role in _vuser space

### DIFF
--- a/changelogs/unreleased/gh-10057-box-schema-user-info.md
+++ b/changelogs/unreleased/gh-10057-box-schema-user-info.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed a bug when the `box.schema.user.info()` function could fail if a current
+  user was granted with a non-`public` role (gh-10057).

--- a/src/box/user.h
+++ b/src/box/user.h
@@ -167,6 +167,12 @@ extern struct user *guest_user, *admin_user;
 struct access *
 access_lua_call_find(const char *name, uint32_t name_len);
 
+/**
+ * Check if a role is granted to a user or role with the given auth_token.
+ */
+bool
+role_is_granted(struct user *role, uint8_t auth_token);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 

--- a/test/box-luatest/gh_10057_user_role_test.lua
+++ b/test/box-luatest/gh_10057_user_role_test.lua
@@ -1,0 +1,99 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        box.schema.user.drop('testuser', {if_exists = true})
+        box.schema.role.drop('director', {if_exists = true})
+        box.schema.role.drop('manager', {if_exists = true})
+        box.schema.role.drop('management', {if_exists = true})
+        box.schema.role.drop('infra', {if_exists = true})
+        box.schema.role.drop('staff', {if_exists = true})
+    end)
+end)
+
+g.test_user_role = function(cg)
+    cg.server:exec(function()
+        box.schema.user.create('testuser')
+        box.schema.role.create('manager')
+        box.schema.role.create('director')
+        box.schema.user.grant('testuser', 'manager')
+
+        local original_user = box.session.effective_user()
+        box.session.su('testuser')
+
+        -- Check we don't have a Lua error on box.schema.user.info().
+        local ok = pcall(box.schema.user.info)
+        t.assert(ok)
+
+        -- Check the user has an access to the 'manager' role.
+        t.assert_equals(#box.space._vuser.index.name:select('manager'), 1)
+
+        -- Check the user doesn't have access to the 'director' role.
+        t.assert_equals(#box.space._vuser.index.name:select('director'), 0)
+
+        box.session.su(original_user)
+    end)
+end
+
+g.test_transitive_role = function(cg)
+    cg.server:exec(function()
+        -- Level 1 role.
+        box.schema.role.create('staff')
+
+        -- Level 2 roles.
+        box.schema.role.create('infra')
+        box.schema.role.create('management')
+        box.schema.role.grant('infra', 'staff')
+        box.schema.role.grant('management', 'staff')
+
+        -- Level 3 roles.
+        box.schema.role.create('manager')
+        box.schema.role.create('director')
+        box.schema.role.grant('manager', 'management')
+        box.schema.role.grant('director', 'management')
+
+        -- The test subject.
+        box.schema.user.create('testuser')
+        box.schema.user.grant('testuser', 'manager')
+
+        local original_user = box.session.effective_user()
+        box.session.su('testuser')
+
+        -- Check the user has an access to the 'manager' role.
+        t.assert_equals(#box.space._vuser.index.name:select('manager'), 1)
+        t.assert(pcall(box.schema.role.info, 'manager'))
+        t.assert(pcall(box.schema.user.info, 'testuser'))
+
+        -- Check the user doesn't have access to the 'director' role.
+        t.assert_equals(#box.space._vuser.index.name:select('director'), 0)
+        t.assert(not pcall(box.schema.role.info, 'director'))
+
+        -- Check the user has an access to the 'management' role.
+        t.assert_equals(#box.space._vuser.index.name:select('management'), 1)
+        t.assert(pcall(box.schema.role.info, 'management'))
+        t.assert(pcall(box.schema.role.info, 'manager'))
+
+        -- Check the user doesn't have access to the 'infra' role.
+        t.assert_equals(#box.space._vuser.index.name:select('infra'), 0)
+        t.assert(not pcall(box.schema.role.info, 'infra'))
+
+        -- Check the user has an access to the 'staff' role.
+        t.assert_equals(#box.space._vuser.index.name:select('staff'), 1)
+        t.assert(pcall(box.schema.role.info, 'staff'))
+        t.assert(pcall(box.schema.role.info, 'management'))
+
+        box.session.su(original_user)
+    end)
+end


### PR DESCRIPTION
Prior to this patch it was not possible for a user to see any role in the `_vuser` space except the one created by him and the `public` one.

Let's also make it possible to see roles that he is granted with, so calls to the `box.schema.user.info()` functions won't fail if a user has a non-'public' role granted.

Closes #10057

NO_DOC=bugfix