### PR TITLE
diag: remove debug logging from functions setting diag

### DIFF
--- a/changelogs/unreleased/gh-11840-fix-syslog-reconnect-crash.md
+++ b/changelogs/unreleased/gh-11840-fix-syslog-reconnect-crash.md
@@ -1,0 +1,3 @@
+## bugfix/box
+
+* Fixed a crash on reconnecting to syslog server (gh-11840).

--- a/src/box/xrow.h
+++ b/src/box/xrow.h
@@ -41,6 +41,7 @@
 #include "node_name.h"
 #include "tt_uuid.h"
 #include "vclock/vclock.h"
+#include "say.h"
 
 #if defined(__cplusplus)
 extern "C" {

--- a/src/lib/coll/coll.c
+++ b/src/lib/coll/coll.c
@@ -29,14 +29,16 @@
  * SUCH DAMAGE.
  */
 
-#include "coll.h"
 #include <PMurHash.h>
-#include "diag.h"
-#include "assoc.h"
 #include <unicode/ucol.h>
 #include <unicode/ucnv.h>
 #include <unicode/ucasemap.h>
+
+#include "coll.h"
+#include "diag.h"
+#include "assoc.h"
 #include "tt_static.h"
+#include "say.h"
 
 struct UCaseMap *icu_ucase_default_map = NULL;
 struct UConverter *icu_utf8_conv = NULL;

--- a/src/lib/core/arrow_ipc.c
+++ b/src/lib/core/arrow_ipc.c
@@ -8,6 +8,7 @@
 #include "diag.h"
 #include "small/region.h"
 #include "nanoarrow/nanoarrow_ipc.h"
+#include "tt_strerror.h"
 
 int
 arrow_ipc_encode(struct ArrowArray *array, struct ArrowSchema *schema,

--- a/src/lib/core/diag.h
+++ b/src/lib/core/diag.h
@@ -36,9 +36,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <assert.h>
+#include <errno.h>
 
 #include "error_payload.h"
-#include "say.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -465,7 +465,6 @@ BuildSocketError(const char *file, unsigned line, const char *socketname,
 #define diag_set_detailed(file, line, class, ...) ({			\
 	/* Preserve the original errno. */                              \
 	int save_errno = errno;                                         \
-	say_debug("%s at %s:%i", #class, file, line);			\
 	struct error *e;						\
 	e = Build##class(file, line, ##__VA_ARGS__);			\
 	diag_set_error(diag_get(), e);					\
@@ -479,7 +478,6 @@ BuildSocketError(const char *file, unsigned line, const char *socketname,
 
 #define diag_add(class, ...) ({						\
 	int save_errno = errno;						\
-	say_debug("%s at %s:%i", #class, __FILE__, __LINE__);		\
 	struct error *e;						\
 	e = Build##class(__FILE__, __LINE__, ##__VA_ARGS__);		\
 	diag_add_error(diag_get(), e);					\

--- a/src/lib/core/event.c
+++ b/src/lib/core/event.c
@@ -12,6 +12,7 @@
 #include "trivia/util.h"
 #include "func_adapter.h"
 #include "trigger.h"
+#include "say.h"
 
 /** Registry of all events: name -> event. */
 static struct mh_strnptr_t *event_registry;

--- a/src/lib/core/evio.c
+++ b/src/lib/core/evio.c
@@ -39,6 +39,7 @@
 #include <trivia/util.h>
 #include "exception.h"
 #include "iostream.h"
+#include "say.h"
 #include "tt_strerror.h"
 #include "uri/uri.h"
 

--- a/src/lib/mpstream/mpstream.c
+++ b/src/lib/mpstream/mpstream.c
@@ -17,6 +17,7 @@
 #include "mp_uuid.h"
 #include "mp_datetime.h"
 #include "mp_interval.h"
+#include "say.h"
 
 void
 mpstream_panic_cb(void *error_ctx)

--- a/test/app-luatest/logger_syslog_test.lua
+++ b/test/app-luatest/logger_syslog_test.lua
@@ -1,0 +1,38 @@
+local fio = require('fio')
+local socket = require('socket')
+local fiber = require('fiber')
+local treegen = require('luatest.treegen')
+local justrun = require('luatest.justrun')
+local t = require('luatest')
+
+local g = t.group()
+
+g.test_gh_11840_no_recursive_reconnect = function()
+    local dir = treegen.prepare_directory({}, {})
+    local socket_path = fio.pathjoin(dir, 'socket')
+    local socket = socket('AF_UNIX', 'SOCK_DGRAM', 0)
+    socket:bind('unix/', socket_path)
+
+    local script = string.format([[
+        local log = require('log')
+        box.cfg{
+            log = 'syslog:server=unix:%s',
+            log_level = 'debug',
+        }
+        -- Logging should not cause stack overflow. This or
+        -- that is done during recovery.
+        log.info('Бу!')
+        log.info('Испугался?')
+        os.exit(0)
+    ]], socket_path)
+    treegen.write_file(dir, 'script.lua', script)
+
+    fiber.create(function()
+        socket:readable()
+        socket:close()
+    end)
+
+    local res = justrun.tarantool(dir, {}, {'script.lua'},
+                                  {nojson = true, stderr = true})
+    t.assert_equals(res.exit_code, 0, res.stderr)
+end


### PR DESCRIPTION
When we fail to write a log message to syslog to try to reconnect and write it again in `write_to_syslog()`. If reconnecting failed and log level is debug we log error but this involves another reconnecting attempt and so on. As result Tarantool is crashed due to stack overflow.

Let's remove logging error in `diag_set()` and `diag_add()`. Is not considered useful. Debug logging produces a lot of messages, to make it helpful we are going support turning logging on by module. In this case logging all errors in `diag.h` will not be helpful.

Closes #11840

See also https://github.com/tarantool/tarantool-ee/pull/1499 PR required after these changes.