### PR TITLE
config: forbid instance scope bootstrap_strategy

### DIFF
--- a/changelogs/unreleased/forbid-repl-bootstrap-strategy-instance-scope.md
+++ b/changelogs/unreleased/forbid-repl-bootstrap-strategy-instance-scope.md
@@ -1,0 +1,5 @@
+## bugfix/config
+
+* Now, `replication.bootstrap_strategy` can't be specified in the instance scope
+  since it only makes sense to specify the option for at least for the whole
+  replicaset.

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1336,6 +1336,7 @@ return schema.new('instance_config', schema.record({
         }, {
             box_cfg = 'bootstrap_strategy',
             default = 'auto',
+            validate = validators['replication.bootstrap_strategy'],
         }),
         autoexpel = schema.record({
             enabled = schema.scalar({

--- a/src/box/lua/config/validators.lua
+++ b/src/box/lua/config/validators.lua
@@ -314,6 +314,13 @@ M['replication.autoexpel'] = function(data, w)
     end
 end
 
+M['replication.bootstrap_strategy'] = function(_data, w)
+    -- Forbid in the instance scope, because it has no
+    -- sense to set the option for a part of a
+    -- replicaset.
+    validate_scope(w, {'global', 'group', 'replicaset'})
+end
+
 M['replication.failover'] = function(_data, w)
     -- Forbid in the instance scope, because it has no
     -- sense to set the option for a part of a

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -799,6 +799,18 @@ g.test_scope = function()
             instance = false,
         },
         {
+            name = 'replication.bootstrap_strategy',
+            data = {
+                replication = {
+                    bootstrap_strategy = 'auto',
+                },
+            },
+            global = true,
+            group = true,
+            replicaset = true,
+            instance = false,
+        },
+        {
             name = 'replication.failover',
             data = {
                 replication = {


### PR DESCRIPTION
This patch forbids configurations that have the option
`replication.bootstrap_strategy` in the instance scope. Similarly to
`replication.failover` this option only makes sense in the replicaset
scope and on the upper levels. Otherwise the configuration might be
broken.
