### PR TITLE
box: move txn list out of memtx manager

### DIFF
--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -53,6 +53,9 @@ extern struct rmean *rmean_box;
  */
 extern int64_t txn_next_psn;
 
+/** List of all in-progress transactions. */
+extern struct rlist txns;
+
 struct journal_entry;
 struct engine;
 struct space;
@@ -530,8 +533,8 @@ struct txn {
 	struct rlist point_holes_list;
 	/** List of gap reads. @sa struct inplace_gap_item / nearby_gap_item. */
 	struct rlist gap_list;
-	/** Link in tx_manager::all_txs. */
-	struct rlist in_all_txs;
+	/** Link in global txns. */
+	struct rlist in_txns;
 	/** True in case transaction provides any DDL change. */
 	bool is_schema_changed;
 	/** Timeout for transaction, or TIMEOUT_INFINITY if not set. */

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -1022,7 +1022,6 @@ vinyl_space_prepare_alter(struct space *old_space, struct space *new_space)
 static void
 vinyl_space_invalidate(struct space *space)
 {
-	struct vy_env *env = vy_env(space->engine);
 	/*
 	 * Abort all transactions involving the invalidated space.
 	 * An aborted transaction doesn't allow any DML/DQL requests
@@ -1037,7 +1036,7 @@ vinyl_space_invalidate(struct space *space)
 	 * request bail out early, without dereferencing the space.
 	 */
 	bool unused;
-	vy_tx_manager_abort_writers_for_ddl(env->xm, space, &unused);
+	vy_tx_manager_abort_writers_for_ddl(space, &unused);
 }
 
 /** Argument passed to vy_check_format_on_replace(). */
@@ -1107,7 +1106,7 @@ vinyl_space_check_format(struct space *space, struct tuple_format *format)
 	 * be checked with on_replace trigger so we abort them.
 	 */
 	bool need_wal_sync;
-	vy_tx_manager_abort_writers_for_ddl(env->xm, space, &need_wal_sync);
+	vy_tx_manager_abort_writers_for_ddl(space, &need_wal_sync);
 
 	if (!need_wal_sync && vy_lsm_is_empty(pk))
 		return 0; /* space is empty, nothing to do */
@@ -2531,8 +2530,7 @@ vinyl_engine_rollback_statement(struct engine *engine, struct txn *txn,
 static void
 vinyl_engine_switch_to_ro(struct engine *engine)
 {
-	struct vy_env *env = vy_env(engine);
-	vy_tx_manager_abort_writers_for_ro(env->xm);
+	vy_tx_manager_abort_writers_for_ro(engine);
 }
 
 /* }}} Public API of transaction control */
@@ -4305,7 +4303,7 @@ vinyl_space_build_index(struct space *src_space, struct index *new_index,
 	 * be checked with on_replace trigger so we abort them.
 	 */
 	bool need_wal_sync;
-	vy_tx_manager_abort_writers_for_ddl(env->xm, src_space, &need_wal_sync);
+	vy_tx_manager_abort_writers_for_ddl(src_space, &need_wal_sync);
 
 	if (!need_wal_sync && vy_lsm_is_empty(pk))
 		return 0; /* space is empty, nothing to do */

--- a/test/unit/core_test_utils.c
+++ b/test/unit/core_test_utils.c
@@ -28,6 +28,7 @@
  * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
+#include <small/rlist.h>
 
 /**
  * Mock function to resolve circular dependencies in unit tests
@@ -35,3 +36,5 @@
 void cord_on_yield(void)
 {
 }
+
+RLIST_HEAD(txns);

--- a/tools/tarantool-gdb.py
+++ b/tools/tarantool-gdb.py
@@ -1672,6 +1672,7 @@ class RlistLut(ListLut):
         ('session_on_connect', 'trigger::link'),
         ('session_on_disconnect', 'trigger::link'),
         ('shutdown_list', 'session::in_shutdown_list'),
+        ('txns', 'txn::in_txns'),
     )
     _containers = (
         ('alter_space::ops', 'AlterSpaceOp::link'),
@@ -1727,7 +1728,6 @@ class RlistLut(ListLut):
         ('tx_manager::read_view_txs', 'txn::in_read_view_txs'),
         ('tx_manager::all_stories', 'memtx_story::in_all_stories'),
         ('tx_manager::traverse_all_stories', 'memtx_story::in_all_stories'), # struct rlist*
-        ('tx_manager::all_txs', 'txn::in_all_txs'),
         ('txn::conflict_list', 'tx_conflict_tracker::in_conflict_list'),
         ('txn::conflicted_by_list', 'tx_conflict_tracker::in_conflicted_by_list'),
         ('txn::gap_list', 'gap_item::in_gap_list'),

--- a/tools/tarantool-gdb.py
+++ b/tools/tarantool-gdb.py
@@ -1758,7 +1758,6 @@ class RlistLut(ListLut):
         ('vy_recovery::lsms', 'vy_lsm_recovery_info::in_recovery'),
         ('vy_tx::on_destroy', 'trigger::link'),
         ('vy_tx_manager::read_views', 'vy_read_view::in_read_views'),
-        ('vy_tx_manager::writers', 'vy_tx::in_writers'),
         ('vy_write_iterator::src_list', 'vy_write_src::in_src_list'),
         ('wal_writer::watchers', 'wal_watcher::next'),
         ('watchable::pending_watchers', 'watcher::in_idle_or_pending'),


### PR DESCRIPTION
It is not something intrinsic to the manager and also is useful for other engines.

Part of tarantool/tarantool-ee#893
