### PR TITLE
config: add on_event callback for roles

### DIFF
--- a/changelogs/unreleased/gh-10538-add-on-event-callback-to-roles.md
+++ b/changelogs/unreleased/gh-10538-add-on-event-callback-to-roles.md
@@ -1,0 +1,3 @@
+## feature/config
+
+* Introduced `on_event` callback for roles (gh-10538).


### PR DESCRIPTION
config: add on_event callback for roles

This patch add `on_event` callback for roles.

Closes #10538
Closes TNTP-225

@TarantoolBot document
Title: `on_event` callback for roles

Roles can now set a `on_event` callback, which will be called
every time a `box.status` system event is broadcasted or the
configuration has been updated (after the `apply` has finished).

`on_event` callbacks are called one after another in the order
the roles are applied (according to their dependencies). Each
event (`box.status` or configuration change) triggers a series
of callbacks, next series (for a new event) will be triggered
after the previous finishes.

`on_event` callbacks are executed inside a `pcall` and if error is
raised, it is logged with 'error' level and the series execution
continues.

It is guaranteed that all of the `on_event` triggers are executed as
part of the configuration process (and 'ready' or 'check_warnings'
status is reached only after all of them are done).

When the callback is called, three arguments are provided,
`on_event(config, key, value)` where:
`config` is the current configuration,
`key` is `'config.apply'` if the callback was trigger by configuration
update, or `'box.status'` if it was triggered by `box.status` system
event.
`value` is the same as in `box.status` system event.

Example usage:

```lua
return {
    name = 'my_role',
    validate = ...,
    apply = ...,
    stop = ...,
    on_event = function(config, key, value)
        local log = require('log')

        log.info('on_event is triggered by ' .. key)
        log.info('is_ro: ' .. value.is_ro)

        local roles_cfg = config:get('roles_cfg')
        roles_cfg['my_role']...
    end,
}
```