### PR TITLE
memtx: failing index count limit assertion with MVCC enabled

### DIFF
--- a/changelogs/unreleased/gh-11929-memtx-mvcc-failing-index-count-limit-assertion.md
+++ b/changelogs/unreleased/gh-11929-memtx-mvcc-failing-index-count-limit-assertion.md
@@ -1,0 +1,4 @@
+## bugfix/memtx
+
+* Fixed a crash when using the maximum allowed number of indexes with Memtx-MVCC
+  enabled (gh-11929).

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1037,7 +1037,8 @@ memtx_tx_send_to_read_view(struct txn *txn, int64_t psn)
 static inline size_t
 memtx_story_size(struct memtx_story *story)
 {
-	struct mempool *pool = &txm.memtx_tx_story_pool[story->index_count];
+	assert(story->index_count > 0);
+	struct mempool *pool = &txm.memtx_tx_story_pool[story->index_count - 1];
 	return pool->objsize;
 }
 
@@ -1144,8 +1145,8 @@ memtx_tx_story_new(struct space *space, struct tuple *tuple)
 	txm.must_do_gc_steps += TX_MANAGER_GC_STEPS_SIZE;
 	assert(!tuple_has_flag(tuple, TUPLE_IS_DIRTY));
 	uint32_t index_count = space->index_count;
-	assert(index_count < BOX_INDEX_MAX);
-	struct mempool *pool = &txm.memtx_tx_story_pool[index_count];
+	assert(index_count > 0 && index_count <= BOX_INDEX_MAX);
+	struct mempool *pool = &txm.memtx_tx_story_pool[index_count - 1];
 	struct memtx_story *story = (struct memtx_story *)xmempool_alloc(pool);
 	story->tuple = tuple;
 
@@ -1217,7 +1218,8 @@ memtx_tx_story_delete(struct memtx_story *story)
 	tuple_clear_flag(story->tuple, TUPLE_IS_DIRTY);
 	tuple_unref(story->tuple);
 
-	struct mempool *pool = &txm.memtx_tx_story_pool[story->index_count];
+	assert(story->index_count > 0);
+	struct mempool *pool = &txm.memtx_tx_story_pool[story->index_count - 1];
 	mempool_free(pool, story);
 }
 
@@ -4145,7 +4147,7 @@ memtx_tx_manager_init(void)
 	rlist_create(&txm.read_view_txs);
 	for (size_t i = 0; i < BOX_INDEX_MAX; i++) {
 		size_t item_size = sizeof(struct memtx_story) +
-				   i * sizeof(struct memtx_story_link);
+				   (i + 1) * sizeof(struct memtx_story_link);
 		mempool_create(&txm.memtx_tx_story_pool[i],
 			       cord_slab_cache(), item_size);
 	}

--- a/test/box-luatest/gh_11929_memtx_mvcc_failing_index_count_limit_assertion_test.lua
+++ b/test/box-luatest/gh_11929_memtx_mvcc_failing_index_count_limit_assertion_test.lua
@@ -1,0 +1,38 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group('gh-11929-memtx-mvcc-failing-index-count-limit-assertion')
+--
+-- gh-11929: memtx mvcc failing index count limit assertion
+--
+
+g.before_all(function()
+    g.server = server:new{box_cfg = {memtx_use_mvcc_engine = true}}
+    g.server:start()
+
+    g.server:exec(function()
+        box.schema.space.create("test")
+    end)
+end)
+
+g.after_each(function()
+    g.server:exec(function() box.space.test:truncate() end)
+end)
+
+g.after_all(function()
+    g.server:drop()
+end)
+
+g.test_index_id = function()
+    g.server:exec(function()
+        for i = 1, box.schema.INDEX_MAX do
+            box.space.test:create_index(
+                ('idx_%d'):format(i),
+                {parts={{i, is_nullable=(i > 1)}}, unique=true}
+            )
+        end
+
+        box.space.test:replace{1}
+        t.assert_equals(box.space.test:get(1), {1})
+    end)
+end


### PR DESCRIPTION
Fixed a crash when using the maximum allowed number of indexes with Memtx-MVCC enabled.

Closes #11929

NO_DOC=bugfix