### PR TITLE
lua: fix flaky custom allocator test

### DIFF
--- a/test/app-luatest/alloc_test.lua
+++ b/test/app-luatest/alloc_test.lua
@@ -42,8 +42,13 @@ g.test_used_and_unused = function()
     local function test(amount)
         alloc.setlimit(amount)
         t.assert_equals(collectgarbage('count'), alloc.used() / 1024)
-        t.assert_equals(amount / 1024 - collectgarbage('count'),
-                        alloc.unused() / 1024)
+        -- Check amount of the free memory provided by the
+        -- unused() function is close to the calculated using
+        -- the builtin collectgarbage() function.
+        --
+        -- Allow some margin of 16Kb to avoid false negatives.
+        t.assert_almost_equals(amount / 1024 - collectgarbage('count'),
+                               alloc.unused() / 1024, 16)
         t.assert_equals(alloc.used() + alloc.unused(), alloc.getlimit())
     end
 


### PR DESCRIPTION
This patch fixes the flaky test verifying `used()` and `unused()` functions of the `internal.alloc` module in the `alloc_test` suite.

The test compares the value of the unused memory with the one calculated by the builtin Lua functions. This test has been failing on a few coverage workflows. The executed and the real values has been close to each other though not equal. This false negative result likely happens because of the details of the `collectgarbage()` implementation.

This patch fixes it by adding arbitrary margin equal to 16Kb of memory when comparing the value calculated using the LuaJIT call with the one provided by the module function.