### PR TITLE
[backport 3.2] box: export txn savepoint symbols

### DIFF
--- a/changelogs/unreleased/gh-11731-box-txn-savepoint-c-api.md
+++ b/changelogs/unreleased/gh-11731-box-txn-savepoint-c-api.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Transaction savepoint functions are now properly exported in the C API
+  (gh-11731).

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -1112,6 +1112,31 @@ box_txn_commit(void);
 API_EXPORT int
 box_txn_rollback(void);
 
+/** Savepoint. */
+typedef struct txn_savepoint box_txn_savepoint_t;
+
+/**
+ * Create a new savepoint.
+ * @retval not NULL Savepoint object.
+ * @retval     NULL Client or memory error.
+ */
+API_EXPORT box_txn_savepoint_t *
+box_txn_savepoint(void);
+
+/**
+ * Rollback to @a savepoint. Rollback all statements newer than a
+ * saved statement. @a savepoint can be rolled back multiple
+ * times. All existing savepoints, newer than @a savepoint, are
+ * deleted and can not be used.
+ * @a savepoint must be from a current transaction, else the
+ * rollback crashes. To validate savepoints store transaction id
+ * together with @a savepoint.
+ * @retval  0 Success.
+ * @retval -1 Client error.
+ */
+API_EXPORT int
+box_txn_rollback_to_savepoint(box_txn_savepoint_t *savepoint);
+
 /**
  * Allocate memory on txn memory pool.
  * The memory is automatically deallocated when the transaction
@@ -1155,30 +1180,6 @@ box_txn_make_sync(void);
 /** Commit the current txn with the chosen wait mode. */
 int
 box_txn_commit_ex(enum txn_commit_wait_mode wait_mode);
-
-typedef struct txn_savepoint box_txn_savepoint_t;
-
-/**
- * Create a new savepoint.
- * @retval not NULL Savepoint object.
- * @retval     NULL Client or memory error.
- */
-API_EXPORT box_txn_savepoint_t *
-box_txn_savepoint(void);
-
-/**
- * Rollback to @a savepoint. Rollback all statements newer than a
- * saved statement. @A savepoint can be rolled back multiple
- * times. All existing savepoints, newer than @a savepoint, are
- * deleted and can not be used.
- * @A savepoint must be from a current transaction, else the
- * rollback crashes. To validate savepoints store transaction id
- * together with @a savepoint.
- * @retval  0 Success.
- * @retval -1 Client error.
- */
-API_EXPORT int
-box_txn_rollback_to_savepoint(box_txn_savepoint_t *savepoint);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/test/app-tap/module_api.c
+++ b/test/app-tap/module_api.c
@@ -3364,6 +3364,54 @@ test_fiber_basic_api(lua_State *L)
 	return 1;
 }
 
+static int
+test_box_txn_begin(struct lua_State *L)
+{
+	fail_unless(lua_gettop(L) == 0);
+	int rc = box_txn_begin();
+	lua_pushboolean(L, rc == 0);
+	return 1;
+}
+
+static int
+test_box_txn_commit(struct lua_State *L)
+{
+	fail_unless(lua_gettop(L) == 0);
+	int rc = box_txn_commit();
+	lua_pushboolean(L, rc == 0);
+	return 1;
+}
+
+static int
+test_box_txn_rollback(struct lua_State *L)
+{
+	fail_unless(lua_gettop(L) == 0);
+	int rc = box_txn_rollback();
+	lua_pushboolean(L, rc == 0);
+	return 1;
+}
+
+static int
+test_box_txn_savepoint(struct lua_State *L)
+{
+	fail_unless(lua_gettop(L) == 0);
+	box_txn_savepoint_t *svp = box_txn_savepoint();
+	if (svp == NULL)
+		return 0;
+	lua_pushlightuserdata(L, svp);
+	return 1;
+}
+
+static int
+test_box_txn_rollback_to_savepoint(struct lua_State *L)
+{
+	fail_unless(lua_gettop(L) == 1);
+	box_txn_savepoint_t *svp = lua_touserdata(L, 1);
+	int rc = box_txn_rollback_to_savepoint(svp);
+	lua_pushboolean(L, rc == 0);
+	return 1;
+}
+
 LUA_API int
 luaopen_module_api(lua_State *L)
 {
@@ -3422,6 +3470,12 @@ luaopen_module_api(lua_State *L)
 		{"box_iproto_send", test_box_iproto_send},
 		{"box_iproto_override_set", test_box_iproto_override_set},
 		{"box_iproto_override_reset", test_box_iproto_override_reset},
+		{"box_txn_begin", test_box_txn_begin},
+		{"box_txn_commit", test_box_txn_commit},
+		{"box_txn_rollback", test_box_txn_rollback},
+		{"box_txn_savepoint", test_box_txn_savepoint},
+		{"box_txn_rollback_to_savepoint",
+			test_box_txn_rollback_to_savepoint},
 		{NULL, NULL}
 	};
 	luaL_register(L, "module_api", lib);


### PR DESCRIPTION
*(This PR is a backport of #11903 to `release/3.2` to a future `3.2.3` release.)*

When txn savepoint machinery was implemented, its functions were marked with API_EXPORT qualifier and they were added to `extra/exports` list. However, they were decalred out of `cond public` scope, so they weren't exported actually - the commit fixes that mistake.

Along the way, the commit covers exported functions controlling transaction flow with tests.

Closes #11731

@TarantoolBot document

Title: Fix txn savepoint methods in C API
Since: 3.2.3, 3.3.4, 3.4.2, 3.5.1, 3.6.0

Current documentation contains incorrect definitions of savepoint related functions. The correct ones are:

```c
API_EXPORT box_txn_savepoint_t *
box_txn_savepoint(void);

API_EXPORT int
box_txn_rollback_to_savepoint(box_txn_savepoint_t *savepoint);
```

Also, these functions were not exported by mistake. So we should delete them from docs of old Tarantool versions or write a note explaining that these methods were forgotten and one can find them in newer versions.

(cherry picked from commit 8a1dad8aa00c16d8c48722533e77ff7640398623)