### PR TITLE
box: mark replication role as system

### DIFF
--- a/changelogs/unreleased/gh-11848-box-replication-role-system.md
+++ b/changelogs/unreleased/gh-11848-box-replication-role-system.md
@@ -1,0 +1,6 @@
+## bugfix/box
+
+* Fixed an issue where the predefined `replication` role was not treated
+  as a system role and therefore could be dropped or modified. Now it is
+  properly protected like other system roles (`guest`, `admin`, `public`,
+  `super`) (gh-11848).

--- a/src/box/lua/space.cc
+++ b/src/box/lua/space.cc
@@ -1036,6 +1036,8 @@ box_lua_space_init(struct lua_State *L)
 	lua_setfield(L, -2, "GUEST_ID");
 	lua_pushnumber(L, PUBLIC);
 	lua_setfield(L, -2, "PUBLIC_ROLE_ID");
+	lua_pushnumber(L, REPLICATION);
+	lua_setfield(L, -2, "REPLICATION_ROLE_ID");
 	lua_pushnumber(L, SUPER);
 	lua_setfield(L, -2, "SUPER_ROLE_ID");
 	lua_pushnumber(L, BOX_INDEX_MAX);

--- a/src/box/user_def.h
+++ b/src/box/user_def.h
@@ -185,9 +185,10 @@ enum {
 	BOX_SYSTEM_USER_ID_MIN = 0,
 	GUEST = 0,
 	ADMIN =  1,
-	PUBLIC = 2, /* role */
-	SUPER = 31, /* role */
-	BOX_SYSTEM_USER_ID_MAX = PUBLIC
+	PUBLIC = 2,      /* role */
+	REPLICATION = 3, /* role */
+	SUPER = 31,      /* role */
+	BOX_SYSTEM_USER_ID_MAX = REPLICATION
 };
 
 #if defined(__cplusplus)

--- a/test/box/access.result
+++ b/test/box/access.result
@@ -915,6 +915,27 @@ delete_user(box.schema.PUBLIC_ROLE_ID)
 ---
 - true
 ...
+-- gh-11848 replication role must be treated as system
+box.schema.role.drop('replication')
+---
+- error: 'Failed to drop user or role ''replication'': the user or the role is a system'
+...
+box.schema.user.drop('replication')
+---
+- error: User 'replication' is not found
+...
+delete_user('replication')
+---
+- error: 'Failed to drop user or role ''replication'': the user or the role is a system'
+...
+delete_user(box.schema.REPLICATION_ROLE_ID)
+---
+- error: 'Failed to drop user or role ''replication'': the user or the role is a system'
+...
+#box.schema.role.info('replication') > 0
+---
+- true
+...
 box.schema.role.drop('super')
 ---
 - error: 'Failed to drop user or role ''super'': the user or the role is a system'

--- a/test/box/access.test.lua
+++ b/test/box/access.test.lua
@@ -375,6 +375,12 @@ box.schema.role.drop('public')
 delete_user('public')
 delete_user(box.schema.PUBLIC_ROLE_ID)
 #box.schema.role.info('public') > 0
+-- gh-11848 replication role must be treated as system
+box.schema.role.drop('replication')
+box.schema.user.drop('replication')
+delete_user('replication')
+delete_user(box.schema.REPLICATION_ROLE_ID)
+#box.schema.role.info('replication') > 0
 box.schema.role.drop('super')
 box.schema.user.drop('super')
 delete_user('super')


### PR DESCRIPTION
The `replication` role (id = 3) was predefined but not included in the system users/roles definitions. As a result, it was not protected from being dropped or modified, unlike `guest`, `admin`, `public`, and `super`.

This patch adds `replication` to the list of system roles and extends `BOX_SYSTEM_USER_ID_MAX` accordingly, so that the role is treated consistently as a system entity.

Follow-up to #1205, #3084.

Closes #11848

NO_DOC=already in doc