### PR TITLE
config: sync users with config on reload

### DIFF
--- a/changelogs/unreleased/gh-11827-sync-users-after-reload.md
+++ b/changelogs/unreleased/gh-11827-sync-users-after-reload.md
@@ -1,0 +1,20 @@
+## bugfix/box
+
+* Users and roles defined in `credentials.*` are now synchronized with the
+  config on reload and instance restart: users and roles removed from config
+  are dropped automatically, while manually created users and roles remain
+  untouched (gh-11827).
+
+----
+
+Manual action required: ensure that all users and roles are managed by the
+YAML configuration.
+
+A customer has to run the following script [1] to ensure that all the users
+and roles are managed solely by the YAML configuration.
+
+It allows to identify users/roles that are kept forever, because created from
+Lua (or from config on tarantool version less than 3.6.0), and decide whether
+to transfer the ownership to the YAML configuration or finally delete them.
+
+[1]: https://raw.githubusercontent.com/tarantool/tarantool/refs/heads/master/tools/find-orphan-users.lua'

--- a/test/config-luatest/credentials_sync_test.lua
+++ b/test/config-luatest/credentials_sync_test.lua
@@ -1,0 +1,286 @@
+local t = require('luatest')
+local cbuilder = require('luatest.cbuilder')
+local cluster = require('luatest.cluster')
+local fio = require('fio')
+
+local g = t.group(
+    "credentials_sync",
+    t.helpers.matrix({
+        restart = {
+            function(c, config)
+                -- Instance restart
+                --
+                -- We must call sync method before stop/start.
+                -- Otherwise, the new configuration won't be written to disk and
+                -- the instance will restart with the old one.
+                c:sync(config)
+                c:stop()
+                c:start()
+            end,
+            function(c, config)
+                -- Config reload
+                c:reload(config)
+            end,
+        }
+    })
+)
+
+local default_user_config = cbuilder:new()
+    :add_instance('i-001', {})
+    :set_global_option('credentials.users.alice')
+    :set_global_option('credentials.users.alice.password', 'ALICE')
+    :set_global_option('credentials.users.charlie')
+    :set_global_option('credentials.users.charlie.password', 'CHARLIE')
+    :config()
+
+local default_role_config = cbuilder:new()
+    :add_instance('i-001', {})
+    :set_global_option('credentials.roles.reader', {
+        privileges = {
+            {permissions = {'read'}, universe = true},
+        },
+    })
+    :set_global_option('credentials.roles.writer', {
+        privileges = {
+            {permissions = {'write'}, universe = true},
+        },
+    })
+    :config()
+
+local function user_exists(inst, name)
+    return inst:exec(function(n)
+        return box.schema.user.exists(n)
+    end, {name})
+end
+
+local function role_exists(inst, name)
+    return inst:exec(function(n)
+        return box.schema.role.exists(n)
+    end, {name})
+end
+
+local function get_perms(inst, who)
+    return inst:exec(function(name)
+        local internal =
+            require('internal.config.applier.credentials')._internal
+        return internal.privileges_from_box(name)
+    end, {who})
+end
+
+g.test_config_user_removed = function(g)
+    local c = cluster:new(default_user_config)
+    c:start()
+
+    c['i-001']:exec(function()
+        box.schema.user.create('bob')
+    end)
+
+    t.assert(user_exists(c['i-001'], 'alice'))
+    t.assert(user_exists(c['i-001'], 'charlie'))
+    t.assert(user_exists(c['i-001'], 'bob'))
+
+    local new_config = cbuilder:new(default_user_config)
+        :set_global_option('credentials.users.alice', nil)
+        :config()
+
+    g.params.restart(c, new_config)
+
+    -- User removed from config must be dropped.
+    t.assert_not(user_exists(c['i-001'], 'alice'))
+
+    -- Users still in config must remain.
+    t.assert(user_exists(c['i-001'], 'charlie'))
+
+    -- Manually created user must remain.
+    t.assert(user_exists(c['i-001'], 'bob'))
+end
+
+g.test_config_role_removed = function(g)
+    local c = cluster:new(default_role_config)
+    c:start()
+
+    c['i-001']:exec(function()
+        if not box.schema.role.exists('auditor') then
+            box.schema.role.create('auditor')
+        end
+    end)
+
+    t.assert(role_exists(c['i-001'], 'reader'))
+    t.assert(role_exists(c['i-001'], 'writer'))
+    t.assert(role_exists(c['i-001'], 'auditor'))
+
+    local new_config = cbuilder:new(default_role_config)
+        :set_global_option('credentials.roles.reader', nil)
+        :config()
+
+    g.params.restart(c, new_config)
+
+    -- Role removed from config must be dropped.
+    t.assert_not(role_exists(c['i-001'], 'reader'))
+
+    -- Roles still in config must remain.
+    t.assert(role_exists(c['i-001'], 'writer'))
+
+    -- Manually created role must remain.
+    t.assert(role_exists(c['i-001'], 'auditor'))
+end
+
+g.test_manual_then_config_then_removed_from_config = function(g)
+    -- Start without dualuser/dualrole in the config.
+    local base_cfg = cbuilder:new()
+        :add_instance('i-001', {})
+        :set_global_option('credentials.users.guest', {roles = {'super'}})
+        :config()
+
+    local c = cluster:new(base_cfg)
+    c:start()
+
+    -- Create user and role manually.
+    c['i-001']:exec(function()
+        if not box.schema.user.exists('dualuser') then
+            box.schema.user.create('dualuser')
+        end
+        if not box.schema.role.exists('dualrole') then
+            box.schema.role.create('dualrole')
+        end
+    end)
+
+    t.assert(user_exists(c['i-001'], 'dualuser'))
+    t.assert(role_exists(c['i-001'],  'dualrole'))
+
+    -- At this point there must be no config-origin privileges yet.
+    local perms_user  = get_perms(c['i-001'], 'dualuser')
+    local perms_role  = get_perms(c['i-001'], 'dualrole')
+    t.assert_equals(((perms_user.universe or {})[''] or {}).execute, nil)
+    t.assert_equals(((perms_role.universe or {})[''] or {}).read, nil)
+
+    -- Add dualuser/dualrole to the config with privileges.
+    local new_config = cbuilder:new(base_cfg)
+        :set_global_option('credentials.users.dualuser', {
+            privileges = {{permissions = {'execute'}, universe = true}},
+        })
+        :set_global_option('credentials.roles.dualrole', {
+            privileges = {{permissions = {'read'}, universe = true}},
+        })
+        :config()
+
+    g.params.restart(c, new_config)
+
+    -- After reload: objects still exist (they were manual),
+    -- and config-origin privileges are added.
+    t.assert(user_exists(c['i-001'], 'dualuser'))
+    t.assert(role_exists(c['i-001'],  'dualrole'))
+
+    perms_user = get_perms(c['i-001'], 'dualuser')
+    perms_role = get_perms(c['i-001'], 'dualrole')
+    t.assert_equals(((perms_user.universe or {})[''] or {}).execute, true)
+    t.assert_equals(((perms_role.universe or {})[''] or {}).read, true)
+
+    -- Remove them from the config and reload again.
+    new_config = cbuilder:new(new_config)
+        :set_global_option('credentials.users.dualuser', nil)
+        :set_global_option('credentials.roles.dualrole', nil)
+        :config()
+
+    g.params.restart(c, new_config)
+
+    -- dualuser/dualrole remain (manual origin still exists),
+    -- BUT config-origin privileges are revoked.
+    t.assert(user_exists(c['i-001'], 'dualuser'))
+    t.assert(role_exists(c['i-001'],  'dualrole'))
+
+    perms_user = get_perms(c['i-001'], 'dualuser')
+    perms_role = get_perms(c['i-001'], 'dualrole')
+
+    -- execute from YAML must be revoked
+    t.assert_equals(((perms_user.universe or {})[''] or {}).execute, nil)
+
+    -- read from YAML must be revoked
+    t.assert_equals(((perms_role.universe or {})[''] or {}).read, nil)
+end
+
+local g2 = t.group("find-orphan-users")
+
+g2.test_find_orphan_users_script = function()
+    local config = cbuilder:new(default_user_config)
+        :set_global_option('credentials.roles.reader', {})
+        :set_global_option('credentials.roles.writer', {})
+        :config()
+
+    local c = cluster:new(config)
+    c:start()
+
+    -- Create user and role manually.
+    c['i-001']:exec(function()
+        box.schema.user.create('alice')  -- duplicates config user
+        box.schema.user.create('bob')    -- orphan user
+        box.schema.role.create('reader') -- duplicates config role
+        box.schema.role.create('tester') -- orphan role
+    end)
+
+    c:reload(config)
+
+    local find_orphan_users_script =
+        fio.abspath('tools/find-orphan-users.lua')
+    t.assert(fio.path.exists(find_orphan_users_script))
+
+    c['i-001']:exec(function(find_orphan_users_script)
+        local info = require('config'):info()
+        local exp_alert_sub =
+            'Found users/roles authored from Lua and not managed by'
+        t.assert_equals(info.status, 'check_warnings', info)
+        t.assert_equals(#info.alerts, 1, info.alerts)
+        t.assert_equals(info.alerts[1].type, 'warn')
+        t.assert_str_contains(tostring(info.alerts[1].message), exp_alert_sub)
+
+        -- Run the helper. It returns a table of lines.
+        local lines = dofile(find_orphan_users_script)
+        t.assert_equals(type(lines), 'table')
+
+        -- Helper to check that a line exists (order-independent).
+        local function has_line(needle)
+            for _, s in ipairs(lines) do
+                if s == needle then
+                    return true
+                end
+            end
+            return false
+        end
+
+        -- Validate a few key lines from the sample.
+        -- Entries listed as managed by YAML:
+        t.assert(has_line('role "reader"'))
+        t.assert(has_line('role "writer"'))
+        t.assert(has_line('user "replicator"')) -- from base_config in cbuilder
+        t.assert(has_line('user "client"'))     -- from base_config in cbuilder
+        t.assert(has_line('user "alice"'))
+        t.assert(has_line('user "charlie"'))
+
+        -- Commands to transfer ownership to YAML (disown duplicates):
+        t.assert(has_line('box.schema.role.disown("reader")'))
+        t.assert(has_line('box.schema.user.disown("alice")'))
+
+        -- Commands to drop orphans:
+        t.assert(has_line('box.schema.user.drop("bob")'))
+        t.assert(has_line('box.schema.role.drop("tester")'))
+
+        -- Execute all generated commands (both disown and drop).
+        -- We find all lines that look like box.schema.*.<op>(...)
+        for _, s in ipairs(lines) do
+            if s:match('^box%.schema%.[%w_]+%.[%w_]+%(') then
+                local fn, err = load(s)
+                t.assert(fn, ('failed to compile: %s'):format(err or s))
+                fn()
+            end
+        end
+    end, {find_orphan_users_script})
+
+    -- Reload with the same config: the orphan/duplicate alerts should be gone.
+    c:reload(config)
+
+    c['i-001']:exec(function()
+        local info = require('config'):info()
+        t.assert_equals(info.status, 'ready', info)
+        t.assert_equals(#info.alerts, 0, info.alerts)
+    end)
+end

--- a/tools/find-orphan-users.lua
+++ b/tools/find-orphan-users.lua
@@ -1,0 +1,177 @@
+-- Print commands to drop users and roles that are not managed by
+-- the YAML configuration.
+--
+-- These are ones created from a Lua code using one of the
+-- following functions:
+--
+--  | box.schema.user.create()
+--  | box.schema.role.create()
+--
+-- If users/roles are managed using the YAML configuration, then
+-- it is likely that all of them are supposed to be managed this
+-- way. If a user/a role is removed from the YAML configuration,
+-- the admin expectation is likely that it is deleted from the
+-- database.
+--
+-- However, users/roles created from Lua are not deleted
+-- automatically due to compatibility concerns. It is an
+-- admin responsibility to run this script and ensure that
+-- there are no stalled entries. See [1] for the motivating
+-- scenario.
+--
+-- [1]: https://github.com/tarantool/tarantool/issues/11827
+--
+-- Note: Users/roles created from the YAML configuration by
+-- tarantool versions less than 3.6 can't be distinguished from
+-- ones created from Lua and considered as the Lua ones.
+--
+-- Note: A user/a role can be created from Lua and from the YAML
+-- configuration both. In this case box.schema.*.drop() deletes
+-- the entry created from Lua. The entry that comes from the YAML
+-- configuration remains in the database (until deleted from the
+-- configuration).
+--
+-- Usage:
+--
+-- dofile('/path/to/this/file.lua')
+
+local DEFAULT_ORIGIN = ''
+local CONFIG_ORIGIN = 'config'
+local USER_OPTS_FIELD = 8
+
+-- Return origins for user/role from the given tuple.
+local function user_origins_from_tuple(tuple)
+    if tuple[USER_OPTS_FIELD] == nil or
+       tuple[USER_OPTS_FIELD].origins == nil then
+        return {[DEFAULT_ORIGIN] = true}
+    end
+    return tuple[USER_OPTS_FIELD].origins
+end
+
+local function is_system(tuple)
+    return tuple.id <= box.schema.SYSTEM_USER_ID_MAX or
+        tuple.id == box.schema.SUPER_ROLE_ID
+end
+
+local function disown_command(tuple)
+    return ('box.schema.%s.disown(%q)'):format(tuple.type, tuple.name)
+end
+
+local function drop_command(tuple)
+    return ('box.schema.%s.drop(%q)'):format(tuple.type, tuple.name)
+end
+
+local config_entries = {}
+local duplicate_entries = {}
+local orphan_entries = {}
+
+for _, t in box.space._user:pairs() do
+    if not is_system(t) then
+        local origins = user_origins_from_tuple(t)
+        local comes_from_config = origins[CONFIG_ORIGIN]
+        local comes_from_lua = origins[DEFAULT_ORIGIN]
+
+        if comes_from_config then
+            table.insert(config_entries, ('%s %q'):format(t.type, t.name))
+        end
+
+        if comes_from_lua and comes_from_config then
+            table.insert(duplicate_entries, disown_command(t))
+        end
+
+        if comes_from_lua and not comes_from_config then
+            table.insert(orphan_entries, drop_command(t))
+        end
+    end
+end
+
+local function gen_disown_f(user_or_role)
+    assert(user_or_role == 'user' or user_or_role == 'role')
+
+    local func_name = ('box.schema.%s.disown'):format(user_or_role)
+    local function e(fmt, ...)
+        error(('%s: %s'):format(func_name, fmt:format(...)), 0)
+    end
+
+    return function(name)
+        if type(name) ~= 'string' then
+            e('expected string, got %s', type(name))
+        end
+
+        local t = box.space._user.index.name:get({name})
+        if t == nil then
+            e('unable to find %s %q', user_or_role, name)
+        end
+
+        local origins = user_origins_from_tuple(t)
+        local comes_from_config = origins[CONFIG_ORIGIN]
+        local comes_from_lua = origins[DEFAULT_ORIGIN]
+
+        if not comes_from_config then
+            e('the %s %q is not owned by the YAML configuration', user_or_role,
+                name)
+        end
+
+        if not comes_from_lua then
+            e('the %s %q is not owned by the Lua code', user_or_role, name)
+        end
+
+        box.schema[user_or_role].drop(name)
+    end
+end
+
+if #config_entries == 0 then
+    return 'Found no users/roles created from the YAML configuration.',
+        'Assuming that the users/roles are managed in the old-fashion way',
+        '(from Lua).',
+        'No further actions are expected.'
+end
+
+if #duplicate_entries == 0 and #orphan_entries == 0 then
+    return 'Found no users/roles created from Lua. Everything is managed ' ..
+        'using the YAML configuration. Fine.'
+end
+
+-- The output is a return value, because print() is not visible to
+-- the caller in case of a remote console connection.
+local output = {}
+
+-- Shortcut function: output a string.
+local function o(v)
+    table.insert(output, v)
+end
+
+-- Output a list.
+local function l(vs)
+    for _, v in ipairs(vs) do
+        o(v)
+    end
+end
+
+o('Found users/roles that are managed using the YAML configuration')
+o('')
+l(config_entries)
+
+if #duplicate_entries > 0 then
+    -- Add these functions only if needed.
+    box.schema.user.disown = gen_disown_f('user')
+    box.schema.role.disown = gen_disown_f('role')
+
+    o('')
+    o('Some of them will be kept even if removed from the YAML configuration.')
+    o('This is a security risk. Use the following commands to transfer the')
+    o('ownership to the configuration.')
+    o('')
+    l(duplicate_entries)
+end
+
+if #orphan_entries > 0 then
+    o('')
+    o('The following users/roles are NOT managed by the YAML configuration.')
+    o('It is recommended to add them to the configuration or remove (if they')
+    o('are obsoleted). The following commands remove them.')
+    o('')
+    l(orphan_entries)
+end
+
+return output


### PR DESCRIPTION
Previously, if a user or role was removed from `credentials.users` or `credentials.roles` in config, it still remained in the instance after reload. This was intentional to prevent bricking when an empty `credentials` section was rolled out, but it left stale accounts and roles in the system, which is a security risk.

Now both users and roles are synchronized with config on reload:
 - users/roles missing from config are dropped,
 - users/roles present in config are created/updated,
 - manually created users/roles remain untouched.
 
 Closes #11827 