### PR TITLE
[backport 3.3] Fix `MP_INT` misusage in SQL

### DIFF
--- a/changelogs/unreleased/gh-10132-full-mp_int-support-sql.md
+++ b/changelogs/unreleased/gh-10132-full-mp_int-support-sql.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Fixed undefined behavior of SQL when using positive `MP_INT` numbers in
+  MessagePack anywhere (bound arguments, tuples, C functions) (gh-10132).

--- a/src/box/sql/func.c
+++ b/src/box/sql/func.c
@@ -940,7 +940,7 @@ func_random(struct sql_context *ctx, int argc, const struct Mem *argv)
 	(void)argv;
 	int64_t r;
 	sql_randomness(sizeof(r), &r);
-	mem_set_int(ctx->pOut, r, r < 0);
+	mem_set_int_with_sign(ctx->pOut, r, r < 0);
 }
 
 /**
@@ -1178,13 +1178,13 @@ func_date_part(struct sql_context *ctx, int argc, const struct Mem *argv)
 	const char *str = tt_cstr(part->z, part->n);
 	const struct datetime *dt = &date->u.dt;
 	if (strcasecmp("millennium", str) == 0)
-		return mem_set_int64(ctx->pOut, datetime_millennium(dt));
+		return mem_set_int(ctx->pOut, datetime_millennium(dt));
 	if (strcasecmp("century", str) == 0)
-		return mem_set_int64(ctx->pOut, datetime_century(dt));
+		return mem_set_int(ctx->pOut, datetime_century(dt));
 	if (strcasecmp("decade", str) == 0)
-		return mem_set_int64(ctx->pOut, datetime_decade(dt));
+		return mem_set_int(ctx->pOut, datetime_decade(dt));
 	if (strcasecmp("year", str) == 0)
-		return mem_set_int64(ctx->pOut, datetime_year(dt));
+		return mem_set_int(ctx->pOut, datetime_year(dt));
 	if (strcasecmp("quarter", str) == 0)
 		return mem_set_uint(ctx->pOut, datetime_quarter(dt));
 	if (strcasecmp("month", str) == 0)
@@ -1210,9 +1210,9 @@ func_date_part(struct sql_context *ctx, int argc, const struct Mem *argv)
 	if (strcasecmp("nanosecond", str) == 0)
 		return mem_set_uint(ctx->pOut, datetime_nsec(dt));
 	if (strcasecmp("epoch", str) == 0)
-		return mem_set_int64(ctx->pOut, datetime_epoch(dt));
+		return mem_set_int(ctx->pOut, datetime_epoch(dt));
 	if (strcasecmp("timezone_offset", str) == 0)
-		return mem_set_int64(ctx->pOut, datetime_tzoffset(dt));
+		return mem_set_int(ctx->pOut, datetime_tzoffset(dt));
 }
 
 #define Utf8Read(s, e) \

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -3004,7 +3004,7 @@ mem_from_mp_ephemeral(struct Mem *mem, const char *buf, uint32_t *len)
 	}
 	case MP_INT: {
 		mem->u.i = mp_decode_int(&buf);
-		mem->type = MEM_TYPE_INT;
+		mem->type = mem->u.i < 0 ? MEM_TYPE_INT : MEM_TYPE_UINT;
 		mem->flags = 0;
 		break;
 	}

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -2609,8 +2609,8 @@ mem_cmp_msgpack(const struct Mem *a, const char **b, int *result,
 		mem.u.u = mp_decode_uint(b);
 		break;
 	case MP_INT:
-		mem.type = MEM_TYPE_INT;
 		mem.u.i = mp_decode_int(b);
+		mem.type = mem.u.i < 0 ? MEM_TYPE_INT : MEM_TYPE_UINT;
 		break;
 	case MP_FLOAT:
 		mem.type = MEM_TYPE_DOUBLE;

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -314,7 +314,7 @@ mem_set_null(struct Mem *mem)
 }
 
 void
-mem_set_int(struct Mem *mem, int64_t value, bool is_neg)
+mem_set_int_with_sign(struct Mem *mem, int64_t value, bool is_neg)
 {
 	mem_clear(mem);
 	mem->u.i = value;
@@ -826,7 +826,7 @@ str_to_int(struct Mem *mem)
 	int64_t i;
 	if (sql_atoi64(mem->z, &i, &is_neg, mem->n) != 0)
 		return -1;
-	mem_set_int(mem, i, is_neg);
+	mem_set_int_with_sign(mem, i, is_neg);
 	return 0;
 }
 
@@ -2095,7 +2095,7 @@ mem_add_num(const struct Mem *left, const struct Mem *right, struct Mem *result)
 		diag_set(ClientError, ER_SQL_EXECUTE, "integer is overflowed");
 		return -1;
 	}
-	mem_set_int(result, res, is_neg);
+	mem_set_int_with_sign(result, res, is_neg);
 	return 0;
 }
 
@@ -2201,7 +2201,7 @@ mem_sub_num(const struct Mem *left, const struct Mem *right, struct Mem *result)
 		diag_set(ClientError, ER_SQL_EXECUTE, "integer is overflowed");
 		return -1;
 	}
-	mem_set_int(result, res, is_neg);
+	mem_set_int_with_sign(result, res, is_neg);
 	return 0;
 }
 
@@ -2309,7 +2309,7 @@ mem_mul(const struct Mem *left, const struct Mem *right, struct Mem *result)
 		diag_set(ClientError, ER_SQL_EXECUTE, "integer is overflowed");
 		return -1;
 	}
-	mem_set_int(result, res, is_neg);
+	mem_set_int_with_sign(result, res, is_neg);
 	return 0;
 }
 
@@ -2367,7 +2367,7 @@ mem_div(const struct Mem *left, const struct Mem *right, struct Mem *result)
 		diag_set(ClientError, ER_SQL_EXECUTE, "integer is overflowed");
 		return -1;
 	}
-	mem_set_int(result, res, is_neg);
+	mem_set_int_with_sign(result, res, is_neg);
 	return 0;
 }
 
@@ -2399,7 +2399,7 @@ mem_rem(const struct Mem *left, const struct Mem *right, struct Mem *result)
 		diag_set(ClientError, ER_SQL_EXECUTE, "integer is overflowed");
 		return -1;
 	}
-	mem_set_int(result, res, is_neg);
+	mem_set_int_with_sign(result, res, is_neg);
 	return 0;
 }
 

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -3584,9 +3584,10 @@ port_c_get_vdbemem(struct port *base, uint32_t *size)
 			val[i].u.r = d;
 			break;
 		case MP_INT:
-			val[i].type = MEM_TYPE_INT;
 			assert(val[i].flags == 0);
 			val[i].u.i = mp_decode_int(&data);
+			val[i].type = val[i].u.i < 0 ?
+				MEM_TYPE_INT : MEM_TYPE_UINT;
 			break;
 		case MP_UINT:
 			val[i].type = MEM_TYPE_UINT;

--- a/src/box/sql/mem.h
+++ b/src/box/sql/mem.h
@@ -330,9 +330,9 @@ mem_delete(struct Mem *);
 void
 mem_set_null(struct Mem *mem);
 
-/** Clear MEM and set it to INTEGER. */
+/** Clear MEM and set it to INTEGER with the given sign. */
 void
-mem_set_int(struct Mem *mem, int64_t value, bool is_neg);
+mem_set_int_with_sign(struct Mem *mem, int64_t value, bool is_neg);
 
 /** Clear MEM and set it to UNSIGNED. */
 void
@@ -344,7 +344,7 @@ mem_set_nint(struct Mem *mem, int64_t value);
 
 /** Clear MEM and set it to INT64. */
 static inline void
-mem_set_int64(struct Mem *mem, int64_t value)
+mem_set_int(struct Mem *mem, int64_t value)
 {
 	if (value < 0)
 		mem_set_nint(mem, value);

--- a/src/box/sql/mem.h
+++ b/src/box/sql/mem.h
@@ -715,48 +715,12 @@ int
 mem_cast_implicit_number(struct Mem *mem, enum field_type type);
 
 /**
- * Return value for MEM of INTEGER type. For MEM of all other types convert
- * value of the MEM to INTEGER if possible and return converted value. Original
- * MEM is not changed.
- */
-int
-mem_get_int(const struct Mem *mem, int64_t *i, bool *is_neg);
-
-/**
  * Return value of MEM converted to int64_t. This function is not safe, since it
- * returns 0 if mem_get_int() fails. There is no proper handling for this case.
+ * returns 0 if the value can't be converted to an int of any sign.
  * Also it works incorrectly with integer values that are more than INT64_MAX.
  */
-static inline int64_t
-mem_get_int_unsafe(const struct Mem *mem)
-{
-	int64_t i;
-	bool is_neg;
-	if (mem_get_int(mem, &i, &is_neg) != 0)
-		return 0;
-	return i;
-}
-
-/**
- * Return value for MEM of UNSIGNED type. For MEM of all other types convert
- * value of the MEM to UNSIGNED if possible and return converted value. Original
- * MEM is not changed.
- */
-int
-mem_get_uint(const struct Mem *mem, uint64_t *u);
-
-/**
- * Return value of MEM converted to uint64_t. This function is not safe, since it
- * returns 0 if mem_get_uint() fails. There is no proper handling for this case.
- */
-static inline uint64_t
-mem_get_uint_unsafe(const struct Mem *mem)
-{
-	uint64_t u;
-	if (mem_get_uint(mem, &u) != 0)
-		return 0;
-	return u;
-}
+int64_t
+mem_get_int_unsafe(const struct Mem *mem);
 
 /**
  * Return value for MEM of DOUBLE type. For MEM of all other types convert
@@ -778,57 +742,6 @@ mem_get_double_unsafe(const struct Mem *mem)
 	if (mem_get_double(mem, &d) != 0)
 		return 0.;
 	return d;
-}
-
-/**
- * Return value for MEM of BOOLEAN type. For MEM of all other types convert
- * value of the MEM to BOOLEAN if possible and return converted value. Original
- * MEM is not changed.
- */
-int
-mem_get_bool(const struct Mem *mem, bool *b);
-
-/**
- * Return value of MEM converted to boolean. This function is not safe since
- * there is no proper processing in case mem_get_bool() return an error. In
- * this case this function returns FALSE.
- */
-static inline bool
-mem_get_bool_unsafe(const struct Mem *mem)
-{
-	bool b;
-	if (mem_get_bool(mem, &b) != 0)
-		return false;
-	return b;
-}
-
-/**
- * Return value for MEM of VARBINARY type. For MEM of all other types convert
- * value of the MEM to VARBINARY if possible and return converted value.
- * Original MEM is not changed.
- */
-int
-mem_get_bin(const struct Mem *mem, const char **s);
-
-/**
- * Return length of value for MEM of STRING or VARBINARY type. Original MEM is
- * not changed.
- */
-int
-mem_len(const struct Mem *mem, size_t *len);
-
-/**
- * Return length of value for MEM of STRING or VARBINARY type. This function is
- * not safe since there is no proper processing in case mem_len() return an
- * error. In this case this function returns 0.
- */
-static inline int
-mem_len_unsafe(const struct Mem *mem)
-{
-	size_t len;
-	if (mem_len(mem, &len) != 0)
-		return 0;
-	return len;
 }
 
 /**

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -703,7 +703,7 @@ case OP_Halt: {
  */
 case OP_Integer: {         /* out2 */
 	pOut = vdbe_prepare_null_out(p, pOp->p2);
-	mem_set_int(pOut, pOp->p1, pOp->p1 < 0);
+	mem_set_int(pOut, pOp->p1);
 	break;
 }
 
@@ -728,7 +728,7 @@ case OP_Bool: {         /* out2 */
 case OP_Int64: {           /* out2 */
 	pOut = vdbe_prepare_null_out(p, pOp->p2);
 	assert(pOp->p4.pI64!=0);
-	mem_set_int(pOut, *pOp->p4.pI64, pOp->p4type == P4_INT64);
+	mem_set_int_with_sign(pOut, *pOp->p4.pI64, pOp->p4type == P4_INT64);
 	break;
 }
 

--- a/src/box/sql/vdbeapi.c
+++ b/src/box/sql/vdbeapi.c
@@ -422,7 +422,7 @@ sql_bind_int64(struct Vdbe *p, int i, int64_t iValue)
 		return -1;
 	int rc = sql_bind_type(p, i, "integer");
 	assert(iValue < 0);
-	mem_set_int(&p->aVar[i - 1], iValue, true);
+	mem_set_nint(&p->aVar[i - 1], iValue);
 	return rc;
 }
 

--- a/src/box/sql/vdbeapi.c
+++ b/src/box/sql/vdbeapi.c
@@ -421,8 +421,7 @@ sql_bind_int64(struct Vdbe *p, int i, int64_t iValue)
 	if (vdbeUnbind(p, i) != 0)
 		return -1;
 	int rc = sql_bind_type(p, i, "integer");
-	assert(iValue < 0);
-	mem_set_nint(&p->aVar[i - 1], iValue);
+	mem_set_int(&p->aVar[i - 1], iValue);
 	return rc;
 }
 

--- a/src/box/sql/vdbeaux.c
+++ b/src/box/sql/vdbeaux.c
@@ -1227,13 +1227,13 @@ sqlVdbeList(Vdbe * p)
 			}
 		}
 
-		mem_set_int(pMem, pOp->p1, pOp->p1 < 0);
+		mem_set_int(pMem, pOp->p1);
 		pMem++;
 
-		mem_set_int(pMem, pOp->p2, pOp->p2 < 0);
+		mem_set_int(pMem, pOp->p2);
 		pMem++;
 
-		mem_set_int(pMem, pOp->p3, pOp->p3 < 0);
+		mem_set_int(pMem, pOp->p3);
 		pMem++;
 
 		char *buf = sql_xmalloc(256);

--- a/test/sql-luatest/CMakeLists.txt
+++ b/test/sql-luatest/CMakeLists.txt
@@ -5,6 +5,7 @@ build_module(sql_interval sql_interval.c)
 target_link_libraries(sql_interval msgpuck core)
 build_module(gh_6572 gh_6572_nan_is_not_null_test.c)
 target_link_libraries(gh_6572 msgpuck core)
+build_module(gh_10132 gh_10132_mp_int_bugs.c)
 
 tarantool_make_lua_path(LUA_CPATH
   PATHS

--- a/test/sql-luatest/gh_10132_mp_int_bugs.c
+++ b/test/sql-luatest/gh_10132_mp_int_bugs.c
@@ -1,0 +1,11 @@
+#include "module.h"
+#include "msgpuck.h"
+
+int
+get_mp_int_one(box_function_ctx_t *ctx, const char *args, const char *args_end)
+{
+	(void)args;
+	(void)args_end;
+	char data[] = "\xd0\x01";
+	return box_return_mp(ctx, data, data + (sizeof(data) - 1));
+}

--- a/test/sql-luatest/gh_10132_mp_int_bugs_test.lua
+++ b/test/sql-luatest/gh_10132_mp_int_bugs_test.lua
@@ -39,6 +39,8 @@ end
 g.test_compare = function(cg)
     cg.server:exec(function()
         box.space.test:replace{_G.make_mp('\xd0\x01')}
+        t.assert(_G.do_sql('SELECT id > 0 FROM test WHERE id = 1'))
+        t.assert_equals(_G.do_sql('SELECT id + 0 FROM test WHERE id = 1'), 1)
         box.space.test:replace{_G.make_mp('\xd0\x02')}
         t.assert_equals(_G.do_sql('SELECT 1 FROM test WHERE id <= 1'), 1)
         box.space.test:delete{1}

--- a/test/sql-luatest/gh_10132_mp_int_bugs_test.lua
+++ b/test/sql-luatest/gh_10132_mp_int_bugs_test.lua
@@ -1,0 +1,32 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group('gh-10132')
+
+g.before_all(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+    cg.server:exec(function()
+        local msgpack = require('msgpack')
+        rawset(_G, 'conn', require('net.box').connect(box.cfg.listen))
+        rawset(_G, 'do_sql', function(...)
+            local rows = _G.conn:execute(...).rows
+            t.assert_equals(#rows, 1)
+            t.assert_equals(#rows[1], 1)
+            return rows[1][1]
+        end)
+        rawset(_G, 'make_mp', function(...)
+            return msgpack.object_from_raw(...)
+        end)
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:stop()
+end)
+
+g.test_bind = function(cg)
+    cg.server:exec(function()
+        t.assert_equals(_G.do_sql('SELECT ?', {_G.make_mp('\xd0\x01')}), 1)
+    end)
+end

--- a/test/sql-luatest/gh_10132_mp_int_bugs_test.lua
+++ b/test/sql-luatest/gh_10132_mp_int_bugs_test.lua
@@ -18,6 +18,11 @@ g.before_all(function(cg)
         rawset(_G, 'make_mp', function(...)
             return msgpack.object_from_raw(...)
         end)
+        local format = {
+            {'id', 'integer'},
+        }
+        local s = box.schema.create_space('test', {format = format})
+        s:create_index('pk')
     end)
 end)
 
@@ -28,5 +33,15 @@ end)
 g.test_bind = function(cg)
     cg.server:exec(function()
         t.assert_equals(_G.do_sql('SELECT ?', {_G.make_mp('\xd0\x01')}), 1)
+    end)
+end
+
+g.test_compare = function(cg)
+    cg.server:exec(function()
+        box.space.test:replace{_G.make_mp('\xd0\x01')}
+        box.space.test:replace{_G.make_mp('\xd0\x02')}
+        t.assert_equals(_G.do_sql('SELECT 1 FROM test WHERE id <= 1'), 1)
+        box.space.test:delete{1}
+        box.space.test:delete{2}
     end)
 end


### PR DESCRIPTION
Backport of #11152.