### PR TITLE
ci: verify the downgrade list before the release

### DIFF
--- a/.github/workflows/downgrade_versions.yml
+++ b/.github/workflows/downgrade_versions.yml
@@ -2,8 +2,12 @@ name: downgrade_versions
 
 on:
   push:
+    branches:
+      - 'master'
+      - 'release/**'
     tags:
       - '**'
+  pull_request:
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow

--- a/tools/check-downgrade-versions.sh
+++ b/tools/check-downgrade-versions.sh
@@ -12,7 +12,8 @@
 # -- DOWNGRADE VERSIONS END
 #
 # The check is only done for the commit tagged as release version
-# (annotated tag with name like 2.11.4).
+# (annotated tag with name like 2.11.4) or if the release notes
+# file is added for the upcoming release.
 
 set -eo pipefail
 
@@ -32,13 +33,38 @@ tag_exceptions=`mktemp`
 echo 2.9.0 > $tag_exceptions
 
 this_tag=`git describe --exact-match 2>/dev/null || true`
+
+# If we're on a X.Y.Z-entrypoint-blablabla commit, then the X.Y.Z
+# release is planned (or at least possible).
+#
+# If changelogs/X.Y.Z.md is already added, it means that the X.Y.Z
+# release is coming soon and it is a good time to verify the
+# downgrade version list. It is better to do so before pushing the
+# release tag.
+#
+# OTOH, don't require the future version to be in the list on the
+# early stage of development of the release.
+next_tag=`git describe --always --long | sed -n 's/^\([0-9]\+\.[0-9]\+\.[0-9]\+\)-entrypoint-.*$/\1/p'`
+if [ -z "${this_tag}" ] && [ -f "changelogs/${next_tag}.md" ]; then
+    this_tag="${next_tag}"
+fi
+
 tag_pattern='^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$'
 # Make downgrade check only for the release tags.
 if [[ $this_tag =~ $tag_pattern ]]; then
     # File with expected versions.
     expected_versions=`mktemp`
     # Sorted (in version order) list of release tags.
-    tags=`git tag | grep -E $tag_pattern | sort -V`
+    #
+    # Add ${this_tag} manually, because it is possible that we
+    # deduced it from the ${next_tag} logic above and there is
+    # no such a tag at the moment (but we know that it is coming
+    # soon).
+    #
+    # NB: ${this_tag} may appear twice, but that's harmless due to
+    # the [[ $skip -eq 0 ]] logic below. Once we met it, all the
+    # following tags are skipped, including these duplicates.
+    tags=`(git tag; echo "${this_tag}") | grep -E $tag_pattern | sort -V`
     skip=1
     # Cut tags below 2.8.2 and above $this_tag
     for tag in $tags; do


### PR DESCRIPTION
There is a CI workflow that verifies correctness of the list of versions to where the downgrade is possible, see commit 6d8563472785 ("ci: add workflow to check downgrade versions").

However, this check is run only on push of a tag that marks the new release. It is too late, because other CI workflows that deploy source tarball and built packages are run by pushing this tag too. The uploads are already in-progress or done, when a human sees that the downgrade list check fails.

Let's add another criteria to run the check:

* the commit is `X.Y.Z-entrypoint-<...>`, and
* there is the `changelogs/X.Y.Z.md` file.

This way we can catch the problem while preparing the release notes, *before the release*.

Follows up #8319