### PR TITLE
[backport 3.2] config: add error on the same replicaset/instance names

### DIFF
--- a/changelogs/unreleased/gh-10347-proper-instance-duplicates-messages.md
+++ b/changelogs/unreleased/gh-10347-proper-instance-duplicates-messages.md
@@ -1,0 +1,6 @@
+## bugfix/config
+
+* Now Tarantool writes a detailed error message if it finds
+  replica sets with the same names in different groups or instances
+  with the same names in different replica sets in the provided
+  configuration (gh-10347).

--- a/test/config-luatest/cluster.lua
+++ b/test/config-luatest/cluster.lua
@@ -260,6 +260,7 @@ end
 -- given error message.
 local function startup_error(g, config, exp_err)
     assert(g)  -- temporary stub to not fail luacheck due to unused var
+    assert(type(config) == 'table')
     assert(config._config == nil, "Please provide cbuilder:new():config()")
     -- Prepare a temporary directory and write a configuration
     -- file.

--- a/test/config-luatest/cluster_config_test.lua
+++ b/test/config-luatest/cluster_config_test.lua
@@ -311,3 +311,21 @@ g.test_misplace_option = function(g)
     cluster.startup_error(g, config, "replicaset \"sharding\" should " ..
                                      "include at least one instance.")
 end
+
+g.test_replicasets_with_same_name = function(g)
+    local config = cbuilder:new()
+        :use_group('g-001')
+        :use_replicaset('r-001')
+        :add_instance('i-001', {})
+
+        :use_group('g-002')
+        :use_replicaset('r-001')
+        :add_instance('i-002', {})
+
+        :config()
+
+
+    cluster.startup_error(g, config, 'found replicasets with the same ' ..
+                                     'name "r-001" in the groups ' ..
+                                     '"g-001" and "g-002".')
+end

--- a/test/config-luatest/cluster_config_test.lua
+++ b/test/config-luatest/cluster_config_test.lua
@@ -329,3 +329,37 @@ g.test_replicasets_with_same_name = function(g)
                                      'name "r-001" in the groups ' ..
                                      '"g-001" and "g-002".')
 end
+
+g.test_instances_with_same_name = function(g)
+    local config = cbuilder:new()
+        :use_group('g-001')
+        :use_replicaset('r-001')
+        :add_instance('i-001', {})
+
+        :use_replicaset('r-002')
+        :add_instance('i-001', {})
+
+        :config()
+
+    cluster.startup_error(g, config, 'found instances with the same ' ..
+                                     'name "i-001" in the replicasets ' ..
+                                     '"r-001" and "r-002" in the group ' ..
+                                     '"g-001".')
+
+    config = cbuilder:new()
+        :use_group('g-001')
+        :use_replicaset('r-001')
+        :add_instance('i-001', {})
+
+        :use_group('g-002')
+        :use_replicaset('r-002')
+        :add_instance('i-001', {})
+
+        :config()
+
+    cluster.startup_error(g, config, 'found instances with the same ' ..
+                                     'name "i-001" in the replicaset ' ..
+                                     '"r-001" in the group "g-001" and ' ..
+                                     'in the replicaset "r-002" in the ' ..
+                                     'group "g-002".')
+end


### PR DESCRIPTION
*(This is a backport of PR #10913 to `release/3.2`, a future `3.2.2` release.)*

----

Tarantool couldn't start with more than one group/replicaset/instance with the same name. Applying cluster configuration with name duplicates results with failed checks during the config application and violated constraints w/o proper error message.

This patchset makes Tarantool throw proper error messages when it has replicasets with the same name in different groups or instances with the same names in different replicasets in the cluster configuration.

Closes #10347