### PR TITLE
[backport 2.11] small: bump version

### DIFF
--- a/perf/light.cc
+++ b/perf/light.cc
@@ -7,6 +7,8 @@
 
 #include <benchmark/benchmark.h>
 
+#include <small/matras.h>
+
 // This test contains benchmarks for Light - data structure implementing
 // Tarantool HASH index and being hash table under the hood.
 //
@@ -195,26 +197,21 @@ namespace {
 	};
 
 	static constexpr std::size_t light_extent_size = 16 * KB;
-	static std::size_t extents_count = 0;
 
 	inline void *
-	light_malloc_extend(void *ctx)
+	light_malloc_extend(struct matras_allocator *allocator)
 	{
-		std::size_t *p_extents_count = (size_t *) ctx;
-		assert(p_extents_count == &extents_count);
-		++*p_extents_count;
+		(void)allocator;
 		return malloc(light_extent_size);
 	}
 
 	inline void
-	light_free_extend(void *ctx, void *p)
+	light_free_extend(struct matras_allocator *allocator, void *p)
 	{
-		size_t *p_extents_count = (size_t *) ctx;
-		assert(p_extents_count == &extents_count);
-		--*p_extents_count;
+		(void)allocator;
 		free(p);
 	}
-}; // namespace
+}; /* namespace */
 
 #define LIGHT_NAME
 #define LIGHT_DATA_TYPE const TupleRaw *
@@ -476,12 +473,14 @@ class Light {
 public:
 	Light()
 	{
-		light_create(&ht, light_extent_size, light_malloc_extend,
-			     light_free_extend, &extents_count, 0);
+		matras_allocator_create(&allocator, light_extent_size,
+					light_malloc_extend, light_free_extend);
+		light_create(&ht, 0, &allocator);
 	}
 	~Light()
 	{
 		light_destroy(&ht);
+		matras_allocator_destroy(&allocator);
 	}
 
 	// Functions return smth in order to suppress "error: invalid use of void expression".
@@ -519,8 +518,7 @@ public:
 	clear()
 	{
 		light_destroy(&ht);
-		light_create(&ht, light_extent_size, light_malloc_extend,
-			     light_free_extend, &extents_count, 0);
+		light_create(&ht, 0, &allocator);
 	}
 
 	void
@@ -541,6 +539,7 @@ public:
 	}
 private:
 	struct light_core ht;
+	struct matras_allocator allocator;
 };
 
 using USet = std::unordered_set<TupleRef, Hash::TupleHash, TupleEqual>;

--- a/src/box/memtx_bitset.cc
+++ b/src/box/memtx_bitset.cc
@@ -538,9 +538,8 @@ memtx_bitset_index_new(struct memtx_engine *memtx, struct index_def *def)
 	index->id_to_tuple = (struct matras *)malloc(sizeof(*index->id_to_tuple));
 	if (index->id_to_tuple == NULL)
 		panic("failed to allocate memtx bitset index");
-	matras_create(index->id_to_tuple, MEMTX_EXTENT_SIZE, sizeof(struct tuple *),
-		      memtx_index_extent_alloc, memtx_index_extent_free, memtx,
-		      NULL);
+	matras_create(index->id_to_tuple, sizeof(struct tuple *),
+		      &memtx->index_extent_allocator, NULL);
 
 	index->tuple_to_id = mh_bitset_index_new();
 #endif /* #ifndef OLD_GOOD_BITSET */

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -91,7 +91,14 @@ static inline struct tuple *
 memtx_tuple_new_raw_impl(struct tuple_format *format, const char *data,
 			 const char *end, bool validate);
 
-template <class ALLOC>
+static void *
+memtx_index_extent_alloc(struct matras_allocator *matras_allocator);
+
+static void
+memtx_index_extent_free(struct matras_allocator *matras_allocator,
+			void *extent);
+
+template<class ALLOC>
 static void
 memtx_alloc_init(void)
 {
@@ -205,12 +212,7 @@ memtx_engine_shutdown(struct engine *engine)
 	mempool_destroy(&memtx->iterator_pool);
 	if (mempool_is_initialized(&memtx->rtree_iterator_pool))
 		mempool_destroy(&memtx->rtree_iterator_pool);
-	void *p = memtx->reserved_extents;
-	while (p != NULL) {
-		void *next = *(void **)p;
-		memtx_index_extent_free(memtx, p);
-		p = next;
-	}
+	matras_allocator_destroy(&memtx->index_extent_allocator);
 	mempool_destroy(&memtx->index_extent_pool);
 	slab_cache_destroy(&memtx->index_slab_cache);
 	mh_ptr_delete(memtx->malloc_extents);
@@ -1692,10 +1694,12 @@ memtx_engine_new(const char *snap_dirname, bool force_recovery,
 	slab_cache_create(&memtx->index_slab_cache, &memtx->arena);
 	mempool_create(&memtx->index_extent_pool, &memtx->index_slab_cache,
 		       MEMTX_EXTENT_SIZE);
+	matras_allocator_create(&memtx->index_extent_allocator,
+				MEMTX_EXTENT_SIZE,
+				memtx_index_extent_alloc,
+				memtx_index_extent_free);
 	mempool_create(&memtx->iterator_pool, cord_slab_cache(),
 		       MEMTX_ITERATOR_SIZE);
-	memtx->num_reserved_extents = 0;
-	memtx->reserved_extents = NULL;
 	memtx->malloc_extents = mh_ptr_new();
 
 	memtx->state = MEMTX_INITIALIZED;
@@ -1929,17 +1933,12 @@ create_memtx_tuple_format_vtab(struct tuple_format_vtab *vtab)
 /**
  * Allocate a block of size MEMTX_EXTENT_SIZE for memtx index
  */
-void *
-memtx_index_extent_alloc(void *ctx)
+static void *
+memtx_index_extent_alloc(struct matras_allocator *matras_allocator)
 {
-	struct memtx_engine *memtx = (struct memtx_engine *)ctx;
-	if (memtx->reserved_extents) {
-		assert(memtx->num_reserved_extents > 0);
-		memtx->num_reserved_extents--;
-		void *result = memtx->reserved_extents;
-		memtx->reserved_extents = *(void **)memtx->reserved_extents;
-		return result;
-	}
+	struct memtx_engine *memtx = container_of(matras_allocator,
+						  struct memtx_engine,
+						  index_extent_allocator);
 	ERROR_INJECT(ERRINJ_INDEX_ALLOC, { goto fail; });
 	void *ret;
 	while ((ret = mempool_alloc(&memtx->index_extent_pool)) == NULL) {
@@ -1971,10 +1970,12 @@ fail:
 /**
  * Free a block previously allocated by memtx_index_extent_alloc
  */
-void
-memtx_index_extent_free(void *ctx, void *extent)
+static void
+memtx_index_extent_free(struct matras_allocator *matras_allocator, void *extent)
 {
-	struct memtx_engine *memtx = (struct memtx_engine *)ctx;
+	struct memtx_engine *memtx = container_of(matras_allocator,
+						  struct memtx_engine,
+						  index_extent_allocator);
 	mh_int_t p = mh_ptr_find(memtx->malloc_extents, extent, NULL);
 	if (p != mh_end(memtx->malloc_extents)) {
 		mh_ptr_del(memtx->malloc_extents, p, NULL);
@@ -1997,25 +1998,7 @@ memtx_index_extent_reserve(struct memtx_engine *memtx, int num)
 			 "mempool", "new slab");
 		return -1;
 	});
-	struct mempool *pool = &memtx->index_extent_pool;
-	while (memtx->num_reserved_extents < num) {
-		void *ext;
-		while ((ext = mempool_alloc(pool)) == NULL) {
-			bool stop;
-			memtx_engine_run_gc(memtx, &stop);
-			if (stop)
-				break;
-		}
-		if (ext == NULL) {
-			diag_set(OutOfMemory, MEMTX_EXTENT_SIZE,
-				 "mempool", "new slab");
-			return -1;
-		}
-		*(void **)ext = memtx->reserved_extents;
-		memtx->reserved_extents = ext;
-		memtx->num_reserved_extents++;
-	}
-	return 0;
+	return matras_allocator_reserve(&memtx->index_extent_allocator, num);
 }
 
 bool

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -36,6 +36,7 @@
 #include <small/quota.h>
 #include <small/small.h>
 #include <small/mempool.h>
+#include <small/matras.h>
 
 #include "engine.h"
 #include "xlog.h"
@@ -151,17 +152,10 @@ struct memtx_engine {
 	struct slab_cache slab_cache;
 	/** Slab cache for allocating index extents. */
 	struct slab_cache index_slab_cache;
-	/** Index extent allocator. */
+	/** Index extent source. */
 	struct mempool index_extent_pool;
-	/**
-	 * To ensure proper statement-level rollback in case
-	 * of out of memory conditions, we maintain a number
-	 * of slack memory extents reserved before a statement
-	 * is begun. If there isn't enough slack memory,
-	 * we don't begin the statement.
-	 */
-	int num_reserved_extents;
-	void *reserved_extents;
+	/** Index extent allocator. */
+	struct matras_allocator index_extent_allocator;
 	/** Maximal allowed tuple size, box.cfg.memtx_max_tuple_size. */
 	size_t max_tuple_size;
 	/** Memory pool for rtree index iterator. */
@@ -260,20 +254,6 @@ enum {
 extern struct tuple *
 (*memtx_tuple_new_raw)(struct tuple_format *format, const char *data,
 		       const char *end, bool validate);
-
-/**
- * Allocate a block of size MEMTX_EXTENT_SIZE for memtx index
- * @ctx must point to memtx engine
- */
-void *
-memtx_index_extent_alloc(void *ctx);
-
-/**
- * Free a block previously allocated by memtx_index_extent_alloc
- * @ctx must point to memtx engine
- */
-void
-memtx_index_extent_free(void *ctx, void *extent);
 
 /**
  * Reserve num extents in pool.

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -688,9 +688,8 @@ memtx_hash_index_new(struct memtx_engine *memtx, struct index_def *def)
 	index_create(&index->base, (struct engine *)memtx,
 		     &memtx_hash_index_vtab, def);
 
-	light_index_create(&index->hash_table, MEMTX_EXTENT_SIZE,
-			   memtx_index_extent_alloc, memtx_index_extent_free,
-			   memtx, index->base.def->key_def);
+	light_index_create(&index->hash_table, index->base.def->key_def,
+			   &memtx->index_extent_allocator);
 	return &index->base;
 }
 

--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -444,8 +444,7 @@ memtx_rtree_index_new(struct memtx_engine *memtx, struct index_def *def)
 		     &memtx_rtree_index_vtab, def);
 
 	index->dimension = def->opts.dimension;
-	rtree_init(&index->tree, index->dimension, MEMTX_EXTENT_SIZE,
-		   memtx_index_extent_alloc, memtx_index_extent_free, memtx,
-		   distance_type);
+	rtree_init(&index->tree, index->dimension, distance_type,
+		   &memtx->index_extent_allocator);
 	return &index->base;
 }

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -2160,8 +2160,8 @@ memtx_tree_index_new_tpl(struct memtx_engine *memtx, struct index_def *def,
 	cmp_def = def->opts.is_unique && !def->key_def->is_nullable ?
 			index->base.def->key_def : index->base.def->cmp_def;
 
-	memtx_tree_create(&index->tree, cmp_def, memtx_index_extent_alloc,
-			  memtx_index_extent_free, memtx);
+	memtx_tree_create(&index->tree, cmp_def,
+			  &memtx->index_extent_allocator);
 	index->is_func = def->key_def->func_index_func != NULL;
 	return &index->base;
 }

--- a/src/box/sequence.c
+++ b/src/box/sequence.c
@@ -85,11 +85,12 @@ sequence_data_equal_key(struct sequence_data data, uint32_t id)
 
 static struct light_sequence_core sequence_data_index;
 static struct mempool sequence_data_extent_pool;
+static struct matras_allocator sequence_data_extent_allocator;
 
 static void *
-sequence_data_extent_alloc(void *ctx)
+sequence_data_extent_alloc(struct matras_allocator *allocator)
 {
-	(void)ctx;
+	(void)allocator;
 	void *ret = mempool_alloc(&sequence_data_extent_pool);
 	if (ret == NULL)
 		diag_set(OutOfMemory, SEQUENCE_DATA_EXTENT_SIZE,
@@ -98,9 +99,9 @@ sequence_data_extent_alloc(void *ctx)
 }
 
 static void
-sequence_data_extent_free(void *ctx, void *extent)
+sequence_data_extent_free(struct matras_allocator *allocator, void *extent)
 {
-	(void)ctx;
+	(void)allocator;
 	mempool_free(&sequence_data_extent_pool, extent);
 }
 
@@ -115,15 +116,19 @@ sequence_init(void)
 {
 	mempool_create(&sequence_data_extent_pool, &cord()->slabc,
 		       SEQUENCE_DATA_EXTENT_SIZE);
-	light_sequence_create(&sequence_data_index, SEQUENCE_DATA_EXTENT_SIZE,
-			      sequence_data_extent_alloc,
-			      sequence_data_extent_free, NULL, 0);
+	matras_allocator_create(&sequence_data_extent_allocator,
+				SEQUENCE_DATA_EXTENT_SIZE,
+				sequence_data_extent_alloc,
+				sequence_data_extent_free);
+	light_sequence_create(&sequence_data_index, 0,
+			      &sequence_data_extent_allocator);
 }
 
 void
 sequence_free(void)
 {
 	light_sequence_destroy(&sequence_data_index);
+	matras_allocator_destroy(&sequence_data_extent_allocator);
 	mempool_destroy(&sequence_data_extent_pool);
 }
 

--- a/src/box/vy_cache.c
+++ b/src/box/vy_cache.c
@@ -52,6 +52,20 @@ enum {
 	VY_CACHE_CLEANUP_MAX_STEPS = 10,
 };
 
+static void *
+vy_cache_tree_page_alloc(struct matras_allocator *allocator)
+{
+	(void)allocator;
+	return xmalloc(VY_CACHE_TREE_EXTENT_SIZE);
+}
+
+static void
+vy_cache_tree_page_free(struct matras_allocator *allocator, void *ptr)
+{
+	(void)allocator;
+	free(ptr);
+}
+
 void
 vy_cache_env_create(struct vy_cache_env *e, struct slab_cache *slab_cache)
 {
@@ -60,6 +74,10 @@ vy_cache_env_create(struct vy_cache_env *e, struct slab_cache *slab_cache)
 	e->mem_quota = 0;
 	mempool_create(&e->cache_node_mempool, slab_cache,
 		       sizeof(struct vy_cache_node));
+	matras_allocator_create(&e->allocator,
+				VY_CACHE_TREE_EXTENT_SIZE,
+				vy_cache_tree_page_alloc,
+				vy_cache_tree_page_free);
 }
 
 /** Delete a node from the cache. */
@@ -74,6 +92,7 @@ vy_cache_env_destroy(struct vy_cache_env *e)
 	while (e->mem_used > 0)
 		vy_cache_gc_step(e);
 #endif
+	matras_allocator_destroy(&e->allocator);
 	mempool_destroy(&e->cache_node_mempool);
 }
 
@@ -123,26 +142,6 @@ vy_cache_node_delete(struct vy_cache_env *env, struct vy_cache_node *node)
 	mempool_free(&env->cache_node_mempool, node);
 }
 
-static void *
-vy_cache_tree_page_alloc(void *ctx)
-{
-	struct vy_env *env = (struct vy_env *)ctx;
-	(void)env;
-	void *ret = malloc(VY_CACHE_TREE_EXTENT_SIZE);
-	if (ret == NULL)
-		diag_set(OutOfMemory, VY_CACHE_TREE_EXTENT_SIZE, "malloc",
-			 "ret");
-	return ret;
-}
-
-static void
-vy_cache_tree_page_free(void *ctx, void *p)
-{
-	struct vy_env *env = (struct vy_env *)ctx;
-	(void)env;
-	free(p);
-}
-
 void
 vy_cache_create(struct vy_cache *cache, struct vy_cache_env *env,
 		struct key_def *cmp_def, bool is_primary)
@@ -151,9 +150,7 @@ vy_cache_create(struct vy_cache *cache, struct vy_cache_env *env,
 	cache->cmp_def = cmp_def;
 	cache->is_primary = is_primary;
 	cache->version = 1;
-	vy_cache_tree_create(&cache->cache_tree, cmp_def,
-			     vy_cache_tree_page_alloc,
-			     vy_cache_tree_page_free, env);
+	vy_cache_tree_create(&cache->cache_tree, cmp_def, &env->allocator);
 }
 
 void

--- a/src/box/vy_cache.h
+++ b/src/box/vy_cache.h
@@ -119,6 +119,8 @@ struct vy_cache_env {
 	struct rlist cache_lru;
 	/** Common mempool for vy_cache_node struct */
 	struct mempool cache_node_mempool;
+	/** Common matras extent allocator. */
+	struct matras_allocator allocator;
 	/** Size of memory occupied by cached tuples */
 	size_t mem_used;
 	/** Max memory size that can be used for cache */

--- a/src/box/vy_mem.c
+++ b/src/box/vy_mem.c
@@ -71,9 +71,10 @@ vy_mem_env_destroy(struct vy_mem_env *env)
 /** {{{ vy_mem */
 
 static void *
-vy_mem_tree_extent_alloc(void *ctx)
+vy_mem_tree_extent_alloc(struct matras_allocator *allocator)
 {
-	struct vy_mem *mem = (struct vy_mem *) ctx;
+	struct vy_mem *mem = container_of(allocator, struct vy_mem,
+					  matras_allocator);
 	struct vy_mem_env *env = mem->env;
 	void *ret = lsregion_aligned_alloc(&env->allocator,
 					   VY_MEM_TREE_EXTENT_SIZE,
@@ -89,10 +90,10 @@ vy_mem_tree_extent_alloc(void *ctx)
 }
 
 static void
-vy_mem_tree_extent_free(void *ctx, void *p)
+vy_mem_tree_extent_free(struct matras_allocator *allocator, void *p)
 {
 	/* Can't free part of region allocated memory. */
-	(void)ctx;
+	(void)allocator;
 	(void)p;
 }
 
@@ -114,9 +115,12 @@ vy_mem_new(struct vy_mem_env *env, struct key_def *cmp_def,
 	index->space_cache_version = space_cache_version;
 	index->format = format;
 	tuple_format_ref(format);
+	matras_allocator_create(&index->matras_allocator,
+				VY_MEM_TREE_EXTENT_SIZE,
+				vy_mem_tree_extent_alloc,
+				vy_mem_tree_extent_free);
 	vy_mem_tree_create(&index->tree, cmp_def,
-			   vy_mem_tree_extent_alloc,
-			   vy_mem_tree_extent_free, index);
+			   &index->matras_allocator);
 	rlist_create(&index->in_sealed);
 	fiber_cond_create(&index->pin_cond);
 	return index;
@@ -126,6 +130,13 @@ void
 vy_mem_delete(struct vy_mem *index)
 {
 	index->env->tree_extent_size -= index->tree_extent_size;
+	/*
+	 * It would be expected to destroy the index->matras_allocator and
+	 * the index->tree here, but they simply free allocated and reserved
+	 * memory blocks, and the lsregion used for allocation of the memory
+	 * does not support freeing arbitrary blocks, so they're effectively
+	 * no-ops. Let's omit them.
+	 */
 	tuple_format_unref(index->format);
 	fiber_cond_destroy(&index->pin_cond);
 	TRASH(index);

--- a/src/box/vy_mem.h
+++ b/src/box/vy_mem.h
@@ -162,6 +162,8 @@ struct vy_mem {
 	struct rlist in_sealed;
 	/** BPS tree */
 	struct vy_mem_tree tree;
+	/* The matras allocator used by the tree. */
+	struct matras_allocator matras_allocator;
 	/** Size of memory used for storing tree extents. */
 	size_t tree_extent_size;
 	/** Number of statements. */

--- a/src/lib/salad/bps_tree.h
+++ b/src/lib/salad/bps_tree.h
@@ -651,10 +651,8 @@ typedef void (*bps_tree_extent_free_f)(void *ctx, void *extent);
  *  see bps_tree_extent_free_f description for details
  */
 static inline void
-bps_tree_create(struct bps_tree *tree, bps_tree_arg_t arg,
-		bps_tree_extent_alloc_f extent_alloc_func,
-		bps_tree_extent_free_f extent_free_func,
-		void *alloc_ctx);
+bps_tree_create(struct bps_tree *t, bps_tree_arg_t arg,
+		struct matras_allocator *allocator);
 
 /**
  * @brief Fills a new (asserted) tree with values from sorted array.
@@ -1285,9 +1283,7 @@ struct bps_leaf_path_elem {
  */
 static inline void
 bps_tree_create(struct bps_tree *t, bps_tree_arg_t arg,
-		bps_tree_extent_alloc_f extent_alloc_func,
-		bps_tree_extent_free_f extent_free_func,
-		void *alloc_ctx)
+		struct matras_allocator *allocator)
 {
 	struct bps_tree_common *tree = &t->common;
 	tree->root_id = (bps_tree_block_id_t)(-1);
@@ -1301,9 +1297,7 @@ bps_tree_create(struct bps_tree *t, bps_tree_arg_t arg,
 	tree->garbage_head_id = (bps_tree_block_id_t)(-1);
 	tree->arg = arg;
 	memset(&tree->max_elem, 0, sizeof(tree->max_elem));
-	matras_create(&t->matras,
-		      BPS_TREE_EXTENT_SIZE, BPS_TREE_BLOCK_SIZE,
-		      extent_alloc_func, extent_free_func, alloc_ctx, NULL);
+	matras_create(&t->matras, BPS_TREE_BLOCK_SIZE, allocator, NULL);
 	matras_head_read_view(&t->view);
 	tree->matras = &t->matras;
 	tree->view = &t->view;

--- a/src/lib/salad/light.h
+++ b/src/lib/salad/light.h
@@ -216,10 +216,8 @@ static const uint32_t LIGHT(end) = 0xFFFFFFFF;
  * @param arg - optional parameter to save for comparing function
  */
 static inline void
-LIGHT(create)(struct LIGHT(core) *ht, size_t extent_size,
-	      LIGHT(extent_alloc_t) extent_alloc_func,
-	      LIGHT(extent_free_t) extent_free_func,
-	      void *alloc_ctx, LIGHT_CMP_ARG_TYPE arg);
+LIGHT(create)(struct LIGHT(core) *ht, LIGHT_CMP_ARG_TYPE arg,
+	      struct matras_allocator *allocator);
 
 /**
  * @brief Hash table destruction. Frees all allocated memory
@@ -443,10 +441,8 @@ LIGHT(view_iterator_get_and_next)(const struct LIGHT(view) *v,
  * @param arg - optional parameter to save for comparing function
  */
 static inline void
-LIGHT(create)(struct LIGHT(core) *htab, size_t extent_size,
-	      LIGHT(extent_alloc_t) extent_alloc_func,
-	      LIGHT(extent_free_t) extent_free_func,
-	      void *alloc_ctx, LIGHT_CMP_ARG_TYPE arg)
+LIGHT(create)(struct LIGHT(core) *htab, LIGHT_CMP_ARG_TYPE arg,
+	      struct matras_allocator *allocator)
 {
 	struct LIGHT(common) *ht = &htab->common;
 	assert((LIGHT_GROW_INCREMENT & (LIGHT_GROW_INCREMENT - 1)) == 0);
@@ -455,9 +451,8 @@ LIGHT(create)(struct LIGHT(core) *htab, size_t extent_size,
 	ht->table_size = 0;
 	ht->empty_slot = LIGHT(end);
 	ht->arg = arg;
-	matras_create(&htab->mtable,
-		      extent_size, sizeof(struct LIGHT(record)),
-		      extent_alloc_func, extent_free_func, alloc_ctx, NULL);
+	matras_create(&htab->mtable, sizeof(struct LIGHT(record)),
+		      allocator, NULL);
 	matras_head_read_view(&htab->view);
 	ht->mtable = &htab->mtable;
 	ht->view = &htab->view;

--- a/src/lib/salad/rtree.c
+++ b/src/lib/salad/rtree.c
@@ -941,9 +941,9 @@ rtree_iterator_next(struct rtree_iterator *itr)
 /*------------------------------------------------------------------------- */
 
 int
-rtree_init(struct rtree *tree, unsigned dimension, uint32_t extent_size,
-	   rtree_extent_alloc_t extent_alloc, rtree_extent_free_t extent_free,
-	   void *alloc_ctx, enum rtree_distance_type distance_type)
+rtree_init(struct rtree *tree, unsigned dimension,
+	   enum rtree_distance_type distance_type,
+	   struct matras_allocator *allocator)
 {
 	tree->n_records = 0;
 	tree->height = 0;
@@ -969,8 +969,7 @@ rtree_init(struct rtree *tree, unsigned dimension, uint32_t extent_size,
 	tree->neighbours_in_page = (tree->page_size - sizeof(void *))
 		/ sizeof(struct rtree_neighbor);
 
-	matras_create(&tree->mtab, extent_size, tree->page_size,
-		      extent_alloc, extent_free, alloc_ctx, NULL);
+	matras_create(&tree->mtab, tree->page_size, allocator, NULL);
 	return 0;
 }
 

--- a/src/lib/salad/rtree.h
+++ b/src/lib/salad/rtree.h
@@ -235,9 +235,9 @@ rtree_set2dp(struct rtree_rect *rect, coord_t x, coord_t y);
  * @return 0 on success, -1 on error
  */
 int
-rtree_init(struct rtree *tree, unsigned dimension, uint32_t extent_size,
-	   rtree_extent_alloc_t extent_alloc, rtree_extent_free_t extent_free,
-	   void *alloc_ctx, enum rtree_distance_type distance_type);
+rtree_init(struct rtree *tree, unsigned dimension,
+	   enum rtree_distance_type distance_type,
+	   struct matras_allocator *allocator);
 
 /**
  * @brief Destroy a tree

--- a/test/unit/bps_tree_view.c
+++ b/test/unit/bps_tree_view.c
@@ -16,23 +16,25 @@
 #include "salad/bps_tree.h"
 
 static void *
-extent_alloc(void *ctx)
+extent_alloc(struct matras_allocator *allocator)
 {
-	(void)ctx;
+	(void)allocator;
 	return xmalloc(BPS_TREE_EXTENT_SIZE);
 }
 
 static void
-extent_free(void *ctx, void *extent)
+extent_free(struct matras_allocator *allocator, void *extent)
 {
-	(void)ctx;
+	(void)allocator;
 	free(extent);
 }
+
+struct matras_allocator allocator;
 
 static void
 test_tree_do_create(struct test_tree *tree)
 {
-	test_tree_create(tree, NULL, extent_alloc, extent_free, NULL);
+	test_tree_create(tree, NULL, &allocator);
 }
 
 static void
@@ -454,6 +456,9 @@ main(void)
 	plan(8);
 	header();
 
+	matras_allocator_create(&allocator, BPS_TREE_EXTENT_SIZE,
+				extent_alloc, extent_free);
+
 	test_size();
 	test_find();
 	test_first();
@@ -462,6 +467,8 @@ main(void)
 	test_upper_bound();
 	test_iterator();
 	test_iterator_is_equal();
+
+	matras_allocator_destroy(&allocator);
 
 	footer();
 	return check_plan();

--- a/test/unit/light_view.c
+++ b/test/unit/light_view.c
@@ -39,23 +39,25 @@ equal_key(struct data a, int b)
 #include "salad/light.h"
 
 static void *
-alloc_extent(void *ctx)
+alloc_extent(struct matras_allocator *allocator)
 {
-	(void)ctx;
+	(void)allocator;
 	return xmalloc(extent_size);
 }
 
 static void
-free_extent(void *ctx, void *p)
+free_extent(struct matras_allocator *allocator, void *p)
 {
-	(void)ctx;
+	(void)allocator;
 	free(p);
 }
+
+static struct matras_allocator allocator;
 
 static void
 light_do_create(struct light_core *ht)
 {
-	light_create(ht, extent_size, alloc_extent, free_extent, NULL, NULL);
+	light_create(ht, NULL, &allocator);
 }
 
 static void
@@ -253,9 +255,14 @@ main(void)
 	plan(3);
 	header();
 
+	matras_allocator_create(&allocator, extent_size,
+				alloc_extent, free_extent);
+
 	test_count();
 	test_find();
 	test_iterator();
+
+	matras_allocator_destroy(&allocator);
 
 	footer();
 	return check_plan();

--- a/test/unit/rtree.cc
+++ b/test/unit/rtree.cc
@@ -11,22 +11,22 @@ static int page_count = 0;
 const uint32_t extent_size = 1024 * 8;
 
 static void *
-extent_alloc(void *ctx)
+extent_alloc(struct matras_allocator *allocator)
 {
-	int *p_page_count = (int *)ctx;
-	assert(p_page_count == &page_count);
-	++*p_page_count;
+	(void)allocator;
+	++page_count;
 	return malloc(extent_size);
 }
 
 static void
-extent_free(void *ctx, void *page)
+extent_free(struct matras_allocator *allocator, void *page)
 {
-	int *p_page_count = (int *)ctx;
-	assert(p_page_count == &page_count);
-	--*p_page_count;
+	(void)allocator;
+	--page_count;
 	free(page);
 }
+
+static struct matras_allocator allocator;
 
 static void
 simple_check()
@@ -39,9 +39,7 @@ simple_check()
 	header();
 
 	struct rtree tree;
-	rtree_init(&tree, 2, extent_size,
-		   extent_alloc, extent_free, &page_count,
-		   RTREE_EUCLID);
+	rtree_init(&tree, 2, RTREE_EUCLID, &allocator);
 
 	printf("Insert 1..X, remove 1..X\n");
 	for (size_t i = 1; i <= rounds; i++) {
@@ -233,9 +231,7 @@ neighbor_test()
 
 	for (size_t i = 0; i <= test_count; i++) {
 		struct rtree tree;
-		rtree_init(&tree, 2, extent_size,
-			   extent_alloc, extent_free, &page_count,
-			   RTREE_EUCLID);
+		rtree_init(&tree, 2, RTREE_EUCLID, &allocator);
 
 		rtree_test_build(&tree, arr, i);
 
@@ -258,8 +254,7 @@ neighbor_test()
 	struct rtree_iterator iterator;
 	rtree_iterator_init(&iterator);
 	struct rtree tree;
-	rtree_init(&tree, 2, extent_size, extent_alloc, extent_free, &page_count, 
-			RTREE_EUCLID);
+	rtree_init(&tree, 2, RTREE_EUCLID, &allocator);
 	if (rtree_search(&tree, &basis, SOP_NEIGHBOR, &iterator)) {
 		fail("found in empty", "true");
 	}
@@ -279,9 +274,12 @@ neighbor_test()
 int
 main(void)
 {
+	matras_allocator_create(&allocator, extent_size,
+				extent_alloc, extent_free);
 	simple_check();
 	neighbor_test();
 	if (page_count != 0) {
 		fail("memory leak!", "true");
 	}
+	matras_allocator_destroy(&allocator);
 }

--- a/test/unit/rtree_multidim.cc
+++ b/test/unit/rtree_multidim.cc
@@ -24,22 +24,22 @@ const unsigned TEST_ROUNDS = 1000;
 static int page_count = 0;
 
 static void *
-extent_alloc(void *ctx)
+extent_alloc(struct matras_allocator *allocator)
 {
-	int *p_page_count = (int *)ctx;
-	assert(p_page_count == &page_count);
-	++*p_page_count;
+	(void)allocator;
+	++page_count;
 	return malloc(extent_size);
 }
 
 static void
-extent_free(void *ctx, void *page)
+extent_free(struct matras_allocator *allocator, void *page)
 {
-	int *p_page_count = (int *)ctx;
-	assert(p_page_count == &page_count);
-	--*p_page_count;
+	(void)allocator;
+	--page_count;
 	free(page);
 }
+
+static struct matras_allocator matras_allocator;
 
 struct CCoordPair {
 	coord_t a, b;
@@ -487,9 +487,7 @@ rand_test()
 	CBoxSet<DIMENSION> set;
 
 	struct rtree tree;
-	rtree_init(&tree, DIMENSION, extent_size,
-		   extent_alloc, extent_free, &page_count,
-		   RTREE_EUCLID);
+	rtree_init(&tree, DIMENSION, RTREE_EUCLID, &matras_allocator);
 
 	printf("\tDIMENSION: %u, page size: %u, max fill good: %d\n",
 	       DIMENSION, tree.page_size, tree.page_max_fill >= 10);
@@ -534,6 +532,8 @@ rand_test()
 int
 main(void)
 {
+	matras_allocator_create(&matras_allocator, extent_size,
+				extent_alloc, extent_free);
 	srand(time(0));
 	rand_test<1>();
 	rand_test<2>();
@@ -543,4 +543,5 @@ main(void)
 	if (page_count != 0) {
 		fail("memory leak!", "true");
 	}
+	matras_allocator_destroy(&matras_allocator);
 }


### PR DESCRIPTION
A long time ago the it's been found that in some circumstances the RTREE index could fail to rollback because of OOM. This is the case because removal of a key from such an index can sometimes lead to allocation of new blocks that could fail. So, in order to guarantee a successful rollback of an insertion into the index, the memtx engine extent reservation machinery had been introduced (see the issue #727).

But some time ago it's beed found out that the reservation of memory prior to insertion can be not enough to guarantee a successful roll back of the statements, so it's been decided to use a regular malloc for failed allocations performed during rollback (see #10551). This also fixed the RTREE issue for which the extent reservation had been introduced in the first place.

But this functionality allows to simplify code of data structures, such as BPS tree, so that we can reserve the max amount of extents that could be required to perform an operation and, if reservation succeeds, be sure that we're safe from any kind of OOM up until we have finished the operation.

But it's only known to specific data structures which amount of memory will be required for them to perform their operations, and all current memtx structures (BPS tree, light hash, rtree, bitset) use matras to deal with memory allocations, so it would be nice to make them able to reserve exactly as much extents as they need themselves instead of reserving max sane amount of ones as it's done now (see the constants: `RESERVE_EXTENTS_BEFORE_REPLACE` and `RESERVE_EXTENTS_BEFORE_DELETE`).

The problem is that if we reserve extents in each matras instance we will possibly be wasting a lot of memory in each index, so it would be much better to share the reserved extents as it's done in the memtx engine now.

So, in order to allow indexes reserve memoy for themselves and share the reserved memory amoug all indexes, let's introduce a new entity: `matras_allocator`.

The entity is to be shared amoug all memtx indexes and it allows to reserve memory for indexes for various purposes. So instead of matras holding the reserved extents, it's the deal of the new shared entity.

And the entity is exactly what the small submodule bump introduces.

Needed for tarantool/tarantool-ee#822

NO_DOC=submodule bump
NO_TEST=submodule bump
NO_CHANGELOG=submodule bump

(cherry picked from commit 7f1b3ef192ce532a6949c3d22f2a3ef2d1614612)