### PR TITLE
replication: fix crash on non-empty limbo exit

### DIFF
--- a/changelogs/unreleased/gh-10766-synchro-crash-on-exit.md
+++ b/changelogs/unreleased/gh-10766-synchro-crash-on-exit.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed a crash which could happen while an instance was shut down
+  having an unfinished synchronous transaction (gh-10766).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -6276,6 +6276,7 @@ box_storage_init(void)
 	gc_init(on_garbage_collection);
 	engine_init();
 	schema_init();
+	txn_limbo_init();
 	replication_init(cfg_geti_default("replication_threads", 1));
 	iproto_init(cfg_geti("iproto_threads"));
 	sql_init();
@@ -6300,12 +6301,12 @@ box_storage_free(void)
 {
 	if (!is_storage_initialized)
 		return;
+	wal_free();
 	iproto_free();
 	replication_free();
+	txn_limbo_free();
 	gc_free();
 	engine_free();
-	/* schema_free(); */
-	wal_free();
 	flightrec_free();
 	audit_log_free();
 	sql_built_in_functions_cache_free();
@@ -6344,7 +6345,6 @@ box_init(void)
 	schema_module_init();
 	if (tuple_init(lua_hash) != 0)
 		diag_raise();
-	txn_limbo_init();
 	sequence_init();
 	box_watcher_init();
 	box_raft_init();
@@ -6422,8 +6422,6 @@ box_free(void)
 {
 	/* References engines. */
 	space_cache_destroy();
-	/* References engine tuples. */
-	txn_limbo_free();
 	box_storage_free();
 	builtin_events_free();
 	security_free();

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -1168,7 +1168,7 @@ wal_write_to_disk(struct cmsg *msg)
 	 */
 
 	struct xlog *l = &writer->current_wal;
-
+	ERROR_INJECT_SLEEP_FOR(ERRINJ_WAL_DELAY_DURATION);
 	/*
 	 * Iterate over requests (transactions)
 	 */
@@ -1194,7 +1194,6 @@ wal_write_to_disk(struct cmsg *msg)
 		err_code = JOURNAL_ENTRY_ERR_IO;
 		goto done;
 	}
-
 	writer->checkpoint_wal_size += rc;
 	last_committed = stailq_last(&wal_msg->commit);
 	vclock_merge(&writer->vclock, &vclock_diff);

--- a/src/lib/core/errinj.h
+++ b/src/lib/core/errinj.h
@@ -184,6 +184,7 @@ struct errinj {
 	_(ERRINJ_WAL_BREAK_LSN, ERRINJ_INT, {.iparam = -1}) \
 	_(ERRINJ_WAL_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_WAL_DELAY_COUNTDOWN, ERRINJ_INT, {.iparam = -1}) \
+	_(ERRINJ_WAL_DELAY_DURATION, ERRINJ_DOUBLE, {.dparam = 0}) \
 	_(ERRINJ_WAL_FALLOCATE, ERRINJ_INT, {.iparam = 0}) \
 	_(ERRINJ_WAL_IO, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_WAL_IO_COUNTDOWN, ERRINJ_INT, {.iparam = -1}) \
@@ -288,6 +289,8 @@ void errinj_set_with_environment_vars(void);
 		{ crash_produce_coredump = false; illegal_instruction(); })
 #define ERROR_INJECT_INT(ID, COND, CODE) ERROR_INJECT_COND(ID, ERRINJ_INT, COND, CODE)
 #define ERROR_INJECT_DOUBLE(ID, COND, CODE) ERROR_INJECT_COND(ID, ERRINJ_DOUBLE, COND, CODE)
+#define ERROR_INJECT_SLEEP_FOR(ID) \
+	ERROR_INJECT_DOUBLE(ID, inj->dparam > 0, usleep(inj->dparam * 1000000))
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/test/replication-luatest/gh_10766_shutdown_non_empty_limbo_test.lua
+++ b/test/replication-luatest/gh_10766_shutdown_non_empty_limbo_test.lua
@@ -1,0 +1,110 @@
+local t = require('luatest')
+local treegen = require('luatest.treegen')
+local justrun = require('luatest.justrun')
+local server = require('luatest.server')
+local fiber = require('fiber')
+
+local g = t.group()
+
+g.after_each(function(cg)
+    if cg.master then
+        cg.master:drop()
+    end
+end)
+
+g.test_non_empty_limbo_shutdown_wait_mode = function()
+    t.tarantool.skip_if_not_debug()
+    local script = [[
+        box.cfg{}
+        local s = box.schema.space.create('test', {is_sync = true})
+        s:create_index('pk')
+        box.ctl.promote()
+        box.cfg{replication_synchro_quorum = 2}
+        box.error.injection.set('ERRINJ_WAL_DELAY_DURATION', 0.2);
+
+        box.begin()
+        -- Make a dummy trigger to see if it leaks or properly destroyed in
+        -- ASAN leaks sanitizer build.
+        box.on_commit(function() assert(true) end)
+        s:replace{1}
+        box.commit({wait = 'none'})
+
+        -- Give the transaction time to reach WAL thread.
+        require('fiber').sleep(0.1)
+        os.exit(0)
+    ]]
+    local dir = treegen.prepare_directory({}, {})
+    local script_name = 'gh_10766_1.lua'
+    treegen.write_file(dir, script_name, script)
+    local opts = {nojson = true}
+    local res = justrun.tarantool(dir, {}, {script_name}, opts)
+    t.assert_equals(res.exit_code, 0)
+    t.assert_equals(res.stdout, '')
+end
+
+g.test_non_empty_limbo_shutdown_applier = function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.master = server:new()
+    cg.master:start()
+    cg.master:exec(function()
+        local s = box.schema.space.create('test', {is_sync = true})
+        s:create_index('pk')
+        box.ctl.promote()
+    end)
+    --
+    -- Replica waits for a synchronous txn and shuts itself down as soon as the
+    -- txn reaches the WAL thread.
+    --
+    local replica_f = fiber.new(function()
+        local script = ([[
+            box.cfg{
+                bootstrap_strategy = 'legacy',
+                replication = "%s",
+            }
+        ]]):format(cg.master.net_box_uri)
+        script = script .. [[
+            local fiber = require('fiber')
+            local cond = fiber.cond()
+            box.space._space:on_replace(function()
+                box.on_commit(function()
+                    cond:broadcast()
+                end)
+            end)
+            while box.space.test == nil do
+                cond:wait()
+            end
+            box.space.test:on_replace(function()
+                -- Make a dummy trigger to see if it leaks or properly destroyed
+                -- in ASAN leaks sanitizer build.
+                box.on_commit(function() assert(true) end)
+            end)
+            box.error.injection.set('ERRINJ_WAL_DELAY_DURATION', 0.2);
+            while box.info.synchro.queue.len == 0 do
+                fiber.sleep(0.001)
+            end
+            -- Give the transaction time to reach WAL.
+            require('fiber').sleep(0.1)
+            os.exit(0)
+        ]]
+        local dir = treegen.prepare_directory({}, {})
+        local script_name = 'gh_10766_2.lua'
+        treegen.write_file(dir, script_name, script)
+        local opts = {nojson = true}
+        return justrun.tarantool(dir, {}, {script_name}, opts)
+    end)
+    replica_f:set_joinable(true)
+    cg.master:exec(function()
+        -- Only make the txn after the replica is registered and the quorum is
+        -- bumped. Otherwise the txn would be committed before the replica joins
+        -- and it wouldn't go to the replica's limbo.
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert_equals(box.info.synchro.quorum, 2)
+        end)
+        local s = box.space.test
+        require('fiber').create(s.replace, s, {1})
+    end)
+    local ok, res = replica_f:join()
+    t.assert(ok)
+    t.assert_equals(res.exit_code, 0)
+    t.assert_equals(res.stdout, '')
+end


### PR DESCRIPTION
Normally it couldn't happen with user-originated transactions, because they were always attached to a fiber, and the shutdown code would panic if any user fibers couldn't be cancelled and joined fast enough.

However it could always happen with applier txns (async, no fiber) and now is possible with `wait='none'` or `'submit'` commit modes.

When this would happen, at least 2 situations were possible:

- The txn was not synchro and was just ignored, deleted together with the memory allocator.

- The txn was synchro and waiting for ACKs. It was "freed" (put back into the txn cache) without completion, and its triggers would leak.

- The txn was synchro and being written to WAL right now. Then it was also freed (including its region memory removal), and the WAL thread would sometimes crash on use-after-free.

The last case was a problem.

The solution is to stop freeing the txns in the limbo. They do not belong to the limbo anyway, only live there temporarily, and in case of actual completion they would have to be "completed" (txn_complete_fail() and txn_complete_success()) anyway, not just freed.

Those orphan txns need to be ignored then. They will never complete.

Another potential problem was that the limbo was created before WAL, but destroyed after WAL. Although in this particular case it didn't matter.

Note, that freeing the txns isn't possible even after the WAL thread is stopped. Because their freeing would try to unref the txn stmt tuples, which are already destroyed. Because the engine was destroyed before the limbo, and memtx allocators destruction frees all the memtx tuple memory, regardless of their refs.

Another approach would be to init the limbo after the engine and destroy it before the engine. But the txns objects still leak. Their cache is never freed. It would need a deeper rework if ever necessary.

Part of #10766

NO_DOC=bugfix