### PR TITLE
box: set TXN_WAIT_SYNC with xrow rather than limbo state during recovery

### DIFF
--- a/changelogs/unreleased/gh-11053-gc_consumers-record-lost-after-promote-and-restart.md
+++ b/changelogs/unreleased/gh-11053-gc_consumers-record-lost-after-promote-and-restart.md
@@ -1,0 +1,5 @@
+## bugfix/box
+
+* Fixed a bug when a record could be lost from the `_gc_consumers` space after
+  receiving a promote request from another instance and restarting the current
+  instance (gh-11053).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -831,8 +831,10 @@ wal_stream_apply_dml_row(struct wal_stream *stream, struct xrow_header *row)
 	assert(txn != NULL);
 	if (!row->is_commit)
 		return 0;
-	if (row->wait_ack)
-		box_txn_make_sync();
+	txn_set_xrow_flags(row->flags);
+	if (!txn_has_flag(txn, TXN_WAIT_SYNC) &&
+	    !txn_has_flag(txn, TXN_WAIT_ACK))
+		txn_set_flags(txn, TXN_FORCE_ASYNC);
 	/*
 	 * For fully local transactions the TSN check won't work like for global
 	 * transactions, because it is not known if there are global rows until

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -1475,6 +1475,12 @@ box_txn_set_timeout(double timeout)
 void
 box_txn_make_sync(void)
 {
+	txn_set_xrow_flags(IPROTO_FLAG_WAIT_ACK);
+}
+
+void
+txn_set_xrow_flags(uint8_t xrow_flags)
+{
 	struct txn *txn = in_txn();
 	/*
 	 * Do nothing if transaction is not started,
@@ -1483,7 +1489,13 @@ box_txn_make_sync(void)
 	if (!txn)
 		return;
 
-	txn_set_flags(txn, TXN_WAIT_ACK);
+	const uint8_t flags_map[] = {
+		[IPROTO_FLAG_WAIT_SYNC] = TXN_WAIT_SYNC,
+		[IPROTO_FLAG_WAIT_ACK] = TXN_WAIT_ACK,
+	};
+
+	txn->flags |= flags_map[xrow_flags & IPROTO_FLAG_WAIT_SYNC];
+	txn->flags |= flags_map[xrow_flags & IPROTO_FLAG_WAIT_ACK];
 }
 
 /** Wait for a linearization point for a transaction. */

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -567,6 +567,12 @@ txn_set_flags(struct txn *txn, unsigned int flags)
 	txn->flags |= flags;
 }
 
+/**
+ * Set flags from xrow on the transaction.
+ */
+void
+txn_set_xrow_flags(uint8_t xrow_flags);
+
 static inline void
 txn_clear_flags(struct txn *txn, unsigned int flags)
 {

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -96,7 +96,9 @@ enum txn_flag {
 	 * A transaction may be forced to be asynchronous, not
 	 * wait for any ACKs, and not depend on prepending sync
 	 * transactions. This happens in a few special cases. For
-	 * example, when applier receives snapshot from master.
+	 * example, when applier receives snapshot from master. This also
+	 * happens during recovery of all transactions that did not go through
+	 * the limbo at commit time.
 	 */
 	TXN_FORCE_ASYNC = 0x40,
 	/**

--- a/test/replication-luatest/gh_11053_gc_consumer_record_lost_after_promote_and_restart_test.lua
+++ b/test/replication-luatest/gh_11053_gc_consumer_record_lost_after_promote_and_restart_test.lua
@@ -1,0 +1,82 @@
+local t = require('luatest')
+local replica_set = require('luatest.replica_set')
+local server = require('luatest.server')
+
+local g = t.group()
+
+g.before_each(function(cg)
+    cg.replica_set = replica_set:new{}
+    cg.box_cfg = {
+        replication = {
+            server.build_listen_uri('master', cg.replica_set.id),
+            server.build_listen_uri('replica', cg.replica_set.id),
+        },
+        replication_timeout = 0.1,
+        replication_synchro_timeout = 120,
+        -- Prevent synchronous transactions from getting confirmed: require 4
+        -- acks in a 3-node cluster.
+        replication_synchro_quorum = 4,
+    }
+    cg.master = cg.replica_set:build_and_add_server{
+        alias = 'master',
+        box_cfg = cg.box_cfg,
+    }
+    cg.replica = cg.replica_set:build_and_add_server{
+        alias = 'replica',
+        box_cfg = cg.box_cfg,
+    }
+    cg.replica_set:start()
+    cg.replica_set:wait_for_fullmesh()
+    cg.master:exec(function()
+        box.schema.space.create('s', {is_sync = true}):create_index('p')
+        box.ctl.promote()
+    end)
+    cg.master:wait_for_downstream_to(cg.replica)
+end)
+
+g.after_each(function(cg)
+    cg.replica_set:drop()
+end)
+
+g.test_gc_consumer_record_not_lost_after_promote_and_restart = function(cg)
+    -- Simulate network partitioning.
+    cg.replica:update_box_cfg{replication = ''}
+    -- Submit a synchronous transaction while being partitioned from replica.
+    cg.master:exec(function()
+        box.atomic({wait = 'submit'}, function() box.space.s:replace{0} end)
+        t.assert_equals(box.info.synchro.queue.len, 1)
+        t.assert_equals(box.space._gc_consumers:len(), 1)
+    end)
+    -- Join a new replica.
+    cg.new_replica = cg.replica_set:build_and_add_server{
+        alias = 'new_replica',
+        box_cfg = cg.box_cfg,
+    }
+    -- The join cannot be processed completely because we have a pending
+    -- transaction in the synchronous queue.
+    cg.new_replica:start({wait_until_ready = false})
+    -- Wait for the new replica's `_gc_consumer` record to appear on the master.
+    cg.master:exec(function()
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.space._gc_consumers:len(), 2)
+        end)
+    end)
+    -- Promote the partitioned replica.
+    cg.replica:exec(function()
+        box.ctl.promote()
+    end)
+    -- Wait for the old master to receive promote from the partitioned replica.
+    cg.master:exec(function(replica_id)
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.synchro.queue.owner, replica_id)
+        end)
+        t.assert_equals(box.info.synchro.queue.len, 0)
+    end, {cg.replica:get_instance_id()})
+    -- Restart the old master.
+    cg.master:restart()
+    -- Check that the new replica's `_gc_consumer` record is still present on
+    -- the old master.
+    cg.master:exec(function()
+        t.assert_equals(box.space._gc_consumers:len(), 2)
+    end)
+end


### PR DESCRIPTION
This patchset fixes a bug with `TXN_FORCE_ASYNC` transactions being lost after receiving a promote request from another instance and restarting the current instance.

Closes #11053