### PR TITLE
perf: fix a clang warning for BPS tree perftest

### DIFF
--- a/perf/bps_tree.cc
+++ b/perf/bps_tree.cc
@@ -138,7 +138,7 @@
  */
 template<int EXTENT_SIZE>
 struct DummyAllocator {
-	std::unique_ptr<char[]> m_buf;
+	char *m_buf;
 	size_t m_buf_size;
 	size_t m_pos = 0;
 	struct matras_allocator matras_allocator;
@@ -152,12 +152,13 @@ struct DummyAllocator {
 		/* The calculated size is incorrect for small trees. */
 		if (m_buf_size < EXTENT_SIZE * 10)
 			m_buf_size = EXTENT_SIZE * 10;
-		m_buf = std::unique_ptr<char[]>(new char[m_buf_size]);
+		m_buf = new char[m_buf_size];
 	}
 
 	~DummyAllocator()
 	{
 		matras_allocator_destroy(&matras_allocator);
+		delete[] m_buf;
 	}
 
 	void


### PR DESCRIPTION
Clang warned about the getting the offset of a field in a structure
with a non-standard layout because of a `std::unique_ptr` field in
the `DummyAllocator` class. Let's simply replace it with a regular
pointer.

Closes #11122

NO_DOC=minor
NO_TEST=minor
NO_CHANGELOG=minor