### PR TITLE
[backport 3.2] config/schema: deep-merge tables under `any` type

### DIFF
--- a/changelogs/unreleased/config-schema-deep-merge.md
+++ b/changelogs/unreleased/config-schema-deep-merge.md
@@ -1,0 +1,7 @@
+## bugfix/config
+
+* `<schema object>:merge()` now performs a deep merge inside an `any` scalar
+  value if left-hand and right-hand values are both tables, where all the keys
+  are strings. This way the cluster configuration options that are marked as
+  `any` in the schema (fields of `app.cfg` and `roles_cfg`) are merged deeply
+  (gh-10450).

--- a/test/config-luatest/app_test.lua
+++ b/test/config-luatest/app_test.lua
@@ -109,3 +109,32 @@ g.test_reload_success = function(g)
         end,
     })
 end
+
+-- Verify that an application configuration is deeply merged for
+-- tables with string keys.
+--
+-- This is supported after gh-10450.
+g.test_app_cfg_deep_merge = function(g)
+    local paths = {
+        global = 'app.cfg',
+        group = 'groups.group-001.app.cfg',
+        replicaset = 'groups.group-001.replicasets.replicaset-001.app.cfg',
+        instance = 'groups.group-001.replicasets.replicaset-001.instances.' ..
+            'instance-001.app.cfg'
+    }
+
+    helpers.success_case(g, {
+        options = {
+            [paths.global]     = {x = {y = {z = {a = 1}}}},
+            [paths.group]      = {x = {y = {z = {b = 2}}}},
+            [paths.replicaset] = {x = {y = {z = {c = 3}}}},
+            [paths.instance]   = {x = {y = {z = {d = 4}}}},
+        },
+        verify = function()
+            local config = require('config')
+
+            local res = config:get('app.cfg.x.y.z')
+            t.assert_equals(res, {a = 1, b = 2, c = 3, d = 4})
+        end,
+    })
+end

--- a/test/config-luatest/roles_test.lua
+++ b/test/config-luatest/roles_test.lua
@@ -636,3 +636,32 @@ g.test_role_is_not_a_table = function()
             'expected table, got number',
     })
 end
+
+-- Verify that a role configuration is deeply merged for tables
+-- with string keys.
+--
+-- This is supported after gh-10450.
+g.test_roles_cfg_deep_merge = function(g)
+    local paths = {
+        global = 'roles_cfg',
+        group = 'groups.group-001.roles_cfg',
+        replicaset = 'groups.group-001.replicasets.replicaset-001.roles_cfg',
+        instance = 'groups.group-001.replicasets.replicaset-001.instances.' ..
+            'instance-001.roles_cfg'
+    }
+
+    helpers.success_case(g, {
+        options = {
+            [paths.global]     = {x = {y = {z = {a = 1}}}},
+            [paths.group]      = {x = {y = {z = {b = 2}}}},
+            [paths.replicaset] = {x = {y = {z = {c = 3}}}},
+            [paths.instance]   = {x = {y = {z = {d = 4}}}},
+        },
+        verify = function()
+            local config = require('config')
+
+            local res = config:get('roles_cfg.x.y.z')
+            t.assert_equals(res, {a = 1, b = 2, c = 3, d = 4})
+        end,
+    })
+end


### PR DESCRIPTION
*(This is a backport of PR #10921 to `release/3.2`, a future `3.2.2` release.)*

----

`<schema object>:merge()` now performs a deep merge inside an `any` scalar value if left-hand and right-hand values are both tables, where all the keys are strings.

The cluster configuration options that are marked as `any` in the schema (fields of `app.cfg` and `roles_cfg`) are now merged deeply.

Fixes #10450