### PR TITLE
memtx: reserve memory in the rtree itself

### DIFF
--- a/src/lib/salad/rtree.h
+++ b/src/lib/salad/rtree.h
@@ -285,6 +285,20 @@ bool
 rtree_remove(struct rtree *tree, const struct rtree_rect *rect, record_t obj);
 
 /**
+ * @brief Insert, replace or delete a record in the tree
+ * @return 0 on success, -1 on memory error
+ * @param tree - pointer to a tree
+ * @param old_rect - rectangle of the record to delete
+ * @param old_obj - record to delete
+ * @param new_rect - rectangle to insert
+ * @param new_obj - record to insert
+ * @param removed - set to true if the old_obj is removed
+ */
+int
+rtree_replace(struct rtree *tree, struct rtree_rect *old_rect, record_t old_obj,
+	      struct rtree_rect *new_rect, record_t new_obj, bool *removed);
+
+/**
  * @brief Size of memory used by tree
  * @param tree - pointer to a tree
  **/


### PR DESCRIPTION
Currently we reserve the amount of memory possibly required to perform
operations on the RTREE index in the `memtx_rtree.cc`. Let's move the
functionality into the data structure itself and use it as it's been
supposed to: calculate the real amount of new allocations required on
rtree operartions and reserve them using the new matras's API.

A new `rtree_replace` method had been introduced for that.

Closes #10831

NO_DOC=internal
NO_TEST=covered by existing tests
NO_CHANGELOG=internal