### PR TITLE
cmake: shuffle testcases in luatest's tests

### DIFF
--- a/test/app-luatest/CMakeLists.txt
+++ b/test/app-luatest/CMakeLists.txt
@@ -41,6 +41,7 @@ foreach(test_path ${tests})
                    # see https://github.com/tarantool/test-run/issues/119.
                    -e "io.stdout:setvbuf('no')"
                    ${LUATEST_COMMAND_WITH_FLAGS}
+                   --shuffle all:${RANDOM_SEED}
                    ${test_title}
            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   )

--- a/test/config-luatest/CMakeLists.txt
+++ b/test/config-luatest/CMakeLists.txt
@@ -30,6 +30,7 @@ foreach(test_path ${tests})
                    # see https://github.com/tarantool/test-run/issues/119.
                    -e "io.stdout:setvbuf('no')"
                    ${LUATEST_COMMAND_WITH_FLAGS}
+                   --shuffle all:${RANDOM_SEED}
                    ${test_title}
            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   )

--- a/test/metrics-luatest/CMakeLists.txt
+++ b/test/metrics-luatest/CMakeLists.txt
@@ -29,6 +29,7 @@ foreach(test_path ${tests})
                    # see https://github.com/tarantool/test-run/issues/119.
                    -e "io.stdout:setvbuf('no')"
                    ${LUATEST_COMMAND_WITH_FLAGS}
+                   --shuffle all:${RANDOM_SEED}
                    ${test_title}
            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   )

--- a/test/vinyl-luatest/CMakeLists.txt
+++ b/test/vinyl-luatest/CMakeLists.txt
@@ -29,6 +29,7 @@ foreach(test_path ${tests})
                    # see https://github.com/tarantool/test-run/issues/119.
                    -e "io.stdout:setvbuf('no')"
                    ${LUATEST_COMMAND_WITH_FLAGS}
+                   --shuffle all:${RANDOM_SEED}
                    ${test_title}
            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   )


### PR DESCRIPTION
luatest has an option `--shuffle` that allows to reorder testcases before execution. This can be useful to detect a test that passes just because it happens to run after an unrelated test that leaves the system in a favourable state. Patch enables tests shuffling with predefined random seed generated by CMake [1] and a fixes for a tests were failed after enabling shuffle mode. Seed is useful for reproducing a problems related to the specific test order.

The patch enables shuffle mode only in `appl-luatest`, `metrics-luatest`, `config-luatest` and `vinyl-luatest`. In other test suites tests failed with enabled shuffle mode. For these suites mode will be enabled later.

Follows up commit 9e3e9eedc025
("cmake: support luatest tests by CTest")

1. https://cmake.org/cmake/help/latest/command/string.html#random

NO_CHANGELOG=testing
NO_DOC=testing
NO_TEST=testing