### PR TITLE
iproto: add min version to feature comments

### DIFF
--- a/src/box/iproto_features.h
+++ b/src/box/iproto_features.h
@@ -19,11 +19,15 @@ extern "C" {
 #define IPROTO_FEATURES(_)						\
 	/**
 	 * Streams support: IPROTO_STREAM_ID header key.
+	 *
+	 * Available since IPROTO protocol version 1.
 	 */								\
 	_(STREAMS, 0)							\
 	/**
 	 * Transactions in the protocol:
 	 * IPROTO_BEGIN, IPROTO_COMMIT, IPROTO_ROLLBACK commands.
+	 *
+	 * Available since IPROTO protocol version 1.
 	 */								\
 	_(TRANSACTIONS, 1)						\
 	/**
@@ -36,17 +40,23 @@ extern "C" {
 	 * converted to a string error message). If the feature bit is set and
 	 * encode_errors_as_ext is true, errors will be encoded as MP_ERROR
 	 * MsgPack extension.
+	 *
+	 * Available since IPROTO protocol version 2.
 	 */								\
 	_(ERROR_EXTENSION, 2)						\
 	/**
 	 * Remote watchers support:
 	 * IPROTO_WATCH, IPROTO_UNWATCH, IPROTO_EVENT commands.
+	 *
+	 * Available since IPROTO protocol version 3.
 	 */								\
 	_(WATCHERS, 3)							\
 	/**
 	 * Pagination support:
 	 * IPROTO_AFTER_POSITION, IPROTO_AFTER_TUPLE, IPROTO_FETCH_POSITION
 	 * request fields and IPROTO_POSITION response field.
+	 *
+	 * Available since IPROTO protocol version 4.
 	 */								\
 	_(PAGINATION, 4)						\
 	/**
@@ -55,41 +65,59 @@ extern "C" {
 	 * IPROTO_UPDATE and IPROTO_DELETE request body;
 	 * IPROTO_SPACE_NAME field in IPROTO_INSERT, IPROTO_REPLACE,
 	 * IPROTO_UPDATE and IPROTO_UPSERT request body.
+	 *
+	 * Available since IPROTO protocol version 5.
 	 */								\
 	_(SPACE_AND_INDEX_NAMES,  5)					\
-	/** IPROTO_WATCH_ONCE request support. */			\
+	/**
+	 * IPROTO_WATCH_ONCE request support.
+	 *
+	 * Available since IPROTO protocol version 6.
+	 */								\
 	_(WATCH_ONCE,  6)						\
 	/**
 	 * Tuple format in DML request responses support:
 	 * Tuples in IPROTO_DATA response field are encoded as MP_TUPLE and
 	 * tuple format is sent in IPROTO_TUPLE_FORMATS field.
+	 *
+	 * Available since IPROTO protocol version 7.
 	 */								\
 	_(DML_TUPLE_EXTENSION, 7)					\
 	/**
 	 * Tuple format in call and eval request responses support:
 	 * Tuples in IPROTO_DATA response field are encoded as MP_TUPLE and
 	 * tuple formats are sent in IPROTO_TUPLE_FORMATS field.
+	 *
+	 * Available since IPROTO protocol version 7.
 	 */								\
 	_(CALL_RET_TUPLE_EXTENSION, 8)					\
 	/**
 	 * Tuple format in call and eval request arguments support:
 	 * Tuples in IPROTO_TUPLE request field are encoded as MP_TUPLE and
 	 * tuple formats are received in IPROTO_TUPLE_FORMATS field.
+	 *
+	 * Available since IPROTO protocol version 7.
 	 */								\
 	_(CALL_ARG_TUPLE_EXTENSION, 9)					\
 	/**
 	 * Cursor (for checkpoint join) in FETCH_SNAPSHOT support:
 	 * IPROTO_IS_CHECKPOINT_JOIN, IPROTO_CHECKPOINT_VCLOCK and
 	 * IRPOTO_CHECKPOINT_LSN.
+	 *
+	 * Available since IPROTO protocol version 8.
 	 */								\
 	_(FETCH_SNAPSHOT_CURSOR, 10)					\
 	/**
 	 * Synchronous transaction support:
 	 * IS_SYNC flag in IPROTO_BEGIN, IPROTO_COMMIT
+	 *
+	 * Available since IPROTO protocol version 9.
 	 */								\
 	_(IS_SYNC, 11)							\
 	/**
 	 * Support of data insertion in Arrow format.
+	 *
+	 * Available since IPROTO protocol version 10.
 	 */								\
 	_(INSERT_ARROW, 12)						\
 


### PR DESCRIPTION
Currently, the only way to find the IPROTO protocol version where a particular feature first appeared is to read the Git history, which is inconvenient. Let's add this information to comments.