### PR TITLE
datetime: add new behavior for setting timezones

### DIFF
--- a/changelogs/unreleased/gh-10363-datetime-handle-timezone.md
+++ b/changelogs/unreleased/gh-10363-datetime-handle-timezone.md
@@ -1,0 +1,7 @@
+## bugfix/datetime
+
+* Proper behavior of applying timezones to datetime objects can
+  now be enabled by setting configuration option
+  `compat.datetime_apply_timezone_action` to `'new'`. It makes
+  changing timezones of `datetime` objects preserve the represented
+  timestamp and affect the represented time of day (gh-10363).

--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -338,6 +338,15 @@ I['compat.console_session_scope_vars'] = format_text([[
       from the console are written to globals
 ]])
 
+I['compat.datetime_apply_timezone_action'] = format_text([[
+    Controls the behavior of applying timezone to datetime objects:
+
+    - `new` (4.x default): applying a timezone doesn't affect the timestamp but
+      changes the represented time of day
+    - `old` (3.x default): applying a timezone alters the represented timestamp
+      but preserves the time of day
+]])
+
 I['compat.fiber_channel_close_mode'] = format_text([[
     Define the behavior of fiber channels after closing:
 

--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -414,6 +414,15 @@ I['compat.console_session_scope_vars'] = format_text([[
       from the console are written to globals
 ]])
 
+I['compat.datetime_apply_timezone_action'] = format_text([[
+    Controls the behavior of applying timezone to datetime objects:
+
+    - `new` (4.x default): applying a timezone doesn't affect the timestamp but
+      changes the represented time of day
+    - `old` (3.x default): applying a timezone alters the represented timestamp
+      but preserves the time of day
+]])
+
 I['compat.fiber_channel_close_mode'] = format_text([[
     Define the behavior of fiber channels after closing:
 

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2156,6 +2156,12 @@ return schema.new('instance_config', schema.record({
         }, {
             default = 'old',
         }),
+        datetime_apply_timezone_action = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'old',
+        }),
         box_consider_system_spaces_synchronous = schema.enum({
             'old',
             'new',

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2410,6 +2410,12 @@ return schema.new('instance_config', schema.record({
         }, {
             default = 'old',
         }),
+        datetime_apply_timezone_action = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'old',
+        }),
         box_consider_system_spaces_synchronous = schema.enum({
             'old',
             'new',

--- a/src/lib/core/datetime.c
+++ b/src/lib/core/datetime.c
@@ -32,6 +32,13 @@ static bool datetime_setfn_timestamp_type_check = false;
 TWEAK_BOOL(datetime_setfn_timestamp_type_check);
 
 /**
+ * Makes applying a timezone to a datetime object preserve the
+ * timestamp instead of the represented time of day.
+ */
+static bool datetime_apply_timezone_preserves_timestamp = false;
+TWEAK_BOOL(datetime_apply_timezone_preserves_timestamp);
+
+/**
  * Floored modulo and divide.
  * (a < 0) & (b < 0) case isn't supported.
  */

--- a/src/lua/compat.lua
+++ b/src/lua/compat.lua
@@ -72,6 +72,16 @@ type check for timestamp in set().
 https://tarantool.io/compat/datetime_setfn_timestamp_type_check
 ]]
 
+local DATETIME_APPLY_TIMEZONE_ACTION_BRIEF = [[
+Whether applying timezone alters the represented time of day or the timestamp.
+The new behavior makes setting a timezone for a datetime object change the time
+of day and preserve the timestamp. The old behavior makes providing a timezone
+for a datetime object affect the timestamp but preserve the represented time of
+day.
+
+https://tarantool.io/compat/datetime_apply_timezone_action
+]]
+
 local SQL_PRIV_BRIEF = [[
 Whether to enable access checks for SQL requests. The old behavior is to let
 any user execute an arbitrary SQL request over IPROTO. With the new behavior,
@@ -264,6 +274,13 @@ local options = {
         obsolete = nil,
         brief = DATETIME_SETFN_TIMESTAMP_TYPE_CHECK_BRIEF,
         action = tweak_action('datetime_setfn_timestamp_type_check',
+                              false, true),
+    },
+    datetime_apply_timezone_action = {
+        default = 'old',
+        obsolete = nil,
+        brief = DATETIME_APPLY_TIMEZONE_ACTION_BRIEF,
+        action = tweak_action('datetime_apply_timezone_preserves_timestamp',
                               false, true),
     },
     sql_priv = {

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -584,6 +584,23 @@ local function datetime_new(obj)
     else
         nsec = 0
     end
+
+    local offset = obj.tzoffset
+    if offset ~= nil then
+        offset = get_timezone(offset, 'tzoffset')
+        -- At the moment the range of known timezones is
+        -- UTC-12:00..UTC+14:00.
+        --
+        -- https://en.wikipedia.org/wiki/List_of_UTC_time_offsets
+        check_range(offset, -720, 840, 'tzoffset')
+    end
+
+    local tzindex = 0
+    local tzname = obj.tz
+    if tzname ~= nil then
+        offset, tzindex = parse_tzname(epoch_from_dt(dt), tzname)
+    end
+
     local ts = obj.timestamp
     if ts ~= nil then
         if ymd then
@@ -615,14 +632,6 @@ local function datetime_new(obj)
         hms = true
     end
 
-    local offset = obj.tzoffset
-    if offset ~= nil then
-        offset = get_timezone(offset, 'tzoffset')
-        -- at the moment the range of known timezones is UTC-12:00..UTC+14:00
-        -- https://en.wikipedia.org/wiki/List_of_UTC_time_offsets
-        check_range(offset, -720, 840, 'tzoffset')
-    end
-
     -- .year, .month, .day
     if ymd then
         y = y or 1970
@@ -638,12 +647,6 @@ local function datetime_new(obj)
             end
         end
         dt = dt_from_ymd_checked(y, M, d)
-    end
-
-    local tzindex = 0
-    local tzname = obj.tz
-    if tzname ~= nil then
-        offset, tzindex = parse_tzname(epoch_from_dt(dt), tzname)
     end
 
     -- .hour, .minute, .second

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -585,6 +585,7 @@ end
 
 -- Returns UTC epoch if timestamp is defined.
 -- Returns nsec as fraction part of timestamp if nsec isn't defined.
+-- Returns has_nsec flag whether the returned nsec is defined.
 -- Post: defined(epoch) => defined(nsec).
 -- from_set is needed to prevent timestamp type check for set() to save
 -- backward compatibility, see [1].
@@ -593,7 +594,7 @@ end
 local function extract_obj_epoch_and_update_nsec(obj, ymd, hms, nsec, from_set)
     local ts = obj.timestamp
     if ts == nil then
-        return nil, nsec
+        return nil, nsec, nsec ~= nil
     end
 
     if ymd then
@@ -623,7 +624,7 @@ local function extract_obj_epoch_and_update_nsec(obj, ymd, hms, nsec, from_set)
                 'if nsec, usec, or msecs provided', 3)
     end
 
-    return epoch, nsec
+    return epoch, nsec, nsec ~= nil
 end
 
 local function get_timezone(offset, msg, error_level_up)
@@ -655,12 +656,14 @@ local function extract_obj_tzoffset_tzindex(obj, base_epoch)
     return tzoffset, tzindex
 end
 
--- Timestamp is erroneously considered as "local", not UTC (gh10363).
--- Handle this historical case here.
+-- Historically the timestamp is erroneously considered as
+-- "local", not UTC, so it is adjusted by the timezone offset.
+-- The new compat behavior treats the timestamp as UTC and
+-- preserves it as is (gh-10363).
 local function check_and_update_epoch(epoch, offset)
-    -- Convert "local" timestamp to UTC timestamp.
-    -- Removing this adjustment will fix gh10363.
-    epoch = utc_secs(epoch, offset)
+    if not tweaks.datetime_apply_timezone_preserves_timestamp then
+        epoch = utc_secs(epoch, offset)
+    end
     check_range(epoch, MIN_EPOCH_SECS_VALUE, MAX_EPOCH_SECS_VALUE, 'timestamp',
         nil, 1)
     return epoch
@@ -676,8 +679,9 @@ local function datetime_new(obj)
     local y, M, d, ymd = extract_obj_ymd(obj)
     local h, m, s, hms = extract_obj_hms(obj)
     local nsec = extract_obj_nsec(obj)
-    local epoch
-    epoch, nsec = extract_obj_epoch_and_update_nsec(obj, ymd, hms, nsec)
+    local epoch, has_nsec
+    epoch, nsec, has_nsec = extract_obj_epoch_and_update_nsec(obj, ymd, hms,
+                                                              nsec)
     nsec = nsec or 0
 
     -- Timestamp case.
@@ -699,6 +703,14 @@ local function datetime_new(obj)
     local tzoffset, tzindex = extract_obj_tzoffset_tzindex(obj,
         epoch_from_dt(dt))
     tzoffset, tzindex = tzoffset or 0, tzindex or 0
+
+    -- Only the timezone is provided. The new compat behavior
+    -- preserves the zero timestamp, so `new{tz = x}` remains
+    -- equivalent to `new{}:set{tz = x}` (gh-10363).
+    if not ymd and not hms and not has_nsec and
+       tweaks.datetime_apply_timezone_preserves_timestamp then
+        return datetime_new_raw(0, 0, tzoffset, tzindex)
+    end
 
     -- .hour, .minute, .second
     local secs = 0
@@ -989,8 +1001,15 @@ local function datetime_parse_from(str, obj)
 
     -- Override timezone, if it was not specified in a parsed
     -- string.
-    if date.tz == '' and date.tzoffset == 0 then
+    if date.tzindex == 0 and date.tzoffset == 0 then
         datetime_set(date, { tzoffset = tzoffset, tz = tzname })
+
+        -- If working in a "preserve timestamp" mode the set
+        -- call changes the represented time of day and it should
+        -- be adjusted (gh-10363).
+        if tweaks.datetime_apply_timezone_preserves_timestamp then
+            date.epoch = utc_secs(date.epoch, date.tzoffset)
+        end
     end
 
     return date, len
@@ -1074,8 +1093,9 @@ function datetime_set(self, obj)
     local y, M, d, ymd = extract_obj_ymd(obj)
     local h, m, s, hms = extract_obj_hms(obj)
     local nsec = extract_obj_nsec(obj)
-    local epoch
-    epoch, nsec = extract_obj_epoch_and_update_nsec(obj, ymd, hms, nsec, true)
+    local epoch, has_nsec
+    epoch, nsec, has_nsec = extract_obj_epoch_and_update_nsec(obj, ymd, hms,
+                                                              nsec, true)
 
     if epoch ~= nil then
         local tzoffset, tzindex = extract_obj_tzoffset_tzindex(obj, epoch)
@@ -1085,6 +1105,18 @@ function datetime_set(self, obj)
         self.epoch = epoch
         self.nsec = nsec
         self.tzoffset = effective_tzoffset
+        self.tzindex = tzindex or self.tzindex
+        return self
+    end
+
+    -- Only the timezone is changed. The new compat behavior
+    -- preserves the timestamp, so the epoch is not recalculated
+    -- (gh-10363). Time units provided together with a timezone
+    -- are still applied to the wall clock time below.
+    if not ymd and not hms and not has_nsec and
+       tweaks.datetime_apply_timezone_preserves_timestamp then
+        local tzoffset, tzindex = extract_obj_tzoffset_tzindex(obj, self.epoch)
+        self.tzoffset = tzoffset or self.tzoffset
         self.tzindex = tzindex or self.tzindex
         return self
     end

--- a/test/app-luatest/datetime_test.lua
+++ b/test/app-luatest/datetime_test.lua
@@ -2932,3 +2932,198 @@ g_ghs_146_stack_overflow.test_many_zones_pollutes_stack = function()
 end
 
 -- }}} ghs-146 stack overflow test.
+
+-- {{{ Compat option for applying timezones test (gh-10363).
+
+-- The listed timezones must not use DST at the moment and must
+-- have whole-hour offsets: the expected hour values below are
+-- calculated by adding the offsets converted to hours.
+local TIMEZONES = {
+    {
+        tzname = 'Europe/Moscow',
+        tzoffset = 180,
+    },
+    {
+        tzname = 'Africa/Abidjan',
+        tzoffset = 0,
+    },
+    {
+        tzname = 'America/Argentina/Buenos_Aires',
+        tzoffset = -180,
+    },
+    {
+        tzname = 'Asia/Krasnoyarsk',
+        tzoffset = 420,
+    },
+    {
+        tzname = 'Pacific/Fiji',
+        tzoffset = 720,
+    }
+}
+
+local function tz_behavior_test_case(behavior, create_dt, expected)
+    return function()
+        t.assert_equals(compat.datetime_apply_timezone_action.default, 'old')
+        compat.datetime_apply_timezone_action = behavior
+
+        local dt_obj = create_dt()
+
+        t.assert_equals(dt_obj.hour, expected.hour)
+        t.assert_equals(dt_obj.timestamp, expected.timestamp)
+    end
+end
+
+-- Test new/old behavior of applying timezone to datetime objects
+-- (gh-10363).
+for _, case in ipairs(TIMEZONES) do
+    local function add_test_case(method, behavior, ...)
+        local testcase_name = ('test_tz_behavior_%s_%s_%s')
+            :format(method, case.tzname:gsub('/', '_'), behavior)
+        pg[testcase_name] = tz_behavior_test_case(behavior, ...)
+    end
+
+    local now = dt.now()
+
+    -- Ensure the hardcoded offset is still correct for the
+    -- timezone, it may change with a tzdata update.
+    assert(dt.new{timestamp = now.timestamp, tz = case.tzname}.tzoffset ==
+           case.tzoffset, ('outdated tzoffset for %s'):format(case.tzname))
+
+    -- Note the following when using old behavior.
+    --
+    -- `datetime.new{timestamp = now.timestamp,
+    --               tzoffset = now.tzoffset}`
+    -- creates a datetime object representing time of day in GMT+0
+    -- corresponding to `now` time of day within the provided
+    -- timezone instead of creating a complete `now` copy.
+    local old_expected = {
+        hour = (now.hour - now.tzoffset / 60) % 24,
+        timestamp = now.timestamp - case.tzoffset * 60,
+    }
+    local new_expected = {
+        hour = (now.hour + (case.tzoffset - now.tzoffset) / 60) % 24,
+        timestamp = now.timestamp,
+    }
+
+    local create_dt = function()
+        return dt.new{timestamp = now.timestamp, tzoffset = case.tzoffset}
+    end
+    add_test_case('create_tzoffset', 'old', create_dt, old_expected)
+    add_test_case('create_tzoffset', 'new', create_dt, new_expected)
+
+    create_dt = function()
+        return dt.new{timestamp = now.timestamp, tz = case.tzname}
+    end
+    add_test_case('create_tzname', 'old', create_dt, old_expected)
+    add_test_case('create_tzname', 'new', create_dt, new_expected)
+
+    create_dt = function()
+        return dt.new{timestamp = now.timestamp}:set{tzoffset = case.tzoffset}
+    end
+    add_test_case('set_tzoffset', 'old', create_dt, old_expected)
+    add_test_case('set_tzoffset', 'new', create_dt, new_expected)
+
+    create_dt = function()
+        return dt.new{timestamp = now.timestamp}:set{tz = case.tzname}
+    end
+    add_test_case('set_tzname', 'old', create_dt, old_expected)
+    add_test_case('set_tzname', 'new', create_dt, new_expected)
+
+    create_dt = function()
+        return dt.new{}:set{timestamp = now.timestamp,
+                            tzoffset = case.tzoffset}
+    end
+    add_test_case('set_timestamp_tzoffset', 'old', create_dt, old_expected)
+    add_test_case('set_timestamp_tzoffset', 'new', create_dt, new_expected)
+
+    create_dt = function()
+        return dt.new{}:set{timestamp = now.timestamp, tz = case.tzname}
+    end
+    add_test_case('set_timestamp_tzname', 'old', create_dt, old_expected)
+    add_test_case('set_timestamp_tzname', 'new', create_dt, new_expected)
+end
+
+-- Test new/old behavior of applying timezone when parsing
+-- datetime objects.
+-- Adapted from app-tap/datetime.test.lua (gh-10363).
+pg.test_new_tz_behavior_parse = function()
+    t.assert_equals(compat.datetime_apply_timezone_action.default, 'old')
+    compat.datetime_apply_timezone_action = 'new'
+
+    t.assert(dt.parse("1970-01-01T01:00:00Z") ==
+            dt.new{year=1970, mon=1, day=1, hour=1, min=0, sec=0})
+    t.assert(dt.parse("1970-01-01T01:00:00Z", {format = 'iso8601'}) ==
+            dt.new{year=1970, mon=1, day=1, hour=1, min=0, sec=0})
+    t.assert(dt.parse("1970-01-01T01:00:00Z", {format = 'rfc3339'}) ==
+            dt.new{year=1970, mon=1, day=1, hour=1, min=0, sec=0})
+    t.assert(dt.parse("2020-01-01T01:00:00+00:00", {format = 'rfc3339'}) ==
+            dt.parse("2020-01-01T01:00:00+00:00", {format = 'iso8601'}))
+    t.assert(dt.parse("1970-01-01T02:00:00+02:00") ==
+            dt.new{year=1970, mon=1, day=1, hour=2, min=0, sec=0, tzoffset=120})
+
+    t.assert(dt.parse("1970-01-01T01:00:00", {tzoffset = 120}) ==
+        dt.new{year=1970, mon=1, day=1, hour=1, min=0, sec=0, tzoffset=120})
+    t.assert(dt.parse("1970-01-01T01:00:00", {tzoffset = '+0200'}) ==
+            dt.new{year=1970, mon=1, day=1, hour=1, min=0, sec=0, tzoffset=120})
+    t.assert(dt.parse("1970-01-01T01:00:00", {tzoffset = '+02:00'}) ==
+            dt.new{year=1970, mon=1, day=1, hour=1, min=0, sec=0, tzoffset=120})
+    t.assert(dt.parse("1970-01-01T01:00:00Z", {tzoffset = '+02:00'}) ==
+            dt.new{year=1970, mon=1, day=1, hour=1, min=0, sec=0, tzoffset=0})
+    t.assert(dt.parse("1970-01-01T01:00:00+01:00", {tzoffset = '+02:00'}) ==
+            dt.new{year=1970, mon=1, day=1, hour=1, min=0, sec=0, tzoffset=60})
+    t.assert(dt.parse('1998-11-25', { format = '%Y-%m-%d', tzoffset = 180 }) ==
+            dt.new({ year = 1998, month = 11, day = 25, tzoffset = 180 }))
+    t.assert(dt.parse('1998', { format = '%Y', tzoffset = '+03:00' }) ==
+            dt.new({ year = 1998, tzoffset = 180 }))
+
+    -- Testcases with override timezone by setting tz.
+    -- Timezone is not specified in a parsed string.
+    t.assert(dt.parse("1970-01-01T01:00:00", {tz = "MSK"}) ==
+        dt.new{year = 1970, mon = 1, day = 1,
+               hour = 1, min = 0, sec = 0, tzoffset=180})
+    -- Timezone is specified in a parsed string as a military timezone.
+    t.assert(dt.parse("1970-01-01T01:00:00Z", {tz = "Europe/Moscow"}) ==
+        dt.new{year = 1970, mon = 1, day = 1,
+               hour = 1, min = 0, sec = 0, tzoffset = 0})
+    -- Timezone is specified in a parsed string as an offset.
+    t.assert(dt.parse("1970-01-01T01:00:00+01:00", {tz = "Asia/Omsk"}) ==
+        dt.new{year = 1970, mon = 1, day = 1,
+               hour = 1, min = 0, sec = 0, tzoffset = 60})
+    -- Timezone is not specified in a parsed string and format is passed.
+    t.assert(dt.parse("1998-11-25", { format = "%Y-%m-%d", tz = "MSK" }) ==
+        dt.new{year = 1998, month = 11, day = 25, tzoffset = 180})
+end
+
+-- Test the new behavior preserves the zero timestamp when only
+-- a timezone is provided to `new()`, so it stays equivalent to
+-- setting the timezone on a default datetime object (gh-10363).
+pg.test_new_tz_behavior_tz_only_new = function()
+    t.assert_equals(compat.datetime_apply_timezone_action.default, 'old')
+    compat.datetime_apply_timezone_action = 'new'
+
+    local d = dt.new{tz = 'MSK'}
+    t.assert_equals(d.timestamp, 0)
+    t.assert_equals(tostring(d), tostring(dt.new{}:set{tz = 'MSK'}))
+    t.assert_equals(tostring(d), '1970-01-01T03:00:00 MSK')
+
+    d = dt.new{tzoffset = 180}
+    t.assert_equals(d.timestamp, 0)
+    t.assert_equals(tostring(d), tostring(dt.new{}:set{tzoffset = 180}))
+    t.assert_equals(tostring(d), '1970-01-01T03:00:00+0300')
+end
+
+-- Test time units provided together with a timezone are applied
+-- to the wall clock time regardless of the compat option value
+-- (gh-10363).
+pg.test_tz_behavior_time_units_with_tz = function()
+    t.assert_equals(compat.datetime_apply_timezone_action.default, 'old')
+    for _, behavior in ipairs({'old', 'new'}) do
+        compat.datetime_apply_timezone_action = behavior
+        local d = dt.new{hour = 3, tz = 'MSK'}
+        t.assert_equals(tostring(d), '1970-01-01T03:00:00 MSK', behavior)
+        d = d:set{msec = 1, tzoffset = 6 * 60}
+        t.assert_equals(tostring(d), '1970-01-01T03:00:00.001+0600', behavior)
+    end
+end
+
+-- }}} Compat option for applying timezones test (gh-10363).

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -439,6 +439,7 @@ g.test_defaults = function()
             box_error_unpack_type_and_code = 'old',
             console_session_scope_vars = 'old',
             wal_cleanup_delay_deprecation = 'old',
+            datetime_apply_timezone_action = 'old',
         },
         isolated = false,
     }

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -464,6 +464,7 @@ g.test_defaults = function()
             skip_replication_names = 'new',
             datetime_setfn_timestamp_type_check = 'old',
             box_backup_default_ttl = 'old',
+            datetime_apply_timezone_action = 'old',
         },
         isolated = false,
         stateboard = {


### PR DESCRIPTION
This patch adds a fix making `datetime` handle `tz` and `tzoffset`
parameters properly.

Previously, changing a timezone altered the timestamp value but
preserved the time of day. Now you may enable new behavior making
specifying a timezone preserve the timestamp and update the represented
time of day.

This behavior could be achieved by setting a new compat option
`datetime_apply_timezone_action` to `'new'`. The option is going to be
enabled by default in 4.x.

Enabling new behavior involves the following.
1. Creating a datetime object with non-empty `tz`/`tzoffset` and
   `timestamp` values results with a time of day corresponding to
   the timestamp value plus the timezone offset. E.g if we create a
   datetime object with a timestamp corresponding to 9:12 o'clock in
   `+0000` timezone and set `tzoffset = -60` the resulting timestamp
   will represent 8:12 o'clock.
2. Setting a new `tz`/`tzoffset` affects the time of day represented by
   the datetime. E.g. if you update a datetime object of 11:12 o'clock
   having `tzoffset = 180` with `tzoffset = 120` the resulting datetime
   object will represent 10:12.

Closes #10363

Doc request tarantool/doc#4720

