### PR TITLE
build: support cmake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 project(tarantool C CXX ASM)
 

--- a/static-build/CMakeLists.txt
+++ b/static-build/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 # Detect system compilers for further dependencies configuring to be
 # built with these compilers. This is used to build tarantool and


### PR DESCRIPTION
as cmake < 3.5 support has been removed in cmake 4, bump the minimum_version to 3.5

```
  CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
    Compatibility with CMake < 3.5 has been removed from CMake.
```

relates to https://github.com/Homebrew/homebrew-core/pull/219323