### PR TITLE
test: stabilize engine/errinj_ddl test

### DIFF
--- a/test/engine/errinj_ddl.result
+++ b/test/engine/errinj_ddl.result
@@ -38,12 +38,15 @@ for i = 101, 200 do s:replace{i, pad} end
 ch = fiber.channel(1)
 ---
 ...
+ch1 = fiber.channel(1)
+---
+...
 test_run:cmd("setopt delimiter ';'")
 ---
 - true
 ...
 _ = fiber.create(function()
-    fiber.sleep(0.01)
+    ch1:get()
     for i = 1, 100 do
         s:replace{i, box.NULL}
     end
@@ -62,6 +65,10 @@ format[2].is_nullable = false
 errinj.set("ERRINJ_CHECK_FORMAT_DELAY", true)
 ---
 - ok
+...
+ch1:put(true)
+---
+- true
 ...
 s:format(format) -- must fail
 ---
@@ -262,12 +269,15 @@ for i = 101, 200 do s:replace{i, i, pad} end
 ch = fiber.channel(1)
 ---
 ...
+ch1 = fiber.channel(1)
+---
+...
 test_run:cmd("setopt delimiter ';'")
 ---
 - true
 ...
 _ = fiber.create(function()
-    fiber.sleep(0.01)
+    ch1:get()
     for i = 1, 100 do
         s:replace{i}
     end
@@ -283,6 +293,10 @@ test_run:cmd("setopt delimiter ''");
 errinj.set("ERRINJ_BUILD_INDEX_DELAY", true)
 ---
 - ok
+...
+ch1:put(true)
+---
+- true
 ...
 s:create_index('sk', {parts = {2, 'unsigned'}}) -- must fail
 ---
@@ -318,12 +332,15 @@ for i = 101, 200 do s:replace{i, i, pad} end
 ch = fiber.channel(1)
 ---
 ...
+ch1 = fiber.channel(1)
+---
+...
 test_run:cmd("setopt delimiter ';'")
 ---
 - true
 ...
 _ = fiber.create(function()
-    fiber.sleep(0.01)
+    ch1:get()
     for i = 1, 100 do
         s:replace{i, i + 1}
     end
@@ -339,6 +356,10 @@ test_run:cmd("setopt delimiter ''");
 errinj.set("ERRINJ_BUILD_INDEX_DELAY", true)
 ---
 - ok
+...
+ch1:put(true)
+---
+- true
 ...
 ok, err = pcall(s.create_index, s, 'sk', {parts = {2, 'unsigned'}})
 ---

--- a/test/engine/errinj_ddl.test.lua
+++ b/test/engine/errinj_ddl.test.lua
@@ -17,9 +17,10 @@ pad = string.rep('x', 16)
 for i = 101, 200 do s:replace{i, pad} end
 
 ch = fiber.channel(1)
+ch1 = fiber.channel(1)
 test_run:cmd("setopt delimiter ';'")
 _ = fiber.create(function()
-    fiber.sleep(0.01)
+    ch1:get()
     for i = 1, 100 do
         s:replace{i, box.NULL}
     end
@@ -30,6 +31,7 @@ test_run:cmd("setopt delimiter ''");
 
 format[2].is_nullable = false
 errinj.set("ERRINJ_CHECK_FORMAT_DELAY", true)
+ch1:put(true)
 s:format(format) -- must fail
 ch:get()
 
@@ -116,9 +118,10 @@ pad = string.rep('x', 16)
 for i = 101, 200 do s:replace{i, i, pad} end
 
 ch = fiber.channel(1)
+ch1 = fiber.channel(1)
 test_run:cmd("setopt delimiter ';'")
 _ = fiber.create(function()
-    fiber.sleep(0.01)
+    ch1:get()
     for i = 1, 100 do
         s:replace{i}
     end
@@ -128,6 +131,7 @@ end);
 test_run:cmd("setopt delimiter ''");
 
 errinj.set("ERRINJ_BUILD_INDEX_DELAY", true)
+ch1:put(true)
 s:create_index('sk', {parts = {2, 'unsigned'}}) -- must fail
 
 ch:get()
@@ -146,9 +150,10 @@ pad = string.rep('x', 16)
 for i = 101, 200 do s:replace{i, i, pad} end
 
 ch = fiber.channel(1)
+ch1 = fiber.channel(1)
 test_run:cmd("setopt delimiter ';'")
 _ = fiber.create(function()
-    fiber.sleep(0.01)
+    ch1:get()
     for i = 1, 100 do
         s:replace{i, i + 1}
     end
@@ -158,6 +163,7 @@ end);
 test_run:cmd("setopt delimiter ''");
 
 errinj.set("ERRINJ_BUILD_INDEX_DELAY", true)
+ch1:put(true)
 ok, err = pcall(s.create_index, s, 'sk', {parts = {2, 'unsigned'}})
 assert(not ok)
 assert(tostring(err):find('Duplicate key') ~= nil)

--- a/test/engine/suite.ini
+++ b/test/engine/suite.ini
@@ -17,9 +17,6 @@ fragile = {
         "conflict.test.lua": {
             "issues": [ "gh-5516" ]
         },
-        "errinj_ddl.test.lua": {
-            "issues": [ "gh-5585" ]
-        },
         "replica_join.test.lua": {
             "issues": [ "gh-5504" ]
         }


### PR DESCRIPTION
The test relied on fibers finishing execution in particular order and setting/unsetting error injections in time. Of course it was flaky. In all the 3 flaky cases the fiber unsetting the injection could be executed before the fiber which sets the injection, and the rest of the test would run with that injection being set.

Fix this properly and remove the test from the fragile list.

Closes tarantool/tarantool-qa#20

NO_CHANGELOG=flaky test
NO_DOC=flaky test