### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-10709-luajit-fixes.md
+++ b/changelogs/unreleased/gh-10709-luajit-fixes.md
@@ -1,0 +1,16 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-10709). The following
+issues were fixed as part of this activity:
+
+* Fixed compilation of `getmetatable()` for `io` objects.
+* Fixed dirty reads from recorded `IR_NOP`.
+* Fixed fusing optimization across `table.clear()` or insertion of a new key.
+* Disabled FMA optimization on aarch64 to avoid incorrect results in floating
+  point arithmetics. Optimization may be enabled for the JIT engine via the
+  command `jit.opt.start("+fma")`.
+* Fixed machine code zone overflow for trace recording on x86/x64.
+* Fixed possible infinite loop during recording a chunk that uses upvalues.
+* Fixed recording of `bit.bor()`/`bit.bxor()`/`bit.band()` with string
+  arguments.
+* Fixed parsing of `for _ in` loop.


### PR DESCRIPTION
* Fix compilation of getmetatable() for UDTYPE_IO_FILE
* Ensure full init of IR_NOP instructions.
* cmake: run tests with Valgrind
* ci: add Valgrind testing workflow
* x86/x64: Don't fuse loads across table.clear.
* Improve last commit.
* x86/x64: Don't fuse loads across IR_NEWREF.
* Fix last commit.
* Cleanup CPU detection and tuning for old CPUs.
* Disable FMA by default. Use -Ofma or jit.opt.start("+fma") to enable.
* x86/x64: Add more red zone checks to assembler backend.
* Prevent loop in snap_usedef().
* FFI: Add missing coercion when recording 64-bit bit.*().
* Fix command-line argv handling.
* Fix predict_next() in parser (for real now).

Closes #10709

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump