### PR TITLE
box: export txn savepoint symbols

### DIFF
--- a/changelogs/unreleased/gh-11731-box-txn-savepoint-c-api.md
+++ b/changelogs/unreleased/gh-11731-box-txn-savepoint-c-api.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Transaction savepoint functions are now properly exported in the C API
+  (gh-11731).

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -1160,6 +1160,31 @@ box_txn_commit(void);
 API_EXPORT int
 box_txn_rollback(void);
 
+/** Savepoint. */
+typedef struct txn_savepoint box_txn_savepoint_t;
+
+/**
+ * Create a new savepoint.
+ * @retval not NULL Savepoint object.
+ * @retval     NULL Client or memory error.
+ */
+API_EXPORT box_txn_savepoint_t *
+box_txn_savepoint(void);
+
+/**
+ * Rollback to @a savepoint. Rollback all statements newer than a
+ * saved statement. @a savepoint can be rolled back multiple
+ * times. All existing savepoints, newer than @a savepoint, are
+ * deleted and can not be used.
+ * @a savepoint must be from a current transaction, else the
+ * rollback crashes. To validate savepoints store transaction id
+ * together with @a savepoint.
+ * @retval  0 Success.
+ * @retval -1 Client error.
+ */
+API_EXPORT int
+box_txn_rollback_to_savepoint(box_txn_savepoint_t *savepoint);
+
 /**
  * Allocate memory on txn memory pool.
  * The memory is automatically deallocated when the transaction
@@ -1203,30 +1228,6 @@ box_txn_make_sync(void);
 /** Commit the current txn with the chosen wait mode. */
 int
 box_txn_commit_ex(enum txn_commit_wait_mode wait_mode);
-
-typedef struct txn_savepoint box_txn_savepoint_t;
-
-/**
- * Create a new savepoint.
- * @retval not NULL Savepoint object.
- * @retval     NULL Client or memory error.
- */
-API_EXPORT box_txn_savepoint_t *
-box_txn_savepoint(void);
-
-/**
- * Rollback to @a savepoint. Rollback all statements newer than a
- * saved statement. @A savepoint can be rolled back multiple
- * times. All existing savepoints, newer than @a savepoint, are
- * deleted and can not be used.
- * @A savepoint must be from a current transaction, else the
- * rollback crashes. To validate savepoints store transaction id
- * together with @a savepoint.
- * @retval  0 Success.
- * @retval -1 Client error.
- */
-API_EXPORT int
-box_txn_rollback_to_savepoint(box_txn_savepoint_t *savepoint);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/test/app-tap/module_api.c
+++ b/test/app-tap/module_api.c
@@ -3509,6 +3509,54 @@ test_box_insert_arrow(struct lua_State *L)
 	return 1;
 }
 
+static int
+test_box_txn_begin(struct lua_State *L)
+{
+	fail_unless(lua_gettop(L) == 0);
+	int rc = box_txn_begin();
+	lua_pushboolean(L, rc == 0);
+	return 1;
+}
+
+static int
+test_box_txn_commit(struct lua_State *L)
+{
+	fail_unless(lua_gettop(L) == 0);
+	int rc = box_txn_commit();
+	lua_pushboolean(L, rc == 0);
+	return 1;
+}
+
+static int
+test_box_txn_rollback(struct lua_State *L)
+{
+	fail_unless(lua_gettop(L) == 0);
+	int rc = box_txn_rollback();
+	lua_pushboolean(L, rc == 0);
+	return 1;
+}
+
+static int
+test_box_txn_savepoint(struct lua_State *L)
+{
+	fail_unless(lua_gettop(L) == 0);
+	box_txn_savepoint_t *svp = box_txn_savepoint();
+	if (svp == NULL)
+		return 0;
+	lua_pushlightuserdata(L, svp);
+	return 1;
+}
+
+static int
+test_box_txn_rollback_to_savepoint(struct lua_State *L)
+{
+	fail_unless(lua_gettop(L) == 1);
+	box_txn_savepoint_t *svp = lua_touserdata(L, 1);
+	int rc = box_txn_rollback_to_savepoint(svp);
+	lua_pushboolean(L, rc == 0);
+	return 1;
+}
+
 LUA_API int
 luaopen_module_api(lua_State *L)
 {
@@ -3570,6 +3618,12 @@ luaopen_module_api(lua_State *L)
 		{"box_iproto_override_set", test_box_iproto_override_set},
 		{"box_iproto_override_reset", test_box_iproto_override_reset},
 		{"box_insert_arrow", test_box_insert_arrow},
+		{"box_txn_begin", test_box_txn_begin},
+		{"box_txn_commit", test_box_txn_commit},
+		{"box_txn_rollback", test_box_txn_rollback},
+		{"box_txn_savepoint", test_box_txn_savepoint},
+		{"box_txn_rollback_to_savepoint",
+			test_box_txn_rollback_to_savepoint},
 		{NULL, NULL}
 	};
 	luaL_register(L, "module_api", lib);

--- a/test/app-tap/module_api.test.lua
+++ b/test/app-tap/module_api.test.lua
@@ -676,8 +676,35 @@ local function test_box_insert_arrow(test, module)
             "box_insert_arrow API")
 end
 
+local function test_box_txn(test, module)
+    test:plan(12)
+    local svp = module.box_txn_savepoint()
+    test:is(svp, nil, "box_txn_savepoint without active txn")
+
+    test:ok(module.box_txn_begin(), "box_txn_begin")
+    test:is(module.box_txn_begin(), false, "begin with active transaction")
+
+    svp = module.box_txn_savepoint()
+    test:isnt(svp, nil, "box_txn_savepoint")
+
+    -- Two times to check if checkpoint can be used several times.
+    for _ = 1, 2 do
+        box.space.test:insert({1984})
+        test:ok(module.box_txn_rollback_to_savepoint(svp),
+                "box_txn_rollback_to_savepoint")
+        test:is(box.space.test:get(1984), nil)
+    end
+
+    box.space.test:insert({1984})
+    test:ok(module.box_txn_rollback(), "box_txn_rollback")
+    test:is(box.space.test:get(1984), nil)
+
+    test:ok(module.box_txn_begin(), "box_txn_begin")
+    test:ok(module.box_txn_commit(), "box_txn_commit")
+end
+
 require('tap').test("module_api", function(test)
-    test:plan(54)
+    test:plan(55)
     local status, module = pcall(require, 'module_api')
     test:is(status, true, "module")
     test:ok(status, "module is loaded")
@@ -716,6 +743,7 @@ require('tap').test("module_api", function(test)
     test:test("box_iproto_override", test_box_iproto_override, module)
     test:test("box_ibuf", test_box_ibuf, module)
     test:test("box_insert_arrow", test_box_insert_arrow, module)
+    test:test("box_txn", test_box_txn, module)
 
     space:drop()
 end)


### PR DESCRIPTION
When txn savepoint machinery was implemented, its functions were marked with API_EXPORT qualifier and they were added to `extra/exports` list. However, they were decalred out of `cond public` scope, so they weren't exported actually - the commit fixes that mistake.

Along the way, the commit covers exported functions controlling transaction flow with tests.

Closes #11731