### PR TITLE
[backport 3.2] replication: do not account booting replicas in sync quorum

### DIFF
--- a/changelogs/unreleased/gh-10760-rcq-booting-replica.md
+++ b/changelogs/unreleased/gh-10760-rcq-booting-replica.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed a bug when master entered read-only mode and couldn't add new replicas
+  to the replica set after replication reconfiguration (gh-10760).

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -2825,6 +2825,7 @@ tx_process_replication(struct cmsg *m)
 	struct iproto_connection *con = msg->connection;
 	struct iostream *io = &con->io;
 	assert(!in_txn());
+	ERROR_INJECT_YIELD(ERRINJ_IPROTO_PROCESS_REPLICATION_DELAY);
 	try {
 		if (tx_check_msg(msg) != 0)
 			diag_raise();

--- a/src/box/replication.cc
+++ b/src/box/replication.cc
@@ -192,10 +192,28 @@ replicaset_sync_quorum(void)
 	}
 }
 
+/**
+ * Replica set configuration state, shared among appliers.
+ */
+struct replicaset_connect_state {
+	/** Number of successfully connected appliers. */
+	int connected;
+	/**
+	 * Number of appliers which were connected to a loading instance. This
+	 * is a subset of \a connected excluded from replicaset_sync_quorum
+	 * calculation.
+	 */
+	int booting;
+	/** Number of appliers that failed to connect. */
+	int failed;
+	/** Signaled when an applier connects or stops. */
+	struct fiber_cond wakeup;
+};
+
 static void
-replicaset_set_sync_quorum(void)
+replicaset_set_sync_quorum(const struct replicaset_connect_state *state)
 {
-	replication_sync_quorum_auto = replicaset.applier.connected;
+	replication_sync_quorum_auto = state->connected - state->booting;
 }
 
 void
@@ -890,24 +908,7 @@ next:
 			replica_delete(replica);
 		}
 	}
-	/*
-	 * Remember how many appliers are connected to check
-	 * replicaset_sync_quorum later on.
-	 */
-	replicaset_set_sync_quorum();
 }
-
-/**
- * Replica set configuration state, shared among appliers.
- */
-struct replicaset_connect_state {
-	/** Number of successfully connected appliers. */
-	int connected;
-	/** Number of appliers that failed to connect. */
-	int failed;
-	/** Signaled when an applier connects or stops. */
-	struct fiber_cond wakeup;
-};
 
 struct applier_on_connect {
 	struct trigger base;
@@ -1006,11 +1007,14 @@ replicaset_is_connected(struct replicaset_connect_state *state,
 	}
 	/* Update connected and failed counters. */
 	state->connected = 0;
+	state->booting = 0;
 	state->failed = 0;
 	for (int i = 0; i < count; i++) {
 		struct applier *applier = appliers[i];
 		if (applier->state == APPLIER_CONNECTED) {
 			state->connected++;
+			if (!applier->ballot.is_booted)
+				state->booting++;
 		} else if (applier->state == APPLIER_STOPPED ||
 			   applier->state == APPLIER_OFF) {
 			state->failed++;
@@ -1040,7 +1044,12 @@ void
 replicaset_connect(const struct uri_set *uris,
 		   bool connect_quorum, bool keep_connect)
 {
+	struct replicaset_connect_state state;
+	memset(&state, 0, sizeof(state));
+	fiber_cond_create(&state.wakeup);
+
 	if (uris->uri_count == 0) {
+		replicaset_set_sync_quorum(&state);
 		/* Cleanup the replica set. */
 		replicaset_update(NULL, 0, false);
 		uri_set_destroy(&replication_uris);
@@ -1095,10 +1104,6 @@ replicaset_connect(const struct uri_set *uris,
 
 	/* Memory for on_state triggers registered in appliers */
 	struct applier_on_connect triggers[VCLOCK_MAX];
-
-	struct replicaset_connect_state state;
-	state.connected = state.failed = 0;
-	fiber_cond_create(&state.wakeup);
 
 	double timeout = replication_connect_timeout;
 
@@ -1161,6 +1166,11 @@ replicaset_connect(const struct uri_set *uris,
 	}
 	triggers_guard.is_active = false;
 
+	/*
+	 * Remember how many appliers are connected to check
+	 * replicaset_sync_quorum later on.
+	 */
+	replicaset_set_sync_quorum(&state);
 	/* Now all the appliers are connected, update the replica set. */
 	replicaset_update(appliers, count, keep_connect);
 	appliers_guard.is_active = false;

--- a/src/lib/core/errinj.h
+++ b/src/lib/core/errinj.h
@@ -102,6 +102,7 @@ struct errinj {
 	_(ERRINJ_IPROTO_DISABLE_ID, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_IPROTO_DISABLE_WATCH, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_IPROTO_FLIP_FEATURE, ERRINJ_INT, {.iparam = -1}) \
+	_(ERRINJ_IPROTO_PROCESS_REPLICATION_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_IPROTO_SET_VERSION, ERRINJ_INT, {.iparam = -1}) \
 	_(ERRINJ_IPROTO_TX_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_IPROTO_WRITE_ERROR_DELAY, ERRINJ_BOOL, {.bparam = false})\

--- a/test/replication-luatest/gh_10087_update_quorum_in_on_commit_trigger_test.lua
+++ b/test/replication-luatest/gh_10087_update_quorum_in_on_commit_trigger_test.lua
@@ -38,21 +38,20 @@ g_three_member_cluster.before_all(function(cg)
     cg.replica_set = replica_set:new{}
     cg.master = cg.replica_set:build_and_add_server{alias = 'master'}
     cg.master:start()
-    cg.replica_to_be_disabled =
-        cg.replica_set:build_and_add_server{alias = 'to_be_disabled',
-                                            box_cfg = {
+    local box_cfg = {
         replication = {
             cg.master.net_box_uri,
             server.build_listen_uri('replica', cg.replica_set.id),
-        },
-    }}
-    cg.replica = cg.replica_set:build_and_add_server{alias = 'replica',
-                                                     box_cfg = {
-        replication = {
-            cg.master.net_box_uri,
             server.build_listen_uri('to_be_disabled', cg.replica_set.id),
         },
-    }}
+        bootstrap_strategy = 'config',
+        bootstrap_leader = cg.master.net_box_uri,
+    }
+    cg.replica_to_be_disabled =
+        cg.replica_set:build_and_add_server{alias = 'to_be_disabled',
+                                            box_cfg = box_cfg}
+    cg.replica = cg.replica_set:build_and_add_server{alias = 'replica',
+                                                     box_cfg = box_cfg}
     cg.replica_set:start()
 
     -- Make `_cluster` space synchronous.

--- a/test/replication-luatest/gh_10088_apply_deletion_of_replica_from_cluster_on_deleted_replica_test.lua
+++ b/test/replication-luatest/gh_10088_apply_deletion_of_replica_from_cluster_on_deleted_replica_test.lua
@@ -86,22 +86,21 @@ g_three_member_cluster.before_each(function(cg)
         replication_synchro_timeout = 120,
     }}
     cg.master:start()
-    cg.replica =
-        cg.replica_set:build_and_add_server{alias = 'replica',
-                                            box_cfg = {
-        replication = {
-            cg.master.net_box_uri,
-            server.build_listen_uri('to_be_deleted', cg.replica_set.id),
-        },
-    }}
-    cg.replica_to_be_deleted =
-        cg.replica_set:build_and_add_server{alias = 'to_be_deleted',
-                                            box_cfg = {
+    local box_cfg = {
         replication = {
             cg.master.net_box_uri,
             server.build_listen_uri('replica', cg.replica_set.id),
+            server.build_listen_uri('to_be_deleted', cg.replica_set.id),
         },
-    }}
+        bootstrap_strategy = 'config',
+        bootstrap_leader = cg.master.net_box_uri,
+    }
+    cg.replica =
+        cg.replica_set:build_and_add_server{alias = 'replica',
+                                            box_cfg = box_cfg}
+    cg.replica_to_be_deleted =
+        cg.replica_set:build_and_add_server{alias = 'to_be_deleted',
+                                            box_cfg = box_cfg}
     cg.replica_set:start()
     cg.replica:wait_for_downstream_to(cg.replica_to_be_deleted)
     cg.replica_to_be_deleted:wait_for_downstream_to(cg.replica)

--- a/test/replication-luatest/gh_10760_connect_quorum_calculation_test.lua
+++ b/test/replication-luatest/gh_10760_connect_quorum_calculation_test.lua
@@ -1,0 +1,68 @@
+local t = require('luatest')
+local server = require('luatest.server')
+local replica_set = require('luatest.replica_set')
+
+local g = t.group()
+
+g.before_each(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.replica_set = replica_set:new{}
+    local box_cfg = {
+        replication_timeout = 0.1,
+        replication = {
+            server.build_listen_uri('master', cg.replica_set.id),
+        },
+    }
+    cg.master = cg.replica_set:build_and_add_server{
+        alias = 'master',
+        box_cfg = box_cfg,
+    }
+    cg.replica = cg.replica_set:build_and_add_server{
+        alias = 'replica',
+        box_cfg = box_cfg,
+    }
+
+    cg.master:start()
+end)
+
+-- Test that not yet joined or booting replicas are not accounted as a quorum to
+-- sync with during master reconfiguration. Otherwise adding new replicas to a
+-- cluster with centralized configuration wouldn't work: master would try to
+-- sync with the not yet joined replicas and enter read-only state, and replicas
+-- wouldn't be able to join due to master being read-only.
+g.test_booting_replica_not_accounted_in_sync_quorum = function(cg)
+    -- Make sure that master is connected to the booting replica and starts
+    -- syncing before replica tries to join.
+    cg.master:exec(function()
+        t.assert(not box.info.ro)
+        box.error.injection.set('ERRINJ_IPROTO_PROCESS_REPLICATION_DELAY', true)
+    end)
+    local cfg = {
+        replication = {
+            server.build_listen_uri('master', cg.replica_set.id),
+            server.build_listen_uri('replica', cg.replica_set.id),
+        },
+        replication_connect_timeout = 1000,
+    }
+    cg.master:exec(function(cfg)
+        require('fiber').new(function()
+            box.cfg(cfg)
+        end)
+    end, {cfg})
+    cg.replica:start{wait_until_ready = false}
+    t.helpers.retrying({}, function()
+        t.assert(cg.master:grep_log('connected to 2 replicas'))
+    end)
+    cg.master:exec(function()
+        box.error.injection.set('ERRINJ_IPROTO_PROCESS_REPLICATION_DELAY',
+                                false)
+    end)
+    cg.replica:wait_until_ready()
+    t.helpers.retrying({}, function()
+        cg.replica:assert_follows_upstream(cg.master:get_instance_id())
+    end)
+end
+
+g.after_each(function(cg)
+    cg.replica_set:drop()
+end)


### PR DESCRIPTION
With `bootstrap_strategy ~= 'legacy'` all replicas to which a node managed to connect enter the pool of nodes with which the node has to sync before leaving orphan mode.

This leads to inability to add new replicas to the cluster with centralized configuration: if master manages to connect to some of the new replicas before they are joined, it considers them part of sync quorum and enters orphan mode. The nodes cannot be joined, because master is read only, and master remains read only, because it can't sync with a not yet booted node.

Let's fix this and not account connected but not yet booted nodes in sync quorum.

Also fix the gh_10087 and gh_10088 tests. They started failing after the patch because one of the replicas started becoming writable earlier, before the other replica was bootstrapped. This made the other replica occasionally bootstrap from it instead of bootstrapping from master. Such situation was possible even before the patch, if one of the replicas timed out waiting for the other to start, but was really unlikely to happen, so the test wasn't ready for it.

Closes #10760

NO_DOC=bugfix

(cherry picked from commit 89cd7f43fd37e7afa459bf1a8f0e5159085c73ae)