### PR TITLE
feature: added fiber limit validation based on vm.max_map_count

### DIFF
--- a/changelogs/unreleased/gh-10169-fiber-limit.md
+++ b/changelogs/unreleased/gh-10169-fiber-limit.md
@@ -1,0 +1,7 @@
+## feature/core
+
+* Added a dynamic validation mechanism to fiber_new_ex() that limits
+the number of client fibers based on vm.max_map_count. This prevents
+excessive fiber creation and potential memory allocation failures.
+The validation ensures that the number of client fibers does not
+exceed 45% of available mappings.

--- a/src/lib/core/diag.h
+++ b/src/lib/core/diag.h
@@ -422,6 +422,8 @@ BuildFiberIsCancelled(const char *file, unsigned line);
 struct error *
 BuildFiberSliceIsExceeded(const char *file, unsigned line);
 struct error *
+BuildFiberCountIsExceeded(const char *file, unsigned line);
+struct error *
 BuildTimedOut(const char *file, unsigned line);
 struct error *
 BuildChannelIsClosed(const char *file, unsigned line);

--- a/src/lib/core/exception.cc
+++ b/src/lib/core/exception.cc
@@ -211,6 +211,15 @@ FiberSliceIsExceeded::FiberSliceIsExceeded(const char *file, unsigned line)
 	error_format_msg(this, "fiber slice is exceeded");
 }
 
+const struct type_info type_FiberCountIsExceeded =
+	make_type("FiberCountIsExceeded", &type_Exception);
+
+FiberCountIsExceeded::FiberCountIsExceeded(const char *file, unsigned line)
+	: Exception(&type_FiberCountIsExceeded, file, line)
+{
+	error_format_msg(this, "fiber count is exceeded");
+}
+
 const struct type_info type_LuajitError =
 	make_type("LuajitError", &type_Exception);
 
@@ -352,6 +361,12 @@ struct error *
 BuildFiberSliceIsExceeded(const char *file, unsigned line)
 {
 	return new FiberSliceIsExceeded(file, line);
+}
+
+struct error *
+BuildFiberCountIsExceeded(const char *file, unsigned line)
+{
+	return new FiberCountIsExceeded(file, line);
 }
 
 struct error *

--- a/src/lib/core/exception.h
+++ b/src/lib/core/exception.h
@@ -57,6 +57,8 @@ extern const struct type_info type_RaftError;
 extern const struct type_info type_FileFormatError;
 /* type_info for FiberSliceIsExceeded exception */
 extern const struct type_info type_FiberSliceIsExceeded;
+/* type_info for iberCountIsExceeded exception */
+extern const struct type_info type_FiberCountIsExceeded;
 /* type_info for EncodeError exception */
 extern const struct type_info type_EncodeError;
 /* type_info for DecodeError exception */
@@ -189,6 +191,18 @@ public:
 
 	FiberSliceIsExceeded()
 		: Exception(&type_FiberSliceIsExceeded, NULL, 0)
+	{
+	}
+
+	virtual void raise() { throw this; }
+};
+
+class FiberCountIsExceeded : public Exception {
+public:
+	FiberCountIsExceeded(const char *file, unsigned line);
+
+	FiberCountIsExceeded()
+	: Exception(&type_FiberCountIsExceeded, NULL, 0)
 	{
 	}
 

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -278,6 +278,25 @@ API_EXPORT struct fiber *
 fiber_new_ex(const char *name, const struct fiber_attr *fiber_attr, fiber_func f);
 
 /**
+ * Reads the maximum number of memory maps available.
+ * @return The maximum map count, or -1 on failure.
+ */
+int
+read_max_map_count();
+
+/**
+ * Sets the limit for client fiber creation.
+ * @param limit The maximum number of client fibers allowed.
+ */
+void
+fiber_set_client_limit(int limit);
+
+/**
+ * Maximum number of allowed client fibers.
+ */
+extern int64_t fiber_max_count;
+
+/**
  * Return control to another fiber and wait until it'll be woken.
  *
  * \note this is not a cancellation point (\sa fiber_testcancel()), but it is

--- a/src/lua/fiber.c
+++ b/src/lua/fiber.c
@@ -1066,6 +1066,24 @@ lbox_fiber_set_max_slice(struct lua_State *L)
 	return 0;
 }
 
+static int
+lbox_fiber_client_limit(struct lua_State *L)
+{
+	int old_limit = fiber_max_count;
+
+	if (lua_gettop(L) != 0) {
+		int new_limit = lua_tointeger(L, -1);
+		if (new_limit <= 0) {
+			diag_set(IllegalParams, "fiber limit must be > 0");
+			luaT_error(L);
+		}
+		fiber_max_count = new_limit;
+	}
+
+	lua_pushinteger(L, old_limit);
+	return 1;
+}
+
 static const struct luaL_Reg lbox_fiber_meta [] = {
 	{"id", lbox_fiber_id},
 	{"name", lbox_fiber_name},
@@ -1090,6 +1108,7 @@ static const struct luaL_Reg fiberlib[] = {
 	{"top_enable", lbox_fiber_top_enable},
 	{"top_disable", lbox_fiber_top_disable},
 	{"tx_user_pool_size", lbox_fiber_tx_user_pool_size},
+	{"client_fiber_limit", lbox_fiber_client_limit},
 #ifdef ENABLE_BACKTRACE
 	{"parent_backtrace_enable", lbox_fiber_parent_backtrace_enable},
 	{"parent_backtrace_disable", lbox_fiber_parent_backtrace_disable},

--- a/test/box-luatest/gh_10169_fiber_limit_test.lua
+++ b/test/box-luatest/gh_10169_fiber_limit_test.lua
@@ -1,0 +1,60 @@
+local t = require('luatest')
+local server = require('luatest.server')
+local netbox = require('net.box')
+
+local g = t.group('fiber_limit_test')
+
+g.before_all(function()
+    g.server = server:new({
+        alias = 'limited_instance',
+        box_cfg = {}
+    })
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:stop()
+    g.server:drop()
+end)
+
+g.test_fiber_limit_and_system_fibers = function()
+    local fiber_limit = 30
+
+    local result = g.server:exec(function(fiber_limit)
+        local fiber = require('fiber')
+        fiber.client_fiber_limit(fiber_limit)
+        local errors = {}
+
+        for _ = 1, fiber_limit + 5 do
+            local ok, err = pcall(fiber.new, function() fiber.sleep(100) end)
+            if not ok then
+                table.insert(errors, tostring(err))
+                break
+            end
+        end
+
+        return { errors = errors }
+    end, {fiber_limit})
+
+    local errors = result.errors
+    t.assert_gt(#errors, 0)
+    t.assert_str_contains(errors[1], "fiber count is exceeded")
+
+    local conns = {}
+    for i = 1, 10 do
+        conns[i] = netbox.connect(g.server.net_box_uri)
+        t.assert(conns[i]:ping())
+    end
+
+    local sys_fiber_ok = g.server:exec(function()
+        return true
+    end)
+    t.assert(
+        sys_fiber_ok,
+        "System fibers should work, even if the client limit is exceeded"
+    )
+
+    for i = 1, 10 do
+        conns[i]:close()
+    end
+end


### PR DESCRIPTION
feature: add fiber limit validation based on vm.max_map_count

Added a dynamic validation mechanism to `fiber_new_ex()` that limits
the number of client fibers based on `vm.max_map_count`. This prevents
excessive fiber creation and potential memory allocation failures.
The validation ensures that the number of client fibers does not
exceed 45% of available mappings.

Closes #10169
@TarantoolBot document
Title: Fiber limit management based on vm.max_map_count
Since: 3.4

A new mechanism has been introduced to prevent excessive fiber creation that 
could lead to memory allocation failures.

Automatic Fiber Limit Calculation

The maximum number of client fibers (`client_fiber_count`) is set dynamically 
based on the system's `vm.max_map_count`.
The default limit is 45% of `vm.max_map_count / 2`, ensuring that at most 
90% of available mappings are used.
If the limit is exceeded, new client fibers cannot be created, and an error 
is logged.

Manual Configuration
Users can manually set the client fiber limit via:
```lua
fiber.client_fiber_limit(N)
```

System Fibers Are Not Restricted
The limit only applies to client fibers.
System fibers (such as replication workers) are not affected.