### PR TITLE
say: do not close stderr at exit

### DIFF
--- a/src/lib/core/errinj.h
+++ b/src/lib/core/errinj.h
@@ -196,6 +196,7 @@ struct errinj {
 	_(ERRINJ_WAL_WRITE_DISK, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_WAL_WRITE_EOF, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_WAL_WRITE_PARTIAL, ERRINJ_INT, {.iparam = -1}) \
+	_(ERRINJ_WRITE_EXIT_CODE_TO_STDERR, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_XLOG_GARBAGE, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_XLOG_META, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_XLOG_READ, ERRINJ_INT, {.iparam = -1}) \

--- a/src/main.cc
+++ b/src/main.cc
@@ -1104,5 +1104,8 @@ main(int argc, char **argv)
 	if (!shutdown_finished)
 		ev_run(loop(), 0);
 	tarantool_free();
+	ERROR_INJECT(ERRINJ_WRITE_EXIT_CODE_TO_STDERR, {
+		fprintf(stderr, "Tarantool exited with code %d\n", exit_code);
+	});
 	return exit_code;
 }

--- a/test/app-luatest/gh_11323_write_to_stderr_at_exit_test.lua
+++ b/test/app-luatest/gh_11323_write_to_stderr_at_exit_test.lua
@@ -1,0 +1,25 @@
+local popen = require('popen')
+local t = require('luatest')
+
+local g = t.group()
+
+g.test_write_to_stderr_at_exit = function()
+    t.tarantool.skip_if_not_debug()
+    local ph = popen.new({
+        arg[-1], '-e', [[
+            box.error.injection.set('ERRINJ_WRITE_EXIT_CODE_TO_STDERR', true)
+            require('log').cfg()
+            os.exit(42)
+        ]]
+    }, {
+        stderr = popen.opts.PIPE,
+    })
+    local output = {}
+    repeat
+        local s = ph:read({stderr = true})
+        table.insert(output, s)
+    until s == ''
+    output = table.concat(output)
+    ph:close()
+    t.assert_str_contains(output, 'Tarantool exited with code 42')
+end


### PR DESCRIPTION
We must not close stderr because it's used for reporting crashes and memory leaks, but if the logger is configured to log to stderr, it's closed at exit. Let's fix it.

While we are at it, let's also remove usage of `pm_atomic_store()` and `pm_atomic_load()` for updating `log::type` because it makes no sense.

The bug was introduced by commit 6d7437dae2dfc ("say: Add several loggers support").

Close #11323