### PR TITLE
config/schema: support `unique_items` annotation

### DIFF
--- a/changelogs/unreleased/config-schema-unique-items.md
+++ b/changelogs/unreleased/config-schema-unique-items.md
@@ -1,0 +1,5 @@
+## feature/config
+
+* `<schema object>:validate()` now takes into account the `unique_items` annotation.
+
+  Also, `schema.set()` now accepts a user-provided `validate` annotation.

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1739,11 +1739,12 @@ return schema.new('instance_config', schema.record({
             default = 1,
             validate = validators['sharding.weight'],
         }),
-        -- TODO: Add validate.
         roles = schema.set({
             'router',
             'storage',
             'rebalancer',
+        }, {
+            validate = validators['sharding.roles'],
         }),
         -- Global vshard options.
         shard_index = schema.scalar({
@@ -1811,8 +1812,6 @@ return schema.new('instance_config', schema.record({
             default = 1,
             validate = validators['sharding.sched_move_quota'],
         }),
-    }, {
-        validate = validators['sharding'],
     }),
     audit_log = enterprise_edition(schema.record({
         -- The same as the destination for the logger, audit logger destination

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -625,32 +625,6 @@ g.test_name_failure = function()
     end
 end
 
-g.test_sharding = function()
-    local config = {
-        groups = {
-            ['group-001'] = {
-                replicasets = {
-                    ['replicaset-001'] = {
-                        instances = {
-                            ['instance-001'] = {
-                                sharding = {
-                                    roles = {'storage'},
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-        },
-    }
-    local err = '[cluster_config] groups.group-001.replicasets.' ..
-                'replicaset-001.instances.instance-001.sharding: ' ..
-                'sharding.roles cannot be defined in the instance scope'
-    t.assert_error_msg_equals(err, function()
-        cluster_config:validate(config)
-    end)
-end
-
 -- Verify options consistency on the global level.
 --
 -- Expected instance config fields plus the following additional
@@ -778,6 +752,7 @@ end
 -- * sharding.shard_index
 -- * sharding.sync_timeout
 -- * sharding.weight
+-- * sharding.roles
 g.test_scope = function()
     local function exp_err(path, scope)
         return ('[cluster_config] %s: The option must not be present in the ' ..
@@ -996,6 +971,18 @@ g.test_scope = function()
             data = {
                 sharding = {
                     weight = 10,
+                },
+            },
+            global = true,
+            group = true,
+            replicaset = true,
+            instance = false,
+        },
+        {
+            name = 'sharding.roles',
+            data = {
+                sharding = {
+                    roles = {'storage'},
                 },
             },
             global = true,

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1727,8 +1727,8 @@ g.test_sharding = function()
             roles = {'router', 'rebalancer'},
         },
     }
-    local err = '[instance_config] sharding: The rebalancer role cannot be ' ..
-                'present without the storage role'
+    local err = '[instance_config] sharding.roles: The rebalancer role ' ..
+                'cannot be present without the storage role'
     t.assert_error_msg_equals(err, function()
         instance_config:validate(iconfig)
     end)


### PR DESCRIPTION
Now, the `experimental.config.utils.schema` module has the `unique_items` annotation taken into account by the `<schema object>:validate()` method.

The annotation can be assigned to a schema node that represents an array of strings. An attempt to assign it to another schema node leads to an error on the schema object creation (`schema.new()`).

The `<schema object>:validate()` method now raises an error if the `unique_items` annotation is assigned and truthly, but the corresponding value (an array) contains the same string two or more times.

The `schema.set()` constructor (creates an array with enumerated values without duplicates) now assigns the `unique_items` annotation to the created schema node instead of defining its own `validate` annotation.

The `schema.set()` constructor now allows a user to define the `validate` annotation for the new schema node.

Example 1 (use `unique_items`):

```lua
local schema = require('experimental.config.utils.schema')

local s = schema.new('myschema', schema.array({
    items = schema.scalar({type = 'string'}),
    unique_items = true,
}))

s:validate({'foo', 'bar'})
-- OK

s:validate({'foo', 'foo'})
-- error: [myschema] Values should be unique, but "foo" appears at least
-- twice
```

Example 2 (use the `schema.set()` constructor):

```lua
local schema = require('experimental.config.utils.schema')

local s = schema.new('myschema', schema.set({'foo', 'bar'}))

s:validate({'foo', 'bar'})
-- OK

s:validate({'foo', 'foo'})
-- error: [myschema] Values should be unique, but "foo" appears at least
-- twice
```

Example 3 (use the `validate` annotation):

```lua
local fun = require('fun')
local schema = require('experimental.config.utils.schema')

local s = schema.new('myschema', schema.set({
    'router',
    'storage',
    'rebalancer',
}, {
    validate = function(data, w)
        local kv = fun.iter(data):map(function(x) return x, true end):tomap()
        if kv.rebalancer and not kv.storage then
            w.error('rebalancer needs storage role enabled')
        end
    end,
}))

s:validate({'storage', 'rebalancer'})
-- OK

s:validate({'rebalancer'})
-- error: [myschema] rebalancer needs storage role enabled
```

Example 4 (`unique_items` on an unsupported type):

```lua
local schema = require('experimental.config.utils.schema')

local s = schema.new('myschema', schema.array({
    items = schema.scalar({type = 'integer'}),
    unique_items = true,
}))
-- error: [myschema] "unique_items" requires an array of strings, got an
-- array of integer items
```

----

The second patch uses the new feature to simplify config's validation code a bit. It uses the `schema.set()` constructor with the `validate` annotation, because now it is possible.