### PR TITLE
test: add missed *.test.sql pattern

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -179,6 +179,7 @@ file(GLOB_RECURSE tests
   ${PROJECT_SOURCE_DIR}/test/*.test.lua
   ${PROJECT_SOURCE_DIR}/test/*.test.py
   ${PROJECT_SOURCE_DIR}/test/*_test.lua
+  ${PROJECT_SOURCE_DIR}/test/*.test.sql
 )
 foreach(test_path ${tests})
   get_filename_component(test_name ${test_path} NAME)


### PR DESCRIPTION
The glob `*.test.sql` is missed in ctest search patterns. The patch fixes that. Follows up a9b9f2eb4f71
("test: execute tests using CTest").

NO_CHANGELOG=testing
NO_DOC=testing
NO_TEST=testing