### PR TITLE
test: parallelize failover_and_election_mode_test

### DIFF
--- a/test/config-luatest/failover_and_election_mode_test.lua
+++ b/test/config-luatest/failover_and_election_mode_test.lua
@@ -1,3 +1,5 @@
+-- tags: parallel
+
 -- Verify all the compositions of possible replication.failover
 -- and replication.election_mode values.
 --


### PR DESCRIPTION
This test file has 36 test cases and gains some speed from the parallelization (35-40 seconds to 15-25 seconds on my laptop).

However, it is more important that now the test-run's test timeout (110 seconds by default) is applied for each particular test case. I met some test timeout fails on this test in CI. Don't remember precisely, but it is likely on a slow machine or on a build instrumented by the address sanitizer.