### PR TITLE
[backport 3.3] memtx: raise an error when trying to use unsupported MVCC feature

### DIFF
--- a/changelogs/unreleased/memtx-mvcc-forbid-multikey-and-func.md
+++ b/changelogs/unreleased/memtx-mvcc-forbid-multikey-and-func.md
@@ -1,0 +1,6 @@
+## bugfix/memtx
+
+* Tarantool allowed to create multikey and functional indexes with
+  memtx MVCC enabled, but they were not supported. This led to a crash
+  or a panic. Now Tarantool raises an error when one tries to create
+  an index of the kind with memtx MVCC enabled (gh-6385, gh-11099).

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -878,6 +878,21 @@ memtx_space_check_index_def(struct space *space, struct index_def *index_def)
 	/* Only HASH and TREE indexes check parts there. */
 	if (index_def_check_field_types(index_def, space_name(space)) != 0)
 		return -1;
+
+	/* Checks for memtx MVCC unsupported features. */
+	if (memtx_tx_manager_use_mvcc_engine) {
+		if (key_def->is_multikey) {
+			diag_set(ClientError, ER_UNSUPPORTED,
+				 "Memtx MVCC engine", "multikey indexes");
+			return -1;
+		}
+		if (key_def->for_func_index) {
+			diag_set(ClientError, ER_UNSUPPORTED,
+				 "Memtx MVCC engine", "functional indexes");
+			return -1;
+		}
+	}
+
 	return 0;
 }
 

--- a/test/box-luatest/memtx_mvcc_unsupported_features_test.lua
+++ b/test/box-luatest/memtx_mvcc_unsupported_features_test.lua
@@ -1,0 +1,109 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_each(function(cg)
+    cg.server = server:new{box_cfg = {memtx_use_mvcc_engine = true}}
+    cg.server:start()
+end)
+
+g.after_each(function(cg)
+    cg.server:stop()
+end)
+
+-- Checks that unsupported MVCC features cannot be enabled along with MVCC.
+g.test_unsupported_features = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        s:create_index('pk')
+
+        box.schema.func.create('test', {
+            is_deterministic = true,
+            is_sandboxed = true,
+            body = [[function(tuple)
+                return {tuple[1]}
+            end]]
+        })
+
+        local errmsg = "Memtx MVCC engine does not support functional indexes"
+        t.assert_error_msg_content_equals(errmsg, function()
+            s:create_index('test_secondary', {
+                func = 'test',
+                parts = {{1, 'unsigned'}},
+            })
+        end)
+
+        errmsg = "Memtx MVCC engine does not support multikey indexes"
+        t.assert_error_msg_content_equals(errmsg, function()
+            s:create_index('test_secondary', {
+                parts = {{2, 'unsigned', path = '[*]'}},
+            })
+        end)
+    end)
+end
+
+-- Checks that recovery of unsupported MVCC features fails.
+g.test_recovery_with_unsupported_features = function(cg)
+    local server_log_path = g.server:exec(function()
+        return rawget(_G, 'box_cfg_log_file') or box.cfg.log
+    end)
+
+    -- Check functional multikey index.
+    cg.server:restart({box_cfg = {memtx_use_mvcc_engine = false}})
+    cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        s:create_index('pk')
+
+        box.schema.func.create('test', {
+            is_deterministic = true,
+            is_sandboxed = true,
+            body = [[function(tuple)
+                return {tuple[1]}
+            end]]
+        })
+
+        s:create_index('test_secondary', {
+            func = 'test',
+            parts = {{1, 'unsigned'}},
+        })
+    end)
+
+    cg.server:restart({box_cfg = {memtx_use_mvcc_engine = true}},
+        {wait_until_ready = false})
+    t.helpers.retrying({}, function()
+        t.assert(g.server:grep_log(
+            "F> can't initialize storage: Memtx MVCC engine does not support" ..
+            " functional indexes", nil, {filename = server_log_path}))
+    end)
+
+    -- Check regular multikey index.
+    cg.server:restart({box_cfg = {memtx_use_mvcc_engine = false}})
+    cg.server:exec(function()
+        box.space.test.index.test_secondary:drop()
+        box.space.test:create_index('test_secondary', {
+            parts = {{2, 'unsigned', path = '[*]'}},
+        })
+        -- We need to do a snapshot to make the definition (and, potentially,
+        -- data inserted to the index) disappear from snapshot and WAL.
+        box.snapshot()
+    end)
+
+    cg.server:restart({box_cfg = {memtx_use_mvcc_engine = true}},
+        {wait_until_ready = false})
+    t.helpers.retrying({}, function()
+        t.assert(g.server:grep_log(
+            "F> can't initialize storage: Memtx MVCC engine does not support" ..
+            " multikey indexes", nil, {filename = server_log_path}))
+    end)
+
+    cg.server:restart({box_cfg = {memtx_use_mvcc_engine = false}})
+    cg.server:exec(function()
+        box.space.test.index.test_secondary:drop()
+        -- We need to do a snapshot to make the definition (and, potentially,
+        -- data inserted to the index) disappear from snapshot and WAL.
+        box.snapshot()
+    end)
+
+    cg.server:restart({box_cfg = {memtx_use_mvcc_engine = true}})
+end


### PR DESCRIPTION
Memtx MVCC does not support multikey indexes, but allows to use them. If one will use them, Tarantool is most likely to crash, and that's the best scenario - otherwise Tarantool will work, but something terribly wrong will be happening under the hood. Let's simply forbid to create such indexes along with MVCC until we support them.

In addition to that, the commit forbids to create functional indexes along with memtx MVCC enabled since target Tarantool version for this commit does not support them completely.

Workaround for #6385
Workaround for #11099

NO_DOC=backport

(cherry picked from commit ae067afb6f45e65913c2996bdedb752d14a1ec64)