### PR TITLE
config: add failover.log option options

### DIFF
--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2394,6 +2394,23 @@ return schema.new('instance_config', schema.record({
                 }),
             }),
         }),
+        log = schema.record({
+            to = schema.enum({
+                'stderr',
+                'file',
+            }, {
+                default = 'stderr',
+            }),
+            file = schema.scalar({
+                type = 'string',
+            }),
+        }, {
+            validate = function(data, w)
+                if data.to == 'file' and data.file == nil then
+                    w.error('log.file must be specified when log.to is "file"')
+                end
+            end,
+        }),
     }),
     -- Compatibility options.
     compat = schema.record({

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1736,7 +1736,11 @@ g.test_failover = function()
                         instance001 = 1
                     }
                 }
-            }
+            },
+            log = {
+                to = 'file',
+                file = 'var/log/tarantool/failover.log',
+            },
         }
     }
 


### PR DESCRIPTION
Needed for EE tarantool/tarantool-ee#925.

NO_CHANGELOG=changelog is a part of tarantool/tarantool-ee#925 NO_TEST=will be tested as a part of tarantool/tarantool-ee#925

@TarantoolBot document
Title: New configuration options `failover.log`

Now `failover.log.to` and `failover.log.file` options can be used to configure failover logger output.

Those options behave in similar way to `log.to` and `log.file` options.

`failover.log.to` defines the location for failover logs. This option accepts the following values:
- `stderr`: write logs to the standard error stream.
- `file`: write logs to a file defined in `failover.log.file`.

`failover.log.file` specifies a file for logs destination. It is mandatory to set this option if `failover.log.to` is set to `file`. If `failover.log.to` is set to anything else, this option is ignored.

The option is enterprise-only since it's a part of the supervised failover coordinator.