### PR TITLE
core: move EE error injections to extras

### DIFF
--- a/src/lib/core/errinj.h
+++ b/src/lib/core/errinj.h
@@ -34,6 +34,13 @@
 #include <stddef.h>
 #include "trivia/util.h"
 #include "crash.h"
+
+#ifdef ENABLE_ERRINJ_EXTRAS
+#include "errinj_extras.h"
+#else
+#define ERRINJ_EXTRAS(_)
+#endif
+
 #if defined(__cplusplus)
 extern "C" {
 #endif /* defined(__cplusplus) */
@@ -91,8 +98,6 @@ struct errinj {
 	_(ERRINJ_ENGINE_JOIN_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_FIBER_MADVISE, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_FIBER_MPROTECT, ERRINJ_INT, {.iparam = -1}) \
-	_(ERRINJ_FLIGHTREC_RECREATE_RENAME, ERRINJ_BOOL, {.bparam = false}) \
-	_(ERRINJ_FLIGHTREC_LOG_DELAY, ERRINJ_DOUBLE, {.dparam = 0}) \
 	_(ERRINJ_HTTPC_EXECUTE, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_HTTP_RESPONSE_ADD_WAIT, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_INDEX_ALLOC, ERRINJ_BOOL, {.bparam = false}) \
@@ -143,7 +148,6 @@ struct errinj {
 	_(ERRINJ_SNAP_WRITE_MISSING_SPACE_ROW, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_SNAP_WRITE_TIMEOUT, ERRINJ_DOUBLE, {.dparam = 0}) \
 	_(ERRINJ_SNAP_WRITE_UNKNOWN_ROW_TYPE, ERRINJ_BOOL, {.bparam = false}) \
-	_(ERRINJ_SPACE_UPGRADE_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_SWIM_FD_ONLY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_TESTING, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_TUPLE_ALLOC, ERRINJ_BOOL, {.bparam = false}) \
@@ -211,6 +215,7 @@ struct errinj {
 	_(ERRINJ_XLOG_WRITE_INVALID_VALUE, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_XLOG_WRITE_UNKNOWN_KEY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_XLOG_WRITE_UNKNOWN_TYPE, ERRINJ_BOOL, {.bparam = false}) \
+	ERRINJ_EXTRAS(_)
 
 ENUM0(errinj_id, ERRINJ_LIST);
 extern struct errinj errinjs[];

--- a/src/trivia/config.h.cmake
+++ b/src/trivia/config.h.cmake
@@ -283,6 +283,7 @@
 /* Cacheline size to calculate alignments */
 #define CACHELINE_SIZE 64
 
+#cmakedefine ENABLE_ERRINJ_EXTRAS 1
 #cmakedefine ENABLE_FLIGHT_RECORDER 1
 #cmakedefine ENABLE_TUPLE_COMPRESSION 1
 #cmakedefine ENABLE_SPACE_UPGRADE 1


### PR DESCRIPTION
To introduce a new error injection to the EE repository, one has to first add it to the CE repository and bump the CE submodule in EE. This is inconvenient. Let's move all EE error injections to extras and define them in the EE repository.

EE part: https://github.com/tarantool/tarantool-ee/pull/1264