### PR TITLE
lua: fix flaky custom allocator test again

### DIFF
--- a/test/app-luatest/alloc_test.lua
+++ b/test/app-luatest/alloc_test.lua
@@ -41,12 +41,13 @@ end
 g.test_used_and_unused = function()
     local function test(amount)
         alloc.setlimit(amount)
-        t.assert_equals(collectgarbage('count'), alloc.used() / 1024)
-        -- Check amount of the free memory provided by the
-        -- unused() function is close to the calculated using
-        -- the builtin collectgarbage() function.
+        -- Check memory values provided by the used() and
+        -- unused() functions are close to the ones calculated
+        -- by the builtin collectgarbage() function.
         --
         -- Allow some margin of 16Kb to avoid false negatives.
+        t.assert_almost_equals(collectgarbage('count'),
+                               alloc.used() / 1024, 16)
         t.assert_almost_equals(amount / 1024 - collectgarbage('count'),
                                alloc.unused() / 1024, 16)
         t.assert_equals(alloc.used() + alloc.unused(), alloc.getlimit())


### PR DESCRIPTION
This patch fixes the flaky test verifying `used()` and `unused()` functions of the `internal.alloc` module in the `alloc_test` suite.

The test compares the value of the used memory with the one calculated by the builtin Lua functions. The executed and the real values has been close to each other though not equal. This false negative result likely happens because of the details of the `collectgarbage()` implementation.

This patch fixes it by adding arbitrary margin equal to 16Kb of memory when comparing the value calculated using the LuaJIT call with the one provided by the module function.

The same problem has been fixed in terms of the commit 7731d13d0af6a1 ("lua: fix flaky custom allocator test"). The previous commit fixed corresponding checks on the `unused()` value. This one fixes `used()` checks that seem to be not precise in coverage workflows.
