### PR TITLE
salad: reserve block before bps_tree_insert_first_elem

### DIFF
--- a/changelogs/unreleased/gh-11788-crash-in-bps_tree_memtx_tree_garbage_pop.md
+++ b/changelogs/unreleased/gh-11788-crash-in-bps_tree_memtx_tree_garbage_pop.md
@@ -1,0 +1,3 @@
+## bugfix/memtx
+
+* Fixed a crash on OOM on insertion in tree index of memtx engine (gh-11788).

--- a/test/unit/bps_tree.cc
+++ b/test/unit/bps_tree.cc
@@ -957,10 +957,45 @@ gh_11326_oom_on_insertion_test()
 	check_plan();
 }
 
+static void
+gh_11788_oom_on_first_insertion_test()
+{
+	plan(1);
+	header();
+
+	test tree;
+	test_view view;
+	type_t replaced;
+	struct test_iterator iterator;
+
+	test_create(&tree, 0, &allocator, NULL);
+	test_insert(&tree, 0, &replaced, NULL);
+	test_delete(&tree, 0, &replaced);
+	test_view_create(&view, &tree);
+
+	extent_alloc_failure = true;
+	fail_unless(test_insert(&tree, 0, &replaced, NULL) == 0);
+	debug_check(&tree);
+	fail_unless(test_size(&tree) == 1);
+	iterator = test_first(&tree);
+	type_t *v = test_iterator_get_elem(&tree, &iterator);
+	fail_unless(v != NULL && *v == 0);
+	fail_unless(test_iterator_next(&tree, &iterator) == false);
+	extent_alloc_failure = false;
+
+	test_view_destroy(&view);
+	test_destroy(&tree);
+
+	ok(true, "gh-11788: OOM on first insertion test");
+
+	footer();
+	check_plan();
+}
+
 int
 main(void)
 {
-	plan(13);
+	plan(14);
 	header();
 
 	matras_allocator_create(&allocator, BPS_TREE_EXTENT_SIZE,
@@ -984,6 +1019,7 @@ main(void)
 	matras_allocator_create(&allocator, BPS_TREE_EXTENT_SIZE,
 				extent_alloc, extent_free);
 	gh_11326_oom_on_insertion_test();
+	gh_11788_oom_on_first_insertion_test();
 	matras_allocator_destroy(&allocator);
 
 	footer();


### PR DESCRIPTION
The commit 51c56d9b3319 ("salad: reserve extents for matras_touch on BPS tree operations") already made the tree self-sufficient  - reserved blocks in garbage and extents for `matras_touch` calls prior to insertion and deletion. However, it didn't account for the addition of the first element to the tree, which creates the root leaf - this could also trigger `matras_touch` in `bps_tree_garbage_pop`.

However, it turns out there is no need to touch blocks before taking them out of the garbage. There is an invariant that blocks in the garbage are definitely not used by any read views. Although from the point of view of the matras, they require copying and could potentially have been needed by these read views. Let's just remove this `matras_touch` from `bps_tree_garbage_pop`. Also let's reserve a block in the garbage before calling `bps_tree_insert_first_elem` to bring the tree even closer to self-sufficiency.

Closes #11788

NO_DOC=bugfix
