### PR TITLE
[backport 3.3] config: fix on_event roles callback config argument

### DIFF
--- a/changelogs/unreleased/gh-10934-fix-roles-on_event-config-argument.md
+++ b/changelogs/unreleased/gh-10934-fix-roles-on_event-config-argument.md
@@ -1,0 +1,3 @@
+## bugfix/config
+
+* Fixed `on_event` roles callback receiving wrong `config` argument (gh-10934).

--- a/test/config-luatest/roles_test.lua
+++ b/test/config-luatest/roles_test.lua
@@ -641,6 +641,7 @@ end
 g.test_role_on_event = function(g)
     local one = [[
         _G.foo = -1
+        _G.bar = nil
         _G.is_ro = 'unknown'
 
         return {
@@ -650,10 +651,12 @@ g.test_role_on_event = function(g)
             end,
             stop = function()
                 _G.foo = -1
+                _G.bar = nil
             end,
-            on_event = function(_, key, value)
+            on_event = function(config, key, value)
                 assert(_G.foo >= 0)
 
+                assert(config == 12345)
                 if(_G.foo == 0) then
                     assert(key == 'config.apply')
                 else
@@ -662,23 +665,27 @@ g.test_role_on_event = function(g)
 
                 _G.is_ro = value.is_ro
                 _G.foo = _G.foo + 1
+                _G.bar = config
             end,
         }
     ]]
 
     local verify = function()
         t.assert_equals(_G.foo, 1)
+        t.assert_equals(_G.bar, 12345)
         t.assert_equals(_G.is_ro, false)
 
         box.cfg({read_only = true})
         t.helpers.retrying({}, function()
             t.assert_equals(_G.foo, 2)
+            t.assert_equals(_G.bar, 12345)
             t.assert_equals(_G.is_ro, true)
         end)
 
         box.cfg({read_only = false})
         t.helpers.retrying({}, function()
             t.assert_equals(_G.foo, 3)
+            t.assert_equals(_G.bar, 12345)
             t.assert_equals(_G.is_ro, false)
         end)
     end
@@ -686,6 +693,7 @@ g.test_role_on_event = function(g)
     helpers.success_case(g, {
         roles = {one = one},
         options = {
+            ['roles_cfg'] = {one = 12345},
             ['roles'] = {'one'}
         },
         verify = verify,
@@ -696,6 +704,7 @@ end
 g.test_role_on_event_reload = function(g)
     local one = [[
         _G.foo = -1
+        _G.bar = nil
         _G.is_ro = 'unknown'
 
         return {
@@ -705,33 +714,40 @@ g.test_role_on_event_reload = function(g)
             end,
             stop = function()
                 _G.foo = -1
+                _G.bar = nil
             end,
-            on_event = function(_, _, value)
+            on_event = function(config, _, value)
                 assert(_G.foo >= 0)
+                assert(config == 12345)
                 _G.is_ro = value.is_ro
                 _G.foo = _G.foo + 1
+                _G.bar = config
             end,
         }
     ]]
 
     local verify = function()
         t.assert_equals(rawget(_G, 'foo'), nil)
+        t.assert_equals(rawget(_G, 'bar'), nil)
         t.assert_equals(rawget(_G, 'is_ro'), nil)
     end
 
     local verify_2 = function()
         t.assert_equals(_G.foo, 1)
+        t.assert_equals(_G.bar, 12345)
         t.assert_equals(_G.is_ro, false)
 
         box.cfg({read_only = true})
         t.helpers.retrying({}, function()
             t.assert_equals(_G.foo, 2)
+            t.assert_equals(_G.bar, 12345)
             t.assert_equals(_G.is_ro, true)
         end)
 
         box.cfg({read_only = false})
         t.helpers.retrying({}, function()
             t.assert_equals(_G.foo, 3)
+            t.assert_equals(_G.bar, 12345)
             t.assert_equals(_G.is_ro, false)
         end)
     end
@@ -740,6 +756,76 @@ g.test_role_on_event_reload = function(g)
         roles = {one = one},
         options = {},
         options_2 = {
+            ['roles_cfg'] = {one = 12345},
+            ['roles'] = {'one'},
+        },
+        verify = verify,
+        verify_2 = verify_2,
+    })
+end
+
+-- Ensure that on_event callback receives new config on update.
+g.test_role_on_event_config_update = function(g)
+    local one = [[
+        _G.foo = -1
+        _G.bar = nil
+
+        return {
+            validate = function() end,
+            apply = function() end,
+            stop = function()
+                _G.foo = -1
+                _G.bar = nil
+            end,
+            on_event = function(config, _, _)
+                _G.foo = _G.foo + 1
+                _G.bar = config
+            end,
+        }
+    ]]
+
+    local verify = function()
+        t.assert_equals(_G.foo, 0)
+        t.assert_equals(_G.bar, 12345)
+
+        box.cfg({read_only = true})
+        t.helpers.retrying({}, function()
+            t.assert_equals(_G.foo, 1)
+            t.assert_equals(_G.bar, 12345)
+        end)
+
+        box.cfg({read_only = false})
+        t.helpers.retrying({}, function()
+            t.assert_equals(_G.foo, 2)
+            t.assert_equals(_G.bar, 12345)
+        end)
+    end
+
+    local verify_2 = function()
+        t.assert_equals(_G.foo, 3)
+        t.assert_equals(_G.bar, 54321)
+
+        box.cfg({read_only = true})
+        t.helpers.retrying({}, function()
+            t.assert_equals(_G.foo, 4)
+            t.assert_equals(_G.bar, 54321)
+        end)
+
+        box.cfg({read_only = false})
+        t.helpers.retrying({}, function()
+            t.assert_equals(_G.foo, 5)
+            t.assert_equals(_G.bar, 54321)
+        end)
+    end
+
+    helpers.reload_success_case(g, {
+        roles = {one = one},
+        options = {
+            ['roles_cfg'] = {one = 12345},
+            ['roles'] = {'one'},
+        },
+        options_2 = {
+            ['roles_cfg'] = {one = 54321},
             ['roles'] = {'one'},
         },
         verify = verify,


### PR DESCRIPTION
*(This is a backport of PR #10935 to `release/3.3`, a future `3.3.1` release.)*

----

The config object was passed to the `on_event` callback instead of the corresponding roles config before. Lets fix it, implementing the intended behavior.

Closes #10934