### PR TITLE
config/schema: deep-merge tables under `any` type

### DIFF
--- a/changelogs/unreleased/config-schema-deep-merge.md
+++ b/changelogs/unreleased/config-schema-deep-merge.md
@@ -1,0 +1,7 @@
+## bugfix/config
+
+* `<schema object>:merge()` now performs a deep merge inside an `any` scalar
+  value if left-hand and right-hand values are both tables, where all the keys
+  are strings. This way the cluster configuration options that are marked as
+  `any` in the schema (fields of `app.cfg` and `roles_cfg`) are merged deeply
+  (gh-10450).

--- a/src/box/lua/config/utils/schema.lua
+++ b/src/box/lua/config/utils/schema.lua
@@ -1445,7 +1445,27 @@ end
 
 -- {{{ <schema object>:merge()
 
-local function merge_impl(schema, a, b, ctx)
+-- Are all keys in the given table strings?
+local function table_is_object(t)
+    assert(type(t) == 'table')
+
+    for k, _ in pairs(t) do
+        if type(k) ~= 'string' then
+            return false
+        end
+    end
+
+    return true
+end
+
+-- Perform a deep merge with some specific rules:
+--
+-- * Prefer box.NULL over nil.
+-- * Prefer X ~= nil over nil/box.NULL.
+-- * Prefer B if A or B is not a table.
+-- * Prefer B if A or B is a table with a non-string key.
+-- * Perform the deep merge otherwise.
+local function merge_schemaless(a, b)
     -- Prefer box.NULL over nil.
     if a == nil and b == nil then
         if type(a) == 'nil' then
@@ -1464,7 +1484,62 @@ local function merge_impl(schema, a, b, ctx)
 
     assert(a ~= nil and b ~= nil)
 
-    -- Scalars and arrays are not to be merged.
+    -- Prefer B if A or B is not a table.
+    if type(a) ~= 'table' or type(b) ~= 'table' then
+        return b
+    end
+
+    -- Prefer B if A or B is a table with a non-string key.
+    if not table_is_object(a) or not table_is_object(b) then
+        return b
+    end
+
+    -- Perform the deep merge otherwise.
+    local res = {}
+
+    for k, v in pairs(a) do
+        res[k] = merge_schemaless(v, b[k])
+    end
+
+    for k, v in pairs(b) do
+        -- Copy B's fields that are not present in A.
+        --
+        -- Don't do the recursive call here, because A's field is
+        -- known as nil.
+        if type(a[k]) == 'nil' then
+            res[k] = v
+        end
+    end
+
+    return res
+end
+
+local function merge_impl(schema, a, b, ctx)
+    -- Deduce shape information from the data itself if the schema
+    -- doesn't specify it.
+    if is_scalar(schema) and schema.type == 'any' then
+        return merge_schemaless(a, b)
+    end
+
+    -- Prefer box.NULL over nil.
+    if a == nil and b == nil then
+        if type(a) == 'nil' then
+            return b
+        else
+            return a
+        end
+    end
+
+    -- Prefer X ~= nil over nil/box.NULL.
+    if a == nil then
+        return b
+    elseif b == nil then
+        return a
+    end
+
+    assert(a ~= nil and b ~= nil)
+
+    -- Scalars (except 'any') and arrays are not to be merged.
     --
     -- At this point neither a == nil, nor b == nil, so return the
     -- preferred value, `b`.
@@ -1525,9 +1600,14 @@ end
 -- box.NULL is preferred over nil, any X where X ~= nil is
 -- preferred over nil/box.NULL.
 --
--- Records and maps are deeply merged. Scalars and arrays are
--- all-or-nothing: the right hand one is chosen if both are
--- not nil/box.NULL.
+-- Records and maps are deeply merged. Scalars (except 'any') and
+-- arrays are all-or-nothing: the right hand one is chosen if both
+-- are not nil/box.NULL.
+--
+-- Data marked as a scalar of the 'any' type in the schema are
+-- merged depending of the data shape: if both sides are tables
+-- with string keys, they're deeply merged. Otherwise, the right
+-- hand value is chosen (if both are not nil/box.NULL).
 --
 -- The formal rules are below.
 --
@@ -1552,6 +1632,7 @@ end
 -- 10. merge(<array A>, <array B>) -> <array B>
 -- 11. merge(<record A>, <record B>) -> deep-merge(A, B)
 -- 12. merge(<map A>, <map B>) -> deep-merge(A, B)
+-- 13. merge(<any A>, <any B>) -> see merge_schemaless()
 --
 -- For each key K in A and each key K in B: deep-merge(A, B)[K] is
 -- merge(A[K], B[K]).

--- a/test/config-luatest/app_test.lua
+++ b/test/config-luatest/app_test.lua
@@ -109,3 +109,32 @@ g.test_reload_success = function(g)
         end,
     })
 end
+
+-- Verify that an application configuration is deeply merged for
+-- tables with string keys.
+--
+-- This is supported after gh-10450.
+g.test_app_cfg_deep_merge = function(g)
+    local paths = {
+        global = 'app.cfg',
+        group = 'groups.group-001.app.cfg',
+        replicaset = 'groups.group-001.replicasets.replicaset-001.app.cfg',
+        instance = 'groups.group-001.replicasets.replicaset-001.instances.' ..
+            'instance-001.app.cfg'
+    }
+
+    helpers.success_case(g, {
+        options = {
+            [paths.global]     = {x = {y = {z = {a = 1}}}},
+            [paths.group]      = {x = {y = {z = {b = 2}}}},
+            [paths.replicaset] = {x = {y = {z = {c = 3}}}},
+            [paths.instance]   = {x = {y = {z = {d = 4}}}},
+        },
+        verify = function()
+            local config = require('config')
+
+            local res = config:get('app.cfg.x.y.z')
+            t.assert_equals(res, {a = 1, b = 2, c = 3, d = 4})
+        end,
+    })
+end

--- a/test/config-luatest/schema_test.lua
+++ b/test/config-luatest/schema_test.lua
@@ -3002,10 +3002,11 @@ g.test_merge_array = function()
     t.assert_equals(s:merge(b, a), a)
 end
 
--- Verify that scalars of type 'any' are NOT deeply merged.
+-- Verify that scalars of type 'any' are deeply merged, if they're
+-- tables with string keys.
 --
--- We need table values for the scalars for that.
-g.test_merge_any = function()
+-- This is supported after gh-10450.
+g.test_merge_any_map = function()
     local s = schema.new('myschema', schema.scalar({
         type = 'any',
     }))
@@ -3013,14 +3014,135 @@ g.test_merge_any = function()
     local a = {foo = 'aaa'}
     local b = {bar = 'bbb'}
 
-    t.assert_equals(s:merge(a, b), b)
-    t.assert_equals(s:merge(b, a), a)
+    local exp = {
+        foo = 'aaa',
+        bar = 'bbb',
+    }
+    t.assert_equals(s:merge(a, b), exp)
+    t.assert_equals(s:merge(b, a), exp)
+end
+
+-- Verify that scalars of type 'any' are NOT deeply merged, if
+-- they're arrays.
+g.test_merge_any_array = function()
+    local s = schema.new('myschema', schema.scalar({
+        type = 'any',
+    }))
 
     local a = {1, 2, 3}
     local b = {4, 5, 6}
 
     t.assert_equals(s:merge(a, b), b)
     t.assert_equals(s:merge(b, a), a)
+end
+
+-- More scenarios of merging data corresponding to an 'any'
+-- scalar.
+--
+-- This is supported after gh-10450.
+g.test_merge_any_more = function()
+    local s = schema.new('myschema', schema.scalar({
+        type = 'any',
+    }))
+
+    local cases = {
+        -- Prefer box.NULL over nil.
+        {
+            a = nil,
+            b = box.NULL,
+            exp = box.NULL,
+        },
+        -- Prefer box.NULL over nil.
+        {
+            a = box.NULL,
+            b = nil,
+            exp = box.NULL,
+        },
+        -- Prefer X ~= nil over nil/box.NULL.
+        {
+            a = nil,
+            b = 1,
+            exp = 1,
+        },
+        -- Prefer X ~= nil over nil/box.NULL.
+        {
+            a = 1,
+            b = nil,
+            exp = 1,
+        },
+        -- Prefer X ~= nil over nil/box.NULL.
+        {
+            a = box.NULL,
+            b = 1,
+            exp = 1,
+        },
+        -- Prefer X ~= nil over nil/box.NULL.
+        {
+            a = 1,
+            b = box.NULL,
+            exp = 1,
+        },
+        -- Prefer B if A or B is not a table.
+        {
+            a = 1,
+            b = {foo = 1},
+            exp = {foo = 1},
+        },
+        -- Prefer B if A or B is not a table.
+        {
+            a = {foo = 1},
+            b = 1,
+            exp = 1,
+        },
+        -- Prefer B if A or B is a table with a non-string key.
+        {
+            a = {[1] = 'x'},
+            b = {foo = 1},
+            exp = {foo = 1},
+        },
+        -- Prefer B if A or B is a table with a non-string key.
+        {
+            a = {foo = 1},
+            b = {[1] = 'x'},
+            exp = {[1] = 'x'},
+        },
+        -- Same, but keys are string and non-string.
+        {
+            a = {[5] = 'x', foo = 2},
+            b = {foo = 1},
+            exp = {foo = 1},
+        },
+        -- Same, but keys are string and non-string.
+        {
+            a = {foo = 1},
+            b = {[5] = 'x', foo = 2},
+            exp = {[5] = 'x', foo = 2},
+        },
+        -- A deep merge.
+        {
+            a = {foo = {bar = 42}},
+            b = {foo = {baz = 43}},
+            exp = {foo = {bar = 42, baz = 43}},
+        },
+    }
+
+    for _, case in ipairs(cases) do
+        -- Verify on the top level.
+        local a = case.a
+        local b = case.b
+        local exp = case.exp
+        local res = s:merge(a, b)
+        t.assert_equals(res, exp)
+        t.assert_type(res, type(exp))
+
+        -- The same, but nested.
+        local a = {foo = case.a}
+        local b = {foo = case.b}
+        local exp = {foo = case.exp}
+        local res = s:merge(a, b)
+        t.assert_equals(res, exp)
+        t.assert_type(res.foo, type(exp.foo))
+    end
 end
 
 -- }}} <schema object>:merge()


### PR DESCRIPTION
`<schema object>:merge()` now performs a deep merge inside an `any` scalar value if left-hand and right-hand values are both tables, where all the keys are strings.

The cluster configuration options that are marked as `any` in the schema (fields of `app.cfg` and `roles_cfg`) are now merged deeply.

Fixes #10450