### PR TITLE
sql: remove unused value

### DIFF
--- a/src/box/sql/insert.c
+++ b/src/box/sql/insert.c
@@ -417,7 +417,6 @@ sqlInsert(Parse * pParse,	/* Parser context */
 		memset(&sNC, 0, sizeof(sNC));
 		sNC.pParse = pParse;
 		srcTab = -1;
-		reg_eph = -1;
 		assert(useTempTable == 0);
 		if (pList) {
 			nColumn = pList->nExpr;


### PR DESCRIPTION
This patch removes unused value to avoid coverity warning.

NO_DOC=refactoring
NO_TEST=refactoring
NO_CHANGELOG=refactoring