### PR TITLE
lib: fix build error with fresh gcc compiler

### DIFF
--- a/src/lib/tzcode/localtime.c
+++ b/src/lib/tzcode/localtime.c
@@ -307,6 +307,9 @@ union input_buffer {
 };
 
 /* TZDIR with a trailing '/' rather than a trailing '\0'.  */
+#if __has_attribute(nonstring)
+__attribute__((nonstring))
+#endif
 static char const tzdirslash[sizeof TZDIR] = TZDIR "/";
 
 /* Local storage needed for 'tzloadbody'.  */

--- a/test/unit/uuid.c
+++ b/test/unit/uuid.c
@@ -122,13 +122,13 @@ main(void)
                                 .time_hi_and_version = 18482,
                                 .clock_seq_hi_and_reserved = 175,
                                 .clock_seq_low = 139,
-                                .node = "Ad\325,b\353"},
+                                .node = {'A', 'd', '\325', ',', 'b', '\353'}},
                 (struct tt_uuid){.time_low = 409910263,
                                 .time_mid = 53143,
                                 .time_hi_and_version = 20014,
                                 .clock_seq_hi_and_reserved = 139,
                                 .clock_seq_low = 27,
-                                .node = "v\025Oo9I"},
+                                .node = {'v', '\025', 'O', 'o', '9', 'I'}},
                 1);
 
 
@@ -138,13 +138,13 @@ main(void)
                                 .time_hi_and_version = 11903,
                                 .clock_seq_hi_and_reserved = 175,
                                 .clock_seq_low = 80,
-                                .node = "Ad\325,b\353"},
+                                .node = {'A', 'd', '\325', ',', 'b', '\353'}},
                 (struct tt_uuid){.time_low = 532451999,
                                 .time_mid = 23976,
                                 .time_hi_and_version = 10437,
                                 .clock_seq_hi_and_reserved = 139,
                                 .clock_seq_low = 54,
-                                .node = "v\025Oo9I"},
+                                .node = {'v', '\025', 'O', 'o', '9', 'I'}},
                 -1);
 
         mp_uuid_test();


### PR DESCRIPTION
Build start to fail with my distro's new gcc version 15.1.1:

```
in file included from /home/shiny/dev/tarantool/src/lib/tzcode/localtime.c:18:
/home/shiny/dev/tarantool/src/lib/tzcode/tzfile.h:25:15: error: initializer-string for array of ‘char’ truncates NUL terminator but destination lacks ‘nonstring’ attribute (2> 1 chars into 20 available) [-Werror=unterminated-string-initialization]
   25 | #define TZDIR "/usr/share/zoneinfo" /* Time zone object file directory */
      |               ^~~~~~~~~~~~~~~~~~~~~
/home/shiny/dev/tarantool/src/lib/tzcode/localtime.c:310:46: note: in expansion of macro ‘TZDIR’
  310 | static char const tzdirslash[sizeof TZDIR] = TZDIR "/";
      |
```

Fix by adding `__attribute((nonstring))__` where required.