### PR TITLE
box: introduce aggregates

### DIFF
--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -1999,6 +1999,7 @@ memtx_tuple_new_raw_impl(struct tuple_format *format, const char *data,
 	char *raw;
 	bool make_compact;
 	bool validate = (flags & MEMTX_TUPLE_NEW_RAW_NO_VALIDATE) == 0;
+	bool limit_size = (flags & MEMTX_TUPLE_NEW_RAW_NO_TUPLE_MAX_SIZE) == 0;
 	if (tuple_field_map_create(format, data, validate, &builder) != 0)
 		goto end;
 	field_map_size = field_map_build_size(&builder);
@@ -2024,7 +2025,7 @@ memtx_tuple_new_raw_impl(struct tuple_format *format, const char *data,
 		diag_set(OutOfMemory, total, "slab allocator", "memtx_tuple");
 		goto end;
 	});
-	if (unlikely(total > memtx->max_tuple_size)) {
+	if (unlikely(total > memtx->max_tuple_size) && limit_size) {
 		diag_set(ClientError, ER_MEMTX_MAX_TUPLE_SIZE, total,
 			 memtx->max_tuple_size);
 		error_log(diag_last_error(diag_get()));

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -82,12 +82,12 @@ create_memtx_tuple_format_vtab(struct tuple_format_vtab *vtab);
 
 struct tuple *
 (*memtx_tuple_new_raw)(struct tuple_format *format, const char *data,
-		       const char *end, bool validate);
+		       const char *end, unsigned flags);
 
 template <class ALLOC>
 static inline struct tuple *
 memtx_tuple_new_raw_impl(struct tuple_format *format, const char *data,
-			 const char *end, bool validate);
+			 const char *end, unsigned flags);
 
 static void
 memtx_engine_run_gc(struct memtx_engine *memtx, bool *stop);
@@ -1986,7 +1986,7 @@ memtx_engine_set_max_tuple_size(struct memtx_engine *memtx, size_t max_size)
 template<class ALLOC>
 static struct tuple *
 memtx_tuple_new_raw_impl(struct tuple_format *format, const char *data,
-			 const char *end, bool validate)
+			 const char *end, unsigned flags)
 {
 	struct memtx_engine *memtx = (struct memtx_engine *)format->engine;
 	assert(mp_typeof(*data) == MP_ARRAY);
@@ -1998,6 +1998,7 @@ memtx_tuple_new_raw_impl(struct tuple_format *format, const char *data,
 	uint32_t data_offset, field_map_size;
 	char *raw;
 	bool make_compact;
+	bool validate = (flags & MEMTX_TUPLE_NEW_RAW_NO_VALIDATE) == 0;
 	if (tuple_field_map_create(format, data, validate, &builder) != 0)
 		goto end;
 	field_map_size = field_map_build_size(&builder);
@@ -2057,7 +2058,7 @@ template<class ALLOC>
 static inline struct tuple *
 memtx_tuple_new(struct tuple_format *format, const char *data, const char *end)
 {
-	return memtx_tuple_new_raw_impl<ALLOC>(format, data, end, true);
+	return memtx_tuple_new_raw_impl<ALLOC>(format, data, end, 0);
 }
 
 template<class ALLOC>

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -241,6 +241,8 @@ enum {
 enum {
 	/** This flag allows to disable data validation on tuple allocation. */
 	MEMTX_TUPLE_NEW_RAW_NO_VALIDATE = 1 << 0,
+	/** This flag allows to bypass tuple max size limitation. */
+	MEMTX_TUPLE_NEW_RAW_NO_TUPLE_MAX_SIZE = 1 << 1,
 };
 
 /**

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -235,12 +235,21 @@ enum {
 };
 
 /**
- * Allocate and return new memtx tuple. Data validation depends
- * on @a validate value. On error returns NULL and set diag.
+ * Flags for 'memtx_tuple_new_raw' function that allow
+ * to tune its behavior.
+ */
+enum {
+	/** This flag allows to disable data validation on tuple allocation. */
+	MEMTX_TUPLE_NEW_RAW_NO_VALIDATE = 1 << 0,
+};
+
+/**
+ * Allocate and return new memtx tuple. Behavior can be tuned with flags.
+ * On error returns NULL and set diag.
  */
 extern struct tuple *
 (*memtx_tuple_new_raw)(struct tuple_format *format, const char *data,
-		       const char *end, bool validate);
+		       const char *end, unsigned flags);
 
 /**
  * Generic implementation of index_vtab::def_change_requires_rebuild,

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -884,6 +884,11 @@ memtx_space_check_index_def(struct space *space, struct index_def *index_def)
 			 "'layout' option");
 		return -1;
 	}
+	if (index_def->opts.aggregates != NULL) {
+		diag_set(ClientError, ER_UNSUPPORTED, "memtx",
+			 "'aggregates' option");
+		return -1;
+	}
 
 	/* Checks for memtx MVCC unsupported features. */
 	if (memtx_tx_manager_use_mvcc_engine) {

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -704,6 +704,11 @@ vinyl_space_check_index_def(struct space *space, struct index_def *index_def)
 			 "'layout' option");
 		return -1;
 	}
+	if (index_def->opts.aggregates != NULL) {
+		diag_set(ClientError, ER_UNSUPPORTED, "vinyl",
+			 "'aggregates' option");
+		return -1;
+	}
 	return 0;
 }
 

--- a/test/box-luatest/index_aggregates_test.lua
+++ b/test/box-luatest/index_aggregates_test.lua
@@ -1,0 +1,114 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+g.test_arg_check = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            name = 'ILLEGAL_PARAMS',
+            message = "options parameter 'aggregates' should be of type table",
+        }, s.create_index, s, 'pk', {aggregates = 1234})
+
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'WRONG_INDEX_OPTIONS',
+            message = "Wrong index options: 'aggregates' elements must be map",
+        }, s.create_index, s, 'pk', {aggregates = {1234}})
+
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'WRONG_INDEX_OPTIONS',
+            message = "Wrong index options: 'aggregates' must be array",
+        }, box.space._index.insert, box.space._index, {
+            s.id, 0, 'pk', 'tree', {aggregates = 1234}, {{[0] = 'unsigned'}}
+        })
+
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'WRONG_INDEX_OPTIONS',
+            message = "Wrong index options: 'aggregates' elements must be map",
+        }, box.space._index.insert, box.space._index, {
+            s.id, 0, 'pk', 'tree', {aggregates = {1234}}, {{[0] = 'unsigned'}}
+        })
+    end)
+end
+
+g.test_fields = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.create_space('test', {
+            format = {{'a', 'unsigned'}, {'b', 'string'}}
+        })
+        --
+        -- Test space:create_index.
+        --
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "options.aggregates[1]: field (name or number) is " ..
+                      "expected",
+        }, s.create_index, s, 'pk', {aggregates = {{field = {}}}})
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "options.aggregates[1]: field (number) must be one-based",
+        }, s.create_index, s, 'pk', {aggregates = {{field = 0}}})
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "options.aggregates[1]: field was not found by name 'x'",
+        }, s.create_index, s, 'pk', {aggregates = {{field = 'x'}}})
+        --
+        -- Test index:alter
+        --
+        local pk = s:create_index('pk')
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "options.aggregates[1]: field (name or number) is " ..
+                      "expected",
+        }, pk.alter, pk, {aggregates = {{field = {}}}})
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "options.aggregates[1]: field (number) must be one-based",
+        }, pk.alter, pk, {aggregates = {{field = 0}}})
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "options.aggregates[1]: field was not found by name 'x'",
+        }, pk.alter, pk, {aggregates = {{field = 'x'}}})
+    end)
+end
+
+g.test_unsupported = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('test', {engine = 'memtx'})
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'UNSUPPORTED',
+            message = "memtx does not support 'aggregates' option",
+        }, s.create_index, s, 'pk', {aggregates = {{field = 1}}})
+        s:drop()
+
+        s = box.schema.space.create('test', {engine = 'vinyl'})
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'UNSUPPORTED',
+            message = "vinyl does not support 'aggregates' option",
+        }, s.create_index, s, 'pk', {aggregates = {{field = 1}}})
+    end)
+end


### PR DESCRIPTION
This is CE part of MemCS skip index patch. See commits for details.

Note that I didn't do refactoring of MemTX allocator (allocate blocks instead of tuples) because we definitely won't make it to the nearest release then. Let's do this refactoring in the future, after basic BRIN functionality is implemented.

EE part: https://github.com/tarantool/tarantool-ee/pull/1288.