### PR TITLE
[backport 3.3] config: allow failover only in the global scope

### DIFF
--- a/changelogs/unreleased/config-failover-section-in-global-scope.md
+++ b/changelogs/unreleased/config-failover-section-in-global-scope.md
@@ -1,0 +1,4 @@
+## bugfix/config
+
+* Now the `failover` section can be defined only in the global configuration
+  scope.

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2381,8 +2381,6 @@ return schema.new('instance_config', schema.record({
         items = schema.scalar({type = 'string'})
     }),
     -- Options of the failover coordinator service.
-    --
-    -- TODO: Allow only in the global scope.
     failover = schema.record({
         probe_interval = schema.scalar({
             type = 'number',
@@ -2488,6 +2486,10 @@ return schema.new('instance_config', schema.record({
                 end
             end,
         }),
+    }, {
+        validate = function(_data, w)
+            validate_scope(w, {'global'})
+        end,
     }),
     -- Compatibility options.
     compat = schema.record({

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -792,6 +792,20 @@ g.test_scope = function()
             replicaset = true,
             instance = false,
         },
+        {
+            name = 'failover',
+            data = {
+                failover = {
+                    stateboard = {
+                        enabled = true,
+                    },
+                },
+            },
+            global = true,
+            group = false,
+            replicaset = false,
+            instance = false,
+        },
     }
 
     for _, case in ipairs(cases) do


### PR DESCRIPTION
*(This PR is a backport of #11072 to `release/3.3` to a future `3.3.2` release.)*

---

This patch adds validation on the scope of the `failover` section in the instance configuration. This section configures a EE-only supervised failover and it should be configured only in the global configuration scope. This patch implements this restriction.

(cherry picked from commit f63a8dad657a66db51dc44eb3b0318cf90dd1d89)