### PR TITLE
[backport 2.11] test: stabilize replication/sync test

### DIFF
--- a/test/replication/suite.ini
+++ b/test/replication/suite.ini
@@ -18,9 +18,6 @@ fragile = {
         "skip_conflict_row.test.lua": {
             "issues": [ "gh-4958" ]
         },
-        "sync.test.lua": {
-            "issues": [ "gh-3835" ]
-        },
         "transaction.test.lua": {
             "issues": [ "gh-4312", "gh-5331" ]
         },

--- a/test/replication/sync.result
+++ b/test/replication/sync.result
@@ -249,32 +249,9 @@ test_run:cmd("switch default")
 ---
 - true
 ...
-box.error.injection.set('ERRINJ_RELAY_TIMEOUT', 0)
+box.error.injection.set('ERRINJ_RELAY_EXIT_DELAY', 5)
 ---
 - ok
-...
-box.error.injection.set('ERRINJ_WAL_DELAY', true)
----
-- ok
-...
-test_run:cmd("setopt delimiter ';'")
----
-- true
-...
-_ = fiber.create(function()
-    box.space.test:replace{123456789}
-end);
----
-...
-_ = fiber.create(function()
-    fiber.sleep(0.1)
-    box.error.injection.set('ERRINJ_WAL_DELAY', false)
-end);
----
-...
-test_run:cmd("setopt delimiter ''");
----
-- true
 ...
 test_run:cmd("switch replica")
 ---
@@ -309,6 +286,10 @@ test_run:wait_log("replica", "ER_CFG.*", nil, 200)
 test_run:cmd("switch default")
 ---
 - true
+...
+box.error.injection.set('ERRINJ_RELAY_EXIT_DELAY', 0)
+---
+- ok
 ...
 test_run:cmd("stop server replica")
 ---

--- a/test/replication/sync.test.lua
+++ b/test/replication/sync.test.lua
@@ -135,17 +135,7 @@ box.cfg{replication_sync_lag = 1}
 box.cfg{replication_sync_timeout = 10}
 
 test_run:cmd("switch default")
-box.error.injection.set('ERRINJ_RELAY_TIMEOUT', 0)
-box.error.injection.set('ERRINJ_WAL_DELAY', true)
-test_run:cmd("setopt delimiter ';'")
-_ = fiber.create(function()
-    box.space.test:replace{123456789}
-end);
-_ = fiber.create(function()
-    fiber.sleep(0.1)
-    box.error.injection.set('ERRINJ_WAL_DELAY', false)
-end);
-test_run:cmd("setopt delimiter ''");
+box.error.injection.set('ERRINJ_RELAY_EXIT_DELAY', 5)
 test_run:cmd("switch replica")
 
 replication = box.cfg.replication
@@ -157,6 +147,7 @@ box.info.replication[1].upstream.status -- follow
 test_run:wait_log("replica", "ER_CFG.*", nil, 200)
 
 test_run:cmd("switch default")
+box.error.injection.set('ERRINJ_RELAY_EXIT_DELAY', 0)
 test_run:cmd("stop server replica")
 
 -- gh-3830: Sync fails if there's a gap at the end of the master's WAL.


### PR DESCRIPTION
When replication is restarted with the same replica, there's a chance that an old relay may be not stopped yet when a new applier connects. In this case the applier should get ER_CFG error and it should continue trying to sync with master.

The test stopped the relay from exiting with slowing sending of the rows. This is not reliable and sometimes relay successfully exited before replica tried to connect, which leads to the absence of the ER_CFG error. Let's block relay exit with ERRINJ_RELAY_EXIT_DELAY instead, which is much more reliable.

Closes tarantool/tarantool-qa#6
Closes #4129

NO_CHANGELOG=flaky test
NO_DOC=flaky test

(cherry picked from commit e0c6126742e1ba9016f8dcb5b749210f6020e9a7)