### PR TITLE
box: introduce index covers option

### DIFF
--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -401,7 +401,7 @@ index_def_new_from_tuple(struct tuple *tuple, struct space *space)
 		return NULL;
 	/*
 	 * Set opts.hint to the unambiguous ON or OFF value. This
-	 * allows to compare opts.hint like in index_opts_cmp()
+	 * allows to compare opts.hint like in index_opts_is_equal()
 	 * or memtx_index_def_change_requires_rebuild().
 	 */
 	if (index_def->opts.hint == INDEX_HINT_DEFAULT) {
@@ -2673,7 +2673,7 @@ on_replace_dd_index(struct trigger * /* trigger */, void *event)
 					     alter->new_min_field_count);
 		if (alter_space_move_indexes(alter, 0, iid))
 			return -1;
-		if (index_def_cmp(index_def, old_index->def) == 0) {
+		if (index_def_is_equal(index_def, old_index->def)) {
 			/* Index is not changed so just move it. */
 			try {
 				(void) new MoveIndex(alter, old_index->def->iid);

--- a/src/box/index_def.c
+++ b/src/box/index_def.c
@@ -164,21 +164,21 @@ index_def_delete(struct index_def *index_def)
 	free(index_def);
 }
 
-int
-index_def_cmp(const struct index_def *key1, const struct index_def *key2)
+bool
+index_def_is_equal(const struct index_def *def1, const struct index_def *def2)
 {
-	assert(key1->space_id == key2->space_id);
-	if (key1->iid != key2->iid)
-		return key1->iid < key2->iid ? -1 : 1;
-	if (strcmp(key1->name, key2->name))
-		return strcmp(key1->name, key2->name);
-	if (key1->type != key2->type)
-		return (int) key1->type < (int) key2->type ? -1 : 1;
-	if (index_opts_cmp(&key1->opts, &key2->opts))
-		return index_opts_cmp(&key1->opts, &key2->opts);
-
-	return key_part_cmp(key1->key_def->parts, key1->key_def->part_count,
-			    key2->key_def->parts, key2->key_def->part_count);
+	assert(def1->space_id == def2->space_id);
+	if (def1->iid != def2->iid)
+		return false;
+	if (strcmp(def1->name, def2->name) != 0)
+		return false;
+	if (def1->type != def2->type)
+		return false;
+	if (!index_opts_is_equal(&def1->opts, &def2->opts))
+		return false;
+	return key_part_cmp(
+			def1->key_def->parts, def1->key_def->part_count,
+			def2->key_def->parts, def2->key_def->part_count) == 0;
 }
 
 struct key_def **

--- a/src/box/index_def.h
+++ b/src/box/index_def.h
@@ -132,31 +132,30 @@ index_opts_destroy(struct index_opts *opts)
 	TRASH(opts);
 }
 
-static inline int
-index_opts_cmp(const struct index_opts *o1, const struct index_opts *o2)
+static inline bool
+index_opts_is_equal(const struct index_opts *o1, const struct index_opts *o2)
 {
 	if (o1->is_unique != o2->is_unique)
-		return o1->is_unique < o2->is_unique ? -1 : 1;
+		return false;
 	if (o1->dimension != o2->dimension)
-		return o1->dimension < o2->dimension ? -1 : 1;
+		return false;
 	if (o1->distance != o2->distance)
-		return o1->distance < o2->distance ? -1 : 1;
+		return false;
 	if (o1->range_size != o2->range_size)
-		return o1->range_size < o2->range_size ? -1 : 1;
+		return false;
 	if (o1->page_size != o2->page_size)
-		return o1->page_size < o2->page_size ? -1 : 1;
+		return false;
 	if (o1->run_count_per_level != o2->run_count_per_level)
-		return o1->run_count_per_level < o2->run_count_per_level ?
-		       -1 : 1;
+		return false;
 	if (o1->run_size_ratio != o2->run_size_ratio)
-		return o1->run_size_ratio < o2->run_size_ratio ? -1 : 1;
+		return false;
 	if (o1->bloom_fpr != o2->bloom_fpr)
-		return o1->bloom_fpr < o2->bloom_fpr ? -1 : 1;
+		return false;
 	if (o1->func_id != o2->func_id)
-		return o1->func_id - o2->func_id;
+		return false;
 	if (o1->hint != o2->hint)
-		return o1->hint - o2->hint;
-	return 0;
+		return false;
+	return true;
 }
 
 /* Definition of an index. */
@@ -297,12 +296,14 @@ struct key_def **
 index_def_to_key_def(struct rlist *index_defs, int *size);
 
 /**
- * One key definition is greater than the other if it's id is
- * greater, it's name is greater,  it's index type is greater
- * (HASH < TREE < BITSET) or its key part array is greater.
+ * Check whether index definitions def1 and def2 are equals.
+ *
+ * @param def1 index definition 1.
+ * @param def2 index definition 2.
+ * @retval true if definitions are equal, false if not.
  */
-int
-index_def_cmp(const struct index_def *key1, const struct index_def *key2);
+bool
+index_def_is_equal(const struct index_def *def1, const struct index_def *def2);
 
 /**
  * Check a key definition for violation of various limits.

--- a/src/box/index_def.h
+++ b/src/box/index_def.h
@@ -109,6 +109,17 @@ struct index_opts {
 	 * Use hint optimization for tree index.
 	 */
 	enum index_hint_cfg hint;
+	/**
+	 * Engine dependent. For engines supporting covering indexes means
+	 * explicitly covered fields. That is fields other then fields of
+	 * index key and primary index key. The latter fields are always
+	 * covered. Sorted in ascending order.
+	 */
+	uint32_t *covered_fields;
+	/**
+	 * Number of covered fields.
+	 */
+	uint32_t covered_field_count;
 };
 
 extern const struct index_opts index_opts_default;
@@ -155,6 +166,12 @@ index_opts_is_equal(const struct index_opts *o1, const struct index_opts *o2)
 		return false;
 	if (o1->hint != o2->hint)
 		return false;
+	if (o1->covered_field_count != o2->covered_field_count)
+		return false;
+	for (uint32_t i = 0; i < o1->covered_field_count; i++) {
+		if (o1->covered_fields[i] != o2->covered_fields[i])
+			return false;
+	}
 	return true;
 }
 
@@ -174,8 +191,8 @@ struct index_def {
 	char *name;
 	/** Index type. */
 	enum index_type type;
+	/** Index options. */
 	struct index_opts opts;
-
 	/** Index key definition. */
 	struct key_def *key_def;
 	/**

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -878,6 +878,11 @@ memtx_space_check_index_def(struct space *space, struct index_def *index_def)
 	/* Only HASH and TREE indexes check parts there. */
 	if (index_def_check_field_types(index_def, space_name(space)) != 0)
 		return -1;
+	if (index_def->opts.covered_field_count != 0) {
+		diag_set(ClientError, ER_UNSUPPORTED, "memtx",
+			 "covering index");
+		return -1;
+	}
 	return 0;
 }
 

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -694,6 +694,11 @@ vinyl_space_check_index_def(struct space *space, struct index_def *index_def)
 			 "functional index");
 		return -1;
 	}
+	if (index_def->opts.covered_field_count != 0) {
+		diag_set(ClientError, ER_UNSUPPORTED, "vinyl",
+			 "covering index");
+		return -1;
+	}
 	return 0;
 }
 

--- a/src/trivia/util.h
+++ b/src/trivia/util.h
@@ -745,6 +745,17 @@ double_compare_int64(double lhs, int64_t rhs, int k)
 }
 
 /**
+ * Compare two operands as unt32_t.
+ * Needed for qsort.
+ */
+static inline int
+cmp_u32(const void *_a, const void *_b)
+{
+	const uint32_t *a = (const uint32_t *)_a, *b = (const uint32_t *)_b;
+	return COMPARE_RESULT(*a, *b);
+}
+
+/**
  * Compare two operands as int64_t.
  * Needed for qsort.
  */

--- a/test/box-luatest/index_covers_test.lua
+++ b/test/box-luatest/index_covers_test.lua
@@ -1,0 +1,179 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(g)
+    t.tarantool.skip_if_not_debug()
+    g.server = server:new()
+    g.server:start()
+end)
+
+g.after_all(function(g)
+    g.server:drop()
+end)
+
+g.after_each(function(g)
+    g.server:exec(function()
+        box.space.test:drop()
+    end)
+end)
+
+g.test_covers_validation = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('test', {
+            format = {{'a', 'unsigned'}, {'b', 'string'}}
+        })
+        t.assert_error_covers({
+            type = 'ClientError',
+            code = box.error.WRONG_INDEX_OPTIONS,
+            message = "Wrong index options: covers is allowed only for" ..
+                      " secondary index"
+        }, box.space._index.insert, box.space._index, {
+            s.id, 0, 'pk', 'tree', {covers = {1}},
+            {{0, 'unsigned'}}
+        })
+        t.assert_error_covers({
+            type = 'ClientError',
+            code = box.error.WRONG_INDEX_OPTIONS,
+            message = "Wrong index options: covers is allowed only for" ..
+                      " secondary index"
+        }, s.create_index, s, 'pk', {covers = {2}})
+        s:create_index('pk')
+        t.assert_error_covers({
+            type = 'ClientError',
+            code = box.error.WRONG_INDEX_OPTIONS,
+            message = "Wrong index options: covers is allowed only for" ..
+                      " secondary index"
+        }, s.index.pk.alter, s.index.pk, {covers = {1}})
+        --
+        -- Test space:create_index.
+        --
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "options parameter 'covers' should be of type table",
+        }, s.create_index, s, 'sk', {covers = 1})
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "options.covers[1]: field (name or number) is expected",
+        }, s.create_index, s, 'sk', {covers = {{}}})
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "options.covers[1]: field (number) must be one-based",
+        }, s.create_index, s, 'sk', {covers = {0}})
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "options.covers[1]: field was not found by name 'x'",
+        }, s.create_index, s, 'sk', {covers = {'x'}})
+        t.assert_error_covers({
+            type = 'ClientError',
+            code = box.error.WRONG_INDEX_OPTIONS,
+            message = "Wrong index options: 'covers' has duplicates",
+        }, s.create_index, s, 'sk', {covers = {1, 1}})
+        t.assert_error_covers({
+            type = 'ClientError',
+            code = box.error.WRONG_INDEX_OPTIONS,
+            message = "Wrong index options: 'covers' elements must be unsigned",
+        }, s.create_index, s, 'sk', {covers = {1.1}})
+        --
+        -- Test index:alter
+        --
+        local sk = s:create_index('sk')
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "options parameter 'covers' should be of type table",
+        }, sk.alter, sk, {covers = 1})
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "options.covers[1]: field (name or number) is expected",
+        }, sk.alter, sk, {covers = {{}}})
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "options.covers[1]: field (number) must be one-based",
+        }, sk.alter, sk, {covers = {0}})
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "options.covers[1]: field was not found by name 'x'",
+        }, sk.alter, sk, {covers = {'x'}})
+        t.assert_error_covers({
+            type = 'ClientError',
+            code = box.error.WRONG_INDEX_OPTIONS,
+            message = "Wrong index options: 'covers' has duplicates",
+        }, sk.alter, sk, {covers = {1, 1}})
+        t.assert_error_covers({
+            type = 'ClientError',
+            code = box.error.WRONG_INDEX_OPTIONS,
+            message = "Wrong index options: 'covers' elements must be unsigned",
+        }, sk.alter, sk, {covers = {1.1}})
+        s.index.sk:drop()
+        --
+        -- Test box.space._index:insert.
+        --
+        t.assert_error_covers({
+            type = 'ClientError',
+            code = box.error.WRONG_INDEX_OPTIONS,
+            message = "Wrong index options: 'covers' must be array",
+        }, box.space._index.insert, box.space._index, {
+            s.id, 1, 'sk', 'tree', {unique = true, covers = 1},
+            {{0, 'unsigned'}}
+        })
+        t.assert_error_covers({
+            type = 'ClientError',
+            code = box.error.WRONG_INDEX_OPTIONS,
+            message = "Wrong index options: 'covers' elements must be unsigned",
+        }, box.space._index.insert, box.space._index, {
+            s.id, 1, 'sk', 'tree', {unique = true, covers = {-1}},
+            {{0, 'unsigned'}}
+        })
+        t.assert_error_covers({
+            type = 'ClientError',
+            code = box.error.WRONG_INDEX_OPTIONS,
+            message = "Wrong index options: 'covers' elements must be unsigned",
+        }, box.space._index.insert, box.space._index, {
+            s.id, 1, 'sk', 'tree', {unique = true, covers = {1.1}},
+            {{0, 'unsigned'}}
+        })
+        t.assert_error_covers({
+            type = 'ClientError',
+            code = box.error.WRONG_INDEX_OPTIONS,
+            message = "Wrong index options: 'covers' elements must be unsigned",
+        }, box.space._index.insert, box.space._index, {
+            s.id, 1, 'sk', 'tree', {unique = true, covers = {2^32}},
+            {{0, 'unsigned'}}
+        })
+        t.assert_error_covers({
+            type = 'ClientError',
+            code = box.error.WRONG_INDEX_OPTIONS,
+            message = "Wrong index options: 'covers' has duplicates",
+        }, box.space._index.insert, box.space._index, {
+            s.id, 1, 'sk', 'tree', {unique = true, covers = {1, 1}},
+            {{0, 'unsigned'}}
+        })
+    end)
+end
+
+g.test_covers_stubs = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('test', {
+            engine = 'memtx',
+            format = {{'a', 'unsigned'}, {'b', 'string'}}
+        })
+        s:create_index('pk')
+        t.assert_error_covers({
+            type = 'ClientError',
+            code = box.error.UNSUPPORTED,
+            message = "memtx does not support covering index",
+        }, s.create_index, s, 'sk', {covers = {2}})
+        s:drop()
+        local s = box.schema.create_space('test', {
+            engine = 'vinyl',
+            format = {{'a', 'unsigned'}, {'b', 'string'}}
+        })
+        s:create_index('pk')
+        t.assert_error_covers({
+            type = 'ClientError',
+            code = box.error.UNSUPPORTED,
+            message = "vinyl does not support covering index",
+        }, s.create_index, s, 'sk', {covers = {2}})
+    end)
+end


### PR DESCRIPTION
It is intended to be used by memcs engine to specify columns of the secondary index. Usage example: `space:create_index('sk', {parts = {2}, covers = {5, 7}}`.

Part of tarantool/tarantool-ee#893

Required for PR https://github.com/tarantool/tarantool-ee/pull/1129.