### PR TITLE
[backport 3.3] ci: use cmake 3.17 in static_build_cmake_linux

### DIFF
--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -84,6 +84,13 @@ jobs:
         with:
           submodule: ${{ inputs.submodule }}
           revision: ${{ inputs.revision }}
+      # Install CMake using PyPI, because option
+      # `--repeat until-pass:3` required by CTest was added since
+      # CMake 3.17.
+      - name: install cmake
+        run: |
+          apt -y remove cmake
+          pip3 install cmake==3.17.3
       - name: test
         run: make -f .test.mk test-static-cmake
       - name: Send VK Teams message on failure

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -207,6 +207,7 @@ foreach(test_path ${tests})
                    # Enable long run tests.
                    --long
                    --vardir ${VARDIR}/${SALT}-${test_name}
+                   --retries 0
                    ${suite}/${test_name}
   )
   set_tests_properties(${test_title} PROPERTIES


### PR DESCRIPTION
Orig PR: https://github.com/tarantool/tarantool/pull/10995