### PR TITLE
[backport 3.2] config: fix handling of options removal

### DIFF
--- a/changelogs/unreleased/config-audit-log-spaces-removal.md
+++ b/changelogs/unreleased/config-audit-log-spaces-removal.md
@@ -1,0 +1,3 @@
+## bugfix/config
+
+* Fixed handling of `audit_log.spaces` option removal (ghe-964).

--- a/changelogs/unreleased/config-log-modules-removal.md
+++ b/changelogs/unreleased/config-log-modules-removal.md
@@ -1,0 +1,3 @@
+## bugfix/config
+
+* Fixed handling of `log.modules` option removal (gh-10728).

--- a/changelogs/unreleased/config-wal-ext-removal.md
+++ b/changelogs/unreleased/config-wal-ext-removal.md
@@ -1,0 +1,3 @@
+## bugfix/config
+
+* Fixed handling of `wal.ext` option removal (ghe-963).

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -4,6 +4,7 @@ local instance_config = require('internal.config.instance_config')
 local snapshot = require('internal.config.utils.snapshot')
 local schedule_task = fiber._internal.schedule_task
 local mkversion = require('internal.mkversion')
+local tarantool = require('tarantool')
 
 local function peer_uris(configdata)
     local peers = configdata:peers()
@@ -374,6 +375,13 @@ local function apply(config)
         else
             box_cfg.audit_filter = 'compatibility'
         end
+    end
+
+    -- TODO(gh-10756): This is not needed when :apply_default()
+    -- supports default values for composite types.
+    if tarantool.package == 'Tarantool Enterprise' and
+       type(box_cfg.wal_ext) == 'nil' then
+        box_cfg.wal_ext = box.NULL
     end
 
     -- The startup process may need a special handling and differs

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -354,6 +354,12 @@ local function apply(config)
     local cfg_log = configdata:get('log', {use_default = true})
     box_cfg.log = log_destination(cfg_log)
 
+    -- TODO(gh-10756): This is not needed when :apply_default()
+    -- supports default values for composite types.
+    if type(box_cfg.log_modules) == 'nil' then
+        box_cfg.log_modules = box.NULL
+    end
+
     -- Construct audit logger destination and audit filter (box_cfg.audit_log
     -- and audit_filter).
     --

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -847,8 +847,8 @@ return schema.new('instance_config', schema.record({
                 type = 'number, string',
             }),
             box_cfg = 'log_modules',
-            -- TODO: This default doesn't work now. It needs
-            -- support of non-scalar schema nodes in
+            -- TODO(gh-10756): This default doesn't work now. It
+            -- needs support of non-scalar schema nodes in
             -- <schema object>:map().
             default = box.NULL,
         }),

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2243,6 +2243,9 @@ return schema.new('instance_config', schema.record({
             }),
             box_cfg = 'audit_spaces',
             box_cfg_nondynamic = true,
+            -- TODO(gh-10756): This default doesn't work now. It
+            -- needs support of non-scalar schema nodes in
+            -- <schema object>:map().
             default = box.NULL,
         })),
         extract_key = enterprise_edition(schema.scalar({

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1347,8 +1347,8 @@ return schema.new('instance_config', schema.record({
             }),
         }, {
             box_cfg = 'wal_ext',
-            -- TODO: This default doesn't work now. It needs
-            -- support of non-scalar schema nodes in
+            -- TODO(gh-10756): This default doesn't work now. It
+            -- needs support of non-scalar schema nodes in
             -- <schema object>:map().
             default = box.NULL,
         })),

--- a/test/config-luatest/audit_log_spaces_test.lua
+++ b/test/config-luatest/audit_log_spaces_test.lua
@@ -1,0 +1,73 @@
+local t = require('luatest')
+local cbuilder = require('luatest.cbuilder')
+local cluster = require('test.config-luatest.cluster')
+
+local g = t.group()
+
+g.before_all(cluster.init)
+g.after_each(cluster.drop)
+g.after_all(cluster.clean)
+
+g.before_all(function()
+    t.tarantool.skip_if_not_enterprise(
+        'The audit_log.spaces option is supported only by Tarantool ' ..
+        'Enterprise Edition')
+end)
+
+-- Verify that if the audit_log.spaces option is changed (removed,
+-- for example) in the declarative configuration, a warning about
+-- a non-dynamic option change is issued, but the option is NOT
+-- changed in the underlying box-level configuration
+-- (box.cfg.audit_spaces) after config:reload().
+--
+-- This scenario is described in tarantool/tarantool-ee#964.
+g.test_basic = function(g)
+    local config = cbuilder:new()
+        :set_global_option('audit_log.spaces', {'myspace'})
+        :add_instance('i-001', {})
+        :config()
+
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    -- Verify a test case prerequisite: the option is applied.
+    cluster['i-001']:exec(function()
+        t.assert_equals(box.cfg.audit_spaces, {'myspace'})
+    end)
+
+    -- Remove the audit_log.spaces option, write and reload the
+    -- new configuration.
+    local config_2 = cbuilder:new(config)
+        :set_global_option('audit_log.spaces', nil)
+        :config()
+    cluster:reload(config_2)
+
+    -- Verify that the option remains unchanged and a warning is
+    -- issued.
+    --
+    -- The warning was not issued before
+    -- tarantool/tarantool-ee#964.
+    cluster['i-001']:exec(function()
+        local function find_alert(exp)
+            local alerts = box.info.config.alerts
+
+            for _, a in ipairs(alerts) do
+                if a.message:find(exp) then
+                    return a
+                end
+            end
+
+            return false, {
+                alerts = alerts,
+                needle = exp,
+            }
+        end
+
+        -- Check the warning.
+        t.assert(find_alert('non%-dynamic option audit_spaces will not be ' ..
+            'set until the instance is restarted'))
+
+        -- Verify the actual box-level value.
+        t.assert_equals(box.cfg.audit_spaces, {'myspace'})
+    end)
+end

--- a/test/config-luatest/log_modules_test.lua
+++ b/test/config-luatest/log_modules_test.lua
@@ -1,0 +1,232 @@
+local fio = require('fio')
+local digest = require('digest')
+local t = require('luatest')
+local cbuilder = require('luatest.cbuilder')
+local cluster = require('test.config-luatest.cluster')
+
+local g = t.group()
+
+g.before_all(cluster.init)
+g.after_each(cluster.drop)
+g.after_all(cluster.clean)
+
+-- Execute the given function on the given server and collect logs
+-- produced during its execution.
+--
+-- Comparing to <server object>:exec() it has a limited
+-- functionality:
+--
+-- * no arguments passing
+-- * no return value receiving
+-- * no luatest upvalue autorebinding
+-- * no check that there are no other upvalues
+--
+-- Though, it is enough for the test cases below.
+--
+-- It would be nice to integrate the log capturing functionality
+-- right into <server object>:exec() in a future. It would also be
+-- nice to support logging to stderr, not just file, because
+-- luatest anyway captures it.
+--
+-- Unlike <server object>:grep_log() this function is bounded to
+-- a particular given function and leans on unique log markers, so
+-- it is suitable in a situation, when several testing scenarios
+-- are producing similar output.
+--
+-- Also, it just feels more user-friendly.
+local function log_capturing_exec(server, f)
+    -- Generate markers to issue them before/after the execution
+    -- of the provided function and look them up inside logs
+    -- later.
+    local start_marker = digest.urandom(40):hex()
+    local end_marker = digest.urandom(40):hex()
+
+    -- Execute the provided function (and issue the markers
+    -- before/after it).
+    local func_body = string.dump(f)
+    server:exec(function(func_body, start_marker, end_marker)
+        local log = require('log')
+        local func = loadstring(func_body)
+        log.info(start_marker)
+        func()
+        log.info(end_marker)
+    end, {func_body, start_marker, end_marker})
+
+    -- Determine a path to the log file of the given server.
+    local file = fio.pathjoin(server.chdir, 'var/log', server.alias,
+        'tarantool.log')
+
+    -- Cut off a text between start and end markers: the output
+    -- of the provided function.
+    local raw_log = t.helpers.retrying({timeout = 60}, function()
+        -- Read the log file.
+        local fh = assert(fio.open(file, {'O_RDONLY'}))
+        local data = fh:read()
+        fh:close()
+
+        -- Look up positions of the start and the end markers.
+        --
+        -- We need the last position of the start marker and the
+        -- first position of the end marker.
+        local _, s = data:find(('%s\n'):format(start_marker))
+        assert(s ~= nil, ('no test start marker: %s'):format(start_marker))
+        local e = data:find(('\n[^\n]+%s'):format(end_marker), s)
+        assert(e ~= nil, ('no test end marker: %s'):format(end_marker))
+
+        -- All the text between them is what we're searching for.
+        return data:sub(s + 1, e - 1)
+    end)
+
+    -- Split per line.
+    --
+    -- Remove all the columns except the log level and the
+    -- message.
+    local res = {}
+    for _, line in ipairs(raw_log:split('\n')) do
+        table.insert(res, line:match('.> .*$'))
+    end
+    return res
+end
+
+-- A function that issues log messages using various loggers on
+-- different levels.
+local function issue_logs()
+    local log = require('log')
+
+    for _, logger_name in ipairs({
+        'mfatal',
+        'msyserror',
+        'merror',
+        'mcrit',
+        'mwarn',
+        'minfo',
+        'mdefault',
+        'mverbose',
+        'mdebug',
+    }) do
+        local logger = log.new(logger_name)
+        for _, level in ipairs({
+            'error',
+            'warn',
+            'info',
+            'verbose',
+            'debug',
+        }) do
+            logger[level]('hello from logger %s', logger_name)
+        end
+    end
+end
+
+-- Verify an effect of the log.modules option and an effect of
+-- removing it (after :reload(), without restart).
+--
+-- This scenario was broken before gh-10728.
+g.test_basic = function(g)
+    local config = cbuilder:new()
+        :add_instance('i-001', {})
+        -- luatest.server doesn't provide an API to catch
+        -- tarantool's stdout/stderr output. Feed the logs to a
+        -- file to read them from the test case.
+        :set_global_option('log.to', 'file')
+        -- Define loggers with different levels.
+        :set_global_option('log.modules', {
+            mfatal = 'fatal',
+            msyserror = 'syserror',
+            merror = 'error',
+            mcrit = 'crit',
+            mwarn = 'warn',
+            minfo = 'info',
+            -- mdefault is unset deliberately to verify the
+            -- default level.
+            mverbose = 'verbose',
+            mdebug = 'debug',
+        })
+        :config()
+
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    -- Each logger shows log messages of the corresponding levels.
+    --
+    -- For example, minfo messages are on error, warn, info
+    -- levels, while verbose and debug messages are suppressed.
+    local res = log_capturing_exec(cluster['i-001'], issue_logs)
+    t.assert_equals(res, {
+        'E> hello from logger merror',
+
+        'E> hello from logger mcrit',
+
+        'E> hello from logger mwarn',
+        'W> hello from logger mwarn',
+
+        'E> hello from logger minfo',
+        'W> hello from logger minfo',
+        'I> hello from logger minfo',
+
+        'E> hello from logger mdefault',
+        'W> hello from logger mdefault',
+        'I> hello from logger mdefault',
+
+        'E> hello from logger mverbose',
+        'W> hello from logger mverbose',
+        'I> hello from logger mverbose',
+        'V> hello from logger mverbose',
+
+        'E> hello from logger mdebug',
+        'W> hello from logger mdebug',
+        'I> hello from logger mdebug',
+        'V> hello from logger mdebug',
+        'D> hello from logger mdebug',
+    })
+
+    -- Remove the log.modules option, write and reload the new
+    -- configuration.
+    --
+    -- The log.modules option removal had no effect before
+    -- gh-10728.
+    local config_2 = cbuilder:new(config)
+        :set_global_option('log.modules', nil)
+        :config()
+    cluster:reload(config_2)
+
+    -- Now all the loggers are working on the default (info)
+    -- level.
+    local res = log_capturing_exec(cluster['i-001'], issue_logs)
+    t.assert_equals(res, {
+        'E> hello from logger mfatal',
+        'W> hello from logger mfatal',
+        'I> hello from logger mfatal',
+
+        'E> hello from logger msyserror',
+        'W> hello from logger msyserror',
+        'I> hello from logger msyserror',
+
+        'E> hello from logger merror',
+        'W> hello from logger merror',
+        'I> hello from logger merror',
+
+        'E> hello from logger mcrit',
+        'W> hello from logger mcrit',
+        'I> hello from logger mcrit',
+
+        'E> hello from logger mwarn',
+        'W> hello from logger mwarn',
+        'I> hello from logger mwarn',
+
+        'E> hello from logger minfo',
+        'W> hello from logger minfo',
+        'I> hello from logger minfo',
+
+        'E> hello from logger mdefault',
+        'W> hello from logger mdefault',
+        'I> hello from logger mdefault',
+
+        'E> hello from logger mverbose',
+        'W> hello from logger mverbose',
+        'I> hello from logger mverbose',
+
+        'E> hello from logger mdebug',
+        'W> hello from logger mdebug',
+        'I> hello from logger mdebug',
+    })
+end

--- a/test/config-luatest/wal_ext_test.lua
+++ b/test/config-luatest/wal_ext_test.lua
@@ -1,0 +1,50 @@
+local t = require('luatest')
+local cbuilder = require('luatest.cbuilder')
+local cluster = require('test.config-luatest.cluster')
+
+local g = t.group()
+
+g.before_all(cluster.init)
+g.after_each(cluster.drop)
+g.after_all(cluster.clean)
+
+g.before_all(function()
+    t.tarantool.skip_if_not_enterprise(
+        'The wal.ext option is supported only by Tarantool Enterprise Edition')
+end)
+
+-- Verify that if the wal.ext option is removed from the
+-- declarative configuration, it is removed from the box-level
+-- configuration (box.cfg.wal_ext) after config:reload().
+--
+-- This scenario was broken before tarantool/tarantool-ee#963.
+g.test_basic = function(g)
+    local config = cbuilder:new()
+        :set_global_option('wal.ext', {old = true, new = true})
+        :add_instance('i-001', {})
+        :config()
+
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    -- Verify a test case prerequisite: the option is applied.
+    cluster['i-001']:exec(function()
+        t.assert_equals(box.cfg.wal_ext, {old = true, new = true})
+    end)
+
+    -- Remove the wal.ext option, write and reload the new
+    -- configuration.
+    --
+    -- The wal.ext option removal had no effect before
+    -- tarantool/tarantool-ee#963.
+    local config_2 = cbuilder:new(config)
+        :set_global_option('wal.ext', nil)
+        :config()
+    cluster:reload(config_2)
+
+    -- Verify that the option is set to its default.
+    cluster['i-001']:exec(function()
+        t.assert_equals(box.cfg.wal_ext, nil)
+        t.assert_type(box.cfg.wal_ext, 'nil')
+    end)
+end


### PR DESCRIPTION
*(This is a backport of PR #10757, PR #10758, PR #10759 to `release/3.2`, a future `3.2.2` release.)*

----

The `log.modules` and `wal.ext` options were not set to their default values on `config:reload()` (without restarting the instance) if removed from the YAML configuration. The first two patches work the problem around.

If the `audit_log.spaces` option is removed from the YAML configuration, `config:reload()` should add an alert that a non-dynamic option is changed and it will be applied after a restart. The third patch works this problem around.

The root of these problems will be fixed in #10756 in tarantool 3.3 (not to be backported to 3.2).

Fixes #10728
Fixes tarantool/tarantool-ee#963
Fixes tarantool/tarantool-ee#964