### PR TITLE
replication: add early and graceful make_bootstrap_leader()

### DIFF
--- a/changelogs/unreleased/allow-bootstrap-in-ro-in-supervised-bs.md
+++ b/changelogs/unreleased/allow-bootstrap-in-ro-in-supervised-bs.md
@@ -1,0 +1,4 @@
+## feature/replication
+
+* Allow to bootstrap the initial database in read-only mode in the 'supervised'
+  bootstrap strategy.

--- a/changelogs/unreleased/early-make-bootstrap-leader.md
+++ b/changelogs/unreleased/early-make-bootstrap-leader.md
@@ -1,0 +1,4 @@
+## feature/replication
+
+* Allowed to call `box.ctl.make_bootstrap_leader()` before the first
+  `box.cfg()` call in the `'supervised'` bootstrap strategy (gh-10858).

--- a/changelogs/unreleased/graceful-make-bootstrap-leader.md
+++ b/changelogs/unreleased/graceful-make-bootstrap-leader.md
@@ -1,0 +1,3 @@
+## feature/replication
+
+* Added the `graceful` option to `box.ctl.make_bootstrap_leader()` (gh-11272).

--- a/changelogs/unreleased/single-instance-in-supervised-bs.md
+++ b/changelogs/unreleased/single-instance-in-supervised-bs.md
@@ -1,0 +1,5 @@
+## feature/replication
+
+* Now `box.cfg({bootstrap_strategy = 'supervised'})` without upstreams waits
+  for the `box.ctl.make_bootstrap_leader(<...>)` command till the replication
+  connect timeout instead of an immediate fail.

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -4337,6 +4337,8 @@ on_commit_schema_set_bootstrap_leader_uuid(struct trigger *trigger, void *event)
 	struct tt_uuid *uuid = (struct tt_uuid *)trigger->data;
 	bootstrap_leader_uuid = *uuid;
 	is_supervised_bootstrap_leader = tt_uuid_is_equal(uuid, &INSTANCE_UUID);
+	say_info("instance %s is assigned as a bootstrap leader",
+		 tt_uuid_str(uuid));
 	box_broadcast_ballot();
 	return 0;
 }

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -4336,6 +4336,7 @@ on_commit_schema_set_bootstrap_leader_uuid(struct trigger *trigger, void *event)
 	(void)event;
 	struct tt_uuid *uuid = (struct tt_uuid *)trigger->data;
 	bootstrap_leader_uuid = *uuid;
+	is_supervised_bootstrap_leader = tt_uuid_is_equal(uuid, &INSTANCE_UUID);
 	box_broadcast_ballot();
 	return 0;
 }

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -2275,8 +2275,10 @@ box_make_bootstrap_leader_graceful(void)
 		 "takes this role");
 
 	/* Wake up replicaset_connect() if the flag is turn on. */
-	if (!tt_uuid_is_nil(&INSTANCE_UUID))
+	if (!tt_uuid_is_nil(&INSTANCE_UUID)) {
 		box_broadcast_ballot();
+		replicaset_connect_wakeup();
+	}
 
 	return 0;
 }
@@ -2304,6 +2306,7 @@ box_make_bootstrap_leader_nongraceful(void)
 		bootstrap_leader_uuid = INSTANCE_UUID;
 		is_supervised_bootstrap_leader = true;
 		box_broadcast_ballot();
+		replicaset_connect_wakeup();
 		return 0;
 	}
 }

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -5388,8 +5388,17 @@ check_global_ids_integrity(void)
 static void
 bootstrap_master(void)
 {
-	/* Do not allow to bootstrap a readonly instance as master. */
-	if (cfg_geti("read_only") == 1) {
+	/*
+	 * Do not allow to bootstrap a readonly instance as master.
+	 *
+	 * Allow an exception for the supervised bootstrap
+	 * strategy, because the command to bootstrap may be
+	 * received during the in progress box.cfg() call and
+	 * there is no way to change box.cfg.read_only at this
+	 * time.
+	 */
+	if (bootstrap_strategy != BOOTSTRAP_STRATEGY_SUPERVISED &&
+	    cfg_geti("read_only") == 1) {
 		tnt_raise(ClientError, ER_BOOTSTRAP_READONLY);
 	}
 	/*

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -2267,6 +2267,7 @@ box_make_bootstrap_leader(void)
 		 * this action till the bootstrap.
 		 */
 		is_supervised_bootstrap_leader = true;
+		say_info("this instance is assigned as a bootstrap leader");
 		return 0;
 	}
 	/* Bootstrap strategy is read by the time instance uuid is known. */

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -452,9 +452,14 @@ box_iterator_position_unpack(const char *packed_pos,
 
 /**
  * For bootstrap_strategy = "supervised", set this node as the bootstrap leader.
+ *
+ * If the `graceful` flag is set, an attempt to connect to other nodes is
+ * performed first (during box.cfg.replication_connect_timeout) and if another
+ * node advertises itself as a bootstrap leader, the current node joins to the
+ * existing replicaset.
  */
 int
-box_make_bootstrap_leader(void);
+box_make_bootstrap_leader(bool graceful);
 
 /**
  * Select data, satisfying filters (key and iterator), and dump it to port.

--- a/src/box/lua/ctl.c
+++ b/src/box/lua/ctl.c
@@ -118,7 +118,22 @@ lbox_ctl_demote(struct lua_State *L)
 static int
 lbox_ctl_make_bootstrap_leader(struct lua_State *L)
 {
-	if (box_make_bootstrap_leader() != 0)
+	bool graceful = false;
+
+	if (!lua_isnoneornil(L, 1)) {
+		if (!lua_istable(L, 1)) {
+			diag_set(IllegalParams,
+				 "box.ctl.make_bootstrap_leader() expects a "
+				 "table as the first argument, got %s",
+				 luaL_typename(L, 1));
+			return luaT_error(L);
+		}
+		lua_getfield(L, 1, "graceful");
+		graceful = lua_toboolean(L, -1) != 0;
+		lua_pop(L, 1);
+	}
+
+	if (box_make_bootstrap_leader(graceful) != 0)
 		return luaT_error(L);
 	return 0;
 }

--- a/src/box/replication.h
+++ b/src/box/replication.h
@@ -154,6 +154,20 @@ extern struct uri cfg_bootstrap_leader_uri;
 extern char cfg_bootstrap_leader_name[];
 
 /**
+ * Whether the given instance is configured to make bootstrap of
+ * the replicaset.
+ *
+ * Has an effect only in the supervised bootstrap strategy.
+ *
+ * This flag have to be consistent with bootstrap_leader_uuid
+ * except the following cases:
+ *
+ * - INSTANCE_UUID is zero UUID
+ * - the bootstrap strategy is not 'supervised'
+ */
+extern bool is_supervised_bootstrap_leader;
+
+/**
  * Configured name of this instance. Might be different from the actual name if
  * the configuration is not fully applied yet.
  */

--- a/src/box/replication.h
+++ b/src/box/replication.h
@@ -168,6 +168,13 @@ extern char cfg_bootstrap_leader_name[];
 extern bool is_supervised_bootstrap_leader;
 
 /**
+ * A graceful bootstrap leadership request means that we check
+ * other peers first and if there is no bootstrap leader across
+ * them, continue as the bootstrap leader.
+ */
+extern bool is_graceful_supervised_bootstrap_requested;
+
+/**
  * Configured name of this instance. Might be different from the actual name if
  * the configuration is not fully applied yet.
  */

--- a/src/box/replication.h
+++ b/src/box/replication.h
@@ -706,6 +706,18 @@ replicaset_connect(const struct uri_set *uris,
 		   bool connect_quorum, bool keep_connect);
 
 /**
+ * Wake up replicaset_connect() to re-verify if the waiting for
+ * connect quorum/bootstrap leader can be finished. To be called
+ * after changing local bootstrap leadership flags in the
+ * supervised bootstrap strategy.
+ *
+ * No-op if replicaset_connect() is not in the waiting loop or not
+ * in progress at all.
+ */
+void
+replicaset_connect_wakeup(void);
+
+/**
  * Reload replica URIs.
  *
  * Called on reconfiguration in case the remote peer URIs are the same.


### PR DESCRIPTION
This patchset contains a few tightly coupled features.

## Early `box.ctl.make_bootstrap_leader()`

Now, it is allowed to call `box.ctl.make_bootstrap_leader()` before a first `box.cfg()` call to mark the instance as a bootstrap leader.

It works if `box.cfg({bootstrap_strategy = 'supervised'})` is set, ignored otherwise.

So, the following code is now possible:

```lua
box.ctl.make_bootstrap_leader()
box.cfg({
    bootstrap_strategy = 'supervised',
})
```

In earlier Tarantool version a user has to call `box.cfg()` in a separate fiber first and then call `box.ctl.make_bootstrap_leader()`.

Also, earlier Tarantool versions do not allow to bootstrap a database using the `'supervised'` bootstrap strategy if there are no upstreams configured (empty `box.cfg.replication`). It means that there were no way to bootstrap the database without iproto listening port configured (`box.cfg.listen`) except using another bootstrap strategy.

Now, the `'supervised'` bootstrap strategy let a user a full control over the replicaset bootstrapping process.

Fixes #10858

## `box.ctl.make_bootstrap_leader({graceful = true})`

The new option is added to the `box.ctl.make_bootstrap_leader()` call:

```lua
box.ctl.make_bootstrap_leader({graceful = true})
```

It checks a presence of a bootstrap leader across other peers first and, if there are no one, bootstraps the initial database on the current instance.

Strictly speaking:

* If there are no local database:
  * Start connecting to all the peers from `box.cfg.replication` (without waiting).
  * Wait for one of the three situations:
    * Found a peer with the bootstrap leader flag.
    * Connected to all the peers from `box.cfg.replication`, but there is no one with the bootstrap leader flag.
    * `box.cfg.replication_connect_timeout` is over.
  * If the bootstrap leader is found, go as a replica. Otherwise, assign itself as a bootstrap leader.
* If there is a local database, the call is no-op.

The motivating scenario is when we don't really know, whether the replicaset is already bootstrapped and want to bootstrap it from the given instance if not.

The new option doesn't give any protection in the situation, when the replicaset is not bootstrapped and two instances are simultaneously trying to gracefully bootstrap it.

Fixes #11272

## Allow to bootstrap in RO in the `supervised` bootstrap strategy

It allows to run `box.cfg({read_only = true})` on all the instances and wait for an external coordinator to choose one of the instances as the bootstrap leader:

```lua
box.ctl.make_bootstrap_leader({graceful = true})
box.cfg({read_only = false})
```

Needed for #10857

## Wait for bootstrap leader if there are no configured upstreams in the `supervised` bootstrap strategy

It allows to follow the same startup flow for multi-instance and single-instance replicasets:

```lua
box.cfg({
    bootstrap_strategy = 'supervised',
    replication = <...>, -- exists or not
})
```

Then via iproto or the admin console:

```lua
box.ctl.make_bootstrap_leader({graceful = true})
box.cfg({read_only = false})
```

Needed for #10857