### PR TITLE
ci: drop unused inputs for distrib workflow

### DIFF
--- a/.github/workflows/distrib.yml
+++ b/.github/workflows/distrib.yml
@@ -10,16 +10,6 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize, labeled ]
   workflow_dispatch:
-  workflow_call:
-    inputs:
-      submodule:
-        description: Name of submodule to bump.
-        required: true
-        type: string
-      revision:
-        description: Git revision from submodule repository
-        required: true
-        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow


### PR DESCRIPTION
This patch is a follow-up for the commit
d1574f794da59786daabb3a9a5d069d77c074fda ("ci: disable the reusable run for some workflows"). It has removed the inputs usage from the distrib.yml workflow (former packaging.yml), but didn't remove inputs declaration at the beginning like for other workflows. This patch drops unused inputs.

NO_DOC=CI
NO_TEST=CI
NO_CHANGELOG=CI