### PR TITLE
config: add config.etcd.http.request.verbose

### DIFF
--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -487,6 +487,15 @@ I['config.etcd.http.request.timeout'] = format_text([[
 I['config.etcd.http.request.unix_socket'] = format_text([[
     A Unix domain socket used to connect to an etcd server.
 ]])
+I['config.etcd.http.request.verbose'] = format_text([[
+    Whether to print debugging information about HTTP requests and responses
+    issued by the etcd configuration source.
+
+    The information is written to stderr (disregarding tarantool log
+    configuration). In a typical setup it arrives to journald.
+
+    See https://curl.se/libcurl/c/CURLOPT_VERBOSE.html for details.
+]])
 
 I['config.etcd.password'] = 'A password used for authentication.'
 

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -363,6 +363,9 @@ return schema.new('instance_config', schema.record({
                     unix_socket = schema.scalar({
                         type = 'string',
                     }),
+                    verbose = schema.scalar({
+                        type = 'boolean',
+                    }),
                 }),
             }),
             watchers = schema.record({

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -111,6 +111,7 @@ g.test_config_enterprise = function()
                     request = {
                         timeout = 1,
                         unix_socket = 'six',
+                        verbose = true,
                     }
                 },
                 watchers = {


### PR DESCRIPTION
This option enables the `http.client`'s `verbose` option for the etcd client that is used in the etcd configuration source. It allows to get more debugging information is case of a problem.

Part of tarantool/tarantool-ee#1314