### PR TITLE
Fix FP compilation warning in func_adapter test

### DIFF
--- a/test/unit/func_adapter_func.c
+++ b/test/unit/func_adapter_func.c
@@ -118,7 +118,7 @@ test_func_adapter_func_is_pinned(void)
 			func_adapter_func_create(func, pin_type);
 		fail_if(func_adapter == NULL);
 
-		enum func_holder_type returned_pin_type;
+		enum func_holder_type returned_pin_type = FUNC_HOLDER_MAX;
 		ok(func_is_pinned(func, &returned_pin_type),
 		   "Underlying func must be pinned");
 		is(returned_pin_type, pin_type,

--- a/test/unit/func_cache.c
+++ b/test/unit/func_cache.c
@@ -38,7 +38,7 @@ func_cache_pin_test_one_holder(void)
 
 	func_cache_init();
 	struct func *f1 = test_func_new(1, "func1");
-	enum func_holder_type type;
+	enum func_holder_type type = FUNC_HOLDER_MAX;
 	struct func_cache_holder h1;
 
 	func_cache_insert(f1);
@@ -73,7 +73,7 @@ func_cache_pin_test_fifo(void)
 
 	func_cache_init();
 	struct func *f1 = test_func_new(1, "func1");
-	enum func_holder_type type;
+	enum func_holder_type type = FUNC_HOLDER_MAX;
 	struct func_cache_holder h1, h2;
 
 	func_cache_insert(f1);
@@ -109,7 +109,7 @@ func_cache_pin_test_lifo(void)
 
 	func_cache_init();
 	struct func *f1 = test_func_new(1, "func1");
-	enum func_holder_type type;
+	enum func_holder_type type = FUNC_HOLDER_MAX;
 	struct func_cache_holder h1, h2;
 
 	func_cache_insert(f1);
@@ -146,7 +146,7 @@ func_cache_pin_test_several(void)
 	func_cache_init();
 	struct func *f1 = test_func_new(1, "func1");
 	struct func *f2 = test_func_new(2, "func2");
-	enum func_holder_type type;
+	enum func_holder_type type = FUNC_HOLDER_MAX;
 	struct func_cache_holder h1, h2, h3;
 
 	func_cache_insert(f1);


### PR DESCRIPTION
When I use LTO and warning-as-an-error locally with GCC 13 I got the following build failure:

```c
In function ‘test_func_adapter_func_is_pinned’,
    inlined from ‘test_main’ at <...>/test/unit/func_adapter_func.c:142:2,
    inlined from ‘main’ at <...>/test/unit/func_adapter_func.c:163:11:
<...>/test/unit/func_adapter_func.c:124:17: error: ‘returned_pin_type’ may be used uninitialized [-Werror=maybe-uninitialized]
  124 |                 is(returned_pin_type, pin_type,
      |                 ^
<...>/test/unit/func_adapter_func.c: In function ‘main’:
<...>/test/unit/func_adapter_func.c:121:39: note: ‘returned_pin_type’ was declared here
  121 |                 enum func_holder_type returned_pin_type;
      |                                       ^
lto1: all warnings being treated as errors
```

The build command:

```sh
cmake -S . -B . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_WERROR=ON -DTEST_BUILD=ON -DENABLE_LTO=ON
```

The fix is suggested by Andrey Saranchin (@drewdzzz).

This problem surprisingly happens in CI on increasing cmake minimum version to 3.5 (see #11382). Not sure about a reason, but since it hits me on `master` without any patches, that's definitely worth to fix.

While I'm here, initialize the `enum func_holder_type` variables in the `func_cache` unit test.