### PR TITLE
core: fix interval MsgPack decoding

### DIFF
--- a/changelogs/unreleased/gh-10360-fix-interval-decoding.md
+++ b/changelogs/unreleased/gh-10360-fix-interval-decoding.md
@@ -1,0 +1,5 @@
+## bugfix/core
+
+* Fixed reading after MsgPack end of invalid interval MsgPack on decoding.
+  Fixed checking bounds on decoding of year, month, week, and nanosecond, and
+  adjusted the fields of the interval MsgPack (gh-10360).

--- a/src/lib/core/datetime.h
+++ b/src/lib/core/datetime.h
@@ -100,11 +100,16 @@ struct datetime {
  * We add/subtract interval components separately, and rebase upon resultant
  * date only at the moment when we apply them to the datetime object, at this
  * time all leap seconds/leap year logic taken into consideration.
+ *
  * Datetime supports range of values -5879610..5879611, thus interval should be
  * able to support positive and negative increments covering full distance from
  * minimum to maximum i.e. 11759221. Such years, months, and weeks values might
  * be handled by 32-bit integer, but should be extended to 64-bit once we need
  * to handle corresponding days, hours and seconds values.
+ *
+ * The structure is exported to Lua via FFI. Thus double and int32_t
+ * types are used as they exported as number. double is used for fields
+ * with range larger than int32_t range.
  */
 struct interval {
 	/** Duration in seconds. */

--- a/src/lib/core/mp_interval.c
+++ b/src/lib/core/mp_interval.c
@@ -109,12 +109,11 @@ interval_unpack(const char **data, uint32_t len, struct interval *itv)
 
 	const char *end = *data + len;
 	uint32_t count = mp_load_u8(data);
-	len -= sizeof(uint8_t);
-	if (count > 0 && len < 2)
-		return NULL;
 
 	memset(itv, 0, sizeof(*itv));
 	for (uint32_t i = 0; i < count; ++i) {
+		if (end - *data < 2)
+			return NULL;
 		uint32_t field = mp_load_u8(data);
 		int64_t value;
 		enum mp_type type = mp_typeof(**data);
@@ -127,35 +126,47 @@ interval_unpack(const char **data, uint32_t len, struct interval *itv)
 		} else {
 			return NULL;
 		}
-		if (mp_read_int64(data, &value) != 0)
-			return NULL;
 		switch (field) {
 		case FIELD_YEAR:
-			itv->year = value;
+			if (mp_read_int32(data, &itv->year) != 0)
+				return NULL;
 			break;
 		case FIELD_MONTH:
-			itv->month = value;
+			if (mp_read_int32(data, &itv->month) != 0)
+				return NULL;
 			break;
 		case FIELD_WEEK:
-			itv->week = value;
+			if (mp_read_int32(data, &itv->week) != 0)
+				return NULL;
 			break;
 		case FIELD_DAY:
+			if (mp_read_int64(data, &value) != 0)
+				return NULL;
 			itv->day = value;
 			break;
 		case FIELD_HOUR:
+			if (mp_read_int64(data, &value) != 0)
+				return NULL;
 			itv->hour = value;
 			break;
 		case FIELD_MINUTE:
+			if (mp_read_int64(data, &value) != 0)
+				return NULL;
 			itv->min = value;
 			break;
 		case FIELD_SECOND:
+			if (mp_read_int64(data, &value) != 0)
+				return NULL;
 			itv->sec = value;
 			break;
 		case FIELD_NANOSECOND:
-			itv->nsec = value;
+			if (mp_read_int32(data, &itv->nsec) != 0)
+				return NULL;
 			break;
 		case FIELD_ADJUST:
-			if (value > (int64_t)DT_SNAP)
+			if (mp_read_int64(data, &value) != 0)
+				return NULL;
+			if (value < 0 || value > DT_SNAP)
 				return NULL;
 			itv->adjust = (dt_adjust_t)value;
 			break;

--- a/test/unit/interval.c
+++ b/test/unit/interval.c
@@ -16,6 +16,9 @@ enum {
 static void
 test_interval_sizeof(void)
 {
+	header();
+	plan(6);
+
 	struct interval itv;
 	memset(&itv, 0, sizeof(itv));
 	uint32_t size = 3;
@@ -35,6 +38,9 @@ test_interval_sizeof(void)
 	itv.sec = -2000000000;
 	size = 24;
 	is(mp_sizeof_interval(&itv), size, "Size of interval is %d", size);
+
+	check_plan();
+	footer();
 }
 
 static bool
@@ -60,6 +66,9 @@ interval_mp_recode(const struct interval *in, struct interval *out)
 static void
 test_interval_encode_decode(void)
 {
+	header();
+	plan(15);
+
 	struct interval itv;
 	memset(&itv, 0, sizeof(itv));
 	struct interval result;
@@ -95,11 +104,17 @@ test_interval_encode_decode(void)
 	is(result.sec, -2000000000, "Second value is right");
 	is(result.nsec, 0, "Nanosecond value is right");
 	is(result.adjust, DT_EXCESS, "Adjust value is right");
+
+	check_plan();
+	footer();
 }
 
 static void
 test_interval_encode_decode_values_outside_int32_limits(void)
 {
+	header();
+	plan(9);
+
 	struct interval itv;
 	memset(&itv, 0, sizeof(itv));
 	struct interval result;
@@ -137,14 +152,98 @@ test_interval_encode_decode_values_outside_int32_limits(void)
 	itv.sec = (double)INT32_MAX + 1;
 	interval_mp_recode(&itv, &result);
 	ok(is_interval_equal(&itv, &result), "Intervals are equal.");
+
+	check_plan();
+	footer();
+}
+
+static void
+test_interval_validate(void)
+{
+	header();
+	plan(24);
+
+	/* Check reading field key is checked. */
+	ok(mp_validate_interval("\x02", 1) != 0,
+	   "reading interval field 1 key is checked");
+	ok(mp_validate_interval("\x02\x00\x00", 3) != 0,
+	   "reading interval field 2 key is checked");
+
+	/* Check reading field value is checked. */
+	ok(mp_validate_interval("\x01\x00\xce", 2) != 0,
+	   "reading interval field positive value type is checked");
+	ok(mp_validate_interval("\x01\x00\xce", 3) != 0,
+	   "reading interval field positive value is checked");
+	ok(mp_validate_interval("\x01\x00\xd3", 2) != 0,
+	   "reading interval field negative value type is checked");
+	ok(mp_validate_interval("\x01\x00\xd3", 3) != 0,
+	   "reading interval field negative value is checked");
+
+	/* Check adjust decoding. */
+	ok(mp_validate_interval("\x01\x08\x03", 3) != 0,
+	   "check adjust value is not greater than DT_SNAP");
+	ok(mp_validate_interval("\x01\x08\xff", 3) != 0,
+	   "check adjust value is not less that DT_EXCESS (0)");
+
+	/* Check year decoding. */
+	ok(mp_validate_interval("\x01\x00\xd2\x80\x00\x00\x00", 7) == 0,
+	   "check year equal to INT32_MIN");
+	ok(mp_validate_interval(
+		"\x01\x00\xd3\xff\xff\xff\xff\x7f\xff\xff\xff", 11) != 0,
+		"check year less than INT32_MIN");
+	ok(mp_validate_interval("\x01\x00\xce\x7f\xff\xff\xff", 7) == 0,
+	   "check year equal to INT32_MAX");
+	ok(mp_validate_interval("\x01\x00\xce\x80\x00\x00\x00", 7) != 0,
+	   "check year larger than INT32_MAX");
+
+	/* Check month decoding. */
+	ok(mp_validate_interval("\x01\x01\xd2\x80\x00\x00\x00", 7) == 0,
+	   "check month equal to INT32_MIN");
+	ok(mp_validate_interval(
+		"\x01\x01\xd3\xff\xff\xff\xff\x7f\xff\xff\xff", 11) != 0,
+		"check month less than INT32_MIN");
+	ok(mp_validate_interval("\x01\x01\xce\x7f\xff\xff\xff", 7) == 0,
+	   "check month equal to INT32_MAX");
+	ok(mp_validate_interval("\x01\x01\xce\x80\x00\x00\x00", 7) != 0,
+	   "check month larger than INT32_MAX");
+
+	/* Check week decoding. */
+	ok(mp_validate_interval("\x01\x02\xd2\x80\x00\x00\x00", 7) == 0,
+	   "check week equal to INT32_MIN");
+	ok(mp_validate_interval(
+		"\x01\x02\xd3\xff\xff\xff\xff\x7f\xff\xff\xff", 11) != 0,
+		"check week less than INT32_MIN");
+	ok(mp_validate_interval("\x01\x02\xce\x7f\xff\xff\xff", 7) == 0,
+	   "check week equal to INT32_MAX");
+	ok(mp_validate_interval("\x01\x02\xce\x80\x00\x00\x00", 7) != 0,
+	   "check week larger than INT32_MAX");
+
+	/* Check nanosecond decoding. */
+	ok(mp_validate_interval("\x01\x07\xd2\x80\x00\x00\x00", 7) == 0,
+	   "check nanosecond equal to INT32_MIN");
+	ok(mp_validate_interval(
+		"\x01\x07\xd3\xff\xff\xff\xff\x7f\xff\xff\xff", 11) != 0,
+		"check nanosecond less than INT32_MIN");
+	ok(mp_validate_interval("\x01\x07\xce\x7f\xff\xff\xff", 7) == 0,
+	   "check nanosecond equal to INT32_MAX");
+	ok(mp_validate_interval("\x01\x07\xce\x80\x00\x00\x00", 7) != 0,
+	   "check nanosecond larger than INT32_MAX");
+
+	check_plan();
+	footer();
 }
 
 int
 main(void)
 {
-	plan(30);
+	header();
+	plan(4);
+
 	test_interval_sizeof();
 	test_interval_encode_decode();
 	test_interval_encode_decode_values_outside_int32_limits();
+	test_interval_validate();
+
+	footer();
 	return check_plan();
 }


### PR DESCRIPTION
Currently we do not check if we have enough data to read when loading field key.

While at it also fix limits checking for `year`, `month`, `week` and `nanoseconds` fields we lost in the commit 01c7ae1128e1 ("msgpack: fix decoding intervals with int64").

Also as we check the upper limit for `ajust` field let's check the lower limit too.

Closes #10360