### PR TITLE
lsan: add suppression for Curl_http_write_resp

### DIFF
--- a/asan/lsan.supp
+++ b/asan/lsan.supp
@@ -84,3 +84,6 @@ leak:fiber_gc_checker_init
 
 # FIXME(gh-11740)
 leak:iproto_thread_accept
+
+# FIXME(tarantool/tarantool-ee#1407)
+leak:Curl_http_write_resp


### PR DESCRIPTION
Leak sanitizer started detecting new leaks in etcd-client tests in the enterprise repo. This only happens on 3.2 branch, and must be due to the fact we haven't backported commits regarding correct Lua state cleanup on shutdown. Commit 80a11c49c35e ("box: close Lua state on exit") in particular.

Since that patch series is rather heavy, let's simply suppress the leak in 3.2 branch.

The leak in question:
```
Direct leak of 52 byte(s) in 1 object(s) allocated from:
   #0 0x556c873b3aae in malloc (/__w/tarantool-ee/tarantool-ee/tarantool/src/tarantool+0x1573aae) (BuildId: b2a73382837eb52617097838e12bd4d33ce21792)
   #1 0x556c89ebd8ec in small_asan_alloc /__w/tarantool-ee/tarantool-ee/tarantool/src/lib/small/small/util.c:94:24
   #2 0x556c89eb5f84 in region_prepare_buf /__w/tarantool-ee/tarantool-ee/tarantool/src/lib/small/small/region_asan.c:39:4
   #3 0x556c89eb6919 in region_aligned_alloc /__w/tarantool-ee/tarantool-ee/tarantool/src/lib/small/small/region_asan.c:94:14
   #4 0x556c8895d4b9 in region_alloc /__w/tarantool-ee/tarantool-ee/tarantool/src/lib/small/include/small/region_asan.h:131:9
   #5 0x556c8894b88a in curl_easy_header_cb /__w/tarantool-ee/tarantool-ee/tarantool/src/httpc.c:124:12
   #6 0x556c89477809 in cw_out_ptr_flush /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/cw-out.c:223:16
   #7 0x556c89477364 in cw_out_do_write /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/cw-out.c:377:14
   #8 0x556c89476df4 in cw_out_write /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/cw-out.c:415:14
   #9 0x556c894bab21 in Curl_cwriter_write /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/sendf.c:183:10
   #10 0x556c894bc525 in cw_download_write /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/sendf.c:253:14
   #11 0x556c894bab21 in Curl_cwriter_write /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/sendf.c:183:10
   #12 0x556c8948578e in hds_cw_collect_write /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/headers.c:367:10
   #13 0x556c894bab21 in Curl_cwriter_write /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/sendf.c:183:10
   #14 0x556c894bcb6d in cw_raw_write /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/sendf.c:367:10
   #15 0x556c894bab21 in Curl_cwriter_write /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/sendf.c:183:10
   #16 0x556c894ba8fe in Curl_client_write /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/sendf.c:91:12
   #17 0x556c89493ab4 in http_write_header /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/http.c:3363:12
   #18 0x556c89492fab in http_on_response /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/http.c:3399:14
   #19 0x556c894909fe in http_rw_hd /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/http.c:3688:14
   #20 0x556c894918b2 in http_parse_headers /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/http.c:3929:14
   #21 0x556c894913f9 in Curl_http_write_resp_hds /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/http.c:3986:14
   #22 0x556c8948a3af in Curl_http_write_resp /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/http.c:4010:12
   #23 0x556c894d6385 in Curl_xfer_write_resp /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/transfer.c:1168:14
   #24 0x556c894d45b4 in sendrecv_dl /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/transfer.c:343:14
   #25 0x556c894d3eb3 in Curl_sendrecv /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/transfer.c:451:14
   #26 0x556c894af0b0 in multi_runsingle /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/multi.c:2374:16
   #27 0x556c894b388a in multi_run_expired /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/multi.c:3151:14
   #28 0x556c894b15d4 in multi_socket /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/multi.c:3234:12
   #29 0x556c894b1701 in curl_multi_socket_action /__w/tarantool-ee/tarantool-ee/tarantool/third_party/curl/lib/multi.c:3358:10
```

In scope of tarantool/tarantool-ee#1407

NO_DOC=lsan
NO_TEST=lsan
NO_CHANGELOG=lsan