### PR TITLE
[backport 2.11] box: set TXN_WAIT_SYNC with xrow rather than limbo state during recovery

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -803,6 +803,10 @@ wal_stream_apply_dml_row(struct wal_stream *stream, struct xrow_header *row)
 	assert(txn != NULL);
 	if (!row->is_commit)
 		return 0;
+	txn_set_xrow_flags(row->flags);
+	if (!txn_has_flag(txn, TXN_WAIT_SYNC) &&
+	    !txn_has_flag(txn, TXN_WAIT_ACK))
+		txn_set_flags(txn, TXN_FORCE_ASYNC);
 	/*
 	 * For fully local transactions the TSN check won't work like for global
 	 * transactions, because it is not known if there are global rows until

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -1287,6 +1287,26 @@ box_txn_set_timeout(double timeout)
 	return 0;
 }
 
+void
+txn_set_xrow_flags(uint8_t xrow_flags)
+{
+	struct txn *txn = in_txn();
+	/*
+	 * Do nothing if transaction is not started,
+	 * it's the same as BEGIN + COMMIT.
+	 */
+	if (!txn)
+		return;
+
+	const uint8_t flags_map[] = {
+		[IPROTO_FLAG_WAIT_SYNC] = TXN_WAIT_SYNC,
+		[IPROTO_FLAG_WAIT_ACK] = TXN_WAIT_ACK,
+	};
+
+	txn->flags |= flags_map[xrow_flags & IPROTO_FLAG_WAIT_SYNC];
+	txn->flags |= flags_map[xrow_flags & IPROTO_FLAG_WAIT_ACK];
+}
+
 /** Wait for a linearization point for a transaction. */
 static int
 txn_make_linearizable(struct txn *txn)

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -93,7 +93,9 @@ enum txn_flag {
 	 * A transaction may be forced to be asynchronous, not
 	 * wait for any ACKs, and not depend on prepending sync
 	 * transactions. This happens in a few special cases. For
-	 * example, when applier receives snapshot from master.
+	 * example, when applier receives snapshot from master. This also
+	 * happens during recovery of all transactions that did not go through
+	 * the limbo at commit time.
 	 */
 	TXN_FORCE_ASYNC = 0x40,
 	/**

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -552,6 +552,12 @@ txn_set_flags(struct txn *txn, unsigned int flags)
 	txn->flags |= flags;
 }
 
+/**
+ * Set flags from xrow on the transaction.
+ */
+void
+txn_set_xrow_flags(uint8_t xrow_flags);
+
 static inline void
 txn_clear_flags(struct txn *txn, unsigned int flags)
 {


### PR DESCRIPTION
*(This PR is a backport of #11295 to `release/2.11` to a future `2.11.7` release.)*

----

This patchset fixes a bug with `TXN_FORCE_ASYNC` transactions being lost after receiving a promote request from another instance and restarting the current instance.

Closes #11053