### PR TITLE
config: call roles `stop` callback on shutdown

### DIFF
--- a/changelogs/unreleased/gh-10795-role-stop-on-shutdown.md
+++ b/changelogs/unreleased/gh-10795-role-stop-on-shutdown.md
@@ -1,0 +1,3 @@
+## feature/config
+* Now the `stop` callback for the roles is called during graceful shutdown. The
+  `stop` callbacks are called in the reverse order of roles startup (gh-10795).


### PR DESCRIPTION
This commit makes it so the `stop` callbacks are called for all registered roles, in the reverse order of roles startup.

Closed #10795
Closes TNTP-667

@TarantoolBot document
Title: roles are stopped on graceful shutdown

From now on during the graceful shutdown process `stop` callback for all registered roles are called in the reverse order of roles startup.