### PR TITLE
box: increase max user count to 4096

### DIFF
--- a/changelogs/unreleased/gh-11337-new-max-user-count.md
+++ b/changelogs/unreleased/gh-11337-new-max-user-count.md
@@ -1,0 +1,3 @@
+## feature/box
+
+* Increased the user count limit to 4096 (gh-11337).

--- a/src/box/execute.c
+++ b/src/box/execute.c
@@ -71,7 +71,8 @@ access_check_sql(void)
 	access &= ~cr->universal_access;
 	if (access == 0)
 		return 0;
-	access &= ~universe.access_sql[cr->auth_token].effective;
+	access &= ~accesses_get(&universe.accesses_sql,
+				cr->auth_token).effective;
 	if (access == 0)
 		return 0;
 	struct user *user = user_find(cr->uid);

--- a/src/box/func.h
+++ b/src/box/func.h
@@ -72,7 +72,7 @@ struct func {
 	/**
 	 * Cached runtime access information.
 	 */
-	struct access access[BOX_USER_MAX];
+	struct accesses accesses;
 };
 
 /**

--- a/src/box/schema.h
+++ b/src/box/schema.h
@@ -194,33 +194,33 @@ extern struct rlist on_alter_func;
 
 /** Global grants to classes of objects. */
 struct entity_access {
-       struct access space[BOX_USER_MAX];
-       struct access function[BOX_USER_MAX];
-       struct access user[BOX_USER_MAX];
-       struct access role[BOX_USER_MAX];
-       struct access sequence[BOX_USER_MAX];
+	struct accesses space;
+	struct accesses function;
+	struct accesses user;
+	struct accesses role;
+	struct accesses sequence;
 };
 
 /** A single instance of the global entities. */
 extern struct entity_access entity_access;
 
-static inline
-struct access *
-entity_access_get(enum schema_object_type type)
+/* Get user access for an object class. */
+static inline struct access
+entity_access_get(enum schema_object_type type, auth_token_t auth_token)
 {
 	switch (type) {
 	case SC_SPACE:
-		return entity_access.space;
+		return accesses_get(&entity_access.space, auth_token);
 	case SC_FUNCTION:
-		return entity_access.function;
+		return accesses_get(&entity_access.function, auth_token);
 	case SC_USER:
-		return entity_access.user;
+		return accesses_get(&entity_access.user, auth_token);
 	case SC_ROLE:
-		return entity_access.role;
+		return accesses_get(&entity_access.role, auth_token);
 	case SC_SEQUENCE:
-		return entity_access.sequence;
+		return accesses_get(&entity_access.sequence, auth_token);
 	default:
-		return NULL;
+		return (struct access){0, 0};
 	}
 }
 

--- a/src/box/schema_def.h
+++ b/src/box/schema_def.h
@@ -48,7 +48,7 @@ enum {
 	FIELD_TYPE_NAME_MAX = 16,
 	GRANT_NAME_MAX = 16,
 	BOX_FIELD_MAX = INT32_MAX,
-	BOX_USER_MAX = 32,
+	BOX_USER_MAX = 4096,
 	/**
 	 * A fairly arbitrary limit which is still necessary
 	 * to keep tuple_format object small.

--- a/src/box/sequence.c
+++ b/src/box/sequence.c
@@ -273,13 +273,15 @@ access_check_sequence(struct sequence *seq)
 
 	user_access_t access = PRIV_U | PRIV_W;
 	user_access_t sequence_access = access & ~cr->universal_access;
-	sequence_access &= ~entity_access_get(SC_SEQUENCE)[cr->auth_token].effective;
+	sequence_access &=
+		~entity_access_get(SC_SEQUENCE, cr->auth_token).effective;
 	if (sequence_access &&
 	    /* Check for missing Usage access, ignore owner rights. */
 	    (sequence_access & PRIV_U ||
 	     /* Check for missing specific access, respect owner rights. */
 	     (seq->def->uid != cr->uid &&
-	      sequence_access & ~seq->access[cr->auth_token].effective))) {
+	      sequence_access & ~accesses_get(&seq->accesses,
+					      cr->auth_token).effective))) {
 
 		/* Access violation, report error. */
 		struct user *user = user_find(cr->uid);

--- a/src/box/sequence.h
+++ b/src/box/sequence.h
@@ -83,7 +83,7 @@ struct sequence {
 	/** Set if the sequence is automatically generated. */
 	bool is_generated;
 	/** Cached runtime access information. */
-	struct access access[BOX_USER_MAX];
+	struct accesses accesses;
 };
 
 static inline size_t

--- a/src/box/session.c
+++ b/src/box/session.c
@@ -517,7 +517,8 @@ access_check_session(struct user *user)
 	 * Can't use here access_check_universe
 	 * as current_user is not assigned yet
 	 */
-	if (!(universe.access[user->auth_token].effective & PRIV_S)) {
+	if (!(accesses_get(&universe.accesses, user->auth_token).effective &
+	      PRIV_S)) {
 		diag_set(AccessDeniedError, priv_name(PRIV_S),
 			 schema_object_name(SC_UNIVERSE), "",
 			 user->def->name);

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -118,14 +118,15 @@ access_check_space(struct space *space, user_access_t access)
 	 * Similarly to global access, subtract entity-level access
 	 * (access to all spaces) if it is present.
 	 */
-	space_access &= ~entity_access_get(SC_SPACE)[cr->auth_token].effective;
+	space_access &= ~entity_access_get(SC_SPACE, cr->auth_token).effective;
 
 	if (space_access &&
 	    /* Check for missing USAGE access, ignore owner rights. */
 	    (space_access & PRIV_U ||
 	     /* Check for missing specific access, respect owner rights. */
 	    (space->def->uid != cr->uid &&
-	     space_access & ~space->access[cr->auth_token].effective))) {
+	     space_access & ~accesses_get(&space->accesses,
+					  cr->auth_token).effective))) {
 		/*
 		 * Report access violation. Throw "no such user"
 		 * error if there is no user with this id.

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -188,7 +188,7 @@ struct space {
 	/** Virtual function table. */
 	const struct space_vtab *vtab;
 	/** Cached runtime access information. */
-	struct access access[BOX_USER_MAX];
+	struct accesses accesses;
 	/** Engine used by this space. */
 	struct engine *engine;
 	/** Triggers fired before executing a request. */

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -1639,7 +1639,7 @@ vdbe_emit_revoke_object(struct Parse *parser, const char *object_type,
 	 */
 	int key_reg = sqlGetTempRange(parser, 4);
 	bool had_grants = false;
-	for (uint8_t token = 0; token < BOX_USER_MAX; ++token) {
+	for (auth_token_t token = 0; token < BOX_USER_MAX; ++token) {
 		if (!accesses_get(accesses, token).granted)
 			continue;
 		had_grants = true;

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -1628,7 +1628,7 @@ sql_view_assign_cursors(struct Parse *parse, const char *view_stmt)
  */
 static void
 vdbe_emit_revoke_object(struct Parse *parser, const char *object_type,
-			uint32_t object_id, const struct access *access)
+			uint32_t object_id, const struct accesses *accesses)
 {
 	struct Vdbe *v = sqlGetVdbe(parser);
 	assert(v != NULL);
@@ -1640,7 +1640,7 @@ vdbe_emit_revoke_object(struct Parse *parser, const char *object_type,
 	int key_reg = sqlGetTempRange(parser, 4);
 	bool had_grants = false;
 	for (uint8_t token = 0; token < BOX_USER_MAX; ++token) {
-		if (!access[token].granted)
+		if (!accesses_get(accesses, token).granted)
 			continue;
 		had_grants = true;
 		const struct user *user = user_find_by_token(token);
@@ -1676,7 +1676,7 @@ sql_code_drop_table(struct Parse *parse_context, const struct space *space,
 	 * the table being dropped.
 	 */
 	vdbe_emit_revoke_object(parse_context, "space", space->def->id,
-				space->access);
+				&space->accesses);
 	/*
 	 * Drop all triggers associated with the table being
 	 * dropped. Code is generated to remove entries from
@@ -1723,7 +1723,7 @@ sql_code_drop_table(struct Parse *parse_context, const struct space *space,
 			/* Delete entries from _priv */
 		        vdbe_emit_revoke_object(parse_context, "sequence",
 						space->sequence->def->id,
-						space->sequence->access);
+						&space->sequence->accesses);
 			/* Delete entry by id from _sequence. */
 			sqlVdbeAddOp3(v, OP_MakeRecord, sequence_id_reg, 1,
 				      idx_rec_reg);

--- a/src/box/sql/func.c
+++ b/src/box/sql/func.c
@@ -2348,7 +2348,7 @@ sql_built_in_functions_cache_init(void)
 		rlist_create(&func->base.func_cache_pin_list);
 		func->base.vtab = &func_sql_builtin_vtab;
 		credentials_create_empty(&func->base.owner_credentials);
-		memset(func->base.access, 0, sizeof(func->base.access));
+		accesses_init(&func->base.accesses);
 
 		func->param_list = desc->argt;
 		func->flags = dict->flags;

--- a/src/box/sysview.c
+++ b/src/box/sysview.c
@@ -282,9 +282,9 @@ vspace_filter(struct space *source, struct tuple *tuple)
 	if (PRIV_WRDA & cr->universal_access)
 		return true;
 	/* Allow access for a user with space privileges. */
-	if (PRIV_WRDA & entity_access_get(SC_SPACE)[cr->auth_token].effective)
+	if (PRIV_WRDA & entity_access_get(SC_SPACE, cr->auth_token).effective)
 		return true;
-	if (PRIV_R & source->access[cr->auth_token].effective)
+	if (PRIV_R & accesses_get(&source->accesses, cr->auth_token).effective)
 		return true; /* read access to _space space */
 	uint32_t space_id;
 	if (tuple_field_u32(tuple, BOX_SPACE_FIELD_ID, &space_id) != 0)
@@ -292,7 +292,8 @@ vspace_filter(struct space *source, struct tuple *tuple)
 	struct space *space = space_cache_find(space_id);
 	if (space == NULL)
 		return false;
-	user_access_t effective = space->access[cr->auth_token].effective;
+	user_access_t effective =
+		accesses_get(&space->accesses, cr->auth_token).effective;
 	/*
 	 * Allow access for space owners and users with any
 	 * privilege for the space.
@@ -311,7 +312,7 @@ vuser_filter(struct space *source, struct tuple *tuple)
 	 */
 	if (PRIV_WRDA & cr->universal_access)
 		return true;
-	if (PRIV_R & source->access[cr->auth_token].effective)
+	if (PRIV_R & accesses_get(&source->accesses, cr->auth_token).effective)
 		return true; /* read access to _user space */
 
 	uint32_t uid;
@@ -343,7 +344,7 @@ vpriv_filter(struct space *source, struct tuple *tuple)
 	 */
 	if (PRIV_WRDA & cr->universal_access)
 		return true;
-	if (PRIV_R & source->access[cr->auth_token].effective)
+	if (PRIV_R & accesses_get(&source->accesses, cr->auth_token).effective)
 		return true; /* read access to _priv space */
 
 	uint32_t grantor_id;
@@ -368,9 +369,9 @@ vfunc_filter(struct space *source, struct tuple *tuple)
 		return true;
 	/* Allow access for a user with function privileges. */
 	if ((PRIV_WRDA | PRIV_X) &
-	    entity_access_get(SC_FUNCTION)[cr->auth_token].effective)
+	    entity_access_get(SC_FUNCTION, cr->auth_token).effective)
 		return true;
-	if (PRIV_R & source->access[cr->auth_token].effective)
+	if (PRIV_R & accesses_get(&source->accesses, cr->auth_token).effective)
 		return true; /* read access to _func space */
 
 	uint32_t name_len;
@@ -380,7 +381,8 @@ vfunc_filter(struct space *source, struct tuple *tuple)
 		return false;
 	struct func *func = func_by_name(name, name_len);
 	assert(func != NULL);
-	user_access_t effective = func->access[cr->auth_token].effective;
+	user_access_t effective =
+		accesses_get(&func->accesses, cr->auth_token).effective;
 	return func->def->uid == cr->uid ||
 	       ((PRIV_WRDA | PRIV_X) & effective);
 }
@@ -397,9 +399,9 @@ vsequence_filter(struct space *source, struct tuple *tuple)
 		return true;
 	/* Allow access for a user with sequence privileges. */
 	if ((PRIV_WRDA | PRIV_X) &
-	    entity_access_get(SC_SEQUENCE)[cr->auth_token].effective)
+	    entity_access_get(SC_SEQUENCE, cr->auth_token).effective)
 		return true;
-	if (PRIV_R & source->access[cr->auth_token].effective)
+	if (PRIV_R & accesses_get(&source->accesses, cr->auth_token).effective)
 		return true; /* read access to _sequence space */
 
 	uint32_t id;
@@ -408,7 +410,8 @@ vsequence_filter(struct space *source, struct tuple *tuple)
 	struct sequence *sequence = sequence_by_id(id);
 	if (sequence == NULL)
 		return false;
-	user_access_t effective = sequence->access[cr->auth_token].effective;
+	user_access_t effective =
+		accesses_get(&sequence->accesses, cr->auth_token).effective;
 	return sequence->def->uid == cr->uid ||
 	       ((PRIV_WRDA | PRIV_X) & effective);
 }

--- a/src/box/user.cc
+++ b/src/box/user.cc
@@ -230,28 +230,30 @@ struct access_lua_call_node {
 	/** Length of the name string. */
 	uint32_t name_len;
 	/** Cached runtime access information. */
-	struct access access[BOX_USER_MAX];
+	struct accesses accesses;
 };
 
-struct access *
-access_lua_call_find(const char *name, uint32_t name_len)
+bool
+access_lua_call_find(const char *name, uint32_t name_len,
+		     auth_token_t auth_token, struct access *result)
 {
 	struct mh_strnptr_t *h = access_lua_call_registry;
 	mh_int_t i = mh_strnptr_find_str(h, name, name_len);
 	if (i != mh_end(h)) {
 		struct access_lua_call_node *node =
 			(typeof(node))mh_strnptr_node(h, i)->val;
-		return node->access;
+		*result = accesses_get(&node->accesses, auth_token);
+		return true;
 	}
-	return NULL;
+	return false;
 }
 
 /**
  * Returns cached runtime access information for the given Lua function name.
  * Creates one if it doesn't exist.
  */
-static struct access *
-access_lua_call_find_or_create(const char *name, uint32_t name_len)
+static struct accesses *
+accesses_lua_call_find_or_create(const char *name, uint32_t name_len)
 {
 	uint32_t name_hash = mh_strn_hash(name, name_len);
 	struct mh_strnptr_t *h = access_lua_call_registry;
@@ -260,7 +262,7 @@ access_lua_call_find_or_create(const char *name, uint32_t name_len)
 	if (i != mh_end(h)) {
 		struct access_lua_call_node *node =
 			(typeof(node))mh_strnptr_node(h, i)->val;
-		return node->access;
+		return &node->accesses;
 	}
 	struct access_lua_call_node *node;
 	grp_alloc all = grp_alloc_initializer();
@@ -270,11 +272,11 @@ access_lua_call_find_or_create(const char *name, uint32_t name_len)
 	node = (typeof(node))grp_alloc_create_data(&all, sizeof(*node));
 	node->name = grp_alloc_create_str(&all, name, name_len);
 	node->name_len = name_len;
-	memset(node->access, 0, sizeof(node->access));
+	accesses_init(&node->accesses);
 	assert(grp_alloc_size(&all) == 0);
 	mh_strnptr_node_t n = {node->name, name_len, name_hash, node};
 	mh_strnptr_put(h, &n, NULL, NULL);
-	return node->access;
+	return &node->accesses;
 }
 
 /**
@@ -282,16 +284,16 @@ access_lua_call_find_or_create(const char *name, uint32_t name_len)
  * (i.e. grants no access to any user).
  */
 static void
-access_lua_call_delete_if_empty(struct access *object)
+access_lua_call_delete_if_empty(struct accesses *object)
 {
 	for (int i = 0; i < BOX_USER_MAX; ++i) {
-		struct access *access = &object[i];
-		if (access->granted != 0 || access->effective != 0)
+		struct access access = accesses_get(object, i);
+		if (access.granted != 0 || access.effective != 0)
 			return;
 	}
 	struct mh_strnptr_t *h = access_lua_call_registry;
 	struct access_lua_call_node *node = (typeof(node))(
-		(char *)object - offsetof(typeof(*node), access));
+		(char *)object - offsetof(typeof(*node), accesses));
 	mh_int_t i = mh_strnptr_find_str(h, node->name, node->name_len);
 	assert(i != mh_end(h));
 	assert(mh_strnptr_node(h, i)->val == node);
@@ -300,72 +302,75 @@ access_lua_call_delete_if_empty(struct access *object)
 }
 
 /**
- * Find the corresponding access structure for the given privilege.
- * Must be released with access_put() after use.
+ * Find the corresponding access structure for the given privilege. If the
+ * access is entity-specific and the entity does not exist - sets `exists`
+ * to false (true othervise).
+ *
+ * Must be released with priv_access_put() after use.
  */
-static struct access *
-access_get(const struct priv_def *priv)
+static struct accesses *
+priv_accesses_get(const struct priv_def *priv)
 {
 	switch (priv->object_type) {
 	case SC_UNIVERSE:
-		return universe.access;
+		return &universe.accesses;
 	case SC_LUA_CALL:
 		if (priv->is_entity_access)
-			return universe.access_lua_call;
+			return &universe.accesses_lua_call;
 		/*
 		 * lua_call objects aren't persisted in the database so
 		 * we create an access struct on demand and delete it in
-		 * access_put() if it's empty.
+		 * priv_access_put() if it's empty.
 		 */
-		return access_lua_call_find_or_create(priv->object_name,
-						      priv->object_name_len);
+		return accesses_lua_call_find_or_create(priv->object_name,
+							priv->object_name_len);
 	case SC_LUA_EVAL:
-		return universe.access_lua_eval;
+		return &universe.accesses_lua_eval;
 	case SC_SQL:
-		return universe.access_sql;
+		return &universe.accesses_sql;
 	case SC_SPACE:
 	{
 		if (priv->is_entity_access)
-			return entity_access.space;
+			return &entity_access.space;
 		struct space *space = space_by_id(priv->object_id);
-		return space != NULL ? space->access : NULL;
+		return space != NULL ? &space->accesses : NULL;
 	}
 	case SC_FUNCTION:
 	{
 		if (priv->is_entity_access)
-			return entity_access.function;
+			return &entity_access.function;
 		struct func *func = func_by_id(priv->object_id);
-		return func != NULL ? func->access : NULL;
+		return func != NULL ? &func->accesses : NULL;
 	}
 	case SC_USER:
 	{
 		if (priv->is_entity_access)
-			return entity_access.user;
+			return &entity_access.user;
 		struct user *user = user_by_id(priv->object_id);
-		return user != NULL ? user->access : NULL;
+		return user != NULL ? &user->accesses : NULL;
 	}
 	case SC_ROLE:
 	{
 		if (priv->is_entity_access)
-			return entity_access.role;
+			return &entity_access.role;
 		struct user *role = user_by_id(priv->object_id);
-		return role != NULL ? role->access : NULL;
+		return role != NULL ? &role->accesses : NULL;
 	}
 	case SC_SEQUENCE:
 	{
 		if (priv->is_entity_access)
-			return entity_access.sequence;
+			return &entity_access.sequence;
 		struct sequence *seq = sequence_by_id(priv->object_id);
-		return seq != NULL ? seq->access : NULL;
+		return seq != NULL ? &seq->accesses : NULL;
 	}
 	default:
 		return NULL;
 	}
 }
 
-/** Releases an object returned by access_get(). */
+/** Releases an object returned by priv_accesses_get(). */
 static void
-access_put(const struct priv_def *priv, struct access *object)
+priv_access_put(const struct priv_def *priv, struct accesses *object)
 {
 	switch (priv->object_type) {
 	case SC_LUA_CALL:
@@ -392,13 +397,14 @@ user_set_effective_access(struct user *user)
 	privset_ifirst(&user->privs, &it);
 	struct priv_def *priv;
 	while ((priv = privset_inext(&it)) != NULL) {
-		struct access *object = access_get(priv);
-		 /* Protect against a concurrent drop. */
+		struct accesses *object = priv_accesses_get(priv);
+		/* Protect against a concurrent drop. */
 		if (object == NULL)
 			continue;
-		struct access *access = &object[user->auth_token];
-		access->effective = access->granted | priv->access;
-		access_put(priv, object);
+		struct access access = accesses_get(object, user->auth_token);
+		access.effective = access.granted | priv->access;
+		accesses_set(object, user->auth_token, access);
+		priv_access_put(priv, object);
 	}
 }
 
@@ -520,7 +526,8 @@ next_tuple:
 	user_set_effective_access(user);
 	user->is_dirty = false;
 	struct credentials *creds;
-	user_access_t new_access = universe.access[user->auth_token].effective;
+	user_access_t new_access =
+		accesses_get(&universe.accesses, user->auth_token).effective;
 	rlist_foreach_entry(creds, &user->credentials_list, in_user)
 		creds->universal_access = new_access;
 	return 0;
@@ -723,7 +730,9 @@ user_cache_init(void)
 	 * When user_cache_init() is called, admin user access is
 	 * not loaded yet (is 0), force global access.
 	 */
-	universe.access[ADMIN].effective = USER_ACCESS_FULL;
+	struct access access = accesses_get(&universe.accesses, ADMIN);
+	access.effective = USER_ACCESS_FULL;
+	accesses_set(&universe.accesses, ADMIN, access);
 	/* ADMIN is both the auth token and user id for 'admin' user. */
 	assert(user->def->uid == ADMIN && user->auth_token == ADMIN);
 }
@@ -945,19 +954,20 @@ int
 priv_grant(struct user *grantee, struct priv_def *priv,
 	   struct txn_stmt *rolled_back_stmt)
 {
-	struct access *object = access_get(priv);
+	struct accesses *object = priv_accesses_get(priv);
 	if (object == NULL)
 		return 0;
 	if (grantee->auth_token == ADMIN && priv->object_type == SC_UNIVERSE &&
 	    priv->access != USER_ACCESS_FULL) {
 		diag_set(ClientError, ER_GRANT,
 			 "can't revoke universe from the admin user");
-		access_put(priv, object);
+		priv_access_put(priv, object);
 		return -1;
 	}
-	struct access *access = &object[grantee->auth_token];
-	access->granted = priv->access;
-	access_put(priv, object);
+	struct access access = accesses_get(object, grantee->auth_token);
+	access.granted = priv->access;
+	accesses_set(object, grantee->auth_token, access);
+	priv_access_put(priv, object);
 	if (rebuild_effective_grants(grantee, rolled_back_stmt) != 0)
 		return -1;
 	return 0;
@@ -969,7 +979,8 @@ void
 credentials_create(struct credentials *cr, struct user *user)
 {
 	cr->auth_token = user->auth_token;
-	cr->universal_access = universe.access[user->auth_token].effective;
+	cr->universal_access =
+		accesses_get(&universe.accesses, user->auth_token).effective;
 	cr->uid = user->def->uid;
 	rlist_add_entry(&user->credentials_list, cr, in_user);
 }

--- a/src/box/user.h
+++ b/src/box/user.h
@@ -42,13 +42,13 @@ extern "C" {
 /** Global grants. */
 struct universe {
 	/** Global privileges this user has on the universe. */
-	struct access access[BOX_USER_MAX];
+	struct accesses accesses;
 	/** Privileges to execute any global Lua function with IPROTO_CALL. */
-	struct access access_lua_call[BOX_USER_MAX];
+	struct accesses accesses_lua_call;
 	/** Privileges to execute any Lua expression with IPROTO_EVAL. */
-	struct access access_lua_eval[BOX_USER_MAX];
+	struct accesses accesses_lua_eval;
 	/** Privileges to execute SQL requests with IPROTO_EXECUTE. */
-	struct access access_sql[BOX_USER_MAX];
+	struct accesses accesses_sql;
 };
 
 /** A single instance of the universe. */
@@ -102,7 +102,7 @@ struct user
 	 */
 	struct rlist credentials_list;
 	/** Cached runtime access imformation. */
-	struct access access[BOX_USER_MAX];
+	struct accesses accesses;
 };
 
 /** Find user by id. */
@@ -164,8 +164,9 @@ extern struct user *guest_user, *admin_user;
  * Returns cached runtime access information for the given Lua function name.
  * If it doesn't exist, returns NULL.
  */
-struct access *
-access_lua_call_find(const char *name, uint32_t name_len);
+bool
+access_lua_call_find(const char *name, uint32_t name_len,
+		     auth_token_t auth_token, struct access *result);
 
 /**
  * Check if a role is granted to a user or role with the given auth_token.

--- a/src/box/user.h
+++ b/src/box/user.h
@@ -84,7 +84,7 @@ struct user
 	 * An id in privileges array to quickly find a
 	 * respective privilege.
 	 */
-	uint8_t auth_token;
+	auth_token_t auth_token;
 	/** List of users or roles this role has been granted to */
 	struct user_map users;
 	/** List of roles granted to this role or user. */
@@ -118,7 +118,7 @@ user_find(uint32_t uid);
 
 /* Find a user by authentication token. */
 struct user *
-user_find_by_token(uint8_t auth_token);
+user_find_by_token(auth_token_t auth_token);
 
 /** Create a cache of user's privileges in @a cr. */
 void
@@ -172,7 +172,7 @@ access_lua_call_find(const char *name, uint32_t name_len,
  * Check if a role is granted to a user or role with the given auth_token.
  */
 bool
-role_is_granted(struct user *role, uint8_t auth_token);
+role_is_granted(struct user *role, auth_token_t auth_token);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/box/user_def.c
+++ b/src/box/user_def.c
@@ -42,12 +42,15 @@ priv_name(user_access_t access)
 void
 accesses_init(struct accesses *accesses)
 {
-	memset(accesses->access, 0, sizeof(accesses->access));
+	accesses->count = 0;
+	accesses->access = NULL;
 }
 
 struct access
 accesses_get(const struct accesses *accesses, auth_token_t auth_token)
 {
+	if (auth_token >= accesses->count)
+		return (struct access){0, 0}; /* Empty. */
 	return accesses->access[auth_token];
 }
 
@@ -55,6 +58,16 @@ void
 accesses_set(struct accesses *accesses, auth_token_t auth_token,
 	     struct access access)
 {
+	if (auth_token >= accesses->count) {
+		size_t old_count = accesses->count;
+		size_t new_count = auth_token + 1;
+		size_t diff = new_count - old_count;
+		accesses->count = new_count;
+		accesses->access = xrealloc(accesses->access,
+					    sizeof(access) * new_count);
+		/* Reset the new memory. */
+		memset(accesses->access + old_count, 0, sizeof(access) * diff);
+	}
 	accesses->access[auth_token] = access;
 }
 

--- a/src/box/user_def.c
+++ b/src/box/user_def.c
@@ -39,6 +39,25 @@ priv_name(user_access_t access)
 	return "Any";
 }
 
+void
+accesses_init(struct accesses *accesses)
+{
+	memset(accesses->access, 0, sizeof(accesses->access));
+}
+
+struct access
+accesses_get(const struct accesses *accesses, auth_token_t auth_token)
+{
+	return accesses->access[auth_token];
+}
+
+void
+accesses_set(struct accesses *accesses, auth_token_t auth_token,
+	     struct access access)
+{
+	accesses->access[auth_token] = access;
+}
+
 struct user_def *
 user_def_new(uint32_t uid, uint32_t owner, enum schema_object_type type,
 	     const char *name, uint32_t name_len)

--- a/src/box/user_def.h
+++ b/src/box/user_def.h
@@ -29,7 +29,7 @@ typedef uint64_t auth_token_t;
  */
 struct credentials {
 	/** A look up key to quickly find session user. */
-	uint8_t auth_token;
+	auth_token_t auth_token;
 	/**
 	 * Cached global grants, to avoid an extra look up
 	 * when checking global grants.
@@ -142,7 +142,10 @@ struct access {
  * The collection of accesses granted to users.
  */
 struct accesses {
-	struct access access[BOX_USER_MAX];
+	/* Accesses of users that had an access defined. */
+	struct access *access;
+	/* The size of the array above. */
+	size_t count;
 };
 
 /**

--- a/src/box/user_def.h
+++ b/src/box/user_def.h
@@ -19,6 +19,8 @@ extern "C" {
 struct authenticator;
 
 typedef uint16_t user_access_t;
+typedef uint64_t auth_token_t;
+
 /**
  * Effective session user. A cache of user data
  * and access stored in session and fiber local storage.
@@ -135,6 +137,32 @@ struct access {
 	 */
 	user_access_t effective;
 };
+
+/**
+ * The collection of accesses granted to users.
+ */
+struct accesses {
+	struct access access[BOX_USER_MAX];
+};
+
+/**
+ * Initialize an empty access rights collection.
+ */
+void
+accesses_init(struct accesses *accesses);
+
+/**
+ * Get user access rights by auth_token.
+ */
+struct access
+accesses_get(const struct accesses *accesses, auth_token_t auth_token);
+
+/**
+ * Set user access rights by auth_token.
+ */
+void
+accesses_set(struct accesses *accesses, auth_token_t auth_token,
+	     struct access access);
 
 /**
  * A cache entry for an existing user. Entries for all existing

--- a/test/box/access.result
+++ b/test/box/access.result
@@ -100,7 +100,7 @@ end;
 ...
 usermax();
 ---
-- error: 'A limit on the total number of users has been reached: 32'
+- error: 'A limit on the total number of users has been reached: 4096'
 ...
 function usermax()
     local i = 1
@@ -113,7 +113,7 @@ end;
 ...
 usermax();
 ---
-- error: User 'user27' is not found
+- error: User 'user4091' is not found
 ...
 test_run:cmd("setopt delimiter ''");
 ---


### PR DESCRIPTION
We used to be able to have at most 32 users introduced in Tarantool.
Let's increase the limit so one can have up to 4k users. The max user
count is used to maintain static arrays of access rights, so let's
make these dynamic to reduce the memory waste.

Closes #11337