### PR TITLE
config: don't replicate data from/to isolated instance

### DIFF
--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -99,6 +99,13 @@ local function switch_isolated_mode_before_box_cfg(configdata, box_cfg)
     -- An instance in the isolated mode shouldn't process a
     -- traffic from a user.
     box_cfg.listen = box.NULL
+
+    -- Don't replicate data from other replicaset members.
+    --
+    -- The isolated mode can be enabled to stop data modifications
+    -- on the given instance, including ones from the replication.
+    -- It may help to debug a problem or extract some needed data.
+    box_cfg.replication = box.NULL
 end
 
 -- Perform post-box-cfg actions to enable the isolated mode (if


### PR DESCRIPTION
The isolated mode can be enabled to stop data modifications on the given instance, including ones from the replication: it may help to debug a problem or extract some needed data. So, it seems worthful to stop replication from the non-isolated part of the replicaset to the instance.

The isolated instance goes to RO and drops iproto connections -- it should effectively stop replication from it *to* the non-isolated part of the replicaset. There is no sense to retry an attempt to connect to it and flood logs with errors. Let's just remove the isolated instance from the upstreams list.

Part of #10796