### PR TITLE
box: expose box_lua_find via tnt_internal_symbol

### DIFF
--- a/src/box/lua/call.c
+++ b/src/box/lua/call.c
@@ -95,13 +95,7 @@ get_call_serializer(void)
 	}
 }
 
-/**
- * A helper to resolve a Lua function by full name, for example like:
- * foo.bar['biz']["baz"][3].object:function
- * Puts the function on top of the stack, followed by an object (if present).
- * Returns number of items pushed (1 or 2) or -1 in case of error (diag is set).
- */
-static int
+int
 box_lua_find(lua_State *L, const char *name, const char *name_end)
 {
 	lua_checkstack(L, 2); /* No more than 2 entries are needed. */

--- a/src/box/lua/call.h
+++ b/src/box/lua/call.h
@@ -58,6 +58,15 @@ int
 box_lua_eval(const char *expr, uint32_t expr_len,
 	     struct port *args, struct port *ret);
 
+/**
+ * A helper to resolve a Lua function by full name, for example like:
+ * foo.bar['biz']["baz"][3].object:function
+ * Puts the function on top of the stack, followed by an object (if present).
+ * Returns number of items pushed (1 or 2) or -1 in case of error (diag is set).
+ */
+int
+box_lua_find(struct lua_State *L, const char *name, const char *name_end);
+
 /** Construct a Lua function object. */
 struct func *
 func_lua_new(const struct func_def *def);

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -25,6 +25,8 @@
  */
 
 extern void
+box_lua_find(void);
+extern void
 fiber_channel_close(void);
 extern void
 fiber_channel_create(void);
@@ -62,6 +64,7 @@ struct symbol_def {
 };
 
 static struct symbol_def symbols[] = {
+	{"box_lua_find", box_lua_find},
 	{"fiber_channel_close", fiber_channel_close},
 	{"fiber_channel_create", fiber_channel_create},
 	{"fiber_channel_delete", fiber_channel_delete},

--- a/test/app-luatest/tnt_internal_symbol_test.lua
+++ b/test/app-luatest/tnt_internal_symbol_test.lua
@@ -12,6 +12,7 @@ end)
 
 g.test_fiber_channel = function()
     local symbols = {
+        'box_lua_find',
         'fiber_channel_close',
         'fiber_channel_create',
         'fiber_channel_delete',


### PR DESCRIPTION
In some cases, one might want to access a deeply nested Lua function from C, which is exactly the functionality implemented by the `box_lua_find`. Since the function in question is quite complex to re-implement, it is beneficial to expose it for internal use.

NO_DOC=internal
NO_CHANGELOG=internal