### PR TITLE
read view: add read view space engine name field

### DIFF
--- a/src/box/read_view.c
+++ b/src/box/read_view.c
@@ -100,10 +100,13 @@ space_read_view_new(struct space *space, const struct read_view_opts *opts)
 	struct grp_alloc all = grp_alloc_initializer();
 	grp_alloc_reserve_data(&all, sizeof(*space_rv));
 	grp_alloc_reserve_str0(&all, space_name(space));
+	grp_alloc_reserve_str0(&all, space_engine_name(space));
 	grp_alloc_reserve_data(&all, index_map_size);
 	grp_alloc_use(&all, xmalloc(grp_alloc_size(&all)));
 	space_rv = grp_alloc_create_data(&all, sizeof(*space_rv));
 	space_rv->name = grp_alloc_create_str0(&all, space_name(space));
+	space_rv->engine = grp_alloc_create_str0(&all,
+						 space_engine_name(space));
 	space_rv->index_map = grp_alloc_create_data(&all, index_map_size);
 	assert(grp_alloc_size(&all) == 0);
 

--- a/src/box/read_view.h
+++ b/src/box/read_view.h
@@ -34,6 +34,8 @@ struct space_read_view {
 	uint32_t id;
 	/** Space name. */
 	char *name;
+	/** Space engine */
+	char *engine;
 	/**
 	 * Tuple field definition array used by this space. Allocated only if
 	 * read_view_opts::enable_field_names is set, otherwise set to NULL.

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -407,6 +407,13 @@ space_name(const struct space *space)
 	return space->def->name;
 }
 
+/** Get space engine name. */
+static inline const char *
+space_engine_name(const struct space *space)
+{
+	return space->engine->name;
+}
+
 /** Return true if space is data-temporary. */
 static inline bool
 space_is_data_temporary(const struct space *space)


### PR DESCRIPTION
read view: add read view space engine name field

Added space `engine` name field to space read view,
so that we can expose it in a public read view API
method in Tarantool-EE.
    
Part of [#1276](https://github.com/tarantool/tarantool-ee/issues/1276)

Required by Tarantool-EE PR [#1297](https://github.com/tarantool/tarantool-ee/pull/1297)