### PR TITLE
index: add virtual methods for creating arrow streams

### DIFF
--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -1158,7 +1158,7 @@ generic_index_create_iterator(struct index *base, enum iterator_type type,
 	(void)key;
 	(void)part_count;
 	(void)pos;
-	diag_set(UnsupportedIndexFeature, base->def, "read view");
+	diag_set(UnsupportedIndexFeature, base->def, "iterator");
 	return NULL;
 }
 
@@ -1215,6 +1215,41 @@ generic_index_read_view_create_iterator_with_offset(
 	return 0;
 fail:
 	index_read_view_iterator_destroy(it);
+	return -1;
+}
+
+int
+generic_index_create_arrow_stream(struct index *index,
+				  uint32_t field_count, const uint32_t *fields,
+				  const char *key, uint32_t part_count,
+				  const struct arrow_options *options,
+				  struct ArrowArrayStream *stream)
+{
+	(void)field_count;
+	(void)fields;
+	(void)key;
+	(void)part_count;
+	(void)options;
+	(void)stream;
+	diag_set(UnsupportedIndexFeature, index->def, "arrow stream");
+	return -1;
+}
+
+int
+generic_index_read_view_create_arrow_stream(
+	struct index_read_view *rv,
+	uint32_t field_count, const uint32_t *fields,
+	const char *key, uint32_t part_count,
+	const struct arrow_options *options,
+	struct ArrowArrayStream *stream)
+{
+	(void)field_count;
+	(void)fields;
+	(void)key;
+	(void)part_count;
+	(void)options;
+	(void)stream;
+	diag_set(UnsupportedIndexFeature, rv->def, "arrow stream in read view");
 	return -1;
 }
 

--- a/src/box/memtx_bitset.cc
+++ b/src/box/memtx_bitset.cc
@@ -525,6 +525,7 @@ static const struct index_vtab memtx_bitset_index_vtab = {
 	/* .create_iterator = */ memtx_bitset_index_create_iterator,
 	/* .create_iterator_with_offset = */
 	generic_index_create_iterator_with_offset,
+	/* .create_arrow_stream = */ generic_index_create_arrow_stream,
 	/* .create_read_view = */ generic_index_create_read_view,
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -632,6 +632,8 @@ memtx_hash_index_create_read_view(struct index *base)
 		.create_iterator = hash_read_view_create_iterator,
 		.create_iterator_with_offset =
 			generic_index_read_view_create_iterator_with_offset,
+		.create_arrow_stream =
+			generic_index_read_view_create_arrow_stream,
 	};
 	struct memtx_hash_index *index = (struct memtx_hash_index *)base;
 	struct hash_read_view *rv =
@@ -670,6 +672,7 @@ static const struct index_vtab memtx_hash_index_vtab = {
 	/* .create_iterator = */ memtx_hash_index_create_iterator,
 	/* .create_iterator_with_offset = */
 	generic_index_create_iterator_with_offset,
+	/* .create_arrow_stream = */ generic_index_create_arrow_stream,
 	/* .create_read_view = */ memtx_hash_index_create_read_view,
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,

--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -423,6 +423,7 @@ static const struct index_vtab memtx_rtree_index_vtab = {
 	/* .create_iterator = */ memtx_rtree_index_create_iterator,
 	/* .create_iterator_with_offset = */
 	generic_index_create_iterator_with_offset,
+	/* .create_arrow_stream = */ generic_index_create_arrow_stream,
 	/* .create_read_view = */ generic_index_create_read_view,
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -2455,6 +2455,8 @@ memtx_tree_index_create_read_view(struct index *base)
 		.create_iterator = tree_read_view_create_iterator<USE_HINT>,
 		.create_iterator_with_offset =
 			tree_read_view_create_iterator_with_offset<USE_HINT>,
+		.create_arrow_stream =
+			generic_index_read_view_create_arrow_stream,
 	};
 	struct memtx_tree_index<USE_HINT> *index =
 		(struct memtx_tree_index<USE_HINT> *)base;
@@ -2500,6 +2502,7 @@ static const struct index_vtab memtx_tree_disabled_index_vtab = {
 	/* .create_iterator = */ generic_index_create_iterator,
 	/* .create_iterator_with_offset = */
 	generic_index_create_iterator_with_offset,
+	/* .create_arrow_stream = */ generic_index_create_arrow_stream,
 	/* .create_read_view = */ generic_index_create_read_view,
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,
@@ -2566,6 +2569,7 @@ get_memtx_tree_index_vtab(void)
 			memtx_tree_index_create_iterator<USE_HINT>,
 		/* .create_iterator_with_offset = */
 		memtx_tree_index_create_iterator_with_offset<USE_HINT>,
+		/* .create_arrow_stream = */ generic_index_create_arrow_stream,
 		/* .create_read_view = */
 			memtx_tree_index_create_read_view<USE_HINT>,
 		/* .stat = */ generic_index_stat,

--- a/src/box/read_view.c
+++ b/src/box/read_view.c
@@ -75,6 +75,8 @@ static void
 space_read_view_delete(struct space_read_view *space_rv)
 {
 	assert(space_rv->format == NULL);
+	if (space_rv->field_count > 0)
+		field_def_array_delete(space_rv->fields, space_rv->field_count);
 	free(space_rv->format_data);
 	for (uint32_t i = 0; i <= space_rv->index_id_max; i++) {
 		struct index_read_view *index_rv = space_rv->index_map[i];
@@ -107,6 +109,15 @@ space_read_view_new(struct space *space, const struct read_view_opts *opts)
 
 	space_rv->id = space_id(space);
 	space_rv->group_id = space_group_id(space);
+	if (opts->enable_field_names && space->def->field_count > 0) {
+		space_rv->fields = field_def_array_dup(space->def->fields,
+						       space->def->field_count);
+		assert(space_rv->fields != NULL);
+		space_rv->field_count = space->def->field_count;
+	} else {
+		space_rv->fields = NULL;
+		space_rv->field_count = 0;
+	}
 	if (opts->enable_field_names &&
 	    space->def->format_data != NULL) {
 		space_rv->format_data = xmalloc(space->def->format_data_len);

--- a/src/box/read_view.h
+++ b/src/box/read_view.h
@@ -35,10 +35,16 @@ struct space_read_view {
 	/** Space name. */
 	char *name;
 	/**
+	 * Tuple field definition array used by this space. Allocated only if
+	 * read_view_opts::enable_field_names is set, otherwise set to NULL.
+	 */
+	struct field_def *fields;
+	/** Number of entries in the fields array. */
+	uint32_t field_count;
+	/**
 	 * Tuple format data used by this space. Allocated only if
 	 * read_view_opts::enable_field_names is set, otherwise set to NULL.
-	 * Used for creation of space_read_view::format and
-	 * box_raw_read_view_space::fields.
+	 * Used for creation of space_read_view::format.
 	 */
 	char *format_data;
 	/** Length of tuple format data. */

--- a/src/box/sequence.c
+++ b/src/box/sequence.c
@@ -419,6 +419,8 @@ sequence_data_read_view_create(struct index *index)
 		.create_iterator = sequence_data_iterator_create,
 		.create_iterator_with_offset =
 			generic_index_read_view_create_iterator_with_offset,
+		.create_arrow_stream =
+			generic_index_read_view_create_arrow_stream,
 	};
 	struct sequence_data_read_view *rv = xmalloc(sizeof(*rv));
 	index_read_view_create(&rv->base, &vtab, index->def);

--- a/src/box/session_settings.c
+++ b/src/box/session_settings.c
@@ -285,6 +285,7 @@ static const struct index_vtab session_settings_index_vtab = {
 	/* .create_iterator = */ session_settings_index_create_iterator,
 	/* .create_iterator_with_offset = */
 	generic_index_create_iterator_with_offset,
+	/* .create_arrow_stream = */ generic_index_create_arrow_stream,
 	/* .create_read_view = */ generic_index_create_read_view,
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,

--- a/src/box/sysview.c
+++ b/src/box/sysview.c
@@ -196,6 +196,7 @@ static const struct index_vtab sysview_index_vtab = {
 	/* .create_iterator = */ sysview_index_create_iterator,
 	/* .create_iterator_with_offset = */
 	generic_index_create_iterator_with_offset,
+	/* .create_arrow_stream = */ generic_index_create_arrow_stream,
 	/* .create_read_view = */ generic_index_create_read_view,
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -4840,6 +4840,7 @@ static const struct index_vtab vinyl_index_vtab = {
 	/* .create_iterator = */ vinyl_index_create_iterator,
 	/* .create_iterator_with_offset = */
 	generic_index_create_iterator_with_offset,
+	/* .create_arrow_stream = */ generic_index_create_arrow_stream,
 	/* .create_read_view = */ generic_index_create_read_view,
 	/* .stat = */ vinyl_index_stat,
 	/* .compact = */ vinyl_index_compact,


### PR DESCRIPTION
Currently, these methods are implemented only by memcs (available in EE only) so we don't really need to make them virtual. In future, however, we're planning to introduce a new column store engine, which will export the arrow API, too.

EE part: https://github.com/tarantool/tarantool-ee/pull/1203