### PR TITLE
box: implementation of rtree pagination

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -4118,7 +4118,7 @@ box_iterator_position_pack(const char *pos, const char *pos_end,
 int
 box_iterator_position_unpack(const char *packed_pos,
 			     const char *packed_pos_end,
-			     struct key_def *cmp_def, const char *key,
+			     struct index_def *index_def, const char *key,
 			     uint32_t key_part_count, int iterator,
 			     const char **pos, const char **pos_end)
 {
@@ -4136,7 +4136,7 @@ box_iterator_position_unpack(const char *packed_pos,
 		uint32_t pos_part_count = mp_decode_array(pos);
 		enum iterator_type type = (enum iterator_type)iterator;
 		if (iterator_position_validate(*pos, pos_part_count, key,
-					       key_part_count, cmp_def,
+					       key_part_count, index_def,
 					       type) != 0)
 			return -1;
 	} else {
@@ -4181,7 +4181,7 @@ box_select(uint32_t space_id, uint32_t index_id,
 		return -1;
 	const char *pos, *pos_end;
 	if (box_iterator_position_unpack(*packed_pos, *packed_pos_end,
-					 index->def->cmp_def, key, part_count,
+					 index->def, key, part_count,
 					 type, &pos, &pos_end) != 0)
 		return -1;
 

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -54,6 +54,7 @@ struct auth_request;
 struct space;
 struct vclock;
 struct key_def;
+struct index_def;
 struct ballot;
 
 /**
@@ -479,7 +480,7 @@ box_iterator_position_pack(const char *pos, const char *pos_end,
 int
 box_iterator_position_unpack(const char *packed_pos,
 			     const char *packed_pos_end,
-			     struct key_def *cmp_def, const char *key,
+			     struct index_def *index_def, const char *key,
 			     uint32_t key_part_count, int iterator,
 			     const char **pos, const char **pos_end);
 

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -666,7 +666,7 @@ box_index_iterator_with_offset(uint32_t space_id, uint32_t index_id, int type,
 				runtime_memory_free(pos_buf, pos_buf_size);
 		});
 	if (box_iterator_position_unpack(packed_pos, packed_pos_end,
-					 index->def->cmp_def, key, part_count,
+					 index->def, key, part_count,
 					 type, &pos, &pos_end) != 0)
 		return NULL;
 	if (pos != NULL) {
@@ -879,22 +879,25 @@ fail:
 int
 iterator_position_validate(const char *pos, uint32_t pos_part_count,
 			   const char *key, uint32_t key_part_count,
-			   struct key_def *cmp_def, enum iterator_type type)
+			   struct index_def *index_def, enum iterator_type type)
 {
 	int cmp;
+	struct key_def *cmp_def = index_def->cmp_def;
 	/* Position must be compatible with the index. */
 	if (cmp_def->part_count != pos_part_count)
 		goto fail;
 	const char *pos_end;
 	if (key_validate_parts(cmp_def, pos, pos_part_count, true, &pos_end) != 0)
 		goto fail;
-	/* Position msut meet the search criteria. */
-	cmp = key_compare(pos, pos_part_count, HINT_NONE,
-			  key, key_part_count, HINT_NONE, cmp_def);
-	if (iterator_direction(type) * cmp < 0)
-		goto fail;
-	if ((type == ITER_EQ || type == ITER_REQ) && cmp != 0)
-		goto fail;
+	if (index_def->type == TREE) {
+		/* Position must meet the search criteria. */
+		cmp = key_compare(pos, pos_part_count, HINT_NONE,
+				  key, key_part_count, HINT_NONE, cmp_def);
+		if (iterator_direction(type) * cmp < 0)
+			goto fail;
+		if ((type == ITER_EQ || type == ITER_REQ) && cmp != 0)
+			goto fail;
+	}
 	return 0;
 fail:
 	diag_set(ClientError, ER_ITERATOR_POSITION);

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -450,7 +450,8 @@ iterator_position_unpack(const char *packed_pos, const char *packed_pos_end,
 int
 iterator_position_validate(const char *pos, uint32_t pos_part_count,
 			   const char *key, uint32_t key_part_count,
-			   struct key_def *cmp_def, enum iterator_type type);
+			   struct index_def *index_def,
+			   enum iterator_type type);
 
 /**
  * Get position of iterator - extracted cmp_def of last fetched

--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -66,6 +66,18 @@ enum memtx_rtree_reserve_extents_num {
 
 /* {{{ Utilities. *************************************************/
 
+/** Callback for sorting neighbors with same distance. */
+int tie_cmp_cb(const struct rtree_neighbor *a,
+	       const struct rtree_neighbor *b)
+{
+	struct index *index = (struct index *)a->cmp_ctx;
+	return tuple_compare((struct tuple *)a->child,
+                    	     HINT_NONE,
+                    	     (struct tuple *)b->child,
+                    	     HINT_NONE,
+                    	     index->def->pk_def);
+}
+
 static inline int
 mp_decode_num(const char **data, uint32_t fieldno, double *ret)
 {
@@ -381,6 +393,7 @@ memtx_rtree_index_create_iterator(struct index *base, enum iterator_type type,
 	it->base.next = memtx_iterator_next;
 	it->base.position = generic_iterator_position;
 	it->base.free = index_rtree_iterator_free;
+	it->impl.tie_cmp = tie_cmp_cb;
 	rtree_iterator_init(&it->impl);
 	/*
 	 * We don't care if rtree_search() does or does not find anything

--- a/src/lib/salad/rtree.c
+++ b/src/lib/salad/rtree.c
@@ -80,10 +80,11 @@ neighbor_cmp(const struct rtree_neighbor *a, const struct rtree_neighbor *b)
 {
 	return a->distance < b->distance ? -1 :
 	       a->distance > b->distance ? 1 :
-	       a->level < b->level ? -1 :
-	       a->level > b->level ? 1 :
-	       a < b ? -1 : a > b ? 1 : 0;
-	return 0;
+	       a->level > b->level ? -1 :
+	       a->level < b->level ? 1 :
+	       a->level > 0 ? (a < b ? -1 : a > b ? 1 : 0) :
+	       a->tie_cmp != NULL ? a->tie_cmp(a, b) :
+	       (a < b ? -1 : a > b ? 1 : 0);
 }
 
 rb_gen(, rtnt_, rtnt_t, struct rtree_neighbor, link, neighbor_cmp);
@@ -840,6 +841,11 @@ rtree_iterator_new_neighbor(struct rtree_iterator *itr,
 	n->child = child;
 	n->distance = distance;
 	n->level = level;
+	if (itr->tie_cmp != NULL) {
+		n->cmp_ctx = itr->cmp_ctx;
+	} else {
+		n->cmp_ctx = NULL;
+	}
 	return n;
 }
 

--- a/src/lib/salad/rtree.h
+++ b/src/lib/salad/rtree.h
@@ -62,6 +62,9 @@ struct rtree_neighbor {
 	sq_coord_t distance;
 	/* Is used for sorting neighbors with same distence */
 	int (*tie_cmp)(const struct rtree_neighbor *a, const struct rtree_neighbor *b);
+	/* Is uesd for neighbor pagination */
+	void *cmp_ctx;
+	sq_coord_t distance_max;
 };
 
 typedef rb_tree(struct rtree_neighbor) rtnt_t;
@@ -183,6 +186,11 @@ struct rtree_iterator
 	/* Is used for sorting neighbors with same distence */
 	int (*tie_cmp)(const struct rtree_neighbor *a, const struct rtree_neighbor *b);
 
+	/* Is used for neighbor pagination */
+	void *cmp_ctx;
+	sq_coord_t pos_distance;
+	const char *pr_key_pos;
+
 	/* Comparators for comparison rectagnle of the iterator with
 	 * rectangles of tree nodes. If the comparator returns true,
 	 * the node is accepted; if false - skipped.
@@ -278,6 +286,18 @@ rtree_search(const struct rtree *tree, const struct rtree_rect *rect,
  */
 void
 rtree_insert(struct rtree *tree, struct rtree_rect *rect, record_t obj);
+
+/**
+ * @brief Skip neighbors for neighbor pagination
+ * @param itr - pointer to iterator (must be initialized earlier),
+ *  iterator itr should be used for accessing found record
+ * @param pos_distance min distance of last fetched rect
+ * @param is_upper_distance flag
+ */
+record_t *
+rtree_skip_neighbors_equal_distance(struct rtree_iterator *itr,
+				    sq_coord_t pos_distance,
+				    bool *is_upper_distance);
 
 /**
  * @brief Remove the record from a tree

--- a/src/lib/salad/rtree.h
+++ b/src/lib/salad/rtree.h
@@ -60,6 +60,8 @@ struct rtree_neighbor {
 	void *child;
 	int level;
 	sq_coord_t distance;
+	/* Is used for sorting neighbors with same distence */
+	int (*tie_cmp)(const struct rtree_neighbor *a, const struct rtree_neighbor *b);
 };
 
 typedef rb_tree(struct rtree_neighbor) rtnt_t;
@@ -177,6 +179,9 @@ struct rtree_iterator
 	struct rtree_neighbor_page *page_list;
 	/* Position of ready-to-use list entry in allocated page */
 	unsigned page_pos;
+
+	/* Is used for sorting neighbors with same distence */
+	int (*tie_cmp)(const struct rtree_neighbor *a, const struct rtree_neighbor *b);
 
 	/* Comparators for comparison rectagnle of the iterator with
 	 * rectangles of tree nodes. If the comparator returns true,

--- a/test/box-luatest/rtree_pagination_test.lua
+++ b/test/box-luatest/rtree_pagination_test.lua
@@ -1,0 +1,522 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group('rtree-neighbor-pagination')
+
+g.before_all(function()
+    g.server = server:new()
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_rtree_pagination_neighbor = function()
+    g.server:exec(function()
+
+        local s = box.schema.space.create('test_rect')
+        s:format({ { type = 'number', name = 'id' },
+            { type = 'array', name = 'content' } })
+        local hash_index = s:create_index('primary',
+            { type = 'tree', parts = {'id'} })
+        local rtree_index = s:create_index('rtree_ind',
+            { type = 'rtree', unique = false,
+             parts = {'content'} })
+
+        for i = 1, 10 do
+            for j = 1, 10 do
+                s:insert{i * 10 + j,
+                    {i, j, i + 1, j + 1}}
+            end
+        end
+
+        local tuples
+        local pos
+        hash_index:select{0};
+
+        tuples, pos = rtree_index:select({1, 1},
+            {iterator = 'neighbor',
+            fetch_pos=true, limit=4})
+
+        t.assert_equals(tuples[1],
+            {11, {1, 1, 2, 2}})
+
+        t.assert_equals(tuples,
+            {{11, {1, 1, 2, 2}}, {12, {1, 2, 2, 3}},
+             {21, {2, 1, 3, 2}}, {22, {2, 2, 3, 3}}})
+
+        tuples, pos = rtree_index:select({1, 1},
+            {iterator = 'neighbor', fetch_pos=true,
+            limit=3, after=pos})
+
+        t.assert_equals(tuples,
+            {{13, {1, 3, 2, 4}}, {31, {3, 1, 4, 2}},
+             {23, {2, 3, 3, 4}}})
+
+        tuples = rtree_index:select({1, 1},
+            {iterator = 'neighbor',
+            fetch_pos=false, limit=2, after=pos})
+        t.assert_equals(tuples,
+            {{32, {3, 2, 4, 3}}, {33, {3, 3, 4, 4}}})
+    end)
+end
+
+g.test_rtree_pagination_neighbor_points = function()
+    g.server:exec(function()
+
+        local s = box.schema.space.create('test_points')
+        s:format({ { type = 'number', name = 'id' },
+            { type = 'array', name = 'content' } })
+        local hash_index = s:create_index('primary',
+            { type = 'tree', parts = {'id'} })
+        local rtree_index = s:create_index('rtree_ind',
+            { type = 'rtree', unique = false,
+             parts = {'content'} })
+
+        for i = 2, 6, 2 do
+            for j = 1, 10 do
+                s:insert{i * 10 + j, {i, j + 3}}
+            end
+        end
+
+        local tuples
+        local pos
+        hash_index:select{0};
+
+        tuples, pos = rtree_index:select({1, 1},
+            {iterator = 'neighbor',
+            fetch_pos=true, limit=4})
+
+        t.assert_equals(tuples,
+            {{21,{2,4}}, {22,{2,5}},
+             {41,{4,4}}, {42,{4,5}}})
+
+        tuples, pos = rtree_index:select({1, 1},
+            {iterator = 'neighbor',
+            fetch_pos=true, limit=4, after=pos})
+
+        t.assert_equals(tuples,
+            {{23,{2,6}}, {43,{4,6}},
+             {61,{6,4}}, {24,{2,7}}})
+
+        tuples, pos = rtree_index:select({1, 1},
+            {iterator = 'neighbor',
+            fetch_pos=false, limit=4, after=pos})
+        t.assert_equals(tuples,
+            {{62,{6,5}}, {44,{4,7}},
+             {25,{2,8}}, {63,{6,6}}})
+
+        tuples, pos = rtree_index:select({1, 1},
+            {iterator = 'neighbor',
+            fetch_pos=true, limit=0, after=pos})
+        t.assert_equals(tuples, {})
+        t.assert_equals(pos, nil)
+    end)
+end
+
+g.test_rtree_pagination_point_in_rect = function()
+    g.server:exec(function()
+
+        local s = box.schema.space.create(
+            'point_in_rect')
+        s:format({ { type = 'number', name = 'id' },
+            { type = 'array', name = 'content' } })
+        local hash_index = s:create_index('primary',
+            { type = 'tree', parts = {'id'} })
+        local rtree_index = s:create_index('rtree_ind',
+            { type = 'rtree', unique = false,
+            parts = {'content'} })
+
+        for i = 2, 6, 2 do
+            for j = 1, 10 do
+                s:insert{i * 10 + j,
+                    {i, j + 3, -i, -j * 2}}
+            end
+        end
+
+        local tuples
+        local pos
+        hash_index:select{0};
+
+        tuples, pos = rtree_index:select({1, 0},
+            {iterator = 'neighbor',
+            fetch_pos=true, limit=4})
+
+        t.assert_equals(tuples,
+            {{21,{2,4,-2,-2}},{22,{2,5,-2,-4}},
+             {23,{2,6,-2,-6}},{24,{2,7,-2,-8}}})
+
+        tuples, pos = rtree_index:select({1, 0},
+            {iterator = 'neighbor',
+            fetch_pos=true, limit=4, after=pos})
+
+        t.assert_equals(tuples,
+            {{25,{2,8,-2,-10}},{26,{2,9,-2,-12}},
+             {27,{2,10,-2,-14}},{28,{2,11,-2,-16}}})
+
+        tuples, pos = rtree_index:select({1, 0},
+            {iterator = 'neighbor',
+            fetch_pos=false, limit=4, after=pos})
+
+        t.assert_equals(tuples,
+            {{29,{2,12,-2,-18}},{30,{2,13,-2,-20}},
+             {41,{4,4,-4,-2}},{42,{4,5,-4,-4}}})
+
+        tuples, pos = rtree_index:select({1, 0},
+            {iterator = 'neighbor',
+            fetch_pos=true, limit=0, after=pos})
+
+        t.assert_equals(tuples, {})
+        t.assert_equals(pos, nil)
+    end)
+end
+
+g.test_rtree_pagination_neighbor_3d_space = function()
+    g.server:exec(function()
+
+        local s = box.schema.space.create(
+            'test_3d_space')
+
+        s:format({ { type = 'number', name = 'id' },
+            { type = 'array', name = 'content' } })
+        local hash_index = s:create_index('primary',
+            { type = 'tree', parts = {'id'} })
+        local rtree_index = s:create_index('spatial',
+            { type = 'rtree', unique = false,
+                dimension = 3, parts = {'content'}})
+
+        for k = 5, 10, 2 do
+            for i = 2, 8, 2 do
+                for j = 1, 10 do
+                    s:insert{i * 10 + j + k * 100,
+                        {i, j, k, j + 1, i + j, -k * 2}}
+                end
+            end
+        end
+
+        local tuples
+        local pos
+        hash_index:select{0};
+
+        tuples, pos = rtree_index:select({1, 1, 0},
+            {iterator = 'neighbor', fetch_pos=true,
+             limit=5})
+
+        t.assert_equals(tuples,
+            {{521,{2,1,5,2,3,-10}},{541,{4,1,5,2,5,-10}},
+             {561,{6,1,5,2,7,-10}},{581,{8,1,5,2,9,-10}},
+             {721,{2,1,7,2,3,-14}}})
+
+        tuples, pos = rtree_index:select({1, 1, 0},
+            {iterator = 'neighbor', fetch_pos=true,
+             limit=4, after=pos})
+
+        t.assert_equals(tuples,
+            {{741,{4,1,7,2,5,-14}},{761,{6,1,7,2,7,-14}},
+             {781,{8,1,7,2,9,-14}},{921,{2,1,9,2,3,-18}}})
+
+        tuples, pos = rtree_index:select({1, 1, 0},
+            {iterator = 'neighbor', fetch_pos=false,
+             limit=4, after=pos})
+
+        t.assert_equals(tuples,
+            {{941,{4,1,9,2,5,-18}},{961,{6,1,9,2,7,-18}},
+             {981,{8,1,9,2,9,-18}},{522,{2,2,5,3,4,-10}}})
+
+        tuples, pos = rtree_index:select({1, 1, 0},
+            {iterator = 'neighbor', fetch_pos=true,
+             limit=0, after=pos})
+
+        t.assert_equals(tuples, {})
+        t.assert_equals(pos, nil)
+    end)
+end
+
+g.test_rtree_pagination_neighbor_4d_space = function()
+    g.server:exec(function()
+
+        local s = box.schema.space.create(
+            'test_4d_space')
+
+        s:format({ { type = 'number', name = 'id' },
+            { type = 'array', name = 'content' } })
+        local hash_index = s:create_index('primary',
+            { type = 'tree', parts = {'id'} })
+        local rtree_index = s:create_index('spatial',
+            { type = 'rtree', unique = false,
+                dimension = 4, parts = {'content'}})
+
+        for n = 1, 5 do
+            for k = 5, 10, 2 do
+                for i = 2, 8, 2 do
+                    for j = 1, 10 do
+                        s:insert{i*10 + j + k*100 + n*1000,
+                        {i, j, k, n, j + 1, i + j,
+                         -k * 2, n + 1}}
+                    end
+                end
+            end
+        end
+        local tuples
+        local pos
+        hash_index:select{0};
+
+        tuples, pos = rtree_index:select({0, 0, 0, 0},
+            {iterator = 'neighbor', fetch_pos=true, limit=4})
+
+        t.assert_equals(tuples,
+          {{1521,{2,1,5,1,2,3,-10,2}},{1541,{4,1,5,1,2,5,-10,2}},
+           {1561,{6,1,5,1,2,7,-10,2}},{1581,{8,1,5,1,2,9,-10,2}}})
+
+        tuples, pos = rtree_index:select({0, 0, 0, 0},
+           {iterator = 'neighbor', fetch_pos=true,
+            limit=4, after=pos})
+
+        t.assert_equals(tuples,
+          {{1721,{2,1,7,1,2,3,-14,2}},{1741,{4,1,7,1,2,5,-14,2}},
+           {1761,{6,1,7,1,2,7,-14,2}},{1781,{8,1,7,1,2,9,-14,2}}})
+
+        tuples, pos = rtree_index:select({0, 0, 0, 0},
+           {iterator = 'neighbor', fetch_pos=true,
+            limit=4, after=pos})
+
+        t.assert_equals(tuples,
+           {{1921,{2,1,9,1,2,3,-18,2}},{1941,{4,1,9,1,2,5,-18,2}},
+            {1961,{6,1,9,1,2,7,-18,2}},{1981,{8,1,9,1,2,9,-18,2}}})
+
+        tuples = rtree_index:select({0, 0, 0, 0},
+           {iterator = 'neighbor', fetch_pos=false,
+            limit=1, after=pos})
+
+        t.assert_equals(tuples, {{1522,{2,2,5,1,3,4,-10,2}}})
+    end)
+end
+
+g.test_rtree_pagination_equal_distance = function()
+    g.server:exec(function()
+
+        local s = box.schema.space.create('equal_distance')
+        s:format({ { type = 'number', name = 'id' },
+            { type = 'array', name = 'content' } })
+        local hash_index = s:create_index('primary',
+            { type = 'tree', parts = {'id'} })
+        local rtree_index = s:create_index('rtree_ind',
+            { type = 'rtree', unique = false,
+             parts = {'content'} })
+
+        local tuples = {{21,{50,0}}, {20,{43.301,25}},
+           {17,{25,43.301}}, {16,{0,50}}, {4,{-25,43.301}},
+           {7,{-43.301,25}}, {13,{-50, 0}}, {0,{-43.301,-25}},
+           {25,{-25,-43.301}}, {41,{0,-50}}, {40,{25,-43.301}},
+           {39,{43.301,-25}}, {1,{35.355,35.355}},
+           {6,{11.5,48.659}}, {5,{48.659,-11.5}},
+           {2, {-35.355,35.355}}, {3, {35.355,-35.355}}}
+        for i = 1, #tuples do
+            local first_value, second_tuple = unpack(tuples[i])
+            s:insert({first_value, second_tuple})
+        end
+
+        local pos
+        hash_index:select{0}
+
+        tuples, pos = rtree_index:select({0, 0},
+           {iterator = 'neighbor',
+           fetch_pos=true, limit=5})
+
+        t.assert_equals(tuples,
+           {{5,{48.659,-11.5}},{6,{11.5,48.659}},
+            {1,{35.355,35.355}},{2,{-35.355,35.355}},
+            {3,{35.355,-35.355}}})
+
+        tuples, pos = rtree_index:select({0, 0},
+           {iterator = 'neighbor',
+           fetch_pos=true, limit=4, after=pos})
+
+        t.assert_equals(tuples,
+           {{0,{-43.301,-25}},{4,{-25,43.301}},
+            {7,{-43.301,25}},{17,{25,43.301}}})
+
+        tuples, pos = rtree_index:select({0, 0},
+            {iterator = 'neighbor',
+            fetch_pos=true, limit=4, after=pos})
+
+        t.assert_equals(tuples,
+            {{20,{43.301,25}},{25,{-25,-43.301}},
+             {39,{43.301,-25}},{40,{25,-43.301}}})
+
+        tuples, pos = rtree_index:select({0, 0},
+            {iterator = 'neighbor',
+            fetch_pos=false, limit=5, after=pos})
+        t.assert_equals(tuples,
+            {{13,{-50,0}},{16,{0,50}},
+             {21,{50,0}},{41,{0,-50}}})
+
+        t.assert_equals(pos, nil)
+    end)
+end
+
+g.test_rtree_pagination_manhattan = function()
+    g.server:exec(function()
+
+        local s = box.schema.space.create(
+            'manhattan')
+        s:format({ { type = 'number', name = 'id' },
+            { type = 'array', name = 'content' } })
+        local hash_index = s:create_index('primary',
+            { type = 'tree', parts = {'id'} })
+        local rtree_index = s:create_index('rtree_ind',
+            { type = 'rtree', unique = false,
+            distance = 'manhattan',
+            parts = {'content'} })
+
+        for i = 2, 6, 2 do
+            for j = 1, 10 do
+                s:insert{i * 10 + j,
+                    {i, j + 3, -i, -j * 2}}
+            end
+        end
+
+        local tuples
+        local pos
+        hash_index:select{0};
+
+        tuples, pos = rtree_index:select({100, 100},
+            {iterator = 'neighbor',
+            fetch_pos=true, limit=4})
+
+        t.assert_equals(tuples,
+            {{70,{6,13,-6,-20}},{69,{6,12,-6,-18}},
+             {50,{4,13,-4,-20}},{68,{6,11,-6,-16}}})
+
+        tuples, pos = rtree_index:select({100, 100},
+            {iterator = 'neighbor',
+            fetch_pos=true, limit=4, after=pos})
+
+        t.assert_equals(tuples,
+            {{49,{4,12,-4,-18}},{67,{6,10,-6,-14}},
+             {30,{2,13,-2,-20}},{48,{4,11,-4,-16}}})
+
+        tuples, pos = rtree_index:select({100, 100},
+            {iterator = 'neighbor',
+            fetch_pos=false, limit=3, after=pos})
+
+        t.assert_equals(tuples,
+            {{66,{6,9,-6,-12}},{29,{2,12,-2,-18}},
+             {47,{4,10,-4,-14}}})
+
+        tuples, pos = rtree_index:select({100, 100},
+            {iterator = 'neighbor',
+            fetch_pos=true, limit=0, after=pos})
+
+        t.assert_equals(tuples, {})
+        t.assert_equals(pos, nil)
+    end)
+end
+
+g.test_rtree_pagination_delete_tuple = function()
+    g.server:exec(function()
+
+        local s = box.schema.space.create('delete_tuple')
+        s:format({ { type = 'number', name = 'id' },
+            { type = 'array', name = 'content' } })
+        local hash_index = s:create_index('primary',
+            { type = 'tree', parts = {'id'} })
+        local rtree_index = s:create_index('rtree_ind',
+            { type = 'rtree', unique = false,
+             distance = 'manhattan',
+             parts = {'content'} })
+
+        for i = 2, 6, 2 do
+            for j = 1, 10 do
+                s:insert{i * 10 + j,
+                    {i, j + 3, -i, -j * 2}}
+            end
+        end
+
+        local tuples
+        local pos
+        hash_index:select{0};
+
+        tuples, pos = rtree_index:select({100, 100},
+            {iterator = 'neighbor',
+            fetch_pos=true, limit=4})
+
+        t.assert_equals(tuples,
+            {{70,{6,13,-6,-20}},{69,{6,12,-6,-18}},
+             {50,{4,13,-4,-20}},{68,{6,11,-6,-16}}})
+
+        s:delete{68}
+
+        tuples, pos = rtree_index:select({100, 100},
+            {iterator = 'neighbor',
+            fetch_pos=true, limit=4, after=pos})
+
+        t.assert_equals(tuples,
+            {{49,{4,12,-4,-18}},{67,{6,10,-6,-14}},
+             {30,{2,13,-2,-20}},{48,{4,11,-4,-16}}})
+
+        s:delete{48}
+        s:delete{66}
+        s:delete{29}
+        s:delete{47}
+
+        tuples, pos = rtree_index:select({100, 100},
+            {iterator = 'neighbor',
+            fetch_pos=true, limit=4, after=pos})
+        t.assert_equals(tuples,
+            {{65,{6,8,-6,-10}},{28,{2,11,-2,-16}},
+             {46,{4,9,-4,-12}},{64,{6,7,-6,-8}}})
+
+        s:delete{64}
+
+        tuples, pos = rtree_index:select({100, 100},
+            {iterator = 'neighbor',
+            fetch_pos=false, limit=4, after=pos})
+        t.assert_equals(tuples,
+            {{27,{2,10,-2,-14}},{45,{4,8,-4,-10}},
+             {63,{6,6,-6,-6}},{26,{2,9,-2,-12}}})
+        t.assert_equals(pos, nil)
+    end)
+end
+
+g.test_rtree_pagination_errors = function()
+    g.server:exec(function()
+
+        local s = box.schema.space.create('errors')
+        s:format({ { type = 'number', name = 'id' },
+            { type = 'array', name = 'content' } })
+        local hash_index = s:create_index('primary',
+            { type = 'tree', parts = {'id'} })
+        local rtree_index = s:create_index('rtree_ind',
+            { type = 'rtree', unique = false,
+             parts = {'content'} })
+
+        hash_index:select{0};
+
+        local iters = {'eq', 'le', 'lt', 'ge', 'gt',
+            'overlaps'}
+
+        for _, iter in pairs(iters) do
+            t.assert_error_msg_contains(
+              'does not support pagination',
+              rtree_index.select,
+              rtree_index, {0, 0},
+              {iterator = iter, fetch_pos=true})
+        end
+        s:insert{1, {1, 1}}
+        local tuples, pos = rtree_index:select({0, 0},
+            {iterator = 'neighbor',
+            fetch_pos=true, limit=1})
+        t.assert_equals(tuples[1], {1, {1, 1}})
+
+        for _, iter in pairs(iters) do
+            t.assert_error_msg_contains(
+              'pagination with wrong iterator type.',
+              rtree_index.select,
+              rtree_index, {0, 0},
+              {iterator = iter, fetch_pos=true,
+               after=pos})
+        end
+    end)
+end

--- a/test/box-luatest/rtree_sorting_neighbors.lua
+++ b/test/box-luatest/rtree_sorting_neighbors.lua
@@ -1,0 +1,54 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group('rtree-neighbor-sort')
+
+g.before_all(function()
+    g.server = server:new()
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+end)
+
+g.test_rtree_equal_distance = function()
+    g.server:exec(function()
+
+        local s = box.schema.space.create('equal_distance')
+        s:format({ { type = 'number', name = 'id' },
+            { type = 'array', name = 'content' } })
+        local hash_index = s:create_index('primary',
+            { type = 'tree', parts = {'id'} })
+        local rtree_index = s:create_index('rtree_ind',
+            { type = 'rtree', unique = false,
+             parts = {'content'} })
+
+        local tuples = {{21,{50,0}}, {20,{43.301,25}},
+           {17,{25,43.301}}, {16,{0,50}}, {4,{-25,43.301}},
+           {7,{-43.301,25}}, {13,{-50, 0}}, {0,{-43.301,-25}},
+           {25,{-25,-43.301}}, {41,{0,-50}}, {40,{25,-43.301}},
+           {39,{43.301,-25}}, {1,{35.355,35.355}},
+           {6,{11.5,48.659}}, {5,{48.659,-11.5}},
+           {2, {-35.355,35.355}}, {3, {35.355,-35.355}}}
+        for i = 1, #tuples do
+            local first_value, second_tuple = unpack(tuples[i])
+            s:insert({first_value, second_tuple})
+        end
+
+        hash_index:select{0}
+
+        tuples = rtree_index:select({0, 0},
+           {iterator = 'neighbor', limit=17})
+
+        t.assert_equals(tuples,
+           {{5,{48.659,-11.5}},{6,{11.5,48.659}},
+            {1,{35.355,35.355}},{2,{-35.355,35.355}},
+            {3,{35.355,-35.355}},{0,{-43.301,-25}},
+            {4,{-25,43.301}},{7,{-43.301,25}},
+            {17,{25,43.301}},{20,{43.301,25}},
+            {25,{-25,-43.301}},{39,{43.301,-25}},
+            {40,{25,-43.301}},{13,{-50,0}},
+            {16,{0,50}},{21,{50,0}},{41,{0,-50}}})
+    end)
+end

--- a/test/engine-luatest/pagination_test.lua
+++ b/test/engine-luatest/pagination_test.lua
@@ -929,7 +929,6 @@ end
 local no_sup = t.group('Unsupported pagination', {
             {engine = 'memtx', type = 'hash'},
             {engine = 'memtx', type = 'bitset'},
-            {engine = 'memtx', type = 'rtree'},
 })
 
 no_sup.before_all(function(cg)
@@ -964,9 +963,6 @@ no_sup.test_unsupported_pagination = function(cg)
                 box.space.s.index.sk.select, box.space.s.index.sk,
                 nil, {fullscan=true, fetch_pos=true})
         local tuple = {0, 0}
-        if index_type == 'rtree' then
-            tuple = {0, {0, 0}}
-        end
         t.assert_error_msg_contains('does not support pagination',
                 box.space.s.index.sk.select, box.space.s.index.sk,
                 nil, {fullscan=true, after=tuple})


### PR DESCRIPTION
Implementation of rtree pagination for neighbor iterator.

for example:
```
tuples, pos = rtree_index:select ({1, 1}, {iterator = 'neighbor', fetch_pos=true, limit=6})
tuples, pos = rtree_index:select ({1, 1}, {iterator = 'neighbor', fetch_pos=true, limit=3, after=pos})
```
