### PR TITLE
[backport 3.2] test: parallelize config-luatest/compat_test

### DIFF
--- a/test/config-luatest/compat_test.lua
+++ b/test/config-luatest/compat_test.lua
@@ -1,3 +1,5 @@
+-- tags: parallel
+
 local fun = require('fun')
 local compat = require('compat')
 local instance_config = require('internal.config.instance_config')


### PR DESCRIPTION
*(This is a backport of PR #10867 to `release/3.2`.)*

*Once it reaches a timeout on the ASAN job in CI, so I decided to backport it.*

----

It spawns a lot of processes and sometimes hits a test timeout limit on my machine, when run in parallel with other tests.

Also, if I run the single test with the parallelization, the parallel execution reduces time from 45 to 25 seconds.