### PR TITLE
config: add ro_reason to stateboard description

### DIFF
--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -2367,9 +2367,11 @@ I['stateboard'] = format_text([[
     the `config.*.prefix` option. The provided information is in YAML format
     with the following fields:
 
-    - `hostname` (`string`): hostname
-    - `pid` (`integer`): Tarantool process ID
+    - `hostname` (`string`): hostname.
+    - `pid` (`integer`): Tarantool process ID.
     - `mode` (`'ro'` or `'rw'`): instance mode (see `box.info.ro`).
+    - `ro_reason` (`string`): the reason why the instance is read-only (see
+      `box.info.ro_reason`).
     - `status` (`string`): instance status (see `box.info.status` for possible
       values and their description).
 ]])


### PR DESCRIPTION
This patch adds `ro_reason` field to the `stateboard` configuration
section. The section describes the information reported by instances to
remote storage having a stateboard client configured. Reporting
`ro_reason` supplies `box.info.ro_reason` allowing one to understand
why the instance is RO. Adding this option to the list of the reported
has been suggested later that's why it's added separately.

It also adds two missing dots at the end of the elements list in the
description just for consistency.

Part of tarantool/tarantool-ee#1229
