### PR TITLE
box: fix error propagation in box.atomic

### DIFF
--- a/changelogs/unreleased/gh-11823-box-atomic-fix-error-propagation.md
+++ b/changelogs/unreleased/gh-11823-box-atomic-fix-error-propagation.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed an issue when `tostring()` is applied to an error raised inside
+  `box.atomic()` (gh-11823).

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -442,7 +442,7 @@ local function atomic_tail(level, options, status, ...)
     else
         -- Keep original trace and append trace of level + 1 as
         -- in case of box.error.
-        error(tostring(err), level + 1)
+        error(err, level + 1)
     end
 end
 

--- a/test/box-luatest/box_atomic_test.lua
+++ b/test/box-luatest/box_atomic_test.lua
@@ -1,0 +1,26 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(g)
+    g.server = server:new()
+    g.server:start()
+end)
+
+g.after_all(function(g)
+    g.server:drop()
+end)
+
+g.test_error_propagation = function(cg)
+    cg.server:exec(function()
+        local non_box_err = {x = 1}
+        local ok, err = pcall(box.atomic, function() error(non_box_err) end)
+        t.assert_not(ok)
+        t.assert_equals(err, non_box_err)
+        local box_err = box.error.new('custom', 'foo')
+        local ok, err = pcall(box.atomic, function() error(box_err) end)
+        t.assert_not(ok)
+        t.assert_equals(err, box_err)
+    end)
+end


### PR DESCRIPTION
Currently there is mistaken conversion to string. We don't need it at all.

Closes #11823