### PR TITLE
box: change uuid validation in iproto requests

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -4810,7 +4810,8 @@ box_connect_replica(const struct tt_uuid *uuid, const struct vclock *gc_vclock,
 
 	/* No replica object with nil UUID. */
 	if (tt_uuid_is_nil(uuid)) {
-		tnt_raise(ClientError, ER_NIL_UUID);
+		*out = NULL;
+		return ReplicaConnectionGuard(NULL);
 	}
 
 	struct replica *replica = replica_by_uuid(uuid);
@@ -4943,6 +4944,10 @@ box_process_register(struct iostream *io, const struct xrow_header *header)
 	if (!is_box_configured)
 		tnt_raise(ClientError, ER_LOADING);
 
+	/* No replica object with nil UUID. */
+	if (tt_uuid_is_nil(&req.instance_uuid))
+		tnt_raise(ClientError, ER_NIL_UUID);
+
 	if (tt_uuid_is_equal(&req.instance_uuid, &INSTANCE_UUID))
 		tnt_raise(ClientError, ER_CONNECTION_TO_SELF);
 
@@ -5067,6 +5072,10 @@ box_process_join(struct iostream *io, const struct xrow_header *header)
 	if (!is_box_configured)
 		tnt_raise(ClientError, ER_LOADING);
 
+	/* No replica object with nil UUID. */
+	if (tt_uuid_is_nil(&req.instance_uuid))
+		tnt_raise(ClientError, ER_NIL_UUID);
+
 	/* Forbid connection to itself */
 	if (tt_uuid_is_equal(&req.instance_uuid, &INSTANCE_UUID))
 		tnt_raise(ClientError, ER_CONNECTION_TO_SELF);
@@ -5168,6 +5177,10 @@ box_process_subscribe(struct iostream *io, const struct xrow_header *header)
 
 	struct subscribe_request req;
 	xrow_decode_subscribe_xc(header, &req);
+
+	/* No replica object with nil UUID. */
+	if (tt_uuid_is_nil(&req.instance_uuid))
+		tnt_raise(ClientError, ER_NIL_UUID);
 
 	/* Forbid connection to itself */
 	if (tt_uuid_is_equal(&req.instance_uuid, &INSTANCE_UUID))

--- a/test/replication-luatest/gh_11531_crash_in_anonymous_subscribe_request_test.lua
+++ b/test/replication-luatest/gh_11531_crash_in_anonymous_subscribe_request_test.lua
@@ -31,7 +31,7 @@ g.test_no_crash_with_anon_subscribe_request_and_nil_instance_uuid = function()
     -- requests don't have enough time to be deleted and, as a result the
     -- ER_PROTOCOL error is raised. We shouldn't fail our test due to this
     -- error.
-    t.helpers.retrying({delay = 0.1}, function()
+    t.helpers.retrying({delay = 0.1, timeout = 60}, function()
         -- If the ER_PROTOCOL error is raised, the connection is closed.
         -- In this scenario our test will fail due to ER_NO_CONNECTION error.
         -- On each iteration of t.helpers.retrying we should check that our

--- a/test/replication-luatest/persistent_gc_anon_test.lua
+++ b/test/replication-luatest/persistent_gc_anon_test.lua
@@ -136,10 +136,7 @@ end)
 
 g.test_fetch_snapshot_no_uuid = function(g)
     write_fetch_snapshot(g.s)
-    local h, b = socket_read(g.s)
-    t.assert_equals(h[key.REQUEST_TYPE], type.TYPE_ERROR + box.error.NIL_UUID)
-    t.assert_equals(b[key.ERROR_24],
-                    'Nil UUID is reserved and can\'t be used in replication')
+    read_fetch_snapshot_response(g)
     g.server:exec(function()
         t.assert_equals(box.info.gc().consumers, {})
         t.assert_equals(box.space._gc_consumers:select{}, {})


### PR DESCRIPTION
In the previous patch #11593 we banned connecting to replicas with nil `instance_uuid` in all iproto requests, including `IPROTO_FETCH_SNAPSHOT`. It is necessary to allow passing a nil `instance_uuid` to this iproto request, because:
1) For `IPROTO_FETCH_SNAPSHOT` it became possible to pass an `instance_uuid`only starting with Tarantool 3.3.
2) While implementing the patch #10755 we wanted to leave `instance_uuid` field optional for this type of iproto request.

To fix this issue we move checking of nil `instance_uuid` from `box_connect_replica` to appropriate box functions of each iproto replication request, excluding `IPROTO_FETCH_SNAPSHOT`.

Also we change some tests:
1) `gh_11531_crash_in_anonymous_subscribe_request_test`: add timeout in
   retrying block in order to avoid flakies. The master node may not be
   able to establish connection during 5 sec. with `net_box` instance.
2) `persistent_gc_anon_test`: introduce `read_fetch_snapshot_response`
   into `test_fetch_snapshot_no_uuid` in order to expect a correct
   iproto response of `IPROTO_FETCH_SNAPSHOT`.

Closes #11668

NO_DOC=bugfix

NO_CHANGELOG=unreleased