### PR TITLE
test/fuzz: add dummy mp_check_on_error in xrow fuzzer

### DIFF
--- a/test/fuzz/xrow_header_decode_fuzzer.c
+++ b/test/fuzz/xrow_header_decode_fuzzer.c
@@ -5,10 +5,18 @@
 void
 cord_on_yield(void) {}
 
+static void
+fuzz_check_on_error(const struct mp_check_error *mperr)
+{
+	/* Dummy error. */
+	diag_set(ClientError, ER_INVALID_MSGPACK, "dummy");
+}
+
 __attribute__((constructor))
 static void
 setup(void)
 {
+	mp_check_on_error = fuzz_check_on_error;
 	memory_init();
 }
 


### PR DESCRIPTION
`xrow_decode()` expects that diag is set in case of invalid xrow body MsgPack. Thus add `mp_check_on_error()` stub which will the expectation.

Closes #11178