### PR TITLE
cmake: fix search patterns used by ctest

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -175,8 +175,11 @@ list(APPEND EXECUTED_WITHOUT_TEST_RUN
     vinyl-luatest
 )
 
-file(GLOB_RECURSE tests ${PROJECT_SOURCE_DIR}/test
-  *.test.lua *.test.py *_test.lua)
+file(GLOB_RECURSE tests
+  ${PROJECT_SOURCE_DIR}/test/*.test.lua
+  ${PROJECT_SOURCE_DIR}/test/*.test.py
+  ${PROJECT_SOURCE_DIR}/test/*_test.lua
+)
 foreach(test_path ${tests})
   get_filename_component(test_name ${test_path} NAME)
   get_filename_component(basedir ${test_path} DIRECTORY)


### PR DESCRIPTION
In CMake command `file(GLOB_RECURSE ...)` latest unnamed arguments are search patterns `<globbing-expressions>`. In the patch with initial CTest support pattern `${PROJECT_SOURCE_DIR}/test` was used and with commands below:

```
$ mkdir -p {a,b}/my
$ touch {a,b}/my/test
$ cmake .
```

this leads to an error:

```
-- Add regression tests
CMake Error at test/CMakeLists.txt:196 (add_test):
  add_test given test NAME "test/my/test" which already exists in this
  directory.
```

The patch fixes the problem. Follows up commit a9b9f2eb4f71 ("test: execute tests using CTest").

1. https://cmake.org/cmake/help/latest/command/file.html#glob-recurse

NO_CHANGELOG=testing
NO_DOC=testing
NO_TEST=testing

Reported-By: Alexander Turenko <alexander.turenko@tarantool.org>
Reported-By: Sergey Kaplun <skaplun@tarantool.org>