### PR TITLE
box: expose box_status C API

### DIFF
--- a/changelogs/unreleased/gh-11490-expose-box-status.md
+++ b/changelogs/unreleased/gh-11490-expose-box-status.md
@@ -1,0 +1,4 @@
+## feature/box
+
+* A new `box_status` function is now available in the C API. It is accessible
+  in the TX thread without `box.info.status` Lua calls.

--- a/extra/exports
+++ b/extra/exports
@@ -121,6 +121,7 @@ box_session_id
 box_session_push
 box_slab_info
 box_space_id_by_name
+box_status
 box_truncate
 box_tuple_bsize
 box_tuple_compare

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -6265,7 +6265,7 @@ box_backup_stop(void)
 	}
 }
 
-const char *
+API_EXPORT const char *
 box_status(void)
 {
     return status;

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -292,10 +292,16 @@ box_backup_start(int checkpoint_idx, box_backup_cb cb, void *cb_arg);
 void
 box_backup_stop(void);
 
+/** \cond public */
+
 /**
- * Spit out some basic module status (master/slave, etc.
+ * The current status of the instance. It is either "running", "loading",
+ * "orphan" or "hot_standby". See box.info.status Lua API for the reference.
  */
-const char *box_status(void);
+API_EXPORT const char *
+box_status(void);
+
+/** \endcond public */
 
 /**
  * Reset box statistics.

--- a/test/box-luatest/gh_11490_expose_box_status_test.lua
+++ b/test/box-luatest/gh_11490_expose_box_status_test.lua
@@ -1,0 +1,24 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group()
+
+g.before_all(function(g)
+    g.server = server:new()
+    g.server:start()
+end)
+
+g.test_expose_box_status = function(g)
+    g.server:exec(function()
+        local ffi = require('ffi')
+        ffi.cdef([[
+            const char * box_status(void);
+        ]])
+        local box_status_capi = ffi.string(ffi.C.box_status())
+        t.assert_equals(box.info.status, box_status_capi)
+    end)
+end
+
+g.after_all(function(g)
+    g.server:drop()
+end)


### PR DESCRIPTION
Make `box_status` function result avialable in TX thread bypassing lua stack.

Fixes #11490

@TarantoolBot document
Title: `box_status` exposed in C API.