### PR TITLE
relay: fix crash during shut down

### DIFF
--- a/changelogs/unreleased/gh-9920-tx-with-dead-relay.md
+++ b/changelogs/unreleased/gh-9920-tx-with-dead-relay.md
@@ -1,0 +1,3 @@
+## bugfix/replication
+
+* Fixed a crash which could happen during relay thread shut down (gh-9920).

--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -584,6 +584,7 @@ relay_status_update(struct cmsg *msg)
 static void
 tx_status_update(struct cmsg *msg)
 {
+	ERROR_INJECT_YIELD(ERRINJ_RELAY_TX_STATUS_UPDATE_DELAY);
 	struct relay_status_msg *status = (struct relay_status_msg *)msg;
 	struct relay *relay = status->relay;
 	vclock_copy(&relay->tx.vclock, &status->vclock);
@@ -616,6 +617,15 @@ tx_status_update(struct cmsg *msg)
 			      vclock_get(ack.vclock, instance_id));
 	}
 	trigger_run(&replicaset.on_ack, &ack);
+
+	if (!relay->tx.is_paired) {
+		/*
+		 * Reset the route so that `relay_check_status_needs_update`
+		 * could process it later, during `relay_subscribe_update`.
+		 */
+		cmsg_init(msg, NULL);
+		return;
+	}
 
 	static const struct cmsg_hop route[] = {
 		{relay_status_update, NULL}

--- a/src/lib/core/errinj.h
+++ b/src/lib/core/errinj.h
@@ -124,6 +124,7 @@ struct errinj {
 	_(ERRINJ_RELAY_REPORT_INTERVAL, ERRINJ_DOUBLE, {.dparam = 0}) \
 	_(ERRINJ_RELAY_SEND_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_RELAY_TIMEOUT, ERRINJ_DOUBLE, {.dparam = 0}) \
+	_(ERRINJ_RELAY_TX_STATUS_UPDATE_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_RELAY_WAL_START_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_RELAY_READ_ACK_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_REPLICASET_VCLOCK, ERRINJ_BOOL, {.bparam = false}) \

--- a/test/replication-luatest/gh_9920_tx_with_dead_relay_test.lua
+++ b/test/replication-luatest/gh_9920_tx_with_dead_relay_test.lua
@@ -1,0 +1,57 @@
+local t = require('luatest')
+local replica_set = require('luatest.replica_set')
+local server = require('luatest.server')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.replica_set = replica_set:new{}
+    local box_cfg = {
+        replication = {
+            server.build_listen_uri('server1', cg.replica_set.id),
+            server.build_listen_uri('server2', cg.replica_set.id),
+        },
+        replication_timeout = 0.1,
+    }
+    cg.server1 = cg.replica_set:build_and_add_server{
+        alias = 'server1',
+        box_cfg = box_cfg,
+    }
+    cg.server2 = cg.replica_set:build_and_add_server{
+        alias = 'server2',
+        box_cfg = box_cfg,
+    }
+    cg.replica_set:start()
+    cg.replica_set:wait_for_fullmesh()
+    cg.server1:exec(function()
+        box.schema.space.create('test'):create_index('pk')
+    end)
+    cg.server2:wait_for_vclock_of(cg.server1)
+end)
+
+g.after_all(function(cg)
+    cg.replica_set:drop()
+end)
+
+g.test_tx_send_msg_to_dead_relay = function(cg)
+    cg.server1:exec(function()
+        box.error.injection.set('ERRINJ_RELAY_TX_STATUS_UPDATE_DELAY', true)
+        box.error.injection.set('ERRINJ_RELAY_REPORT_INTERVAL', 1e-9)
+        box.space.test:insert({1})
+    end)
+
+    cg.server2:wait_for_vclock_of(cg.server1)
+    cg.server2:stop()
+
+    t.helpers.retrying({}, function()
+        t.assert(cg.server1:grep_log('exiting the relay loop'))
+    end)
+
+    cg.server1:exec(function()
+        box.error.injection.set('ERRINJ_RELAY_TX_STATUS_UPDATE_DELAY', false)
+        box.error.injection.set('ERRINJ_RELAY_REPORT_INTERVAL', 0)
+    end)
+
+    t.assert(cg.server1.process:is_alive())
+    cg.server2:start()
+end


### PR DESCRIPTION
In relay there's a message, which travels between relay and tx threads and which is used to deliver vclock of the relay to tx thread.

However, when the message is in tx thread, it may happen, that relay thread dies and tx may try to send message back without checking, whether the thread is alive.

Let's check `is_paired` flag, which is set to `false`, when relay thread dies, before sending the cbus message.

Closes #9920