### PR TITLE
cmake: link extra libraries to box

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -405,6 +405,6 @@ add_custom_command(OUTPUT ${SQL_BIN_DIR}/opcodes.c
         ${SQL_BIN_DIR}/opcodes.h)
 
 target_link_libraries(box box_error tuple xrow xlog vclock crc32 raft
-                      node_name ${common_libraries})
+    node_name ${common_libraries} ${EXTRA_BOX_LINK_LIBRARIES})
 
 add_dependencies(box build_bundled_libs generate_sql_files)


### PR DESCRIPTION
We can link extra libraries to core (see `EXTRA_CORE_LINK_LIBRARIES`). Let's also do it for box.

Will be used to link the Apache Arrow library to Tarantool EE.