### PR TITLE
lua: bump metrics module

### DIFF
--- a/changelogs/unreleased/bump-metrics-to-1.3.0.md
+++ b/changelogs/unreleased/bump-metrics-to-1.3.0.md
@@ -1,0 +1,12 @@
+## feature/metrics
+
+* Updated the metrics submodule to 1.3.0.
+
+  - Fixed read-only status detection in the replication metrics
+    ([gh-495][mgh-495]).
+
+  - Added a new `cpu_extended` metrics category, enabled by default
+    ([gh-498][mgh-498]).
+
+[mgh-495]: https://github.com/tarantool/metrics/pull/495
+[mgh-498]: https://github.com/tarantool/metrics/pull/498

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1704,6 +1704,7 @@ return schema.new('instance_config', schema.record({
             'luajit',
             'clock',
             'event_loop',
+            'cpu_extended',
         }),
         exclude = schema.set({
             'all',
@@ -1723,6 +1724,7 @@ return schema.new('instance_config', schema.record({
             'luajit',
             'clock',
             'event_loop',
+            'cpu_extended',
         }),
         labels = schema.map({
             key = schema.scalar({type = 'string'}),

--- a/test/config-luatest/config_test.lua
+++ b/test/config-luatest/config_test.lua
@@ -825,6 +825,45 @@ g.test_metrics_options = function()
     end)
 end
 
+g.test_metrics_1_3_0_options = function()
+    local dir = treegen.prepare_directory({}, {})
+    local config = [[
+        credentials:
+          users:
+            guest:
+              roles:
+              - super
+
+        iproto:
+          listen:
+            - uri: unix/:./{{ instance_name }}.iproto
+
+        metrics:
+          include: [all]
+          exclude: [cpu_extended]
+
+        groups:
+          group-001:
+            replicasets:
+              replicaset-001:
+                instances:
+                  instance-001: {}
+    ]]
+
+    local config_file = treegen.write_file(dir, 'base_config.yaml', config)
+    local opts = {
+        config_file = config_file,
+        alias = 'instance-001',
+        chdir = dir,
+    }
+    g.server = server:new(opts)
+    g.server:start()
+    g.server:exec(function()
+        t.assert_equals(box.cfg.metrics.include, {'all'})
+        t.assert_equals(box.cfg.metrics.exclude, {'cpu_extended'})
+    end)
+end
+
 g.test_audit_options = function()
     t.tarantool.skip_if_not_enterprise()
     local dir = treegen.prepare_directory({}, {})


### PR DESCRIPTION
Bump metrics package submodule. Commits from PRs [1-2] affect Tarantool, the other ones are related to module infrastructure.

1. tarantool/metrics#495
2. tarantool/metrics#498

NO_DOC=doc is a part of the submodule