### PR TITLE
[backport 3.2] lib/bit: introduce `bit_set_range()`

### DIFF
--- a/src/lib/bit/bit.c
+++ b/src/lib/bit/bit.c
@@ -79,6 +79,9 @@ bit_set(void *data, size_t pos);
 extern inline bool
 bit_clear(void *data, size_t pos);
 
+extern inline void
+bit_set_range(void *data, size_t pos, size_t count, bool val);
+
 extern inline int
 bit_ctz_u32(uint32_t x);
 

--- a/test/unit/bit.c
+++ b/test/unit/bit.c
@@ -251,6 +251,44 @@ test_bitmap_size(void)
 	footer();
 }
 
+/**
+ * Check all possible valid inputs of `bit_set_range()'.
+ */
+static void
+test_bit_set_range(void)
+{
+	header();
+
+	const size_t data_size = 64; /* In bytes. */
+	const size_t data_count = data_size * CHAR_BIT; /* In bits. */
+
+	for (size_t pos = 0; pos < data_count; pos++) {
+		for (size_t count = 0; count <= data_count - pos; count++) {
+			for (int val = 0; val <= 1; val++) {
+				uint8_t data[data_size];
+				uint8_t ref[data_size];
+
+				/* Initialize buffers. */
+				memset(data, 0xA5, sizeof(data));
+				memset(ref, 0xA5, sizeof(ref));
+				/* Calculate reference result. */
+				for (size_t i = pos; i < pos + count; i++) {
+					if (val == 0)
+						bit_clear(ref, i);
+					else
+						bit_set(ref, i);
+				}
+				/* The function under test. */
+				bit_set_range(data, pos, count, val);
+				/* Compare results. */
+				fail_if(memcmp(data, ref, sizeof(data)) != 0);
+			}
+		}
+	}
+
+	footer();
+}
+
 int
 main(void)
 {
@@ -263,4 +301,5 @@ main(void)
 	test_bit_iter_empty();
 	test_bit_iter_fractional();
 	test_bitmap_size();
+	test_bit_set_range();
 }

--- a/test/unit/bit.result
+++ b/test/unit/bit.result
@@ -715,3 +715,5 @@ Clear: 0, 1, 2, 4, 5, 6, 7, 8, 10, 12, 13, 14, 15, 19, 20, 21, 23, 26, 28, 30, 3
 	*** test_bit_iter_fractional: done ***
 	*** test_bitmap_size ***
 	*** test_bitmap_size: done ***
+	*** test_bit_set_range ***
+	*** test_bit_set_range: done ***


### PR DESCRIPTION
This function sets a range of bits to all-zeros or all-ones.

Needed for tarantool/tarantool-ee#1050

NO_DOC=internal
NO_CHANGELOG=internal

(cherry picked from commit 41c33ed046ecdbb3b819706e8290a44b9d95158c)