### PR TITLE
`box.ctl.on_replication_split_brain_rollback` event

### DIFF
--- a/changelogs/unreleased/gh-10460-on_replication_split_brain_rollback-event.md
+++ b/changelogs/unreleased/gh-10460-on_replication_split_brain_rollback-event.md
@@ -1,0 +1,6 @@
+## feature/box
+
+* Added a new `box.ctl.on_replication_split_brain_rollback` event that occurs
+  when asynchronously committed transaction stored in the synchronous
+  transaction queue get rolled back by a PROMOTE request to prevent split brain
+  (gh-10460).

--- a/changelogs/unreleased/gh-11053-gc_consumers-record-lost-after-promote-and-restart.md
+++ b/changelogs/unreleased/gh-11053-gc_consumers-record-lost-after-promote-and-restart.md
@@ -1,0 +1,5 @@
+## bugfix/box
+
+* Fixed a bug when a record could be lost from the `_gc_consumers` space after
+  receiving a promote request from another instance and restarting the current
+  instance (gh-11053).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -831,8 +831,8 @@ wal_stream_apply_dml_row(struct wal_stream *stream, struct xrow_header *row)
 	assert(txn != NULL);
 	if (!row->is_commit)
 		return 0;
-	if (row->wait_ack)
-		box_txn_make_sync();
+	txn_set_xrow_flags(row->flags);
+	txn_recovery_set_limbo_policy();
 	/*
 	 * For fully local transactions the TSN check won't work like for global
 	 * transactions, because it is not known if there are global rows until

--- a/src/box/lua/call.c
+++ b/src/box/lua/call.c
@@ -52,6 +52,7 @@
 #include "box/session.h"
 #include "box/iproto_features.h"
 #include "core/mp_ctx.h"
+#include "box/tuple.h"
 
 /**
  * Handlers identifiers to obtain lua_Cfunction reference from

--- a/src/box/lua/tuple.c
+++ b/src/box/lua/tuple.c
@@ -487,15 +487,6 @@ luamp_encode_tuple_with_ctx(struct lua_State *L, struct luaL_serializer *cfg,
 	return 0;
 }
 
-void
-tuple_to_mpstream(struct tuple *tuple, struct mpstream *stream)
-{
-	size_t bsize = box_tuple_bsize(tuple);
-	char *ptr = mpstream_reserve(stream, bsize);
-	box_tuple_to_buf(tuple, ptr, bsize);
-	mpstream_advance(stream, bsize);
-}
-
 /**
  * Convert a tuple into lua table. Named fields are stored as
  * {name = value} pairs. Not named fields are stored as

--- a/src/box/lua/tuple.h
+++ b/src/box/lua/tuple.h
@@ -152,9 +152,6 @@ luamp_encode_tuple(struct lua_State *L, struct luaL_serializer *cfg,
 }
 
 void
-tuple_to_mpstream(struct tuple *tuple, struct mpstream *stream);
-
-void
 box_lua_tuple_init(struct lua_State *L);
 
 #if defined(__cplusplus)

--- a/src/box/tuple.c
+++ b/src/box/tuple.c
@@ -37,6 +37,7 @@
 #include "small/small.h"
 #include "xrow_update.h"
 #include "coll_id_cache.h"
+#include "mpstream/mpstream.h"
 
 static struct mempool tuple_iterator_pool;
 static struct small_alloc runtime_alloc;
@@ -715,6 +716,15 @@ box_tuple_to_buf(box_tuple_t *tuple, char *buf, size_t size)
 {
 	assert(tuple != NULL);
 	return tuple_to_buf(tuple, buf, size);
+}
+
+void
+tuple_to_mpstream(struct tuple *tuple, struct mpstream *stream)
+{
+	size_t bsize = box_tuple_bsize(tuple);
+	char *ptr = mpstream_reserve(stream, bsize);
+	box_tuple_to_buf(tuple, ptr, bsize);
+	mpstream_advance(stream, bsize);
 }
 
 box_tuple_format_t *

--- a/src/box/tuple.h
+++ b/src/box/tuple.h
@@ -1523,6 +1523,12 @@ ssize_t
 tuple_to_buf(struct tuple *tuple, char *buf, size_t size);
 
 /**
+ * Serialize a tuple to a MsgPack stream.
+ */
+void
+tuple_to_mpstream(struct tuple *tuple, struct mpstream *stream);
+
+/**
  * Amount of memory allocated on runtime arena for tuples.
  *
  * This metric disregards the internal fragmentation: it does not

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -1444,6 +1444,17 @@ txn_set_xrow_flags(uint8_t xrow_flags)
 	txn->flags |= flags_map[xrow_flags & IPROTO_FLAG_WAIT_ACK];
 }
 
+void
+txn_recovery_set_limbo_policy(void)
+{
+	struct txn *txn = in_txn();
+	if (!txn)
+		return;
+	if (!txn_has_flag(txn, TXN_WAIT_SYNC) &&
+	    !txn_has_flag(txn, TXN_WAIT_ACK))
+		txn_set_flags(txn, TXN_FORCE_ASYNC);
+}
+
 /** Wait for a linearization point for a transaction. */
 static int
 txn_make_linearizable(struct txn *txn)

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -1421,6 +1421,12 @@ box_txn_set_timeout(double timeout)
 void
 box_txn_make_sync(void)
 {
+	txn_set_xrow_flags(IPROTO_FLAG_WAIT_ACK);
+}
+
+void
+txn_set_xrow_flags(uint8_t xrow_flags)
+{
 	struct txn *txn = in_txn();
 	/*
 	 * Do nothing if transaction is not started,
@@ -1429,7 +1435,13 @@ box_txn_make_sync(void)
 	if (!txn)
 		return;
 
-	txn_set_flags(txn, TXN_WAIT_ACK);
+	const uint8_t flags_map[] = {
+		[IPROTO_FLAG_WAIT_SYNC] = TXN_WAIT_SYNC,
+		[IPROTO_FLAG_WAIT_ACK] = TXN_WAIT_ACK,
+	};
+
+	txn->flags |= flags_map[xrow_flags & IPROTO_FLAG_WAIT_SYNC];
+	txn->flags |= flags_map[xrow_flags & IPROTO_FLAG_WAIT_ACK];
 }
 
 /** Wait for a linearization point for a transaction. */

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -96,7 +96,9 @@ enum txn_flag {
 	 * A transaction may be forced to be asynchronous, not
 	 * wait for any ACKs, and not depend on prepending sync
 	 * transactions. This happens in a few special cases. For
-	 * example, when applier receives snapshot from master.
+	 * example, when applier receives snapshot from master. This also
+	 * happens during recovery of all transactions that did not go through
+	 * the limbo at commit time.
 	 */
 	TXN_FORCE_ASYNC = 0x40,
 	/**
@@ -572,6 +574,12 @@ txn_set_flags(struct txn *txn, unsigned int flags)
  */
 void
 txn_set_xrow_flags(uint8_t xrow_flags);
+
+/**
+ * Set the limbo policy for recovering the transaction.
+ */
+void
+txn_recovery_set_limbo_policy(void);
 
 static inline void
 txn_clear_flags(struct txn *txn, unsigned int flags)

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -567,6 +567,12 @@ txn_set_flags(struct txn *txn, unsigned int flags)
 	txn->flags |= flags;
 }
 
+/**
+ * Set flags from xrow on the transaction.
+ */
+void
+txn_set_xrow_flags(uint8_t xrow_flags);
+
 static inline void
 txn_clear_flags(struct txn *txn, unsigned int flags)
 {

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -269,6 +269,12 @@ struct txn_limbo {
 	 * `confirmed_lsn`.
 	 */
 	struct fiber *worker;
+	/**
+	 * Event that occurs when an asynchronously committed synchronous
+	 * transaction gets rolled back by a PROMOTE request to prevent a split
+	 * brain.
+	 */
+	struct event *on_split_brain_rollback;
 };
 
 /**

--- a/test/replication-luatest/gh_11053_gc_consumer_record_lost_after_promote_and_restart_test.lua
+++ b/test/replication-luatest/gh_11053_gc_consumer_record_lost_after_promote_and_restart_test.lua
@@ -1,0 +1,80 @@
+local t = require('luatest')
+local replica_set = require('luatest.replica_set')
+local server = require('luatest.server')
+
+local g = t.group()
+
+g.before_each(function(cg)
+    cg.replica_set = replica_set:new{}
+    cg.box_cfg = {
+        replication = {
+            server.build_listen_uri('master', cg.replica_set.id),
+            server.build_listen_uri('replica', cg.replica_set.id),
+        },
+        replication_timeout = 0.1,
+        replication_synchro_timeout = 120,
+        replication_synchro_quorum = 4,
+    }
+    cg.master = cg.replica_set:build_and_add_server{
+        alias = 'master',
+        box_cfg = cg.box_cfg,
+    }
+    cg.replica = cg.replica_set:build_and_add_server{
+        alias = 'replica',
+        box_cfg = cg.box_cfg,
+    }
+    cg.replica_set:start()
+    cg.replica_set:wait_for_fullmesh()
+    cg.master:exec(function()
+        box.schema.space.create('s', {is_sync = true}):create_index('p')
+        box.ctl.promote()
+    end)
+    cg.master:wait_for_downstream_to(cg.replica)
+end)
+
+g.after_each(function(cg)
+    cg.replica_set:drop()
+end)
+
+g.test_gc_consumer_record_not_lost_after_promote_and_restart = function(cg)
+    -- Simulate network partitioning.
+    cg.replica:update_box_cfg{replication = ''}
+    -- Submit a synchronous transaction while being partitioned from replica.
+    cg.master:exec(function()
+        box.atomic({wait = 'submit'}, function() box.space.s:replace{0} end)
+        t.assert_equals(box.info.synchro.queue.len, 1)
+        t.assert_equals(box.space._gc_consumers:len(), 1)
+    end)
+    -- Join a new replica.
+    cg.new_replica = cg.replica_set:build_and_add_server{
+        alias = 'new_replica',
+        box_cfg = cg.box_cfg,
+    }
+    -- The join cannot be processed completely because we have a pending
+    -- transaction in the synchronous queue.
+    cg.new_replica:start({wait_until_ready = false})
+    -- Wait for the new replica's `_gc_consumer` record to appear on the master.
+    cg.master:exec(function()
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.space._gc_consumers:len(), 2)
+        end)
+    end)
+    -- Promote the partitioned replica.
+    cg.replica:exec(function()
+        box.ctl.promote()
+    end)
+    -- Wait for the old master to receive promote from the partitioned replica.
+    cg.master:exec(function(replica_id)
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.synchro.queue.owner, replica_id)
+        end)
+        t.assert_equals(box.info.synchro.queue.len, 0)
+    end, {cg.replica:get_instance_id()})
+    -- Restart the old master.
+    cg.master:restart()
+    -- Check that the new replica's `_gc_consumer` record is still present on
+    -- the old master.
+    cg.master:exec(function()
+        t.assert_equals(box.space._gc_consumers:len(), 2)
+    end)
+end

--- a/test/replication-luatest/on_replication_split_brain_rollback_event_test.lua
+++ b/test/replication-luatest/on_replication_split_brain_rollback_event_test.lua
@@ -1,0 +1,503 @@
+local t = require('luatest')
+local server = require('luatest.server')
+local replica_set = require('luatest.replica_set')
+
+local g = t.group()
+
+g.before_each(function(cg)
+    cg.replica_set = replica_set:new{}
+    cg.box_cfg = {
+        replication = {
+            server.build_listen_uri('master', cg.replica_set.id),
+            server.build_listen_uri('replica', cg.replica_set.id),
+        },
+        replication_timeout = 0.1,
+        replication_synchro_timeout = 120,
+        replication_synchro_quorum = 3,
+    }
+    cg.master = cg.replica_set:build_and_add_server{
+        alias = 'master',
+        box_cfg = cg.box_cfg,
+    }
+    cg.replica = cg.replica_set:build_and_add_server{
+        alias = 'replica',
+        box_cfg = cg.box_cfg,
+    }
+    cg.replica_set:start()
+    cg.replica_set:wait_for_fullmesh()
+    cg.master:exec(function()
+        rawset(_G, 'trigger', require('trigger'))
+        rawset(_G, 'trigger_ok', false)
+        local event = 'box.ctl.on_replication_split_brain_rollback'
+        local body = 'function() rawset(_G, "trigger_called", true) end'
+        box.schema.func.create('f', {body = body, trigger = event})
+        box.schema.space.create('a', {is_sync = false}):create_index('p')
+        box.schema.space.create('s', {is_sync = true}):create_index('p')
+        box.schema.space.create('l', {is_local = true}):create_index('p')
+        box.ctl.promote()
+    end)
+    cg.master:wait_for_downstream_to(cg.replica)
+end)
+
+g.after_each(function(cg)
+    cg.replica_set:drop()
+end)
+
+local function partition_server(s)
+    s:exec(function()
+        box.cfg{replication = ''}
+    end)
+end
+
+local function cause_split_brain(master, replica)
+    partition_server(replica)
+    master:exec(function()
+        box.atomic({wait = 'submit'}, function() box.space.s:replace{0} end)
+        t.assert_equals(box.info.synchro.queue.len, 1)
+    end)
+    replica:exec(function()
+        box.ctl.promote()
+    end)
+end
+
+local function check_promote_from_partitioned_server(partitioned, master,
+                                                     replication)
+    partitioned:exec(function()
+        box.ctl.promote()
+    end)
+    master:exec(function()
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.synchro.queue.len, 0)
+        end)
+        t.assert(_G.trigger_ok)
+    end)
+    partitioned:exec(function(replication)
+        box.cfg{replication = replication}
+    end, {replication})
+    master:exec(function()
+        box.ctl.promote()
+    end)
+    master:wait_for_downstream_to(partitioned)
+end
+
+local function test_stmt(cg, stmt)
+    partition_server(cg.replica)
+    cg.master:exec(function(stmt)
+        box.atomic({wait = 'submit'}, function()
+            box.space.s[stmt.request](box.space.s, stmt.arg, stmt.ops)
+        end)
+        t.assert_equals(box.info.synchro.queue.len, 1)
+        local event = 'box.ctl.on_replication_split_brain_rollback'
+        _G.trigger.set(event, 't', _G.generate_trigger_test_case(stmt))
+    end, {stmt})
+    check_promote_from_partitioned_server(cg.replica, cg.master,
+                                          cg.box_cfg.replication)
+end
+
+local function test_several_stmts(cg)
+    partition_server(cg.replica)
+    cg.master:exec(function()
+        box.atomic({wait = 'submit'}, function()
+            box.space.s:replace{0}
+            box.space.s:replace{0}
+        end)
+        t.assert_equals(box.info.synchro.queue.len, 1)
+        local event = 'box.ctl.on_replication_split_brain_rollback'
+        local stmt = {request = 'replace', arg = {0}, ops = nil,
+                      old_tuple = nil, new_tuple = {0}}
+        _G.trigger.set(event, 't', _G.generate_trigger_test_case(stmt, 2))
+    end)
+    check_promote_from_partitioned_server(cg.replica, cg.master,
+                                          cg.box_cfg.replication)
+end
+
+g.before_test('test_different_stmts', function(cg)
+    cg.master:exec(function()
+        rawset(_G, 'generate_trigger_test_case',
+            function(stmt, n_stmts)
+                return function(it)
+                    n_stmts = n_stmts ~= nil and n_stmts or 1
+                    local counter = 1
+                    for obj in it() do
+                        _G.trigger_ok = pcall(function()
+                            local meta = obj.meta
+                            local rid = meta.replica_id
+                            local lsn = meta.lsn
+                            local term = meta.term
+                            local sid = obj.statement.space_id
+                            local op_type = obj.statement.op_type
+                            local arg
+                            if stmt.request == "replace" or
+                               stmt.request == "insert" or
+                               stmt.request == "upsert" then
+                                arg = obj.statement.tuple
+                                t.assert_equals(obj.statement.key, nil)
+                            else
+                                arg = obj.statement.key
+                            end
+                            local ops
+                            if stmt.request == "update" then
+                                ops = obj.statement.tuple
+                                t.assert_equals(obj.statement.ops, nil)
+                            else
+                                ops = obj.statement.ops
+                            end
+                            local old_tuple = obj.statement.old_tuple
+                            local new_tuple = obj.statement.new_tuple
+
+                            t.assert_equals(term, box.info.synchro.queue.term)
+                            t.assert_equals(rid, box.info.id)
+                            if counter == n_stmts then
+                               t.assert_equals(lsn, box.info.lsn)
+                            end
+                            t.assert_equals(sid, box.space.s.id)
+                            t.assert_equals(op_type, stmt.request:upper())
+                            t.assert_equals(arg, stmt.arg)
+                            if stmt.ops ~= nil then
+                                t.assert_equals(ops, stmt.ops)
+                            end
+                            if counter == 1 then
+                                t.assert_equals(old_tuple, stmt.old_tuple)
+                            else
+                                t.assert_equals(old_tuple, arg)
+                            end
+                            t.assert_equals(new_tuple, stmt.new_tuple)
+                            counter = counter + 1
+                        end)
+                    end
+                    t.assert_equals(n_stmts, counter - 1)
+                end
+            end)
+        box.cfg{replication_synchro_quorum = 'N/2 + 1'}
+        -- Add a tuple to test `update` and `upsert` requests.
+        box.space.s:replace{777, 0}
+        box.cfg{replication_synchro_quorum = 3}
+    end)
+end)
+
+-- Test that the event iterator returns correct information for different
+-- transaction statements.
+g.test_different_stmts = function(cg)
+    local stmts = {
+        {request = 'replace', arg = {0}, ops = nil,
+         old_tuple = nil, new_tuple = {0}},
+        {request = 'replace', arg = {777, 1}, ops = nil,
+         old_tuple = {777, 0}, new_tuple = {777, 1}},
+        {request = 'insert', arg = {0}, ops = nil,
+         old_tuple = nil, new_tuple = {0}},
+        {request = 'delete', arg = {0}, ops = nil,
+         old_tuple = nil, new_tuple = nil},
+        {request = 'delete', arg = {777}, ops = nil,
+         old_tuple = {777, 0}, new_tuple = nil},
+        {request = 'update', arg = {777}, ops = {{'=', 2, 1}},
+         old_tuple = {777, 0}, new_tuple = {777, 1}},
+        {request = 'update', arg = {777}, ops = {{'=', 2, 1}, {'=', 3, 1}},
+         old_tuple = {777, 0}, new_tuple = {777, 1, 1}},
+        {request = 'upsert', arg = {777}, ops = {{'=', 2, 1}},
+         old_tuple = {777, 0}, new_tuple = {777, 1}},
+        {request = 'upsert', arg = {0}, ops = {{'=', 2, 1}},
+         old_tuple = nil, new_tuple = {0}},
+    }
+    for _, stmt in ipairs(stmts) do
+       test_stmt(cg, stmt)
+    end
+
+    test_several_stmts(cg)
+end
+
+-- Test that the trigger does not fire during recovery.
+g.test_recovery = function(cg)
+    cause_split_brain(cg.master, cg.replica)
+    cg.master:exec(function()
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.synchro.queue.len, 0)
+        end)
+        t.assert(_G.trigger_called)
+    end)
+    cg.master:restart()
+    cg.master:exec(function()
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.synchro.queue.len, 0)
+        end)
+        t.assert_not(rawget(_G, 'trigger_called'))
+    end)
+end
+
+-- Test that the trigger is fired for an asynchronously committed asynchronous
+-- transaction.
+g.test_async_committed_async_tx_in_limbo = function(cg)
+    partition_server(cg.replica)
+    cg.master:exec(function()
+        require('fiber').create(function()
+            box.space.s:replace{0}
+        end)
+        box.atomic({wait = 'submit'}, function() box.space.a:replace{0} end)
+        t.assert_equals(box.info.synchro.queue.len, 2)
+    end)
+    cg.replica:exec(function()
+        box.ctl.promote()
+    end)
+    cg.master:exec(function()
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.synchro.queue.len, 0)
+        end)
+        t.assert(_G.trigger_called)
+    end)
+end
+
+-- Test that the trigger does not fire for synchronously committed synchronous
+-- transactions.
+g.test_sync_committed_sync_tx = function(cg)
+    partition_server(cg.replica)
+    cg.master:exec(function()
+        require('fiber').create(function()
+            box.space.s:replace{0}
+        end)
+        t.assert_equals(box.info.synchro.queue.len, 1)
+    end)
+    cg.replica:exec(function()
+        box.ctl.promote()
+    end)
+    cg.master:exec(function()
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.synchro.queue.len, 0)
+        end)
+        t.assert_not(rawget(_G, 'trigger_called'))
+    end)
+end
+
+g.before_test('test_replica', function(cg)
+    local test_replica_uri =
+        server.build_listen_uri('test_replica', cg.replica_set.id)
+    table.insert(cg.box_cfg.replication, test_replica_uri)
+    cg.test_replica = cg.replica_set:build_and_add_server{
+        alias = 'test_replica',
+        box_cfg = cg.box_cfg,
+    }
+    cg.test_replica:start()
+    cg.master:update_box_cfg{replication = cg.box_cfg.replication}
+    cg.replica:update_box_cfg{replication = cg.box_cfg.replication}
+    cg.replica_set:wait_for_fullmesh()
+end)
+
+-- Test that the trigger does not fire on replicas.
+g.test_replica = function(cg)
+    partition_server(cg.replica)
+    cg.master:exec(function()
+        box.atomic({wait = 'submit'}, function() box.space.s:replace{0} end)
+        t.assert_equals(box.info.synchro.queue.len, 1)
+    end)
+    cg.test_replica:exec(function()
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.synchro.queue.len, 1)
+        end)
+    end)
+    cg.replica:exec(function()
+        box.ctl.promote()
+    end)
+    cg.replica:wait_for_downstream_to(cg.test_replica)
+    cg.test_replica:exec(function()
+        t.assert_equals(box.info.synchro.queue.len, 0)
+        t.assert_not(rawget(_G, 'trigger_called'))
+    end)
+end
+
+g.after_test('test_replica', function(cg)
+    cg.test_replica:drop()
+    table.remove(cg.box_cfg.replication)
+end)
+
+g.before_test('test_trigger_failure', function(cg)
+    cg.master:exec(function()
+        local event = 'box.ctl.on_replication_split_brain_rollback'
+        _G.trigger.set(event, 't', function()
+            rawset(_G, 'trigger_called', true)
+            box.space.l:replace{0}
+            error('777')
+        end)
+    end)
+end)
+
+-- Test that the trigger failure causes split brain and rollback of transaction.
+g.test_trigger_failure = function(cg)
+    cause_split_brain(cg.master, cg.replica)
+    cg.master:exec(function(replica_id)
+        t.helpers.retrying({timeout = 120}, function()
+            local upstream = box.info.replication[replica_id].upstream
+            t.assert_equals(upstream.status, 'stopped')
+            local msg = 'Split-Brain discovered: ' ..
+                        'box.ctl.on_split_brain_rollback trigger failed'
+            t.assert_equals(upstream.message, msg)
+        end)
+        t.assert_equals(box.info.synchro.queue.len, 1)
+        t.assert_equals(box.space.l:get{0}, nil)
+        t.assert(_G.trigger_called)
+    end, {cg.replica:get_instance_id()})
+end
+
+g.before_test('test_non_fully_local_txns', function(cg)
+    cg.master:exec(function()
+        local event = 'box.ctl.on_replication_split_brain_rollback'
+        _G.trigger.set(event, 't', function()
+            local msg = "Can't modify data on a read-only instance"
+            _G.trigger_ok = pcall(function()
+                t.assert_error_msg_contains(msg, function()
+                    box.space.a:replace{0}
+                end)
+            end)
+        end)
+    end)
+end)
+
+-- Test that non fully local transactions are forbidden during execution of the
+-- event triggers.
+g.test_non_fully_local_txns = function(cg)
+    cause_split_brain(cg.master, cg.replica)
+    cg.master:exec(function()
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.synchro.queue.len, 0)
+        end)
+        t.assert(_G.trigger_ok)
+    end)
+end
+
+g.before_test('test_fully_local_txn', function(cg)
+    cg.master:exec(function()
+        local event = 'box.ctl.on_replication_split_brain_rollback'
+        _G.trigger.set(event, 't', function()
+            t.assert(box.is_in_txn())
+            box.space.l:replace{0}
+        end)
+    end)
+end)
+
+-- Test that fully local transactions are allowed during execution of the event
+-- triggers.
+g.test_fully_local_txn = function(cg)
+    partition_server(cg.replica)
+    cg.master:exec(function()
+        -- Test that the trigger is called multiple times and can update fully
+        -- local spaces throughout the whole time.
+        box.atomic({wait = 'submit'}, function() box.space.s:replace{0} end)
+        box.atomic({wait = 'submit'}, function() box.space.s:replace{0} end)
+        t.assert_equals(box.info.synchro.queue.len, 2)
+    end)
+    cg.replica:exec(function()
+        box.ctl.promote()
+    end)
+    cg.master:exec(function()
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.synchro.queue.len, 0)
+        end)
+        t.assert_equals(box.space.l:get{0}, {0})
+    end)
+    cg.master:restart()
+    cg.master:exec(function()
+        t.assert_equals(box.info.synchro.queue.len, 0)
+        t.assert_equals(box.space.l:get{0}, {0})
+    end)
+end
+
+g.before_test('test_explicit_commit', function(cg)
+    cg.master:exec(function()
+        local event = 'box.ctl.on_replication_split_brain_rollback'
+        _G.trigger.set(event, 't', function()
+            box.space.l:replace{0}
+            box.commit()
+        end)
+    end)
+end)
+
+-- Test that the explicit commit of the transaction is handled correctly.
+g.test_explicit_commit = function(cg)
+    cause_split_brain(cg.master, cg.replica)
+    cg.master:exec(function()
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.synchro.queue.len, 0)
+        end)
+        t.assert_equals(box.space.l:get{0}, {0})
+    end)
+    cg.master:restart()
+    cg.master:exec(function()
+        t.assert_equals(box.info.synchro.queue.len, 0)
+        t.assert_equals(box.space.l:get{0}, {0})
+    end)
+end
+
+g.before_test('test_implicit_commit_failure', function(cg)
+    cg.master:exec(function()
+        local event = 'box.ctl.on_replication_split_brain_rollback'
+        _G.trigger.set(event, 't', function()
+            box.error.injection.set('ERRINJ_WAL_IO', true)
+            box.space.l:replace{0}
+            box.on_rollback(function()
+                box.error.injection.set('ERRINJ_WAL_IO', false)
+            end)
+        end)
+    end)
+end)
+
+-- Test that failure to implicitly commit a pending transaction after execution
+-- of the event triggers finishes caused split brain.
+g.test_implicit_commit_failure = function(cg)
+    t.tarantool.skip_if_not_debug()
+
+    cause_split_brain(cg.master, cg.replica)
+    cg.master:exec(function(replica_id)
+        t.helpers.retrying({timeout = 120}, function()
+            local upstream = box.info.replication[replica_id].upstream
+            t.assert_equals(upstream.status, 'stopped')
+            local msg = 'Failed to write to disk'
+            t.assert_equals(upstream.message, msg)
+        end)
+        t.assert_equals(box.info.synchro.queue.len, 1)
+    end, {cg.replica:get_instance_id()})
+end
+
+g.before_test('test_second_tx_failure', function(cg)
+    cg.master:exec(function()
+        local event = 'box.ctl.on_replication_split_brain_rollback'
+        _G.trigger.set(event, 't', function()
+            box.commit()
+            _G.trigger_ok = pcall(function() box.space.l:replace{0} end)
+        end)
+    end)
+end)
+
+-- Test that the second transaction started in the trigger will fail, since it
+-- won't have the `TXN_FORCE_ASYNC` flag set.
+g.test_second_tx_failure = function(cg)
+    cause_split_brain(cg.master, cg.replica)
+    cg.master:exec(function()
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.synchro.queue.len, 0)
+        end)
+        t.assert_not(_G.trigger_ok)
+    end)
+end
+
+g.before_test('test_second_tx_implicit_commit_failure', function(cg)
+    cg.master:exec(function()
+        local event = 'box.ctl.on_replication_split_brain_rollback'
+        _G.trigger.set(event, 't', function()
+            box.commit()
+            box.begin()
+            box.space.l:replace{0}
+        end)
+    end)
+end)
+
+-- Test that the implicit commit of the second transaction started in the
+-- trigger will fail, since it won't have the `TXN_FORCE_ASYNC` flag set.
+g.test_second_tx_implicit_commit_failure = function(cg)
+    cause_split_brain(cg.master, cg.replica)
+    cg.master:exec(function(replica_id)
+        t.helpers.retrying({timeout = 120}, function()
+            local upstream = box.info.replication[replica_id].upstream
+            t.assert_equals(upstream.status, 'loading')
+            local msg = 'A rollback for a synchronous transaction is received'
+            t.assert_equals(upstream.message, msg)
+        end)
+        t.assert_equals(box.info.synchro.queue.len, 1)
+    end, {cg.replica:get_instance_id()})
+end


### PR DESCRIPTION
This patch set adds a new `box.ctl.on_replication_split_brain_rollback` event that occurs when an asynchronously committed synchronous transaction gets rolled back by a PROMOTE request to prevent a split brain.

Closes #10460
Closes #11053