### PR TITLE
config: simplify scope validation code

### DIFF
--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1234,6 +1234,7 @@ return schema.new('instance_config', schema.record({
             'supervised',
         }, {
             default = 'off',
+            validate = validators['replication.failover'],
         }),
         -- XXX: needs more validation
         peers = schema.array({
@@ -2195,18 +2196,6 @@ return schema.new('instance_config', schema.record({
         default = false,
         validate = validators['isolated'],
     }),
-}, {
-    -- This kind of validation cannot be implemented as the
-    -- 'validate' annotation of a particular schema node. There
-    -- are two reasons:
-    --
-    -- * Missed fields are not validated.
-    -- * The outmost instance config record is marked with the
-    --   'scope' annotation (when the instance config is part of
-    --   the cluster config), but this annotation is not easy to
-    --   reach from the 'validate' function of a nested schema
-    --   node.
-    validate = validators[''],
 }), {
     methods = {
         instance_uri = instance_uri,

--- a/src/box/lua/config/validators.lua
+++ b/src/box/lua/config/validators.lua
@@ -153,8 +153,8 @@ end
 
 M['config.storage.endpoints'] = function(data, w)
     if #data == 0 then
-        w.error('At least one endpoint must be' ..
-            'specified in config.storage.endpoints')
+        w.error('At least one endpoint must be specified in ' ..
+            'config.storage.endpoints')
     end
 end
 

--- a/src/box/lua/config/validators.lua
+++ b/src/box/lua/config/validators.lua
@@ -361,158 +361,60 @@ M['sharding'] = function(data, w)
     end
 end
 
-M['sharding.bucket_count'] = function(data, w)
-    local scope = w.schema.computed.annotations.scope
-    if data == nil or scope == nil then
-        return
-    end
-    if scope ~= 'global' then
-        w.error('sharding.bucket_count should be a defined in '..
-                'global scope')
-    end
+M['sharding.bucket_count'] = function(_data, w)
+    validate_scope(w, {'global'})
 end
 
-M['sharding.connection_outdate_delay'] = function(data, w)
-    local scope = w.schema.computed.annotations.scope
-    if data == nil or scope == nil then
-        return
-    end
-    if scope ~= 'global' then
-        w.error('sharding.connection_outdate_delay should be a '..
-                'defined in global scope')
-    end
+M['sharding.connection_outdate_delay'] = function(_data, w)
+    validate_scope(w, {'global'})
 end
 
-M['sharding.discovery_mode'] = function(data, w)
-    local scope = w.schema.computed.annotations.scope
-    if data == nil or scope == nil then
-        return
-    end
-    if scope ~= 'global' then
-        w.error('sharding.discovery_mode should be a defined in '..
-                'global scope')
-    end
+M['sharding.discovery_mode'] = function(_data, w)
+    validate_scope(w, {'global'})
 end
 
-M['sharding.failover_ping_timeout'] = function(data, w)
-    local scope = w.schema.computed.annotations.scope
-    if data == nil or scope == nil then
-        return
-    end
-    if scope ~= 'global' then
-        w.error('sharding.failover_ping_timeout should be a '..
-                'defined in global scope')
-    end
+M['sharding.failover_ping_timeout'] = function(_data, w)
+    validate_scope(w, {'global'})
 end
 
-M['sharding.lock'] = function(data, w)
-    local scope = w.schema.computed.annotations.scope
-    if data == nil or scope == nil then
-        return
-    end
-    if scope == 'instance' then
-        w.error('sharding.lock cannot be defined in the instance '..
-                'scope')
-    end
+M['sharding.lock'] = function(_data, w)
+    validate_scope(w, {'global', 'group', 'replicaset'})
 end
 
-M['sharding.rebalancer_disbalance_threshold'] = function(data, w)
-    local scope = w.schema.computed.annotations.scope
-    if data == nil or scope == nil then
-        return
-    end
-    if scope ~= 'global' then
-        w.error('sharding.rebalancer_disbalance_threshold should '..
-                'be a defined in global scope')
-    end
+M['sharding.rebalancer_disbalance_threshold'] = function(_data, w)
+    validate_scope(w, {'global'})
 end
 
-M['sharding.rebalancer_max_receiving'] = function(data, w)
-    local scope = w.schema.computed.annotations.scope
-    if data == nil or scope == nil then
-        return
-    end
-    if scope ~= 'global' then
-        w.error('sharding.rebalancer_max_receiving should '..
-                'be a defined in global scope')
-    end
+M['sharding.rebalancer_max_receiving'] = function(_data, w)
+    validate_scope(w, {'global'})
 end
 
-M['sharding.rebalancer_max_sending'] = function(data, w)
-    local scope = w.schema.computed.annotations.scope
-    if data == nil or scope == nil then
-        return
-    end
-    if scope ~= 'global' then
-        w.error('sharding.rebalancer_max_sending should '..
-                'be a defined in global scope')
-    end
+M['sharding.rebalancer_max_sending'] = function(_data, w)
+    validate_scope(w, {'global'})
 end
 
-M['sharding.rebalancer_mode'] = function(data, w)
-    local scope = w.schema.computed.annotations.scope
-    if data == nil or scope == nil then
-        return
-    end
-    if scope ~= 'global' then
-        w.error('sharding.rebalancer_enabled must be defined in ' ..
-                'the global scope.')
-    end
+M['sharding.rebalancer_mode'] = function(_data, w)
+    validate_scope(w, {'global'})
 end
 
-M['sharding.sched_move_quota'] = function(data, w)
-    local scope = w.schema.computed.annotations.scope
-    if data == nil or scope == nil then
-        return
-    end
-    if scope ~= 'global' then
-        w.error('sharding.sched_move_quota should be a defined ' ..
-                'in global scope')
-    end
+M['sharding.sched_move_quota'] = function(_data, w)
+    validate_scope(w, {'global'})
 end
 
-M['sharding.sched_ref_quota'] = function(data, w)
-    local scope = w.schema.computed.annotations.scope
-    if data == nil or scope == nil then
-        return
-    end
-    if scope ~= 'global' then
-        w.error('sharding.sched_ref_quota should be a defined ' ..
-                'in global scope')
-    end
+M['sharding.sched_ref_quota'] = function(_data, w)
+    validate_scope(w, {'global'})
 end
 
-M['sharding.shard_index'] = function(data, w)
-    local scope = w.schema.computed.annotations.scope
-    if data == nil or scope == nil then
-        return
-    end
-    if scope ~= 'global' then
-        w.error('sharding.shard_index should be a defined in '..
-                'global scope')
-    end
+M['sharding.shard_index'] = function(_data, w)
+    validate_scope(w, {'global'})
 end
 
-M['sharding.sync_timeout'] = function(data, w)
-    local scope = w.schema.computed.annotations.scope
-    if data == nil or scope == nil then
-        return
-    end
-    if scope ~= 'global' then
-        w.error('sharding.sync_timeout should be a defined in '..
-                'global scope')
-    end
+M['sharding.sync_timeout'] = function(_data, w)
+    validate_scope(w, {'global'})
 end
 
-M['sharding.weight'] = function(data, w)
-    local scope = w.schema.computed.annotations.scope
-    if data == nil or scope == nil then
-        return
-    end
-    if scope == 'instance' then
-        w.error('sharding.weight cannot be defined in the ' ..
-                'instance scope')
-    end
+M['sharding.weight'] = function(_data, w)
+    validate_scope(w, {'global', 'group', 'replicaset'})
 end
 
 -- }}} sharding

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -762,6 +762,8 @@ end
 --
 -- * isolated
 -- * replication.autoexpel
+-- * failover
+-- * replication.failover
 g.test_scope = function()
     local function exp_err(path, scope)
         return ('[cluster_config] %s: The option must not be present in the ' ..
@@ -805,6 +807,18 @@ g.test_scope = function()
             global = true,
             group = false,
             replicaset = false,
+            instance = false,
+        },
+        {
+            name = 'replication.failover',
+            data = {
+                replication = {
+                    failover = 'manual',
+                },
+            },
+            global = true,
+            group = true,
+            replicaset = true,
             instance = false,
         },
     }

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -764,6 +764,20 @@ end
 -- * replication.autoexpel
 -- * failover
 -- * replication.failover
+-- * sharding.bucket_count
+-- * sharding.connection_outdate_delay
+-- * sharding.discovery_mode
+-- * sharding.failover_ping_timeout
+-- * sharding.lock
+-- * sharding.rebalancer_disbalance_threshold
+-- * sharding.rebalancer_max_receiving
+-- * sharding.rebalancer_max_sending
+-- * sharding.rebalancer_mode
+-- * sharding.sched_move_quota
+-- * sharding.sched_ref_quota
+-- * sharding.shard_index
+-- * sharding.sync_timeout
+-- * sharding.weight
 g.test_scope = function()
     local function exp_err(path, scope)
         return ('[cluster_config] %s: The option must not be present in the ' ..
@@ -814,6 +828,174 @@ g.test_scope = function()
             data = {
                 replication = {
                     failover = 'manual',
+                },
+            },
+            global = true,
+            group = true,
+            replicaset = true,
+            instance = false,
+        },
+        {
+            name = 'sharding.bucket_count',
+            data = {
+                sharding = {
+                    bucket_count = 30000,
+                },
+            },
+            global = true,
+            group = false,
+            replicaset = false,
+            instance = false,
+        },
+        {
+            name = 'sharding.connection_outdate_delay',
+            data = {
+                sharding = {
+                    connection_outdate_delay = 10,
+                },
+            },
+            global = true,
+            group = false,
+            replicaset = false,
+            instance = false,
+        },
+        {
+            name = 'sharding.discovery_mode',
+            data = {
+                sharding = {
+                    discovery_mode = 'off',
+                },
+            },
+            global = true,
+            group = false,
+            replicaset = false,
+            instance = false,
+        },
+        {
+            name = 'sharding.failover_ping_timeout',
+            data = {
+                sharding = {
+                    failover_ping_timeout = 10,
+                },
+            },
+            global = true,
+            group = false,
+            replicaset = false,
+            instance = false,
+        },
+        {
+            name = 'sharding.lock',
+            data = {
+                sharding = {
+                    lock = true,
+                },
+            },
+            global = true,
+            group = true,
+            replicaset = true,
+            instance = false,
+        },
+        {
+            name = 'sharding.rebalancer_disbalance_threshold',
+            data = {
+                sharding = {
+                    rebalancer_disbalance_threshold = 7,
+                },
+            },
+            global = true,
+            group = false,
+            replicaset = false,
+            instance = false,
+        },
+        {
+            name = 'sharding.rebalancer_max_receiving',
+            data = {
+                sharding = {
+                    rebalancer_max_receiving = 1000,
+                },
+            },
+            global = true,
+            group = false,
+            replicaset = false,
+            instance = false,
+        },
+        {
+            name = 'sharding.rebalancer_max_sending',
+            data = {
+                sharding = {
+                    rebalancer_max_sending = 10,
+                },
+            },
+            global = true,
+            group = false,
+            replicaset = false,
+            instance = false,
+        },
+        {
+            name = 'sharding.rebalancer_mode',
+            data = {
+                sharding = {
+                    rebalancer_mode = 'off',
+                },
+            },
+            global = true,
+            group = false,
+            replicaset = false,
+            instance = false,
+        },
+        {
+            name = 'sharding.sched_move_quota',
+            data = {
+                sharding = {
+                    sched_move_quota = 10,
+                },
+            },
+            global = true,
+            group = false,
+            replicaset = false,
+            instance = false,
+        },
+        {
+            name = 'sharding.sched_ref_quota',
+            data = {
+                sharding = {
+                    sched_ref_quota = 1000,
+                },
+            },
+            global = true,
+            group = false,
+            replicaset = false,
+            instance = false,
+        },
+        {
+            name = 'sharding.shard_index',
+            data = {
+                sharding = {
+                    shard_index = 'my_bucket_id',
+                },
+            },
+            global = true,
+            group = false,
+            replicaset = false,
+            instance = false,
+        },
+        {
+            name = 'sharding.sync_timeout',
+            data = {
+                sharding = {
+                    sync_timeout = 10,
+                },
+            },
+            global = true,
+            group = false,
+            replicaset = false,
+            instance = false,
+        },
+        {
+            name = 'sharding.weight',
+            data = {
+                sharding = {
+                    weight = 10,
                 },
             },
             global = true,

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -77,6 +77,25 @@ g.test_config = function()
     t.assert_equals(res, exp)
 end
 
+-- If the array of the endpoints is provided, it should be
+-- non-empty.
+g.test_config_storage_empty_endpoints = function()
+    local iconfig = {
+        config = {
+            storage = {
+                prefix = '/foo',
+                endpoints = {},
+            },
+        },
+    }
+
+    local exp_err = '[instance_config] config.storage.endpoints: At least ' ..
+        'one endpoint must be specified in config.storage.endpoints'
+    t.assert_error_msg_equals(exp_err, function()
+        instance_config:validate(iconfig)
+    end)
+end
+
 g.test_config_enterprise = function()
     t.tarantool.skip_if_not_enterprise()
     local iconfig = {


### PR DESCRIPTION
This patchset revisits `replication.failover` and `sharding.*` scope validation code. It uses the computed annotations feature (see 4ddb9f21f6b6) to simplify these checks and reduces code duplication.

No functional changes except wording in validation failure messages.