### PR TITLE
test: fix app-luatest/gh_7000_compat_module_test.lua

### DIFF
--- a/test/app-luatest/gh_7000_compat_module_test.lua
+++ b/test/app-luatest/gh_7000_compat_module_test.lua
@@ -45,6 +45,7 @@ g.before_all(function()
         compat.add_option(option_def)
     end
     option_1_called = false
+    option_2_called = false
 end)
 g.after_all( function() reset(compat) end)
 


### PR DESCRIPTION
The commit 8af038b00d32
("cmake: shuffle testcases in luatest's tests") enabled shuffle mode in app-luatest suite. This makes a test
`app-luatest/gh_7000_compat_module_test.lua` flaky, because testcases shares a common state with compat options state
 (`option_1_called`, `option_2_called`). The patch adds
initiatilization for the state of the second option to make the test more reliable.

NO_CHANGELOG=codehealth
NO_DOC=codehealth
NO_TEST=codehealth