### PR TITLE
[backport 3.2] test: speedup and stabilize the gh_7605_qsort_recovery test

### DIFF
--- a/test/box-luatest/gh_7605_qsort_recovery_test.lua
+++ b/test/box-luatest/gh_7605_qsort_recovery_test.lua
@@ -34,15 +34,13 @@ end)
 
 g.test_qsort_recovery = function()
     g.server:exec(function()
-        local PACK = 10000
-        local TOTAL = 2000000
+        local PACK = 1000
+        local TOTAL = 20000
         local uuid = require "uuid"
         local fiber = require "fiber"
 
+        fiber.set_max_slice(600)
         for i = 1, TOTAL / PACK do
-            if fiber.set_slice then
-                fiber.set_slice(600)
-            end
             box.begin()
             for k = 1, PACK do
                 box.space.test:replace{(i - 1) * 1000 + k, uuid.str()}
@@ -58,10 +56,12 @@ g.test_qsort_recovery = function()
 
     -- check secondary index correctness
     g.server:exec(function()
-        local PACK = 10000
+        local PACK = 1000
         local prev_tuple = nil
         local fiber = require "fiber"
         local i = 0
+
+        fiber.set_max_slice(600)
         for _,tuple in box.space.test.index.i:pairs() do
             if prev_tuple ~= nil then
                 t.assert(prev_tuple[2] < tuple[2], "Unordered!")
@@ -77,15 +77,13 @@ g.test_qsort_recovery = function()
 
     -- original test
     g.server:exec(function()
-        local PACK = 10000
-        local TOTAL = 2000000
+        local PACK = 1000
+        local TOTAL = 20000
         local uuid = require "uuid"
         local fiber = require "fiber"
 
+        fiber.set_max_slice(600)
         for i = 1, TOTAL / PACK do
-            if fiber.set_slice then
-                fiber.set_slice(600)
-            end
             box.begin()
             for k = 1, PACK do
                 box.space.test:replace{(i - 1) * 1000 + k, uuid.str()}

--- a/test/box-luatest/suite.ini
+++ b/test/box-luatest/suite.ini
@@ -3,4 +3,4 @@ core = luatest
 description = Database tests
 is_parallel = True
 release_disabled = gh_6819_iproto_watch_not_implemented_test.lua
-long_run = gh_7605_qsort_recovery_test.lua gh_7670_memtx_tx_manager_idx_rand_inconsistency_test.lua
+long_run = gh_7670_memtx_tx_manager_idx_rand_inconsistency_test.lua


### PR DESCRIPTION
The test used to take around 180 seconds in debug build and was quite flaky.

When the test was introduced in commit e1d961708504 ("Fix a bug in qsort") it was stated that such a long test with 2 million keys was needed to reproduce the bug.

Since the test introduction our sort implementation was rewritten in commit ec34bf7ba3ea ("core: introduce sample sort algorithm") and commit 4f617b702f0f ("box: introduce memtx_sort_threads config parameter").

Now multithread sort is used as long as there are more than a 1024 keys to sort, so such a huge test seems unnecessary.

Let's reduce test size to 20000 keys from 2000000 and make the test code yield every 1000 iterations instead of 10000, which is a more common practice.

When running the test a lot times in parallel the fiber slice check may still fail during index correctness check, so set fiber slice there as well.

Now the test runs around 6 seconds in debug build and may be removed from long-run list.

The test still spots the original problem in case it appears which can be verified by reverting the fix from the original commit.

Closes #10961

NO_CHANGELOG=test
NO_DOC=test

(cherry picked from commit cfc6b4a2792dbe869955d428db7347d4b7b64384)