### PR TITLE
test: parallelize config-luatest/log_wrapper_test

### DIFF
--- a/test/config-luatest/log_wrapper_test.lua
+++ b/test/config-luatest/log_wrapper_test.lua
@@ -1,3 +1,5 @@
+-- tags: parallel
+
 local t = require('luatest')
 local treegen = require('luatest.treegen')
 local justrun = require('luatest.justrun')


### PR DESCRIPTION
The test has 172 test cases and spawns a lot of processes. It takes ~30 seconds (+/-10 seconds) on my laptop in the sequential and in the parallel run both. The difference seems within the noise level. The parallel execution seems slightly longer, approximately +5 seconds.

However, if we run the test cases separately, the test timeout limit (110 seconds by default) is applied to each particular test case. It may be important for testing runs on a slow machine or when a slow instrumented build (such as ASAN) is used.