### PR TITLE
config: expand vars in `any` nodes

### DIFF
--- a/changelogs/unreleased/gh-10595-config-expand_any.md
+++ b/changelogs/unreleased/gh-10595-config-expand_any.md
@@ -1,0 +1,4 @@
+## bugfix/config
+
+* Template variables now expand inside `app.cfg.*` and `roles_cfg.*`
+  (`any` type fields) (gh-10595).

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -188,8 +188,7 @@ local function instance_uri(self, iconfig, advertise_type, opts)
 end
 
 local function apply_vars_f(data, w, vars)
-    if w.schema.type == 'string' and data ~= nil then
-        assert(type(data) == 'string')
+    if data ~= nil and type(data) == 'string' then
         return (data:gsub('{{ *(.-) *}}', function(var_name)
             if vars[var_name] ~= nil then
                 return vars[var_name]

--- a/test/config-luatest/expand_any_test.lua
+++ b/test/config-luatest/expand_any_test.lua
@@ -1,0 +1,62 @@
+local t = require('luatest')
+local helpers = require('test.config-luatest.helpers')
+
+local g = helpers.group('expand_any')
+
+g.test_context_vars_under_any = function(g)
+    helpers.success_case(g, {
+        options = {
+            ['config.context.title'] = {from = 'env', env = 'TITLE'},
+            ['process'] = {title = '{{ context.title }}'},
+            ['app.cfg'] = {title = '{{ context.title }}'},
+            ['app.cfg.number'] = 42,
+            ['roles_cfg.foo'] = {title = '{{ context.title }}', flag = true},
+        },
+        env = {TITLE = 'xxx'},
+        verify = function()
+            local t = require('luatest')
+            local config = require('config')
+            t.assert_equals(config:get('process.title'), 'xxx')
+            t.assert_equals(config:get('app.cfg.title'), 'xxx')
+            t.assert_equals(config:get('roles_cfg.foo.title'), 'xxx')
+            t.assert_equals(config:get('app.cfg.number'), 42)
+            t.assert_equals(config:get('roles_cfg.foo.flag'), true)
+        end,
+    })
+end
+
+g.test_builtin_vars_under_any = function(g)
+    helpers.success_case(g, {
+        options = {
+            ['process'] = {title = '{{ instance_name }}'},
+            ['app.cfg'] = {title = '{{ instance_name }}'},
+            ['roles_cfg.foo'] = {title = '{{ instance_name }}'},
+        },
+        verify = function()
+            local config = require('config')
+            t.assert_equals(config:get('process.title'), 'instance-001')
+            t.assert_equals(config:get('app.cfg.title'), 'instance-001')
+            t.assert_equals(config:get('roles_cfg.foo.title'), 'instance-001')
+        end,
+    })
+end
+
+g.test_any_transforms_keys = function(g)
+    helpers.success_case(g, {
+        options = {
+            ['app.cfg.rpc_priority'] = {
+                ['instance-002'] = 2,
+                ['instance-003'] = 3,
+                ['{{ instance_name }}'] = 99,
+            },
+        },
+        verify = function()
+            local config = require('config')
+            local priorities = config:get('app.cfg.rpc_priority')
+            t.assert_equals(priorities['instance-001'], 99)
+            t.assert_equals(priorities['instance-002'], 2)
+            t.assert_equals(priorities['instance-003'], 3)
+            t.assert_equals(priorities['{{ instance_name }}'], nil)
+        end,
+    })
+end


### PR DESCRIPTION
Template variables (e.g. `{{ context.title }}`, `{{ instance_name }})` are now expanded inside `app.cfg.*` and `roles_cfg.*` (`any` type fields).

Closes #10595