### PR TITLE
ci: replace debian-buster by debian-bookworm

### DIFF
--- a/.github/workflows/distrib.yml
+++ b/.github/workflows/distrib.yml
@@ -44,7 +44,7 @@ jobs:
       arch: x86_64
       test-matrix: '{
         "include": [
-          {"os": "debian-buster"}, {"os": "debian-bullseye"},
+          {"os": "debian-bullseye"}, {"os": "debian-bookworm"},
           {"os": "centos-8"},
           {"os": "fedora-35"}, {"os": "fedora-36"},
           {"os": "ubuntu-focal"}, {"os": "ubuntu-jammy"}
@@ -65,7 +65,7 @@ jobs:
       arch: aarch64
       test-matrix: '{
         "include": [
-          {"os": "debian-buster"}, {"os": "debian-bullseye"},
+          {"os": "debian-bullseye"}, {"os": "debian-bookworm"},
           {"os": "centos-8"},
           {"os": "fedora-35"}, {"os": "fedora-36"},
           {"os": "ubuntu-focal"}, {"os": "ubuntu-jammy"}


### PR DESCRIPTION
EOL or debian-buster was over a year ago. It makes sense to replace it with the more modern debin-bookworm.

NO_DOC=CI
NO_TEST=CI
NO_CHANGELOG=CI