### PR TITLE
[backport/release/3.3] test: enable back tests for LuaJIT

### DIFF
--- a/cmake/luajit.cmake
+++ b/cmake/luajit.cmake
@@ -39,8 +39,14 @@ set(LUAJIT_SMART_STRINGS ON CACHE BOOL
     "Harder string hashing function" FORCE)
 set(LUAJIT_TEST_BINARY $<TARGET_FILE:tarantool> CACHE STRING
     "Lua implementation to be used for tests (tarantool)" FORCE)
-set(LUAJIT_USE_TEST OFF CACHE BOOL
-    "Generate <test> target" FORCE)
+
+if(ENABLE_ASAN)
+  # FIXME: Disabled due to
+  # https://github.com/tarantool/tarantool/issues/10733.
+  set(LUAJIT_USE_TEST OFF CACHE BOOL "Generate <test> target" FORCE)
+else()
+  set(LUAJIT_USE_TEST ON CACHE BOOL "Generate <test> target" FORCE)
+endif()
 
 # XXX: There is <strict> module enabled by default in Tarantool
 # built in Debug, so we need to tweak LuaJIT testing environment.

--- a/test/luajit-test-init.lua
+++ b/test/luajit-test-init.lua
@@ -1,6 +1,8 @@
 -- Disable strict for Tarantool.
 require("strict").off()
 
+local ffi = require('ffi')
+local alloc = require('internal.alloc')
 local loaders = require('internal.loaders')
 
 -- XXX: lua-Harness test suite uses it's own tap.lua module
@@ -136,6 +138,15 @@ assert(type(pairs) == 'function')
 -- test suite, but likely it would be more correct to discard the
 -- test case.
 loaders.override_builtin_disable()
+
+-- Increase the default Lua memory limit.
+--
+-- Some tests in the tarantool-tests suite of LuaJIT assume that
+-- for the GC64 build we have more than 4 GB of Lua memory.
+-- Increase the limit to 128 TiB (LuaJIT maximum for GC64 mode).
+if ffi.abi('gc64') then
+  alloc.setlimit(128 * 1024 * 1024 * 1024 * 1024)
+end
 
 -- This is workaround introduced for flaky macosx tests reported by
 -- https://github.com/tarantool/tarantool/issues/7058


### PR DESCRIPTION
Orig PR: https://github.com/tarantool/tarantool/pull/10824.

---

The first patch adds some fixups to be able to run LuaJIT tests under Tarantool in GC64 mode.

Since the commit https://github.com/tarantool/tarantool/commit/db351d3bc46cf80f4f673129c46a3a4b8be3cadd ("luajit: bump new version"), which introduces CTest as a launcher for LuaJIT's test suites, the LuaJIT tests are not run by Tarantool since LUAJIT_USE_TEST is disabled. The second patch enables all tests, except ASAN build, due to https://github.com/tarantool/tarantool/issues/10733.
