### PR TITLE
box: call destroy callback for stmt on rollback trigger

### DIFF
--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -335,6 +335,8 @@ txn_stmt_destroy(struct txn_stmt *stmt)
 {
 	assert(stmt->add_story == NULL && stmt->del_story == NULL);
 
+	if (stmt->has_triggers)
+		trigger_destroy(&stmt->on_rollback);
 	if (stmt->old_tuple != NULL)
 		tuple_unref(stmt->old_tuple);
 	if (stmt->new_tuple != NULL)

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -817,8 +817,6 @@ static inline void
 txn_stmt_on_rollback(struct txn_stmt *stmt, struct trigger *trigger)
 {
 	txn_stmt_init_triggers(stmt);
-	/* Statement triggers are private and never have anything to free. */
-	assert(trigger->destroy == NULL);
 	trigger_add(&stmt->on_rollback, trigger);
 }
 


### PR DESCRIPTION
Without it we have to add on commit trigger just to destroy on rollback trigger in memcs and memtx index build.

Part of tarantool/tarantool-ee#893

Required for EE PR https://github.com/tarantool/tarantool-ee/pull/1153.