### PR TITLE
box: fix key corruption when pagination by tuple is used

### DIFF
--- a/changelogs/unreleased/gh-11221-pagination-key-corruption.md
+++ b/changelogs/unreleased/gh-11221-pagination-key-corruption.md
@@ -1,0 +1,3 @@
+## bugfix/box
+
+* Fixed key corruption when pagination by tuple was used (gh-11221).

--- a/src/box/lua/tuple.lua
+++ b/src/box/lua/tuple.lua
@@ -112,6 +112,7 @@ local encode_array = msgpackffi.internal.encode_array
 local encode_r = msgpackffi.internal.encode_r
 
 local tuple_encode = function(tmpbuf, obj, level)
+    local used = tmpbuf:size()
     if obj == nil then
         encode_fix(tmpbuf, 0x90, 0)  -- empty array
     elseif is_tuple(obj) then
@@ -130,7 +131,7 @@ local tuple_encode = function(tmpbuf, obj, level)
         encode_fix(tmpbuf, 0x90, 1)  -- array of one element
         encode_r(tmpbuf, obj, 1, level and level + 1)
     end
-    return tmpbuf.rpos, tmpbuf.wpos
+    return tmpbuf.rpos + used, tmpbuf.wpos
 end
 
 local tuple_gc = function(tuple)


### PR DESCRIPTION
Function `iterator_pos_set` works completely incorrectly when tuple
is passed to the option `after`.

Firstly, before extracting position, we call `ibuf:consume()` for
the memory allocated before position (this method is actaully ASAN
poisoning) - that's not correct since consumed memory contains query key
that will be used later. Let's remove this call.

Secondly, new allocation on ibuf can lead to its reallocation, so
pointers to old allocations can be invalidated. Let's set the pointers
to the key after all allocations are done, just like in `index:quantile()`.

What's about performance, `perf/lua/box_select.lua` shows no degradation.

Closes https://github.com/tarantool/tarantool/issues/11221
Closes https://github.com/tarantool/tarantool/issues/11648