### PR TITLE
gc: use *.snap st_mtime to schedule after restart

### DIFF
--- a/changelogs/unreleased/gh-9820-checkpoint-interval-after-restart.md
+++ b/changelogs/unreleased/gh-9820-checkpoint-interval-after-restart.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed a bug when the timestamps of snapshots created before the server restart
+  were not taken into account with `checkpoint_interval` enabled (gh-9820).

--- a/src/box/checkpoint_schedule.h
+++ b/src/box/checkpoint_schedule.h
@@ -53,10 +53,12 @@ struct checkpoint_schedule {
  *
  * @now is the current time.
  * @interval is the configured interval between checkpoints.
+ * @time_since_checkpoint is the time since the last checkpoint
  */
 void
 checkpoint_schedule_cfg(struct checkpoint_schedule *sched,
-			double now, double interval);
+			double now, double interval,
+			double time_since_checkpoint);
 
 /**
  * Reset a checkpoint schedule.

--- a/src/box/gc.h
+++ b/src/box/gc.h
@@ -61,6 +61,8 @@ struct gc_checkpoint {
 	struct rlist in_checkpoints;
 	/** VClock of the checkpoint. */
 	struct vclock vclock;
+	/** Timestamp of the checkpoint. */
+	double timestamp;
 	/**
 	 * List of checkpoint references, linked by
 	 * gc_checkpoint_ref::in_refs.
@@ -329,7 +331,7 @@ gc_set_checkpoint_interval(double interval);
  * old checkpoints.
  */
 void
-gc_add_checkpoint(const struct vclock *vclock);
+gc_add_checkpoint(const struct vclock *vclock, double timestamp);
 
 /**
  * Make a *manual* checkpoint.

--- a/test/box-luatest/gh_9820_checkpoint_interval_after_restart_test.lua
+++ b/test/box-luatest/gh_9820_checkpoint_interval_after_restart_test.lua
@@ -1,0 +1,68 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group()
+
+g.before_all(function(g)
+    g.server = server:new({box_cfg = {
+        checkpoint_interval = 5,
+        checkpoint_count = 1e9,
+    }})
+    g.server:start()
+    g.server:exec(function()
+        local s = box.schema.space.create('test')
+        s:create_index('pk', {sequence = true})
+    end)
+end)
+
+g.before_each(function(g)
+    g.server:exec(function()
+        box.space.test:truncate()
+        box.cfg{checkpoint_interval=5}
+        t.helpers.retrying({}, function()
+            t.assert_not(box.info.gc().checkpoint_is_in_progress)
+        end)
+    end)
+end)
+
+g.test_box_checkpoint_after_restart = function(g)
+    local fiber = require('fiber')
+    local checkpoint_count = g.server:exec(function()
+        local s = box.space.test
+        -- Insert something to make sure that box.snapshot() will do something.
+        s:insert({box.NULL})
+        -- Reschedule future snapshots.
+        box.snapshot()
+        local checkpoint_count = #box.info.gc().checkpoints
+        s:insert({box.NULL})
+        return checkpoint_count
+    end)
+    g.server:stop()
+    fiber.sleep(5)
+    g.server:start()
+    g.server:exec(function(checkpoint_count)
+        local fiber = require('fiber')
+        fiber.sleep(7)
+        t.assert_gt(#box.info.gc().checkpoints, checkpoint_count)
+    end, {checkpoint_count})
+end
+
+g.test_box_checkpoint_after_reconfigure = function(g)
+    g.server:exec(function()
+        box.cfg{checkpoint_interval = 25}
+        local fiber = require('fiber')
+        local s = box.space.test
+        s:insert({box.NULL})
+        box.snapshot()
+        local checkpoint_count = #box.info.gc().checkpoints
+        s:insert({box.NULL})
+        fiber.sleep(5)
+        box.cfg{checkpoint_interval = 5}
+        fiber.sleep(7)
+        t.assert_gt(#box.info.gc().checkpoints, checkpoint_count)
+    end)
+end
+
+g.after_all(function(g)
+    g.server:drop()
+end)

--- a/test/unit/checkpoint_schedule.c
+++ b/test/unit/checkpoint_schedule.c
@@ -25,7 +25,7 @@ main()
 	double now = rand();
 
 	struct checkpoint_schedule sched;
-	checkpoint_schedule_cfg(&sched, now, 0);
+	checkpoint_schedule_cfg(&sched, now, 0, 0);
 
 	is(checkpoint_schedule_timeout(&sched, now), 0,
 	   "checkpointing disabled - timeout after configuration");
@@ -43,7 +43,7 @@ main()
 	for (int i = 0; i < intervals_len; i++) {
 		double interval = intervals[i];
 
-		checkpoint_schedule_cfg(&sched, now, interval);
+		checkpoint_schedule_cfg(&sched, now, interval, 0);
 		double t = checkpoint_schedule_timeout(&sched, now);
 		ok(t >= interval && t <= interval * 2,
 		   "checkpoint interval %.0lf - timeout after configuration",
@@ -51,7 +51,7 @@ main()
 
 		double t0;
 		for (int j = 0; j < 100; j++) {
-			checkpoint_schedule_cfg(&sched, now, interval);
+			checkpoint_schedule_cfg(&sched, now, interval, 0);
 			t0 = checkpoint_schedule_timeout(&sched, now);
 			if (fabs(t - t0) > interval / 4)
 				break;


### PR DESCRIPTION
Introduce the `timestamp` field in `gc_checkpoint` so now `gc.{c,h}` are aware of actual times of checkpoints, which is important since this subsystem is responsible for scheduling. Now, one can track the unix time of a new checkpoint with new `timestamp` argument of `gc_add_checkpoint`. This change allows us to track previous checkpoints made before the server restart and even `checkpoint_interval` value reconfiguring.

This approach was chosen instead of just scanning the `snap_dir` in `gc.c` because it was engine-independent. One may also notice that even if the actual time after the last snapshot before the restart is greater than `2 * checkpoint_interval` we won't start checkpointing immediately because that may cause high disk load in case of multiple instances. So in this case we just schedule a checkpoint at a random moment in the first `checkpoint_interval` seconds after the restart. It seems like even with this scheduling strategy a snapshot will be eventually created even during constant restarting.

Fixes #9820
NO_DOC=bugfix