### PR TITLE
vinyl: abort readers on DDL

### DIFF
--- a/changelogs/unreleased/gh-10786-abort-vinyl-readers-on-ddl.md
+++ b/changelogs/unreleased/gh-10786-abort-vinyl-readers-on-ddl.md
@@ -1,0 +1,5 @@
+## bugfix/vinyl
+
+* A DDL operation altering a space now aborts all transactions reading
+  from the altered space. This should fix use-after-free and non-repeatable
+  read issues that could occur during a DDL operation (gh-10707, gh-10786).

--- a/src/box/vy_tx.c
+++ b/src/box/vy_tx.c
@@ -1245,6 +1245,19 @@ vy_tx_manager_abort_writers_for_ro(struct vy_tx_manager *xm)
 }
 
 void
+vy_lsm_abort_readers(struct vy_lsm *lsm)
+{
+	struct vy_lsm_read_set_iterator it;
+	vy_lsm_read_set_ifirst(&lsm->read_set, &it);
+	struct vy_read_interval *interval;
+	while ((interval = vy_lsm_read_set_inext(&it)) != NULL) {
+		struct vy_tx *tx = interval->tx;
+		if (tx->state == VINYL_TX_READY)
+			vy_tx_abort(tx);
+	}
+}
+
+void
 vy_txw_iterator_open(struct vy_txw_iterator *itr,
 		     struct vy_txw_iterator_stat *stat,
 		     struct vy_tx *tx, struct vy_lsm *lsm,

--- a/src/box/vy_tx.h
+++ b/src/box/vy_tx.h
@@ -343,6 +343,12 @@ vy_tx_manager_abort_writers_for_ddl(struct vy_tx_manager *xm,
 void
 vy_tx_manager_abort_writers_for_ro(struct vy_tx_manager *xm);
 
+/**
+ * Abort all transactions reading from the given LSM tree.
+ */
+void
+vy_lsm_abort_readers(struct vy_lsm *lsm);
+
 /** Initialize a tx object. */
 void
 vy_tx_create(struct vy_tx_manager *xm, struct vy_tx *tx);

--- a/test/vinyl/errinj_ddl.result
+++ b/test/vinyl/errinj_ddl.result
@@ -738,7 +738,7 @@ s:drop();
 ...
 ch:get();
 ---
-- [1]
+- Transaction has been aborted by conflict
 ...
 box.error.injection.set('ERRINJ_VY_READ_PAGE_TIMEOUT', 0);
 ---


### PR DESCRIPTION
When a space is altered, we must abort all transactions writing to the space because otherwise they would access a stale pointer stored in `txn_stmt::space` on commit. We do that in `vinyl_space_invalidate()`, which is called when a space is removed from the cache. There we iterate over all writing transactions and abort those of them whose write sets contain statements for the altered space, see commit c602cc2c82963 ("vinyl: abort rw transactions before DDL"). To handle transactions that are currently waiting for a disk read before they can create a write statement (such as an update, which needs to read the old tuple first), we also store the current space when we begin a statement, see commit 4f62ec2102f49 ("vinyl: make tx_manager_abort_writers_for_ddl more thorough").

However, those checks actually aren't enough: a transaction statement may turn out to be a no-op, for example, if it updates a non-existent key, in which case it isn't added to the transaction write set. If we don't abort such a statement, we'll get a use-after-free bug when we try to commit it. Let's handle this issue by aborting all transactions that read from the altered space. This would also be consistent with the memtx engine.

Closes #10707
Closes #10786