### PR TITLE
box: fix interval/decimal/tuple MsgPack decoding of zero length data

### DIFF
--- a/changelogs/unreleased/gh-10361-box-zero-len-mp-decoding.md
+++ b/changelogs/unreleased/gh-10361-box-zero-len-mp-decoding.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed a crash on an attempt to decode a malformed MsgPack extension
+  with zero payload (gh-10361).

--- a/src/box/mp_tuple.c
+++ b/src/box/mp_tuple.c
@@ -98,12 +98,9 @@ tuple_to_mpstream_as_ext(struct tuple *tuple, struct mpstream *stream)
 int
 mp_validate_tuple(const char *data, uint32_t len)
 {
-	/*
-	 * MsgPack extensions have length greater or equal than 1 by
-	 * specification.
-	 */
-	assert(len > 0);
 	const char *end = data + len;
+	if (data == end)
+		return -1;
 	enum mp_type type = mp_typeof(*data);
 	if (type != MP_UINT || mp_check_uint(data, end) > 0)
 		return -1;

--- a/src/lib/core/decimal.c
+++ b/src/lib/core/decimal.c
@@ -781,15 +781,11 @@ static_assert(DECIMAL_DIGIT_CAPACITY % 2 == 1 ||
 decimal_t *
 decimal_unpack(const char **data, uint32_t len, decimal_t *dec)
 {
-	/*
-	 * MsgPack extensions have length greater or equal than 1 by
-	 * specification.
-	 */
-	assert(len > 0);
-
 	int32_t scale;
 	const char *end = *data + len;
 	const char *p = *data;
+	if (len < 1)
+		return NULL;
 	enum mp_type type = mp_typeof(*p);
 	if (type == MP_UINT) {
 		if (mp_check_uint(p, end) > 0)

--- a/src/lib/core/mp_interval.c
+++ b/src/lib/core/mp_interval.c
@@ -101,13 +101,9 @@ interval_pack(char *data, const struct interval *itv)
 struct interval *
 interval_unpack(const char **data, uint32_t len, struct interval *itv)
 {
-	/*
-	 * MsgPack extensions have length greater or equal than 1 by
-	 * specification.
-	 */
-	assert(len > 0);
-
 	const char *end = *data + len;
+	if (end - *data < 1)
+		return NULL;
 	uint32_t count = mp_load_u8(data);
 
 	memset(itv, 0, sizeof(*itv));

--- a/test/unit/decimal.c
+++ b/test/unit/decimal.c
@@ -480,6 +480,18 @@ test_mp_print(void)
 }
 
 static void
+test_mp_validate(void)
+{
+	plan(1);
+	header();
+
+	ok(mp_validate_decimal("", 0) != 0, "reading scale type is checked");
+
+	footer();
+	check_plan();
+}
+
+static void
 test_print(void)
 {
 	plan(4);
@@ -881,7 +893,7 @@ test_scale_to_int256(void)
 int
 main(void)
 {
-	plan(334);
+	plan(335);
 
 	dectest(314, 271, uint64, uint64_t);
 	dectest(65535, 23456, uint64, uint64_t);
@@ -949,6 +961,7 @@ main(void)
 
 	test_mp_decimal();
 	test_mp_print();
+	test_mp_validate();
 	test_print();
 	test_fits_fixed_point();
 	test_scale_from_int32();

--- a/test/unit/interval.c
+++ b/test/unit/interval.c
@@ -161,7 +161,11 @@ static void
 test_interval_validate(void)
 {
 	header();
-	plan(24);
+	plan(25);
+
+	/* Check reading count is checked. */
+	ok(mp_validate_interval("", 0) != 0,
+	   "reading count is checked");
 
 	/* Check reading field key is checked. */
 	ok(mp_validate_interval("\x02", 1) != 0,

--- a/test/unit/mp_tuple.c
+++ b/test/unit/mp_tuple.c
@@ -100,7 +100,7 @@ test_tuple_to_mpstream_as_ext(void)
 static int
 test_mp_validate_tuple(void)
 {
-	plan(8);
+	plan(9);
 	header();
 
 	char buf[1024];
@@ -182,6 +182,9 @@ test_mp_validate_tuple(void)
 	ext_len = mp_decode_extl(&r, &unused);
 	isnt(mp_validate_tuple(r, ext_len), 0,
 	     "MP_TUPLE validation works correctly for invalid tuple");
+
+	isnt(mp_validate_tuple(buf, 0), 0,
+	     "MP_TUPLE validation works correctly for 0 length data");
 
 	footer();
 	return check_plan();


### PR DESCRIPTION
Zero length data is possible input for MsgPack validation functions. So let's handle it for decimal, interval and tuple.

Closes #10361