### PR TITLE
[2.11] build: fix install paths in Ubuntu Noble package

### DIFF
--- a/.github/actions/pack-and-deploy/action.yml
+++ b/.github/actions/pack-and-deploy/action.yml
@@ -12,6 +12,9 @@ runs:
         # Create packages.
         make -f .pack.mk package
 
+        # Verify package content.
+        make -f .pack.mk verify-package
+
         # Deploy pre-release (since 2.10) and release packages. It's expected
         # that no one will push tags are used for pre-releases and releases.
         if ${{ ( startsWith(github.ref, 'refs/tags/2.') ||

--- a/debian/control
+++ b/debian/control
@@ -34,6 +34,15 @@ Build-Depends: cdbs (>= 0.4.100), debhelper (>= 9), dpkg-dev (>= 1.16.1~),
  tzdata,
 # For third-party subprojects that are built with autotools.
  autoconf, automake, libtool,
+# pkg-config is needed to determine a prefix to install systemd
+# service.
+ pkgconf,
+# systemd.pc is shipped within the systemd package until 253-1,
+# but starting from 253-2 the pkg-config file is moved to the
+# separate systemd-dev package.
+ systemd-dev | systemd (<< 253-2~),
+# dh-exec is needed to preprocess *.install files.
+ dh-exec,
 Section: database
 Standards-Version: 4.5.1
 Homepage: http://tarantool.org/

--- a/debian/rules
+++ b/debian/rules
@@ -6,6 +6,8 @@ UVERSION := $(shell echo $(VERSION)|sed 's/-[[:digit:]]\+$$//')
 
 ifneq ($(wildcard /usr/bin/dh_systemd_start),)
 WITH_SYSTEMD:=ON
+export deb_systemdsystemunitdir = $(shell pkgconf --variable=systemdsystemunitdir systemd)
+export deb_systemdsystemgeneratordir = $(shell pkgconf --variable=systemdsystemgeneratordir systemd)
 else
 WITH_SYSTEMD:=OFF
 endif

--- a/debian/tarantool-common.install.systemd.in
+++ b/debian/tarantool-common.install.systemd.in
@@ -1,9 +1,10 @@
+#!/usr/bin/dh-exec
 /etc/default/tarantool
 /usr/bin/tarantoolctl
 /etc/tarantool/instances.available/example.lua
 /etc/logrotate.d/tarantool
-/lib/systemd/system/tarantool.service
-/lib/systemd/system/tarantool@.service
-/lib/systemd/system-generators/tarantool-generator
+${deb_systemdsystemunitdir}/tarantool.service
+${deb_systemdsystemunitdir}/tarantool@.service
+${deb_systemdsystemgeneratordir}/tarantool-generator
 /usr/lib/tmpfiles.d/tarantool.conf
 /usr/share/man/man1/tarantoolctl.1


### PR DESCRIPTION
The tarantool-common package should install systemd service files and the generator file into `/usr/lib/systemd` (not `/lib/systemd`) on Ubuntu 24.04 Noble.

This commits fixes the paths in the same way as it was done in https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1063699. The paths in the previous OS versions are not changed and a related test is added.

Also, note that Debian Bookworm package should keep installing these files into `/lib/systemd`. It was decided by the Debian Technical Committee (quoted from https://lists.debian.org/debian-devel/2021/10/msg00190.html):

> Please stop moving individual packages' files from the root filesystem into /usr, at least for now.

The problem only affects 2.11 series, because 3.x doesn't ship systemd service files.

Fixes #11234