### PR TITLE
memtx: finalize prepare of all transactions in memtx MVCC

### DIFF
--- a/changelogs/unreleased/gh-10715-memtx-mvcc-conflict-with-prepared-sysview-txn.md
+++ b/changelogs/unreleased/gh-10715-memtx-mvcc-conflict-with-prepared-sysview-txn.md
@@ -1,0 +1,5 @@
+## bugfix/memtx
+
+* Fixed a crash when memtx MVCC tried to abort an already committed
+  non-memtx transaction if it used a system space view or tried to
+  perform a DDL operation (gh-10715).

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -626,7 +626,6 @@ memtx_engine_prepare(struct engine *engine, struct txn *txn)
 			assert(stmt->space->engine == engine);
 			memtx_tx_history_prepare_stmt(stmt);
 		}
-		memtx_tx_prepare_finalize(txn);
 	}
 	return 0;
 }

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -2687,7 +2687,7 @@ memtx_tx_history_prepare_stmt(struct txn_stmt *stmt)
 }
 
 void
-memtx_tx_prepare_finalize(struct txn *txn)
+memtx_tx_prepare_finalize_slow(struct txn *txn)
 {
 	/* Just free all other lists - we don't need 'em anymore. */
 	memtx_tx_clear_txn_read_lists(txn);

--- a/src/box/memtx_tx.h
+++ b/src/box/memtx_tx.h
@@ -225,14 +225,24 @@ void
 memtx_tx_history_prepare_stmt(struct txn_stmt *stmt);
 
 /**
+ * Helper of `memtx_tx_prepare_finalize`.
+ */
+void
+memtx_tx_prepare_finalize_slow(struct txn *txn);
+
+/**
  * Finish preparing of a transaction.
  * Must be called for entire transaction after `memtx_tx_history_rollback_stmt`
  * was called for each transaction statement.
  *
  * NB: can trigger story garbage collection.
  */
-void
-memtx_tx_prepare_finalize(struct txn *txn);
+static inline void
+memtx_tx_prepare_finalize(struct txn *txn)
+{
+	if (memtx_tx_manager_use_mvcc_engine)
+		memtx_tx_prepare_finalize_slow(txn);
+}
 
 /**
  * @brief Commit statement in history.

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -1069,6 +1069,12 @@ txn_prepare(struct txn *txn)
 			return -1;
 		}
 	}
+	/*
+	 * Non-memtx transactions can use memtx MVCC (for example, transactions
+	 * reading from sysview), so we need to finalize prepare of all
+	 * transactions, not only memtx ones.
+	 */
+	memtx_tx_prepare_finalize(txn);
 
 	trigger_clear(&txn->fiber_on_stop);
 	trigger_clear(&txn->fiber_on_yield);

--- a/test/box-luatest/gh_10715_memtx_mvcc_conflict_with_prepared_sysview_txn_test.lua
+++ b/test/box-luatest/gh_10715_memtx_mvcc_conflict_with_prepared_sysview_txn_test.lua
@@ -1,0 +1,78 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+-- The original issue is about non-memtx transactions, but let's
+-- test memtx along the way.
+local g = t.group(nil, {{engine = 'memtx'}, {engine = 'vinyl'}})
+
+g.before_all(function(g)
+    g.server = server:new{
+        box_cfg = {memtx_use_mvcc_engine = true}
+    }
+    g.server:start()
+end)
+
+g.after_all(function(g)
+    g.server:drop()
+end)
+
+g.before_each(function(g)
+    g.server:exec(function(engine)
+        local s = box.schema.space.create('s', {engine = engine})
+        s:create_index('pk')
+    end, {g.params.engine})
+end)
+
+g.after_each(function(g)
+    g.server:exec(function()
+        box.space.s:drop()
+    end)
+end)
+
+g.test_conflict_with_prepared_sysview_transaction = function(g)
+    g.server:exec(function()
+        local fiber = require('fiber')
+
+        local ch = fiber.channel(1)
+        local f = fiber.create(function()
+            box.begin()
+            -- Read from sysview over _space to conflict this
+            -- transaction with future DDL.
+            box.space._vspace:select{}
+            box.space.s:replace{1}
+            ch:put(true)
+            box.commit()
+        end)
+        f:set_joinable(true)
+
+        -- The crash happened because we conflicted a prepared non-memtx
+        -- transaction. Here we check that we don't conflict such
+        -- transactions anymore.
+        t.assert_equals({ch:get()}, {true})
+        box.space.s:format({{'f1', 'unsigned'}})
+        t.assert_equals({f:join()}, {true})
+    end)
+end
+
+-- Along the way, make sure that conflict of in-progress transaction
+-- caused by sysview read works well.
+g.test_conflict_with_in_progress_sysview_transaction = function(g)
+    g.server:exec(function()
+        local fiber = require('fiber')
+
+        box.begin()
+        -- Read from sysview over _space to conflict this
+        -- transaction with future DDL.
+        box.space._vspace:select{}
+        box.space.s:replace{1}
+
+        local f = fiber.create(function()
+            box.space.s:format({{'f1', 'unsigned'}})
+        end)
+        f:set_joinable(true)
+        t.assert_equals({f:join()}, {true})
+
+        t.assert_error_msg_equals(
+            'Transaction has been aborted by conflict', box.commit)
+    end)
+end


### PR DESCRIPTION
We have a special `sysview` engine that bypasses transaction management and reads right from memtx indexes. The problem is memtx indexes use memtx MVCC by themselves, so despite `sysview` bypasses transaction management process, it actually uses memtx MVCC. So the problem here is that transaction can actually read something using `sysview`, a tracker in MVCC will be allocated, but `txn->engine[memtx->id]` still will be `NULL`, so the preparation of the transaction won't be finalized by memtx_tx and the tracker won't be deleted when transaction is prepared. On conflict, MVCC will try to abort that already prepared transaction and it will lead to a crash.

Actually, crashing scenarios are rather synthetic and break only our engine fuzzer. Here is an example of such scenario without manual use of system spaces:
1. Open a transaction and do an operation in a vinyl space.
2. Try to alter the space in the same transaction - it will fail with cross-engine transaction error.
3. Commit the transaction, but do not wait for WAL write (internally, such state is called `prepared`).
4. Alter the space in another transaction and commit it before the previous transaction was written to WAL. Here MVCC will try to conflict that already prepared transaction and it will break Tarantool.

To solve the problem, we could try to write quite a large patch to handle such transactions differently in memtx MVCC. But instead, let's simply finalize prepare of all transaction in MVCC. The current design already lacks encapsulation - all transactions (even non-memtx) are registered there, so such solution not only simple but also consistent with other MVCC parts. Note that memtx MVCC still can abort such non-memtx transactions when they are in-progress, but it seems that such behavior doesn't break other yielding engines (`vinyl` is the only one).

In order not to do unnecessary function call when MVCC is disabled, function `memtx_tx_prepare_finalize` is `static inline` now and uses a `*_slow` helper when MVCC is actually enabled - such approach is common in this subsystem.

Closes #10715