### PR TITLE
test/fuzz: fix possible timeout in result chunks

### DIFF
--- a/test/fuzz/luaL_loadbuffer/serializer.cc
+++ b/test/fuzz/luaL_loadbuffer/serializer.cc
@@ -221,7 +221,7 @@ GetCounterIncrement(const std::string &counter_name)
 	std::string retval = counter_name;
 	retval += " = ";
 	retval += counter_name;
-	retval += " + 1\n";
+	retval += " + 1;\n";
 	return retval;
 }
 
@@ -1200,6 +1200,10 @@ PROTO_TOSTRING(UnaryOperator, op)
 PROTO_TOSTRING(Name, name)
 {
 	std::string ident = ConvertToStringDefault(name.name(), true);
+	/* Prevent using reserved keywords as identifiers. */
+	if (KReservedLuaKeywords.find(ident) != KReservedLuaKeywords.end()) {
+		ident += "_1";
+	}
 	/* Identifier has default name, add an index. */
 	if (!ident.compare(kDefaultIdent)) {
 		ident += std::to_string(name.num() % kMaxIdentifiers);


### PR DESCRIPTION
This patch fixes the Lua inputs in `luaL_loadbuffer_fuzzer` that generate the infinite cycles or recursive function calls, like the following:

```lua
if counter_0 > 5 then break end
counter_0 = counter_0 + 1
and (0.000000 );
```

The `and` here is generated by the `NameToString()` function, which doesn't check that the name shouldn't be reserved.

This patch adds the corresponding check and separates the counter increment with `;` to avoid any ambiguous syntax.

NO_CHANGELOG=fuzzing
NO_DOC=fuzzing