### PR TITLE
popen: add `is_closed()` method

### DIFF
--- a/changelogs/unreleased/gh-11492-popen-is-closed-method.md
+++ b/changelogs/unreleased/gh-11492-popen-is-closed-method.md
@@ -1,0 +1,4 @@
+## feature/lua/popen
+
+* Added a new method, `is_closed()`, to popen handle to check if the handle
+  has been closed (gh-11492).

--- a/src/lua/popen.c
+++ b/src/lua/popen.c
@@ -2277,6 +2277,30 @@ lbox_popen_close(struct lua_State *L)
 }
 
 /**
+ * Check if the popen handle is closed.
+ *
+ * @param handle  a handle to check
+ *
+ * Raise an error on incorrect parameters:
+ *
+ * - IllegalParams: an incorrect handle parameter.
+ *
+ * Return `true` if popen handle is closed, `false` otherwise.
+ */
+static int
+lbox_popen_is_closed(struct lua_State *L)
+{
+	bool is_closed;
+	struct popen_handle *handle = luaT_check_popen_handle(L, 1, &is_closed);
+	if (handle == NULL) {
+		diag_set(IllegalParams, "Bad params, use: ph:is_closed()");
+		return luaT_error(L);
+	}
+	lua_pushboolean(L, is_closed);
+	return 1;
+}
+
+/**
  * Get a field from a handle.
  *
  * @param handle  a handle of a child process
@@ -2507,6 +2531,7 @@ tarantool_lua_popen_init(struct lua_State *L)
 		{"shutdown",		lbox_popen_shutdown,	},
 		{"info",		lbox_popen_info,	},
 		{"close",		lbox_popen_close,	},
+		{"is_closed",		lbox_popen_is_closed	},
 		{"__index",		lbox_popen_index	},
 		{"__serialize",		lbox_popen_serialize	},
 		{"__gc",		lbox_popen_gc		},


### PR DESCRIPTION
This commit adds a method to make it easier to check that popen handle is closed.

Closes #11492

@TarantoolBot document
Title: `popen_handle:is_closed()` method

The new `is_closed()` method returns `true` if the popen handle is closed, and `false` otherwise.

Usage example:

```lua
local ph = popen.new(<...>)
assert(ph:is_closed() == false)
...
ph:close()
assert(ph:is_closed() == true)
```