### PR TITLE
config: add config.etcd.http.request.interface

### DIFF
--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -480,6 +480,15 @@ I['config.etcd.http'] = format_text([[
 
 I['config.etcd.http.request'] = 'HTTP client request options.'
 
+I['config.etcd.http.request.interface'] = format_text([[
+    Set the interface to use as outgoing network interface for the etcd
+    configuration source.
+
+    The interface can be specified as an interface name, an IP address, or a
+    hostname.
+
+    See https://curl.se/libcurl/c/CURLOPT_INTERFACE.html for details.
+]])
 I['config.etcd.http.request.timeout'] = format_text([[
     A time period required to process an HTTP request to an etcd server:
     from sending a request to receiving a response.

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -366,6 +366,9 @@ return schema.new('instance_config', schema.record({
                     verbose = schema.scalar({
                         type = 'boolean',
                     }),
+                    interface = schema.scalar({
+                        type = 'string',
+                    }),
                 }),
             }),
             watchers = schema.record({

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -112,6 +112,7 @@ g.test_config_enterprise = function()
                         timeout = 1,
                         unix_socket = 'six',
                         verbose = true,
+                        interface = 'eth0',
                     }
                 },
                 watchers = {


### PR DESCRIPTION
This option enables the `http.client`'s `interface` option for the etcd client that is used in the etcd configuration source. It allows to specify certain network interface for outgoing connections.

Part of tarantool/tarantool-ee#1322