### PR TITLE
perf: fix 1mops replication

### DIFF
--- a/perf/lua/1mops_write.lua
+++ b/perf/lua/1mops_write.lua
@@ -169,7 +169,7 @@ print(string.format([[
 
 box.cfg{
     log_level = 0,
-    listen = 0,
+    listen = '127.0.0.1:0',
     read_only = false,
     memtx_memory = 2*1024*1024*1024,
     work_dir = test_dir,


### PR DESCRIPTION
Since the commit 4c8463cc498d ("core: bind to all addresses") we bind to all addresses so the test expectation that master is listen only on single address is broken. Let's fix it by taking the first address if there are many of them.

Closes #11843