### PR TITLE
txn: propagate transaction timeout to `box.commit`

### DIFF
--- a/changelogs/unreleased/gh-10181-propagate-transaction-timeout-to-box-commit.md
+++ b/changelogs/unreleased/gh-10181-propagate-transaction-timeout-to-box-commit.md
@@ -1,0 +1,7 @@
+## feature/box
+
+* A new compat option `compat.box_begin_timeout_meaning` has been added.
+  Controls the behavior of the timeout `box.begin{timeout=`. If set to 'new',
+  the transaction timeout is propagated further to `box.commit`. If set to
+  'old', the behavior is no different from what it was before this patch
+  appeared (gh-10181).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -276,6 +276,9 @@ TWEAK_DOUBLE(box_shutdown_timeout);
 static double box_fiber_pool_idle_timeout = FIBER_POOL_IDLE_TIMEOUT;
 TWEAK_DOUBLE(box_fiber_pool_idle_timeout);
 
+bool box_begin_timeout_new_meaning = false;
+TWEAK_BOOL(box_begin_timeout_new_meaning);
+
 static int
 box_run_on_recovery_state(enum box_recovery_state state)
 {

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -111,6 +111,9 @@ extern struct tt_uuid bootstrap_leader_uuid;
 /** box.cfg.force_recovery. */
 extern bool box_is_force_recovery;
 
+/** Whether box.begin timeout behaviour is new. */
+extern bool box_begin_timeout_new_meaning;
+
 /*
  * Initialize box library
  * @throws C++ exception

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -438,6 +438,7 @@ struct errcode_record {
 	_(ER_REPLICA_GC, 291,			"Cannot clean up replica's resources", "uuid", STRING, "details", STRING) \
 	_(ER_ALIEN_ENGINE, 292,			"Snapshot contains alien space engine row", "engine", STRING) \
 	_(ER_MVCC_UNAVAILABLE, 293,		"MVCC is unavailable for storage engine '%s' so it cannot be used in the same transaction with '%s', which supports MVCC", "engine_without_mvcc", STRING, "engine_with_mvcc", STRING) \
+	_(ER_COMMIT_TIMEOUT, 294,		"Transaction timeout has expired during commit. It's not aborted and continues to commit in background.", "expired_at", STRING) \
 	TEST_ERROR_CODES(_) /** This one should be last. */
 
 /*

--- a/src/box/lua/config/applier/compat.lua
+++ b/src/box/lua/config/applier/compat.lua
@@ -1,13 +1,33 @@
 local compat = require('compat')
 local log = require('internal.config.utils.log')
 
+local function get_effective(option)
+    return compat[option]:is_new() and 'new' or 'old'
+end
+
+local function validate_config(config)
+    local function get_value(option)
+        local config_value = config[option]
+        local current_value = get_effective(option)
+        return config_value ~= nil and config_value or current_value
+    end
+    if get_value('replication_synchro_timeout') == 'old' and
+        get_value('box_begin_timeout_meaning') == 'new' then
+        error("Compat options 'replication_synchro_timeout' and " ..
+            "'box_begin_timeout_meaning' cannot be set to 'old' " ..
+            "and 'new' simultaneously")
+    end
+end
+
 local function apply(config)
     local configdata = config._configdata
     local compat_options = compat._options()
+    local compat_config = configdata:get('compat', {use_default = true})
 
-    for k, v in pairs(configdata:get('compat', {use_default = true})) do
-        local effective_value = compat[k]:is_new() and 'new' or 'old'
-        local is_changed = effective_value ~= v
+    validate_config(compat_config)
+
+    for k, v in pairs(compat_config) do
+        local is_changed = get_effective(k) ~= v
         if is_changed then
             local def = compat_options[k].default == v and '(default)' or
                 '(NOT default)'

--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -375,6 +375,21 @@ I['compat.replication_synchro_timeout'] = format_text([[
       after a `replication.synchro_timeout`
 ]])
 
+I['compat.box_begin_timeout_meaning'] = format_text([[
+    The `compat.box_begin_timeout_meaning` option controls the behavior of
+    the timeout `box.begin{timeout=`.
+
+    - `new` (4.x default): timeout does not stop working after `box_commit()`
+       is called, it covers the entire process of committing the transaction:
+       - If the timeout expires before `box.commit()` is called or while
+         `before_commit` triggers are executing, the transaction is aborted.
+       - If the timeout expires later, the user receives an error but
+         transaction continues to commit, thus user's fiber is ready to execute
+         something else.
+    - `old` (3.x default): timeout can only abort the transaction until
+      `box_commit()` is called.
+]])
+
 I['compat.sql_priv'] = format_text([[
     Whether to enable access checks for SQL requests over iproto:
 

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2174,6 +2174,12 @@ return schema.new('instance_config', schema.record({
         }, {
             default = 'old',
         }),
+        box_begin_timeout_meaning = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'old',
+        }),
     }),
     -- Instance labels.
     labels = schema.map({

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -544,6 +544,8 @@ struct txn {
 	 * to complete within the timeout specified when it was created.
 	 */
 	struct ev_timer *rollback_timer;
+	/** Transaction begin time. */
+	double begin_time;
 	/**
 	 * For synchronous transactions - their context in the synchro queue.
 	 */

--- a/src/box/txn_event_trigger.c
+++ b/src/box/txn_event_trigger.c
@@ -220,7 +220,7 @@ run_triggers_general(struct txn *txn, struct txn_stmt *stmt,
 			/*
 			 * The transaction could be aborted while the previous
 			 * trigger was running (e.g. if the trigger-function
-			 * yielded or failed).
+			 * yielded, failed or transaction timeout expired).
 			 */
 			rc = txn_check_can_continue(txn);
 			if (rc != 0)

--- a/src/lua/compat.lua
+++ b/src/lua/compat.lua
@@ -164,6 +164,14 @@ gc-checkpointing.
 https://tarantool.io/compat/replication_synchro_timeout
 ]]
 
+local BOX_BEGIN_TIMEOUT_MEANING_BRIEF = [[
+Controls the behavior of the timeout `box.begin{timeout=`. The option can be
+set to 'new' only if the compat option replication_synchro_timeout is set to
+'new'. The new behavior propagates the timeout further to `box.commit`.
+
+https://tarantool.io/compat/box_begin_timeout_meaning
+]]
+
 -- Returns an action callback that toggles a tweak.
 local function tweak_action(tweak_name, old_tweak_value, new_tweak_value)
     return function(is_new)
@@ -300,6 +308,13 @@ local options = {
         brief = REPLICATION_SYNCHRO_TIMEOUT_COMPAT_BRIEF,
         action = tweak_action(
             'replication_synchro_timeout_rollback_enabled', true, false),
+    },
+    box_begin_timeout_meaning = {
+        default = 'old',
+        obsolete = nil,
+        brief = BOX_BEGIN_TIMEOUT_MEANING_BRIEF,
+        action = tweak_action('box_begin_timeout_new_meaning', false, true),
+        dependencies = { 'replication_synchro_timeout', }
     },
 }
 

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -503,6 +503,7 @@ t;
  |   291: box.error.REPLICA_GC
  |   292: box.error.ALIEN_ENGINE
  |   293: box.error.MVCC_UNAVAILABLE
+ |   294: box.error.COMMIT_TIMEOUT
  | ...
 
 test_run:cmd("setopt delimiter ''");

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -439,6 +439,7 @@ g.test_defaults = function()
             box_error_unpack_type_and_code = 'old',
             console_session_scope_vars = 'old',
             wal_cleanup_delay_deprecation = 'old',
+            box_begin_timeout_meaning = 'old',
         },
         isolated = false,
     }

--- a/test/config-luatest/compat_test.lua
+++ b/test/config-luatest/compat_test.lua
@@ -61,39 +61,54 @@ end
 -- the configuration.
 local function switch(cluster, option_name, startup_config, v)
     local config = cbuilder:new(startup_config)
-        :set_instance_option('instance-001', 'compat', {
-            [option_name] = v ~= 'default' and v or box.NULL,
-        })
+        :set_instance_option('instance-001', 'compat.' .. option_name,
+            v ~= 'default' and v or box.NULL)
         :config()
     cluster:reload(config)
 end
 
+local get_startup_config = function(startup_compat)
+    return cbuilder:new()
+        :add_instance('instance-001', {
+            compat = fun.iter(startup_compat):filter(
+                function(_, v) return v ~= 'default' end):tomap(),
+        })
+        :config()
+end
+
 -- Start an instance with the given compat option value and verify
 -- that it is actually set.
-local function gen_startup_case(option_name, v)
+local function gen_startup_success_case(startup_compat)
+    local startup_compat = table.copy(startup_compat)
     return function(g)
-        local startup_config = cbuilder:new()
-            :add_instance('instance-001', {
-                compat = {
-                    [option_name] = v ~= 'default' and v or nil,
-                },
-            })
-            :config()
+        local startup_config = get_startup_config(startup_compat)
 
         local cluster = cluster.new(g, startup_config)
         cluster:start()
 
-        verify(cluster, option_name, v)
+        for option_name, v in pairs(startup_compat) do
+            verify(cluster, option_name, v)
+        end
+    end
+end
+
+local function gen_startup_failure_case(startup_compat, exp_err)
+    local startup_compat = table.copy(startup_compat)
+    return function(g)
+        local startup_config = cbuilder:new()
+            :add_instance('instance-001', { compat = startup_compat, })
+            :config()
+
+        cluster.startup_error(g, startup_config, exp_err)
     end
 end
 
 -- Start an instance and try to switch the given compat option
 -- with a reload and a verification of the effect.
-local function gen_reload_case(option_name)
+local function gen_reload_case(option_name, startup_compat)
+    local startup_compat = table.copy(startup_compat)
     return function(g)
-        local startup_config = cbuilder:new()
-            :add_instance('instance-001', {})
-            :config()
+        local startup_config = get_startup_config(startup_compat)
 
         local cluster = cluster.new(g, startup_config)
         cluster:start()
@@ -113,22 +128,18 @@ end
 
 -- Verify that an attempt to change the option on reload leads to
 -- an error.
-local function gen_reload_failure_case(option_name, startup_value, reload_value)
+local function gen_reload_failure_case(
+    option_name, reload_value, startup_compat, exp_err)
+    local startup_compat = table.copy(startup_compat)
     return function(g)
-        local startup_config = cbuilder:new()
-            :add_instance('instance-001', {
-                compat = {
-                    [option_name] = startup_value ~= 'default' and
-                        startup_value or nil,
-                },
-            })
-            :config()
+        local startup_value = startup_compat[option_name]
+
+        local startup_config = get_startup_config(startup_compat)
 
         local cluster = cluster.new(g, startup_config)
         cluster:start()
 
         -- Attempt to switch the option to another value.
-        local exp_err = non_dynamic[option_name].error
         t.assert_error_msg_content_equals(exp_err, switch, cluster,
             option_name, startup_config, reload_value)
 
@@ -176,16 +187,10 @@ end
 
 -- Verify that start with the given compat option value and reload
 -- it to the second given value is successful.
-local function gen_reload_success_case(option_name, startup_value, reload_value)
+local function gen_reload_success_case(
+    option_name, reload_value, startup_compat)
     return function(g)
-        local startup_config = cbuilder:new()
-            :add_instance('instance-001', {
-                compat = {
-                    [option_name] = startup_value ~= 'default' and
-                        startup_value or nil,
-                },
-            })
-            :config()
+        local startup_config = get_startup_config(startup_compat)
 
         local cluster = cluster.new(g, startup_config)
         cluster:start()
@@ -210,17 +215,27 @@ local function gen_reload_success_case(option_name, startup_value, reload_value)
     end
 end
 
+local skip = {
+    replication_synchro_timeout = true,
+    box_begin_timeout_meaning = true,
+}
+
 -- Walk over the compat options and generate test cases for them.
 for option_name, _ in pairs(compat._options()) do
+    if skip[option_name] then
+        goto continue
+    end
     -- Start with the given option value.
     local case_name_prefix = ('test_startup_%s_'):format(option_name)
     for _, v in ipairs({'default', 'old', 'new'}) do
-        g[case_name_prefix .. v] = gen_startup_case(option_name, v)
+        local startup_compat = {}
+        startup_compat[option_name] = v
+        g[case_name_prefix .. v] = gen_startup_success_case(startup_compat)
     end
 
     if non_dynamic[option_name] == nil then
         -- Start without compat option and set it on reload.
-        g['test_reload_' .. option_name] = gen_reload_case(option_name)
+        g['test_reload_' .. option_name] = gen_reload_case(option_name, {})
     else
         -- Start with one option name and set another on reload (expect an
         -- error).
@@ -229,16 +244,24 @@ for option_name, _ in pairs(compat._options()) do
         -- used interchangeably and switching from one to another
         -- on reload doesn't trigger any error.
         local case_name_prefix = ('test_reload_%s_'):format(option_name)
+        local exp_err = non_dynamic[option_name].error
+        local startup_compat = {}
+        startup_compat[option_name] = 'old'
         g[case_name_prefix .. 'failure_old_to_new'] = gen_reload_failure_case(
-            option_name, 'old', 'new')
+            option_name, 'new', startup_compat, exp_err)
+        startup_compat[option_name] = 'new'
         g[case_name_prefix .. 'failure_new_to_old'] = gen_reload_failure_case(
-            option_name, 'new', 'old')
+            option_name, 'old', startup_compat, exp_err)
         local def = compat._options()[option_name].default
         if def == 'old' then
+            startup_compat[option_name] = 'default'
             g[case_name_prefix .. 'failure_default_to_new'] =
-                gen_reload_failure_case(option_name, 'default', 'new')
+                gen_reload_failure_case(option_name, 'new',
+                startup_compat, exp_err)
+            startup_compat[option_name] = 'new'
             g[case_name_prefix .. 'failure_new_to_default'] =
-                gen_reload_failure_case(option_name, 'new', 'default')
+                gen_reload_failure_case(option_name, 'default',
+                startup_compat, exp_err)
             g[case_name_prefix .. 'success_default_to_old'] =
                 gen_reload_success_case(option_name, 'default', 'old')
             g[case_name_prefix .. 'success_old_to_default'] =
@@ -248,10 +271,73 @@ for option_name, _ in pairs(compat._options()) do
                 gen_reload_success_case(option_name, 'default', 'new')
             g[case_name_prefix .. 'success_new_to_default'] =
                 gen_reload_success_case(option_name, 'new', 'default')
+            startup_compat[option_name] = 'default'
             g[case_name_prefix .. 'failure_default_to_old'] =
-                gen_reload_failure_case(option_name, 'default', 'old')
+                gen_reload_failure_case(option_name, 'old',
+                startup_compat, exp_err)
+            startup_compat[option_name] = 'old'
             g[case_name_prefix .. 'failure_old_to_default'] =
-                gen_reload_failure_case(option_name, 'old', 'default')
+                gen_reload_failure_case(option_name, 'default',
+                startup_compat, exp_err)
         end
+    end
+    ::continue::
+end
+
+do
+    -- Check all possible successful startups
+    local test_name_fmt = "test_startup_replication_synchro_timeout_%s_" ..
+        "box_begin_timeout_meaning_%s_success"
+    local startup_compat = {
+        replication_synchro_timeout = 'old',
+        box_begin_timeout_meaning = 'old',
+    }
+    g[test_name_fmt:format(startup_compat.replication_synchro_timeout,
+        startup_compat.box_begin_timeout_meaning)] =
+        gen_startup_success_case(startup_compat)
+
+    startup_compat['replication_synchro_timeout'] = 'new'
+    g[test_name_fmt:format(startup_compat.replication_synchro_timeout,
+        startup_compat.box_begin_timeout_meaning)] =
+        gen_startup_success_case(startup_compat)
+
+    startup_compat['box_begin_timeout_meaning'] = 'new'
+    g[test_name_fmt:format(startup_compat.replication_synchro_timeout,
+        startup_compat.box_begin_timeout_meaning)] =
+        gen_startup_success_case(startup_compat)
+
+    -- Check all possible successful reloads
+    test_name_fmt = "test_reload_%s"
+    startup_compat = { replication_synchro_timeout = 'new' }
+    g[test_name_fmt:format('box_begin_timeout_meaning')] =
+        gen_reload_case('box_begin_timeout_meaning', startup_compat)
+
+    startup_compat = { box_begin_timeout_meaning = 'old' }
+    g[test_name_fmt:format('replication_synchro_timeout')] =
+        gen_reload_case('replication_synchro_timeout', startup_compat)
+
+    -- Check startup with invalid combination of values
+    test_name_fmt = "test_startup_replication_synchro_timeout_%s_" ..
+        "box_begin_timeout_meaning_%s_failure"
+    local invalid_compat = {
+        replication_synchro_timeout = 'old',
+        box_begin_timeout_meaning = 'new',
+    }
+    local exp_err = "Compat options 'replication_synchro_timeout' and " ..
+        "'box_begin_timeout_meaning' cannot be set to 'old' " ..
+        "and 'new' simultaneously"
+    g[test_name_fmt:format(startup_compat.replication_synchro_timeout,
+        startup_compat.box_begin_timeout_meaning)] =
+        gen_startup_failure_case(invalid_compat, exp_err)
+
+    -- Check all possible invalid reloads
+    for option_name, reload_value in pairs(invalid_compat) do
+        local startup_value = reload_value == 'new' and 'old' or 'new'
+        startup_compat = table.copy(invalid_compat)
+        startup_compat[option_name] = startup_value
+        g["test_reload_" .. option_name .. "_failure_" ..
+            startup_value .. "_to_" .. reload_value] =
+            gen_reload_failure_case(option_name, reload_value,
+                startup_compat, exp_err)
     end
 end

--- a/test/replication-luatest/gh_10181_transaction_timeout_new_meaning_test.lua
+++ b/test/replication-luatest/gh_10181_transaction_timeout_new_meaning_test.lua
@@ -1,0 +1,121 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group('gh-10181-transaction-timeout-new-meaning')
+--
+-- gh-10181: transaction timeout new meaning
+--
+local wait_timeout = 10
+
+g.before_all(function(cg)
+    cg.master = server:new{
+        alias = 'master',
+        box_cfg = {
+            replication_timeout = 0.1,
+            memtx_use_mvcc_engine = true,
+        },
+        env = {
+            TARANTOOL_RUN_BEFORE_BOX_CFG = [[
+                require('compat')({
+                    replication_synchro_timeout = 'new',
+                    box_begin_timeout_meaning = 'new',
+                })
+            ]]
+        },
+    }
+    cg.master:start()
+    cg.master:exec(function()
+        box.ctl.promote()
+        box.ctl.wait_rw()
+        box.schema.space.create('test', {is_sync = true})
+        box.space.test:create_index('pk')
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.master:drop()
+end)
+
+local err_msg_rollback = 'Transaction has been aborted by timeout'
+local err_msg_return = 'Transaction timeout has expired during commit. ' ..
+    'It\'s not aborted and continues to commit in background.'
+
+g.test_rollback_if_timeout_expired_at_yield = function(cg)
+    cg.master:exec(function(err_msg)
+        t.assert_error_msg_equals(err_msg, function()
+            box.begin({timeout = 0.05}) require('fiber').sleep(0.5) box.commit()
+        end)
+    end, {err_msg_rollback})
+end
+
+g.test_rollback_if_timeout_expired_at_yield_in_before_commit_trigger =
+function(cg)
+    cg.master:exec(function(err_msg)
+        local trigger = require('trigger')
+        trigger.set('box.before_commit.space.test', 't',
+            function() require('fiber').sleep(0.5) end)
+        t.assert_error_msg_equals(err_msg, function()
+            box.begin({timeout = 0.05}) box.space.test:insert{1} box.commit()
+        end)
+        trigger.del('box.before_commit.space.test', 't')
+    end, {err_msg_rollback})
+end
+
+for _, case in ipairs({
+    {
+        skip_if_not_debug = true,
+        preamble_cb = function()
+            box.error.injection.set('ERRINJ_WAL_DELAY', true)
+        end,
+        epilogue_cb = function()
+            box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        end,
+        expired_at = 'WAL write',
+    },
+    {
+        skip_if_not_debug = false,
+        preamble_cb = function()
+            box.cfg{replication_synchro_quorum = 2}
+        end,
+        epilogue_cb = function()
+            box.cfg{replication_synchro_quorum = box.NULL}
+        end,
+        expired_at = 'quorum collection',
+    },
+    {
+        skip_if_not_debug = true,
+        preamble_cb = function()
+            box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 1)
+        end,
+        epilogue_cb = function()
+            box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        end,
+        expired_at = 'CONFIRM write',
+    },
+}) do
+    local case_name_suffix = string.gsub(case.expired_at, ' ', '_')
+    g['test_return_if_timeout_expired_at_' .. case_name_suffix] = function(cg)
+        if case.skip_if_not_debug then
+            t.tarantool.skip_if_not_debug()
+        end
+        cg.master:exec(case.preamble_cb)
+        cg.master:exec(function(expired_at, err_msg)
+            rawset(_G, 'lsn', box.info.lsn)
+            local ok, err = pcall(function()
+                box.begin({timeout = 0.5})
+                box.space.test:insert{1}
+                box.commit()
+            end)
+            t.assert(not ok)
+            t.assert_equals(err.type, 'ClientError')
+            t.assert_equals(err.message, err_msg)
+            t.assert_equals(err.expired_at, expired_at)
+        end, {case.expired_at, err_msg_return})
+        cg.master:exec(case.epilogue_cb)
+        cg.master:exec(function(wait_timeout)
+            t.helpers.retrying({timeout = wait_timeout},
+                function() t.assert(box.info.lsn >= _G.lsn + 1) end)
+            box.space.test:delete{1}
+        end, {wait_timeout})
+    end
+end


### PR DESCRIPTION
New `compat.box_begin_timeout_meaning` option controls the behavior of the timeout `box.begin{timeout=`.

When the option is set to 'old' the behavior of `box.begin{timeout=` is no different from the behavior that was before this patch. This timeout can only abort the transaction until `box_commit()` is called. If the transaction is synchronous and `compat.replication_synchro_timeout='old'`, then immediately after the transaction is written to WAL, `replication_synchro_timeout` will start working. If the transaction didn't have time to gather a quorum within the timeout, it is rolled back.

~~The new behavior can only be enabled if `compat.replication_synchro_timeout` is set to 'new', that is, when `replication_synchro_timeout` is not running.~~ With the new behavior, `replication_synchro_timeout` does not work
regardless of what value is set in `compat.box_cfg_replication_synchro_timeout`.
In the new behavior, the timeout does not stop working after `box_commit()` is called, it covers the entire process of committing the transaction:

 * If the timeout expires before `box.commit()` is called **or while `before_commit` triggers are executing**, the transaction is aborted. The user receives an error "Transaction has been aborted by timeout".
 * If the timeout expires later, the user receives an error "Transaction timeout has expired during commit. It continues to commit." with field `.expired_at` with following possible values: "WAL write", "quorum collection", "CONFIRM write" depending on at what point of fiber clocks the timeout expired. As can be seen from the error text, the transaction is not rolled back, it continues to be committed, but the user's fiber is ready to execute something else.

Closes #10181