### PR TITLE
relay: fix sending raft requests with GROUP_DEFAULT id

### DIFF
--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -468,6 +468,7 @@ relay_initial_join(struct iostream *io, uint64_t sync, struct vclock *vclock,
 	relay_start(relay, io, sync, relay_send_initial_join_row, relay_yield,
 		    UINT64_MAX);
 	xrow_stream_create(&relay->xrow_stream);
+	relay->version_id = replica_version_id;
 	auto relay_guard = make_scoped_guard([=] {
 		xrow_stream_destroy(&relay->xrow_stream);
 		relay_stop(relay);
@@ -1131,12 +1132,12 @@ relay_filter_raft(struct xrow_header *packet, uint32_t version)
 {
 	assert(iproto_type_is_raft_request(packet->type));
 	if (version > version_id(3, 2, 1) ||
-	    (version > version_id(2, 11, 4) && version < version_id(3, 0, 0)))
+	    (version > version_id(2, 11, 5) && version < version_id(3, 0, 0)))
 		return;
 	/**
 	 * Until Tarantool 3.2.2 all raft requests were sent with GROUP_LOCAL
 	 * id. In order not to break the upgrade process, raft rows are still
-	 * sent as local to old replicas. This was also backported to 2.11.5.
+	 * sent as local to old replicas. This was also backported to 2.11.6.
 	 */
 	packet->group_id = GROUP_LOCAL;
 }

--- a/test/replication-luatest/gh_10727_no_local_rows_test.lua
+++ b/test/replication-luatest/gh_10727_no_local_rows_test.lua
@@ -1,10 +1,115 @@
 local t = require('luatest')
 local server = require('luatest.server')
-local proxy = require('luatest.replica_proxy')
+local msgpack = require('msgpack')
+local version = require('version')
+local socket = require('socket')
+local uuid = require('uuid')
+local uri = require('uri')
 
 local g = t.group()
 
-g.before_all(function(cg)
+local timeout = 60
+local key = box.iproto.key
+local type = box.iproto.type
+
+local function socket_connect(server)
+    local u = uri.parse(server.net_box_uri)
+    local s = socket.tcp_connect(u.host, u.service)
+    t.assert_not_equals(s, nil)
+    -- Skip the greeting.
+    s:read(box.iproto.GREETING_SIZE, timeout)
+    return s
+end
+
+local function socket_write(s, header, body)
+    return s:write(box.iproto.encode_packet(header, body))
+end
+
+local function socket_read(s)
+    local size_mp = s:read(5, timeout)
+    t.assert_equals(#size_mp, 5)
+    local size = msgpack.decode(size_mp)
+    local response = s:read(size, timeout)
+    t.assert_equals(#response, size)
+    return box.iproto.decode_packet(size_mp .. response)
+end
+
+local function write_join(s, version_id, instance_uuid)
+    local header = {
+        [key.REQUEST_TYPE] = box.iproto.type.JOIN,
+        [key.SYNC] = 1,
+    }
+    local body = {
+        -- Trigger meta stage.
+        [key.SERVER_VERSION] = version_id,
+        [key.INSTANCE_UUID] = instance_uuid,
+    }
+    return socket_write(s, header, body)
+end
+
+local function encode_map(map)
+    return msgpack.object(setmetatable(map, {__serialize = 'map'}))
+end
+
+local function write_subscribe(s, version_id, instance_uuid, rs_uuid, vclock)
+    local header = {
+        [key.REQUEST_TYPE] = box.iproto.type.SUBSCRIBE,
+        [key.SYNC] = version_id,
+    }
+    local body = {
+        [key.REPLICASET_UUID] = rs_uuid,
+        [key.INSTANCE_UUID] = instance_uuid,
+        [key.VCLOCK] = encode_map(vclock),
+    }
+    return socket_write(s, header, body)
+end
+
+local function parse_replication_stream(s, assert, cond)
+    local h, b
+    while true do
+        h, b = socket_read(s)
+        assert(h)
+        if cond(h, b) then
+            break
+        end
+    end
+    return b
+end
+
+local function until_vclock_cond(h, b)
+    return h[key.REQUEST_TYPE] == type.OK and b and b[key.VCLOCK]
+end
+
+local function until_promote_cond(h, _)
+    return h[key.REQUEST_TYPE] == type.RAFT_PROMOTE
+end
+
+local function test_replication_stream(cg, version_id, assert)
+    local s = socket_connect(cg.master)
+    --
+    -- JOIN stage.
+    --
+    local instance_uuid = uuid.str()
+    write_join(s, version_id, instance_uuid)
+    -- Start of initial join.
+    parse_replication_stream(s, assert, until_vclock_cond)
+    -- End of initial join.
+    parse_replication_stream(s, assert, until_vclock_cond)
+    -- End of final join.
+    local b = parse_replication_stream(s, assert, until_vclock_cond)
+    local expected_vclock = cg.master:get_vclock()
+    expected_vclock[0] = nil
+    t.assert_equals(b[key.VCLOCK], expected_vclock)
+    --
+    -- SUBSCRIBE stage.
+    --
+    local rs_uuid = cg.master:eval('return box.info.replicaset.uuid')
+    write_subscribe(s, version_id, instance_uuid, rs_uuid, b[key.VCLOCK])
+    cg.master:eval('pcall(box.ctl.promote)')
+    parse_replication_stream(s, assert, until_promote_cond)
+end
+
+g.before_each(function(cg)
     cg.master = server:new{alias = 'master'}
     cg.master:start()
     cg.master:exec(function()
@@ -13,40 +118,38 @@ g.before_all(function(cg)
     end)
 end)
 
-g.after_all(function(cg)
+g.after_each(function(cg)
     cg.master:stop()
 end)
 
-local found_local_row = false
-local function process_replication_flow(conn, data)
-    local ok, h = pcall(box.iproto.decode_packet, data)
-    if ok and h.group_id == 1 then
-        found_local_row = true
-    end
+local no_local_rows_versions = {
+    '3.2.2',
+    '2.11.6',
+}
 
-    conn:forward_to_client(data)
+for _, v in ipairs(no_local_rows_versions) do
+    g['test_no_local_rows_are_sent_' .. v] = function(cg)
+        local version_id = box.internal.version_to_id(version(v))
+        test_replication_stream(cg, version_id, function(h)
+            t.assert_not_equals(h[key.GROUP_ID], 1)
+        end)
+    end
 end
 
-g.test_no_local_rows_are_sent = function(cg)
-    local proxy_uri = server.build_listen_uri('master_proxy')
-    local replica = server:new{alias = 'replica', box_cfg = {
-        replication = { proxy_uri },
-    }}
-    local server_proxy = proxy:new({
-        client_socket_path = proxy_uri,
-        server_socket_path = cg.master.net_box_uri,
-        process_server = {
-            func = process_replication_flow,
-        },
-    })
+local local_raft_versions = {
+    '3.2.1',
+    '2.11.5'
+}
 
-    server_proxy:start({force = true})
-    replica:start()
-    replica:wait_for_vclock_of(cg.master)
-    cg.master:exec(function() box.ctl.promote() end)
-    replica:wait_for_vclock_of(cg.master)
-    t.assert_equals(found_local_row, false)
-
-    replica:stop()
-    server_proxy:stop()
+for _, v in ipairs(local_raft_versions) do
+    g['test_local_rows_are_sent_' .. v] = function(cg)
+        local version_id = box.internal.version_to_id(version(v))
+        test_replication_stream(cg, version_id, function(h)
+            if h[key.REQUEST_TYPE] == type.RAFT then
+                t.assert_equals(h[key.GROUP_ID], 1)
+            else
+                t.assert_not_equals(h[key.GROUP_ID], 1)
+            end
+        end)
+    end
 end


### PR DESCRIPTION
Commit 7aac790ef3e28 ("relay: send raft requests with GROUP_DEFAULT id") tried to send all raft rows with GROUP_DEFAULT id. However, relay didn't know the version_id of the instance during initial JOIN, so raft state was sent with GROUP_LOCAL id. The test didn't properly work.

This commit fixes relay by setting proper version_id during initial JOIN. The test is also fully rewritten.

Follows up #10727