### PR TITLE
changelog: cleanup 3.3.1 changelogs

### DIFF
--- a/changelogs/unreleased/config-lack-of-sharding-role.md
+++ b/changelogs/unreleased/config-lack-of-sharding-role.md
@@ -1,4 +1,0 @@
-## bugfix/config
-
-* Don't fail if the `sharding.roles` option is not set for some instances
-  (gh-10458).

--- a/changelogs/unreleased/config-schema-deep-merge.md
+++ b/changelogs/unreleased/config-schema-deep-merge.md
@@ -1,7 +1,0 @@
-## bugfix/config
-
-* `<schema object>:merge()` now performs a deep merge inside an `any` scalar
-  value if left-hand and right-hand values are both tables, where all the keys
-  are strings. This way the cluster configuration options that are marked as
-  `any` in the schema (fields of `app.cfg` and `roles_cfg`) are merged deeply
-  (gh-10450).

--- a/changelogs/unreleased/gh-10347-proper-instance-duplicates-messages.md
+++ b/changelogs/unreleased/gh-10347-proper-instance-duplicates-messages.md
@@ -1,6 +1,0 @@
-## bugfix/config
-
-* Now Tarantool writes a detailed error message if it finds
-  replica sets with the same names in different groups or instances
-  with the same names in different replica sets in the provided
-  configuration (gh-10347).

--- a/changelogs/unreleased/gh-10561-anon-replicas-dont-participate-in-elections.md
+++ b/changelogs/unreleased/gh-10561-anon-replicas-dont-participate-in-elections.md
@@ -1,6 +1,0 @@
-## bugfix/replication
-
-* Fixed a bug when anonymous replicas could participate in elections or even
-  be chosen as a leader. It is now forbidden to configure a replica so
-  that `replication_anon` is `true` and `election_mode` is not `off`
-  (gh-10561).

--- a/changelogs/unreleased/gh-10707-fix-vinyl-abort-writers-on-ddl.md
+++ b/changelogs/unreleased/gh-10707-fix-vinyl-abort-writers-on-ddl.md
@@ -1,4 +1,0 @@
-## bugfix/vinyl
-
-* Fixed a use-after-free bug in the transaction manager that could be triggered
-  by a race between DDL and DML operations affecting the same space (gh-10707).

--- a/changelogs/unreleased/gh-10855-schema-get-set-changes-path.md
+++ b/changelogs/unreleased/gh-10855-schema-get-set-changes-path.md
@@ -1,4 +1,0 @@
-## bugfix/config
-
-* `schema:get()`/`schema:set()` and `config:get()` no longer changes the
-  passed path if it is passed as a table (gh-10855).

--- a/changelogs/unreleased/gh-10870-fix-vinyl-tx-stmt-overwrite-multikey.md
+++ b/changelogs/unreleased/gh-10870-fix-vinyl-tx-stmt-overwrite-multikey.md
@@ -1,6 +1,0 @@
-## bugfix/vinyl
-
-* Fixed a bug when a tuple could disappear from a multikey index in case it
-  replaced a tuple with duplicate multikey array entries created in the same
-  transaction. With the enabled `defer_deletes` space option, the bug could
-  also trigger a crash (gh-10869, gh-10870).

--- a/changelogs/unreleased/gh-10879-fix-vinyl-cache-invalidation-on-rollback.md
+++ b/changelogs/unreleased/gh-10879-fix-vinyl-cache-invalidation-on-rollback.md
@@ -1,5 +1,0 @@
-## bugfix/vinyl
-
-* Fixed a bug when the tuple cache was not properly invalidated in case
-  a WAL write error occurred while committing a `space.delete()` operation.
-  The bug could lead to a crash or an invalid read query result (gh-10879).

--- a/changelogs/unreleased/gh-10895-fix-vinyl-deferred-delete-compaction.md
+++ b/changelogs/unreleased/gh-10895-fix-vinyl-deferred-delete-compaction.md
@@ -1,4 +1,0 @@
-## bugfix/vinyl
-
-* Fixed a bug when a deleted secondary index key wasn't purged on compaction
-  of a space with the `defer_deletes` option enabled (gh-10895).

--- a/changelogs/unreleased/gh-10934-fix-roles-on_event-config-argument.md
+++ b/changelogs/unreleased/gh-10934-fix-roles-on_event-config-argument.md
@@ -1,3 +1,0 @@
-## bugfix/config
-
-* Fixed `on_event` roles callback receiving wrong `config` argument (gh-10934).

--- a/changelogs/unreleased/gh-9923-fix-invalid-iproto-name-mapping-on-the-server-side.md
+++ b/changelogs/unreleased/gh-9923-fix-invalid-iproto-name-mapping-on-the-server-side.md
@@ -1,3 +1,0 @@
-## bugfix/core
-
- * Fixed a bug when IPROTO_INDEX_NAME was mapped into a wrong index identifier (gh-9923).

--- a/src/box/lua/upgrade.lua
+++ b/src/box/lua/upgrade.lua
@@ -2224,6 +2224,7 @@ local downgrade_versions = {
     "3.2.0",
     "3.2.1",
     "3.3.0",
+    "3.3.1",
     -- DOWNGRADE VERSIONS END
 }
 


### PR DESCRIPTION
Remove all changelogs reported in release notes for 3.3.1.

Also add the new downgrade version to the downgrade versions list.

NO_DOC=changelog
NO_TEST=changelog
NO_CHANGELOG=changelog