### PR TITLE
xlog: drop xdir type

### DIFF
--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -286,7 +286,7 @@ memtx_engine_recover_snapshot(struct memtx_engine *memtx,
 	say_info("recovery start");
 	int64_t signature = vclock_sum(vclock);
 	const char *filename = xdir_format_filename(&memtx->snap_dir,
-						    signature, NONE);
+						    signature);
 
 	say_info("recovering from `%s'", filename);
 	struct xlog_cursor cursor;
@@ -1302,7 +1302,7 @@ memtx_engine_backup(struct engine *engine, const struct vclock *vclock,
 {
 	struct memtx_engine *memtx = (struct memtx_engine *)engine;
 	const char *filename = xdir_format_filename(&memtx->snap_dir,
-						    vclock_sum(vclock), NONE);
+						    vclock_sum(vclock));
 	return cb(filename, cb_arg);
 }
 
@@ -1703,8 +1703,7 @@ memtx_engine_new(const char *snap_dirname, bool force_recovery,
 	     vclock != NULL;
 	     vclock = vclockset_next(&memtx->snap_dir.index, vclock)) {
 		const char *name = xdir_format_filename(&memtx->snap_dir,
-							vclock_sum(vclock),
-							NONE);
+							vclock_sum(vclock));
 		struct stat attr;
 		double timestamp = ev_time();
 		if (stat(name, &attr) != 0)

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -922,7 +922,7 @@ checkpoint_new(const char *snap_dirname, uint64_t snap_io_rate_limit)
 	opts.rate_limit = snap_io_rate_limit;
 	opts.sync_interval = SNAP_SYNC_INTERVAL;
 	opts.free_cache = true;
-	xdir_create(&ckpt->dir, snap_dirname, SNAP, &INSTANCE_UUID, &opts);
+	xdir_create(&ckpt->dir, snap_dirname, "SNAP", &INSTANCE_UUID, &opts);
 	xlog_clear(&ckpt->snap);
 	vclock_create(&ckpt->vclock);
 	box_raft_checkpoint_local(&ckpt->raft);
@@ -1671,7 +1671,7 @@ memtx_engine_new(const char *snap_dirname, bool force_recovery,
 		return NULL;
 	}
 
-	xdir_create(&memtx->snap_dir, snap_dirname, SNAP, &INSTANCE_UUID,
+	xdir_create(&memtx->snap_dir, snap_dirname, "SNAP", &INSTANCE_UUID,
 		    &xlog_opts_default);
 	memtx->snap_dir.force_recovery = force_recovery;
 

--- a/src/box/recovery.cc
+++ b/src/box/recovery.cc
@@ -96,7 +96,7 @@ recovery_new(const char *wal_dirname, bool force_recovery,
 		free(r);
 	});
 
-	xdir_create(&r->wal_dir, wal_dirname, XLOG, &INSTANCE_UUID,
+	xdir_create(&r->wal_dir, wal_dirname, "XLOG", &INSTANCE_UUID,
 		    &xlog_opts_default);
 	r->wal_dir.force_recovery = force_recovery;
 

--- a/src/box/vy_log.c
+++ b/src/box/vy_log.c
@@ -213,7 +213,7 @@ vy_log_rotate(const struct vclock *vclock);
 static inline const char *
 vy_log_filename(int64_t signature)
 {
-	return xdir_format_filename(&vy_log.dir, signature, NONE);
+	return xdir_format_filename(&vy_log.dir, signature);
 }
 
 /**

--- a/src/box/vy_log.c
+++ b/src/box/vy_log.c
@@ -715,7 +715,7 @@ vy_log_record_dup(struct region *pool, const struct vy_log_record *src)
 void
 vy_log_init(const char *dir)
 {
-	xdir_create(&vy_log.dir, dir, VYLOG, &INSTANCE_UUID,
+	xdir_create(&vy_log.dir, dir, "VYLOG", &INSTANCE_UUID,
 		    &xlog_opts_default);
 	latch_create(&vy_log.latch);
 	mempool_create(&vy_log.tx_pool, cord_slab_cache(),

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -433,7 +433,10 @@ wal_writer_create(struct wal_writer *writer, enum wal_mode wal_mode,
 
 	struct xlog_opts opts = xlog_opts_default;
 	opts.sync_is_async = true;
-	xdir_create(&writer->wal_dir, wal_dirname, XLOG, instance_uuid, &opts);
+	xdir_create(&writer->wal_dir, wal_dirname, "XLOG", instance_uuid,
+		    &opts);
+	writer->wal_dir.force_recovery = true;
+	writer->wal_dir.store_prev_vclock = true;
 	/*
 	 * wal_retention_period must be set before gc is woken up.
 	 * Otherwise files which must be preserved can be deleted.

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -480,7 +480,7 @@ wal_open_f(struct cbus_call_msg *msg)
 	(void)msg;
 	struct wal_writer *writer = &wal_writer_singleton;
 	const char *path = xdir_format_filename(&writer->wal_dir,
-				vclock_sum(&writer->vclock), NONE);
+				vclock_sum(&writer->vclock));
 	assert(!xlog_is_open(&writer->current_wal));
 
 	uint64_t sum_already_on_disk = 0;
@@ -490,8 +490,7 @@ wal_open_f(struct cbus_call_msg *msg)
 		if (vclock_compare(&writer->checkpoint_vclock, vclock) > 0)
 			continue;
 		const char *name = xdir_format_filename(&writer->wal_dir,
-							vclock_sum(vclock),
-							NONE);
+							vclock_sum(vclock));
 		struct stat attr;
 		if (stat(name, &attr) != 0)
 			say_warn("failed to get file size %s, consider it"
@@ -511,7 +510,7 @@ static int
 wal_open(struct wal_writer *writer)
 {
 	const char *path = xdir_format_filename(&writer->wal_dir,
-				vclock_sum(&writer->vclock), NONE);
+				vclock_sum(&writer->vclock));
 	if (access(path, F_OK) != 0) {
 		if (errno == ENOENT) {
 			/* No WAL, nothing to do. */

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -948,8 +948,9 @@ wal_opt_rotate(struct wal_writer *writer)
 	if (xlog_is_open(&writer->current_wal))
 		return 0;
 
-	if (xdir_create_xlog(&writer->wal_dir, &writer->current_wal,
-			     &writer->vclock) != 0)
+	if (xdir_create_materialized_xlog(&writer->wal_dir,
+					  &writer->current_wal,
+					  &writer->vclock) != 0)
 		return -1;
 	/*
 	 * Keep track of the new WAL vclock. Required for garbage
@@ -1314,8 +1315,8 @@ wal_writer_f(va_list ap)
 	     vclock_compare(&writer->vclock,
 			    &writer->current_wal.meta.vclock) > 0)) {
 		struct xlog l;
-		if (xdir_create_xlog(&writer->wal_dir, &l,
-				     &writer->vclock) == 0)
+		if (xdir_create_materialized_xlog(&writer->wal_dir, &l,
+						  &writer->vclock) == 0)
 			wal_xlog_close(&l);
 		else
 			diag_log();

--- a/src/box/xlog.h
+++ b/src/box/xlog.h
@@ -227,8 +227,7 @@ xdir_set_retention_vclock(struct xdir *xdir, struct vclock *vclock);
  * sum, and a suffix (.inprogress or not).
  */
 const char *
-xdir_format_filename(struct xdir *dir, int64_t signature,
-		     enum log_suffix suffix);
+xdir_format_filename(struct xdir *dir, int64_t signature);
 
 /**
  * Return true if the given directory index has files whose

--- a/src/box/xlog.h
+++ b/src/box/xlog.h
@@ -89,17 +89,6 @@ extern const struct xlog_opts xlog_opts_default;
 /* {{{ log dir */
 
 /**
- * Type of log directory. A single filesystem directory can be
- * used for write ahead logs, memtx snapshots or vinyl run files,
- * but an xlog object sees only those files which match its type.
- */
-enum xdir_type {
-	SNAP,		/* memtx snapshot */
-	XLOG,		/* write ahead log */
-	VYLOG,		/* vinyl metadata log */
-};
-
-/**
  * Suffix added to path of inprogress files.
  */
 #define inprogress_suffix ".inprogress"
@@ -122,6 +111,11 @@ struct xdir {
 	 */
 	bool force_recovery;
 	/**
+	 * Store vclock of the previous file in the meta to
+	 * check for gaps on recovery.
+	 */
+	bool store_prev_vclock;
+	/**
 	 * Additional flags to apply at open(2) to write.
 	 */
 	int open_wflags;
@@ -138,11 +132,11 @@ struct xdir {
 	 * XLOG (meaning it's a write ahead log) SNAP (a
 	 * snapshot) or VYLOG.
 	 */
-	const char *filetype;
+	char filetype[10];
 	/**
 	 * File name extension (.xlog or .snap).
 	 */
-	const char *filename_ext;
+	char filename_ext[11];
 	/** File create mode in this directory. */
 	mode_t mode;
 	/*
@@ -159,15 +153,13 @@ struct xdir {
 	 * Directory path.
 	 */
 	char dirname[PATH_MAX];
-	/** Snapshots or xlogs */
-	enum xdir_type type;
 };
 
 /**
  * Initialize a log dir.
  */
 void
-xdir_create(struct xdir *dir, const char *dirname, enum xdir_type type,
+xdir_create(struct xdir *dir, const char *dirname, const char *filetype,
 	    const struct tt_uuid *instance_uuid, const struct xlog_opts *opts);
 
 /**

--- a/src/box/xlog.h
+++ b/src/box/xlog.h
@@ -100,13 +100,6 @@ enum xdir_type {
 };
 
 /**
- * Newly created snapshot files get .inprogress filename suffix.
- * The suffix is removed  when the file is finished
- * and closed.
- */
-enum log_suffix { NONE, INPROGRESS };
-
-/**
  * Suffix added to path of inprogress files.
  */
 #define inprogress_suffix ".inprogress"
@@ -128,8 +121,6 @@ struct xdir {
 	 * are skipped.
 	 */
 	bool force_recovery;
-	/* Default filename suffix for a new file. */
-	enum log_suffix suffix;
 	/**
 	 * Additional flags to apply at open(2) to write.
 	 */
@@ -467,6 +458,7 @@ xdir_touch_xlog(struct xdir *dir, const struct vclock *vclock);
  * Create a new file and open it in write (append) mode.
  * Note: an existing file is impossible to open for append,
  * the old files are never appended to.
+ * Note: the new xlog isn't materialized, see xlog_materialize().
  *
  * @param xdir xdir
  * @param[out] xlog xlog structure
@@ -480,6 +472,13 @@ xdir_touch_xlog(struct xdir *dir, const struct vclock *vclock);
 int
 xdir_create_xlog(struct xdir *dir, struct xlog *xlog,
 		 const struct vclock *vclock);
+
+/**
+ * Shortcut for xdir_create_xlog() + xlog_materialize().
+ */
+int
+xdir_create_materialized_xlog(struct xdir *dir, struct xlog *xlog,
+			      const struct vclock *vclock);
 
 /**
  * Create new xlog writer based on fd.

--- a/test/unit/xlog.c
+++ b/test/unit/xlog.c
@@ -35,7 +35,7 @@ create_xlog(struct xlog *xlog, char *dirname)
 	memset(&tt_uuid, 1, sizeof(tt_uuid));
 	memset(&vclock, 0, sizeof(vclock));
 
-	xdir_create(&xdir, dirname, XLOG, &tt_uuid, &xlog_opts_default);
+	xdir_create(&xdir, dirname, "XLOG", &tt_uuid, &xlog_opts_default);
 
 	fail_if(xdir_create_materialized_xlog(&xdir, xlog, &vclock) < 0);
 }

--- a/test/unit/xlog.c
+++ b/test/unit/xlog.c
@@ -37,7 +37,7 @@ create_xlog(struct xlog *xlog, char *dirname)
 
 	xdir_create(&xdir, dirname, XLOG, &tt_uuid, &xlog_opts_default);
 
-	fail_if(xdir_create_xlog(&xdir, xlog, &vclock) < 0);
+	fail_if(xdir_create_materialized_xlog(&xdir, xlog, &vclock) < 0);
 }
 
 /**


### PR DESCRIPTION
To use xdir in EE, one has to add a new type to the CE repository, which is inconvenient. Let's refactor xdir so that one can specify an arbitrary type string and drop the xdir type enumeration.

Needed for https://github.com/tarantool/tarantool-ee/issues/1254