### PR TITLE
box: fix session use-after-free

### DIFF
--- a/changelogs/unreleased/gh-11267-fix-session-use-after-free.md
+++ b/changelogs/unreleased/gh-11267-fix-session-use-after-free.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed use-after-free for session created implicitly when using
+  `tnt_tx_push()` to execute code making access checks (gh-11267).

--- a/src/box/session.c
+++ b/src/box/session.c
@@ -108,6 +108,8 @@ session_on_stop(struct trigger *trigger, void *event)
 	trigger_clear(trigger);
 	/* Destroy the session */
 	session_delete(fiber_get_session(fiber()));
+	fiber_set_session(fiber(), NULL);
+	fiber_set_user(fiber(), NULL);
 	return 0;
 }
 


### PR DESCRIPTION
If session is created on demand in fiber we delete it when fiber is stopped. But we do not clear session and credentials in fiber storage. It is not an issue for standalone fiber (outside of fiber pool) as fiber will be destroyed or recycled and will not have chance to execute any code before that. In case of fiber pool it become dangerous as fiber is reused. Fortunately we never hit this because we either reset session and credentials at start in code executed in fiber (like in iproto) or execute code that does not check access (like in vinyl).

Recently we add `tnt_tx_push()` to execute callback in TX. This time the issue is revealed.

Let's just clear session and credentials in fiber storage when fiber is stopped.

Closes #11267