### PR TITLE
box: validate fixed integer types keys range

### DIFF
--- a/changelogs/unreleased/gh-10777-check-fixed-int-key-in-range.md
+++ b/changelogs/unreleased/gh-10777-check-fixed-int-key-in-range.md
@@ -1,0 +1,3 @@
+## bugfix/box
+
+- Added missing key value check for fixed integer types (gh-10777).

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -434,6 +434,7 @@ struct errcode_record {
 	_(ER_WAL_QUEUE_FULL, 287,		"The WAL queue is full") \
 	_(ER_INVALID_VCLOCK, 288,		"Invalid vclock", "value", STRING) \
 	_(ER_SYNC_QUEUE_FULL, 289,		"The synchronous transaction queue is full") \
+	_(ER_KEY_PART_VALUE_OUT_OF_RANGE, 290,	"The value of key part exceeds the supported range for type", "partno", UINT, "field_type", STRING, "value", MSGPACK, "min", MSGPACK, "max", MSGPACK) \
 	TEST_ERROR_CODES(_) /** This one should be last. */
 
 /*

--- a/src/box/field_def.h
+++ b/src/box/field_def.h
@@ -112,6 +112,17 @@ bool
 field_type1_contains_type2(enum field_type type1, enum field_type type2);
 
 /**
+ * Return true for fixed-size integer field `type'.
+ */
+static inline bool
+field_type_is_fixed_int(enum field_type type)
+{
+	assert(type < field_type_MAX);
+	return field_type_is_fixed_signed[type] ||
+	       field_type_is_fixed_unsigned[type];
+}
+
+/**
  * Get field type by name
  */
 enum field_type
@@ -198,6 +209,25 @@ field_mp_type_is_compatible(enum field_type type, const char *data,
 		}
 	}
 }
+
+/**
+ * Check if MsgPack value fits into the range for fixed size integer type.
+ * @param type - fixed size integer type.
+ * @param data - MsgPack value.
+ * @param mp_min - buffer to hold MsgPack of minimum value for type
+ *   if value does not fit.
+ * @param mp_max - buffer to hold MsgPack of maximum value for type
+ *   if value does not fit.
+ * @param details[out] - pointer to hold pointer to statically allocated
+ *   string with error details if value does not fit. Can be NULL if
+ *   details are not required.
+ * @retval true if fits and false otherwise. If not fit then mp_min, mp_max
+ *   and details are filled with error details.
+ */
+bool
+field_mp_is_in_fixed_int_range(enum field_type type, const char *data,
+			       char *mp_min, char *mp_max,
+			       const char **details);
 
 static inline bool
 action_is_nullable(enum on_conflict_action nullable_action)

--- a/src/box/key_def.h
+++ b/src/box/key_def.h
@@ -884,6 +884,16 @@ key_part_validate(enum field_type key_type, const char *key,
 			 field_type_strs[key_type]);
 		return -1;
 	}
+	if (field_type_is_fixed_int(key_type)) {
+		char mp_min[16], mp_max[16];
+		if (!field_mp_is_in_fixed_int_range(
+				key_type, key, mp_min, mp_max, NULL)) {
+			diag_set(ClientError, ER_KEY_PART_VALUE_OUT_OF_RANGE,
+				 field_no, field_type_strs[key_type], key,
+				 mp_min, mp_max);
+			return -1;
+		}
+	}
 	return 0;
 }
 

--- a/src/box/tuple_format.h
+++ b/src/box/tuple_format.h
@@ -201,17 +201,6 @@ tuple_field_has_default(const struct tuple_field *tuple_field)
 }
 
 /**
- * Return true for fixed-size integer field `type'.
- */
-static inline bool
-tuple_field_type_is_fixed_int(enum field_type type)
-{
-	assert(type < field_type_MAX);
-	return field_type_is_fixed_signed[type] ||
-	       field_type_is_fixed_unsigned[type];
-}
-
-/**
  * Return path to a tuple field. Used for error reporting.
  */
 const char *

--- a/test/box-luatest/gh_10777_fixed_size_keys_test.lua
+++ b/test/box-luatest/gh_10777_fixed_size_keys_test.lua
@@ -1,0 +1,131 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+g.test_range = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('test', {format = {
+            {'i8', 'int8'},
+            {'i16', 'int16'},
+            {'i32', 'int32'},
+            {'i64', 'int64'},
+            {'u8', 'uint8'},
+            {'u16', 'uint16'},
+            {'u32', 'uint32'},
+        }})
+        local errmsg =
+                'The value of key part exceeds the supported range for type'
+        local test_signed_size = function(bits)
+            local exp = bits - 1
+            local index = s:create_index('test', {parts = {'i' .. bits}})
+            t.assert_error_covers({
+                code = box.error.KEY_PART_VALUE_OUT_OF_RANGE,
+                key = {-2^exp - 1},
+                message = errmsg,
+                partno = 0,
+                field_type = 'int' .. bits,
+                value = -2^exp - 1,
+                min = -2^exp,
+                max = 2^exp - 1,
+            }, index.get, index, {-2^exp - 1})
+            t.assert_equals(index:get{-2^exp}, nil)
+            t.assert_error_covers({
+                code = box.error.KEY_PART_VALUE_OUT_OF_RANGE,
+                key = {2^exp},
+                message = errmsg,
+                partno = 0,
+                field_type = 'int' .. bits,
+                value = 2^exp,
+                min = -2^exp,
+                max = 2^exp - 1,
+            }, index.get, index, {2^exp})
+            t.assert_equals(index:get{2^exp - 1}, nil)
+            index:drop()
+        end
+        local test_unsigned_size = function(bits)
+            local exp = bits
+            local index = s:create_index('test', {parts = {'u' .. bits}})
+            t.assert_error_covers({
+                code = box.error.KEY_PART_VALUE_OUT_OF_RANGE,
+                key = {2^exp},
+                message = errmsg,
+                partno = 0,
+                field_type = 'uint' .. bits,
+                value = 2^exp,
+                min = 0,
+                max = 2^exp - 1,
+            }, index.get, index, {2^exp})
+            t.assert_equals(index:get{2^exp - 1}, nil)
+            index:drop()
+        end
+        test_signed_size(8)
+        test_signed_size(16)
+        test_signed_size(32)
+        test_unsigned_size(8)
+        test_unsigned_size(16)
+        test_unsigned_size(32)
+        local index = s:create_index('test', {parts = {'i64'}})
+        t.assert_error_covers({
+            code = box.error.KEY_PART_VALUE_OUT_OF_RANGE,
+            key = {9223372036854775808ULL},
+            message = errmsg,
+            partno = 0,
+            field_type = 'int64',
+            value = 9223372036854775808ULL,
+            min = -9223372036854775808LL,
+            max = 9223372036854775807LL,
+        }, index.get, index, {9223372036854775808ULL})
+        t.assert_equals(index:get{9223372036854775807ULL}, nil)
+    end)
+end
+
+g.test_error_partno = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('test', {format = {
+            {'f1', 'uint8'},
+            {'f2', 'int8'},
+        }})
+        local index = s:create_index('test', {parts = {'f1', 'f2'}})
+        -- Test `partno` is correct.
+        t.assert_error_covers({
+            code = box.error.KEY_PART_VALUE_OUT_OF_RANGE,
+            key = {0, 2^7},
+            partno = 1,
+            field_type = 'int8',
+            value = 2^7,
+            min = -2^7,
+            max = 2^7 - 1,
+        }, index.get, index, {0, 2^7})
+    end)
+end
+
+g.test_null_value = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('test', {format = {
+            {'f1', 'unsigned'},
+            {'f2', 'uint8', is_nullable = true},
+        }})
+        s:create_index('pk')
+        local index = s:create_index('sk', {parts = {'f2'}})
+        -- Use count as it allows nullable parts.
+        t.assert_equals(index:count({box.NULL}), 0)
+    end)
+end

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -500,6 +500,7 @@ t;
  |   287: box.error.WAL_QUEUE_FULL
  |   288: box.error.INVALID_VCLOCK
  |   289: box.error.SYNC_QUEUE_FULL
+ |   290: box.error.KEY_PART_VALUE_OUT_OF_RANGE
  | ...
 
 test_run:cmd("setopt delimiter ''");


### PR DESCRIPTION
Currently `index:get({256})` is valid request for 'uint8' field for example.  It is not on par with error for negative values and for range check for tuples. Let's add range check for fixed integer types for keys too.

While at it let's move and rename `tuple_field_type_is_fixed_int`. Also function for checking range is fixed to fill min and max MsgPack values only on errors. This potential performance issue was introduced in the commit 7410a4f0f291 ("box: add payload info for client error codes").

Follow-up #9548
Closes #10777