### PR TITLE
read view: add read view space engine field

### DIFF
--- a/src/box/read_view.c
+++ b/src/box/read_view.c
@@ -135,6 +135,7 @@ space_read_view_new(struct space *space, const struct read_view_opts *opts)
 	} else {
 		space_rv->upgrade = NULL;
 	}
+	space_rv->engine = space->engine;
 	space_rv->index_id_max = space->index_id_max;
 	memset(space_rv->index_map, 0, index_map_size);
 	for (uint32_t i = 0; i <= space->index_id_max; i++) {

--- a/src/box/read_view.h
+++ b/src/box/read_view.h
@@ -17,6 +17,7 @@ extern "C" {
 #endif /* defined(__cplusplus) */
 
 struct cord;
+struct engine;
 struct field_def;
 struct index;
 struct index_read_view;
@@ -34,6 +35,8 @@ struct space_read_view {
 	uint32_t id;
 	/** Space name. */
 	char *name;
+	/** Space engine */
+	struct engine *engine;
 	/**
 	 * Tuple field definition array used by this space. Allocated only if
 	 * read_view_opts::enable_field_names is set, otherwise set to NULL.


### PR DESCRIPTION
Added space `engine` field to space read view, so that we can expose its name in a public read view API method in Tarantool-EE.

Part of tarantool/tarantool-ee#1276

Required by Tarantool-EE PR [#1297](https://github.com/tarantool/tarantool-ee/pull/1297)

NO_CHANGELOG=internal
NO_DOC=internal
NO_TEST=field addition