### PR TITLE
[backport 3.3] replication: fix several issues related to the 'orphan' status

### DIFF
--- a/changelogs/unreleased/gh-10592-replica-does-not-receive-its-own-rows.md
+++ b/changelogs/unreleased/gh-10592-replica-does-not-receive-its-own-rows.md
@@ -1,0 +1,7 @@
+## bugfix/recovery
+
+* Fixed a bug where a master node that crashed and lost its xlog files for
+  some reason might never get some of its own rows from upstreams after
+  reconnecting. A new ro-reason "waiting_for_own_rows" was introduced for this.
+  Now, until the instance has received all its rows, it is in this mode and
+  remains read only (gh-10592).

--- a/changelogs/unreleased/gh-11156-fix-calculation-of-sync-quorum-in-config-and-supervised.md
+++ b/changelogs/unreleased/gh-11156-fix-calculation-of-sync-quorum-in-config-and-supervised.md
@@ -1,0 +1,6 @@
+## bugfix/replication
+
+* Fixed a bug when the node configured as
+  `box.cfg.bootstrap_mode` = `'config'`/`'supervised''` didn't switch to
+  the 'orphan' status even if it failed to synchronize with each of the
+  connected nodes. (gh-11156).

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -2371,7 +2371,7 @@ applier_subscribe(struct applier *applier)
 	 * Stop accepting local rows coming from a remote
 	 * instance as soon as local WAL starts accepting writes.
 	 */
-	req.id_filter = box_is_orphan() ? 0 : 1 << instance_id;
+	req.id_filter = box_is_waiting_for_own_rows() ? 0 : 1 << instance_id;
 	RegionGuard region_guard(&fiber()->gc);
 	xrow_encode_subscribe(&row, &req);
 	coio_write_xrow(io, &row);

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -2093,11 +2093,10 @@ box_set_election_fencing_mode(void)
 }
 
 /*
- * Sync box.cfg.replication with the cluster registry, but
- * don't start appliers.
+ * Sync box.cfg.replication with the cluster registry.
  */
 static void
-box_sync_replication(bool do_quorum, bool do_reuse)
+box_sync_replication(bool demand_quorum, bool keep_connect, bool wait_all)
 {
 	struct uri_set uri_set;
 	int rc = cfg_get_uri_set("replication", &uri_set);
@@ -2106,15 +2105,16 @@ box_sync_replication(bool do_quorum, bool do_reuse)
 	auto uri_set_guard = make_scoped_guard([&]{
 		uri_set_destroy(&uri_set);
 	});
-	replicaset_connect(&uri_set, do_quorum, do_reuse);
+	replicaset_connect(&uri_set, demand_quorum, keep_connect, wait_all);
 }
 
 static inline void
 box_restart_replication(void)
 {
-	const bool do_quorum = true;
-	const bool do_reuse = false;
-	box_sync_replication(do_quorum, do_reuse);
+	const bool demand_quorum = true;
+	const bool keep_connect = false;
+	const bool wait_all = true;
+	box_sync_replication(demand_quorum, keep_connect, wait_all);
 }
 
 static inline void
@@ -2126,9 +2126,11 @@ box_update_replication(void)
 	 * In every other mode, try to connect to everyone during the given time
 	 * period, but do not fail even if no connections were established.
 	 */
-	const bool do_quorum = bootstrap_strategy != BOOTSTRAP_STRATEGY_LEGACY;
-	const bool do_reuse = true;
-	box_sync_replication(do_quorum, do_reuse);
+	const bool demand_quorum =
+		bootstrap_strategy != BOOTSTRAP_STRATEGY_LEGACY;
+	const bool keep_connect = true;
+	const bool wait_all = bootstrap_strategy != BOOTSTRAP_STRATEGY_LEGACY;
+	box_sync_replication(demand_quorum, keep_connect, wait_all);
 }
 
 void

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -136,6 +136,9 @@ struct tt_uuid bootstrap_leader_uuid;
 
 bool box_is_force_recovery = false;
 
+waiting_for_own_rows_trigger
+	box_check_waiting_for_own_rows_trigger;
+
 /**
  * If backup is in progress, this points to the gc reference
  * object that prevents the garbage collector from deleting
@@ -172,6 +175,12 @@ static fiber_cond ro_cond;
  * a quorum and so was forced to switch to read-only mode.
  */
 static bool is_orphan;
+
+/**
+ * The following flag is set if the instance is waiting for some
+ * of its own transactions that it lost to be replicated to it.
+ */
+static bool is_waiting_for_own_rows = false;
 
 /**
  * Summary flag incorporating all the instance attributes,
@@ -348,8 +357,8 @@ void
 box_update_ro_summary(void)
 {
 	bool old_is_ro_summary = is_ro_summary;
-	is_ro_summary = is_ro || is_orphan || raft_is_ro(box_raft()) ||
-			txn_limbo_is_ro(&txn_limbo);
+	is_ro_summary = is_ro || is_orphan || is_waiting_for_own_rows ||
+			raft_is_ro(box_raft()) || txn_limbo_is_ro(&txn_limbo);
 	/* In 99% nothing changes. Filter this out first. */
 	if (is_ro_summary == old_is_ro_summary)
 		return;
@@ -371,6 +380,9 @@ box_ro_reason(void)
 		return "synchro";
 	if (is_ro)
 		return "config";
+	if (is_waiting_for_own_rows)
+		return "waiting to receive its own transactions "
+			"back from the replicaset";
 	if (is_orphan)
 		return "orphan";
 	return NULL;
@@ -448,7 +460,12 @@ box_check_writable(void)
 	} else {
 		if (is_ro)
 			error_append_msg(e, "box.cfg.read_only is true");
-		else if (is_orphan)
+		else if (is_waiting_for_own_rows) {
+			error_append_msg(e, "it has lost some of its own "
+					 "transactions and is waiting to "
+					 "receive them back from the "
+					 "replicaset");
+		} else if (is_orphan)
 			error_append_msg(e, "it is an orphan");
 		else
 			assert(false);
@@ -549,6 +566,12 @@ box_is_orphan(void)
 }
 
 bool
+box_is_waiting_for_own_rows(void)
+{
+	return is_waiting_for_own_rows;
+}
+
+bool
 box_is_anon(void)
 {
 	return instance_id == REPLICA_ID_NIL;
@@ -577,17 +600,39 @@ box_do_set_orphan(bool orphan)
 }
 
 void
+box_update_title()
+{
+	if (is_waiting_for_own_rows)
+		title("waiting_for_own_rows");
+	else if (is_orphan)
+		title("orphan");
+	else
+		title("running");
+}
+
+void
 box_set_orphan(bool orphan)
 {
 	box_do_set_orphan(orphan);
 	/* Update the title to reflect the new status. */
-	if (is_orphan) {
+	if (is_orphan)
 		say_info("entering orphan mode");
-		title("orphan");
-	} else {
+	else
 		say_info("leaving orphan mode");
-		title("running");
-	}
+	box_update_title();
+}
+
+void
+box_set_waiting_for_own_rows(bool waiting_for_own_rows)
+{
+	is_waiting_for_own_rows = waiting_for_own_rows;
+	box_update_ro_summary();
+	/* Update the title to reflect the new status. */
+	if (is_waiting_for_own_rows)
+		say_info("entering waiting_for_own_rows mode");
+	else
+		say_info("leaving waiting_for_own_rows mode");
+	box_update_title();
 }
 
 struct wal_stream {
@@ -2555,6 +2600,37 @@ box_quorum_on_ack_f(struct trigger *trigger, void *event)
 		trigger_clear(trigger);
 	}
 	return 0;
+}
+
+static int
+box_check_waiting_for_own_rows_f(struct trigger *trigger, void *event)
+{
+	(void)event;
+	auto &t = box_check_waiting_for_own_rows_trigger;
+	assert((struct trigger *)&t == trigger);
+	int64_t local_lsn = vclock_get(instance_vclock, instance_id);
+	if (local_lsn >= t.target_lsn) {
+		box_set_waiting_for_own_rows(false);
+		trigger_clear(trigger);
+	}
+	return 0;
+}
+
+void
+box_check_waiting_for_own_rows(void)
+{
+	auto &t = box_check_waiting_for_own_rows_trigger;
+	t.target_lsn = replicaset_max_instance_lsn();
+	int64_t local_lsn = vclock_get(instance_vclock, instance_id);
+
+	if (local_lsn < t.target_lsn) {
+		box_set_waiting_for_own_rows(true);
+		trigger_create(&t.base, box_check_waiting_for_own_rows_f,
+			       NULL, NULL);
+		trigger_add(&wal_on_write, &t.base);
+	} else {
+		box_set_waiting_for_own_rows(false);
+	}
 }
 
 /**
@@ -5936,6 +6012,16 @@ box_cfg_xc(void)
 	}
 
 	rmean_cleanup(rmean_box);
+
+	/**
+	 * All the applier are stopped now on point before subscribing. They are
+	 * stopped at the moment they got the CONNECTED status. Now it need to
+	 * make sure that the current instance is aware of all its own
+	 * transactions. This needs to be done before subscribing, in order to
+	 * correctly determine the id_filter value in the subscribe request.
+	 * The appliers will continue after calling replicaset_follow.
+	 */
+	box_check_waiting_for_own_rows();
 
 	/* Follow replica */
 	replicaset_follow();

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -31,6 +31,7 @@
  * SUCH DAMAGE.
  */
 #include "trivia/util.h"
+#include "trigger.h"
 
 #include <stdbool.h>
 
@@ -110,6 +111,17 @@ extern struct tt_uuid bootstrap_leader_uuid;
 
 /** box.cfg.force_recovery. */
 extern bool box_is_force_recovery;
+
+/**
+ * A trigger that is set on the wal_on_write event to track the moment when the
+ * instance receives from the replicaset all of its transactions that it lost.
+ */
+extern struct waiting_for_own_rows_trigger {
+	/** Inherit trigger. */
+	struct trigger base;
+	/** Target LSN to wait for. */
+	int64_t target_lsn;
+} box_check_waiting_for_own_rows_trigger;
 
 /*
  * Initialize box library
@@ -197,6 +209,13 @@ box_is_ro(void);
 
 bool
 box_is_orphan(void);
+
+/**
+ * Check if the instance is waiting for some of its own transactions
+ * that it lost to be replicated back to it.
+ */
+bool
+box_is_waiting_for_own_rows(void);
 
 /** Check if the instance is not registered in the replicaset. */
 bool

--- a/src/box/replication.cc
+++ b/src/box/replication.cc
@@ -1156,7 +1156,7 @@ bootstrap_leader_is_connected(struct applier **appliers, int count)
 static bool
 replicaset_is_connected(struct replicaset_connect_state *state,
 			struct applier **appliers, int count,
-			bool connect_quorum)
+			bool wait_all)
 {
 	if (replicaset_state == REPLICASET_BOOTSTRAP ||
 	    replicaset_state == REPLICASET_JOIN) {
@@ -1204,7 +1204,7 @@ replicaset_is_connected(struct replicaset_connect_state *state,
 	 * different cluster UUIDs.
 	 */
 	if (state->connected >= replicaset_connect_quorum(count) &&
-	    !connect_quorum) {
+	    !wait_all) {
 		return true;
 	}
 	if (count - state->failed < replicaset_connect_quorum(count))
@@ -1214,7 +1214,7 @@ replicaset_is_connected(struct replicaset_connect_state *state,
 
 void
 replicaset_connect(const struct uri_set *uris,
-		   bool connect_quorum, bool keep_connect)
+		   bool demand_quorum, bool keep_connect, bool wait_all)
 {
 	struct replicaset_connect_state state;
 	memset(&state, 0, sizeof(state));
@@ -1247,7 +1247,7 @@ replicaset_connect(const struct uri_set *uris,
 
 	say_info("connecting to %d replicas", count);
 
-	if (!connect_quorum) {
+	if (!demand_quorum) {
 		/*
 		 * Enter orphan mode on configuration change and
 		 *
@@ -1302,8 +1302,7 @@ replicaset_connect(const struct uri_set *uris,
 			trigger_clear(&trigger->base);
 		}
 	});
-	while (!replicaset_is_connected(&state, appliers, count,
-					connect_quorum)) {
+	while (!replicaset_is_connected(&state, appliers, count, wait_all)) {
 		double wait_start = ev_monotonic_now(loop());
 		if (fiber_cond_wait_timeout(&state.wakeup, timeout) != 0) {
 			fiber_testcancel();
@@ -1316,7 +1315,7 @@ replicaset_connect(const struct uri_set *uris,
 			 count - state.connected, count);
 		/* Timeout or connection failure. */
 		if (state.connected < replicaset_connect_quorum(count) &&
-		    connect_quorum) {
+		    demand_quorum) {
 			tnt_raise(ClientError, ER_CFG, "replication",
 				  "failed to connect to one or more replicas");
 		}

--- a/src/box/replication.cc
+++ b/src/box/replication.cc
@@ -728,7 +728,14 @@ replica_on_applier_connect(struct replica *replica)
 {
 	if (replica->applier_sync_state == APPLIER_CONNECTED)
 		return;
+
 	struct applier *applier = replica->applier;
+	if (box_is_waiting_for_own_rows()) {
+		auto &t = box_check_waiting_for_own_rows_trigger;
+		int64_t remote_lsn =
+			vclock_get(&applier->ballot.vclock, instance_id);
+		t.target_lsn = MAX(t.target_lsn, remote_lsn);
+	}
 
 	assert(tt_uuid_is_nil(&replica->uuid));
 	assert(!tt_uuid_is_nil(&applier->uuid));
@@ -1495,6 +1502,19 @@ replicaset_check_quorum(void)
 {
 	if (replicaset.applier.synced >= replicaset_sync_quorum())
 		box_set_orphan(false);
+}
+
+int64_t
+replicaset_max_instance_lsn(void)
+{
+	int64_t max_lsn = 0;
+	replicaset_foreach(replica) {
+		if (replica->applier == NULL)
+			continue;
+		struct vclock *remote_vclock = &replica->applier->ballot.vclock;
+		max_lsn = MAX(max_lsn, vclock_get(remote_vclock, instance_id));
+	}
+	return max_lsn;
 }
 
 /** A helper to update relay health on its start/stop. */

--- a/src/box/replication.h
+++ b/src/box/replication.h
@@ -663,16 +663,22 @@ replicaset_add_anon(const struct tt_uuid *replica_uuid);
  *
  * \param uris           remote peer URIs
  * \param timeout        connection timeout
- * \param connect_quorum if this flag is set, fail unless at
- *                       least replication_connect_quorum
- *                       appliers have successfully connected.
- * \param keep_connect   if this flag is set do not force a reconnect if the
+ * \param demand_quorum  whether it should fail in case it can't connect
+ *                       to a quorum.
+ * \param keep_connect   whether it shouldn't force a reconnect if the
  *                       old connection to the replica is fine.
+ * \param wait_all       whether it should wait for all connections to be
+ *                       established for a full replication_connect_timeout,
+ *                       or it may exit as soon as a quorum is gathered. Even
+ *                       if wait_all = true, and during the timeout it failed
+ *                       to connect to everyone, but enough connections were
+ *                       established to gather a quorum, it does not throw
+ *                       anything. More connections are better, but it doesn't
+ *                       matter if you can't connect to everyone.
  */
 void
 replicaset_connect(const struct uri_set *uris,
-		   bool connect_quorum, bool keep_connect);
-
+		   bool demand_quorum, bool keep_connect, bool wait_all);
 /**
  * Reload replica URIs.
  *

--- a/src/box/replication.h
+++ b/src/box/replication.h
@@ -722,6 +722,16 @@ replicaset_sync(void);
 void
 replicaset_check_quorum(void);
 
+/**
+ * Find the maximum lsn of a transaction created by the current instance in a
+ * replicaset. There may be situations when a transaction created at some
+ * point on the current instance is no longer present on this instance, but is
+ * present on some node in the replicaset. This may happen as a result of a
+ * crash and loss of logs.
+ */
+int64_t
+replicaset_max_instance_lsn(void);
+
 #endif /* defined(__cplusplus) */
 
 #endif

--- a/test/replication-luatest/gh_10592_replica_does_not_receive_its_own_rows_test.lua
+++ b/test/replication-luatest/gh_10592_replica_does_not_receive_its_own_rows_test.lua
@@ -1,0 +1,224 @@
+local t = require('luatest')
+local cluster = require('luatest.replica_set')
+local fio = require('fio')
+local server = require('luatest.server')
+local proxy = require('luatest.replica_proxy')
+
+local g = t.group('replica-does-not-receive-its-own-rows')
+
+local wait_timeout = 20
+
+local function wait_pair_sync(server1, server2)
+    -- Without retrying it fails sometimes when vclocks are empty and both
+    -- instances are in 'connect' state instead of 'follow'.
+    t.helpers.retrying({timeout = wait_timeout}, function()
+        server1:wait_for_vclock_of(server2)
+        server2:wait_for_vclock_of(server1)
+        server1:assert_follows_upstream(server2:get_instance_id())
+        server2:assert_follows_upstream(server1:get_instance_id())
+    end)
+end
+
+g.after_each(function(cg)
+    cg.cluster:drop()
+end)
+
+g.before_test('test_master_falls_and_loses_xlogs', function(cg)
+    cg.cluster = cluster:new({})
+
+    local box_cfg = {
+        replication = {
+            server.build_listen_uri('master', cg.cluster.id),
+            server.build_listen_uri('replica', cg.cluster.id),
+        },
+        replication_timeout = 0.1,
+    }
+    cg.master = cg.cluster:build_and_add_server({
+        alias = 'master',
+        box_cfg = box_cfg
+    })
+    cg.replica = cg.cluster:build_and_add_server({
+        alias = 'replica',
+        box_cfg = box_cfg
+    })
+    cg.cluster:start()
+    cg.master:exec(function()
+        box.ctl.promote()
+        box.ctl.wait_rw()
+        box.schema.space.create('test')
+        box.space.test:create_index('pk')
+    end)
+    wait_pair_sync(cg.replica, cg.master)
+end)
+
+local function grep_log(server, str)
+    local logfile = fio.pathjoin(server.workdir, server.alias .. '.log')
+    t.helpers.retrying({ timeout = wait_timeout }, function()
+        t.assert(server:grep_log(str, nil, {filename = logfile}))
+    end)
+end
+
+g.test_master_falls_and_loses_xlogs = function(cg)
+    cg.master:exec(function()
+        box.snapshot()
+        box.space.test:insert{1}
+    end)
+    wait_pair_sync(cg.replica, cg.master)
+    cg.master:stop()
+    local xlog = fio.glob(fio.pathjoin(cg.master.workdir, '*.xlog'))
+    for _, file in pairs(xlog) do fio.unlink(file) end
+    cg.master:restart()
+
+    grep_log(cg.master, "entering waiting_for_own_rows mode")
+    wait_pair_sync(cg.replica, cg.master)
+
+    grep_log(cg.master, "leaving waiting_for_own_rows mode")
+    grep_log(cg.master, "ready to accept requests")
+
+    cg.master:exec(function()
+        t.assert_not_equals(box.space.test:get{1}, nil)
+    end)
+end
+
+g.before_test('test_new_connections_while_waiting_for_own_rows', function(cg)
+    t.tarantool.skip_if_not_debug()
+
+    cg.cluster = cluster:new({})
+
+    cg.replica = {}
+    cg.replica_uri = {
+        server.build_listen_uri('replica1', cg.cluster.id),
+        server.build_listen_uri('replica2_proxy'),
+    }
+    cg.replica_cfg = {}
+
+    local master_uri = server.build_listen_uri('master', cg.cluster.id)
+
+    for i = 1, 2 do
+        cg.replica_cfg[i] = {
+            bootstrap_strategy = 'config',
+            bootstrap_leader = master_uri,
+            replication = { master_uri, cg.replica_uri[i], },
+        }
+        cg.replica[i] = cg.cluster:build_and_add_server({
+            alias = string.format('replica%d', i),
+            box_cfg = cg.replica_cfg[i],
+        })
+    end
+
+    cg.master = cg.cluster:build_and_add_server({
+        alias = 'master',
+        box_cfg = {
+            bootstrap_strategy = 'config',
+            bootstrap_leader = master_uri,
+            replication = {
+                master_uri, cg.replica_uri[1], cg.replica_uri[2],
+            },
+            replication_connect_timeout = 1,
+        },
+    })
+
+    -- We want replica2 to be specified in replication on the master,
+    -- but the connection could not be established.
+    cg.replica2_proxy = proxy:new({
+        client_socket_path = cg.replica_uri[2],
+        server_socket_path =
+            server.build_listen_uri('replica2', cg.cluster.id),
+    })
+    t.assert(cg.replica2_proxy:start({force = true}))
+
+    cg.cluster:start()
+    cg.master:exec(function()
+        box.ctl.promote()
+        box.ctl.wait_rw()
+        box.schema.space.create('test')
+        box.space.test:create_index('pk')
+    end)
+end)
+
+-- Test that new connections are taken into account while the node is waiting
+-- for own rows. In this test, replica2 connects to the master while it waits
+-- for its own rows. The master must take into account that there is also a
+-- second row, located uniquely on replica2. After this, syncing with replica1
+-- alone should not be enough to leave the state waiting_for_own_rows mode,
+-- master must sync with replica1 to get all its own rows back.
+g.test_new_connections_while_waiting_for_own_rows = function(cg)
+    -- Both replicas get the first row.
+    cg.master:exec(function()
+        box.snapshot()
+        box.space.test:insert{1}
+    end)
+    wait_pair_sync(cg.replica[1], cg.master)
+    -- But only the second replica gets the second row.
+    cg.replica[1]:update_box_cfg({ replication = { cg.replica_uri[1], } })
+    cg.master:exec(function() box.space.test:insert{2} end)
+    wait_pair_sync(cg.replica[2], cg.master)
+
+    cg.master:stop()
+    -- Return replica1 to initial cfg (just to make wait_pair_sync work).
+    cg.replica[1]:update_box_cfg({
+        replication = cg.replica_cfg[1].replication,
+        replication_connect_timeout = 1,
+    })
+    -- Truncate xlogs on master.
+    local xlog = fio.glob(fio.pathjoin(cg.master.workdir, '*.xlog'))
+    for _, file in pairs(xlog) do fio.unlink(file) end
+    -- Stop replication from both replica1 and replica2.
+    for i = 1, 2 do
+        cg.replica[i]:exec(function()
+            box.error.injection.set('ERRINJ_RELAY_SEND_DELAY', true)
+        end)
+    end
+    -- Stop proxy to prevent connection with replica2. The master will
+    -- receive ballot only from replica1 and will not know about the
+    -- existence of the second row for some time.
+    cg.replica2_proxy:pause()
+
+    cg.master:restart()
+    -- Master sees that replica1 has one row created by master itself
+    -- before the crash, so it goes waiting_for_own_rows mode.
+    grep_log(cg.master, "entering waiting_for_own_rows mode")
+    cg.master:exec(function(wait_timeout)
+        t.helpers.retrying({ timeout = wait_timeout }, function()
+            t.assert_equals(box.info.status, "waiting_for_own_rows")
+        end)
+    end, { wait_timeout })
+    cg.replica2_proxy:resume()
+    -- Let's wait until the master receives the ballot from replica2
+    -- and update self rows max lsn. Otherwise the master could
+    -- exit waiting_for_own_rows too soon.
+    local replica2_id = cg.replica[2]:get_instance_id()
+    cg.master:exec(function(replica2_id, wait_timeout)
+        t.helpers.retrying({ timeout = wait_timeout }, function()
+            t.assert_not_equals(
+                box.info.replication[replica2_id].upstream.status, 'sync')
+        end)
+    end, { replica2_id, wait_timeout })
+    cg.replica[1]:exec(function()
+        box.error.injection.set('ERRINJ_RELAY_SEND_DELAY', false)
+    end)
+    wait_pair_sync(cg.replica[1], cg.master)
+    -- Syncing with replica1 is not enough to leave waiting_for_own_rows mode.
+    cg.master:exec(function()
+        t.assert_equals(box.info.status, "waiting_for_own_rows")
+    end)
+    -- But syncing with replica2 is enough.
+    cg.replica[2]:exec(function()
+        box.error.injection.set('ERRINJ_RELAY_SEND_DELAY', false)
+    end)
+    wait_pair_sync(cg.replica[2], cg.master)
+    cg.master:exec(function()
+        t.assert_equals(box.info.status, "running")
+    end)
+    grep_log(cg.master, "leaving waiting_for_own_rows mode")
+    grep_log(cg.master, "ready to accept requests")
+    -- Сheck that the master actually received these rows.
+    cg.master:exec(function()
+        t.assert_not_equals(box.space.test:get{1}, nil)
+        t.assert_not_equals(box.space.test:get{2}, nil)
+    end)
+end
+
+g.after_test('test_new_connections_while_waiting_for_own_rows', function()
+    g.replica2_proxy:stop()
+end)

--- a/test/replication-luatest/gh_11156_calculation_of_sync_quorum_in_config_and_supervised_test.lua
+++ b/test/replication-luatest/gh_11156_calculation_of_sync_quorum_in_config_and_supervised_test.lua
@@ -1,0 +1,170 @@
+local t = require('luatest')
+local cluster = require('luatest.replica_set')
+local server = require('luatest.server')
+local fio = require('fio')
+local socket = require('socket')
+local proxy = require('luatest.replica_proxy')
+
+local g =
+    t.group('gh-11156-calculation-of-sync-quorum-in-config-and-supervised')
+--
+-- gh-11156:
+-- Calculation of sync quorum in 'config'/'supervised' bootstrap modes.
+--
+local wait_timeout = 20
+
+g.before_each(function(cg)
+    t.tarantool.skip_if_not_debug()
+
+    cg.cluster = cluster:new({})
+
+    local box_cfg = {
+        replication = {
+            server.build_listen_uri('master', cg.cluster.id),
+            server.build_listen_uri('replica1', cg.cluster.id),
+            server.build_listen_uri('replica2', cg.cluster.id),
+            server.build_listen_uri('replica3', cg.cluster.id),
+        },
+        bootstrap_strategy = 'supervised',
+        -- Retry bootstrap immediately.
+        replication_timeout = 0.1,
+    }
+
+    -- There will be some non-booted nodes,
+    -- so the net box will not be able to connect to them.
+    local console_listen = "require('console').listen('unix/:%s')\n"
+
+    -- Bootstrap master.
+    cg.master = cg.cluster:build_and_add_server({
+        alias = 'master',
+        box_cfg = box_cfg,
+    })
+    cg.master_admin = fio.pathjoin(cg.master.workdir, 'master.admin')
+    cg.master.env.TARANTOOL_RUN_BEFORE_BOX_CFG =
+        string.format(console_listen, cg.master_admin)
+
+    -- Booted, non-replicable.
+    cg.non_synced_replicas = { 'replica2', 'replica3' }
+    for _, replica_name in ipairs(cg.non_synced_replicas) do
+        cg[replica_name] = cg.cluster:build_and_add_server({
+            alias = replica_name,
+            box_cfg = box_cfg,
+        })
+        cg[replica_name].env.TARANTOOL_RUN_BEFORE_BOX_CFG =
+            -- Stop the relay so that replica1 cannot
+            -- synchronize with replica2, replica3.
+            "box.error.injection.set('ERRINJ_RELAY_SEND_DELAY', true)\n"
+    end
+
+    -- Set low value to immediately go into an 'orphan' status.
+    box_cfg.replication_sync_timeout = 0.001
+    box_cfg.replication[1] = server.build_listen_uri('master_proxy')
+
+    cg.replica1 = cg.cluster:build_and_add_server({
+        alias = 'replica1',
+        box_cfg = box_cfg,
+    })
+    -- Set `log_level` to "debug" to track appliers connection,
+    -- this will be useful to guarantee a certain sync quorum in the test.
+    cg.replica1.box_cfg.log_level = 'debug'
+
+    cg.master_proxy = proxy:new({
+        client_socket_path = server.build_listen_uri('master_proxy'),
+        server_socket_path = server.build_listen_uri('master', cg.cluster.id),
+    })
+    t.assert(cg.master_proxy:start({force = true}))
+    cg.master_proxy:pause()
+
+    cg.cluster:start({wait_until_ready = false})
+end)
+
+g.after_each(function(cg)
+    cg.cluster:drop()
+end)
+
+local function connect_console(sockname)
+    local sock, err = socket.tcp_connect('unix/', sockname)
+    t.assert_equals(err, nil, 'Connection successful')
+    local greeting = sock:read(box.iproto.GREETING_SIZE, wait_timeout)
+    t.assert_str_contains(greeting, 'Tarantool', 'Connected to console')
+    t.assert_str_contains(greeting, 'Lua console', 'Connected to console')
+    return sock
+end
+
+local function make_bootstrap_leader(sock)
+    sock:write('box.ctl.make_bootstrap_leader()\n', wait_timeout)
+    local response = sock:read(8, wait_timeout)
+    t.assert_equals(response, '---\n...\n', 'The call succeeded')
+end
+
+local function wait_uuid(server)
+    local logfile = fio.pathjoin(server.workdir, server.alias .. '.log')
+    t.helpers.retrying({ timeout = wait_timeout }, function()
+        -- In debug logging mode the file size may exceed the default value
+        -- `bytes_num`. Therefore, let's set some large value manually.
+        t.assert(server:grep_log(
+            "instance uuid", 10000000, {filename = logfile}))
+    end)
+end
+
+local function wait_applier_connected(server, upstream)
+    local logfile = fio.pathjoin(server.workdir, server.alias .. '.log')
+    local pattern =
+        string.format("%s%%.sock[^\n]*D> => CONNECTED", upstream.alias)
+    t.helpers.retrying({ timeout = wait_timeout }, function()
+        -- In debug logging mode the file size may exceed the default value
+        -- `bytes_num`. Therefore, let's set some large value manually.
+        t.assert(server:grep_log(
+            pattern, 10000000, {filename = logfile}))
+    end)
+end
+
+g.test_calculation_of_sync_quorum = function(cg)
+    wait_uuid(cg.master)
+
+    local master_sock = t.helpers.retrying(
+        { timeout = wait_timeout }, connect_console, cg.master_admin)
+    make_bootstrap_leader(master_sock)
+    master_sock:close()
+
+    -- Wait until the nodes get bootstraped.
+    cg.master:wait_until_ready()
+    for _, replica_name in ipairs(cg.non_synced_replicas) do
+        cg[replica_name]:wait_until_ready()
+    end
+
+    -- Wait for replica1 to connect to replica2, replica3 before connecting
+    -- to the bootstrap master to ensure that replica2, replica3
+    -- is counted in the sync quorum.
+    wait_applier_connected(cg.replica1, cg.replica2)
+    wait_applier_connected(cg.replica1, cg.replica3)
+    cg.master_proxy:resume()
+    -- Now cg.replica1 exits `replicaset_connect` with `state->connected = 4`,
+    -- `state->booting: 1` so `replication_sync_quorum_auto` will be set to 3.
+
+    -- We need exactly 2 non-replicable replicas (replica2, replica3),
+    -- one is not enough, because of the second bug gh-11157. If we had only
+    -- one non-replicable replica, then `replication_sync_quorum_auto` would be
+    -- 2, and replica1 would consider itself to be in sync with the master and
+    -- with ITSELF, DESPITE THE FACT THAT IT ITSELF IS NOT BOOTED. So we use
+    -- 2 non-replicable replicas here to separate the effects of one bug from
+    -- the effects of the other (gh-11156 from gh-11157).
+
+    -- Wait until replica1 get bootstraped.
+    cg.replica1:wait_until_ready()
+
+    -- Replica1 cannot synchronize with replica2, replica3,
+    -- so it goes into an 'orphan' status.
+    cg.replica1:exec(function(wait_timeout)
+        t.helpers.retrying({ timeout = wait_timeout }, function()
+            t.assert_equals(box.info.status, 'orphan')
+        end)
+    end, { wait_timeout })
+
+    -- Shutdown.
+    for _, replica_name in ipairs(cg.non_synced_replicas) do
+        cg[replica_name]:exec(function()
+            box.error.injection.set('ERRINJ_RELAY_SEND_DELAY', false)
+        end)
+    end
+end


### PR DESCRIPTION
This is a backport of #11060 to `release/3.3` to a future `3.3.3` release.