### PR TITLE
[backport 3.3] replication: fix wrong assumption in `box.ctl.make_bootstrap_leader`

### DIFF
--- a/changelogs/unreleased/gh-11704-make-bootstrap-leader-error-during-recovery.md
+++ b/changelogs/unreleased/gh-11704-make-bootstrap-leader-error-during-recovery.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed a false-positive assertion failure that could occur when calling
+  `box.ctl.make_bootstrap_leader()` during recovery (gh-11704).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -2277,9 +2277,14 @@ box_make_bootstrap_leader(void)
 			 "promoting this instance before box.cfg() is called");
 		return -1;
 	}
-	/* Bootstrap strategy is read by the time instance uuid is known. */
-	assert(bootstrap_strategy != BOOTSTRAP_STRATEGY_INVALID);
-	if (bootstrap_strategy != BOOTSTRAP_STRATEGY_SUPERVISED) {
+	/*
+	 * If the bootstrap strategy is not yet set by `box.cfg`
+	 * (`BOOTSTRAP_STRATEGY_INVALID`), we proceed further, since the
+	 * configuration changes below will be discarded when the bootstrap
+	 * strategy is going to be set if it is not `supervised`.
+	 */
+	if (bootstrap_strategy != BOOTSTRAP_STRATEGY_SUPERVISED &&
+	    bootstrap_strategy != BOOTSTRAP_STRATEGY_INVALID) {
 		diag_set(ClientError, ER_UNSUPPORTED,
 			 tt_sprintf("bootstrap_strategy = '%s'",
 				    cfg_gets("bootstrap_strategy")),
@@ -2287,6 +2292,7 @@ box_make_bootstrap_leader(void)
 			 "box.ctl.make_bootstrap_leader()");
 		return -1;
 	}
+
 	if (is_box_configured) {
 		if (box_check_writable() != 0)
 			return -1;

--- a/test/replication-luatest/bootstrap_strategy_test.lua
+++ b/test/replication-luatest/bootstrap_strategy_test.lua
@@ -774,3 +774,55 @@ g_supervised.test_no_bootstrap_without_replication = function(cg)
     t.assert(cg.server1:grep_log(query, nil, {filename = logfile}),
              'Bootstrap leader not found')
 end
+
+local g_make_bootstrap_leader_during_recovery =
+    t.group('gh-11704-make-bootstrap-leader-error-during-recovery')
+
+g_make_bootstrap_leader_during_recovery.after_each(function(cg)
+    cg.replica_set:drop()
+end)
+
+g_make_bootstrap_leader_during_recovery.before_test('test_error', function(cg)
+    cg.replica_set = replica_set:new{}
+    cg.box_cfg = {
+        replication = {
+            server.build_listen_uri('server1', cg.replica_set.id),
+            server.build_listen_uri('server2', cg.replica_set.id),
+        },
+        replication_timeout = 0.1,
+    }
+    for i = 1, 2 do
+        local alias = 'server' .. i
+        cg[alias] = cg.replica_set:build_and_add_server{
+            alias = alias,
+            box_cfg = cg.box_cfg,
+        }
+    end
+    cg.replica_set:start()
+    cg.replica_set:wait_for_fullmesh()
+end)
+
+-- Check that `box.ctl.make_bootstrap_leader` is handled correctly during
+-- recovery.
+g_make_bootstrap_leader_during_recovery.test_error = function(cg)
+    cg.box_cfg.bootstrap_strategy = 'supervised'
+    cg.server2:restart({box_cfg = cg.box_cfg}, {wait_until_ready = false})
+    -- During recovery, the fiber executing `box.cfg` will set the instance UUID
+    -- from the snapshot and yield because of `iproto_do_cfg`, but this will
+    -- happen before the bootstrap strategy is set.
+    local run_before_cfg = [[
+        rawset(_G, "make_bootstrap_leader_ok", false)
+        require('fiber').new(function()
+            local ok = pcall(box.ctl.make_bootstrap_leader)
+            _G.make_bootstrap_leader_ok = ok
+        end)
+    ]]
+    cg.server1:restart({box_cfg = cg.box_cfg,
+                        env = {
+        ['TARANTOOL_RUN_BEFORE_BOX_CFG'] = run_before_cfg,
+    }},
+    {wait_until_ready = true})
+    cg.server1:exec(function()
+        t.assert(_G.make_bootstrap_leader_ok)
+    end)
+end


### PR DESCRIPTION
(This PR is a backport of #11862 to `release/3.3` to a future `3.3.4` release.)

`box_make_bootstrap_leader` assumes that by the time the instance UID is assigned, the bootstrap strategy is also assigned. However, this assumption does not hold during recovery, since the instance UID is assigned during engine recovery from the snapshot at an earlier stage of recovery, and the fiber executing `box.cfg` yields because of `iproto_do_cfg` before the bootstrap strategy is set.

To fix this, let's throw an error iff the bootstrap strategy is set, and it is not `supervised`.

Closes #11704

NO_DOC=<bugfix>

(cherry picked from commit c5ca705e5710afb85335d25355af9f535c03123a)