### PR TITLE
config: add API to test if role is set for instance

### DIFF
--- a/changelogs/unreleased/gh-11288-enabled-roles-api.md
+++ b/changelogs/unreleased/gh-11288-enabled-roles-api.md
@@ -1,0 +1,3 @@
+## feature/config
+* Added the `has_role`, `is_router`, and `is_storage` methods to the
+  `config` module to check if a role is enabled on an instance (gh-11288).

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -529,6 +529,68 @@ function methods.info(self, version)
         table.concat(supported_versions, ', '), version), 0)
 end
 
+function methods.is_storage(self, opts)
+    selfcheck(self, 'is_storage')
+    initcheck(self, 'is_storage', 'cluster')
+
+    opts = opts or {}
+    if opts.instance ~= nil and type(opts.instance) ~= 'string' then
+        error(('Expected string, got %s'):format(type(opts.instance)), 0)
+    end
+
+    local sharding_roles = self:get(
+        'sharding.roles', {instance = opts.instance}) or {}
+
+    for _, role in ipairs(sharding_roles) do
+        if role == 'storage' then
+            return true
+        end
+    end
+    return false
+end
+
+function methods.is_router(self, opts)
+    selfcheck(self, 'is_router')
+    initcheck(self, 'is_router', 'cluster')
+
+    opts = opts or {}
+    if opts.instance ~= nil and type(opts.instance) ~= 'string' then
+        error(('Expected string, got %s'):format(type(opts.instance)), 0)
+    end
+
+    local sharding_roles = self:get(
+        'sharding.roles', {instance = opts.instance}) or {}
+
+    for _, role in ipairs(sharding_roles) do
+        if role == 'router' then
+            return true
+        end
+    end
+    return false
+end
+
+function methods.has_role(self, role, opts)
+    selfcheck(self, 'has_role')
+    initcheck(self, 'has_role', 'cluster')
+    if type(role) ~= 'string' then
+        error(('Expected string, got %s'):format(type(role)), 0)
+    end
+
+    opts = opts or {}
+    if opts.instance ~= nil and type(opts.instance) ~= 'string' then
+        error(('Expected string, got %s'):format(type(opts.instance)), 0)
+    end
+
+    local roles = self:get('roles', {instance = opts.instance}) or {}
+
+    for _, r in ipairs(roles) do
+        if r == role then
+            return true
+        end
+    end
+    return false
+end
+
 -- Cluster configuration (internal method).
 --
 -- It is given as is after merging from all the configuration


### PR DESCRIPTION
config: add API to test if role is set for instance

New `has_role`, `is_router` and `is_storage` methods added to the config
module.

Closes #11288
Closes TNTP-969

@TarantoolBot document
Title: config module `has_role`, `is_router` and `is_storage` methods

`has_role(<role_name>, {instance = <instance_name})` returns true if
the instance with the name <instance_name> has role <role_name> enabled
in the current config, false if not. Second argument is optional, and
if not provided the check will be done for the instance the method is
called on.

`is_router({instance = <instance_name})` returns true if the instance
with name <instance_name> is a vshard router, according to the current
config, false if not. Argument is optional, and if not provided the
check will be done for the instance the method is called on.

`is_storage({instance = <instance_name})` returns true if the instance
with name <instance_name> is a vshard storage, according to the current
config, false if not. Argument is optional, and if not provided the
check will be done for the instance the method is called on.