### PR TITLE
[backport 2.11] Refactoring needed for banning change of indexed fields by space upgrade

### DIFF
--- a/changelogs/unreleased/change-er-invalid-dec-errcode.md
+++ b/changelogs/unreleased/change-er-invalid-dec-errcode.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Changed error code of `box.error.INVALID_DEC`. It was mistakenly assigned a
+  value 279. Now it is 277.

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -1133,6 +1133,19 @@ CheckSpaceFormat::prepare(struct alter_space *alter)
 	struct space *old_space = alter->old_space;
 	struct tuple_format *new_format = new_space->format;
 	struct tuple_format *old_format = old_space->format;
+
+	if (old_format == NULL)
+		return;
+
+	assert(new_format != NULL);
+	for (uint32_t i = 0; i < old_space->index_count; i++) {
+		struct key_def *key_def =
+			alter->old_space->index[i]->def->key_def;
+		if (!tuple_format_is_compatible_with_key_def(new_format,
+							     key_def))
+			diag_raise();
+	}
+
 	if (new_space->upgrade != NULL) {
 		/*
 		 * Tuples stored in the space will be checked against
@@ -1140,19 +1153,8 @@ CheckSpaceFormat::prepare(struct alter_space *alter)
 		 */
 		return;
 	}
-	if (old_format != NULL) {
-		assert(new_format != NULL);
-		for (uint32_t i = 0; i < old_space->index_count; i++) {
-			struct key_def *key_def =
-				alter->old_space->index[i]->def->key_def;
-			if (!tuple_format_is_compatible_with_key_def(new_format,
-								     key_def))
-				diag_raise();
-		}
-		if (!tuple_format1_can_store_format2_tuples(new_format,
-							    old_format))
-			space_check_format_with_yield(old_space, new_format);
-	}
+	if (!tuple_format1_can_store_format2_tuples(new_format, old_format))
+		space_check_format_with_yield(old_space, new_format);
 }
 
 /** Change non-essential properties of a space. */

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -329,9 +329,9 @@ struct errcode_record {
 	/*274 */_(ER_UNCONFIGURED,		"Please call box.cfg{} first") \
 	/*275 */_(ER_UNUSED8,			"") \
 	/*276 */_(ER_UNUSED9,			"") \
-	/*277 */_(ER_UNUSED10,			"") \
+	/*277 */_(ER_INVALID_DEC,		"Invalid decimal: '%s'") \
 	/*278 */_(ER_IN_ANOTHER_PROMOTE,	"box.ctl.promote() is already running") \
-	/*279 */_(ER_INVALID_DEC,		"Invalid decimal: '%s'") \
+	/*279 */_(ER_UNUSED10,			"") \
 
 /*
  * !IMPORTANT! Please follow instructions at start of the file

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -332,6 +332,21 @@ struct errcode_record {
 	/*277 */_(ER_INVALID_DEC,		"Invalid decimal: '%s'") \
 	/*278 */_(ER_IN_ANOTHER_PROMOTE,	"box.ctl.promote() is already running") \
 	/*279 */_(ER_UNUSED10,			"") \
+	/*280 */_(ER_UNUSED11,			"") \
+	/*281 */_(ER_UNUSED12,			"") \
+	/*282 */_(ER_UNUSED13,			"") \
+	/*283 */_(ER_UNUSED14,			"") \
+	/*284 */_(ER_UNUSED15,			"") \
+	/*285 */_(ER_UNUSED16,			"") \
+	/*286 */_(ER_UNUSED17,			"") \
+	/*287 */_(ER_UNUSED18,			"") \
+	/*288 */_(ER_UNUSED19,			"") \
+	/*289 */_(ER_UNUSED20,			"") \
+	/*290 */_(ER_UNUSED21,			"") \
+	/*291 */_(ER_UNUSED22,			"") \
+	/*292 */_(ER_UNUSED23,			"") \
+	/*293 */_(ER_UNUSED24,			"") \
+	/*294 */_(ER_CANT_UPGRADE_INDEXED_FIELD, "Space upgrade doesn't support changing indexed fields (space %s (%d), index %s, old tuple - %s, new tuple - %s)") \
 
 /*
  * !IMPORTANT! Please follow instructions at start of the file

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -486,8 +486,8 @@ t;
  |   266: box.error.MISSING_SYSTEM_SPACES
  |   272: box.error.SCHEMA_UPGRADE_IN_PROGRESS
  |   274: box.error.UNCONFIGURED
+ |   277: box.error.INVALID_DEC
  |   278: box.error.IN_ANOTHER_PROMOTE
- |   279: box.error.INVALID_DEC
  | ...
 
 test_run:cmd("setopt delimiter ''");

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -488,6 +488,7 @@ t;
  |   274: box.error.UNCONFIGURED
  |   277: box.error.INVALID_DEC
  |   278: box.error.IN_ANOTHER_PROMOTE
+ |   294: box.error.CANT_UPGRADE_INDEXED_FIELD
  | ...
 
 test_run:cmd("setopt delimiter ''");


### PR DESCRIPTION
This is a backport of https://github.com/tarantool/tarantool/pull/11317 to a future 2.11.7 release.

Along the way we fix a wrong error code being assigned to `ER_INVALID_DEC` error during its backport to 2.11.