### PR TITLE
log: encode table arguments in json

### DIFF
--- a/changelogs/unreleased/gh-8611-log-tables-in-json.md
+++ b/changelogs/unreleased/gh-8611-log-tables-in-json.md
@@ -1,0 +1,3 @@
+## feature/lua
+
+* Built-in logger now encodes table arguments in the JSON format (gh-8611).

--- a/src/lua/log.lua
+++ b/src/lua/log.lua
@@ -166,9 +166,19 @@ local function say(self, level, fmt, ...)
     local type_fmt = type(fmt)
     local format = "%s"
     local msg
-    if select('#', ...) ~= 0 then
+    local argc = select('#', ...)
+    if argc ~= 0 then
+        local args = {...}
+        for i = 1, argc do
+            if type(args[i]) == 'table' then
+                local mt = getmetatable(args[i])
+                if mt == nil or mt.__tostring == nil then
+                    args[i] = json.encode(args[i])
+                end
+            end
+        end
         local stat
-        stat, msg = pcall(string.format, fmt, ...)
+        stat, msg = pcall(string.format, fmt, unpack(args, 1, argc))
         if not stat then
             error(msg, 3)
         end

--- a/test/app-luatest/gh_8611_log_tables_in_json_test.lua
+++ b/test/app-luatest/gh_8611_log_tables_in_json_test.lua
@@ -1,0 +1,28 @@
+local t = require('luatest')
+local treegen = require('luatest.treegen')
+local justrun = require('luatest.justrun')
+
+local g = t.group()
+
+g.test_log_tables_in_json = function()
+    local dir = treegen.prepare_directory({}, {})
+    treegen.write_file(dir, 'main.lua', [[
+        local log = require('log')
+        log.info('%s, %s, %s, %s', 123, {foo = 'bar'}, 'abc', {1, 2, 3})
+        log.info('%s, %s, %s, %s, %s', nil, nil, nil, nil, {1, 2, 3})
+        log.info('%s', setmetatable({foo = 'bar'}, {
+            __index = {fuzz = 'buzz'},
+        }))
+        log.info('%s', setmetatable({foo = 'bar'}, {
+            __tostring = function() return 'foobar' end,
+        }))
+    ]])
+    local res = justrun.tarantool(dir, {}, {'main.lua'},
+                                  {stderr = true, nojson = true})
+    t.assert_equals(res.exit_code, 0)
+    t.assert_equals(res.stderr,
+[[123, {"foo":"bar"}, abc, [1,2,3]
+nil, nil, nil, nil, [1,2,3]
+{"foo":"bar"}
+foobar]])
+end


### PR DESCRIPTION
This is more convenient than calling `json.encode` manually. It is also more efficient in case logging is skipped due to the log level.

How it used to work:

```
tarantool> require('log').info('%s', {foo = 'bar'})
table: 0x41f9d2e8
```

How it works now:

```
tarantool> require('log').info('%s', {foo = 'bar'})
{"foo":"bar"}
```

Note, JSON encoding is enabled only for tables that don't have the `__tostring` meta-method:

```
tarantool> require('log').info('%s', setmetatable({foo = 'bar'}, {__tostring = function() return 'foobar' end}))
foobar
```

Closes #8611