### PR TITLE
perf: add memtx mvcc benchmarks

### DIFF
--- a/perf/lua/CMakeLists.txt
+++ b/perf/lua/CMakeLists.txt
@@ -73,7 +73,13 @@ function(create_perf_lua_test)
 endfunction()
 
 create_perf_lua_test(NAME 1mops_write)
+create_perf_lua_test(NAME 1mops_write SUBCASE tree
+                     OPTIONS --index=TREE)
+create_perf_lua_test(NAME 1mops_write SUBCASE mvcc_tree
+                     OPTIONS --index=TREE --memtx_use_mvcc)
 create_perf_lua_test(NAME box_select)
+create_perf_lua_test(NAME box_select SUBCASE mvcc
+                     OPTIONS --memtx_use_mvcc)
 create_perf_lua_test(NAME gh-7089-vclock-copy)
 create_perf_lua_test(NAME uri_escape_unescape)
 create_perf_lua_test(NAME luafun)

--- a/perf/lua/CMakeLists.txt
+++ b/perf/lua/CMakeLists.txt
@@ -8,8 +8,8 @@ message(STATUS "Add test suite ${TEST_SUITE_NAME}")
 function(create_perf_lua_test)
   set(prefix PERF)
   set(noValues)
-  set(singleValues NAME)
-  set(multiValues DEPENDS)
+  set(singleValues NAME SUBCASE)
+  set(multiValues DEPENDS OPTIONS)
 
   # FIXME: if we update to CMake >= 3.5, can remove this line.
   include(CMakeParseArguments)
@@ -19,7 +19,14 @@ function(create_perf_lua_test)
                         "${multiValues}"
                         ${ARGN})
 
-  set(TEST_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${PERF_NAME}.lua)
+
+  set(PERF_FILENAME ${PERF_NAME})
+  if (DEFINED PERF_SUBCASE)
+    set(PERF_NAME ${PERF_NAME}_${PERF_SUBCASE})
+  endif()
+
+  set(TEST_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${PERF_FILENAME}.lua)
+  set(TEST_OPTIONS ${PERF_OPTIONS})
   set(BENCH_RESULT ${PERF_OUTPUT_DIR}/${PERF_NAME}.json)
   set(BENCH_TARGET ${PERF_NAME}_perftest)
   set(BENCH_RESULT_TARGET ${BENCH_TARGET}_result)
@@ -38,6 +45,7 @@ function(create_perf_lua_test)
           ${BENCH_CMD_SEPARATE} ${TARANTOOL_BIN} ${TEST_PATH}
             --output="${BENCH_RESULT}"
             --output_format=json
+        OPTIONS ${TEST_OPTIONS}
         DEPENDS ${TEST_DEPS}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
@@ -54,9 +62,9 @@ function(create_perf_lua_test)
   set(BENCH_RESULTS ${BENCH_RESULT_TARGET} ${BENCH_RESULTS}  PARENT_SCOPE)
   set(test_title "perf/lua/${PERF_NAME}.lua")
   add_test(NAME ${test_title}
-           COMMAND ${TARANTOOL_BIN}
-                   ${CMAKE_CURRENT_SOURCE_DIR}/${PERF_NAME}.lua
+           COMMAND ${TARANTOOL_BIN} ${TEST_PATH}
                    --output=${BENCH_RESULT} --output_format=json
+            OPTIONS ${TEST_OPTIONS}
   )
   set_tests_properties(${test_title} PROPERTIES
     ENVIRONMENT "LUA_PATH=${LUA_PATH}"

--- a/perf/lua/box_select.lua
+++ b/perf/lua/box_select.lua
@@ -13,6 +13,7 @@ local USAGE = [[
                                 possible to specify more than one pattern
                                 separated by '|', for example, 'get|select'
    read_view <boolean, false> - use a read view
+   memtx_use_mvcc <boolean>   - enable memtx MVCC engine
 
  Being run without options, this benchmark measures the performance of
  various space select (get, select, pairs) operations.
@@ -21,6 +22,7 @@ local USAGE = [[
 local params = benchmark.argparse(arg, {
     {'pattern', 'string'},
     {'read_view', 'boolean'},
+    {'memtx_use_mvcc', 'boolean'},
 }, USAGE)
 
 if params.pattern then
@@ -29,7 +31,7 @@ end
 
 local bench = benchmark.new(params)
 
-box.cfg({log_level = 'error'})
+box.cfg({log_level = 'error', memtx_use_mvcc_engine = params.memtx_use_mvcc})
 box.once('perf_select_init', function()
     local s = box.schema.space.create('perf_select_space')
     s:create_index('primary')


### PR DESCRIPTION
The patchset adds an opportunity to create perftest targets of parametrized Lua tests, populates `1mops_write` and `box_select` benchmarks with `memtx_use_mvcc` option and creates new targets for memtx mvcc benchmarks.