### PR TITLE
config: migrate extras module definitions to EE

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -78,10 +78,7 @@ lua_source(lua_sources lua/config/utils/funcutils.lua      config_utils_funcutil
 lua_source(lua_sources lua/config/utils/network.lua        config_utils_network_lua)
 
 if (ENABLE_CONFIG_EXTRAS)
-    lua_source(lua_sources ${CONFIG_EXTRAS_DIR}/source/etcd.lua config_source_etcd_lua)
-    lua_source(lua_sources ${CONFIG_EXTRAS_DIR}/storage/init.lua config_storage_init_lua)
-    lua_source(lua_sources ${CONFIG_EXTRAS_DIR}/source/storage.lua config_source_storage_lua)
-    lua_source(lua_sources ${CONFIG_EXTRAS_DIR}/extras.lua config_extras_lua)
+    lua_multi_source(lua_sources ${CONFIG_EXTRAS_LUA_SOURCES})
 endif()
 # }}} config
 

--- a/src/box/lua/config/extras.h
+++ b/src/box/lua/config/extras.h
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2024, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include "trivia/config.h"
+
+#if defined(ENABLE_CONFIG_EXTRAS)
+#include "lua/config/extras_impl.h"
+#else /* !defined(ENABLE_CONFIG_EXTRAS) */
+
+#define CONFIG_EXTRAS_LUA_MODULES
+
+#endif /* !defined(ENABLE_CONFIG_EXTRAS) */

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -35,7 +35,7 @@ local function load_extras()
     return extras
 end
 
-local extras = load_extras()
+local extras
 
 -- {{{ Helpers
 
@@ -105,6 +105,8 @@ function methods._register_applier(self, applier)
 end
 
 function methods._initialize(self)
+    extras = load_extras()
+
     -- The sources are synchronized in the order of registration:
     -- env, file, etcd (present in Tarantool EE), env for
     -- defaults.

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -84,6 +84,7 @@
 #include "box/lua/config/utils/expression_lexer.h"
 #include "box/lua/failover.h"
 #include "box/lua/integrity.h"
+#include "box/lua/config/extras.h"
 
 #include "mpstream/mpstream.h"
 
@@ -181,12 +182,6 @@ extern char session_lua[],
 	config_utils_textutils_lua[],
 	config_utils_funcutils_lua[],
 	config_utils_network_lua[],
-#if ENABLE_CONFIG_EXTRAS
-	config_source_etcd_lua[],
-	config_storage_init_lua[],
-	config_source_storage_lua[],
-	config_extras_lua[],
-#endif
 	/* }}} config */
 
 	connpool_lua[];
@@ -433,20 +428,6 @@ static const char *lua_sources[] = {
 	"internal.config.applier.autoexpel",
 	config_applier_autoexpel_lua,
 
-#if ENABLE_CONFIG_EXTRAS
-	"config/source/etcd",
-	"internal.config.source.etcd",
-	config_source_etcd_lua,
-
-	"config/source/storage",
-	"internal.config.source.storage",
-	config_source_storage_lua,
-
-	"config/extras",
-	"internal.config.extras",
-	config_extras_lua,
-#endif
-
 	"config/applier/box_cfg",
 	"internal.config.applier.box_cfg",
 	config_applier_box_cfg_lua,
@@ -495,11 +476,7 @@ static const char *lua_sources[] = {
 	"config",
 	config_init_lua,
 
-#if ENABLE_CONFIG_EXTRAS
-	"config/storage/init",
-	"config.storage",
-	config_storage_init_lua,
-#endif
+	CONFIG_EXTRAS_LUA_MODULES
 
 	/* }}} config */
 


### PR DESCRIPTION
This patch migrates config.extras module definitions to Tarantool EE.
Now its sources are defined there.

Also, it makes Tarantool validate extras module during a config
initialization phase. It is changed this way to achieve possibility to
load configuration extras after loading the basic config module to
simplify the order of modules loading.

Previous loading order:
* Load `config.extras`.
* Load `config`.
* Load a few more `config.extras`.

New loading order:
* Load `config`.
* Load `config.extras`.

The simplification comes with a cost of less checks in no-configuration
mode though they're not so important since the scenario when we add
`config.extras` and work in no-configuration mode sounds quite strange.

Needed for tarantool/tarantool-ee#1024
