### PR TITLE
lua: rewrite `tuple_field_by_path()` in FFI

### DIFF
--- a/src/box/lua/tuple.c
+++ b/src/box/lua/tuple.c
@@ -661,38 +661,6 @@ cleanup:
 	return 1;
 }
 
-/**
- * Find a tuple field by JSON path. If a field was not found and a
- * path contains JSON syntax errors, then an exception is raised.
- * @param L Lua state.
- * @param tuple 1-th argument on a lua stack, tuple to get field
- *        from.
- * @param path 2-th argument on lua stack. Can be field name or a
- *        JSON path to a field.
- *
- * @retval not nil Found field value.
- * @retval     nil A field is NULL or does not exist.
- */
-static int
-lbox_tuple_field_by_path(struct lua_State *L)
-{
-	struct tuple *tuple = luaT_checktuple(L, 1);
-	size_t len;
-	const char *path = luaL_checklstring(L, 2, &len);
-	if (len == 0)
-		return 0;
-	const char *field = tuple_field_raw_by_full_path(tuple_format(tuple),
-							 tuple_data(tuple),
-							 tuple_field_map(tuple),
-							 path, (uint32_t)len,
-							 lua_hashstring(L, 2),
-							 TUPLE_INDEX_BASE);
-	if (field == NULL)
-		return 0;
-	luamp_decode(L, luaL_msgpack_default, &field);
-	return 1;
-}
-
 static int
 lbox_tuple_to_string(struct lua_State *L)
 {
@@ -780,7 +748,6 @@ static const struct luaL_Reg lbox_tuple_meta[] = {
 	{"slice", lbox_tuple_slice},
 	{"transform", lbox_tuple_transform},
 	{"tuple_to_map", lbox_tuple_to_map},
-	{"tuple_field_by_path", lbox_tuple_field_by_path},
 	{"new", lbox_tuple_new},
 	{"info", lbox_tuple_info},
 	{"tuple_get_format", lbox_tuple_get_format},


### PR DESCRIPTION
This refactoring allows us to fully take advantage of the JIT compiler for the indexing tuple by the given path. The most common cases of tuples containing strings or numbers are accessed 1.5-2.5 times faster. The drawback is the field contains the cdata from the msgpack extensions (like decimals). Their decoding still takes approximately the same time (maybe 5% slower).

NO_CHANGELOG=performance improvement
NO_DOC=performance improvement
NO_TEST=performance improvement

---
Depends on #11182.

Before the patch the trace related to the tuple indexing is stitched on the call to the `lbox_tuple_field_by_path()`.
The related part of the JIT dump:

```
0052       >  p32 HREFK  0051  "tuple_field_by_path" @15 ; internal.tuple.tuple_field_by_path
0053       >  fun HLOAD  0052
0054       >  fun EQ     0053  C:557d735f7810            ; lbox_tuple_field_by_path
0055 xmm7     num CONV   0001  num.int
....              SNAP   #4   [ ---- ---- ---- ---- 0055 ---- ---- 0055 0009 [0x00001ee5] tuple.lua:361|0009 0010 trace: 0x40a1c138 [0x00003cfc] C:557d735f7810|0009 0010 ]
---- TRACE 3 stop -> stitch

---- TRACE 4 start 3/stitch tuple.lua:373
---- TRACE 4 IR
....              SNAP   #0   [ ---- ]
0001          u8  XLOAD  [0x401594c1]  V
0002          int BAND   0001  +12 
0003       >  int EQ     0002  +0  
0004       >  num SLOAD  #3    T
....              SNAP   #1   [ ---- ---- ---- ---- ]
---- TRACE 4 stop -> return
```

As one can see, our main trace is stitched on the call to the C function.
Stitching of trace is not so bad as its abortion, but it still affects the performance of the LuaJIT:
* The stitching to the Lua C call is slower than inlined call to the trace.
* Less optimizations can be performed on the IRs _after_ the stitching (i.e., on the second trace), since these traces are unrelated. So, we miss opportunities for CSE, sink optimization, etc.
* The call to the Lua C API may use Lua C encoders and decoders, which also have the same problem.

See the simple bench below. It has the same idea as the benchmark in #11182. 

```
src/tarantool -v
Tarantool 3.4.0-entrypoint-135-gb08aafa56f
Target: Linux-x86_64-RelWithDebInfo
# ...

src/tarantool -e "

local clock = require('clock')
local tuple = box.tuple.new({1, 'a', 2, 'b'}, {format = {
    {'id', 'number'},
    {'name', 'string'},
    {'id2', 'number'},
    {'name2', 'string'},
}})

local function bench_field(name)
    local s = clock.time()
    local r = nil
    for _ = 1, 1e8 do
        r = tuple[name]
    end
    local f = clock.time()
    print('Result field (type time):', type(r), f - s)
end

bench_field('name')
jit.flush() -- not neccessary, actually
bench_field('id2')

os.exit(0)
"
```

Before (less is better):
```
Result field (type time):       string  11.514987945557
Result field (type time):       number  10.62696647644
```

After (~2.5 times faster):
```
Result field (type time):       string  4.749881029129
Result field (type time):       number  3.924590587616
```

After (without `jit.flush()`) (~1.5 times faster for the side traces):
```
Result field (type time):       string  4.9711482524872
Result field (type time):       number  7.3136208057404
```

Since the performance of side traces is out of the scope of this issue and this result is still better than the non-compiled code, it still makes sense to rewrite this part via FFI usage.

Before the patch with `1e6` iterations and disabled JIT:
```
Result field (type time):       string  1.4563248157501
Result field (type time):       number  1.1693773269653
```

After the patch with `1e6` iterations and disabled JIT:
```
Result field (type time):       string  4.0131645202637
Result field (type time):       number  3.3648021221161
```

This is expected, since we have decoding in pure Lua without JIT goodies.
But since the default behaviour is improved, this is not crucial, I suppose. At least I don't know any user stories related to JIT disabling.

OTOH, it may give around 5% regression for cdata (decimal) objects:
Before
```
Result field (type time):       cdata   31.235522031784
```

After
```
Result field (type time):       cdata   32.801337957382
```
