### PR TITLE
[backport/release/3.2] luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-11055-luajit-fixes.md
+++ b/changelogs/unreleased/gh-11055-luajit-fixes.md
@@ -1,0 +1,11 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-11055). The following
+issues were fixed as part of this activity:
+
+* Fixed compiler warning in `setfenv()` / `getfenv()` with negative levels as
+  the argument.
+* Fixed register allocation for stores into sunk values (gh-10746).
+* Fixed a crash when using a Lua C function as a vmevent handler for trace
+  events.
+* Fixed the compilation of `...` in `select()`.


### PR DESCRIPTION
* test: define UNUSED macro only once
* Reject negative getfenv()/setfenv() levels to prevent compiler warning.
* Fix detection of inconsistent renames due to sunk values.
* Handle all stack layouts in (delayed) TRACE vmevent.
* Fix recording of BC_VARG.

Closes tarantool/tarantool#10746
Needed for tarantool/aeon#282
Part of tarantool/tarantool#11055

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump