### PR TITLE
iproto: add Lua API to drop connections (internal)

### DIFF
--- a/src/box/lua/iproto.c
+++ b/src/box/lua/iproto.c
@@ -241,6 +241,29 @@ lbox_iproto_session_new(struct lua_State *L)
 }
 
 /**
+ * Drop all current connections.
+ *
+ * Accepts a timeout (in seconds).
+ *
+ * Returns nothing on success, raises an error on a failure.
+ *
+ * See iproto_drop_connections() for details.
+ */
+static int
+lbox_iproto_drop_connections(struct lua_State *L)
+{
+	int n_args = lua_gettop(L);
+	if (n_args != 1 || lua_type(L, 1) != LUA_TNUMBER)
+		return luaL_error(L, "Usage: box.iproto.internal."
+				  "drop_connections(timeout)");
+	double timeout = lua_tonumber(L, 1);
+	int rc = iproto_drop_connections(timeout);
+	if (rc < 0)
+		return luaT_error(L);
+	return 0;
+}
+
+/**
  * Encodes a packet header/body argument to MsgPack: if the argument is a
  * string, then no encoding is needed — otherwise the argument must be a Lua
  * table. The Lua table is encoded to MsgPack using IPROTO key translation
@@ -618,6 +641,7 @@ box_lua_iproto_init(struct lua_State *L)
 	luaL_findtable(L, -1, "internal", 0);
 	static const struct luaL_Reg internal_funcs[] = {
 		{"session_new", lbox_iproto_session_new},
+		{"drop_connections", lbox_iproto_drop_connections},
 		{NULL, NULL}
 	};
 	luaL_setfuncs(L, internal_funcs, 0);

--- a/test/box-luatest/iproto_drop_connections_test.lua
+++ b/test/box-luatest/iproto_drop_connections_test.lua
@@ -1,0 +1,66 @@
+local net_box = require('net.box')
+local t = require('luatest')
+local server = require('luatest.server')
+local it = require('test.interactive_tarantool')
+
+local g = t.group()
+
+g.after_each(function(g)
+    if g.server ~= nil then
+        g.server:stop()
+    end
+    if g.it ~= nil then
+        g.it:close()
+    end
+    if g.conn ~= nil then
+        g.conn:close()
+    end
+end)
+
+-- Verify the internal function to drop iproto connections.
+g.test_basic = function(g)
+    -- Start a server.
+    g.server = server:new({alias = 'server'})
+    g.server:start()
+
+    -- Start a console on the server to feed testing commands
+    -- without iproto.
+    g.server:exec(function()
+        local console = require('console')
+
+        console.listen('unix/:./tarantool.control')
+    end)
+
+    -- Connect to the server's console and verify that it works.
+    g.it = it.connect(g.server)
+    g.it:roundtrip('42', 42)
+
+    -- Connect to the server using iproto and verify that it
+    -- works.
+    local uri = g.server.net_box_uri
+    g.conn = net_box.connect(uri)
+    t.assert(g.conn:ping())
+
+    -- Drop connections.
+    local timeout = 60
+    g.it:roundtrip(('box.iproto.internal.drop_connections(%d)'):format(timeout))
+
+    -- Verify that our connection was dropped.
+    t.assert_not(g.conn:ping())
+
+    -- However, we can reconnect.
+    g.conn:close()
+    g.conn = net_box.connect(uri)
+    t.assert(g.conn:ping())
+
+    -- Verify error reporting.
+    t.assert_error_msg_equals('timed out', function()
+        g.it:roundtrip('box.iproto.internal.drop_connections(0)')
+    end)
+
+    -- Verify that connections are dropped in background anyway
+    -- despite the reported timeout error.
+    t.helpers.retrying({timeout = 60}, function()
+        t.assert_not(g.conn:ping())
+    end)
+end


### PR DESCRIPTION
This low-level API is needed to prevent execution of user's requests over iproto, when an instance is marked as disabled/isolated. See details about this mode in #10796.

Part of #10796