### PR TITLE
replication: anon replicas don't participate in elections

### DIFF
--- a/changelogs/unreleased/gh-10561-anon-replicas-dont-participate-in-elections.md
+++ b/changelogs/unreleased/gh-10561-anon-replicas-dont-participate-in-elections.md
@@ -1,0 +1,6 @@
+## bugfix/replication
+
+* Fixed a bug when anonymous replicas could participate in elections or even
+  be chosen as a leader. It is now forbidden to configure a replica so
+  that `replication_anon` is `true` and `election_mode` is not `off`
+  (gh-10561).

--- a/test/replication-luatest/anon_test.lua
+++ b/test/replication-luatest/anon_test.lua
@@ -1,15 +1,16 @@
+local cluster = require('luatest.replica_set')
 local server = require('luatest.server')
 local t = require('luatest')
-local g = t.group()
+local g1 = t.group('group1')
 
 local wait_timeout = 60
 
-g.before_all = function(lg)
+g1.before_all = function(lg)
     lg.master = server:new({alias = 'master'})
     lg.master:start()
 end
 
-g.after_all = function(lg)
+g1.after_all = function(lg)
     lg.master:drop()
 end
 
@@ -17,7 +18,7 @@ end
 -- When an instance failed to apply cfg{replication_anon = false}, it used to
 -- report itself as non-anon in the ballot anyway. Shouldn't be so.
 --
-g.test_ballot_on_deanon_fail = function(lg)
+g1.test_ballot_on_deanon_fail = function(lg)
     local box_cfg = {
         replication_anon = true,
         read_only = true,
@@ -66,7 +67,7 @@ end
 -- gh-9916: txns being applied from the master during the name change process
 -- could crash the replica or cause "double LSN" error in release.
 --
-g.test_txns_replication_during_registration = function(lg)
+g1.test_txns_replication_during_registration = function(lg)
     t.tarantool.skip_if_not_debug()
     lg.master:exec(function()
         local s = box.schema.create_space('test')
@@ -139,4 +140,98 @@ g.test_txns_replication_during_registration = function(lg)
         box.space.test:drop()
         box.space._cluster:delete{id}
     end, {replica_id})
+end
+
+--
+-- gh-10561:
+-- Anonymous replicas don't participate in elections.
+--
+
+local function build_cluster(lg, election_mode, replication_anon)
+    lg.cluster = cluster:new({})
+    lg.master = lg.cluster:build_and_add_server({alias = 'master'})
+    lg.replica_cfg = {
+        replication = server.build_listen_uri('master', lg.cluster.id),
+        election_mode = election_mode,
+        replication_anon = replication_anon,
+        read_only = true,
+    }
+    lg.replica = lg.cluster:build_and_add_server({
+        alias = 'replica',
+        box_cfg = lg.replica_cfg,
+    })
+    lg.cluster:start()
+    lg.master:exec(function() box.ctl.promote() end)
+    t.helpers.retrying({timeout = wait_timeout}, function()
+        lg.replica:assert_follows_upstream(lg.master:get_instance_id())
+    end)
+end
+
+local g2 = t.group('group2')
+
+g2.before_all(function(lg)
+    build_cluster(lg, 'off', true)
+end)
+
+g2.after_all(function(lg)
+    lg.cluster:drop()
+end)
+
+for _, mode in ipairs({'candidate', 'manual', 'voter'}) do
+    g2["test_anon_replica_startup_with_election_mode_" .. mode] = function(lg)
+        -- box_check_config is called only during the first box.cfg,
+        -- so we need a restart here to cover it
+        local ok, _ = pcall(function()
+            lg.replica:restart({box_cfg = {
+                replication = server.build_listen_uri('master', lg.cluster.id),
+                election_mode = mode,
+                replication_anon = true,
+                read_only = true,
+            }}, {wait_until_ready = true})
+        end)
+        t.assert(not ok)
+        lg.replica:restart({box_cfg = lg.replica_cfg})
+    end
+end
+
+for _, mode in ipairs({'candidate', 'manual', 'voter'}) do
+    g2["test_anon_replica_switch_to_election_mode_" .. mode] =
+        function(lg)
+            lg.replica:exec(function(election_mode)
+                local err_msg = "Incorrect value for option " ..
+                    "'election_mode': the value may only be set to 'off' " ..
+                    "when 'replication_anon' is set to true"
+                t.assert_error_msg_equals(err_msg, box.cfg,
+                    {election_mode = election_mode})
+            end, {mode})
+        end
+end
+
+g2.test_anon_replica_promote_unsupported = function(lg)
+    lg.replica:exec(function()
+        local err_msg = "replication_anon=true " ..
+            "does not support manual elections"
+        t.assert_error_msg_equals(err_msg, box.ctl.promote)
+        t.assert_error_msg_equals(err_msg, box.ctl.demote)
+    end)
+end
+
+local g3 = t.group('group3')
+
+for _, mode in ipairs({'candidate', 'manual', 'voter'}) do
+    g3["test_replica_with_" .. mode .. "election_mode_switch_to_anon"] =
+        function(lg)
+            -- We are forced to rebuild the cluster every time, because if the
+            -- replica was not previously registered in the cluster, it cannot
+            -- connect as a non-anonymous replica
+            build_cluster(lg, mode, false)
+            lg.replica:exec(function()
+                local err_msg = "Incorrect value for option " ..
+                    "'replication_anon': the value may be set to true only " ..
+                    "when 'election_mode' is set to 'off'"
+                t.assert_error_msg_equals(err_msg, box.cfg,
+                    {replication_anon = true})
+            end)
+            lg.cluster:drop()
+        end
 end


### PR DESCRIPTION
Fixed a bug where anonymous replicas could participate in elections or even be chosen as a leader. It is now forbidden to configure a replica so `replication_anon == true` and `election_mode != 'off'`. It is also now prohibited to issue PROMOTE from an anonymous replica.

Closes #10561
