### PR TITLE
[Backport 2.11] sql: do not use raw index for count

### DIFF
--- a/changelogs/unreleased/gh-10825-sql-count-as-first-stmt.md
+++ b/changelogs/unreleased/gh-10825-sql-count-as-first-stmt.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+- Fixed a bug when an SQL count statement wasn't tracked by MVCC if it was
+  the first in a transaction (gh-10825).

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -255,6 +255,11 @@ tarantoolsqlEphemeralCount(struct BtCursor *pCur)
 {
 	assert(pCur->curFlags & BTCF_TEphemCursor);
 	struct index *primary_index = space_index(pCur->space, 0 /* PK */);
+	/*
+	 * Cannot use `box_index_count` since the ephemeral space has no id.
+	 * Anyway, ephemeral spaces are internal and actually bypass
+	 * the transactional engine so it's safe to use raw index here.
+	 */
 	return index_count(primary_index, pCur->iter_type, NULL, 0);
 }
 
@@ -262,7 +267,11 @@ int64_t
 tarantoolsqlCount(struct BtCursor *pCur)
 {
 	assert(pCur->curFlags & BTCF_TaCursor);
-	return index_count(pCur->index, pCur->iter_type, NULL, 0);
+	/* Empty key encoded in MsgPack. */
+	const char empty_key[] = {0x90};
+	return box_index_count(pCur->space->def->id, pCur->index->def->iid,
+			       pCur->iter_type, empty_key,
+			       empty_key + sizeof(empty_key));
 }
 
 struct sql_space_info *

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -2133,6 +2133,8 @@ case OP_Count: {         /* out2 */
 		assert((pCrsr->curFlags & BTCF_TEphemCursor) != 0);
 		nEntry = tarantoolsqlEphemeralCount(pCrsr);
 	}
+	if (nEntry < 0)
+		goto abort_due_to_error;
 	pOut = vdbe_prepare_null_out(p, pOp->p2);
 	mem_set_uint(pOut, nEntry);
 	break;

--- a/test/engine-luatest/gh_10825_sql_count_ro_txn_test.lua
+++ b/test/engine-luatest/gh_10825_sql_count_ro_txn_test.lua
@@ -1,0 +1,76 @@
+local t = require('luatest')
+
+local server = require('luatest.server')
+
+local g = t.group(nil, t.helpers.matrix{engine = {'memtx', 'vinyl'}})
+
+g.before_all(function(cg)
+    -- Memtx MVCC is required for memtx test to do a concurrent write
+    cg.server = server:new({box_cfg = {memtx_use_mvcc_engine = true}})
+    cg.server:start()
+    cg.server:exec(function(engine)
+        box.schema.space.create('test', {engine = engine})
+        box.space.test:format({{'field1', 'unsigned'}})
+        box.space.test:create_index('pk')
+    end, {cg.params.engine})
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        box.space.test:truncate()
+    end)
+end)
+
+-- The case covers a bug when SQL count didn't begin transaction
+-- in engine if it was the first statement.
+g.test_sql_count_does_not_begin_txn_in_engine = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+
+        -- Open a transaction and count tuples
+        box.begin()
+        local count = box.execute([[SELECT COUNT() FROM SEQSCAN "test"]])
+        t.assert_equals(count.rows, {{0}})
+
+        -- Make a concurrent insert
+        local f = fiber.create(function()
+            box.space.test:insert{1}
+        end)
+        f:set_joinable(true)
+
+        -- Wait for write to be committed and count tuples again
+        f:join()
+        local count = box.execute([[SELECT COUNT() FROM SEQSCAN "test"]])
+        t.assert_equals(count.rows, {{0}})
+        box.commit()
+    end)
+end
+
+-- The case covers a problem when SQL didn't check if the count
+-- was successful.
+g.test_sql_count_does_not_handle_error = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+
+        -- Make aborted-by-conflict transaction so that count will fail.
+        box.begin()
+        box.space.test:insert{1}
+
+        -- Conflicting insert will abort our transaction.
+        local f = fiber.create(function()
+            box.space.test:insert{1}
+        end)
+        f:set_joinable(true)
+        t.assert_equals({f:join()}, {true})
+
+        -- Now transaction must be aborted by conflict so count will fail.
+        local _, err = box.execute([[SELECT COUNT() FROM SEQSCAN "test"]])
+        t.assert_not_equals(err, nil)
+        t.assert_equals(err.message, 'Transaction has been aborted by conflict')
+        box.rollback()
+    end)
+end


### PR DESCRIPTION
Currently, we use raw index for count operation instead of `box_index_count`. As a result, we skip a check if current transaction can continue and we don't begin transaction in engine if needed. So, if count statement is the first in a transaction, it won't be tracked by MVCC since it wasn't notified about the transaction. The commit fixes the mistake. Also, the commit adds a check if count was successful and covers it with a test.

See the commit for additional details.

Closes #10825