### PR TITLE
Extend alerts public API

### DIFF
--- a/changelogs/unreleased/gh-11894-alerts-read-api.md
+++ b/changelogs/unreleased/gh-11894-alerts-read-api.md
@@ -1,0 +1,3 @@
+## feature/config
+
+* Introduced public API for reading alerts from namespaces (gh-11894).

--- a/changelogs/unreleased/gh-11895-system-alerts-read-api.md
+++ b/changelogs/unreleased/gh-11895-system-alerts-read-api.md
@@ -1,0 +1,3 @@
+## feature/config
+
+* Introduced public API for reading system alerts (gh-11895).

--- a/src/box/lua/config/utils/aboard.lua
+++ b/src/box/lua/config/utils/aboard.lua
@@ -3,6 +3,25 @@
 local datetime = require('datetime')
 local log = require('internal.config.utils.log')
 
+-- Creates a shallow copy of the table `t` without fields that start with
+-- an underscore character.
+local function copy_public_fields(t)
+    if t == nil then
+        return nil
+    end
+
+    assert(type(t) == 'table')
+
+    local res = {}
+    for k, v in pairs(t) do
+        if not k:startswith('_') then
+            res[k] = v
+        end
+    end
+
+    return res
+end
+
 -- Set an alert.
 --
 -- Optional `opts.key` declares an unique identifier of the alert.
@@ -118,13 +137,7 @@ local function aboard_alerts(self)
     -- Don't return alert keys.
     local alerts = {}
     for _, alert in pairs(self._alerts) do
-        -- Don't show fields that start from an underscore.
-        local serialized = {}
-        for k, v in pairs(alert) do
-            if not k:startswith('_') then
-                serialized[k] = v
-            end
-        end
+        local serialized = copy_public_fields(alert)
         table.insert(alerts, serialized)
     end
     -- Sort by timestamps.
@@ -183,15 +196,9 @@ local function process_alert(namespace, alert)
     assert(alert.type == nil or alert.type == 'warn',
            'alert.type must be nil or "warn"')
 
-    local a = table.copy(alert)
+    local a = copy_public_fields(alert)
+
     a.type = 'warn'
-
-    for k, _ in pairs(a) do
-        if k:startswith('_') then
-            a[k] = nil
-        end
-    end
-
     a._namespace = namespace._name
 
     return a
@@ -209,6 +216,51 @@ function namespace_methods.add(self, alert)
     namespace_selfcheck(self, 'add')
     local a = process_alert(self, alert)
     self._aboard:set(a)
+end
+
+function namespace_methods.get(self, key)
+    namespace_selfcheck(self, 'get')
+    assert(type(key) == 'string', 'alert key must be a string')
+    local alert = self._aboard:get(process_key(self, key))
+
+    return copy_public_fields(alert)
+end
+
+function namespace_methods.alerts(self)
+    namespace_selfcheck(self, 'alerts')
+    local alerts = {}
+
+    local next_idx = 1
+    for key, alert in pairs(self._aboard._alerts) do
+        if alert._namespace == self._name then
+            if type(key) == 'string' then
+                -- Remove the namespace prefix from the key.
+                local prefix = self._name .. ':'
+                assert(key:startswith(prefix))
+                key = key:sub(#prefix + 1)
+            else
+                key = next_idx
+                next_idx = next_idx + 1
+            end
+
+            alerts[key] = copy_public_fields(alert)
+        end
+    end
+
+    return alerts
+end
+
+namespace_methods.count = function(self)
+    namespace_selfcheck(self, 'count')
+
+    local count = 0
+    for _, alert in pairs(self._aboard._alerts) do
+        if alert._namespace == self._name then
+            count = count + 1
+        end
+    end
+
+    return count
 end
 
 function namespace_methods.set(self, key, alert)

--- a/test/config-luatest/alerts_test.lua
+++ b/test/config-luatest/alerts_test.lua
@@ -1,3 +1,5 @@
+-- tags: parallel
+
 local t = require('luatest')
 local helpers = require('test.config-luatest.helpers')
 
@@ -16,10 +18,14 @@ g.test_alert_add_clear = function(g)
         }
 
         alerts:add(alert)
+
+        t.assert_equals(alerts:count(), 1)
+        t.assert_covers(alerts:alerts()[1], alert)
         t.assert_equals(#box.info.config.alerts, 1)
-        t.assert_items_include(box.info.config.alerts[1], alert)
+        t.assert_covers(box.info.config.alerts[1], alert)
 
         alerts:clear()
+        t.assert_equals(alerts:count(), 0)
         t.assert_equals(#box.info.config.alerts, 0)
     end
 
@@ -33,6 +39,7 @@ end
 g.test_alert_set_reset_unset_clear = function(g)
     local verify = function()
         local alerts = require('config'):new_alerts_namespace('my_alerts')
+        t.assert_equals(alerts:count(), 0)
         t.assert_equals(#box.info.config.alerts, 0)
 
         local key_1 = 'my_key_1'
@@ -54,32 +61,69 @@ g.test_alert_set_reset_unset_clear = function(g)
         }
 
         alerts:set(key_1, alert_1)
+        t.assert_covers(alerts:get(key_1), alert_1)
+        t.assert_equals(alerts:count(), 1)
+        t.assert_covers(alerts:alerts()[key_1], alert_1)
         t.assert_equals(#box.info.config.alerts, 1)
-        t.assert_items_include(box.info.config.alerts[1], alert_1)
+        t.assert_covers(box.info.config.alerts[1], alert_1)
+
+        -- Check that allert doesn't contain private fields.
+        for k, _ in pairs(alerts:get(key_1)) do
+            t.assert_not_equals(k[1], '_')
+        end
+        for k, _ in pairs(alerts:alerts()[key_1]) do
+            t.assert_not_equals(k[1], '_')
+        end
+        for k, _ in pairs(box.info.config.alerts[1]) do
+            t.assert_not_equals(k[1], '_')
+        end
 
         alerts:set(key_2, alert_2)
+        t.assert_covers(alerts:get(key_1), alert_1)
+        t.assert_covers(alerts:get(key_2), alert_2)
+        t.assert_equals(alerts:count(), 2)
+        t.assert_covers(alerts:alerts()[key_1], alert_1)
+        t.assert_covers(alerts:alerts()[key_2], alert_2)
         t.assert_equals(#box.info.config.alerts, 2)
-        t.assert_items_include(box.info.config.alerts[1], alert_1)
-        t.assert_items_include(box.info.config.alerts[2], alert_2)
+        t.assert_covers(box.info.config.alerts[1], alert_1)
+        t.assert_covers(box.info.config.alerts[2], alert_2)
 
         alerts:add(alert_2)
+        t.assert_covers(alerts:get(key_1), alert_1)
+        t.assert_covers(alerts:get(key_2), alert_2)
+        t.assert_equals(alerts:count(), 3)
+        t.assert_covers(alerts:alerts()[key_1], alert_1)
+        t.assert_covers(alerts:alerts()[key_2], alert_2)
+        t.assert_covers(alerts:alerts()[1], alert_2)
         t.assert_equals(#box.info.config.alerts, 3)
-        t.assert_items_include(box.info.config.alerts[1], alert_1)
-        t.assert_items_include(box.info.config.alerts[2], alert_2)
-        t.assert_items_include(box.info.config.alerts[3], alert_2)
+        t.assert_covers(box.info.config.alerts[1], alert_1)
+        t.assert_covers(box.info.config.alerts[2], alert_2)
+        t.assert_covers(box.info.config.alerts[3], alert_2)
 
         alerts:set(key_1, alert_3)
+        t.assert_covers(alerts:get(key_1), alert_3)
+        t.assert_covers(alerts:get(key_2), alert_2)
+        t.assert_equals(alerts:count(), 3)
+        t.assert_covers(alerts:alerts()[key_1], alert_3)
+        t.assert_covers(alerts:alerts()[key_2], alert_2)
+        t.assert_covers(alerts:alerts()[1], alert_2)
         t.assert_equals(#box.info.config.alerts, 3)
-        t.assert_items_include(box.info.config.alerts[1], alert_2)
-        t.assert_items_include(box.info.config.alerts[2], alert_2)
-        t.assert_items_include(box.info.config.alerts[3], alert_3)
+        t.assert_covers(box.info.config.alerts[1], alert_2)
+        t.assert_covers(box.info.config.alerts[2], alert_2)
+        t.assert_covers(box.info.config.alerts[3], alert_3)
 
         alerts:unset(key_2)
+        t.assert_covers(alerts:get(key_1), alert_3)
+        t.assert_equals(alerts:get(key_2), nil)
+        t.assert_equals(alerts:count(), 2)
+        t.assert_covers(alerts:alerts()[key_1], alert_3)
+        t.assert_covers(alerts:alerts()[1], alert_2)
         t.assert_equals(#box.info.config.alerts, 2)
-        t.assert_items_include(box.info.config.alerts[1], alert_2)
-        t.assert_items_include(box.info.config.alerts[2], alert_3)
+        t.assert_covers(box.info.config.alerts[1], alert_2)
+        t.assert_covers(box.info.config.alerts[2], alert_3)
 
         alerts:clear()
+        t.assert_equals(alerts:count(), 0)
         t.assert_equals(#box.info.config.alerts, 0)
     end
 
@@ -92,6 +136,7 @@ end
 g.test_alert_multiple_add_clear = function(g)
     local verify = function()
         local alerts = require('config'):new_alerts_namespace('my_alerts')
+        t.assert_equals(alerts:count(), 0)
         t.assert_equals(#box.info.config.alerts, 0)
 
         local alert_1 = {
@@ -105,15 +150,21 @@ g.test_alert_multiple_add_clear = function(g)
         }
 
         alerts:add(alert_1)
+        t.assert_equals(alerts:count(), 1)
+        t.assert_covers(alerts:alerts()[1], alert_1)
         t.assert_equals(#box.info.config.alerts, 1)
-        t.assert_items_include(box.info.config.alerts[1], alert_1)
+        t.assert_covers(box.info.config.alerts[1], alert_1)
 
         alerts:add(alert_2)
+        t.assert_equals(alerts:count(), 2)
+        t.assert_covers(alerts:alerts()[1], alert_1)
+        t.assert_covers(alerts:alerts()[2], alert_2)
         t.assert_equals(#box.info.config.alerts, 2)
-        t.assert_items_include(box.info.config.alerts[1], alert_1)
-        t.assert_items_include(box.info.config.alerts[2], alert_2)
+        t.assert_covers(box.info.config.alerts[1], alert_1)
+        t.assert_covers(box.info.config.alerts[2], alert_2)
 
         alerts:clear()
+        t.assert_equals(alerts:count(), 0)
         t.assert_equals(#box.info.config.alerts, 0)
     end
 
@@ -127,6 +178,8 @@ g.test_multiple_alerts_namespaces = function(g)
     local verify = function()
         local alerts_1 = require('config'):new_alerts_namespace('my_alerts_1')
         local alerts_2 = require('config'):new_alerts_namespace('my_alerts_2')
+        t.assert_equals(alerts_1:count(), 0)
+        t.assert_equals(alerts_2:count(), 0)
         t.assert_equals(#box.info.config.alerts, 0)
 
         local alert_1 = {
@@ -139,19 +192,31 @@ g.test_multiple_alerts_namespaces = function(g)
         }
 
         alerts_1:add(alert_1)
+        t.assert_equals(alerts_1:count(), 1)
+        t.assert_equals(alerts_2:count(), 0)
+        t.assert_covers(alerts_1:alerts()[1], alert_1)
         t.assert_equals(#box.info.config.alerts, 1)
-        t.assert_items_include(box.info.config.alerts[1], alert_1)
+        t.assert_covers(box.info.config.alerts[1], alert_1)
 
         alerts_2:add(alert_2)
+        t.assert_equals(alerts_1:count(), 1)
+        t.assert_equals(alerts_2:count(), 1)
+        t.assert_covers(alerts_1:alerts()[1], alert_1)
+        t.assert_covers(alerts_2:alerts()[1], alert_2)
         t.assert_equals(#box.info.config.alerts, 2)
-        t.assert_items_include(box.info.config.alerts[1], alert_1)
-        t.assert_items_include(box.info.config.alerts[2], alert_2)
+        t.assert_covers(box.info.config.alerts[1], alert_1)
+        t.assert_covers(box.info.config.alerts[2], alert_2)
 
         alerts_1:clear()
+        t.assert_equals(alerts_1:count(), 0)
+        t.assert_equals(alerts_2:count(), 1)
+        t.assert_covers(alerts_2:alerts()[1], alert_2)
         t.assert_equals(#box.info.config.alerts, 1)
-        t.assert_items_include(box.info.config.alerts[1], alert_2)
+        t.assert_covers(box.info.config.alerts[1], alert_2)
 
         alerts_2:clear()
+        t.assert_equals(alerts_1:count(), 0)
+        t.assert_equals(alerts_2:count(), 0)
         t.assert_equals(#box.info.config.alerts, 0)
     end
 
@@ -165,6 +230,8 @@ g.test_alerts_namespaces_with_same_name = function(g)
     local verify = function()
         local alerts_1 = require('config'):new_alerts_namespace('my_alerts')
         local alerts_2 = require('config'):new_alerts_namespace('my_alerts')
+        t.assert_equals(alerts_1:count(), 0)
+        t.assert_equals(alerts_2:count(), 0)
         t.assert_equals(#box.info.config.alerts, 0)
 
         local alert = {
@@ -173,10 +240,16 @@ g.test_alerts_namespaces_with_same_name = function(g)
         }
 
         alerts_1:add(alert)
+        t.assert_equals(alerts_1:count(), 1)
+        t.assert_equals(alerts_2:count(), 1)
         t.assert_equals(#box.info.config.alerts, 1)
-        t.assert_items_include(box.info.config.alerts[1], alert)
+        t.assert_covers(alerts_1:alerts()[1], alert)
+        t.assert_covers(alerts_2:alerts()[1], alert)
+        t.assert_covers(box.info.config.alerts[1], alert)
 
         alerts_2:clear()
+        t.assert_equals(alerts_1:count(), 0)
+        t.assert_equals(alerts_2:count(), 0)
         t.assert_equals(#box.info.config.alerts, 0)
     end
 
@@ -190,6 +263,7 @@ g.test_alerts_cleaned_by_aboard = function(g)
     local verify = function()
         local config = require('config')
         local alerts = config:new_alerts_namespace('my_alerts')
+        t.assert_equals(alerts:count(), 0)
         t.assert_equals(#box.info.config.alerts, 0)
 
         local alert = {
@@ -198,10 +272,13 @@ g.test_alerts_cleaned_by_aboard = function(g)
         }
 
         alerts:add(alert)
+        t.assert_equals(alerts:count(), 1)
         t.assert_equals(#box.info.config.alerts, 1)
-        t.assert_items_include(box.info.config.alerts[1], alert)
+        t.assert_covers(alerts:alerts()[1], alert)
+        t.assert_covers(box.info.config.alerts[1], alert)
 
         config._aboard:clean()
+        t.assert_equals(alerts:count(), 0)
         t.assert_equals(#box.info.config.alerts, 0)
     end
 
@@ -210,113 +287,198 @@ g.test_alerts_cleaned_by_aboard = function(g)
     })
 end
 
--- Ensure that all faults are caught and reported correctly.
-g.test_alerts_assertions = function()
-    local cases = {
-        {
-            script = [[
-                local config = require('config')
-                config.new_alerts_namespace('my_alerts')
-            ]],
-            err = 'Use config:new_alerts_namespace',
-        },
-        {
-            script = [[
-                local config = require('config')
-                local alerts = config:new_alerts_namespace('my_alerts')
-                alerts.add({message = 'Test alert'})
-            ]],
-            err = 'Use alerts_namespace:add',
-        },
-        {
-            script = [[
-                local config = require('config')
-                local alerts = config:new_alerts_namespace('my_alerts')
-                alerts.set("my_key", {message = 'Test alert'})
-            ]],
-            err = 'Use alerts_namespace:set',
-        },
-        {
-            script = [[
-                local config = require('config')
-                local alerts = config:new_alerts_namespace('my_alerts')
-                alerts.unset("my_key")
-            ]],
-            err = 'Use alerts_namespace:unset',
-        },
-        {
-            script = [[
-                local config = require('config')
-                local alerts = config:new_alerts_namespace('my_alerts')
-                alerts.clear()
-            ]],
-            err = 'Use alerts_namespace:clear',
-        },
-        {
-            script = [[
-                local config = require('config')
-                local alerts = config:new_alerts_namespace('my_alerts')
-                alerts:add("Test alert")
-            ]],
-            err = 'alert must be a table',
-        },
-        {
-            script = [[
-                local config = require('config')
-                local alerts = config:new_alerts_namespace('my_alerts')
-                alerts:add({message = 'Test alert', type = 'error'})
-            ]],
-            err = 'alert.type must be nil or "warn"',
-        },
-        {
-            script = [[
-                local config = require('config')
-                local alerts = config:new_alerts_namespace(123)
-            ]],
-            err = 'namespace name must be a string',
-        },
-        {
-            script = [[
-                local config = require('config')
-                local alerts = config:new_alerts_namespace("my:alerts")
-            ]],
-            err = 'namespace name cannot contain a colon',
-        },
-        {
-            script = [[
-                local config = require('config')
-                local alerts = config:new_alerts_namespace('my_alerts')
-                alerts:set(123, {message = 'Test alert'})
-            ]],
-            err = 'alert key must be a string',
-        },
-        {
-            script = [[
-                local config = require('config')
-                local alerts = config:new_alerts_namespace('my_alerts')
-                alerts:set("my:key", {message = 'Test alert'})
-            ]],
-            err = 'alert key cannot contain a colon',
-        },
-        {
-            script = [[
-                local config = require('config')
-                local alerts = config:new_alerts_namespace('my_alerts')
-                alerts:unset(123)
-            ]],
-            err = 'alert key must be a string',
-        },
-        {
-            script = [[
-                local config = require('config')
-                local alerts = config:new_alerts_namespace('my_alerts')
-                alerts:unset("my:key")
-            ]],
-            err = 'alert key cannot contain a colon',
-        },
-    }
+-- Ensure that alerts returned by get and alerts methods are copies.
+-- Modifying them does not affect the stored alerts.
+g.test_alerts_return_copies = function(g)
+    local verify = function()
+        local config = require('config')
+        local alerts = config:new_alerts_namespace('my_alerts')
+        t.assert_equals(alerts:count(), 0)
+        t.assert_equals(#box.info.config.alerts, 0)
 
-    for _, case in ipairs(cases) do
+        local key = 'my_key'
+        local alert = {
+            message = 'Test alert',
+            my_field = 'my_value',
+        }
+
+        alerts:set(key, alert)
+        t.assert_covers(alerts:get(key), alert)
+        t.assert_equals(alerts:count(), 1)
+        t.assert_covers(alerts:alerts()[key], alert)
+        t.assert_equals(#box.info.config.alerts, 1)
+        t.assert_covers(box.info.config.alerts[1], alert)
+
+        -- Modify the returned alert from get method.
+        local got_alert = alerts:get(key)
+        got_alert.message = 'Modified message'
+        got_alert.new_field = 'new_value'
+
+        -- Check that the stored alert is not affected.
+        t.assert_covers(alerts:get(key), alert)
+        t.assert_equals(alerts:count(), 1)
+        t.assert_covers(alerts:alerts()[key], alert)
+        t.assert_equals(#box.info.config.alerts, 1)
+        t.assert_covers(box.info.config.alerts[1], alert)
+
+        -- Modify the returned alerts from alerts method.
+        local got_alerts = alerts:alerts()
+        got_alerts[key].message = 'Modified message'
+        got_alerts[key].new_field = 'new_value'
+
+        -- Check that the stored alert is not affected.
+        t.assert_covers(alerts:get(key), alert)
+        t.assert_equals(alerts:count(), 1)
+        t.assert_covers(alerts:alerts()[key], alert)
+        t.assert_equals(#box.info.config.alerts, 1)
+        t.assert_covers(box.info.config.alerts[1], alert)
+    end
+
+    helpers.success_case(g, {
+        verify = verify,
+    })
+end
+
+-- Ensure that all faults are caught and reported correctly.
+local errorneous_cases = {
+    {
+        script = [[
+            local config = require('config')
+            config.new_alerts_namespace('my_alerts')
+        ]],
+        err = 'Use config:new_alerts_namespace',
+    },
+    {
+        script = [[
+            local config = require('config')
+            local alerts = config:new_alerts_namespace('my_alerts')
+            alerts.add({message = 'Test alert'})
+        ]],
+        err = 'Use alerts_namespace:add',
+    },
+    {
+        script = [[
+            local config = require('config')
+            local alerts = config:new_alerts_namespace('my_alerts')
+            alerts.set('my_key', {message = 'Test alert'})
+        ]],
+        err = 'Use alerts_namespace:set',
+    },
+    {
+        script = [[
+            local config = require('config')
+            local alerts = config:new_alerts_namespace('my_alerts')
+            alerts.unset('my_key')
+        ]],
+        err = 'Use alerts_namespace:unset',
+    },
+    {
+        script = [[
+            local config = require('config')
+            local alerts = config:new_alerts_namespace('my_alerts')
+            alerts.clear()
+        ]],
+        err = 'Use alerts_namespace:clear',
+    },
+    {
+        script = [[
+            local config = require('config')
+            local alerts = config:new_alerts_namespace('my_alerts')
+            alerts.get('my_key')
+        ]],
+        err = 'Use alerts_namespace:get',
+    },
+    {
+        script = [[
+            local config = require('config')
+            local alerts = config:new_alerts_namespace('my_alerts')
+            alerts.alerts()
+        ]],
+        err = 'Use alerts_namespace:alerts',
+    },
+    {
+        script = [[
+            local config = require('config')
+            local alerts = config:new_alerts_namespace('my_alerts')
+            alerts.count()
+        ]],
+        err = 'Use alerts_namespace:count',
+    },
+    {
+        script = [[
+            local config = require('config')
+            local alerts = config:new_alerts_namespace('my_alerts')
+            alerts:add('Test alert')
+        ]],
+        err = 'alert must be a table',
+    },
+    {
+        script = [[
+            local config = require('config')
+            local alerts = config:new_alerts_namespace('my_alerts')
+            alerts:add({message = 'Test alert', type = 'error'})
+        ]],
+        err = 'alert.type must be nil or "warn"',
+    },
+    {
+        script = [[
+            local config = require('config')
+            local alerts = config:new_alerts_namespace(123)
+        ]],
+        err = 'namespace name must be a string',
+    },
+    {
+        script = [[
+            local config = require('config')
+            local alerts = config:new_alerts_namespace('my:alerts')
+        ]],
+        err = 'namespace name cannot contain a colon',
+    },
+    {
+        script = [[
+            local config = require('config')
+            local alerts = config:new_alerts_namespace('my_alerts')
+            alerts:set(123, {message = 'Test alert'})
+        ]],
+        err = 'alert key must be a string',
+    },
+    {
+        script = [[
+            local config = require('config')
+            local alerts = config:new_alerts_namespace('my_alerts')
+            alerts:set('my:key', {message = 'Test alert'})
+        ]],
+        err = 'alert key cannot contain a colon',
+    },
+    {
+        script = [[
+            local config = require('config')
+            local alerts = config:new_alerts_namespace('my_alerts')
+            alerts:unset(123)
+        ]],
+        err = 'alert key must be a string',
+    },
+    {
+        script = [[
+            local config = require('config')
+            local alerts = config:new_alerts_namespace('my_alerts')
+            alerts:unset('my:key')
+        ]],
+        err = 'alert key cannot contain a colon',
+    },
+    {
+        script = [[
+            local config = require('config')
+            local alerts = config:new_alerts_namespace('my_alerts')
+            alerts:get(123)
+        ]],
+        err = 'alert key must be a string',
+    },
+}
+
+for i, case in ipairs(errorneous_cases) do
+    local test_name = 'test_alerts_assertions_' .. tostring(i)
+    g[test_name] = function()
         helpers.failure_case({
             options = {['app.module'] = 'main'},
             script = case.script,


### PR DESCRIPTION
Two commits, extending alerts public API:

- Read existing alerts in a namespace via `get(key)`, `alerts()` and `count()` methods.
- Read-only access to system alerts via `config:new_alerts_namespace()` call, restricted to `get(key)`, `alerts()` and `count()` methods

See commit messages for details.

Closes #11894
Closes #11895
Closes TNTP-4983