### PR TITLE
connpool: close unused connections automatically

### DIFF
--- a/changelogs/unreleased/connpool-close-unused-conns.md
+++ b/changelogs/unreleased/connpool-close-unused-conns.md
@@ -1,0 +1,6 @@
+## feature/connpool
+
+* `experimental.connpool` now automatically closes unused connections opened by
+  `connpool.call()` and `connpool.filter()`. This deadline can be configured
+  using the `connpool.set_idle_timeout()` method or the `connpool.idle_timeout`
+  configuration option.

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -49,6 +49,7 @@ lua_source(lua_sources lua/config/applier/autoexpel.lua    config_applier_autoex
 lua_source(lua_sources lua/config/applier/box_cfg.lua      config_applier_box_cfg_lua)
 lua_source(lua_sources lua/config/applier/runtime_priv.lua config_applier_runtime_priv_lua)
 lua_source(lua_sources lua/config/applier/compat.lua       config_applier_compat_lua)
+lua_source(lua_sources lua/config/applier/connpool.lua     config_applier_connpool_lua)
 lua_source(lua_sources lua/config/applier/console.lua      config_applier_console_lua)
 lua_source(lua_sources lua/config/applier/credentials.lua  config_applier_credentials_lua)
 lua_source(lua_sources lua/config/applier/fiber.lua        config_applier_fiber_lua)

--- a/src/box/lua/config/applier/connpool.lua
+++ b/src/box/lua/config/applier/connpool.lua
@@ -1,0 +1,19 @@
+local log = require('internal.config.utils.log')
+
+local function apply(config)
+    -- require() it here to avoid a circular dependency.
+    local connpool = require('experimental.connpool')
+
+    local configdata = config._configdata
+    local idle_timeout = configdata:get('connpool.idle_timeout',
+                                        {use_default = true})
+
+    connpool.set_idle_timeout(idle_timeout)
+
+    log.verbose(('connpool.apply: set idle timeout to %d'):format(idle_timeout))
+end
+
+return {
+    name = 'connpool',
+    apply = apply,
+}

--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -624,6 +624,21 @@ I['config.storage.timeout'] = format_text([[
 
 -- }}} config configuration
 
+-- {{{ connpool configuration
+
+I['connpool'] = format_text([[
+    The `connpool` section defines configuration parameters related to
+    the Tarantool connection pool that can be used to communicate with other
+    instances within the cluster.
+]])
+
+I['connpool.idle_timeout'] = format_text([[
+    A timeout (in seconds) in which the unused connections opened by
+    unused connections indirectly opened by connpool methods.
+]])
+
+-- }}} connpool configuration
+
 -- {{{ console configuration
 
 I['console'] = format_text([[

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -137,6 +137,7 @@ function methods._initialize(self)
     self:_register_applier(require('internal.config.applier.autoexpel'))
     self:_register_applier(require('internal.config.applier.roles').stage_2)
     self:_register_applier(require('internal.config.applier.app').stage_2)
+    self:_register_applier(require('internal.config.applier.connpool'))
 
     if extras ~= nil then
         extras.initialize(self)

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2211,6 +2211,12 @@ return schema.new('instance_config', schema.record({
             default = 10,
         }),
     })),
+    connpool = schema.record({
+        idle_timeout = schema.scalar({
+            type = 'number',
+            default = 60,
+        }),
+    }),
 }), {
     methods = {
         instance_uri = instance_uri,

--- a/src/box/lua/connpool.lua
+++ b/src/box/lua/connpool.lua
@@ -25,6 +25,50 @@ local function is_connection_valid(conn, opts)
     return true
 end
 
+function pool_methods._unused_connection_watchdog_step(self)
+    local now = fiber.clock()
+    local until_next_deadline = math.huge
+
+    for name, conn in pairs(self._connections) do
+        local until_deadline = conn._deadline - now
+
+        if until_deadline <= 0 then
+            if is_connection_valid(conn, {}) then
+                conn:close()
+            end
+
+            self._connections[name] = nil
+        elseif until_deadline < until_next_deadline then
+            until_next_deadline = until_deadline
+        end
+    end
+
+    return until_next_deadline
+end
+
+function pool_methods._unused_connection_watchdog_loop(self)
+    while true do
+        local until_next_deadline = self:_unused_connection_watchdog_step()
+
+        if until_next_deadline == math.huge then
+            break
+        end
+
+        self._unused_connection_watchdog_cond:wait(until_next_deadline)
+    end
+end
+
+function pool_methods._unused_connection_watchdog_wake(self)
+    local f = self._unused_connection_watchdog_fiber
+    if f ~= nil and f:status() ~= 'dead' then
+        self._unused_connection_watchdog_cond:broadcast()
+        return
+    end
+
+    f = fiber.new(self._unused_connection_watchdog_loop, self)
+    self._unused_connection_watchdog_fiber = f
+end
+
 --- Connect to an instance or receive a cached connection by
 --- name.
 ---
@@ -32,6 +76,7 @@ end
 --- and an error message as the second one.
 function pool_methods.connect(self, instance_name, opts)
     checks('table', 'string', {
+        ttl = '?number',
         connect_timeout = '?number',
         wait_connected = '?boolean',
         fetch_schema = '?boolean',
@@ -70,6 +115,15 @@ function pool_methods.connect(self, instance_name, opts)
             self._connection_mode_update_cond:broadcast()
         end
         conn:watch('box.status', watch_status)
+    end
+
+    local idle_timeout = opts.ttl or self._idle_timeout
+    local new_deadline = fiber.clock() + idle_timeout
+    local old_deadline = conn._deadline or 0
+
+    if new_deadline > old_deadline then
+        conn._deadline = new_deadline
+        self:_unused_connection_watchdog_wake()
     end
 
     -- If opts.wait_connected is not false we wait until the connection is
@@ -118,7 +172,7 @@ function pool_methods.connect_to_multiple(self, instances, opts)
 
     local delay = WATCHER_DELAY
     local timeout = opts.timeout or WATCHER_TIMEOUT
-    local connect_deadline = clock.monotonic() + timeout
+    local connect_deadline = fiber.clock() + timeout
 
     for _, instance_name in pairs(instances) do
         self:connect(instance_name, {wait_connected = false})
@@ -149,6 +203,12 @@ local function create_pool()
     return setmetatable({
         _connections = {},
         _connection_mode_update_cond = fiber.cond(),
+
+        -- Unused connection management
+        _unused_connection_watchdog_fiber = nil,
+        _unused_connection_watchdog_cond = fiber.cond(),
+
+        _idle_timeout = 60,
     }, pool_mt)
 end
 
@@ -156,12 +216,19 @@ end
 
 local pool = create_pool()
 
+local function set_idle_timeout(idle_timeout)
+    pool._idle_timeout = idle_timeout
+end
+
 local function connect(instance_name, opts)
     checks('string', {
         connect_timeout = '?number',
         wait_connected = '?boolean',
         fetch_schema = '?boolean',
     })
+
+    opts = opts or {}
+    opts.ttl = math.huge
 
     local conn, err  = pool:connect(instance_name, opts)
     if err ~= nil then
@@ -540,4 +607,6 @@ return {
     connect = connect,
     filter = filter,
     call = call,
+
+    set_idle_timeout = set_idle_timeout,
 }

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -155,6 +155,7 @@ extern char session_lua[],
 	config_applier_box_cfg_lua[],
 	config_applier_runtime_priv_lua[],
 	config_applier_compat_lua[],
+	config_applier_connpool_lua[],
 	config_applier_console_lua[],
 	config_applier_credentials_lua[],
 	config_applier_fiber_lua[],
@@ -435,6 +436,10 @@ static const char *lua_sources[] = {
 	"config/applier/compat",
 	"internal.config.applier.compat",
 	config_applier_compat_lua,
+
+	"config/applier/connpool",
+	"internal.config.applier.connpool",
+	config_applier_connpool_lua,
 
 	"config/applier/console",
 	"internal.config.applier.console",

--- a/test/config-luatest/rpc_test.lua
+++ b/test/config-luatest/rpc_test.lua
@@ -4,6 +4,8 @@ local t = require('luatest')
 local fun = require('fun')
 local treegen = require('luatest.treegen')
 local server = require('luatest.server')
+local cbuilder = require('luatest.cbuilder')
+local cluster = require('luatest.cluster')
 local socket = require('socket')
 local helpers = require('test.config-luatest.helpers')
 
@@ -1166,3 +1168,68 @@ end
 g.after_test('test_call_connects_to_all_if_prioritized', function(g)
     stop_stub_servers(g)
 end)
+
+g.test_closes_unused_connections = function()
+    local config = cbuilder:new()
+        :set_global_option('credentials.users.myuser',
+            {password =  'secret',
+             roles = { 'replication' },
+             privileges = {{permissions = {'execute'}, universe = true}}})
+        :set_global_option('iproto.advertise.peer.login', 'myuser')
+        :set_global_option('connpool.idle_timeout', 2)
+        :add_instance('i-001', { database = { mode = 'rw' } })
+        :add_instance('i-002', {})
+        :config()
+
+    local cluster = cluster:new(config)
+
+    -- Simulate a lag before connecting to differentiate
+    -- if a new connection has been established.
+    treegen.write_file(cluster._dir, 'override/net/box.lua',
+        string.dump(function()
+        local fiber = require('fiber')
+        local loaders = require('internal.loaders')
+
+        local builtin_netbox = loaders.builtin['net.box']
+        local builtin_connect = builtin_netbox.connect
+        builtin_netbox.connect = function(...)
+            fiber.sleep(1)
+            return builtin_connect(...)
+        end
+
+        return builtin_netbox
+    end))
+
+    cluster:start()
+
+    cluster['i-001']:exec(function()
+        local connpool = require('experimental.connpool')
+        local clock = require('clock')
+        local fiber = require('fiber')
+
+
+        local function time(f, ...)
+            local t0 = clock.monotonic()
+            f(...)
+            local t1 = clock.monotonic()
+            return t1 - t0
+        end
+
+        -- Check the frequent access is performed without a
+        -- delay.
+        local t1 = time(function()
+            for _=1,10 do
+                connpool.call('box.info', nil, {mode = 'ro'})
+            end
+        end)
+        t.assert_lt(t1, 2)
+
+        -- Wait for the connection to be closed due to
+        -- inactivity.
+        fiber.sleep(3)
+
+        -- Check opening a new connection took some time.
+        local t2 = time(connpool.call, 'box.info', nil, {mode = 'ro'})
+        t.assert_gt(t2, 0.9)
+    end)
+end


### PR DESCRIPTION
This patch makes the Tarantool builtin connection pool automatically close the
unused connections. It means that if connections to instances are established
by high-level `connpool.filter()` and `connpool.call()` calls they might be
closed if they're not accessed by these calls for a while (by default the time
is equals to 60 seconds). If the connection is explicitly opened using
`connpool.connect()` then it won't be closed.

This logic overall makes Tarantool not hold unused descriptors opened for too
long.

The first patch adds logic for closing unused connections itself.

The later adds configuration option to specify the time when the unused
connections would be closed called `connpool.idle_timeout`.
