### PR TITLE
ci: update path whitelist in a fuzzing workflow

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -9,10 +9,14 @@ on:
       - '**'
     paths:
       - '.github/workflows/fuzzing.yml'
+      - 'cmake/**'
       - 'src/**'
       - '!src/**.lua'
       - 'test/fuzz/**'
-      - 'test/static/corpus/**'
+      - 'third_party/c-dt/**'
+      - 'third_party/decNumber/**'
+      - 'third_party/luajit/**'
+      - 'third_party/tz/**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
 


### PR DESCRIPTION
- The path `test/static/corpus/**` is gone in the commit b24328cd57b7 ("test/static: replace seed corpus with repository").
- The paths `third_party/c-dt` and `third_party/tz` are affected by datetime fuzzing tests `datetime_parse_full_fuzzer` and `datetime_strptime_fuzzer`.
- The path `third_party/decNumber` is affected by fuzzing test `decimal_to_int64_fuzzer`.
- The path `third_party/luajit` is affected by fuzzing test `luaL_loadbuffer_fuzzer`.
- The path `cmake` contains CMake modules for third party components and also `cmake/BuildLuaTests.cmake` that builds additional fuzzing tests maintained in external repository.

NO_CHANGELOG=ci
NO_DOC=ci
NO_TEST=ci