### PR TITLE
config: drop iproto connections in isolated mode

### DIFF
--- a/test/config-luatest/isolated_mode_test.lua
+++ b/test/config-luatest/isolated_mode_test.lua
@@ -1,4 +1,5 @@
 local yaml = require('yaml')
+local net_box = require('net.box')
 local t = require('luatest')
 local cbuilder = require('luatest.cbuilder')
 local treegen = require('luatest.treegen')
@@ -16,7 +17,28 @@ g.after_each(function(g)
     if g.it ~= nil then
         g.it:close()
     end
+    if g.conn ~= nil then
+        g.conn:close()
+    end
 end)
+
+-- Connect to the given server's console and wait for "ready"
+-- configuration status.
+--
+-- Save to g.it to let the after_each hook close the connection in
+-- case of an error.
+local function connect_console(g, server)
+    t.helpers.retrying({timeout = 60}, function()
+        g.it = it.connect(server)
+    end)
+
+    -- The same check as <luatest.server>:start() performs, but
+    -- using the console connection.
+    t.helpers.retrying({timeout = 60}, function()
+        local status = g.it:roundtrip('box.info.config.status')
+        assert(status == 'ready' or status == 'check_warnings')
+    end)
+end
 
 -- Verify that an instance can't start in the isolated mode if
 -- there is no local snapshot.
@@ -74,16 +96,29 @@ g.test_startup_with_snap = function(g)
     -- the file.
     local config_2 = cbuilder:new(config)
         :set_instance_option('i-003', 'isolated', true)
+        -- If we don't drop replication.peers, the instance will
+        -- attempt to connect to itself. However, iproto stops
+        -- listening for incoming connections and it freezes for
+        -- some time.
+        --
+        -- TODO: Tarantool should stop replication to the isolated
+        -- instance. Let's drop this option from the test, when it
+        -- is implemented.
+        :set_instance_option('i-003', 'replication.peers', {})
         :config()
     cluster:sync(config_2)
 
     -- Start the instance again from the local snapshot in the
     -- isolated mode.
-    cluster['i-003']:start()
+    --
+    -- Don't check the readiness condition, because it is
+    -- performed over an iproto connection and it has no chance to
+    -- succeed (iproto stops listening in the isolated mode).
+    cluster['i-003']:start({wait_until_ready = false})
 
     -- Use the console connection, because an instance in the
     -- isolated mode doesn't accept iproto requests.
-    g.it = it.connect(cluster['i-003'])
+    connect_console(g, cluster['i-003'])
 
     -- Verify that the instance is started in the isolated mode.
     g.it:roundtrip("require('config'):get('isolated')", true)
@@ -118,24 +153,34 @@ g.test_read_only = function(g)
     local cluster = cluster.new(g, config)
     cluster:start()
 
-    -- Mark i-001 as isolated, reload the configuration.
-    local config_2 = cbuilder:new(config)
-        :set_instance_option('i-001', 'isolated', true)
-        :config()
-    cluster:reload(config_2)
-
     -- Use the console connection, because an instance in the
     -- isolated mode doesn't accept iproto requests.
     g.it = it.connect(cluster['i-001'])
+
+    -- Mark i-001 as isolated, reload the configuration.
+    local config_2 = cbuilder:new(config)
+        :set_instance_option('i-001', 'isolated', true)
+        -- TODO: Tarantool should stop replication to the isolated
+        -- instance. Let's drop this option from the test, when it
+        -- is implemented.
+        :set_instance_option('i-001', 'replication.peers', {})
+        :config()
+    cluster:sync(config_2)
+    g.it:roundtrip("require('config'):reload()")
 
     -- The isolated mode is applied, the instance goes to RO.
     assert_isolated(true)
     assert_read_only(true)
 
     -- Restart i-001, reconnect the console.
+    --
+    -- Don't check the readiness condition, because it is
+    -- performed over an iproto connection and it has no chance to
+    -- succeed (iproto stops listening in the isolated mode).
     g.it:close()
-    cluster['i-001']:restart()
-    g.it = it.connect(cluster['i-001'])
+    cluster['i-001']:stop()
+    cluster['i-001']:start({wait_until_ready = false})
+    connect_console(g, cluster['i-001'])
 
     -- Still in the isolated mode and RO.
     assert_isolated(true)
@@ -145,9 +190,202 @@ g.test_read_only = function(g)
     local config_3 = cbuilder:new(config_2)
         :set_instance_option('i-001', 'isolated', nil)
         :config()
-    cluster:reload(config_3)
+    cluster:sync(config_3)
+    g.it:roundtrip("require('config'):reload()")
 
     -- Goes to RW.
     assert_isolated(false)
     assert_read_only(false)
+end
+
+-- Verify that an instance in the isolated mode stops listening
+-- for new iproto connections and drops existing connections.
+g.test_iproto_stop = function(g)
+    local config = cbuilder:new()
+        :add_instance('i-001', {})
+        :config()
+
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    -- Connect to the server's console and verify that it works.
+    g.it = it.connect(cluster['i-001'])
+    g.it:roundtrip('42', 42)
+
+    -- Connect to the server using iproto and verify that it
+    -- works.
+    local uri = cluster['i-001'].net_box_uri
+    g.conn = net_box.connect(uri)
+    t.assert(g.conn:ping())
+
+    -- Go to the isolated mode.
+    local config_2 = cbuilder:new(config)
+        :set_instance_option('i-001', 'isolated', true)
+        :config()
+    cluster:sync(config_2)
+    g.it:roundtrip("require('config'):reload()")
+
+    -- The isolated mode is applied.
+    g.it:roundtrip("require('config'):get('isolated')", true)
+
+    -- The existing connection is dropped.
+    t.assert_not(g.conn:ping())
+
+    -- A new connection is not accepted.
+    g.conn:close()
+    g.conn = net_box.connect(uri)
+    t.assert_equals(g.conn.state, 'error')
+    t.assert_not(g.conn:ping())
+end
+
+-- Similar to the previous one, but imitates a timeout error on
+-- waiting for iproto connections drop.
+--
+-- The idea of the test case is to verify that the alert is issued
+-- in the case.
+g.test_iproto_stop_failure = function(g)
+    local config = cbuilder:new()
+        :add_instance('i-001', {})
+        :config()
+
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    -- Imitate a timeout error on dropping iproto connections.
+    cluster['i-001']:exec(function()
+        os.setenv('TT_CONFIG_DROP_CONNECTION_TIMEOUT', '0')
+    end)
+
+    -- Connect to the server's console and verify that it works.
+    g.it = it.connect(cluster['i-001'])
+    g.it:roundtrip('42', 42)
+
+    -- Connect to the server using iproto and verify that it
+    -- works.
+    local uri = cluster['i-001'].net_box_uri
+    g.conn = net_box.connect(uri)
+    t.assert(g.conn:ping())
+
+    -- Go to the isolated mode.
+    local config_2 = cbuilder:new(config)
+        :set_instance_option('i-001', 'isolated', true)
+        :config()
+    cluster:sync(config_2)
+    g.it:roundtrip("require('config'):reload()")
+
+    -- The isolated mode is applied.
+    g.it:roundtrip("require('config'):get('isolated')", true)
+
+    -- Verify that an alert is issued.
+    --
+    -- The alert is set in background, so let's retry the check
+    -- until the alert is found.
+    local info
+    local exp = 'isolated mode: can\'t drop iproto connections during 0 ' ..
+        'seconds (continued in background): timed out'
+    t.helpers.retrying({timeout = 60}, function()
+        info = g.it:roundtrip("require('config'):info()")
+        t.assert_covers(info, {
+            alerts = {
+                {
+                    type = 'warn',
+                    message = exp,
+                }
+            },
+        })
+    end)
+
+    -- Only one alert, no duplicates or extra warnings.
+    t.assert_equals(#info.alerts, 1)
+
+    -- The existing connection is dropped despite the alert.
+    t.assert_not(g.conn:ping())
+
+    -- A new connection is not accepted despite the alert.
+    g.conn:close()
+    g.conn = net_box.connect(uri)
+    t.assert_equals(g.conn.state, 'error')
+    t.assert_not(g.conn:ping())
+end
+
+-- Similar to the previous one, but imitates a timeout error on
+-- waiting for iproto connections drop on startup.
+--
+-- The test case mostly to verify that the alert is not
+-- duplicated.
+g.test_iproto_stop_failure_on_startup = function(g)
+    local config = cbuilder:new()
+        :add_instance('i-001', {})
+        :config()
+
+    local cluster = cluster.new(g, config, {
+        env = {
+            -- Imitate a timeout error on dropping iproto
+            -- connections.
+            ['TT_CONFIG_DROP_CONNECTION_TIMEOUT'] = '0',
+        },
+    })
+    cluster:start()
+
+    -- Enable the isolated mode, write the new config.
+    local config_2 = cbuilder:new(config)
+        :set_instance_option('i-001', 'isolated', true)
+        :config()
+    cluster:sync(config_2)
+
+    -- If there are no connections to the instance, it is possible
+    -- that the alert is not issued even with zero timeout.
+    --
+    -- It is OK. Just retry the startup in the case to attempt to
+    -- trigger the alert again.
+    local info
+    t.helpers.retrying({timeout = 60}, function()
+        -- Stop i-001. It leaves a local snapshot, so it can be
+        -- started in the isolated mode.
+        cluster['i-001']:stop()
+
+        -- Start the instance from the local snapshot in the
+        -- isolated mode.
+        --
+        -- Don't check the readiness condition, because it is
+        -- performed over an iproto connection and it has no
+        -- chance to succeed (iproto stops listening in the
+        -- isolated mode).
+        cluster['i-001']:start({wait_until_ready = false})
+
+        -- Use the console connection, because an instance in the
+        -- isolated mode doesn't accept iproto requests.
+        connect_console(g, cluster['i-001'])
+
+        -- The isolated mode is applied.
+        g.it:roundtrip("require('config'):get('isolated')", true)
+
+        -- Verify that an alert is issued.
+        --
+        -- The alert is set in background, so let's retry the check
+        -- until the alert is found or a short timeout exceeds
+        -- (in this case the outer retrying logic will catch it).
+        local exp = 'isolated mode: can\'t drop iproto connections during 0 ' ..
+            'seconds (continued in background): timed out'
+        t.helpers.retrying({timeout = 1}, function()
+            info = g.it:roundtrip("require('config'):info()")
+            t.assert_covers(info, {
+                alerts = {
+                    {
+                        type = 'warn',
+                        message = exp,
+                    }
+                },
+            })
+        end)
+    end)
+
+    -- Only one alert, no duplicates or extra warnings.
+    t.assert_equals(#info.alerts, 1)
+
+    -- A new connection is not accepted despite the alert.
+    local uri = cluster['i-001'].net_box_uri
+    g.conn = net_box.connect(uri)
+    t.assert_equals(g.conn.state, 'error')
+    t.assert_not(g.conn:ping())
 end


### PR DESCRIPTION
An isolated instance shouldn't process user traffic. This commit adds a logic to the isolated mode that stop listening for new connections and drop existing connections in iproto.

Part of #10796