### PR TITLE
[backport 2.11] log: fix truncating log message to 1024 bytes in 'json' log

### DIFF
--- a/changelogs/unreleased/gh-10918-fix-log-message-truncate.md
+++ b/changelogs/unreleased/gh-10918-fix-log-message-truncate.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Fixed log message being truncated to 1024 bytes with JSON logger (gh-10918).

--- a/src/lib/core/say.c
+++ b/src/lib/core/say.c
@@ -31,7 +31,6 @@
 #include "say.h"
 #include "fiber.h"
 #include "errinj.h"
-#include "tt_static.h"
 #include "tt_strerror.h"
 
 #include <errno.h>
@@ -880,8 +879,8 @@ say_format_plain(struct log *log, char *buf, int len, int level,
 
 /**
  * Format log message in json format:
- * {"time": 1507026445.23232, "level": "WARN", "message": <message>,
- * "pid": <pid>, "cord_name": <name>, "fiber_id": <id>,
+ * {"time": "2024-12-23T20:04:26.491+0300", "level": "WARN",
+ * "message": <message>, "pid": <pid>, "cord_name": <name>, "fiber_id": <id>,
  * "fiber_name": <fiber_name>, file": <filename>, "line": <fds>,
  * "module": <module_name>}
  */
@@ -890,11 +889,16 @@ say_format_json(struct log *log, char *buf, int len, int level,
 		const char *module, const char *filename, int line,
 		const char *error, const char *format, va_list ap)
 {
-	(void) log;
+	(void)log;
+
 	int total = 0;
+	char *buf_end = buf + len;
 
+	/*
+	 * Print time in format YYYY-MM-DDThh:mm:ss.ms+tz_offset.
+	 * For example 2024-12-23T20:04:26.491+0300.
+	 */
 	SNPRINT(total, snprintf, buf, len, "{\"time\": \"");
-
 	struct tm tm;
 	double tm_sec;
 	get_current_time(&tm, &tm_sec);
@@ -905,38 +909,29 @@ say_format_json(struct log *log, char *buf, int len, int level,
 	buf += written, len -= written, total += written;
 	SNPRINT(total, snprintf, buf, len, "\", ");
 
+	/* Print level. */
 	SNPRINT(total, snprintf, buf, len, "\"level\": \"%s\", ",
-			level_to_string(level));
+		level_to_string(level));
 
-	if (strncmp(format, "json", sizeof("json")) == 0) {
-		/*
-		 * Message is already JSON-formatted.
-		 * Get rid of {} brackets and append to the output buffer.
-		 */
-		const char *str = va_arg(ap, const char *);
-		assert(str != NULL);
-		int str_len = strlen(str);
-		assert(str_len > 2 && str[0] == '{' && str[str_len - 1] == '}');
-		SNPRINT(total, snprintf, buf, len, "%.*s, ",
-			str_len - 2, str + 1);
-	} else {
-		/* Format message */
-		char *tmp = tt_static_buf();
-		if (vsnprintf(tmp, TT_STATIC_BUF_LEN, format, ap) < 0)
-			return -1;
-		SNPRINT(total, snprintf, buf, len, "\"message\": \"");
-		/* Escape and print message */
-		SNPRINT(total, json_escape, buf, len, tmp);
-		SNPRINT(total, snprintf, buf, len, "\", ");
-	}
+	/*
+	 * Remember where the message starts for now, will write the message,
+	 * after writing the rest of the context and moving it to the end of
+	 * the buffer.
+	 * Currently our buffer looks like this:
+	 * | head \0| garbage |
+	 *         ^ buf       ^ buf_end
+	 */
+	char *msg_ptr = buf;
+	const int head_len = total;
 
-	/* in case of system errors */
+	/* Print error, if any. */
 	if (error) {
 		SNPRINT(total, snprintf, buf, len, "\"error\": \"");
 		SNPRINT(total, json_escape, buf, len, error);
 		SNPRINT(total, snprintf, buf, len, "\", ");
 	}
 
+	/* Print PID, cord name, fiber id and fiber name. */
 	SNPRINT(total, snprintf, buf, len, "\"pid\": %i ", getpid());
 	SNPRINT(total, snprintf, buf, len, ", \"cord_name\": \"");
 	SNPRINT(total, json_escape, buf, len, cord()->name);
@@ -949,6 +944,7 @@ say_format_json(struct log *log, char *buf, int len, int level,
 		SNPRINT(total, snprintf, buf, len, "\"");
 	}
 
+	/* Print filename, line and module name if any. */
 	if (filename) {
 		SNPRINT(total, snprintf, buf, len, ", \"file\": \"");
 		SNPRINT(total, json_escape, buf, len, filename);
@@ -959,7 +955,92 @@ say_format_json(struct log *log, char *buf, int len, int level,
 		SNPRINT(total, json_escape, buf, len, module);
 		SNPRINT(total, snprintf, buf, len, "\"");
 	}
+
 	SNPRINT(total, snprintf, buf, len, "}\n");
+
+	/*
+	 * Finished printing context for the log entry. Will move tail to the
+	 * end of the buffer.
+	 * The buffer looks like this:
+	 * | head |   tail  \0| garbage |
+	 *         ^ msg_ptr ^ buf       ^ buf_end
+	 */
+
+	const int tail_len = total - head_len;
+	char *tail_ptr = buf_end - tail_len - 1; /* Reserve space for '\0'. */
+
+	/* Move the tail of the context to the end of the buffer. */
+	memmove(tail_ptr, msg_ptr, tail_len);
+	tail_ptr[tail_len] = '\0';
+	int msg_cap = tail_ptr - msg_ptr;
+
+	/* After moving the tail, the buffer looks like this:
+	 * | head |   garbage   |   tail   \0|
+	 *         ^ msg_ptr     ^ tail_ptr   ^ buf_end
+	 */
+
+	/* Write the message. */
+	if (strncmp(format, "json", sizeof("json")) == 0) {
+		/*
+		 * Message is already JSON-formatted.
+		 * Get rid of {} brackets and print it as-is.
+		 */
+		const char *str = va_arg(ap, const char *);
+		assert(str != NULL);
+		int str_len = strlen(str);
+		assert(str_len > 2 && str[0] == '{' && str[str_len - 1] == '}');
+
+		/*
+		 * Can't use SNPRINT macro here, because it sets the pointer to
+		 * null, if the message didn't fit into the provided buffer,
+		 * but we still need to use the pointer after.
+		 */
+		int msg_len = snprintf(msg_ptr, msg_cap,
+				       "%.*s, ", str_len - 2, str + 1);
+
+		if (msg_len < 0) {
+			return -1;
+		}
+
+		msg_len = MIN(msg_len, msg_cap);
+		len -= msg_len;
+		total += msg_len;
+		msg_ptr += msg_len;
+	} else {
+		/* Print message header. */
+		SNPRINT(total, snprintf, msg_ptr, msg_cap, "\"message\": \"");
+
+		static const char msg_tail[] = "\", ";
+		msg_cap -= strlen(msg_tail);
+
+		/*
+		 * Print the message.
+		 * Need to cast msg_cap to unsigned, because otherwise
+		 * during LTO build stringop-overread warning is triggered.
+		 * Can't use SNPRINT macro here, because it sets the pointer to
+		 * null, if the message didn't fit into the provided buffer,
+		 * but we still need to use the pointer after.
+		 */
+		vsnprintf(msg_ptr, (unsigned)msg_cap, format, ap);
+
+		/* Escape the message. */
+		int msg_len = json_escape_inplace(msg_ptr, msg_cap);
+		len -= msg_len;
+		total += msg_len;
+		msg_ptr += msg_len;
+
+		/* Print message tail. */
+		SNPRINT(total, snprintf, msg_ptr, len, msg_tail);
+	}
+
+	/*
+	 * We now will move the tail with '\0' to the end of the message.
+	 * After escaping the message, the buffer looks like this:
+	 * | head | message \0| garbage |   tail   \0|
+	 *                   ^ msg_ptr   ^ tail_ptr   ^ buf_end
+	 */
+	memmove(msg_ptr, tail_ptr, tail_len + 1);
+
 	return total;
 }
 

--- a/src/lib/core/util.c
+++ b/src/lib/core/util.c
@@ -268,6 +268,64 @@ json_escape(char *buf, int size, const char *data)
 	return total;
 }
 
+int
+json_escape_inplace(char *buf, int size)
+{
+	/* We need at least one byte for the null terminator later. */
+	if (buf == NULL || size <= 0)
+		return 0;
+
+	int total = 0;
+	int data_len = 0;
+
+	/*
+	 * Calculate the length of the string and the escaped string in on go.
+	 * If the buffer is not large enough, we will "truncate" the input
+	 * string, so the escaped string will fit into the buffer.
+	 */
+	for (char *p = buf; p < buf + size && *p != '\0'; p++) {
+		char c = *p;
+		const char *esc_str = json_escape_char(c);
+		int esc_len = esc_str != NULL ? strlen(esc_str) : 1;
+
+		if (total + esc_len >= size) {
+			break;
+		}
+
+		total += esc_len;
+		data_len++;
+	}
+
+	/* Write the null terminator. */
+	assert(total + 1 <= size); /* Guaranteed by the loop above. */
+	buf[total + 1] = '\0';
+
+	/* Write the escaped string from the end to the beginning. */
+	char *pw = buf + total;
+	int written = 0;
+	for (char *pr = buf + data_len - 1; pr >= buf; --pr) {
+		char c = *pr;
+		const char *esc_str = json_escape_char(c);
+
+		if (esc_str != NULL) {
+			int esc_len = strlen(esc_str);
+			pw -= esc_len;
+			assert(pw > pr - 1);
+			memcpy(pw, esc_str, esc_len);
+			written += esc_len;
+		} else {
+			pw--;
+			assert(pw > pr - 1);
+			*pw = c;
+			written++;
+		}
+	}
+
+	assert(pw <= buf);
+	assert(written == total);
+	return written;
+}
+
 const char *precision_fmts[] = {
 	"%.0lg", "%.1lg", "%.2lg", "%.3lg", "%.4lg", "%.5lg", "%.6lg", "%.7lg",
 	"%.8lg", "%.9lg", "%.10lg", "%.11lg", "%.12lg", "%.13lg", "%.14lg"

--- a/src/trivia/util.h
+++ b/src/trivia/util.h
@@ -623,6 +623,12 @@ int
 json_escape(char *buf, int size, const char *data);
 
 /**
+ * Escape special characters in @a buf inplace
+ */
+int
+json_escape_inplace(char *buf, int size);
+
+/**
  * Helper macro to handle easily snprintf() result
  */
 #define SNPRINT(_total, _fun, _buf, _size, ...) do {				\


### PR DESCRIPTION
*(This PR is a backport of #10952 to `release/2.11` to a future `2.11.6` release.)*

----

Before this patch, when log format was set to 'json' and log entry was written with format-string API (`require('log').info(<format string>, args...)`), in the output the message was truncated to 1024 bytes.

This patch fixes this behavior, and now the message will only be truncated if the full log entry (with all the context) doesn't fit into the 16KiB buffer. The message will be truncated in a way, so all the context is present.

Closes #10918

NO_DOC=bugfix