### PR TITLE
box: check if iterator was created when loading WAL GC consumers

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -5915,8 +5915,10 @@ box_cfg_xc(void)
 	/*
 	 * Load persistent WAL GC consumers.
 	 */
-	if (gc_load_consumers() != 0)
+	if (gc_load_consumers() != 0) {
+		say_error("Failed to recover WAL GC consumers");
 		diag_raise();
+	}
 
 	/*
 	 * Initialize GC of anonymous replicas after loading WAL GC consumers.

--- a/src/box/gc.c
+++ b/src/box/gc.c
@@ -1093,6 +1093,8 @@ gc_load_consumers(void)
 	struct index *index = space_index(space, 0);
 	assert(index != NULL);
 	struct iterator *it = index_create_iterator(index, ITER_ALL, NULL, 0);
+	if (it == NULL)
+		return -1;
 	struct tuple *tuple = NULL;
 	struct gc_consumer_def def;
 	int rc = 0;

--- a/test/box-luatest/ghs_135_check_iterator_when_loading_gc_consumers_test.lua
+++ b/test/box-luatest/ghs_135_check_iterator_when_loading_gc_consumers_test.lua
@@ -1,0 +1,43 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_check_iterator_when_loading_gc_consumers = function(cg)
+    local server_log_path = g.server:exec(function()
+        return rawget(_G, 'box_cfg_log_file') or box.cfg.log
+    end)
+
+    -- Inject error after recovery - right before WAL GC consumers are loaded.
+    local run_before_cfg = [[
+        local trigger = require('trigger')
+        trigger.set('box.ctl.on_recovery_state', 'errinj', function(state)
+            if state == 'wal_recovered' then
+                box.error.injection.set('ERRINJ_INDEX_ITERATOR_NEW', true)
+            end
+        end)
+    ]]
+    cg.server:restart({
+        env = {
+            ['TARANTOOL_RUN_BEFORE_BOX_CFG'] = run_before_cfg,
+        }
+    }, {wait_until_ready = false})
+    t.helpers.retrying({}, function()
+        -- Check if the application panics.
+        t.assert(g.server:grep_log("F> can't initialize storage", nil,
+            {filename = server_log_path}))
+        -- Check if loading WAL GC consumers is the reason.
+        t.assert(g.server:grep_log("Failed to recover WAL GC consumers", nil,
+            {filename = server_log_path}))
+    end)
+end


### PR DESCRIPTION
We load WAL GC consumers right after recovery - it is done by iterating over space `_gc_consumers`. However, we forgot to check if the iterator is successfully created, hence, in the case of OOM right after recovery, Tarantool will crash because iterator is NULL. The commit adds the check. Along the way, let's log an explanatory message when we fail to load consumers to make the problem clear. Also, this message will allow us to write a more stable test.

Closes tarantool/security#135