### PR TITLE
test: parallelize config-luatest/rpc_test

### DIFF
--- a/test/config-luatest/rpc_test.lua
+++ b/test/config-luatest/rpc_test.lua
@@ -1,3 +1,5 @@
+-- tags: parallel
+
 local t = require('luatest')
 local fun = require('fun')
 local treegen = require('luatest.treegen')


### PR DESCRIPTION
The test gains a lot from the parallelization, because there are test cases that verify connpool's connection timeout (10 seconds) and they have to wait for the connection failure for this time interval without any actual workload.

On my laptop the parallelization reduces the execution time from 58 seconds to 15-16 seconds.

Also, I met a failure of this test due to the default test-run's test timeout (110 seconds), when it is run in parallel with others. Now it shouldn't occur anymore.