### PR TITLE
relay: disable WAL recovery logging during subscribe

### DIFF
--- a/changelogs/unreleased/gh-11752-relay-disable-wal-recovery-logging.md
+++ b/changelogs/unreleased/gh-11752-relay-disable-wal-recovery-logging.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Disabled informational log messages that were printed while sending WAL logs
+  to subscribed replicas (gh-11752).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -5838,8 +5838,11 @@ local_recovery(const struct vclock *checkpoint_vclock)
 		wal_stream_abort(&wal_stream);
 		wal_stream_destroy(&wal_stream);
 	});
-	struct recovery *recovery = recovery_new(
-		wal_dir(), box_is_force_recovery, checkpoint_vclock);
+	unsigned recovery_flags = 0;
+	if (box_is_force_recovery)
+		recovery_flags |= RECOVERY_IGNORE_ERRORS;
+	struct recovery *recovery = recovery_new(wal_dir(), recovery_flags,
+						 checkpoint_vclock);
 	/*
 	 * Make sure we report the actual recovery position
 	 * in box.info while local recovery is in progress.

--- a/src/box/recovery.h
+++ b/src/box/recovery.h
@@ -43,11 +43,28 @@ extern "C" {
 struct xrow_header;
 struct xstream;
 
+enum recovery_flag {
+	/**
+	 * Do not abort recovery if a recovery error occurs. Instead log
+	 * the error and proceed. This flag is set if the force_recovery
+	 * configuration option is used.
+	 */
+	RECOVERY_IGNORE_ERRORS = 1 << 0,
+	/**
+	 * Do not print informational log messages.
+	 */
+	RECOVERY_SUPPRESS_LOGGING = 1 << 1,
+};
+
 struct recovery {
+	/** Current recovery vclock. */
 	struct vclock vclock;
 	/** The WAL cursor we're currently reading/writing from/to. */
 	struct xlog_cursor cursor;
+	/** Directory that contains WAL files. */
 	struct xdir wal_dir;
+	/** Recovery flags. See recovery_flag enum for available flags. */
+	unsigned flags;
 	/**
 	 * This fiber is used in local hot standby mode.
 	 * It looks for changes in the wal_dir and applies
@@ -59,7 +76,7 @@ struct recovery {
 };
 
 struct recovery *
-recovery_new(const char *wal_dirname, bool force_recovery,
+recovery_new(const char *wal_dirname, unsigned flags,
 	     const struct vclock *vclock);
 
 void

--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -541,7 +541,7 @@ relay_final_join(struct replica *replica, struct iostream *io, uint64_t sync,
 	 * Save the first vclock as 'received'. Because it was really received.
 	 */
 	vclock_copy_ignore0(&relay->last_recv_ack.vclock, start_vclock);
-	relay->r = recovery_new(wal_dir(), false, start_vclock);
+	relay->r = recovery_new(wal_dir(), 0, start_vclock);
 	vclock_copy(&relay->stop_vclock, stop_vclock);
 
 	struct cord cord;
@@ -1115,7 +1115,8 @@ relay_subscribe(struct replica *replica, struct iostream *io, uint64_t sync,
 	 * Save the first vclock as 'received'. Because it was really received.
 	 */
 	vclock_copy_ignore0(&relay->last_recv_ack.vclock, start_vclock);
-	relay->r = recovery_new(wal_dir(), false, start_vclock);
+	relay->r = recovery_new(wal_dir(), RECOVERY_SUPPRESS_LOGGING,
+				start_vclock);
 	vclock_copy_ignore0(&relay->tx.vclock, start_vclock);
 	relay->version_id = replica_version_id;
 	relay->id_filter |= replica_id_filter;


### PR DESCRIPTION
If a master instance is under load, it will print hundreds of messages "xxM rows processed" while sending WAL logs to subscribed replicas. This is annoying. These messages are useless because once a replica is subscribed, one can track replication progress through box.info. Let's suppress them.

Closes #11752