### PR TITLE
box: disallow alter of primary index with dependent secondary

### DIFF
--- a/changelogs/unreleased/gh-10951-alter-pk-with-dependent-sk.md
+++ b/changelogs/unreleased/gh-10951-alter-pk-with-dependent-sk.md
@@ -1,0 +1,5 @@
+## bugfix/memtx
+
+* Disallowed alteration of the primary index in a space with
+  non-unique or nullable secondary indexes because such alters
+  would crash Tarantool (gh-10951).

--- a/test/box/tree_pk.result
+++ b/test/box/tree_pk.result
@@ -608,7 +608,26 @@ i3:select{box.NULL}
   - [6, 1, null, 2]
   - [7, 1, null, 100]
 ...
+-- Alter of PK is forbidden
 i1:alter{parts = {4, 'unsigned'}}
+---
+- error: Tarantool does not support non-trivial alter of primary index along with
+    rebuild of dependent secondary indexes
+...
+-- Drop indexes, alter PK, and create them again
+i2:drop()
+---
+...
+i3:drop()
+---
+...
+i1:alter{parts = {4, 'unsigned'}}
+---
+...
+i2 = s:create_index('i2', { type = 'tree', parts = {2, 'unsigned'}, unique = false })
+---
+...
+i3 = s:create_index('i3', { type = 'tree', parts = {{3, 'unsigned', is_nullable = true}}, unique = true })
 ---
 ...
 i2:select{1}
@@ -642,7 +661,19 @@ i3:select{box.NULL}
 s:truncate()
 ---
 ...
+i2:drop()
+---
+...
+i3:drop()
+---
+...
 i1:alter{parts = {1, 'str'}}
+---
+...
+i2 = s:create_index('i2', { type = 'tree', parts = {2, 'unsigned'}, unique = false })
+---
+...
+i3 = s:create_index('i3', { type = 'tree', parts = {{3, 'unsigned', is_nullable = true}}, unique = true })
 ---
 ...
 _ = s:replace{"5", 1, box.NULL}

--- a/test/box/tree_pk.test.lua
+++ b/test/box/tree_pk.test.lua
@@ -214,14 +214,28 @@ i2:select{2}
 i2:select{1, 5}
 i3:select{box.NULL}
 
+-- Alter of PK is forbidden
 i1:alter{parts = {4, 'unsigned'}}
+
+-- Drop indexes, alter PK, and create them again
+i2:drop()
+i3:drop()
+i1:alter{parts = {4, 'unsigned'}}
+i2 = s:create_index('i2', { type = 'tree', parts = {2, 'unsigned'}, unique = false })
+i3 = s:create_index('i3', { type = 'tree', parts = {{3, 'unsigned', is_nullable = true}}, unique = true })
+
 i2:select{1}
 i2:select{2}
 i2:select{1, 1}
 i3:select{box.NULL}
 
 s:truncate()
+i2:drop()
+i3:drop()
 i1:alter{parts = {1, 'str'}}
+i2 = s:create_index('i2', { type = 'tree', parts = {2, 'unsigned'}, unique = false })
+i3 = s:create_index('i3', { type = 'tree', parts = {{3, 'unsigned', is_nullable = true}}, unique = true })
+
 _ = s:replace{"5", 1, box.NULL}
 _ = s:replace{"4", 1, box.NULL}
 _ = s:replace{"6", 1, box.NULL}

--- a/test/engine-luatest/gh_10951_memtx_alter_pk_with_dependent_sk_test.lua
+++ b/test/engine-luatest/gh_10951_memtx_alter_pk_with_dependent_sk_test.lua
@@ -1,0 +1,89 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group(nil, {{engine = 'vinyl'}, {engine = 'memtx'}})
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+    cg.server:exec(function()
+        -- Checks that rebuild of index (that is passed as `func`) is disabled.
+        local function check_rebuild_disabled(func, ...)
+            t.assert_error_covers({
+                type = "ClientError",
+                name = "UNSUPPORTED",
+                message = "Tarantool does not support non-trivial alter of " ..
+                          "primary index along with rebuild of dependent " ..
+                          "secondary indexes",
+            }, func, ...)
+        end
+        rawset(_G, 'check_rebuild_disabled', check_rebuild_disabled)
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.before_each(function(cg)
+    cg.server:exec(function(engine)
+        local fiber = require('fiber')
+
+        local s = box.schema.create_space('test', {engine = engine})
+        s:create_index('pk')
+
+        fiber.set_slice(30)
+        box.begin()
+        for i = 1, 2000 do
+            s:replace{i, i}
+        end
+        box.commit()
+    end, {cg.params.engine})
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        box.space.test:drop()
+    end)
+end)
+
+g.test_unique_index = function(cg)
+    cg.server:exec(function(engine)
+        local check_rebuild_disabled = rawget(_G, 'check_rebuild_disabled')
+
+        local s = box.space.test
+        s:create_index('sk', {unique = true})
+
+        if engine == 'memtx' then
+            -- Unique non-nullable index in memtx doesn't depend on PK.
+            s.index.pk:alter({parts = {2, 'unsigned'}})
+        else
+            assert(engine == 'vinyl')
+            check_rebuild_disabled(s.index.pk.alter, s.index.pk,
+                                   {parts = {2, 'unsigned'}})
+        end
+    end, {cg.params.engine})
+end
+
+g.test_non_unique_index = function(cg)
+    cg.server:exec(function()
+        local check_rebuild_disabled = rawget(_G, 'check_rebuild_disabled')
+
+        local s = box.space.test
+        s:create_index('sk', {unique = false})
+
+        check_rebuild_disabled(s.index.pk.alter, s.index.pk,
+                               {parts = {2, 'unsigned'}})
+    end)
+end
+
+g.test_nullable_index = function(cg)
+    cg.server:exec(function()
+        local check_rebuild_disabled = rawget(_G, 'check_rebuild_disabled')
+
+        local s = box.space.test
+        s:create_index('sk', {parts = {2, 'unsigned', is_nullable = true}})
+        check_rebuild_disabled(s.index.pk.alter, s.index.pk,
+                               {parts = {2, 'unsigned'}})
+    end)
+end


### PR DESCRIPTION
Rebuild of several indexes in one statement is broken because we need to maintain consistency of built indexes while building the next ones, and we don't do that. Such rebuilds can happen only when primary index is altered and all non-unique and nullable indexes need to be rebuilt as well. Let's simply forbid such alters.

We could forbid any alter of primary index, and the patch would be even a bit simpler, but let's allow to alter primary in a space without dependent secondary indexes - it seems to work fine, and people would use it, at least someone reported this problem, hence, someone actually tried to alter primary.

Closes #10951