### PR TITLE
perf: don't raise an error for tests on macOS

### DIFF
--- a/perf/lua/benchmark.lua
+++ b/perf/lua/benchmark.lua
@@ -132,7 +132,13 @@ end
 
 local function load_average()
     local path = '/proc/loadavg'
-    local fh = assert(fio.open(path, {'O_RDONLY'}))
+    local fh, errmsg = fio.open(path, {'O_RDONLY'})
+    if not fh then
+        -- It is a different file layout on macOS, so there is no
+        -- </proc>. Just do not initialize that field.
+        io.stderr:write(("Can't open file '%s': %s\n"):format(path, errmsg))
+        return nil
+    end
     local loadavg_buf = fh:read(1024)
     fh:close()
     -- Format is '0.89 0.66 0.80 2/1576 1203510'.


### PR DESCRIPTION
There is no </proc> in the macOS file layout, so performance tests fail when trying to open the /proc/loadavg file:

| SystemError: fio: No such file or directory
| fatal error, exiting the event loop

This patch ignores the absence of the file and just prints the warning in that case without initialization of the corresponding field.

Closes #11158

NO_CHANGELOG=performance
NO_DOC=performance
NO_TEST=performance