### PR TITLE
gitignore: add generated TLA+ Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ test/Makefile
 test/*/Makefile
 test/*/*/Makefile
 test/*/*-workdir-*
+proofs/tla/test/Makefile
 Doxyfile.API
 RPM
 *.src.rpm


### PR DESCRIPTION
Useful for in-source build.