### PR TITLE
lib bit: add `bit_count` implementation 

### DIFF
--- a/src/lib/bit/NOTICE
+++ b/src/lib/bit/NOTICE
@@ -1,0 +1,82 @@
+This product includes code from Apache Arrow https://github.com/apache/arrow
+(Apache 2.0), which includes the following in its NOTICE file:
+
+Apache Arrow
+Copyright 2016-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This product includes software from the SFrame project (BSD, 3-clause).
+* Copyright (C) 2015 Dato, Inc.
+* Copyright (c) 2009 Carnegie Mellon University.
+
+This product includes software from the Feather project (Apache 2.0)
+https://github.com/wesm/feather
+
+This product includes software from the DyND project (BSD 2-clause)
+https://github.com/libdynd
+
+This product includes software from the LLVM project
+ * distributed under the University of Illinois Open Source
+
+This product includes software from the mman-win32 project
+ * Copyright https://code.google.com/p/mman-win32/
+ * Licensed under the MIT License;
+
+This product includes software from the LevelDB project
+ * Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * Moved from Kudu http://github.com/cloudera/kudu
+
+This product includes software from the CMake project
+ * Copyright 2001-2009 Kitware, Inc.
+ * Copyright 2012-2014 Continuum Analytics, Inc.
+ * All rights reserved.
+
+This product includes software from https://github.com/matthew-brett/multibuild (BSD 2-clause)
+ * Copyright (c) 2013-2016, Matt Terry and Matthew Brett; all rights reserved.
+
+This product includes software from the Ibis project (Apache 2.0)
+ * Copyright (c) 2015 Cloudera, Inc.
+ * https://github.com/cloudera/ibis
+
+This product includes software from Dremio (Apache 2.0)
+  * Copyright (C) 2017-2018 Dremio Corporation
+  * https://github.com/dremio/dremio-oss
+
+This product includes software from Google Guava (Apache 2.0)
+  * Copyright (C) 2007 The Guava Authors
+  * https://github.com/google/guava
+
+This product include software from CMake (BSD 3-Clause)
+  * CMake - Cross Platform Makefile Generator
+  * Copyright 2000-2019 Kitware, Inc. and Contributors
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Kudu, which includes the following in
+its NOTICE file:
+
+  Apache Kudu
+  Copyright 2016 The Apache Software Foundation
+
+  This product includes software developed at
+  The Apache Software Foundation (http://www.apache.org/).
+
+  Portions of this software were developed at
+  Cloudera, Inc (http://www.cloudera.com/).
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache ORC, which includes the following in
+its NOTICE file:
+
+  Apache ORC
+  Copyright 2013-2019 The Apache Software Foundation
+
+  This product includes software developed by The Apache Software
+  Foundation (http://www.apache.org/).
+
+  This product includes software developed by Hewlett-Packard:
+  (c) Copyright [2014-2015] Hewlett-Packard Development Company, L.P

--- a/src/lib/bit/bit.h
+++ b/src/lib/bit/bit.h
@@ -674,6 +674,21 @@ bit_count_u64(uint64_t x)
 #undef POPCOUNT_NAIVE
 
 /**
+ * @brief Returns the number of 1-bits in @a data vector starting from
+ *	  @a bit_offset.
+ * @param data byte vector of length @a length bits.
+ * @param bit_offset offset within the byte vector from where to start
+ *		     counting 1-bits.
+ * @param length length in bits of byte vector @a data.
+ * @return the number of 1-bits in @a data.
+ *
+ * Implementation adopted from the internals of the Apache
+ * Arrow C++ library.
+ */
+size_t
+bit_count(const uint8_t *data, size_t bit_offset, size_t length);
+
+/**
  * @brief Rotate @a x left by @a r bits
  * @param x integer
  * @param r number for bits to rotate

--- a/src/lib/bit/bit.h
+++ b/src/lib/bit/bit.h
@@ -50,11 +50,6 @@
 extern "C" {
 #endif /* defined(__cplusplus) */
 
-/** @cond false **/
-#define bit_likely(x)    __builtin_expect((x),1)
-#define bit_unlikely(x)  __builtin_expect((x),0)
-/** @endcond **/
-
 /**
  * @brief Unaligned load from memory.
  * @param p pointer
@@ -869,7 +864,7 @@ bit_iterator_init(struct bit_iterator *it, const void *data, size_t size,
 	it->start = (const char *) data;
 	it->next = it->start;
 	it->end = it->next + size;
-	if (bit_unlikely(size == 0)) {
+	if (unlikely(size == 0)) {
 		it->word = 0;
 		return;
 	}
@@ -878,7 +873,7 @@ bit_iterator_init(struct bit_iterator *it, const void *data, size_t size,
 	it->word_base = 0;
 
 	/* Check if size is a multiple of sizeof(ITER_UINT) */
-	if (bit_likely(size % sizeof(ITER_UINT) == 0)) {
+	if (likely(size % sizeof(ITER_UINT) == 0)) {
 		it->word = ITER_LOAD(it->next);
 		it->next += sizeof(ITER_UINT);
 	} else {
@@ -901,8 +896,8 @@ bit_iterator_init(struct bit_iterator *it, const void *data, size_t size,
 inline size_t
 bit_iterator_next(struct bit_iterator *it)
 {
-	while (bit_unlikely(it->word == 0)) {
-		if (bit_unlikely(it->next >= it->end))
+	while (unlikely(it->word == 0)) {
+		if (unlikely(it->next >= it->end))
 			return SIZE_MAX;
 
 		/* Extract the next word from memory */

--- a/src/trivia/util.h
+++ b/src/trivia/util.h
@@ -65,6 +65,9 @@ extern "C" {
 } while (0)
 
 #define DIV_ROUND_UP(n, d) (((n) + (d) - 1) / (d))
+#define ROUND_UP_TO_POWER_OF_2(x, f) (((x) + ((f) - 1)) & ~((f) - 1))
+#define ROUND_DOWN(x, f) (((x) / (f)) * f)
+#define IS_POWER_OF_2(x) ((x) > 0 && ((x) & ((x) - 1)) == 0)
 
 /* Macros to define enum and corresponding strings. */
 #define ENUM0_MEMBER(s, ...) s,

--- a/test/unit/bit.result
+++ b/test/unit/bit.result
@@ -723,3 +723,5 @@ Source value: true
 	*** test_bit_copy_range ***
 Source value: false
 	*** test_bit_copy_range: done ***
+	*** test_bit_count ***
+	*** test_bit_count: done ***


### PR DESCRIPTION
Add `bit_count_vec` function utilizing batching vectorized instructions on word aligned boundaries.