### PR TITLE
ci: fixate the runner for perf_micro workflow

### DIFF
--- a/.github/workflows/perf_micro.yml
+++ b/.github/workflows/perf_micro.yml
@@ -48,7 +48,17 @@ jobs:
           ( github.event_name == 'pull_request' &&
             !contains(github.event.pull_request.labels.*.name, 'notest') ) )
 
-    runs-on: ubuntu-20.04-self-hosted
+    # 'performance' label _must_ be set only for the single runner
+    # to guarantee that results are not dependent on the machine.
+    # For runs whose statistics are not collected, it is OK to use
+    # any runner.
+    runs-on:
+      - self-hosted
+      - Linux
+      - x86_64
+      - ${{ (github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository) &&
+          'performance' || 'regular' }}
 
     timeout-minutes: 60
 

--- a/.test.mk
+++ b/.test.mk
@@ -73,6 +73,7 @@ test-release: build run-luajit-test run-test
 .PHONY: test-perf
 test-perf: CMAKE_ENV = BENCH_CMD="${BENCH_CMD}"
 test-perf: CMAKE_PARAMS = -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                          -DENABLE_BUNDLED_LIBBENCHMARK=ON \
                           -DENABLE_WERROR=ON \
                           -DTEST_BUILD=ON
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -772,7 +772,6 @@ include (cmake/package.cmake)
 #
 include (cmake/rpm.cmake)
 
-add_subdirectory(src)
 add_subdirectory(extra)
 add_subdirectory(test)
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -780,6 +779,10 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 else ()
     add_subdirectory(perf)
 endif ()
+# XXX: src should be processed after perf, since small perf tests
+# require bundled libbenchmark library defined in the perf
+# subdirectory.
+add_subdirectory(src)
 add_subdirectory(doc)
 
 option(WITH_NOTIFY_SOCKET "Enable notifications on NOTIFY_SOCKET" ON)

--- a/cmake/BuildBenchmark.cmake
+++ b/cmake/BuildBenchmark.cmake
@@ -1,0 +1,65 @@
+set(BENCHMARK_VERSION v1.9.0)
+set(BENCHMARK_HASH 21a2604efeded8b4cbabc72f3e1c7a2a)
+set(BENCHMARK_INSTALL_DIR ${BUNDLED_LIBS_INSTALL_DIR}/benchmark-prefix)
+set(BENCHMARK_INCLUDE_DIR ${BENCHMARK_INSTALL_DIR}/src/include)
+
+set(BENCHMARK_LIB ${BENCHMARK_INSTALL_DIR}/build/src/libbenchmark.a)
+set(BENCHMARK_LIB_MAIN ${BENCHMARK_INSTALL_DIR}/build/src/libbenchmark_main.a)
+
+list(APPEND BENCHMARK_CMAKE_FLAGS
+     "-DBENCHMARK_ENABLE_TESTING=OFF"
+     "-DBENCHMARK_ENABLE_LTO=OFF"
+     "-DBENCHMARK_USE_LIBCXX=OFF"
+     "-DBENCHMARK_ENABLE_GTEST_TESTS=OFF"
+     "-DBENCHMARK_ENABLE_LIBPFM=OFF"
+     # By default, this library is built in Debug. Propagate the
+     # non-Debug build for benchmarks (benchmarks aren't built in
+     # the Debug mode).
+     "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+)
+
+include(ExternalProject)
+ExternalProject_Add(bundled-benchmark-project
+    PREFIX ${BENCHMARK_INSTALL_DIR}
+    SOURCE_DIR ${BENCHMARK_INSTALL_DIR}/src
+    BINARY_DIR ${BENCHMARK_INSTALL_DIR}/build
+    STAMP_DIR ${BENCHMARK_INSTALL_DIR}/stamp
+    URL_MD5 ${BENCHMARK_HASH}
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    URL https://github.com/google/benchmark/archive/refs/tags/${BENCHMARK_VERSION}.tar.gz
+    CONFIGURE_COMMAND
+        ${CMAKE_COMMAND} -B <BINARY_DIR> -S <SOURCE_DIR>
+            -G ${CMAKE_GENERATOR} ${BENCHMARK_CMAKE_FLAGS}
+    BUILD_COMMAND cd <BINARY_DIR> && ${CMAKE_MAKE_PROGRAM} -j
+    INSTALL_COMMAND ""
+    CMAKE_GENERATOR ${CMAKE_GENERATOR}
+    BUILD_BYPRODUCTS ${BENCHMARK_LIB} ${BENCHMARK_LIB_MAIN}
+)
+
+add_library(bundled-benchmark STATIC IMPORTED GLOBAL)
+set_target_properties(bundled-benchmark PROPERTIES IMPORTED_LOCATION
+  ${BENCHMARK_LIB})
+add_dependencies(bundled-benchmark bundled-benchmark-project)
+
+add_library(bundled-benchmark-main STATIC IMPORTED GLOBAL)
+set_target_properties(bundled-benchmark-main PROPERTIES IMPORTED_LOCATION
+  ${BENCHMARK_LIB_MAIN})
+add_dependencies(bundled-benchmark-main bundled-benchmark-project)
+
+add_custom_target(bundled-libbenchmark
+    DEPENDS bundled-benchmark bundled-benchmark-main)
+set(BENCHMARK_LIBRARIES bundled-benchmark-main bundled-benchmark)
+set(BENCHMARK_INCLUDE_DIRS ${BENCHMARK_INCLUDE_DIR})
+set(benchmark_FOUND TRUE)
+# Propagate to the parent scope for small perf tests.
+set(BENCHMARK_LIBRARIES ${BENCHMARK_LIBRARIES} PARENT_SCOPE)
+set(benchmark_FOUND ${benchmark_FOUND} PARENT_SCOPE)
+set(BENCHMARK_INCLUDE_DIRS ${BENCHMARK_INCLUDE_DIRS} PARENT_SCOPE)
+
+unset(BENCHMARK_VERSION)
+unset(BENCHMARK_HASH)
+unset(BENCHMARK_INSTALL_DIR)
+unset(BENCHMARK_INCLUDE_DIR)
+unset(BENCHMARK_CMAKE_FLAGS)
+
+message(STATUS "Using bundled Google Benchmark")

--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -15,8 +15,17 @@ separate_arguments(BENCH_CMD_SEPARATE UNIX_COMMAND ${BENCH_CMD})
 
 add_subdirectory(lua)
 
-find_package(benchmark QUIET)
-if (NOT ${benchmark_FOUND})
+if(ENABLE_BUNDLED_LIBBENCHMARK)
+    include(BuildBenchmark)
+    add_dependencies(build_bundled_libs bundled-libbenchmark)
+    include_directories(${BENCHMARK_INCLUDE_DIRS})
+else()
+    find_package(benchmark QUIET)
+    set(BENCHMARK_LIBRARIES benchmark::benchmark)
+endif()
+
+# Always set for bundled libbenchmark.
+if(NOT ${benchmark_FOUND})
     message(AUTHOR_WARNING "Google Benchmark library was not found")
     set(MSG "Target test-c-perf is dummy, Google Benchmark library was not found")
     add_custom_target(test-c-perf
@@ -97,19 +106,19 @@ endfunction()
 
 create_perf_test(NAME tuple
                  SOURCES tuple.cc ${PROJECT_SOURCE_DIR}/test/unit/box_test_utils.c
-                 LIBRARIES core box tuple benchmark::benchmark
+                 LIBRARIES core box tuple ${BENCHMARK_LIBRARIES}
 )
 create_perf_test_target(TARGET tuple)
 
 create_perf_test(NAME bps_tree
                  SOURCES bps_tree.cc ${PROJECT_SOURCE_DIR}/test/unit/box_test_utils.c
-                 LIBRARIES core box tuple benchmark::benchmark
+                 LIBRARIES core box tuple ${BENCHMARK_LIBRARIES}
 )
 create_perf_test_target(TARGET bps_tree)
 
 create_perf_test(NAME light
                  SOURCES light.cc ${PROJECT_SOURCE_DIR}/test/unit/box_test_utils.c
-                 LIBRARIES small benchmark::benchmark
+                 LIBRARIES small ${BENCHMARK_LIBRARIES}
 )
 create_perf_test_target(TARGET light)
 
@@ -117,7 +126,7 @@ create_perf_test_target(TARGET small)
 
 create_perf_test(NAME memtx
                  SOURCES memtx.cc ${PROJECT_SOURCE_DIR}/test/unit/box_test_utils.c
-                 LIBRARIES core box server benchmark::benchmark
+                 LIBRARIES core box server ${BENCHMARK_LIBRARIES}
 )
 create_perf_test_target(TARGET memtx)
 


### PR DESCRIPTION
This patch fixates the GitHub CI runner with the label 'performance' for the aforementioned workflow, if it is run from the master, release branch, or triggered by PR from the main repository. It helps to avoid disturbance in the results of benchmarks due to different machine parameters.

NO_TEST=ci
NO_CHANGELOG=ci
NO_DOC=ci

----

Depends on https://github.com/tarantool/small/pull/100