### PR TITLE
config-storage: reflect changed priv requirements

### DIFF
--- a/doc/examples/config/config-storage/config.yaml
+++ b/doc/examples/config/config-storage/config.yaml
@@ -10,8 +10,9 @@ credentials:
           # `tt connect` uses eval to execute commands.
           # So, specify permission in this way.
           universe: true
-        - permissions: [read, write]
-          spaces: [config_storage, config_storage_meta]
+        # Not necessary since tarantool 3.5.0, 3.4.1, 3.3.3, 3.2.2.
+        # - permissions: [read, write]
+        #   spaces: [config_storage, config_storage_meta]
 
 iproto:
   advertise:

--- a/doc/examples/config/config-storage/config.yaml
+++ b/doc/examples/config/config-storage/config.yaml
@@ -7,9 +7,13 @@ credentials:
       password: 'secret'
       privileges:
         - permissions: [execute]
-          # `tt connect` uses eval to execute commands.
-          # So, specify permission in this way.
-          universe: true
+          lua_call:
+            - config.storage.get
+            - config.storage.put
+            - config.storage.delete
+            - config.storage.keepalive
+            - config.storage.txn
+            - config.storage.info
         # Not necessary since tarantool 3.5.0, 3.4.1, 3.3.3, 3.2.2.
         # - permissions: [read, write]
         #   spaces: [config_storage, config_storage_meta]


### PR DESCRIPTION
This patchset adjusts config storage configuration example to reflect recent Tarantool EE changes. See https://github.com/tarantool/tarantool-ee/issues/1227.

Also, it changes the `universe` permission to more granular ones, where we show all the config storage API functions.