### PR TITLE
config/schema: transform composite types in :map()

### DIFF
--- a/changelogs/unreleased/config-transform-composite-type.md
+++ b/changelogs/unreleased/config-transform-composite-type.md
@@ -1,0 +1,7 @@
+## feature/config
+
+* The `<schema object>:map()` method now supports transformation of a composite
+  type (gh-10756).
+
+  It also makes `<schema object>:apply_default()` support the `default`
+  annotation for a composite type.


### PR DESCRIPTION
`<schema object>:map()` now calls the user-provided transformation function not only on scalar schema nodes, but also on `record`, `map` and `array` nodes. The function is called on the outmost node first, then on the descandant ones.

`<schema object>:apply_default()` now supports the `default` annotation (and the `apply_default_if` one) for composite types. Similarly to `:map()` it traverses the nodes in the pre-order way.

Fixes #10756