### PR TITLE
test/fuzz: build fix

### DIFF
--- a/test/fuzz/xrow_header_decode_fuzzer.c
+++ b/test/fuzz/xrow_header_decode_fuzzer.c
@@ -1,5 +1,6 @@
 #include "box/iproto_constants.h"
 #include "box/xrow.h"
+#include "box/error.h"
 #include "memory.h"
 
 void


### PR DESCRIPTION
The commit dc3fbcc64071 ("test/fuzz: add dummy mp_check_on_error in xrow fuzzer") broke fuzzing build. Let's add missing dependency on box_error library.

```
/src/tarantool/test/fuzz/xrow_header_decode_fuzzer.c:12:2: warning: call to undeclared function 'BuildClientError'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   12 |         diag_set(ClientError, ER_INVALID_MSGPACK, "dummy");
      |         ^
/src/tarantool/src/lib/core/diag.h:477:2: note: expanded from macro 'diag_set'
  477 |         diag_set_detailed(__FILE__, __LINE__, __VA_ARGS__)
      |         ^
/src/tarantool/src/lib/core/diag.h:469:6: note: expanded from macro 'diag_set_detailed'
  469 |         e = Build##class(file, line, ##__VA_ARGS__);                    \
      |             ^
<scratch space>:194:1: note: expanded from here
  194 | BuildClientError
      | ^
/src/tarantool/test/fuzz/xrow_header_decode_fuzzer.c:12:24: error: use of undeclared identifier 'ER_INVALID_MSGPACK'
   12 |         diag_set(ClientError, ER_INVALID_MSGPACK, "dummy");
      |
```

Follow up ##11178