### PR TITLE
config: add `include` field for config files

### DIFF
--- a/changelogs/unreleased/gh-11583-config-files-include.md
+++ b/changelogs/unreleased/gh-11583-config-files-include.md
@@ -1,0 +1,3 @@
+## feature/config
+
+* Introduced a new `include` field for configuration files (gh-11510).

--- a/src/box/lua/config/cluster_config.lua
+++ b/src/box/lua/config/cluster_config.lua
@@ -209,6 +209,9 @@ local nested_cluster_config = schema.new(schema_name, record_from_fields({
             }),
         }),
     }),
+    include = schema.array({
+        items = schema.scalar({type = 'string'}),
+    }),
 }))
 
 -- {{{ Support conditional sections

--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -2729,6 +2729,21 @@ C['groups.*.replicasets.*.bootstrap_leader'] = format_text([[
 
 -- }}} groups configuration
 
+-- {{{ include configuration
+
+C['include'] = format_text([[
+    A list of paths to include in the cluster configuration. The paths are
+    included in the order they are specified in the list.
+]])
+
+C['include.*'] = format_text([[
+    An absolute or relative path to a config file to be included, or a wildcard
+    pattern. Relative path are considered relative to the file, where they are
+    included.
+]])
+
+-- }}} include configuration
+
 -- }}} Cluster descriptions
 
 return {

--- a/src/box/lua/config/source/file.lua
+++ b/src/box/lua/config/source/file.lua
@@ -1,29 +1,84 @@
+local fio = require('fio')
+local log = require('internal.config.utils.log')
 local yaml = require('yaml')
 local file = require('internal.config.utils.file')
+local cluster_config = require('internal.config.cluster_config')
+
+local stack_methods = {}
+local Stack = {
+    __index = stack_methods,
+}
+
+local function stack_selfcheck(self, method_name)
+    if type(self) ~= 'table' or getmetatable(self) ~= Stack then
+        local fmt_str = 'Use Stack:%s(<...>) instead of Stack.%s(<...>)'
+        error(fmt_str:format(method_name, method_name), 0)
+    end
+end
+
+local function new_stack(table)
+    if table == nil then
+        table = {}
+    end
+
+    if type(table) ~= 'table' then
+        error('Expected table, got ' .. type(table))
+    end
+
+    return setmetatable({
+        _stack = table,
+        _count = #table,
+    }, Stack)
+end
+
+function stack_methods:push(value)
+    stack_selfcheck(self, 'push')
+
+    if value == nil then
+        return
+    end
+
+    self._count = self._count + 1
+    self._stack[self._count] = value
+end
+
+function stack_methods:pop()
+    if self._count == 0 then
+        return nil
+    end
+
+    local value = self._stack[self._count]
+    self._stack[self._count] = nil
+    self._count = self._count - 1
+
+    return value
+end
+
+function stack_methods:iterator()
+    return self.pop, self
+end
 
 local methods = {}
 local mt = {
     __index = methods,
 }
 
-function methods.sync(self, config_module, _iconfig)
-    assert(config_module._config_file ~= nil)
-
-    local data = file.universal_read(config_module._config_file, 'config file')
+local function read_config_file(path)
+    local data = file.universal_read(path, 'config file')
 
     -- Integrity module is available only in Tarantool Enterprise Edition
     -- builds.
     local ok, integrity = pcall(require, 'integrity')
-    if ok and not integrity.verify_file(config_module._config_file, data) then
+    if ok and not integrity.verify_file(path, data) then
         local err = 'Integrity check failed for configuration file %q'
-        error(err:format(config_module._config_file))
+        error(err:format(path))
     end
 
     local res
     ok, res = pcall(yaml.decode, data)
     if not ok then
         error(('Unable to parse config file %q as YAML: %s'):format(
-            config_module._config_file, res))
+            path, res))
     end
 
     -- YAML returns `nil` or `box.NULL` on empty file,
@@ -32,11 +87,7 @@ function methods.sync(self, config_module, _iconfig)
         res = {}
     end
 
-    self._values = res
-end
-
-function methods.get(self)
-    return self._values
+    return res
 end
 
 local function new()
@@ -45,6 +96,71 @@ local function new()
         type = 'cluster',
         _values = {},
     }, mt)
+end
+
+function methods.sync(self, config_module, _iconfig)
+    assert(config_module._config_file ~= nil)
+
+    local config_paths = new_stack({config_module._config_file})
+    local processed_paths = {}
+    local cconfig = {}
+
+    -- Do a DFS traversal using stack.
+    local config
+    for config_path in config_paths:iterator() do
+        -- Prevent recursion.
+        if processed_paths[config_path] then
+            log.warn('skipping already processed config file: %q',
+                     config_path)
+            goto continue
+        end
+        processed_paths[config_path] = true
+
+        log.debug('processing config file %q', config_path)
+        config = read_config_file(config_path)
+
+        -- The contract is that we must validate the config before doing
+        -- anything with it.
+        cluster_config:validate(config)
+        config = cluster_config:apply_conditional(config)
+
+        if config.include ~= nil then
+            local current_config_dir = fio.dirname(config_path)
+
+            -- Because we need to preserve the order of the includes, create a
+            -- new stack for new paths, where we will push all new config files
+            -- found in `include` section. This stack will contain them in
+            -- reverse order, so we will be able to push them to the
+            -- config_paths stack in the correct order.
+            local new_config_paths = new_stack()
+
+            for _, glob in ipairs(config.include) do
+                -- Treat relative include paths as relative
+                -- to the config file, where they are included.
+                glob = file.rebase_file_abspath(current_config_dir, glob)
+                local paths = fio.glob(glob)
+                for _, path in ipairs(paths) do
+                    new_config_paths:push(path)
+                end
+            end
+
+            for new_config_path in new_config_paths:iterator() do
+                config_paths:push(new_config_path)
+            end
+
+            config.include = nil
+        end
+
+        cconfig = cluster_config:merge(cconfig, config)
+
+        ::continue::
+    end
+
+    self._values = cconfig
+end
+
+function methods.get(self)
+    return self._values
 end
 
 return {

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -645,6 +645,7 @@ end
 --
 -- * groups (map)
 -- * conditional (array of maps)
+-- * include (array of strings)
 g.test_additional_options_global = function()
     -- Some valid values for the additional fields.
     local additional_options = {
@@ -653,7 +654,11 @@ g.test_additional_options_global = function()
             {
                 ['if'] = '1.2.3 == 1.2.3',
             },
-        }
+        },
+        include = {
+            'config_a.yaml',
+            '/etc/tarantool/conf.d/*.yaml',
+        },
     }
 
     -- Verify that the fields on the given level are instance

--- a/test/config-luatest/config_include_test.lua
+++ b/test/config-luatest/config_include_test.lua
@@ -1,0 +1,624 @@
+local t = require('luatest')
+local server = require('luatest.server')
+local treegen = require('luatest.treegen')
+local yaml = require('yaml')
+
+---@class luatest.group
+local g = t.group()
+
+local common_config = {
+    credentials = {
+        users = {
+            guest = {
+                roles = {'super'},
+            },
+        },
+    },
+
+    iproto = {
+        listen = {
+            {uri = 'unix/:./instance-001.iproto'},
+        },
+    },
+
+    groups = {
+        ['group-001'] = {
+            replicasets = {
+                ['replicaset-001'] = {
+                    instances = {
+                        ['instance-001'] = {
+                            labels = {
+                                value_1 = 'from config.yaml',
+                                value_2 = 'from config.yaml',
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+}
+
+g.before_each(function()
+    g.dir = treegen.prepare_directory({}, {})
+end)
+
+g.after_each(function()
+    g.server:drop()
+    g.server = nil
+end)
+
+g.test_initial_merge = function()
+    local config = table.deepcopy(common_config)
+    config.include = {'included_config.yaml'}
+    local included_config = {
+        groups = {
+            ['group-001'] = {
+                replicasets = {
+                    ['replicaset-001'] = {
+                        instances = {
+                            ['instance-001'] = {
+                                labels = {
+                                    value_2 = 'from included_config.yaml',
+                                    value_3 = 'from included_config.yaml',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    local config_file = treegen.write_file(
+        g.dir, 'config.yaml', yaml.encode(config))
+    treegen.write_file(
+        g.dir, 'included_config.yaml', yaml.encode(included_config))
+
+    local opts = {
+        config_file = config_file,
+        alias = 'instance-001',
+        chdir = g.dir,
+    }
+    g.server = server:new(opts)
+    g.server:start()
+
+    g.server:exec(function()
+        t.assert_equals(
+            require('config'):get('labels'),
+            {
+                value_1 = 'from config.yaml',
+                value_2 = 'from included_config.yaml',
+                value_3 = 'from included_config.yaml',
+            }
+        )
+    end)
+end
+
+g.test_reload_merge = function()
+    local config = table.deepcopy(common_config)
+    local included_config = {
+        groups = {
+            ['group-001'] = {
+                replicasets = {
+                    ['replicaset-001'] = {
+                        instances = {
+                            ['instance-001'] = {
+                                labels = {
+                                    value_2 = 'from included_config.yaml',
+                                    value_3 = 'from included_config.yaml',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    local config_file = treegen.write_file(
+        g.dir, 'config.yaml', yaml.encode(config))
+    treegen.write_file(
+        g.dir, 'included_config.yaml', yaml.encode(included_config))
+
+    local opts = {
+        config_file = config_file,
+        alias = 'instance-001',
+        chdir = g.dir,
+    }
+    g.server = server:new(opts)
+    g.server:start()
+
+    g.server:exec(function()
+        t.assert_equals(
+            require('config'):get('labels'),
+            {
+                value_1 = 'from config.yaml',
+                value_2 = 'from config.yaml',
+                value_3 = nil,
+            }
+        )
+    end)
+
+    config.include = {'included_config.yaml'}
+    treegen.write_file(g.dir, 'config.yaml', yaml.encode(config))
+
+    g.server:exec(function()
+        require('config'):reload()
+        t.assert_equals(
+            require('config'):get('labels'),
+            {
+                value_1 = 'from config.yaml',
+                value_2 = 'from included_config.yaml',
+                value_3 = 'from included_config.yaml',
+            }
+        )
+    end)
+end
+
+g.test_include_non_existing = function()
+    local config = table.deepcopy(common_config)
+    config.include = {'non_existing_config.yaml'}
+    local config_file = treegen.write_file(
+        g.dir, 'config.yaml', yaml.encode(config))
+
+    local opts = {
+        config_file = config_file,
+        alias = 'instance-001',
+        chdir = g.dir,
+    }
+    g.server = server:new(opts)
+    g.server:start()
+
+    g.server:exec(function()
+        t.assert_equals(
+            require('config'):get('labels'),
+            {
+                value_1 = 'from config.yaml',
+                value_2 = 'from config.yaml',
+                value_3 = nil,
+            }
+        )
+    end)
+end
+
+g.test_include_glob = function()
+    local config = table.deepcopy(common_config)
+    config.include = {'conf.d/*.yaml'}
+    local config_file = treegen.write_file(
+        g.dir, 'config.yaml', yaml.encode(config))
+
+    local included_config_1 = {
+        groups = {
+            ['group-001'] = {
+                replicasets = {
+                    ['replicaset-001'] = {
+                        instances = {
+                            ['instance-001'] = {
+                                labels = {
+                                    value_2 = 'from included_config_1.yaml',
+                                    value_3 = 'from included_config_1.yaml',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    local included_config_2 = {
+        groups = {
+            ['group-001'] = {
+                replicasets = {
+                    ['replicaset-001'] = {
+                        instances = {
+                            ['instance-001'] = {
+                                labels = {
+                                    value_2 = 'from included_config_2.yaml',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    treegen.write_file(
+        g.dir, 'conf.d/config_1.yaml', yaml.encode(included_config_1))
+    treegen.write_file(
+        g.dir, 'conf.d/config_2.yaml', yaml.encode(included_config_2))
+
+    local opts = {
+        config_file = config_file,
+        alias = 'instance-001',
+        chdir = g.dir,
+    }
+    g.server = server:new(opts)
+    g.server:start()
+
+    g.server:exec(function()
+        t.assert_equals(
+            require('config'):get('labels'),
+            {
+                value_1 = 'from config.yaml',
+                value_2 = 'from included_config_2.yaml',
+                value_3 = 'from included_config_1.yaml',
+            }
+        )
+    end)
+end
+
+g.test_include_multiple = function()
+    local config = table.deepcopy(common_config)
+    config.include = {
+        'included_config_1.yaml',
+        'included_config_2.yaml',
+    }
+    local config_file = treegen.write_file(
+        g.dir, 'config.yaml', yaml.encode(config))
+
+    local included_config_1 = {
+        groups = {
+            ['group-001'] = {
+                replicasets = {
+                    ['replicaset-001'] = {
+                        instances = {
+                            ['instance-001'] = {
+                                labels = {
+                                    value_2 = 'from included_config_1.yaml',
+                                    value_3 = 'from included_config_1.yaml',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    local included_config_2 = {
+        groups = {
+            ['group-001'] = {
+                replicasets = {
+                    ['replicaset-001'] = {
+                        instances = {
+                            ['instance-001'] = {
+                                labels = {
+                                    value_2 = 'from included_config_2.yaml',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    treegen.write_file(
+        g.dir, 'included_config_1.yaml', yaml.encode(included_config_1))
+    treegen.write_file(
+        g.dir, 'included_config_2.yaml', yaml.encode(included_config_2))
+
+    local opts = {
+        config_file = config_file,
+        alias = 'instance-001',
+        chdir = g.dir,
+    }
+    g.server = server:new(opts)
+    g.server:start()
+
+    g.server:exec(function()
+        t.assert_equals(
+            require('config'):get('labels'),
+            {
+                value_1 = 'from config.yaml',
+                value_2 = 'from included_config_2.yaml',
+                value_3 = 'from included_config_1.yaml',
+            }
+        )
+    end)
+end
+
+g.test_include_nested = function()
+    local config = table.deepcopy(common_config)
+    config.include = {'included_config_1.yaml'}
+    local config_file = treegen.write_file(
+        g.dir, 'config.yaml', yaml.encode(config))
+
+    local included_config_1 = {
+        include = {'included_config_2.yaml'},
+        groups = {
+            ['group-001'] = {
+                replicasets = {
+                    ['replicaset-001'] = {
+                        instances = {
+                            ['instance-001'] = {
+                                labels = {
+                                    value_2 = 'from included_config_1.yaml',
+                                    value_3 = 'from included_config_1.yaml',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    local included_config_2 = {
+        groups = {
+            ['group-001'] = {
+                replicasets = {
+                    ['replicaset-001'] = {
+                        instances = {
+                            ['instance-001'] = {
+                                labels = {
+                                    value_2 = 'from included_config_2.yaml',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    treegen.write_file(
+        g.dir, 'included_config_1.yaml', yaml.encode(included_config_1))
+    treegen.write_file(
+        g.dir, 'included_config_2.yaml', yaml.encode(included_config_2))
+
+    local opts = {
+        config_file = config_file,
+        alias = 'instance-001',
+        chdir = g.dir,
+    }
+    g.server = server:new(opts)
+    g.server:start()
+
+    g.server:exec(function()
+        t.assert_equals(
+            require('config'):get('labels'),
+            {
+                value_1 = 'from config.yaml',
+                value_2 = 'from included_config_2.yaml',
+                value_3 = 'from included_config_1.yaml',
+            }
+        )
+    end)
+end
+
+g.test_include_relative = function()
+    local config = table.deepcopy(common_config)
+    config.include = {'conf.d/included_config_1.yaml'}
+    local config_file = treegen.write_file(
+        g.dir, 'config.yaml', yaml.encode(config))
+
+    local included_config_1 = {
+        include = {'included_config_2.yaml'},
+        groups = {
+            ['group-001'] = {
+                replicasets = {
+                    ['replicaset-001'] = {
+                        instances = {
+                            ['instance-001'] = {
+                                labels = {
+                                    value_2 = 'from included_config_1.yaml',
+                                    value_3 = 'from included_config_1.yaml',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    local included_config_2 = {
+        groups = {
+            ['group-001'] = {
+                replicasets = {
+                    ['replicaset-001'] = {
+                        instances = {
+                            ['instance-001'] = {
+                                labels = {
+                                    value_2 = 'from included_config_2.yaml',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    treegen.write_file(
+        g.dir, 'conf.d/included_config_1.yaml', yaml.encode(included_config_1))
+    treegen.write_file(
+        g.dir, 'conf.d/included_config_2.yaml', yaml.encode(included_config_2))
+
+    local opts = {
+        config_file = config_file,
+        alias = 'instance-001',
+        chdir = g.dir,
+    }
+    g.server = server:new(opts)
+    g.server:start()
+
+    g.server:exec(function()
+        t.assert_equals(
+            require('config'):get('labels'),
+            {
+                value_1 = 'from config.yaml',
+                value_2 = 'from included_config_2.yaml',
+                value_3 = 'from included_config_1.yaml',
+            }
+        )
+    end)
+end
+
+g.test_include_recursion = function()
+    local config = table.deepcopy(common_config)
+    config.log = {to = 'file'}
+
+    local included_config = {
+        include = {'config.yaml'},
+        groups = {
+            ['group-001'] = {
+                replicasets = {
+                    ['replicaset-001'] = {
+                        instances = {
+                            ['instance-001'] = {
+                                labels = {
+                                    value_2 = 'from included_config.yaml',
+                                    value_3 = 'from included_config.yaml',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    local config_file = treegen.write_file(
+        g.dir, 'config.yaml', yaml.encode(config))
+    treegen.write_file(
+        g.dir, 'included_config.yaml', yaml.encode(included_config))
+
+    local opts = {
+        config_file = config_file,
+        alias = 'instance-001',
+        chdir = g.dir,
+    }
+    g.server = server:new(opts)
+    g.server:start()
+
+    g.server:exec(function()
+        t.assert_equals(
+            require('config'):get('labels'),
+            {
+                value_1 = 'from config.yaml',
+                value_2 = 'from config.yaml',
+                value_3 = nil,
+            }
+        )
+    end)
+
+    config.include = {'included_config.yaml'}
+    treegen.write_file(g.dir, 'config.yaml', yaml.encode(config))
+
+    g.server:exec(function()
+        require('config'):reload()
+        t.assert_equals(
+            require('config'):get('labels'),
+            {
+                value_1 = 'from config.yaml',
+                value_2 = 'from included_config.yaml',
+                value_3 = 'from included_config.yaml',
+            }
+        )
+    end)
+
+    t.helpers.retrying({timeout = 10}, function()
+        t.assert(g.server:grep_log(
+            ('skipping already processed config file: ' ..
+            '"%s/config.yaml"'):format(g.dir),
+            1024, {filename = g.dir .. '/var/log/instance-001/tarantool.log'}
+        ))
+    end)
+end
+
+g.test_include_erroneous = function()
+    local config = table.deepcopy(common_config)
+    local errorneous_config = ":"
+
+    local config_file = treegen.write_file(
+        g.dir, 'config.yaml', yaml.encode(config))
+    treegen.write_file(g.dir, 'errorneous_config.yaml', errorneous_config)
+
+    local opts = {
+        config_file = config_file,
+        alias = 'instance-001',
+        chdir = g.dir,
+    }
+
+    g.server = server:new(opts)
+    g.server:start()
+
+    config.include = {'errorneous_config.yaml'}
+    treegen.write_file(g.dir, 'config.yaml', yaml.encode(config))
+
+    t.assert_error_msg_matches(
+        ".*Unable to parse config file .* as YAML.*",
+        g.server.exec, g.server, function()
+            require('config'):reload()
+    end)
+end
+
+g.test_conditional_include = function()
+    local config = table.deepcopy(common_config)
+    config.conditional = {
+        {
+            ['if'] = 'tarantool_version >= 0.0.0',
+            ['include'] = {'included_config.yaml'},
+        },
+    }
+
+    local included_config = {
+        groups = {
+            ['group-001'] = {
+                replicasets = {
+                    ['replicaset-001'] = {
+                        instances = {
+                            ['instance-001'] = {
+                                labels = {
+                                    value_1 = 'from included_config.yaml',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    local config_file = treegen.write_file(
+        g.dir, 'config.yaml', yaml.encode(config))
+    treegen.write_file(
+        g.dir, 'included_config.yaml', yaml.encode(included_config))
+
+    local opts = {
+        config_file = config_file,
+        alias = 'instance-001',
+        chdir = g.dir,
+    }
+    g.server = server:new(opts)
+    g.server:start()
+
+    g.server:exec(function()
+        t.assert_equals(
+            require('config'):get('labels').value_1,
+            'from included_config.yaml'
+        )
+    end)
+
+    config = table.deepcopy(common_config)
+    config.conditional = {
+        {
+            ['if'] = 'tarantool_version < 0.0.0',
+            ['include'] = {'included_config.yaml'},
+        },
+    }
+    treegen.write_file(g.dir, 'config.yaml', yaml.encode(config))
+
+    g.server:exec(function()
+        require('config'):reload()
+        t.assert_equals(
+            require('config'):get('labels').value_1,
+            'from config.yaml'
+        )
+    end)
+end


### PR DESCRIPTION
Closes #11583
Closes TNTP-229

@TarantoolBot document
Title: config: `include` section for config files.

Using this section it is possible to include one or several other config
files from any config file. This is a top level field for file-based
configuration. If present, this field must be an array of strings.
Each entry in this array can be an absolute or relative path to a config
file to be included, or a wildcard pattern. Relative path are considered
relative to the file, where they are included.
Include section can be placed inside a `conditional` section.
The non-existing included files are skipped. If an included file exists
and is not a valid tarantool config file, an error will be raised.

Example config.yaml:
```yaml
include:
  - config_a.yaml
  - /etc/tarantool/config_b.yaml
  - conf.d/*.yaml
```

For the provided example the resulting configuration will be merged
according to the rules:
1. Config file provided by `--config` flag is read (`config.yaml` in
   our example).
2. `config_a.yaml` from the same directory as the `config.yaml` is
   merged onto it.
3. Recursively, the includes of `config_a.yaml` are merged onto the
   configuration.
4. `/etc/tarantool/config_b.yaml` is merged.
5. Recursively, the includes of `/etc/tarantool/config_b.yaml` are
   merged onto the configuration.
6. For each config file, matching the wildcard pattern, in alphabetical
   order the configuration from the file itself is merged, then its
   includes are processed recursively, before processing the next
   wildcard match.
