### PR TITLE
asan: fix integration of pagination with ASAN

### DIFF
--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -2130,7 +2130,6 @@ local function iterator_pos_set(index, pos, ibuf, level)
         iterator_pos_end[0] = iterator_pos[0] + #pos
         return true
     else
-        ibuf:consume(ibuf.wpos - ibuf.rpos)
         local tuple, tuple_end = tuple_encode(ibuf, pos, level + 1)
         return builtin.box_index_tuple_position(
                 index.space_id, index.id, tuple, tuple_end,

--- a/src/lua/buffer.lua
+++ b/src/lua/buffer.lua
@@ -154,13 +154,6 @@ local function ibuf_read(buf, size)
     return rpos
 end
 
-local function ibuf_consume(buf, size)
-    checkibuf(buf, 'consume')
-    checksize(buf, size)
-    utils.poison_memory_region(buf.rpos, size);
-    buf.rpos = buf.rpos + size
-end
-
 local function ibuf_serialize(buf)
     local properties = { rpos = buf.rpos, wpos = buf.wpos }
     return { ibuf = properties }
@@ -175,7 +168,6 @@ local ibuf_methods = {
 
     checksize = ibuf_checksize;
     read = ibuf_read;
-    consume = ibuf_consume;
     __serialize = ibuf_serialize;
 
     size = ibuf_used;


### PR DESCRIPTION
When setting position needed for pagination, we call `ibuf:consume()` for the memory allocated before position (this method is actaully ASAN poisoning) - that's not correct since consumed memory contains query key that will be used later. The commit removes the incorrect `ibuf:consume()` call.

Also, Lua method `ibuf:consume()` was used only for pagination, and now it's not used anymore, so let's drop it completely.

Note that ASAN poisoning doesn't work well with small memory areas, and we use only small keys in pagination tests, so the problem wasn't found before - the commit adds a test case with large key that covers this problem, but only with enabled ASAN.