### PR TITLE
config: don't fail on lack of sharding.roles

### DIFF
--- a/changelogs/unreleased/config-lack-of-sharding-role.md
+++ b/changelogs/unreleased/config-lack-of-sharding-role.md
@@ -1,0 +1,4 @@
+## bugfix/config
+
+* Don't fail if the `sharding.roles` option is not set for some instances
+  (gh-10458).

--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -179,8 +179,11 @@ function methods.sharding(self)
                 end
                 if is_rebalancer == nil then
                     local roles = self:get('sharding.roles', opts)
-                    for _, role in pairs(roles) do
-                        is_rebalancer = is_rebalancer or role == 'rebalancer'
+                    if roles ~= nil then -- nil or box.NULL
+                        for _, role in pairs(roles) do
+                            is_rebalancer = is_rebalancer or
+                                role == 'rebalancer'
+                        end
                     end
                     if is_rebalancer then
                         table.insert(rebalancers, replicaset_name)


### PR DESCRIPTION
Before this change an instance with enabled sharding role assumes that all the other instances in the cluster have some sharding role enabled or at least an empty list of sharding roles.

This is a bug: a cluster may have instances that have no role in regards to sharding.

Fixes #10458