### PR TITLE
box: fix box.commit({wait = 'none'}) could yield

### DIFF
--- a/changelogs/unreleased/gh-11224-fix-commit-wait-none-yield.md
+++ b/changelogs/unreleased/gh-11224-fix-commit-wait-none-yield.md
@@ -1,0 +1,3 @@
+## bugfix/box
+
+* Fixed bug when `box.commit({wait = 'none'})` could yield (gh-11224).

--- a/src/box/journal.c
+++ b/src/box/journal.c
@@ -94,7 +94,7 @@ void
 journal_queue_wakeup(void)
 {
 	if (!stailq_empty(&journal_queue.requests) &&
-	    !journal_queue_is_full()) {
+	    journal_queue.size < journal_queue.max_size) {
 		struct journal_entry *req =
 				stailq_first_entry(&journal_queue.requests,
 						   typeof(*req), fifo);
@@ -105,7 +105,7 @@ journal_queue_wakeup(void)
 int
 journal_queue_wait(struct journal_entry *entry)
 {
-	if (!journal_queue_is_full() &&
+	if (journal_queue.size < journal_queue.max_size &&
 	    stailq_empty(&journal_queue.requests))
 		return 0;
 	int rc = -1;

--- a/src/box/journal.h
+++ b/src/box/journal.h
@@ -187,17 +187,6 @@ struct journal {
 void
 journal_queue_wakeup(void);
 
-/**
- * Check whether any of the queue size limits is reached.
- * If the queue is full, we must wait for some of the entries to be written
- * before proceeding with a new asynchronous write request.
- */
-static inline bool
-journal_queue_is_full(void)
-{
-	return journal_queue.size >= journal_queue.max_size;
-}
-
 /** Yield until there's some space in the journal queue. */
 int
 journal_queue_wait(struct journal_entry *entry);
@@ -253,6 +242,14 @@ extern struct journal *current_journal;
 /** Write a single row in a blocking way. */
 int
 journal_write_row(struct xrow_header *row);
+
+/** Checks whether journal_write_submit() call will yield. */
+static inline bool
+journal_queue_would_block(void)
+{
+	return journal_queue.size > journal_queue.max_size ||
+	       !stailq_empty(&journal_queue.requests);
+}
 
 /**
  * Queue a single entry to the journal in asynchronous way.

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -1162,7 +1162,7 @@ txn_commit_impl(struct txn *txn, enum txn_commit_wait_mode wait_mode)
 			goto rollback_abort;
 		});
 		if (wait_mode == TXN_COMMIT_WAIT_MODE_NONE &&
-		    journal_queue_is_full()) {
+		    journal_queue_would_block()) {
 			diag_set(ClientError, ER_WAL_QUEUE_FULL);
 			goto rollback_abort;
 		}

--- a/test/box-luatest/gh_11224_fix_commit_wait_none_journal_queue_test.lua
+++ b/test/box-luatest/gh_11224_fix_commit_wait_none_journal_queue_test.lua
@@ -1,0 +1,60 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_test('test_box_commit_non_empty_journal_queue', function(cg)
+    cg.server:exec(function()
+        box.cfg{wal_queue_max_size = box.NULL}
+    end)
+end)
+
+g.test_box_commit_non_empty_journal_queue = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        local s = box.schema.create_space('test')
+        s:create_index('pk')
+        box.cfg{wal_queue_max_size = 100}
+
+        local yielded
+        local commit_ok
+        local commit_err
+        fiber.create(function()
+            box.begin()
+            box.on_commit(function()
+                -- 3. When 1. is written to WAL queue size is decreased
+                -- but 2. is still in queue so `wait = 'none'` should fail.
+                fiber.create(function()
+                    box.begin()
+                    s:insert({3})
+                    local csw = fiber.self().info().csw
+                    commit_ok, commit_err = pcall(box.commit, {wait = 'none'})
+                    yielded = fiber.self().info().csw ~= csw
+                end)
+            end)
+            --- 1. Insert large tuple to block journal queue.
+            s:insert({1, string.rep('a', 1000)})
+            box.commit()
+        end)
+        -- 2. Next insertion will wait in journal queue.
+        s:insert({2})
+
+        t.assert_not(yielded)
+        t.assert_not(commit_ok)
+        t.assert_covers(commit_err:unpack(), {
+            type = 'ClientError',
+            code = box.error.WAL_QUEUE_FULL,
+            message = "The WAL queue is full",
+        })
+        t.assert_equals(s:select({1}, {iterator = 'gt'}), {{2}})
+    end)
+end


### PR DESCRIPTION
The issue is in order to decide whether submitting request to journal would yield or not we check the journal queue size. But the size can be less then limit while queue is not empty. At this moment submitting new request will yield.

Closes #11224