### PR TITLE
config: remove tricks around non-scalar defaults

### DIFF
--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -680,9 +680,6 @@ return schema.new('instance_config', schema.record({
                 type = 'number, string',
             }),
             box_cfg = 'log_modules',
-            -- TODO(gh-10756): This default doesn't work now. It
-            -- needs support of non-scalar schema nodes in
-            -- <schema object>:map().
             default = box.NULL,
         }),
     }, {
@@ -725,6 +722,7 @@ return schema.new('instance_config', schema.record({
                 validate = validators['iproto.listen.*'],
             }),
             box_cfg = 'listen',
+            default = box.NULL,
         }),
         -- URIs for clients to let them know where to connect.
         --
@@ -1147,9 +1145,6 @@ return schema.new('instance_config', schema.record({
             }),
         }, {
             box_cfg = 'wal_ext',
-            -- TODO(gh-10756): This default doesn't work now. It
-            -- needs support of non-scalar schema nodes in
-            -- <schema object>:map().
             default = box.NULL,
         })),
     }),
@@ -1929,9 +1924,6 @@ return schema.new('instance_config', schema.record({
             }),
             box_cfg = 'audit_spaces',
             box_cfg_nondynamic = true,
-            -- TODO(gh-10756): This default doesn't work now. It
-            -- needs support of non-scalar schema nodes in
-            -- <schema object>:map().
             default = box.NULL,
         })),
         extract_key = enterprise_edition(schema.scalar({


### PR DESCRIPTION
This is purely refactoring change: it eliminates code that was needed before the schema module began to support default values for schema nodes of composite types (see #10756). Now, we can just assign the defaults in the schema and it works as expected.

Follows up #10756
Follows up #10757
Follows up #10758
Follows up #10759
Follows up #11153