### PR TITLE
box.sequence: sequence_data recovery after reset

### DIFF
--- a/changelogs/unreleased/gh_9871_sequence_data_recovery_after_reset.md
+++ b/changelogs/unreleased/gh_9871_sequence_data_recovery_after_reset.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a bug when the `sequence:reset()` call result was not recovered
+  after the server restart (gh-9871).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -4258,13 +4258,43 @@ box_sequence_set(uint32_t seq_id, int64_t value)
 API_EXPORT int
 box_sequence_reset(uint32_t seq_id)
 {
+	bool was_in_txn = box_txn();
+	box_txn_savepoint_t *savepoint = NULL;
+	if (was_in_txn) {
+		savepoint = box_txn_savepoint();
+		if (savepoint == NULL)
+			return -1;
+	} else if (!was_in_txn && box_txn_begin() != 0) {
+		return -1;
+	}
 	struct sequence *seq = sequence_cache_find(seq_id);
 	if (seq == NULL)
-		return -1;
+		goto error;
 	if (access_check_sequence(seq) != 0)
-		return -1;
+		goto error;
+	int64_t sequence_value;
+
+	if (sequence_get_value(seq, &sequence_value) == 0) {
+		/*
+		 * Without the update here sequence_data_delete call result
+		 * below may not be recovered due to the specifics of how
+		 * on_replace trigger work in the absence of old_tuple
+		 */
+		if (sequence_data_update(seq_id, sequence_value) != 0)
+			goto error;
+	}
 	sequence_reset(seq);
-	return sequence_data_delete(seq_id);
+	if (sequence_data_delete(seq_id) != 0)
+		goto error;
+	if (!was_in_txn && box_txn_commit() != 0)
+		goto error;
+	return 0;
+error:
+	if (was_in_txn)
+		box_txn_rollback_to_savepoint(savepoint);
+	else
+		box_txn_rollback();
+	return -1;
 }
 
 API_EXPORT int

--- a/src/box/request.c
+++ b/src/box/request.c
@@ -240,9 +240,15 @@ request_handle_sequence(struct request *request, struct space *space,
 		 * auto increment request never tries to insert a
 		 * value that is already in the space. Note, this
 		 * code is also invoked on final recovery to restore
-		 * the sequence value from WAL.
+		 * the sequence value from WAL. However, during the
+		 * initial recovery, proper sequence values are stored
+		 * in snapshots, and one should use these because
+		 * otherwise, sequence values would depend on
+		 * the order of recovered spaces which may be
+		 * misleading.
 		 */
-		if (likely(mp_read_int64(&key, &value) == 0))
+		if (likely(mp_read_int64(&key, &value) == 0 &&
+			   recovery_state != INITIAL_RECOVERY))
 			return sequence_update(seq, value);
 	}
 	request_update_header(request, request->header, region);

--- a/test/engine-luatest/gh_9871_sequence_restart_after_reset_test.lua
+++ b/test/engine-luatest/gh_9871_sequence_restart_after_reset_test.lua
@@ -1,0 +1,79 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local group_config = {
+    {engine = 'memtx', use_txn = true},
+    {engine = 'memtx', use_txn = false},
+    {engine = 'vinyl', use_txn = false}
+}
+local g = t.group('storage', group_config)
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.before_each(function(cg)
+    cg.server:exec(function(engine, use_txn)
+        box.schema.sequence.create('id_seq')
+        local s = box.schema.create_space('test', {
+            format = {
+                {'id', type='unsigned', is_nullable=false},
+                {'name', type='string', is_nullable=false},
+            },
+            engine = engine,
+            if_not_exists = true,
+        })
+        s:create_index('primary', {
+            sequence = 'id_seq',
+            if_not_exists = true
+        })
+        if use_txn then
+            box.begin()
+        end
+        s:insert{nil, 'aaa'}
+        s:insert{nil, 'bbb'}
+        s:insert{nil, 'ccc'}
+        local seq = box.sequence.id_seq
+        seq:reset()
+        s:delete(1)
+        if use_txn then
+            box.commit()
+        end
+    end, {cg.params.engine, cg.params.use_txn})
+end)
+
+local function commit()
+    local s = box.space.test
+    s:insert{nil, 'ddd'}
+    local ddd = s:get(1)
+    t.assert_equals(ddd[2], 'ddd')
+end
+
+g.test_no_recovery = function(cg)
+    cg.server:exec(commit)
+end
+
+g.test_snapshot_recovery = function(cg)
+    cg.server:exec(function()
+        box.snapshot()
+    end)
+    cg.server:restart()
+    cg.server:exec(commit)
+end
+
+g.test_wal_recovery = function(cg)
+    cg.server:restart()
+    cg.server:exec(commit)
+end
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        box.space.test:drop()
+        box.sequence.id_seq:drop()
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)


### PR DESCRIPTION
There are two sources of sequence state in tarantool: `_sequence_data` table and it's light version used in `box/sequence.c` which is stored in a hashmap. The reason for this decision was lack of cross-engine transactions. The first is used in lua API, the second -- internally to process memtx index updates. Now lua `reset()` call always produce WAL entry and we don't rely on memtx tables content during the initial recovery since the latest hasmap state is stored into snapshot directly.

Fixes #9871
NO_DOC=bugfix