### PR TITLE
log: fix truncating log message to 1024 bytes in 'json' log

### DIFF
--- a/changelogs/unreleased/gh-10918-fix-log-message-truncate.md
+++ b/changelogs/unreleased/gh-10918-fix-log-message-truncate.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fixed log message being truncated to 1024 bytes with JSON logger (gh-10918).

--- a/src/trivia/util.h
+++ b/src/trivia/util.h
@@ -696,6 +696,12 @@ int
 json_escape(char *buf, int size, const char *data);
 
 /**
+ * Escape special characters in @a buf inplace
+ */
+int
+json_escape_inplace(char *buf, int size);
+
+/**
  * Helper macro to handle easily snprintf() result
  */
 #define SNPRINT(_total, _fun, _buf, _size, ...) do {				\


### PR DESCRIPTION
Before this patch, when log format was set to 'json' and log entry was written with format-string API (`require('log').info(<format string>, args...)`), in the output the message was truncated to 1024 bytes.

This patch fixes this behavior, and now the message will only be truncated if the full log entry (with all the context) doesn't fit into the 16KiB buffer. The message will be truncated in a way, so all the context is present.

Closes #10918

NO_DOC=bugfix