### PR TITLE
test: fix box/net.box_reuse_tuple_formats_gh-6217.test for EE

### DIFF
--- a/test/box/net.box_reuse_tuple_formats_gh-6217.result
+++ b/test/box/net.box_reuse_tuple_formats_gh-6217.result
@@ -11,7 +11,7 @@ box.schema.user.grant('guest', 'execute', 'universe')
  | ...
 
 -- Check that formats created by net.box for schema are reused (gh-6217).
-COUNT = 113
+COUNT = 200
  | ---
  | ...
 errinj.set('ERRINJ_TUPLE_FORMAT_COUNT', COUNT)

--- a/test/box/net.box_reuse_tuple_formats_gh-6217.test.lua
+++ b/test/box/net.box_reuse_tuple_formats_gh-6217.test.lua
@@ -4,7 +4,7 @@ errinj = box.error.injection
 box.schema.user.grant('guest', 'execute', 'universe')
 
 -- Check that formats created by net.box for schema are reused (gh-6217).
-COUNT = 113
+COUNT = 200
 errinj.set('ERRINJ_TUPLE_FORMAT_COUNT', COUNT)
 connections = {}
 for i = 1, COUNT do                                                         \


### PR DESCRIPTION
In the commit cf1c250eb1af ("box: add format_object field to spaces") the test is modified due to number of format created internally is increased. But the change is not enough for EE version. Let's raise count to 200.

Follow-up #9979