### PR TITLE
box: Sorting neighbors with same distance

### DIFF
--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -66,6 +66,18 @@ enum memtx_rtree_reserve_extents_num {
 
 /* {{{ Utilities. *************************************************/
 
+/** Callback for sorting neighbors with same distance. */
+int tie_cmp_cb(const struct rtree_neighbor *a,
+	       const struct rtree_neighbor *b)
+{
+	struct index *index = (struct index *)a->cmp_ctx;
+	return tuple_compare((struct tuple *)a->child,
+                    	     HINT_NONE,
+                    	     (struct tuple *)b->child,
+                    	     HINT_NONE,
+                    	     index->def->pk_def);
+}
+
 static inline int
 mp_decode_num(const char **data, uint32_t fieldno, double *ret)
 {
@@ -381,6 +393,7 @@ memtx_rtree_index_create_iterator(struct index *base, enum iterator_type type,
 	it->base.next = memtx_iterator_next;
 	it->base.position = generic_iterator_position;
 	it->base.free = index_rtree_iterator_free;
+	it->impl.tie_cmp = tie_cmp_cb;
 	rtree_iterator_init(&it->impl);
 	/*
 	 * We don't care if rtree_search() does or does not find anything

--- a/src/lib/salad/rtree.c
+++ b/src/lib/salad/rtree.c
@@ -80,10 +80,11 @@ neighbor_cmp(const struct rtree_neighbor *a, const struct rtree_neighbor *b)
 {
 	return a->distance < b->distance ? -1 :
 	       a->distance > b->distance ? 1 :
-	       a->level < b->level ? -1 :
-	       a->level > b->level ? 1 :
-	       a < b ? -1 : a > b ? 1 : 0;
-	return 0;
+	       a->level > b->level ? -1 :
+	       a->level < b->level ? 1 :
+	       a->level > 0 ? (a < b ? -1 : a > b ? 1 : 0) :
+	       a->tie_cmp != NULL ? a->tie_cmp(a, b) :
+	       (a < b ? -1 : a > b ? 1 : 0);
 }
 
 rb_gen(, rtnt_, rtnt_t, struct rtree_neighbor, link, neighbor_cmp);
@@ -840,6 +841,11 @@ rtree_iterator_new_neighbor(struct rtree_iterator *itr,
 	n->child = child;
 	n->distance = distance;
 	n->level = level;
+	if (itr->tie_cmp != NULL) {
+		n->cmp_ctx = itr->cmp_ctx;
+	} else {
+		n->cmp_ctx = NULL;
+	}
 	return n;
 }
 

--- a/src/lib/salad/rtree.h
+++ b/src/lib/salad/rtree.h
@@ -60,6 +60,8 @@ struct rtree_neighbor {
 	void *child;
 	int level;
 	sq_coord_t distance;
+	/* Is used for sorting neighbors with same distence */
+	int (*tie_cmp)(const struct rtree_neighbor *a, const struct rtree_neighbor *b);
 };
 
 typedef rb_tree(struct rtree_neighbor) rtnt_t;
@@ -177,6 +179,9 @@ struct rtree_iterator
 	struct rtree_neighbor_page *page_list;
 	/* Position of ready-to-use list entry in allocated page */
 	unsigned page_pos;
+
+	/* Is used for sorting neighbors with same distence */
+	int (*tie_cmp)(const struct rtree_neighbor *a, const struct rtree_neighbor *b);
 
 	/* Comparators for comparison rectagnle of the iterator with
 	 * rectangles of tree nodes. If the comparator returns true,


### PR DESCRIPTION
Sorting neighbors with same distance. 

Later it will be used in neighbor pagination 
Add new call back `tie_cmp_cb` for using it in `neighbor_cmp`
