### PR TITLE
box: deprecate triggers during recovery

### DIFF
--- a/changelogs/unreleased/gh-11756-deprecate-on-recovery-triggers.md
+++ b/changelogs/unreleased/gh-11756-deprecate-on-recovery-triggers.md
@@ -1,0 +1,4 @@
+## feature/box
+
+* Space and transactional triggers during recovery are now deprecated
+  (gh-11756).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -154,6 +154,12 @@ static struct gc_checkpoint_ref *backup_gc;
 bool box_read_ffi_is_disabled;
 
 /**
+ * Whether triggers during recovery should be disabled.
+ */
+static bool box_recovery_triggers_disabled;
+TWEAK_BOOL(box_recovery_triggers_disabled);
+
+/**
  * Counter behind box_read_ffi_is_disabled: FFI is re-enabled
  * when it hits zero.
  */
@@ -6160,6 +6166,10 @@ box_cfg_xc(void)
 	});
 
 	bool is_bootstrap_leader = false;
+	if (box_recovery_triggers_disabled) {
+		space_events_enable(false);
+		txn_events_enable(false);
+	}
 	if (checkpoint != NULL) {
 		/* Recover the instance from the local directory */
 		local_recovery(&checkpoint->vclock);
@@ -6167,6 +6177,8 @@ box_cfg_xc(void)
 		/* Bootstrap a new instance */
 		bootstrap(&is_bootstrap_leader);
 	}
+	space_events_enable(true);
+	txn_events_enable(true);
 	/*
 	 * During bootstrap from a remote master try not to ignore the
 	 * conflicts, neither during snapshot fetch, not join.

--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -282,6 +282,14 @@ I['compat.box_info_cluster_meaning'] = format_text([[
     - `old` (2.x default): `box.info.cluster` shows info about the replica set
 ]])
 
+I['compat.box_recovery_triggers_deprecation'] = format_text([[
+    Whether to trigger space and transactional events during local recovery
+    or join:
+
+    - `new` (4.x default): do not trigger events
+    - `old` (3.x default): trigger events
+]])
+
 I['compat.box_session_push_deprecation'] = format_text([[
     Whether to raise errors on attempts to call the deprecated function
     `box.session.push`:

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2165,6 +2165,12 @@ return schema.new('instance_config', schema.record({
         }, {
             default = 'old',
         }),
+        box_recovery_triggers_deprecation = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'old',
+        }),
     }),
     -- Instance labels.
     labels = schema.map({

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -766,6 +766,10 @@ error_set_space(struct error *error, struct space_def *def)
 void
 space_cleanup_constraints(struct space *space);
 
+/** Enable/disable space events. */
+void
+space_events_enable(bool value);
+
 /*
  * Virtual method stubs.
  */

--- a/src/box/txn_event_trigger.c
+++ b/src/box/txn_event_trigger.c
@@ -9,8 +9,13 @@
 #include "small/mempool.h"
 #include "txn.h"
 
+/**
+ * Whether txn events should be disabled.
+ */
+static bool txn_events_enabled = true;
+
 /** Global events, i.e. triggered by all transactions. */
-struct event *txn_global_events[txn_event_id_MAX];
+static struct event *txn_global_events[txn_event_id_MAX];
 
 /**
  * Data used to create txn iterators.
@@ -347,6 +352,8 @@ static int
 run_triggers(struct txn *txn, struct txn_stmt *stmt, int event_id,
 	     bool can_abort)
 {
+	if (!txn_events_enabled)
+		return 0;
 	/*
 	 * Run triggers, set on spaces that are modified by the transaction.
 	 */
@@ -388,4 +395,10 @@ txn_event_on_rollback_to_svp_run_triggers(struct txn *txn,
 	struct txn_stmt *stmt;
 	stmt = stailq_first_entry(stmts, struct txn_stmt, next);
 	return run_triggers(txn, stmt, TXN_EVENT_ON_ROLLBACK, false);
+}
+
+void
+txn_events_enable(bool value)
+{
+	txn_events_enabled = value;
 }

--- a/src/box/txn_event_trigger.h
+++ b/src/box/txn_event_trigger.h
@@ -95,6 +95,10 @@ int
 txn_event_on_rollback_to_svp_run_triggers(struct txn *txn,
 					  struct stailq *stmts);
 
+/** Enable/disable txn events. */
+void
+txn_events_enable(bool value);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/src/lua/compat.lua
+++ b/src/lua/compat.lua
@@ -164,6 +164,13 @@ gc-checkpointing.
 https://tarantool.io/compat/replication_synchro_timeout
 ]]
 
+local BOX_RECOVERY_TRIGGERS_DEPRECATION_BRIEF = [[
+On recovery triggers are deprecated. The new behavior is to do not trigger
+space and transactional events during local recovery or join.
+
+https://tarantool.io/compat/box_recovery_triggers_deprecation
+]]
+
 -- Returns an action callback that toggles a tweak.
 local function tweak_action(tweak_name, old_tweak_value, new_tweak_value)
     return function(is_new)
@@ -300,6 +307,13 @@ local options = {
         brief = REPLICATION_SYNCHRO_TIMEOUT_COMPAT_BRIEF,
         action = tweak_action(
             'replication_synchro_timeout_rollback_enabled', true, false),
+    },
+    box_recovery_triggers_deprecation = {
+        default = 'old',
+        obsolete = nil,
+        brief = BOX_RECOVERY_TRIGGERS_DEPRECATION_BRIEF,
+        action = tweak_action(
+            'box_recovery_triggers_disabled', false, true),
     },
 }
 

--- a/test/box-luatest/gh_11756_triggers_on_recovery_test.lua
+++ b/test/box-luatest/gh_11756_triggers_on_recovery_test.lua
@@ -1,0 +1,102 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+local setup_triggers = [[
+    local compat = require('compat')
+    local trigger = require('trigger')
+
+    local id = %d
+    local name = '%s'
+
+    compat.box_recovery_triggers_deprecation = 'new'
+
+    local events = {
+        'box.space[' .. id .. '].before_recovery_replace',
+        'box.space.' .. name .. '.before_recovery_replace',
+        'box.space[' .. id .. '].on_recovery_replace',
+        'box.space.' .. name .. '.on_recovery_replace',
+        'box.before_commit',
+        'box.before_commit.space.' .. name,
+        'box.before_commit.space[' .. id .. ']',
+        'box.on_commit',
+        'box.on_commit.space.' .. name,
+        'box.on_commit.space[' .. id .. ']',
+    }
+
+    for _, event in ipairs(events) do
+        trigger.set(
+            event, 'event_check', function()
+               -- luatest server gives grants for guest, so check
+               -- current box status to filter out correspondent
+               -- trigger invocation.
+                if box.info.status ~= "running" and
+                   rawget(_G, 'trigger_fired') == nil then
+                    rawset(_G, 'trigger_fired', event)
+                end
+            end
+        )
+    end
+]]
+
+g.after_all(function(cg)
+    if cg.server ~= nil then
+        cg.server:drop()
+        cg.server = nil
+    end
+    if cg.replica ~= nil then
+        cg.replica:drop()
+        cg.replica = nil
+    end
+end)
+
+g.test_recovery_triggers = function(cg)
+    -- Bootstrap test.
+    local before_box_cfg = string.format(setup_triggers, 280, '_space')
+    cg.server = server:new({
+        env = {TARANTOOL_RUN_BEFORE_BOX_CFG = before_box_cfg}
+    })
+    cg.server:start()
+    cg.server:exec(function()
+        local compat = require('compat')
+
+        t.assert_equals(compat.box_recovery_triggers_deprecation.current, 'new')
+        t.assert_equals(rawget(_G, 'trigger_fired'), nil)
+
+        local s = box.schema.create_space('test')
+        s:create_index('pk')
+        s:insert({1})
+        s:insert({2})
+
+        t.assert_equals(s.id, 512)
+    end)
+
+    -- Local recovery test.
+    local before_box_cfg = string.format(setup_triggers, 512, 'test')
+    cg.server:restart({
+        env = {TARANTOOL_RUN_BEFORE_BOX_CFG = before_box_cfg}
+    })
+    cg.server:exec(function()
+        local compat = require('compat')
+
+        t.assert_equals(compat.box_recovery_triggers_deprecation.current, 'new')
+        t.assert_equals(rawget(_G, 'trigger_fired'), nil)
+    end)
+
+    -- Replica join test.
+    cg.replica = server:new({
+        alias = 'replica',
+        env = {TARANTOOL_RUN_BEFORE_BOX_CFG = before_box_cfg},
+        box_cfg = {replication = cg.server.net_box_uri },
+    })
+    cg.replica:start()
+    cg.replica:wait_for_vclock_of(cg.server)
+
+    cg.replica:exec(function()
+        local compat = require('compat')
+
+        t.assert_equals(compat.box_recovery_triggers_deprecation.current, 'new')
+        t.assert_equals(rawget(_G, 'trigger_fired'), nil)
+    end)
+end

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -450,6 +450,7 @@ g.test_defaults = function()
             box_error_unpack_type_and_code = 'old',
             console_session_scope_vars = 'old',
             wal_cleanup_delay_deprecation = 'old',
+            box_recovery_triggers_deprecation = 'old',
         },
         isolated = false,
         stateboard = {


### PR DESCRIPTION
See the issue for motivation.

Now if `compat.box_recovery_triggers_deprecation` is 'new' we do not trigger space and transactional events during recovery.

Closes #11756

@TarantoolBot document
Title: Deprecate triggers during recovery

Deprecate space and transactional triggers during recovery.

(Please create https://tarantool.io/compat/box_recovery_triggers_deprecation)

We are planning to switch the compat option to the new behavior starting from Tarantool 4.0 with the ability to revert to the old behavior. Starting from Tarantool 5.0 there will be no option to trigger events during recovery.