### PR TITLE
[backport/release/2.11] test: enable back tests for LuaJIT

### DIFF
--- a/cmake/luajit.cmake
+++ b/cmake/luajit.cmake
@@ -39,8 +39,14 @@ set(LUAJIT_SMART_STRINGS ON CACHE BOOL
     "Harder string hashing function" FORCE)
 set(LUAJIT_TEST_BINARY $<TARGET_FILE:tarantool> CACHE STRING
     "Lua implementation to be used for tests (tarantool)" FORCE)
-set(LUAJIT_USE_TEST OFF CACHE BOOL
-    "Generate <test> target" FORCE)
+
+if(ENABLE_ASAN)
+  # FIXME: Disabled due to
+  # https://github.com/tarantool/tarantool/issues/10733.
+  set(LUAJIT_USE_TEST OFF CACHE BOOL "Generate <test> target" FORCE)
+else()
+  set(LUAJIT_USE_TEST ON CACHE BOOL "Generate <test> target" FORCE)
+endif()
 
 # XXX: There is <strict> module enabled by default in Tarantool
 # built in Debug, so we need to tweak LuaJIT testing environment.


### PR DESCRIPTION
Orig PR: https://github.com/tarantool/tarantool/pull/10824.

The first commit isn't taken, since the Lua memory limit is introduced for version 3.3+.

---

Since the commit db351d3bc46cf80f4f673129c46a3a4b8be3cadd ("luajit: bump new version"), which introduces CTest as a launcher for LuaJIT's test suites, the LuaJIT tests are not run by Tarantool since `LUAJIT_USE_TEST` is disabled. This patch enables all tests, except ASAN build, due to #10733.

NO_DOC=testing
NO_CHANGELOG=testing
NO_TEST=enable tests back

(cherry picked from commit 1f09ba66ed30311256fb0235a08870a1193f750c)