### PR TITLE
config: allow to automatically expel instances

### DIFF
--- a/changelogs/unreleased/config-replication-autoexpel.md
+++ b/changelogs/unreleased/config-replication-autoexpel.md
@@ -1,0 +1,3 @@
+## feature/config
+
+* Added the `replication.autoexpel` option (gh-10823).

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -45,6 +45,7 @@ lua_source(lua_sources lua/version.lua internal_version_lua)
 
 # {{{ config
 lua_source(lua_sources lua/config/applier/app.lua          config_applier_app_lua)
+lua_source(lua_sources lua/config/applier/autoexpel.lua    config_applier_autoexpel_lua)
 lua_source(lua_sources lua/config/applier/box_cfg.lua      config_applier_box_cfg_lua)
 lua_source(lua_sources lua/config/applier/runtime_priv.lua config_applier_runtime_priv_lua)
 lua_source(lua_sources lua/config/applier/compat.lua       config_applier_compat_lua)

--- a/src/box/lua/config/applier/autoexpel.lua
+++ b/src/box/lua/config/applier/autoexpel.lua
@@ -1,0 +1,214 @@
+local log = require('internal.config.utils.log')
+
+-- {{{ General-purpose utils
+
+-- {'a', 'b', 'c'} => {a = true, b = true, c = true}
+local function array2set(t)
+    local res = {}
+    for _, v in ipairs(t) do
+        res[v] = true
+    end
+    return res
+end
+
+-- }}} General-purpose utils
+
+-- {{{ box status notifier
+
+local _box_status_watcher
+
+-- Invoke the given callback when box.status event occurs.
+--
+-- It reacts on RO->RW, RW->RO switch and the data dictionary
+-- schema version update.
+local function box_status_notifier_start(cb)
+    if _box_status_watcher ~= nil then
+        return
+    end
+
+    _box_status_watcher = box.watch('box.status', function(_status)
+        cb()
+    end)
+end
+
+-- Stop to call the callback and free resources.
+local function box_status_notifier_stop()
+    if _box_status_watcher == nil then
+        return
+    end
+
+    _box_status_watcher:unregister()
+    _box_status_watcher = nil
+end
+
+-- }}} box status notifier
+
+-- {{{ Hold last config
+
+local _last_cfg
+
+local function save_cfg(cfg)
+    _last_cfg = cfg
+end
+
+local function load_cfg()
+    return _last_cfg
+end
+
+-- }}} Hold last config
+
+-- {{{ Issue or drop an alert
+
+-- The key is to leave only the latest alert if several failed
+-- attempts to perform the expelling were done.
+--
+-- Also, it allows to drop the alert using the key.
+local _alert_key = 'autoexpel_error'
+
+local function set_alert(reason)
+    -- require() it here to avoid a circular dependency.
+    local config = require('config')
+
+    local message = ('autoexpel failed (reload the configuration to retry): ' ..
+        '%s'):format(reason)
+
+    config._aboard:set({
+        type = 'warn',
+        message = message,
+    }, {
+        key = _alert_key,
+    })
+end
+
+local function drop_alert()
+    -- require() it here to avoid a circular dependency.
+    local config = require('config')
+
+    config._aboard:drop(_alert_key)
+end
+
+-- }}} Issue or drop an alert
+
+-- {{{ Autoexpel domain-specific logic
+
+local function _autoexpel_precondition(cfg)
+    -- Can't perform DDL on a read-only instance.
+    if box.info.ro then
+        return false
+    end
+
+    -- Refuse to do automatic replicaset management operations
+    -- during the upgrading procedure, because it seems dangerous.
+    --
+    -- There is a warning about a non-upgraded database schema and
+    -- it shouldn't be a surprise for a user that the
+    -- autoexpelling is not performed in this state.
+    local current_version = box.internal.dd_version()
+    local latest_version = box.internal.latest_dd_version()
+    if current_version < latest_version then
+        return false
+    end
+
+    -- If autoexpelling is stopped but we reach this code somehow
+    -- (a race between the watcher unregistering and the watcher
+    -- event?), just don't do anything.
+    if cfg == nil then
+        return false
+    end
+
+    return true
+end
+
+local function _autoexpel_txn(cfg)
+    local collected = {}
+
+    for _, tuple in box.space._cluster:pairs() do
+        local name = tuple[3]
+        -- NB: The check for presence in `peers` is always true
+        -- for the current instance, because an attempt to apply a
+        -- configuration without the current instance fails on the
+        -- validation step (see config/init.lua:_store).
+        local m = type(name) == 'string' and
+            cfg.peers[name] == nil and
+            name:startswith(cfg.prefix)
+        if m then
+            log.verbose('autoexpel: instance %q is marked to expel', name)
+            table.insert(collected, tuple)
+        end
+    end
+
+    for _, tuple in ipairs(collected) do
+        local pk = {tuple[1]}
+        local name = tuple[3]
+        box.space._cluster:delete(pk)
+        log.info('autoexpel: instance %q is expelled', name)
+    end
+end
+
+-- Save to call in RO or if other criteria to perform the
+-- autoexpel don't met: no-op in the case.
+local function autoexpel_do()
+    local cfg = load_cfg()
+
+    -- This way we don't bother about spurious calls and can just
+    -- call autoexpel_do() on any reconfiguration or box.status
+    -- change.
+    if not _autoexpel_precondition(cfg) then
+        return
+    end
+
+    -- Deletes from _cluster are performed in a transaction.
+    local ok, err = pcall(box.atomic, _autoexpel_txn, cfg)
+
+    -- If an error occurs, report it to the user using the alerts
+    -- mechanism.
+    --
+    -- The alert is dropped on the next configuration reloading or
+    -- if the next expelling attempt is successful (it may be
+    -- triggered by a box.status watcher event).
+    if ok then
+        drop_alert()
+    else
+        set_alert(err)
+    end
+end
+
+-- }}} Autoexpel domain-specific logic
+
+-- {{{ On new configuration
+
+local function apply(config)
+    local configdata = config._configdata
+
+    local user_cfg = configdata:get('replication.autoexpel',
+        {use_default = true})
+
+    if user_cfg == nil or not user_cfg.enabled then
+        log.verbose('autoexpel: stopped (disabled by the configuration)')
+        box_status_notifier_stop()
+        save_cfg(nil)
+        return
+    end
+
+    log.verbose('autoexpel: started (enabled by the configuration)')
+
+    assert(user_cfg.enabled)
+    assert(user_cfg.by == 'prefix')
+    assert(user_cfg.prefix)
+
+    save_cfg({
+        prefix = user_cfg.prefix,
+        peers = array2set(configdata:peers()),
+    })
+    autoexpel_do()
+    box_status_notifier_start(autoexpel_do)
+
+    log.verbose('autoexpel: a new config is sent to the worker fiber')
+end
+
+-- }}} On new configuration
+
+return {
+    name = 'autoexpel',
+    apply = apply,
+}

--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -1741,6 +1741,65 @@ I['replication.anon'] = format_text([[
       or replica set leader.
 ]])
 
+I['replication.autoexpel'] = format_text([[
+    Automatically expel instances.
+
+    The option is useful for management of dynamic clusters using the YAML
+    configuration. The option allows to automatically expel instances
+    that are removed from the YAML configuration.
+
+    Only instances whose names start from the given prefix are taken into
+    account, all the others are ignored. Also, instances without a
+    persistent name set are ignored too.
+
+    If an instance is in read-write mode and has a latest database schema,
+    it performs expelling of the instances:
+
+    - with the given prefix, *and*
+    - not present in the YAML configuration.
+
+    The expelling process the usual one: deletion from the `_cluster` system
+    space.
+
+    The autoexpel logic works on startup and reacts on the reconfiguration
+    and the `box.status` watcher event. If a new instance is joined and
+    neither of these two events occur, autoexpel does not perform any
+    actions on it. In other words, it doesn't forbid joining of an instance
+    that met the autoexpel criterion.
+
+    The option is allowed on the `replicaset`, `group` and `global` levels,
+    but forbidden on the `instance` level of the cluster configuration.
+]])
+
+I['replication.autoexpel.by'] = format_text([[
+    The autoexpel criterion: it defines how to determine that an instance is
+    part of the cluster configuration and is not an external service that
+    uses the replication channel (such as a CDC tool).
+
+    Now, only `replication.autoexpel.by` = `prefix` criterion is supported.
+    A user have to set it explicitly.
+
+    In future we can provide other criteria and set one of them as default.
+]])
+
+I['replication.autoexpel.enabled'] = format_text([[
+    Determines, whether the autoexpelling logic is enabled at all. If the option
+    is set, `replication.autoexpel.by` and `replication.autoexpel.prefix` are
+    required.
+]])
+
+I['replication.autoexpel.prefix'] = format_text([[
+    Defines a pattern for instance names that are considered a part of the
+    cluster (not some external services).
+
+    For example, if all the instances in the cluster configuration are prefixed
+    with the replica set name, one can use `replication.autoexpel.prefix` =
+    '{{ replicaset_name }}'`.
+
+    If all the instances follow the `i-\d\d\d` pattern, the option can be set
+    to `i-`.
+]])
+
 I['replication.bootstrap_strategy'] = format_text([[
     Specifies a strategy used to bootstrap a replica set. The following
     strategies are available:

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -130,6 +130,7 @@ function methods._initialize(self)
     self:_register_applier(require('internal.config.applier.credentials'))
     self:_register_applier(require('internal.config.applier.fiber'))
     self:_register_applier(require('internal.config.applier.sharding'))
+    self:_register_applier(require('internal.config.applier.autoexpel'))
     self:_register_applier(require('internal.config.applier.roles'))
     self:_register_applier(require('internal.config.applier.app'))
 

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -150,6 +150,7 @@ extern char session_lua[],
 	metrics_version_lua[],
 	/* {{{ config */
 	config_applier_app_lua[],
+	config_applier_autoexpel_lua[],
 	config_applier_box_cfg_lua[],
 	config_applier_runtime_priv_lua[],
 	config_applier_compat_lua[],
@@ -412,6 +413,10 @@ static const char *lua_sources[] = {
 	"config/applier/app",
 	"internal.config.applier.app",
 	config_applier_app_lua,
+
+	"config/applier/autoexpel",
+	"internal.config.applier.autoexpel",
+	config_applier_autoexpel_lua,
 
 #if ENABLE_CONFIG_EXTRAS
 	"config/source/etcd",

--- a/test/config-luatest/autoexpel_test.lua
+++ b/test/config-luatest/autoexpel_test.lua
@@ -1,0 +1,341 @@
+local yaml = require('yaml')
+local t = require('luatest')
+local treegen = require('luatest.treegen')
+local justrun = require('luatest.justrun')
+local cbuilder = require('luatest.cbuilder')
+local cluster = require('test.config-luatest.cluster')
+
+local g = t.group()
+
+g.before_all(cluster.init)
+g.after_each(cluster.drop)
+g.after_all(cluster.clean)
+
+-- {{{ Helpers
+
+local function assert_rs(server, exp)
+    server:exec(function(exp)
+        local res = box.space._cluster:pairs():map(function(t)
+            return t[3]
+        end):totable()
+        table.sort(res)
+        t.assert_equals(res, exp)
+    end, {exp})
+end
+
+local function reload(server)
+    server:exec(function()
+        local config = require('config')
+
+        config:reload()
+    end)
+end
+
+local function promote(server)
+    server:exec(function()
+        local fiber = require('fiber')
+
+        t.helpers.retrying({timeout = 60}, function()
+            -- Run box.ctl.promote() in background, because it
+            -- seems that there are situations, when this call
+            -- continues infinitely.
+            --
+            -- TODO: This behavior is surprising and we possibly
+            -- should consider it as a bug.
+            fiber.new(box.ctl.promote)
+            t.helpers.retrying({timeout = 1}, function()
+                assert(box.info.ro == false)
+            end)
+        end)
+    end)
+end
+
+local function errinj_wal_io(server, enabled)
+    server:exec(function(enabled)
+        box.error.injection.set('ERRINJ_WAL_IO', enabled)
+    end, {enabled})
+end
+
+local function find_alert(server, prefix)
+    return server:exec(function(prefix)
+        for _, alert in ipairs(box.info.config.alerts) do
+            if alert.message:startswith(prefix) then
+                return alert
+            end
+        end
+        return nil
+    end, {prefix})
+end
+
+-- Shortcut to make test cases more readable.
+local function wait(f, ...)
+    return t.helpers.retrying({timeout = 60}, f, ...)
+end
+
+local function wait_alert(server, prefix)
+    return wait(function()
+        local res = find_alert(server, prefix)
+        assert(res ~= nil)
+        return res
+    end)
+end
+
+-- }}} Helpers
+
+-- Verify that the autoexpelling reacts on the configuration
+-- reloading.
+g.test_works_on_reload = function(g)
+    local config = cbuilder:new()
+        :set_replicaset_option('replication.autoexpel', {
+            enabled = true,
+            by = 'prefix',
+            prefix = 'i-'
+        })
+        :set_replicaset_option('replication.failover', 'manual')
+        :set_replicaset_option('leader', 'i-001')
+        :add_instance('i-001', {})
+        :add_instance('i-002', {})
+        :add_instance('i-003', {})
+        -- i-004 matches the prefix, so will be expelled when
+        -- removed from the configuration.
+        :add_instance('i-004', {})
+        -- x-005 doesn't match the prefix, so it will be kept,
+        -- when removed from the configuration.
+        :add_instance('x-005', {})
+        :config()
+
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    -- Test case prerequisite.
+    assert_rs(cluster['i-001'], {'i-001', 'i-002', 'i-003', 'i-004', 'x-005'})
+
+    local config_2 = cbuilder:new(config)
+        :set_replicaset_option('instances.i-004', nil)
+        :set_replicaset_option('instances.x-005', nil)
+        :config()
+    cluster:sync(config_2)
+    reload(cluster['i-001'])
+
+    -- Don't assume that the autoexpelling effects immediately
+    -- after the configuration reload. It is possible that the
+    -- instance is temporarily in RO due to replication
+    -- reconfiguration and goes to RW soon. After that it performs
+    -- the expelling.
+    wait(assert_rs, cluster['i-001'], {'i-001', 'i-002', 'i-003', 'x-005'})
+end
+
+-- Verify that the autoexpelling reacts on going to RW.
+g.test_works_on_rw = function(g)
+    local config = cbuilder:new()
+        :set_replicaset_option('replication.autoexpel', {
+            enabled = true,
+            by = 'prefix',
+            prefix = 'i-'
+        })
+        :set_replicaset_option('replication.failover', 'election')
+        :add_instance('i-001', {})
+        :add_instance('i-002', {})
+        :add_instance('i-003', {})
+        -- i-004 matches the prefix, so will be expelled when
+        -- removed from the configuration.
+        :add_instance('i-004', {})
+        -- x-005 doesn't match the prefix, so it will be kept,
+        -- when removed from the configuration.
+        :add_instance('x-005', {})
+        :config()
+
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    -- Promote i-002 to leaders to make i-001 RO.
+    promote(cluster['i-002'])
+
+    -- Test case precondition.
+    assert_rs(cluster['i-001'], {'i-001', 'i-002', 'i-003', 'i-004', 'x-005'})
+
+    -- Load config without i-004 and x-005 on i-001.
+    local config_2 = cbuilder:new(config)
+        :set_replicaset_option('instances.i-004', nil)
+        :set_replicaset_option('instances.x-005', nil)
+        :config()
+    cluster:sync(config_2)
+    reload(cluster['i-001'])
+
+    -- i-001 is RO.
+    assert_rs(cluster['i-001'], {'i-001', 'i-002', 'i-003', 'i-004', 'x-005'})
+
+    -- When i-001 is RW, it can expel instances.
+    promote(cluster['i-001'])
+    wait(assert_rs, cluster['i-001'], {'i-001', 'i-002', 'i-003', 'x-005'})
+end
+
+-- Verify that if the autoexpelling fails, an alert is reported.
+g.test_alert_on_write_error = function(g)
+    t.tarantool.skip_if_not_debug(
+        'errinj based test cases only work in the Debug build')
+
+    local config = cbuilder:new()
+        :set_replicaset_option('replication.autoexpel', {
+            enabled = true,
+            by = 'prefix',
+            prefix = 'i-'
+        })
+        :set_replicaset_option('replication.failover', 'manual')
+        :set_replicaset_option('leader', 'i-001')
+        :add_instance('i-001', {})
+        :add_instance('i-002', {})
+        :add_instance('i-003', {})
+        :add_instance('i-004', {})
+        :config()
+
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    -- Test case prerequisite.
+    assert_rs(cluster['i-001'], {'i-001', 'i-002', 'i-003', 'i-004'})
+
+    -- Block WAL.
+    errinj_wal_io(cluster['i-001'], true)
+
+    local config_2 = cbuilder:new(config)
+        :set_replicaset_option('instances.i-004', nil)
+        :set_replicaset_option('instances.x-005', nil)
+        :config()
+    cluster:sync(config_2)
+    reload(cluster['i-001'])
+
+    -- Nothing changes: the WAL is blocked.
+    assert_rs(cluster['i-001'], {'i-001', 'i-002', 'i-003', 'i-004'})
+
+    local err_msg_prefix = 'autoexpel failed (reload the configuration ' ..
+        'to retry): '
+    local err_reason = 'Failed to write to disk'
+
+    -- The alert regarding inability to perform the expelling is
+    -- reported.
+    local alert = wait_alert(cluster['i-001'], err_msg_prefix)
+    t.assert(alert)
+    t.assert_covers(alert, {
+        type = 'warn',
+        message = err_msg_prefix .. err_reason,
+    })
+
+    -- Unblock WAL.
+    errinj_wal_io(cluster['i-001'], false)
+
+    -- Autoexpel is not woken up yet. It is expected.
+    assert_rs(cluster['i-001'], {'i-001', 'i-002', 'i-003', 'i-004'})
+    local alert = find_alert(cluster['i-001'], err_msg_prefix)
+    t.assert(alert)
+    t.assert_covers(alert, {
+        type = 'warn',
+        message = err_msg_prefix .. err_reason,
+    })
+
+    -- We need the configuration reloading or box.status event to
+    -- wake up the autoexpelling fiber. Do the reload and verify
+    -- that the autoexpelling do the work (and drops the alert).
+    reload(cluster['i-001'])
+    wait(assert_rs, cluster['i-001'], {'i-001', 'i-002', 'i-003'})
+    local alert = find_alert(cluster['i-001'], err_msg_prefix)
+    t.assert_equals(alert, nil)
+end
+
+-- Verify that enabling the autoexpelling and configuring several
+-- RW instances is forbidden.
+g.test_error_on_multiple_rw_on_startup = function()
+    local config = cbuilder:new()
+        :set_replicaset_option('replication.autoexpel', {
+            enabled = true,
+            by = 'prefix',
+            prefix = 'i-'
+        })
+        :add_instance('i-001', {database = {mode = 'rw'}})
+        :add_instance('i-002', {database = {mode = 'rw'}})
+        :add_instance('i-003', {})
+        :config()
+
+    -- Write config to a temporary directory.
+    local dir = treegen.prepare_directory({}, {})
+    local config_file = treegen.write_file(dir, 'config.yaml',
+        yaml.encode(config))
+
+    -- Run tarantool instance that is expected to exit
+    -- immediately.
+    local env = {}
+    local args = {'--name', 'i-001', '--config', config_file}
+    local opts = {nojson = true, stderr = true}
+    local res = justrun.tarantool(dir, env, args, opts)
+
+    -- Verify the exit code and the error reported to stderr.
+    local exp_err = 'replication.autoexpel.enabled = true doesn\'t support ' ..
+        'the multi-master configuration'
+    t.assert_covers(res, {
+        exit_code = 1,
+        stderr = ('LuajitError: %s\nfatal error, exiting the event loop')
+            :format(exp_err),
+    })
+end
+
+-- Similar to the previous one, but checks the error on the
+-- configuration reloading.
+g.test_error_on_multiple_rw_on_reload = function(g)
+    local config = cbuilder:new()
+        :set_replicaset_option('replication.autoexpel', {
+            enabled = true,
+            by = 'prefix',
+            prefix = 'i-'
+        })
+        :add_instance('i-001', {database = {mode = 'rw'}})
+        :add_instance('i-002', {})
+        :add_instance('i-003', {})
+        :add_instance('i-004', {})
+        :config()
+
+    local cluster = cluster.new(g, config)
+    cluster:start()
+
+    -- Test case prerequisite.
+    assert_rs(cluster['i-001'], {'i-001', 'i-002', 'i-003', 'i-004'})
+
+    local exp_err = 'replication.autoexpel.enabled = true doesn\'t support ' ..
+        'the multi-master configuration'
+
+    -- Assign the second master, try to reload the configuration.
+    --
+    -- config:reload() should raise an error.
+    local config_2 = cbuilder:new(config)
+        :set_instance_option('i-002', 'database.mode', 'rw')
+        :set_replicaset_option('instances.i-004', nil)
+        :config()
+    cluster:sync(config_2)
+    t.assert_error_msg_equals(exp_err, reload, cluster['i-001'])
+
+    -- i-004 is still registered.
+    assert_rs(cluster['i-001'], {'i-001', 'i-002', 'i-003', 'i-004'})
+
+    -- The alert regarding the misconfiguration is reported.
+    local alert = find_alert(cluster['i-001'], exp_err)
+    t.assert(alert)
+    t.assert_covers(alert, {
+        type = 'error',
+        message = exp_err,
+    })
+
+    -- Leave only one master (but keep replication.failover = off).
+    --
+    -- It is considered OK.
+    local config_3 = cbuilder:new(config_2)
+        :set_instance_option('i-002', 'database.mode', nil)
+        :config()
+    cluster:sync(config_3)
+    reload(cluster['i-001'])
+
+    -- i-004 is expelled.
+    wait(assert_rs, cluster['i-001'], {'i-001', 'i-002', 'i-003'})
+
+    -- No alert.
+    local alert = find_alert(cluster['i-001'], exp_err)
+    t.assert_equals(alert, nil)
+end


### PR DESCRIPTION
The new option is useful for management of dynamic clusters using the YAML configuration. The option allows to automatically expel instances that are removed from the YAML configuration.

A ready-to-run example:

```yaml
credentials:
  users:
    guest:
      roles: [super]

replication:
  failover: manual
  autoexpel:
    enabled: true
    by: prefix
    prefix: '{{ replicaset_name }}'

iproto:
  listen:
    - uri: 'unix/:./var/run/{{ instance_name }}.iproto'

groups:
  g-001:
    replicasets:
      r-001:
        leader: r-001-i-001
        instances:
          r-001-i-001: {}
          r-001-i-002: {}
          r-001-i-003: {}
```

How to run the example:

1. Start all the three instances:

   ```shell
   $ tarantool --name r-001-i-001 --config config.yaml -i
   $ tarantool --name r-001-i-002 --config config.yaml -i
   $ tarantool --name r-001-i-003 --config config.yaml -i
   ```

2. Remove `r-001-i-003` from `config.yaml`.

3. Reload the configuration on `r-001-i-001` (leader) and check the effect:

   ```lua
   tarantool> box.space._cluster:fselect()
   <..r-001-i-003 is here..>

   tarantool> config = require('config')
   tarantool> config:reload()

   tarantool> box.space._cluster:fselect()
   <..r-001-i-003 is deleted..>
   ```

Only instances whose names start from the given prefix are taken into account, all the others are ignored. Also, instances without a persistent name set are ignored too.

If an instance is in read-write mode and has a latest database schema, it performs expelling of the instances:

* with the given prefix, *and*
* not present in the YAML configuration.

The expelling process the usual one: deletion from the `_cluster` system space.

The autoexpel logic works on startup and reacts on the reconfiguration and the `box.status` watcher event. If a new instance is joined and neither of these two events occur, autoexpel does not perform any actions on it. IOW, it doesn't forbid joining of an instance that met the autoexpel criterion.

From the configuration point of view, the new `replication.autoexpel` option of type `record` is added to the replicaset, group and global levels. It has no much sense to set it for individual instances, so it is forbidden on the instance level of the cluster configuration.

The record contains the following fields:

* `enabled` (`boolean`, default `false`)
* `by` (`string`, default `nil`)
  - allows only `prefix` value
* `prefix` (string, default `nil`)

`replication.autoexpel.enabled` determines, whether the autoexpelling logic is enabled at all. If the option is set, `replication.autoexpel.by` and `replication.autoexpel.prefix` are required.

`replication.autoexpel.by` is the autoexpel criterion: it defines how to determine that an instance is part of the cluster configuration and is not an external service that uses the replication channel (such as a CDC tool). Now, only `replication.autoexpel.by` = `prefix` criterion is supported. A user have to set it explicitly. In future we can provide other criteria and set one of them as default.

`replication.autoexpel.prefix` defines a pattern for instance names that are considered a part of the cluster (not some external services). For example, if all the instances in the cluster configuration are prefixed with the replicaset name, one can use `prefix: '{{ replicaset_name }}'`. If all the instances follow the `i-\d\d\d` pattern, the option can be set to `i-`.

Fixes #10823