### PR TITLE
ci: deploy Ubuntu Noble (24.04) packages

### DIFF
--- a/.github/workflows/ubuntu_24_04.yml
+++ b/.github/workflows/ubuntu_24_04.yml
@@ -1,0 +1,86 @@
+name: ubuntu_24_04
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/**'
+    tags:
+      - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
+
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch, and
+  # tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+jobs:
+  ubuntu_24_04:
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+
+    runs-on: ubuntu-20.04-self-hosted
+
+    timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build-type: [ '', 'gc64' ]
+
+    steps:
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: packaging
+        env:
+          RWS_AUTH: ${{ secrets.RWS_AUTH }}
+          OS: 'ubuntu'
+          DIST: 'noble'
+          GC64: ${{ matrix.build-type == 'gc64' }}
+        uses: ./.github/actions/pack-and-deploy
+      - name: Send VK Teams message on failure
+        if: failure()
+        uses: ./.github/actions/report-job-status
+        with:
+          bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
+      - name: artifacts
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: ubuntu-noble${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
+          retention-days: 21
+          path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/release/') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/.github/workflows/ubuntu_24_04_aarch64.yml
+++ b/.github/workflows/ubuntu_24_04_aarch64.yml
@@ -1,0 +1,85 @@
+name: ubuntu_24_04_aarch64
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/**'
+    tags:
+      - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
+
+concurrency:
+  # Update of a developer branch cancels the previously scheduled workflow
+  # run for this branch. However, the 'master' branch, release branch, and
+  # tag workflow runs are never canceled.
+  #
+  # We use a trick here: define the concurrency group as 'workflow run ID' +
+  # 'workflow run attempt' because it is a unique combination for any run.
+  # So it effectively discards grouping.
+  #
+  # Important: we cannot use `github.sha` as a unique identifier because
+  # pushing a tag may cancel a run that works on a branch push event.
+  group: ${{ (
+    github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/heads/release/') ||
+    startsWith(github.ref, 'refs/tags/')) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+jobs:
+  ubuntu_24_04_aarch64:
+    # Run on push to the 'master' and release branches of tarantool/tarantool
+    # or on pull request if the 'full-ci' label is set.
+    if: github.repository == 'tarantool/tarantool' &&
+        ( github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'full-ci') )
+
+    runs-on: graviton
+
+    timeout-minutes: 60
+
+    steps:
+      - name: Prepare checkout
+        uses: tarantool/actions/prepare-checkout@master
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - name: packaging
+        env:
+          RWS_AUTH: ${{ secrets.RWS_AUTH }}
+          OS: 'ubuntu'
+          DIST: 'noble'
+          # We're using LXD containers as aarch64 runners. For some reason, OOM
+          # killer just kills the compilation process when `make -j $(nproc)`.
+          # The issue happens only with builds where LTO is enabled. It's found,
+          # that `-j4` works fine. The bigger value causes problems.
+          SMPFLAGS: '-j4'
+        uses: ./.github/actions/pack-and-deploy
+      - name: Send VK Teams message on failure
+        if: failure()
+        uses: ./.github/actions/report-job-status
+        with:
+          bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
+      - name: artifacts
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: ubuntu-noble
+          retention-days: 21
+          path: ${{ env.VARDIR }}/artifacts
+      - name: Upload artifacts to S3
+        uses: ./.github/actions/s3-upload-artifact
+        if: ( success() || failure() ) && ( github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/release/') ||
+          startsWith(github.ref, 'refs/tags/') )
+        with:
+          job-name: ${{ github.job }}
+          access-key-id: ${{ secrets.MULTIVAC_S3_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MULTIVAC_S3_SECRET_ACCESS_KEY }}
+          source: ${{ env.VARDIR }}/artifacts

--- a/changelogs/unreleased/add-ubuntu-noble.md
+++ b/changelogs/unreleased/add-ubuntu-noble.md
@@ -1,0 +1,3 @@
+## bugfix/build
+
+* Ubuntu Noble (24.04) is now supported.


### PR DESCRIPTION
Copy workflow files for Ubuntu Jammy (22.04) with replacing `22.04` -> `24.04` and `jammy` -> `noble`.

<details>
<summary><code>diff -u .github/workflows/ubuntu_{22_04,24_04}.yml</code></summary>

```diff
--- .github/workflows/ubuntu_22_04.yml
+++ .github/workflows/ubuntu_24_04.yml
@@ -1,4 +1,4 @@
-name: ubuntu_22_04
+name: ubuntu_24_04

 on:
   push:
@@ -31,7 +31,7 @@
   cancel-in-progress: true

 jobs:
-  ubuntu_22_04:
+  ubuntu_24_04:
     # Run on push to the 'master' and release branches of tarantool/tarantool
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
@@ -59,7 +59,7 @@
         env:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'ubuntu'
-          DIST: 'jammy'
+          DIST: 'noble'
           GC64: ${{ matrix.build-type == 'gc64' }}
         uses: ./.github/actions/pack-and-deploy
       - name: Send VK Teams message on failure
@@ -71,7 +71,7 @@
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: ubuntu-jammy${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
+          name: ubuntu-noble${{ matrix.build-type == 'gc64' && '-gc64' || '' }}
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
       - name: Upload artifacts to S3
```
</details>

<details>
<summary><code>diff -u .github/workflows/ubuntu_{22_04,24_04}_aarch64.yml</code></summary>

```diff
--- .github/workflows/ubuntu_22_04_aarch64.yml
+++ .github/workflows/ubuntu_24_04_aarch64.yml
@@ -1,4 +1,4 @@
-name: ubuntu_22_04_aarch64
+name: ubuntu_24_04_aarch64

 on:
   push:
@@ -31,7 +31,7 @@
   cancel-in-progress: true

 jobs:
-  ubuntu_22_04_aarch64:
+  ubuntu_24_04_aarch64:
     # Run on push to the 'master' and release branches of tarantool/tarantool
     # or on pull request if the 'full-ci' label is set.
     if: github.repository == 'tarantool/tarantool' &&
@@ -54,7 +54,7 @@
         env:
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           OS: 'ubuntu'
-          DIST: 'jammy'
+          DIST: 'noble'
           # We're using LXD containers as aarch64 runners. For some reason, OOM
           # killer just kills the compilation process when `make -j $(nproc)`.
           # The issue happens only with builds where LTO is enabled. It's found,
@@ -70,7 +70,7 @@
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: ubuntu-jammy
+          name: ubuntu-noble
           retention-days: 21
           path: ${{ env.VARDIR }}/artifacts
       - name: Upload artifacts to S3
```
</details>

The building and deployment infrastructure is already prepared for Ubuntu Noble:

* https://github.com/packpack/packpack-docker-images/pull/118
* https://github.com/tarantool/rws/pull/97