### PR TITLE
config: fix handling of wal.ext removal

### DIFF
--- a/changelogs/unreleased/config-wal-ext-removal.md
+++ b/changelogs/unreleased/config-wal-ext-removal.md
@@ -1,0 +1,3 @@
+## bugfix/config
+
+* Fixed handling of `wal.ext` option removal (ghe-963).

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -4,6 +4,7 @@ local instance_config = require('internal.config.instance_config')
 local snapshot = require('internal.config.utils.snapshot')
 local schedule_task = fiber._internal.schedule_task
 local mkversion = require('internal.mkversion')
+local tarantool = require('tarantool')
 
 local function peer_uris(configdata)
     local peers = configdata:peers()
@@ -374,6 +375,13 @@ local function apply(config)
         else
             box_cfg.audit_filter = 'compatibility'
         end
+    end
+
+    -- TODO(gh-10756): This is not needed when :apply_default()
+    -- supports default values for composite types.
+    if tarantool.package == 'Tarantool Enterprise' and
+       type(box_cfg.wal_ext) == 'nil' then
+        box_cfg.wal_ext = box.NULL
     end
 
     -- The startup process may need a special handling and differs

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1348,8 +1348,8 @@ return schema.new('instance_config', schema.record({
             }),
         }, {
             box_cfg = 'wal_ext',
-            -- TODO: This default doesn't work now. It needs
-            -- support of non-scalar schema nodes in
+            -- TODO(gh-10756): This default doesn't work now. It
+            -- needs support of non-scalar schema nodes in
             -- <schema object>:map().
             default = box.NULL,
         })),

--- a/test/config-luatest/wal_ext_test.lua
+++ b/test/config-luatest/wal_ext_test.lua
@@ -1,0 +1,50 @@
+local t = require('luatest')
+local cbuilder = require('luatest.cbuilder')
+local cluster = require('test.config-luatest.cluster')
+
+local g = t.group()
+
+g.before_all(cluster.init)
+g.after_each(cluster.drop)
+g.after_all(cluster.clean)
+
+g.before_all(function()
+    t.tarantool.skip_if_not_enterprise(
+        'The wal.ext option is supported only by Tarantool Enterprise Edition')
+end)
+
+-- Verify that if the wal.ext option is removed from the
+-- declarative configuration, it is removed from the box-level
+-- configuration (box.cfg.wal_ext) after config:reload().
+--
+-- This scenario was broken before tarantool/tarantool-ee#963.
+g.test_basic = function(g)
+    local config = cbuilder:new()
+        :set_global_option('wal.ext', {old = true, new = true})
+        :add_instance('i-001', {})
+        :config()
+
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    -- Verify a test case prerequisite: the option is applied.
+    cluster['i-001']:exec(function()
+        t.assert_equals(box.cfg.wal_ext, {old = true, new = true})
+    end)
+
+    -- Remove the wal.ext option, write and reload the new
+    -- configuration.
+    --
+    -- The wal.ext option removal had no effect before
+    -- tarantool/tarantool-ee#963.
+    local config_2 = cbuilder:new(config)
+        :set_global_option('wal.ext', nil)
+        :config()
+    cluster:reload(config_2)
+
+    -- Verify that the option is set to its default.
+    cluster['i-001']:exec(function()
+        t.assert_equals(box.cfg.wal_ext, nil)
+        t.assert_type(box.cfg.wal_ext, 'nil')
+    end)
+end


### PR DESCRIPTION
The option was not set to its default value on `config:reload()` (without restarting the instance) if removed from the YAML configuration. This patch works the problem around. The root of the problem will be fixed in #10756.

Fixes tarantool/tarantool-ee#963