### PR TITLE
config: add `fail_if` tag for roles and scripts

### DIFF
--- a/changelogs/unreleased/gh-10987-min-tarantool-version-for-roles.md
+++ b/changelogs/unreleased/gh-10987-min-tarantool-version-for-roles.md
@@ -1,0 +1,3 @@
+## feature/config
+
+* Introduced a `fail_if` tag for roles and scripts (gh-10987).

--- a/test/config-luatest/app_test.lua
+++ b/test/config-luatest/app_test.lua
@@ -138,3 +138,64 @@ g.test_app_cfg_deep_merge = function(g)
         end,
     })
 end
+
+g.test_tarantool_version_check = function(g)
+    local one = [[-- --- #tarantool.metadata.v1
+-- fail_if: "tarantool_version < 0.0.0"
+-- ...
+    ]]
+
+    local two = [[-- --- #tarantool.metadata.v1
+-- fail_if: "tarantool_version > 0.0.0"
+-- ...
+    ]]
+
+    local three = [[-- --- #tarantool.metadata.v1
+-- fail_if: "tarantool_version >< 0.0.0"
+-- ...
+    ]]
+
+    helpers.success_case(g, {
+        script = one,
+        options = {
+            ['app.file'] = 'main.lua',
+        },
+        verify = function() end,
+    })
+
+    helpers.success_case(g, {
+        script = one,
+        options = {
+            ['app.module'] = 'main',
+        },
+        verify = function() end,
+    })
+
+    helpers.failure_case({
+        script = two,
+        options = {['app.file'] = 'main.lua'},
+        exp_err = 'App "main.lua" failed the "fail_if" check: ' ..
+                  '"tarantool_version > 0.0.0"'
+    })
+
+    helpers.failure_case({
+        script = two,
+        options = {['app.module'] = 'main'},
+        exp_err = 'App "main" failed the "fail_if" check: ' ..
+                  '"tarantool_version > 0.0.0"'
+    })
+
+    helpers.failure_case({
+        script = three,
+        options = {['app.file'] = 'main.lua'},
+        exp_err = 'App "main.lua" has invalid "fail_if" expression: ' ..
+                  'Unexpected token "<"'
+    })
+
+    helpers.failure_case({
+        script = three,
+        options = {['app.module'] = 'main'},
+        exp_err = 'App "main" has invalid "fail_if" expression: ' ..
+                  'Unexpected token "<"'
+    })
+end


### PR DESCRIPTION
Closes #10987
Closes TNTP-1016

@TarantoolBot document
Title: `fail_if` tag for roles and scripts.

If the tag `fail_if` is set to an expression string role/script loading will raise an error, if fail_if expression is evaluated to be `true`.

The syntax for `fail_if` tag is the same as in config `conditional.if` section.

Example:
```lua
-- --- #tarantool.metadata.v1
-- fail_if: "tarantool_version < 3.1.0"
-- ...
```