### PR TITLE
salad: fix crash on insertion into bps tree with OOM conditions

### DIFF
--- a/changelogs/unreleased/gh-11326-fix-crash-on-insertion-on-oom.md
+++ b/changelogs/unreleased/gh-11326-fix-crash-on-insertion-on-oom.md
@@ -1,0 +1,3 @@
+## bugfix/memtx
+
+* Fixed a crash on OOM on insertion in tree index of memtx engine (gh-11326).

--- a/src/lib/salad/bps_tree.h
+++ b/src/lib/salad/bps_tree.h
@@ -3156,7 +3156,6 @@ static inline void
 bps_tree_garbage_push(struct bps_tree_common *tree, struct bps_block *block,
 		      bps_tree_block_id_t id)
 {
-	assert(block); (void) block;
 	bps_tree_block_id_t next_leaf_id = (bps_tree_block_id_t)(-1);
 	bps_tree_block_id_t prev_leaf_id = (bps_tree_block_id_t)(-1);
 	if (block->type == BPS_TREE_BT_LEAF) {
@@ -3165,8 +3164,7 @@ bps_tree_garbage_push(struct bps_tree_common *tree, struct bps_block *block,
 		prev_leaf_id = leaf->prev_id;
 	}
 
-	struct bps_garbage *garbage = (struct bps_garbage *)
-		bps_tree_touch_block(tree, id);
+	struct bps_garbage *garbage = (struct bps_garbage *)block;
 	garbage->header.type = BPS_TREE_BT_GARBAGE;
 	garbage->next_id = tree->garbage_head_id;
 	garbage->next_leaf_id = next_leaf_id;


### PR DESCRIPTION
On insertion into bps tree we first reserve blocks for the case we need to insert new leaf during rebalancing. Next there can be a free block on last extent in matras but no more free extents in tuple arena. So `bps_tree_reserve_blocks()` is able to allocate a block but then `bps_tree_garbage_push()` is called that touches a block. As there no free extents touch is failed which is unexpected and causes a crash.

We don't need to touch the block on this path as block is newly allocated and is not shared with any read view. We don't need to touch block on other paths too (disposing a leaf or a inner node) because we move data from this node before so it is already should be touched.

So just don't touch the block in `bps_tree_garbage_push()`.

The issue is introduced in the commit 51c56d9b3319 ("salad: reserve extents for matras_touch on BPS tree operations") and unlocked in the commit 32b0678a74ab ("memtx: reserve extents in the RTREE index itself") where we removed crutches where we heuristically reserve memory for index operations.

Closes #11326