### PR TITLE
[backport 3.3] replication: anon replicas don't participate in elections

### DIFF
--- a/changelogs/unreleased/gh-10561-anon-replicas-dont-participate-in-elections.md
+++ b/changelogs/unreleased/gh-10561-anon-replicas-dont-participate-in-elections.md
@@ -1,0 +1,6 @@
+## bugfix/replication
+
+* Fixed a bug when anonymous replicas could participate in elections or even
+  be chosen as a leader. It is now forbidden to configure a replica so
+  that `replication_anon` is `true` and `election_mode` is not `off`
+  (gh-10561).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -1147,22 +1147,38 @@ box_check_auth_type(void)
 }
 
 static enum election_mode
-box_check_election_mode(void)
+election_mode_by_name(const char *name)
 {
-	const char *mode = cfg_gets("election_mode");
-	if (strcmp(mode, "off") == 0)
+	if (strcmp(name, "off") == 0)
 		return ELECTION_MODE_OFF;
-	else if (strcmp(mode, "voter") == 0)
+	else if (strcmp(name, "voter") == 0)
 		return ELECTION_MODE_VOTER;
-	else if (strcmp(mode, "manual") == 0)
+	else if (strcmp(name, "manual") == 0)
 		return ELECTION_MODE_MANUAL;
-	else if (strcmp(mode, "candidate") == 0)
+	else if (strcmp(name, "candidate") == 0)
 		return ELECTION_MODE_CANDIDATE;
 
 	diag_set(ClientError, ER_CFG, "election_mode",
 		"the value must be one of the following strings: "
 		"'off', 'voter', 'candidate', 'manual'");
 	return ELECTION_MODE_INVALID;
+}
+
+int
+box_check_election_mode(enum election_mode *mode)
+{
+	const char *mode_name = cfg_gets("election_mode");
+	*mode = election_mode_by_name(mode_name);
+	if (*mode == ELECTION_MODE_INVALID)
+		return -1;
+	bool anon = cfg_geti("replication_anon") != 0;
+	if (anon && *mode != ELECTION_MODE_OFF) {
+		diag_set(ClientError, ER_CFG, "election_mode",
+			 "the value may only be set to 'off' when "
+			 "'replication_anon' is set to true");
+		return -1;
+	}
+	return 0;
 }
 
 static double
@@ -1521,10 +1537,19 @@ box_check_replication_anon(void)
 {
 	bool anon = cfg_geti("replication_anon") != 0;
 	bool ro = cfg_geti("read_only") != 0;
+	const char *mode_name = cfg_gets("election_mode");
+	enum election_mode mode = election_mode_by_name(mode_name);
+	if (mode == ELECTION_MODE_INVALID)
+		diag_raise();
 	if (anon && !ro) {
 		tnt_raise(ClientError, ER_CFG, "replication_anon",
 			  "the value may be set to true only when "
 			  "the instance is read-only");
+	}
+	if (anon && mode != ELECTION_MODE_OFF) {
+		tnt_raise(ClientError, ER_CFG, "replication_anon",
+			  "the value may be set to true only when "
+			  "'election_mode' is set to 'off'");
 	}
 	return anon;
 }
@@ -1951,6 +1976,7 @@ box_check_config(void)
 	struct uri uri;
 	struct uri_set uri_set;
 	char name[NODE_NAME_SIZE_MAX];
+	enum election_mode election_mode;
 	box_check_say();
 	if (audit_log_check_cfg() != 0)
 		diag_raise();
@@ -1965,7 +1991,7 @@ box_check_config(void)
 		diag_raise();
 	if (box_check_replicaset_uuid(&uuid) != 0)
 		diag_raise();
-	if (box_check_election_mode() == ELECTION_MODE_INVALID)
+	if (box_check_election_mode(&election_mode) != 0)
 		diag_raise();
 	if (box_check_election_timeout() < 0)
 		diag_raise();
@@ -2036,8 +2062,8 @@ box_set_auth_type(void)
 int
 box_set_election_mode(void)
 {
-	enum election_mode mode = box_check_election_mode();
-	if (mode == ELECTION_MODE_INVALID)
+	enum election_mode mode;
+	if (box_check_election_mode(&mode) != 0)
 		return -1;
 	box_raft_cfg_election_mode(mode);
 	box_broadcast_ballot();
@@ -3070,21 +3096,33 @@ box_promote_qsync(void)
 }
 
 int
-box_promote(void)
-{
+box_check_promote(void) {
 	if (is_in_box_promote) {
-		diag_set(ClientError, ER_UNSUPPORTED, "box.ctl.promote",
+		diag_set(ClientError, ER_UNSUPPORTED, "box.ctl.promote/demote",
 			 "simultaneous invocations");
 		return -1;
 	}
+	if (cfg_replication_anon) {
+		diag_set(ClientError, ER_UNSUPPORTED, "replication_anon=true",
+			 "manual elections");
+		return -1;
+	}
+	return 0;
+}
+
+int
+box_promote(void)
+{
+	if (!is_box_configured)
+		return 0;
+	if (box_check_promote() != 0)
+		return -1;
+
 	struct raft *raft = box_raft();
 	is_in_box_promote = true;
 	auto promote_guard = make_scoped_guard([&] {
 		is_in_box_promote = false;
 	});
-
-	if (!is_box_configured)
-		return 0;
 	/*
 	 * Currently active leader (the instance that is seen as leader by both
 	 * raft and txn_limbo) can't issue another PROMOTE.
@@ -3130,18 +3168,15 @@ box_promote(void)
 int
 box_demote(void)
 {
-	if (is_in_box_promote) {
-		diag_set(ClientError, ER_UNSUPPORTED, "box.ctl.demote",
-			 "simultaneous invocations");
+	if (!is_box_configured)
+		return 0;
+	if (box_check_promote() != 0)
 		return -1;
-	}
+
 	is_in_box_promote = true;
 	auto promote_guard = make_scoped_guard([&] {
 		is_in_box_promote = false;
 	});
-
-	if (!is_box_configured)
-		return 0;
 
 	const struct raft *raft = box_raft();
 	if (box_election_mode != ELECTION_MODE_OFF) {
@@ -5010,10 +5045,13 @@ void
 box_process_vote(struct ballot *ballot)
 {
 	ballot->is_ro_cfg = cfg_geti("read_only") != 0;
-	enum election_mode mode = box_check_election_mode();
+	const char *mode_name = cfg_gets("election_mode");
+	enum election_mode mode = election_mode_by_name(mode_name);
+	assert(mode != ELECTION_MODE_INVALID);
 	ballot->can_lead = mode == ELECTION_MODE_CANDIDATE ||
 			   mode == ELECTION_MODE_MANUAL;
 	ballot->is_anon = cfg_replication_anon;
+	assert(!(ballot->is_anon && ballot->can_lead));
 	ballot->is_ro = is_ro_summary;
 	ballot->is_booted = is_box_configured;
 	vclock_copy(&ballot->vclock, instance_vclock);

--- a/test/replication-luatest/anon_test.lua
+++ b/test/replication-luatest/anon_test.lua
@@ -1,15 +1,16 @@
+local cluster = require('luatest.replica_set')
 local server = require('luatest.server')
 local t = require('luatest')
-local g = t.group()
+local g1 = t.group('group1')
 
 local wait_timeout = 60
 
-g.before_all = function(lg)
+g1.before_all = function(lg)
     lg.master = server:new({alias = 'master'})
     lg.master:start()
 end
 
-g.after_all = function(lg)
+g1.after_all = function(lg)
     lg.master:drop()
 end
 
@@ -17,7 +18,7 @@ end
 -- When an instance failed to apply cfg{replication_anon = false}, it used to
 -- report itself as non-anon in the ballot anyway. Shouldn't be so.
 --
-g.test_ballot_on_deanon_fail = function(lg)
+g1.test_ballot_on_deanon_fail = function(lg)
     local box_cfg = {
         replication_anon = true,
         read_only = true,
@@ -66,7 +67,7 @@ end
 -- gh-9916: txns being applied from the master during the name change process
 -- could crash the replica or cause "double LSN" error in release.
 --
-g.test_txns_replication_during_registration = function(lg)
+g1.test_txns_replication_during_registration = function(lg)
     t.tarantool.skip_if_not_debug()
     lg.master:exec(function()
         local s = box.schema.create_space('test')
@@ -139,4 +140,98 @@ g.test_txns_replication_during_registration = function(lg)
         box.space.test:drop()
         box.space._cluster:delete{id}
     end, {replica_id})
+end
+
+--
+-- gh-10561:
+-- Anonymous replicas don't participate in elections.
+--
+
+local function build_cluster(lg, election_mode, replication_anon)
+    lg.cluster = cluster:new({})
+    lg.master = lg.cluster:build_and_add_server({alias = 'master'})
+    lg.replica_cfg = {
+        replication = server.build_listen_uri('master', lg.cluster.id),
+        election_mode = election_mode,
+        replication_anon = replication_anon,
+        read_only = true,
+    }
+    lg.replica = lg.cluster:build_and_add_server({
+        alias = 'replica',
+        box_cfg = lg.replica_cfg,
+    })
+    lg.cluster:start()
+    lg.master:exec(function() box.ctl.promote() end)
+    t.helpers.retrying({timeout = wait_timeout}, function()
+        lg.replica:assert_follows_upstream(lg.master:get_instance_id())
+    end)
+end
+
+local g2 = t.group('group2')
+
+g2.before_all(function(lg)
+    build_cluster(lg, 'off', true)
+end)
+
+g2.after_all(function(lg)
+    lg.cluster:drop()
+end)
+
+for _, mode in ipairs({'candidate', 'manual', 'voter'}) do
+    g2["test_anon_replica_startup_with_election_mode_" .. mode] = function(lg)
+        -- box_check_config is called only during the first box.cfg,
+        -- so we need a restart here to cover it
+        local ok, _ = pcall(function()
+            lg.replica:restart({box_cfg = {
+                replication = server.build_listen_uri('master', lg.cluster.id),
+                election_mode = mode,
+                replication_anon = true,
+                read_only = true,
+            }}, {wait_until_ready = true})
+        end)
+        t.assert(not ok)
+        lg.replica:restart({box_cfg = lg.replica_cfg})
+    end
+end
+
+for _, mode in ipairs({'candidate', 'manual', 'voter'}) do
+    g2["test_anon_replica_switch_to_election_mode_" .. mode] =
+        function(lg)
+            lg.replica:exec(function(election_mode)
+                local err_msg = "Incorrect value for option " ..
+                    "'election_mode': the value may only be set to 'off' " ..
+                    "when 'replication_anon' is set to true"
+                t.assert_error_msg_equals(err_msg, box.cfg,
+                    {election_mode = election_mode})
+            end, {mode})
+        end
+end
+
+g2.test_anon_replica_promote_unsupported = function(lg)
+    lg.replica:exec(function()
+        local err_msg = "replication_anon=true " ..
+            "does not support manual elections"
+        t.assert_error_msg_equals(err_msg, box.ctl.promote)
+        t.assert_error_msg_equals(err_msg, box.ctl.demote)
+    end)
+end
+
+local g3 = t.group('group3')
+
+for _, mode in ipairs({'candidate', 'manual', 'voter'}) do
+    g3["test_replica_with_" .. mode .. "election_mode_switch_to_anon"] =
+        function(lg)
+            -- We are forced to rebuild the cluster every time, because if the
+            -- replica was not previously registered in the cluster, it cannot
+            -- connect as a non-anonymous replica
+            build_cluster(lg, mode, false)
+            lg.replica:exec(function()
+                local err_msg = "Incorrect value for option " ..
+                    "'replication_anon': the value may be set to true only " ..
+                    "when 'election_mode' is set to 'off'"
+                t.assert_error_msg_equals(err_msg, box.cfg,
+                    {replication_anon = true})
+            end)
+            lg.cluster:drop()
+        end
 end


### PR DESCRIPTION
Fixed a bug where anonymous replicas could participate in elections or even be chosen as a leader. It is now forbidden to configure a replica so that `replication_anon` is `true` and `election_mode` is not `off`. It is also now prohibited to issue PROMOTE from an anonymous replica.

Closes #10561

@TarantoolBot document
Title: changes in `replication_anon` and `election_mode` configuration Product: Tarantool
Since: 3.3

[replication-anon] https://www.tarantool.io/ru/doc/latest/reference/configuration/#cfg-replication-replication-anon

```diff
- In order to make a replica anonymous, pass the option `replication_anon=true` to `box.cfg` and set `read_only` to `true`.
+ In order to make a replica anonymous, pass the option `replication_anon=true` to `box.cfg`, set `read_only` to `true` and `election_mode` to `off`.
```

[election_mode] https://www.tarantool.io/ru/doc/latest/reference/configuration/#cfg-replication-election-mode

For an anonymous replica, `election_mode` can only be set to `off`.

(cherry picked from commit 97616f76470901c0c5f8186b5c25652ac5b66e78)