### PR TITLE
vinyl: fix space truncation being aborted by yield under load

### DIFF
--- a/changelogs/unreleased/gh-11249-vy-space-truncate-under-load-fix.md
+++ b/changelogs/unreleased/gh-11249-vy-space-truncate-under-load-fix.md
@@ -1,0 +1,4 @@
+## bugfix/vinyl
+
+* Fixed a bug when `space:truncate()` failed with `ER_TRANSACTION_YIELD`
+  (gh-11249).

--- a/test/engine-luatest/gh_11249_space_truncate_under_load_test.lua
+++ b/test/engine-luatest/gh_11249_space_truncate_under_load_test.lua
@@ -1,0 +1,99 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group('space_truncate_under_load', t.helpers.matrix{
+    engine = {'memtx', 'vinyl'},
+})
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new({
+        box_cfg = {memtx_use_mvcc_engine = true},
+    })
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+g.test_space_truncate_under_load = function(cg)
+    cg.server:exec(function(params)
+        local fiber = require('fiber')
+
+        local s = box.schema.space.create('test', {engine = params.engine})
+        s:create_index('primary')
+        s:create_index('secondary', {
+            unique = false,
+            parts = {{2, 'unsigned'}},
+        })
+
+        for i = 1, 10 do
+            s:replace({i, i * 10})
+        end
+
+        local cond = fiber.cond()
+        local inprogress = {}
+        for i = 1, 5 do
+            local f = fiber.new(function()
+                box.begin()
+                s:replace({i, i * 100})
+                s:replace({i + 10, i * 5})
+                cond:wait()
+                box.commit()
+            end)
+            f:set_joinable(true)
+            table.insert(inprogress, f)
+        end
+
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+
+        local unconfirmed = {}
+        for i = 5, 10 do
+            local f = fiber.new(function()
+                box.begin()
+                s:replace({i, i * 100})
+                s:replace({i + 10, i * 5})
+                box.commit()
+            end)
+            f:set_joinable(true)
+            table.insert(unconfirmed, f)
+        end
+        fiber.yield()
+
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        s:truncate()
+
+        t.assert_equals(s:select(), {})
+
+        local function join(f)
+            local ok, err = f:join(10)
+            if not ok then
+                error(err)
+            end
+        end
+
+        cond:broadcast()
+        for _, f in ipairs(inprogress) do
+            t.assert_error_covers({
+                type = 'ClientError',
+                code = box.error.TRANSACTION_CONFLICT,
+            }, join, f)
+        end
+
+        for _, f in ipairs(unconfirmed) do
+            join(f)
+        end
+
+        t.assert_equals(s:select(), {})
+    end, {cg.params})
+end


### PR DESCRIPTION
Under the hood, `space:truncate()` calls `space_vtab::build_index` to notify the engine about index recreation, see `TruncateIndex::prepare`. `space_vtab::build_index` isn't supposed to yield in this case because the space is empty (note that `TruncateIndex::prepare` passes the new space to the callback). However, there's a bug in vinyl that makes this callback yield for no good reason, aborting `space:truncate()` with `ER_TRANSACTION_YIELD`.

The problem lies in `vy_tx_manager_abort_writers_for_ddl()`, which is called by `vinyl_space_build_index()` to abort all transactions that write to the target space. If a transaction can't be aborted because it has reached WAL, the function sets the `need_wal_sync` flag which indicates the caller that they should call `wal_sync()` to flush all unconfirmed transactions. In case of a space truncation, the function should do nothing because there can't possibly be a transaction writing to the new space, but actually it sets `need_wal_sync` if there's any transaction waiting for WAL. This mistake doesn't lead to any problems during an actual index build, but in case of a space truncation it results in the transaction being aborted by a fiber yield.

Let's fix this problem by setting the `need_wal_sync` flag only if there are transactions that actually write to the target space.

Closes #11249