### PR TITLE
config: structurize applier/box_cfg

### DIFF
--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -32,6 +32,8 @@ end
 
 -- }}} iproto.listen
 
+-- {{{ replication.peers
+
 local function peer_uris(configdata)
     local peers = configdata:peers()
     if #peers <= 1 then
@@ -93,6 +95,15 @@ local function peer_uris(configdata)
 
     return uris
 end
+
+local function set_replication_peers(configdata, box_cfg)
+    -- Construct box_cfg.replication.
+    if box_cfg.replication == nil then
+        box_cfg.replication = peer_uris(configdata)
+    end
+end
+
+-- }}} replication.peers
 
 -- Modify box-level configuration values and perform other actions
 -- to enable the isolated mode (if configured).
@@ -582,11 +593,7 @@ local function apply(config)
 
     local box_cfg = collect_by_box_cfg_annotation(configdata)
     set_iproto_listen(configdata, box_cfg)
-
-    -- Construct box_cfg.replication.
-    if box_cfg.replication == nil then
-        box_cfg.replication = peer_uris(configdata)
-    end
+    set_replication_peers(configdata, box_cfg)
 
     -- Construct logger destination (box_cfg.log) and log modules.
     --

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -183,6 +183,19 @@ end
 
 -- }}} audit_log
 
+-- {{{ wal.ext
+
+local function set_wal_ext(_configdata, box_cfg)
+    -- TODO(gh-10756): This is not needed when :apply_default()
+    -- supports default values for composite types.
+    if tarantool.package == 'Tarantool Enterprise' and
+       type(box_cfg.wal_ext) == 'nil' then
+        box_cfg.wal_ext = box.NULL
+    end
+end
+
+-- }}} wal.ext
+
 -- Modify box-level configuration values and perform other actions
 -- to enable the isolated mode (if configured).
 local function switch_isolated_mode_before_box_cfg(config, box_cfg)
@@ -649,13 +662,7 @@ local function apply(config)
     set_replication_peers(configdata, box_cfg)
     set_log(configdata, box_cfg)
     set_audit_log(configdata, box_cfg)
-
-    -- TODO(gh-10756): This is not needed when :apply_default()
-    -- supports default values for composite types.
-    if tarantool.package == 'Tarantool Enterprise' and
-       type(box_cfg.wal_ext) == 'nil' then
-        box_cfg.wal_ext = box.NULL
-    end
+    set_wal_ext(configdata, box_cfg)
 
     -- The startup process may need a special handling and differs
     -- from the configuration reloading process.

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -700,6 +700,14 @@ end
 
 -- }}} Instance/replicaset names
 
+-- {{{ <replicaset>.bootstrap_leader
+
+local function set_bootstrap_leader(configdata, box_cfg)
+    box_cfg.bootstrap_leader = configdata:bootstrap_leader()
+end
+
+-- }}} <replicaset>.bootstrap_leader
+
 -- Modify box-level configuration values and perform other actions
 -- to enable the isolated mode (if configured).
 local function switch_isolated_mode_before_box_cfg(config, box_cfg)
@@ -928,9 +936,7 @@ local function apply(config)
     set_ro_rw(configdata, box_cfg)
     revert_non_dynamic_options(config, box_cfg)
     set_names_in_background(config, box_cfg)
-
-    -- Set bootstrap_leader option.
-    box_cfg.bootstrap_leader = configdata:bootstrap_leader()
+    set_bootstrap_leader(configdata, box_cfg)
 
     local names = configdata:names()
 

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -19,6 +19,19 @@ end
 
 -- }}} Collect options with the box_cfg annotation
 
+-- {{{ iproto.listen
+
+local function set_iproto_listen(configdata, box_cfg)
+    -- Explicitly set box_cfg.listen to box.NULL if iproto.listen is not
+    -- provided.
+    -- TODO: drop this when default for array value will be supported.
+    if configdata:get('iproto.listen') == nil then
+        box_cfg.listen = box.NULL
+    end
+end
+
+-- }}} iproto.listen
+
 local function peer_uris(configdata)
     local peers = configdata:peers()
     if #peers <= 1 then
@@ -568,13 +581,7 @@ local function apply(config)
     local configdata = config._configdata
 
     local box_cfg = collect_by_box_cfg_annotation(configdata)
-
-    -- Explicitly set box_cfg.listen to box.NULL if iproto.listen is not
-    -- provided.
-    -- TODO: drop this when default for array value will be supported.
-    if configdata:get('iproto.listen') == nil then
-        box_cfg.listen = box.NULL
-    end
+    set_iproto_listen(configdata, box_cfg)
 
     -- Construct box_cfg.replication.
     if box_cfg.replication == nil then

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -726,6 +726,8 @@ end
 
 -- }}} metrics
 
+-- {{{ isolated
+
 -- Modify box-level configuration values and perform other actions
 -- to enable the isolated mode (if configured).
 local function switch_isolated_mode_before_box_cfg(config, box_cfg)
@@ -897,6 +899,13 @@ local function switch_isolated_mode_after_box_cfg(config)
     end)
 end
 
+local function set_isolated(config, box_cfg, post_box_cfg_hooks)
+    switch_isolated_mode_before_box_cfg(config, box_cfg)
+    post_box_cfg_hooks:add(switch_isolated_mode_after_box_cfg, config)
+end
+
+-- }}} isolated
+
 -- See hooks_new().
 local hooks_mt = {
     __index = {
@@ -959,8 +968,7 @@ local function apply(config)
 
     -- RO may be enforced by the isolated mode, so we call the
     -- function after all the other logic that may set RW.
-    switch_isolated_mode_before_box_cfg(config, box_cfg)
-    post_box_cfg_hooks:add(switch_isolated_mode_after_box_cfg, config)
+    set_isolated(config, box_cfg, post_box_cfg_hooks)
 
     local is_startup = type(box.cfg) == 'function'
     local names = configdata:names()


### PR DESCRIPTION
The patchset splits the large apply() function in the `box_cfg` configuration applier into meaningful pieces. This way it is easier to navigate over this code.