### PR TITLE
vinyl: fix gc of incomplete runs left after dropped space

### DIFF
--- a/changelogs/unreleased/gh-11163-vy-incomplete-run-gc-fix.md
+++ b/changelogs/unreleased/gh-11163-vy-incomplete-run-gc-fix.md
@@ -1,0 +1,5 @@
+## bugfix/vinyl
+
+* Fixed a bug when the garbage collector purged run files left after a dropped
+  space without waiting for compaction completion. The bug could result in
+  a compaction failure with a "No such file or directory" error (gh-11163).

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -3285,9 +3285,13 @@ vy_gc_lsm(struct vy_lsm_recovery_info *lsm_info)
 	}
 	struct vy_run_recovery_info *run_info;
 	rlist_foreach_entry(run_info, &lsm_info->runs, in_lsm) {
-		if (lsm_info->create_lsn < 0)
-			run_info->is_incomplete = true;
-		if (!run_info->is_dropped) {
+		/*
+		 * Drop all runs that belong to the dropped LSM tree except
+		 * incomplete ones because the latter may still be written by
+		 * background tasks. They will be dropped on task completion,
+		 * see vy_run_discard().
+		 */
+		if (!run_info->is_dropped && !run_info->is_incomplete) {
 			run_info->is_dropped = true;
 			run_info->gc_lsn = lsm_info->drop_lsn;
 			vy_log_drop_run(run_info->id, run_info->gc_lsn);
@@ -3324,7 +3328,8 @@ vy_gc(struct vy_env *env, struct vy_recovery *recovery,
 			if ((run_info->is_dropped &&
 			     run_info->gc_lsn < gc_lsn &&
 			     (gc_mask & VY_GC_DROPPED) != 0) ||
-			    (run_info->is_incomplete &&
+			    ((run_info->is_incomplete ||
+			      lsm_info->create_lsn < 0) &&
 			     (gc_mask & VY_GC_INCOMPLETE) != 0)) {
 				vy_gc_run(env, lsm_info, run_info);
 			}

--- a/test/vinyl-luatest/gh_11163_gc_while_compaction_in_progress_test.lua
+++ b/test/vinyl-luatest/gh_11163_gc_while_compaction_in_progress_test.lua
@@ -1,0 +1,91 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new({
+        box_cfg = {
+            log_level = 'verbose',
+            checkpoint_count = 1,
+        },
+    })
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        box.error.injection.set('ERRINJ_VY_COMPACTION_DELAY', false)
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+        box.space._schema:delete('test')
+    end)
+end)
+
+g.test_gc_while_compaction_in_progress = function(cg)
+    cg.server:exec(function()
+        local fio = require('fio')
+
+        local s = box.schema.space.create('test', {engine = 'vinyl'})
+        s:create_index('primary')
+
+        -- Vinyl cleans up its metadata log (vylog) only when a checkpoint
+        -- is created and it always keeps the vylog file corresponding to
+        -- the previous checkpoint. Besides, a vylog record is removed in
+        -- three steps: first, we mark it as dropped; second, we mark it as
+        -- unused; finally, we purge it. So to collect all garbage, we have
+        -- to create four checkpoints.
+        local function run_gc()
+            for i = 1, 4 do
+                box.space._schema:replace({'test', i})
+                box.snapshot()
+            end
+        end
+
+        -- Block compaction.
+        box.error.injection.set('ERRINJ_VY_COMPACTION_DELAY', true)
+
+        s:replace({1, 10})
+        box.snapshot()
+        s:replace({1, 20})
+        box.snapshot()
+
+        -- Trigger compaction and wait for it to start.
+        s.index.primary:compact()
+        t.helpers.retrying({}, function()
+            t.assert_covers(box.stat.vinyl(), {
+                scheduler = {tasks_inprogress = 1}
+            })
+        end)
+
+        -- Drop the space and run garbage collection.
+        s:drop()
+        run_gc()
+
+        -- Vinyl metadata must not be deleted while compaction is
+        -- in progress.
+        t.assert_not_equals(fio.glob('*.vylog'), {})
+
+        -- Unblock compaction and wait for it to complete.
+        box.error.injection.set('ERRINJ_VY_COMPACTION_DELAY', false)
+        t.helpers.retrying({}, function()
+            t.assert_covers(box.stat.vinyl(), {
+                scheduler = {tasks_inprogress = 0}
+            })
+        end)
+
+        -- Run garbage collection and check that all remaining vinyl
+        -- files have been purged.
+        t.assert(fio.path.exists('512'))
+        t.assert_not_equals(fio.glob('*.vylog'), {})
+        run_gc()
+        t.assert_not(fio.path.exists('512'))
+        t.assert_equals(fio.glob('*.vylog'), {})
+    end)
+end


### PR DESCRIPTION
A space may be dropped while it's being compacted. The vinyl garbage collector purges all run files left after a dropped space, including `.run.inprogress` and `.index.inprogress` files currently being written by compaction tasks. As a result, when a compaction task is completed, it may fail to rename the new run file with a `ENOENT` error:

```
vinyl.compaction.0/102/task xlog.c:800 !> can't rename ./512/0/00000000000000000006.index.inprogress to ./512/0/00000000000000000006.index: No such file or directory
```

This bug has another effect. If the compaction starts writing the file after the garbage collector purges meta-information about it from vylog, the run file will be successfully written but never committed to vylog. As a result, it will never be deleted.

Let's fix this issue by making the garbage collector skip incomplete runs unless explicitly instructed to delete them (`VY_GC_INCOMPLETE`). Compaction tasks now discard run files on completion if the space was dropped while compaction was in progress so that they are removed during the next garbage collection round.

Closes #11163