### PR TITLE
vinyl: fix race between manual compaction and range splitting

### DIFF
--- a/src/box/vy_lsm.c
+++ b/src/box/vy_lsm.c
@@ -1141,9 +1141,6 @@ vy_lsm_split_range(struct vy_lsm *lsm, struct vy_range *range)
 			if (new_slice != NULL)
 				vy_range_add_slice(part, new_slice);
 		}
-		part->needs_compaction = range->needs_compaction;
-		vy_range_update_compaction_priority(part, &lsm->opts);
-		vy_range_update_dumps_per_compaction(part);
 	}
 
 	/*
@@ -1174,6 +1171,9 @@ vy_lsm_split_range(struct vy_lsm *lsm, struct vy_range *range)
 
 	for (int i = 0; i < n_parts; i++) {
 		part = parts[i];
+		part->needs_compaction = range->needs_compaction;
+		vy_range_update_compaction_priority(part, &lsm->opts);
+		vy_range_update_dumps_per_compaction(part);
 		vy_lsm_add_range(lsm, part);
 		vy_lsm_acct_range(lsm, part);
 	}


### PR DESCRIPTION
To force compaction, `index:compact()` sets the `needs_compaction` flag on all ranges of the target LSM tree. When a range is split, the new ranges inherit this flag. The problem is that there's a yield caused by `vy_log_tx_commit()` between setting the flag in `vy_lsm_split_range()` and adding the new ranges to the LSM tree. If `vinyl_index_compact()` is called while `vy_lsm_split_range()` is waiting for `vy_log_tx_commit()` to complete, the `needs_compaction` flag will be set for the old range but not for the new ranges hence compaction won't be triggered for them. This breaks assumptions made by some tests (`select_consistency_test`, for example).

Fix this issue by setting the needs_compaction flag right before modifying the LSM tree, after the vylog record is committed.

Note that `vy_lsm_coalesce_range()` isn't affected because it already sets the flag after the vylog write.

The issue has no adverse side-effects and there's an easy work around: if the race occurs, the user can just call `index:compact()` again to trigger compaction.

Closes #11019