### PR TITLE
perf: include used containers in `perf/tuple.cc`

### DIFF
--- a/perf/tuple.cc
+++ b/perf/tuple.cc
@@ -4,8 +4,10 @@
 #include "memtx_engine.h"
 #include <allocator.h>
 
+#include <array>
 #include <benchmark/benchmark.h>
 #include <random>
+#include <vector>
 
 static const size_t NUM_TEST_TUPLES = 4096;
 


### PR DESCRIPTION
Recently, we started to use `std::array` in tuple benchmark, however we
forget to include its header, so build fails on some runners. The commit
adds the missing header. Along the way, it adds missing `std::vector`
header as well.

I've checked it on runner that is used in `master` workflows - the build doesn't fail there anymore.