### PR TITLE
[backport 3.3] test: parallelize several `config-luatest/*` tests

### DIFF
--- a/test/config-luatest/failover_and_election_mode_test.lua
+++ b/test/config-luatest/failover_and_election_mode_test.lua
@@ -1,3 +1,5 @@
+-- tags: parallel
+
 -- Verify all the compositions of possible replication.failover
 -- and replication.election_mode values.
 --

--- a/test/config-luatest/log_wrapper_test.lua
+++ b/test/config-luatest/log_wrapper_test.lua
@@ -1,3 +1,5 @@
+-- tags: parallel
+
 local t = require('luatest')
 local treegen = require('luatest.treegen')
 local justrun = require('luatest.justrun')

--- a/test/config-luatest/rpc_test.lua
+++ b/test/config-luatest/rpc_test.lua
@@ -1,3 +1,5 @@
+-- tags: parallel
+
 local t = require('luatest')
 local fun = require('fun')
 local treegen = require('luatest.treegen')


### PR DESCRIPTION
This is a backport of several PRs to `release/3.3`.

| Test                                                 | Pull request |
| ---------------------------------------------------- | ------------ |
| `config-luatest/log_wrapper_test.lua`                | #10960       |
| `config-luatest/failover_and_election_mode_test.lua` | #10962       |
| `config-luatest/rpc_test.lua`                        | #10963       |