### PR TITLE
txn: do not rollback transaction statements on timeout

### DIFF
--- a/changelogs/unreleased/gh-11088-vy-tx-crash-on-timeout-fix.md
+++ b/changelogs/unreleased/gh-11088-vy-tx-crash-on-timeout-fix.md
@@ -1,0 +1,4 @@
+## bugfix/vinyl
+
+* Fixed a bug when aborting a transaction by timeout while it was executing
+  a statement could trigger a crash (gh-11088).

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -1639,12 +1639,11 @@ txn_on_stop(struct trigger *trigger, void *event)
 /**
  * Transaction rollback timer callback.
  *
- * If there are `on_rollback' triggers, the transaction can not be rolled back
- * completely here, because this callback is invoked outside of the transaction,
- * however triggers must be executed in the fiber with the active transaction.
- * Thus, the transaction is marked as aborted here, and rolled back at commit.
  * As opposed to abort-by-yield, it is OK to postpone the rollback, because in
  * memtx the transaction can be aborted by timeout only when MVCC is on.
+ * Moreover, rolling back the transaction here would actually be harmful for
+ * vinyl because it could delete the statement executed at this very moment
+ * if it yielded for too long while reading disk.
  */
 static void
 txn_on_timeout(ev_loop *loop, ev_timer *watcher, int revents)
@@ -1652,10 +1651,6 @@ txn_on_timeout(ev_loop *loop, ev_timer *watcher, int revents)
 	(void) loop;
 	(void) revents;
 	struct txn *txn = (struct txn *)watcher->data;
-	if (!txn_has_flag(txn, TXN_HAS_TRIGGERS) ||
-	    rlist_empty(&txn->on_rollback)) {
-		txn_rollback_to_svp(txn, NULL, false);
-	}
 	txn->status = TXN_ABORTED;
 	txn_set_flags(txn, TXN_IS_ABORTED_BY_TIMEOUT);
 }

--- a/test/vinyl-luatest/gh_11088_tx_abort_on_timeout_test.lua
+++ b/test/vinyl-luatest/gh_11088_tx_abort_on_timeout_test.lua
@@ -1,0 +1,49 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        box.error.injection.set('ERRINJ_VY_READ_PAGE_DELAY', false)
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+g.test_tx_abort_on_timeout = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        local timeout = 0.1
+
+        local s = box.schema.space.create('test', {engine = 'vinyl'})
+        s:create_index('pk')
+        s:replace({1})
+        box.snapshot()
+
+        box.error.injection.set('ERRINJ_VY_READ_PAGE_DELAY', true)
+        fiber.new(function()
+            fiber.sleep(timeout * 2)
+            box.error.injection.set('ERRINJ_VY_READ_PAGE_DELAY', false)
+        end)
+
+        box.begin({timeout = timeout})
+        s:update({1}, {{'!', 2, 20}})
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'TRANSACTION_TIMEOUT',
+        }, box.commit)
+        t.assert_equals(s:select(), {{1}})
+    end)
+end


### PR DESCRIPTION
The transaction timeout may be triggered by vinyl taking too long to read disk while executing a statement. If we roll back the transaction in this case, the statement will be deleted, resulting in a crash when we finally try to commit the statement. Actually, in contrast to the case when a transaction is aborted by a fiber yield, there's no need to rollback the transaction on timeout  We don't rollback the transaction on conflict so let's not do it on timeout, either.

Closes #11088