### PR TITLE
box: flush WAL queue on sync

### DIFF
--- a/changelogs/unreleased/gh-11118-flush-journal-on-wal-sync.md
+++ b/changelogs/unreleased/gh-11118-flush-journal-on-wal-sync.md
@@ -1,0 +1,5 @@
+## bugfix/box
+
+* Fixed bug when WAL queue is no flushed properly. In particular
+ when building index of vinyl space. In the latter case it may lead
+ the new index missing data from transactions in the queue (gh-11118, gh-11119).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -2990,7 +2990,6 @@ box_wait_limbo_acked(double timeout)
 	if (last_entry->lsn < 0) {
 		int64_t tid = last_entry->txn->id;
 
-		journal_queue_flush();
 		if (wal_sync(NULL) != 0)
 			return -1;
 

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -644,6 +644,7 @@ wal_sync(struct vclock *vclock)
 		diag_set(ClientError, ER_CASCADE_ROLLBACK);
 		return -1;
 	}
+	journal_queue_flush();
 	struct wal_vclock_msg msg;
 	int rc = cbus_call(&writer->wal_pipe, &writer->tx_prio_pipe, &msg.base,
 			   wal_sync_f);


### PR DESCRIPTION
`wal_sync()` is expected to flush all prepared txns on disk. Currently it is not so because we do not flush txns waiting in WAL queue. AFAIU the issue exists for all the places where we use `wal_sync()` (except for `box_wait_limbo_acked()` where we already flush WAL queue). The test is only added for the vinyl index build as there are explicit tickets for that.

Closes #11118
Closes #11119