### PR TITLE
config: apply lua_call privileges before bootstrap

### DIFF
--- a/changelogs/unreleased/lua-call-runtime-priv-before-bootstrap.md
+++ b/changelogs/unreleased/lua-call-runtime-priv-before-bootstrap.md
@@ -1,0 +1,5 @@
+## bugfix/config
+
+* Now runtime `lua_call` privileges are also applied before the initial
+  bootstrap, making it possible to permit some functions to be executed by the
+  guest user before setting up the cluster.

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -317,14 +317,15 @@ function methods._store(self, iconfig, cconfig, source_info)
     self._configdata = configdata.new(iconfig, cconfig, self._instance_name)
 end
 
--- Invoke lua, compat, mkdir, console and box_cfg appliers at the
--- first phase. Invoke all the other ones at the second phase.
+-- Invoke the appliers depending on the phase. The first phase
+-- might be long due to the long recovery process.
 function methods._apply_on_startup(self, opts)
     local first_phase_appliers = {
         lua = true,
         compat = true,
         mkdir = true,
         console = true,
+        runtime_priv = true,
         box_cfg = true,
     }
 
@@ -401,10 +402,10 @@ function methods._startup(self, instance_name, config_file)
 
     -- Startup phase 1/2.
     --
-    -- Start compat, mkdir, console and box_cfg appliers. The
-    -- latter may force the read-only mode on this phase.
+    -- Start first-phase appliers. The box_cfg applier may force
+    -- the read-only mode on this phase.
     --
-    -- This phase may take a long time.
+    -- This phase may take a long time due to recovery.
     self:_store(self:_collect({sync_source = 'all'}))
     local needs_retry = self:_apply_on_startup({phase = 1})
 


### PR DESCRIPTION
This patch is a bugfix of the `lua_call` runtime access implemented in
commit 38c6b0d38254 ("config: grant runtime access to lua_call from
config").

One of the main reason for runtime privileges is to allow granting guest
user `lua_call` access before the initial bootstrap. During the
implementation of the #10857 in terms of the new behavior of the
supervised failover with the supervised bootstrap strategy it turned out
runtime privileges haven't been added as a first-phase applier making it
impossible to executing some of the lua functions before the initial
bootstrap. This patch fixes it by adding a first-phase applier.

For instance, you might allow guest connection to fetch information on
instances before the bootstrap by configuring `credentials` section like
this.

```yaml
credentials:
  guest:
    privileges:
    - permissions: [ execute ]
      lua_call: [box.info]
```

See tarantool/doc#4552 on a new comment mentioning this change.
