### PR TITLE
[backport 3.2] config: allow failover only in the global scope

### DIFF
--- a/changelogs/unreleased/config-failover-section-in-global-scope.md
+++ b/changelogs/unreleased/config-failover-section-in-global-scope.md
@@ -1,0 +1,4 @@
+## bugfix/config
+
+* Now the `failover` section can be defined only in the global configuration
+  scope.

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2263,8 +2263,6 @@ return schema.new('instance_config', schema.record({
         items = schema.scalar({type = 'string'})
     }),
     -- Options of the failover coordinator service.
-    --
-    -- TODO: Allow only in the global scope.
     failover = schema.record({
         probe_interval = schema.scalar({
             type = 'number',
@@ -2312,7 +2310,18 @@ return schema.new('instance_config', schema.record({
                 type = 'number',
                 default = 10,
             }),
-        })
+        }),
+    }, {
+        validate = function(data, w)
+            local scope = w.schema.computed.annotations.scope
+            if data == nil or scope == nil then
+                return
+            end
+            if scope ~= 'global' then
+                w.error(('The option must not be present in the %s scope')
+                        :format(scope))
+            end
+        end,
     }),
     -- Compatibility options.
     compat = schema.record({


### PR DESCRIPTION
*(This PR is a backport of #11072 to `release/3.2` to a future `3.2.2` release.)*

---

This patch adds validation on the scope of the `failover` section in the instance configuration. This section configures a EE-only supervised failover and it should be configured only in the global configuration scope. This patch implements this restriction.

(cherry picked from commit f63a8dad657a66db51dc44eb3b0318cf90dd1d89)