### PR TITLE
box: do not normalize `covers` twice on index alter

### DIFF
--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -1909,11 +1909,11 @@ box.schema.index.alter = atomic_wrapper(function(space_id, index_id, options)
         box.error(box.error.MODIFY_INDEX, space.index[index_id].name,
                   space.name, "multikey index can't use hints", 2)
     end
-    if index_opts.func ~= nil and type(index_opts.func) == 'string' then
-        index_opts.func = func_id_by_name(index_opts.func, 2)
+    if options.func ~= nil and type(options.func) == 'string' then
+        index_opts.func = func_id_by_name(options.func, 2)
     end
-    if index_opts.covers ~= nil then
-        index_opts.covers = normalize_fields(index_opts.covers, format,
+    if options.covers ~= nil then
+        index_opts.covers = normalize_fields(options.covers, format,
                                              'options.covers', 2)
     end
     local sequence_proxy = space_sequence_alter_prepare(format, parts, options,


### PR DESCRIPTION
Currently, we normalize option `covers` on each alter, even if it wasn't changed and this option is already normalized. Since normalization is not idempotent (it shifts all numeric fields from 1-indexation to 0-indexation), such alter can break `covers` option. Let's normalize `covers` only if it was updated.

Along the way, use `options` variable instead of `index_opts` to make `box.schema.index.alter` code more consistent.

Part of tarantool/tarantool-ee#1335

Covers was introduced in Tarantool 3.4.

EE part: https://github.com/tarantool/tarantool-ee/pull/1356