### PR TITLE
config: add replication.disabled option

### DIFF
--- a/changelogs/unreleased/config-replication-disabled.md
+++ b/changelogs/unreleased/config-replication-disabled.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* Added the `replication.disabled` option to temporary exclude an instance from
+  its replica set (gh-10776).

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1386,6 +1386,10 @@ return schema.new('instance_config', schema.record({
         }),
     }),
     replication = schema.record({
+        disabled = schema.scalar({
+            type = 'boolean',
+            default = false,
+        }),
         failover = schema.enum({
             -- No failover ('off').
             --

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -223,6 +223,7 @@ g.test_defaults = function()
             use_mvcc_engine = false,
         },
         replication = {
+            disabled = false,
             failover = 'off',
             anon = false,
             threads = 1,

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1116,6 +1116,7 @@ end
 g.test_replication = function()
     local iconfig = {
         replication = {
+            disabled = false,
             failover = 'off',
             peers = {'one', 'two'},
             anon = true,
@@ -1139,6 +1140,7 @@ g.test_replication = function()
                     instance_config.schema.fields.replication)
 
     local exp = {
+        disabled = false,
         failover = 'off',
         anon = false,
         threads = 1,


### PR DESCRIPTION
The commit adds the main logic behind the `replication.disabled` option. It is useful to temporary exclude an instance from its replica set.

The instance with `replication.disabled = true` disconnects from all the upstreams.

All the other instances in the replica set refuse to fetch data from the disabled instance.

If the instance is non-anonymous it is kept in the `_cluster` system space, so the replication from/to it can be enabled back.

*(One bullet from #10776 is not solved here: refuse to bootstrap if the option is set. This functionality is to be implemented in a separate patch.)*

Part of #10776