### PR TITLE
feature: add validate method to space and tuple.format objects

### DIFF
--- a/changelogs/unreleased/gh-9979-space-format-object.md
+++ b/changelogs/unreleased/gh-9979-space-format-object.md
@@ -1,0 +1,3 @@
+## feature/box
+
+* Populated space objects with a new field `format_object` (gh-9979).

--- a/changelogs/unreleased/gh-9979-tuple-format-validate.md
+++ b/changelogs/unreleased/gh-9979-tuple-format-validate.md
@@ -1,0 +1,3 @@
+## feature/box
+
+* Populated `box.tuple.format` objects with a new method `validate` (gh-9979).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -816,10 +816,7 @@ alter_space_new(struct space *old_space)
 	alter->txn = in_txn();
 	alter->old_space = old_space;
 	alter->space_def = space_def_dup(alter->old_space->def);
-	if (old_space->format != NULL)
-		alter->new_min_field_count = old_space->format->min_field_count;
-	else
-		alter->new_min_field_count = 0;
+	alter->new_min_field_count = old_space->format->min_field_count;
 	alter->n_rows = txn_n_rows(txn);
 	return alter;
 }
@@ -1207,10 +1204,6 @@ CheckSpaceFormat::prepare(struct alter_space *alter)
 	struct space *new_space = alter->new_space;
 	struct space *old_space = alter->old_space;
 	struct tuple_format *new_format = new_space->format;
-	struct tuple_format *old_format = old_space->format;
-
-	if (old_format == NULL)
-		return;
 
 	assert(new_format != NULL);
 	for (uint32_t i = 0; i < old_space->index_count; i++) {
@@ -1831,12 +1824,10 @@ alter_space_move_indexes(struct alter_space *alter, uint32_t begin,
 		 * old and new tuples.
 		 */
 		is_min_field_count_changed = true;
-	} else if (old_space->format != NULL) {
+	} else {
 		is_min_field_count_changed =
 			old_space->format->min_field_count !=
 			alter->new_min_field_count;
-	} else {
-		is_min_field_count_changed = false;
 	}
 	for (uint32_t index_id = begin; index_id < end; ++index_id) {
 		struct index *old_index = space_index(old_space, index_id);

--- a/src/box/lua/space.cc
+++ b/src/box/lua/space.cc
@@ -32,6 +32,7 @@
 #include "box/lua/trigger.h"
 #include "box/lua/space.h"
 #include "box/lua/tuple.h"
+#include "box/lua/tuple_format.h"
 #include "box/lua/key_def.h"
 #include "box/sql/sqlLimit.h"
 #include "lua/utils.h"
@@ -509,6 +510,11 @@ lbox_fillspace(struct lua_State *L, struct space *space, int i)
 	/* space:on_replace */
 	lua_pushstring(L, "on_replace");
 	lua_pushcfunction(L, lbox_space_on_replace);
+	lua_settable(L, i);
+
+	/* space.format_object */
+	lua_pushstring(L, "format_object");
+	luaT_push_tuple_format(L, space->format);
 	lua_settable(L, i);
 
 	/* space:before_replace */

--- a/src/box/lua/tuple_format.c
+++ b/src/box/lua/tuple_format.c
@@ -168,6 +168,18 @@ lbox_tuple_format_validate(lua_State *L)
 	return 0;
 }
 
+void
+luaT_push_tuple_format(struct lua_State *L, struct tuple_format *format)
+{
+	struct tuple_format **format_ptr =
+		lua_newuserdata(L, sizeof(*format_ptr));
+	*format_ptr = NULL;
+	luaL_getmetatable(L, tuple_format_typename);
+	lua_setmetatable(L, -2);
+	tuple_format_ref(format);
+	*format_ptr = format;
+}
+
 /*
  * Simply returns `ipairs(format:totable())`.
  */

--- a/src/box/lua/tuple_format.h
+++ b/src/box/lua/tuple_format.h
@@ -35,6 +35,14 @@ int
 box_tuple_format_serialize_impl(struct lua_State *L,
 				struct tuple_format *format);
 
+/**
+ * Allocate and push a box.tuple.format userdata onto the Lua stack.
+ * The created tuple format object is initialized with a reference to
+ * the given format.
+ */
+void
+luaT_push_tuple_format(struct lua_State *L, struct tuple_format *format);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -260,9 +260,6 @@ space_reattach_constraints(struct space *space)
 void
 space_cleanup_constraints(struct space *space)
 {
-	if (space->format == NULL)
-		return;
-
 	struct tuple_format *format = space->format;
 	for (size_t j = 0; j < format->constraint_count; j++) {
 		struct tuple_constraint *constr = &format->constraint[j];
@@ -587,9 +584,9 @@ space_create(struct space *space, struct engine *engine,
 	rlist_create(&space->coll_id_holders);
 	space->run_triggers = true;
 
+	assert(format != NULL);
 	space->format = format;
-	if (format != NULL)
-		tuple_format_ref(format);
+	tuple_format_ref(format);
 
 	space->def = space_def_dup(def);
 	bool is_on_recovery = recovery_state < FINISHED_RECOVERY;
@@ -674,11 +671,9 @@ fail:
 	free(space->check_unique_constraint_map);
 	if (space->def != NULL)
 		space_def_delete(space->def);
-	if (space->format != NULL) {
-		space_cleanup_constraints(space);
-		space_unpin_defaults(space);
-		tuple_format_unref(space->format);
-	}
+	space_cleanup_constraints(space);
+	space_unpin_defaults(space);
+	tuple_format_unref(space->format);
 	space_unpin_collations(space);
 	return -1;
 }
@@ -746,11 +741,9 @@ space_delete(struct space *space)
 	}
 	free(space->index_map);
 	free(space->check_unique_constraint_map);
-	if (space->format != NULL) {
-		space_cleanup_constraints(space);
-		space_unpin_defaults(space);
-		tuple_format_unref(space->format);
-	}
+	space_cleanup_constraints(space);
+	space_unpin_defaults(space);
+	tuple_format_unref(space->format);
 	space_unpin_collations(space);
 	trigger_destroy(&space->before_replace);
 	trigger_destroy(&space->on_replace);

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -235,8 +235,7 @@ struct space {
 	/** This space has foreign key constraints in its format. */
 	bool has_foreign_keys;
 	/**
-	 * Space format or NULL if space does not have format
-	 * (sysview engine, for example).
+	 * Space format, cannot be NULL.
 	 */
 	struct tuple_format *format;
 	/**

--- a/test/box-luatest/gh_4693_formats_for_standalone_tuples_test.lua
+++ b/test/box-luatest/gh_4693_formats_for_standalone_tuples_test.lua
@@ -63,6 +63,7 @@ g.test_box_tuple_format_gc = function(cg)
     t.tarantool.skip_if_not_debug()
 
     cg.server:exec(function()
+        collectgarbage()
         box.tuple.format.new{{name = 'field0'}}
         collectgarbage()
         box.tuple.format.new{{name = 'field1'}}

--- a/test/box-luatest/gh_9979_tuple_format_validate_test.lua
+++ b/test/box-luatest/gh_9979_tuple_format_validate_test.lua
@@ -1,0 +1,129 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:drop()
+end)
+
+g.test_tuple_format_validate = function()
+    g.server:exec(function()
+        local format = box.tuple.format.new({
+            {name = 'key', type = 'string'},
+            {name = 'value', type = 'any'},
+            {name = 'count', type = 'unsigned'},
+            {name = 'tags', type = 'array'},
+            {name = 'metadata', type = 'map'},
+        })
+
+        local valid_cases = {
+            {'key1', 'value1', 1, {'tag1', 'tag2'}, {author = 'user'}},
+            {'key2', 140, 0, {}, setmetatable({}, {__serialize = 'map'})},
+            {'key3', 0.5, 100, {1, 2, 3}, {info = {value = 1}}},
+            {'key4', true, 42, {'a'}, {x = 1, y = 2}},
+            {'id1', nil, 5, {'tagA', 'tagB'}, {created_by = 'system'}},
+            {'item1', {sub = 'obj'}, 10, {}, {role = 'admin', active = true}},
+            {'abc', 3.14, 7, {'pi'}, {math = 'pi', valid = true}},
+            {'name', {}, 2, {'test'}, {lang = 'en'}},
+            {'key5', box.NULL, 0, {}, {status = 'none'}},
+            {'k1', 'v1', 999999, {}, {size = 'big'}},
+            {'key6', {nested = {more = {levels = true}}}, 1, {'tag'},
+                {structure = 'ok'}},
+            {'t1', 'b1', 123, {'x', 'y', 'z'}, {list = {1, 2, 3}, note = 'yes'}},
+            {'json1', {x = 1}, 10, {'json'}, {data = {valid = true}}},
+        }
+
+        for _, case in ipairs(valid_cases) do
+            format:validate(case)
+            local tuple_case = box.tuple.new(case)
+            format:validate(tuple_case)
+        end
+
+        local invalid_cases = {
+            {
+                -- key not a string
+                value = {1, 'value', 1, {}, {}},
+                field = 1, name = 'key', expected = 'string',
+                actual = 'unsigned',
+            },
+            {
+                -- count negative
+                value = {'key', 'value', -1, {}, {}},
+                field = 3, name = 'count', expected = 'unsigned',
+                actual = 'integer',
+            },
+            {
+                -- metadata not a map
+                value = {'key', 'value', 1, {}, {}},
+                field = 5, name = 'metadata', expected = 'map',
+                actual = 'array',
+            },
+            {
+                -- tags not an array
+                value = {'key', 'value', 1, 'not_array', {}},
+                field = 4, name = 'tags',
+                expected = 'array', actual = 'string',
+            },
+        }
+
+        for _, case in ipairs(invalid_cases) do
+            local message = string.format(
+                "Tuple field %d (%s) type does not match one required " ..
+                "by operation: expected %s, got %s",
+                case.field, case.name, case.expected, case.actual
+            )
+
+            t.assert_error_covers({
+                type = 'ClientError',
+                code = box.error.FIELD_TYPE,
+                message = message,
+            },
+            format.validate, format, case.value)
+
+            local tuple_case = box.tuple.new(case.value)
+            t.assert_error_covers({
+                type = 'ClientError',
+                code = box.error.FIELD_TYPE,
+                message = message,
+            },
+            format.validate, format, tuple_case)
+        end
+    end)
+end
+
+g.test_format_validate_usage_error = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        local format = box.tuple.format.new({{name = 'a', type = 'unsigned'}})
+
+        -- invalid format objects (`self`)
+        for _, bad_fmt in ipairs({123, 'str', true, box.NULL, {}}) do
+            t.assert_error_msg_equals(
+                string.format(
+                    "bad argument #1 to '?' (box.tuple.format expected, got %s)",
+                    type(bad_fmt)
+                ), format.validate, bad_fmt, {1}
+            )
+        end
+
+        -- no args
+        t.assert_error_msg_equals(
+            'Usage: format:validate(tuple_or_table)',
+            format.validate, format
+        )
+
+        -- wrong arg types
+        for _, bad in ipairs({123, 'str', true, box.NULL}) do
+            t.assert_error_msg_equals(
+                'Expected tuple or table',
+                format.validate, format, bad
+            )
+        end
+    end)
+end

--- a/test/box/net.box_reuse_tuple_formats_gh-6217.result
+++ b/test/box/net.box_reuse_tuple_formats_gh-6217.result
@@ -11,7 +11,7 @@ box.schema.user.grant('guest', 'execute', 'universe')
  | ...
 
 -- Check that formats created by net.box for schema are reused (gh-6217).
-COUNT = 100
+COUNT = 113
  | ---
  | ...
 errinj.set('ERRINJ_TUPLE_FORMAT_COUNT', COUNT)

--- a/test/box/net.box_reuse_tuple_formats_gh-6217.test.lua
+++ b/test/box/net.box_reuse_tuple_formats_gh-6217.test.lua
@@ -4,7 +4,7 @@ errinj = box.error.injection
 box.schema.user.grant('guest', 'execute', 'universe')
 
 -- Check that formats created by net.box for schema are reused (gh-6217).
-COUNT = 100
+COUNT = 113
 errinj.set('ERRINJ_TUPLE_FORMAT_COUNT', COUNT)
 connections = {}
 for i = 1, COUNT do                                                         \

--- a/test/wal_off/alter.result
+++ b/test/wal_off/alter.result
@@ -33,6 +33,7 @@ end;
 -- cleanup
 for k, v in pairs(spaces) do
     v:drop()
+    spaces[k] = nil
 end;
 ---
 ...

--- a/test/wal_off/alter.test.lua
+++ b/test/wal_off/alter.test.lua
@@ -15,6 +15,7 @@ end;
 -- cleanup
 for k, v in pairs(spaces) do
     v:drop()
+    spaces[k] = nil
 end;
 test_run:cmd("setopt delimiter ''");
 


### PR DESCRIPTION
Added field `format_object` to spaces and method `validate` to `tuple.format`

#### Implementation note
The `format_object` field is not available for spaces accessed over net.box,
because creating it would trigger C-level validation of field types and collation 
IDs on the client. If the format references a field type unknown to the client or
a collation ID that isn’t present locally, an error will be raised during schema
installation.

#### Test adjustments:
The `format_object` field creates references to `tuple_format` for space objects
via `tuple_format_ref`. These references can be retained by spaces remaining in
memory (e.g., in the global space table), especially if other tests create spaces.

- In `gh_4693_formats_for_standalone_tuples_test`, added an initial call to
`collectgarbage()` to clear the tuple format pool before creating new `tuple_format`
objects. This ensures a clean environment for the test.

- In `net.box_reuse_tuple_formats_gh-6217.test`, increased the
`ERRINJ_TUPLE_FORMAT_COUNT` limit from 100 to 113. Initially, more than 100 tuple
formats are created in the session due to references held by the `format_object` method.
Increasing the limit accounts for these existing formats.

- In `wal_off/alter.test`, added explicit deletion of references to allow the Lua garbage
collector to free space objects and their `format_object` instances, preventing format
pool exhaustion.

Closes #9979
