### PR TITLE
box: fix update operations on the fixed-size floating-point fields

### DIFF
--- a/changelogs/unreleased/gh-9929-fix-updates-on-fixed-size-fp-fields.md
+++ b/changelogs/unreleased/gh-9929-fix-updates-on-fixed-size-fp-fields.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a bug that prevented `update()` operations on the fields with a
+  fixed-size floating-point type (gh-9929).

--- a/src/box/xrow_update_field.c
+++ b/src/box/xrow_update_field.c
@@ -676,6 +676,15 @@ xrow_update_store_scalar(const struct xrow_update_scalar *scalar,
 		}
 		break;
 	case XUPDATE_TYPE_DOUBLE:
+		if (this_node != NULL) {
+			enum field_type type =
+				json_tree_entry(this_node, struct tuple_field,
+						token)->type;
+			if (type == FIELD_TYPE_FLOAT32) {
+				out = mp_encode_float(out, (float)scalar->dbl);
+				break;
+			}
+		}
 		out = mp_encode_double(out, scalar->dbl);
 		break;
 	case XUPDATE_TYPE_FLOAT:
@@ -683,7 +692,8 @@ xrow_update_store_scalar(const struct xrow_update_scalar *scalar,
 			enum field_type type =
 				json_tree_entry(this_node, struct tuple_field,
 						token)->type;
-			if (type == FIELD_TYPE_DOUBLE) {
+			if (type == FIELD_TYPE_DOUBLE ||
+			    type == FIELD_TYPE_FLOAT64) {
 				out = mp_encode_double(out, scalar->flt);
 				break;
 			}


### PR DESCRIPTION
Currently for floating-point arithmetic operations the smallest type that can represent the resulting value is chosen (`MP_FLOAT` vs. `MP_DOUBLE`).
This doesn't work for fixed-size field types (`float32` and `float64`) that require the data to be encoded only to the corresponding type.

Closes #9929
Follow-up #9548