### PR TITLE
connpool: make `filter()` and `call()` faster via advanced connection management

### DIFF
--- a/changelogs/unreleased/connpool-reconnect-to-recent.md
+++ b/changelogs/unreleased/connpool-reconnect-to-recent.md
@@ -1,0 +1,5 @@
+## feature/connpool
+
+* The `experimental.connpool` methods now try to reconnect to recently accessed
+  instances when they become unavailable. Reconnect attempts happen after a
+  constant interval and are stopped if the instance is no longer needed.

--- a/changelogs/unreleased/gh-10330-connpool-works-faster.md
+++ b/changelogs/unreleased/gh-10330-connpool-works-faster.md
@@ -1,0 +1,5 @@
+## feature/connpool
+
+* `experimental.connpool` methods `call()` and `filter()` became faster. They do
+  not wait for unavailable instances if it is known they have been inaccessible
+  recently.

--- a/src/box/lua/connpool.lua
+++ b/src/box/lua/connpool.lua
@@ -241,10 +241,12 @@ end
 --- This method connects to the specified instances and returns
 --- the set of successfully connected ones.
 ---
---- Specifying a callback accepting an instance name and returning
---- a boolean value in `opts.any` changes the behavior to connect
---- to multiple instances until there is at least one satisfying
---- the condition or the timeout occurs.
+--- If a callback accepting an instance name and returning a
+--- boolean value is provided in `opts.any` the method connects
+--- to multiple instances and try to find one satisfying the
+--- callback. It lasts until all of the instances are known to
+--- be unsuitable (either failed or not satisfying the callback)
+--- or the timeout is reached.
 function pool_methods.connect_to_multiple(self, instances, opts)
     checks('table', 'table', {
         any = '?function',
@@ -291,10 +293,10 @@ function pool_methods.connect_to_multiple(self, instances, opts)
             if fun.iter(instances):any(opts.any) then
                 break
             end
-        else
-            if fun.iter(instances):all(is_instance_checked) then
-                break
-            end
+        end
+
+        if fun.iter(instances):all(is_instance_checked) then
+            break
         end
 
         self._connection_mode_update_cond:wait(delay)


### PR DESCRIPTION
The main aim of the patchset is to make the connection pool methods
`connpool.call()` and `connpool.filter()` faster by making they behave as
follows when they need a connection to multiple instances.

* Run some of the mentioned connpool methods.
* Apply static configuration filters and find instance candidates.
* Check if there are "actual" connections to all of the candidates.
  - Yes, there are "actual" connections to all of them (both active and broken).
    In that case, try to use the active and available ones. If the
    connection is not available, we may guarantee that it has been also
    unavailable during past 3 seconds interval (hardcoded reconnect after interval). That
    means there is no need to wait and try to reconnect to it.
  - No, some instances have not been accessed yet or they have been accessed
    a long time ago. In that case, connect to all of the remaining in
    parallel and wait until the connect is established/failed.

The guarantee of the recentness of the existing connection state is achieved by
adding a logic on automatic reconnecting to recently accessed instances with
constant interval of time between retries. Reconnect attempts are stopped if
the instances are no longer needed. A few preliminary are also needed to
introduce the logic.

A detailed description on each patch is in the commit message.

Closes #10330
