### PR TITLE
[backport 3.3] Refactoring needed for banning change of indexed fields by space upgrade

### DIFF
--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -1173,6 +1173,19 @@ CheckSpaceFormat::prepare(struct alter_space *alter)
 	struct space *old_space = alter->old_space;
 	struct tuple_format *new_format = new_space->format;
 	struct tuple_format *old_format = old_space->format;
+
+	if (old_format == NULL)
+		return;
+
+	assert(new_format != NULL);
+	for (uint32_t i = 0; i < old_space->index_count; i++) {
+		struct key_def *key_def =
+			alter->old_space->index[i]->def->key_def;
+		if (!tuple_format_is_compatible_with_key_def(new_format,
+							     key_def))
+			diag_raise();
+	}
+
 	if (new_space->upgrade != NULL) {
 		/*
 		 * Tuples stored in the space will be checked against
@@ -1180,17 +1193,7 @@ CheckSpaceFormat::prepare(struct alter_space *alter)
 		 */
 		return;
 	}
-	if (old_format != NULL) {
-		assert(new_format != NULL);
-		for (uint32_t i = 0; i < old_space->index_count; i++) {
-			struct key_def *key_def =
-				alter->old_space->index[i]->def->key_def;
-			if (!tuple_format_is_compatible_with_key_def(new_format,
-								     key_def))
-				diag_raise();
-		}
-		space_check_format_with_yield(old_space, new_format);
-	}
+	space_check_format_with_yield(old_space, new_format);
 }
 
 /** Change non-essential properties of a space. */

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -436,6 +436,9 @@ struct errcode_record {
 	_(ER_SYNC_QUEUE_FULL, 289,		"The synchronous transaction queue is full") \
 	_(ER_KEY_PART_VALUE_OUT_OF_RANGE, 290,	"The value of key part exceeds the supported range for type", "partno", UINT, "field_type", STRING, "value", MSGPACK, "min", MSGPACK, "max", MSGPACK) \
 	_(ER_REPLICA_GC, 291,			"Cannot clean up replica's resources", "uuid", STRING, "details", STRING) \
+	/* ER_ALIEN_ENGINE, 292, Unused */ \
+	/* ER_MVCC_UNAVAILABLE, 293, Unused */ \
+	_(ER_CANT_UPGRADE_INDEXED_FIELD, 294,	"Space upgrade doesn't support changing indexed fields", "space", STRING, "space_id", UINT, "index", STRING, "old_tuple", TUPLE, "new_tuple", TUPLE) \
 	TEST_ERROR_CODES(_) /** This one should be last. */
 
 /*

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -502,6 +502,7 @@ t;
  |   289: box.error.SYNC_QUEUE_FULL
  |   290: box.error.KEY_PART_VALUE_OUT_OF_RANGE
  |   291: box.error.REPLICA_GC
+ |   294: box.error.CANT_UPGRADE_INDEXED_FIELD
  | ...
 
 test_run:cmd("setopt delimiter ''");


### PR DESCRIPTION
This is a backport of #11317 to a future `3.3.2` release.