### PR TITLE
Limbo confirmed LSN race

### DIFF
--- a/changelogs/unreleased/gh-10853-async-commit-async-tx-after-sync-tx-synchro-timeout-crash.md
+++ b/changelogs/unreleased/gh-10853-async-commit-async-tx-after-sync-tx-synchro-timeout-crash.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed the crash caused by asynchronously committing an asynchronous
+  transaction following a synchronous timed out transaction (gh-10853).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -6433,6 +6433,8 @@ box_shutdown(void)
 void
 box_free(void)
 {
+	/* References engine tuples. */
+	txn_limbo_free();
 	box_storage_free();
 	builtin_events_free();
 	security_free();

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -6394,6 +6394,7 @@ box_storage_shutdown()
 	}
 	replication_shutdown();
 	box_raft_shutdown();
+	txn_limbo_shutdown();
 	gc_shutdown();
 	engine_shutdown();
 	fiber_pool_shutdown(&tx_fiber_pool);

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -459,7 +459,7 @@ box_check_writable(void)
 			error_set_uuid(e, "queue_owner_uuid", &r->uuid);
 			error_append_msg(e, " (%s)", tt_uuid_str(&r->uuid));
 		}
-		if (txn_limbo.owner_id == instance_id) {
+		if (txn_limbo_is_owned_by_current_instance(&txn_limbo)) {
 			if (txn_limbo.is_frozen_due_to_fencing) {
 				error_append_msg(e, " and is frozen due to "
 						    "fencing");
@@ -3170,7 +3170,7 @@ box_promote(void)
 	 */
 	bool is_leader =
 		txn_limbo_replica_term(&txn_limbo, instance_id) == raft->term &&
-		txn_limbo.owner_id == instance_id &&
+		txn_limbo_is_owned_by_current_instance(&txn_limbo) &&
 		!txn_limbo.is_frozen_until_promotion;
 	if (box_election_mode != ELECTION_MODE_OFF)
 		is_leader = is_leader && raft->state == RAFT_STATE_LEADER;
@@ -3224,7 +3224,7 @@ box_demote(void)
 		if (txn_limbo_replica_term(&txn_limbo, instance_id) !=
 		    raft->term)
 			return 0;
-		if (txn_limbo.owner_id != instance_id)
+		if (!txn_limbo_is_owned_by_current_instance(&txn_limbo))
 			return 0;
 		box_raft_leader_step_off();
 		return 0;
@@ -3244,7 +3244,7 @@ box_demote(void)
 	 * local promote(), or call demote() on the actual owner.
 	 */
 	if (txn_limbo.promote_greatest_term == raft->term &&
-	    txn_limbo.owner_id != instance_id)
+	    !txn_limbo_is_owned_by_current_instance(&txn_limbo))
 		return 0;
 	if (box_trigger_elections() != 0)
 		return -1;

--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -608,7 +608,7 @@ tx_status_update(struct cmsg *msg)
 	 * the single master in 100% so far). Other instances wait
 	 * for master's CONFIRM message instead.
 	 */
-	if (txn_limbo.owner_id == instance_id && !anon) {
+	if (txn_limbo_is_owned_by_current_instance(&txn_limbo) && !anon) {
 		txn_limbo_ack(&txn_limbo, ack.source,
 			      vclock_get(ack.vclock, instance_id));
 	}

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -457,10 +457,7 @@ txn_new(void)
 	return txn;
 }
 
-/*
- * Free txn memory and return it to a cache.
- */
-inline static void
+void
 txn_free(struct txn *txn)
 {
 	assert(txn->limbo_entry == NULL);

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -900,6 +900,10 @@ txn_on_journal_write(struct journal_entry *entry)
 		txn_limbo_assign_lsn(&txn_limbo, txn->limbo_entry, lsn);
 		if (txn->fiber != NULL)
 			fiber_wakeup(txn->fiber);
+		if (txn_limbo_is_owned_by_current_instance(&txn_limbo) &&
+		    txn_has_flag(txn, TXN_WAIT_ACK))
+			txn_limbo_ack(&txn_limbo, txn_limbo.owner_id,
+				      txn->limbo_entry->lsn);
 	}
 finish:
 	fiber_set_txn(fiber(), NULL);
@@ -1178,15 +1182,6 @@ txn_commit_impl(struct txn *txn, enum txn_commit_wait_mode wait_mode)
 	if (txn_has_flag(txn, TXN_WAIT_SYNC)) {
 		struct txn_limbo_entry *limbo_entry = txn->limbo_entry;
 		assert(limbo_entry->lsn > 0);
-		/*
-		 * XXX: ACK should be done on WAL write too. But it can make
-		 * another WAL write. Can't be done until it works
-		 * asynchronously.
-		 */
-		if (txn_has_flag(txn, TXN_WAIT_ACK)) {
-			txn_limbo_ack(&txn_limbo, txn_limbo.owner_id,
-				      limbo_entry->lsn);
-		}
 		int rc = txn_limbo_wait_complete(&txn_limbo, limbo_entry);
 		if (rc < 0) {
 			if (fiber_is_cancelled()) {

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -1040,6 +1040,12 @@ tx_region_acquire(struct txn *txn);
 void
 tx_region_release(struct txn *txn, enum tx_alloc_type alloc_type);
 
+/*
+ * Free txn memory and return it to a cache.
+ */
+void
+txn_free(struct txn *txn);
+
 /**
  * FFI bindings: do not throw exceptions, do not accept extra
  * arguments

--- a/src/box/txn_checkpoint.c
+++ b/src/box/txn_checkpoint.c
@@ -3,10 +3,84 @@
 #include "raft.h"
 #include "txn.h"
 
+/** Data of the in-progress checkpoint to carry into the triggers. */
+struct txn_checkpoint_context {
+	/** The checkpoint to be created. */
+	struct txn_checkpoint *checkpoint;
+	/** The owner fiber sleeping on the result. */
+	struct fiber *owner;
+	/** If is committed. */
+	bool is_commit;
+	/** If is rolled back. */
+	bool is_rollback;
+};
+
+static void
+txn_checkpoint_collect(struct txn_checkpoint *c)
+{
+	txn_limbo_checkpoint(&txn_limbo, &c->limbo_checkpoint,
+			     &c->limbo_vclock);
+	box_raft_checkpoint_remote(&c->raft_remote_checkpoint);
+}
+
+/** On commit of the limbo txn. */
+static int
+txn_commit_cb(struct trigger *trigger, void *event)
+{
+	(void)event;
+	struct txn_checkpoint_context *ctx = trigger->data;
+	ctx->is_commit = true;
+	txn_checkpoint_collect(ctx->checkpoint);
+	fiber_wakeup(ctx->owner);
+	return 0;
+}
+
+/** On rollback of the limbo txn. */
+static int
+txn_rollback_cb(struct trigger *trigger, void *event)
+{
+	(void)event;
+	struct txn_checkpoint_context *ctx = trigger->data;
+	ctx->is_rollback = true;
+	fiber_wakeup(ctx->owner);
+	return 0;
+}
+
 int
 txn_checkpoint_build(struct txn_checkpoint *out)
 {
 	struct txn_limbo *limbo = &txn_limbo;
+	/* Fast path. */
+	if (txn_limbo_is_empty(limbo)) {
+		txn_checkpoint_collect(out);
+		return txn_persist_all_prepared(&out->journal_vclock);
+	}
+	/*
+	 * Slow path. When the limbo is not empty, it is relatively complicated
+	 * to create a checkpoint of it. Because while waiting for the journal
+	 * sync, it might receive new volatile txns. And then it becomes too
+	 * late to "wait for last synchro txn to get committed". Because the
+	 * last synchro txn has changed.
+	 *
+	 * The only possible way is to remember what was the last txn before
+	 * doing any waiting. And then collect the checkpoint **exactly** when
+	 * the last txn gets committed. Doing it even one fiber yield later
+	 * might result into more synchro txns getting confirmed and moving the
+	 * limbo state forward. Making the collected checkpoint "too new".
+	 */
+	struct txn_checkpoint_context ctx = {
+		.checkpoint = out,
+		.owner = fiber(),
+		.is_commit = false,
+		.is_rollback = false,
+	};
+	struct trigger on_commit;
+	trigger_create(&on_commit, txn_commit_cb, &ctx, NULL);
+	struct trigger on_rollback;
+	trigger_create(&on_rollback, txn_rollback_cb, &ctx, NULL);
+	struct txn_limbo_entry *tle = txn_limbo_last_synchro_entry(limbo);
+	txn_on_commit(tle->txn, &on_commit);
+	txn_on_rollback(tle->txn, &on_rollback);
 	/*
 	 * Make sure that all changes at the time of checkpoint start have
 	 * reached WAL and get the vclock collected exactly at that moment.
@@ -21,11 +95,19 @@ txn_checkpoint_build(struct txn_checkpoint *out)
 	 * committed. Lets make sure they are, so the checkpoint won't have any
 	 * rolled back data.
 	 */
-	if (txn_limbo_wait_confirm(limbo) != 0)
+	while (!ctx.is_rollback && !ctx.is_commit) {
+		if (fiber_is_cancelled()) {
+			trigger_clear(&on_commit);
+			trigger_clear(&on_rollback);
+			diag_set(FiberIsCancelled);
+			return -1;
+		}
+		fiber_yield();
+	}
+	if (ctx.is_rollback) {
+		diag_set(ClientError, ER_SYNC_ROLLBACK);
 		return -1;
-
-	txn_limbo_checkpoint(limbo, &out->limbo_checkpoint, &out->limbo_vclock);
-	box_raft_checkpoint_remote(&out->raft_remote_checkpoint);
+	}
 	return 0;
 }
 

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -37,6 +37,7 @@
 #include "raft.h"
 #include "tt_static.h"
 #include "session.h"
+#include "trivia/config.h"
 
 struct txn_limbo txn_limbo;
 
@@ -62,6 +63,75 @@ txn_limbo_age(struct txn_limbo *limbo)
 	return fiber_clock() - txn_limbo_first_entry(limbo)->insertion_time;
 }
 
+/** Create a request for a specific limbo and write it to WAL. */
+static int
+txn_limbo_write_synchro(struct txn_limbo *limbo, uint16_t type, int64_t lsn,
+			uint64_t term, struct vclock *vclock);
+
+/** Confirm all the entries <= @a lsn. */
+static void
+txn_limbo_read_confirm(struct txn_limbo *limbo, int64_t lsn);
+
+/**
+ * Write a confirmation entry to the WAL. After it's written all the
+ * transactions waiting for confirmation may be finished.
+ */
+static int
+txn_limbo_write_confirm(struct txn_limbo *limbo, int64_t lsn)
+{
+	assert(lsn > limbo->confirmed_lsn);
+	assert(!limbo->is_in_rollback);
+	return txn_limbo_write_synchro(limbo, IPROTO_RAFT_CONFIRM, lsn, 0,
+				       NULL);
+}
+
+/**
+ * Bring the persisted confirmed LSN closer to the currently known volatile
+ * confirmed LSN.
+ */
+static int
+txn_limbo_worker_bump_confirmed_lsn(struct txn_limbo *limbo)
+{
+	assert(limbo->volatile_confirmed_lsn >= limbo->confirmed_lsn);
+	while (txn_limbo_is_owned_by_current_instance(limbo) &&
+	       limbo->volatile_confirmed_lsn > limbo->confirmed_lsn) {
+		if (limbo->is_in_rollback)
+			return -1;
+		/* It can get bumped again while we are writing. */
+		int64_t volatile_confirmed_lsn = limbo->volatile_confirmed_lsn;
+		if (txn_limbo_write_confirm(limbo,
+					    volatile_confirmed_lsn) != 0) {
+			diag_log();
+			return -1;
+		}
+		ERROR_INJECT_YIELD(ERRINJ_TXN_LIMBO_WORKER_DELAY);
+		txn_limbo_read_confirm(limbo, volatile_confirmed_lsn);
+	}
+	assert(limbo->volatile_confirmed_lsn >= limbo->confirmed_lsn);
+	return 0;
+}
+
+static int
+txn_limbo_worker_f(va_list args)
+{
+	(void)args;
+	struct txn_limbo *limbo = fiber()->f_arg;
+	assert(limbo == &txn_limbo);
+	while (!fiber_is_cancelled()) {
+		fiber_check_gc();
+		ERROR_INJECT_YIELD(ERRINJ_TXN_LIMBO_WORKER_DELAY);
+		if (txn_limbo_worker_bump_confirmed_lsn(limbo) != 0)
+#ifdef TEST_BUILD
+			fiber_sleep(0.01);
+#else
+			fiber_sleep(1);
+#endif
+		else
+			fiber_yield();
+	}
+	return 0;
+}
+
 static inline void
 txn_limbo_create(struct txn_limbo *limbo)
 {
@@ -75,6 +145,7 @@ txn_limbo_create(struct txn_limbo *limbo)
 	limbo->promote_greatest_term = 0;
 	latch_create(&limbo->promote_latch);
 	limbo->confirmed_lsn = 0;
+	limbo->volatile_confirmed_lsn = 0;
 	limbo->entry_to_confirm = NULL;
 	limbo->rollback_count = 0;
 	limbo->is_in_rollback = false;
@@ -83,6 +154,12 @@ txn_limbo_create(struct txn_limbo *limbo)
 	limbo->is_frozen_until_promotion = true;
 	limbo->do_validate = false;
 	limbo->confirm_lag = 0;
+	limbo->worker = fiber_new_system("txn_limbo_worker",
+					 txn_limbo_worker_f);
+	if (limbo->worker == NULL)
+		panic("failed to allocate synchronous queue worker fiber");
+	limbo->worker->f_arg = limbo;
+	fiber_set_joinable(limbo->worker, true);
 }
 
 static inline void
@@ -97,6 +174,13 @@ txn_limbo_destroy(struct txn_limbo *limbo)
 	}
 	fiber_cond_destroy(&limbo->wait_cond);
 	TRASH(limbo);
+}
+
+static inline void
+txn_limbo_stop(struct txn_limbo *limbo)
+{
+	fiber_cancel(limbo->worker);
+	VERIFY(fiber_join(limbo->worker) == 0);
 }
 
 static inline bool
@@ -372,7 +456,7 @@ txn_limbo_wait_complete(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
 
 	/* First in the queue is always a synchronous transaction. */
 	assert(entry->lsn > 0);
-	if (entry->lsn <= limbo->confirmed_lsn) {
+	if (entry->lsn <= limbo->volatile_confirmed_lsn) {
 		/*
 		 * Yes, the wait timed out, but there is an on-going CONFIRM WAL
 		 * write in another fiber covering this LSN. Can't rollback it
@@ -445,6 +529,22 @@ synchro_request_write(const struct synchro_request *req)
 	return journal_write_row(&row);
 }
 
+static int
+txn_limbo_write_synchro(struct txn_limbo *limbo, uint16_t type, int64_t lsn,
+			uint64_t term, struct vclock *vclock)
+{
+	assert(lsn >= 0);
+
+	struct synchro_request req = {
+		.type = type,
+		.replica_id = limbo->owner_id,
+		.lsn = lsn,
+		.term = term,
+		.confirmed_vclock = vclock,
+	};
+	return synchro_request_write(&req);
+}
+
 /** Write a request to WAL or panic. */
 static void
 synchro_request_write_or_panic(const struct synchro_request *req)
@@ -481,21 +581,6 @@ txn_limbo_write_synchro_or_panic(struct txn_limbo *limbo, uint16_t type,
 	synchro_request_write_or_panic(&req);
 }
 
-/**
- * Write a confirmation entry to WAL. After it's written all the
- * transactions waiting for confirmation may be finished.
- */
-static void
-txn_limbo_write_confirm(struct txn_limbo *limbo, int64_t lsn)
-{
-	assert(lsn > limbo->confirmed_lsn);
-	assert(!limbo->is_in_rollback);
-	limbo->confirmed_lsn = lsn;
-	vclock_follow(&limbo->confirmed_vclock, limbo->owner_id, lsn);
-	txn_limbo_write_synchro(limbo, IPROTO_RAFT_CONFIRM, lsn, 0, NULL);
-}
-
-/** Confirm all the entries <= @a lsn. */
 static void
 txn_limbo_read_confirm(struct txn_limbo *limbo, int64_t lsn)
 {
@@ -566,8 +651,9 @@ txn_limbo_read_confirm(struct txn_limbo *limbo, int64_t lsn)
 static void
 txn_limbo_confirm_lsn(struct txn_limbo *limbo, int64_t confirm_lsn)
 {
-	txn_limbo_write_confirm(limbo, confirm_lsn);
-	txn_limbo_read_confirm(limbo, confirm_lsn);
+	assert(confirm_lsn > limbo->volatile_confirmed_lsn);
+	limbo->volatile_confirmed_lsn = confirm_lsn;
+	fiber_wakeup(limbo->worker);
 }
 
 /**
@@ -659,6 +745,7 @@ txn_limbo_read_promote(struct txn_limbo *limbo, uint32_t replica_id,
 	limbo->owner_id = replica_id;
 	limbo->confirmed_lsn = vclock_get(&limbo->confirmed_vclock,
 					  replica_id);
+	limbo->volatile_confirmed_lsn = limbo->confirmed_lsn;
 	limbo->entry_to_confirm = NULL;
 	box_update_ro_summary();
 }
@@ -1232,10 +1319,8 @@ txn_limbo_req_prepare(struct txn_limbo *limbo,
 	case IPROTO_RAFT_PROMOTE:
 	case IPROTO_RAFT_DEMOTE: {
 		assert(limbo->svp_confirmed_lsn == -1);
-		limbo->svp_confirmed_lsn = limbo->confirmed_lsn;
-		limbo->confirmed_lsn = req->lsn;
-		vclock_reset(&limbo->confirmed_vclock, limbo->owner_id,
-			     req->lsn);
+		limbo->svp_confirmed_lsn = limbo->volatile_confirmed_lsn;
+		limbo->volatile_confirmed_lsn = req->lsn;
 		txn_limbo_update_system_spaces_is_sync_state(
 			limbo, req, /*is_rollback=*/false);
 		break;
@@ -1258,9 +1343,7 @@ txn_limbo_req_rollback(struct txn_limbo *limbo,
 	case IPROTO_RAFT_DEMOTE: {
 		assert(limbo->is_in_rollback);
 		assert(limbo->svp_confirmed_lsn >= 0);
-		limbo->confirmed_lsn = limbo->svp_confirmed_lsn;
-		vclock_reset(&limbo->confirmed_vclock, limbo->owner_id,
-			     limbo->svp_confirmed_lsn);
+		limbo->volatile_confirmed_lsn = limbo->svp_confirmed_lsn;
 		limbo->svp_confirmed_lsn = -1;
 		txn_limbo_update_system_spaces_is_sync_state(
 			limbo, req, /*is_rollback=*/true);
@@ -1412,4 +1495,10 @@ void
 txn_limbo_free(void)
 {
 	txn_limbo_destroy(&txn_limbo);
+}
+
+void
+txn_limbo_shutdown(void)
+{
+	txn_limbo_stop(&txn_limbo);
 }

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -555,6 +555,14 @@ txn_limbo_read_confirm(struct txn_limbo *limbo, int64_t lsn)
 	}
 }
 
+/** Confirm an LSN in the limbo. */
+static void
+txn_limbo_confirm_lsn(struct txn_limbo *limbo, int64_t confirm_lsn)
+{
+	txn_limbo_write_confirm(limbo, confirm_lsn);
+	txn_limbo_read_confirm(limbo, confirm_lsn);
+}
+
 /**
  * Write a rollback message to WAL. After it's written all the
  * transactions following the current one and waiting for
@@ -726,8 +734,7 @@ txn_limbo_confirm(struct txn_limbo *limbo)
 		}
 	}
 	assert(max_assigned_lsn != -1);
-	txn_limbo_write_confirm(limbo, max_assigned_lsn);
-	txn_limbo_read_confirm(limbo, max_assigned_lsn);
+	txn_limbo_confirm_lsn(limbo, max_assigned_lsn);
 }
 
 void

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -432,8 +432,7 @@ txn_limbo_checkpoint(const struct txn_limbo *limbo, struct synchro_request *req,
 	req->confirmed_vclock = vclock;
 }
 
-/** Write a request to WAL. */
-static void
+static int
 synchro_request_write(const struct synchro_request *req)
 {
 	/*
@@ -443,7 +442,14 @@ synchro_request_write(const struct synchro_request *req)
 	char body[XROW_BODY_LEN_MAX];
 	struct xrow_header row;
 	xrow_encode_synchro(&row, body, req);
-	if (journal_write_row(&row) == 0)
+	return journal_write_row(&row);
+}
+
+/** Write a request to WAL or panic. */
+static void
+synchro_request_write_or_panic(const struct synchro_request *req)
+{
+	if (synchro_request_write(req) == 0)
 		return;
 	diag_log();
 	/*
@@ -457,10 +463,11 @@ synchro_request_write(const struct synchro_request *req)
 	      "type = %s\n", (long long)req->lsn, iproto_type_name(req->type));
 }
 
-/** Create a request for a specific limbo and write it to WAL. */
+/** Create a request for a specific limbo and write it to WAL or panic. */
 static void
-txn_limbo_write_synchro(struct txn_limbo *limbo, uint16_t type, int64_t lsn,
-			uint64_t term, struct vclock *vclock)
+txn_limbo_write_synchro_or_panic(struct txn_limbo *limbo, uint16_t type,
+				 int64_t lsn, uint64_t term,
+				 struct vclock *vclock)
 {
 	assert(lsn >= 0);
 
@@ -471,7 +478,7 @@ txn_limbo_write_synchro(struct txn_limbo *limbo, uint16_t type, int64_t lsn,
 		.term = term,
 		.confirmed_vclock = vclock,
 	};
-	synchro_request_write(&req);
+	synchro_request_write_or_panic(&req);
 }
 
 /**
@@ -574,7 +581,8 @@ txn_limbo_write_rollback(struct txn_limbo *limbo, int64_t lsn)
 	assert(lsn > limbo->confirmed_lsn);
 	assert(!limbo->is_in_rollback);
 	limbo->is_in_rollback = true;
-	txn_limbo_write_synchro(limbo, IPROTO_RAFT_ROLLBACK, lsn, 0, NULL);
+	txn_limbo_write_synchro_or_panic(limbo, IPROTO_RAFT_ROLLBACK, lsn, 0,
+					 NULL);
 	limbo->is_in_rollback = false;
 }
 
@@ -632,7 +640,7 @@ txn_limbo_write_promote(struct txn_limbo *limbo, int64_t lsn, uint64_t term)
 	};
 	if (txn_limbo_req_prepare(limbo, &req) < 0)
 		return -1;
-	synchro_request_write(&req);
+	synchro_request_write_or_panic(&req);
 	txn_limbo_req_commit(limbo, &req);
 	return 0;
 }
@@ -672,7 +680,7 @@ txn_limbo_write_demote(struct txn_limbo *limbo, int64_t lsn, uint64_t term)
 	};
 	if (txn_limbo_req_prepare(limbo, &req) < 0)
 		return -1;
-	synchro_request_write(&req);
+	synchro_request_write_or_panic(&req);
 	txn_limbo_req_commit(limbo, &req);
 	return 0;
 }

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -85,6 +85,20 @@ txn_limbo_create(struct txn_limbo *limbo)
 	limbo->confirm_lag = 0;
 }
 
+static inline void
+txn_limbo_destroy(struct txn_limbo *limbo)
+{
+	struct txn_limbo_entry *entry;
+	while (!rlist_empty(&limbo->queue)) {
+		entry = rlist_shift_entry(&limbo->queue,
+					  typeof(*entry), in_queue);
+		entry->txn->limbo_entry = NULL;
+		txn_free(entry->txn);
+	}
+	fiber_cond_destroy(&limbo->wait_cond);
+	TRASH(limbo);
+}
+
 static inline bool
 txn_limbo_is_frozen(const struct txn_limbo *limbo)
 {
@@ -1376,4 +1390,10 @@ void
 txn_limbo_init(void)
 {
 	txn_limbo_create(&txn_limbo);
+}
+
+void
+txn_limbo_free(void)
+{
+	txn_limbo_destroy(&txn_limbo);
 }

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -474,7 +474,6 @@ txn_limbo_wait_complete(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
 		txn_limbo_complete_fail(limbo, e, TXN_SIGNATURE_QUORUM_TIMEOUT);
 		if (e == entry)
 			break;
-		fiber_wakeup(e->txn->fiber);
 	}
 	diag_set(ClientError, ER_SYNC_QUORUM_TIMEOUT);
 	return -1;

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -484,6 +484,13 @@ txn_limbo_has_owner(struct txn_limbo *limbo)
 	return limbo->owner_id != REPLICA_ID_NIL;
 }
 
+/** Return whether limbo is owned by current instance. */
+static inline bool
+txn_limbo_is_owned_by_current_instance(const struct txn_limbo *limbo)
+{
+	return limbo->owner_id == instance_id;
+}
+
 /**
  * Initialize qsync engine.
  */

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -490,6 +490,12 @@ txn_limbo_has_owner(struct txn_limbo *limbo)
 void
 txn_limbo_init();
 
+/**
+ * Denitialize qsync engine.
+ */
+void
+txn_limbo_free();
+
 #if defined(__cplusplus)
 }
 #endif /* defined(__cplusplus) */

--- a/src/lib/core/errinj.h
+++ b/src/lib/core/errinj.h
@@ -157,7 +157,8 @@ struct errinj {
 	_(ERRINJ_TUPLE_FORMAT_COUNT, ERRINJ_INT, {.iparam = -1}) \
 	_(ERRINJ_TX_DELAY_PRIO_ENDPOINT, ERRINJ_DOUBLE, {.dparam = 0}) \
 	_(ERRINJ_TXN_COMMIT_ASYNC, ERRINJ_BOOL, {.bparam = false})\
-	_(ERRINJ_TXN_LIMBO_BEGIN_DELAY, ERRINJ_BOOL, {.bparam = false})\
+	_(ERRINJ_TXN_LIMBO_BEGIN_DELAY, ERRINJ_BOOL, {.bparam = false}) \
+	_(ERRINJ_TXN_LIMBO_WORKER_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_VYRUN_DATA_READ, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_VY_COMPACTION_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_VY_DUMP_DELAY, ERRINJ_BOOL, {.bparam = false}) \

--- a/test/box-luatest/gh_10628_ack_limbo_owner_wal_writes_to_limbo_async_test.lua
+++ b/test/box-luatest/gh_10628_ack_limbo_owner_wal_writes_to_limbo_async_test.lua
@@ -1,0 +1,96 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_each(function(cg)
+    cg.s = server:new({
+        alias = 'default',
+        box_cfg = {
+            replication_synchro_timeout = 120,
+        },
+    })
+    cg.s:start()
+    cg.s:exec(function()
+        rawset(_G, 'fiber', require('fiber'))
+
+        box.schema.create_space('s', {is_sync = true}):create_index('pk')
+        box.ctl.promote()
+    end)
+end)
+
+g.after_each(function(cg)
+    cg.s:drop()
+end)
+
+-- Test that CONFIRM request WAL write failure is retried.
+g.test_confirm_write_failure = function(cg)
+    t.tarantool.skip_if_not_debug()
+
+    local wal_error_occurred = false
+    cg.s.net_box:watch('box.wal_error', function(k, v)
+        t.assert_equals(k, 'box.wal_error')
+        if v ~= nil then
+           wal_error_occurred = true
+        end
+    end)
+
+    cg.s:exec(function()
+        -- Make the CONFIRM request WAL write fail.
+        box.error.injection.set('ERRINJ_WAL_IO_COUNTDOWN', 1)
+        local f = _G.fiber.create(function() box.space.s:replace{0} end)
+        f:set_joinable(true)
+
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_IO'))
+        end)
+
+        -- Allow the CONFIRM request WAL write to succeed.
+        box.error.injection.set('ERRINJ_WAL_IO', false)
+        t.assert(f:join())
+    end)
+    cg.s:grep_log('txn_limbo_worker .+ ER_WAL_IO: Failed to write to disk')
+    t.assert(wal_error_occurred)
+end
+
+-- Test that CONFIRM request WAL write concurrently with new transaction
+-- confirmation works correctly.
+g.test_confirm_write_failure = function(cg)
+    t.tarantool.skip_if_not_debug()
+
+    cg.s:exec(function()
+        -- Make the CONFIRM request WAL write hang.
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 1)
+        -- Bump the volatile confirmed LSN.
+        local f1 = _G.fiber.create(function() box.space.s:replace{0} end)
+        f1:set_joinable(true)
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.synchro.queue.len, 1)
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+        end)
+
+        -- Make the limbo worker hang after the CONFIRM request WAL write
+        -- finishes.
+        box.error.injection.set('ERRINJ_TXN_LIMBO_WORKER_DELAY', true)
+
+        -- Bump the volatile confirmed LSN concurrently.
+        local f2 = _G.fiber.create(function() box.space.s:replace{0} end)
+        f2:set_joinable(true)
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.synchro.queue.len, 2)
+        end)
+
+        local lsn = box.info.lsn
+        -- Allow the WAL writes to proceed.
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.lsn, lsn + 2)
+        end)
+
+        -- Allow the limbo's worker fiber to proceed.
+        box.error.injection.set('ERRINJ_TXN_LIMBO_WORKER_DELAY', false)
+
+        t.assert(f1:join())
+        t.assert(f2:join())
+    end)
+end

--- a/test/box-luatest/gh_10853_async_commit_async_tx_after_sync_tx_synchro_timeout_crash_test.lua
+++ b/test/box-luatest/gh_10853_async_commit_async_tx_after_sync_tx_synchro_timeout_crash_test.lua
@@ -1,0 +1,40 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_each(function(cg)
+    cg.s = server:new({
+        alias = 'default',
+        box_cfg = {
+            replication_synchro_timeout = 120,
+            replication_synchro_quorum = 2,
+        },
+    })
+    cg.s:start()
+    cg.s:exec(function()
+        box.schema.create_space('a', {is_sync = false}):create_index('p')
+        box.schema.create_space('s', {is_sync = true}):create_index('p')
+        box.ctl.promote()
+    end)
+end)
+
+g.after_each(function(cg)
+    cg.s:drop()
+end)
+
+-- Test that asynchronously committing an async transaction after a sync
+-- transaction that later times out on `replication_synchro_timeout` works
+-- correctly.
+g.test_async_commit_async_async_tx_after_sync_tx_synchro_timeout = function(cg)
+   cg.s:exec(function()
+       local f = require('fiber').create(function() box.space.s:replace{0} end)
+       f:set_joinable(true)
+       box.atomic({wait = 'none'}, function() box.space.a:replace{0} end)
+       t.assert_equals(box.info.synchro.queue.len, 2)
+       box.cfg{replication_synchro_timeout = 0.001}
+       t.assert_not(f:join())
+       t.assert_equals(box.info.synchro.queue.len, 0)
+       t.assert_equals(box.space.a:get{0}, nil)
+   end)
+end

--- a/test/replication-luatest/gh_10628_ack_limbo_owner_wal_writes_to_limbo_async_test.lua
+++ b/test/replication-luatest/gh_10628_ack_limbo_owner_wal_writes_to_limbo_async_test.lua
@@ -1,0 +1,83 @@
+local replica_set = require('luatest.replica_set')
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_each(function(cg)
+    cg.replica_set = replica_set:new{}
+    cg.box_cfg = {
+        replication = {
+            server.build_listen_uri('master', cg.replica_set.id),
+            server.build_listen_uri('replica', cg.replica_set.id),
+        },
+        replication_timeout = 0.1,
+        replication_synchro_timeout = 120,
+    }
+    cg.master = cg.replica_set:build_and_add_server{
+        alias = 'master',
+        box_cfg = cg.box_cfg,
+    }
+    cg.replica = cg.replica_set:build_and_add_server{
+        alias = 'replica',
+        box_cfg = cg.box_cfg,
+    }
+    cg.replica_set:start()
+    cg.replica_set:wait_for_fullmesh()
+    cg.master:exec(function()
+        rawset(_G, 'fiber', require('fiber'))
+
+        box.schema.space.create('s', {is_sync = true}):create_index('p')
+        box.ctl.promote()
+    end)
+    cg.master:wait_for_downstream_to(cg.replica)
+end)
+
+g.after_each(function(cg)
+    cg.replica_set:drop()
+end)
+
+-- Test that the CONFIRM request WAL write is not done if the limbo is
+-- `in_rollback` state.
+g.test_limbo_in_rollback_confirm_not_written = function(cg)
+    t.tarantool.skip_if_not_debug()
+
+    local fid = cg.master:exec(function()
+        -- Delay the limbo worker wake up.
+        box.error.injection.set('ERRINJ_TXN_LIMBO_WORKER_DELAY', true)
+        -- Make the PROMOTE request WAL write hang.
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 1)
+        local f = _G.fiber.create(function() box.space.s:replace{0} end)
+        f:set_joinable(true)
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.synchro.queue.len, 1)
+        end)
+        return f:id()
+    end)
+
+    cg.master:wait_for_downstream_to(cg.replica)
+
+    cg.replica:exec(function()
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.synchro.queue.len, 1)
+        end)
+        box.cfg{replication_synchro_timeout = 0.01}
+        box.ctl.promote()
+    end)
+
+    cg.master:exec(function(fid)
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+        end)
+        t.assert(box.info.synchro.queue.busy)
+
+        local write_count = box.error.injection.get('ERRINJ_WAL_WRITE_COUNT')
+        box.error.injection.set('ERRINJ_TXN_LIMBO_WORKER_DELAY', false)
+        _G.fiber.sleep(0.1)
+        t.assert_equals(box.info.synchro.queue.len, 1)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        t.assert(_G.fiber.find(fid):join())
+        -- Check that CONFIRM request was not written to the WAL.
+        t.assert(box.error.injection.get('ERRINJ_WAL_WRITE_COUNT'), write_count)
+    end, {fid})
+end

--- a/test/replication-luatest/gh_11790_qsync_confirmed_lsn_race_test.lua
+++ b/test/replication-luatest/gh_11790_qsync_confirmed_lsn_race_test.lua
@@ -1,0 +1,277 @@
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+
+local test_timeout = 60
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new({
+        box_cfg = {
+            replication_synchro_timeout = 1000,
+            election_mode = 'manual',
+        }
+    })
+    cg.server:start()
+    cg.server:exec(function(test_timeout)
+        rawset(_G, 'fiber', require('fiber'))
+        box.ctl.promote()
+        box.ctl.wait_rw()
+        local s = box.schema.create_space('test', {is_sync = true})
+        s:create_index('pk')
+        rawset(_G, 'test_timeout', test_timeout)
+        rawset(_G, 'test_data', string.rep('a', 1000))
+    end, {test_timeout})
+end)
+
+g.after_each(function(cg)
+    if cg.replica then
+        cg.replica:drop()
+        cg.replica = nil
+    end
+    cg.server:exec(function()
+        box.ctl.promote()
+        box.ctl.wait_rw()
+        t.assert_equals(box.info.replication_anon.count, 0)
+        box.space.test:truncate()
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+--
+-- gh-11790 and gh-11180: during checkpoint creation the master has to make sure
+-- all the txns in it are confirmed. And only then it can create a checkpoint of
+-- the synchronous replication states like Raft and limbo.
+--
+-- There was a bug that the master, during waiting for the read-view txns to
+-- get persisted and the journal synced, would miss a new synchro txn appearing,
+-- and would later wait for its confirmation. Even though it is not even in the
+-- read-view. Then it would send to the replica a too new synchro state
+-- (confirm lsn > read-view's). Later the replica would receive the confirm of
+-- the newer txn and would think it is a conflicting confirmation. Because the
+-- replica would already have the too new confirmation lsn remembered.
+--
+-- In gh-11180 this bug would be reproducible and fixable on its own, because
+-- some txns could have been blocked on the limbo's max size being reached. But
+-- for gh-11790 on 3.2 this test is mostly doing the same as the next ones in
+-- this file. It is cherry-picked from 3.6 for consistency.
+--
+g.test_get_limbo_checkpoint_exactly_on_time = function(cg)
+    cg.server:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+        local function make_txn_fiber(id, on_commit)
+            return _G.fiber.create(function()
+                _G.fiber.self():set_joinable(true)
+                box.begin()
+                box.on_commit(function()
+                    if on_commit then
+                        on_commit()
+                    end
+                end)
+                box.space.test:insert{id, _G.test_data}
+                box.commit()
+            end)
+        end
+        rawset(_G, 'test_f1', make_txn_fiber(1))
+        --
+        -- On Tarantool 3.3 and newer right when the first txn gets committed,
+        -- the second one is created. It goes to the limbo and is trying to
+        -- trick the master to wait for its confirmation instead of the first
+        -- txn.
+        --
+        -- On 3.2 and older all the txns right after creation are just sent to
+        -- WAL directly without waiting for free space in the limbo.
+        --
+        rawset(_G, 'test_f2', make_txn_fiber(2, function()
+            rawset(_G, 'test_f3', make_txn_fiber(3))
+        end))
+        t.helpers.retrying({timeout = _G.test_timeout}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+        end)
+    end)
+    cg.replica = server:new({
+        box_cfg = {
+            replication = cg.server.net_box_uri,
+            replication_timeout = 0.1,
+            replication_anon = true,
+            read_only = true,
+        }
+    })
+    cg.replica:start({wait_until_ready = false})
+    t.helpers.retrying({timeout = test_timeout}, function()
+        t.assert(cg.server:grep_log('sending read%-view'))
+    end)
+    cg.server:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        t.assert((_G.test_f1:join()))
+        t.assert((_G.test_f2:join()))
+        t.assert((_G.test_f3:join()))
+        t.assert(box.space.test:get{1})
+        t.assert(box.space.test:get{2})
+        t.assert(box.space.test:get{3})
+    end)
+    cg.replica:wait_until_ready()
+    -- The third txn wasn't in the read-view. So it is going to be sent as a
+    -- follow-up. Need to wait for it explicitly.
+    cg.replica:wait_for_vclock_of(cg.server)
+    cg.replica:exec(function()
+        t.assert(box.space.test:get{1})
+        t.assert(box.space.test:get{2})
+        t.assert(box.space.test:get{3})
+    end)
+    --
+    -- Ensure the replication still works.
+    --
+    cg.server:exec(function()
+        box.space.test:insert{4}
+    end)
+    cg.replica:wait_for_vclock_of(cg.server)
+    cg.replica:exec(function()
+        t.assert(box.space.test:get{4})
+    end)
+end
+
+--
+-- Collection of the limbo checkpoint must happen exactly when the last synchro
+-- txn included into the checkpoint gets committed. Moreover, this checkpoint
+-- must not cover any newer txns. Or the replica would mistakenly believe it
+-- has confirmed even the data that wasn't sent to it.
+--
+g.test_limbo_checkpoint_batch_confirm = function(cg)
+    --
+    -- The test is making the limbo write a single CONFIRM for 2 txns: one
+    -- included into the checkpoint for a new replica and one is not. The
+    -- checkpoint sent to the replica must not include the last txn.
+    --
+    cg.server:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+        rawset(_G, 'make_txn_fiber', function(id)
+            return _G.fiber.create(function()
+                _G.fiber.self():set_joinable(true)
+                box.space.test:insert{id, _G.test_data}
+            end)
+        end)
+        rawset(_G, 'test_f1', _G.make_txn_fiber(1))
+        rawset(_G, 'test_f2', _G.make_txn_fiber(2))
+        t.helpers.retrying({timeout = _G.test_timeout}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+        end)
+        -- Stall the limbo worker so it collects more than one CONFIRM in a
+        -- single batch.
+        box.error.injection.set('ERRINJ_TXN_LIMBO_WORKER_DELAY', true)
+    end)
+    cg.replica = server:new({
+        box_cfg = {
+            replication = cg.server.net_box_uri,
+            replication_timeout = 0.1,
+            replication_anon = true,
+            read_only = true,
+        }
+    })
+    cg.replica:start({wait_until_ready = false})
+    t.helpers.retrying({timeout = test_timeout}, function()
+        t.assert(cg.server:grep_log('sending read%-view'))
+    end)
+    cg.server:exec(function()
+        --
+        -- Get the first 2 txns into WAL and unblock the relay from its write
+        -- into _gc_consumers on Tarantool 3.3 and newer. On <= 3.2 there is no
+        -- _gc_consumers. Which means on older versions the relay has already
+        -- started read-view creation at this point.
+        --
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        box.ctl.wal_sync()
+        --
+        -- The relay must have started the read-view creation. Make a newer txn
+        -- which must not end up in the limbo's checkpoint.
+        --
+        _G.test_f2:wakeup()
+        local f3 = _G.make_txn_fiber(3)
+        box.error.injection.set('ERRINJ_TXN_LIMBO_WORKER_DELAY', false)
+        t.assert((_G.test_f1:join()))
+        t.assert((_G.test_f2:join()))
+        t.assert((f3:join()))
+    end)
+    cg.replica:wait_until_ready()
+    --
+    -- Ensure the replication still works.
+    --
+    cg.server:exec(function()
+        box.space.test:insert{4}
+    end)
+    cg.replica:wait_for_vclock_of(cg.server)
+    cg.replica:exec(function()
+        t.assert(box.space.test:get{4})
+    end)
+end
+
+--
+-- gh-11790 and gh-11180: the replica on join makes a journal sync to get the
+-- vclock of the read-view that it is going to receive. It also collects the
+-- limbo checkpoint to know the confirmed LSN of the last synchro txn.
+--
+-- It might happen that those 2 values won't be in sync. The master might do
+-- the journal sync, and only then, eventually, the last one or many synchro
+-- txns get CONFIRMs. The replica wouldn't have the lsns of these CONFIRMs, but
+-- would have the transactions confirmed by them. Which is ok.
+--
+-- The problem is that later the replica would receive those CONFIRMs while
+-- catching up on master's xlogs. And it must not treat this as an error, that
+-- the received CONFIRMs <= already known confirm LSN.
+--
+g.test_limbo_checkpoint_confirm_after_wal_sync = function(cg)
+    cg.server:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+        local function make_txn_fiber(id)
+            return _G.fiber.create(function()
+                _G.fiber.self():set_joinable(true)
+                box.space.test:insert{id, _G.test_data}
+            end)
+        end
+        rawset(_G, 'test_f1', make_txn_fiber(1))
+        t.helpers.retrying({timeout = _G.test_timeout}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+        end)
+        box.error.injection.set('ERRINJ_TXN_LIMBO_WORKER_DELAY', true)
+    end)
+    cg.replica = server:new({
+        box_cfg = {
+            replication = cg.server.net_box_uri,
+            replication_timeout = 0.1,
+            replication_anon = true,
+            read_only = true,
+        }
+    })
+    cg.replica:start({wait_until_ready = false})
+    t.helpers.retrying({timeout = test_timeout}, function()
+        t.assert(cg.server:grep_log('sending read%-view'))
+    end)
+    cg.server:exec(function()
+        --
+        -- The synchro txn gets written to WAL and the relay creates a
+        -- read-view. But a CONFIRM isn't written yet.
+        --
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        box.ctl.wal_sync()
+        --
+        -- Now the CONFIRM gets written. After read-view creation and journal
+        -- sync for the replica.
+        --
+        box.error.injection.set('ERRINJ_TXN_LIMBO_WORKER_DELAY', false)
+        t.assert((_G.test_f1:join()))
+    end)
+    cg.replica:wait_until_ready()
+    --
+    -- Ensure the replication still works.
+    --
+    cg.server:exec(function()
+        box.space.test:insert{2}
+    end)
+    cg.replica:wait_for_vclock_of(cg.server)
+    cg.replica:exec(function()
+        t.assert(box.space.test:get{2})
+    end)
+end

--- a/test/replication-luatest/gh_5295_split_brain_test.lua
+++ b/test/replication-luatest/gh_5295_split_brain_test.lua
@@ -161,6 +161,10 @@ g.test_bad_confirm_old_term = function(cg)
     reconnect_and_check_split_brain(cg)
 end
 
+g.before_test('test_good_confirm_old_term', function(cg)
+    cg.main:update_box_cfg{replication_synchro_timeout = 1000}
+end)
+
 -- Obsolete sync transaction confirmation might be fine when it doesn't
 -- contradict local history.
 g.test_good_confirm_old_term = function(cg)
@@ -186,6 +190,10 @@ g.test_good_confirm_old_term = function(cg)
     end)
     reconnect_and_check_no_split_brain(cg)
 end
+
+g.after_test('test_good_confirm_old_term', function(cg)
+    cg.main:update_box_cfg{replication_synchro_timeout = 0.01}
+end)
 
 -- A conflicting sync transaction rollback from an obsolete term means a
 -- split-brain.
@@ -309,6 +317,7 @@ g_very_old_term.before_each(function(cg)
     cg.box_cfg = {
         replication_timeout = 0.1,
         replication_synchro_quorum = 1,
+        replication_sync_timeout = 1000,
         replication = {
             server.build_listen_uri('server1', cg.cluster.id),
             server.build_listen_uri('server2', cg.cluster.id),


### PR DESCRIPTION
#11790 + second part of #11180.

The patchset from #11180 couldn't be all applied right away, because the second half of it depends on the limbo having a worker fiber and doing confirmations asynchronously.

Coincidentally, this also led (seemingly) to #11790. On old versions (3.2 and older) the confirmation LSN was updated by the limbo before the WAL write. So after the WAL write it could happen that the "volatile" confirmed LSN has moved forward already, and the just written CONFIRM is already stale.

That case was just ignored previously, but this was blocking the second part of #11180 fixes.

The patchset entirely consists of some existing commits being cherry-picked from the master, but in a bit weird order. Since most of them were done long time ago and just were not considered as necessary for 3.2.

Closes #11790 