### PR TITLE
test: bump luatest to new version

### DIFF
--- a/.github/actions/install-deps-debian/action.yml
+++ b/.github/actions/install-deps-debian/action.yml
@@ -28,7 +28,7 @@ runs:
           libtool \
           util-linux \
           tt
-        tt rocks install luatest 1.2.0
+        tt rocks install luatest 1.2.1
         tt rocks install luacheck 0.26.0
         gem install coveralls-lcov
       shell: bash


### PR DESCRIPTION
Bump to version 1.2.1.

NO_DOC=test
NO_CHANGELOG=test
NO_TEST=luatest bump

This update is needed because of a bug in `Server:grep_log()`, because of which setting the `reset` option was not possible see https://github.com/tarantool/luatest/pull/428 for details. This fix is mandatory for test in https://github.com/tarantool/tarantool-ee/pull/1449 to function correctly.