### PR TITLE
config: set election mode from `failover.replicasets.*.mode`

### DIFF
--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -365,6 +365,40 @@ end
 
 -- }}} Set RO/RW
 
+-- {{{ failover.replicasets.*.mode
+
+-- Set box.cfg.election_mode = 'manual' to tune box.ctl.promote()
+-- behavior: this way it checks vclock of this instance with a
+-- quorum of replicas to ensure that it is the latest one.
+-- Otherwise, box.ctl.promote() fails.
+--
+-- The box.ctl.promote() function is called in the appoint_commit
+-- function (it is part of the failover coordinator, which is
+-- currently closed source).
+--
+-- This is only revelant for replication.failover = supervised,
+-- when 'qsync' appoint mode is enabled and the instance is not an
+-- anonymous replica.
+local function set_supervised_failover_mode(configdata, box_cfg)
+    local failover = configdata:get('replication.failover',
+        {use_default = true})
+    if failover ~= 'supervised' then
+        return
+    end
+
+    local replicaset_name = configdata._replicaset_name
+    local path = {'failover', 'replicasets', replicaset_name, 'mode'}
+    local mode = configdata:get(path, {use_default = true})
+    if mode ~= 'qsync' then
+        return
+    end
+
+    local is_anon = configdata:get('replication.anon', {use_default = true})
+    box_cfg.election_mode = is_anon and 'off' or 'manual'
+end
+
+-- }}} failover.replicasets.*.mode
+
 -- {{{ Revert changes in non-dynamic options
 
 local function revert_non_dynamic_options(config, box_cfg)
@@ -1332,6 +1366,7 @@ local function apply(config)
     set_log(configdata, box_cfg)
     set_audit_log(configdata, box_cfg)
     set_ro_rw(config, box_cfg)
+    set_supervised_failover_mode(configdata, box_cfg)
     revert_non_dynamic_options(config, box_cfg)
     set_names_in_background(config, box_cfg)
     set_bootstrap_leader(configdata, box_cfg)

--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -564,8 +564,52 @@ local function validate_failover(found, peers, failover, leader)
         end
     end
 
-    -- Verify that 'election_mode' option is set to a value other
-    -- than 'off' only in the 'failover: election' mode.
+    -- Verify that 'election_mode' is unset or null if
+    -- 'failover: supervised'.
+    --
+    -- The actual box.cfg.election_mode value is deduced from
+    -- failover.replicasets.<replicaset_name>.mode (and
+    -- replication.anon).
+    --
+    -- Also, it is allowed to explicitly set the deduced value.
+    if failover == 'supervised' then
+        for peer_name, peer in pairs(peers) do
+            local election_mode = instance_config:get(peer.iconfig_def,
+                'replication.election_mode')
+            local is_anon = instance_config:get(peer.iconfig_def,
+                'replication.anon')
+
+            -- This option is allowed only in the global scope,
+            -- so it can't vary across peers of the same
+            -- replicaset, but it is taken on each loop iteration
+            -- for simplicity.
+            local mode_path = {'failover', 'replicasets', found.replicaset_name,
+                'mode'}
+            local mode = instance_config:get(peer.iconfig_def, mode_path)
+
+            -- The election_mode value is deduced automatically,
+            -- but if a user set the same value explicitly, it is
+            -- OK.
+            local expected = 'off'
+            if mode == 'qsync' and not is_anon then
+                expected = 'manual'
+            end
+
+            if election_mode ~= nil and election_mode ~= expected then
+                error(('replication.election_mode = %q is set for instance ' ..
+                    '%q of replicaset %q of group %q, but this option is ' ..
+                    'to be deduced from failover.replicasets.%s.mode when ' ..
+                    'replication.failover = "supervised"; the suggestion is ' ..
+                    'to leave the replication.election_mode option ' ..
+                    'unset'):format(election_mode, peer_name,
+                    found.replicaset_name, found.group_name,
+                    found.replicaset_name), 0)
+            end
+        end
+    end
+
+    -- Verify that 'election_mode' is 'off' if 'failover: off' or
+    -- 'failover: manual'.
     --
     -- The alternative would be silent ignoring the election
     -- mode if failover mode is not 'election'.
@@ -577,7 +621,7 @@ local function validate_failover(found, peers, failover, leader)
     -- We can relax it in a future, though. For example, if two
     -- conflicting options are set in different scopes, we can
     -- ignore one from the outer scope.
-    if failover ~= 'election' then
+    if failover ~= 'election' and failover ~= 'supervised' then
         for peer_name, peer in pairs(peers) do
             local election_mode = instance_config:get(peer.iconfig_def,
                 'replication.election_mode')

--- a/test/config-luatest/failover_and_election_mode_test.lua
+++ b/test/config-luatest/failover_and_election_mode_test.lua
@@ -3,6 +3,10 @@
 -- Verify all the compositions of possible replication.failover
 -- and replication.election_mode values.
 --
+-- If the election mode is set to a value other than null and the
+-- failover mode is 'supervised', the configuration is considered
+-- incorrect.
+--
 -- If the election mode is set to a value other than null or 'off'
 -- and the failover mode is not 'election', the configuration is
 -- considered incorrect.
@@ -19,6 +23,20 @@ local g = t.group()
 g.before_all(cluster.init)
 g.after_each(cluster.drop)
 g.after_all(cluster.clean)
+
+-- An error that should appear if replication.failover =
+-- supervised and replication.election_mode is set.
+--
+-- It a template and it should parametrized with election mode
+-- supervised_error_t:format(election_mode).
+local supervised_error_t = textutils.toline([[
+    replication.election_mode = %q is set for instance
+    "instance-004" of replicaset "replicaset-001" of group
+    "group-001", but this option is to be deduced from
+    failover.replicasets.replicaset-001.mode when
+    replication.failover = "supervised"; the suggestion is to
+    leave the replication.election_mode option unset
+]])
 
 -- An error that should appear if replication.failover and
 -- replication.election_mode are conflicting.
@@ -50,7 +68,7 @@ local error_t = textutils.toline([[
 --
 -- All the instances are in a replicaset with the given failover
 -- mode.
-local function build_config(failover, election_mode)
+local function build_config(failover, election_mode, supervised_mode, anon)
     local cb = cbuilder:new()
         :set_replicaset_option('replication.failover', failover)
         :add_instance('instance-001', {})
@@ -59,6 +77,7 @@ local function build_config(failover, election_mode)
         :add_instance('instance-004', {
             replication = {
                 election_mode = election_mode,
+                anon = anon,
             },
         })
 
@@ -70,14 +89,20 @@ local function build_config(failover, election_mode)
         cb:set_replicaset_option('leader', 'instance-001')
     end
 
+    if supervised_mode ~= nil then
+        cb:set_global_option('failover.replicasets.replicaset-001.mode',
+            supervised_mode)
+    end
+
     return cb:config()
 end
 
 -- Verify that the given incorrect configuration is reported as
 -- startup error.
-local function failure_case(failover, election_mode)
+local function failure_case(failover, election_mode, supervised_mode, anon)
     return function(g)
-        local config = build_config(failover, election_mode)
+        local config = build_config(failover, election_mode, supervised_mode,
+            anon)
 
         -- The error message shows the replication.failover
         -- parameter by its default value if it is missed or null.
@@ -87,27 +112,46 @@ local function failure_case(failover, election_mode)
             failover = 'off'
         end
 
-        cluster.startup_error(g, config, error_t:format(
-            election_mode, failover))
+        if failover == 'supervised' then
+            cluster.startup_error(g, config, supervised_error_t:format(
+                election_mode, failover))
+        else
+            cluster.startup_error(g, config, error_t:format(
+                election_mode, failover))
+        end
     end
 end
 
 -- Verify that the given correct configuration allows to start a
 -- replicaset successfully.
-local function success_case(failover, election_mode)
+local function success_case(failover, election_mode, supervised_mode, anon)
     return function(g)
-        local config = build_config(failover, election_mode)
+        local config = build_config(failover, election_mode, supervised_mode,
+            anon)
         local cluster = cluster.new(g, config)
         cluster:start()
 
-        cluster['instance-004']:exec(function(failover, election_mode)
-            -- The effective default value is 'off' or
-            -- 'candidate'.
+        cluster['instance-004']:exec(function(failover, election_mode,
+                                              supervised_mode, anon)
+            -- The effective default value is 'off' except:
+            --
+            -- * 'candidate' if failover = election
+            -- * 'manual' if failover = supervised and
+            --   failover.replicasets.<replicaset_name>.mode =
+            --   qsync
             if election_mode == nil then
-                election_mode = failover == 'election' and 'candidate' or 'off'
+                if failover == 'election' then
+                    election_mode = 'candidate'
+                elseif failover == 'supervised' and
+                       supervised_mode == 'qsync' and
+                       not anon then
+                    election_mode = 'manual'
+                else
+                    election_mode = 'off'
+                end
             end
             t.assert_equals(box.cfg.election_mode, election_mode)
-        end, {failover, election_mode})
+        end, {failover, election_mode, supervised_mode, anon})
     end
 end
 
@@ -163,6 +207,45 @@ for failover_str, enabled in pairs(failover_enables_election) do
             g[case_name] = failure_case(failover, election_mode)
         else
             g[case_name] = success_case(failover, election_mode)
+        end
+    end
+end
+
+-- Add test cases with
+-- failover.replicasets.<replicaset_name>.mode = qsync.
+for _, anon in ipairs({false, true}) do
+    for election_mode_str, _ in pairs(election_mode_requires_election) do
+        local supervised_mode = 'qsync'
+        local failover_str = 'supervised'
+        local expect_failure
+        if anon then
+            expect_failure =
+                election_mode_str ~= 'missed' and
+                election_mode_str ~= 'null' and
+                election_mode_str ~= 'off'
+        else
+            expect_failure =
+                election_mode_str ~= 'missed' and
+                election_mode_str ~= 'null' and
+                election_mode_str ~= 'manual'
+        end
+        local case_name = 'test_' .. table.concat({
+            'failover', failover_str,
+            'election_mode', election_mode_str,
+            'supervised_mode', supervised_mode,
+            'anon', tostring(anon),
+            'expect', expect_failure and 'failure' or 'success',
+        }, '_')
+
+        local failover = decode_missed_and_null(failover_str)
+        local election_mode = decode_missed_and_null(election_mode_str)
+
+        if expect_failure then
+            g[case_name] = failure_case(failover, election_mode,
+                supervised_mode, anon)
+        else
+            g[case_name] = success_case(failover, election_mode,
+                supervised_mode, anon)
         end
     end
 end


### PR DESCRIPTION
**Sent for the visual review. Works only after PR #11684.**

----

The new `failover.replicasets.*.mode` option is added. Most of the logic behind it works inside the `appoint_commit` endpoint called by the failover coordinator. However, we also need some logic at applying a configuration. It is added here.

If the option is `qsync` and the instance is not an anonymous replica, set `box.cfg.election_mode` to `manual`, otherwise `off`. That's all.

It is a little problematic that a user is able to provide its own `replication.election_mode` option, while we want to deduce our own value. We need to validate that `replication.election_mode` is unset or at least the same as the deduced value.

See https://github.com/tarantool/doc/issues/5269 for the description of the option.

Part of tarantool/tarantool-ee#1369