### PR TITLE
box: add configuration option for quiver storage engine

### DIFF
--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -2487,6 +2487,33 @@ I['vinyl.write_threads'] = format_text([[
 
 -- }}} vinyl configuration
 
+-- {{{ quiver configuration
+
+I['quiver'] = format_text([[
+   This section defines configuration parameters related to
+   the quiver storage engine.
+]])
+
+I['quiver.dir'] = format_text([[
+    A directory where quiver files or subdirectories will be stored. This option
+    may contain a relative file path. In this case, it is interpreted as
+    relative to `process.work_dir`.
+]])
+
+I['quiver.memory'] = format_text([[
+    The maximum size of in-memory buffers used for accumulating write requests.
+    The quiver engine decides when it should start dumping in-memory buffers to
+    disk depending on this parameter.
+]])
+
+I['quiver.run_size'] = format_text([[
+    The maximum size of a run file, in bytes. When the quiver engine dumps
+    in-memory buffers to disk, it splits the output stream into files depending
+    on this parameter.
+]])
+
+-- }}} quiver configuration
+
 -- {{{ wal configuration
 
 I['wal'] = format_text([[

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1069,6 +1069,25 @@ return schema.new('instance_config', schema.record({
             default = 4,
         }),
     }),
+    quiver = enterprise_edition(schema.record({
+        dir = enterprise_edition(schema.scalar({
+            type = 'string',
+            box_cfg = 'quiver_dir',
+            box_cfg_nondynamic = true,
+            mkdir = true,
+            default = 'var/lib/{{ instance_name }}',
+        })),
+        memory = enterprise_edition(schema.scalar({
+            type = 'integer',
+            box_cfg = 'quiver_memory',
+            default = 128 * 1024 * 1024,
+        })),
+        run_size = enterprise_edition(schema.scalar({
+            type = 'integer',
+            box_cfg = 'quiver_run_size',
+            default = 16 * 1024 * 1024,
+        })),
+    })),
     wal = schema.record({
         dir = schema.scalar({
             type = 'string',

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -83,6 +83,12 @@ local function ifdef_wal_retention_period(value)
     end
 end
 
+local function ifdef_quiver(value)
+    if private.cfg_set_quiver_memory ~= nil then
+        return value
+    end
+end
+
 -- all available options
 local default_cfg = {
     listen              = nil,
@@ -111,6 +117,10 @@ local default_cfg = {
     vinyl_range_size          = nil, -- set automatically
     vinyl_page_size           = 8 * 1024,
     vinyl_bloom_fpr           = 0.05,
+
+    quiver_dir          = ifdef_quiver('.'),
+    quiver_memory       = ifdef_quiver(128 * 1024 * 1024),
+    quiver_run_size     = ifdef_quiver(16 * 1024 * 1024),
 
     log                 = log.cfg.log,
     log_nonblock        = log.cfg.nonblock,
@@ -316,6 +326,10 @@ local template_cfg = {
     vinyl_page_size           = 'number',
     vinyl_bloom_fpr           = 'number',
 
+    quiver_dir          = ifdef_quiver('string'),
+    quiver_memory       = ifdef_quiver('number'),
+    quiver_run_size     = ifdef_quiver('number'),
+
     log                 = 'string',
     log_nonblock        = 'boolean',
     log_level           = 'number, string',
@@ -519,6 +533,8 @@ local dynamic_cfg = {
     vinyl_cache             = private.cfg_set_vinyl_cache,
     vinyl_timeout           = private.cfg_set_vinyl_timeout,
     vinyl_defer_deletes     = nop,
+    quiver_memory           = private.cfg_set_quiver_memory,
+    quiver_run_size         = private.cfg_set_quiver_run_size,
     checkpoint_count        = private.cfg_set_checkpoint_count,
     checkpoint_interval     = private.cfg_set_checkpoint_interval,
     checkpoint_wal_threshold = private.cfg_set_checkpoint_wal_threshold,
@@ -710,6 +726,8 @@ local dynamic_cfg_skip_at_load = {
     vinyl_max_tuple_size    = true,
     vinyl_cache             = true,
     vinyl_timeout           = true,
+    quiver_memory           = ifdef_quiver(true),
+    quiver_run_size         = ifdef_quiver(true),
     too_long_threshold      = true,
     election_mode           = true,
     election_timeout        = true,

--- a/test/box/box.lua
+++ b/test/box/box.lua
@@ -21,6 +21,9 @@ local _hide = {
 }
 
 local _enterprise_keys = {
+    quiver_dir = true,
+    quiver_memory = true,
+    quiver_run_size = true,
     audit_log = true,
     audit_nonblock = true,
     audit_format = true,

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -78,6 +78,7 @@ local instance_config_fields = {
     'sql',
     'memtx',
     'vinyl',
+    'quiver',
     'wal',
     'snapshot',
     'replication',
@@ -292,6 +293,11 @@ g.test_defaults = function()
             memory = 134217728,
             timeout = 60,
         },
+        quiver = is_enterprise and {
+            dir = 'var/lib/{{ instance_name }}',
+            memory = 134217728,
+            run_size = 16777216,
+        } or nil,
         database = {
             instance_uuid = box.NULL,
             replicaset_uuid = box.NULL,

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1451,6 +1451,7 @@ g.test_box_cfg_coverage = function()
         pid_file = true,
         wal_dir = true,
         vinyl_dir = true,
+        quiver_dir = true,
 
         -- The effective default is determined depending of
         -- the replication.failover option.


### PR DESCRIPTION
This commit adds the following configuration options:

```
* quiver.dir (box.cfg.quiver_dir)
* quiver.memory (box.cfg.quiver_memory)
* quiver.run_size (box.cfg.quiver_run_size)
```

They will be implemented in the EE repository.

Needed for tarantool/tarantool-ee#1258
Needed for tarantool/tarantool-ee#1259
Needed for tarantool/tarantool-ee#1260

EE PR that bumps the CE submodule: https://github.com/tarantool/tarantool-ee/pull/1313