### PR TITLE
[backport 3.3] ci: replace debian-buster by debian-bookworm

### DIFF
--- a/.github/workflows/distrib.yml
+++ b/.github/workflows/distrib.yml
@@ -54,7 +54,7 @@ jobs:
       arch: x86_64
       test-matrix: '{
         "include": [
-          {"os": "debian-buster"}, {"os": "debian-bullseye"},
+          {"os": "debian-bullseye"}, {"os": "debian-bookworm"},
           {"os": "centos-8"},
           {"os": "fedora-35"}, {"os": "fedora-36"},
           {"os": "ubuntu-focal"}, {"os": "ubuntu-jammy"}
@@ -75,7 +75,7 @@ jobs:
       arch: aarch64
       test-matrix: '{
         "include": [
-          {"os": "debian-buster"}, {"os": "debian-bullseye"},
+          {"os": "debian-bullseye"}, {"os": "debian-bookworm"},
           {"os": "centos-8"},
           {"os": "fedora-35"}, {"os": "fedora-36"},
           {"os": "ubuntu-focal"}, {"os": "ubuntu-jammy"}


### PR DESCRIPTION
EOL or debian-buster was over a year ago. It makes sense to replace it with the more modern debin-bookworm.

NO_DOC=CI
NO_TEST=CI
NO_CHANGELOG=CI

(cherry picked from commit 86233df6d73cb76649de0e0285d03b33862d448a)