### PR TITLE
memtx: use index definition's `key_def` for point hole comparisons

### DIFF
--- a/changelogs/unreleased/gh-10159-11292-mvcc-bitwise-key-comparison.md
+++ b/changelogs/unreleased/gh-10159-11292-mvcc-bitwise-key-comparison.md
@@ -1,0 +1,4 @@
+## bugfix/memtx
+
+* Fixed a bug that caused the memtx MVCC to miss conflicts over key definitions
+  that used the number type or collations (gh-10159, gh-11292).

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -919,8 +919,6 @@ index_create(struct index *index, struct engine *engine,
 	index->def = def;
 	index->refs = 1;
 	index->space_cache_version = space_cache_version;
-	static uint32_t unique_id = 0;
-	index->unique_id = unique_id++;
 	/* Unusable until set to proper value during space creation. */
 	index->dense_id = UINT32_MAX;
 	rlist_create(&index->read_gaps);

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -704,8 +704,6 @@ struct index {
 	int refs;
 	/** Space cache version at the time of construction. */
 	uint32_t space_cache_version;
-	/** Globally unique ID. */
-	uint32_t unique_id;
 	/** Compact ID - index in space->index array. */
 	uint32_t dense_id;
 	/**

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -3982,9 +3982,12 @@ memtx_tx_manager_free(void)
 
 	for (size_t i = 0; i < BOX_INDEX_MAX; i++)
 		mempool_destroy(&txm.memtx_tx_story_pool[i]);
+	assert(mh_size(txm.history) == 0);
 	mh_history_delete(txm.history);
+	assert(mh_size(txm.func_key_storage) == 0);
 	mh_func_key_storage_delete(txm.func_key_storage);
 	memtx_tx_mempool_destroy(&txm.point_hole_item_pool);
+	assert(mh_size(txm.point_holes) == 0);
 	mh_point_holes_delete(txm.point_holes);
 	memtx_tx_mempool_destroy(&txm.inplace_gap_item_mempoool);
 	memtx_tx_mempool_destroy(&txm.nearby_gap_item_mempoool);

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -196,8 +196,6 @@ struct point_hole_item {
 	const char *key;
 	/** Storage for short key. @key may point here. */
 	char short_key[16];
-	/** Saved space id. */
-	uint32_t space_id;
 	/** Flag that the hash tables stores pointer to this item. */
 	bool is_head;
 };
@@ -3269,7 +3267,7 @@ memtx_tx_abort_space_schema_readers(struct space *space, struct txn *ddl_owner)
 		struct point_hole_item *hole_item;
 		rlist_foreach_entry(hole_item, &txn->point_holes_list,
 				    in_point_holes_list) {
-			if (space->def->id == hole_item->space_id) {
+			if (space->def->id == hole_item->index->def->space_id) {
 				txn_abort_with_conflict(txn);
 				break;
 			}
@@ -3487,7 +3485,6 @@ point_hole_storage_new(struct index *index, const char *key,
 						     MEMTX_TX_ALLOC_TRACKER);
 	}
 	memcpy((char *)object->key, key, key_len);
-	object->space_id = index->def->space_id;
 	object->is_head = true;
 
 	struct key_def *def = index->def->key_def;

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -3513,7 +3513,6 @@ point_hole_storage_delete(struct point_hole_item *object)
 		 * list and that's enough.
 		 */
 		assert(!rlist_empty(&object->ring));
-		rlist_del(&object->ring);
 	} else if (!rlist_empty(&object->ring)) {
 		/*
 		 * Hash table point to this item, but there are more
@@ -3529,7 +3528,6 @@ point_hole_storage_delete(struct point_hole_item *object)
 		struct point_hole_item **preplaced = &replaced;
 		mh_point_holes_put(txm.point_holes, put, &preplaced, 0);
 		assert(replaced == object);
-		rlist_del(&object->ring);
 		another->is_head = true;
 	} else {
 		/*
@@ -3542,6 +3540,7 @@ point_hole_storage_delete(struct point_hole_item *object)
 		assert(pos != mh_end(txm.point_holes));
 		mh_point_holes_del(txm.point_holes, pos, 0);
 	}
+	rlist_del(&object->ring);
 	rlist_del(&object->in_point_holes_list);
 	struct memtx_tx_mempool *pool = &txm.point_hole_item_pool;
 	memtx_tx_mempool_free(object->txn, pool, object);

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -186,8 +186,8 @@ struct point_hole_item {
 	struct rlist ring;
 	/** Link in txn->point_holes_list. */
 	struct rlist in_point_holes_list;
-	/** Saved index->unique_id. */
-	uint32_t index_unique_id;
+	/** Saved index. */
+	struct index *index;
 	/** Precalculated hash for storing in hash table.. */
 	uint32_t hash;
 	/** Saved txn. */
@@ -372,7 +372,7 @@ static uint32_t
 point_hole_storage_combine_index_and_tuple_hash(struct index *index,
 						uint32_t tuple_hash)
 {
-	return (uintptr_t)index->unique_id ^ tuple_hash;
+	return (uintptr_t)index ^ tuple_hash;
 }
 
 /** Hash calculatore for the key. */
@@ -400,7 +400,7 @@ point_hole_storage_equal(const struct point_hole_item *obj1,
 			 const struct point_hole_item *obj2)
 {
 	/* Canonical msgpack is comparable by memcmp. */
-	if (obj1->index_unique_id != obj2->index_unique_id ||
+	if (obj1->index != obj2->index ||
 	    obj1->key_len != obj2->key_len)
 		return 1;
 	return memcmp(obj1->key, obj2->key, obj1->key_len) != 0;
@@ -411,7 +411,7 @@ static int
 point_hole_storage_key_equal(const struct point_hole_key *key,
 			     const struct point_hole_item *object)
 {
-	if (key->index->unique_id != object->index_unique_id)
+	if (key->index != object->index)
 		return 1;
 	assert(key->index != NULL);
 	assert(key->tuple != NULL);
@@ -1827,6 +1827,7 @@ point_hole_item_delete(struct point_hole_item *object)
 {
 	rlist_del(&object->ring);
 	rlist_del(&object->in_point_holes_list);
+	index_unref(object->index);
 	struct memtx_tx_mempool *pool = &txm.point_hole_item_pool;
 	memtx_tx_mempool_free(object->txn, pool, object);
 }
@@ -3477,7 +3478,8 @@ point_hole_storage_new(struct index *index, const char *key,
 	rlist_create(&object->ring);
 	rlist_create(&object->in_point_holes_list);
 	object->txn = txn;
-	object->index_unique_id = index->unique_id;
+	object->index = index;
+	index_ref(index);
 	if (key_len <= sizeof(object->short_key)) {
 		object->key = object->short_key;
 	} else {

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -194,8 +194,6 @@ struct point_hole_item {
 	struct txn *txn;
 	/** Saved key. Points to @a short_key or allocated in txn's region. */
 	const char *key;
-	/** Saved key len. */
-	size_t key_len;
 	/** Storage for short key. @key may point here. */
 	char short_key[16];
 	/** Saved space id. */
@@ -399,11 +397,13 @@ static int
 point_hole_storage_equal(const struct point_hole_item *obj1,
 			 const struct point_hole_item *obj2)
 {
-	/* Canonical msgpack is comparable by memcmp. */
-	if (obj1->index != obj2->index ||
-	    obj1->key_len != obj2->key_len)
+	if (obj1->index != obj2->index)
 		return 1;
-	return memcmp(obj1->key, obj2->key, obj1->key_len) != 0;
+	struct key_def *key_def = obj1->index->def->key_def;
+	uint32_t part_count = key_def->part_count;
+	return key_compare(obj1->key, part_count, HINT_NONE,
+			   obj2->key, part_count, HINT_NONE,
+			   key_def) != 0;
 }
 
 /** point_hole_item comparator with key. */
@@ -3487,7 +3487,6 @@ point_hole_storage_new(struct index *index, const char *key,
 						     MEMTX_TX_ALLOC_TRACKER);
 	}
 	memcpy((char *)object->key, key, key_len);
-	object->key_len = key_len;
 	object->space_id = index->def->space_id;
 	object->is_head = true;
 

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -188,14 +188,14 @@ struct point_hole_item {
 	struct rlist in_point_holes_list;
 	/** Saved index. */
 	struct index *index;
-	/** Precalculated hash for storing in hash table.. */
-	uint32_t hash;
 	/** Saved txn. */
 	struct txn *txn;
 	/** Saved key. Points to @a short_key or allocated in txn's region. */
 	const char *key;
 	/** Storage for short key. @key may point here. */
 	char short_key[16];
+	/** Precalculated hash for storing in hash table. */
+	uint32_t hash;
 	/** Flag that the hash tables stores pointer to this item. */
 	bool is_head;
 };

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -367,6 +367,14 @@ struct point_hole_key {
 	struct tuple *func_key;
 };
 
+/** Combine hash of index with hash of tuple. */
+static uint32_t
+point_hole_storage_combine_index_and_tuple_hash(struct index *index,
+						uint32_t tuple_hash)
+{
+	return (uintptr_t)index->unique_id ^ tuple_hash;
+}
+
 /** Hash calculatore for the key. */
 static uint32_t
 point_hole_storage_key_hash(struct point_hole_key *key)
@@ -382,8 +390,8 @@ point_hole_storage_key_hash(struct point_hole_key *key)
 		mp_decode_array(&data);
 		tuple_hash = key_hash(data, def);
 	}
-	return key->index->unique_id ^ tuple_hash;
-
+	return point_hole_storage_combine_index_and_tuple_hash(key->index,
+							       tuple_hash);
 }
 
 /** point_hole_item comparator. */
@@ -3474,7 +3482,9 @@ point_hole_storage_new(struct index *index, const char *key,
 	object->is_head = true;
 
 	struct key_def *def = index->def->key_def;
-	object->hash = object->index_unique_id ^ key_hash(key, def);
+	uint32_t hash = key_hash(key, def);
+	object->hash = point_hole_storage_combine_index_and_tuple_hash(index,
+								       hash);
 
 	const struct point_hole_item **put =
 		(const struct point_hole_item **) &object;

--- a/test/box-luatest/gh_10159_11292_mvcc_bitwise_key_comparison_test.lua
+++ b/test/box-luatest/gh_10159_11292_mvcc_bitwise_key_comparison_test.lua
@@ -1,0 +1,107 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_each(function(cg)
+    cg.server = server:new({box_cfg = {memtx_use_mvcc_engine = true}})
+    cg.server:start()
+    cg.server:exec(function()
+        rawset(_G, 'fiber', require('fiber'))
+
+        box.schema.space.create('s')
+    end)
+end)
+
+g.after_each(function(cg)
+    cg.server:drop()
+end)
+
+g.before_test('test_number', function(cg)
+    cg.server:exec(function()
+        box.space.s:create_index('p', {parts = {1, 'double'}})
+    end)
+end)
+
+g.test_number = function(cg)
+    cg.server:exec(function()
+        local s = box.space.s
+
+        local f1 = _G.fiber.new(function()
+            box.atomic(function()
+                s:get{0}
+                _G.fiber.yield()
+                s:replace{0}
+            end)
+        end)
+        f1:set_joinable(true)
+
+        local f2 = _G.fiber.new(function()
+            box.atomic(function()
+                s:get{require('ffi').cast('double', 0)}
+                _G.fiber.yield()
+                s:replace{0}
+            end)
+        end)
+        f2:set_joinable(true)
+
+        _G.fiber.yield()
+
+        s:replace{0}
+
+        local msg = "Transaction has been aborted by conflict"
+
+        local ok, err = f1:join()
+        t.assert_not(ok)
+        t.assert_equals(err.message, msg)
+
+        ok, err = f2:join()
+        t.assert_not(ok)
+        t.assert_equals(err.message, msg)
+    end)
+end
+
+g.before_test('test_collation', function(cg)
+    cg.server:exec(function()
+        box.space.s:create_index('s', {parts = {1, 'str',
+                                                collation = 'unicode_ci'}})
+    end)
+end)
+
+g.test_collation = function(cg)
+    cg.server:exec(function()
+        local s = box.space.s
+
+        local f1 = _G.fiber.new(function()
+            box.atomic(function()
+                s:get{'a'}
+                _G.fiber.yield()
+                s:replace{'a'}
+            end)
+        end)
+        f1:set_joinable(true)
+
+        local f2 = _G.fiber.new(function()
+            box.atomic(function()
+                s:get{'A'}
+                _G.fiber.yield()
+                s:replace{'a'}
+            end)
+        end)
+        f2:set_joinable(true)
+
+        _G.fiber.yield()
+
+        s:replace{'a'}
+
+        local msg = "Transaction has been aborted by conflict"
+
+        local ok, err = f1:join()
+        t.assert_not(ok)
+        t.assert_equals(err.message, msg)
+
+        ok, err = f2:join()
+        t.assert_not(ok)
+        t.assert_equals(err.message, msg)
+    end)
+end

--- a/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
+++ b/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
@@ -14,7 +14,7 @@ local SIZE_OF_TUPLE = 9
 local SIZE_OF_XROW = 163
 -- Tracker can allocate additional memory, be careful!
 local SIZE_OF_READ_TRACKER = 48
-local SIZE_OF_POINT_TRACKER = 88
+local SIZE_OF_POINT_TRACKER = 80
 local SIZE_OF_INPLACE_GAP_TRACKER = 48
 local SIZE_OF_NEARBY_GAP_TRACKER = 88
 


### PR DESCRIPTION
This patchset fixes the incorrect assumption that point hole equivalence classes are defined by
their keys' binary (MsgPack) representation.

Closes #10159
Closes #11292