### PR TITLE
[backport 3.3] Spurious Wakeupaloosa: spurious wakups and cascading rollbacks in the limbo and WAL

### DIFF
--- a/changelogs/unreleased/gh-11180-outdated-snapshot.md
+++ b/changelogs/unreleased/gh-11180-outdated-snapshot.md
@@ -1,0 +1,7 @@
+## bugfix/core
+
+* Fixed the creation of broken snapshots, which could contain outdated entries
+  also applied in the following xlog files. This could happen if the
+  transactions would pile up and fill the whole WAL queue
+  (`box.cfg.wal_queue_max_size` was reached), and a snapshot was created at this
+  moment (gh-11180).

--- a/changelogs/unreleased/gh-11180-synchro-spurious-wakeup.md
+++ b/changelogs/unreleased/gh-11180-synchro-spurious-wakeup.md
@@ -1,0 +1,8 @@
+## bugfix/raft
+
+* Fixed inconsistent data which could happen when the synchro queue was full
+  (`box.cfg.replication_synchro_queue_max_size` was reached) and the
+  transactions blocked on that queue were woken up or cancelled spuriously (for
+  example, manually via `fiber:wakeup()` or `fiber:cancel()`). Specifically,
+  transactions could get committed in a wrong order or newly joined replicas
+  could have data not present on the master (gh-11180).

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -256,6 +256,7 @@ set(box_sources
     session.c
     port.c
     txn.c
+    txn_checkpoint.c
     txn_limbo.c
     txn_event_trigger.c
     raft.c

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -1525,23 +1525,19 @@ applier_synchro_filter_tx(struct stailq *rows)
 	row = &stailq_last_entry(rows, struct applier_tx_row, next)->row;
 	uint64_t term = txn_limbo_replica_term(&txn_limbo, row->replica_id);
 	assert(term <= txn_limbo.promote_greatest_term);
-	if (term == txn_limbo.promote_greatest_term)
-		return 0;
-
-	/*
-	 * We do not nopify promotion/demotion and most of confirm/rollback.
-	 * Such syncrhonous requests should be filtered by txn_limbo to detect
-	 * possible split brain situations.
-	 *
-	 * This means the only filtered out transactions are synchronous ones or
-	 * the ones depending on them.
-	 *
-	 * Any asynchronous transaction from an obsolete term when limbo is
-	 * claimed by someone is a marker of split-brain by itself: consider it
-	 * a synchronous transaction, which is committed with quorum 1.
-	 */
+	bool is_current_term = term == txn_limbo.promote_greatest_term;
 	struct applier_tx_row *item;
-	if (iproto_type_is_dml(row->type) && !row->wait_sync) {
+	if (iproto_type_is_dml(row->type)) {
+		if (is_current_term)
+			return 0;
+		/*
+		 * Any asynchronous transaction from an obsolete term when limbo
+		 * is claimed by someone is a marker of split-brain by itself:
+		 * consider it a synchronous transaction, which is committed
+		 * with quorum 1.
+		 */
+		if (row->wait_sync)
+			goto nopify;
 		if (txn_limbo.owner_id == REPLICA_ID_NIL)
 			return 0;
 		stailq_foreach_entry(item, rows, next) {
@@ -1553,39 +1549,72 @@ applier_synchro_filter_tx(struct stailq *rows)
 			return -1;
 		}
 		return 0;
-	} else if (iproto_type_is_synchro_request(row->type)) {
-		item = stailq_last_entry(rows, typeof(*item), next);
-		struct synchro_request req = item->req.synchro;
-		/* Note! Might be different from row->replica_id. */
-		uint32_t owner_id = req.replica_id;
-		int64_t confirmed_lsn =
-			txn_limbo_replica_confirmed_lsn(&txn_limbo, owner_id);
+	}
+	/*
+	 * We do not nopify promotion/demotion and most of confirm/rollback.
+	 * Such syncrhonous requests should be filtered by txn_limbo to detect
+	 * possible split brain situations.
+	 *
+	 * This means the only filtered out transactions are synchronous ones or
+	 * the ones depending on them.
+	 */
+	assert(iproto_type_is_synchro_request(row->type));
+	const struct synchro_request *req;
+	int64_t confirmed_lsn;
+	item = stailq_last_entry(rows, typeof(*item), next);
+	req = &item->req.synchro;
+	/* Note! Might be different from row->replica_id. */
+	confirmed_lsn = txn_limbo_replica_confirmed_lsn(&txn_limbo,
+							req->replica_id);
+	switch (row->type) {
+	case IPROTO_RAFT_PROMOTE:
+	case IPROTO_RAFT_DEMOTE:
+		/*
+		 * Never need to be nopified. Every PROMOTE / DEMOTE is either a
+		 * valid one or is a split brain. There is no such thing as an
+		 * "old already applied promotion".
+		 */
+		return 0;
+	case IPROTO_RAFT_CONFIRM:
+		if (req->lsn > confirmed_lsn)
+			return 0;
 		/*
 		 * A CONFIRM with lsn <= known confirm lsn for this replica may
 		 * be nopified without a second thought. The transactions it's
 		 * going to confirm were already confirmed by one of the
 		 * PROMOTE/DEMOTE requests in a new term.
 		 *
-		 * Same about a ROLLBACK with lsn > known confirm lsn.
-		 * These requests, although being out of date, do not contradict
-		 * anything, so we may silently skip them.
+		 * See that the CONFIRM can be nopified even in the current term
+		 * if it wants to commit already committed txns. This is a niche
+		 * case which might happen when a replica joins a master and
+		 * receives a valid fully confirmed read-view from it, but some
+		 * CONFIRM WAL entries might have been written by the master
+		 * after the read-view is sent. Then the replica would receive
+		 * those "already known" CONFIRMs during xlogs catch up.
+		 *
+		 * Besides, logically a confirmation of already confirmed txns
+		 * doesn't contradict anything.
 		 */
-		switch (row->type) {
-		case IPROTO_RAFT_PROMOTE:
-		case IPROTO_RAFT_DEMOTE:
+		break;
+	case IPROTO_RAFT_ROLLBACK:
+		if (req->lsn <= confirmed_lsn)
 			return 0;
-		case IPROTO_RAFT_CONFIRM:
-			if (req.lsn > confirmed_lsn)
-				return 0;
-			break;
-		case IPROTO_RAFT_ROLLBACK:
-			if (req.lsn <= confirmed_lsn)
-				return 0;
-			break;
-		default:
-			unreachable();
-		}
+		/*
+		 * Rollback in the current term wants to roll some currently
+		 * waiting transactions back. No case when it can be considered
+		 * outdated.
+		 */
+		if (is_current_term)
+			return 0;
+		/*
+		 * In older terms though this is fine to nopify it. Those txns
+		 * must have already been cancelled by the new leader anyway.
+		 */
+		break;
+	default:
+		unreachable();
 	}
+nopify:
 	stailq_foreach_entry(item, rows, next) {
 		row = &item->row;
 		row->type = IPROTO_NOP;

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -65,6 +65,7 @@
 #include "index.h"
 #include "port.h"
 #include "txn.h"
+#include "txn_checkpoint.h"
 #include "txn_limbo.h"
 #include "user.h"
 #include "cfg.h"
@@ -3042,7 +3043,7 @@ box_wait_limbo_acked(double timeout)
 	/* Wait for the last entries WAL write. */
 	if (last_entry->lsn < 0) {
 		int64_t tid = last_entry->txn->id;
-		if (journal_sync(NULL) != 0)
+		if (txn_persist_all_prepared(NULL) != 0)
 			return -1;
 		if (box_check_promote_term_intact(promote_term) != 0)
 			return -1;

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -6399,6 +6399,12 @@ on_garbage_collection(void)
 }
 
 static void
+box_on_journal_cascading_rollback(void)
+{
+	txn_limbo_rollback_all_volatile(&txn_limbo);
+}
+
+static void
 box_storage_init(void)
 {
 	assert(!is_storage_initialized);
@@ -6417,6 +6423,7 @@ box_storage_init(void)
 	engine_init();
 	schema_init();
 	txn_limbo_init();
+	journal_on_cascading_rollback = box_on_journal_cascading_rollback;
 	replication_init(cfg_geti_default("replication_threads", 1));
 	iproto_init(cfg_geti("iproto_threads"));
 	sql_init();

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -698,7 +698,7 @@ static void
 recovery_journal_create(struct vclock *v)
 {
 	static struct recovery_journal journal;
-	journal_create(&journal.base, recovery_journal_write);
+	journal_create(&journal.base, recovery_journal_write, NULL);
 	journal.vclock = v;
 	journal_set(&journal.base);
 }
@@ -3042,10 +3042,8 @@ box_wait_limbo_acked(double timeout)
 	/* Wait for the last entries WAL write. */
 	if (last_entry->lsn < 0) {
 		int64_t tid = last_entry->txn->id;
-
-		if (wal_sync(NULL) != 0)
+		if (journal_sync(NULL) != 0)
 			return -1;
-
 		if (box_check_promote_term_intact(promote_term) != 0)
 			return -1;
 		if (txn_limbo_is_empty(&txn_limbo))
@@ -5953,7 +5951,7 @@ box_cfg_xc(void)
 	}
 
 	struct journal bootstrap_journal;
-	journal_create(&bootstrap_journal, bootstrap_journal_write);
+	journal_create(&bootstrap_journal, bootstrap_journal_write, NULL);
 	journal_set(&bootstrap_journal);
 	auto bootstrap_journal_guard = make_scoped_guard([] {
 		journal_set(NULL);

--- a/src/box/gc.c
+++ b/src/box/gc.c
@@ -540,6 +540,9 @@ gc_do_checkpoint(bool is_scheduled)
 	rc = engine_begin_checkpoint(is_scheduled);
 	if (rc != 0)
 		goto out;
+	rc = txn_limbo_flush(&txn_limbo);
+	if (rc != 0)
+		goto out;
 	rc = wal_begin_checkpoint(&checkpoint);
 	if (rc != 0)
 		goto out;

--- a/src/box/journal.c
+++ b/src/box/journal.c
@@ -85,8 +85,7 @@ diag_set_journal_res_detailed(const char *file, unsigned line, int64_t res)
 
 struct journal_entry *
 journal_entry_new(size_t n_rows, struct region *region,
-		  journal_write_async_f write_async_cb,
-		  void *complete_data)
+		  journal_on_write_f on_write, void *complete_data)
 {
 	struct journal_entry *entry;
 
@@ -99,9 +98,7 @@ journal_entry_new(size_t n_rows, struct region *region,
 		diag_set(OutOfMemory, size, "region", "struct journal_entry");
 		return NULL;
 	}
-
-	journal_entry_create(entry, n_rows, 0, write_async_cb,
-			     complete_data);
+	journal_entry_create(entry, n_rows, 0, on_write, complete_data);
 	return entry;
 }
 
@@ -176,7 +173,7 @@ journal_queue_wait(struct journal_entry *entry)
 		else
 			req->res = JOURNAL_ENTRY_ERR_CASCADE;
 		req->is_complete = true;
-		req->write_async_cb(req);
+		req->on_write(req);
 	}
 	diag_set(FiberIsCancelled);
 	return -1;
@@ -208,7 +205,7 @@ journal_queue_rollback(void)
 	stailq_foreach_entry(req, &rollback, fifo) {
 		req->res = JOURNAL_ENTRY_ERR_CASCADE;
 		req->is_complete = true;
-		req->write_async_cb(req);
+		req->on_write(req);
 	}
 }
 

--- a/src/box/journal.h
+++ b/src/box/journal.h
@@ -53,6 +53,9 @@ typedef int
 typedef int
 (*journal_sync_f)(struct journal *journal, struct vclock *out);
 
+typedef void
+(*journal_on_cascading_rollback_f)(void);
+
 enum {
 	/** Entry didn't attempt a journal write. */
 	JOURNAL_ENTRY_ERR_UNKNOWN = -1,
@@ -250,6 +253,13 @@ journal_async_complete(struct journal_entry *entry)
  * points at a concrete implementation of the journal.
  */
 extern struct journal *current_journal;
+/**
+ * The callback invoked when the journal is about to perform a cascading
+ * rollback. It is expected that all the newer txns which might be prepared but
+ * not yet visible to the journal would get rolled back as well when this
+ * callback is fired.
+ */
+extern journal_on_cascading_rollback_f journal_on_cascading_rollback;
 
 /** Write a single row in a blocking way. */
 int

--- a/src/box/journal.h
+++ b/src/box/journal.h
@@ -40,10 +40,14 @@ extern "C" {
 #endif /* defined(__cplusplus) */
 
 struct xrow_header;
+struct journal;
 struct journal_entry;
 
 typedef void
 (*journal_on_write_f)(struct journal_entry *entry);
+
+typedef int
+(*journal_submit_f)(struct journal *journal, struct journal_entry *entry);
 
 enum {
 	/** Entry didn't attempt a journal write. */
@@ -177,8 +181,7 @@ extern struct journal_queue journal_queue;
  */
 struct journal {
 	/** Asynchronous write */
-	int (*write_async)(struct journal *journal,
-			   struct journal_entry *entry);
+	journal_submit_f submit;
 };
 
 /** Wake the journal queue up. */
@@ -262,10 +265,10 @@ journal_write_submit(struct journal_entry *entry)
 		return -1;
 	/*
 	 * We cannot account entry after write. If journal is synchronous
-	 * the journal_queue_on_complete() is called in write_async().
+	 * the journal_queue_on_complete() is called in submit().
 	 */
 	journal_queue_on_append(entry);
-	if (current_journal->write_async(current_journal, entry) != 0) {
+	if (current_journal->submit(current_journal, entry) != 0) {
 		journal_queue_on_complete(entry);
 		journal_queue_rollback();
 		return -1;
@@ -312,17 +315,15 @@ journal_set(struct journal *new_journal)
 }
 
 static inline void
-journal_create(struct journal *journal,
-	       int (*write_async)(struct journal *journal,
-				  struct journal_entry *entry))
+journal_create(struct journal *journal, journal_submit_f submit)
 {
-	journal->write_async = write_async;
+	journal->submit = submit;
 }
 
 static inline bool
 journal_is_initialized(struct journal *journal)
 {
-	return journal->write_async != NULL;
+	return journal->submit != NULL;
 }
 
 #if defined(__cplusplus)

--- a/src/box/journal.h
+++ b/src/box/journal.h
@@ -42,12 +42,16 @@ extern "C" {
 struct xrow_header;
 struct journal;
 struct journal_entry;
+struct vclock;
 
 typedef void
 (*journal_on_write_f)(struct journal_entry *entry);
 
 typedef int
 (*journal_submit_f)(struct journal *journal, struct journal_entry *entry);
+
+typedef int
+(*journal_sync_f)(struct journal *journal, struct vclock *out);
 
 enum {
 	/** Entry didn't attempt a journal write. */
@@ -182,6 +186,8 @@ extern struct journal_queue journal_queue;
 struct journal {
 	/** Asynchronous write */
 	journal_submit_f submit;
+	/** Ensure all the currently queued requests are written. */
+	journal_sync_f sync;
 };
 
 /** Wake the journal queue up. */
@@ -192,7 +198,11 @@ journal_queue_wakeup(void);
 int
 journal_queue_wait(struct journal_entry *entry);
 
-/** Flush journal queue. Next wal_sync() will sync flushed requests. */
+/**
+ * Make sure the volatile journal queue is emptied (either sent to WAL or rolled
+ * back). Keep in mind that it doesn't guarantee the success of the flushed
+ * entries.
+ */
 int
 journal_queue_flush(void);
 
@@ -287,6 +297,12 @@ journal_write(struct journal_entry *entry)
 	return 0;
 }
 
+static inline int
+journal_sync(struct vclock *out)
+{
+	return current_journal->sync(current_journal, out);
+}
+
 /**
  * Change the current implementation of the journaling API.
  * Happens during life cycle of an instance:
@@ -315,9 +331,11 @@ journal_set(struct journal *new_journal)
 }
 
 static inline void
-journal_create(struct journal *journal, journal_submit_f submit)
+journal_create(struct journal *journal, journal_submit_f submit,
+	       journal_sync_f sync)
 {
 	journal->submit = submit;
+	journal->sync = sync;
 }
 
 static inline bool

--- a/src/box/lua/ctl.c
+++ b/src/box/lua/ctl.c
@@ -181,7 +181,7 @@ lbox_ctl_set_iproto_lockdown(struct lua_State *L)
 static int
 lbox_ctl_wal_sync(struct lua_State *L)
 {
-	if (wal_sync(NULL))
+	if (journal_sync(NULL))
 		return luaT_error(L);
 	return 0;
 }

--- a/src/box/lua/info.c
+++ b/src/box/lua/info.c
@@ -726,14 +726,10 @@ lbox_info_synchro(struct lua_State *L)
 	lua_setfield(L, -2, "busy");
 	luaL_pushuint64(L, queue->promote_greatest_term);
 	lua_setfield(L, -2, "term");
-	if (queue->len == 0) {
+	if (queue->len == 0)
 		lua_pushnumber(L, 0);
-	} else {
-		struct txn_limbo_entry *oldest_entry =
-			txn_limbo_first_entry(queue);
-		double now = fiber_clock();
-		lua_pushnumber(L, now - oldest_entry->insertion_time);
-	}
+	else
+		lua_pushnumber(L, txn_limbo_age(queue));
 	lua_setfield(L, -2, "age");
 	lua_pushnumber(L, queue->confirm_lag);
 	lua_setfield(L, -2, "confirm_lag");

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -62,7 +62,6 @@
 #include "memtx_space_upgrade.h"
 #include "tt_sort.h"
 #include "assoc.h"
-#include "wal.h"
 
 #include <type_traits>
 
@@ -1473,9 +1472,8 @@ memtx_engine_join(struct engine *engine, struct engine_join_ctx *arg,
 	 * yield between read-view creation. Moreover, wal syncing
 	 * should happen after creation of all engine's read-views.
 	 */
-	if (wal_sync(arg->vclock) != 0)
+	if (journal_sync(arg->vclock) != 0)
 		return -1;
-
 	/*
 	 * Start sending data only when the latest sync
 	 * transaction is confirmed.

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -40,6 +40,7 @@
 #include "info/info.h"
 #include "tuple.h"
 #include "txn.h"
+#include "txn_checkpoint.h"
 #include "memtx_tx.h"
 #include "memtx_tree.h"
 #include "iproto_constants.h"
@@ -1460,37 +1461,21 @@ memtx_engine_join(struct engine *engine, struct engine_join_ctx *arg,
 		(struct memtx_join_ctx *)arg->data[engine->id];
 	ctx->stream = stream;
 
-	struct vclock limbo_vclock;
-	struct raft_request raft_req;
-	struct synchro_request synchro_req;
-	/*
-	 * Sync WAL to make sure that all changes visible from
-	 * the frozen read view are successfully committed and
-	 * obtain corresponding vclock.
-	 *
-	 * This cannot be done in prepare_join, as we should not
-	 * yield between read-view creation. Moreover, wal syncing
-	 * should happen after creation of all engine's read-views.
-	 */
-	if (journal_sync(arg->vclock) != 0)
+	struct txn_checkpoint txn_cp;
+	if (txn_checkpoint_build(&txn_cp) != 0)
 		return -1;
-	/*
-	 * Start sending data only when the latest sync
-	 * transaction is confirmed.
-	 */
-	if (txn_limbo_wait_confirm(&txn_limbo) != 0)
-		return -1;
+	vclock_copy(arg->vclock, &txn_cp.journal_vclock);
+	struct raft_request *raft_checkpoint = &txn_cp.raft_remote_checkpoint;
+	struct synchro_request *synchro_checkpoint = &txn_cp.limbo_checkpoint;
 
-	txn_limbo_checkpoint(&txn_limbo, &synchro_req, &limbo_vclock);
-	box_raft_checkpoint_remote(&raft_req);
 	/* See raft_process_recovery, why these fields are not needed. */
-	raft_req.state = 0;
-	raft_req.vclock = NULL;
+	raft_checkpoint->state = 0;
+	raft_checkpoint->vclock = NULL;
 
 	/* Respond with vclock and JOIN_META. */
 	send_join_header(stream, arg->vclock);
 	if (arg->send_meta) {
-		send_join_meta(stream, &raft_req, &synchro_req);
+		send_join_meta(stream, raft_checkpoint, synchro_checkpoint);
 		struct xrow_header row;
 		/* Mark the beginning of the data stream. */
 		xrow_encode_type(&row, IPROTO_JOIN_SNAPSHOT);

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -1108,25 +1108,17 @@ static int
 txn_add_limbo_entry(struct txn *txn, const struct journal_entry *req,
 		    enum txn_commit_wait_mode wait_mode)
 {
-	uint32_t origin_id = req->rows[0]->replica_id;
-	if (origin_id == 0 && txn_limbo_is_full(&txn_limbo)) {
-		if (wait_mode == TXN_COMMIT_WAIT_MODE_NONE) {
-			diag_set(ClientError, ER_SYNC_QUEUE_FULL);
-			return -1;
-		}
-		if (txn_limbo_wait_for_space(&txn_limbo) != 0)
-			return -1;
-	}
-
 	/*
 	 * Remote rows, if any, come before local rows, so check for originating
 	 * instance id in the first row.
 	 */
-	txn->limbo_entry = txn_limbo_append(&txn_limbo, origin_id, txn,
-					    req->approx_len);
-	if (txn->limbo_entry == NULL)
+	uint32_t origin_id = req->rows[0]->replica_id;
+	if (origin_id == 0 && txn_limbo_would_block(&txn_limbo) &&
+	    wait_mode == TXN_COMMIT_WAIT_MODE_NONE) {
+		diag_set(ClientError, ER_SYNC_QUEUE_FULL);
 		return -1;
-	return 0;
+	}
+	return txn_limbo_submit(&txn_limbo, origin_id, txn, req->approx_len);
 }
 
 static int

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -1011,10 +1011,7 @@ txn_journal_entry_new(struct txn *txn)
 	return req;
 }
 
-/**
- * Prepare a transaction using engines, run triggers, etc.
- */
-static int
+int
 txn_prepare(struct txn *txn)
 {
 	if (txn_check_can_continue(txn) != 0)

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -691,6 +691,12 @@ struct txn *
 txn_begin(void);
 
 /**
+ * Prepare a transaction using engines, run triggers, etc.
+ */
+int
+txn_prepare(struct txn *txn);
+
+/**
  * Complete transaction processing with an error. All the changes are going to
  * be rolled back. The transaction's signature should be set to the rollback
  * reason.

--- a/src/box/txn_checkpoint.c
+++ b/src/box/txn_checkpoint.c
@@ -1,0 +1,30 @@
+#include "txn_checkpoint.h"
+#include "txn_limbo.h"
+#include "raft.h"
+#include "txn.h"
+
+int
+txn_checkpoint_build(struct txn_checkpoint *out)
+{
+	struct txn_limbo *limbo = &txn_limbo;
+	/*
+	 * Make sure that all changes at the time of checkpoint start have
+	 * reached WAL and get the vclock collected exactly at that moment.
+	 *
+	 * For async txns the persistence means commit. For sync txns need to
+	 * wait for their confirmation explicitly.
+	 */
+	if (journal_sync(&out->journal_vclock) != 0)
+		return -1;
+	/*
+	 * The synchronous transactions, persisted above, might still be not
+	 * committed. Lets make sure they are, so the checkpoint won't have any
+	 * rolled back data.
+	 */
+	if (txn_limbo_wait_confirm(limbo) != 0)
+		return -1;
+
+	txn_limbo_checkpoint(limbo, &out->limbo_checkpoint, &out->limbo_vclock);
+	box_raft_checkpoint_remote(&out->raft_remote_checkpoint);
+	return 0;
+}

--- a/src/box/txn_checkpoint.c
+++ b/src/box/txn_checkpoint.c
@@ -32,5 +32,24 @@ txn_checkpoint_build(struct txn_checkpoint *out)
 int
 txn_persist_all_prepared(struct vclock *out)
 {
+	/*
+	 * All the txns after preparation until all the journal write follow the
+	 * same path:
+	 * - The limbo volatile queue.
+	 * - The journal volatile queue.
+	 * - The journal write.
+	 *
+	 * Some steps might be skipped (for instance, the limbo might be if the
+	 * txn is force-async or just async and the limbo is empty). But the
+	 * order never changes.
+	 *
+	 * It means, that if one would want to closely follow the latest known
+	 * prepared txn until it reaches WAL, then following this path the
+	 * needed txn will be surely found before any new txn is added (except
+	 * for force-async, which might skip the volatile limbo queue and go
+	 * directly to the journal).
+	 */
+	if (txn_limbo_flush(&txn_limbo) != 0)
+		return -1;
 	return journal_sync(out);
 }

--- a/src/box/txn_checkpoint.c
+++ b/src/box/txn_checkpoint.c
@@ -14,7 +14,7 @@ txn_checkpoint_build(struct txn_checkpoint *out)
 	 * For async txns the persistence means commit. For sync txns need to
 	 * wait for their confirmation explicitly.
 	 */
-	if (journal_sync(&out->journal_vclock) != 0)
+	if (txn_persist_all_prepared(&out->journal_vclock) != 0)
 		return -1;
 	/*
 	 * The synchronous transactions, persisted above, might still be not
@@ -27,4 +27,10 @@ txn_checkpoint_build(struct txn_checkpoint *out)
 	txn_limbo_checkpoint(limbo, &out->limbo_checkpoint, &out->limbo_vclock);
 	box_raft_checkpoint_remote(&out->raft_remote_checkpoint);
 	return 0;
+}
+
+int
+txn_persist_all_prepared(struct vclock *out)
+{
+	return journal_sync(out);
 }

--- a/src/box/txn_checkpoint.c
+++ b/src/box/txn_checkpoint.c
@@ -3,10 +3,84 @@
 #include "raft.h"
 #include "txn.h"
 
+/** Data of the in-progress checkpoint to carry into the triggers. */
+struct txn_checkpoint_context {
+	/** The checkpoint to be created. */
+	struct txn_checkpoint *checkpoint;
+	/** The owner fiber sleeping on the result. */
+	struct fiber *owner;
+	/** If is committed. */
+	bool is_commit;
+	/** If is rolled back. */
+	bool is_rollback;
+};
+
+static void
+txn_checkpoint_collect(struct txn_checkpoint *c)
+{
+	txn_limbo_checkpoint(&txn_limbo, &c->limbo_checkpoint,
+			     &c->limbo_vclock);
+	box_raft_checkpoint_remote(&c->raft_remote_checkpoint);
+}
+
+/** On commit of the limbo txn. */
+static int
+txn_commit_cb(struct trigger *trigger, void *event)
+{
+	(void)event;
+	struct txn_checkpoint_context *ctx = trigger->data;
+	ctx->is_commit = true;
+	txn_checkpoint_collect(ctx->checkpoint);
+	fiber_wakeup(ctx->owner);
+	return 0;
+}
+
+/** On rollback of the limbo txn. */
+static int
+txn_rollback_cb(struct trigger *trigger, void *event)
+{
+	(void)event;
+	struct txn_checkpoint_context *ctx = trigger->data;
+	ctx->is_rollback = true;
+	fiber_wakeup(ctx->owner);
+	return 0;
+}
+
 int
 txn_checkpoint_build(struct txn_checkpoint *out)
 {
 	struct txn_limbo *limbo = &txn_limbo;
+	/* Fast path. */
+	if (txn_limbo_is_empty(limbo)) {
+		txn_checkpoint_collect(out);
+		return txn_persist_all_prepared(&out->journal_vclock);
+	}
+	/*
+	 * Slow path. When the limbo is not empty, it is relatively complicated
+	 * to create a checkpoint of it. Because while waiting for its flush and
+	 * then waiting for the journal sync, it might receive new volatile
+	 * txns. And then it becomes too late to "wait for last synchro txn to
+	 * get committed". Because the last synchro txn has changed.
+	 *
+	 * The only possible way is to remember what was the last txn before
+	 * doing any waiting. And then collect the checkpoint **exactly** when
+	 * the last txn gets committed. Doing it even one fiber yield later
+	 * might result into more synchro txns getting confirmed and moving the
+	 * limbo state forward. Making the collected checkpoint "too new".
+	 */
+	struct txn_checkpoint_context ctx = {
+		.checkpoint = out,
+		.owner = fiber(),
+		.is_commit = false,
+		.is_rollback = false,
+	};
+	struct trigger on_commit;
+	trigger_create(&on_commit, txn_commit_cb, &ctx, NULL);
+	struct trigger on_rollback;
+	trigger_create(&on_rollback, txn_rollback_cb, &ctx, NULL);
+	struct txn_limbo_entry *tle = txn_limbo_last_synchro_entry(limbo);
+	txn_on_commit(tle->txn, &on_commit);
+	txn_on_rollback(tle->txn, &on_rollback);
 	/*
 	 * Make sure that all changes at the time of checkpoint start have
 	 * reached WAL and get the vclock collected exactly at that moment.
@@ -21,11 +95,19 @@ txn_checkpoint_build(struct txn_checkpoint *out)
 	 * committed. Lets make sure they are, so the checkpoint won't have any
 	 * rolled back data.
 	 */
-	if (txn_limbo_wait_confirm(limbo) != 0)
+	while (!ctx.is_rollback && !ctx.is_commit) {
+		if (fiber_is_cancelled()) {
+			trigger_clear(&on_commit);
+			trigger_clear(&on_rollback);
+			diag_set(FiberIsCancelled);
+			return -1;
+		}
+		fiber_yield();
+	}
+	if (ctx.is_rollback) {
+		diag_set(ClientError, ER_SYNC_ROLLBACK);
 		return -1;
-
-	txn_limbo_checkpoint(limbo, &out->limbo_checkpoint, &out->limbo_vclock);
-	box_raft_checkpoint_remote(&out->raft_remote_checkpoint);
+	}
 	return 0;
 }
 

--- a/src/box/txn_checkpoint.h
+++ b/src/box/txn_checkpoint.h
@@ -1,0 +1,43 @@
+#pragma once
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2025, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include "xrow.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+/** Data collected precisely when all the prepared txns are committed. */
+struct txn_checkpoint {
+	/**
+	 * VClock taken when the last known prepared txn was written to WAL. For
+	 * non-synchronous txns it is equal to their commit moment.
+	 */
+	struct vclock journal_vclock;
+	/**
+	 * Full descriptor of the Raft state machine collected exactly when the
+	 * last known synchronous txn was confirmed.
+	 */
+	struct raft_request raft_remote_checkpoint;
+	/**
+	 * Full descriptor of the txn limbo collected exactly when the last
+	 * known synchronous txn was confirmed.
+	 */
+	struct synchro_request limbo_checkpoint;
+	/** VClock of the limbo's state. */
+	struct vclock limbo_vclock;
+};
+
+/**
+ * Wait until all the currently prepared txns are committed and collect all the
+ * global transaction-related data at this exact moment.
+ */
+int
+txn_checkpoint_build(struct txn_checkpoint *out);
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */

--- a/src/box/txn_checkpoint.h
+++ b/src/box/txn_checkpoint.h
@@ -38,6 +38,14 @@ struct txn_checkpoint {
 int
 txn_checkpoint_build(struct txn_checkpoint *out);
 
+/**
+ * Wait until all the prepared txns have been successfully written to the
+ * journal. However there is not guarantee that they are going to be committed.
+ * For synchronous txns just a journal write isn't enough.
+ */
+int
+txn_persist_all_prepared(struct vclock *out);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -48,6 +48,28 @@ txn_limbo_write_synchro(struct txn_limbo *limbo, uint16_t type, int64_t lsn,
 static void
 txn_limbo_read_confirm(struct txn_limbo *limbo, int64_t lsn);
 
+static inline struct txn_limbo_entry *
+txn_limbo_first_entry(struct txn_limbo *limbo)
+{
+	return rlist_first_entry(&limbo->queue, struct txn_limbo_entry,
+				 in_queue);
+}
+
+static inline struct txn_limbo_entry *
+txn_limbo_last_entry(struct txn_limbo *limbo)
+{
+	return rlist_last_entry(&limbo->queue, struct txn_limbo_entry,
+				in_queue);
+}
+
+double
+txn_limbo_age(struct txn_limbo *limbo)
+{
+	if (txn_limbo_is_empty(limbo))
+		return 0;
+	return fiber_clock() - txn_limbo_first_entry(limbo)->insertion_time;
+}
+
 /**
  * Write a confirmation entry to the WAL. After it's written all the
  * transactions waiting for confirmation may be finished.

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -202,7 +202,7 @@ txn_limbo_pop_first(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
 	txn_limbo_on_remove(limbo, entry);
 }
 
-void
+static void
 txn_limbo_complete(struct txn *txn, bool is_success)
 {
 	/*
@@ -234,6 +234,40 @@ txn_limbo_complete(struct txn *txn, bool is_success)
 	fiber_set_txn(fiber(), NULL);
 	fiber_set_user(fiber(), orig_creds);
 	fiber_set_session(fiber(), orig_session);
+}
+
+/** Complete the given limbo entry with a failure and the given reason. */
+static void
+txn_limbo_complete_fail(struct txn_limbo *limbo, struct txn_limbo_entry *entry,
+			int64_t signature)
+{
+	assert(entry->state == TXN_LIMBO_ENTRY_SUBMITTED);
+	struct txn *txn = entry->txn;
+	txn->signature = signature;
+	txn->limbo_entry = NULL;
+	txn_limbo_abort(limbo, entry);
+	txn_clear_flags(txn, TXN_WAIT_SYNC | TXN_WAIT_ACK);
+	txn_limbo_complete(txn, false);
+}
+
+/** Complete the given limbo entry with a success. */
+static void
+txn_limbo_complete_success(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
+{
+	assert(entry->state == TXN_LIMBO_ENTRY_SUBMITTED);
+	struct txn *txn = entry->txn;
+	entry->state = TXN_LIMBO_ENTRY_COMMIT;
+	if (txn_has_flag(txn, TXN_WAIT_ACK))
+		limbo->confirm_lag = fiber_clock() - entry->insertion_time;
+	txn->limbo_entry = NULL;
+	txn_limbo_pop_first(limbo, entry);
+	txn_clear_flags(txn, TXN_WAIT_SYNC | TXN_WAIT_ACK);
+	/*
+	 * Should be written to WAL by now. Confirm is always written after the
+	 * affected transactions.
+	 */
+	assert(txn->signature >= 0);
+	txn_limbo_complete(txn, true);
 }
 
 struct txn_limbo_entry *
@@ -459,11 +493,7 @@ txn_limbo_wait_complete(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
 	struct txn_limbo_entry *tmp;
 	rlist_foreach_entry_safe_reverse(e, &limbo->queue,
 					 in_queue, tmp) {
-		e->txn->signature = TXN_SIGNATURE_QUORUM_TIMEOUT;
-		e->txn->limbo_entry = NULL;
-		txn_limbo_abort(limbo, e);
-		txn_clear_flags(e->txn, TXN_WAIT_SYNC | TXN_WAIT_ACK);
-		txn_limbo_complete(e->txn, false);
+		txn_limbo_complete_fail(limbo, e, TXN_SIGNATURE_QUORUM_TIMEOUT);
 		if (e == entry)
 			break;
 	}
@@ -626,19 +656,7 @@ txn_limbo_read_confirm(struct txn_limbo *limbo, int64_t lsn)
 			e->txn = NULL;
 			continue;
 		}
-		assert(e->state == TXN_LIMBO_ENTRY_SUBMITTED);
-		e->state = TXN_LIMBO_ENTRY_COMMIT;
-		if (txn_has_flag(e->txn, TXN_WAIT_ACK))
-			limbo->confirm_lag = fiber_clock() - e->insertion_time;
-		e->txn->limbo_entry = NULL;
-		txn_limbo_pop_first(limbo, e);
-		txn_clear_flags(e->txn, TXN_WAIT_SYNC | TXN_WAIT_ACK);
-		/*
-		 * Should be written to WAL by now. Confirm is always written
-		 * after the affected transactions.
-		 */
-		assert(e->txn->signature >= 0);
-		txn_limbo_complete(e->txn, true);
+		txn_limbo_complete_success(limbo, e);
 	}
 	/*
 	 * Track CONFIRM lsn on replica in order to detect split-brain by
@@ -694,16 +712,12 @@ txn_limbo_read_rollback(struct txn_limbo *limbo, int64_t lsn)
 	if (last_rollback == NULL)
 		return;
 	rlist_foreach_entry_safe_reverse(e, &limbo->queue, in_queue, tmp) {
-		txn_limbo_abort(limbo, e);
-		txn_clear_flags(e->txn, TXN_WAIT_ACK);
 		/*
 		 * Should be written to WAL by now. Rollback is always written
 		 * after the affected transactions.
 		 */
 		assert(e->txn->signature >= 0);
-		e->txn->signature = TXN_SIGNATURE_SYNC_ROLLBACK;
-		e->txn->limbo_entry = NULL;
-		txn_limbo_complete(e->txn, false);
+		txn_limbo_complete_fail(limbo, e, TXN_SIGNATURE_SYNC_ROLLBACK);
 		if (e == last_rollback)
 			break;
 	}

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -309,7 +309,7 @@ txn_limbo_append(struct txn_limbo *limbo, uint32_t id, struct txn *txn,
 }
 
 static inline void
-txn_limbo_remove(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
+txn_limbo_pop_first(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
 {
 	assert(!rlist_empty(&entry->in_queue));
 	assert(txn_limbo_first_entry(limbo) == entry);
@@ -317,32 +317,24 @@ txn_limbo_remove(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
 	txn_limbo_on_remove(limbo, entry);
 }
 
-static inline void
-txn_limbo_pop(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
-{
-	assert(!rlist_empty(&entry->in_queue));
-	assert(txn_limbo_last_entry(limbo) == entry);
-	assert(entry->state == TXN_LIMBO_ENTRY_ROLLBACK);
-
-	rlist_del_entry(entry, in_queue);
-	txn_limbo_on_remove(limbo, entry);
-	++limbo->rollback_count;
-}
-
 void
 txn_limbo_abort(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
 {
 	assert(entry->state == TXN_LIMBO_ENTRY_SUBMITTED);
-	entry->state = TXN_LIMBO_ENTRY_ROLLBACK;
-	if (entry == limbo->entry_to_confirm)
-		limbo->entry_to_confirm = NULL;
+	assert(!rlist_empty(&entry->in_queue));
 	/*
 	 * The simple rule about rollback/commit order applies
 	 * here as well: commit always in the order of WAL write,
 	 * rollback in the reversed order. Rolled back transaction
 	 * is always the last.
 	 */
-	txn_limbo_pop(limbo, entry);
+	assert(txn_limbo_last_entry(limbo) == entry);
+	entry->state = TXN_LIMBO_ENTRY_ROLLBACK;
+	if (entry == limbo->entry_to_confirm)
+		limbo->entry_to_confirm = NULL;
+	rlist_del_entry(entry, in_queue);
+	txn_limbo_on_remove(limbo, entry);
+	++limbo->rollback_count;
 }
 
 void
@@ -622,7 +614,7 @@ txn_limbo_read_confirm(struct txn_limbo *limbo, int64_t lsn)
 			 * created in the applier.
 			 */
 			txn_clear_flags(e->txn, TXN_WAIT_SYNC);
-			txn_limbo_remove(limbo, e);
+			txn_limbo_pop_first(limbo, e);
 			/*
 			 * The limbo entry now should not be used by the owner
 			 * transaction since it just became a plain one. Nullify
@@ -638,7 +630,7 @@ txn_limbo_read_confirm(struct txn_limbo *limbo, int64_t lsn)
 		if (txn_has_flag(e->txn, TXN_WAIT_ACK))
 			limbo->confirm_lag = fiber_clock() - e->insertion_time;
 		e->txn->limbo_entry = NULL;
-		txn_limbo_remove(limbo, e);
+		txn_limbo_pop_first(limbo, e);
 		txn_clear_flags(e->txn, TXN_WAIT_SYNC | TXN_WAIT_ACK);
 		/*
 		 * Should be written to WAL by now. Confirm is always written

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -826,10 +826,7 @@ txn_limbo_read_confirm(struct txn_limbo *limbo, int64_t lsn)
 {
 	assert(limbo->owner_id != REPLICA_ID_NIL || txn_limbo_is_empty(limbo));
 	assert(limbo == &txn_limbo);
-	if (limbo->confirmed_lsn < lsn) {
-		limbo->confirmed_lsn = lsn;
-		vclock_follow(&limbo->confirmed_vclock, limbo->owner_id, lsn);
-	}
+	assert(limbo->confirmed_lsn <= lsn);
 	struct txn_limbo_entry *e, *next;
 	rlist_foreach_entry_safe(e, &limbo->queue, in_queue, next) {
 		/*
@@ -848,6 +845,22 @@ txn_limbo_read_confirm(struct txn_limbo *limbo, int64_t lsn)
 			 */
 			if (e->lsn == -1)
 				break;
+			if (!rlist_empty(&e->txn->on_commit)) {
+				/*
+				 * Bump the confirmed LSN right now, do not
+				 * batch with any newer txns. So on-commit
+				 * triggers would see the confirmation LSN
+				 * matching this txn exactly. Making an illusion
+				 * like each txn has its own confirmation.
+				 */
+				if (limbo->confirmed_lsn < e->lsn) {
+					limbo->confirmed_lsn = e->lsn;
+					vclock_follow(&limbo->confirmed_vclock,
+						      limbo->owner_id, e->lsn);
+				} else {
+					assert(limbo->confirmed_lsn == lsn);
+				}
+			}
 		} else if (e->txn->signature == TXN_SIGNATURE_UNKNOWN) {
 			/*
 			 * A transaction might be covered by the CONFIRM even if
@@ -890,6 +903,10 @@ txn_limbo_read_confirm(struct txn_limbo *limbo, int64_t lsn)
 			continue;
 		}
 		txn_limbo_complete_success(limbo, e);
+	}
+	if (limbo->confirmed_lsn < lsn) {
+		limbo->confirmed_lsn = lsn;
+		vclock_follow(&limbo->confirmed_vclock, limbo->owner_id, lsn);
 	}
 }
 

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -826,6 +826,10 @@ txn_limbo_read_confirm(struct txn_limbo *limbo, int64_t lsn)
 {
 	assert(limbo->owner_id != REPLICA_ID_NIL || txn_limbo_is_empty(limbo));
 	assert(limbo == &txn_limbo);
+	if (limbo->confirmed_lsn < lsn) {
+		limbo->confirmed_lsn = lsn;
+		vclock_follow(&limbo->confirmed_vclock, limbo->owner_id, lsn);
+	}
 	struct txn_limbo_entry *e, *next;
 	rlist_foreach_entry_safe(e, &limbo->queue, in_queue, next) {
 		/*
@@ -886,15 +890,6 @@ txn_limbo_read_confirm(struct txn_limbo *limbo, int64_t lsn)
 			continue;
 		}
 		txn_limbo_complete_success(limbo, e);
-	}
-	/*
-	 * Track CONFIRM lsn on replica in order to detect split-brain by
-	 * comparing existing confirm_lsn with the one arriving from a remote
-	 * instance.
-	 */
-	if (limbo->confirmed_lsn < lsn) {
-		limbo->confirmed_lsn = lsn;
-		vclock_follow(&limbo->confirmed_vclock, limbo->owner_id, lsn);
 	}
 }
 

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -334,6 +334,12 @@ txn_limbo_rollback_volatile_up_to(struct txn_limbo *limbo,
 	}
 }
 
+void
+txn_limbo_rollback_all_volatile(struct txn_limbo *limbo)
+{
+	txn_limbo_rollback_volatile_up_to(limbo, NULL);
+}
+
 bool
 txn_limbo_would_block(struct txn_limbo *limbo)
 {

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -1349,90 +1349,6 @@ txn_limbo_filter_generic(struct txn_limbo *limbo,
 }
 
 /**
- * A common filter for all synchro requests, checking that request operates
- * over a valid lsn range.
- */
-static int
-txn_limbo_filter_queue_boundaries(struct txn_limbo *limbo,
-				  const struct synchro_request *req)
-{
-	int64_t lsn = req->lsn;
-	/*
-	 * Easy case - processed LSN matches the new one which comes inside
-	 * request, everything is consistent. This is allowed only for
-	 * PROMOTE/DEMOTE.
-	 */
-	if (limbo->confirmed_lsn == lsn) {
-		if (iproto_type_is_promote_request(req->type)) {
-			return 0;
-		} else {
-			say_error("%s. Duplicate request with confirmed lsn "
-				  "%lld = request lsn %lld", reject_str(req),
-				  (long long)limbo->confirmed_lsn,
-				  (long long)lsn);
-			diag_set(ClientError, ER_UNSUPPORTED, "Replication",
-				 "Duplicate CONFIRM/ROLLBACK request");
-			return -1;
-		}
-	}
-
-	/*
-	 * Explicit split brain situation. Request comes in with an old LSN
-	 * which we've already processed.
-	 */
-	if (limbo->confirmed_lsn > lsn) {
-		say_error("%s. confirmed lsn %lld > request lsn %lld",
-			  reject_str(req), (long long)limbo->confirmed_lsn,
-			  (long long)lsn);
-		diag_set(ClientError, ER_SPLIT_BRAIN,
-			 "got a request with lsn from an already "
-			 "processed range");
-		return -1;
-	}
-
-	/*
-	 * The last case requires a few subcases.
-	 */
-	assert(limbo->confirmed_lsn < lsn);
-
-	if (txn_limbo_is_empty(limbo)) {
-		/*
-		 * Transactions are rolled back already,
-		 * since the limbo is empty.
-		 */
-		say_error("%s. confirmed lsn %lld < request lsn %lld "
-			  "and empty limbo", reject_str(req),
-			  (long long)limbo->confirmed_lsn,
-			  (long long)lsn);
-		diag_set(ClientError, ER_SPLIT_BRAIN,
-			 "got a request mentioning future lsn");
-		return -1;
-	} else {
-		/*
-		 * Some entries are present in the limbo, we need to make sure
-		 * that request lsn lays inside limbo [first; last] range.
-		 * So that the request has some queued data to process,
-		 * otherwise it means the request comes from split brained node.
-		 */
-		int64_t first_lsn = txn_limbo_first_entry(limbo)->lsn;
-		int64_t last_lsn = txn_limbo_last_synchro_entry(limbo)->lsn;
-
-		if (lsn < first_lsn || last_lsn < lsn) {
-			say_error("%s. request lsn %lld out of range "
-				  "[%lld; %lld]", reject_str(req),
-				  (long long)lsn,
-				  (long long)first_lsn,
-				  (long long)last_lsn);
-			diag_set(ClientError, ER_SPLIT_BRAIN,
-				 "got a request lsn out of queue range");
-			return -1;
-		}
-	}
-
-	return 0;
-}
-
-/**
  * Filter CONFIRM and ROLLBACK packets.
  */
 static int
@@ -1441,6 +1357,7 @@ txn_limbo_filter_confirm_rollback(struct txn_limbo *limbo,
 {
 	assert(latch_is_locked(&limbo->promote_latch));
 	assert(limbo->do_validate);
+	(void)limbo;
 	assert(req->type == IPROTO_RAFT_CONFIRM ||
 	       req->type == IPROTO_RAFT_ROLLBACK);
 	/*
@@ -1452,8 +1369,7 @@ txn_limbo_filter_confirm_rollback(struct txn_limbo *limbo,
 			 "zero LSN for CONFIRM/ROLLBACK");
 		return -1;
 	}
-
-	return txn_limbo_filter_queue_boundaries(limbo, req);
+	return 0;
 }
 
 /** A filter PROMOTE and DEMOTE packets. */
@@ -1488,8 +1404,61 @@ txn_limbo_filter_promote_demote(struct txn_limbo *limbo,
 			 "got a PROMOTE/DEMOTE with an obsolete term");
 		return -1;
 	}
-
-	return txn_limbo_filter_queue_boundaries(limbo, req);
+	/*
+	 * Explicit split brain situation. Request comes in with an old LSN
+	 * which we've already processed.
+	 */
+	if (limbo->confirmed_lsn > req->lsn) {
+		say_error("%s. confirmed lsn %lld > request lsn %lld",
+			  reject_str(req), (long long)limbo->confirmed_lsn,
+			  (long long)req->lsn);
+		diag_set(ClientError, ER_SPLIT_BRAIN,
+			 "got a request with lsn from an already "
+			 "processed range");
+		return -1;
+	}
+	/*
+	 * Easy case - processed LSN matches the new one which comes inside
+	 * request, everything is consistent. This is allowed only for
+	 * PROMOTE/DEMOTE.
+	 */
+	if (limbo->confirmed_lsn == req->lsn)
+		return 0;
+	/*
+	 * The last case requires a few subcases.
+	 */
+	if (txn_limbo_is_empty(limbo)) {
+		/*
+		 * Transactions are rolled back already,
+		 * since the limbo is empty.
+		 */
+		say_error("%s. confirmed lsn %lld < request lsn %lld "
+			  "and empty limbo", reject_str(req),
+			  (long long)limbo->confirmed_lsn,
+			  (long long)req->lsn);
+		diag_set(ClientError, ER_SPLIT_BRAIN,
+			 "got a request mentioning future lsn");
+		return -1;
+	}
+	/*
+	 * Some entries are present in the limbo, we need to make sure that
+	 * request lsn lays inside limbo [first; last] range. So that the
+	 * request has some queued data to process, otherwise it means the
+	 * request comes from split brained node.
+	 */
+	int64_t first_lsn = txn_limbo_first_entry(limbo)->lsn;
+	int64_t last_lsn = txn_limbo_last_synchro_entry(limbo)->lsn;
+	if (req->lsn < first_lsn || last_lsn < req->lsn) {
+		say_error("%s. request lsn %lld out of range "
+			  "[%lld; %lld]", reject_str(req),
+			  (long long)req->lsn,
+			  (long long)first_lsn,
+			  (long long)last_lsn);
+		diag_set(ClientError, ER_SPLIT_BRAIN,
+			 "got a request lsn out of queue range");
+		return -1;
+	}
+	return 0;
 }
 
 /** A fine-grained filter checking specific request type constraints. */

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -282,6 +282,10 @@ struct txn_limbo {
  */
 extern struct txn_limbo txn_limbo;
 
+/** Get the age of the oldest non-confirmed limbo entry. */
+double
+txn_limbo_age(struct txn_limbo *limbo);
+
 static inline bool
 txn_limbo_is_empty(struct txn_limbo *limbo)
 {
@@ -296,20 +300,6 @@ txn_limbo_is_full(struct txn_limbo *limbo)
 
 bool
 txn_limbo_is_ro(struct txn_limbo *limbo);
-
-static inline struct txn_limbo_entry *
-txn_limbo_first_entry(struct txn_limbo *limbo)
-{
-	return rlist_first_entry(&limbo->queue, struct txn_limbo_entry,
-				 in_queue);
-}
-
-static inline struct txn_limbo_entry *
-txn_limbo_last_entry(struct txn_limbo *limbo)
-{
-	return rlist_last_entry(&limbo->queue, struct txn_limbo_entry,
-				in_queue);
-}
 
 /**
  * Return the latest term as seen in PROMOTE requests from instance with id

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -490,6 +490,16 @@ txn_limbo_write_demote(struct txn_limbo *limbo, int64_t lsn, uint64_t term);
 void
 txn_limbo_on_parameters_change(struct txn_limbo *limbo);
 
+/**
+ * Rollback all the volatile txns. That is, the ones waiting for space in the
+ * limbo and not yet sent to the journal. It is supposed to happen when some
+ * older txn wants to get rolled back. For example, when its WAL write fails.
+ * The it must cascading-rollback all the newer txns, including the ones not yet
+ * visible to the journal.
+ */
+void
+txn_limbo_rollback_all_volatile(struct txn_limbo *limbo);
+
 /** Start filtering incoming syncrho requests. */
 void
 txn_limbo_filter_enable(struct txn_limbo *limbo);

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -339,6 +339,22 @@ int
 txn_limbo_submit(struct txn_limbo *limbo, uint32_t id, struct txn *txn,
 		 size_t approx_len);
 
+/**
+ * Wait until all the limbo entries existing at the moment of calling are fully
+ * submitted into the limbo.
+ *
+ * It is guaranteed that if this function returns success, then all those limbo
+ * entries have been submitted to WAL. And the caller, for example, might do a
+ * journal sync right away to find out the vclock at the moment of the last
+ * limbo entry journal write.
+ *
+ * Any limbo entries added during the waiting are not going to be waited for.
+ * And are guaranteed not to be sent to the journal yet after this function
+ * returns success, until the next yield of the caller fiber.
+ */
+int
+txn_limbo_flush(struct txn_limbo *limbo);
+
 /** Remove the entry from the limbo, mark as rolled back. */
 void
 txn_limbo_abort(struct txn_limbo *limbo, struct txn_limbo_entry *entry);

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -1130,7 +1130,7 @@ vinyl_space_check_format(struct space *space, struct tuple_format *format)
 	 */
 	int rc;
 	if (need_wal_sync) {
-		rc = wal_sync(NULL);
+		rc = journal_sync(NULL);
 		if (rc != 0)
 			goto out;
 	}
@@ -4377,7 +4377,7 @@ vinyl_space_build_index(struct space *src_space, struct index *new_index,
 	 */
 	int rc;
 	if (need_wal_sync) {
-		rc = wal_sync(NULL);
+		rc = journal_sync(NULL);
 		if (rc != 0)
 			goto out;
 	}

--- a/src/box/vy_tx.h
+++ b/src/box/vy_tx.h
@@ -324,7 +324,7 @@ vy_tx_manager_destroy_read_view(struct vy_tx_manager *xm,
  *
  * @need_wal_sync is set if at least one transaction can't be
  * aborted, because it has reached WAL. The caller is supposed
- * to call wal_sync() to flush them.
+ * to call journal_sync() to flush them.
  */
 void
 vy_tx_manager_abort_writers_for_ddl(struct vy_tx_manager *xm,

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -746,6 +746,8 @@ wal_begin_checkpoint(struct wal_checkpoint *checkpoint)
 		diag_set(ClientError, ER_CASCADE_ROLLBACK);
 		return -1;
 	}
+	if (journal_queue_flush() != 0)
+		return -1;
 	return cbus_call(&writer->wal_pipe, &writer->tx_prio_pipe,
 			 &checkpoint->base, wal_begin_checkpoint_f);
 }

--- a/src/box/wal.h
+++ b/src/box/wal.h
@@ -211,15 +211,6 @@ wal_clear_watcher(struct wal_watcher *watcher,
 enum wal_mode
 wal_mode(void);
 
-/**
- * Wait until all submitted writes are successfully flushed
- * to disk. Returns 0 on success, -1 if write failed.
- * Corresponding vclock is returned in @a vclock unless it is
- * NULL.
- */
-int
-wal_sync(struct vclock *vclock);
-
 struct wal_checkpoint {
 	struct cbus_call_msg base;
 	/**

--- a/test/box-luatest/gh_11180_wal_volatile_snapshot_test.lua
+++ b/test/box-luatest/gh_11180_wal_volatile_snapshot_test.lua
@@ -1,0 +1,60 @@
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new({box_cfg = {wal_queue_max_size = 1000}})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+--
+-- gh-11180: the snapshot creation used to ignore the volatile journal entries
+-- waiting for the space in the journal queue. It could result into some data
+-- being present in the snapshot with an old vclock. And then on restart those
+-- entries would be re-applied from the following xlogs, leading to the
+-- operations applied twice.
+--
+g.test_wal_queue_rollback_in_flight = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        local data = string.rep('a', 1000)
+        local timeout = 60
+        local s = box.schema.create_space('test')
+        s:create_index('pk')
+
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+        local function make_txn_fiber(id)
+            return fiber.create(function()
+                fiber.self():set_joinable(true)
+                -- Insert will fail if would try to be applied both from the
+                -- snapshot and from the following xlog.
+                s:insert{id, data}
+            end)
+        end
+        -- One txn is in WAL. Another is waiting for space.
+        local f1 = make_txn_fiber(1)
+        local f2 = make_txn_fiber(2)
+        t.helpers.retrying({timeout = timeout}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+        end)
+        -- The snapshot must wait until all the journal entries are flushed.
+        local f_snap = fiber.create(function()
+            fiber.self():set_joinable(true)
+            box.snapshot()
+        end)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        t.assert((f1:join()))
+        t.assert((f2:join()))
+        t.assert((f_snap:join()))
+    end)
+    cg.server:restart()
+    cg.server:exec(function()
+        t.assert(box.space.test:get{1})
+        t.assert(box.space.test:get{2})
+    end)
+end

--- a/test/replication-luatest/gh_11180_qsync_join_overfilled_limbo_test.lua
+++ b/test/replication-luatest/gh_11180_qsync_join_overfilled_limbo_test.lua
@@ -1,0 +1,168 @@
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new({
+        box_cfg = {
+            replication_synchro_queue_max_size = 1000,
+            replication_synchro_timeout = 1000,
+            election_mode = 'manual',
+        }
+    })
+    cg.server:start()
+    cg.server:exec(function()
+        rawset(_G, 'fiber', require('fiber'))
+        box.ctl.promote()
+        box.ctl.wait_rw()
+        local s = box.schema.create_space('test', {is_sync = true})
+        s:create_index('pk')
+        rawset(_G, 'test_timeout', 60)
+        rawset(_G, 'test_data', string.rep('a', 1000))
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+    if cg.replica then
+        cg.replica:drop()
+    end
+end)
+
+g.test_cancel_before_waiting_for_limbo_space = function(cg)
+    cg.server:exec(function()
+        local s = box.space.test
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+        local f1 = _G.fiber.create(function()
+            _G.fiber.self():set_joinable(true)
+            s:insert{1, _G.test_data}
+        end)
+        local f2 = _G.fiber.create(function()
+            local self = _G.fiber.self()
+            self:set_joinable(true)
+            pcall(self.cancel, self)
+            -- Must fail right away, because the cancellation is checked before
+            -- waiting for the limbo space.
+            s:insert{2, _G.test_data}
+        end)
+        t.helpers.retrying({timeout = _G.test_timeout}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+        end)
+        local ok, err = f2:join()
+        t.assert_not(ok)
+        t.assert_covers(err:unpack(), {name = 'SYNC_ROLLBACK'})
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        t.assert((f1:join()))
+        t.assert(box.space.test:get{1})
+        t.assert_not(box.space.test:get{2})
+        s:truncate()
+    end)
+end
+
+--
+-- gh-11180: joining a new replica needs to create a read-view with all the data
+-- and ensure this read-view only has committed data. There was a bug that the
+-- "waiting for commit of the read-view data" wouldn't notice a rollback of the
+-- latest synchro txn if the latter was waiting for free space in the limbo at
+-- the moment of read-view creation.
+--
+g.test_cascading_rollback_while_waiting_for_limbo_space = function(cg)
+    --
+    -- One txn is waiting inside WAL. Another one is waiting for limbo space.
+    --
+    cg.server:exec(function()
+        local s = box.space.test
+
+        rawset(_G, 'test_is_committed', false)
+        local function make_txn_fiber(id)
+            return _G.fiber.create(function()
+                _G.fiber.self():set_joinable(true)
+                box.begin()
+                box.on_commit(function()
+                    t.assert(not _G.test_is_committed)
+                    _G.test_is_committed = true
+                end)
+                s:insert{id, _G.test_data}
+                box.commit()
+            end)
+        end
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+        rawset(_G, 'test_f1', make_txn_fiber(1))
+        rawset(_G, 'test_f2', make_txn_fiber(2))
+        t.helpers.retrying({timeout = _G.test_timeout}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+        end)
+    end)
+    --
+    -- Replica tries to join and a read-view is created for it.
+    --
+    cg.replica = server:new({
+        box_cfg = {
+            replication = cg.server.net_box_uri,
+            replication_timeout = 0.1,
+            replication_anon = true,
+            read_only = true,
+        }
+    })
+    cg.replica:start({wait_until_ready = false})
+    cg.server:exec(function()
+        t.helpers.retrying({timeout = _G.test_timeout}, function()
+            t.assert_gt(box.info.replication_anon.count, 0)
+        end)
+        --
+        -- The first txn is committed. The second one is stuck in WAL.
+        --
+        t.helpers.retrying({timeout = _G.test_timeout}, function()
+            if _G.test_is_committed then
+                return
+            end
+            -- Allow one WAL entry at a time until txn1 is committed and txn2 is
+            -- not.
+            box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+            box.error.injection.set('ERRINJ_WAL_DELAY', false)
+            t.helpers.retrying({timeout = _G.test_timeout}, function()
+                t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+            end)
+            t.assert_not('retry')
+        end)
+        t.assert((_G.test_f1:join()))
+        --
+        -- Now txn2 fails to get written to WAL and is rolled back.
+        --
+        box.error.injection.set('ERRINJ_WAL_ROTATE', true)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        local ok, err = _G.test_f2:join()
+        t.assert_not(ok)
+        t.assert_covers(err:unpack(), {name = 'WAL_IO'})
+        box.error.injection.set('ERRINJ_WAL_ROTATE', false)
+
+        t.assert(box.space.test:get{1})
+        t.assert_not(box.space.test:get{2})
+    end)
+    --
+    -- The replica's join process must fail due to the rollback, then it gets
+    -- retried, and gets the correct data.
+    --
+    cg.replica:wait_until_ready()
+    cg.replica:exec(function()
+        t.assert(box.space.test:get{1})
+        t.assert_not(box.space.test:get{2})
+    end)
+    --
+    -- The replication continues working.
+    --
+    cg.server:exec(function()
+        -- After WAL "error" the leader steps down.
+        box.ctl.promote()
+        box.ctl.wait_rw()
+        box.space.test:insert{3}
+    end)
+    cg.replica:wait_for_vclock_of(cg.server)
+    cg.replica:exec(function()
+        t.assert(box.space.test:get{3})
+    end)
+    cg.server:exec(function()
+        box.space.test:truncate()
+    end)
+end

--- a/test/replication-luatest/gh_11180_qsync_order_test.lua
+++ b/test/replication-luatest/gh_11180_qsync_order_test.lua
@@ -1,0 +1,305 @@
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new({
+        box_cfg = {
+            replication_synchro_queue_max_size = 1000,
+            wal_queue_max_size = 1000,
+            replication_synchro_timeout = 1000,
+            election_mode = 'manual',
+        }
+    })
+    cg.server:start()
+    cg.server:exec(function()
+        rawset(_G, 'fiber', require('fiber'))
+        rawset(_G, 'test_timeout', 60)
+        rawset(_G, 'test_data', string.rep('a', 1000))
+        box.ctl.promote()
+        box.ctl.wait_rw()
+        local s = box.schema.create_space('test', {is_sync = true})
+        s:create_index('pk')
+        s = box.schema.create_space('test_async')
+        s:create_index('pk')
+
+        rawset(_G, 'join_with_error', function(f, expected_err)
+            local ok, err = f:join()
+            t.assert_not(ok)
+            t.assert_covers(err:unpack(), expected_err)
+        end)
+    end)
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        box.space.test:truncate()
+        box.space.test_async:truncate()
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+--
+-- gh-11180: rollback of a txn waiting for space in the limbo wouldn't cascading
+-- rollback the newer txns.
+--
+g.test_cascading_rollback_while_waiting_for_limbo_space = function(cg)
+    cg.server:exec(function()
+        local s = box.space.test
+        local results = {}
+        local function make_txn_fiber(id)
+            return _G.fiber.create(function()
+                _G.fiber.self():set_joinable(true)
+                box.begin()
+                box.on_rollback(function()
+                    table.insert(results, ('rollback %s'):format(id))
+                end)
+                box.on_commit(function()
+                    table.insert(results, ('commit %s'):format(id))
+                end)
+                s:insert{id, _G.test_data}
+                box.commit()
+            end)
+        end
+        --
+        -- txn1 is stuck in WAL, txn2-5 are waiting for limbo space.
+        --
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+        local f1 = make_txn_fiber(1)
+        local f2 = make_txn_fiber(2)
+        local f3 = make_txn_fiber(3)
+        local f4 = make_txn_fiber(4)
+        local f5 = make_txn_fiber(5)
+        t.helpers.retrying({timeout = _G.test_timeout}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+        end)
+        --
+        -- txn3 is cancelled and rolled back. txn4 and txn5 are cascading rolled
+        -- back. The cancel is done for 2 txns to see what happens when one of
+        -- them is both cancelled AND rolled back cascading.
+        --
+        f3:cancel()
+        f4:cancel()
+        -- Limbo doesn't set the cascading rollback error. No reason why.
+        _G.join_with_error(f3, {name = 'SYNC_ROLLBACK'})
+        _G.join_with_error(f4, {name = 'SYNC_ROLLBACK'})
+        _G.join_with_error(f5, {name = 'SYNC_ROLLBACK'})
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        --
+        -- The older txns were not affected by the rollback of newer txns.
+        --
+        t.assert((f1:join(_G.test_timeout)))
+        t.assert((f2:join(_G.test_timeout)))
+        t.assert_equals(results, {'rollback 5', 'rollback 4', 'rollback 3',
+                                  'commit 1', 'commit 2'})
+        t.assert_equals(s:select(), {{1, _G.test_data}, {2, _G.test_data}})
+    end)
+end
+
+--
+-- One txn is submitted to the limbo and is stuck in WAL. The other txn is
+-- volatile and waits for limbo space. Suddenly there becomes enough space. The
+-- second then should see that it is not the first one, but it is the first
+-- volatile one and hence can proceed to WAL.
+--
+g.test_unblock_nonfirst_volatile_entry = function(cg)
+    cg.server:exec(function()
+        local s = box.space.test
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+        local f1 = _G.fiber.create(function()
+            _G.fiber.self():set_joinable(true)
+            s:insert{1, _G.test_data}
+        end)
+        local f2 = _G.fiber.create(function()
+            _G.fiber.self():set_joinable(true)
+            s:insert{2, _G.test_data}
+        end)
+        t.assert_equals(box.info.synchro.queue.len, 1)
+        local old_size = box.cfg.replication_synchro_queue_max_size
+        box.cfg{replication_synchro_queue_max_size = 1000000}
+        f2:wakeup()
+        t.helpers.retrying({timeout = _G.test_timeout}, function()
+            t.assert_equals(box.info.synchro.queue.len, 2)
+        end)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        t.assert((f1:join()))
+        t.assert((f2:join()))
+        t.assert_equals(s:select(), {{1, _G.test_data}, {2, _G.test_data}})
+        box.cfg{replication_synchro_queue_max_size = old_size}
+    end)
+end
+
+--
+-- One volatile async transaction in the limbo queue after a synchro txn. It is
+-- going to try being added to the limbo, but it won't be.
+--
+g.test_volatile_async_one = function(cg)
+    cg.server:exec(function()
+        local sync = box.space.test
+        local async = box.space.test_async
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+        local f1 = _G.fiber.create(function()
+            _G.fiber.self():set_joinable(true)
+            sync:insert{1, _G.test_data}
+        end)
+        local f2 = _G.fiber.create(function()
+            _G.fiber.self():set_joinable(true)
+            async:insert{1}
+        end)
+        t.assert_equals(box.info.synchro.queue.len, 1)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        t.assert((f1:join()))
+        t.assert((f2:join()))
+        t.assert_equals(sync:select(), {{1, _G.test_data}})
+        t.assert_equals(async:select(), {{1}})
+    end)
+end
+
+--
+-- Same, but multiple async txns in the tail.
+--
+g.test_volatile_async_many = function(cg)
+    cg.server:exec(function()
+        local sync = box.space.test
+        local async = box.space.test_async
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+        local f1 = _G.fiber.create(function()
+            _G.fiber.self():set_joinable(true)
+            sync:insert{1, _G.test_data}
+        end)
+        local f2 = _G.fiber.create(function()
+            _G.fiber.self():set_joinable(true)
+            async:insert{1}
+        end)
+        local f3 = _G.fiber.create(function()
+            _G.fiber.self():set_joinable(true)
+            async:insert{2}
+        end)
+        t.assert_equals(box.info.synchro.queue.len, 1)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        t.assert((f1:join()))
+        t.assert((f2:join()))
+        t.assert((f3:join()))
+        t.assert_equals(sync:select(), {{1, _G.test_data}})
+        t.assert_equals(async:select(), {{1}, {2}})
+    end)
+end
+
+--
+-- The limbo might be not full and yet have volatile entries in the end. The
+-- newly coming entries then should still respect the order.
+--
+g.test_non_full_but_volatile = function(cg)
+    cg.server:exec(function()
+        local sync = box.space.test
+        local async = box.space.test_async
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+        local results = {}
+        local function make_txn_fiber(space, id, on_commit, opts)
+            return _G.fiber.create(function()
+                _G.fiber.self():set_joinable(true)
+                box.begin()
+                box.on_commit(function()
+                    table.insert(results, id)
+                    if on_commit then
+                        on_commit()
+                    end
+                end)
+                space:insert{id, _G.test_data}
+                box.commit(opts)
+            end)
+        end
+        local f3, f4
+        --
+        -- When txn1 gets committed, it is already removed from the limbo, so
+        -- the limbo becomes "not full". But in this case txn2 is volatile and
+        -- is waiting for its space in the limbo. So new entries should line up
+        -- after txn2. Despite the limbo being not full.
+        --
+        local f1 = make_txn_fiber(sync, 1, function()
+            -- Blocking is required, so wait_mode=none is not possible.
+            f3 = make_txn_fiber(async, 3, nil, {wait = 'none'})
+            -- Try the old blocking way.
+            f4 = make_txn_fiber(async, 4)
+        end)
+        t.helpers.retrying({timeout = _G.test_timeout}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+        end)
+        local f2 = make_txn_fiber(sync, 2)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        t.assert((f1:join()))
+        t.assert((f2:join()))
+        _G.join_with_error(f3, {name = 'SYNC_QUEUE_FULL'})
+        t.assert((f4:join()))
+        t.assert_equals(results, {1, 2, 4})
+    end)
+end
+
+--
+-- gh-11180: volatile txns waiting for the limbo space didn't form any queue
+-- and their spurious wakeups could lead to them finishing the commits not in
+-- the same order as the commits were started.
+--
+g.test_spurious_wakeup = function(cg)
+    cg.server:exec(function()
+        local s = box.space.test
+        local f1, f2, f3
+        --
+        -- This fiber gets executed on each event loop iteration, right after
+        -- the scheduler-fiber. It is able then to mess up any plans that the
+        -- next fibers would have about waking each other up in any special
+        -- order.
+        --
+        local wakeuper = _G.fiber.create(function()
+            while true do
+                _G.fiber.testcancel()
+                --
+                -- f2 is supposed to finish before f3, but lets wake them up
+                -- always in the reversed order.
+                --
+                if f3 then
+                    pcall(f3.wakeup, f3)
+                end
+                if f2 then
+                    pcall(f2.wakeup, f2)
+                end
+                _G.fiber.yield()
+            end
+        end)
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+        local results = {}
+        local function make_txn_fiber(id)
+            return _G.fiber.create(function()
+                _G.fiber.self():set_joinable(true)
+                box.begin()
+                box.on_rollback(function()
+                    table.insert(results, ('rollback %s'):format(id))
+                end)
+                box.on_commit(function()
+                    table.insert(results, ('commit %s'):format(id))
+                end)
+                s:insert{id, _G.test_data}
+                box.commit()
+            end)
+        end
+        f1 = make_txn_fiber(1)
+        f2 = make_txn_fiber(2)
+        f3 = make_txn_fiber(3)
+        t.helpers.retrying({timeout = _G.test_timeout}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+        end)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        t.assert((f1:join(_G.test_timeout)))
+        t.assert((f2:join(_G.test_timeout)))
+        t.assert((f3:join(_G.test_timeout)))
+        wakeuper:cancel()
+        t.assert_equals(results, {'commit 1', 'commit 2', 'commit 3'})
+        t.assert_equals(s:select(), {
+            {1, _G.test_data}, {2, _G.test_data}, {3, _G.test_data}
+        })
+    end)
+end

--- a/test/replication-luatest/gh_11180_qsync_volatile_snapshot_test.lua
+++ b/test/replication-luatest/gh_11180_qsync_volatile_snapshot_test.lua
@@ -1,0 +1,60 @@
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new({box_cfg = {
+        replication_synchro_queue_max_size = 1000,
+        replication_synchro_timeout = 1000,
+        election_mode = 'manual',
+    }})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+--
+-- gh-11180: the snapshot creation used to ignore the volatile limbo entries
+-- waiting for the space in the limbo. It could result into some data being
+-- present in the snapshot with an old vclock. And then on restart those entries
+-- would be re-applied from the following xlogs, leading to the operations
+-- applied twice.
+--
+g.test_qsync_volatile_snapshot = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        local data = string.rep('a', 1000)
+        local timeout = 60
+        local s = box.schema.create_space('test', {is_sync = true})
+        s:create_index('pk')
+
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+        local function make_txn_fiber(id)
+            return fiber.create(function()
+                fiber.self():set_joinable(true)
+                s:insert{id, data}
+            end)
+        end
+        local f1 = make_txn_fiber(1)
+        local f2 = make_txn_fiber(2)
+        t.helpers.retrying({timeout = timeout}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+        end)
+        local f_snap = fiber.create(function()
+            fiber.self():set_joinable(true)
+            box.snapshot()
+        end)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        t.assert((f1:join()))
+        t.assert((f2:join()))
+        t.assert((f_snap:join()))
+    end)
+    cg.server:restart()
+    cg.server:exec(function()
+        t.assert(box.space.test:get{1})
+        t.assert(box.space.test:get{2})
+    end)
+end

--- a/test/replication-luatest/gh_6033_box_promote_demote_test.lua
+++ b/test/replication-luatest/gh_6033_box_promote_demote_test.lua
@@ -112,6 +112,7 @@ local function cluster_reinit(g)
         server:exec(function()
             box.ctl.demote()
         end)
+        wait_sync(g.cluster.servers)
     end
 end
 

--- a/test/unit/snap_quorum_delay.cc
+++ b/test/unit/snap_quorum_delay.cc
@@ -106,8 +106,8 @@ txn_process_func(va_list ap)
 	 * Instead, we push the transaction to the limbo manually
 	 * and call txn_commit (or another) later.
 	 */
-	struct txn_limbo_entry *entry = txn_limbo_append(
-		&txn_limbo, instance_id, txn, 0);
+	txn_limbo_submit(&txn_limbo, instance_id, txn, 0);
+	struct txn_limbo_entry *entry = txn->limbo_entry;
 	/*
 	 * The trigger is used to verify that the transaction has been
 	 * completed.


### PR DESCRIPTION
This is a backport of https://github.com/tarantool/tarantool/pull/11605 to branch `release/3.3` to a future `3.3.4` release.