### PR TITLE
vinyl: fix cache read view

### DIFF
--- a/changelogs/unreleased/gh-11079-vy-cache-read-view-fix.md
+++ b/changelogs/unreleased/gh-11079-vy-cache-read-view-fix.md
@@ -1,0 +1,4 @@
+## bugfix/vinyl
+
+* Fixed a bug in the tuple cache when a transaction operating in a read view
+  could skip a tuple deleted after the read view creation (gh-11079).

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -1301,6 +1301,11 @@ vy_is_committed(struct vy_env *env, struct vy_lsm *lsm)
  * @param entry       Tuple read from a secondary index.
  * @param[out] result The found tuple is stored here. Must be
  *                    unreferenced after usage.
+ * @param[in,out] skipped_lsn If the result is NULL and the input value
+ *                            is less, set to the LSN of the statement
+ *                            that was skipped because it didn't match
+ *                            the partial tuple key. In other words, it's
+ *                            the LSN of the deferred DELETE statement.
  *
  * @param  0 Success.
  * @param -1 Memory error or read error.
@@ -1308,7 +1313,8 @@ vy_is_committed(struct vy_env *env, struct vy_lsm *lsm)
 static int
 vy_get_by_secondary_tuple(struct vy_lsm *lsm, struct vy_tx *tx,
 			  const struct vy_read_view **rv,
-			  struct vy_entry entry, struct vy_entry *result)
+			  struct vy_entry entry, struct vy_entry *result,
+			  int64_t *skipped_lsn)
 {
 	int rc = 0;
 	assert(lsm->index_id > 0);
@@ -1338,14 +1344,16 @@ vy_get_by_secondary_tuple(struct vy_lsm *lsm, struct vy_tx *tx,
 	lsm->pk->stat.lookup++;
 
 	struct vy_entry pk_entry;
-	if (vy_point_lookup(lsm->pk, tx, rv, key, &pk_entry) != 0) {
+	if (vy_point_lookup(lsm->pk, tx, rv, key, /*keep_delete=*/true,
+			    &pk_entry) != 0) {
 		rc = -1;
 		goto out;
 	}
 
 	bool match = false;
 	struct vy_entry full_entry;
-	if (pk_entry.stmt != NULL) {
+	if (pk_entry.stmt != NULL &&
+	    vy_stmt_type(pk_entry.stmt) != IPROTO_DELETE) {
 		vy_stmt_foreach_entry(full_entry, pk_entry.stmt, lsm->cmp_def) {
 			if (vy_entry_compare(full_entry, entry,
 					     lsm->cmp_def) == 0) {
@@ -1367,6 +1375,8 @@ vy_get_by_secondary_tuple(struct vy_lsm *lsm, struct vy_tx *tx,
 		if (pk_entry.stmt != NULL) {
 			vy_stmt_counter_acct_tuple(&lsm->pk->stat.skip,
 						   pk_entry.stmt);
+			*skipped_lsn = MAX(*skipped_lsn,
+					   vy_stmt_lsn(pk_entry.stmt));
 			tuple_unref(pk_entry.stmt);
 		}
 		/*
@@ -1432,6 +1442,7 @@ vy_get(struct vy_lsm *lsm, struct vy_tx *tx,
 
 	int rc;
 	struct vy_entry partial, entry;
+	int64_t skipped_lsn = 0;
 
 	struct vy_entry key;
 	key.stmt = key_stmt;
@@ -1445,11 +1456,12 @@ vy_get(struct vy_lsm *lsm, struct vy_tx *tx,
 		 */
 		if (tx != NULL)
 			vy_tx_track_point(tx, lsm, key);
-		if (vy_point_lookup(lsm, tx, rv, key, &partial) != 0)
+		if (vy_point_lookup(lsm, tx, rv, key, /*keep_delete=*/false,
+				    &partial) != 0)
 			goto fail;
 		if (lsm->index_id > 0 && partial.stmt != NULL) {
-			rc = vy_get_by_secondary_tuple(lsm, tx, rv,
-						       partial, &entry);
+			rc = vy_get_by_secondary_tuple(lsm, tx, rv, partial,
+						       &entry, &skipped_lsn);
 			tuple_unref(partial.stmt);
 			if (rc != 0)
 				goto fail;
@@ -1470,12 +1482,13 @@ vy_get(struct vy_lsm *lsm, struct vy_tx *tx,
 				tuple_ref(entry.stmt);
 			break;
 		}
-		rc = vy_get_by_secondary_tuple(lsm, tx, rv, partial, &entry);
+		rc = vy_get_by_secondary_tuple(lsm, tx, rv, partial, &entry,
+					       &skipped_lsn);
 		if (rc != 0 || entry.stmt != NULL)
 			break;
 	}
 	if (rc == 0)
-		vy_read_iterator_cache_add(&itr, entry);
+		vy_read_iterator_cache_add(&itr, entry, skipped_lsn);
 	vy_read_iterator_close(&itr);
 	if (rc != 0)
 		goto fail;
@@ -3471,7 +3484,8 @@ vy_squash_process(struct vy_squash *squash)
 	 */
 	struct vy_entry result;
 	if (vy_point_lookup(lsm, NULL, &env->xm->p_committed_read_view,
-			    squash->entry, &result) != 0)
+			    squash->entry, /*keep_delete=*/false,
+			    &result) != 0)
 		return -1;
 	if (result.stmt == NULL)
 		return 0;
@@ -3755,7 +3769,8 @@ vinyl_iterator_primary_next(struct iterator *base, struct tuple **ret)
 	struct vy_entry entry;
 	if (vy_read_iterator_next(&it->iterator, &entry) != 0)
 		goto fail;
-	vy_read_iterator_cache_add(&it->iterator, entry);
+	vy_read_iterator_cache_add(&it->iterator, entry,
+				   /*skipped_lsn=*/0);
 	vinyl_iterator_account_read(it, start_time, entry.stmt);
 	if (entry.stmt == NULL) {
 		/* EOF. Close the iterator immediately. */
@@ -3789,6 +3804,7 @@ vinyl_iterator_secondary_next(struct iterator *base, struct tuple **ret)
 	vy_lsm_ref(lsm);
 
 	struct vy_entry partial, entry;
+	int64_t skipped_lsn = 0;
 next:
 	if (vinyl_iterator_check_tx(it) != 0)
 		goto fail;
@@ -3798,7 +3814,8 @@ next:
 
 	if (partial.stmt == NULL) {
 		/* EOF. Close the iterator immediately. */
-		vy_read_iterator_cache_add(&it->iterator, vy_entry_none());
+		vy_read_iterator_cache_add(&it->iterator, vy_entry_none(),
+					   skipped_lsn);
 		vinyl_iterator_account_read(it, start_time, NULL);
 		vinyl_iterator_close(it);
 		*ret = NULL;
@@ -3806,11 +3823,11 @@ next:
 	}
 	/* Get the full tuple from the primary index. */
 	if (vy_get_by_secondary_tuple(lsm, it->tx, vy_tx_read_view(it->tx),
-				      partial, &entry) != 0)
+				      partial, &entry, &skipped_lsn) != 0)
 		goto fail;
 	if (entry.stmt == NULL)
 		goto next;
-	vy_read_iterator_cache_add(&it->iterator, entry);
+	vy_read_iterator_cache_add(&it->iterator, entry, skipped_lsn);
 	vinyl_iterator_account_read(it, start_time, entry.stmt);
 	vinyl_iterator_update_pos(it, entry);
 	*ret = entry.stmt;
@@ -4189,7 +4206,8 @@ vy_build_recover_stmt(struct vy_lsm *lsm, struct vy_lsm *pk,
 	const struct vy_read_view rv = { .vlsn = lsn - 1 };
 	const struct vy_read_view *p_rv = &rv;
 	struct vy_entry old;
-	if (vy_point_lookup(pk, NULL, &p_rv, mem_entry, &old) != 0)
+	if (vy_point_lookup(pk, /*tx=*/NULL, &p_rv, mem_entry,
+			    /*keep_delete=*/false, &old) != 0)
 		return -1;
 	/*
 	 * Create DELETE + INSERT statements corresponding to

--- a/src/box/vy_cache.c
+++ b/src/box/vy_cache.c
@@ -123,6 +123,8 @@ vy_cache_node_new(struct vy_cache_env *env, struct vy_cache *cache,
 	node->flags = 0;
 	node->left_boundary_level = cache->cmp_def->part_count;
 	node->right_boundary_level = cache->cmp_def->part_count;
+	node->left_lsn = 0;
+	node->right_lsn = 0;
 	rlist_add(&env->cache_lru, &node->in_lru);
 	env->mem_used += vy_cache_node_size(node);
 	vy_stmt_counter_acct_tuple(&cache->stat.count, entry.stmt);
@@ -233,7 +235,7 @@ vy_cache_env_set_quota(struct vy_cache_env *env, size_t quota)
 
 void
 vy_cache_add(struct vy_cache *cache, struct vy_entry curr,
-	     struct vy_entry prev, bool is_first,
+	     struct vy_entry prev, bool is_first, int64_t link_lsn,
 	     struct vy_entry key, enum iterator_type order)
 {
 	assert(!is_first || prev.stmt == NULL);
@@ -326,12 +328,19 @@ vy_cache_add(struct vy_cache *cache, struct vy_entry curr,
 		node->flags = replaced->flags;
 		node->left_boundary_level = replaced->left_boundary_level;
 		node->right_boundary_level = replaced->right_boundary_level;
+		node->left_lsn = replaced->left_lsn;
+		node->right_lsn = replaced->right_lsn;
 		vy_cache_node_delete(cache->env, replaced);
 	}
-	if (direction > 0 && boundary_level < node->left_boundary_level)
+	if (direction > 0 &&
+	    boundary_level < node->left_boundary_level) {
 		node->left_boundary_level = boundary_level;
-	else if (direction < 0 && boundary_level < node->right_boundary_level)
+		node->left_lsn = link_lsn;
+	} else if (direction < 0 &&
+		   boundary_level < node->right_boundary_level) {
 		node->right_boundary_level = boundary_level;
+		node->right_lsn = link_lsn;
+	}
 
 	vy_stmt_counter_acct_tuple(&cache->stat.put, curr.stmt);
 
@@ -412,6 +421,8 @@ vy_cache_add(struct vy_cache *cache, struct vy_entry curr,
 		prev_node->flags = replaced->flags;
 		prev_node->left_boundary_level = replaced->left_boundary_level;
 		prev_node->right_boundary_level = replaced->right_boundary_level;
+		prev_node->left_lsn = replaced->left_lsn;
+		prev_node->right_lsn = replaced->right_lsn;
 		vy_cache_node_delete(cache->env, replaced);
 	}
 
@@ -420,6 +431,14 @@ vy_cache_add(struct vy_cache *cache, struct vy_entry curr,
 	/* Set inverted flag in the previous node */
 	prev_node->flags |= (VY_CACHE_LEFT_LINKED |
 			     VY_CACHE_RIGHT_LINKED) ^ flag;
+	/* Set chain link LSN when two nodes are linked */
+	if (direction > 0) {
+		node->left_lsn = link_lsn;
+		prev_node->right_lsn = link_lsn;
+	} else {
+		node->right_lsn = link_lsn;
+		prev_node->left_lsn = link_lsn;
+	}
 }
 
 struct vy_entry
@@ -538,6 +557,29 @@ vy_cache_iterator_curr(struct vy_cache_iterator *itr)
 }
 
 /**
+ * Return true if the given LSN is visible from the iterator read view.
+ */
+static bool
+vy_cache_iterator_lsn_is_visible(struct vy_cache_iterator *itr, int64_t lsn)
+{
+	if (lsn > (**itr->read_view).vlsn)
+		return false;
+	if (!itr->is_prepared_ok && vy_lsn_is_prepared(lsn))
+		return false;
+	return true;
+}
+
+/**
+ * Return true if the given statement is visible from the iterator read view.
+ */
+static bool
+vy_cache_iterator_stmt_is_visible(struct vy_cache_iterator *itr,
+				  struct tuple *stmt)
+{
+	return vy_cache_iterator_lsn_is_visible(itr, vy_stmt_lsn(stmt));
+}
+
+/**
  * Determine whether the merge iterator must be stopped or not.
  * That is made by examining flags of a cache record.
  *
@@ -553,15 +595,15 @@ vy_cache_iterator_is_stop(struct vy_cache_iterator *itr,
 	/* select{} is actually an EQ iterator with part_count == 0 */
 	bool iter_is_eq = itr->iterator_type == ITER_EQ || key_level == 0;
 	if (iterator_direction(itr->iterator_type) > 0) {
-		if (node->flags & VY_CACHE_LEFT_LINKED)
-			return true;
-		if (iter_is_eq && node->left_boundary_level <= key_level)
-			return true;
+		if ((node->flags & VY_CACHE_LEFT_LINKED) ||
+		    (iter_is_eq && node->left_boundary_level <= key_level))
+			return vy_cache_iterator_lsn_is_visible(
+						itr, node->left_lsn);
 	} else {
-		if (node->flags & VY_CACHE_RIGHT_LINKED)
-			return true;
-		if (iter_is_eq && node->right_boundary_level <= key_level)
-			return true;
+		if ((node->flags & VY_CACHE_RIGHT_LINKED) ||
+		    (iter_is_eq && node->right_boundary_level <= key_level))
+			return vy_cache_iterator_lsn_is_visible(
+						itr, node->right_lsn);
 	}
 	return false;
 }
@@ -583,15 +625,17 @@ vy_cache_iterator_is_end_stop(struct vy_cache_iterator *itr,
 	/* select{} is actually an EQ iterator with part_count == 0 */
 	bool iter_is_eq = itr->iterator_type == ITER_EQ || key_level == 0;
 	if (iterator_direction(itr->iterator_type) > 0) {
-		if (last_node->flags & VY_CACHE_RIGHT_LINKED)
-			return true;
-		if (iter_is_eq && last_node->right_boundary_level <= key_level)
-			return true;
+		if ((last_node->flags & VY_CACHE_RIGHT_LINKED) ||
+		    (iter_is_eq &&
+		     last_node->right_boundary_level <= key_level))
+			return vy_cache_iterator_lsn_is_visible(
+						itr, last_node->right_lsn);
 	} else {
-		if (last_node->flags & VY_CACHE_LEFT_LINKED)
-			return true;
-		if (iter_is_eq && last_node->left_boundary_level <= key_level)
-			return true;
+		if ((last_node->flags & VY_CACHE_LEFT_LINKED) ||
+		    (iter_is_eq &&
+		     last_node->left_boundary_level <= key_level))
+			return vy_cache_iterator_lsn_is_visible(
+						itr, last_node->left_lsn);
 	}
 	return false;
 }
@@ -635,21 +679,6 @@ vy_cache_iterator_step(struct vy_cache_iterator *itr)
 	itr->curr = node->entry;
 	tuple_ref(itr->curr.stmt);
 	return vy_cache_iterator_is_stop(itr, node);
-}
-
-/**
- * Return true if the given statement is visible from the iterator
- * read view.
- */
-static inline bool
-vy_cache_iterator_stmt_is_visible(struct vy_cache_iterator *itr,
-				  struct tuple *stmt)
-{
-	if (vy_stmt_lsn(stmt) > (**itr->read_view).vlsn)
-		return false;
-	if (!itr->is_prepared_ok && vy_stmt_is_prepared(stmt))
-		return false;
-	return true;
 }
 
 /**

--- a/src/box/vy_lsm.c
+++ b/src/box/vy_lsm.c
@@ -1046,6 +1046,15 @@ vy_lsm_commit_stmt(struct vy_lsm *lsm, struct vy_mem *mem,
 		vy_lsm_commit_upsert(lsm, mem, entry);
 
 	vy_stmt_counter_acct_tuple(&lsm->stat.put, entry.stmt);
+
+	/*
+	 * If a cache chain covering a prepared DELETE statement is added
+	 * to the cache, it will be invisible to any transaction operating in
+	 * the 'read-confirmed' isolation level. To avoid that, we invalidate
+	 * the cache when a statement is confirmed so that the chain can be
+	 * re-created on the next read with its final LSN.
+	 */
+	vy_cache_on_write(&lsm->cache, entry, NULL);
 }
 
 void

--- a/src/box/vy_point_lookup.c
+++ b/src/box/vy_point_lookup.c
@@ -215,7 +215,8 @@ vy_point_lookup_scan_slices(struct vy_lsm *lsm, const struct vy_read_view **rv,
 int
 vy_point_lookup(struct vy_lsm *lsm, struct vy_tx *tx,
 		const struct vy_read_view **rv,
-		struct vy_entry key, struct vy_entry *ret)
+		struct vy_entry key, bool keep_delete,
+		struct vy_entry *ret)
 {
 	/* All key parts must be set for a point lookup. */
 	assert(vy_stmt_is_full_key(key.stmt, lsm->cmp_def));
@@ -301,7 +302,7 @@ done:
 	if (rc == 0) {
 		int upserts_applied;
 		rc = vy_history_apply(&history, lsm->cmp_def,
-				      false, &upserts_applied, ret);
+				      keep_delete, &upserts_applied, ret);
 		lsm->stat.upsert.applied += upserts_applied;
 	}
 	vy_history_cleanup(&history);

--- a/src/box/vy_point_lookup.h
+++ b/src/box/vy_point_lookup.h
@@ -61,6 +61,9 @@ struct vy_read_view;
  * tuple in the LSM tree. The tuple is returned in @ret with its
  * reference counter elevated.
  *
+ * If @keep_delete flag is set, the function will return the latest
+ * DELETE statement instead of NULL if it exists.
+ *
  * Note, this function doesn't track the result in the transaction
  * read set, i.e. it is up to the caller to call vy_tx_track() if
  * necessary.
@@ -68,7 +71,8 @@ struct vy_read_view;
 int
 vy_point_lookup(struct vy_lsm *lsm, struct vy_tx *tx,
 		const struct vy_read_view **rv,
-		struct vy_entry key, struct vy_entry *ret);
+		struct vy_entry key, bool keep_delete,
+		struct vy_entry *ret);
 
 /**
  * Look up a tuple by key in memory.

--- a/src/box/vy_read_iterator.c
+++ b/src/box/vy_read_iterator.c
@@ -1013,7 +1013,8 @@ next_key:
 }
 
 void
-vy_read_iterator_cache_add(struct vy_read_iterator *itr, struct vy_entry entry)
+vy_read_iterator_cache_add(struct vy_read_iterator *itr, struct vy_entry entry,
+			   int64_t skipped_lsn)
 {
 	if ((**itr->read_view).vlsn != INT64_MAX) {
 		if (itr->last_cached.stmt != NULL)
@@ -1022,7 +1023,8 @@ vy_read_iterator_cache_add(struct vy_read_iterator *itr, struct vy_entry entry)
 		return;
 	}
 	vy_cache_add(&itr->lsm->cache, entry, itr->last_cached,
-		     itr->is_first_cached, itr->cache_link_lsn,
+		     itr->is_first_cached,
+		     MAX(itr->cache_link_lsn, skipped_lsn),
 		     itr->key, itr->iterator_type);
 	if (entry.stmt != NULL)
 		tuple_ref(entry.stmt);

--- a/src/box/vy_read_iterator.c
+++ b/src/box/vy_read_iterator.c
@@ -996,6 +996,10 @@ next_key:
 				tuple_unref(itr->last_cached.stmt);
 			itr->last_cached = vy_entry_none();
 			itr->is_first_cached = false;
+			itr->cache_link_lsn = 0;
+		} else {
+			itr->cache_link_lsn = MAX(itr->cache_link_lsn,
+						  vy_stmt_lsn(entry.stmt));
 		}
 		goto next_key;
 	}
@@ -1018,13 +1022,15 @@ vy_read_iterator_cache_add(struct vy_read_iterator *itr, struct vy_entry entry)
 		return;
 	}
 	vy_cache_add(&itr->lsm->cache, entry, itr->last_cached,
-		     itr->is_first_cached, itr->key, itr->iterator_type);
+		     itr->is_first_cached, itr->cache_link_lsn,
+		     itr->key, itr->iterator_type);
 	if (entry.stmt != NULL)
 		tuple_ref(entry.stmt);
 	if (itr->last_cached.stmt != NULL)
 		tuple_unref(itr->last_cached.stmt);
 	itr->last_cached = entry;
 	itr->is_first_cached = false;
+	itr->cache_link_lsn = 0;
 }
 
 /**

--- a/src/box/vy_read_iterator.c
+++ b/src/box/vy_read_iterator.c
@@ -995,6 +995,7 @@ next_key:
 			if (itr->last_cached.stmt != NULL)
 				tuple_unref(itr->last_cached.stmt);
 			itr->last_cached = vy_entry_none();
+			itr->is_first_cached = false;
 		}
 		goto next_key;
 	}

--- a/src/box/vy_read_iterator.h
+++ b/src/box/vy_read_iterator.h
@@ -79,6 +79,11 @@ struct vy_read_iterator {
 	 * See vy_read_iterator_cache_add().
 	 */
 	bool is_first_cached;
+	/**
+	 * LSN of the cache chain link following the last cached statement.
+	 * Used by vy_read_iterator_cache_add().
+	 */
+	int64_t cache_link_lsn;
 	/** Last statement returned by vy_read_iterator_next(). */
 	struct vy_entry last;
 	/**

--- a/src/box/vy_read_iterator.h
+++ b/src/box/vy_read_iterator.h
@@ -185,6 +185,8 @@ vy_read_iterator_next(struct vy_read_iterator *itr, struct vy_entry *result);
  * Add the last tuple returned by the read iterator to the cache.
  * @param itr   Read iterator
  * @param entry Last tuple returned by the iterator.
+ * @param skipped_lsn Max LSN among all full statements skipped because
+ *                    they didn't match the partial tuple key.
  *
  * We use a separate function for populating the cache rather than
  * doing that right in vy_read_iterator_next() so that we can store
@@ -196,9 +198,14 @@ vy_read_iterator_next(struct vy_read_iterator *itr, struct vy_entry *result);
  *   to the partial tuple returned by the iterator.
  * - Call vy_read_iterator_cache_add() on the full tuple to add
  *   the result to the cache.
+ *
+ * The skipped_lsn is used for the cache chain link. Basically, it's the max
+ * LSN over all deferred DELETE statements that fall between the previous and
+ * the current cache nodes.
  */
 void
-vy_read_iterator_cache_add(struct vy_read_iterator *itr, struct vy_entry entry);
+vy_read_iterator_cache_add(struct vy_read_iterator *itr, struct vy_entry entry,
+			   int64_t skipped_lsn);
 
 /**
  * Close the iterator and free resources.

--- a/src/box/vy_stmt.h
+++ b/src/box/vy_stmt.h
@@ -208,11 +208,21 @@ vy_stmt_set_lsn(struct tuple *stmt, int64_t lsn)
 	((struct vy_stmt *) stmt)->lsn = lsn;
 }
 
+/**
+ * Return true if the given LSN is a PLSN, i.e. an LSN used for a prepared
+ * (not yet written to WAL) statement.
+ */
+static inline bool
+vy_lsn_is_prepared(int64_t lsn)
+{
+	return lsn >= MAX_LSN;
+}
+
 /** Return true if the statement was prepared, but not yet written to WAL. */
 static inline bool
 vy_stmt_is_prepared(struct tuple *stmt)
 {
-	return vy_stmt_lsn(stmt) >= MAX_LSN;
+	return vy_lsn_is_prepared(vy_stmt_lsn(stmt));
 }
 
 /** Get type of the vinyl statement. */

--- a/test/unit/vy_iterators_helper.c
+++ b/test/unit/vy_iterators_helper.c
@@ -172,7 +172,7 @@ vy_cache_insert_templates_chain(struct vy_cache *cache,
 
 	for (uint i = 0; i < length; ++i) {
 		entry = vy_new_simple_stmt(format, cache->cmp_def, &chain[i]);
-		vy_cache_add(cache, entry, prev_entry, is_first, key, order);
+		vy_cache_add(cache, entry, prev_entry, is_first, 0, key, order);
 		if (i != 0)
 			tuple_unref(prev_entry.stmt);
 		prev_entry = entry;

--- a/test/unit/vy_point_lookup.c
+++ b/test/unit/vy_point_lookup.c
@@ -279,7 +279,8 @@ test_basic()
 			struct vy_entry key = vy_new_simple_stmt(format, key_def,
 								 &tmpl_key);
 			struct vy_entry res;
-			rc = vy_point_lookup(pk, NULL, &prv, key, &res);
+			rc = vy_point_lookup(pk, /*tx=*/NULL, &prv, key,
+					     /*keep_delete=*/false, &res);
 			tuple_unref(key.stmt);
 			if (rc != 0) {
 				has_errors = true;

--- a/test/vinyl-luatest/gh_11079_invisible_delete_caching_test.lua
+++ b/test/vinyl-luatest/gh_11079_invisible_delete_caching_test.lua
@@ -1,0 +1,65 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new({
+        box_cfg = {
+            vinyl_cache = 64 * 1024 * 1024,
+        },
+    })
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+g.test_tx_delete = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+
+        local s = box.schema.space.create('test', {engine = 'vinyl'})
+        s:create_index('primary')
+        for i = 10, 50, 10 do
+            s:insert({i})
+        end
+
+        local c1 = fiber.channel(1)
+        local c2 = fiber.channel(1)
+        local f = fiber.new(function()
+            box.begin()
+            s:delete({10})
+            s:delete({30})
+            s:delete({50})
+            s:select()
+            s:select({}, {iterator = 'lt'})
+            c1:put(true)
+            c2:get()
+            box.commit()
+        end)
+        f:set_joinable(true)
+        t.assert_equals(c1:get(5), true)
+
+        -- The DELETE statements must be invisible because they haven't been
+        -- committed yet.
+        t.assert_equals(s:select(), {{10}, {20}, {30}, {40}, {50}})
+        t.assert_equals(s:select({}, {iterator = 'lt'}),
+                        {{50}, {40}, {30}, {20}, {10}})
+
+        c2:put(true)
+        t.assert_equals({f:join(5)}, {true})
+
+        t.assert_equals(s:select(), {{20}, {40}})
+        t.assert_equals(s:select({}, {iterator = 'lt'}), {{40}, {20}})
+    end)
+end

--- a/test/vinyl-luatest/gh_11079_invisible_delete_caching_test.lua
+++ b/test/vinyl-luatest/gh_11079_invisible_delete_caching_test.lua
@@ -63,3 +63,90 @@ g.test_tx_delete = function(cg)
         t.assert_equals(s:select({}, {iterator = 'lt'}), {{40}, {20}})
     end)
 end
+
+g.test_prepared_delete = function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server:exec(function()
+        local fiber = require('fiber')
+
+        local s = box.schema.space.create('test', {engine = 'vinyl'})
+        s:create_index('primary')
+        for i = 10, 50, 10 do
+            s:insert({i})
+        end
+
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+
+        local c = fiber.channel(1)
+        local f = fiber.new(function()
+            box.begin()
+            s:delete({10})
+            s:delete({30})
+            s:delete({50})
+            c:put(true)
+            box.commit()
+        end)
+        f:set_joinable(true)
+        t.assert_equals(c:get(5), true)
+
+        -- The DELETE statements must be visible with the 'read-committed'
+        -- isolation level, but not with 'read-confirmed' because they haven't
+        -- been written to the WAL yet.
+        box.begin{txn_isolation = 'read-committed'}
+        t.assert_equals(s:select(), {{20}, {40}})
+        t.assert_equals(s:select({}, {iterator = 'lt'}), {{40}, {20}})
+        box.commit()
+
+        box.begin{txn_isolation = 'read-confirmed'}
+        t.assert_equals(s:select(), {{10}, {20}, {30}, {40}, {50}})
+        t.assert_equals(s:select({}, {iterator = 'lt'}),
+                        {{50}, {40}, {30}, {20}, {10}})
+        box.commit()
+
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        t.assert_equals({f:join(5)}, {true})
+    end)
+end
+
+g.after_test('test_prepared_delete', function(cg)
+    cg.server:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+    end)
+end)
+
+g.test_confirmed_delete = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+
+        local s = box.schema.space.create('test', {engine = 'vinyl'})
+        s:create_index('primary')
+        for i = 10, 50, 10 do
+            s:insert({i})
+        end
+
+        box.begin()
+        t.assert_equals(s:get(30), {30})
+
+        local f = fiber.new(function()
+            box.begin()
+            s:delete({10})
+            s:delete({30})
+            s:delete({50})
+            box.commit()
+            s:select()
+            s:select({}, {iterator = 'lt'})
+        end)
+        f:set_joinable(true)
+        t.assert_equals({f:join(5)}, {true})
+
+        -- The transaction must be able to see the deleted tuples because
+        -- it was sent to a read view on deletion.
+        t.assert_equals(s:select(), {{10}, {20}, {30}, {40}, {50}})
+        t.assert_equals(s:select({}, {iterator = 'lt'}),
+                        {{50}, {40}, {30}, {20}, {10}})
+        box.commit()
+
+        t.assert_equals(s:select(), {{20}, {40}})
+        t.assert_equals(s:select({}, {iterator = 'lt'}), {{40}, {20}})
+    end)
+end

--- a/test/vinyl/cache.result
+++ b/test/vinyl/cache.result
@@ -1033,14 +1033,14 @@ for i = 1, 100 do s:get{i} end
 ...
 box.stat.vinyl().memory.tuple_cache
 ---
-- 107700
+- 109300
 ...
 box.cfg{vinyl_cache = 50 * 1000}
 ---
 ...
 box.stat.vinyl().memory.tuple_cache
 ---
-- 49542
+- 49185
 ...
 box.cfg{vinyl_cache = 0}
 ---
@@ -1116,7 +1116,7 @@ s.index.i2:count()
 ...
 box.stat.vinyl().memory.tuple_cache -- should be about 200 KB
 ---
-- 218400
+- 223200
 ...
 s:drop()
 ---

--- a/test/vinyl/deferred_delete.result
+++ b/test/vinyl/deferred_delete.result
@@ -87,9 +87,9 @@ pk:stat().get.rows -- 5
 ---
 - 5
 ...
-pk:stat().skip.rows -- 5
+pk:stat().skip.rows -- 10
 ---
-- 5
+- 10
 ...
 i2:select()
 ---
@@ -115,9 +115,9 @@ pk:stat().get.rows -- 10
 ---
 - 10
 ...
-pk:stat().skip.rows -- 10
+pk:stat().skip.rows -- 20
 ---
-- 10
+- 20
 ...
 -- Overwritten/deleted tuples are not stored in the cache so calling
 -- SELECT for a second time does only 5 lookups.

--- a/test/vinyl/deferred_delete.test.lua
+++ b/test/vinyl/deferred_delete.test.lua
@@ -37,13 +37,13 @@ i1:stat().get.rows -- 5
 i1:stat().skip.rows -- 10
 pk:stat().lookup -- 15
 pk:stat().get.rows -- 5
-pk:stat().skip.rows -- 5
+pk:stat().skip.rows -- 10
 i2:select()
 i2:stat().get.rows -- 5
 i2:stat().skip.rows -- 10
 pk:stat().lookup -- 30
 pk:stat().get.rows -- 10
-pk:stat().skip.rows -- 10
+pk:stat().skip.rows -- 20
 
 -- Overwritten/deleted tuples are not stored in the cache so calling
 -- SELECT for a second time does only 5 lookups.

--- a/test/vinyl/stat.result
+++ b/test/vinyl/stat.result
@@ -789,7 +789,7 @@ _ = s:get(1)
 ...
 stat_diff(gstat(), st, 'memory.tuple_cache')
 ---
-- 1101
+- 1117
 ...
 s:delete(1)
 ---
@@ -1152,7 +1152,7 @@ gstat()
     gap_locks: 0
     read_views: 0
   memory:
-    tuple_cache: 14313
+    tuple_cache: 14521
     tx: 0
     bloom_filter: 140
     page_index: 1250


### PR DESCRIPTION
This commit fixes a few issues in the tuple cache when a transaction operating in a read view could skip tuples deleted after the read view was created.

Closes #11079