### PR TITLE
[backport/release/3.2] luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-11055-luajit-fixes.md
+++ b/changelogs/unreleased/gh-11055-luajit-fixes.md
@@ -9,3 +9,4 @@ issues were fixed as part of this activity:
 * Fixed a crash when using a Lua C function as a vmevent handler for trace
   events.
 * Fixed the compilation of `...` in `select()`.
+* Fixed closing the report file without samples for `jit.p`.

--- a/changelogs/unreleased/luajit-prof-features.md
+++ b/changelogs/unreleased/luajit-prof-features.md
@@ -1,0 +1,11 @@
+## feature/tools
+
+Made LuaJIT profilers more user-friendly:
+* `misc.memprof.start()` without arguments writes the dump into the default file
+  named `memprof.bin` instead of raising an error.
+* `misc.sysprof.start()` provides more verbose errors in case of profiler
+  misuse.
+* If the profiler is disabled for the target platform, it is now mentioned in
+  the error message explicitly.
+* `misc.sysprof.start()` without arguments starts the profiler in the default
+  mode `"D"`.

--- a/changelogs/unreleased/luajit-prof-fixes.md
+++ b/changelogs/unreleased/luajit-prof-fixes.md
@@ -1,0 +1,7 @@
+## bugfix/tools
+
+Fixed a bunch of bugs in LuaJIT profilers:
+* `misc.sysprof.stop()` returns a correct error message if the profiler is not
+  running.
+* `misc.sysprof.start()` now raises an error if an argument has an incorrect
+  type.


### PR DESCRIPTION
* Always close profiler output file.
* test: add descriptions to sysprof testcases
* test: align test title with test filename
* sysprof: fix typo in the comment
* sysprof: introduce specific errors and default mode
* test: introduce flag LUAJIT_DISABLE_MEMPROF
* ci: add workflow with disabled profilers
* misc: specific message for disabled profilers
* memprof: set default path to profiling output file
* sysprof: rename sysprof_error to prof_error
* misc: use prof_error for handling errors
* sysprof: fix a message with stop without run

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump