### PR TITLE
vinyl: do not reset cache link LSN on partial key lookup

### DIFF
--- a/changelogs/unreleased/gh-11079-vy-cache-read-view-fix.md
+++ b/changelogs/unreleased/gh-11079-vy-cache-read-view-fix.md
@@ -1,4 +1,4 @@
 ## bugfix/vinyl
 
 * Fixed a bug in the tuple cache when a transaction operating in a read view
-  could skip a tuple deleted after the read view creation (gh-11079).
+  could skip a tuple deleted after the read view creation (gh-11079, gh-11294).

--- a/src/box/vy_cache.c
+++ b/src/box/vy_cache.c
@@ -333,10 +333,12 @@ vy_cache_add(struct vy_cache *cache, struct vy_entry curr,
 		vy_cache_node_delete(cache->env, replaced);
 	}
 	if (direction > 0 &&
+	    !(node->flags & VY_CACHE_LEFT_LINKED) &&
 	    boundary_level < node->left_boundary_level) {
 		node->left_boundary_level = boundary_level;
 		node->left_lsn = link_lsn;
 	} else if (direction < 0 &&
+		   !(node->flags & VY_CACHE_RIGHT_LINKED) &&
 		   boundary_level < node->right_boundary_level) {
 		node->right_boundary_level = boundary_level;
 		node->right_lsn = link_lsn;


### PR DESCRIPTION
Since commit e8109b2fe0b3 ("vinyl: ignore cache chains with invisible DELETEs") each cache node stores the LSNs of the left and right links. They are used to ignore links that are invisible from the current read view (created after the read view was opened). We update the LSN not only when we link two nodes together but also when we update the node's boundary level. This is incorrect if the node is linked.

For example, suppose we have an index over two fields that contains tuples {0,2} and {2,0} and there's a transaction that was sent to a read view. Now another transaction inserts {0,1} and deletes {0,2}, then selects all tuples. This results in creation of two interlinked cache nodes: {0,1} and {2,0}. The link is invisible from the read view: since we skipped DELETE{0,2}, its LSN equals the LSN of the DELETE statement, which is greater than the read view LSN. However, if we now select GT{1}, we will update the boundary level of the node storing {2,0} from 2 to 1 and reset its LSN to 0 because we didn't skip any DELETE statements. As a result, if the transaction operating in the read view tries to select GT{0,1}, it will find {2,0}, see that it's left-linked and the link LSN is 0, and return it right away, skipping {0,2}, which is visible from the read view.

To fix this issue, let's skip the boundary level update if the node is linked. It doesn't make sense anyway because the boundary level is used only for unlinked nodes, see `vy_cache_iterator_is_stop()`.

Follow-up #11079
Closes #11294