### PR TITLE
[backport 3.3] config: fix schema:get()/set() changes passed path

### DIFF
--- a/changelogs/unreleased/gh-10855-schema-get-set-changes-path.md
+++ b/changelogs/unreleased/gh-10855-schema-get-set-changes-path.md
@@ -1,0 +1,4 @@
+## bugfix/config
+
+* `schema:get()`/`schema:set()` and `config:get()` no longer changes the
+  passed path if it is passed as a table (gh-10855).

--- a/src/box/lua/config/utils/schema.lua
+++ b/src/box/lua/config/utils/schema.lua
@@ -895,8 +895,9 @@ function methods.get(self, data, path)
     local ctx = walkthrough_start(self, {
         -- The `path` field is already in the context and it means
         -- the passed path. Let's name the remaining path as
-        -- `journey`.
-        journey = path,
+        -- `journey` and perform a shallow copy of it since
+        -- we're changing it.
+        journey = table.copy(path),
     })
     return get_impl(schema, data, ctx)
 end
@@ -1071,8 +1072,9 @@ function methods.set(self, data, path, rhs)
     local ctx = walkthrough_start(self, {
         -- The `path` field is already in the context and it means
         -- the passed path. Let's name the remaining path as
-        -- `journey`.
-        journey = path,
+        -- `journey` and perform a shallow copy of it since
+        -- we're changing it.
+        journey = table.copy(path),
     })
     return set_impl(schema, data, rhs, ctx)
 end

--- a/test/config-luatest/config_test.lua
+++ b/test/config-luatest/config_test.lua
@@ -2034,3 +2034,22 @@ g.test_do_no_revoke_user_privs = function(g)
         t.assert_equals(actual_privs, exp)
     end)
 end
+
+-- This scenario has been broken before gh-10855.
+-- Before gh-10855 config:get() used to change the passed path
+-- if it's been passed as a table.
+g.test_get_not_changes_path = function(g)
+    local verify = function()
+        local config = require('config')
+        local path = {'fiber', 'slice'}
+
+        -- The result of config:get() isn't tested.
+        local _ = config:get(path)
+        -- Make sure the passed path hasn't changed.
+        t.assert_equals(path, {'fiber', 'slice'})
+
+    end
+    helpers.success_case(g, {
+        verify = verify,
+    })
+end

--- a/test/config-luatest/schema_test.lua
+++ b/test/config-luatest/schema_test.lua
@@ -1344,6 +1344,21 @@ g.test_get_index_scalar = function()
     end)
 end
 
+-- This scenario has been broken before gh-10855.
+-- Before gh-10855 schema:get() used to change the passed path
+-- if it's been passed as a table.
+g.test_get_not_changes_path = function()
+    local s = schema.new('myschema', schema.record({
+        foo = schema.scalar({type = 'number'}),
+    }))
+
+    local path = {'foo'}
+    -- The result of schema:get() isn't tested.
+    s:get({foo = 5}, path)
+    -- Make sure the passed path hasn't changed.
+    t.assert_equals(path, {'foo'})
+end
+
 -- }}} <schema object>:get()
 
 -- {{{ <schema object>:set()
@@ -1779,6 +1794,21 @@ g.test_set_invalid_rhs = function()
 
     -- Verify that the data remains unchanged after an error.
     t.assert_equals(data, {})
+end
+
+-- This scenario has been broken before gh-10855.
+-- Before gh-10855 schema:set() used to change the passed path
+-- if it's been passed as a table.
+g.test_set_not_changes_path = function()
+    local s = schema.new('myschema', schema.record({
+        foo = schema.scalar({type = 'number'}),
+    }))
+
+    local path = {'foo'}
+    -- The result of schema:set() isn't tested.
+    s:set({foo = 5}, path, 6)
+    -- Make sure the passed path hasn't changed.
+    t.assert_equals(path, {'foo'})
 end
 
 -- }}} <schema object>:set()


### PR DESCRIPTION
*(This is a backport of PR #10886 to `release/3.3`, a future `3.3.1` release.)*

----

This patch makes `schema:get()`, `schema:set()` and `config:get()` not change the passed path argument when it is a table.

The problem was in the way the walkthrough process is set up during the `schema:get()` and `schema:set()` method execution. These methods used `walkthrough_start()` performing a shallow copy of the passed option table containing the information on the desired path. The value of the path was modified during the walkthrough itself. The patch makes the methods perform a shallow copy of the path field. It also fixes `config:get()` since it's internally uses `schema:get()`.

This is how broken scenario could be reproduced when using `config:get()`:
```
tarantool> config = require('config')
tarantool> path = {'fiber', 'slice'}
tarantool> config:get(path)
---
- err: 1
  warn: 0.5
...

tarantool> path
---
- []
...
```

Closes #10855