### PR TITLE
[backport/release/3.3] luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-11055-luajit-fixes.md
+++ b/changelogs/unreleased/gh-11055-luajit-fixes.md
@@ -10,3 +10,9 @@ issues were fixed as part of this activity:
   events.
 * Fixed the compilation of `...` in `select()`.
 * Fixed closing the report file without samples for `jit.p`.
+* Fixed the OOM error handling during recording of the `__concat` metamethod.
+* Fixed the second `trace.flush()` call for the already flushed trace.
+* Fixed bit op coercion for shifts in DUALNUM builds.
+* Fixed `IR_ABC` hoisting.
+* Returned the rehashing of the cdata finalizer table at the end of the GC
+  cycle to avoid memory overgrowing for cdata-intensive workloads.


### PR DESCRIPTION
* ci: disable integration-tarantool-ecosystem.yml
* codehealth: fix warnings for the codespell 2.3.0
* test: unify helpers for a custom allocator setting
* Restore state when recording __concat metamethod throws OOM.
* Fix state restore when recording __concat metamethod.
* Avoid unpatching bytecode twice after a trace flush.
* Fix bit op coercion for shifts in DUALNUM builds.
* Fix IR_ABC hoisting.
* ffi/gc: restore back rehashing of finalizers table

Closes #11055

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump