### PR TITLE
[backport: release/3.2] cmake: fix LTO build on Fedora

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -32,6 +32,21 @@ function(create_unit_test)
   add_executable(${UNIT_PREFIX}.test ${UNIT_SOURCES})
   target_compile_definitions(${UNIT_PREFIX}.test PRIVATE ${UNIT_COMPILE_DEFINITIONS})
   target_link_libraries(${UNIT_PREFIX}.test ${UNIT_LIBRARIES})
+  # FIXME: Since version 3.4, CMake doesn't add flags to export
+  # symbols from executables without the ENABLE_EXPORTS target
+  # property, see CMP0065 [1] for details. Without this property,
+  # some unit tests produce build warnings with LTO optimization
+  # enabled (for example, on Fedora 39), see also [2].
+  # [1]: https://cmake.org/cmake/help/latest/policy/CMP0065.html
+  # [2]: https://github.com/tarantool/tarantool/issues/11517
+  if(ENABLE_LTO)
+      # The CMP0065 is removed from CMake version 4.0 [1].
+      # Thus, set the ENABLE_EXPORTS directly.
+      # [1]: https://cmake.org/cmake/help/latest/manual/cmake-policies.7.html#policies-introduced-by-cmake-3-4-removed-by-cmake-4-0
+      set_target_properties(${UNIT_PREFIX}.test
+          PROPERTIES ENABLE_EXPORTS TRUE
+      )
+  endif()
   set(UNIT_TEST_TARGETS "${UNIT_TEST_TARGETS} ${UNIT_PREFIX}.test" PARENT_SCOPE)
 endfunction()
 


### PR DESCRIPTION
This patch is a follow-up to the commit
25af976f5279720079e00be390fb065d1ea5446d ("build: support cmake 4.0"). Since version 3.4, CMake doesn't add flags to export symbols from executables without the ENABLE_EXPORTS target property, see CMP0065 [1] for details.  Without this property, some unit C tests produce build warnings with LTO optimization enabled (for example, on Fedora 39):

NO_WRAP
```
[ 72%] Linking CXX executable luaT_tuple_new.test
In function ‘rmean_collect’,
    inlined from ‘txn_complete_success’ at src/box/txn.c:836:2,
    inlined from ‘txn_limbo_complete’ at src/box/txn_limbo.c:205:3:
src/lib/core/rmean.c:65:9: error: ‘__atomic_add_fetch_8’ writing 8 bytes into a region of size 0 overflows the destination [-Werror=stringop-overflow=]
   65 |         __atomic_add_fetch(&rmean->stats[name].value[0], value, __ATOMIC_RELAXED);
      |         ^
In function ‘txn_limbo_complete’:
lto1: note: destination object is likely at address zero
```
NO_WRAP

The real reason should be investigated in the scope of #11517. The compilation warning may be suppressed, but it may also mask the actual problems in the future tests. The CMP0065 is removed from CMake version 4.0 [2]. Thus, this patch fixes the behaviour by setting the property `ENABLE_EXPORTS` for unit tests directly.

[1]: https://cmake.org/cmake/help/latest/policy/CMP0065.html
[2]: https://cmake.org/cmake/help/latest/manual/cmake-policies.7.html#policies-introduced-by-cmake-3-4-removed-by-cmake-4-0

NO_DOC=build
NO_TEST=build
NO_CHANGELOG=build

(cherry picked from commit 2bde9262e7ec437c65dca243cf2b0a6dff3d63c7)