### PR TITLE
[backport 3.3] test: stabilize the gh_8650_add_is_sync_option test

### DIFF
--- a/test/box-luatest/gh_8650_add_is_sync_option_test.lua
+++ b/test/box-luatest/gh_8650_add_is_sync_option_test.lua
@@ -88,6 +88,9 @@ g.test_box_begin_commit_is_sync = function(cg)
     end), {{1, 'is_sync = false'}, {2, 'is_sync = true'},
            {3, 'is_sync = true'}, {4, 'is_sync = true'}})
 
+    -- Since replica has MVCC enabled, synchronous transactions won't be visible
+    -- until CONFIRM from master reaches the replica.
+    cg.replica:wait_for_vclock_of(cg.master)
     t.assert_equals(cg.replica:exec(function()
         return box.space.test:select()
     end), {{1, 'is_sync = false'}, {2, 'is_sync = true'},
@@ -162,6 +165,9 @@ g.test_box_atomic_is_sync = function(cg)
     end), {{1, 'is_sync = false'}, {2, 'is_sync = false'},
            {3, 'is_sync = true'}, {4, 'is_sync = true'}})
 
+    -- Since replica has MVCC enabled, synchronous transactions won't be visible
+    -- until CONFIRM from master reaches the replica.
+    cg.replica:wait_for_vclock_of(cg.master)
     t.assert_equals(cg.replica:exec(function()
         return box.space.test:select()
     end), {{1, 'is_sync = false'}, {2, 'is_sync = false'},


### PR DESCRIPTION
The test runs with memtx mvcc engine turned on, so a synchronous transaction committed on master may not be visible on replica immediately. It becomes visible only after a corresponding CONFIRM entry arrives on replica. Fix the test accordingly.

NO_CHANGELOG=test
NO_DOC=test

(cherry picked from commit 714052225ebd282797cb6bf92d431811c6eea5d1)