### PR TITLE
[backport 3.2] box: fix crash while nil-uuid subscribe request

### DIFF
--- a/changelogs/unreleased/gh-11531-crash-in-anon-subscribe-request-with-nil-id.md
+++ b/changelogs/unreleased/gh-11531-crash-in-anon-subscribe-request-with-nil-id.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Bug fixed: master node used to crash at processing anonymous
+  requests with a nil instance uuid (gh-11531).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -4602,6 +4602,10 @@ box_process_register(struct iostream *io, const struct xrow_header *header)
 	if (!is_box_configured)
 		tnt_raise(ClientError, ER_LOADING);
 
+	/* No replica object with nil UUID. */
+	if (tt_uuid_is_nil(&req.instance_uuid))
+		tnt_raise(ClientError, ER_NIL_UUID);
+
 	if (tt_uuid_is_equal(&req.instance_uuid, &INSTANCE_UUID))
 		tnt_raise(ClientError, ER_CONNECTION_TO_SELF);
 
@@ -4747,6 +4751,10 @@ box_process_join(struct iostream *io, const struct xrow_header *header)
 	if (!is_box_configured)
 		tnt_raise(ClientError, ER_LOADING);
 
+	/* No replica object with nil UUID. */
+	if (tt_uuid_is_nil(&req.instance_uuid))
+		tnt_raise(ClientError, ER_NIL_UUID);
+
 	/* Forbid connection to itself */
 	if (tt_uuid_is_equal(&req.instance_uuid, &INSTANCE_UUID))
 		tnt_raise(ClientError, ER_CONNECTION_TO_SELF);
@@ -4866,6 +4874,10 @@ box_process_subscribe(struct iostream *io, const struct xrow_header *header)
 
 	struct subscribe_request req;
 	xrow_decode_subscribe_xc(header, &req);
+
+	/* No replica object with nil UUID. */
+	if (tt_uuid_is_nil(&req.instance_uuid))
+		tnt_raise(ClientError, ER_NIL_UUID);
 
 	/* Forbid connection to itself */
 	if (tt_uuid_is_equal(&req.instance_uuid, &INSTANCE_UUID))

--- a/test/replication-luatest/gh_11531_crash_in_anonymous_subscribe_request_test.lua
+++ b/test/replication-luatest/gh_11531_crash_in_anonymous_subscribe_request_test.lua
@@ -1,0 +1,53 @@
+local t = require("luatest")
+local server = require("luatest.server")
+local net_box = require("net.box")
+
+local g = t.group()
+
+g.before_all(function()
+    g.master = server:new({ alias = "master" })
+    g.master:start()
+    g.conn = net_box.connect(g.master.net_box_uri)
+end)
+
+g.after_all(function()
+    g.master:drop()
+    g.conn:close()
+end)
+
+g.test_no_crash_with_anon_subscribe_request_and_nil_instance_uuid = function()
+    local replicaset_id = g.master:exec(function()
+        return box.info.replicaset.uuid
+    end)
+
+    local encoded_packet = box.iproto.encode_packet(
+        {[box.iproto.key.SYNC] = g.conn:_next_sync(),
+         [box.iproto.key.REQUEST_TYPE] = box.iproto.type.SUBSCRIBE},
+        {[box.iproto.key.REPLICASET_UUID] = replicaset_id,
+         [box.iproto.key.REPLICA_ANON] = true})
+
+    -- There can be a rare situation when our subscribe request can't be
+    -- processed due to some pending requests in our connection. These pending
+    -- requests don't have enough time to be deleted and, as a result the
+    -- ER_PROTOCOL error is raised. We shouldn't fail our test due to this
+    -- error.
+    t.helpers.retrying({delay = 0.1}, function()
+        -- If the ER_PROTOCOL error is raised, the connection is closed.
+        -- In this scenario our test will fail due to ER_NO_CONNECTION error.
+        -- On each iteration of t.helpers.retrying we should check that our
+        -- connection is alive.
+        if not g.conn:is_connected() then
+            g.conn = net_box.connect(g.master.net_box_uri)
+            g.conn:wait_connected()
+        end
+        local res, err = pcall(g.conn._inject, g.conn, encoded_packet)
+        -- If some kind of crashes (e.g. segmentation fault) appears in
+        -- g.conn._inject, the result of pcall will equal to true. It means
+        -- that if we fail on another assertion we can lose our crash info.
+        -- In this case if we get a crash inside g.conn._inject, it will
+        -- be printed in console, otherwise we will check error's code.
+        if not res then
+            t.assert_equals(err.code, box.error.NIL_UUID)
+        end
+    end)
+end


### PR DESCRIPTION
(This PR is a backport of https://github.com/tarantool/tarantool/pull/11593 to release/3.2 to a future 3.2.2 release.)

Before this patch a master node could crash when it processed an anonymous iproto subscribe request which had a nil instance uuid. The reason of this error is that in `box_connect_replica` we didn't throw an error when non-exist replica tried to connect to node. It led to a situation when the nullified replica object was tried to dereferenced while iproto subscribe request. Now, we raise an ER_NIL_UUID error if we get an iproto request with nil `instance_uuid`.

After this change `test_fetch_snapshot_no_uuid` and `test_checkpoint_join` start fail. The reason of these failures is an incorrect err.type and err.msg of iproto response when we try to send an iproto request with nil `instance_uuid`. Now, these tests are fixed by changing an err.type and err.msg to appropriate values.

Also we change `gh_10155_make_iproto_resistant_to_misusage` test because `write_fetch_snapshot` wasn't be able to send iproto fetch_snapshot request with uuid. It led to situation when ER_NIL_UUID error was raised during fetch_snapshot and as a result we weren't be able to read snapshot after this. It broke
`test_iproto_crash_fetch_snapshot_subscribe` and
`test_iproto_crash_fetch_snapshot_subscribe_not_anon`.

Closes #11531

NO_DOC=bugfix

(cherry picked from commit 0ba7505b9672ce32067e24fd7a0d31e022b1ef34)