### PR TITLE
cmake: fix LTO build on Fedora

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -43,6 +43,21 @@ function(create_unit_test)
   add_executable(${UNIT_PREFIX}.test ${UNIT_SOURCES})
   target_compile_definitions(${UNIT_PREFIX}.test PRIVATE ${UNIT_COMPILE_DEFINITIONS})
   target_link_libraries(${UNIT_PREFIX}.test ${UNIT_LIBRARIES})
+  # FIXME: Since version 3.4, CMake doesn't add flags to export
+  # symbols from executables without the ENABLE_EXPORTS target
+  # property, see CMP0065 [1] for details. Without this property,
+  # some unit tests produce build warnings with LTO optimization
+  # enabled (for example, on Fedora 39), see also [2].
+  # [1]: https://cmake.org/cmake/help/latest/policy/CMP0065.html
+  # [2]: https://github.com/tarantool/tarantool/issues/11517
+  if(ENABLE_LTO)
+      # The CMP0065 is removed from CMake version 4.0 [1].
+      # Thus, set the ENABLE_EXPORTS directly.
+      # [1]: https://cmake.org/cmake/help/latest/manual/cmake-policies.7.html#policies-introduced-by-cmake-3-4-removed-by-cmake-4-0
+      set_target_properties(${UNIT_PREFIX}.test
+          PROPERTIES ENABLE_EXPORTS TRUE
+      )
+  endif()
   add_dependencies(${TEST_SUITE_NAME}-deps ${UNIT_PREFIX}.test)
   set(UNIT_TEST_TARGETS "${UNIT_TEST_TARGETS} ${UNIT_PREFIX}.test" PARENT_SCOPE)
   # Every unit test is a self-contained program without


### PR DESCRIPTION
This patch is a follow-up to the commit
25af976f5279720079e00be390fb065d1ea5446d ("build: support cmake 4.0"). Since version 3.4, CMake doesn't add flags to export symbols from executables without the ENABLE_EXPORTS target property, see CMP0065 [1] for details.  Without this property, some unit C tests produce build warnings with LTO optimization enabled (for example, on Fedora 39):

NO_WRAP
```
[ 72%] Linking CXX executable luaT_tuple_new.test
In function ‘rmean_collect’,
    inlined from ‘txn_complete_success’ at src/box/txn.c:836:2,
    inlined from ‘txn_limbo_complete’ at src/box/txn_limbo.c:205:3:
src/lib/core/rmean.c:65:9: error: ‘__atomic_add_fetch_8’ writing 8 bytes into a region of size 0 overflows the destination [-Werror=stringop-overflow=]
   65 |         __atomic_add_fetch(&rmean->stats[name].value[0], value, __ATOMIC_RELAXED);
      |         ^
In function ‘txn_limbo_complete’:
lto1: note: destination object is likely at address zero
```
NO_WRAP

The CMP0065 is removed from CMake version 4.0 [2]. Thus, this patch fixes the behaviour by setting the property `ENABLE_EXPORTS` for unit tests directly.

[1]: https://cmake.org/cmake/help/latest/policy/CMP0065.html
[2]: https://cmake.org/cmake/help/latest/manual/cmake-policies.7.html#policies-introduced-by-cmake-3-4-removed-by-cmake-4-0

NO_DOC=build
NO_TEST=build
NO_CHANGELOG=build

---

Originally observed on 2.11, see [this CI run](https://github.com/tarantool/tarantool/actions/runs/15021502966/job/42211584949?pr=11502#step:5:8147). But may be reproduced on the master branch with the following Dockerfile:
```Dockerfile
FROM fedora:39
RUN dnf upgrade --refresh -y
RUN dnf install -y git
RUN dnf install -y vim
RUN dnf install -y bash
RUN dnf install -y make
RUN dnf install -y cmake
RUN dnf install -y gcc
RUN dnf install -y g++
RUN dnf install -y libicu-devel
RUN dnf install -y openssl-devel
RUN dnf install -y readline-devel
RUN dnf install -y zlib-devel
RUN dnf install -y autoconf automake
RUN dnf install -y libtool

CMD ["bash"]
```

In the Docker: clone the Tarantool repo and build with the following command:
```sh
cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_LTO=ON -DENABLE_WERROR=ON -DENABLE_DIST=ON && make -j3
```