### PR TITLE
test: stabilize replication rebootstrap and bootstrap_leader tests

### DIFF
--- a/test/replication/bootstrap_leader.result
+++ b/test/replication/bootstrap_leader.result
@@ -43,11 +43,20 @@ while (#box.info.replication < 3) do
 end;
  | ---
  | ...
-test_run:cmd("switch default");
+
+test_run:cmd("switch replica2");
+ | ---
+ | - true
+ | ...
+test_run:wait_upstream(1, {status = "follow"});
  | ---
  | - true
  | ...
 
+test_run:cmd("switch default");
+ | ---
+ | - true
+ | ...
 for i = 1,3 do
     test_run:cmd("stop server replica"..i.." with cleanup=1")
     test_run:cmd("delete server replica"..i)

--- a/test/replication/bootstrap_leader.test.lua
+++ b/test/replication/bootstrap_leader.test.lua
@@ -17,8 +17,11 @@ fiber = require('fiber');
 while (#box.info.replication < 3) do
     fiber.sleep(0.05)
 end;
-test_run:cmd("switch default");
 
+test_run:cmd("switch replica2");
+test_run:wait_upstream(1, {status = "follow"});
+
+test_run:cmd("switch default");
 for i = 1,3 do
     test_run:cmd("stop server replica"..i.." with cleanup=1")
     test_run:cmd("delete server replica"..i)

--- a/test/replication/rebootstrap.result
+++ b/test/replication/rebootstrap.result
@@ -40,6 +40,9 @@ test_run:cmd('switch default')
 ---
 - true
 ...
+test_run:wait_fullmesh(SERVERS)
+---
+...
 test_run:drop_cluster(SERVERS)
 ---
 ...

--- a/test/replication/rebootstrap.test.lua
+++ b/test/replication/rebootstrap.test.lua
@@ -18,4 +18,5 @@ test_run:cmd('switch rebootstrap1')
 box.info.status -- running
 
 test_run:cmd('switch default')
+test_run:wait_fullmesh(SERVERS)
 test_run:drop_cluster(SERVERS)

--- a/test/replication/suite.cfg
+++ b/test/replication/suite.cfg
@@ -1,6 +1,7 @@
 {
     "anon.test.lua": {},
     "anon_register_gap.test.lua": {},
+    "bootstrap_leader.test.lua": {},
     "gh-2991-misc-asserts-on-update.test.lua": {},
     "gh-3055-election-promote.test.lua": {},
     "gh-3055-promote-wakeup-crash.test.lua": {},

--- a/test/replication/suite.ini
+++ b/test/replication/suite.ini
@@ -99,9 +99,6 @@ fragile = {
         "gh-5426-election-on-off.test.lua": {
             "issues": [ "gh-5506" ]
         },
-        "rebootstrap.test.lua": {
-            "issues": [ "gh-5524" ]
-        },
         "qsync_with_anon.test.lua": {
             "issues": [ "gh-5582" ]
         },

--- a/test/replication/suite.ini
+++ b/test/replication/suite.ini
@@ -96,9 +96,6 @@ fragile = {
         "gc.test.lua": {
             "issues": [ "gh-5474" ]
         },
-        "bootstrap_leader.test.lua": {
-            "issues": [ "gh-5478" ]
-        },
         "gh-5426-election-on-off.test.lua": {
             "issues": [ "gh-5506" ]
         },


### PR DESCRIPTION
The commit 89cd7f43fd37 ("replication: do not account booting replicas in sync quorum") allowed replicas to leave orphan mode without waiting for everyone listed in box.cfg.replication.

As a result, bootstrap_leader test started exiting too early, because it relied on one of the replicas staying in orphan mode until all the others finish bootstrap. Fix it.

Also, remove "memtx" and "vinyl" configuration for the test. There is nothing in the test related to engines.

While we're at it, remove the test from fragile list. It hasn't flaked since long ago, excluding the last couple of weeks, which's fixed now.

Closes tarantool/tarantool-qa#63

NO_CHANGELOG=flaky test
NO_DOC=flaky test