### PR TITLE
test: fix flakiness in gh_7000_compat_module_test

### DIFF
--- a/test/app-luatest/gh_7000_compat_module_test.lua
+++ b/test/app-luatest/gh_7000_compat_module_test.lua
@@ -39,13 +39,16 @@ local definitions = {
   },
 }
 
+g.before_each(function()
+    option_1_called = false
+    option_2_called = false
+end)
+
 g.before_all(function()
     reset(compat)
     for _, option_def in pairs(definitions) do
         compat.add_option(option_def)
     end
-    option_1_called = false
-    option_2_called = false
 end)
 g.after_all( function() reset(compat) end)
 
@@ -55,7 +58,7 @@ local obsolete_option_def = {
     default = 'new',
     brief = 'obsolete_option',
     obsolete = '5.0'
-  }
+}
 
 local test_options_calls = function()
     t.assert(option_1_called)
@@ -172,7 +175,6 @@ g.test_call = function()
     for _, option_def in pairs(definitions) do
         t.assert_equals(compat[option_def.name].current, OLD)
     end
-    test_options_calls()
 end
 
 g.test_serialize = function()


### PR DESCRIPTION
The original test use global variables that altered during testcase execution. Moreover, testcases were depend on global state changed previous testcases. This leads to a flaky behaviour. The patch add a hook `g.before_each` that set global options to `false` before running each testcase, remove calling `test_options_calls` in testcase `g.test_call` because this testcase does not set options to a `true`. Also, the patch fixes formatting for a table.

Follows up commit 25a979a1abd4
("test: fix app-luatest/gh_7000_compat_module_test.lua").

Follows up #7000

NO_CHANGELOG=testing
NO_DOC=testing
NO_TEST=testing