### PR TITLE
limbo: speed up synchro confirm writing

### DIFF
--- a/changelogs/unreleased/gh-11404-speed-up-txn-limbo-confirm-writing.md
+++ b/changelogs/unreleased/gh-11404-speed-up-txn-limbo-confirm-writing.md
@@ -1,0 +1,4 @@
+## bugfix/limbo
+
+* Optimized limbo worker writing confirmations for synchronous transactions
+  (gh-11404).

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -269,6 +269,16 @@ struct txn_limbo {
 	 * `confirmed_lsn`.
 	 */
 	struct fiber *worker;
+	/** `confirm_entry` memory pool. */
+	struct mempool confirm_entry_pool;
+	/**
+	 * Let's imagine the greatest confirm-lsn was ever submitted. Then if
+	 * this entry is not yet complete, then `submitted_confirm_lsn` equals
+	 * to this greatest confirm-lsn. But if this entry ended (no matter
+	 * with success or failure), then `submitted_confirm_lsn` equals to -1,
+	 * until greatest confirm-lsn is bumped.
+	 */
+	int64_t submitted_confirm_lsn;
 };
 
 /**

--- a/test/replication-luatest/gh_10628_ack_limbo_owner_wal_writes_to_limbo_async_test.lua
+++ b/test/replication-luatest/gh_10628_ack_limbo_owner_wal_writes_to_limbo_async_test.lua
@@ -78,6 +78,7 @@ g.test_limbo_in_rollback_confirm_not_written = function(cg)
         box.error.injection.set('ERRINJ_WAL_DELAY', false)
         t.assert(_G.fiber.find(fid):join())
         -- Check that CONFIRM request was not written to the WAL.
-        t.assert(box.error.injection.get('ERRINJ_WAL_WRITE_COUNT'), write_count)
+        t.assert_equals(
+            box.error.injection.get('ERRINJ_WAL_WRITE_COUNT'), write_count)
     end, {fid})
 end


### PR DESCRIPTION
In the case of a single node cluster, the limbo worker was not writing synchro confirms fast enough.
* The problem was, firstly, that sometimes it was possible to queue a confirm writing immediately (without yielding) from the `txn_on_journal_write` write-callback, instead of waking up the limbo worker to queue this writing on the next iteration of the event loop.
* The second problem was that limbo worker wrote confirms synchronously. There is no point in waiting for the confirm writing to finish, because while the worker is waiting, `volatile_confirmed_lsn` could have bumped and it doesn't matter how the previous writing ends, because you can already write a confirm to the updated greater lsn and retry only it if necessary, there is no point in retry unsuccessful writes with lower lsn.

```console
tarantool:~$ tarantool perf/lua/1mops_write.lua --nodes=31 --fibers=6000 --ops=1000000 --transaction=1 --warmup=10 --sync
# making 1000000 REPLACE operations,
# 1 operations per txn,
# using 6000 fibers,
...
```

<table border="1" cellspacing="0" cellpadding="8">
    <thead>
        <tr>
            <th>--nodes=</th>
            <th>Before</th>
            <th>After</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>1</td>
            <td>master average speed: 283773 ops/sec</td>
            <td>master average speed: 586668 ops/sec</td>
        </tr>
        <tr>
            <td rowspan="2">2</td>
            <td>master average speed: 233323 ops/sec</td>
            <td>master average speed: 233565 ops/sec</td>
        </tr>
        <tr>
            <td>1mops_replica_rps: 233320</td>
            <td>1mops_replica_rps: 233563</td>
        </tr>
        <tr>
            <td rowspan="2">3</td>
            <td>master average speed: 196305 ops/sec</td>
            <td>master average speed: 205243 ops/sec</td>
        </tr>
        <tr>
            <td>1mops_replica_rps: 196303</td>
            <td>1mops_replica_rps: 205235</td>
        </tr>
        <tr>
            <td rowspan="2">31</td>
            <td>master average speed: 49210 ops/sec</td>
            <td>master average speed: 49945 ops/sec</td>
        </tr>
        <tr>
            <td>1mops_replica_rps: 49207</td>
            <td>1mops_replica_rps: 49943</td>
        </tr>
    </tbody>
</table>

Closes https://github.com/tarantool/tarantool/issues/11404

NO_DOC=performance improvement
NO_TEST=performance improvement