### PR TITLE
engine: abort writing transactions after ro switch

### DIFF
--- a/changelogs/unreleased/gh-9937-commit-transaction-after-readonly.md
+++ b/changelogs/unreleased/gh-9937-commit-transaction-after-readonly.md
@@ -1,0 +1,4 @@
+## bugfix/memtx
+
+* Fixed a bug when it was possible to commit the transaction even if the node
+  became read-only (gh-9937).

--- a/src/box/blackhole.c
+++ b/src/box/blackhole.c
@@ -189,7 +189,6 @@ static const struct engine_vtab blackhole_engine_vtab = {
 	/* .rollback = */ generic_engine_rollback,
 	/* .send_to_read_view = */ generic_engine_send_to_read_view,
 	/* .abort_with_conflict = */ generic_engine_abort_with_conflict,
-	/* .switch_to_ro = */ generic_engine_switch_to_ro,
 	/* .bootstrap = */ generic_engine_bootstrap,
 	/* .begin_initial_recovery = */ generic_engine_begin_initial_recovery,
 	/* .begin_final_recovery = */ generic_engine_begin_final_recovery,

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -415,7 +415,6 @@ box_update_ro_summary(void)
 	if (is_ro_summary == old_is_ro_summary)
 		return;
 	if (is_ro_summary) {
-		engine_switch_to_ro();
 		struct txn *txn;
 		rlist_foreach_entry(txn, &txns, in_txns) {
 			if (txn->n_new_rows != 0 &&

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -416,6 +416,15 @@ box_update_ro_summary(void)
 		return;
 	if (is_ro_summary) {
 		engine_switch_to_ro();
+		struct txn *txn;
+		rlist_foreach_entry(txn, &txns, in_txns) {
+			if (txn->n_new_rows != 0 &&
+			    txn->n_new_rows != txn->n_local_rows &&
+			    txn->status == TXN_INPROGRESS) {
+				txn_abort_with_conflict(txn);
+				txn_set_flags(txn, TXN_IS_ABORTED_RO_NODE);
+			}
+		}
 		char *buf = tt_static_buf();
 		VERIFY(box_ro_state_msg(buf, TT_STATIC_BUF_LEN) == 0);
 		say_info("box switched to read-only - %s", buf);

--- a/src/box/engine.c
+++ b/src/box/engine.c
@@ -84,14 +84,6 @@ engine_free(void)
 	engine_count = 0;
 }
 
-void
-engine_switch_to_ro(void)
-{
-	struct engine *engine;
-	engine_foreach(engine)
-		engine->vtab->switch_to_ro(engine);
-}
-
 int
 engine_bootstrap(void)
 {
@@ -362,12 +354,6 @@ generic_engine_abort_with_conflict(struct engine *engine, struct txn *txn)
 	(void)engine;
 	(void)txn;
 	unreachable();
-}
-
-void
-generic_engine_switch_to_ro(struct engine *engine)
-{
-	(void)engine;
 }
 
 int

--- a/src/box/engine.h
+++ b/src/box/engine.h
@@ -198,12 +198,6 @@ struct engine_vtab {
 	 */
 	void (*abort_with_conflict)(struct engine *engine, struct txn *txn);
 	/**
-	 * Notify the engine that the instance is about to switch
-	 * to read-only mode. The engine is supposed to abort all
-	 * active rw transactions when this method is called.
-	 */
-	void (*switch_to_ro)(struct engine *);
-	/**
 	 * Bootstrap an empty data directory
 	 */
 	int (*bootstrap)(struct engine *);
@@ -481,12 +475,6 @@ void
 engine_free(void);
 
 /**
- * Called before switching the instance to read-only mode.
- */
-void
-engine_switch_to_ro(void);
-
-/**
  * Initialize an empty data directory
  */
 int
@@ -569,7 +557,6 @@ void generic_engine_rollback_statement(struct engine *, struct txn *,
 void generic_engine_rollback(struct engine *, struct txn *);
 void generic_engine_send_to_read_view(struct engine *, struct txn *, int64_t);
 void generic_engine_abort_with_conflict(struct engine *, struct txn *);
-void generic_engine_switch_to_ro(struct engine *);
 int generic_engine_bootstrap(struct engine *);
 int generic_engine_begin_initial_recovery(struct engine *,
 					  const struct vclock *);

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -1568,7 +1568,6 @@ static const struct engine_vtab memtx_engine_vtab = {
 	/* .rollback = */ generic_engine_rollback,
 	/* .send_to_read_view = */ memtx_engine_send_to_read_view,
 	/* .abort_with_conflict = */ memtx_engine_abort_with_conflict,
-	/* .switch_to_ro = */ generic_engine_switch_to_ro,
 	/* .bootstrap = */ memtx_engine_bootstrap,
 	/* .begin_initial_recovery = */ memtx_engine_begin_initial_recovery,
 	/* .begin_final_recovery = */ memtx_engine_begin_final_recovery,

--- a/src/box/service_engine.c
+++ b/src/box/service_engine.c
@@ -103,7 +103,6 @@ static const struct engine_vtab service_engine_vtab = {
 	/* .rollback = */ generic_engine_rollback,
 	/* .send_to_read_view = */ generic_engine_send_to_read_view,
 	/* .abort_with_conflict = */ generic_engine_abort_with_conflict,
-	/* .switch_to_ro = */ generic_engine_switch_to_ro,
 	/* .bootstrap = */ generic_engine_bootstrap,
 	/* .begin_initial_recovery = */ generic_engine_begin_initial_recovery,
 	/* .begin_final_recovery = */ generic_engine_begin_final_recovery,

--- a/src/box/sysview.c
+++ b/src/box/sysview.c
@@ -573,7 +573,6 @@ static const struct engine_vtab sysview_engine_vtab = {
 	/* .rollback = */ generic_engine_rollback,
 	/* .send_to_read_view = */ generic_engine_send_to_read_view,
 	/* .abort_with_conflict = */ generic_engine_abort_with_conflict,
-	/* .switch_to_ro = */ generic_engine_switch_to_ro,
 	/* .bootstrap = */ generic_engine_bootstrap,
 	/* .begin_initial_recovery = */ generic_engine_begin_initial_recovery,
 	/* .begin_final_recovery = */ generic_engine_begin_final_recovery,

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -127,6 +127,11 @@ enum txn_flag {
 	 * then memory allocated even if memory limit is reached.
 	 */
 	TXN_STMT_ROLLBACK = 0x1000,
+	/**
+	 * Transaction has been aborted since the instance has become
+	 * read-only so no writes should be committed.
+	 */
+	TXN_IS_ABORTED_RO_NODE = 0x2000,
 };
 
 enum {
@@ -596,6 +601,8 @@ txn_clear_flags(struct txn *txn, unsigned int flags)
 static inline enum box_error_code
 txn_flags_to_error_code(struct txn *txn)
 {
+	if (txn_has_flag(txn, TXN_IS_ABORTED_RO_NODE))
+		return ER_READONLY;
 	if (txn_has_flag(txn, TXN_IS_CONFLICTED))
 		return ER_TRANSACTION_CONFLICT;
 	else if (txn_has_flag(txn, TXN_IS_ABORTED_BY_YIELD))

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -2634,12 +2634,6 @@ vinyl_engine_abort_with_conflict(struct engine *engine, struct txn *txn)
 	vy_tx_abort_with_conflict_impl(tx);
 }
 
-static void
-vinyl_engine_switch_to_ro(struct engine *engine)
-{
-	vy_tx_manager_abort_writers_for_ro(engine);
-}
-
 /* }}} Public API of transaction control */
 
 /** {{{ Environment */
@@ -4774,7 +4768,7 @@ static const struct engine_vtab vinyl_engine_vtab = {
 	/* .rollback = */ vinyl_engine_rollback,
 	/* .send_to_read_view = */ vinyl_engine_send_to_read_view,
 	/* .abort_with_conflict = */ vinyl_engine_abort_with_conflict,
-	/* .switch_to_ro = */ vinyl_engine_switch_to_ro,
+	/* .switch_to_ro = */ generic_engine_switch_to_ro,
 	/* .bootstrap = */ vinyl_engine_bootstrap,
 	/* .begin_initial_recovery = */ vinyl_engine_begin_initial_recovery,
 	/* .begin_final_recovery = */ vinyl_engine_begin_final_recovery,

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -4768,7 +4768,6 @@ static const struct engine_vtab vinyl_engine_vtab = {
 	/* .rollback = */ vinyl_engine_rollback,
 	/* .send_to_read_view = */ vinyl_engine_send_to_read_view,
 	/* .abort_with_conflict = */ vinyl_engine_abort_with_conflict,
-	/* .switch_to_ro = */ generic_engine_switch_to_ro,
 	/* .bootstrap = */ vinyl_engine_bootstrap,
 	/* .begin_initial_recovery = */ vinyl_engine_begin_initial_recovery,
 	/* .begin_final_recovery = */ vinyl_engine_begin_final_recovery,

--- a/src/box/vy_tx.c
+++ b/src/box/vy_tx.c
@@ -1110,20 +1110,6 @@ vy_tx_manager_abort_writers_for_ddl(struct space *space, bool *need_wal_sync)
 }
 
 void
-vy_tx_manager_abort_writers_for_ro(struct engine *engine)
-{
-	struct txn *txn;
-	rlist_foreach_entry(txn, &txns, in_txns) {
-		struct vy_tx *tx = txn->engines_tx[engine->id];
-		if (tx == NULL || stailq_empty(&txn->stmts))
-			continue;
-		/* Applier ignores ro flag. */
-		if (tx->state == VINYL_TX_READY && !tx->is_applier_session)
-			vy_tx_abort_with_conflict(tx);
-	}
-}
-
-void
 vy_txw_iterator_open(struct vy_txw_iterator *itr,
 		     struct vy_txw_iterator_stat *stat,
 		     struct vy_tx *tx, struct vy_lsm *lsm,

--- a/src/box/vy_tx.h
+++ b/src/box/vy_tx.h
@@ -332,13 +332,6 @@ vy_tx_manager_destroy_read_view(struct vy_tx_manager *xm,
 void
 vy_tx_manager_abort_writers_for_ddl(struct space *space, bool *need_wal_sync);
 
-/**
- * Abort all local rw transactions that haven't reached WAL yet.
- * Called before switching to read-only mode.
- */
-void
-vy_tx_manager_abort_writers_for_ro(struct engine *engine);
-
 /** Initialize a tx object. */
 void
 vy_tx_create(struct vy_tx_manager *xm, struct vy_tx *tx);

--- a/test/engine-luatest/gh_9937_commit_transaction_after_readonly_test.lua
+++ b/test/engine-luatest/gh_9937_commit_transaction_after_readonly_test.lua
@@ -1,0 +1,84 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group('storage', {{engine = 'memtx'}, {engine = 'vinyl'}})
+
+g.before_all(function(cg)
+    cg.server = server:new({box_cfg = {memtx_use_mvcc_engine = true}})
+    cg.server:start()
+end)
+
+g.after_each(function(cg)
+    cg.server:update_box_cfg{read_only = false}
+    cg.server:exec(function()
+        box.space.test:drop()
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_try_commit_after_readonly = function(cg)
+    cg.server:exec(function(engine)
+        local fiber = require('fiber')
+        local s = box.schema.space.create('test', {engine = engine})
+        s:create_index('pk')
+        local inserted_before_ro = false
+        local insert_fiber = fiber.new(function()
+            box.begin()
+            s:insert{1}
+            inserted_before_ro = true
+            box.ctl.wait_ro()
+            box.commit()
+        end)
+        insert_fiber:set_joinable(true)
+        t.helpers.retrying({}, function()
+            t.assert(inserted_before_ro)
+        end)
+        box.cfg{read_only = true}
+        t.assert_error_covers({
+            type = 'ClientError',
+            code = box.error.READONLY,
+        }, function()
+            local ok, err = insert_fiber:join()
+            if not ok then
+                error(err)
+            end
+        end)
+        t.assert_equals(#s:select(), 0)
+    end, {cg.params.engine})
+end
+
+local function commit_success_template(cg, space_opt)
+    cg.server:exec(function(space_opt)
+        local fiber = require('fiber')
+        local s = box.schema.space.create('test', space_opt)
+        s:create_index('pk')
+        local inserted_before_ro = false
+        local insert_fiber = fiber.new(function()
+            box.begin()
+            s:insert{1}
+            inserted_before_ro = true
+            box.ctl.wait_ro()
+            box.commit()
+        end)
+        insert_fiber:set_joinable(true)
+        t.helpers.retrying({}, function()
+            t.assert(inserted_before_ro)
+        end)
+        box.cfg{read_only = true}
+        local ok, _ = insert_fiber:join()
+        t.assert(ok)
+        t.assert_equals(#s:select(), 1)
+    end, {space_opt})
+end
+
+g.test_try_commit_local_after_readonly = function(cg)
+    commit_success_template(cg, {engine = cg.params.engine, is_local = true})
+end
+
+g.test_try_commit_temporary_after_readonly = function(cg)
+    t.skip_if(cg.params.engine ~= 'memtx')
+    commit_success_template(cg, {engine = cg.params.engine, temporary = true})
+end

--- a/test/vinyl/misc.result
+++ b/test/vinyl/misc.result
@@ -358,11 +358,11 @@ ch1:get()
 ...
 ch1:get()
 ---
-- Transaction has been aborted by conflict
+- Can't modify data on a read-only instance
 ...
 ch1:get()
 ---
-- Transaction has been aborted by conflict
+- Can't modify data on a read-only instance
 ...
 ch2:get()
 ---


### PR DESCRIPTION
The `switch_to_ro` callback was first introduced in the `engine_vtab` as a solution to the issue in vinyl, where it was possible to commit a transaction after becoming read-only. Since mvcc was introduced in the memtx engine, a similar issue became possible. A possible solution in the memtx engine with implementing the `switch_to_ro` callback would just abort all writing transactions related to memtx, so cross-engine transactions would be aborted in vinyl and memtx, which doesn't introduce a bug but seems redundant. So now we just abort all writing transactions disregarding the engine which resulted in the `switch_to_ro` callback becoming useless. It is now impossible for a fiber to awake and commit after switching the node to read-only. Also more explicit error messages were implemented to address this situation.

Fixes https://github.com/tarantool/tarantool/issues/9937
NO_DOC=bugfix