### PR TITLE
[backport 3.2] memtx: use index definition's key_def for point hole comparisons

### DIFF
--- a/changelogs/unreleased/gh-10159-11292-mvcc-bitwise-key-comparison.md
+++ b/changelogs/unreleased/gh-10159-11292-mvcc-bitwise-key-comparison.md
@@ -1,0 +1,4 @@
+## bugfix/memtx
+
+* Fixed a bug that caused the memtx MVCC to miss conflicts over key definitions
+  that used the number type or collations (gh-10159, gh-11292).

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -783,8 +783,6 @@ index_create(struct index *index, struct engine *engine,
 	index->def = def;
 	index->refs = 1;
 	index->space_cache_version = space_cache_version;
-	static uint32_t unique_id = 0;
-	index->unique_id = unique_id++;
 	/* Unusable until set to proper value during space creation. */
 	index->dense_id = UINT32_MAX;
 	rlist_create(&index->read_gaps);

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -611,8 +611,6 @@ struct index {
 	int refs;
 	/** Space cache version at the time of construction. */
 	uint32_t space_cache_version;
-	/** Globally unique ID. */
-	uint32_t unique_id;
 	/** Compact ID - index in space->index array. */
 	uint32_t dense_id;
 	/**

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1559,6 +1559,19 @@ memtx_tx_track_story_gap(struct txn *txn, struct memtx_story *story,
 			 uint32_t ind);
 
 /**
+ * Deletes the point hole item. The deletion of the item from the point hole
+ * storage is handled separately.
+ */
+static void
+point_hole_item_delete(struct point_hole_item *object)
+{
+	rlist_del(&object->ring);
+	rlist_del(&object->in_point_holes_list);
+	struct memtx_tx_mempool *pool = &txm.point_hole_item_pool;
+	memtx_tx_mempool_free(object->txn, pool, object);
+}
+
+/**
  * Check for possible conflict relations during insertion of @a new tuple,
  * (with the corresponding @a story) into index @a ind. It is needed if and
  * only if that was real insertion - there was no replaced tuple in the index.
@@ -1586,7 +1599,6 @@ memtx_tx_handle_point_hole_write(struct space *space, struct memtx_story *story,
 	 */
 	mh_point_holes_del(ht, pos, 0);
 
-	struct memtx_tx_mempool *pool = &txm.point_hole_item_pool;
 	bool has_more_items;
 	do {
 		memtx_tx_track_story_gap(item->txn, story, ind);
@@ -1595,11 +1607,7 @@ memtx_tx_handle_point_hole_write(struct space *space, struct memtx_story *story,
 			rlist_entry(item->ring.next,
 				    struct point_hole_item, ring);
 		has_more_items = next_item != item;
-
-		rlist_del(&item->ring);
-		rlist_del(&item->in_point_holes_list);
-		memtx_tx_mempool_free(item->txn, pool, item);
-
+		point_hole_item_delete(item);
 		item = next_item;
 	} while (has_more_items);
 }
@@ -3111,10 +3119,7 @@ point_hole_storage_delete(struct point_hole_item *object)
 		assert(pos != mh_end(txm.point_holes));
 		mh_point_holes_del(txm.point_holes, pos, 0);
 	}
-	rlist_del(&object->ring);
-	rlist_del(&object->in_point_holes_list);
-	struct memtx_tx_mempool *pool = &txm.point_hole_item_pool;
-	memtx_tx_mempool_free(object->txn, pool, object);
+	point_hole_item_delete(object);
 }
 
 /**

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -3084,7 +3084,6 @@ point_hole_storage_delete(struct point_hole_item *object)
 		 * list and that's enough.
 		 */
 		assert(!rlist_empty(&object->ring));
-		rlist_del(&object->ring);
 	} else if (!rlist_empty(&object->ring)) {
 		/*
 		 * Hash table point to this item, but there are more
@@ -3100,7 +3099,6 @@ point_hole_storage_delete(struct point_hole_item *object)
 		struct point_hole_item **preplaced = &replaced;
 		mh_point_holes_put(txm.point_holes, put, &preplaced, 0);
 		assert(replaced == object);
-		rlist_del(&object->ring);
 		another->is_head = true;
 	} else {
 		/*
@@ -3113,6 +3111,7 @@ point_hole_storage_delete(struct point_hole_item *object)
 		assert(pos != mh_end(txm.point_holes));
 		mh_point_holes_del(txm.point_holes, pos, 0);
 	}
+	rlist_del(&object->ring);
 	rlist_del(&object->in_point_holes_list);
 	struct memtx_tx_mempool *pool = &txm.point_hole_item_pool;
 	memtx_tx_mempool_free(object->txn, pool, object);

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -180,8 +180,8 @@ struct point_hole_item {
 	struct rlist ring;
 	/** Link in txn->point_holes_list. */
 	struct rlist in_point_holes_list;
-	/** Saved index->unique_id. */
-	uint32_t index_unique_id;
+	/** Saved index. */
+	struct index *index;
 	/** Precalculated hash for storing in hash table.. */
 	uint32_t hash;
 	/** Saved txn. */
@@ -318,7 +318,7 @@ static uint32_t
 point_hole_storage_combine_index_and_tuple_hash(struct index *index,
 						uint32_t tuple_hash)
 {
-	return (uintptr_t)index->unique_id ^ tuple_hash;
+	return (uintptr_t)index ^ tuple_hash;
 }
 
 /** Hash calculatore for the key. */
@@ -337,7 +337,7 @@ point_hole_storage_equal(const struct point_hole_item *obj1,
 			 const struct point_hole_item *obj2)
 {
 	/* Canonical msgpack is comparable by memcmp. */
-	if (obj1->index_unique_id != obj2->index_unique_id ||
+	if (obj1->index != obj2->index ||
 	    obj1->key_len != obj2->key_len)
 		return 1;
 	return memcmp(obj1->key, obj2->key, obj1->key_len) != 0;
@@ -348,7 +348,7 @@ static int
 point_hole_storage_key_equal(const struct point_hole_key *key,
 			     const struct point_hole_item *object)
 {
-	if (key->index->unique_id != object->index_unique_id)
+	if (key->index != object->index)
 		return 1;
 	assert(key->index != NULL);
 	assert(key->tuple != NULL);
@@ -1567,6 +1567,7 @@ point_hole_item_delete(struct point_hole_item *object)
 {
 	rlist_del(&object->ring);
 	rlist_del(&object->in_point_holes_list);
+	index_unref(object->index);
 	struct memtx_tx_mempool *pool = &txm.point_hole_item_pool;
 	memtx_tx_mempool_free(object->txn, pool, object);
 }
@@ -3048,7 +3049,8 @@ point_hole_storage_new(struct index *index, const char *key,
 	rlist_create(&object->ring);
 	rlist_create(&object->in_point_holes_list);
 	object->txn = txn;
-	object->index_unique_id = index->unique_id;
+	object->index = index;
+	index_ref(index);
 	if (key_len <= sizeof(object->short_key)) {
 		object->key = object->short_key;
 	} else {

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -182,14 +182,14 @@ struct point_hole_item {
 	struct rlist in_point_holes_list;
 	/** Saved index. */
 	struct index *index;
-	/** Precalculated hash for storing in hash table.. */
-	uint32_t hash;
 	/** Saved txn. */
 	struct txn *txn;
 	/** Saved key. Points to @a short_key or allocated in txn's region. */
 	const char *key;
 	/** Storage for short key. @key may point here. */
 	char short_key[16];
+	/** Precalculated hash for storing in hash table. */
+	uint32_t hash;
 	/** Flag that the hash tables stores pointer to this item. */
 	bool is_head;
 };

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -190,8 +190,6 @@ struct point_hole_item {
 	const char *key;
 	/** Storage for short key. @key may point here. */
 	char short_key[16];
-	/** Saved space id. */
-	uint32_t space_id;
 	/** Flag that the hash tables stores pointer to this item. */
 	bool is_head;
 };
@@ -2812,7 +2810,7 @@ memtx_tx_abort_space_schema_readers(struct space *space, struct txn *ddl_owner)
 		struct point_hole_item *hole_item;
 		rlist_foreach_entry(hole_item, &txn->point_holes_list,
 				    in_point_holes_list) {
-			if (space->def->id == hole_item->space_id) {
+			if (space->def->id == hole_item->index->def->space_id) {
 				memtx_tx_abort_with_conflict(txn);
 				break;
 			}
@@ -3058,7 +3056,6 @@ point_hole_storage_new(struct index *index, const char *key,
 						     MEMTX_TX_ALLOC_TRACKER);
 	}
 	memcpy((char *)object->key, key, key_len);
-	object->space_id = index->def->space_id;
 	object->is_head = true;
 
 	struct key_def *def = index->def->key_def;

--- a/test/box-luatest/gh_10159_11292_mvcc_bitwise_key_comparison_test.lua
+++ b/test/box-luatest/gh_10159_11292_mvcc_bitwise_key_comparison_test.lua
@@ -1,0 +1,107 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_each(function(cg)
+    cg.server = server:new({box_cfg = {memtx_use_mvcc_engine = true}})
+    cg.server:start()
+    cg.server:exec(function()
+        rawset(_G, 'fiber', require('fiber'))
+
+        box.schema.space.create('s')
+    end)
+end)
+
+g.after_each(function(cg)
+    cg.server:drop()
+end)
+
+g.before_test('test_number', function(cg)
+    cg.server:exec(function()
+        box.space.s:create_index('p', {parts = {1, 'double'}})
+    end)
+end)
+
+g.test_number = function(cg)
+    cg.server:exec(function()
+        local s = box.space.s
+
+        local f1 = _G.fiber.new(function()
+            box.atomic(function()
+                s:get{0}
+                _G.fiber.yield()
+                s:replace{0}
+            end)
+        end)
+        f1:set_joinable(true)
+
+        local f2 = _G.fiber.new(function()
+            box.atomic(function()
+                s:get{require('ffi').cast('double', 0)}
+                _G.fiber.yield()
+                s:replace{0}
+            end)
+        end)
+        f2:set_joinable(true)
+
+        _G.fiber.yield()
+
+        s:replace{0}
+
+        local msg = "Transaction has been aborted by conflict"
+
+        local ok, err = f1:join()
+        t.assert_not(ok)
+        t.assert_equals(err.message, msg)
+
+        ok, err = f2:join()
+        t.assert_not(ok)
+        t.assert_equals(err.message, msg)
+    end)
+end
+
+g.before_test('test_collation', function(cg)
+    cg.server:exec(function()
+        box.space.s:create_index('s', {parts = {1, 'str',
+                                                collation = 'unicode_ci'}})
+    end)
+end)
+
+g.test_collation = function(cg)
+    cg.server:exec(function()
+        local s = box.space.s
+
+        local f1 = _G.fiber.new(function()
+            box.atomic(function()
+                s:get{'a'}
+                _G.fiber.yield()
+                s:replace{'a'}
+            end)
+        end)
+        f1:set_joinable(true)
+
+        local f2 = _G.fiber.new(function()
+            box.atomic(function()
+                s:get{'A'}
+                _G.fiber.yield()
+                s:replace{'a'}
+            end)
+        end)
+        f2:set_joinable(true)
+
+        _G.fiber.yield()
+
+        s:replace{'a'}
+
+        local msg = "Transaction has been aborted by conflict"
+
+        local ok, err = f1:join()
+        t.assert_not(ok)
+        t.assert_equals(err.message, msg)
+
+        ok, err = f2:join()
+        t.assert_not(ok)
+        t.assert_equals(err.message, msg)
+    end)
+end

--- a/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
+++ b/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
@@ -14,7 +14,7 @@ local SIZE_OF_TUPLE = 9
 local SIZE_OF_XROW = 163
 -- Tracker can allocate additional memory, be careful!
 local SIZE_OF_READ_TRACKER = 48
-local SIZE_OF_POINT_TRACKER = 88
+local SIZE_OF_POINT_TRACKER = 80
 local SIZE_OF_INPLACE_GAP_TRACKER = 48
 local SIZE_OF_NEARBY_GAP_TRACKER = 88
 


### PR DESCRIPTION
*(This PR is a backport of #11388 to `release/3.2` to a future `3.2.2` release.)*

----

This patchset fixes the incorrect assumption that point hole equivalence classes are defined by
their keys' binary (MsgPack) representation.

Closes #10159
Closes #11292