### PR TITLE
config: add the `stateboard` section

### DIFF
--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -2355,6 +2355,41 @@ I['sql.cache_size'] = format_text([[
 
 -- }}} sql configuration
 
+-- {{{ stateboard configuration
+
+I['stateboard'] = format_text([[
+    These options define configuration parameters related to the stateboard
+    service allowing Tarantool instances to report their state into some extra
+    key-value storage (e.g. etcd or Tarantool config.storage).
+
+    An instance with an enabled stateboard reports its status to
+    `<prefix>/state/by-name/{{ instance_name }}` where prefix is received from
+    the `config.*.prefix` option. The provided information is in YAML format
+    with the following fields:
+
+    - `hostname` (`string`): hostname
+    - `pid` (`integer`): Tarantool process ID
+    - `mode` (`'ro'` or `'rw'`): instance mode (see `box.info.ro`).
+    - `status` (`string`): instance status (see `box.info.status` for possible
+      values and their description).
+]])
+
+I['stateboard.enabled'] = format_text([[
+    Enable or disable the stateboard service.
+]])
+
+I['stateboard.keepalive_interval'] = format_text([[
+    A time interval (in seconds) that specifies how long a transient state
+    information is stored.
+]])
+
+I['stateboard.renew_interval'] = format_text([[
+    A time interval (in seconds) that specifies how often a Tarantool instance
+    writes its state information to the stateboard.
+]])
+
+-- }}} stateboard configuration
+
 -- {{{ vinyl configuration
 
 I['vinyl'] = format_text([[

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2196,6 +2196,21 @@ return schema.new('instance_config', schema.record({
         default = false,
         validate = validators['isolated'],
     }),
+    -- Options for the stateboard service.
+    stateboard = enterprise_edition(schema.record({
+        enabled = schema.scalar({
+            type = 'boolean',
+            default = false,
+        }),
+        renew_interval = schema.scalar({
+            type = 'number',
+            default = 2,
+        }),
+        keepalive_interval = schema.scalar({
+            type = 'number',
+            default = 10,
+        }),
+    })),
 }), {
     methods = {
         instance_uri = instance_uri,

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -91,6 +91,7 @@ local instance_config_fields = {
     'audit_log',
     'roles_cfg',
     'roles',
+    'stateboard',
     'failover',
     'compat',
     'labels',
@@ -443,6 +444,11 @@ g.test_defaults = function()
             wal_cleanup_delay_deprecation = 'old',
         },
         isolated = false,
+        stateboard = {
+            enabled = false,
+            renew_interval = 2,
+            keepalive_interval = 10,
+        },
     }
 
     -- Global defaults.


### PR DESCRIPTION
This patch introduces a new `stateboard` configuration section. It's used for configuring a service reporting instance state to the configured remote key-value storage.

Part of tarantool/tarantool-ee#1229
Doc request tarantool/doc#5091