### PR TITLE
cmake: fix AppleClang detection

### DIFF
--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -12,7 +12,8 @@ endif()
 # We support building with Clang and gcc. First check 
 # what we're using for build.
 #
-if (CMAKE_C_COMPILER_ID STREQUAL Clang)
+if (CMAKE_C_COMPILER_ID STREQUAL Clang OR
+    CMAKE_C_COMPILER_ID STREQUAL AppleClang)
     set(CMAKE_COMPILER_IS_CLANG  ON)
     set(CMAKE_COMPILER_IS_GNUCC  OFF)
     set(CMAKE_COMPILER_IS_GNUCXX OFF)


### PR DESCRIPTION
CMake 3.0 and above recognize that Apple Clang is a different compiler than upstream Clang. CMake 4.0 prefers to set the
`CMAKE_<LANG>_COMPILER_ID` variable to AppleClang instead of Clang. See [1] for details.

This patch adds the corresponding check to set `CMAKE_COMPILER_IS_CLANG` for the Apple Clang too.

[1]: https://cmake.org/cmake/help/v4.0/policy/CMP0025.html

NO_DOC=build
NO_TEST=build
NO_CHANGELOG=build