### PR TITLE
mvcc: reduce false-positive aborts

### DIFF
--- a/changelogs/unreleased/gh-11927-memtx-mvcc-reduce-false-positive-aborts.md
+++ b/changelogs/unreleased/gh-11927-memtx-mvcc-reduce-false-positive-aborts.md
@@ -1,0 +1,3 @@
+## feature/memtx
+
+* Memtx-MVCC now aborts transactions less frequently (gh-11927).

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -2631,8 +2631,7 @@ memtx_tx_handle_dups_in_secondary_index(
 		 * Ignore case when other TX executes insert after
 		 * precedence delete.
 		 */
-		if (newer_story->link[ind].is_own_change &&
-		    test_stmt->del_story == NULL)
+		if (test_stmt->txn->flag)
 			continue;
 		/*
 		 * Ignore the case when other TX overwrites in both
@@ -2677,6 +2676,23 @@ memtx_tx_handle_dups_and_gaps_on_rollback(struct memtx_story *story)
 	}
 }
 
+#define assert_zero_or_one_del_stmt(_story, _txn) do { \
+	assert(_story == NULL || _story->del_stmt == NULL || \
+		   (_story->del_stmt->txn == _txn && \
+		   _story->del_stmt->next_in_del_list == NULL)); \
+} while (0)
+
+void clear_flag(struct memtx_story *story)
+{
+	if (story == NULL)
+		return;
+	struct txn_stmt *del_stmt = story->del_stmt;
+	while (del_stmt != NULL) {
+		del_stmt->txn->flag = false;
+		del_stmt = del_stmt->next_in_del_list;
+	}
+}
+
 /*
  * Rollback addition of story by statement.
  */
@@ -2708,6 +2724,7 @@ memtx_tx_history_rollback_added_story(struct txn_stmt *stmt)
 	 * to read this prepared state.
 	 */
 	if (stmt->txn->psn != 0) {
+		assert_zero_or_one_del_stmt(del_story, stmt->txn);
 		/*
 		 * During preparation of this statement there were two cases:
 		 * * del_story != NULL: all in-progress transactions that were
@@ -2741,6 +2758,7 @@ memtx_tx_history_rollback_added_story(struct txn_stmt *stmt)
 				/* Link to del_story's list. */
 				memtx_tx_story_link_deleted_by(del_story,
 							       test_stmt);
+				test_stmt->txn->flag = true;
 			}
 		}
 
@@ -2758,13 +2776,15 @@ memtx_tx_history_rollback_added_story(struct txn_stmt *stmt)
 		 * be aborted.
 		 */
 		memtx_tx_abort_story_readers(add_story);
+
+		clear_flag(del_story);
 	}
 
 	/* Unlink stories from the statement. */
 	memtx_tx_story_unlink_added_by(add_story, stmt);
 	if (del_story != NULL)
 		memtx_tx_story_unlink_deleted_by(del_story, stmt);
-
+	
 	add_story->del_psn = MEMTX_TX_ROLLBACKED_PSN;
 }
 
@@ -2806,6 +2826,7 @@ memtx_tx_history_rollback_deleted_story(struct txn_stmt *stmt)
 	 * to read this prepared state.
 	 */
 	if (stmt->txn->psn != 0) {
+		assert_zero_or_one_del_stmt(del_story, stmt->txn);
 		/*
 		 * During preparation of deletion we could unlink other
 		 * transactions that want to overwrite this story. Now we have
@@ -2827,12 +2848,15 @@ memtx_tx_history_rollback_deleted_story(struct txn_stmt *stmt)
 			assert(test_stmt->del_story == NULL);
 			assert(test_stmt->txn->psn == 0);
 			memtx_tx_story_link_deleted_by(del_story, test_stmt);
+			test_stmt->txn->flag = true;
 		}
 
 		memtx_tx_handle_dups_and_gaps_on_rollback(del_story);
 
 		/* Revert psn assignment. */
 		del_story->del_psn = 0;
+
+		clear_flag(del_story);
 	}
 
 	/* Unlink the story from the statement. */
@@ -2995,6 +3019,8 @@ memtx_tx_history_prepare_insert_stmt(struct txn_stmt *stmt)
 		(void)old_story;
 	}
 
+	assert_zero_or_one_del_stmt(story, stmt->txn);
+
 	/*
 	 * Set newer (in-progress) statements in the primary chain to delete
 	 * this story.
@@ -3019,6 +3045,7 @@ memtx_tx_history_prepare_insert_stmt(struct txn_stmt *stmt)
 			assert(test_stmt->del_story == NULL);
 			assert(test_stmt->txn->psn == 0);
 			memtx_tx_story_link_deleted_by(story, test_stmt);
+			test_stmt->txn->flag = true;
 		}
 	} else {
 		/*
@@ -3048,6 +3075,7 @@ memtx_tx_history_prepare_insert_stmt(struct txn_stmt *stmt)
 
 			/* Link to story's list. */
 			memtx_tx_story_link_deleted_by(story, test_stmt);
+			test_stmt->txn->flag = true;
 		}
 	}
 
@@ -3090,6 +3118,8 @@ memtx_tx_history_prepare_insert_stmt(struct txn_stmt *stmt)
 		 */
 		memtx_tx_handle_conflict_gap_readers(top_story, i, stmt->txn);
 	}
+
+	clear_flag(story);
 }
 
 /**

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -570,6 +570,7 @@ txn_begin(void)
 	txn_set_flags(txn, TXN_SUPPORTS_MVCC);
 	memtx_tx_register_txn(txn);
 	rmean_collect(rmean_box, IPROTO_BEGIN, 1);
+	txn->flag = false;
 	return txn;
 }
 

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -570,6 +570,7 @@ struct txn {
 	 * Nesting level of space on_replace triggers for current txn.
 	 */
 	int space_on_replace_triggers_depth;
+	bool flag;
 };
 
 static inline bool

--- a/test/box-luatest/gh_11927_memtx_mvcc_reduce_false_positive_aborts_test.lua
+++ b/test/box-luatest/gh_11927_memtx_mvcc_reduce_false_positive_aborts_test.lua
@@ -1,0 +1,77 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group('gh-11927-memtx-mvcc-reduce-false-positive-aborts')
+--
+-- gh-11927: memtx mvcc reduce false-positive aborts
+--
+
+g.before_all(function()
+    g.server = server:new{
+        box_cfg = {
+            memtx_use_mvcc_engine = true
+        }
+    }
+    g.server:start()
+
+    g.server:exec(function()
+        box.schema.space.create("test")
+        box.space.test:format{{'a', type='unsigned'}, {'b', type='unsigned'}}
+        box.space.test:create_index("pk", {parts={{'a'}}})
+        box.space.test:create_index("sk", {parts={{'b'}}, unique=true})
+    end)
+end)
+
+g.after_each(function()
+    g.server:exec(function() box.space.test:truncate() end)
+end)
+
+g.after_all(function()
+    g.server:drop()
+end)
+
+for _, case in ipairs({
+    -- gh-11927
+    {
+        name = 'false_positive_aborts_of_identical_replaces',
+        tuples = { {1, 1}, {1, 1}, {1, 1} },
+    },
+    -- gh-11942
+    {
+        name = 'avoidable_false_positive_transaction_aborts',
+        tuples = { {1, 2}, {1, 1}, {2, 2} },
+    },
+}) do
+    g['test_' .. case.name] = function()
+        g.server:exec(function(tuples)
+            local fiber = require('fiber')
+
+            local c1 = fiber.cond()
+            local f1 = fiber.create(function()
+                box.begin()
+                box.space.test:replace(tuples[1])
+                c1:wait()
+                box.commit()
+            end)
+            f1:set_joinable(true)
+
+            local c2 = fiber.cond()
+            local f2 = fiber.create(function()
+                box.begin()
+                box.space.test:replace(tuples[2])
+                box.space.test:replace(tuples[3])
+                c2:wait()
+                box.commit()
+            end)
+            f2:set_joinable(true)
+
+            c1:signal()
+            local ok = f1:join()
+            t.assert(ok)
+
+            c2:signal()
+            ok = f2:join()
+            t.assert(ok)
+        end, { case.tuples })
+    end
+end


### PR DESCRIPTION
It was discovered that Memtx MVCC aborts transactions too frequently, even in cases where it would seem possible to avoid doing so. The issue was in how potential duplicates in secondary indexes were handled when a statement became "prepared".

The processing worked as follows. When a replace/insert statement `stmt` becomes "prepared" (`stmt->add_story != NULL`):

- Iterate through each chain (except the primary one) upwards from `stmt->add_story`
- For each `story` along the path, check:
    - If the `story` was added by the same transaction as `stmt->add_story`, skip it. The check has already been performed for such stories and nothing could have been corrupted.
    - If the `story` was added by a transaction that previously deleted (**using DELETE statement**) a tuple with the same key, skip it. It couldn't have been a duplicate of `stmt->add_story->tuple` because at the serialization point when `story->tuple` was inserted, `stmt->add_story->tuple` was definitely deleted.
    - If `story->tuple` has a primary key different from the primary key of `stmt->add_story->tuple` (`story->add_stmt->del_story != stmt->add_story`), then abort `story->add_stmt->txn` - it's a duplicate.

This patch addresses the second point. Actually, it doesn't matter to us which type of statement deleted a tuple with the same key: a `DELETE` or a `REPLACE`. Up until now, we have only handled `DELETE`, because its `del_story` reference is constant and always points to the same tuple, and the read tracker "monitors" the lifetime of the tuple pointed to by this reference. Because the reference is set only once, it was easy for us to handle this case. With `REPLACE` statements, things are a bit more complicated, as their `del_story` reference can change any number of times. At different points in time, this property ("the story was added by a transaction that previously replaced a tuple with the same key") can toggle between true and false as other transactions become "prepared". Therefore, we need some mechanism to quickly handle the queries "transaction `TXN` has become prepared" and "does our property hold for story `story`?".

~To handle such cases, this patch introduces an additional hashmap named `dels` into the `tx_manager` structure: `(txn, story) -> stmt`. The presence of an entry `(txn, story) -> stmt` in this hashmap signifies that transaction `txn` deleted/replaced `story->tuple` by executing statement `stmt`. Note that within a single transaction, at most one statement could have deleted/replaced a specific `story`. Now, the second point in the duplicate check becomes very straightforward.~

Closes #11927, #11942

NO_DOC=bugfix