### PR TITLE
config: add failover learners section

### DIFF
--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -592,6 +592,23 @@ local function validate_failover_config(instances, failover_config)
         replicasets[def.replicaset_name] = true
     end
 
+    local function verify_instance_in_replicaset(instance_name, replicaset_name)
+        if instances[instance_name] == nil then
+            error(('instance %s from replicaset %s specified in the '..
+                   'failover.replicasets section doesn\'t exist')
+                  :format(instance_name, replicaset_name), 0)
+        end
+
+        local instance_replicaset = instances[instance_name].replicaset_name
+        if instance_replicaset ~= replicaset_name then
+            error(('instance %s from replicaset %s is specified in ' ..
+                   'the wrong replicaset %s in the failover.replicasets ' ..
+                   'configuration section')
+                  :format(instance_name, instance_replicaset,
+                          replicaset_name), 0)
+        end
+    end
+
     for replicaset_name, replicaset in pairs(failover_config.replicasets) do
         if replicasets[replicaset_name] == nil then
             error(('replicaset %s specified in the failover configuration '..
@@ -600,20 +617,13 @@ local function validate_failover_config(instances, failover_config)
 
         -- Validate the priority section of the specific replicasets.
         for instance_name, _ in pairs(replicaset.priority or {}) do
-            if instances[instance_name] == nil then
-                error(('instance %s from replicaset %s specified in the '..
-                       'failover configuration doesn\'t exist')
-                      :format(instance_name, replicaset_name), 0)
-            end
+            verify_instance_in_replicaset(instance_name, replicaset_name)
+        end
 
-            local instance_replicaset = instances[instance_name].replicaset_name
-            if instance_replicaset ~= replicaset_name then
-                error(('instance %s from replicaset %s is specified in ' ..
-                       'the wrong replicaset %s in the failover ' ..
-                       'configuration section')
-                      :format(instance_name, instance_replicaset,
-                              replicaset_name), 0)
-            end
+        -- Validate the learner instances section of the
+        -- specific replicaset.
+        for _, instance_name in ipairs(replicaset.learners or {}) do
+            verify_instance_in_replicaset(instance_name, replicaset_name)
         end
     end
 end

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2325,6 +2325,13 @@ return schema.new('instance_config', schema.record({
                 type = 'string',
             }),
             value = schema.record({
+                -- Instances that can't be chosen as a master
+                -- by the supervised failover coordinator.
+                learners = schema.array({
+                    items = schema.scalar({
+                        type = 'string',
+                    }),
+                }),
                 -- Priorities for the supervised failover mode.
                 priority = schema.map({
                     key = schema.scalar({

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1726,6 +1726,9 @@ g.test_failover = function()
             },
             replicasets = {
                 replicaset001 = {
+                    learners = {
+                        'instance002',
+                    },
                     priority = {
                         instance001 = 1
                     }


### PR DESCRIPTION
This patch adds the support for `failover.replicasets.<replicaset-name>.learners` configuration section and corresponding checks for it.

This option is used to specify the list of instances from the specific replicaset that can't be selected as a master by the supervised failover coordinator.

The supervised coordinator is enterprise-edition feature.

EE issue: tarantool/tarantool-ee#991
EE PR: tarantool/tarantool-ee#992

Jira task: [TNTP-192](https://jira.vk.team/browse/TNTP-192)