### PR TITLE
[backport 2.11] box: handle cancelling fiber waiting in wal queue

### DIFF
--- a/changelogs/unreleased/gh-11078-handle-cancel-of-request-in-wal-queue.md
+++ b/changelogs/unreleased/gh-11078-handle-cancel-of-request-in-wal-queue.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed a bug when cancelling a fiber waiting in WAL queue corrupted the
+  the WAL (gh-11078).

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -1479,7 +1479,7 @@ apply_plain_tx(uint32_t replica_id, struct stailq *rows)
 
 	trigger_create(on_wal_write, applier_txn_wal_write_cb, rcb, NULL);
 	txn_on_wal_write(txn, on_wal_write);
-	return txn_commit_try_async(txn);
+	return txn_commit_submit(txn);
 fail:
 	txn_abort(txn);
 	return -1;

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -819,11 +819,11 @@ wal_stream_apply_dml_row(struct wal_stream *stream, struct xrow_header *row)
 	 * the only fiber processing recovery will get stuck on the first
 	 * synchronous tx it meets until confirm timeout is reached and the tx
 	 * is rolled back, yielding an error.
-	 * Moreover, txn_commit_try_async() doesn't hurt at all during local
+	 * Moreover, txn_commit_submit() doesn't hurt at all during local
 	 * recovery, since journal_write is faked at this stage and returns
 	 * immediately.
 	 */
-	if (txn_commit_try_async(txn) != 0) {
+	if (txn_commit_submit(txn) != 0) {
 		/* Commit fail automatically leads to rollback. */
 		assert(in_txn() == NULL);
 		say_error("couldn't commit a recovery transaction");

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -625,8 +625,7 @@ static void
 recovery_journal_create(struct vclock *v)
 {
 	static struct recovery_journal journal;
-	journal_create(&journal.base, recovery_journal_write,
-		       recovery_journal_write);
+	journal_create(&journal.base, recovery_journal_write);
 	journal.vclock = v;
 	journal_set(&journal.base);
 }
@@ -5166,7 +5165,7 @@ box_cfg_xc(void)
 	}
 
 	struct journal bootstrap_journal;
-	journal_create(&bootstrap_journal, NULL, bootstrap_journal_write);
+	journal_create(&bootstrap_journal, bootstrap_journal_write);
 	journal_set(&bootstrap_journal);
 	auto bootstrap_journal_guard = make_scoped_guard([] {
 		journal_set(NULL);

--- a/src/box/journal.c
+++ b/src/box/journal.c
@@ -102,7 +102,8 @@ journal_queue_wait(void)
 	++journal_queue.waiter_count;
 	rlist_add_tail_entry(&journal_queue.waiters, fiber(), state);
 	/*
-	 * Will be waken up by either queue emptying or a synchronous write.
+	 * Is woken up when this position in the queue should go into the next
+	 * journal batch.
 	 */
 	fiber_yield();
 	--journal_queue.waiter_count;

--- a/src/box/journal.h
+++ b/src/box/journal.h
@@ -180,10 +180,6 @@ struct journal {
 	/** Asynchronous write */
 	int (*write_async)(struct journal *journal,
 			   struct journal_entry *entry);
-
-	/** Synchronous write */
-	int (*write)(struct journal *journal,
-		     struct journal_entry *entry);
 };
 
 /** Wake the journal queue up. */
@@ -263,20 +259,6 @@ journal_async_complete(struct journal_entry *entry)
  */
 extern struct journal *current_journal;
 
-/**
- * Write a single entry to the journal in synchronous way.
- *
- * @return 0 if write was processed by a backend or -1 in case of an error.
- */
-static inline int
-journal_write(struct journal_entry *entry)
-{
-	journal_queue_flush();
-	journal_queue_on_append(entry);
-
-	return current_journal->write(current_journal, entry);
-}
-
 /** Write a single row in a blocking way. */
 int
 journal_write_row(struct xrow_header *row);
@@ -299,6 +281,17 @@ journal_write_try_async(struct journal_entry *entry)
 		journal_queue_on_complete(entry);
 		return -1;
 	}
+	return 0;
+}
+
+/** Write a single entry to the journal in synchronous way. */
+static inline int
+journal_write(struct journal_entry *entry)
+{
+	if (journal_write_try_async(entry) != 0)
+		return -1;
+	while (!entry->is_complete)
+		fiber_yield();
 	return 0;
 }
 
@@ -332,18 +325,15 @@ journal_set(struct journal *new_journal)
 static inline void
 journal_create(struct journal *journal,
 	       int (*write_async)(struct journal *journal,
-				  struct journal_entry *entry),
-	       int (*write)(struct journal *journal,
-			    struct journal_entry *entry))
+				  struct journal_entry *entry))
 {
-	journal->write_async	= write_async;
-	journal->write		= write;
+	journal->write_async = write_async;
 }
 
 static inline bool
 journal_is_initialized(struct journal *journal)
 {
-	return journal->write != NULL;
+	return journal->write_async != NULL;
 }
 
 #if defined(__cplusplus)

--- a/src/box/journal.h
+++ b/src/box/journal.h
@@ -269,7 +269,7 @@ journal_write_row(struct xrow_header *row);
  * @return 0 if write was queued to a backend or -1 in case of an error.
  */
 static inline int
-journal_write_try_async(struct journal_entry *entry)
+journal_write_submit(struct journal_entry *entry)
 {
 	journal_queue_wait();
 	/*
@@ -288,7 +288,7 @@ journal_write_try_async(struct journal_entry *entry)
 static inline int
 journal_write(struct journal_entry *entry)
 {
-	if (journal_write_try_async(entry) != 0)
+	if (journal_write_submit(entry) != 0)
 		return -1;
 	while (!entry->is_complete)
 		fiber_yield();

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -1002,65 +1002,41 @@ txn_add_limbo_entry(struct txn *txn, const struct journal_entry *req)
 	return 0;
 }
 
-int
-txn_commit_try_async(struct txn *txn)
+static int
+txn_commit_impl(struct txn *txn, enum txn_commit_wait_mode wait_mode)
 {
 	struct journal_entry *req;
-
-	ERROR_INJECT(ERRINJ_TXN_COMMIT_ASYNC, {
-		diag_set(ClientError, ER_INJECTION,
-			 "txn commit async injection");
-		goto rollback;
-	});
-
-	if (txn_prepare(txn) != 0)
-		goto rollback;
-
-	if (txn_commit_nop(txn))
-		return 0;
-
-	req = txn_journal_entry_new(txn);
-	if (req == NULL)
-		goto rollback;
-
-	if (txn_has_flag(txn, TXN_WAIT_SYNC) &&
-	    txn_add_limbo_entry(txn, req) != 0) {
-		goto rollback;
-	}
-
-	fiber_set_txn(fiber(), NULL);
-	if (journal_write_try_async(req) != 0) {
-		fiber_set_txn(fiber(), txn);
-		diag_log();
-		goto rollback;
-	}
-
-	return 0;
-
-rollback:
-	assert(txn->fiber == NULL);
-	txn_abort(txn);
-	return -1;
-}
-
-int
-txn_commit(struct txn *txn)
-{
-	struct journal_entry *req;
-
 	txn->fiber = fiber();
-
 	if (txn_prepare(txn) != 0)
 		goto rollback_abort;
-
 	if (txn_commit_nop(txn)) {
 		txn_free(txn);
 		return 0;
 	}
-
 	req = txn_journal_entry_new(txn);
 	if (req == NULL)
 		goto rollback_abort;
+	if (wait_mode != TXN_COMMIT_WAIT_MODE_COMPLETE) {
+		assert(wait_mode == TXN_COMMIT_WAIT_MODE_SUBMIT);
+		ERROR_INJECT(ERRINJ_TXN_COMMIT_ASYNC, {
+			diag_set(ClientError, ER_INJECTION,
+				 "txn commit async injection");
+			goto rollback_abort;
+		});
+		/*
+		 * The main reason why it is disabled is that the sync txn's
+		 * original instance wants to write CONFIRM. But it can't be
+		 * done asynchronously in the current code design. Also it is
+		 * logically strange to commit a synchronous transaction in an
+		 * async way, but the CONFIRM problem is the technical one.
+		 */
+		bool is_original = req->rows[0]->replica_id == 0;
+		if (txn_has_flag(txn, TXN_WAIT_ACK) && is_original) {
+			diag_set(ClientError, ER_UNSUPPORTED, "Tarantool",
+				 "Non-blocking commit of a synchronous txn");
+			goto rollback_abort;
+		}
+	}
 	/*
 	 * Do not cache the flag value in a variable. The flag might be deleted
 	 * during WAL write. This can happen for async transactions created
@@ -1072,10 +1048,19 @@ txn_commit(struct txn *txn)
 	    txn_add_limbo_entry(txn, req) != 0) {
 		goto rollback_abort;
 	}
-
 	fiber_set_txn(fiber(), NULL);
-	if (journal_write(req) != 0)
+	if (journal_write_submit(req) != 0) {
+		fiber_set_txn(fiber(), txn);
 		goto rollback_io;
+	}
+	if (wait_mode != TXN_COMMIT_WAIT_MODE_COMPLETE) {
+		if (txn_has_flag(txn, TXN_IS_DONE))
+			goto finish_done;
+		txn->fiber = NULL;
+		return 0;
+	}
+	while (!req->is_complete)
+		fiber_yield();
 	if (req->res < 0) {
 		diag_set_journal_res(req->res);
 		goto rollback_io;
@@ -1102,10 +1087,9 @@ txn_commit(struct txn *txn)
 			}
 		}
 	}
+finish_done:
 	assert(txn_has_flag(txn, TXN_IS_DONE));
 	assert(txn->signature >= 0);
-
-	/* Synchronous transactions are freed by the calling fiber. */
 	txn_free(txn);
 	return 0;
 
@@ -1124,6 +1108,18 @@ rollback:
 	}
 	txn_free(txn);
 	return -1;
+}
+
+int
+txn_commit_submit(struct txn *txn)
+{
+	return txn_commit_impl(txn, TXN_COMMIT_WAIT_MODE_SUBMIT);
+}
+
+int
+txn_commit(struct txn *txn)
+{
+	return txn_commit_impl(txn, TXN_COMMIT_WAIT_MODE_COMPLETE);
 }
 
 void

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -1049,10 +1049,8 @@ txn_commit_impl(struct txn *txn, enum txn_commit_wait_mode wait_mode)
 		goto rollback_abort;
 	}
 	fiber_set_txn(fiber(), NULL);
-	if (journal_write_submit(req) != 0) {
-		fiber_set_txn(fiber(), txn);
+	if (journal_write_submit(req) != 0)
 		goto rollback_io;
-	}
 	if (wait_mode != TXN_COMMIT_WAIT_MODE_COMPLETE) {
 		if (txn_has_flag(txn, TXN_IS_DONE))
 			goto finish_done;

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -164,6 +164,17 @@ enum {
 	TXN_SIGNATURE_ABORT = JOURNAL_ENTRY_ERR_MIN - 4,
 };
 
+enum txn_commit_wait_mode {
+	/** Commit blocks until the txn is complete. */
+	TXN_COMMIT_WAIT_MODE_COMPLETE,
+	/**
+	 * Txn is sent to the journal is completed later asynchronously. Commit
+	 * returns right away. Unless the journal queue is full. Then the commit
+	 * is blocked until there is space in the queue.
+	 */
+	TXN_COMMIT_WAIT_MODE_SUBMIT,
+};
+
 /** \cond public */
 /**
  * When a transaction calls `commit`, this action can last for some time until
@@ -670,7 +681,7 @@ txn_abort(struct txn *txn);
  * freed.
  */
 int
-txn_commit_try_async(struct txn *txn);
+txn_commit_submit(struct txn *txn);
 
 /**
  * Most txns don't have triggers, and txn objects

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -139,6 +139,7 @@ enum {
 	TXN_SIGNATURE_UNKNOWN = JOURNAL_ENTRY_ERR_UNKNOWN,
 	TXN_SIGNATURE_IO = JOURNAL_ENTRY_ERR_IO,
 	TXN_SIGNATURE_CASCADE = JOURNAL_ENTRY_ERR_CASCADE,
+	TXN_SIGNATURE_CANCELLED = JOURNAL_ENTRY_ERR_CANCELLED,
 	/**
 	 * The default signature value for failed transactions.
 	 * Indicates either write failure or any other failure

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -330,7 +330,7 @@ txn_limbo_assign_local_lsn(struct txn_limbo *limbo,
  * remote transactions. The function exists to be used in a
  * context, where a transaction is not known whether it is local
  * or not. For example, when a transaction is committed not bound
- * to any fiber (txn_commit_try_async()), it can be created by applier
+ * to any fiber (txn_commit_submit()), it can be created by applier
  * (then it is remote) or by recovery (then it is local). Besides,
  * recovery can commit remote transactions as well, when works on
  * a replica - it will recover data received from master.

--- a/test/box-luatest/gh_11078_wal_queue_fiber_cancel_test.lua
+++ b/test/box-luatest/gh_11078_wal_queue_fiber_cancel_test.lua
@@ -1,0 +1,80 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local variants = {}
+for i = 1, 5 do
+    table.insert(variants, {pos = i})
+end
+local g = t.group('wal', variants)
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        box.space.test:drop()
+    end)
+end)
+
+g.test_wal_queue_fiber_cancel = function(cg)
+    cg.server:exec(function(pos)
+        local fiber = require('fiber')
+        local s = box.schema.create_space('test')
+        s:create_index('pk')
+        box.cfg{wal_queue_max_size = 100}
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+        fiber.create(function()
+            box.begin()
+            s:insert({100, string.rep('a', 1000)})
+            s:insert({0})
+            box.commit()
+        end)
+        local fibers = {}
+        for i = 1, 5 do
+            local f = fiber.new(function()
+                -- Crafted to check that WAL records are in correct order
+                -- on recovery after restart.
+                box.begin()
+                s:delete({i - 1})
+                s:insert({i})
+                box.commit()
+            end)
+            f:set_joinable(true)
+            table.insert(fibers, f)
+            fiber.yield()
+        end
+        fibers[pos]:cancel()
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        for i = 1, pos - 1 do
+            t.assert_equals({fibers[i]:join()}, {true})
+        end
+        local ok, err = fibers[pos]:join()
+        t.assert_not(ok)
+        t.assert_covers(err:unpack(), {
+            type = 'FiberIsCancelled',
+        })
+        for i = pos + 1, 5 do
+            local ok, err = fibers[i]:join()
+            t.assert_not(ok)
+            t.assert_covers(err:unpack(), {
+                type = 'ClientError',
+                code = box.error.CASCADE_ROLLBACK,
+                message = "WAL has a rollback in progress",
+            })
+        end
+        t.assert_equals(s:select({100}, {iterator = 'lt'}), {{pos - 1}})
+    end, {cg.params.pos})
+    cg.server:restart()
+    cg.server:exec(function(pos)
+        local s = box.space.test
+        t.assert_equals(s:select({100}, {iterator = 'lt'}), {{pos - 1}})
+    end, {cg.params.pos})
+end


### PR DESCRIPTION
Currently if fiber waiting in wal queue is cancelled it will go on writing to all breaking queue order. So wal is corrupted so that even next Tarantool restart may fail. Unfortunately we cancel fibers on Tarantool shutdown so the issue may arise just buy terminating Tarantool instance.

Let's instead fail the cancelled request and all the newer request in the queue.

Work around is to disable wal queue by `box.cfg{wal_queue_max_size = 0}` so that only one write request can be in the queue.

Closes #11078

> [!NOTE]
> We have to cherry-pick additionally 2 commits that refactor journal and txn.