### PR TITLE
say: inherit log level when printing rate limit warning

### DIFF
--- a/changelogs/unreleased/say-ratelimit-warning-fix.md
+++ b/changelogs/unreleased/say-ratelimit-warning-fix.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Changed the level of the "N messages suppressed" warning logged when
+  Tarantool processes snapshot rows at a high rate from "warn" to "info".

--- a/src/lib/core/say.h
+++ b/src/lib/core/say.h
@@ -453,8 +453,8 @@ enum {
 	int suppressed = 0;						\
 	bool ret = ratelimit_check((rl), ev_monotonic_now(loop()),	\
 				   &suppressed);			\
-	if ((level) >= S_WARN && suppressed > 0)			\
-		say_warn("%d messages suppressed", suppressed);		\
+	if (suppressed > 0)			\
+		say(level, NULL, "%d messages suppressed", suppressed);	\
 	ret;								\
 })
 


### PR DESCRIPTION
`say_info_ratelimited()` logs a warning when it suppresses some messages. This is confusing: we must not alert the user in this case. Let's use the "info" log level instead of "warn".

This removes warnings logged on checkpoint and recovery when Tarantool processes snapshot rows at a high rate.