### PR TITLE
 [Backport 2.11] Fix GCC's UBsan and update a list of disabled UBSan checks

### DIFF
--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -246,32 +246,18 @@ macro(enable_tnt_compile_flags)
             object-size
             # See https://github.com/tarantool/tarantool/issues/10742.
             pointer-overflow
-            # Intrusive data structures may abuse '&obj->member' on pointer
-            # 'obj' which is not really a pointer at an object of its type.
-            # For example, rlist uses '&item->member' expression in macro cycles
-            # to check end of cycle, but on the last iteration 'item' points at
-            # the list metadata head, not at an object of type stored in this
-            # list.
-            vptr
             # Integer overflow and truncation are disabled due to extensive
             # usage of this UB in SQL code to 'implement' some kind of int65_t.
-            implicit-signed-integer-truncation
-            implicit-integer-sign-change
             signed-integer-overflow
             # NULL checking is disabled, because this is not a UB and raises
             # lots of false-positive fails such as typeof(*obj) with
-            # obj == NULL, or memcpy() with NULL argument and 0 size. All
-            # nullability sanitations are disabled, because from the tests it
-            # seems they implicitly turn each other on, when one is used. For
-            # example, having "returns-nonnull-attribute" may lead to fail in
-            # the typeof(*obj) when obj is NULL, even though there is nothing
-            # related to return.
+            # obj == NULL, or memcpy() with NULL argument and 0 size.
+            # "UBSan: check null is globally suppressed",
+            # https://github.com/tarantool/tarantool/issues/10741
             null
+            # "UBSan: check nonnull-attribute is globally suppressed",
+            # https://github.com/tarantool/tarantool/issues/10740
             nonnull-attribute
-            nullability-arg
-            returns-nonnull-attribute
-            nullability-assign
-            nullability-return
             # Not interested in function type mismatch errors.
             function
         )

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -246,9 +246,6 @@ macro(enable_tnt_compile_flags)
             object-size
             # See https://github.com/tarantool/tarantool/issues/10742.
             pointer-overflow
-            # Integer overflow and truncation are disabled due to extensive
-            # usage of this UB in SQL code to 'implement' some kind of int65_t.
-            signed-integer-overflow
             # NULL checking is disabled, because this is not a UB and raises
             # lots of false-positive fails such as typeof(*obj) with
             # obj == NULL, or memcpy() with NULL argument and 0 size.

--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -3166,6 +3166,11 @@ error:
  * @param neg_flag True if value is negative.
  * @param mem Register to store parsed integer
  */
+#if ENABLE_UB_SANITIZER
+static void
+expr_code_int(struct Parse *parse, struct Expr *expr, bool is_neg, int mem)
+__attribute__((no_sanitize("signed-integer-overflow")));
+#endif
 static void
 expr_code_int(struct Parse *parse, struct Expr *expr, bool is_neg,
 	      int mem)

--- a/src/box/sql/func.c
+++ b/src/box/sql/func.c
@@ -234,6 +234,11 @@ step_group_concat(struct sql_context *ctx, int argc, const struct Mem *argv)
 }
 
 /** Implementations of the ABS() function. */
+#if ENABLE_UB_SANITIZER
+static void
+func_abs_int(struct sql_context *ctx, int argc, const struct Mem *argv)
+  __attribute__((no_sanitize("signed-integer-overflow")));
+#endif
 static void
 func_abs_int(struct sql_context *ctx, int argc, const struct Mem *argv)
 {

--- a/src/box/sql/util.c
+++ b/src/box/sql/util.c
@@ -820,6 +820,13 @@ sqlHexToBlob(const char *z, int n)
 	return zBlob;
 }
 
+#if ENABLE_UB_SANITIZER
+/* See https://github.com/tarantool/tarantool/issues/10703. */
+int
+sql_add_int(int64_t lhs, bool is_lhs_neg, int64_t rhs, bool is_rhs_neg,
+	    int64_t *res, bool *is_res_neg)
+  __attribute__((no_sanitize("signed-integer-overflow")));
+#endif
 int
 sql_add_int(int64_t lhs, bool is_lhs_neg, int64_t rhs, bool is_rhs_neg,
 	    int64_t *res, bool *is_res_neg)
@@ -849,6 +856,13 @@ sql_add_int(int64_t lhs, bool is_lhs_neg, int64_t rhs, bool is_rhs_neg,
 	return 0;
 }
 
+#if ENABLE_UB_SANITIZER
+/* See https://github.com/tarantool/tarantool/issues/10703. */
+int
+sql_sub_int(int64_t lhs, bool is_lhs_neg, int64_t rhs, bool is_rhs_neg,
+	    int64_t *res, bool *is_res_neg)
+  __attribute__((no_sanitize("signed-integer-overflow")));
+#endif
 int
 sql_sub_int(int64_t lhs, bool is_lhs_neg, int64_t rhs, bool is_rhs_neg,
 	    int64_t *res, bool *is_res_neg)
@@ -934,6 +948,13 @@ sql_mul_int(int64_t lhs, bool is_lhs_neg, int64_t rhs, bool is_rhs_neg,
 	return 0;
 }
 
+#if ENABLE_UB_SANITIZER
+/* See https://github.com/tarantool/tarantool/issues/10703. */
+int
+sql_div_int(int64_t lhs, bool is_lhs_neg, int64_t rhs, bool is_rhs_neg,
+	    int64_t *res, bool *is_res_neg)
+  __attribute__((no_sanitize("signed-integer-overflow")));
+#endif
 int
 sql_div_int(int64_t lhs, bool is_lhs_neg, int64_t rhs, bool is_rhs_neg,
 	    int64_t *res, bool *is_res_neg)

--- a/src/lib/core/datetime.c
+++ b/src/lib/core/datetime.c
@@ -34,6 +34,12 @@
  * since Rata Die (0001-01-01).
  * DT_EPOCH_1970_OFFSET is the distance in days from Rata Die to Epoch.
  */
+#if ENABLE_UB_SANITIZER
+/* See https://github.com/tarantool/tarantool/issues/10704. */
+static int
+local_dt(int64_t secs)
+  __attribute__((no_sanitize("signed-integer-overflow")));
+#endif
 static int
 local_dt(int64_t secs)
 {

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -276,6 +276,11 @@ static __thread bool fiber_parent_backtrace_enabled;
  * An action performed each time a context switch happens.
  * Used to count each fiber's processing time.
  */
+#if ENABLE_UB_SANITIZER
+static inline void
+clock_set_on_csw(struct fiber *caller)
+  __attribute__((no_sanitize("signed-integer-overflow")));
+#endif
 static inline void
 clock_set_on_csw(struct fiber *caller)
 {

--- a/src/trivia/config.h.cmake
+++ b/src/trivia/config.h.cmake
@@ -273,6 +273,7 @@
 #define DEFAULT_CFG SYSCONF_DIR "/" DEFAULT_CFG_FILENAME
 
 #cmakedefine ENABLE_ASAN 1
+#cmakedefine ENABLE_UB_SANITIZER 1
 
 /* Cacheline size to calculate alignments */
 #define CACHELINE_SIZE 64


### PR DESCRIPTION
Orig PR: https://github.com/tarantool/tarantool/pull/10702