### PR TITLE
relay: fix synchro queue limitation after a local recovery

### DIFF
--- a/changelogs/unreleased/gh-11091-synchro-queue-is-unlimited-after-local-recovery.md
+++ b/changelogs/unreleased/gh-11091-synchro-queue-is-unlimited-after-local-recovery.md
@@ -1,0 +1,5 @@
+## bugfix/replication
+
+* Fixed a bug when the synchronous queue size limit was not enabled
+  after recovering from local snapshot-files, i.e. its size was not limited by
+  `replication_synchro_queue_max_size` (gh-11091).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -5711,6 +5711,9 @@ local_recovery(const struct vclock *checkpoint_vclock)
 		diag_raise();
 
 	engine_end_recovery_xc();
+	if (box_set_replication_synchro_queue_max_size() != 0)
+		diag_raise();
+
 	if (check_global_ids_integrity() != 0)
 		diag_raise();
 	box_run_on_recovery_state(RECOVERY_STATE_WAL_RECOVERED);


### PR DESCRIPTION
Fixed a bug when the synchronous queue size limit was not enabled after a local reсvery, i.e. its size was not limited by `replication_synchro_queue_max_size`.

Closes #11091

NO_DOC=bugfix