### PR TITLE
box: don't use txns on snapshot recovery if possible

### DIFF
--- a/src/box/memtx_space.h
+++ b/src/box/memtx_space.h
@@ -90,6 +90,14 @@ int
 memtx_space_replace_all_keys(struct space *, struct tuple *, struct tuple *,
 			     enum dup_replace_mode, struct tuple **);
 
+/**
+ * Recover snapshot row.
+ *
+ * Does not support force recovery.
+ */
+int
+memtx_space_recover_snapshot_row(struct space *space, struct request *request);
+
 struct space *
 memtx_space_new(struct memtx_engine *memtx,
 		struct space_def *def, struct rlist *key_list);

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -1545,6 +1545,12 @@ space_events_enable(bool value)
 	space_events_enabled = value;
 }
 
+bool
+space_events_are_enabled(void)
+{
+	return space_events_enabled;
+}
+
 /* {{{ Virtual method stubs */
 
 size_t

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -770,6 +770,10 @@ space_cleanup_constraints(struct space *space);
 void
 space_events_enable(bool value);
 
+/** Whether space events are enabled. */
+bool
+space_events_are_enabled(void);
+
 /*
  * Virtual method stubs.
  */

--- a/src/box/txn_event_trigger.c
+++ b/src/box/txn_event_trigger.c
@@ -402,3 +402,9 @@ txn_events_enable(bool value)
 {
 	txn_events_enabled = value;
 }
+
+bool
+txn_events_are_enabled(void)
+{
+	return txn_events_enabled;
+}

--- a/src/box/txn_event_trigger.h
+++ b/src/box/txn_event_trigger.h
@@ -99,6 +99,10 @@ txn_event_on_rollback_to_svp_run_triggers(struct txn *txn,
 void
 txn_events_enable(bool value);
 
+/** Whether txn events are enabled. */
+bool
+txn_events_are_enabled(void);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/test/box-luatest/gh_11452_no_txns_on_snapshot_recovery_test.lua
+++ b/test/box-luatest/gh_11452_no_txns_on_snapshot_recovery_test.lua
@@ -1,0 +1,54 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group('main', t.helpers.matrix({
+    force_recovery = {false, true},
+    memtx_use_mvcc_engine = {false, true},
+    memtx_use_sort_data = {false, true},
+}))
+
+local disable_triggers = [[
+    local compat = require('compat')
+    compat.box_recovery_triggers_deprecation = 'new'
+]]
+
+g.before_all(function(cg)
+    cg.server = server:new({
+        box_cfg = {
+            memtx_use_sort_data = true,
+        },
+    })
+    cg.server:start()
+    cg.server:exec(function()
+        local s = box.schema.create_space('test')
+        s:create_index('pk')
+        s:create_index('sk', {parts = {{2, 'unsigned'}}})
+        box.begin()
+        for i = 1, 1000 do
+            s:insert({i, 1000 + i})
+        end
+        box.commit()
+        box.snapshot()
+    end)
+end)
+
+g.after_all(function(cg)
+    if cg.server ~= nil then
+        cg.server:drop()
+        cg.server = nil
+    end
+end)
+
+g.test_snapshot_recovery_without_txns = function(cg)
+    cg.server:restart({
+        env = {TARANTOOL_RUN_BEFORE_BOX_CFG = disable_triggers},
+        box_cfg = {
+            force_recovery = cg.params.force_recovery,
+            memtx_use_mvcc_engine = cg.params.memtx_use_mvcc_engine,
+            memtx_use_sort_data = cg.params.memtx_use_sort_data,
+        },
+    })
+    cg.server:exec(function()
+        t.assert_equals(box.space.test:count(), 1000)
+    end)
+end


### PR DESCRIPTION
We don't basically need transactions when recovering from snapshot, except for when recovering system spaces. Another exception is client recovery triggers. So let's avoid using transactions if recovery triggers are disabled. This gives a significant performance improvement.

Part of #11452

**Performance test results**

Recovery performance is evaluated using below perf test setup with compat option `'old'` or `'new'`. The test does not work with `1.10.5` so it was manually patched to remove non existing options and modules.

```
tarantool perf/lua/recovery.lua \
	  --row_count 10000000 --column_count 10 --recovery_count 5 \
	  --preload_script "require('compat').box_recovery_triggers_deprecation = 'new'"
```
```
 Run                | Perf, krps |
---------------------------------|
master triggers on  |    710     |
---------------------------------|
master trigger off  |    1060    |
---------------------------------|
1.10.5              |    1315    |
```

So 1.10.5 is 85% faster then current master with triggers. Disabling triggers give master 49% boost, so that `1.10.5` is only 24% faster then master.