### PR TITLE
box: fix WAL queue size accounting on errors

### DIFF
--- a/changelogs/unreleased/gh-11081-fix-wal-queue-size-accounting.md
+++ b/changelogs/unreleased/gh-11081-fix-wal-queue-size-accounting.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed the issue with hanging write operations forever triggered by heavy
+  write load and WAL writing failures on cascade rollback (gh-11081).

--- a/src/box/journal.h
+++ b/src/box/journal.h
@@ -272,9 +272,16 @@ static inline int
 journal_write_submit(struct journal_entry *entry)
 {
 	journal_queue_wait();
+	/*
+	 * We cannot account entry after write. If journal is synchronous
+	 * the journal_queue_on_complete() is called in write_async().
+	 */
 	journal_queue_on_append(entry);
-
-	return current_journal->write_async(current_journal, entry);
+	if (current_journal->write_async(current_journal, entry) != 0) {
+		journal_queue_on_complete(entry);
+		return -1;
+	}
+	return 0;
 }
 
 /** Write a single entry to the journal in synchronous way. */

--- a/test/box-luatest/gh_11081_wal_queue_size_accounting_test.lua
+++ b/test/box-luatest/gh_11081_wal_queue_size_accounting_test.lua
@@ -1,0 +1,37 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(g)
+    t.tarantool.skip_if_not_debug()
+    g.server = server:new()
+    g.server:start()
+end)
+
+g.after_all(function(g)
+    g.server:drop()
+end)
+
+-- Deliberately avoid dropping test space. It would hang.
+
+g.test_accounting_on_error = function(g)
+    g.server:exec(function()
+        local fiber = require('fiber')
+        local s = box.schema.create_space('test')
+        s:create_index('pk')
+        box.cfg{wal_queue_max_size = 100}
+        box.error.injection.set('ERRINJ_WAL_IO', true)
+        t.assert_error_covers({
+            type = 'ClientError',
+            code = box.error.WAL_IO,
+            message = 'Failed to write to disk',
+        }, s.insert, s, {1, string.rep('a', 1000)})
+        box.error.injection.set('ERRINJ_WAL_IO', false)
+        local f = fiber.new(function()
+            s:insert({1})
+        end)
+        f:set_joinable(true)
+        t.assert(f:join(10))
+    end)
+end


### PR DESCRIPTION
If cascade rollback is in progress any new write to WAL will be accounted in queue size forever. Eventually queue size will become larger then threshold forever and writing to WAL will be blocked.

Closes #11081