### PR TITLE
box: fix setting box error name

### DIFF
--- a/changelogs/unreleased/gh-10708-fix-setting-error-name.md
+++ b/changelogs/unreleased/gh-10708-fix-setting-error-name.md
@@ -1,0 +1,3 @@
+## bugfix/box
+
+* Fixed a bug of missed setting box error name in some cases (gh-10708).

--- a/doc/rfc/1148-stacked-diagnostics.md
+++ b/doc/rfc/1148-stacked-diagnostics.md
@@ -43,9 +43,7 @@ Type of error is represented by a few C++ classes (all are inherited from
 Exception class). For instance hierarchy for ClientError is following:
 ```
 ClientError
- | LoggedError
  | AccessDeniedError
- | UnsupportedIndexFeature
 ```
 
 All codes and names of ClientError class are available in box.error.

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -366,15 +366,23 @@ applier_connection_init(struct iostream *io, const struct uri *uri,
 		diag_raise();
 
 	/* Decode instance version and name from greeting */
-	if (greeting_decode(greetingbuf, greeting) != 0)
-		tnt_raise(LoggedError, ER_PROTOCOL, "Invalid greeting");
+	if (greeting_decode(greetingbuf, greeting) != 0) {
+		diag_set(ClientError, ER_PROTOCOL, "Invalid greeting");
+		diag_log();
+		diag_raise();
+	}
 
 	if (strcmp(greeting->protocol, "Binary") != 0) {
-		tnt_raise(LoggedError, ER_PROTOCOL,
-			  "Unsupported protocol for replication");
+		diag_set(ClientError, ER_PROTOCOL,
+			 "Unsupported protocol for replication");
+		diag_log();
+		diag_raise();
 	}
-	if (tt_uuid_is_nil(&greeting->uuid))
-		tnt_raise(LoggedError, ER_NIL_UUID);
+	if (tt_uuid_is_nil(&greeting->uuid)) {
+		diag_set(ClientError, ER_NIL_UUID);
+		diag_log();
+		diag_raise();
+	}
 }
 
 /**

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -252,7 +252,7 @@ struct errcode_record {
 	_(ER_WRONG_SCHEMA_VERSION, 109,		"Wrong schema version, current: %d, in request: %llu", "actual", ULLONG, "expected", ULLONG) \
 	_(ER_MEMTX_MAX_TUPLE_SIZE, 110,		"Failed to allocate %u bytes for tuple: tuple is too large. Check 'memtx_max_tuple_size' configuration option.", "value", ULLONG, "max", ULLONG) \
 	_(ER_WRONG_SPACE_OPTIONS, 111,		"Wrong space options: %s", "details", STRING) \
-	_(ER_UNSUPPORTED_INDEX_FEATURE, 112,	"Index '%s' (%s) of space '%s' (%s) does not support %s") \
+	_(ER_UNSUPPORTED_INDEX_FEATURE, 112,	"Index '%s' (%s) of space '%s' (%s) does not support %s", "index", STRING, "index_type", STRING, "space", STRING, "engine", STRING, "feature", STRING) \
 	_(ER_VIEW_IS_RO, 113,			"View '%s' is read-only", "space", STRING) \
 	_(ER_NO_TRANSACTION, 114,		"No active transaction") \
 	_(ER_SYSTEM, 115,			"%s") \

--- a/src/box/error.cc
+++ b/src/box/error.cc
@@ -73,37 +73,29 @@ box_error_clear(void)
 	diag_clear(&fiber()->diag);
 }
 
-int
-box_error_set(const char *file, unsigned line, uint32_t code,
-		const char *fmt, ...)
-{
-	struct error *e = BuildClientError(file, line, ER_UNKNOWN);
-	ClientError *client_error = type_cast(ClientError, e);
-	client_error->code = code;
-	va_list ap;
-	va_start(ap, fmt);
-	error_vformat_msg(e, fmt, ap);
-	va_end(ap);
-	diag_set_error(&fiber()->diag, e);
-	return -1;
-}
-
+/** Creates new error based on code and custom_type. */
 static struct error *
 box_error_new_va(const char *file, unsigned line, uint32_t code,
 		 const char *custom_type, const char *fmt, va_list ap)
 {
-	struct error *e;
-	if (custom_type != NULL) {
-		e = BuildCustomError(file, line, custom_type, code);
-	} else if (code == ER_ILLEGAL_PARAMS) {
-		e = BuildIllegalParams(file, line, "");
-	} else {
-		e = BuildClientError(file, line, ER_UNKNOWN);
-		ClientError *client_error = type_cast(ClientError, e);
-		client_error->code = code;
-	}
-	error_vformat_msg(e, fmt, ap);
-	return e;
+	if (custom_type != NULL)
+		return new CustomError(file, line, custom_type, code, fmt, ap);
+	else if (code == ER_ILLEGAL_PARAMS)
+		return new IllegalParams(file, line, fmt, ap);
+	else
+		return new ClientError(file, line, code, fmt, ap);
+}
+
+int
+box_error_set(const char *file, unsigned line, uint32_t code,
+	      const char *fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	struct error *e = box_error_new_va(file, line, code, NULL, fmt, ap);
+	va_end(ap);
+	diag_set_error(&fiber()->diag, e);
+	return -1;
 }
 
 struct error *
@@ -154,14 +146,38 @@ const char *rmean_error_strings[RMEAN_ERROR_LAST] = {
 	"ERROR"
 };
 
-/** Format client error with arguments in `ap` according to error format. */
-static void
-client_error_create(struct error *e, va_list ap)
+const struct type_info type_ClientError =
+	make_type("ClientError", &type_Exception);
+
+ClientError::ClientError(const type_info *type, const char *file, unsigned line,
+			 uint32_t errcode)
+	: Exception(type, file, line)
 {
-	const struct errcode_record *r = tnt_errcode_record(e->code);
+	code = errcode;
+	if (rmean_error)
+		rmean_collect(rmean_error, RMEAN_ERROR, 1);
+}
+
+ClientError::ClientError(const char *file, unsigned line, uint32_t errcode,
+			 va_list ap)
+	: ClientError(file, line, errcode, /*fmt=*/NULL, ap)
+{
+}
+
+ClientError::ClientError(const char *file, unsigned line, uint32_t errcode,
+			 const char *fmt, va_list ap)
+	: ClientError(&type_ClientError, file, line, errcode)
+{
+	const struct errcode_record *r = tnt_errcode_record(code);
+	assert(strncmp("ER_", r->errstr, 3) == 0);
+	error_set_str(this, "name", r->errstr + 3);
+	if (fmt != NULL) {
+		error_vformat_msg(this, fmt, ap);
+		return;
+	}
 	va_list ap_copy;
 	va_copy(ap_copy, ap);
-	error_vformat_msg(e, r->errdesc, ap_copy);
+	error_vformat_msg(this, r->errdesc, ap_copy);
 	va_end(ap_copy);
 	for (int i = 0; i < r->errfields_count; i++) {
 		const char *name = r->errfields[i].name;
@@ -170,49 +186,49 @@ client_error_create(struct error *e, va_list ap)
 		case ERRCODE_FIELD_TYPE_CHAR: {
 			char buf[2] = {(char)va_arg(ap, int), '\0'};
 			if (set_payload)
-				error_set_str(e, name, buf);
+				error_set_str(this, name, buf);
 			break;
 		}
 		case ERRCODE_FIELD_TYPE_INT: {
 			int v = va_arg(ap, int);
 			if (set_payload)
-				error_set_int(e, name, v);
+				error_set_int(this, name, v);
 			break;
 		}
 		case ERRCODE_FIELD_TYPE_UINT: {
 			unsigned v = va_arg(ap, unsigned);
 			if (set_payload)
-				error_set_uint(e, name, v);
+				error_set_uint(this, name, v);
 			break;
 		}
 		case ERRCODE_FIELD_TYPE_LONG: {
 			long v = va_arg(ap, long);
 			if (set_payload)
-				error_set_int(e, name, v);
+				error_set_int(this, name, v);
 			break;
 		}
 		case ERRCODE_FIELD_TYPE_ULONG: {
 			unsigned long v = va_arg(ap, unsigned long);
 			if (set_payload)
-				error_set_uint(e, name, v);
+				error_set_uint(this, name, v);
 			break;
 		}
 		case ERRCODE_FIELD_TYPE_LLONG: {
 			long long v = va_arg(ap, long long);
 			if (set_payload)
-				error_set_int(e, name, v);
+				error_set_int(this, name, v);
 			break;
 		}
 		case ERRCODE_FIELD_TYPE_ULLONG: {
 			unsigned long long v = va_arg(ap, unsigned long long);
 			if (set_payload)
-				error_set_uint(e, name, v);
+				error_set_uint(this, name, v);
 			break;
 		}
 		case ERRCODE_FIELD_TYPE_STRING: {
 			const char *s = va_arg(ap, const char *);
 			if (set_payload && s != NULL)
-				error_set_str(e, name, s);
+				error_set_str(this, name, s);
 			break;
 		}
 		case ERRCODE_FIELD_TYPE_MSGPACK: {
@@ -221,7 +237,7 @@ client_error_create(struct error *e, va_list ap)
 			assert(set_payload);
 			if (mp != NULL) {
 				mp_next(&mp_end);
-				error_set_mp(e, name, mp, mp_end - mp);
+				error_set_mp(this, name, mp, mp_end - mp);
 			}
 			break;
 		}
@@ -229,7 +245,7 @@ client_error_create(struct error *e, va_list ap)
 			struct tuple *tuple = va_arg(ap, struct tuple *);
 			assert(set_payload);
 			if (tuple != NULL)
-				error_set_mp(e, name, tuple_data(tuple),
+				error_set_mp(this, name, tuple_data(tuple),
 					     tuple_bsize(tuple));
 			break;
 		}
@@ -237,30 +253,6 @@ client_error_create(struct error *e, va_list ap)
 			assert(false);
 		}
 	}
-	assert(strncmp("ER_", r->errstr, 3) == 0);
-	error_set_str(e, "name", r->errstr + 3);
-}
-
-const struct type_info type_ClientError =
-	make_type("ClientError", &type_Exception);
-
-ClientError::ClientError(const type_info *type, const char *file, unsigned line,
-			 uint32_t errcode)
-	:Exception(type, file, line)
-{
-	code = errcode;
-	if (rmean_error)
-		rmean_collect(rmean_error, RMEAN_ERROR, 1);
-}
-
-ClientError::ClientError(const char *file, unsigned line,
-			 uint32_t errcode, ...)
-	:ClientError(&type_ClientError, file, line, errcode)
-{
-	va_list ap;
-	va_start(ap, errcode);
-	client_error_create(this, ap);
-	va_end(ap);
 }
 
 struct error *
@@ -272,11 +264,9 @@ BuildClientError(const char *file, unsigned line, uint32_t errcode, ...)
 	assert(errcode != ER_SSL); /* use SSLError */
 	assert(errcode != ER_XLOG_GAP); /* use XlogGapError */
 	assert(errcode != ER_ACCESS_DENIED); /* use AccessDeniedError */
-	ClientError *e = new ClientError(file, line, ER_UNKNOWN);
 	va_list ap;
 	va_start(ap, errcode);
-	e->code = errcode;
-	client_error_create(e, ap);
+	ClientError *e = new ClientError(file, line, errcode, ap);
 	va_end(ap);
 	return e;
 }
@@ -382,15 +372,22 @@ const struct type_info type_CustomError =
 	make_type("CustomError", &type_ClientError);
 
 CustomError::CustomError(const char *file, unsigned int line,
-			 const char *custom_type, uint32_t errcode)
+			 const char *custom_type, uint32_t errcode,
+			 const char *fmt, va_list ap)
 	:ClientError(&type_CustomError, file, line, errcode)
 {
+	error_vformat_msg(this, fmt, ap);
 	error_set_str(this, "custom_type", custom_type);
 }
 
 struct error *
 BuildCustomError(const char *file, unsigned int line, const char *custom_type,
-		 uint32_t errcode)
+		 uint32_t errcode, const char *format, ...)
 {
-	return new CustomError(file, line, custom_type, errcode);
+	va_list ap;
+	va_start(ap, format);
+	CustomError *e = new CustomError(file, line, custom_type, errcode,
+					 format, ap);
+	va_end(ap);
+	return e;
 }

--- a/src/box/error.h
+++ b/src/box/error.h
@@ -55,7 +55,7 @@ BuildXlogGapError(const char *file, unsigned line,
 
 struct error *
 BuildCustomError(const char *file, unsigned int line, const char *custom_type,
-		 uint32_t errcode);
+		 uint32_t errcode, const char *format, ...);
 
 /** \cond public */
 
@@ -233,7 +233,10 @@ public:
 		return code;
 	}
 
-	ClientError(const char *file, unsigned line, uint32_t errcode, ...);
+	ClientError(const char *file, unsigned line, uint32_t errcode,
+		    va_list ap);
+	ClientError(const char *file, unsigned line, uint32_t errcode,
+		    const char *fmt, va_list ap);
 
 	ClientError()
 		:Exception(&type_ClientError, NULL, 0)
@@ -244,18 +247,6 @@ public:
 protected:
 	ClientError(const type_info *type, const char *file, unsigned line,
 		    uint32_t errcode);
-};
-
-class LoggedError: public ClientError
-{
-public:
-	template <typename ... Args>
-	LoggedError(const char *file, unsigned line, uint32_t errcode, Args ... args)
-		: ClientError(file, line, errcode, args...)
-	{
-		/* TODO: actually calls ClientError::log */
-		error_log(this);
-	}
 };
 
 /**
@@ -340,7 +331,8 @@ class CustomError: public ClientError
 {
 public:
 	CustomError(const char *file, unsigned int line,
-		    const char *custom_type, uint32_t errcode);
+		    const char *custom_type, uint32_t errcode, const char *fmt,
+		    va_list ap);
 
 	CustomError()
 		:ClientError(&type_CustomError, NULL, 0, 0)

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -47,26 +47,14 @@ struct rlist box_on_select = RLIST_HEAD_INITIALIZER(box_on_select);
 
 /* {{{ Utilities. **********************************************/
 
-UnsupportedIndexFeature::UnsupportedIndexFeature(const char *file,
-	unsigned line, struct index_def *index_def, const char *what)
-	: ClientError(file, line, ER_UNKNOWN)
-{
-	code = ER_UNSUPPORTED_INDEX_FEATURE;
-	error_format_msg(this, tnt_errcode_desc(code), index_def->name,
-			 index_type_strs[index_def->type],
-			 index_def->space_name, index_def->engine_name, what);
-	error_set_str(this, "index", index_def->name);
-	error_set_str(this, "index_type", index_type_strs[index_def->type]);
-	error_set_str(this, "space", index_def->space_name);
-	error_set_str(this, "engine", index_def->engine_name);
-	error_set_str(this, "feature", what);
-}
-
 struct error *
 BuildUnsupportedIndexFeature(const char *file, unsigned line,
 			     struct index_def *index_def, const char *what)
 {
-	return new UnsupportedIndexFeature(file, line, index_def, what);
+	return BuildClientError(
+			file, line, ER_UNSUPPORTED_INDEX_FEATURE,
+			index_def->name, index_type_strs[index_def->type],
+			index_def->space_name, index_def->engine_name, what);
 }
 
 /**

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -1324,20 +1324,15 @@ generic_index_read_view_iterator_position(struct index_read_view_iterator *it,
 void
 generic_index_read_view_iterator_destroy(struct index_read_view_iterator *it);
 
+/** Helper to build ER_UNSUPPORTED_INDEX_FEATURE error from index definition. */
+struct error *
+BuildUnsupportedIndexFeature(const char *file, unsigned line,
+			     struct index_def *index_def, const char *what);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 
 #include "diag.h"
-
-/*
- * A wrapper for ClientError(ER_UNSUPPORTED_INDEX_FEATURE, ...) to format
- * nice error messages (see gh-1042). You never need to catch this class.
- */
-class UnsupportedIndexFeature: public ClientError {
-public:
-	UnsupportedIndexFeature(const char *file, unsigned line,
-				struct index_def *index_def, const char *what);
-};
 
 struct IteratorGuard
 {

--- a/src/box/lua/error.cc
+++ b/src/box/lua/error.cc
@@ -272,8 +272,6 @@ raise:
 			if (name[0] != '\0')
 				luaT_error_payload_set(L, error, name, i);
 		}
-		assert(strncmp("ER_", record->errstr, 3) == 0);
-		error_set_str(error, "name", record->errstr + 3);
 	}
 	return error;
 }

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -48,6 +48,7 @@ extern "C" {
 #endif /* defined(__cplusplus) */
 
 struct index;
+struct index_def;
 struct index_read_view;
 struct info_handler;
 struct iterator;

--- a/src/box/recovery.cc
+++ b/src/box/recovery.cc
@@ -171,7 +171,6 @@ recovery_close_log(struct recovery *r)
 static void
 recovery_open_log(struct recovery *r, const struct vclock *vclock)
 {
-	XlogGapError *e;
 	struct xlog_meta meta = r->cursor.meta;
 	enum xlog_cursor_state state = r->cursor.state;
 
@@ -213,10 +212,10 @@ out:
 	return;
 
 gap_error:
-	e = tnt_error(XlogGapError, &r->vclock, vclock);
+	diag_set(XlogGapError, &r->vclock, vclock);
 	if (!(r->flags & RECOVERY_IGNORE_ERRORS))
-		throw e;
-	error_log(e);
+		diag_raise();
+	diag_log();
 	say_warn("ignoring a gap in LSN");
 	goto out;
 }

--- a/src/box/user.cc
+++ b/src/box/user.cc
@@ -30,6 +30,7 @@
  */
 #include "user.h"
 #include "assoc.h"
+#include "error.h"
 #include "schema.h"
 #include "space.h"
 #include "func.h"
@@ -557,7 +558,9 @@ auth_token_get(void)
 		 * Check for BOX_USER_MAX to cover case when
 		 * USER_MAP_BITS > BOX_USER_MAX.
 		 */
-		tnt_raise(LoggedError, ER_USER_MAX, BOX_USER_MAX);
+		diag_set(ClientError, ER_USER_MAX, BOX_USER_MAX);
+		diag_log();
+		diag_raise();
 	}
         /*
          * find-first-set returns bit index starting from 1,

--- a/src/lib/core/diag.h
+++ b/src/lib/core/diag.h
@@ -458,11 +458,6 @@ BuildDecodeError(const char *file, unsigned line, const char *format,
 struct error *
 BuildFileFormatError(const char *file, unsigned line, const char *format, ...);
 
-struct index_def;
-
-struct error *
-BuildUnsupportedIndexFeature(const char *file, unsigned line,
-			     struct index_def *index_def, const char *what);
 struct error *
 BuildSocketError(const char *file, unsigned line, const char *socketname,
 		 const char *format, ...);

--- a/src/lib/core/exception.h
+++ b/src/lib/core/exception.h
@@ -94,8 +94,8 @@ class SystemError: public Exception {
 public:
 	virtual void raise() { throw this; }
 
-	SystemError(const char *file, unsigned line,
-		    const char *format, ...);
+	SystemError(const char *file, unsigned line, const char *format,
+		    va_list ap);
 
 	SystemError()
 		:Exception(&type_SystemError, NULL, 0)
@@ -103,14 +103,15 @@ public:
 	}
 
 protected:
-	SystemError(const struct type_info *type, const char *file, unsigned line);
+	SystemError(const struct type_info *type, const char *file,
+		    unsigned line);
 };
 
 extern const struct type_info type_SocketError;
 class SocketError: public SystemError {
 public:
 	SocketError(const char *file, unsigned line, const char *socketname,
-		    const char *format, ...);
+		    const char *format, va_list ap);
 
 	SocketError()
 		:SystemError(&type_SocketError, NULL, 0)
@@ -208,7 +209,8 @@ public:
 
 class IllegalParams: public Exception {
 public:
-	IllegalParams(const char *file, unsigned line, const char *format, ...);
+	IllegalParams(const char *file, unsigned line, const char *format,
+		      va_list ap);
 
 	IllegalParams()
 		:Exception(&type_IllegalParams, NULL, 0)
@@ -221,7 +223,7 @@ public:
 class CollationError: public Exception {
 public:
 	CollationError(const char *file, unsigned line, const char *format,
-		       ...);
+		       va_list ap);
 
 	CollationError()
 		:Exception(&type_CollationError, NULL, 0)
@@ -233,7 +235,8 @@ public:
 
 class SwimError: public Exception {
 public:
-	SwimError(const char *file, unsigned line, const char *format, ...);
+	SwimError(const char *file, unsigned line, const char *format,
+		  va_list ap);
 
 	SwimError()
 		:Exception(&type_SwimError, NULL, 0)
@@ -245,7 +248,8 @@ public:
 
 class CryptoError: public Exception {
 public:
-	CryptoError(const char *file, unsigned line, const char *format, ...);
+	CryptoError(const char *file, unsigned line, const char *format,
+		    va_list ap);
 
 	CryptoError()
 		:Exception(&type_CryptoError, NULL, 0)
@@ -257,53 +261,54 @@ public:
 
 class RaftError: public Exception {
 public:
-	RaftError(const char *file, unsigned line, const char *format, ...);
+	RaftError(const char *file, unsigned line, const char *format,
+		  va_list ap);
+
 	virtual void raise() { throw this; }
 };
 
 class FileFormatError: public Exception {
 public:
-	FileFormatError(const char *file, unsigned line,
-			const char *format, ...);
+	FileFormatError(const char *file, unsigned line, const char *format,
+			va_list ap);
 
 	FileFormatError()
 		: Exception(&type_FileFormatError, NULL, 0)
 	{
 	}
+
 	virtual void raise() { throw this; }
 };
 
 class EncodeError: public Exception {
 public:
-	EncodeError(const char *file, unsigned line, const char *format, ...);
+	EncodeError(const char *file, unsigned line, const char *format,
+		    const char *details);
 
 	EncodeError()
 		: Exception(&type_EncodeError, NULL, 0)
 	{
 	}
+
 	virtual void raise() { throw this; }
 };
 
 class DecodeError: public Exception {
 public:
-	DecodeError(const char *file, unsigned line, const char *format, ...);
+	DecodeError(const char *file, unsigned line, const char *format,
+		    const char *details);
 
 	DecodeError()
 		: Exception(&type_DecodeError, NULL, 0)
 	{
 	}
+
 	virtual void raise() { throw this; }
 };
 
-#define tnt_error(class, ...) ({					\
-	say_debug("%s at %s:%i", #class, __FILE__, __LINE__);		\
-	class *e = new class(__FILE__, __LINE__, ##__VA_ARGS__);	\
-	diag_set_error(diag_get(), e);					\
-	e;								\
-})
-
 #define tnt_raise(...) do {						\
-	throw tnt_error(__VA_ARGS__);					\
+	diag_set(__VA_ARGS__);						\
+	diag_raise();							\
 } while (0)
 
 #endif /* defined(__cplusplus) */

--- a/test/app/fiber.result
+++ b/test/app/fiber.result
@@ -1038,8 +1038,7 @@ st;
 ...
 e:unpack();
 ---
-- name: ILLEGAL_PARAMS
-  code: 0
+- code: 0
   base_type: IllegalParams
   type: IllegalParams
   message: oh my

--- a/test/box-luatest/error_subsystem_improvements_test.lua
+++ b/test/box-luatest/error_subsystem_improvements_test.lua
@@ -454,8 +454,11 @@ end)
 
 -- Test error has 'name' field with error name.
 g.test_error_name = function()
-    local e = box.error.new(box.error.ILLEGAL_PARAMS, 'foo')
-    t.assert_equals(e.name, 'ILLEGAL_PARAMS')
+    local e = box.error.new(box.error.UNSUPPORTED, 'foo', 'bar')
+    t.assert_equals(e.name, 'UNSUPPORTED')
+
+    local e = box.error.new({code = box.error.UNSUPPORTED})
+    t.assert_equals(e.name, 'UNSUPPORTED')
 end
 
 g.test_dml_key_validation_errors = function(cg)

--- a/test/box-luatest/index_aggregates_test.lua
+++ b/test/box-luatest/index_aggregates_test.lua
@@ -25,7 +25,6 @@ g.test_arg_check = function(cg)
         local s = box.schema.space.create('test')
         t.assert_error_covers({
             type = 'IllegalParams',
-            name = 'ILLEGAL_PARAMS',
             message = "options parameter 'aggregates' should be of type table",
         }, s.create_index, s, 'pk', {aggregates = 1234})
 

--- a/test/box-luatest/index_layout_test.lua
+++ b/test/box-luatest/index_layout_test.lua
@@ -25,7 +25,6 @@ g.test_arg_check = function(cg)
         local s = box.schema.space.create('test')
         t.assert_error_covers({
             type = 'IllegalParams',
-            name = 'ILLEGAL_PARAMS',
             message = "options parameter 'layout' should be of type string",
         }, s.create_index, s, 'pk', {layout = 1234})
 

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -40,8 +40,7 @@ u.trace[1].line = nil
  | ...
 u
  | ---
- | - name: ILLEGAL_PARAMS
- |   code: 0
+ | - code: 0
  |   base_type: IllegalParams
  |   type: IllegalParams
  |   message: foo

--- a/test/unit/mp_error.cc
+++ b/test/unit/mp_error.cc
@@ -624,7 +624,7 @@ test_mp_print(void)
 
 	struct error *e1 = BuildClientError("file1", 1, 0);
 	error_ref(e1);
-	struct error *e2 = BuildCustomError("file2", 4, "type", 5);
+	struct error *e2 = BuildCustomError("file2", 4, "type", 5, "");
 	struct error *e3 = BuildAccessDeniedError("file3", 6, "field1",
 						  "field2", "field3", "field4");
 	error_set_prev(e1, e2);


### PR DESCRIPTION
Currently we fail to set box error name is some cases. Error name is error payload with key `name`.

Closes #10708