### PR TITLE
box: release array and schema in box_insert_arrow

### DIFF
--- a/perf/lua/column_insert_module.c
+++ b/perf/lua/column_insert_module.c
@@ -276,8 +276,6 @@ insert_batch_lua_func(struct lua_State *L)
 				 batch_row_count, sparse_mode);
 		if (box_insert_arrow(space_id, &array, &schema) != 0)
 			return luaT_error(L);
-		schema.release(&schema);
-		array.release(&array);
 	}
 	return 0;
 }

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -4134,7 +4134,12 @@ box_insert_arrow(uint32_t space_id, struct ArrowArray *array,
 	request.space_id = space_id;
 	request.arrow_array = array;
 	request.arrow_schema = schema;
-	return box_process1(&request, NULL);
+	int rc = box_process1(&request, NULL);
+	if (array->release != NULL)
+		array->release(array);
+	if (schema->release != NULL)
+		schema->release(schema);
+	return rc;
 }
 
 /**

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -683,7 +683,7 @@ struct ArrowSchema;
  * If a column is nullable in space format, it can be omitted. All non-nullable
  * columns (including primary key parts) must be present in the batch.
  *
- * This function does not release neither `array` nor `schema`.
+ * Both `array` and `schema` are moved or released, even on failure.
  *
  * \param space_id space identifier
  * \param array input data in ArrowArray format

--- a/src/box/lua/index.c
+++ b/src/box/lua/index.c
@@ -437,12 +437,7 @@ lbox_insert_arrow(lua_State *L)
 	struct ArrowSchema schema;
 	if (arrow_ipc_decode(&array, &schema, data, data + len) != 0)
 		return luaT_error(L);
-	int rc = box_insert_arrow(space_id, &array, &schema);
-	if (schema.release != NULL)
-		schema.release(&schema);
-	if (array.release != NULL)
-		array.release(&array);
-	if (rc != 0)
+	if (box_insert_arrow(space_id, &array, &schema) != 0)
 		return luaT_error(L);
 	return 0;
 }

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -71,6 +71,11 @@ struct space_vtab {
 	int (*execute_update)(struct space *, struct txn *,
 			      struct request *, struct tuple **result);
 	int (*execute_upsert)(struct space *, struct txn *, struct request *);
+	/**
+	 * Executes a batch insert request.
+	 *
+	 * The implementation may move or release the input array and schema.
+	 */
 	int (*execute_insert_arrow)(struct space *space, struct txn *txn,
 				    struct ArrowArray *array,
 				    struct ArrowSchema *schema);


### PR DESCRIPTION
According to the documentation to the Apache Arrow C data interface:

> Consumers MUST call a base structure’s release callback when they
> won’t be using it anymore[^1]

`box_insert_arrow()` is clearly a consumer so it must move or release the input Arrow array and schema to conform to the specification while currently it does not. This patch fixes this issue.

Note that for performance reasons (to avoid extra copying), the engine callback that implements batch insertion should be allowed to move the input Arrow array and schema to a private location. To allow for that, we have to move the code that encodes the input Arrow in the IPC format for xlog from `txn_add_redo()` to `space_execute_insert_arrow()`.

Closes #11338

[^1]: https://arrow.apache.org/docs/format/CDataInterface.html#release-callback-semantics-for-consumers