### PR TITLE
box: fix fixed point decimal validation of MP_NIL

### DIFF
--- a/changelogs/unreleased/gh-ee-1454-fix-fixed-decimal-validation.md
+++ b/changelogs/unreleased/gh-ee-1454-fix-fixed-decimal-validation.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed a crash when a tuple field or key part of a fixed decimal type is
+  `MP_NIL` (gh-ee-1454).

--- a/src/box/field_def.c
+++ b/src/box/field_def.c
@@ -43,6 +43,7 @@
 #include "tuple_format.h"
 #include "salad/grp_alloc.h"
 #include "small/region.h"
+#include "mp_decimal.h"
 
 const char *mp_type_strs[] = {
 	/* .MP_NIL    = */ "nil",
@@ -591,6 +592,20 @@ field_mp_is_in_fixed_int_range(enum field_type type, const char *data,
 }
 
 #undef ERROR_MSG
+
+bool
+field_mp_fits_fixed_point_decimal(enum field_type type, int64_t scale,
+				  const char *data)
+{
+	assert(field_type_is_fixed_decimal[type]);
+	decimal_t dec;
+	enum mp_type mp_type = mp_typeof(*data);
+	if (mp_type == MP_NIL)
+		return true;
+	VERIFY(mp_decode_decimal(&data, &dec) != NULL);
+	int precision = field_type_decimal_precision[type];
+	return decimal_fits_fixed_point(&dec, precision, scale);
+}
 
 /**
  * Parse default field value from msgpack.

--- a/src/box/field_def.h
+++ b/src/box/field_def.h
@@ -248,6 +248,17 @@ field_mp_is_in_fixed_int_range(enum field_type type, const char *data,
 			       char *mp_min, char *mp_max,
 			       const char **details);
 
+/**
+ * Check if MsgPack value fits into fixed point decimal.
+ * @param type - fixed point decimal type.
+ * @param scale - fixed point decimal scale.
+ * @param data - MsgPack value.
+ * @retval true if fits and false otherwise.
+ */
+bool
+field_mp_fits_fixed_point_decimal(enum field_type type, int64_t scale,
+				  const char *data);
+
 static inline bool
 action_is_nullable(enum on_conflict_action nullable_action)
 {


### PR DESCRIPTION
Currently if part of key or tuple field that corresponds to fixed point decimal type is MP_NIL we crash.

Closes tarantool/tarantool-ee#1454