### PR TITLE
config: allow guest to perform `failover.execute`

### DIFF
--- a/changelogs/unreleased/allow-guest-call-failover-execute.md
+++ b/changelogs/unreleased/allow-guest-call-failover-execute.md
@@ -1,0 +1,6 @@
+## feature/config
+
+* Now, when the instance is configured with bootstrap strategy `supervised` or
+  `native` and uses a supervised failover coordinator the guest user is
+  automatically granted with privileges for performing the initial bootstrap
+  using the `failover.execute` call.

--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -1836,6 +1836,12 @@ I['replication.bootstrap_strategy'] = format_text([[
       `replication_connect_quorum` number of other nodes to be connected. This
       option is added to keep the compatibility with the current versions of
       Cartridge and might be removed in the future.
+
+    Note: when using bootstrap strategies `supervised` or `native` with a
+    supervised failover (see `replication.failover` configuration option)
+    Tarantool automatically grants the guest user privileges allowing to execute
+    the internal `failover.execute` call for performing the initial cluster
+    bootstrap.
 ]])
 
 I['replication.connect_timeout'] = format_text([[


### PR DESCRIPTION
This patch grants the guest user runtime privileges for running
`failover.execute` function. This is an internal function used by the
supervised failover coordinator. This privileges are needed for the
guest user to be able to perform the initial bootstrap since there is no
other users available before it.

Technically it's a part of a native and supervised bootstrap strategy
support allowing the external agent (i.e the supervised failover
coordinator) to perform the initial bootstrap.

Needed for tarantool/tarantool-ee#1194