### PR TITLE
[backport 3.2] Spurious Wakeupaloosa: spurious wakups and cascading rollbacks in the limbo and WAL

### DIFF
--- a/changelogs/unreleased/gh-11180-outdated-snapshot.md
+++ b/changelogs/unreleased/gh-11180-outdated-snapshot.md
@@ -1,0 +1,7 @@
+## bugfix/core
+
+* Fixed the creation of broken snapshots, which could contain outdated entries
+  also applied in the following xlog files. This could happen if the
+  transactions would pile up and fill the whole WAL queue
+  (`box.cfg.wal_queue_max_size` was reached), and a snapshot was created at this
+  moment (gh-11180).

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -250,6 +250,7 @@ set(box_sources
     session.c
     port.c
     txn.c
+    txn_checkpoint.c
     txn_limbo.c
     txn_event_trigger.c
     raft.c

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -65,6 +65,7 @@
 #include "index.h"
 #include "port.h"
 #include "txn.h"
+#include "txn_checkpoint.h"
 #include "txn_limbo.h"
 #include "user.h"
 #include "cfg.h"
@@ -3005,7 +3006,7 @@ box_wait_limbo_acked(double timeout)
 	/* Wait for the last entries WAL write. */
 	if (last_entry->lsn < 0) {
 		int64_t tid = last_entry->txn->id;
-		if (journal_sync(NULL) != 0)
+		if (txn_persist_all_prepared(NULL) != 0)
 			return -1;
 		if (box_check_promote_term_intact(promote_term) != 0)
 			return -1;

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -708,7 +708,7 @@ static void
 recovery_journal_create(struct vclock *v)
 {
 	static struct recovery_journal journal;
-	journal_create(&journal.base, recovery_journal_write);
+	journal_create(&journal.base, recovery_journal_write, NULL);
 	journal.vclock = v;
 	journal_set(&journal.base);
 }
@@ -3005,10 +3005,8 @@ box_wait_limbo_acked(double timeout)
 	/* Wait for the last entries WAL write. */
 	if (last_entry->lsn < 0) {
 		int64_t tid = last_entry->txn->id;
-
-		if (wal_sync(NULL) != 0)
+		if (journal_sync(NULL) != 0)
 			return -1;
-
 		if (box_check_promote_term_intact(promote_term) != 0)
 			return -1;
 		if (txn_limbo_is_empty(&txn_limbo))
@@ -5836,7 +5834,7 @@ box_cfg_xc(void)
 	}
 
 	struct journal bootstrap_journal;
-	journal_create(&bootstrap_journal, bootstrap_journal_write);
+	journal_create(&bootstrap_journal, bootstrap_journal_write, NULL);
 	journal_set(&bootstrap_journal);
 	auto bootstrap_journal_guard = make_scoped_guard([] {
 		journal_set(NULL);

--- a/src/box/journal.c
+++ b/src/box/journal.c
@@ -85,8 +85,7 @@ diag_set_journal_res_detailed(const char *file, unsigned line, int64_t res)
 
 struct journal_entry *
 journal_entry_new(size_t n_rows, struct region *region,
-		  journal_write_async_f write_async_cb,
-		  void *complete_data)
+		  journal_on_write_f on_write, void *complete_data)
 {
 	struct journal_entry *entry;
 
@@ -99,9 +98,7 @@ journal_entry_new(size_t n_rows, struct region *region,
 		diag_set(OutOfMemory, size, "region", "struct journal_entry");
 		return NULL;
 	}
-
-	journal_entry_create(entry, n_rows, 0, write_async_cb,
-			     complete_data);
+	journal_entry_create(entry, n_rows, 0, on_write, complete_data);
 	return entry;
 }
 
@@ -176,7 +173,7 @@ journal_queue_wait(struct journal_entry *entry)
 		else
 			req->res = JOURNAL_ENTRY_ERR_CASCADE;
 		req->is_complete = true;
-		req->write_async_cb(req);
+		req->on_write(req);
 	}
 	diag_set(FiberIsCancelled);
 	return -1;
@@ -208,7 +205,7 @@ journal_queue_rollback(void)
 	stailq_foreach_entry(req, &rollback, fifo) {
 		req->res = JOURNAL_ENTRY_ERR_CASCADE;
 		req->is_complete = true;
-		req->write_async_cb(req);
+		req->on_write(req);
 	}
 }
 

--- a/src/box/journal.h
+++ b/src/box/journal.h
@@ -40,10 +40,14 @@ extern "C" {
 #endif /* defined(__cplusplus) */
 
 struct xrow_header;
+struct journal;
 struct journal_entry;
 
 typedef void
 (*journal_on_write_f)(struct journal_entry *entry);
+
+typedef int
+(*journal_submit_f)(struct journal *journal, struct journal_entry *entry);
 
 enum {
 	/** Entry didn't attempt a journal write. */
@@ -177,8 +181,7 @@ extern struct journal_queue journal_queue;
  */
 struct journal {
 	/** Asynchronous write */
-	int (*write_async)(struct journal *journal,
-			   struct journal_entry *entry);
+	journal_submit_f submit;
 };
 
 /** Wake the journal queue up. */
@@ -262,10 +265,10 @@ journal_write_submit(struct journal_entry *entry)
 		return -1;
 	/*
 	 * We cannot account entry after write. If journal is synchronous
-	 * the journal_queue_on_complete() is called in write_async().
+	 * the journal_queue_on_complete() is called in submit().
 	 */
 	journal_queue_on_append(entry);
-	if (current_journal->write_async(current_journal, entry) != 0) {
+	if (current_journal->submit(current_journal, entry) != 0) {
 		journal_queue_on_complete(entry);
 		journal_queue_rollback();
 		return -1;
@@ -312,17 +315,15 @@ journal_set(struct journal *new_journal)
 }
 
 static inline void
-journal_create(struct journal *journal,
-	       int (*write_async)(struct journal *journal,
-				  struct journal_entry *entry))
+journal_create(struct journal *journal, journal_submit_f submit)
 {
-	journal->write_async = write_async;
+	journal->submit = submit;
 }
 
 static inline bool
 journal_is_initialized(struct journal *journal)
 {
-	return journal->write_async != NULL;
+	return journal->submit != NULL;
 }
 
 #if defined(__cplusplus)

--- a/src/box/journal.h
+++ b/src/box/journal.h
@@ -42,12 +42,16 @@ extern "C" {
 struct xrow_header;
 struct journal;
 struct journal_entry;
+struct vclock;
 
 typedef void
 (*journal_on_write_f)(struct journal_entry *entry);
 
 typedef int
 (*journal_submit_f)(struct journal *journal, struct journal_entry *entry);
+
+typedef int
+(*journal_sync_f)(struct journal *journal, struct vclock *out);
 
 enum {
 	/** Entry didn't attempt a journal write. */
@@ -182,6 +186,8 @@ extern struct journal_queue journal_queue;
 struct journal {
 	/** Asynchronous write */
 	journal_submit_f submit;
+	/** Ensure all the currently queued requests are written. */
+	journal_sync_f sync;
 };
 
 /** Wake the journal queue up. */
@@ -192,7 +198,11 @@ journal_queue_wakeup(void);
 int
 journal_queue_wait(struct journal_entry *entry);
 
-/** Flush journal queue. Next wal_sync() will sync flushed requests. */
+/**
+ * Make sure the volatile journal queue is emptied (either sent to WAL or rolled
+ * back). Keep in mind that it doesn't guarantee the success of the flushed
+ * entries.
+ */
 int
 journal_queue_flush(void);
 
@@ -287,6 +297,12 @@ journal_write(struct journal_entry *entry)
 	return 0;
 }
 
+static inline int
+journal_sync(struct vclock *out)
+{
+	return current_journal->sync(current_journal, out);
+}
+
 /**
  * Change the current implementation of the journaling API.
  * Happens during life cycle of an instance:
@@ -315,9 +331,11 @@ journal_set(struct journal *new_journal)
 }
 
 static inline void
-journal_create(struct journal *journal, journal_submit_f submit)
+journal_create(struct journal *journal, journal_submit_f submit,
+	       journal_sync_f sync)
 {
 	journal->submit = submit;
+	journal->sync = sync;
 }
 
 static inline bool

--- a/src/box/lua/ctl.c
+++ b/src/box/lua/ctl.c
@@ -46,7 +46,7 @@
 #include "box/memtx_engine.h"
 #include "box/raft.h"
 #include "box/security.h"
-#include "box/wal.h"
+#include "box/journal.h"
 
 #include "core/event.h"
 
@@ -180,7 +180,7 @@ lbox_ctl_set_iproto_lockdown(struct lua_State *L)
 static int
 lbox_ctl_wal_sync(struct lua_State *L)
 {
-	if (wal_sync(NULL))
+	if (journal_sync(NULL))
 		return luaT_error(L);
 	return 0;
 }

--- a/src/box/lua/info.c
+++ b/src/box/lua/info.c
@@ -724,14 +724,10 @@ lbox_info_synchro(struct lua_State *L)
 	lua_setfield(L, -2, "busy");
 	luaL_pushuint64(L, queue->promote_greatest_term);
 	lua_setfield(L, -2, "term");
-	if (queue->len == 0) {
+	if (queue->len == 0)
 		lua_pushnumber(L, 0);
-	} else {
-		struct txn_limbo_entry *oldest_entry =
-			txn_limbo_first_entry(queue);
-		double now = fiber_clock();
-		lua_pushnumber(L, now - oldest_entry->insertion_time);
-	}
+	else
+		lua_pushnumber(L, txn_limbo_age(queue));
 	lua_setfield(L, -2, "age");
 	lua_pushnumber(L, queue->confirm_lag);
 	lua_setfield(L, -2, "confirm_lag");

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -40,6 +40,7 @@
 #include "info/info.h"
 #include "tuple.h"
 #include "txn.h"
+#include "txn_checkpoint.h"
 #include "memtx_tx.h"
 #include "memtx_tree.h"
 #include "iproto_constants.h"
@@ -1479,37 +1480,21 @@ memtx_engine_join(struct engine *engine, struct engine_join_ctx *arg,
 		(struct memtx_join_ctx *)arg->data[engine->id];
 	ctx->stream = stream;
 
-	struct vclock limbo_vclock;
-	struct raft_request raft_req;
-	struct synchro_request synchro_req;
-	/*
-	 * Sync WAL to make sure that all changes visible from
-	 * the frozen read view are successfully committed and
-	 * obtain corresponding vclock.
-	 *
-	 * This cannot be done in prepare_join, as we should not
-	 * yield between read-view creation. Moreover, wal syncing
-	 * should happen after creation of all engine's read-views.
-	 */
-	if (journal_sync(arg->vclock) != 0)
+	struct txn_checkpoint txn_cp;
+	if (txn_checkpoint_build(&txn_cp) != 0)
 		return -1;
-	/*
-	 * Start sending data only when the latest sync
-	 * transaction is confirmed.
-	 */
-	if (txn_limbo_wait_confirm(&txn_limbo) != 0)
-		return -1;
+	vclock_copy(arg->vclock, &txn_cp.journal_vclock);
+	struct raft_request *raft_checkpoint = &txn_cp.raft_remote_checkpoint;
+	struct synchro_request *synchro_checkpoint = &txn_cp.limbo_checkpoint;
 
-	txn_limbo_checkpoint(&txn_limbo, &synchro_req, &limbo_vclock);
-	box_raft_checkpoint_remote(&raft_req);
 	/* See raft_process_recovery, why these fields are not needed. */
-	raft_req.state = 0;
-	raft_req.vclock = NULL;
+	raft_checkpoint->state = 0;
+	raft_checkpoint->vclock = NULL;
 
 	/* Respond with vclock and JOIN_META. */
 	send_join_header(stream, arg->vclock);
 	if (arg->send_meta) {
-		send_join_meta(stream, &raft_req, &synchro_req);
+		send_join_meta(stream, raft_checkpoint, synchro_checkpoint);
 		struct xrow_header row;
 		/* Mark the beginning of the data stream. */
 		xrow_encode_type(&row, IPROTO_JOIN_SNAPSHOT);

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -62,7 +62,6 @@
 #include "memtx_space_upgrade.h"
 #include "tt_sort.h"
 #include "assoc.h"
-#include "wal.h"
 
 #include <type_traits>
 
@@ -1492,9 +1491,8 @@ memtx_engine_join(struct engine *engine, struct engine_join_ctx *arg,
 	 * yield between read-view creation. Moreover, wal syncing
 	 * should happen after creation of all engine's read-views.
 	 */
-	if (wal_sync(arg->vclock) != 0)
+	if (journal_sync(arg->vclock) != 0)
 		return -1;
-
 	/*
 	 * Start sending data only when the latest sync
 	 * transaction is confirmed.

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -1108,10 +1108,7 @@ txn_add_limbo_entry(struct txn *txn, const struct journal_entry *req)
 	 * instance id in the first row.
 	 */
 	uint32_t origin_id = req->rows[0]->replica_id;
-	txn->limbo_entry = txn_limbo_append(&txn_limbo, origin_id, txn);
-	if (txn->limbo_entry == NULL)
-		return -1;
-	return 0;
+	return txn_limbo_submit(&txn_limbo, origin_id, txn);
 }
 
 static int

--- a/src/box/txn_checkpoint.c
+++ b/src/box/txn_checkpoint.c
@@ -1,0 +1,30 @@
+#include "txn_checkpoint.h"
+#include "txn_limbo.h"
+#include "raft.h"
+#include "txn.h"
+
+int
+txn_checkpoint_build(struct txn_checkpoint *out)
+{
+	struct txn_limbo *limbo = &txn_limbo;
+	/*
+	 * Make sure that all changes at the time of checkpoint start have
+	 * reached WAL and get the vclock collected exactly at that moment.
+	 *
+	 * For async txns the persistence means commit. For sync txns need to
+	 * wait for their confirmation explicitly.
+	 */
+	if (journal_sync(&out->journal_vclock) != 0)
+		return -1;
+	/*
+	 * The synchronous transactions, persisted above, might still be not
+	 * committed. Lets make sure they are, so the checkpoint won't have any
+	 * rolled back data.
+	 */
+	if (txn_limbo_wait_confirm(limbo) != 0)
+		return -1;
+
+	txn_limbo_checkpoint(limbo, &out->limbo_checkpoint, &out->limbo_vclock);
+	box_raft_checkpoint_remote(&out->raft_remote_checkpoint);
+	return 0;
+}

--- a/src/box/txn_checkpoint.c
+++ b/src/box/txn_checkpoint.c
@@ -14,7 +14,7 @@ txn_checkpoint_build(struct txn_checkpoint *out)
 	 * For async txns the persistence means commit. For sync txns need to
 	 * wait for their confirmation explicitly.
 	 */
-	if (journal_sync(&out->journal_vclock) != 0)
+	if (txn_persist_all_prepared(&out->journal_vclock) != 0)
 		return -1;
 	/*
 	 * The synchronous transactions, persisted above, might still be not
@@ -27,4 +27,10 @@ txn_checkpoint_build(struct txn_checkpoint *out)
 	txn_limbo_checkpoint(limbo, &out->limbo_checkpoint, &out->limbo_vclock);
 	box_raft_checkpoint_remote(&out->raft_remote_checkpoint);
 	return 0;
+}
+
+int
+txn_persist_all_prepared(struct vclock *out)
+{
+	return journal_sync(out);
 }

--- a/src/box/txn_checkpoint.h
+++ b/src/box/txn_checkpoint.h
@@ -1,0 +1,43 @@
+#pragma once
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2025, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include "xrow.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+/** Data collected precisely when all the prepared txns are committed. */
+struct txn_checkpoint {
+	/**
+	 * VClock taken when the last known prepared txn was written to WAL. For
+	 * non-synchronous txns it is equal to their commit moment.
+	 */
+	struct vclock journal_vclock;
+	/**
+	 * Full descriptor of the Raft state machine collected exactly when the
+	 * last known synchronous txn was confirmed.
+	 */
+	struct raft_request raft_remote_checkpoint;
+	/**
+	 * Full descriptor of the txn limbo collected exactly when the last
+	 * known synchronous txn was confirmed.
+	 */
+	struct synchro_request limbo_checkpoint;
+	/** VClock of the limbo's state. */
+	struct vclock limbo_vclock;
+};
+
+/**
+ * Wait until all the currently prepared txns are committed and collect all the
+ * global transaction-related data at this exact moment.
+ */
+int
+txn_checkpoint_build(struct txn_checkpoint *out);
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */

--- a/src/box/txn_checkpoint.h
+++ b/src/box/txn_checkpoint.h
@@ -38,6 +38,14 @@ struct txn_checkpoint {
 int
 txn_checkpoint_build(struct txn_checkpoint *out);
 
+/**
+ * Wait until all the prepared txns have been successfully written to the
+ * journal. However there is not guarantee that they are going to be committed.
+ * For synchronous txns just a journal write isn't enough.
+ */
+int
+txn_persist_all_prepared(struct vclock *out);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -187,8 +187,8 @@ txn_limbo_last_synchro_entry(struct txn_limbo *limbo)
 	return NULL;
 }
 
-struct txn_limbo_entry *
-txn_limbo_append(struct txn_limbo *limbo, uint32_t id, struct txn *txn)
+int
+txn_limbo_submit(struct txn_limbo *limbo, uint32_t id, struct txn *txn)
 {
 	assert(txn_has_flag(txn, TXN_WAIT_SYNC));
 	assert(limbo == &txn_limbo);
@@ -209,13 +209,13 @@ txn_limbo_append(struct txn_limbo *limbo, uint32_t id, struct txn *txn)
 		 * it should be done right now. See in the limbo comments why.
 		 */
 		diag_set(ClientError, ER_SYNC_ROLLBACK);
-		return NULL;
+		return -1;
 	}
 	if (id == 0)
 		id = instance_id;
 	if  (limbo->owner_id == REPLICA_ID_NIL) {
 		diag_set(ClientError, ER_SYNC_QUEUE_UNCLAIMED);
-		return NULL;
+		return -1;
 	} else if (limbo->owner_id != id && !txn_is_fully_local(txn)) {
 		if (txn_limbo_is_empty(limbo)) {
 			diag_set(ClientError, ER_SYNC_QUEUE_FOREIGN,
@@ -224,7 +224,7 @@ txn_limbo_append(struct txn_limbo *limbo, uint32_t id, struct txn *txn)
 			diag_set(ClientError, ER_UNCOMMITTED_FOREIGN_SYNC_TXNS,
 				 limbo->owner_id);
 		}
-		return NULL;
+		return -1;
 	}
 	size_t size;
 	struct txn_limbo_entry *e = region_alloc_object(&txn->region,
@@ -236,15 +236,16 @@ txn_limbo_append(struct txn_limbo *limbo, uint32_t id, struct txn *txn)
 	}
 	if (e == NULL) {
 		diag_set(OutOfMemory, size, "region_alloc_object", "e");
-		return NULL;
+		return -1;
 	}
 	e->txn = txn;
 	e->lsn = -1;
 	e->state = TXN_LIMBO_ENTRY_SUBMITTED;
 	e->insertion_time = fiber_clock();
+	txn->limbo_entry = e;
 	rlist_add_tail_entry(&limbo->queue, e, in_queue);
 	limbo->len++;
-	return e;
+	return 0;
 }
 
 void
@@ -504,6 +505,7 @@ txn_limbo_read_confirm(struct txn_limbo *limbo, int64_t lsn)
 			 * CONFIRM was being written to WAL.
 			 */
 			assert(e->txn->status == TXN_PREPARED);
+			assert(e->state == TXN_LIMBO_ENTRY_SUBMITTED);
 			/*
 			 * Let it complete normally as a plain transaction. It
 			 * is important to remove the limbo entry, because the

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -174,8 +174,7 @@ txn_limbo_append(struct txn_limbo *limbo, uint32_t id, struct txn *txn)
 	}
 	e->txn = txn;
 	e->lsn = -1;
-	e->is_commit = false;
-	e->is_rollback = false;
+	e->state = TXN_LIMBO_ENTRY_SUBMITTED;
 	e->insertion_time = fiber_clock();
 	rlist_add_tail_entry(&limbo->queue, e, in_queue);
 	limbo->len++;
@@ -196,7 +195,7 @@ txn_limbo_pop(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
 {
 	assert(!rlist_empty(&entry->in_queue));
 	assert(txn_limbo_last_entry(limbo) == entry);
-	assert(entry->is_rollback);
+	assert(entry->state == TXN_LIMBO_ENTRY_ROLLBACK);
 
 	rlist_del_entry(entry, in_queue);
 	limbo->len--;
@@ -206,7 +205,8 @@ txn_limbo_pop(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
 void
 txn_limbo_abort(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
 {
-	entry->is_rollback = true;
+	assert(entry->state == TXN_LIMBO_ENTRY_SUBMITTED);
+	entry->state = TXN_LIMBO_ENTRY_ROLLBACK;
 	if (entry == limbo->entry_to_confirm)
 		limbo->entry_to_confirm = NULL;
 	/*
@@ -351,7 +351,7 @@ complete:
 	 * The first tx to be rolled back already performed all
 	 * the necessary cleanups for us.
 	 */
-	if (entry->is_rollback) {
+	if (entry->state == TXN_LIMBO_ENTRY_ROLLBACK) {
 		diag_set(ClientError, ER_SYNC_ROLLBACK);
 		return -1;
 	}
@@ -480,7 +480,8 @@ txn_limbo_read_confirm(struct txn_limbo *limbo, int64_t lsn)
 			e->txn = NULL;
 			continue;
 		}
-		e->is_commit = true;
+		assert(e->state == TXN_LIMBO_ENTRY_SUBMITTED);
+		e->state = TXN_LIMBO_ENTRY_COMMIT;
 		if (txn_has_flag(e->txn, TXN_WAIT_ACK))
 			limbo->confirm_lag = fiber_clock() - e->insertion_time;
 		e->txn->limbo_entry = NULL;

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -86,7 +86,7 @@ txn_limbo_pop_first(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
 	limbo->len--;
 }
 
-void
+static void
 txn_limbo_complete(struct txn *txn, bool is_success)
 {
 	/*
@@ -118,6 +118,40 @@ txn_limbo_complete(struct txn *txn, bool is_success)
 	fiber_set_txn(fiber(), NULL);
 	fiber_set_user(fiber(), orig_creds);
 	fiber_set_session(fiber(), orig_session);
+}
+
+/** Complete the given limbo entry with a failure and the given reason. */
+static void
+txn_limbo_complete_fail(struct txn_limbo *limbo, struct txn_limbo_entry *entry,
+			int64_t signature)
+{
+	assert(entry->state == TXN_LIMBO_ENTRY_SUBMITTED);
+	struct txn *txn = entry->txn;
+	txn->signature = signature;
+	txn->limbo_entry = NULL;
+	txn_limbo_abort(limbo, entry);
+	txn_clear_flags(txn, TXN_WAIT_SYNC | TXN_WAIT_ACK);
+	txn_limbo_complete(txn, false);
+}
+
+/** Complete the given limbo entry with a success. */
+static void
+txn_limbo_complete_success(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
+{
+	assert(entry->state == TXN_LIMBO_ENTRY_SUBMITTED);
+	struct txn *txn = entry->txn;
+	entry->state = TXN_LIMBO_ENTRY_COMMIT;
+	if (txn_has_flag(txn, TXN_WAIT_ACK))
+		limbo->confirm_lag = fiber_clock() - entry->insertion_time;
+	txn->limbo_entry = NULL;
+	txn_limbo_pop_first(limbo, entry);
+	txn_clear_flags(txn, TXN_WAIT_SYNC | TXN_WAIT_ACK);
+	/*
+	 * Should be written to WAL by now. Confirm is always written after the
+	 * affected transactions.
+	 */
+	assert(txn->signature >= 0);
+	txn_limbo_complete(txn, true);
 }
 
 struct txn_limbo_entry *
@@ -315,11 +349,7 @@ txn_limbo_wait_complete(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
 	struct txn_limbo_entry *e, *tmp;
 	rlist_foreach_entry_safe_reverse(e, &limbo->queue,
 					 in_queue, tmp) {
-		e->txn->signature = TXN_SIGNATURE_QUORUM_TIMEOUT;
-		e->txn->limbo_entry = NULL;
-		txn_limbo_abort(limbo, e);
-		txn_clear_flags(e->txn, TXN_WAIT_SYNC | TXN_WAIT_ACK);
-		txn_limbo_complete(e->txn, false);
+		txn_limbo_complete_fail(limbo, e, TXN_SIGNATURE_QUORUM_TIMEOUT);
 		if (e == entry)
 			break;
 		fiber_wakeup(e->txn->fiber);
@@ -473,19 +503,7 @@ txn_limbo_read_confirm(struct txn_limbo *limbo, int64_t lsn)
 			e->txn = NULL;
 			continue;
 		}
-		assert(e->state == TXN_LIMBO_ENTRY_SUBMITTED);
-		e->state = TXN_LIMBO_ENTRY_COMMIT;
-		if (txn_has_flag(e->txn, TXN_WAIT_ACK))
-			limbo->confirm_lag = fiber_clock() - e->insertion_time;
-		e->txn->limbo_entry = NULL;
-		txn_limbo_pop_first(limbo, e);
-		txn_clear_flags(e->txn, TXN_WAIT_SYNC | TXN_WAIT_ACK);
-		/*
-		 * Should be written to WAL by now. Confirm is always written
-		 * after the affected transactions.
-		 */
-		assert(e->txn->signature >= 0);
-		txn_limbo_complete(e->txn, true);
+		txn_limbo_complete_success(limbo, e);
 	}
 	/*
 	 * Track CONFIRM lsn on replica in order to detect split-brain by
@@ -531,16 +549,12 @@ txn_limbo_read_rollback(struct txn_limbo *limbo, int64_t lsn)
 	if (last_rollback == NULL)
 		return;
 	rlist_foreach_entry_safe_reverse(e, &limbo->queue, in_queue, tmp) {
-		txn_limbo_abort(limbo, e);
-		txn_clear_flags(e->txn, TXN_WAIT_ACK);
 		/*
 		 * Should be written to WAL by now. Rollback is always written
 		 * after the affected transactions.
 		 */
 		assert(e->txn->signature >= 0);
-		e->txn->signature = TXN_SIGNATURE_SYNC_ROLLBACK;
-		e->txn->limbo_entry = NULL;
-		txn_limbo_complete(e->txn, false);
+		txn_limbo_complete_fail(limbo, e, TXN_SIGNATURE_SYNC_ROLLBACK);
 		if (e == last_rollback)
 			break;
 	}

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -76,6 +76,16 @@ txn_limbo_is_ro(struct txn_limbo *limbo)
 	       (limbo->owner_id != instance_id || txn_limbo_is_frozen(limbo));
 }
 
+/** Pop the first entry. */
+static inline void
+txn_limbo_pop_first(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
+{
+	assert(!rlist_empty(&entry->in_queue));
+	assert(txn_limbo_first_entry(limbo) == entry);
+	rlist_del_entry(entry, in_queue);
+	limbo->len--;
+}
+
 void
 txn_limbo_complete(struct txn *txn, bool is_success)
 {
@@ -179,15 +189,6 @@ txn_limbo_append(struct txn_limbo *limbo, uint32_t id, struct txn *txn)
 	rlist_add_tail_entry(&limbo->queue, e, in_queue);
 	limbo->len++;
 	return e;
-}
-
-static inline void
-txn_limbo_pop_first(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
-{
-	assert(!rlist_empty(&entry->in_queue));
-	assert(txn_limbo_first_entry(limbo) == entry);
-	rlist_del_entry(entry, in_queue);
-	limbo->len--;
 }
 
 void

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -182,7 +182,7 @@ txn_limbo_append(struct txn_limbo *limbo, uint32_t id, struct txn *txn)
 }
 
 static inline void
-txn_limbo_remove(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
+txn_limbo_pop_first(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
 {
 	assert(!rlist_empty(&entry->in_queue));
 	assert(txn_limbo_first_entry(limbo) == entry);
@@ -190,32 +190,24 @@ txn_limbo_remove(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
 	limbo->len--;
 }
 
-static inline void
-txn_limbo_pop(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
-{
-	assert(!rlist_empty(&entry->in_queue));
-	assert(txn_limbo_last_entry(limbo) == entry);
-	assert(entry->state == TXN_LIMBO_ENTRY_ROLLBACK);
-
-	rlist_del_entry(entry, in_queue);
-	limbo->len--;
-	++limbo->rollback_count;
-}
-
 void
 txn_limbo_abort(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
 {
 	assert(entry->state == TXN_LIMBO_ENTRY_SUBMITTED);
-	entry->state = TXN_LIMBO_ENTRY_ROLLBACK;
-	if (entry == limbo->entry_to_confirm)
-		limbo->entry_to_confirm = NULL;
+	assert(!rlist_empty(&entry->in_queue));
 	/*
 	 * The simple rule about rollback/commit order applies
 	 * here as well: commit always in the order of WAL write,
 	 * rollback in the reversed order. Rolled back transaction
 	 * is always the last.
 	 */
-	txn_limbo_pop(limbo, entry);
+	assert(txn_limbo_last_entry(limbo) == entry);
+	entry->state = TXN_LIMBO_ENTRY_ROLLBACK;
+	if (entry == limbo->entry_to_confirm)
+		limbo->entry_to_confirm = NULL;
+	rlist_del_entry(entry, in_queue);
+	limbo->len--;
+	++limbo->rollback_count;
 }
 
 void
@@ -469,7 +461,7 @@ txn_limbo_read_confirm(struct txn_limbo *limbo, int64_t lsn)
 			 * created in the applier.
 			 */
 			txn_clear_flags(e->txn, TXN_WAIT_SYNC);
-			txn_limbo_remove(limbo, e);
+			txn_limbo_pop_first(limbo, e);
 			/*
 			 * The limbo entry now should not be used by the owner
 			 * transaction since it just became a plain one. Nullify
@@ -485,7 +477,7 @@ txn_limbo_read_confirm(struct txn_limbo *limbo, int64_t lsn)
 		if (txn_has_flag(e->txn, TXN_WAIT_ACK))
 			limbo->confirm_lag = fiber_clock() - e->insertion_time;
 		e->txn->limbo_entry = NULL;
-		txn_limbo_remove(limbo, e);
+		txn_limbo_pop_first(limbo, e);
 		txn_clear_flags(e->txn, TXN_WAIT_SYNC | TXN_WAIT_ACK);
 		/*
 		 * Should be written to WAL by now. Confirm is always written

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -40,6 +40,28 @@
 
 struct txn_limbo txn_limbo;
 
+static inline struct txn_limbo_entry *
+txn_limbo_first_entry(struct txn_limbo *limbo)
+{
+	return rlist_first_entry(&limbo->queue, struct txn_limbo_entry,
+				 in_queue);
+}
+
+static inline struct txn_limbo_entry *
+txn_limbo_last_entry(struct txn_limbo *limbo)
+{
+	return rlist_last_entry(&limbo->queue, struct txn_limbo_entry,
+				in_queue);
+}
+
+double
+txn_limbo_age(struct txn_limbo *limbo)
+{
+	if (txn_limbo_is_empty(limbo))
+		return 0;
+	return fiber_clock() - txn_limbo_first_entry(limbo)->insertion_time;
+}
+
 static inline void
 txn_limbo_create(struct txn_limbo *limbo)
 {

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -259,6 +259,10 @@ struct txn_limbo {
  */
 extern struct txn_limbo txn_limbo;
 
+/** Get the age of the oldest non-confirmed limbo entry. */
+double
+txn_limbo_age(struct txn_limbo *limbo);
+
 static inline bool
 txn_limbo_is_empty(struct txn_limbo *limbo)
 {
@@ -267,20 +271,6 @@ txn_limbo_is_empty(struct txn_limbo *limbo)
 
 bool
 txn_limbo_is_ro(struct txn_limbo *limbo);
-
-static inline struct txn_limbo_entry *
-txn_limbo_first_entry(struct txn_limbo *limbo)
-{
-	return rlist_first_entry(&limbo->queue, struct txn_limbo_entry,
-				 in_queue);
-}
-
-static inline struct txn_limbo_entry *
-txn_limbo_last_entry(struct txn_limbo *limbo)
-{
-	return rlist_last_entry(&limbo->queue, struct txn_limbo_entry,
-				in_queue);
-}
 
 /**
  * Return the latest term as seen in PROMOTE requests from instance with id

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -44,6 +44,15 @@ extern "C" {
 struct txn;
 struct synchro_request;
 
+enum txn_limbo_entry_state {
+	/** Is saved and accounted in the limbo. */
+	TXN_LIMBO_ENTRY_SUBMITTED,
+	/** Committed, not in the limbo anymore. */
+	TXN_LIMBO_ENTRY_COMMIT,
+	/** Rolled back, not in the limbo anymore. */
+	TXN_LIMBO_ENTRY_ROLLBACK,
+};
+
 /**
  * Transaction and its quorum metadata, to be stored in limbo.
  */
@@ -58,13 +67,8 @@ struct txn_limbo_entry {
 	 * written to WAL yet.
 	 */
 	int64_t lsn;
-	/**
-	 * Result flags. Only one of them can be true. But both
-	 * can be false if the transaction is still waiting for
-	 * its resolution.
-	 */
-	bool is_commit;
-	bool is_rollback;
+	/** State of this entry. */
+	enum txn_limbo_entry_state state;
 	/** When this entry was added to the queue. */
 	double insertion_time;
 };
@@ -72,7 +76,7 @@ struct txn_limbo_entry {
 static inline bool
 txn_limbo_entry_is_complete(const struct txn_limbo_entry *e)
 {
-	return e->is_commit || e->is_rollback;
+	return e->state > TXN_LIMBO_ENTRY_SUBMITTED;
 }
 
 /**

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -303,8 +303,8 @@ txn_limbo_last_synchro_entry(struct txn_limbo *limbo);
  * Allocate, create, and append a new transaction to the limbo.
  * The limbo entry is allocated on the transaction's region.
  */
-struct txn_limbo_entry *
-txn_limbo_append(struct txn_limbo *limbo, uint32_t id, struct txn *txn);
+int
+txn_limbo_submit(struct txn_limbo *limbo, uint32_t id, struct txn *txn);
 
 /** Remove the entry from the limbo, mark as rolled back. */
 void

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -1130,7 +1130,7 @@ vinyl_space_check_format(struct space *space, struct tuple_format *format)
 	 */
 	int rc;
 	if (need_wal_sync) {
-		rc = wal_sync(NULL);
+		rc = journal_sync(NULL);
 		if (rc != 0)
 			goto out;
 	}
@@ -4394,7 +4394,7 @@ vinyl_space_build_index(struct space *src_space, struct index *new_index,
 	 */
 	int rc;
 	if (need_wal_sync) {
-		rc = wal_sync(NULL);
+		rc = journal_sync(NULL);
 		if (rc != 0)
 			goto out;
 	}

--- a/src/box/vy_tx.h
+++ b/src/box/vy_tx.h
@@ -324,7 +324,7 @@ vy_tx_manager_destroy_read_view(struct vy_tx_manager *xm,
  *
  * @need_wal_sync is set if at least one transaction can't be
  * aborted, because it has reached WAL. The caller is supposed
- * to call wal_sync() to flush them.
+ * to call journal_sync() to flush them.
  */
 void
 vy_tx_manager_abort_writers_for_ddl(struct vy_tx_manager *xm,

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -746,6 +746,8 @@ wal_begin_checkpoint(struct wal_checkpoint *checkpoint)
 		diag_set(ClientError, ER_CASCADE_ROLLBACK);
 		return -1;
 	}
+	if (journal_queue_flush() != 0)
+		return -1;
 	return cbus_call(&writer->wal_pipe, &writer->tx_prio_pipe,
 			 &checkpoint->base, wal_begin_checkpoint_f);
 }

--- a/src/box/wal.h
+++ b/src/box/wal.h
@@ -211,15 +211,6 @@ wal_clear_watcher(struct wal_watcher *watcher,
 enum wal_mode
 wal_mode(void);
 
-/**
- * Wait until all submitted writes are successfully flushed
- * to disk. Returns 0 on success, -1 if write failed.
- * Corresponding vclock is returned in @a vclock unless it is
- * NULL.
- */
-int
-wal_sync(struct vclock *vclock);
-
 struct wal_checkpoint {
 	struct cbus_call_msg base;
 	/**

--- a/test/box-luatest/gh_11180_wal_volatile_snapshot_test.lua
+++ b/test/box-luatest/gh_11180_wal_volatile_snapshot_test.lua
@@ -1,0 +1,60 @@
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new({box_cfg = {wal_queue_max_size = 1000}})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+--
+-- gh-11180: the snapshot creation used to ignore the volatile journal entries
+-- waiting for the space in the journal queue. It could result into some data
+-- being present in the snapshot with an old vclock. And then on restart those
+-- entries would be re-applied from the following xlogs, leading to the
+-- operations applied twice.
+--
+g.test_wal_queue_rollback_in_flight = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        local data = string.rep('a', 1000)
+        local timeout = 60
+        local s = box.schema.create_space('test')
+        s:create_index('pk')
+
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+        local function make_txn_fiber(id)
+            return fiber.create(function()
+                fiber.self():set_joinable(true)
+                -- Insert will fail if would try to be applied both from the
+                -- snapshot and from the following xlog.
+                s:insert{id, data}
+            end)
+        end
+        -- One txn is in WAL. Another is waiting for space.
+        local f1 = make_txn_fiber(1)
+        local f2 = make_txn_fiber(2)
+        t.helpers.retrying({timeout = timeout}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+        end)
+        -- The snapshot must wait until all the journal entries are flushed.
+        local f_snap = fiber.create(function()
+            fiber.self():set_joinable(true)
+            box.snapshot()
+        end)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        t.assert((f1:join()))
+        t.assert((f2:join()))
+        t.assert((f_snap:join()))
+    end)
+    cg.server:restart()
+    cg.server:exec(function()
+        t.assert(box.space.test:get{1})
+        t.assert(box.space.test:get{2})
+    end)
+end

--- a/test/replication-luatest/gh_6033_box_promote_demote_test.lua
+++ b/test/replication-luatest/gh_6033_box_promote_demote_test.lua
@@ -112,6 +112,7 @@ local function cluster_reinit(g)
         server:exec(function()
             box.ctl.demote()
         end)
+        wait_sync(g.cluster.servers)
     end
 end
 

--- a/test/unit/snap_quorum_delay.cc
+++ b/test/unit/snap_quorum_delay.cc
@@ -106,8 +106,8 @@ txn_process_func(va_list ap)
 	 * Instead, we push the transaction to the limbo manually
 	 * and call txn_commit (or another) later.
 	 */
-	struct txn_limbo_entry *entry = txn_limbo_append(&txn_limbo,
-							 instance_id, txn);
+	txn_limbo_submit(&txn_limbo, instance_id, txn);
+	struct txn_limbo_entry *entry = txn->limbo_entry;
 	/*
 	 * The trigger is used to verify that the transaction has been
 	 * completed.


### PR DESCRIPTION
Backport of #11605 to 3.2.