### PR TITLE
xrow: add missing break statement

### DIFF
--- a/src/box/xrow.c
+++ b/src/box/xrow.c
@@ -1614,6 +1614,7 @@ error:
 				goto error;
 			request->tuple_formats = value;
 			request->tuple_formats_end = data;
+			break;
 		default:
 			continue; /* unknown key */
 		}


### PR DESCRIPTION
The old (7.5.0) GCC compiler leaves the following compilation warning (leading to the error with `-Werror`):

NO_WRAP
```
src/box/xrow.c: In function ‘xrow_decode_call’:
src/box/xrow.c:1616:31: error: this statement may fall through [-Werror=implicit-fallthrough=]
    request->tuple_formats_end = data;
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
src/box/xrow.c:1617:3: note: here
   default:
   ^~~~~~~
cc1: all warnings being treated as errors
```
NO_WRAP

The missing statement is harmless since the `default` just does the same thing, but to fix the error for old compilers and make the code cleaner, the missing statement is added in this patch.

NO_DOC=cleanup
NO_TEST=cleanup
NO_CHANGELOG=cleanup