### PR TITLE
codeowners: remove @Totktonada from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,10 +4,6 @@
 /.github/    @tarantool/devx
 /.test.mk    @tarantool/devx
 /test-run/   @tarantool/devx
-# Alexander Turenko wants to track all the activities around the
-# declarative configuration.
-/src/box/lua/config/  @Totktonada
-/test/config-luatest/ @Totktonada
 # Sergey Bronnikov wants to track all the activities around the
 # fuzzing tests.
 /test/fuzz/ @ligurio


### PR DESCRIPTION
Alexander is going to leave the team at the end of September. Still available for discussions, but he shouldn't be in change for the declarative configuration.

The configuration machinery is covered by consistency tests:

* Presence of all box.cfg options in the declarative configuration.
* Presence of all compat options in the declarative configuration.
* Presence of descriptions for all the declarative configuration options (these descriptions are then used in the JSON Schema).

As result of this testing, I saw no significant flaws in patches sent by other developers regarding the configuration. My most significant remark was about using the `integer` schema node type instead of `number` where appropriate (for example, for a value in bytes).

In all the other cases we discussed naming, feature design and so on, not something directly related to the configuration machinery. So, I think that I need not to assign the next person as a mandatory reviewer.

Effectively reverts commit 30fc56558132 ("Add @Totktonada as codeowner for config").