### PR TITLE
memtx: handle OOM on statement rollback

### DIFF
--- a/changelogs/unreleased/gh-11171-fix-crash-on-oom-statement-rollback.md
+++ b/changelogs/unreleased/gh-11171-fix-crash-on-oom-statement-rollback.md
@@ -1,0 +1,3 @@
+## bugfix/memtx
+
+* Fixed crash/panic due to OOM conditions (gh-11171).

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -1217,6 +1217,27 @@ index_read_view_create_arrow_stream(
 					     stream);
 }
 
+#ifndef NDEBUG
+
+/**
+ * After `ERRINJ_INDEX_OOM_COUNTDOWN' countdown start to fail
+ * unless txn flag `TXN_STMT_ROLLBACK' is set or txn is aborted.
+ *
+ * Return 0 on no OOM injection and -1 otherwise.
+ */
+int
+index_inject_oom(void);
+
+#else
+
+static inline int
+index_inject_oom(void)
+{
+	return 0;
+}
+
+#endif /** ifndef NDEBUG */
+
 /*
  * Virtual method stubs.
  */

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -2148,7 +2148,7 @@ memtx_index_extent_alloc(struct matras_allocator *matras_allocator)
 		goto fail;
 	return ret;
 fail:
-	if (in_txn() != NULL && in_txn()->status == TXN_ABORTED) {
+	if (in_txn() != NULL && txn_has_flag(in_txn(), TXN_STMT_ROLLBACK)) {
 		/*
 		 * We cannot sanely reserve blocks for rollback because strictly
 		 * speaking the whole index can change. We cannot tolerate

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -343,45 +343,125 @@ memtx_hash_index_get_internal(struct index *base, const char *key,
 	return 0;
 }
 
+/**
+ * If key is present then replace it's tuple with `new_tuple'. Otherwise
+ * insert `new_tuple'. In case of replace old tuple is returned in `dup_tuple'.
+ * Insert or replace position is returned in `pos'.
+ *
+ * Also adds OOM injection and setting txn flag `TXN_STMT_ROLLBACK'.
+ *
+ * Returns 0 on success and -1 on OOM (diag is set).
+ */
+static int
+memtx_hash_index_replace_impl(struct memtx_hash_index *index,
+			      struct tuple *new_tuple, struct tuple **dup_tuple,
+			      uint32_t *pos)
+{
+	uint32_t h = tuple_hash(new_tuple, index->base.def->key_def);
+	if (index_inject_oom() != 0)
+		goto fail;
+	*pos = light_index_replace(&index->hash_table, h, new_tuple,
+				   dup_tuple);
+	if (*pos == light_index_end) {
+		if (index_inject_oom() != 0)
+			goto fail;
+		*pos = light_index_insert(&index->hash_table, h, new_tuple);
+		if (*pos == light_index_end)
+			goto fail;
+		*dup_tuple = NULL;
+	}
+	return 0;
+fail:
+	txn_set_flags(in_txn(), TXN_STMT_ROLLBACK);
+	return -1;
+}
+
+/**
+ * Similar to light_index_insert but returns status and not position.
+ *
+ * Also adds OOM injection and setting txn flag `TXN_STMT_ROLLBACK' on OOM
+ * to `light_index_insert'.
+ *
+ * Returns 0 on success and -1 on OOM (diag is set).
+ */
+static int
+memtx_hash_index_insert_impl(struct memtx_hash_index *index,
+			     struct tuple *new_tuple)
+{
+	uint32_t h = tuple_hash(new_tuple, index->base.def->key_def);
+	if (index_inject_oom() != 0)
+		goto fail;
+	if (light_index_insert(&index->hash_table,
+			       h, new_tuple) == light_index_end)
+		goto fail;
+	return 0;
+fail:
+	txn_set_flags(in_txn(), TXN_STMT_ROLLBACK);
+	return -1;
+}
+
+/**
+ * Adds OOM injection and setting txn flag `TXN_STMT_ROLLBACK' on OOM
+ * to `light_index_delete'.
+ *
+ * Returns 0 on success and -1 on OOM (diag is set).
+ */
+static int
+memtx_hash_index_delete_impl(struct memtx_hash_index *index, uint32_t pos)
+{
+	if (index_inject_oom() != 0)
+		goto fail;
+	if (light_index_delete(&index->hash_table, pos) != 0)
+		goto fail;
+	return 0;
+fail:
+	txn_set_flags(in_txn(), TXN_STMT_ROLLBACK);
+	return -1;
+}
+
+/**
+ * Adds OOM injection and setting txn flag `TXN_STMT_ROLLBACK' on OOM
+ * to `light_index_delete_value'.
+ *
+ * Returns 0 on success and -1 on OOM (diag is set).
+ */
+static int
+memtx_hash_index_delete_value_impl(struct memtx_hash_index *index,
+				   struct tuple *tuple)
+{
+	uint32_t h = tuple_hash(tuple, index->base.def->key_def);
+	if (index_inject_oom() != 0)
+		goto fail;
+	if (light_index_delete_value(&index->hash_table, h, tuple) != 0)
+		goto fail;
+	return 0;
+fail:
+	txn_set_flags(in_txn(), TXN_STMT_ROLLBACK);
+	return -1;
+}
+
 static int
 memtx_hash_index_replace(struct index *base, struct tuple *old_tuple,
 			 struct tuple *new_tuple, enum dup_replace_mode mode,
 			 struct tuple **result, struct tuple **successor)
 {
 	struct memtx_hash_index *index = (struct memtx_hash_index *)base;
-	struct light_index_core *hash_table = &index->hash_table;
 
 	/* HASH index doesn't support ordering. */
 	*successor = NULL;
 
-	if (new_tuple) {
-		uint32_t h = tuple_hash(new_tuple, base->def->key_def);
-		struct tuple *dup_tuple = NULL;
-		uint32_t pos = light_index_replace(hash_table, h, new_tuple,
-						   &dup_tuple);
-		if (pos == light_index_end)
-			pos = light_index_insert(hash_table, h, new_tuple);
-
-		ERROR_INJECT(ERRINJ_HASH_INDEX_REPLACE, {
-			light_index_delete(hash_table, pos);
-			pos = light_index_end;
-		});
-
-		if (pos == light_index_end) {
-			diag_set(OutOfMemory, MEMTX_EXTENT_SIZE,
-				 "hash_table", "key");
+	if (new_tuple != NULL) {
+		struct tuple *dup_tuple;
+		uint32_t pos;
+		if (memtx_hash_index_replace_impl(
+				index, new_tuple, &dup_tuple, &pos) != 0)
 			return -1;
-		}
 		if (index_check_dup(base, old_tuple, new_tuple,
 				    dup_tuple, mode) != 0) {
-			light_index_delete(hash_table, pos);
-			if (dup_tuple) {
-				uint32_t pos = light_index_insert(hash_table, h, dup_tuple);
-				if (pos == light_index_end) {
-					panic("Failed to allocate memory in "
-					      "recover of int hash_table");
-				}
-			}
+			VERIFY(memtx_hash_index_delete_impl(index, pos) == 0);
+			if (dup_tuple)
+				VERIFY(memtx_hash_index_insert_impl(
+						index, dup_tuple) == 0);
 			return -1;
 		}
 
@@ -391,10 +471,13 @@ memtx_hash_index_replace(struct index *base, struct tuple *old_tuple,
 		}
 	}
 
-	if (old_tuple) {
-		uint32_t h = tuple_hash(old_tuple, base->def->key_def);
-		int res = light_index_delete_value(hash_table, h, old_tuple);
-		assert(res == 0); (void) res;
+	if (old_tuple != NULL) {
+		if (memtx_hash_index_delete_value_impl(index, old_tuple) != 0) {
+			if (new_tuple != NULL)
+				VERIFY(memtx_hash_index_delete_value_impl(
+						index, new_tuple) == 0);
+			return -1;
+		}
 	}
 	*result = old_tuple;
 	return 0;

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -1433,6 +1433,67 @@ tree_iterator_position_func(struct iterator *it, const char **pos,
 						pos, size);
 }
 
+/**
+ * Adds OOM injection and setting txn flag `TXN_STMT_ROLLBACK' on OOM
+ * to `memtx_tree_insert'.
+ */
+template<bool USE_HINT>
+static int
+memtx_tree_index_insert_impl(struct memtx_tree_index<USE_HINT> *index,
+			     struct memtx_tree_data<USE_HINT> new_data,
+			     struct memtx_tree_data<USE_HINT> *dup_data,
+			     struct memtx_tree_data<USE_HINT> *suc_data)
+{
+	if (index_inject_oom() != 0)
+		goto fail;
+	if (memtx_tree_insert(&index->tree, new_data, dup_data, suc_data) != 0)
+		goto fail;
+	return 0;
+fail:
+	txn_set_flags(in_txn(), TXN_STMT_ROLLBACK);
+	return -1;
+}
+
+/**
+ * Adds OOM injection and setting txn flag `TXN_STMT_ROLLBACK' on OOM
+ * to `memtx_tree_delete'.
+ */
+template<bool USE_HINT>
+static int
+memtx_tree_index_delete_impl(struct memtx_tree_index<USE_HINT> *index,
+			     struct memtx_tree_data<USE_HINT> elem_data,
+			     struct memtx_tree_data<USE_HINT> *del_data)
+{
+	if (index_inject_oom() != 0)
+		goto fail;
+	if (memtx_tree_delete(&index->tree, elem_data, del_data) != 0)
+		goto fail;
+	return 0;
+fail:
+	txn_set_flags(in_txn(), TXN_STMT_ROLLBACK);
+	return -1;
+}
+
+/**
+ * Adds OOM injection and setting txn flag `TXN_STMT_ROLLBACK' on OOM
+ * to `memtx_tree_delete_value'.
+ */
+template<bool USE_HINT>
+static int
+memtx_tree_index_delete_value_impl(struct memtx_tree_index<USE_HINT> *index,
+				   struct memtx_tree_data<USE_HINT> elem_data,
+				   struct memtx_tree_data<USE_HINT> *del_data)
+{
+	if (index_inject_oom() != 0)
+		goto fail;
+	if (memtx_tree_delete_value(&index->tree, elem_data, del_data) != 0)
+		goto fail;
+	return 0;
+fail:
+	txn_set_flags(in_txn(), TXN_STMT_ROLLBACK);
+	return -1;
+}
+
 template <bool USE_HINT>
 static int
 memtx_tree_index_replace(struct index *base, struct tuple *old_tuple,
@@ -1453,19 +1514,18 @@ memtx_tree_index_replace(struct index *base, struct tuple *old_tuple,
 		dup_data.tuple = suc_data.tuple = NULL;
 
 		/* Try to optimistically replace the new_tuple. */
-		int tree_res = memtx_tree_insert(&index->tree, new_data,
-						 &dup_data, &suc_data);
-		if (tree_res) {
-			diag_set(OutOfMemory, MEMTX_EXTENT_SIZE,
-				 "memtx_tree_index", "replace");
+		if (memtx_tree_index_insert_impl(index, new_data, &dup_data,
+						 &suc_data) != 0)
 			return -1;
-		}
 
 		if (index_check_dup(base, old_tuple, new_tuple,
 				    dup_data.tuple, mode) != 0) {
-			memtx_tree_delete(&index->tree, new_data, NULL);
+			VERIFY(memtx_tree_index_delete_impl<USE_HINT>(
+						index, new_data, NULL) == 0);
 			if (dup_data.tuple != NULL)
-				memtx_tree_insert(&index->tree, dup_data, NULL, NULL);
+				VERIFY(memtx_tree_index_insert_impl<USE_HINT>(
+						index, dup_data, NULL,
+						NULL) == 0);
 			return -1;
 		}
 		*successor = suc_data.tuple;
@@ -1480,7 +1540,21 @@ memtx_tree_index_replace(struct index *base, struct tuple *old_tuple,
 		old_data.tuple = old_tuple;
 		if (USE_HINT)
 			old_data.set_hint(tuple_hint(old_tuple, cmp_def));
-		memtx_tree_delete(&index->tree, old_data, NULL);
+		if (memtx_tree_index_delete_impl<USE_HINT>(
+					index, old_data, NULL) != 0) {
+			if (new_tuple != NULL &&
+			    !tuple_key_is_excluded(new_tuple, key_def,
+						   MULTIKEY_NONE)) {
+				struct memtx_tree_data<USE_HINT> new_data;
+				new_data.tuple = new_tuple;
+				if (USE_HINT)
+					new_data.set_hint(tuple_hint(new_tuple,
+								     cmp_def));
+				VERIFY(memtx_tree_index_delete_impl<USE_HINT>(
+						index, new_data, NULL) == 0);
+			}
+			return -1;
+		}
 		*result = old_tuple;
 	} else {
 		*result = NULL;
@@ -1506,12 +1580,9 @@ memtx_tree_index_replace_multikey_one(struct memtx_tree_index<true> *index,
 	new_data.hint = hint;
 	dup_data.tuple = NULL;
 	*is_multikey_conflict = false;
-	if (memtx_tree_insert(&index->tree, new_data, &dup_data,
-			      successor_data) != 0) {
-		diag_set(OutOfMemory, MEMTX_EXTENT_SIZE, "memtx_tree_index",
-			 "replace");
+	if (memtx_tree_index_insert_impl(index, new_data, &dup_data,
+					 successor_data) != 0)
 		return -1;
-	}
 	if (dup_data.tuple == new_tuple) {
 		/*
 		 * When tuple contains the same key multiple
@@ -1522,9 +1593,11 @@ memtx_tree_index_replace_multikey_one(struct memtx_tree_index<true> *index,
 	} else if (index_check_dup(&index->base, old_tuple, new_tuple,
 				   dup_data.tuple, mode) != 0) {
 		/* Rollback replace. */
-		memtx_tree_delete(&index->tree, new_data, NULL);
+		VERIFY(memtx_tree_index_delete_impl<true>(
+				index, new_data, NULL) == 0);
 		if (dup_data.tuple != NULL)
-			memtx_tree_insert(&index->tree, dup_data, NULL, NULL);
+			VERIFY(memtx_tree_index_insert_impl<true>(
+					index, dup_data, NULL, NULL) == 0);
 		return -1;
 	}
 	*replaced_data = dup_data;
@@ -1559,9 +1632,12 @@ memtx_tree_index_replace_multikey_rollback(struct memtx_tree_index<true> *index,
 			if (tuple_key_is_excluded(replaced_tuple, key_def, i))
 				continue;
 			data.hint = i;
-			memtx_tree_insert(&index->tree, data, NULL, NULL);
+			VERIFY(memtx_tree_index_insert_impl<true>(
+					index, data, NULL, NULL) == 0);
 		}
 	}
+	if (new_tuple == NULL)
+		return;
 	/*
 	 * Rollback new_tuple insertion by multikey index
 	 * [0, multikey_idx).
@@ -1571,7 +1647,8 @@ memtx_tree_index_replace_multikey_rollback(struct memtx_tree_index<true> *index,
 		if (tuple_key_is_excluded(new_tuple, key_def, i))
 			continue;
 		data.hint = i;
-		memtx_tree_delete_value(&index->tree, data, NULL);
+		VERIFY(memtx_tree_index_delete_value_impl<true>(
+					index, data, NULL) == 0);
 	}
 }
 
@@ -1678,7 +1755,18 @@ memtx_tree_index_replace_multikey(struct index *base, struct tuple *old_tuple,
 			if (tuple_key_is_excluded(old_tuple, key_def, i))
 				continue;
 			data.hint = i;
-			memtx_tree_delete_value(&index->tree, data, NULL);
+			if (memtx_tree_index_delete_value_impl<true>(
+					index, data, NULL) != 0) {
+				uint32_t multikey_count = 0;
+				if (new_tuple != 0)
+					multikey_count =
+						tuple_multikey_count(new_tuple,
+								     cmp_def);
+				memtx_tree_index_replace_multikey_rollback(
+					index, new_tuple, old_tuple,
+					multikey_count);
+				return -1;
+			}
 		}
 	}
 	return 0;
@@ -1697,20 +1785,6 @@ struct func_key_undo {
 	struct memtx_tree_data<true> key;
 };
 
-/** Allocate a new func_key_undo on given region. */
-struct func_key_undo *
-func_key_undo_new(struct region *region)
-{
-	size_t size;
-	struct func_key_undo *undo = region_alloc_object(region, typeof(*undo),
-							 &size);
-	if (undo == NULL) {
-		diag_set(OutOfMemory, size, "region_alloc_object", "undo");
-		return NULL;
-	}
-	return undo;
-}
-
 /**
  * Rollback a sequence of memtx_tree_index_replace_multikey_one
  * insertions for functional index. Routine uses given list to
@@ -1723,11 +1797,13 @@ memtx_tree_func_index_replace_rollback(struct memtx_tree_index<true> *index,
 {
 	struct func_key_undo *entry;
 	rlist_foreach_entry(entry, new_keys, link) {
-		memtx_tree_delete_value(&index->tree, entry->key, NULL);
+		VERIFY(memtx_tree_index_delete_value_impl<true>(
+					index, entry->key, NULL) == 0);
 		tuple_unref((struct tuple *)entry->key.hint);
 	}
 	rlist_foreach_entry(entry, old_keys, link)
-		memtx_tree_insert(&index->tree, entry->key, NULL, NULL);
+		VERIFY(memtx_tree_index_insert_impl<true>(
+				index, entry->key, NULL, NULL) == 0);
 }
 
 /**
@@ -1764,10 +1840,10 @@ memtx_tree_func_index_replace(struct index *base, struct tuple *old_tuple,
 
 	*result = NULL;
 	struct key_list_iterator it;
+	struct rlist old_keys, new_keys;
+	rlist_create(&old_keys);
+	rlist_create(&new_keys);
 	if (new_tuple != NULL) {
-		struct rlist old_keys, new_keys;
-		rlist_create(&old_keys);
-		rlist_create(&new_keys);
 		if (key_list_iterator_create(&it, new_tuple, index_def, true,
 					     memtx->func_key_format) != 0)
 			goto end;
@@ -1782,11 +1858,7 @@ memtx_tree_func_index_replace(struct index *base, struct tuple *old_tuple,
 			if (tuple_key_is_excluded(key, key_def, MULTIKEY_NONE))
 				continue;
 			/* Perform insertion, log it in list. */
-			undo = func_key_undo_new(region);
-			if (undo == NULL) {
-				err = -1;
-				break;
-			}
+			undo = xregion_alloc_object(region, typeof(*undo));
 			tuple_ref(key);
 			undo->key.tuple = new_tuple;
 			undo->key.hint = (hint_t)key;
@@ -1805,19 +1877,8 @@ memtx_tree_func_index_replace(struct index *base, struct tuple *old_tuple,
 			if (!it.func_is_multikey)
 				*successor = successor_data.tuple;
 			if (old_data.tuple != NULL && !is_multikey_conflict) {
-				undo = func_key_undo_new(region);
-				if (undo == NULL) {
-					/*
-					 * Can't append this
-					 * operation in rollback
-					 * journal. Roll it back
-					 * manually.
-					 */
-					memtx_tree_insert(&index->tree,
-							  old_data, NULL, NULL);
-					err = -1;
-					break;
-				}
+				undo = xregion_alloc_object(region,
+							    typeof(*undo));
 				undo->key = old_data;
 				rlist_add(&old_keys, &undo->link);
 				*result = old_data.tuple;
@@ -1845,13 +1906,6 @@ memtx_tree_func_index_replace(struct index *base, struct tuple *old_tuple,
 			assert(old_tuple == NULL || old_tuple == *result);
 			old_tuple = *result;
 		}
-		/*
-		 * Commit changes: release hints for
-		 * replaced entries.
-		 */
-		rlist_foreach_entry(undo, &old_keys, link) {
-			tuple_unref((struct tuple *)undo->key.hint);
-		}
 	}
 	if (old_tuple != NULL) {
 		/*
@@ -1868,19 +1922,30 @@ memtx_tree_func_index_replace(struct index *base, struct tuple *old_tuple,
 		while (key_list_iterator_next(&it, &key) == 0 && key != NULL) {
 			data.hint = (hint_t) key;
 			deleted_data.tuple = NULL;
-			memtx_tree_delete_value(&index->tree, data,
-						&deleted_data);
+			if (memtx_tree_index_delete_value_impl(
+					index, data, &deleted_data) != 0) {
+				memtx_tree_func_index_replace_rollback(
+					index, &old_keys, &new_keys);
+				return -1;
+			}
 			if (deleted_data.tuple != NULL) {
-				/*
-				 * Release related hint and set result on
-				 * successful node deletion.
-				 */
-				tuple_unref((struct tuple *)deleted_data.hint);
 				*result = old_tuple;
+				struct func_key_undo *undo =
+					xregion_alloc_object(region,
+							     typeof(*undo));
+				undo->key = deleted_data;
+				rlist_add(&old_keys, &undo->link);
 			}
 		}
 		assert(key == NULL);
 	}
+	/*
+	 * Commit changes: release hints for
+	 * replaced entries.
+	 */
+	struct func_key_undo *undo;
+	rlist_foreach_entry(undo, &old_keys, link)
+		tuple_unref((struct tuple *)undo->key.hint);
 	rc = 0;
 end:
 	region_truncate(region, region_svp);

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -119,6 +119,14 @@ enum txn_flag {
 	TXN_IS_STARTED_IN_ENGINE = 0x400,
 	/** Transaction supports multiversion concurrency control. */
 	TXN_SUPPORTS_MVCC = 0x800,
+	/**
+	 * Set during statement rollback.
+	 *
+	 * If statetement is rolled back we should not fail due to OOM.
+	 * This flag is set when statement rollback is started. If it is set
+	 * then memory allocated even if memory limit is reached.
+	 */
+	TXN_STMT_ROLLBACK = 0x1000,
 };
 
 enum {

--- a/src/lib/core/errinj.h
+++ b/src/lib/core/errinj.h
@@ -96,9 +96,10 @@ struct errinj {
 	_(ERRINJ_HTTPC_EXECUTE, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_HTTP_RESPONSE_ADD_WAIT, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_INDEX_ALLOC, ERRINJ_BOOL, {.bparam = false}) \
+	_(ERRINJ_INDEX_OOM, ERRINJ_BOOL, {.bparam = false}) \
+	_(ERRINJ_INDEX_OOM_COUNTDOWN, ERRINJ_INT, {.iparam = -1}) \
 	_(ERRINJ_INDEX_RESERVE, ERRINJ_BOOL, {.bparam = false})\
 	_(ERRINJ_INDEX_ITERATOR_NEW, ERRINJ_BOOL, {.bparam = false}) \
-	_(ERRINJ_HASH_INDEX_REPLACE, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_IPROTO_CFG_LISTEN, ERRINJ_INT, {.iparam = 0}) \
 	_(ERRINJ_IPROTO_DISABLE_ID, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_IPROTO_DISABLE_WATCH, ERRINJ_BOOL, {.bparam = false}) \

--- a/test/box-luatest/memtx_oom_test.lua
+++ b/test/box-luatest/memtx_oom_test.lua
@@ -1,0 +1,595 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group()
+
+local after_each = function(cg)
+    cg.server:exec(function()
+        local errinj = box.error.injection
+        errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', -1)
+        errinj.set('ERRINJ_INDEX_OOM', false)
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end)
+end
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new()
+    cg.server:start()
+    cg.server:exec(function()
+        rawset(_G, 'assert_equals_sorted', function(actual, expected)
+            table.sort(actual, function(a, b) return a[1] < b[1] end)
+            t.assert_equals(actual, expected)
+        end)
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(after_each)
+
+------------------
+-- Txn code tests.
+------------------
+
+g.test_stmt_rollback_flag_cleared = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('test')
+        local errinj = box.error.injection
+        s:create_index('pk')
+        s:insert({1, 10})
+        box.begin()
+        s:insert({2, 20})
+        errinj.set('ERRINJ_INDEX_OOM', true)
+        t.assert_error_covers({
+            type = 'OutOfMemory',
+        }, s.insert, s, {3, 30})
+        t.assert_error_covers({
+            type = 'OutOfMemory',
+        }, s.insert, s, {4, 40})
+        box.commit()
+        t.assert_equals(s:select(), {{1, 10}, {2, 20}})
+    end)
+end
+
+--------------------
+-- Tree index tests.
+--------------------
+
+g.test_rollback_tree_insert_oom = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('test')
+        local errinj = box.error.injection
+        for c = 1, 20 do
+            s:create_index('pk')
+            s:create_index('sk1')
+            s:create_index('sk2')
+            s:insert({1, 10})
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', c)
+            local ok, err = pcall(s.insert, s, {2, 20})
+            if ok then
+                local expected = {{1, 10}, {2, 20}}
+                t.assert_equals(s:select(), expected)
+                t.assert_equals(s.index.sk1:select(), expected)
+                t.assert_equals(s.index.sk2:select(), expected)
+            else
+                t.assert_equals(err:unpack().type, 'OutOfMemory')
+                local expected = {{1, 10}}
+                t.assert_equals(s:select(), expected)
+                t.assert_equals(s.index.sk1:select(), expected)
+                t.assert_equals(s.index.sk2:select(), expected)
+            end
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', -1)
+            errinj.set('ERRINJ_INDEX_OOM', false)
+            s.index.sk2:drop()
+            s.index.sk1:drop()
+            s.index.pk:drop()
+        end
+    end)
+end
+
+g.test_rollback_tree_delete_oom = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('test')
+        local errinj = box.error.injection
+        for c = 1, 20 do
+            s:create_index('pk')
+            s:create_index('sk1')
+            s:create_index('sk2')
+            s:insert({1, 10})
+            s:insert({2, 20})
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', c)
+            local ok, err = pcall(s.delete, s, {2})
+            if ok then
+                local expected = {{1, 10}}
+                t.assert_equals(s:select(), expected)
+                t.assert_equals(s.index.sk1:select(), expected)
+                t.assert_equals(s.index.sk2:select(), expected)
+            else
+                t.assert_equals(err:unpack().type, 'OutOfMemory')
+                local expected = {{1, 10}, {2, 20}}
+                t.assert_equals(s:select(), expected)
+                t.assert_equals(s.index.sk1:select(), expected)
+                t.assert_equals(s.index.sk2:select(), expected)
+            end
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', -1)
+            errinj.set('ERRINJ_INDEX_OOM', false)
+            s.index.sk1:drop()
+            s.index.sk2:drop()
+            s.index.pk:drop()
+        end
+    end)
+end
+
+g.test_rollback_tree_replace_oom = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('test')
+        local errinj = box.error.injection
+        for c = 1, 20 do
+            s:create_index('pk')
+            s:create_index('sk1', {parts = {2}})
+            s:create_index('sk2', {parts = {2}})
+            s:insert({1, 10})
+            s:insert({2, 20})
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', c)
+            local ok, err = pcall(s.replace, s, {2, 200})
+            if ok then
+                local expected = {{1, 10}, {2, 200}}
+                t.assert_equals(s:select(), expected)
+                t.assert_equals(s.index.sk1:select(), expected)
+                t.assert_equals(s.index.sk2:select(), expected)
+            else
+                t.assert_equals(err:unpack().type, 'OutOfMemory')
+                local expected = {{1, 10}, {2, 20}}
+                t.assert_equals(s:select(), expected)
+                t.assert_equals(s.index.sk1:select(), expected)
+                t.assert_equals(s.index.sk2:select(), expected)
+            end
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', -1)
+            errinj.set('ERRINJ_INDEX_OOM', false)
+            s.index.sk1:drop()
+            s.index.sk2:drop()
+            s.index.pk:drop()
+        end
+    end)
+end
+
+g.test_rollback_tree_insert_dup = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('test')
+        local errinj = box.error.injection
+        for c = 1, 10 do
+            s:create_index('pk')
+            s:create_index('sk', {parts = {2}})
+            s:insert({1, 10})
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', c)
+            local ok, err = pcall(s.insert, s, {2, 10})
+            t.assert_not(ok)
+            local u = err:unpack()
+            t.assert(u.type == 'OutOfMemory' or
+                     (u.type == 'ClientError' and
+                      u.code == box.error.TUPLE_FOUND), u)
+            t.assert_equals(s.index.pk:select(), {{1, 10}})
+            t.assert_equals(s.index.sk:select(), {{1, 10}})
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', -1)
+            errinj.set('ERRINJ_INDEX_OOM', false)
+            s.index.sk:drop()
+            s.index.pk:drop()
+        end
+    end)
+end
+
+g.test_rollback_tree_update_pk = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('test')
+        local errinj = box.error.injection
+        for c = 1, 20 do
+            s:create_index('pk')
+            s:insert({1, 10})
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', c)
+            local ok, err = pcall(s.update, s, {1}, {{'=', 1, 2}})
+            t.assert_not(ok)
+            local u = err:unpack()
+            t.assert(u.type == 'OutOfMemory' or
+                     (u.type == 'ClientError' and
+                      u.code == box.error.CANT_UPDATE_PRIMARY_KEY), u)
+            t.assert_equals(s:select(), {{1, 10}})
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', -1)
+            errinj.set('ERRINJ_INDEX_OOM', false)
+            s.index.pk:drop()
+        end
+    end)
+end
+
+--------------------
+-- Hash index tests.
+--------------------
+
+g.test_rollback_hash_insert_oom = function(cg)
+    cg.server:exec(function()
+        local errinj = box.error.injection
+        local assert_equals_sorted = _G.assert_equals_sorted
+        local s = box.schema.create_space('test')
+        for c = 1, 20 do
+            s:create_index('pk')
+            s:create_index('sk1', {type = 'HASH', parts = {2}})
+            s:create_index('sk2', {type = 'HASH', parts = {2}})
+            s:insert({1, 10})
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', c)
+            local ok, err = pcall(s.insert, s, {2, 20})
+            if ok then
+                local expected = {{1, 10}, {2, 20}}
+                assert_equals_sorted(s.index.pk:select(), expected)
+                assert_equals_sorted(s.index.sk1:select(), expected)
+                assert_equals_sorted(s.index.sk2:select(), expected)
+            else
+                t.assert_equals(err:unpack().type, 'OutOfMemory')
+                local expected = {{1, 10}}
+                t.assert_equals(s.index.pk:select(), expected)
+                t.assert_equals(s.index.sk1:select(), expected)
+                t.assert_equals(s.index.sk2:select(), expected)
+            end
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', -1)
+            errinj.set('ERRINJ_INDEX_OOM', false)
+            s.index.sk1:drop()
+            s.index.sk2:drop()
+            s.index.pk:drop()
+        end
+    end)
+end
+
+g.test_rollback_hash_delete_oom = function(cg)
+    cg.server:exec(function()
+        local errinj = box.error.injection
+        local assert_equals_sorted = _G.assert_equals_sorted
+        local s = box.schema.create_space('test')
+        for c = 1, 20 do
+            s:create_index('pk')
+            s:create_index('sk1', {type = 'HASH', parts = {2}})
+            s:create_index('sk2', {type = 'HASH', parts = {2}})
+            s:insert({1, 10})
+            s:insert({2, 20})
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', c)
+            local ok, err = pcall(s.delete, s, {2})
+            if ok then
+                local expected = {{1, 10}}
+                t.assert_equals(s.index.pk:select(), expected)
+                t.assert_equals(s.index.sk1:select(), expected)
+                t.assert_equals(s.index.sk2:select(), expected)
+            else
+                t.assert_equals(err:unpack().type, 'OutOfMemory')
+                local expected = {{1, 10}, {2, 20}}
+                assert_equals_sorted(s.index.pk:select(), expected)
+                assert_equals_sorted(s.index.sk1:select(), expected)
+                assert_equals_sorted(s.index.sk2:select(), expected)
+            end
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', -1)
+            errinj.set('ERRINJ_INDEX_OOM', false)
+            s.index.sk1:drop()
+            s.index.sk2:drop()
+            s.index.pk:drop()
+        end
+    end)
+end
+
+g.test_rollback_hash_replace_oom = function(cg)
+    cg.server:exec(function()
+        local errinj = box.error.injection
+        local assert_equals_sorted = _G.assert_equals_sorted
+        local s = box.schema.create_space('test')
+        for c = 1, 20 do
+            s:create_index('pk')
+            s:create_index('sk1', {type = 'HASH', parts = {2}})
+            s:create_index('sk2', {type = 'HASH', parts = {2}})
+            s:insert({1, 10})
+            s:insert({2, 20})
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', c)
+            local ok, err = pcall(s.replace, s, {2, 21})
+            if ok then
+                local expected = {{1, 10}, {2, 21}}
+                assert_equals_sorted(s.index.pk:select(), expected)
+                assert_equals_sorted(s.index.sk1:select(), expected)
+                assert_equals_sorted(s.index.sk2:select(), expected)
+            else
+                t.assert_equals(err:unpack().type, 'OutOfMemory')
+                local expected = {{1, 10}, {2, 20}}
+                assert_equals_sorted(s.index.pk:select(), expected)
+                assert_equals_sorted(s.index.sk1:select(), expected)
+                assert_equals_sorted(s.index.sk2:select(), expected)
+            end
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', -1)
+            errinj.set('ERRINJ_INDEX_OOM', false)
+            s.index.sk1:drop()
+            s.index.sk2:drop()
+            s.index.pk:drop()
+        end
+    end)
+end
+
+g.test_rollback_hash_insert_dup = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('test')
+        local errinj = box.error.injection
+        for c = 1, 20 do
+            s:create_index('pk')
+            s:create_index('sk1', {type = 'HASH', parts = {2}})
+            s:create_index('sk2', {type = 'HASH', parts = {2}})
+            s:insert({1, 10})
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', c)
+            local ok, err = pcall(s.insert, s, {2, 10})
+            t.assert_not(ok)
+            local u = err:unpack()
+            t.assert(u.type == 'OutOfMemory' or
+                     (u.type == 'ClientError' and
+                      u.code == box.error.TUPLE_FOUND), u)
+            t.assert_equals(s.index.pk:select(), {{1, 10}})
+            t.assert_equals(s.index.sk1:select(), {{1, 10}})
+            t.assert_equals(s.index.sk2:select(), {{1, 10}})
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', -1)
+            errinj.set('ERRINJ_INDEX_OOM', false)
+            s.index.sk1:drop()
+            s.index.sk2:drop()
+            s.index.pk:drop()
+        end
+    end)
+end
+
+g.test_rollback_hash_update_pk = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('test')
+        local errinj = box.error.injection
+        for c = 1, 20 do
+            s:create_index('pk', {type = 'HASH'})
+            s:insert({1, 10})
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', c)
+            local ok, err = pcall(s.update, s, {1}, {{'=', 1, 2}})
+            t.assert_not(ok)
+            local u = err:unpack()
+            t.assert(u.type == 'OutOfMemory' or
+                     (u.type == 'ClientError' and
+                      u.code == box.error.CANT_UPDATE_PRIMARY_KEY), u)
+            t.assert_equals(s:select(), {{1, 10}})
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', -1)
+            errinj.set('ERRINJ_INDEX_OOM', false)
+            s.index.pk:drop()
+        end
+    end)
+end
+
+-- gh-1117
+g.test_rollback_trigger_failure = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('test')
+        s:format({
+            {name = 'a', type = 'unsigned'},
+            {name = 'b', 'unsigned', is_nullable = true}
+        })
+        s:create_index('pk', {type = 'HASH'})
+        s:insert({1, 10})
+        s:insert({2, box.NULL})
+        local errinj = box.error.injection
+        for c = 1, 20 do
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', c)
+            local ok, err = pcall(s.format, s, {
+                {name = 'a', type = 'unsigned'},
+                {name = 'b', type = 'unsigned'}
+            })
+            t.assert_not(ok)
+            local u = err:unpack()
+            t.assert(u.type == 'OutOfMemory' or
+                     (u.type == 'ClientError' and
+                      u.code == box.error.FIELD_TYPE and
+                      u.expected == 'unsigned' and
+                      u.actual == 'nil'), u)
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', -1)
+            errinj.set('ERRINJ_INDEX_OOM', false)
+        end
+    end)
+end
+
+g.test_rollback_to_svp = function(cg)
+    cg.server:exec(function()
+        local errinj = box.error.injection
+        local s = box.schema.create_space('test')
+        for c = 1, 20 do
+            s:create_index('pk')
+            local f = function()
+                box.begin()
+                s:insert({1, 10})
+                local svp = box.savepoint()
+                s:insert({2, 20})
+                box.rollback_to_savepoint(svp)
+                box.commit()
+            end
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', c)
+            local ok, err = pcall(f)
+            if ok then
+                t.assert_equals(s:select(), {{1, 10}})
+            else
+                box.rollback()
+                t.assert_equals(err:unpack().type, 'OutOfMemory')
+                t.assert_equals(s:select(), {})
+            end
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', -1)
+            errinj.set('ERRINJ_INDEX_OOM', false)
+            s.index.pk:drop()
+        end
+    end)
+end
+
+-----------------------------------
+-- Multikey/functional index tests.
+-----------------------------------
+
+local g_mk = t.group('multikey', {
+    {index_options = {parts = {{field = 2, path = '[*]'}}, unique = true}},
+    {index_options = {parts = {{1, 'unsigned'}}, func = 'test'}}
+})
+
+g_mk.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+    cg.server:exec(function()
+    box.schema.func.create('test', {
+        body = [[
+            function(tuple)
+                local keys = {}
+                for _, k in ipairs(tuple[2]) do
+                    table.insert(keys, {k})
+                end
+                return keys
+            end
+        ]],
+        is_deterministic = true,
+        is_sandboxed = true,
+        opts = {is_multikey = true},
+    })
+    end)
+end)
+
+g_mk.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g_mk.after_each(after_each)
+
+g_mk.test_rollback_tree_insert_oom = function(cg)
+    cg.server:exec(function(index_options)
+        local s = box.schema.create_space('test')
+        local errinj = box.error.injection
+        for c = 1, 20 do
+            s:create_index('pk')
+            s:create_index('sk1', index_options)
+            s:create_index('sk2', index_options)
+            s:insert({1, {10}})
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', c)
+            local ok, err = pcall(s.insert, s, {2, {20, 30}})
+            if ok then
+                local expected_pk = {{1, {10}}, {2, {20, 30}}}
+                local expected_sk = {{1, {10}}, {2, {20, 30}}, {2, {20, 30}}}
+                t.assert_equals(s:select(), expected_pk)
+                t.assert_equals(s.index.sk1:select(), expected_sk)
+                t.assert_equals(s.index.sk2:select(), expected_sk)
+            else
+                local expected = {{1, {10}}}
+                t.assert_equals(err:unpack().type, 'OutOfMemory')
+                t.assert_equals(s:select(), expected)
+                t.assert_equals(s.index.sk1:select(), expected)
+                t.assert_equals(s.index.sk2:select(), expected)
+            end
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', -1)
+            errinj.set('ERRINJ_INDEX_OOM', false)
+            s.index.sk1:drop()
+            s.index.sk2:drop()
+            s.index.pk:drop()
+        end
+    end, {cg.params.index_options})
+end
+
+g_mk.test_rollback_tree_delete_oom = function(cg)
+    cg.server:exec(function(index_options)
+        local s = box.schema.create_space('test')
+        local errinj = box.error.injection
+        for c = 1, 100 do
+            s:create_index('pk')
+            s:create_index('sk1', index_options)
+            s:create_index('sk2', index_options)
+            s:insert({1, {10, 11}, 100})
+            s:insert({2, {20, 21}, 200})
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', c)
+            local ok, err = pcall(s.delete, s, {2})
+            if ok then
+                local expected_pk = {{1, {10, 11}, 100}}
+                local expected_sk = {{1, {10, 11}, 100}, {1, {10, 11}, 100}}
+                t.assert_equals(s:select(), expected_pk)
+                t.assert_equals(s.index.sk1:select(), expected_sk)
+                t.assert_equals(s.index.sk2:select(), expected_sk)
+            else
+                local expected_pk = {{1, {10, 11}, 100}, {2, {20, 21}, 200}}
+                local expected_sk = {
+                    {1, {10, 11}, 100}, {1, {10, 11}, 100},
+                    {2, {20, 21}, 200}, {2, {20, 21}, 200},
+                }
+                t.assert_equals(err:unpack().type, 'OutOfMemory')
+                t.assert_equals(s:select(), expected_pk)
+                t.assert_equals(s.index.sk1:select(), expected_sk)
+                t.assert_equals(s.index.sk2:select(), expected_sk)
+            end
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', -1)
+            errinj.set('ERRINJ_INDEX_OOM', false)
+            s.index.sk1:drop()
+            s.index.sk2:drop()
+            s.index.pk:drop()
+        end
+    end, {cg.params.index_options})
+end
+
+g_mk.test_rollback_tree_replace_oom = function(cg)
+    cg.server:exec(function(index_options)
+        local s = box.schema.create_space('test')
+        local errinj = box.error.injection
+        for c = 1, 100 do
+            s:create_index('pk')
+            s:create_index('sk1', index_options)
+            s:create_index('sk2', index_options)
+            s:insert({1, {10, 20, 30}, 100})
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', c)
+            local ok, err = pcall(s.replace, s, {1, {15, 20, 25}, 200})
+            if ok then
+                local expected_pk = {{1, {15, 20, 25}, 200}}
+                local expected_sk = {
+                    {1, {15, 20, 25}, 200}, {1, {15, 20, 25}, 200},
+                    {1, {15, 20, 25}, 200}
+                }
+                t.assert_equals(s:select(), expected_pk)
+                t.assert_equals(s.index.sk1:select(), expected_sk)
+                t.assert_equals(s.index.sk2:select(), expected_sk)
+            else
+                local expected_pk = {{1, {10, 20, 30}, 100}}
+                local expected_sk = {
+                    {1, {10, 20, 30}, 100}, {1, {10, 20, 30}, 100},
+                    {1, {10, 20, 30}, 100}
+                }
+                t.assert_equals(err:unpack().type, 'OutOfMemory')
+                t.assert_equals(s:select(), expected_pk)
+                t.assert_equals(s.index.sk1:select(), expected_sk)
+                t.assert_equals(s.index.sk2:select(), expected_sk)
+            end
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', -1)
+            errinj.set('ERRINJ_INDEX_OOM', false)
+            s.index.sk1:drop()
+            s.index.sk2:drop()
+            s.index.pk:drop()
+        end
+    end, {cg.params.index_options})
+end
+
+g_mk.test_rollback_tree_insert_dup = function(cg)
+    cg.server:exec(function(index_options)
+        local s = box.schema.create_space('test')
+        local errinj = box.error.injection
+        for c = 1, 100 do
+            s:create_index('pk')
+            s:create_index('sk', index_options)
+            s:insert({1, {10}})
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', c)
+            local ok, err = pcall(s.insert, s, {2, {10}})
+            t.assert_not(ok)
+            local u = err:unpack()
+            t.assert(u.type == 'OutOfMemory' or
+                     (u.type == 'ClientError' and
+                      u.code == box.error.TUPLE_FOUND), u)
+            local expected = {{1, {10}}}
+            t.assert_equals(s:select(), expected)
+            t.assert_equals(s.index.sk:select(), expected)
+            errinj.set('ERRINJ_INDEX_OOM_COUNTDOWN', -1)
+            errinj.set('ERRINJ_INDEX_OOM', false)
+            s.index.sk:drop()
+            s.index.pk:drop()
+        end
+    end, {cg.params.index_options})
+end

--- a/test/box/errinj_index.result
+++ b/test/box/errinj_index.result
@@ -93,7 +93,7 @@ res
 ...
 for i = 501,2500 do s:insert{i, i} end
 ---
-- error: Failed to allocate 16384 bytes in memtx_tree_index for replace
+- error: Failed to allocate 16384 bytes in mempool for new slab
 ...
 s:delete{1} -- still can delete, it does not require extents if no read view
 ---
@@ -136,7 +136,7 @@ check_iter_and_size(621)
 ...
 for i = 2501,3500 do s:insert{i, i} end
 ---
-- error: Failed to allocate 16384 bytes in memtx_tree_index for replace
+- error: Failed to allocate 16384 bytes in mempool for new slab
 ...
 s:delete{2} -- still can delete, it does not require extents if no read view
 ---
@@ -322,7 +322,7 @@ res
 ...
 for i = 501,2500 do s:insert{i, i} end
 ---
-- error: Failed to allocate 16384 bytes in hash_table for key
+- error: Failed to allocate 16384 bytes in mempool for new slab
 ...
 s:delete{1} -- still can delete, it does not require extents if no read view
 ---
@@ -362,7 +362,7 @@ check_iter_and_size(1023)
 ...
 for i = 2501,3500 do s:insert{i, i} end
 ---
-- error: Failed to allocate 16384 bytes in hash_table for key
+- error: Failed to allocate 16384 bytes in mempool for new slab
 ...
 s:delete{2} -- still can delete, it does not require extents if no read view
 ---
@@ -391,7 +391,7 @@ res
 ...
 for i = 3501,4500 do s:insert{i, i} end
 ---
-- error: Failed to allocate 16384 bytes in hash_table for key
+- error: Failed to allocate 16384 bytes in mempool for new slab
 ...
 s:delete{3} -- still can delete, it does not require extents if no read view
 ---
@@ -462,15 +462,15 @@ res
   - [5009, 5009]
   - [5010, 5010]
 ...
-errinj.set("ERRINJ_HASH_INDEX_REPLACE", true)
+errinj.set("ERRINJ_INDEX_OOM", true)
 ---
 - ok
 ...
 s:replace{3594, 3594}
 ---
-- error: Failed to allocate 16384 bytes in hash_table for key
+- error: Failed to allocate 0 bytes in errinj for errinj
 ...
-errinj.set("ERRINJ_HASH_INDEX_REPLACE", false)
+errinj.set("ERRINJ_INDEX_OOM", false)
 ---
 - ok
 ...

--- a/test/box/errinj_index.test.lua
+++ b/test/box/errinj_index.test.lua
@@ -118,9 +118,9 @@ res = {}
 for i = 5001,5010 do table.insert(res, (s:get{i})) end
 res
 
-errinj.set("ERRINJ_HASH_INDEX_REPLACE", true)
+errinj.set("ERRINJ_INDEX_OOM", true)
 s:replace{3594, 3594}
-errinj.set("ERRINJ_HASH_INDEX_REPLACE", false)
+errinj.set("ERRINJ_INDEX_OOM", false)
 
 s:drop()
 

--- a/test/fuzz/lua/test_engine.lua
+++ b/test/fuzz/lua/test_engine.lua
@@ -1474,13 +1474,18 @@ local errinj_set = {
         enable = enable_errinj_boolean,
         disable = disable_errinj_boolean,
     },
+    -- Set to number of passes before starting to fail primitive index data
+    -- operations.
+    ERRINJ_INDEX_OOM_COUNTDOWN = {
+        enable = function()
+            return math.random(100)
+        end,
+        disable = function()
+            return -1
+        end,
+    },
     -- Set to true to fail index iterator creation.
     ERRINJ_INDEX_ITERATOR_NEW = {
-        enable = enable_errinj_boolean,
-        disable = disable_errinj_boolean,
-    },
-    -- Set to true to fail insertion into memtx hash index.
-    ERRINJ_HASH_INDEX_REPLACE = {
         enable = enable_errinj_boolean,
         disable = disable_errinj_boolean,
     },


### PR DESCRIPTION
Currently during statement rollback we either assume that rollback does not fail or panic on failure. Unfortunately rollback can fail due to OOM because of opened read view and reservations done for rollback.

Let's handle this situation similar to transaction rollback in [1]. Let's set new transaction flag `TXN_STMT_ROLLBACK` before doing statement rollback and check it when we need to allocate memory in memtx arena. If flag is set and memory exhausted then allocate memory outside the arena.

Handle is added to `HASH` and `TREE `indexes. `RTREE` data structure does not handle OOM's yet, we have heuristic reservation in `RTREE `index. `BITSET` partially allocates memory using `realloc`.

To test the situation we can add something like `ERRINJ_INDEX_ALLOC_COUNTDOWN` injection to imitate memory exhausting during statement execution. But tests with such injection are fragile - they depend specific pattern of memory allocation in index data structure. Instead let's build injection around index data structure calls using introduced `INDEX_OOM_ERRINJ`. This way we may have injections that are not possible but it does not hurt. It is not a problem that we check we handle impossible failures too in tests.

[1] commit 32ea713af0a4 ("box: fix crash on rollback on memtx memory OOM and massive index change")

The second commit closes #11171.