### PR TITLE
 box: fix old tuple format in on_replace trigger on space upgrade

### DIFF
--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -347,6 +347,18 @@ txn_stmt_prepare_rollback_info(struct txn_stmt *stmt, struct tuple *old_tuple,
 		tuple_ref(stmt->rollback_info.new_tuple);
 }
 
+void
+txn_stmt_set_tuples(struct txn_stmt *stmt, struct tuple *old_tuple,
+		    struct tuple *new_tuple)
+{
+	stmt->old_tuple = old_tuple;
+	if (stmt->old_tuple != NULL)
+		tuple_ref(stmt->old_tuple);
+	stmt->new_tuple = new_tuple;
+	if (stmt->new_tuple != NULL)
+		tuple_ref(stmt->new_tuple);
+}
+
 /*
  * Run the statement's rollback triggers and undo changes done by the statement.
  *

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -862,6 +862,13 @@ void
 txn_stmt_prepare_rollback_info(struct txn_stmt *stmt, struct tuple *old_tuple,
 			       struct tuple *new_tuple);
 
+/**
+ * Save @a old_tuple and @a new_tuple of replace in @a stmt.
+ */
+void
+txn_stmt_set_tuples(struct txn_stmt *stmt, struct tuple *old_tuple,
+		    struct tuple *new_tuple);
+
 /*
  * Return the total number of rows committed in the txn.
  */


### PR DESCRIPTION
Currently format of old tuple in `on_replace` trigger may be in new or old format during space upgrade depending on whether replace is done before or after upgrade cursor. Space upgrade is designed to be instant from user POV: it returns upgraded tuples in `space.get()` for example even if tuple is not upgraded internally. So to make the trigger consistent with overall design let's always return old tuple in new format.

The old tuple visible in trigger is set by `memtx_space_replace_tuple()` function. Instead of fixing it let's get rid of it for a few reasons:

- The interface is a bit odd. `old_tuple` is compressed and `new_tuple` is not. Also reference for `new_tuple` is taken by the function and is not for `old_tuple`.  
- With this function we do some a bit heavy actions twice. For example on update we decompress old tuple before update but then decompress it again to set to `stmt->old_tuple` in this function.

Closes tarantool/tarantool-ee#1458

See also bump in EE in PR https://github.com/tarantool/tarantool-ee/pull/1461.