### PR TITLE
config: add failover.stateboard.enabled option

### DIFF
--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2300,6 +2300,22 @@ return schema.new('instance_config', schema.record({
         -- are configured in the `config.etcd` or the
         -- `config.storage` section.
         stateboard = schema.record({
+            -- Stateboard enabled/disabled status.
+            -- A coordinator having stateboard enabled doesn't
+            -- start without specifying compatible remote config
+            -- storage in the config.
+            --
+            -- Beware: disabling stateboard leads to the
+            -- following consequences:
+            -- * Failover commands aren't supported.
+            -- * Failover state monitoring isn't provided.
+            -- * Multiple coordinators over the same replicaset
+            --   behave in an unpredictable way. Two RW instances
+            --   are possible.
+            enabled = schema.scalar({
+                type = 'boolean',
+                default = true,
+            }),
             -- How often information in the stateboard is updated.
             renew_interval = schema.scalar({
                 type = 'number',

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -326,6 +326,7 @@ g.test_defaults = function()
             lease_interval = 30,
             renew_interval = 10,
             stateboard = {
+                enabled = true,
                 renew_interval = 2,
                 keepalive_interval = 10,
             },

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1721,6 +1721,7 @@ g.test_failover = function()
             lease_interval = 10,
             renew_interval = 1,
             stateboard = {
+                enabled = true,
                 renew_interval = 1,
                 keepalive_interval = 5,
             },
@@ -1744,6 +1745,7 @@ g.test_failover = function()
         lease_interval = 30,
         renew_interval = 10,
         stateboard = {
+            enabled = true,
             renew_interval = 2,
             keepalive_interval = 10,
         },


### PR DESCRIPTION
Now `failover.stateboard.enabled` boolean option can be used to enable/disable the failover coordinator stateboard. Default value equals to `true`.

`failover.stateboard.enabled: true` requires for one of the compatible remote config sources to be set in the `config` section. Otherwise the failover coordinator doesn't start.

The option is enterprise-only since it's a part of the supervised failover.

Needed for EE tarantool/tarantool-ee#996.