### PR TITLE
test: drop `box_index_scanner()` usage from perf and fuzz tests

### DIFF
--- a/perf/lua/column_scan.lua
+++ b/perf/lua/column_scan.lua
@@ -22,7 +22,6 @@ local USAGE = [[
    row_count <number, 1000000>      - number of rows in the test space
    use_read_view <boolean, false>   - use a read view
    use_arrow_api <boolean, false>   - use the arrow stream API
-   use_scanner_api <boolean, false> - use the column scanner API
 
  Being run without options, this benchmark measures the run time of a full scan
  from the space.
@@ -34,7 +33,6 @@ local params = benchmark.argparse(arg, {
     {'row_count', 'number'},
     {'use_read_view', 'boolean'},
     {'use_arrow_api', 'boolean'},
-    {'use_scanner_api', 'boolean'},
 }, USAGE)
 
 local DEFAULT_ENGINE = 'memtx'
@@ -46,12 +44,6 @@ params.column_count = params.column_count or DEFAULT_COLUMN_COUNT
 params.row_count = params.row_count or DEFAULT_ROW_COUNT
 params.use_read_view = params.use_read_view or false
 params.use_arrow_api = params.use_arrow_api or false
-params.use_scanner_api = params.use_scanner_api or false
-
-if params.use_arrow_api and params.use_scanner_api then
-    io.stderr:write('--use_arrow_api and --use_scanner_api are incompatible.')
-    os.exit(1)
-end
 
 local bench = benchmark.new(params)
 
@@ -70,9 +62,7 @@ local test_funcs = {}
 
 for _, func_name in ipairs({'sum'}) do
     local full_func_name
-    if params.use_scanner_api then
-        full_func_name = func_name .. '_scanner'
-    elseif params.use_arrow_api then
+    if params.use_arrow_api then
         full_func_name = func_name .. '_arrow'
     else
         full_func_name = func_name .. '_iterator'


### PR DESCRIPTION
It will be removed from Tarantool Enterprise Edition.

Needed for tarantool/tarantool-ee#1040