### PR TITLE
test: fix flaky trigger module test

### DIFF
--- a/test/app-luatest/trigger_module_test.lua
+++ b/test/app-luatest/trigger_module_test.lua
@@ -652,13 +652,15 @@ g.test_trigger_on_change_error = function()
         t.assert_equals(handler_fired_count, 4)
     end)
     local on_change = 'tarantool.trigger.on_change'
-    t.assert(test_server:grep_log(string.format(
-        "error while running trigger 'h1' on event '%s'", on_change)))
-    t.assert(test_server:grep_log(string.format(
-        "error while running trigger 'h2' on event '%s'", on_change)))
-    t.assert(test_server:grep_log('handler_err1: ' .. on_change))
-    t.assert(test_server:grep_log('handler_err2: ' .. on_change))
-    t.assert(test_server:grep_log('handler_err1: test_event'))
-    t.assert(test_server:grep_log('handler_err2: test_event'))
+    t.helpers.retrying({}, function()
+        t.assert(test_server:grep_log(string.format(
+            "error while running trigger 'h1' on event '%s'", on_change)))
+        t.assert(test_server:grep_log(string.format(
+            "error while running trigger 'h2' on event '%s'", on_change)))
+        t.assert(test_server:grep_log('handler_err1: ' .. on_change))
+        t.assert(test_server:grep_log('handler_err2: ' .. on_change))
+        t.assert(test_server:grep_log('handler_err1: test_event'))
+        t.assert(test_server:grep_log('handler_err2: test_event'))
+    end)
     test_server:drop()
 end


### PR DESCRIPTION
There is a case that greps log in order to check that an error was logged. On slow runner or when lots of tests are run in parallel, logs may appear with delay - it will fail the test. Let's retry this check to make the test stable.