### PR TITLE
[backport 3.2] box: make bootstrap_leader cfg option dynamic

### DIFF
--- a/changelogs/unreleased/gh-10604-bootstrap-leader-dynamic.md
+++ b/changelogs/unreleased/gh-10604-bootstrap-leader-dynamic.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* The `bootstrap_leader` configuration option is now dynamic (gh-10604).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -1583,6 +1583,8 @@ static int
 box_check_bootstrap_leader(struct uri *uri, struct tt_uuid *uuid, char *name)
 {
 	*uuid = uuid_nil;
+	if (!uri_is_nil(uri))
+		uri_destroy(uri);
 	uri_create(uri, NULL);
 	*name = '\0';
 	const char *source = cfg_gets("bootstrap_leader");
@@ -1965,6 +1967,7 @@ box_check_config(void)
 	box_check_replication_sync_timeout();
 	if (box_check_bootstrap_strategy() == BOOTSTRAP_STRATEGY_INVALID)
 		diag_raise();
+	uri_create(&uri, NULL);
 	if (box_check_bootstrap_leader(&uri, &uuid, name) != 0)
 		diag_raise();
 	uri_destroy(&uri);
@@ -2146,7 +2149,7 @@ box_set_bootstrap_strategy(void)
 	return 0;
 }
 
-static int
+int
 box_set_bootstrap_leader(void)
 {
 	return box_check_bootstrap_leader(&cfg_bootstrap_leader_uri,

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -388,6 +388,7 @@ int box_set_txn_timeout(void);
 int box_set_txn_isolation(void);
 int box_set_auth_type(void);
 int box_set_bootstrap_strategy(void);
+int box_set_bootstrap_leader(void);
 
 /**
  * Initialize logger on box init.

--- a/src/box/lua/cfg.cc
+++ b/src/box/lua/cfg.cc
@@ -82,6 +82,14 @@ lbox_cfg_set_bootstrap_strategy(struct lua_State *L)
 }
 
 static int
+lbox_cfg_set_bootstrap_leader(struct lua_State *L)
+{
+	if (box_set_bootstrap_leader() != 0)
+		luaT_error(L);
+	return 0;
+}
+
+static int
 lbox_cfg_set_replication(struct lua_State *L)
 {
 	try {
@@ -495,6 +503,7 @@ box_lua_cfg_init(struct lua_State *L)
 		{"cfg_load", lbox_cfg_load},
 		{"cfg_set_listen", lbox_cfg_set_listen},
 		{"cfg_set_bootstrap_strategy", lbox_cfg_set_bootstrap_strategy},
+		{"cfg_set_bootstrap_leader", lbox_cfg_set_bootstrap_leader},
 		{"cfg_set_replication", lbox_cfg_set_replication},
 		{"cfg_set_worker_pool_threads", lbox_cfg_set_worker_pool_threads},
 		{"cfg_set_readahead", lbox_cfg_set_readahead},

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -523,6 +523,7 @@ local dynamic_cfg = {
     replication_skip_conflict = private.cfg_set_replication_skip_conflict,
     replication_anon        = private.cfg_set_replication_anon,
     bootstrap_strategy      = private.cfg_set_bootstrap_strategy,
+    bootstrap_leader        = private.cfg_set_bootstrap_leader,
     instance_uuid           = check_instance_uuid,
     instance_name           = private.cfg_set_instance_name,
     replicaset_uuid         = check_replicaset_uuid,
@@ -641,6 +642,7 @@ local dynamic_cfg_order = {
     -- Apply bootstrap_strategy before replication, but after
     -- replication_connect_quorum. The latter might influence its value.
     bootstrap_strategy      = 175,
+    bootstrap_leader        = 175,
     replication             = 200,
     -- Anon is set after `replication` as a temporary workaround
     -- for the problem, that `replication` and `replication_anon`
@@ -686,6 +688,7 @@ local dynamic_cfg_skip_at_load = {
     replication_skip_conflict = true,
     replication_anon        = true,
     bootstrap_strategy      = true,
+    bootstrap_leader        = true,
     wal_dir_rescan_delay    = true,
     wal_queue_max_size      = true,
     custom_proc_title       = true,

--- a/src/box/replication.cc
+++ b/src/box/replication.cc
@@ -247,6 +247,9 @@ replication_free(void)
 	latch_destroy(&replicaset.applier.order_latch);
 	applier_free();
 
+	if (!uri_is_nil(&cfg_bootstrap_leader_uri))
+		uri_destroy(&cfg_bootstrap_leader_uri);
+
 	TRASH(&replicaset);
 }
 


### PR DESCRIPTION
bootstrap_leader configuration option only takes effect during instance bootstrap. For this reason, the option was made static. One can't change the bootstrap_leader after initial box.cfg() call.

So when a user has bootstrap_strategy = 'config' and joins new nodes during replicaset lifespan, he ends up with instances having different `bootstrap_leader` configuration, depending on which node was writable at the moment of each instance bootstrap.

It would be better to have matching configuration on each replica set member with no exceptions and to be able to set bootstrap_leader to the same value on all the instances of the replica set, even on the ones which are already bootstrapped.

Let's allow changing `bootstrap_leader` option even though it affects nothing.

While we're at it, fix a memory leak of bootstrap leader uri on tarantool shutdown.

Closes #10604

@TarantoolBot document
Title: clarify `bootstrap_leader` configuration option meaning

The option `bootstrap_leader` is dynamic, but it's important to note that changing it after instance bootstrap affects nothing. It's left dynamic simply for the sake of centralized configuration, when it's preferable to have matching configurations on all instances of a replica set.

(cherry picked from commit 97ec171f542947485291716762c408d761d0c751)

This is a backport of #10769