### PR TITLE
box: populate sysview iterator with position method

### DIFF
--- a/changelogs/unreleased/gh-11953-pagination-sysview.md
+++ b/changelogs/unreleased/gh-11953-pagination-sysview.md
@@ -1,0 +1,3 @@
+## bugfix/box
+
+* Fixed a crash when pagination was used on a `sysview` space (gh-11953).

--- a/src/box/sysview.c
+++ b/src/box/sysview.c
@@ -102,6 +102,18 @@ sysview_iterator_next(struct iterator *iterator, struct tuple **ret)
 	return rc;
 }
 
+/**
+ * Implementation of `position` iterator method for this engine. Simply calls
+ * the same method of the source iterator.
+ */
+static int
+sysview_iterator_position(struct iterator *it, const char **pos, uint32_t *size)
+{
+	assert(it->free == sysview_iterator_free);
+	struct sysview_iterator *sysview_it = sysview_iterator(it);
+	return iterator_position(sysview_it->source, pos, size);
+}
+
 static void
 sysview_index_destroy(struct index *index)
 {
@@ -140,6 +152,7 @@ sysview_index_create_iterator(struct index *base, enum iterator_type type,
 	it->pool = &sysview->iterator_pool;
 	it->base.next = sysview_iterator_next;
 	it->base.free = sysview_iterator_free;
+	it->base.position = sysview_iterator_position;
 
 	it->source = index_create_iterator_after(pk, type, key, part_count,
 						 pos);

--- a/test/engine-luatest/gh_11953_pagination_sysview_test.lua
+++ b/test/engine-luatest/gh_11953_pagination_sysview_test.lua
@@ -1,0 +1,75 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group('pagination_sysview', {{filter = false}, {filter = true}})
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_pagination_sysview = function(cg)
+    cg.server:exec(function(filter)
+        if filter then
+            -- User with no space permissions so that only subset of spaces
+            -- (I mean all the `sysview` spaces) is visible. Is needed to check
+            -- how pagination works along with filtration.
+            box.schema.user.create('testuser')
+            box.session.su('testuser')
+        end
+
+        local s = box.space._vspace
+
+        local tuples1
+        local tuples2
+        local tuples_offset
+        local pos
+        local last_tuple
+
+        -- Test fullscan pagination
+        pos = ""
+        last_tuple = box.NULL
+        local i = 0
+        repeat
+            tuples1, pos = s:select(nil,
+                    {limit=2, fullscan=true, fetch_pos=true, after=pos})
+            tuples2 = s:select(nil,
+                    {limit=2, fullscan=true, after=last_tuple})
+            last_tuple = tuples2[#tuples2]
+            tuples_offset = s:select(nil,
+                    {limit=2, fullscan=true, offset=i*2})
+            t.assert_equals(tuples1, tuples_offset)
+            t.assert_equals(tuples2, tuples_offset)
+            i = i + 1
+        until #tuples1 == 0
+
+        -- Test pagination on range iterators
+        local key = 289
+        local iters = {'GE', 'GT', 'LE', 'LT'}
+        for _, iter in pairs(iters) do
+            pos = ""
+            last_tuple = box.NULL
+            i = 0
+            repeat
+                tuples1, pos = s:select(key,
+                        {limit=2, iterator=iter, fetch_pos=true, after=pos})
+                tuples2 = s:select(key,
+                        {limit=2, iterator=iter, after=last_tuple})
+                last_tuple = tuples2[#tuples2]
+                tuples_offset = s:select(key,
+                        {limit=2, iterator=iter, offset=i*2})
+                t.assert_equals(tuples1, tuples_offset)
+                t.assert_equals(tuples2, tuples_offset)
+                i = i + 1
+            until #tuples1 == 0
+        end
+        if filter then
+            box.session.su('admin')
+            box.schema.user.drop('testuser')
+        end
+    end, {cg.params.filter})
+end


### PR DESCRIPTION
Currently Tarantool crashes when one tries to use pagination on a `sysview` space because it doesn't have `iterator_position` method and it's even not initialized to a generic version throwing an error. Anyway, `sysview` spaces support only `tree` indexes, so pagination definitely may work there - let's populate this engine with `iterator_position` method which simply call the same method of the underlying iterator.

Closes #11953

NO_DOC=bugfix