### PR TITLE
box: fix misleading errors on privilege revoke from admin

### DIFF
--- a/changelogs/unreleased/gh-11526-misleading-admin-priv-revoke-error.md
+++ b/changelogs/unreleased/gh-11526-misleading-admin-priv-revoke-error.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a misleading error thrown on attempt to revoke privileges from the
+  'admin' user and 'super' role (gh-11526).

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -3243,7 +3243,10 @@ local function privilege_check(privilege, object_type, level)
            bit.band(priv_hex, priv_object_combo[object_type] or 0) ~= priv_hex then
         box.error(box.error.UNSUPPORTED_PRIV, object_type, privilege, level + 1)
     end
-    return priv_hex
+    -- Cast to uint64_t to force bit library to use unsigned 64 bit arithmetics.
+    -- Otherwise box.priv.ALL == 2^32 - 1 would be treated as signed 32-bit
+    -- integer == -1. See https://bitop.luajit.org/semantics.html#range.
+    return priv_hex + 0ULL
 end
 
 local function privilege_name(privilege)

--- a/test/box-luatest/gh_11526_misleading_privilege_error_test.lua
+++ b/test/box-luatest/gh_11526_misleading_privilege_error_test.lua
@@ -1,0 +1,26 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_privilege_revoke_from_admin = function(cg)
+    cg.server:exec(function()
+        local errmsg = "can't revoke universe from the admin user"
+        t.assert_error_msg_contains(errmsg, function()
+            box.schema.user.revoke('admin', 'read', 'universe')
+        end)
+        local ok, _ = pcall(function()
+            box.schema.role.revoke('super', 'read', 'universe')
+        end)
+        t.assert(ok)
+    end)
+end


### PR DESCRIPTION
Trying to revoke privileges from an admin user or a super role results in misleading errors:
```
error: 'Tuple field 5 (privilege) type does not match one required by operation:
    expected unsigned, got integer'
```

The reason is that privileges use bit module for privilege grant/revoke, and this module operates 32-bit **signed** integers (see https://bitop.luajit.org/semantics.html#range for details). So any bit operation on a privilege set greater than 2^31 (for example, box.priv.ALL == 2^32 - 1) results in a negative number:

```lua
tarantool> bit.band(box.priv.ALL, bit.bnot(box.priv.W))
---
- -3
...

```

Fortunately, this can be fixed by casting one of the operands to a uint64_t type, so let's cast all granted or revoked privileges prior to calculating the resulting privilege set.

Closes #11526

NO_DOC=bugfix