### PR TITLE
netbox: fix in-progress request counter underflow during schema fetch

### DIFF
--- a/changelogs/unreleased/gh-11062-net-box-fetch-schema-restart-fix.md
+++ b/changelogs/unreleased/gh-11062-net-box-fetch-schema-restart-fix.md
@@ -1,0 +1,7 @@
+## bugfix/lua/netbox
+
+* Fixed a bug when the request counter used by a `net.box` client to implement
+  the graceful shutdown protocol could underflow while it was fetching the
+  schema from the remote end. In case of a debug build, the bug would crash
+  the client. In case of a release build, the bug would result in a timeout
+  while executing the remote server shutdown (gh-11062).

--- a/test/box-luatest/gh_11062_net_box_fetch_schema_restart_test.lua
+++ b/test/box-luatest/gh_11062_net_box_fetch_schema_restart_test.lua
@@ -1,0 +1,37 @@
+local net = require('net.box')
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_each(function(cg)
+    cg.server = server:new{
+        -- This should make the fetch schema requests issued by a net.box
+        -- client get throttled, thus opening a time window for the server
+        -- to update the schema.
+        box_cfg = {net_msg_max = 2},
+    }
+    cg.server:start()
+end)
+
+g.after_each(function(cg)
+    cg.server:drop()
+end)
+
+g.test_fetch_schema_restart = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        fiber.create(function()
+            for i = 1, 10000 do
+                local s = box.schema.space.create('test' .. i)
+                s:create_index('pk')
+            end
+        end)
+    end)
+    local conn = net.connect(cg.server.net_box_uri, {fetch_schema = true})
+    for _ = 1, 10000 do
+        t.assert(conn:ping())
+    end
+    -- Sic: do not close the connection to check that the server does not hang
+    -- on graceful shutdown.
+end


### PR DESCRIPTION
If the remote schema changes while the client is fetching it, it will restart the procedure. This effectively abandons the requests issued in the previous attempt to fetch the schema. The server will still reply to them though - when this happens, the client will subtract the counter of in-progress requests, underflowing it, because these requests were never accounted in the first place.

In case of a debug build, this bug results in a client crash due to an assertion failure. In case of a release build, the client doesn't crash, but the server will hang on shutdown because the counter is used for implementing the graceful shutdown protocol.

Let's fix this issue by accounting these abandoned requests when we restart fetching the remote schema.

Closes #11062