### PR TITLE
wal: use WAL_SYNC_FLAG instead of O_SYNC

### DIFF
--- a/changelogs/unreleased/gh-10784-O_DSYNC-instead-of-O_SYNC.md
+++ b/changelogs/unreleased/gh-10784-O_DSYNC-instead-of-O_SYNC.md
@@ -1,0 +1,6 @@
+## feature/core:
+
+* Now `O_DSYNC` flag is used instead of `O_SYNC` with `wal_mode = fsync` configuration
+  This makes WAL operations in fsync mode slightly faster
+  Note: WAL files may have outdated access/modification time in metadata
+  Restores behavior that was accidentally removed in commit caae99e

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -460,7 +460,7 @@ wal_writer_create(struct wal_writer *writer, enum wal_mode wal_mode,
 	xdir_set_retention_period(&writer->wal_dir, wal_retention_period);
 	xlog_clear(&writer->current_wal);
 	if (wal_mode == WAL_FSYNC)
-		writer->wal_dir.open_wflags |= O_SYNC;
+		writer->wal_dir.open_wflags |= WAL_SYNC_FLAG;
 
 	stailq_create(&writer->rollback);
 	writer->is_in_rollback = false;


### PR DESCRIPTION
Use WAL_SYNC_FLAG macro which properly selects between O_DSYNC (when available) and O_SYNC (as fallback) for WAL file writes.

This restores the intended behavior that was lost during refactoring and improves performance by using O_DSYNC when only data sync is needed rather than full file metadata sync.

Closes #10784