### PR TITLE
box: compare pagination position against key only for tree index

### DIFF
--- a/changelogs/unreleased/gh-11963-crash-pagination-with-key-rtree.md
+++ b/changelogs/unreleased/gh-11963-crash-pagination-with-key-rtree.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed a crash when trying to use pagination along with the key
+  in RTREE indexes (gh-11963).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -4124,7 +4124,7 @@ box_iterator_position_pack(const char *pos, const char *pos_end,
 int
 box_iterator_position_unpack(const char *packed_pos,
 			     const char *packed_pos_end,
-			     struct key_def *cmp_def, const char *key,
+			     struct index_def *index_def, const char *key,
 			     uint32_t key_part_count, int iterator,
 			     const char **pos, const char **pos_end)
 {
@@ -4142,7 +4142,7 @@ box_iterator_position_unpack(const char *packed_pos,
 		uint32_t pos_part_count = mp_decode_array(pos);
 		enum iterator_type type = (enum iterator_type)iterator;
 		if (iterator_position_validate(*pos, pos_part_count, key,
-					       key_part_count, cmp_def,
+					       key_part_count, index_def,
 					       type) != 0)
 			return -1;
 	} else {
@@ -4187,7 +4187,7 @@ box_select(uint32_t space_id, uint32_t index_id,
 		return -1;
 	const char *pos, *pos_end;
 	if (box_iterator_position_unpack(*packed_pos, *packed_pos_end,
-					 index->def->cmp_def, key, part_count,
+					 index->def, key, part_count,
 					 type, &pos, &pos_end) != 0)
 		return -1;
 

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -55,6 +55,7 @@ struct space;
 struct vclock;
 struct key_def;
 struct ballot;
+struct index_def;
 
 /**
  * Pointer to TX thread local vclock.
@@ -479,7 +480,7 @@ box_iterator_position_pack(const char *pos, const char *pos_end,
 int
 box_iterator_position_unpack(const char *packed_pos,
 			     const char *packed_pos_end,
-			     struct key_def *cmp_def, const char *key,
+			     struct index_def *index_def, const char *key,
 			     uint32_t key_part_count, int iterator,
 			     const char **pos, const char **pos_end);
 

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -29,6 +29,7 @@
  * SUCH DAMAGE.
  */
 #include "index.h"
+#include "index_def.h"
 #include "tuple.h"
 #include "say.h"
 #include "schema.h"
@@ -654,7 +655,7 @@ box_index_iterator_with_offset(uint32_t space_id, uint32_t index_id, int type,
 				runtime_memory_free(pos_buf, pos_buf_size);
 		});
 	if (box_iterator_position_unpack(packed_pos, packed_pos_end,
-					 index->def->cmp_def, key, part_count,
+					 index->def, key, part_count,
 					 type, &pos, &pos_end) != 0)
 		return NULL;
 	if (pos != NULL) {
@@ -867,22 +868,30 @@ fail:
 int
 iterator_position_validate(const char *pos, uint32_t pos_part_count,
 			   const char *key, uint32_t key_part_count,
-			   struct key_def *cmp_def, enum iterator_type type)
+			   struct index_def *index_def,
+			   enum iterator_type type)
 {
 	int cmp;
 	/* Position must be compatible with the index. */
-	if (cmp_def->part_count != pos_part_count)
+	if (index_def->cmp_def->part_count != pos_part_count)
 		goto fail;
 	const char *pos_end;
-	if (key_validate_parts(cmp_def, pos, pos_part_count, true, &pos_end) != 0)
+	if (key_validate_parts(index_def->cmp_def, pos, pos_part_count, true,
+			       &pos_end) != 0)
 		goto fail;
-	/* Position msut meet the search criteria. */
-	cmp = key_compare(pos, pos_part_count, HINT_NONE,
-			  key, key_part_count, HINT_NONE, cmp_def);
-	if (iterator_direction(type) * cmp < 0)
-		goto fail;
-	if ((type == ITER_EQ || type == ITER_REQ) && cmp != 0)
-		goto fail;
+	/*
+	 * Position must meet the search criteria.
+	 * This check makes sense only for TREE index.
+	 */
+	if (index_def->type == TREE) {
+		cmp = key_compare(pos, pos_part_count, HINT_NONE,
+				  key, key_part_count, HINT_NONE,
+				  index_def->cmp_def);
+		if (iterator_direction(type) * cmp < 0)
+			goto fail;
+		if ((type == ITER_EQ || type == ITER_REQ) && cmp != 0)
+			goto fail;
+	}
 	return 0;
 fail:
 	diag_set(ClientError, ER_ITERATOR_POSITION);

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -450,7 +450,8 @@ iterator_position_unpack(const char *packed_pos, const char *packed_pos_end,
 int
 iterator_position_validate(const char *pos, uint32_t pos_part_count,
 			   const char *key, uint32_t key_part_count,
-			   struct key_def *cmp_def, enum iterator_type type);
+			   struct index_def *index_def,
+			   enum iterator_type type);
 
 /**
  * Get position of iterator - extracted cmp_def of last fetched

--- a/test/engine-luatest/pagination_test.lua
+++ b/test/engine-luatest/pagination_test.lua
@@ -964,12 +964,17 @@ no_sup.test_unsupported_pagination = function(cg)
                 box.space.s.index.sk.select, box.space.s.index.sk,
                 nil, {fullscan=true, fetch_pos=true})
         local tuple = {0, 0}
+        local key = {0}
         if index_type == 'rtree' then
             tuple = {0, {0, 0}}
+            key = {0, 0}
         end
         t.assert_error_msg_contains('does not support pagination',
                 box.space.s.index.sk.select, box.space.s.index.sk,
                 nil, {fullscan=true, after=tuple})
+        t.assert_error_msg_contains('does not support pagination',
+                box.space.s.index.sk.select, box.space.s.index.sk,
+                key, {fullscan=true, after=tuple})
         -- tuple_pos works everywhere instead of func and multikey indexes
         local pos = box.space.s.index.sk:tuple_pos(tuple)
         t.assert_error_msg_contains('does not support pagination',


### PR DESCRIPTION
Currently, we check that pagination position meets search criteria, otherwise the invalid position can break Tarantool or lead to invalid results. However, this check mustn't be done for `rtree` index because it works with `array` fields and our comparators don't support them. Since this check makes sense only for `tree` index (because it's the only ordered index), let's simply omit this check for other indexes.

Closes #11963