### PR TITLE
replication: update raft instance id on anon replica register

### DIFF
--- a/changelogs/unreleased/gh-11938-stale-election-state-after-register.md
+++ b/changelogs/unreleased/gh-11938-stale-election-state-after-register.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed the election state corruption after an anonymous replica
+  becomes non-anonymous (gh-11938).

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -2619,8 +2619,22 @@ applier_f(va_list ap)
 			bool need_name =
 				*cfg_instance_name != 0 &&
 				strcmp(INSTANCE_NAME, cfg_instance_name) != 0;
-			if (need_id || need_name)
+			if (need_id || need_name) {
 				applier_register(applier, was_anon);
+				/*
+				 * It's hard to catch the exact moment when
+				 * instance id settles, for example, it could
+				 * change multiple times during register, but we
+				 * have to configure raft with it before
+				 * `applier_subscribe` starts, because we'll
+				 * start receiving raft messages there.
+				 */
+				if (need_id && was_anon) {
+					assert(instance_id != 0);
+					raft_cfg_instance_id(box_raft(),
+							     instance_id);
+				}
+			}
 			applier_subscribe(applier);
 			/*
 			 * subscribe() has an infinite loop which

--- a/test/replication-luatest/gh_11938_anon_replica_register_election_crash_test.lua
+++ b/test/replication-luatest/gh_11938_anon_replica_register_election_crash_test.lua
@@ -1,0 +1,40 @@
+local t = require('luatest')
+local server = require('luatest.server')
+local replica_set = require('luatest.replica_set')
+
+local g = t.group()
+
+g.before_each(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.replica_set = replica_set:new{}
+    cg.master = cg.replica_set:build_and_add_server({
+        box_cfg = {
+            election_mode = 'candidate',
+        },
+        alias = 'master',
+    })
+    cg.replica = cg.replica_set:build_and_add_server({
+        box_cfg = {
+            replication = {
+                server.build_listen_uri('master', cg.replica_set.id),
+            },
+            replication_anon = true,
+            read_only = true,
+        },
+        alias = 'replica',
+    })
+end)
+
+g.after_each(function(cg)
+    cg.replica_set:drop()
+end)
+
+g.test_anon_replica_election_state_is_consistent_after_register = function(cg)
+    cg.replica_set:start()
+    cg.replica:update_box_cfg({
+        replication_anon = false,
+    })
+    t.helpers.retrying({}, function()
+        cg.replica:assert_follows_upstream(cg.master:get_instance_id())
+    end)
+end


### PR DESCRIPTION
The raft subsystem has its own copy of an instance id, raft::self. It's set during initial `box.cfg()` call, after local recovery or bootstrap.

It was forgotten to update raft::self after an anonymous replica register. This could lead to various assertion failures in raft code in debug build, and in the release build the raft state would be silently corrupted. Fix this.

Closes #11938

NO_DOC=bugfix