### PR TITLE
vinyl: fix abort of writers on DDL

### DIFF
--- a/changelogs/unreleased/gh-10707-fix-vinyl-abort-writers-on-ddl.md
+++ b/changelogs/unreleased/gh-10707-fix-vinyl-abort-writers-on-ddl.md
@@ -1,0 +1,4 @@
+## bugfix/vinyl
+
+* Fixed a use-after-free bug in the transaction manager that could be triggered
+  by a race between DDL and DML operations affecting the same space (gh-10707).

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -2424,7 +2424,7 @@ vinyl_engine_begin(struct engine *engine, struct txn *txn)
 {
 	struct vy_env *env = vy_env(engine);
 	assert(txn->engines_tx[engine->id] == NULL);
-	txn->engines_tx[engine->id] = vy_tx_begin(env->xm, txn->isolation);
+	txn->engines_tx[engine->id] = vy_tx_begin(env->xm, txn);
 	if (txn->engines_tx[engine->id] == NULL)
 		return -1;
 	return 0;
@@ -2516,7 +2516,7 @@ vinyl_engine_begin_statement(struct engine *engine, struct txn *txn)
 	struct vy_tx *tx = txn->engines_tx[engine->id];
 	struct txn_stmt *stmt = txn_current_stmt(txn);
 	assert(tx != NULL);
-	return vy_tx_begin_statement(tx, stmt->space, &stmt->engine_savepoint);
+	return vy_tx_begin_statement(tx, &stmt->engine_savepoint);
 }
 
 static void

--- a/src/box/vy_lsm.c
+++ b/src/box/vy_lsm.c
@@ -905,13 +905,8 @@ vy_lsm_set(struct vy_lsm *lsm, struct vy_mem *mem,
 
 	assert(vy_stmt_is_refable(entry.stmt));
 	assert(*region_stmt == NULL || !vy_stmt_is_refable(*region_stmt));
-
-	/* Abort transaction if format was changed by DDL */
-	if (!vy_stmt_is_key(entry.stmt) &&
-	    format_id != tuple_format_id(mem->format)) {
-		diag_set(ClientError, ER_TRANSACTION_CONFLICT);
-		return -1;
-	}
+	assert(vy_stmt_is_key(entry.stmt) ||
+	       format_id == tuple_format_id(mem->format));
 
 	/* Invalidate cache element. */
 	struct vy_entry deleted = vy_entry_none();


### PR DESCRIPTION
When a DDL statement is committed, all transactions writing to the space must be aborted so that they don't access the stale `txn_stmt::space` pointer on commit. In Vinyl we abort all writers from the special `space_invalidate` engine callback, where we iterate over all writing transactions and abort those of them that have a write set entry pointing to the primary key of the invalidated space, see commit d3e1236956515 ("vinyl: abort affected transactions when space is removed from cache"). We also abort transactions that haven't yet created a write set entry because they need to read the disk first, for example, to perform a tuple update, see commit 4f62ec2102f4 ("vinyl: make tx_manager_abort_writers_for_ddl more thorough").

However, as spotted by @drewdzzz, this code doesn't always work as expected. The problem is, unless dropped, the primary index is moved to the new space container so using the primary index stored in the old space container to abort transactions is wrong: there can't possibly be any transactions associated with it. We don't get a crash because we have an extra check in `vy_lsm_set` that aborts the transaction if the space format was updated (it is updated on every space change), see commit e3c5fde4b57cd ("vinyl: fix DDL with active transactions").

Another problem with `space_invalidate` is that it doesn't abort transactions that turned out to be no-op, such as an update of a non-existing key because such transactions don't add any entries to the write set. Still, they must be aborted because they have a `txn_stmt` pointing to the old space. Letting them proceed to commit would result in a use-after-free bug, see #10707.

Let's fix `space_invalidate` by making it iterate over all statements of writing transactions instead of checking their Vinyl write sets. To achieve that, we store a pointer to `struct txn` in `struct vy_tx`. This lets us drop `vy_tx::last_stmt_space` and `vy_tx::isolation` because they can be accessed via `txn`. We also replace the format check in `vy_lsm_set` mentioned above with an assertion because such transactions should be aborted by `space_invalidate` now.

Closes #10707