### PR TITLE
memtx: disallow alter of primary index with dependent secondary

### DIFF
--- a/changelogs/unreleased/gh-10951-alter-pk-with-dependent-sk.md
+++ b/changelogs/unreleased/gh-10951-alter-pk-with-dependent-sk.md
@@ -1,0 +1,5 @@
+## bugfix/memtx
+
+* Disallowed alteration of the primary index in a space with
+  non-unique or nullable secondary indexes because such alters
+  would crash Tarantool (gh-10951).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -1876,18 +1876,42 @@ alter_space_move_indexes(struct alter_space *alter, uint32_t begin,
 					old_def->key_def, alter->pk_def);
 		index_def_update_optionality(new_def, min_field_count);
 		auto guard = make_scoped_guard([=] { index_def_delete(new_def); });
-		if (!index_def_change_requires_rebuild(old_index, new_def))
+		bool space_is_empty = index_size(space_index(old_space, 0)) == 0;
+		if (!index_def_change_requires_rebuild(old_index, new_def)) {
 			try {
 				(void) new ModifyIndex(alter, old_index, new_def);
 			} catch (Exception *e) {
 				return -1;
 			}
-		else
+		} else if (space_is_empty && !space_is_vinyl(old_space)) {
+			/*
+			 * Allow to rebuild indexes for empty space since it
+			 * doesn't actually yield, see the next branch comment
+			 * to see why it's bad.
+			 *
+			 * Note that it's not safe for vinyl because it can sync
+			 * WAL, hence, yield, even if the space is empty.
+			 */
 			try {
 				(void) new RebuildIndex(alter, new_def, old_def);
 			} catch (Exception *e) {
 				return -1;
 			}
+		} else {
+			/*
+			 * Rebuild of several indexes in one statement is broken
+			 * because we need to maintain consistency of built
+			 * indexes while building the next ones, and we don't.
+			 * So when build of the next index yields and new tuples
+			 * appear in the space, already built indexes are not
+			 * populated with them. So simply forbid such alters.
+			 */
+			diag_set(ClientError, ER_UNSUPPORTED, "Tarantool",
+				 "non-trivial alter of primary index along "
+				 "with rebuild of dependent secondary "
+				 "indexes");
+			return -1;
+		}
 		guard.is_active = false;
 	}
 	return 0;

--- a/test/box/tree_pk.result
+++ b/test/box/tree_pk.result
@@ -608,7 +608,26 @@ i3:select{box.NULL}
   - [6, 1, null, 2]
   - [7, 1, null, 100]
 ...
+-- Alter of PK is forbidden
 i1:alter{parts = {4, 'unsigned'}}
+---
+- error: Tarantool does not support non-trivial alter of primary index along with
+    rebuild of dependent secondary indexes
+...
+-- Drop indexes, alter PK, and create them again
+i2:drop()
+---
+...
+i3:drop()
+---
+...
+i1:alter{parts = {4, 'unsigned'}}
+---
+...
+i2 = s:create_index('i2', { type = 'tree', parts = {2, 'unsigned'}, unique = false })
+---
+...
+i3 = s:create_index('i3', { type = 'tree', parts = {{3, 'unsigned', is_nullable = true}}, unique = true })
 ---
 ...
 i2:select{1}
@@ -642,7 +661,19 @@ i3:select{box.NULL}
 s:truncate()
 ---
 ...
+i2:drop()
+---
+...
+i3:drop()
+---
+...
 i1:alter{parts = {1, 'str'}}
+---
+...
+i2 = s:create_index('i2', { type = 'tree', parts = {2, 'unsigned'}, unique = false })
+---
+...
+i3 = s:create_index('i3', { type = 'tree', parts = {{3, 'unsigned', is_nullable = true}}, unique = true })
 ---
 ...
 _ = s:replace{"5", 1, box.NULL}

--- a/test/box/tree_pk.test.lua
+++ b/test/box/tree_pk.test.lua
@@ -214,14 +214,28 @@ i2:select{2}
 i2:select{1, 5}
 i3:select{box.NULL}
 
+-- Alter of PK is forbidden
 i1:alter{parts = {4, 'unsigned'}}
+
+-- Drop indexes, alter PK, and create them again
+i2:drop()
+i3:drop()
+i1:alter{parts = {4, 'unsigned'}}
+i2 = s:create_index('i2', { type = 'tree', parts = {2, 'unsigned'}, unique = false })
+i3 = s:create_index('i3', { type = 'tree', parts = {{3, 'unsigned', is_nullable = true}}, unique = true })
+
 i2:select{1}
 i2:select{2}
 i2:select{1, 1}
 i3:select{box.NULL}
 
 s:truncate()
+i2:drop()
+i3:drop()
 i1:alter{parts = {1, 'str'}}
+i2 = s:create_index('i2', { type = 'tree', parts = {2, 'unsigned'}, unique = false })
+i3 = s:create_index('i3', { type = 'tree', parts = {{3, 'unsigned', is_nullable = true}}, unique = true })
+
 _ = s:replace{"5", 1, box.NULL}
 _ = s:replace{"4", 1, box.NULL}
 _ = s:replace{"6", 1, box.NULL}

--- a/test/engine-luatest/gh_10951_memtx_alter_pk_with_dependent_sk_test.lua
+++ b/test/engine-luatest/gh_10951_memtx_alter_pk_with_dependent_sk_test.lua
@@ -1,0 +1,106 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group(nil, {{engine = 'vinyl'}, {engine = 'memtx'}})
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.before_each(function(cg)
+    cg.server:exec(function(engine)
+        local s = box.schema.create_space('test', {engine = engine})
+        s:create_index('pk')
+        box.begin()
+        for i = 1, 10000 do
+            s:replace{i, i}
+        end
+        box.commit()
+    end, {cg.params.engine})
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        box.space.test:drop()
+    end)
+end)
+
+g.test_empty_index = function(cg)
+    cg.server:exec(function(engine)
+        local s = box.space.test
+        s:truncate()
+
+        s:create_index('sk1', {unique = false})
+        s:create_index('sk2', {parts = {2, 'unsigned', is_nullable = true}})
+
+        if engine == 'memtx' then
+            -- Empty space should be succesfully altered in memtx.
+            s.index.pk:alter({parts = {2, 'unsigned'}})
+        else
+            assert(engine == 'vinyl')
+            t.assert_error_covers({
+                type = "ClientError",
+                name = "UNSUPPORTED",
+                message = "Tarantool does not support non-trivial alter of " ..
+                          "primary index along with rebuild of dependent " ..
+                          "secondary indexes",
+            }, s.index.pk.alter, s.index.pk, {parts = {2, 'unsigned'}})
+        end
+    end, {cg.params.engine})
+end
+
+g.test_unique_index = function(cg)
+    cg.server:exec(function(engine)
+        local s = box.space.test
+        s:create_index('sk', {unique = true})
+
+        if engine == 'memtx' then
+            -- Unique non-nullable index in memtx doesn't depend on PK.
+            s.index.pk:alter({parts = {2, 'unsigned'}})
+        else
+            assert(engine == 'vinyl')
+            t.assert_error_covers({
+                type = "ClientError",
+                name = "UNSUPPORTED",
+                message = "Tarantool does not support non-trivial alter of " ..
+                          "primary index along with rebuild of dependent " ..
+                          "secondary indexes",
+            }, s.index.pk.alter, s.index.pk, {parts = {2, 'unsigned'}})
+        end
+    end, {cg.params.engine})
+end
+
+g.test_non_unique_index = function(cg)
+    cg.server:exec(function(engine)
+        local s = box.space.test
+        s:create_index('sk', {unique = false})
+
+        t.assert_error_covers({
+            type = "ClientError",
+            name = "UNSUPPORTED",
+            message = "Tarantool does not support non-trivial alter of " ..
+                      "primary index along with rebuild of dependent " ..
+                      "secondary indexes",
+        }, s.index.pk.alter, s.index.pk, {parts = {2, 'unsigned'}})
+    end, {cg.params.engine})
+end
+
+g.test_nullable_index = function(cg)
+    cg.server:exec(function(engine)
+        local s = box.space.test
+        s:create_index('sk', {parts = {2, 'unsigned', is_nullable = true}})
+
+        t.assert_error_covers({
+            type = "ClientError",
+            name = "UNSUPPORTED",
+            message = "Tarantool does not support non-trivial alter of " ..
+                      "primary index along with rebuild of dependent " ..
+                      "secondary indexes",
+        }, s.index.pk.alter, s.index.pk, {parts = {2, 'unsigned'}})
+    end, {cg.params.engine})
+end


### PR DESCRIPTION
Rebuild of several indexes in one statement is broken because we need to maintain consistency of built indexes while building the next ones, and we don't do that. Such rebuilds can happen only when primary index is altered and all non-unique and nullable indexes need to be rebuilt as well. Let's simply forbid such alters.

We could forbid any alter of primary index, and the patch would be even a bit simpler, but let's allow to alter primary in a space without dependent secondary indexes - it seems to work fine, and people would use it, at least someone reported this problem, hence, someone actually tried to alter primary.

Closes #10951