### PR TITLE
box: add quiver engine initialization stub

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -353,6 +353,10 @@ if(ENABLE_MEMCS_ENGINE)
     list(APPEND box_sources ${MEMCS_ENGINE_SOURCES})
 endif()
 
+if(ENABLE_QUIVER_ENGINE)
+    list(APPEND box_sources ${QUIVER_ENGINE_SOURCES})
+endif()
+
 add_library(box STATIC ${box_sources})
 if(OSS_FUZZ)
   target_link_options(box PUBLIC "-stdlib=libstdc++")

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -57,6 +57,7 @@
 #include "memtx_engine.h"
 #include "memtx_space.h"
 #include "memcs_engine.h"
+#include "quiver_engine.h"
 #include "sysview.h"
 #include "blackhole.h"
 #include "service_engine.h"
@@ -5303,7 +5304,6 @@ engine_init()
 				    cfg_geti("memtx_sort_threads"),
 				    box_on_indexes_built);
 	engine_register((struct engine *)memtx);
-	assert(memtx->base.id < MAX_TX_ENGINE_COUNT);
 	box_set_memtx_max_tuple_size();
 
 	memcs_engine_register();
@@ -5315,10 +5315,11 @@ engine_init()
 				    cfg_geti("vinyl_write_threads"),
 				    box_is_force_recovery);
 	engine_register(vinyl);
-	assert(vinyl->id < MAX_TX_ENGINE_COUNT);
 	box_set_vinyl_max_tuple_size();
 	box_set_vinyl_cache();
 	box_set_vinyl_timeout();
+
+	quiver_engine_register();
 
 	struct sysview_engine *sysview = sysview_engine_new_xc();
 	engine_register((struct engine *)sysview);

--- a/src/box/engine.c
+++ b/src/box/engine.c
@@ -47,6 +47,8 @@ void
 engine_register(struct engine *engine)
 {
 	assert(engine_count < MAX_ENGINE_COUNT);
+	assert((engine->flags & ENGINE_BYPASS_TX) != 0 ||
+	       engine_count < MAX_TX_ENGINE_COUNT);
 	engine->id = engine_count++;
 	engines[engine->id] = engine;
 }

--- a/src/box/engine.h
+++ b/src/box/engine.h
@@ -45,13 +45,13 @@ enum {
 	 * For simplicity, assume that the total engine count can't exceed
 	 * the value of this constant.
 	 */
-	MAX_ENGINE_COUNT = 10,
+	MAX_ENGINE_COUNT = 7,
 	/**
 	 * Max number of engines involved in a multi-statement transaction.
 	 * This value must be greater than any `engine::id' of an engine
 	 * without `ENGINE_BYPASS_TX' flag.
 	 */
-	MAX_TX_ENGINE_COUNT = 3,
+	MAX_TX_ENGINE_COUNT = 4,
 };
 
 struct engine;

--- a/src/box/quiver_engine.h
+++ b/src/box/quiver_engine.h
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2025, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include "trivia/config.h"
+
+#if defined(ENABLE_QUIVER_ENGINE)
+# include "quiver_engine_impl.h"
+#else /* !defined(ENABLE_QUIVER_ENGINE) */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+static inline void
+quiver_engine_register(void) {}
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */
+
+#endif /* !defined(ENABLE_QUIVER_ENGINE) */

--- a/src/trivia/config.h.cmake
+++ b/src/trivia/config.h.cmake
@@ -294,6 +294,7 @@
 #cmakedefine ENABLE_READ_VIEW 1
 #cmakedefine ENABLE_SECURITY 1
 #cmakedefine ENABLE_MEMCS_ENGINE 1
+#cmakedefine ENABLE_QUIVER_ENGINE 1
 #cmakedefine ENABLE_COMPRESS_MODULE 1
 #cmakedefine ENABLE_ETCD_CLIENT 1
 #cmakedefine ENABLE_CONFIG_EXTRAS 1


### PR DESCRIPTION
The stub will be implemented in Tarantool Enterprise Edition.

Part of tarantool/tarantool-ee#1207

EE part: https://github.com/tarantool/tarantool-ee/pull/1234