### PR TITLE
index_opts: support parsing layout option as msgpack map

### DIFF
--- a/src/box/index_def.c
+++ b/src/box/index_def.c
@@ -120,17 +120,15 @@ static int
 index_opts_parse_layout(const char **data, void *opts, struct region *region)
 {
 	struct index_opts *index_opts = (struct index_opts *)opts;
-	if (mp_typeof(**data) != MP_STR) {
-		diag_set(IllegalParams, "'layout' must be string");
+	if (mp_typeof(**data) != MP_STR && mp_typeof(**data) != MP_MAP) {
+		diag_set(IllegalParams, "'layout' must be string or map");
 		return -1;
 	}
-	uint32_t len = 0;
-	const char *str = mp_decode_str(data, &len);
-	if (len > 0) {
-		index_opts->layout = xregion_alloc(region, len + 1);
-		memcpy(index_opts->layout, str, len);
-		index_opts->layout[len] = '\0';
-	}
+
+	const char *layout = *data;
+	mp_next(data);
+	index_opts->layout = xregion_alloc(region, *data - layout);
+	memcpy(index_opts->layout, layout, *data - layout);
 	return 0;
 }
 
@@ -233,7 +231,7 @@ index_opts_dup(const struct index_opts *opts, struct index_opts *dup)
 		       sizeof(*dup->covered_fields));
 	}
 	if (dup->layout != NULL)
-		dup->layout = xstrdup(dup->layout);
+		dup->layout = mp_dup(dup->layout);
 	if (dup->aggregates != NULL)
 		dup->aggregates = mp_dup(dup->aggregates);
 }

--- a/src/box/index_def.h
+++ b/src/box/index_def.h
@@ -123,7 +123,7 @@ struct index_opts {
 	uint32_t covered_field_count;
 	/**
 	 * Engine dependent. For engines supporting various layouts means a
-	 * string with the layout options.
+	 * MsgPack string or map with the layout options.
 	 */
 	char *layout;
 	/**
@@ -187,7 +187,11 @@ index_opts_is_equal(const struct index_opts *o1, const struct index_opts *o2)
 			return false;
 	}
 	if (o1->layout != NULL && o2->layout != NULL) {
-		if (strcmp(o1->layout, o2->layout) != 0)
+		uint32_t o1_layout_len = mp_len(o1->aggregates);
+		uint32_t o2_layout_len = mp_len(o2->aggregates);
+		if (o1_layout_len != o2_layout_len)
+			return false;
+		if (memcmp(o1->aggregates, o2->aggregates, o1_layout_len) != 0)
 			return false;
 	} else if (o1->layout != NULL || o2->layout != NULL) {
 		return false;

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -1565,7 +1565,7 @@ local index_options = {
     func = 'number, string',
     hint = 'boolean',
     covers = 'table',
-    layout = 'string',
+    layout = 'string,map',
     aggregates = 'table',
 }
 

--- a/src/box/lua/space.cc
+++ b/src/box/lua/space.cc
@@ -645,11 +645,6 @@ lbox_fillspace(struct lua_State *L, struct space *space, int i)
 			lua_setfield(L, -2, "covers");
 		}
 
-		if (index_def->opts.layout != NULL) {
-			lua_pushstring(L, index_def->opts.layout);
-			lua_setfield(L, -2, "layout");
-		}
-
 		lua_pushstring(L, "sequence_id");
 		if (k == 0 && space->sequence != NULL) {
 			lua_pushnumber(L, space->sequence->def->id);

--- a/test/box-luatest/index_layout_test.lua
+++ b/test/box-luatest/index_layout_test.lua
@@ -25,13 +25,13 @@ g.test_arg_check = function(cg)
         local s = box.schema.space.create('test')
         t.assert_error_covers({
             type = 'IllegalParams',
-            message = "options parameter 'layout' should be of type string",
+            message = "options parameter 'layout' should be one of types: string,map",
         }, s.create_index, s, 'pk', {layout = 1234})
 
         t.assert_error_covers({
             type = 'ClientError',
             name = 'WRONG_INDEX_OPTIONS',
-            message = "Wrong index options: 'layout' must be string",
+            message = "Wrong index options: 'layout' must be string or map",
         }, box.space._index.insert, box.space._index, {
             s.id, 0, 'pk', 'tree', {layout = 1234}, {{[0] = 'unsigned'}}
         })


### PR DESCRIPTION
We require that an index's layout option may be parsed as a msgpack string or map. The details are handled by tarantool-ee code.

Required by https://github.com/tarantool/tarantool-ee/issues/1189

NO_CHANGELOG=internal
NO_DOC=internal
NO_TEST=not required