### PR TITLE
vinyl: don't create cache chain over unconfirmed deferred DELETE

### DIFF
--- a/changelogs/unreleased/gh-11140-vy-deferred-delete-rollback-fix.md
+++ b/changelogs/unreleased/gh-11140-vy-deferred-delete-rollback-fix.md
@@ -1,0 +1,5 @@
+## bugfix/vinyl
+
+* Fixed a bug in the tuple cache when a tuple could become inaccessible via
+  a secondary index after a transaction rollback caused by a WAL write error
+  (gh-11140).

--- a/test/vinyl-luatest/gh_11140_deferred_delete_rollback_test.lua
+++ b/test/vinyl-luatest/gh_11140_deferred_delete_rollback_test.lua
@@ -1,0 +1,82 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new({
+        box_cfg = {
+            vinyl_cache = 64 * 1024 * 1024,
+        },
+    })
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_deferred_delete_rollback = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+
+        local s = box.schema.space.create('test', {
+            engine = 'vinyl', defer_deletes = true,
+        })
+        s:create_index('primary')
+        s:create_index('secondary', {unique = false, parts = {2, 'unsigned'}})
+
+        s:insert{1, 10}
+        s:insert{2, 20}
+        s:insert{3, 30}
+        s:insert{4, 40}
+        s:insert{5, 50}
+        box.snapshot()
+
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+
+        local f = fiber.new(function()
+            box.begin()
+            s:delete({1})
+            s:delete({3})
+            s:delete({5})
+            box.commit()
+        end)
+        f:set_joinable(true)
+        fiber.yield()
+
+        box.begin{txn_isolation = 'read-committed'}
+        t.assert_equals(s.index.secondary:select(), {{2, 20}, {4, 40}})
+        box.commit()
+
+        box.error.injection.set('ERRINJ_WAL_WRITE', true)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'WAL_IO',
+        }, function()
+            local ok, err = f:join(5)
+            if not ok then
+                error(err)
+            end
+        end)
+
+        box.begin{txn_isolation = 'read-committed'}
+        t.assert_equals(s.index.secondary:select(), {
+            {1, 10}, {2, 20}, {3, 30}, {4, 40}, {5, 50},
+        })
+        box.commit()
+    end)
+end
+
+g.after_test('test_deferred_delete_rollback', function(cg)
+    cg.server:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        box.error.injection.set('ERRINJ_WAL_WRITE', false)
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end)
+end)


### PR DESCRIPTION
While scanning a non-unique secondary index of a vinyl space, we skip a tuple if there's no match for it in the primary index because it means that the tuple was overwritten by a newer statement but the secondary index DELETE was deferred until compaction. We still create a cache chain link in this case so that we skip the overwritten tuple when we scan the secondary index next time. We do it even if the overwriting statement is unconfirmed (not yet written to WAL), which is actually incorrect. The problem is that if the overwriting statement is rolled back on a WAL write error, the chain created in the secondary index cache won't be broken because nothing was actually written to the secondary index (DELETE was deferred) therefore there's nothing to roll back therefore there's nothing to invalidate the cache by. As a result, the tuple that the user attempted to delete but failed due to a WAL error will become inaccessible via the secondary index because of the stale cache chain.

Fix this issue by disabling creation of a cache chain link in case the read iterator skipped an unconfirmed deferred DELETE statement.

Closes #11140