### PR TITLE
memtx: fix a crash caused by mhash misusage in MVCC

### DIFF
--- a/changelogs/unreleased/gh-11022-memtx-mvcc-point-holes-mhash-abort.md
+++ b/changelogs/unreleased/gh-11022-memtx-mvcc-point-holes-mhash-abort.md
@@ -1,0 +1,4 @@
+## bugfix/memtx
+
+* Fixed a bug when Tarantool with memtx MVCC enabled was aborted on
+  workload with many `index:get()` operations reading nothing (gh-11022).

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1568,6 +1568,11 @@ memtx_tx_handle_point_hole_write(struct space *space, struct memtx_story *story,
 	if (pos == mh_end(ht))
 		return;
 	struct point_hole_item *item = *mh_point_holes_node(ht, pos);
+	/*
+	 * Remove from the storage before deleting the element because
+	 * it still can be used under the hood.
+	 */
+	mh_point_holes_del(ht, pos, 0);
 
 	struct memtx_tx_mempool *pool = &txm.point_hole_item_pool;
 	bool has_more_items;
@@ -1585,8 +1590,6 @@ memtx_tx_handle_point_hole_write(struct space *space, struct memtx_story *story,
 
 		item = next_item;
 	} while (has_more_items);
-
-	mh_point_holes_del(ht, pos, 0);
 }
 
 static bool
@@ -3282,12 +3285,10 @@ point_hole_storage_delete(struct point_hole_item *object)
 		 * Hash table point to this item, and it's the last in the
 		 * list. We have to remove the item from the hash table.
 		 */
-		int exist = 0;
-		const struct point_hole_item **put =
-			(const struct point_hole_item **) &object;
-		mh_int_t pos = mh_point_holes_put_slot(txm.point_holes, put,
-						       &exist, 0);
-		assert(exist);
+		const struct point_hole_item **key =
+			(const struct point_hole_item **)&object;
+		mh_int_t pos = mh_point_holes_get(txm.point_holes, key, 0);
+		assert(pos != mh_end(txm.point_holes));
 		mh_point_holes_del(txm.point_holes, pos, 0);
 	}
 	rlist_del(&object->in_point_holes_list);

--- a/test/box-luatest/gh_11022_memtx_mvcc_point_hole_mhash_abort_test.lua
+++ b/test/box-luatest/gh_11022_memtx_mvcc_point_hole_mhash_abort_test.lua
@@ -1,0 +1,49 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function()
+    g.server = server:new{box_cfg = {memtx_use_mvcc_engine = true}}
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:drop()
+end)
+
+-- The test catches a moment when mhash is being incrementally resized
+-- and deletes a point hole tracker then - it caused crash because we have
+-- deleted the item and only then removed it from the mhash. If incremental
+-- resize is in progress, the element could be still used to calculate bucket
+-- of the element in the shadow hash table.
+g.test_point_holes_mhash_abort = function()
+    g.server:exec(function()
+        local fiber = require('fiber')
+        local s = box.schema.space.create('test')
+        s:create_index('pk')
+
+        -- Two cursors - for gets and for replaces
+        local get_i = 1
+        local replace_i = 1
+
+        -- On each step, get two times and replace one time.
+        -- Thus, the hash table of point hole items will grow
+        -- by 1 on each step - each get populates it with one more
+        -- item, and each replace deletes one.
+        -- Also, we will definitely catch a moment when a point hole item
+        -- is deleted during the resize because we delete them as often
+        -- as possible.
+        fiber.set_max_slice(30)
+        box.begin()
+        for _ = 1, 10000 do
+            s:get{get_i}
+            get_i = get_i + 1
+            s:get{get_i}
+            get_i = get_i + 1
+            s:replace{replace_i}
+            replace_i = replace_i + 1
+        end
+        box.commit()
+    end)
+end


### PR DESCRIPTION
We use mhash in memtx MVCC to store trackers of reads that have read nothing, we call them point holes. When handling a write to such hole, the tracker should be deleted because we can use the new tuple to store reads instead. Deletion flow in mhash is: we find bucket of the element with `find`, then we free the bucket with `del`. It can seem that the element is not needed on `del` because bucket id is used. However, it can be used on incremental resize of mhash. And, since we delete the point holes before releasing the bucket in mhash, in the rare case of incremental resize Tarantool will be aborted by mhash consistency check. The commit fixes the problem - simply release the bucket before deleting the object.

Along the way, the commit fixes another misusage that doesn't acutally break something. Method `put_slot` is internal so shouldn't be used manually - let's use more convenient `get` instead.

Closes #11022