### PR TITLE
[backport: release/3.2] ci: add Tarantool's revision in reusable workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,6 +19,11 @@ on:
         description: Git revision from submodule repository
         required: true
         type: string
+      tarantool_revision:
+        description: Git revision for the Tarantool repository
+        required: false
+        default: 'master'
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -74,7 +79,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           repository: tarantool/tarantool
-          ref: ${{ inputs.submodule && 'master' || github.ref }}
+          ref: ${{ inputs.tarantool_revision || github.ref }}
 
       - name: Set environment
         uses: ./.github/actions/environment

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -19,6 +19,11 @@ on:
         description: Git revision from submodule repository
         required: true
         type: string
+      tarantool_revision:
+        description: Git revision for the Tarantool repository
+        required: false
+        default: 'master'
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -74,7 +79,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           repository: tarantool/tarantool
-          ref: ${{ inputs.submodule && 'master' || github.ref }}
+          ref: ${{ inputs.tarantool_revision || github.ref }}
 
       - name: Set environment
         uses: ./.github/actions/environment

--- a/.github/workflows/debug_aarch64.yml
+++ b/.github/workflows/debug_aarch64.yml
@@ -20,6 +20,11 @@ on:
         description: Git revision from submodule repository
         required: true
         type: string
+      tarantool_revision:
+        description: Git revision for the Tarantool repository
+        required: false
+        default: 'master'
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -73,7 +78,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           repository: tarantool/tarantool
-          ref: ${{ inputs.submodule && 'master' || github.ref }}
+          ref: ${{ inputs.tarantool_revision || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian

--- a/.github/workflows/debug_asan_clang.yml
+++ b/.github/workflows/debug_asan_clang.yml
@@ -20,6 +20,11 @@ on:
         description: Git revision from submodule repository
         required: true
         type: string
+      tarantool_revision:
+        description: Git revision for the Tarantool repository
+        required: false
+        default: 'master'
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -74,7 +79,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           repository: tarantool/tarantool
-          ref: ${{ inputs.submodule && 'master' || github.ref }}
+          ref: ${{ inputs.tarantool_revision || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian

--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -20,6 +20,11 @@ on:
         description: Git revision from submodule repository
         required: true
         type: string
+      tarantool_revision:
+        description: Git revision for the Tarantool repository
+        required: false
+        default: 'master'
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -63,7 +68,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           repository: tarantool/tarantool
-          ref: ${{ inputs.submodule && 'master' || github.ref }}
+          ref: ${{ inputs.tarantool_revision || github.ref }}
       - uses: ./.github/actions/environment
       - name: Optional submodule bump
         if: ${{ inputs.submodule }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,6 +20,11 @@ on:
         description: Git revision from submodule repository
         required: true
         type: string
+      tarantool_revision:
+        description: Git revision for the Tarantool repository
+        required: false
+        default: 'master'
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -51,7 +56,7 @@ jobs:
 
     uses: tarantool/tarantool/.github/workflows/reusable_build.yml@master
     with:
-      ref: ${{ inputs.submodule && 'master' || github.ref }}
+      ref: ${{ inputs.tarantool_revision || github.ref }}
       os: ubuntu
       dist: focal
       submodule: ${{ inputs.submodule }}

--- a/.github/workflows/memtx_allocator_based_on_malloc.yml
+++ b/.github/workflows/memtx_allocator_based_on_malloc.yml
@@ -20,6 +20,11 @@ on:
         description: Git revision from submodule repository
         required: true
         type: string
+      tarantool_revision:
+        description: Git revision for the Tarantool repository
+        required: false
+        default: 'master'
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -73,7 +78,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           repository: tarantool/tarantool
-          ref: ${{ inputs.submodule && 'master' || github.ref }}
+          ref: ${{ inputs.tarantool_revision || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian

--- a/.github/workflows/out_of_source.yml
+++ b/.github/workflows/out_of_source.yml
@@ -20,6 +20,11 @@ on:
         description: Git revision from submodule repository
         required: true
         type: string
+      tarantool_revision:
+        description: Git revision for the Tarantool repository
+        required: false
+        default: 'master'
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -73,7 +78,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           repository: tarantool/tarantool
-          ref: ${{ inputs.submodule && 'master' || github.ref }}
+          ref: ${{ inputs.tarantool_revision || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian

--- a/.github/workflows/perf_micro.yml
+++ b/.github/workflows/perf_micro.yml
@@ -19,6 +19,11 @@ on:
         description: Git revision from submodule repository
         required: true
         type: string
+      tarantool_revision:
+        description: Git revision for the Tarantool repository
+        required: false
+        default: 'master'
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -64,7 +69,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           repository: tarantool/tarantool
-          ref: ${{ inputs.submodule && 'master' || github.ref }}
+          ref: ${{ inputs.tarantool_revision || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ on:
         description: Git revision from submodule repository
         required: true
         type: string
+      tarantool_revision:
+        description: Git revision for the Tarantool repository
+        required: false
+        default: 'master'
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -73,7 +78,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           repository: tarantool/tarantool
-          ref: ${{ inputs.submodule && 'master' || github.ref }}
+          ref: ${{ inputs.tarantool_revision || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian

--- a/.github/workflows/release_asan_clang.yml
+++ b/.github/workflows/release_asan_clang.yml
@@ -20,6 +20,11 @@ on:
         description: Git revision from submodule repository
         required: true
         type: string
+      tarantool_revision:
+        description: Git revision for the Tarantool repository
+        required: false
+        default: 'master'
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -74,7 +79,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           repository: tarantool/tarantool
-          ref: ${{ inputs.submodule && 'master' || github.ref }}
+          ref: ${{ inputs.tarantool_revision || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -20,6 +20,11 @@ on:
         description: Git revision from submodule repository
         required: true
         type: string
+      tarantool_revision:
+        description: Git revision for the Tarantool repository
+        required: false
+        default: 'master'
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -73,7 +78,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           repository: tarantool/tarantool
-          ref: ${{ inputs.submodule && 'master' || github.ref }}
+          ref: ${{ inputs.tarantool_revision || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian

--- a/.github/workflows/release_lto.yml
+++ b/.github/workflows/release_lto.yml
@@ -20,6 +20,11 @@ on:
         description: Git revision from submodule repository
         required: true
         type: string
+      tarantool_revision:
+        description: Git revision for the Tarantool repository
+        required: false
+        default: 'master'
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -73,7 +78,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           repository: tarantool/tarantool
-          ref: ${{ inputs.submodule && 'master' || github.ref }}
+          ref: ${{ inputs.tarantool_revision || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian

--- a/.github/workflows/release_lto_clang.yml
+++ b/.github/workflows/release_lto_clang.yml
@@ -20,6 +20,11 @@ on:
         description: Git revision from submodule repository
         required: true
         type: string
+      tarantool_revision:
+        description: Git revision for the Tarantool repository
+        required: false
+        default: 'master'
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -73,7 +78,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           repository: tarantool/tarantool
-          ref: ${{ inputs.submodule && 'master' || github.ref }}
+          ref: ${{ inputs.tarantool_revision || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -20,6 +20,11 @@ on:
         description: Git revision from submodule repository
         required: true
         type: string
+      tarantool_revision:
+        description: Git revision for the Tarantool repository
+        required: false
+        default: 'master'
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -74,7 +79,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           repository: tarantool/tarantool
-          ref: ${{ inputs.submodule && 'master' || github.ref }}
+          ref: ${{ inputs.tarantool_revision || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian

--- a/.github/workflows/static_build_cmake_linux.yml
+++ b/.github/workflows/static_build_cmake_linux.yml
@@ -20,6 +20,11 @@ on:
         description: Git revision from submodule repository
         required: true
         type: string
+      tarantool_revision:
+        description: Git revision for the Tarantool repository
+        required: false
+        default: 'master'
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -74,7 +79,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           repository: tarantool/tarantool
-          ref: ${{ inputs.submodule && 'master' || github.ref }}
+          ref: ${{ inputs.tarantool_revision || github.ref }}
       - uses: ./.github/actions/environment
       - name: Install deps
         uses: ./.github/actions/install-deps-debian


### PR DESCRIPTION
There is no way to detect the revision of the Tarantool or Tarantool's workflow, which is called in the role of a reusable workflow, since all context is determined by the caller [1]. When a reusable workflow is called on the non-master Tarantool branch, it is desirable to check out Tarantool to the corresponding branch. For now this branch is hardcoded as master, and it is easy to forget to update the hardcoded value after creating a new branch for the Tarantool's release. OTOH, the caller should already update the target branch in its own workflow, so it is easier to maintain this logic in one place (the caller's workflow). Thus, this patch adds an additional optional parameter -- revision of the Tarantool to be checked out during the integration. It is set to 'master' by default to avoid breaking existing workflow integration.

[1]: https://docs.github.com/en/actions/sharing-automations/reusing-workflows

NO_DOC=ci
NO_TEST=ci
NO_CHANGELOG=ci

(cherry picked from commit 5465e559074ac7431d83964fdbe24a29a0eaeae1)

---

Backport for the #11519.
The difference between cherry-picked commit and the original one is the following patch:
```diff
diff --git a/.github/workflows/default_gcc_centos_7.yml b/.github/workflows/default_gcc_centos_7.yml
index 8a120e20c..ea21718a5 100644
--- a/.github/workflows/default_gcc_centos_7.yml
+++ b/.github/workflows/default_gcc_centos_7.yml
@@ -20,6 +20,11 @@ on:
         description: Git revision from submodule repository
         required: true
         type: string
+      tarantool_revision:
+        description: Git revision for the Tarantool repository
+        required: false
+        default: 'master'
+        type: string
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow
@@ -63,7 +68,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           repository: tarantool/tarantool
-          ref: ${{ inputs.submodule && 'master' || github.ref }}
+          ref: ${{ inputs.tarantool_revision || github.ref }}
       - uses: ./.github/actions/environment
       - name: Optional submodule bump
         if: ${{ inputs.submodule }}
```

Also, the part related to the `config_jsonschema_check` workflow is omitted, since it was introduced in 3.3. The conflicts in the `perf_micro` are fixed (related to the performance workflow refactoring in 3.3, such as the cron-sceduled run of the job and the `env.PERF_COMMIT` variable). 