### PR TITLE
luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-11185-sysprof-crash.md
+++ b/changelogs/unreleased/gh-11185-sysprof-crash.md
@@ -1,0 +1,4 @@
+## bugfix/tools
+
+Fixed the sysprof crash (gh-11185, gh-11429) when a sample was collected outside
+the LuaJIT VM.

--- a/changelogs/unreleased/gh-11229-sysprof-report.md
+++ b/changelogs/unreleased/gh-11229-sysprof-report.md
@@ -1,0 +1,4 @@
+## feature/tools
+
+It is now possible to call LuaJIT's platform profile function
+`misc.sysprof.report()` during the profiling as well (gh-11229).

--- a/changelogs/unreleased/gh-11278-luajit-fixes.md
+++ b/changelogs/unreleased/gh-11278-luajit-fixes.md
@@ -1,0 +1,13 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-11278). The following
+issues were fixed as part of this activity:
+
+* Fixed JIT slot overflow during recording of trace with up-recursion.
+* Fixed stack overflow handling.
+* Fixed potential file descriptor leaks in `loadfile()`.
+* Fixed error generation in `loadfile()`.
+* Fixed incorrect snapshot restore due to stack overflow.
+* Fixed assembling of IR SLOAD for the aarch64 architecture.
+* Fixed assembling of IR HREFK for the aarch64 architecture.
+* Fixed incorrect `stp`/`ldp` instructions fusion on aarch64.


### PR DESCRIPTION
* ci: drop CentOS 7 Tarantool integration workflow
* gdb: fix flake-7.2.0 F824 warning
* ci: use Tarantool revision in integration workflow
* ARM64: Fix IR_SLOAD assembly.
* ARM64: Fix code generation for IR_SLOAD with typecheck + conversion.
* sysprof: allow calling sysprof.report before stop
* build: provide LUAJIT_USE_PERFTOOLS option
* Fix JIT slot overflow during up-recursion.
* Rework stack overflow handling.
* ci: add track-fds Valgrind scenario
* Fix potential file descriptor leak in luaL_loadfile*().
* Fix another potential file descriptor leak in luaL_loadfile*().
* Handle partial snapshot restore due to stack overflow.
* Different fix for partial snapshot restore due to stack overflow.
* Avoid out-of-range PC for stack overflow error from snapshot restore.
* ARM64: Fix LDP code generation.
* ARM64: Fix assembly of HREFK.
* ARM64: Fix LDP/STP fusing for unaligned accesses.
* sysprof: fix sampling outside the VM
* Fix error generation in load*.
* test: conditionally disable flaky lj-1196

Closes #11185
Closes #11429
Closes #11300
Closes #11229
Closes #11278
Closes tarantool/security#143
Closes tarantool/security#144
Closes tarantool/security#145

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump