### PR TITLE
memtx: fix tuple waste size calculation

### DIFF
--- a/changelogs/unreleased/gh-10217-fix-tuple-waste-size-calc.md
+++ b/changelogs/unreleased/gh-10217-fix-tuple-waste-size-calc.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Improved the calculation of the `waste_size` in `tuple:info()` and
+  `space:stat()` (gh-10217).

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -112,18 +112,12 @@ memtx_space_update_tuple_stat(struct space *space, struct tuple *old_tuple,
 		assert(stat->data_size >= info.data_size);
 		assert(stat->header_size >= info.header_size);
 		assert(stat->field_map_size >= info.field_map_size);
+		assert(stat->waste_size >= info.waste_size);
 
 		stat->data_size -= info.data_size;
 		stat->header_size -= info.header_size;
 		stat->field_map_size -= info.field_map_size;
-		/*
-		 * Avoid negative values, since waste_size is calculated
-		 * imprecisely.
-		 */
-		if (stat->waste_size > info.waste_size)
-			stat->waste_size -= info.waste_size;
-		else
-			stat->waste_size = 0;
+		stat->waste_size -= info.waste_size;
 	}
 }
 

--- a/src/box/tuple.h
+++ b/src/box/tuple.h
@@ -487,12 +487,7 @@ struct tuple_info {
 	size_t header_size;
 	/** Size of the field_map. See also field_map_build_size(). */
 	size_t field_map_size;
-	/**
-	 * The amount of excess memory used to store the tuple in mempool.
-	 * Note that this value is calculated not during the actual allocation,
-	 * but afterwards. This means that it can be incorrect if the state of
-	 * the allocator changed. See also small_alloc_info().
-	 */
+	/** The amount of excess memory used to store the tuple in mempool. */
 	size_t waste_size;
 	/** Type of the arena where the tuple is allocated. */
 	enum tuple_arena_type arena_type;

--- a/test/box-luatest/gh_6762_tuple_and_space_size_test.lua
+++ b/test/box-luatest/gh_6762_tuple_and_space_size_test.lua
@@ -69,23 +69,23 @@ g1.test_tuple_info_memtx = function(cg)
         -- Compact form of a tuple.
         t.assert_equals(s:insert{string.rep('c', 251), 0}:info(),
                         { data_size = 255,
-                          header_size = 6,
+                          header_size = 10,
                           field_map_size = 4,
-                          waste_size = 247,
+                          waste_size = 243,
                           arena = "memtx" }
         )
         -- Bulky form of a tuple.
         t.assert_equals(s:insert{string.rep('b', 252), 1}:info(),
                         { data_size = 256,
-                          header_size = 10,
+                          header_size = 14,
                           field_map_size = 4,
-                          waste_size = 242,
+                          waste_size = 238,
                           arena = "memtx" }
         )
         -- malloc'ed tuple.
         t.assert_equals(s:insert{string.rep('m', 1100*1000), 2}:info(),
                         { data_size = 1100007,
-                          header_size = 10,
+                          header_size = 14,
                           field_map_size = 4,
                           waste_size = 0,
                           arena = "malloc" }
@@ -168,20 +168,20 @@ g2.test_space_stat_memtx = function(cg)
                         s:stat().tuple.malloc.data_size)
 
         local old_stat = { tuple = {  memtx = { data_size = 511,
-                                                header_size = 16,
+                                                header_size = 24,
                                                 field_map_size = 8,
-                                                waste_size = 489 },
+                                                waste_size = 481 },
                                      malloc = { data_size = 2200014,
-                                                header_size = 20,
+                                                header_size = 28,
                                                 field_map_size = 8,
                                                 waste_size = 0 } }
                          }
         local new_stat = { tuple = {  memtx = { data_size = 517,
-                                                header_size = 22,
+                                                header_size = 34,
                                                 field_map_size = 12,
-                                                waste_size = 537 },
+                                                waste_size = 525 },
                                      malloc = { data_size = 1100007,
-                                                header_size = 10,
+                                                header_size = 14,
                                                 field_map_size = 4,
                                                 waste_size = 0 } }
                          }
@@ -227,5 +227,32 @@ g2.test_errors = function(cg)
         )
         t.assert_equals({s.stat{id = 'xxx'}},
                         {nil, "Space with id '0' doesn't exist"})
+    end)
+end
+
+-- Check that tuple waste size is calculated precisely.
+g2.test_gh_10217 = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('memtx')
+        s:create_index('pk')
+        for i = 1, 100 do
+            s:insert({i, string.rep('x', 100 * 1024)})
+        end
+        t.assert_equals(s:stat().tuple.memtx, {
+            data_size = 10240700,
+            header_size = 1400,
+            field_map_size = 0,
+            waste_size = 7452620,
+        })
+
+        for i = 1, 100 do
+            s:delete({i})
+        end
+        t.assert_equals(s:stat().tuple.memtx, {
+            data_size = 0,
+            header_size = 0,
+            field_map_size = 0,
+            waste_size = 0,
+        })
     end)
 end


### PR DESCRIPTION
The main part of the fix resides in the `small` submodule, see commit "small: improve real_size calculation in small_alloc_info". Current patch fixes the pointer that is passed to `small_alloc_info()` - it should point to the `memtx_tuple` rather than `tuple`. Also `memtx_tuple` contains `uint32_t version` that had not been accounted before, now these 4 bytes are added to the `header_size`.

Closes https://github.com/tarantool/tarantool/issues/10217