### PR TITLE
config: add ability to run code before box.cfg

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,5 +1,5 @@
 std = "luajit"
-globals = {"box", "_TARANTOOL", "tonumber64", "utf8"}
+globals = {"box", "_TARANTOOL", "tonumber64", "utf8", "package"}
 ignore = {
     -- Accessing an undefined field of a global variable <debug>.
     "143/debug",

--- a/changelogs/unreleased/gh-10182-add-ability-to-run-code-before-box-cfg.md
+++ b/changelogs/unreleased/gh-10182-add-ability-to-run-code-before-box-cfg.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* Introduced a `early_load: true` tag for roles and scripts. When set, it makes
+  Tarantool load the role or execute the script before `box.cfg` (gh-10182).

--- a/src/box/lua/config/applier/app.lua
+++ b/src/box/lua/config/applier/app.lua
@@ -1,26 +1,107 @@
 local log = require('internal.config.utils.log')
+local utils_file = require('internal.config.utils.file')
 
-local function apply(_config)
-    log.verbose('app.apply: do nothing')
-end
+local app_state = {
+    -- This variable is used to track the app loaded before the box.cfg() call.
+    -- It might be a string with the file name or module name or true if no
+    -- app was loaded before the box.cfg() call.
+    early_loaded = nil,
+}
 
-local function post_apply(config)
+local function run(config, opts)
     local configdata = config._configdata
     local file = configdata:get('app.file', {use_default = true})
     local module = configdata:get('app.module', {use_default = true})
+
+    if opts == nil then
+        opts = {}
+    end
+
     if file ~= nil then
         assert(module == nil)
+
+        local metadata = {}
+        local ok, res = pcall(utils_file.get_file_metadata, file)
+        if not ok then
+            log.error(('Unable to get metadata for file %q: %s'):format(
+                file, res))
+        else
+            metadata = res
+        end
+
+        if metadata['early_load']
+        and app_state.early_loaded ~= nil
+        and app_state.early_loaded ~= file then
+            log.error(('App %q with the "early_load" tag was added ' ..
+                       'to the config, it cannot be loaded before the ' ..
+                       'first box.cfg call'):format(file))
+        end
+
+        if opts.early_load_only and not metadata['early_load'] then
+            return
+        end
+
         local fn = assert(loadfile(file))
-        log.verbose('app.post_apply: loading '..file)
+        log.verbose('app.run: loading '..file)
         fn(file)
+
+        if metadata['early_load'] and app_state.early_loaded == nil then
+            app_state.early_loaded = file
+        end
     elseif module ~= nil then
-        log.verbose('app.post_apply: loading '..module)
+        local metadata = {}
+        local ok, res = pcall(utils_file.get_module_metadata, module)
+        if not ok then
+            log.error(('Unable to get metadata for module %q: %s'):format(
+                module, res))
+        else
+            metadata = res
+        end
+
+        if metadata['early_load']
+        and app_state.early_loaded ~= nil
+        and app_state.early_loaded ~= module
+        and package.loaded[module] == nil then
+            log.error(('App %q with the "early_load" tag was added ' ..
+                       'to the config, it cannot be loaded before the ' ..
+                       'first box.cfg call'):format(module))
+        end
+
+        if opts.early_load_only and not metadata['early_load'] then
+            return
+        end
+
+        log.verbose('app.run: loading '..module)
         require(module)
+
+        if metadata['early_load'] and app_state.early_loaded == nil then
+            app_state.early_loaded = module
+        end
     end
 end
 
+-- This apply function will be called before the box_cfg applier.
+local function preload(config)
+    run(config, {early_load_only = true})
+    if app_state.early_loaded == nil then
+        -- This was the only run() call before box.cfg() call, lets mark it.
+        app_state.early_loaded = true
+    end
+end
+
+-- This post_apply function will be called after the box_cfg applier.
+local function post_apply(config)
+    run(config, {early_load_only = false})
+end
+
 return {
-    name = 'app',
-    apply = apply,
-    post_apply = post_apply,
+    stage_1 = {
+        name = 'app.stage_1',
+        apply = preload,
+    },
+    stage_2 = {
+        name = 'app.stage_2',
+        apply = function() end,
+        post_apply = post_apply,
+    }
 }

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -127,14 +127,16 @@ function methods._initialize(self)
     self:_register_applier(require('internal.config.applier.mkdir'))
     self:_register_applier(require('internal.config.applier.console'))
     self:_register_applier(require('internal.config.applier.runtime_priv'))
+    self:_register_applier(require('internal.config.applier.roles').stage_1)
+    self:_register_applier(require('internal.config.applier.app').stage_1)
     self:_register_applier(require('internal.config.applier.box_cfg'))
     self:_register_applier(require('internal.config.applier.box_status'))
     self:_register_applier(require('internal.config.applier.credentials'))
     self:_register_applier(require('internal.config.applier.fiber'))
     self:_register_applier(require('internal.config.applier.sharding'))
     self:_register_applier(require('internal.config.applier.autoexpel'))
-    self:_register_applier(require('internal.config.applier.roles'))
-    self:_register_applier(require('internal.config.applier.app'))
+    self:_register_applier(require('internal.config.applier.roles').stage_2)
+    self:_register_applier(require('internal.config.applier.app').stage_2)
 
     if extras ~= nil then
         extras.initialize(self)
@@ -306,6 +308,8 @@ function methods._apply_on_startup(self, opts)
         mkdir = true,
         console = true,
         runtime_priv = true,
+        ['roles.stage_1'] = true,
+        ['app.stage_1'] = true,
         box_cfg = true,
     }
 

--- a/src/box/lua/config/utils/file.lua
+++ b/src/box/lua/config/utils/file.lua
@@ -1,6 +1,7 @@
 local ffi = require('ffi')
 local buffer = require('buffer')
 local fio = require('fio')
+local yaml = require('yaml')
 
 -- Read the file block by block till EOF.
 local function stream_read(fh)
@@ -55,6 +56,117 @@ local function universal_read(file_name, file_kind)
     return data
 end
 
+
+local function get_file_metadata(file_name)
+    local function escape_regex(str)
+        return str:gsub('([%.%+%-%*%?%[%]%(%)%$%^%{%}%|%<%>%~])', '%%%1')
+    end
+
+    -- Tags are only supported for Lua files.
+    if type(file_name) ~= 'string' or not file_name:endswith('.lua') then
+        error(('Invalid file name %q'):format(file_name), 0)
+    end
+
+    local file, err = io.open(file_name, "r")
+    if file == nil then
+        error(('Unable to open %q: %s'):format(file_name, err), 0)
+    end
+
+    local metadata = {}
+
+    local line_count = 0
+    local yaml_string = ''
+    local comment_tag = nil
+    -- Currently the only supported version is 1 and its value is not used.
+    -- luacheck: ignore 311 value assigned to a local variable is unused.
+    local metadata_version = nil
+    local in_comment, in_yaml = false, false
+    while true do
+        local line = file:read("*line")
+        if line == nil then
+            break
+        end
+        line_count = line_count + 1
+
+        -- Skip shebang.
+        if line_count == 1 and line:startswith('#!') then
+            goto next_line
+        end
+
+        -- Skip empty lines.
+        line = line:lstrip()
+        if line == '' then
+            goto next_line
+        end
+
+        if not in_comment and line:startswith('--') then
+            in_comment = true
+        end
+
+        if in_comment then
+            if not line:startswith('--') then
+                break
+            end
+        end
+
+        if in_comment and not in_yaml then
+            comment_tag, metadata_version = line:match(
+                '^(%-%-[%s]+)%-%-%- #tarantool.metadata.v([%d]+)[%s]*$')
+            metadata_version = tonumber(metadata_version)
+
+            if comment_tag ~= nil and metadata_version ~= nil then
+                comment_tag = escape_regex(comment_tag)
+                in_yaml = true
+            end
+        end
+
+        if in_yaml then
+            line = line:match(('^%s(.*)'):format(comment_tag))
+
+            if line == nil then
+                break
+            end
+
+            yaml_string = yaml_string .. '\n' .. line
+
+            if line:startswith('...') then
+                break
+            end
+        end
+
+        ::next_line::
+    end
+    file:close()
+
+    if yaml_string ~= '' then
+        local ok, res = pcall(yaml.decode, yaml_string)
+        if not ok then
+            error(('Unable to decode YAML metadata in %q: %s'):format(
+                file_name, res), 0)
+        elseif type(res) == 'table' then
+            metadata = res
+        end
+    end
+    -- @TODO Add support for multi-line comments
+
+    return metadata
+end
+
+local function get_module_metadata(module_name)
+    local ok, res = pcall(package.search, module_name)
+    if not ok then
+        error(('Unable to locate package %q: %s'):format(module_name, res), 0)
+    end
+
+    if res == nil then
+        error(('Unable to locate package %q'):format(module_name), 0)
+    end
+
+    return get_file_metadata(res)
+end
+
 return {
     universal_read = universal_read,
+    get_file_metadata = get_file_metadata,
+    get_module_metadata = get_module_metadata,
 }

--- a/test/config-luatest/appliers_test.lua
+++ b/test/config-luatest/appliers_test.lua
@@ -56,7 +56,7 @@ local appliers_script = [[
     console.apply(config)
     local fiber = require('internal.config.applier.fiber')
     fiber.apply(config)
-    local app = require('internal.config.applier.app')
+    local app = require('internal.config.applier.app').stage_2
     local ok, err = pcall(app.post_apply, config)
     %s
     os.exit(0)

--- a/test/config-luatest/gh_10182_roles_before_box_cfg_test.lua
+++ b/test/config-luatest/gh_10182_roles_before_box_cfg_test.lua
@@ -1,0 +1,264 @@
+local t = require('luatest')
+local helpers = require('test.config-luatest.helpers')
+
+---@class luatest.group
+local tg = helpers.group()
+
+local simple_role = [[
+    _G.on_load_status = nil
+    _G.on_apply_status = nil
+
+    local function on_load()
+        _G.on_load_status = box.info.status
+    end
+
+    local function apply()
+        _G.on_apply_status = box.info.status
+    end
+
+    on_load()
+
+    return {
+        validate = function() end,
+        apply = apply,
+        stop = function() end,
+    }
+]]
+
+local early_load_role = [[
+    -- --- #tarantool.metadata.v1
+    -- early_load: true
+    -- ...
+]] .. simple_role
+
+local simple_script = [[
+    if (rawget(_G, 'on_load_status') == nil) then
+        _G.on_load_status = box.info.status
+    end
+]]
+
+local early_load_script = [[#!/usr/bin/env tarantool
+    -- --- #tarantool.metadata.v1
+    -- early_load: true
+    -- ...
+]] .. simple_script
+
+tg.test_role_without_early_load_tag = function(g)
+    local verify = function()
+        t.assert_equals(_G.on_load_status, 'running')
+        t.assert_equals(_G.on_apply_status, 'running')
+    end
+
+    helpers.success_case(g, {
+        roles = {
+            one = simple_role
+        },
+        options = {
+            ['roles'] = {'one'}
+        },
+        verify = verify,
+    })
+end
+
+tg.test_role_with_early_load_tag = function(g)
+    local verify = function()
+        t.assert_equals(_G.on_load_status, 'unconfigured')
+        t.assert_equals(_G.on_apply_status, 'running')
+    end
+
+    helpers.success_case(g, {
+        roles = {
+            one = early_load_role
+        },
+        options = {
+            ['roles'] = {'one'}
+        },
+        verify = verify,
+    })
+end
+
+tg.test_role_with_early_load_tag_added = function(g)
+    helpers.reload_success_case(g, {
+        options = {
+            ['log'] = {
+                ['to'] = 'file',
+                ['file'] = 'tarantool.log',
+            },
+            ['roles'] = {'one'},
+        },
+        options_2 = {
+            ['log'] = {
+                ['to'] = 'file',
+                ['file'] = 'tarantool.log',
+            },
+            ['roles'] = {'one', 'two'},
+        },
+        roles = {
+            one = early_load_role,
+        },
+        roles_2 = {
+            one = early_load_role,
+            two = early_load_role,
+        },
+        verify = function() end,
+        verify_2 = function() end,
+    })
+
+    t.assert_not(g.server:grep_log(
+        'Role "one" with the "early_load" tag was added to the config, it ' ..
+        'cannot be loaded before the first box.cfg call',
+        1024, {filename = g.server.chdir .. '/tarantool.log'}))
+
+    t.assert(g.server:grep_log(
+        'Role "two" with the "early_load" tag was added to the config, it ' ..
+        'cannot be loaded before the first box.cfg call',
+        1024, {filename = g.server.chdir .. '/tarantool.log'}))
+end
+
+tg.test_app_without_early_load_tag = function(g)
+    local verify = function()
+        t.assert_equals(_G.on_load_status, 'running')
+    end
+
+    helpers.success_case(g, {
+        script = simple_script,
+        options = {
+               ['app.file'] = 'main.lua',
+           },
+        verify = verify,
+    })
+
+    helpers.success_case(g, {
+        script = simple_script,
+        options = {
+               ['app.module'] = 'main',
+           },
+        verify = verify,
+    })
+end
+
+tg.test_app_with_early_load_tag = function(g)
+
+    local verify = function()
+        t.assert_equals(_G.on_load_status, 'unconfigured')
+    end
+
+    helpers.success_case(g, {
+        script = early_load_script,
+        options = {
+               ['app.file'] = 'main.lua',
+           },
+        verify = verify,
+    })
+
+    helpers.success_case(g, {
+        script = early_load_script,
+        options = {
+               ['app.module'] = 'main',
+           },
+        verify = verify,
+    })
+end
+
+tg.test_app_with_early_load_tag_added = function(g)
+    helpers.reload_success_case(g, {
+        options = {
+            ['log'] = {
+                ['to'] = 'file',
+                ['file'] = 'tarantool.log',
+            },
+        },
+        options_2 = {
+            ['log'] = {
+                ['to'] = 'file',
+                ['file'] = 'tarantool.log',
+            },
+            ['app.file'] = 'main.lua',
+        },
+        verify = function() end,
+        verify_2 = function() end,
+        script_2 = early_load_script,
+    })
+
+    t.assert(g.server:grep_log(
+        'App "main.lua" with the "early_load" tag was added to the config, ' ..
+        'it cannot be loaded before the first box.cfg call',
+        1024, {filename = g.server.chdir .. '/tarantool.log'}))
+
+    helpers.reload_success_case(g, {
+        options = {
+            ['log'] = {
+                ['to'] = 'file',
+                ['file'] = 'tarantool.log',
+            },
+        },
+        options_2 = {
+            ['log'] = {
+                ['to'] = 'file',
+                ['file'] = 'tarantool.log',
+            },
+            ['app.module'] = 'main',
+        },
+        verify = function() end,
+        verify_2 = function() end,
+        script_2 = early_load_script,
+    })
+
+    t.assert(g.server:grep_log(
+        'App "main" with the "early_load" tag was added to the config, ' ..
+        'it cannot be loaded before the first box.cfg call',
+        1024, {filename = g.server.chdir .. '/tarantool.log'}))
+
+
+    helpers.reload_success_case(g, {
+        options = {
+            ['log'] = {
+                ['to'] = 'file',
+                ['file'] = 'tarantool.log',
+            },
+            ['app.file'] = 'main.lua',
+        },
+        options_2 = {
+            ['log'] = {
+                ['to'] = 'file',
+                ['file'] = 'tarantool.log',
+            },
+            ['app.file'] = 'main.lua',
+        },
+        verify = function() end,
+        verify_2 = function() end,
+        script = simple_script,
+        script_2 = early_load_script,
+    })
+
+    t.assert(g.server:grep_log(
+        'App "main.lua" with the "early_load" tag was added to the config, ' ..
+        'it cannot be loaded before the first box.cfg call',
+        1024, {filename = g.server.chdir .. '/tarantool.log'}))
+
+    helpers.reload_success_case(g, {
+        options = {
+            ['log'] = {
+                ['to'] = 'file',
+                ['file'] = 'tarantool.log',
+            },
+            ['app.module'] = 'main',
+        },
+        options_2 = {
+            ['log'] = {
+                ['to'] = 'file',
+                ['file'] = 'tarantool.log',
+            },
+            ['app.module'] = 'main',
+        },
+        verify = function() end,
+        verify_2 = function() end,
+        script = simple_script,
+        script_2 = early_load_script,
+    })
+
+    t.assert_not(g.server:grep_log(
+        'App "main" with the "early_load" tag was added to the config, ' ..
+        'it cannot be loaded before the first box.cfg call',
+        1024, {filename = g.server.chdir .. '/tarantool.log'}))
+end

--- a/test/config-luatest/metadata_test.lua
+++ b/test/config-luatest/metadata_test.lua
@@ -1,0 +1,198 @@
+local fio = require('fio')
+local file = require('internal.config.utils.file')
+
+local t = require('luatest')
+
+---@class luatest.group
+local tg = t.group()
+
+local success_cases = {
+    {
+        name = 'no metadata',
+        source = [[-- This module does not contain any metadata
+]],
+        expected = {},
+    },
+
+    {
+        name = 'empty metadata',
+        source = [[-- This module contains empty metadata
+-- --- #tarantool.metadata.v1
+-- ...
+--
+]],
+        expected = {},
+    },
+
+    {
+        name = 'simple metadata',
+        source = [[-- This module contains simple metadata
+-- --- #tarantool.metadata.v1
+-- name: my_module
+-- ...
+--
+]],
+        expected = {
+            name = 'my_module',
+        },
+    },
+
+    {
+        name = 'complex metadata',
+        source = [[-- This module contains complex metadata
+-- --- #tarantool.metadata.v1
+-- name: my_module
+-- foo: true
+-- bar:
+--   baz: 42
+-- qux:
+--  - a
+--  - b
+--  - c
+-- ...
+--
+]],
+        expected = {
+            name = 'my_module',
+            foo = true,
+            bar = {
+                baz = 42,
+            },
+            qux = {'a', 'b', 'c'},
+        },
+    },
+
+    {
+        name = 'invalid metadata',
+        source = [[-- This module contains invalid metadata tag
+-- --- #wrong_tag.metadata.v1
+-- name: my_module
+-- ...
+--
+]],
+        expected = {},
+    },
+
+    {
+        name = 'no document end tag',
+        source = [[-- This module does not contain document end tag
+-- --- #tarantool.metadata.v1
+-- name: my_module
+--
+]],
+        expected = {
+            name = 'my_module',
+        },
+    },
+
+    {
+        name = 'minimal metadata',
+        source = [[-- --- #tarantool.metadata.v1
+-- name: my_module]],
+        expected = {
+            name = 'my_module',
+        },
+    },
+
+    {
+        name = 'multiple metadata tags',
+        source = [[-- This module contains multiple metadata tags
+-- --- #tarantool.metadata.v1
+-- name: my_module
+-- ...
+--
+-- --- #tarantool.metadata.v1
+-- name: will_be_ignored
+-- ...
+--
+]],
+        expected = {
+            name = 'my_module',
+        },
+    },
+
+    {
+        name = 'different metadata version',
+        source = [[-- This module contains different metadata version
+-- --- #tarantool.metadata.v100
+-- name: my_module
+-- ...
+--
+]],
+        expected = {
+            name = 'my_module',
+        },
+    },
+}
+
+local error_cases = {
+    {
+        name = 'invalid metadata',
+        source = [[-- This module contains invalid metadata
+-- --- #tarantool.metadata.v1
+-- name: my_module: this is invalid
+-- ...
+--
+]],
+        expected = 'Unable to decode YAML metadata',
+    },
+}
+
+tg.before_each(function()
+    tg.origdir = fio.cwd()
+    tg.tmpdir = fio.tempdir()
+    fio.mktree(tg.tmpdir)
+    fio.chdir(tg.tmpdir)
+end)
+
+tg.after_each(function()
+    fio.chdir(tg.origdir)
+    fio.rmtree(tg.tmpdir)
+    tg.origdir = nil
+    tg.tmpdir = nil
+end)
+
+local function write_file(path, content)
+    local fh = assert(fio.open(path, {'O_CREAT', 'O_WRONLY', 'O_TRUNC'}))
+    fh:write(content)
+    fh:close()
+end
+
+---@class g luatest.group
+tg.test_module_metadata = function(g)
+    assert(g.tmpdir ~= nil, 'Temporary directory is not set')
+
+    for _, test in ipairs(success_cases) do
+        write_file(g.tmpdir .. '/my_module.lua', test.source)
+        local metadata = file.get_module_metadata('my_module')
+        t.assert_equals(metadata, test.expected)
+    end
+end
+
+---@class g luatest.group
+tg.test_file_metadata = function(g)
+    assert(g.tmpdir ~= nil, 'Temporary directory is not set')
+
+    for _, test in ipairs(success_cases) do
+        write_file(g.tmpdir .. '/my_file.lua', test.source)
+        local metadata = file.get_file_metadata(g.tmpdir .. '/my_file.lua')
+        t.assert_equals(metadata, test.expected)
+    end
+end
+
+---@class g luatest.group
+tg.test_metadata_with_errors = function(g)
+    assert(g.tmpdir ~= nil, 'Temporary directory is not set')
+
+    for _, test in ipairs(error_cases) do
+        write_file(g.tmpdir .. '/my_module.lua', test.source)
+        t.assert_error_msg_contains(test.expected,
+            file.get_module_metadata, 'my_module')
+    end
+
+    for _, test in ipairs(error_cases) do
+        write_file(g.tmpdir .. '/my_file.lua', test.source)
+        t.assert_error_msg_contains(test.expected,
+            file.get_file_metadata, g.tmpdir .. '/my_file.lua')
+    end
+end


### PR DESCRIPTION
config: add ability to run code before box.cfg

This commit adds 'metadata' support for roles and app scripts.
Currently only 'early_load' tag is supported. If this 'early_load'
tag is set to `true` for a role or a script, this role or script will
be loaded before the execution of `box.cfg` by the config module.

Closes #10182
Closes TNTP-227

@TarantoolBot document
Title: roles and scripts metadata

Metadata can be specified for roles and scripts (module or file in `app`
config section) in lua files. To add metadata to a source file, a
comment must be added to the beginning of the file (or after a shebang).
The metadata comment must contain a YAML-formatted section begging with
'--- #tarantool.metadata.v1' line and ending with '...' line. Example:

```lua
-- This script will be loaded before the first box.cfg() call.
-- --- #tarantool.metadata.v1
-- early_load: true
-- ...
-- More comments can be added here.
```

Currently only 'early_load' tag is supported. Setting 'early_load' tag
makes it so that the tagged file will be loaded (required) before the
execution of `box.cfg` by the config module. During the preload phase
config:get() will not work, both for modules and app scripts.
