### PR TITLE
small: bump version

### DIFF
--- a/src/box/memtx_bitset.cc
+++ b/src/box/memtx_bitset.cc
@@ -538,8 +538,8 @@ memtx_bitset_index_new(struct memtx_engine *memtx, struct index_def *def)
 	index->id_to_tuple = (struct matras *)malloc(sizeof(*index->id_to_tuple));
 	if (index->id_to_tuple == NULL)
 		panic("failed to allocate memtx bitset index");
-	matras_create(index->id_to_tuple, MEMTX_EXTENT_SIZE, sizeof(struct tuple *),
-		      memtx_index_extent_alloc, memtx_index_extent_free, memtx,
+	matras_create(index->id_to_tuple, sizeof(struct tuple *),
+		      &memtx->index_extent_allocator,
 		      &memtx->index_extent_stats);
 
 	index->tuple_to_id = mh_bitset_index_new();

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -144,19 +144,12 @@ struct memtx_engine {
 	struct slab_cache slab_cache;
 	/** Slab cache for allocating index extents. */
 	struct slab_cache index_slab_cache;
-	/** Index extent allocator. */
+	/** Index extent source. */
 	struct mempool index_extent_pool;
+	/** Index extent allocator. */
+	struct matras_allocator index_extent_allocator;
 	/** Index extent allocator statistics. */
 	struct matras_stats index_extent_stats;
-	/**
-	 * To ensure proper statement-level rollback in case
-	 * of out of memory conditions, we maintain a number
-	 * of slack memory extents reserved before a statement
-	 * is begun. If there isn't enough slack memory,
-	 * we don't begin the statement.
-	 */
-	int num_reserved_extents;
-	void *reserved_extents;
 	/** Maximal allowed tuple size, box.cfg.memtx_max_tuple_size. */
 	size_t max_tuple_size;
 	/** Memory pool for rtree index iterator. */
@@ -260,20 +253,6 @@ enum {
 extern struct tuple *
 (*memtx_tuple_new_raw)(struct tuple_format *format, const char *data,
 		       const char *end, bool validate);
-
-/**
- * Allocate a block of size MEMTX_EXTENT_SIZE for memtx index
- * @ctx must point to memtx engine
- */
-void *
-memtx_index_extent_alloc(void *ctx);
-
-/**
- * Free a block previously allocated by memtx_index_extent_alloc
- * @ctx must point to memtx engine
- */
-void
-memtx_index_extent_free(void *ctx, void *extent);
 
 /**
  * Reserve num extents in pool.

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -685,8 +685,7 @@ memtx_hash_index_new(struct memtx_engine *memtx, struct index_def *def)
 		     &memtx_hash_index_vtab, def);
 
 	light_index_create(&index->hash_table, index->base.def->key_def,
-			   MEMTX_EXTENT_SIZE, memtx_index_extent_alloc,
-			   memtx_index_extent_free, memtx,
+			   &memtx->index_extent_allocator,
 			   &memtx->index_extent_stats);
 	return &index->base;
 }

--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -446,7 +446,6 @@ memtx_rtree_index_new(struct memtx_engine *memtx, struct index_def *def)
 
 	index->dimension = def->opts.dimension;
 	rtree_init(&index->tree, index->dimension, distance_type,
-		   MEMTX_EXTENT_SIZE, memtx_index_extent_alloc,
-		   memtx_index_extent_free, memtx, &memtx->index_extent_stats);
+		   &memtx->index_extent_allocator, &memtx->index_extent_stats);
 	return &index->base;
 }

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -2294,8 +2294,8 @@ memtx_tree_index_new_tpl(struct memtx_engine *memtx, struct index_def *def,
 	cmp_def = def->opts.is_unique && !def->key_def->is_nullable ?
 			index->base.def->key_def : index->base.def->cmp_def;
 
-	memtx_tree_create(&index->tree, cmp_def, memtx_index_extent_alloc,
-			  memtx_index_extent_free, memtx,
+	memtx_tree_create(&index->tree, cmp_def,
+			  &memtx->index_extent_allocator,
 			  &memtx->index_extent_stats);
 	index->is_func = def->key_def->func_index_func != NULL;
 	return &index->base;

--- a/src/box/vy_cache.h
+++ b/src/box/vy_cache.h
@@ -119,6 +119,8 @@ struct vy_cache_env {
 	struct rlist cache_lru;
 	/** Common mempool for vy_cache_node struct */
 	struct mempool cache_node_mempool;
+	/** Common matras extent allocator. */
+	struct matras_allocator allocator;
 	/** Size of memory occupied by cached tuples */
 	size_t mem_used;
 	/** Max memory size that can be used for cache */

--- a/src/box/vy_mem.c
+++ b/src/box/vy_mem.c
@@ -71,9 +71,10 @@ vy_mem_env_destroy(struct vy_mem_env *env)
 /** {{{ vy_mem */
 
 static void *
-vy_mem_tree_extent_alloc(void *ctx)
+vy_mem_tree_extent_alloc(struct matras_allocator *allocator)
 {
-	struct vy_mem *mem = (struct vy_mem *) ctx;
+	struct vy_mem *mem = container_of(allocator, struct vy_mem,
+					  matras_allocator);
 	struct vy_mem_env *env = mem->env;
 	void *ret = lsregion_aligned_alloc(&env->allocator,
 					   VY_MEM_TREE_EXTENT_SIZE,
@@ -89,10 +90,10 @@ vy_mem_tree_extent_alloc(void *ctx)
 }
 
 static void
-vy_mem_tree_extent_free(void *ctx, void *p)
+vy_mem_tree_extent_free(struct matras_allocator *allocator, void *p)
 {
 	/* Can't free part of region allocated memory. */
-	(void)ctx;
+	(void)allocator;
 	(void)p;
 }
 
@@ -114,9 +115,12 @@ vy_mem_new(struct vy_mem_env *env, struct key_def *cmp_def,
 	index->space_cache_version = space_cache_version;
 	index->format = format;
 	tuple_format_ref(format);
+	matras_allocator_create(&index->matras_allocator,
+				VY_MEM_TREE_EXTENT_SIZE,
+				vy_mem_tree_extent_alloc,
+				vy_mem_tree_extent_free);
 	vy_mem_tree_create(&index->tree, cmp_def,
-			   vy_mem_tree_extent_alloc,
-			   vy_mem_tree_extent_free, index, NULL);
+			   &index->matras_allocator, NULL);
 	rlist_create(&index->in_sealed);
 	fiber_cond_create(&index->pin_cond);
 	return index;
@@ -126,6 +130,13 @@ void
 vy_mem_delete(struct vy_mem *index)
 {
 	index->env->tree_extent_size -= index->tree_extent_size;
+	/*
+	 * It would be expected to destroy the index->matras_allocator and
+	 * the index->tree here, but they simply free allocated and reserved
+	 * memory blocks, and the lsregion used for allocation of the memory
+	 * does not support freeing arbitrary blocks, so they're effectively
+	 * no-ops. Let's omit them.
+	 */
 	tuple_format_unref(index->format);
 	fiber_cond_destroy(&index->pin_cond);
 	TRASH(index);

--- a/src/box/vy_mem.h
+++ b/src/box/vy_mem.h
@@ -162,6 +162,8 @@ struct vy_mem {
 	struct rlist in_sealed;
 	/** BPS tree */
 	struct vy_mem_tree tree;
+	/* The matras allocator used by the tree. */
+	struct matras_allocator matras_allocator;
 	/** Size of memory used for storing tree extents. */
 	size_t tree_extent_size;
 	/** Number of statements. */

--- a/src/lib/salad/bps_tree.h
+++ b/src/lib/salad/bps_tree.h
@@ -697,10 +697,9 @@ struct bps_tree_iterator {
  * @param alloc_stats - optional extent allocator statistics
  */
 static inline void
-bps_tree_create(struct bps_tree *tree, bps_tree_arg_t arg,
-		matras_alloc_func extent_alloc_func,
-		matras_free_func extent_free_func,
-		void *alloc_ctx, struct matras_stats *alloc_stats);
+bps_tree_create(struct bps_tree *t, bps_tree_arg_t arg,
+		struct matras_allocator *allocator,
+		struct matras_stats *alloc_stats);
 
 /**
  * @brief Fills a new (asserted) tree with values from sorted array.
@@ -1578,9 +1577,8 @@ struct bps_leaf_path_elem {
  */
 static inline void
 bps_tree_create(struct bps_tree *t, bps_tree_arg_t arg,
-		matras_alloc_func extent_alloc_func,
-		matras_free_func extent_free_func,
-		void *alloc_ctx, struct matras_stats *alloc_stats)
+		struct matras_allocator *allocator,
+		struct matras_stats *alloc_stats)
 {
 	struct bps_tree_common *tree = &t->common;
 	tree->root_id = (bps_tree_block_id_t)(-1);
@@ -1594,10 +1592,7 @@ bps_tree_create(struct bps_tree *t, bps_tree_arg_t arg,
 	tree->garbage_head_id = (bps_tree_block_id_t)(-1);
 	tree->arg = arg;
 	memset(&tree->max_elem, 0, sizeof(tree->max_elem));
-	matras_create(&t->matras,
-		      BPS_TREE_EXTENT_SIZE, BPS_TREE_BLOCK_SIZE,
-		      extent_alloc_func, extent_free_func, alloc_ctx,
-		      alloc_stats);
+	matras_create(&t->matras, BPS_TREE_BLOCK_SIZE, allocator, alloc_stats);
 	matras_head_read_view(&t->view);
 	tree->matras = &t->matras;
 	tree->view = &t->view;

--- a/src/lib/salad/light.h
+++ b/src/lib/salad/light.h
@@ -212,8 +212,7 @@ static const uint32_t LIGHT(end) = 0xFFFFFFFF;
  */
 static inline void
 LIGHT(create)(struct LIGHT(core) *ht, LIGHT_CMP_ARG_TYPE arg,
-	      size_t extent_size, matras_alloc_func extent_alloc_func,
-	      matras_free_func extent_free_func, void *alloc_ctx,
+	      struct matras_allocator *allocator,
 	      struct matras_stats *alloc_stats);
 
 /**
@@ -440,8 +439,7 @@ LIGHT(view_iterator_get_and_next)(const struct LIGHT(view) *v,
  */
 static inline void
 LIGHT(create)(struct LIGHT(core) *htab, LIGHT_CMP_ARG_TYPE arg,
-	      size_t extent_size, matras_alloc_func extent_alloc_func,
-	      matras_free_func extent_free_func, void *alloc_ctx,
+	      struct matras_allocator *allocator,
 	      struct matras_stats *alloc_stats)
 {
 	struct LIGHT(common) *ht = &htab->common;
@@ -451,10 +449,8 @@ LIGHT(create)(struct LIGHT(core) *htab, LIGHT_CMP_ARG_TYPE arg,
 	ht->table_size = 0;
 	ht->empty_slot = LIGHT(end);
 	ht->arg = arg;
-	matras_create(&htab->mtable,
-		      extent_size, sizeof(struct LIGHT(record)),
-		      extent_alloc_func, extent_free_func, alloc_ctx,
-		      alloc_stats);
+	matras_create(&htab->mtable, sizeof(struct LIGHT(record)),
+		      allocator, alloc_stats);
 	matras_head_read_view(&htab->view);
 	ht->mtable = &htab->mtable;
 	ht->view = &htab->view;

--- a/src/lib/salad/rtree.c
+++ b/src/lib/salad/rtree.c
@@ -942,9 +942,9 @@ rtree_iterator_next(struct rtree_iterator *itr)
 
 void
 rtree_init(struct rtree *tree, unsigned dimension,
-	   enum rtree_distance_type distance_type, uint32_t extent_size,
-	   matras_alloc_func extent_alloc, matras_free_func extent_free,
-	   void *alloc_ctx, struct matras_stats *alloc_stats)
+	   enum rtree_distance_type distance_type,
+	   struct matras_allocator *allocator,
+	   struct matras_stats *alloc_stats)
 {
 	tree->n_records = 0;
 	tree->height = 0;
@@ -970,8 +970,7 @@ rtree_init(struct rtree *tree, unsigned dimension,
 	tree->neighbours_in_page = (tree->page_size - sizeof(void *))
 		/ sizeof(struct rtree_neighbor);
 
-	matras_create(&tree->mtab, extent_size, tree->page_size,
-		      extent_alloc, extent_free, alloc_ctx, alloc_stats);
+	matras_create(&tree->mtab, tree->page_size, allocator, alloc_stats);
 }
 
 void

--- a/src/lib/salad/rtree.h
+++ b/src/lib/salad/rtree.h
@@ -234,9 +234,9 @@ rtree_set2dp(struct rtree_rect *rect, coord_t x, coord_t y);
  */
 void
 rtree_init(struct rtree *tree, unsigned dimension,
-	   enum rtree_distance_type distance_type, uint32_t extent_size,
-	   matras_alloc_func extent_alloc, matras_free_func extent_free,
-	   void *alloc_ctx, struct matras_stats *alloc_stats);
+	   enum rtree_distance_type distance_type,
+	   struct matras_allocator *allocator,
+	   struct matras_stats *alloc_stats);
 
 /**
  * @brief Destroy a tree

--- a/test/unit/bps_tree.cc
+++ b/test/unit/bps_tree.cc
@@ -175,22 +175,22 @@ compare(type_t a, type_t b)
 static int extents_count = 0;
 
 static void *
-extent_alloc(void *ctx)
+extent_alloc(struct matras_allocator *allocator)
 {
-	int *p_extents_count = (int *)ctx;
-	assert(p_extents_count == &extents_count);
-	++*p_extents_count;
-	return malloc(BPS_TREE_EXTENT_SIZE);
+	(void)allocator;
+	++extents_count;
+	return xmalloc(BPS_TREE_EXTENT_SIZE);
 }
 
 static void
-extent_free(void *ctx, void *extent)
+extent_free(struct matras_allocator *allocator, void *extent)
 {
-	int *p_extents_count = (int *)ctx;
-	assert(p_extents_count == &extents_count);
-	--*p_extents_count;
+	(void)allocator;
+	--extents_count;
 	free(extent);
 }
+
+struct matras_allocator allocator;
 
 static void
 simple_check()
@@ -204,8 +204,7 @@ simple_check()
 
 	const unsigned int rounds = 2000;
 	test tree;
-	test_create(&tree, 0, extent_alloc, extent_free, &extents_count,
-		    &stats);
+	test_create(&tree, 0, &allocator, &stats);
 
 	for (unsigned int i = 0; i < rounds; i++) {
 		type_t v = i;
@@ -345,7 +344,7 @@ compare_with_sptree_check()
 	sptree_test_init(&spt_test, sizeof(type_t), 0, 0, 0, &node_comp, 0, 0);
 
 	test tree;
-	test_create(&tree, 0, extent_alloc, extent_free, &extents_count, NULL);
+	test_create(&tree, 0, &allocator, NULL);
 
 	const int rounds = 16 * 1024;
 	const int elem_limit = 	1024;
@@ -387,7 +386,7 @@ compare_with_sptree_check_branches()
 	sptree_test_init(&spt_test, sizeof(type_t), 0, 0, 0, &node_comp, 0, 0);
 
 	test tree;
-	test_create(&tree, 0, extent_alloc, extent_free, &extents_count, NULL);
+	test_create(&tree, 0, &allocator, NULL);
 
 	const int elem_limit = 2048;
 
@@ -626,8 +625,7 @@ loading_test()
 		arr[i] = i;
 
 	for (type_t i = 0; i <= test_count; i++) {
-		test_create(&tree, 0, extent_alloc, extent_free,
-			    &extents_count, NULL);
+		test_create(&tree, 0, &allocator, NULL);
 
 		if (test_build(&tree, arr, i))
 			fail("building failed", "true");
@@ -655,7 +653,7 @@ static void
 printing_test()
 {
 	test tree;
-	test_create(&tree, 0, extent_alloc, extent_free, &extents_count, NULL);
+	test_create(&tree, 0, &allocator, NULL);
 	const type_t rounds = 22;
 	for (type_t i = 0; i < rounds; i++) {
 		type_t v = rounds + i;
@@ -682,7 +680,7 @@ white_box_test()
 	const int count_in_leaf = BPS_TREE_test_MAX_COUNT_IN_LEAF;
 	const int count_in_inner = BPS_TREE_test_MAX_COUNT_IN_INNER;
 
-	test_create(&tree, 0, extent_alloc, extent_free, &extents_count, NULL);
+	test_create(&tree, 0, &allocator, NULL);
 
 	for (type_t i = 0; i < count_in_leaf; i++)
 		test_insert(&tree, i, 0, 0);
@@ -707,7 +705,7 @@ white_box_test()
 
 	test_destroy(&tree);
 
-	test_create(&tree, 0, extent_alloc, extent_free, &extents_count, NULL);
+	test_create(&tree, 0, &allocator, NULL);
 
 	type_t arr[count_in_leaf * count_in_inner];
 	for (type_t i = 0; i < count_in_leaf * count_in_inner; i++)
@@ -732,8 +730,7 @@ approximate_count()
 	srand(0);
 
 	approx tree;
-	approx_create(&tree, 0, extent_alloc, extent_free, &extents_count,
-		      NULL);
+	approx_create(&tree, 0, &allocator, NULL);
 
 	uint32_t in_leaf_max_count = BPS_TREE_approx_MAX_COUNT_IN_LEAF;
 	uint32_t in_leaf_min_count = in_leaf_max_count * 2 / 3;
@@ -831,7 +828,7 @@ static void
 insert_get_iterator()
 {
 	test tree;
-	test_create(&tree, 0, extent_alloc, extent_free, &extents_count, NULL);
+	test_create(&tree, 0, &allocator, NULL);
 	type_t value = 100000;
 
 	bps_insert_and_check(test, &tree, value, NULL)
@@ -853,8 +850,7 @@ delete_value_check()
 	header();
 
 	struct_tree tree;
-	struct_tree_create(&tree, 0, extent_alloc, extent_free, &extents_count,
-			   NULL);
+	struct_tree_create(&tree, 0, &allocator, NULL);
 	struct elem_t e1 = {1, 1};
 	struct_tree_insert(&tree, e1, NULL, NULL);
 	struct elem_t e2 = {1, 2};
@@ -884,8 +880,7 @@ insert_successor_test()
 
 	for (size_t i = 0; i < sizeof(limits) / sizeof(limits[0]); i++) {
 		size_t limit = limits[i];
-		test_create(&tree, 0, extent_alloc, extent_free, &extents_count,
-			    NULL);
+		test_create(&tree, 0, &allocator, NULL);
 
 		for (size_t j = 0; j < limit; j++) {
 			type_t v = 1 + rand() % (limit - 1);
@@ -924,6 +919,9 @@ main(void)
 	plan(12);
 	header();
 
+	matras_allocator_create(&allocator, BPS_TREE_EXTENT_SIZE,
+				extent_alloc, extent_free);
+
 	simple_check();
 	compare_with_sptree_check();
 	compare_with_sptree_check_branches();
@@ -936,6 +934,8 @@ main(void)
 	insert_get_iterator();
 	delete_value_check();
 	insert_successor_test();
+
+	matras_allocator_destroy(&allocator);
 
 	footer();
 	return check_plan();

--- a/test/unit/bps_tree_iterator.cc
+++ b/test/unit/bps_tree_iterator.cc
@@ -56,22 +56,22 @@ static int compare_key(const elem_t &a, long b)
 int total_extents_allocated = 0;
 
 static void *
-extent_alloc(void *ctx)
+extent_alloc(struct matras_allocator *allocator)
 {
-	int *p_total_extents_allocated = (int *)ctx;
-	assert(p_total_extents_allocated == &total_extents_allocated);
-	++*p_total_extents_allocated;
-	return malloc(BPS_TREE_EXTENT_SIZE);
+	(void)allocator;
+	++total_extents_allocated;
+	return xmalloc(BPS_TREE_EXTENT_SIZE);
 }
 
 static void
-extent_free(void *ctx, void *extent)
+extent_free(struct matras_allocator *allocator, void *extent)
 {
-	int *p_total_extents_allocated = (int *)ctx;
-	assert(p_total_extents_allocated == &total_extents_allocated);
-	--*p_total_extents_allocated;
+	(void)allocator;
+	--total_extents_allocated;
 	free(extent);
 }
+
+struct matras_allocator allocator;
 
 static void
 iterator_check()
@@ -80,8 +80,7 @@ iterator_check()
 	header();
 
 	test tree;
-	test_create(&tree, 0, extent_alloc, extent_free,
-		    &total_extents_allocated, NULL);
+	test_create(&tree, 0, &allocator, NULL);
 
 	{
 		test_iterator tmp1, tmp2;
@@ -245,8 +244,7 @@ iterator_invalidate_check()
 		long del_cnt = rand() % max_delete_count + 1;
 		if (del_pos + del_cnt > test_size)
 			del_cnt = test_size - del_pos;
-		test_create(&tree, 0, extent_alloc, extent_free,
-			    &total_extents_allocated, NULL);
+		test_create(&tree, 0, &allocator, NULL);
 
 		for (long i = 0; i < test_size; i++) {
 			elem_t e;
@@ -290,8 +288,7 @@ iterator_invalidate_check()
 	for (long attempt = 0; attempt < attempt_count; attempt++) {
 		long ins_pos = rand() % test_size;
 		long ins_cnt = rand() % max_insert_count + 1;
-		test_create(&tree, 0, extent_alloc, extent_free,
-			    &total_extents_allocated, NULL);
+		test_create(&tree, 0, &allocator, NULL);
 
 		for (long i = 0; i < test_size; i++) {
 			elem_t e;
@@ -346,8 +343,7 @@ iterator_invalidate_check()
 		long ins_cnt = rand() % max_insert_count + 1;
 		if (del_pos + del_cnt > test_size)
 			del_cnt = test_size - del_pos;
-		test_create(&tree, 0, extent_alloc, extent_free,
-			    &total_extents_allocated, NULL);
+		test_create(&tree, 0, &allocator, NULL);
 
 		for (long i = 0; i < test_size; i++) {
 			elem_t e;
@@ -417,8 +413,7 @@ iterator_freeze_check()
 	struct test tree;
 
 	for (int i = 0; i < 10; i++) {
-		test_create(&tree, 0, extent_alloc, extent_free,
-			    &total_extents_allocated, NULL);
+		test_create(&tree, 0, &allocator, NULL);
 		int comp_buf_size1 = 0;
 		int comp_buf_size2 = 0;
 		for (int j = 0; j < test_data_size; j++) {
@@ -496,11 +491,16 @@ main(void)
 	plan(4);
 	header();
 
+	matras_allocator_create(&allocator, BPS_TREE_EXTENT_SIZE,
+				extent_alloc, extent_free);
+
 	srand(time(0));
 	iterator_check();
 	iterator_invalidate_check();
 	iterator_freeze_check();
 	ok(total_extents_allocated == 0, "memory leak check");
+
+	matras_allocator_destroy(&allocator);
 
 	footer();
 	return check_plan();

--- a/test/unit/bps_tree_view.c
+++ b/test/unit/bps_tree_view.c
@@ -25,7 +25,7 @@
 #include "salad/bps_tree.h"
 
 #define test_tree_do_create(tree) \
-	test_tree_create(tree, NULL, extent_alloc, extent_free, NULL, NULL)
+	test_tree_create(tree, NULL, &allocator, NULL)
 
 #define test_tree_do_insert(tree, val) \
 	fail_if(test_tree_insert((tree), (val), NULL, NULL) != 0)
@@ -34,18 +34,20 @@
 	fail_if(test_tree_view_debug_check((view)))
 
 static void *
-extent_alloc(void *ctx)
+extent_alloc(struct matras_allocator *allocator)
 {
-	(void)ctx;
+	(void)allocator;
 	return xmalloc(BPS_TREE_EXTENT_SIZE);
 }
 
 static void
-extent_free(void *ctx, void *extent)
+extent_free(struct matras_allocator *allocator, void *extent)
 {
-	(void)ctx;
+	(void)allocator;
 	free(extent);
 }
+
+struct matras_allocator allocator;
 
 static void
 test_size(void)
@@ -484,6 +486,9 @@ main(void)
 	plan(8);
 	header();
 
+	matras_allocator_create(&allocator, BPS_TREE_EXTENT_SIZE,
+				extent_alloc, extent_free);
+
 	test_size();
 	test_find();
 	test_first();
@@ -492,6 +497,8 @@ main(void)
 	test_upper_bound();
 	test_iterator();
 	test_iterator_is_equal();
+
+	matras_allocator_destroy(&allocator);
 
 	footer();
 	return check_plan();

--- a/test/unit/light.cc
+++ b/test/unit/light.cc
@@ -41,23 +41,20 @@ equal_key(hash_value_t v1, hash_value_t v2)
 #include "salad/light.h"
 
 inline void *
-my_light_alloc(void *ctx)
+my_light_alloc(struct matras_allocator *allocator)
 {
-	size_t *p_extents_count = (size_t *)ctx;
-	assert(p_extents_count == &extents_count);
-	++*p_extents_count;
+	++extents_count;
 	return malloc(light_extent_size);
 }
 
 inline void
-my_light_free(void *ctx, void *p)
+my_light_free(struct matras_allocator *allocator, void *p)
 {
-	size_t *p_extents_count = (size_t *)ctx;
-	assert(p_extents_count == &extents_count);
-	--*p_extents_count;
+	--extents_count;
 	free(p);
 }
 
+static struct matras_allocator allocator;
 
 static void
 simple_test()
@@ -69,8 +66,7 @@ simple_test()
 	stats.extent_count = extents_count;
 
 	struct light_core ht;
-	light_create(&ht, 0, light_extent_size, my_light_alloc, my_light_free,
-		     &extents_count, &stats);
+	light_create(&ht, 0, &allocator, &stats);
 	std::vector<bool> vect;
 	size_t count = 0;
 	const size_t rounds = 1000;
@@ -135,8 +131,7 @@ collision_test()
 	header();
 
 	struct light_core ht;
-	light_create(&ht, 0, light_extent_size, my_light_alloc, my_light_free,
-		     &extents_count, NULL);
+	light_create(&ht, 0, &allocator, NULL);
 	std::vector<bool> vect;
 	size_t count = 0;
 	const size_t rounds = 100;
@@ -199,8 +194,7 @@ iterator_test()
 	header();
 
 	struct light_core ht;
-	light_create(&ht, 0, light_extent_size, my_light_alloc, my_light_free,
-		     &extents_count, NULL);
+	light_create(&ht, 0, &allocator, NULL);
 	const size_t rounds = 1000;
 	const size_t start_limits = 20;
 
@@ -262,8 +256,7 @@ iterator_freeze_check()
 	struct light_core ht;
 
 	for (int i = 0; i < 10; i++) {
-		light_create(&ht, 0, light_extent_size, my_light_alloc,
-			     my_light_free, &extents_count, NULL);
+		light_create(&ht, 0, &allocator, NULL);
 		int comp_buf_size = 0;
 		int comp_buf_size2 = 0;
 		for (int j = 0; j < test_data_size; j++) {
@@ -337,8 +330,7 @@ slot_in_big_table_test()
 	header();
 
 	struct light_core ht;
-	light_create(&ht, 0, light_extent_size, my_light_alloc, my_light_free,
-		     &extents_count, NULL);
+	light_create(&ht, 0, &allocator, NULL);
 
 	ht.common.table_size = 4000000000;
 	ht.common.cover_mask = 0xffffffff;
@@ -368,8 +360,7 @@ max_capacity_test()
 	const size_t data_count = (size_t)UINT32_MAX + 1 - LIGHT_GROW_INCREMENT;
 
 	struct light_core ht;
-	light_create(&ht, 0, light_extent_size, my_light_alloc, my_light_free,
-		     &extents_count, NULL);
+	light_create(&ht, 0, &allocator, NULL);
 
 	uint64_t seed[4];
 	random_bytes((char *)seed, sizeof(seed));
@@ -407,6 +398,8 @@ int
 main(int, const char**)
 {
 	random_init();
+	matras_allocator_create(&allocator, light_extent_size,
+				my_light_alloc, my_light_free);
 
 	simple_test();
 	collision_test();
@@ -418,5 +411,6 @@ main(int, const char**)
 	if (extents_count != 0)
 		fail("memory leak!", "true");
 
+	matras_allocator_destroy(&allocator);
 	random_free();
 }

--- a/test/unit/light_view.c
+++ b/test/unit/light_view.c
@@ -39,24 +39,25 @@ equal_key(struct data a, int b)
 #include "salad/light.h"
 
 static void *
-alloc_extent(void *ctx)
+alloc_extent(struct matras_allocator *allocator)
 {
-	(void)ctx;
+	(void)allocator;
 	return xmalloc(extent_size);
 }
 
 static void
-free_extent(void *ctx, void *p)
+free_extent(struct matras_allocator *allocator, void *p)
 {
-	(void)ctx;
+	(void)allocator;
 	free(p);
 }
+
+static struct matras_allocator allocator;
 
 static void
 light_do_create(struct light_core *ht)
 {
-	light_create(ht, NULL, extent_size, alloc_extent, free_extent,
-		     NULL, NULL);
+	light_create(ht, NULL, &allocator, NULL);
 }
 
 static void
@@ -254,9 +255,14 @@ main(void)
 	plan(3);
 	header();
 
+	matras_allocator_create(&allocator, extent_size,
+				alloc_extent, free_extent);
+
 	test_count();
 	test_find();
 	test_iterator();
+
+	matras_allocator_destroy(&allocator);
 
 	footer();
 	return check_plan();

--- a/test/unit/rtree_iterator.cc
+++ b/test/unit/rtree_iterator.cc
@@ -10,22 +10,22 @@ static int extent_count = 0;
 const uint32_t extent_size = 1024 * 8;
 
 static void *
-extent_alloc(void *ctx)
+extent_alloc(struct matras_allocator *allocator)
 {
-	int *p_extent_count = (int *)ctx;
-	assert(p_extent_count == &extent_count);
-	++*p_extent_count;
+	(void)allocator;
+	++extent_count;
 	return malloc(extent_size);
 }
 
 static void
-extent_free(void *ctx, void *page)
+extent_free(struct matras_allocator *allocator, void *page)
 {
-	int *p_extent_count = (int *)ctx;
-	assert(p_extent_count == &extent_count);
-	--*p_extent_count;
+	(void)allocator;
+	--extent_count;
 	free(page);
 }
+
+struct matras_allocator allocator;
 
 static void
 iterator_check()
@@ -33,8 +33,7 @@ iterator_check()
 	header();
 
 	struct rtree tree;
-	rtree_init(&tree, 2, RTREE_EUCLID, extent_size,
-		   extent_alloc, extent_free, &extent_count, NULL);
+	rtree_init(&tree, 2, RTREE_EUCLID, &allocator, NULL);
 
 	/* Filling tree */
 	const size_t count1 = 10000;
@@ -215,8 +214,7 @@ iterator_invalidate_check()
 			del_cnt = test_size - del_pos;
 		}
 		struct rtree tree;
-		rtree_init(&tree, 2, RTREE_EUCLID, extent_size,
-			   extent_alloc, extent_free, &extent_count, NULL);
+		rtree_init(&tree, 2, RTREE_EUCLID, &allocator, NULL);
 		struct rtree_iterator iterators[test_size];
 		for (size_t i = 0; i < test_size; i++)
 			rtree_iterator_init(iterators + i);
@@ -260,8 +258,7 @@ iterator_invalidate_check()
 		size_t ins_cnt = rand() % max_insert_count + 1;
 
 		struct rtree tree;
-		rtree_init(&tree, 2, RTREE_EUCLID, extent_size,
-			   extent_alloc, extent_free, &extent_count, NULL);
+		rtree_init(&tree, 2, RTREE_EUCLID, &allocator, NULL);
 		struct rtree_iterator iterators[test_size];
 		for (size_t i = 0; i < test_size; i++)
 			rtree_iterator_init(iterators + i);
@@ -309,9 +306,12 @@ iterator_invalidate_check()
 int
 main(void)
 {
+	matras_allocator_create(&allocator, extent_size,
+				extent_alloc, extent_free);
 	iterator_check();
 	iterator_invalidate_check();
 	if (extent_count != 0) {
 		fail("memory leak!", "false");
 	}
+	matras_allocator_destroy(&allocator);
 }


### PR DESCRIPTION
A long time ago the it's been found that in some circumstances the RTREE index could fail to rollback because of OOM. This is the case because removal of a key from such an index can sometimes lead to allocation of new blocks that could fail. So, in order to guarantee a successful rollback of an insertion into the index, the memtx engine extent reservation machinery had been introduced (see the issue #727).

But some time ago it's beed found out that the reservation of memory prior to insertion can be not enough to guarantee a successful roll back of the statements, so it's been decided to use a regular malloc for failed allocations performed during rollback (see #10551). This also fixed the RTREE issue for which the extent reservation had been introduced in the first place.

But this functionality allows to simplify code of data structures, such as BPS tree, so that we can reserve the max amount of extents that could be required to perform an operation and, if reservation succeeds, be sure that we're safe from any kind of OOM up until we have finished the operation.

But it's only known to specific data structures which amount of memory will be required for them to perform their operations, and all current memtx structures (BPS tree, light hash, rtree, bitset) use matras to deal with memory allocations, so it would be nice to make them able to reserve exactly as much extents as they need themselves instead of reserving max sane amount of ones as it's done now (see the constants: `RESERVE_EXTENTS_BEFORE_REPLACE` and `RESERVE_EXTENTS_BEFORE_DELETE`).

The problem is that if we reserve extents in each matras instance we will possibly be wasting a lot of memory in each index, so it would be much better to share the reserved extents as it's done in the memtx engine now.

So, in order to allow indexes reserve memoy for themselves and share the reserved memory amoug all indexes, let's introduce a new entity: `matras_allocator`.

The entity is to be shared amoug all memtx indexes and it allows to reserve memory for indexes for various purposes. So instead of matras holding the reserved extents, it's the deal of the new shared entity.

And the entity is exactly what the small submodule bump introduces.

Needed for tarantool/tarantool-ee#822

NO_DOC=submodule bump
NO_TEST=submodule bump
NO_CHANGELOG=submodule bump

(cherry picked from commit 7f1b3ef192ce532a6949c3d22f2a3ef2d1614612)