### PR TITLE
[backport 3.3] config: add error on the same replicaset/instance names

### DIFF
--- a/changelogs/unreleased/gh-10347-proper-instance-duplicates-messages.md
+++ b/changelogs/unreleased/gh-10347-proper-instance-duplicates-messages.md
@@ -1,0 +1,6 @@
+## bugfix/config
+
+* Now Tarantool writes a detailed error message if it finds
+  replica sets with the same names in different groups or instances
+  with the same names in different replica sets in the provided
+  configuration (gh-10347).

--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -878,6 +878,60 @@ local function validate_replicaset_names_are_unique(cconfig)
     end
 end
 
+local function validate_instance_names_are_unique(cconfig)
+    local instance2group = {}
+    local instance2replicaset = {}
+
+    for group_name, group in pairs(cconfig.groups) do
+        for replicaset_name, replicaset in pairs(group.replicasets) do
+            for instance_name, _ in pairs(replicaset.instances) do
+                local dup_group_name = instance2group[instance_name]
+                local dup_replicaset_name =
+                    instance2replicaset[instance_name]
+
+                -- Currently, it's not possible to handle
+                -- groups, replicasets, instances with the same
+                -- names in the same subgroup. E.g. such cluster
+                -- config are considered ok (gh-10917):
+                -- * g-001
+                --   * r-001
+                --     * i-001
+                --     * i-001 (duplicate)
+
+                -- Duplicating instance name is found within
+                -- distinct replicasets.
+                if group_name == dup_group_name then
+                    assert(replicaset_name ~= dup_replicaset_name)
+
+                    error(('found instances with the same name %q in ' ..
+                           'the replicasets %q and %q in the group %q.')
+                          :format(instance_name, dup_replicaset_name,
+                                  replicaset_name, group_name), 0)
+                end
+
+                -- Duplicating instance name is found within
+                -- distinct groups.
+                if dup_group_name ~= nil then
+                    assert(group_name ~= dup_group_name)
+                    assert(replicaset_name ~= dup_replicaset_name)
+
+                    error(('found instances with the same name %q in ' ..
+                           'the replicaset %q in the group %q and in the ' ..
+                           'replicaset %q in the group %q.')
+                           :format(instance_name, dup_replicaset_name,
+                                   dup_group_name, replicaset_name,
+                                   group_name), 0)
+                end
+
+                assert(dup_replicaset_name == nil)
+
+                instance2group[instance_name] = group_name
+                instance2replicaset[instance_name] = replicaset_name
+            end
+        end
+    end
+end
+
 local function new(iconfig, cconfig, instance_name)
     -- Find myself in a cluster config, determine peers in the same
     -- replicaset.
@@ -887,6 +941,7 @@ local function new(iconfig, cconfig, instance_name)
     validate_misplacing(cconfig)
 
     validate_replicaset_names_are_unique(cconfig)
+    validate_instance_names_are_unique(cconfig)
 
     -- Precalculate configuration with applied defaults.
     local iconfig_def = instance_config:apply_default(iconfig)

--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -848,6 +848,36 @@ local function validate_multi_master(iconfig_def, peers)
     end
 end
 
+local function validate_replicaset_names_are_unique(cconfig)
+    local replicaset2group = {}
+
+    for group_name, group in pairs(cconfig.groups) do
+        for replicaset_name, _ in pairs(group.replicasets) do
+            local dup_group_name = replicaset2group[replicaset_name]
+
+            -- Currently, it's not possible to handle
+            -- groups, replicasets, instances with the same
+            -- names in the same subgroup. E.g. such cluster
+            -- config are considered ok (gh-10917):
+            -- * g-001
+            --   * r-001
+            --   * r-001 (duplicate)
+
+            -- Duplicating replicaset name is found within
+            -- distinct groups.
+            if dup_group_name ~= nil then
+                assert(group_name ~= dup_group_name)
+
+                error(('found replicasets with the same name %q in the ' ..
+                       'groups %q and %q.')
+                      :format(replicaset_name, dup_group_name, group_name), 0)
+            end
+
+            replicaset2group[replicaset_name] = group_name
+        end
+    end
+end
+
 local function new(iconfig, cconfig, instance_name)
     -- Find myself in a cluster config, determine peers in the same
     -- replicaset.
@@ -855,6 +885,8 @@ local function new(iconfig, cconfig, instance_name)
     assert(found ~= nil)
 
     validate_misplacing(cconfig)
+
+    validate_replicaset_names_are_unique(cconfig)
 
     -- Precalculate configuration with applied defaults.
     local iconfig_def = instance_config:apply_default(iconfig)

--- a/test/config-luatest/cluster.lua
+++ b/test/config-luatest/cluster.lua
@@ -260,6 +260,7 @@ end
 -- given error message.
 local function startup_error(g, config, exp_err)
     assert(g)  -- temporary stub to not fail luacheck due to unused var
+    assert(type(config) == 'table')
     assert(config._config == nil, "Please provide cbuilder:new():config()")
     -- Prepare a temporary directory and write a configuration
     -- file.

--- a/test/config-luatest/cluster_config_test.lua
+++ b/test/config-luatest/cluster_config_test.lua
@@ -311,3 +311,21 @@ g.test_misplace_option = function(g)
     cluster.startup_error(g, config, "replicaset \"sharding\" should " ..
                                      "include at least one instance.")
 end
+
+g.test_replicasets_with_same_name = function(g)
+    local config = cbuilder:new()
+        :use_group('g-001')
+        :use_replicaset('r-001')
+        :add_instance('i-001', {})
+
+        :use_group('g-002')
+        :use_replicaset('r-001')
+        :add_instance('i-002', {})
+
+        :config()
+
+
+    cluster.startup_error(g, config, 'found replicasets with the same ' ..
+                                     'name "r-001" in the groups ' ..
+                                     '"g-001" and "g-002".')
+end

--- a/test/config-luatest/cluster_config_test.lua
+++ b/test/config-luatest/cluster_config_test.lua
@@ -329,3 +329,37 @@ g.test_replicasets_with_same_name = function(g)
                                      'name "r-001" in the groups ' ..
                                      '"g-001" and "g-002".')
 end
+
+g.test_instances_with_same_name = function(g)
+    local config = cbuilder:new()
+        :use_group('g-001')
+        :use_replicaset('r-001')
+        :add_instance('i-001', {})
+
+        :use_replicaset('r-002')
+        :add_instance('i-001', {})
+
+        :config()
+
+    cluster.startup_error(g, config, 'found instances with the same ' ..
+                                     'name "i-001" in the replicasets ' ..
+                                     '"r-001" and "r-002" in the group ' ..
+                                     '"g-001".')
+
+    config = cbuilder:new()
+        :use_group('g-001')
+        :use_replicaset('r-001')
+        :add_instance('i-001', {})
+
+        :use_group('g-002')
+        :use_replicaset('r-002')
+        :add_instance('i-001', {})
+
+        :config()
+
+    cluster.startup_error(g, config, 'found instances with the same ' ..
+                                     'name "i-001" in the replicaset ' ..
+                                     '"r-001" in the group "g-001" and ' ..
+                                     'in the replicaset "r-002" in the ' ..
+                                     'group "g-002".')
+end


### PR DESCRIPTION
*(This is a backport of PR #10913 to `release/3.3`, a future `3.3.1` release.)*

----

Tarantool couldn't start with more than one group/replicaset/instance with the same name. Applying cluster configuration with name duplicates results with failed checks during the config application and violated constraints w/o proper error message.

This patchset makes Tarantool throw proper error messages when it has replicasets with the same name in different groups or instances with the same names in different replicasets in the cluster configuration.

Closes #10347