### PR TITLE
config: allow failover only in the global scope

### DIFF
--- a/changelogs/unreleased/config-failover-section-in-global-scope.md
+++ b/changelogs/unreleased/config-failover-section-in-global-scope.md
@@ -1,0 +1,4 @@
+## bugfix/config
+
+* Now the `failover` section can be defined only in the global configuration
+  scope.

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1942,8 +1942,6 @@ return schema.new('instance_config', schema.record({
         items = schema.scalar({type = 'string'})
     }),
     -- Options of the failover coordinator service.
-    --
-    -- TODO: Allow only in the global scope.
     failover = schema.record({
         probe_interval = schema.scalar({
             type = 'number',
@@ -2045,6 +2043,8 @@ return schema.new('instance_config', schema.record({
         }, {
             validate = validators['failover.log'],
         }),
+    }, {
+        validate = validators['failover'],
     }),
     -- Compatibility options.
     compat = schema.record({

--- a/src/box/lua/config/validators.lua
+++ b/src/box/lua/config/validators.lua
@@ -216,6 +216,10 @@ M['database.replicaset_uuid'] = validate_uuid_str
 
 -- {{{ failover
 
+M['failover'] = function(_data, w)
+    validate_scope(w, {'global'})
+end
+
 M['failover.log'] = function(data, w)
     if data.to == 'file' and data.file == nil then
         w.error('log.file must be specified when log.to is "file"')

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -792,6 +792,20 @@ g.test_scope = function()
             replicaset = true,
             instance = false,
         },
+        {
+            name = 'failover',
+            data = {
+                failover = {
+                    stateboard = {
+                        enabled = true,
+                    },
+                },
+            },
+            global = true,
+            group = false,
+            replicaset = false,
+            instance = false,
+        },
     }
 
     for _, case in ipairs(cases) do


### PR DESCRIPTION
This patch adds validation on the scope of the `failover` section in the instance configuration. This section configures a EE-only supervised failover and it should be configured only in the global configuration scope. This patch implements this restriction.

It's already documented. Only the check hasn't been implemented yet.