### PR TITLE
ci: use TarantoolBot for backporting

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           result-encoding: string
+          github-token: ${{ secrets.PUBLIC_BACKPORT_ACTION_TOKEN }}
           script: |
             const perms = ['none', 'read', 'write', 'admin']
             const response =
@@ -91,6 +92,7 @@ jobs:
         name: Create backport pull requests
         uses: korthout/backport-action@v3
         with:
+          github_token: ${{ secrets.PUBLIC_BACKPORT_ACTION_TOKEN }}
           branch_name: backport/${target_branch}/${pull_number}
           target_branches: ${{ steps.setup.outputs.result }}
           label_pattern: ''
@@ -105,6 +107,7 @@ jobs:
         env:
           CREATED_PULL_NUMBERS: ${{ steps.backport.outputs.created_pull_numbers }}
         with:
+          github-token: ${{ secrets.PUBLIC_BACKPORT_ACTION_TOKEN }}
           script: |
             let tags = await github.paginate(github.rest.repos.listTags.endpoint.merge({
               owner: context.repo.owner,


### PR DESCRIPTION
This patch makes backport workflow use TarantoolBot for creating backport PRs and leaving comments.

After merging tarantool#11040 with `backport/3.3` label the backport PR tarantool#11041 didn't fire CI. Turns out that workflows can't be triggered by the GitHub actions bot [^1]. This patch makes the action use TarantoolBot for creating PRs to start CI automatically.

Also, the comments on backporting are now made by TarantoolBot too just for consistency.

[^1] https://github.com/orgs/community/discussions/25786